### PR TITLE
Fix QML method showVehicleSetupTool invokation from c++ 

### DIFF
--- a/src/QGCApplication.cc
+++ b/src/QGCApplication.cc
@@ -809,7 +809,8 @@ QQuickWindow* QGCApplication::mainRootWindow()
 void QGCApplication::showSetupView()
 {
     if(_rootQmlObject()) {
-        QMetaObject::invokeMethod(_rootQmlObject(), "showSetupTool");
+      QVariant arg = "";
+      QMetaObject::invokeMethod(_rootQmlObject(), "showVehicleSetupTool", Q_ARG(QVariant, arg));
     }
 }
 


### PR DESCRIPTION
Fix
Changed QGCApplication method to invoke "showVehicleSetupTool" instead of incorrect "showSetupTool".

The previous code attempted to invoke the "showSetupTool" method within the QGCApplication class. This has been corrected to "showVehicleSetupTool".