### PR TITLE
Correct FMUv6x-RT ProductID

### DIFF
--- a/src/VehicleSetup/FirmwareUpgradeController.cc
+++ b/src/VehicleSetup/FirmwareUpgradeController.cc
@@ -62,7 +62,7 @@ static QMap<int, QString> px4_board_name_map {
     {54, "px4_fmu-v6u_default"},
     {56, "px4_fmu-v6c_default"},
     {57, "ark_fmu-v6x_default"},
-    {58, "px4_fmu-v6xrt_default"},
+    {29, "px4_fmu-v6xrt_default"},
     {55, "sky-drones_smartap-airlink_default"},
     {88, "airmind_mindpx-v2_default"},
     {12, "bitcraze_crazyflie_default"},


### PR DESCRIPTION
This looks like a mistake, change FMUv6x-RT ProductID to 29 to match PX4 code. 
The product ID of the firmware used in this product shown in the PX4 Code is 0x001d, which is 29. 

[PX4-Autopilot/boards/px4/fmu-v6xrt/nuttx-config/nsh/defconfig ](https://github.com/PX4/PX4-Autopilot/blob/ece60b6165753c26f8cbc24cd6b2b2918ef8d8fe/boards/px4/fmu-v6xrt/nuttx-config/nsh/defconfig#L43)
[PX4-Autopilot/boards/px4/fmu-v6xrt/nuttx-config/bootloader/defconfig](https://github.com/PX4/PX4-Autopilot/blob/ece60b6165753c26f8cbc24cd6b2b2918ef8d8fe/boards/px4/fmu-v6xrt/nuttx-config/bootloader/defconfig#L44)

It looks like user is unable to flash FW via QGC online due to this mismatch. 

![image](https://github.com/mavlink/qgroundcontrol/assets/46874772/9966f04f-a3c2-4f54-b3f3-bcca39c5fb72)
