### PR TITLE
CMake: Make Some Libs Private

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -276,7 +276,6 @@ add_compile_definitions(
     APP_VERSION_STR="${APP_VERSION_STR}"
 )
 
-add_subdirectory(libs)
 add_subdirectory(src)
 target_link_libraries(${PROJECT_NAME} PRIVATE qgc)
 if(QGC_BUILD_TESTING)

--- a/libs/CMakeLists.txt
+++ b/libs/CMakeLists.txt
@@ -1,3 +1,0 @@
-add_subdirectory(libevents)
-add_subdirectory(qtandroidserialport)
-add_subdirectory(qmlglsink)

--- a/libs/qmlglsink/CMakeLists.txt
+++ b/libs/qmlglsink/CMakeLists.txt
@@ -208,9 +208,6 @@ if(QGC_ENABLE_VIDEOSTREAMING)
 	        PRIVATE
 	            HAVE_QT_QPA_HEADER
 	            QT_QPA_HEADER=<QtGui/qpa/qplatformnativeinterface.h>
-	        PUBLIC
-	            QGC_GST_STREAMING
-	            QGC_CMAKE_GST
 	    )
 	    if(LINUX)
 	    	target_compile_definitions(qmlglsink PRIVATE HAVE_QT_X11)

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -93,7 +93,7 @@ if(ANDROID)
 
     target_link_libraries(qgc
         PUBLIC
-            qtandroidserialport
+            Qt6::CorePrivate
     )
 
     target_include_directories(qgc PUBLIC ${CMAKE_SOURCE_DIR}/android/src)

--- a/src/Joystick/CMakeLists.txt
+++ b/src/Joystick/CMakeLists.txt
@@ -27,7 +27,7 @@ else()
 				JoystickSDL.h
 		)
     	target_link_libraries(Joystick
-    		PUBLIC
+    		PRIVATE
     			SDL2::SDL2
     	)
 	endif()

--- a/src/Vehicle/CMakeLists.txt
+++ b/src/Vehicle/CMakeLists.txt
@@ -95,6 +95,8 @@ qt_add_library(Vehicle STATIC
 	VehicleHygrometerFactGroup.h
 )
 
+add_subdirectory(${CMAKE_SOURCE_DIR}/libs/libevents libevents.build)
+
 target_link_libraries(Vehicle
 	PRIVATE
 		Audio

--- a/src/VideoReceiver/CMakeLists.txt
+++ b/src/VideoReceiver/CMakeLists.txt
@@ -1,4 +1,4 @@
-find_package(Qt6 REQUIRED COMPONENTS Core Multimedia)
+find_package(Qt6 REQUIRED COMPONENTS Core)
 
 qt_add_library(VideoReceiver STATIC
     VideoReceiver.h
@@ -6,15 +6,16 @@ qt_add_library(VideoReceiver STATIC
 
 target_link_libraries(VideoReceiver
     PUBLIC
-        Qt6::Multimedia
-        Qt6::OpenGL
-        Qt6::Quick
-        Utilities
+        Qt6::Core
 )
 
 target_include_directories(VideoReceiver PUBLIC ${CMAKE_CURRENT_SOURCE_DIR})
 
+add_subdirectory(${CMAKE_SOURCE_DIR}/libs/qmlglsink qmlglsink.build)
+
 if(GST_FOUND)
+    find_package(Qt6 REQUIRED COMPONENTS Quick)
+
     target_sources(VideoReceiver
         PRIVATE
             gstqgc.c
@@ -26,10 +27,15 @@ if(GST_FOUND)
     )
 
     target_link_libraries(VideoReceiver
-        PUBLIC
+        PRIVATE
             qmlglsink
+            Utilities
+        PUBLIC
+            Qt6::Quick
             Settings
     )
+
+    target_compile_definitions(VideoReceiver PUBLIC QGC_GST_STREAMING)
 
     if(CMAKE_BUILD_TYPE STREQUAL "Release")
         target_compile_definitions(VideoReceiver PRIVATE QGC_INSTALL_RELEASE)

--- a/src/VideoReceiver/GStreamer.cc
+++ b/src/VideoReceiver/GStreamer.cc
@@ -14,7 +14,7 @@
  *   @author Gus Grubba <gus@auterion.com>
  */
 
-#include <QDebug>
+#include <QtCore/QDebug>
 
 #include "GStreamer.h"
 #include "GstVideoReceiver.h"

--- a/src/VideoReceiver/GStreamer.h
+++ b/src/VideoReceiver/GStreamer.h
@@ -1,13 +1,14 @@
 #pragma once
 
 #include <QtCore/QLoggingCategory>
-#include <QQuickItem>
+#include <QtQuick/QQuickItem>
 
 #include "Settings/VideoDecoderOptions.h"
-#include "VideoReceiver.h"
 
 Q_DECLARE_LOGGING_CATEGORY(GStreamerLog)
 Q_DECLARE_LOGGING_CATEGORY(GStreamerAPILog)
+
+class VideoReceiver;
 
 class GStreamer {
 public:

--- a/src/VideoReceiver/GstVideoReceiver.cc
+++ b/src/VideoReceiver/GstVideoReceiver.cc
@@ -17,9 +17,9 @@
 #include "GstVideoReceiver.h"
 #include "QGCLoggingCategory.h"
 
-#include <QDebug>
-#include <QUrl>
-#include <QDateTime>
+#include <QtCore/QDebug>
+#include <QtCore/QUrl>
+#include <QtCore/QDateTime>
 
 QGC_LOGGING_CATEGORY(VideoReceiverLog, "VideoReceiverLog")
 

--- a/src/VideoReceiver/GstVideoReceiver.h
+++ b/src/VideoReceiver/GstVideoReceiver.h
@@ -16,11 +16,11 @@
 #pragma once
 
 #include <QtCore/QLoggingCategory>
-#include <QTimer>
-#include <QThread>
-#include <QWaitCondition>
-#include <QMutex>
-#include <QQueue>
+#include <QtCore/QTimer>
+#include <QtCore/QThread>
+#include <QtCore/QWaitCondition>
+#include <QtCore/QMutex>
+#include <QtCore/QQueue>
 
 #include "VideoReceiver.h"
 

--- a/src/VideoReceiver/VideoReceiver.h
+++ b/src/VideoReceiver/VideoReceiver.h
@@ -15,8 +15,8 @@
 
 #pragma once
 
-#include <QObject>
-#include <QSize>
+#include <QtCore/QObject>
+#include <QtCore/QSize>
 
 class VideoReceiver : public QObject
 {

--- a/src/comm/CMakeLists.txt
+++ b/src/comm/CMakeLists.txt
@@ -52,6 +52,8 @@ target_link_libraries(comm
 )
 
 if(ANDROID)
+	add_subdirectory(${CMAKE_SOURCE_DIR}/libs/qtandroidserialport qtandroidserialport.build)
+
     target_link_libraries(comm PUBLIC qtandroidserialport)
 else()
 	target_link_libraries(comm PUBLIC Qt6::SerialPort)


### PR DESCRIPTION
SDL isn't needed outside of the joysticks lib
qmlglsink isn't needed outside videoreceiver
Import the external dependencies in the libs where needed