### PR TITLE
Add QmlObjectListItem

### DIFF
--- a/qgroundcontrol.pro
+++ b/qgroundcontrol.pro
@@ -513,6 +513,7 @@ HEADERS += \
     src/QmlControls/QGCQGeoCoordinate.h \
     src/Utilities/QGCTemporaryFile.h \
     src/QGCToolbox.h \
+    src/QmlControls/QmlObjectListItem.h \
     src/QmlControls/AppMessages.h \
     src/QmlControls/EditPositionDialogController.h \
     src/QmlControls/FlightPathSegment.h \
@@ -786,6 +787,7 @@ SOURCES += \
     src/QmlControls/QGCQGeoCoordinate.cc \
     src/Utilities/QGCTemporaryFile.cc \
     src/QGCToolbox.cc \
+    src/QmlControls/QmlObjectListItem.cc \
     src/QmlControls/AppMessages.cc \
     src/QmlControls/EditPositionDialogController.cc \
     src/QmlControls/FlightPathSegment.cc \

--- a/src/MissionManager/CameraCalc.cc
+++ b/src/MissionManager/CameraCalc.cc
@@ -323,11 +323,6 @@ void CameraCalc::setDistanceMode(QGroundControlQmlGlobal::AltMode altMode)
     }
 }
 
