### PR TITLE
Remote id indicator: Convert to new UI style, plus other changes

### DIFF
--- a/qgroundcontrol.qrc
+++ b/qgroundcontrol.qrc
@@ -107,6 +107,7 @@
         <file alias="QGroundControl/Controls/LabelledButton.qml">src/QmlControls/LabelledButton.qml</file>
         <file alias="QGroundControl/Controls/LabelledComboBox.qml">src/QmlControls/LabelledComboBox.qml</file>
         <file alias="QGroundControl/Controls/LabelledLabel.qml">src/QmlControls/LabelledLabel.qml</file>
+        <file alias="QGroundControl/Controls/RemoteIDIndicatorPage.qml">src/ui/toolbar/RemoteIDIndicatorPage.qml</file>
         <file alias="QGroundControl/Controls/SettingsGroupLayout.qml">src/QmlControls/SettingsGroupLayout.qml</file>
         <file alias="QGroundControl/Controls/InstrumentValueLabel.qml">src/QmlControls/InstrumentValueLabel.qml</file>
         <file alias="QGroundControl/Controls/InstrumentValueValue.qml">src/QmlControls/InstrumentValueValue.qml</file>

--- a/src/QmlControls/QGroundControl/Controls/qmldir
+++ b/src/QmlControls/QGroundControl/Controls/qmldir
@@ -106,6 +106,7 @@ RallyPointItemEditor                    1.0 RallyPointItemEditor.qml
 RallyPointMapVisuals                    1.0 RallyPointMapVisuals.qml
 RCChannelMonitor                        1.0 RCChannelMonitor.qml
 RCToParamDialog                         1.0 RCToParamDialog.qml
+RemoteIDIndicatorPage                   1.0 RemoteIDIndicatorPage.qml
 QCRoundButton                           1.0 QGCRoundButton.qml
 SectionHeader                           1.0 SectionHeader.qml
 SetupPage                               1.0 SetupPage.qml

--- a/src/QmlControls/QGroundControl/Controls/qmldir
+++ b/src/QmlControls/QGroundControl/Controls/qmldir
@@ -90,7 +90,7 @@ QGCMouseArea                            1.0 QGCMouseArea.qml
 QGCMovableItem                          1.0 QGCMovableItem.qml
 QGCOptionsComboBox                      1.0 QGCOptionsComboBox.qml
 PipView                                 1.0 PipView.qml
-PipState                             1.0 PipState.qml
+PipState                                1.0 PipState.qml
 QGCPopupDialog                          1.0 QGCPopupDialog.qml
 QGCRadioButton                          1.0 QGCRadioButton.qml
 QGCSimpleMessageDialog                  1.0 QGCSimpleMessageDialog.qml

