### PR TITLE
3D View fixes: showing all types of buildings as well as the ROI

### DIFF
--- a/src/FlightDisplay/FlyViewToolStripActionList.qml
+++ b/src/FlightDisplay/FlyViewToolStripActionList.qml
@@ -16,7 +16,6 @@ ToolStripActionList {
     id: _root
 
     signal displayPreFlightChecklist
-    property bool   _viewer3DEnabled:        QGroundControl.settingsManager.viewer3DSettings.enabled.rawValue
 
     model: [
         ToolStripAction {
@@ -28,7 +27,8 @@ ToolStripActionList {
             }
         },
         ToolStripAction {
-            property bool _is3DViewOpen: viewer3DWindow.isOpen
+            property bool _is3DViewOpen:            viewer3DWindow.isOpen
+            property bool   _viewer3DEnabled:       QGroundControl.settingsManager.viewer3DSettings.enabled.rawValue
 
             id: view3DIcon
             visible: _viewer3DEnabled
@@ -47,7 +47,6 @@ ToolStripActionList {
                     view3DIcon.iconSource =     "/qmlimages/PaperPlane.svg"
                     text=           qsTr("Fly")
                 }else{
-                    viewer3DWindow.close()
                     iconSource =     "/qmlimages/Viewer3D/City3DMapIcon.svg"
                     text =           qsTr("3D View")
                 }

--- a/src/Viewer3D/OsmParser.h
+++ b/src/Viewer3D/OsmParser.h
@@ -20,11 +20,34 @@ class OsmParser : public QObject
     struct BuildingType
     {
         std::vector<QGeoCoordinate> points_gps;
+        std::vector<QGeoCoordinate> points_gps_inner;
         std::vector<QVector2D> points_local;
+        std::vector<QVector2D> points_local_inner;
         std::vector<QVector3D> triangulated_mesh;
-        QVector2D bb_max, bb_min; //bounding boxes
+        QVector2D bb_max = QVector2D(-1e6, -1e6); //bounding boxes
+        QVector2D bb_min = QVector2D(1e6, 1e6); //bounding boxes
         float height;
-        int levels;
+        float levels;
+
+        void append(std::vector<QGeoCoordinate> newPoints, bool isInner){
+            for(uint i=0; i<newPoints.size(); i++){
+                if(isInner){
+                points_gps_inner.push_back(newPoints[i]);
+                }else{
+                    points_gps.push_back(newPoints[i]);
+                }
+            }
+        }
+
+        void append(std::vector<QVector2D> newPoints, bool isInner){
+            for(uint i=0; i<newPoints.size(); i++){
+                if(isInner){
+                    points_local_inner.push_back(newPoints[i]);
+                }else{
+                    points_local.push_back(newPoints[i]);
+                }
+            }
+        }
     };
 
     Q_OBJECT
@@ -42,6 +65,7 @@ public:
     void parseOsmFile(QString filePath);
     void decodeNodeTags(QDomElement& xmlComponent, QMap<uint64_t, QGeoCoordinate> &nodeMap);
     void decodeBuildings(QDomElement& xmlComponent, QMap<uint64_t, BuildingType > &buildingMap, QMap<uint64_t, QGeoCoordinate> &nodeMap, QGeoCoordinate gpsRef);
+    void decodeRelations(QDomElement& xmlComponent, QMap<uint64_t, BuildingType > &buildingMap, QMap<uint64_t, QGeoCoordinate> &nodeMap, QGeoCoordinate gpsRef);
 
     QByteArray buildingToMesh();
 
@@ -52,11 +76,14 @@ private:
     QGeoCoordinate _gpsRefPoint;
     QMap<uint64_t, QGeoCoordinate> _mapNodes;
     QMap<uint64_t, BuildingType> _mapBuildings;
+    QGeoCoordinate _coordinate_min, _coordinate_max; //Osm map bounding boxes in global coordinate
 
     bool _gpsRefSet;
     float _buildingLevelHeight;
     bool _mapLoadedFlag;
     Viewer3DSettings* _viewer3DSettings = nullptr;
+    QList<QString> _singleStoreyBuildings;
+    QList<QString> _doubleStoreyLeisure;
 
 
 signals:

--- a/src/Viewer3D/Viewer3D/Models3D/Viewer3DModel.qml
+++ b/src/Viewer3D/Viewer3D/Models3D/Viewer3DModel.qml
@@ -97,8 +97,14 @@ View3D {
             osmParser: (viewer3DManager)?(viewer3DManager.osmParser):(null)
         }
 
-        materials: [ DefaultMaterial {
-                diffuseColor: "gray"
+        materials: [
+            PrincipledMaterial {
+                baseColor: "gray"
+                metalness: 0.1
+                roughness: 0.5
+                specularAmount: 1.0
+                indexOfRefraction: 4.0
+                opacity: 1.0
             }
         ]
     }

--- a/src/Viewer3D/Viewer3D/Models3D/Viewer3DVehicleItems.qml
+++ b/src/Viewer3D/Viewer3D/Models3D/Viewer3DVehicleItems.qml
@@ -32,16 +32,18 @@ Node {
         var _geo2EnuCopy = goe2Enu
 
         for (var i = 1; i < _missionController.visualItems.count; i++) {
-            var _missionItem = _missionController.visualItems.get(i)
-            _geo2EnuCopy.coordinate = _missionItem.coordinate
-            _geo2EnuCopy.coordinate.altitude = 0
-            missionWaypointListModel.append({
-                                                "x": _geo2EnuCopy.localCoordinate.x,
-                                                "y": _geo2EnuCopy.localCoordinate.y,
-                                                "z": _missionItem.altitude.value,
-                                                "isTakeoffItem": _missionItem.isTakeoffItem,
-                                                "index": _missionItem.sequenceNumber,
-                                            })
+            var _missionItem = _missionController.visualItems.get(i); // list of all properties in VisualMissionItem.h and SimpleMissionItem.h
+            if(_missionItem.specifiesCoordinate){
+                _geo2EnuCopy.coordinate = _missionItem.coordinate;
+                _geo2EnuCopy.coordinate.altitude = 0;
+                missionWaypointListModel.append({
+                                                    "x": _geo2EnuCopy.localCoordinate.x,
+                                                    "y": _geo2EnuCopy.localCoordinate.y,
+                                                    "z": _missionItem.altitude.value,
+                                                    "abbreviation": _missionItem.abbreviation,
+                                                    "index": _missionItem.sequenceNumber,
+                                                });
+            }
         }
     }
 
@@ -49,25 +51,28 @@ Node {
         missionPathModel.clear()
         var _geo2EnuCopy = goe2Enu
 
+        var _missionItemPrevious = _missionController.visualItems.get(1)
         for (var i = 2; i < _missionController.visualItems.count; i++) {
-            var _missionItem = _missionController.visualItems.get(i-1)
-            _geo2EnuCopy.coordinate = _missionItem.coordinate
-            _geo2EnuCopy.coordinate.altitude = 0
-            var p1 = Qt.vector3d(_geo2EnuCopy.localCoordinate.x, _geo2EnuCopy.localCoordinate.y, _missionItem.altitude.value)
+            var _missionItem = _missionController.visualItems.get(i)
+            if(_missionItem.abbreviation !== "ROI" && _missionItem.specifiesCoordinate){
+                _geo2EnuCopy.coordinate = _missionItemPrevious.coordinate;
+                _geo2EnuCopy.coordinate.altitude = 0;
+                var p1 = Qt.vector3d(_geo2EnuCopy.localCoordinate.x, _geo2EnuCopy.localCoordinate.y, _missionItemPrevious.altitude.value);
 
-            _missionItem = _missionController.visualItems.get(i)
-            _geo2EnuCopy.coordinate = _missionItem.coordinate
-            _geo2EnuCopy.coordinate.altitude = 0
-            var p2 = Qt.vector3d(_geo2EnuCopy.localCoordinate.x, _geo2EnuCopy.localCoordinate.y, _missionItem.altitude.value)
+                _geo2EnuCopy.coordinate = _missionItem.coordinate;
+                _geo2EnuCopy.coordinate.altitude = 0;
+                var p2 = Qt.vector3d(_geo2EnuCopy.localCoordinate.x, _geo2EnuCopy.localCoordinate.y, _missionItem.altitude.value);
 
-            missionPathModel.append({
-                                        "x_1": p1.x,
-                                        "y_1": p1.y,
-                                        "z_1": p1.z,
-                                        "x_2": p2.x,
-                                        "y_2": p2.y,
-                                        "z_2": p2.z,
-                                    })
+                missionPathModel.append({
+                                            "x_1": p1.x,
+                                            "y_1": p1.y,
+                                            "z_1": p1.z,
+                                            "x_2": p2.x,
+                                            "y_2": p2.y,
+                                            "z_2": p2.z,
+                                        });
+                _missionItemPrevious = _missionItem;
+            }
         }
     }
 

--- a/src/Viewer3D/Viewer3D/Models3D/Waypoint3DModel.qml
+++ b/src/Viewer3D/Viewer3D/Models3D/Waypoint3DModel.qml
@@ -29,10 +29,44 @@ Node{
             id: nose
             source: "#Cone"
             materials: [ DefaultMaterial {
-                    diffuseColor: ( waypointBody.missionItem.isTakeoffItem)?("green"):("black")
-
+                    diffuseColor: {
+                        let _abbreviation = abbreviation;
+                        if(_abbreviation === "Takeoff"){
+                            return "green";
+                        }else if(abbreviation === "ROI"){
+                            return "red"
+                        }
+                        return "black"
+                    }
                 }
             ]
+        }
+    }
+
+    Node
+    {
+        Text {
+            color: "black"
+            text: {
+                let _abbreviation = abbreviation;
+                if(_abbreviation === "Takeoff"){
+                    return "T";
+                }else if(abbreviation === "ROI"){
+                    return "R"
+                }
+                return ""
+            }
+            font.pixelSize: 20
+        }
+
+        eulerRotation{
+            x:90
+            y:0
+            z:0
+        }
+        position{
+            z: 30
+            x: -6
         }
     }
 }

--- a/src/Viewer3D/Viewer3D/Viewer3D.qml
+++ b/src/Viewer3D/Viewer3D/Viewer3D.qml
@@ -24,15 +24,16 @@ Item{
         if(_viewer3DEnabled === true){
             view3DManagerLoader.sourceComponent = viewer3DManagerComponent
             view3DManagerLoader.active = true;
-            viewer3DBody.z = 1
             isOpen = true;
         }
     }
 
     function close(){
-        viewer3DBody.z = 0
         isOpen = false;
     }
+
+    visible: isOpen
+    enabled: isOpen
 
     on_Viewer3DEnabledChanged: {
         if(_viewer3DEnabled === false){


### PR DESCRIPTION
The following changes have been made in this pull request to improve the 3D View:

- All types of buildings are now fetched from the OSM file and added to the 3D View.
- The ROI is shown with a separate marker (Letter "R") in the 3D View
- The takeoff position is also marked with the letter "T" in the 3D View

Here is a picture demonstrating the new changes:

![Screenshot from 2024-03-01 20-54-23](https://github.com/mavlink/qgroundcontrol/assets/115142498/9356d0f7-0cc3-4390-bad0-4a96c25a9874)

