### PR TITLE
CI: Add android debug workflow

### DIFF
--- a/.github/workflows/android_debug.yml
+++ b/.github/workflows/android_debug.yml
@@ -1,0 +1,129 @@
+# The 32 and 64 bit version of these actions should be kept in sync
+name: Android 32/64-bit Debug
+
+on:
+  push:
+    branches:
+      - 'master'
+      - 'Stable*'
+    tags:
+      - 'v*'
+    paths-ignore:
+      - 'docs/**'
+  pull_request:
+    branches:
+    - '*'
+    paths-ignore:
+      - 'docs/**'
+
+defaults:
+  run:
+    shell: bash
+
+env:
+  SOURCE_DIR:   ${{ github.workspace }}
+  QT_VERSION:   6.6.*
+  BUILD_TYPE:   ${{ fromJSON('["DailyBuild", "StableBuild"]')[ github.ref_type == 'tag' || contains(github.ref, 'Stable_' ) ] }}
+
+jobs:
+  build:
+    runs-on:  ubuntu-latest
+
+    strategy:
+      matrix:
+       include:
+         - architecture: 32bits
+           eabi: armeabi-v7a
+           arch: android_armv7
+           ARTIFACT: QGroundControl32.apk
+         - architecture: 64bits
+           eabi: arm64-v8a
+           arch: android_arm64_v8a
+           ARTIFACT: QGroundControl64.apk
+
+    steps:
+      - name: Checkout repo
+        uses: actions/checkout@v4
+        with:
+          submodules: recursive
+
+      - run: sudo apt update
+
+      - name: ccache
+        uses: hendrikmuhs/ccache-action@v1.2
+        with:
+          create-symlink: true
+          key: ${{ runner.os }}-${{ matrix.arch }}-Release
+          restore-keys: ${{ runner.os }}-${{ matrix.arch }}-Release
+          max-size: "2G"
+          append-timestamp: false
+
+      - name: Get all tags for correct version determination
+        working-directory:  ${{ github.workspace }}
+        run: |
+          git fetch --all --tags -f --depth 1
+
+      - name: Install Qt for Linux
+        uses: jurplel/install-qt-action@v3
+        with:
+          version:      ${{ env.QT_VERSION }}
+          aqtversion:   ==3.1.*
+          host:         linux
+          target:       desktop
+          dir:          ${{ runner.temp }}
+          modules:      qtcharts qtlocation qtpositioning qtspeech qt5compat qtmultimedia qtserialport qtimageformats qtshadertools qtconnectivity qtquick3d
+          setup-python: true
+          cache:        false
+
+      - name: Install Qt6 for Android
+        uses: jurplel/install-qt-action@v3
+        with:
+          version:      ${{ env.QT_VERSION }}
+          aqtversion:   ==3.1.*
+          host:         linux
+          target:       android
+          arch:         ${{ matrix.arch }}
+          extra:        --autodesktop
+          dir:          ${{ runner.temp }}
+          modules:      qtcharts qtlocation qtpositioning qtspeech qt5compat qtmultimedia qtserialport qtimageformats qtshadertools qtconnectivity qtquick3d
+          setup-python: true
+          cache:        true
+
+      - name: Remove Android SDKs to force usage of android-33 only
+        run: |
+            ${ANDROID_SDK_ROOT}/cmdline-tools/latest/bin/sdkmanager --uninstall "platforms;android-33-ext5"
+            ${ANDROID_SDK_ROOT}/cmdline-tools/latest/bin/sdkmanager --uninstall "platforms;android-33-ext4"
+            ${ANDROID_SDK_ROOT}/cmdline-tools/latest/bin/sdkmanager --uninstall "platforms;android-34"
+            ${ANDROID_SDK_ROOT}/cmdline-tools/latest/bin/sdkmanager --uninstall "platforms;android-34-ext8"
+
+      - name:               Install gstreamer
+        working-directory:  ${{ github.workspace }}
+        run: |
+            wget --quiet https://gstreamer.freedesktop.org/data/pkg/android/1.18.5/gstreamer-1.0-android-universal-1.18.5.tar.xz
+            mkdir gstreamer-1.0-android-universal-1.18.5
+            tar xf gstreamer-1.0-android-universal-1.18.5.tar.xz -C gstreamer-1.0-android-universal-1.18.5
+
+      - name: Update android manifest
+        if: github.ref_name != 'Stable'
+        run: ${SOURCE_DIR}/tools/update_android_manifest_package.sh ${{ github.ref_name }}
+
+      - name: Install dependencies
+        run:  sudo apt-get install -y ninja-build
+
+      - name: Setup env
+        run: echo "QT_HOST_PATH=${Qt6_DIR}/../gcc_64" >> $GITHUB_ENV
+
+      - name: Create build directory
+        run:  mkdir ${{ runner.temp }}/shadow_build_dir
+
+      - name: Build
+        working-directory: ${{ runner.temp }}/shadow_build_dir
+        run:  |
+            chmod a+x ${Qt6_DIR}/bin/qt-cmake
+            ${Qt6_DIR}/bin/qt-cmake -S ${{ env.SOURCE_DIR }} -B ${{ runner.temp }}/shadow_build_dir/ -G Ninja \
+              -DCMAKE_BUILD_TYPE=Debug \
+              -DANDROID_ABI=${{ matrix.eabi }} \
+              -DANDROID_PLATFORM=android-23 \
+              -DBUILD_TESTING:BOOL=OFF \
+              -DQT_HOST_PATH:PATH=${{ env.QT_HOST_PATH }}
+            cmake --build ${{ runner.temp }}/shadow_build_dir/ --target all

