### PR TITLE
PX4 PID Tuning: Major rework to support smaller screens/scrolling

### DIFF
--- a/src/AutoPilotPlugins/PX4/PX4TuningComponent.qml
+++ b/src/AutoPilotPlugins/PX4/PX4TuningComponent.qml
@@ -1,0 +1,53 @@
+/****************************************************************************
+ *
+ * (c) 2009-2020 QGROUNDCONTROL PROJECT <http://www.qgroundcontrol.org>
+ *
+ * QGroundControl is licensed according to the terms in the file
+ * COPYING.md in the root of the source code directory.
+ *
+ ****************************************************************************/
+
+import QtQuick
+import QtQuick.Controls
+import QtQuick.Layouts
+
+import QGroundControl
+import QGroundControl.Controls
+import QGroundControl.FactSystem
+import QGroundControl.ScreenTools
+
+ColumnLayout {
+    id:         root
+    width:      availableWidth
+    spacing:    ScreenTools.defaultFontPixelWidth
+
+    property var model
+
+    property real _availableHeight:  availableHeight
+
+    FactPanelController {
+        id:         controller
+    }
+
+    QGCTabBar {
+        id:                 tabBar
+        Layout.fillWidth:   true
+        width:              parent.width
+
+        Repeater {
+            model: root.model
+            QGCTabButton {
+                text: buttonText
+            }
+        }
+    }
+
+    Loader {
+        id:                loader
+        source:            model.get(tabBar.currentIndex).tuningPage
+        Layout.fillWidth:   true
+
+        property bool useAutoTuning:    true
+        property real availableHeight:  _availableHeight - loader.y
+    }
+}

--- a/src/AutoPilotPlugins/PX4/PX4TuningComponentCopter.qml
+++ b/src/AutoPilotPlugins/PX4/PX4TuningComponentCopter.qml
@@ -22,7 +22,6 @@ SetupPage {
         id: pageComponent
 
         PX4TuningComponentCopterAll {
-            height: availableHeight
         }
     } // Component - pageComponent
 } // SetupPage

--- a/src/AutoPilotPlugins/PX4/PX4TuningComponentCopterAll.qml
+++ b/src/AutoPilotPlugins/PX4/PX4TuningComponentCopterAll.qml
@@ -16,55 +16,23 @@ import QGroundControl.Controls
 import QGroundControl.FactSystem
 import QGroundControl.ScreenTools
 
