### PR TITLE
Rework instrument and video cluster

### DIFF
--- a/qgroundcontrol.qrc
+++ b/qgroundcontrol.qrc
@@ -220,6 +220,7 @@
         <file alias="QGroundControl/FactControls/qmldir">src/QmlControls/QGroundControl/FactControls/qmldir</file>
         <file alias="QGroundControl/FlightDisplay/FlightDisplayViewVideo.qml">src/FlightDisplay/FlightDisplayViewVideo.qml</file>
         <file alias="QGroundControl/FlightDisplay/FlyView.qml">src/FlightDisplay/FlyView.qml</file>
+        <file alias="QGroundControl/FlightDisplay/FlyViewBottomRightRowLayout.qml">src/FlightDisplay/FlyViewBottomRightRowLayout.qml</file>
         <file alias="QGroundControl/FlightDisplay/FlyViewCustomLayer.qml">src/FlightDisplay/FlyViewCustomLayer.qml</file>
         <file alias="QGroundControl/FlightDisplay/FlyViewInstrumentPanel.qml">src/FlightDisplay/FlyViewInstrumentPanel.qml</file>
         <file alias="QGroundControl/FlightDisplay/FlyViewMap.qml">src/FlightDisplay/FlyViewMap.qml</file>
@@ -229,6 +230,7 @@
         <file alias="QGroundControl/FlightDisplay/FlyViewToolBarIndicators.qml">src/ui/toolbar/FlyViewToolBarIndicators.qml</file>
         <file alias="QGroundControl/FlightDisplay/FlyViewToolStrip.qml">src/FlightDisplay/FlyViewToolStrip.qml</file>
         <file alias="QGroundControl/FlightDisplay/FlyViewToolStripActionList.qml">src/FlightDisplay/FlyViewToolStripActionList.qml</file>
+        <file alias="QGroundControl/FlightDisplay/FlyViewTopRightColumnLayout.qml">src/FlightDisplay/FlyViewTopRightColumnLayout.qml</file>
         <file alias="QGroundControl/FlightDisplay/FlyViewVideo.qml">src/FlightDisplay/FlyViewVideo.qml</file>
         <file alias="QGroundControl/FlightDisplay/FlyViewWidgetLayer.qml">src/FlightDisplay/FlyViewWidgetLayer.qml</file>
         <file alias="QGroundControl/FlightDisplay/GuidedActionActionList.qml">src/FlightDisplay/GuidedActionActionList.qml</file>

