### PR TITLE
Add back custom android serial port support

### DIFF
--- a/android.pri
+++ b/android.pri
@@ -1,3 +1,8 @@
+include($$PWD/libs/qtandroidserialport/src/qtandroidserialport.pri)
+
+ANDROID_MIN_SDK_VERSION = 26
+ANDROID_TARGET_SDK_VERSSION = 33
+
 ANDROID_PACKAGE_SOURCE_DIR          = $$OUT_PWD/ANDROID_PACKAGE_SOURCE_DIR  # Tells Qt location of package files for build
 ANDROID_PACKAGE_QGC_SOURCE_DIR      = $$PWD/android                         # Original location of QGC package files
 ANDROID_PACKAGE_CUSTOM_SOURCE_DIR   = $$PWD/custom/android                  # Original location for custom build override package files
@@ -79,7 +84,17 @@ exists($$PWD/custom/android/AndroidManifest.xml) {
 
 OTHER_FILES += \
     $$PWD/android/res/xml/device_filter.xml \
+    $$PWD/android/src/com/hoho/android/usbserial/driver/CdcAcmSerialDriver.java \
+    $$PWD/android/src/com/hoho/android/usbserial/driver/CommonUsbSerialDriver.java \
+    $$PWD/android/src/com/hoho/android/usbserial/driver/Cp2102SerialDriver.java \
+    $$PWD/android/src/com/hoho/android/usbserial/driver/FtdiSerialDriver.java \
+    $$PWD/android/src/com/hoho/android/usbserial/driver/ProlificSerialDriver.java \
+    $$PWD/android/src/com/hoho/android/usbserial/driver/UsbId.java \
+    $$PWD/android/src/com/hoho/android/usbserial/driver/UsbSerialDriver.java \
+    $$PWD/android/src/com/hoho/android/usbserial/driver/UsbSerialProber.java \
+    $$PWD/android/src/com/hoho/android/usbserial/driver/UsbSerialRuntimeException.java \
     $$PWD/android/src/org/mavlink/qgroundcontrol/QGCActivity.java \
+    $$PWD/android/src/org/mavlink/qgroundcontrol/UsbIoManager.java \
     $$PWD/android/src/org/freedesktop/gstreamer/androidmedia/GstAhcCallback.java \
     $$PWD/android/src/org/freedesktop/gstreamer/androidmedia/GstAhsCallback.java \
     $$PWD/android/src/org/freedesktop/gstreamer/androidmedia/GstAmcOnFrameAvailableListener.java

--- a/android/AndroidManifest.xml
+++ b/android/AndroidManifest.xml
@@ -24,11 +24,11 @@
         android:fullBackupOnly="false"
         android:icon="@drawable/icon">
         <activity
-            android:name="org.qtproject.qt.android.bindings.QtActivity"
+            android:name="org.mavlink.qgroundcontrol.QGCActivity"
             android:configChanges="orientation|uiMode|screenLayout|screenSize|smallestScreenSize|layoutDirection|locale|fontScale|keyboard|keyboardHidden|navigation|mcc|mnc|density"
             android:label="-- %%INSERT_APP_NAME%% --"
             android:launchMode="singleTop"
-            android:screenOrientation="unspecified"
+            android:screenOrientation="sensorLandscape"
             android:exported="true">
             <intent-filter>
                 <action android:name="android.intent.action.MAIN" />
@@ -62,8 +62,6 @@
                 android:resource="@xml/qtprovider_paths"/>
         </provider>
     </application>
-
-    <uses-sdk android:targetSdkVersion="33"/>
 
     <!-- Needed to keep working while 'asleep' -->
     <uses-permission android:name="android.permission.WAKE_LOCK"/>

--- a/android/src/com/hoho/android/usbserial/driver/CdcAcmSerialDriver.java
+++ b/android/src/com/hoho/android/usbserial/driver/CdcAcmSerialDriver.java
@@ -1,0 +1,322 @@
+package com.hoho.android.usbserial.driver;
+
+import android.hardware.usb.UsbConstants;
+import android.hardware.usb.UsbDevice;
+import android.hardware.usb.UsbDeviceConnection;
+import android.hardware.usb.UsbEndpoint;
+import android.hardware.usb.UsbInterface;
+import android.util.Log;
+
+import java.io.IOException;
+import java.util.LinkedHashMap;
+import java.util.Map;
+
+/**
+ * USB CDC/ACM serial driver implementation.
+ *
+ * @author mike wakerly (opensource@hoho.com)
+ * @see <a
+ *      href="http://www.usb.org/developers/devclass_docs/usbcdc11.pdf">Universal
+ *      Serial Bus Class Definitions for Communication Devices, v1.1</a>
+ */
+public class CdcAcmSerialDriver extends CommonUsbSerialDriver {
+
+    private final String TAG = CdcAcmSerialDriver.class.getSimpleName();
+
+    private UsbInterface mControlInterface;
+    private UsbInterface mDataInterface;
+
+    private UsbEndpoint mControlEndpoint;
+    private UsbEndpoint mReadEndpoint;
+    private UsbEndpoint mWriteEndpoint;
+
+    private boolean mRts = false;
+    private boolean mDtr = false;
+
+    private static final int USB_RECIP_INTERFACE = 0x01;
+    private static final int USB_RT_ACM = UsbConstants.USB_TYPE_CLASS | USB_RECIP_INTERFACE;
+
+    private static final int SET_LINE_CODING = 0x20;  // USB CDC 1.1 section 6.2
+    private static final int GET_LINE_CODING = 0x21;
+    private static final int SET_CONTROL_LINE_STATE = 0x22;
+    private static final int SEND_BREAK = 0x23;
+
+    public CdcAcmSerialDriver(UsbDevice device) {
+        super(device);
+    }
+
+    @Override
+    public void open() throws IOException {
+        Log.d(TAG, "device " + mDevice);
+        mControlInterface = null;
+        mDataInterface = null;
+        mWriteEndpoint = null;
+        mReadEndpoint = null;
+
+        // locate all needed interfaces
+        for(int i = 0; i < mDevice.getInterfaceCount();i++){
+            UsbInterface iface = mDevice.getInterface(i);
+
+            switch(iface.getInterfaceClass()){
+                case UsbConstants.USB_CLASS_COMM:
+                    mControlInterface = iface;
+                    Log.d(TAG, "control iface=" + iface);
+                    break;
+                case UsbConstants.USB_CLASS_CDC_DATA:
+                    mDataInterface = iface;
+                    Log.d(TAG, "data iface=" + iface);
+                    break;
+                default:
+                    Log.d(TAG, "skipping iface=" + iface);
+                    break;
+            }
+        }
+
+        // failback to the old way
+        if(mControlInterface == null) {
+            mControlInterface = mDevice.getInterface(0);
+            Log.d(TAG, "Failback: Control iface=" + mControlInterface);
+        }
+
+        if (!mConnection.claimInterface(mControlInterface, true)) {
+            throw new IOException("Could not claim control interface.");
+        }
+
+        mControlEndpoint = mControlInterface.getEndpoint(0);
+        Log.d(TAG, "Control endpoint: " + mControlEndpoint);
+
+
+        if(mDataInterface == null) {
+            mDataInterface = mDevice.getInterface(1);
+            Log.d(TAG, "Failback: data iface=" + mDataInterface);
+        }
+
+        if (!mConnection.claimInterface(mDataInterface, true)) {
+            throw new IOException("Could not claim data interface.");
+        }
+
+        for(int i = 0; i < mDataInterface.getEndpointCount(); i++) {
+            UsbEndpoint endpoint = mDataInterface.getEndpoint(i);
+            switch (endpoint.getDirection()) {
+                case UsbConstants.USB_DIR_OUT:
+                    mWriteEndpoint = endpoint;
+                    Log.d(TAG, "Write endpoint: " + mWriteEndpoint);
+                    break;
+                case UsbConstants.USB_DIR_IN:
+                    mReadEndpoint = endpoint;
+                    Log.d(TAG, "Read endpoint: " + mReadEndpoint);
+                    break;
+            }
+        }
+
+        if(mReadEndpoint == null || mWriteEndpoint == null){
+            // failback to the old method
+            mReadEndpoint = mDataInterface.getEndpoint(0);
+            Log.d(TAG, "Read endpoint direction: " + mReadEndpoint.getDirection());
+            mWriteEndpoint = mDataInterface.getEndpoint(1);
+            Log.d(TAG, "Write endpoint direction: " + mWriteEndpoint.getDirection());
+        }
+    }
+
+    private int sendAcmControlMessage(int request, int value, byte[] buf) {
+        return mConnection.controlTransfer(
+                USB_RT_ACM, request, value, 0, buf, buf != null ? buf.length : 0, 5000);
+    }
+
+    @Override
+    public void close() throws IOException {
+        mConnection.close();
+    }
+
+    @Override
+    public int read(byte[] dest, int timeoutMillis) throws IOException {
+        final int numBytesRead;
+        synchronized (mReadBufferLock) {
+            int readAmt = Math.min(dest.length, mReadBuffer.length);
+            numBytesRead = mConnection.bulkTransfer(mReadEndpoint, mReadBuffer, readAmt,
+                    timeoutMillis);
+            if (numBytesRead < 0) {
+                // This sucks: we get -1 on timeout, not 0 as preferred.
+                // We *should* use UsbRequest, except it has a bug/api oversight
+                // where there is no way to determine the number of bytes read
+                // in response :\ -- http://b.android.com/28023
+                return 0;
+            }
+            System.arraycopy(mReadBuffer, 0, dest, 0, numBytesRead);
+        }
+        return numBytesRead;
+    }
+
+    @Override
+    public int write(byte[] src, int timeoutMillis) throws IOException {
+        // TODO(mikey): Nearly identical to FtdiSerial write. Refactor.
+        int offset = 0;
+
+        while (offset < src.length) {
+            final int writeLength;
+            final int amtWritten;
+
+            synchronized (mWriteBufferLock) {
+                final byte[] writeBuffer;
+
+                writeLength = Math.min(src.length - offset, mWriteBuffer.length);
+                if (offset == 0) {
+                    writeBuffer = src;
+                } else {
+                    // bulkTransfer does not support offsets, make a copy.
+                    System.arraycopy(src, offset, mWriteBuffer, 0, writeLength);
+                    writeBuffer = mWriteBuffer;
+                }
+
+                amtWritten = mConnection.bulkTransfer(mWriteEndpoint, writeBuffer, writeLength,
+                        timeoutMillis);
+            }
+            if (amtWritten <= 0) {
+                throw new IOException("Error writing " + writeLength
+                        + " bytes at offset " + offset + " length=" + src.length);
+            }
+
+            //Log.d(TAG, "Wrote amt=" + amtWritten + " attempted=" + writeLength);
+            offset += amtWritten;
+        }
+        return offset;
+    }
+
+    @Override
+    public void setParameters(int baudRate, int dataBits, int stopBits, int parity) {
+        byte stopBitsByte;
+        switch (stopBits) {
+            case STOPBITS_1: stopBitsByte = 0; break;
+            case STOPBITS_1_5: stopBitsByte = 1; break;
+            case STOPBITS_2: stopBitsByte = 2; break;
+            default: throw new IllegalArgumentException("Bad value for stopBits: " + stopBits);
+        }
+
+        byte parityBitesByte;
+        switch (parity) {
+            case PARITY_NONE: parityBitesByte = 0; break;
+            case PARITY_ODD: parityBitesByte = 1; break;
+            case PARITY_EVEN: parityBitesByte = 2; break;
+            case PARITY_MARK: parityBitesByte = 3; break;
+            case PARITY_SPACE: parityBitesByte = 4; break;
+            default: throw new IllegalArgumentException("Bad value for parity: " + parity);
+        }
+
+        byte[] msg = {
+                (byte) ( baudRate & 0xff),
+                (byte) ((baudRate >> 8 ) & 0xff),
+                (byte) ((baudRate >> 16) & 0xff),
+                (byte) ((baudRate >> 24) & 0xff),
+                stopBitsByte,
+                parityBitesByte,
+                (byte) dataBits};
+        sendAcmControlMessage(SET_LINE_CODING, 0, msg);
+    }
+
+    @Override
+    public boolean getCD() throws IOException {
+        return false;  // TODO
+    }
+
+    @Override
+    public boolean getCTS() throws IOException {
+        return false;  // TODO
+    }
+
+    @Override
+    public boolean getDSR() throws IOException {
+        return false;  // TODO
+    }
+
+    @Override
+    public boolean getDTR() throws IOException {
+        return mDtr;
+    }
+
+    @Override
+    public void setDTR(boolean value) throws IOException {
+        mDtr = value;
+        setDtrRts();
+    }
+
+    @Override
+    public boolean getRI() throws IOException {
+        return false;  // TODO
+    }
+
+    @Override
+    public boolean getRTS() throws IOException {
+        return mRts;
+    }
+
+    @Override
+    public void setRTS(boolean value) throws IOException {
+        mRts = value;
+        setDtrRts();
+    }
+
+    private void setDtrRts() {
+        int value = (mRts ? 0x2 : 0) | (mDtr ? 0x1 : 0);
+        sendAcmControlMessage(SET_CONTROL_LINE_STATE, value, null);
+    }
+
+    public static Map<Integer, int[]> getSupportedDevices() {
+        final Map<Integer, int[]> supportedDevices = new LinkedHashMap<Integer, int[]>();
+        supportedDevices.put(Integer.valueOf(UsbId.VENDOR_ARDUINO),
+                new int[] {
+                        UsbId.ARDUINO_UNO,
+                        UsbId.ARDUINO_UNO_R3,
+                        UsbId.ARDUINO_MEGA_2560,
+                        UsbId.ARDUINO_MEGA_2560_R3,
+                        UsbId.ARDUINO_SERIAL_ADAPTER,
+                        UsbId.ARDUINO_SERIAL_ADAPTER_R3,
+                        UsbId.ARDUINO_MEGA_ADK,
+                        UsbId.ARDUINO_MEGA_ADK_R3,
+                        UsbId.ARDUINO_LEONARDO,
+                });
+        supportedDevices.put(Integer.valueOf(UsbId.VENDOR_VAN_OOIJEN_TECH),
+                new int[] {
+                    UsbId.VAN_OOIJEN_TECH_TEENSYDUINO_SERIAL,
+                });
+        supportedDevices.put(Integer.valueOf(UsbId.VENDOR_ATMEL),
+                new int[] {
+                    UsbId.ATMEL_LUFA_CDC_DEMO_APP,
+                });
+        supportedDevices.put(Integer.valueOf(UsbId.VENDOR_LEAFLABS),
+                new int[] {
+                    UsbId.LEAFLABS_MAPLE,
+                });
+        supportedDevices.put(Integer.valueOf(UsbId.VENDOR_PX4),
+                new int[] {
+                    UsbId.DEVICE_PX4FMU,
+                });
+        supportedDevices.put(Integer.valueOf(UsbId.VENDOR_UBLOX),
+                new int[] {
+                    UsbId.DEVICE_UBLOX_5,
+                    UsbId.DEVICE_UBLOX_6,
+                    UsbId.DEVICE_UBLOX_7,
+                    UsbId.DEVICE_UBLOX_8,
+                });
+        supportedDevices.put(Integer.valueOf(UsbId.VENDOR_OPENPILOT),
+                new int[] {
+                    UsbId.DEVICE_CC3D,
+                    UsbId.DEVICE_REVOLUTION,
+                    UsbId.DEVICE_SPARKY2,
+                    UsbId.DEVICE_OPLINK,
+                });
+        supportedDevices.put(Integer.valueOf(UsbId.VENDOR_ARDUPILOT_CHIBIOS1),
+                new int[] {
+                    UsbId.DEVICE_ARDUPILOT_CHIBIOS,
+                });
+        supportedDevices.put(Integer.valueOf(UsbId.VENDOR_ARDUPILOT_CHIBIOS2),
+                new int[] {
+                    UsbId.DEVICE_ARDUPILOT_CHIBIOS,
+                });
+        supportedDevices.put(Integer.valueOf(UsbId.VENDOR_DRAGONLINK),
+                new int[] {
+                    UsbId.DEVICE_DRAGONLINK,
+                });
+        return supportedDevices;
+    }
+
+}

--- a/android/src/com/hoho/android/usbserial/driver/CommonUsbSerialDriver.java
+++ b/android/src/com/hoho/android/usbserial/driver/CommonUsbSerialDriver.java
@@ -1,0 +1,172 @@
+/* Copyright 2013 Google Inc.
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301,
+ * USA.
+ *
+ * Project home page: http://code.google.com/p/usb-serial-for-android/
+ */
+
+package com.hoho.android.usbserial.driver;
+
+import android.hardware.usb.UsbDevice;
+import android.hardware.usb.UsbDeviceConnection;
+
+import java.io.IOException;
+
+/**
+ * A base class shared by several driver implementations.
+ *
+ * @author mike wakerly (opensource@hoho.com)
+ */
+abstract class CommonUsbSerialDriver implements UsbSerialDriver {
+
+    public static final int DEFAULT_READ_BUFFER_SIZE = 16 * 1024;
+    public static final int DEFAULT_WRITE_BUFFER_SIZE = 16 * 1024;
+
+    protected final UsbDevice   mDevice;
+    protected final Object      mReadBufferLock = new Object();
+    protected final Object      mWriteBufferLock = new Object();
+
+    protected UsbDeviceConnection mConnection = null;
+
+    private int _permissionStatus = permissionStatusRequestRequired;
+
+    /** Internal read buffer.  Guarded by {@link #mReadBufferLock}. */
+    protected byte[] mReadBuffer;
+
+    /** Internal write buffer.  Guarded by {@link #mWriteBufferLock}. */
+    protected byte[] mWriteBuffer;
+
+    public CommonUsbSerialDriver(UsbDevice device) {
+        mDevice = device;
+
+        mReadBuffer = new byte[DEFAULT_READ_BUFFER_SIZE];
+        mWriteBuffer = new byte[DEFAULT_WRITE_BUFFER_SIZE];
+    }
+
+    @Override
+    public void setConnection(UsbDeviceConnection connection) {
+        mConnection = connection;
+    }
+
+    @Override
+    public int permissionStatus() {
+        return _permissionStatus;
+    }
+
+    @Override
+    public void setPermissionStatus(int permissionStatus) {
+        _permissionStatus = permissionStatus;
+    }
+
+    /**
+     * Returns the currently-bound USB device.
+     *
+     * @return the device
+     */
+    @Override
+    public final UsbDevice getDevice() {
+        return mDevice;
+    }
+
+    /**
+     * Returns the currently-bound USB device connection.
+     *
+     * @return the device connection
+     */
+    @Override
+    public final UsbDeviceConnection getDeviceConnection() {
+        return mConnection;
+    }
+
+
+
+    /**
+     * Sets the size of the internal buffer used to exchange data with the USB
+     * stack for read operations.  Most users should not need to change this.
+     *
+     * @param bufferSize the size in bytes
+     */
+    public final void setReadBufferSize(int bufferSize) {
+        synchronized (mReadBufferLock) {
+            if (bufferSize == mReadBuffer.length) {
+                return;
+            }
+            mReadBuffer = new byte[bufferSize];
+        }
+    }
+
+    /**
+     * Sets the size of the internal buffer used to exchange data with the USB
+     * stack for write operations.  Most users should not need to change this.
+     *
+     * @param bufferSize the size in bytes
+     */
+    public final void setWriteBufferSize(int bufferSize) {
+        synchronized (mWriteBufferLock) {
+            if (bufferSize == mWriteBuffer.length) {
+                return;
+            }
+            mWriteBuffer = new byte[bufferSize];
+        }
+    }
+
+    @Override
+    public abstract void open() throws IOException;
+
+    @Override
+    public abstract void close() throws IOException;
+
+    @Override
+    public abstract int read(final byte[] dest, final int timeoutMillis) throws IOException;
+
+    @Override
+    public abstract int write(final byte[] src, final int timeoutMillis) throws IOException;
+
+    @Override
+    public abstract void setParameters(
+            int baudRate, int dataBits, int stopBits, int parity) throws IOException;
+
+    @Override
+    public abstract boolean getCD() throws IOException;
+
+    @Override
+    public abstract boolean getCTS() throws IOException;
+
+    @Override
+    public abstract boolean getDSR() throws IOException;
+
+    @Override
+    public abstract boolean getDTR() throws IOException;
+
+    @Override
+    public abstract void setDTR(boolean value) throws IOException;
+
+    @Override
+    public abstract boolean getRI() throws IOException;
+
+    @Override
+    public abstract boolean getRTS() throws IOException;
+
+    @Override
+    public abstract void setRTS(boolean value) throws IOException;
+
+    @Override
+    public boolean purgeHwBuffers(boolean flushReadBuffers, boolean flushWriteBuffers) throws IOException {
+        return !flushReadBuffers && !flushWriteBuffers;
+    }
+
+}
+

--- a/android/src/com/hoho/android/usbserial/driver/Cp2102SerialDriver.java
+++ b/android/src/com/hoho/android/usbserial/driver/Cp2102SerialDriver.java
@@ -1,0 +1,292 @@
+package com.hoho.android.usbserial.driver;
+
+import android.hardware.usb.UsbConstants;
+import android.hardware.usb.UsbDevice;
+import android.hardware.usb.UsbDeviceConnection;
+import android.hardware.usb.UsbEndpoint;
+import android.hardware.usb.UsbInterface;
+import android.util.Log;
+
+import java.io.IOException;
+import java.util.LinkedHashMap;
+import java.util.Map;
+
+public class Cp2102SerialDriver extends CommonUsbSerialDriver {
+    
+    private static final String TAG = Cp2102SerialDriver.class.getSimpleName();
+    
+    private static final int DEFAULT_BAUD_RATE = 9600;
+    
+    private static final int USB_WRITE_TIMEOUT_MILLIS = 5000;
+    
+    /*
+     * Configuration Request Types
+     */
+    private static final int REQTYPE_HOST_TO_DEVICE = 0x41;
+    
+    /*
+     * Configuration Request Codes
+     */
+    private static final int SILABSER_IFC_ENABLE_REQUEST_CODE = 0x00;
+    private static final int SILABSER_SET_BAUDDIV_REQUEST_CODE = 0x01;
+    private static final int SILABSER_SET_LINE_CTL_REQUEST_CODE = 0x03;
+    private static final int SILABSER_SET_MHS_REQUEST_CODE = 0x07;
+    private static final int SILABSER_SET_BAUDRATE = 0x1E;
+    private static final int SILABSER_FLUSH_REQUEST_CODE = 0x12;
+    
+    private static final int FLUSH_READ_CODE = 0x0a;
+    private static final int FLUSH_WRITE_CODE = 0x05;
+    
+    /*
+     * SILABSER_IFC_ENABLE_REQUEST_CODE
+     */
+    private static final int UART_ENABLE = 0x0001;
+    private static final int UART_DISABLE = 0x0000;
+    
+    /*
+     * SILABSER_SET_BAUDDIV_REQUEST_CODE
+     */
+    private static final int BAUD_RATE_GEN_FREQ = 0x384000;
+    
+    /*
+     * SILABSER_SET_MHS_REQUEST_CODE
+     */
+    private static final int MCR_DTR = 0x0001;
+    private static final int MCR_RTS = 0x0002;
+    private static final int MCR_ALL = 0x0003;
+    
+    private static final int CONTROL_WRITE_DTR = 0x0100;
+    private static final int CONTROL_WRITE_RTS = 0x0200;    
+
+    private UsbEndpoint mReadEndpoint;
+    private UsbEndpoint mWriteEndpoint; 
+    
+    public Cp2102SerialDriver(UsbDevice device) {
+        super(device);
+    }
+    
+    private int setConfigSingle(int request, int value) {
+        return mConnection.controlTransfer(REQTYPE_HOST_TO_DEVICE, request, value, 
+                0, null, 0, USB_WRITE_TIMEOUT_MILLIS);
+    }
+
+    @Override
+    public void open() throws IOException {        
+        boolean opened = false;
+        try {
+            for (int i = 0; i < mDevice.getInterfaceCount(); i++) {                
+                UsbInterface usbIface = mDevice.getInterface(i);
+                if (mConnection.claimInterface(usbIface, true)) {
+                    Log.d(TAG, "claimInterface " + i + " SUCCESS");                    
+                } else {
+                    Log.d(TAG, "claimInterface " + i + " FAIL");
+                }
+            }                       
+            
+            UsbInterface dataIface = mDevice.getInterface(mDevice.getInterfaceCount() - 1);
+            for (int i = 0; i < dataIface.getEndpointCount(); i++) {
+                UsbEndpoint ep = dataIface.getEndpoint(i);
+                if (ep.getType() == UsbConstants.USB_ENDPOINT_XFER_BULK) {
+                    if (ep.getDirection() == UsbConstants.USB_DIR_IN) {
+                        mReadEndpoint = ep;
+                    } else {
+                        mWriteEndpoint = ep;
+                    }
+                }
+            }
+            
+            setConfigSingle(SILABSER_IFC_ENABLE_REQUEST_CODE, UART_ENABLE);
+            setConfigSingle(SILABSER_SET_MHS_REQUEST_CODE, MCR_ALL | CONTROL_WRITE_DTR | CONTROL_WRITE_RTS);
+            setConfigSingle(SILABSER_SET_BAUDDIV_REQUEST_CODE, BAUD_RATE_GEN_FREQ / DEFAULT_BAUD_RATE);            
+//            setParameters(DEFAULT_BAUD_RATE, DEFAULT_DATA_BITS, DEFAULT_STOP_BITS, DEFAULT_PARITY);
+            opened = true;
+        } finally {
+            if (!opened) {
+                close();
+            }
+        }        
+    }
+
+    @Override
+    public void close() throws IOException {
+        setConfigSingle(SILABSER_IFC_ENABLE_REQUEST_CODE, UART_DISABLE);
+        mConnection.close();
+    }
+
+    @Override
+    public int read(byte[] dest, int timeoutMillis) throws IOException {
+        final int numBytesRead;
+        synchronized (mReadBufferLock) {
+            int readAmt = Math.min(dest.length, mReadBuffer.length);
+            numBytesRead = mConnection.bulkTransfer(mReadEndpoint, mReadBuffer, readAmt,
+                    timeoutMillis);
+            if (numBytesRead < 0) {
+                // This sucks: we get -1 on timeout, not 0 as preferred.
+                // We *should* use UsbRequest, except it has a bug/api oversight
+                // where there is no way to determine the number of bytes read
+                // in response :\ -- http://b.android.com/28023
+                return 0;
+            }
+            System.arraycopy(mReadBuffer, 0, dest, 0, numBytesRead);
+        }
+        return numBytesRead;
+    }
+
+    @Override
+    public int write(byte[] src, int timeoutMillis) throws IOException {
+        int offset = 0;
+
+        while (offset < src.length) {
+            final int writeLength;
+            final int amtWritten;
+
+            synchronized (mWriteBufferLock) {
+                final byte[] writeBuffer;
+
+                writeLength = Math.min(src.length - offset, mWriteBuffer.length);
+                if (offset == 0) {
+                    writeBuffer = src;
+                } else {
+                    // bulkTransfer does not support offsets, make a copy.
+                    System.arraycopy(src, offset, mWriteBuffer, 0, writeLength);
+                    writeBuffer = mWriteBuffer;
+                }
+
+                amtWritten = mConnection.bulkTransfer(mWriteEndpoint, writeBuffer, writeLength,
+                        timeoutMillis);
+            }
+            if (amtWritten <= 0) {
+                throw new IOException("Error writing " + writeLength
+                        + " bytes at offset " + offset + " length=" + src.length);
+            }
+
+            //Log.d(TAG, "Wrote amt=" + amtWritten + " attempted=" + writeLength);
+            offset += amtWritten;
+        }
+        return offset;
+    }
+
+    private void setBaudRate(int baudRate) throws IOException {   
+        byte[] data = new byte[] {
+                (byte) ( baudRate & 0xff),
+                (byte) ((baudRate >> 8 ) & 0xff),
+                (byte) ((baudRate >> 16) & 0xff),
+                (byte) ((baudRate >> 24) & 0xff)
+        };
+        int ret = mConnection.controlTransfer(REQTYPE_HOST_TO_DEVICE, SILABSER_SET_BAUDRATE, 
+                0, 0, data, 4, USB_WRITE_TIMEOUT_MILLIS);
+        if (ret < 0) {
+            throw new IOException("Error setting baud rate.");
+        }
+    }
+
+    @Override
+    public void setParameters(int baudRate, int dataBits, int stopBits, int parity)
+            throws IOException {
+        setBaudRate(baudRate);
+                
+        int configDataBits = 0;
+        switch (dataBits) {
+            case DATABITS_5:
+                configDataBits |= 0x0500;
+                break;
+            case DATABITS_6:
+                configDataBits |= 0x0600;
+                break;
+            case DATABITS_7:
+                configDataBits |= 0x0700;
+                break;
+            case DATABITS_8:
+                configDataBits |= 0x0800;
+                break;
+            default:
+                configDataBits |= 0x0800;
+                break;
+        }
+        setConfigSingle(SILABSER_SET_LINE_CTL_REQUEST_CODE, configDataBits);
+
+        int configParityBits = 0; // PARITY_NONE
+        switch (parity) {
+            case PARITY_ODD:
+                configParityBits |= 0x0010;
+                break;
+            case PARITY_EVEN:
+                configParityBits |= 0x0020;
+                break;            
+        }
+        setConfigSingle(SILABSER_SET_LINE_CTL_REQUEST_CODE, configParityBits);
+        
+        int configStopBits = 0;
+        switch (stopBits) {
+            case STOPBITS_1:
+                configStopBits |= 0;
+                break;
+            case STOPBITS_2:
+                configStopBits |= 2;
+                break;
+        }
+        setConfigSingle(SILABSER_SET_LINE_CTL_REQUEST_CODE, configStopBits);        
+    }
+
+    @Override
+    public boolean getCD() throws IOException {
+        return false;
+    }
+
+    @Override
+    public boolean getCTS() throws IOException {
+        return false;
+    }
+
+    @Override
+    public boolean getDSR() throws IOException {
+        return false;
+    }
+
+    @Override
+    public boolean getDTR() throws IOException {
+        return true;
+    }
+
+    @Override
+    public void setDTR(boolean value) throws IOException {
+    }
+
+    @Override
+    public boolean getRI() throws IOException {
+        return false;
+    }
+
+    @Override
+    public boolean getRTS() throws IOException {
+        return true;
+    }
+
+    @Override
+    public boolean purgeHwBuffers(boolean purgeReadBuffers,
+            boolean purgeWriteBuffers) throws IOException {
+        int value = (purgeReadBuffers ? FLUSH_READ_CODE : 0)
+                | (purgeWriteBuffers ? FLUSH_WRITE_CODE : 0);
+
+        if (value != 0) {
+            setConfigSingle(SILABSER_FLUSH_REQUEST_CODE, value);
+        }
+
+        return true;
+    }
+
+    @Override
+    public void setRTS(boolean value) throws IOException {
+    }
+    
+    public static Map<Integer, int[]> getSupportedDevices() {
+        final Map<Integer, int[]> supportedDevices = new LinkedHashMap<Integer, int[]>();
+        supportedDevices.put(Integer.valueOf(UsbId.VENDOR_SILAB),
+                new int[] {
+                        UsbId.SILAB_CP2102
+                });
+        return supportedDevices;
+    }
+
+
+}

--- a/android/src/com/hoho/android/usbserial/driver/FtdiSerialDriver.java
+++ b/android/src/com/hoho/android/usbserial/driver/FtdiSerialDriver.java
@@ -1,0 +1,445 @@
+/* Copyright 2011 Google Inc.
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301,
+ * USA.
+ *
+ * Project home page: http://code.google.com/p/usb-serial-for-android/
+ */
+
+// IMPORTANT NOTE:
+//  This code has been modified from the original source. It now uses the FTDI driver provided by
+//  ftdichip.com to communicate with an FTDI device. The previous code did not work with all FTDI
+//  devices.
+package com.hoho.android.usbserial.driver;
+
+import android.hardware.usb.UsbConstants;
+import android.hardware.usb.UsbDevice;
+import android.hardware.usb.UsbDeviceConnection;
+import android.hardware.usb.UsbEndpoint;
+import android.hardware.usb.UsbRequest;
+import android.util.Log;
+
+import com.ftdi.j2xx.D2xxManager;
+import com.ftdi.j2xx.FT_Device;
+
+import java.io.IOException;
+import java.nio.ByteBuffer;
+import java.util.LinkedHashMap;
+import java.util.Map;
+
+import org.mavlink.qgroundcontrol.QGCActivity;
+
+/**
+ * A {@link CommonUsbSerialDriver} implementation for a variety of FTDI devices
+ * <p>
+ * This driver is based on
+ * <a href="http://www.intra2net.com/en/developer/libftdi">libftdi</a>, and is
+ * copyright and subject to the following terms:
+ *
+ * <pre>
+ *   Copyright (C) 2003 by Intra2net AG
+ *
+ *   This program is free software; you can redistribute it and/or modify
+ *   it under the terms of the GNU Lesser General Public License
+ *   version 2.1 as published by the Free Software Foundation;
+ *
+ *   opensource@intra2net.com
+ *   http://www.intra2net.com/en/developer/libftdi
+ * </pre>
+ *
+ * </p>
+ * <p>
+ * Some FTDI devices have not been tested; see later listing of supported and
+ * unsupported devices. Devices listed as "supported" support the following
+ * features:
+ * <ul>
+ * <li>Read and write of serial data (see {@link #read(byte[], int)} and
+ * {@link #write(byte[], int)}.
+ * <li>Setting baud rate (see {@link #setBaudRate(int)}).
+ * </ul>
+ * </p>
+ * <p>
+ * Supported and tested devices:
+ * <ul>
+ * <li>{@value DeviceType#TYPE_R}</li>
+ * </ul>
+ * </p>
+ * <p>
+ * Unsupported but possibly working devices (please contact the author with
+ * feedback or patches):
+ * <ul>
+ * <li>{@value DeviceType#TYPE_2232C}</li>
+ * <li>{@value DeviceType#TYPE_2232H}</li>
+ * <li>{@value DeviceType#TYPE_4232H}</li>
+ * <li>{@value DeviceType#TYPE_AM}</li>
+ * <li>{@value DeviceType#TYPE_BM}</li>
+ * </ul>
+ * </p>
+ *
+ * @author mike wakerly (opensource@hoho.com)
+ * @see <a href="http://code.google.com/p/usb-serial-for-android/">USB Serial
+ * for Android project page</a>
+ * @see <a href="http://www.ftdichip.com/">FTDI Homepage</a>
+ * @see <a href="http://www.intra2net.com/en/developer/libftdi">libftdi</a>
+ */
+public class FtdiSerialDriver extends CommonUsbSerialDriver {
+
+    public static final int USB_TYPE_STANDARD = 0x00 << 5;
+    public static final int USB_TYPE_CLASS = 0x00 << 5;
+    public static final int USB_TYPE_VENDOR = 0x00 << 5;
+    public static final int USB_TYPE_RESERVED = 0x00 << 5;
+
+    public static final int USB_RECIP_DEVICE = 0x00;
+    public static final int USB_RECIP_INTERFACE = 0x01;
+    public static final int USB_RECIP_ENDPOINT = 0x02;
+    public static final int USB_RECIP_OTHER = 0x03;
+
+    public static final int USB_ENDPOINT_IN = 0x80;
+    public static final int USB_ENDPOINT_OUT = 0x00;
+
+    public static final int USB_WRITE_TIMEOUT_MILLIS = 5000;
+    public static final int USB_READ_TIMEOUT_MILLIS = 5000;
+
+    // From ftdi.h
+    /**
+     * Reset the port.
+     */
+    private static final int SIO_RESET_REQUEST = 0;
+
+    /**
+     * Set the modem control register.
+     */
+    private static final int SIO_MODEM_CTRL_REQUEST = 1;
+
+    /**
+     * Set flow control register.
+     */
+    private static final int SIO_SET_FLOW_CTRL_REQUEST = 2;
+
+    /**
+     * Set baud rate.
+     */
+    private static final int SIO_SET_BAUD_RATE_REQUEST = 3;
+
+    /**
+     * Set the data characteristics of the port.
+     */
+    private static final int SIO_SET_DATA_REQUEST = 4;
+
+    private static final int SIO_RESET_SIO = 0;
+    private static final int SIO_RESET_PURGE_RX = 1;
+    private static final int SIO_RESET_PURGE_TX = 2;
+
+    public static final int FTDI_DEVICE_OUT_REQTYPE =
+            UsbConstants.USB_TYPE_VENDOR | USB_RECIP_DEVICE | USB_ENDPOINT_OUT;
+
+    public static final int FTDI_DEVICE_IN_REQTYPE =
+            UsbConstants.USB_TYPE_VENDOR | USB_RECIP_DEVICE | USB_ENDPOINT_IN;
+
+    /**
+     * Length of the modem status header, transmitted with every read.
+     */
+    private static final int MODEM_STATUS_HEADER_LENGTH = 2;
+
+    private final String TAG = FtdiSerialDriver.class.getSimpleName();
+
+    private DeviceType mType;
+
+    /**
+     * FTDI chip types.
+     */
+    private static enum DeviceType {
+        TYPE_BM, TYPE_AM, TYPE_2232C, TYPE_R, TYPE_2232H, TYPE_4232H;
+    }
+
+    private int mInterface = 0; /* INTERFACE_ANY */
+
+    private int mMaxPacketSize = 64; // TODO(mikey): detect
+
+    /**
+     * Due to http://b.android.com/28023 , we cannot use UsbRequest async reads
+     * since it gives no indication of number of bytes read. Set this to
+     * {@code true} on platforms where it is fixed.
+     */
+    private static final boolean ENABLE_ASYNC_READS = false;
+
+    FT_Device m_ftDev;
+
+    /**
+     * Filter FTDI status bytes from buffer
+     * @param src The source buffer (which contains status bytes)
+     * @param dest The destination buffer to write the status bytes into (can be src)
+     * @param totalBytesRead Number of bytes read to src
+     * @param maxPacketSize The USB endpoint max packet size
+     * @return The number of payload bytes
+     */
+    private final int filterStatusBytes(byte[] src, byte[] dest, int totalBytesRead, int maxPacketSize) {
+        final int packetsCount = totalBytesRead / maxPacketSize + 1;
+        for (int packetIdx = 0; packetIdx < packetsCount; ++packetIdx) {
+            final int count = (packetIdx == (packetsCount - 1))
+                    ? (totalBytesRead % maxPacketSize) - MODEM_STATUS_HEADER_LENGTH
+                    : maxPacketSize - MODEM_STATUS_HEADER_LENGTH;
+            if (count > 0) {
+                System.arraycopy(src,
+                        packetIdx * maxPacketSize + MODEM_STATUS_HEADER_LENGTH,
+                        dest,
+                        packetIdx * (maxPacketSize - MODEM_STATUS_HEADER_LENGTH),
+                        count);
+            }
+        }
+
+      return totalBytesRead - (packetsCount * 2);
+    }
+
+    /**
+     * Constructor.
+     *
+     * @param usbDevice the {@link UsbDevice} to use
+     * @param usbConnection the {@link UsbDeviceConnection} to use
+     * @throws UsbSerialRuntimeException if the given device is incompatible
+     *             with this driver
+     */
+    public FtdiSerialDriver(UsbDevice usbDevice) {
+        super(usbDevice);
+        mType = null;
+    }
+
+    public void reset() throws IOException {
+        int result = mConnection.controlTransfer(FTDI_DEVICE_OUT_REQTYPE, SIO_RESET_REQUEST,
+                SIO_RESET_SIO, 0 /* index */, null, 0, USB_WRITE_TIMEOUT_MILLIS);
+        if (result != 0) {
+            throw new IOException("Reset failed: result=" + result);
+        }
+
+        // TODO(mikey): autodetect.
+        mType = DeviceType.TYPE_R;
+    }
+
+    @Override
+    public void open() throws IOException {
+        D2xxManager ftD2xx = null;
+        try {
+            ftD2xx = D2xxManager.getInstance(QGCActivity.m_context);
+        } catch (D2xxManager.D2xxException ex) {
+            QGCActivity.qgcLogDebug("D2xxManager.getInstance threw exception: " + ex.getMessage());
+        }
+
+        if (ftD2xx == null) {
+            String errMsg = "Unable to retrieve D2xxManager instance.";
+            QGCActivity.qgcLogWarning(errMsg);
+            throw new IOException(errMsg);
+        }
+        QGCActivity.qgcLogDebug("Opened D2xxManager");
+
+        int DevCount = ftD2xx.createDeviceInfoList(QGCActivity.m_context);
+        QGCActivity.qgcLogDebug("Found " + DevCount + " ftdi devices.");
+        if (DevCount < 1) {
+            throw new IOException("No FTDI Devices found");
+        }
+
+        m_ftDev = null;
+        try {
+            m_ftDev = ftD2xx.openByIndex(QGCActivity.m_context, 0);
+        } catch (NullPointerException e) {
+            QGCActivity.qgcLogDebug("ftD2xx.openByIndex exception: " + e.getMessage());
+        } finally {
+            if (m_ftDev == null) {
+                throw new IOException("No FTDI Devices found");
+            }
+        }
+        QGCActivity.qgcLogDebug("Opened FTDI device.");
+    }
+
+    @Override
+    public void close() {
+        if (m_ftDev != null) {
+            try {
+                m_ftDev.close();
+            } catch (Exception e) {
+                QGCActivity.qgcLogWarning("close exception: " + e.getMessage());
+            }
+            m_ftDev = null;
+        }
+    }
+
+    @Override
+    public int read(byte[] dest, int timeoutMillis) throws IOException {
+        int totalBytesRead = 0;
+        int bytesAvailable = m_ftDev.getQueueStatus();
+
+        if (bytesAvailable > 0) {
+            bytesAvailable = Math.min(4096, bytesAvailable);
+            try {
+                totalBytesRead = m_ftDev.read(dest, bytesAvailable, timeoutMillis);
+            } catch (NullPointerException e) {
+                final String errorMsg = "Error reading: " + e.getMessage();
+                QGCActivity.qgcLogWarning(errorMsg);
+                throw new IOException(errorMsg, e);
+            }
+        }
+
+        return totalBytesRead;
+    }
+
+    @Override
+    public int write(byte[] src, int timeoutMillis) throws IOException {
+        try {
+            m_ftDev.write(src);
+            return src.length;
+        } catch (Exception e) {
+            QGCActivity.qgcLogWarning("Error writing: " + e.getMessage());
+        }
+        return 0;
+    }
+
+    private int setBaudRate(int baudRate) throws IOException {
+        try {
+            m_ftDev.setBaudRate(baudRate);
+            return baudRate;
+        } catch (Exception e) {
+            QGCActivity.qgcLogWarning("Error setting baud rate: " + e.getMessage());
+        }
+        return 0;
+    }
+
+    @Override
+    public void setParameters(int baudRate, int dataBits, int stopBits, int parity) throws IOException {
+        setBaudRate(baudRate);
+
+        switch (dataBits) {
+        case 7:
+            dataBits = D2xxManager.FT_DATA_BITS_7;
+            break;
+        case 8:
+        default:
+            dataBits = D2xxManager.FT_DATA_BITS_8;
+            break;
+        }
+
+        switch (stopBits) {
+        default:
+        case 0:
+            stopBits = D2xxManager.FT_STOP_BITS_1;
+            break;
+        case 1:
+            stopBits = D2xxManager.FT_STOP_BITS_2;
+            break;
+        }
+
+        switch (parity) {
+        default:
+        case 0:
+            parity = D2xxManager.FT_PARITY_NONE;
+            break;
+        case 1:
+            parity = D2xxManager.FT_PARITY_ODD;
+            break;
+        case 2:
+            parity = D2xxManager.FT_PARITY_EVEN;
+            break;
+        case 3:
+            parity = D2xxManager.FT_PARITY_MARK;
+            break;
+        case 4:
+            parity = D2xxManager.FT_PARITY_SPACE;
+            break;
+        }
+
+        try {
+            m_ftDev.setDataCharacteristics((byte)dataBits, (byte)stopBits, (byte)parity);
+        } catch (Exception e) {
+            QGCActivity.qgcLogWarning("Error setDataCharacteristics: " + e.getMessage());
+        }
+    }
+    @Override
+    public boolean getCD() throws IOException {
+        return false;
+    }
+
+    @Override
+    public boolean getCTS() throws IOException {
+        return false;
+    }
+
+    @Override
+    public boolean getDSR() throws IOException {
+        return false;
+    }
+
+    @Override
+    public boolean getDTR() throws IOException {
+        return false;
+    }
+
+    @Override
+    public void setDTR(boolean value) throws IOException {
+    }
+
+    @Override
+    public boolean getRI() throws IOException {
+        return false;
+    }
+
+    @Override
+    public boolean getRTS() throws IOException {
+        return false;
+    }
+
+    @Override
+    public void setRTS(boolean value) throws IOException {
+    }
+
+    @Override
+    public boolean purgeHwBuffers(boolean purgeReadBuffers, boolean purgeWriteBuffers) throws IOException {
+        if (purgeReadBuffers) {
+            try {
+                m_ftDev.purge(D2xxManager.FT_PURGE_RX);
+            } catch (Exception e) {
+                String errMsg = "Error purgeHwBuffers(RX): "+ e.getMessage();
+                QGCActivity.qgcLogWarning(errMsg);
+                throw new IOException(errMsg);
+            }
+        }
+
+        if (purgeWriteBuffers) {
+            try {
+                m_ftDev.purge(D2xxManager.FT_PURGE_TX);
+            } catch (Exception e) {
+                String errMsg = "Error purgeHwBuffers(TX): " + e.getMessage();
+                QGCActivity.qgcLogWarning(errMsg);
+                throw new IOException(errMsg);
+            }
+        }
+
+        return true;
+    }
+
+    public static Map<Integer, int[]> getSupportedDevices() {
+        final Map<Integer, int[]> supportedDevices = new LinkedHashMap<Integer, int[]>();
+        supportedDevices.put(Integer.valueOf(UsbId.VENDOR_FTDI),
+                new int[] {
+                    UsbId.FTDI_FT232R,
+                    UsbId.FTDI_FT231X,                    
+                });
+        /*
+        supportedDevices.put(Integer.valueOf(UsbId.VENDOR_PX4),
+                new int[] {
+                    UsbId.DEVICE_PX4FMU
+                });
+        */
+        return supportedDevices;
+    }
+
+}

--- a/android/src/com/hoho/android/usbserial/driver/ProlificSerialDriver.java
+++ b/android/src/com/hoho/android/usbserial/driver/ProlificSerialDriver.java
@@ -1,0 +1,523 @@
+/* This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301,
+ * USA.
+ *
+ * Project home page: http://code.google.com/p/usb-serial-for-android/
+ */
+
+/*
+ * Ported to usb-serial-for-android
+ * by Felix Hädicke <felixhaedicke@web.de>
+ *
+ * Based on the pyprolific driver written
+ * by Emmanuel Blot <emmanuel.blot@free.fr>
+ * See https://github.com/eblot/pyftdi
+ */
+
+package com.hoho.android.usbserial.driver;
+
+import android.hardware.usb.UsbConstants;
+import android.hardware.usb.UsbDevice;
+import android.hardware.usb.UsbDeviceConnection;
+import android.hardware.usb.UsbEndpoint;
+import android.hardware.usb.UsbInterface;
+import android.util.Log;
+
+import java.io.IOException;
+import java.lang.reflect.Method;
+import java.util.LinkedHashMap;
+import java.util.Map;
+
+public class ProlificSerialDriver extends CommonUsbSerialDriver {
+    private static final int USB_READ_TIMEOUT_MILLIS = 1000;
+    private static final int USB_WRITE_TIMEOUT_MILLIS = 5000;
+
+    private static final int USB_RECIP_INTERFACE = 0x01;
+
+    private static final int PROLIFIC_VENDOR_READ_REQUEST = 0x01;
+    private static final int PROLIFIC_VENDOR_WRITE_REQUEST = 0x01;
+
+    private static final int PROLIFIC_VENDOR_OUT_REQTYPE = UsbConstants.USB_DIR_OUT
+            | UsbConstants.USB_TYPE_VENDOR;
+
+    private static final int PROLIFIC_VENDOR_IN_REQTYPE = UsbConstants.USB_DIR_IN
+            | UsbConstants.USB_TYPE_VENDOR;
+
+    private static final int PROLIFIC_CTRL_OUT_REQTYPE = UsbConstants.USB_DIR_OUT
+            | UsbConstants.USB_TYPE_CLASS | USB_RECIP_INTERFACE;
+
+    private static final int WRITE_ENDPOINT = 0x02;
+    private static final int READ_ENDPOINT = 0x83;
+    private static final int INTERRUPT_ENDPOINT = 0x81;
+
+    private static final int FLUSH_RX_REQUEST = 0x08;
+    private static final int FLUSH_TX_REQUEST = 0x09;
+
+    private static final int SET_LINE_REQUEST = 0x20;
+    private static final int SET_CONTROL_REQUEST = 0x22;
+
+    private static final int CONTROL_DTR = 0x01;
+    private static final int CONTROL_RTS = 0x02;
+
+    private static final int STATUS_FLAG_CD = 0x01;
+    private static final int STATUS_FLAG_DSR = 0x02;
+    private static final int STATUS_FLAG_RI = 0x08;
+    private static final int STATUS_FLAG_CTS = 0x80;
+
+    private static final int STATUS_BUFFER_SIZE = 10;
+    private static final int STATUS_BYTE_IDX = 8;
+
+    private static final int DEVICE_TYPE_HX = 0;
+    private static final int DEVICE_TYPE_0 = 1;
+    private static final int DEVICE_TYPE_1 = 2;
+
+    private int mDeviceType = DEVICE_TYPE_HX;
+
+    private UsbEndpoint mReadEndpoint;
+    private UsbEndpoint mWriteEndpoint;
+    private UsbEndpoint mInterruptEndpoint;
+
+    private int mControlLinesValue = 0;
+
+    private int mBaudRate = -1, mDataBits = -1, mStopBits = -1, mParity = -1;
+
+    private int mStatus = 0;
+    private volatile Thread mReadStatusThread = null;
+    private final Object mReadStatusThreadLock = new Object();
+    boolean mStopReadStatusThread = false;
+    private IOException mReadStatusException = null;
+
+    private final String TAG = ProlificSerialDriver.class.getSimpleName();
+
+    private final byte[] inControlTransfer(int requestType, int request,
+            int value, int index, int length) throws IOException {
+        byte[] buffer = new byte[length];
+        int result = mConnection.controlTransfer(requestType, request, value,
+                index, buffer, length, USB_READ_TIMEOUT_MILLIS);
+        if (result != length) {
+            throw new IOException(
+                    String.format("ControlTransfer with value 0x%x failed: %d",
+                            value, result));
+        }
+        return buffer;
+    }
+
+    private final void outControlTransfer(int requestType, int request,
+            int value, int index, byte[] data) throws IOException {
+        int length = (data == null) ? 0 : data.length;
+        int result = mConnection.controlTransfer(requestType, request, value,
+                index, data, length, USB_WRITE_TIMEOUT_MILLIS);
+        if (result != length) {
+            throw new IOException(
+                    String.format("ControlTransfer with value 0x%x failed: %d",
+                            value, result));
+        }
+    }
+
+    private final byte[] vendorIn(int value, int index, int length)
+            throws IOException {
+        return inControlTransfer(PROLIFIC_VENDOR_IN_REQTYPE,
+                PROLIFIC_VENDOR_READ_REQUEST, value, index, length);
+    }
+
+    private final void vendorOut(int value, int index, byte[] data)
+            throws IOException {
+        outControlTransfer(PROLIFIC_VENDOR_OUT_REQTYPE,
+                PROLIFIC_VENDOR_WRITE_REQUEST, value, index, data);
+    }
+
+    private final void ctrlOut(int request, int value, int index, byte[] data)
+            throws IOException {
+        outControlTransfer(PROLIFIC_CTRL_OUT_REQTYPE, request, value, index,
+                data);
+    }
+
+    private void doBlackMagic() throws IOException {
+        vendorIn(0x8484, 0, 1);
+        vendorOut(0x0404, 0, null);
+        vendorIn(0x8484, 0, 1);
+        vendorIn(0x8383, 0, 1);
+        vendorIn(0x8484, 0, 1);
+        vendorOut(0x0404, 1, null);
+        vendorIn(0x8484, 0, 1);
+        vendorIn(0x8383, 0, 1);
+        vendorOut(0, 1, null);
+        vendorOut(1, 0, null);
+        vendorOut(2, (mDeviceType == DEVICE_TYPE_HX) ? 0x44 : 0x24, null);
+    }
+
+    private void resetDevice() throws IOException {
+        purgeHwBuffers(true, true);
+    }
+
+    private void setControlLines(int newControlLinesValue) throws IOException {
+        ctrlOut(SET_CONTROL_REQUEST, newControlLinesValue, 0, null);
+        mControlLinesValue = newControlLinesValue;
+    }
+
+    private final void readStatusThreadFunction() {
+        try {
+            while (!mStopReadStatusThread) {
+                byte[] buffer = new byte[STATUS_BUFFER_SIZE];
+                int readBytesCount = mConnection.bulkTransfer(mInterruptEndpoint,
+                        buffer,
+                        STATUS_BUFFER_SIZE,
+                        500);
+                if (readBytesCount > 0) {
+                    if (readBytesCount == STATUS_BUFFER_SIZE) {
+                        mStatus = buffer[STATUS_BYTE_IDX] & 0xff;
+                    } else {
+                        throw new IOException(
+                                String.format("Invalid CTS / DSR / CD / RI status buffer received, expected %d bytes, but received %d",
+                                        STATUS_BUFFER_SIZE,
+                                        readBytesCount));
+                    }
+                }
+            }
+        } catch (IOException e) {
+            mReadStatusException = e;
+        }
+    }
+
+    private final int getStatus() throws IOException {
+        if ((mReadStatusThread == null) && (mReadStatusException == null)) {
+            synchronized (mReadStatusThreadLock) {
+                if (mReadStatusThread == null) {
+                    byte[] buffer = new byte[STATUS_BUFFER_SIZE];
+                    int readBytes = mConnection.bulkTransfer(mInterruptEndpoint,
+                            buffer,
+                            STATUS_BUFFER_SIZE,
+                            100);
+                    if (readBytes != STATUS_BUFFER_SIZE) {
+                        Log.w(TAG, "Could not read initial CTS / DSR / CD / RI status");
+                    } else {
+                        mStatus = buffer[STATUS_BYTE_IDX] & 0xff;
+                    }
+
+                    mReadStatusThread = new Thread(new Runnable() {
+                        @Override
+                        public void run() {
+                            readStatusThreadFunction();
+                        }
+                    });
+                    mReadStatusThread.setDaemon(true);
+                    mReadStatusThread.start();
+                }
+            }
+        }
+
+        /* throw and clear an exception which occurred in the status read thread */
+        IOException readStatusException = mReadStatusException;
+        if (mReadStatusException != null) {
+            mReadStatusException = null;
+            throw readStatusException;
+        }
+        
+        return mStatus;
+    }
+
+    private final boolean testStatusFlag(int flag) throws IOException {
+        return ((getStatus() & flag) == flag);
+    }
+
+    public ProlificSerialDriver(UsbDevice device) {
+        super(device);
+    }
+
+    @Override
+    public void open() throws IOException {
+        UsbInterface usbInterface = mDevice.getInterface(0);
+
+        if (!mConnection.claimInterface(usbInterface, true)) {
+            throw new IOException("Error claiming Prolific interface 0");
+        }
+
+        boolean openSuccessful = false;
+        try {
+            for (int i = 0; i < usbInterface.getEndpointCount(); ++i) {
+                UsbEndpoint currentEndpoint = usbInterface.getEndpoint(i);
+
+                switch (currentEndpoint.getAddress()) {
+                case READ_ENDPOINT:
+                    mReadEndpoint = currentEndpoint;
+                    break;
+
+                case WRITE_ENDPOINT:
+                    mWriteEndpoint = currentEndpoint;
+                    break;
+
+                case INTERRUPT_ENDPOINT:
+                    mInterruptEndpoint = currentEndpoint;
+                    break;
+                }
+            }
+
+            if (mDevice.getDeviceClass() == 0x02) {
+                mDeviceType = DEVICE_TYPE_0;
+            } else {
+                try {
+                    Method getRawDescriptorsMethod
+                        = mConnection.getClass().getMethod("getRawDescriptors");
+                    byte[] rawDescriptors
+                        = (byte[]) getRawDescriptorsMethod.invoke(mConnection);
+                    byte maxPacketSize0 = rawDescriptors[7];
+                    if (maxPacketSize0 == 64) {
+                        mDeviceType = DEVICE_TYPE_HX;
+                    } else if ((mDevice.getDeviceClass() == 0x00)
+                            || (mDevice.getDeviceClass() == 0xff)) {
+                        mDeviceType = DEVICE_TYPE_1;
+                    } else {
+                      Log.w(TAG, "Could not detect PL2303 subtype, "
+                          + "Assuming that it is a HX device");
+                      mDeviceType = DEVICE_TYPE_HX;
+                    }
+                } catch (NoSuchMethodException e) {
+                    Log.w(TAG, "Method UsbDeviceConnection.getRawDescriptors, "
+                            + "required for PL2303 subtype detection, not "
+                            + "available! Assuming that it is a HX device");
+                    mDeviceType = DEVICE_TYPE_HX;
+                } catch (Exception e) {
+                    Log.e(TAG, "An unexpected exception occurred while trying "
+                            + "to detect PL2303 subtype", e);
+                }
+            }
+
+            setControlLines(mControlLinesValue);
+            resetDevice();
+
+            doBlackMagic();
+            openSuccessful = true;
+        } finally {
+            if (!openSuccessful) {
+              try {
+                mConnection.releaseInterface(usbInterface);
+              } catch (Exception ingored) {
+                // Do not cover possible exceptions
+              }
+            }
+        }
+    }
+
+    @Override
+    public void close() throws IOException {
+        try {
+            mStopReadStatusThread = true;
+            synchronized (mReadStatusThreadLock) {
+                if (mReadStatusThread != null) {
+                    try {
+                        mReadStatusThread.join();
+                    } catch (Exception e) {
+                        Log.w(TAG, "An error occurred while waiting for status read thread", e);
+                    }
+                }
+            }
+
+            resetDevice();
+        } finally {
+            mConnection.releaseInterface(mDevice.getInterface(0));
+        }
+    }
+
+    @Override
+    public int read(byte[] dest, int timeoutMillis) throws IOException {
+        synchronized (mReadBufferLock) {
+            int readAmt = Math.min(dest.length, mReadBuffer.length);
+            int numBytesRead = mConnection.bulkTransfer(mReadEndpoint, mReadBuffer,
+                    readAmt, timeoutMillis);
+            if (numBytesRead < 0) {
+                return 0;
+            }
+            System.arraycopy(mReadBuffer, 0, dest, 0, numBytesRead);
+            return numBytesRead;
+        }
+    }
+
+    @Override
+    public int write(byte[] src, int timeoutMillis) throws IOException {
+        int offset = 0;
+
+        while (offset < src.length) {
+            final int writeLength;
+            final int amtWritten;
+
+            synchronized (mWriteBufferLock) {
+                final byte[] writeBuffer;
+
+                writeLength = Math.min(src.length - offset, mWriteBuffer.length);
+                if (offset == 0) {
+                    writeBuffer = src;
+                } else {
+                    // bulkTransfer does not support offsets, make a copy.
+                    System.arraycopy(src, offset, mWriteBuffer, 0, writeLength);
+                    writeBuffer = mWriteBuffer;
+                }
+
+                amtWritten = mConnection.bulkTransfer(mWriteEndpoint,
+                        writeBuffer, writeLength, timeoutMillis);
+            }
+
+            if (amtWritten <= 0) {
+                throw new IOException("Error writing " + writeLength
+                        + " bytes at offset " + offset + " length="
+                        + src.length);
+            }
+
+            offset += amtWritten;
+        }
+        return offset;
+    }
+
+    @Override
+    public void setParameters(int baudRate, int dataBits, int stopBits,
+            int parity) throws IOException {
+        if ((mBaudRate == baudRate) && (mDataBits == dataBits)
+                && (mStopBits == stopBits) && (mParity == parity)) {
+            // Make sure no action is performed if there is nothing to change
+            return;
+        }
+
+        byte[] lineRequestData = new byte[7];
+
+        lineRequestData[0] = (byte) (baudRate & 0xff);
+        lineRequestData[1] = (byte) ((baudRate >> 8) & 0xff);
+        lineRequestData[2] = (byte) ((baudRate >> 16) & 0xff);
+        lineRequestData[3] = (byte) ((baudRate >> 24) & 0xff);
+
+        switch (stopBits) {
+        case STOPBITS_1:
+            lineRequestData[4] = 0;
+            break;
+
+        case STOPBITS_1_5:
+            lineRequestData[4] = 1;
+            break;
+
+        case STOPBITS_2:
+            lineRequestData[4] = 2;
+            break;
+
+        default:
+            throw new IllegalArgumentException("Unknown stopBits value: " + stopBits);
+        }
+
+        switch (parity) {
+        case PARITY_NONE:
+            lineRequestData[5] = 0;
+            break;
+
+        case PARITY_ODD:
+            lineRequestData[5] = 1;
+            break;
+
+        case PARITY_EVEN:
+            lineRequestData[5] = 2;
+            break;
+
+        case PARITY_MARK:
+            lineRequestData[5] = 3;
+            break;
+
+        case PARITY_SPACE:
+            lineRequestData[5] = 4;
+            break;
+
+        default:
+            throw new IllegalArgumentException("Unknown parity value: " + parity);
+        }
+
+        lineRequestData[6] = (byte) dataBits;
+
+        ctrlOut(SET_LINE_REQUEST, 0, 0, lineRequestData);
+
+        resetDevice();
+
+        mBaudRate = baudRate;
+        mDataBits = dataBits;
+        mStopBits = stopBits;
+        mParity = parity;
+    }
+
+    @Override
+    public boolean getCD() throws IOException {
+        return testStatusFlag(STATUS_FLAG_CD);
+    }
+
+    @Override
+    public boolean getCTS() throws IOException {
+        return testStatusFlag(STATUS_FLAG_CTS);
+    }
+
+    @Override
+    public boolean getDSR() throws IOException {
+        return testStatusFlag(STATUS_FLAG_DSR);
+    }
+
+    @Override
+    public boolean getDTR() throws IOException {
+        return ((mControlLinesValue & CONTROL_DTR) == CONTROL_DTR);
+    }
+
+    @Override
+    public void setDTR(boolean value) throws IOException {
+        int newControlLinesValue;
+        if (value) {
+            newControlLinesValue = mControlLinesValue | CONTROL_DTR;
+        } else {
+            newControlLinesValue = mControlLinesValue & ~CONTROL_DTR;
+        }
+        setControlLines(newControlLinesValue);
+    }
+
+    @Override
+    public boolean getRI() throws IOException {
+        return testStatusFlag(STATUS_FLAG_RI);
+    }
+
+    @Override
+    public boolean getRTS() throws IOException {
+        return ((mControlLinesValue & CONTROL_RTS) == CONTROL_RTS);
+    }
+
+    @Override
+    public void setRTS(boolean value) throws IOException {
+        int newControlLinesValue;
+        if (value) {
+            newControlLinesValue = mControlLinesValue | CONTROL_RTS;
+        } else {
+            newControlLinesValue = mControlLinesValue & ~CONTROL_RTS;
+        }
+        setControlLines(newControlLinesValue);
+    }
+
+    @Override
+    public boolean purgeHwBuffers(boolean purgeReadBuffers, boolean purgeWriteBuffers) throws IOException {
+        if (purgeReadBuffers) {
+            vendorOut(FLUSH_RX_REQUEST, 0, null);
+        }
+
+        if (purgeWriteBuffers) {
+            vendorOut(FLUSH_TX_REQUEST, 0, null);
+        }
+
+        return true;
+    }
+
+    public static Map<Integer, int[]> getSupportedDevices() {
+        final Map<Integer, int[]> supportedDevices = new LinkedHashMap<Integer, int[]>();
+        supportedDevices.put(Integer.valueOf(UsbId.VENDOR_PROLIFIC),
+                new int[] { UsbId.PROLIFIC_PL2303, });
+        return supportedDevices;
+    }
+}
+

--- a/android/src/com/hoho/android/usbserial/driver/UsbId.java
+++ b/android/src/com/hoho/android/usbserial/driver/UsbId.java
@@ -1,0 +1,88 @@
+/* Copyright 2012 Google Inc.
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301,
+ * USA.
+ *
+ * Project home page: http://code.google.com/p/usb-serial-for-android/
+ */
+package com.hoho.android.usbserial.driver;
+
+/**
+ * Registry of USB vendor/product ID constants.
+ *
+ * Culled from various sources; see
+ * <a href="http://www.linux-usb.org/usb.ids">usb.ids</a> for one listing.
+ *
+ * @author mike wakerly (opensource@hoho.com)
+ */
+public final class UsbId {
+
+    public static final int VENDOR_FTDI = 0x0403;
+    public static final int FTDI_FT232R = 0x6001;
+    public static final int FTDI_FT231X = 0x6015;
+
+    public static final int VENDOR_PX4    = 0x26AC;
+    public static final int DEVICE_PX4FMU = 0x11;
+
+    public static final int VENDOR_ATMEL = 0x03EB;
+    public static final int ATMEL_LUFA_CDC_DEMO_APP = 0x2044;
+
+    public static final int VENDOR_ARDUINO = 0x2341;
+    public static final int ARDUINO_UNO = 0x0001;
+    public static final int ARDUINO_MEGA_2560 = 0x0010;
+    public static final int ARDUINO_SERIAL_ADAPTER = 0x003b;
+    public static final int ARDUINO_MEGA_ADK = 0x003f;
+    public static final int ARDUINO_MEGA_2560_R3 = 0x0042;
+    public static final int ARDUINO_UNO_R3 = 0x0043;
+    public static final int ARDUINO_MEGA_ADK_R3 = 0x0044;
+    public static final int ARDUINO_SERIAL_ADAPTER_R3 = 0x0044;
+    public static final int ARDUINO_LEONARDO = 0x8036;
+
+    public static final int VENDOR_VAN_OOIJEN_TECH = 0x16c0;
+    public static final int VAN_OOIJEN_TECH_TEENSYDUINO_SERIAL = 0x0483;
+
+    public static final int VENDOR_LEAFLABS = 0x1eaf;
+    public static final int LEAFLABS_MAPLE = 0x0004;
+    
+    public static final int VENDOR_SILAB = 0x10c4;
+    public static final int SILAB_CP2102 = 0xea60;
+
+    public static final int VENDOR_PROLIFIC = 0x067b;
+    public static final int PROLIFIC_PL2303 = 0x2303;
+
+    public static final int VENDOR_UBLOX = 0x1546;
+    public static final int DEVICE_UBLOX_5 = 0x01a5;
+    public static final int DEVICE_UBLOX_6 = 0x01a6;
+    public static final int DEVICE_UBLOX_7 = 0x01a7;
+    public static final int DEVICE_UBLOX_8 = 0x01a8;
+
+    public static final int VENDOR_OPENPILOT = 0x20A0;
+    public static final int DEVICE_REVOLUTION = 0x415E;
+    public static final int DEVICE_OPLINK = 0x415C;
+    public static final int DEVICE_SPARKY2 = 0x41D0;
+    public static final int DEVICE_CC3D = 0x415D;
+
+    public static final int VENDOR_ARDUPILOT_CHIBIOS1 = 0x0483;
+    public static final int VENDOR_ARDUPILOT_CHIBIOS2 = 0x1209;
+    public static final int DEVICE_ARDUPILOT_CHIBIOS =  0x5740;
+
+    public static final int VENDOR_DRAGONLINK = 0x1FC9;
+    public static final int DEVICE_DRAGONLINK = 0x0083;
+
+    private UsbId() {
+        throw new IllegalAccessError("Non-instantiable class.");
+    }
+
+}

--- a/android/src/com/hoho/android/usbserial/driver/UsbSerialDriver.java
+++ b/android/src/com/hoho/android/usbserial/driver/UsbSerialDriver.java
@@ -1,0 +1,238 @@
+/* Copyright 2011 Google Inc.
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301,
+ * USA.
+ *
+ * Project home page: http://code.google.com/p/usb-serial-for-android/
+ */
+
+package com.hoho.android.usbserial.driver;
+
+import java.io.IOException;
+
+import android.hardware.usb.UsbDevice;
+import android.hardware.usb.UsbDeviceConnection;
+
+/**
+ * Driver interface for a USB serial device.
+ *
+ * @author mike wakerly (opensource@hoho.com)
+ */
+public interface UsbSerialDriver {
+
+    /** 5 data bits. */
+    public static final int DATABITS_5 = 5;
+
+    /** 6 data bits. */
+    public static final int DATABITS_6 = 6;
+
+    /** 7 data bits. */
+    public static final int DATABITS_7 = 7;
+
+    /** 8 data bits. */
+    public static final int DATABITS_8 = 8;
+
+    /** No flow control. */
+    public static final int FLOWCONTROL_NONE = 0;
+
+    /** RTS/CTS input flow control. */
+    public static final int FLOWCONTROL_RTSCTS_IN = 1;
+
+    /** RTS/CTS output flow control. */
+    public static final int FLOWCONTROL_RTSCTS_OUT = 2;
+
+    /** XON/XOFF input flow control. */
+    public static final int FLOWCONTROL_XONXOFF_IN = 4;
+
+    /** XON/XOFF output flow control. */
+    public static final int FLOWCONTROL_XONXOFF_OUT = 8;
+
+    /** No parity. */
+    public static final int PARITY_NONE = 0;
+
+    /** Odd parity. */
+    public static final int PARITY_ODD = 1;
+
+    /** Even parity. */
+    public static final int PARITY_EVEN = 2;
+
+    /** Mark parity. */
+    public static final int PARITY_MARK = 3;
+
+    /** Space parity. */
+    public static final int PARITY_SPACE = 4;
+
+    /** 1 stop bit. */
+    public static final int STOPBITS_1 = 1;
+
+    /** 1.5 stop bits. */
+    public static final int STOPBITS_1_5 = 3;
+
+    /** 2 stop bits. */
+    public static final int STOPBITS_2 = 2;
+
+    public static final int permissionStatusSuccess =           0;
+    public static final int permissionStatusDenied =            1;
+    public static final int permissionStatusRequested =         2;
+    public static final int permissionStatusRequestRequired =   3;
+    public static final int permissionStatusOpen =              4;
+    public int permissionStatus();
+    public void setPermissionStatus(int permissionStatus);
+
+    public void setConnection(UsbDeviceConnection connection);
+
+    /**
+     * Returns the currently-bound USB device.
+     *
+     * @return the device
+     */
+    public UsbDevice getDevice();
+
+
+    /**
+     * Returns the currently-bound USB device.
+     *
+     * @return the device
+     */
+    public UsbDeviceConnection getDeviceConnection();
+
+    /**
+     * Opens and initializes the device as a USB serial device. Upon success,
+     * caller must ensure that {@link #close()} is eventually called.
+     *
+     * @throws IOException on error opening or initializing the device.
+     */
+    public void open() throws IOException;
+
+    /**
+     * Closes the serial device.
+     *
+     * @throws IOException on error closing the device.
+     */
+    public void close() throws IOException;
+
+    /**
+     * Reads as many bytes as possible into the destination buffer.
+     *
+     * @param dest the destination byte buffer
+     * @param timeoutMillis the timeout for reading
+     * @return the actual number of bytes read
+     * @throws IOException if an error occurred during reading
+     */
+    public int read(final byte[] dest, final int timeoutMillis) throws IOException;
+
+    /**
+     * Writes as many bytes as possible from the source buffer.
+     *
+     * @param src the source byte buffer
+     * @param timeoutMillis the timeout for writing
+     * @return the actual number of bytes written
+     * @throws IOException if an error occurred during writing
+     */
+    public int write(final byte[] src, final int timeoutMillis) throws IOException;
+
+    /**
+     * Sets various serial port parameters.
+     *
+     * @param baudRate baud rate as an integer, for example {@code 115200}.
+     * @param dataBits one of {@link #DATABITS_5}, {@link #DATABITS_6},
+     *            {@link #DATABITS_7}, or {@link #DATABITS_8}.
+     * @param stopBits one of {@link #STOPBITS_1}, {@link #STOPBITS_1_5}, or
+     *            {@link #STOPBITS_2}.
+     * @param parity one of {@link #PARITY_NONE}, {@link #PARITY_ODD},
+     *            {@link #PARITY_EVEN}, {@link #PARITY_MARK}, or
+     *            {@link #PARITY_SPACE}.
+     * @throws IOException on error setting the port parameters
+     */
+    public void setParameters(
+            int baudRate, int dataBits, int stopBits, int parity) throws IOException;
+
+    /**
+     * Gets the CD (Carrier Detect) bit from the underlying UART.
+     *
+     * @return the current state, or {@code false} if not supported.
+     * @throws IOException if an error occurred during reading
+     */
+    public boolean getCD() throws IOException;
+
+    /**
+     * Gets the CTS (Clear To Send) bit from the underlying UART.
+     *
+     * @return the current state, or {@code false} if not supported.
+     * @throws IOException if an error occurred during reading
+     */
+    public boolean getCTS() throws IOException;
+
+    /**
+     * Gets the DSR (Data Set Ready) bit from the underlying UART.
+     *
+     * @return the current state, or {@code false} if not supported.
+     * @throws IOException if an error occurred during reading
+     */
+    public boolean getDSR() throws IOException;
+
+    /**
+     * Gets the DTR (Data Terminal Ready) bit from the underlying UART.
+     *
+     * @return the current state, or {@code false} if not supported.
+     * @throws IOException if an error occurred during reading
+     */
+    public boolean getDTR() throws IOException;
+
+    /**
+     * Sets the DTR (Data Terminal Ready) bit on the underlying UART, if
+     * supported.
+     *
+     * @param value the value to set
+     * @throws IOException if an error occurred during writing
+     */
+    public void setDTR(boolean value) throws IOException;
+
+    /**
+     * Gets the RI (Ring Indicator) bit from the underlying UART.
+     *
+     * @return the current state, or {@code false} if not supported.
+     * @throws IOException if an error occurred during reading
+     */
+    public boolean getRI() throws IOException;
+
+    /**
+     * Gets the RTS (Request To Send) bit from the underlying UART.
+     *
+     * @return the current state, or {@code false} if not supported.
+     * @throws IOException if an error occurred during reading
+     */
+    public boolean getRTS() throws IOException;
+
+    /**
+     * Sets the RTS (Request To Send) bit on the underlying UART, if
+     * supported.
+     *
+     * @param value the value to set
+     * @throws IOException if an error occurred during writing
+     */
+    public void setRTS(boolean value) throws IOException;
+
+    /**
+     * Flush non-transmitted output data and / or non-read input data
+     * @param flushRX {@code true} to flush non-transmitted output data
+     * @param flushTX {@code true} to flush non-read input data
+     * @return {@code true} if the operation was successful, or
+     * {@code false} if the operation is not supported by the driver or device
+     * @throws IOException if an error occurred during flush
+     */
+    public boolean purgeHwBuffers(boolean flushRX, boolean flushTX) throws IOException;
+
+}

--- a/android/src/com/hoho/android/usbserial/driver/UsbSerialProber.java
+++ b/android/src/com/hoho/android/usbserial/driver/UsbSerialProber.java
@@ -1,0 +1,224 @@
+/* Copyright 2011 Google Inc.
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301,
+ * USA.
+ *
+ * Project home page: http://code.google.com/p/usb-serial-for-android/
+ */
+
+// IMPORTANT NOTE:
+//  This source has been modified from the original such that testIfSupported only tests for a vendor id
+//  match. If that matches it allows all product ids through. This provides for better match on unknown boards.
+
+package com.hoho.android.usbserial.driver;
+
+import android.hardware.usb.UsbDevice;
+import android.hardware.usb.UsbDeviceConnection;
+import android.hardware.usb.UsbManager;
+import android.util.Log;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * Helper class which finds compatible {@link UsbDevice}s and creates
+ * {@link UsbSerialDriver} instances.
+ *
+ * <p/>
+ * You don't need a Prober to use the rest of the library: it is perfectly
+ * acceptable to instantiate driver instances manually. The Prober simply
+ * provides convenience functions.
+ *
+ * <p/>
+ * For most drivers, the corresponding {@link #probe(UsbManager, UsbDevice)}
+ * method will either return an empty list (device unknown / unsupported) or a
+ * singleton list. However, multi-port drivers may return multiple instances.
+ *
+ * @author mike wakerly (opensource@hoho.com)
+ */
+public enum UsbSerialProber {
+
+    // TODO(mikey): Too much boilerplate.
+
+    /**
+     * Prober for {@link FtdiSerialDriver}.
+     *
+     * @see FtdiSerialDriver
+     */
+    FTDI_SERIAL {
+        @Override
+        public List<UsbSerialDriver> probe(final UsbManager manager, final UsbDevice usbDevice) {
+            if (!testIfSupported(usbDevice, FtdiSerialDriver.getSupportedDevices())) {
+                return Collections.emptyList();
+            }
+            final UsbSerialDriver driver = new FtdiSerialDriver(usbDevice);
+            return Collections.singletonList(driver);
+        }
+    },
+
+    CDC_ACM_SERIAL {
+        @Override
+        public List<UsbSerialDriver> probe(UsbManager manager, UsbDevice usbDevice) {
+            if (!testIfSupported(usbDevice, CdcAcmSerialDriver.getSupportedDevices())) {
+               return Collections.emptyList();
+            }
+            final UsbSerialDriver driver = new CdcAcmSerialDriver(usbDevice);
+            return Collections.singletonList(driver);
+        }
+    },
+
+    SILAB_SERIAL {
+        @Override
+        public List<UsbSerialDriver> probe(final UsbManager manager, final UsbDevice usbDevice) {
+            if (!testIfSupported(usbDevice, Cp2102SerialDriver.getSupportedDevices())) {
+                return Collections.emptyList();
+            }
+            final UsbSerialDriver driver = new Cp2102SerialDriver(usbDevice);
+            return Collections.singletonList(driver);
+        }
+    },
+
+    PROLIFIC_SERIAL {
+        @Override
+        public List<UsbSerialDriver> probe(final UsbManager manager, final UsbDevice usbDevice) {
+            if (!testIfSupported(usbDevice, ProlificSerialDriver.getSupportedDevices())) {
+                return Collections.emptyList();
+            }
+            final UsbSerialDriver driver = new ProlificSerialDriver(usbDevice);
+            return Collections.singletonList(driver);
+        }
+    };
+
+    /**
+     * Tests the supplied {@link UsbDevice} for compatibility with this enum
+     * member, returning one or more driver instances if compatible.
+     *
+     * @param manager the {@link UsbManager} to use
+     * @param usbDevice the raw {@link UsbDevice} to use
+     * @return zero or more {@link UsbSerialDriver}, depending on compatibility
+     *         (never {@code null}).
+     */
+    protected abstract List<UsbSerialDriver> probe(final UsbManager manager, final UsbDevice usbDevice);
+
+    /**
+     * Creates and returns a new {@link UsbSerialDriver} instance for the first
+     * compatible {@link UsbDevice} found on the bus.  If none are found,
+     * returns {@code null}.
+     *
+     * <p/>
+     * The order of devices is undefined, therefore if there are multiple
+     * devices on the bus, the chosen device may not be predictable (clients
+     * should use {@link #findAllDevices(UsbManager)} instead).
+     *
+     * @param usbManager the {@link UsbManager} to use.
+     * @return the first available {@link UsbSerialDriver}, or {@code null} if
+     *         none are available.
+     */
+    public static UsbSerialDriver findFirstDevice(final UsbManager usbManager) {
+        for (final UsbDevice usbDevice : usbManager.getDeviceList().values()) {
+            for (final UsbSerialProber prober : values()) {
+                final List<UsbSerialDriver> probedDevices = prober.probe(usbManager, usbDevice);
+                if (!probedDevices.isEmpty()) {
+                    return probedDevices.get(0);
+                }
+            }
+        }
+        return null;
+    }
+
+    /**
+     * Creates a new {@link UsbSerialDriver} instance for all compatible
+     * {@link UsbDevice}s found on the bus. If no compatible devices are found,
+     * the list will be empty.
+     *
+     * @param usbManager
+     * @return
+     */
+    public static List<UsbSerialDriver> findAllDevices(final UsbManager usbManager) {
+        final List<UsbSerialDriver> result = new ArrayList<UsbSerialDriver>();
+        //Log.i("QGC_UsbSerialProber", "Looking for USB devices");
+        // For each UsbDevice, call probe() for each prober.
+        for (final UsbDevice usbDevice : usbManager.getDeviceList().values()) {
+            //Log.i("QGC_UsbSerialProber", "Probing device: " + usbDevice.getDeviceName() + " mid: " + usbDevice.getVendorId() + " pid: " + usbDevice.getDeviceId());
+            result.addAll(probeSingleDevice(usbManager, usbDevice));
+        }
+        return result;
+    }
+
+    /**
+     * Special method for testing a specific device for driver support,
+     * returning any compatible driver(s).
+     *
+     * <p/>
+     * Clients should ordinarily use {@link #findAllDevices(UsbManager)}, which
+     * operates against the entire bus of devices. This method is useful when
+     * testing against only a single target is desired.
+     *
+     * @param usbManager the {@link UsbManager} to use.
+     * @param usbDevice the device to test against.
+     * @return a list containing zero or more {@link UsbSerialDriver} instances.
+     */
+    public static List<UsbSerialDriver> probeSingleDevice(final UsbManager usbManager,
+            UsbDevice usbDevice)
+    {
+        final List<UsbSerialDriver> result = new ArrayList<UsbSerialDriver>();
+        for (final UsbSerialProber prober : values()) {
+            final List<UsbSerialDriver> probedDevices = prober.probe(usbManager, usbDevice);
+            result.addAll(probedDevices);
+        }
+        return result;
+    }
+
+    /**
+     * Deprecated; Use {@link #findFirstDevice(UsbManager)}.
+     *
+     * @param usbManager
+     * @return
+     */
+    @Deprecated
+    public static UsbSerialDriver acquire(final UsbManager usbManager) {
+        return findFirstDevice(usbManager);
+    }
+
+    /**
+     * Deprecated; use {@link #probeSingleDevice(UsbManager, UsbDevice)}.
+     *
+     * @param usbManager
+     * @param usbDevice
+     * @return
+     */
+    @Deprecated
+    public static UsbSerialDriver acquire(final UsbManager usbManager, final UsbDevice usbDevice) {
+        final List<UsbSerialDriver> probedDevices = probeSingleDevice(usbManager, usbDevice);
+        if (!probedDevices.isEmpty()) {
+            return probedDevices.get(0);
+        }
+        return null;
+    }
+
+    /**
+     * Returns {@code true} if the given device is found in the driver's
+     * vendor/product map.
+     *
+     * @param usbDevice the device to test
+     * @param supportedDevices map of vendor IDs to product ID(s)
+     * @return {@code true} if supported
+     */
+    private static boolean testIfSupported(final UsbDevice usbDevice, final Map<Integer, int[]> supportedDevices) {
+        return supportedDevices.containsKey(usbDevice.getVendorId());
+    }
+}

--- a/android/src/com/hoho/android/usbserial/driver/UsbSerialRuntimeException.java
+++ b/android/src/com/hoho/android/usbserial/driver/UsbSerialRuntimeException.java
@@ -1,0 +1,46 @@
+/*
+ * Copyright 2011 Google Inc.
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301,
+ * USA.
+ */
+
+package com.hoho.android.usbserial.driver;
+
+/**
+ * Generic unchecked exception for the usbserial package.
+ *
+ * @author mike wakerly (opensource@hoho.com)
+ */
+@SuppressWarnings("serial")
+public class UsbSerialRuntimeException extends RuntimeException {
+
+    public UsbSerialRuntimeException() {
+        super();
+    }
+
+    public UsbSerialRuntimeException(String detailMessage, Throwable throwable) {
+        super(detailMessage, throwable);
+    }
+
+    public UsbSerialRuntimeException(String detailMessage) {
+        super(detailMessage);
+    }
+
+    public UsbSerialRuntimeException(Throwable throwable) {
+        super(throwable);
+    }
+
+}

--- a/android/src/org/mavlink/qgroundcontrol/QGCActivity.java
+++ b/android/src/org/mavlink/qgroundcontrol/QGCActivity.java
@@ -62,6 +62,7 @@ import android.bluetooth.BluetoothDevice;
 import android.os.storage.StorageManager;
 import android.os.storage.StorageVolume;
 
+import com.hoho.android.usbserial.driver.*;
 import org.qtproject.qt.android.bindings.QtActivity;
 import org.qtproject.qt.android.bindings.QtApplication;
 
@@ -69,6 +70,10 @@ public class QGCActivity extends QtActivity
 {
     public  static int                                  BAD_DEVICE_ID = 0;
     private static QGCActivity                          _instance = null;
+    private static UsbManager                           _usbManager = null;
+    private static List<UsbSerialDriver>                _drivers;
+    private static HashMap<Integer, UsbIoManager>       m_ioManager;
+    private static HashMap<Integer, Long>               _userDataHashByDeviceId;
     private static final String                         TAG = "QGC_QGCActivity";
     private static PowerManager.WakeLock                _wakeLock;
     private static final String                         ACTION_USB_PERMISSION = "org.mavlink.qgroundcontrol.action.USB_PERMISSION";
@@ -79,19 +84,85 @@ public class QGCActivity extends QtActivity
 
     private final static ExecutorService m_Executor = Executors.newSingleThreadExecutor();
 
+    private final static UsbIoManager.Listener m_Listener =
+            new UsbIoManager.Listener()
+            {
+                @Override
+                public void onRunError(Exception eA, long userData)
+                {
+                    Log.e(TAG, "onRunError Exception");
+                    nativeDeviceException(userData, eA.getMessage());
+                }
+
+                @Override
+                public void onNewData(final byte[] dataA, long userData)
+                {
+                    nativeDeviceNewData(userData, dataA);
+                }
+            };
+
+    private static UsbSerialDriver _findDriverByDeviceId(int deviceId) {
+        for (UsbSerialDriver driver: _drivers) {
+            if (driver.getDevice().getDeviceId() == deviceId) {
+                return driver;
+            }
+        }
+        return null;
+    }
+
+    private static UsbSerialDriver _findDriverByDeviceName(String deviceName) {
+        for (UsbSerialDriver driver: _drivers) {
+            if (driver.getDevice().getDeviceName().equals(deviceName)) {
+                return driver;
+            }
+        }
+        return null;
+    }
+
     private final static BroadcastReceiver _usbReceiver = new BroadcastReceiver() {
             public void onReceive(Context context, Intent intent) {
                 String action = intent.getAction();
                 Log.i(TAG, "BroadcastReceiver USB action " + action);
 
-                try {
-                    // FIXME-QT6 - This is not working
-                    //nativeUpdateAvailableJoysticks();
-                } catch(Exception e) {
-                    Log.e(TAG, "Exception nativeUpdateAvailableJoysticks()");
+                if (ACTION_USB_PERMISSION.equals(action)) {
+                    synchronized (_instance) {
+                        UsbDevice device = (UsbDevice)intent.getParcelableExtra(UsbManager.EXTRA_DEVICE);
+                        if (device != null) {
+                            UsbSerialDriver driver = _findDriverByDeviceId(device.getDeviceId());
+
+                            if (intent.getBooleanExtra(UsbManager.EXTRA_PERMISSION_GRANTED, false)) {
+                                qgcLogDebug("Permission granted to " + device.getDeviceName());
+                                driver.setPermissionStatus(UsbSerialDriver.permissionStatusSuccess);
+                            } else {
+                                qgcLogDebug("Permission denied for " + device.getDeviceName());
+                                driver.setPermissionStatus(UsbSerialDriver.permissionStatusDenied);
+                            }
+                        }
+                    }
+                } else if (UsbManager.ACTION_USB_DEVICE_DETACHED.equals(action)) {
+                    UsbDevice device = (UsbDevice)intent.getParcelableExtra(UsbManager.EXTRA_DEVICE);
+                    if (device != null) {
+                        if (_userDataHashByDeviceId.containsKey(device.getDeviceId())) {
+                            nativeDeviceHasDisconnected(_userDataHashByDeviceId.get(device.getDeviceId()));
+                        }
+                    }
                 }
+
+
+                // FIXME-QT6: Not ye converted to Qt6
+                //try {
+                //    nativeUpdateAvailableJoysticks();
+                //} catch(Exception e) {
+                //    Log.e(TAG, "Exception nativeUpdateAvailableJoysticks()");
+                //}
             }
         };
+
+    // Native C++ functions which connect back to QSerialPort code
+    private static native void nativeDeviceHasDisconnected(long userData);
+    private static native void nativeDeviceException(long userData, String messageA);
+    private static native void nativeDeviceNewData(long userData, byte[] dataA);
+    private static native void nativeUpdateAvailableJoysticks();
 
     // Native C++ functions called to log output
     public static native void qgcLogDebug(String message);
@@ -102,7 +173,10 @@ public class QGCActivity extends QtActivity
     // QGCActivity singleton
     public QGCActivity()
     {
-        _instance = this;
+        _instance =                 this;
+        _drivers =                  new ArrayList<UsbSerialDriver>();
+        _userDataHashByDeviceId =   new HashMap<Integer, Long>();
+        m_ioManager =               new HashMap<Integer, UsbIoManager>();
     }
 
     @Override
@@ -119,12 +193,28 @@ public class QGCActivity extends QtActivity
         }
         _instance.getWindow().addFlags(WindowManager.LayoutParams.FLAG_KEEP_SCREEN_ON);
 
+        _usbManager = (UsbManager)_instance.getSystemService(Context.USB_SERVICE);
+
+        // Register for USB Detach and USB Permission intent
+        IntentFilter filter = new IntentFilter();
+        filter.addAction(UsbManager.ACTION_USB_DEVICE_ATTACHED);
+        filter.addAction(UsbManager.ACTION_USB_DEVICE_DETACHED);
+        filter.addAction(ACTION_USB_PERMISSION);
+        filter.addAction(BluetoothDevice.ACTION_ACL_CONNECTED);
+        filter.addAction(BluetoothDevice.ACTION_ACL_DISCONNECTED);
+        _instance.registerReceiver(_instance._usbReceiver, filter);
+
+        // Create intent for usb permission request
+        _usbPermissionIntent = PendingIntent.getBroadcast(_instance, 0, new Intent(ACTION_USB_PERMISSION), 0);
+
         // Workaround for QTBUG-73138
-        if (_wifiMulticastLock == null) {
-            WifiManager wifi = (WifiManager) _instance.getSystemService(Context.WIFI_SERVICE);
-            _wifiMulticastLock = wifi.createMulticastLock("QGroundControl");
-            _wifiMulticastLock.setReferenceCounted(true);
-        }
+        if (_wifiMulticastLock == null)
+                {
+                    WifiManager wifi = (WifiManager) _instance.getSystemService(Context.WIFI_SERVICE);
+                    _wifiMulticastLock = wifi.createMulticastLock("QGroundControl");
+                    _wifiMulticastLock.setReferenceCounted(true);
+                }
+
         _wifiMulticastLock.acquire();
         Log.d(TAG, "Multicast lock: " + _wifiMulticastLock.toString());
     }
@@ -148,6 +238,424 @@ public class QGCActivity extends QtActivity
 
     public void onInit(int status) {
     }
+
+    /// Incrementally updates the list of drivers connected to the device
+    private static void updateCurrentDrivers()
+    {
+        List<UsbSerialDriver> currentDrivers = UsbSerialProber.findAllDevices(_usbManager);
+
+        // Remove stale drivers
+        for (int i=_drivers.size()-1; i>=0; i--) {
+            boolean found = false;
+            for (UsbSerialDriver currentDriver: currentDrivers) {
+                if (_drivers.get(i).getDevice().getDeviceId() == currentDriver.getDevice().getDeviceId()) {
+                    found = true;
+                    break;
+                }
+            }
+
+            if (!found) {
+                qgcLogDebug("Remove stale driver " + _drivers.get(i).getDevice().getDeviceName());
+                _drivers.remove(i);
+            }
+        }
+
+        // Add new drivers
+        for (int i=0; i<currentDrivers.size(); i++) {
+            boolean found = false;
+            for (int j=0; j<_drivers.size(); j++) {
+                if (currentDrivers.get(i).getDevice().getDeviceId() == _drivers.get(j).getDevice().getDeviceId()) {
+                    found = true;
+                    break;
+                }
+            }
+
+            if (!found) {
+                UsbSerialDriver newDriver =     currentDrivers.get(i);
+                UsbDevice       device =        newDriver.getDevice();
+                String          deviceName =    device.getDeviceName();
+
+                _drivers.add(newDriver);
+                qgcLogDebug("Adding new driver " + deviceName);
+
+                // Request permission if needed
+                if (_usbManager.hasPermission(device)) {
+                    qgcLogDebug("Already have permission to use device " + deviceName);
+                    newDriver.setPermissionStatus(UsbSerialDriver.permissionStatusSuccess);
+                } else {
+                    qgcLogDebug("Requesting permission to use device " + deviceName);
+                    newDriver.setPermissionStatus(UsbSerialDriver.permissionStatusRequested);
+                    _usbManager.requestPermission(device, _usbPermissionIntent);
+                }
+            }
+        }
+    }
+
+    /// Returns array of device info for each unopened device.
+    /// @return Device info format DeviceName:Company:ProductId:VendorId
+    public static String[] availableDevicesInfo()
+    {
+        updateCurrentDrivers();
+
+        if (_drivers.size() <= 0) {
+            return null;
+        }
+
+        List<String> deviceInfoList = new ArrayList<String>();
+
+        for (int i=0; i<_drivers.size(); i++) {
+            String          deviceInfo;
+            UsbSerialDriver driver = _drivers.get(i);
+
+            if (driver.permissionStatus() != UsbSerialDriver.permissionStatusSuccess) {
+                continue;
+            }
+
+            UsbDevice device = driver.getDevice();
+
+            deviceInfo = device.getDeviceName() + ":";
+
+            if (driver instanceof FtdiSerialDriver) {
+                deviceInfo = deviceInfo + "FTDI:";
+            } else if (driver instanceof CdcAcmSerialDriver) {
+                deviceInfo = deviceInfo + "Cdc Acm:";
+            } else if (driver instanceof Cp2102SerialDriver) {
+                deviceInfo = deviceInfo + "Cp2102:";
+            } else if (driver instanceof ProlificSerialDriver) {
+                deviceInfo = deviceInfo + "Prolific:";
+            } else {
+                deviceInfo = deviceInfo + "Unknown:";
+            }
+
+            deviceInfo = deviceInfo + Integer.toString(device.getProductId()) + ":";
+            deviceInfo = deviceInfo + Integer.toString(device.getVendorId()) + ":";
+
+            deviceInfoList.add(deviceInfo);
+        }
+
+        String[] rgDeviceInfo = new String[deviceInfoList.size()];
+        for (int i=0; i<deviceInfoList.size(); i++) {
+            rgDeviceInfo[i] = deviceInfoList.get(i);
+        }
+
+        return rgDeviceInfo;
+    }
+
+    /// Open the specified device
+    ///     @param userData Data to associate with device and pass back through to native calls.
+    /// @return Device id
+    public static int open(Context parentContext, String deviceName, long userData)
+    {
+        int deviceId = BAD_DEVICE_ID;
+
+        m_context = parentContext;
+
+        UsbSerialDriver driver = _findDriverByDeviceName(deviceName);
+        if (driver == null) {
+            qgcLogWarning("Attempt to open unknown device " + deviceName);
+            return BAD_DEVICE_ID;
+        }
+
+        if (driver.permissionStatus() != UsbSerialDriver.permissionStatusSuccess) {
+            qgcLogWarning("Attempt to open device with incorrect permission status " + deviceName + " " + driver.permissionStatus());
+            return BAD_DEVICE_ID;
+        }
+
+        UsbDevice device = driver.getDevice();
+        deviceId = device.getDeviceId();
+
+        try {
+            driver.setConnection(_usbManager.openDevice(device));
+            driver.open();
+            driver.setPermissionStatus(UsbSerialDriver.permissionStatusOpen);
+
+            _userDataHashByDeviceId.put(deviceId, userData);
+
+            UsbIoManager ioManager = new UsbIoManager(driver, m_Listener, userData);
+            m_ioManager.put(deviceId, ioManager);
+            m_Executor.submit(ioManager);
+
+            qgcLogDebug("Port open successful");
+        } catch(IOException exA) {
+            driver.setPermissionStatus(UsbSerialDriver.permissionStatusRequestRequired);
+            _userDataHashByDeviceId.remove(deviceId);
+
+            if(m_ioManager.get(deviceId) != null) {
+                m_ioManager.get(deviceId).stop();
+                m_ioManager.remove(deviceId);
+            }
+            qgcLogWarning("Port open exception: " + exA.getMessage());
+            return BAD_DEVICE_ID;
+        }
+
+        return deviceId;
+    }
+
+    public static void startIoManager(int idA)
+    {
+        if (m_ioManager.get(idA) != null)
+            return;
+
+        UsbSerialDriver driverL = _findDriverByDeviceId(idA);
+
+        if (driverL == null)
+            return;
+
+        UsbIoManager managerL = new UsbIoManager(driverL, m_Listener, _userDataHashByDeviceId.get(idA));
+        m_ioManager.put(idA, managerL);
+        m_Executor.submit(managerL);
+    }
+
+    public static void stopIoManager(int idA)
+    {
+        if(m_ioManager.get(idA) == null)
+            return;
+
+        m_ioManager.get(idA).stop();
+        m_ioManager.remove(idA);
+    }
+
+    ///////////////////////////////////////////////////////////////////////////////////////////////////////
+    //
+    //  Sets the parameters on an open port.
+    //
+    //  Args:   idA - ID number from the open command
+    //          baudRateA - Decimal value of the baud rate.  I.E. 9600, 57600, 115200, etc.
+    //          dataBitsA - number of data bits.  Valid numbers are 5, 6, 7, 8
+    //          stopBitsA - number of stop bits.  Valid numbers are 1, 2
+    //          parityA - No Parity=0, Odd Parity=1, Even Parity=2
+    //
+    //  Returns:  T/F Success/Failure
+    //
+    ////////////////////////////////////////////////////////////////////////////////////////////////////////
+    public static boolean setParameters(int idA, int baudRateA, int dataBitsA, int stopBitsA, int parityA)
+    {
+        UsbSerialDriver driverL = _findDriverByDeviceId(idA);
+
+        if (driverL == null)
+            return false;
+
+        try
+        {
+            driverL.setParameters(baudRateA, dataBitsA, stopBitsA, parityA);
+            return true;
+        }
+        catch(IOException eA)
+        {
+            return false;
+        }
+    }
+
+
+
+    ////////////////////////////////////////////////////////////////////////////////////////////////////////
+    //
+    //  Close the device.
+    //
+    //  Args:  idA - ID number from the open command
+    //
+    //  Returns:  T/F Success/Failure
+    //
+    ////////////////////////////////////////////////////////////////////////////////////////////////////////
+    public static boolean close(int idA)
+    {
+        UsbSerialDriver driverL = _findDriverByDeviceId(idA);
+
+        if (driverL == null)
+            return false;
+
+        try
+        {
+            stopIoManager(idA);
+            _userDataHashByDeviceId.remove(idA);
+            driverL.setPermissionStatus(UsbSerialDriver.permissionStatusRequestRequired);
+            driverL.close();
+
+            return true;
+        }
+        catch(IOException eA)
+        {
+            return false;
+        }
+    }
+
+
+
+    //////////////////////////////////////////////////////////////////////////////////////////////////////
+    //
+    //  Write data to the device.
+    //
+    //  Args:   idA - ID number from the open command
+    //          sourceA - byte array of data to write
+    //          timeoutMsecA - amount of time in milliseconds to wait for the write to occur
+    //
+    //  Returns:  number of bytes written
+    //
+    /////////////////////////////////////////////////////////////////////////////////////////////////////
+    public static int write(int idA, byte[] sourceA, int timeoutMSecA)
+    {
+        UsbSerialDriver driverL = _findDriverByDeviceId(idA);
+
+        if (driverL == null)
+            return 0;
+
+        try
+        {
+            return driverL.write(sourceA, timeoutMSecA);
+        }
+        catch(IOException eA)
+        {
+            return 0;
+        }
+        /*
+        UsbIoManager managerL = m_ioManager.get(idA);
+
+        if(managerL != null)
+        {
+            managerL.writeAsync(sourceA);
+            return sourceA.length;
+        }
+        else
+            return 0;
+        */
+    }
+
+    public static boolean isDeviceNameValid(String nameA)
+    {
+        for (UsbSerialDriver driver: _drivers) {
+            if (driver.getDevice().getDeviceName() == nameA)
+                return true;
+        }
+
+        return false;
+    }
+
+    public static boolean isDeviceNameOpen(String nameA)
+    {
+        for (UsbSerialDriver driverL: _drivers) {
+            if (nameA.equals(driverL.getDevice().getDeviceName()) && driverL.permissionStatus() == UsbSerialDriver.permissionStatusOpen) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+
+
+    /////////////////////////////////////////////////////////////////////////////////////////////////////
+    //
+    //  Set the Data Terminal Ready flag on the device
+    //
+    //  Args:   idA - ID number from the open command
+    //          onA - on=T, off=F
+    //
+    //  Returns:  T/F Success/Failure
+    //
+    ////////////////////////////////////////////////////////////////////////////////////////////////////
+    public static boolean setDataTerminalReady(int idA, boolean onA)
+    {
+        try
+        {
+            UsbSerialDriver driverL = _findDriverByDeviceId(idA);
+
+            if (driverL == null)
+                return false;
+
+            driverL.setDTR(onA);
+            return true;
+        }
+        catch(IOException eA)
+        {
+            return false;
+        }
+    }
+
+
+
+    ////////////////////////////////////////////////////////////////////////////////////////////
+    //
+    //  Set the Request to Send flag
+    //
+    //  Args:   idA - ID number from the open command
+    //          onA - on=T, off=F
+    //
+    //  Returns:  T/F Success/Failure
+    //
+    ////////////////////////////////////////////////////////////////////////////////////////////
+    public static boolean setRequestToSend(int idA, boolean onA)
+    {
+        try
+        {
+            UsbSerialDriver driverL = _findDriverByDeviceId(idA);
+
+            if (driverL == null)
+                return false;
+
+            driverL.setRTS(onA);
+            return true;
+        }
+        catch(IOException eA)
+        {
+            return false;
+        }
+    }
+
+
+
+    ///////////////////////////////////////////////////////////////////////////////////////////////
+    //
+    //  Purge the hardware buffers based on the input and output flags
+    //
+    //  Args:   idA - ID number from the open command
+    //          inputA - input buffer purge.  purge=T
+    //          outputA - output buffer purge.  purge=T
+    //
+    //  Returns:  T/F Success/Failure
+    //
+    ///////////////////////////////////////////////////////////////////////////////////////////////
+    public static boolean purgeBuffers(int idA, boolean inputA, boolean outputA)
+    {
+        try
+        {
+            UsbSerialDriver driverL = _findDriverByDeviceId(idA);
+
+            if (driverL == null)
+                return false;
+
+            return driverL.purgeHwBuffers(inputA, outputA);
+        }
+        catch(IOException eA)
+        {
+            return false;
+        }
+    }
+
+
+
+    //////////////////////////////////////////////////////////////////////////////////////////
+    //
+    //  Get the native device handle (file descriptor)
+    //
+    //  Args:   idA - ID number from the open command
+    //
+    //  Returns:  device handle
+    //
+    ///////////////////////////////////////////////////////////////////////////////////////////
+    public static int getDeviceHandle(int idA)
+    {
+        UsbSerialDriver driverL = _findDriverByDeviceId(idA);
+
+        if (driverL == null)
+            return -1;
+
+        UsbDeviceConnection connectL = driverL.getDeviceConnection();
+        if (connectL == null)
+            return -1;
+        else
+            return connectL.getFileDescriptor();
+    }
+
 
     public static String getSDCardPath() {
         StorageManager storageManager = (StorageManager)_instance.getSystemService(Activity.STORAGE_SERVICE);

--- a/android/src/org/mavlink/qgroundcontrol/UsbIoManager.java
+++ b/android/src/org/mavlink/qgroundcontrol/UsbIoManager.java
@@ -1,0 +1,218 @@
+package org.mavlink.qgroundcontrol;
+
+/* Copyright 2011 Google Inc.
+*
+* This library is free software; you can redistribute it and/or
+* modify it under the terms of the GNU Lesser General Public
+* License as published by the Free Software Foundation; either
+* version 2.1 of the License, or (at your option) any later version.
+*
+* This library is distributed in the hope that it will be useful,
+* but WITHOUT ANY WARRANTY; without even the implied warranty of
+* MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+* Lesser General Public License for more details.
+*
+* You should have received a copy of the GNU Lesser General Public
+* License along with this library; if not, write to the Free Software
+* Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301,
+* USA.
+*
+* Project home page: http://code.google.com/p/usb-serial-for-android/
+*/
+
+
+import com.hoho.android.usbserial.driver.*;
+
+import java.io.IOException;
+import java.nio.ByteBuffer;
+import android.util.Log;
+
+/**
+* Utility class which services a {@link UsbSerialDriver} in its {@link #run()}
+* method.
+*
+* Original author mike wakerly (opensource@hoho.com)
+* Modified by Mike Goza
+*/
+public class UsbIoManager implements Runnable {
+    private static final int READ_WAIT_MILLIS = 100;
+    private static final int BUFSIZ = 4096;
+    private static final String TAG = "QGC_UsbIoManager";
+
+    private final UsbSerialDriver mDriver;
+    private long mUserData;
+    private final ByteBuffer mReadBuffer = ByteBuffer.allocate(BUFSIZ);
+    private final ByteBuffer mWriteBuffer = ByteBuffer.allocate(BUFSIZ);
+
+    private enum State
+    {
+        STOPPED,
+        RUNNING,
+        STOPPING
+    }
+
+    // Synchronized by 'this'
+    private State mState = State.STOPPED;
+
+    // Synchronized by 'this'
+    private Listener mListener;
+
+    public interface Listener
+    {
+        /**
+         * Called when new incoming data is available.
+         */
+        public void onNewData(byte[] data, long userData);
+
+        /**
+         * Called when {@link SerialInputOutputManager#run()} aborts due to an
+         * error.
+         */
+        public void onRunError(Exception e, long userData);
+    }
+
+
+
+    /**
+     * Creates a new instance with no listener.
+     */
+    public UsbIoManager(UsbSerialDriver driver)
+    {
+        this(driver, null, 0);
+        Log.i(TAG, "Instance created");
+    }
+
+
+
+    /**
+     * Creates a new instance with the provided listener.
+     */
+    public UsbIoManager(UsbSerialDriver driver, Listener listener, long userData)
+    {
+        mDriver = driver;
+        mListener = listener;
+        mUserData = userData;
+    }
+
+
+
+    public synchronized void setListener(Listener listener)
+    {
+        mListener = listener;
+    }
+
+
+
+    public synchronized Listener getListener()
+    {
+        return mListener;
+    }
+
+
+
+    public void writeAsync(byte[] data)
+    {
+        synchronized (mWriteBuffer)
+        {
+            mWriteBuffer.put(data);
+        }
+    }
+
+
+
+    public synchronized void stop()
+    {
+        if (getState() == State.RUNNING)
+        {
+            mState = State.STOPPING;
+            mUserData = 0;
+        }
+    }
+
+
+
+    private synchronized State getState()
+    {
+        return mState;
+    }
+
+
+
+    /**
+     * Continuously services the read and write buffers until {@link #stop()} is
+     * called, or until a driver exception is raised.
+     */
+    @Override
+    public void run()
+    {
+        synchronized (this)
+        {
+            if (mState != State.STOPPED)
+                throw new IllegalStateException("Already running.");
+
+            mState = State.RUNNING;
+        }
+
+        try
+        {
+            while (true)
+            {
+                if (mState != State.RUNNING)
+                    break;
+
+                step();
+            }
+        }
+        catch (Exception e)
+        {
+            final Listener listener = getListener();
+            if (listener != null)
+                listener.onRunError(e, mUserData);
+        }
+        finally
+        {
+            synchronized (this)
+            {
+                mState = State.STOPPED;
+            }
+        }
+    }
+
+
+
+    private void step() throws IOException
+    {
+        // Handle incoming data.
+        int len = mDriver.read(mReadBuffer.array(), READ_WAIT_MILLIS);
+
+        if (len > 0)
+        {
+            final Listener listener = getListener();
+            if (listener != null)
+            {
+                final byte[] data = new byte[len];
+                mReadBuffer.get(data, 0, len);
+                listener.onNewData(data, mUserData);
+            }
+            mReadBuffer.clear();
+        }
+/*
+        // Handle outgoing data.
+        byte[] outBuff = null;
+        synchronized (mWriteBuffer)
+        {
+            if (mWriteBuffer.position() > 0)
+            {
+                len = mWriteBuffer.position();
+                outBuff = new byte[len];
+                mWriteBuffer.rewind();
+                mWriteBuffer.get(outBuff, 0, len);
+                mWriteBuffer.clear();
+            }
+        }
+        if (outBuff != null)
+            mDriver.write(outBuff, READ_WAIT_MILLIS);
+*/
+    }
+}
+

--- a/libs/qtandroidserialport/src/qserialport.cpp
+++ b/libs/qtandroidserialport/src/qserialport.cpp
@@ -1367,7 +1367,7 @@ void QSerialPort::setError(QSerialPort::SerialPortError serialPortError, const Q
     else
         setErrorString(errorString);
 
-    emit error(serialPortError);
+    emit errorOccurred(serialPortError);
 }
 
 void QSerialPort::setNativeMethods(void)

--- a/libs/qtandroidserialport/src/qserialport.h
+++ b/libs/qtandroidserialport/src/qserialport.h
@@ -258,7 +258,7 @@ Q_SIGNALS:
     void dataErrorPolicyChanged(QSerialPort::DataErrorPolicy policy);
     void dataTerminalReadyChanged(bool set);
     void requestToSendChanged(bool set);
-    void error(QSerialPort::SerialPortError serialPortError);
+    void errorOccurred(QSerialPort::SerialPortError serialPortError);
     void settingsRestoredOnCloseChanged(bool restore);
 
 protected:

--- a/libs/qtandroidserialport/src/qserialport_android.cpp
+++ b/libs/qtandroidserialport/src/qserialport_android.cpp
@@ -43,8 +43,9 @@
 #include <QtCore/qelapsedtimer.h>
 #include <QtCore/qsocketnotifier.h>
 #include <QtCore/qmap.h>
-#include <QtAndroidExtras/QtAndroidExtras>
-#include <QtAndroidExtras/QAndroidJniObject>
+#include <QJniObject>
+#include <QJniEnvironment>
+#include <QCoreApplication>
 
 #include "qserialport_android_p.h"
 
@@ -54,14 +55,20 @@ QT_BEGIN_NAMESPACE
 
 #define BAD_PORT 0
 
-static const char kJniClassName[] {"org/mavlink/qgroundcontrol/QGCActivity"};
+static const char kJniQGCActivityClassName[] {"org/mavlink/qgroundcontrol/QGCActivity"};
 
 static void jniDeviceHasDisconnected(JNIEnv *envA, jobject thizA, jlong userDataA)
 {
     Q_UNUSED(envA);
     Q_UNUSED(thizA);
-    if (userDataA != 0)
-        (reinterpret_cast<QSerialPortPrivate*>(userDataA))->q_ptr->close();
+
+    qCDebug(AndroidSerialPortLog) << "Device disconnected";
+
+    if (userDataA != 0) {
+        auto serialPort = reinterpret_cast<QSerialPortPrivate*>(userDataA);
+        qCDebug(AndroidSerialPortLog) << "Device disconnected" << serialPort->systemLocation.toLatin1().data();
+        serialPort->q_ptr->close();
+    }
 }
 
 static void jniDeviceNewData(JNIEnv *envA, jobject thizA, jlong userDataA, jbyteArray dataA)
@@ -116,7 +123,7 @@ static void jniLogWarning(JNIEnv *envA, jobject thizA, jstring messageA)
 
 void cleanJavaException()
 {
-    QAndroidJniEnvironment env;
+    QJniEnvironment env;
     if (env->ExceptionCheck()) {
         env->ExceptionDescribe();
         env->ExceptionClear();
@@ -150,15 +157,15 @@ void QSerialPortPrivate::setNativeMethods(void)
         {"qgcLogWarning",               "(Ljava/lang/String;)V",    reinterpret_cast<void *>(jniLogWarning)}
     };
 
-    QAndroidJniEnvironment jniEnv;
+    QJniEnvironment jniEnv;
     if (jniEnv->ExceptionCheck()) {
         jniEnv->ExceptionDescribe();
         jniEnv->ExceptionClear();
     }
 
-    jclass objectClass = jniEnv->FindClass(kJniClassName);
+    jclass objectClass = jniEnv->FindClass(kJniQGCActivityClassName);
     if(!objectClass) {
-        qWarning() << "Couldn't find class:" << kJniClassName;
+        qWarning() << "Couldn't find class:" << kJniQGCActivityClassName;
         return;
     }
 
@@ -181,13 +188,13 @@ bool QSerialPortPrivate::open(QIODevice::OpenMode mode)
     rwMode = mode;
     qCDebug(AndroidSerialPortLog) << "Opening" << systemLocation.toLatin1().data();
 
-    QAndroidJniObject jnameL = QAndroidJniObject::fromString(systemLocation);
+    QJniObject jnameL = QJniObject::fromString(systemLocation);
     cleanJavaException();
-    deviceId = QAndroidJniObject::callStaticMethod<jint>(
-        kJniClassName,
+    deviceId = QJniObject::callStaticMethod<jint>(
+        kJniQGCActivityClassName,
         "open",
         "(Landroid/content/Context;Ljava/lang/String;J)I",
-        QtAndroid::androidActivity().object(),
+        QNativeInterface::QAndroidApplication::context(),
         jnameL.object<jstring>(),
         reinterpret_cast<jlong>(this));
     cleanJavaException();
@@ -214,8 +221,8 @@ void QSerialPortPrivate::close()
 
     qCDebug(AndroidSerialPortLog) << "Closing" << systemLocation.toLatin1().data();
     cleanJavaException();
-    jboolean resultL = QAndroidJniObject::callStaticMethod<jboolean>(
-        kJniClassName,
+    jboolean resultL = QJniObject::callStaticMethod<jboolean>(
+        kJniQGCActivityClassName,
         "close",
         "(I)Z",
         deviceId);
@@ -239,8 +246,8 @@ bool QSerialPortPrivate::setParameters(int baudRateA, int dataBitsA, int stopBit
     }
 
     cleanJavaException();
-    jboolean resultL = QAndroidJniObject::callStaticMethod<jboolean>(
-        kJniClassName,
+    jboolean resultL = QJniObject::callStaticMethod<jboolean>(
+        kJniQGCActivityClassName,
         "setParameters",
         "(IIIII)Z",
         deviceId,
@@ -269,8 +276,8 @@ void QSerialPortPrivate::stopReadThread()
     if (isReadStopped)
         return;
     cleanJavaException();
-    QAndroidJniObject::callStaticMethod<void>(
-        kJniClassName,
+    QJniObject::callStaticMethod<void>(
+        kJniQGCActivityClassName,
         "stopIoManager",
         "(I)V",
         deviceId);
@@ -285,8 +292,8 @@ void QSerialPortPrivate::startReadThread()
     if (!isReadStopped)
         return;
     cleanJavaException();
-    QAndroidJniObject::callStaticMethod<void>(
-        kJniClassName,
+    QJniObject::callStaticMethod<void>(
+        kJniQGCActivityClassName,
         "startIoManager",
         "(I)V",
         deviceId);
@@ -307,8 +314,8 @@ bool QSerialPortPrivate::setDataTerminalReady(bool set)
         return false;
     }
     cleanJavaException();
-    bool res = QAndroidJniObject::callStaticMethod<jboolean>(
-        kJniClassName,
+    bool res = QJniObject::callStaticMethod<jboolean>(
+        kJniQGCActivityClassName,
         "setDataTerminalReady",
         "(IZ)Z",
         deviceId,
@@ -325,8 +332,8 @@ bool QSerialPortPrivate::setRequestToSend(bool set)
         return false;
     }
     cleanJavaException();
-    bool res = QAndroidJniObject::callStaticMethod<jboolean>(
-        kJniClassName,
+    bool res = QJniObject::callStaticMethod<jboolean>(
+        kJniQGCActivityClassName,
         "setRequestToSend",
         "(IZ)Z",
         deviceId,
@@ -363,8 +370,8 @@ bool QSerialPortPrivate::clear(QSerialPort::Directions directions)
     }
 
     cleanJavaException();
-    bool res = QAndroidJniObject::callStaticMethod<jboolean>(
-        kJniClassName,
+    bool res = QJniObject::callStaticMethod<jboolean>(
+        kJniQGCActivityClassName,
         "purgeBuffers",
         "(IZZ)Z",
         deviceId,
@@ -615,13 +622,13 @@ qint64 QSerialPortPrivate::writeToPort(const char *data, qint64 maxSize)
         return 0;
     }
 
-    QAndroidJniEnvironment jniEnv;
+    QJniEnvironment jniEnv;
     jbyteArray jarrayL = jniEnv->NewByteArray(static_cast<jsize>(maxSize));
     jniEnv->SetByteArrayRegion(jarrayL, 0, static_cast<jsize>(maxSize), (jbyte*)data);
     if (jniEnv->ExceptionCheck())
         jniEnv->ExceptionClear();
-    int resultL = QAndroidJniObject::callStaticMethod<jint>(
-        kJniClassName,
+    int resultL = QJniObject::callStaticMethod<jint>(
+        kJniQGCActivityClassName,
         "write",
         "(I[BI)I",
         deviceId,

--- a/libs/qtandroidserialport/src/qserialportinfo.cpp
+++ b/libs/qtandroidserialport/src/qserialportinfo.cpp
@@ -118,7 +118,7 @@ QSerialPortInfo::QSerialPortInfo(const QSerialPortInfoPrivate &dd)
 QSerialPortInfo::~QSerialPortInfo()
 {
 }
-
+#if 0
 /*! \fn void QSerialPortInfo::swap(QSerialPortInfo &other)
 
     Swaps QSerialPortInfo \a other with this QSerialPortInfo. This operation is
@@ -137,7 +137,7 @@ QSerialPortInfo& QSerialPortInfo::operator=(const QSerialPortInfo &other)
     QSerialPortInfo(other).swap(*this);
     return *this;
 }
-
+#endif
 /*!
     Returns the name of the serial port.
 

--- a/libs/qtandroidserialport/src/qserialportinfo.h
+++ b/libs/qtandroidserialport/src/qserialportinfo.h
@@ -84,7 +84,7 @@ private:
     QSerialPortInfo(const QSerialPortInfoPrivate &dd);
     friend QList<QSerialPortInfo> availablePortsByUdev(bool &ok);
     friend QList<QSerialPortInfo> availablePortsBySysfs(bool &ok);
-    friend QList<QSerialPortInfo> availablePortsByFiltersOfDevices(bool &ok);
+    friend QList<QSerialPortInfo> availablePortsByFiltersOfDevices();
 };
 
 inline bool QSerialPortInfo::isNull() const

--- a/libs/qtandroidserialport/src/qserialportinfo_android.cpp
+++ b/libs/qtandroidserialport/src/qserialportinfo_android.cpp
@@ -39,8 +39,8 @@
 
 #include <QtCore/qscopedpointer.h>
 #include <QtCore/qstringlist.h>
-#include <QtAndroidExtras/QtAndroidExtras>
-#include <QtAndroidExtras/QAndroidJniObject>
+#include <QJniObject>
+#include <QJniEnvironment>
 
 #include <android/log.h>
 
@@ -50,31 +50,21 @@ static const char V_TAG[] {"QGC_QSerialPortInfo"};
 
 extern void cleanJavaException();
 
-static int gErrorCount = 0;
-
-QList<QSerialPortInfo> availablePortsByFiltersOfDevices(bool &ok)
+QList<QSerialPortInfo> availablePortsByFiltersOfDevices()
 {
     QList<QSerialPortInfo> serialPortInfoList;
 
-    //__android_log_print(ANDROID_LOG_INFO, V_TAG, "Collecting device list");
-    QAndroidJniObject resultL = QAndroidJniObject::callStaticObjectMethod(
+    QJniObject resultL = QJniObject::callStaticObjectMethod(
         V_jniClassName,
         "availableDevicesInfo",
         "()[Ljava/lang/String;");
     
     if (!resultL.isValid()) {
-        //-- If 5 consecutive errors, ignore it.
-        if(gErrorCount < 5) {
-            gErrorCount++;
-            __android_log_print(ANDROID_LOG_ERROR, V_TAG, "Error from availableDevicesInfo");
-        }
-        ok = false;
+        // No devices found
         return serialPortInfoList;
-    } else {
-        gErrorCount = 0;
     }
 
-    QAndroidJniEnvironment envL;
+    QJniEnvironment envL;
     jobjectArray objArrayL = resultL.object<jobjectArray>();
     int countL = envL->GetArrayLength(objArrayL);
 
@@ -83,7 +73,7 @@ QList<QSerialPortInfo> availablePortsByFiltersOfDevices(bool &ok)
         QSerialPortInfoPrivate priv;
         jstring stringL = (jstring)(envL->GetObjectArrayElement(objArrayL, iL));
         const char *rawStringL = envL->GetStringUTFChars(stringL, 0);
-        //__android_log_print(ANDROID_LOG_INFO, V_TAG, "Adding device: %s", rawStringL);
+        __android_log_print(ANDROID_LOG_INFO, V_TAG, "Adding device: %s", rawStringL);
         QStringList strListL = QString::fromUtf8(rawStringL).split(QStringLiteral(":"));
         envL->ReleaseStringUTFChars(stringL, rawStringL);
         envL->DeleteLocalRef(stringL);
@@ -104,20 +94,17 @@ QList<QSerialPortInfo> availablePortsByFiltersOfDevices(bool &ok)
 
 QList<QSerialPortInfo> availablePortsBySysfs()
 {
-    bool ok;
-    return availablePortsByFiltersOfDevices(ok);
+    return availablePortsByFiltersOfDevices();
 }
 
 QList<QSerialPortInfo> availablePortsByUdev()
 {
-    bool ok;
-    return availablePortsByFiltersOfDevices(ok);
+    return availablePortsByFiltersOfDevices();
 }
 
 QList<QSerialPortInfo> QSerialPortInfo::availablePorts()
 {
-    bool ok;
-    return availablePortsByFiltersOfDevices(ok);
+    return availablePortsByFiltersOfDevices();
 }
 
 QList<qint32> QSerialPortInfo::standardBaudRates()
@@ -127,9 +114,9 @@ QList<qint32> QSerialPortInfo::standardBaudRates()
 
 bool QSerialPortInfo::isBusy() const
 {
-    QAndroidJniObject jstrL = QAndroidJniObject::fromString(d_ptr->portName);
+    QJniObject jstrL = QJniObject::fromString(d_ptr->portName);
     cleanJavaException();
-    jboolean resultL = QAndroidJniObject::callStaticMethod<jboolean>(
+    jboolean resultL = QJniObject::callStaticMethod<jboolean>(
         V_jniClassName,
         "isDeviceNameOpen",
         "(Ljava/lang/String;)Z",
@@ -140,9 +127,9 @@ bool QSerialPortInfo::isBusy() const
 
 bool QSerialPortInfo::isValid() const
 {
-    QAndroidJniObject jstrL = QAndroidJniObject::fromString(d_ptr->portName);
+    QJniObject jstrL = QJniObject::fromString(d_ptr->portName);
     cleanJavaException();
-    jboolean resultL = QAndroidJniObject::callStaticMethod<jboolean>(
+    jboolean resultL = QJniObject::callStaticMethod<jboolean>(
         V_jniClassName,
         "isDeviceNameValid",
         "(Ljava/lang/String;)Z",

--- a/libs/qtandroidserialport/src/qtandroidserialport.pri
+++ b/libs/qtandroidserialport/src/qtandroidserialport.pri
@@ -1,6 +1,6 @@
 android {
 
-    QT += androidextras core-private
+    QT += core-private
 
     INCLUDEPATH += $$PWD
 

--- a/src/GPS/GPSProvider.h
+++ b/src/GPS/GPSProvider.h
@@ -13,7 +13,11 @@
 #include <QString>
 #include <QThread>
 #include <QByteArray>
+#ifdef __android__
+#include "qserialport.h"
+#else
 #include <QSerialPort>
+#endif
 
 #include <atomic>
 

--- a/src/QmlControls/QGCPopupDialog.qml
+++ b/src/QmlControls/QGCPopupDialog.qml
@@ -185,11 +185,11 @@ Popup {
         // If we only have a Close or Ok button on the dialog don't show them and just let the CloseOnPressOutside handle closing
         if (buttons === Dialog.Close) {
             rejectAllowed = true
-            rejectButton.visible = false
+            //rejectButton.visible = false
             closePolicy = Popup.CloseOnPressOutside
         } else if (buttons === Dialog.Ok) {
             acceptAllowed = true
-            acceptButton.visible = false
+            //acceptButton.visible = false
             closePolicy = Popup.CloseOnPressOutside
         }
 

--- a/src/VehicleSetup/Bootloader.h
+++ b/src/VehicleSetup/Bootloader.h
@@ -11,7 +11,11 @@
 
 #include "FirmwareImage.h"
 
+#ifdef __android__
+#include "qserialport.h"
+#else
 #include <QSerialPort>
+#endif
 
 #include <stdint.h>
 

--- a/src/VehicleSetup/FirmwareUpgradeController.h
+++ b/src/VehicleSetup/FirmwareUpgradeController.h
@@ -20,7 +20,11 @@
 #include <QNetworkReply>
 #include <QPixmap>
 #include <QQuickItem>
+#ifdef __android__
+#include "qserialport.h"
+#else
 #include <QSerialPort>
+#endif
 
 #include <stdint.h>
 

--- a/src/VehicleSetup/PX4FirmwareUpgradeThread.cc
+++ b/src/VehicleSetup/PX4FirmwareUpgradeThread.cc
@@ -19,7 +19,11 @@
 
 #include <QTimer>
 #include <QDebug>
+#ifdef __android__
+#include "qserialport.h"
+#else
 #include <QSerialPort>
+#endif
 
 PX4FirmwareUpgradeThreadWorker::PX4FirmwareUpgradeThreadWorker(PX4FirmwareUpgradeThreadController* controller)
     : _controller(controller)

--- a/src/VehicleSetup/PX4FirmwareUpgradeThread.h
+++ b/src/VehicleSetup/PX4FirmwareUpgradeThread.h
@@ -23,7 +23,11 @@
 #include <QThread>
 #include <QTimer>
 #include <QTime>
+#ifdef __android__
+#include "qserialport.h"
+#else
 #include <QSerialPort>
+#endif
 
 #include <stdint.h>
 

--- a/src/comm/LinkManager.cc
+++ b/src/comm/LinkManager.cc
@@ -547,9 +547,6 @@ void LinkManager::_updateAutoConnectLinks(void)
     if (!_isSerialPortConnected()) {
         portList = QGCSerialPortInfo::availablePorts();
     }
-    else {
-        qDebug() << "Skipping serial port list";
-    }
 #else
     portList = QGCSerialPortInfo::availablePorts();
 #endif

--- a/src/comm/SerialLink.cc
+++ b/src/comm/SerialLink.cc
@@ -177,11 +177,7 @@ bool SerialLink::_hardwareConnect(QSerialPort::SerialPortError& error, QString& 
 
     _port = new QSerialPort(_serialConfig->portName(), this);
 
-#ifdef Q_OS_ANDROID
-    QObject::connect(_port, SIGNAL(&QSerialPort::error), this, SLOT(&SerialLink::linkError));
-#else
     QObject::connect(_port, &QSerialPort::errorOccurred, this, &SerialLink::linkError);
-#endif
     QObject::connect(_port, &QIODevice::readyRead, this, &SerialLink::_readBytes);
 
     // After the bootloader times out, it still can take a second or so for the Pixhawk USB driver to come up and make

--- a/src/comm/SerialLink.h
+++ b/src/comm/SerialLink.h
@@ -14,7 +14,11 @@
 #include <QMutex>
 #include <QString>
 
+#ifdef __android__
+#include "qserialport.h"
+#else
 #include <QSerialPort>
+#endif
 #include <QMetaType>
 #include <QLoggingCategory>
 

--- a/src/main.cc
+++ b/src/main.cc
@@ -19,7 +19,6 @@
 #include <QStringListModel>
 #include <QQuickStyle>
 #include <QQuickWindow>
-#include <QSerialPort>
 
 #include "QGC.h"
 #include "QGCApplication.h"
@@ -89,6 +88,9 @@ int WindowsCrtReportHook(int reportType, char* message, int* returnValue)
 #if defined(QGC_ENABLE_PAIRING)
 #include "PairingManager.h"
 #endif
+#if !defined(NO_SERIAL_LINK)
+#include "qserialport.h"
+#endif
 
 static jobject _class_loader = nullptr;
 static jobject _context = nullptr;
@@ -133,7 +135,7 @@ gst_android_init(JNIEnv* env, jobject context)
 }
 
 //-----------------------------------------------------------------------------
-static const char kJniClassName[] {"org/mavlink/qgroundcontrol/QGCActivity"};
+static const char kJniQGCActivityClassName[] {"org/mavlink/qgroundcontrol/QGCActivity"};
 
 void setNativeMethods(void)
 {
@@ -147,9 +149,9 @@ void setNativeMethods(void)
         jniEnv->ExceptionClear();
     }
 
-    jclass objectClass = jniEnv->FindClass(kJniClassName);
+    jclass objectClass = jniEnv->FindClass(kJniQGCActivityClassName);
     if(!objectClass) {
-        qWarning() << "Couldn't find class:" << kJniClassName;
+        qWarning() << "Couldn't find class:" << kJniQGCActivityClassName;
         return;
     }
 
@@ -172,6 +174,7 @@ jint JNI_OnLoad(JavaVM* vm, void* reserved)
 {
     Q_UNUSED(reserved);
 
+    qDebug() << "JNI_OnLoa QGC called";
     JNIEnv* env;
     if (vm->GetEnv(reinterpret_cast<void**>(&env), JNI_VERSION_1_6) != JNI_OK) {
         return -1;
@@ -183,6 +186,10 @@ jint JNI_OnLoad(JavaVM* vm, void* reserved)
     // Tell the androidmedia plugin about the Java VM
     gst_amc_jni_set_java_vm(vm);
 #endif
+
+ #if !defined(NO_SERIAL_LINK)
+    QSerialPort::setNativeMethods();
+ #endif
 
 #ifndef FIXME_QT6_DISABLE_ANDROID_JOYSTICK
     JoystickAndroid::setNativeMethods();


### PR DESCRIPTION
I had thought that Qt6 had android serial port support built in so I removed the custom support during the upgrade. I was wrong about that and had to put the all the old android serial port code back.

Related to #10887


