### PR TITLE
Photo video control rework

### DIFF
--- a/src/Camera/QGCCameraControl.h
+++ b/src/Camera/QGCCameraControl.h
@@ -212,24 +212,24 @@ public:
     Q_PROPERTY(bool         trackingImageStatus READ trackingImageStatus                            NOTIFY trackingImageStatusChanged)
     Q_PROPERTY(QRectF       trackingImageRect   READ trackingImageRect                              NOTIFY trackingImageStatusChanged)
 
-    Q_INVOKABLE virtual void setVideoMode   ();
-    Q_INVOKABLE virtual void setPhotoMode   ();
-    Q_INVOKABLE virtual void toggleMode     ();
-    Q_INVOKABLE virtual bool takePhoto      ();
-    Q_INVOKABLE virtual bool stopTakePhoto  ();
-    Q_INVOKABLE virtual bool startVideo     ();
-    Q_INVOKABLE virtual bool stopVideo      ();
-    Q_INVOKABLE virtual bool toggleVideo    ();
-    Q_INVOKABLE virtual void resetSettings  ();
-    Q_INVOKABLE virtual void formatCard     (int id = 1);
-    Q_INVOKABLE virtual void stepZoom       (int direction);
-    Q_INVOKABLE virtual void startZoom      (int direction);
-    Q_INVOKABLE virtual void stopZoom       ();
-    Q_INVOKABLE virtual void stopStream     ();
-    Q_INVOKABLE virtual void resumeStream   ();
-    Q_INVOKABLE virtual void startTracking  (QRectF rec);
-    Q_INVOKABLE virtual void startTracking  (QPointF point, double radius);
-    Q_INVOKABLE virtual void stopTracking   ();
+    Q_INVOKABLE virtual void setVideoMode       ();
+    Q_INVOKABLE virtual void setPhotoMode       ();
+    Q_INVOKABLE virtual void toggleMode         ();
+    Q_INVOKABLE virtual bool takePhoto          ();
+    Q_INVOKABLE virtual bool stopTakePhoto      ();
+    Q_INVOKABLE virtual bool startVideoRecording();
+    Q_INVOKABLE virtual bool stopVideoRecording ();
+    Q_INVOKABLE virtual bool toggleVideoRecording();
+    Q_INVOKABLE virtual void resetSettings      ();
+    Q_INVOKABLE virtual void formatCard         (int id = 1);
+    Q_INVOKABLE virtual void stepZoom           (int direction);
+    Q_INVOKABLE virtual void startZoom          (int direction);
+    Q_INVOKABLE virtual void stopZoom           ();
+    Q_INVOKABLE virtual void stopStream         ();
+    Q_INVOKABLE virtual void resumeStream       ();
+    Q_INVOKABLE virtual void startTracking      (QRectF rec);
+    Q_INVOKABLE virtual void startTracking      (QPointF point, double radius);
+    Q_INVOKABLE virtual void stopTracking       ();
 
     virtual int         version             () { return _version; }
     virtual QString     modelName           () { return _modelName; }
@@ -407,6 +407,9 @@ private:
     QStringList     _loadExclusions         (QDomNode option);
     QStringList     _loadUpdates            (QDomNode option);
     QString         _getParamName           (const char* param_id);
+    QString         captureImageStatusToStr (uint8_t image_status);
+    QString         captureVideoStatusToStr (uint8_t video_status);
+    QString         storageStatusToStr      (uint8_t status);
 
 protected:
     Vehicle*                            _vehicle            = nullptr;

--- a/src/Camera/QGCCameraManager.cc
+++ b/src/Camera/QGCCameraManager.cc
@@ -445,7 +445,7 @@ QGCCameraManager::_startVideoRecording()
 {
     QGCCameraControl* pCamera = currentCameraInstance();
     if(pCamera) {
-        pCamera->startVideo();
+        pCamera->startVideoRecording();
     }
 }
 
@@ -455,7 +455,7 @@ QGCCameraManager::_stopVideoRecording()
 {
     QGCCameraControl* pCamera = currentCameraInstance();
     if(pCamera) {
-        pCamera->stopVideo();
+        pCamera->stopVideoRecording();
     }
 }
 
@@ -465,7 +465,7 @@ QGCCameraManager::_toggleVideoRecording()
 {
     QGCCameraControl* pCamera = currentCameraInstance();
     if(pCamera) {
-        pCamera->toggleVideo();
+        pCamera->toggleVideoRecording();
     }
 }
 

--- a/src/FlightDisplay/FlyViewTopRightColumnLayout.qml
+++ b/src/FlightDisplay/FlyViewTopRightColumnLayout.qml
@@ -50,8 +50,7 @@ ColumnLayout {
 
     PhotoVideoControl {
         id:                     photoVideoControl
-        Layout.alignment:       Qt.AlignVCenter
-        Layout.fillWidth:       true
+        Layout.alignment:       Qt.AlignVCenter | Qt.AlignRight
 
         property real rightEdgeCenterInset: visible ? parent.width - x : 0
     }

--- a/src/FlightMap/FlightMap.qml
+++ b/src/FlightMap/FlightMap.qml
@@ -111,7 +111,7 @@ Map {
     }
 
     Connections {
-        target: GroundControl.settingsManager.flightMapSettings.mapProvider
+        target: QGroundControl.settingsManager.flightMapSettings.mapProvider
         function onRawValueChanged() { updateActiveMapType() }
     }
 


### PR DESCRIPTION
* Added zoom slider support
* Reordered controls for better grouping of things which go together
* Take less horizontal real estate

Before:
<img width="255" alt="Screenshot 2024-02-29 at 3 17 13 PM" src="https://github.com/mavlink/qgroundcontrol/assets/5876851/31c911b3-2469-44e3-8a47-07063a210085">

After:
<img width="190" alt="Screenshot 2024-02-29 at 3 38 39 PM" src="https://github.com/mavlink/qgroundcontrol/assets/5876851/dd630018-9e22-49ed-9d45-04fa197b86ef">

Simple (non mavlink camera protocol) camera: controls:
<img width="117" alt="Screenshot 2024-02-29 at 3 45 09 PM" src="https://github.com/mavlink/qgroundcontrol/assets/5876851/7925a708-571f-41d2-8833-410b895e050f">

