### PR TITLE
GStreamer: Update to 1.22.11

### DIFF
--- a/.github/workflows/android.yml
+++ b/.github/workflows/android.yml
@@ -133,15 +133,6 @@ jobs:
           modules: qtcharts qtlocation qtpositioning qtspeech qt5compat qtmultimedia qtserialport qtimageformats qtshadertools qtconnectivity qtquick3d
           cache: ${{ github.ref == 'refs/heads/master' && github.event_name != 'pull_request' }}
 
-      - name: Install gstreamer
-        working-directory: ${{ github.workspace }}
-        env:
-          GST_VERSION: 1.18.5
-        run: |
-            wget --quiet https://gstreamer.freedesktop.org/data/pkg/android/${GST_VERSION}/gstreamer-1.0-android-universal-${GST_VERSION}.tar.xz
-            mkdir gstreamer-1.0-android-universal-${GST_VERSION}
-            tar xf gstreamer-1.0-android-universal-${GST_VERSION}.tar.xz -C gstreamer-1.0-android-universal-${GST_VERSION}
-
       - name: Install dependencies
         run: sudo apt-get install -y ninja-build
 

--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -72,10 +72,10 @@ jobs:
 
       - name: Install Gstreamer
         env:
-          GST_VERSION: 1.18.6
+          GST_VERSION: 1.22.11
         run: |
-            wget --quiet https://gstreamer.freedesktop.org/data/pkg/osx/${{ env.GST_VERSION }}/gstreamer-1.0-devel-${{ env.GST_VERSION }}-x86_64.pkg
-            wget --quiet https://gstreamer.freedesktop.org/data/pkg/osx/${{ env.GST_VERSION }}/gstreamer-1.0-${{ env.GST_VERSION }}-x86_64.pkg
+            wget --quiet https://gstreamer.freedesktop.org/data/pkg/osx/${{ env.GST_VERSION }}/gstreamer-1.0-devel-${{ env.GST_VERSION }}-universal.pkg
+            wget --quiet https://gstreamer.freedesktop.org/data/pkg/osx/${{ env.GST_VERSION }}/gstreamer-1.0-${{ env.GST_VERSION }}-universal.pkg
             for package in *.pkg ;
               do sudo installer -verbose -pkg "$package" -target /
             done

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -57,12 +57,14 @@ jobs:
           tools: 'tools_cmake'
 
       - name: Install Dependencies
-        run: choco install --no-progress cmake ninja -y
+        run: |
+          choco install --no-progress ninja -y
+          choco install --no-progress cmake --installargs 'ADD_CMAKE_TO_PATH=System' --apply-install-arguments-to-dependencies
 
       - name: Install Gstreamer
         uses: blinemedical/setup-gstreamer@v1
         with:
-          version: 1.18.6
+          version: 1.22.11
         # run: choco install --no-progress gstreamer gstreamer-devel --version=1.18.6
 
       - name: Set up Visual Studio shell

--- a/cmake/DownloadGStreamer.cmake
+++ b/cmake/DownloadGStreamer.cmake
@@ -1,0 +1,33 @@
+function(download_gstreamer version)
+	# TODO: Verify Version Number
+	set(GST_VERSION ${version})
+
+	include(CMakePrintHelpers)
+
+	if(ANDROID)
+		FetchContent_Declare(gstreamer
+			URL https://gstreamer.freedesktop.org/data/pkg/android/${GST_VERSION}/gstreamer-1.0-android-universal-${GST_VERSION}.tar.xz
+			DOWNLOAD_EXTRACT_TIMESTAMP true
+		)
+		FetchContent_MakeAvailable(gstreamer)
+		cmake_print_variables(gstreamer_SOURCE_DIR)
+
+		if(${CMAKE_ANDROID_ARCH_ABI} STREQUAL armeabi-v7a)
+            set(GSTREAMER_ROOT ${gstreamer_SOURCE_DIR}/armv7 PARENT_SCOPE)
+        elseif(${CMAKE_ANDROID_ARCH_ABI} STREQUAL arm64-v8a)
+            set(GSTREAMER_ROOT ${gstreamer_SOURCE_DIR}/arm64 PARENT_SCOPE)
+        elseif(${CMAKE_ANDROID_ARCH_ABI} STREQUAL x86)
+            set(GSTREAMER_ROOT ${gstreamer_SOURCE_DIR}/x86 PARENT_SCOPE)
+        elseif(${CMAKE_ANDROID_ARCH_ABI} STREQUAL x86_64)
+            set(GSTREAMER_ROOT ${gstreamer_SOURCE_DIR}/x86_64 PARENT_SCOPE)
+        endif()
+	endif()
+
+	FetchContent_Declare(gstreamer_good_plugins
+		URL https://gstreamer.freedesktop.org/src/gst-plugins-good/gst-plugins-good-${GST_VERSION}.tar.xz
+		DOWNLOAD_EXTRACT_TIMESTAMP true
+	)
+	FetchContent_MakeAvailable(gstreamer_good_plugins)
+	cmake_print_variables(gstreamer_good_plugins_SOURCE_DIR)
+	set(GST_QT6_PLUGIN_PATH ${gstreamer_good_plugins_SOURCE_DIR}/ext/qt6 PARENT_SCOPE)
+endfunction()

