### PR TITLE
Plugin airlink

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -241,6 +241,8 @@ if (ENABLE_VIDEOSTREAMING)
     endif ()
 endif ()
 
+option(QGC_AIRLINK_DISABLED "Enable airlink" OFF)
+
 # Sets the default flags for compilation and linking.
 include(CompileOptions)
 

--- a/qgroundcontrol.pro
+++ b/qgroundcontrol.pro
@@ -12,6 +12,7 @@ QMAKE_PROJECT_DEPTH = 0 # undocumented qmake flag to force absolute paths in mak
 # These are disabled until proven correct
 DEFINES += QGC_GST_TAISYNC_DISABLED
 DEFINES += QGC_GST_MICROHARD_DISABLED
+# DEFINES += QGC_AIRLINK_DISABLED
 
 message ("ANDROID_TARGET_ARCH $${ANDROID_TARGET_ARCH} $${QT_ARCH}")
 
@@ -1137,6 +1138,24 @@ contains (DEFINES, QGC_DISABLE_MAVLINK_INSPECTOR) {
         src/AnalyzeView/MAVLinkInspectorController.cc
     QT += \
         charts
+}
+
+#-------------------------------------------------------------------------------------
+# Airlink
+contains (DEFINES, QGC_AIRLINK_DISABLED) {
+    message("AirLink disabled")
+} else {
+    message("AirLink enabled")
+    INCLUDEPATH += \
+        src/AirLink
+
+    HEADERS += \
+        src/AirLink/AirlinkLink.h \
+        src/AirLink/AirLinkManager.h
+
+    SOURCES += \
+        src/AirLink/AirlinkLink.cc \
+        src/AirLink/AirLinkManager.cc
 }
 
 #-------------------------------------------------------------------------------------

--- a/qgroundcontrol.qrc
+++ b/qgroundcontrol.qrc
@@ -31,6 +31,7 @@
         <file alias="QGroundControl/FlightMap/MapLineArrow.qml">src/MissionManager/MapLineArrow.qml</file>
         <file alias="QGroundControl/FlightMap/SplitIndicator.qml">src/FlightMap/MapItems/SplitIndicator.qml</file>
         <file alias="ADSBServerSettings.qml">src/ui/preferences/ADSBServerSettings.qml</file>
+        <file alias="AirLinkSettings.qml">src/AirLink/AirLinkSettings.qml</file>
         <file alias="AnalyzeView.qml">src/AnalyzeView/AnalyzeView.qml</file>
         <file alias="AppSettings.qml">src/ui/AppSettings.qml</file>
         <file alias="BluetoothSettings.qml">src/ui/preferences/BluetoothSettings.qml</file>

--- a/src/AirLink/AirLinkManager.cc
+++ b/src/AirLink/AirLinkManager.cc
@@ -1,0 +1,113 @@
+/****************************************************************************
+ *
+ * (c) 2009-2020 QGROUNDCONTROL PROJECT <http://www.qgroundcontrol.org>
+ *
+ * QGroundControl is licensed according to the terms in the file
+ * COPYING.md in the root of the source code directory.
+ *
+ ****************************************************************************/
+
+#include "AirLinkManager.h"
+#include "QGCApplication.h"
+#include "QGCCorePlugin.h"
+#include "LinkManager.h"
+#include "SettingsManager.h"
+#include "UDPLink.h"
+
+//#include "LinkInterface.h"
+
+#include <QSettings>
+#include <QDebug>
+
+const QString AirLinkManager::airlinkHost = "air-link.space";
+
+AirLinkManager::AirLinkManager(QGCApplication* app, QGCToolbox* toolbox)
+    : QGCTool(app, toolbox)
+{
+}
+
+AirLinkManager::~AirLinkManager()
+{
+}
+
+void AirLinkManager::setToolbox(QGCToolbox* toolbox)
+{
+    QGCTool::setToolbox(toolbox);
+}
+
+QStringList AirLinkManager::droneList() const
+{
+    return _vehiclesFromServer.keys();
+}
+
+void AirLinkManager::updateDroneList(const QString &login, const QString &pass)
+{
+    connectToAirLinkServer(login, pass);
+}
+
+bool AirLinkManager::isOnline(const QString &drone)
+{
+    if (!_vehiclesFromServer.contains(drone)) {
+        return false;
+    } else {
+        return _vehiclesFromServer[drone];
+    }
+}
+
+void AirLinkManager::connectToAirLinkServer(const QString &login, const QString &pass)
+{
+    QNetworkAccessManager *mngr = new QNetworkAccessManager(this);
+
+    const QUrl url("https://air-link.space/api/gs/getModems");
+    QNetworkRequest request(url);
+    request.setHeader(QNetworkRequest::ContentTypeHeader, "application/json");
+
+    QJsonObject obj;
+    obj["login"] = login;
+    obj["password"] = pass;
+    QJsonDocument doc(obj);
+    QByteArray data = doc.toJson();
+
+    _reply = mngr->post(request, data);
+
+    QObject::connect(_reply, &QNetworkReply::finished, [this](){
+        _processReplyAirlinkServer(*_reply);
+        _reply->deleteLater();
+    });
+
+    mngr = nullptr;
+    delete mngr;
+}
+
+void AirLinkManager::updateCredentials(const QString &login, const QString &pass)
+{
+    _toolbox->settingsManager()->appSettings()->loginAirLink()->setRawValue(login);
+    _toolbox->settingsManager()->appSettings()->passAirLink()->setRawValue(pass);
+}
+
+void AirLinkManager::_parseAnswer(const QByteArray &ba)
+{
+    _vehiclesFromServer.clear();
+    for (const auto &arr : QJsonDocument::fromJson(ba)["modems"].toArray()) {
+        QString droneModem = arr.toObject()["name"].toString();
+        bool isOnline = arr.toObject()["isOnline"].toBool();
+        _vehiclesFromServer[droneModem] = isOnline;
+    }
+    emit droneListChanged();
+}
+
+void AirLinkManager::_processReplyAirlinkServer(QNetworkReply &reply)
+{
+    QByteArray ba = reply.readAll();
+
+    if (reply.error() == QNetworkReply::NoError) {
+        if (!QJsonDocument::fromJson(ba)["modems"].toArray().isEmpty()) {
+            _parseAnswer(ba);
+        } else {
+            qDebug() << "No airlink modems in answer";
+        }
+    } else {
+        qDebug() << "Airlink auth - network error";
+    }
+}
+

