### PR TITLE
Fix QGCSwitch  and ClickableColor after migration to Qt6

### DIFF
--- a/src/QmlControls/ClickableColor.qml
+++ b/src/QmlControls/ClickableColor.qml
@@ -1,6 +1,7 @@
 import QtQuick
 import QtQuick.Controls
 import QtQuick.Dialogs
+import Qt.labs.platform
 
 Rectangle {
     id:             _root

--- a/src/QmlControls/QGCSwitch.qml
+++ b/src/QmlControls/QGCSwitch.qml
@@ -9,20 +9,42 @@
 
 import QtQuick
 import QtQuick.Controls
-import QtQuick.Controls
 
 import QGroundControl.Palette
+import QGroundControl.Controls
 import QGroundControl.ScreenTools
 
 Switch {
-    id: _root
-    QGCPalette { id:qgcPal; colorGroupEnabled: true }
+    id: control
+
+    readonly property int _radius: 3
+
+    QGCPalette {
+        id:                 qgcPal
+        colorGroupEnabled:  true
+    }
+
+    contentItem: QGCLabel {
+        text:               control.text
+        verticalAlignment:  Text.AlignVCenter
+        rightPadding:       control.indicator.width + control.spacing
+    }
+
     indicator: Rectangle {
-        implicitWidth:  ScreenTools.defaultFontPixelWidth * 6
-        implicitHeight: ScreenTools.defaultFontPixelHeight
-        color:          (control.checked && control.enabled) ? qgcPal.colorGreen : qgcPal.colorGrey
-        radius:         3
-        border.color:   qgcPal.button
-        border.width:   1
+        implicitWidth: knob.width * 2
+        implicitHeight: knob.height
+        x: control.width - width - control.rightPadding
+        y: parent.height / 2 - height / 2
+        radius: knob.radius
+        color: control.checked ? qgcPal.primaryButton : qgcPal.button
+
+        Rectangle {
+            id: knob
+            x: control.checked ? parent.width - width : 0
+            width: ScreenTools.defaultFontPixelHeight
+            height: ScreenTools.defaultFontPixelHeight
+            radius: height / 2
+            color: qgcPal.buttonText
+        }
     }
 }


### PR DESCRIPTION
After migration to Qt6 these controls were broken 