-void CameraCalc::_setDirty(void)
-{
-    setDirty(true);
-}
-
 void CameraCalc::setCameraBrand(const QString& cameraBrand)
 {
     // Note that cameraBrand can also be manual or custom camera

--- a/src/MissionManager/CameraCalc.h
+++ b/src/MissionManager/CameraCalc.h
@@ -109,7 +109,6 @@ signals:
 
 private slots:
     void _recalcTriggerDistance             (void);
-    void _setDirty                          (void);
     void _cameraNameChanged                 (void);
 
 private:

--- a/src/MissionManager/CameraSection.cc
+++ b/src/MissionManager/CameraSection.cc
@@ -38,7 +38,6 @@ CameraSection::CameraSection(PlanMasterController* masterController, QObject* pa
     , _cameraPhotoIntervalDistanceFact  (0, _cameraPhotoIntervalDistanceName,   FactMetaData::valueTypeDouble)
     , _cameraPhotoIntervalTimeFact      (0, _cameraPhotoIntervalTimeName,       FactMetaData::valueTypeUint32)
     , _cameraModeFact                   (0, _cameraModeName,                    FactMetaData::valueTypeUint32)
-    , _dirty                            (false)
 {
     if (_metaDataMap.isEmpty()) {
         _metaDataMap = FactMetaData::createMapFromJsonFile(QStringLiteral(":/json/CameraSection.FactMetaData.json"), Q_NULLPTR /* metaDataParent */);
@@ -108,14 +107,6 @@ int CameraSection::itemCount(void) const
     }
 
     return itemCount;
-}
-
-void CameraSection::setDirty(bool dirty)
-{
-    if (_dirty != dirty) {
-        _dirty = dirty;
-        emit dirtyChanged(_dirty);
-    }
 }
 
 void CameraSection::appendSectionItems(QList<MissionItem*>& items, QObject* missionItemParent, int& nextSequenceNumber)
@@ -515,11 +506,6 @@ bool CameraSection::scanForSection(QmlObjectListModel* visualItems, int scanInde
     emit settingsSpecifiedChanged(_settingsSpecified);
 
     return _settingsSpecified;
-}
-
-void CameraSection::_setDirty(void)
-{
-    setDirty(true);
 }
 
 void CameraSection::_setDirtyAndUpdateItemCount(void)

--- a/src/MissionManager/CameraSection.h
+++ b/src/MissionManager/CameraSection.h
@@ -80,9 +80,7 @@ public:
 
     // Overrides from Section
     bool available          (void) const override { return _available; }
-    bool dirty              (void) const override { return _dirty; }
     void setAvailable       (bool available) override;
-    void setDirty           (bool dirty) override;
     bool scanForSection     (QmlObjectListModel* visualItems, int scanIndex) override;
     void appendSectionItems (QList<MissionItem*>& items, QObject* missionItemParent, int& seqNum) override;
     int  itemCount          (void) const override;
@@ -95,7 +93,6 @@ signals:
     void specifiedGimbalPitchChanged(double gimbalPitch);
 
 private slots:
-    void _setDirty(void);
     void _setDirtyAndUpdateItemCount(void);
     void _updateSpecifiedGimbalYaw(void);
     void _updateSpecifiedGimbalPitch(void);
@@ -123,7 +120,6 @@ private:
     Fact    _cameraPhotoIntervalDistanceFact;
     Fact    _cameraPhotoIntervalTimeFact;
     Fact    _cameraModeFact;
-    bool    _dirty;
 
     static QMap<QString, FactMetaData*> _metaDataMap;
 

--- a/src/MissionManager/CameraSpec.cc
+++ b/src/MissionManager/CameraSpec.cc
@@ -22,8 +22,7 @@ const char* CameraSpec::_fixedOrientationName =     "FixedOrientation";
 const char* CameraSpec::_minTriggerIntervalName =   "MinTriggerInterval";
 
 CameraSpec::CameraSpec(const QString& settingsGroup, QObject* parent)
-    : QObject                   (parent)
-    , _dirty                    (false)
+    : QmlObjectListItem         (parent)
     , _metaDataMap              (FactMetaData::createMapFromJsonFile(QStringLiteral(":/json/CameraSpec.FactMetaData.json"), this))
     , _sensorWidthFact          (settingsGroup, _metaDataMap[_sensorWidthName])
     , _sensorHeightFact         (settingsGroup, _metaDataMap[_sensorHeightName])
@@ -49,14 +48,6 @@ const CameraSpec& CameraSpec::operator=(const CameraSpec& other)
     _minTriggerIntervalFact.setRawValue (other._minTriggerIntervalFact.rawValue());
 
     return *this;
-}
-
-void CameraSpec::setDirty(bool dirty)
-{
-    if (_dirty != dirty) {
-        _dirty = dirty;
-        emit dirtyChanged(_dirty);
-    }
 }
 
 void CameraSpec::save(QJsonObject& json) const

--- a/src/MissionManager/CameraSpec.h
+++ b/src/MissionManager/CameraSpec.h
@@ -10,8 +10,9 @@
 #pragma once
 
 #include "SettingsFact.h"
+#include <QmlObjectListItem.h>
 
-class CameraSpec : public QObject
+class CameraSpec : public QmlObjectListItem
 {
     Q_OBJECT
 
@@ -39,18 +40,10 @@ public:
     SettingsFact* fixedOrientation  (void) { return &_fixedOrientationFact; }
     SettingsFact* minTriggerInterval(void) { return &_minTriggerIntervalFact; }
 
-    bool dirty      (void) const { return _dirty; }
-    void setDirty   (bool dirty);
-
     void save(QJsonObject& json) const;
     bool load(const QJsonObject& json, QString& errorString);
 
-signals:
-    void dirtyChanged(bool dirty);
-
 private:
-    bool _dirty;
-
     QMap<QString, FactMetaData*> _metaDataMap;
 
     SettingsFact _sensorWidthFact;

--- a/src/MissionManager/CorridorScanComplexItem.cc
+++ b/src/MissionManager/CorridorScanComplexItem.cc
@@ -43,7 +43,7 @@ CorridorScanComplexItem::CorridorScanComplexItem(PlanMasterController* masterCon
     connect(&_corridorWidthFact,    &Fact::valueChanged,                            this, &CorridorScanComplexItem::_setDirty);
     connect(&_corridorPolyline,     &QGCMapPolyline::pathChanged,                   this, &CorridorScanComplexItem::_setDirty);
 
-    connect(&_corridorPolyline,     &QGCMapPolyline::dirtyChanged,                  this, &CorridorScanComplexItem::_polylineDirtyChanged);
+    connect(&_corridorPolyline,     &QGCMapPolyline::dirtyChanged,                  this, &CorridorScanComplexItem::_setIfDirty);
 
     connect(&_corridorPolyline,     &QGCMapPolyline::pathChanged,                   this, &CorridorScanComplexItem::_rebuildCorridorPolygon);
     connect(&_corridorWidthFact,    &Fact::valueChanged,                            this, &CorridorScanComplexItem::_rebuildCorridorPolygon);
@@ -173,13 +173,6 @@ int CorridorScanComplexItem::_calcTransectCount(void) const
 {
     double fullWidth = _corridorWidthFact.rawValue().toDouble();
     return fullWidth > 0.0 ? qCeil(fullWidth / _calcTransectSpacing()) : 1;
-}
-
-void CorridorScanComplexItem::_polylineDirtyChanged(bool dirty)
-{
-    if (dirty) {
-        setDirty(true);
-    }
 }
 
 void CorridorScanComplexItem::rotateEntryPoint(void)

--- a/src/MissionManager/CorridorScanComplexItem.h
+++ b/src/MissionManager/CorridorScanComplexItem.h
@@ -62,7 +62,6 @@ public:
     static const char* corridorWidthName;
 
 private slots:
-    void _polylineDirtyChanged          (bool dirty);
     void _rebuildCorridorPolygon        (void);
     void _updateWizardMode              (void);
 

--- a/src/MissionManager/GeoFenceController.cc
+++ b/src/MissionManager/GeoFenceController.cc
@@ -303,18 +303,6 @@ void GeoFenceController::setDirty(bool dirty)
     }
 }
 
-void GeoFenceController::_polygonDirtyChanged(bool dirty)
-{
-    if (dirty) {
-        setDirty(true);
-    }
-}
-
-void GeoFenceController::_setDirty(void)
-{
-    setDirty(true);
-}
-
 void GeoFenceController::_setFenceFromManager(const QList<QGCFencePolygon>& polygons,
                                               const QList<QGCFenceCircle>&  circles)
 {

--- a/src/MissionManager/GeoFenceController.h
+++ b/src/MissionManager/GeoFenceController.h
@@ -104,8 +104,6 @@ signals:
 #endif
 
 private slots:
-    void _polygonDirtyChanged       (bool dirty);
-    void _setDirty                  (void);
     void _setFenceFromManager       (const QList<QGCFencePolygon>& polygons, const QList<QGCFenceCircle>&  circles);
     void _setReturnPointFromManager (QGeoCoordinate breachReturnPoint);
     void _managerLoadComplete       (void);
@@ -120,7 +118,6 @@ private:
 
     Vehicle*            _managerVehicle =               nullptr;
     GeoFenceManager*    _geoFenceManager =              nullptr;
-    bool                _dirty =                        false;
     QmlObjectListModel  _polygons;
     QmlObjectListModel  _circles;
     QGeoCoordinate      _breachReturnPoint;

--- a/src/MissionManager/LandingComplexItem.cc
+++ b/src/MissionManager/LandingComplexItem.cc
@@ -520,19 +520,6 @@ LandingComplexItem::ReadyForSaveState LandingComplexItem::readyForSaveState(void
     return _landingCoordSet && !_wizardMode ? ReadyForSave : NotReadyForSaveData;
 }
 
-void LandingComplexItem::setDirty(bool dirty)
-{
-    if (_dirty != dirty) {
-        _dirty = dirty;
-        emit dirtyChanged(_dirty);
-    }
-}
-
-void LandingComplexItem::_setDirty(void)
-{
-    setDirty(true);
-}
-
 void LandingComplexItem::setSequenceNumber(int sequenceNumber)
 {
     if (_sequenceNumber != sequenceNumber) {

--- a/src/MissionManager/LandingComplexItem.h
+++ b/src/MissionManager/LandingComplexItem.h
@@ -83,7 +83,6 @@ public:
     int     lastSequenceNumber  (void) const final;
 
     // Overrides from VisualMissionItem
-    bool                dirty                       (void) const final { return _dirty; }
     bool                isSimpleItem                (void) const final { return false; }
     bool                isStandaloneCoordinate      (void) const final { return false; }
     bool                specifiesCoordinate         (void) const final { return true; }
@@ -102,7 +101,6 @@ public:
     double              additionalTimeDelay         (void) const final { return 0; }
     ReadyForSaveState   readyForSaveState           (void) const final;
     bool                exitCoordinateSameAsEntry   (void) const final { return false; }
-    void                setDirty                    (bool dirty) final;
     void                setCoordinate               (const QGeoCoordinate& coordinate) final { setFinalApproachCoordinate(coordinate); }
     void                setSequenceNumber           (int sequenceNumber) final;
     double              amslEntryAlt                (void) const final;
@@ -133,7 +131,6 @@ protected slots:
 
     void _recalcFromHeadingAndDistanceChange        (void);
     void _recalcFromCoordinateChange                (void);
-    void _setDirty                                  (void);
 
 protected:
     virtual const Fact*     _finalApproachAltitude  (void) const = 0;
@@ -161,7 +158,6 @@ protected:
     static bool _scanForItem(QmlObjectListModel* visualItems, bool flyView, PlanMasterController* masterController, IsLandItemFunc isLandItemFunc, CreateItemFunc createItemFunc);
 
     int             _sequenceNumber             = 0;
-    bool            _dirty                      = false;
     QGeoCoordinate  _finalApproachCoordinate;
     QGeoCoordinate  _loiterTangentCoordinate;
     QGeoCoordinate  _landingCoordinate;

--- a/src/MissionManager/MissionSettingsItem.cc
+++ b/src/MissionManager/MissionSettingsItem.cc
@@ -47,8 +47,8 @@ MissionSettingsItem::MissionSettingsItem(PlanMasterController* masterController,
     connect(&_cameraSection,    &CameraSection::itemCountChanged,                       this, &MissionSettingsItem::_setDirtyAndUpdateLastSequenceNumber);
     connect(&_speedSection,     &CameraSection::itemCountChanged,                       this, &MissionSettingsItem::_setDirtyAndUpdateLastSequenceNumber);
     connect(this,               &MissionSettingsItem::terrainAltitudeChanged,           this, &MissionSettingsItem::_setHomeAltFromTerrain);
-    connect(&_cameraSection,    &CameraSection::dirtyChanged,                           this, &MissionSettingsItem::_sectionDirtyChanged);
-    connect(&_speedSection,     &SpeedSection::dirtyChanged,                            this, &MissionSettingsItem::_sectionDirtyChanged);
+    connect(&_cameraSection,    &CameraSection::dirtyChanged,                           this, &MissionSettingsItem::_setIfDirty);
+    connect(&_speedSection,     &SpeedSection::dirtyChanged,                            this, &MissionSettingsItem::_setIfDirty);
     connect(&_cameraSection,    &CameraSection::specifiedGimbalYawChanged,              this, &MissionSettingsItem::specifiedGimbalYawChanged);
     connect(&_cameraSection,    &CameraSection::specifiedGimbalPitchChanged,            this, &MissionSettingsItem::specifiedGimbalPitchChanged);
     connect(&_speedSection,     &SpeedSection::specifiedFlightSpeedChanged,             this, &MissionSettingsItem::specifiedFlightSpeedChanged);
@@ -177,11 +177,6 @@ double MissionSettingsItem::complexDistance(void) const
     return 0;
 }
 
-void MissionSettingsItem::_setDirty(void)
-{
-    setDirty(true);
-}
-
 void MissionSettingsItem::_setCoordinateWorker(const QGeoCoordinate& coordinate)
 {
     if (_plannedHomePositionCoordinate != coordinate) {
@@ -236,13 +231,6 @@ void MissionSettingsItem::_setDirtyAndUpdateLastSequenceNumber(void)
 {
     emit lastSequenceNumberChanged(lastSequenceNumber());
     setDirty(true);
-}
-
-void MissionSettingsItem::_sectionDirtyChanged(bool dirty)
-{
-    if (dirty) {
-        setDirty(true);
-    }
 }
 
 double MissionSettingsItem::specifiedGimbalYaw(void)

--- a/src/MissionManager/MissionSettingsItem.h
+++ b/src/MissionManager/MissionSettingsItem.h
@@ -67,7 +67,6 @@ public:
     bool    terrainCollision    (void) const final { return false; }
 
     // Overrides from VisualMissionItem
-    bool            dirty                       (void) const final { return _dirty; }
     bool            isSimpleItem                (void) const final { return false; }
     bool            isStandaloneCoordinate      (void) const final { return false; }
     bool            specifiesCoordinate         (void) const final;
@@ -99,8 +98,6 @@ signals:
 
 private slots:
     void _setDirtyAndUpdateLastSequenceNumber   (void);
-    void _setDirty                              (void);
-    void _sectionDirtyChanged                   (bool dirty);
     void _updateAltitudeInCoordinate            (QVariant value);
     void _setHomeAltFromTerrain                 (double terrainAltitude);
     void _setCoordinateWorker                   (const QGeoCoordinate& coordinate);

--- a/src/MissionManager/PlanElementController.cc
+++ b/src/MissionManager/PlanElementController.cc
@@ -11,7 +11,7 @@
 #include "PlanMasterController.h"
 
 PlanElementController::PlanElementController(PlanMasterController* masterController, QObject* parent)
-    : QObject           (parent)
+    : QmlObjectListItem (parent)
     , _masterController (masterController)
     , _flyView          (false)
 {

--- a/src/MissionManager/PlanElementController.h
+++ b/src/MissionManager/PlanElementController.h
@@ -11,12 +11,13 @@
 
 #include <QtCore/QObject>
 
-class PlanMasterController;
+#include <QmlObjectListItem.h>
 
+class PlanMasterController;
 
 /// This is the abstract base clas for Plan Element controllers.
 /// Examples of plan elements are: missions (MissionController), geofence (GeoFenceController)
-class PlanElementController : public QObject
+class PlanElementController : public QmlObjectListItem
 {
     Q_OBJECT
     Q_MOC_INCLUDE("PlanMasterController.h")
@@ -29,7 +30,6 @@ public:
     Q_PROPERTY(bool                     supported           READ supported                      NOTIFY supportedChanged)        ///< true: Element is supported by Vehicle
     Q_PROPERTY(bool                     containsItems       READ containsItems                  NOTIFY containsItemsChanged)    ///< true: Elemement is non-empty
     Q_PROPERTY(bool                     syncInProgress      READ syncInProgress                 NOTIFY syncInProgressChanged)   ///< true: information is currently being saved/sent, false: no active save/send in progress
-    Q_PROPERTY(bool                     dirty               READ dirty          WRITE setDirty  NOTIFY dirtyChanged)            ///< true: unsaved/sent changes are present, false: no changes since last save/send
 
     PlanMasterController* masterController(void) { return _masterController; }
 
@@ -45,8 +45,6 @@ public:
     virtual bool    supported       (void) const = 0;
     virtual bool    containsItems   (void) const = 0;
     virtual bool    syncInProgress  (void) const = 0;
-    virtual bool    dirty           (void) const = 0;
-    virtual void    setDirty        (bool dirty) = 0;
 
     /// Sends the current plan element to the vehicle
     ///     Signals sendComplete when done
@@ -60,7 +58,6 @@ signals:
     void supportedChanged       (bool supported);
     void containsItemsChanged   (bool containsItems);
     void syncInProgressChanged  (bool syncInProgress);
-    void dirtyChanged           (bool dirty);
     void sendComplete           (void);
     void removeAllComplete      (void);
 

--- a/src/MissionManager/PlanMasterController.cc
+++ b/src/MissionManager/PlanMasterController.cc
@@ -38,7 +38,7 @@ const char* PlanMasterController::kJsonGeoFenceObjectKey =      "geoFence";
 const char* PlanMasterController::kJsonRallyPointsObjectKey =   "rallyPoints";
 
 PlanMasterController::PlanMasterController(QObject* parent)
-    : QObject               (parent)
+    : QmlObjectListItem     (parent)
     , _multiVehicleMgr      (qgcApp()->toolbox()->multiVehicleManager())
     , _controllerVehicle    (new Vehicle(Vehicle::MAV_AUTOPILOT_TRACK, Vehicle::MAV_TYPE_TRACK, qgcApp()->toolbox()->firmwarePluginManager(), this))
     , _managerVehicle       (_controllerVehicle)
@@ -51,7 +51,7 @@ PlanMasterController::PlanMasterController(QObject* parent)
 
 #ifdef QT_DEBUG
 PlanMasterController::PlanMasterController(MAV_AUTOPILOT firmwareType, MAV_TYPE vehicleType, QObject* parent)
-    : QObject               (parent)
+    : QmlObjectListItem     (parent)
     , _multiVehicleMgr      (qgcApp()->toolbox()->multiVehicleManager())
     , _controllerVehicle    (new Vehicle(firmwareType, vehicleType, qgcApp()->toolbox()->firmwarePluginManager()))
     , _managerVehicle       (_controllerVehicle)

--- a/src/MissionManager/PlanMasterController.h
+++ b/src/MissionManager/PlanMasterController.h
@@ -15,6 +15,7 @@
 #include "MissionController.h"
 #include "GeoFenceController.h"
 #include "RallyPointController.h"
+#include <QmlObjectListItem.h>
 
 Q_DECLARE_LOGGING_CATEGORY(PlanMasterControllerLog)
 
@@ -23,7 +24,7 @@ class MultiVehicleManager;
 class Vehicle;
 
 /// Master controller for mission, fence, rally
-class PlanMasterController : public QObject
+class PlanMasterController : public QmlObjectListItem
 {
     Q_OBJECT
     Q_MOC_INCLUDE("QmlObjectListModel.h")
@@ -47,7 +48,6 @@ public:
     Q_PROPERTY(bool                     offline                 READ offline                                NOTIFY offlineChanged)          ///< true: controller is not connected to an active vehicle
     Q_PROPERTY(bool                     containsItems           READ containsItems                          NOTIFY containsItemsChanged)    ///< true: Elemement is non-empty
     Q_PROPERTY(bool                     syncInProgress          READ syncInProgress                         NOTIFY syncInProgressChanged)   ///< true: Information is currently being saved/sent, false: no active save/send in progress
-    Q_PROPERTY(bool                     dirty                   READ dirty                  WRITE setDirty  NOTIFY dirtyChanged)            ///< true: Unsaved/sent changes are present, false: no changes since last save/send
     Q_PROPERTY(QString                  fileExtension           READ fileExtension                          CONSTANT)                       ///< File extension for missions
     Q_PROPERTY(QString                  kmlFileExtension        READ kmlFileExtension                       CONSTANT)
     Q_PROPERTY(QString                  currentPlanFile         READ currentPlanFile                        NOTIFY currentPlanFileChanged)
@@ -91,8 +91,8 @@ public:
     bool        offline         (void) const { return _offline; }
     bool        containsItems   (void) const;
     bool        syncInProgress  (void) const;
-    bool        dirty           (void) const;
-    void        setDirty        (bool dirty);
+    bool        dirty           (void) const final;
+    void        setDirty        (bool dirty) final;
     QString     fileExtension   (void) const;
     QString     kmlFileExtension(void) const;
     QString     currentPlanFile (void) const { return _currentPlanFile; }
@@ -116,7 +116,6 @@ public:
 signals:
     void containsItemsChanged               (bool containsItems);
     void syncInProgressChanged              (void);
-    void dirtyChanged                       (bool dirty);
     void offlineChanged                     (bool offlineEditing);
     void currentPlanFileChanged             (void);
     void planCreatorsChanged                (QmlObjectListModel* planCreators);

--- a/src/MissionManager/RallyPoint.cc
+++ b/src/MissionManager/RallyPoint.cc
@@ -16,8 +16,7 @@ const char* RallyPoint::_altitudeFactName =     "RelativeAltitude";
 QMap<QString, FactMetaData*> RallyPoint::_metaDataMap;
 
 RallyPoint::RallyPoint(const QGeoCoordinate& coordinate, QObject* parent)
-    : QObject(parent)
-    , _dirty(false)
+    : QmlObjectListItem(parent)
     , _longitudeFact(0, _longitudeFactName, FactMetaData::valueTypeDouble)
     , _latitudeFact(0, _latitudeFactName, FactMetaData::valueTypeDouble)
     , _altitudeFact(0, _altitudeFactName, FactMetaData::valueTypeDouble)
@@ -28,8 +27,7 @@ RallyPoint::RallyPoint(const QGeoCoordinate& coordinate, QObject* parent)
 }
 
 RallyPoint::RallyPoint(const RallyPoint& other, QObject* parent)
-    : QObject(parent)
-    , _dirty(false)
+    : QmlObjectListItem(parent)
     , _longitudeFact(0, _longitudeFactName, FactMetaData::valueTypeDouble)
     , _latitudeFact(0, _latitudeFactName, FactMetaData::valueTypeDouble)
     , _altitudeFact(0, _altitudeFactName, FactMetaData::valueTypeDouble)
@@ -88,14 +86,6 @@ void RallyPoint::setCoordinate(const QGeoCoordinate& coordinate)
         _altitudeFact.setRawValue(coordinate.altitude());
         emit coordinateChanged(coordinate);
         setDirty(true);
-    }
-}
-
-void RallyPoint::setDirty(bool dirty)
-{
-    if (dirty != _dirty) {
-        _dirty = dirty;
-        emit dirtyChanged(dirty);
     }
 }
 

--- a/src/MissionManager/RallyPoint.h
+++ b/src/MissionManager/RallyPoint.h
@@ -13,10 +13,11 @@
 #include <QtPositioning/QGeoCoordinate>
 
 #include "Fact.h"
+#include <QmlObjectListItem.h>
 
 /// This class is used to encapsulate the QGeoCoordinate associated with a Rally Point into a QObject such
 /// that it can be used in a QmlObjectListMode for Qml.
-class RallyPoint : public QObject
+class RallyPoint : public QmlObjectListItem
 {
     Q_OBJECT
     
@@ -29,20 +30,15 @@ public:
     const RallyPoint& operator=(const RallyPoint& other);
     
     Q_PROPERTY(QGeoCoordinate   coordinate      READ coordinate     WRITE setCoordinate     NOTIFY coordinateChanged)
-    Q_PROPERTY(bool             dirty           READ dirty          WRITE setDirty          NOTIFY dirtyChanged)
     Q_PROPERTY(QVariantList     textFieldFacts  MEMBER _textFieldFacts                      CONSTANT)
 
     QGeoCoordinate coordinate(void) const;
     void setCoordinate(const QGeoCoordinate& coordinate);
 
-    bool dirty(void) const { return _dirty; }
-    void setDirty(bool dirty);
-
     static double getDefaultFactAltitude();
 
 signals:
     void coordinateChanged      (const QGeoCoordinate& coordinate);
-    void dirtyChanged           (bool dirty);
 
 private slots:
     void _sendCoordinateChanged(void);
@@ -51,7 +47,6 @@ private:
     void _factSetup(void);
     static void _cacheFactMetadata();
 
-    bool _dirty;
     Fact _longitudeFact;
     Fact _latitudeFact;
     Fact _altitudeFact;

--- a/src/MissionManager/RallyPointController.cc
+++ b/src/MissionManager/RallyPointController.cc
@@ -187,14 +187,6 @@ bool RallyPointController::syncInProgress(void) const
     return _rallyPointManager->inProgress();
 }
 
-void RallyPointController::setDirty(bool dirty)
-{
-    if (dirty != _dirty) {
-        _dirty = dirty;
-        emit dirtyChanged(dirty);
-    }
-}
-
 QString RallyPointController::editorQml(void) const
 {
     return _rallyPointManager->editorQml();

--- a/src/MissionManager/RallyPointController.h
+++ b/src/MissionManager/RallyPointController.h
@@ -45,8 +45,6 @@ public:
     void removeAll                  (void) final;
     void removeAllFromVehicle       (void) final;
     bool syncInProgress             (void) const final;
-    bool dirty                      (void) const final { return _dirty; }
-    void setDirty                   (bool dirty) final;
     bool containsItems              (void) const final;
     bool showPlanFromManagerVehicle (void) final;
 
@@ -72,7 +70,6 @@ private slots:
 private:
     Vehicle*            _managerVehicle =       nullptr;
     RallyPointManager*  _rallyPointManager =    nullptr;
-    bool                _dirty =                false;
     QmlObjectListModel  _points;
     QObject*            _currentRallyPoint =    nullptr;
     bool                _itemsRequested =       false;

--- a/src/MissionManager/Section.h
+++ b/src/MissionManager/Section.h
@@ -12,6 +12,8 @@
 #include <QtCore/QObject>
 #include <QtCore/QLoggingCategory>
 
+#include <QmlObjectListItem.h>
+
 Q_DECLARE_LOGGING_CATEGORY(SectionLog)
 
 class PlanMasterController;
@@ -19,28 +21,25 @@ class QmlObjectListModel;
 class MissionItem;
 
 // A Section encapsulates a set of mission commands which can be associated with another simple mission item.
-class Section : public QObject
+class Section : public QmlObjectListItem
 {
     Q_OBJECT
 
 public:
     Section(PlanMasterController* masterController, QObject* parent = nullptr)
-        : QObject           (parent)
+        : QmlObjectListItem (parent)
         , _masterController (masterController)
     {
-
+        connect(this, &Section::dirtyChanged, this, &Section::availableChanged);
     }
 
     Q_PROPERTY(bool     available           READ available          WRITE setAvailable  NOTIFY availableChanged)
     Q_PROPERTY(bool     settingsSpecified   READ settingsSpecified                      NOTIFY settingsSpecifiedChanged)
-    Q_PROPERTY(bool     dirty               READ dirty              WRITE setDirty      NOTIFY availableChanged)
 
     virtual bool available          (void) const = 0;
     virtual bool settingsSpecified  (void) const = 0;
-    virtual bool dirty              (void) const = 0;
 
     virtual void setAvailable       (bool available) = 0;
-    virtual void setDirty           (bool dirty) = 0;
 
     /// Scans the loaded items for the section items
     ///     @param visualItems Item list
@@ -61,7 +60,6 @@ public:
 signals:
     void availableChanged           (bool available);
     void settingsSpecifiedChanged   (bool settingsSpecified);
-    void dirtyChanged               (bool dirty);
     void itemCountChanged           (int itemCount);
 
 protected:

--- a/src/MissionManager/SimpleMissionItem.cc
+++ b/src/MissionManager/SimpleMissionItem.cc
@@ -674,13 +674,6 @@ void SimpleMissionItem::setDirty(bool dirty)
     }
 }
 
-void SimpleMissionItem::_setDirty(void)
-{
-    if (!_ignoreDirtyChangeSignals) {
-        setDirty(true);
-    }
-}
-
 void SimpleMissionItem::_sendCoordinateChanged(void)
 {
     emit coordinateChanged(coordinate());
@@ -952,14 +945,14 @@ void SimpleMissionItem::_updateOptionalSections(void)
         _speedSection->setAvailable(true);
     }
 
-    connect(_cameraSection, &CameraSection::dirtyChanged,                   this, &SimpleMissionItem::_sectionDirtyChanged);
+    connect(_cameraSection, &CameraSection::dirtyChanged,                   this, &SimpleMissionItem::_setIfDirty);
     connect(_cameraSection, &CameraSection::itemCountChanged,               this, &SimpleMissionItem::_updateLastSequenceNumber);
     connect(_cameraSection, &CameraSection::availableChanged,               this, &SimpleMissionItem::specifiedGimbalYawChanged);
     connect(_cameraSection, &CameraSection::availableChanged,               this, &SimpleMissionItem::specifiedGimbalPitchChanged);
     connect(_cameraSection, &CameraSection::specifiedGimbalPitchChanged,    this, &SimpleMissionItem::specifiedGimbalPitchChanged);
     connect(_cameraSection, &CameraSection::specifiedGimbalYawChanged,      this, &SimpleMissionItem::specifiedGimbalYawChanged);
 
-    connect(_speedSection,  &SpeedSection::dirtyChanged,                this, &SimpleMissionItem::_sectionDirtyChanged);
+    connect(_speedSection,  &SpeedSection::dirtyChanged,                this, &SimpleMissionItem::_setIfDirty);
     connect(_speedSection,  &SpeedSection::itemCountChanged,            this, &SimpleMissionItem::_updateLastSequenceNumber);
     connect(_speedSection,  &SpeedSection::specifiedFlightSpeedChanged, this, &SimpleMissionItem::specifiedFlightSpeedChanged);
 
@@ -976,13 +969,6 @@ int SimpleMissionItem::lastSequenceNumber(void) const
 void SimpleMissionItem::_updateLastSequenceNumber(void)
 {
     emit lastSequenceNumberChanged(lastSequenceNumber());
-}
-
-void SimpleMissionItem::_sectionDirtyChanged(bool dirty)
-{
-    if (dirty) {
-        setDirty(true);
-    }
 }
 
 void SimpleMissionItem::appendMissionItems(QList<MissionItem*>& items, QObject* missionItemParent)

--- a/src/MissionManager/SimpleMissionItem.h
+++ b/src/MissionManager/SimpleMissionItem.h
@@ -106,7 +106,6 @@ public:
     const MissionItem& missionItem(void) const { return _missionItem; }
 
     // Overrides from VisualMissionItem
-    bool            dirty                       (void) const override { return _dirty; }
     bool            isSimpleItem                (void) const final { return true; }
     bool            isStandaloneCoordinate      (void) const final;
     bool            isLandCommand               (void) const final;
@@ -151,8 +150,6 @@ signals:
     void loiterRadiusChanged        (double loiterRadius);
 
 private slots:
-    void _setDirty                              (void);
-    void _sectionDirtyChanged                   (bool dirty);
     void _sendCommandChanged                    (void);
     void _sendCoordinateChanged                 (void);
     void _sendFriendlyEditAllowedChanged        (void);
@@ -177,8 +174,6 @@ private:
 
     MissionItem     _missionItem;
     bool            _rawEdit =                  false;
-    bool            _dirty =                    false;
-    bool            _ignoreDirtyChangeSignals = false;
     QGeoCoordinate  _mapCenterHint;
     SpeedSection*   _speedSection =             nullptr;
     CameraSection*  _cameraSection =             nullptr;

--- a/src/MissionManager/SpeedSection.cc
+++ b/src/MissionManager/SpeedSection.cc
@@ -20,7 +20,6 @@ QMap<QString, FactMetaData*> SpeedSection::_metaDataMap;
 SpeedSection::SpeedSection(PlanMasterController* masterController, QObject* parent)
     : Section               (masterController, parent)
     , _available            (false)
-    , _dirty                (false)
     , _specifyFlightSpeed   (false)
     , _flightSpeedFact      (0, _flightSpeedName,   FactMetaData::valueTypeDouble)
 {
@@ -58,14 +57,6 @@ void SpeedSection::setAvailable(bool available)
             _available = available;
             emit availableChanged(available);
         }
-    }
-}
-
-void SpeedSection::setDirty(bool dirty)
-{
-    if (_dirty != dirty) {
-        _dirty = dirty;
-        emit dirtyChanged(_dirty);
     }
 }
 

--- a/src/MissionManager/SpeedSection.h
+++ b/src/MissionManager/SpeedSection.h
@@ -35,9 +35,7 @@ public:
 
     // Overrides from Section
     bool available          (void) const override { return _available; }
-    bool dirty              (void) const override { return _dirty; }
     void setAvailable       (bool available) override;
-    void setDirty           (bool dirty) override;
     bool scanForSection     (QmlObjectListModel* visualItems, int scanIndex) override;
     void appendSectionItems (QList<MissionItem*>& items, QObject* missionItemParent, int& seqNum) override;
     int  itemCount          (void) const override;
@@ -53,7 +51,6 @@ private slots:
 
 private:
     bool    _available;
-    bool    _dirty;
     bool    _specifyFlightSpeed;
     Fact    _flightSpeedFact;
 

--- a/src/MissionManager/StructureScanComplexItem.cc
+++ b/src/MissionManager/StructureScanComplexItem.cc
@@ -70,7 +70,7 @@ StructureScanComplexItem::StructureScanComplexItem(PlanMasterController* masterC
 
     connect(&_entranceAltFact, &Fact::valueChanged, this, &StructureScanComplexItem::_updateCoordinateAltitudes);
 
-    connect(&_structurePolygon, &QGCMapPolygon::dirtyChanged,   this, &StructureScanComplexItem::_polygonDirtyChanged);
+    connect(&_structurePolygon, &QGCMapPolygon::dirtyChanged,   this, &StructureScanComplexItem::_setIfDirty);
     connect(&_structurePolygon, &QGCMapPolygon::pathChanged,    this, &StructureScanComplexItem::_rebuildFlightPolygon);
     connect(&_structurePolygon, &QGCMapPolygon::isValidChanged, this, &StructureScanComplexItem::readyForSaveStateChanged);
     connect(&_structurePolygon, &QGCMapPolygon::isValidChanged,     this, &StructureScanComplexItem::_updateWizardMode);
@@ -163,14 +163,6 @@ int StructureScanComplexItem::lastSequenceNumber(void) const
     int itemCount = multiLayerItemCount + 2 + 2;
 
     return _sequenceNumber + itemCount - 1;
-}
-
-void StructureScanComplexItem::setDirty(bool dirty)
-{
-    if (_dirty != dirty) {
-        _dirty = dirty;
-        emit dirtyChanged(_dirty);
-    }
 }
 
 void StructureScanComplexItem::save(QJsonArray&  missionItems)
@@ -476,21 +468,9 @@ void StructureScanComplexItem::setMissionFlightStatus(MissionController::Mission
     }
 }
 
-void StructureScanComplexItem::_setDirty(void)
-{
-    setDirty(true);
-}
-
 void StructureScanComplexItem::applyNewAltitude(double newAltitude)
 {
     _entranceAltFact.setRawValue(newAltitude);
-}
-
-void StructureScanComplexItem::_polygonDirtyChanged(bool dirty)
-{
-    if (dirty) {
-        setDirty(true);
-    }
 }
 
 double StructureScanComplexItem::timeBetweenShots(void)

--- a/src/MissionManager/StructureScanComplexItem.h
+++ b/src/MissionManager/StructureScanComplexItem.h
@@ -71,7 +71,6 @@ public:
     QString mapVisualQML        (void) const final { return QStringLiteral("StructureScanMapVisual.qml"); }
 
     // Overrides from VisualMissionItem
-    bool                dirty                       (void) const final { return _dirty; }
     bool                isSimpleItem                (void) const final { return false; }
     bool                isStandaloneCoordinate      (void) const final { return false; }
     bool                specifiesCoordinate         (void) const final { return true; }
@@ -91,7 +90,6 @@ public:
     double              additionalTimeDelay         (void) const final { return 0; }
     ReadyForSaveState   readyForSaveState           (void) const final;
     bool                exitCoordinateSameAsEntry   (void) const final { return true; }
-    void                setDirty                    (bool dirty) final;
     void                setCoordinate               (const QGeoCoordinate& coordinate) final { Q_UNUSED(coordinate); }
     void                setSequenceNumber           (int sequenceNumber) final;
     void                save                        (QJsonArray&  missionItems) final;
@@ -120,8 +118,6 @@ signals:
 
 private slots:
     void _segmentTerrainCollisionChanged            (bool terrainCollision) final;
-    void _setDirty                                  (void);
-    void _polygonDirtyChanged                       (bool dirty);
     void _flightPathChanged                         (void);
     void _clearInternal                             (void);
     void _updateCoordinateAltitudes                 (void);

--- a/src/MissionManager/TakeoffMissionItem.h
+++ b/src/MissionManager/TakeoffMissionItem.h
@@ -51,8 +51,6 @@ public:
     bool load(QTextStream &loadStream) final;
     bool load(const QJsonObject& json, int sequenceNumber, QString& errorString) final;
 
-    //void setDirty(bool dirty) final;
-
 signals:
     void launchCoordinateChanged            (const QGeoCoordinate& launchCoordinate);
     void launchTakeoffAtSameLocationChanged (bool launchTakeoffAtSameLocation);

--- a/src/MissionManager/TransectStyleComplexItem.cc
+++ b/src/MissionManager/TransectStyleComplexItem.cc
@@ -138,10 +138,7 @@ void TransectStyleComplexItem::setDirty(bool dirty)
         _surveyAreaPolygon.setDirty(false);
         _cameraCalc.setDirty(false);
     }
-    if (_dirty != dirty) {
-        _dirty = dirty;
-        emit dirtyChanged(_dirty);
-    }
+    QmlObjectListItem::setDirty(dirty);
 }
 
 void TransectStyleComplexItem::_save(QJsonObject& complexObject)
@@ -360,18 +357,6 @@ void TransectStyleComplexItem::setMissionFlightStatus(MissionController::Mission
         // Vehicle speed change affects max climb/descent rates calcs for terrain so we need to re-adjust
         _rebuildTransects();
         emit timeBetweenShotsChanged();
-    }
-}
-
-void TransectStyleComplexItem::_setDirty(void)
-{
-    setDirty(true);
-}
-
-void TransectStyleComplexItem::_setIfDirty(bool dirty)
-{
-    if (dirty) {
-        setDirty(true);
     }
 }
 

