### PR TITLE
CMake: APM and PX4 Firmware Separation

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -202,15 +202,7 @@ set(QGC_RESOURCES
     ${CMAKE_SOURCE_DIR}/qgcresources.qrc
     ${CMAKE_SOURCE_DIR}/qgroundcontrol.qrc
     ${CMAKE_SOURCE_DIR}/resources/InstrumentValueIcons/InstrumentValueIcons.qrc
-    ${CMAKE_SOURCE_DIR}/src/FirmwarePlugin/APM/APMResources.qrc
-    ${CMAKE_SOURCE_DIR}/src/FirmwarePlugin/PX4/PX4Resources.qrc
 )
-
-if(CONFIG_UTM_ADAPTER)
-    list(APPEND QGC_RESOURCES ${CMAKE_SOURCE_DIR}/src/UTMSP/utmsp.qrc)
-else()
-    list(APPEND QGC_RESOURCES ${CMAKE_SOURCE_DIR}/src/UTMSP/dummy/utmsp_dummy.qrc)
-endif()
 
 if(WIN32)
     list(APPEND QGC_RESOURCES ${CMAKE_SOURCE_DIR}/deploy/windows/QGroundControl.rc)

--- a/src/AutoPilotPlugins/APM/APMAirframeComponent.h
+++ b/src/AutoPilotPlugins/APM/APMAirframeComponent.h
@@ -8,8 +8,7 @@
  ****************************************************************************/
 
 
-#ifndef APMAirframeComponent_H
-#define APMAirframeComponent_H
+#pragma once
 
 #include "VehicleComponent.h"
 
@@ -42,5 +41,3 @@ private:
 
     static const char* _frameClassParam;
 };
-
-#endif

--- a/src/AutoPilotPlugins/APM/APMAirframeComponentController.h
+++ b/src/AutoPilotPlugins/APM/APMAirframeComponentController.h
@@ -9,7 +9,7 @@
 
 #pragma once
 
-#include <QObject>
+#include <QtCore/QObject>
 
 #include "FactPanelController.h"
 

--- a/src/AutoPilotPlugins/APM/APMAutoPilotPlugin.cc
+++ b/src/AutoPilotPlugins/APM/APMAutoPilotPlugin.cc
@@ -10,6 +10,7 @@
 
 #include "APMAutoPilotPlugin.h"
 #include "VehicleComponent.h"
+#include "Vehicle.h"
 #include "APMAirframeComponent.h"
 #include "APMFlightModesComponent.h"
 #include "APMRadioComponent.h"

--- a/src/AutoPilotPlugins/APM/APMAutoPilotPlugin.h
+++ b/src/AutoPilotPlugins/APM/APMAutoPilotPlugin.h
@@ -8,11 +8,9 @@
  ****************************************************************************/
 
 
-#ifndef APMAutoPilotPlugin_H
-#define APMAutoPilotPlugin_H
+#pragma once
 
 #include "AutoPilotPlugin.h"
-#include "Vehicle.h"
 
 class APMAirframeComponent;
 class APMFlightModesComponent;
@@ -29,6 +27,7 @@ class ESP8266Component;
 class APMHeliComponent;
 class APMRemoteSupportComponent;
 class APMFollowComponent;
+class Vehicle;
 
 /// This is the APM specific implementation of the AutoPilot class.
 class APMAutoPilotPlugin : public AutoPilotPlugin
@@ -72,5 +71,3 @@ private slots:
 private:
     QVariantList                _components;
 };
-
-#endif

--- a/src/AutoPilotPlugins/APM/APMCameraComponent.cc
+++ b/src/AutoPilotPlugins/APM/APMCameraComponent.cc
@@ -13,6 +13,7 @@
 
 #include "APMCameraComponent.h"
 #include "APMAutoPilotPlugin.h"
+#include "Vehicle.h"
 
 APMCameraComponent::APMCameraComponent(Vehicle* vehicle, AutoPilotPlugin* autopilot, QObject* parent)
     : VehicleComponent(vehicle, autopilot, parent)

--- a/src/AutoPilotPlugins/APM/APMCameraComponent.h
+++ b/src/AutoPilotPlugins/APM/APMCameraComponent.h
@@ -8,8 +8,7 @@
  ****************************************************************************/
 
 
-#ifndef APMCameraComponent_H
-#define APMCameraComponent_H
+#pragma once
 
 #include "VehicleComponent.h"
 
@@ -35,5 +34,3 @@ public:
 private:
     const QString   _name;
 };
-
-#endif

--- a/src/AutoPilotPlugins/APM/APMFlightModesComponent.cc
+++ b/src/AutoPilotPlugins/APM/APMFlightModesComponent.cc
@@ -9,7 +9,6 @@
 
 
 #include "APMFlightModesComponent.h"
-#include "APMAutoPilotPlugin.h"
 
 APMFlightModesComponent::APMFlightModesComponent(Vehicle* vehicle, AutoPilotPlugin* autopilot, QObject* parent) :
     VehicleComponent(vehicle, autopilot, parent),

--- a/src/AutoPilotPlugins/APM/APMFlightModesComponent.h
+++ b/src/AutoPilotPlugins/APM/APMFlightModesComponent.h
@@ -8,8 +8,7 @@
  ****************************************************************************/
 
 
-#ifndef APMFlightModesComponent_H
-#define APMFlightModesComponent_H
+#pragma once
 
 #include "VehicleComponent.h"
 
@@ -35,5 +34,3 @@ public:
 private:
     const QString   _name;
 };
-
-#endif

--- a/src/AutoPilotPlugins/APM/APMFlightModesComponentController.cc
+++ b/src/AutoPilotPlugins/APM/APMFlightModesComponentController.cc
@@ -12,7 +12,7 @@
 #include "FactSystem.h"
 
 #include <QtCore/QVariant>
-#include <QtQml/QtQml>
+#include <QtQml/QQmlEngine>
 
 bool APMFlightModesComponentController::_typeRegistered = false;
 

--- a/src/AutoPilotPlugins/APM/APMFlightModesComponentController.h
+++ b/src/AutoPilotPlugins/APM/APMFlightModesComponentController.h
@@ -8,12 +8,10 @@
  ****************************************************************************/
 
 
-#ifndef APMFlightModesComponentController_H
-#define APMFlightModesComponentController_H
+#pragma once
 
-#include <QStringList>
+#include <QtCore/QStringList>
 
-#include "AutoPilotPlugin.h"
 #include "FactPanelController.h"
 #include "Vehicle.h"
 
@@ -86,5 +84,3 @@ private:
 
     static bool _typeRegistered;
 };
-
-#endif

--- a/src/AutoPilotPlugins/APM/APMFollowComponentController.cc
+++ b/src/AutoPilotPlugins/APM/APMFollowComponentController.cc
@@ -8,6 +8,7 @@
  ****************************************************************************/
 
 #include "APMFollowComponentController.h"
+#include "ArduRoverFirmwarePlugin.h"
 
 const char* APMFollowComponentController::settingsGroup =   "APMFollow";
 const char* APMFollowComponentController::angleName =       "angle";
@@ -21,4 +22,9 @@ APMFollowComponentController::APMFollowComponentController(void)
     , _heightFact   (settingsGroup, _metaDataMap[heightName])
 {
 
+}
+
+bool APMFollowComponentController::roverFirmware()
+{
+    return !!qobject_cast<ArduRoverFirmwarePlugin*>(_vehicle->firmwarePlugin());
 }

