### PR TITLE
Audio Output: Fix Mute

### DIFF
--- a/src/Audio/AudioOutput.h
+++ b/src/Audio/AudioOutput.h
@@ -36,7 +36,7 @@ public:
     bool isMuted() const;
     void setMuted( bool enable );
 
-    void say( const QString& text, AudioOutput::TextMods textMods = TextMod::None );
+    void read( const QString& text, AudioOutput::TextMods textMods = TextMod::None );
 
     static AudioOutput* instance();
     static bool getMillisecondString( const QString& string, QString& match, int& number );
@@ -47,7 +47,7 @@ signals:
 
 private:
     qsizetype m_textQueueSize = 0;
-    bool m_lastMuted = false;
+    bool m_muted = false;
     static const QHash<QString, QString> s_textHash;
 };
 Q_DECLARE_OPERATORS_FOR_FLAGS( AudioOutput::TextMods )

--- a/src/QGCApplication.cc
+++ b/src/QGCApplication.cc
@@ -526,6 +526,7 @@ bool QGCApplication::_initForNormalAppBoot()
     {
         AudioOutput::instance()->setMuted( value.toBool() );
     });
+    AudioOutput::instance()->setMuted( toolbox()->settingsManager()->appSettings()->audioMuted()->rawValue().toBool() );
 
     _qmlAppEngine = toolbox()->corePlugin()->createQmlApplicationEngine(this);
     toolbox()->corePlugin()->createRootWindow(_qmlAppEngine);

--- a/src/Vehicle/Vehicle.cc
+++ b/src/Vehicle/Vehicle.cc
@@ -2511,7 +2511,7 @@ void Vehicle::virtualTabletJoystickValue(double roll, double pitch, double yaw, 
 
 void Vehicle::_say(const QString& text)
 {
-    AudioOutput::instance()->say(text.toLower());
+    AudioOutput::instance()->read(text.toLower());
 }
 
 bool Vehicle::airship() const


### PR DESCRIPTION
Apparently some engines don't support volume changes so mute has to be handled independently from volume, which makes more sense anyways.
Also fixes initial mute value and renamed say to read to avoid shadowing QTextToSpeech's say function