--- a/src/MissionManager/TransectStyleComplexItem.h
+++ b/src/MissionManager/TransectStyleComplexItem.h
@@ -86,7 +86,6 @@ public:
     bool                specifiesCoordinate         (void) const override = 0;
     void                appendMissionItems          (QList<MissionItem*>& items, QObject* missionItemParent) final;
     void                applyNewAltitude            (double newAltitude) final;
-    bool                dirty                       (void) const final { return _dirty; }
     bool                isSimpleItem                (void) const final { return false; }
     bool                isStandaloneCoordinate      (void) const final { return false; }
     bool                specifiesAltitudeOnly       (void) const final { return false; }
@@ -127,8 +126,7 @@ signals:
     void _updateFlightPathSegmentsSignal(void);
 
 protected slots:
-    void _setDirty                          (void);
-    void _setIfDirty                        (bool dirty);
+
     void _updateCoordinateAltitudes         (void);
     void _polyPathTerrainData               (bool success, const QList<TerrainPathQuery::PathHeightInfo_t>& rgPathHeightInfo);
     void _missionItemCoordTerrainData       (bool success, QList<double> heights);

--- a/src/MissionManager/VisualMissionItem.cc
+++ b/src/MissionManager/VisualMissionItem.cc
@@ -20,7 +20,7 @@ const char* VisualMissionItem::jsonTypeComplexItemValue =   "ComplexItem";
 // All VisualMissionItem derived classes are parented to masterController in order to tie their lifecycles together.
 
 VisualMissionItem::VisualMissionItem(PlanMasterController* masterController, bool flyView)
