### PR TITLE
Remove Qt5 Compatibility Module

### DIFF
--- a/.github/workflows/android_debug.yml
+++ b/.github/workflows/android_debug.yml
@@ -101,7 +101,7 @@ jobs:
           arch:         ${{ matrix.arch }}
           dir:          ${{ runner.temp }}
           extra:        --autodesktop
-          modules:      qtcharts qtlocation qtpositioning qtspeech qt5compat qtmultimedia qtserialport qtimageformats qtshadertools qtconnectivity qtquick3d
+          modules:      qtcharts qtlocation qtpositioning qtspeech qtmultimedia qtserialport qtimageformats qtshadertools qtconnectivity qtquick3d
           cache:        true
 
       - name: Remove Android SDKs to force usage of android-33 only

--- a/.github/workflows/android_release.yml
+++ b/.github/workflows/android_release.yml
@@ -75,7 +75,7 @@ jobs:
           arch:         ${{ matrix.arch }}
           extra:        --autodesktop
           dir:          ${{ runner.temp }}
-          modules:      qtcharts qtlocation qtpositioning qtspeech qt5compat qtmultimedia qtserialport qtimageformats qtshadertools qtconnectivity qtquick3d
+          modules:      qtcharts qtlocation qtpositioning qtspeech qtmultimedia qtserialport qtimageformats qtshadertools qtconnectivity qtquick3d
           setup-python: true
           cache: true
 

--- a/.github/workflows/linux_debug.yml
+++ b/.github/workflows/linux_debug.yml
@@ -56,7 +56,7 @@ jobs:
           host:         linux
           target:       desktop
           dir:          ${{ runner.temp }}
-          modules:      qtcharts qtlocation qtpositioning qtspeech qt5compat qtmultimedia qtserialport qtimageformats qtshadertools qtconnectivity qtquick3d
+          modules:      qtcharts qtlocation qtpositioning qtspeech qtmultimedia qtserialport qtimageformats qtshadertools qtconnectivity qtquick3d
           setup-python: true
           cache: true
 

--- a/.github/workflows/linux_release.yml
+++ b/.github/workflows/linux_release.yml
@@ -60,7 +60,7 @@ jobs:
           host:         linux
           target:       desktop
           dir:          ${{ runner.temp }}
-          modules:      qtcharts qtlocation qtpositioning qtspeech qt5compat qtmultimedia qtserialport qtimageformats qtshadertools qtconnectivity qtquick3d
+          modules:      qtcharts qtlocation qtpositioning qtspeech qtmultimedia qtserialport qtimageformats qtshadertools qtconnectivity qtquick3d
           setup-python: true
           cache: true
 

--- a/.github/workflows/macos_debug.yml
+++ b/.github/workflows/macos_debug.yml
@@ -57,7 +57,7 @@ jobs:
           host:         mac
           target:       desktop
           dir:          ${{ runner.temp }}
-          modules:      qtcharts qtlocation qtpositioning qtspeech qt5compat qtmultimedia qtserialport qtimageformats qtshadertools qtconnectivity qtquick3d
+          modules:      qtcharts qtlocation qtpositioning qtspeech qtmultimedia qtserialport qtimageformats qtshadertools qtconnectivity qtquick3d
           setup-python: false
           cache: true
 

--- a/.github/workflows/macos_release.yml
+++ b/.github/workflows/macos_release.yml
@@ -58,7 +58,7 @@ jobs:
           host:         mac
           target:       desktop
           dir:          ${{ runner.temp }}
-          modules:      qtcharts qtlocation qtpositioning qtspeech qt5compat qtmultimedia qtserialport qtimageformats qtshadertools qtconnectivity qtquick3d
+          modules:      qtcharts qtlocation qtpositioning qtspeech qtmultimedia qtserialport qtimageformats qtshadertools qtconnectivity qtquick3d
           setup-python: false
           cache: true
 

--- a/.github/workflows/windows_debug.yml
+++ b/.github/workflows/windows_debug.yml
@@ -59,7 +59,7 @@ jobs:
           target:       desktop
           arch:         win64_msvc2019_64
           dir:          ${{ runner.temp }}
-          modules:      qtcharts qtlocation qtpositioning qtspeech qt5compat qtmultimedia qtserialport qtimageformats qtshadertools qtconnectivity qtquick3d
+          modules:      qtcharts qtlocation qtpositioning qtspeech qtmultimedia qtserialport qtimageformats qtshadertools qtconnectivity qtquick3d
           setup-python: true
           cache:        true
 

