### PR TITLE
Fix Stable_V4.3 android build workflow

### DIFF
--- a/.github/workflows/android_release.yml
+++ b/.github/workflows/android_release.yml
@@ -75,6 +75,7 @@ jobs:
             ${ANDROID_SDK_ROOT}/cmdline-tools/latest/bin/sdkmanager --uninstall "platforms;android-33-ext4"
             ${ANDROID_SDK_ROOT}/cmdline-tools/latest/bin/sdkmanager --uninstall "platforms;android-34"
             ${ANDROID_SDK_ROOT}/cmdline-tools/latest/bin/sdkmanager --uninstall "platforms;android-34-ext8"
+            ${ANDROID_SDK_ROOT}/cmdline-tools/latest/bin/sdkmanager --uninstall "platforms;android-34-ext10"
 
       - name: Install ccache
         run:  sudo apt-get install ccache


### PR DESCRIPTION
https://github.com/mavlink/qgroundcontrol/issues/10968

android-34-ext10 was being installed which was causing the build step on Stable-V4.3 to fail. 

I noticed similar issues were experienced in the past here: https://github.com/mavlink/qgroundcontrol/pull/10848

With this change I managed to get past the build step successfully. However, every branch our fork fails at the "Upload build to S3 Bucket" step, so I cannot confirm with full certainty that it will succeed.

Here's that workflow run if you are curious:
https://github.com/AscendEngineering/qgroundcontrol/actions/runs/7936789857/job/21672792328