-    : QObject           (masterController)
+    : QmlObjectListItem (masterController)
     , _flyView          (flyView)
     , _masterController (masterController)
     , _missionController(masterController->missionController())
@@ -30,8 +30,8 @@ VisualMissionItem::VisualMissionItem(PlanMasterController* masterController, boo
 }
 
 VisualMissionItem::VisualMissionItem(const VisualMissionItem& other, bool flyView)
-    : QObject                   (other._masterController)
-    , _flyView                  (flyView)
+    : QmlObjectListItem (other._masterController)
+    , _flyView          (flyView)
 {
     *this = other;
 

--- a/src/MissionManager/VisualMissionItem.h
+++ b/src/MissionManager/VisualMissionItem.h
@@ -16,6 +16,7 @@
 
 #include "QGCMAVLink.h"
 #include "QmlObjectListModel.h"
+#include <QmlObjectListItem.h>
 #include "MissionController.h"
 
 class MissionItem;
@@ -24,7 +25,7 @@ class TerrainAtCoordinateQuery;
 class Vehicle;
 
 // Abstract base class for all Simple and Complex visual mission objects.
-class VisualMissionItem : public QObject
+class VisualMissionItem : public QmlObjectListItem
 {
     Q_OBJECT
     Q_MOC_INCLUDE("PlanMasterController.h")
@@ -54,7 +55,6 @@ public:
     Q_PROPERTY(QString          commandDescription                  READ commandDescription                                                 NOTIFY commandDescriptionChanged)
     Q_PROPERTY(QString          commandName                         READ commandName                                                        NOTIFY commandNameChanged)
     Q_PROPERTY(QString          abbreviation                        READ abbreviation                                                       NOTIFY abbreviationChanged)
-    Q_PROPERTY(bool             dirty                               READ dirty                              WRITE setDirty                  NOTIFY dirtyChanged)                                ///< Item is dirty and requires save/send
     Q_PROPERTY(bool             isCurrentItem                       READ isCurrentItem                      WRITE setIsCurrentItem          NOTIFY isCurrentItemChanged)
     Q_PROPERTY(bool             hasCurrentChildItem                 READ hasCurrentChildItem                WRITE setHasCurrentChildItem    NOTIFY hasCurrentChildItemChanged)                  ///< true: On of this items children is current
     Q_PROPERTY(int              sequenceNumber                      READ sequenceNumber                     WRITE setSequenceNumber         NOTIFY sequenceNumberChanged)
@@ -134,7 +134,6 @@ public:
 
     // Pure virtuals which must be provides by derived classes
 
-    virtual bool            dirty                   (void) const = 0;
     virtual bool            isSimpleItem            (void) const = 0;
     virtual bool            isTakeoffItem           (void) const { return false; }
     virtual bool            isLandCommand           (void) const { return false; }
@@ -164,7 +163,6 @@ public:
 
     virtual bool exitCoordinateSameAsEntry          (void) const = 0;
 
-    virtual void setDirty           (bool dirty) = 0;
     virtual void setCoordinate      (const QGeoCoordinate& coordinate) = 0;
     virtual void setSequenceNumber  (int sequenceNumber) = 0;
     virtual int  lastSequenceNumber (void) const = 0;
@@ -209,7 +207,6 @@ signals:
     void abbreviationChanged            (void);
     void coordinateChanged              (const QGeoCoordinate& coordinate);
     void exitCoordinateChanged          (const QGeoCoordinate& exitCoordinate);
-    void dirtyChanged                   (bool dirty);
     void distanceChanged                (double distance);
     void distanceFromStartChanged       (double distanceFromStart);
     void isCurrentItemChanged           (bool isCurrentItem);
@@ -249,7 +246,6 @@ protected:
     bool                         _flyView                   = false;
     bool                        _isCurrentItem              = false;
     bool                        _hasCurrentChildItem        = false;
-    bool                        _dirty                      = false;
     bool                        _homePositionSpecialCase    = false;                            ///< true: This item is being used as a ui home position indicator
     bool                        _wizardMode                 = false;                            ///< true: Item editor is showing wizard completion panel
     double                      _terrainAltitude            = qQNaN();                          ///< Altitude of terrain at coordinate position, NaN for not known

--- a/src/QmlControls/CMakeLists.txt
+++ b/src/QmlControls/CMakeLists.txt
@@ -43,6 +43,8 @@ qt_add_library(QmlControls STATIC
 	QGCPalette.h
 	QGroundControlQmlGlobal.cc
 	QGroundControlQmlGlobal.h
+	QmlObjectListItem.cc
+	QmlObjectListItem.h
 	QmlObjectListModel.cc
 	QmlObjectListModel.h
 	QmlUnitsConversion.h
@@ -68,6 +70,7 @@ target_link_libraries(QmlControls
         Geo
         GPS
         MockLink
+        Vehicle
 	PUBLIC
 		Qt6::Core
 		Qt6::Gui
@@ -89,7 +92,6 @@ target_link_libraries(QmlControls
         Terrain
 		Utilities
 		UTMSP
-        Vehicle
         VideoManager
 )
 

--- a/src/QmlControls/QGCFenceCircle.cc
+++ b/src/QmlControls/QGCFenceCircle.cc
@@ -47,11 +47,6 @@ const QGCFenceCircle& QGCFenceCircle::operator=(const QGCFenceCircle& other)
     return *this;
 }
 
-void QGCFenceCircle::_setDirty(void)
-{
-    setDirty(true);
-}
-
 void QGCFenceCircle::saveToJson(QJsonObject& json)
 {
     json[JsonHelper::jsonVersionKey] = _jsonCurrentVersion;

--- a/src/QmlControls/QGCFenceCircle.h
+++ b/src/QmlControls/QGCFenceCircle.h
@@ -43,9 +43,6 @@ public:
 signals:
     void inclusionChanged(bool inclusion);
 
-private slots:
-    void _setDirty(void);
-
 private:
     void _init(void);
 

--- a/src/QmlControls/QGCFencePolygon.cc
+++ b/src/QmlControls/QGCFencePolygon.cc
@@ -40,11 +40,6 @@ const QGCFencePolygon& QGCFencePolygon::operator=(const QGCFencePolygon& other)
     return *this;
 }
 
-void QGCFencePolygon::_setDirty(void)
-{
-    setDirty(true);
-}
-
 void QGCFencePolygon::saveToJson(QJsonObject& json)
 {
     json[JsonHelper::jsonVersionKey] = _jsonCurrentVersion;

--- a/src/QmlControls/QGCFencePolygon.h
+++ b/src/QmlControls/QGCFencePolygon.h
@@ -43,9 +43,6 @@ public:
 signals:
     void inclusionChanged   (bool inclusion);
 
-private slots:
-    void _setDirty(void);
-
 private:
     void _init(void);
 

--- a/src/QmlControls/QGCMapCircle.cc
+++ b/src/QmlControls/QGCMapCircle.cc
@@ -17,8 +17,7 @@ const char* QGCMapCircle::_jsonRadiusKey =  "radius";
 const char* QGCMapCircle::_radiusFactName = "Radius";
 
 QGCMapCircle::QGCMapCircle(QObject* parent)
-    : QObject           (parent)
-    , _dirty            (false)
+    : QmlObjectListItem (parent)
     , _interactive      (false)
     , _showRotation     (false)
     , _clockwiseRotation(true)
@@ -27,8 +26,7 @@ QGCMapCircle::QGCMapCircle(QObject* parent)
 }
 
 QGCMapCircle::QGCMapCircle(const QGeoCoordinate& center, double radius, bool showRotation, bool clockwiseRotation, QObject* parent)
-    : QObject           (parent)
-    , _dirty            (false)
+    : QmlObjectListItem (parent)
     , _center           (center)
     , _radius           (FactSystem::defaultComponentId, _radiusFactName, FactMetaData::valueTypeDouble)
     , _interactive      (false)
@@ -40,8 +38,7 @@ QGCMapCircle::QGCMapCircle(const QGeoCoordinate& center, double radius, bool sho
 }
 
 QGCMapCircle::QGCMapCircle(const QGCMapCircle& other, QObject* parent)
-    : QObject           (parent)
-    , _dirty            (false)
+    : QmlObjectListItem (parent)
     , _center           (other._center)
     , _radius           (FactSystem::defaultComponentId, _radiusFactName, FactMetaData::valueTypeDouble)
     , _interactive      (false)
@@ -68,14 +65,6 @@ void QGCMapCircle::_init(void)
 
     connect(this,       &QGCMapCircle::centerChanged,   this, &QGCMapCircle::_setDirty);
     connect(&_radius,   &Fact::rawValueChanged,         this, &QGCMapCircle::_setDirty);
-}
-
-void QGCMapCircle::setDirty(bool dirty)
-{
-    if (_dirty != dirty) {
-        _dirty = dirty;
-        emit dirtyChanged(dirty);
-    }
 }
 
 void QGCMapCircle::saveToJson(QJsonObject& json)
@@ -132,11 +121,6 @@ void QGCMapCircle::setCenter(QGeoCoordinate newCenter)
         setDirty(true);
         emit centerChanged(newCenter);
     }
-}
-
-void QGCMapCircle::_setDirty(void)
-{
-    setDirty(true);
 }
 
 void QGCMapCircle::setInteractive(bool interactive)

