### PR TITLE
CI: Cleanup to avoid running out of space

### DIFF
--- a/.github/workflows/android.yml
+++ b/.github/workflows/android.yml
@@ -64,7 +64,7 @@ jobs:
           create-symlink: true
           key: ${{ runner.os }}-Android-${{ matrix.BuildType }}
           restore-keys: ${{ runner.os }}-Android-${{ matrix.BuildType }}
-          max-size: 2G
+          max-size: 1G
           append-timestamp: false
           save: ${{ github.event_name == 'push' && github.ref == 'refs/heads/master' }}
 
@@ -156,7 +156,11 @@ jobs:
           modules: qtcharts qtlocation qtpositioning qtspeech qt5compat qtmultimedia qtserialport qtimageformats qtshadertools qtconnectivity qtquick3d
           cache: ${{ github.ref == 'refs/heads/master' && github.event_name != 'pull_request' }}
 
-      - run: mkdir ${{ runner.temp }}/shadow_build_dir
+      - name: Cleanup
+        run: sudo apt clean
+
+      - name: Create build directory
+        run: mkdir ${{ runner.temp }}/shadow_build_dir
 
       - name: Configure
         working-directory: ${{ runner.temp }}/shadow_build_dir

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -91,8 +91,11 @@ jobs:
           cache: ${{ github.ref == 'refs/heads/master' && github.event_name != 'pull_request' }}
           tools: 'tools_cmake'
 
-      # - name: Build GStreamer
-        # uses: ./.github/actions/gstreamer
+    # - name: Build GStreamer
+    #   uses: ./.github/actions/gstreamer
+
+      - name: Cleanup
+        run: sudo apt clean
 
       - name: Create build directory
         run:  mkdir ${{ runner.temp }}/shadow_build_dir


### PR DESCRIPTION
Some debug builds were running out of space because of the limited 500MB to CI builds.