--- a/src/AirLink/AirLinkManager.h
+++ b/src/AirLink/AirLinkManager.h
@@ -1,0 +1,57 @@
+/****************************************************************************
+ *
+ * (c) 2009-2020 QGROUNDCONTROL PROJECT <http://www.qgroundcontrol.org>
+ *
+ * QGroundControl is licensed according to the terms in the file
+ * COPYING.md in the root of the source code directory.
+ *
+ ****************************************************************************/
+
+#pragma once
+
+#include "QGCToolbox.h"
+#include "QGCLoggingCategory.h"
+#include "Fact.h"
+#include "LinkConfiguration.h"
+
+#include <QTimer>
+#include <QTime>
+#include <QNetworkReply>
+#include <QMutex>
+
+class AppSettings;
+class QGCApplication;
+class LinkInterface;
+
+//-----------------------------------------------------------------------------
+class AirLinkManager : public QGCTool
+{
+    Q_OBJECT
+
+public:
+    Q_PROPERTY(QStringList droneList READ droneList NOTIFY droneListChanged)
+    Q_INVOKABLE void updateDroneList(const QString &login, const QString &pass);
+    Q_INVOKABLE bool isOnline(const QString &drone);
+    Q_INVOKABLE void connectToAirLinkServer(const QString &login, const QString &pass);
+    Q_INVOKABLE void updateCredentials(const QString &login, const QString &pass);
+
+    explicit AirLinkManager(QGCApplication* app, QGCToolbox* toolbox);
+    ~AirLinkManager() override;
+
+    void setToolbox (QGCToolbox* toolbox) override;
+    QStringList droneList() const;
+
+    static const QString airlinkHost;
+    static constexpr int airlinkPort = 10000;
+
+signals:
+    void    droneListChanged();
+
+private:
+    void                _parseAnswer                (const QByteArray &ba);
+    void                _processReplyAirlinkServer  (QNetworkReply &reply);
+
+private:
+    QMap<QString, bool> _vehiclesFromServer;
+    QNetworkReply*      _reply;
+};

