### PR TITLE
Hidden flight modes: Separate list for each firmware type and vehicle class combination

### DIFF
--- a/src/Settings/FlightMode.SettingsGroup.json
+++ b/src/Settings/FlightMode.SettingsGroup.json
@@ -10,8 +10,74 @@
     "default":      "Offboard"
 },
 {
-    "name":         "apmHiddenFlightModes",
-    "shortDesc":    "Comma separated list of hidden flight modes",
+    "name":         "px4HiddenFlightModesMultiRotor",
+    "shortDesc":    "Comma separated list of hidden flight modes for MultiRotor",
+    "type":         "string",
+    "default2":      "Manual,Offboard,Rattitude,Precision Land"
+},
+{
+    "name":         "px4HiddenFlightModesFixedWing",
+    "shortDesc":    "Comma separated list of hidden flight modes for FixedWing",
+    "type":         "string",
+    "default":      "Offboard,Acro,Rattitude"
+},
+{
+    "name":         "px4HiddenFlightModesVTOL",
+    "shortDesc":    "Comma separated list of hidden flight modes for VTOL",
+    "type":         "string",
+    "default":      "Offboard,Rattitude,Precision Land"
+},
+{
+    "name":         "px4HiddenFlightModesRoverBoat",
+    "shortDesc":    "Comma separated list of hidden flight modes for RoverBoat",
+    "type":         "string",
+    "default":      "Offboard"
+},
+{
+    "name":         "px4HiddenFlightModesSub",
+    "shortDesc":    "Comma separated list of hidden flight modes for Sub",
+    "type":         "string",
+    "default":      "Offboard"
+},
+{
+    "name":         "px4HiddenFlightModesAirship",
+    "shortDesc":    "Comma separated list of hidden flight modes for Airship",
+    "type":         "string",
+    "default":      "Offboard"
+},
+{
+    "name":         "apmHiddenFlightModesMultiRotor",
+    "shortDesc":    "Comma separated list of hidden flight modes for MultiRotor",
+    "type":         "string",
+    "default":      "Acro,Circle,Drift,Sport,Flip,Brake,Throw,Guided,Guided No GPS,Flow Hold,ZigZag,Turtle,Autotune,SystemID,AutoRotate"
+},
+{
+    "name":         "apmHiddenFlightModesFixedWing",
+    "shortDesc":    "Comma separated list of hidden flight modes for FixedWing",
+    "type":         "string",
+    "default":      "Circle,Training,Acro,FBW B,Cruise,Autotune,QuadPlane Stabilize,Guided,QuadPlane Hover,QuadPlane Loiter,QuadPlane Land,QuadPlane RTL,QuadPlane AutoTune,QuadPlane Acro,Thermal"
+},
+{
+    "name":         "apmHiddenFlightModesVTOL",
+    "shortDesc":    "Comma separated list of hidden flight modes for VTOL",
+    "type":         "string",
+    "default":      ""
+},
+{
+    "name":         "apmHiddenFlightModesRoverBoat",
+    "shortDesc":    "Comma separated list of hidden flight modes for RoverBoat",
+    "type":         "string",
+    "default":      ""
+},
+{
+    "name":         "apmHiddenFlightModesSub",
+    "shortDesc":    "Comma separated list of hidden flight modes for Sub",
+    "type":         "string",
+    "default":      ""
+},
+{
+    "name":         "apmHiddenFlightModesAirship",
+    "shortDesc":    "Comma separated list of hidden flight modes for Airship",
     "type":         "string",
     "default":      ""
 }

--- a/src/Settings/FlightModeSettings.cc
+++ b/src/Settings/FlightModeSettings.cc
@@ -16,5 +16,15 @@ DECLARE_SETTINGGROUP(FlightMode, "FlightMode")
     qmlRegisterUncreatableType<FlightModeSettings>("QGroundControl.SettingsManager", 1, 0, "FlightModeSettings", "Reference only");
 }
 
