### PR TITLE
Convert Fact Names to QStringLiterals

### DIFF
--- a/src/Vehicle/GPSRTKFactGroup.cc
+++ b/src/Vehicle/GPSRTKFactGroup.cc
@@ -9,16 +9,6 @@
 
 #include "GPSRTKFactGroup.h"
 
-const char* GPSRTKFactGroup::_connectedFactName =                "connected";
-const char* GPSRTKFactGroup::_currentAccuracyFactName =          "currentAccuracy";
-const char* GPSRTKFactGroup::_currentDurationFactName =          "currentDuration";
-const char* GPSRTKFactGroup::_currentLatitudeFactName =          "currentLatitude";
-const char* GPSRTKFactGroup::_currentLongitudeFactName =         "currentLongitude";
-const char* GPSRTKFactGroup::_currentAltitudeFactName =          "currentAltitude";
-const char* GPSRTKFactGroup::_validFactName =                    "valid";
-const char* GPSRTKFactGroup::_activeFactName =                   "active";
-const char* GPSRTKFactGroup::_numSatellitesFactName =            "numSatellites";
-
 GPSRTKFactGroup::GPSRTKFactGroup(QObject* parent)
     : FactGroup             (1000, ":/json/Vehicle/GPSRTKFact.json", parent)
     , _connected            (0, _connectedFactName,         FactMetaData::valueTypeBool)

--- a/src/Vehicle/GPSRTKFactGroup.h
+++ b/src/Vehicle/GPSRTKFactGroup.h
@@ -39,17 +39,17 @@ public:
     Fact* active            (void) { return &_active; }
     Fact* numSatellites     (void) { return &_numSatellites; }
 
-    static const char* _connectedFactName;
-    static const char* _currentDurationFactName;
-    static const char* _currentAccuracyFactName;
-    static const char* _currentLatitudeFactName;
-    static const char* _currentLongitudeFactName;
-    static const char* _currentAltitudeFactName;
-    static const char* _validFactName;
-    static const char* _activeFactName;
-    static const char* _numSatellitesFactName;
-
 private:
+    const QString _connectedFactName =                QStringLiteral("connected");
+    const QString _currentAccuracyFactName =          QStringLiteral("currentAccuracy");
+    const QString _currentDurationFactName =          QStringLiteral("currentDuration");
+    const QString _currentLatitudeFactName =          QStringLiteral("currentLatitude");
+    const QString _currentLongitudeFactName =         QStringLiteral("currentLongitude");
+    const QString _currentAltitudeFactName =          QStringLiteral("currentAltitude");
+    const QString _validFactName =                    QStringLiteral("valid");
+    const QString _activeFactName =                   QStringLiteral("active");
+    const QString _numSatellitesFactName =            QStringLiteral("numSatellites");
+
     Fact _connected;        ///< is an RTK gps connected?
     Fact _currentDuration;  ///< survey-in status in [s]
     Fact _currentAccuracy;  ///< survey-in accuracy in [mm]

--- a/src/Vehicle/TerrainFactGroup.cc
+++ b/src/Vehicle/TerrainFactGroup.cc
@@ -9,9 +9,6 @@
 
 #include "TerrainFactGroup.h"
 
-const char* TerrainFactGroup::_blocksPendingFactName =  "blocksPending";
-const char* TerrainFactGroup::_blocksLoadedFactName =   "blocksLoaded";
-
 TerrainFactGroup::TerrainFactGroup(QObject* parent)
     : FactGroup         (1000, ":/json/Vehicle/TerrainFactGroup.json", parent)
     , _blocksPendingFact(0, _blocksPendingFactName, FactMetaData::valueTypeDouble)

--- a/src/Vehicle/TerrainFactGroup.h
+++ b/src/Vehicle/TerrainFactGroup.h
@@ -26,10 +26,10 @@ public:
     Fact* blocksPending () { return &_blocksPendingFact; }
     Fact* blocksLoaded  () { return &_blocksLoadedFact; }
 
-    static const char* _blocksPendingFactName;
-    static const char* _blocksLoadedFactName;
-
 private:
+    const QString _blocksPendingFactName =  QStringLiteral("blocksPending");
+    const QString _blocksLoadedFactName =   QStringLiteral("blocksLoaded");
+
     Fact _blocksPendingFact;
     Fact _blocksLoadedFact;
 };

--- a/src/Vehicle/Vehicle.cc
+++ b/src/Vehicle/Vehicle.cc
@@ -65,56 +65,6 @@ QGC_LOGGING_CATEGORY(VehicleLog, "VehicleLog")
 
 const QString guided_mode_not_supported_by_vehicle = QObject::tr("Guided mode not supported by Vehicle.");
 
