### PR TITLE
Use github runner default NDK

### DIFF
--- a/.github/workflows/android_release.yml
+++ b/.github/workflows/android_release.yml
@@ -10,13 +10,11 @@ on:
       - 'v*'
     paths-ignore:
       - 'docs/**'
-      - '.github/workflows/**'
   pull_request:
     branches:
     - '*'
     paths-ignore:
       - 'docs/**'
-      - '.github/workflows/**'
       
 defaults:
   run:
@@ -67,13 +65,6 @@ jobs:
           modules:      qtcharts qtlocation qtpositioning qtspeech qt5compat qtmultimedia qtserialport qtimageformats qtshadertools qtimageformats qtshadertools qtconnectivity
           setup-python: true
 
-      - name: Install Android NDK
-        uses: nttld/setup-ndk@v1
-        id: setup-ndk
-        with:
-          ndk-version: r25b
-          add-to-path: false
-
       - name: Remove Android SDKs to force usage of android-33 only
         run: |
             ${ANDROID_SDK_ROOT}/cmdline-tools/latest/bin/sdkmanager --uninstall "platforms;android-33-ext5"
@@ -123,10 +114,6 @@ jobs:
         working-directory: ${{ runner.temp }}/shadow_build_dir
         env:
           ANDROID_KEYSTORE_PASSWORD: ${{ secrets.ANDROID_KEYSTORE_PASSWORD }}
-          ANDROID_NDK_ROOT: ${{ steps.setup-ndk.outputs.ndk-path }}
-          ANDROID_NDK_HOME: ${{ steps.setup-ndk.outputs.ndk-path }}
-          ANDROID_NDK_LATEST_HOME: ${{ steps.setup-ndk.outputs.ndk-path }}
-          ANDROID_NDK: ${{ steps.setup-ndk.outputs.ndk-path }}
         run:  |
             ls /home/runner/work/_temp/Qt/6.6.1
             qmake -r ${SOURCE_DIR}/qgroundcontrol.pro -spec android-clang CONFIG+=${BUILD_TYPE} CONFIG+=installer ANDROID_ABIS="${{ matrix.eabi }}"

--- a/.github/workflows/linux_debug.yml
+++ b/.github/workflows/linux_debug.yml
@@ -6,13 +6,11 @@ on:
     - 'master'
     paths-ignore:
       - 'docs/**'
-      - '.github/workflows/**'
   pull_request:
     branches:
     - '*'
     paths-ignore:
       - 'docs/**'
-      - '.github/workflows/**'
 
 defaults:
   run:

--- a/.github/workflows/linux_release.yml
+++ b/.github/workflows/linux_release.yml
@@ -9,13 +9,11 @@ on:
       - 'v*'
     paths-ignore:
       - 'docs/**'
-      - '.github/workflows/**'
   pull_request:
     branches:
     - '*'
     paths-ignore:
       - 'docs/**'
-      - '.github/workflows/**'
 
 defaults:
   run:

--- a/.github/workflows/macos_release.yml
+++ b/.github/workflows/macos_release.yml
@@ -9,13 +9,11 @@ on:
       - 'v*'
     paths-ignore:
       - 'docs/**'
-      - '.github/workflows/**'
   pull_request:
     branches:
     - '*'
     paths-ignore:
       - 'docs/**'
-      - '.github/workflows/**'
 
 defaults:
   run:

--- a/.github/workflows/windows_release.yml
+++ b/.github/workflows/windows_release.yml
@@ -9,13 +9,11 @@ on:
       - 'v*'
     paths-ignore:
       - 'docs/**'
-      - '.github/workflows/**'
   pull_request:
     branches:
     - '*'
     paths-ignore:
       - 'docs/**'
-      - '.github/workflows/**'
 
 defaults:
   run:


### PR DESCRIPTION
Also removed paths-ignore for workflows. Previous mechanism installed the NDK manually. This was causes problem in that binaries were not being stripped leading to huge APKs.


