### PR TITLE
Reworked Compass Instrument to be less cluttered

### DIFF
--- a/qgroundcontrol.qrc
+++ b/qgroundcontrol.qrc
@@ -269,7 +269,8 @@
         <file alias="QGroundControl/FlightMap/CameraTriggerIndicator.qml">src/FlightMap/MapItems/CameraTriggerIndicator.qml</file>
         <file alias="QGroundControl/FlightMap/CenterMapDropButton.qml">src/FlightMap/Widgets/CenterMapDropButton.qml</file>
         <file alias="QGroundControl/FlightMap/CenterMapDropPanel.qml">src/FlightMap/Widgets/CenterMapDropPanel.qml</file>
-        <file alias="QGroundControl/FlightMap/CompassRing.qml">src/FlightMap/Widgets/CompassRing.qml</file>
+        <file alias="QGroundControl/FlightMap/CompassDial.qml">src/FlightMap/Widgets/CompassDial.qml</file>
+        <file alias="QGroundControl/FlightMap/CompassHeadingIndicator.qml">src/FlightMap/Widgets/CompassHeadingIndicator.qml</file>
         <file alias="QGroundControl/FlightMap/CustomMapItems.qml">src/FlightMap/MapItems/CustomMapItems.qml</file>
         <file alias="QGroundControl/FlightMap/FlightMap.qml">src/FlightMap/FlightMap.qml</file>
         <file alias="QGroundControl/FlightMap/MapFitFunctions.qml">src/FlightMap/Widgets/MapFitFunctions.qml</file>

--- a/src/FactSystem/FactControls/LabelledFactSlider.qml
+++ b/src/FactSystem/FactControls/LabelledFactSlider.qml
@@ -21,6 +21,7 @@ RowLayout {
     property alias from:                    factSlider.from
     property alias to:                      factSlider.to
     property real  sliderPreferredWidth:    -1
+    enabled:       fact
 
     spacing: ScreenTools.defaultFontPixelWidth * 2
 

--- a/src/FirmwarePlugin/FirmwarePlugin.cc
+++ b/src/FirmwarePlugin/FirmwarePlugin.cc
@@ -317,11 +317,6 @@ QString FirmwarePlugin::vehicleImageOutline(const Vehicle*) const
     return QStringLiteral("/qmlimages/vehicleArrowOutline.svg");
 }
 