-const char* Vehicle::_settingsGroup =               "Vehicle%1";        // %1 replaced with mavlink system id
-const char* Vehicle::_joystickEnabledSettingsKey =  "JoystickEnabled";
-
-const char* Vehicle::_rollFactName =                "roll";
-const char* Vehicle::_pitchFactName =               "pitch";
-const char* Vehicle::_headingFactName =             "heading";
-const char* Vehicle::_rollRateFactName =             "rollRate";
-const char* Vehicle::_pitchRateFactName =           "pitchRate";
-const char* Vehicle::_yawRateFactName =             "yawRate";
-const char* Vehicle::_airSpeedFactName =            "airSpeed";
-const char* Vehicle::_airSpeedSetpointFactName =    "airSpeedSetpoint";
-const char* Vehicle::_xTrackErrorFactName =         "xTrackError";
-const char* Vehicle::_rangeFinderDistFactName =     "rangeFinderDist";
-const char* Vehicle::_groundSpeedFactName =         "groundSpeed";
-const char* Vehicle::_climbRateFactName =           "climbRate";
-const char* Vehicle::_altitudeRelativeFactName =    "altitudeRelative";
-const char* Vehicle::_altitudeAMSLFactName =        "altitudeAMSL";
-const char* Vehicle::_altitudeAboveTerrFactName =   "altitudeAboveTerr";
-const char* Vehicle::_altitudeTuningFactName =      "altitudeTuning";
-const char* Vehicle::_altitudeTuningSetpointFactName = "altitudeTuningSetpoint";
-const char* Vehicle::_flightDistanceFactName =      "flightDistance";
-const char* Vehicle::_flightTimeFactName =          "flightTime";
-const char* Vehicle::_distanceToHomeFactName =      "distanceToHome";
-const char* Vehicle::_timeToHomeFactName =          "timeToHome";
-const char* Vehicle::_missionItemIndexFactName =    "missionItemIndex";
-const char* Vehicle::_headingToNextWPFactName =     "headingToNextWP";
-const char* Vehicle::_distanceToNextWPFactName =    "distanceToNextWP";
-const char* Vehicle::_headingToHomeFactName =       "headingToHome";
-const char* Vehicle::_distanceToGCSFactName =       "distanceToGCS";
-const char* Vehicle::_hobbsFactName =               "hobbs";
-const char* Vehicle::_throttlePctFactName =         "throttlePct";
-const char* Vehicle::_imuTempFactName =             "imuTemp";
-
-const char* Vehicle::_gpsFactGroupName =                "gps";
-const char* Vehicle::_gps2FactGroupName =               "gps2";
-const char* Vehicle::_windFactGroupName =               "wind";
-const char* Vehicle::_vibrationFactGroupName =          "vibration";
-const char* Vehicle::_temperatureFactGroupName =        "temperature";
-const char* Vehicle::_clockFactGroupName =              "clock";
-const char* Vehicle::_setpointFactGroupName =           "setpoint";
-const char* Vehicle::_distanceSensorFactGroupName =     "distanceSensor";
-const char* Vehicle::_localPositionFactGroupName =      "localPosition";
-const char* Vehicle::_localPositionSetpointFactGroupName ="localPositionSetpoint";
-const char* Vehicle::_escStatusFactGroupName =          "escStatus";
-const char* Vehicle::_estimatorStatusFactGroupName =    "estimatorStatus";
-const char* Vehicle::_terrainFactGroupName =            "terrain";
-const char* Vehicle::_hygrometerFactGroupName =         "hygrometer";
-const char* Vehicle::_generatorFactGroupName =          "generator";
-const char* Vehicle::_efiFactGroupName =                "efi";
-
 // Standard connected vehicle
 Vehicle::Vehicle(LinkInterface*             link,
                  int                        vehicleId,

--- a/src/Vehicle/Vehicle.h
+++ b/src/Vehicle/Vehicle.h
@@ -1418,6 +1418,56 @@ private:
 
     // FactGroup facts
 
+    const QString _settingsGroup =               QStringLiteral("Vehicle%1");        // %1 replaced with mavlink system id
+    const QString _joystickEnabledSettingsKey =  QStringLiteral("JoystickEnabled");
+
+    const QString _rollFactName =                QStringLiteral("roll");
+    const QString _pitchFactName =               QStringLiteral("pitch");
+    const QString _headingFactName =             QStringLiteral("heading");
+    const QString _rollRateFactName =             QStringLiteral("rollRate");
+    const QString _pitchRateFactName =           QStringLiteral("pitchRate");
+    const QString _yawRateFactName =             QStringLiteral("yawRate");
+    const QString _airSpeedFactName =            QStringLiteral("airSpeed");
+    const QString _airSpeedSetpointFactName =    QStringLiteral("airSpeedSetpoint");
+    const QString _xTrackErrorFactName =         QStringLiteral("xTrackError");
+    const QString _rangeFinderDistFactName =     QStringLiteral("rangeFinderDist");
+    const QString _groundSpeedFactName =         QStringLiteral("groundSpeed");
+    const QString _climbRateFactName =           QStringLiteral("climbRate");
+    const QString _altitudeRelativeFactName =    QStringLiteral("altitudeRelative");
+    const QString _altitudeAMSLFactName =        QStringLiteral("altitudeAMSL");
+    const QString _altitudeAboveTerrFactName =   QStringLiteral("altitudeAboveTerr");
+    const QString _altitudeTuningFactName =      QStringLiteral("altitudeTuning");
+    const QString _altitudeTuningSetpointFactName = QStringLiteral("altitudeTuningSetpoint");
+    const QString _flightDistanceFactName =      QStringLiteral("flightDistance");
+    const QString _flightTimeFactName =          QStringLiteral("flightTime");
+    const QString _distanceToHomeFactName =      QStringLiteral("distanceToHome");
+    const QString _timeToHomeFactName =          QStringLiteral("timeToHome");
+    const QString _missionItemIndexFactName =    QStringLiteral("missionItemIndex");
+    const QString _headingToNextWPFactName =     QStringLiteral("headingToNextWP");
+    const QString _distanceToNextWPFactName =    QStringLiteral("distanceToNextWP");
+    const QString _headingToHomeFactName =       QStringLiteral("headingToHome");
+    const QString _distanceToGCSFactName =       QStringLiteral("distanceToGCS");
+    const QString _hobbsFactName =               QStringLiteral("hobbs");
+    const QString _throttlePctFactName =         QStringLiteral("throttlePct");
+    const QString _imuTempFactName =             QStringLiteral("imuTemp");
+
+    const QString _gpsFactGroupName =                QStringLiteral("gps");
+    const QString _gps2FactGroupName =               QStringLiteral("gps2");
+    const QString _windFactGroupName =               QStringLiteral("wind");
+    const QString _vibrationFactGroupName =          QStringLiteral("vibration");
+    const QString _temperatureFactGroupName =        QStringLiteral("temperature");
+    const QString _clockFactGroupName =              QStringLiteral("clock");
+    const QString _setpointFactGroupName =           QStringLiteral("setpoint");
+    const QString _distanceSensorFactGroupName =     QStringLiteral("distanceSensor");
+    const QString _localPositionFactGroupName =      QStringLiteral("localPosition");
+    const QString _localPositionSetpointFactGroupName = QStringLiteral("localPositionSetpoint");
+    const QString _escStatusFactGroupName =          QStringLiteral("escStatus");
+    const QString _estimatorStatusFactGroupName =    QStringLiteral("estimatorStatus");
+    const QString _terrainFactGroupName =            QStringLiteral("terrain");
+    const QString _hygrometerFactGroupName =         QStringLiteral("hygrometer");
+    const QString _generatorFactGroupName =          QStringLiteral("generator");
+    const QString _efiFactGroupName =                QStringLiteral("efi");
+
     Fact _rollFact;
     Fact _pitchFact;
     Fact _headingFact;
@@ -1479,58 +1529,7 @@ private:
     RemoteIDManager*                _remoteIDManager            = nullptr;
     StandardModes*                  _standardModes              = nullptr;
 
-    static const char* _rollFactName;
-    static const char* _pitchFactName;
-    static const char* _headingFactName;
-    static const char* _rollRateFactName;
-    static const char* _pitchRateFactName;
-    static const char* _yawRateFactName;
-    static const char* _groundSpeedFactName;
-    static const char* _airSpeedFactName;
-    static const char* _airSpeedSetpointFactName;
-    static const char* _climbRateFactName;
-    static const char* _altitudeRelativeFactName;
-    static const char* _altitudeAMSLFactName;
-    static const char* _altitudeAboveTerrFactName;
-    static const char* _altitudeTuningFactName;
-    static const char* _altitudeTuningSetpointFactName;
-    static const char* _xTrackErrorFactName;
-    static const char* _rangeFinderDistFactName;
-    static const char* _flightDistanceFactName;
-    static const char* _flightTimeFactName;
-    static const char* _distanceToHomeFactName;
-    static const char* _timeToHomeFactName;
-    static const char* _missionItemIndexFactName;
-    static const char* _headingToNextWPFactName;
-    static const char* _distanceToNextWPFactName;
-    static const char* _headingToHomeFactName;
-    static const char* _distanceToGCSFactName;
-    static const char* _hobbsFactName;
-    static const char* _throttlePctFactName;
-    static const char* _imuTempFactName;
-
-    static const char* _gpsFactGroupName;
-    static const char* _gps2FactGroupName;
-    static const char* _windFactGroupName;
-    static const char* _vibrationFactGroupName;
-    static const char* _temperatureFactGroupName;
-    static const char* _clockFactGroupName;
-    static const char* _setpointFactGroupName;
-    static const char* _distanceSensorFactGroupName;
-    static const char* _localPositionFactGroupName;
-    static const char* _localPositionSetpointFactGroupName;
-    static const char* _escStatusFactGroupName;
-    static const char* _estimatorStatusFactGroupName;
-    static const char* _hygrometerFactGroupName;
-    static const char* _generatorFactGroupName;
-    static const char* _efiFactGroupName;
-    static const char* _terrainFactGroupName;
-
     static const int _vehicleUIUpdateRateMSecs      = 100;
-
-    // Settings keys
-    static const char* _settingsGroup;
-    static const char* _joystickEnabledSettingsKey;
 
     // Terrain query members, used to get terrain altitude for doSetHome()
     TerrainAtCoordinateQuery*   _currentDoSetHomeTerrainAtCoordinateQuery = nullptr;

--- a/src/Vehicle/VehicleBatteryFactGroup.cc
+++ b/src/Vehicle/VehicleBatteryFactGroup.cc
@@ -11,22 +11,7 @@
 #include "QmlObjectListModel.h"
 #include "Vehicle.h"
 
-const char* VehicleBatteryFactGroup::_batteryFactGroupNamePrefix    = "battery";
-
-const char* VehicleBatteryFactGroup::_batteryIdFactName             = "id";
-const char* VehicleBatteryFactGroup::_batteryFunctionFactName       = "batteryFunction";
-const char* VehicleBatteryFactGroup::_batteryTypeFactName           = "batteryType";
-const char* VehicleBatteryFactGroup::_voltageFactName               = "voltage";
-const char* VehicleBatteryFactGroup::_percentRemainingFactName      = "percentRemaining";
-const char* VehicleBatteryFactGroup::_mahConsumedFactName           = "mahConsumed";
-const char* VehicleBatteryFactGroup::_currentFactName               = "current";
-const char* VehicleBatteryFactGroup::_temperatureFactName           = "temperature";
-const char* VehicleBatteryFactGroup::_instantPowerFactName          = "instantPower";
-const char* VehicleBatteryFactGroup::_timeRemainingFactName         = "timeRemaining";
-const char* VehicleBatteryFactGroup::_timeRemainingStrFactName      = "timeRemainingStr";
-const char* VehicleBatteryFactGroup::_chargeStateFactName           = "chargeState";
-
-const char* VehicleBatteryFactGroup::_settingsGroup =                       "Vehicle.battery";
+const char* VehicleBatteryFactGroup::_batteryFactGroupNamePrefix = "battery";
 
 VehicleBatteryFactGroup::VehicleBatteryFactGroup(uint8_t batteryId, QObject* parent)
     : FactGroup             (1000, ":/json/Vehicle/BatteryFact.json", parent)

--- a/src/Vehicle/VehicleBatteryFactGroup.h
+++ b/src/Vehicle/VehicleBatteryFactGroup.h
@@ -47,21 +47,6 @@ public:
     Fact* timeRemainingStr          () { return &_timeRemainingStrFact; }
     Fact* chargeState               () { return &_chargeStateFact; }
 
-    static const char* _batteryIdFactName;
-    static const char* _batteryFunctionFactName;
-    static const char* _batteryTypeFactName;
-    static const char* _temperatureFactName;
-    static const char* _voltageFactName;
-    static const char* _currentFactName;
-    static const char* _mahConsumedFactName;
-    static const char* _percentRemainingFactName;
-    static const char* _timeRemainingFactName;
-    static const char* _timeRemainingStrFactName;
-    static const char* _chargeStateFactName;
-    static const char* _instantPowerFactName;
-
-    static const char* _settingsGroup;
-
     /// Creates a new fact group for the battery id as needed and updates the Vehicle with it
     static void handleMessageForFactGroupCreation(Vehicle* vehicle, mavlink_message_t& message);
 
@@ -77,6 +62,21 @@ private:
     static void                     _handleBatteryStatus        (Vehicle* vehicle, mavlink_message_t& message);
     static VehicleBatteryFactGroup* _findOrAddBatteryGroupById  (Vehicle* vehicle, uint8_t batteryId);
 
+    static const char* _batteryFactGroupNamePrefix;
+
+    const QString _batteryIdFactName             = QStringLiteral("id");
+    const QString _batteryFunctionFactName       = QStringLiteral("batteryFunction");
+    const QString _batteryTypeFactName           = QStringLiteral("batteryType");
+    const QString _voltageFactName               = QStringLiteral("voltage");
+    const QString _percentRemainingFactName      = QStringLiteral("percentRemaining");
+    const QString _mahConsumedFactName           = QStringLiteral("mahConsumed");
+    const QString _currentFactName               = QStringLiteral("current");
+    const QString _temperatureFactName           = QStringLiteral("temperature");
+    const QString _instantPowerFactName          = QStringLiteral("instantPower");
+    const QString _timeRemainingFactName         = QStringLiteral("timeRemaining");
+    const QString _timeRemainingStrFactName      = QStringLiteral("timeRemainingStr");
+    const QString _chargeStateFactName           = QStringLiteral("chargeState");
+
     Fact            _batteryIdFact;
     Fact            _batteryFunctionFact;
     Fact            _batteryTypeFact;
@@ -89,6 +89,4 @@ private:
     Fact            _timeRemainingStrFact;
     Fact            _chargeStateFact;
     Fact            _instantPowerFact;
-
-    static const char* _batteryFactGroupNamePrefix;
 };

