### PR TITLE
Dont cache pull requests

### DIFF
--- a/.github/workflows/android_release.yml
+++ b/.github/workflows/android_release.yml
@@ -58,6 +58,7 @@ jobs:
           restore-keys: ${{ runner.os }}-${{ matrix.arch }}-Release
           max-size: "2G"
           append-timestamp: false
+        if: github.ref == 'refs/heads/master' && github.event_name != 'pull_request'
 
       - name: Get all tags for correct version determination
         working-directory:  ${{ github.workspace }}

--- a/.github/workflows/linux_debug.yml
+++ b/.github/workflows/linux_debug.yml
@@ -41,6 +41,7 @@ jobs:
           restore-keys: ${{ runner.os }}-Debug
           max-size: "2G"
           append-timestamp: false
+        if: github.ref == 'refs/heads/master' && github.event_name != 'pull_request'
 
       - name: Install Qt
         uses: jurplel/install-qt-action@v3

--- a/.github/workflows/linux_release.yml
+++ b/.github/workflows/linux_release.yml
@@ -45,6 +45,7 @@ jobs:
           restore-keys: ${{ runner.os }}-Release
           max-size: "2G"
           append-timestamp: false
+        if: github.ref == 'refs/heads/master' && github.event_name != 'pull_request'
 
       - name: Get all tags for correct version determination
         working-directory:  ${{ github.workspace }}

--- a/.github/workflows/macos_release.yml
+++ b/.github/workflows/macos_release.yml
@@ -43,6 +43,7 @@ jobs:
           restore-keys: ${{ runner.os }}-Release
           max-size: "2G"
           append-timestamp: false
+        if: github.ref == 'refs/heads/master' && github.event_name != 'pull_request'
 
       - name: Get all tags for correct version determination
         working-directory:  ${{ github.workspace }}

--- a/.github/workflows/videoapp_linux.yml
+++ b/.github/workflows/videoapp_linux.yml
@@ -43,6 +43,7 @@ jobs:
           restore-keys: ${{ runner.os }}-Debug
           max-size: "1G"
           append-timestamp: false
+        if: github.ref == 'refs/heads/master' && github.event_name != 'pull_request'
 
       - name: Install Qt
         uses: jurplel/install-qt-action@v3

--- a/.github/workflows/windows_release.yml
+++ b/.github/workflows/windows_release.yml
@@ -44,6 +44,7 @@ jobs:
           max-size: "2G"
           append-timestamp: false
           variant: "sccache"
+        if: github.ref == 'refs/heads/master' && github.event_name != 'pull_request'
 
       - name: Get all tags for correct version determination
         working-directory:  ${{ github.workspace }}


### PR DESCRIPTION
This prevents separate caches being created for every single pull request. Not sure if this is an issue with the ccache action or what but I don't see a way to change it. So only pushes on master will be cached for now.