### PR TITLE
Make Build Testing an option for debug builds

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -48,6 +48,9 @@ else ()
     add_definitions(-DDAILY_BUILD)
 endif ()
 
+include(CMakeDependentOption)
+cmake_dependent_option(BUILD_TESTING "Enable testing" ON "CMAKE_BUILD_TYPE STREQUAL Debug" OFF)
+
 #######################################################
 #               OS Configuration
 #######################################################
@@ -276,10 +279,6 @@ else()
     list(APPEND QGC_RESOURCES
             ${CMAKE_CURRENT_SOURCE_DIR}/src/UTMSP/dummy/utmsp_dummy.qrc
     )
-endif()
-
-if(BUILD_TESTING)
-    list(APPEND QGC_RESOURCES ${CMAKE_CURRENT_SOURCE_DIR}/test/UnitTest.qrc)
 endif()
 
 #######################################################

--- a/cmake/CompileOptions.cmake
+++ b/cmake/CompileOptions.cmake
@@ -2,7 +2,6 @@
 if(${CMAKE_BUILD_TYPE} MATCHES "Debug")
 	include(CTest)
 	enable_testing()
-    set(BUILD_TESTING ON)
 	if(BUILD_TESTING)
         message("Building tests")
 		add_definitions(-DUNITTEST_BUILD)

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -2,6 +2,7 @@ if (BUILD_TESTING)
     qt_add_library(qgctest
         STATIC
             UnitTestList.cc
+            UnitTest.qrc
     )
 
     add_custom_target(check


### PR DESCRIPTION
#11098
You had moved UnitTest.qrc but I don't believe that was necessary. This just makes build testing a cmake option that defaults to true when building in debug