### PR TITLE
[Draft] On Emergency Button hit, send MAV_CMD_ODID_SET_EMERGENCY

### DIFF
--- a/src/Vehicle/RemoteIDManager.cc
+++ b/src/Vehicle/RemoteIDManager.cc
@@ -485,6 +485,20 @@ void RemoteIDManager::setEmergency(bool declare)
 {
     _emergencyDeclared = declare;
     emit emergencyDeclaredChanged();
+
+    // We send a MAV Command to the vehicle to start or stop the emergency
+    _vehicle->sendMavCommand(
+        _vehicle->compId(),        // Target component
+        static_cast<MAV_CMD>(12900),  // MAV_CMD_ODID_SET_EMERGENCY - Called from number because from development.xml
+        true,                     // ShowError
+        _emergencyDeclared ? 1 : 0,
+        0,
+        0,
+        0,
+        0,
+        0,
+        0);
+
     // Wether we are starting an emergency or cancelling it, we need to enforce sending
     // this message. Otherwise, if non optimal connection quality, vehicle RID device
     // could remain in the wrong state. It is clarified to the user in remoteidsettings.qml


### PR DESCRIPTION
<!--- Title -->

On Emergency button hit, sends the new MAV_CMD_ODID_SET_EMERGENCY command which was pushed to upstream MAVLink here: https://github.com/mavlink/mavlink/pull/2086

Discussions about it are here: https://github.com/mavlink/mavlink/wiki/20240228-Dev-Meeting 
and here: https://github.com/mavlink/mavlink/pull/2027#top
-----------
<!--- Describe your changes in detail. -->

Sends the new MAVLink command MAV_CMD_ODID_SET_EMERGENCY when the emergency button is activated. 

**NOTE:** This is currently a draft because the MAVLink library on QGC needs to be updated to allow for this message to be sent. 

Test Steps
-----------
1. Ensure successfully builds and runs
2. Flash PX4 firmware which has support of this message (I will also create a draft PR for that, but MAVLink also needs to be updated on PX4)
3. Plug in remote id module with flight controller.
4. Ensure remote ID module is detected on QGC
5. Install a drone scanning app to view the status of the drone
6. Hold the emergency button and see if the status goes to emergency

Checklist:
----------
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [ ] [Review Contribution Guidelines](https://github.com/mavlink/qgroundcontrol/blob/master/.github/CONTRIBUTING.md).
- [ ] [Review Code of Conduct](https://github.com/mavlink/qgroundcontrol/blob/master/.github/CODE_OF_CONDUCT.md).
- [ ] I have tested my changes.

Related Issue
-----------
<!-- If any, please provide issue ID. -->


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.