### PR TITLE
Fix variable name typo in Android config

### DIFF
--- a/android.pri
+++ b/android.pri
@@ -1,7 +1,7 @@
 include($$PWD/libs/qtandroidserialport/src/qtandroidserialport.pri)
 
 ANDROID_MIN_SDK_VERSION = 26
-ANDROID_TARGET_SDK_VERSSION = 33
+ANDROID_TARGET_SDK_VERSION = 33
 
 ANDROID_PACKAGE_SOURCE_DIR          = $$OUT_PWD/ANDROID_PACKAGE_SOURCE_DIR  # Tells Qt location of package files for build
 ANDROID_PACKAGE_QGC_SOURCE_DIR      = $$PWD/android                         # Original location of QGC package files


### PR DESCRIPTION
When building for Android locally, I was getting this error: `Dependency 'androidx.core:core:1.10.1' requires libraries and applications thatdepend on it to compile against version 33 or later of theAndroid APIs.`

Also Qt Creator highlights the variable name after fixing the typo