### PR TITLE
Move max rc channels into mavlink

### DIFF
--- a/src/AutoPilotPlugins/APM/APMFlightModesComponentController.cc
+++ b/src/AutoPilotPlugins/APM/APMFlightModesComponentController.cc
@@ -10,6 +10,8 @@
 
 #include "APMFlightModesComponentController.h"
 #include "FactSystem.h"
+#include "Fact.h"
+#include "Vehicle.h"
 
 #include <QtCore/QVariant>
 #include <QtQml/QQmlEngine>
@@ -21,7 +23,7 @@ const char* APMFlightModesComponentController::_superSimpleParamName =  "SUPER_S
 
 APMFlightModesComponentController::APMFlightModesComponentController(void)
     : _activeFlightMode     (0)
-    , _channelCount         (Vehicle::cMaxRcChannels)
+    , _channelCount         (QGCMAVLink::maxRcChannels)
     , _simpleMode           (SimpleModeStandard)
     , _simpleModeFact       (parameterExists(-1, _simpleParamName)      ? getParameterFact(-1, _simpleParamName) : nullptr)
     , _superSimpleModeFact  (parameterExists(-1, _superSimpleParamName) ? getParameterFact(-1, _superSimpleParamName) : nullptr)
@@ -75,7 +77,7 @@ APMFlightModesComponentController::APMFlightModesComponentController(void)
 }
 
 /// Connected to Vehicle::rcChannelsChanged signal