--- a/libs/qmlglsink/CMakeLists.txt
+++ b/libs/qmlglsink/CMakeLists.txt
@@ -9,11 +9,20 @@ if(QGC_ENABLE_VIDEOSTREAMING)
 	endif()
 
     if(LINUX)
-	    set(GST_TARGET_VERSION 1.16)
-	elseif(ANDROID)
-		set(GST_TARGET_VERSION 1.18.5)
+    	if(DEFINED ENV{GST_VERSION})
+    		set(GST_TARGET_VERSION $ENV{GST_VERSION})
+		else()
+	    	set(GST_TARGET_VERSION 1.16)
+	    endif()
 	else()
-		set(GST_TARGET_VERSION 1.18)
+		if(DEFINED ENV{GST_VERSION})
+			set(GST_TARGET_VERSION $ENV{GST_VERSION})
+		else()
+			set(GST_TARGET_VERSION 1.22.11)
+		endif()
+		include(DownloadGStreamer)
+		# TODO: Download using ${GST_gstreamer-1.0_VERSION}
+		download_gstreamer(${GST_TARGET_VERSION})
 	endif()
 
 	set(GST_TARGET_PLUGINS
@@ -45,46 +54,38 @@ if(QGC_ENABLE_VIDEOSTREAMING)
 		gstreamer-video-1.0
 	)
 	if(LINUX)
-		list(APPEND GST_TARGET_MODULES egl)
+		list(APPEND GST_TARGET_MODULES
+			# gstreamer-gl-x11-1.0
+			# gstreamer-gl-egl-1.0
+			# gstreamer-gl-wayland-1.0
+			egl
+		)
 	endif()
 