--- a/cmake/Qt6QGCConfiguration.cmake
+++ b/cmake/Qt6QGCConfiguration.cmake
@@ -3,7 +3,7 @@ if(DEFINED ENV{QT_VERSION})
 endif()
 
 if(NOT QT_VERSION)
-	# if QT version not specified then use any available version (5.12 or 5.15 only)
+	# if QT version not specified then use any available version
 	file(GLOB FOUND_QT_VERSIONS
 		LIST_DIRECTORIES true
 		$ENV{HOME}/Qt/6.6.*
@@ -12,7 +12,7 @@ if(NOT QT_VERSION)
 		return()
 	endif()
 	list(GET FOUND_QT_VERSIONS 0 QT_VERSION_PATH)
-	get_filename_component(QT_VERSION ${QT_VERSION_PATH} NAME)	
+	get_filename_component(QT_VERSION ${QT_VERSION_PATH} NAME)
 endif()
 
 if(DEFINED ENV{QT_MKSPEC})
@@ -34,6 +34,12 @@ if(NOT QT_MKSPEC)
 		set(QT_MKSPEC gcc_64)
 	elseif(WIN32)
 		set(QT_MKSPEC msvc2017_64)
+	elseif(ANDROID)
+		if(${ANDROID_ABI} STREQUAL armeabi-v7a)
+			set(QT_MKSPEC android_armv7)
+		elseif(${ANDROID_ABI} STREQUAL arm64-v8a)
+			set(QT_MKSPEC android_arm64_v8a)
+		endif()
 	endif()
 endif()
 

--- a/test/qgcunittest/UnitTest.h
+++ b/test/qgcunittest/UnitTest.h
@@ -7,7 +7,6 @@
  *
  ****************************************************************************/
 
-#ifndef __mobile__
 #pragma once
 
 #include <QObject>
@@ -209,5 +208,3 @@ public:
 private:
     QSharedPointer<T> _unitTest;
 };
-
-#endif


### PR DESCRIPTION
This doesn't build successfully because of a missing QtQuick3DTools lib, but I only see that available in the desktop Qt build? I'm not sure if this is a Qt bug or there's something I'm misunderstanding. Having set QT_HOST_PATH correctly, it shouldn't be related to the fact that it's cross-compiling for mobile. Although it builds for qmake so that shows I'm probably doing something wrong tho.
`Qt6Quick3D could not be found because dependency Qt6Quick3DTools could not be found.`

Here are the available Android libs:
![image](https://github.com/mavlink/qgroundcontrol/assets/68555040/4f6deb11-8d56-418d-865c-eb8de2906e16)
And here's the same for Linux:
![image](https://github.com/mavlink/qgroundcontrol/assets/68555040/aa200d6c-c987-499a-ba7c-a297e514a3f7)

There is no Qt6Quick3DTools for Android so I don't really understand.


Also, I know there's a lot of workflows and they take forever now. Hopefully we can narrow that down soon but this at least ensures CMake will  work for everything.