### PR TITLE
libevents: update submodule

### DIFF
--- a/libs/libevents/CMakeLists.txt
+++ b/libs/libevents/CMakeLists.txt
@@ -1,64 +1,9 @@
 find_package(Qt6 REQUIRED COMPONENTS Core)
 
-qt_add_library(libevents_generated STATIC
-    libevents/libs/cpp/generated/events_generated.h
+add_subdirectory(libevents/libs/cpp)
+
+qt_add_library(libevents_wrapper STATIC
+        logging.cpp
 )
-
-target_include_directories(libevents_generated
-    PUBLIC
-        ${CMAKE_CURRENT_SOURCE_DIR}
-        libevents/libs/cpp/generated
-)
-
-
-qt_add_library(libevents_parser STATIC
-    definitions.cpp
-    libevents_definitions.h
-    libevents/libs/cpp/parse/parser.cpp
-    libevents/libs/cpp/parse/parser.h
-    libevents/libs/cpp/protocol/receive.cpp
-    libevents/libs/cpp/protocol/receive.h
-)
-
-add_subdirectory(libevents/libs/cpp/parse/nlohmann_json)
-
-target_include_directories(libevents_parser
-    PUBLIC
-        ${CMAKE_CURRENT_SOURCE_DIR}
-        libevents/libs/cpp/parse
-        libevents/libs/cpp/protocol
-)
-
-target_link_libraries(libevents_parser
-    PRIVATE
-        qgc
-    PUBLIC
-        Qt6::Core
-        comm
-)
-
-
-qt_add_library(libevents_health_and_arming_checks STATIC
-    libevents/libs/cpp/parse/health_and_arming_checks.cpp
-    libevents/libs/cpp/parse/health_and_arming_checks.h
-)
-
-target_include_directories(libevents_health_and_arming_checks
-    PUBLIC
-        ${CMAKE_CURRENT_SOURCE_DIR}
-        libevents/libs/cpp/parse
-)
-
-target_link_libraries(libevents_health_and_arming_checks
-    PUBLIC
-        libevents_parser
-)
-
-
-qt_add_library(libevents STATIC)
-
-target_link_libraries(libevents
-    PUBLIC
-        libevents_generated
-        libevents_health_and_arming_checks
-)
+target_include_directories(libevents_wrapper PUBLIC ${CMAKE_CURRENT_SOURCE_DIR})
+target_link_libraries(libevents_wrapper PUBLIC Qt6::Core comm libevents)

--- a/libs/libevents/libevents_includes.h
+++ b/libs/libevents/libevents_includes.h
@@ -7,11 +7,6 @@
  *
  ****************************************************************************/
 
-/*
- * This header defines the events::EventType type.
- *
- */
-
 #pragma once
 
 #include <cstdlib>
@@ -26,12 +21,9 @@ void qgc_events_parser_debug_printf(const char *fmt, ...);
 //#define LIBEVENTS_PARSER_DEBUG_PRINTF qgc_events_parser_debug_printf
 #define LIBEVENTS_DEBUG_PRINTF qgc_events_parser_debug_printf
 
-#include "MAVLinkProtocol.h"
+#include <MAVLinkProtocol.h>
 
-namespace events
-{
-using EventType = mavlink_event_t;
-} // namespace events
-
-
-
+#include "libevents/libs/cpp/protocol/receive.h"
+#include "libevents/libs/cpp/parse/health_and_arming_checks.h"
+#include "libevents/libs/cpp/parse/parser.h"
+#include "libevents/libs/cpp/generated/events_generated.h"

--- a/libs/libevents/logging.cpp
+++ b/libs/libevents/logging.cpp
@@ -7,9 +7,9 @@
  *
  ****************************************************************************/
 
-#include "libevents_definitions.h"
-
 #include <QGCLoggingCategory.h>
+
+#include "libevents_includes.h"
 
 QGC_LOGGING_CATEGORY(EventsLog, "EventsLog");
 
@@ -24,4 +24,3 @@ void qgc_events_parser_debug_printf(const char *fmt, ...) {
     if (len > 0) msg[len-1] = '\0'; // remove newline
     qCDebug(EventsLog) << msg;
 }
-

--- a/src/Vehicle/CMakeLists.txt
+++ b/src/Vehicle/CMakeLists.txt
@@ -122,7 +122,7 @@ target_link_libraries(Vehicle
 		Qt6::Core
 		Qt6::Gui
 		Qt6::Positioning
-        libevents
+		libevents_wrapper
 		comm
 		FactSystem
                 MissionManager

--- a/src/Vehicle/EventHandler.cc
+++ b/src/Vehicle/EventHandler.cc
@@ -72,7 +72,7 @@ void EventHandler::gotEvent(const mavlink_event_t& event)
         return;
     }
 
-    std::unique_ptr<events::parser::ParsedEvent> parsed_event = _parser.parse(event);
+    std::unique_ptr<events::parser::ParsedEvent> parsed_event = _parser.parse(events::EventType(event));
     if (parsed_event == nullptr) {
         qCWarning(EventsLog) << "Got Event w/o known metadata: ID:" << event.id << "comp id:" << _compid;
         return;

--- a/src/Vehicle/EventHandler.h
+++ b/src/Vehicle/EventHandler.h
@@ -15,10 +15,7 @@
 
 #include <functional>
 
-#include <libevents/libs/cpp/protocol/receive.h>
-#include <libevents/libs/cpp/parse/health_and_arming_checks.h>
-#include <libevents/libs/cpp/parse/parser.h>
-#include <libevents/libs/cpp/generated/events_generated.h>
+#include <libevents_includes.h>
 
 class EventHandler : public QObject
 {

--- a/src/Vehicle/HealthAndArmingCheckReport.cc
+++ b/src/Vehicle/HealthAndArmingCheckReport.cc
@@ -11,7 +11,6 @@
 #include "QGCMAVLink.h"
 #include "QmlObjectListModel.h"
 
-#include <libevents/libs/cpp/generated/events_generated.h>
 
 HealthAndArmingCheckReport::HealthAndArmingCheckReport(QObject *parent)
     : QObject(parent)

--- a/src/Vehicle/HealthAndArmingCheckReport.h
+++ b/src/Vehicle/HealthAndArmingCheckReport.h
@@ -9,7 +9,7 @@
 
 #pragma once
 
-#include <libevents/libs/cpp/parse/health_and_arming_checks.h>
+#include <libevents_includes.h>
 
 #include <QtCore/QObject>
 #include <QtCore/QString>


### PR DESCRIPTION
Simplifies the integration a bit. We can also use `ExternalProject_Add` instead of the submodule when removing qmake completely.