### PR TITLE
Qmdnsengine: Fetch Through Cmake

### DIFF
--- a/libs/CMakeLists.txt
+++ b/libs/CMakeLists.txt
@@ -3,9 +3,6 @@ add_subdirectory(qtandroidserialport)
 add_subdirectory(sdl2)
 add_subdirectory(qmlglsink)
 
-set(BUILD_SHARED_LIBS OFF CACHE BOOL "Force qmdnsengine & shapelib to build as static" FORCE)
-add_subdirectory(qmdnsengine)
-
 qt_add_library(xz STATIC
     xz-embedded/linux/include/linux/xz.h
     xz-embedded/linux/include/linux/decompress/unxz.h

--- a/src/comm/CMakeLists.txt
+++ b/src/comm/CMakeLists.txt
@@ -59,8 +59,20 @@ endif()
 
 option(QGC_ZEROCONF_ENABLED "Enable ZeroConf Compatibility" OFF)
 if(QGC_ZEROCONF_ENABLED)
+	set(BUILD_SHARED_LIBS OFF CACHE INTERNAL "")
+	set(BUILD_DOC OFF CACHE INTERNAL "")
+	set(BUILD_EXAMPLES OFF CACHE INTERNAL "")
+	set(BUILD_TESTS OFF CACHE INTERNAL "")
+
+	include(FetchContent)
+	FetchContent_Declare(
+        qmdnsengine
+		GIT_REPOSITORY https://github.com/nitroshare/qmdnsengine.git
+		GIT_TAG d61e497
+	)
+	FetchContent_MakeAvailable(qmdnsengine)
+
 	target_link_libraries(comm PRIVATE qmdnsengine)
-	target_include_directories(comm PRIVATE ${CMAKE_SOURCE_DIR}/libs)
 endif()
 
 target_compile_definitions(comm PUBLIC QGC_ENABLE_BLUETOOTH)


### PR DESCRIPTION
This collects the qmdnsengine library through cmake instead of using the submodule. When qmake goes, the submodule can go.