### PR TITLE
CI: Cleanup Workflows

### DIFF
--- a/.github/workflows/android.yml
+++ b/.github/workflows/android.yml
@@ -41,16 +41,6 @@ jobs:
           submodules: recursive
           fetch-tags: true
 
-      - name: Set up Cache
-        uses: hendrikmuhs/ccache-action@v1.2
-        if: github.ref == 'refs/heads/master' && github.event_name != 'pull_request'
-        with:
-          create-symlink: true
-          key: ${{ runner.os }}-Android-${{ matrix.BuildType }}
-          restore-keys: ${{ runner.os }}-Android-${{ matrix.BuildType }}
-          max-size: 1G
-          append-timestamp: false
-
       - name: Setup Java Environment
         uses: actions/setup-java@v4
         with:
@@ -85,6 +75,7 @@ jobs:
           dir: ${{ runner.temp }}
           modules: qtcharts qtlocation qtpositioning qtspeech qt5compat qtmultimedia qtserialport qtimageformats qtshadertools qtconnectivity qtquick3d
           cache: ${{ github.ref == 'refs/heads/master' && github.event_name != 'pull_request' }}
+          tools: 'tools_cmake tools_ninja'
 
       - name: Install Qt6 for Android (armv7)
         uses: ./install-qt-action/action/

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -38,16 +38,6 @@ jobs:
           submodules: recursive
           fetch-tags: true
 
-      - name: Set up Cache
-        uses: hendrikmuhs/ccache-action@v1.2
-        if: github.ref == 'refs/heads/master' && github.event_name != 'pull_request'
-        with:
-          create-symlink: true
-          key: ${{ runner.os }}-${{ matrix.BuildType }}
-          restore-keys: ${{ runner.os }}-${{ matrix.BuildType }}
-          max-size: 1G
-          append-timestamp: false
-
       - name: Install Qt
         uses: jurplel/install-qt-action@v3
         with:
@@ -59,6 +49,7 @@ jobs:
           modules: qtcharts qtlocation qtpositioning qtspeech qt5compat qtmultimedia qtserialport qtimageformats qtshadertools qtconnectivity qtquick3d
           setup-python: true
           cache: ${{ github.ref == 'refs/heads/master' && github.event_name != 'pull_request' }}
+          tools: 'tools_cmake tools_ninja'
 
       - name: Install Dependencies
         run:  |

--- a/.github/workflows/macos_debug.yml
+++ b/.github/workflows/macos_debug.yml
@@ -1,84 +1,92 @@
-name: MacOS Debug and Tests
+name: MacOS Debug
 
 on:
   push:
     branches:
-      - 'master'
+      - master
       - 'Stable*'
     tags:
       - 'v*'
     paths-ignore:
       - 'docs/**'
+      - 'android/**'
   pull_request:
-    branches:
-    - '*'
     paths-ignore:
       - 'docs/**'
-
-defaults:
-  run:
-    shell: bash
-
-env:
-  SOURCE_DIR:   ${{ github.workspace }}
-  QT_VERSION:   6.6.*
-  ARTIFACT:     QGroundControl.dmg
-  BUILD_TYPE:   ${{ fromJSON('["DailyBuild", "StableBuild"]')[ github.ref_type == 'tag' || contains(github.ref, 'Stable_' ) ] }}
+      - 'android/**'
 
 jobs:
   build:
-    runs-on:  macos-latest
+    runs-on: macos-latest
+
+    strategy:
+      matrix:
+        BuildType: [Debug]
+
+    defaults:
+      run:
+        shell: bash
+
+    env:
+      QT_VERSION: 6.6.3
+      ARTIFACT: QGroundControl.dmg
 
     steps:
       - name: Checkout repo
         uses: actions/checkout@v4
         with:
           submodules: recursive
+          fetch-tags: true
 
-      - name: ccache
+      - name: Set Up Cache
         uses: hendrikmuhs/ccache-action@v1.2
+        if: github.ref == 'refs/heads/master' && github.event_name != 'pull_request'
         with:
           create-symlink: true
-          key: ${{ runner.os }}-Debug
-          restore-keys: ${{ runner.os }}-Debug
-          max-size: "2G"
+          key: ${{ runner.os }}-${{ matrix.BuildType }}
+          restore-keys: ${{ runner.os }}-${{ matrix.BuildType }}
+          max-size: 2G
           append-timestamp: false
-
-      - name: Get all tags for correct version determination
-        working-directory:  ${{ github.workspace }}
-        run: |
-          git fetch --all --tags -f --depth 1
 
       - name: Install Qt
         uses: jurplel/install-qt-action@v3
         with:
-          version:      ${{ env.QT_VERSION }}
-          aqtversion:   ==3.1.*
-          host:         mac
-          target:       desktop
-          dir:          ${{ runner.temp }}
-          modules:      qtcharts qtlocation qtpositioning qtspeech qt5compat qtmultimedia qtserialport qtimageformats qtshadertools qtconnectivity qtquick3d
-          setup-python: false
-          cache: true
+          version: ${{ env.QT_VERSION }}
+          aqtversion: ==3.1.*
+          host: mac
+          target: desktop
+          dir: ${{ runner.temp }}
+          modules: qtcharts qtlocation qtpositioning qtspeech qt5compat qtmultimedia qtserialport qtimageformats qtshadertools qtconnectivity qtquick3d
+          setup-python: true
+          cache: ${{ github.ref == 'refs/heads/master' && github.event_name != 'pull_request' }}
+          tools: 'tools_cmake tools_ninja'
 
       - name: Install Dependencies
         run: brew install ninja SDL2
 
-      - name: Setup GStreamer
-        uses: blinemedical/setup-gstreamer@v1
-        with:
-          version: 1.18.6
+      - name: Install Gstreamer
+        env:
+          GST_VERSION: 1.18.6
+        run: |
+            wget --quiet https://gstreamer.freedesktop.org/data/pkg/osx/${{ env.GST_VERSION }}/gstreamer-1.0-devel-${{ env.GST_VERSION }}-x86_64.pkg
+            wget --quiet https://gstreamer.freedesktop.org/data/pkg/osx/${{ env.GST_VERSION }}/gstreamer-1.0-${{ env.GST_VERSION }}-x86_64.pkg
+            for package in *.pkg ;
+              do sudo installer -verbose -pkg "$package" -target /
+            done
 
       - name: Create build directory
         run:  mkdir ${{ runner.temp }}/shadow_build_dir
 
+      - name: Configure
+        working-directory: ${{ runner.temp }}/shadow_build_dir
+        run: cmake -S ${{ github.workspace }} -B . -G Ninja
+              -DCMAKE_BUILD_TYPE=${{ matrix.BuildType }}
+              -DQGC_STABLE_BUILD=${{ github.ref_type == 'tag' || contains(github.ref, 'Stable') && 'ON' || 'OFF' }}
+
       - name: Build
         working-directory: ${{ runner.temp }}/shadow_build_dir
-        run:  |
-              cmake -S ${{ env.SOURCE_DIR }} -B ${{ runner.temp }}/shadow_build_dir/ -G Ninja -DCMAKE_BUILD_TYPE=Debug
-              cmake --build ${{ runner.temp }}/shadow_build_dir/ --target all --config Debug
-              cmake --install ${{ runner.temp }}/shadow_build_dir
+        run: cmake --build . --target all --config ${{ matrix.BuildType }}
 
-      # - name: Run unit tests
-      #  working-directory: ${{ runner.temp }}/shadow_build_dir
-      #  run: open ${{ runner.temp }}/shadow_build_dir/staging/QGroundControl.app --args --unittest
+      - name: Install
+        working-directory: ${{ runner.temp }}/shadow_build_dir
+        run: cmake --install . --config ${{ matrix.BuildType }}

--- a/.github/workflows/macos_release.yml
+++ b/.github/workflows/macos_release.yml
@@ -3,69 +3,65 @@ name: MacOS Release
 on:
   push:
     branches:
-      - 'master'
+      - master
       - 'Stable*'
     tags:
       - 'v*'
     paths-ignore:
       - 'docs/**'
+      - 'android/**'
   pull_request:
-    branches:
-    - '*'
     paths-ignore:
       - 'docs/**'
-
-defaults:
-  run:
-    shell: bash
-
-env:
-  SOURCE_DIR:   ${{ github.workspace }}
-  QT_VERSION:   6.6.*
-  ARTIFACT:     QGroundControl.dmg
-  BUILD_TYPE:   ${{ fromJSON('["DailyBuild", "StableBuild"]')[ github.ref_type == 'tag' || contains(github.ref, 'Stable_' ) ] }}
+      - 'android/**'
 
 jobs:
   build:
     runs-on:  macos-latest
+
+    defaults:
+      run:
+        shell: bash
+
+    env:
+      QT_VERSION: 6.6.3
+      ARTIFACT: QGroundControl.dmg
 
     steps:
       - name: Checkout repo
         uses: actions/checkout@v4
         with:
           submodules: recursive
