### PR TITLE
Fixes for joystick event handling in QML

### DIFF
--- a/src/VehicleSetup/JoystickConfigButtons.qml
+++ b/src/VehicleSetup/JoystickConfigButtons.qml
@@ -27,7 +27,7 @@ ColumnLayout {
     
     Connections {
         target: _activeJoystick
-        onRawButtonPressedChanged: {
+        onRawButtonPressedChanged: (index, pressed) => {
             if (buttonActionRepeater.itemAt(index)) {
                 buttonActionRepeater.itemAt(index).pressed = pressed
             }
@@ -40,7 +40,6 @@ ColumnLayout {
     ColumnLayout {
         id:         flowColumn
         width:      parent.width
-        anchors.centerIn:   parent
         spacing:    ScreenTools.defaultFontPixelHeight
 
         // Note for reminding the use of multiple buttons for the same action

--- a/src/VehicleSetup/JoystickConfigCalibration.qml
+++ b/src/VehicleSetup/JoystickConfigCalibration.qml
@@ -99,7 +99,7 @@ Item {
                 anchors.verticalCenter: parent.verticalCenter
                 Connections {
                     target: controller
-                    onAxisValueChanged: {
+                    onAxisValueChanged: (axis, value) => {
                         if (axisMonitorRepeater.itemAt(axis)) {
                             axisMonitorRepeater.itemAt(axis).axis.axisValue = value
                         }

--- a/src/VehicleSetup/JoystickConfigGeneral.qml
+++ b/src/VehicleSetup/JoystickConfigGeneral.qml
@@ -211,7 +211,7 @@ Item {
 
                     Connections {
                         target:             _activeJoystick
-                        onAxisValues: {
+                        onAxisValues: (roll, pitch, yaw, throttle) => {
                             rollAxis.axisValue      = roll  * 32768.0
                             pitchAxis.axisValue     = pitch * 32768.0
                             yawAxis.axisValue       = yaw   * 32768.0


### PR DESCRIPTION
This update changes the method signatures for "onAxisValueChanged", "onRawButtonPressedChanged", and "onAxisValues" events in QML according to Qt6 requirements. Each event now directly accepts the necessary arguments.