-	# find_library(GSTREAMER_${_upper_name}_LIBRARY
-    #      NAMES
-    #      	gst${_lower_name}-${_abi_version}
-    #      HINTS
-    #      	${PKG_GSTREAMER_${_upper_name}_LIBRARY_DIRS}
-    #         ${PKG_GSTREAMER_${_upper_name}_LIBDIR}
-    # )
-
-    # find_path(GSTREAMER_${_upper_name}_INCLUDE_DIR
-	# 	gst/${_lower_name}/${_header}
-	# 	HINTS
-	# 		${PKG_GSTREAMER_${_upper_name}_INCLUDE_DIRS}
-	# 		PKG_GSTREAMER_${_upper_name}_INCLUDEDIR}
-	# 	PATH_SUFFIXES gstreamer-${_abi_version}
-    # )
-
-	set(GSTREAMER_ROOT)
-	if(WIN32)
-		if(EXISTS $ENV{GSTREAMER_ROOT_X86_64})
-			set(GSTREAMER_ROOT $ENV{GSTREAMER_ROOT_X86_64})
-		elseif(EXISTS $ENV{GSTREAMER_1_0_ROOT_MSVC_X86_64})
-			set(GSTREAMER_ROOT $ENV{GSTREAMER_1_0_ROOT_MSVC_X86_64})
-		else()
-			set(GSTREAMER_ROOT "C:/gstreamer/1.0/msvc_x86_64")
+    if(NOT GSTREAMER_ROOT)
+		set(GSTREAMER_ROOT)
+		if(WIN32)
+			if(DEFINED ENV{GSTREAMER_ROOT_X86_64} AND EXISTS $ENV{GSTREAMER_ROOT_X86_64})
+				set(GSTREAMER_ROOT $ENV{GSTREAMER_ROOT_X86_64})
+			elseif(DEFINED ENV{GSTREAMER_1_0_ROOT_MSVC_X86_64} AND EXISTS $ENV{GSTREAMER_1_0_ROOT_MSVC_X86_64})
+				set(GSTREAMER_ROOT $ENV{GSTREAMER_1_0_ROOT_MSVC_X86_64})
+			else()
+				set(GSTREAMER_ROOT "C:/gstreamer/1.0/msvc_x86_64")
+			endif()
+		elseif(MACOS)
+			set(GSTREAMER_ROOT "/Library/Frameworks/GStreamer.framework")
+		elseif(ANDROID)
+			set(ANDROID_GSTREAMER_ROOT ${CMAKE_SOURCE_DIR}/gstreamer-1.0-android-universal-${GST_TARGET_VERSION})
+			if(${ANDROID_ABI} STREQUAL armeabi-v7a)
+	            set(GSTREAMER_ROOT ${ANDROID_GSTREAMER_ROOT}/armv7)
+	        elseif(${ANDROID_ABI} STREQUAL arm64-v8a)
+	            set(GSTREAMER_ROOT ${ANDROID_GSTREAMER_ROOT}/arm64)
+	        elseif(${ANDROID_ABI} STREQUAL x86)
+	            set(GSTREAMER_ROOT ${ANDROID_GSTREAMER_ROOT}/x86)
+	        elseif(${ANDROID_ABI} STREQUAL x86_64)
+	            set(GSTREAMER_ROOT ${ANDROID_GSTREAMER_ROOT}/x86_64)
+	        endif()
 		endif()
-	elseif(MACOS)
-		set(GSTREAMER_ROOT "/Library/Frameworks/GStreamer.framework")
-	elseif(ANDROID)
-		if(${ANDROID_ABI} STREQUAL armeabi-v7a)
-            set(GSTREAMER_ROOT ${CMAKE_SOURCE_DIR}/gstreamer-1.0-android-universal-${GST_TARGET_VERSION}/armv7)
-        elseif(${ANDROID_ABI} STREQUAL arm64-v8a)
-            set(GSTREAMER_ROOT ${CMAKE_SOURCE_DIR}/gstreamer-1.0-android-universal-${GST_TARGET_VERSION}/arm64)
-        elseif(${ANDROID_ABI} STREQUAL x86)
-            set(GSTREAMER_ROOT ${CMAKE_SOURCE_DIR}/gstreamer-1.0-android-universal-${GST_TARGET_VERSION}/x86)
-        elseif(${ANDROID_ABI} STREQUAL x86_64)
-            set(GSTREAMER_ROOT ${CMAKE_SOURCE_DIR}/gstreamer-1.0-android-universal-${GST_TARGET_VERSION}/x86_64)
-        endif()
 	endif()
 
 	find_package(PkgConfig)
@@ -135,6 +136,10 @@ if(QGC_ENABLE_VIDEOSTREAMING)
 		if(TARGET PkgConfig::GST)
 			target_link_libraries(qmlglsink PUBLIC PkgConfig::GST)
 			target_include_directories(qmlglsink PUBLIC ${GSTREAMER_ROOT}/include/gstreamer-1.0)
+			message(STATUS "GStreamer version: ${GST_gstreamer-1.0_VERSION}")
+		    message(STATUS "GStreamer prefix: ${GST_gstreamer-1.0_PREFIX}")
+		    message(STATUS "GStreamer include dir: ${GST_gstreamer-1.0_INCLUDEDIR}")
+		    message(STATUS "GStreamer libdir: ${GST_gstreamer-1.0_LIBDIR}")
 			if(GST_STATIC_BUILD)
 		        target_link_libraries(qmlglsink PUBLIC ${GST_STATIC_LINK_LIBRARIES})
 	    		target_link_directories(qmlglsink PUBLIC ${GST_STATIC_LIBRARY_DIRS})
