### PR TITLE
Cache CI Qt Downloads

### DIFF
--- a/.github/workflows/android_release.yml
+++ b/.github/workflows/android_release.yml
@@ -53,17 +53,6 @@ jobs:
         run: |
           git fetch --all --tags -f --depth 1
 
-      - name: Install Qt6 for Linux (required for Android)
-        uses: jurplel/install-qt-action@v3
-        with:
-          version:      ${{ env.QT_VERSION }}
-          aqtversion:   ==3.1.*
-          host:         linux
-          target:       desktop
-          dir:          ${{ runner.temp }}
-          modules:      qtcharts qtlocation qtpositioning qtspeech qt5compat qtmultimedia qtserialport qtimageformats qtshadertools qtconnectivity qtquick3d
-          setup-python: true
-
       - name: Install Qt6 for Android
         uses: jurplel/install-qt-action@v3
         with:
@@ -76,6 +65,7 @@ jobs:
           dir:          ${{ runner.temp }}
           modules:      qtcharts qtlocation qtpositioning qtspeech qt5compat qtmultimedia qtserialport qtimageformats qtshadertools qtconnectivity qtquick3d
           setup-python: true
+          cache: true
 
       - name: Remove Android SDKs to force usage of android-33 only
         run: |

--- a/.github/workflows/linux_debug.yml
+++ b/.github/workflows/linux_debug.yml
@@ -41,6 +41,7 @@ jobs:
           dir:          ${{ runner.temp }}
           modules:      qtcharts qtlocation qtpositioning qtspeech qt5compat qtmultimedia qtserialport qtimageformats qtshadertools qtquick3d
           setup-python: true
+          cache: true
 
       - name: Install github environment dependencies for unit test running
         run:  sudo apt-get install libxcb-xinerama0

--- a/.github/workflows/linux_release.yml
+++ b/.github/workflows/linux_release.yml
@@ -50,6 +50,7 @@ jobs:
           dir:          ${{ runner.temp }}
           modules:      qtcharts qtlocation qtpositioning qtspeech qt5compat qtmultimedia qtserialport qtimageformats qtshadertools qtquick3d
           setup-python: true
+          cache: true
 
       - name: Install QGC source dependencies
         run:  sudo apt-get install -y libsdl2-dev

--- a/.github/workflows/macos_release.yml
+++ b/.github/workflows/macos_release.yml
@@ -50,6 +50,7 @@ jobs:
           dir:          ${{ runner.temp }}
           modules:      qtcharts qtlocation qtpositioning qtspeech qt5compat qtmultimedia qtserialport qtimageformats qtshadertools qtquick3d
           setup-python: false
+          cache: true
 
       - name: Install Gstreamer
         run: |

--- a/.github/workflows/videoapp_linux.yml
+++ b/.github/workflows/videoapp_linux.yml
@@ -43,6 +43,7 @@ jobs:
           dir:          ${{ runner.temp }}
           modules:      qtcharts qtlocation qtpositioning qtspeech qt5compat qtmultimedia qtserialport qtimageformats qtshadertools
           setup-python: true
+          cache: true
 
       - name: Install github environment dependencies for unit test running
         run:  sudo apt-get install libxcb-xinerama0

--- a/.github/workflows/windows_release.yml
+++ b/.github/workflows/windows_release.yml
@@ -51,6 +51,7 @@ jobs:
           dir:          ${{ runner.temp }}
           modules:      qtcharts qtlocation qtpositioning qtspeech qt5compat qtmultimedia qtserialport qtimageformats qtshadertools qtquick3d
           setup-python: false
+          cache: true
 
       - name: Download JOM
         uses: suisei-cn/actions-download-file@v1.3.0


### PR DESCRIPTION
This adds the automatic caching option to the install-qt-action. Also it removes the extra linux install from the android workflow, which is handled automatically by setting `extra:        --autodesktop` in the android Qt download.

One extra note: CCache isn't working in the workflows and hasn't been for some time, I might try and fix it but it's probably better to just wait until we switch to CMake, where ninja will make ccache less relevant.