### PR TITLE
CMake: Create linux appimage

### DIFF
--- a/.github/workflows/linux_debug.yml
+++ b/.github/workflows/linux_debug.yml
@@ -84,4 +84,4 @@ jobs:
 
       - name: Run unit tests
         working-directory:  ${{ runner.temp }}/shadow_build_dir
-        run:                xvfb-run -a ${{ runner.temp }}/shadow_build_dir/staging/bin/QGroundControl --unittest
+        run:  xvfb-run -a ${{ runner.temp }}/shadow_build_dir/QGroundControl*.AppImage --unittest

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -56,6 +56,10 @@ message(STATUS "Build Type: ${CMAKE_BUILD_TYPE}")
 message(STATUS "Qt version: ${QT_VERSION}")
 message(STATUS "Qt spec: ${QT_MKSPEC}")
 
+if(LINUX)
+    set(CMAKE_INSTALL_PREFIX ${CMAKE_BINARY_DIR}/AppDir/usr)
+endif()
+
 # Find Qt6 libraries
 find_package(Qt6
     REQUIRED
@@ -92,8 +96,8 @@ qt_policy(
     SET QTP0002 NEW
 )
 
-set(QT_QML_OUTPUT_DIRECTORY "${CMAKE_BINARY_DIR}/qml" CACHE PATH "Install path for QML" FORCE)
-set(QML_IMPORT_PATH "${CMAKE_BINARY_DIR}/qml" CACHE STRING "Extra QML Import Paths" FORCE)
+# set(QT_QML_OUTPUT_DIRECTORY "${CMAKE_BINARY_DIR}/qml" CACHE PATH "Install path for QML" FORCE)
+# set(QML_IMPORT_PATH "${CMAKE_BINARY_DIR}/qml" CACHE STRING "Extra QML Import Paths" FORCE)
 
 #######################################################
 #                QML Configuration
@@ -242,6 +246,14 @@ install(
     ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR}
     BUNDLE  DESTINATION .
 )
+if(NOT ANDROID)
+    qt_generate_deploy_qml_app_script(
+        TARGET ${PROJECT_NAME}
+        OUTPUT_SCRIPT deploy_script
+        MACOS_BUNDLE_POST_BUILD
+    )
+    install(SCRIPT ${deploy_script})
+endif()
 install(
     DIRECTORY ${CMAKE_SOURCE_DIR}/resources/
     DESTINATION ${CMAKE_INSTALL_DATADIR}/qgroundcontrol
@@ -265,12 +277,5 @@ if(LINUX)
         FILES ${CMAKE_BINARY_DIR}/metainfo/org.mavlink.qgroundcontrol.metainfo.xml
         DESTINATION ${CMAKE_INSTALL_DATADIR}/metainfo/
     )
-endif()
-if(NOT ANDROID)
-    qt_generate_deploy_qml_app_script(
-        TARGET ${PROJECT_NAME}
-        OUTPUT_SCRIPT deploy_script
-        MACOS_BUNDLE_POST_BUILD
-    )
-    install(SCRIPT ${deploy_script})
+    install(SCRIPT "${CMAKE_SOURCE_DIR}/cmake/CreateAppImage.cmake")
 endif()

--- a/cmake/CreateAppImage.cmake
+++ b/cmake/CreateAppImage.cmake
@@ -1,0 +1,25 @@
+message(STATUS Creating AppImage)
+
+set(APPDIR_PATH "${CMAKE_BINARY_DIR}/AppDir")
+# set(AIT_PATH "${CMAKE_BINARY_DIR}/appimagetool-x86_64.AppImage")
+set(LD_PATH "${CMAKE_BINARY_DIR}/linuxdeploy-x86_64.AppImage")
+#set(LD_QTPLUGIN_PATH "${CMAKE_BINARY_DIR}/linuxdeploy-plugin-qt-x86_64.AppImage")
+
+# if(NOT EXISTS "${AIT_PATH}")
+#     file(DOWNLOAD https://github.com/AppImage/AppImageKit/releases/download/continuous/appimagetool-x86_64.AppImage "${AIT_PATH}")
+#     execute_process(COMMAND chmod a+x "${AIT_PATH}")
+# endif()
+if(NOT EXISTS "${LD_PATH}")
+    file(DOWNLOAD https://github.com/linuxdeploy/linuxdeploy/releases/download/1-alpha-20240109-1/linuxdeploy-x86_64.AppImage "${LD_PATH}")
+    execute_process(COMMAND chmod a+x "${LD_PATH}")
+endif()
+# if(NOT EXISTS "${LD_QTPLUGIN_PATH}")
+#     file(DOWNLOAD https://github.com/linuxdeploy/linuxdeploy-plugin-qt/releases/download/1-alpha-20240109-1/linuxdeploy-plugin-qt-x86_64.AppImage "${LD_QTPLUGIN_PATH}")
+#     execute_process(COMMAND chmod a+x "${LD_QTPLUGIN_PATH}")
+# endif()
+
+# execute_process(COMMAND chmod a+x "${APPDIR_PATH}/AppRun")
+
+# execute_process(COMMAND ${AIT_PATH} --appdir ${APPDIR_PATH} --output appimage)
+# execute_process(COMMAND ${LDQT_PATH} ${APPDIR_PATH}/usr/share/applications/org.mavlink.qgroundcontrol.desktop -unsupported-allow-new-glibc -verbose=2 -appimage)
+execute_process(COMMAND ${LD_PATH} --appdir ${APPDIR_PATH} --output appimage)


### PR DESCRIPTION
I'm not sure linuxdeployqt is needed anymore because of the built in qt_generate_deploy_qml_app_script, but let's try it out anyway. I can only test via CI because the AppImageToolkit/linuxdeployqt guys are hostile about supporting newer os. I believe [this](https://github.com/linuxdeploy/linuxdeploy-plugin-qt) might be the better option

Edit: I have several different methods commented out to try in the cmake file.