@@ -144,6 +149,22 @@ if(QGC_ENABLE_VIDEOSTREAMING)
 	    		if(ANDROID)
 					target_link_options(PkgConfig::GST INTERFACE "-Wl,-Bsymbolic")
 				endif()
+				list(REMOVE_DUPLICATES GST_STATIC_LIBRARIES)
+				list(REMOVE_DUPLICATES GST_STATIC_LINK_LIBRARIES)
+				list(REMOVE_DUPLICATES GST_STATIC_LIBRARY_DIRS)
+				list(REMOVE_DUPLICATES GST_STATIC_INCLUDE_DIRS)
+				list(REMOVE_DUPLICATES GST_STATIC_LDFLAGS)
+				list(REMOVE_DUPLICATES GST_STATIC_LDFLAGS_OTHER)
+				list(REMOVE_DUPLICATES GST_STATIC_CFLAGS)
+				list(REMOVE_DUPLICATES GST_STATIC_CFLAGS_OTHER)
+			    message(VERBOSE "GStreamer static libs: ${GST_STATIC_LIBRARIES}")
+			    message(VERBOSE "GStreamer static link libs: ${GST_STATIC_LINK_LIBRARIES}")
+			    message(VERBOSE "GStreamer static link dirs: ${GST_STATIC_LIBRARY_DIRS}")
+			    message(VERBOSE "GStreamer static include dirs: ${GST_STATIC_INCLUDE_DIRS}")
+			    message(VERBOSE "GStreamer static ldflags: ${GST_STATIC_LDFLAGS}")
+			    message(VERBOSE "GStreamer static ldflags other: ${GST_STATIC_LDFLAGS_OTHER}")
+			    message(VERBOSE "GStreamer static cflags: ${GST_STATIC_CFLAGS}")
+			    message(VERBOSE "GStreamer static cflags other: ${GST_STATIC_CFLAGS_OTHER}")
 	    	else()
 		        target_link_libraries(qmlglsink PUBLIC ${GST_LINK_LIBRARIES})
 	    		target_link_directories(qmlglsink PUBLIC ${GST_LIBRARY_DIRS})
@@ -157,8 +178,23 @@ if(QGC_ENABLE_VIDEOSTREAMING)
 		    		# TODO: Only install needed libs
 		    		install(FILES ${GST_WIN_BINS} DESTINATION ${CMAKE_INSTALL_BINDIR})
 		    	endif()
+		    	list(REMOVE_DUPLICATES GST_LIBRARIES)
+				list(REMOVE_DUPLICATES GST_LINK_LIBRARIES)
+				list(REMOVE_DUPLICATES GST_LIBRARY_DIRS)
+				list(REMOVE_DUPLICATES GST_LDFLAGS)
+				list(REMOVE_DUPLICATES GST_LDFLAGS_OTHER)
+				list(REMOVE_DUPLICATES GST_INCLUDE_DIRS)
+				list(REMOVE_DUPLICATES GST_CFLAGS)
+				list(REMOVE_DUPLICATES GST_CFLAGS_OTHER)
+			    message(VERBOSE "GStreamer libs: ${GST_LIBRARIES}")
+			    message(VERBOSE "GStreamer link libs: ${GST_LINK_LIBRARIES}")
+			    message(VERBOSE "GStreamer link dirs: ${GST_LIBRARY_DIRS}")
+			    message(VERBOSE "GStreamer ldflags: ${GST_LDFLAGS}")
+			    message(VERBOSE "GStreamer ldflags other: ${GST_LDFLAGS_OTHER}")
+			    message(VERBOSE "GStreamer include dirs: ${GST_INCLUDE_DIRS}")
+			    message(VERBOSE "GStreamer cflags: ${GST_CFLAGS}")
+			    message(VERBOSE "GStreamer cflags other: ${GST_CFLAGS_OTHER}")
 	    	endif()
-	    	# file(GET_RUNTIME_DEPENDENCIES)
 		endif()
 	else()
 		message(WARNING "Gstreamer Not Found")
