### PR TITLE
fix cmake build: add UTM library

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -270,6 +270,16 @@ if (WIN32)
             ${CMAKE_CURRENT_SOURCE_DIR}/windows/QGroundControl.rc)
 endif()
 
+if(CONFIG_UTM_ADAPTER)
+    list(APPEND QGC_RESOURCES
+            ${CMAKE_CURRENT_SOURCE_DIR}/src/UTMSP/utmsp.qrc
+    )
+else()
+    list(APPEND QGC_RESOURCES
+            ${CMAKE_CURRENT_SOURCE_DIR}/src/UTMSP/dummy/utmsp_dummy.qrc
+    )
+endif()
+
 if(BUILD_TESTING)
     list(APPEND QGC_RESOURCES
             UnitTest.qrc

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -164,6 +164,7 @@ if (${QGC_GST_TAISYNC_ENABLED})
 endif ()
 add_subdirectory(Terrain)
 add_subdirectory(uas)
+add_subdirectory(UTMSP)
 add_subdirectory(Vehicle)
 add_subdirectory(VehicleSetup)
 add_subdirectory(VideoManager)
@@ -203,6 +204,7 @@ target_link_libraries(${PROJECT_NAME}
             Settings
             Terrain
             uas
+            UTMSP
             Vehicle
             VehicleSetup
             VideoManager

--- a/src/UTMSP/CMakeLists.txt
+++ b/src/UTMSP/CMakeLists.txt
@@ -13,7 +13,6 @@ if(CONFIG_UTM_ADAPTER)
             UTMSPServiceController.cpp
             UTMSPVehicle.cpp
             UTMSPManager.cpp
-            utmsp.qrc
             )
 
     add_custom_target(UTMSPQml
@@ -25,7 +24,7 @@ if(CONFIG_UTM_ADAPTER)
 
 else()
     # If CONFIG_UTM_ADAPTER is not set, use utmsp_dummy.qrc
-    message("Dummy is Initialized")
+    message(STATUS "UTMSP: Dummy is Initialized")
 
     add_library(UTMSP
             dummy/utmsp_dummy.qrc


### PR DESCRIPTION
Fixes the error:
qrc:/qml/MainRootWindow.qml:23:1: module "QGroundControl.UTMSP" is not installed

I had to add utmsp_dummy.qrc directly to QGC_RESOURCES, adding it to the UTMSP library wasn't enough.


