### PR TITLE
Mac video cmake plus video streaming change

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -209,6 +209,8 @@ if (ENABLE_VIDEOSTREAMING)
         message(STATUS "GStreamer egl libs: ${GST_EGL_LIBS}")
     endif ()
 
+    add_definitions(-DQGC_GST_STREAMING)
+
     message(STATUS "gst found ${GST_FOUND}")
 endif ()
 
@@ -279,7 +281,9 @@ endif()
 qt_add_executable(${PROJECT_NAME} ${QGC_RESOURCES})
 
 if(APPLE)
-    set_target_properties(${PROJECT_NAME} PROPERTIES MACOSX_BUNDLE TRUE)
+    set_target_properties(${PROJECT_NAME} PROPERTIES 
+        MACOSX_BUNDLE TRUE
+        MACOSX_BUNDLE_INFO_PLIST ${CMAKE_SOURCE_DIR}/cmake/MacOSXBundleInfo.plist.in) # According to cmake docs this should happen automatically. But it doesn't work so we add manually.
 elseif(WIN32)
     set_target_properties(${PROJECT_NAME} PROPERTIES WIN32_EXECUTABLE TRUE)
 elseif(ANDROID)

--- a/cmake/QGCDeploy.cmake
+++ b/cmake/QGCDeploy.cmake
@@ -45,10 +45,6 @@ elseif(APPLE)
 			hdiutil convert /tmp/tmp.dmg -format UDBZ -o ${CMAKE_BINARY_DIR}/package/QGroundControl.dmg
 	)
 
-	set_target_properties(QGroundControl PROPERTIES 
-        MACOSX_BUNDLE YES
-        MACOSX_BUNDLE_INFO_PLIST ${CMAKE_SOURCE_DIR}/cmake/MacOSXBundleInfo.plist.in)
-
 elseif(WIN32)
 	if(MSVC) # Check if we are using the Visual Studio compiler
 		set_target_properties(${PROJECT_NAME} PROPERTIES

--- a/src/main.cc
+++ b/src/main.cc
@@ -345,6 +345,11 @@ int main(int argc, char *argv[])
 #endif
 #endif // QT_DEBUG
 
+#ifdef Q_OS_DARWIN
+    // Gstreamer video playback requires OpenGL
+    QQuickWindow::setGraphicsApi(QSGRendererInterface::OpenGL);
+#endif
+    
     QQuickStyle::setStyle("Basic");
     QGCApplication* app = new QGCApplication(argc, argv, runUnitTests);
     Q_CHECK_PTR(app);


### PR DESCRIPTION
* cmake wasn't building video code
* Fixed OSX app bundle permissions for camera/location
* Set Qt to use OpenGL for rendering backend to fix video streaming. Related to #11020