### PR TITLE
Set Message Rates From Mavlink Inspector

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -7,6 +7,7 @@ Note: This file only contains high level features or important fixes.
 * New combined compass and attitude instrument
 * You can select between multiple instruments by clicking on the instrument conntrol on a desktop build or press and hold on mobile builds
 * Support for Fly View and Joystick custom mavlink actions has changed. Both the name and formation of the command file is different now. Go to QGC docs to understand how it works now.
+* Support for setting individual Mavlink message rates in the Mavlink Inspector.
 
 ## 4.1
 

--- a/src/AnalyzeView/MAVLinkInspectorController.cc
+++ b/src/AnalyzeView/MAVLinkInspectorController.cc
@@ -210,9 +210,9 @@ void
 QGCMAVLinkMessage::updateFreq()
 {
     quint64 msgCount = _count - _lastCount;
-    _messageHz = (0.2 * _messageHz) + (0.8 * msgCount);
+    _actualRateHz = (0.2 * _actualRateHz) + (0.8 * msgCount);
     _lastCount = _count;
-    emit freqChanged();
+    emit actualRateHzChanged();
 }
 
 void QGCMAVLinkMessage::setSelected(bool sel)
@@ -221,6 +221,15 @@ void QGCMAVLinkMessage::setSelected(bool sel)
         _selected = sel;
         _updateFields();
         emit selectedChanged();
+    }
+}
+
+void QGCMAVLinkMessage::setTargetRateHz(int32_t rate)
+{
+    if(rate != _targetRateHz)
+    {
+        _targetRateHz = rate;
+        emit targetRateHzChanged();
     }
 }
 
@@ -481,12 +490,12 @@ QGCMAVLinkSystem::~QGCMAVLinkSystem()
 
 //-----------------------------------------------------------------------------
 QGCMAVLinkMessage*
-QGCMAVLinkSystem::findMessage(uint32_t id, uint8_t cid)
+QGCMAVLinkSystem::findMessage(uint32_t id, uint8_t compId)
 {
     for(int i = 0; i < _messages.count(); i++) {
         QGCMAVLinkMessage* m = qobject_cast<QGCMAVLinkMessage*>(_messages.get(i));
         if(m) {
-            if(m->id() == id && m->cid() == cid) {
+            if(m->id() == id && m->compId() == compId) {
                 return m;
             }
         }
@@ -536,6 +545,16 @@ QGCMAVLinkSystem::setSelected(int sel)
     }
 }
 
+QGCMAVLinkMessage* QGCMAVLinkSystem::selectedMsg()
+{
+    QGCMAVLinkMessage* selectedMsg = nullptr;
+    if(_messages.count())
+    {
+        selectedMsg = qobject_cast<QGCMAVLinkMessage*>(_messages.get(_selected));
+    }
+    return selectedMsg;
+}
+
 //-----------------------------------------------------------------------------
 static bool
 messages_sort(QObject* a, QObject* b)
@@ -560,7 +579,7 @@ QGCMAVLinkSystem::append(QGCMAVLinkMessage* message)
         message->setSelected(true);
     }
     _messages.append(message);
