### PR TITLE
CI: Add MacOS gstreamer pkgconfig path

### DIFF
--- a/.github/workflows/macos_debug.yml
+++ b/.github/workflows/macos_debug.yml
@@ -73,6 +73,7 @@ jobs:
             for package in *.pkg ;
               do sudo installer -verbose -pkg "$package" -target /
             done
+            echo "PKG_CONFIG_PATH=/Library/Frameworks/GStreamer.framework/lib/pkgconfig:${{ env.PKG_CONFIG_PATH }}" >> "$GITHUB_ENV"
 
       - name: Create build directory
         run:  mkdir ${{ runner.temp }}/shadow_build_dir

--- a/.github/workflows/macos_release.yml
+++ b/.github/workflows/macos_release.yml
@@ -17,7 +17,7 @@ on:
 
 jobs:
   build:
-    runs-on:  macos-latest
+    runs-on: macos-latest
 
     defaults:
       run:
@@ -60,11 +60,12 @@ jobs:
         env:
           GST_VERSION: 1.18.6
         run: |
-            wget https://gstreamer.freedesktop.org/data/pkg/osx/${{ env.GST_VERSION }}/gstreamer-1.0-devel-${{ env.GST_VERSION }}-x86_64.pkg
-            wget https://gstreamer.freedesktop.org/data/pkg/osx/${{ env.GST_VERSION }}/gstreamer-1.0-${{ env.GST_VERSION }}-x86_64.pkg
+            wget --quiet https://gstreamer.freedesktop.org/data/pkg/osx/${{ env.GST_VERSION }}/gstreamer-1.0-devel-${{ env.GST_VERSION }}-x86_64.pkg
+            wget --quiet https://gstreamer.freedesktop.org/data/pkg/osx/${{ env.GST_VERSION }}/gstreamer-1.0-${{ env.GST_VERSION }}-x86_64.pkg
             for package in *.pkg ;
               do sudo installer -verbose -pkg "$package" -target /
             done
+            echo "PKG_CONFIG_PATH=/Library/Frameworks/GStreamer.framework/lib/pkgconfig:${{ env.PKG_CONFIG_PATH }}" >> "$GITHUB_ENV"
 
       - name: Create build directory
         run:  mkdir ${{ runner.temp }}/shadow_build_dir
@@ -84,3 +85,4 @@ jobs:
           artifact_name: ${{ env.ARTIFACT }}
           aws_key_id: ${{ secrets.AWS_ACCESS_KEY_ID }}
           aws_secret_access_key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          source: ''


### PR DESCRIPTION
Using pkgconfig is the easiest way to find gstreamer and dependencies in cmake.