--- a/src/AutoPilotPlugins/APM/APMFollowComponentController.h
+++ b/src/AutoPilotPlugins/APM/APMFollowComponentController.h
@@ -10,7 +10,6 @@
 #pragma once
 
 #include "FactPanelController.h"
-#include "ArduRoverFirmwarePlugin.h"
 #include "SettingsFact.h"
 
 class APMFollowComponentController : public FactPanelController
@@ -28,7 +27,7 @@ public:
     Fact* angleFact     (void) { return &_angleFact; }
     Fact* distanceFact  (void) { return &_distanceFact; }
     Fact* heightFact    (void) { return &_heightFact; }
-    bool  roverFirmware (void) { return !!qobject_cast<ArduRoverFirmwarePlugin*>(_vehicle->firmwarePlugin()); }
+    bool  roverFirmware (void);
 
     static const char* settingsGroup;
     static const char* angleName;

--- a/src/AutoPilotPlugins/APM/APMLightsComponent.cc
+++ b/src/AutoPilotPlugins/APM/APMLightsComponent.cc
@@ -13,7 +13,6 @@
 ///     @author Rustom Jehangir <rusty@bluerobotics.com>
 
 #include "APMLightsComponent.h"
-#include "APMAutoPilotPlugin.h"
 
 APMLightsComponent::APMLightsComponent(Vehicle* vehicle, AutoPilotPlugin* autopilot, QObject* parent)
     : VehicleComponent(vehicle, autopilot, parent)

--- a/src/AutoPilotPlugins/APM/APMLightsComponent.h
+++ b/src/AutoPilotPlugins/APM/APMLightsComponent.h
@@ -8,8 +8,7 @@
  ****************************************************************************/
 
 
-#ifndef APMLightsComponent_H
-#define APMLightsComponent_H
+#pragma once
 
 #include "VehicleComponent.h"
 
@@ -35,5 +34,3 @@ public:
 private:
     const QString   _name;
 };
-
-#endif

--- a/src/AutoPilotPlugins/APM/APMMotorComponent.h
+++ b/src/AutoPilotPlugins/APM/APMMotorComponent.h
@@ -8,8 +8,7 @@
  ****************************************************************************/
 
 
-#ifndef APMMotorComponent_H
-#define APMMotorComponent_H
+#pragma once
 
 #include "MotorComponent.h"
 
@@ -31,5 +30,3 @@ public:
 private:
     const QString   _name;
 };
-
-#endif

--- a/src/AutoPilotPlugins/APM/APMPowerComponent.cc
+++ b/src/AutoPilotPlugins/APM/APMPowerComponent.cc
@@ -9,7 +9,6 @@
 
 
 #include "APMPowerComponent.h"
-#include "APMAutoPilotPlugin.h"
 
 APMPowerComponent::APMPowerComponent(Vehicle* vehicle, AutoPilotPlugin* autopilot, QObject* parent)
     : VehicleComponent(vehicle, autopilot, parent),

--- a/src/AutoPilotPlugins/APM/APMPowerComponent.h
+++ b/src/AutoPilotPlugins/APM/APMPowerComponent.h
@@ -8,8 +8,7 @@
  ****************************************************************************/
 
 
-#ifndef APMPowerComponent_H
-#define APMPowerComponent_H
+#pragma once
 
 #include "VehicleComponent.h"
 
@@ -37,5 +36,3 @@ private:
     const QString   _name;
     QVariantList    _summaryItems;
 };
-
-#endif

--- a/src/AutoPilotPlugins/APM/APMRadioComponent.cc
+++ b/src/AutoPilotPlugins/APM/APMRadioComponent.cc
@@ -9,9 +9,10 @@
 
 
 #include "APMRadioComponent.h"
-#include "APMAutoPilotPlugin.h"
 #include "ParameterManager.h"
 #include "FactSystem.h"
+#include "Fact.h"
+#include "Vehicle.h"
 
 APMRadioComponent::APMRadioComponent(Vehicle* vehicle, AutoPilotPlugin* autopilot, QObject* parent) :
     VehicleComponent(vehicle, autopilot, parent),

--- a/src/AutoPilotPlugins/APM/APMRadioComponent.h
+++ b/src/AutoPilotPlugins/APM/APMRadioComponent.h
@@ -8,11 +8,11 @@
  ****************************************************************************/
 
 
-#ifndef APMRadioComponent_H
-#define APMRadioComponent_H
+#pragma once
 
 #include "VehicleComponent.h"
-#include "Fact.h"
+
+class Fact;
 
 class APMRadioComponent : public VehicleComponent
 {
@@ -43,5 +43,3 @@ private:
     QStringList     _mapParams;
     QList<Fact*>    _triggerFacts;
 };
-
-#endif

--- a/src/AutoPilotPlugins/APM/APMSafetyComponent.cc
+++ b/src/AutoPilotPlugins/APM/APMSafetyComponent.cc
@@ -12,7 +12,8 @@
 ///     @author Don Gagne <don@thegagnes.com>
 
 #include "APMSafetyComponent.h"
-#include "APMAutoPilotPlugin.h"
+#include "Vehicle.h"
+#include "QGCMAVLink.h"
 
 APMSafetyComponent::APMSafetyComponent(Vehicle* vehicle, AutoPilotPlugin* autopilot, QObject* parent)
     : VehicleComponent(vehicle, autopilot, parent)

--- a/src/AutoPilotPlugins/APM/APMSafetyComponent.h
+++ b/src/AutoPilotPlugins/APM/APMSafetyComponent.h
@@ -8,8 +8,7 @@
  ****************************************************************************/
 
 
-#ifndef APMSafetyComponent_H
-#define APMSafetyComponent_H
+#pragma once
 
 #include "VehicleComponent.h"
 
@@ -38,5 +37,3 @@ private:
     const QString   _name;
     QVariantList    _summaryItems;
 };
-
-#endif

--- a/src/AutoPilotPlugins/APM/APMSensorsComponent.cc
+++ b/src/AutoPilotPlugins/APM/APMSensorsComponent.cc
@@ -9,9 +9,9 @@
 
 
 #include "APMSensorsComponent.h"
-#include "APMAutoPilotPlugin.h"
 #include "ParameterManager.h"
 #include "FactSystem.h"
+#include "Vehicle.h"
 
 // These two list must be kept in sync
 

--- a/src/AutoPilotPlugins/APM/APMSensorsComponent.h
+++ b/src/AutoPilotPlugins/APM/APMSensorsComponent.h
@@ -8,8 +8,7 @@
  ****************************************************************************/
 
 
-#ifndef APMSensorsComponent_H
-#define APMSensorsComponent_H
+#pragma once
 
 #include "VehicleComponent.h"
 
@@ -39,5 +38,3 @@ private:
     const QString   _name;
     QVariantList    _summaryItems;
 };
-
-#endif

--- a/src/AutoPilotPlugins/APM/APMSensorsComponentController.cc
+++ b/src/AutoPilotPlugins/APM/APMSensorsComponentController.cc
@@ -9,6 +9,7 @@
 
 
 #include "APMSensorsComponentController.h"
+#include "APMSensorsComponent.h"
 #include "QGCApplication.h"
 #include "APMAutoPilotPlugin.h"
 #include "ParameterManager.h"