-void APMFlightModesComponentController::_rcChannelsChanged(int channelCount, int pwmValues[Vehicle::cMaxRcChannels])
+void APMFlightModesComponentController::_rcChannelsChanged(int channelCount, int pwmValues[QGCMAVLink::maxRcChannels])
 {
     int flightModeChannel = 4;
 

--- a/src/AutoPilotPlugins/APM/APMFlightModesComponentController.h
+++ b/src/AutoPilotPlugins/APM/APMFlightModesComponentController.h
@@ -13,7 +13,7 @@
 #include <QtCore/QStringList>
 
 #include "FactPanelController.h"
-#include "Vehicle.h"
+#include "QGCMAVLink.h"
 
 /// MVC Controller for FlightModesComponent.qml.
 class APMFlightModesComponentController : public FactPanelController
@@ -56,7 +56,7 @@ signals:
     void superSimpleModeEnabledChanged  (void);
 
 private slots:
-    void _rcChannelsChanged                     (int channelCount, int pwmValues[Vehicle::cMaxRcChannels]);
+    void _rcChannelsChanged                     (int channelCount, int pwmValues[QGCMAVLink::maxRcChannels]);
     void _updateSimpleParamsFromSimpleMode      (void);
     void _setupSimpleModeEnabled     (void);
 

--- a/src/AutoPilotPlugins/APM/CMakeLists.txt
+++ b/src/AutoPilotPlugins/APM/CMakeLists.txt
@@ -45,19 +45,20 @@ qt_add_library(APMAutoPilotPlugin STATIC
 
 target_link_libraries(APMAutoPilotPlugin
     PRIVATE
-        VehicleActuators
         APMFirmwarePlugin
         AutoPilotPlugins
         FactSystem
         QGC
         Settings
         Utilities
+        Vehicle
+        VehicleActuators
     PUBLIC
         Qt6::Core
         Qt6::Quick
+        Comms
         CommonAutoPilotPlugin
         FactControls
-        Vehicle
         VehicleSetup
 )
 

--- a/src/AutoPilotPlugins/Common/CMakeLists.txt
+++ b/src/AutoPilotPlugins/Common/CMakeLists.txt
@@ -21,10 +21,12 @@ target_link_libraries(CommonAutoPilotPlugin
         FactSystem
         QGC
         Utilities
+        Vehicle
     PUBLIC
         Qt6::Core
         Qt6::Network
         Qt6::Quick
+        Comms
         FactControls
         VehicleSetup
 )

--- a/src/AutoPilotPlugins/Common/RadioComponentController.cc
+++ b/src/AutoPilotPlugins/Common/RadioComponentController.cc
@@ -15,6 +15,8 @@
 #include "RadioComponentController.h"
 #include "QGCApplication.h"
 #include "FactSystem.h"
+#include "Fact.h"
+#include "Vehicle.h"
 #include "QGCLoggingCategory.h"
 
 #include <QtCore/QSettings>
@@ -224,7 +226,7 @@ void RadioComponentController::_setupCurrentState(void)
 }
 
 /// Connected to Vehicle::rcChannelsChanged signal
-void RadioComponentController::_rcChannelsChanged(int channelCount, int pwmValues[Vehicle::cMaxRcChannels])
+void RadioComponentController::_rcChannelsChanged(int channelCount, int pwmValues[QGCMAVLink::maxRcChannels])
 {
     for (int channel=0; channel<channelCount; channel++) {
         int channelValue = pwmValues[channel];

--- a/src/AutoPilotPlugins/Common/RadioComponentController.h
+++ b/src/AutoPilotPlugins/Common/RadioComponentController.h
@@ -16,9 +16,10 @@
 #pragma once
 
 #include "FactPanelController.h"
-#include "Vehicle.h"
+#include "QGCMAVLink.h"
 
 #include <QtCore/QLoggingCategory>
+#include <QtCore/QElapsedTimer>
 #include <QtQuick/QQuickItem>
 
 Q_DECLARE_LOGGING_CATEGORY(RadioComponentControllerLog)
@@ -138,7 +139,7 @@ signals:
     void throttleReversedCalFailure(void);
 
 private slots:
-    void _rcChannelsChanged(int channelCount, int pwmValues[Vehicle::cMaxRcChannels]);
+    void _rcChannelsChanged(int channelCount, int pwmValues[QGCMAVLink::maxRcChannels]);
 
 private:
     /// @brief These identify the various controls functions. They are also used as indices into the _rgFunctioInfo

--- a/src/AutoPilotPlugins/PX4/ActuatorComponent.cc
+++ b/src/AutoPilotPlugins/PX4/ActuatorComponent.cc
@@ -10,6 +10,7 @@
 #include "ActuatorComponent.h"
 #include "QGCApplication.h"
 #include "GeometryImage.h"
+#include "Actuators/Actuators.h"
 
 #include <QtQml/QQmlApplicationEngine>
 

--- a/src/AutoPilotPlugins/PX4/ActuatorComponent.h
+++ b/src/AutoPilotPlugins/PX4/ActuatorComponent.h
@@ -11,7 +11,8 @@
 #pragma once
 
 #include "VehicleComponent.h"
-#include "Actuators/Actuators.h"
+
+class Actuators;
 
 class ActuatorComponent : public VehicleComponent
 {
@@ -36,4 +37,3 @@ private:
     const QString   _name;
     Actuators& _actuators;
 };
-

--- a/src/AutoPilotPlugins/PX4/AirframeComponent.h
+++ b/src/AutoPilotPlugins/PX4/AirframeComponent.h
@@ -8,8 +8,7 @@
  ****************************************************************************/
 
 
-#ifndef AIRFRAMECOMPONENT_H
-#define AIRFRAMECOMPONENT_H
+#pragma once
 
 #include "VehicleComponent.h"
 
@@ -40,5 +39,3 @@ private:
     const QString   _name;
     QVariantList     _summaryItems;
 };
-
-#endif

--- a/src/AutoPilotPlugins/PX4/AirframeComponentAirframes.h
+++ b/src/AutoPilotPlugins/PX4/AirframeComponentAirframes.h
@@ -11,8 +11,7 @@
 /// @file
 ///     @author Don Gagne <don@thegagnes.com>
 
-#ifndef AIRFRAMECOMPONENTAIRFRAMES_H
-#define AIRFRAMECOMPONENTAIRFRAMES_H
+#pragma once
 
 #include <QtCore/QList>
 #include <QtCore/QMap>
@@ -41,5 +40,3 @@ protected:
     
 private:
 };
-
-#endif

--- a/src/AutoPilotPlugins/PX4/AirframeComponentController.h
+++ b/src/AutoPilotPlugins/PX4/AirframeComponentController.h
@@ -11,8 +11,7 @@
 /// @file
 ///     @author Don Gagne <don@thegagnes.com>
 
-#ifndef AIRFRAMECOMPONENTCONTROLLER_H
-#define AIRFRAMECOMPONENTCONTROLLER_H
+#pragma once
 
 #include <QtCore/QObject>
 #include <QtCore/QVariant>
@@ -98,5 +97,3 @@ private:
     QString         _imageResource;
     QVariantList    _airframes;
 };
