### PR TITLE
Exclude shapelib and zlib from cmake install process

### DIFF
--- a/src/Compression/CMakeLists.txt
+++ b/src/Compression/CMakeLists.txt
@@ -9,6 +9,7 @@ qt_add_library(compression STATIC
 
 set(ZLIB_BUILD_EXAMPLES OFF CACHE INTERNAL "")
 set(BUILD_SHARED_LIBS OFF CACHE INTERNAL "")
+set(SKIP_INSTALL_ALL ON CACHE INTERNAL "")
 
 include(FetchContent)
 FetchContent_Declare(zlib

--- a/src/Utilities/CMakeLists.txt
+++ b/src/Utilities/CMakeLists.txt
@@ -37,9 +37,13 @@ include(FetchContent)
 FetchContent_Declare(shapelib
 	GIT_REPOSITORY https://github.com/OSGeo/shapelib.git
 	GIT_TAG v1.6.0
-    GIT_SHALLOW TRUE
+	GIT_SHALLOW TRUE
 )
-FetchContent_MakeAvailable(shapelib)
+FetchContent_GetProperties(shapelib)
+if(NOT shapelib_POPULATED)
+	FetchContent_Populate(shapelib)
+	add_subdirectory(${shapelib_SOURCE_DIR} ${shapelib_BINARY_DIR} EXCLUDE_FROM_ALL)
+endif()
 
 target_link_libraries(Utilities
 	PRIVATE


### PR DESCRIPTION
Modify CMakeLists for shapelib and zlib fetch process to exclude them from install procedure