### PR TITLE
Fix video output on Qt6 for Windows platform

### DIFF
--- a/libs/qmlglsink/qt6/gstqt6glutility.cc
+++ b/libs/qmlglsink/qt6/gstqt6glutility.cc
@@ -254,7 +254,7 @@ gst_qml6_get_gl_wrapcontext (GstGLDisplay * display,
     gst_gl_display_filter_gl_api (display, gst_gl_context_get_gl_api (*wrap_glcontext));
     gst_gl_context_activate (*wrap_glcontext, FALSE);
   }
-#if 0
+#if 1
 #if GST_GL_HAVE_WINDOW_WIN32 && GST_GL_HAVE_PLATFORM_WGL && defined (HAVE_QT_WIN32)
   g_return_val_if_fail (context != NULL, FALSE);
 

--- a/src/main.cc
+++ b/src/main.cc
@@ -143,14 +143,18 @@ int main(int argc, char *argv[])
 #endif
 
 #ifdef Q_OS_WIN
+    // Unlike Qt5, Qt6 on Windows use Direct3D by default,
+    // so force it to use OpenGL since it is required by qt6glitem
+    QQuickWindow::setGraphicsApi(QSGRendererInterface::OpenGL);
+
     // Set our own OpenGL buglist
     qputenv("QT_OPENGL_BUGLIST", ":/opengl/resources/opengl/buglist.json");
 
     // Allow for command line override of renderer
     for (int i = 0; i < argc; i++) {
         const QString arg(argv[i]);
-        if (arg == QStringLiteral("-angle")) {
-            QCoreApplication::setAttribute(Qt::AA_UseOpenGLES);
+        if (arg == QStringLiteral("-desktop")) {
+            QCoreApplication::setAttribute(Qt::AA_UseDesktopOpenGL);
             break;
         } else if (arg == QStringLiteral("-swrast")) {
             QCoreApplication::setAttribute(Qt::AA_UseSoftwareOpenGL);


### PR DESCRIPTION
Fix video output on Qt6 for Windows platform

Description
-----------
Fixes #11020 for me.
It's due to changes in Qt6: https://doc.qt.io/qt-6/windows-graphics.html

Test Steps
-----------
1. Build
2. Run and enable video reception in the settings (for example, RTSP)
3. Start video streaming to QGroundControl

Checklist:
----------
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] [Review Contribution Guidelines](https://github.com/mavlink/qgroundcontrol/blob/master/.github/CONTRIBUTING.md).
- [x] [Review Code of Conduct](https://github.com/mavlink/qgroundcontrol/blob/master/.github/CODE_OF_CONDUCT.md).
- [x] I have tested my changes.

Related Issue
-----------
#11020


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.