### PR TITLE
Using GST structure to confirm video decoding stream format.

### DIFF
--- a/src/VideoReceiver/GstVideoReceiver.cc
+++ b/src/VideoReceiver/GstVideoReceiver.cc
@@ -717,18 +717,21 @@ GstVideoReceiver::_filterParserCaps(GstElement* bin, GstPad* pad, GstElement* el
 
     GstCaps* filter;
 
-    if ((filter = gst_caps_from_string("video/x-h264")) != nullptr) {
-        if (gst_caps_can_intersect(srcCaps, filter)) {
-            sinkCaps = gst_caps_from_string("video/x-h264,stream-format=avc");
-        }
+    GstStructure* structure;
 
-        gst_caps_unref(filter);
-        filter = nullptr;
-    } else if ((filter = gst_caps_from_string("video/x-h265")) != nullptr) {
+    structure = gst_caps_get_structure(srcCaps, 0);
+    if(gst_structure_has_name(structure, "video/x-h265")){
+        filter = gst_caps_from_string("video/x-h265");
         if (gst_caps_can_intersect(srcCaps, filter)) {
             sinkCaps = gst_caps_from_string("video/x-h265,stream-format=hvc1");
         }
-
+        gst_caps_unref(filter);
+        filter = nullptr;
+    } else if(gst_structure_has_name(structure, "video/x-h264")){
+        filter = gst_caps_from_string("video/x-h264");
+        if (gst_caps_can_intersect(srcCaps, filter)) {
+            sinkCaps = gst_caps_from_string("video/x-h264,stream-format=avc");
+        }
         gst_caps_unref(filter);
         filter = nullptr;
     }


### PR DESCRIPTION
Bugfix - Unable to record h.265 video on Android devices.

Description
-----------
Some Android h.264 and h.265 decoders use 'byte stream' as the stream format. The existing code is intended to check for h.264 or h.265 streams and rename the stream format from 'byte stream' to either 'avc' or 'hvc1', which are compatible with the mux components used for the filesink downstream in the pipeline.

The existing code fails by always taking the h.264 option, irrespective of the stream type. This means the 'valve fails to link to the filesink', which means the h.265 stream cannot be recorded on Android devices. The error is caused by using the gst_caps_from_string() function, which effectively just creates a h.264 filter every time.

This fix replaces gst_caps_from_string() with the gst_caps_get_structure() function. It uses the GstStructure to test the presence of 'video/x-h264' or 'video/x-h265' within the actual pipeline that has been created. The remainder of the existing code is then correctly called to rename the stream format.

Test Steps
-----------
1. Install QGC on an Android device (Tested on Samsung Galaxy S20).
2. Connect to an rtsp source which is using h.264 encoding.
3. Try to record video.
4. Connect to an rtsp source which is using h.265 encoding.
5. Try to record video.

The existing code fails to record the h.265 stream, reporting the 'valve failed to link to filesink' error.
The proposed code successfully records both streams.

Checklist:
----------
- [X ] [Review Contribution Guidelines](https://github.com/mavlink/qgroundcontrol/blob/master/.github/CONTRIBUTING.md).
- [ X] [Review Code of Conduct](https://github.com/mavlink/qgroundcontrol/blob/master/.github/CODE_OF_CONDUCT.md).
- [ X] I have tested my changes.

Related Issue
-----------

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.