### PR TITLE
Qmake: Android fixes

### DIFF
--- a/QGCCommon.pri
+++ b/QGCCommon.pri
@@ -242,7 +242,7 @@ AndroidBuild {
 
     message(Android version info: $${ANDROID_VERSION_CODE} bitness:$${ANDROID_VERSION_BITNESS} major:$${MAJOR_VERSION} minor:$${MINOR_VERSION} patch:$${PATCH_VERSION} dev:$${DEV_VERSION})
 
-    ANDROID_VERSION_NAME    = APP_VERSION_STR
+    ANDROID_VERSION_NAME    = $${APP_VERSION_STR}
 
     QMAKE_LFLAGS += -Wl,-Bsymbolic
 }

--- a/android.pri
+++ b/android.pri
@@ -74,44 +74,44 @@ contains(DEFINES, NO_SERIAL_LINK) {
 
 # OTHER_FILES makes the specified files be visible in Qt Creator for editing
 
-exists($$PWD/custom/android/AndroidManifest.xml) {
-    OTHER_FILES += \
-    $$PWD/custom/android/AndroidManifest.xml
+exists($$ANDROID_PACKAGE_CUSTOM_SOURCE_DIR/AndroidManifest.xml) {
+    DISTFILES += \
+        $$ANDROID_PACKAGE_CUSTOM_SOURCE_DIR/AndroidManifest.xml
 } else {
-    OTHER_FILES += \
-    $$PWD/android/AndroidManifest.xml
+    DISTFILES += \
+        $$ANDROID_PACKAGE_QGC_SOURCE_DIR/AndroidManifest.xml
 }
 
-OTHER_FILES += \
-    $$PWD/android/res/xml/device_filter.xml \
-    $$PWD/android/src/com/hoho/android/usbserial/driver/CdcAcmSerialDriver.java \
-    $$PWD/android/src/com/hoho/android/usbserial/driver/CommonUsbSerialDriver.java \
-    $$PWD/android/src/com/hoho/android/usbserial/driver/Cp2102SerialDriver.java \
-    $$PWD/android/src/com/hoho/android/usbserial/driver/FtdiSerialDriver.java \
-    $$PWD/android/src/com/hoho/android/usbserial/driver/ProlificSerialDriver.java \
-    $$PWD/android/src/com/hoho/android/usbserial/driver/UsbId.java \
-    $$PWD/android/src/com/hoho/android/usbserial/driver/UsbSerialDriver.java \
-    $$PWD/android/src/com/hoho/android/usbserial/driver/UsbSerialProber.java \
-    $$PWD/android/src/com/hoho/android/usbserial/driver/UsbSerialRuntimeException.java \
-    $$PWD/android/src/org/mavlink/qgroundcontrol/QGCActivity.java \
-    $$PWD/android/src/org/mavlink/qgroundcontrol/UsbIoManager.java \
-    $$PWD/android/src/org/freedesktop/gstreamer/androidmedia/GstAhcCallback.java \
-    $$PWD/android/src/org/freedesktop/gstreamer/androidmedia/GstAhsCallback.java \
-    $$PWD/android/src/org/freedesktop/gstreamer/androidmedia/GstAmcOnFrameAvailableListener.java
-
 DISTFILES += \
-    $$PWD/android/gradle/wrapper/gradle-wrapper.jar \
-    $$PWD/android/gradlew \
-    $$PWD/android/res/values/libs.xml \
-    $$PWD/android/build.gradle \
-    $$PWD/android/gradle/wrapper/gradle-wrapper.properties \
-    $$PWD/android/gradlew.bat
+    $$ANDROID_PACKAGE_QGC_SOURCE_DIR/build.gradle \
+    $$ANDROID_PACKAGE_QGC_SOURCE_DIR/gradle/wrapper/gradle-wrapper.jar \
+    $$ANDROID_PACKAGE_QGC_SOURCE_DIR/gradle/wrapper/gradle-wrapper.properties \
+    $$ANDROID_PACKAGE_QGC_SOURCE_DIR/gradlew \
+    $$ANDROID_PACKAGE_QGC_SOURCE_DIR/gradlew.bat \
+    $$ANDROID_PACKAGE_QGC_SOURCE_DIR/res/values/libs.xml \
+    $$ANDROID_PACKAGE_QGC_SOURCE_DIR/res/xml/device_filter.xml \
+    $$ANDROID_PACKAGE_QGC_SOURCE_DIR/res/xml/network_security_config.xml \
+    $$ANDROID_PACKAGE_QGC_SOURCE_DIR/res/xml/qtprovider_paths.xml \
+    $$ANDROID_PACKAGE_QGC_SOURCE_DIR/src/com/hoho/android/usbserial/driver/CdcAcmSerialDriver.java \
+    $$ANDROID_PACKAGE_QGC_SOURCE_DIR/src/com/hoho/android/usbserial/driver/CommonUsbSerialDriver.java \
+    $$ANDROID_PACKAGE_QGC_SOURCE_DIR/src/com/hoho/android/usbserial/driver/Cp2102SerialDriver.java \
+    $$ANDROID_PACKAGE_QGC_SOURCE_DIR/src/com/hoho/android/usbserial/driver/FtdiSerialDriver.java \
+    $$ANDROID_PACKAGE_QGC_SOURCE_DIR/src/com/hoho/android/usbserial/driver/ProlificSerialDriver.java \
+    $$ANDROID_PACKAGE_QGC_SOURCE_DIR/src/com/hoho/android/usbserial/driver/UsbId.java \
+    $$ANDROID_PACKAGE_QGC_SOURCE_DIR/src/com/hoho/android/usbserial/driver/UsbSerialDriver.java \
+    $$ANDROID_PACKAGE_QGC_SOURCE_DIR/src/com/hoho/android/usbserial/driver/UsbSerialProber.java \
+    $$ANDROID_PACKAGE_QGC_SOURCE_DIR/src/com/hoho/android/usbserial/driver/UsbSerialRuntimeException.java \
+    $$ANDROID_PACKAGE_QGC_SOURCE_DIR/src/org/freedesktop/gstreamer/androidmedia/GstAhcCallback.java \
+    $$ANDROID_PACKAGE_QGC_SOURCE_DIR/src/org/freedesktop/gstreamer/androidmedia/GstAhsCallback.java \
+    $$ANDROID_PACKAGE_QGC_SOURCE_DIR/src/org/freedesktop/gstreamer/androidmedia/GstAmcOnFrameAvailableListener.java \
+    $$ANDROID_PACKAGE_QGC_SOURCE_DIR/src/org/mavlink/qgroundcontrol/QGCActivity.java \
+    $$ANDROID_PACKAGE_QGC_SOURCE_DIR/src/org/mavlink/qgroundcontrol/UsbIoManager.java
 
 SOURCES += \
-    $$PWD/android/src/AndroidInterface.cc
+    $$ANDROID_PACKAGE_QGC_SOURCE_DIR/src/AndroidInterface.cc
 
 HEADERS += \
-    $$PWD/android/src/AndroidInterface.h
+    $$ANDROID_PACKAGE_QGC_SOURCE_DIR/src/AndroidInterface.h
 
 INCLUDEPATH += \
-    $$PWD/android/src
+    $$ANDROID_PACKAGE_QGC_SOURCE_DIR/src

--- a/qgroundcontrol.pro
+++ b/qgroundcontrol.pro
@@ -1205,7 +1205,6 @@ AndroidBuild {
     contains (CONFIG, DISABLE_BUILTIN_ANDROID) {
         message("Skipping builtin support for Android")
     } else {
-        QT -= core-private
         include(android.pri)
     }
 }


### PR DESCRIPTION
I pulled out the qmake changes from #11233 and put them here. This is mostly for anybody doing custom builds so this is probably the last qmake change before switching to cmake entirely.

- ANDROID_VERSION_NAME was being set to the literal string "APP_VERSION_STR"
- Use existing directory variables to clarify file locations
- core-private is still used in qtandroidserialport

Edit: This one isn't all that important