### PR TITLE
Update CMake Deployment

### DIFF
--- a/.github/workflows/linux_debug.yml
+++ b/.github/workflows/linux_debug.yml
@@ -50,24 +50,21 @@ jobs:
           host:         linux
           target:       desktop
           dir:          ${{ runner.temp }}
-          modules:      qtcharts qtlocation qtpositioning qtspeech qt5compat qtmultimedia qtserialport qtimageformats qtshadertools qtquick3d
+          modules:      qtcharts qtlocation qtpositioning qtspeech qt5compat qtmultimedia qtserialport qtimageformats qtshadertools qtconnectivity qtquick3d
           setup-python: true
           cache: true
 
       - name: Install github environment dependencies for unit test running
-        run:  sudo apt-get install libxcb-xinerama0
+        run:  sudo apt-get install -y libxcb-xinerama0 libxkbcommon-x11-0 libxcb-cursor0
 
       - name: Install QGC source dependencies
         run:  sudo apt-get install -y libsdl2-dev
-
-      - name: Install source dependencies required to run unit tests in workflow container
-        run:  sudo apt-get install -y libxkbcommon-x11-0 libxcb-cursor0
 
       - name: Install Gstreamer dev packages
         run:  sudo apt-get install -y libgstreamer-plugins-base1.0-dev libgstreamer1.0-0:amd64 libgstreamer1.0-dev
 
       - name: Install post-link dependencies
-        run:  sudo apt-get install -y binutils patchelf
+        run:  sudo apt-get install -y binutils patchelf ninja-build
 
       - name: Create build directory
         run:  mkdir ${{ runner.temp }}/shadow_build_dir
@@ -75,8 +72,9 @@ jobs:
       - name: Build
         working-directory: ${{ runner.temp }}/shadow_build_dir
         run:  |
-              qmake -r ${SOURCE_DIR}/qgroundcontrol.pro CONFIG+=debug CONFIG+=${BUILD_TYPE}
-              make -j2
+              cmake -S ${SOURCE_DIR} -B ${SOURCE_DIR}/shadow_build_dir/ -G Ninja -DCMAKE_BUILD_TYPE=Debug
+              cmake --build ${SOURCE_DIR}/shadow_build_dir/ --target all
+              cmake --install ${SOURCE_DIR}/shadow_build_dir
 
       - name: Setup for unit tests
         working-directory: ${{ runner.temp }}/shadow_build_dir
@@ -87,4 +85,4 @@ jobs:
 
       - name: Run unit tests
         working-directory:  ${{ runner.temp }}/shadow_build_dir
-        run:                xvfb-run -a ./staging/qgroundcontrol-start.sh --unittest
+        run:                xvfb-run -a ${SOURCE_DIR}/shadow_build_dir/staging/bin/QGroundControl --unittest

--- a/.github/workflows/linux_release.yml
+++ b/.github/workflows/linux_release.yml
@@ -59,7 +59,7 @@ jobs:
           host:         linux
           target:       desktop
           dir:          ${{ runner.temp }}
-          modules:      qtcharts qtlocation qtpositioning qtspeech qt5compat qtmultimedia qtserialport qtimageformats qtshadertools qtquick3d
+          modules:      qtcharts qtlocation qtpositioning qtspeech qt5compat qtmultimedia qtserialport qtimageformats qtshadertools qtconnectivity qtquick3d
           setup-python: true
           cache: true
 

--- a/.github/workflows/macos_release.yml
+++ b/.github/workflows/macos_release.yml
@@ -57,7 +57,7 @@ jobs:
           host:         mac
           target:       desktop
           dir:          ${{ runner.temp }}
-          modules:      qtcharts qtlocation qtpositioning qtspeech qt5compat qtmultimedia qtserialport qtimageformats qtshadertools qtquick3d
+          modules:      qtcharts qtlocation qtpositioning qtspeech qt5compat qtmultimedia qtserialport qtimageformats qtshadertools qtconnectivity qtquick3d
           setup-python: false
           cache: true
 

--- a/.github/workflows/videoapp_linux.yml
+++ b/.github/workflows/videoapp_linux.yml
@@ -57,22 +57,16 @@ jobs:
           cache: true
 
       - name: Install github environment dependencies for unit test running