--- a/src/Vehicle/VehicleClockFactGroup.cc
+++ b/src/Vehicle/VehicleClockFactGroup.cc
@@ -10,10 +10,6 @@
 #include "VehicleClockFactGroup.h"
 #include "Vehicle.h"
 
-const char* VehicleClockFactGroup::_currentTimeFactName = "currentTime";
-const char* VehicleClockFactGroup::_currentUTCTimeFactName = "currentUTCTime";
-const char* VehicleClockFactGroup::_currentDateFactName = "currentDate";
-
 VehicleClockFactGroup::VehicleClockFactGroup(QObject* parent)
     : FactGroup(1000, ":/json/Vehicle/ClockFact.json", parent)
     , _currentTimeFact  (0, _currentTimeFactName,    FactMetaData::valueTypeString)

--- a/src/Vehicle/VehicleClockFactGroup.h
+++ b/src/Vehicle/VehicleClockFactGroup.h
@@ -29,16 +29,16 @@ public:
     Fact* currentUTCTime () { return &_currentUTCTimeFact; }
     Fact* currentDate () { return &_currentDateFact; }
 
-    static const char* _currentTimeFactName;
-    static const char* _currentUTCTimeFactName;
-    static const char* _currentDateFactName;
 
-    static const char* _settingsGroup;
 
 private slots:
     void _updateAllValues() override;
 
 private:
+    const QString _currentTimeFactName = QStringLiteral("currentTime");
+    const QString _currentUTCTimeFactName = QStringLiteral("currentUTCTime");
+    const QString _currentDateFactName = QStringLiteral("currentDate");
+
     Fact            _currentTimeFact;
     Fact            _currentUTCTimeFact;
     Fact            _currentDateFact;

--- a/src/Vehicle/VehicleDistanceSensorFactGroup.cc
+++ b/src/Vehicle/VehicleDistanceSensorFactGroup.cc
@@ -10,19 +10,6 @@
 #include "VehicleDistanceSensorFactGroup.h"
 #include "Vehicle.h"
 
-const char* VehicleDistanceSensorFactGroup::_rotationNoneFactName =     "rotationNone";
-const char* VehicleDistanceSensorFactGroup::_rotationYaw45FactName =    "rotationYaw45";
-const char* VehicleDistanceSensorFactGroup::_rotationYaw90FactName =    "rotationYaw90";
-const char* VehicleDistanceSensorFactGroup::_rotationYaw135FactName =   "rotationYaw135";
-const char* VehicleDistanceSensorFactGroup::_rotationYaw180FactName =   "rotationYaw180";
-const char* VehicleDistanceSensorFactGroup::_rotationYaw225FactName =   "rotationYaw225";
-const char* VehicleDistanceSensorFactGroup::_rotationYaw270FactName =   "rotationYaw270";
-const char* VehicleDistanceSensorFactGroup::_rotationYaw315FactName =   "rotationYaw315";
-const char* VehicleDistanceSensorFactGroup::_rotationPitch90FactName =  "rotationPitch90";
-const char* VehicleDistanceSensorFactGroup::_rotationPitch270FactName = "rotationPitch270";
-const char* VehicleDistanceSensorFactGroup::_minDistanceFactName =      "minDistance";
-const char* VehicleDistanceSensorFactGroup::_maxDistanceFactName =      "maxDistance";
-
 VehicleDistanceSensorFactGroup::VehicleDistanceSensorFactGroup(QObject* parent)
     : FactGroup             (1000, ":/json/Vehicle/DistanceSensorFact.json", parent)
     , _rotationNoneFact     (0, _rotationNoneFactName,      FactMetaData::valueTypeDouble)

