### PR TITLE
CMake: Disable Adding Qml Modules For Now

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -29,15 +29,15 @@ add_subdirectory(Comms)
 add_subdirectory(Compression)
 add_subdirectory(FactSystem)
 add_subdirectory(FirmwarePlugin)
-add_subdirectory(FirstRunPromptDialogs)
-add_subdirectory(FlightDisplay)
-add_subdirectory(FlightMap)
+# add_subdirectory(FirstRunPromptDialogs)
+# add_subdirectory(FlightDisplay)
+# add_subdirectory(FlightMap)
 add_subdirectory(FollowMe)
 add_subdirectory(Geo)
 add_subdirectory(GPS)
 add_subdirectory(Joystick)
 add_subdirectory(MissionManager)
-add_subdirectory(PlanView)
+# add_subdirectory(PlanView)
 add_subdirectory(PositionManager)
 add_subdirectory(QmlControls)
 add_subdirectory(QtLocationPlugin)
@@ -73,14 +73,14 @@ target_link_libraries(QGC
 		CommonAutoPilotPlugin
 		FactSystem
 		FirmwarePlugin
-		FirstRunPromptDialogs
-		FlightMap
-		FlightDisplay
+		# FirstRunPromptDialogs
+		# FlightMap
+		# FlightDisplay
 		FollowMe
 		GPS
 		Joystick
 		MissionManager
-		PlanView
+		# PlanView
 		PositionManager
 		QmlControls
 		Settings

--- a/src/FactSystem/FactControls/CMakeLists.txt
+++ b/src/FactSystem/FactControls/CMakeLists.txt
@@ -19,36 +19,36 @@ target_link_libraries(FactControls
 
 target_include_directories(FactControls INTERFACE ${CMAKE_CURRENT_SOURCE_DIR})
 
-qt_add_qml_module(FactControls
-    URI QGroundControl.FactControls
-    VERSION 1.0
-    QML_FILES
-		AltitudeFactTextField.qml
-		FactBitmask.qml
-		FactCheckBox.qml
-		FactCheckBoxSlider.qml
-		FactComboBox.qml
-		FactLabel.qml
-		FactTextField.qml
-		FactTextFieldGrid.qml
-		FactTextFieldRow.qml
-		FactTextFieldSlider.qml
-		FactValueSlider.qml
-        LabelledFactComboBox.qml
-        LabelledFactSlider.qml
-        LabelledFactTextField.qml
-    OUTPUT_TARGETS FactControls_targets
-    IMPORT_PATH ${QT_QML_OUTPUT_DIRECTORY}
-    IMPORTS
-		QtQuick
-		QtQuick.Controls
-		QtQuick.Dialogs
-		QtQuick.Layouts
-		QGroundControl
-		QGroundControl.Palette
-		QGroundControl.Controls
-		QGroundControl.FactSystem
-		QGroundControl.ScreenTools
-    DEPENDENCIES
-        QtCore
-)
+# qt_add_qml_module(FactControls
+#     URI QGroundControl.FactControls
+#     VERSION 1.0
+#     QML_FILES
+# 		AltitudeFactTextField.qml
+# 		FactBitmask.qml
+# 		FactCheckBox.qml
+# 		FactCheckBoxSlider.qml
+# 		FactComboBox.qml
+# 		FactLabel.qml
+# 		FactTextField.qml
+# 		FactTextFieldGrid.qml
+# 		FactTextFieldRow.qml
+# 		FactTextFieldSlider.qml
+# 		FactValueSlider.qml
+#         LabelledFactComboBox.qml
+#         LabelledFactSlider.qml
+#         LabelledFactTextField.qml
+#     OUTPUT_TARGETS FactControls_targets
+#     IMPORT_PATH ${QT_QML_OUTPUT_DIRECTORY}
+#     IMPORTS
+# 		QtQuick
+# 		QtQuick.Controls
+# 		QtQuick.Dialogs
+# 		QtQuick.Layouts
+# 		QGroundControl
+# 		QGroundControl.Palette
+# 		QGroundControl.Controls
+# 		QGroundControl.FactSystem
+# 		QGroundControl.ScreenTools
+#     DEPENDENCIES
+#         QtCore
+# )


### PR DESCRIPTION
Resources are being double added because of stuff that remains to work with qmake.