### PR TITLE
Toolbar Indicators expanded content for ArduPilot

### DIFF
--- a/src/FirmwarePlugin/APM/APMBatteryIndicator.qml
+++ b/src/FirmwarePlugin/APM/APMBatteryIndicator.qml
@@ -1,0 +1,72 @@
+/****************************************************************************
+ *
+ * (c) 2009-2020 QGROUNDCONTROL PROJECT <http://www.qgroundcontrol.org>
+ *
+ * QGroundControl is licensed according to the terms in the file
+ * COPYING.md in the root of the source code directory.
+ *
+ ****************************************************************************/
+
+import QtQuick
+import QtQuick.Layouts
+
+import QGroundControl
+import QGroundControl.Controls
+import QGroundControl.MultiVehicleManager
+import QGroundControl.ScreenTools
+import QGroundControl.Palette
+import QGroundControl.FactSystem
+import QGroundControl.FactControls
+import MAVLink
+
+BatteryIndicator {
+    waitForParameters: true
+
+    expandedPageComponent: Component {
+        SettingsGroupLayout {
+            Layout.fillWidth:   true
+            heading:            qsTr("Battery Failsafes")
+            visible:            batt1Monitor.rawValue !== 0
+
+            FactPanelController { id: controller }
+
+            property Fact batt1Monitor: controller.getParameterFact(-1, "BATT_MONITOR")
+
+            LabelledFactComboBox {
+                label:              qsTr("Low Action")
+                fact:               controller.getParameterFact(-1, "BATT_FS_LOW_ACT")
+                indexModel:         false
+            }
+
+            LabelledFactTextField {
+                Layout.fillWidth:   true
+                label:              qsTr("Low Voltage Threshold")
+                fact:               controller.getParameterFact(-1, "BATT_LOW_VOLT")
+            }
+
+            LabelledFactTextField {
+                Layout.fillWidth:   true
+                label:              qsTr("Low mAh Threshold")
+                fact:               controller.getParameterFact(-1, "BATT_LOW_MAH")
+            }
+
+            LabelledFactComboBox {
+                label:              qsTr("Critical Action")
+                fact:               controller.getParameterFact(-1, "BATT_FS_LOW_ACT")
+                indexModel:         false
+            }
+
+            LabelledFactTextField {
+                Layout.fillWidth:   true
+                label:              qsTr("Low Voltage Threshold")
+                fact:               controller.getParameterFact(-1, "BATT_CRT_VOLT")
+            }
+
+            LabelledFactTextField {
+                Layout.fillWidth:   true
+                label:              qsTr("Low mAh Threshold")
+                fact:               controller.getParameterFact(-1, "BATT_CRT_MAH")
+            }
+        }
+    }
+}

--- a/src/FirmwarePlugin/APM/APMFirmwarePlugin.cc
+++ b/src/FirmwarePlugin/APM/APMFirmwarePlugin.cc
@@ -647,9 +647,27 @@ const QVariantList& APMFirmwarePlugin::toolIndicators(const Vehicle* vehicle)
     if (_toolIndicatorList.size() == 0) {
         // First call the base class to get the standard QGC list
         _toolIndicatorList = FirmwarePlugin::toolIndicators(vehicle);
+
+        // Find the generic flight mode indicator and replace with the custom one
+        for (int i=0; i<_toolIndicatorList.size(); i++) {
+            if (_toolIndicatorList.at(i).toUrl().toString().contains("FlightModeIndicator.qml")) {
+                _toolIndicatorList[i] = QVariant::fromValue(QUrl::fromUserInput("qrc:/APM/Indicators/APMFlightModeIndicator.qml"));
+                break;
+            }
+        }
+
+        // Find the generic battery indicator and replace with the custom one
+        for (int i=0; i<_toolIndicatorList.size(); i++) {
+            if (_toolIndicatorList.at(i).toUrl().toString().contains("BatteryIndicator.qml")) {
+                _toolIndicatorList[i] = QVariant::fromValue(QUrl::fromUserInput("qrc:/APM/Indicators/APMBatteryIndicator.qml"));
+                break;
+            }
+        }
+
         // Then add the forwarding support indicator
         _toolIndicatorList.append(QVariant::fromValue(QUrl::fromUserInput("qrc:/toolbar/APMSupportForwardingIndicator.qml")));
     }
+
     return _toolIndicatorList;
 }
 