--- a/src/QmlControls/QGCMapCircle.h
+++ b/src/QmlControls/QGCMapCircle.h
@@ -13,9 +13,10 @@
 #include <QtPositioning/QGeoCoordinate>
 
 #include "Fact.h"
+#include <QmlObjectListItem.h>
 
 /// The QGCMapCircle represents a circular area which can be displayed on a Map control.
-class QGCMapCircle : public QObject
+class QGCMapCircle : public QmlObjectListItem
 {
     Q_OBJECT
 
@@ -27,7 +28,6 @@ public:
 
     const QGCMapCircle& operator=(const QGCMapCircle& other);
 
-    Q_PROPERTY(bool             dirty               READ dirty              WRITE setDirty              NOTIFY dirtyChanged)
     Q_PROPERTY(QGeoCoordinate   center              READ center             WRITE setCenter             NOTIFY centerChanged)
     Q_PROPERTY(Fact*            radius              READ radius                                         CONSTANT)
     Q_PROPERTY(bool             interactive         READ interactive        WRITE setInteractive        NOTIFY interactiveChanged)
@@ -46,14 +46,12 @@ public:
 
     // Property methods
 
-    bool            dirty               (void) const { return _dirty; }
     QGeoCoordinate  center              (void) const { return _center; }
     Fact*           radius              (void) { return &_radius; }
     bool            interactive         (void) const { return _interactive; }
     bool            showRotation        (void) const { return _showRotation; }
     bool            clockwiseRotation   (void) const { return _clockwiseRotation; }
 
-    void setDirty               (bool dirty);
     void setCenter              (QGeoCoordinate newCenter);
     void setInteractive         (bool interactive);
     void setShowRotation        (bool showRotation);
@@ -62,19 +60,14 @@ public:
     static const char* jsonCircleKey;
 
 signals:
-    void dirtyChanged               (bool dirty);
     void centerChanged              (QGeoCoordinate center);
     void interactiveChanged         (bool interactive);
     void showRotationChanged        (bool showRotation);
     void clockwiseRotationChanged   (bool clockwiseRotation);
 
-private slots:
-    void _setDirty(void);
-
 private:
     void _init(void);
 
-    bool            _dirty;
     QGeoCoordinate  _center;
     Fact            _radius;
     bool            _interactive;

--- a/src/QmlControls/QGCMapPolygon.cc
+++ b/src/QmlControls/QGCMapPolygon.cc
@@ -20,8 +20,7 @@
 const char* QGCMapPolygon::jsonPolygonKey = "polygon";
 
 QGCMapPolygon::QGCMapPolygon(QObject* parent)
-    : QObject               (parent)
-    , _dirty                (false)
+    : QmlObjectListItem     (parent)
     , _centerDrag           (false)
     , _ignoreCenterUpdates  (false)
     , _interactive          (false)
@@ -31,8 +30,7 @@ QGCMapPolygon::QGCMapPolygon(QObject* parent)
 }
 
 QGCMapPolygon::QGCMapPolygon(const QGCMapPolygon& other, QObject* parent)