-
-#endif

--- a/src/AutoPilotPlugins/PX4/CMakeLists.txt
+++ b/src/AutoPilotPlugins/PX4/CMakeLists.txt
@@ -39,18 +39,18 @@ qt_add_library(PX4AutoPilotPlugin STATIC
 
 target_link_libraries(PX4AutoPilotPlugin
     PRIVATE
-		Comms
+		FactSystem
         QGC
 		Utilities
+		Vehicle
+        VehicleActuators
 	PUBLIC
 		Qt6::Core
 		Qt6::Quick
 		AutoPilotPlugins
 		CommonAutoPilotPlugin
+		Comms
 		FactControls
-		FactSystem
-		Vehicle
-        VehicleActuators
         VehicleSetup
 )
 

--- a/src/AutoPilotPlugins/PX4/CameraComponent.h
+++ b/src/AutoPilotPlugins/PX4/CameraComponent.h
@@ -8,8 +8,7 @@
  ****************************************************************************/
 
 
-#ifndef CameraComponent_H
-#define CameraComponent_H
+#pragma once
 
 #include "VehicleComponent.h"
 
@@ -42,5 +41,3 @@ private:
     const QString   _name;
     QVariantList    _summaryItems;
 };
-
-#endif

--- a/src/AutoPilotPlugins/PX4/FlightModesComponent.h
+++ b/src/AutoPilotPlugins/PX4/FlightModesComponent.h
@@ -8,8 +8,7 @@
  ****************************************************************************/
 
 
-#ifndef FLIGHTMODESCOMPONENT_H
-#define FLIGHTMODESCOMPONENT_H
+#pragma once
 
 #include "VehicleComponent.h"
 
@@ -40,5 +39,3 @@ private:
     const QString   _name;
     QVariantList    _summaryItems;
 };
-
-#endif

--- a/src/AutoPilotPlugins/PX4/PX4AirframeLoader.h
+++ b/src/AutoPilotPlugins/PX4/PX4AirframeLoader.h
@@ -8,8 +8,7 @@
  ****************************************************************************/
 
 
-#ifndef PX4AIRFRAMELOADER_H
-#define PX4AIRFRAMELOADER_H
+#pragma once
 
 #include <QtCore/QObject>
 #include <QtCore/QMap>
@@ -52,5 +51,3 @@ private:
     static bool _airframeMetaDataLoaded;   ///< true: parameter meta data already loaded
     static QMap<QString, FactMetaData*> _mapParameterName2FactMetaData; ///< Maps from a parameter name to FactMetaData
 };
-
-#endif // PX4AIRFRAMELOADER_H

--- a/src/AutoPilotPlugins/PX4/PX4AutoPilotPlugin.cc
+++ b/src/AutoPilotPlugins/PX4/PX4AutoPilotPlugin.cc
@@ -20,6 +20,7 @@
 #include "FactSystem.h"
 #include "ParameterManager.h"
 #include "Vehicle.h"
+#include "Actuators.h"
 #include "ActuatorComponent.h"
 
 /// @file

--- a/src/AutoPilotPlugins/PX4/PX4AutoPilotPlugin.h
+++ b/src/AutoPilotPlugins/PX4/PX4AutoPilotPlugin.h
@@ -8,8 +8,7 @@
  ****************************************************************************/
 
 
