### PR TITLE
Src: Remove unneeded includes of QGCConfig.h

### DIFF
--- a/src/QGCApplication.cc
+++ b/src/QGCApplication.cc
@@ -33,6 +33,7 @@
 #include "GStreamer.h"
 #endif
 
+#include "QGCConfig.h"
 #include "QGC.h"
 #include "QGCApplication.h"
 #include "CmdLineOptParser.h"

--- a/src/QGCConfig.h
+++ b/src/QGCConfig.h
@@ -1,13 +1,6 @@
 #ifndef QGC_CONFIGURATION_H
 #define QGC_CONFIGURATION_H
 
-#include <QString>
-
-/** @brief Polling interval in ms */
-#define SERIAL_POLL_INTERVAL 4
-
-#define WITH_TEXT_TO_SPEECH 1
-
 // If you need to make an incompatible changes to stored settings, bump this version number
 // up by 1. This will caused store settings to be cleared on next boot.
 #define QGC_SETTINGS_VERSION 9

--- a/src/Utilities/QGC.h
+++ b/src/Utilities/QGC.h
@@ -13,8 +13,6 @@
 #include <QColor>
 #include <QThread>
 
-#include "QGCConfig.h"
-
 namespace QGC
 {
 

--- a/src/comm/SerialLink.h
+++ b/src/comm/SerialLink.h
@@ -25,7 +25,6 @@
 // We use QSerialPort::SerialPortError in a signal so we must declare it as a meta type
 Q_DECLARE_METATYPE(QSerialPort::SerialPortError)
 
-#include "QGCConfig.h"
 #include "LinkConfiguration.h"
 #include "LinkInterface.h"
 

--- a/src/comm/TCPLink.h
+++ b/src/comm/TCPLink.h
@@ -15,7 +15,6 @@
 #include <QMutex>
 #include <QHostAddress>
 #include <LinkInterface.h>
-#include "QGCConfig.h"
 
 // Even though QAbstractSocket::SocketError is used in a signal by Qt, Qt doesn't declare it as a meta type.
 // This in turn causes debug output to be kicked out about not being able to queue the signal. We declare it

--- a/src/comm/UDPLink.h
+++ b/src/comm/UDPLink.h
@@ -22,7 +22,6 @@
 #include <dns_sd.h>
 #endif
 
-#include "QGCConfig.h"
 #include "LinkConfiguration.h"
 #include "LinkInterface.h"
 


### PR DESCRIPTION
There is only one macro that is used and it is used in QGCApplication.