### PR TITLE
CI: Free up more space in linux builds

### DIFF
--- a/.github/workflows/android.yml
+++ b/.github/workflows/android.yml
@@ -50,6 +50,13 @@ jobs:
           submodules: recursive
           fetch-tags: true
 
+      # Temporary solution
+      - name: Remove unused dependencies
+        run: |
+          rm -rf libs/Frameworks
+          rm -rf libs/sdl2
+          rm -rf libs/OpenSSL
+
       - name: Install dependencies
         run: |
           sudo apt-get install -y ninja-build

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -44,6 +44,13 @@ jobs:
           submodules: recursive
           fetch-tags: true
 
+      # Temporary solution
+      - name: Remove unused dependencies
+        run: |
+          rm -rf libs/Frameworks
+          rm -rf libs/sdl2
+          rm -rf libs/OpenSSL
+
       - name: Install Dependencies
         run: |
           chmod a+x ./tools/setup/install-dependencies-debian.sh


### PR DESCRIPTION
The OpenSSL submodule is taking up over 50% of allowed space, so just delete it after cloning repo in linux.