--- a/src/Vehicle/VehicleDistanceSensorFactGroup.h
+++ b/src/Vehicle/VehicleDistanceSensorFactGroup.h
@@ -50,20 +50,20 @@ public:
     // Overrides from FactGroup
     void handleMessage(Vehicle* vehicle, mavlink_message_t& message) override;
 
-    static const char* _rotationNoneFactName;
-    static const char* _rotationYaw45FactName;
-    static const char* _rotationYaw90FactName;
-    static const char* _rotationYaw135FactName;
-    static const char* _rotationYaw180FactName;
-    static const char* _rotationYaw225FactName;
-    static const char* _rotationYaw270FactName;
-    static const char* _rotationYaw315FactName;
-    static const char* _rotationPitch90FactName;
-    static const char* _rotationPitch270FactName;
-    static const char* _minDistanceFactName;
-    static const char* _maxDistanceFactName;
-
 private:
+    const QString _rotationNoneFactName =     QStringLiteral("rotationNone");
+    const QString _rotationYaw45FactName =    QStringLiteral("rotationYaw45");
+    const QString _rotationYaw90FactName =    QStringLiteral("rotationYaw90");
+    const QString _rotationYaw135FactName =   QStringLiteral("rotationYaw135");
+    const QString _rotationYaw180FactName =   QStringLiteral("rotationYaw180");
+    const QString _rotationYaw225FactName =   QStringLiteral("rotationYaw225");
+    const QString _rotationYaw270FactName =   QStringLiteral("rotationYaw270");
+    const QString _rotationYaw315FactName =   QStringLiteral("rotationYaw315");
+    const QString _rotationPitch90FactName =  QStringLiteral("rotationPitch90");
+    const QString _rotationPitch270FactName = QStringLiteral("rotationPitch270");
+    const QString _minDistanceFactName =      QStringLiteral("minDistance");
+    const QString _maxDistanceFactName =      QStringLiteral("maxDistance");
+
     Fact _rotationNoneFact;
     Fact _rotationYaw45Fact;
     Fact _rotationYaw90Fact;

--- a/src/Vehicle/VehicleEFIFactGroup.cc
+++ b/src/Vehicle/VehicleEFIFactGroup.cc
@@ -1,24 +1,6 @@
 #include "VehicleEFIFactGroup.h"
 #include "Vehicle.h"
 
-const char* VehicleEFIFactGroup::_healthFactName =          "health";
-const char* VehicleEFIFactGroup::_ecuIndexFactName =        "ecuIndex";
-const char* VehicleEFIFactGroup::_rpmFactName =             "rpm";
-const char* VehicleEFIFactGroup::_fuelConsumedFactName =    "fuelConsumed";
-const char* VehicleEFIFactGroup::_fuelFlowFactName =        "fuelFlow";
-const char* VehicleEFIFactGroup::_engineLoadFactName =      "engineLoad";
-const char* VehicleEFIFactGroup::_throttlePosFactName =     "throttlePos";
-const char* VehicleEFIFactGroup::_sparkTimeFactName =       "sparkTime";
-const char* VehicleEFIFactGroup::_baroPressFactName =       "baroPress";
-const char* VehicleEFIFactGroup::_intakePressFactName =     "intakePress";
-const char* VehicleEFIFactGroup::_intakeTempFactName =      "intakeTemp";
-const char* VehicleEFIFactGroup::_cylinderTempFactName =    "cylinderTemp";
-const char* VehicleEFIFactGroup::_ignTimeFactName =         "ignTime";
-const char* VehicleEFIFactGroup::_injTimeFactName =         "injTime";
-const char* VehicleEFIFactGroup::_exGasTempFactName =       "exGasTemp";
-const char* VehicleEFIFactGroup::_throttleOutFactName =     "throttleOut";
-const char* VehicleEFIFactGroup::_ptCompFactName =          "ptComp";
-
 
 VehicleEFIFactGroup::VehicleEFIFactGroup(QObject* parent)
     : FactGroup(1000, ":/json/Vehicle/EFIFact.json", parent)

--- a/src/Vehicle/VehicleEFIFactGroup.h
+++ b/src/Vehicle/VehicleEFIFactGroup.h
@@ -51,27 +51,26 @@ public:
     // Overrides from FactGroup
     virtual void handleMessage(Vehicle* vehicle, mavlink_message_t& message) override;
 
-    static const char* _healthFactName;
-    static const char* _ecuIndexFactName;
-    static const char* _rpmFactName;
-    static const char* _fuelConsumedFactName;
-    static const char* _fuelFlowFactName;
-    static const char* _engineLoadFactName;
-    static const char* _throttlePosFactName;
-    static const char* _sparkTimeFactName;
-    static const char* _baroPressFactName;
-    static const char* _intakePressFactName;
-    static const char* _intakeTempFactName;
-    static const char* _cylinderTempFactName;
-    static const char* _ignTimeFactName;
-    static const char* _injTimeFactName;
-    static const char* _exGasTempFactName;
-    static const char* _throttleOutFactName;
-    static const char* _ptCompFactName;
-    static const char* _ignVoltageFactName;
-
-protected:
+private:
     void _handleEFIStatus(mavlink_message_t& message);
+
+    const QString _healthFactName =         QStringLiteral("health");
+    const QString _ecuIndexFactName =       QStringLiteral("ecuIndex");
+    const QString _rpmFactName =            QStringLiteral("rpm");
+    const QString _fuelConsumedFactName =   QStringLiteral("fuelConsumed");
+    const QString _fuelFlowFactName =       QStringLiteral("fuelFlow");
+    const QString _engineLoadFactName =     QStringLiteral("engineLoad");
+    const QString _throttlePosFactName =    QStringLiteral("throttlePos");
+    const QString _sparkTimeFactName =      QStringLiteral("sparkTime");
+    const QString _baroPressFactName =      QStringLiteral("baroPress");
+    const QString _intakePressFactName =    QStringLiteral("intakePress");
+    const QString _intakeTempFactName =     QStringLiteral("intakeTemp");
+    const QString _cylinderTempFactName =   QStringLiteral("cylinderTemp");
+    const QString _ignTimeFactName =        QStringLiteral("ignTime");
+    const QString _injTimeFactName =        QStringLiteral("injTime");
+    const QString _exGasTempFactName =      QStringLiteral("exGasTemp");
+    const QString _throttleOutFactName =    QStringLiteral("throttleOut");
+    const QString _ptCompFactName =         QStringLiteral("ptComp");
 
     Fact _healthFact;
     Fact _ecuIndexFact;

--- a/src/Vehicle/VehicleEscStatusFactGroup.cc
+++ b/src/Vehicle/VehicleEscStatusFactGroup.cc
@@ -10,23 +10,6 @@
 #include "VehicleEscStatusFactGroup.h"
 #include "Vehicle.h"
 