--- a/src/Settings/RemoteID.SettingsGroup.json
+++ b/src/Settings/RemoteID.SettingsGroup.json
@@ -4,12 +4,6 @@
     "QGC.MetaData.Facts":
 [
 {
-    "name":         "enable",
-    "shortDesc":    "Show Drone ID settings page when enabled",
-    "type":         "bool",
-    "default":      false
-},
-{
     "name":         "operatorID",
     "shortDesc":    "Operator ID",
     "longDesc":     "Operator ID. Maximum 20 characters.",

--- a/src/Settings/RemoteIDSettings.cc
+++ b/src/Settings/RemoteIDSettings.cc
@@ -17,7 +17,6 @@ DECLARE_SETTINGGROUP(RemoteID, "RemoteID")
     qmlRegisterUncreatableType<RemoteIDSettings>("QGroundControl.SettingsManager", 1, 0, "RemoteIDSettings", "Reference only"); \
 }
 
-DECLARE_SETTINGSFACT(RemoteIDSettings,  enable)
 DECLARE_SETTINGSFACT(RemoteIDSettings,  operatorID)
 DECLARE_SETTINGSFACT(RemoteIDSettings,  operatorIDValid)
 DECLARE_SETTINGSFACT(RemoteIDSettings,  operatorIDType)

--- a/src/Settings/RemoteIDSettings.h
+++ b/src/Settings/RemoteIDSettings.h
@@ -18,7 +18,6 @@ public:
     RemoteIDSettings(QObject* parent = nullptr);
     DEFINE_SETTING_NAME_GROUP()
 
-    DEFINE_SETTINGFACT(enable)
     DEFINE_SETTINGFACT(operatorID)
     DEFINE_SETTINGFACT(operatorIDValid)
     DEFINE_SETTINGFACT(operatorIDType)

--- a/src/Vehicle/RemoteIDManager.cc
+++ b/src/Vehicle/RemoteIDManager.cc
@@ -161,11 +161,6 @@ void RemoteIDManager::_handleArmStatus(mavlink_message_t& message)
 // Function that sends messages periodically
 void RemoteIDManager::_sendMessages()
 {
-    // We only send RemoteID messages if we have it enabled in General settings
-    if (!_settings->enable()->rawValue().toBool()) {
-        return;
-    }
-
     // We always try to send System
     _sendSystem();
 

--- a/src/Vehicle/RemoteIDManager.cc
+++ b/src/Vehicle/RemoteIDManager.cc
@@ -111,6 +111,12 @@ void RemoteIDManager::_handleArmStatus(mavlink_message_t& message)
         return;
     }
 
+    if (!_available) {
+        _available = true;
+        emit availableChanged();
+        qCDebug(RemoteIDManagerLog) << "Receiving ODID_ARM_STATUS for first time. Mavlink Open Drone ID support is available.";
+    }
+
     // We set the targetsystem
     if (_targetSystem != message.sysid) {
         _targetSystem = message.sysid;

--- a/src/Vehicle/RemoteIDManager.h
+++ b/src/Vehicle/RemoteIDManager.h
@@ -30,13 +30,14 @@ class RemoteIDManager : public QObject
 public:
     RemoteIDManager(Vehicle* vehicle);
 
-    Q_PROPERTY (bool    armStatusGood       READ armStatusGood      NOTIFY armStatusGoodChanged)
-    Q_PROPERTY (QString armStatusError      READ armStatusError     NOTIFY armStatusErrorChanged)
-    Q_PROPERTY (bool    commsGood           READ commsGood          NOTIFY commsGoodChanged)
-    Q_PROPERTY (bool    gcsGPSGood          READ gcsGPSGood         NOTIFY gcsGPSGoodChanged)
-    Q_PROPERTY (bool    basicIDGood         READ basicIDGood        NOTIFY basicIDGoodChanged)
-    Q_PROPERTY (bool    emergencyDeclared   READ emergencyDeclared  NOTIFY emergencyDeclaredChanged)
-    Q_PROPERTY (bool    operatorIDGood      READ operatorIDGood     NOTIFY operatorIDGoodChanged)
+    Q_PROPERTY(bool    available            READ available          NOTIFY availableChanged)             ///< true: the vehicle supports Mavlink Open Drone ID messages
+    Q_PROPERTY(bool    armStatusGood        READ armStatusGood      NOTIFY armStatusGoodChanged)
+    Q_PROPERTY(QString armStatusError       READ armStatusError     NOTIFY armStatusErrorChanged)
+    Q_PROPERTY(bool    commsGood            READ commsGood          NOTIFY commsGoodChanged)
+    Q_PROPERTY(bool    gcsGPSGood           READ gcsGPSGood         NOTIFY gcsGPSGoodChanged)
+    Q_PROPERTY(bool    basicIDGood          READ basicIDGood        NOTIFY basicIDGoodChanged)
+    Q_PROPERTY(bool    emergencyDeclared    READ emergencyDeclared  NOTIFY emergencyDeclaredChanged)
+    Q_PROPERTY(bool    operatorIDGood       READ operatorIDGood     NOTIFY operatorIDGoodChanged)
 
 
     Q_INVOKABLE void checkOperatorID(const QString& operatorID);
@@ -45,6 +46,7 @@ public:
     // Declare emergency
     Q_INVOKABLE void setEmergency(bool declare);
 
+    bool    available           (void) const { return _available; }
     bool    armStatusGood       (void) const { return _armStatusGood; }
     QString armStatusError      (void) const { return _armStatusError; }
     bool    commsGood           (void) const { return _commsGood; }
@@ -67,6 +69,7 @@ public:
     };
 
 signals:
+    void availableChanged();
     void armStatusGoodChanged();
     void armStatusErrorChanged();
     void commsGoodChanged();
@@ -107,6 +110,7 @@ private:
     QGCPositionManager* _positionManager;
 
     // Flags ODID
+    bool    _available = false;
     bool    _armStatusGood;
     QString _armStatusError;
     bool    _commsGood;

--- a/src/ui/SettingsPagesModel.qml
+++ b/src/ui/SettingsPagesModel.qml
@@ -85,7 +85,7 @@ ListModel {
         name: qsTr("Remote ID")
         url: "/qml/RemoteIDSettings.qml"
         iconUrl: "qrc:/qmlimages/RidIconGrey.svg"
-        pageVisible: function() { return QGroundControl.settingsManager.remoteIDSettings.enable.rawValue }
+        pageVisible: function() { return true }
     }
 
     ListElement {

--- a/src/ui/toolbar/CMakeLists.txt
+++ b/src/ui/toolbar/CMakeLists.txt
@@ -5,6 +5,7 @@ add_custom_target(UiToolbarQml
 		FlightModeMenuIndicator.qml
         FlyViewToolBar.qml
 		GPSIndicator.qml
+		GPSIndicatorPage.qml
 		GPSRTKIndicator.qml
 		JoystickIndicator.qml
 		LinkIndicator.qml
@@ -14,6 +15,7 @@ add_custom_target(UiToolbarQml
 		MultiVehicleSelector.qml
         PlanViewToolBar.qml
 		RCRSSIIndicator.qml
+		RemoteIDIndicator.qml
 		SignalStrength.qml
 		TelemetryRSSIIndicator.qml
 )

--- a/src/ui/toolbar/CMakeLists.txt
+++ b/src/ui/toolbar/CMakeLists.txt
@@ -16,6 +16,7 @@ add_custom_target(UiToolbarQml
         PlanViewToolBar.qml
 		RCRSSIIndicator.qml
 		RemoteIDIndicator.qml
+		RemoteIDIndicatorPage.qml
 		SignalStrength.qml
 		TelemetryRSSIIndicator.qml
 )

--- a/src/ui/toolbar/RemoteIDIndicator.qml
+++ b/src/ui/toolbar/RemoteIDIndicator.qml
@@ -19,32 +19,25 @@ import QGroundControl.Palette
 //-------------------------------------------------------------------------
 //-- Remote ID Indicator
 Item {
-    id:             _root
+    id:             control
     width:          remoteIDIcon.width * 1.1
     anchors.top:    parent.top
     anchors.bottom: parent.bottom
 
-    property bool showIndicator: QGroundControl.settingsManager.remoteIDSettings.enable.value
+    property bool   showIndicator:      remoteIDManager.available
 
-    property var    _activeVehicle:     QGroundControl.multiVehicleManager.activeVehicle
+    property var    activeVehicle:      QGroundControl.multiVehicleManager.activeVehicle
+    property var    remoteIDManager:    activeVehicle ? activeVehicle.remoteIDManager : null
+
+    property bool   gpsFlag:            activeVehicle && remoteIDManager ? remoteIDManager.gcsGPSGood         : false
+    property bool   basicIDFlag:        activeVehicle && remoteIDManager ? remoteIDManager.basicIDGood        : false
+    property bool   armFlag:            activeVehicle && remoteIDManager ? remoteIDManager.armStatusGood      : false
+    property bool   commsFlag:          activeVehicle && remoteIDManager ? remoteIDManager.commsGood          : false
+    property bool   emergencyDeclared:  activeVehicle && remoteIDManager ? remoteIDManager.emergencyDeclared  : false
+    property bool   operatorIDFlag:     activeVehicle && remoteIDManager ? remoteIDManager.operatorIDGood     : false
     property int    remoteIDState:      getRemoteIDState()
-
-    property bool   gpsFlag:            _activeVehicle && _activeVehicle.remoteIDManager ? _activeVehicle.remoteIDManager.gcsGPSGood         : false
-    property bool   basicIDFlag:        _activeVehicle && _activeVehicle.remoteIDManager ? _activeVehicle.remoteIDManager.basicIDGood        : false
-    property bool   armFlag:            _activeVehicle && _activeVehicle.remoteIDManager ? _activeVehicle.remoteIDManager.armStatusGood      : false
-    property bool   commsFlag:          _activeVehicle && _activeVehicle.remoteIDManager ? _activeVehicle.remoteIDManager.commsGood          : false
-    property bool   emergencyDeclared:  _activeVehicle && _activeVehicle.remoteIDManager ? _activeVehicle.remoteIDManager.emergencyDeclared  : false
-    property bool   operatorIDFlag:     _activeVehicle && _activeVehicle.remoteIDManager ? _activeVehicle.remoteIDManager.operatorIDGood     : false
     
-    property int    _regionOperation:   QGroundControl.settingsManager.remoteIDSettings.region.value
-
-    // Flags visual properties
-    property real   flagsWidth:         ScreenTools.defaultFontPixelWidth * 10
-    property real   flagsHeight:        ScreenTools.defaultFontPixelWidth * 5
-    property int    radiusFlags:        5
-
-    // Visual properties
-    property real   _margins:           ScreenTools.defaultFontPixelWidth
+    property int    regionOperation:    QGroundControl.settingsManager.remoteIDSettings.region.value
 
     enum RIDState {
         HEALTHY,
@@ -78,7 +71,7 @@ Item {
     }
 
     function getRemoteIDState() {
-        if (!_activeVehicle) {
+        if (!activeVehicle) {
             return RemoteIDIndicator.RIDState.UNAVAILABLE
         }
         // We need to have comms and arm healthy to even be in any other state other than ERROR
@@ -88,7 +81,7 @@ Item {
         if (!gpsFlag || !basicIDFlag) {
             return RemoteIDIndicator.RIDState.WARNING
         }
-        if (_regionOperation == RemoteIDIndicator.RegionOperation.EU || QGroundControl.settingsManager.remoteIDSettings.sendOperatorID.value) {
+        if (regionOperation == RemoteIDIndicator.RegionOperation.EU || QGroundControl.settingsManager.remoteIDSettings.sendOperatorID.value) {
             if (!operatorIDFlag) {
                 return RemoteIDIndicator.RIDState.WARNING
             }
@@ -100,242 +93,6 @@ Item {
         if (!mainWindow.preventViewSwitch()) {
             globals.commingFromRIDIndicator = true
             mainWindow.showSettingsTool()
-        }
-    }
-
-    Component {
-        id: remoteIDInfo
-
-        Rectangle {
-            width:          remoteIDCol.width + ScreenTools.defaultFontPixelWidth  * 3
-            height:         remoteIDCol.height + ScreenTools.defaultFontPixelHeight * 2 + (emergencyButtonItem.visible ? emergencyButtonItem.height : 0)
-            radius:         ScreenTools.defaultFontPixelHeight * 0.5
-            color:          qgcPal.window
-            border.color:   qgcPal.text
-
-            Column {
-                id:                         remoteIDCol
-                spacing:                    ScreenTools.defaultFontPixelHeight * 0.5
-                width:                      Math.max(remoteIDGrid.width, remoteIDLabel.width)
-                anchors.margins:            ScreenTools.defaultFontPixelHeight
-                anchors.top:                parent.top
-                anchors.horizontalCenter:   parent.horizontalCenter
-
-                QGCLabel {
-                    id:                         remoteIDLabel
-                    text:                       qsTr("RemoteID Status")
-                    font.family:                ScreenTools.demiboldFontFamily
-                    anchors.horizontalCenter:   parent.horizontalCenter
-                }
-
-                GridLayout {
-                    id:                         remoteIDGrid
-                    anchors.margins:            ScreenTools.defaultFontPixelHeight
-                    columnSpacing:              ScreenTools.defaultFontPixelWidth
-                    anchors.horizontalCenter:   parent.horizontalCenter
-                    columns:                    2
-
-                    Image {
-                        id:                 armFlagImage
-                        width:              flagsWidth
-                        height:             flagsHeight
-                        source:             armFlag ? "/qmlimages/RidFlagBackgroundGreen.svg" : "/qmlimages/RidFlagBackgroundRed.svg"
-                        fillMode:           Image.PreserveAspectFit
-                        sourceSize.height:  height
-                        visible:            commsFlag
-
-                        QGCLabel {
-                            anchors.fill:           parent
-                            text:                   qsTr("ARM STATUS")
-                            wrapMode:               Text.WordWrap
-                            horizontalAlignment:    Text.AlignHCenter
-                            verticalAlignment:      Text.AlignVCenter
-                            font.bold:              true
-                            font.pointSize:         ScreenTools.smallFontPointSize
-                        }
-
-                        QGCMouseArea {
-                            anchors.fill:   parent
-                            onClicked:      goToSettings()
-                        }
-                    }
-
-                    Image {
-                        id:                 commsFlagImage
-                        width:              flagsWidth
-                        height:             flagsHeight
-                        source:             commsFlag ? "/qmlimages/RidFlagBackgroundGreen.svg" : "/qmlimages/RidFlagBackgroundRed.svg"
-                        fillMode:           Image.PreserveAspectFit
-                        sourceSize.height:  height
-
-                        QGCLabel {
-                            anchors.fill:           parent
-                            text:                   commsFlag ? qsTr("RID COMMS") : qsTr("NOT CONNECTED")
-                            wrapMode:               Text.WordWrap
-                            horizontalAlignment:    Text.AlignHCenter
-                            verticalAlignment:      Text.AlignVCenter
-                            font.bold:              true
-                            font.pointSize:         ScreenTools.smallFontPointSize
-                        }
-
-                        QGCMouseArea {
-                            anchors.fill:   parent
-                            onClicked:      goToSettings()
-                        }
-                    }
-                    
-                    Image {
-                        id:                 gpsFlagImage
-                        width:              flagsWidth
-                        height:             flagsHeight
-                        source:             gpsFlag ? "/qmlimages/RidFlagBackgroundGreen.svg" : "/qmlimages/RidFlagBackgroundRed.svg"
-                        fillMode:           Image.PreserveAspectFit
-                        sourceSize.height:  height
-                        visible:            commsFlag
-
-                        QGCLabel {
-                            anchors.fill:           parent
-                            text:                   qsTr("GCS GPS")
-                            wrapMode:               Text.WordWrap
-                            horizontalAlignment:    Text.AlignHCenter
-                            verticalAlignment:      Text.AlignVCenter
-                            font.bold:              true
-                            font.pointSize:         ScreenTools.smallFontPointSize
-                        }
-
-                        QGCMouseArea {
-                            anchors.fill:   parent
-                            onClicked:      goToSettings()
-                        }
-                    }
-
-                    Image {
-                        id:                 basicIDFlagIge
-                        width:              flagsWidth
-                        height:             flagsHeight
-                        source:             basicIDFlag ? "/qmlimages/RidFlagBackgroundGreen.svg" : "/qmlimages/RidFlagBackgroundRed.svg"
-                        fillMode:           Image.PreserveAspectFit
-                        sourceSize.height:  height
-                        visible:            commsFlag
-
-                        QGCLabel {
-                            anchors.fill:           parent
-                            text:                   qsTr("BASIC ID")
-                            wrapMode:               Text.WordWrap
-                            horizontalAlignment:    Text.AlignHCenter
-                            verticalAlignment:      Text.AlignVCenter
-                            font.bold:              true
-                            font.pointSize:         ScreenTools.smallFontPointSize
-                        }
-
-                        QGCMouseArea {
-                            anchors.fill:   parent
-                            onClicked:      goToSettings()
-                        }
-                    }
-
-                    Image {
-                        id:                 operatorIDFlagImage
-                        width:              flagsWidth
-                        height:             flagsHeight
-                        source:             operatorIDFlag ? "/qmlimages/RidFlagBackgroundGreen.svg" : "/qmlimages/RidFlagBackgroundRed.svg"
-                        fillMode:           Image.PreserveAspectFit
-                        sourceSize.height:  height
-                        visible:            commsFlag && _activeVehicle ? (QGroundControl.settingsManager.remoteIDSettings.sendOperatorID.value || _regionOperation == RemoteIDIndicator.RegionOperation.EU) : false
-
-                        QGCLabel {
-                            anchors.fill:           parent
-                            text:                   qsTr("OPERATOR ID")
-                            wrapMode:               Text.WordWrap
-                            horizontalAlignment:    Text.AlignHCenter
-                            verticalAlignment:      Text.AlignVCenter
-                            font.bold:              true
-                            font.pointSize:         ScreenTools.smallFontPointSize
-                        }
-
-                        QGCMouseArea {
-                            anchors.fill:   parent
-                            onClicked:      goToSettings()
-                        }
-                    }
-                }
-            }
-
-            Item {
-                id:             emergencyButtonItem
-                anchors.top:    remoteIDCol.bottom
-                anchors.left:   parent.left
-                anchors.right:  parent.right
-                height:         emergencyDeclareLabel.height + emergencyButton.height + (_margins * 4)
-                visible:        commsFlag
-
-                QGCLabel {
-                    id:                     emergencyDeclareLabel
-                    text:                   emergencyDeclared ? qsTr("EMERGENCY HAS BEEN DECLARED, Press and Hold for 3 seconds to cancel") : qsTr("Press and Hold below button to declare emergency")
-                    font.family:            ScreenTools.demiboldFontFamily
-                    anchors.top:            parent.top
-                    anchors.left:           parent.left
-                    anchors.right:          parent.right
-                    anchors.margins:        _margins
-                    anchors.topMargin:      _margins * 3
-                    wrapMode:               Text.WordWrap
-                    horizontalAlignment:    Text.AlignHCenter
-                    visible:                true
-                }
-
-                Image {
-                    id:                         emergencyButton
-                    width:                      flagsWidth * 2
-                    height:                     flagsHeight * 1.5
-                    source:                     "/qmlimages/RidEmergencyBackground.svg"
-                    sourceSize.height:          height
-                    anchors.horizontalCenter:   parent.horizontalCenter
-                    anchors.top:                emergencyDeclareLabel.bottom
-                    anchors.margins:            _margins
-                    visible:                    true
-
-                    QGCLabel {
-                        anchors.fill:           parent
-                        text:                   emergencyDeclared ? qsTr("Clear Emergency") : qsTr("EMERGENCY")
-                        wrapMode:               Text.WordWrap
-                        horizontalAlignment:    Text.AlignHCenter
-                        verticalAlignment:      Text.AlignVCenter
-                        font.bold:              true
-                        font.pointSize:         ScreenTools.largeFontPointSize
-                    }
-
-                    Timer {
-                        id:             emergencyButtonTimer
-                        interval:       350
-                        onTriggered: {
-                            if (emergencyButton.source == "/qmlimages/RidEmergencyBackgroundHighlight.svg" ) {
-                                emergencyButton.source = "/qmlimages/RidEmergencyBackground.svg"
-                            } else {
-                                emergencyButton.source = "/qmlimages/RidEmergencyBackgroundHighlight.svg"
-                            }
-                        }
-                    }
-
-                    MouseArea {
-                        anchors.fill:           parent
-                        hoverEnabled:           true
-                        onEntered:              emergencyButton.source = "/qmlimages/RidEmergencyBackgroundHighlight.svg"
-                        onExited:               emergencyButton.source = "/qmlimages/RidEmergencyBackground.svg"
-                        pressAndHoldInterval:   emergencyDeclared ? 3000 : 800
-                        onPressAndHold: {
-                            if (emergencyButton.source == "/qmlimages/RidEmergencyBackgroundHighlight.svg" ) {
-                                emergencyButton.source = "/qmlimages/RidEmergencyBackground.svg"
-                            } else {
-                                emergencyButton.source = "/qmlimages/RidEmergencyBackgroundHighlight.svg"
-                            }
-                            emergencyButtonTimer.restart()
-                            if (_activeVehicle) {
-                                _activeVehicle.remoteIDManager.setEmergency(!emergencyDeclared)
-                            }
-                        }
-                    }
-                }
-            }
         }
     }
 
@@ -351,8 +108,12 @@ Item {
 
     MouseArea {
         anchors.fill:   parent
-        onClicked: {
-            mainWindow.showIndicatorPopup(_root, remoteIDInfo)
-        }
+        onClicked:      mainWindow.showIndicatorDrawer(indicatorPage, control)
+    }
+
+    Component {
+        id: indicatorPage
+
+        RemoteIDIndicatorPage { }
     }
 }

--- a/src/ui/toolbar/RemoteIDIndicatorPage.qml
+++ b/src/ui/toolbar/RemoteIDIndicatorPage.qml
@@ -1,0 +1,288 @@
+/****************************************************************************
+ *
+ * (c) 2009-2020 QGROUNDCONTROL PROJECT <http://www.qgroundcontrol.org>
+ *
+ * QGroundControl is licensed according to the terms in the file
+ * COPYING.md in the root of the source code directory.
+ *
+ ****************************************************************************/
+
+import QtQuick
+import QtQuick.Layouts
+
+import QGroundControl
+import QGroundControl.Controls
+import QGroundControl.MultiVehicleManager
+import QGroundControl.ScreenTools
+import QGroundControl.Palette
+import QGroundControl.FactSystem
+import QGroundControl.FactControls
+
+ToolIndicatorPage {
+    showExpand: false
+
+    property var    _activeVehicle:     QGroundControl.multiVehicleManager.activeVehicle
+
+    property bool   gpsFlag:            _activeVehicle && _activeVehicle.remoteIDManager ? _activeVehicle.remoteIDManager.gcsGPSGood         : false
+    property bool   basicIDFlag:        _activeVehicle && _activeVehicle.remoteIDManager ? _activeVehicle.remoteIDManager.basicIDGood        : false
+    property bool   armFlag:            _activeVehicle && _activeVehicle.remoteIDManager ? _activeVehicle.remoteIDManager.armStatusGood      : false
+    property bool   commsFlag:          _activeVehicle && _activeVehicle.remoteIDManager ? _activeVehicle.remoteIDManager.commsGood          : false
+    property bool   emergencyDeclared:  _activeVehicle && _activeVehicle.remoteIDManager ? _activeVehicle.remoteIDManager.emergencyDeclared  : false
+    property bool   operatorIDFlag:     _activeVehicle && _activeVehicle.remoteIDManager ? _activeVehicle.remoteIDManager.operatorIDGood     : false
+    
+    property int    _regionOperation:   QGroundControl.settingsManager.remoteIDSettings.region.value
+
+    // Flags visual properties
+    property real   flagsWidth:         ScreenTools.defaultFontPixelWidth * 10
+    property real   flagsHeight:        ScreenTools.defaultFontPixelWidth * 5
+    property int    radiusFlags:        5
+
+    // Visual properties
+    property real   _margins:           ScreenTools.defaultFontPixelWidth
+
+    enum RegionOperation {
+        FAA,
+        EU
+    }
+
+    function goToSettings() {
+        if (!mainWindow.preventViewSwitch()) {
+            globals.commingFromRIDIndicator = true
+            mainWindow.showSettingsTool()
+        }
+    }
+
+    contentComponent: Component {
+        Rectangle {
+            width:          remoteIDCol.width + ScreenTools.defaultFontPixelWidth  * 3
+            height:         remoteIDCol.height + ScreenTools.defaultFontPixelHeight * 2 + (emergencyButtonItem.visible ? emergencyButtonItem.height : 0)
+            radius:         ScreenTools.defaultFontPixelHeight * 0.5
+            color:          qgcPal.window
+            border.color:   qgcPal.text
+
+            Column {
+                id:                         remoteIDCol
+                spacing:                    ScreenTools.defaultFontPixelHeight * 0.5
+                width:                      Math.max(remoteIDGrid.width, remoteIDLabel.width)
+                anchors.margins:            ScreenTools.defaultFontPixelHeight
+                anchors.top:                parent.top
+                anchors.horizontalCenter:   parent.horizontalCenter
+
+                QGCLabel {
+                    id:                         remoteIDLabel
+                    text:                       qsTr("RemoteID Status")
+                    font.family:                ScreenTools.demiboldFontFamily
+                    anchors.horizontalCenter:   parent.horizontalCenter
+                }
+
+                GridLayout {
+                    id:                         remoteIDGrid
+                    anchors.margins:            ScreenTools.defaultFontPixelHeight
+                    columnSpacing:              ScreenTools.defaultFontPixelWidth
+                    anchors.horizontalCenter:   parent.horizontalCenter
+                    columns:                    2
+
+                    Image {
+                        id:                 armFlagImage
+                        width:              flagsWidth
+                        height:             flagsHeight
+                        source:             armFlag ? "/qmlimages/RidFlagBackgroundGreen.svg" : "/qmlimages/RidFlagBackgroundRed.svg"
+                        fillMode:           Image.PreserveAspectFit
+                        sourceSize.height:  height
+                        visible:            commsFlag
+
+                        QGCLabel {
+                            anchors.fill:           parent
+                            text:                   qsTr("ARM STATUS")
+                            wrapMode:               Text.WordWrap
+                            horizontalAlignment:    Text.AlignHCenter
+                            verticalAlignment:      Text.AlignVCenter
+                            font.bold:              true
+                            font.pointSize:         ScreenTools.smallFontPointSize
+                        }
+
+                        QGCMouseArea {
+                            anchors.fill:   parent
+                            onClicked:      goToSettings()
+                        }
+                    }
+
+                    Image {
+                        id:                 commsFlagImage
+                        width:              flagsWidth
+                        height:             flagsHeight
+                        source:             commsFlag ? "/qmlimages/RidFlagBackgroundGreen.svg" : "/qmlimages/RidFlagBackgroundRed.svg"
+                        fillMode:           Image.PreserveAspectFit
+                        sourceSize.height:  height
+
+                        QGCLabel {
+                            anchors.fill:           parent
+                            text:                   commsFlag ? qsTr("RID COMMS") : qsTr("NOT CONNECTED")
+                            wrapMode:               Text.WordWrap
+                            horizontalAlignment:    Text.AlignHCenter
+                            verticalAlignment:      Text.AlignVCenter
+                            font.bold:              true
+                            font.pointSize:         ScreenTools.smallFontPointSize
+                        }
+
+                        QGCMouseArea {
+                            anchors.fill:   parent
+                            onClicked:      goToSettings()
+                        }
+                    }
+                    
+                    Image {
+                        id:                 gpsFlagImage
+                        width:              flagsWidth
+                        height:             flagsHeight
+                        source:             gpsFlag ? "/qmlimages/RidFlagBackgroundGreen.svg" : "/qmlimages/RidFlagBackgroundRed.svg"
+                        fillMode:           Image.PreserveAspectFit
+                        sourceSize.height:  height
+                        visible:            commsFlag
+
+                        QGCLabel {
+                            anchors.fill:           parent
+                            text:                   qsTr("GCS GPS")
+                            wrapMode:               Text.WordWrap
+                            horizontalAlignment:    Text.AlignHCenter
+                            verticalAlignment:      Text.AlignVCenter
+                            font.bold:              true
+                            font.pointSize:         ScreenTools.smallFontPointSize
+                        }
+
+                        QGCMouseArea {
+                            anchors.fill:   parent
+                            onClicked:      goToSettings()
+                        }
+                    }
+
+                    Image {
+                        id:                 basicIDFlagIge
+                        width:              flagsWidth
+                        height:             flagsHeight
+                        source:             basicIDFlag ? "/qmlimages/RidFlagBackgroundGreen.svg" : "/qmlimages/RidFlagBackgroundRed.svg"
+                        fillMode:           Image.PreserveAspectFit
+                        sourceSize.height:  height
+                        visible:            commsFlag
+
+                        QGCLabel {
+                            anchors.fill:           parent
+                            text:                   qsTr("BASIC ID")
+                            wrapMode:               Text.WordWrap
+                            horizontalAlignment:    Text.AlignHCenter
+                            verticalAlignment:      Text.AlignVCenter
+                            font.bold:              true
+                            font.pointSize:         ScreenTools.smallFontPointSize
+                        }
+
+                        QGCMouseArea {
+                            anchors.fill:   parent
+                            onClicked:      goToSettings()
+                        }
+                    }
+
+                    Image {
+                        id:                 operatorIDFlagImage
+                        width:              flagsWidth
+                        height:             flagsHeight
+                        source:             operatorIDFlag ? "/qmlimages/RidFlagBackgroundGreen.svg" : "/qmlimages/RidFlagBackgroundRed.svg"
+                        fillMode:           Image.PreserveAspectFit
+                        sourceSize.height:  height
+                        visible:            commsFlag && _activeVehicle ? (QGroundControl.settingsManager.remoteIDSettings.sendOperatorID.value || _regionOperation == RemoteIDIndicatorPage.EU) : false
+
+                        QGCLabel {
+                            anchors.fill:           parent
+                            text:                   qsTr("OPERATOR ID")
+                            wrapMode:               Text.WordWrap
+                            horizontalAlignment:    Text.AlignHCenter
+                            verticalAlignment:      Text.AlignVCenter
+                            font.bold:              true
+                            font.pointSize:         ScreenTools.smallFontPointSize
+                        }
+
+                        QGCMouseArea {
+                            anchors.fill:   parent
+                            onClicked:      goToSettings()
+                        }
+                    }
+                }
+            }
+
+            Item {
+                id:             emergencyButtonItem
+                anchors.top:    remoteIDCol.bottom
+                anchors.left:   parent.left
+                anchors.right:  parent.right
+                height:         emergencyDeclareLabel.height + emergencyButton.height + (_margins * 4)
+                visible:        commsFlag
+
+                QGCLabel {
+                    id:                     emergencyDeclareLabel
+                    text:                   emergencyDeclared ? qsTr("EMERGENCY HAS BEEN DECLARED, Press and Hold for 3 seconds to cancel") : qsTr("Press and Hold below button to declare emergency")
+                    font.family:            ScreenTools.demiboldFontFamily
+                    anchors.top:            parent.top
+                    anchors.left:           parent.left
+                    anchors.right:          parent.right
+                    anchors.margins:        _margins
+                    anchors.topMargin:      _margins * 3
+                    wrapMode:               Text.WordWrap
+                    horizontalAlignment:    Text.AlignHCenter
+                    visible:                true
+                }
+
+                Image {
+                    id:                         emergencyButton
+                    width:                      flagsWidth * 2
+                    height:                     flagsHeight * 1.5
+                    source:                     "/qmlimages/RidEmergencyBackground.svg"
+                    sourceSize.height:          height
+                    anchors.horizontalCenter:   parent.horizontalCenter
+                    anchors.top:                emergencyDeclareLabel.bottom
+                    anchors.margins:            _margins
+                    visible:                    true
+
+                    QGCLabel {
+                        anchors.fill:           parent
+                        text:                   emergencyDeclared ? qsTr("Clear Emergency") : qsTr("EMERGENCY")
+                        wrapMode:               Text.WordWrap
+                        horizontalAlignment:    Text.AlignHCenter
+                        verticalAlignment:      Text.AlignVCenter
+                        font.bold:              true
+                        font.pointSize:         ScreenTools.largeFontPointSize
+                    }
+
+                    Timer {
+                        id:             emergencyButtonTimer
+                        interval:       350
+                        onTriggered: {
+                            if (emergencyButton.source == "/qmlimages/RidEmergencyBackgroundHighlight.svg" ) {
+                                emergencyButton.source = "/qmlimages/RidEmergencyBackground.svg"
+                            } else {
+                                emergencyButton.source = "/qmlimages/RidEmergencyBackgroundHighlight.svg"
+                            }
+                        }
+                    }
+
+                    MouseArea {
+                        anchors.fill:           parent
+                        hoverEnabled:           true
+                        onEntered:              emergencyButton.source = "/qmlimages/RidEmergencyBackgroundHighlight.svg"
+                        onExited:               emergencyButton.source = "/qmlimages/RidEmergencyBackground.svg"
+                        pressAndHoldInterval:   emergencyDeclared ? 3000 : 800
+                        onPressAndHold: {
+                            if (emergencyButton.source == "/qmlimages/RidEmergencyBackgroundHighlight.svg" ) {
+                                emergencyButton.source = "/qmlimages/RidEmergencyBackground.svg"
+                            } else {
+                                emergencyButton.source = "/qmlimages/RidEmergencyBackgroundHighlight.svg"
+                            }
+                            emergencyButtonTimer.restart()
+                            if (_activeVehicle) {
+                                _activeVehicle.remoteIDManager.setEmergency(!emergencyDeclared)
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    }
+}


### PR DESCRIPTION
* Converted Remote ID Indicator to new style
* Removed the remote id enable setting:
  * Remote ID settings page is always shown
  * If comms are good in the remote id manager open drone id message are sent to the vehicle
* Added RemoteIDManager.available property. This indicates whether the vehicle support Open Drone ID of not
* Remote ID toolbar indicator will not be shown if the vehicle does not support Mavlink Open Drone ID

ToDo:
* Rework remote id settings to the new ui style
* Allow remote id settings to be configured in expanded page of the toolbar indicator

@Davidsastresas FYI: Other than the enable thing, the functionality is exactly the same. Just visual changes.

<img width="227" alt="Screenshot 2024-03-09 at 12 22 47 PM" src="https://github.com/mavlink/qgroundcontrol/assets/5876851/f2721d4e-04bf-4bae-adc9-3aa3f9bacffb">