--- a/src/AirLink/AirLinkSettings.qml
+++ b/src/AirLink/AirLinkSettings.qml
@@ -1,0 +1,144 @@
+/****************************************************************************
+ *
+ * (c) 2009-2020 QGROUNDCONTROL PROJECT <http://www.qgroundcontrol.org>
+ *
+ * QGroundControl is licensed according to the terms in the file
+ * COPYING.md in the root of the source code directory.
+ *
+ ****************************************************************************/
+
+
+import QtMultimedia
+import QtQuick
+import QtQuick.Controls
+import QtQuick.Dialogs
+import QtQuick.Layouts
+import QtLocation
+import QtPositioning
+
+import QGroundControl
+import QGroundControl.Controllers
+import QGroundControl.Controls
+import QGroundControl.FactControls
+import QGroundControl.FactSystem
+import QGroundControl.Palette
+import QGroundControl.ScreenTools
+import QGroundControl.SettingsManager
+
+ColumnLayout {
+    spacing: _rowSpacing
+
+    property Fact _loginFact:   QGroundControl.settingsManager.appSettings.loginAirLink
+    property Fact _passFact:    QGroundControl.settingsManager.appSettings.passAirLink
+
+    function saveSettings() {
+        // No need
+    }
+
+    function updateConnectionName(modem) {
+        nameField.text = "Airlink " + modem
+    }
+
+    GridLayout {
+        columns:        2
+        columnSpacing:  _colSpacing
+        rowSpacing:     _rowSpacing
+
+        QGCLabel {
+            text: qsTr("Login:")
+        }
+
+        QGCTextField {
+            id:                     loginField
+            text:                   _loginFact.rawValue
+            focus:                  true
+            Layout.preferredWidth:  _secondColumnWidth
+            onTextChanged:          subEditConfig.username = loginField.text
+        }
+
+
+        QGCLabel {
+            text: qsTr("Password:")
+        }
+
+        QGCTextField {
+            id:                     passwordField
+            text:                   _passFact.rawValue
+            focus:                  true
+            Layout.preferredWidth:  _secondColumnWidth
+            echoMode:               TextInput.Password
+            onTextChanged:          subEditConfig.password = passwordField.text
+        }
+    }
+    QGCLabel {
+        text: "Forgot Your AirLink Password?"
+        font.underline: true
+        Layout.columnSpan:  2
+        MouseArea {
+            anchors.fill:   parent
+            hoverEnabled:   true
+            cursorShape:    Qt.PointingHandCursor
+            onClicked:      Qt.openUrlExternally("https://air-link.space/forgot-pass")
+        }
+    }
+
+    RowLayout {
+        spacing:  _colSpacing
+        QGCLabel {
+            wrapMode:               Text.WordWrap
+            text:                   qsTr("Don't have an account?")
+        }
+        QGCLabel {
+            font.underline:         true
+            wrapMode:               Text.WordWrap
+            text:                   qsTr("Register")
+            MouseArea {
+                anchors.fill:   parent
+                hoverEnabled:   true
+                cursorShape:    Qt.PointingHandCursor
+                onClicked:      Qt.openUrlExternally("https://air-link.space/registration")
+            }
+        }
+    }
+
+    QGCLabel {
+        text: qsTr("List of available devices")
+    }
+
+    RowLayout {
+        QGCComboBox {
+            Layout.fillWidth: true
+            model:            QGroundControl.airlinkManager.droneList
+            onActivated: {
+                subEditConfig.modemName = QGroundControl.airlinkManager.droneList[index]
+                updateConnectionName(subEditConfig.modemName)
+            }
+            Connections {
+                target: QGroundControl.airlinkManager
+                // model update does not trigger onActivated, so we catch first element manually
+                onDroneListChanged: {
+                    if (QGroundControl.airlinkManager.droneList[0] !== undefined) {
+                        subEditConfig.modemName = QGroundControl.airlinkManager.droneList[0]
+                        updateConnectionName(subEditConfig.modemName)
+                    }
+                }
+            }
+        }
+        QGCButton {
+            text:       qsTr("Refresh")
+            onClicked:  {
+                QGroundControl.airlinkManager.updateDroneList(loginField.text, passwordField.text)
+                refreshHint.visible = false
+                QGroundControl.airlinkManager.updateCredentials(loginField.text, passwordField.text)
+            }
+        }
+    }
+
+    QGCLabel {
+        id:                     refreshHint
+        Layout.fillWidth:       true
+        font.pointSize:         ScreenTools.smallFontPointSize
+        wrapMode:               Text.WordWrap
+        text:                   qsTr("Click \"Refresh\" to authorize")
+    }
+}

