### PR TITLE
Do Not Merge: Check Compatibility with Newest Qt Version

### DIFF
--- a/.github/workflows/android.yml
+++ b/.github/workflows/android.yml
@@ -35,7 +35,7 @@ jobs:
 
     env:
       ARTIFACT: QGroundControl.apk
-      QT_VERSION: 6.6.3
+      QT_VERSION: 6.*.*
       QT_ANDROID_KEYSTORE_PATH: ${{ github.workspace }}/deploy/android/android_release.keystore
       QT_ANDROID_KEYSTORE_ALIAS: QGCAndroidKeyStore
       QT_ANDROID_KEYSTORE_STORE_PASS: ${{ secrets.ANDROID_KEYSTORE_PASSWORD }}

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -31,7 +31,7 @@ jobs:
 
     env:
       ARTIFACT: QGroundControl-x86_64.AppImage
-      QT_VERSION: 6.6.3
+      QT_VERSION: 6.*.*
 
     defaults:
       run:

--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -35,7 +35,7 @@ jobs:
 
     env:
       ARTIFACT: QGroundControl.dmg
-      QT_VERSION: 6.6.3
+      QT_VERSION: 6.*.*
       GST_VERSION: 1.22.11
 
     steps:

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -34,7 +34,7 @@ jobs:
         shell: cmd
 
     env:
-      QT_VERSION: 6.6.3
+      QT_VERSION: 6.*.*
       GST_VERSION: 1.22.11
       ARTIFACT: QGroundControl-Installer.exe
 

--- a/cmake/Qt6QGCConfiguration.cmake
+++ b/cmake/Qt6QGCConfiguration.cmake
@@ -6,7 +6,7 @@ if(NOT QT_VERSION)
 	# if QT version not specified then use any available version
 	file(GLOB FOUND_QT_VERSIONS
 		LIST_DIRECTORIES true
-		$ENV{HOME}/Qt/6.6.*
+		$ENV{HOME}/Qt/6.*.*
 	)
 	if(NOT FOUND_QT_VERSIONS)
 		return()

--- a/qgroundcontrol.pro
+++ b/qgroundcontrol.pro
@@ -19,11 +19,11 @@ exists($${OUT_PWD}/qgroundcontrol.pro) {
 
 message(Qt version $$[QT_VERSION])
 
-!contains(CONFIG, DISABLE_QT_VERSION_CHECK) {
-    !equals(QT_MAJOR_VERSION, 6) | !equals(QT_MINOR_VERSION, 6) {
-        error("Unsupported Qt version, 6.6 is required. Found $$QT_MAJOR_VERSION.$$QT_MINOR_VERSION")
-    }
-}
+#!contains(CONFIG, DISABLE_QT_VERSION_CHECK) {
+#    !equals(QT_MAJOR_VERSION, 6) | !equals(QT_MINOR_VERSION, 6) {
+#        error("Unsupported Qt version, 6.6 is required. Found $$QT_MAJOR_VERSION.$$QT_MINOR_VERSION")
+#    }
+#}
 
 include(QGCCommon.pri)
 


### PR DESCRIPTION
This draft will just exist to check building with newest Qt version and find future incompatibilities. Should be rerun whenever a new Qt Version is out.