-const char* VehicleEscStatusFactGroup::_indexFactName =                             "index";
-
-const char* VehicleEscStatusFactGroup::_rpmFirstFactName =                          "rpm1";
-const char* VehicleEscStatusFactGroup::_rpmSecondFactName =                         "rpm2";
-const char* VehicleEscStatusFactGroup::_rpmThirdFactName =                          "rpm3";
-const char* VehicleEscStatusFactGroup::_rpmFourthFactName =                         "rpm4";
-
-const char* VehicleEscStatusFactGroup::_currentFirstFactName =                      "current1";
-const char* VehicleEscStatusFactGroup::_currentSecondFactName =                     "current2";
-const char* VehicleEscStatusFactGroup::_currentThirdFactName =                      "current3";
-const char* VehicleEscStatusFactGroup::_currentFourthFactName =                     "current4";
-
-const char* VehicleEscStatusFactGroup::_voltageFirstFactName =                      "voltage1";
-const char* VehicleEscStatusFactGroup::_voltageSecondFactName =                     "voltage2";
-const char* VehicleEscStatusFactGroup::_voltageThirdFactName =                      "voltage3";
-const char* VehicleEscStatusFactGroup::_voltageFourthFactName =                     "voltage4";
-
 VehicleEscStatusFactGroup::VehicleEscStatusFactGroup(QObject* parent)
     : FactGroup                         (1000, ":/json/Vehicle/EscStatusFactGroup.json", parent)
     , _indexFact                        (0, _indexFactName,                         FactMetaData::valueTypeUint8)

--- a/src/Vehicle/VehicleEscStatusFactGroup.h
+++ b/src/Vehicle/VehicleEscStatusFactGroup.h
@@ -58,23 +58,24 @@ public:
     // Overrides from FactGroup
     void handleMessage(Vehicle* vehicle, mavlink_message_t& message) override;
 
-    static const char* _indexFactName;
-
-    static const char* _rpmFirstFactName;
-    static const char* _rpmSecondFactName;
-    static const char* _rpmThirdFactName;
-    static const char* _rpmFourthFactName;
-
-    static const char* _currentFirstFactName;
-    static const char* _currentSecondFactName;
-    static const char* _currentThirdFactName;
-    static const char* _currentFourthFactName;
-
-    static const char* _voltageFirstFactName;
-    static const char* _voltageSecondFactName;
-    static const char* _voltageThirdFactName;
-    static const char* _voltageFourthFactName;
 private:
+    const QString _indexFactName =                            QStringLiteral("index");
+
+    const QString _rpmFirstFactName =                         QStringLiteral("rpm1");
+    const QString _rpmSecondFactName =                        QStringLiteral("rpm2");
+    const QString _rpmThirdFactName =                         QStringLiteral("rpm3");
+    const QString _rpmFourthFactName =                        QStringLiteral("rpm4");
+
+    const QString _currentFirstFactName =                     QStringLiteral("current1");
+    const QString _currentSecondFactName =                    QStringLiteral("current2");
+    const QString _currentThirdFactName =                     QStringLiteral("current3");
+    const QString _currentFourthFactName =                    QStringLiteral("current4");
+
+    const QString _voltageFirstFactName =                     QStringLiteral("voltage1");
+    const QString _voltageSecondFactName =                    QStringLiteral("voltage2");
+    const QString _voltageThirdFactName =                     QStringLiteral("voltage3");
+    const QString _voltageFourthFactName =                    QStringLiteral("voltage4");
+
     Fact _indexFact;
 
     Fact _rpmFirstFact;

--- a/src/Vehicle/VehicleEstimatorStatusFactGroup.cc
+++ b/src/Vehicle/VehicleEstimatorStatusFactGroup.cc
@@ -10,27 +10,6 @@
 #include "VehicleEstimatorStatusFactGroup.h"
 #include "Vehicle.h"
 
-const char* VehicleEstimatorStatusFactGroup::_goodAttitudeEstimateFactName =        "goodAttitudeEsimate";
-const char* VehicleEstimatorStatusFactGroup::_goodHorizVelEstimateFactName =        "goodHorizVelEstimate";
-const char* VehicleEstimatorStatusFactGroup::_goodVertVelEstimateFactName =         "goodVertVelEstimate";
-const char* VehicleEstimatorStatusFactGroup::_goodHorizPosRelEstimateFactName =     "goodHorizPosRelEstimate";
-const char* VehicleEstimatorStatusFactGroup::_goodHorizPosAbsEstimateFactName =     "goodHorizPosAbsEstimate";
-const char* VehicleEstimatorStatusFactGroup::_goodVertPosAbsEstimateFactName =      "goodVertPosAbsEstimate";
-const char* VehicleEstimatorStatusFactGroup::_goodVertPosAGLEstimateFactName =      "goodVertPosAGLEstimate";
-const char* VehicleEstimatorStatusFactGroup::_goodConstPosModeEstimateFactName =    "goodConstPosModeEstimate";
-const char* VehicleEstimatorStatusFactGroup::_goodPredHorizPosRelEstimateFactName = "goodPredHorizPosRelEstimate";
-const char* VehicleEstimatorStatusFactGroup::_goodPredHorizPosAbsEstimateFactName = "goodPredHorizPosAbsEstimate";
-const char* VehicleEstimatorStatusFactGroup::_gpsGlitchFactName =                   "gpsGlitch";
-const char* VehicleEstimatorStatusFactGroup::_accelErrorFactName =                  "accelError";
-const char* VehicleEstimatorStatusFactGroup::_velRatioFactName =                    "velRatio";
-const char* VehicleEstimatorStatusFactGroup::_horizPosRatioFactName =               "horizPosRatio";
-const char* VehicleEstimatorStatusFactGroup::_vertPosRatioFactName =                "vertPosRatio";
-const char* VehicleEstimatorStatusFactGroup::_magRatioFactName =                    "magRatio";
-const char* VehicleEstimatorStatusFactGroup::_haglRatioFactName =                   "haglRatio";
-const char* VehicleEstimatorStatusFactGroup::_tasRatioFactName =                    "tasRatio";
-const char* VehicleEstimatorStatusFactGroup::_horizPosAccuracyFactName =            "horizPosAccuracy";
-const char* VehicleEstimatorStatusFactGroup::_vertPosAccuracyFactName =             "vertPosAccuracy";
-
 VehicleEstimatorStatusFactGroup::VehicleEstimatorStatusFactGroup(QObject* parent)
     : FactGroup                         (500, ":/json/Vehicle/EstimatorStatusFactGroup.json", parent)
     , _goodAttitudeEstimateFact         (0, _goodAttitudeEstimateFactName,          FactMetaData::valueTypeBool)

--- a/src/Vehicle/VehicleEstimatorStatusFactGroup.h
+++ b/src/Vehicle/VehicleEstimatorStatusFactGroup.h
@@ -66,28 +66,28 @@ public:
     // Overrides from FactGroup
     void handleMessage(Vehicle* vehicle, mavlink_message_t& message) override;
 
-    static const char* _goodAttitudeEstimateFactName;
-    static const char* _goodHorizVelEstimateFactName;
-    static const char* _goodVertVelEstimateFactName;
-    static const char* _goodHorizPosRelEstimateFactName;
-    static const char* _goodHorizPosAbsEstimateFactName;
-    static const char* _goodVertPosAbsEstimateFactName;
-    static const char* _goodVertPosAGLEstimateFactName;
-    static const char* _goodConstPosModeEstimateFactName;
-    static const char* _goodPredHorizPosRelEstimateFactName;
-    static const char* _goodPredHorizPosAbsEstimateFactName;
-    static const char* _gpsGlitchFactName;
-    static const char* _accelErrorFactName;
-    static const char* _velRatioFactName;
-    static const char* _horizPosRatioFactName;
-    static const char* _vertPosRatioFactName;
-    static const char* _magRatioFactName;
-    static const char* _haglRatioFactName;
-    static const char* _tasRatioFactName;
-    static const char* _horizPosAccuracyFactName;
-    static const char* _vertPosAccuracyFactName;
-
 private:
+    const QString _goodAttitudeEstimateFactName =        QStringLiteral("goodAttitudeEsimate");
+    const QString _goodHorizVelEstimateFactName =        QStringLiteral("goodHorizVelEstimate");
+    const QString _goodVertVelEstimateFactName =         QStringLiteral("goodVertVelEstimate");
+    const QString _goodHorizPosRelEstimateFactName =     QStringLiteral("goodHorizPosRelEstimate");
+    const QString _goodHorizPosAbsEstimateFactName =     QStringLiteral("goodHorizPosAbsEstimate");
+    const QString _goodVertPosAbsEstimateFactName =      QStringLiteral("goodVertPosAbsEstimate");
+    const QString _goodVertPosAGLEstimateFactName =      QStringLiteral("goodVertPosAGLEstimate");
+    const QString _goodConstPosModeEstimateFactName =    QStringLiteral("goodConstPosModeEstimate");
+    const QString _goodPredHorizPosRelEstimateFactName = QStringLiteral("goodPredHorizPosRelEstimate");
+    const QString _goodPredHorizPosAbsEstimateFactName = QStringLiteral("goodPredHorizPosAbsEstimate");
+    const QString _gpsGlitchFactName =                   QStringLiteral("gpsGlitch");
+    const QString _accelErrorFactName =                  QStringLiteral("accelError");
+    const QString _velRatioFactName =                    QStringLiteral("velRatio");
+    const QString _horizPosRatioFactName =               QStringLiteral("horizPosRatio");
+    const QString _vertPosRatioFactName =                QStringLiteral("vertPosRatio");
+    const QString _magRatioFactName =                    QStringLiteral("magRatio");
+    const QString _haglRatioFactName =                   QStringLiteral("haglRatio");
+    const QString _tasRatioFactName =                    QStringLiteral("tasRatio");
+    const QString _horizPosAccuracyFactName =            QStringLiteral("horizPosAccuracy");
+    const QString _vertPosAccuracyFactName =             QStringLiteral("vertPosAccuracy");
+
     Fact _goodAttitudeEstimateFact;
     Fact _goodHorizVelEstimateFact;
     Fact _goodVertVelEstimateFact;

--- a/src/Vehicle/VehicleGPSFactGroup.cc
+++ b/src/Vehicle/VehicleGPSFactGroup.cc
@@ -11,15 +11,6 @@
 #include "Vehicle.h"
 #include "QGCGeo.h"
 
-const char* VehicleGPSFactGroup::_latFactName =                 "lat";
-const char* VehicleGPSFactGroup::_lonFactName =                 "lon";
-const char* VehicleGPSFactGroup::_mgrsFactName =                "mgrs";
-const char* VehicleGPSFactGroup::_hdopFactName =                "hdop";
-const char* VehicleGPSFactGroup::_vdopFactName =                "vdop";
-const char* VehicleGPSFactGroup::_courseOverGroundFactName =    "courseOverGround";
-const char* VehicleGPSFactGroup::_countFactName =               "count";
-const char* VehicleGPSFactGroup::_lockFactName =                "lock";
-
 VehicleGPSFactGroup::VehicleGPSFactGroup(QObject* parent)
     : FactGroup(1000, ":/json/Vehicle/GPSFact.json", parent)
     , _latFact              (0, _latFactName,               FactMetaData::valueTypeDouble)

--- a/src/Vehicle/VehicleGPSFactGroup.h
+++ b/src/Vehicle/VehicleGPSFactGroup.h
@@ -40,19 +40,19 @@ public:
     // Overrides from FactGroup
     virtual void handleMessage(Vehicle* vehicle, mavlink_message_t& message) override;
 
-    static const char* _latFactName;
-    static const char* _lonFactName;
-    static const char* _mgrsFactName;
-    static const char* _hdopFactName;
-    static const char* _vdopFactName;
-    static const char* _courseOverGroundFactName;
-    static const char* _countFactName;
-    static const char* _lockFactName;
-
 protected:
     void _handleGpsRawInt   (mavlink_message_t& message);
     void _handleHighLatency (mavlink_message_t& message);
     void _handleHighLatency2(mavlink_message_t& message);
+
+    const QString _latFactName =                 QStringLiteral("lat");
+    const QString _lonFactName =                 QStringLiteral("lon");
+    const QString _mgrsFactName =                QStringLiteral("mgrs");
+    const QString _hdopFactName =                QStringLiteral("hdop");
+    const QString _vdopFactName =                QStringLiteral("vdop");
+    const QString _courseOverGroundFactName =    QStringLiteral("courseOverGround");
+    const QString _countFactName =               QStringLiteral("count");
+    const QString _lockFactName =                QStringLiteral("lock");
 
     Fact _latFact;
     Fact _lonFact;

--- a/src/Vehicle/VehicleGeneratorFactGroup.cc
+++ b/src/Vehicle/VehicleGeneratorFactGroup.cc
@@ -2,18 +2,6 @@
 #include "Vehicle.h"
 #include <bitset>
 
-const char* VehicleGeneratorFactGroup::_statusFactName =                "status";
-const char* VehicleGeneratorFactGroup::_genSpeedFactName =              "genSpeed";
-const char* VehicleGeneratorFactGroup::_batteryCurrentFactName =        "batteryCurrent";
-const char* VehicleGeneratorFactGroup::_loadCurrentFactName =           "loadCurrent";
-const char* VehicleGeneratorFactGroup::_powerGeneratedFactName =        "powerGenerated";
-const char* VehicleGeneratorFactGroup::_busVoltageFactName =            "busVoltage";
-const char* VehicleGeneratorFactGroup::_rectifierTempFactName =         "rectifierTemp";
-const char* VehicleGeneratorFactGroup::_batCurrentSetpointFactName =    "batCurrentSetpoint";
-const char* VehicleGeneratorFactGroup::_genTempFactName =               "genTemp";
-const char* VehicleGeneratorFactGroup::_runtimeFactName =               "runtime";
-const char* VehicleGeneratorFactGroup::_timeMaintenanceFactName =       "timeMaintenance";
-
 VehicleGeneratorFactGroup::VehicleGeneratorFactGroup(QObject* parent)
     : FactGroup(1000, ":/json/Vehicle/GeneratorFact.json", parent)
     , _statusFact               (0, _statusFactName,                FactMetaData::valueTypeUint64)

--- a/src/Vehicle/VehicleGeneratorFactGroup.h
+++ b/src/Vehicle/VehicleGeneratorFactGroup.h
@@ -39,24 +39,24 @@ public:
     // Overrides from FactGroup
     virtual void handleMessage(Vehicle* vehicle, mavlink_message_t& message) override;
 
-    static const char* _statusFactName;
-    static const char* _genSpeedFactName;
-    static const char* _batteryCurrentFactName;
-    static const char* _loadCurrentFactName;
-    static const char* _powerGeneratedFactName;
-    static const char* _busVoltageFactName;
-    static const char* _rectifierTempFactName;
-    static const char* _batCurrentSetpointFactName;
-    static const char* _genTempFactName;
-    static const char* _runtimeFactName;
-    static const char* _timeMaintenanceFactName;
-
 signals:
     void flagsListGeneratorChanged();
 
 protected:
     void _handleGeneratorStatus(mavlink_message_t& message);
     void _updateGeneratorFlags();