@@ -166,115 +202,84 @@ if(QGC_ENABLE_VIDEOSTREAMING)
 
 	if(GST_FOUND)
 		message(STATUS "GST Modules Found")
-		target_sources(qmlglsink
-	        PRIVATE
-	            qt6/gstplugin.cc
-	            qt6/gstqml6glsink.cc
-	            qt6/gstqml6glsink.h
-	            qt6/gstqsg6glnode.cc
-	            qt6/gstqsg6glnode.h
-	            qt6/gstqt6element.cc
-	            qt6/gstqt6elements.h
-	            qt6/gstqt6gl.h
-	            qt6/gstqt6glutility.cc
-	            qt6/gstqt6glutility.h
-	            qt6/qt6glitem.cc
-	            qt6/qt6glitem.h
-	    )
-
-		find_package(Qt6 REQUIRED COMPONENTS Core Gui OpenGL Qml Quick)
-	    target_link_libraries(qmlglsink
-	        PUBLIC
-				Qt6::Core
-				Qt6::Gui
-				Qt6::GuiPrivate
-				Qt6::OpenGL
-				Qt6::Qml
-				Qt6::Quick
-		)
-		if(WIN32)
-			find_package(OpenGL)
-			target_link_libraries(qmlglsink PUBLIC OpenGL::GL)
-		elseif(LINUX)
-			# find_package(Qt6 COMPONENTS WaylandClient)
-			if(Qt6WaylandClient_FOUND)
-				target_link_libraries(qmlglsink PRIVATE Qt6::WaylandClient)
-			endif()
+		if(NOT GST_QT6_PLUGIN_PATH)
+			set(GST_QT6_PLUGIN_PATH ${CMAKE_CURRENT_SOURCE_DIR}/qt6)
 		endif()
+		cmake_print_variables(GST_QT6_PLUGIN_PATH)
+		if(EXISTS ${GST_QT6_PLUGIN_PATH})
+			set(GST_QT6_PLUGIN_FOUND TRUE CACHE INTERNAL "")
+			target_sources(qmlglsink
+		        PRIVATE
+		            ${GST_QT6_PLUGIN_PATH}/gstplugin.cc
+		            ${GST_QT6_PLUGIN_PATH}/gstqml6glsink.cc
+		            ${GST_QT6_PLUGIN_PATH}/gstqml6glsink.h
+		            ${GST_QT6_PLUGIN_PATH}/gstqsg6glnode.cc
+		            ${GST_QT6_PLUGIN_PATH}/gstqsg6glnode.h
+		            ${GST_QT6_PLUGIN_PATH}/gstqt6element.cc
+		            ${GST_QT6_PLUGIN_PATH}/gstqt6elements.h
+		            ${GST_QT6_PLUGIN_PATH}/gstqt6gl.h
+		            ${GST_QT6_PLUGIN_PATH}/gstqt6glutility.cc
+		            ${GST_QT6_PLUGIN_PATH}/gstqt6glutility.h
+		            ${GST_QT6_PLUGIN_PATH}/qt6glitem.cc
+		            ${GST_QT6_PLUGIN_PATH}/qt6glitem.h
+		    )
 
-	    target_include_directories(qmlglsink PUBLIC qt6)
-
-	    target_compile_definitions(qmlglsink
-	        PRIVATE
-	            HAVE_QT_QPA_HEADER
-	            QT_QPA_HEADER=<QtGui/qpa/qplatformnativeinterface.h>
-	    )
-	    if(LINUX)
-	    	target_compile_definitions(qmlglsink PRIVATE HAVE_QT_X11)
-	    	if(EGL_FOUND)
-				target_compile_definitions(qmlglsink PRIVATE HAVE_QT_EGLFS)
+			find_package(Qt6 REQUIRED COMPONENTS Core Gui OpenGL Qml Quick)
+		    target_link_libraries(qmlglsink
+		        PUBLIC
+					Qt6::Core
+					Qt6::Gui
+					Qt6::GuiPrivate
+					Qt6::OpenGL
+					Qt6::Qml
+					Qt6::Quick
+			)
+			if(WIN32)
+				find_package(OpenGL)
+				target_link_libraries(qmlglsink PUBLIC OpenGL::GL)
+			elseif(LINUX)
+				# find_package(Qt6 COMPONENTS WaylandClient)
+				if(Qt6WaylandClient_FOUND)
+					target_link_libraries(qmlglsink PRIVATE Qt6::WaylandClient)
+				endif()
 			endif()