-DECLARE_SETTINGSFACT(FlightModeSettings, px4HiddenFlightModes)
-DECLARE_SETTINGSFACT(FlightModeSettings, apmHiddenFlightModes)
+DECLARE_SETTINGSFACT(FlightModeSettings, px4HiddenFlightModesMultiRotor)
+DECLARE_SETTINGSFACT(FlightModeSettings, px4HiddenFlightModesFixedWing)
+DECLARE_SETTINGSFACT(FlightModeSettings, px4HiddenFlightModesVTOL)
+DECLARE_SETTINGSFACT(FlightModeSettings, px4HiddenFlightModesRoverBoat)
+DECLARE_SETTINGSFACT(FlightModeSettings, px4HiddenFlightModesSub)
+DECLARE_SETTINGSFACT(FlightModeSettings, px4HiddenFlightModesAirship)
+DECLARE_SETTINGSFACT(FlightModeSettings, apmHiddenFlightModesMultiRotor)
+DECLARE_SETTINGSFACT(FlightModeSettings, apmHiddenFlightModesFixedWing)
+DECLARE_SETTINGSFACT(FlightModeSettings, apmHiddenFlightModesVTOL)
+DECLARE_SETTINGSFACT(FlightModeSettings, apmHiddenFlightModesRoverBoat)
+DECLARE_SETTINGSFACT(FlightModeSettings, apmHiddenFlightModesSub)
+DECLARE_SETTINGSFACT(FlightModeSettings, apmHiddenFlightModesAirship)

--- a/src/Settings/FlightModeSettings.h
+++ b/src/Settings/FlightModeSettings.h
@@ -19,6 +19,16 @@ public:
     FlightModeSettings(QObject* parent = nullptr);
 
     DEFINE_SETTING_NAME_GROUP()
-    DEFINE_SETTINGFACT(px4HiddenFlightModes)
-    DEFINE_SETTINGFACT(apmHiddenFlightModes)
+    DEFINE_SETTINGFACT(px4HiddenFlightModesMultiRotor)
+    DEFINE_SETTINGFACT(px4HiddenFlightModesFixedWing)
+    DEFINE_SETTINGFACT(px4HiddenFlightModesVTOL)
+    DEFINE_SETTINGFACT(px4HiddenFlightModesRoverBoat)
+    DEFINE_SETTINGFACT(px4HiddenFlightModesSub)
+    DEFINE_SETTINGFACT(px4HiddenFlightModesAirship)
+    DEFINE_SETTINGFACT(apmHiddenFlightModesMultiRotor)
+    DEFINE_SETTINGFACT(apmHiddenFlightModesFixedWing)
+    DEFINE_SETTINGFACT(apmHiddenFlightModesVTOL)
+    DEFINE_SETTINGFACT(apmHiddenFlightModesRoverBoat)
+    DEFINE_SETTINGFACT(apmHiddenFlightModesSub)
+    DEFINE_SETTINGFACT(apmHiddenFlightModesAirship)
 };

--- a/src/Vehicle/Vehicle.cc
+++ b/src/Vehicle/Vehicle.cc
@@ -2607,6 +2607,11 @@ QString Vehicle::vehicleTypeName() const {
     return typeNames[_vehicleType];
 }
 
+QString Vehicle::vehicleClassInternalName() const
+{
+    return QGCMAVLink::vehicleClassToInternalString(vehicleClass());
+}
+
 /// Returns the string to speak to identify the vehicle
 QString Vehicle::_vehicleIdSpeech()
 {

--- a/src/Vehicle/Vehicle.h
+++ b/src/Vehicle/Vehicle.h
@@ -525,6 +525,7 @@ public:
     MAV_TYPE vehicleType() const { return _vehicleType; }
     QGCMAVLink::VehicleClass_t vehicleClass(void) const { return QGCMAVLink::vehicleClass(_vehicleType); }
     Q_INVOKABLE QString vehicleTypeName() const;
+    Q_INVOKABLE QString vehicleClassInternalName() const;
 
     /// Sends a message to the specified link
     /// @return true: message sent, false: Link no longer connected

--- a/src/comm/QGCMAVLink.cc
+++ b/src/comm/QGCMAVLink.cc
@@ -141,7 +141,7 @@ QGCMAVLink::VehicleClass_t QGCMAVLink::vehicleClass(MAV_TYPE mavType)
     }
 }
 
-QString QGCMAVLink::vehicleClassToString(VehicleClass_t vehicleClass)
+QString QGCMAVLink::vehicleClassToUserVisibleString(VehicleClass_t vehicleClass)
 {
     switch (vehicleClass) {
     case VehicleClassAirship:
@@ -160,6 +160,28 @@ QString QGCMAVLink::vehicleClassToString(VehicleClass_t vehicleClass)
         return QT_TRANSLATE_NOOP("Vehicle Class", "Generic");
     default:
         return QT_TRANSLATE_NOOP("Vehicle Class", "Unknown");
+    }
+}
+
+QString QGCMAVLink::vehicleClassToInternalString(VehicleClass_t vehicleClass)
+{
+    switch (vehicleClass) {
+    case VehicleClassAirship:
+        return QStringLiteral("Airship");
+    case VehicleClassFixedWing:
+        return QStringLiteral("FixedWing");
+    case VehicleClassRoverBoat:
+        return QStringLiteral("RoverBoat");
+    case VehicleClassSub:
+        return QStringLiteral("Sub");
+    case VehicleClassMultiRotor:
+        return QStringLiteral("MultiRotor");
+    case VehicleClassVTOL:
+        return QStringLiteral("VTOL");
+    case VehicleClassGeneric:
+        return QStringLiteral("Generic");
+    default:
+        return QStringLiteral("Unknown");
     }
 }
 

