### PR TITLE
Fix cmake build after migration to qt_add_library

### DIFF
--- a/src/ADSB/CMakeLists.txt
+++ b/src/ADSB/CMakeLists.txt
@@ -1,5 +1,5 @@
 
-qt_add_library(ADSB
+qt_add_library(ADSB STATIC
 	ADSBVehicle.cc
 	ADSBVehicle.h
 	ADSBVehicleManager.cc

--- a/src/AirLink/CMakeLists.txt
+++ b/src/AirLink/CMakeLists.txt
@@ -1,6 +1,6 @@
 find_package(Qt6 COMPONENTS Core Network REQUIRED)
 
-qt_add_library(AirLink
+qt_add_library(AirLink STATIC
     AirlinkLink.cc
     AirlinkLink.h
     AirLinkManager.cc

--- a/src/AnalyzeView/CMakeLists.txt
+++ b/src/AnalyzeView/CMakeLists.txt
@@ -1,5 +1,5 @@
 
-qt_add_library(AnalyzeView
+qt_add_library(AnalyzeView STATIC
 	ExifParser.cc
 	ExifParser.h
 	GeoTagController.cc

--- a/src/Audio/CMakeLists.txt
+++ b/src/Audio/CMakeLists.txt
@@ -1,5 +1,5 @@
 
-qt_add_library(Audio
+qt_add_library(Audio STATIC
 	AudioOutput.cc
 )
 

--- a/src/AutoPilotPlugins/CMakeLists.txt
+++ b/src/AutoPilotPlugins/CMakeLists.txt
@@ -3,7 +3,7 @@ add_subdirectory(APM)
 add_subdirectory(Common)
 add_subdirectory(PX4)
 
-qt_add_library(AutoPilotPlugins
+qt_add_library(AutoPilotPlugins STATIC
 	APM/APMAirframeComponent.cc
 	APM/APMAirframeComponentController.cc
 	APM/APMAutoPilotPlugin.cc

--- a/src/Camera/CMakeLists.txt
+++ b/src/Camera/CMakeLists.txt
@@ -1,5 +1,5 @@
 
-qt_add_library(Camera
+qt_add_library(Camera STATIC
 	QGCCameraControl.cc
 	QGCCameraIO.cc
 	QGCCameraManager.cc

--- a/src/Compression/CMakeLists.txt
+++ b/src/Compression/CMakeLists.txt
@@ -1,7 +1,7 @@
 
 set(XZ_EMBEDDED_DIR ${CMAKE_SOURCE_DIR}/libs/xz-embedded)
 
-qt_add_library(compression
+qt_add_library(compression STATIC
 	QGCLZMA.cc
 	QGCLZMA.h
 	QGCZlib.cc

--- a/src/FactSystem/CMakeLists.txt
+++ b/src/FactSystem/CMakeLists.txt
@@ -1,7 +1,7 @@
 
 add_subdirectory(FactControls)
 
-qt_add_library(FactSystem
+qt_add_library(FactSystem STATIC
 	Fact.cc
 	FactGroup.cc
 	FactGroup.h

--- a/src/FactSystem/FactControls/CMakeLists.txt
+++ b/src/FactSystem/FactControls/CMakeLists.txt
@@ -1,4 +1,4 @@
-qt_add_library(FactControls
+qt_add_library(FactControls STATIC
     FactPanelController.cc
 )
 

--- a/src/FirmwarePlugin/CMakeLists.txt
+++ b/src/FirmwarePlugin/CMakeLists.txt
@@ -1,7 +1,7 @@
 add_subdirectory(APM)
 add_subdirectory(PX4)
 
-qt_add_library(FirmwarePlugin
+qt_add_library(FirmwarePlugin STATIC
 	CameraMetaData.cc
 	FirmwarePlugin.cc
 	FirmwarePluginManager.cc

--- a/src/FlightMap/CMakeLists.txt
+++ b/src/FlightMap/CMakeLists.txt
@@ -2,7 +2,7 @@
 add_subdirectory(MapItems)
 add_subdirectory(Widgets)
 
-qt_add_library(FlightMap
+qt_add_library(FlightMap STATIC
 	#Widgets/ValuesWidgetController.cc
 )
 

--- a/src/FollowMe/CMakeLists.txt
+++ b/src/FollowMe/CMakeLists.txt
@@ -1,5 +1,5 @@
 
-qt_add_library(FollowMe
+qt_add_library(FollowMe STATIC
 	FollowMe.cc
 )
 

--- a/src/GPS/CMakeLists.txt
+++ b/src/GPS/CMakeLists.txt
@@ -1,6 +1,6 @@
 
 
-qt_add_library(gps
+qt_add_library(gps STATIC
 	Drivers/src/ashtech.cpp
 	Drivers/src/gps_helper.cpp
 	Drivers/src/mtk.cpp

--- a/src/Geo/CMakeLists.txt
+++ b/src/Geo/CMakeLists.txt
@@ -1,5 +1,5 @@
 
-qt_add_library(Geo
+qt_add_library(Geo STATIC
 	Constants.hpp
 	Math.cpp
 	Math.hpp

--- a/src/Joystick/CMakeLists.txt
+++ b/src/Joystick/CMakeLists.txt
@@ -7,7 +7,7 @@ if (ANDROID)
 	)
 endif()
 
-qt_add_library(Joystick
+qt_add_library(Joystick STATIC
 	Joystick.cc
 	JoystickManager.cc
 	JoystickSDL.cc

--- a/src/MissionManager/CMakeLists.txt
+++ b/src/MissionManager/CMakeLists.txt
@@ -1,5 +1,5 @@
 
-qt_add_library(MissionManager
+qt_add_library(MissionManager STATIC
 	BlankPlanCreator.cc
 	BlankPlanCreator.h
 	CameraCalc.cc

--- a/src/PositionManager/CMakeLists.txt
+++ b/src/PositionManager/CMakeLists.txt
@@ -1,5 +1,5 @@
 
-qt_add_library(PositionManager
+qt_add_library(PositionManager STATIC
 	PositionManager.cpp
 	SimulatedPosition.cc
 )

--- a/src/QmlControls/CMakeLists.txt
+++ b/src/QmlControls/CMakeLists.txt
@@ -1,4 +1,4 @@
-qt_add_library(QmlControls
+qt_add_library(QmlControls STATIC
 	AppMessages.cc
 	AppMessages.h
 	EditPositionDialogController.cc

--- a/src/QtLocationPlugin/CMakeLists.txt
+++ b/src/QtLocationPlugin/CMakeLists.txt
@@ -1,5 +1,5 @@
 
-qt_add_library(QtLocationPlugin
+qt_add_library(QtLocationPlugin STATIC
 	BingMapProvider.cpp
 	ElevationMapProvider.cpp
 	EsriMapProvider.cpp

--- a/src/Settings/CMakeLists.txt
+++ b/src/Settings/CMakeLists.txt
@@ -1,5 +1,5 @@
 
-qt_add_library(Settings
+qt_add_library(Settings STATIC
 	ADSBVehicleManagerSettings.cc
 	ADSBVehicleManagerSettings.h
 	APMMavlinkStreamRateSettings.cc

--- a/src/Terrain/CMakeLists.txt
+++ b/src/Terrain/CMakeLists.txt
@@ -1,5 +1,5 @@
 
-qt_add_library(Terrain
+qt_add_library(Terrain STATIC
 	TerrainQuery.cc
 )
 

--- a/src/Vehicle/Actuators/CMakeLists.txt
+++ b/src/Vehicle/Actuators/CMakeLists.txt
@@ -1,5 +1,5 @@
 
-qt_add_library(Actuators
+qt_add_library(Actuators STATIC
 	ActuatorActions.cc
 	ActuatorActions.h
 	ActuatorOutputs.cc

--- a/src/Vehicle/CMakeLists.txt
+++ b/src/Vehicle/CMakeLists.txt
@@ -1,7 +1,7 @@
 
 add_subdirectory(Actuators)
 
-qt_add_library(Vehicle
+qt_add_library(Vehicle STATIC
 	Autotune.cpp
 	Autotune.h
 	CompInfo.cc

--- a/src/VehicleSetup/CMakeLists.txt
+++ b/src/VehicleSetup/CMakeLists.txt
@@ -1,5 +1,5 @@
 
-qt_add_library(VehicleSetup
+qt_add_library(VehicleSetup STATIC
 	Bootloader.cc
 	Bootloader.h
 	FirmwareImage.cc

--- a/src/VideoManager/CMakeLists.txt
+++ b/src/VideoManager/CMakeLists.txt
@@ -1,4 +1,4 @@
-qt_add_library(VideoManager
+qt_add_library(VideoManager STATIC
     GLVideoItemStub.cc
     GLVideoItemStub.h
     SubtitleWriter.cc

--- a/src/VideoReceiver/CMakeLists.txt
+++ b/src/VideoReceiver/CMakeLists.txt
@@ -14,7 +14,7 @@ if (GST_FOUND)
     set(EXTRA_LIBRARIES qmlglsink ${GST_LINK_LIBRARIES})
 endif()
 
-qt_add_library(VideoReceiver
+qt_add_library(VideoReceiver STATIC
     ${EXTRA_SOURCES}
     VideoReceiver.h
 )

--- a/src/Viewer3D/CMakeLists.txt
+++ b/src/Viewer3D/CMakeLists.txt
@@ -1,5 +1,5 @@
 
-qt_add_library(Viewer3D
+qt_add_library(Viewer3D STATIC
     CityMapGeometry.cc
     CityMapGeometry.h
     earcut.hpp

--- a/src/api/CMakeLists.txt
+++ b/src/api/CMakeLists.txt
@@ -1,5 +1,5 @@
 
-qt_add_library(api
+qt_add_library(api STATIC
 	QGCCorePlugin.cc
 	QGCOptions.cc
 	QGCSettings.cc

--- a/src/comm/CMakeLists.txt
+++ b/src/comm/CMakeLists.txt
@@ -11,7 +11,7 @@ if(BUILD_TESTING)
 	)
 endif()
 
-qt_add_library(comm
+qt_add_library(comm STATIC
 	#BluetoothLink.cc
 	#BluetoothLink.h
 	LinkConfiguration.cc


### PR DESCRIPTION
By default, qt_add_library creates a library type based on how Qt was built - in our scenario, it's set to SHARED.


