### PR TITLE
CMake: Make PCH Private

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -123,4 +123,4 @@ else()
 	)
 endif()
 
-target_precompile_headers(qgc PUBLIC ${CMAKE_SOURCE_DIR}/src/pch.h)
+target_precompile_headers(qgc PRIVATE ${CMAKE_SOURCE_DIR}/src/pch.h)


### PR DESCRIPTION
This was why the build was taking so much space