### PR TITLE
Restore Vagrant

### DIFF
--- a/deploy/vagrant/.vagrantconfig.yml
+++ b/deploy/vagrant/.vagrantconfig.yml
@@ -1,0 +1,21 @@
+configs:
+    dev:
+        'qt_deps_unpack_parent_dir': '/home/vagrant'
+
+        'qt_deps_unpack_dir': '/home/vagrant/Qt'
+        'qt_deps_bin_unpack_dir': '/home/vagrant/Qt/5.15.2/gcc_64/bin'
+        'qt_deps_lib_unpack_dir': '/home/vagrant/Qt/5.15.2/gcc_64/lib'
+        'qt_deps_plugins_unpack_dir': '/home/vagrant/Qt/5.15.2/gcc_64/plugins'
+        'qt_deps_qml_unpack_dir': '/home/vagrant/Qt/5.15.2/gcc_64/qml'
+
+        'project_root_dir': '/vagrant'
+
+        'qt_deps_dir': '/vagrant/shadow-build/release/Qt'
+        'qt_deps_bin_dir': '/vagrant/shadow-build/release/Qt/bin'
+        'qt_deps_lib_dir': '/vagrant/shadow-build/release/Qt/libs'
+        'qt_deps_plugins_dir': '/vagrant/shadow-build/release/Qt/plugins'
+        'qt_deps_qml_dir': '/vagrant/shadow-build/release/Qt/qml'
+
+        'spec': 'linux-g++-64'
+        'shadow_build_dir': '/vagrant/shadow-build'
+        'pro': '/vagrant/qgroundcontrol.pro'

--- a/deploy/vagrant/.vagrantconfig.yml
+++ b/deploy/vagrant/.vagrantconfig.yml
@@ -3,10 +3,10 @@ configs:
         'qt_deps_unpack_parent_dir': '/home/vagrant'
 
         'qt_deps_unpack_dir': '/home/vagrant/Qt'
-        'qt_deps_bin_unpack_dir': '/home/vagrant/Qt/5.15.2/gcc_64/bin'
-        'qt_deps_lib_unpack_dir': '/home/vagrant/Qt/5.15.2/gcc_64/lib'
-        'qt_deps_plugins_unpack_dir': '/home/vagrant/Qt/5.15.2/gcc_64/plugins'
-        'qt_deps_qml_unpack_dir': '/home/vagrant/Qt/5.15.2/gcc_64/qml'
+        'qt_deps_bin_unpack_dir': '/home/vagrant/Qt/6.6.3/gcc_64/bin'
+        'qt_deps_lib_unpack_dir': '/home/vagrant/Qt/6.6.3/gcc_64/lib'
+        'qt_deps_plugins_unpack_dir': '/home/vagrant/Qt/6.6.3/gcc_64/plugins'
+        'qt_deps_qml_unpack_dir': '/home/vagrant/Qt/6.6.3/gcc_64/qml'
 
         'project_root_dir': '/vagrant'
 

--- a/deploy/vagrant/Vagrantfile
+++ b/deploy/vagrant/Vagrantfile
@@ -14,16 +14,11 @@ env_global = [
 ]
 
 packages = [
-  'build-essential',
-  'fuse',
-  'git',
-  'libgstreamer-plugins-base1.0-dev',
-  'libgstreamer1.0-0:amd64',
-  'libgstreamer1.0-dev',
-  'libsdl2-dev',
   'libudev-dev',
   'speech-dispatcher',
-  'wget'
+  'wget',
+  'xubuntu-desktop',
+  'qtcreator',
 ]
 
 
@@ -60,6 +55,13 @@ Vagrant.configure(2) do |config|
   # qgroundcontrol on the host machine with:
   # "cd shadow-build/release; ./qgroundcontrol-start.sh"
 
