### PR TITLE
QGCButton: Put back missing implicitWidth/Height

### DIFF
--- a/src/QmlControls/QGCButton.qml
+++ b/src/QmlControls/QGCButton.qml
@@ -39,6 +39,8 @@ Button {
     background: Rectangle {
         id:             backRect
         radius:         backRadius
+        implicitWidth:  ScreenTools.implicitButtonWidth
+        implicitHeight: ScreenTools.implicitButtonHeight
         border.width:   showBorder ? 1 : 0
         border.color:   qgcPal.buttonBorder
         color:          _showHighlight ? qgcPal.buttonHighlight : (primary ? qgcPal.primaryButton : qgcPal.button)


### PR DESCRIPTION
I screwed this up in my previous pull to fix icons on buttons. Change is subtle but important on small touch screen targets.

Before:
<img width="322" alt="Screenshot 2024-03-14 at 12 32 06 PM" src="https://github.com/mavlink/qgroundcontrol/assets/5876851/881d835a-8805-4b6c-935e-a8027d272deb">

After:
<img width="329" alt="Screenshot 2024-03-14 at 12 32 53 PM" src="https://github.com/mavlink/qgroundcontrol/assets/5876851/3110feda-b0d0-41c2-8b00-656243ec23db">
