### PR TITLE
Fix flight map DragHandler signal bleeding through the pages

### DIFF
--- a/src/FlightMap/FlightMap.qml
+++ b/src/FlightMap/FlightMap.qml
@@ -149,6 +149,7 @@ Map {
 
     DragHandler {
         target: null
+        grabPermissions: PointerHandler.TakeOverForbidden
 
         onActiveChanged: {
             if (active) {

--- a/src/ui/MainRootWindow.qml
+++ b/src/ui/MainRootWindow.qml
@@ -246,14 +246,12 @@ ApplicationWindow {
     FlyView { 
         id:                     flyView
         anchors.fill:           parent
-        enabled:                !toolDrawer.visible //The DragHandler in FlightMap.qml needs to be disabled when the toolDrawer is open, otherwise touch signals bleed through the pages
         utmspSendActTrigger:    _utmspSendActTrigger
     }
 
     PlanView {
         id:             planView
         anchors.fill:   parent
-        enabled:                !toolDrawer.visible //The DragHandler in FlightMap.qml needs to be disabled when the toolDrawer is open, otherwise touch signals bleed through the pages
         visible:        false
 
         onActivationParamsSent:{


### PR DESCRIPTION
In the previous version, touch signals would undesirably propagate through the pages due to the DragHandler in FlightMap.qml not being correctly disabled when the toolDrawer was open. This update resolves this issue by adjusting the 'grabPermissions' setting and removing the flawed disabling of FlyView and PlanView that was previously based on the toolDrawer's visibility.