### PR TITLE
Correct NO_SERIAL_LINK Checks

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -191,6 +191,8 @@ if(QGC_DEBUG_QML)
     add_compile_definitions(QT_QML_DEBUG)
 endif()
 
+cmake_dependent_option(QGC_NO_SERIAL_LINK "Build QGroundControl without Serial Support Support." OFF "NOT IOS" ON)
+
 #######################################################
 #                QGroundControl Resources
 #######################################################

--- a/android/src/AndroidInterface.cc
+++ b/android/src/AndroidInterface.cc
@@ -9,7 +9,7 @@
 
 #include "AndroidInterface.h"
 
-#include <QJniObject>
+#include <QtCore/QJniObject>
 #include <QtCore/private/qandroidextras_p.h>
 
 bool AndroidInterface::checkStoragePermissions()

--- a/src/FactSystem/CMakeLists.txt
+++ b/src/FactSystem/CMakeLists.txt
@@ -24,7 +24,6 @@ target_link_libraries(FactSystem
     	Qt6::Qml
     	api
 		AutoPilotPlugins
-		comm
 		FactControls
 		FirmwarePlugin
 		Settings
@@ -33,6 +32,7 @@ target_link_libraries(FactSystem
 		VehicleComponents
     PUBLIC
     	Qt6::Core
+		comm
 		qgc
 )
 

--- a/src/GPS/CMakeLists.txt
+++ b/src/GPS/CMakeLists.txt
@@ -1,56 +1,61 @@
 find_package(Qt6 REQUIRED COMPONENTS Core)
 
-# include(FetchContent)
-# FetchContent_Declare(gps_drivers
-#     GIT_REPOSITORY https://github.com/PX4/PX4-GPSDrivers.git
-#     GIT_TAG main
-#     GIT_SHALLOW TRUE
-# )
-# FetchContent_GetProperties(gps_drivers)
-# if(NOT gps_drivers_POPULATED)
-# 	FetchContent_Populate(gps_drivers)
-# 	add_subdirectory(${gps_drivers_SOURCE_DIR} ${gps_drivers_BINARY_DIR} EXCLUDE_FROM_ALL)
-# endif()
+qt_add_library(gps STATIC)
 
-qt_add_library(gps STATIC
-	definitions.h
-	Drivers/src/ashtech.cpp
-	Drivers/src/ashtech.h
-	Drivers/src/gps_helper.cpp
-	Drivers/src/gps_helper.h
-	Drivers/src/mtk.cpp
-	Drivers/src/mtk.h
-	Drivers/src/rtcm.cpp
-	Drivers/src/rtcm.h
-	Drivers/src/sbf.cpp
-	Drivers/src/sbf.h
-	Drivers/src/ubx.cpp
-	Drivers/src/ubx.h
-	GPSManager.cc
-	GPSManager.h
-	GPSPositionMessage.h
-	GPSProvider.cc
-	GPSProvider.h
-	RTCMMavlink.cc
-	RTCMMavlink.h
-	satellite_info.h
-	sensor_gnss_relative.h
-	sensor_gps.h
-)
+if(NOT QGC_NO_SERIAL_LINK)
+	# include(FetchContent)
+	# FetchContent_Declare(gps_drivers
+	#     GIT_REPOSITORY https://github.com/PX4/PX4-GPSDrivers.git
+	#     GIT_TAG main
+	#     GIT_SHALLOW TRUE
+	# )
+	# FetchContent_GetProperties(gps_drivers)
+	# if(NOT gps_drivers_POPULATED)
+	# 	FetchContent_Populate(gps_drivers)
+	# 	add_subdirectory(${gps_drivers_SOURCE_DIR} ${gps_drivers_BINARY_DIR} EXCLUDE_FROM_ALL)
+	# endif()
 
-target_link_libraries(gps
-	PRIVATE
-		comm
-		Settings
-		Utilities
-                Vehicle
-	PUBLIC
-		Qt6::Core
-		qgc
-)
+	target_sources(gps
+		PRIVATE
+			definitions.h
+			Drivers/src/ashtech.cpp
+			Drivers/src/ashtech.h
+			Drivers/src/gps_helper.cpp
+			Drivers/src/gps_helper.h
+			Drivers/src/mtk.cpp
+			Drivers/src/mtk.h
+			Drivers/src/rtcm.cpp
+			Drivers/src/rtcm.h
+			Drivers/src/sbf.cpp
+			Drivers/src/sbf.h
+			Drivers/src/ubx.cpp
+			Drivers/src/ubx.h
+			GPSManager.cc
+			GPSManager.h
+			GPSPositionMessage.h
+			GPSProvider.cc
+			GPSProvider.h
+			RTCMMavlink.cc
+			RTCMMavlink.h
+			satellite_info.h
+			sensor_gnss_relative.h
+			sensor_gps.h
+	)
 
-target_include_directories(gps
-	PUBLIC
-		${CMAKE_CURRENT_SOURCE_DIR}
-		Drivers/src
-)
+	target_link_libraries(gps
+		PRIVATE
+			Settings
+			Utilities
+			Vehicle
+		PUBLIC
+			Qt6::Core
+			comm
+			qgc
+	)
+
+	target_include_directories(gps
+		PUBLIC
+			${CMAKE_CURRENT_SOURCE_DIR}
+			Drivers/src
+	)
+endif()

--- a/src/Joystick/CMakeLists.txt
+++ b/src/Joystick/CMakeLists.txt
@@ -54,7 +54,6 @@ target_link_libraries(Joystick
 		AutoPilotPlugins
 		Camera
         FirmwarePlugin
-		qgc
 		Settings
 		Utilities
 		Vehicle
@@ -62,6 +61,7 @@ target_link_libraries(Joystick
 	PUBLIC
 		Qt6::Core
 		comm
+		qgc
 		QmlControls
 )
 

--- a/src/MissionManager/CMakeLists.txt
+++ b/src/MissionManager/CMakeLists.txt
@@ -105,6 +105,7 @@ target_link_libraries(MissionManager
                 Geo
 	PUBLIC
 		Qt6::Xml
+		comm
 		qgc
                 Settings
 		UTMSP

--- a/src/MissionManager/VisualMissionItem.h
+++ b/src/MissionManager/VisualMissionItem.h
@@ -18,7 +18,6 @@
 
 #include "QGCMAVLink.h"
 #include "QmlObjectListModel.h"
-#include "QmlObjectListModel.h"
 #include "Vehicle.h"
 #include "MissionController.h"
 

--- a/src/PositionManager/CMakeLists.txt
+++ b/src/PositionManager/CMakeLists.txt
@@ -9,6 +9,7 @@ qt_add_library(PositionManager STATIC
 
 target_link_libraries(PositionManager
 	PRIVATE
+		Qt6::PositioningPrivate
 		api
 		Vehicle
 	PUBLIC

--- a/src/QGCApplication.cc
+++ b/src/QGCApplication.cc
@@ -110,16 +110,13 @@
 #include "Viewer3DTerrainTexture.h"
 #include "LinkConfiguration.h"
 
-#ifndef __mobile__
-#include "FirmwareUpgradeController.h"
-#endif
-
 #ifndef NO_SERIAL_LINK
+#include "FirmwareUpgradeController.h"
 #include "SerialLink.h"
 #endif
 
 #ifdef Q_OS_LINUX
-#ifndef __mobile__
+#ifndef Q_OS_ANDROID
 #include <unistd.h>
 #include <sys/types.h>
 #endif
@@ -185,7 +182,7 @@ QGCApplication::QGCApplication(int &argc, char* argv[], bool unitTesting)
     _msecsElapsedTime.start();
 
 #ifdef Q_OS_LINUX
-#ifndef __mobile__
+#ifndef Q_OS_ANDROID
     if (!_runningUnitTests) {
         if (getuid() == 0) {
             _exitWithError(QString(
@@ -486,10 +483,8 @@ void QGCApplication::_initCommon()
     qmlRegisterType<ToolStripAction>                ("QGroundControl.Controls",             1, 0, "ToolStripAction");
     qmlRegisterType<ToolStripActionList>            ("QGroundControl.Controls",             1, 0, "ToolStripActionList");
 
-#ifndef __mobile__
 #ifndef NO_SERIAL_LINK
     qmlRegisterType<FirmwareUpgradeController>      (kQGCControllers,                       1, 0, "FirmwareUpgradeController");
-#endif
 #endif
     qmlRegisterType<GeoTagController>               (kQGCControllers,                       1, 0, "GeoTagController");
     qmlRegisterType<MavlinkConsoleController>       (kQGCControllers,                       1, 0, "MavlinkConsoleController");
@@ -543,7 +538,7 @@ bool QGCApplication::_initForNormalAppBoot()
     }
 
     #ifdef Q_OS_LINUX
-    #ifndef __mobile__
+    #ifndef Q_OS_ANDROID
     #ifndef NO_SERIAL_LINK
         if (!_runningUnitTests) {
             // Determine if we have the correct permissions to access USB serial devices

--- a/src/QGCToolbox.cc
+++ b/src/QGCToolbox.cc
@@ -10,7 +10,7 @@
 
 #include "FactSystem.h"
 #include "FirmwarePluginManager.h"
-#ifndef __mobile__
+#ifndef NO_SERIAL_LINK
 #include "GPSManager.h"
 #endif
 #include "JoystickManager.h"
@@ -64,7 +64,7 @@ QGCToolbox::QGCToolbox(QGCApplication* app)
     _scanAndLoadPlugins(app);
     _factSystem             = new FactSystem                (app, this);
     _firmwarePluginManager  = new FirmwarePluginManager     (app, this);
-#ifndef __mobile__
+#ifndef NO_SERIAL_LINK
     _gpsManager             = new GPSManager                (app, this);
 #endif
     _imageProvider          = new QGCImageProvider          (app, this);
@@ -99,7 +99,7 @@ void QGCToolbox::setChildToolboxes(void)
     _corePlugin->setToolbox(this);
     _factSystem->setToolbox(this);
     _firmwarePluginManager->setToolbox(this);
-#ifndef __mobile__
+#ifndef NO_SERIAL_LINK
     _gpsManager->setToolbox(this);
 #endif
     _imageProvider->setToolbox(this);

--- a/src/QGCToolbox.h
+++ b/src/QGCToolbox.h
@@ -62,7 +62,7 @@ public:
     QGCCorePlugin*              corePlugin              () { return _corePlugin; }
     SettingsManager*            settingsManager         () { return _settingsManager; }
     ADSBVehicleManager*         adsbVehicleManager      () { return _adsbVehicleManager; }
-#ifndef __mobile__
+#ifndef NO_SERIAL_LINK
     GPSManager*                 gpsManager              () { return _gpsManager; }
 #endif
 #ifndef QGC_AIRLINK_DISABLED
@@ -79,7 +79,7 @@ private:
 
     FactSystem*                 _factSystem             = nullptr;
     FirmwarePluginManager*      _firmwarePluginManager  = nullptr;
-#ifndef __mobile__
+#ifndef NO_SERIAL_LINK
     GPSManager*                 _gpsManager             = nullptr;
 #endif
     QGCImageProvider*           _imageProvider          = nullptr;

--- a/src/QmlControls/QGroundControlQmlGlobal.cc
+++ b/src/QmlControls/QGroundControlQmlGlobal.cc
@@ -14,7 +14,7 @@
 #include "QGCMapUrlEngine.h"
 #include "FirmwarePluginManager.h"
 #include "AppSettings.h"
-#ifndef __mobile__
+#ifndef NO_SERIAL_LINK
 #include "GPSManager.h"
 #endif
 #include "QGCPalette.h"
@@ -86,7 +86,7 @@ void QGroundControlQmlGlobal::setToolbox(QGCToolbox* toolbox)
     _corePlugin             = toolbox->corePlugin();
     _firmwarePluginManager  = toolbox->firmwarePluginManager();
     _settingsManager        = toolbox->settingsManager();
-#ifndef __mobile__
+#ifndef NO_SERIAL_LINK
     _gpsRtkFactGroup        = toolbox->gpsManager()->gpsRtkFactGroup();
 #endif
     _adsbVehicleManager     = toolbox->adsbVehicleManager();

--- a/src/QmlControls/QGroundControlQmlGlobal.h
+++ b/src/QmlControls/QGroundControlQmlGlobal.h
@@ -80,7 +80,9 @@ public:
     Q_PROPERTY(ADSBVehicleManager*  adsbVehicleManager      READ    adsbVehicleManager      CONSTANT)
     Q_PROPERTY(QGCCorePlugin*       corePlugin              READ    corePlugin              CONSTANT)
     Q_PROPERTY(MissionCommandTree*  missionCommandTree      READ    missionCommandTree      CONSTANT)
+#ifndef NO_SERIAL_LINK
     Q_PROPERTY(FactGroup*           gpsRtk                  READ    gpsRtkFactGroup         CONSTANT)
+#endif
 #ifndef QGC_AIRLINK_DISABLED
     Q_PROPERTY(AirLinkManager*      airlinkManager          READ    airlinkManager          CONSTANT)
 #endif
@@ -173,7 +175,9 @@ public:
     MAVLinkLogManager*      mavlinkLogManager   ()  { return _mavlinkLogManager; }
     QGCCorePlugin*          corePlugin          ()  { return _corePlugin; }
     SettingsManager*        settingsManager     ()  { return _settingsManager; }
+#ifndef NO_SERIAL_LINK
     FactGroup*              gpsRtkFactGroup     ()  { return _gpsRtkFactGroup; }
+#endif
     ADSBVehicleManager*     adsbVehicleManager  ()  { return _adsbVehicleManager; }
     QmlUnitsConversion*     unitsConversion     ()  { return &_unitsConversion; }
     static QGeoCoordinate   flightMapPosition   ()  { return _coord; }
@@ -262,7 +266,9 @@ private:
     QGCCorePlugin*          _corePlugin             = nullptr;
     FirmwarePluginManager*  _firmwarePluginManager  = nullptr;
     SettingsManager*        _settingsManager        = nullptr;
+#ifndef NO_SERIAL_LINK
     FactGroup*              _gpsRtkFactGroup        = nullptr;
+#endif
     AirLinkManager*         _airlinkManager         = nullptr;
     ADSBVehicleManager*     _adsbVehicleManager     = nullptr;
     QGCPalette*             _globalPalette          = nullptr;

--- a/src/VehicleSetup/CMakeLists.txt
+++ b/src/VehicleSetup/CMakeLists.txt
@@ -1,23 +1,14 @@
 find_package(Qt6 REQUIRED COMPONENTS Core Gui Qml Quick)
 
 qt_add_library(VehicleSetup STATIC
-	Bootloader.cc
-	Bootloader.h
-	FirmwareImage.cc
-	FirmwareImage.h
-	FirmwareUpgradeController.cc
-	FirmwareUpgradeController.h
 	JoystickConfigController.cc
 	JoystickConfigController.h
-	PX4FirmwareUpgradeThread.cc
-	PX4FirmwareUpgradeThread.h
 	VehicleComponent.cc
 	VehicleComponent.h
 )
 
 add_custom_target(VehicleSetupQml
 	SOURCES
-		FirmwareUpgrade.qml
 		JoystickConfig.qml
 		JoystickConfigAdvanced.qml
 		JoystickConfigButtons.qml
@@ -51,3 +42,24 @@ target_link_libraries(VehicleSetup
 )
 
 target_include_directories(VehicleSetup PUBLIC ${CMAKE_CURRENT_SOURCE_DIR})
+
+if(NOT QGC_NO_SERIAL_LINK)
+	target_sources(VehicleSetup
+		PRIVATE
+			Bootloader.cc
+			Bootloader.h
+			FirmwareImage.cc
+			FirmwareImage.h
+			FirmwareUpgradeController.cc
+			FirmwareUpgradeController.h
+			PX4FirmwareUpgradeThread.cc
+			PX4FirmwareUpgradeThread.h
+	)
+
+	target_link_libraries(VehicleSetup PUBLIC comm)
+
+	target_sources(VehicleSetupQml
+		PRIVATE
+			FirmwareUpgrade.qml
+	)
+endif()

--- a/src/comm/CMakeLists.txt
+++ b/src/comm/CMakeLists.txt
@@ -40,27 +40,11 @@ target_link_libraries(comm
 		Utilities
 )
 
-if(NOT MOBILE)
-	target_link_libraries(comm
-		PRIVATE
-			gps
-			PositionManager
-	)
-endif()
-
 target_include_directories(comm PUBLIC ${CMAKE_CURRENT_SOURCE_DIR})
 
-option(QGC_NO_SERIAL_LINK "Disable Serial Links" OFF)
 if(QGC_NO_SERIAL_LINK)
 	target_compile_definitions(comm PUBLIC NO_SERIAL_LINK)
 else()
-	if(ANDROID)
-		add_subdirectory(${CMAKE_SOURCE_DIR}/libs/qtandroidserialport qtandroidserialport.build)
-	    target_link_libraries(comm PUBLIC qtandroidserialport)
-	else()
-		find_package(Qt6 REQUIRED COMPONENTS SerialPort)
-		target_link_libraries(comm PUBLIC Qt6::SerialPort)
-	endif()
 	target_sources(comm
 		PRIVATE
 			QGCSerialPortInfo.cc
@@ -68,6 +52,18 @@ else()
 			SerialLink.cc
 			SerialLink.h
 	)
+	target_link_libraries(comm
+		PRIVATE
+			gps
+			PositionManager
+	)
+	if(ANDROID)
+		add_subdirectory(${CMAKE_SOURCE_DIR}/libs/qtandroidserialport qtandroidserialport.build)
+	    target_link_libraries(comm PUBLIC qtandroidserialport)
+	else()
+		find_package(Qt6 REQUIRED COMPONENTS SerialPort)
+		target_link_libraries(comm PUBLIC Qt6::SerialPort)
+	endif()
 endif()
 
 # option(QGC_NO_SERIAL_LINK "Enable Bluetooth Links" ON)

--- a/src/comm/QGCSerialPortInfo.cc
+++ b/src/comm/QGCSerialPortInfo.cc
@@ -7,7 +7,6 @@
  *
  ****************************************************************************/
 
-
 #include "QGCSerialPortInfo.h"
 #include "JsonHelper.h"
 #include "QGCLoggingCategory.h"
@@ -46,7 +45,7 @@ QList<QGCSerialPortInfo::BoardRegExpFallback_t> QGCSerialPortInfo::_boardManufac
 QGCSerialPortInfo::QGCSerialPortInfo(void) :
     QSerialPortInfo()
 {
-
+    qRegisterMetaType<QGCSerialPortInfo>();
 }
 
 QGCSerialPortInfo::QGCSerialPortInfo(const QSerialPort & port) :
@@ -240,7 +239,7 @@ bool QGCSerialPortInfo::getBoardInfo(QGCSerialPortInfo::BoardType_t& boardType, 
             const BoardRegExpFallback_t& boardFallback = _boardDescriptionFallbackList[i];
 
             if (description().contains(QRegularExpression(boardFallback.regExp, QRegularExpression::CaseInsensitiveOption))) {
-#ifndef __android
+#ifndef Q_OS_ANDROID
                 if (boardFallback.androidOnly) {
                     continue;
                 }
@@ -255,7 +254,7 @@ bool QGCSerialPortInfo::getBoardInfo(QGCSerialPortInfo::BoardType_t& boardType, 
             const BoardRegExpFallback_t& boardFallback = _boardManufacturerFallbackList[i];
 
             if (manufacturer().contains(QRegularExpression(boardFallback.regExp, QRegularExpression::CaseInsensitiveOption))) {
-#ifndef __android
+#ifndef Q_OS_ANDROID
                 if (boardFallback.androidOnly) {
                     continue;
                 }

--- a/src/comm/QGCSerialPortInfo.h
+++ b/src/comm/QGCSerialPortInfo.h
@@ -92,4 +92,3 @@ private:
     static QList<BoardRegExpFallback_t>         _boardDescriptionFallbackList;
     static QList<BoardRegExpFallback_t>         _boardManufacturerFallbackList;
 };
-

--- a/src/comm/SerialLink.cc
+++ b/src/comm/SerialLink.cc
@@ -13,8 +13,6 @@
 #include "QGCLoggingCategory.h"
 #ifdef Q_OS_ANDROID
 #include "LinkManager.h"
-#endif
-#ifdef Q_OS_ANDROID
 #include "qserialportinfo.h"
 #else
 #include <QtSerialPort/QSerialPortInfo>
@@ -29,6 +27,7 @@ SerialLink::SerialLink(SharedLinkConfigurationPtr& config, bool isPX4Flow)
     : LinkInterface(config, isPX4Flow)
     , _serialConfig(qobject_cast<SerialConfiguration*>(config.get()))
 {
+    qRegisterMetaType<QSerialPort::SerialPortError>();
     qCDebug(SerialLinkLog) << "Create SerialLink portName:baud:flowControl:parity:dataButs:stopBits" << _serialConfig->portName() << _serialConfig->baud() << _serialConfig->flowControl()
                            << _serialConfig->parity() << _serialConfig->dataBits() << _serialConfig->stopBits();
 }

--- a/src/comm/SerialLink.h
+++ b/src/comm/SerialLink.h
@@ -145,4 +145,3 @@ private:
     SerialConfiguration*    _serialConfig       = nullptr;
 
 };
-

--- a/src/main.cc
+++ b/src/main.cc
@@ -12,19 +12,13 @@
 #include "AppMessages.h"
 #include "QGCMapEngine.h"
 #include "Vehicle.h"
+
 #ifndef __mobile__
-    #ifndef NO_SERIAL_LINK
-        #include <QtSerialPort/QSerialPort>
-    #endif
-    #include "QGCSerialPortInfo.h"
     #include "RunGuard.h"
 #endif
 
 #ifdef Q_OS_ANDROID
     #include "AndroidInterface.h"
-    #ifndef NO_SERIAL_LINK
-        #include "qserialport.h"
-    #endif
 #endif
 
 #ifdef UNITTEST_BUILD
@@ -52,12 +46,6 @@
 /* SDL does ugly things to main() */
 #ifdef main
 #undef main
-#endif
-
-#ifndef __mobile__
-#ifndef NO_SERIAL_LINK
-    Q_DECLARE_METATYPE(QGCSerialPortInfo)
-#endif
 #endif
 
 #ifdef Q_OS_WIN
@@ -168,19 +156,11 @@ int main(int argc, char *argv[])
     // that we use these types in signals, and without calling qRegisterMetaType we can't queue
     // these signals. In general we don't queue these signals, but we do what the warning says
     // anyway to silence the debug output.
-#ifndef NO_SERIAL_LINK
-    qRegisterMetaType<QSerialPort::SerialPortError>();
-#endif
 #ifdef QGC_ENABLE_BLUETOOTH
     qRegisterMetaType<QBluetoothSocket::SocketError>();
     qRegisterMetaType<QBluetoothServiceInfo>();
 #endif
     qRegisterMetaType<QAbstractSocket::SocketError>();
-#ifndef __mobile__
-#ifndef NO_SERIAL_LINK
-    qRegisterMetaType<QGCSerialPortInfo>();
-#endif
-#endif
 
     qRegisterMetaType<Vehicle::MavCmdResultFailureCode_t>("Vehicle::MavCmdResultFailureCode_t");
 


### PR DESCRIPTION
Fixes build with QGC_NO_SERIAL_LINK set by expanding usage of NO_SERIAL_LINK to cover remaining serial code. Also Adjusts __ mobile __ macros to NO_SERIAL_LINK where appropriate since iOS builds will always build with NO_SERIAL_LINK but android can use its serial port for the GpsManager. This is necessary before iOS builds will compile.