-    : QObject               (parent)
-    , _dirty                (false)
+    : QmlObjectListItem     (parent)
     , _centerDrag           (false)
     , _ignoreCenterUpdates  (false)
     , _interactive          (false)
@@ -45,7 +43,7 @@ QGCMapPolygon::QGCMapPolygon(const QGCMapPolygon& other, QObject* parent)
 
 void QGCMapPolygon::_init(void)
 {
-    connect(&_polygonModel, &QmlObjectListModel::dirtyChanged, this, &QGCMapPolygon::_polygonModelDirtyChanged);
+    connect(&_polygonModel, &QmlObjectListModel::dirtyChanged, this, &QGCMapPolygon::_setIfDirty);
     connect(&_polygonModel, &QmlObjectListModel::countChanged, this, &QGCMapPolygon::_polygonModelCountChanged);
 
     connect(this, &QGCMapPolygon::pathChanged,  this, &QGCMapPolygon::_updateCenter);
@@ -287,13 +285,6 @@ void QGCMapPolygon::appendVertices(const QVariantList& varCoords)
         rgCoords.append(varCoord.value<QGeoCoordinate>());
     }
     appendVertices(rgCoords);
-}
-
-void QGCMapPolygon::_polygonModelDirtyChanged(bool dirty)
-{
-    if (dirty) {
-        setDirty(true);
-    }
 }
 
 void QGCMapPolygon::removeVertex(int vertexIndex)

