### PR TITLE
UVC video fixes

### DIFF
--- a/cmake/MacOSXBundleInfo.plist.in
+++ b/cmake/MacOSXBundleInfo.plist.in
@@ -34,5 +34,7 @@
     <string>${MACOSX_BUNDLE_COPYRIGHT}</string>
     <key>NSPrincipalClass</key>
     <string>NSApplication</string>
+    <key>NSCameraUsageDescription</key>
+    <string>Camera devices used for FPV</string>
 </dict>
 </plist>

--- a/cmake/QGCDeploy.cmake
+++ b/cmake/QGCDeploy.cmake
@@ -45,7 +45,9 @@ elseif(APPLE)
 			hdiutil convert /tmp/tmp.dmg -format UDBZ -o ${CMAKE_BINARY_DIR}/package/QGroundControl.dmg
 	)
 
-	set_target_properties(QGroundControl PROPERTIES MACOSX_BUNDLE YES)
+	set_target_properties(QGroundControl PROPERTIES 
+        MACOSX_BUNDLE YES
+        MACOSX_BUNDLE_INFO_PLIST ${CMAKE_SOURCE_DIR}/cmake/MacOSXBundleInfo.plist.in)
 
 elseif(WIN32)
 	if(MSVC) # Check if we are using the Visual Studio compiler

--- a/src/VideoManager/VideoManager.cc
+++ b/src/VideoManager/VideoManager.cc
@@ -475,8 +475,7 @@ VideoManager::_updateUVC()
         for (const auto& cameraDevice: videoInputs) {
             if (cameraDevice.description() == videoSource) {
                 _uvcVideoSourceID = cameraDevice.description();
-                qCDebug(VideoManagerLog)
-                    << "Found USB source:" << _uvcVideoSourceID << " Name:" << videoSource;
+                qCDebug(VideoManagerLog) << "Found USB source:" << _uvcVideoSourceID << " Name:" << videoSource;
                 break;
             }
         }
@@ -484,10 +483,19 @@ VideoManager::_updateUVC()
 
     if (oldUvcVideoSrcID != _uvcVideoSourceID) {
         qCDebug(VideoManagerLog) << "UVC changed from [" << oldUvcVideoSrcID << "] to [" << _uvcVideoSourceID << "]";
+#if QT_CONFIG(permissions)
+        QCameraPermission cameraPermission;
+        if (qApp->checkPermission(cameraPermission) == Qt::PermissionStatus::Undetermined) {
+            qApp->requestPermission(cameraPermission, [](const QPermission &permission) {
+                if (permission.status() == Qt::PermissionStatus::Granted) {
+                    qgcApp()->showRebootAppMessage(tr("Restart application for changes to take effect."));
+                }
+            });
+        }
+#endif
         emit uvcVideoSourceIDChanged();
         emit isUvcChanged();
     }
-
 #endif
 }
 


### PR DESCRIPTION
* cmake builds were not generating Info.plist file from template in OSX builds
* Added camera permission to Info.plist
* Updated VideoManager to request camera permissions. Given camera permission for UVC for the first time now requires QGC reboot to take effect. Theoretically this should not be needed but I couldn't figure out how to make Qt happy without it. Wondering if there is maybe a Qt bug there somewhere.
* Update UVC video qml to Qt6 changes