--- a/src/AirLink/AirlinkLink.cc
+++ b/src/AirLink/AirlinkLink.cc
@@ -1,0 +1,186 @@
+#include "AirlinkLink.h"
+#include <QGC.h>
+#include <QGCApplication.h>
+#include <AppSettings.h>
+#include <SettingsManager.h>
+#include <AirLinkManager.h>
+
+AirlinkConfiguration::AirlinkConfiguration(const QString &name) : UDPConfiguration(name)
+{
+
+}
+
+AirlinkConfiguration::AirlinkConfiguration(AirlinkConfiguration *source) : UDPConfiguration(source)
+{
+    _copyFrom(source);
+}
+
+AirlinkConfiguration::~AirlinkConfiguration()
+{
+}
+
+void AirlinkConfiguration::setUsername(QString username)
+{
+    _username = username;
+}
+
+void AirlinkConfiguration::setPassword(QString password)
+{
+    _password = password;
+}
+
+void AirlinkConfiguration::setModemName(QString modemName)
+{
+    _modemName = modemName;
+}
+
+void AirlinkConfiguration::loadSettings(QSettings &settings, const QString &root)
+{
+    AppSettings *appSettings = qgcApp()->toolbox()->settingsManager()->appSettings();
+    settings.beginGroup(root);
+    _username = settings.value(_usernameSettingsKey, appSettings->loginAirLink()->rawValueString()).toString();
+    _password = settings.value(_passwordSettingsKey, appSettings->passAirLink()->rawValueString()).toString();
+    _modemName = settings.value(_modemNameSettingsKey).toString();
+    settings.endGroup();
+}
+
+void AirlinkConfiguration::saveSettings(QSettings &settings, const QString &root)
+{
+    settings.beginGroup(root);
+    settings.setValue(_usernameSettingsKey, _username);
+    settings.setValue(_passwordSettingsKey, _password);
+    settings.setValue(_modemNameSettingsKey, _modemName);
+    settings.endGroup();
+}
+
+void AirlinkConfiguration::copyFrom(LinkConfiguration *source)
+{
+    LinkConfiguration::copyFrom(source);
+    auto* udpSource = qobject_cast<UDPConfiguration*>(source);
+    if (udpSource) {
+        UDPConfiguration::copyFrom(source);
+    }
+    _copyFrom(source);
+}
+
+void AirlinkConfiguration::_copyFrom(LinkConfiguration *source)
+{
+    auto* airlinkSource = qobject_cast<AirlinkConfiguration*>(source);
+    if (airlinkSource) {
+        _username = airlinkSource->username();
+        _password = airlinkSource->password();
+        _modemName = airlinkSource->modemName();
+    } else {
+        qWarning() << "Internal error: cannot read AirlinkConfiguration from given source";
+    }
+}
+
+
+AirlinkLink::AirlinkLink(SharedLinkConfigurationPtr &config) : UDPLink(config)
+{
+    _configureUdpSettings();
+}
+
+AirlinkLink::~AirlinkLink()
+{
+}
+
+// bool AirlinkLink::isConnected() const
+// {
+//     return UDPLink::isConnected();
+// }
+
+void AirlinkLink::disconnect()
+{
+    _setConnectFlag(false);
+    UDPLink::disconnect();
+}
+
+// void AirlinkLink::run()
+// {
+//     UDPLink::run();
+// }
+
+bool AirlinkLink::_connect()
+{
+    start(NormalPriority);
+    QTimer *pendingTimer = new QTimer;
+    connect(pendingTimer, &QTimer::timeout, [this, pendingTimer] {
+        pendingTimer->setInterval(3000);
+        if (_stillConnecting()) {
+            qDebug() << "Connecting...";
+            _sendLoginMsgToAirLink();
+        } else {
+            qDebug() << "Stopping...";
+            pendingTimer->stop();
+            pendingTimer->deleteLater();
+        }
+    });
+    MAVLinkProtocol *mavlink = qgcApp()->toolbox()->mavlinkProtocol();
+    auto conn = std::make_shared<QMetaObject::Connection>();
+    *conn = connect(mavlink, &MAVLinkProtocol::messageReceived, [this, conn] (LinkInterface* linkSrc, mavlink_message_t message) {
+        if (this != linkSrc || message.msgid != MAVLINK_MSG_ID_AIRLINK_AUTH_RESPONSE) {
+            return;
+        }
+        mavlink_airlink_auth_response_t responseMsg;
+        mavlink_msg_airlink_auth_response_decode(&message, &responseMsg);
+        int answer = responseMsg.resp_type;
+        if (answer != AIRLINK_AUTH_RESPONSE_TYPE::AIRLINK_AUTH_OK) {
+            qDebug() << "Airlink auth failed";
+            return;
+        }
+        qDebug() << "Connected successfully";
+        QObject::disconnect(*conn);
+        _setConnectFlag(false);
+    });
+    _setConnectFlag(true);
+    pendingTimer->start(0);
+    return true;
+}
+
+void AirlinkLink::_configureUdpSettings()
+{
+    quint16 availablePort = 14550;
+    QUdpSocket udpSocket;
+    while (!udpSocket.bind(QHostAddress::LocalHost, availablePort))
+        availablePort++;
+    UDPConfiguration* udpConfig = dynamic_cast<UDPConfiguration*>(UDPLink::_config.get());
+    udpConfig->addHost(AirLinkManager::airlinkHost, AirLinkManager::airlinkPort);
+    udpConfig->setLocalPort(availablePort);
+    udpConfig->setDynamic(false);
+}
+
+void AirlinkLink::_sendLoginMsgToAirLink()
+{
+    __mavlink_airlink_auth_t auth;
+    uint8_t buffer[MAVLINK_MAX_PACKET_LEN];
+    mavlink_message_t mavmsg;
+    AirlinkConfiguration* config = dynamic_cast<AirlinkConfiguration*>(_config.get());
+    QString login = config->modemName(); ///< Connect not to account but to specific modem
+    QString pass  = config->password();
+
+    memset(&auth.login, 0, sizeof(auth.login));
+    memset(&auth.password, 0, sizeof(auth.password));
+    strcpy(auth.login, login.toUtf8().constData());
+    strcpy(auth.password, pass.toUtf8().constData());
+
+    mavlink_msg_airlink_auth_pack(0, 0, &mavmsg, auth.login, auth.password);
+    uint16_t len = mavlink_msg_to_send_buffer(buffer, &mavmsg);
+    if (!_stillConnecting()) {
+        qDebug() << "Force exit from connection";
+        return;
+    }
+    writeBytesThreadSafe((const char *)buffer, len);
+}
+
+bool AirlinkLink::_stillConnecting()
+{
+    QMutexLocker locker(&_mutex);
+    return _needToConnect;
+}
+
+void AirlinkLink::_setConnectFlag(bool connect)
+{
+    QMutexLocker locker(&_mutex);
+    _needToConnect = connect;
+}