--- a/src/AutoPilotPlugins/APM/APMSensorsComponentController.h
+++ b/src/AutoPilotPlugins/APM/APMSensorsComponentController.h
@@ -10,7 +10,6 @@
 #pragma once
 
 #include "FactPanelController.h"
-#include "APMSensorsComponent.h"
 
 #include <QtQuick/QQuickItem>
 #include <QtCore/QObject>
@@ -18,6 +17,8 @@
 
 Q_DECLARE_LOGGING_CATEGORY(APMSensorsComponentControllerLog)
 Q_DECLARE_LOGGING_CATEGORY(APMSensorsComponentControllerVerboseLog)
+
+class APMSensorsComponent;
 
 /// Sensors Component MVC Controller for SensorsComponent.qml.
 class APMSensorsComponentController : public FactPanelController

--- a/src/AutoPilotPlugins/APM/APMSubFrameComponent.cc
+++ b/src/AutoPilotPlugins/APM/APMSubFrameComponent.cc
@@ -13,7 +13,6 @@
 ///     @author Jacob Walser <jwalser90@gmail.com>
 
 #include "APMSubFrameComponent.h"
-#include "APMAutoPilotPlugin.h"
 
 APMSubFrameComponent::APMSubFrameComponent(Vehicle* vehicle, AutoPilotPlugin* autopilot, QObject* parent)
     : VehicleComponent(vehicle, autopilot, parent)

--- a/src/AutoPilotPlugins/APM/APMSubFrameComponent.h
+++ b/src/AutoPilotPlugins/APM/APMSubFrameComponent.h
@@ -8,8 +8,7 @@
  ****************************************************************************/
 
 
-#ifndef APMSubFrameComponent_H
-#define APMSubFrameComponent_H
+#pragma once
 
 #include "VehicleComponent.h"
 
@@ -35,5 +34,3 @@ public:
 private:
     const QString   _name;
 };
-
-#endif

--- a/src/AutoPilotPlugins/APM/APMSubMotorComponentController.h
+++ b/src/AutoPilotPlugins/APM/APMSubMotorComponentController.h
@@ -8,8 +8,7 @@
  ****************************************************************************/
 
 
-#ifndef APMSubMotorComponentController_H
-#define APMSubMotorComponentController_H
+#pragma once
 
 #include "FactPanelController.h"
 
@@ -32,5 +31,3 @@ private slots:
 private:
     QString _motorDetectionMessages;
 };
-
-#endif

--- a/src/AutoPilotPlugins/APM/APMTuningComponent.cc
+++ b/src/AutoPilotPlugins/APM/APMTuningComponent.cc
@@ -9,7 +9,7 @@
 
 
 #include "APMTuningComponent.h"
-#include "APMAutoPilotPlugin.h"
+#include "Vehicle.h"
 
 APMTuningComponent::APMTuningComponent(Vehicle* vehicle, AutoPilotPlugin* autopilot, QObject* parent)
     : VehicleComponent(vehicle, autopilot, parent)

--- a/src/AutoPilotPlugins/APM/APMTuningComponent.h
+++ b/src/AutoPilotPlugins/APM/APMTuningComponent.h
@@ -8,8 +8,7 @@
  ****************************************************************************/
 
 
-#ifndef APMTuningComponent_H
-#define APMTuningComponent_H
+#pragma once
 
 #include "VehicleComponent.h"
 
@@ -37,5 +36,3 @@ private:
     const QString   _name;
     QVariantList    _summaryItems;
 };
-
-#endif

--- a/src/AutoPilotPlugins/APM/CMakeLists.txt
+++ b/src/AutoPilotPlugins/APM/CMakeLists.txt
@@ -1,37 +1,64 @@
-find_package(Qt6 REQUIRED COMPONENTS Core Qml)
+find_package(Qt6 REQUIRED COMPONENTS Core Quick)
 
