### PR TITLE
Fact text field validation

### DIFF
--- a/src/FactSystem/FactControls/FactTextField.qml
+++ b/src/FactSystem/FactControls/FactTextField.qml
@@ -9,12 +9,12 @@ import QGroundControl.Controls
 import QGroundControl.ScreenTools
 
 QGCTextField {
-    id: _textField
+    id: control
 
     text:               fact ? fact.valueString : ""
     unitsLabel:         fact ? fact.units : ""
     showUnits:          true
-    showHelp:           true
+    showHelp:           false
     numericValuesOnly:  fact && !fact.typeIsString
 
     signal updated()
@@ -26,15 +26,31 @@ QGCTextField {
     onEditingFinished: {
         var errorString = fact.validate(text, false /* convertOnly */)
         if (errorString === "") {
+            globals.validationError = false
+            validationToolTip.visible = false
             fact.value = text
-            _textField.updated()
+            control.updated()
         } else {
-            _validateString = text
-            validationErrorDialogComponent.createObject(mainWindow).open()
+            globals.validationError = true
+            validationToolTip.text = errorString
+            validationToolTip.visible = true
         }
     }
 
     onHelpClicked: helpDialogComponent.createObject(mainWindow).open()
+
+    ToolTip {
+        id: validationToolTip
+
+        QGCMouseArea {
+            anchors.fill: parent
+            onClicked: {
+                control.text = fact.valueString
+                validationToolTip.visible = false
+                globals.validationError = false
+            }
+        }
+    }
 
     Component {
         id: validationErrorDialogComponent
@@ -43,7 +59,7 @@ QGCTextField {
             title:          qsTr("Invalid Value")
             validate:       true
             validateValue:  _validateString
-            fact:           _textField.fact
+            fact:           control.fact
         }
     }
 
@@ -52,7 +68,7 @@ QGCTextField {
 
         ParameterEditorDialog {
             title:          qsTr("Value Details")
-            fact:           _textField.fact
+            fact:           control.fact
         }
     }
 }

--- a/src/QmlControls/EditPositionDialog.qml
+++ b/src/QmlControls/EditPositionDialog.qml
@@ -22,7 +22,7 @@ import QGroundControl.Controllers
 QGCPopupDialog {
     id:         root
     title:      qsTr("Edit Position")
-    buttons:    mainWindow.showDialogDefaultWidth, Dialog.Close
+    buttons:    Dialog.Close
 
     property alias coordinate: controller.coordinate
 

--- a/src/QmlControls/QGCTextField.qml
+++ b/src/QmlControls/QGCTextField.qml
@@ -9,6 +9,8 @@ import QGroundControl.ScreenTools
 TextField {
     id:                 control
     color:              qgcPal.textFieldText
+    selectionColor:     qgcPal.textFieldText
+    selectedTextColor:  qgcPal.textField
     activeFocusOnPress: true
     antialiasing:       true
     font.pointSize:     ScreenTools.defaultFontPointSize

--- a/src/ui/MainRootWindow.qml
+++ b/src/ui/MainRootWindow.qml
@@ -68,8 +68,6 @@ ApplicationWindow {
         }
     }
 
-    property var                _rgPreventViewSwitch:       [ false ]
-
     readonly property real      _topBottomMargins:          ScreenTools.defaultFontPixelHeight * 0.5
 
     //-------------------------------------------------------------------------
@@ -86,6 +84,7 @@ ApplicationWindow {
 
         property var                planMasterControllerPlanView:   null
         property var                currentPlanMissionItem:         planMasterControllerPlanView ? planMasterControllerPlanView.missionController.currentPlanViewItem : null
+        property bool               validationError:                false   // There is a FactTextField somewhere with a validation error
 
         // Property to manage RemoteID quick acces to settings page
         property bool               commingFromRIDIndicator:        false
@@ -107,23 +106,9 @@ ApplicationWindow {
     //-------------------------------------------------------------------------
     //-- Global Scope Functions
 
-    /// Prevent view switching
-    function pushPreventViewSwitch() {
-        _rgPreventViewSwitch.push(true)
-    }
-
-    /// Allow view switching
-    function popPreventViewSwitch() {
-        if (_rgPreventViewSwitch.length == 1) {
-            console.warn("mainWindow.popPreventViewSwitch called when nothing pushed")
-            return
-        }
-        _rgPreventViewSwitch.pop()
-    }
-
     /// @return true: View switches are not currently allowed
     function preventViewSwitch() {
-        return _rgPreventViewSwitch[_rgPreventViewSwitch.length - 1]
+        return globals.validationError
     }
 
     function viewSwitch(currentToolbar) {


### PR DESCRIPTION
Fixed a pile of problems related to validating fact values from the ui text fields:
* When a validation fails it now shows a tooltip with the error instead of popping up the whole monster parameter editing dialog.
* Created new system for signalling ui validation error which in turn prevents you from moving away to another part of the ui until you resolve the validation error.
* QGCPopupDialog with CloseOnPressOutside would skip the validation step. Leading to all sorts of strange behavior.
* Fixed a bunch of bugs in the Parametedr Editor dialog

Here's an example of the tooltip:
![Screenshot 2023-12-27 at 10 29 07 AM](https://github.com/mavlink/qgroundcontrol/assets/5876851/92f0f692-bbf8-4c93-b75c-fb83493b45d6)
