### PR TITLE
CI: Action to Build GStreamer

### DIFF
--- a/.github/actions/gstreamer/action.yml
+++ b/.github/actions/gstreamer/action.yml
@@ -1,0 +1,91 @@
+name: Build GStreamer
+description: Builds GStreamer using Meson
+inputs:
+  gst_version:
+    description: Version of GStreamer to Build
+    required: true
+    default: 1.22.11
+  build_type:
+    description: Build Type "release" or "debug"
+    required: true
+    default: release
+  working_directory:
+    description: Where to clone GStreamer source
+    required: true
+    default: ${{ runner.temp }}
+  install_directory:
+    description: Where to install GStreamer Build
+    required: true
+    default: ${{ runner.temp }}/gst
+runs:
+  using: "composite"
+  steps:
+    - name: Clone GStreamer
+      working-directory: ${{ inputs.working_directory }}
+      run: git clone --depth 1 --branch ${{ inputs.gst_version }} https://github.com/GStreamer/gstreamer.git
+      shell: bash
+
+    - name: Configure GStreamer
+      working-directory: ${{ inputs.working_directory }}/gstreamer
+      run: meson setup
+        --prefix=${{ inputs.install_directory }}
+        --buildtype=${{ inputs.build_type }}
+        --default-library=static
+        --wrap-mode=forcefallback
+        --strip
+        -Dauto_features=disabled
+        -Dgst-full-libraries=gstreamer,base,controller,net,app,audio,fft,pbutils,riff,rtp,rtsp,tag,video,gl,codecparsers,photography
+        -Dgpl=enabled
+        -Dlibav=enabled
+        -Dorc=enabled
+        -Dbase=enabled
+        -Dgst-plugins-base:gl=enabled
+        -Dgst-plugins-base:gl_platform=glx
+        -Dgst-plugins-base:gl_winsys=x11
+        -Dgst-plugins-base:x11=enabled
+        -Dgst-plugins-base:playback=enabled
+        -Dgst-plugins-base:tcp=enabled
+        -Dgood=enabled
+        -Dgst-plugins-good:qt6=enabled
+        -Dgst-plugins-good:qt-x11=enabled
+        -Dgst-plugins-good:qt-method=auto
+        -Dgst-plugins-good:isomp4=enabled
+        -Dgst-plugins-good:matroska=enabled
+        -Dgst-plugins-good:rtp=enabled
+        -Dgst-plugins-good:rtpmanager=enabled
+        -Dgst-plugins-good:rtsp=enabled
+        -Dgst-plugins-good:udp=enabled
+        -Dbad=enabled
+        -Dgst-plugins-bad:gl=enabled
+        -Dgst-plugins-bad:mpegtsdemux=enabled
+        -Dgst-plugins-bad:rtp=enabled
+        -Dgst-plugins-bad:videoparsers=enabled
+        -Dgst-plugins-bad:sdp=enabled
+        -Dgst-plugins-bad:x11=enabled
+        -Dugly=enabled
+        -Dgst-plugins-ugly:x264=enabled
+        builddir
+        # -Dqt6=enabled
+        # -Dgst-full-target-type=static_library
+        # -Dgst-plugins-base:gl_platform=glx,egl
+        # -Dgst-plugins-base:gl_winsys=x11,egl,wayland
+        # -Dgst-plugins-good:qt-wayland=enabled
+        # -Dgst-plugins-good:qt-egl=enabled
+        # -Dgst-plugins-bad:xshm=enabled
+        # -Dgst-plugins-bad:wayland=enabled
+      shell: bash
+
+    - name: Compile GStreamer
+      working-directory: ${{ inputs.working_directory }}/gstreamer
+      run: meson compile -C builddir
+      shell: bash
+
+    - name: Install GStreamer
+      working-directory: ${{ inputs.working_directory }}/gstreamer
+      run: meson install -C builddir
+      shell: bash
+
+    - name: Setup Environment
+      working-directory: ${{ runner.temp }}/gstreamer
+      run: echo "PKG_CONFIG_PATH=${{ runner.temp }}/gst/lib/x86_64-linux-gnu/pkgconfig:${{ env.PKG_CONFIG_PATH }}" >> "$GITHUB_ENV"
+      shell: bash

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -56,7 +56,7 @@ jobs:
           tools: 'tools_cmake'
 
       - name: Install Dependencies
-        run:  |
+        run: |
               chmod a+x ./tools/setup/ubuntu.sh
               ./tools/setup/ubuntu.sh
 
@@ -74,6 +74,9 @@ jobs:
           sudo wget -qO /etc/apt/sources.list.d/lunarg-vulkan-focal.list http://packages.lunarg.com/vulkan/lunarg-vulkan-focal.list
           sudo apt update
           sudo apt install vulkan-sdk
+
+      # - name: Build GStreamer
+        # uses: ./.github/actions/gstreamer
 
       - name: Create build directory
         run:  mkdir ${{ runner.temp }}/shadow_build_dir

--- a/tools/setup/ubuntu.sh
+++ b/tools/setup/ubuntu.sh
@@ -3,6 +3,7 @@
 set -e
 
 sudo apt-get update -y --quiet
+
 sudo DEBIAN_FRONTEND=noninteractive apt-get -y --quiet --no-install-recommends install \
 	build-essential \
 	ccache \
@@ -17,17 +18,39 @@ sudo DEBIAN_FRONTEND=noninteractive apt-get -y --quiet --no-install-recommends i
 	make \
 	ninja-build \
 	rsync \
-	libsdl2-dev \
-    libgstreamer-plugins-base1.0-dev \
-    libgstreamer1.0-0:amd64 \
-    libgstreamer1.0-dev \
     binutils \
-    patchelf \
-    libxcb-xinerama0 \
+    patchelf
+
+sudo DEBIAN_FRONTEND=noninteractive apt-get -y --quiet install \
+	libxcb-xinerama0 \
     libxkbcommon-x11-0 \
     libxcb-cursor0 \
     libdrm-dev \
+	libsdl2-dev \
 	libspeechd2 \
 	flite \
 	speech-dispatcher \
 	speech-dispatcher-flite
+
+sudo DEBIAN_FRONTEND=noninteractive apt-get -y --quiet install \
+	libgstreamer1.0-dev \
+	libgstreamer-plugins-base1.0-dev \
+	libgstreamer-plugins-good1.0-dev \
+	libgstreamer-plugins-bad1.0-dev \
+	gstreamer1.0-plugins-base \
+	gstreamer1.0-plugins-good \
+	gstreamer1.0-plugins-bad \
+	gstreamer1.0-plugins-ugly \
+	gstreamer1.0-plugins-rtp \
+	gstreamer1.0-libav \
+	gstreamer1.0-tools \
+	gstreamer1.0-x \
+	gstreamer1.0-alsa \
+	gstreamer1.0-gl \
+	gstreamer1.0-gtk3 \
+	gstreamer1.0-qt5 \
+	gstreamer1.0-pulseaudio \
+	gstreamer1.0-gl \
+	gstreamer1.0-libav \
+	gstreamer1.0-vaapi \
+	gstreamer1.0-rtsp


### PR DESCRIPTION
Adds an action to build the linux GStreamer. Very minor modifications would be needed to adapt to be able to use with other platforms. 1.24 allows fully static linking.