--- a/src/AirLink/AirlinkLink.h
+++ b/src/AirLink/AirlinkLink.h
@@ -1,0 +1,82 @@
+#ifndef AIRLINKLINK_H
+#define AIRLINKLINK_H
+
+#include <UDPLink.h>
+#include <QMutex>
+
+class AirlinkConfiguration : public UDPConfiguration
+{
+    Q_OBJECT
+public:
+    Q_PROPERTY(QString username     READ username       WRITE setUsername   NOTIFY usernameChanged)
+    Q_PROPERTY(QString password     READ password       WRITE setPassword   NOTIFY passwordChanged)
+    Q_PROPERTY(QString modemName    READ modemName      WRITE setModemName  NOTIFY modemNameChanged)
+
+    AirlinkConfiguration(const QString& name);
+    AirlinkConfiguration(AirlinkConfiguration* source);
+    ~AirlinkConfiguration();
+
+    QString username () const { return _username; }
+    QString password () const { return _password; }
+    QString modemName() const { return _modemName; }
+
+    void setUsername    (QString username);
+    void setPassword    (QString password);
+    void setModemName   (QString modemName);
+
+    /// LinkConfiguration overrides
+    LinkType    type                 (void) override { return LinkConfiguration::Airlink; }
+    void        loadSettings         (QSettings& settings, const QString& root) override;
+    void        saveSettings         (QSettings& settings, const QString& root) override;
+    QString     settingsURL          (void) override { return "AirLinkSettings.qml"; }
+    QString     settingsTitle        (void) override { return tr("Airlink Link Settings"); }
+    void        copyFrom             (LinkConfiguration* source) override;
+
+
+signals:
+    void usernameChanged    (void);
+    void passwordChanged    (void);
+    void modemNameChanged   (void);
+
+private:
+    void _copyFrom          (LinkConfiguration *source);
+
+
+    QString _username;
+    QString _password;
+    QString _modemName;
+
+    const QString _usernameSettingsKey = "username";
+    const QString _passwordSettingsKey = "password";
+    const QString _modemNameSettingsKey = "modemName";
+};
+
+class AirlinkLink : public UDPLink
+{
+    Q_OBJECT
+public:
+    AirlinkLink(SharedLinkConfigurationPtr& config);
+    virtual ~AirlinkLink();
+
+    /// LinkInterface overrides
+    // bool isConnected(void) const override;
+    void disconnect (void) override;
+
+    /// QThread overrides
+    // void run(void) override;
+
+private:
+    /// LinkInterface overrides
+    bool _connect(void) override;
+
+    void _configureUdpSettings();
+    void _sendLoginMsgToAirLink();
+    bool _stillConnecting();
+    void _setConnectFlag(bool connect);
+
+    QMutex _mutex;
+    /// Access this varible only with _mutex locked
+    bool _needToConnect {false};
+};
+
+#endif // AIRLINKLINK_H

