### PR TITLE
CI: Remove Debug Workflows

### DIFF
--- a/.github/workflows/android.yml
+++ b/.github/workflows/android.yml
@@ -19,7 +19,7 @@ jobs:
 
     strategy:
       matrix:
-        BuildType: [Debug, Release]
+        BuildType: [Release]
 
     defaults:
       run:

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -21,7 +21,7 @@ jobs:
 
     strategy:
       matrix:
-        BuildType: [Debug, Release]
+        BuildType: [Release]
 
     defaults:
       run:


### PR DESCRIPTION
Removes Android and Windows debug workflows because there are a lot of builds that take a while. I left macos alone until @DonLakeFlyer finishes the macos cmake conversion.

Edit: Maybe it's better to only run debug versions on PRs and both on commits?