+
+    const QString _statusFactName =                QStringLiteral("status");
+    const QString _genSpeedFactName =              QStringLiteral("genSpeed");
+    const QString _batteryCurrentFactName =        QStringLiteral("batteryCurrent");
+    const QString _loadCurrentFactName =           QStringLiteral("loadCurrent");
+    const QString _powerGeneratedFactName =        QStringLiteral("powerGenerated");
+    const QString _busVoltageFactName =            QStringLiteral("busVoltage");
+    const QString _rectifierTempFactName =         QStringLiteral("rectifierTemp");
+    const QString _batCurrentSetpointFactName =    QStringLiteral("batCurrentSetpoint");
+    const QString _genTempFactName =               QStringLiteral("genTemp");
+    const QString _runtimeFactName =               QStringLiteral("runtime");
+    const QString _timeMaintenanceFactName =       QStringLiteral("timeMaintenance");
 
     Fact _statusFact;
     Fact _genSpeedFact;

--- a/src/Vehicle/VehicleHygrometerFactGroup.cc
+++ b/src/Vehicle/VehicleHygrometerFactGroup.cc
@@ -11,10 +11,6 @@
 #include "Vehicle.h"
 #include "QGCGeo.h"
 
-const char* VehicleHygrometerFactGroup::_hygroHumiFactName =      "humidity";
-const char* VehicleHygrometerFactGroup::_hygroTempFactName =    "temperature";
-const char* VehicleHygrometerFactGroup::_hygroIDFactName =    "hygrometerid";
-
 VehicleHygrometerFactGroup::VehicleHygrometerFactGroup(QObject* parent)
     : FactGroup(1000, ":/json/Vehicle/HygrometerFact.json", parent)
     , _hygroTempFact             (0, _hygroTempFactName,         FactMetaData::valueTypeDouble)

--- a/src/Vehicle/VehicleHygrometerFactGroup.h
+++ b/src/Vehicle/VehicleHygrometerFactGroup.h
@@ -30,12 +30,12 @@ public:
     // Overrides from FactGroup
     virtual void handleMessage(Vehicle* vehicle, mavlink_message_t& message) override;
 
-    static const char* _hygroIDFactName;
-    static const char* _hygroTempFactName;
-    static const char* _hygroHumiFactName;
-
 protected:
     void _handleHygrometerSensor        (mavlink_message_t& message);
+
+    const QString _hygroHumiFactName =      QStringLiteral("humidity");
+    const QString _hygroTempFactName =    QStringLiteral("temperature");
+    const QString _hygroIDFactName =    QStringLiteral("hygrometerid");
 
     Fact _hygroTempFact;
     Fact _hygroHumiFact;

--- a/src/Vehicle/VehicleLocalPositionFactGroup.cc
+++ b/src/Vehicle/VehicleLocalPositionFactGroup.cc
@@ -12,13 +12,6 @@
 
 #include <QtMath>
 
-const char* VehicleLocalPositionFactGroup::_xFactName =     "x";
-const char* VehicleLocalPositionFactGroup::_yFactName =     "y";
-const char* VehicleLocalPositionFactGroup::_zFactName =     "z";
-const char* VehicleLocalPositionFactGroup::_vxFactName =    "vx";
-const char* VehicleLocalPositionFactGroup::_vyFactName =    "vy";
-const char* VehicleLocalPositionFactGroup::_vzFactName =    "vz";
-
 VehicleLocalPositionFactGroup::VehicleLocalPositionFactGroup(QObject* parent)
     : FactGroup     (1000, ":/json/Vehicle/LocalPositionFact.json", parent)
     , _xFact    (0, _xFactName,     FactMetaData::valueTypeDouble)

--- a/src/Vehicle/VehicleLocalPositionFactGroup.h
+++ b/src/Vehicle/VehicleLocalPositionFactGroup.h
@@ -36,14 +36,14 @@ public:
     // Overrides from FactGroup
     void handleMessage(Vehicle* vehicle, mavlink_message_t& message) override;
 
-    static const char* _xFactName;
-    static const char* _yFactName;
-    static const char* _zFactName;
-    static const char* _vxFactName;
-    static const char* _vyFactName;
-    static const char* _vzFactName;
-
 private:
+    const QString _xFactName =     QStringLiteral("x");
+    const QString _yFactName =     QStringLiteral("y");
+    const QString _zFactName =     QStringLiteral("z");
+    const QString _vxFactName =    QStringLiteral("vx");
+    const QString _vyFactName =    QStringLiteral("vy");
+    const QString _vzFactName =    QStringLiteral("vz");
+
     Fact _xFact;
     Fact _yFact;
     Fact _zFact;

--- a/src/Vehicle/VehicleLocalPositionSetpointFactGroup.cc
+++ b/src/Vehicle/VehicleLocalPositionSetpointFactGroup.cc
@@ -12,13 +12,6 @@
 
 #include <QtMath>
 
-const char* VehicleLocalPositionSetpointFactGroup::_xFactName =     "x";
-const char* VehicleLocalPositionSetpointFactGroup::_yFactName =     "y";
-const char* VehicleLocalPositionSetpointFactGroup::_zFactName =     "z";
-const char* VehicleLocalPositionSetpointFactGroup::_vxFactName =    "vx";
-const char* VehicleLocalPositionSetpointFactGroup::_vyFactName =    "vy";
-const char* VehicleLocalPositionSetpointFactGroup::_vzFactName =    "vz";
-
 VehicleLocalPositionSetpointFactGroup::VehicleLocalPositionSetpointFactGroup(QObject* parent)
     : FactGroup     (1000, ":/json/Vehicle/LocalPositionSetpointFact.json", parent)
     , _xFact    (0, _xFactName,     FactMetaData::valueTypeDouble)

--- a/src/Vehicle/VehicleLocalPositionSetpointFactGroup.h
+++ b/src/Vehicle/VehicleLocalPositionSetpointFactGroup.h
@@ -36,14 +36,14 @@ public:
     // Overrides from FactGroup
     void handleMessage(Vehicle* vehicle, mavlink_message_t& message) override;
 
-    static const char* _xFactName;
-    static const char* _yFactName;
-    static const char* _zFactName;
-    static const char* _vxFactName;
-    static const char* _vyFactName;
-    static const char* _vzFactName;
-
 private:
+    const QString _xFactName =     QStringLiteral("x");
+    const QString _yFactName =     QStringLiteral("y");
+    const QString _zFactName =     QStringLiteral("z");
+    const QString _vxFactName =    QStringLiteral("vx");
+    const QString _vyFactName =    QStringLiteral("vy");
+    const QString _vzFactName =    QStringLiteral("vz");
+
     Fact _xFact;
     Fact _yFact;
     Fact _zFact;

--- a/src/Vehicle/VehicleSetpointFactGroup.cc
+++ b/src/Vehicle/VehicleSetpointFactGroup.cc
@@ -12,13 +12,6 @@
 
 #include <QtMath>
 
