### PR TITLE
CI: Allow Docs Deploy on Manual Runs

### DIFF
--- a/.github/workflows/docs_deploy.yml
+++ b/.github/workflows/docs_deploy.yml
@@ -44,7 +44,7 @@ jobs:
           retention-days: 1
 
   deploy:
-    if: ${{ github.event_name == 'push' || (github.event_name == 'pull_request' && github.event.pull_request.merged) }}
+    if: ${{ github.event_name == 'push' || github.event_name == 'workflow_dispatch' || (github.event_name == 'pull_request' && github.event.pull_request.merged) }}
     needs: build
     runs-on: ubuntu-latest
 


### PR DESCRIPTION
The docs workflow needs to be rerun after fixing it. This allows us to do so without making a commit that changes the docs directory.