+  # rm -rf /vagrant/shadow_build
+  # mkdir /vagrant/shadow_build
+  # cd /vagrant/shadow_build
+  # time cmake -S /vagrant -B . -G Ninja -DCMAKE_BUILD_TYPE=Release -DQGC_BUILD_TESTING=ON -DQGC_STABLE_BUILD=OFF  # 34s
+  # time cmake --build . --target all --config Release  # 75m
+  # time cmake --install . --config Release
+
   $config_shell = <<-'SHELL'
      set -e
      set -x
@@ -70,7 +72,12 @@ Vagrant.configure(2) do |config|
      sudo apt-get update -y
      # we need this long command to keep packages (grub-pc esp.) from prompting for input
      sudo DEBIAN_FRONTEND=noninteractive apt-get -y -o Dpkg::Options::="--force-confdef" -o Dpkg::Options::="--force-confold" dist-upgrade
-     sudo DEBIAN_FRONTEND=noninteractive apt-get -y -o Dpkg::Options::="--force-confdef" -o Dpkg::Options::="--force-confold" install %{apt_pkgs} xubuntu-desktop qtcreator
+
+     sudo DEBIAN_FRONTEND=noninteractive apt-get -y -o Dpkg::Options::="--force-confdef" -o Dpkg::Options::="--force-confold" install %{apt_pkgs}
+
+     # use common package installation:
+     /usr/bin/env bash /vagrant/tools/setup/ubuntu.sh
+
      sudo systemctl set-default graphical.target
 
      echo 'Initialising submodules'
@@ -84,28 +91,29 @@ Vagrant.configure(2) do |config|
      apt-get install -y patchelf
 
      dir="%{qt_deps_unpack_dir}"
-     version="5.15.2"
+     version="6.6"
      host="linux"
      target="desktop"
-     modules="qtcharts"
+     modules="qtcharts qtlocation qtpositioning qtspeech qt5compat qtmultimedia qtserialport qtimageformats qtshadertools qtconnectivity qtquick3d"
      su - vagrant -c "rm -rf ${dir}"
      su - vagrant -c "mkdir -p ${dir}"
      su - vagrant -c "python3 -m aqt install-qt -O ${dir} ${host} ${target} ${version} -m ${modules}"
 
-     mkdir -p /vagrant/shadow-build
+     # appimage requires FUSE, so allow Vagrant to use FUSE:
+     perl -pe 's/#user_allow_other/user_allow_other/' -i /etc/fuse.conf
 
      # write out a pair of scripts to make rebuilding on the VM easy:
-     su - vagrant -c "cat <<QMAKE >do-qmake.sh
+     su - vagrant -c "cat <<CONFIGURE >do-configure.sh
 #!/bin/bash
 
 set -e
 set -x
 
-cd %{shadow_build_dir}
-export LD_LIBRARY_PATH=%{qt_deps_lib_unpack_dir}
-export PATH=%{qt_deps_bin_unpack_dir}:\$PATH
-qmake -r %{pro} CONFIG+=\${CONFIG} CONFIG+=WarningsAsErrorsOn -spec %{spec}
-QMAKE
+rm -rf /vagrant/shadow_build
+mkdir /vagrant/shadow_build
+cd /vagrant/shadow_build
+time cmake -S /vagrant -B . -G Ninja -DCMAKE_BUILD_TYPE=Release -DQGC_BUILD_TESTING=ON -DQGC_STABLE_BUILD=OFF  # 34s
+CONFIGURE
 "
 
      su - vagrant -c "cat <<MAKE >do-make.sh
@@ -114,20 +122,22 @@ QMAKE
 set -e
 set -x
 
-cd %{shadow_build_dir}
-export LD_LIBRARY_PATH=%{qt_deps_lib_unpack_dir}
-export PATH=%{qt_deps_bin_unpack_dir}:\$PATH
-make -j${JOBS}
+cd /vagrant/shadow_build
+
+time cmake --build . --target all --config Release  # 75m
+rm -rf AppDir
+time cmake --install . --config Release
 MAKE
 "
-    su - vagrant -c "chmod +x do-qmake.sh do-make.sh"
+
+    su - vagrant -c "chmod +x do-configure.sh do-make.sh"
 
     # increase the allowed number of open files (the link step takes a
     # lot of open filehandles!):
 echo '*               soft    nofile          2048' >/etc/security/limits.d/fileno.conf
 
     # now run the scripts:
