### PR TITLE
Cleanup source includes

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -296,7 +296,15 @@ add_compile_definitions(
 )
 
 add_subdirectory(src)
-target_link_libraries(${PROJECT_NAME} PRIVATE qgc)
+target_link_libraries(${PROJECT_NAME}
+    PRIVATE
+        Qt6::Core
+        Qt6::Gui
+        Qt6::Qml
+        Qt6::Quick
+        Qt6::QuickControls2
+        qgc
+)
 if(QGC_BUILD_TESTING)
     add_subdirectory(test)
     target_link_libraries(${PROJECT_NAME} PRIVATE qgctest)

--- a/src/ADSB/ADSBVehicle.cc
+++ b/src/ADSB/ADSBVehicle.cc
@@ -11,8 +11,9 @@
 #include "QGCLoggingCategory.h"
 #include "QGC.h"
 
-#include <QDebug>
-#include <QtMath>
+#include <QtCore/QtNumeric>
+
+QGC_LOGGING_CATEGORY(ADSBVehicleManagerLog, "ADSBVehicleManagerLog")
 
 ADSBVehicle::ADSBVehicle(const ADSBVehicleInfo_t & vehicleInfo, QObject* parent)
     : QObject       (parent)

--- a/src/ADSB/ADSBVehicle.h
+++ b/src/ADSB/ADSBVehicle.h
@@ -9,9 +9,12 @@
 
 #pragma once
 