@@ -1177,4 +1195,9 @@ void APMFirmwarePlugin::guidedModeChangeEquivalentAirspeedMetersSecond(Vehicle* 
         -1,                                   // throttle, no change
         0                                     // 0: absolute speed, 1: relative to current
         );                                    // param 5-7 unused
+}
+
+QVariant APMFirmwarePlugin::mainStatusIndicatorContentItem(const Vehicle*) const
+{
+    return QVariant::fromValue(QUrl::fromUserInput("qrc:/APM/Indicators/APMMainStatusIndicatorContentItem.qml"));
 }

--- a/src/FirmwarePlugin/APM/APMFirmwarePlugin.h
+++ b/src/FirmwarePlugin/APM/APMFirmwarePlugin.h
@@ -84,6 +84,7 @@ public:
     double              minimumEquivalentAirspeed       (Vehicle* vehicle) override;
     bool                fixedWingAirSpeedLimitsAvailable(Vehicle* vehicle) override;
     void                guidedModeChangeEquivalentAirspeedMetersSecond(Vehicle* vehicle, double airspeed_equiv) override;
+    QVariant            mainStatusIndicatorContentItem  (const Vehicle* vehicle) const override;
 
 protected:
     /// All access to singleton is through stack specific implementation

--- a/src/FirmwarePlugin/APM/APMFlightModeIndicator.qml
+++ b/src/FirmwarePlugin/APM/APMFlightModeIndicator.qml
@@ -1,0 +1,85 @@
+/****************************************************************************
+ *
+ * (c) 2009-2022 QGROUNDCONTROL PROJECT <http://www.qgroundcontrol.org>
+ *
+ * QGroundControl is licensed according to the terms in the file
+ * COPYING.md in the root of the source code directory.
+ *
+ ****************************************************************************/
+
+import QtQuick
+import QtQuick.Controls
+import QtQuick.Layouts
+
+import QGroundControl
+import QGroundControl.Controls
+import QGroundControl.MultiVehicleManager
+import QGroundControl.ScreenTools
+import QGroundControl.Palette
+import QGroundControl.FactSystem
+import QGroundControl.FactControls
+
+FlightModeIndicator {
+    waitForParameters:      true
+    expandedPageComponent:  activeVehicle.multiRotor ? copterComponent : undefined
+
+    property var  activeVehicle: QGroundControl.multiVehicleManager.activeVehicle
+
+    Component {
+        id: copterComponent
+
+        SettingsGroupLayout {
+            Layout.fillWidth:   true
+            heading:            qsTr("Return to Launch")
+
+            property Fact rtlAltFact: controller.getParameterFact(-1, "RTL_ALT")
+
+            FactPanelController { id: controller }
+
+            RowLayout {
+                Layout.fillWidth:   true
+                spacing:            ScreenTools.defaultFontPixelWidth * 2
+
+                QGCLabel {
+                    id:                 label  
+                    Layout.fillWidth:   true
+                    text:               qsTr("Return At")
+                }
+
+                QGCComboBox {
+                    id:             returnAtCombo
+                    sizeToContents: true
+                    model:          [ qsTr("Current alttiude"), qsTr("Specified altitude") ]
+
+                    function setCurrentIndex() {
+                        if (rtlAltFact.value === 0) {
+                            returnAtCombo.currentIndex = 0
+                        } else {
+                            returnAtCombo.currentIndex = 1
+                        }
+                    }
+
+                    Component.onCompleted: setCurrentIndex()
+
+                    onActivated: (index) => {
+                        if (index === 0) {
+                            rtlAltFact.rawValue = 0
+                        } else {
+                            rtlAltFact.rawValue = 1500
+                        }
+                    }
+
+                    Connections {
+                        target:             rtlAltFact
+                        onRawValueChanged:  returnAtCombo.setCurrentIndex()
+                    }
+                }
+
+                FactTextField {
+                    fact:       rtlAltFact
+                    enabled:    rtlAltFact.rawValue !== 0
+                }
+            }
+        }
+    }
+}

