### PR TITLE
CMake: Adjust Firmware Plugin Links

### DIFF
--- a/src/AutoPilotPlugins/APM/CMakeLists.txt
+++ b/src/AutoPilotPlugins/APM/CMakeLists.txt
@@ -45,7 +45,7 @@ qt_add_library(APMAutoPilotPlugin STATIC
 
 target_link_libraries(APMAutoPilotPlugin
     PRIVATE
-        Actuators
+        VehicleActuators
         APMFirmwarePlugin
         AutoPilotPlugins
         FactSystem

--- a/src/FirmwarePlugin/APM/CMakeLists.txt
+++ b/src/FirmwarePlugin/APM/CMakeLists.txt
@@ -1,12 +1,12 @@
 find_package(Qt6 REQUIRED COMPONENTS Core Network)
 
-# set(APM_RESOURCES)
-# qt_add_resources(APM_RESOURCES APMResources.qrc)
+set(APM_RESOURCES)
+qt_add_resources(APM_RESOURCES APMResources.qrc)
 qt_add_library(APMFirmwarePlugin STATIC
     APMFirmwarePlugin.cc
     APMFirmwarePlugin.h
-    APMFirmwarePluginFactory.cc
-    APMFirmwarePluginFactory.h
+    # APMFirmwarePluginFactory.cc
+    # APMFirmwarePluginFactory.h
     APMParameterMetaData.cc
     APMParameterMetaData.h
     ArduCopterFirmwarePlugin.cc
@@ -17,7 +17,7 @@ qt_add_library(APMFirmwarePlugin STATIC
     ArduRoverFirmwarePlugin.h
     ArduSubFirmwarePlugin.cc
     ArduSubFirmwarePlugin.h
-    # ${APM_RESOURCES}
+    ${APM_RESOURCES}
 )
 
 target_link_libraries(APMFirmwarePlugin

--- a/src/FirmwarePlugin/CMakeLists.txt
+++ b/src/FirmwarePlugin/CMakeLists.txt
@@ -10,12 +10,18 @@ qt_add_library(FirmwarePlugin STATIC
 	FirmwarePlugin.h
 	FirmwarePluginManager.cc
 	FirmwarePluginManager.h
+    APM/APMFirmwarePluginFactory.cc
+    APM/APMFirmwarePluginFactory.h
+    PX4/PX4FirmwarePluginFactory.cc
+    PX4/PX4FirmwarePluginFactory.h
 )
 
 target_link_libraries(FirmwarePlugin
     PRIVATE
         AutoPilotPlugins
         CommonAutoPilotPlugin
+        APMFirmwarePlugin
+        PX4FirmwarePlugin
         Camera
         MissionManager
         qgc

--- a/src/FirmwarePlugin/PX4/CMakeLists.txt
+++ b/src/FirmwarePlugin/PX4/CMakeLists.txt
@@ -1,16 +1,16 @@
 find_package(Qt6 REQUIRED COMPONENTS Core)
 
-# set(PX4_RESOURCES)
-# qt_add_resources(PX4_RESOURCES PX4Resources.qrc)
+set(PX4_RESOURCES)
+qt_add_resources(PX4_RESOURCES PX4Resources.qrc)
 qt_add_library(PX4FirmwarePlugin STATIC
     px4_custom_mode.h
     PX4FirmwarePlugin.cc
     PX4FirmwarePlugin.h
-    PX4FirmwarePluginFactory.cc
-    PX4FirmwarePluginFactory.h
+    # PX4FirmwarePluginFactory.cc
+    # PX4FirmwarePluginFactory.h
     PX4ParameterMetaData.cc
     PX4ParameterMetaData.h
-    # ${PX4_RESOURCES}
+    ${PX4_RESOURCES}
 )
 
 target_link_libraries(PX4FirmwarePlugin


### PR DESCRIPTION
When making new libraries for individual firmware plugins, you need to link their factory loaders into the base firmware plugin library.