### PR TITLE
Fix QGCComboBox popup width calculation when need to size popup to content

### DIFF
--- a/src/QmlControls/QGCComboBox.qml
+++ b/src/QmlControls/QGCComboBox.qml
@@ -54,7 +54,8 @@ T.ComboBox {
     }
 
     function _calcPopupWidth() {
-        if (_onCompleted && model) {
+        _popupWidth = control.width
+        if (_onCompleted && sizeToContents && model) {
             var largestTextWidth = 0
             for (var i = 0; i < model.length; i++){
                 textMetrics.text = model[i]


### PR DESCRIPTION
Prevent behavior like this
![Screenshot from 2024-02-15 18-59-37](https://github.com/mavlink/qgroundcontrol/assets/2522054/8effdcce-9d8a-449b-aed2-62b7b4a135cf)


