### PR TITLE
Rework Remote ID settings to new style

### DIFF
--- a/src/FactSystem/FactControls/LabelledFactTextField.qml
+++ b/src/FactSystem/FactControls/LabelledFactTextField.qml
@@ -22,6 +22,7 @@ RowLayout {
     property alias  textFieldUnitsLabel:     _factTextField.unitsLabel
     property alias  textFieldShowUnits:      _factTextField.showUnits
     property alias  textFieldShowHelp:       _factTextField.showHelp
+    property alias  textField:               _factTextField
 
     spacing: ScreenTools.defaultFontPixelWidth * 2
 

--- a/src/QmlControls/ParameterEditorDialog.qml
+++ b/src/QmlControls/ParameterEditorDialog.qml
@@ -75,7 +75,6 @@ QGCPopupDialog {
     }
 
     Component.onCompleted: {
-        console.log("ParameterEditor")
         if (validate) {
             valueField.text = validateValue
             validationError.text = fact.validate(validateValue, false /* convertOnly */)
@@ -116,11 +115,12 @@ QGCPopupDialog {
             }
 
             QGCComboBox {
-                id:         factCombo
-                width:      _editFieldWidth
-                model:      fact.enumStrings
-                visible:    _showCombo
-                focus:      setFocus && visible
+                id:             factCombo
+                width:          _editFieldWidth
+                model:          fact.enumStrings
+                sizeToContents: true
+                visible:        _showCombo
+                focus:          setFocus && visible
 
                 Component.onCompleted: {
                     // We can't bind directly to fact.enumIndex since that would add an unknown value

--- a/src/QmlControls/SettingsGroupLayout.qml
+++ b/src/QmlControls/SettingsGroupLayout.qml
@@ -6,10 +6,10 @@ import QGroundControl.ScreenTools
 import QGroundControl.Palette
 
 ColumnLayout {
-    id:             control    
-    spacing:        _margins / 2
-    implicitWidth:  _contentLayout.implicitWidth + (_margins * 2)
-    implicitHeight: _contentLayout.implicitHeight + (_margins * 2)
+    id:                 control    
+    spacing:            _margins / 2
+    implicitWidth:      _contentLayout.implicitWidth + (_margins * 2)
+    implicitHeight:     _contentLayout.implicitHeight + (_margins * 2)
 
     default property alias contentItem: _contentLayout.data
 

--- a/src/Settings/RemoteID.SettingsGroup.json
+++ b/src/Settings/RemoteID.SettingsGroup.json
@@ -34,21 +34,21 @@
 },
 {
     "name":         "selfIDFree",
-    "shortDesc":    "Self ID",
+    "shortDesc":    "Flight Purpose",
     "longDesc":     "Optional plain text for operator to specify operations data (Free Text). Maximum 23 characters.",
     "type":         "string",
     "default":      ""
 },
 {
     "name":         "selfIDEmergency",
-    "shortDesc":    "Self ID",
+    "shortDesc":    "Emergency Text",
     "longDesc":     "Optional plain text for operator to specify operations data (Emergency Text). Maximum 23 characters.",
     "type":         "string",
     "default":      "Pilot Emergency Status"
 },
 {
     "name":         "selfIDExtended",
-    "shortDesc":    "Self ID",
+    "shortDesc":    "Extended Status",
     "longDesc":     "Optional plain text for operator to specify operations data (Extended Text). Maximum 23 characters.",
     "type":         "string",
     "default":      ""
@@ -57,7 +57,7 @@
     "name":         "selfIDType",
     "shortDesc":    "Self ID type",
     "type":         "uint8",
-    "enumStrings":  "Free Text,Emergency,Extended Status",
+    "enumStrings":  "Flight Purpose,Emergency,Extended Status",
     "enumValues":   "0,1,2",
     "default":      0
 },
@@ -78,7 +78,7 @@
     "name":         "basicIDType",
     "shortDesc":    "Basic ID Type",
     "type":         "uint8",
-    "enumStrings":  "None, SerialNumber(ANSI/CTA-2063), CAA, UTM(RFC4122), Specific",
+    "enumStrings":  "None,SerialNumber (ANSI/CTA-2063),CAA,UTM (RFC4122),Specific",
     "enumValues":   "0,1,2,3,4",
     "default":      2
 },
@@ -86,7 +86,7 @@
     "name":         "basicIDUaType",
     "shortDesc":    "UA type",
     "type":         "uint8",
-    "enumStrings":  "Undefined,Airplane/FixedWing,Helicopter/Multirrotor, Gyroplane, VTOL, Ornithopter, Glider, Kite, Free Ballon, Captive Ballon, Airship, Parachute, Rocket, Tethered powered aircraft, Ground Obstacle, Other",
+    "enumStrings":  "Undefined,Airplane/FixedWing,Helicopter/Multirrotor,Gyroplane,VTOL,Ornithopter,Glider,Kite,Free Ballon,Captive Ballon,Airship,Parachute,Rocket,Tethered powered aircraft,Ground Obstacle,Other",
     "enumValues":   "0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15",
     "default":      0
 },
@@ -111,58 +111,62 @@
     "shortDesc":    "Location Type",
     "longDesc":     "Operator location Type",
     "type":         "uint8",
-    "enumStrings":  "Takeoff(Not Supported),Live GNNS, Fixed",
-    "enumValues":   "0,1,2",
+    "enumStrings":  "Live,Fixed",
+    "enumValues":   "1,2",
     "default":      1
 },
 {
-    "name":         "latitudeFixed",
-    "shortDesc":    "Latitude Fixed",
-    "longDesc":     "Fixed latitude to send on SYSTEM message",
-    "type":         "double",
-    "decimalPlaces":7,
-    "default":      0
+    "name":             "latitudeFixed",
+    "shortDesc":        "Latitude Fixed",
+    "longDesc":         "Fixed latitude to send on SYSTEM message",
+    "type":             "double",
+    "minValue":         "-90",
+    "maxValue":         "90",
+    "decimalPlaces":    7,
+    "default":          0
 },
 {
-    "name":         "longitudeFixed",
-    "shortDesc":    "Longitude Fixed",
-    "longDesc":     "Fixed Longitude to send on SYSTEM message",
-    "type":         "double",
-    "decimalPlaces":7,
-    "default":      0
+    "name":             "longitudeFixed",
+    "shortDesc":        "Longitude Fixed",
+    "longDesc":         "Fixed Longitude to send on SYSTEM message",
+    "type":             "double",
+    "minValue":         "-180",
+    "maxValue":         "180",
+    "decimalPlaces":    7,
+    "default":          0
 },
 {
-    "name":         "altitudeFixed",
-    "shortDesc":    "Altitude Fixed",
-    "longDesc":     "Fixed Altitude to send on SYSTEM message",
-    "type":         "double",
-    "decimalPlaces":7,
-    "default":      0
+    "name":             "altitudeFixed",
+    "shortDesc":        "Altitude Fixed",
+    "longDesc":         "Fixed Altitude to send on SYSTEM message",
+    "type":             "double",
+    "decimalPlaces":    7,
+    "default":          0
 },
 {
     "name":         "classificationType",
     "shortDesc":    "Classification Type",
-    "longDesc":     "Classification Type of UA",
+    "longDesc":     "Classification Type of UAS",
     "type":         "uint8",
-    "enumStrings":  "Undefined,EU",
+    "enumStrings":  "Undeclared,EU",
     "enumValues":   "0,1",
     "default":      0
 },
 {
     "name":         "categoryEU",
-    "shortDesc":    "Category EU",
+    "shortDesc":    "Category",
     "longDesc":     "Category of the UAS in the EU region",
     "type":         "uint8",
-    "enumStrings":  "Undeclared,Open, Specific, Certified",
+    "enumStrings":  "Undeclared,Open,Specific,Certified",
     "enumValues":   "0,1,2,3",
     "default":      0
 },
 {
     "name":         "classEU",
-    "shortDesc":    "Class EU",
+    "shortDesc":    "Class",
     "longDesc":     "Class of the UAS in the EU region",
     "type":         "uint8",
-    "enumStrings":  "Undeclared,Class 0, Class 1, Class 2, Class 3, Class 4, Class 5, Class 6",
+    "enumStrings":  "Undeclared,Class 0,Class 1,Class 2,Class 3,Class 4,Class 5,Class 6",
     "enumValues":   "0,1,2,3,4,5,6,7",
     "default":      0
 }

--- a/src/Vehicle/RemoteIDManager.cc
+++ b/src/Vehicle/RemoteIDManager.cc
@@ -20,6 +20,9 @@ QGC_LOGGING_CATEGORY(RemoteIDManagerLog, "RemoteIDManagerLog")
 
 #define AREA_COUNT 1
 #define AREA_RADIUS 0
+#define MAVLINK_UNKNOWN_METERS -1000.0f
+#define MAVLINK_UNKNOWN_LAT 0
+#define MAVLINK_UNKNOWN_LON 0
 #define SENDING_RATE_MSEC 1000
 #define ALLOWED_GPS_DELAY 5000
 #define RID_TIMEOUT 2500 // Messages should be arriving at 1 Hz, so we set a 2 second timeout
@@ -342,15 +345,15 @@ void RemoteIDManager::_sendSystem()
                                                     _id_or_mac_unknown,
                                                     _settings->locationType()->rawValue().toUInt(),
                                                     _settings->classificationType()->rawValue().toUInt(),
-                                                    _gcsGPSGood ? ( gcsPosition.latitude()  * 1.0e7 ) : 0, // If position not valid, send a 0
-                                                    _gcsGPSGood ? ( gcsPosition.longitude() * 1.0e7 ) : 0, // If position not valid, send a 0
+                                                    _gcsGPSGood ? ( gcsPosition.latitude()  * 1.0e7 ) : MAVLINK_UNKNOWN_LAT,
+                                                    _gcsGPSGood ? ( gcsPosition.longitude() * 1.0e7 ) : MAVLINK_UNKNOWN_LON,
                                                     AREA_COUNT,
                                                     AREA_RADIUS,
-                                                    -1000.0f,
-                                                    -1000.0f,
+                                                    MAVLINK_UNKNOWN_METERS,
+                                                    MAVLINK_UNKNOWN_METERS,
                                                     _settings->categoryEU()->rawValue().toUInt(),
                                                     _settings->classEU()->rawValue().toUInt(),
-                                                    _gcsGPSGood ? gcsPosition.altitude() : 0, // If position not valid, send a 0
+                                                    _gcsGPSGood ? gcsPosition.altitude() : MAVLINK_UNKNOWN_METERS,
                                                     _timestamp2019()), // Time stamp needs to be since 00:00:00 1/1/2019
         _vehicle->sendMessageOnLinkThreadSafe(sharedLink.get(), msg);
     }

