### PR TITLE
BatteryIndicator remove duplicate qml Component and add flag for battery percentage availability

### DIFF
--- a/src/ui/toolbar/BatteryIndicator.qml
+++ b/src/ui/toolbar/BatteryIndicator.qml
@@ -159,12 +159,13 @@ Item {
         id: batteryValuesAvailableComponent
 
         QtObject {
-            property bool functionAvailable:        battery.function.rawValue !== MAVLink.MAV_BATTERY_FUNCTION_UNKNOWN
-            property bool temperatureAvailable:     !isNaN(battery.temperature.rawValue)
-            property bool currentAvailable:         !isNaN(battery.current.rawValue)
-            property bool mahConsumedAvailable:     !isNaN(battery.mahConsumed.rawValue)
-            property bool timeRemainingAvailable:   !isNaN(battery.timeRemaining.rawValue)
-            property bool chargeStateAvailable:     battery.chargeState.rawValue !== MAVLink.MAV_BATTERY_CHARGE_STATE_UNDEFINED
+            property bool functionAvailable:         battery.function.rawValue !== MAVLink.MAV_BATTERY_FUNCTION_UNKNOWN
+            property bool temperatureAvailable:      !isNaN(battery.temperature.rawValue)
+            property bool currentAvailable:          !isNaN(battery.current.rawValue)
+            property bool mahConsumedAvailable:      !isNaN(battery.mahConsumed.rawValue)
+            property bool timeRemainingAvailable:    !isNaN(battery.timeRemaining.rawValue)
+            property bool percentRemainingAvailable: !isNaN(battery.percentRemaining.rawValue)
+            property bool chargeStateAvailable:      battery.chargeState.rawValue !== MAVLink.MAV_BATTERY_CHARGE_STATE_UNDEFINED
         }
     }
 
@@ -222,6 +223,7 @@ Item {
                     LabelledLabel {
                         label:      qsTr("Remaining")
                         labelText:  object.percentRemaining.valueString + " " + object.percentRemaining.units
+                        visible:    batteryValuesAvailable.percentRemainingAvailable
                     }
 
                     LabelledLabel {

--- a/src/ui/toolbar/BatteryIndicator.qml
+++ b/src/ui/toolbar/BatteryIndicator.qml
@@ -156,20 +156,6 @@ Item {
     }
 
     Component {
-        id: batteryValuesAvailableComponent
-
-        QtObject {
-            property bool functionAvailable:         battery.function.rawValue !== MAVLink.MAV_BATTERY_FUNCTION_UNKNOWN
-            property bool temperatureAvailable:      !isNaN(battery.temperature.rawValue)
-            property bool currentAvailable:          !isNaN(battery.current.rawValue)
-            property bool mahConsumedAvailable:      !isNaN(battery.mahConsumed.rawValue)
-            property bool timeRemainingAvailable:    !isNaN(battery.timeRemaining.rawValue)
-            property bool percentRemainingAvailable: !isNaN(battery.percentRemaining.rawValue)
-            property bool chargeStateAvailable:      battery.chargeState.rawValue !== MAVLink.MAV_BATTERY_CHARGE_STATE_UNDEFINED
-        }
-    }
-
-    Component {
         id: batteryContentComponent
 
         ColumnLayout {
@@ -181,13 +167,14 @@ Item {
                 id: batteryValuesAvailableComponent
 
                 QtObject {
-                    property bool functionAvailable:        battery.function.rawValue !== MAVLink.MAV_BATTERY_FUNCTION_UNKNOWN
-                    property bool showFunction:             functionAvailable && battery.function.rawValue != MAVLink.MAV_BATTERY_FUNCTION_ALL
-                    property bool temperatureAvailable:     !isNaN(battery.temperature.rawValue)
-                    property bool currentAvailable:         !isNaN(battery.current.rawValue)
-                    property bool mahConsumedAvailable:     !isNaN(battery.mahConsumed.rawValue)
-                    property bool timeRemainingAvailable:   !isNaN(battery.timeRemaining.rawValue)
-                    property bool chargeStateAvailable:     battery.chargeState.rawValue !== MAVLink.MAV_BATTERY_CHARGE_STATE_UNDEFINED
+                    property bool functionAvailable:         battery.function.rawValue !== MAVLink.MAV_BATTERY_FUNCTION_UNKNOWN
+                    property bool showFunction:              functionAvailable && battery.function.rawValue != MAVLink.MAV_BATTERY_FUNCTION_ALL
+                    property bool temperatureAvailable:      !isNaN(battery.temperature.rawValue)
+                    property bool currentAvailable:          !isNaN(battery.current.rawValue)
+                    property bool mahConsumedAvailable:      !isNaN(battery.mahConsumed.rawValue)
+                    property bool timeRemainingAvailable:    !isNaN(battery.timeRemaining.rawValue)
+                    property bool percentRemainingAvailable: !isNaN(battery.percentRemaining.rawValue)
+                    property bool chargeStateAvailable:      battery.chargeState.rawValue !== MAVLink.MAV_BATTERY_CHARGE_STATE_UNDEFINED
                 }
             }
 


### PR DESCRIPTION
BatteryIndicator remove duplicate qml Component and add flag for battery percentage availability

Description
-----------
This is a small change that adds the check for the availability of the percentRemaining data of the battery, since it can be unavailable in some autopilot configurations. Since all other values that can be unavailable have the check of the availability on the BatteryIndicator.qml page, same logic is applied for the percentRemaining Fact. In addition, this pull request removes the duplicate batteryValuesAvailableComponent element of type Component, containing all boolean values that define which data is to be displayed. 

Test Steps
-----------
Connect autopilot sending the -1 value of the field _battery_remaining_ in Mavlink BATTERY_STATUS message and check if data is displayed in the battery popup.

Checklist:
----------
- [x] [Review Contribution Guidelines](https://github.com/mavlink/qgroundcontrol/blob/master/.github/CONTRIBUTING.md).
- [x] [Review Code of Conduct](https://github.com/mavlink/qgroundcontrol/blob/master/.github/CODE_OF_CONDUCT.md).
- [x] I have tested my changes.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.