-const char* VehicleSetpointFactGroup::_rollFactName =       "roll";
-const char* VehicleSetpointFactGroup::_pitchFactName =      "pitch";
-const char* VehicleSetpointFactGroup::_yawFactName =        "yaw";
-const char* VehicleSetpointFactGroup::_rollRateFactName =   "rollRate";
-const char* VehicleSetpointFactGroup::_pitchRateFactName =  "pitchRate";
-const char* VehicleSetpointFactGroup::_yawRateFactName =    "yawRate";
-
 VehicleSetpointFactGroup::VehicleSetpointFactGroup(QObject* parent)
     : FactGroup     (1000, ":/json/Vehicle/SetpointFact.json", parent)
     , _rollFact     (0, _rollFactName,      FactMetaData::valueTypeDouble)

--- a/src/Vehicle/VehicleSetpointFactGroup.h
+++ b/src/Vehicle/VehicleSetpointFactGroup.h
@@ -36,14 +36,14 @@ public:
     // Overrides from FactGroup
     void handleMessage(Vehicle* vehicle, mavlink_message_t& message) override;
 
-    static const char* _rollFactName;
-    static const char* _pitchFactName;
-    static const char* _yawFactName;
-    static const char* _rollRateFactName;
-    static const char* _pitchRateFactName;
-    static const char* _yawRateFactName;
-
 private:
+    const QString _rollFactName =       QStringLiteral("roll");
+    const QString _pitchFactName =      QStringLiteral("pitch");
+    const QString _yawFactName =        QStringLiteral("yaw");
+    const QString _rollRateFactName =   QStringLiteral("rollRate");
+    const QString _pitchRateFactName =  QStringLiteral("pitchRate");
+    const QString _yawRateFactName =    QStringLiteral("yawRate");
+
     Fact _rollFact;
     Fact _pitchFact;
     Fact _yawFact;

--- a/src/Vehicle/VehicleTemperatureFactGroup.cc
+++ b/src/Vehicle/VehicleTemperatureFactGroup.cc
@@ -10,10 +10,6 @@
 #include "VehicleSetpointFactGroup.h"
 #include "Vehicle.h"
 
-const char* VehicleTemperatureFactGroup::_temperature1FactName =      "temperature1";
-const char* VehicleTemperatureFactGroup::_temperature2FactName =      "temperature2";
-const char* VehicleTemperatureFactGroup::_temperature3FactName =      "temperature3";
-
 VehicleTemperatureFactGroup::VehicleTemperatureFactGroup(QObject* parent)
     : FactGroup(1000, ":/json/Vehicle/TemperatureFact.json", parent)
     , _temperature1Fact    (0, _temperature1FactName,     FactMetaData::valueTypeDouble)

--- a/src/Vehicle/VehicleTemperatureFactGroup.h
+++ b/src/Vehicle/VehicleTemperatureFactGroup.h
@@ -30,20 +30,16 @@ public:
     // Overrides from FactGroup
     void handleMessage(Vehicle* vehicle, mavlink_message_t& message) override;
 
-    static const char* _temperature1FactName;
-    static const char* _temperature2FactName;
-    static const char* _temperature3FactName;
-
-    static const char* _settingsGroup;
-
-    static const double _temperatureUnavailable;
-
 private:
     void _handleScaledPressure  (mavlink_message_t& message);
     void _handleScaledPressure2 (mavlink_message_t& message);
     void _handleScaledPressure3 (mavlink_message_t& message);
     void _handleHighLatency     (mavlink_message_t& message);
     void _handleHighLatency2    (mavlink_message_t& message);
+
+    const QString _temperature1FactName =      QStringLiteral("temperature1");
+    const QString _temperature2FactName =      QStringLiteral("temperature2");
+    const QString _temperature3FactName =      QStringLiteral("temperature3");
 
     Fact            _temperature1Fact;
     Fact            _temperature2Fact;

--- a/src/Vehicle/VehicleVibrationFactGroup.cc
+++ b/src/Vehicle/VehicleVibrationFactGroup.cc
@@ -10,13 +10,6 @@
 #include "VehicleVibrationFactGroup.h"
 #include "Vehicle.h"
 
-const char* VehicleVibrationFactGroup::_xAxisFactName =      "xAxis";
-const char* VehicleVibrationFactGroup::_yAxisFactName =      "yAxis";
-const char* VehicleVibrationFactGroup::_zAxisFactName =      "zAxis";
-const char* VehicleVibrationFactGroup::_clipCount1FactName = "clipCount1";
-const char* VehicleVibrationFactGroup::_clipCount2FactName = "clipCount2";
-const char* VehicleVibrationFactGroup::_clipCount3FactName = "clipCount3";
-
 VehicleVibrationFactGroup::VehicleVibrationFactGroup(QObject* parent)
     : FactGroup         (1000, ":/json/Vehicle/VibrationFact.json", parent)
     , _xAxisFact        (0, _xAxisFactName,         FactMetaData::valueTypeDouble)

--- a/src/Vehicle/VehicleVibrationFactGroup.h
+++ b/src/Vehicle/VehicleVibrationFactGroup.h
@@ -36,14 +36,16 @@ public:
     // Overrides from FactGroup
     void handleMessage(Vehicle* vehicle, mavlink_message_t& message) override;
 
-    static const char* _xAxisFactName;
-    static const char* _yAxisFactName;
-    static const char* _zAxisFactName;
-    static const char* _clipCount1FactName;
-    static const char* _clipCount2FactName;
-    static const char* _clipCount3FactName;
+
 
 private:
+    const QString _xAxisFactName =      QStringLiteral("xAxis");
+    const QString _yAxisFactName =      QStringLiteral("yAxis");
+    const QString _zAxisFactName =      QStringLiteral("zAxis");
+    const QString _clipCount1FactName = QStringLiteral("clipCount1");
+    const QString _clipCount2FactName = QStringLiteral("clipCount2");
+    const QString _clipCount3FactName = QStringLiteral("clipCount3");
+
     Fact        _xAxisFact;
     Fact        _yAxisFact;
     Fact        _zAxisFact;

--- a/src/Vehicle/VehicleWindFactGroup.cc
+++ b/src/Vehicle/VehicleWindFactGroup.cc
@@ -12,10 +12,6 @@
 
 #include <QtMath>
 
-const char* VehicleWindFactGroup::_directionFactName =      "direction";
-const char* VehicleWindFactGroup::_speedFactName =          "speed";
-const char* VehicleWindFactGroup::_verticalSpeedFactName =  "verticalSpeed";
-
 VehicleWindFactGroup::VehicleWindFactGroup(QObject* parent)
     : FactGroup(1000, ":/json/Vehicle/WindFact.json", parent)
     , _directionFact    (0, _directionFactName,     FactMetaData::valueTypeDouble)

--- a/src/Vehicle/VehicleWindFactGroup.h
+++ b/src/Vehicle/VehicleWindFactGroup.h
@@ -30,10 +30,6 @@ public:
     // Overrides from FactGroup
     void handleMessage(Vehicle* vehicle, mavlink_message_t& message) override;
 
-    static const char* _directionFactName;
-    static const char* _speedFactName;
-    static const char* _verticalSpeedFactName;
-
 private:
     void _handleHighLatency (mavlink_message_t& message);
     void _handleHighLatency2(mavlink_message_t& message);
@@ -41,6 +37,10 @@ private:
 #if !defined(NO_ARDUPILOT_DIALECT)
     void _handleWind        (mavlink_message_t& message);
 #endif
+
+    const QString _directionFactName =      QStringLiteral("direction");
+    const QString _speedFactName =          QStringLiteral("speed");
+    const QString _verticalSpeedFactName =  QStringLiteral("verticalSpeed");
 
     Fact        _directionFact;
     Fact        _speedFact;


### PR DESCRIPTION
Instead of converting all of the char arrays to QStrings at vehicle creation when creating and adding facts, use QStringLiterals to do it during compilation. 