### PR TITLE
Revert "Quick controls2 basic missing libraries added  "

### DIFF
--- a/QGCPostLinkCommon.pri
+++ b/QGCPostLinkCommon.pri
@@ -110,8 +110,6 @@ LinuxBuild {
         libQt6DBus.so.6 \
         libQt6OpenGLWidgets.so.6 \
         libQt6QuickControls2.so.6 \
-        libQt6QuickControls2Basic.so.6 \
-        libQt6QuickControls2BasicStyleImpl.so.6 \
         libQt6SerialPort.so.6 \
         libQt6Gui.so.6 \ 
         libQt6PositioningQuick.so.6 \


### PR DESCRIPTION
Reverts mavlink/qgroundcontrol#11273
Just curious if it passes without this, ultimately won't matter switching to cmake