--- a/src/FirmwarePlugin/APM/APMMainStatusIndicatorContentItem.qml
+++ b/src/FirmwarePlugin/APM/APMMainStatusIndicatorContentItem.qml
@@ -1,0 +1,74 @@
+/****************************************************************************
+ *
+ * (c) 2009-2022 QGROUNDCONTROL PROJECT <http://www.qgroundcontrol.org>
+ *
+ * QGroundControl is licensed according to the terms in the file
+ * COPYING.md in the root of the source code directory.
+ *
+ ****************************************************************************/
+
+import QtQuick
+import QtQuick.Controls
+import QtQuick.Layouts
+
+import QGroundControl
+import QGroundControl.Controls
+import QGroundControl.MultiVehicleManager
+import QGroundControl.ScreenTools
+import QGroundControl.Palette
+import QGroundControl.FactSystem
+import QGroundControl.FactControls
+
+ColumnLayout {
+    spacing: ScreenTools.defaultFontPixelHeight / 2
+
+    FactPanelController { id: controller }
+
+    SettingsGroupLayout {
+        heading:            qsTr("GCS Failsafe")
+        Layout.fillWidth:   true
+
+        LabelledFactComboBox {
+            label:      qsTr("Action")
+            fact:       controller.getParameterFact(-1, "FS_GCS_ENABLE")
+            indexModel: false
+        }
+
+        LabelledFactSlider {
+            Layout.fillWidth:       true
+            label:                  qsTr("Timeout")
+            fact:                   controller.getParameterFact(-1, "FS_GCS_TIMEOUT")
+            sliderPreferredWidth:   ScreenTools.defaultFontPixelWidth * 20
+        }
+    }
+
+    SettingsGroupLayout {
+        heading:            qsTr("Failsafe Options")
+        Layout.fillWidth:   true
+
+        Repeater {
+            id:     repeater
+            model:  fact ? fact.bitmaskStrings : []
+
+            property Fact fact: controller.getParameterFact(-1, "FS_OPTIONS")
+
+            QGCCheckBoxSlider {
+                Layout.fillWidth: true
+                text:               modelData
+                checked:            fact.value & fact.bitmaskValues[index]
+
+                property Fact fact: repeater.fact
+
+                onClicked: {
+                    var i
+                    var otherCheckbox
+                    if (checked) {
+                        fact.value |= fact.bitmaskValues[index]
+                    } else {
+                        fact.value &= ~fact.bitmaskValues[index]
+                    }
+                }
+            }
+        }
+    }
+}

--- a/src/FirmwarePlugin/APM/APMResources.qrc
+++ b/src/FirmwarePlugin/APM/APMResources.qrc
@@ -34,6 +34,11 @@
         <file alias="QGroundControl/ArduPilot/APMSensorIdDecoder.qml">APMSensorIdDecoder.qml</file>
         <file alias="QGroundControl/ArduPilot/qmldir">QGroundControl.ArduPilot.qmldir</file>
     </qresource>
+    <qresource prefix="/APM/Indicators">
+        <file alias="APMBatteryIndicator.qml">APMBatteryIndicator.qml</file>
+        <file alias="APMFlightModeIndicator.qml">APMFlightModeIndicator.qml</file>
+        <file alias="APMMainStatusIndicatorContentItem.qml">APMMainStatusIndicatorContentItem.qml</file>
+    </qresource>
     <qresource prefix="/json">
         <file alias="APM-MavCmdInfoCommon.json">APM-MavCmdInfoCommon.json</file>
         <file alias="APM-MavCmdInfoFixedWing.json">APM-MavCmdInfoFixedWing.json</file>

--- a/src/FirmwarePlugin/APM/CMakeLists.txt
+++ b/src/FirmwarePlugin/APM/CMakeLists.txt
@@ -1,4 +1,7 @@
 add_custom_target(APMFirmwarePluginQml
-SOURCES
-    APMSensorParams.qml
+    SOURCES
+        APMBatteryIndicator.qml
+        APMFlightModeIndicator.qml
+        APMMainStatusIndicatorContentItem.qml
+        APMSensorParams.qml
 )

--- a/src/FirmwarePlugin/PX4/PX4FirmwarePlugin.cc
+++ b/src/FirmwarePlugin/PX4/PX4FirmwarePlugin.cc
@@ -744,18 +744,28 @@ QVariant PX4FirmwarePlugin::mainStatusIndicatorContentItem(const Vehicle*) const
     return QVariant::fromValue(QUrl::fromUserInput("qrc:/PX4/Indicators/PX4MainStatusIndicatorContentItem.qml"));
 }
 