-add_custom_target(APMAutoPilotPluginQml
-    SOURCES
-        APMAirframeComponent.qml
-        APMAirframeComponentSummary.qml
-        APMCameraComponent.qml
-        APMCameraComponentSummary.qml
-        APMCameraSubComponent.qml
-        APMFlightModesComponent.qml
-        APMFlightModesComponentSummary.qml
-        APMHeliComponent.qml
-        APMLightsComponent.qml
-        APMLightsComponentSummary.qml
-        APMNotSupported.qml
-        APMPowerComponent.qml
-        APMPowerComponentSummary.qml
-        APMRadioComponentSummary.qml
-        APMRemoteSupportComponent.qml
-        APMSafetyComponent.qml
-        APMSafetyComponentCopter.qml
-        APMSafetyComponentPlane.qml
-        APMSafetyComponentRover.qml
-        APMSafetyComponentSub.qml
-        APMSafetyComponentSummary.qml
-        APMSafetyComponentSummaryCopter.qml
-        APMSafetyComponentSummaryPlane.qml
-        APMSafetyComponentSummaryRover.qml
-        APMSafetyComponentSummarySub.qml
-        APMSensorsComponent.qml
-        APMSensorsComponentSummary.qml
-        APMSubFrameComponent.qml
-        APMSubFrameComponentSummary.qml
-        APMSubMotorComponent.qml
-        APMTuningComponentCopter.qml
-        APMTuningComponentSub.qml
+qt_add_library(APMAutoPilotPlugin STATIC
+    APMAirframeComponent.cc
+    APMAirframeComponent.h
+    APMAirframeComponentController.cc
+    APMAirframeComponentController.h
+    APMAutoPilotPlugin.cc
+    APMAutoPilotPlugin.h
+    APMCameraComponent.cc
+    APMCameraComponent.h
+    APMFlightModesComponent.cc
+    APMFlightModesComponent.h
+    APMFlightModesComponentController.cc
+    APMFlightModesComponentController.h
+    APMFollowComponent.cc
+    APMFollowComponent.h
+    APMFollowComponentController.cc
+    APMFollowComponentController.h
+    APMHeliComponent.cc
+    APMHeliComponent.h
+    APMLightsComponent.cc
+    APMLightsComponent.h
+    APMMotorComponent.cc
+    APMMotorComponent.h
+    APMPowerComponent.cc
+    APMPowerComponent.h
+    APMRadioComponent.cc
+    APMRadioComponent.h
+    APMRemoteSupportComponent.cc
+    APMRemoteSupportComponent.h
+    APMSafetyComponent.cc
+    APMSafetyComponent.h
+    APMSensorsComponent.cc
+    APMSensorsComponent.h
+    APMSensorsComponentController.cc
+    APMSensorsComponentController.h
+    APMSubFrameComponent.cc
+    APMSubFrameComponent.h
+    APMSubMotorComponentController.cc
+    APMSubMotorComponentController.h
+    APMTuningComponent.cc
+    APMTuningComponent.h
 )
+
+target_link_libraries(APMAutoPilotPlugin
+    PRIVATE
+        Actuators
+        APMFirmwarePlugin
+        AutoPilotPlugins
+        FactSystem
+        qgc
+        Settings
+        Utilities
+    PUBLIC
+        Qt6::Core
+        Qt6::Quick
+        CommonAutoPilotPlugin
+        FactControls
+        Vehicle
+        VehicleSetup
+)
+
+target_include_directories(APMAutoPilotPlugin PUBLIC ${CMAKE_CURRENT_SOURCE_DIR})

--- a/src/AutoPilotPlugins/AutoPilotPlugin.cc
+++ b/src/AutoPilotPlugins/AutoPilotPlugin.cc
@@ -15,7 +15,7 @@
 #include "QGCApplication.h"
 #include "FirmwarePlugin.h"
 #include "Vehicle.h"
-#include "FactSystem.h"
+#include "VehicleComponent.h"
 
 AutoPilotPlugin::AutoPilotPlugin(Vehicle* vehicle, QObject* parent)
     : QObject(parent)

--- a/src/AutoPilotPlugins/AutoPilotPlugin.h
+++ b/src/AutoPilotPlugins/AutoPilotPlugin.h
@@ -9,14 +9,13 @@
 
 #pragma once
 
-#include "VehicleComponent.h"
-
 #include <QtCore/QObject>
 #include <QtCore/QString>
 #include <QtCore/QVariantList>
 
 class Vehicle;
 class FirmwarePlugin;
+class VehicleComponent;
 
 /// This is the base class for AutoPilot plugins
 ///

--- a/src/AutoPilotPlugins/CMakeLists.txt
+++ b/src/AutoPilotPlugins/CMakeLists.txt
@@ -5,117 +5,24 @@ add_subdirectory(PX4)
 find_package(Qt6 REQUIRED COMPONENTS Core)
 
 qt_add_library(AutoPilotPlugins STATIC
-	APM/APMAirframeComponent.cc
-	APM/APMAirframeComponent.h
-	APM/APMAirframeComponentController.cc
-	APM/APMAirframeComponentController.h
-	APM/APMAutoPilotPlugin.cc
-	APM/APMAutoPilotPlugin.h
-	APM/APMCameraComponent.cc
-	APM/APMCameraComponent.h
-	APM/APMFlightModesComponent.cc
-	APM/APMFlightModesComponent.h
-	APM/APMFlightModesComponentController.cc
-	APM/APMFlightModesComponentController.h
-	APM/APMFollowComponent.cc
-	APM/APMFollowComponent.h
-	APM/APMFollowComponentController.cc
-	APM/APMFollowComponentController.h
-	APM/APMHeliComponent.cc
-	APM/APMHeliComponent.h
-	APM/APMLightsComponent.cc
-	APM/APMLightsComponent.h
-	APM/APMMotorComponent.cc
-	APM/APMMotorComponent.h
-	APM/APMPowerComponent.cc
-	APM/APMPowerComponent.h
-	APM/APMRadioComponent.cc
-	APM/APMRadioComponent.h
-	APM/APMRemoteSupportComponent.cc
-	APM/APMRemoteSupportComponent.h
-	APM/APMSafetyComponent.cc
-	APM/APMSafetyComponent.h
-	APM/APMSensorsComponent.cc
-	APM/APMSensorsComponent.h
-	APM/APMSensorsComponentController.cc
-	APM/APMSensorsComponentController.h
-	APM/APMSubFrameComponent.cc
-	APM/APMSubFrameComponent.h
-	APM/APMSubMotorComponentController.cc
-	APM/APMSubMotorComponentController.h
-	APM/APMTuningComponent.cc
-	APM/APMTuningComponent.h
-
-	Common/ESP8266Component.cc
-	Common/ESP8266Component.h
-	Common/ESP8266ComponentController.cc
-	Common/ESP8266ComponentController.h
-	Common/MotorComponent.cc
-	Common/MotorComponent.h
-	Common/RadioComponentController.cc
-	Common/RadioComponentController.h
-	Common/SyslinkComponent.cc
-	Common/SyslinkComponent.h
-	Common/SyslinkComponentController.cc
-	Common/SyslinkComponentController.h
-
-	Generic/GenericAutoPilotPlugin.cc
-	Generic/GenericAutoPilotPlugin.h
-
-	PX4/ActuatorComponent.cc
-	PX4/ActuatorComponent.h
-	PX4/AirframeComponent.cc
-	PX4/AirframeComponent.h
-	PX4/AirframeComponentAirframes.cc
-	PX4/AirframeComponentAirframes.h
-	PX4/AirframeComponentController.cc
-	PX4/AirframeComponentController.h
-	PX4/CameraComponent.cc
-	PX4/CameraComponent.h
-	PX4/FlightModesComponent.cc
-	PX4/FlightModesComponent.h
-	PX4/PowerComponent.cc
-	PX4/PowerComponent.h
-	PX4/PowerComponentController.cc
-	PX4/PowerComponentController.h
-	PX4/PX4AirframeLoader.cc
-	PX4/PX4AirframeLoader.h
-	PX4/PX4AutoPilotPlugin.cc
-	PX4/PX4AutoPilotPlugin.h
-	PX4/PX4FlightBehavior.cc
-	PX4/PX4FlightBehavior.h
-	PX4/PX4RadioComponent.cc
-	PX4/PX4RadioComponent.h
-	PX4/PX4SimpleFlightModesController.cc
-	PX4/PX4SimpleFlightModesController.h
-	PX4/PX4TuningComponent.cc
-	PX4/PX4TuningComponent.h
-	PX4/SafetyComponent.cc
-	PX4/SafetyComponent.h
-	PX4/SensorsComponent.cc
-	PX4/SensorsComponent.h
-	PX4/SensorsComponentController.cc
-	PX4/SensorsComponentController.h
-
 	AutoPilotPlugin.cc
 	AutoPilotPlugin.h
+	Generic/GenericAutoPilotPlugin.cc
+	Generic/GenericAutoPilotPlugin.h
 )
 
 target_link_libraries(AutoPilotPlugins
+    PRIVATE
+        FirmwarePlugin
+        qgc
+        Vehicle
+        VehicleSetup
 	PUBLIC
 		Qt6::Core
-		Qt6::Quick
-                FirmwarePlugin
-                VehicleSetup
-    PRIVATE
-        VehicleActuators
-        qgc
 )
 
 target_include_directories(AutoPilotPlugins
 	PUBLIC
 		${CMAKE_CURRENT_SOURCE_DIR}
-		APM
-		Common
-		PX4
+		Generic
 )

--- a/src/AutoPilotPlugins/Common/CMakeLists.txt
+++ b/src/AutoPilotPlugins/Common/CMakeLists.txt
@@ -1,11 +1,32 @@
-find_package(Qt6 REQUIRED COMPONENTS Core Qml)
+find_package(Qt6 REQUIRED COMPONENTS Core Network Quick)
 
-add_custom_target(CommonAutoPilotPluginQml
-    SOURCES
-        ESP8266Component.qml
-        ESP8266ComponentSummary.qml
-        MotorComponent.qml
-        RadioComponent.qml
-        SetupPage.qml
-        SyslinkComponent.qml
+qt_add_library(CommonAutoPilotPlugin STATIC
+    ESP8266Component.cc
+    ESP8266Component.h
+    ESP8266ComponentController.cc
+    ESP8266ComponentController.h
+    MotorComponent.cc
+    MotorComponent.h
+    RadioComponentController.cc
+    RadioComponentController.h
+    SyslinkComponent.cc
+    SyslinkComponent.h
+    SyslinkComponentController.cc
+    SyslinkComponentController.h
 )
+
+target_link_libraries(CommonAutoPilotPlugin
+    PRIVATE
+        AutoPilotPlugins
+        FactSystem
+        qgc
+        Utilities
+    PUBLIC
+        Qt6::Core
+        Qt6::Network
+        Qt6::Quick
+        FactControls
+        VehicleSetup
+)
+
+target_include_directories(CommonAutoPilotPlugin PUBLIC ${CMAKE_CURRENT_SOURCE_DIR})

--- a/src/AutoPilotPlugins/Common/ESP8266ComponentController.cc
+++ b/src/AutoPilotPlugins/Common/ESP8266ComponentController.cc
@@ -15,6 +15,7 @@
 #include "ESP8266ComponentController.h"
 #include "ParameterManager.h"
 #include "QGCLoggingCategory.h"
+
 #include <QtNetwork/QHostAddress>
 
 QGC_LOGGING_CATEGORY(ESP8266ComponentControllerLog, "ESP8266ComponentControllerLog")

--- a/src/AutoPilotPlugins/PX4/AirframeComponentAirframes.h
+++ b/src/AutoPilotPlugins/PX4/AirframeComponentAirframes.h
@@ -14,8 +14,8 @@
 #ifndef AIRFRAMECOMPONENTAIRFRAMES_H
 #define AIRFRAMECOMPONENTAIRFRAMES_H
 
-#include <QList>
-#include <QMap>
+#include <QtCore/QList>
+#include <QtCore/QMap>
 
 /// MVC Controller for AirframeComponent.qml.
 class AirframeComponentAirframes

--- a/src/AutoPilotPlugins/PX4/AirframeComponentController.h
+++ b/src/AutoPilotPlugins/PX4/AirframeComponentController.h
@@ -14,7 +14,7 @@
 #ifndef AIRFRAMECOMPONENTCONTROLLER_H
 #define AIRFRAMECOMPONENTCONTROLLER_H
 
-#include <QObject>
+#include <QtCore/QObject>
 
 #include "FactPanelController.h"
 

--- a/src/AutoPilotPlugins/PX4/CMakeLists.txt
+++ b/src/AutoPilotPlugins/PX4/CMakeLists.txt
@@ -1,25 +1,57 @@
-find_package(Qt6 REQUIRED COMPONENTS Core Qml)
+find_package(Qt6 REQUIRED COMPONENTS Core Quick)
 
-add_custom_target(PX4AutoPilotPluginQml
-	SOURCES
-		AirframeComponent.qml
-		AirframeComponentSummary.qml
-		BatteryParams.qml
-		CameraComponent.qml
-		CameraComponentSummary.qml
-		FlightModesComponentSummary.qml
-		PowerComponent.qml
-		PowerComponentSummary.qml
-		PX4FlightModes.qml
-		PX4RadioComponentSummary.qml
-		PX4SimpleFlightModes.qml
-		PX4TuningComponentCopter.qml
-		PX4TuningComponentPlane.qml
-		PX4TuningComponentVTOL.qml
-		SafetyComponent.qml
-		SafetyComponentSummary.qml
-		SensorsComponent.qml
-		SensorsComponentSummary.qml
-		SensorsComponentSummaryFixedWing.qml
-		SensorsSetup.qml
+qt_add_library(PX4AutoPilotPlugin STATIC
+	ActuatorComponent.cc
+	ActuatorComponent.h
+	AirframeComponent.cc
+	AirframeComponent.h
+	AirframeComponentAirframes.cc
+	AirframeComponentAirframes.h
+	AirframeComponentController.cc
+	AirframeComponentController.h
+	CameraComponent.cc
+	CameraComponent.h
+	FlightModesComponent.cc
+	FlightModesComponent.h
+	PowerComponent.cc
+	PowerComponent.h
+	PowerComponentController.cc
+	PowerComponentController.h
+	PX4AirframeLoader.cc
+	PX4AirframeLoader.h
+	PX4AutoPilotPlugin.cc
+	PX4AutoPilotPlugin.h
+	PX4FlightBehavior.cc
+	PX4FlightBehavior.h
+	PX4RadioComponent.cc
+	PX4RadioComponent.h
+	PX4SimpleFlightModesController.cc
+	PX4SimpleFlightModesController.h
+	PX4TuningComponent.cc
+	PX4TuningComponent.h
+	SafetyComponent.cc
+	SafetyComponent.h
+	SensorsComponent.cc
+	SensorsComponent.h
+	SensorsComponentController.cc
+	SensorsComponentController.h
 )
+
+target_link_libraries(PX4AutoPilotPlugin
+    PRIVATE
+		comm
+        qgc
+		Utilities
+	PUBLIC
+		Qt6::Core
+		Qt6::Quick
+		AutoPilotPlugins
+		CommonAutoPilotPlugin
+		FactControls
+		FactSystem
+		Vehicle
+        VehicleActuators
+        VehicleSetup
+)
+
+target_include_directories(PX4AutoPilotPlugin PUBLIC ${CMAKE_CURRENT_SOURCE_DIR})

--- a/src/AutoPilotPlugins/PX4/PX4AirframeLoader.cc
+++ b/src/AutoPilotPlugins/PX4/PX4AirframeLoader.cc
@@ -15,6 +15,7 @@
 #include "QGCApplication.h"
 #include "QGCLoggingCategory.h"
 #include "AirframeComponentAirframes.h"
+#include "AutoPilotPlugin.h"
 
 #include <QFile>
 #include <QFileInfo>

--- a/src/AutoPilotPlugins/PX4/PX4AirframeLoader.h
+++ b/src/AutoPilotPlugins/PX4/PX4AirframeLoader.h
@@ -11,11 +11,11 @@
 #ifndef PX4AIRFRAMELOADER_H
 #define PX4AIRFRAMELOADER_H
 
-#include <QObject>
-#include <QMap>
-#include <QLoggingCategory>
+#include <QtCore/QObject>
+#include <QtCore/QMap>
+#include <QtCore/QLoggingCategory>
 
-#include "AutoPilotPlugin.h"
+class AutoPilotPlugin;
 
 /// @file PX4AirframeLoader.h
 ///     @author Lorenz Meier <lm@qgroundcontrol.org>

--- a/src/AutoPilotPlugins/PX4/PX4AutoPilotPlugin.cc
+++ b/src/AutoPilotPlugins/PX4/PX4AutoPilotPlugin.cc
@@ -20,6 +20,7 @@
 #include "FactSystem.h"
 #include "ParameterManager.h"
 #include "Vehicle.h"
+#include "ActuatorComponent.h"
 
 /// @file
 ///     @brief This is the AutoPilotPlugin implementatin for the MAV_AUTOPILOT_PX4 type.

--- a/src/AutoPilotPlugins/PX4/PX4AutoPilotPlugin.h
+++ b/src/AutoPilotPlugins/PX4/PX4AutoPilotPlugin.h
@@ -26,7 +26,8 @@
 #include "PX4TuningComponent.h"
 #include "PX4FlightBehavior.h"
 #include "SyslinkComponent.h"
-#include "Vehicle.h"
+
+class Vehicle;
 
 /// @file
 ///     @brief This is the PX4 specific implementation of the AutoPilot class.

--- a/src/AutoPilotPlugins/PX4/PX4SimpleFlightModesController.h
+++ b/src/AutoPilotPlugins/PX4/PX4SimpleFlightModesController.h
@@ -11,7 +11,6 @@
 #ifndef PX4SimpleFlightModesController_H
 #define PX4SimpleFlightModesController_H
 
-#include "AutoPilotPlugin.h"
 #include "FactPanelController.h"
 #include "Vehicle.h"
 

--- a/src/AutoPilotPlugins/PX4/SensorsComponentController.h
+++ b/src/AutoPilotPlugins/PX4/SensorsComponentController.h
@@ -14,7 +14,7 @@
 #ifndef SENSORSCOMPONENTCONTROLLER_H
 #define SENSORSCOMPONENTCONTROLLER_H
 
-#include <QQuickItem>
+#include <QtQuick/QQuickItem>
 #include <QtCore/QLoggingCategory>
 
 #include "FactPanelController.h"

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -69,6 +69,7 @@ target_link_libraries(qgc
                 AutoPilotPlugins
                 Camera
                 comm
+                CommonAutoPilotPlugin
                 FactSystem
                 FirmwarePlugin
                 FlightMap

--- a/src/FirmwarePlugin/APM/APMFirmwarePlugin.cc
+++ b/src/FirmwarePlugin/APM/APMFirmwarePlugin.cc
@@ -29,7 +29,7 @@
 #include "LinkManager.h"
 #include "QGCLoggingCategory.h"
 
-#include <QTcpSocket>
+#include <QtNetwork/QTcpSocket>
 #include <QtCore/QRegularExpression>
 #include <QtCore/QRegularExpressionMatch>
 

--- a/src/FirmwarePlugin/APM/APMFirmwarePlugin.h
+++ b/src/FirmwarePlugin/APM/APMFirmwarePlugin.h
@@ -13,7 +13,7 @@
 #include "APMParameterMetaData.h"
 #include "FollowMe.h"
 
-#include <QAbstractSocket>
+#include <QtNetwork/QAbstractSocket>
 #include <QtCore/QMutex>
 #include <QtCore/QLoggingCategory>
 

--- a/src/FirmwarePlugin/APM/APMFirmwarePluginFactory.cc
+++ b/src/FirmwarePlugin/APM/APMFirmwarePluginFactory.cc
@@ -8,10 +8,10 @@
  ****************************************************************************/
 
 #include "APMFirmwarePluginFactory.h"
-#include "APM/ArduCopterFirmwarePlugin.h"
-#include "APM/ArduPlaneFirmwarePlugin.h"
-#include "APM/ArduRoverFirmwarePlugin.h"
-#include "APM/ArduSubFirmwarePlugin.h"
+#include "ArduCopterFirmwarePlugin.h"
+#include "ArduPlaneFirmwarePlugin.h"
+#include "ArduRoverFirmwarePlugin.h"
+#include "ArduSubFirmwarePlugin.h"
 
 APMFirmwarePluginFactory APMFirmwarePluginFactory;
 

--- a/src/FirmwarePlugin/APM/APMParameterMetaData.cc
+++ b/src/FirmwarePlugin/APM/APMParameterMetaData.cc
@@ -11,8 +11,8 @@
 #include "APMParameterMetaData.h"
 #include "QGCLoggingCategory.h"
 
-#include <QFile>
-#include <QStack>
+#include <QtCore/QFile>
+#include <QtCore/QStack>
 #include <QtCore/QRegularExpression>
 #include <QtCore/QRegularExpressionMatch>
 

--- a/src/FirmwarePlugin/APM/APMParameterMetaData.h
+++ b/src/FirmwarePlugin/APM/APMParameterMetaData.h
@@ -8,13 +8,12 @@
  ****************************************************************************/
 
 
-#ifndef APMParameterMetaData_H
-#define APMParameterMetaData_H
+#pragma once
 
-#include <QObject>
-#include <QMap>
-#include <QXmlStreamReader>
-#include <QLoggingCategory>
+#include <QtCore/QObject>
+#include <QtCore/QMap>
+#include <QtCore/QXmlStreamReader>
+#include <QtCore/QLoggingCategory>
 
 #include "QGCMAVLink.h"
 #include "FactMetaData.h"
@@ -86,5 +85,3 @@ private:
     // FIXME: metadata is vehicle type specific now
     QMap<QString, ParameterNametoFactMetaDataMap>   _vehicleTypeToParametersMap;                ///< Maps from a vehicle type to paramametertoFactMeta map>
 };
-
-#endif

--- a/src/FirmwarePlugin/APM/ArduCopterFirmwarePlugin.h
+++ b/src/FirmwarePlugin/APM/ArduCopterFirmwarePlugin.h
@@ -11,8 +11,7 @@
 /// @file
 ///     @author Don Gagne <don@thegagnes.com>
 
-#ifndef ArduCopterFirmwarePlugin_H
-#define ArduCopterFirmwarePlugin_H
+#pragma once
 
 #include "APMFirmwarePlugin.h"
 
@@ -80,5 +79,3 @@ private:
     static bool _remapParamNameIntialized;
     static FirmwarePlugin::remapParamNameMajorVersionMap_t  _remapParamName;
 };
-
-#endif

--- a/src/FirmwarePlugin/APM/ArduPlaneFirmwarePlugin.h
+++ b/src/FirmwarePlugin/APM/ArduPlaneFirmwarePlugin.h
@@ -11,8 +11,7 @@
 /// @file
 ///     @author Pritam Ghanghas <pritam.ghanghas@gmail.com>
 
-#ifndef ArduPlaneFirmwarePlugin_H
-#define ArduPlaneFirmwarePlugin_H
+#pragma once
 
 #include "APMFirmwarePlugin.h"
 
@@ -68,5 +67,3 @@ private:
     static bool _remapParamNameIntialized;
     static FirmwarePlugin::remapParamNameMajorVersionMap_t  _remapParamName;
 };
-
-#endif

--- a/src/FirmwarePlugin/APM/ArduRoverFirmwarePlugin.h
+++ b/src/FirmwarePlugin/APM/ArduRoverFirmwarePlugin.h
@@ -11,8 +11,7 @@
 /// @file
 ///     @author Pritam Ghanghas <pritam.ghanghas@gmail.com>
 
-#ifndef ArduRoverFirmwarePlugin_H
-#define ArduRoverFirmwarePlugin_H
+#pragma once
 
 #include "APMFirmwarePlugin.h"
 
@@ -59,5 +58,3 @@ private:
     static bool _remapParamNameIntialized;
     static FirmwarePlugin::remapParamNameMajorVersionMap_t  _remapParamName;
 };
