### PR TITLE
APM: Update Parameter Repository

### DIFF
--- a/src/FirmwarePlugin/APM/APMFirmwarePlugin.h
+++ b/src/FirmwarePlugin/APM/APMFirmwarePlugin.h
@@ -113,6 +113,7 @@ private:
     void _handleRCChannelsRaw(Vehicle* vehicle, mavlink_message_t* message);
     QString _getLatestVersionFileUrl(Vehicle* vehicle) override;
     QString _versionRegex() override;
+    QString _vehicleClassToString(QGCMAVLink::VehicleClass_t vehicleClass) const;
 
     // Any instance data here must be global to all vehicles
     // Vehicle specific data should go into APMFirmwarePluginInstanceData

--- a/src/FirmwarePlugin/APM/APMResources.qrc
+++ b/src/FirmwarePlugin/APM/APMResources.qrc
@@ -56,6 +56,8 @@
         <file alias="APMParameterFactMetaData.Plane.4.1.xml">ArduPilot-Parameter-Repository/Plane-4.1/apm.pdef.xml</file>
         <file alias="APMParameterFactMetaData.Plane.4.2.xml">ArduPilot-Parameter-Repository/Plane-4.2/apm.pdef.xml</file>
         <file alias="APMParameterFactMetaData.Plane.4.3.xml">ArduPilot-Parameter-Repository/Plane-4.3/apm.pdef.xml</file>
+        <file alias="APMParameterFactMetaData.Plane.4.4.xml">ArduPilot-Parameter-Repository/Plane-4.3/apm.pdef.xml</file>
+        <file alias="APMParameterFactMetaData.Plane.4.5.xml">ArduPilot-Parameter-Repository/Plane-4.3/apm.pdef.xml</file>
         <file alias="APMParameterFactMetaData.Copter.3.5.xml">ArduPilot-Parameter-Repository/Copter-3.5/apm.pdef.xml</file>
         <file alias="APMParameterFactMetaData.Copter.3.6.xml">ArduPilot-Parameter-Repository/Copter-3.6/apm.pdef.xml</file>
         <file alias="APMParameterFactMetaData.Copter.3.7.xml">ArduPilot-Parameter-Repository/Copter-3.7/apm.pdef.xml</file>
@@ -63,12 +65,16 @@
         <file alias="APMParameterFactMetaData.Copter.4.1.xml">ArduPilot-Parameter-Repository/Copter-4.1/apm.pdef.xml</file>
         <file alias="APMParameterFactMetaData.Copter.4.2.xml">ArduPilot-Parameter-Repository/Copter-4.2/apm.pdef.xml</file>
         <file alias="APMParameterFactMetaData.Copter.4.3.xml">ArduPilot-Parameter-Repository/Copter-4.3/apm.pdef.xml</file>
+        <file alias="APMParameterFactMetaData.Copter.4.4.xml">ArduPilot-Parameter-Repository/Copter-4.3/apm.pdef.xml</file>
+        <file alias="APMParameterFactMetaData.Copter.4.5.xml">ArduPilot-Parameter-Repository/Copter-4.3/apm.pdef.xml</file>
         <file alias="APMParameterFactMetaData.Rover.3.4.xml">ArduPilot-Parameter-Repository/Rover-3.4/apm.pdef.xml</file>
         <file alias="APMParameterFactMetaData.Rover.3.5.xml">ArduPilot-Parameter-Repository/Rover-3.5/apm.pdef.xml</file>
         <file alias="APMParameterFactMetaData.Rover.3.6.xml">ArduPilot-Parameter-Repository/Rover-3.6/apm.pdef.xml</file>
         <file alias="APMParameterFactMetaData.Rover.4.0.xml">ArduPilot-Parameter-Repository/Rover-4.0/apm.pdef.xml</file>
         <file alias="APMParameterFactMetaData.Rover.4.1.xml">ArduPilot-Parameter-Repository/Rover-4.1/apm.pdef.xml</file>
         <file alias="APMParameterFactMetaData.Rover.4.2.xml">ArduPilot-Parameter-Repository/Rover-4.2/apm.pdef.xml</file>
+        <file alias="APMParameterFactMetaData.Rover.4.4.xml">ArduPilot-Parameter-Repository/Rover-4.2/apm.pdef.xml</file>
+        <file alias="APMParameterFactMetaData.Rover.4.5.xml">ArduPilot-Parameter-Repository/Rover-4.2/apm.pdef.xml</file>
         <file alias="APMParameterFactMetaData.Sub.3.4.xml">ArduPilot-Parameter-Repository/Sub-3.4/apm.pdef.xml</file>
         <file alias="APMParameterFactMetaData.Sub.3.5.xml">ArduPilot-Parameter-Repository/Sub-3.5/apm.pdef.xml</file>
         <file alias="APMParameterFactMetaData.Sub.3.6.xml">ArduPilot-Parameter-Repository/Sub-3.6/apm.pdef.xml</file>


### PR DESCRIPTION
Brings Ardupilot params up to date again. Still need to make this autorun.
Also auto searches for most recent parameters available if vehicle version is higher than the meta data files available.
Previously it would just use the oldest version if the requested one was unavailable.
If the vehicle version is invalid, then search for the oldest available file.