--- a/src/ui/preferences/RemoteIDSettings.qml
+++ b/src/ui/preferences/RemoteIDSettings.qml
@@ -244,7 +244,7 @@ Rectangle {
                         Layout.preferredWidth:  flagsWidth
                         color:                  _activeRID ? (_activeVehicle.remoteIDManager.operatorIDGood ? qgcPal.colorGreen : qgcPal.colorRed) : qgcPal.colorGrey
                         radius:                 radiusFlags
-                        visible:                commsGood && _activeRID ? (QGroundControl.settingsManager.remoteIDSettings.sendOperatorID.value || _regionOperation == RemoteIDSettings.RegionOperation.EU) : false
+                        visible:                commsGood && _activeRID ? (QGroundControl.settingsManager.remoteIDSettings.sendOperatorID.value || _regionOperation == RemoteIDIndicatorPage.RegionOperation.EU) : false
 
                         QGCLabel {
                             anchors.fill:           parent
@@ -378,43 +378,43 @@ Rectangle {
                             // In case we change from EU to FAA having the location Type to FIXED, since its not supported in FAA
                             // we need to change it to Live GNSS
                             onActivated: (index) => {
-                                if (currentIndex == RemoteIDSettings.RegionOperation.FAA && QGroundControl.settingsManager.remoteIDSettings.locationType.value != RemoteIDSettings.LocationType.LIVE)
-                                QGroundControl.settingsManager.remoteIDSettings.locationType.value = RemoteIDSettings.LocationType.LIVE
+                                if (currentIndex == RemoteIDIndicatorPage.RegionOperation.FAA && QGroundControl.settingsManager.remoteIDSettings.locationType.value != RemoteIDIndicatorPage.LocationType.LIVE)
+                                QGroundControl.settingsManager.remoteIDSettings.locationType.value = RemoteIDIndicatorPage.LocationType.LIVE
                             }
                         }
 
                         QGCLabel {
                             text:               QGroundControl.settingsManager.remoteIDSettings.classificationType.shortDescription
-                            visible:            _regionOperation == RemoteIDSettings.RegionOperation.EU
+                            visible:            _regionOperation == RemoteIDIndicatorPage.RegionOperation.EU
                             Layout.fillWidth:   true
                         }
                         FactComboBox {
                             fact:               QGroundControl.settingsManager.remoteIDSettings.classificationType
-                            visible:            _regionOperation == RemoteIDSettings.RegionOperation.EU
+                            visible:            _regionOperation == RemoteIDIndicatorPage.RegionOperation.EU
                             Layout.fillWidth:   true
                             sizeToContents:     true
                         }
 
                         QGCLabel {
                             text:               QGroundControl.settingsManager.remoteIDSettings.categoryEU.shortDescription
-                            visible:            (_classificationType == RemoteIDSettings.ClassificationType.EU) && (_regionOperation == RemoteIDSettings.RegionOperation.EU)
+                            visible:            (_classificationType == RemoteIDIndicatorPage.ClassificationType.EU) && (_regionOperation == RemoteIDIndicatorPage.RegionOperation.EU)
                             Layout.fillWidth:   true
                         }
                         FactComboBox {
                             fact:               QGroundControl.settingsManager.remoteIDSettings.categoryEU
-                            visible:            (_classificationType == RemoteIDSettings.ClassificationType.EU) && (_regionOperation == RemoteIDSettings.RegionOperation.EU)
+                            visible:            (_classificationType == RemoteIDIndicatorPage.ClassificationType.EU) && (_regionOperation == RemoteIDIndicatorPage.RegionOperation.EU)
                             Layout.fillWidth:   true
                             sizeToContents:     true
                         }
 
                         QGCLabel {
                             text:               QGroundControl.settingsManager.remoteIDSettings.classEU.shortDescription
-                            visible:            (_classificationType == RemoteIDSettings.ClassificationType.EU) && (_regionOperation == RemoteIDSettings.RegionOperation.EU)
+                            visible:            (_classificationType == RemoteIDIndicatorPage.ClassificationType.EU) && (_regionOperation == RemoteIDIndicatorPage.RegionOperation.EU)
                             Layout.fillWidth:   true
                         }
                         FactComboBox {
                             fact:               QGroundControl.settingsManager.remoteIDSettings.classEU
-                            visible:            (_classificationType == RemoteIDSettings.ClassificationType.EU) && (_regionOperation == RemoteIDSettings.RegionOperation.EU)
+                            visible:            (_classificationType == RemoteIDIndicatorPage.ClassificationType.EU) && (_regionOperation == RemoteIDIndicatorPage.RegionOperation.EU)
                             Layout.fillWidth:   true
                             sizeToContents:     true
                         }
@@ -475,7 +475,7 @@ Rectangle {
 
                             onActivated: (index) => {
                                 // FAA doesnt allow to set a Fixed position. Is either Live GNSS or Takeoff
-                                if (_regionOperation == RemoteIDSettings.RegionOperation.FAA) {
+                                if (_regionOperation == RemoteIDIndicatorPage.RegionOperation.FAA) {
                                     if (currentIndex != 1) {
                                        QGroundControl.settingsManager.remoteIDSettings.locationType.value = 1
                                         currentIndex = 1
@@ -496,33 +496,33 @@ Rectangle {
 
                         QGCLabel {
                             text:               qsTr("Latitude Fixed(-90 to 90)")
-                            visible:            _locationType == RemoteIDSettings.LocationType.FIXED
+                            visible:            _locationType == RemoteIDIndicatorPage.LocationType.FIXED
                             Layout.fillWidth:   true
                         }
                         FactTextField {
-                            visible:            _locationType == RemoteIDSettings.LocationType.FIXED
+                            visible:            _locationType == RemoteIDIndicatorPage.LocationType.FIXED
                             Layout.fillWidth:   true
                             fact:               QGroundControl.settingsManager.remoteIDSettings.latitudeFixed
                         }
 
                         QGCLabel {
                             text:               qsTr("Longitude Fixed(-180 to 180)")
-                            visible:            _locationType == RemoteIDSettings.LocationType.FIXED
+                            visible:            _locationType == RemoteIDIndicatorPage.LocationType.FIXED
                             Layout.fillWidth:   true
                         }
                         FactTextField {
-                            visible:            _locationType == RemoteIDSettings.LocationType.FIXED
+                            visible:            _locationType == RemoteIDIndicatorPage.LocationType.FIXED
                             Layout.fillWidth:   true
                             fact:               QGroundControl.settingsManager.remoteIDSettings.longitudeFixed
                         }
 
                         QGCLabel {
                             text:               qsTr("Altitude Fixed")
-                            visible:            _locationType == RemoteIDSettings.LocationType.FIXED
+                            visible:            _locationType == RemoteIDIndicatorPage.LocationType.FIXED
                             Layout.fillWidth:   true
                         }
                         FactTextField {
-                            visible:            _locationType == RemoteIDSettings.LocationType.FIXED
+                            visible:            _locationType == RemoteIDIndicatorPage.LocationType.FIXED
                             Layout.fillWidth:   true
                             fact:               QGroundControl.settingsManager.remoteIDSettings.altitudeFixed
                         }
@@ -530,58 +530,58 @@ Rectangle {
                         QGCLabel {
                             text:               qsTr("Latitude")
                             Layout.fillWidth:   true
-                            visible:            _locationType != RemoteIDSettings.LocationType.TAKEOFF
+                            visible:            _locationType != RemoteIDIndicatorPage.LocationType.TAKEOFF
                         }
                         QGCLabel {
                             text:               gcsPosition.isValid ? gcsPosition.latitude : "N/A"
                             Layout.fillWidth:   true
-                            visible:            _locationType != RemoteIDSettings.LocationType.TAKEOFF
+                            visible:            _locationType != RemoteIDIndicatorPage.LocationType.TAKEOFF
                         }
 
                         QGCLabel {
                             text:               qsTr("Longitude")
                             Layout.fillWidth:   true
-                            visible:            _locationType != RemoteIDSettings.LocationType.TAKEOFF
+                            visible:            _locationType != RemoteIDIndicatorPage.LocationType.TAKEOFF
                         }
                         QGCLabel {
                             text:               gcsPosition.isValid ? gcsPosition.longitude : "N/A"
                             Layout.fillWidth:   true
-                            visible:            _locationType != RemoteIDSettings.LocationType.TAKEOFF
+                            visible:            _locationType != RemoteIDIndicatorPage.LocationType.TAKEOFF
                         }
 
                         QGCLabel {
-                            text:               _regionOperation == RemoteIDSettings.RegionOperation.FAA ?
+                            text:               _regionOperation == RemoteIDIndicatorPage.RegionOperation.FAA ?
                                                 qsTr("Altitude") + qsTr(" (Mandatory)") :
                                                 qsTr("Altitude")
                             Layout.fillWidth:   true
-                            visible:            _locationType != RemoteIDSettings.LocationType.TAKEOFF
+                            visible:            _locationType != RemoteIDIndicatorPage.LocationType.TAKEOFF
                         }
                         QGCLabel {
                             text:               gcsPosition.isValid && !isNaN(gcsPosition.altitude) ? gcsPosition.altitude : "N/A"
                             Layout.fillWidth:   true
-                            visible:            _locationType != RemoteIDSettings.LocationType.TAKEOFF
+                            visible:            _locationType != RemoteIDIndicatorPage.LocationType.TAKEOFF
                         }
 
                         QGCLabel {
                             text:               qsTr("Heading")
                             Layout.fillWidth:   true
-                            visible:            _locationType != RemoteIDSettings.LocationType.TAKEOFF
+                            visible:            _locationType != RemoteIDIndicatorPage.LocationType.TAKEOFF
                         }
                         QGCLabel {
                             text:               gcsPosition.isValid && !isNaN(gcsHeading) ? gcsHeading : "N/A"
                             Layout.fillWidth:   true
-                            visible:            _locationType != RemoteIDSettings.LocationType.TAKEOFF
+                            visible:            _locationType != RemoteIDIndicatorPage.LocationType.TAKEOFF
                         }
 
                         QGCLabel {
                             text:               qsTr("Hor. Accuracy")
                             Layout.fillWidth:   true
-                            visible:            _locationType != RemoteIDSettings.LocationType.TAKEOFF
+                            visible:            _locationType != RemoteIDIndicatorPage.LocationType.TAKEOFF
                         }
                         QGCLabel {
                             text:               gcsPosition.isValid && gcsHDOP ? ( gcsHDOP + " m" ) : "N/A"
                             Layout.fillWidth:   true
-                            visible:            _locationType != RemoteIDSettings.LocationType.TAKEOFF
+                            visible:            _locationType != RemoteIDIndicatorPage.LocationType.TAKEOFF
                         }
                     }
 
@@ -590,7 +590,7 @@ Rectangle {
                         visible:                    !ScreenTools.isMobile
                                                     && QGroundControl.settingsManager.autoConnectSettings.autoConnectNmeaPort.visible
                                                     && QGroundControl.settingsManager.autoConnectSettings.autoConnectNmeaBaud.visible
-                                                    && _locationType != RemoteIDSettings.LocationType.TAKEOFF
+                                                    && _locationType != RemoteIDIndicatorPage.LocationType.TAKEOFF
                         anchors.margins:            _margins
                         anchors.top:                gpsGridData.bottom
                         anchors.horizontalCenter:   parent.horizontalCenter
@@ -770,7 +770,7 @@ Rectangle {
                     Layout.fillWidth:       true
 
                     border.width:   _borderWidth
-                    border.color:   (_regionOperation == RemoteIDSettings.RegionOperation.EU || QGroundControl.settingsManager.remoteIDSettings.sendOperatorID.value) ?
+                    border.color:   (_regionOperation == RemoteIDIndicatorPage.RegionOperation.EU || QGroundControl.settingsManager.remoteIDSettings.sendOperatorID.value) ?
                                     (_activeRID && !_activeVehicle.remoteIDManager.operatorIDGood ? qgcPal.colorRed : color) : color
 
                     GridLayout {
@@ -801,7 +801,7 @@ Rectangle {
                         }
 
                         QGCLabel {
-                            text:               _regionOperation == RemoteIDSettings.RegionOperation.FAA ?
+                            text:               _regionOperation == RemoteIDIndicatorPage.RegionOperation.FAA ?
                                                 QGroundControl.settingsManager.remoteIDSettings.operatorID.shortDescription :
                                                 QGroundControl.settingsManager.remoteIDSettings.operatorID.shortDescription + qsTr(" (Mandatory)")
                             visible:            QGroundControl.settingsManager.remoteIDSettings.operatorID.visible
@@ -833,14 +833,14 @@ Rectangle {
                         // Spacer
                         QGCLabel {
                             text:               ""
-                            visible:            _regionOperation == RemoteIDSettings.RegionOperation.EU
+                            visible:            _regionOperation == RemoteIDIndicatorPage.RegionOperation.EU
                             Layout.alignment:   Qt.AlignHCenter
                             Layout.fillWidth:   true
                         }
 
                         QGCLabel {
                             text:               QGroundControl.settingsManager.remoteIDSettings.operatorID.shortDescription + qsTr(QGroundControl.settingsManager.remoteIDSettings.operatorIDValid.rawValue == true ? " valid" : " invalid")
-                            visible:            _regionOperation == RemoteIDSettings.RegionOperation.EU
+                            visible:            _regionOperation == RemoteIDIndicatorPage.RegionOperation.EU
                             Layout.alignment:   Qt.AlignHCenter
                             Layout.fillWidth:   true
                         }
@@ -848,11 +848,11 @@ Rectangle {
                         QGCLabel {
                             text:               QGroundControl.settingsManager.remoteIDSettings.sendOperatorID.shortDescription
                             Layout.fillWidth:   true
-                            visible:            _regionOperation == RemoteIDSettings.RegionOperation.FAA
+                            visible:            _regionOperation == RemoteIDIndicatorPage.RegionOperation.FAA
                         }
                         FactCheckBox {
                             fact:       QGroundControl.settingsManager.remoteIDSettings.sendOperatorID
-                            visible:    _regionOperation == RemoteIDSettings.RegionOperation.FAA
+                            visible:    _regionOperation == RemoteIDIndicatorPage.RegionOperation.FAA
                             onClicked: {
                                 if (checked) {
                                     if (_activeVehicle) {

--- a/src/ui/toolbar/RemoteIDIndicatorPage.qml
+++ b/src/ui/toolbar/RemoteIDIndicatorPage.qml
@@ -19,7 +19,7 @@ import QGroundControl.FactSystem
 import QGroundControl.FactControls
 
 ToolIndicatorPage {
-    showExpand: false
+    showExpand: true
 
     property var    _activeVehicle:     QGroundControl.multiVehicleManager.activeVehicle
 
@@ -42,6 +42,17 @@ ToolIndicatorPage {
 
     enum RegionOperation {
         FAA,
+        EU
+    }
+
+    enum LocationType {
+        TAKEOFF,
+        LIVE,
+        FIXED
+    }
+
+    enum ClassificationType {
+        UNDEFINED,
         EU
     }
 
@@ -280,6 +291,303 @@ ToolIndicatorPage {
                                 _activeVehicle.remoteIDManager.setEmergency(!emergencyDeclared)
                             }
                         }
+                    }
+                }
+            }
+        }
+    }
+
+    expandedComponent: Component {
+        RowLayout {
+            spacing: ScreenTools.defaultFontPixelWidth
+
+            property var  remoteIDSettings:QGroundControl.settingsManager.remoteIDSettings
+            property Fact regionFact:           remoteIDSettings.region
+            property Fact sendOperatorIdFact:   remoteIDSettings.sendOperatorID
+            property Fact locationTypeFact:     remoteIDSettings.locationType
+            property bool isEURegion:           regionFact.rawValue == RemoteIDIndicatorPage.EU
+            property bool isFAARegion:          regionFact.rawValue == RemoteIDIndicatorPage.FAA
+            property real textFieldWidth:       ScreenTools.defaultFontPixelWidth * 24
+            property real textLabelWidth:       ScreenTools.defaultFontPixelWidth * 30
+
+            Connections {
+                target: regionFact
+                onRawValueChanged: {
+                    if (regionFact.rawValue === RemoteIDIndicatorPage.EU) {
+                        sendOperatorIdFact.rawValue = true
+                    }
+                    if (regionFact.rawValue === RemoteIDIndicatorPage.FAA) {
+                        locationTypeFact.value = RemoteIDIndicatorPage.LocationType.LIVE
+                    }
+                }
+            }
+
+            ColumnLayout {
+                spacing:            ScreenTools.defaultFontPixelHeight / 2
+                Layout.alignment:   Qt.AlignTop
+
+                SettingsGroupLayout {
+                    Layout.fillWidth:   true
+
+                    LabelledFactComboBox {
+                        label:              fact.shortDescription
+                        fact:               QGroundControl.settingsManager.remoteIDSettings.region
+                        visible:            QGroundControl.settingsManager.remoteIDSettings.region.visible
+                        Layout.fillWidth:   true
+                    }
+                }
+
+                SettingsGroupLayout {
+                    LabelledLabel {
+                        label:              qsTr("Arm Status Error")
+                        labelText:          remoteIDManager.armStatusError
+                        visible:            labelText !== ""
+                        Layout.fillWidth:   true
+                    }
+                }
+
+                SettingsGroupLayout {
+                    heading:                qsTr("Basic ID")
+                    headingDescription:     qsTr("If Basic ID is already set on the RID device, this will be registered as Basic ID 2")
+                    Layout.fillWidth:       true
+                    Layout.preferredWidth:  textLabelWidth
+
+                    FactCheckBoxSlider {
+                        id:                 sendBasicIDSlider
+                        text:               qsTr("Broadcast")
+                        fact:               _fact
+                        visible:            _fact.visible
+                        Layout.fillWidth:   true
+
+                        property Fact _fact: remoteIDSettings.sendBasicID
+                    }
+
+                    LabelledFactComboBox {
+                        id:                 basicIDTypeCombo
+                        label:              _fact.shortDescription
+                        fact:               _fact
+                        indexModel:         false
+                        visible:            _fact.visible
+                        enabled:            sendBasicIDSlider._fact.rawValue
+                        Layout.fillWidth:   true
+
+                        property Fact _fact: remoteIDSettings.basicIDType
+                    }
+
+                    LabelledFactComboBox {
+                        label:              _fact.shortDescription
+                        fact:               _fact
+                        indexModel:         false
+                        visible:            _fact.visible
+                        enabled:            sendBasicIDSlider._fact.rawValue
+                        Layout.fillWidth:   true
+
+                        property Fact _fact: remoteIDSettings.basicIDUaType
+                    }
+
+                    LabelledFactTextField {
+                        label:                      _fact.shortDescription
+                        fact:                       _fact
+                        visible:                    _fact.visible
+                        enabled:            sendBasicIDSlider._fact.rawValue
+                        textField.maximumLength:    20
+                        Layout.fillWidth:           true
+                        textFieldPreferredWidth:    textFieldWidth
+
+                        property Fact _fact: remoteIDSettings.basicID
+                    }
+                }
+
+                SettingsGroupLayout {
+                    heading:            qsTr("Operator ID")
+                    Layout.fillWidth:   true
+
+                    FactCheckBoxSlider {
+                        text:               qsTr("Broadcast%1").arg(isEURegion ? " (EU Required)" : "")
+                        fact:               sendOperatorIdFact
+                        visible:            sendOperatorIdFact.visible
+                        enabled:            isFAARegion
+                        Layout.fillWidth:   true
+
+                        property Fact _fact: remoteIDSettings.sendOperatorID
+                    }
+
+                    LabelledFactComboBox {
+                        id:                 regionOperationCombo
+                        label:              _fact.shortDescription
+                        fact:               _fact
+                        indexModel:         false
+                        visible:            _fact.visible && (_fact.enumValues.length > 1)
+                        Layout.fillWidth:   true
+
+                        property Fact _fact: remoteIDSettings.operatorIDType
+                    }
+
+                    LabelledFactTextField {
+                        id:                         operatorIDLabel
+                        label:                      _fact.shortDescription + (regionOperationCombo.visible ? "" :  qsTr(" (%1)").arg(regionOperationCombo.comboBox.currentText))
+                        fact:                       _fact
+                        visible:                    _fact.visible
+                        textField.maximumLength:    20
+                        textField.inputMask:        ">AAA999999999999<N\-NNN"
+                        Layout.fillWidth:           true
+                        textFieldPreferredWidth:    textFieldWidth
+
+                        property Fact _fact: remoteIDSettings.operatorID
+                    }
+                }
+
+                SettingsGroupLayout {
+                    heading:                qsTr("Self ID")
+                    headingDescription:     qsTr("If an emergency is declared, Emergency Text will be broadcast even if Broadcast setting is not enabled.")
+                    Layout.fillWidth:       true
+                    Layout.preferredWidth:  textLabelWidth
+
+                    FactCheckBoxSlider {
+                        id:                 sendSelfIDSlider
+                        text:               qsTr("Broadcast")
+                        fact:               _fact
+                        visible:            _fact.visible
+                        Layout.fillWidth:   true
+
+                        property Fact _fact: remoteIDSettings.sendSelfID
+                    }
+
+                    LabelledFactComboBox {
+                        id:                 selfIDTypeCombo
+                        label:              qsTr("Broadcast Message")
+                        fact:               _fact
+                        indexModel:         false
+                        visible:            _fact.visible
+                        enabled:            sendSelfIDSlider._fact.rawValue
+                        Layout.fillWidth:   true
+
+                        property Fact _fact: remoteIDSettings.selfIDType
+                    }
+
+                    LabelledFactTextField {
+                        label:                      _fact.shortDescription
+                        fact:                       _fact
+                        visible:                    _fact.visible
+                        enabled:                     sendSelfIDSlider._fact.rawValue
+                        textField.maximumLength:    23
+                        Layout.fillWidth:           true
+                        textFieldPreferredWidth:    textFieldWidth
+
+                        property Fact _fact: remoteIDSettings.selfIDFree
+                    }
+
+                    LabelledFactTextField {
+                        label:                      _fact.shortDescription
+                        fact:                       _fact
+                        visible:                    _fact.visible
+                        enabled:                    sendSelfIDSlider._fact.rawValue
+                        textField.maximumLength:    23
+                        Layout.fillWidth:           true
+                        textFieldPreferredWidth:    textFieldWidth
+
+                        property Fact _fact: remoteIDSettings.selfIDExtended
+                    }
+
+                    LabelledFactTextField {
+                        label:                      _fact.shortDescription
+                        fact:                       _fact
+                        visible:                    _fact.visible
+                        textField.maximumLength:    23
+                        Layout.fillWidth:           true
+                        textFieldPreferredWidth:    textFieldWidth
+
+                        property Fact _fact: remoteIDSettings.selfIDEmergency
+                    }
+                }
+            }
+
+            ColumnLayout {
+                spacing:            ScreenTools.defaultFontPixelHeight / 2
+                Layout.alignment:   Qt.AlignTop
+
+                SettingsGroupLayout {
+                    heading:            qsTr("GroundStation Location")
+                    Layout.fillWidth:   true
+
+                    LabelledFactComboBox {
+                        label:              locationTypeFact.shortDescription
+                        fact:               locationTypeFact
+                        indexModel:         false
+                        Layout.fillWidth:   true
+                    }
+
+                    LabelledFactTextField {
+                        label:                      _fact.shortDescription
+                        fact:                       _fact
+                        textField.maximumLength:    20
+                        enabled:                    locationTypeFact.rawValue === RemoteIDIndicatorPage.LocationType.FIXED
+                        Layout.fillWidth:           true
+                        textFieldPreferredWidth:    textFieldWidth
+
+                        property Fact _fact: remoteIDSettings.latitudeFixed
+                    }
+
+                    LabelledFactTextField {
+                        label:                      _fact.shortDescription
+                        fact:                       _fact
+                        textField.maximumLength:    20
+                        enabled:                    locationTypeFact.rawValue === RemoteIDIndicatorPage.LocationType.FIXED
+                        Layout.fillWidth:           true
+                        textFieldPreferredWidth:    textFieldWidth
+
+                        property Fact _fact: remoteIDSettings.longitudeFixed
+                    }
+
+                    LabelledFactTextField {
+                        label:                      _fact.shortDescription
+                        fact:                       _fact
+                        textField.maximumLength:    20
+                        enabled:                    locationTypeFact.rawValue === RemoteIDIndicatorPage.LocationType.FIXED
+                        Layout.fillWidth:           true
+                        textFieldPreferredWidth:    textFieldWidth
+
+                        property Fact _fact: remoteIDSettings.altitudeFixed
+                    }
+                }
+
+                SettingsGroupLayout {
+                    heading:            qsTr("EU Vehicle Info")
+                    visible:            isEURegion
+                    Layout.fillWidth:   true
+
+                    QGCCheckBoxSlider {
+                        id:                 euProvideInfoSlider
+                        text:               qsTr("Provide Information")
+                        checked:            _fact.rawValue === RemoteIDIndicatorPage.ClassificationType.EU
+                        visible:            _fact.visible
+                        Layout.fillWidth:   true
+                        onClicked:          _fact.rawValue = !_fact.rawValue
+
+                        property Fact _fact: remoteIDSettings.classificationType
+                    }
+
+                    LabelledFactComboBox {
+                        id:                 euCategoryCombo
+                        label:              _fact.shortDescription
+                        fact:               _fact
+                        indexModel:         false
+                        visible:            _fact.visible
+                        enabled:            euProvideInfoSlider.checked
+                        Layout.fillWidth:   true
+
+                        property Fact _fact: remoteIDSettings.categoryEU
+                    }
+
+                    LabelledFactComboBox {
+                        label:              _fact.shortDescription
+                        fact:               _fact
+                        indexModel:         false
+                        visible:            _fact.visible
+                        enabled:            euCategoryCombo.enabled
+                        Layout.fillWidth:   true
+
+                        property Fact _fact: remoteIDSettings.classEU
                     }
                 }
             }


### PR DESCRIPTION
This is a major rework of the Remote ID SettingsUI to fit the new UI style. Currently it is available from the expanded page of the Remote ID toolbar indicator. I have left the Remote ID Settings page in App Settings alone for now. It works but is still missing things like correct validation. 

The goal was also to try a little bit to make this more usable to someone (like me) who doesn't understand all the gory details of Remote ID. At this point you can consider this still be a major WIP part of my changes.

<img width="900" alt="Screenshot 2024-03-10 at 10 41 58 AM" src="https://github.com/mavlink/qgroundcontrol/assets/5876851/1b04c9dc-256a-4424-8cdb-b1cf32b729fb">
