### PR TITLE
CMake: Fix Android Executable

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -183,7 +183,7 @@ endif()
 #               QGroundControl Target
 #######################################################
 
-qt_add_executable(${PROJECT_NAME} ${QGC_RESOURCES})
+qt_add_executable(${PROJECT_NAME} src/main.cc ${QGC_RESOURCES})
 
 set_target_properties(${PROJECT_NAME}
     PROPERTIES
@@ -214,7 +214,7 @@ elseif(ANDROID)
             QT_ANDROID_PACKAGE_SOURCE_DIR ${CMAKE_SOURCE_DIR}/android
             QT_ANDROID_VERSION_NAME ${APP_VERSION_STR}
             # QT_ANDROID_VERSION_CODE 5.0
-            QT_QML_ROOT_PATH ${CMAKE_SOURCE_DIR}/src
+            QT_QML_ROOT_PATH ${CMAKE_SOURCE_DIR}
     )
 
     if(CMAKE_BUILD_TYPE STREQUAL "Release" AND ANDROID_KEYSTORE_PASSWORD)
@@ -230,7 +230,7 @@ target_link_libraries(${PROJECT_NAME} PRIVATE qgc)
 
 if(QGC_BUILD_TESTING)
     add_subdirectory(test)
-    target_link_libraries(qgc PRIVATE qgctest)
+    target_link_libraries(${PROJECT_NAME} PRIVATE qgctest)
 endif()
 
 #######################################################

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -9,7 +9,6 @@ project(qgc)
 qt_add_library(${PROJECT_NAME} STATIC
         CmdLineOptParser.cc
         CmdLineOptParser.h
-        main.cc
         QGCApplication.cc
         QGCApplication.h
         QGCConfig.h
@@ -64,8 +63,8 @@ add_subdirectory(Viewer3D)
 #######################################################
 target_link_libraries(${PROJECT_NAME}
         PRIVATE
-            Qt6::QuickControls2
         PUBLIC
+            Qt6::QuickControls2
             Qt6::QuickWidgets
             Qt6::Widgets
             Qt6::Core5Compat


### PR DESCRIPTION
At first I was noticing an issue with where the Viewer3D qmldir was. I found out it was related to QT_QML_ROOT_PATH, so I changed that value. Then I had to fix the android app not finding the main function, which meant moving main.cc to the root executable.