-	        if(Qt6WaylandClient_FOUND)
-				target_compile_definitions(qmlglsink PRIVATE HAVE_QT_WAYLAND)
-			endif()
-		elseif(ANDROID)
-			target_compile_definitions(qmlglsink PRIVATE HAVE_QT_ANDROID)
-		elseif(WIN32)
-			target_compile_definitions(qmlglsink PRIVATE HAVE_QT_WIN32)
-	    elseif(MACOS)
-	    	target_compile_definitions(qmlglsink PRIVATE HAVE_QT_MAC)
-	    elseif(IOS)
-			target_compile_definitions(qmlglsink PRIVATE HAVE_QT_IOS)
-			message(WARNING "qmlglsink not supported for IOS")
-	   	endif()
 
-	   	if(UNIX)
-	   		target_compile_options(qmlglsink
-	            PRIVATE
-	                -Wno-unused-parameter
-	                -Wno-implicit-fallthrough
-	                -Wno-unused-private-field
-	        )
-	    endif()
+		    target_include_directories(qmlglsink PUBLIC qt6)
 
-	    message(STATUS "GStreamer version: ${GST_gstreamer-1.0_VERSION}")
-	    message(STATUS "GStreamer prefix: ${GST_gstreamer-1.0_PREFIX}")
-	    message(STATUS "GStreamer include dir: ${GST_gstreamer-1.0_INCLUDEDIR}")
-	    message(STATUS "GStreamer libdir: ${GST_gstreamer-1.0_LIBDIR}")
-		if(GST_STATIC_BUILD)
-			list(REMOVE_DUPLICATES GST_STATIC_LIBRARIES)
-			list(REMOVE_DUPLICATES GST_STATIC_LINK_LIBRARIES)
-			list(REMOVE_DUPLICATES GST_STATIC_LIBRARY_DIRS)
-			list(REMOVE_DUPLICATES GST_STATIC_INCLUDE_DIRS)
-			list(REMOVE_DUPLICATES GST_STATIC_LDFLAGS)
-			list(REMOVE_DUPLICATES GST_STATIC_LDFLAGS_OTHER)
-			list(REMOVE_DUPLICATES GST_STATIC_CFLAGS)
-			list(REMOVE_DUPLICATES GST_STATIC_CFLAGS_OTHER)
-		    message(VERBOSE "GStreamer static libs: ${GST_STATIC_LIBRARIES}")
-		    message(VERBOSE "GStreamer static link libs: ${GST_STATIC_LINK_LIBRARIES}")
-		    message(VERBOSE "GStreamer static link dirs: ${GST_STATIC_LIBRARY_DIRS}")
-		    message(VERBOSE "GStreamer static include dirs: ${GST_STATIC_INCLUDE_DIRS}")
-		    message(VERBOSE "GStreamer static ldflags: ${GST_STATIC_LDFLAGS}")
-		    message(VERBOSE "GStreamer static ldflags other: ${GST_STATIC_LDFLAGS_OTHER}")
-		    message(VERBOSE "GStreamer static cflags: ${GST_STATIC_CFLAGS}")
-		    message(VERBOSE "GStreamer static cflags other: ${GST_STATIC_CFLAGS_OTHER}")
+		    target_compile_definitions(qmlglsink
+		        PRIVATE
+		            HAVE_QT_QPA_HEADER
+		            QT_QPA_HEADER=<QtGui/qpa/qplatformnativeinterface.h>
+		    )
+		    if(LINUX)
+		    	target_compile_definitions(qmlglsink PRIVATE HAVE_QT_X11)
+		    	if(EGL_FOUND)
+					target_compile_definitions(qmlglsink PRIVATE HAVE_QT_EGLFS)
+				endif()
+		        if(Qt6WaylandClient_FOUND)
+					target_compile_definitions(qmlglsink PRIVATE HAVE_QT_WAYLAND)
+				endif()
+			elseif(ANDROID)
+				target_compile_definitions(qmlglsink PRIVATE HAVE_QT_ANDROID)
+			elseif(WIN32)
+				target_compile_definitions(qmlglsink PRIVATE HAVE_QT_WIN32)
+		    elseif(MACOS)
+		    	target_compile_definitions(qmlglsink PRIVATE HAVE_QT_MAC)
+		    elseif(IOS)
+				target_compile_definitions(qmlglsink PRIVATE HAVE_QT_IOS)
+				message(WARNING "qmlglsink not supported for IOS")
+		   	endif()
+
+		   	if(UNIX)
+		   		target_compile_options(qmlglsink
+		            PRIVATE
+		                -Wno-unused-parameter
+		                -Wno-implicit-fallthrough
+		                -Wno-unused-private-field
+		        )
+		    endif()
 		else()