--- a/src/QmlControls/QGCMapPolygon.h
+++ b/src/QmlControls/QGCMapPolygon.h
@@ -16,12 +16,13 @@
 #include <QtXml/QDomElement>
 
 #include "QmlObjectListModel.h"
+#include <QmlObjectListItem.h>
 
 class KMLDomDocument;
 
 /// The QGCMapPolygon class provides a polygon which can be displayed on a map using a map visuals control.
 /// It maintains a representation of the polygon on QVariantList and QmlObjectListModel format.
-class QGCMapPolygon : public QObject
+class QGCMapPolygon : public QmlObjectListItem
 {
     Q_OBJECT
 
@@ -35,7 +36,6 @@ public:
     Q_PROPERTY(QVariantList         path            READ path                                   NOTIFY pathChanged)
     Q_PROPERTY(double               area            READ area                                   NOTIFY pathChanged)
     Q_PROPERTY(QmlObjectListModel*  pathModel       READ qmlPathModel                           CONSTANT)
-    Q_PROPERTY(bool                 dirty           READ dirty          WRITE setDirty          NOTIFY dirtyChanged)
     Q_PROPERTY(QGeoCoordinate       center          READ center         WRITE setCenter         NOTIFY centerChanged)
     Q_PROPERTY(bool                 centerDrag      READ centerDrag     WRITE setCenterDrag     NOTIFY centerDragChanged)
     Q_PROPERTY(bool                 interactive     READ interactive    WRITE setInteractive    NOTIFY interactiveChanged)
@@ -104,8 +104,7 @@ public:
     // Property methods
 
     int             count       (void) const { return _polygonPath.count(); }
-    bool            dirty       (void) const { return _dirty; }
-    void            setDirty    (bool dirty);
+    void            setDirty    (bool dirty) final;
     QGeoCoordinate  center      (void) const { return _center; }
     bool            centerDrag  (void) const { return _centerDrag; }
     bool            interactive (void) const { return _interactive; }
@@ -133,7 +132,6 @@ public:
 signals:
     void countChanged       (int count);
     void pathChanged        (void);
-    void dirtyChanged       (bool dirty);
     void cleared            (void);
     void centerChanged      (QGeoCoordinate center);
     void centerDragChanged  (bool centerDrag);
@@ -146,7 +144,6 @@ signals:
 
 private slots:
     void _polygonModelCountChanged(int count);
-    void _polygonModelDirtyChanged(bool dirty);
     void _updateCenter(void);
 
 private:
@@ -159,7 +156,6 @@ private:
 
     QVariantList        _polygonPath;
     QmlObjectListModel  _polygonModel;
-    bool                _dirty =                false;
     QGeoCoordinate      _center;
     bool                _centerDrag =           false;
     bool                _ignoreCenterUpdates =  false;

--- a/src/QmlControls/QGCMapPolyline.cc
+++ b/src/QmlControls/QGCMapPolyline.cc
@@ -20,8 +20,7 @@
 const char* QGCMapPolyline::jsonPolylineKey = "polyline";
 
 QGCMapPolyline::QGCMapPolyline(QObject* parent)
-    : QObject               (parent)
-    , _dirty                (false)
+    : QmlObjectListItem     (parent)
     , _interactive          (false)
     , _resetActive          (false)
 {
@@ -29,8 +28,7 @@ QGCMapPolyline::QGCMapPolyline(QObject* parent)
 }
 
 QGCMapPolyline::QGCMapPolyline(const QGCMapPolyline& other, QObject* parent)
-    : QObject               (parent)
-    , _dirty                (false)
+    : QmlObjectListItem     (parent)
     , _interactive          (false)
     , _resetActive          (false)
 {
@@ -55,7 +53,7 @@ const QGCMapPolyline& QGCMapPolyline::operator=(const QGCMapPolyline& other)
 
 void QGCMapPolyline::_init(void)
 {
-    connect(&_polylineModel, &QmlObjectListModel::dirtyChanged, this, &QGCMapPolyline::_polylineModelDirtyChanged);
+    connect(&_polylineModel, &QmlObjectListModel::dirtyChanged, this, &QGCMapPolyline::_setIfDirty);
     connect(&_polylineModel, &QmlObjectListModel::countChanged, this, &QGCMapPolyline::_polylineModelCountChanged);
 
     connect(this, &QGCMapPolyline::countChanged, this, &QGCMapPolyline::isValidChanged);
@@ -365,13 +363,6 @@ bool QGCMapPolyline::loadKMLFile(const QString& kmlFile)
     _endResetIfNotActive();
 
     return true;
-}
-
-void QGCMapPolyline::_polylineModelDirtyChanged(bool dirty)
-{
-    if (dirty) {
-        setDirty(true);
-    }
 }
 
 void QGCMapPolyline::_polylineModelCountChanged(int count)

--- a/src/QmlControls/QGCMapPolyline.h
+++ b/src/QmlControls/QGCMapPolyline.h
@@ -14,8 +14,9 @@
 #include <QtPositioning/QGeoCoordinate>
 
 #include "QmlObjectListModel.h"
+#include <QmlObjectListItem.h>
 
-class QGCMapPolyline : public QObject
+class QGCMapPolyline : public QmlObjectListItem
 {
     Q_OBJECT
 
@@ -28,7 +29,6 @@ public:
     Q_PROPERTY(int                  count       READ count                                  NOTIFY countChanged)
     Q_PROPERTY(QVariantList         path        READ path                                   NOTIFY pathChanged)
     Q_PROPERTY(QmlObjectListModel*  pathModel   READ qmlPathModel                           CONSTANT)
-    Q_PROPERTY(bool                 dirty       READ dirty          WRITE setDirty          NOTIFY dirtyChanged)
     Q_PROPERTY(bool                 interactive READ interactive    WRITE setInteractive    NOTIFY interactiveChanged)
     Q_PROPERTY(bool                 isValid     READ isValid                                NOTIFY isValidChanged)
     Q_PROPERTY(bool                 empty       READ empty                                  NOTIFY isEmptyChanged)
@@ -84,8 +84,7 @@ public:
 
     // Property methods
     int             count       (void) const { return _polylinePath.count(); }
-    bool            dirty       (void) const { return _dirty; }
-    void            setDirty    (bool dirty);
+    void            setDirty    (bool dirty) final;
     bool            interactive (void) const { return _interactive; }
     QVariantList    path        (void) const { return _polylinePath; }
     bool            isValid     (void) const { return _polylineModel.count() >= 2; }
@@ -107,7 +106,6 @@ public:
 signals:
     void countChanged       (int count);
     void pathChanged        (void);
-    void dirtyChanged       (bool dirty);
     void cleared            (void);
     void interactiveChanged (bool interactive);
     void isValidChanged     (void);
@@ -117,7 +115,6 @@ signals:
 
 private slots:
     void _polylineModelCountChanged(int count);
-    void _polylineModelDirtyChanged(bool dirty);
 
 private:
     void            _init                   (void);
@@ -128,7 +125,6 @@ private:
 
     QVariantList        _polylinePath;
     QmlObjectListModel  _polylineModel;
-    bool                _dirty;
     bool                _interactive;
     bool                _resetActive;
     bool                _traceMode = false;

--- a/src/QmlControls/QGCQGeoCoordinate.cc
+++ b/src/QmlControls/QGCQGeoCoordinate.cc
@@ -12,9 +12,8 @@
 #include <QtQml/QQmlEngine>
 
 QGCQGeoCoordinate::QGCQGeoCoordinate(const QGeoCoordinate& coord, QObject* parent)
-    : QObject       (parent)
+    : QmlObjectListItem(parent)
     , _coordinate   (coord)
-    , _dirty        (false)
 {
     QQmlEngine::setObjectOwnership(this, QQmlEngine::CppOwnership);
 }
@@ -25,13 +24,5 @@ void QGCQGeoCoordinate::setCoordinate(const QGeoCoordinate& coordinate)
         _coordinate = coordinate;
         emit coordinateChanged(coordinate);
         setDirty(true);
-    }
-}
-
-void QGCQGeoCoordinate::setDirty(bool dirty)
-{
-    if (_dirty != dirty) {
-        _dirty = dirty;
-        emit dirtyChanged(dirty);
     }
 }

--- a/src/QmlControls/QGCQGeoCoordinate.h
+++ b/src/QmlControls/QGCQGeoCoordinate.h
@@ -12,8 +12,10 @@
 #include <QtCore/QObject>
 #include <QtPositioning/QGeoCoordinate>
 
+#include <QmlObjectListItem.h>
+
 /// This is a QGeoCoordinate within a QObject such that it can be used on a QmlObjectListModel
-class QGCQGeoCoordinate : public QObject
+class QGCQGeoCoordinate : public QmlObjectListItem
 {
     Q_OBJECT
 
@@ -21,18 +23,13 @@ public:
     QGCQGeoCoordinate(const QGeoCoordinate& coord, QObject* parent = nullptr);
 
     Q_PROPERTY(QGeoCoordinate   coordinate  READ coordinate WRITE setCoordinate NOTIFY coordinateChanged)
-    Q_PROPERTY(bool             dirty       READ dirty      WRITE setDirty      NOTIFY dirtyChanged)
 
     QGeoCoordinate  coordinate      (void) const { return _coordinate; }
     void            setCoordinate   (const QGeoCoordinate& coordinate);
-    bool            dirty           (void) const { return _dirty; }
-    void            setDirty        (bool dirty);
 
 signals:
     void coordinateChanged  (QGeoCoordinate coordinate);
-    void dirtyChanged       (bool dirty);
 
 private:
     QGeoCoordinate  _coordinate;
-    bool            _dirty;
 };

--- a/src/QmlControls/QmlObjectListItem.cc
+++ b/src/QmlControls/QmlObjectListItem.cc
@@ -1,0 +1,34 @@
+#include "QmlObjectListItem.h"
+
+QmlObjectListItem::QmlObjectListItem(QObject* parent)
+    : QObject(parent)
+{
+
+}
+
+QmlObjectListItem::~QmlObjectListItem()
+{
+
+}
+
+void QmlObjectListItem::setDirty(bool dirty)
+{
+    if (dirty != _dirty) {
+        _dirty = dirty;
+        emit dirtyChanged(dirty);
+    }
+}
+
+void QmlObjectListItem::_setDirty(void)
+{
+    if (!_ignoreDirtyChangeSignals) {
+        setDirty(true);
+    }
+}
+
+void QmlObjectListItem::_setIfDirty(bool dirty)
+{
+    if (dirty) {
+        setDirty(true);
+    }
+}

--- a/src/QmlControls/QmlObjectListItem.h
+++ b/src/QmlControls/QmlObjectListItem.h
@@ -1,0 +1,28 @@
+#pragma once
+
+#include <QtCore/QObject>
+
+class QmlObjectListItem : public QObject
+{
+    Q_OBJECT
+
+public:
+    QmlObjectListItem(QObject* parent = nullptr);
+    ~QmlObjectListItem();
+
+    Q_PROPERTY(bool dirty READ dirty WRITE setDirty NOTIFY dirtyChanged)
+
+    virtual bool dirty(void) const { return _dirty; }
+    virtual void setDirty(bool dirty);
+
+signals:
+    void dirtyChanged(bool dirty);
+
+protected slots:
+    void _setDirty(void);
+    void _setIfDirty(bool dirty);
+
+protected:
+    bool _dirty = false;
+    bool _ignoreDirtyChangeSignals = false;
+};


### PR DESCRIPTION
Provides the required functions to be used in a QmlObjectListModel.
This cuts a bit down on repeated code and makes it more clear where these classes are used.
@DonLakeFlyer This is what I was talking about in my reply to the other PR.