### PR TITLE
CMake: Update compile definitions

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -38,18 +38,17 @@ if(QGC_STABLE_BUILD)
     message(STATUS "Stable Build")
 else()
     message(STATUS "Daily Build")
-    add_definitions(-DDAILY_BUILD)
+    add_compile_definitions(DAILY_BUILD)
 endif()
 
 include(CMakeDependentOption)
 cmake_dependent_option(QGC_BUILD_TESTING "Enable testing" ON "CMAKE_BUILD_TYPE STREQUAL Debug" OFF)
 
+include(CompileOptions)
+
 #######################################################
 #               Qt6 Configuration
 #######################################################
-
-add_compile_definitions(QT_DISABLE_DEPRECATED_BEFORE=0x060600)
-add_compile_definitions(QT_DEBUG_FIND_PACKAGE=ON)
 
 include(Qt6QGCConfiguration)
 message(STATUS "Build Type: ${CMAKE_BUILD_TYPE}")
@@ -82,7 +81,7 @@ find_package(Qt6
     OPTIONAL_COMPONENTS
         SerialPort
     HINTS
-        {QT_LIBRARY_HINTS}
+        ${QT_LIBRARY_HINTS}
 )
 
 qt_standard_project_setup(REQUIRES 6.6.0)
@@ -114,8 +113,10 @@ option(QGC_DEBUG_QML "Build QGroundControl with QML debugging/profiling support.
 add_feature_info(DEBUG_QML DEBUG_QML "Build QGroundControl with QML debugging/profiling support.")
 if(QGC_DEBUG_QML)
     message(STATUS "To enable the QML debugger/profiler, run with: '-qmljsdebugger=port:1234'")
-    add_definitions(-DQMLJSDEBUGGER)
-    add_definitions(-DQT_QML_DEBUG)
+    add_compile_definitions(
+        QMLJSDEBUGGER
+        QT_QML_DEBUG
+    )
 endif()
 
 #######################################################
@@ -126,10 +127,10 @@ set(COMPANY "Mavlink")
 set(COPYRIGHT "Copyright (c) 2018 QGroundControl. All rights reserved.")
 set(IDENTIFIER "io.mavlink.qgroundcontrol")
 
-add_definitions(
-    -DQGC_APPLICATION_NAME="QGroundControl"
-    -DQGC_ORG_NAME="QGroundControl.org"
-    -DQGC_ORG_DOMAIN="org.qgroundcontrol"
+add_compile_definitions(
+    QGC_APPLICATION_NAME="QGroundControl"
+    QGC_ORG_NAME="QGroundControl.org"
+    QGC_ORG_DOMAIN="org.qgroundcontrol"
 )
 
 #######################################################
@@ -139,8 +140,6 @@ add_definitions(
 include(Git)
 message(STATUS "QGroundControl version: ${APP_VERSION_STR}")
 # set_target_properties(${PROJECT_NAME} PROPERTIES VERSION 1.0)
-
-include(CompileOptions)
 
 #######################################################
 #                QGroundControl Resources

--- a/cmake/CompileOptions.cmake
+++ b/cmake/CompileOptions.cmake
@@ -1,24 +1,33 @@
+if(UNIX AND NOT APPLE AND NOT ANDROID)
+	set(LINUX TRUE)
+endif()
 
-if(${CMAKE_BUILD_TYPE} MATCHES "Debug")
+if(APPLE AND NOT IOS)
+	set(MACOS TRUE)
+endif()
+
+if(${CMAKE_BUILD_TYPE} STREQUAL "Debug")
 	include(CTest)
 	enable_testing()
 	if(QGC_BUILD_TESTING)
         message("Building tests")
-		add_definitions(-DUNITTEST_BUILD)
+		add_compile_definitions(UNITTEST_BUILD) # TODO: QGC_UNITTEST_BUILD
 	else()
 		# will prevent the definition of QT_DEBUG, which enables code that uses MockLink
 		add_compile_definitions(QT_NO_DEBUG)
 	endif()
+elseif(${CMAKE_BUILD_TYPE} STREQUAL "Release")
+	add_compile_definitions(QGC_INSTALL_RELEASE)
 endif()
 
-if (CMAKE_CXX_COMPILER_ID MATCHES "Clang")
+if(CMAKE_CXX_COMPILER_ID STREQUAL "Clang")
 	# clang and AppleClang
 	add_compile_options(
 		-Wall
 		-Wextra
 		-Wno-address-of-packed-member # ignore for mavlink
 	)
-elseif (CMAKE_CXX_COMPILER_ID STREQUAL "GNU")
+elseif(CMAKE_CXX_COMPILER_ID STREQUAL "GNU")
 	# GCC
 	if(CMAKE_CXX_COMPILER_VERSION VERSION_GREATER 4.9)
 		add_compile_options(-fdiagnostics-color=always)
@@ -28,12 +37,17 @@ elseif (CMAKE_CXX_COMPILER_ID STREQUAL "GNU")
 		-Wall
 		-Wextra
 	)
-elseif (WIN32)
-	add_definitions(-D_USE_MATH_DEFINES)
+elseif(WIN32)
+	add_compile_definitions(_USE_MATH_DEFINES)
 	add_compile_options(
 		/wd4244 # warning C4244: '=': conversion from 'double' to 'float', possible loss of data
     )
 endif()
+
+add_compile_definitions(
+    QT_DISABLE_DEPRECATED_BEFORE=0x060600
+    QT_DEBUG_FIND_PACKAGE=ON
+)
 
 if(ANDROID OR IOS)
 	set(MOBILE TRUE)
@@ -45,3 +59,10 @@ if(ANDROID)
 elseif(IOS)
 	add_compile_definitions(__ios__)
 endif()
+
+if(NOT EXISTS ${CMAKE_SOURCE_DIR}/libs/mavlink/include/mavlink/v2.0/ardupilotmega)
+	add_compile_definitions(NO_ARDUPILOT_DIALECT) # TODO: Make this QGC_NO_ARDUPILOT_DIALECT
+endif()
+
+# option(QGC_CUSTOM_BUILD "Enable Custom Build" OFF)
+# option(QGC_DISABLE_MAVLINK_INSPECTOR "Disable Mavlink Inspector" OFF) # This removes QtCharts which is GPL licensed

--- a/cmake/Qt6QGCConfiguration.cmake
+++ b/cmake/Qt6QGCConfiguration.cmake
@@ -19,14 +19,6 @@ if(DEFINED ENV{QT_MKSPEC})
 	set(QT_MKSPEC $ENV{QT_MKSPEC})
 endif()
 
-if(UNIX AND NOT APPLE AND NOT ANDROID)
-	set(LINUX TRUE)
-endif()
-
-if(APPLE AND NOT IOS)
-	set(MACOS TRUE)
-endif()
-
 if(NOT QT_MKSPEC)
 	if(APPLE)
 		set(QT_MKSPEC clang_64)

--- a/libs/CMakeLists.txt
+++ b/libs/CMakeLists.txt
@@ -1,28 +1,46 @@
 add_subdirectory(libevents)
-
-if(ANDROID)
-    include(${CMAKE_CURRENT_SOURCE_DIR}/OpenSSL/android_openssl/android_openssl.cmake)
-    add_subdirectory(qtandroidserialport)
-elseif(WIN32)
-    add_subdirectory(sdl2)
-    add_subdirectory(zlib)
-endif()
-
-option(QGC_ENABLE_VIDEOSTREAMING "Enable video streaming" ON)
-if(QGC_ENABLE_VIDEOSTREAMING)
-    message(STATUS "Enabling video streaming support")
-    add_subdirectory(qmlglsink)
-else()
-    message(STATUS "Video streaming disabled")
-endif()
+add_subdirectory(OpenSSL)
+add_subdirectory(qtandroidserialport)
+add_subdirectory(sdl2)
+add_subdirectory(zlib)
+add_subdirectory(qmlglsink)
 
 set(BUILD_SHARED_LIBS OFF CACHE BOOL "Force qmdnsengine & shapelib to build as static" FORCE)
 add_subdirectory(shapelib)
+add_subdirectory(qmdnsengine)
 
-option(QGC_QT6_DISABLE_DNSENGINE "Disable DNS Engine" OFF)
-if(QGC_QT6_DISABLE_DNSENGINE)
-    message(STATUS "DNS Engine disabled")
-    add_compile_definitions(QT6_DISABLE_DNSENGINE=ON)
-else()
-    add_subdirectory(qmdnsengine)
-endif()
+qt_add_library(xz STATIC
+    xz-embedded/linux/include/linux/xz.h
+    xz-embedded/linux/include/linux/decompress/unxz.h
+    # xz-embedded/linux/lib/decompress_unxz.c
+    xz-embedded/linux/lib/xz/xz_crc32.c
+    xz-embedded/linux/lib/xz/xz_crc64.c
+    xz-embedded/linux/lib/xz/xz_dec_bcj.c
+    xz-embedded/linux/lib/xz/xz_dec_lzma2.c
+    xz-embedded/linux/lib/xz/xz_dec_stream.c
+    # xz-embedded/linux/lib/xz/xz_dec_syms.c
+    # xz-embedded/linux/lib/xz/xz_dec_test.c
+    xz-embedded/linux/lib/xz/xz_lzma2.h
+    xz-embedded/linux/lib/xz/xz_private.h
+    xz-embedded/linux/lib/xz/xz_stream.h
+    # xz-embedded/userspace/boottest.c
+    # xz-embedded/userspace/buftest.c
+    # xz-embedded/userspace/bytetest.c
+    xz-embedded/userspace/xz_config.h
+    # xz-embedded/userspace/xzminidec.c
+)
+
+target_include_directories(xz
+    PUBLIC
+        xz-embedded/linux/include
+        xz-embedded/linux/include/linux
+        xz-embedded/linux/include/linux/decompress
+        xz-embedded/linux/lib/xz
+        xz-embedded/userspace
+)
+
+target_compile_definitions(xz
+    PUBLIC
+        XZ_DEC_ANY_CHECK
+        XZ_USE_CRC64
+)

--- a/libs/OpenSSL/CMakeLists.txt
+++ b/libs/OpenSSL/CMakeLists.txt
@@ -1,0 +1,3 @@
+if(ANDROID)
+    include(android_openssl/android_openssl.cmake)
+endif()

--- a/libs/libevents/CMakeLists.txt
+++ b/libs/libevents/CMakeLists.txt
@@ -1,17 +1,64 @@
-find_package(Qt6 COMPONENTS Core REQUIRED)
+find_package(Qt6 REQUIRED COMPONENTS Core)
 
-add_library(libevents_generated)
-target_include_directories(libevents_generated INTERFACE ${CMAKE_CURRENT_SOURCE_DIR}/libevents/libs/cpp/generated)
+qt_add_library(libevents_generated STATIC
+    libevents/libs/cpp/generated/events_generated.h
+)
 
-add_library(libevents_parser
-        definitions.cpp
-        libevents/libs/cpp/parse/parser.cpp
-        libevents/libs/cpp/protocol/receive.cpp
-        )
-target_include_directories(libevents_parser PUBLIC ${CMAKE_CURRENT_SOURCE_DIR})
-target_link_libraries(libevents_parser PUBLIC Qt6::Core)
-target_link_libraries(libevents_parser PUBLIC comm)
+target_include_directories(libevents_generated
+    PUBLIC
+        ${CMAKE_CURRENT_SOURCE_DIR}
+        libevents/libs/cpp/generated
+)
 
-add_library(libevents_health_and_arming_checks
-    libevents/libs/cpp/parse/health_and_arming_checks.cpp)
-target_link_libraries(libevents_health_and_arming_checks PRIVATE comm)
+
+qt_add_library(libevents_parser STATIC
+    definitions.cpp
+    libevents_definitions.h
+    libevents/libs/cpp/parse/parser.cpp
+    libevents/libs/cpp/parse/parser.h
+    libevents/libs/cpp/protocol/receive.cpp
+    libevents/libs/cpp/protocol/receive.h
+)
+
+add_subdirectory(libevents/libs/cpp/parse/nlohmann_json)
+
+target_include_directories(libevents_parser
+    PUBLIC
+        ${CMAKE_CURRENT_SOURCE_DIR}
+        libevents/libs/cpp/parse
+        libevents/libs/cpp/protocol
+)
+
+target_link_libraries(libevents_parser
+    PRIVATE
+        qgc
+    PUBLIC
+        Qt6::Core
+        comm
+)
+
+
+qt_add_library(libevents_health_and_arming_checks STATIC
+    libevents/libs/cpp/parse/health_and_arming_checks.cpp
+    libevents/libs/cpp/parse/health_and_arming_checks.h
+)
+
+target_include_directories(libevents_health_and_arming_checks
+    PUBLIC
+        ${CMAKE_CURRENT_SOURCE_DIR}
+        libevents/libs/cpp/parse
+)
+
+target_link_libraries(libevents_health_and_arming_checks
+    PUBLIC
+        libevents_parser
+)
+
+
+qt_add_library(libevents STATIC)
+
+target_link_libraries(libevents
+    PUBLIC
+        libevents_generated
+        libevents_health_and_arming_checks
+)

--- a/libs/qmlglsink/CMakeLists.txt
+++ b/libs/qmlglsink/CMakeLists.txt
@@ -1,99 +1,111 @@
-find_package(PkgConfig)
+option(QGC_ENABLE_VIDEOSTREAMING "Enable video streaming" ON)
+if(QGC_ENABLE_VIDEOSTREAMING)
+    message(STATUS "Enabling video streaming support")
 
-set(GST_DEPENDENCIES
-    gstreamer-1.0>=1.16
-    gstreamer-video-1.0>=1.16
-    gstreamer-gl-1.0>=1.16
-)
+	find_package(PkgConfig)
 
-if(LINUX OR ANDROID)
-    set(GST_DEPENDENCIES ${GST_DEPENDENCIES} egl)
-endif()
-
-if(NOT ANDROID)
-	pkg_check_modules(GST
-	    ${GST_DEPENDENCIES}
-	)
-endif()
-
-message(STATUS "GStreamer libs: ${GST_LIBRARIES}")
-message(STATUS "GStreamer include dirs: ${GST_INCLUDE_DIRS}")
-message(STATUS "GStreamer link dirs: ${GST_LIBRARY_DIRS}")
-message(STATUS "GStreamer cflags: ${GST_CFLAGS}")
-message(STATUS "GStreamer ldflags: ${GST_LDFLAGS}")
-message(STATUS "GStreamer libs: ${GST_LIBS}")
-
-if(LINUX OR ANDROID)
-    message(STATUS "GStreamer egl libs: ${GST_EGL_LIBRARIES}")
-    message(STATUS "GStreamer egl include dirs: ${GST_EGL_INCLUDE_DIRS}")
-    message(STATUS "GStreamer egl link dirs: ${GST_EGL_LIBRARY_DIRS}")
-    message(STATUS "GStreamer egl cflags: ${GST_EGL_CFLAGS}")
-    message(STATUS "GStreamer egl ldflags: ${GST_EGL_LDFLAGS}")
-    message(STATUS "GStreamer egl libs: ${GST_EGL_LIBS}")
-endif()
-
-message(STATUS "gst found ${GST_FOUND}")
-
-if(GST_FOUND)
-    message(STATUS "Building qmlglsink")
-
-	find_package(Qt6 REQUIRED COMPONENTS Gui OpenGL)
-	find_package(OpenGL)
-
-	add_library(qmlglsink
-		gst-plugins-good/ext/qt6/gstplugin.cc
-	    gst-plugins-good/ext/qt6/gstqml6glsink.cc
-	    gst-plugins-good/ext/qt6/gstqsg6glnode.cc
-	    gst-plugins-good/ext/qt6/gstqt6element.cc
-	    gst-plugins-good/ext/qt6/gstqt6glutility.cc
-	    gst-plugins-good/ext/qt6/qt6glitem.cc
-	    gst-plugins-good/ext/qt6/gstqt6gl.h
+	set(GST_DEPENDENCIES
+	    gstreamer-1.0>=1.16
+	    gstreamer-video-1.0>=1.16
+	    gstreamer-gl-1.0>=1.16
 	)
 
-    target_compile_definitions(qmlglsink PUBLIC QGC_GST_STREAMING)
+	if(LINUX OR ANDROID)
+	    list(APPEND GST_DEPENDENCIES egl)
+	endif()
 
-	if(LINUX)
-		option(USE_WAYLAND "Use Wayland instead of X11 for building GST" ON)
-		if(USE_WAYLAND)
-			message(STATUS "Using wayland for qmlglsink")
-			target_compile_definitions(qmlglsink PUBLIC HAVE_QT_WAYLAND)
-		else()
-			message(STATUS "Using x11 for qmlglsink")
-			target_compile_definitions(qmlglsink PUBLIC HAVE_QT_X11)
+    if(NOT ANDROID)
+        pkg_check_modules(GST
+            ${GST_DEPENDENCIES}
+        )
+    endif()
+
+	message(STATUS "GStreamer libs: ${GST_LIBRARIES}")
+	message(STATUS "GStreamer include dirs: ${GST_INCLUDE_DIRS}")
+	message(STATUS "GStreamer link dirs: ${GST_LIBRARY_DIRS}")
+	message(STATUS "GStreamer cflags: ${GST_CFLAGS}")
+	message(STATUS "GStreamer ldflags: ${GST_LDFLAGS}")
+	message(STATUS "GStreamer libs: ${GST_LIBS}")
+
+	if(LINUX OR ANDROID)
+	    message(STATUS "GStreamer egl libs: ${GST_EGL_LIBRARIES}")
+	    message(STATUS "GStreamer egl include dirs: ${GST_EGL_INCLUDE_DIRS}")
+	    message(STATUS "GStreamer egl link dirs: ${GST_EGL_LIBRARY_DIRS}")
+	    message(STATUS "GStreamer egl cflags: ${GST_EGL_CFLAGS}")
+	    message(STATUS "GStreamer egl ldflags: ${GST_EGL_LDFLAGS}")
+	    message(STATUS "GStreamer egl libs: ${GST_EGL_LIBS}")
+	endif()
+
+	message(STATUS "gst found ${GST_FOUND}")
+
+	if(GST_FOUND)
+	    message(STATUS "Building qmlglsink")
+
+		find_package(Qt6 REQUIRED COMPONENTS Gui OpenGL)
+		find_package(OpenGL)
+
+		qt_add_library(qmlglsink STATIC
+			gst-plugins-good/ext/qt6/gstplugin.cc
+		    gst-plugins-good/ext/qt6/gstqml6glsink.cc
+		    gst-plugins-good/ext/qt6/gstqml6glsink.h
+		    gst-plugins-good/ext/qt6/gstqsg6glnode.cc
+		    gst-plugins-good/ext/qt6/gstqsg6glnode.h
+		    gst-plugins-good/ext/qt6/gstqt6element.cc
+		    gst-plugins-good/ext/qt6/gstqt6elements.h
+		    gst-plugins-good/ext/qt6/gstqt6gl.h
+		    gst-plugins-good/ext/qt6/gstqt6glutility.cc
+		    gst-plugins-good/ext/qt6/gstqt6glutility.h
+		    gst-plugins-good/ext/qt6/qt6glitem.cc
+		    gst-plugins-good/ext/qt6/qt6glitem.h
+		)
+
+	    target_compile_definitions(qmlglsink PUBLIC QGC_GST_STREAMING)
+
+		if(LINUX)
+			option(USE_WAYLAND "Use Wayland instead of X11 for building GST" ON)
+			if(USE_WAYLAND)
+				message(STATUS "Using wayland for qmlglsink")
+				target_compile_definitions(qmlglsink PUBLIC HAVE_QT_WAYLAND)
+			else()
+				message(STATUS "Using x11 for qmlglsink")
+				target_compile_definitions(qmlglsink PUBLIC HAVE_QT_X11)
+			endif()
+			target_compile_definitions(qmlglsink PUBLIC HAVE_QT_EGLFS HAVE_QT_QPA_HEADER)
+		elseif(MACOS)
+			target_compile_definitions(qmlglsink PUBLIC HAVE_QT_MAC)
+		elseif(IOS)
+			target_compile_definitions(qmlglsink PUBLIC HAVE_QT_IOS)
+		elseif(WIN32)
+			target_compile_definitions(qmlglsink PUBLIC HAVE_QT_WIN32 HAVE_QT_QPA_HEADER)
+
+			target_link_libraries(qmlglsink
+				PUBLIC
+					OpenGL::GL
+					user32.lib
+			)
+		elseif(ANDROID)
+			target_compile_definitions(qmlglsink PUBLIC HAVE_QT_ANDROID)
 		endif()
-		target_compile_definitions(qmlglsink PUBLIC HAVE_QT_EGLFS HAVE_QT_QPA_HEADER)
-	elseif(APPLE)
-		target_compile_definitions(qmlglsink PUBLIC HAVE_QT_MAC)
-	elseif(IOS)
-		target_compile_definitions(qmlglsink PUBLIC HAVE_QT_MAC)
-	elseif(WIN32)
-		target_compile_definitions(qmlglsink PUBLIC HAVE_QT_WIN32 HAVE_QT_QPA_HEADER)
 
 		target_link_libraries(qmlglsink
 			PUBLIC
-				OpenGL::GL
-				user32.lib
+				Qt6::Core
+				Qt6::OpenGL
+				Qt6::GuiPrivate
+				${GST_LINK_LIBRARIES}
 		)
-	elseif(ANDROID)
-		target_compile_definitions(qmlglsink PUBLIC HAVE_QT_ANDROID)
-	endif()
 
-	target_link_libraries(qmlglsink
-		PUBLIC
-			Qt6::Core
-			Qt6::OpenGL
-			Qt6::GuiPrivate
-			${GST_LINK_LIBRARIES}
-	)
-
-	target_include_directories(qmlglsink PRIVATE ${GST_INCLUDE_DIRS})
-	if (MSVC)
-		target_include_directories(qmlglsink PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/windows)
-	else()
-		target_compile_options(qmlglsink
-			PRIVATE
-				-Wno-unused-parameter
-				-Wno-implicit-fallthrough
-			)
+		target_include_directories(qmlglsink PRIVATE ${GST_INCLUDE_DIRS})
+		if (MSVC)
+			target_include_directories(qmlglsink PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/windows)
+		else()
+			target_compile_options(qmlglsink
+				PRIVATE
+					-Wno-unused-parameter
+					-Wno-implicit-fallthrough
+				)
+		endif()
 	endif()
+else()
+    message(STATUS "Video streaming disabled")
 endif()

--- a/libs/qtandroidserialport/CMakeLists.txt
+++ b/libs/qtandroidserialport/CMakeLists.txt
@@ -1,9 +1,15 @@
+if(ANDROID)
+	find_package(Qt6 REQUIRED COMPONENTS Core)
 
-if (ANDROID)
-	add_library(qtandroidserialport
+	qt_add_library(qtandroidserialport STATIC
 		src/qserialport.cpp
+		src/qserialport.h
+		src/qserialport_p.h
 		src/qserialport_android.cpp
+		src/qserialport_android_p.h
 		src/qserialportinfo.cpp
+		src/qserialportinfo.h
+		src/qserialportinfo_p.h
 		src/qserialportinfo_android.cpp
 	)
 

--- a/libs/sdl2/CMakeLists.txt
+++ b/libs/sdl2/CMakeLists.txt
@@ -1,14 +1,26 @@
-set(SDL2_LIB_BASE_PATH ${CMAKE_CURRENT_SOURCE_DIR}/msvc/lib)
+qt_add_library(sdl2 STATIC)
 
-add_library(sdl2 SHARED IMPORTED GLOBAL)
+if(WIN32)
+    set(SDL2_LIB_BASE_PATH ${CMAKE_CURRENT_SOURCE_DIR}/msvc/lib)
 
-if(CMAKE_SIZEOF_VOID_P EQUAL 8)  # 64 bits
-    set(SDL2_LIB_BASE_PATH ${SDL2_LIB_BASE_PATH}/x64)
+    if(CMAKE_SIZEOF_VOID_P EQUAL 8)  # 64 bits
+        set(SDL2_LIB_BASE_PATH ${SDL2_LIB_BASE_PATH}/x64)
+    endif()
+
+    target_link_libraries(sdl2 INTERFACE ${SDL2_LIB_BASE_PATH}/SDL2.lib)
+    target_include_directories(sdl2 INTERFACE ${CMAKE_CURRENT_SOURCE_DIR}/msvc/include)
+    set_property(TARGET sdl2 PROPERTY IMPORTED_IMPLIB_RELEASE "${SDL2_LIB_BASE_PATH}/SDL2.lib")
+    set_property(TARGET sdl2 PROPERTY IMPORTED_LOCATION_RELEASE "${SDL2_LIB_BASE_PATH}/SDL2.dll")
+    set_property(TARGET sdl2 PROPERTY IMPORTED_IMPLIB_DEBUG "${SDL2_LIB_BASE_PATH}/SDL2.lib")
+    set_property(TARGET sdl2 PROPERTY IMPORTED_LOCATION_DEBUG "${SDL2_LIB_BASE_PATH}/SDL2.dll")
+elseif(NOT ANDROID)
+    find_package(SDL2 REQUIRED)
+        if(IS_DIRECTORY "${SDL2_INCLUDE_DIRS}")
+            target_include_directories(sdl2 INTERFACE ${SDL2_INCLUDE_DIRS})
+            string(STRIP "${SDL2_LIBRARIES}" SDL2_LIBRARIES)
+            target_link_libraries(sdl2 INTERFACE ${SDL2_LIBRARIES})
+        else()
+            target_include_directories(sdl2 INTERFACE ${SDL2_DIR})
+            target_link_libraries(sdl2 INTERFACE SDL2::SDL2)
+        endif()
 endif()
-
-target_link_libraries(sdl2 INTERFACE ${SDL2_LIB_BASE_PATH}/SDL2.lib)
-target_include_directories(sdl2 INTERFACE ${CMAKE_CURRENT_SOURCE_DIR}/msvc/include)
-set_property(TARGET sdl2 PROPERTY IMPORTED_IMPLIB_RELEASE "${SDL2_LIB_BASE_PATH}/SDL2.lib")
-set_property(TARGET sdl2 PROPERTY IMPORTED_LOCATION_RELEASE "${SDL2_LIB_BASE_PATH}/SDL2.dll")
-set_property(TARGET sdl2 PROPERTY IMPORTED_IMPLIB_DEBUG "${SDL2_LIB_BASE_PATH}/SDL2.lib")
-set_property(TARGET sdl2 PROPERTY IMPORTED_LOCATION_DEBUG "${SDL2_LIB_BASE_PATH}/SDL2.dll")

--- a/libs/zlib/CMakeLists.txt
+++ b/libs/zlib/CMakeLists.txt
@@ -1,3 +1,9 @@
-add_library(z STATIC)
-target_link_libraries(z PUBLIC ${CMAKE_CURRENT_SOURCE_DIR}/windows/lib/zlibstatic.lib)
-target_include_directories(z PUBLIC ${CMAKE_CURRENT_SOURCE_DIR}/windows/include)
+qt_add_library(zlib STATIC)
+
+if(WIN32)
+	target_link_libraries(zlib PUBLIC ${CMAKE_CURRENT_SOURCE_DIR}/windows/lib/zlibstatic.lib)
+	target_include_directories(zlib PUBLIC ${CMAKE_CURRENT_SOURCE_DIR}/windows/include)
+else()
+	find_package(ZLIB)
+	target_link_libraries(zlib PUBLIC ZLIB::ZLIB)
+endif()

--- a/src/AutoPilotPlugins/APM/APMAutoPilotPlugin.cc
+++ b/src/AutoPilotPlugins/APM/APMAutoPilotPlugin.cc
@@ -32,7 +32,7 @@
 #include "QGCApplication.h"
 #include "ParameterManager.h"
 
-#if !defined(NO_SERIAL_LINK) && !defined(__android__)
+#if !defined(NO_SERIAL_LINK) && !defined(Q_OS_ANDROID)
 #include <QSerialPortInfo>
 #endif
 
@@ -59,7 +59,7 @@ APMAutoPilotPlugin::APMAutoPilotPlugin(Vehicle* vehicle, QObject* parent)
     , _followComponent          (nullptr)
 #endif
 {
-#if !defined(NO_SERIAL_LINK) && !defined(__android__)
+#if !defined(NO_SERIAL_LINK) && !defined(Q_OS_ANDROID)
     connect(vehicle->parameterManager(), &ParameterManager::parametersReadyChanged, this, &APMAutoPilotPlugin::_checkForBadCubeBlack);
 #endif
 }
@@ -200,7 +200,7 @@ QString APMAutoPilotPlugin::prerequisiteSetup(VehicleComponent* component) const
     return QString();
 }
 
-#if !defined(NO_SERIAL_LINK) && !defined(__android__)
+#if !defined(NO_SERIAL_LINK) && !defined(Q_OS_ANDROID)
 /// The following code is executed when the Vehicle is parameter ready. It checks for the service bulletin against Cube Blacks.
 void APMAutoPilotPlugin::_checkForBadCubeBlack(void)
 {

--- a/src/AutoPilotPlugins/APM/APMAutoPilotPlugin.h
+++ b/src/AutoPilotPlugins/APM/APMAutoPilotPlugin.h
@@ -64,7 +64,7 @@ protected:
     APMFollowComponent*         _followComponent;
 #endif
 
-#if !defined(NO_SERIAL_LINK) && !defined(__android__)
+#if !defined(NO_SERIAL_LINK) && !defined(Q_OS_ANDROID)
 private slots:
     void _checkForBadCubeBlack(void);
 #endif

--- a/src/Compression/CMakeLists.txt
+++ b/src/Compression/CMakeLists.txt
@@ -1,38 +1,20 @@
-
-set(XZ_EMBEDDED_DIR ${CMAKE_SOURCE_DIR}/libs/xz-embedded)
-
 qt_add_library(compression STATIC
 	QGCLZMA.cc
 	QGCLZMA.h
 	QGCZlib.cc
 	QGCZlib.h
-
-	${XZ_EMBEDDED_DIR}/linux/include/linux/xz.h
-	${XZ_EMBEDDED_DIR}/linux/lib/xz/xz_lzma2.h
-	${XZ_EMBEDDED_DIR}/linux/lib/xz/xz_private.h
-	${XZ_EMBEDDED_DIR}/linux/lib/xz/xz_stream.h
-	${XZ_EMBEDDED_DIR}/userspace/xz_config.h
-	${XZ_EMBEDDED_DIR}/linux/lib/xz/xz_crc32.c
-	${XZ_EMBEDDED_DIR}/linux/lib/xz/xz_crc64.c
-	${XZ_EMBEDDED_DIR}/linux/lib/xz/xz_dec_lzma2.c
-	${XZ_EMBEDDED_DIR}/linux/lib/xz/xz_dec_stream.c
 )
-
-target_compile_definitions(compression PRIVATE XZ_DEC_ANY_CHECK XZ_USE_CRC64)
 
 target_link_libraries(compression
 	PRIVATE
-        z # zlib
+        zlib
+        xz
 	PUBLIC
 		Qt6::Core
 		qgc
 )
 
 target_include_directories(compression
-	INTERFACE
+	PUBLIC
 		${CMAKE_CURRENT_SOURCE_DIR}
-	PRIVATE
-		${XZ_EMBEDDED_DIR}/userspace
-		${XZ_EMBEDDED_DIR}/linux/include/linux
 )
-

--- a/src/FactSystem/CMakeLists.txt
+++ b/src/FactSystem/CMakeLists.txt
@@ -19,7 +19,7 @@ qt_add_library(FactSystem STATIC
 )
 
 target_link_libraries(FactSystem
-	PRIVATE
+        PRIVATE
 		qgc
 		FactControls
 )

--- a/src/GPS/GPSProvider.h
+++ b/src/GPS/GPSProvider.h
@@ -13,7 +13,7 @@
 #include <QString>
 #include <QThread>
 #include <QByteArray>
-#ifdef __android__
+#ifdef Q_OS_ANDROID
 #include "qserialport.h"
 #else
 #include <QSerialPort>

--- a/src/Joystick/CMakeLists.txt
+++ b/src/Joystick/CMakeLists.txt
@@ -1,40 +1,43 @@
-
-set(EXTRA_SRC)
-
-if (ANDROID)
-	list(APPEND EXTRA_SRC
-		JoystickAndroid.cc
-	)
-else()
-	list(APPEND EXTRA_SRC
-		JoystickSDL.cc
-	)
-endif()
+find_package(Qt6 REQUIRED COMPONENTS Core)
 
 qt_add_library(Joystick STATIC
 	Joystick.cc
+	Joystick.h
 	JoystickManager.cc
+	JoystickManager.h
 	JoystickMavCommand.cc
-	${EXTRA_SRC}
+	JoystickMavCommand.h
 )
+
+if(ANDROID)
+	target_sources(Joystick
+		PRIVATE
+			JoystickAndroid.cc
+			JoystickAndroid.h
+	)
+
+	target_link_libraries(Joystick
+		PUBLIC
+			Qt6::CorePrivate
+	)
+else()
+	target_sources(Joystick
+		PRIVATE
+			JoystickSDL.cc
+			JoystickSDL.h
+	)
+
+	target_link_libraries(Joystick
+		PUBLIC
+			sdl2
+	)
+endif()
 
 target_link_libraries(Joystick
 	PUBLIC
+		Qt6::Core
 		qgc
+		Vehicle
 )
 
 target_include_directories(Joystick PUBLIC ${CMAKE_CURRENT_SOURCE_DIR})
-
-if(WIN32)
-	target_link_libraries(Joystick PUBLIC sdl2)
-elseif(NOT ANDROID)
-	find_package(SDL2 REQUIRED)
-	if (IS_DIRECTORY "${SDL2_INCLUDE_DIRS}")
-		include_directories(${SDL2_INCLUDE_DIRS})
-		string(STRIP "${SDL2_LIBRARIES}" SDL2_LIBRARIES)
-		target_link_libraries(Joystick PRIVATE ${SDL2_LIBRARIES})
-	else()
-		include_directories(${SDL2_DIR})
-		target_link_libraries(Joystick PRIVATE SDL2::SDL2)
-	endif()
-endif()

--- a/src/Joystick/JoystickManager.cc
+++ b/src/Joystick/JoystickManager.cc
@@ -18,7 +18,7 @@
     #define __sdljoystick__
 #endif
 
-#ifdef __android__
+#ifdef Q_OS_ANDROID
     #include "JoystickAndroid.h"
 #endif
 
@@ -59,7 +59,7 @@ void JoystickManager::init() {
         return;
     }
     _setActiveJoystickFromSettings();
-#elif defined(__android__)
+#elif defined(Q_OS_ANDROID)
     if (!JoystickAndroid::init(this)) {
         return;
     }
@@ -77,7 +77,7 @@ void JoystickManager::_setActiveJoystickFromSettings(void)
 #ifdef __sdljoystick__
     // Get the latest joystick mapping
     newMap = JoystickSDL::discover(_multiVehicleManager);
-#elif defined(__android__)
+#elif defined(Q_OS_ANDROID)
     newMap = JoystickAndroid::discover(_multiVehicleManager);
 #endif
 
@@ -210,7 +210,7 @@ void JoystickManager::_updateAvailableJoysticks()
             break;
         }
     }
-#elif defined(__android__)
+#elif defined(Q_OS_ANDROID)
     _joystickCheckTimerCounter--;
     _setActiveJoystickFromSettings();
     if (_joystickCheckTimerCounter <= 0) {

--- a/src/PositionManager/PositionManager.cpp
+++ b/src/PositionManager/PositionManager.cpp
@@ -11,7 +11,7 @@
 #include "QGCApplication.h"
 #include "QGCCorePlugin.h"
 
-#if !defined(NO_SERIAL_LINK) && !defined(__android__)
+#if !defined(NO_SERIAL_LINK) && !defined(Q_OS_ANDROID)
 #include <QSerialPortInfo>
 #endif
 

--- a/src/QmlControls/QGroundControlQmlGlobal.cc
+++ b/src/QmlControls/QGroundControlQmlGlobal.cc
@@ -262,11 +262,14 @@ void QGroundControlQmlGlobal::setFlightMapZoom(double zoom)
 QString QGroundControlQmlGlobal::qgcVersion(void) const
 {
     QString versionStr = qgcApp()->applicationVersion();
-#ifdef __androidArm32__
-    versionStr += QStringLiteral(" %1").arg(tr("32 bit"));
-#elif __androidArm64__
-    versionStr += QStringLiteral(" %1").arg(tr("64 bit"));
-#endif
+    if(QSysInfo::buildAbi().contains("32"))
+    {
+        versionStr += QStringLiteral(" %1").arg(tr("32 bit"));
+    }
+    else if(QSysInfo::buildAbi().contains("64"))
+    {
+        versionStr += QStringLiteral(" %1").arg(tr("64 bit"));
+    }
     return versionStr;
 }
 

--- a/src/QmlControls/ScreenToolsController.cc
+++ b/src/QmlControls/ScreenToolsController.cc
@@ -19,7 +19,7 @@
 
 #include "SettingsManager.h"
 
-#if defined(__ios__)
+#if defined(Q_OS_IOS)
 #include <sys/utsname.h>
 #endif
 
@@ -42,7 +42,7 @@ ScreenToolsController::hasTouch() const
 QString
 ScreenToolsController::iOSDevice() const
 {
-#if defined(__ios__)
+#if defined(Q_OS_IOS)
     struct utsname systemInfo;
     uname(&systemInfo);
     return QString(systemInfo.machine);

--- a/src/QtLocationPlugin/CMakeLists.txt
+++ b/src/QtLocationPlugin/CMakeLists.txt
@@ -1,5 +1,7 @@
 find_package(Qt6 REQUIRED COMPONENTS Core Core5Compat Location Network Qml Sql)
 
+# QGC_NO_GOOGLE_MAPS
+
 qt_add_plugin(QGCLocation
     STATIC
     CLASS_NAME QGeoServiceProviderFactoryQGC

--- a/src/QtLocationPlugin/QGCTileCacheWorker.cpp
+++ b/src/QtLocationPlugin/QGCTileCacheWorker.cpp
@@ -1156,7 +1156,7 @@ QGCCacheWorker::_testInternet()
         TCP connection to 8.8.8.8:53 on Android and do the lookup/connect on the
         other platforms.
     */
-#if defined(__android__)
+#if defined(Q_OS_ANDROID)
     QTcpSocket socket;
     socket.connectToHost("8.8.8.8", 53);
     if (socket.waitForConnected(2000)) {
@@ -1177,7 +1177,7 @@ QGCCacheWorker::_testInternet()
 void
 QGCCacheWorker::_lookupReady(QHostInfo info)
 {
-#if defined(__android__)
+#if defined(Q_OS_ANDROID)
     Q_UNUSED(info);
 #else
     _hostLookupID = 0;

--- a/src/Settings/AppSettings.cc
+++ b/src/Settings/AppSettings.cc
@@ -12,7 +12,7 @@
 #include "QGCApplication.h"
 #include "ParameterManager.h"
 
-#ifdef __android__
+#ifdef Q_OS_ANDROID
 #include "AndroidInterface.h"
 #endif
 
@@ -95,13 +95,13 @@ DECLARE_SETTINGGROUP(App, "")
 
     if (!userHasModifiedSavePath) {
 #ifdef __mobile__
-    #ifdef __ios__
+    #ifdef Q_OS_IOS
         // This will expose the directories directly to the File iOs app
         QDir rootDir = QDir(QStandardPaths::writableLocation(QStandardPaths::DocumentsLocation));
         savePathFact->setRawValue(rootDir.absolutePath());
     #else
         QString rootDirPath;
-        #ifdef __android__
+        #ifdef Q_OS_ANDROID
         if (androidSaveToSDCard()->rawValue().toBool()) {
                 rootDirPath = AndroidInterface::getSDCardPath();
             qDebug() << "AndroidInterface::getSDCardPath();" << rootDirPath;

--- a/src/Settings/AutoConnectSettings.cc
+++ b/src/Settings/AutoConnectSettings.cc
@@ -28,7 +28,7 @@ DECLARE_SETTINGSFACT_NO_FUNC(AutoConnectSettings, autoConnectPixhawk)
 {
     if (!_autoConnectPixhawkFact) {
         _autoConnectPixhawkFact = _createSettingsFact(autoConnectPixhawkName);
-#ifdef __ios__
+#ifdef Q_OS_IOS
         _autoConnectPixhawkFact->setVisible(false);
 #endif
     }
@@ -39,7 +39,7 @@ DECLARE_SETTINGSFACT_NO_FUNC(AutoConnectSettings, autoConnectSiKRadio)
 {
     if (!_autoConnectSiKRadioFact) {
         _autoConnectSiKRadioFact = _createSettingsFact(autoConnectSiKRadioName);
-#ifdef __ios__
+#ifdef Q_OS_IOS
         _autoConnectSiKRadioFact->setVisible(false);
 #endif
     }
@@ -50,7 +50,7 @@ DECLARE_SETTINGSFACT_NO_FUNC(AutoConnectSettings, autoConnectPX4Flow)
 {
     if (!_autoConnectPX4FlowFact) {
         _autoConnectPX4FlowFact = _createSettingsFact(autoConnectPX4FlowName);
-#ifdef __ios__
+#ifdef Q_OS_IOS
         _autoConnectPX4FlowFact->setVisible(false);
 #endif
     }
@@ -61,7 +61,7 @@ DECLARE_SETTINGSFACT_NO_FUNC(AutoConnectSettings, autoConnectRTKGPS)
 {
     if (!_autoConnectRTKGPSFact) {
         _autoConnectRTKGPSFact = _createSettingsFact(autoConnectRTKGPSName);
-#ifdef __ios__
+#ifdef Q_OS_IOS
         _autoConnectRTKGPSFact->setVisible(false);
 #endif
     }
@@ -72,7 +72,7 @@ DECLARE_SETTINGSFACT_NO_FUNC(AutoConnectSettings, autoConnectLibrePilot)
 {
     if (!_autoConnectLibrePilotFact) {
         _autoConnectLibrePilotFact = _createSettingsFact(autoConnectLibrePilotName);
-#ifdef __ios__
+#ifdef Q_OS_IOS
         _autoConnectLibrePilotFact->setVisible(false);
 #endif
     }
@@ -83,7 +83,7 @@ DECLARE_SETTINGSFACT_NO_FUNC(AutoConnectSettings, autoConnectNmeaPort)
 {
     if (!_autoConnectNmeaPortFact) {
         _autoConnectNmeaPortFact = _createSettingsFact(autoConnectNmeaPortName);
-#ifdef __ios__
+#ifdef Q_OS_IOS
         _autoConnectNmeaPortFact->setVisible(false);
 #endif
     }
@@ -94,7 +94,7 @@ DECLARE_SETTINGSFACT_NO_FUNC(AutoConnectSettings, autoConnectNmeaBaud)
 {
     if (!_autoConnectNmeaBaudFact) {
         _autoConnectNmeaBaudFact = _createSettingsFact(autoConnectNmeaBaudName);
-#ifdef __ios__
+#ifdef Q_OS_IOS
         _autoConnectNmeaBaudFact->setVisible(false);
 #endif
     }
@@ -105,7 +105,7 @@ DECLARE_SETTINGSFACT_NO_FUNC(AutoConnectSettings, autoConnectZeroConf)
 {
     if (!_autoConnectZeroConfFact) {
         _autoConnectZeroConfFact = _createSettingsFact(autoConnectZeroConfName);
-#ifdef __ios__
+#ifdef Q_OS_IOS
         _autoConnectZeroConfFact->setVisible(false);
 #endif
     }

--- a/src/UTMSP/CMakeLists.txt
+++ b/src/UTMSP/CMakeLists.txt
@@ -1,5 +1,6 @@
 find_package(Threads REQUIRED)
 
+option(CONFIG_UTM_ADAPTER "Enable UTM Adapter" OFF) # TODO: Make this QGC_CONFIG_UTM_ADAPTER
 if(CONFIG_UTM_ADAPTER)
     message(STATUS "UTMSP is Initialized")
     add_library(UTMSP
@@ -39,7 +40,7 @@ target_include_directories(UTMSP PUBLIC services )
 target_link_libraries(UTMSP
 
 PRIVATE
-        libevents_parser
+        nlohmann_json
 PUBLIC
         Qt6::Core
         Qt6::Location

--- a/src/Vehicle/CMakeLists.txt
+++ b/src/Vehicle/CMakeLists.txt
@@ -98,15 +98,12 @@ target_link_libraries(Vehicle
 	PRIVATE
 		Actuators
 		compression
-		libevents_generated
-		libevents_parser
-		libevents_health_and_arming_checks
 	PUBLIC
 		qgc
+		libevents
 )
 
 target_include_directories(Vehicle
 	PUBLIC
 		${CMAKE_CURRENT_SOURCE_DIR}
-		${CMAKE_SOURCE_DIR}/libs/libevents
 )

--- a/src/Vehicle/MultiVehicleManager.cc
+++ b/src/Vehicle/MultiVehicleManager.cc
@@ -18,7 +18,7 @@
 #include "QGCOptions.h"
 #include "LinkManager.h"
 
-#if defined (__ios__) || defined(__android__)
+#if defined (Q_OS_IOS) || defined(Q_OS_ANDROID)
 #include "MobileScreenMgr.h"
 #endif
 
@@ -149,7 +149,7 @@ void MultiVehicleManager::_vehicleHeartbeatInfo(LinkInterface* link, int vehicle
         setActiveVehicle(vehicle);
     }
 
-#if defined (__ios__) || defined(__android__)
+#if defined (Q_OS_IOS) || defined(Q_OS_ANDROID)
     if(_vehicles.count() == 1) {
         //-- Once a vehicle is connected, keep screen from going off
         qCDebug(MultiVehicleManagerLog) << "QAndroidJniObject::keepScreenOn";
@@ -212,7 +212,7 @@ void MultiVehicleManager::_deleteVehiclePhase1(Vehicle* vehicle)
     emit vehicleRemoved(vehicle);
     vehicle->prepareDelete();
 
-#if defined (__ios__) || defined(__android__)
+#if defined (Q_OS_IOS) || defined(Q_OS_ANDROID)
     if(_vehicles.count() == 0) {
         //-- Once no vehicles are connected, we no longer need to keep screen from going off
         qCDebug(MultiVehicleManagerLog) << "QAndroidJniObject::restoreScreenOn";

--- a/src/VehicleSetup/Bootloader.h
+++ b/src/VehicleSetup/Bootloader.h
@@ -11,7 +11,7 @@
 
 #include "FirmwareImage.h"
 
-#ifdef __android__
+#ifdef Q_OS_ANDROID
 #include "qserialport.h"
 #else
 #include <QSerialPort>

--- a/src/VehicleSetup/FirmwareUpgradeController.h
+++ b/src/VehicleSetup/FirmwareUpgradeController.h
@@ -20,7 +20,7 @@
 #include <QNetworkReply>
 #include <QPixmap>
 #include <QQuickItem>
-#ifdef __android__
+#ifdef Q_OS_ANDROID
 #include "qserialport.h"
 #else
 #include <QSerialPort>

--- a/src/VehicleSetup/PX4FirmwareUpgradeThread.cc
+++ b/src/VehicleSetup/PX4FirmwareUpgradeThread.cc
@@ -19,7 +19,7 @@
 
 #include <QTimer>
 #include <QDebug>
-#ifdef __android__
+#ifdef Q_OS_ANDROID
 #include "qserialport.h"
 #else
 #include <QSerialPort>

--- a/src/VehicleSetup/PX4FirmwareUpgradeThread.h
+++ b/src/VehicleSetup/PX4FirmwareUpgradeThread.h
@@ -23,7 +23,7 @@
 #include <QThread>
 #include <QTimer>
 #include <QTime>
-#ifdef __android__
+#ifdef Q_OS_ANDROID
 #include "qserialport.h"
 #else
 #include <QSerialPort>

--- a/src/VideoManager/CMakeLists.txt
+++ b/src/VideoManager/CMakeLists.txt
@@ -1,3 +1,5 @@
+# QGC_DISABLE_UVC
+
 qt_add_library(VideoManager STATIC
     GLVideoItemStub.cc
     GLVideoItemStub.h

--- a/src/VideoReceiver/GStreamer.cc
+++ b/src/VideoReceiver/GStreamer.cc
@@ -65,7 +65,7 @@ static void qt_gst_log(GstDebugCategory * category,
     object_info = nullptr;
 }
 
-#if defined(__ios__)
+#if defined(Q_OS_IOS)
 #include "gst_ios_init.h"
 #endif
 
@@ -73,7 +73,7 @@ static void qt_gst_log(GstDebugCategory * category,
 
 G_BEGIN_DECLS
 // The static plugins we use
-#if defined(__android__) || defined(__ios__)
+#if defined(Q_OS_ANDROID) || defined(Q_OS_IOS)
     GST_PLUGIN_STATIC_DECLARE(coreelements);
     GST_PLUGIN_STATIC_DECLARE(playback);
     GST_PLUGIN_STATIC_DECLARE(libav);
@@ -88,9 +88,9 @@ G_BEGIN_DECLS
     GST_PLUGIN_STATIC_DECLARE(mpegtsdemux);
     GST_PLUGIN_STATIC_DECLARE(opengl);
     GST_PLUGIN_STATIC_DECLARE(tcp);
-#if defined(__android__)
+#if defined(Q_OS_ANDROID)
     GST_PLUGIN_STATIC_DECLARE(androidmedia);
-#elif defined(__ios__)
+#elif defined(Q_OS_IOS)
     GST_PLUGIN_STATIC_DECLARE(applemedia);
 #endif
 #endif
@@ -192,7 +192,7 @@ GStreamer::initialize(int argc, char* argv[], int debuglevel)
     }
 
     // Initialize GStreamer
-#if defined(__ios__)
+#if defined(Q_OS_IOS)
     //-- iOS specific initialization
     gst_ios_pre_init();
 #endif
@@ -204,7 +204,7 @@ GStreamer::initialize(int argc, char* argv[], int debuglevel)
     }
 
     // The static plugins we use
-#if defined(__android__) || defined(__ios__)
+#if defined(Q_OS_ANDROID) || defined(Q_OS_IOS)
     GST_PLUGIN_STATIC_REGISTER(coreelements);
     GST_PLUGIN_STATIC_REGISTER(playback);
     GST_PLUGIN_STATIC_REGISTER(libav);
@@ -220,14 +220,14 @@ GStreamer::initialize(int argc, char* argv[], int debuglevel)
     GST_PLUGIN_STATIC_REGISTER(opengl);
     GST_PLUGIN_STATIC_REGISTER(tcp);
 
-#if defined(__android__)
+#if defined(Q_OS_ANDROID)
     GST_PLUGIN_STATIC_REGISTER(androidmedia);
-#elif defined(__ios__)
+#elif defined(Q_OS_IOS)
     GST_PLUGIN_STATIC_REGISTER(applemedia);
 #endif
 #endif
 
-#if defined(__ios__)
+#if defined(Q_OS_IOS)
     gst_ios_post_init();
 #endif
 

--- a/src/api/QGCCorePlugin.cc
+++ b/src/api/QGCCorePlugin.cc
@@ -170,7 +170,7 @@ bool QGCCorePlugin::adjustSettingMetaData(const QString& settingsGroup, FactMeta
         }
 #endif
 
-#ifndef __android__
+#ifndef Q_OS_ANDROID
         if (metaData.name() == AppSettings::androidSaveToSDCardName) {
             // This only shows on android builds
             return false;

--- a/src/comm/BluetoothLink.cc
+++ b/src/comm/BluetoothLink.cc
@@ -32,7 +32,7 @@ BluetoothLink::BluetoothLink(SharedLinkConfigurationPtr& config)
 BluetoothLink::~BluetoothLink()
 {
     disconnect();
-#ifdef __ios__
+#ifdef Q_OS_IOS
     if(_discoveryAgent) {
         _shutDown = true;
         _discoveryAgent->stop();
@@ -72,7 +72,7 @@ void BluetoothLink::readBytes()
 
 void BluetoothLink::disconnect(void)
 {
-#ifdef __ios__
+#ifdef Q_OS_IOS
     if(_discoveryAgent) {
         _shutDown = true;
         _discoveryAgent->stop();
@@ -98,7 +98,7 @@ bool BluetoothLink::_connect(void)
 
 bool BluetoothLink::_hardwareConnect()
 {
-#ifdef __ios__
+#ifdef Q_OS_IOS
     if(_discoveryAgent) {
         _shutDown = true;
         _discoveryAgent->stop();
@@ -134,7 +134,7 @@ void BluetoothLink::_createSocket()
     QObject::connect(_targetSocket, &QBluetoothSocket::errorOccurred, this, &BluetoothLink::deviceError);
 }
 
-#ifdef __ios__
+#ifdef Q_OS_IOS
 void BluetoothLink::serviceDiscovered(const QBluetoothServiceInfo& info)
 {
     if(!info.device().name().isEmpty() && !_targetSocket)
@@ -148,7 +148,7 @@ void BluetoothLink::serviceDiscovered(const QBluetoothServiceInfo& info)
 }
 #endif
 
-#ifdef __ios__
+#ifdef Q_OS_IOS
 void BluetoothLink::discoveryFinished()
 {
     if(_discoveryAgent && !_shutDown)
@@ -236,7 +236,7 @@ void BluetoothConfiguration::saveSettings(QSettings& settings, const QString& ro
 {
     settings.beginGroup(root);
     settings.setValue("deviceName", _device.name);
-#ifdef __ios__
+#ifdef Q_OS_IOS
     settings.setValue("uuid", _device.uuid.toString());
 #else
     settings.setValue("address",_device.address);
@@ -248,7 +248,7 @@ void BluetoothConfiguration::loadSettings(QSettings& settings, const QString& ro
 {
     settings.beginGroup(root);
     _device.name    = settings.value("deviceName", _device.name).toString();
-#ifdef __ios__
+#ifdef Q_OS_IOS
     QString suuid   = settings.value("uuid", _device.uuid.toString()).toString();
     _device.uuid    = QUuid(suuid);
 #else
@@ -299,7 +299,7 @@ void BluetoothConfiguration::deviceDiscovered(QBluetoothDeviceInfo info)
 #endif
         BluetoothData data;
         data.name    = info.name();
-#ifdef __ios__
+#ifdef Q_OS_IOS
         data.uuid    = info.deviceUuid();
 #else
         data.address = info.address().toString();
@@ -332,7 +332,7 @@ void BluetoothConfiguration::setDevName(const QString &name)
         {
             _device = data;
             emit devNameChanged();
-#ifndef __ios__
+#ifndef Q_OS_IOS
             emit addressChanged();
 #endif
             return;
@@ -342,7 +342,7 @@ void BluetoothConfiguration::setDevName(const QString &name)
 
 QString BluetoothConfiguration::address()
 {
-#ifdef __ios__
+#ifdef Q_OS_IOS
     return {};
 #else
     return _device.address;

--- a/src/comm/BluetoothLink.h
+++ b/src/comm/BluetoothLink.h
@@ -39,7 +39,7 @@ public:
     }
     bool operator==(const BluetoothData& other) const
     {
-#ifdef __ios__
+#ifdef Q_OS_IOS
         return uuid == other.uuid && name == other.name;
 #else
         return name == other.name && address == other.address;
@@ -48,7 +48,7 @@ public:
     BluetoothData& operator=(const BluetoothData& other)
     {
         name = other.name;
-#ifdef __ios__
+#ifdef Q_OS_IOS
         uuid = other.uuid;
 #else
         address = other.address;
@@ -56,7 +56,7 @@ public:
         return *this;
     }
     QString name;
-#ifdef __ios__
+#ifdef Q_OS_IOS
     QBluetoothUuid uuid;
 #else
     QString address;
@@ -134,7 +134,7 @@ public slots:
     void    deviceConnected     (void);
     void    deviceDisconnected  (void);
     void    deviceError         (QBluetoothSocket::SocketError error);
-#ifdef __ios__
+#ifdef Q_OS_IOS
     void    serviceDiscovered   (const QBluetoothServiceInfo &info);
     void    discoveryFinished   (void);
 #endif
@@ -152,7 +152,7 @@ private:
     void _createSocket      (void);
 
     QBluetoothSocket*                   _targetSocket    = nullptr;
-#ifdef __ios__
+#ifdef Q_OS_IOS
     QBluetoothServiceDiscoveryAgent*    _discoveryAgent = nullptr;
 #endif
     bool                                _shutDown       = false;

--- a/src/comm/CMakeLists.txt
+++ b/src/comm/CMakeLists.txt
@@ -1,3 +1,4 @@
+# NO_SERIAL_LINK # TODO: Make this QGC_NO_SERIAL_LINK
 
 set(EXTRA_SRC)
 if(QGC_BUILD_TESTING)
@@ -53,8 +54,10 @@ target_link_libraries(comm
 		Qt6::Bluetooth
 )
 
-if(NOT QT6_DISABLE_DNSENGINE)
-	target_link_libraries(comm PUBLIC qmdnsengine)
+option(QGC_ZEROCONF_ENABLED "Enable ZeroConf Compatibility" OFF)
+if(QGC_ZEROCONF_ENABLED)
+	target_link_libraries(comm PRIVATE qmdnsengine)
+	target_include_directories(comm PRIVATE ${CMAKE_SOURCE_DIR}/libs)
 endif()
 
 target_compile_definitions(comm PUBLIC QGC_ENABLE_BLUETOOTH)

--- a/src/comm/LinkManager.cc
+++ b/src/comm/LinkManager.cc
@@ -42,11 +42,13 @@
 #include <AirlinkLink.h>
 #endif
 
+#ifdef QGC_ZEROCONF_ENABLED
 #include <qmdnsengine/browser.h>
 #include <qmdnsengine/cache.h>
 #include <qmdnsengine/mdns.h>
 #include <qmdnsengine/server.h>
 #include <qmdnsengine/service.h>
+#endif
 
 QGC_LOGGING_CATEGORY(LinkManagerLog, "LinkManagerLog")
 QGC_LOGGING_CATEGORY(LinkManagerVerboseLog, "LinkManagerVerboseLog")
@@ -443,6 +445,7 @@ void LinkManager::_addMAVLinkForwardingLink(void)
     }
 }
 
+#ifdef QGC_ZEROCONF_ENABLED
 void LinkManager::_addZeroConfAutoConnectLink(void)
 {
     if (!_autoConnectSettings->autoConnectZeroConf()->rawValue().toBool()) {
@@ -513,6 +516,7 @@ void LinkManager::_addZeroConfAutoConnectLink(void)
         }
     });
 }
+#endif
 
 void LinkManager::_updateAutoConnectLinks(void)
 {
@@ -522,7 +526,9 @@ void LinkManager::_updateAutoConnectLinks(void)
 
     _addUDPAutoConnectLink();
     _addMAVLinkForwardingLink();
+#ifdef QGC_ZEROCONF_ENABLED
     _addZeroConfAutoConnectLink();
+#endif
 
 #ifndef __mobile__
 #ifndef NO_SERIAL_LINK
@@ -551,7 +557,7 @@ void LinkManager::_updateAutoConnectLinks(void)
 #ifndef NO_SERIAL_LINK
     QStringList                 currentPorts;
     QList<QGCSerialPortInfo>    portList;
-#ifdef __android__
+#ifdef Q_OS_ANDROID
     // Android builds only support a single serial connection. Repeatedly calling availablePorts after that one serial
     // port is connected leaks file handles due to a bug somewhere in android serial code. In order to work around that
     // bug after we connect the first serial port we stop probing for additional ports.

--- a/src/comm/LinkManager.h
+++ b/src/comm/LinkManager.h
@@ -154,7 +154,9 @@ private:
     void                _updateSerialPorts          (void);
     void                _removeConfiguration        (LinkConfiguration* config);
     void                _addUDPAutoConnectLink      (void);
+#ifdef QGC_ZEROCONF_ENABLED
     void                _addZeroConfAutoConnectLink (void);
+#endif
     void                _addMAVLinkForwardingLink   (void);
     bool                _isSerialPortConnected      (void);
     void                _createDynamicForwardLink   (const char* linkName, QString hostName);

--- a/src/comm/QGCSerialPortInfo.h
+++ b/src/comm/QGCSerialPortInfo.h
@@ -10,7 +10,7 @@
 
 #pragma once
 
-#ifdef __android__
+#ifdef Q_OS_ANDROID
     #include "qserialportinfo.h"
 #else
     #include <QSerialPortInfo>

--- a/src/comm/SerialLink.cc
+++ b/src/comm/SerialLink.cc
@@ -12,7 +12,7 @@
 #include <QSettings>
 #include <QMutexLocker>
 
-#ifdef __android__
+#ifdef Q_OS_ANDROID
 #include "qserialport.h"
 #else
 #include <QSerialPort>
@@ -87,7 +87,7 @@ void SerialLink::disconnect(void)
         emit disconnected();
     }
 
-#ifdef __android__
+#ifdef Q_OS_ANDROID
     qgcApp()->toolbox()->linkManager()->suspendConfigurationUpdates(false);
 #endif
 }
@@ -101,7 +101,7 @@ bool SerialLink::_connect(void)
         return true;
     }
 
-#ifdef __android__
+#ifdef Q_OS_ANDROID
     qgcApp()->toolbox()->linkManager()->suspendConfigurationUpdates(true);
 #endif
 
@@ -182,7 +182,7 @@ bool SerialLink::_hardwareConnect(QSerialPort::SerialPortError& error, QString& 
 
     // After the bootloader times out, it still can take a second or so for the Pixhawk USB driver to come up and make
     // the port available for open. So we retry a few times to wait for it.
-#ifdef __android__
+#ifdef Q_OS_ANDROID
     _port->open(QIODevice::ReadWrite);
 #else
 

--- a/src/comm/SerialLink.h
+++ b/src/comm/SerialLink.h
@@ -14,7 +14,7 @@
 #include <QMutex>
 #include <QString>
 
-#ifdef __android__
+#ifdef Q_OS_ANDROID
 #include "qserialport.h"
 #else
 #include <QSerialPort>

--- a/src/main.cc
+++ b/src/main.cc
@@ -79,7 +79,7 @@ int WindowsCrtReportHook(int reportType, char* message, int* returnValue)
 
 #endif
 
-#if defined(__android__)
+#if defined(Q_OS_ANDROID)
 #include <jni.h>
 #include "AndroidInterface.h"
 #include "JoystickAndroid.h"
@@ -249,7 +249,7 @@ int main(int argc, char *argv[])
     AppMessages::installHandler();
 
 #ifdef Q_OS_MAC
-#ifndef __ios__
+#ifndef Q_OS_IOS
     // Prevent Apple's app nap from screwing us over
     // tip: the domain can be cross-checked on the command line with <defaults domains>
     QProcess::execute("defaults", {"write org.qgroundcontrol.qgroundcontrol NSAppSleepDisabled -bool YES"});
@@ -397,7 +397,7 @@ int main(int argc, char *argv[])
 #endif
     {
 
-#ifdef __android__
+#ifdef Q_OS_ANDROID
         AndroidInterface::checkStoragePermissions();
 #endif
         if (!app->_initForNormalAppBoot()) {


### PR DESCRIPTION
I went through all of the qmake files to see what defines were missing from the cmake side. There were a handful of things that needed to be added as cmake options (like CONFIG_UTM_ADAPTER), and some needed to be added as defines (like __ mobile __). In doing so, I found __ android __ and __ ios __ were missing but it seemed redundant to define those when Q_OS_ANDROID and Q_OS_IOS already exist so I replaced those in the source. 

This also started to fix some of the issues with Android for cmake. There are some issues with almost all of the external libraries for Android but this fixes a couple of them and does a bit of minor rework to better organize how external libraries are included. A separate PR fixing the remaining Android specific issues will follow.

I also found QGC_DISABLE_DNSENGINE and QGC_ZEROCONF_ENABLED had no bearing on if qmdnsengine was included in LinkManager and _addZeroConfAutoConnectLink was called, the check in _addZeroConfAutoConnectLink was only based on __ios__ but qmdnsengine shouldn't even be included if it's not used. 