### PR TITLE
Fix setting default style

### DIFF
--- a/src/QGCApplication.cc
+++ b/src/QGCApplication.cc
@@ -220,9 +220,6 @@ QGCApplication::QGCApplication(int &argc, char* argv[], bool unitTesting)
             }
             permFile.close();
         }
-
-        // Always set style to default, this way QT_QUICK_CONTROLS_STYLE environment variable doesn't cause random changes in ui
-        QQuickStyle::setStyle("Default");
     }
 #endif
 #endif

--- a/src/main.cc
+++ b/src/main.cc
@@ -345,9 +345,9 @@ int main(int argc, char *argv[])
 #endif
 #endif // QT_DEBUG
 
+    QQuickStyle::setStyle("Basic");
     QGCApplication* app = new QGCApplication(argc, argv, runUnitTests);
     Q_CHECK_PTR(app);
-    QQuickStyle::setStyle("Basic");
     if(app->isErrorState()) {
         app->exec();
         return -1;


### PR DESCRIPTION
Fixes `ERROR: QQuickStyle::setStyle() must be called before loading QML that imports Qt Quick Controls 2.`

QQuickStyle calls QQuickStyleSpec which is a global static, so it can be called before the QApp is made. Usually this error will only happen `_exitWithError` but at least it won't output an irrelevant error anymore.