### PR TITLE
CI: Add iOS Workflow

### DIFF
--- a/.github/workflows/ios.yml
+++ b/.github/workflows/ios.yml
@@ -1,0 +1,93 @@
+name: iOS
+
+on:
+  workflow_dispatch:
+
+jobs:
+  build:
+    runs-on: macos-13
+
+    strategy:
+      matrix:
+        BuildType: [Debug, Release]
+
+    defaults:
+      run:
+        shell: bash
+
+    env:
+      ARTIFACT: QGroundControl.app
+      QT_VERSION: 6.6.3
+
+    steps:
+      - name: Checkout repo
+        uses: actions/checkout@v4
+        with:
+          submodules: recursive
+          fetch-tags: true
+
+      - uses: actions/checkout@v4
+        with:
+          repository: jurplel/install-qt-action
+          ref: master
+          path: install-qt-action
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: npm
+          cache-dependency-path: install-qt-action/action/
+
+      - name: Build jurplel/install-qt-action
+        run: |
+          cd install-qt-action/action/
+          npm ci || npm install
+          npm run build
+        shell: bash
+
+      - name: Install Qt6 for MacOS
+        uses: ./install-qt-action/action/
+        with:
+          version: ${{ env.QT_VERSION }}
+          host: mac
+          target: desktop
+          dir: ${{ runner.temp }}
+          modules: qtcharts qtlocation qtpositioning qtspeech qt5compat qtmultimedia qtserialport qtimageformats qtshadertools qtconnectivity qtquick3d
+          cache: ${{ github.ref == 'refs/heads/master' && github.event_name != 'pull_request' }}
+          tools: 'tools_cmake'
+
+      - name: Install Qt6 for iOS
+        uses: ./install-qt-action/action/
+        with:
+          version: ${{ env.QT_VERSION }}
+          host: mac
+          target: ios
+          dir: ${{ runner.temp }}
+          extra: --autodesktop
+          modules: qtcharts qtlocation qtpositioning qtspeech qt5compat qtmultimedia qtimageformats qtshadertools qtconnectivity qtquick3d
+          cache: ${{ github.ref == 'refs/heads/master' && github.event_name != 'pull_request' }}
+
+      - name: Install Dependencies
+        run: |
+          brew update
+          brew install cmake ninja
+
+      - name: Create build directory
+        run:  mkdir ${{ runner.temp }}/shadow_build_dir
+
+      - name: Configure
+        working-directory: ${{ runner.temp }}/shadow_build_dir
+        run: ${{ env.QT_ROOT_DIR }}/bin/qt-cmake -S ${{ github.workspace }} -B . -G Ninja
+              -DCMAKE_BUILD_TYPE=${{ matrix.BuildType }}
+              -DQT_HOST_PATH="${{ env.QT_ROOT_DIR }}/../macos"
+              -DQGC_STABLE_BUILD=${{ github.ref_type == 'tag' || contains(github.ref, 'Stable') && 'ON' || 'OFF' }}
+
+      - name: Build
+        working-directory: ${{ runner.temp }}/shadow_build_dir
+        run: cmake --build . --target all --config ${{ matrix.BuildType }}
+
+      - name: Save APK
+        uses: actions/upload-artifact@v4
+        with:
+          name: ${{ env.ARTIFACT }}
+          path: ${{ runner.temp }}/shadow_build_dir/*.app


### PR DESCRIPTION
#11295
Adds iOS release build to CI workflows and uploads .app file.
This required updating the bluetooth link interface and expanding the NO_SERIAL_LINK checks since SerialPort isn't available for iOS. I replaced some mobile checks with NO_SERIAL_LINK when it made sense to, as technically android can use a serial gps if the serial implementation is reworked a bit (which I am working on), but since most androids only have a single serial port you could only do so if you don't already have a comm link via serial.

Edit: I just noticed #10250 and this is something that could be done in the future after my android serial updates

Edit2: Adjusted to just be CI related