-const QVariantList& PX4FirmwarePlugin::toolIndicators(const Vehicle*)
+const QVariantList& PX4FirmwarePlugin::toolIndicators(const Vehicle* vehicle)
 {
-    //-- Default list of indicators for all vehicles.
-    if(_toolIndicatorList.size() == 0) {
-        _toolIndicatorList = QVariantList({
-            QVariant::fromValue(QUrl::fromUserInput("qrc:/PX4/Indicators/PX4FlightModeIndicator.qml")),
-            QVariant::fromValue(QUrl::fromUserInput("qrc:/toolbar/MessageIndicator.qml")),
-            QVariant::fromValue(QUrl::fromUserInput("qrc:/toolbar/GPSIndicator.qml")),
-            QVariant::fromValue(QUrl::fromUserInput("qrc:/toolbar/TelemetryRSSIIndicator.qml")),
-            QVariant::fromValue(QUrl::fromUserInput("qrc:/toolbar/RCRSSIIndicator.qml")),
-            QVariant::fromValue(QUrl::fromUserInput("qrc:/PX4/Indicators/PX4BatteryIndicator.qml")),
-        });
+    if (_toolIndicatorList.size() == 0) {
+        // First call the base class to get the standard QGC list
+        _toolIndicatorList = FirmwarePlugin::toolIndicators(vehicle);
+
+        // Find the generic flight mode indicator and replace with the custom one
+        for (int i=0; i<_toolIndicatorList.size(); i++) {
+            if (_toolIndicatorList.at(i).toUrl().toString().contains("FlightModeIndicator.qml")) {
+                _toolIndicatorList[i] = QVariant::fromValue(QUrl::fromUserInput("qrc:/PX4/Indicators/PX4FlightModeIndicator.qml"));
+                break;
+            }
+        }
+
+        // Find the generic battery indicator and replace with the custom one
+        for (int i=0; i<_toolIndicatorList.size(); i++) {
+            if (_toolIndicatorList.at(i).toUrl().toString().contains("BatteryIndicator.qml")) {
+                _toolIndicatorList[i] = QVariant::fromValue(QUrl::fromUserInput("qrc:/PX4/Indicators/PX4BatteryIndicator.qml"));
+                break;
+            }
+        }
     }
+
     return _toolIndicatorList;
 }

--- a/src/FirmwarePlugin/PX4/PX4FlightModeIndicator.qml
+++ b/src/FirmwarePlugin/PX4/PX4FlightModeIndicator.qml
@@ -45,7 +45,7 @@ FlightModeIndicator {
                     Layout.fillWidth:       true
                     label:                  qsTr("RTL Altitude")
                     fact:                   controller.getParameterFact(-1, "RTL_RETURN_ALT")
-                    to:                     fact.maxIsDefaultForType ? QGroundControl.unitsConversion.metersToAppSettingsHorizontalDistanceUnits(121.92) : fact.maximum
+                    to:                     fact.maxIsDefaultForType ? QGroundControl.unitsConversion.metersToAppSettingsHorizontalDistanceUnits(121.92) : fact.max
                     sliderPreferredWidth:   sliderWidth
                 }
 
@@ -53,7 +53,7 @@ FlightModeIndicator {
                     Layout.fillWidth:       true
                     label:                  qsTr("Land Descent Rate")
                     fact:                   mpcLandSpeedFact
-                    to:                     fact.maxIsDefaultForType ? QGroundControl.unitsConversion.metersToAppSettingsHorizontalDistanceUnits(4) : fact.maximum
+                    to:                     fact.maxIsDefaultForType ? QGroundControl.unitsConversion.metersToAppSettingsHorizontalDistanceUnits(4) : fact.max
                     sliderPreferredWidth:   sliderWidth
                     visible:                mpcLandSpeedFact && controller.vehicle && !controller.vehicle.fixedWing
                 }


### PR DESCRIPTION
This brings in line the ArduPilot firmware specific side of things with respect to toolbar indicator expanded content. The goal of all of this is to provide a simpler place to modify vehicle settings which are changed frequently instead of having to root through the mass of Vehicle Setup pages.

Expanded main status indicator provides direct access to GCS Failsafe, and General Failsafe Options:
<img width="644" alt="Screenshot 2024-02-25 at 2 41 22 PM" src="https://github.com/mavlink/qgroundcontrol/assets/5876851/65be2bba-bec5-42a4-8783-0da49b6a80de">

Expanded flight mode indicator provides direct access to RTL settings:
<img width="532" alt="Screenshot 2024-02-25 at 2 41 29 PM" src="https://github.com/mavlink/qgroundcontrol/assets/5876851/aa4b2f9a-dd98-46f9-a89c-6efa91b6d73a">

Expanded battery indicator provides direct access to Battery Failsafe settings:
<img width="473" alt="Screenshot 2024-02-25 at 2 41 36 PM" src="https://github.com/mavlink/qgroundcontrol/assets/5876851/39ffeac9-2f2c-40bd-90f9-102a2c6c8c43">
