### PR TITLE
Update Vehicle::guidedModeGotoLocation doc comment

### DIFF
--- a/src/Vehicle/Vehicle.h
+++ b/src/Vehicle/Vehicle.h
@@ -388,7 +388,7 @@ public:
     /// @return Minumum equivalent airspeed.
     Q_INVOKABLE double minimumEquivalentAirspeed();
 
-    /// Command vehicle to move to specified location (altitude is included and relative)
+    /// Command vehicle to move to specified location (altitude is ignored)
     Q_INVOKABLE void guidedModeGotoLocation(const QGeoCoordinate& gotoCoord);
 
     /// Command vehicle to change altitude


### PR DESCRIPTION
Both ArduPilot firmware and PX4 discard the altitude when called by this function:

https://github.com/mavlink/qgroundcontrol/blob/16f59b49208fe840ab511b5726a8e506c18681e7/src/FirmwarePlugin/APM/APMFirmwarePlugin.cc#L848

https://github.com/mavlink/qgroundcontrol/blob/16f59b49208fe840ab511b5726a8e506c18681e7/src/FirmwarePlugin/PX4/PX4FirmwarePlugin.cc#L487

I created the PR with the most obvious and least invasive fix, because for end-user there are still possibilities to change the altitude. If there would be a need to implement the API to call it with altitude, I'd contribute it guided by a maintainer what would be most useful for you