### PR TITLE
CI: Linux Build with GNU-13

### DIFF
--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -60,6 +60,14 @@ jobs:
               chmod a+x ./tools/setup/ubuntu.sh
               ./tools/setup/ubuntu.sh
 
+      - name: Install Build Tools
+        run: |
+          sudo add-apt-repository ppa:ubuntu-toolchain-r/ppa
+          sudo apt install gcc-13 g++-13
+          sudo update-alternatives --install /usr/bin/gcc gcc /usr/bin/gcc-13 100 --slave /usr/bin/g++ g++ /usr/bin/g++-13 --slave /usr/bin/gcov gcov /usr/bin/gcov-13
+          sudo update-alternatives --set gcc /usr/bin/gcc-13
+          python3 -m pip install --user ninja meson
+
       - name: Install Vulkan
         run: |
           wget -qO - http://packages.lunarg.com/lunarg-signing-key-pub.asc | sudo apt-key add -


### PR DESCRIPTION
Switches from GCC-9 to GCC-13.
I'm also not entirely sure [Ubuntu 20.04 is officially supported](https://doc.qt.io/qt-6/supported-platforms.html) anymore?