### PR TITLE
AudioOutput: Improvements

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -134,7 +134,6 @@ find_package(Qt6
         Sql
         Svg
         Test
-        TextToSpeech
         Widgets
         Xml
     OPTIONAL_COMPONENTS

--- a/src/AnalyzeView/CMakeLists.txt
+++ b/src/AnalyzeView/CMakeLists.txt
@@ -35,7 +35,6 @@ target_link_libraries(AnalyzeView
 	PUBLIC
 		Qt6::Charts
 		Qt6::Location
-		Qt6::TextToSpeech
 		Qt6::Widgets
 )
 

--- a/src/Audio/CMakeLists.txt
+++ b/src/Audio/CMakeLists.txt
@@ -1,4 +1,4 @@
-find_package(Qt6 REQUIRED COMPONENTS Core TextToSpeech Widgets)
+find_package(Qt6 REQUIRED COMPONENTS Core Qml TextToSpeech)
 
 qt_add_library(Audio STATIC
 	AudioOutput.cc
@@ -7,10 +7,10 @@ qt_add_library(Audio STATIC
 
 target_link_libraries(Audio
 	PRIVATE
-		Qt6::Widgets
-		qgc
+		Utilities
 	PUBLIC
 		Qt6::Core
+		Qt6::QmlIntegration
 		Qt6::TextToSpeech
 )
 

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -46,6 +46,7 @@ add_subdirectory(Viewer3D)
 #######################################################
 target_link_libraries(qgc
 	PRIVATE
+		Audio
 	PUBLIC
 		Qt6::QuickControls2
 		Qt6::QuickWidgets
@@ -56,7 +57,6 @@ target_link_libraries(qgc
 		AirLink
 		AnalyzeView
 		api
-		Audio
 		AutoPilotPlugins
 		Camera
 		comm

--- a/src/QGCApplication.cc
+++ b/src/QGCApplication.cc
@@ -105,7 +105,7 @@
 #include "RemoteIDManager.h"
 #include "CustomAction.h"
 #include "CustomActionManager.h"
-
+#include "AudioOutput.h"
 #include "CityMapGeometry.h"
 #include "Viewer3DQmlBackend.h"
 #include "Viewer3DQmlVariableTypes.h"
@@ -521,6 +521,11 @@ void QGCApplication::_initCommon()
 bool QGCApplication::_initForNormalAppBoot()
 {
     QSettings settings;
+
+    ( void ) connect( toolbox()->settingsManager()->appSettings()->audioMuted(), &Fact::valueChanged, AudioOutput::instance(), []( QVariant value )
+    {
+        AudioOutput::instance()->setMuted( value.toBool() );
+    });
 
     _qmlAppEngine = toolbox()->corePlugin()->createQmlApplicationEngine(this);
     toolbox()->corePlugin()->createRootWindow(_qmlAppEngine);

--- a/src/QGCApplication.h
+++ b/src/QGCApplication.h
@@ -28,7 +28,6 @@
 #include "FirmwarePluginManager.h"
 #include "MultiVehicleManager.h"
 #include "JoystickManager.h"
-#include "AudioOutput.h"
 #include "UASMessageHandler.h"
 #include "FactSystem.h"
 

--- a/src/QGCToolbox.cc
+++ b/src/QGCToolbox.cc
@@ -10,7 +10,6 @@
 
 #include "FactSystem.h"
 #include "FirmwarePluginManager.h"
-#include "AudioOutput.h"
 #ifndef __mobile__
 #include "GPSManager.h"
 #endif
@@ -64,7 +63,6 @@ QGCToolbox::QGCToolbox(QGCApplication* app)
 
     //-- Scan and load plugins
     _scanAndLoadPlugins(app);
-    _audioOutput            = new AudioOutput               (app, this);
     _factSystem             = new FactSystem                (app, this);
     _firmwarePluginManager  = new FirmwarePluginManager     (app, this);
 #ifndef __mobile__
@@ -100,7 +98,6 @@ void QGCToolbox::setChildToolboxes(void)
     _settingsManager->setToolbox(this);
 
     _corePlugin->setToolbox(this);
-    _audioOutput->setToolbox(this);
     _factSystem->setToolbox(this);
     _firmwarePluginManager->setToolbox(this);
 #ifndef __mobile__

--- a/src/QGCToolbox.h
+++ b/src/QGCToolbox.h
@@ -15,7 +15,6 @@
 
 class FactSystem;
 class FirmwarePluginManager;
-class AudioOutput;
 class GPSManager;
 class JoystickManager;
 class FollowMe;
@@ -48,7 +47,6 @@ public:
     QGCToolbox(QGCApplication* app);
 
     FirmwarePluginManager*      firmwarePluginManager   () { return _firmwarePluginManager; }
-    AudioOutput*                audioOutput             () { return _audioOutput; }
     JoystickManager*            joystickManager         () { return _joystickManager; }
     LinkManager*                linkManager             () { return _linkManager; }
     MAVLinkProtocol*            mavlinkProtocol         () { return _mavlinkProtocol; }
@@ -79,7 +77,6 @@ private:
     void _scanAndLoadPlugins(QGCApplication *app);
 
 
-    AudioOutput*                _audioOutput            = nullptr;
     FactSystem*                 _factSystem             = nullptr;
     FirmwarePluginManager*      _firmwarePluginManager  = nullptr;
 #ifndef __mobile__

--- a/src/QmlControls/CMakeLists.txt
+++ b/src/QmlControls/CMakeLists.txt
@@ -148,7 +148,6 @@ target_link_libraries(QmlControls
 	PUBLIC
 		Qt6::Concurrent
 		Qt6::Location
-		Qt6::TextToSpeech
 		Qt6::Widgets
 )
 

--- a/src/Vehicle/CMakeLists.txt
+++ b/src/Vehicle/CMakeLists.txt
@@ -97,11 +97,12 @@ qt_add_library(Vehicle STATIC
 
 target_link_libraries(Vehicle
 	PRIVATE
+		Audio
 		compression
 	PUBLIC
 		qgc
 		libevents
-                Actuators
+		Actuators
 )
 
 target_include_directories(Vehicle PUBLIC ${CMAKE_CURRENT_SOURCE_DIR})

--- a/src/Vehicle/Vehicle.cc
+++ b/src/Vehicle/Vehicle.cc
@@ -50,6 +50,7 @@
 #include "MockLink.h"
 #endif
 #include "RemoteIDManager.h"
+#include "AudioOutput.h"
 
 QGC_LOGGING_CATEGORY(VehicleLog, "VehicleLog")
 
@@ -929,7 +930,7 @@ void Vehicle::_chunkedStatusTextCompleted(uint8_t compId)
 
     if (readAloud) {
         if (!skipSpoken) {
-            qgcApp()->toolbox()->audioOutput()->say(messageText);
+            _say(messageText);
         }
     }
     emit textMessageReceived(id(), compId, severity, messageText.toHtmlEscaped(), "");
@@ -2510,7 +2511,7 @@ void Vehicle::virtualTabletJoystickValue(double roll, double pitch, double yaw, 
 
 void Vehicle::_say(const QString& text)
 {
-    _toolbox->audioOutput()->say(text.toLower());
+    AudioOutput::instance()->say(text.toLower());
 }
 
 bool Vehicle::airship() const
@@ -4365,7 +4366,7 @@ void Vehicle::_handleFenceStatus(const mavlink_message_t& message)
                     break;
             }
 
-            qgcApp()->toolbox()->audioOutput()->say(breachTypeStr + " " + tr("fence breached"));
+            _say(breachTypeStr + " " + tr("fence breached"));
         }
     } else {
         lastUpdate = now;

--- a/test/Audio/CMakeLists.txt
+++ b/test/Audio/CMakeLists.txt
@@ -5,8 +5,9 @@ qt_add_library(AudioTest
 )
 
 target_link_libraries(AudioTest
+        PRIVATE
+                Audio
 	PUBLIC
-		qgc
 		qgcunittest
 )
 


### PR DESCRIPTION
Modernizes AudioOutput with new functionality from [Qt6.6](https://doc-snapshots.qt.io/qt6-6.6/whatsnew66.html#qt-texttospeech-module).

- The queue is now handled internally in the QTextToSpeech object.
- Now available to use from QML.
- No longer dependent on QGCApplication making it an isolated utility available everywhere with a singleton using static methods.
- Inherits from QTextToSpeech making all [functions](https://doc.qt.io/qt-6/qtexttospeech.html) available.
- Makes use of a QHash for faster translations
- Uses InvokeMethod for thread safety