--- a/.github/workflows/windows_release.yml
+++ b/.github/workflows/windows_release.yml
@@ -60,7 +60,7 @@ jobs:
           target:       desktop
           arch:         win64_msvc2019_64
           dir:          ${{ runner.temp }}
-          modules:      qtcharts qtlocation qtpositioning qtspeech qt5compat qtmultimedia qtserialport qtimageformats qtshadertools qtconnectivity qtquick3d
+          modules:      qtcharts qtlocation qtpositioning qtspeech qtmultimedia qtserialport qtimageformats qtshadertools qtconnectivity qtquick3d
           setup-python: false
           cache: true
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -67,7 +67,6 @@ find_package(Qt6
         Charts
         Concurrent
         Core
-        Core5Compat
         Location
         Multimedia
         Network

--- a/QGCPostLinkCommon.pri
+++ b/QGCPostLinkCommon.pri
@@ -95,7 +95,6 @@ LinuxBuild {
         libQt6QmlWorkerScript.so.6 \
         libQt6QuickShapes.so.6 \
         libQt6XcbQpa.so.6 \
-        libQt6Core5Compat.so.6 \
         libQt6Network.so.6 \ 
         libQt6QmlXmlListModel.so.6 \
         libQt6Quick.so.6 \

--- a/deploy/docker/Dockerfile-build-linux
+++ b/deploy/docker/Dockerfile-build-linux
@@ -6,7 +6,7 @@ FROM ubuntu:20.04
 LABEL authors="Daniel Agar <daniel@agar.ca>, Patrick José Pereira <patrickelectric@gmail.com>"
 
 ARG QT_VERSION=6.6.1
-ARG QT_MODULES="qtlocation qtpositioning qtspeech qt5compat qtquick3d qtmultimedia qtserialport qtcharts qtshadertools"
+ARG QT_MODULES="qtlocation qtpositioning qtspeech qtquick3d qtmultimedia qtserialport qtcharts qtshadertools"
 
 ENV DEBIAN_FRONTEND noninteractive
 

--- a/qgroundcontrol.pro
+++ b/qgroundcontrol.pro
@@ -257,7 +257,6 @@ QT += \
     xml \
     texttospeech \
     core-private \
-    core5compat \
     quick3d
 
 # Multimedia only used if QVC is enabled

--- a/src/AutoPilotPlugins/APM/APMSafetyComponent.qml
+++ b/src/AutoPilotPlugins/APM/APMSafetyComponent.qml
@@ -10,7 +10,6 @@
 import QtQuick
 import QtQuick.Controls
 import QtQuick.Layouts
-import Qt5Compat.GraphicalEffects
 
 import QGroundControl.FactSystem
 import QGroundControl.FactControls
@@ -551,25 +550,19 @@ SetupPage {
                         height: landSpeedField.y + landSpeedField.height + _margins
                         color:  ggcPal.windowShade
 
-                        Image {
+                        QGCColoredImage {
                             id:                 icon
+                            visible:            _showIcon
                             anchors.margins:    _margins
                             anchors.left:       parent.left
                             anchors.top:        parent.top
                             height:             ScreenTools.defaultFontPixelWidth * 20
                             width:              ScreenTools.defaultFontPixelWidth * 20
+                            color:              ggcPal.text
                             sourceSize.width:   width
                             mipmap:             true
                             fillMode:           Image.PreserveAspectFit
-                            visible:            false
                             source:             "/qmlimages/ReturnToHomeAltitude.svg"
-                        }
-
-                        ColorOverlay {
-                            anchors.fill:   icon
-                            source:         icon
-                            color:          ggcPal.text
-                            visible:        _showIcon
                         }
 
                         QGCRadioButton {

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -52,7 +52,6 @@ target_link_libraries(qgc
 		Qt6::QuickControls2
 		Qt6::QuickWidgets
 		Qt6::Widgets
-		Qt6::Core5Compat
 
 		ADSB
 		AirLink

--- a/src/FlightMap/MapItems/VehicleMapItem.qml
+++ b/src/FlightMap/MapItems/VehicleMapItem.qml
@@ -8,9 +8,9 @@
  ****************************************************************************/
 
 import QtQuick
+import QtQuick.Effects
 import QtLocation
 import QtPositioning
-import Qt5Compat.GraphicalEffects
 
 import QGroundControl
 import QGroundControl.ScreenTools
@@ -44,23 +44,19 @@ MapQuickItem {
         height:     vehicleIcon.height
         opacity:    _adsbVehicle || vehicle === _activeVehicle ? 1.0 : 0.5
 
-        Rectangle {
-            id:                 vehicleShadow
-            anchors.fill:       vehicleIcon
-            color:              Qt.rgba(1,1,1,1)
-            radius:             width * 0.5
-            visible:            false
+        MultiEffect {
+            source: vehicleIcon
+            shadowEnabled: vehicleIcon.visible && _adsbVehicle
+            shadowColor: Qt.rgba(0.94,0.91,0,1.0)
+            shadowVerticalOffset: 4
+            shadowHorizontalOffset: 4
+            shadowBlur: 1.0
+            shadowOpacity: 0.5
+            shadowScale: 1.3
+            blurMax: 32
+            blurMultiplier: .1
         }
-        DropShadow {
-            anchors.fill:       vehicleShadow
-            visible:            vehicleIcon.visible && _adsbVehicle
-            horizontalOffset:   4
-            verticalOffset:     4
-            radius:             32.0
-            samples:            65
-            color:              Qt.rgba(0.94,0.91,0,0.5)
-            source:             vehicleShadow
-        }
+
         Image {
             id:                 vehicleIcon
             source:             _adsbVehicle ? (alert ? "/qmlimages/AlertAircraft.svg" : "/qmlimages/AwarenessAircraft.svg") : vehicle.vehicleImageOpaque

--- a/src/FlightMap/Widgets/QGCAttitudeWidget.qml
+++ b/src/FlightMap/Widgets/QGCAttitudeWidget.qml
@@ -15,7 +15,7 @@
  */
 
 import QtQuick
-import Qt5Compat.GraphicalEffects
+import QtQuick.Effects
 
 import QGroundControl
 import QGroundControl.Controls
@@ -99,18 +99,26 @@ Item {
         }
     }
 
-    Rectangle {
-        id:             mask
-        anchors.fill:   instrument
-        radius:         width / 2
-        color:          "black"
-        visible:        false
+    MultiEffect {
+        source: instrument
+        anchors.fill: instrument
+        maskEnabled: true
+        maskSource: mask
     }
 
-    OpacityMask {
-        anchors.fill: instrument
-        source: instrument
-        maskSource: mask
+    Item {
+        id: mask
+        width: instrument.width
+        height: instrument.height
+        layer.enabled: true
+        visible: false
+
+        Rectangle {
+            width: parent.width
+            height: parent.height
+            radius: width/2
+            color: "black"
+        }
     }
 
     Rectangle {

--- a/src/QmlControls/QGCColoredImage.qml
+++ b/src/QmlControls/QGCColoredImage.qml
@@ -1,6 +1,6 @@
 import QtQuick
 import QtQuick.Controls
-import Qt5Compat.GraphicalEffects
+import QtQuick.Effects
 
 import QGroundControl.Palette
 
@@ -35,9 +35,10 @@ Item {
         sourceSize.height:  height
     }
 
-    ColorOverlay {
-        anchors.fill:       image
-        source:             image
-        color:              parent.color
+    MultiEffect {
+        source: image
+        anchors.fill: image
+        colorizationColor: parent.color
+        colorization: 1.0
     }
 }

--- a/src/QtLocationPlugin/CMakeLists.txt
+++ b/src/QtLocationPlugin/CMakeLists.txt
@@ -1,4 +1,4 @@
-find_package(Qt6 REQUIRED COMPONENTS Core Core5Compat Location Network Qml Sql)
+find_package(Qt6 REQUIRED COMPONENTS Core Location Network Qml Sql)
 
 # QGC_NO_GOOGLE_MAPS
 
@@ -48,8 +48,6 @@ qt_add_plugin(QGCLocation STATIC
 target_compile_definitions(QGCLocation PRIVATE CMAKE_LOCATION_PLUGIN)
 
 target_link_libraries(QGCLocation
-	PRIVATE
-		Qt6::Core5Compat
 	PUBLIC
 		Qt6::Core
 		Qt6::Location

--- a/src/QtLocationPlugin/GoogleMapProvider.cpp
+++ b/src/QtLocationPlugin/GoogleMapProvider.cpp
@@ -8,15 +8,16 @@
  ****************************************************************************/
 
 #include "GoogleMapProvider.h"
+#include "QGCMapEngine.h"
 #if defined(DEBUG_GOOGLE_MAPS)
 #include <QFile>
 #include <QStandardPaths>
 #endif
 #include <QtGlobal>
-#include <QtCore5Compat/QRegExp>
 #include <QtNetwork/QNetworkProxy>
+#include <QtCore/QRegularExpression>
+#include <QtCore/QRegularExpressionMatch>
 
-#include "QGCMapEngine.h"
 
 GoogleMapProvider::GoogleMapProvider(const QString &imageFormat, const quint32 averageSize, const QGeoMapType::MapStyle mapType, QObject* parent)
     : MapProvider(QStringLiteral("https://www.google.com/maps/preview"), imageFormat, averageSize, mapType, parent)
@@ -78,19 +79,24 @@ void GoogleMapProvider::_googleVersionCompleted() {
     }
 #endif
 
-    QRegExp reg(QStringLiteral("\"*https?://mt\\D?\\d..*/vt\\?lyrs=m@(\\d*)"), Qt::CaseInsensitive);
-    if (reg.indexIn(html) != -1) {
-        _versionGoogleMap = QString(QStringLiteral("m@%1")).arg(reg.capturedTexts().value(1, QString()));
+    static const QRegularExpression regMap("\"*https?://mt\\D?\\d..*/vt\\?lyrs=m@(\\d*)", QRegularExpression::CaseInsensitiveOption);
+    const QRegularExpressionMatch matchMap = regMap.match(html);
+    if (matchMap.hasMatch()) {
+        _versionGoogleMap = QString("m@%1").arg(matchMap.captured(1));
     }
-    reg = QRegExp(QStringLiteral("\"*https?://khm\\D?\\d.googleapis.com/kh\\?v=(\\d*)"), Qt::CaseInsensitive);
-    if (reg.indexIn(html) != -1) {
-        _versionGoogleSatellite = reg.capturedTexts().value(1);
+
+    static const QRegularExpression regSatellite( "\"*https?://khm\\D?\\d.googleapis.com/kh\\?v=(\\d*)", QRegularExpression::CaseInsensitiveOption);
+    const QRegularExpressionMatch matchSatellite = regSatellite.match( html );
+    if (matchSatellite.hasMatch()) {
+        _versionGoogleSatellite = matchSatellite.captured(1);
     }
-    reg = QRegExp(QStringLiteral("\"*https?://mt\\D?\\d..*/vt\\?lyrs=t@(\\d*),r@(\\d*)"), Qt::CaseInsensitive);
-    if (reg.indexIn(html) != -1) {
-        const QStringList gc  = reg.capturedTexts();
-        _versionGoogleTerrain = QString(QStringLiteral("t@%1,r@%2")).arg(gc.value(1), gc.value(2));
+
+    static const QRegularExpression regTerrain( "\"*https?://mt\\D?\\d..*/vt\\?lyrs=t@(\\d*),r@(\\d*)", QRegularExpression::CaseInsensitiveOption);
+    const QRegularExpressionMatch matchTerrain = regTerrain.match(html);
+    if (matchTerrain.hasMatch()) {
+        _versionGoogleTerrain = QString("t@%1,r@%2").arg( matchTerrain.captured(1), matchTerrain.captured(2));
     }
+
     _googleReply->deleteLater();
     _googleReply = nullptr;
 }


### PR DESCRIPTION
Resolves #11081. Removes all usage of the Qt5 Compatibility Module which I believe was made due to licensing issues with libraries Qt was using for the GraphicalEffects.
This also fixed a couple of issues:

- APMParameterMetaData::getParameterMetaDataVersionInfo was not getting the version numbers correctly
- APMFirmwarePlugin::_handleIncomingStatusText was never setting _coaxialMotors

All Qml visuals are 100% identical except for the ADSB shadow because I am terrible at graphical design. Here is a before and after:
![DropShadow_Before](https://github.com/mavlink/qgroundcontrol/assets/68555040/e8deba69-2238-4bf3-81a3-2c068e6734ac)
![DropShadow_After](https://github.com/mavlink/qgroundcontrol/assets/68555040/d09c2b04-4e5f-492e-85e3-36076dd6c4ef)

@DonLakeFlyer Hopefully you can just tune a couple of the settings [here](https://github.com/HTRamsey/qgroundcontrol/blob/1dcc5f25c2581e83d0f1882e70f3beb76ae35824/src/FlightMap/MapItems/VehicleMapItem.qml#L47) to make it look better. I try to avoid touching Qml files since you're much better at it but I needed to in this circumstance.