-        run:  sudo apt-get install libxcb-xinerama0
+        run:  sudo apt-get install libxcb-xinerama0 libxkbcommon-x11-0 libxcb-cursor0
 
       - name: Install QGC source dependencies
         run:  sudo apt-get install -y libsdl2-dev
 
-      - name: Install source dependencies required to run unit tests in workflow container
-        run:  sudo apt-get install -y libxkbcommon-x11-0 libxcb-cursor0
-
       - name: Install Gstreamer dev packages
         run:  sudo apt-get install -y libgstreamer-plugins-base1.0-dev libgstreamer1.0-0:amd64 libgstreamer1.0-dev
 
-      - name: Install ninja
-        run:  sudo apt-get install ninja-build
-
       - name: Install post-link dependencies
-        run:  sudo apt-get install -y binutils patchelf
+        run:  sudo apt-get install -y binutils patchelf ninja-build
 
       - name: Create build directory
         run:  mkdir ${{ runner.temp }}/shadow_build_dir
@@ -80,6 +74,6 @@ jobs:
       - name: Build
         working-directory: ${{ runner.temp }}/shadow_build_dir
         run:  |
-          cmake -S ${SOURCE_DIR}/VideoReceiverApp -B ${SOURCE_DIR}/VideoReceiverApp/build/ -G Ninja
-          cmake --build ${SOURCE_DIR}/VideoReceiverApp/build/ --target all
+          cmake -S ${SOURCE_DIR}/VideoReceiverApp -B ${SOURCE_DIR}/VideoReceiverApp/shadow_build_dir/ -G Ninja
+          cmake --build ${SOURCE_DIR}/VideoReceiverApp/shadow_build_dir/ --target all
 

--- a/.github/workflows/windows_release.yml
+++ b/.github/workflows/windows_release.yml
@@ -59,7 +59,7 @@ jobs:
           target:       desktop
           arch:         win64_msvc2019_64
           dir:          ${{ runner.temp }}
-          modules:      qtcharts qtlocation qtpositioning qtspeech qt5compat qtmultimedia qtserialport qtimageformats qtshadertools qtquick3d
+          modules:      qtcharts qtlocation qtpositioning qtspeech qt5compat qtmultimedia qtserialport qtimageformats qtshadertools qtconnectivity qtquick3d
           setup-python: false
           cache: true
 
@@ -91,13 +91,13 @@ jobs:
             cmd /c start /wait msiexec /package ${{ runner.temp }}\gstreamer-1.0-msvc-x86_64-1.18.1.msi /passive ADDLOCAL=ALL
             cmd /c start /wait msiexec /package ${{ runner.temp }}\gstreamer-1.0-devel-msvc-x86_64-1.18.1.msi /passive ADDLOCAL=ALL
 
-      - name: Create build directory
-        run:  mkdir ${{ runner.temp }}\shadow_build_dir
-
       - name: Set up Visual Studio shell
         uses: egor-tensin/vs-shell@v2
         with:
           arch: x64
+
+      - name: Create build directory
+        run:  mkdir ${{ runner.temp }}\shadow_build_dir
 
       - name: Build
         working-directory: ${{ runner.temp }}\shadow_build_dir

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -5,6 +5,7 @@ cmake_minimum_required(VERSION 3.21.1 FATAL_ERROR)
 #######################################################
 
 project(QGroundControl LANGUAGES C CXX)
+# set_target_properties(${PROJECT_NAME} PROPERTIES VERSION 1.0)
 
 #######################################################
 #            CMake Configuration Options