-
-#endif

--- a/src/FirmwarePlugin/APM/ArduSubFirmwarePlugin.h
+++ b/src/FirmwarePlugin/APM/ArduSubFirmwarePlugin.h
@@ -24,8 +24,7 @@
 /// @file
 ///     @author Rustom Jehangir <rusty@bluerobotics.com>
 
-#ifndef ArduSubFirmwarePlugin_H
-#define ArduSubFirmwarePlugin_H
+#pragma once
 
 #include "APMFirmwarePlugin.h"
 #include "FactGroup.h"
@@ -155,4 +154,3 @@ private:
     QMap<QString, FactGroup*> _nameToFactGroupMap;
     APMSubmarineFactGroup _infoFactGroup;
 };
-#endif

--- a/src/FirmwarePlugin/APM/CMakeLists.txt
+++ b/src/FirmwarePlugin/APM/CMakeLists.txt
@@ -1,9 +1,42 @@
-find_package(Qt6 REQUIRED COMPONENTS Core Qml)
+find_package(Qt6 REQUIRED COMPONENTS Core Network)
 
-add_custom_target(APMFirmwarePluginQml
-    SOURCES
-        APMBatteryIndicator.qml
-        APMFlightModeIndicator.qml
-        APMMainStatusIndicatorContentItem.qml
-        APMSensorParams.qml
+set(APM_RESOURCES)
+qt_add_resources(APM_RESOURCES APMResources.qrc)
+qt_add_library(APMFirmwarePlugin STATIC
+    APMFirmwarePlugin.cc
+    APMFirmwarePlugin.h
+    APMFirmwarePluginFactory.cc
+    APMFirmwarePluginFactory.h
+    APMParameterMetaData.cc
+    APMParameterMetaData.h
+    ArduCopterFirmwarePlugin.cc
+    ArduCopterFirmwarePlugin.h
+    ArduPlaneFirmwarePlugin.cc
+    ArduPlaneFirmwarePlugin.h
+    ArduRoverFirmwarePlugin.cc
+    ArduRoverFirmwarePlugin.h
+    ArduSubFirmwarePlugin.cc
+    ArduSubFirmwarePlugin.h
+    ${APM_RESOURCES}
 )
+
+target_link_libraries(APMFirmwarePlugin
+    PRIVATE
+        APMAutoPilotPlugin
+        AutoPilotPlugins
+        MissionManager
+        qgc
+        Settings
+        Utilities
+        Vehicle
+        VehicleSetup
+    PUBLIC
+        Qt6::Core
+        Qt6::Network
+        comm
+        FactSystem
+        FollowMe
+        FirmwarePlugin
+)
+
+target_include_directories(APMFirmwarePlugin PUBLIC ${CMAKE_CURRENT_SOURCE_DIR})

--- a/src/FirmwarePlugin/CMakeLists.txt
+++ b/src/FirmwarePlugin/CMakeLists.txt
@@ -1,7 +1,7 @@
 add_subdirectory(APM)
 add_subdirectory(PX4)
 
-find_package(Qt6 REQUIRED COMPONENTS Core)
+find_package(Qt6 REQUIRED COMPONENTS Core Positioning)
 
 qt_add_library(FirmwarePlugin STATIC
 	CameraMetaData.cc
@@ -10,46 +10,23 @@ qt_add_library(FirmwarePlugin STATIC
 	FirmwarePlugin.h
 	FirmwarePluginManager.cc
 	FirmwarePluginManager.h
-
-	APM/APMFirmwarePlugin.cc
-	APM/APMFirmwarePlugin.h
-	APM/APMFirmwarePluginFactory.cc
-	APM/APMFirmwarePluginFactory.h
-	APM/APMParameterMetaData.cc
-	APM/APMParameterMetaData.h
-	APM/ArduCopterFirmwarePlugin.cc
-	APM/ArduCopterFirmwarePlugin.h
-	APM/ArduPlaneFirmwarePlugin.cc
-	APM/ArduPlaneFirmwarePlugin.h
-	APM/ArduRoverFirmwarePlugin.cc
-	APM/ArduRoverFirmwarePlugin.h
-	APM/ArduSubFirmwarePlugin.cc
-	APM/ArduSubFirmwarePlugin.h
-	APM/APMResources.qrc
-
-	PX4/px4_custom_mode.h
-	PX4/PX4FirmwarePlugin.cc
-	PX4/PX4FirmwarePlugin.h
-	PX4/PX4FirmwarePluginFactory.cc
-	PX4/PX4FirmwarePluginFactory.h
-	PX4/PX4ParameterMetaData.cc
-	PX4/PX4ParameterMetaData.h
-	PX4/PX4Resources.qrc
 )
 
 target_link_libraries(FirmwarePlugin
-	PRIVATE
-            Camera
-		qgc
-        PUBLIC
-            AutoPilotPlugins
-            FollowMe
-            MissionManager
-            VehicleSetup
+    PRIVATE
+        AutoPilotPlugins
+        CommonAutoPilotPlugin
+        Camera
+        MissionManager
+        qgc
+        Utilities
+        VehicleSetup
+    PUBLIC
+    	Qt6::Core
+        Qt6::Positioning
+        comm
+        FactSystem
+        FollowMe
 )
 
-target_include_directories(FirmwarePlugin
-	PUBLIC
-		${CMAKE_CURRENT_SOURCE_DIR}
-        APM
-)
+target_include_directories(FirmwarePlugin PUBLIC ${CMAKE_CURRENT_SOURCE_DIR})

--- a/src/FirmwarePlugin/FirmwarePlugin.cc
+++ b/src/FirmwarePlugin/FirmwarePlugin.cc
@@ -9,13 +9,15 @@
 
 #include "FirmwarePlugin.h"
 #include "QGCApplication.h"
-#include "Generic/GenericAutoPilotPlugin.h"
+#include "GenericAutoPilotPlugin.h"
+#include "AutoPilotPlugin.h"
 #include "CameraMetaData.h"
 #include "QGCFileDownload.h"
 #include "QGCCameraManager.h"
 #include "RadioComponentController.h"
 #include "Autotune.h"
 #include "VehicleCameraControl.h"
+#include "VehicleComponent.h"
 #include "QGC.h"
 #include "QGCLoggingCategory.h"
 

--- a/src/FirmwarePlugin/FirmwarePlugin.h
+++ b/src/FirmwarePlugin/FirmwarePlugin.h
@@ -10,17 +10,17 @@
 #pragma once
 /// @file
 
-#include "QGCMAVLink.h"
-#include "VehicleComponent.h"
-#include "AutoPilotPlugin.h"
-#include "GeoFenceManager.h"
-#include "RallyPointManager.h"
-#include "FollowMe.h"
-
 #include <QtCore/QList>
 #include <QtCore/QString>
 #include <QtCore/QVariantList>
+#include <QtPositioning/QGeoCoordinate>
 
+#include "QGCMAVLink.h"
+#include "FollowMe.h"
+#include "FactMetaData.h"
+
+class VehicleComponent;
+class AutoPilotPlugin;
 class Vehicle;
 class MavlinkCameraControl;
 class QGCCameraManager;

--- a/src/FirmwarePlugin/FirmwarePluginManager.h
+++ b/src/FirmwarePlugin/FirmwarePluginManager.h
@@ -9,11 +9,11 @@
 
 #pragma once
 
+#include <QtCore/QObject>
 
 #include "QGCMAVLink.h"
 #include "QGCToolbox.h"
 
-#include <QtCore/QObject>
 
 class QGCApplication;
 class FirmwarePlugin;

--- a/src/FirmwarePlugin/PX4/CMakeLists.txt
+++ b/src/FirmwarePlugin/PX4/CMakeLists.txt
@@ -1,7 +1,32 @@
-find_package(Qt6 REQUIRED COMPONENTS Core Qml)
+find_package(Qt6 REQUIRED COMPONENTS Core)
 
-add_custom_target(PX4FirmwarePluginQml
-	SOURCES
-        PX4FlightModeIndicator.qml
-        PX4MainStatusIndicatorContentItem.qml
+set(PX4_RESOURCES)
+qt_add_resources(PX4_RESOURCES PX4Resources.qrc)
+qt_add_library(PX4FirmwarePlugin STATIC
+    px4_custom_mode.h
+    PX4FirmwarePlugin.cc
+    PX4FirmwarePlugin.h
+    PX4FirmwarePluginFactory.cc
+    PX4FirmwarePluginFactory.h
+    PX4ParameterMetaData.cc
+    PX4ParameterMetaData.h
+    ${PX4_RESOURCES}
 )
+
+target_link_libraries(PX4FirmwarePlugin
+    PRIVATE
+        AutoPilotPlugins
+        MissionManager
+        PX4AutoPilotPlugin
+        qgc
+        Settings
+        VehicleSetup
+        Utilities
+    PUBLIC
+        Qt6::Core
+        comm
+        FactSystem
+        FirmwarePlugin
+)
+
+target_include_directories(PX4FirmwarePlugin PUBLIC ${CMAKE_CURRENT_SOURCE_DIR})

--- a/src/FirmwarePlugin/PX4/PX4FirmwarePluginFactory.cc
+++ b/src/FirmwarePlugin/PX4/PX4FirmwarePluginFactory.cc
@@ -8,7 +8,7 @@
  ****************************************************************************/
 
 #include "PX4FirmwarePluginFactory.h"
-#include "PX4/PX4FirmwarePlugin.h"
+#include "PX4FirmwarePlugin.h"
 
 PX4FirmwarePluginFactory PX4FirmwarePluginFactory;
 

--- a/src/FirmwarePlugin/PX4/PX4ParameterMetaData.cc
+++ b/src/FirmwarePlugin/PX4/PX4ParameterMetaData.cc
@@ -14,10 +14,10 @@
 #include "PX4ParameterMetaData.h"
 #include "QGCLoggingCategory.h"
 
-#include <QFile>
-#include <QDir>
-#include <QDebug>
-#include <QXmlStreamReader>
+#include <QtCore/QFile>
+#include <QtCore/QDir>
+#include <QtCore/QDebug>
+#include <QtCore/QXmlStreamReader>
 
 static const char* kInvalidConverstion = "Internal Error: No support for string parameters";
 

--- a/src/FirmwarePlugin/PX4/PX4ParameterMetaData.h
+++ b/src/FirmwarePlugin/PX4/PX4ParameterMetaData.h
@@ -9,11 +9,12 @@
 
 #pragma once
 
-#include <QObject>
-#include <QLoggingCategory>
 
 #include "QGCMAVLink.h"
 #include "FactMetaData.h"
+
+#include <QtCore/QObject>
+#include <QtCore/QLoggingCategory>
 
 /// @file
 ///     @author Don Gagne <don@thegagnes.com>
@@ -26,7 +27,7 @@ Q_DECLARE_LOGGING_CATEGORY(PX4ParameterMetaDataLog)
 class PX4ParameterMetaData : public QObject
 {
     Q_OBJECT
-    
+
 public:
     PX4ParameterMetaData(void);
 
@@ -43,7 +44,7 @@ private:
         XmlStateFoundGroup,
         XmlStateFoundParameter,
         XmlStateDone
-    };    
+    };
 
     QVariant _stringToTypedVariant(const QString& string, FactMetaData::ValueType_t type, bool* convertOk);
     static void _outputFileWarning(const QString& metaDataFile, const QString& error1, const QString& error2);

--- a/src/UTMSP/CMakeLists.txt
+++ b/src/UTMSP/CMakeLists.txt
@@ -1,9 +1,5 @@
 find_package(Qt6 REQUIRED COMPONENTS Core)
 
-qt_add_library(UTMSP STATIC)
-
-# set(UTMSP_RESOURCES)
-
 option(QGC_UTM_ADAPTER "Enable UTM Adapter" OFF)
 if(QGC_UTM_ADAPTER)
     message(STATUS "UTMSP is Initialized")
@@ -11,7 +7,10 @@ if(QGC_UTM_ADAPTER)
     find_package(Qt6 REQUIRED COMPONENTS Qml Location Widgets)
     find_package(Threads REQUIRED)
 
-    target_sources(UTMSP
+    set(UTMSP_RESOURCES)
+    qt_add_resources(UTMSP_RESOURCES utmsp.qrc)
+
+    qt_add_library(UTMSP STATIC
         PRIVATE
             UTMSPAircraft.cpp
             UTMSPAircraft.h
@@ -33,6 +32,7 @@ if(QGC_UTM_ADAPTER)
             UTMSPServiceController.h
             UTMSPVehicle.cpp
             UTMSPVehicle.h
+            ${UTMSP_RESOURCES}
     )
 
     target_link_libraries(UTMSP
@@ -61,11 +61,11 @@ if(QGC_UTM_ADAPTER)
             UTMSPMapVisuals.qml
     )
 
-    # qt_add_resources(UTMSP_RESOURCES utmsp.qrc)
 else()
     message(STATUS "UTMSP: Dummy is Initialized")
 
-    # qt_add_resources(UTMSP_RESOURCES dummy/utmsp_dummy.qrc)
-endif()
+    set(UTMSP_RESOURCES)
+    qt_add_resources(UTMSP_RESOURCES dummy/utmsp_dummy.qrc)
 
-# target_sources(UTMSP PUBLIC ${UTMSP_RESOURCES})
+    qt_add_library(UTMSP STATIC ${UTMSP_RESOURCES})
+endif()

--- a/src/Vehicle/CMakeLists.txt
+++ b/src/Vehicle/CMakeLists.txt
@@ -46,12 +46,14 @@ target_link_libraries(Vehicle
 		VehicleActuators
 		VehicleComponents
 		ADSB
-        api
+                api
 		Audio
-        Camera
+                AutoPilotPlugins
+        	Camera
 		FirmwarePlugin
-        MockLink
-        Utilities
+                Joystick
+        	MockLink
+        	Utilities
 		UTMSP
 	PUBLIC
 		Qt6::Core
@@ -60,9 +62,9 @@ target_link_libraries(Vehicle
 		libevents_wrapper
 		comm
 		FactSystem
-        MissionManager
-        qgc
-        VehicleFactGroups
+	        MissionManager
+	        qgc
+	        VehicleFactGroups
 )
 
 target_include_directories(Vehicle PUBLIC ${CMAKE_CURRENT_SOURCE_DIR})

--- a/src/Vehicle/InitialConnectStateMachine.cc
+++ b/src/Vehicle/InitialConnectStateMachine.cc
@@ -16,6 +16,8 @@
 #include "ComponentInformationManager.h"
 #include "MissionManager.h"
 #include "StandardModes.h"
+#include "GeoFenceManager.h"
+#include "RallyPointManager.h"
 #include "QGCLoggingCategory.h"
 
 QGC_LOGGING_CATEGORY(InitialConnectStateMachineLog, "InitialConnectStateMachineLog")

--- a/src/Vehicle/Vehicle.cc
+++ b/src/Vehicle/Vehicle.cc
@@ -51,6 +51,7 @@
 #include "TerrainQuery.h"
 #include "StandardModes.h"
 #include "UASMessageHandler.h"
+#include "AutoPilotPlugin.h"
 #ifdef CONFIG_UTM_ADAPTER
 #include "UTMSPVehicle.h"
 #include "UTMSPManager.h"


### PR DESCRIPTION
Separates APM and PX4 in CMake. Needed to be able to exclude unneeded firmwares in custom builds.