-			list(REMOVE_DUPLICATES GST_LIBRARIES)
-			list(REMOVE_DUPLICATES GST_LINK_LIBRARIES)
-			list(REMOVE_DUPLICATES GST_LIBRARY_DIRS)
-			list(REMOVE_DUPLICATES GST_LDFLAGS)
-			list(REMOVE_DUPLICATES GST_LDFLAGS_OTHER)
-			list(REMOVE_DUPLICATES GST_INCLUDE_DIRS)
-			list(REMOVE_DUPLICATES GST_CFLAGS)
-			list(REMOVE_DUPLICATES GST_CFLAGS_OTHER)
-		    message(VERBOSE "GStreamer libs: ${GST_LIBRARIES}")
-		    message(VERBOSE "GStreamer link libs: ${GST_LINK_LIBRARIES}")
-		    message(VERBOSE "GStreamer link dirs: ${GST_LIBRARY_DIRS}")
-		    message(VERBOSE "GStreamer ldflags: ${GST_LDFLAGS}")
-		    message(VERBOSE "GStreamer ldflags other: ${GST_LDFLAGS_OTHER}")
-		    message(VERBOSE "GStreamer include dirs: ${GST_INCLUDE_DIRS}")
-		    message(VERBOSE "GStreamer cflags: ${GST_CFLAGS}")
-		    message(VERBOSE "GStreamer cflags other: ${GST_CFLAGS_OTHER}")
+			message(WARNING "GST Qt Plugin Not Found")
 		endif()
 	else()
 		message(WARNING "GST Modules Not Found")
@@ -282,3 +287,21 @@ if(QGC_ENABLE_VIDEOSTREAMING)
 else()
     message(STATUS "Video streaming disabled")
 endif()
+
+# find_library(GSTREAMER_${_upper_name}_LIBRARY
+#      NAMES
+#      	gst${_lower_name}-${_abi_version}
+#      HINTS
+#      	${PKG_GSTREAMER_${_upper_name}_LIBRARY_DIRS}
+#         ${PKG_GSTREAMER_${_upper_name}_LIBDIR}
+# )
+
+# find_path(GSTREAMER_${_upper_name}_INCLUDE_DIR
+# 	gst/${_lower_name}/${_header}
+# 	HINTS
+# 		${PKG_GSTREAMER_${_upper_name}_INCLUDE_DIRS}
+# 		PKG_GSTREAMER_${_upper_name}_INCLUDEDIR}
+# 	PATH_SUFFIXES gstreamer-${_abi_version}
+# )
+
+# file(GET_RUNTIME_DEPENDENCIES)

--- a/libs/qmlglsink/qt6/gstplugin.cc
+++ b/libs/qmlglsink/qt6/gstplugin.cc
@@ -41,7 +41,7 @@ plugin_init (GstPlugin * plugin)
 
 static void registerMetatypes()
 {
-    qmlRegisterType<Qt6GLVideoItem> ("org.freedesktop.gstreamer.GLVideoItem", 1, 0, "GstGLVideoItem");
+    qmlRegisterType<Qt6GLVideoItem> ("org.freedesktop.gstreamer.Qt6GLVideoItem", 1, 0, "GstGLQt6VideoItem");
 }
 
 Q_CONSTRUCTOR_FUNCTION(registerMetatypes)

