### PR TITLE
Don't append timestamps to caches

### DIFF
--- a/.github/workflows/linux_debug.yml
+++ b/.github/workflows/linux_debug.yml
@@ -40,7 +40,7 @@ jobs:
           key: ${{ runner.os }}-Debug
           restore-keys: ${{ runner.os }}-Debug
           max-size: "2G"
-          append-timestamp: true
+          append-timestamp: false
 
       - name: Install Qt
         uses: jurplel/install-qt-action@v3

--- a/.github/workflows/linux_release.yml
+++ b/.github/workflows/linux_release.yml
@@ -44,7 +44,7 @@ jobs:
           key: ${{ runner.os }}-Release
           restore-keys: ${{ runner.os }}-Release
           max-size: "2G"
-          append-timestamp: true
+          append-timestamp: false
 
       - name: Get all tags for correct version determination
         working-directory:  ${{ github.workspace }}

--- a/.github/workflows/macos_release.yml
+++ b/.github/workflows/macos_release.yml
@@ -42,7 +42,7 @@ jobs:
           key: ${{ runner.os }}-Release
           restore-keys: ${{ runner.os }}-Release
           max-size: "2G"
-          append-timestamp: true
+          append-timestamp: false
 
       - name: Get all tags for correct version determination
         working-directory:  ${{ github.workspace }}

--- a/.github/workflows/videoapp_linux.yml
+++ b/.github/workflows/videoapp_linux.yml
@@ -42,7 +42,7 @@ jobs:
           key: ${{ runner.os }}-Debug
           restore-keys: ${{ runner.os }}-Debug
           max-size: "1G"
-          append-timestamp: true
+          append-timestamp: false
 
       - name: Install Qt
         uses: jurplel/install-qt-action@v3

--- a/.github/workflows/windows_release.yml
+++ b/.github/workflows/windows_release.yml
@@ -42,7 +42,7 @@ jobs:
           key: ${{ runner.os }}-Release
           restore-keys: ${{ runner.os }}-Release
           max-size: "2G"
-          append-timestamp: true
+          append-timestamp: false
           variant: "sccache"
 
       - name: Get all tags for correct version determination


### PR DESCRIPTION
This will finally prevent it from creating so many caches,

Also, can you delete all the caches with timestamps appended again like `ccache-Linux-Debug-2024-02-20T19:46:10.843Z`? The Qt download caches are working well, but the timestamps are causing misses for the builds.