-#ifndef PX4AUTOPILOT_H
-#define PX4AUTOPILOT_H
+#pragma once
 
 #include "AutoPilotPlugin.h"
 #include "ActuatorComponent.h"
@@ -66,5 +65,3 @@ protected:
 private:
     QVariantList            _components;
 };
-
-#endif

--- a/src/AutoPilotPlugins/PX4/PX4RadioComponent.h
+++ b/src/AutoPilotPlugins/PX4/PX4RadioComponent.h
@@ -8,8 +8,7 @@
  ****************************************************************************/
 
 
-#ifndef PX4RadioComponent_H
-#define PX4RadioComponent_H
+#pragma once
 
 #include "VehicleComponent.h"
 
@@ -36,5 +35,3 @@ private:
     const QString   _name;
     QVariantList    _summaryItems;
 };
-
-#endif

--- a/src/AutoPilotPlugins/PX4/PX4SimpleFlightModesController.cc
+++ b/src/AutoPilotPlugins/PX4/PX4SimpleFlightModesController.cc
@@ -10,10 +10,12 @@
 
 #include "PX4SimpleFlightModesController.h"
 #include "FactSystem.h"
+#include "Fact.h"
+#include "Vehicle.h"
 
 PX4SimpleFlightModesController::PX4SimpleFlightModesController(void)
     : _activeFlightMode(0)
-    , _channelCount(Vehicle::cMaxRcChannels)
+    , _channelCount(QGCMAVLink::maxRcChannels)
 
 {
     QStringList usedParams;
@@ -28,7 +30,7 @@ PX4SimpleFlightModesController::PX4SimpleFlightModesController(void)
 }
 
 /// Connected to Vehicle::rcChannelsChanged signal
-void PX4SimpleFlightModesController::_rcChannelsChanged(int channelCount, int pwmValues[Vehicle::cMaxRcChannels])
+void PX4SimpleFlightModesController::_rcChannelsChanged(int channelCount, int pwmValues[QGCMAVLink::maxRcChannels])
 {
     _rcChannelValues.clear();
     for (int i=0; i<channelCount; i++) {

--- a/src/AutoPilotPlugins/PX4/PX4SimpleFlightModesController.h
+++ b/src/AutoPilotPlugins/PX4/PX4SimpleFlightModesController.h
@@ -8,11 +8,10 @@
  ****************************************************************************/
 
 
-#ifndef PX4SimpleFlightModesController_H
-#define PX4SimpleFlightModesController_H
+#pragma once
 
 #include "FactPanelController.h"
-#include "Vehicle.h"
+#include "QGCMAVLink.h"
 
 /// MVC Controller for PX4SimpleFlightModes.qml
 class PX4SimpleFlightModesController : public FactPanelController
@@ -34,12 +33,10 @@ signals:
     void rcChannelValuesChanged(void);
     
 private slots:
-    void _rcChannelsChanged(int channelCount, int pwmValues[Vehicle::cMaxRcChannels]);
+    void _rcChannelsChanged(int channelCount, int pwmValues[QGCMAVLink::maxRcChannels]);
     
 private:
     int             _activeFlightMode;
     int             _channelCount;
     QVariantList    _rcChannelValues;
 };
-
-#endif

--- a/src/AutoPilotPlugins/PX4/PX4TuningComponent.h
+++ b/src/AutoPilotPlugins/PX4/PX4TuningComponent.h
@@ -8,8 +8,7 @@
  ****************************************************************************/
 
 
-#ifndef PX4TuningComponent_H
-#define PX4TuningComponent_H
+#pragma once
 
 #include "VehicleComponent.h"
 
@@ -37,5 +36,3 @@ public:
 private:
     const QString   _name;
 };
-
-#endif