--- a/src/FlightDisplay/CMakeLists.txt
+++ b/src/FlightDisplay/CMakeLists.txt
@@ -6,6 +6,7 @@ add_custom_target(FligthDisplayQml
 		FlightDisplayViewDummy.qml
 		FlightDisplayViewUVC.qml
 		FlightDisplayViewVideo.qml
+        FlyViewBottomRightRowLayout.qml
 		FlyViewCustomLayer.qml
 		FlyViewInstrumentPanel.qml
 		FlyViewMap.qml
@@ -14,6 +15,7 @@ add_custom_target(FligthDisplayQml
 		FlyView.qml
 		FlyViewToolStripActionList.qml
 		FlyViewToolStrip.qml
+        FlyViewTopRightColumnLayout.qml
 		FlyViewVideo.qml
 		FlyViewWidgetLayer.qml
 		GuidedActionActionList.qml

--- a/src/FlightDisplay/FlyView.qml
+++ b/src/FlightDisplay/FlyView.qml
@@ -72,8 +72,8 @@ Item {
 
     QGCToolInsets {
         id:                     _toolInsets
-        leftEdgeBottomInset:    _pipOverlay.visible ? _pipOverlay.x + _pipOverlay.width : 0
-        bottomEdgeLeftInset:    _pipOverlay.visible ? parent.height - _pipOverlay.y : 0
+        leftEdgeBottomInset:    _pipOverlay.leftEdgeBottomInset
+        bottomEdgeLeftInset:    _pipOverlay.bottomEdgeLeftInset
     }
 
     FlyViewToolBar {
@@ -110,19 +110,17 @@ Item {
             visible:            !QGroundControl.videoManager.fullScreen
         }
 
-        // Development tool for visualizing the insets for a paticular layer, enable if needed
-        /*
+        // Development tool for visualizing the insets for a paticular layer, show if needed
         FlyViewInsetViewer {
             id:                     widgetLayerInsetViewer
             anchors.top:            parent.top
             anchors.bottom:         parent.bottom
             anchors.left:           parent.left
             anchors.right:          guidedValueSlider.visible ? guidedValueSlider.left : parent.right
-
             z:                      widgetLayer.z + 1
-
-            insetsToView:           customOverlay.totalToolInsets
-        }*/
+            insetsToView:           widgetLayer.totalToolInsets
+            visible:                false
+        }
 
         GuidedActionsController {
             id:                 guidedActionsController
@@ -183,6 +181,9 @@ Item {
             pipZOrder:              _pipItemZorder
             show:                   !QGroundControl.videoManager.fullScreen &&
                                         (videoControl.pipState.state === videoControl.pipState.pipState || mapControl.pipState.state === mapControl.pipState.pipState)
+
+            property real leftEdgeBottomInset: visible ? width + anchors.margins : 0
+            property real bottomEdgeLeftInset: visible ? height + anchors.margins : 0
         }
     }
 }

--- a/src/FlightDisplay/FlyViewBottomRightRowLayout.qml
+++ b/src/FlightDisplay/FlyViewBottomRightRowLayout.qml
@@ -8,16 +8,20 @@
  ****************************************************************************/
 
 import QtQuick
+import QtQuick.Layouts
 
 import QGroundControl
 import QGroundControl.Controls
+import QGroundControl.FlightDisplay
 
-SelectableControl {
-    z:                      QGroundControl.zOrderWidgets
-    selectionUIRightAnchor: true
-    selectedControl:        QGroundControl.settingsManager.flyViewSettings.instrumentQmlFile
+RowLayout {
+    TelemetryValuesBar {
+        Layout.alignment:   Qt.AlignBottom
+        extraWidth:         instrumentPanel.extraValuesWidth
+    }
 
-    property var  missionController:    _missionController
-    property real extraInset:           innerControl.extraInset
-    property real extraValuesWidth:     innerControl.extraValuesWidth
+    FlyViewInstrumentPanel {
+        id:         instrumentPanel
+        visible:    QGroundControl.corePlugin.options.flyView.showInstrumentPanel && _showSingleVehicleUI
+    }
 }

--- a/src/FlightDisplay/FlyViewTopRightColumnLayout.qml
+++ b/src/FlightDisplay/FlyViewTopRightColumnLayout.qml
@@ -1,0 +1,76 @@
+/****************************************************************************
+ *
+ * (c) 2009-2020 QGROUNDCONTROL PROJECT <http://www.qgroundcontrol.org>
+ *
+ * QGroundControl is licensed according to the terms in the file
+ * COPYING.md in the root of the source code directory.
+ *
+ ****************************************************************************/
+
+import QtQuick
+import QtQuick.Layouts
+
+import QGroundControl
+import QGroundControl.Controls
+import QGroundControl.FlightDisplay
+import QGroundControl.FlightMap
+import QGroundControl.Palette
+import QGroundControl.ScreenTools
+
+ColumnLayout {
+    Layout.fillHeight: true
+
+    ColumnLayout {
+        Layout.alignment:   Qt.AlignTop
+        Layout.fillHeight:  false
+        spacing:            parent.spacing
+
+        RowLayout {
+            id:                 multiVehiclePanelSelector
+            Layout.fillWidth:   false
+            Layout.fillHeight:  false
+            spacing:            ScreenTools.defaultFontPixelWidth
+            visible:            QGroundControl.multiVehicleManager.vehicles.count > 1 && QGroundControl.corePlugin.options.flyView.showMultiVehicleList
+
+            QGCMapPalette { id: mapPal; lightColors: true }
+
+            QGCRadioButton {
+                id:             singleVehicleRadio
+                text:           qsTr("Single")
+                checked:        _showSingleVehicleUI
+                onClicked:      _showSingleVehicleUI = true
+                textColor:      mapPal.text
+            }
+
+            QGCRadioButton {
+                text:           qsTr("Multi-Vehicle")
+                textColor:      mapPal.text
+                onClicked:      _showSingleVehicleUI = false
+            }
+        }
+
+        ColumnLayout {
+            Layout.fillHeight:      false
+            Layout.preferredWidth:  _rightPanelWidth
+            spacing:                parent.spacing
+            visible:                _showSingleVehicleUI
+
+            TerrainProgress {
+                Layout.fillWidth: true
+            }
+
+            PhotoVideoControl {
+                id:                     photoVideoControl
+                Layout.fillWidth:       true
+
+                property real rightEdgeCenterInset: visible ? parent.width - x : 0
+            }
+        }
+    }
+
+    MultiVehicleList {
+        Layout.preferredWidth:  _rightPanelWidth
+        Layout.fillHeight:      true
+        visible:                !_showSingleVehicleUI
+    }
+}

--- a/src/FlightDisplay/FlyViewWidgetLayer.qml
+++ b/src/FlightDisplay/FlyViewWidgetLayer.qml
@@ -47,23 +47,51 @@ Item {
     property rect   _centerViewport:        Qt.rect(0, 0, width, height)
     property real   _rightPanelWidth:       ScreenTools.defaultFontPixelWidth * 30
     property alias  _gripperMenu:           gripperOptions
+    property real   _layoutMargin:          ScreenTools.defaultFontPixelWidth * 0.75
+    property bool   _layoutSpacing:         ScreenTools.defaultFontPixelWidth
+    property bool   _showSingleVehicleUI:   true
 
     property bool utmspActTrigger
 
     QGCToolInsets {
         id:                     _totalToolInsets
         leftEdgeTopInset:       toolStrip.leftEdgeTopInset
-        leftEdgeCenterInset:    parentToolInsets.leftEdgeCenterInset
+        leftEdgeCenterInset:    toolStrip.leftEdgeCenterInset
         leftEdgeBottomInset:    virtualJoystickMultiTouch.visible ? virtualJoystickMultiTouch.leftEdgeBottomInset : parentToolInsets.leftEdgeBottomInset
-        rightEdgeTopInset:      instrumentPanel.rightEdgeTopInset
-        rightEdgeCenterInset:   (telemetryPanel.rightEdgeCenterInset > photoVideoControl.rightEdgeCenterInset) ? telemetryPanel.rightEdgeCenterInset : photoVideoControl.rightEdgeCenterInset
-        rightEdgeBottomInset:   virtualJoystickMultiTouch.visible ? virtualJoystickMultiTouch.rightEdgeBottomInset : parentToolInsets.rightEdgeBottomInset
+        rightEdgeTopInset:      topRightColumnLayout.rightEdgeTopInset
+        rightEdgeCenterInset:   topRightColumnLayout.rightEdgeCenterInset
+        rightEdgeBottomInset:   bottomRightRowLayout.rightEdgeBottomInset
         topEdgeLeftInset:       toolStrip.topEdgeLeftInset
         topEdgeCenterInset:     mapScale.topEdgeCenterInset
-        topEdgeRightInset:      instrumentPanel.topEdgeRightInset
+        topEdgeRightInset:      topRightColumnLayout.topEdgeRightInset
         bottomEdgeLeftInset:    virtualJoystickMultiTouch.visible ? virtualJoystickMultiTouch.bottomEdgeLeftInset : parentToolInsets.bottomEdgeLeftInset
-        bottomEdgeCenterInset:  telemetryPanel.bottomEdgeCenterInset
-        bottomEdgeRightInset:   virtualJoystickMultiTouch.visible ? virtualJoystickMultiTouch.bottomEdgeRightInset : parentToolInsets.bottomEdgeRightInset
+        bottomEdgeCenterInset:  bottomRightRowLayout.bottomEdgeCenterInset
+        bottomEdgeRightInset:   virtualJoystickMultiTouch.visible ? virtualJoystickMultiTouch.bottomEdgeRightInset : bottomRightRowLayout.bottomEdgeRightInset
+    }
+
+    FlyViewTopRightColumnLayout {
+        id:                 topRightColumnLayout
+        anchors.margins:    _layoutMargin
+        anchors.top:        parent.top
+        anchors.bottom:     bottomRightRowLayout.top
+        anchors.right:      parent.right
+        spacing:            _layoutSpacing
+
+        property real topEdgeRightInset:    childrenRect.height + _layoutMargin
+        property real rightEdgeTopInset:    width + _layoutMargin
+        property real rightEdgeCenterInset: rightEdgeTopInset
+    }
+
+    FlyViewBottomRightRowLayout {
+        id:                 bottomRightRowLayout
+        anchors.margins:    _layoutMargin
+        anchors.bottom:     parent.bottom
+        anchors.right:      parent.right
+        spacing:            _layoutSpacing
+
+        property real bottomEdgeRightInset:     height + _layoutMargin
+        property real bottomEdgeCenterInset:    bottomEdgeRightInset
+        property real rightEdgeBottomInset:     width + _layoutMargin
     }
 
     FlyViewMissionCompleteDialog {
@@ -72,42 +100,6 @@ Item {
         rallyPointController:   _rallyPointController
     }
 
-    Row {
-        id:                 multiVehiclePanelSelector
-        anchors.margins:    _toolsMargin
-        anchors.top:        parent.top
-        anchors.right:      parent.right
-        width:              _rightPanelWidth
-        spacing:            ScreenTools.defaultFontPixelWidth
-        visible:            QGroundControl.multiVehicleManager.vehicles.count > 1 && QGroundControl.corePlugin.options.flyView.showMultiVehicleList
-
-        property bool showSingleVehiclePanel:  !visible || singleVehicleRadio.checked
-
-        QGCMapPalette { id: mapPal; lightColors: true }
-
-        QGCRadioButton {
-            id:             singleVehicleRadio
-            text:           qsTr("Single")
-            checked:        true
-            textColor:      mapPal.text
-        }
-
-        QGCRadioButton {
-            text:           qsTr("Multi-Vehicle")
-            textColor:      mapPal.text
-        }
-    }
-
-    MultiVehicleList {
-        anchors.margins:    _toolsMargin
-        anchors.top:        multiVehiclePanelSelector.bottom
-        anchors.right:      parent.right
-        width:              _rightPanelWidth
-        height:             parent.height - y - _toolsMargin
-        visible:            !multiVehiclePanelSelector.showSingleVehiclePanel
-    }
-
-
     GuidedActionConfirm {
         anchors.margins:            _toolsMargin
         anchors.top:                parent.top
@@ -115,113 +107,7 @@ Item {
         z:                          QGroundControl.zOrderTopMost
         guidedController:           _guidedController
         guidedValueSlider:          _guidedValueSlider
-        utmspSliderTrigger:          utmspActTrigger
-    }
-
-    FlyViewInstrumentPanel {
-        id:                         instrumentPanel
-        anchors.margins:            _toolsMargin
-        anchors.top:                multiVehiclePanelSelector.visible ? multiVehiclePanelSelector.bottom : parent.top
-        anchors.right:              parent.right
-        spacing:                    _toolsMargin
-        visible:                    QGroundControl.corePlugin.options.flyView.showInstrumentPanel && multiVehiclePanelSelector.showSingleVehiclePanel
-        availableHeight:            parent.height - y - _toolsMargin
-
-        property real rightEdgeTopInset: visible ? parent.width - x : 0
-        property real topEdgeRightInset: visible ? y + height : 0
-    }
-
-    PhotoVideoControl {
-        id:                     photoVideoControl
-        anchors.margins:        _toolsMargin
-        anchors.top:            instrumentPanel.bottom
-        anchors.right:          parent.right
-        width:                  _rightPanelWidth
-
-        property real rightEdgeCenterInset: visible ? parent.width - x : 0
-    }
-
-    TelemetryValuesBar {
-        id:                 telemetryPanel
-        x:                  recalcXPosition()
-        anchors.margins:    _toolsMargin
-
-        property real bottomEdgeCenterInset: 0
-        property real rightEdgeCenterInset: 0
-
-        // States for custom layout support
-        states: [
-            State {
-                name: "bottom"
-                when: telemetryPanel.bottomMode
-
-                AnchorChanges {
-                    target: telemetryPanel
-                    anchors.top: undefined
-                    anchors.bottom: parent.bottom
-                    anchors.right: undefined
-                    anchors.verticalCenter: undefined
-                }
-
-                PropertyChanges {
-                    target: telemetryPanel
-                    x: recalcXPosition()
-                    bottomEdgeCenterInset: visible ? parent.height-y : 0
-                    rightEdgeCenterInset: 0
-                }
-            },
-
-            State {
-                name: "right-video"
-                when: !telemetryPanel.bottomMode && photoVideoControl.visible
-
-                AnchorChanges {
-                    target: telemetryPanel
-                    anchors.top: photoVideoControl.bottom
-                    anchors.bottom: undefined
-                    anchors.right: parent.right
-                    anchors.verticalCenter: undefined
-                }
-                PropertyChanges {
-                    target: telemetryPanel
-                    bottomEdgeCenterInset: 0
-                    rightEdgeCenterInset: visible ? parent.width - x : 0
-                }
-            },
-
-            State {
-                name: "right-novideo"
-                when: !telemetryPanel.bottomMode && !photoVideoControl.visible
-
-                AnchorChanges {
-                    target: telemetryPanel
-                    anchors.top: undefined
-                    anchors.bottom: undefined
-                    anchors.right: parent.right
-                    anchors.verticalCenter: parent.verticalCenter
-                }
-                PropertyChanges {
-                    target: telemetryPanel
-                    bottomEdgeCenterInset: 0
-                    rightEdgeCenterInset: visible ? parent.width - x : 0
-                }
-            }
-        ]
-
-        function recalcXPosition() {
-            // First try centered
-            var halfRootWidth   = _root.width / 2
-            var halfPanelWidth  = telemetryPanel.width / 2
-            var leftX           = (halfRootWidth - halfPanelWidth) - _toolsMargin
-            var rightX          = (halfRootWidth + halfPanelWidth) + _toolsMargin
-            if (leftX >= parentToolInsets.leftEdgeBottomInset || rightX <= parentToolInsets.rightEdgeBottomInset ) {
-                // It will fit in the horizontalCenter
-                return halfRootWidth - halfPanelWidth
-            } else {
-                // Anchor to left edge
-                return parentToolInsets.leftEdgeBottomInset + _toolsMargin
-            }
-        }
+        utmspSliderTrigger:         utmspActTrigger
     }
 
     //-- Virtual Joystick
@@ -262,8 +148,9 @@ Item {
         onDisplayPreFlightChecklist: preFlightChecklistPopup.createObject(mainWindow).open()
 
 
-        property real topEdgeLeftInset: visible ? y + height : 0
-        property real leftEdgeTopInset: visible ? x + width : 0
+        property real topEdgeLeftInset:     visible ? y + height : 0
+        property real leftEdgeTopInset:     visible ? x + width : 0
+        property real leftEdgeCenterInset:  leftEdgeTopInset
     }
 
     GripperMenu {

--- a/src/FlightDisplay/TelemetryValuesBar.qml
+++ b/src/FlightDisplay/TelemetryValuesBar.qml
@@ -16,57 +16,32 @@ import QGroundControl.Vehicle
 import QGroundControl.Controls
 import QGroundControl.Palette
 
-Rectangle {
-    id:                 telemetryPanel
-    height:             telemetryLayout.height + (_toolsMargin * 2)
-    width:              telemetryLayout.width + (_toolsMargin * 2)
-    color:              qgcPal.window
-    radius:             ScreenTools.defaultFontPixelWidth / 2
+Item {
+    id:             control
+    implicitWidth:  mainLayout.width + (_toolsMargin * 2)
+    implicitHeight: mainLayout.height + (_toolsMargin * 2)
 
-    property bool       bottomMode: true
+    property real extraWidth: 0 ///< Extra width to add to the background rectangle
 
-    DeadMouseArea { anchors.fill: parent }
+    Rectangle {
+        id:         backgroundRect
+        width:      control.width + extraWidth
+        height:     control.height
+        color:      qgcPal.window
+        radius:     ScreenTools.defaultFontPixelWidth / 2
+        opacity:    0.75
+    }
+
+    //DeadMouseArea { anchors.fill: parent }
 
     ColumnLayout {
-        id:                 telemetryLayout
+        id:                 mainLayout
         anchors.margins:    _toolsMargin
         anchors.bottom:     parent.bottom
         anchors.left:       parent.left
 
-         RowLayout {
+        RowLayout {
             visible: mouseArea.containsMouse || valueArea.settingsUnlocked
-
-            QGCColoredImage {
-                source:             "/res/layout-bottom.svg"
-                mipmap:             true
-                width:              ScreenTools.minTouchPixels * 0.75
-                height:             width
-                sourceSize.width:   width
-                color:              qgcPal.text
-                fillMode:           Image.PreserveAspectFit
-                visible:            !bottomMode
-
-                QGCMouseArea {
-                    fillItem:   parent
-                    onClicked:  bottomMode = true
-                }
-            }
-
-            QGCColoredImage {
-                source:             "/res/layout-right.svg"
-                mipmap:             true
-                width:              ScreenTools.minTouchPixels * 0.75
-                height:             width
-                sourceSize.width:   width
-                color:              qgcPal.text
-                fillMode:           Image.PreserveAspectFit
-                visible:            bottomMode
-
-                QGCMouseArea {
-                    fillItem:   parent
-                    onClicked:  bottomMode = false
-                }
-            }
 
             QGCColoredImage {
                 source:             valueArea.settingsUnlocked ? "/res/LockOpen.svg" : "/res/pencil.svg"
@@ -95,10 +70,10 @@ Rectangle {
 
     QGCMouseArea {
         id:                         mouseArea
-        x:                          telemetryLayout.x
-        y:                          telemetryLayout.y
-        width:                      telemetryLayout.width
-        height:                     telemetryLayout.height
+        x:                          mainLayout.x
+        y:                          mainLayout.y
+        width:                      mainLayout.width
+        height:                     mainLayout.height
         hoverEnabled:               !ScreenTools.isMobile
         propagateComposedEvents:    true
         visible:                    !valueArea.settingsUnlocked

--- a/src/FlightDisplay/TerrainProgress.qml
+++ b/src/FlightDisplay/TerrainProgress.qml
@@ -17,9 +17,9 @@ import QGroundControl.Controls
 import QGroundControl.Palette
 
 Rectangle {
-    height:     mainLayout.height + (_margins * 2)
-    visible:    false
-    color:      qgcPal.window
+    implicitHeight: mainLayout.height + (_margins * 2)
+    visible:        false
+    color:          qgcPal.window
 
     property var    _activeVehicle: QGroundControl.multiVehicleManager.activeVehicle
     property real   _margins:       ScreenTools.defaultFontPixelWidth / 2

--- a/src/FlightMap/Widgets/CMakeLists.txt
+++ b/src/FlightMap/Widgets/CMakeLists.txt
@@ -5,6 +5,8 @@ add_custom_target(FligthMapWidgetsQml
         CompassDial.qml
         CompassHeadingIndicator.qml
 		HorizontalCompassAttitude.qml
+        IntegratedAttitudeIndicator.qml
+        IntegratedCompassAttitude.qml
 		MapFitFunctions.qml
 		PhotoVideoControl.qml
 		QGCArtificialHorizon.qml

--- a/src/FlightMap/Widgets/HorizontalCompassAttitude.qml
+++ b/src/FlightMap/Widgets/HorizontalCompassAttitude.qml
@@ -23,6 +23,9 @@ ColumnLayout {
     spacing:    ScreenTools.defaultFontPixelHeight / 4
     width:      Math.min(_defaultWidth, _maxWidth)
 
+    property real extraInset:           0
+    property real extraValuesWidth:     _outerRadius
+
     property real   _defaultWidth:      mainWindow.width * 0.2
     property real   _maxWidth:          ScreenTools.defaultFontPixelHeight * 15
     property real   _innerRadius:       (width - (_topBottomMargin * 3)) / 4

--- a/src/FlightMap/Widgets/IntegratedAttitudeIndicator.qml
+++ b/src/FlightMap/Widgets/IntegratedAttitudeIndicator.qml
@@ -16,18 +16,19 @@ import QGroundControl.FlightDisplay
 import QGroundControl.FlightMap
 
 Item {
+    implicitWidth:  _totalRadius * 2
+    implicitHeight: implicitWidth
+
+    property real compassRadius:        ScreenTools.defaultFontPixelHeight * 6 / 2
     property real attitudeAngleDegrees: 0
-    property real attitudeSize:         ScreenTools.defaultFontPixelHeight * 0.75
-    property real attitudeSpacing:      ScreenTools.defaultFontPixelHeight / 4
 
-    property real _totalRadius:      compassRadius + attitudeSpacing + attitudeSize
-    property real compassRadius:    ScreenTools.defaultFontPixelHeight * 6 / 2
-    property real compassBorder:    ScreenTools.defaultFontPixelHeight / 2
-    property real _attitudeRadius:  (width / 2) - (attitudeSize / 2)
+    readonly property real attitudeSize:         ScreenTools.defaultFontPixelHeight * 0.75
+    readonly property real attitudeSpacing:      ScreenTools.defaultFontPixelHeight / 4
 
-    property real _maxAngleDegrees: 30
-    property real _maxRadians:      _maxAngleDegrees * Math.PI / 180
-
+    property real _totalRadius:             compassRadius + attitudeSpacing + attitudeSize
+    property real _attitudeRadius:          (width / 2) - (attitudeSize / 2)
+    property real _maxAngleDegrees:         30
+    property real _maxRadians:              _maxAngleDegrees * Math.PI / 180
     property real _zeroAttitudeRadians:     Math.PI * 1.5
     property real _clampedAngleDegrees:     Math.min(Math.max(attitudeAngleDegrees, -_maxAngleDegrees), _maxAngleDegrees)
     property real _attitudeAnglePercent:    _clampedAngleDegrees / _maxAngleDegrees

--- a/src/FlightMap/Widgets/IntegratedCompassAttitude.qml
+++ b/src/FlightMap/Widgets/IntegratedCompassAttitude.qml
@@ -16,12 +16,14 @@ import QGroundControl.FlightDisplay
 import QGroundControl.FlightMap
 
 Item {
-    width:  totalRadius * 2
-    height: width
+    id:             control
+    implicitWidth:  (compassRadius * 2) + attitudeSpacing + attitudeSize
+    implicitHeight: implicitWidth
 
-    property real totalRadius:          compassRadius + attitudeSpacing + attitudeSize
     property real attitudeSize:         rollIndicator.attitudeSize
     property real attitudeSpacing:      rollIndicator.attitudeSpacing
+    property real extraInset:           attitudeSize + attitudeSpacing
+    property real extraValuesWidth:     compassRadius
     property real defaultCompassRadius: (mainWindow.width * 0.15) / 2
     property real maxCompassRadius:     ScreenTools.defaultFontPixelHeight * 7 / 2
     property real compassRadius:        Math.min(defaultCompassRadius, maxCompassRadius)
@@ -29,26 +31,29 @@ Item {
     property var  vehicle:              globals.activeVehicle
     property var  qgcPal:               QGroundControl.globalPalette
 
+    property real _totalAttitudeSize: attitudeSize + attitudeSpacing
+
     IntegratedAttitudeIndicator {
         id:                     rollIndicator
-        anchors.fill:           parent
+        x:                      -_totalAttitudeSize
         attitudeAngleDegrees:   vehicle ? vehicle.roll.rawValue : 0
+        compassRadius:          control.compassRadius
     }
 
     IntegratedAttitudeIndicator {
-        anchors.fill:           parent
+        x:                      -_totalAttitudeSize
         attitudeAngleDegrees:   vehicle ? vehicle.pitch.rawValue : 0
+        compassRadius:          control.compassRadius
         transformOrigin:        Item.Center
         rotation:               90
     }
-    Rectangle {
-        anchors.centerIn:   parent
-        width:              compassRadius * 2
-        height:             width
-        radius:             width / 2
-        color:              qgcPal.window
 
-        DeadMouseArea { anchors.fill: parent }
+    Rectangle {
+        y:      _totalAttitudeSize
+        width:  compassRadius * 2
+        height: width
+        radius: width / 2
+        color:  qgcPal.window
 
         QGCCompassWidget {
             size:               parent.width - compassBorder

--- a/src/FlightMap/Widgets/PhotoVideoControl.qml
+++ b/src/FlightMap/Widgets/PhotoVideoControl.qml
@@ -23,10 +23,10 @@ import QGroundControl.FactSystem
 import QGroundControl.FactControls
 
 Rectangle {
-    height:     mainLayout.height + (_margins * 2)
-    color:      Qt.rgba(qgcPal.window.r, qgcPal.window.g, qgcPal.window.b, 0.5)
-    radius:     _margins
-    visible:    (_mavlinkCamera || _videoStreamAvailable || _simpleCameraAvailable) && multiVehiclePanelSelector.showSingleVehiclePanel
+    implicitHeight: mainLayout.height + (_margins * 2)
+    color:          Qt.rgba(qgcPal.window.r, qgcPal.window.g, qgcPal.window.b, 0.5)
+    radius:         _margins
+    visible:        (_mavlinkCamera || _videoStreamAvailable || _simpleCameraAvailable) && _showSingleVehicleUI
 
     property real   _margins:                                   ScreenTools.defaultFontPixelHeight / 2
     property var    _activeVehicle:                             QGroundControl.multiVehicleManager.activeVehicle

--- a/src/FlightMap/Widgets/VerticalCompassAttitude.qml
+++ b/src/FlightMap/Widgets/VerticalCompassAttitude.qml
@@ -22,6 +22,9 @@ Rectangle {
     radius: _outerRadius
     color:  QGroundControl.globalPalette.window
 
+    property real extraInset:           0
+    property real extraValuesWidth:     _outerRadius
+
     property real _outerMargin: (width * 0.05) / 2
     property real _outerRadius: width / 2
     property real _innerRadius: _outerRadius - _outerMargin

--- a/src/QmlControls/CMakeLists.txt
+++ b/src/QmlControls/CMakeLists.txt
@@ -126,6 +126,7 @@ add_custom_target(QmlControlsQml
 		QGCRoundButton.qml
 		ScreenTools.qml
 		SectionHeader.qml
+        SelectableControl.qml
         SettingsGroupLayout.qml
 		SliderSwitch.qml
 		SubMenuButton.qml

--- a/src/QmlControls/QGroundControl/FlightDisplay/qmldir
+++ b/src/QmlControls/QGroundControl/FlightDisplay/qmldir
@@ -1,6 +1,7 @@
 Module QGroundControl.FlightDisplay
 
 FlyView                         1.0 FlyView.qml
+FlyViewBottomRightRowLayout     1.0 FlyViewBottomRightRowLayout.qml
 FlyViewCustomLayer              1.0 FlyViewCustomLayer.qml
 FlyViewInstrumentPanel          1.0 FlyViewInstrumentPanel.qml
 FlyViewMap                      1.0 FlyViewMap.qml
@@ -10,6 +11,7 @@ FlyViewToolBar                  1.0 FlyViewToolBar.qml
 FlyViewToolBarIndicators        1.0 FlyViewToolBarIndicators.qml
 FlyViewToolStrip                1.0 FlyViewToolStrip.qml
 FlyViewToolStripActionList      1.0 FlyViewToolStripActionList.qml
+FlyViewTopRightColumnLayout     1.0 FlyViewTopRightColumnLayout.qml
 FlyViewVideo                    1.0 FlyViewVideo.qml
 FlyViewWidgetLayer              1.0 FlyViewWidgetLayer.qml
 FlyViewInsetViewer              1.0 FlyViewInsetViewer.qml

--- a/src/QmlControls/SelectableControl.qml
+++ b/src/QmlControls/SelectableControl.qml
@@ -31,6 +31,7 @@ Control {
     
     property Fact selectedControl               ///< Fact which has enumStrings/Values where values are the qml file for the control
     property bool selectionUIRightAnchor: false
+    property var  innerControl:           loader.item
 
     property bool _showSelectionUI: false
 


### PR DESCRIPTION
<img width="1111" alt="Screenshot 2024-02-21 at 12 10 04 PM" src="https://github.com/mavlink/qgroundcontrol/assets/5876851/166bd731-d185-454e-9c96-cd50ac6ec70f">

* Telemetry values and instruments are merged together aligned to bottom right edge. Custom builds folks may remember this look being in the old custom build example.
* Photo/Video control is aligned to top/right edge
* Goal is to keep center of screen as clear as possible
* Also created new layout mechanism for custom builds to more easily add to ui layer. They can resource override FlyViewTopRightColumnLayout.qml and/or FlyViewBottomRightRowLayout.qml to to add their own controls into the flow. The custom widget layer continues to work as before as does all the QGCToolInsets stuff. But these new mechanisms allow for less upstream change and simpler mods to get what you want.

More to come in cleaning up the Photo/Video control to not be such a large monstrosity.