### PR TITLE
Convert cmake to use qt_add_library

### DIFF
--- a/src/ADSB/CMakeLists.txt
+++ b/src/ADSB/CMakeLists.txt
@@ -1,5 +1,5 @@
 
-add_library(ADSB
+qt_add_library(ADSB
 	ADSBVehicle.cc
 	ADSBVehicle.h
 	ADSBVehicleManager.cc

--- a/src/AirLink/CMakeLists.txt
+++ b/src/AirLink/CMakeLists.txt
@@ -1,18 +1,20 @@
-set(SOURCES
+find_package(Qt6 COMPONENTS Core Network REQUIRED)
+
+qt_add_library(AirLink
     AirlinkLink.cc
     AirlinkLink.h
     AirLinkManager.cc
     AirLinkManager.h
     AirLinkSettings.qml
-        )
+)
 
-find_package(Qt6 COMPONENTS Core REQUIRED)
-find_package(Qt6 COMPONENTS Network REQUIRED)
+target_link_libraries(AirLink
+    PUBLIC
+        Qt6::Core
+        Qt6::Network
+        FactSystem
+        Settings
+        qgc
+)
 
-add_library(AirLink ${SOURCES})
-target_link_libraries(AirLink PUBLIC FactSystem)
-target_link_libraries(AirLink PUBLIC Settings)
-target_link_libraries(AirLink PUBLIC qgc)
-target_link_libraries(AirLink PUBLIC Qt6::Core)
-target_link_libraries(AirLink PUBLIC Qt6::Network)
 target_include_directories(AirLink PUBLIC ${CMAKE_CURRENT_SOURCE_DIR})

--- a/src/AnalyzeView/CMakeLists.txt
+++ b/src/AnalyzeView/CMakeLists.txt
@@ -1,5 +1,5 @@
 
-add_library(AnalyzeView
+qt_add_library(AnalyzeView
 	ExifParser.cc
 	ExifParser.h
 	GeoTagController.cc

--- a/src/Audio/CMakeLists.txt
+++ b/src/Audio/CMakeLists.txt
@@ -1,5 +1,5 @@
 
-add_library(Audio
+qt_add_library(Audio
 	AudioOutput.cc
 )
 

--- a/src/AutoPilotPlugins/CMakeLists.txt
+++ b/src/AutoPilotPlugins/CMakeLists.txt
@@ -3,7 +3,7 @@ add_subdirectory(APM)
 add_subdirectory(Common)
 add_subdirectory(PX4)
 
-add_library(AutoPilotPlugins
+qt_add_library(AutoPilotPlugins
 	APM/APMAirframeComponent.cc
 	APM/APMAirframeComponentController.cc
 	APM/APMAutoPilotPlugin.cc

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -27,7 +27,7 @@ endif ()
 #######################################################
 #             Source Files
 #######################################################
-add_library(${PROJECT_NAME} STATIC
+qt_add_library(${PROJECT_NAME} STATIC
         ${EXTRA_SRC}
 
         CmdLineOptParser.cc

--- a/src/Camera/CMakeLists.txt
+++ b/src/Camera/CMakeLists.txt
@@ -1,5 +1,5 @@
 
-add_library(Camera
+qt_add_library(Camera
 	QGCCameraControl.cc
 	QGCCameraIO.cc
 	QGCCameraManager.cc

--- a/src/Compression/CMakeLists.txt
+++ b/src/Compression/CMakeLists.txt
@@ -1,7 +1,7 @@
 
 set(XZ_EMBEDDED_DIR ${CMAKE_SOURCE_DIR}/libs/xz-embedded)
 
-add_library(compression
+qt_add_library(compression
 	QGCLZMA.cc
 	QGCLZMA.h
 	QGCZlib.cc

--- a/src/FactSystem/CMakeLists.txt
+++ b/src/FactSystem/CMakeLists.txt
@@ -1,7 +1,7 @@
 
 add_subdirectory(FactControls)
 
-add_library(FactSystem
+qt_add_library(FactSystem
 	Fact.cc
 	FactGroup.cc
 	FactGroup.h

--- a/src/FactSystem/FactControls/CMakeLists.txt
+++ b/src/FactSystem/FactControls/CMakeLists.txt
@@ -1,4 +1,4 @@
-add_library(FactControls
+qt_add_library(FactControls
     FactPanelController.cc
 )
 

--- a/src/FirmwarePlugin/CMakeLists.txt
+++ b/src/FirmwarePlugin/CMakeLists.txt
@@ -1,7 +1,7 @@
 add_subdirectory(APM)
 add_subdirectory(PX4)
 
-add_library(FirmwarePlugin
+qt_add_library(FirmwarePlugin
 	CameraMetaData.cc
 	FirmwarePlugin.cc
 	FirmwarePluginManager.cc

--- a/src/FlightMap/CMakeLists.txt
+++ b/src/FlightMap/CMakeLists.txt
@@ -2,7 +2,7 @@
 add_subdirectory(MapItems)
 add_subdirectory(Widgets)
 
-add_library(FlightMap
+qt_add_library(FlightMap
 	#Widgets/ValuesWidgetController.cc
 )
 

--- a/src/FollowMe/CMakeLists.txt
+++ b/src/FollowMe/CMakeLists.txt
@@ -1,5 +1,5 @@
 
-add_library(FollowMe
+qt_add_library(FollowMe
 	FollowMe.cc
 )
 

--- a/src/GPS/CMakeLists.txt
+++ b/src/GPS/CMakeLists.txt
@@ -1,6 +1,6 @@
 
 
-add_library(gps
+qt_add_library(gps
 	Drivers/src/ashtech.cpp
 	Drivers/src/gps_helper.cpp
 	Drivers/src/mtk.cpp

--- a/src/Geo/CMakeLists.txt
+++ b/src/Geo/CMakeLists.txt
@@ -1,5 +1,5 @@
 
-add_library(Geo
+qt_add_library(Geo
 	Constants.hpp
 	Math.cpp
 	Math.hpp

--- a/src/Joystick/CMakeLists.txt
+++ b/src/Joystick/CMakeLists.txt
@@ -7,7 +7,7 @@ if (ANDROID)
 	)
 endif()
 
-add_library(Joystick
+qt_add_library(Joystick
 	Joystick.cc
 	JoystickManager.cc
 	JoystickSDL.cc

--- a/src/MissionManager/CMakeLists.txt
+++ b/src/MissionManager/CMakeLists.txt
@@ -1,5 +1,5 @@
 
-add_library(MissionManager
+qt_add_library(MissionManager
 	BlankPlanCreator.cc
 	BlankPlanCreator.h
 	CameraCalc.cc

--- a/src/PositionManager/CMakeLists.txt
+++ b/src/PositionManager/CMakeLists.txt
@@ -1,5 +1,5 @@
 
-add_library(PositionManager
+qt_add_library(PositionManager
 	PositionManager.cpp
 	SimulatedPosition.cc
 )

--- a/src/QmlControls/CMakeLists.txt
+++ b/src/QmlControls/CMakeLists.txt
@@ -1,4 +1,4 @@
-add_library(QmlControls
+qt_add_library(QmlControls
 	AppMessages.cc
 	AppMessages.h
 	EditPositionDialogController.cc

--- a/src/QtLocationPlugin/CMakeLists.txt
+++ b/src/QtLocationPlugin/CMakeLists.txt
@@ -1,5 +1,5 @@
 
-add_library(QtLocationPlugin
+qt_add_library(QtLocationPlugin
 	BingMapProvider.cpp
 	ElevationMapProvider.cpp
 	EsriMapProvider.cpp

--- a/src/Settings/CMakeLists.txt
+++ b/src/Settings/CMakeLists.txt
@@ -1,5 +1,5 @@
 
-add_library(Settings
+qt_add_library(Settings
 	ADSBVehicleManagerSettings.cc
 	ADSBVehicleManagerSettings.h
 	APMMavlinkStreamRateSettings.cc

--- a/src/Terrain/CMakeLists.txt
+++ b/src/Terrain/CMakeLists.txt
@@ -1,5 +1,5 @@
 
-add_library(Terrain
+qt_add_library(Terrain
 	TerrainQuery.cc
 )
 

--- a/src/Vehicle/Actuators/CMakeLists.txt
+++ b/src/Vehicle/Actuators/CMakeLists.txt
@@ -1,5 +1,5 @@
 
-add_library(Actuators
+qt_add_library(Actuators
 	ActuatorActions.cc
 	ActuatorActions.h
 	ActuatorOutputs.cc

--- a/src/Vehicle/CMakeLists.txt
+++ b/src/Vehicle/CMakeLists.txt
@@ -1,7 +1,7 @@
 
 add_subdirectory(Actuators)
 
-add_library(Vehicle
+qt_add_library(Vehicle
 	Autotune.cpp
 	Autotune.h
 	CompInfo.cc

--- a/src/VehicleSetup/CMakeLists.txt
+++ b/src/VehicleSetup/CMakeLists.txt
@@ -1,5 +1,5 @@
 
-add_library(VehicleSetup
+qt_add_library(VehicleSetup
 	Bootloader.cc
 	Bootloader.h
 	FirmwareImage.cc

--- a/src/VideoManager/CMakeLists.txt
+++ b/src/VideoManager/CMakeLists.txt
@@ -1,4 +1,4 @@
-add_library(VideoManager
+qt_add_library(VideoManager
     GLVideoItemStub.cc
     GLVideoItemStub.h
     SubtitleWriter.cc

--- a/src/VideoReceiver/CMakeLists.txt
+++ b/src/VideoReceiver/CMakeLists.txt
@@ -14,7 +14,7 @@ if (GST_FOUND)
     set(EXTRA_LIBRARIES qmlglsink ${GST_LINK_LIBRARIES})
 endif()
 
-add_library(VideoReceiver
+qt_add_library(VideoReceiver
     ${EXTRA_SOURCES}
     VideoReceiver.h
 )

--- a/src/Viewer3D/CMakeLists.txt
+++ b/src/Viewer3D/CMakeLists.txt
@@ -1,5 +1,5 @@
 
-add_library(Viewer3D
+qt_add_library(Viewer3D
     CityMapGeometry.cc
     CityMapGeometry.h
     earcut.hpp

--- a/src/api/CMakeLists.txt
+++ b/src/api/CMakeLists.txt
@@ -1,5 +1,5 @@
 
-add_library(api
+qt_add_library(api
 	QGCCorePlugin.cc
 	QGCOptions.cc
 	QGCSettings.cc

--- a/src/comm/CMakeLists.txt
+++ b/src/comm/CMakeLists.txt
@@ -11,7 +11,7 @@ if(BUILD_TESTING)
 	)
 endif()
 
-add_library(comm
+qt_add_library(comm
 	#BluetoothLink.cc
 	#BluetoothLink.h
 	LinkConfiguration.cc


### PR DESCRIPTION
Use qt_add_library instead of add_library, which I believe handles some things internally to help with deploying. Next task will be to add qml modules.