### PR TITLE
Shapelib: Fetch through Cmake

### DIFF
--- a/.github/workflows/android_debug.yml
+++ b/.github/workflows/android_debug.yml
@@ -136,7 +136,6 @@ jobs:
               -DCMAKE_BUILD_TYPE=Debug \
               -DANDROID_ABI=${{ matrix.eabi }} \
               -DANDROID_PLATFORM=android-23 \
-              -DBUILD_TESTING:BOOL=OFF \
               -DQT_HOST_PATH:PATH=${QT_ROOT_DIR}/../gcc_64 \
               -DQT_DEBUG_FIND_PACKAGE=ON
             cmake --build ${{ runner.temp }}/shadow_build_dir/ --target all

--- a/libs/CMakeLists.txt
+++ b/libs/CMakeLists.txt
@@ -6,7 +6,6 @@ add_subdirectory(zlib)
 add_subdirectory(qmlglsink)
 
 set(BUILD_SHARED_LIBS OFF CACHE BOOL "Force qmdnsengine & shapelib to build as static" FORCE)
-add_subdirectory(shapelib)
 add_subdirectory(qmdnsengine)
 
 qt_add_library(xz STATIC

--- a/src/Utilities/CMakeLists.txt
+++ b/src/Utilities/CMakeLists.txt
@@ -29,6 +29,18 @@ if(MOBILE)
 	)
 endif()
 
+set(BUILD_SHAPELIB_CONTRIB OFF CACHE INTERNAL "")
+set(BUILD_SHARED_LIBS OFF CACHE INTERNAL "")
+set(BUILD_TESTING OFF CACHE INTERNAL "")
+
+include(FetchContent)
+FetchContent_Declare(shapelib
+	GIT_REPOSITORY https://github.com/OSGeo/shapelib.git
+	GIT_TAG v1.6.0
+    GIT_SHALLOW TRUE
+)
+FetchContent_MakeAvailable(shapelib)
+
 target_link_libraries(Utilities
 	PRIVATE
 		Qt6::Qml


### PR DESCRIPTION
This collects shapelib through fetchcontent in cmake, so that the submodule can be removed when qmake goes. They have done some cleanup to their cmake implementation since 1.5.0 but most of it seems to be coming after 1.6.0.