### PR TITLE
Major rework on toolbar indicator dropdowns

### DIFF
--- a/.github/workflows/linux_debug.yml
+++ b/.github/workflows/linux_debug.yml
@@ -44,6 +44,9 @@ jobs:
           modules:      qtcharts qtlocation qtpositioning qtspeech qt5compat qtmultimedia qtserialport qtimageformats qtshadertools
           setup-python: true
 
+      - name: Install github environment dependencies for unit test running
+        run:  sudo apt-get install libxcb-xinerama0
+
       - name: Install QGC source dependencies
         run:  sudo apt-get install -y libsdl2-dev
 

--- a/custom-example/qgroundcontrol.qrc
+++ b/custom-example/qgroundcontrol.qrc
@@ -4,7 +4,6 @@
 	</qresource>
 	<qresource prefix="/toolbar">
 		<file alias="ArmedIndicator.qml">../src/ui/toolbar/ArmedIndicator.qml</file>
-		<file alias="BatteryIndicator.qml">../src/ui/toolbar/BatteryIndicator.qml</file>
 		<file alias="GPSIndicator.qml">../src/ui/toolbar/GPSIndicator.qml</file>
 		<file alias="GPSRTKIndicator.qml">../src/ui/toolbar/GPSRTKIndicator.qml</file>
 		<file alias="JoystickIndicator.qml">../src/ui/toolbar/JoystickIndicator.qml</file>
@@ -308,6 +307,7 @@
 		<file alias="EditPositionDialog.FactMetaData.json">../src/QmlControls/EditPositionDialog.FactMetaData.json</file>
 		<file alias="FirmwareUpgrade.SettingsGroup.json">../src/Settings/FirmwareUpgrade.SettingsGroup.json</file>
 		<file alias="FlightMap.SettingsGroup.json">../src/Settings/FlightMap.SettingsGroup.json</file>
+		<file alias="FlightMode.SettingsGroup.json">../src/Settings/FlightMode.SettingsGroup.json</file>
 		<file alias="FlyView.SettingsGroup.json">../src/Settings/FlyView.SettingsGroup.json</file>
 		<file alias="FWLandingPattern.FactMetaData.json">../src/MissionManager/FWLandingPattern.FactMetaData.json</file>
 		<file alias="MavCmdInfoCommon.json">../src/MissionManager/MavCmdInfoCommon.json</file>

--- a/qgroundcontrol.pro
+++ b/qgroundcontrol.pro
@@ -686,6 +686,7 @@ HEADERS += \
     src/Settings/RemoteIDSettings.h \
     src/Settings/FirmwareUpgradeSettings.h \
     src/Settings/FlightMapSettings.h \
+    src/Settings/FlightModeSettings.h \
     src/Settings/FlyViewSettings.h \
     src/Settings/OfflineMapsSettings.h \
     src/Settings/PlanViewSettings.h \
@@ -944,6 +945,7 @@ SOURCES += \
     src/Settings/RemoteIDSettings.cc \
     src/Settings/FirmwareUpgradeSettings.cc \
     src/Settings/FlightMapSettings.cc \
+    src/Settings/FlightModeSettings.cc \
     src/Settings/FlyViewSettings.cc \
     src/Settings/OfflineMapsSettings.cc \
     src/Settings/PlanViewSettings.cc \

--- a/qgroundcontrol.pro
+++ b/qgroundcontrol.pro
@@ -682,6 +682,7 @@ HEADERS += \
     src/Settings/ADSBVehicleManagerSettings.h \
     src/Settings/AppSettings.h \
     src/Settings/AutoConnectSettings.h \
+    src/Settings/BatteryIndicatorSettings.h \
     src/Settings/BrandImageSettings.h \
     src/Settings/RemoteIDSettings.h \
     src/Settings/FirmwareUpgradeSettings.h \
@@ -941,6 +942,7 @@ SOURCES += \
     src/Settings/ADSBVehicleManagerSettings.cc \
     src/Settings/AppSettings.cc \
     src/Settings/AutoConnectSettings.cc \
+    src/Settings/BatteryIndicatorSettings.cc \
     src/Settings/BrandImageSettings.cc \
     src/Settings/RemoteIDSettings.cc \
     src/Settings/FirmwareUpgradeSettings.cc \

--- a/qgroundcontrol.qrc
+++ b/qgroundcontrol.qrc
@@ -311,6 +311,7 @@
         <file alias="APMMavlinkStreamRate.SettingsGroup.json">src/Settings/APMMavlinkStreamRate.SettingsGroup.json</file>
         <file alias="App.SettingsGroup.json">src/Settings/App.SettingsGroup.json</file>
         <file alias="AutoConnect.SettingsGroup.json">src/Settings/AutoConnect.SettingsGroup.json</file>
+        <file alias="BatteryIndicator.SettingsGroup.json">src/Settings/BatteryIndicator.SettingsGroup.json</file>
         <file alias="BrandImage.SettingsGroup.json">src/Settings/BrandImage.SettingsGroup.json</file>
         <file alias="BreachReturn.FactMetaData.json">src/MissionManager/BreachReturn.FactMetaData.json</file>
         <file alias="CameraCalc.FactMetaData.json">src/MissionManager/CameraCalc.FactMetaData.json</file>

--- a/qgroundcontrol.qrc
+++ b/qgroundcontrol.qrc
@@ -4,7 +4,6 @@
     </qresource>
     <qresource prefix="/toolbar">
         <file alias="ArmedIndicator.qml">src/ui/toolbar/ArmedIndicator.qml</file>
-        <file alias="BatteryIndicator.qml">src/ui/toolbar/BatteryIndicator.qml</file>
         <file alias="GPSIndicator.qml">src/ui/toolbar/GPSIndicator.qml</file>
         <file alias="GPSRTKIndicator.qml">src/ui/toolbar/GPSRTKIndicator.qml</file>
         <file alias="JoystickIndicator.qml">src/ui/toolbar/JoystickIndicator.qml</file>
@@ -84,6 +83,8 @@
         <file alias="QGroundControl/Controls/AppMessages.qml">src/QmlControls/AppMessages.qml</file>
         <file alias="QGroundControl/Controls/AltModeDialog.qml">src/QmlControls/AltModeDialog.qml</file>
         <file alias="QGroundControl/Controls/AxisMonitor.qml">src/QmlControls/AxisMonitor.qml</file>
+        <file alias="QGroundControl/Controls/BatteryIndicator.qml">src/ui/toolbar/BatteryIndicator.qml</file>
+        <file alias="QGroundControl/Controls/BatteryIndicatorContentItem.qml">src/ui/toolbar/BatteryIndicatorContentItem.qml</file>
         <file alias="QGroundControl/Controls/CameraCalcCamera.qml">src/PlanView/CameraCalcCamera.qml</file>
         <file alias="QGroundControl/Controls/CameraCalcGrid.qml">src/PlanView/CameraCalcGrid.qml</file>
         <file alias="QGroundControl/Controls/CameraSection.qml">src/PlanView/CameraSection.qml</file>
@@ -94,16 +95,21 @@
         <file alias="QGroundControl/Controls/DropPanel.qml">src/QmlControls/DropPanel.qml</file>
         <file alias="QGroundControl/Controls/EditPositionDialog.qml">src/QmlControls/EditPositionDialog.qml</file>
         <file alias="QGroundControl/Controls/ExclusiveGroupItem.qml">src/QmlControls/ExclusiveGroupItem.qml</file>
+        <file alias="QGroundControl/Controls/FactSlider.qml">src/QmlControls/FactSlider.qml</file>
         <file alias="QGroundControl/Controls/FactSliderPanel.qml">src/QmlControls/FactSliderPanel.qml</file>
         <file alias="QGroundControl/Controls/FirstRunPrompt.qml">src/FirstRunPromptDialogs/FirstRunPrompt.qml</file>
         <file alias="QGroundControl/Controls/FileButton.qml">src/QmlControls/FileButton.qml</file>
+        <file alias="QGroundControl/Controls/FlightModeIndicator.qml">src/ui/toolbar/FlightModeIndicator.qml</file>
         <file alias="QGroundControl/Controls/FlightModeDropdown.qml">src/QmlControls/FlightModeDropdown.qml</file>
         <file alias="QGroundControl/Controls/FlightModeMenu.qml">src/QmlControls/FlightModeMenu.qml</file>
         <file alias="QGroundControl/Controls/FWLandingPatternMapVisual.qml">src/PlanView/FWLandingPatternMapVisual.qml</file>
+        <file alias="QGroundControl/Controls/GPSIndicatorPage.qml">src/ui/toolbar/GPSIndicatorPage.qml</file>
         <file alias="QGroundControl/Controls/GeoFenceEditor.qml">src/PlanView/GeoFenceEditor.qml</file>
         <file alias="QGroundControl/Controls/GeoFenceMapVisuals.qml">src/PlanView/GeoFenceMapVisuals.qml</file>
         <file alias="QGroundControl/Controls/HorizontalFactValueGrid.qml">src/QmlControls/HorizontalFactValueGrid.qml</file>
         <file alias="QGroundControl/Controls/IndicatorButton.qml">src/QmlControls/IndicatorButton.qml</file>
+        <file alias="QGroundControl/Controls/IndicatorPageButtonRow.qml">src/QmlControls/IndicatorPageButtonRow.qml</file>
+        <file alias="QGroundControl/Controls/IndicatorPageGroupLayout.qml">src/QmlControls/IndicatorPageGroupLayout.qml</file>
         <file alias="QGroundControl/Controls/InstrumentValueLabel.qml">src/QmlControls/InstrumentValueLabel.qml</file>
         <file alias="QGroundControl/Controls/InstrumentValueValue.qml">src/QmlControls/InstrumentValueValue.qml</file>
         <file alias="QGroundControl/Controls/InstrumentValueEditDialog.qml">src/QmlControls/InstrumentValueEditDialog.qml</file>
@@ -113,6 +119,7 @@
         <file alias="QGroundControl/Controls/MainStatusIndicator.qml">src/ui/toolbar/MainStatusIndicator.qml</file>
         <file alias="QGroundControl/Controls/FlightModeMenuIndicator.qml">src/ui/toolbar/FlightModeMenuIndicator.qml</file>
         <file alias="QGroundControl/Controls/MainToolBar.qml">src/ui/toolbar/MainToolBar.qml</file>
+        <file alias="QGroundControl/Controls/MainStatusIndicatorOfflinePage.qml">src/ui/toolbar/MainStatusIndicatorOfflinePage.qml</file>
         <file alias="QGroundControl/Controls/MainWindowSavedState.qml">src/QmlControls/MainWindowSavedState.qml</file>
         <file alias="QGroundControl/Controls/MAVLinkChart.qml">src/QmlControls/MAVLinkChart.qml</file>
         <file alias="QGroundControl/Controls/MAVLinkMessageButton.qml">src/QmlControls/MAVLinkMessageButton.qml</file>
@@ -136,6 +143,7 @@
         <file alias="QGroundControl/Controls/QGCColumnButton.qml">src/QmlControls/QGCColumnButton.qml</file>
         <file alias="QGroundControl/Controls/AutotuneUI.qml">src/QmlControls/AutotuneUI.qml</file>
         <file alias="QGroundControl/Controls/QGCCheckBox.qml">src/QmlControls/QGCCheckBox.qml</file>
+        <file alias="QGroundControl/Controls/QGCCheckBoxSlider.qml">src/QmlControls/QGCCheckBoxSlider.qml</file>
         <file alias="QGroundControl/Controls/QGCColoredImage.qml">src/QmlControls/QGCColoredImage.qml</file>
         <file alias="QGroundControl/Controls/QGCControlDebug.qml">src/QmlControls/QGCControlDebug.qml</file>
         <file alias="QGroundControl/Controls/QGCComboBox.qml">src/QmlControls/QGCComboBox.qml</file>
@@ -150,6 +158,7 @@
         <file alias="QGroundControl/Controls/QGCMapLabel.qml">src/QmlControls/QGCMapLabel.qml</file>
         <file alias="QGroundControl/Controls/QGCMapPolygonVisuals.qml">src/MissionManager/QGCMapPolygonVisuals.qml</file>
         <file alias="QGroundControl/Controls/QGCMapPolylineVisuals.qml">src/MissionManager/QGCMapPolylineVisuals.qml</file>
+        <file alias="QGroundControl/Controls/QGCMarqueeLabel.qml">src/QmlControls/QGCMarqueeLabel.qml</file>
         <file alias="QGroundControl/Controls/QGCMenu.qml">src/QmlControls/QGCMenu.qml</file>
         <file alias="QGroundControl/Controls/QGCMenuItem.qml">src/QmlControls/QGCMenuItem.qml</file>
         <file alias="QGroundControl/Controls/QGCMenuSeparator.qml">src/QmlControls/QGCMenuSeparator.qml</file>
@@ -184,6 +193,7 @@
         <file alias="QGroundControl/Controls/SurveyMapVisual.qml">src/PlanView/SurveyMapVisual.qml</file>
         <file alias="QGroundControl/Controls/TerrainStatus.qml">src/PlanView/TerrainStatus.qml</file>
         <file alias="QGroundControl/Controls/TakeoffItemMapVisual.qml">src/PlanView/TakeoffItemMapVisual.qml</file>
+        <file alias="QGroundControl/Controls/ToolIndicatorPage.qml">src/QmlControls/ToolIndicatorPage.qml</file>
         <file alias="QGroundControl/Controls/ToolStrip.qml">src/QmlControls/ToolStrip.qml</file>
         <file alias="QGroundControl/Controls/ToolStripHoverButton.qml">src/QmlControls/ToolStripHoverButton.qml</file>
         <file alias="QGroundControl/Controls/TransectStyleComplexItemEditor.qml">src/PlanView/TransectStyleComplexItemEditor.qml</file>
@@ -196,6 +206,7 @@
         <file alias="QGroundControl/FactControls/AltitudeFactTextField.qml">src/FactSystem/FactControls/AltitudeFactTextField.qml</file>
         <file alias="QGroundControl/FactControls/FactBitmask.qml">src/FactSystem/FactControls/FactBitmask.qml</file>
         <file alias="QGroundControl/FactControls/FactCheckBox.qml">src/FactSystem/FactControls/FactCheckBox.qml</file>
+        <file alias="QGroundControl/FactControls/FactCheckBoxSlider.qml">src/FactSystem/FactControls/FactCheckBoxSlider.qml</file>
         <file alias="QGroundControl/FactControls/FactComboBox.qml">src/FactSystem/FactControls/FactComboBox.qml</file>
         <file alias="QGroundControl/FactControls/FactLabel.qml">src/FactSystem/FactControls/FactLabel.qml</file>
         <file alias="QGroundControl/FactControls/FactTextField.qml">src/FactSystem/FactControls/FactTextField.qml</file>
@@ -203,6 +214,7 @@
         <file alias="QGroundControl/FactControls/FactTextFieldRow.qml">src/FactSystem/FactControls/FactTextFieldRow.qml</file>
         <file alias="QGroundControl/FactControls/FactTextFieldSlider.qml">src/FactSystem/FactControls/FactTextFieldSlider.qml</file>
         <file alias="QGroundControl/FactControls/FactValueSlider.qml">src/FactSystem/FactControls/FactValueSlider.qml</file>
+        <file alias="QGroundControl/FactControls/IndicatorPageFactTextFieldRow.qml">src/FactSystem/FactControls/IndicatorPageFactTextFieldRow.qml</file>
         <file alias="QGroundControl/FactControls/qmldir">src/QmlControls/QGroundControl/FactControls/qmldir</file>
         <file alias="QGroundControl/FlightDisplay/FlightDisplayViewVideo.qml">src/FlightDisplay/FlightDisplayViewVideo.qml</file>
         <file alias="QGroundControl/FlightDisplay/FlightDisplayViewWidgets.qml">src/FlightDisplay/FlightDisplayViewWidgets.qml</file>
@@ -309,6 +321,7 @@
         <file alias="EditPositionDialog.FactMetaData.json">src/QmlControls/EditPositionDialog.FactMetaData.json</file>
         <file alias="FirmwareUpgrade.SettingsGroup.json">src/Settings/FirmwareUpgrade.SettingsGroup.json</file>
         <file alias="FlightMap.SettingsGroup.json">src/Settings/FlightMap.SettingsGroup.json</file>
+        <file alias="FlightMode.SettingsGroup.json">src/Settings/FlightMode.SettingsGroup.json</file>
         <file alias="FlyView.SettingsGroup.json">src/Settings/FlyView.SettingsGroup.json</file>
         <file alias="FWLandingPattern.FactMetaData.json">src/MissionManager/FWLandingPattern.FactMetaData.json</file>
         <file alias="MavCmdInfoCommon.json">src/MissionManager/MavCmdInfoCommon.json</file>

--- a/src/FactSystem/FactControls/FactCheckBoxSlider.qml
+++ b/src/FactSystem/FactControls/FactCheckBoxSlider.qml
@@ -1,0 +1,21 @@
+import QtQuick
+import QtQuick.Controls
+
+import QGroundControl.FactSystem
+import QGroundControl.Palette
+import QGroundControl.Controls
+
+QGCCheckBoxSlider {
+    property Fact fact: Fact { }
+
+    property var checkedValue:   fact.typeIsBool ? true : 1
+    property var uncheckedValue: fact.typeIsBool ? false : 0
+
+    Binding on checked {
+        value: fact ?
+                (fact.value === uncheckedValue ? Qt.Unchecked : Qt.Checked) :
+                Qt.Unchecked
+    }
+
+    onClicked: fact.value = (checked ? checkedValue : uncheckedValue)
+}

