### PR TITLE
Make RC RSSI Indicator show via checkbox

### DIFF
--- a/src/Settings/App.SettingsGroup.json
+++ b/src/Settings/App.SettingsGroup.json
@@ -340,6 +340,13 @@
     "longDesc":  "Ardupilot Support server to forward mavlink to. i.e: support.ardupilot.org:xxxx",
     "type":      "string",
     "default":   "support.ardupilot.org:xxxx"
+    },
+ {
+     "name": "showRcRssiIndicator",
+     "type": "bool",
+     "shortDescription": "Show RC RSSI Indicator",
+     "longDescription": "Enable or disable the RC RSSI Indicator in the Fly View.",
+     "defaultValue": true
 }
 ]
 }

--- a/src/Settings/AppSettings.cc
+++ b/src/Settings/AppSettings.cc
@@ -171,6 +171,7 @@ DECLARE_SETTINGSFACT(AppSettings, firstRunPromptIdsShown)
 DECLARE_SETTINGSFACT(AppSettings, forwardMavlink)
 DECLARE_SETTINGSFACT(AppSettings, forwardMavlinkHostName)
 DECLARE_SETTINGSFACT(AppSettings, forwardMavlinkAPMSupportHostName)
+DECLARE_SETTINGSFACT(AppSettings, showRcRssiIndicator)
 
 DECLARE_SETTINGSFACT_NO_FUNC(AppSettings, indoorPalette)
 {

--- a/src/Settings/AppSettings.h
+++ b/src/Settings/AppSettings.h
@@ -67,6 +67,7 @@ public:
     DEFINE_SETTINGFACT(forwardMavlink)
     DEFINE_SETTINGFACT(forwardMavlinkHostName)
     DEFINE_SETTINGFACT(forwardMavlinkAPMSupportHostName)
+    DEFINE_SETTINGFACT(showRcRssiIndicator)
 
 
     // Although this is a global setting it only affects ArduPilot vehicle since PX4 automatically starts the stream from the vehicle side

--- a/src/ui/preferences/GeneralSettings.qml
+++ b/src/ui/preferences/GeneralSettings.qml
@@ -731,6 +731,12 @@ Rectangle {
                                     visible:    _remoteIDEnable.visible
                                     property Fact _remoteIDEnable: QGroundControl.settingsManager.remoteIDSettings.enable
                                 }
+
+                                 FactCheckBox {
+                                     text:       qsTr("Show RC RSSI Indicator")
+                                     fact:       QGroundControl.settingsManager.appSettings.showRcRssiIndicator
+                                     visible:    true
+                                }
                             }
                         }
 

--- a/src/ui/toolbar/RCRSSIIndicator.qml
+++ b/src/ui/toolbar/RCRSSIIndicator.qml
@@ -24,10 +24,11 @@ Item {
     anchors.top:    parent.top
     anchors.bottom: parent.bottom
 
-    property bool showIndicator: _activeVehicle.supportsRadio && _rcRSSIAvailable
+    property bool showIndicator: _activeVehicle && QGroundControl.settingsManager.appSettings.showRcRssiIndicator.rawValue
 
     property var    _activeVehicle:     QGroundControl.multiVehicleManager.activeVehicle
     property bool   _rcRSSIAvailable:   _activeVehicle ? _activeVehicle.rcRSSI > 0 && _activeVehicle.rcRSSI <= 100 : false
+
 
     Component {
         id: rcRSSIInfo


### PR DESCRIPTION
Adds a checkbox to app settings for turning the RC rssi indicator on and off.