### PR TITLE
Pinch Zoom Fix

### DIFF
--- a/src/FlightMap/FlightMap.qml
+++ b/src/FlightMap/FlightMap.qml
@@ -147,42 +147,18 @@ Map {
         property:           "zoomLevel"
     }
 
-    MouseArea {
-        anchors.fill:       parent
-        acceptedButtons:    Qt.LeftButton
+    DragHandler {
+        target: null
 
-        property real startMouseX: 0
-        property real startMouseY: 0
-        property real lastMouseX: 0
-        property real lastMouseY: 0
-
-        onClicked: (mouse) => {
-            var deltaX = Math.abs(startMouseX - lastMouseX)
-            var deltaY = Math.abs(startMouseY - lastMouseY)
-            if (deltaX < 5 && deltaY < 5) {
-                mapClicked(mouse)
+        onActiveChanged: {
+            if (active) {
+                mapPanStart()
+            } else {
+                mapPanStop()
             }
         }
 
-        onPressed: (mouse) => {
-            lastMouseX = Math.round(mouse.x)
-            lastMouseY = Math.round(mouse.y)
-            startMouseX = lastMouseX
-            startMouseY = lastMouseY
-            mapPanStart()
-        }
-
-        onPositionChanged: (mouse) => { 
-            var newMouseX = Math.round(mouse.x)
-            var newMouseY = Math.round(mouse.y)
-            _map.pan(lastMouseX - newMouseX, lastMouseY - newMouseY)     
-            lastMouseX = newMouseX
-            lastMouseY = newMouseY
-        }
-
-        onReleased: {
-            mapPanStop()
-        }
+        onActiveTranslationChanged: (delta) => _map.pan(-delta.x, -delta.y)
     }
 
     TapHandler {

--- a/src/ui/MainRootWindow.qml
+++ b/src/ui/MainRootWindow.qml
@@ -118,10 +118,12 @@ ApplicationWindow {
     }
 
     function showPlanView() {
+        flyView.visible = false
         planView.visible = true
     }
 
     function showFlyView() {
+        flyView.visible = true
         planView.visible = false
     }
 

--- a/src/ui/MainRootWindow.qml
+++ b/src/ui/MainRootWindow.qml
@@ -246,12 +246,14 @@ ApplicationWindow {
     FlyView { 
         id:                     flyView
         anchors.fill:           parent
+        enabled:                !toolDrawer.visible //The DragHandler in FlightMap.qml needs to be disabled when the toolDrawer is open, otherwise touch signals bleed through the pages
         utmspSendActTrigger:    _utmspSendActTrigger
     }
 
     PlanView {
         id:             planView
         anchors.fill:   parent
+        enabled:                !toolDrawer.visible //The DragHandler in FlightMap.qml needs to be disabled when the toolDrawer is open, otherwise touch signals bleed through the pages
         visible:        false
 
         onActivationParamsSent:{


### PR DESCRIPTION
The MouseArea fix was dominating the PinchHandler. Figured we should stick to the QML intended implementation of the Map and just disable the views if the tool drawer is open