### PR TITLE
Bug fix: QGC will crashed when disconnecting a vehicle and then recon…

### DIFF
--- a/src/Joystick/Joystick.cc
+++ b/src/Joystick/Joystick.cc
@@ -1,4 +1,4 @@
-/****************************************************************************
+﻿/****************************************************************************
  *
  * (c) 2009-2020 QGROUNDCONTROL PROJECT <http://www.qgroundcontrol.org>
  *
@@ -770,6 +770,7 @@ void Joystick::stopPolling(void)
         }
         _exitThread = true;
     }
+    _activeVehicle = nullptr;
 }
 
 void Joystick::setCalibration(int axis, Calibration_t& calibration)


### PR DESCRIPTION
<!--- Title -->

Description
-----------
QGC will crashed when disconnecting a vehicle and then reconnect again! 
<!--- -->

Test Steps
-----------
1. Start QGC with a joystick connected. 
2. Connect a vehicle to QGC. When connected, QGC shows relative interface.
3. Unplug vehicle, then plug vehicle again, QGC will crash.
<!--  -->

Checklist:
----------
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x ] [Review Contribution Guidelines](https://github.com/mavlink/qgroundcontrol/blob/master/.github/CONTRIBUTING.md).
- [x ] [Review Code of Conduct](https://github.com/mavlink/qgroundcontrol/blob/master/.github/CODE_OF_CONDUCT.md).
- [ x] I have tested my changes.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.