--- a/src/AirLink/CMakeLists.txt
+++ b/src/AirLink/CMakeLists.txt
@@ -1,0 +1,18 @@
+set(SOURCES
+    AirlinkLink.cc
+    AirlinkLink.h
+    AirLinkManager.cc
+    AirLinkManager.h
+    AirLinkSettings.qml
+        )
+
+find_package(Qt6 COMPONENTS Core REQUIRED)
+find_package(Qt6 COMPONENTS Network REQUIRED)
+
+add_library(AirLink ${SOURCES})
+target_link_libraries(AirLink PUBLIC FactSystem)
+target_link_libraries(AirLink PUBLIC Settings)
+target_link_libraries(AirLink PUBLIC qgc)
+target_link_libraries(AirLink PUBLIC Qt6::Core)
+target_link_libraries(AirLink PUBLIC Qt6::Network)
+target_include_directories(AirLink PUBLIC ${CMAKE_CURRENT_SOURCE_DIR})

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -109,6 +109,9 @@ add_subdirectory(Settings)
 if (${QGC_GST_TAISYNC_ENABLED})
     add_subdirectory(Taisync)
 endif ()
+if (NOT ${QGC_AIRLINK_DISABLED})
+    add_subdirectory(AirLink)
+endif()
 add_subdirectory(Terrain)
 add_subdirectory(uas)
 add_subdirectory(UTMSP)
@@ -171,6 +174,12 @@ if (GST_FOUND)
         target_link_libraries(${PROJECT_NAME} PUBLIC Taisync)
     endif ()
 endif ()