--- a/src/FactSystem/FactControls/FactComboBox.qml
+++ b/src/FactSystem/FactControls/FactComboBox.qml
@@ -25,7 +25,7 @@ QGCComboBox {
         })
     }
 
-    onActivated: {
+    onActivated: (index) => {
         if (indexModel) {
             fact.value = index
         } else {

--- a/src/FactSystem/FactControls/IndicatorPageFactTextFieldRow.qml
+++ b/src/FactSystem/FactControls/IndicatorPageFactTextFieldRow.qml
@@ -1,0 +1,38 @@
+/****************************************************************************
+ *
+ * (c) 2009-2022 QGROUNDCONTROL PROJECT <http://www.qgroundcontrol.org>
+ *
+ * QGroundControl is licensed according to the terms in the file
+ * COPYING.md in the root of the source code directory.
+ *
+ ****************************************************************************/
+
+import QtQuick          2.15
+import QtQuick.Layouts  1.15
+
+import QGroundControl.Controls      1.0
+import QGroundControl.ScreenTools   1.0
+import QGroundControl.FactSystem    1.0
+import QGroundControl.FactControls  1.0
+
+RowLayout {
+    property alias label:                   _label.text
+    property alias fact:                    _factTextField.fact
+    property real  textFieldPreferredWidth: -1
+    property alias textFieldUnitsLabel:     _factTextField.unitsLabel
+    property alias textFieldShowUnits:      _factTextField.showUnits
+    property alias textFieldShowHelp:       _factTextField.showHelp
+
+    spacing: ScreenTools.defaultFontPixelWidth * 2
+
+    QGCLabel {
+        id:                 _label  
+        Layout.fillWidth:   true
+    }
+
+    FactTextField {
+        id:                     _factTextField
+        Layout.preferredWidth:  textFieldPreferredWidth
+    }
+}
+

--- a/src/FirmwarePlugin/FirmwarePlugin.cc
+++ b/src/FirmwarePlugin/FirmwarePlugin.cc
@@ -322,16 +322,22 @@ QString FirmwarePlugin::vehicleImageCompass(const Vehicle*) const
     return QStringLiteral("/qmlimages/compassInstrumentArrow.svg");
 }
 
+QVariant FirmwarePlugin::mainStatusIndicatorExpandedItem(const Vehicle*) const
+{
+    return QVariant();
+}
+
 const QVariantList& FirmwarePlugin::toolIndicators(const Vehicle*)
 {
     //-- Default list of indicators for all vehicles.
     if(_toolIndicatorList.size() == 0) {
         _toolIndicatorList = QVariantList({
+            QVariant::fromValue(QUrl::fromUserInput("qrc:/qml/QGroundControl/Controls/FlightModeIndicator.qml")),
             QVariant::fromValue(QUrl::fromUserInput("qrc:/toolbar/MessageIndicator.qml")),
             QVariant::fromValue(QUrl::fromUserInput("qrc:/toolbar/GPSIndicator.qml")),
             QVariant::fromValue(QUrl::fromUserInput("qrc:/toolbar/TelemetryRSSIIndicator.qml")),
             QVariant::fromValue(QUrl::fromUserInput("qrc:/toolbar/RCRSSIIndicator.qml")),
-            QVariant::fromValue(QUrl::fromUserInput("qrc:/toolbar/BatteryIndicator.qml")),
+            QVariant::fromValue(QUrl::fromUserInput("qrc:/qml/QGroundControl/Controls/BatteryIndicator.qml")),
             QVariant::fromValue(QUrl::fromUserInput("qrc:/toolbar/RemoteIDIndicator.qml")),
         });
     }

--- a/src/FirmwarePlugin/FirmwarePlugin.h
+++ b/src/FirmwarePlugin/FirmwarePlugin.h
@@ -295,6 +295,9 @@ public:
     /// Return the resource file which contains the vehicle icon used in the compass
     virtual QString vehicleImageCompass(const Vehicle* vehicle) const;
 
+    // This is the expanded item for the main status indicator
+    virtual QVariant mainStatusIndicatorExpandedItem(const Vehicle* vehicle) const;
+
     /// Returns the list of toolbar tool indicators associated with a vehicle
     ///     signals toolIndicatorsChanged
     /// @return A list of QUrl with the indicators
@@ -384,7 +387,7 @@ protected:
     // Returns regex QString to extract version information from text
     virtual QString _versionRegex() { return QString(); }
 
-private:
+protected:
     QVariantList _toolIndicatorList;
     QVariantList _modeIndicatorList;
 

--- a/src/FirmwarePlugin/PX4/PX4BatteryIndicator.qml
+++ b/src/FirmwarePlugin/PX4/PX4BatteryIndicator.qml
@@ -1,0 +1,69 @@
+/****************************************************************************
+ *
+ * (c) 2009-2020 QGROUNDCONTROL PROJECT <http://www.qgroundcontrol.org>
+ *
+ * QGroundControl is licensed according to the terms in the file
+ * COPYING.md in the root of the source code directory.
+ *
+ ****************************************************************************/
+
+import QtQuick
+import QtQuick.Layouts
+
+import QGroundControl
+import QGroundControl.Controls
+import QGroundControl.MultiVehicleManager
+import QGroundControl.ScreenTools
+import QGroundControl.Palette
+import QGroundControl.FactSystem
+import QGroundControl.FactControls
+import MAVLink
+
+BatteryIndicator {
+    waitForParameters: true
+
+    expandedPageComponent: Component {
+        ColumnLayout {
+            spacing: ScreenTools.defaultFontPixelHeight / 2
+
+            FactPanelController { id: controller }
+
+            IndicatorPageGroupLayout {
+                Layout.fillWidth:   true
+                heading:            qsTr("Low Battery")
+
+                GridLayout {
+                    columns: 2
+                    columnSpacing: ScreenTools.defaultFontPixelHeight
+
+                    QGCLabel { text: qsTr("Warning Level") }
+                    FactTextField {
+                        Layout.fillWidth:       true
+                        fact:                   controller.getParameterFact(-1, "BAT_LOW_THR")
+                    }
+
+                    QGCLabel { text: qsTr("Failsafe Level") }
+                    FactTextField {
+                        Layout.fillWidth:       true
+                        fact:                   controller.getParameterFact(-1, "BAT_CRIT_THR")
+                    }
+
+                    QGCLabel { text: qsTr("Failsafe Action") }
+                    FactComboBox {
+                        Layout.fillWidth:       true
+                        Layout.preferredWidth:  ScreenTools.implicitTextFieldWidth
+                        fact:                   controller.getParameterFact(-1, "COM_LOW_BAT_ACT")
+                        indexModel:             false
+                        sizeToContents:         true
+                    }
+
+                    QGCLabel { text: qsTr("Emergency Level") }
+                    FactTextField {
+                        Layout.fillWidth:       true
+                        fact:                   controller.getParameterFact(-1, "BAT_EMERGEN_THR")
+                    }
+                }
+            }
+        }
+    }
+}

--- a/src/FirmwarePlugin/PX4/PX4FirmwarePlugin.cc
+++ b/src/FirmwarePlugin/PX4/PX4FirmwarePlugin.cc
@@ -738,3 +738,24 @@ bool PX4FirmwarePlugin::hasGripper(const Vehicle* vehicle) const
     }
     return false;
 }
+
+QVariant PX4FirmwarePlugin::mainStatusIndicatorExpandedItem(const Vehicle*) const
+{
+    return QVariant::fromValue(QUrl::fromUserInput("qrc:/PX4/Indicators/PX4MainStatusIndicatorExpandedItem.qml"));
+}
+
+const QVariantList& PX4FirmwarePlugin::toolIndicators(const Vehicle*)
+{
+    //-- Default list of indicators for all vehicles.
+    if(_toolIndicatorList.size() == 0) {
+        _toolIndicatorList = QVariantList({
+            QVariant::fromValue(QUrl::fromUserInput("qrc:/PX4/Indicators/PX4FlightModeIndicator.qml")),
+            QVariant::fromValue(QUrl::fromUserInput("qrc:/toolbar/MessageIndicator.qml")),
+            QVariant::fromValue(QUrl::fromUserInput("qrc:/toolbar/GPSIndicator.qml")),
+            QVariant::fromValue(QUrl::fromUserInput("qrc:/toolbar/TelemetryRSSIIndicator.qml")),
+            QVariant::fromValue(QUrl::fromUserInput("qrc:/toolbar/RCRSSIIndicator.qml")),
+            QVariant::fromValue(QUrl::fromUserInput("qrc:/PX4/Indicators/PX4BatteryIndicator.qml")),
+        });
+    }
+    return _toolIndicatorList;
+}

--- a/src/FirmwarePlugin/PX4/PX4FirmwarePlugin.h
+++ b/src/FirmwarePlugin/PX4/PX4FirmwarePlugin.h
@@ -73,6 +73,8 @@ public:
     bool                supportsNegativeThrust          (Vehicle* vehicle) override;
     QString             getHobbsMeter                   (Vehicle* vehicle) override;
     bool                hasGripper                      (const Vehicle* vehicle) const override;
+    QVariant            mainStatusIndicatorExpandedItem(const Vehicle* vehicle) const override;
+    const QVariantList& toolIndicators                  (const Vehicle* vehicle) override;
 
 protected:
     typedef struct {

--- a/src/FirmwarePlugin/PX4/PX4FlightModeIndicator.qml
+++ b/src/FirmwarePlugin/PX4/PX4FlightModeIndicator.qml
@@ -1,0 +1,218 @@
+/****************************************************************************
+ *
+ * (c) 2009-2022 QGROUNDCONTROL PROJECT <http://www.qgroundcontrol.org>
+ *
+ * QGroundControl is licensed according to the terms in the file
+ * COPYING.md in the root of the source code directory.
+ *
+ ****************************************************************************/
+
+import QtQuick
+import QtQuick.Controls
+import QtQuick.Layouts
+
+import QGroundControl
+import QGroundControl.Controls
+import QGroundControl.MultiVehicleManager
+import QGroundControl.ScreenTools
+import QGroundControl.Palette
+import QGroundControl.FactSystem
+import QGroundControl.FactControls
+
+FlightModeIndicator {
+    waitForParameters: true
+
+    expandedPageComponent: Component {
+        ColumnLayout {
+            Layout.preferredWidth:  ScreenTools.defaultFontPixelWidth * 60
+            spacing:                margins / 2
+
+            property Fact mpcLandSpeedFact:         controller.getParameterFact(-1, "MPC_LAND_SPEED", false)
+            property Fact precisionLandingFact:     controller.getParameterFact(-1, "RTL_PLD_MD", false)
+            property Fact sys_vehicle_resp:         controller.getParameterFact(-1, "SYS_VEHICLE_RESP", false)
+            property Fact mpc_xy_vel_all:           controller.getParameterFact(-1, "MPC_XY_VEL_ALL", false)
+            property Fact mpc_z_vel_all:            controller.getParameterFact(-1, "MPC_Z_VEL_ALL", false)
+            property var  qgcPal:                   QGroundControl.globalPalette
+            property real margins:                  ScreenTools.defaultFontPixelHeight
+            property real valueColumnWidth:         Math.max(ScreenTools.implicitTextFieldWidth, precisionLandingCombo.implicitWidth)
+
+            FactPanelController { id: controller }
+
+            IndicatorPageGroupLayout {
+                Layout.fillWidth: true
+
+                IndicatorPageFactTextFieldRow {
+                    Layout.fillWidth:           true;
+                    label:                      qsTr("RTL Altitude")
+                    fact:                       controller.getParameterFact(-1, "RTL_RETURN_ALT")
+                    textFieldPreferredWidth:    valueColumnWidth
+                }
+
+                IndicatorPageFactTextFieldRow {
+                    Layout.fillWidth:           true;
+                    label:                      qsTr("Land Descent Rate")
+                    fact:                       mpcLandSpeedFact
+                    textFieldPreferredWidth:    valueColumnWidth
+                    visible:                    mpcLandSpeedFact && controller.vehicle && !controller.vehicle.fixedWing
+                }
+
+                RowLayout {
+                    Layout.fillWidth: true
+                    spacing:          ScreenTools.defaultFontPixelWidth * 2
+                    visible:          precisionLandingFact
+
+                    QGCLabel {
+                        Layout.fillWidth:   true;
+                        text:               qsTr("Precision Landing")
+                    }
+                    FactComboBox {
+                        id:                     precisionLandingCombo
+                        Layout.minimumWidth:    ScreenTools.implicitTextFieldWidth
+                        fact:                   precisionLandingFact
+                        indexModel:             false
+                        sizeToContents:         true
+                    }
+                }
+            }
+
+            IndicatorPageGroupLayout {
+                Layout.fillWidth:   true
+                visible:            sys_vehicle_resp
+
+                ColumnLayout {
+                    Layout.fillWidth:   true
+
+                    QGCCheckBoxSlider {
+                        id:                 responsivenessCheckBox
+                        Layout.fillWidth:   true
+                        text:               qsTr("Overall Responsiveness")
+                        checked:            sys_vehicle_resp && sys_vehicle_resp.value >= 0
+
+                        onClicked: {
+                            if (checked) {
+                                sys_vehicle_resp.value = Math.abs(sys_vehicle_resp.value)
+                            } else {
+                                sys_vehicle_resp.value = -Math.abs(sys_vehicle_resp.value)
+                            }
+                        }
+                    }
+
+                    FactSlider {
+                        Layout.fillWidth:   true
+                        enabled:            responsivenessCheckBox.checked
+                        fact:               sys_vehicle_resp
+                        from:               0.01
+                        to:                 1
+                        stepSize:           0.01
+                    }
+
+                    QGCLabel {
+                        Layout.fillWidth:   true
+                        enabled:            responsivenessCheckBox.checked
+                        text:               qsTr("A higher value makes the vehicle react faster. Be aware that this affects braking as well, and a combination of slow responsiveness with high maximum velocity will lead to long braking distances.")
+                        wrapMode:           QGCLabel.WordWrap
+                    }
+                    QGCLabel {
+                        Layout.fillWidth:   true
+                        visible:            sys_vehicle_resp && sys_vehicle_resp.value > 0.8
+                        color:              qgcPal.warningText
+                        text:               qsTr("Warning: a high responsiveness requires a vehicle with large thrust-to-weight ratio. The vehicle might lose altitude otherwise.")
+                        wrapMode:           QGCLabel.WordWrap
+                    }
+                }
+
+                Item {
+                    Layout.fillWidth:   true
+                    height:             1
+                }
+
+                ColumnLayout {
+                    Layout.fillWidth:   true
+                    visible:            mpc_xy_vel_all
+
+                    QGCCheckBoxSlider {
+                        id:                 xyVelCheckBox
+                        Layout.fillWidth:   true
+                        text:               qsTr("Overall Horizontal Velocity (m/s)")
+                        checked:            mpc_xy_vel_all && mpc_xy_vel_all.value >= 0
+
+                        onClicked: {
+                            if (checked) {
+                                mpc_xy_vel_all.value = Math.abs(mpc_xy_vel_all.value)
+                            } else {
+                                mpc_xy_vel_all.value = -Math.abs(mpc_xy_vel_all.value)
+                            }
+                        }
+                    }
+
+                    FactSlider {
+                        Layout.fillWidth:   true
+                        enabled:            xyVelCheckBox.checked
+                        fact:               mpc_xy_vel_all
+                        from:               0.5
+                        to:                 20
+                        stepSize:           0.5
+                    }
+
+                    Item {
+                        Layout.fillWidth: true
+                        height: 1
+                    }
+
+                    ColumnLayout {
+                        Layout.fillWidth:   true
+                        visible:            mpc_z_vel_all
+
+                        QGCCheckBoxSlider {
+                            id:                 zVelCheckBox
+                            Layout.fillWidth:   true
+                            text:               qsTr("Overall Vertical Velocity (m/s)")
+                            checked:            mpc_z_vel_all && mpc_z_vel_all.value >= 0
+
+                            onClicked: {
+                                if (checked) {
+                                    mpc_z_vel_all.value = Math.abs(mpc_z_vel_all.value)
+                                } else {
+                                    mpc_z_vel_all.value = -Math.abs(mpc_z_vel_all.value)
+                                }
+                            }
+                        }
+
+                        FactSlider {
+                            Layout.fillWidth:   true
+                            enabled:            zVelCheckBox.checked
+                            fact:               mpc_z_vel_all
+                            from:               0.2
+                            to:                 8
+                            stepSize:           0.2
+                        }
+                    }
+                }
+            }
+
+            IndicatorPageGroupLayout {
+                Layout.fillWidth:  true
+
+                ColumnLayout {
+                    Layout.fillWidth: true
+
+                    QGCLabel { text: qsTr("Mission Turning Radius") }
+
+                    FactSlider {
+                        Layout.fillWidth:   true
+                        fact:               controller.getParameterFact(-1, "NAV_ACC_RAD")
+                        from:               2
+                        to:                 16
+                        stepSize:           0.5
+                    }
+
+                    QGCLabel {
+                        Layout.fillWidth:   true
+                        text:               qsTr("Increasing this leads to rounder turns in missions (corner cutting). Use the minimum value for accurate corner tracking.")
+                        wrapMode:           QGCLabel.WordWrap
+                    }
+                }
+            }
+        }
+    }
+}

--- a/src/FirmwarePlugin/PX4/PX4MainStatusIndicatorExpandedItem.qml
+++ b/src/FirmwarePlugin/PX4/PX4MainStatusIndicatorExpandedItem.qml
@@ -1,0 +1,88 @@
+/****************************************************************************
+ *
+ * (c) 2009-2022 QGROUNDCONTROL PROJECT <http://www.qgroundcontrol.org>
+ *
+ * QGroundControl is licensed according to the terms in the file
+ * COPYING.md in the root of the source code directory.
+ *
+ ****************************************************************************/
+
+import QtQuick          2.15
+import QtQuick.Controls 2.15
+import QtQuick.Layouts  1.11
+
+import QGroundControl                       1.0
+import QGroundControl.Controls              1.0
+import QGroundControl.MultiVehicleManager   1.0
+import QGroundControl.ScreenTools           1.0
+import QGroundControl.Palette               1.0
+import QGroundControl.FactSystem            1.0
+import QGroundControl.FactControls          1.0
+
+IndicatorPageGroupLayout {
+    spacing:        ScreenTools.defaultFontPixelHeight / 2
+    showDivider:    false
+
+    property real valueColumnWidth:         Math.max(ScreenTools.implicitTextFieldWidth, failsafeActionCombo.implicitWidth)
+
+    FactPanelController { id: controller }
+
+    IndicatorPageGroupLayout {
+        heading:            qsTr("Ground Control Data Link Loss")
+        Layout.fillWidth:   true
+
+        RowLayout {
+            Layout.fillWidth: true
+            spacing:          ScreenTools.defaultFontPixelWidth * 2
+
+            QGCLabel {
+                Layout.fillWidth:   true;
+                text:               qsTr("Failsafe Action")
+            }
+            FactComboBox {
+                id:                     failsafeActionCombo
+                Layout.minimumWidth:    ScreenTools.implicitTextFieldWidth
+                fact:                   controller.getParameterFact(-1, "NAV_DLL_ACT")
+                indexModel:             false
+                sizeToContents:         true
+            }
+        }
+
+        IndicatorPageFactTextFieldRow {
+            Layout.fillWidth:           true;
+            label:                      qsTr("Data Link Loss Timeout")
+            fact:                       controller.getParameterFact(-1, "COM_DL_LOSS_T")
+            textFieldPreferredWidth:    valueColumnWidth
+        }
+    }
+
+    IndicatorPageGroupLayout {
+        Layout.fillWidth:   true
+        showDivider:        false
+
+        GridLayout {
+            columns:            2
+            rowSpacing:         ScreenTools.defaultFontPixelHeight / 2
+            columnSpacing:      ScreenTools.defaultFontPixelWidth *2
+            Layout.fillWidth:   true
+
+            QGCLabel { Layout.fillWidth: true; text: qsTr("Vehicle Parameters") }
+            QGCButton {
+                text: qsTr("Configure")
+                onClicked: {                            
+                    mainWindow.showVehicleSetupTool(qsTr("Parameters"))
+                    drawer.close()
+                }
+            }
+
+            QGCLabel { Layout.fillWidth: true; text: qsTr("Initial Vehicle Setup") }
+            QGCButton {
+                text: qsTr("Configure")
+                onClicked: {                            
+                    mainWindow.showVehicleSetupTool()
+                    drawer.close()
+                }
+            }
+        }
+    }
+}

--- a/src/FirmwarePlugin/PX4/PX4Resources.qrc
+++ b/src/FirmwarePlugin/PX4/PX4Resources.qrc
@@ -32,6 +32,12 @@
         <file alias="QGroundControl/PX4/qmldir">../../QmlControls/QGroundControl/PX4/qmldir</file>
         <file alias="QGroundControl/PX4/BatteryParams.qml">../../AutoPilotPlugins/PX4/BatteryParams.qml</file>
     </qresource>
+    <qresource prefix="/PX4/Indicators">
+        <file alias="PX4FlightModeIndicator.qml">PX4FlightModeIndicator.qml</file>
+        <file alias="PX4BatteryIndicator.qml">PX4BatteryIndicator.qml</file>
+        <file alias="PX4MainStatusIndicatorExpandedItem.qml">PX4MainStatusIndicatorExpandedItem.qml</file>
+    </qresource>
+
     <qresource prefix="/json">
         <file alias="PX4-MavCmdInfoCommon.json">PX4-MavCmdInfoCommon.json</file>
         <file alias="PX4-MavCmdInfoFixedWing.json">PX4-MavCmdInfoFixedWing.json</file>

--- a/src/QmlControls/FactSlider.qml
+++ b/src/QmlControls/FactSlider.qml
@@ -1,0 +1,103 @@
+/****************************************************************************
+ *
+ * (c) 2009-2020 QGROUNDCONTROL PROJECT <http://www.qgroundcontrol.org>
+ *
+ * QGroundControl is licensed according to the terms in the file
+ * COPYING.md in the root of the source code directory.
+ *
+ ****************************************************************************/
+
+import QtQuick                  2.15
+import QtQuick.Controls         2.15
+import QtQuick.Layouts          1.15
+
+import QGroundControl.FactSystem    1.0
+import QGroundControl.Palette       1.0
+import QGroundControl.ScreenTools   1.0
+
+Slider {
+    id:             control
+    value:          fact.value
+    snapMode:       stepSize ? Slider.SnapAlways : Slider.NoSnap
+    live:           true
+    bottomPadding:  sliderLabel.contentHeight
+    leftPadding:    0
+    rightPadding:   0
+
+    property Fact fact
+
+    property bool _loadComplete: false
+
+    Component.onCompleted: _loadComplete = true
+
+    Timer {
+        id:             updateTimer
+        interval:       1000
+        repeat:         false
+        running:        false
+        onTriggered:    fact.value = control.value
+    }
+
+    onValueChanged: {
+        if (_loadComplete && enabled) {
+            // We don't want to spam the vehicle with parameter updates
+            updateTimer.restart()
+        }
+    }
+
+    QGCPalette {
+        id:                 qgcPal
+        colorGroupEnabled:  control.enabled
+    }
+
+    background: Item {
+        implicitWidth:  ScreenTools.defaultFontPixelWidth * 40
+        implicitHeight: ScreenTools.defaultFontPixelHeight + sliderLabel.contentHeight
+
+        Rectangle {
+            id:     sliderBar
+            x:      control.leftPadding
+            y:      control.topPadding + (control.availableHeight / 2) - (height / 2)
+            height: ScreenTools.defaultFontPixelHeight / 3
+            width:  control.availableWidth
+            radius: height / 2
+            color:  qgcPal.button
+        }
+
+        QGCLabel {
+            id:         sliderLabel
+            text:       control.from.toFixed(fact.decimalPlaces)
+            visible:    control.value !== control.from
+            anchors {
+                left:   parent.left
+                bottom: parent.bottom
+            }
+        }
+
+        QGCLabel {
+            text:       control.to.toFixed(fact.decimalPlaces)
+            visible:    control.value !== control.to
+            anchors {
+                right:  parent.right
+                bottom: parent.bottom
+            }
+        }
+
+        QGCLabel {
+            anchors.bottom:         parent.bottom
+            x:                      control.leftPadding + (control.visualPosition * (control.availableWidth - width))
+            text:                   control.value.toFixed(control.fact.decimalPlaces)
+            horizontalAlignment:    Text.AlignHCenter
+        }
+    }
+
+    handle: Rectangle {
+        x:              control.leftPadding + control.visualPosition * (control.availableWidth - width)
+        y:              control.topPadding + control.availableHeight / 2 - height / 2
+        implicitWidth:  implicitHeight
+        implicitHeight: ScreenTools.defaultFontPixelHeight
+        radius:         implicitHeight / 2
+        color:          qgcPal.button
+        border.color:   qgcPal.buttonText
+    }
+}

--- a/src/QmlControls/IndicatorPageButtonRow.qml
+++ b/src/QmlControls/IndicatorPageButtonRow.qml
@@ -1,0 +1,37 @@
+/****************************************************************************
+ *
+ * (c) 2009-2022 QGROUNDCONTROL PROJECT <http://www.qgroundcontrol.org>
+ *
+ * QGroundControl is licensed according to the terms in the file
+ * COPYING.md in the root of the source code directory.
+ *
+ ****************************************************************************/
+
+import QtQuick          2.15
+import QtQuick.Layouts  1.15
+
+import QGroundControl.Controls      1.0
+import QGroundControl.ScreenTools   1.0
+
+RowLayout {
+    property alias label:                   _label.text
+    property alias buttonText:              _button.text
+    property real  buttonPreferredWidth:    -1
+
+    signal clicked
+
+    id:         _root
+    spacing:    ScreenTools.defaultFontPixelWidth * 2
+
+    QGCLabel { 
+        id:                 _label
+        Layout.fillWidth:   true 
+    }
+
+    QGCButton {
+        id:                     _button
+        Layout.preferredWidth:  buttonPreferredWidth
+        onClicked:              _root.clicked()
+    }
+}
+

--- a/src/QmlControls/IndicatorPageGroupLayout.qml
+++ b/src/QmlControls/IndicatorPageGroupLayout.qml
@@ -1,0 +1,33 @@
+import QtQuick          2.15
+import QtQuick.Layouts  1.15
+
+import QGroundControl               1.0
+import QGroundControl.ScreenTools   1.0
+
+ColumnLayout {
+    id:         _root
+    spacing:    ScreenTools.defaultFontPixelHeight / 2
+
+    property alias heading:     headingLabel.text
+    property bool  showDivider: true
+
+    default property alias contentItem: _contentItem.data
+
+    QGCLabel { 
+        id:         headingLabel
+        visible:    heading !== ""
+    }
+
+    ColumnLayout {
+        id:                 _contentItem
+        Layout.fillWidth:   children[0].Layout.fillWidth
+        Layout.leftMargin:  heading === "" ? 0 : ScreenTools.defaultFontPixelWidth * 2
+    }
+
+    Rectangle {
+        height:             1
+        Layout.fillWidth:   true
+        color:              QGroundControl.globalPalette.text
+        visible:            showDivider
+    }
+}

--- a/src/QmlControls/QGCCheckBoxSlider.qml
+++ b/src/QmlControls/QGCCheckBoxSlider.qml
@@ -1,0 +1,54 @@
+/****************************************************************************
+ *
+ * (c) 2009-2020 QGROUNDCONTROL PROJECT <http://www.qgroundcontrol.org>
+ *
+ * QGroundControl is licensed according to the terms in the file
+ * COPYING.md in the root of the source code directory.
+ *
+ ****************************************************************************/
+
+import QtQuick
+import QtQuick.Controls
+import QtQuick.Layouts
+
+import QGroundControl.Palette
+import QGroundControl.ScreenTools
+
+AbstractButton   {
+    id:             control
+    checkable:      true
+    padding:        0
+
+    QGCPalette { id: qgcPal; colorGroupEnabled: control.enabled }
+
+    contentItem: Item {
+        implicitWidth:  label.contentWidth + indicator.width + ScreenTools.defaultFontPixelWidth
+        implicitHeight: label.contentHeight
+
+        QGCLabel { 
+            id:             label
+            anchors.left:   parent.left
+            text:           visible ? control.text : "X"
+            visible:        control.text !== ""
+        }
+    
+        Rectangle {
+            id:                     indicator
+            anchors.right:          parent.right
+            anchors.verticalCenter: parent.verticalCenter
+            height:                 ScreenTools.defaultFontPixelHeight
+            width:                  height * 2
+            radius:                 height / 2
+            color:                  control.checked ? qgcPal.primaryButton : qgcPal.button
+
+            Rectangle {
+                anchors.verticalCenter: parent.verticalCenter
+                x:                      checked ? indicator.width - width - 1: 1
+                height:                 parent.height - 2
+                width:                  height
+                radius:                 height / 2
+                color:                  qgcPal.buttonText
+            }
+        }
+    }
+}

--- a/src/QmlControls/QGCMarqueeLabel.qml
+++ b/src/QmlControls/QGCMarqueeLabel.qml
@@ -1,0 +1,123 @@
+import QtQuick                  2.12
+import QtQuick.Controls         2.12
+
+import QGroundControl.Palette       1.0
+import QGroundControl.ScreenTools   1.0
+
+Item {
+    property color  color:          qgcPal.text
+    property alias  contentHeight:  _measureText.contentHeight
+    property font   font
+    property string text:           ""
+    property real   maxWidth:       _measureText.implicitWidth
+
+    id:             _root
+    clip:           true
+    implicitWidth:  Math.min(_measureText.implicitWidth, maxWidth)
+    implicitHeight: _measureText.implicitHeight
+    font.pointSize: ScreenTools.defaultFontPointSize
+    font.family:    ScreenTools.normalFontFamily
+
+    property bool _scrollMarquee:       _measureText.implicitWidth > maxWidth
+    property real _scrollWidth:         _measureText.implicitWidth + _measureBlanks.implicitWidth
+    property int  _scrollDuration:      _root.text.length * 500
+    property real _innerText1StartX:    0
+    property real _innerText2StartX:    _scrollWidth
+    property bool _componentCompleted:  false
+
+    Component.onCompleted: {
+        _componentCompleted = true
+        if (_scrollMarquee) {
+            _innerText1Animation.start()
+            _innerText2Animation.start()
+        }
+    }
+
+    on_ScrollWidthChanged: _recalcTimer.restart()    // Wait for update storm to settle out before recalcing
+
+    Timer {
+        id:         _recalcTimer
+        interval:   100
+
+        onTriggered: {
+            if (!_componentCompleted) {
+                return
+            }
+            _innerText1Animation.stop()
+            _innerText2Animation.stop()
+            _innerText1.startX  = _innerText1StartX
+            _innerText2.startX  = _innerText2StartX
+            _innerText1.x       = _innerText1.startX
+            _innerText2.x       = _innerText2.startX
+            if (_measureText.implicitWidth > maxWidth) {
+                _innerText1Animation.start()
+                _innerText2Animation.start()
+            }
+        }
+    }
+
+    QGCPalette { id: qgcPal; colorGroupEnabled: enabled }
+
+    Text {
+        id:                     _innerText1
+        anchors.verticalCenter: parent.verticalCenter
+        font:                   _root.font
+        color:                 _root.color
+        antialiasing:           true
+        text:                   _root.text
+
+        property real startX: _innerText1StartX
+
+        NumberAnimation on x {
+            id:         _innerText1Animation
+            from:       _innerText1.startX
+            to:         _innerText1.startX -_scrollWidth
+            duration:   _scrollDuration
+
+            onFinished: {
+                _innerText2Animation.stop()
+                var text1StartX = _innerText1.startX
+                var text2StartX = _innerText2.startX
+                _innerText1.startX = text2StartX
+                _innerText2.startX = text1StartX
+                start()
+                _innerText2Animation.start()
+            }
+        }
+    }
+
+    Text {
+        id:                     _innerText2
+        anchors.verticalCenter: parent.verticalCenter
+        font:                   _root.font
+        color:                 _root.color
+        antialiasing:           true
+        text:                   _root.text
+        visible:                _scrollMarquee
+
+        property real startX: _innerText2StartX
+
+        NumberAnimation on x {
+            id:         _innerText2Animation
+            from:       _innerText2.startX
+            to:         _innerText2.startX -_scrollWidth
+            duration:   _scrollDuration
+        }
+    }
+
+    Text {
+        id:             _measureText
+        font:           _root.font
+        antialiasing:   true
+        text:           _root.text
+        visible:        false
+    }
+
+    Text {
+        id:             _measureBlanks
+        font:           _root.font
+        antialiasing:   true
+        text:           "  "
+        visible:        false
+    }
+}

--- a/src/QmlControls/QGCTextField.qml
+++ b/src/QmlControls/QGCTextField.qml
@@ -9,14 +9,13 @@ import QGroundControl.ScreenTools
 TextField {
     id:                 control
     color:              qgcPal.textFieldText
-    implicitHeight:     ScreenTools.implicitTextFieldHeight
     activeFocusOnPress: true
     antialiasing:       true
     font.pointSize:     ScreenTools.defaultFontPointSize
     font.family:        ScreenTools.normalFontFamily
     inputMethodHints:   numericValuesOnly && !ScreenTools.isiOS ?
-                          Qt.ImhFormattedNumbersOnly:  // Forces use of virtual numeric keyboard instead of full keyboard
-                          Qt.ImhNone                   // iOS numeric keyboard has no done button, we can't use it.
+                            Qt.ImhFormattedNumbersOnly:  // Forces use of virtual numeric keyboard instead of full keyboard
+                            Qt.ImhNone                   // iOS numeric keyboard has no done button, we can't use it.
     leftPadding:        _marginPadding
     rightPadding:       _marginPadding + unitsHelpLayout.width
     topPadding:         _marginPadding
@@ -58,6 +57,7 @@ TextField {
         color:          qgcPal.textField
         implicitWidth:  ScreenTools.implicitTextFieldWidth
         implicitHeight: ScreenTools.implicitTextFieldHeight
+        implicitWidth:  ScreenTools.implicitTextFieldWidth
 
         RowLayout {
             id:                     unitsHelpLayout

--- a/src/QmlControls/QGCTextField.qml
+++ b/src/QmlControls/QGCTextField.qml
@@ -57,7 +57,6 @@ TextField {
         color:          qgcPal.textField
         implicitWidth:  ScreenTools.implicitTextFieldWidth
         implicitHeight: ScreenTools.implicitTextFieldHeight
-        implicitWidth:  ScreenTools.implicitTextFieldWidth
 
         RowLayout {
             id:                     unitsHelpLayout

--- a/src/QmlControls/QGroundControl/Controls/qmldir
+++ b/src/QmlControls/QGroundControl/Controls/qmldir
@@ -4,6 +4,8 @@ AnalyzePage                             1.0 AnalyzePage.qml
 AppMessages                             1.0 AppMessages.qml
 AltModeDialog                           1.0 AltModeDialog.qml
 AxisMonitor                             1.0 AxisMonitor.qml
+BatteryIndicator                        1.0 BatteryIndicator.qml
+BatteryIndicatorContentItem             1.0 BatteryIndicatorContentItem.qml
 CameraCalcCamera                        1.0 CameraCalcCamera.qml
 CameraCalcGrid                          1.0 CameraCalcGrid.qml
 ContentAreaCalc                         1.0 ContentAreaCalc.qml
@@ -15,17 +17,22 @@ DropButton                              1.0 DropButton.qml
 DropPanel                               1.0 DropPanel.qml
 EditPositionDialog                      1.0 EditPositionDialog.qml
 ExclusiveGroupItem                      1.0 ExclusiveGroupItem.qml
+FactSlider                              1.0 FactSlider.qml
 FactSliderPanel                         1.0 FactSliderPanel.qml
 FirstRunPrompt                          1.0 FirstRunPrompt.qml
 FileButton                              1.0 FileButton.qml
+FlightModeIndicator                     1.0 FlightModeIndicator.qml
 FlightModeDropdown                      1.0 FlightModeDropdown.qml
 FlightModeMenu                          1.0 FlightModeMenu.qml
 GeoFenceEditor                          1.0 GeoFenceEditor.qml
 GeoFenceMapVisuals                      1.0 GeoFenceMapVisuals.qml
+GPSIndicatorPage                        1.0 GPSIndicatorPage.qml
 HackFileDialog                          1.0 HackFileDialog.qml
 HeightIndicator                         1.0 HeightIndicator.qml
 HorizontalFactValueGrid                 1.0 HorizontalFactValueGrid.qml
 IndicatorButton                         1.0 IndicatorButton.qml
+IndicatorPageButtonRow                  1.0 IndicatorPageButtonRow.qml
+IndicatorPageGroupLayout                1.0 IndicatorPageGroupLayout.qml
 InstrumentValueLabel                    1.0 InstrumentValueLabel.qml
 InstrumentValueValue                    1.0 InstrumentValueValue.qml
 InstrumentValueEditDialog               1.0 InstrumentValueEditDialog.qml
@@ -35,6 +42,7 @@ LogReplayStatusBar                      1.0 LogReplayStatusBar.qml
 MainStatusIndicator                     1.0 MainStatusIndicator.qml
 FlightModeMenuIndicator                 1.0 FlightModeMenuIndicator.qml
 MainToolBar                             1.0 MainToolBar.qml
+MainStatusIndicatorOfflinePage          1.0 MainStatusIndicatorOfflinePage.qml
 MainWindowSavedState                    1.0 MainWindowSavedState.qml
 MAVLinkMessageButton                    1.0 MAVLinkMessageButton.qml
 MissionCommandDialog                    1.0 MissionCommandDialog.qml
@@ -58,6 +66,7 @@ QGCButton                               1.0 QGCButton.qml
 QGCColumnButton                         1.0 QGCColumnButton.qml
 AutotuneUI                              1.0 AutotuneUI.qml
 QGCCheckBox                             1.0 QGCCheckBox.qml
+QGCCheckBoxSlider                       1.0 QGCCheckBoxSlider.qml
 QGCColoredImage                         1.0 QGCColoredImage.qml
 QGCComboBox                             1.0 QGCComboBox.qml
 QGCControlDebug                         1.0 QGCControlDebug.qml
@@ -71,6 +80,7 @@ QGCMapCircleVisuals                     1.0 QGCMapCircleVisuals.qml
 QGCMapLabel                             1.0 QGCMapLabel.qml
 QGCMapPolygonVisuals                    1.0 QGCMapPolygonVisuals.qml
 QGCMapPolylineVisuals                   1.0 QGCMapPolylineVisuals.qml
+QGCMarqueeLabel                         1.0 QGCMarqueeLabel.qml
 QGCMenu                                 1.0 QGCMenu.qml
 QGCMenuItem                             1.0 QGCMenuItem.qml
 QGCMenuSeparator                        1.0 QGCMenuSeparator.qml
@@ -103,6 +113,7 @@ SliderSwitch                            1.0 SliderSwitch.qml
 SubMenuButton                           1.0 SubMenuButton.qml
 SurveyMapVisuals                        1.0 SurveyMapVisuals.qml
 TerrainStatus                           1.0 TerrainStatus.qml
+ToolIndicatorPage                       1.0 ToolIndicatorPage.qml
 TransectStyleComplexItemEditor          1.0 TransectStyleComplexItemEditor.qml
 TransectStyleComplexItemStats           1.0 TransectStyleComplexItemStats.qml
 TransectStyleComplexItemTabBar          1.0 TransectStyleComplexItemTabBar.qml

--- a/src/QmlControls/QGroundControl/FactControls/qmldir
+++ b/src/QmlControls/QGroundControl/FactControls/qmldir
@@ -1,12 +1,14 @@
 Module QGroundControl.FactControls
 
-AltitudeFactTextField   1.0 AltitudeFactTextField.qml
-FactBitmask             1.0 FactBitmask.qml
-FactCheckBox            1.0 FactCheckBox.qml
-FactComboBox            1.0 FactComboBox.qml
-FactLabel               1.0 FactLabel.qml
-FactTextField           1.0 FactTextField.qml
-FactTextFieldGrid       1.0 FactTextFieldGrid.qml
-FactTextFieldRow        1.0 FactTextFieldRow.qml
-FactValueSlider         1.0 FactValueSlider.qml
-FactTextFieldSlider     1.0 FactTextFieldSlider.qml
+AltitudeFactTextField           1.0 AltitudeFactTextField.qml
+FactBitmask                     1.0 FactBitmask.qml
+FactCheckBox                    1.0 FactCheckBox.qml
+FactCheckBoxSlider              1.0 FactCheckBoxSlider.qml
+FactComboBox                    1.0 FactComboBox.qml
+FactLabel                       1.0 FactLabel.qml
+FactTextField                   1.0 FactTextField.qml
+FactTextFieldGrid               1.0 FactTextFieldGrid.qml
+FactTextFieldRow                1.0 FactTextFieldRow.qml
+FactValueSlider                 1.0 FactValueSlider.qml
+FactTextFieldSlider             1.0 FactTextFieldSlider.qml
+IndicatorPageFactTextFieldRow   1.0 IndicatorPageFactTextFieldRow.qml

--- a/src/QmlControls/ScreenTools.qml
+++ b/src/QmlControls/ScreenTools.qml
@@ -97,6 +97,7 @@ Item {
     property real implicitRadioButtonHeight:        implicitCheckBoxHeight
     property real implicitTextFieldWidth:           defaultFontPixelWidth * 15
     property real implicitTextFieldHeight:          Math.round(defaultFontPixelHeight * (isMobile ? 2.0 : 1.6))
+    property real implicitTextFieldWidth:           ScreenTools.defaultFontPixelWidth * 13
     property real implicitComboBoxHeight:           Math.round(defaultFontPixelHeight * (isMobile ? 2.0 : 1.6))
     property real implicitComboBoxWidth:            Math.round(defaultFontPixelWidth *  (isMobile ? 7.0 : 5.0))
     property real comboBoxPadding:                  defaultFontPixelWidth

--- a/src/QmlControls/ScreenTools.qml
+++ b/src/QmlControls/ScreenTools.qml
@@ -95,9 +95,8 @@ Item {
     property real implicitButtonHeight:             Math.round(defaultFontPixelHeight * (isMobile ? 2.0 : 1.6))
     property real implicitCheckBoxHeight:           Math.round(defaultFontPixelHeight * (isMobile ? 2.0 : 1.0))
     property real implicitRadioButtonHeight:        implicitCheckBoxHeight
-    property real implicitTextFieldWidth:           defaultFontPixelWidth * 15
+    property real implicitTextFieldWidth:           defaultFontPixelWidth * 13
     property real implicitTextFieldHeight:          Math.round(defaultFontPixelHeight * (isMobile ? 2.0 : 1.6))
-    property real implicitTextFieldWidth:           ScreenTools.defaultFontPixelWidth * 13
     property real implicitComboBoxHeight:           Math.round(defaultFontPixelHeight * (isMobile ? 2.0 : 1.6))
     property real implicitComboBoxWidth:            Math.round(defaultFontPixelWidth *  (isMobile ? 7.0 : 5.0))
     property real comboBoxPadding:                  defaultFontPixelWidth

--- a/src/QmlControls/ToolIndicatorPage.qml
+++ b/src/QmlControls/ToolIndicatorPage.qml
@@ -1,0 +1,70 @@
+/****************************************************************************
+ *
+ * (c) 2009-2020 QGROUNDCONTROL PROJECT <http://www.qgroundcontrol.org>
+ *
+ * QGroundControl is licensed according to the terms in the file
+ * COPYING.md in the root of the source code directory.
+ *
+ ****************************************************************************/
+
+import QtQuick
+import QtQuick.Layouts
+
+import QGroundControl
+import QGroundControl.ScreenTools
+
+// ToolIndicatorPage
+//      The base control for all Toolbar Indicator drop down pages. It supports a normal and expanded view.
+
+RowLayout {
+    id:         control
+    spacing:    _margins
+
+    property bool       showExpand:         false   // Controls whether the expand widget is shown or not
+    property bool       waitForParameters:  false   // UI won't show until parameters are ready
+    property Component  contentComponent            // Item for the normal view portion of the page
+    property Component  expandedComponent           // Item for the expanded portion of the page
+    property var        pageProperties              // Allows you to share a QtObject full of properties between pages
+
+    // These properties are bound by the MainRoowWindow loader
+    property bool expanded: false
+    property var  drawer
+
+
+    property var    activeVehicle:      QGroundControl.multiVehicleManager.vehicle
+    property bool   parametersReady:    QGroundControl.multiVehicleManager.parameterReadyVehicleAvailable
+
+    property real _margins:     ScreenTools.defaultFontPixelHeight
+    property bool _loadPages:   !waitForParameters || parametersReady
+
+    QGCLabel {
+        text:       qsTr("Waiting for parameters...")
+        visible:    waitForParameters && !parametersReady
+    }
+
+    Loader {
+        id:                 contentItemLoader
+        Layout.alignment:   Qt.AlignTop
+        sourceComponent:    _loadPages ? contentComponent : undefined
+
+        property var pageProperties: control.pageProperties
+    }
+
+    Rectangle {
+        id:                     divider
+        Layout.preferredWidth:  visible ? 1 : -1
+        Layout.fillHeight:      true
+        color:                  QGroundControl.globalPalette.text
+        visible:                expanded
+    }
+
+    Loader {
+        id:                     expandedItemLoader
+        Layout.alignment:       Qt.AlignTop
+        Layout.preferredWidth:  visible ? -1 : 0
+        visible:                expanded
+        sourceComponent:        expanded ? expandedComponent : undefined
+
+        property var pageProperties: control.pageProperties
+    }
+}

--- a/src/Settings/BatteryIndicator.SettingsGroup.json
+++ b/src/Settings/BatteryIndicator.SettingsGroup.json
@@ -1,0 +1,15 @@
+{
+    "version":      1,
+    "fileType":  "FactMetaData",
+    "QGC.MetaData.Facts":
+[
+{
+    "name":         "display",
+    "shortDesc":    "Select values to display in indicator",
+    "enumStrings":  "Percentage,Voltage,Both",
+    "enumValues":   "0,1,2",
+    "type":         "uint32",
+    "default":      false
+}
+]
+}

--- a/src/Settings/BatteryIndicatorSettings.cc
+++ b/src/Settings/BatteryIndicatorSettings.cc
@@ -1,0 +1,20 @@
+/****************************************************************************
+ *
+ * (c) 2009-2020 QGROUNDCONTROL PROJECT <http://www.qgroundcontrol.org>
+ *
+ * QGroundControl is licensed according to the terms in the file
+ * COPYING.md in the root of the source code directory.
+ *
+ ****************************************************************************/
+
+#include "BatteryIndicatorSettings.h"
+
+#include <QQmlEngine>
+#include <QtQml>
+
+DECLARE_SETTINGGROUP(BatteryIndicator, "BatteryIndicator")
+{
+    qmlRegisterUncreatableType<BatteryIndicatorSettings>("QGroundControl.SettingsManager", 1, 0, "BatteryIndicatorSettings", "Reference only");
+}
+
+DECLARE_SETTINGSFACT(BatteryIndicatorSettings, display)

--- a/src/Settings/BatteryIndicatorSettings.h
+++ b/src/Settings/BatteryIndicatorSettings.h
@@ -1,0 +1,22 @@
+/****************************************************************************
+ *
+ * (c) 2009-2020 QGROUNDCONTROL PROJECT <http://www.qgroundcontrol.org>
+ *
+ * QGroundControl is licensed according to the terms in the file
+ * COPYING.md in the root of the source code directory.
+ *
+ ****************************************************************************/
+
+#pragma once
+
+#include "SettingsGroup.h"
+
+class BatteryIndicatorSettings : public SettingsGroup
+{
+    Q_OBJECT
+public:
+    BatteryIndicatorSettings(QObject* parent = nullptr);
+    DEFINE_SETTING_NAME_GROUP()
+
+    DEFINE_SETTINGFACT(display)
+};

--- a/src/Settings/FlightMode.SettingsGroup.json
+++ b/src/Settings/FlightMode.SettingsGroup.json
@@ -1,0 +1,19 @@
+{
+    "version":  1,
+    "fileType": "FactMetaData",
+    "QGC.MetaData.Facts":
+[
+{
+    "name":         "px4HiddenFlightModes",
+    "shortDesc":    "Comma separated list of hidden flight modes",
+    "type":         "string",
+    "default":      "Offboard"
+},
+{
+    "name":         "apmHiddenFlightModes",
+    "shortDesc":    "Comma separated list of hidden flight modes",
+    "type":         "string",
+    "default":      ""
+}
+]
+}

--- a/src/Settings/FlightModeSettings.cc
+++ b/src/Settings/FlightModeSettings.cc
@@ -1,0 +1,25 @@
+/****************************************************************************
+ *
+ * (c) 2009-2020 QGROUNDCONTROL PROJECT <http://www.qgroundcontrol.org>
+ *
+ * QGroundControl is licensed according to the terms in the file
+ * COPYING.md in the root of the source code directory.
+ *
+ ****************************************************************************/
+
+#include "QGCApplication.h"
+#include "FlightModeSettings.h"
+#include "QGCMapEngine.h"
+#include "AppSettings.h"
+#include "SettingsManager.h"
+
+#include <QQmlEngine>
+#include <QtQml>
+
+DECLARE_SETTINGGROUP(FlightMode, "FlightMode")
+{
+    qmlRegisterUncreatableType<FlightModeSettings>("QGroundControl.SettingsManager", 1, 0, "FlightModeSettings", "Reference only");
+}
+
+DECLARE_SETTINGSFACT(FlightModeSettings, px4HiddenFlightModes)
+DECLARE_SETTINGSFACT(FlightModeSettings, apmHiddenFlightModes)

--- a/src/Settings/FlightModeSettings.h
+++ b/src/Settings/FlightModeSettings.h
@@ -1,0 +1,24 @@
+/****************************************************************************
+ *
+ * (c) 2009-2020 QGROUNDCONTROL PROJECT <http://www.qgroundcontrol.org>
+ *
+ * QGroundControl is licensed according to the terms in the file
+ * COPYING.md in the root of the source code directory.
+ *
+ ****************************************************************************/
+
+#pragma once
+
+#include "SettingsGroup.h"
+
+class FlightModeSettings : public SettingsGroup
+{
+    Q_OBJECT
+
+public:
+    FlightModeSettings(QObject* parent = nullptr);
+
+    DEFINE_SETTING_NAME_GROUP()
+    DEFINE_SETTINGFACT(px4HiddenFlightModes)
+    DEFINE_SETTINGFACT(apmHiddenFlightModes)
+};

--- a/src/Settings/SettingsManager.cc
+++ b/src/Settings/SettingsManager.cc
@@ -19,6 +19,7 @@ SettingsManager::SettingsManager(QGCApplication* app, QGCToolbox* toolbox)
     , _autoConnectSettings          (nullptr)
     , _videoSettings                (nullptr)
     , _flightMapSettings            (nullptr)
+    , _flightModeSettings           (nullptr)
     , _rtkSettings                  (nullptr)
     , _flyViewSettings              (nullptr)
     , _planViewSettings             (nullptr)
@@ -45,6 +46,7 @@ void SettingsManager::setToolbox(QGCToolbox *toolbox)
     _autoConnectSettings =          new AutoConnectSettings         (this);
     _videoSettings =                new VideoSettings               (this);
     _flightMapSettings =            new FlightMapSettings           (this);
+    _flightModeSettings =           new FlightModeSettings          (this);
     _rtkSettings =                  new RTKSettings                 (this);
     _flyViewSettings =              new FlyViewSettings             (this);
     _planViewSettings =             new PlanViewSettings            (this);

--- a/src/Settings/SettingsManager.cc
+++ b/src/Settings/SettingsManager.cc
@@ -27,6 +27,7 @@ SettingsManager::SettingsManager(QGCApplication* app, QGCToolbox* toolbox)
     , _offlineMapsSettings          (nullptr)
     , _firmwareUpgradeSettings      (nullptr)
     , _adsbVehicleManagerSettings   (nullptr)
+    , _batteryIndicatorSettings     (nullptr)
 #if !defined(NO_ARDUPILOT_DIALECT)
     , _apmMavlinkStreamRateSettings (nullptr)
 #endif
@@ -54,6 +55,7 @@ void SettingsManager::setToolbox(QGCToolbox *toolbox)
     _offlineMapsSettings =          new OfflineMapsSettings         (this);
     _firmwareUpgradeSettings =      new FirmwareUpgradeSettings     (this);
     _adsbVehicleManagerSettings =   new ADSBVehicleManagerSettings  (this);
+    _batteryIndicatorSettings =     new BatteryIndicatorSettings    (this);
 #if !defined(NO_ARDUPILOT_DIALECT)
     _apmMavlinkStreamRateSettings = new APMMavlinkStreamRateSettings(this);
 #endif

--- a/src/Settings/SettingsManager.h
+++ b/src/Settings/SettingsManager.h
@@ -28,6 +28,7 @@
 #include "APMMavlinkStreamRateSettings.h"
 #include "FirmwareUpgradeSettings.h"
 #include "ADSBVehicleManagerSettings.h"
+#include "BatteryIndicatorSettings.h"
 #include <QVariantList>
 #include "RemoteIDSettings.h"
 
@@ -52,6 +53,7 @@ public:
     Q_PROPERTY(QObject* offlineMapsSettings             READ offlineMapsSettings            CONSTANT)
     Q_PROPERTY(QObject* firmwareUpgradeSettings         READ firmwareUpgradeSettings        CONSTANT)
     Q_PROPERTY(QObject* adsbVehicleManagerSettings      READ adsbVehicleManagerSettings     CONSTANT)
+    Q_PROPERTY(QObject* batteryIndicatorSettings        READ batteryIndicatorSettings       CONSTANT)
 #if !defined(NO_ARDUPILOT_DIALECT)
     Q_PROPERTY(QObject* apmMavlinkStreamRateSettings    READ apmMavlinkStreamRateSettings   CONSTANT)
 #endif
@@ -72,6 +74,7 @@ public:
     OfflineMapsSettings*            offlineMapsSettings         (void) { return _offlineMapsSettings; }
     FirmwareUpgradeSettings*        firmwareUpgradeSettings     (void) { return _firmwareUpgradeSettings; }
     ADSBVehicleManagerSettings*     adsbVehicleManagerSettings  (void) { return _adsbVehicleManagerSettings; }
+    BatteryIndicatorSettings*       batteryIndicatorSettings    (void) { return _batteryIndicatorSettings; }
 #if !defined(NO_ARDUPILOT_DIALECT)
     APMMavlinkStreamRateSettings*   apmMavlinkStreamRateSettings(void) { return _apmMavlinkStreamRateSettings; }
 #endif
@@ -90,6 +93,7 @@ private:
     OfflineMapsSettings*            _offlineMapsSettings;
     FirmwareUpgradeSettings*        _firmwareUpgradeSettings;
     ADSBVehicleManagerSettings*     _adsbVehicleManagerSettings;
+    BatteryIndicatorSettings*       _batteryIndicatorSettings;
 #if !defined(NO_ARDUPILOT_DIALECT)
     APMMavlinkStreamRateSettings*   _apmMavlinkStreamRateSettings;
 #endif

--- a/src/Settings/SettingsManager.h
+++ b/src/Settings/SettingsManager.h
@@ -19,6 +19,7 @@
 #include "AutoConnectSettings.h"
 #include "VideoSettings.h"
 #include "FlightMapSettings.h"
+#include "FlightModeSettings.h"
 #include "RTKSettings.h"
 #include "FlyViewSettings.h"
 #include "PlanViewSettings.h"
@@ -43,6 +44,7 @@ public:
     Q_PROPERTY(QObject* autoConnectSettings             READ autoConnectSettings            CONSTANT)
     Q_PROPERTY(QObject* videoSettings                   READ videoSettings                  CONSTANT)
     Q_PROPERTY(QObject* flightMapSettings               READ flightMapSettings              CONSTANT)
+    Q_PROPERTY(QObject* flightModeSettings              READ flightModeSettings             CONSTANT)
     Q_PROPERTY(QObject* rtkSettings                     READ rtkSettings                    CONSTANT)
     Q_PROPERTY(QObject* flyViewSettings                 READ flyViewSettings                CONSTANT)
     Q_PROPERTY(QObject* planViewSettings                READ planViewSettings               CONSTANT)
@@ -62,6 +64,7 @@ public:
     AutoConnectSettings*            autoConnectSettings         (void) { return _autoConnectSettings; }
     VideoSettings*                  videoSettings               (void) { return _videoSettings; }
     FlightMapSettings*              flightMapSettings           (void) { return _flightMapSettings; }
+    FlightModeSettings*             flightModeSettings          (void) { return _flightModeSettings; }
     RTKSettings*                    rtkSettings                 (void) { return _rtkSettings; }
     FlyViewSettings*                flyViewSettings             (void) { return _flyViewSettings; }
     PlanViewSettings*               planViewSettings            (void) { return _planViewSettings; }
@@ -79,6 +82,7 @@ private:
     AutoConnectSettings*            _autoConnectSettings;
     VideoSettings*                  _videoSettings;
     FlightMapSettings*              _flightMapSettings;
+    FlightModeSettings*             _flightModeSettings;
     RTKSettings*                    _rtkSettings;
     FlyViewSettings*                _flyViewSettings;
     PlanViewSettings*               _planViewSettings;

--- a/src/Vehicle/Vehicle.cc
+++ b/src/Vehicle/Vehicle.cc
@@ -1999,7 +1999,7 @@ QString Vehicle::formattedMessages()
 {
     QString messages;
     for(UASMessage* message: _toolbox->uasMessageHandler()->messages()) {
-        messages += message->getFormatedText();
+        messages.prepend(message->getFormatedText());
     }
     return messages;
 }
@@ -3819,6 +3819,14 @@ QString Vehicle::vehicleImageCompass() const
         return _firmwarePlugin->vehicleImageCompass(this);
     else
         return QString();
+}
+
+QVariant Vehicle::mainStatusIndicatorExpandedItem()
+{
+    if(_firmwarePlugin) {
+        return _firmwarePlugin->mainStatusIndicatorExpandedItem(this);
+    }
+    return QVariant();
 }
 
 const QVariantList& Vehicle::toolIndicators()

--- a/src/Vehicle/Vehicle.h
+++ b/src/Vehicle/Vehicle.h
@@ -243,6 +243,7 @@ public:
     Q_PROPERTY(unsigned int         telemetryTXBuffer           READ telemetryTXBuffer                                              NOTIFY telemetryTXBufferChanged)
     Q_PROPERTY(int                  telemetryLNoise             READ telemetryLNoise                                                NOTIFY telemetryLNoiseChanged)
     Q_PROPERTY(int                  telemetryRNoise             READ telemetryRNoise                                                NOTIFY telemetryRNoiseChanged)
+    Q_PROPERTY(QVariant         mainStatusIndicatorExpandedItem READ mainStatusIndicatorExpandedItem                                CONSTANT)
     Q_PROPERTY(QVariantList         toolIndicators              READ toolIndicators                                                 NOTIFY toolIndicatorsChanged)
     Q_PROPERTY(QVariantList         modeIndicators              READ modeIndicators                                                 NOTIFY modeIndicatorsChanged)
     Q_PROPERTY(bool              initialPlanRequestComplete     READ initialPlanRequestComplete                                     NOTIFY initialPlanRequestCompleteChanged)
@@ -882,9 +883,10 @@ public:
     QString vehicleImageOutline () const;
     QString vehicleImageCompass () const;
 
-    const QVariantList&         toolIndicators      ();
-    const QVariantList&         modeIndicators      ();
-    const QVariantList&         staticCameraList    () const;
+    QVariant                    mainStatusIndicatorExpandedItem ();
+    const QVariantList&         toolIndicators                  ();
+    const QVariantList&         modeIndicators                  ();
+    const QVariantList&         staticCameraList                () const;
 
     bool capabilitiesKnown      () const { return _capabilityBitsKnown; }
     uint64_t capabilityBits     () const { return _capabilityBits; }    // Change signalled by capabilityBitsChanged

--- a/src/VehicleSetup/SetupView.qml
+++ b/src/VehicleSetup/SetupView.qml
@@ -91,6 +91,22 @@ Rectangle {
         }
     }
 
+    function showNamedComponentPanel(panelButtonName) {
+        if (mainWindow.preventViewSwitch()) {
+            return
+        }
+        for (var i=0; i<componentRepeater.count; i++) {
+            var panelButton = componentRepeater.itemAt(i)
+            if (panelButton.text === panelButtonName) {
+                showVehicleComponentPanel(panelButton.componentUrl)
+                break;
+            }
+        }
+        if (panelButtonName === parametersButton.text) {
+            parametersButton.clicked()
+        }
+    }
+
     Component.onCompleted: _showSummaryPanel()
 
     Connections {
@@ -284,11 +300,14 @@ Rectangle {
                     text:               modelData.name
                     visible:            modelData.setupSource.toString() !== ""
                     Layout.fillWidth:   true
-                    onClicked:          showVehicleComponentPanel(modelData)
+                    onClicked:          showVehicleComponentPanel(componentUrl)
+
+                    property var componentUrl: modelData
                 }
             }
 
             SubMenuButton {
+                id:                 parametersButton
                 setupIndicator:     false
                 buttonGroup:     setupButtonGroup
                 visible:            QGroundControl.multiVehicleManager.parameterReadyVehicleAvailable &&

--- a/src/ui/AppSettings.qml
+++ b/src/ui/AppSettings.qml
@@ -32,6 +32,16 @@ Rectangle {
 
     property bool _commingFromRIDSettings:  false
 
+    function showSettingsPage(settingsPage) {
+        for (var i=0; i<buttonRepeater.count; i++) {
+            var button = buttonRepeater.itemAt(i)
+            if (button.text === settingsPage) {
+                button.clicked()
+                break
+            }
+        }
+    }
+
     QGCPalette { id: qgcPal }
 
     Component.onCompleted: {
@@ -63,7 +73,9 @@ Rectangle {
             property real _maxButtonWidth: 0
 
             Repeater {
+                id:     buttonRepeater
                 model:  QGroundControl.corePlugin.settingsPages
+
                 QGCButton {
                     height:             _buttonHeight
                     text:               modelData.title

--- a/src/ui/MainRootWindow.qml
+++ b/src/ui/MainRootWindow.qml
@@ -166,12 +166,18 @@ ApplicationWindow {
         showTool(qsTr("Analyze Tools"), "AnalyzeView.qml", "/qmlimages/Analyze.svg")
     }
 
-    function showSetupTool() {
+    function showVehicleSetupTool(setupPage = "") {
         showTool(qsTr("Vehicle Setup"), "SetupView.qml", "/qmlimages/Gears.svg")
+        if (setupPage !== "") {
+            toolDrawerLoader.item.showNamedComponentPanel(setupPage)
+        }
     }
 
-    function showSettingsTool() {
+    function showSettingsTool(settingsPage = "") {
         showTool(qsTr("Application Settings"), "AppSettings.qml", "/res/QGCLogoWhite")
+        if (settingsPage !== "") {
+            toolDrawerLoader.item.showSettingsPage(settingsPage)
+        }
     }
 
     //-------------------------------------------------------------------------
@@ -280,159 +286,160 @@ ApplicationWindow {
 
     function showToolSelectDialog() {
         if (!mainWindow.preventViewSwitch()) {
-            toolSelectDialogComponent.createObject(mainWindow).open()
+            mainWindow.showIndicatorDrawer(toolSelectComponent)
         }
     }
 
     Component {
-        id: toolSelectDialogComponent
+        id: toolSelectComponent
 
-        QGCPopupDialog {
+        ToolIndicatorPage {
             id:         toolSelectDialog
-            title:      qsTr("Select Tool")
-            buttons:    Dialog.Close
+            //title:      qsTr("Select Tool")
 
             property real _toolButtonHeight:    ScreenTools.defaultFontPixelHeight * 3
             property real _margins:             ScreenTools.defaultFontPixelWidth
 
-            ColumnLayout {
-                width:  innerLayout.width + (toolSelectDialog._margins * 2)
-                height: innerLayout.height + (toolSelectDialog._margins * 2)
-
+            contentComponent: Component {
                 ColumnLayout {
-                    id:             innerLayout
-                    Layout.margins: toolSelectDialog._margins
-                    spacing:        ScreenTools.defaultFontPixelWidth
-
-                    SubMenuButton {
-                        id:                 setupButton
-                        height:             toolSelectDialog._toolButtonHeight
-                        Layout.fillWidth:   true
-                        text:               qsTr("Vehicle Setup")
-                        imageColor:         qgcPal.text
-                        imageResource:      "/qmlimages/Gears.svg"
-                        onClicked: {
-                            if (!mainWindow.preventViewSwitch()) {
-                                toolSelectDialog.close()
-                                mainWindow.showSetupTool()
-                            }
-                        }
-                    }
-
-                    SubMenuButton {
-                        id:                 analyzeButton
-                        height:             toolSelectDialog._toolButtonHeight
-                        Layout.fillWidth:   true
-                        text:               qsTr("Analyze Tools")
-                        imageResource:      "/qmlimages/Analyze.svg"
-                        imageColor:         qgcPal.text
-                        visible:            QGroundControl.corePlugin.showAdvancedUI
-                        onClicked: {
-                            if (!mainWindow.preventViewSwitch()) {
-                                toolSelectDialog.close()
-                                mainWindow.showAnalyzeTool()
-                            }
-                        }
-                    }
-
-                    SubMenuButton {
-                        id:                 settingsButton
-                        height:             toolSelectDialog._toolButtonHeight
-                        Layout.fillWidth:   true
-                        text:               qsTr("Application Settings")
-                        imageResource:      "/res/QGCLogoFull"
-                        imageColor:         "transparent"
-                        visible:            !QGroundControl.corePlugin.options.combineSettingsAndSetup
-                        onClicked: {
-                            if (!mainWindow.preventViewSwitch()) {
-                                toolSelectDialog.close()
-                                mainWindow.showSettingsTool()
-                            }
-                        }
-                    }
+                    width:  innerLayout.width + (toolSelectDialog._margins * 2)
+                    height: innerLayout.height + (toolSelectDialog._margins * 2)
 
                     ColumnLayout {
-                        width:                  innerLayout.width
-                        spacing:                0
-                        Layout.alignment:       Qt.AlignHCenter
+                        id:             innerLayout
+                        Layout.margins: toolSelectDialog._margins
+                        spacing:        ScreenTools.defaultFontPixelWidth
 
-                        QGCLabel {
-                            id:                     versionLabel
-                            text:                   qsTr("%1 Version").arg(QGroundControl.appName)
-                            font.pointSize:         ScreenTools.smallFontPointSize
-                            wrapMode:               QGCLabel.WordWrap
-                            Layout.maximumWidth:    parent.width
-                            Layout.alignment:       Qt.AlignHCenter
+                        SubMenuButton {
+                            id:                 setupButton
+                            height:             toolSelectDialog._toolButtonHeight
+                            Layout.fillWidth:   true
+                            text:               qsTr("Vehicle Setup")
+                            imageColor:         qgcPal.text
+                            imageResource:      "/qmlimages/Gears.svg"
+                            onClicked: {
+                                if (!mainWindow.preventViewSwitch()) {
+                                    drawer.close()
+                                    mainWindow.showVehicleSetupTool()
+                                }
+                            }
                         }
 
-                        QGCLabel {
-                            text:                   QGroundControl.qgcVersion
-                            font.pointSize:         ScreenTools.smallFontPointSize
-                            wrapMode:               QGCLabel.WrapAnywhere
-                            Layout.maximumWidth:    parent.width
+                        SubMenuButton {
+                            id:                 analyzeButton
+                            height:             toolSelectDialog._toolButtonHeight
+                            Layout.fillWidth:   true
+                            text:               qsTr("Analyze Tools")
+                            imageResource:      "/qmlimages/Analyze.svg"
+                            imageColor:         qgcPal.text
+                            visible:            QGroundControl.corePlugin.showAdvancedUI
+                            onClicked: {
+                                if (!mainWindow.preventViewSwitch()) {
+                                    drawer.close()
+                                    mainWindow.showAnalyzeTool()
+                                }
+                            }
+                        }
+
+                        SubMenuButton {
+                            id:                 settingsButton
+                            height:             toolSelectDialog._toolButtonHeight
+                            Layout.fillWidth:   true
+                            text:               qsTr("Application Settings")
+                            imageResource:      "/res/QGCLogoFull"
+                            imageColor:         "transparent"
+                            visible:            !QGroundControl.corePlugin.options.combineSettingsAndSetup
+                            onClicked: {
+                                if (!mainWindow.preventViewSwitch()) {
+                                    drawer.close()
+                                    mainWindow.showSettingsTool()
+                                }
+                            }
+                        }
+
+                        ColumnLayout {
+                            width:                  innerLayout.width
+                            spacing:                0
                             Layout.alignment:       Qt.AlignHCenter
 
-                            QGCMouseArea {
-                                id:                 easterEggMouseArea
-                                anchors.topMargin:  -versionLabel.height
-                                anchors.fill:       parent
+                            QGCLabel {
+                                id:                     versionLabel
+                                text:                   qsTr("%1 Version").arg(QGroundControl.appName)
+                                font.pointSize:         ScreenTools.smallFontPointSize
+                                wrapMode:               QGCLabel.WordWrap
+                                Layout.maximumWidth:    parent.width
+                                Layout.alignment:       Qt.AlignHCenter
+                            }
 
-                                onClicked: (mouse) => {
-                                    console.log("clicked")
-                                    if (mouse.modifiers & Qt.ControlModifier) {
+                            QGCLabel {
+                                text:                   QGroundControl.qgcVersion
+                                font.pointSize:         ScreenTools.smallFontPointSize
+                                wrapMode:               QGCLabel.WrapAnywhere
+                                Layout.maximumWidth:    parent.width
+                                Layout.alignment:       Qt.AlignHCenter
+
+                                QGCMouseArea {
+                                    id:                 easterEggMouseArea
+                                    anchors.topMargin:  -versionLabel.height
+                                    anchors.fill:       parent
+
+                                    onClicked: (mouse) => {
+                                        console.log("clicked")
+                                        if (mouse.modifiers & Qt.ControlModifier) {
+                                            QGroundControl.corePlugin.showTouchAreas = !QGroundControl.corePlugin.showTouchAreas
+                                            showTouchAreasNotification.open()
+                                        } else if (ScreenTools.isMobile || mouse.modifiers & Qt.ShiftModifier) {
+                                            if(!QGroundControl.corePlugin.showAdvancedUI) {
+                                                advancedModeOnConfirmation.open()
+                                            } else {
+                                                advancedModeOffConfirmation.open()
+                                            }
+                                        }
+                                    }
+
+                                    // This allows you to change this on mobile
+                                    onPressAndHold: {
                                         QGroundControl.corePlugin.showTouchAreas = !QGroundControl.corePlugin.showTouchAreas
                                         showTouchAreasNotification.open()
-                                    } else if (ScreenTools.isMobile || mouse.modifiers & Qt.ShiftModifier) {
-                                        if(!QGroundControl.corePlugin.showAdvancedUI) {
-                                            advancedModeOnConfirmation.open()
-                                        } else {
-                                            advancedModeOffConfirmation.open()
+                                    }
+
+                                    MessageDialog {
+                                        id:                 showTouchAreasNotification
+                                        title:              qsTr("Debug Touch Areas")
+                                        text:               qsTr("Touch Area display toggled")
+                                        buttons:            MessageDialog.Ok
+                                    }
+
+                                    MessageDialog {
+                                        id:                 advancedModeOnConfirmation
+                                        title:              qsTr("Advanced Mode")
+                                        text:               QGroundControl.corePlugin.showAdvancedUIMessage
+                                        buttons:            MessageDialog.Yes | MessageDialog.No
+                                        onButtonClicked: function (button, role) {
+                                            switch (button) {
+                                            case MessageDialog.Yes:
+                                                QGroundControl.corePlugin.showAdvancedUI = true
+                                                advancedModeOnConfirmation.close()
+                                                break;
+                                            }
                                         }
                                     }
-                                }
 
-                                // This allows you to change this on mobile
-                                onPressAndHold: {
-                                    QGroundControl.corePlugin.showTouchAreas = !QGroundControl.corePlugin.showTouchAreas
-                                    showTouchAreasNotification.open()
-                                }
-
-                                MessageDialog {
-                                    id:                 showTouchAreasNotification
-                                    title:              qsTr("Debug Touch Areas")
-                                    text:               qsTr("Touch Area display toggled")
-                                    buttons:            MessageDialog.Ok
-                                }
-
-                                MessageDialog {
-                                    id:                 advancedModeOnConfirmation
-                                    title:              qsTr("Advanced Mode")
-                                    text:               QGroundControl.corePlugin.showAdvancedUIMessage
-                                    buttons:            MessageDialog.Yes | MessageDialog.No
-                                    onButtonClicked: function (button, role) {
-                                        switch (button) {
-                                        case MessageDialog.Yes:
-                                            QGroundControl.corePlugin.showAdvancedUI = true
-                                            advancedModeOnConfirmation.close()
-                                            break;
-                                        }
-                                    }
-                                }
-
-                                MessageDialog {
-                                    id:                 advancedModeOffConfirmation
-                                    title:              qsTr("Advanced Mode")
-                                    text:               qsTr("Turn off Advanced Mode?")
-                                    buttons:            MessageDialog.Yes | MessageDialog.No
-                                    onButtonClicked: function (button, role) {
-                                        switch (button) {
-                                        case MessageDialog.Yes:
-                                            QGroundControl.corePlugin.showAdvancedUI = false
-                                            advancedModeOffConfirmation.close()
-                                            break;
-                                        case MessageDialog.No:
-                                            resetPrompt.close()
-                                            break;
+                                    MessageDialog {
+                                        id:                 advancedModeOffConfirmation
+                                        title:              qsTr("Advanced Mode")
+                                        text:               qsTr("Turn off Advanced Mode?")
+                                        buttons:            MessageDialog.Yes | MessageDialog.No
+                                        onButtonClicked: function (button, role) {
+                                            switch (button) {
+                                            case MessageDialog.Yes:
+                                                QGroundControl.corePlugin.showAdvancedUI = false
+                                                advancedModeOffConfirmation.close()
+                                                break;
+                                            case MessageDialog.No:
+                                                resetPrompt.close()
+                                                break;
+                                            }
                                         }
                                     }
                                 }
@@ -653,7 +660,7 @@ ApplicationWindow {
     }
 
     //-------------------------------------------------------------------------
-    //-- Indicator Popups
+    //-- Indicator Popups - deprecated, use Indicator Drawer instead
 
     function showIndicatorPopup(item, dropItem) {
         indicatorPopup.currentIndicator = dropItem
@@ -696,6 +703,99 @@ ApplicationWindow {
         onClosed: {
             loader.sourceComponent = null
             indicatorPopup.currentIndicator = null
+        }
+    }
+
+    //-------------------------------------------------------------------------
+    //-- Indicator Drawer
+
+    function showIndicatorDrawer(drawerComponent) {
+        indicatorDrawer.sourceComponent = drawerComponent
+        indicatorDrawer.open()
+    }
+
+    Popup {
+        id:             indicatorDrawer
+        x:              _margins
+        y:              _margins
+        leftInset:      0
+        rightInset:     0
+        topInset:       0
+        bottomInset:    0
+        padding:        _margins * 2
+        visible:        false
+        modal:          true
+        focus:          true
+        closePolicy:    Popup.CloseOnEscape | Popup.CloseOnPressOutside
+
+        property var sourceComponent
+
+        property bool _expanded:    false
+        property real _margins:     ScreenTools.defaultFontPixelHeight / 4
+
+        onOpened: {
+            _expanded                               = false;
+            indicatorDrawerLoader.sourceComponent   = indicatorDrawer.sourceComponent
+        }
+        onClosed: {
+            _expanded                               = false
+            indicatorDrawerLoader.sourceComponent   = undefined
+        }
+
+        background: Item {
+            Rectangle {
+                id:             backgroundRect
+                anchors.fill:   parent
+                color:          QGroundControl.globalPalette.window
+                radius:         indicatorDrawer._margins
+                opacity:        0.85
+            }
+
+            Rectangle {
+                anchors.horizontalCenter:   backgroundRect.right
+                anchors.verticalCenter:     backgroundRect.top
+                width:                      ScreenTools.defaultFontPixelHeight
+                height:                     width
+                radius:                     width / 2
+                color:                      QGroundControl.globalPalette.button
+                border.color:               QGroundControl.globalPalette.buttonText
+                visible:                    indicatorDrawerLoader.item && indicatorDrawerLoader.item.showExpand && !indicatorDrawer._expanded
+
+                QGCLabel {
+                    anchors.centerIn:   parent
+                    text:               ">"
+                    color:              QGroundControl.globalPalette.buttonText
+                }  
+
+                QGCMouseArea {
+                    fillItem: parent
+                    onClicked: indicatorDrawer._expanded = true
+                }
+            }
+        }
+
+        contentItem: QGCFlickable {
+            id:             indicatorDrawerLoaderFlickable
+            implicitWidth:  Math.min(mainWindow.contentItem.width - (2 * indicatorDrawer._margins) - (indicatorDrawer.padding * 2), indicatorDrawerLoader.width)
+            implicitHeight: Math.min(mainWindow.contentItem.height - (2 * indicatorDrawer._margins) - (indicatorDrawer.padding * 2), indicatorDrawerLoader.height)
+            contentWidth:   indicatorDrawerLoader.width
+            contentHeight:  indicatorDrawerLoader.height
+
+            Loader {
+                id: indicatorDrawerLoader
+
+                Binding {
+                    target:     indicatorDrawerLoader.item
+                    property:   "expanded"
+                    value:      indicatorDrawer._expanded
+                }
+
+                Binding {
+                    target:     indicatorDrawerLoader.item
+                    property:   "drawer"
+                    value:      indicatorDrawer
+                }
+            }
         }
     }
 

--- a/src/ui/toolbar/BatteryIndicatorContentItem.qml
+++ b/src/ui/toolbar/BatteryIndicatorContentItem.qml
@@ -1,0 +1,112 @@
+/****************************************************************************
+ *
+ * (c) 2009-2020 QGROUNDCONTROL PROJECT <http://www.qgroundcontrol.org>
+ *
+ * QGroundControl is licensed according to the terms in the file
+ * COPYING.md in the root of the source code directory.
+ *
+ ****************************************************************************/
+
+import QtQuick          2.11
+import QtQuick.Layouts  1.11
+
+import QGroundControl                       1.0
+import QGroundControl.Controls              1.0
+import QGroundControl.MultiVehicleManager   1.0
+import QGroundControl.ScreenTools           1.0
+import QGroundControl.Palette               1.0
+import QGroundControl.FactSystem            1.0
+import QGroundControl.FactControls          1.0
+import MAVLink                              1.0
+
+// This is the contentItem portion of the ToolIndicatorPage for the Battery toolbar item.
+// It works for both PX4 and APM firmware.
+
+ColumnLayout {
+    id:         mainLayout
+    spacing:    ScreenTools.defaultFontPixelHeight
+
+    property var _activeVehicle: QGroundControl.multiVehicleManager.activeVehicle
+
+    Component {
+        id: batteryValuesAvailableComponent
+
+        QtObject {
+            property bool functionAvailable:        battery.function.rawValue !== MAVLink.MAV_BATTERY_FUNCTION_UNKNOWN
+            property bool showFunction:             functionAvailable && battery.function.rawValue != MAVLink.MAV_BATTERY_FUNCTION_ALL
+            property bool temperatureAvailable:     !isNaN(battery.temperature.rawValue)
+            property bool currentAvailable:         !isNaN(battery.current.rawValue)
+            property bool mahConsumedAvailable:     !isNaN(battery.mahConsumed.rawValue)
+            property bool timeRemainingAvailable:   !isNaN(battery.timeRemaining.rawValue)
+            property bool chargeStateAvailable:     battery.chargeState.rawValue !== MAVLink.MAV_BATTERY_CHARGE_STATE_UNDEFINED
+        }
+    }
+
+    QGCLabel {
+        Layout.alignment:   Qt.AlignCenter
+        text:               qsTr("Battery Status")
+        font.family:        ScreenTools.demiboldFontFamily
+    }
+
+    RowLayout {
+        spacing: ScreenTools.defaultFontPixelWidth
+
+        ColumnLayout {
+            Repeater {
+                id:     col1Repeater
+                model:  _activeVehicle ? _activeVehicle.batteries : 0
+
+                ColumnLayout {
+                    spacing: 0
+
+                    property var batteryValuesAvailable: nameAvailableLoader.item
+
+                    Loader {
+                        id:                 nameAvailableLoader
+                        sourceComponent:    batteryValuesAvailableComponent
+
+                        property var battery: object
+                    }
+
+                    QGCLabel { text: qsTr("Battery %1").arg(object.id.rawValue);    visible: col1Repeater.count !== 1 }
+                    QGCLabel { text: qsTr("Charge State");                          visible: batteryValuesAvailable.chargeStateAvailable }
+                    QGCLabel { text: qsTr("Remaining");                             visible: batteryValuesAvailable.timeRemainingAvailable }
+                    QGCLabel { text: qsTr("Remaining") }
+                    QGCLabel { text: qsTr("Voltage") }
+                    QGCLabel { text: qsTr("Consumed");                              visible: batteryValuesAvailable.mahConsumedAvailable }
+                    QGCLabel { text: qsTr("Temperature");                           visible: batteryValuesAvailable.temperatureAvailable }
+                    QGCLabel { text: qsTr("Function");                              visible: batteryValuesAvailable.showFunction }
+                }
+            }
+        }
+
+        ColumnLayout {
+            Repeater {
+                id:     col2Repeater
+                model:  _activeVehicle ? _activeVehicle.batteries : 0
+
+                ColumnLayout {
+                    spacing: 0
+
+                    property var batteryValuesAvailable: valueAvailableLoader.item
+
+                    Loader {
+                        id:                 valueAvailableLoader
+                        sourceComponent:    batteryValuesAvailableComponent
+
+                        property var battery: object
+                    }
+
+                    QGCLabel { text: "";                                                                        visible: col2Repeater.count !== 1 }
+                    QGCLabel { text: object.chargeState.enumStringValue;                                        visible: batteryValuesAvailable.chargeStateAvailable }
+                    QGCLabel { text: object.timeRemainingStr.value;                                             visible: batteryValuesAvailable.timeRemainingAvailable }
+                    QGCLabel { text: object.percentRemaining.valueString + " " + object.percentRemaining.units }
+                    QGCLabel { text: object.voltage.valueString + " " + object.voltage.units }
+                    QGCLabel { text: object.mahConsumed.valueString + " " + object.mahConsumed.units;           visible: batteryValuesAvailable.mahConsumedAvailable }
+                    QGCLabel { text: object.temperature.valueString + " " + object.temperature.units;           visible: batteryValuesAvailable.temperatureAvailable }
+                    QGCLabel { text: object.function.enumStringValue;                                           visible: batteryValuesAvailable.showFunction }
+                }
+            }
+        }
+    }
+}

--- a/src/ui/toolbar/CMakeLists.txt
+++ b/src/ui/toolbar/CMakeLists.txt
@@ -17,5 +17,4 @@ add_custom_target(UiToolbarQml
 		ROIIndicator.qml
 		SignalStrength.qml
 		TelemetryRSSIIndicator.qml
-		VTOLModeIndicator.qml
 )

--- a/src/ui/toolbar/FlightModeIndicator.qml
+++ b/src/ui/toolbar/FlightModeIndicator.qml
@@ -1,0 +1,203 @@
+/****************************************************************************
+ *
+ * (c) 2009-2022 QGROUNDCONTROL PROJECT <http://www.qgroundcontrol.org>
+ *
+ * QGroundControl is licensed according to the terms in the file
+ * COPYING.md in the root of the source code directory.
+ *
+ ****************************************************************************/
+
+import QtQuick
+import QtQuick.Controls
+import QtQuick.Layouts
+
+import QGroundControl
+import QGroundControl.Controls
+import QGroundControl.MultiVehicleManager
+import QGroundControl.ScreenTools
+import QGroundControl.Palette
+import QGroundControl.FactSystem
+import QGroundControl.FactControls
+
+RowLayout {
+    id:         control
+    spacing:    0
+
+    property bool   showIndicator:          true
+    property var    expandedPageComponent
+    property bool   waitForParameters:      false
+
+    property real fontPointSize:    ScreenTools.largeFontPointSize
+    property var  activeVehicle:    QGroundControl.multiVehicleManager.activeVehicle
+    property bool editMode:         false
+
+    RowLayout {
+        Layout.fillWidth: true
+
+        QGCColoredImage {
+            id:         flightModeIcon
+            width:      ScreenTools.defaultFontPixelWidth * 3
+            height:     ScreenTools.defaultFontPixelHeight
+            fillMode:   Image.PreserveAspectFit
+            mipmap:     true
+            color:      qgcPal.text
+            source:     "/qmlimages/FlightModesComponentIcon.png"
+        }
+
+        QGCLabel {
+            text:               activeVehicle ? activeVehicle.flightMode : qsTr("N/A", "No data to display")
+            font.pointSize:     fontPointSize
+            Layout.alignment:   Qt.AlignCenter
+
+            MouseArea {
+                anchors.fill:   parent
+                onClicked:      mainWindow.showIndicatorDrawer(drawerComponent)
+            }
+        }
+    }
+
+    Component {
+        id: drawerComponent
+
+        ToolIndicatorPage {
+            showExpand:         true
+            waitForParameters:  control.waitForParameters
+
+            contentComponent:    flightModeContentComponent
+            expandedComponent:   flightModeExpandedComponent
+        }
+    }
+
+    Component {
+        id: flightModeContentComponent
+
+        ColumnLayout {
+            id:         modeColumn
+            spacing:    ScreenTools.defaultFontPixelWidth / 2
+
+            property var  activeVehicle:            QGroundControl.multiVehicleManager.activeVehicle
+            property var  flightModeSettings:       QGroundControl.settingsManager.flightModeSettings
+            property var  hiddenFlightModesFact:    null
+            property var  hiddenFlightModesList:    [] 
+
+            Component.onCompleted: {
+                if (activeVehicle.px4Firmware) {
+                    hiddenFlightModesFact = flightModeSettings.px4HiddenFlightModes
+                } else if (activeVehicle.apmFirmware) {
+                    hiddenFlightModesFact = flightModeSettings.apmHiddenFlightModes
+                } else {
+                    modeEditCheckBox.enabled = false
+                }
+                // Split string into list of flight modes
+                if (hiddenFlightModesFact) {
+                    hiddenFlightModesList = hiddenFlightModesFact.value.split(",")
+                }
+            }
+
+            Connections {
+                target: control
+                onEditModeChanged: {
+                    if (editMode) {
+                        for (var i=0; i<modeRepeater.count; i++) {
+                            var button      = modeRepeater.itemAt(i).children[0]
+                            var checkBox    = modeRepeater.itemAt(i).children[1]
+
+                            checkBox.checked = !hiddenFlightModesList.find(item => { return item === button.text } )
+                        }
+                    }
+                }
+            }
+
+            Repeater {
+                id:     modeRepeater
+                model:  activeVehicle ? activeVehicle.flightModes : []
+
+                RowLayout {
+                    spacing: ScreenTools.defaultFontPixelWidth
+                    visible: editMode || !hiddenFlightModesList.find(item => { return item === modelData } )
+
+                    QGCButton {
+                        id:                 modeButton
+                        text:               modelData
+                        Layout.fillWidth:   true
+
+                        onClicked: {
+                            if (editMode) {
+                                parent.children[1].toggle()
+                                parent.children[1].clicked()
+                            } else {
+                                activeVehicle.flightMode = modelData
+                                drawer.close()
+                            }
+                        }
+                    }
+
+                    QGCCheckBoxSlider {
+                        visible: editMode
+
+                        onClicked: {
+                            hiddenFlightModesList = []
+                            for (var i=0; i<modeRepeater.count; i++) {
+                                var checkBox = modeRepeater.itemAt(i).children[1]
+                                if (!checkBox.checked) {
+                                    hiddenFlightModesList.push(modeRepeater.model[i])
+                                }
+                            }
+                            hiddenFlightModesFact.value = hiddenFlightModesList.join(",")
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    Component {
+        id: flightModeExpandedComponent
+
+        ColumnLayout {
+            Layout.preferredWidth:  ScreenTools.defaultFontPixelWidth * 60
+            spacing:                margins / 2
+
+            property var  qgcPal:   QGroundControl.globalPalette
+            property real margins:  ScreenTools.defaultFontPixelHeight
+
+            Loader {
+                sourceComponent: expandedPageComponent
+            }
+
+            IndicatorPageGroupLayout {
+                Layout.fillWidth:  true
+
+                RowLayout {
+                    Layout.fillWidth: true
+
+                    QGCLabel {
+                        Layout.fillWidth:   true
+                        text:               qsTr("Edit Displayed Flight Modes")
+                    }
+
+                    QGCCheckBoxSlider {
+                        id:         editModeCheckBox
+                        onClicked:  control.editMode = checked
+                    }
+                }
+            }
+
+            IndicatorPageGroupLayout {
+                Layout.fillWidth:   true
+                showDivider:        false
+
+                IndicatorPageButtonRow {
+                    Layout.fillWidth:   true
+                    label:              qsTr("RC Transmitter Flight Modes")
+                    buttonText:         qsTr("Configure")
+
+                    onClicked: {
+                        mainWindow.showVehicleSetupTool(qsTr("Radio"))
+                        drawer.close()
+                    }
+                }
+            }
+        }
+    }
+}

--- a/src/ui/toolbar/GPSIndicator.qml
+++ b/src/ui/toolbar/GPSIndicator.qml
@@ -26,54 +26,7 @@ Item {
 
     property bool showIndicator: true
 
-    property var _activeVehicle: QGroundControl.multiVehicleManager.activeVehicle
-
-    Component {
-        id: gpsInfo
-
-        Rectangle {
-            width:  gpsCol.width   + ScreenTools.defaultFontPixelWidth  * 3
-            height: gpsCol.height  + ScreenTools.defaultFontPixelHeight * 2
-            radius: ScreenTools.defaultFontPixelHeight * 0.5
-            color:  qgcPal.window
-            border.color:   qgcPal.text
-
-            Column {
-                id:                 gpsCol
-                spacing:            ScreenTools.defaultFontPixelHeight * 0.5
-                width:              Math.max(gpsGrid.width, gpsLabel.width)
-                anchors.margins:    ScreenTools.defaultFontPixelHeight
-                anchors.centerIn:   parent
-
-                QGCLabel {
-                    id:             gpsLabel
-                    text:           (_activeVehicle && _activeVehicle.gps.count.value >= 0) ? qsTr("GPS Status") : qsTr("GPS Data Unavailable")
-                    font.family:    ScreenTools.demiboldFontFamily
-                    anchors.horizontalCenter: parent.horizontalCenter
-                }
-
-                GridLayout {
-                    id:                 gpsGrid
-                    visible:            (_activeVehicle && _activeVehicle.gps.count.value >= 0)
-                    anchors.margins:    ScreenTools.defaultFontPixelHeight
-                    columnSpacing:      ScreenTools.defaultFontPixelWidth
-                    anchors.horizontalCenter: parent.horizontalCenter
-                    columns: 2
-
-                    QGCLabel { text: qsTr("GPS Count:") }
-                    QGCLabel { text: _activeVehicle ? _activeVehicle.gps.count.valueString : qsTr("N/A", "No data to display") }
-                    QGCLabel { text: qsTr("GPS Lock:") }
-                    QGCLabel { text: _activeVehicle ? _activeVehicle.gps.lock.enumStringValue : qsTr("N/A", "No data to display") }
-                    QGCLabel { text: qsTr("HDOP:") }
-                    QGCLabel { text: _activeVehicle ? _activeVehicle.gps.hdop.valueString : qsTr("--.--", "No data to display") }
-                    QGCLabel { text: qsTr("VDOP:") }
-                    QGCLabel { text: _activeVehicle ? _activeVehicle.gps.vdop.valueString : qsTr("--.--", "No data to display") }
-                    QGCLabel { text: qsTr("Course Over Ground:") }
-                    QGCLabel { text: _activeVehicle ? _activeVehicle.gps.courseOverGround.valueString : qsTr("--.--", "No data to display") }
-                }
-            }
-        }
-    }
+    property var    _activeVehicle: QGroundControl.multiVehicleManager.activeVehicle
 
     QGCColoredImage {
         id:                 gpsIcon
@@ -110,8 +63,14 @@ Item {
 
     MouseArea {
         anchors.fill:   parent
-        onClicked: {
-            mainWindow.showIndicatorPopup(_root, gpsInfo)
+        onClicked:      mainWindow.showIndicatorDrawer(gpsIndicatorPage)
+    }
+
+    Component {
+        id: gpsIndicatorPage
+
+        GPSIndicatorPage {
+
         }
     }
 }

--- a/src/ui/toolbar/GPSIndicatorPage.qml
+++ b/src/ui/toolbar/GPSIndicatorPage.qml
@@ -1,0 +1,236 @@
+/****************************************************************************
+ *
+ * (c) 2009-2020 QGROUNDCONTROL PROJECT <http://www.qgroundcontrol.org>
+ *
+ * QGroundControl is licensed according to the terms in the file
+ * COPYING.md in the root of the source code directory.
+ *
+ ****************************************************************************/
+
+import QtQuick          2.11
+import QtQuick.Layouts  1.11
+
+import QGroundControl                       1.0
+import QGroundControl.Controls              1.0
+import QGroundControl.MultiVehicleManager   1.0
+import QGroundControl.ScreenTools           1.0
+import QGroundControl.Palette               1.0
+import QGroundControl.FactSystem            1.0
+import QGroundControl.FactControls          1.0
+
+ToolIndicatorPage {
+    showExpand: true
+
+    property real   _margins:       ScreenTools.defaultFontPixelHeight
+    property var    _activeVehicle: QGroundControl.multiVehicleManager.activeVehicle
+    property string _NA:            qsTr("N/A", "No data to display")
+    property string _valueNA:       qsTr("--.--", "No data to display")
+
+    contentComponent: Component {
+        ColumnLayout {
+            spacing: _margins
+
+            QGCLabel {
+                Layout.alignment:   Qt.AlignHCenter
+                text:               qsTr("Vehicle GPS Status")
+                font.family:        ScreenTools.demiboldFontFamily
+            }
+
+            GridLayout {
+                Layout.fillWidth:   true
+                columnSpacing:      _margins
+                columns:            2
+
+                QGCLabel { Layout.fillWidth: true; text: qsTr("Satellites") }
+                QGCLabel { text: _activeVehicle ? _activeVehicle.gps.count.valueString : _NA }
+
+                QGCLabel { Layout.fillWidth: true; text: qsTr("GPS Lock") }
+                QGCLabel { text: _activeVehicle ? _activeVehicle.gps.lock.enumStringValue : _NA }
+
+                QGCLabel { Layout.fillWidth: true; text: qsTr("HDOP") }
+                QGCLabel { text: _activeVehicle ? _activeVehicle.gps.hdop.valueString : _valueNA }
+
+                QGCLabel { Layout.fillWidth: true; text: qsTr("VDOP") }
+                QGCLabel { text: _activeVehicle ? _activeVehicle.gps.vdop.valueString : _valueNA }
+
+                QGCLabel { Layout.fillWidth: true; text: qsTr("Course Over Ground") }
+                QGCLabel { text: _activeVehicle ? _activeVehicle.gps.courseOverGround.valueString : _valueNA }
+            }
+
+            QGCLabel {
+                Layout.alignment:   Qt.AlignHCenter
+                text:               qsTr("RTK GPS Status")
+                font.family:        ScreenTools.demiboldFontFamily
+                visible:            QGroundControl.gpsRtk.connected.value
+            }
+
+            GridLayout {
+                Layout.fillWidth:   true
+                columnSpacing:      _margins
+                columns:            2
+                visible:            QGroundControl.gpsRtk.connected.value
+
+                QGCLabel {
+                    Layout.alignment:   Qt.AlignLeft
+                    Layout.columnSpan:  2
+                    text:               (QGroundControl.gpsRtk.active.value) ? qsTr("Survey-in Active") : qsTr("RTK Streaming")
+                }
+
+                QGCLabel { Layout.fillWidth: true; text: qsTr("Satellites") }
+                QGCLabel { text: QGroundControl.gpsRtk.numSatellites.value }
+
+                QGCLabel { Layout.fillWidth: true; text: qsTr("Duration") }
+                QGCLabel { text: QGroundControl.gpsRtk.currentDuration.value + ' s' }
+
+                QGCLabel {
+                    // during survey-in show the current accuracy, after that show the final accuracy
+                    id:                 accuracyLabel
+                    Layout.fillWidth:   true
+                    text:               QGroundControl.gpsRtk.valid.value ? qsTr("Accuracy") : qsTr("Current Accuracy")
+                    visible:            QGroundControl.gpsRtk.currentAccuracy.value > 0
+                }
+                QGCLabel {
+                    text:       QGroundControl.gpsRtk.currentAccuracy.valueString + " " + QGroundControl.unitsConversion.appSettingsHorizontalDistanceUnitsString
+                    visible:    accuracyLabel.visible
+                }
+            }
+        }
+    }
+
+    expandedComponent: Component {
+        IndicatorPageGroupLayout {
+            heading:        qsTr("RTK GPS Settings")
+            showDivider:    false
+
+            FactCheckBoxSlider {
+                Layout.fillWidth:   true
+                text:               qsTr("AutoConnect")
+                fact:               QGroundControl.settingsManager.autoConnectSettings.autoConnectRTKGPS
+                visible:            fact.visible
+            }
+
+            GridLayout {
+                id:         rtkGrid
+                columns:    3
+
+                property var  rtkSettings:      QGroundControl.settingsManager.rtkSettings
+                property bool useFixedPosition: rtkSettings.useFixedBasePosition.rawValue
+                property real firstColWidth:    ScreenTools.defaultFontPixelWidth * 5
+
+                FactCheckBoxSlider {
+                    Layout.columnSpan:  3
+                    Layout.fillWidth:   true
+                    text:               qsTr("Perform Survey-In")
+                    fact:               rtkGrid.rtkSettings.useFixedBasePosition
+                    checkedValue:       false
+                    uncheckedValue:     true
+                    visible:            rtkGrid.rtkSettings.useFixedBasePosition.visible
+                }
+
+                Item { width: rtkGrid.firstColWidth; height: 1 }
+                QGCLabel {
+                    text:       rtkGrid.rtkSettings.surveyInAccuracyLimit.shortDescription
+                    visible:    rtkGrid.rtkSettings.surveyInAccuracyLimit.visible
+                    enabled:    !rtkGrid.useFixedPosition
+                }
+                FactTextField {
+                    fact:                   rtkGrid.rtkSettings.surveyInAccuracyLimit
+                    visible:                rtkGrid.rtkSettings.surveyInAccuracyLimit.visible
+                    enabled:                !rtkGrid.useFixedPosition
+                }
+
+                Item { width: rtkGrid.firstColWidth; height: 1 }
+                QGCLabel {
+                    text:       rtkGrid.rtkSettings.surveyInMinObservationDuration.shortDescription
+                    visible:    rtkGrid.rtkSettings.surveyInMinObservationDuration.visible
+                    enabled:    !rtkGrid.useFixedPosition
+                }
+                FactTextField {
+                    fact:                   rtkGrid.rtkSettings.surveyInMinObservationDuration
+                    visible:                rtkGrid.rtkSettings.surveyInMinObservationDuration.visible
+                    enabled:                !rtkGrid.useFixedPosition
+                }
+
+                FactCheckBoxSlider {
+                    Layout.columnSpan:  3
+                    Layout.fillWidth:   true
+                    text:               qsTr("Use Specified Base Position")
+                    fact:               rtkGrid.rtkSettings.useFixedBasePosition
+                    visible:            rtkGrid.rtkSettings.useFixedBasePosition.visible
+                }
+
+                Item { width: rtkGrid.firstColWidth; height: 1 }
+                QGCLabel {
+                    text:       rtkGrid.rtkSettings.fixedBasePositionLatitude.shortDescription
+                    visible:    rtkGrid.rtkSettings.fixedBasePositionLatitude.visible
+                    enabled:    rtkGrid.useFixedPosition
+                }
+                FactTextField {
+                    fact:                   rtkGrid.rtkSettings.fixedBasePositionLatitude
+                    visible:                rtkGrid.rtkSettings.fixedBasePositionLatitude.visible
+                    enabled:                rtkGrid.useFixedPosition
+                }
+
+                Item { width: rtkGrid.firstColWidth; height: 1 }
+                QGCLabel {
+                    text:       rtkGrid.rtkSettings.fixedBasePositionLongitude.shortDescription
+                    visible:    rtkGrid.rtkSettings.fixedBasePositionLongitude.visible
+                    enabled:    rtkGrid.useFixedPosition
+                }
+                FactTextField {
+                    fact:               rtkGrid.rtkSettings.fixedBasePositionLongitude
+                    visible:            rtkGrid.rtkSettings.fixedBasePositionLongitude.visible
+                    enabled:            rtkGrid.useFixedPosition
+                }
+
+                Item { width: rtkGrid.firstColWidth; height: 1 }
+                QGCLabel {
+                    text:       rtkGrid.rtkSettings.fixedBasePositionAltitude.shortDescription
+                    visible:    rtkGrid.rtkSettings.fixedBasePositionAltitude.visible
+                    enabled:    rtkGrid.useFixedPosition
+                }
+                FactTextField {
+                    fact:               rtkGrid.rtkSettings.fixedBasePositionAltitude
+                    visible:            rtkGrid.rtkSettings.fixedBasePositionAltitude.visible
+                    enabled:            rtkGrid.useFixedPosition
+                }
+
+                Item { width: rtkGrid.firstColWidth; height: 1 }
+                QGCLabel {
+                    text:       rtkGrid.rtkSettings.fixedBasePositionAccuracy.shortDescription
+                    visible:    rtkGrid.rtkSettings.fixedBasePositionAccuracy.visible
+                    enabled:    rtkGrid.useFixedPosition
+                }
+                FactTextField {
+                    fact:               rtkGrid.rtkSettings.fixedBasePositionAccuracy
+                    visible:            rtkGrid.rtkSettings.fixedBasePositionAccuracy.visible
+                    enabled:            rtkGrid.useFixedPosition
+                }
+
+                Item { width: rtkGrid.firstColWidth; height: 1 }
+                RowLayout {
+                    Layout.columnSpan:  2
+
+                    QGCLabel {
+                        Layout.fillWidth:   true;
+                        text:               qsTr("Current Base Position")
+                        enabled:            saveBasePositionButton.enabled
+                    }
+
+                    QGCButton {
+                        id:         saveBasePositionButton
+                        text:       enabled ? qsTr("Save") : qsTr("Not Yet Valid")
+                        enabled:    QGroundControl.gpsRtk.valid.value
+
+                        onClicked: {
+                            rtkGrid.rtkSettings.fixedBasePositionLatitude.rawValue  = QGroundControl.gpsRtk.currentLatitude.rawValue
+                            rtkGrid.rtkSettings.fixedBasePositionLongitude.rawValue = QGroundControl.gpsRtk.currentLongitude.rawValue
+                            rtkGrid.rtkSettings.fixedBasePositionAltitude.rawValue  = QGroundControl.gpsRtk.currentAltitude.rawValue
+                            rtkGrid.rtkSettings.fixedBasePositionAccuracy.rawValue  = QGroundControl.gpsRtk.currentAccuracy.rawValue
+                        }
+                    }
+                }
+            }
+        }
+    }
+}

--- a/src/ui/toolbar/GPSRTKIndicator.qml
+++ b/src/ui/toolbar/GPSRTKIndicator.qml
@@ -25,62 +25,6 @@ Item {
 
     property bool showIndicator: QGroundControl.gpsRtk ? QGroundControl.gpsRtk.connected.value : false
 
-    Component {
-        id: gpsInfo
-
-        Rectangle {
-            width:  gpsCol.width   + ScreenTools.defaultFontPixelWidth  * 3
-            height: gpsCol.height  + ScreenTools.defaultFontPixelHeight * 2
-            radius: ScreenTools.defaultFontPixelHeight * 0.5
-            color:  qgcPal.window
-            border.color:   qgcPal.text
-
-            Column {
-                id:                 gpsCol
-                spacing:            ScreenTools.defaultFontPixelHeight * 0.5
-                width:              Math.max(gpsGrid.width, gpsLabel.width)
-                anchors.margins:    ScreenTools.defaultFontPixelHeight
-                anchors.centerIn:   parent
-
-                QGCLabel {
-                    id:             gpsLabel
-                    text: (QGroundControl.gpsRtk.active.value) ? qsTr("Survey-in Active") : qsTr("RTK Streaming")
-                    font.family:    ScreenTools.demiboldFontFamily
-                    anchors.horizontalCenter: parent.horizontalCenter
-                }
-
-                GridLayout {
-                    id:                 gpsGrid
-                    visible:            true
-                    anchors.margins:    ScreenTools.defaultFontPixelHeight
-                    columnSpacing:      ScreenTools.defaultFontPixelWidth
-                    anchors.horizontalCenter: parent.horizontalCenter
-                    columns: 2
-
-                    QGCLabel {
-                        text: qsTr("Duration:")
-                        visible: QGroundControl.gpsRtk.active.value
-                        }
-                    QGCLabel {
-                        text: QGroundControl.gpsRtk.currentDuration.value + ' s'
-                        visible: QGroundControl.gpsRtk.active.value
-                        }
-                    QGCLabel {
-                        // during survey-in show the current accuracy, after that show the final accuracy
-                        text: QGroundControl.gpsRtk.valid.value ? qsTr("Accuracy:") : qsTr("Current Accuracy:")
-                        visible: QGroundControl.gpsRtk.currentAccuracy.value > 0
-                        }
-                    QGCLabel {
-                        text: QGroundControl.gpsRtk.currentAccuracy.valueString + " " + QGroundControl.unitsConversion.appSettingsHorizontalDistanceUnitsString
-                        visible: QGroundControl.gpsRtk.currentAccuracy.value > 0
-                        }
-                    QGCLabel { text: qsTr("Satellites:") }
-                    QGCLabel { text: QGroundControl.gpsRtk.numSatellites.value }
-                }
-            }
-        }
-    }
-
     QGCColoredImage {
         id:                 gpsIcon
         width:              height
@@ -108,8 +52,14 @@ Item {
 
     MouseArea {
         anchors.fill:   parent
-        onClicked: {
-            mainWindow.showIndicatorPopup(_root, gpsInfo)
+        onClicked:      mainWindow.showIndicatorDrawer(gpsIndicatorPage)
+    }
+
+    Component {
+        id: gpsIndicatorPage
+
+        GPSIndicatorPage {
+
         }
     }
 }

--- a/src/ui/toolbar/MainStatusIndicatorOfflinePage.qml
+++ b/src/ui/toolbar/MainStatusIndicatorOfflinePage.qml
@@ -1,0 +1,116 @@
+/****************************************************************************
+ *
+ * (c) 2009-2022 QGROUNDCONTROL PROJECT <http://www.qgroundcontrol.org>
+ *
+ * QGroundControl is licensed according to the terms in the file
+ * COPYING.md in the root of the source code directory.
+ *
+ ****************************************************************************/
+
+import QtQuick          2.15
+import QtQuick.Controls 2.15
+import QtQuick.Layouts  1.11
+
+import QGroundControl                       1.0
+import QGroundControl.Controls              1.0
+import QGroundControl.MultiVehicleManager   1.0
+import QGroundControl.ScreenTools           1.0
+import QGroundControl.Palette               1.0
+import QGroundControl.FactSystem            1.0
+import QGroundControl.FactControls          1.0
+
+ToolIndicatorPage {
+    showExpand: true
+
+    property var    linkConfigs:            QGroundControl.linkManager.linkConfigurations
+    property bool   noLinks:                true
+    property var    editingConfig:          null
+    property var    autoConnectSettings:    QGroundControl.settingsManager.autoConnectSettings
+
+    Component.onCompleted: {
+        for (var i = 0; i < linkConfigs.count; i++) {
+            var linkConfig = linkConfigs.get(i)
+            if (!linkConfig.dynamic && !linkConfig.isAutoConnect) {
+                noLinks = false
+                break
+            }
+        }
+    }
+
+    contentComponent: Component {
+            ColumnLayout { 
+            spacing: ScreenTools.defaultFontPixelHeight / 2
+
+            QGCLabel {
+                Layout.alignment:   Qt.AlignTop
+                text:               noLinks ? qsTr("No Links Configured") : qsTr("Connect To Link")
+                font.pointSize:     noLinks ? ScreenTools.largeFontPointSize : ScreenTools.defaultFontPointSize
+            }
+            
+            Repeater {
+                model: linkConfigs
+
+                delegate: QGCButton {
+                    Layout.fillWidth:   true
+                    text:               object.name + (object.link ? " (" + qsTr("Connected") + ")" : "")
+                    visible:            !object.dynamic
+                    enabled:            !object.link
+                    autoExclusive:      true
+
+                    onClicked: {
+                        QGroundControl.linkManager.createConnectedLink(object)
+                        drawer.close()
+                    }
+                }
+            }
+        }
+    }
+
+    expandedComponent: Component {
+        ColumnLayout {
+            spacing: ScreenTools.defaultFontPixelHeight / 2
+
+            IndicatorPageGroupLayout {
+                RowLayout {
+                    QGCLabel { Layout.fillWidth: true; text: qsTr("Communication Links") }
+                    
+                    QGCButton {
+                        text:       qsTr("Configure")
+                        onClicked: {
+                            mainWindow.showSettingsTool(qsTr("Comm Links"))
+                            drawer.close()
+                        }
+                    }
+                }
+            }
+
+            IndicatorPageGroupLayout {
+                heading:        qsTr("AutoConnect")
+                visible:        autoConnectSettings.visible
+                showDivider:    false
+
+                Repeater {
+                    id: autoConnectRepeater
+
+                    model: [ 
+                        autoConnectSettings.autoConnectPixhawk,
+                        autoConnectSettings.autoConnectSiKRadio,
+                        autoConnectSettings.autoConnectPX4Flow,
+                        autoConnectSettings.autoConnectLibrePilot,
+                        autoConnectSettings.autoConnectUDP,
+                        autoConnectSettings.autoConnectZeroConf,
+                    ]
+
+                    property var names: [ qsTr("Pixhawk"), qsTr("SiK Radio"), qsTr("PX4 Flow"), qsTr("LibrePilot"), qsTr("UDP"), qsTr("Zero-Conf") ]
+
+                    FactCheckBoxSlider {
+                        Layout.fillWidth:   true
+                        text:               autoConnectRepeater.names[index]
+                        fact:               modelData
+                        visible:            modelData.visible
+                    }
+                }
+            }
+        }
+    }
+}

--- a/src/ui/toolbar/MessageIndicator.qml
+++ b/src/ui/toolbar/MessageIndicator.qml
@@ -33,7 +33,7 @@ Item {
     property bool   _isMessageImportant:    _activeVehicle ? !_activeVehicle.messageTypeNormal && !_activeVehicle.messageTypeNone : false
 
     function dropMessageIndicator() {
-        mainWindow.showIndicatorPopup(_root, vehicleMessagesPopup);
+        mainWindow.showIndicatorDrawer(drawerComponent)
     }
 
     function getMessageColor() {
@@ -53,6 +53,8 @@ Item {
         //-- It can only get here when closing (vehicle gone while window active)
         return qgcPal.colorGrey
     }
+
+    property var qgcPal: QGroundControl.globalPalette
 
     Image {
         id:                 criticalMessageIcon
@@ -79,14 +81,30 @@ Item {
     }
 
     Component {
-        id: vehicleMessagesPopup
+        id: drawerComponent
 
-        Rectangle {
-            width:          mainWindow.width  * 0.666
-            height:         mainWindow.height * 0.666
-            radius:         ScreenTools.defaultFontPixelHeight / 2
-            color:          qgcPal.window
-            border.color:   qgcPal.text
+        ToolIndicatorPage {
+            showExpand:         false
+            contentComponent:   messageContentComponent
+        }
+    }
+
+    Component {
+        id: messageContentComponent
+
+        TextArea {
+            id:                     messageText
+            width:                  Math.max(ScreenTools.defaultFontPixelHeight * 20, contentWidth + ScreenTools.defaultFontPixelWidth)
+            height:                 Math.max(ScreenTools.defaultFontPixelHeight * 20, contentHeight)
+            readOnly:               true
+            textFormat:             TextEdit.RichText
+            color:                  qgcPal.text
+            placeholderText:        qsTr("No Messages")
+            placeholderTextColor:   qgcPal.text
+            padding:                0
+
+            property bool   _noMessages:    messageText.length === 0
+            property var    _fact:          null
 
             function formatMessage(message) {
                 message = message.replace(new RegExp("<#E>", "g"), "color: " + qgcPal.warningText + "; font: " + (ScreenTools.defaultFontPointSize.toFixed(0) - 1) + "pt monospace;");
@@ -97,95 +115,116 @@ Item {
 
             Component.onCompleted: {
                 messageText.text = formatMessage(_activeVehicle.formattedMessages)
-                //-- Hack to scroll to last message
-                for (var i = 0; i < _activeVehicle.messageCount; i++)
-                    messageFlick.flick(0,-5000)
                 _activeVehicle.resetAllMessages()
             }
 
             Connections {
-                target: _activeVehicle
-                onNewFormattedMessage :{
-                    messageText.append(formatMessage(formattedMessage))
-                    //-- Hack to scroll down
-                    messageFlick.flick(0,-500)
-                }
-            }
-
-            QGCLabel {
-                anchors.centerIn:   parent
-                text:               qsTr("No Messages")
-                visible:            messageText.length === 0
-            }
-
-            //-- Clear Messages
-            QGCColoredImage {
-                anchors.bottom:     parent.bottom
-                anchors.right:      parent.right
-                anchors.margins:    ScreenTools.defaultFontPixelHeight * 0.5
-                height:             ScreenTools.isMobile ? ScreenTools.defaultFontPixelHeight * 1.5 : ScreenTools.defaultFontPixelHeight
-                width:              height
-                sourceSize.height:   height
-                source:             "/res/TrashDelete.svg"
-                fillMode:           Image.PreserveAspectFit
-                mipmap:             true
-                smooth:             true
-                color:              qgcPal.text
-                visible:            messageText.length !== 0
-                MouseArea {
-                    anchors.fill:   parent
-                    onClicked: {
-                        if (_activeVehicle) {
-                            _activeVehicle.clearMessages()
-                            mainWindow.hideIndicatorPopup()
-                        }
-                    }
-                }
+                target:                 _activeVehicle
+                onNewFormattedMessage:  messageText.insert(0, formatMessage(formattedMessage))
             }
 
             FactPanelController {
                 id: controller
             }
 
-            QGCFlickable {
-                id:                 messageFlick
-                anchors.margins:    ScreenTools.defaultFontPixelHeight
-                anchors.fill:       parent
-                contentHeight:      messageText.height
-                contentWidth:       messageText.width
-                pixelAligned:       true
-
-                TextEdit {
-                    id:                 messageText
-                    readOnly:           true
-                    textFormat:         TextEdit.RichText
-                    selectByMouse:      true
-                    color:              qgcPal.text
-                    selectionColor:     qgcPal.text
-                    selectedTextColor:  qgcPal.window
-                    property var fact:  null
-                    onLinkActivated: {
-                        if (link.startsWith('param://')) {
-                            var paramName = link.substr(8);
-                            fact = controller.getParameterFact(-1, paramName, true)
-                            if (fact != null) {
-                                paramEditorDialogComponent.createObject(mainWindow).open()
-                            }
-                        } else {
-                            Qt.openUrlExternally(link);
-                        }
+            onLinkActivated: (link) => {
+                if (link.startsWith('param://')) {
+                    var paramName = link.substr(8);
+                    _fact = controller.getParameterFact(-1, paramName, true)
+                    if (_fact != null) {
+                        paramEditorDialogComponent.createObject(mainWindow).open()
                     }
+                } else {
+                    Qt.openUrlExternally(link);
                 }
-                Component {
-                    id: paramEditorDialogComponent
+            }
 
-                    ParameterEditorDialog {
-                        title:          qsTr("Edit Parameter")
-                        fact:           messageText.fact
-                        destroyOnClose: true
+            Component {
+                id: paramEditorDialogComponent
+
+                ParameterEditorDialog {
+                    title:          qsTr("Edit Parameter")
+                    fact:           messageText._fact
+                    destroyOnClose: true
+                }
+            }
+
+            Rectangle {
+                anchors.right:   parent.right
+                anchors.top:     parent.top
+                width:                      ScreenTools.defaultFontPixelHeight * 1.25
+                height:                     width
+                radius:                     width / 2
+                color:                      QGroundControl.globalPalette.button
+                border.color:               QGroundControl.globalPalette.buttonText
+                visible:                    !_noMessages
+
+                QGCColoredImage {
+                    anchors.margins:    ScreenTools.defaultFontPixelHeight * 0.25
+                    anchors.centerIn:   parent
+                    anchors.fill:       parent
+                    sourceSize.height:  height
+                    source:             "/res/TrashDelete.svg"
+                    fillMode:           Image.PreserveAspectFit
+                    mipmap:             true
+                    smooth:             true
+                    color:              qgcPal.text
+                }
+
+                QGCMouseArea {
+                    fillItem: parent
+                    onClicked: {
+                        _activeVehicle.clearMessages()
+                        drawer.close()
                     }
                 }
             }
         }
     }
+
+    /*
+    FIXME-NEXTGEN: Reimplement this
+    FactPanelController {
+        id: controller
+    }
+
+    QGCFlickable {
+        id:                 messageFlick
+        anchors.margins:    ScreenTools.defaultFontPixelHeight
+        anchors.fill:       parent
+        contentHeight:      messageText.height
+        contentWidth:       messageText.width
+        pixelAligned:       true
+
+        TextEdit {
+            id:                 messageText
+            readOnly:           true
+            textFormat:         TextEdit.RichText
+            selectByMouse:      true
+            color:              qgcPal.text
+            selectionColor:     qgcPal.text
+            selectedTextColor:  qgcPal.window
+            onLinkActivated: {
+                if (link.startsWith('param://')) {
+                    var paramName = link.substr(8);
+                    fact = controller.getParameterFact(-1, paramName, true)
+                    if (fact != null) {
+                        paramEditorDialogComponent.createObject(mainWindow).open()
+                    }
+                } else {
+                    Qt.openUrlExternally(link);
+                }
+            }
+        }
+        Component {
+            id: paramEditorDialogComponent
+
+            ParameterEditorDialog {
+                title:          qsTr("Edit Parameter")
+                fact:           messageText.fact
+                destroyOnClose: true
+            }
+        }
+    }
+    */
 }


### PR DESCRIPTION
This is the first step of major ui rework described here: https://github.com/mavlink/qgroundcontrol/issues/10617

The goal of these change are to prevent the user needing to wade through the myriad of vehicle setup and app settings pages once they have reached the stage where they are simply flying an already configured vehicle. Say a commercially purchased vehicle or a DIY vehicle which has already completed all the airframe, radio/sensor cal, flight mode setup and so forth steps. And now you are just flying to vehicle to do work.

The initial dropdown for each toolbar button continues to have the pervious information in the dropdown. But you can now expand them which will show vehicle settings which you may use during every day flight. Some of these settings come from vehicle parameters and some may come from QGC App settings. Within this expanded set of information the FirmwarePlugin has control of part of the page. Such that those settings are firmware specific as well as providing the ability for custom builds to override and customize.

As it currently stands I have implemented the first cut at the PX4 version of these settings. Consider these choices to be a WIP. I'd like to gather input as to what folks think should be made available and not. The ArduPilot ones are NYI and will not show parameter based settings in the expanded drop-down yet. Looking for folks to help fill out the ArduPilot side of things.

All toolbar dropdowns are anchored to the left of the screen and the Q dropdown works just like the other tool dropdowns.
<img width="531" alt="Screenshot 2023-12-07 at 11 42 15 AM" src="https://github.com/mavlink/qgroundcontrol/assets/5876851/095cc4a7-22aa-4da5-acd3-f59d71868389">

The main status indicator in regular mode:
<img width="509" alt="Screenshot 2023-12-07 at 11 42 24 AM" src="https://github.com/mavlink/qgroundcontrol/assets/5876851/e70bf89a-e9c3-4373-8742-30de9ec9a7bb">

Expanded mode. Here you can see that the first set of settings (failsafe, data link) are parameter based settings and it also provides access to the full vehicle setup pages.
<img width="536" alt="Screenshot 2023-12-07 at 11 42 35 AM" src="https://github.com/mavlink/qgroundcontrol/assets/5876851/2053087c-8488-475d-8e8d-983c9a7bb21d">

Here's the rest of the regular and expanded drop downs:
<img width="526" alt="Screenshot 2023-12-07 at 11 42 52 AM" src="https://github.com/mavlink/qgroundcontrol/assets/5876851/7e2b6308-bcd6-4982-9a2c-2ed59f18d34c">
<img width="926" alt="Screenshot 2023-12-07 at 11 43 01 AM" src="https://github.com/mavlink/qgroundcontrol/assets/5876851/a4c63c4a-e337-4c63-a642-46deddec9af1">
 
The flight mode expanded section also provides new support for hiding flight modes from usage. There is a default set for each firmware type which automatically stars out as hidden:
<img width="980" alt="Screenshot 2023-12-07 at 11 43 10 AM" src="https://github.com/mavlink/qgroundcontrol/assets/5876851/457b516f-79e3-4a12-9634-464802f69651">
<img width="520" alt="Screenshot 2023-12-07 at 11 43 19 AM" src="https://github.com/mavlink/qgroundcontrol/assets/5876851/70e0281d-c058-4a79-b0eb-e6cb06d2d7fc">
<img width="622" alt="Screenshot 2023-12-07 at 11 43 26 AM" src="https://github.com/mavlink/qgroundcontrol/assets/5876851/ca925d04-976b-48b2-9100-a8eb005442b5">
<img width="527" alt="Screenshot 2023-12-07 at 11 43 33 AM" src="https://github.com/mavlink/qgroundcontrol/assets/5876851/49f1262b-9b2f-443a-9281-dbd8b5957ef5">
<img width="513" alt="Screenshot 2023-12-07 at 11 43 42 AM" src="https://github.com/mavlink/qgroundcontrol/assets/5876851/31cae789-2132-479a-8fb9-a5d09de00012">