-    //-- Sort messages by id and then cid
+    //-- Sort messages by id and then compId
     if (_messages.count() > 0) {
         _messages.beginReset();
         std::sort(_messages.objectList()->begin(), _messages.objectList()->end(), messages_sort);
@@ -584,10 +603,10 @@ QGCMAVLinkSystem::_checkCompID(QGCMAVLinkMessage* message)
     if(_compIDsStr.isEmpty()) {
         _compIDsStr << tr("Comp All");
     }
-    if(!_compIDs.contains(static_cast<int>(message->cid()))) {
-        int cid = static_cast<int>(message->cid());
-        _compIDs.append(cid);
-        _compIDsStr << tr("Comp %1").arg(cid);
+    if(!_compIDs.contains(static_cast<int>(message->compId()))) {
+        int compId = static_cast<int>(message->compId());
+        _compIDs.append(compId);
+        _compIDsStr << tr("Comp %1").arg(compId);
         emit compIDsChanged();
     }
 }
@@ -727,12 +746,11 @@ MAVLinkInspectorController::MAVLinkInspectorController()
     MultiVehicleManager* multiVehicleManager = qgcApp()->toolbox()->multiVehicleManager();
     connect(multiVehicleManager, &MultiVehicleManager::vehicleAdded,   this, &MAVLinkInspectorController::_vehicleAdded);
     connect(multiVehicleManager, &MultiVehicleManager::vehicleRemoved, this, &MAVLinkInspectorController::_vehicleRemoved);
+    connect(multiVehicleManager, &MultiVehicleManager::activeVehicleChanged, this, &MAVLinkInspectorController::_setActiveVehicle);
     MAVLinkProtocol* mavlinkProtocol = qgcApp()->toolbox()->mavlinkProtocol();
     connect(mavlinkProtocol, &MAVLinkProtocol::messageReceived, this, &MAVLinkInspectorController::_receiveMessage);
     connect(&_updateFrequencyTimer, &QTimer::timeout, this, &MAVLinkInspectorController::_refreshFrequency);
     _updateFrequencyTimer.start(1000);
-    MultiVehicleManager *manager = qgcApp()->toolbox()->multiVehicleManager();
-    connect(manager, &MultiVehicleManager::activeVehicleChanged, this, &MAVLinkInspectorController::_setActiveVehicle);
     _timeScaleSt.append(new TimeScale_st(this, tr("5 Sec"),   5 * 1000));
     _timeScaleSt.append(new TimeScale_st(this, tr("10 Sec"), 10 * 1000));
     _timeScaleSt.append(new TimeScale_st(this, tr("30 Sec"), 30 * 1000));
@@ -835,13 +853,28 @@ MAVLinkInspectorController::_refreshFrequency()
 void
 MAVLinkInspectorController::_vehicleAdded(Vehicle* vehicle)
 {
-    QGCMAVLinkSystem* v = _findVehicle(static_cast<uint8_t>(vehicle->id()));
-    if(v) {
-        v->messages()->clearAndDeleteContents();
-    } else {
-        v = new QGCMAVLinkSystem(this, static_cast<uint8_t>(vehicle->id()));
-        _systems.append(v);
+    QGCMAVLinkSystem* sys = _findVehicle(static_cast<uint8_t>(vehicle->id()));
+    if(sys)
+    {
+        sys->messages()->clearAndDeleteContents();
+    }
+    else
+    {
+        sys = new QGCMAVLinkSystem(this, static_cast<uint8_t>(vehicle->id()));
+        _systems.append(sys);
         _systemNames.append(tr("System %1").arg(vehicle->id()));
+        connect(vehicle, &Vehicle::mavlinkMsgIntervalsChanged, sys, [sys](uint8_t compid, uint16_t msgId, int32_t rate)
+        {
+            for(int i = 0; i < sys->messages()->count(); i++)
+            {
+                QGCMAVLinkMessage* msg = qobject_cast<QGCMAVLinkMessage*>(sys->messages()->get(i));
+                if((msg->compId() == compid) && (msg->id() == msgId))
+                {
+                    msg->setTargetRateHz(rate);
+                    break;
+                }
+            }
+        });
     }
     emit systemsChanged();
 }
@@ -939,3 +972,36 @@ void MAVLinkInspectorController::setActiveSystem(int systemId)
     }
 }
 
+void MAVLinkInspectorController::setMessageInterval(int32_t rate)
+{
+    if(!_activeSystem) return;
+
+    MultiVehicleManager* multiVehicleManager = qgcApp()->toolbox()->multiVehicleManager();
+    if(!multiVehicleManager) return;
+
+    const uint8_t sysId = _selectedSystemID();
+    if(sysId == 0) return;
+
+    Vehicle* vehicle = multiVehicleManager->getVehicleById(sysId);
+    if(!vehicle) return;
+
+    QGCMAVLinkMessage* msg = _activeSystem->selectedMsg();
+    if(!msg) return;
+
+    const uint8_t compId = _selectedComponentID();
+    if(compId == 0) return;
+
+    // TODO: Make QGCMAVLinkMessage a part of comm and use signals/slots for msg rate changes
+    vehicle->setMessageRate(compId, msg->id(), rate);
+}
+
+uint8_t MAVLinkInspectorController::_selectedSystemID() const
+{
+    return _activeSystem ? _activeSystem->id() : 0;
+}
+
+uint8_t MAVLinkInspectorController::_selectedComponentID() const
+{
+    QGCMAVLinkMessage* msg = _activeSystem->selectedMsg();
+    return (msg ? msg->compId() : 0);
+}