-QString FirmwarePlugin::vehicleImageCompass(const Vehicle*) const
-{
-    return QStringLiteral("/qmlimages/compassInstrumentArrow.svg");
-}
-
 QVariant FirmwarePlugin::mainStatusIndicatorExpandedItem(const Vehicle*) const
 {
     return QVariant();

--- a/src/FirmwarePlugin/FirmwarePlugin.h
+++ b/src/FirmwarePlugin/FirmwarePlugin.h
@@ -292,9 +292,6 @@ public:
     /// Return the resource file which contains the vehicle icon used in the flight view when the view is light (Map for instance)
     virtual QString vehicleImageOutline(const Vehicle* vehicle) const;
 
-    /// Return the resource file which contains the vehicle icon used in the compass
-    virtual QString vehicleImageCompass(const Vehicle* vehicle) const;
-
     // This is the expanded item for the main status indicator
     virtual QVariant mainStatusIndicatorExpandedItem(const Vehicle* vehicle) const;
 

--- a/src/FlightMap/Widgets/CMakeLists.txt
+++ b/src/FlightMap/Widgets/CMakeLists.txt
@@ -2,7 +2,8 @@ add_custom_target(FligthMapWidgetsQml
 	SOURCES
 		CenterMapDropButton.qml
 		CenterMapDropPanel.qml
-		CompassRing.qml
+        CompassDial.qml
+        CompassHeadingIndicator.qml
 		HorizontalCompassAttitude.qml
 		MapFitFunctions.qml
 		PhotoVideoControl.qml

--- a/src/FlightMap/Widgets/CompassDial.qml
+++ b/src/FlightMap/Widgets/CompassDial.qml
@@ -1,0 +1,112 @@
+/****************************************************************************
+ *
+ * (c) 2009-2020 QGROUNDCONTROL PROJECT <http://www.qgroundcontrol.org>
+ *
+ * QGroundControl is licensed according to the terms in the file
+ * COPYING.md in the root of the source code directory.
+ *
+ ****************************************************************************/
+
+import QtQuick
+
+import QGroundControl
+import QGroundControl.Controls
+import QGroundControl.ScreenTools
+import QGroundControl.Palette
+
+/// This is the dial background for the compass
+
+Item {
+    id: control
+
+    property real offsetRadius: width / 2 - ScreenTools.defaultFontPixelHeight / 2
+
+    function translateCenterToAngleX(radius, angle) {
+        return radius * Math.sin(angle * (Math.PI / 180))
+    } 
+
+    function translateCenterToAngleY(radius, angle) {
+        return -radius * Math.cos(angle * (Math.PI / 180))
+    }
+
+    QGCLabel {
+        anchors.centerIn:   parent
+        text:               "N"
+
+        transform: Translate {
+            x: translateCenterToAngleX(control.offsetRadius, 0)
+            y: translateCenterToAngleY(control.offsetRadius, 0)
+        }
+    }
+
+    QGCLabel {
+        anchors.centerIn:   parent
+        text:               "E"
+
+        transform: Translate {
+            x: translateCenterToAngleX(control.offsetRadius, 90)
+            y: translateCenterToAngleY(control.offsetRadius, 90)
+        }
+    }
+
+    QGCLabel {
+        anchors.centerIn:   parent
+        text:               "S"
+
+        transform: Translate {
+            x: translateCenterToAngleX(control.offsetRadius, 180)
+            y: translateCenterToAngleY(control.offsetRadius, 180)
+        }
+    }
+
+    QGCLabel {
+        anchors.centerIn:   parent
+        text:               "W"
+
+        transform: Translate {
+            x: translateCenterToAngleX(control.offsetRadius, 270)
+            y: translateCenterToAngleY(control.offsetRadius, 270)
+        }
+    }
+
+    // Major tick marks
+    Repeater {
+        model: 4
+
+        Rectangle {
+            id:                 majorTick
+            x:                  size / 2
+            width:              1
+            height:             ScreenTools.defaultFontPixelHeight * 0.5
+            color:              qgcPal.text
+
+            transform: Rotation {
+                origin.x:   0
+                origin.y:   size / 2
+                angle:      45 + (90 * index)
+            }
+        }
+    }
+
+    // Minor tick marks
+    Repeater {
+        model: 8
+
+        Rectangle {
+            id:                 majorTick
+            x:                  size / 2
+            y:                  _margin
+            width:              1
+            height:             _margin
+            color:              qgcPal.text
+
+            property real _margin: ScreenTools.defaultFontPixelHeight * 0.25
+
+            transform: Rotation {
+                origin.x:   0
+                origin.y:   size / 2 - _margin
+                angle:      45 / 2 + (45 * index)
+            }
+        }
+    }    
+}

--- a/src/FlightMap/Widgets/CompassHeadingIndicator.qml
+++ b/src/FlightMap/Widgets/CompassHeadingIndicator.qml
@@ -1,0 +1,61 @@
+/****************************************************************************
+ *
+ * (c) 2009-2020 QGROUNDCONTROL PROJECT <http://www.qgroundcontrol.org>
+ *
+ * QGroundControl is licensed according to the terms in the file
+ * COPYING.md in the root of the source code directory.
+ *
+ ****************************************************************************/
+
+import QtQuick
+
+import QGroundControl
+import QGroundControl.Controls
+import QGroundControl.ScreenTools
+import QGroundControl.Vehicle
+import QGroundControl.Palette
+
+Canvas {
+    id:                 control
+    anchors.centerIn:   parent
+    width:              compassSize * 1/3
+    height:             width
+
+    property real compassSize
+    property real heading
+
+    property var _qgcPal: QGroundControl.globalPalette
+
+    Connections {
+        target:                 _qgcPal
+        onGlobalThemeChanged:   control.requestPaint()
+    }
+
+    onPaint: {
+        var ctx = getContext("2d")
+        ctx.strokeStyle = _qgcPal.text
+        ctx.fillStyle = "#EE3424"
+        ctx.lineWidth = 1
+        ctx.beginPath()
+        ctx.moveTo(width / 2, 0)
+        ctx.lineTo(width, height)
+        ctx.lineTo(width / 2, height * 0.75)
+        ctx.lineTo(width / 2, 0)
+        ctx.fill()
+        ctx.stroke()
+        ctx.fillStyle = "#C72B27"
+        ctx.beginPath()
+        ctx.moveTo(width / 2, 0)
+        ctx.lineTo(0, height)
+        ctx.lineTo(width / 2, height * 0.75)
+        ctx.lineTo(width / 2, 0)
+        ctx.fill()
+        ctx.stroke()
+    }
+
+    transform: Rotation {
+        origin.x:   control.width / 2
+        origin.y:   control.height / 2
+        angle:      heading
+    }
+}

--- a/src/FlightMap/Widgets/IntegratedCompassAttitude.qml
+++ b/src/FlightMap/Widgets/IntegratedCompassAttitude.qml
@@ -41,68 +41,6 @@ Item {
         transformOrigin:        Item.Center
         rotation:               90
     }
-
-    /*
-    // Roll background
-    Canvas {
-        anchors.fill: parent
-
-        onPaint: {
-            var centerX = width / 2
-            var centerY = height / 2
-            var ctx = getContext("2d")
-            ctx.reset()
-            ctx.strokeStyle = qgcPal.window
-            ctx.lineWidth = attitudeSize
-            ctx.beginPath()
-            ctx.arc(centerX, centerY, attitudeRadius, zeroRollRadians - maxRadians, zeroRollRadians + maxRadians)
-            ctx.stroke()
-        }
-    }
-
-    // Roll value indicator
-    Canvas {
-        id:             rollIndicator
-        anchors.fill:   parent
-        visible:        Math.abs(rollAngle) > 1
-
-        property real startRollRadiansRaw:      zeroRollRadians
-        property real endRollRadiansRaw:        zeroRollRadians + (rollAnglePercent * maxRadians)
-        property real startRollRadiansOrdered:  Math.min(startRollRadiansRaw, endRollRadiansRaw)
-        property real endRollRadiansOrdered:    Math.max(startRollRadiansRaw, endRollRadiansRaw)
-
-        onPaint: {
-            var centerX = width / 2
-            var centerY = height / 2
-            var ctx = getContext("2d")
-            ctx.reset()
-            ctx.strokeStyle = qgcPal.text
-            ctx.lineWidth = attitudeSize
-            ctx.beginPath()
-            ctx.arc(centerX, centerY, attitudeRadius, startRollRadiansOrdered, endRollRadiansOrdered)
-            ctx.stroke()
-        }
-    }
-
-    // Roll 0 value tick mark
-    Canvas {
-        anchors.fill: parent
-
-        onPaint: {
-            var centerX = width / 2
-            var centerY = height / 2
-            var ctx = getContext("2d")
-            ctx.reset()
-            ctx.strokeStyle = qgcPal.text
-            ctx.lineWidth = 2
-            ctx.beginPath()
-            ctx.moveTo(centerX, 0)
-            ctx.lineTo(centerX, attitudeSize)
-            ctx.stroke()
-        }
-    }
-    */
-
     Rectangle {
         anchors.centerIn:   parent
         width:              compassRadius * 2

--- a/src/QGCPalette.cc
+++ b/src/QGCPalette.cc
@@ -83,6 +83,7 @@ void QGCPalette::_buildMap()
     DECLARE_QGC_COLOR(statusPassedText,     "#9d9d9d", "#000000", "#707070", "#ffffff")
     DECLARE_QGC_COLOR(statusPendingText,    "#9d9d9d", "#000000", "#707070", "#ffffff")
     DECLARE_QGC_COLOR(toolbarBackground,    "#ffffff", "#ffffff", "#222222", "#222222")
+    DECLARE_QGC_COLOR(groupBorder,          "#bbbbbb", "#bbbbbb", "#707070", "#707070")
 
     // Colors not affecting by theming
     //                                              Disabled    Enabled

--- a/src/QGCPalette.h
+++ b/src/QGCPalette.h
@@ -153,6 +153,7 @@ public:
     DEFINE_QGC_COLOR(toolbarBackground,             setToolbarBackground)
     DEFINE_QGC_COLOR(toolStripFGColor,              setToolStripFGColor)
     DEFINE_QGC_COLOR(toolStripHoverColor,           setToolStripHoverColor)
+    DEFINE_QGC_COLOR(groupBorder,                   setGroupBorder)
 
 #ifdef CONFIG_UTM_ADAPTER
     DEFINE_QGC_COLOR(switchUTMSP,                    setSwitchUTMSP)

--- a/src/QmlControls/FactSlider.qml
+++ b/src/QmlControls/FactSlider.qml
@@ -26,9 +26,10 @@ Slider {
     bottomPadding:  sliderValueLabel.contentHeight
     leftPadding:    0
     rightPadding:   0
+    enabled:        fact
 
-    property Fact fact
-    property bool showUnits: true
+    property Fact fact:         undefined
+    property bool showUnits:    true
 
     property bool _loadComplete:            false
     property real _minMaxVisibilityPadding: ScreenTools.defaultFontPixelWidth
@@ -85,7 +86,7 @@ Slider {
 
         QGCLabel {
             text:       control.from.toFixed(_fact.decimalPlaces)
-            visible:    sliderValueLabel.x > x + contentWidth + _minMaxVisibilityPadding
+            visible:    fact && sliderValueLabel.x > x + contentWidth + _minMaxVisibilityPadding
             anchors {
                 left:   parent.left
                 bottom: parent.bottom
@@ -94,7 +95,7 @@ Slider {
 
         QGCLabel {
             text:       control.to.toFixed(_fact.decimalPlaces)
-            visible:    sliderValueLabel.x + sliderValueLabel.contentWidth < x - _minMaxVisibilityPadding
+            visible:    fact && sliderValueLabel.x + sliderValueLabel.contentWidth < x - _minMaxVisibilityPadding
             anchors {
                 right:  parent.right
                 bottom: parent.bottom
@@ -105,7 +106,7 @@ Slider {
             id:                     sliderValueLabel
             anchors.bottom:         parent.bottom
             x:                      control.leftPadding + (control.visualPosition * (control.availableWidth - width))
-            text:                   valuePlusUnits(control.value.toFixed(control._fact.decimalPlaces))
+            text:                   fact ? valuePlusUnits(control.value.toFixed(control._fact.decimalPlaces)) : qsTr("N/A")
             horizontalAlignment:    Text.AlignHCenter
         }
     }

--- a/src/QmlControls/QGCCheckBoxSlider.qml
+++ b/src/QmlControls/QGCCheckBoxSlider.qml
@@ -19,6 +19,8 @@ AbstractButton   {
     checkable:      true
     padding:        0
 
+    property bool   _showBorder: qgcPal.globalTheme === QGCPalette.Light
+
     QGCPalette { id: qgcPal; colorGroupEnabled: control.enabled }
 
     contentItem: Item {
@@ -40,6 +42,8 @@ AbstractButton   {
             width:                  height * 2
             radius:                 height / 2
             color:                  control.checked ? qgcPal.primaryButton : qgcPal.button
+            border.width:           _showBorder ? 1 : 0
+            border.color:           qgcPal.buttonBorder
 
             Rectangle {
                 anchors.verticalCenter: parent.verticalCenter

--- a/src/QmlControls/QGroundControl/FlightMap/qmldir
+++ b/src/QmlControls/QGroundControl/FlightMap/qmldir
@@ -7,7 +7,8 @@ QGCVideoBackground  1.0 QGCVideoBackground.qml
 # Widgets
 CenterMapDropButton         1.0 CenterMapDropButton.qml
 CenterMapDropPanel          1.0 CenterMapDropPanel.qml
-CompassRing                 1.0 CompassRing.qml
+CompassDial                 1.0 CompassDial.qml
+CompassHeadingIndicator     1.0 CompassHeadingIndicator.qml
 MapFitFunctions             1.0 MapFitFunctions.qml
 MapLineArrow                1.0 MapLineArrow.qml
 MapScale                    1.0 MapScale.qml

--- a/src/QmlControls/SettingsGroupLayout.qml
+++ b/src/QmlControls/SettingsGroupLayout.qml
@@ -48,7 +48,7 @@ ColumnLayout {
         implicitWidth:      _contentLayout.implicitWidth + (_margins * 2)
         implicitHeight:     _contentLayout.implicitHeight + (_margins * 2)
         color:              "transparent"
-        border.color:       Qt.darker(QGroundControl.globalPalette.text, 4)
+        border.color:       QGroundControl.globalPalette.groupBorder
         border.width:       1
         radius:             ScreenTools.defaultFontPixelHeight / 2
 
@@ -60,7 +60,7 @@ ColumnLayout {
                 y:                  _contentItem.y + _contentItem.height + _margins + _margins
                 width:              parent.width - (_margins * 2)
                 height:             1
-                color:              outerRect.border.color
+                color:              QGroundControl.globalPalette.groupBorder
                 visible:            _contentItem.visible && 
                                         _contentItem.width !== 0 && _contentItem.height !== 0 &&
                                         index < _contentLayout.children.length - 1

--- a/src/Vehicle/Vehicle.cc
+++ b/src/Vehicle/Vehicle.cc
@@ -3856,14 +3856,6 @@ QString Vehicle::vehicleImageOutline() const
         return QString();
 }
 
-QString Vehicle::vehicleImageCompass() const
-{
-    if(_firmwarePlugin)
-        return _firmwarePlugin->vehicleImageCompass(this);
-    else
-        return QString();
-}
-
 QVariant Vehicle::mainStatusIndicatorExpandedItem()
 {
     if(_firmwarePlugin) {

--- a/src/Vehicle/Vehicle.h
+++ b/src/Vehicle/Vehicle.h
@@ -243,7 +243,6 @@ public:
     Q_PROPERTY(QString              vehicleTypeString           READ vehicleTypeString                                              NOTIFY vehicleTypeChanged)
     Q_PROPERTY(QString              vehicleImageOpaque          READ vehicleImageOpaque                                             CONSTANT)
     Q_PROPERTY(QString              vehicleImageOutline         READ vehicleImageOutline                                            CONSTANT)
-    Q_PROPERTY(QString              vehicleImageCompass         READ vehicleImageCompass                                            CONSTANT)
     Q_PROPERTY(int                  telemetryRRSSI              READ telemetryRRSSI                                                 NOTIFY telemetryRRSSIChanged)
     Q_PROPERTY(int                  telemetryLRSSI              READ telemetryLRSSI                                                 NOTIFY telemetryLRSSIChanged)
     Q_PROPERTY(unsigned int         telemetryRXErrors           READ telemetryRXErrors                                              NOTIFY telemetryRXErrorsChanged)
@@ -897,7 +896,6 @@ public:
 
     QString vehicleImageOpaque  () const;
     QString vehicleImageOutline () const;
-    QString vehicleImageCompass () const;
 
     QVariant                    mainStatusIndicatorExpandedItem ();
     const QVariantList&         toolIndicators                  ();


### PR DESCRIPTION
<img width="167" alt="Screenshot 2024-02-15 at 3 32 10 PM" src="https://github.com/mavlink/qgroundcontrol/assets/5876851/5b83422a-5c46-4ea6-bb5e-79ec56789532">

Other changes:
* Heading to Home indicator now shown as "L" to match Launch Point item in map
* Other indicators: course over ground, heading to next waypoint, remain the same.
* Position/size of heading degrees text is much more visible than before
* A number of other minor visual fixes
* Custom build note: The Compass Heading Indicator (the red vehicle looking thingy) is now a Qml control which custom build can override using a resource override. Replacing this via FirmwarePlugin C++ code is no longer supported. Reason being, resource override is way simpler than writing C code. In general I'm moving the custom build support from C code overrides to simpler resource overrides where possible.