### PR TITLE
Add FMU V6XRT Board Info

### DIFF
--- a/src/comm/USBBoardInfo.json
+++ b/src/comm/USBBoardInfo.json
@@ -16,6 +16,7 @@
         { "vendorID": 12677, "productID": 51,       "boardClass": "Pixhawk",    "name": "PX4 FMU V5X" },
         { "vendorID": 7052, "productID": 54,        "boardClass": "Pixhawk",    "name": "PX4 FMU V6U" },
         { "vendorID": 12677, "productID": 53,       "boardClass": "Pixhawk",    "name": "PX4 FMU V6X" },
+        { "vendorID": 13891, "productID": 29,       "boardClass": "Pixhawk",    "name": "PX4 FMU V6XRT" },
         { "vendorID": 12677, "productID": 56,       "boardClass": "Pixhawk",    "name": "PX4 FMU V6C" },
         { "vendorID": 9900, "productID": 64,        "boardClass": "Pixhawk",    "name": "TAP V1" },
         { "vendorID": 9900, "productID": 65,        "boardClass": "Pixhawk",    "name": "ASC V1" },


### PR DESCRIPTION
Vendor ID & Product ID is from [fmu v6xrt nsh file](https://github.com/PX4/PX4-Autopilot/tree/main/boards/px4/fmu-v6xrt/nuttx-config/nsh)