--- a/src/QmlControls/QGCComboBox.qml
+++ b/src/QmlControls/QGCComboBox.qml
@@ -58,7 +58,7 @@ T.ComboBox {
         if (_onCompleted && sizeToContents && model) {
             var largestTextWidth = 0
             for (var i = 0; i < model.length; i++){
-                textMetrics.text = model[i]
+                textMetrics.text = control.textRole ? (Array.isArray(control.model) ? model[i][control.textRole] : model[control.textRole]) : model[i]
                 largestTextWidth = Math.max(textMetrics.width, largestTextWidth)
             }
             _popupWidth = largestTextWidth + itemDelegateMetrics.leftPadding + itemDelegateMetrics.rightPadding

--- a/src/Vehicle/Vehicle.cc
+++ b/src/Vehicle/Vehicle.cc
@@ -780,6 +780,11 @@ void Vehicle::_mavlinkMessageReceived(LinkInterface* link, mavlink_message_t mes
         emit logData(log.ofs, log.id, log.count, log.data);
         break;
     }
+    case MAVLINK_MSG_ID_MESSAGE_INTERVAL:
+    {
+        _handleMessageInterval(message);
+        break;
+    }
     }
 
     // This must be emitted after the vehicle processes the message. This way the vehicle state is up to date when anyone else
@@ -4533,4 +4538,94 @@ void Vehicle::pairRX(int rxType, int rxSubType)
                    true,
                    rxType,
                    rxSubType);
+}
+
+void Vehicle::_handleMessageInterval(const mavlink_message_t& message)
+{
+    mavlink_message_interval_t data;
+    mavlink_msg_message_interval_decode(&message, &data);
+
+    const MavCompMsgId compMsgId = {message.compid, data.message_id};
+    const int32_t rate = ( data.interval_us > 0 ) ? 1000000.0 / data.interval_us : data.interval_us;
+
+    if(!_mavlinkMsgIntervals.contains(compMsgId) || _mavlinkMsgIntervals.value(compMsgId) != rate)
+    {
+        (void) _mavlinkMsgIntervals.insert(compMsgId, rate);
+        emit mavlinkMsgIntervalsChanged(message.compid, data.message_id, rate);
+    }
+}
+
+void Vehicle::_requestMessageMessageIntervalResultHandler(void* resultHandlerData, MAV_RESULT result, RequestMessageResultHandlerFailureCode_t failureCode, const mavlink_message_t& message)
+{
+    if((result != MAV_RESULT_ACCEPTED) || (failureCode != RequestMessageNoFailure))
+    {
+        mavlink_message_interval_t data;
+        mavlink_msg_message_interval_decode(&message, &data);
+
+        Vehicle* vehicle = static_cast<Vehicle*>(resultHandlerData);
+        (void) vehicle->_unsupportedMessageIds.insert(message.compid, data.message_id);
+    }
+}
+
+void Vehicle::_requestMessageInterval(uint8_t compId, uint16_t msgId)
+{
+    if(!_unsupportedMessageIds.contains(compId, msgId))
+    {
+        requestMessage(
+            &Vehicle::_requestMessageMessageIntervalResultHandler,
+            this,
+            compId,
+            MAVLINK_MSG_ID_MESSAGE_INTERVAL,
+            msgId
+        );
+    }
+}
+
+int32_t Vehicle::getMessageRate(uint8_t compId, uint16_t msgId)
+{
+    // TODO: Use QGCMavlinkMessage
+    const MavCompMsgId compMsgId = {compId, msgId};
+    int32_t rate = 0;
+    if(_mavlinkMsgIntervals.contains(compMsgId))
+    {
+        rate = _mavlinkMsgIntervals.value(compMsgId);
+    }
+    else
+    {
+        _requestMessageInterval(compId, msgId);
+    }
+    return rate;
+}
+
+void Vehicle::_setMessageRateCommandResultHandler(void* resultHandlerData, int compId, const mavlink_command_ack_t& ack, MavCmdResultFailureCode_t failureCode)
+{
+    if((ack.result == MAV_RESULT_ACCEPTED) && (failureCode == MavCmdResultCommandResultOnly))
+    {
+        Vehicle* vehicle = static_cast<Vehicle*>(resultHandlerData);
+        if(vehicle)
+        {
+            vehicle->_requestMessageInterval(compId, vehicle->_lastSetMsgIntervalMsgId);
+        }
+    }
+}
+
+void Vehicle::setMessageRate(uint8_t compId, uint16_t msgId, int32_t rate)
+{
+    const MavCmdAckHandlerInfo_t handlerInfo = {
+        /* .resultHandler = */ &Vehicle::_setMessageRateCommandResultHandler,
+        /* .resultHandlerData =  */ this,
+        /* .progressHandler =  */ nullptr,
+        /* .progressHandlerData =  */ nullptr
+    };
+
+    const float interval = (rate > 0) ? 1000000.0 / rate : rate;
+    _lastSetMsgIntervalMsgId = msgId;
+
+    sendMavCommandWithHandler(
+        &handlerInfo,
+        compId,
+        MAV_CMD_SET_MESSAGE_INTERVAL,
+        msgId,
+        interval
+    );
 }

