### PR TITLE
Toolbar indicator dropdown: Fix position when at extreme right edge

### DIFF
--- a/src/ui/MainRootWindow.qml
+++ b/src/ui/MainRootWindow.qml
@@ -717,7 +717,7 @@ ApplicationWindow {
         function calcXPosition() {
             if (indicatorItem) {
                 var xCenter = indicatorItem.mapToItem(mainWindow.contentItem, indicatorItem.width / 2, 0).x
-                return Math.max(_margins, xCenter - (contentItem.implicitWidth / 2))
+                return Math.max(_margins, Math.min(xCenter - (contentItem.implicitWidth / 2), mainWindow.contentItem.width - contentItem.implicitWidth - _margins - (indicatorDrawer.padding * 2) - (ScreenTools.defaultFontPixelHeight / 2)))
             } else {
                 return _margins
             }


### PR DESCRIPTION
Fix #11432

Hacked version of QGC which exacerbates the problem and shows the fix:
<img width="978" alt="Screenshot 2024-05-01 at 3 06 49 PM" src="https://github.com/mavlink/qgroundcontrol/assets/5876851/34e3da60-bada-4d92-933c-9fd5cb8a9be7">
