### PR TITLE
Position manager fix

### DIFF
--- a/src/PositionManager/PositionManager.cpp
+++ b/src/PositionManager/PositionManager.cpp
@@ -182,7 +182,10 @@ void QGCPositionManager::setPositionSource(QGCPositionManager::QGCPositionSource
     if (_currentSource != nullptr) {
         _updateInterval = _currentSource->minimumUpdateInterval();
         _currentSource->setPreferredPositioningMethods(QGeoPositionInfoSource::SatellitePositioningMethods);
+        // OSX and iOS do not support setting the update interval
+#if !defined(Q_OS_DARWIN) && !defined(Q_OS_IOS)
         _currentSource->setUpdateInterval(_updateInterval);
+#endif
         connect(_currentSource, &QGeoPositionInfoSource::positionUpdated, this, &QGCPositionManager::_positionUpdated);
         connect(_currentSource, &QGeoPositionInfoSource::errorOccurred, this, &QGCPositionManager::_error);
         _currentSource->startUpdates();

--- a/src/QGCApplication.cc
+++ b/src/QGCApplication.cc
@@ -72,7 +72,6 @@
 #include "HorizontalFactValueGrid.h"
 #include "InstrumentValueData.h"
 #include "AppMessages.h"
-#include "SimulatedPosition.h"
 #include "PositionManager.h"
 #include "FollowMe.h"
 #include "MissionCommandTree.h"

--- a/src/QmlControls/QGroundControlQmlGlobal.h
+++ b/src/QmlControls/QGroundControlQmlGlobal.h
@@ -12,7 +12,6 @@
 #include "QGCToolbox.h"
 #include "QGCApplication.h"
 #include "SettingsFact.h"
-#include "SimulatedPosition.h"
 #include "QGCLoggingCategory.h"
 #include "AppSettings.h"
 #include "ADSBVehicleManager.h"


### PR DESCRIPTION
QGeoPositionInfoSource::setUpdateInterval not support on iOS/OSX. If you do call it, it causes update timeout errors to be reported.