### PR TITLE
CMake: Readjust Resource Linking

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -202,7 +202,19 @@ set(QGC_RESOURCES
     ${CMAKE_SOURCE_DIR}/qgcresources.qrc
     ${CMAKE_SOURCE_DIR}/qgroundcontrol.qrc
     ${CMAKE_SOURCE_DIR}/resources/InstrumentValueIcons/InstrumentValueIcons.qrc
+    ${CMAKE_SOURCE_DIR}/src/FirmwarePlugin/APM/APMResources.qrc
+    ${CMAKE_SOURCE_DIR}/src/FirmwarePlugin/PX4/PX4Resources.qrc
 )
+
+if(CONFIG_UTM_ADAPTER)
+    list(APPEND QGC_RESOURCES ${CMAKE_SOURCE_DIR}/src/UTMSP/utmsp.qrc)
+else()
+    list(APPEND QGC_RESOURCES ${CMAKE_SOURCE_DIR}/src/UTMSP/dummy/utmsp_dummy.qrc)
+endif()
+
+if(QGC_BUILD_TESTING)
+    list(APPEND QGC_RESOURCES ${CMAKE_SOURCE_DIR}/test/UnitTest.qrc)
+endif()
 
 if(WIN32)
     list(APPEND QGC_RESOURCES ${CMAKE_SOURCE_DIR}/deploy/windows/QGroundControl.rc)

--- a/src/FirmwarePlugin/APM/CMakeLists.txt
+++ b/src/FirmwarePlugin/APM/CMakeLists.txt
@@ -1,7 +1,7 @@
 find_package(Qt6 REQUIRED COMPONENTS Core Network)
 
-set(APM_RESOURCES)
-qt_add_resources(APM_RESOURCES APMResources.qrc)
+# set(APM_RESOURCES)
+# qt_add_resources(APM_RESOURCES APMResources.qrc)
 qt_add_library(APMFirmwarePlugin STATIC
     APMFirmwarePlugin.cc
     APMFirmwarePlugin.h
@@ -17,7 +17,7 @@ qt_add_library(APMFirmwarePlugin STATIC
     ArduRoverFirmwarePlugin.h
     ArduSubFirmwarePlugin.cc
     ArduSubFirmwarePlugin.h
-    ${APM_RESOURCES}
+    # ${APM_RESOURCES}
 )
 
 target_link_libraries(APMFirmwarePlugin

--- a/src/FirmwarePlugin/PX4/CMakeLists.txt
+++ b/src/FirmwarePlugin/PX4/CMakeLists.txt
@@ -1,7 +1,7 @@
 find_package(Qt6 REQUIRED COMPONENTS Core)
 
-set(PX4_RESOURCES)
-qt_add_resources(PX4_RESOURCES PX4Resources.qrc)
+# set(PX4_RESOURCES)
+# qt_add_resources(PX4_RESOURCES PX4Resources.qrc)
 qt_add_library(PX4FirmwarePlugin STATIC
     px4_custom_mode.h
     PX4FirmwarePlugin.cc
@@ -10,7 +10,7 @@ qt_add_library(PX4FirmwarePlugin STATIC
     PX4FirmwarePluginFactory.h
     PX4ParameterMetaData.cc
     PX4ParameterMetaData.h
-    ${PX4_RESOURCES}
+    # ${PX4_RESOURCES}
 )
 
 target_link_libraries(PX4FirmwarePlugin

--- a/src/UTMSP/CMakeLists.txt
+++ b/src/UTMSP/CMakeLists.txt
@@ -2,8 +2,6 @@ find_package(Qt6 REQUIRED COMPONENTS Core)
 
 qt_add_library(UTMSP STATIC)
 
-set(UTMSP_RESOURCES)
-
 option(QGC_UTM_ADAPTER "Enable UTM Adapter" OFF)
 if(QGC_UTM_ADAPTER)
     message(STATUS "UTMSP is Initialized")
@@ -11,7 +9,9 @@ if(QGC_UTM_ADAPTER)
     find_package(Qt6 REQUIRED COMPONENTS Qml Location Widgets)
     find_package(Threads REQUIRED)
 
-    qt_add_library(UTMSP STATIC
+    # set(UTMSP_RESOURCES)
+    # qt_add_resources(UTMSP_RESOURCES utmsp.qrc)
+    target_sources(UTMSP
         PRIVATE
             UTMSPAircraft.cpp
             UTMSPAircraft.h
@@ -33,7 +33,7 @@ if(QGC_UTM_ADAPTER)
             UTMSPServiceController.h
             UTMSPVehicle.cpp
             UTMSPVehicle.h
-            ${UTMSP_RESOURCES}
+            # ${UTMSP_RESOURCES}
     )
 
     target_link_libraries(UTMSP
@@ -62,13 +62,12 @@ if(QGC_UTM_ADAPTER)
             UTMSPMapVisuals.qml
     )
 
-    qt_add_resources(UTMSP_RESOURCES utmsp.qrc)
 
 else()
     message(STATUS "UTMSP: Dummy is Initialized")
 
-    qt_add_resources(UTMSP_RESOURCES dummy/utmsp_dummy.qrc)
+    # set(UTMSP_RESOURCES)
+    # qt_add_resources(UTMSP_RESOURCES dummy/utmsp_dummy.qrc)
+    # qt_add_library(UTMSP STATIC ${UTMSP_RESOURCES})
 
 endif()
-
-target_sources(UTMSP PUBLIC ${UTMSP_RESOURCES})

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -5,13 +5,13 @@ endif()
 include(CTest)
 enable_testing()
 
-set(UNIT_TESTING_RESOURCES)
-qt_add_resources(UNIT_TESTING_RESOURCES UnitTest.qrc)
+# set(UNIT_TESTING_RESOURCES)
+# qt_add_resources(UNIT_TESTING_RESOURCES UnitTest.qrc)
 
 qt_add_library(qgctest
     STATIC
         UnitTestList.cc
-        ${UNIT_TESTING_RESOURCES}
+        # ${UNIT_TESTING_RESOURCES}
 )
 
 add_custom_target(check


### PR DESCRIPTION
Executable can't find them if they are private to lib, and lib can't find it if is private to executable.