-Item {
-    width:                            availableWidth
-    property bool _autotuningEnabled: true // used to restore setting when switching between tabs
-
-    FactPanelController {
-        id:         controller
-    }
-
-    QGCTabBar {
-        id:             bar
-        width:          parent.width
-        anchors.top:    parent.top
-        QGCTabButton {
-            text:       qsTr("Rate Controller")
+PX4TuningComponent {
+    model: ListModel {
+        ListElement { 
+            buttonText: qsTr("Rate Controller")
+            tuningPage: "PX4TuningComponentCopterRate.qml"
         }
-        QGCTabButton {
-            text:       qsTr("Attitude Controller")
+        ListElement { 
+            buttonText: qsTr("Attitude Controller")
+            tuningPage: "PX4TuningComponentCopterAttitude.qml"
         }
-        QGCTabButton {
-            text:       qsTr("Velocity Controller")
+        ListElement { 
+            buttonText: qsTr("Velocity Controller")
+            tuningPage: "PX4TuningComponentCopterVelocity.qml"
         }
-        QGCTabButton {
-            text:       qsTr("Position Controller")
-        }
-        onCurrentIndexChanged: {
-            if (typeof loader.item.autotuningEnabled !== "undefined") {
-                _autotuningEnabled = loader.item.autotuningEnabled;
-            }
-        }
-    }
-
-    property var pages:  [
-        "PX4TuningComponentCopterRate.qml",
-        "PX4TuningComponentCopterAttitude.qml",
-        "PX4TuningComponentCopterVelocity.qml",
-        "PX4TuningComponentCopterPosition.qml"
-    ]
-
-    Loader {
-        id:                loader
-        source:            pages[bar.currentIndex]
-        width:             parent.width
-        anchors.top:       bar.bottom
-        anchors.topMargin: ScreenTools.defaultFontPixelWidth
-        anchors.bottom:    parent.bottom
-        onLoaded: {
-            if (typeof loader.item.autotuningEnabled !== "undefined") {
-                loader.item.autotuningEnabled = _autotuningEnabled;
-            }
+        ListElement { 
+            buttonText: qsTr("Position Controller")
+            tuningPage: "PX4TuningComponentCopterPosition.qml"
         }
     }
 }

--- a/src/AutoPilotPlugins/PX4/PX4TuningComponentCopterAttitude.qml
+++ b/src/AutoPilotPlugins/PX4/PX4TuningComponentCopterAttitude.qml
@@ -19,13 +19,10 @@ import QGroundControl.ScreenTools
 import QGroundControl.Vehicle
 
 ColumnLayout {
-    width: availableWidth
-    anchors.fill: parent
-    property alias autotuningEnabled: pidTuning.autotuningEnabled
-
     PIDTuning {
-        width: availableWidth
-        id:    pidTuning
+        id:                 pidTuning
+        Layout.fillWidth:   true
+        availableHeight:    _availableHeight - pidTuning.y
 
         property var roll: QtObject {
             property string name: qsTr("Roll")

--- a/src/AutoPilotPlugins/PX4/PX4TuningComponentCopterPosition.qml
+++ b/src/AutoPilotPlugins/PX4/PX4TuningComponentCopterPosition.qml
@@ -19,9 +19,7 @@ import QGroundControl.ScreenTools
 import QGroundControl.Vehicle
 
 ColumnLayout {
-    width: availableWidth
-    anchors.fill: parent
-    property Fact _mcPosMode:       controller.getParameterFact(-1, "MPC_POS_MODE", false)
+    property Fact _mcPosMode: controller.getParameterFact(-1, "MPC_POS_MODE", false)
 
     GridLayout {
         columns: 2
@@ -38,7 +36,10 @@ ColumnLayout {
     }
 
     PIDTuning {
-        width: availableWidth
+        id:                 pidTuning
+        Layout.fillWidth:   true
+        availableHeight:    _availableHeight - pidTuning.y
+
         property var horizontal: QtObject {
             property string name: qsTr("Horizontal")
             property string plotTitle: qsTr("Horizontal (Y direction, sidewards)")

--- a/src/AutoPilotPlugins/PX4/PX4TuningComponentCopterRate.qml
+++ b/src/AutoPilotPlugins/PX4/PX4TuningComponentCopterRate.qml
@@ -19,19 +19,17 @@ import QGroundControl.ScreenTools
 import QGroundControl.Vehicle
 
 ColumnLayout {
-    width: availableWidth
-    anchors.fill: parent
-    property Fact _airmode:           controller.getParameterFact(-1, "MC_AIRMODE", false)
-    property Fact _thrustModelFactor: controller.getParameterFact(-1, "THR_MDL_FAC", false)
-    property alias autotuningEnabled: pidTuning.autotuningEnabled
+    property real _availableHeight:     availableHeight
+    property Fact _airmode:             controller.getParameterFact(-1, "MC_AIRMODE", false)
+    property Fact _thrustModelFactor:   controller.getParameterFact(-1, "THR_MDL_FAC", false)
 
-    GridLayout {
-        columns: 2
+    RowLayout {
+        spacing: ScreenTools.defaultFontPixelWidth
 
         QGCLabel {
             textFormat:         Text.RichText
-            text:               qsTr("Airmode (disable during tuning) <b><a href=\"https://docs.px4.io/master/en/config_mc/pid_tuning_guide_multicopter.html#airmode-mixer-saturation\">?</a></b>:")
-            onLinkActivated:    Qt.openUrlExternally(link)
+            text:               qsTr("Airmode (disable during tuning) <b><a href=\"https://docs.px4.io/master/en/config_mc/pid_tuning_guide_multicopter.html#airmode-mixer-saturation\">?</a></b>")
+            onLinkActivated:    (link) => Qt.openUrlExternally(link)
             visible:            _airmode
         }
         FactComboBox {
@@ -40,10 +38,15 @@ ColumnLayout {
             visible:            _airmode
         }
 
+        Item {
+            width: 1
+            height: 1
+        }
+
         QGCLabel {
             textFormat:         Text.RichText
-            text:               qsTr("Thrust curve <b><a href=\"https://docs.px4.io/master/en/config_mc/pid_tuning_guide_multicopter.html#thrust-curve\">?</a></b>:")
-            onLinkActivated:    Qt.openUrlExternally(link)
+            text:               qsTr("Thrust curve <b><a href=\"https://docs.px4.io/master/en/config_mc/pid_tuning_guide_multicopter.html#thrust-curve\">?</a></b>")
+            onLinkActivated:    (link) => Qt.openUrlExternally(link)
             visible:            _thrustModelFactor
         }
         FactTextField {
@@ -51,9 +54,18 @@ ColumnLayout {
             visible:            _thrustModelFactor
         }
     }
+
     PIDTuning {
-        width: availableWidth
-        id:    pidTuning
+        id:                 pidTuning
+        Layout.fillWidth:   true
+        availableHeight:    _availableHeight - pidTuning.y
+        title:              qsTr("Rate")
+        tuningMode:         Vehicle.ModeRateAndAttitude
+        unit:               qsTr("deg/s")
+        axis:               [ roll, pitch, yaw ]
+        chartDisplaySec:    3
+        showAutoModeChange: true
+        showAutoTuning:     true
 
         property var roll: QtObject {
             property string name: qsTr("Roll")
@@ -146,13 +158,6 @@ ColumnLayout {
                 }
             }
         }
-        title: "Rate"
-        tuningMode: Vehicle.ModeRateAndAttitude
-        unit: "deg/s"
-        axis: [ roll, pitch, yaw ]
-        chartDisplaySec: 3
-        showAutoModeChange: true
-        showAutoTuning:     true
     }
 }
 

--- a/src/AutoPilotPlugins/PX4/PX4TuningComponentCopterVelocity.qml
+++ b/src/AutoPilotPlugins/PX4/PX4TuningComponentCopterVelocity.qml
@@ -19,9 +19,7 @@ import QGroundControl.ScreenTools
 import QGroundControl.Vehicle
 
 ColumnLayout {
-    width: availableWidth
-    anchors.fill: parent
-    property Fact _mcPosMode:       controller.getParameterFact(-1, "MPC_POS_MODE", false)
+    property Fact _mcPosMode:  controller.getParameterFact(-1, "MPC_POS_MODE", false)
 
     GridLayout {
         columns: 2
@@ -38,7 +36,10 @@ ColumnLayout {
     }
 
     PIDTuning {
-        width: availableWidth
+        id:                 pidTuning
+        Layout.fillWidth:   true
+        availableHeight:    _availableHeight - pidTuning.y
+
         property var horizontal: QtObject {
             property string name: qsTr("Horizontal")
             property string plotTitle: qsTr("Horizontal (Y direction, sidewards)")

--- a/src/AutoPilotPlugins/PX4/PX4TuningComponentPlaneAll.qml
+++ b/src/AutoPilotPlugins/PX4/PX4TuningComponentPlaneAll.qml
@@ -16,35 +16,15 @@ import QGroundControl.Controls
 import QGroundControl.FactSystem
 import QGroundControl.ScreenTools
 
-Item {
-    width: availableWidth
-
-    FactPanelController {
-        id:         controller
-    }
-
-    QGCTabBar {
-        id:             bar
-        width:          parent.width
-        anchors.top:    parent.top
-        QGCTabButton {
-            text:       qsTr("Rate Controller")
+PX4TuningComponent {
+    model: ListModel {
+        ListElement { 
+            buttonText: qsTr("Rate Controller")
+            tuningPage: "PX4TuningComponentPlaneRate.qml" 
         }
-        QGCTabButton {
-            text:       qsTr("Attitude Controller")
+        ListElement { 
+            buttonText: qsTr("Rate Controller")
+            tuningPage: "PX4TuningComponentPlaneAttitude.qml" 
         }
-    }
-
-    property var pages:  [
-        "PX4TuningComponentPlaneRate.qml",
-        "PX4TuningComponentPlaneAttitude.qml",
-    ]
-
-    Loader {
-        source:            pages[bar.currentIndex]
-        width:             parent.width
-        anchors.top:       bar.bottom
-        anchors.topMargin: ScreenTools.defaultFontPixelWidth
-        anchors.bottom:    parent.bottom
     }
 }

--- a/src/AutoPilotPlugins/PX4/PX4TuningComponentPlaneAttitude.qml
+++ b/src/AutoPilotPlugins/PX4/PX4TuningComponentPlaneAttitude.qml
@@ -19,13 +19,10 @@ import QGroundControl.ScreenTools
 import QGroundControl.Vehicle
 
 ColumnLayout {
-    width: availableWidth
-    anchors.fill: parent
-    property alias autotuningEnabled: pidTuning.autotuningEnabled
-
     PIDTuning {
-        width: availableWidth
-        id:    pidTuning
+        id:                 pidTuning
+        Layout.fillWidth:   true
+        availableHeight:    _availableHeight - pidTuning.y
 
         property var roll: QtObject {
             property string name: qsTr("Roll")

--- a/src/AutoPilotPlugins/PX4/PX4TuningComponentPlaneRate.qml
+++ b/src/AutoPilotPlugins/PX4/PX4TuningComponentPlaneRate.qml
@@ -19,16 +19,13 @@ import QGroundControl.ScreenTools
 import QGroundControl.Vehicle
 
 ColumnLayout {
-    width: availableWidth
-    anchors.fill: parent
-    property alias autotuningEnabled: pidTuning.autotuningEnabled
-
     GridLayout {
         columns: 2
     }
     PIDTuning {
-        width: availableWidth
-        id:    pidTuning
+        id:                 pidTuning
+        Layout.fillWidth:   true
+        availableHeight:    _availableHeight - pidTuning.y
 
         property var roll: QtObject {
             property string name: qsTr("Roll")

--- a/src/AutoPilotPlugins/PX4/PX4TuningComponentPlaneTECS.qml
+++ b/src/AutoPilotPlugins/PX4/PX4TuningComponentPlaneTECS.qml
@@ -19,11 +19,11 @@ import QGroundControl.ScreenTools
 import QGroundControl.Vehicle
 
 ColumnLayout {
-    width: availableWidth
-    anchors.fill: parent
-
     PIDTuning {
-        width: availableWidth
+        id:                 pidTuning
+        Layout.fillWidth:   true
+        availableHeight:    _availableHeight - pidTuning.y
+
         property var data: QtObject {
             property string name: qsTr("Altitude & Airspeed")
             property var plot: [

--- a/src/AutoPilotPlugins/PX4/PX4TuningComponentVTOL.qml
+++ b/src/AutoPilotPlugins/PX4/PX4TuningComponentVTOL.qml
@@ -15,46 +15,15 @@ import QGroundControl.Controls
 import QGroundControl.FactSystem
 import QGroundControl.ScreenTools
 
-SetupPage {
-    id:             tuningPage
-    pageComponent:  pageComponent
-
-    Component {
-        id: pageComponent
-
-        Item {
-            width: availableWidth
-            height: availableHeight
-
-            FactPanelController {
-                id:         controller
-            }
-
-            QGCTabBar {
-                id:             bar
-                width:          parent.width
-                anchors.top:    parent.top
-
-                QGCTabButton {
-                    text:       qsTr("Multirotor")
-                }
-                //QGCTabButton {
-                //    text:       qsTr("Fixedwing")
-                //}
-            }
-
-            property var pages:  [
-                "PX4TuningComponentCopterAll.qml",
-                //"PX4TuningComponentPlaneAll.qml"
-            ]
-
-            Loader {
-                source:            pages[bar.currentIndex]
-                width:             parent.width
-                anchors.top:       bar.bottom
-                anchors.topMargin: ScreenTools.defaultFontPixelWidth
-                anchors.bottom:    parent.bottom
-            }
+PX4TuningComponent {
+    model: ListModel {
+        ListElement {
+            buttonText: qsTr("Multirotor")
+            tuningPage: "PX4TuningComponentCopterAll.qml"
         }
-    } // Component - pageComponent
+        //ListElement {
+        //    buttonText: qsTr("Fixed Wing")
+        //    tuningPage: "PX4TuningComponentPlaneAll.qml"
+        //}
+    }
 }

--- a/src/FirmwarePlugin/PX4/PX4Resources.qrc
+++ b/src/FirmwarePlugin/PX4/PX4Resources.qrc
@@ -11,6 +11,7 @@
         <file alias="PX4RadioComponentSummary.qml">../../AutoPilotPlugins/PX4/PX4RadioComponentSummary.qml</file>
         <file alias="PX4SimpleFlightModes.qml">../../AutoPilotPlugins/PX4/PX4SimpleFlightModes.qml</file>
         <file alias="PX4FlightBehaviorCopter.qml">../../AutoPilotPlugins/PX4/PX4FlightBehaviorCopter.qml</file>
+        <file alias="PX4TuningComponent.qml">../../AutoPilotPlugins/PX4/PX4TuningComponent.qml</file>
         <file alias="PX4TuningComponentCopter.qml">../../AutoPilotPlugins/PX4/PX4TuningComponentCopter.qml</file>
         <file alias="PX4TuningComponentCopterAll.qml">../../AutoPilotPlugins/PX4/PX4TuningComponentCopterAll.qml</file>
         <file alias="PX4TuningComponentCopterAttitude.qml">../../AutoPilotPlugins/PX4/PX4TuningComponentCopterAttitude.qml</file>

--- a/src/Vehicle/Autotune.cpp
+++ b/src/Vehicle/Autotune.cpp
@@ -18,9 +18,6 @@ Autotune::Autotune(Vehicle *vehicle) :
     QObject(vehicle)
     , _vehicle(vehicle)
 {
-    connect(_vehicle, &Vehicle::flyingChanged,  this, &Autotune::handleEnabled);
-    connect(_vehicle, &Vehicle::landingChanged, this, &Autotune::handleEnabled);
-
     _pollTimer.setInterval(1000); // 1s for the polling interval
     _pollTimer.setSingleShot(false);
     connect(&_pollTimer, &QTimer::timeout, this, &Autotune::sendMavlinkRequest);
@@ -81,20 +78,6 @@ void Autotune::progressHandler(void* progressHandlerData, int compId, const mavl
         qWarning() << "Ack received for a command different from MAV_CMD_DO_AUTOTUNE_ENABLE ot wrong UI state.";
     }
 }
-
-//-----------------------------------------------------------------------------
-bool Autotune::autotuneEnabled()
-{
-    return _vehicle->flying() || _autotuneInProgress;
-}
-
-
-//-----------------------------------------------------------------------------
-void Autotune::handleEnabled()
-{
-    emit autotuneChanged();
-}
-
 
 //-----------------------------------------------------------------------------
 void Autotune::handleAckStatus(uint8_t ackProgress)

--- a/src/Vehicle/Autotune.h
+++ b/src/Vehicle/Autotune.h
@@ -21,7 +21,6 @@ class Autotune : public QObject
 public:
     explicit Autotune(Vehicle *vehicle);
 
-    Q_PROPERTY(bool      autotuneEnabled      READ autotuneEnabled        NOTIFY autotuneChanged)
     Q_PROPERTY(bool      autotuneInProgress   READ autotuneInProgress     NOTIFY autotuneChanged)
     Q_PROPERTY(float     autotuneProgress     READ autotuneProgress       NOTIFY autotuneChanged)
     Q_PROPERTY(QString   autotuneStatus       READ autotuneStatus         NOTIFY autotuneChanged)
@@ -31,16 +30,16 @@ public:
     static void ackHandler      (void* resultHandlerData,   int compId, const mavlink_command_ack_t& ack, Vehicle::MavCmdResultFailureCode_t failureCode);
     static void progressHandler (void* progressHandlerData, int compId, const mavlink_command_ack_t& ack);
 
-    bool      autotuneEnabled    ();
     bool      autotuneInProgress () { return _autotuneInProgress; }
     float     autotuneProgress   () { return _autotuneProgress; }
     QString   autotuneStatus     () { return _autotuneStatus; }
 
 
 public slots:
-    void handleEnabled ();
     void sendMavlinkRequest();
 
+signals:
+    void autotuneChanged ();
 
 private:
     void handleAckStatus(uint8_t ackProgress);
@@ -48,10 +47,6 @@ private:
     void handleAckError(uint8_t ackError);
     void startTimers();
     void stopTimers();
-
-
-private slots:
-
 
 private:
     Vehicle* _vehicle                {nullptr};
@@ -62,7 +57,4 @@ private:
 
     QTimer   _pollTimer;         // the frequency at which the polling should be performed
 
-
-signals:
-    void autotuneChanged ();
 };


### PR DESCRIPTION
Previously tuning was turned off in mobile. Fixes #10975. It works exactly like it did before except I changed the AutoTune Enabled slider to radio buttons and a few other tweaks to make it more understandable. At first I couldn't figure out what that slider meant. I think the radio buttons make things more clear. The chart now has a minimum size below which it will not go. After that, the page will scroll to show everything. Given the complexity of this page it required major changes to make it resize nicely. So help with testing is appreciated.

Note: I was unable to test Plane and VTOL since I'm stuck with only jmavsim SITL on OSX arm.

![Screenshot 2024-01-18 at 12 07 18](https://github.com/mavlink/qgroundcontrol/assets/5876851/f04d4abd-1714-4321-9c6c-a457fc67b477)