--- a/src/AutoPilotPlugins/PX4/PowerComponent.h
+++ b/src/AutoPilotPlugins/PX4/PowerComponent.h
@@ -8,8 +8,7 @@
  ****************************************************************************/
 
 
-#ifndef PowerComponent_H
-#define PowerComponent_H
+#pragma once
 
 #include "VehicleComponent.h"
 
@@ -41,5 +40,3 @@ private:
     const QString   _name;
     QVariantList    _summaryItems;
 };
-
-#endif

--- a/src/AutoPilotPlugins/PX4/PowerComponentController.h
+++ b/src/AutoPilotPlugins/PX4/PowerComponentController.h
@@ -11,8 +11,7 @@
 /// @file
 ///     @author Don Gagne <don@thegagnes.com>
 
-#ifndef PowerComponentController_H
-#define PowerComponentController_H
+#pragma once
 
 #include "FactPanelController.h"
 
@@ -48,5 +47,3 @@ private:
     QStringList _warningMessages;
     static const int _neededFirmwareRev = 1;
 };
-
-#endif

--- a/src/AutoPilotPlugins/PX4/SafetyComponent.h
+++ b/src/AutoPilotPlugins/PX4/SafetyComponent.h
@@ -8,8 +8,7 @@
  ****************************************************************************/
 
 
-#ifndef SafetyComponent_H
-#define SafetyComponent_H
+#pragma once
 
 #include "VehicleComponent.h"
 
@@ -43,5 +42,3 @@ private:
     const QString   _name;
     QVariantList    _summaryItems;
 };
-
-#endif

--- a/src/AutoPilotPlugins/PX4/SensorsComponent.h
+++ b/src/AutoPilotPlugins/PX4/SensorsComponent.h
@@ -8,8 +8,7 @@
  ****************************************************************************/
 
 
-#ifndef SENSORSCOMPONENT_H
-#define SENSORSCOMPONENT_H
+#pragma once
 
 #include "VehicleComponent.h"
 
@@ -48,5 +47,3 @@ private:
     static const char* _magEnabledParam;
     static const char* _magCalParam;
 };
-
-#endif

--- a/src/AutoPilotPlugins/PX4/SensorsComponentController.h
+++ b/src/AutoPilotPlugins/PX4/SensorsComponentController.h
@@ -11,8 +11,7 @@
 /// @file
 ///     @author Don Gagne <don@thegagnes.com>
 
-#ifndef SENSORSCOMPONENTCONTROLLER_H
-#define SENSORSCOMPONENTCONTROLLER_H
+#pragma once
 
 #include <QtQuick/QQuickItem>
 #include <QtCore/QLoggingCategory>
@@ -167,5 +166,3 @@ private:
     
     static const int _supportedFirmwareCalVersion = 2;
 };
-
-#endif

--- a/src/Comms/QGCMAVLink.h
+++ b/src/Comms/QGCMAVLink.h
@@ -71,6 +71,8 @@ public:
     static constexpr VehicleClass_t VehicleClassVTOL        = MAV_TYPE_VTOL_TAILSITTER_QUADROTOR;
     static constexpr VehicleClass_t VehicleClassGeneric     = MAV_TYPE_GENERIC;
 
+    static constexpr uint8_t        maxRcChannels           = 18; // mavlink_rc_channels_t->chancount
+
     static bool                     isPX4FirmwareClass          (MAV_AUTOPILOT autopilot) { return autopilot == MAV_AUTOPILOT_PX4; }
     static bool                     isArduPilotFirmwareClass    (MAV_AUTOPILOT autopilot) { return autopilot == MAV_AUTOPILOT_ARDUPILOTMEGA; }
     static bool                     isGenericFirmwareClass      (MAV_AUTOPILOT autopilot) { return !isPX4FirmwareClass(autopilot) && ! isArduPilotFirmwareClass(autopilot); }

--- a/src/FirmwarePlugin/APM/APMFirmwarePlugin.cc
+++ b/src/FirmwarePlugin/APM/APMFirmwarePlugin.cc
@@ -28,6 +28,7 @@
 #include "ArduSubFirmwarePlugin.h"
 #include "APMParameterMetaData.h"
 #include "LinkManager.h"