+
+if (NOT ${QGC_AIRLINK_DISABLED})
+    target_link_libraries(${PROJECT_NAME} PUBLIC AirLink)
+else()
+    target_compile_definitions(${PROJECT_NAME} PUBLIC QGC_AIRLINK_DISABLED)
+endif()
 
 target_include_directories(${PROJECT_NAME}
         PUBLIC

--- a/src/QGCToolbox.cc
+++ b/src/QGCToolbox.cc
@@ -31,6 +31,9 @@
 #include "SettingsManager.h"
 #include "QGCApplication.h"
 #include "ADSBVehicleManager.h"
+#ifndef QGC_AIRLINK_DISABLED
+#include "AirLinkManager.h"
+#endif
 
 #if defined(QGC_CUSTOM_BUILD)
 #include CUSTOMHEADER
@@ -83,6 +86,9 @@ QGCToolbox::QGCToolbox(QGCApplication* app)
 
     _mavlinkLogManager      = new MAVLinkLogManager         (app, this);
     _adsbVehicleManager     = new ADSBVehicleManager        (app, this);
+#ifndef QGC_AIRLINK_DISABLED
+    _airlinkManager         = new AirLinkManager            (app, this);
+#endif
 #ifdef CONFIG_UTM_ADAPTER
     _utmspManager            = new UTMSPManager               (app, this);
 #endif
@@ -113,6 +119,9 @@ void QGCToolbox::setChildToolboxes(void)
     _videoManager->setToolbox(this);
     _mavlinkLogManager->setToolbox(this);
     _adsbVehicleManager->setToolbox(this);
+#ifndef QGC_AIRLINK_DISABLED
+    _airlinkManager->setToolbox(this);
+#endif
 #ifdef CONFIG_UTM_ADAPTER
     _utmspManager->setToolbox(this);
 #endif

--- a/src/QGCToolbox.h
+++ b/src/QGCToolbox.h
@@ -33,6 +33,9 @@ class MAVLinkLogManager;
 class QGCCorePlugin;
 class SettingsManager;
 class ADSBVehicleManager;
+#ifndef QGC_AIRLINK_DISABLED
+class AirLinkManager;
+#endif
 #ifdef CONFIG_UTM_ADAPTER
 class UTMSPManager;
 #endif
@@ -64,6 +67,9 @@ public:
 #ifndef __mobile__
     GPSManager*                 gpsManager              () { return _gpsManager; }
 #endif
+#ifndef QGC_AIRLINK_DISABLED
+    AirLinkManager*              airlinkManager          () { return _airlinkManager; }
+#endif
 #ifdef CONFIG_UTM_ADAPTER
     UTMSPManager*                utmspManager             () { return _utmspManager; }
 #endif
@@ -94,6 +100,9 @@ private:
     QGCCorePlugin*              _corePlugin             = nullptr;
     SettingsManager*            _settingsManager        = nullptr;
     ADSBVehicleManager*         _adsbVehicleManager     = nullptr;
+#ifndef QGC_AIRLINK_DISABLED
+    AirLinkManager*             _airlinkManager         = nullptr;
+#endif
 
 #ifdef CONFIG_UTM_ADAPTER
     UTMSPManager*                _utmspManager            = nullptr;

--- a/src/QmlControls/QGroundControlQmlGlobal.cc
+++ b/src/QmlControls/QGroundControlQmlGlobal.cc
@@ -82,6 +82,9 @@ void QGroundControlQmlGlobal::setToolbox(QGCToolbox* toolbox)
     _gpsRtkFactGroup        = qgcApp()->gpsRtkFactGroup();
     _adsbVehicleManager     = toolbox->adsbVehicleManager();
     _globalPalette          = new QGCPalette(this);
+#ifndef QGC_AIRLINK_DISABLED
+    _airlinkManager         = toolbox->airlinkManager();
+#endif
 #ifdef CONFIG_UTM_ADAPTER
     _utmspManager            = toolbox->utmspManager();
 #endif

--- a/src/QmlControls/QGroundControlQmlGlobal.h
+++ b/src/QmlControls/QGroundControlQmlGlobal.h
@@ -18,6 +18,11 @@
 #include "ADSBVehicleManager.h"
 #include "QGCPalette.h"
 #include "QmlUnitsConversion.h"
+#ifndef QGC_AIRLINK_DISABLED
+#include "AirLinkManager.h"
+#else
+class AirLinkManager;
+#endif
 #ifdef CONFIG_UTM_ADAPTER
 #include "UTMSPManager.h"
 #endif
@@ -64,6 +69,10 @@ public:
     Q_PROPERTY(QGCCorePlugin*       corePlugin              READ    corePlugin              CONSTANT)
     Q_PROPERTY(MissionCommandTree*  missionCommandTree      READ    missionCommandTree      CONSTANT)
     Q_PROPERTY(FactGroup*           gpsRtk                  READ    gpsRtkFactGroup         CONSTANT)
+#ifndef QGC_AIRLINK_DISABLED
+    Q_PROPERTY(AirLinkManager*      airlinkManager          READ    airlinkManager          CONSTANT)
+#endif
+    Q_PROPERTY(bool                 airlinkSupported        READ    airlinkSupported        CONSTANT)
     Q_PROPERTY(QGCPalette*          globalPalette           MEMBER  _globalPalette          CONSTANT)   ///< This palette will always return enabled colors
     Q_PROPERTY(QmlUnitsConversion*  unitsConversion         READ    unitsConversion         CONSTANT)
     Q_PROPERTY(bool                 singleFirmwareSupport   READ    singleFirmwareSupport   CONSTANT)
@@ -158,6 +167,12 @@ public:
     static QGeoCoordinate   flightMapPosition   ()  { return _coord; }
     static double           flightMapZoom       ()  { return _zoom; }
 
+    AirLinkManager*         airlinkManager      ()  { return _airlinkManager; }
+#ifndef QGC_AIRLINK_DISABLED
+    bool                    airlinkSupported    ()  { return true; }
+#else
+    bool                    airlinkSupported    () { return false; }
+#endif
 
 #ifdef CONFIG_UTM_ADAPTER
     UTMSPManager*            utmspManager         ()  {return _utmspManager;}
@@ -236,6 +251,7 @@ private:
     FirmwarePluginManager*  _firmwarePluginManager  = nullptr;
     SettingsManager*        _settingsManager        = nullptr;
     FactGroup*              _gpsRtkFactGroup        = nullptr;
+    AirLinkManager*         _airlinkManager         = nullptr;
     ADSBVehicleManager*     _adsbVehicleManager     = nullptr;
     QGCPalette*             _globalPalette          = nullptr;
     QmlUnitsConversion      _unitsConversion;

--- a/src/Settings/App.SettingsGroup.json
+++ b/src/Settings/App.SettingsGroup.json
@@ -327,6 +327,18 @@
     "longDesc":  "Ardupilot Support server to forward mavlink to. i.e: support.ardupilot.org:xxxx",
     "type":      "string",
     "default":   "support.ardupilot.org:xxxx"
+},
+{
+    "name": "loginAirLink",
+    "shortDesc": "AirLink User Name",
+    "type": "string",
+    "default": ""
+},
+{
+    "name": "passAirLink",
+    "shortDesc": "AirLink Password",
+    "type": "string",
+    "default": ""
 }
 ]
 }

--- a/src/Settings/AppSettings.cc
+++ b/src/Settings/AppSettings.cc
@@ -170,6 +170,8 @@ DECLARE_SETTINGSFACT(AppSettings, firstRunPromptIdsShown)
 DECLARE_SETTINGSFACT(AppSettings, forwardMavlink)
 DECLARE_SETTINGSFACT(AppSettings, forwardMavlinkHostName)
 DECLARE_SETTINGSFACT(AppSettings, forwardMavlinkAPMSupportHostName)
