### PR TITLE
Quick controls2 basic missing libraries added  

### DIFF
--- a/QGCPostLinkCommon.pri
+++ b/QGCPostLinkCommon.pri
@@ -111,6 +111,8 @@ LinuxBuild {
         libQt6DBus.so.6 \
         libQt6OpenGLWidgets.so.6 \
         libQt6QuickControls2.so.6 \
+        libQt6QuickControls2Basic.so.6 \
+        libQt6QuickControls2BasicStyleImpl.so.6 \
         libQt6SerialPort.so.6 \
         libQt6Gui.so.6 \ 
         libQt6PositioningQuick.so.6 \


### PR DESCRIPTION
<!--- Title -->
# Quick controls2 basic missing libraries added  
Description
-----------
<!--- Describe your changes in detail. -->

Some missing libraries for AppImage were added to `QGCPostLinkCommon.pri` to load the Quick Controls2 Basic resources

Test Steps
-----------
<!-- Describe the steps to reproduce. -->
1. Download and enable QGC AppImage as usual into a Linux Distro
2. Run the AppImage
3. Expect to run without issues coming from missing libraries 

Checklist:
----------
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] [Review Contribution Guidelines](https://github.com/mavlink/qgroundcontrol/blob/master/.github/CONTRIBUTING.md).
- [x] [Review Code of Conduct](https://github.com/mavlink/qgroundcontrol/blob/master/.github/CODE_OF_CONDUCT.md).
- [x] I have tested my changes.

Related Issue
-----------
<!-- If any, please provide issue ID. -->

More details about the problem can be found  in #11272 


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.