### PR TITLE
Qml: Register Elements via Qt6 method

### DIFF
--- a/src/AnalyzeView/GeoTagController.h
+++ b/src/AnalyzeView/GeoTagController.h
@@ -77,6 +77,7 @@ private:
 class GeoTagController : public QObject
 {
     Q_OBJECT
+    QML_ELEMENT
 public:
     GeoTagController();
     ~GeoTagController();

--- a/src/AnalyzeView/LogDownloadController.h
+++ b/src/AnalyzeView/LogDownloadController.h
@@ -78,6 +78,7 @@ private:
 class LogDownloadController : public QObject
 {
     Q_OBJECT
+    QML_ELEMENT
 
 public:
     LogDownloadController(void);

--- a/src/AnalyzeView/MAVLinkInspectorController.h
+++ b/src/AnalyzeView/MAVLinkInspectorController.h
@@ -179,6 +179,8 @@ private:
 /// MAVLink message charting controller
 class MAVLinkChartController : public QObject {
     Q_OBJECT
+    QML_ELEMENT
+    QML_UNCREATABLE("")
 public:
     MAVLinkChartController(MAVLinkInspectorController* parent, int index);
 
@@ -241,6 +243,7 @@ private:
 class MAVLinkInspectorController : public QObject
 {
     Q_OBJECT
+    QML_ELEMENT
 public:
     MAVLinkInspectorController();
     ~MAVLinkInspectorController();

--- a/src/AnalyzeView/MavlinkConsoleController.h
+++ b/src/AnalyzeView/MavlinkConsoleController.h
@@ -25,6 +25,7 @@ class Vehicle;
 class MavlinkConsoleController : public QStringListModel
 {
     Q_OBJECT
+    QML_ELEMENT
 
 public:
     MavlinkConsoleController();

--- a/src/AutoPilotPlugins/AutoPilotPlugin.h
+++ b/src/AutoPilotPlugins/AutoPilotPlugin.h
@@ -32,6 +32,8 @@ class FirmwarePlugin;
 class AutoPilotPlugin : public QObject
 {
     Q_OBJECT
+    QML_ELEMENT
+    QML_UNCREATABLE("")
 
 public:
     AutoPilotPlugin(Vehicle* vehicle, QObject* parent);

--- a/src/AutoPilotPlugins/Common/ESP8266ComponentController.h
+++ b/src/AutoPilotPlugins/Common/ESP8266ComponentController.h
@@ -31,6 +31,7 @@ namespace Ui {
 class ESP8266ComponentController : public FactPanelController
 {
     Q_OBJECT
+    QML_ELEMENT
 
 public:
     ESP8266ComponentController      ();

--- a/src/AutoPilotPlugins/Common/SyslinkComponentController.h
+++ b/src/AutoPilotPlugins/Common/SyslinkComponentController.h
@@ -23,6 +23,7 @@ namespace Ui {
 class SyslinkComponentController : public FactPanelController
 {
     Q_OBJECT
+    QML_ELEMENT
 
 public:
     SyslinkComponentController      ();

--- a/src/Camera/MavlinkCameraControl.h
+++ b/src/Camera/MavlinkCameraControl.h
@@ -29,6 +29,8 @@ Q_DECLARE_LOGGING_CATEGORY(CameraControlVerboseLog)
 class QGCVideoStreamInfo : public QObject
 {
     Q_OBJECT
+    QML_ELEMENT
+    QML_UNCREATABLE("")
 
 public:
     QGCVideoStreamInfo(QObject* parent, const mavlink_video_stream_information_t* si);
@@ -63,6 +65,8 @@ private:
 class MavlinkCameraControl : public FactGroup
 {
     Q_OBJECT
+    QML_ELEMENT
+    QML_UNCREATABLE("")
     friend class QGCCameraParamIO;
 
 public:

--- a/src/Camera/QGCCameraManager.h
+++ b/src/Camera/QGCCameraManager.h
@@ -27,6 +27,8 @@ class SimulatedCameraControl;
 class QGCCameraManager : public QObject
 {
     Q_OBJECT
+    QML_ELEMENT
+    QML_UNCREATABLE("")
 public:
     QGCCameraManager(Vehicle* vehicle);
     virtual ~QGCCameraManager();

--- a/src/FactSystem/FactValueSliderListModel.h
+++ b/src/FactSystem/FactValueSliderListModel.h
@@ -10,13 +10,15 @@
 #pragma once
 
 #include <QAbstractListModel>
-
+#include <QtQmlIntegration/QtQmlIntegration>
 #include "Fact.h"
 
 /// Provides a list model of values for incrementing/decrementing the value of a Fact
 class FactValueSliderListModel : public QAbstractListModel
 {
     Q_OBJECT
+    QML_ELEMENT
+    QML_UNCREATABLE("")
     
 public:
     FactValueSliderListModel(Fact& fact, QObject* parent = nullptr);

--- a/src/FactSystem/ParameterManager.h
+++ b/src/FactSystem/ParameterManager.h
@@ -32,7 +32,8 @@ class ParameterEditorController;
 class ParameterManager : public QObject
 {
     Q_OBJECT
-
+    QML_ELEMENT
+    QML_UNCREATABLE("")
     friend class ParameterEditorController;
 
 public:

--- a/src/Joystick/Joystick.h
+++ b/src/Joystick/Joystick.h
@@ -53,6 +53,8 @@ private:
 class Joystick : public QThread
 {
     Q_OBJECT
+    QML_ELEMENT
+    QML_UNCREATABLE("")
 public:
     Joystick(const QString& name, int axisCount, int buttonCount, int hatCount, MultiVehicleManager* multiVehicleManager);
 

--- a/src/Joystick/JoystickManager.h
+++ b/src/Joystick/JoystickManager.h
@@ -25,6 +25,8 @@ Q_DECLARE_LOGGING_CATEGORY(JoystickManagerLog)
 class JoystickManager : public QGCTool
 {
     Q_OBJECT
+    QML_ELEMENT
+    QML_UNCREATABLE("")
 
 public:
     JoystickManager(QGCApplication* app, QGCToolbox* toolbox);

--- a/src/MissionManager/CameraCalc.h
+++ b/src/MissionManager/CameraCalc.h
@@ -18,6 +18,8 @@ class PlanMasterController;
 class CameraCalc : public CameraSpec
 {
     Q_OBJECT
+    QML_ELEMENT
+    QML_UNCREATABLE("")
 
 public:
     CameraCalc(PlanMasterController* masterController, const QString& settingsGroup, QObject* parent = nullptr);

--- a/src/MissionManager/GeoFenceController.h
+++ b/src/MissionManager/GeoFenceController.h
@@ -25,6 +25,8 @@ class GeoFenceManager;
 class GeoFenceController : public PlanElementController
 {
     Q_OBJECT
+    QML_ELEMENT
+    QML_UNCREATABLE("")
     
 public:
     GeoFenceController(PlanMasterController* masterController, QObject* parent = nullptr);

--- a/src/MissionManager/MissionCommandTree.h
+++ b/src/MissionManager/MissionCommandTree.h
@@ -45,6 +45,8 @@ class MissionCommandTreeTest;
 class MissionCommandTree : public QGCTool
 {
     Q_OBJECT
+    QML_ELEMENT
+    QML_UNCREATABLE("")
     
 public:
     MissionCommandTree(QGCApplication* app, QGCToolbox* toolbox, bool unitTest = false);

--- a/src/MissionManager/MissionController.h
+++ b/src/MissionManager/MissionController.h
@@ -43,6 +43,8 @@ typedef QHash<VisualItemPair, FlightPathSegment*> FlightPathSegmentHashTable;
 class MissionController : public PlanElementController
 {
     Q_OBJECT
+    QML_ELEMENT
+    QML_UNCREATABLE("")
 
 public:
     MissionController(PlanMasterController* masterController, QObject* parent = nullptr);

--- a/src/MissionManager/MissionItem.h
+++ b/src/MissionManager/MissionItem.h
@@ -36,6 +36,8 @@ class MissionController;
 class MissionItem : public QObject
 {
     Q_OBJECT
+    QML_ELEMENT
+    QML_UNCREATABLE("")
     
 public:
     MissionItem(QObject* parent = nullptr);

--- a/src/MissionManager/MissionManager.h
+++ b/src/MissionManager/MissionManager.h
@@ -16,6 +16,8 @@ Q_DECLARE_LOGGING_CATEGORY(MissionManagerLog)
 class MissionManager : public PlanManager
 {
     Q_OBJECT
+    QML_ELEMENT
+    QML_UNCREATABLE("")
     
 public:
     MissionManager(Vehicle* vehicle);

--- a/src/MissionManager/PlanMasterController.h
+++ b/src/MissionManager/PlanMasterController.h
@@ -25,6 +25,7 @@ Q_DECLARE_LOGGING_CATEGORY(PlanMasterControllerLog)
 class PlanMasterController : public QObject
 {
     Q_OBJECT
+    QML_ELEMENT
     
 public:
     PlanMasterController(QObject* parent = nullptr);

--- a/src/MissionManager/QGCMapCircle.h
+++ b/src/MissionManager/QGCMapCircle.h
@@ -21,6 +21,7 @@
 class QGCMapCircle : public QObject
 {
     Q_OBJECT
+    QML_ELEMENT
 
 public:
     QGCMapCircle(QObject* parent = nullptr);

--- a/src/MissionManager/QGCMapPolygon.h
+++ b/src/MissionManager/QGCMapPolygon.h
@@ -23,6 +23,8 @@
 class QGCMapPolygon : public QObject
 {
     Q_OBJECT
+    QML_ELEMENT
+    QML_UNCREATABLE("")
 
 public:
     QGCMapPolygon(QObject* parent = nullptr);

--- a/src/MissionManager/RallyPointController.h
+++ b/src/MissionManager/RallyPointController.h
@@ -24,6 +24,8 @@ class GeoFenceManager;
 class RallyPointController : public PlanElementController
 {
     Q_OBJECT
+    QML_ELEMENT
+    QML_UNCREATABLE("")
     
 public:
     RallyPointController(PlanMasterController* masterController, QObject* parent = nullptr);

--- a/src/MissionManager/VisualMissionItem.h
+++ b/src/MissionManager/VisualMissionItem.h
@@ -34,6 +34,8 @@ class TerrainAtCoordinateQuery;
 class VisualMissionItem : public QObject
 {
     Q_OBJECT
+    QML_ELEMENT
+    QML_UNCREATABLE("")
 
 public:
     VisualMissionItem(PlanMasterController* masterController, bool flyView);

--- a/src/PositionManager/PositionManager.h
+++ b/src/PositionManager/PositionManager.h
@@ -11,7 +11,7 @@
 
 #include <QGeoPositionInfoSource>
 #include <QNmeaPositionInfoSource>
-
+#include <QtQmlIntegration/QtQmlIntegration>
 #include <QVariant>
 
 #include "QGCToolbox.h"
@@ -19,6 +19,8 @@
 
 class QGCPositionManager : public QGCTool {
     Q_OBJECT
+    QML_ELEMENT
+    QML_UNCREATABLE("")
 
 public:
     static constexpr size_t MinHorizonalAccuracyMeters = 100;

--- a/src/QGCApplication.cc
+++ b/src/QGCApplication.cc
@@ -523,7 +523,7 @@ void QGCApplication::_initCommon()
     qmlRegisterSingletonType<QGroundControlQmlGlobal>   ("QGroundControl",                          1, 0, "QGroundControl",         qgroundcontrolQmlGlobalSingletonFactory);
     qmlRegisterSingletonType<ScreenToolsController>     ("QGroundControl.ScreenToolsController",    1, 0, "ScreenToolsController",  screenToolsControllerSingletonFactory);
     qmlRegisterSingletonType<ShapeFileHelper>           ("QGroundControl.ShapeFileHelper",          1, 0, "ShapeFileHelper",        shapeFileHelperSingletonFactory);
-    qmlRegisterSingletonType<ShapeFileHelper>           ("MAVLink",                                 1, 0, "MAVLink",                mavlinkSingletonFactory);
+    qmlRegisterSingletonType<QGCMAVLink>                ("MAVLink",                                 1, 0, "MAVLink",                mavlinkSingletonFactory);
 
     // Although this should really be in _initForNormalAppBoot putting it here allowws us to create unit tests which pop up more easily
     if(QFontDatabase::addApplicationFont(":/fonts/opensans") < 0) {

--- a/src/QmlControls/CustomAction.h
+++ b/src/QmlControls/CustomAction.h
@@ -15,6 +15,7 @@
 class CustomAction: public QObject
 {
     Q_OBJECT
+    QML_ELEMENT
 
     Q_PROPERTY(QString label   READ label   CONSTANT)
 

--- a/src/QmlControls/CustomActionManager.h
+++ b/src/QmlControls/CustomActionManager.h
@@ -14,6 +14,7 @@
 class CustomActionManager : public QObject
 {
     Q_OBJECT
+    QML_ELEMENT
 
     Q_PROPERTY(QmlObjectListModel*  actions     READ  actions     NOTIFY  actionsChanged)
     Q_PROPERTY(bool                 hasActions  READ  hasActions  NOTIFY  actionsChanged)

--- a/src/QmlControls/EditPositionDialogController.h
+++ b/src/QmlControls/EditPositionDialogController.h
@@ -11,12 +11,13 @@
 
 #include <QObject>
 #include <QGeoCoordinate>
-
+#include <QtQmlIntegration/QtQmlIntegration>
 #include "FactSystem.h"
 
 class EditPositionDialogController : public QObject
 {
     Q_OBJECT
+    QML_ELEMENT
     
 public:
     EditPositionDialogController(void);

--- a/src/QmlControls/FactValueGrid.h
+++ b/src/QmlControls/FactValueGrid.h
@@ -21,6 +21,8 @@ class InstrumentValueData;
 class FactValueGrid : public QQuickItem
 {
     Q_OBJECT
+    QML_ELEMENT
+    QML_UNCREATABLE("")
 
 public:
     FactValueGrid(QQuickItem *parent = nullptr);

--- a/src/QmlControls/FlightPathSegment.h
+++ b/src/QmlControls/FlightPathSegment.h
@@ -22,6 +22,8 @@ Q_DECLARE_LOGGING_CATEGORY(FlightPathSegmentLog)
 class FlightPathSegment : public QObject
 {
     Q_OBJECT
+    QML_ELEMENT
+    QML_UNCREATABLE("")
     
 public:
     enum SegmentType {

--- a/src/QmlControls/HorizontalFactValueGrid.h
+++ b/src/QmlControls/HorizontalFactValueGrid.h
@@ -19,6 +19,7 @@ class InstrumentValueData;
 class HorizontalFactValueGrid : public FactValueGrid
 {
     Q_OBJECT
+    QML_ELEMENT
 
 public:
     HorizontalFactValueGrid(QQuickItem *parent = nullptr);

--- a/src/QmlControls/InstrumentValueData.h
+++ b/src/QmlControls/InstrumentValueData.h
@@ -19,6 +19,8 @@
 class InstrumentValueData : public QObject
 {
     Q_OBJECT
+    QML_ELEMENT
+    QML_UNCREATABLE("")
 
 public:
     enum RangeType {

--- a/src/QmlControls/ParameterEditorController.h
+++ b/src/QmlControls/ParameterEditorController.h
@@ -83,6 +83,7 @@ signals:
 class ParameterEditorController : public FactPanelController
 {
     Q_OBJECT
+    QML_ELEMENT
 
 public:
     ParameterEditorController(void);

--- a/src/QmlControls/QGCFileDialogController.h
+++ b/src/QmlControls/QGCFileDialogController.h
@@ -13,7 +13,7 @@
 
 #include <QObject>
 #include <QUrl>
-
+#include <QtQmlIntegration/QtQmlIntegration>
 #include "QGCLoggingCategory.h"
 
 Q_DECLARE_LOGGING_CATEGORY(QGCFileDialogControllerLog)
@@ -21,6 +21,7 @@ Q_DECLARE_LOGGING_CATEGORY(QGCFileDialogControllerLog)
 class QGCFileDialogController : public QObject
 {
     Q_OBJECT
+    QML_ELEMENT
 
 public:
     /// Return all file in the specified path which match the specified extension

--- a/src/QmlControls/QGCGeoBoundingCube.h
+++ b/src/QmlControls/QGCGeoBoundingCube.h
@@ -12,11 +12,14 @@
 
 #include <QObject>
 #include <QGeoCoordinate>
+#include <QtQmlIntegration/QtQmlIntegration>
 
 // A bounding "cube" for small surface areas (doesn't take in consideration earth's curvature)
 // Coordinate system makes NW Up Left Bottom (0,0,0) and SE Bottom Right Top (y,x,z)
 class QGCGeoBoundingCube : public QObject {
     Q_OBJECT
+    QML_ELEMENT
+    QML_UNCREATABLE("")
 public:
     QGCGeoBoundingCube(QObject* parent = nullptr);
 

--- a/src/QmlControls/QGCMapPalette.h
+++ b/src/QmlControls/QGCMapPalette.h
@@ -13,6 +13,7 @@
 
 #include <QObject>
 #include <QColor>
+#include <QtQmlIntegration/QtQmlIntegration>
 
 /*!
  QGCMapPalette is a variant of QGCPalette which is used to hold colors used for display over
@@ -39,6 +40,7 @@
 class QGCMapPalette : public QObject
 {
     Q_OBJECT
+    QML_ELEMENT
     
     Q_PROPERTY(bool lightColors READ lightColors WRITE setLightColors NOTIFY paletteChanged)
 

--- a/src/QmlControls/QGCPalette.h
+++ b/src/QmlControls/QGCPalette.h
@@ -13,6 +13,7 @@
 #include <QObject>
 #include <QColor>
 #include <QMap>
+#include <QtQmlIntegration/QtQmlIntegration>
 
 #define DECLARE_QGC_COLOR(name, lightDisabled, lightEnabled, darkDisabled, darkEnabled) \
     { \
@@ -91,6 +92,7 @@
 class QGCPalette : public QObject
 {
     Q_OBJECT
+    QML_ELEMENT
 
 public:
     enum ColorGroup {

--- a/src/QmlControls/QGroundControlQmlGlobal.h
+++ b/src/QmlControls/QGroundControlQmlGlobal.h
@@ -42,6 +42,8 @@ Q_MOC_INCLUDE("MissionCommandTree.h")
 class QGroundControlQmlGlobal : public QGCTool
 {
     Q_OBJECT
+    QML_ELEMENT
+    // QML_SINGLETON
 
 public:
     QGroundControlQmlGlobal(QGCApplication* app, QGCToolbox* toolbox);

--- a/src/QmlControls/QmlObjectListModel.h
+++ b/src/QmlControls/QmlObjectListModel.h
@@ -12,10 +12,13 @@
 #define QmlObjectListModel_H
 
 #include <QAbstractListModel>
+#include <QtQmlIntegration/QtQmlIntegration>
 
 class QmlObjectListModel : public QAbstractListModel
 {
     Q_OBJECT
+    QML_ELEMENT
+    QML_UNCREATABLE("")
     
 public:
     QmlObjectListModel(QObject* parent = nullptr);

--- a/src/QmlControls/RCChannelMonitorController.h
+++ b/src/QmlControls/RCChannelMonitorController.h
@@ -20,6 +20,7 @@
 class RCChannelMonitorController : public FactPanelController
 {
     Q_OBJECT
+    QML_ELEMENT
 
 public:
     RCChannelMonitorController(void);

--- a/src/QmlControls/RCToParamDialogController.h
+++ b/src/QmlControls/RCToParamDialogController.h
@@ -11,12 +11,13 @@
 
 #include <QObject>
 #include <QGeoCoordinate>
-
+#include <QtQmlIntegration/QtQmlIntegration>
 #include "FactSystem.h"
 
 class RCToParamDialogController : public QObject
 {
     Q_OBJECT
+    QML_ELEMENT
     
 public:
     RCToParamDialogController(void);

--- a/src/QmlControls/ScreenToolsController.h
+++ b/src/QmlControls/ScreenToolsController.h
@@ -26,6 +26,9 @@
 class ScreenToolsController : public QQuickItem
 {
     Q_OBJECT
+    QML_ELEMENT
+    // QML_SINGLETON
+
 public:
     ScreenToolsController();
 

--- a/src/QmlControls/TerrainProfile.h
+++ b/src/QmlControls/TerrainProfile.h
@@ -27,6 +27,7 @@ Q_MOC_INCLUDE("MissionController.h")
 class TerrainProfile : public QQuickItem
 {
     Q_OBJECT
+    QML_ELEMENT
 
 public:
     TerrainProfile(QQuickItem *parent = nullptr);

--- a/src/QmlControls/ToolStripAction.h
+++ b/src/QmlControls/ToolStripAction.h
@@ -16,6 +16,7 @@
 class ToolStripAction : public QObject
 {
     Q_OBJECT
+    QML_ELEMENT
     
 public:
     ToolStripAction(QObject* parent = nullptr);

--- a/src/QmlControls/ToolStripActionList.h
+++ b/src/QmlControls/ToolStripActionList.h
@@ -11,10 +11,12 @@
 
 #include <QObject>
 #include <QQmlListProperty>
+#include <QtQmlIntegration/QtQmlIntegration>
 
 class ToolStripActionList : public QObject
 {
     Q_OBJECT
+    QML_ELEMENT
     
 public:
     ToolStripActionList(QObject* parent = nullptr);

--- a/src/Utilities/ShapeFileHelper.h
+++ b/src/Utilities/ShapeFileHelper.h
@@ -13,11 +13,14 @@
 #include <QList>
 #include <QGeoCoordinate>
 #include <QVariant>
+#include <QtQmlIntegration/QtQmlIntegration>
 
 /// Routines for loading polygons or polylines from KML or SHP files.
 class ShapeFileHelper : public QObject
 {
     Q_OBJECT
+    QML_ELEMENT
+    // QML_SINGLETON
 
 public:
     enum ShapeType {

--- a/src/Vehicle/Autotune.h
+++ b/src/Vehicle/Autotune.h
@@ -16,7 +16,8 @@
 class Autotune : public QObject
 {
     Q_OBJECT
-
+    QML_ELEMENT
+    QML_UNCREATABLE("")
 
 public:
     explicit Autotune(Vehicle *vehicle);

--- a/src/Vehicle/RemoteIDManager.h
+++ b/src/Vehicle/RemoteIDManager.h
@@ -26,6 +26,8 @@ class QGCPositionManager;
 class RemoteIDManager : public QObject
 {
     Q_OBJECT
+    QML_ELEMENT
+    QML_UNCREATABLE("")
 
 public:
     RemoteIDManager(Vehicle* vehicle);

--- a/src/Vehicle/TrajectoryPoints.h
+++ b/src/Vehicle/TrajectoryPoints.h
@@ -18,6 +18,8 @@ class Vehicle;
 class TrajectoryPoints : public QObject
 {
     Q_OBJECT
+    QML_ELEMENT
+    QML_UNCREATABLE("")
 
 public:
     TrajectoryPoints(Vehicle* vehicle, QObject* parent = nullptr);

--- a/src/Vehicle/Vehicle.h
+++ b/src/Vehicle/Vehicle.h
@@ -110,7 +110,8 @@ Q_DECLARE_LOGGING_CATEGORY(VehicleLog)
 class Vehicle : public FactGroup
 {
     Q_OBJECT
-
+    // QML_ELEMENT
+    // QML_UNCREATABLE("")
     friend class InitialConnectStateMachine;
     friend class VehicleLinkManager;
     friend class VehicleBatteryFactGroup;           // Allow VehicleBatteryFactGroup to call _addFactGroup

--- a/src/Vehicle/VehicleLinkManager.h
+++ b/src/Vehicle/VehicleLinkManager.h
@@ -27,6 +27,8 @@ class VehicleLinkManagerTest;
 class VehicleLinkManager : public QObject
 {
     Q_OBJECT
+    QML_ELEMENT
+    QML_UNCREATABLE("")
 
     friend class Vehicle;
     friend class VehicleLinkManagerTest;

--- a/src/Vehicle/VehicleObjectAvoidance.h
+++ b/src/Vehicle/VehicleObjectAvoidance.h
@@ -20,6 +20,8 @@ class Vehicle;
 class VehicleObjectAvoidance : public QObject
 {
     Q_OBJECT
+    QML_ELEMENT
+    QML_UNCREATABLE("")
 public:
     VehicleObjectAvoidance(Vehicle* vehicle, QObject* parent = nullptr);
 

--- a/src/VehicleSetup/FirmwareUpgradeController.h
+++ b/src/VehicleSetup/FirmwareUpgradeController.h
@@ -34,6 +34,7 @@
 class FirmwareUpgradeController : public QObject
 {
     Q_OBJECT
+    QML_ELEMENT
     
 public:
         typedef enum {

--- a/src/VehicleSetup/JoystickConfigController.h
+++ b/src/VehicleSetup/JoystickConfigController.h
@@ -32,6 +32,7 @@ namespace Ui {
 class JoystickConfigController : public FactPanelController
 {
     Q_OBJECT
+    QML_ELEMENT
 
     //friend class RadioConfigTest; ///< This allows our unit test to access internal information needed.
 

--- a/src/VehicleSetup/VehicleComponent.h
+++ b/src/VehicleSetup/VehicleComponent.h
@@ -28,6 +28,8 @@ class AutoPilotPlugin;
 class VehicleComponent : public QObject
 {
     Q_OBJECT
+    QML_ELEMENT
+    QML_UNCREATABLE("")
     
     Q_PROPERTY(QString  name                    READ name                   CONSTANT)
     Q_PROPERTY(QString  description             READ description            CONSTANT)

--- a/src/Viewer3D/CityMapGeometry.h
+++ b/src/Viewer3D/CityMapGeometry.h
@@ -14,6 +14,7 @@ class Viewer3DSettings;
 class CityMapGeometry : public QQuick3DGeometry
 {
     Q_OBJECT
+    QML_ELEMENT
     Q_PROPERTY(QString modelName READ modelName WRITE setModelName NOTIFY modelNameChanged)
     Q_PROPERTY(OsmParser* osmParser READ osmParser WRITE setOsmParser NOTIFY osmParserChanged)
 

--- a/src/Viewer3D/OsmParser.h
+++ b/src/Viewer3D/OsmParser.h
@@ -51,6 +51,8 @@ class OsmParser : public QObject
     };
 
     Q_OBJECT
+    QML_ELEMENT
+    QML_UNCREATABLE("")
 
     // Q_PROPERTY(float buildingLevelHeight READ buildingLevelHeight WRITE setBuildingLevelHeight NOTIFY buildingLevelHeightChanged)
 

--- a/src/Viewer3D/Viewer3DManager.h
+++ b/src/Viewer3D/Viewer3DManager.h
@@ -14,7 +14,7 @@ class SettingsManager;
 class Viewer3DManager : public QObject
 {
     Q_OBJECT
-
+    QML_ELEMENT
     Q_PROPERTY(OsmParser* osmParser MEMBER _osmParser CONSTANT)
     Q_PROPERTY(Viewer3DQmlBackend* qmlBackend MEMBER _qmlBackend CONSTANT)
 

--- a/src/Viewer3D/Viewer3DQmlBackend.h
+++ b/src/Viewer3D/Viewer3DQmlBackend.h
@@ -15,7 +15,8 @@ class Viewer3DSettings;
 class Viewer3DQmlBackend : public QObject
 {
     Q_OBJECT
-
+    QML_ELEMENT
+    QML_UNCREATABLE("")
     Q_PROPERTY(QGeoCoordinate gpsRef READ gpsRef NOTIFY gpsRefChanged)
 
 public:

--- a/src/Viewer3D/Viewer3DQmlVariableTypes.h
+++ b/src/Viewer3D/Viewer3DQmlVariableTypes.h
@@ -11,6 +11,7 @@
 class GeoCoordinateType: public QObject
 {
     Q_OBJECT
+    QML_ELEMENT
     Q_PROPERTY(QGeoCoordinate gpsRef READ gpsRef WRITE setGpsRef NOTIFY gpsRefChanged)
     Q_PROPERTY(QGeoCoordinate coordinate READ coordinate WRITE setCoordinate NOTIFY coordinateChanged)
     Q_PROPERTY(QVector3D localCoordinate READ localCoordinate NOTIFY localCoordinateChanged)

--- a/src/comm/LinkInterface.h
+++ b/src/comm/LinkInterface.h
@@ -18,6 +18,7 @@
 #include <QSharedPointer>
 #include <QDebug>
 #include <QTimer>
+#include <QtQmlIntegration/QtQmlIntegration>
 
 #include <memory>
 
@@ -36,6 +37,8 @@ Q_DECLARE_LOGGING_CATEGORY(LinkInterfaceLog)
 class LinkInterface : public QThread
 {
     Q_OBJECT
+    QML_ELEMENT
+    QML_UNCREATABLE("")
 
     friend class LinkManager;
 

--- a/src/comm/LogReplayLink.h
+++ b/src/comm/LogReplayLink.h
@@ -51,6 +51,8 @@ private:
 class LogReplayLink : public LinkInterface
 {
     Q_OBJECT
+    QML_ELEMENT
+    QML_UNCREATABLE("")
 
 public:
     LogReplayLink(SharedLinkConfigurationPtr& config);
@@ -139,6 +141,8 @@ private:
 class LogReplayLinkController : public QObject
 {
     Q_OBJECT
+    QML_ELEMENT
+    QML_UNCREATABLE("")
 
 public:
     Q_PROPERTY(LogReplayLink*   link            READ link               WRITE setLink               NOTIFY linkChanged)

--- a/src/comm/QGCMAVLink.h
+++ b/src/comm/QGCMAVLink.h
@@ -12,6 +12,7 @@
 #include <QObject>
 #include <QString>
 #include <QList>
+#include <QtQmlIntegration/QtQmlIntegration>
 
 #define MAVLINK_USE_MESSAGE_INFO
 #define MAVLINK_EXTERNAL_RX_STATUS  // Single m_mavlink_status instance is in QGCApplication.cc
@@ -51,6 +52,8 @@ extern mavlink_status_t m_mavlink_status[MAVLINK_COMM_NUM_BUFFERS];
 class QGCMAVLink : public QObject
 {
     Q_OBJECT
+    QML_ELEMENT
+    // QML_SINGLETON
 
 public:
     // Creating an instance of QGCMAVLink is only meant to be used for the Qml Singleton


### PR DESCRIPTION
This registers qml elements in the Qt6 way, I have left the QML_SINGLETON's commented out for now to avoid create duplicate singletons until we are ready to remove the `qmlRegisterSingletonType` code.