### PR TITLE
CMake: Cleanup Compression Linking

### DIFF
--- a/libs/CMakeLists.txt
+++ b/libs/CMakeLists.txt
@@ -1,39 +1,3 @@
 add_subdirectory(libevents)
 add_subdirectory(qtandroidserialport)
 add_subdirectory(qmlglsink)
-
-qt_add_library(xz STATIC
-    xz-embedded/linux/include/linux/xz.h
-    xz-embedded/linux/include/linux/decompress/unxz.h
-    # xz-embedded/linux/lib/decompress_unxz.c
-    xz-embedded/linux/lib/xz/xz_crc32.c
-    xz-embedded/linux/lib/xz/xz_crc64.c
-    xz-embedded/linux/lib/xz/xz_dec_bcj.c
-    xz-embedded/linux/lib/xz/xz_dec_lzma2.c
-    xz-embedded/linux/lib/xz/xz_dec_stream.c
-    # xz-embedded/linux/lib/xz/xz_dec_syms.c
-    # xz-embedded/linux/lib/xz/xz_dec_test.c
-    xz-embedded/linux/lib/xz/xz_lzma2.h
-    xz-embedded/linux/lib/xz/xz_private.h
-    xz-embedded/linux/lib/xz/xz_stream.h
-    # xz-embedded/userspace/boottest.c
-    # xz-embedded/userspace/buftest.c
-    # xz-embedded/userspace/bytetest.c
-    xz-embedded/userspace/xz_config.h
-    # xz-embedded/userspace/xzminidec.c
-)
-
-target_include_directories(xz
-    PUBLIC
-        xz-embedded/linux/include
-        xz-embedded/linux/include/linux
-        xz-embedded/linux/include/linux/decompress
-        xz-embedded/linux/lib/xz
-        xz-embedded/userspace
-)
-
-target_compile_definitions(xz
-    PUBLIC
-        XZ_DEC_ANY_CHECK
-        XZ_USE_CRC64
-)

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -60,7 +60,6 @@ target_link_libraries(qgc
 		AutoPilotPlugins
 		Camera
 		comm
-		compression
 		FactSystem
 		FirmwarePlugin
 		FlightMap

--- a/src/Camera/CMakeLists.txt
+++ b/src/Camera/CMakeLists.txt
@@ -14,6 +14,8 @@ qt_add_library(Camera STATIC
 )
 
 target_link_libraries(Camera
+	PRIVATE
+		Compression
 	PUBLIC
 		qgc
 )

--- a/src/Compression/CMakeLists.txt
+++ b/src/Compression/CMakeLists.txt
@@ -1,15 +1,18 @@
 find_package(Qt6 REQUIRED COMPONENTS Core)
 
-qt_add_library(compression STATIC
+qt_add_library(Compression STATIC
 	QGCLZMA.cc
 	QGCLZMA.h
 	QGCZlib.cc
 	QGCZlib.h
 )
 
+############### ZLIB
+
 set(ZLIB_BUILD_EXAMPLES OFF CACHE INTERNAL "")
 set(BUILD_SHARED_LIBS OFF CACHE INTERNAL "")
 set(SKIP_INSTALL_FILES ON CACHE INTERNAL "")
+set(SKIP_INSTALL_LIBRARIES ON CACHE INTERNAL "")
 
 include(FetchContent)
 FetchContent_Declare(zlib
@@ -19,12 +22,45 @@ FetchContent_Declare(zlib
 )
 FetchContent_MakeAvailable(zlib)
 
-target_link_libraries(compression
+############### XZ
+
+set(XZ_EMBEDDED_DIR ${CMAKE_SOURCE_DIR}/libs/xz-embedded)
+
+qt_add_library(xz STATIC
+    ${XZ_EMBEDDED_DIR}/linux/include/linux/xz.h
+    ${XZ_EMBEDDED_DIR}/linux/lib/xz/xz_crc32.c
+    ${XZ_EMBEDDED_DIR}/linux/lib/xz/xz_crc64.c
+    ${XZ_EMBEDDED_DIR}/linux/lib/xz/xz_dec_lzma2.c
+    ${XZ_EMBEDDED_DIR}/linux/lib/xz/xz_dec_stream.c
+    ${XZ_EMBEDDED_DIR}/linux/lib/xz/xz_lzma2.h
+    ${XZ_EMBEDDED_DIR}/linux/lib/xz/xz_private.h
+    ${XZ_EMBEDDED_DIR}/linux/lib/xz/xz_stream.h
+    ${XZ_EMBEDDED_DIR}/userspace/xz_config.h
+)
+
+target_include_directories(xz
+	PUBLIC
+        ${XZ_EMBEDDED_DIR}/linux/include/linux
+    PRIVATE
+        ${XZ_EMBEDDED_DIR}/linux/lib/xz
+        ${XZ_EMBEDDED_DIR}/userspace
+)
+
+target_compile_definitions(xz
+    PRIVATE
+        XZ_DEC_ANY_CHECK
+    PUBLIC
+        XZ_USE_CRC64
+)
+
+###############
+
+target_link_libraries(Compression
 	PRIVATE
-        zlib
+        zlibstatic
         xz
 	PUBLIC
 		Qt6::Core
 )
 
-target_include_directories(compression PUBLIC ${CMAKE_CURRENT_SOURCE_DIR})
+target_include_directories(Compression PUBLIC ${CMAKE_CURRENT_SOURCE_DIR})

--- a/src/Compression/QGCLZMA.cc
+++ b/src/Compression/QGCLZMA.cc
@@ -9,8 +9,8 @@
 
 #include "QGCLZMA.h"
 
-#include <QFile>
-#include <QtDebug>
+#include <QtCore/QFile>
+#include <QtCore/QtDebug>
 
 #include <mutex>
 

--- a/src/Compression/QGCZlib.cc
+++ b/src/Compression/QGCZlib.cc
@@ -9,8 +9,8 @@
 
 #include "QGCZlib.h"
 
-#include <QFile>
-#include <QtDebug>
+#include <QtCore/QFile>
+#include <QtCore/QtDebug>
 
 #include "zlib.h"
 

--- a/src/Compression/QGCZlib.h
+++ b/src/Compression/QGCZlib.h
@@ -9,7 +9,7 @@
 
 #pragma once
 
-#include <QString>
+#include <QtCore/QString>
 
 class QGCZlib
 {

--- a/src/Vehicle/CMakeLists.txt
+++ b/src/Vehicle/CMakeLists.txt
@@ -98,7 +98,7 @@ qt_add_library(Vehicle STATIC
 target_link_libraries(Vehicle
 	PRIVATE
 		Audio
-		compression
+		Compression
 	PUBLIC
 		qgc
 		libevents

--- a/src/VehicleSetup/CMakeLists.txt
+++ b/src/VehicleSetup/CMakeLists.txt
@@ -31,7 +31,7 @@ add_custom_target(VehicleSetupQml
 
 target_link_libraries(VehicleSetup
 	PRIVATE
-		compression
+		Compression
 	PUBLIC
 		qgc
 )


### PR DESCRIPTION
- Moves xz lib integration to Compression.
- Removes a couple unneeded files from the xz qt lib.
- Changes some public linking to private.
- Only link Compression lib where needed.
- Link to zlibstatic
- Capitalize Compression for lib name
- Dont install shared libs