### PR TITLE
CMake: FetchContent Improvements

### DIFF
--- a/cmake/BuildSdl2.cmake
+++ b/cmake/BuildSdl2.cmake
@@ -1,5 +1,8 @@
 function(build_sdl2)
     include(FetchContent)
+
+    set(SDL2_DISABLE_INSTALL TRUE CACHE INTERNAL "")
+    set(SDL2_DISABLE_UNINSTALL TRUE CACHE INTERNAL "")
     set(SDL2_DISABLE_SDL2MAIN TRUE CACHE INTERNAL "")
     set(SDL_SHARED FALSE CACHE INTERNAL "")
     set(SDL_STATIC TRUE CACHE INTERNAL "")
@@ -24,8 +27,11 @@ function(build_sdl2)
     set(SDL_TIMERS FALSE CACHE INTERNAL "")
     set(SDL_VIDEO FALSE CACHE INTERNAL "")
 
-    FetchContent_Declare(
-        SDL
+    set(SDL_3DNOW FALSE CACHE INTERNAL "")
+    set(SDL_MMX FALSE CACHE INTERNAL "")
+    set(SDL_VIRTUAL_JOYSTICK FALSE CACHE INTERNAL "")
+
+    FetchContent_Declare(SDL
         GIT_REPOSITORY https://github.com/libsdl-org/SDL.git
         GIT_TAG release-2.30.2
         GIT_SHALLOW TRUE

--- a/src/Compression/CMakeLists.txt
+++ b/src/Compression/CMakeLists.txt
@@ -24,26 +24,31 @@ FetchContent_MakeAvailable(zlib)
 
 ############### XZ
 
-set(XZ_EMBEDDED_DIR ${CMAKE_SOURCE_DIR}/libs/xz-embedded)
+FetchContent_Declare(xz
+    GIT_REPOSITORY https://github.com/tukaani-project/xz-embedded.git
+    GIT_TAG v2024-04-05
+    GIT_SHALLOW TRUE
+)
+FetchContent_MakeAvailable(xz)
 
 qt_add_library(xz STATIC
-    ${XZ_EMBEDDED_DIR}/linux/include/linux/xz.h
-    ${XZ_EMBEDDED_DIR}/linux/lib/xz/xz_crc32.c
-    ${XZ_EMBEDDED_DIR}/linux/lib/xz/xz_crc64.c
-    ${XZ_EMBEDDED_DIR}/linux/lib/xz/xz_dec_lzma2.c
-    ${XZ_EMBEDDED_DIR}/linux/lib/xz/xz_dec_stream.c
-    ${XZ_EMBEDDED_DIR}/linux/lib/xz/xz_lzma2.h
-    ${XZ_EMBEDDED_DIR}/linux/lib/xz/xz_private.h
-    ${XZ_EMBEDDED_DIR}/linux/lib/xz/xz_stream.h
-    ${XZ_EMBEDDED_DIR}/userspace/xz_config.h
+    ${xz_SOURCE_DIR}/linux/include/linux/xz.h
+    ${xz_SOURCE_DIR}/linux/lib/xz/xz_crc32.c
+    ${xz_SOURCE_DIR}/linux/lib/xz/xz_crc64.c
+    ${xz_SOURCE_DIR}/linux/lib/xz/xz_dec_lzma2.c
+    ${xz_SOURCE_DIR}/linux/lib/xz/xz_dec_stream.c
+    ${xz_SOURCE_DIR}/linux/lib/xz/xz_lzma2.h
+    ${xz_SOURCE_DIR}/linux/lib/xz/xz_private.h
+    ${xz_SOURCE_DIR}/linux/lib/xz/xz_stream.h
+    ${xz_SOURCE_DIR}/userspace/xz_config.h
 )
 
 target_include_directories(xz
 	PUBLIC
-        ${XZ_EMBEDDED_DIR}/linux/include/linux
+        ${xz_SOURCE_DIR}/linux/include/linux
     PRIVATE
-        ${XZ_EMBEDDED_DIR}/linux/lib/xz
-        ${XZ_EMBEDDED_DIR}/userspace
+        ${xz_SOURCE_DIR}/linux/lib/xz
+        ${xz_SOURCE_DIR}/userspace
 )
 
 target_compile_definitions(xz

--- a/src/GPS/CMakeLists.txt
+++ b/src/GPS/CMakeLists.txt
@@ -1,5 +1,17 @@
 find_package(Qt6 REQUIRED COMPONENTS Core)
 
+# include(FetchContent)
+# FetchContent_Declare(gps_drivers
+#     GIT_REPOSITORY https://github.com/PX4/PX4-GPSDrivers.git
+#     GIT_TAG main
+#     GIT_SHALLOW TRUE
+# )
+# FetchContent_GetProperties(gps_drivers)
+# if(NOT gps_drivers_POPULATED)
+# 	FetchContent_Populate(gps_drivers)
+# 	add_subdirectory(${gps_drivers_SOURCE_DIR} ${gps_drivers_BINARY_DIR} EXCLUDE_FROM_ALL)
+# endif()
+
 qt_add_library(gps STATIC
 	definitions.h
 	Drivers/src/ashtech.cpp

--- a/src/Geo/CMakeLists.txt
+++ b/src/Geo/CMakeLists.txt
@@ -1,5 +1,13 @@
 find_package(Qt6 REQUIRED COMPONENTS Core Positioning)
 
+# include(FetchContent)
+# FetchContent_Declare(geographiclib
+# 	GIT_REPOSITORY https://github.com/geographiclib/geographiclib.git
+# 	GIT_TAG v2.3
+# 	GIT_SHALLOW TRUE
+# )
+# FetchContent_MakeAvailable(geographiclib)
+
 qt_add_library(Geo STATIC
 	Constants.hpp
 	Math.cpp

--- a/src/Joystick/CMakeLists.txt
+++ b/src/Joystick/CMakeLists.txt
@@ -18,14 +18,33 @@ if(ANDROID)
 else()
 	include(BuildSdl2)
 	build_sdl2()
+
 	if(SDL2_FOUND)
 		message(STATUS "Building JoystickSDL")
+
 		target_sources(Joystick
 			PRIVATE
 				JoystickSDL.cc
 				JoystickSDL.h
 		)
-    	target_link_libraries(Joystick PRIVATE SDL2::SDL2)
+
+    	target_link_libraries(Joystick PRIVATE SDL2::SDL2-static)
+
+    	include(FetchContent)
+	    FetchContent_Declare(sdl_db
+	        GIT_REPOSITORY https://github.com/mdqinc/SDL_GameControllerDB.git
+	        GIT_TAG master
+	        GIT_SHALLOW TRUE
+	    )
+	    FetchContent_MakeAvailable(sdl_db)
+	    set_source_files_properties(${sdl_db_SOURCE_DIR}/gamecontrollerdb.txt
+		    PROPERTIES
+		        QT_RESOURCE_ALIAS gamecontrollerdb.txt
+		)
+	    qt_add_resources(Joystick "gamecontrollerdb.txt"
+		    PREFIX "/db/mapping/joystick"
+		    FILES ${sdl_db_SOURCE_DIR}/gamecontrollerdb.txt
+	    )
 	endif()
 endif()
 

--- a/src/Utilities/CMakeLists.txt
+++ b/src/Utilities/CMakeLists.txt
@@ -32,11 +32,12 @@ endif()
 set(BUILD_SHAPELIB_CONTRIB OFF CACHE INTERNAL "")
 set(BUILD_SHARED_LIBS OFF CACHE INTERNAL "")
 set(BUILD_TESTING OFF CACHE INTERNAL "")
+set(BUILD_APPS OFF CACHE INTERNAL "")
 
 include(FetchContent)
 FetchContent_Declare(shapelib
 	GIT_REPOSITORY https://github.com/OSGeo/shapelib.git
-	GIT_TAG v1.6.0
+	GIT_TAG 6fe5012
 	GIT_SHALLOW TRUE
 )
 FetchContent_GetProperties(shapelib)
@@ -60,8 +61,4 @@ target_link_libraries(Utilities
 		Qt6::Positioning
 )
 
-target_include_directories(Utilities
-	PUBLIC
-		${CMAKE_CURRENT_SOURCE_DIR}
-        ${CMAKE_SOURCE_DIR}/libs/shapelib
-)
+target_include_directories(Utilities PUBLIC ${CMAKE_CURRENT_SOURCE_DIR})

--- a/src/Vehicle/CMakeLists.txt
+++ b/src/Vehicle/CMakeLists.txt
@@ -95,6 +95,14 @@ qt_add_library(Vehicle STATIC
 	VehicleHygrometerFactGroup.h
 )
 
+# include(FetchContent)
+# FetchContent_Declare(libevents
+# 	GIT_REPOSITORY https://github.com/mavlink/libevents.git
+# 	GIT_TAG main
+# 	GIT_SHALLOW TRUE
+# )
+# FetchContent_MakeAvailable(libevents)
+
 add_subdirectory(${CMAKE_SOURCE_DIR}/libs/libevents libevents.build)
 
 target_link_libraries(Vehicle

--- a/src/comm/CMakeLists.txt
+++ b/src/comm/CMakeLists.txt
@@ -95,10 +95,10 @@ if(QGC_ZEROCONF_ENABLED)
 	set(BUILD_TESTS OFF CACHE INTERNAL "")
 
 	include(FetchContent)
-	FetchContent_Declare(
-        qmdnsengine
+	FetchContent_Declare(qmdnsengine
 		GIT_REPOSITORY https://github.com/nitroshare/qmdnsengine.git
 		GIT_TAG d61e497
+		GIT_SHALLOW TRUE
 	)
 	FetchContent_MakeAvailable(qmdnsengine)
 


### PR DESCRIPTION
Disables a couple more SDL options from being built and adds commented out structures for FetchContent in CMake for more dependencies.