--- a/src/FlightMap/QGCVideoBackground.qml
+++ b/src/FlightMap/QGCVideoBackground.qml
@@ -16,9 +16,9 @@
 
 import QtQuick
 import QtQuick.Controls
-import org.freedesktop.gstreamer.GLVideoItem
+import org.freedesktop.gstreamer.Qt6GLVideoItem
 
-GstGLVideoItem {
+GstGLQt6VideoItem {
     id: videoBackground
     property var receiver
 }

--- a/src/VideoManager/VideoManager.cc
+++ b/src/VideoManager/VideoManager.cc
@@ -50,7 +50,7 @@ VideoManager::VideoManager(QGCApplication* app, QGCToolbox* toolbox)
 #if !defined(QGC_GST_STREAMING)
     static bool once = false;
     if (!once) {
-        qmlRegisterType<GLVideoItemStub>("org.freedesktop.gstreamer.GLVideoItem", 1, 0, "GstGLVideoItem");
+        qmlRegisterType<GLVideoItemStub>("org.freedesktop.gstreamer.Qt6GLVideoItem", 1, 0, "GstGLQt6VideoItem");
         once = true;
     }
 #endif

--- a/src/VideoReceiver/CMakeLists.txt
+++ b/src/VideoReceiver/CMakeLists.txt
@@ -13,7 +13,9 @@ target_include_directories(VideoReceiver PUBLIC ${CMAKE_CURRENT_SOURCE_DIR})
 
 add_subdirectory(${CMAKE_SOURCE_DIR}/libs/qmlglsink qmlglsink.build)
 
-if(GST_FOUND)
+if(GST_QT6_PLUGIN_FOUND)
+    message(STATUS "Building VideoReceiver")
+
     find_package(Qt6 REQUIRED COMPONENTS Quick)
 
     target_sources(VideoReceiver

--- a/src/VideoReceiver/VideoReceiver.pri
+++ b/src/VideoReceiver/VideoReceiver.pri
@@ -70,16 +70,18 @@ LinuxBuild {
         QMAKE_POST_LINK += $$escape_expand(\\n) xcopy \"$$GST_ROOT_WIN\\lib\\gstreamer-1.0\\*.dll\" \"$$DESTDIR_WIN\\gstreamer-plugins\\\" /Y $$escape_expand(\\n)
     }
 } else:AndroidBuild {
-    #- gstreamer assumed to be installed in $$PWD/../../gstreamer-1.0-android-universal-1.18.5/***
+    GST_VERSION = 1.22.11
+    #- gstreamer assumed to be installed in $$PWD/../../gstreamer-1.0-android-universal-$$GST_VERSION/***
+    ANDROID_GST_ROOT = $$PWD/../../gstreamer-1.0-android-universal-$$GST_VERSION
     contains(ANDROID_TARGET_ARCH, armeabi-v7a) {
-        GST_ROOT = $$PWD/../../gstreamer-1.0-android-universal-1.18.5/armv7
+        GST_ROOT = $$ANDROID_GST_ROOT/armv7
     } else:contains(ANDROID_TARGET_ARCH, arm64-v8a) {
-        GST_ROOT = $$PWD/../../gstreamer-1.0-android-universal-1.18.5/arm64
+        GST_ROOT = $$ANDROID_GST_ROOT/arm64
     } else:contains(ANDROID_TARGET_ARCH, x86_64) {
-        GST_ROOT = $$PWD/../../gstreamer-1.0-android-universal-1.18.5/x86_64
+        GST_ROOT = $$ANDROID_GST_ROOT/x86_64
     } else {
         message(Unknown ANDROID_TARGET_ARCH $$ANDROID_TARGET_ARCH)
-        GST_ROOT = $$PWD/../../gstreamer-1.0-android-universal-1.18.5/x86
+        GST_ROOT = $$ANDROID_GST_ROOT/x86
     }
     exists($$GST_ROOT) {
         QMAKE_CXXFLAGS  += -pthread


### PR DESCRIPTION
- Updates GStreamer to 1.22.11 for everything but Linux which will require building by source
- Auto Download GStreamer for Android in CMake instead of CI
- Auto Download Qt6 Plugin for all Platforms