--- a/src/Vehicle/Vehicle.h
+++ b/src/Vehicle/Vehicle.h
@@ -1541,6 +1541,26 @@ private:
     // We use this to limit above terrain altitude queries based on distance and altitude change
     QGeoCoordinate              _altitudeAboveTerrLastCoord;
     float                       _altitudeAboveTerrLastRelAlt = qQNaN();
+
+public:
+    int32_t getMessageRate(uint8_t compId, uint16_t msgId);
+    void setMessageRate(uint8_t compId, uint16_t msgId, int32_t rate);
+
+signals:
+    void mavlinkMsgIntervalsChanged(uint8_t compid, uint16_t msgId, int32_t rate);
+
+private:
+    void _handleMessageInterval(const mavlink_message_t& message);
+
+    static void _requestMessageMessageIntervalResultHandler(void* resultHandlerData, MAV_RESULT result, RequestMessageResultHandlerFailureCode_t failureCode, const mavlink_message_t& message);
+    void _requestMessageInterval(uint8_t compId, uint16_t msgId);
+
+    static void _setMessageRateCommandResultHandler(void* resultHandlerData, int compId, const mavlink_command_ack_t& ack, MavCmdResultFailureCode_t failureCode);
+
+    typedef QPair<uint8_t, uint16_t> MavCompMsgId;
+    QHash<MavCompMsgId, int32_t> _mavlinkMsgIntervals;
+    QMultiHash<uint8_t, uint16_t> _unsupportedMessageIds;
+    uint16_t _lastSetMsgIntervalMsgId = 0;
 };
 
 Q_DECLARE_METATYPE(Vehicle::MavCmdResultFailureCode_t)


### PR DESCRIPTION
Uses the currently selected message in the MavlinkInspector of the Analyze View to adjust individual message rates (rather than stream rates for groups of messages like is currently used for ArduPilot).
@DonLakeFlyer Design Advice? Maybe a TextField or SpinBox instead? Also, if you're cool with it I would like to move the QGCMAVLinkMessage and QGCMAVLinkSystem out of MavlinkInspectorController and into comm to be used by MAVLinkProtocol.
![MavInspectorMsgRate](https://github.com/mavlink/qgroundcontrol/assets/68555040/1d9285f1-8ed8-4463-9325-3224b3732e1e)
![MavInspectRates](https://github.com/mavlink/qgroundcontrol/assets/68555040/55d1a05e-d38e-4647-9058-5862d3e70ace)