+#include "Vehicle.h"
 #include "QGCLoggingCategory.h"
 
 #include <QtNetwork/QTcpSocket>

--- a/src/QmlControls/CMakeLists.txt
+++ b/src/QmlControls/CMakeLists.txt
@@ -3,6 +3,7 @@ find_package(Qt6 REQUIRED COMPONENTS Concurrent Core Gui Location Positioning Qm
 qt_add_library(QmlControls STATIC
 	AppMessages.cc
 	AppMessages.h
+	CustomAction.cc
 	CustomAction.h
 	CustomActionManager.cc
 	CustomActionManager.h
@@ -146,12 +147,10 @@ target_link_libraries(QmlControls
 		Qt6::Concurrent
 		Qt6::Location
 		Qt6::Widgets
-        API
         FirmwarePlugin
         Geo
         GPS
         MockLink
-		Settings
 	PUBLIC
 		Qt6::Core
 		Qt6::Gui
@@ -159,15 +158,20 @@ target_link_libraries(QmlControls
 		Qt6::Quick
 		ADSB
         AirLink
+        API
         Comms
         FactControls
 		FactSystem
-		PositionManager # Only used to register to QML
+		MissionManager
+        PositionManager
 		QGC
+		QGCLocation
+		Settings
         Terrain
 		Utilities
 		UTMSP
         Vehicle
+        VideoManager
 )
 
 target_include_directories(QmlControls PUBLIC ${CMAKE_CURRENT_SOURCE_DIR})

--- a/src/QmlControls/CustomAction.cc
+++ b/src/QmlControls/CustomAction.cc
@@ -1,0 +1,9 @@
+#include "CustomAction.h"
+#include "Vehicle.h"
+
+void CustomAction::sendTo(Vehicle* vehicle) {
+    if (vehicle) {
+        const bool showError = true;
+        vehicle->sendMavCommand(_compId, _mavCmd, showError, _params[0], _params[1], _params[2], _params[3], _params[4], _params[5], _params[6]);
+    }
+};

--- a/src/QmlControls/CustomAction.h
+++ b/src/QmlControls/CustomAction.h
@@ -10,9 +10,10 @@
 #pragma once
 
 #include "QGCMAVLink.h"
-#include "Vehicle.h"
 
 #include <QtCore/QObject>
+
+class Vehicle;
 
 class CustomAction: public QObject
 {
@@ -44,13 +45,7 @@ public:
         , _params       { param1, param2, param3, param4, param5, param6, param7 }
     {};
 
-    Q_INVOKABLE void sendTo(Vehicle* vehicle) 
-    {
-        if (vehicle) {
-            const bool showError = true;
-            vehicle->sendMavCommand(_compId, _mavCmd, showError, _params[0], _params[1], _params[2], _params[3], _params[4], _params[5], _params[6]);
-        }
-    };
+    Q_INVOKABLE void sendTo(Vehicle* vehicle);
 
     QString  label      () const { return _label; }
     QString  description() const { return _description; }

--- a/src/QmlControls/QGroundControlQmlGlobal.cc
+++ b/src/QmlControls/QGroundControlQmlGlobal.cc
@@ -14,6 +14,7 @@
 #include "QGCMapUrlEngine.h"
 #include "FirmwarePluginManager.h"
 #include "AppSettings.h"
+#include "PositionManager.h"
 #ifndef NO_SERIAL_LINK
 #include "GPSManager.h"
 #endif

--- a/src/QmlControls/RCChannelMonitorController.cc
+++ b/src/QmlControls/RCChannelMonitorController.cc
@@ -9,6 +9,7 @@
 
 
 #include "RCChannelMonitorController.h"
+#include "Vehicle.h"
 
 RCChannelMonitorController::RCChannelMonitorController(void)
     : _chanCount(0)
@@ -16,7 +17,7 @@ RCChannelMonitorController::RCChannelMonitorController(void)
     connect(_vehicle, &Vehicle::rcChannelsChanged, this, &RCChannelMonitorController::_rcChannelsChanged);
 }
 
-void RCChannelMonitorController::_rcChannelsChanged(int channelCount, int pwmValues[Vehicle::cMaxRcChannels])
+void RCChannelMonitorController::_rcChannelsChanged(int channelCount, int pwmValues[QGCMAVLink::maxRcChannels])
 {
     for (int channel=0; channel<channelCount; channel++) {
         int channelValue = pwmValues[channel];

--- a/src/QmlControls/RCChannelMonitorController.h
+++ b/src/QmlControls/RCChannelMonitorController.h
@@ -11,7 +11,7 @@
 #pragma once
 
 #include "FactPanelController.h"
-#include "Vehicle.h"
+#include "QGCMAVLink.h"
 
 class RCChannelMonitorController : public FactPanelController
 {
@@ -29,7 +29,7 @@ signals:
     void channelRCValueChanged(int channel, int rcValue);
 
 private slots:
-    void _rcChannelsChanged(int channelCount, int pwmValues[Vehicle::cMaxRcChannels]);
+    void _rcChannelsChanged(int channelCount, int pwmValues[QGCMAVLink::maxRcChannels]);
 
 private:
     int _chanCount;

--- a/src/Vehicle/Vehicle.cc
+++ b/src/Vehicle/Vehicle.cc
@@ -1840,7 +1840,7 @@ void Vehicle::_handleRCChannels(mavlink_message_t& message)
 
     mavlink_msg_rc_channels_decode(&message, &channels);
 
-    uint16_t* _rgChannelvalues[cMaxRcChannels] = {
+    uint16_t* _rgChannelvalues[QGCMAVLink::maxRcChannels] = {
         &channels.chan1_raw,
         &channels.chan2_raw,
         &channels.chan3_raw,
@@ -1860,9 +1860,9 @@ void Vehicle::_handleRCChannels(mavlink_message_t& message)
         &channels.chan17_raw,
         &channels.chan18_raw,
     };
-    int pwmValues[cMaxRcChannels];
+    int pwmValues[QGCMAVLink::maxRcChannels];
 
-    for (int i=0; i<cMaxRcChannels; i++) {
+    for (int i=0; i<QGCMAVLink::maxRcChannels; i++) {
         uint16_t channelValue = *_rgChannelvalues[i];
 
         if (i < channels.chancount) {

--- a/src/Vehicle/Vehicle.h
+++ b/src/Vehicle/Vehicle.h
@@ -754,8 +754,6 @@ public:
     Autotune*                       autotune            () const { return _autotune; }
     RemoteIDManager*                remoteIDManager     () { return _remoteIDManager; }
 
-    static const int cMaxRcChannels = 18;
-
     /// Sends the specified MAV_CMD to the vehicle. If no Ack is received command will be retried. If a sendMavCommand is already in progress
     /// the command will be queued and sent when the previous command completes.
     ///     @param compId Component to send to.
@@ -1009,9 +1007,9 @@ signals:
     void loadProgressChanged            (float value);
 
     /// New RC channel values coming from RC_CHANNELS message
-    ///     @param channelCount Number of available channels, cMaxRcChannels max
+    ///     @param channelCount Number of available channels, maxRcChannels max
     ///     @param pwmValues -1 signals channel not available
-    void rcChannelsChanged              (int channelCount, int pwmValues[cMaxRcChannels]);
+    void rcChannelsChanged              (int channelCount, int pwmValues[QGCMAVLink::maxRcChannels]);
 
     /// Remote control RSSI changed  (0% - 100%)
     void remoteControlRSSIChanged       (uint8_t rssi);


### PR DESCRIPTION
Some libs only needed to be publicly linked to vehicle because of a single value, which is actually derived from mavlink rather than the vehicle. 