+DECLARE_SETTINGSFACT(AppSettings, loginAirLink)
+DECLARE_SETTINGSFACT(AppSettings, passAirLink)
 
 DECLARE_SETTINGSFACT_NO_FUNC(AppSettings, indoorPalette)
 {

--- a/src/Settings/AppSettings.h
+++ b/src/Settings/AppSettings.h
@@ -65,6 +65,8 @@ public:
     DEFINE_SETTINGFACT(forwardMavlink)
     DEFINE_SETTINGFACT(forwardMavlinkHostName)
     DEFINE_SETTINGFACT(forwardMavlinkAPMSupportHostName)
+    DEFINE_SETTINGFACT(loginAirLink)
+    DEFINE_SETTINGFACT(passAirLink)
 
 
     // Although this is a global setting it only affects ArduPilot vehicle since PX4 automatically starts the stream from the vehicle side

--- a/src/comm/LinkConfiguration.cc
+++ b/src/comm/LinkConfiguration.cc
@@ -20,6 +20,9 @@
 #ifdef QT_DEBUG
 #include "MockLink.h"
 #endif
+#ifndef QGC_AIRLINK_DISABLED
+#include <AirlinkLink.h>
+#endif
 
 #define LINK_SETTING_ROOT "LinkConfigurations"
 
@@ -93,6 +96,11 @@ LinkConfiguration* LinkConfiguration::createSettings(int type, const QString& na
             config = new MockConfiguration(name);
             break;
 #endif
+#ifndef QGC_AIRLINK_DISABLED
+        case LinkConfiguration::Airlink:
+            config = new AirlinkConfiguration(name);
+            break;
+#endif
     }
     return config;
 }
@@ -127,6 +135,11 @@ LinkConfiguration* LinkConfiguration::duplicateSettings(LinkConfiguration* sourc
 #ifdef QT_DEBUG
         case TypeMock:
             dupe = new MockConfiguration(qobject_cast<MockConfiguration*>(source));
+            break;
+#endif
+#ifndef QGC_AIRLINK_DISABLED
+        case Airlink:
+            dupe = new AirlinkConfiguration(qobject_cast<AirlinkConfiguration*>(source));
             break;
 #endif
         case TypeLast:

--- a/src/comm/LinkConfiguration.h
+++ b/src/comm/LinkConfiguration.h
@@ -58,6 +58,9 @@ public:
 #ifdef QT_DEBUG
         TypeMock,       ///< Mock Link for Unitesting
 #endif
+#ifndef QGC_AIRLINK_DISABLED
+        Airlink,
+#endif
         TypeLogReplay,
         TypeLast        // Last type value (type >= TypeLast == invalid)
     };

--- a/src/comm/LinkManager.cc
+++ b/src/comm/LinkManager.cc
@@ -37,6 +37,11 @@
 #include "MockLink.h"
 #endif
 
+#ifndef QGC_AIRLINK_DISABLED
+#include <AirLinkManager.h>
+#include <AirlinkLink.h>
+#endif
+
 #include <qmdnsengine/browser.h>
 #include <qmdnsengine/cache.h>
 #include <qmdnsengine/mdns.h>
@@ -137,6 +142,11 @@ bool LinkManager::createConnectedLink(SharedLinkConfigurationPtr& config, bool i
 #ifdef QT_DEBUG
     case LinkConfiguration::TypeMock:
         link = std::make_shared<MockLink>(config);
+        break;
+#endif
+#ifndef QGC_AIRLINK_DISABLED
+    case LinkConfiguration::Airlink:
+        link = std::make_shared<AirlinkLink>(config);
         break;
 #endif
     case LinkConfiguration::TypeLast:
@@ -334,6 +344,11 @@ void LinkManager::loadLinkConfigurationList()
 #ifdef QT_DEBUG
                             case LinkConfiguration::TypeMock:
                                 link = new MockConfiguration(name);
+                                break;
+#endif
+#ifndef QGC_AIRLINK_DISABLED
+                            case LinkConfiguration::Airlink:
+                                link = new AirlinkConfiguration(name);
                                 break;
 #endif
                             case LinkConfiguration::TypeLast:
@@ -694,6 +709,9 @@ QStringList LinkManager::linkTypeStrings(void) const
 #endif
 #ifdef QT_DEBUG
         list += tr("Mock Link");
+#endif
+#ifndef QGC_AIRLINK_DISABLED
+        list += tr("AirLink");
 #endif
 #ifndef __mobile__
         list += tr("Log Replay");


### PR DESCRIPTION
Dear QGroundControl community,

My name is Constanteen, and I am a developer at ClearSky, the company behind airlink flight controllers.
To impove our products we decided to add support for connection to drones via LTE. My predecessor took an oportunity to add this feature. But during pull request dialog he faced requirement to impliment result of our work in form of plugin like microhard or taisync. The old pull request was deleted and my predecessor gave me full power of his repository. So here we are. Airlink features was extracted from LinkManager and airlink plugin settings was added.

Thank you for considering our contribution.

Best regards,

Constanteen
Airlink Team
ClearSky Company