### PR TITLE
Larger width for parameter editor dialog

### DIFF
--- a/src/QmlControls/ParameterEditorDialog.qml
+++ b/src/QmlControls/ParameterEditorDialog.qml
@@ -88,7 +88,7 @@ QGCPopupDialog {
     }
 
     ColumnLayout {
-        width:      editRow.width
+        width:      Math.min(mainWindow.width * .75, Math.max(ScreenTools.defaultFontPixelWidth * 60, editRow.width))
         spacing:    globals.defaultTextHeight
 
         QGCLabel {


### PR DESCRIPTION
It was still narrowly sized for the old right panel style dialogs. That dialog can be pretty wordy so wider is better.

<img width="1073" alt="Screenshot 2024-02-22 at 2 33 34 PM" src="https://github.com/mavlink/qgroundcontrol/assets/5876851/9bc4cc66-52f4-4a77-85c1-2672acf38ecd">