+          fetch-tags: true
 
-      - name: ccache
+      - name: Set Up Cache
         uses: hendrikmuhs/ccache-action@v1.2
+        if: github.ref == 'refs/heads/master' && github.event_name != 'pull_request'
         with:
           create-symlink: true
           key: ${{ runner.os }}-Release
           restore-keys: ${{ runner.os }}-Release
-          max-size: "2G"
+          max-size: 2G
           append-timestamp: false
-        if: github.ref == 'refs/heads/master' && github.event_name != 'pull_request'
-
-      - name: Get all tags for correct version determination
-        working-directory:  ${{ github.workspace }}
-        run: |
-          git fetch --all --tags -f --depth 1
 
       - name: Install Qt
         uses: jurplel/install-qt-action@v3
         with:
-          version:      ${{ env.QT_VERSION }}
-          aqtversion:   ==3.1.*
-          host:         mac
-          target:       desktop
-          dir:          ${{ runner.temp }}
-          modules:      qtcharts qtlocation qtpositioning qtspeech qt5compat qtmultimedia qtserialport qtimageformats qtshadertools qtconnectivity qtquick3d
-          setup-python: false
-          cache: true
+          version: ${{ env.QT_VERSION }}
+          aqtversion: ==3.1.*
+          host: mac
+          target: desktop
+          dir: ${{ runner.temp }}
+          modules: qtcharts qtlocation qtpositioning qtspeech qt5compat qtmultimedia qtserialport qtimageformats qtshadertools qtconnectivity qtquick3d
+          setup-python: true
+          cache: ${{ github.ref == 'refs/heads/master' && github.event_name != 'pull_request' }}
 
       - name: Install Gstreamer
+        env:
+          GST_VERSION: 1.18.6
         run: |
-            wget https://gstreamer.freedesktop.org/data/pkg/osx/1.18.6/gstreamer-1.0-devel-1.18.6-x86_64.pkg
-            wget https://gstreamer.freedesktop.org/data/pkg/osx/1.18.6/gstreamer-1.0-1.18.6-x86_64.pkg
+            wget https://gstreamer.freedesktop.org/data/pkg/osx/${{ env.GST_VERSION }}/gstreamer-1.0-devel-${{ env.GST_VERSION }}-x86_64.pkg
+            wget https://gstreamer.freedesktop.org/data/pkg/osx/${{ env.GST_VERSION }}/gstreamer-1.0-${{ env.GST_VERSION }}-x86_64.pkg
             for package in *.pkg ;
               do sudo installer -verbose -pkg "$package" -target /
             done
@@ -75,10 +71,12 @@ jobs:
 
       - name: Build
         working-directory: ${{ runner.temp }}/shadow_build_dir
-        run:  |
-              export JOBS=$((`sysctl -n hw.ncpu`+1))
-              qmake -r ${SOURCE_DIR}/qgroundcontrol.pro CONFIG+=installer CONFIG+=${BUILD_TYPE}
-              make -j$JOBS
+        env:
+          BUILD_TYPE: ${{ fromJSON('["DailyBuild", "StableBuild"]')[ github.ref_type == 'tag' || contains(github.ref, 'Stable' ) ] }}
+        run: |
+            export JOBS=$((`sysctl -n hw.ncpu`+1))
+            qmake -r ${{ github.workspace }}/qgroundcontrol.pro CONFIG+=installer CONFIG+=${BUILD_TYPE}
+            make -j$JOBS
 
       - name: Upload Build File
         uses: ./.github/actions/upload

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -50,15 +50,16 @@ jobs:
           modules: qtcharts qtlocation qtpositioning qtspeech qt5compat qtmultimedia qtserialport qtimageformats qtshadertools qtconnectivity qtquick3d
           setup-python: true
           cache: ${{ github.ref == 'refs/heads/master' && github.event_name != 'pull_request' }}
+          tools: 'tools_cmake tools_ninja'
+
+      - name: Install Dependencies
+        run: choco install --no-progress cmake ninja -y
 
       - name: Install Gstreamer
         uses: blinemedical/setup-gstreamer@v1
         with:
           version: 1.18.6
         # run: choco install --no-progress gstreamer gstreamer-devel --version=1.18.6
-
-      - name: Install Dependencies
-        run: choco install --no-progress ninja -y
 
       - name: Set up Visual Studio shell
         uses: ilammy/msvc-dev-cmd@v1


### PR DESCRIPTION
There is not enough cache space to use ccache for everything so just use it for MacOS which takes the longest.
Also temporarily bring MacOS builds up to date until the full cmake conversion.