### PR TITLE
Fix scrolling widgets on map view for touchscreen

### DIFF
--- a/src/FlightMap/FlightMap.qml
+++ b/src/FlightMap/FlightMap.qml
@@ -159,6 +159,8 @@ Map {
         }
 
         onActiveTranslationChanged: (delta) => _map.pan(-delta.x, -delta.y)
+
+        grabPermissions: PointerHandler.TakeOverForbidden
     }
 
     TapHandler {


### PR DESCRIPTION
<!--- Title -->

Description
-----------
Hi everyone, it has been a while since I haven't PR :-)
I noticed that with the latest master, it's not possible to scroll on a touchscreen through the mission item list, neither the action list (if longer than the screen).
I looked at the recent fixes for the map zoom and menu scroll and ended up fixing it by changing the grabPermission of the map, so map dragHandler doesn't take over the other widgets. (See Qt doc here : https://doc.qt.io/qt-6/qml-qtquick-draghandler.html#grabPermissions-prop).

Test Steps
-----------
Tested on Android, looks OK.

Checklist:
----------
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [X] [Review Contribution Guidelines](https://github.com/mavlink/qgroundcontrol/blob/master/.github/CONTRIBUTING.md).
- [X] [Review Code of Conduct](https://github.com/mavlink/qgroundcontrol/blob/master/.github/CODE_OF_CONDUCT.md).
- [X] I have tested my changes.

Related Issue
-----------
<!-- If any, please provide issue ID. -->


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.