### PR TITLE
Corrected case in MavlinkLogSettings file names

### DIFF
--- a/src/Settings/CMakeLists.txt
+++ b/src/Settings/CMakeLists.txt
@@ -20,8 +20,8 @@ add_library(Settings
 	FlightModeSettings.h
 	FlyViewSettings.cc
 	FlyViewSettings.h
-    MavLinkLogSettings.cc
-    MavLinkLogSettings.h
+    MavlinkLogSettings.cc
+    MavlinkLogSettings.h
 	OfflineMapsSettings.cc
 	OfflineMapsSettings.h
 	PlanViewSettings.cc


### PR DESCRIPTION
The build was failing due to a case mismatch in the filenames MavLinkLogSettings.cc and MavLinkLogSettings.h in CMakeLists.txt. Changed the file names to correct case MavlinkLogSettings.cc and MavlinkLogSettings.h to fix the issue.