--- a/src/comm/QGCMAVLink.h
+++ b/src/comm/QGCMAVLink.h
@@ -87,7 +87,8 @@ public:
     static bool                     isVTOL                      (MAV_TYPE mavType);
     static VehicleClass_t           vehicleClass                (MAV_TYPE mavType);
     static MAV_TYPE                 vehicleClassToMavType       (VehicleClass_t vehicleClass) { return static_cast<MAV_TYPE>(vehicleClass); }
-    static QString                  vehicleClassToString        (VehicleClass_t vehicleClass);
+    static QString                  vehicleClassToUserVisibleString(VehicleClass_t vehicleClass);
+    static QString                  vehicleClassToInternalString(VehicleClass_t vehicleClass);
     static QList<VehicleClass_t>    allVehicleClasses           (void);
 
     static QString                  mavResultToString           (MAV_RESULT result);

--- a/test/MissionManager/MissionCommandTreeEditorTest.cc
+++ b/test/MissionManager/MissionCommandTreeEditorTest.cc
@@ -21,7 +21,7 @@ MissionCommandTreeEditorTest::MissionCommandTreeEditorTest(void)
 void MissionCommandTreeEditorTest::_testEditorsWorker(QGCMAVLink::FirmwareClass_t firmwareClass, QGCMAVLink::VehicleClass_t vehicleClass)
 {
     QString firmwareClassString = QGCMAVLink::firmwareClassToString(firmwareClass).replace(" ", "");
-    QString vehicleClassString  = QGCMAVLink::vehicleClassToString(vehicleClass).replace(" ", "");
+    QString vehicleClassString  = QGCMAVLink::vehicleClassToUserVisibleString(vehicleClass).replace(" ", "");
 
     AppSettings* appSettings = qgcApp()->toolbox()->settingsManager()->appSettings();
     appSettings->offlineEditingFirmwareClass()->setRawValue(firmwareClass);

--- a/test/MissionManager/SimpleMissionItemTest.cc
+++ b/test/MissionManager/SimpleMissionItemTest.cc
@@ -121,7 +121,7 @@ bool SimpleMissionItemTest::_classMatch(QGCMAVLink::VehicleClass_t vehicleClass,
 
 void SimpleMissionItemTest::_testEditorFactsWorker(QGCMAVLink::VehicleClass_t vehicleClass, QGCMAVLink::VehicleClass_t vtolMode, const ItemExpected_t* rgExpected)
 {
-    qDebug() << "vehicleClass:vtolMode" << QGCMAVLink::vehicleClassToString(vehicleClass) << QGCMAVLink::vehicleClassToString(vtolMode);
+    qDebug() << "vehicleClass:vtolMode" << QGCMAVLink::vehicleClassToUserVisibleString(vehicleClass) << QGCMAVLink::vehicleClassToUserVisibleString(vtolMode);
 
     PlanMasterController planController(MAV_AUTOPILOT_PX4, QGCMAVLink::vehicleClassToMavType(vehicleClass));
 


### PR DESCRIPTION
* The vehicle classes are: Airship, Fixed Wing, Rover/Boat, Sub, Multi Rotor, VTOL
* This allows you have to separate hidden flight modes for a multi-rotor which are different for a fixed-wing for example
* The defaults have been adjusted to be vehicle class specific
* Updated defaults for ArduPilot vehicle classes according to discussion here: #11118
* Likely to have more updates to hidden defaults are I collect feedback

Example with default hidden flight modes applied on ArduCopter:
<img width="128" alt="Screenshot 2024-04-06 at 2 27 00 PM" src="https://github.com/mavlink/qgroundcontrol/assets/5876851/bb7d587e-57d0-4b66-bf47-984693bd2587">

As opposed to the full list which scrolls off the screen!
<img width="130" alt="Screenshot 2024-04-06 at 2 27 34 PM" src="https://github.com/mavlink/qgroundcontrol/assets/5876851/96ee357e-ddb8-493d-87aa-9d19fede200f">