-#include <QObject>
-#include <QGeoCoordinate>
-#include <QElapsedTimer>
+#include <QtCore/QObject>
+#include <QtCore/QElapsedTimer>
+#include <QtCore/QLoggingCategory>
+#include <QtPositioning/QGeoCoordinate>
+
+Q_DECLARE_LOGGING_CATEGORY(ADSBVehicleManagerLog)
 
 class ADSBVehicle : public QObject
 {

--- a/src/ADSB/ADSBVehicleManager.cc
+++ b/src/ADSB/ADSBVehicleManager.cc
@@ -8,12 +8,12 @@
  ****************************************************************************/
 
 #include "ADSBVehicleManager.h"
-#include "QGCLoggingCategory.h"
 #include "QGCApplication.h"
 #include "SettingsManager.h"
 #include "ADSBVehicleManagerSettings.h"
 
-#include <QDebug>
+#include <QtNetwork/QTcpSocket>
+#include <QtPositioning/QGeoCoordinate>
 
 ADSBVehicleManager::ADSBVehicleManager(QGCApplication* app, QGCToolbox* toolbox)
     : QGCTool(app, toolbox)
@@ -27,7 +27,7 @@ void ADSBVehicleManager::setToolbox(QGCToolbox* toolbox)
     _adsbVehicleCleanupTimer.setSingleShot(false);
     _adsbVehicleCleanupTimer.start(1000);
 
-    ADSBVehicleManagerSettings* settings = qgcApp()->toolbox()->settingsManager()->adsbVehicleManagerSettings();
+    ADSBVehicleManagerSettings* settings = toolbox->settingsManager()->adsbVehicleManagerSettings();
     if (settings->adsbServerConnectEnabled()->rawValue().toBool()) {
         _tcpLink = new ADSBTCPLink(settings->adsbServerHostAddress()->rawValue().toString(), settings->adsbServerPort()->rawValue().toInt(), this);
         connect(_tcpLink, &ADSBTCPLink::adsbVehicleUpdate,  this, &ADSBVehicleManager::adsbVehicleUpdate,   Qt::QueuedConnection);

--- a/src/ADSB/ADSBVehicleManager.h
+++ b/src/ADSB/ADSBVehicleManager.h
@@ -13,12 +13,11 @@
 #include "QmlObjectListModel.h"
 #include "ADSBVehicle.h"
 
-#include <QThread>
-#include <QTcpSocket>
-#include <QTimer>
-#include <QGeoCoordinate>
+#include <QtCore/QThread>
+#include <QtCore/QTimer>
 
 class ADSBVehicleManagerSettings;
+class QTcpSocket;
 
 class ADSBTCPLink : public QThread
 {

--- a/src/ADSB/CMakeLists.txt
+++ b/src/ADSB/CMakeLists.txt
@@ -8,11 +8,13 @@ qt_add_library(ADSB STATIC
 )
 
 target_link_libraries(ADSB
+	PRIVATE
+		Qt6::Network
+		Settings
+		Utilities
 	PUBLIC
 		Qt6::Core
-		Qt6::Network
 		Qt6::Positioning
-		comm
 		qgc
 		QmlControls
 )

--- a/src/AirLink/AirLinkManager.cc
+++ b/src/AirLink/AirLinkManager.cc
@@ -13,8 +13,7 @@
 #include "LinkManager.h"
 #include "SettingsManager.h"
 
-#include <QSettings>
-#include <QDebug>
+#include <QtCore/QSettings>
 #include <QtCore/QJsonDocument>
 #include <QtCore/QJsonArray>
 

--- a/src/AirLink/AirLinkManager.h
+++ b/src/AirLink/AirLinkManager.h
@@ -11,10 +11,7 @@
 
 #include "QGCToolbox.h"
 
-#include <QTimer>
-#include <QTime>
-#include <QNetworkReply>
-#include <QMutex>
+#include <QtNetwork/QNetworkReply>
 
 class AppSettings;
 class QGCApplication;

--- a/src/AirLink/AirlinkLink.cc
+++ b/src/AirLink/AirlinkLink.cc
@@ -1,9 +1,12 @@
 #include "AirlinkLink.h"
-#include <QGC.h>
-#include <QGCApplication.h>
-#include <AppSettings.h>
-#include <SettingsManager.h>
-#include <AirLinkManager.h>
+#include "AirLinkManager.h"
+#include "QGCApplication.h"
+#include "AppSettings.h"
+#include "SettingsManager.h"
+#include "MAVLinkProtocol.h"
+
+#include <QtNetwork/QUdpSocket>
+
 
 AirlinkConfiguration::AirlinkConfiguration(const QString &name) : UDPConfiguration(name)
 {

--- a/src/AirLink/AirlinkLink.h
+++ b/src/AirLink/AirlinkLink.h
@@ -1,8 +1,7 @@
-#ifndef AIRLINKLINK_H
-#define AIRLINKLINK_H
+#pragma once
 
-#include <UDPLink.h>
-#include <QMutex>
+#include "UDPLink.h"
+#include <QtCore/QMutex>
 
 class AirlinkConfiguration : public UDPConfiguration
 {
@@ -78,5 +77,3 @@ private:
     /// Access this varible only with _mutex locked
     bool _needToConnect {false};
 };
-
-#endif // AIRLINKLINK_H

--- a/src/AirLink/CMakeLists.txt
+++ b/src/AirLink/CMakeLists.txt
@@ -2,8 +2,8 @@ find_package(Qt6 REQUIRED COMPONENTS Core)
 
 qt_add_library(AirLink STATIC)
 
-option(QGC_AIRLINK_DISABLED "Enable airlink" OFF)
-if(NOT ${QGC_AIRLINK_DISABLED})
+option(QGC_AIRLINK_DISABLED "Enable airlink" ON)
+if(NOT QGC_AIRLINK_DISABLED)
     find_package(Qt6 COMPONENTS Network REQUIRED)
 
     target_sources(AirLink
@@ -20,11 +20,13 @@ if(NOT ${QGC_AIRLINK_DISABLED})
     )
 
     target_link_libraries(AirLink
+        PRIVATE
+            api
+            Settings
         PUBLIC
             Qt6::Core
             Qt6::Network
-            FactSystem
-            Settings
+            comm
             qgc
     )
 

--- a/src/AnalyzeView/CMakeLists.txt
+++ b/src/AnalyzeView/CMakeLists.txt
@@ -1,4 +1,4 @@
-find_package(Qt6 REQUIRED COMPONENTS Core Charts Location Widgets)
+find_package(Qt6 REQUIRED COMPONENTS Core Charts Gui Qml Widgets)
 
 qt_add_library(AnalyzeView STATIC
 	ExifParser.cc
@@ -30,13 +30,19 @@ add_custom_target(AnalyzeViewQml
 
 target_link_libraries(AnalyzeView
 	PRIVATE
-		qgc
-
-	PUBLIC
 		Qt6::Charts
-		Qt6::Location
-		Qt6::Widgets
+        Qt6::Gui
+		Qt6::Qml
+        Qt6::Widgets
+		FactSystem
+		qgc
+		QGCLocation
+		Settings
+		Utilities
+		Vehicle
+	PUBLIC
+		Qt6::Core
+		QmlControls
 )
 
-target_include_directories(AnalyzeView INTERFACE ${CMAKE_CURRENT_SOURCE_DIR})
-
+target_include_directories(AnalyzeView PUBLIC ${CMAKE_CURRENT_SOURCE_DIR})

--- a/src/AnalyzeView/ExifParser.cc
+++ b/src/AnalyzeView/ExifParser.cc
@@ -1,7 +1,7 @@
 #include "ExifParser.h"
-#include <math.h>
-#include <QtEndian>
-#include <QDateTime>
+#include <QtCore/QtEndian>
+#include <QtCore/QDateTime>
+
 
 ExifParser::ExifParser()
 {

--- a/src/AnalyzeView/ExifParser.h
+++ b/src/AnalyzeView/ExifParser.h
@@ -1,10 +1,7 @@
-#ifndef EXIFPARSER_H
-#define EXIFPARSER_H
-
-#include <QGeoCoordinate>
-#include <QDebug>
+#pragma once
 
 #include "GeoTagController.h"
+#include <QtCore/QByteArray>
 
 class ExifParser
 {
@@ -14,5 +11,3 @@ public:
     double readTime(QByteArray& buf);
     bool write(QByteArray& buf, GeoTagWorker::cameraFeedbackPacket& geotag);
 };
-
-#endif // EXIFPARSER_H

--- a/src/AnalyzeView/GeoTagController.cc
+++ b/src/AnalyzeView/GeoTagController.cc
@@ -8,15 +8,13 @@
  ****************************************************************************/
 
 #include "GeoTagController.h"
-#include "QGCLoggingCategory.h"
-#include <QtEndian>
-#include <QDebug>
-#include <QDir>
-#include <QUrl>
-
 #include "ExifParser.h"
 #include "ULogParser.h"
 #include "PX4LogParser.h"
+#include "QGCLoggingCategory.h"
+#include <QtCore/QtEndian>
+#include <QtCore/QDir>
+#include <QtCore/QUrl>
 
 static const char* kTagged = "/TAGGED";
 

--- a/src/AnalyzeView/GeoTagController.h
+++ b/src/AnalyzeView/GeoTagController.h
@@ -7,16 +7,12 @@
  *
  ****************************************************************************/
 
-#ifndef GeoTagController_H
-#define GeoTagController_H
+#pragma once
 
-#include <QObject>
-#include <QString>
-#include <QThread>
-#include <QFileInfoList>
-#include <QElapsedTimer>
-#include <QDebug>
-#include <QGeoCoordinate>
+#include <QtCore/QObject>
+#include <QtCore/QString>
+#include <QtCore/QThread>
+#include <QtCore/QFileInfoList>
 
 class GeoTagWorker : public QThread
 {
@@ -125,5 +121,3 @@ private:
 
     GeoTagWorker        _worker;
 };
-
-#endif

--- a/src/AnalyzeView/LogDownloadController.cc
+++ b/src/AnalyzeView/LogDownloadController.cc
@@ -14,15 +14,13 @@
 #include "QGCToolbox.h"
 #include "QGCMapEngine.h"
 #include "ParameterManager.h"
+#include "FactSystem.h"
 #include "Vehicle.h"
 #include "SettingsManager.h"
 #include "QGCLoggingCategory.h"
 
-#include <QDebug>
-#include <QSettings>
-#include <QUrl>
-#include <QBitArray>
-#include <QtCore/qmath.h>
+#include <QtCore/QBitArray>
+#include <QtCore/QtMath>
 
 #define kTimeOutMilliseconds 500
 #define kGUIRateMilliseconds 17

--- a/src/AnalyzeView/LogDownloadController.h
+++ b/src/AnalyzeView/LogDownloadController.h
@@ -8,17 +8,15 @@
  ****************************************************************************/
 
 
-#ifndef LogDownloadController_H
-#define LogDownloadController_H
-
-#include <QObject>
-#include <QTimer>
-#include <QAbstractListModel>
-#include <QLocale>
-#include <QElapsedTimer>
+#pragma once
 
 #include "AutoPilotPlugin.h"
 #include "QmlObjectListModel.h"
+
+#include <QtCore/QObject>
+#include <QtCore/QTimer>
+#include <QtCore/QLoggingCategory>
+#include <QtCore/QDateTime>
 
 class  MultiVehicleManager;
 class  Vehicle;
@@ -135,5 +133,3 @@ private:
     int                 _apmOneBased;
     QString             _downloadPath;
 };
-
-#endif

--- a/src/AnalyzeView/MAVLinkInspectorController.cc
+++ b/src/AnalyzeView/MAVLinkInspectorController.cc
@@ -10,6 +10,7 @@
 #include "MAVLinkInspectorController.h"
 #include "QGCApplication.h"
 #include "MultiVehicleManager.h"
+#include "Vehicle.h"
 #include "QGC.h"
 #include "QGCLoggingCategory.h"
 

--- a/src/AnalyzeView/MAVLinkInspectorController.h
+++ b/src/AnalyzeView/MAVLinkInspectorController.h
@@ -13,13 +13,15 @@
 
 #pragma once
 
-#include "Vehicle.h"
-
-#include <QObject>
-#include <QString>
-#include <QDebug>
-#include <QVariantList>
-#include <QAbstractSeries>
+#include "QGCMAVLink.h"
+#include "QmlObjectListModel.h"
+#include <QtCore/QObject>
+#include <QtCore/QString>
+#include <QtCore/QTimer>
+#include <QtCore/QDateTime>
+#include <QtCore/QVariantList>
+#include <QtCore/QLoggingCategory>
+#include <QtCharts/QAbstractSeries>
 
 Q_DECLARE_LOGGING_CATEGORY(MAVLinkInspectorLog)
 
@@ -27,6 +29,8 @@ class QGCMAVLinkMessage;
 class QGCMAVLinkSystem;
 class MAVLinkChartController;
 class MAVLinkInspectorController;
+class Vehicle;
+class LinkInterface;
 
 //-----------------------------------------------------------------------------
 /// MAVLink message field

--- a/src/AnalyzeView/MavlinkConsoleController.cc
+++ b/src/AnalyzeView/MavlinkConsoleController.cc
@@ -9,8 +9,11 @@
 
 #include "MavlinkConsoleController.h"
 #include "QGCApplication.h"
+#include "QGCToolbox.h"
+#include "MultiVehicleManager.h"
 
-#include <QClipboard>
+#include <QtWidgets/QApplication>
+#include <QtGui/QClipboard>
 
 MavlinkConsoleController::MavlinkConsoleController()
     : QStringListModel()

--- a/src/AnalyzeView/MavlinkConsoleController.h
+++ b/src/AnalyzeView/MavlinkConsoleController.h
@@ -10,10 +10,10 @@
 #pragma once
 
 #include "QGCPalette.h"
-#include <QObject>
-#include <QString>
-#include <QMetaObject>
-#include <QStringListModel>
+#include <QtCore/QObject>
+#include <QtCore/QString>
+#include <QtCore/QMetaObject>
+#include <QtCore/QStringListModel>
 
 // Fordward decls
 class Vehicle;

--- a/src/AnalyzeView/PX4LogParser.cc
+++ b/src/AnalyzeView/PX4LogParser.cc
@@ -1,7 +1,5 @@
 #include "PX4LogParser.h"
-#include <math.h>
-#include <QtEndian>
-#include <QDateTime>
+#include <QtCore/QtEndian>
 
 PX4LogParser::PX4LogParser()
 {

--- a/src/AnalyzeView/PX4LogParser.h
+++ b/src/AnalyzeView/PX4LogParser.h
@@ -1,10 +1,7 @@
-#ifndef PX4LOGPARSER_H
-#define PX4LOGPARSER_H
-
-#include <QGeoCoordinate>
-#include <QDebug>
+#pragma once
 
 #include "GeoTagController.h"
+#include <QtCore/QByteArray>
 
 class PX4LogParser
 {
@@ -16,5 +13,3 @@ public:
 private:
 
 };
-
-#endif // PX4LOGPARSER_H

--- a/src/AnalyzeView/ULogParser.cc
+++ b/src/AnalyzeView/ULogParser.cc
@@ -1,6 +1,4 @@
 #include "ULogParser.h"
-#include <math.h>
-#include <QDateTime>
 
 ULogParser::ULogParser()
 {

--- a/src/AnalyzeView/ULogParser.h
+++ b/src/AnalyzeView/ULogParser.h
@@ -1,11 +1,12 @@
-#ifndef ULOGPARSER_H
-#define ULOGPARSER_H
+#pragma once
 
-#include <QGeoCoordinate>
-#include <QDebug>
-#include <QCoreApplication>
 
 #include "GeoTagController.h"
+#include <QtCore/QByteArray>
+#include <QtCore/QMap>
+#include <QtCore/QString>
+#include <QtCore/QCoreApplication>
+
 
 #define ULOG_FILE_HEADER_LEN 16
 
@@ -68,5 +69,3 @@ private:
 	};
 
 };
-
-#endif // ULOGPARSER_H

--- a/src/AutoPilotPlugins/APM/APMAirframeComponent.cc
+++ b/src/AutoPilotPlugins/APM/APMAirframeComponent.cc
@@ -9,6 +9,8 @@
 
 #include "APMAirframeComponent.h"
 #include "ParameterManager.h"
+#include "FactSystem.h"
+#include "Vehicle.h"
 
 const char* APMAirframeComponent::_frameClassParam = "FRAME_CLASS";
 

--- a/src/AutoPilotPlugins/APM/APMAirframeComponent.h
+++ b/src/AutoPilotPlugins/APM/APMAirframeComponent.h
@@ -13,6 +13,9 @@
 
 #include "VehicleComponent.h"
 
+class AutoPilotPlugin;
+class Fact;
+
 class APMAirframeComponent : public VehicleComponent
 {
     Q_OBJECT

--- a/src/AutoPilotPlugins/APM/APMAirframeComponentController.cc
+++ b/src/AutoPilotPlugins/APM/APMAirframeComponentController.cc
@@ -12,6 +12,7 @@
 #include "QGCApplication.h"
 #include "QGCFileDownload.h"
 #include "ParameterManager.h"
+#include "FactSystem.h"
 #include "ArduCopterFirmwarePlugin.h"
 #include "ArduRoverFirmwarePlugin.h"
 

--- a/src/AutoPilotPlugins/APM/APMFlightModesComponentController.cc
+++ b/src/AutoPilotPlugins/APM/APMFlightModesComponentController.cc
@@ -9,8 +9,10 @@
 
 
 #include "APMFlightModesComponentController.h"
+#include "FactSystem.h"
 
-#include <QVariant>
+#include <QtCore/QVariant>
+#include <QtQml/QtQml>
 
 bool APMFlightModesComponentController::_typeRegistered = false;
 

--- a/src/AutoPilotPlugins/APM/APMMotorComponent.cc
+++ b/src/AutoPilotPlugins/APM/APMMotorComponent.cc
@@ -8,6 +8,8 @@
  ****************************************************************************/
 
 #include "APMMotorComponent.h"
+#include "AutoPilotPlugin.h"
+#include "Vehicle.h"
 
 APMMotorComponent::APMMotorComponent(Vehicle* vehicle, AutoPilotPlugin* autopilot, QObject* parent) :
     MotorComponent(vehicle, autopilot, parent),

--- a/src/AutoPilotPlugins/APM/APMMotorComponent.h
+++ b/src/AutoPilotPlugins/APM/APMMotorComponent.h
@@ -13,6 +13,8 @@
 
 #include "MotorComponent.h"
 
+class AutoPilotPlugin;
+
 class APMMotorComponent : public MotorComponent
 {
     Q_OBJECT

--- a/src/AutoPilotPlugins/APM/APMRadioComponent.cc
+++ b/src/AutoPilotPlugins/APM/APMRadioComponent.cc
@@ -11,6 +11,7 @@
 #include "APMRadioComponent.h"
 #include "APMAutoPilotPlugin.h"
 #include "ParameterManager.h"
+#include "FactSystem.h"
 
 APMRadioComponent::APMRadioComponent(Vehicle* vehicle, AutoPilotPlugin* autopilot, QObject* parent) :
     VehicleComponent(vehicle, autopilot, parent),

--- a/src/AutoPilotPlugins/APM/APMSensorsComponent.cc
+++ b/src/AutoPilotPlugins/APM/APMSensorsComponent.cc
@@ -11,6 +11,7 @@
 #include "APMSensorsComponent.h"
 #include "APMAutoPilotPlugin.h"
 #include "ParameterManager.h"
+#include "FactSystem.h"
 
 // These two list must be kept in sync
 

--- a/src/AutoPilotPlugins/APM/APMSensorsComponentController.cc
+++ b/src/AutoPilotPlugins/APM/APMSensorsComponentController.cc
@@ -12,8 +12,10 @@
 #include "QGCApplication.h"
 #include "APMAutoPilotPlugin.h"
 #include "ParameterManager.h"
+#include "FactSystem.h"
 #include "QGCLoggingCategory.h"
-#include <QVariant>
+
+#include <QtCore/QVariant>
 
 QGC_LOGGING_CATEGORY(APMSensorsComponentControllerLog, "APMSensorsComponentControllerLog")
 QGC_LOGGING_CATEGORY(APMSensorsComponentControllerVerboseLog, "APMSensorsComponentControllerVerboseLog")

--- a/src/AutoPilotPlugins/APM/APMSensorsComponentController.h
+++ b/src/AutoPilotPlugins/APM/APMSensorsComponentController.h
@@ -9,11 +9,12 @@
 
 #pragma once
 
-#include <QObject>
-#include <QtCore/QLoggingCategory>
-
 #include "FactPanelController.h"
 #include "APMSensorsComponent.h"
+
+#include <QtQuick/QQuickItem>
+#include <QtCore/QObject>
+#include <QtCore/QLoggingCategory>
 
 Q_DECLARE_LOGGING_CATEGORY(APMSensorsComponentControllerLog)
 Q_DECLARE_LOGGING_CATEGORY(APMSensorsComponentControllerVerboseLog)

--- a/src/AutoPilotPlugins/AutoPilotPlugin.cc
+++ b/src/AutoPilotPlugins/AutoPilotPlugin.cc
@@ -14,6 +14,8 @@
 #include "AutoPilotPlugin.h"
 #include "QGCApplication.h"
 #include "FirmwarePlugin.h"
+#include "Vehicle.h"
+#include "FactSystem.h"
 
 AutoPilotPlugin::AutoPilotPlugin(Vehicle* vehicle, QObject* parent)
     : QObject(parent)

--- a/src/AutoPilotPlugins/AutoPilotPlugin.h
+++ b/src/AutoPilotPlugins/AutoPilotPlugin.h
@@ -7,17 +7,13 @@
  *
  ****************************************************************************/
 
-#ifndef AUTOPILOTPLUGIN_H
-#define AUTOPILOTPLUGIN_H
-
-#include <QObject>
-#include <QList>
-#include <QString>
-#include <QQmlContext>
+#pragma once
 
 #include "VehicleComponent.h"
-#include "FactSystem.h"
-#include "Vehicle.h"
+
+#include <QtCore/QObject>
+#include <QtCore/QString>
+#include <QtCore/QVariantList>
 
 class Vehicle;
 class FirmwarePlugin;
@@ -68,5 +64,3 @@ protected:
 private slots:
     void _recalcSetupComplete(void);
 };
-
-#endif

--- a/src/AutoPilotPlugins/CMakeLists.txt
+++ b/src/AutoPilotPlugins/CMakeLists.txt
@@ -102,8 +102,11 @@ qt_add_library(AutoPilotPlugins STATIC
 )
 
 target_link_libraries(AutoPilotPlugins
-        PRIVATE
-                qgc
+	PUBLIC
+		Qt6::Core
+		Qt6::Quick
+    PRIVATE
+        qgc
 )
 
 target_include_directories(AutoPilotPlugins

--- a/src/AutoPilotPlugins/Common/ESP8266Component.h
+++ b/src/AutoPilotPlugins/Common/ESP8266Component.h
@@ -8,8 +8,7 @@
  ****************************************************************************/
 
 
-#ifndef ESP8266Component_H
-#define ESP8266Component_H
+#pragma once
 
 #include "VehicleComponent.h"
 
@@ -35,5 +34,3 @@ private:
     const QString   _name;
     QVariantList    _summaryItems;
 };
-
-#endif

--- a/src/AutoPilotPlugins/Common/ESP8266ComponentController.cc
+++ b/src/AutoPilotPlugins/Common/ESP8266ComponentController.cc
@@ -15,7 +15,7 @@
 #include "ESP8266ComponentController.h"
 #include "ParameterManager.h"
 #include "QGCLoggingCategory.h"
-#include <QHostAddress>
+#include <QtNetwork/QHostAddress>
 
 QGC_LOGGING_CATEGORY(ESP8266ComponentControllerLog, "ESP8266ComponentControllerLog")
 

--- a/src/AutoPilotPlugins/Common/ESP8266ComponentController.h
+++ b/src/AutoPilotPlugins/Common/ESP8266ComponentController.h
@@ -13,13 +13,11 @@
 ///     @brief  ESP8266 WiFi Config Qml Controller
 ///     @author Gus Grubba <gus@auterion.com>
 
-#ifndef ESP8266ComponentController_H
-#define ESP8266ComponentController_H
-
-#include <QtCore/QLoggingCategory>
+#pragma once
 
 #include "FactPanelController.h"
-#include "AutoPilotPlugin.h"
+
+#include <QtCore/QLoggingCategory>
 
 Q_DECLARE_LOGGING_CATEGORY(ESP8266ComponentControllerLog)
 
@@ -104,5 +102,3 @@ private:
     int         _waitType;
     int         _retries;
 };
-
-#endif // ESP8266ComponentController_H

--- a/src/AutoPilotPlugins/Common/MotorComponent.cc
+++ b/src/AutoPilotPlugins/Common/MotorComponent.cc
@@ -8,6 +8,7 @@
  ****************************************************************************/
 
 #include "MotorComponent.h"
+#include "AutoPilotPlugin.h"
 
 MotorComponent::MotorComponent(Vehicle* vehicle, AutoPilotPlugin* autopilot, QObject* parent) :
     VehicleComponent(vehicle, autopilot, parent),

--- a/src/AutoPilotPlugins/Common/MotorComponent.h
+++ b/src/AutoPilotPlugins/Common/MotorComponent.h
@@ -8,8 +8,7 @@
  ****************************************************************************/
 
 
-#ifndef MotorComponent_H
-#define MotorComponent_H
+#pragma once
 
 #include "VehicleComponent.h"
 
@@ -35,5 +34,3 @@ public:
 private:
     const QString   _name;
 };
-
-#endif

--- a/src/AutoPilotPlugins/Common/RadioComponentController.cc
+++ b/src/AutoPilotPlugins/Common/RadioComponentController.cc
@@ -14,8 +14,10 @@
 
 #include "RadioComponentController.h"
 #include "QGCApplication.h"
+#include "FactSystem.h"
 #include "QGCLoggingCategory.h"
-#include <QSettings>
+
+#include <QtCore/QSettings>
 
 QGC_LOGGING_CATEGORY(RadioComponentControllerLog, "RadioComponentControllerLog")
 QGC_LOGGING_CATEGORY(RadioComponentControllerVerboseLog, "RadioComponentControllerVerboseLog")

--- a/src/AutoPilotPlugins/Common/RadioComponentController.h
+++ b/src/AutoPilotPlugins/Common/RadioComponentController.h
@@ -13,13 +13,12 @@
 ///     @brief Radio Config Qml Controller
 ///     @author Don Gagne <don@thegagnes.com
 
-#ifndef RadioComponentController_H
-#define RadioComponentController_H
-
-#include <QtCore/QLoggingCategory>
+#pragma once
 
 #include "FactPanelController.h"
-#include "AutoPilotPlugin.h"
+
+#include <QtCore/QLoggingCategory>
+#include <QtQuick/QQuickItem>
 
 Q_DECLARE_LOGGING_CATEGORY(RadioComponentControllerLog)
 Q_DECLARE_LOGGING_CATEGORY(RadioComponentControllerVerboseLog)
@@ -318,5 +317,3 @@ private:
     static RadioComponentController*    _unitTestController;
 #endif
 };
-
-#endif // RadioComponentController_H

--- a/src/AutoPilotPlugins/Common/SyslinkComponent.h
+++ b/src/AutoPilotPlugins/Common/SyslinkComponent.h
@@ -8,8 +8,7 @@
  ****************************************************************************/
 
 
-#ifndef SyslinkComponent_H
-#define SyslinkComponent_H
+#pragma once
 
 #include "VehicleComponent.h"
 
@@ -37,4 +36,3 @@ private:
     QVariantList    _summaryItems;
 };
 
-#endif

--- a/src/AutoPilotPlugins/Common/SyslinkComponentController.h
+++ b/src/AutoPilotPlugins/Common/SyslinkComponentController.h
@@ -7,13 +7,11 @@
  *
  ****************************************************************************/
 
-#ifndef SyslinkComponentController_H
-#define SyslinkComponentController_H
-
-#include <QtCore/QLoggingCategory>
+#pragma once
 
 #include "FactPanelController.h"
-#include "AutoPilotPlugin.h"
+
+#include <QtCore/QLoggingCategory>
 
 Q_DECLARE_LOGGING_CATEGORY(SyslinkComponentControllerLog)
 
@@ -62,5 +60,3 @@ private:
     QStringList _dataRates;
 
 };
-
-#endif // SyslinkComponentController_H

--- a/src/AutoPilotPlugins/Generic/GenericAutoPilotPlugin.h
+++ b/src/AutoPilotPlugins/Generic/GenericAutoPilotPlugin.h
@@ -8,8 +8,7 @@
  ****************************************************************************/
 
 
-#ifndef GENERICAUTOPILOT_H
-#define GENERICAUTOPILOT_H
+#pragma once
 
 #include "AutoPilotPlugin.h"
 
@@ -29,5 +28,3 @@ public:
     const QVariantList& vehicleComponents(void) final;
     QString prerequisiteSetup(VehicleComponent* component) const final;
 };
-
-#endif

--- a/src/AutoPilotPlugins/PX4/AirframeComponent.cc
+++ b/src/AutoPilotPlugins/PX4/AirframeComponent.cc
@@ -13,6 +13,8 @@
 
 #include "AirframeComponent.h"
 #include "ParameterManager.h"
+#include "FactSystem.h"
+#include "Vehicle.h"
 
 AirframeComponent::AirframeComponent(Vehicle* vehicle, AutoPilotPlugin* autopilot, QObject* parent) :
     VehicleComponent(vehicle, autopilot, parent),

--- a/src/AutoPilotPlugins/PX4/AirframeComponentController.cc
+++ b/src/AutoPilotPlugins/PX4/AirframeComponentController.cc
@@ -13,8 +13,10 @@
 #include "QGCApplication.h"
 #include "LinkManager.h"
 #include "QGC.h"
+#include "FactSystem.h"
 
-#include <QVariant>
+#include <QtCore/QVariant>
+#include <QtQml/QtQml>
 
 bool AirframeComponentController::_typesRegistered = false;
 

--- a/src/AutoPilotPlugins/PX4/FlightModesComponent.cc
+++ b/src/AutoPilotPlugins/PX4/FlightModesComponent.cc
@@ -12,7 +12,9 @@
 ///     @author Don Gagne <don@thegagnes.com>
 
 #include "FlightModesComponent.h"
+#include "FactSystem.h"
 #include "ParameterManager.h"
+#include "Vehicle.h"
 
 struct SwitchListItem {
     const char* param;

--- a/src/AutoPilotPlugins/PX4/PX4AirframeLoader.cc
+++ b/src/AutoPilotPlugins/PX4/PX4AirframeLoader.cc
@@ -21,6 +21,7 @@
 #include <QDir>
 #include <QDebug>
 #include <QtCore/QXmlStreamReader>
+#include <QtCore/QSettings>
 
 QGC_LOGGING_CATEGORY(PX4AirframeLoaderLog, "PX4AirframeLoaderLog")
 

--- a/src/AutoPilotPlugins/PX4/PX4AirframeLoader.h
+++ b/src/AutoPilotPlugins/PX4/PX4AirframeLoader.h
@@ -22,6 +22,8 @@
 
 Q_DECLARE_LOGGING_CATEGORY(PX4AirframeLoaderLog)
 
+class FactMetaData;
+
 /// Collection of Parameter Facts for PX4 AutoPilot
 
 class PX4AirframeLoader : QObject

--- a/src/AutoPilotPlugins/PX4/PX4AutoPilotPlugin.cc
+++ b/src/AutoPilotPlugins/PX4/PX4AutoPilotPlugin.cc
@@ -17,6 +17,9 @@
 #include "PowerComponent.h"
 #include "SafetyComponent.h"
 #include "SensorsComponent.h"
+#include "FactSystem.h"
+#include "ParameterManager.h"
+#include "Vehicle.h"
 
 /// @file
 ///     @brief This is the AutoPilotPlugin implementatin for the MAV_AUTOPILOT_PX4 type.

--- a/src/AutoPilotPlugins/PX4/PX4FlightBehavior.cc
+++ b/src/AutoPilotPlugins/PX4/PX4FlightBehavior.cc
@@ -9,6 +9,8 @@
 
 
 #include "PX4FlightBehavior.h"
+#include "QGCMAVLink.h"
+#include "Vehicle.h"
 
 PX4FlightBehavior::PX4FlightBehavior(Vehicle* vehicle, AutoPilotPlugin* autopilot, QObject* parent)
     : VehicleComponent(vehicle, autopilot, parent)

--- a/src/AutoPilotPlugins/PX4/PX4RadioComponent.cc
+++ b/src/AutoPilotPlugins/PX4/PX4RadioComponent.cc
@@ -10,6 +10,8 @@
 
 #include "PX4RadioComponent.h"
 #include "ParameterManager.h"
+#include "FactSystem.h"
+#include "Vehicle.h"
 
 PX4RadioComponent::PX4RadioComponent(Vehicle* vehicle, AutoPilotPlugin* autopilot, QObject* parent) :
     VehicleComponent(vehicle, autopilot, parent),

--- a/src/AutoPilotPlugins/PX4/PX4SimpleFlightModesController.cc
+++ b/src/AutoPilotPlugins/PX4/PX4SimpleFlightModesController.cc
@@ -9,6 +9,7 @@
 
 
 #include "PX4SimpleFlightModesController.h"
+#include "FactSystem.h"
 
 PX4SimpleFlightModesController::PX4SimpleFlightModesController(void)
     : _activeFlightMode(0)

--- a/src/AutoPilotPlugins/PX4/PX4TuningComponent.cc
+++ b/src/AutoPilotPlugins/PX4/PX4TuningComponent.cc
@@ -9,6 +9,8 @@
 
 
 #include "PX4TuningComponent.h"
+#include "QGCMAVLink.h"
+#include "Vehicle.h"
 
 PX4TuningComponent::PX4TuningComponent(Vehicle* vehicle, AutoPilotPlugin* autopilot, QObject* parent)
     : VehicleComponent(vehicle, autopilot, parent)

--- a/src/AutoPilotPlugins/PX4/PowerComponent.cc
+++ b/src/AutoPilotPlugins/PX4/PowerComponent.cc
@@ -13,6 +13,8 @@
 
 #include "PowerComponent.h"
 #include "ParameterManager.h"
+#include "FactSystem.h"
+#include "Vehicle.h"
 
 PowerComponent::PowerComponent(Vehicle* vehicle, AutoPilotPlugin* autopilot, QObject* parent) :
     VehicleComponent(vehicle, autopilot, parent),

--- a/src/AutoPilotPlugins/PX4/SensorsComponent.cc
+++ b/src/AutoPilotPlugins/PX4/SensorsComponent.cc
@@ -12,7 +12,9 @@
 ///     @author Don Gagne <don@thegagnes.com>
 
 #include "SensorsComponent.h"
+#include "FactSystem.h"
 #include "ParameterManager.h"
+#include "Vehicle.h"
 
 const char* SensorsComponent::_airspeedBreakerParam =   "CBRK_AIRSPD_CHK";
 const char* SensorsComponent::_airspeedDisabledParam =  "FW_ARSP_MODE";

--- a/src/AutoPilotPlugins/PX4/SensorsComponentController.cc
+++ b/src/AutoPilotPlugins/PX4/SensorsComponentController.cc
@@ -10,6 +10,7 @@
 #include "SensorsComponentController.h"
 #include "QGCApplication.h"
 #include "ParameterManager.h"
+#include "FactSystem.h"
 #include "QGCLoggingCategory.h"
 
 QGC_LOGGING_CATEGORY(SensorsComponentControllerLog, "SensorsComponentControllerLog")

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -56,12 +56,16 @@ add_subdirectory(Viewer3D)
 #######################################################
 target_link_libraries(qgc
 	PRIVATE
-		Audio
-	PUBLIC
+		Qt6::Quick
 		Qt6::QuickControls2
 		Qt6::QuickWidgets
-		Qt6::Widgets
 		Qt6::Core5Compat
+		Qt6::Bluetooth
+		Audio
+	PUBLIC
+		Qt6::Core
+		Qt6::CorePrivate
+		Qt6::Widgets
 
 		ADSB
 		AirLink

--- a/src/Camera/CMakeLists.txt
+++ b/src/Camera/CMakeLists.txt
@@ -1,4 +1,4 @@
-find_package(Qt6 REQUIRED COMPONENTS Core)
+find_package(Qt6 REQUIRED COMPONENTS Core Network Qml Xml)
 
 qt_add_library(Camera STATIC
 	MavlinkCameraControl.cc
@@ -15,8 +15,22 @@ qt_add_library(Camera STATIC
 
 target_link_libraries(Camera
 	PRIVATE
+		Qt6::Network
+		Qt6::Qml
+		Qt6::Xml
+		api
 		Compression
+		FirmwarePlugin
+		Joystick
+		QGCLocation
+		Settings
+		Vehicle
+		VideoManager
 	PUBLIC
+		Qt6::Core
+		comm
+		FactSystem
+		QmlControls
 		qgc
 )
 

--- a/src/Camera/MavlinkCameraControl.h
+++ b/src/Camera/MavlinkCameraControl.h
@@ -12,10 +12,10 @@
 #include "FactGroup.h"
 #include "QmlObjectListModel.h"
 
-#include <QObject>
-#include <QSizeF>
-#include <QRectF>
-#include <QPointF>
+#include <QtCore/QObject>
+#include <QtCore/QSizeF>
+#include <QtCore/QRectF>
+#include <QtCore/QPointF>
 #include <QtCore/QLoggingCategory>
 
 class QGCCameraParamIO;

--- a/src/Camera/QGCCameraIO.cc
+++ b/src/Camera/QGCCameraIO.cc
@@ -11,6 +11,9 @@
 #include "QGCCameraIO.h"
 #include "QGCLoggingCategory.h"
 #include "QGCApplication.h"
+#include "QGCToolbox.h"
+#include "LinkInterface.h"
+#include "Vehicle.h"
 
 #include <QtQml/QQmlEngine>
 

--- a/src/Camera/QGCCameraIO.h
+++ b/src/Camera/QGCCameraIO.h
@@ -10,7 +10,7 @@
 #pragma once
 
 #include "QGCMAVLink.h"
-#include <QLoggingCategory>
+#include <QtCore/QLoggingCategory>
 
 class MavlinkCameraControl;
 class Fact;

--- a/src/Camera/QGCCameraManager.cc
+++ b/src/Camera/QGCCameraManager.cc
@@ -11,6 +11,9 @@
 #include "QGCApplication.h"
 #include "JoystickManager.h"
 #include "SimulatedCameraControl.h"
+#include "MultiVehicleManager.h"
+#include "Vehicle.h"
+#include "FirmwarePlugin.h"
 #include "QGCLoggingCategory.h"
 
 #include <QtQml/QQmlEngine>

--- a/src/Camera/QGCCameraManager.h
+++ b/src/Camera/QGCCameraManager.h
@@ -9,13 +9,13 @@
 
 #pragma once
 
-#include <QLoggingCategory>
 #include "QmlObjectListModel.h"
 #include "MavlinkCameraControl.h"
 
-#include <QObject>
-#include <QTimer>
+#include <QtCore/QObject>
+#include <QtCore/QTimer>
 #include <QtCore/QElapsedTimer>
+#include <QtCore/QLoggingCategory>
 
 Q_DECLARE_LOGGING_CATEGORY(CameraManagerLog)
 

--- a/src/Camera/SimulatedCameraControl.cc
+++ b/src/Camera/SimulatedCameraControl.cc
@@ -11,6 +11,7 @@
 #include "VideoManager.h"
 #include "QGCApplication.h"
 #include "SettingsManager.h"
+#include "Vehicle.h"
 
 #include <QtQml/QQmlEngine>
 

--- a/src/Camera/SimulatedCameraControl.h
+++ b/src/Camera/SimulatedCameraControl.h
@@ -11,8 +11,8 @@
 
 #include "MavlinkCameraControl.h"
 
-#include <QTimer>
-#include <QElapsedTimer>
+#include <QtCore/QTimer>
+#include <QtCore/QElapsedTimer>
 
 class VideoManager;
 class Vehicle;

--- a/src/Camera/VehicleCameraControl.cc
+++ b/src/Camera/VehicleCameraControl.cc
@@ -15,11 +15,14 @@
 #include "FTPManager.h"
 #include "QGCLZMA.h"
 #include "QGCCorePlugin.h"
+#include "Vehicle.h"
+#include "LinkInterface.h"
 
 #include <QtNetwork/QNetworkAccessManager>
-#include <QDir>
-#include <QDomDocument>
-#include <QDomNodeList>
+#include <QtCore/QDir>
+#include <QtCore/QSettings>
+#include <QtXml/QDomDocument>
+#include <QtXml/QDomNodeList>
 #include <QtQml/QQmlEngine>
 #include <QtNetwork/QNetworkProxy>
 

--- a/src/CmdLineOptParser.cc
+++ b/src/CmdLineOptParser.cc
@@ -14,8 +14,6 @@
 
 #include "CmdLineOptParser.h"
 
-#include <QString>
-
 /// @brief Implements a simple command line parser which sets booleans to true if the option is found.
 void ParseCmdLineOptions(int&           argc,                   ///< count of arguments in argv
                          char*          argv[],                 ///< command line arguments

--- a/src/CmdLineOptParser.h
+++ b/src/CmdLineOptParser.h
@@ -14,8 +14,7 @@
 
 #pragma once
 
-#include <QString>
-#include <cstring>
+#include <QtCore/QString>
 
 /// @brief Structure used to pass command line options to the ParseCmdLineOptions function.
 typedef struct {

--- a/src/Compression/QGCLZMA.h
+++ b/src/Compression/QGCLZMA.h
@@ -9,7 +9,7 @@
 
 #pragma once
 
-#include <QString>
+#include <QtCore/QString>
 
 class QGCLZMA
 {

--- a/src/FactSystem/CMakeLists.txt
+++ b/src/FactSystem/CMakeLists.txt
@@ -1,6 +1,6 @@
 add_subdirectory(FactControls)
 
-find_package(Qt6 REQUIRED COMPONENTS Core)
+find_package(Qt6 REQUIRED COMPONENTS Core Qml)
 
 qt_add_library(FactSystem STATIC
 	Fact.cc
@@ -20,9 +20,19 @@ qt_add_library(FactSystem STATIC
 )
 
 target_link_libraries(FactSystem
-    PUBLIC
-		qgc
+	PRIVATE
+    	Qt6::Qml
+    	api
+		AutoPilotPlugins
+		comm
 		FactControls
+		FirmwarePlugin
+		Settings
+		Utilities
+		Vehicle
+    PUBLIC
+    	Qt6::Core
+		qgc
 )
 
 target_include_directories(FactSystem PUBLIC ${CMAKE_CURRENT_SOURCE_DIR})

--- a/src/FactSystem/Fact.h
+++ b/src/FactSystem/Fact.h
@@ -11,9 +11,9 @@
 
 #include "FactMetaData.h"
 
-#include <QObject>
-#include <QString>
-#include <QVariant>
+#include <QtCore/QObject>
+#include <QtCore/QString>
+#include <QtCore/QVariant>
 
 class FactValueSliderListModel;
 

--- a/src/FactSystem/FactControls/CMakeLists.txt
+++ b/src/FactSystem/FactControls/CMakeLists.txt
@@ -23,8 +23,13 @@ add_custom_target(FactControlsQml
 )
 
 target_link_libraries(FactControls
-	PUBLIC
+	PRIVATE
+		AutoPilotPlugins
+		FactSystem
 		qgc
+		Utilities
+	PUBLIC
+		Vehicle
 )
 
 target_include_directories(FactControls PUBLIC ${CMAKE_CURRENT_SOURCE_DIR})

--- a/src/FactSystem/FactControls/FactPanelController.cc
+++ b/src/FactSystem/FactControls/FactPanelController.cc
@@ -11,9 +11,11 @@
 #include "MultiVehicleManager.h"
 #include "QGCApplication.h"
 #include "ParameterManager.h"
+#include "FactSystem.h"
+#include "AutoPilotPlugin.h"
 #include "QGCLoggingCategory.h"
 
-#include <QQmlEngine>
+#include <QtQml/QQmlEngine>
 
 /// @file
 ///     @author Don Gagne <don@thegagnes.com>

--- a/src/FactSystem/FactControls/FactPanelController.h
+++ b/src/FactSystem/FactControls/FactPanelController.h
@@ -13,12 +13,14 @@
 /// @file
 ///     @author Don Gagne <don@thegagnes.com>
 
-#include <QObject>
+#include "Vehicle.h"
+
+#include <QtCore/QObject>
 #include <QtCore/QLoggingCategory>
 
-#include "AutoPilotPlugin.h"
-
 Q_DECLARE_LOGGING_CATEGORY(FactPanelControllerLog)
+
+class AutoPilotPlugin;
 
 /// FactPanelController is used for handling missing Facts from C++ code.
 class FactPanelController : public QObject

--- a/src/FactSystem/FactGroup.cc
+++ b/src/FactSystem/FactGroup.cc
@@ -10,9 +10,9 @@
 
 #include "FactGroup.h"
 
-#include <QJsonDocument>
-#include <QJsonArray>
-#include <QQmlEngine>
+#include <QtCore/QJsonDocument>
+#include <QtCore/QJsonArray>
+#include <QtQml/QQmlEngine>
 
 FactGroup::FactGroup(int updateRateMsecs, const QString& metaDataFile, QObject* parent, bool ignoreCamelCase)
     : QObject(parent)

--- a/src/FactSystem/FactGroup.h
+++ b/src/FactSystem/FactGroup.h
@@ -12,9 +12,9 @@
 #include "Fact.h"
 #include "QGCMAVLink.h"
 
-#include <QStringList>
-#include <QMap>
-#include <QTimer>
+#include <QtCore/QStringList>
+#include <QtCore/QMap>
+#include <QtCore/QTimer>
 
 class Vehicle;
 

--- a/src/FactSystem/FactMetaData.cc
+++ b/src/FactSystem/FactMetaData.cc
@@ -12,12 +12,8 @@
 #include "JsonHelper.h"
 #include "QGCApplication.h"
 
-#include <QDebug>
-#include <QtMath>
-#include <QJsonArray>
-
-#include <limits>
-#include <cmath>
+#include <QtCore/QtMath>
+#include <QtCore/QJsonArray>
 
 // Conversion Constants
 // Time

--- a/src/FactSystem/FactMetaData.h
+++ b/src/FactSystem/FactMetaData.h
@@ -9,10 +9,10 @@
 
 #pragma once
 
-#include <QObject>
-#include <QString>
-#include <QVariant>
-#include <QJsonObject>
+#include <QtCore/QObject>
+#include <QtCore/QString>
+#include <QtCore/QVariant>
+#include <QtCore/QJsonObject>
 
 /// Holds the meta data associated with a Fact.
 ///

--- a/src/FactSystem/FactSystem.cc
+++ b/src/FactSystem/FactSystem.cc
@@ -15,7 +15,7 @@
 #include "FactGroup.h"
 #include "FactPanelController.h"
 
-#include <QtQml>
+#include <QtQml/QtQml>
 
 const char* FactSystem::_factSystemQmlUri = "QGroundControl.FactSystem";
 

--- a/src/FactSystem/FactValueSliderListModel.cc
+++ b/src/FactSystem/FactValueSliderListModel.cc
@@ -9,8 +9,8 @@
 
 #include "FactValueSliderListModel.h"
 
-#include <QQmlEngine>
-#include <QtMath>
+#include <QtQml/QQmlEngine>
+#include <QtCore/QtMath>
 
 const int FactValueSliderListModel::_valueRole =        Qt::UserRole;
 const int FactValueSliderListModel::_valueIndexRole =   Qt::UserRole + 1;

--- a/src/FactSystem/FactValueSliderListModel.h
+++ b/src/FactSystem/FactValueSliderListModel.h
@@ -9,9 +9,9 @@
 
 #pragma once
 
-#include <QAbstractListModel>
-
 #include "Fact.h"
+
+#include <QtCore/QAbstractListModel>
 
 /// Provides a list model of values for incrementing/decrementing the value of a Fact
 class FactValueSliderListModel : public QAbstractListModel

--- a/src/FactSystem/ParameterManager.cc
+++ b/src/FactSystem/ParameterManager.cc
@@ -16,11 +16,15 @@
 #include "ComponentInformationManager.h"
 #include "CompInfoParam.h"
 #include "FTPManager.h"
+#include "Vehicle.h"
+#include "AutoPilotPlugin.h"
+#include "MAVLinkProtocol.h"
+#include "FactSystem.h"
 #include "QGC.h"
 
-#include <QEasingCurve>
-#include <QFile>
-#include <QVariantAnimation>
+#include <QtCore/QEasingCurve>
+#include <QtCore/QFile>
+#include <QtCore/QVariantAnimation>
 #include <QtCore/QStandardPaths>
 
 QGC_LOGGING_CATEGORY(ParameterManagerVerbose1Log,           "ParameterManagerVerbose1Log")
@@ -1421,6 +1425,8 @@ bool ParameterManager::pendingWrites(void)
 
     return false;
 }
+
+Vehicle* ParameterManager::vehicle(void) { return _vehicle; }
 
 
 /* Parse the binary parameter file and inject the parameters in the qgc

--- a/src/FactSystem/ParameterManager.h
+++ b/src/FactSystem/ParameterManager.h
@@ -9,20 +9,23 @@
 
 #pragma once
 
-#include <QObject>
-#include <QMap>
-#include <QLoggingCategory>
-#include <QDir>
+#include "QGCMAVLink.h"
+#include "Fact.h"
 
-#include "MAVLinkProtocol.h"
-#include "AutoPilotPlugin.h"
-#include "Vehicle.h"
+#include <QtCore/QObject>
+#include <QtCore/QMap>
+#include <QtCore/QDir>
+#include <QtCore/QTimer>
+#include <QtCore/QString>
+#include <QtCore/QLoggingCategory>
 
 Q_DECLARE_LOGGING_CATEGORY(ParameterManagerVerbose1Log)
 Q_DECLARE_LOGGING_CATEGORY(ParameterManagerVerbose2Log)
 Q_DECLARE_LOGGING_CATEGORY(ParameterManagerDebugCacheFailureLog)
 
 class ParameterEditorController;
+class Vehicle;
+class MAVLinkProtocol;
 
 class ParameterManager : public QObject
 {
@@ -86,7 +89,7 @@ public:
 
     bool pendingWrites(void);
 
-    Vehicle* vehicle(void) { return _vehicle; }
+    Vehicle* vehicle(void);
 
     static MAV_PARAM_TYPE               factTypeToMavType(FactMetaData::ValueType_t factType);
     static FactMetaData::ValueType_t    mavTypeToFactType(MAV_PARAM_TYPE mavType);

--- a/src/FactSystem/SettingsFact.cc
+++ b/src/FactSystem/SettingsFact.cc
@@ -12,7 +12,7 @@
 #include "QGCCorePlugin.h"
 #include "QGCApplication.h"
 
-#include <QSettings>
+#include <QtCore/QSettings>
 #include <QtQml/QQmlEngine>
 
 SettingsFact::SettingsFact(QObject* parent)

--- a/src/FirmwarePlugin/APM/APMFirmwarePlugin.cc
+++ b/src/FirmwarePlugin/APM/APMFirmwarePlugin.cc
@@ -18,6 +18,7 @@
 #include "APMSubMotorComponentController.h"
 #include "MissionManager.h"
 #include "ParameterManager.h"
+#include "FactSystem.h"
 #include "SettingsManager.h"
 #include "AppSettings.h"
 #include "APMMavlinkStreamRateSettings.h"

--- a/src/FirmwarePlugin/APM/APMFirmwarePlugin.h
+++ b/src/FirmwarePlugin/APM/APMFirmwarePlugin.h
@@ -14,6 +14,7 @@
 #include "FollowMe.h"
 
 #include <QAbstractSocket>
+#include <QtCore/QMutex>
 #include <QtCore/QLoggingCategory>
 
 Q_DECLARE_LOGGING_CATEGORY(APMFirmwarePluginLog)

--- a/src/FirmwarePlugin/APM/ArduCopterFirmwarePlugin.cc
+++ b/src/FirmwarePlugin/APM/ArduCopterFirmwarePlugin.cc
@@ -13,6 +13,8 @@
 
 #include "ArduCopterFirmwarePlugin.h"
 #include "ParameterManager.h"
+#include "Vehicle.h"
+#include "FactSystem.h"
 
 bool ArduCopterFirmwarePlugin::_remapParamNameIntialized = false;
 FirmwarePlugin::remapParamNameMajorVersionMap_t ArduCopterFirmwarePlugin::_remapParamName;

--- a/src/FirmwarePlugin/APM/ArduPlaneFirmwarePlugin.cc
+++ b/src/FirmwarePlugin/APM/ArduPlaneFirmwarePlugin.cc
@@ -8,6 +8,7 @@
  ****************************************************************************/
 
 #include "ArduPlaneFirmwarePlugin.h"
+#include "Vehicle.h"
 
 bool ArduPlaneFirmwarePlugin::_remapParamNameIntialized = false;
 FirmwarePlugin::remapParamNameMajorVersionMap_t ArduPlaneFirmwarePlugin::_remapParamName;

--- a/src/FirmwarePlugin/APM/ArduRoverFirmwarePlugin.cc
+++ b/src/FirmwarePlugin/APM/ArduRoverFirmwarePlugin.cc
@@ -9,6 +9,7 @@
 
 #include "ArduRoverFirmwarePlugin.h"
 #include "QGCApplication.h"
+#include "Vehicle.h"
 
 bool ArduRoverFirmwarePlugin::_remapParamNameIntialized = false;
 FirmwarePlugin::remapParamNameMajorVersionMap_t ArduRoverFirmwarePlugin::_remapParamName;

--- a/src/FirmwarePlugin/APM/ArduSubFirmwarePlugin.cc
+++ b/src/FirmwarePlugin/APM/ArduSubFirmwarePlugin.cc
@@ -25,6 +25,7 @@
 ///     @author Rustom Jehangir <rusty@bluerobotics.com>
 
 #include "ArduSubFirmwarePlugin.h"
+#include "Vehicle.h"
 
 bool ArduSubFirmwarePlugin::_remapParamNameIntialized = false;
 FirmwarePlugin::remapParamNameMajorVersionMap_t ArduSubFirmwarePlugin::_remapParamName;

--- a/src/FirmwarePlugin/APM/ArduSubFirmwarePlugin.h
+++ b/src/FirmwarePlugin/APM/ArduSubFirmwarePlugin.h
@@ -28,6 +28,8 @@
 #define ArduSubFirmwarePlugin_H
 
 #include "APMFirmwarePlugin.h"
+#include "FactGroup.h"
+
 class APMSubmarineFactGroup : public FactGroup
 {
     Q_OBJECT

--- a/src/FirmwarePlugin/CameraMetaData.h
+++ b/src/FirmwarePlugin/CameraMetaData.h
@@ -9,7 +9,7 @@
 
 #pragma once
 
-#include <QObject>
+#include <QtCore/QObject>
 
 /// Set of meta data which describes a camera available on the vehicle
 class CameraMetaData : public QObject

--- a/src/FirmwarePlugin/FirmwarePlugin.cc
+++ b/src/FirmwarePlugin/FirmwarePlugin.cc
@@ -19,7 +19,7 @@
 #include "QGC.h"
 #include "QGCLoggingCategory.h"
 
-#include <QRegularExpression>
+#include <QtCore/QRegularExpression>
 
 QGC_LOGGING_CATEGORY(FirmwarePluginLog, "FirmwarePluginLog")
 

--- a/src/FirmwarePlugin/FirmwarePlugin.h
+++ b/src/FirmwarePlugin/FirmwarePlugin.h
@@ -17,14 +17,16 @@
 #include "RallyPointManager.h"
 #include "FollowMe.h"
 
-#include <QList>
-#include <QString>
-#include <QVariantList>
+#include <QtCore/QList>
+#include <QtCore/QString>
+#include <QtCore/QVariantList>
 
 class Vehicle;
 class MavlinkCameraControl;
 class QGCCameraManager;
 class Autotune;
+class LinkInterface;
+class FactGroup;
 
 /// This is the base class for Firmware specific plugins
 ///

--- a/src/FirmwarePlugin/FirmwarePluginManager.h
+++ b/src/FirmwarePlugin/FirmwarePluginManager.h
@@ -9,13 +9,15 @@
 
 #pragma once
 
-#include <QObject>
 
-#include "FirmwarePlugin.h"
 #include "QGCMAVLink.h"
 #include "QGCToolbox.h"
 
+#include <QtCore/QObject>
+
 class QGCApplication;
+class FirmwarePlugin;
+class FirmwarePluginFactory;
 
 /// FirmwarePluginManager is a singleton which is used to return the correct FirmwarePlugin for a MAV_AUTOPILOT type.
 

--- a/src/FirmwarePlugin/PX4/PX4FirmwarePlugin.cc
+++ b/src/FirmwarePlugin/PX4/PX4FirmwarePlugin.cc
@@ -17,6 +17,9 @@
 #include "PowerComponentController.h"
 #include "SettingsManager.h"
 #include "PlanViewSettings.h"
+#include "ParameterManager.h"
+#include "FactSystem.h"
+#include "Vehicle.h"
 
 #include <QDebug>
 

--- a/src/FollowMe/CMakeLists.txt
+++ b/src/FollowMe/CMakeLists.txt
@@ -6,10 +6,15 @@ qt_add_library(FollowMe STATIC
 )
 
 target_link_libraries(FollowMe
-	PUBLIC
-		Qt6::Core
+	PRIVATE
 		Qt6::Positioning
 		comm
+		PositionManager
+		Settings
+		Utilities
+		Vehicle
+	PUBLIC
+		Qt6::Core
 		qgc
 )
 

--- a/src/FollowMe/FollowMe.cc
+++ b/src/FollowMe/FollowMe.cc
@@ -7,18 +7,18 @@
  *
  ****************************************************************************/
 
-#include <QElapsedTimer>
-#include <cmath>
-
+#include "FollowMe.h"
 #include "MultiVehicleManager.h"
 #include "FirmwarePlugin.h"
 #include "MAVLinkProtocol.h"
-#include "FollowMe.h"
 #include "Vehicle.h"
 #include "PositionManager.h"
 #include "SettingsManager.h"
 #include "AppSettings.h"
 #include "QGCLoggingCategory.h"
+
+#include <QtPositioning/QGeoPositionInfo>
+#include <cmath>
 
 QGC_LOGGING_CATEGORY(FollowMeLog, "FollowMeLog")
 

--- a/src/FollowMe/FollowMe.h
+++ b/src/FollowMe/FollowMe.h
@@ -10,14 +10,13 @@
 
 #pragma once
 
-#include <QTimer>
-
 #include "QGCToolbox.h"
-#include "MAVLinkProtocol.h"
-
-class Vehicle;
+#include <QtCore/QTimer>
+#include <QtCore/QLoggingCategory>
 
 Q_DECLARE_LOGGING_CATEGORY(FollowMeLog)
+
+class Vehicle;
 
 class FollowMe : public QGCTool
 {

--- a/src/GPS/CMakeLists.txt
+++ b/src/GPS/CMakeLists.txt
@@ -27,9 +27,12 @@ qt_add_library(gps STATIC
 )
 
 target_link_libraries(gps
+	PRIVATE
+		comm
+		Settings
+		Utilities
 	PUBLIC
 		Qt6::Core
-		comm
 		qgc
 )
 

--- a/src/GPS/GPSManager.cc
+++ b/src/GPS/GPSManager.cc
@@ -9,10 +9,14 @@
 
 
 #include "GPSManager.h"
-#include "QGCLoggingCategory.h"
+#include "GPSProvider.h"
 #include "QGCApplication.h"
 #include "SettingsManager.h"
 #include "RTKSettings.h"
+#include "GPSRTKFactGroup.h"
+#include "RTCMMavlink.h"
+#include "QGCLoggingCategory.h"
+
 
 GPSManager::GPSManager(QGCApplication* app, QGCToolbox* toolbox)
     : QGCTool(app, toolbox)
@@ -128,6 +132,10 @@ void GPSManager::disconnectGPS(void)
     _gpsProvider = nullptr;
     _rtcmMavlink = nullptr;
 }
+
+bool GPSManager::connected() const { return _gpsProvider && _gpsProvider->isRunning(); }
+
+FactGroup* GPSManager::gpsRtkFactGroup(void) { return _gpsRtkFactGroup; }
 
 void GPSManager::GPSPositionUpdate(GPSPositionMessage msg)
 {

--- a/src/GPS/GPSManager.h
+++ b/src/GPS/GPSManager.h
@@ -10,13 +10,16 @@
 
 #pragma once
 
-#include "GPSProvider.h"
-#include "RTCMMavlink.h"
-#include "GPSRTKFactGroup.h"
-#include <QGCToolbox.h>
+#include "QGCToolbox.h"
+#include "GPSPositionMessage.h"
 
-#include <QString>
-#include <QObject>
+#include <QtCore/QString>
+#include <QtCore/QObject>
+
+class GPSRTKFactGroup;
+class FactGroup;
+class RTCMMavlink;
+class GPSProvider;
 
 /**
  ** class GPSManager
@@ -33,8 +36,8 @@ public:
 
     void connectGPS     (const QString& device, const QString& gps_type);
     void disconnectGPS  (void);
-    bool connected      (void) const { return _gpsProvider && _gpsProvider->isRunning(); }
-    FactGroup* gpsRtkFactGroup(void) { return _gpsRtkFactGroup; }
+    bool connected      (void) const;
+    FactGroup* gpsRtkFactGroup(void);
 
 signals:
     void onConnect();

--- a/src/GPS/GPSPositionMessage.h
+++ b/src/GPS/GPSPositionMessage.h
@@ -12,7 +12,7 @@
 
 #include "sensor_gps.h"
 #include "satellite_info.h"
-#include <QMetaType>
+#include <QtCore/QMetaType>
 
 /**
  ** struct GPSPositionMessage
@@ -22,7 +22,6 @@ struct GPSPositionMessage
 {
     sensor_gps_s position_data;
 };
-
 Q_DECLARE_METATYPE(GPSPositionMessage);
 
 

--- a/src/GPS/GPSProvider.cc
+++ b/src/GPS/GPSProvider.cc
@@ -10,16 +10,19 @@
 
 #include "GPSProvider.h"
 #include "QGCLoggingCategory.h"
-
-#define GPS_RECEIVE_TIMEOUT 1200
-
-#include <QDebug>
-
 #include "Drivers/src/ubx.h"
 #include "Drivers/src/sbf.h"
 #include "Drivers/src/ashtech.h"
 #include "Drivers/src/base_station.h"
 #include "definitions.h"
+
+#ifdef Q_OS_ANDROID
+#include "qserialport.h"
+#else
+#include <QSerialPort>
+#endif
+
+#define GPS_RECEIVE_TIMEOUT 1200
 
 //#define SIMULATE_RTCM_OUTPUT //if defined, generate simulated RTCM messages
                                //additionally make sure to call connectGPS(""), eg. from QGCToolbox.cc

--- a/src/GPS/GPSProvider.h
+++ b/src/GPS/GPSProvider.h
@@ -10,19 +10,15 @@
 
 #pragma once
 
-#include <QString>
-#include <QThread>
-#include <QByteArray>
-#ifdef Q_OS_ANDROID
-#include "qserialport.h"
-#else
-#include <QSerialPort>
-#endif
-
-#include <atomic>
 
 #include "GPSPositionMessage.h"
 #include "Drivers/src/gps_helper.h"
+
+#include <QtCore/QString>
+#include <QtCore/QThread>
+#include <QtCore/QByteArray>
+
+class QSerialPort;
 
 
 /**

--- a/src/GPS/RTCMMavlink.cc
+++ b/src/GPS/RTCMMavlink.cc
@@ -9,11 +9,8 @@
 
 
 #include "RTCMMavlink.h"
-
 #include "MultiVehicleManager.h"
 #include "Vehicle.h"
-
-#include <cstdio>
 
 RTCMMavlink::RTCMMavlink(QGCToolbox& toolbox)
     : _toolbox(toolbox)
@@ -27,7 +24,7 @@ void RTCMMavlink::RTCMDataUpdate(QByteArray message)
     _bandwidthByteCounter += message.size();
     qint64 elapsed = _bandwidthTimer.elapsed();
     if (elapsed > 1000) {
-        printf("RTCM bandwidth: %.2f kB/s\n", (float) _bandwidthByteCounter / elapsed * 1000.f / 1024.f);
+        qDebug() << QStringLiteral("RTCM bandwidth: %1 kB/s\n").arg(_bandwidthByteCounter / elapsed * 1000.f / 1024.f);
         _bandwidthTimer.restart();
         _bandwidthByteCounter = 0;
     }

--- a/src/GPS/RTCMMavlink.h
+++ b/src/GPS/RTCMMavlink.h
@@ -10,11 +10,11 @@
 
 #pragma once
 
-#include <QObject>
-#include <QElapsedTimer>
-
 #include "QGCToolbox.h"
 #include "QGCMAVLink.h"
+
+#include <QtCore/QObject>
+#include <QtCore/QElapsedTimer>
 
 /**
  ** class RTCMMavlink

--- a/src/Geo/QGCGeo.cc
+++ b/src/Geo/QGCGeo.cc
@@ -7,15 +7,14 @@
  *
  ****************************************************************************/
 
-#include <QDebug>
-#include <QString>
-
-#include <cmath>
-#include <limits>
-
 #include "QGCGeo.h"
 #include "UTMUPS.hpp"
 #include "MGRS.hpp"
+
+#include <QtCore/QString>
+
+#include <cmath>
+#include <limits>
 
 // These defines are private
 #define M_DEG_TO_RAD (M_PI / 180.0)

--- a/src/Geo/QGCGeo.h
+++ b/src/Geo/QGCGeo.h
@@ -15,10 +15,9 @@
 ///     @link http://dspace.dsto.defence.gov.au/dspace/bitstream/1947/3538/1/DSTO-TN-0432.pdf
 ///     @author David Goodman <dagoodma@gmail.com>
 
-#ifndef QGCGEO_H
-#define QGCGEO_H
+#pragma once
 
-#include <QGeoCoordinate>
+#include <QtPositioning/QGeoCoordinate>
 
 /**
  * @brief Project a geodetic coordinate on to local tangential plane (LTP) as coordinate with East,
@@ -104,5 +103,3 @@ QString convertGeoToMGRS(const QGeoCoordinate& coord);
 // Returns:
 // The function returns true if conversion succeeded.
 bool convertMGRSToGeo(QString mgrs, QGeoCoordinate& coord);
-
-#endif // QGCGEO_H

--- a/src/Joystick/CMakeLists.txt
+++ b/src/Joystick/CMakeLists.txt
@@ -1,4 +1,4 @@
-find_package(Qt6 REQUIRED COMPONENTS Core)
+find_package(Qt6 REQUIRED COMPONENTS Core Qml)
 
 qt_add_library(Joystick STATIC
 	Joystick.cc
@@ -14,10 +14,7 @@ if(ANDROID)
 			JoystickAndroid.h
 	)
 
-	target_link_libraries(Joystick
-		PUBLIC
-			Qt6::CorePrivate
-	)
+	target_link_libraries(Joystick PRIVATE Qt6::CorePrivate)
 else()
 	include(BuildSdl2)
 	build_sdl2()
@@ -28,18 +25,25 @@ else()
 				JoystickSDL.cc
 				JoystickSDL.h
 		)
-    	target_link_libraries(Joystick
-    		PRIVATE
-    			SDL2::SDL2
-    	)
+    	target_link_libraries(Joystick PRIVATE SDL2::SDL2)
 	endif()
 endif()
 
 target_link_libraries(Joystick
+	PRIVATE
+		Qt6::Qml
+		AutoPilotPlugins
+		Camera
+        FirmwarePlugin
+		qgc
+		Settings
+		Utilities
+		Vehicle
+		VideoManager
 	PUBLIC
 		Qt6::Core
-		qgc
-		Vehicle
+		comm
+		QmlControls
 )
 
 target_include_directories(Joystick PUBLIC ${CMAKE_CURRENT_SOURCE_DIR})

--- a/src/Joystick/Joystick.cc
+++ b/src/Joystick/Joystick.cc
@@ -17,9 +17,12 @@
 #include "CustomAction.h"
 #include "SettingsManager.h"
 #include "CustomMavlinkActionsSettings.h"
+#include "Vehicle.h"
+#include "MultiVehicleManager.h"
+#include "FirmwarePlugin.h"
 #include "QGCLoggingCategory.h"
 
-#include <QSettings>
+#include <QtCore/QSettings>
 
 // JoystickLog Category declaration moved to QGCLoggingCategory.cc to allow access in Vehicle
 QGC_LOGGING_CATEGORY(JoystickValuesLog, "JoystickValuesLog")

--- a/src/Joystick/Joystick.h
+++ b/src/Joystick/Joystick.h
@@ -12,18 +12,19 @@
 
 #pragma once
 
-#include <QObject>
-#include <QThread>
-#include <QtCore/QLoggingCategory>
-#include <atomic>
-
-#include "Vehicle.h"
-#include "MultiVehicleManager.h"
+#include "QGCMAVLink.h"
 #include "CustomActionManager.h"
+
+#include <QtCore/QObject>
+#include <QtCore/QThread>
+#include <QtCore/QLoggingCategory>
 
 // JoystickLog Category declaration moved to QGCLoggingCategory.cc to allow access in Vehicle
 Q_DECLARE_LOGGING_CATEGORY(JoystickValuesLog)
 Q_DECLARE_METATYPE(GRIPPER_ACTIONS)
+
+class MultiVehicleManager;
+class Vehicle;
 
 /// Action assigned to button
 class AssignedButtonAction : public QObject {

--- a/src/Joystick/JoystickAndroid.cc
+++ b/src/Joystick/JoystickAndroid.cc
@@ -1,9 +1,10 @@
 #include "JoystickAndroid.h"
 #include "JoystickManager.h"
+#include "MultiVehicleManager.h"
 #include "QGCLoggingCategory.h"
 
-#include <QJniEnvironment>
-#include <QJniObject>
+#include <QtCore/QJniEnvironment>
+#include <QtCore/QJniObject>
 
 int JoystickAndroid::_androidBtnListCount;
 int *JoystickAndroid::_androidBtnList;

--- a/src/Joystick/JoystickAndroid.h
+++ b/src/Joystick/JoystickAndroid.h
@@ -1,11 +1,10 @@
-#ifndef JOYSTICKANDROID_H
-#define JOYSTICKANDROID_H
+#pragma once
 
 #include "Joystick.h"
-#include "Vehicle.h"
-#include "MultiVehicleManager.h"
-
 #include <QtCore/private/qandroidextras_p.h>
+
+class MultiVehicleManager;
+class JoystickManager;
 
 class JoystickAndroid : public Joystick, public QtAndroidPrivate::GenericMotionEventListener, public QtAndroidPrivate::KeyEventListener
 {
@@ -45,5 +44,3 @@ private:
 
     int deviceId;
 };
-
-#endif // JOYSTICKANDROID_H

--- a/src/Joystick/JoystickManager.cc
+++ b/src/Joystick/JoystickManager.cc
@@ -9,19 +9,16 @@
 
 
 #include "JoystickManager.h"
-#include "QGCApplication.h"
-#include "QGCLoggingCategory.h"
-
-#include <QQmlEngine>
-
+#include "MultiVehicleManager.h"
 #ifndef __mobile__
     #include "JoystickSDL.h"
     #define __sdljoystick__
 #endif
-
 #ifdef Q_OS_ANDROID
     #include "JoystickAndroid.h"
 #endif
+#include "QGCLoggingCategory.h"
+#include <QtQml/QQmlEngine>
 
 QGC_LOGGING_CATEGORY(JoystickManagerLog, "JoystickManagerLog")
 

--- a/src/Joystick/JoystickManager.h
+++ b/src/Joystick/JoystickManager.h
@@ -13,12 +13,14 @@
 #pragma once
 
 #include "Joystick.h"
-#include "MultiVehicleManager.h"
 #include "QGCToolbox.h"
 
-#include <QVariantList>
+#include <QtCore/QVariantList>
+#include <QtCore/QTimer>
 
 Q_DECLARE_LOGGING_CATEGORY(JoystickManagerLog)
+
+class MultiVehicleManager;
 
 /// Joystick Manager
 class JoystickManager : public QGCTool

--- a/src/Joystick/JoystickSDL.cc
+++ b/src/Joystick/JoystickSDL.cc
@@ -1,7 +1,8 @@
 #include "JoystickSDL.h"
+#include "MultiVehicleManager.h"
 #include "QGCLoggingCategory.h"
 
-#include <QTextStream>
+#include <QtCore/QTextStream>
 
 JoystickSDL::JoystickSDL(const QString& name, int axisCount, int buttonCount, int hatCount, int index, bool isGameController, MultiVehicleManager* multiVehicleManager)
     : Joystick(name,axisCount,buttonCount,hatCount,multiVehicleManager)

--- a/src/Joystick/JoystickSDL.h
+++ b/src/Joystick/JoystickSDL.h
@@ -13,10 +13,10 @@
 #pragma once
 
 #include "Joystick.h"
-#include "Vehicle.h"
-#include "MultiVehicleManager.h"
 
 #include <SDL.h>
+
+class MultiVehicleManager;
 
 /// @brief SDL Joystick Interface
 class JoystickSDL : public Joystick

--- a/src/MissionManager/GeoFenceController.cc
+++ b/src/MissionManager/GeoFenceController.cc
@@ -22,6 +22,7 @@
 #include "PlanMasterController.h"
 #include "SettingsManager.h"
 #include "AppSettings.h"
+#include "FactSystem.h"
 #include "QGCLoggingCategory.h"
 
 #include <QJsonArray>

--- a/src/MissionManager/MissionCommandTree.cc
+++ b/src/MissionManager/MissionCommandTree.cc
@@ -11,6 +11,7 @@
 #include "Vehicle.h"
 #include "FirmwarePluginManager.h"
 #include "QGCApplication.h"
+#include "FirmwarePlugin.h"
 #include "MissionCommandUIInfo.h"
 #include "MissionCommandList.h"
 

--- a/src/MissionManager/TransectStyleComplexItem.cc
+++ b/src/MissionManager/TransectStyleComplexItem.cc
@@ -16,6 +16,7 @@
 #include "MissionCommandTree.h"
 #include "MissionCommandUIInfo.h"
 #include "QGC.h"
+#include "FirmwarePlugin.h"
 #include "QGCLoggingCategory.h"
 
 QGC_LOGGING_CATEGORY(TransectStyleComplexItemLog, "TransectStyleComplexItemLog")

--- a/src/PositionManager/CMakeLists.txt
+++ b/src/PositionManager/CMakeLists.txt
@@ -8,6 +8,9 @@ qt_add_library(PositionManager STATIC
 )
 
 target_link_libraries(PositionManager
+	PRIVATE
+		api
+		Vehicle
 	PUBLIC
 		Qt6::Core
 		Qt6::Positioning

--- a/src/PositionManager/PositionManager.cpp
+++ b/src/PositionManager/PositionManager.cpp
@@ -12,12 +12,9 @@
 #include "QGCCorePlugin.h"
 #include "SimulatedPosition.h"
 
-#if !defined(NO_SERIAL_LINK) && !defined(Q_OS_ANDROID)
-#include <QSerialPortInfo>
-#endif
-
-#include <QtPositioning/private/qgeopositioninfosource_p.h>
 #include <QtCore/QPermissions>
+#include <QtPositioning/private/qgeopositioninfosource_p.h>
+#include <QtPositioning/QNmeaPositionInfoSource>
 
 QGCPositionManager::QGCPositionManager(QGCApplication* app, QGCToolbox* toolbox)
     : QGCTool           (app, toolbox)

--- a/src/PositionManager/PositionManager.h
+++ b/src/PositionManager/PositionManager.h
@@ -9,10 +9,10 @@
 
 #pragma once
 
-#include <QGeoPositionInfoSource>
-#include <QNmeaPositionInfoSource>
-
 #include "QGCToolbox.h"
+#include <QtPositioning/QGeoPositionInfoSource>
+
+class QNmeaPositionInfoSource;
 
 class QGCPositionManager : public QGCTool {
     Q_OBJECT

--- a/src/PositionManager/SimulatedPosition.cc
+++ b/src/PositionManager/SimulatedPosition.cc
@@ -7,12 +7,12 @@
  *
  ****************************************************************************/
 
-#include <QDateTime>
-#include <QDate>
-
 #include "SimulatedPosition.h"
 #include "QGCApplication.h"
 #include "MultiVehicleManager.h"
+
+#include <QtCore/QDateTime>
+#include <QtCore/QDate>
 
 SimulatedPosition::SimulatedPosition()
     : QGeoPositionInfoSource(nullptr)

--- a/src/PositionManager/SimulatedPosition.h
+++ b/src/PositionManager/SimulatedPosition.h
@@ -9,8 +9,8 @@
 
 #pragma once
 
-#include <QtPositioning/qgeopositioninfosource.h>
-#include <QTimer>
+#include <QtCore/QTimer>
+#include <QtPositioning/QGeoPositionInfoSource>
 
 class Vehicle;
 

--- a/src/QGCApplication.cc
+++ b/src/QGCApplication.cc
@@ -16,18 +16,16 @@
  *
  */
 
-#include <QFile>
-#include <QRegularExpression>
-#include <QFontDatabase>
-#include <QQuickWindow>
-#include <QQuickImageProvider>
-#include <QQuickStyle>
+#include <QtCore/QFile>
+#include <QtCore/QRegularExpression>
+#include <QtGui/QFontDatabase>
+#include <QtQuick/QQuickWindow>
+#include <QtQuick/QQuickImageProvider>
+#include <QtQuickControls2/QQuickStyle>
 
 #ifdef QGC_ENABLE_BLUETOOTH
-#include <QBluetoothLocalDevice>
+#include <QtBluetooth/QBluetoothLocalDevice>
 #endif
-
-#include <QDebug>
 
 #if defined(QGC_GST_STREAMING)
 #include "GStreamer.h"
@@ -39,6 +37,7 @@
 #include "CmdLineOptParser.h"
 #include "UDPLink.h"
 #include "LinkManager.h"
+#include "MAVLinkProtocol.h"
 #include "UASMessageHandler.h"
 #include "QGCTemporaryFile.h"
 #include "QGCPalette.h"
@@ -78,6 +77,7 @@
 #include "MissionCommandTree.h"
 #include "QGCMapPolygon.h"
 #include "QGCMapCircle.h"
+#include "QGCMapEngine.h"
 #include "ParameterManager.h"
 #include "SettingsManager.h"
 #include "QGCCorePlugin.h"
@@ -113,6 +113,8 @@
 #include "Viewer3DManager.h"
 #include "Viewer3DTerrainGeometry.h"
 #include "Viewer3DTerrainTexture.h"
+#include "FactSystem.h"
+#include "LinkConfiguration.h"
 
 #ifndef __mobile__
 #include "FirmwareUpgradeController.h"
@@ -122,10 +124,6 @@
 #include "SerialLink.h"
 #endif
 
-#ifdef QGC_RTLAB_ENABLED
-#include "OpalLink.h"
-#endif
-
 #ifdef Q_OS_LINUX
 #ifndef __mobile__
 #include <unistd.h>
@@ -133,7 +131,6 @@
 #endif
 #endif
 
-#include "QGCMapEngine.h"
 
 class FinishVideoInitialization : public QRunnable
 {

--- a/src/QGCApplication.h
+++ b/src/QGCApplication.h
@@ -9,36 +9,24 @@
 
 #pragma once
 
-#include <QApplication>
-#include <QTimer>
-#include <QElapsedTimer>
-#include <QMap>
-#include <QSet>
-#include <QMetaMethod>
-#include <QMetaObject>
-#include <QTranslator>
+#include <QtWidgets/QApplication>
+#include <QtCore/QTimer>
+#include <QtCore/QElapsedTimer>
+#include <QtCore/QMap>
+#include <QtCore/QSet>
+#include <QtCore/QEvent>
+#include <QtCore/QMetaMethod>
+#include <QtCore/QMetaObject>
+#include <QtCore/QTranslator>
 
 // These private headers are require to implement the signal compress support below
-#include <private/qthread_p.h>
-#include <private/qobject_p.h>
-
-#include "LinkConfiguration.h"
-#include "MAVLinkProtocol.h"
-#include "FlightMapSettings.h"
-#include "FirmwarePluginManager.h"
-#include "MultiVehicleManager.h"
-#include "JoystickManager.h"
-#include "UASMessageHandler.h"
-#include "FactSystem.h"
-
-#ifdef QGC_RTLAB_ENABLED
-#include "OpalLink.h"
-#endif
+#include <QtCore/private/qthread_p.h>
+#include <QtCore/private/qobject_p.h>
 
 // Work around circular header includes
 class QQmlApplicationEngine;
-class QGCSingleton;
 class QGCToolbox;
+class QQuickWindow;
 
 /**
  * @brief The main application and management class.

--- a/src/QGCConfig.h
+++ b/src/QGCConfig.h
@@ -1,15 +1,5 @@
-#ifndef QGC_CONFIGURATION_H
-#define QGC_CONFIGURATION_H
-
-#include <QString>
-
-/** @brief Polling interval in ms */
-#define SERIAL_POLL_INTERVAL 4
-
-#define WITH_TEXT_TO_SPEECH 1
+#pragma once
 
 // If you need to make an incompatible changes to stored settings, bump this version number
 // up by 1. This will caused store settings to be cleared on next boot.
 #define QGC_SETTINGS_VERSION 9
-
-#endif // QGC_CONFIGURATION_H

--- a/src/QGCToolbox.cc
+++ b/src/QGCToolbox.cc
@@ -26,7 +26,6 @@
 #include "VideoManager.h"
 #include "MAVLinkLogManager.h"
 #include "QGCCorePlugin.h"
-#include "QGCOptions.h"
 #include "SettingsManager.h"
 #include "QGCApplication.h"
 #include "ADSBVehicleManager.h"

--- a/src/QGCToolbox.h
+++ b/src/QGCToolbox.h
@@ -8,10 +8,10 @@
  ****************************************************************************/
 
 
-#ifndef QGCToolbox_h
-#define QGCToolbox_h
+#pragma once
 
-#include <QObject>
+
+#include <QtCore/QObject>
 
 class FactSystem;
 class FirmwarePluginManager;
@@ -124,5 +124,3 @@ protected:
     QGCApplication* _app;
     QGCToolbox*     _toolbox;
 };
-
-#endif

--- a/src/QmlControls/CMakeLists.txt
+++ b/src/QmlControls/CMakeLists.txt
@@ -148,6 +148,7 @@ target_link_libraries(QmlControls
 		Qt6::Widgets
 	PUBLIC
 		qgc
+                AirLink
 		FactSystem
 		UTMSP
 )

--- a/src/QmlControls/EditPositionDialogController.cc
+++ b/src/QmlControls/EditPositionDialogController.cc
@@ -10,6 +10,9 @@
 #include "EditPositionDialogController.h"
 #include "QGCGeo.h"
 #include "QGCApplication.h"
+#include "QGCToolbox.h"
+#include "MultiVehicleManager.h"
+#include "Vehicle.h"
 
 const char*  EditPositionDialogController::_latitudeFactName =      "Latitude";
 const char*  EditPositionDialogController::_longitudeFactName =     "Longitude";

--- a/src/QmlControls/FactValueGrid.cc
+++ b/src/QmlControls/FactValueGrid.cc
@@ -11,8 +11,11 @@
 #include "InstrumentValueData.h"
 #include "QGCApplication.h"
 #include "QGCCorePlugin.h"
+#include "MultiVehicleManager.h"
+#include "Vehicle.h"
 
-#include <QSettings>
+#include <QtCore/QSettings>
+#include <QtCore/QDir>
 
 const char* FactValueGrid::_columnsKey          = "columns";
 const char* FactValueGrid::_rowsKey             = "rows";

--- a/src/QmlControls/InstrumentValueData.cc
+++ b/src/QmlControls/InstrumentValueData.cc
@@ -12,6 +12,9 @@
 #include "QGCApplication.h"
 #include "QGCCorePlugin.h"
 #include "QGC.h"
+#include "MultiVehicleManager.h"
+#include "Vehicle.h"
+#include "FactGroup.h"
 
 const char*  InstrumentValueData::vehicleFactGroupName =   "Vehicle";
 

--- a/src/QmlControls/QGroundControlQmlGlobal.cc
+++ b/src/QmlControls/QGroundControlQmlGlobal.cc
@@ -9,9 +9,14 @@
 
 #include "QGroundControlQmlGlobal.h"
 #include "LinkManager.h"
+#include "MAVLinkProtocol.h"
+#include "QGCMapUrlEngine.h"
+#include "FirmwarePluginManager.h"
+#include "AppSettings.h"
 #ifndef __mobile__
 #include "GPSManager.h"
 #endif
+#include "QGCPalette.h"
 #include <QSettings>
 #include <QLineF>
 #include <QPointF>
@@ -319,4 +324,39 @@ QString QGroundControlQmlGlobal::altitudeModeShortDescription(AltMode altMode)
 
     // Should never get here but makes some compilers happy
     return QString();
+}
+
+bool QGroundControlQmlGlobal::isVersionCheckEnabled()
+{
+    return _toolbox->mavlinkProtocol()->versionCheckEnabled();
+}
+
+int QGroundControlQmlGlobal::mavlinkSystemID()
+{
+    return _toolbox->mavlinkProtocol()->getSystemId();
+}
+
+QString QGroundControlQmlGlobal::elevationProviderName()
+{
+    return UrlFactory::kCopernicusElevationProviderKey;
+}
+
+QString QGroundControlQmlGlobal::elevationProviderNotice()
+{
+    return UrlFactory::kCopernicusElevationProviderNotice;
+}
+
+QString QGroundControlQmlGlobal::parameterFileExtension() const
+{
+    return AppSettings::parameterFileExtension;
+}
+
+QString QGroundControlQmlGlobal::missionFileExtension() const
+{
+    return AppSettings::missionFileExtension;
+}
+
+QString QGroundControlQmlGlobal::telemetryFileExtension() const
+{
+    return AppSettings::telemetryFileExtension;
 }

--- a/src/QmlControls/QGroundControlQmlGlobal.h
+++ b/src/QmlControls/QGroundControlQmlGlobal.h
@@ -12,23 +12,26 @@
 #include "QGCToolbox.h"
 #include "QGCApplication.h"
 #include "QGCLoggingCategory.h"
-#include "AppSettings.h"
-#include "ADSBVehicleManager.h"
-#include "QGCPalette.h"
 #include "QmlUnitsConversion.h"
-#include "QGCMapUrlEngine.h"
-#ifndef QGC_AIRLINK_DISABLED
-#include "AirLinkManager.h"
-#else
-class AirLinkManager;
-#endif
-#ifdef CONFIG_UTM_ADAPTER
-#include "UTMSPManager.h"
-#endif
+
+#include <QtCore/QTimer>
+#include <QtPositioning/QGeoCoordinate>
 
 class QGCToolbox;
 class LinkManager;
+class FactGroup;
+class QGCPalette;
+class AirLinkManager;
+class UTMSPManager;
+class ADSBVehicleManager;
+class MultiVehicleManager;
+class QGCPositionManager;
+class SettingsManager;
+class QGCCorePlugin;
+class MissionCommandTree;
 
+Q_MOC_INCLUDE("QGCPalette.h")
+Q_MOC_INCLUDE("FactGroup.h")
 Q_MOC_INCLUDE("LinkManager.h")
 Q_MOC_INCLUDE("QGCMapEngineManager.h")
 Q_MOC_INCLUDE("PositionManager.h")
@@ -37,6 +40,15 @@ Q_MOC_INCLUDE("MAVLinkLogManager.h")
 Q_MOC_INCLUDE("SettingsManager.h")
 Q_MOC_INCLUDE("QGCCorePlugin.h")
 Q_MOC_INCLUDE("MissionCommandTree.h")
+Q_MOC_INCLUDE("ADSBVehicleManager.h")
+Q_MOC_INCLUDE("MultiVehicleManager.h")
+Q_MOC_INCLUDE("PositionManager.h")
+#ifdef CONFIG_UTM_ADAPTER
+Q_MOC_INCLUDE("UTMSPManager.h")
+#endif
+#ifndef QGC_AIRLINK_DISABLED
+Q_MOC_INCLUDE("AirLinkManager.h")
+#endif
 
 class QGroundControlQmlGlobal : public QGCTool
 {
@@ -185,8 +197,8 @@ public:
     qreal zOrderTrajectoryLines     () { return 48; }
     qreal zOrderWaypointLines       () { return 47; }
 
-    bool    isVersionCheckEnabled   () { return _toolbox->mavlinkProtocol()->versionCheckEnabled(); }
-    int     mavlinkSystemID         () { return _toolbox->mavlinkProtocol()->getSystemId(); }
+    bool    isVersionCheckEnabled   ();
+    int     mavlinkSystemID         ();
 #if defined(NO_ARDUPILOT_DIALECT)
     bool    hasAPMSupport           () { return false; }
 #else
@@ -199,8 +211,8 @@ public:
     bool    hasMAVLinkInspector     () { return true; }
 #endif
 
-    QString elevationProviderName   () { return UrlFactory::kCopernicusElevationProviderKey; }
-    QString elevationProviderNotice () { return UrlFactory::kCopernicusElevationProviderNotice; }
+    QString elevationProviderName   ();
+    QString elevationProviderNotice ();
 
     bool    singleFirmwareSupport   ();
     bool    singleVehicleSupport    ();
@@ -214,9 +226,9 @@ public:
     void    setFlightMapPosition        (QGeoCoordinate& coordinate);
     void    setFlightMapZoom            (double zoom);
 
-    QString parameterFileExtension  (void) const  { return AppSettings::parameterFileExtension; }
-    QString missionFileExtension    (void) const    { return AppSettings::missionFileExtension; }
-    QString telemetryFileExtension  (void) const  { return AppSettings::telemetryFileExtension; }
+    QString parameterFileExtension  (void) const;
+    QString missionFileExtension    (void) const;
+    QString telemetryFileExtension  (void) const;
 
     QString qgcVersion              (void) const;
 

--- a/src/QmlControls/RCToParamDialogController.cc
+++ b/src/QmlControls/RCToParamDialogController.cc
@@ -9,7 +9,11 @@
 
 #include "RCToParamDialogController.h"
 #include "QGCApplication.h"
+#include "QGCToolbox.h"
 #include "ParameterManager.h"
+#include "MultiVehicleManager.h"
+#include "Vehicle.h"
+#include "FactSystem.h"
 
 const char*  RCToParamDialogController::_scaleFactName =    "Scale";
 const char*  RCToParamDialogController::_centerFactName =   "CenterValue";

--- a/src/QtLocationPlugin/EsriMapProvider.cpp
+++ b/src/QtLocationPlugin/EsriMapProvider.cpp
@@ -11,6 +11,8 @@
 #include "QGCApplication.h"
 #include "SettingsManager.h"
 
+#include <QtNetwork/QNetworkRequest>
+
 EsriMapProvider::EsriMapProvider(const quint32 averageSize, const QGeoMapType::MapStyle mapType, QObject *parent)
     : MapProvider(QString(), QString(), averageSize, mapType, parent) {}
 

--- a/src/QtLocationPlugin/QMLControl/QGCMapEngineManager.cc
+++ b/src/QtLocationPlugin/QMLControl/QGCMapEngineManager.cc
@@ -23,6 +23,7 @@
 #include "QGCLoggingCategory.h"
 
 #include <QSettings>
+#include <QtCore/QRegularExpression>
 #include <QStorageInfo>
 #include <QtQml/QQmlEngine>
 

--- a/src/RunGuard.cc
+++ b/src/RunGuard.cc
@@ -9,7 +9,7 @@
 
 #include "RunGuard.h"
 
-#include <QCryptographicHash>
+#include <QtCore/QCryptographicHash>
 
 namespace
 {

--- a/src/RunGuard.h
+++ b/src/RunGuard.h
@@ -7,12 +7,12 @@
  *
  ****************************************************************************/
 
-#ifndef RunGuard_H
-#define RunGuard_H
+#pragma once
 
-#include <QObject>
-#include <QSharedMemory>
-#include <QSystemSemaphore>
+
+#include <QtCore/QObject>
+#include <QtCore/QSharedMemory>
+#include <QtCore/QSystemSemaphore>
 
 class RunGuard
 {
@@ -34,5 +34,3 @@ private:
 
     Q_DISABLE_COPY( RunGuard )
 };
-
-#endif

--- a/src/Settings/APMMavlinkStreamRateSettings.cc
+++ b/src/Settings/APMMavlinkStreamRateSettings.cc
@@ -9,6 +9,8 @@
 
 #include "APMMavlinkStreamRateSettings.h"
 #include "QGCApplication.h"
+#include "Vehicle.h"
+#include "MultiVehicleManager.h"
 
 #include <QtQml/QQmlEngine>
 

--- a/src/Settings/AppSettings.cc
+++ b/src/Settings/AppSettings.cc
@@ -10,13 +10,16 @@
 #include "AppSettings.h"
 #include "QGCPalette.h"
 #include "QGCApplication.h"
+#include "QGCMAVLink.h"
 
 #ifdef Q_OS_ANDROID
 #include "AndroidInterface.h"
 #endif
 
 #include <QtQml/QQmlEngine>
-#include <QStandardPaths>
+#include <QtCore/QStandardPaths>
+#include <QtCore/QDir>
+#include <QtCore/QSettings>
 
 const char* AppSettings::parameterFileExtension =   "params";
 const char* AppSettings::planFileExtension =        "plan";

--- a/src/Settings/CMakeLists.txt
+++ b/src/Settings/CMakeLists.txt
@@ -1,4 +1,4 @@
-find_package(Qt6 REQUIRED COMPONENTS Core Qml Multimedia)
+find_package(Qt6 REQUIRED COMPONENTS Core Multimedia Qml)
 
 qt_add_library(Settings STATIC
 	ADSBVehicleManagerSettings.cc
@@ -48,10 +48,15 @@ qt_add_library(Settings STATIC
 target_link_libraries(Settings
 	PRIVATE
 		Qt6::Multimedia
+		api
+		QmlControls
+		Vehicle
 	PUBLIC
-		qgc
 		Qt6::Core
 		Qt6::Qml
+		comm
+		FactSystem
+		qgc
 )
 
 target_include_directories(Settings PUBLIC ${CMAKE_CURRENT_SOURCE_DIR})

--- a/src/Settings/CustomMavlinkActionsSettings.cc
+++ b/src/Settings/CustomMavlinkActionsSettings.cc
@@ -11,7 +11,8 @@
 #include "QGCApplication.h"
 
 #include <QtQml/QQmlEngine>
-#include <QFile>
+#include <QtCore/QFile>
+#include <QtCore/QSettings>
 
 DECLARE_SETTINGGROUP(CustomMavlinkActions, "CustomMavlinkActions")
 {

--- a/src/Settings/SettingsGroup.h
+++ b/src/Settings/SettingsGroup.h
@@ -7,8 +7,8 @@
  *
  ****************************************************************************/
 
-#ifndef SettingsGroup_H
-#define SettingsGroup_H
+#pragma once
+
 
 #include "SettingsFact.h"
 
@@ -71,5 +71,3 @@ protected:
 
     QMap<QString, FactMetaData*> _nameToMetaDataMap;
 };
-
-#endif

--- a/src/Settings/SettingsManager.h
+++ b/src/Settings/SettingsManager.h
@@ -7,10 +7,8 @@
  *
  ****************************************************************************/
 
-#ifndef SettingsManager_H
-#define SettingsManager_H
+#pragma once
 
-#include "MultiVehicleManager.h"
 #include "QGCToolbox.h"
 #include "AppSettings.h"
 #include "UnitsSettings.h"
@@ -111,5 +109,3 @@ private:
     RemoteIDSettings*               _remoteIDSettings;
     CustomMavlinkActionsSettings*   _customMavlinkActionsSettings;
 };
-
-#endif

--- a/src/Settings/UnitsSettings.h
+++ b/src/Settings/UnitsSettings.h
@@ -7,8 +7,8 @@
  *
  ****************************************************************************/
 
-#ifndef UnitsSettings_H
-#define UnitsSettings_H
+#pragma once
+
 
 #include "SettingsGroup.h"
 
@@ -74,5 +74,3 @@ public:
     DEFINE_SETTINGFACT(temperatureUnits)
     DEFINE_SETTINGFACT(weightUnits)
 };
-
-#endif

--- a/src/Settings/VideoDecoderOptions.h
+++ b/src/Settings/VideoDecoderOptions.h
@@ -7,8 +7,8 @@
  *
  ****************************************************************************/
 
-#ifndef VIDEODECODEROPTIONS_H
-#define VIDEODECODEROPTIONS_H
+#pragma once
+
 
 enum VideoDecoderOptions {
     ForceVideoDecoderDefault = 0,
@@ -18,5 +18,3 @@ enum VideoDecoderOptions {
     ForceVideoDecoderDirectX3D,
     ForceVideoDecoderVideoToolbox,
 };
-
-#endif //VIDEODECODEROPTIONS_H

--- a/src/Settings/VideoSettings.cc
+++ b/src/Settings/VideoSettings.cc
@@ -12,11 +12,11 @@
 #include "VideoManager.h"
 
 #include <QtQml/QQmlEngine>
-#include <QVariantList>
+#include <QtCore/QVariantList>
 
 #ifndef QGC_DISABLE_UVC
-#include <QMediaDevices>
-#include <QCameraDevice>
+#include <QtMultimedia/QMediaDevices>
+#include <QtMultimedia/QCameraDevice>
 #endif
 
 const char* VideoSettings::videoSourceNoVideo           = QT_TRANSLATE_NOOP("VideoSettings", "No Video Available");

--- a/src/Settings/VideoSettings.h
+++ b/src/Settings/VideoSettings.h
@@ -7,8 +7,7 @@
  *
  ****************************************************************************/
 
-#ifndef VideoSettings_H
-#define VideoSettings_H
+#pragma once
 
 #include "SettingsGroup.h"
 #include "VideoDecoderOptions.h"
@@ -82,5 +81,3 @@ private:
     bool _noVideo = false;
 
 };
-
-#endif

--- a/src/Terrain/CMakeLists.txt
+++ b/src/Terrain/CMakeLists.txt
@@ -11,11 +11,12 @@ target_link_libraries(Terrain
 	PRIVATE
 		Qt6::LocationPrivate
 		qgc
+		QGCLocation
+		Utilities
 	PUBLIC
 		Qt6::Core
 		Qt6::Network
 		Qt6::Positioning
-		Utilities
 )
 
 target_include_directories(Terrain PUBLIC ${CMAKE_CURRENT_SOURCE_DIR})

--- a/src/Terrain/TerrainQuery.cc
+++ b/src/Terrain/TerrainQuery.cc
@@ -14,16 +14,16 @@
 #include "QGCApplication.h"
 #include "QGCLoggingCategory.h"
 
-#include <QUrl>
-#include <QUrlQuery>
-#include <QNetworkRequest>
-#include <QNetworkProxy>
-#include <QNetworkReply>
-#include <QSslConfiguration>
-#include <QJsonDocument>
-#include <QJsonObject>
-#include <QJsonArray>
-#include <QTimer>
+#include <QtCore/QUrl>
+#include <QtCore/QUrlQuery>
+#include <QtNetwork/QNetworkRequest>
+#include <QtNetwork/QNetworkProxy>
+#include <QtNetwork/QNetworkReply>
+#include <QtNetwork/QSslConfiguration>
+#include <QtCore/QJsonDocument>
+#include <QtCore/QJsonObject>
+#include <QtCore/QJsonArray>
+#include <QtCore/QTimer>
 #include <QtLocation/private/qgeotilespec_p.h>
 #include <QtLocation/private/qgeotiledmapreply_p.h>
 #include <cmath>

--- a/src/Terrain/TerrainQuery.h
+++ b/src/Terrain/TerrainQuery.h
@@ -11,12 +11,12 @@
 
 #include "TerrainTile.h"
 
-#include <QObject>
-#include <QGeoCoordinate>
-#include <QGeoRectangle>
-#include <QNetworkAccessManager>
-#include <QNetworkReply>
-#include <QTimer>
+#include <QtCore/QObject>
+#include <QtPositioning/QGeoCoordinate>
+#include <QtPositioning/QGeoRectangle>
+#include <QtNetwork/QNetworkAccessManager>
+#include <QtNetwork/QNetworkReply>
+#include <QtCore/QTimer>
 #include <QtCore/QMutex>
 #include <QtCore/QLoggingCategory>
 

--- a/src/Terrain/TerrainTile.cc
+++ b/src/Terrain/TerrainTile.cc
@@ -11,10 +11,10 @@
 #include "JsonHelper.h"
 #include "QGCLoggingCategory.h"
 
-#include <QJsonDocument>
-#include <QJsonObject>
-#include <QJsonArray>
-#include <QtMath>
+#include <QtCore/QJsonDocument>
+#include <QtCore/QJsonObject>
+#include <QtCore/QJsonArray>
+#include <QtCore/QtNumeric>
 
 QGC_LOGGING_CATEGORY(TerrainTileLog, "TerrainTileLog");
 

--- a/src/Terrain/TerrainTile.h
+++ b/src/Terrain/TerrainTile.h
@@ -1,8 +1,7 @@
-#ifndef TERRAINTILE_H
-#define TERRAINTILE_H
+#pragma once
 
-#include <QGeoCoordinate>
-#include <QList>
+#include <QtPositioning/QGeoCoordinate>
+#include <QtCore/QList>
 #include <QtCore/QLoggingCategory>
 
 Q_DECLARE_LOGGING_CATEGORY(TerrainTileLog)
@@ -102,5 +101,3 @@ private:
     static const char*  _jsonAvgElevationKey;
     static const char*  _jsonCarpetKey;
 };
-
-#endif // TERRAINTILE_H

--- a/src/Utilities/CMakeLists.txt
+++ b/src/Utilities/CMakeLists.txt
@@ -49,7 +49,11 @@ target_link_libraries(Utilities
 	PRIVATE
 		Qt6::Qml
 		shp
+		FactSystem
+		Geo
 		qgc
+		QmlControls
+		Settings
 	PUBLIC
 		Qt6::Core
 		Qt6::Network

--- a/src/Utilities/JsonHelper.cc
+++ b/src/Utilities/JsonHelper.cc
@@ -14,10 +14,11 @@
 #include "FactMetaData.h"
 #include "QGCApplication.h"
 
-#include <QJsonArray>
-#include <QJsonParseError>
-#include <QObject>
-#include <QFile>
+#include <QtCore/QJsonArray>
+#include <QtCore/QJsonParseError>
+#include <QtCore/QObject>
+#include <QtCore/QFile>
+#include <QtCore/QFileInfo>
 
 const char* JsonHelper::jsonVersionKey                      = "version";
 const char* JsonHelper::jsonGroundStationKey                = "groundStation";

--- a/src/Utilities/JsonHelper.h
+++ b/src/Utilities/JsonHelper.h
@@ -9,10 +9,10 @@
 
 #pragma once
 
-#include <QJsonObject>
-#include <QVariantList>
-#include <QGeoCoordinate>
-#include <QCoreApplication>
+#include <QtCore/QJsonObject>
+#include <QtCore/QVariantList>
+#include <QtCore/QCoreApplication>
+#include <QtPositioning/QGeoCoordinate>
 
 /// @file
 /// @author Don Gagne <don@thegagnes.com>

--- a/src/Utilities/MobileScreenMgr.h
+++ b/src/Utilities/MobileScreenMgr.h
@@ -8,16 +8,15 @@
  ****************************************************************************/
 
 
-#ifndef MobileScreenMgr_H
-#define MobileScreenMgr_H
+#pragma once
 
 #ifdef __mobile__
+
 class MobileScreenMgr {
     
 public:
     /// Turns on/off screen sleep on mobile devices
     static void setKeepScreenOn(bool keepScreenOn);
 };
-#endif
 
 #endif

--- a/src/Utilities/QGC.cc
+++ b/src/Utilities/QGC.cc
@@ -10,11 +10,10 @@
 
 #include "QGC.h"
 
-#include <qmath.h>
-#include <float.h>
-
 #include <QtCore/QDateTime>
-#include <QtGlobal>
+#include <QtCore/QtNumeric>
+
+#include <float.h>
 
 namespace QGC
 {

--- a/src/Utilities/QGC.h
+++ b/src/Utilities/QGC.h
@@ -9,7 +9,7 @@
 
 #pragma once
 
-#include <QThread>
+#include <QtCore/QThread>
 
 namespace QGC
 {

--- a/src/Utilities/QGCCachedFileDownload.cc
+++ b/src/Utilities/QGCCachedFileDownload.cc
@@ -11,7 +11,7 @@
 #include "QGCCachedFileDownload.h"
 #include "QGCFileDownload.h"
 
-#include <QNetworkDiskCache>
+#include <QtNetwork/QNetworkDiskCache>
 
 QGCCachedFileDownload::QGCCachedFileDownload(QObject* parent, const QString& cacheDirectory)
     : QObject(parent), _fileDownload(new QGCFileDownload(this)), _diskCache(new QNetworkDiskCache(this))

--- a/src/Utilities/QGCFileDownload.cc
+++ b/src/Utilities/QGCFileDownload.cc
@@ -10,9 +10,9 @@
 
 #include "QGCFileDownload.h"
 
-#include <QFileInfo>
-#include <QStandardPaths>
-#include <QNetworkProxy>
+#include <QtCore/QFileInfo>
+#include <QtCore/QStandardPaths>
+#include <QtNetwork/QNetworkProxy>
 
 QGCFileDownload::QGCFileDownload(QObject* parent)
     : QNetworkAccessManager(parent)

--- a/src/Utilities/QGCFileDownload.h
+++ b/src/Utilities/QGCFileDownload.h
@@ -10,6 +10,7 @@
 #pragma once
 
 #include <QtNetwork/QNetworkReply>
+#include <QtNetwork/QNetworkRequest>
 
 class QGCFileDownload : public QNetworkAccessManager
 {

--- a/src/Utilities/QGCLoggingCategory.cc
+++ b/src/Utilities/QGCLoggingCategory.cc
@@ -13,7 +13,7 @@
 
 #include "QGCLoggingCategory.h"
 
-#include <QSettings>
+#include <QtCore/QSettings>
 
 static const char* kVideoAllLogCategory = "VideoAllLog";
 
@@ -26,7 +26,6 @@ QGC_LOGGING_CATEGORY(ParameterManagerLog,           "ParameterManagerLog")
 QGC_LOGGING_CATEGORY(GeotaggingLog,                 "GeotaggingLog")
 QGC_LOGGING_CATEGORY(RTKGPSLog,                     "RTKGPSLog")
 QGC_LOGGING_CATEGORY(GuidedActionsControllerLog,    "GuidedActionsControllerLog")
-QGC_LOGGING_CATEGORY(ADSBVehicleManagerLog,         "ADSBVehicleManagerLog")
 QGC_LOGGING_CATEGORY(LocalizationLog,               "LocalizationLog")
 QGC_LOGGING_CATEGORY(VideoAllLog,                   kVideoAllLogCategory)
 QGC_LOGGING_CATEGORY(JoystickLog,                   "JoystickLog")

--- a/src/Utilities/QGCLoggingCategory.h
+++ b/src/Utilities/QGCLoggingCategory.h
@@ -9,9 +9,9 @@
 
 #pragma once
 
-#include <QLoggingCategory>
-#include <QStringList>
-#include <QObject>
+#include <QtCore/QLoggingCategory>
+#include <QtCore/QStringList>
+#include <QtCore/QObject>
 
 // Add Global logging categories (not class specific) here using Q_DECLARE_LOGGING_CATEGORY
 Q_DECLARE_LOGGING_CATEGORY(FirmwareUpgradeLog)
@@ -22,7 +22,6 @@ Q_DECLARE_LOGGING_CATEGORY(ParameterManagerLog)
 Q_DECLARE_LOGGING_CATEGORY(GeotaggingLog)
 Q_DECLARE_LOGGING_CATEGORY(RTKGPSLog)
 Q_DECLARE_LOGGING_CATEGORY(GuidedActionsControllerLog)
-Q_DECLARE_LOGGING_CATEGORY(ADSBVehicleManagerLog)
 Q_DECLARE_LOGGING_CATEGORY(LocalizationLog)
 Q_DECLARE_LOGGING_CATEGORY(VideoAllLog) // turns on all individual QGC video logs
 Q_DECLARE_LOGGING_CATEGORY(JoystickLog)

--- a/src/Utilities/QGCQGeoCoordinate.cc
+++ b/src/Utilities/QGCQGeoCoordinate.cc
@@ -9,7 +9,7 @@
 
 #include "QGCQGeoCoordinate.h"
 
-#include <QQmlEngine>
+#include <QtQml/QQmlEngine>
 
 QGCQGeoCoordinate::QGCQGeoCoordinate(const QGeoCoordinate& coord, QObject* parent)
     : QObject       (parent)

--- a/src/Utilities/QGCQGeoCoordinate.h
+++ b/src/Utilities/QGCQGeoCoordinate.h
@@ -9,8 +9,8 @@
 
 #pragma once
 
-#include <QObject>
-#include <QGeoCoordinate>
+#include <QtCore/QObject>
+#include <QtPositioning/QGeoCoordinate>
 
 /// This is a QGeoCoordinate within a QObject such that it can be used on a QmlObjectListModel
 class QGCQGeoCoordinate : public QObject

--- a/src/Utilities/QGCTemporaryFile.cc
+++ b/src/Utilities/QGCTemporaryFile.cc
@@ -17,9 +17,9 @@
 
 #include "QGCTemporaryFile.h"
 
-#include <QDir>
-#include <QRandomGenerator>
-#include <QStandardPaths>
+#include <QtCore/QDir>
+#include <QtCore/QRandomGenerator>
+#include <QtCore/QStandardPaths>
 
 QGCTemporaryFile::QGCTemporaryFile(const QString& fileTemplate, QObject* parent) :
     QFile(parent),

--- a/src/Utilities/QGCTemporaryFile.h
+++ b/src/Utilities/QGCTemporaryFile.h
@@ -9,7 +9,7 @@
 
 #pragma once
 
-#include <QFile>
+#include <QtCore/QFile>
 
 /// @file
 ///     @brief This class mimics QTemporaryFile. We have our own implementation due to the fact that

--- a/src/Utilities/SHPFileHelper.cc
+++ b/src/Utilities/SHPFileHelper.cc
@@ -10,10 +10,9 @@
 #include "SHPFileHelper.h"
 #include "QGCGeo.h"
 
-#include <QFile>
-#include <QVariant>
+#include <QtCore/QFile>
 #include <QtCore/QDebug>
-#include <QRegularExpression>
+#include <QtCore/QRegularExpression>
 
 const char* SHPFileHelper::_errorPrefix = QT_TR_NOOP("SHP file load failed. %1");
 

--- a/src/Utilities/SHPFileHelper.h
+++ b/src/Utilities/SHPFileHelper.h
@@ -9,13 +9,13 @@
 
 #pragma once
 
-#include <QObject>
-#include <QList>
-#include <QGeoCoordinate>
-
-#include "shapefil.h"
 
 #include "ShapeFileHelper.h"
+#include "shapefil.h"
+
+#include <QtCore/QObject>
+#include <QtCore/QList>
+#include <QtPositioning/QGeoCoordinate>
 
 /// The QGCMapPolygon class provides a polygon which can be displayed on a map using a map visuals control.
 /// It maintains a representation of the polygon on QVariantList and QmlObjectListModel format.

--- a/src/Utilities/ShapeFileHelper.h
+++ b/src/Utilities/ShapeFileHelper.h
@@ -9,10 +9,10 @@
 
 #pragma once
 
-#include <QObject>
-#include <QList>
-#include <QGeoCoordinate>
-#include <QVariant>
+#include <QtCore/QObject>
+#include <QtCore/QList>
+#include <QtCore/QVariant>
+#include <QtPositioning/QGeoCoordinate>
 
 /// Routines for loading polygons or polylines from KML or SHP files.
 class ShapeFileHelper : public QObject

--- a/src/Vehicle/Actuators/ActuatorActions.h
+++ b/src/Vehicle/Actuators/ActuatorActions.h
@@ -9,12 +9,12 @@
 
 #pragma once
 
-#include <QObject>
-#include <QString>
-
 #include "Common.h"
+#include "Vehicle.h"
+#include "QmlObjectListModel.h"
 
-#include <QmlObjectListModel.h>
+#include <QtCore/QObject>
+#include <QtCore/QString>
 
 namespace ActuatorActions {
 

--- a/src/Vehicle/Actuators/ActuatorOutputs.cc
+++ b/src/Vehicle/Actuators/ActuatorOutputs.cc
@@ -8,8 +8,8 @@
  ****************************************************************************/
 
 #include "ActuatorOutputs.h"
-
-#include <QDebug>
+#include "FactSystem.h"
+#include "ParameterManager.h"
 
 using namespace ActuatorOutputs;
 

--- a/src/Vehicle/Actuators/ActuatorOutputs.h
+++ b/src/Vehicle/Actuators/ActuatorOutputs.h
@@ -9,15 +9,14 @@
 
 #pragma once
 
-#include <QObject>
-#include <QString>
-
-#include <functional>
-
 #include "Common.h"
 #include "ActuatorActions.h"
+#include "QmlObjectListModel.h"
 
-#include <QmlObjectListModel.h>
+#include <QtCore/QObject>
+#include <QtCore/QString>
+
+#include <functional>
 
 namespace ActuatorOutputs {
 

--- a/src/Vehicle/Actuators/ActuatorTesting.cc
+++ b/src/Vehicle/Actuators/ActuatorTesting.cc
@@ -11,10 +11,6 @@
 #include "Common.h"
 #include "QGCApplication.h"
 
-#include <QDebug>
-
-#include <cmath>
-
 using namespace ActuatorTesting;
 
 ActuatorTest::ActuatorTest(Vehicle* vehicle)

--- a/src/Vehicle/Actuators/ActuatorTesting.h
+++ b/src/Vehicle/Actuators/ActuatorTesting.h
@@ -9,14 +9,13 @@
 
 #pragma once
 
-#include <QObject>
-#include <QString>
 
-#include <QmlObjectListModel.h>
-
-#include <QTimer>
+#include "QmlObjectListModel.h"
 #include "Vehicle.h"
-#include "MAVLinkProtocol.h"
+#include "QGCMAVLink.h"
+#include <QtCore/QObject>
+#include <QtCore/QString>
+#include <QtCore/QTimer>
 
 namespace ActuatorTesting {
 

--- a/src/Vehicle/Actuators/Actuators.cc
+++ b/src/Vehicle/Actuators/Actuators.cc
@@ -9,12 +9,14 @@
 
 #include "Actuators.h"
 #include "GeometryImage.h"
+#include "FactSystem.h"
+#include "ParameterManager.h"
+#include "Vehicle.h"
 
-#include <QString>
-#include <QFile>
-#include <QtGlobal>
-#include <QJsonArray>
-#include <QJsonObject>
+#include <QtCore/QString>
+#include <QtCore/QFile>
+#include <QtCore/QJsonArray>
+#include <QtCore/QJsonObject>
 
 #include <algorithm>
 

--- a/src/Vehicle/Actuators/Actuators.h
+++ b/src/Vehicle/Actuators/Actuators.h
@@ -9,15 +9,16 @@
 
 #pragma once
 
-#include <QObject>
-#include <QString>
-#include <QJsonDocument>
-
 #include "ActuatorOutputs.h"
 #include "ActuatorTesting.h"
 #include "Mixer.h"
 #include "MotorAssignment.h"
 
+#include <QtCore/QObject>
+#include <QtCore/QString>
+#include <QtCore/QJsonDocument>
+
+class Vehicle;
 
 class Actuators : public QObject
 {

--- a/src/Vehicle/Actuators/CMakeLists.txt
+++ b/src/Vehicle/Actuators/CMakeLists.txt
@@ -1,4 +1,4 @@
-find_package(Qt6 REQUIRED COMPONENTS Core)
+find_package(Qt6 REQUIRED COMPONENTS Core Gui)
 
 qt_add_library(Actuators STATIC
 	ActuatorActions.cc
@@ -22,6 +22,14 @@ qt_add_library(Actuators STATIC
 target_link_libraries(Actuators
 	PRIVATE
 		qgc
+		Utilities
+	PUBLIC
+		Qt6::Core
+		Qt6::Gui
+		comm
+		FactSystem
+		QmlControls
+		Vehicle
 )
 
 target_include_directories(Actuators PUBLIC ${CMAKE_CURRENT_SOURCE_DIR})

--- a/src/Vehicle/Actuators/Common.cc
+++ b/src/Vehicle/Actuators/Common.cc
@@ -8,9 +8,9 @@
  ****************************************************************************/
 
 #include "Common.h"
+#include "FactSystem.h"
+#include "ParameterManager.h"
 #include "QGCLoggingCategory.h"
-
-#include <QDebug>
 
 QGC_LOGGING_CATEGORY(ActuatorsConfigLog, "ActuatorsConfigLog")
 

--- a/src/Vehicle/Actuators/Common.h
+++ b/src/Vehicle/Actuators/Common.h
@@ -9,18 +9,17 @@
 
 #pragma once
 
+#include "Fact.h"
 
-#include <QString>
-#include <QVector3D>
-#include <QJsonValue>
+#include <QtCore/QString>
+#include <QtCore/QJsonValue>
 #include <QtCore/QLoggingCategory>
+#include <QtGui/QVector3D>
 
-#include <stdint.h>
-
-#include "ParameterManager.h"
 
 Q_DECLARE_LOGGING_CATEGORY(ActuatorsConfigLog)
 
+class ParameterManager;
 
 /**
  * Represents a per-channel or per-item vehicle configuration parameter

--- a/src/Vehicle/Actuators/GeometryImage.cc
+++ b/src/Vehicle/Actuators/GeometryImage.cc
@@ -9,7 +9,7 @@
 
 #include "GeometryImage.h"
 
-#include <QDir>
+#include <QtCore/QDir>
 
 #include <array>
 

--- a/src/Vehicle/Actuators/GeometryImage.h
+++ b/src/Vehicle/Actuators/GeometryImage.h
@@ -9,13 +9,13 @@
 
 #pragma once
 
-#include <QObject>
-#include <QString>
-#include <QQuickImageProvider>
-#include <QPainter>
-
-#include <QGCPalette.h>
+#include "QGCPalette.h"
 #include "Common.h"
+
+#include <QtCore/QObject>
+#include <QtCore/QString>
+#include <QtQuick/QQuickImageProvider>
+#include <QtGui/QPainter>
 
 
 namespace GeometryImage {

--- a/src/Vehicle/Actuators/Mixer.cc
+++ b/src/Vehicle/Actuators/Mixer.cc
@@ -8,10 +8,8 @@
  ****************************************************************************/
 
 #include "Mixer.h"
-
-#include <QDebug>
-
-#include <cmath>
+#include "FactSystem.h"
+#include "ParameterManager.h"
 
 using namespace Mixer;
 

--- a/src/Vehicle/Actuators/Mixer.h
+++ b/src/Vehicle/Actuators/Mixer.h
@@ -9,15 +9,14 @@
 
 #pragma once
 
-#include <QObject>
-#include <QString>
-#include <QList>
-#include <QMap>
-#include <QSet>
-
 #include "Common.h"
+#include "QmlObjectListModel.h"
 
-#include <QmlObjectListModel.h>
+#include <QtCore/QObject>
+#include <QtCore/QString>
+#include <QtCore/QList>
+#include <QtCore/QMap>
+#include <QtCore/QSet>
 
 namespace Mixer {
 

--- a/src/Vehicle/Actuators/MotorAssignment.cc
+++ b/src/Vehicle/Actuators/MotorAssignment.cc
@@ -8,8 +8,9 @@
  ****************************************************************************/
 
 #include "MotorAssignment.h"
-#include "ActuatorOutputs.h"
 #include "QGCApplication.h"
+#include "ActuatorOutputs.h"
+#include "QmlObjectListModel.h"
 
 #include <vector>
 

--- a/src/Vehicle/Actuators/MotorAssignment.h
+++ b/src/Vehicle/Actuators/MotorAssignment.h
@@ -9,13 +9,13 @@
 
 #pragma once
 
-#include <QObject>
-#include <QString>
-#include <QTimer>
-
-#include "QmlControls/QmlObjectListModel.h"
 #include "Vehicle.h"
 
+#include <QtCore/QObject>
+#include <QtCore/QString>
+#include <QtCore/QTimer>
+
+class QmlObjectListModel;
 
 /**
  * Handles automatic motor ordering assignment by spinning individual motors, and then having the user

--- a/src/Vehicle/CompInfoParam.cc
+++ b/src/Vehicle/CompInfoParam.cc
@@ -14,6 +14,7 @@
 #include "FirmwarePluginManager.h"
 #include "QGCApplication.h"
 #include "QGCLoggingCategory.h"
+#include "Vehicle.h"
 
 #include <QJsonDocument>
 #include <QJsonArray>

--- a/src/Vehicle/MAVLinkLogManager.cc
+++ b/src/Vehicle/MAVLinkLogManager.cc
@@ -11,6 +11,7 @@
 #include "QGCApplication.h"
 #include "SettingsManager.h"
 #include "QGCLoggingCategory.h"
+#include "MultiVehicleManager.h"
 
 #include <QQmlEngine>
 #include <QSettings>

--- a/src/Vehicle/Vehicle.cc
+++ b/src/Vehicle/Vehicle.cc
@@ -46,6 +46,7 @@
 #include "EventHandler.h"
 #include "Actuators/Actuators.h"
 #include "QGC.h"
+#include "FactSystem.h"
 #ifdef QT_DEBUG
 #include "MockLink.h"
 #endif

--- a/src/Vehicle/VehicleLinkManager.cc
+++ b/src/Vehicle/VehicleLinkManager.cc
@@ -12,6 +12,9 @@
 #include "QGCLoggingCategory.h"
 #include "LinkManager.h"
 #include "QGCApplication.h"
+#ifndef NO_SERIAL_LINK
+    #include "SerialLink.h"
+#endif
 
 QGC_LOGGING_CATEGORY(VehicleLinkManagerLog, "VehicleLinkManagerLog")
 

--- a/src/VehicleSetup/Bootloader.cc
+++ b/src/VehicleSetup/Bootloader.cc
@@ -10,9 +10,8 @@
 #include "Bootloader.h"
 #include "QGCLoggingCategory.h"
 #include "QGC.h"
-#include <QFile>
-#include <QDebug>
-#include <QElapsedTimer>
+#include <QtCore/QFile>
+#include <QtCore/QElapsedTimer>
 
 /// This class manages interactions with the bootloader
 Bootloader::Bootloader(bool sikRadio, QObject *parent)

--- a/src/VehicleSetup/Bootloader.h
+++ b/src/VehicleSetup/Bootloader.h
@@ -17,8 +17,6 @@
 #include <QSerialPort>
 #endif
 
-#include <stdint.h>
-
 /// Bootloader Utility routines. Works with PX4 and 3DR Radio bootloaders.
 class Bootloader : public QObject
 {

--- a/src/VehicleSetup/CMakeLists.txt
+++ b/src/VehicleSetup/CMakeLists.txt
@@ -1,4 +1,4 @@
-find_package(Qt6 REQUIRED COMPONENTS Core Qml)
+find_package(Qt6 REQUIRED COMPONENTS Core Gui Qml Quick)
 
 qt_add_library(VehicleSetup STATIC
 	Bootloader.cc
@@ -31,9 +31,21 @@ add_custom_target(VehicleSetupQml
 
 target_link_libraries(VehicleSetup
 	PRIVATE
+		Qt6::Qml
+		api
 		Compression
-	PUBLIC
+		FactSystem
 		qgc
+		Settings
+		Utilities
+		Vehicle
+	PUBLIC
+		Qt6::Core
+		Qt6::Gui
+		Qt6::Quick
+		comm
+		FactControls
+		Joystick
 )
 
 target_include_directories(VehicleSetup PUBLIC ${CMAKE_CURRENT_SOURCE_DIR})

--- a/src/VehicleSetup/FirmwareImage.cc
+++ b/src/VehicleSetup/FirmwareImage.cc
@@ -14,13 +14,12 @@
 #include "CompInfoParam.h"
 #include "Bootloader.h"
 
-#include <QDebug>
-#include <QFile>
-#include <QTextStream>
-#include <QJsonDocument>
-#include <QJsonObject>
-#include <QFileInfo>
-#include <QDir>
+#include <QtCore/QFile>
+#include <QtCore/QTextStream>
+#include <QtCore/QJsonDocument>
+#include <QtCore/QJsonObject>
+#include <QtCore/QFileInfo>
+#include <QtCore/QDir>
 
 const char* FirmwareImage::_jsonBoardIdKey =            "board_id";
 const char* FirmwareImage::_jsonParamXmlSizeKey =       "parameter_xml_size";

--- a/src/VehicleSetup/FirmwareImage.h
+++ b/src/VehicleSetup/FirmwareImage.h
@@ -11,16 +11,14 @@
 /// @file
 ///     @author Don Gagne <don@thegagnes.com>
 
-#ifndef FirmwareImage_H
-#define FirmwareImage_H
+#pragma once
 
-#include <QObject>
-#include <QString>
-#include <QByteArray>
-#include <QList>
-#include <QTextStream>
 
-#include <stdint.h>
+#include <QtCore/QObject>
+#include <QtCore/QString>
+#include <QtCore/QByteArray>
+#include <QtCore/QList>
+#include <QtCore/QTextStream>
 
 /// Support for Intel Hex firmware file
 class FirmwareImage : public QObject
@@ -99,4 +97,3 @@ private:
     static const char* _jsonMavAutopilotKey;
 };
 
-#endif

--- a/src/VehicleSetup/FirmwareUpgradeController.cc
+++ b/src/VehicleSetup/FirmwareUpgradeController.cc
@@ -19,11 +19,12 @@
 #include "JsonHelper.h"
 #include "LinkManager.h"
 #include "QGCLoggingCategory.h"
+#include "MultiVehicleManager.h"
 
-#include <QStandardPaths>
-#include <QJsonDocument>
-#include <QJsonObject>
-#include <QJsonArray>
+#include <QtCore/QStandardPaths>
+#include <QtCore/QJsonDocument>
+#include <QtCore/QJsonObject>
+#include <QtCore/QJsonArray>
 
 const char* FirmwareUpgradeController::_manifestFirmwareJsonKey =               "firmware";
 const char* FirmwareUpgradeController::_manifestBoardIdJsonKey =                "board_id";

--- a/src/VehicleSetup/FirmwareUpgradeController.h
+++ b/src/VehicleSetup/FirmwareUpgradeController.h
@@ -10,20 +10,19 @@
 #pragma once
 
 #include "PX4FirmwareUpgradeThread.h"
+#include "QGCSerialPortInfo.h"
 #include "FirmwareImage.h"
 #include "Fact.h"
 
-#include <QObject>
-#include <QTimer>
-#include <QPixmap>
-#include <QQuickItem>
+#include <QtCore/QObject>
+#include <QtCore/QTimer>
+#include <QtGui/QPixmap>
+#include <QtQuick/QQuickItem>
 #ifdef Q_OS_ANDROID
-#include "qserialport.h"
+#include "qserialportinfo.h"
 #else
-#include <QSerialPort>
+#include <QtSerialPort/QSerialPortInfo>
 #endif
-
-#include <stdint.h>
 
 /// Supported firmware types. If you modify these you will need to update the qml file as well.
 

--- a/src/VehicleSetup/JoystickConfigController.cc
+++ b/src/VehicleSetup/JoystickConfigController.cc
@@ -11,6 +11,7 @@
 #include "JoystickConfigController.h"
 #include "JoystickManager.h"
 #include "QGCApplication.h"
+#include "MultiVehicleManager.h"
 #include "QGCLoggingCategory.h"
 
 QGC_LOGGING_CATEGORY(JoystickConfigControllerLog, "JoystickConfigControllerLog")

--- a/src/VehicleSetup/JoystickConfigController.h
+++ b/src/VehicleSetup/JoystickConfigController.h
@@ -11,14 +11,13 @@
 ///     @brief Joystick Config Qml Controller
 ///     @author Don Gagne <don@thegagnes.com
 
-#ifndef JoystickConfigController_H
-#define JoystickConfigController_H
-
-#include <QElapsedTimer>
-#include <QtCore/QLoggingCategory>
+#pragma once
 
 #include "FactPanelController.h"
 #include "Joystick.h"
+
+#include <QtCore/QElapsedTimer>
+#include <QtCore/QLoggingCategory>
 
 Q_DECLARE_LOGGING_CATEGORY(JoystickConfigControllerLog)
 
@@ -254,4 +253,3 @@ private:
     JoystickManager*    _joystickManager;
 };
 
-#endif // JoystickConfigController_H

--- a/src/VehicleSetup/PX4FirmwareUpgradeThread.cc
+++ b/src/VehicleSetup/PX4FirmwareUpgradeThread.cc
@@ -14,10 +14,11 @@
 
 #include "PX4FirmwareUpgradeThread.h"
 #include "Bootloader.h"
+#include "FirmwareImage.h"
 #include "QGCLoggingCategory.h"
 
-#include <QTimer>
-#include <QDebug>
+#include <QtCore/QThread>
+#include <QtCore/QTimer>
 
 PX4FirmwareUpgradeThreadWorker::PX4FirmwareUpgradeThreadWorker(PX4FirmwareUpgradeThreadController* controller)
     : _controller(controller)

--- a/src/VehicleSetup/PX4FirmwareUpgradeThread.h
+++ b/src/VehicleSetup/PX4FirmwareUpgradeThread.h
@@ -12,19 +12,19 @@
 ///     @brief PX4 Firmware Upgrade operations which occur on a separate thread.
 ///     @author Don Gagne <don@thegagnes.com>
 
-#ifndef PX4FirmwareUpgradeThread_H
-#define PX4FirmwareUpgradeThread_H
+#pragma once
 
-#include "Bootloader.h"
-#include "FirmwareImage.h"
+
 #include "QGCSerialPortInfo.h"
 
-#include <QObject>
-#include <QThread>
-#include <QTimer>
-#include <QTime>
+#include <QtCore/QObject>
+#include <QtCore/QTime>
 
 class PX4FirmwareUpgradeThreadController;
+class Bootloader;
+class FirmwareImage;
+class QThread;
+class QTimer;
 
 /// @brief Used to run bootloader commands on a separate thread. These routines are mainly meant to to be called
 ///         internally by the PX4FirmwareUpgradeThreadController. Clients should call the various public methods
@@ -135,4 +135,3 @@ private:
     const FirmwareImage* _image;
 };
 
-#endif

--- a/src/VehicleSetup/VehicleComponent.cc
+++ b/src/VehicleSetup/VehicleComponent.cc
@@ -14,6 +14,11 @@
 #include "VehicleComponent.h"
 #include "AutoPilotPlugin.h"
 #include "ParameterManager.h"
+#include "Vehicle.h"
+#include "FactSystem.h"
+
+#include <QtQml/QQmlContext>
+#include <QtQuick/QQuickItem>
 
 VehicleComponent::VehicleComponent(Vehicle* vehicle, AutoPilotPlugin* autopilot, QObject* parent) :
     QObject(parent),

--- a/src/VehicleSetup/VehicleComponent.h
+++ b/src/VehicleSetup/VehicleComponent.h
@@ -11,16 +11,17 @@
 /// @file
 ///     @author Don Gagne <don@thegagnes.com>
 
-#ifndef VEHICLECOMPONENT_H
-#define VEHICLECOMPONENT_H
+#pragma once
 
-#include <QObject>
-#include <QQmlContext>
-#include <QQuickItem>
-
-#include "Vehicle.h"
+#include <QtCore/QObject>
+#include <QtCore/QUrl>
+#include <QtCore/QVariant>
+#include <QtCore/QStringList>
 
 class AutoPilotPlugin;
+class Vehicle;
+class QQuickItem;
+class QQmlContext;
 
 /// A vehicle component is an object which abstracts the physical portion of a vehicle into a set of
 /// configurable values and user interface.
@@ -78,5 +79,3 @@ protected:
     Vehicle*            _vehicle;
     AutoPilotPlugin*    _autopilot;
 };
-
-#endif

--- a/src/VideoManager/CMakeLists.txt
+++ b/src/VideoManager/CMakeLists.txt
@@ -1,6 +1,4 @@
-find_package(Qt6 REQUIRED COMPONENTS Core Multimedia)
-
-# QGC_DISABLE_UVC
+find_package(Qt6 REQUIRED COMPONENTS Core Quick)
 
 qt_add_library(VideoManager STATIC
     GLVideoItemStub.cc
@@ -13,10 +11,26 @@ qt_add_library(VideoManager STATIC
 
 target_link_libraries(VideoManager
     PRIVATE
-        Qt6::Multimedia
+        api
+        Camera
+        FactSystem
+        QmlControls
+        Settings
+        Utilities
+        Vehicle
     PUBLIC
+        Qt6::Core
+        Qt6::Quick
         qgc
         VideoReceiver
 )
+
+option(QGC_DISABLE_UVC "Disable UVC Devices" OFF)
+if(QGC_DISABLE_UVC)
+    target_compile_options(VideoManager PUBLIC QGC_DISABLE_UVC)
+else()
+    find_package(Qt6 REQUIRED COMPONENTS Multimedia)
+    target_link_libraries(VideoManager PRIVATE Qt6::Multimedia)
+endif()
 
 target_include_directories(VideoManager PUBLIC ${CMAKE_CURRENT_SOURCE_DIR})

--- a/src/VideoManager/SubtitleWriter.cc
+++ b/src/VideoManager/SubtitleWriter.cc
@@ -16,15 +16,15 @@
 
 #include "SubtitleWriter.h"
 #include "QGCApplication.h"
-#include "QGCCorePlugin.h"
+#include "MultiVehicleManager.h"
+#include "Fact.h"
 #include "FactValueGrid.h"
 #include "HorizontalFactValueGrid.h"
 #include "InstrumentValueData.h"
 #include "QGCLoggingCategory.h"
 
-#include <QDateTime>
-#include <QString>
-#include <QDate>
+#include <QtCore/QDateTime>
+#include <QtCore/QString>
 
 QGC_LOGGING_CATEGORY(SubtitleWriterLog, "SubtitleWriterLog")
 

--- a/src/VideoManager/SubtitleWriter.h
+++ b/src/VideoManager/SubtitleWriter.h
@@ -16,11 +16,13 @@
 
 #pragma once
 
-#include "Fact.h"
-#include <QObject>
-#include <QTimer>
-#include <QFile>
+#include <QtCore/QObject>
+#include <QtCore/QTimer>
+#include <QtCore/QTime>
+#include <QtCore/QFile>
 #include <QtCore/QLoggingCategory>
+
+class Fact;
 
 Q_DECLARE_LOGGING_CATEGORY(SubtitleWriterLog)
 

--- a/src/VideoManager/VideoManager.cc
+++ b/src/VideoManager/VideoManager.cc
@@ -7,32 +7,30 @@
  *
  ****************************************************************************/
 
-
-#include <QQmlEngine>
-#include <QDir>
-#include <QQuickWindow>
-
-#ifndef QGC_DISABLE_UVC
-#include <QMediaDevices>
-#include <QCameraDevice>
-#include <QtCore/QPermissions>
-#endif
-
 #include "QGCApplication.h"
 #include "VideoManager.h"
 #include "QGCToolbox.h"
 #include "QGCCorePlugin.h"
 #include "MultiVehicleManager.h"
-#include "Settings/SettingsManager.h"
+#include "SettingsManager.h"
 #include "Vehicle.h"
 #include "QGCCameraManager.h"
 #include "QGCLoggingCategory.h"
+#include <QtQml/QQmlEngine>
 
 #if defined(QGC_GST_STREAMING)
 #include "GStreamer.h"
 #include "VideoSettings.h"
+#include <QtCore/QDir>
 #else
 #include "GLVideoItemStub.h"
+#endif
+
+#ifndef QGC_DISABLE_UVC
+#include <QtMultimedia/QMediaDevices>
+#include <QtMultimedia/QCameraDevice>
+#include <QtCore/QPermissions>
+#include <QtQuick/QQuickWindow>
 #endif
 
 QGC_LOGGING_CATEGORY(VideoManagerLog, "VideoManagerLog")

--- a/src/VideoManager/VideoManager.h
+++ b/src/VideoManager/VideoManager.h
@@ -8,8 +8,7 @@
  ****************************************************************************/
 
 
-#ifndef VideoManager_H
-#define VideoManager_H
+#pragma once
 
 #include "VideoReceiver.h"
 #include "QGCToolbox.h"
@@ -165,5 +164,3 @@ protected:
     bool                    _fullScreen             = false;
     Vehicle*                _activeVehicle          = nullptr;
 };
-
-#endif

--- a/src/VideoReceiver/GStreamer.cc
+++ b/src/VideoReceiver/GStreamer.cc
@@ -14,11 +14,11 @@
  *   @author Gus Grubba <gus@auterion.com>
  */
 
-#include <QtCore/QDebug>
-
 #include "GStreamer.h"
 #include "GstVideoReceiver.h"
 #include "QGCLoggingCategory.h"
+
+#include <QtCore/QDebug>
 
 QGC_LOGGING_CATEGORY(GStreamerLog, "GStreamerLog")
 QGC_LOGGING_CATEGORY(GStreamerAPILog, "GStreamerAPILog")

--- a/src/Viewer3D/Viewer3DQmlBackend.cc
+++ b/src/Viewer3D/Viewer3DQmlBackend.cc
@@ -1,6 +1,7 @@
 #include "Viewer3DQmlBackend.h"
 #include "QGCApplication.h"
 #include "SettingsManager.h"
+#include "MultiVehicleManager.h"
 #include "Vehicle.h"
 
 #define GPS_REF_NOT_SET                 0

--- a/src/api/CMakeLists.txt
+++ b/src/api/CMakeLists.txt
@@ -1,4 +1,4 @@
-find_package(Qt6 REQUIRED COMPONENTS Core)
+find_package(Qt6 REQUIRED COMPONENTS Core Gui Qml)
 
 qt_add_library(api STATIC
 	QGCCorePlugin.cc
@@ -12,8 +12,20 @@ qt_add_library(api STATIC
 )
 
 target_link_libraries(api
+	PRIVATE
+		Qt6::Qml
+		FactSystem
+		Joystick
+		Settings
+		Utilities
+		VideoReceiver
+		VideoManager
 	PUBLIC
+		Qt6::Core
+		Qt6::Gui
+		comm
 		qgc
+		QmlControls
 )
 
 target_include_directories(api PUBLIC ${CMAKE_CURRENT_SOURCE_DIR})

--- a/src/api/QGCCorePlugin.cc
+++ b/src/api/QGCCorePlugin.cc
@@ -7,8 +7,8 @@
  *
  ****************************************************************************/
 
-#include "QGCApplication.h"
 #include "QGCCorePlugin.h"
+#include "QGCApplication.h"
 #include "QGCOptions.h"
 #include "QmlComponentInfo.h"
 #include "FactMetaData.h"
@@ -16,6 +16,7 @@
 #include "AppMessages.h"
 #include "QmlObjectListModel.h"
 #include "VideoManager.h"
+#include "JoystickManager.h"
 #if defined(QGC_GST_STREAMING)
 #include "GStreamer.h"
 #include "VideoReceiver.h"
@@ -24,8 +25,9 @@
 #include "HorizontalFactValueGrid.h"
 #include "InstrumentValueData.h"
 
-#include <QtQml>
-#include <QQmlEngine>
+#include <QtQml/QQmlEngine>
+#include <QtQml/QQmlApplicationEngine>
+#include <QtQml/QQmlContext>
 
 /// @file
 ///     @brief Core Plugin Interface for QGroundControl - Default Implementation

--- a/src/api/QGCCorePlugin.h
+++ b/src/api/QGCCorePlugin.h
@@ -14,9 +14,9 @@
 #include "QGCMAVLink.h"
 #include "QmlObjectListModel.h"
 
-#include <QObject>
-#include <QVariantList>
-#include <QFile>
+#include <QtCore/QObject>
+#include <QtCore/QVariantList>
+#include <QtCore/QFile>
 
 /// @file
 /// @brief Core Plugin Interface for QGroundControl

--- a/src/api/QGCOptions.cc
+++ b/src/api/QGCOptions.cc
@@ -9,7 +9,7 @@
 
 #include "QGCOptions.h"
 
-#include <QtQml>
+#include <QtQml/QQmlEngine>
 
 /// @file
 ///     @brief Core Plugin Interface for QGroundControl - Application Options

--- a/src/api/QGCOptions.h
+++ b/src/api/QGCOptions.h
@@ -9,10 +9,10 @@
 
 #pragma once
 
-#include <QObject>
-#include <QString>
-#include <QUrl>
-#include <QColor>
+#include <QtCore/QObject>
+#include <QtCore/QString>
+#include <QtCore/QUrl>
+#include <QtGui/QColor>
 
 class QGCOptions;
 

--- a/src/api/QGCSettings.h
+++ b/src/api/QGCSettings.h
@@ -9,8 +9,8 @@
 
 #pragma once
 
-#include <QObject>
-#include <QUrl>
+#include <QtCore/QObject>
+#include <QtCore/QUrl>
 
 /// @file
 /// @brief Core Plugin Interface for QGroundControl. Settings element.

--- a/src/api/QmlComponentInfo.h
+++ b/src/api/QmlComponentInfo.h
@@ -9,8 +9,8 @@
 
 #pragma once
 
-#include <QObject>
-#include <QUrl>
+#include <QtCore/QObject>
+#include <QtCore/QUrl>
 
 /// Represents a Qml component which can be loaded from a resource.
 class QmlComponentInfo : public QObject

--- a/src/comm/BluetoothLink.cc
+++ b/src/comm/BluetoothLink.cc
@@ -7,19 +7,17 @@
  *
  ****************************************************************************/
 
-#include <QtGlobal>
-#include <QTimer>
-#include <QList>
-#include <QDebug>
+#include "BluetoothLink.h"
+#include "QGCApplication.h"
+#include "LinkManager.h"
 
 #include <QtBluetooth/QBluetoothDeviceDiscoveryAgent>
 #include <QtBluetooth/QBluetoothLocalDevice>
 #include <QtBluetooth/QBluetoothUuid>
 #include <QtBluetooth/QBluetoothSocket>
-
-#include "QGCApplication.h"
-#include "BluetoothLink.h"
-#include "LinkManager.h"
+#ifdef Q_OS_IOS
+#include <QtBluetooth/QBluetoothServiceDiscoveryAgent>
+#endif
 
 BluetoothLink::BluetoothLink(SharedLinkConfigurationPtr& config)
     : LinkInterface     (config)

--- a/src/comm/BluetoothLink.h
+++ b/src/comm/BluetoothLink.h
@@ -9,19 +9,19 @@
 
 #pragma once
 
-#include <QString>
-#include <QList>
-#include <QBluetoothDeviceInfo>
-#include <QtBluetooth/QBluetoothSocket>
-#include <qbluetoothserviceinfo.h>
-#include <qbluetoothservicediscoveryagent.h>
-
 #include "LinkConfiguration.h"
 #include "LinkInterface.h"
 
-class QBluetoothDeviceDiscoveryAgent;
+#include <QtCore/QString>
+#include <QtCore/QList>
+#include <QtBluetooth/QBluetoothDeviceInfo>
+#include <QtBluetooth/QBluetoothSocket>
+#ifdef Q_OS_IOS
+#include <QtBluetooth/QBluetoothServiceInfo>
 class QBluetoothServiceDiscoveryAgent;
-class LinkManager;
+#endif
+
+class QBluetoothDeviceDiscoveryAgent;
 
 class BluetoothData
 {

--- a/src/comm/CMakeLists.txt
+++ b/src/comm/CMakeLists.txt
@@ -1,10 +1,6 @@
-find_package(Qt6 REQUIRED COMPONENTS Bluetooth Core Network Test Widgets)
-
-# NO_SERIAL_LINK # TODO: Make this QGC_NO_SERIAL_LINK
+find_package(Qt6 REQUIRED COMPONENTS Core Network Qml Test Widgets)
 
 qt_add_library(comm STATIC
-	BluetoothLink.cc
-	BluetoothLink.h
 	LinkConfiguration.cc
 	LinkConfiguration.h
 	LinkInterface.cc
@@ -17,10 +13,6 @@ qt_add_library(comm STATIC
 	MAVLinkProtocol.h
 	QGCMAVLink.cc
 	QGCMAVLink.h
-	QGCSerialPortInfo.cc
-	QGCSerialPortInfo.h
-	SerialLink.cc
-	SerialLink.h
 	TCPLink.cc
 	TCPLink.h
 	UdpIODevice.cc
@@ -43,22 +35,57 @@ endif()
 
 target_link_libraries(comm
 	PRIVATE
+		Qt6::Qml
 		Qt6::Test
-	PUBLIC
-		qgc
 		Qt6::Widgets
-		Qt6::Bluetooth
+		AirLink
+		Settings
+		Vehicle
+	PUBLIC
+		Qt6::Core
 		Qt6::Network
+		qgc
+		QmlControls
+		Utilities
 )
 
-if(ANDROID)
-	add_subdirectory(${CMAKE_SOURCE_DIR}/libs/qtandroidserialport qtandroidserialport.build)
-
-    target_link_libraries(comm PUBLIC qtandroidserialport)
-else()
-	find_package(Qt6 REQUIRED COMPONENTS SerialPort)
-	target_link_libraries(comm PUBLIC Qt6::SerialPort)
+if(NOT MOBILE)
+	target_link_libraries(comm
+		PRIVATE
+			gps
+			PositionManager
+	)
 endif()
+
+option(QGC_NO_SERIAL_LINK "Disable Serial Links" OFF)
+if(QGC_NO_SERIAL_LINK)
+	target_compile_definitions(comm PUBLIC NO_SERIAL_LINK)
+else()
+	if(ANDROID)
+		add_subdirectory(${CMAKE_SOURCE_DIR}/libs/qtandroidserialport qtandroidserialport.build)
+	    target_link_libraries(comm PUBLIC qtandroidserialport)
+	else()
+		find_package(Qt6 REQUIRED COMPONENTS SerialPort)
+		target_link_libraries(comm PUBLIC Qt6::SerialPort)
+	endif()
+	target_sources(comm
+		PRIVATE
+			QGCSerialPortInfo.cc
+			QGCSerialPortInfo.h
+			SerialLink.cc
+			SerialLink.h
+	)
+endif()
+
+# option(QGC_NO_SERIAL_LINK "Enable Bluetooth Links" ON)
+target_compile_definitions(comm PUBLIC QGC_ENABLE_BLUETOOTH)
+find_package(Qt6 REQUIRED COMPONENTS Bluetooth)
+target_link_libraries(comm PUBLIC Qt6::Bluetooth)
+target_sources(comm
+	PRIVATE
+		BluetoothLink.cc
+		BluetoothLink.h
+)
 
 option(QGC_ZEROCONF_ENABLED "Enable ZeroConf Compatibility" OFF)
 if(QGC_ZEROCONF_ENABLED)
@@ -76,9 +103,8 @@ if(QGC_ZEROCONF_ENABLED)
 	FetchContent_MakeAvailable(qmdnsengine)
 
 	target_link_libraries(comm PRIVATE qmdnsengine)
+	target_compile_definitions(comm PUBLIC QGC_ZEROCONF_ENABLED)
 endif()
-
-target_compile_definitions(comm PUBLIC QGC_ENABLE_BLUETOOTH)
 
 # if(CMAKE_CXX_COMPILER_ID STREQUAL "GNU")
 # 	target_compile_options(comm PRIVATE -Wno-address-of-packed-member)

--- a/src/comm/LinkConfiguration.cc
+++ b/src/comm/LinkConfiguration.cc
@@ -21,7 +21,7 @@
 #include "MockLink.h"
 #endif
 #ifndef QGC_AIRLINK_DISABLED
-#include <AirlinkLink.h>
+#include "AirlinkLink.h"
 #endif
 
 #define LINK_SETTING_ROOT "LinkConfigurations"

--- a/src/comm/LinkConfiguration.h
+++ b/src/comm/LinkConfiguration.h
@@ -9,7 +9,7 @@
 
 #pragma once
 
-#include <QSettings>
+#include <QtCore/QSettings>
 
 #include <memory>
 

--- a/src/comm/LinkInterface.h
+++ b/src/comm/LinkInterface.h
@@ -9,12 +9,12 @@
 
 #pragma once
 
-#include <QThread>
-#include <QLoggingCategory>
+#include "LinkConfiguration.h"
+
+#include <QtCore/QThread>
+#include <QtCore/QLoggingCategory>
 
 #include <memory>
-
-#include "LinkConfiguration.h"
 
 class LinkManager;
 

--- a/src/comm/LinkManager.cc
+++ b/src/comm/LinkManager.cc
@@ -7,16 +7,16 @@
  *
  ****************************************************************************/
 
-#include <QList>
-
-#include <memory>
-
 #include "LinkManager.h"
 #include "QGCApplication.h"
 #include "UDPLink.h"
 #include "TCPLink.h"
 #include "SettingsManager.h"
 #include "LogReplayLink.h"
+#include "MAVLinkProtocol.h"
+#include "MultiVehicleManager.h"
+#include "QGCLoggingCategory.h"
+
 #ifdef QGC_ENABLE_BLUETOOTH
 #include "BluetoothLink.h"
 #endif
@@ -43,7 +43,14 @@
 #include <qmdnsengine/service.h>
 #endif
 
-#include "QGCLoggingCategory.h"
+#ifndef NO_SERIAL_LINK
+    #include "SerialLink.h"
+#endif
+
+#include <QtQml/QtQml>
+#include <QtCore/QList>
+
+#include <memory>
 
 QGC_LOGGING_CATEGORY(LinkManagerLog, "LinkManagerLog")
 QGC_LOGGING_CATEGORY(LinkManagerVerboseLog, "LinkManagerVerboseLog")

--- a/src/comm/LinkManager.h
+++ b/src/comm/LinkManager.h
@@ -9,33 +9,36 @@
 
 #pragma once
 
-#include <QList>
-#include <QtCore/QTimer>
-#include <QtCore/QLoggingCategory>
-#include <limits>
-
 #include "LinkConfiguration.h"
 #include "LinkInterface.h"
 #include "QGCToolbox.h"
-#include "MAVLinkProtocol.h"
-#if !defined(__mobile__)
-#include "LogReplayLink.h"
-#include "UdpIODevice.h"
-#endif
 #include "QmlObjectListModel.h"
 
 #ifndef NO_SERIAL_LINK
-    #include "SerialLink.h"
     #include "QGCSerialPortInfo.h"
+    #ifndef __mobile__
+        #include "UdpIODevice.h"
+    #endif
 #endif
+
+#include <QtCore/QList>
+#include <QtCore/QStringList>
+#include <QtCore/QTimer>
+#include <QtCore/QLoggingCategory>
+
+#include <limits>
 
 Q_DECLARE_LOGGING_CATEGORY(LinkManagerLog)
 Q_DECLARE_LOGGING_CATEGORY(LinkManagerVerboseLog)
 
 class QGCApplication;
+class MAVLinkProtocol;
 class UDPConfiguration;
 class AutoConnectSettings;
 class LogReplayLink;
+#ifndef NO_SERIAL_LINK
+    class SerialLink;
+#endif
 
 /// @brief Manage communication links
 ///

--- a/src/comm/LogReplayLink.cc
+++ b/src/comm/LogReplayLink.cc
@@ -11,9 +11,12 @@
 #include "LogReplayLink.h"
 #include "LinkManager.h"
 #include "QGCApplication.h"
+#include "MAVLinkProtocol.h"
+#include "MultiVehicleManager.h"
 
-#include <QFileInfo>
-#include <QSignalSpy>
+#include <QtCore/QFileInfo>
+#include <QtCore/QtEndian>
+#include <QtTest/QSignalSpy>
 
 const char*  LogReplayLinkConfiguration::_logFilenameKey = "logFilename";
 

--- a/src/comm/LogReplayLink.h
+++ b/src/comm/LogReplayLink.h
@@ -9,12 +9,15 @@
 
 #pragma once
 
-#include "MAVLinkProtocol.h"
+#include "LinkConfiguration.h"
+#include "LinkInterface.h"
+#include "QGCMAVLink.h"
 
-#include <QTimer>
-#include <QFile>
+#include <QtCore/QTimer>
+#include <QtCore/QFile>
 
 class LinkManager;
+class MAVLinkProtocol;
 
 class LogReplayLinkConfiguration : public LinkConfiguration
 {

--- a/src/comm/MAVLinkProtocol.cc
+++ b/src/comm/MAVLinkProtocol.cc
@@ -7,20 +7,19 @@
  *
  ****************************************************************************/
 
-#include <QDebug>
-#include <QApplication>
-#include <QSettings>
-#include <QStandardPaths>
-#include <QMetaType>
-#include <QDir>
-#include <QFileInfo>
-
 #include "MAVLinkProtocol.h"
 #include "LinkManager.h"
 #include "QGCApplication.h"
 #include "QGCLoggingCategory.h"
 #include "MultiVehicleManager.h"
 #include "SettingsManager.h"
+
+#include <QtWidgets/QApplication>
+#include <QtCore/QSettings>
+#include <QtCore/QStandardPaths>
+#include <QtCore/QMetaType>
+#include <QtCore/QDir>
+#include <QtCore/QFileInfo>
 
 Q_DECLARE_METATYPE(mavlink_message_t)
 

--- a/src/comm/MAVLinkProtocol.h
+++ b/src/comm/MAVLinkProtocol.h
@@ -9,14 +9,14 @@
 
 #pragma once
 
-#include <QString>
-#include <QByteArray>
-#include <QLoggingCategory>
-
 #include "LinkInterface.h"
 #include "QGCMAVLink.h"
 #include "QGCTemporaryFile.h"
 #include "QGCToolbox.h"
+
+#include <QtCore/QString>
+#include <QtCore/QByteArray>
+#include <QtCore/QLoggingCategory>
 
 class LinkManager;
 class MultiVehicleManager;

--- a/src/comm/MockLink.cc
+++ b/src/comm/MockLink.cc
@@ -13,10 +13,9 @@
 #include "LinkManager.h"
 #include "QGCLoggingCategory.h"
 
-#include <QDebug>
-#include <QFile>
-#include <QMutexLocker>
-#include <QTimer>
+#include <QtCore/QFile>
+#include <QtCore/QMutexLocker>
+#include <QtCore/QTimer>
 #include <QtCore/QTemporaryFile>
 #include <QtCore/QRandomGenerator>
 

--- a/src/comm/MockLink.h
+++ b/src/comm/MockLink.h
@@ -9,15 +9,17 @@
 
 #pragma once
 
-#include <QElapsedTimer>
-#include <QGeoCoordinate>
-#include <QLoggingCategory>
-#include <QMap>
-#include <QMutex>
-
 #include "MockLinkMissionItemHandler.h"
 #include "MockLinkFTP.h"
 #include "QGCMAVLink.h"
+#include "LinkInterface.h"
+#include "LinkConfiguration.h"
+
+#include <QtPositioning/QGeoCoordinate>
+#include <QtCore/QLoggingCategory>
+#include <QtCore/QElapsedTimer>
+#include <QtCore/QMap>
+#include <QtCore/QMutex>
 
 Q_DECLARE_LOGGING_CATEGORY(MockLinkLog)
 Q_DECLARE_LOGGING_CATEGORY(MockLinkVerboseLog)

--- a/src/comm/MockLinkFTP.cc
+++ b/src/comm/MockLinkFTP.cc
@@ -10,6 +10,7 @@
 
 #include "MockLinkFTP.h"
 #include "MockLink.h"
+#include "QGCTemporaryFile.h"
 
 const MockLinkFTP::ErrorMode_t MockLinkFTP::rgFailureModes[] = {
     MockLinkFTP::errModeNoResponse,

--- a/src/comm/MockLinkFTP.h
+++ b/src/comm/MockLinkFTP.h
@@ -12,8 +12,8 @@
 
 #include "QGCMAVLink.h"
 
-#include <QStringList>
-#include <QFile>
+#include <QtCore/QStringList>
+#include <QtCore/QFile>
 
 class MockLink;
 

--- a/src/comm/MockLinkMissionItemHandler.cc
+++ b/src/comm/MockLinkMissionItemHandler.cc
@@ -10,8 +10,10 @@
 
 #include "MockLinkMissionItemHandler.h"
 #include "MockLink.h"
+#include "MAVLinkProtocol.h"
+#include "QGCLoggingCategory.h"
 
-#include <QDebug>
+#include <QtCore/QDebug>
 
 QGC_LOGGING_CATEGORY(MockLinkMissionItemHandlerLog, "MockLinkMissionItemHandlerLog")
 

--- a/src/comm/MockLinkMissionItemHandler.h
+++ b/src/comm/MockLinkMissionItemHandler.h
@@ -10,15 +10,15 @@
 
 #pragma once
 
-#include <QObject>
-#include <QMap>
-#include <QTimer>
-
 #include "QGCMAVLink.h"
-#include "QGCLoggingCategory.h"
-#include "MAVLinkProtocol.h"
+
+#include <QtCore/QObject>
+#include <QtCore/QMap>
+#include <QtCore/QTimer>
+#include <QtCore/QLoggingCategory>
 
 class MockLink;
+class MAVLinkProtocol;
 
 Q_DECLARE_LOGGING_CATEGORY(MockLinkMissionItemHandlerLog)
 

--- a/src/comm/QGCMAVLink.cc
+++ b/src/comm/QGCMAVLink.cc
@@ -9,7 +9,7 @@
 
 #include "QGCMAVLink.h"
 
-#include <QDebug>
+#include <QtCore/QDebug>
 
 constexpr QGCMAVLink::FirmwareClass_t QGCMAVLink::FirmwareClassPX4;
 constexpr QGCMAVLink::FirmwareClass_t QGCMAVLink::FirmwareClassArduPilot;

--- a/src/comm/QGCMAVLink.h
+++ b/src/comm/QGCMAVLink.h
@@ -9,9 +9,9 @@
 
 #pragma once
 
-#include <QObject>
-#include <QString>
-#include <QList>
+#include <QtCore/QObject>
+#include <QtCore/QString>
+#include <QtCore/QList>
 
 #define MAVLINK_USE_MESSAGE_INFO
 #define MAVLINK_EXTERNAL_RX_STATUS  // Single m_mavlink_status instance is in QGCApplication.cc

--- a/src/comm/QGCSerialPortInfo.cc
+++ b/src/comm/QGCSerialPortInfo.cc
@@ -12,10 +12,10 @@
 #include "JsonHelper.h"
 #include "QGCLoggingCategory.h"
 
-#include <QFile>
-#include <QJsonDocument>
-#include <QJsonObject>
-#include <QJsonArray>
+#include <QtCore/QFile>
+#include <QtCore/QJsonDocument>
+#include <QtCore/QJsonObject>
+#include <QtCore/QJsonArray>
 
 QGC_LOGGING_CATEGORY(QGCSerialPortInfoLog, "QGCSerialPortInfoLog")
 

--- a/src/comm/QGCSerialPortInfo.h
+++ b/src/comm/QGCSerialPortInfo.h
@@ -14,7 +14,7 @@
 #ifdef Q_OS_ANDROID
     #include "qserialportinfo.h"
 #else
-    #include <QSerialPortInfo>
+    #include <QtSerialPort/QSerialPortInfo>
 #endif
 
 #include <QtCore/QLoggingCategory>

--- a/src/comm/SerialLink.cc
+++ b/src/comm/SerialLink.cc
@@ -7,21 +7,19 @@
  *
  ****************************************************************************/
 
-#include <QTimer>
-#include <QDebug>
-#include <QSettings>
-
-#ifdef Q_OS_ANDROID
-#include "qserialport.h"
-#else
-#include <QSerialPort>
-#endif
-
 #include "SerialLink.h"
 #include "QGC.h"
-#include "QGCLoggingCategory.h"
 #include "QGCApplication.h"
+#include "QGCLoggingCategory.h"
+#ifdef Q_OS_ANDROID
 #include "LinkManager.h"
+#endif
+#ifdef Q_OS_ANDROID
+#include "qserialportinfo.h"
+#else
+#include <QtSerialPort/QSerialPortInfo>
+#endif
+#include <QtCore/QSettings>
 
 QGC_LOGGING_CATEGORY(SerialLinkLog, "SerialLinkLog")
 

--- a/src/comm/SerialLink.h
+++ b/src/comm/SerialLink.h
@@ -9,24 +9,23 @@
 
 #pragma once
 
-#include <QMutex>
-#include <QString>
-
-#ifdef Q_OS_ANDROID
-#include "qserialport.h"
-#else
-#include <QSerialPort>
-#endif
-#include <QMetaType>
-#include <QLoggingCategory>
-
-// We use QSerialPort::SerialPortError in a signal so we must declare it as a meta type
-Q_DECLARE_METATYPE(QSerialPort::SerialPortError)
-
 #include "LinkConfiguration.h"
 #include "LinkInterface.h"
 
+#include <QtCore/QMutex>
+#include <QtCore/QString>
+#include <QtCore/QLoggingCategory>
+#include <QtCore/QMetaType>
+#ifdef Q_OS_ANDROID
+#include "qserialport.h"
+#else
+#include <QtSerialPort/QSerialPort>
+#endif
+
 Q_DECLARE_LOGGING_CATEGORY(SerialLinkLog)
+
+// We use QSerialPort::SerialPortError in a signal so we must declare it as a meta type
+Q_DECLARE_METATYPE(QSerialPort::SerialPortError)
 
 class LinkManager;
 

--- a/src/comm/TCPLink.cc
+++ b/src/comm/TCPLink.cc
@@ -7,12 +7,11 @@
  *
  ****************************************************************************/
 
-#include <QList>
-#include <QDebug>
-#include <QHostInfo>
-#include <QSignalSpy>
-
 #include "TCPLink.h"
+
+#include <QtCore/QList>
+#include <QtNetwork/QTcpSocket>
+#include <QtTest/QSignalSpy>
 
 TCPLink::TCPLink(SharedLinkConfigurationPtr& config)
     : LinkInterface(config)

--- a/src/comm/TCPLink.h
+++ b/src/comm/TCPLink.h
@@ -9,16 +9,19 @@
 
 #pragma once
 
-#include <QString>
-#include <QMutex>
-#include <LinkInterface.h>
 
-#include <QTcpSocket>
+#include "LinkInterface.h"
+#include "LinkConfiguration.h"
+
+#include <QtCore/QString>
+#include <QtCore/QMutex>
+#include <QtNetwork/QAbstractSocket>
 
 //#define TCPLINK_READWRITE_DEBUG   // Use to debug data reads/writes
 
 class TCPLinkTest;
 class LinkManager;
+class QTcpSocket;
 
 #define QGC_TCP_PORT 5760
 

--- a/src/comm/UDPLink.cc
+++ b/src/comm/UDPLink.cc
@@ -7,18 +7,17 @@
  *
  ****************************************************************************/
 
-#include <QtGlobal>
-#include <QList>
-#include <QDebug>
-#include <QMutexLocker>
-#include <QNetworkProxy>
-#include <QNetworkInterface>
-#include <QHostInfo>
-
 #include "UDPLink.h"
 #include "QGCApplication.h"
 #include "SettingsManager.h"
 #include "AutoConnectSettings.h"
+
+#include <QtCore/QList>
+#include <QtCore/QMutexLocker>
+#include <QtNetwork/QNetworkProxy>
+#include <QtNetwork/QNetworkInterface>
+#include <QtNetwork/QHostInfo>
+#include <QtNetwork/QUdpSocket>
 
 static const char* kZeroconfRegistration = "_qgroundcontrol._udp";
 

--- a/src/comm/UDPLink.h
+++ b/src/comm/UDPLink.h
@@ -9,21 +9,22 @@
 
 #pragma once
 
-#include <QString>
-#include <QList>
-#include <QMutex>
-#include <QUdpSocket>
-#include <QMutex>
-#include <QByteArray>
+#include "LinkConfiguration.h"
+#include "LinkInterface.h"
+
+#include <QtCore/QString>
+#include <QtCore/QList>
+#include <QtCore/QMutex>
+#include <QtCore/QMutex>
+#include <QtCore/QByteArray>
+#include <QtNetwork/QHostAddress>
 
 #if defined(QGC_ZEROCONF_ENABLED)
 #include <dns_sd.h>
 #endif
 
-#include "LinkConfiguration.h"
-#include "LinkInterface.h"
-
 class LinkManager;
+class QUdpSocket;
 
 class UDPCLient {
 public:

--- a/src/comm/UdpIODevice.cc
+++ b/src/comm/UdpIODevice.cc
@@ -8,7 +8,7 @@
  ****************************************************************************/
 
 #include "UdpIODevice.h"
-#include <algorithm>
+
 
 UdpIODevice::UdpIODevice(QObject *parent) : QUdpSocket(parent)
 {

--- a/src/comm/UdpIODevice.h
+++ b/src/comm/UdpIODevice.h
@@ -8,7 +8,8 @@
  ****************************************************************************/
 #pragma once
 
-#include <QUdpSocket>
+#include <QtCore/QByteArray>
+#include <QtNetwork/QUdpSocket>
 
 /**
  * @brief QUdpSocket implementation of canReadLine() readLineData() in server mode.

--- a/src/main.cc
+++ b/src/main.cc
@@ -7,28 +7,14 @@
  *
  ****************************************************************************/
 
-#include <QtGlobal>
-#include <QApplication>
-#include <QIcon>
-#include <QSslSocket>
-#include <QMessageBox>
-#include <QProcessEnvironment>
-#include <QHostAddress>
-#include <QUdpSocket>
-#include <QtPlugin>
-#include <QStringListModel>
-#include <QQuickStyle>
-#include <QQuickWindow>
-
-#include "QGC.h"
 #include "QGCApplication.h"
+#include "QGC.h"
 #include "AppMessages.h"
-
-#include <iostream>
-
+#include "QGCMapEngine.h"
+#include "Vehicle.h"
 #ifndef __mobile__
     #ifndef NO_SERIAL_LINK
-        #include <QSerialPort>
+        #include <QtSerialPort/QSerialPort>
     #endif
     #include "QGCSerialPortInfo.h"
     #include "RunGuard.h"
@@ -52,11 +38,16 @@
     #endif
 #endif
 
+#include <QtWidgets/QApplication>
+#include <QtGui/QIcon>
+#include <QtWidgets/QMessageBox>
+#include <QtCore/QProcessEnvironment>
+#include <QtCore/QtPlugin>
+#include <QtQuickControls2/QQuickStyle>
+#include <QtQuick/QQuickWindow>
 #ifdef QGC_ENABLE_BLUETOOTH
 #include <QtBluetooth/QBluetoothSocket>
 #endif
-
-#include "QGCMapEngine.h"
 
 /* SDL does ugly things to main() */
 #ifdef main
@@ -72,6 +63,7 @@
 #ifdef Q_OS_WIN
 
 #include <windows.h>
+#include <iostream>
 
 /// @brief CRT Report Hook installed using _CrtSetReportHook. We install this hook when
 /// we don't want asserts to pop a dialog on windows.

--- a/test/FactSystem/FactSystemTestBase.cc
+++ b/test/FactSystem/FactSystemTestBase.cc
@@ -13,6 +13,7 @@
 
 #include "FactSystemTestBase.h"
 #include "LinkManager.h"
+#include "FactSystem.h"
 #ifdef QT_DEBUG
 #include "MockLink.h"
 #endif

--- a/test/MissionManager/MissionCommandTreeEditorTest.cc
+++ b/test/MissionManager/MissionCommandTreeEditorTest.cc
@@ -10,6 +10,8 @@
 #include "MissionCommandTreeEditorTest.h"
 #include "QGCApplication.h"
 #include "QGCCorePlugin.h"
+#include "FirmwarePlugin.h"
+#include "FirmwarePluginManager.h"
 #include "SimpleMissionItem.h"
 #include "PlanMasterController.h"
 

--- a/test/Vehicle/VehicleLinkManagerTest.cc
+++ b/test/Vehicle/VehicleLinkManagerTest.cc
@@ -11,6 +11,7 @@
 #include "QGCApplication.h"
 #include "MockLink.h"
 #include "LinkManager.h"
+#include "MultiVehicleManager.h"
 #include "QGCApplication.h"
 #include "MultiSignalSpyV2.h"
 

--- a/test/qgcunittest/UnitTest.cc
+++ b/test/qgcunittest/UnitTest.cc
@@ -10,6 +10,7 @@
 #include "UnitTest.h"
 #include "QGCApplication.h"
 #include "MAVLinkProtocol.h"
+#include "MultiVehicleManager.h"
 #include "Vehicle.h"
 #include "AppSettings.h"
 #include "SettingsManager.h"


### PR DESCRIPTION
Further cleanup of includes, this time using forward declarations where necessary
Use module source in includes so that we know which modules to link to
Replace some header guards with pragma once to be consistent
Fill in module dependencies in cmake