-    su - vagrant -c ./do-qmake.sh
+    su - vagrant -c ./do-configure.sh
     su - vagrant -c ./do-make.sh
 
    SHELL

--- a/deploy/vagrant/Vagrantfile
+++ b/deploy/vagrant/Vagrantfile
@@ -1,0 +1,159 @@
+# -*- mode: ruby -*-
+# vi: set ft=ruby :
+
+require 'yaml'
+
+current_dir    = File.dirname(File.expand_path(__FILE__))
+configfile     = YAML.load_file("#{current_dir}/.vagrantconfig.yml")
+yaml_config    = configfile['configs']['dev']
+
+env_global = [
+  'JOBS=4',
+  'SHADOW_BUILD_DIR=/tmp/shadow_build_dir',
+  'CODESIGN=nocodesign',
+]
+
+packages = [
+  'build-essential',
+  'fuse',
+  'git',
+  'libgstreamer-plugins-base1.0-dev',
+  'libgstreamer1.0-0:amd64',
+  'libgstreamer1.0-dev',
+  'libsdl2-dev',
+  'libudev-dev',
+  'speech-dispatcher',
+  'wget'
+]
+
+
+Vagrant.configure(2) do |config|
+  # This trick is used to prefer a VM box over docker
+  config.vm.provider "virtualbox"
+  config.vm.provider "vmware_fusion"
+
+  config.vm.box = "ubuntu/jammy64"
+  config.vm.provider :docker do |docker, override|
+    override.vm.box = "tknerr/baseimage-ubuntu-16.04"
+  end
+  config.vm.provider :virtualbox do |vb|
+    vb.customize ["modifyvm", :id, "--memory", "6144"]
+    vb.customize ["modifyvm", :id, "--cpus", "1"]
+    vb.gui = true
+  end
+  ["vmware_fusion", "vmware_workstation"].each do |p|
+    config.vm.provider p do |v|
+      v.vmx["memsize"] = "6144"
+      v.vmx["numvcpus"] = "1"
+      v.gui = true
+    end
+  end
+  if Vagrant.has_plugin?("vagrant-cachier")
+    config.cache.scope = :box
+    config.cache.synced_folder_opts = {
+      owner: "_apt"
+    }
+  end
+
+  # the "dev configuration puts the build products and a suitable
+  # environment into the /vagrant directory.  This allows you to run
+  # qgroundcontrol on the host machine with:
+  # "cd shadow-build/release; ./qgroundcontrol-start.sh"
+
+  $config_shell = <<-'SHELL'
+     set -e
+     set -x
+
+     export %{build_env}
+     export JOBS=$((`cat /proc/cpuinfo | grep -c ^processor`+1))
+
+     sudo apt-get update -y
+     # we need this long command to keep packages (grub-pc esp.) from prompting for input
+     sudo DEBIAN_FRONTEND=noninteractive apt-get -y -o Dpkg::Options::="--force-confdef" -o Dpkg::Options::="--force-confold" dist-upgrade
+     sudo DEBIAN_FRONTEND=noninteractive apt-get -y -o Dpkg::Options::="--force-confdef" -o Dpkg::Options::="--force-confold" install %{apt_pkgs} xubuntu-desktop qtcreator
+     sudo systemctl set-default graphical.target
+
+     echo 'Initialising submodules'
+     su - vagrant -c 'cd %{project_root_dir}; git submodule init && git submodule update'
+
+     # with reference to https://github.com/jurplel/install-qt-action@v3/blob/master/src/main.ts and .github/workflows/linux_release.yml:
+     echo 'Installing QT'
+     apt-get install -y python3-pip
+     su - vagrant -c "pip3 install --user aqtinstall"
+
+     apt-get install -y patchelf
+
+     dir="%{qt_deps_unpack_dir}"
+     version="5.15.2"
+     host="linux"
+     target="desktop"
+     modules="qtcharts"
+     su - vagrant -c "rm -rf ${dir}"
+     su - vagrant -c "mkdir -p ${dir}"
+     su - vagrant -c "python3 -m aqt install-qt -O ${dir} ${host} ${target} ${version} -m ${modules}"
+
+     mkdir -p /vagrant/shadow-build
+
+     # write out a pair of scripts to make rebuilding on the VM easy:
+     su - vagrant -c "cat <<QMAKE >do-qmake.sh
+#!/bin/bash
+
+set -e
+set -x
+
+cd %{shadow_build_dir}
+export LD_LIBRARY_PATH=%{qt_deps_lib_unpack_dir}
+export PATH=%{qt_deps_bin_unpack_dir}:\$PATH
+qmake -r %{pro} CONFIG+=\${CONFIG} CONFIG+=WarningsAsErrorsOn -spec %{spec}
+QMAKE
+"
+
+     su - vagrant -c "cat <<MAKE >do-make.sh
+#!/bin/bash
+
+set -e
+set -x
+
+cd %{shadow_build_dir}
+export LD_LIBRARY_PATH=%{qt_deps_lib_unpack_dir}
+export PATH=%{qt_deps_bin_unpack_dir}:\$PATH
+make -j${JOBS}
+MAKE
+"
+    su - vagrant -c "chmod +x do-qmake.sh do-make.sh"
+
+    # increase the allowed number of open files (the link step takes a
+    # lot of open filehandles!):
+echo '*               soft    nofile          2048' >/etc/security/limits.d/fileno.conf
+
+    # now run the scripts:
+    su - vagrant -c ./do-qmake.sh
+    su - vagrant -c ./do-make.sh
+
+   SHELL
+
+  config.vm.provision "dev", type: "shell", inline: $config_shell  % {
+    :shadow_build_dir => yaml_config['shadow_build_dir'],
+    :qt_deps_tarball => yaml_config['qt_deps_tarball'],
+    :pro => yaml_config['pro'],
+    :spec => yaml_config['spec'],
+    :apt_pkgs => (packages).join(' '),
+    :build_env => env_global.select { |item| item.is_a?(String) }.join(' '),
+
+    :project_root_dir => yaml_config['project_root_dir'],
+    :qt_deps_unpack_parent_dir => yaml_config['qt_deps_unpack_parent_dir'],
+    :qt_deps_unpack_dir => yaml_config['qt_deps_unpack_dir'],
+    :qt_deps_bin_unpack_dir => yaml_config['qt_deps_bin_unpack_dir'],
+    :qt_deps_lib_unpack_dir => yaml_config['qt_deps_lib_unpack_dir'],
+    :qt_deps_plugins_unpack_dir => yaml_config['qt_deps_plugins_unpack_dir'],
+    :qt_deps_qml_unpack_dir => yaml_config['qt_deps_qml_unpack_dir'],
+
+    :qt_deps_dir => yaml_config['qt_deps_dir'],
+    :qt_deps_bin_dir => yaml_config['qt_deps_bin_dir'],
+    :qt_deps_lib_dir => yaml_config['qt_deps_lib_dir'],
+    :qt_deps_plugins_dir => yaml_config['qt_deps_plugins_dir'],
+    :qt_deps_qml_dir => yaml_config['qt_deps_qml_dir'],
+  }
+
+
+end


### PR DESCRIPTION
Restore Vagrant build / get it working

Description
-----------
Vagrant support was removed, seemingly as some broad build-system changes, which was a little unfortunate.

This PR restores Vagrant support.

Test Steps
-----------
After running

```
VAGRANT_VAGRANTFILE=deploy/vagrant/Vagrantfile vagrant up
```

I can then run
```
/home/pbarker/rc/qgroundcontrol/shadow_build/AppDir/usr/bin/QGroundControl
```

and have that receive data from an ArduPilot SITL instance.

This is useful enough, I think.  I'd prefer to be able to generate AppImage, but there appears to be some issues with generating that on the VM.  I will continue to poke at that; there's a permission error which is relatively easily moved past but then something else <waves hands> pops up.
