### PR TITLE
Fix QML method invocations from C++

### DIFF
--- a/src/AutoPilotPlugins/APM/APMSensorsComponentController.cc
+++ b/src/AutoPilotPlugins/APM/APMSensorsComponentController.cc
@@ -85,12 +85,10 @@ void APMSensorsComponentController::_appendStatusLog(const QString& text)
 {
     Q_ASSERT(_statusLog);
     
-    QVariant returnedValue;
-    QVariant varText = text;
+    QString varText = text;
     QMetaObject::invokeMethod(_statusLog,
                               "append",
-                              Q_RETURN_ARG(QVariant, returnedValue),
-                              Q_ARG(QVariant, varText));
+                              Q_ARG(QString, varText));
 }
 
 void APMSensorsComponentController::_startLogCalibration(void)

--- a/src/AutoPilotPlugins/PX4/SensorsComponentController.cc
+++ b/src/AutoPilotPlugins/PX4/SensorsComponentController.cc
@@ -83,12 +83,10 @@ void SensorsComponentController::_appendStatusLog(const QString& text)
         return;
     }
     
-    QVariant returnedValue;
-    QVariant varText = text;
+    QString varText = text;
     QMetaObject::invokeMethod(_statusLog,
                               "append",
-                              Q_RETURN_ARG(QVariant, returnedValue),
-                              Q_ARG(QVariant, varText));
+                              Q_ARG(QString, varText));
 }
 
 void SensorsComponentController::_startLogCalibration(void)

--- a/src/VehicleSetup/FirmwareUpgradeController.cc
+++ b/src/VehicleSetup/FirmwareUpgradeController.cc
@@ -506,8 +506,7 @@ void FirmwareUpgradeController::_appendStatusLog(const QString& text, bool criti
 {
     Q_ASSERT(_statusLog);
     
-    QVariant returnedValue;
-    QVariant varText;
+    QString varText;
     
     if (critical) {
         varText = QString("<font color=\"yellow\">%1</font>").arg(text);
@@ -517,8 +516,7 @@ void FirmwareUpgradeController::_appendStatusLog(const QString& text, bool criti
     
     QMetaObject::invokeMethod(_statusLog,
                               "append",
-                              Q_RETURN_ARG(QVariant, returnedValue),
-                              Q_ARG(QVariant, varText));
+                              Q_ARG(QString, varText));
 }
 
 void FirmwareUpgradeController::_errorCancel(const QString& msg)


### PR DESCRIPTION
Fix invocations of the "append" QML method from multiple C++ controllers to directly pass QString instead of QVariant and remove returnValue as there is no return value.


