### PR TITLE
Fix colorized icon with Qt5Compat.GraphicalEffects instead MultiEffet from Qt6

### DIFF
--- a/src/QmlControls/QGCColoredImage.qml
+++ b/src/QmlControls/QGCColoredImage.qml
@@ -1,6 +1,6 @@
 import QtQuick
 import QtQuick.Controls
-import QtQuick.Effects
+import Qt5Compat.GraphicalEffects
 
 import QGroundControl.Palette
 
@@ -35,10 +35,9 @@ Item {
         sourceSize.height:  height
     }
 
-    MultiEffect {
-        source: image
-        anchors.fill: image
-        colorizationColor: parent.color
-        colorization: 1.0
+    ColorOverlay {
+        anchors.fill:       image
+        source:             image
+        color:              parent.color
     }
 }


### PR DESCRIPTION
At the moment, MultiEffect has limitations in its operation. It does not work with black images. Therefore, the most logical solution would be to use the features from Qt5

https://forum.qt.io/topic/144070/qt6-color-svg-using-multieffect/8

Multieffect:
![Screenshot from 2024-04-07 14-36-26](https://github.com/mavlink/qgroundcontrol/assets/2522054/3e368475-8d3d-4e2d-8655-332abf67151f)

ColorOverlay:
![Screenshot from 2024-04-07 14-35-41](https://github.com/mavlink/qgroundcontrol/assets/2522054/581aea67-519d-49a7-b021-a74b5ef86e76)




