### PR TITLE
Zlib: Fetch through Cmake

### DIFF
--- a/libs/CMakeLists.txt
+++ b/libs/CMakeLists.txt
@@ -2,7 +2,6 @@ add_subdirectory(libevents)
 add_subdirectory(OpenSSL)
 add_subdirectory(qtandroidserialport)
 add_subdirectory(sdl2)
-add_subdirectory(zlib)
 add_subdirectory(qmlglsink)
 
 set(BUILD_SHARED_LIBS OFF CACHE BOOL "Force qmdnsengine & shapelib to build as static" FORCE)

--- a/libs/zlib/CMakeLists.txt
+++ b/libs/zlib/CMakeLists.txt
@@ -1,9 +1,0 @@
-qt_add_library(zlib STATIC)
-
-if(WIN32)
-	target_link_libraries(zlib PUBLIC ${CMAKE_CURRENT_SOURCE_DIR}/windows/lib/zlibstatic.lib)
-	target_include_directories(zlib PUBLIC ${CMAKE_CURRENT_SOURCE_DIR}/windows/include)
-else()
-	find_package(ZLIB)
-	target_link_libraries(zlib PUBLIC ZLIB::ZLIB)
-endif()

--- a/src/Compression/CMakeLists.txt
+++ b/src/Compression/CMakeLists.txt
@@ -7,6 +7,17 @@ qt_add_library(compression STATIC
 	QGCZlib.h
 )
 
+set(ZLIB_BUILD_EXAMPLES OFF CACHE INTERNAL "")
+set(BUILD_SHARED_LIBS OFF CACHE INTERNAL "")
+
+include(FetchContent)
+FetchContent_Declare(zlib
+	GIT_REPOSITORY https://github.com/madler/zlib.git
+	GIT_TAG v1.3.1
+	GIT_SHALLOW TRUE
+)
+FetchContent_MakeAvailable(zlib)
+
 target_link_libraries(compression
 	PRIVATE
         zlib


### PR DESCRIPTION
Fetch zlib through cmake and build. This ensures all platforms are on the same version. When qmake goes, the windows zlib can be removed from the libs folder.