### PR TITLE
Openssl: Fetch through cmake

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -216,6 +216,12 @@ elseif(IOS)
 elseif(WIN32)
     set_target_properties(${PROJECT_NAME} PROPERTIES WIN32_EXECUTABLE TRUE)
 elseif(ANDROID)
+    FetchContent_Declare(android_openssl
+        DOWNLOAD_EXTRACT_TIMESTAMP true
+        URL https://github.com/KDAB/android_openssl/archive/refs/heads/master.zip
+    )
+    FetchContent_MakeAvailable(android_openssl)
+    include(${android_openssl_SOURCE_DIR}/android_openssl.cmake)
     add_android_openssl_libraries(${PROJECT_NAME})
 
     set_target_properties(${PROJECT_NAME}

--- a/libs/CMakeLists.txt
+++ b/libs/CMakeLists.txt
@@ -1,5 +1,4 @@
 add_subdirectory(libevents)
-add_subdirectory(OpenSSL)
 add_subdirectory(qtandroidserialport)
 add_subdirectory(sdl2)
 add_subdirectory(zlib)

--- a/libs/OpenSSL/CMakeLists.txt
+++ b/libs/OpenSSL/CMakeLists.txt
@@ -1,3 +1,0 @@
-if(ANDROID)
-    include(android_openssl/android_openssl.cmake)
-endif()


### PR DESCRIPTION
Fetch Android Openssl through cmake, When qmake goes, libs/OpenSSL/android_openssl can go.