### PR TITLE
Fix Windows AWS Upload

### DIFF
--- a/.github/actions/upload/action.yml
+++ b/.github/actions/upload/action.yml
@@ -10,6 +10,10 @@ inputs:
   aws_secret_access_key:
     description: 'aws secret access key'
     required: true
+  source:
+    required: false
+    type: string
+    default: 'package'
 runs:
   using: "composite"
   steps:
@@ -17,11 +21,11 @@ runs:
       uses: actions/upload-artifact@master
       with:
         name: ${{ inputs.artifact_name }}
-        path: ${{ runner.temp }}/shadow_build_dir/package/${{ inputs.artifact_name }}
+        path: ${{ runner.temp }}/shadow_build_dir/${{ inputs.source }}/${{ inputs.artifact_name }}
 
     - name: Upload build to S3 Bucket
       if: github.event_name == 'push'
-      working-directory: ${{ runner.temp }}/shadow_build_dir/package
+      working-directory: ${{ runner.temp }}/shadow_build_dir/${{ inputs.source }}
       run: |
             aws configure set aws_access_key_id ${{ inputs.aws_key_id }}
             aws configure set aws_secret_access_key ${{ inputs.aws_secret_access_key }}
@@ -30,7 +34,7 @@ runs:
 
     - name: Upload tagged stable build to S3 latest Bucket
       if: github.event_name == 'push' && github.ref_type == 'tag'
-      working-directory: ${{ runner.temp }}/shadow_build_dir/package
+      working-directory: ${{ runner.temp }}/shadow_build_dir/${{ inputs.source }}
       run: |
             aws configure set aws_access_key_id ${{ inputs.aws_key_id }}
             aws configure set aws_secret_access_key ${{ inputs.aws_secret_access_key }}

--- a/.github/workflows/windows_release.yml
+++ b/.github/workflows/windows_release.yml
@@ -109,7 +109,7 @@ jobs:
         uses: actions/upload-artifact@master
         with:
           name: qgroundcontrol.pdb
-          path: ${{ runner.temp }}\shadow_build_dir\package\qgroundcontrol.pdb
+          path: ${{ runner.temp }}\shadow_build_dir\staging\qgroundcontrol.pdb
 
       - name: Upload Build File
         uses: ./.github/actions/upload
@@ -117,3 +117,4 @@ jobs:
           artifact_name: ${{ env.ARTIFACT }}
           aws_key_id: ${{ secrets.AWS_ACCESS_KEY_ID }}
           aws_secret_access_key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          source: 'staging'


### PR DESCRIPTION
Allows you to specify source directory for upload. Everything uses the default package directory except Windows which is in staging.