@@ -15,6 +16,7 @@ set_property(CACHE CMAKE_BUILD_TYPE PROPERTY STRINGS "Debug;Release;RelWithDebIn
 
 set(CMAKE_CXX_STANDARD 17)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
+set(CMAKE_INSTALL_PREFIX ${CMAKE_BINARY_DIR}/staging)
 
 set(CMAKE_AUTOMOC ON)
 set(CMAKE_AUTOUIC ON)
@@ -23,10 +25,6 @@ set(CMAKE_AUTORCC ON)
 set(CMAKE_INCLUDE_CURRENT_DIR ON)
 
 include(FeatureSummary)
-
-if ("${CMAKE_CXX_COMPILER_ID}" STREQUAL "Clang" OR "${CMAKE_CXX_COMPILER_ID}" STREQUAL "GNU")
-    add_compile_options(-Wall -Wextra)
-endif()
 
 # CMake build type
 # Debug Release RelWithDebInfo MinSizeRel Coverage
@@ -66,7 +64,7 @@ endif ()
 option(QT6_DISABLE_DNSENGINE "Disable DNS Engine" OFF)
 
 # Compilation error for deprecated functions
-add_compile_definitions(QT_DISABLE_DEPRECATED_BEFORE=0x050F00)
+add_compile_definitions(QT_DISABLE_DEPRECATED_BEFORE=0x060600)
 add_compile_definitions(QT_DEBUG_FIND_PACKAGE=ON)
 if (QT6_DISABLE_DNSENGINE)
     message(STATUS "DNS Engine disabled")
@@ -80,12 +78,14 @@ message(STATUS "Qt spec: ${QT_MKSPEC}")
 
 
 # Find Qt6 libraries
-find_package(Qt6 ${QT_VERSION}
+find_package(Qt6
+        REQUIRED
         COMPONENTS
                 Bluetooth
                 Charts
                 Concurrent
                 Core
+                Core5Compat
                 Location
                 Multimedia
                 Network
@@ -100,21 +100,13 @@ find_package(Qt6 ${QT_VERSION}
                 TextToSpeech
                 Widgets
                 Xml
-        REQUIRED
-                Core5Compat
+        OPTIONAL_COMPONENTS
+                SerialPort
         HINTS
                 ${QT_LIBRARY_HINTS}
 )
 
-if(NOT QT_MKSPEC MATCHES "winrt")
-    find_package(Qt6 ${QT_VERSION}
-            COMPONENTS
-            SerialPort
-            REQUIRED
-            HINTS
-            ${QT_LIBRARY_HINTS}
-    )
-endif()
+qt_standard_project_setup(REQUIRES 6.6.0)
 
 # this is required since user can have Qt5 and Qt6 installed at the same time, and then Qt_DIR
 # might point to Qt5, but we want to use Qt6
@@ -152,7 +144,6 @@ add_feature_info(DEBUG_QML DEBUG_QML "Build QGroundControl with QML debugging/pr
 if(DEBUG_QML)
     message(STATUS "To enable the QML debugger/profiler, run with: '-qmljsdebugger=port:1234'")
     add_definitions(-DQMLJSDEBUGGER)
-    add_definitions(-DQT_DECLARATIVE_DEBUG)
     add_definitions(-DQT_QML_DEBUG)
 endif()
 
@@ -172,25 +163,12 @@ add_definitions(
         -DQGC_ORG_DOMAIN="org.qgroundcontrol"
 )
 
-
 #######################################################
 #                QGroundControl Git Information
 #######################################################
 
 include(Git)
 message(STATUS "QGroundControl version: ${APP_VERSION_STR}")
-
-#######################################################
-#                ccache Configuration
-#######################################################
-# Configuring ccache if it's available and not disabled
-
-# bzd tymczasowo
-option(CCACHE "Use ccache if available" OFF)
-find_program(CCACHE_PROGRAM ccache)
-if (CCACHE AND CCACHE_PROGRAM AND NOT DEFINED ENV{CCACHE_DISABLE})
-    set_property(GLOBAL PROPERTY RULE_LAUNCH_COMPILE "${CCACHE_PROGRAM}")
-endif()
 
 #######################################################
 #                GStreamer Configuration
@@ -285,26 +263,52 @@ if (BUILD_TESTING)
     list(APPEND QGC_RESOURCES ${CMAKE_CURRENT_SOURCE_DIR}/test/UnitTest.qrc)
 endif()
 
+if(APPLE)
+    set(MACOSX_BUNDLE_ICON_FILE macx.icns)
+    set(app_icon_macos "${CMAKE_CURRENT_SOURCE_DIR}/resources/icons/macx.icns")
+    set_source_files_properties(${app_icon_macos} PROPERTIES MACOSX_PACKAGE_LOCATION "Resources")
+    list(APPEND QGC_RESOURCES
+            ${app_icon_macos}
+    )
+endif()
+
 #######################################################
 #               QGroundControl Target
 #######################################################
 
-if(ANDROID)
-    add_library(${PROJECT_NAME} SHARED ${QGC_RESOURCES})
-elseif(APPLE)
-    set(MACOSX_BUNDLE_ICON_FILE macx.icns)
-    set(app_icon_macos "${CMAKE_CURRENT_SOURCE_DIR}/resources/icons/macx.icns")
-    set_source_files_properties(${app_icon_macos} PROPERTIES MACOSX_PACKAGE_LOCATION "Resources")
-    qt_add_executable(${PROJECT_NAME} MACOSX_BUNDLE ${QGC_RESOURCES} ${app_icon_macos})
-else()
-    add_executable(${PROJECT_NAME} ${QGC_RESOURCES})
+qt_add_executable(${PROJECT_NAME} ${QGC_RESOURCES})
+
+if(APPLE)
+    set_target_properties(${PROJECT_NAME} PROPERTIES MACOSX_BUNDLE TRUE)
+elseif(WIN32)
+    set_target_properties(${PROJECT_NAME} PROPERTIES WIN32_EXECUTABLE TRUE)
+elseif(ANDROID)
+    add_android_openssl_libraries(${PROJECT_NAME})
+
+    #set_target_properties(${PROJECT_NAME}
+    #    PROPERTIES
+    #        QT_ANDROID_ABIS ${ANDROID_ABI}
+    #        QT_ANDROID_EXTRA_LIBS "${ANDROID_EXTRA_LIBS_APP}"
+    #        QT_ANDROID_MIN_SDK_VERSION 26
+    #        QT_ANDROID_PACKAGE_SOURCE_DIR ${CMAKE_CURRENT_SOURCE_DIR}/android/deploy
+    #        QT_ANDROID_SDK_BUILD_TOOLS_REVISION 34.0.0
+    #        QT_ANDROID_TARGET_SDK_VERSION 33
+    #        QT_ANDROID_VERSION_NAME '0.1'
+    #        QT_ANDROID_VERSION_CODE 0.1
+    #        QT_QML_ROOT_PATH ${CMAKE_CURRENT_SOURCE_DIR}/ui/qml # ${CMAKE_BINARY_DIR}/qml
+    #)
+    #QT_ANDROID_DEPLOY_RELEASE
+    #QT_ANDROID_KEYSTORE_PATH
+    #QT_ANDROID_KEYSTORE_ALIAS
+    #QT_ANDROID_KEYSTORE_STORE_PASS
+    #QT_ANDROID_KEYSTORE_KEY_PASS
+    #QT_ANDROID_SIGN_APK
+    #QT_ENABLE_VERBOSE_DEPLOYMENT
+    #QT_HOST_PATH
+    #QT_PATH_ANDROID_ABI_arm64-v8a
 endif()
 
 target_link_libraries(${PROJECT_NAME} PRIVATE qgc)
-
-if(ANDROID)
-    add_android_openssl_libraries(${PROJECT_NAME})
-endif()
 
 #######################################################
 #               Testing Configuration
@@ -322,6 +326,12 @@ endif()
 include(GNUInstallDirs)
 
 # Files/directories to install
+#install(
+#    TARGETS ${PROJECT_NAME}
+#    LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}
+#    RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR}
+#    ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR}
+#)
 install(
         TARGETS ${PROJECT_NAME}
         DESTINATION ${CMAKE_INSTALL_BINDIR}
@@ -348,6 +358,10 @@ install(
         FILES ${CMAKE_BINARY_DIR}/metainfo/org.mavlink.qgroundcontrol.metainfo.xml
         DESTINATION ${CMAKE_INSTALL_DATADIR}/metainfo/
 )
+if(NOT ANDROID)
+    qt_generate_deploy_qml_app_script(TARGET ${PROJECT_NAME} OUTPUT_SCRIPT deploy_script)
+    install(SCRIPT ${deploy_script})
+endif()
 
 #######################################################
 #               Serial Port Configuration
@@ -359,4 +373,4 @@ if(NOT QT_MKSPEC MATCHES "winrt")
         )
 endif()
 
-include(QGCDeploy)
+#include(QGCDeploy)


### PR DESCRIPTION
This will need a follow up after some more testing, but at least for now the linux_debug workflow has been updated to use CMake and runs the unit tests correctly. Getting this PR merged first will let us verify future CMake changes easier. The other workflows can be converted to CMake after we verify all of the deployment properties for each platform are set correctly.

Also added qtconnectivity which was required for bluetooth.
Ultimately I would like VideoReceiverApp to share the same root CMakeLists.txt and just be a separate executable.