### PR TITLE
QGCApplication Cleanup

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -313,17 +313,12 @@ add_subdirectory(src)
 target_link_libraries(${PROJECT_NAME}
     PRIVATE
         Qt6::Core
-        Qt6::Gui
-        Qt6::Qml
         Qt6::Quick
-        Qt6::QuickControls2
         Qt6::Widgets
         Qt6::Svg # Used to import QSvgPlugin
         QGC
-        QGCLocation
         QmlControls
         Utilities
-        Vehicle
 )
 if(QGC_BUILD_TESTING)
     add_subdirectory(test)

--- a/android/src/AndroidInit.cpp
+++ b/android/src/AndroidInit.cpp
@@ -141,5 +141,9 @@ jint JNI_OnLoad(JavaVM* vm, void* reserved)
 
     JoystickAndroid::setNativeMethods();
 
+    AndroidInterface::checkStoragePermissions();
+
+    QNativeInterface::QAndroidApplication::hideSplashScreen(333);
+
     return JNI_VERSION_1_6;
 }

--- a/src/API/QGCCorePlugin.cc
+++ b/src/API/QGCCorePlugin.cc
@@ -292,6 +292,12 @@ void QGCCorePlugin::factValueGridCreateDefaultSettings(const QString& defaultSet
 QQmlApplicationEngine* QGCCorePlugin::createQmlApplicationEngine(QObject* parent)
 {
     QQmlApplicationEngine* qmlEngine = new QQmlApplicationEngine(parent);
+    /* EventDatabase eventDatabase;
+    EventMonitor eventMonitor;
+    qmlEngine->setInitialProperties({
+        { "eventDatabase", QVariant::fromValue(&eventDatabase) },
+        { "eventMonitor", QVariant::fromValue(&eventMonitor) }
+    }); */
     qmlEngine->addImportPath("qrc:/qml");
     qmlEngine->rootContext()->setContextProperty("joystickManager", qgcApp()->toolbox()->joystickManager());
     qmlEngine->rootContext()->setContextProperty("debugMessageModel", AppMessages::getModel());

--- a/src/AnalyzeView/MAVLinkSystem.cc
+++ b/src/AnalyzeView/MAVLinkSystem.cc
@@ -11,9 +11,6 @@
 #include "MAVLinkMessage.h"
 #include "QGCLoggingCategory.h"
 
-#include <QtCharts/QLineSeries>
-#include <QtCharts/QAbstractSeries>
-
 QGC_LOGGING_CATEGORY(MAVLinkSystemLog, "qgc.analyzeview.mavlinksystem")
 
 //-----------------------------------------------------------------------------

--- a/src/AutoPilotPlugins/APM/APMAirframeComponentController.cc
+++ b/src/AutoPilotPlugins/APM/APMAirframeComponentController.cc
@@ -17,9 +17,11 @@
 #include "ArduCopterFirmwarePlugin.h"
 #include "ArduRoverFirmwarePlugin.h"
 
-#include <QVariant>
-#include <QJsonParseError>
-#include <QJsonObject>
+#include <QtCore/QVariant>
+#include <QtCore/QJsonParseError>
+#include <QtCore/QJsonObject>
+#include <QtGui/QCursor>
+#include <QtGui/QGuiApplication>
 
 // These should match the ArduCopter FRAME_CLASS parameter enum meta data
 #define FRAME_CLASS_UNDEFINED       0
@@ -188,7 +190,7 @@ void APMAirframeComponentController::_loadParametersFromDownloadFile(const QStri
     QFile parametersFile(downloadedParamFile);
     if (!parametersFile.open(QIODevice::ReadOnly | QIODevice::Text)) {
         qWarning() << "Unable to open downloaded parameter file" << downloadedParamFile << parametersFile.errorString();
-        qgcApp()->restoreOverrideCursor();
+        QGuiApplication::restoreOverrideCursor();
         return;
     }
 
@@ -206,13 +208,13 @@ void APMAirframeComponentController::_loadParametersFromDownloadFile(const QStri
             param->setRawValue(QVariant::fromValue(aux.at(1)));
         }
     }
-    qgcApp()->restoreOverrideCursor();
+    QGuiApplication::restoreOverrideCursor();
     _vehicle->parameterManager()->refreshAllParameters();
 }
 
 void APMAirframeComponentController::loadParameters(const QString& paramFile)
 {
-    qgcApp()->setOverrideCursor(Qt::WaitCursor);
+    QGuiApplication::overrideCursor()->setShape(Qt::WaitCursor);
 
     QString paramFileUrl = QStringLiteral("https://api.github.com/repos/ArduPilot/ardupilot/contents/Tools/Frame_params/%1?ref=master");
 
@@ -227,7 +229,7 @@ void APMAirframeComponentController::_githubJsonDownloadComplete(QString /*remot
         QFile jsonFile(localFile);
         if (!jsonFile.open(QIODevice::ReadOnly | QIODevice::Text)) {
             qWarning() << "Unable to open github json file" << localFile << jsonFile.errorString();
-            qgcApp()->restoreOverrideCursor();
+            QGuiApplication::restoreOverrideCursor();
             return;
         }
         QByteArray bytes = jsonFile.readAll();
@@ -237,7 +239,7 @@ void APMAirframeComponentController::_githubJsonDownloadComplete(QString /*remot
         QJsonDocument doc = QJsonDocument::fromJson(bytes, &jsonParseError);
         if (jsonParseError.error != QJsonParseError::NoError) {
             qWarning() <<  "Unable to open json document" << localFile << jsonParseError.errorString();
-            qgcApp()->restoreOverrideCursor();
+            QGuiApplication::restoreOverrideCursor();
             return;
         }
         QJsonObject json = doc.object();
@@ -247,7 +249,7 @@ void APMAirframeComponentController::_githubJsonDownloadComplete(QString /*remot
         downloader->download(json[QLatin1String("download_url")].toString());
     } else {
         qgcApp()->showAppMessage(tr("Param file github json download failed: %1").arg(errorMsg));
-        qgcApp()->restoreOverrideCursor();
+        QGuiApplication::restoreOverrideCursor();
     }
 }
 
@@ -257,7 +259,7 @@ void APMAirframeComponentController::_paramFileDownloadComplete(QString /*remote
         _loadParametersFromDownloadFile(localFile);
     } else {
         qgcApp()->showAppMessage(tr("Param file download failed: %1").arg(errorMsg));
-        qgcApp()->restoreOverrideCursor();
+        QGuiApplication::restoreOverrideCursor();
     }
 }
 

--- a/src/AutoPilotPlugins/AutoPilotPlugin.cc
+++ b/src/AutoPilotPlugins/AutoPilotPlugin.cc
@@ -16,6 +16,7 @@
 #include "FirmwarePlugin.h"
 #include "Vehicle.h"
 #include "VehicleComponent.h"
+#include <QtCore/QCoreApplication>
 
 AutoPilotPlugin::AutoPilotPlugin(Vehicle* vehicle, QObject* parent)
     : QObject(parent)
@@ -77,6 +78,6 @@ void AutoPilotPlugin::parametersReadyPreChecks(void)
 
         // Take the user to Vehicle Summary
         qgcApp()->showSetupView();
-        qgcApp()->processEvents(QEventLoop::ExcludeUserInputEvents);
+        QCoreApplication::processEvents(QEventLoop::ExcludeUserInputEvents);
     }
 }

--- a/src/AutoPilotPlugins/PX4/ActuatorComponent.cc
+++ b/src/AutoPilotPlugins/PX4/ActuatorComponent.cc
@@ -21,6 +21,7 @@ ActuatorComponent::ActuatorComponent(Vehicle* vehicle, AutoPilotPlugin* autopilo
     _name(tr("Actuators")), _actuators(*vehicle->actuators())
 {
     if (!imageProviderAdded) {
+        // TODO: qmlAppEngine should not be accessed inside app
         qgcApp()->qmlAppEngine()->addImageProvider(QLatin1String("actuators"), GeometryImage::VehicleGeometryImageProvider::instance());
         imageProviderAdded = true;
     }

--- a/src/AutoPilotPlugins/PX4/AirframeComponentController.cc
+++ b/src/AutoPilotPlugins/PX4/AirframeComponentController.cc
@@ -19,6 +19,7 @@
 
 #include <QtCore/QVariant>
 #include <QtQml/QtQml>
+#include <QtGui/QCursor>
 
 bool AirframeComponentController::_typesRegistered = false;
 
@@ -88,8 +89,8 @@ void AirframeComponentController::changeAutostart(void)
         qgcApp()->showAppMessage(tr("You cannot change airframe configuration while connected to multiple vehicles."));
 		return;
 	}
-	
-    qgcApp()->setOverrideCursor(Qt::WaitCursor);
+
+    QGuiApplication::overrideCursor()->setShape(Qt::WaitCursor);
     
     Fact* sysAutoStartFact  = getParameterFact(-1, "SYS_AUTOSTART");
     Fact* sysAutoConfigFact = getParameterFact(-1, "SYS_AUTOCONFIG");
@@ -120,12 +121,12 @@ void AirframeComponentController::_waitParamWriteSignal(QVariant value)
 void AirframeComponentController::_rebootAfterStackUnwind(void)
 {    
     _vehicle->sendMavCommand(_vehicle->defaultComponentId(), MAV_CMD_PREFLIGHT_REBOOT_SHUTDOWN, true /* showError */, 1.0f);
-    qgcApp()->processEvents(QEventLoop::ExcludeUserInputEvents);
+    QCoreApplication::processEvents(QEventLoop::ExcludeUserInputEvents);
     for (unsigned i = 0; i < 2000; i++) {
         QGC::SLEEP::usleep(500);
-        qgcApp()->processEvents(QEventLoop::ExcludeUserInputEvents);
+        QCoreApplication::processEvents(QEventLoop::ExcludeUserInputEvents);
     }
-    qgcApp()->restoreOverrideCursor();
+    QGuiApplication::restoreOverrideCursor();
     qgcApp()->toolbox()->linkManager()->disconnectAll();
 }
 

--- a/src/Comms/CMakeLists.txt
+++ b/src/Comms/CMakeLists.txt
@@ -25,7 +25,6 @@ target_link_libraries(Comms
 	PRIVATE
 		Qt6::Qml
 		Qt6::Test
-		Qt6::Widgets
 		AirLink
 		MockLink
 		Settings

--- a/src/Comms/LinkManager.cc
+++ b/src/Comms/LinkManager.cc
@@ -86,6 +86,8 @@ LinkManager::LinkManager(QGCApplication* app, QGCToolbox* toolbox)
     qmlRegisterUncreatableType<LinkInterface>("QGroundControl.Vehicle", 1, 0, "LinkInterface", "Reference only");
     qmlRegisterUncreatableType<LogReplayLink>("QGroundControl",         1, 0, "LogReplayLink", "Reference only");
     qmlRegisterType<LogReplayLinkController> ("QGroundControl",         1, 0, "LogReplayLinkController");
+
+    qRegisterMetaType<QAbstractSocket::SocketError>();
 }
 
 LinkManager::~LinkManager()
@@ -662,7 +664,7 @@ void LinkManager::shutdown(void)
 
     // Wait for all the vehicles to go away to ensure an orderly shutdown and deletion of all objects
     while (_toolbox->multiVehicleManager()->vehicles()->count()) {
-        qgcApp()->processEvents(QEventLoop::ExcludeUserInputEvents);
+        QCoreApplication::processEvents(QEventLoop::ExcludeUserInputEvents);
     }
 }
 

--- a/src/Comms/SerialLink.cc
+++ b/src/Comms/SerialLink.cc
@@ -132,7 +132,7 @@ bool SerialLink::_hardwareConnect(QSerialPort::SerialPortError& error, QString& 
         // Wait 50 ms while continuing to run the event queue
         for (unsigned i = 0; i < 10; i++) {
             QGC::SLEEP::usleep(5000);
-            qgcApp()->processEvents(QEventLoop::ExcludeUserInputEvents);
+            QCoreApplication::processEvents(QEventLoop::ExcludeUserInputEvents);
         }
         delete _port;
         _port = nullptr;
@@ -151,7 +151,7 @@ bool SerialLink::_hardwareConnect(QSerialPort::SerialPortError& error, QString& 
                 // Wait 500 ms while continuing to run the event loop
                 for (unsigned i = 0; i < 100; i++) {
                     QGC::SLEEP::msleep(5);
-                    qgcApp()->processEvents(QEventLoop::ExcludeUserInputEvents);
+                    QCoreApplication::processEvents(QEventLoop::ExcludeUserInputEvents);
                 }
                 break;
             }
@@ -159,7 +159,7 @@ bool SerialLink::_hardwareConnect(QSerialPort::SerialPortError& error, QString& 
             // Wait 500 ms while continuing to run the event loop
             for (unsigned i = 0; i < 100; i++) {
                 QGC::SLEEP::msleep(5);
-                qgcApp()->processEvents(QEventLoop::ExcludeUserInputEvents);
+                QCoreApplication::processEvents(QEventLoop::ExcludeUserInputEvents);
             }
         }
         // Check limit
@@ -188,9 +188,9 @@ bool SerialLink::_hardwareConnect(QSerialPort::SerialPortError& error, QString& 
             // Wait 250 ms while continuing to run the event loop
             for (unsigned i = 0; i < 50; i++) {
                 QGC::SLEEP::msleep(5);
-                qgcApp()->processEvents(QEventLoop::ExcludeUserInputEvents);
+                QCoreApplication::processEvents(QEventLoop::ExcludeUserInputEvents);
             }
-            qgcApp()->processEvents(QEventLoop::ExcludeUserInputEvents);
+            QCoreApplication::processEvents(QEventLoop::ExcludeUserInputEvents);
         } else {
             break;
         }

--- a/src/FactSystem/ParameterManager.cc
+++ b/src/FactSystem/ParameterManager.cc
@@ -1220,7 +1220,7 @@ void ParameterManager::_checkInitialLoadComplete(void)
         QString errorMsg = tr("%1 was unable to retrieve the full set of parameters from vehicle %2. "
                               "This will cause %1 to be unable to display its full user interface. "
                               "If you are using modified firmware, you may need to resolve any vehicle startup errors to resolve the issue. "
-                              "If you are using standard firmware, you may need to upgrade to a newer version to resolve the issue.").arg(qgcApp()->applicationName()).arg(_vehicle->id());
+                              "If you are using standard firmware, you may need to upgrade to a newer version to resolve the issue.").arg(QCoreApplication::applicationName()).arg(_vehicle->id());
         qCDebug(ParameterManagerLog) << errorMsg;
         qgcApp()->showAppMessage(errorMsg);
         if (!qgcApp()->runningUnitTests()) {
@@ -1244,7 +1244,7 @@ void ParameterManager::_initialRequestTimeout(void)
     } else {
         if (!_vehicle->genericFirmware()) {
             QString errorMsg = tr("Vehicle %1 did not respond to request for parameters. "
-                                  "This will cause %2 to be unable to display its full user interface.").arg(_vehicle->id()).arg(qgcApp()->applicationName());
+                                  "This will cause %2 to be unable to display its full user interface.").arg(_vehicle->id()).arg(QCoreApplication::applicationName());
             qCDebug(ParameterManagerLog) << errorMsg;
             qgcApp()->showAppMessage(errorMsg);
         }

--- a/src/FirmwarePlugin/FirmwarePlugin.cc
+++ b/src/FirmwarePlugin/FirmwarePlugin.cc
@@ -937,7 +937,7 @@ bool FirmwarePlugin::_armVehicleAndValidate(Vehicle* vehicle)
             break;
         }
         QGC::SLEEP::msleep(100);
-        qgcApp()->processEvents(QEventLoop::ExcludeUserInputEvents);
+        QCoreApplication::processEvents(QEventLoop::ExcludeUserInputEvents);
     }
 
     return vehicleArmed;
@@ -962,7 +962,7 @@ bool FirmwarePlugin::_setFlightModeAndValidate(Vehicle* vehicle, const QString& 
                 break;
             }
             QGC::SLEEP::msleep(100);
-            qgcApp()->processEvents(QEventLoop::ExcludeUserInputEvents);
+            QCoreApplication::processEvents(QEventLoop::ExcludeUserInputEvents);
         }
         if (flightModeChanged) {
             break;

--- a/src/Joystick/JoystickSDL.cc
+++ b/src/Joystick/JoystickSDL.cc
@@ -15,7 +15,7 @@ JoystickSDL::JoystickSDL(const QString& name, int axisCount, int buttonCount, in
 }
 
 bool JoystickSDL::init(void) {
-    // SDL_SetMainReady
+    SDL_SetMainReady();
     if (SDL_InitSubSystem(SDL_INIT_GAMECONTROLLER | SDL_INIT_JOYSTICK) < 0) {
         SDL_JoystickEventState(SDL_ENABLE);
         qWarning() << "Couldn't initialize SimpleDirectMediaLayer:" << SDL_GetError();

--- a/src/Joystick/JoystickSDL.h
+++ b/src/Joystick/JoystickSDL.h
@@ -14,6 +14,8 @@
 
 #include "Joystick.h"
 
+#define SDL_MAIN_HANDLED
+
 #include <SDL.h>
 
 class MultiVehicleManager;

--- a/src/MAVLink/QGCMAVLink.cc
+++ b/src/MAVLink/QGCMAVLink.cc
@@ -23,6 +23,9 @@ constexpr QGCMAVLink::VehicleClass_t QGCMAVLink::VehicleClassMultiRotor;
 constexpr QGCMAVLink::VehicleClass_t QGCMAVLink::VehicleClassVTOL;
 constexpr QGCMAVLink::VehicleClass_t QGCMAVLink::VehicleClassGeneric;
 
+// Mavlink status structures for entire app
+mavlink_status_t m_mavlink_status[MAVLINK_COMM_NUM_BUFFERS];
+
 QGCMAVLink::QGCMAVLink(QObject* parent)
     : QObject(parent)
 {

--- a/src/MissionManager/KMLPlanDomDocument.cc
+++ b/src/MissionManager/KMLPlanDomDocument.cc
@@ -22,7 +22,7 @@ const char* KMLPlanDomDocument::_missionLineStyleName =     "MissionLineStyle";
 const char* KMLPlanDomDocument::surveyPolygonStyleName =   "SurveyPolygonStyle";
 
 KMLPlanDomDocument::KMLPlanDomDocument()
-    : KMLDomDocument(QStringLiteral("%1 Plan KML").arg(qgcApp()->applicationName()))
+    : KMLDomDocument(QStringLiteral("%1 Plan KML").arg(QCoreApplication::applicationName()))
 {
     _addStyles();
 }

--- a/src/MissionManager/LandingComplexItem.cc
+++ b/src/MissionManager/LandingComplexItem.cc
@@ -634,7 +634,7 @@ bool LandingComplexItem::_load(const QJsonObject& complexObject, int sequenceNum
     QString itemType = complexObject[VisualMissionItem::jsonTypeKey].toString();
     QString complexType = complexObject[ComplexMissionItem::jsonComplexItemTypeKey].toString();
     if (itemType != VisualMissionItem::jsonTypeComplexItemValue || complexType != jsonComplexItemTypeValue) {
-        errorString = tr("%1 does not support loading this complex mission item type: %2:%3").arg(qgcApp()->applicationName()).arg(itemType).arg(complexType);
+        errorString = tr("%1 does not support loading this complex mission item type: %2:%3").arg(QCoreApplication::applicationName()).arg(itemType).arg(complexType);
         return false;
     }
 

--- a/src/MissionManager/MissionController.cc
+++ b/src/MissionManager/MissionController.cc
@@ -981,7 +981,7 @@ bool MissionController::_loadTextMissionFile(QTextStream& stream, QmlObjectListM
             }
         }
     } else {
-        errorString = tr("The mission file is not compatible with this version of %1.").arg(qgcApp()->applicationName());
+        errorString = tr("The mission file is not compatible with this version of %1.").arg(QCoreApplication::applicationName());
         return false;
     }
 

--- a/src/MissionManager/SurveyComplexItem.cc
+++ b/src/MissionManager/SurveyComplexItem.cc
@@ -22,6 +22,7 @@
 
 #include <QtGui/QPolygonF>
 #include <QtCore/QJsonArray>
+#include <QtCore/QLineF>
 
 QGC_LOGGING_CATEGORY(SurveyComplexItemLog, "SurveyComplexItemLog")
 

--- a/src/QGCToolbox.cc
+++ b/src/QGCToolbox.cc
@@ -41,6 +41,7 @@
 #endif
 
 QGCToolbox::QGCToolbox(QGCApplication* app)
+    : QObject(app)
 {
     // SettingsManager must be first so settings are available to any subsequent tools
     _settingsManager        = new SettingsManager           (app, this);

--- a/src/QGCToolbox.h
+++ b/src/QGCToolbox.h
@@ -24,7 +24,6 @@ class MissionCommandTree;
 class MultiVehicleManager;
 class QGCMapEngineManager;
 class QGCApplication;
-class QGCImageProvider;
 class UASMessageHandler;
 class QGCPositionManager;
 class VideoManager;
@@ -53,7 +52,6 @@ public:
     MissionCommandTree*         missionCommandTree      () { return _missionCommandTree; }
     MultiVehicleManager*        multiVehicleManager     () { return _multiVehicleManager; }
     QGCMapEngineManager*        mapEngineManager        () { return _mapEngineManager; }
-    QGCImageProvider*           imageProvider           () { return _imageProvider; }
     UASMessageHandler*          uasMessageHandler       () { return _uasMessageHandler; }
     FollowMe*                   followMe                () { return _followMe; }
     QGCPositionManager*         qgcPositionManager      () { return _qgcPositionManager; }
@@ -82,7 +80,6 @@ private:
 #ifndef NO_SERIAL_LINK
     GPSManager*                 _gpsManager             = nullptr;
 #endif
-    QGCImageProvider*           _imageProvider          = nullptr;
     JoystickManager*            _joystickManager        = nullptr;
     LinkManager*                _linkManager            = nullptr;
     MAVLinkProtocol*            _mavlinkProtocol        = nullptr;

--- a/src/QmlControls/CMakeLists.txt
+++ b/src/QmlControls/CMakeLists.txt
@@ -64,7 +64,6 @@ target_link_libraries(QmlControls
 	PRIVATE
 		Qt6::Concurrent
 		Qt6::Location
-		Qt6::Widgets
         FirmwarePlugin
         Geo
         GPS

--- a/src/QmlControls/QGCFileDialogController.cc
+++ b/src/QmlControls/QGCFileDialogController.cc
@@ -12,7 +12,7 @@
 #include "QGCLoggingCategory.h"
 #include "QGCApplication.h"
 #include "SettingsManager.h"
-#include <QDir>
+#include <QtCore/QDir>
 
 QGC_LOGGING_CATEGORY(QGCFileDialogControllerLog, "QGCFileDialogControllerLog")
 
@@ -85,7 +85,7 @@ QString QGCFileDialogController::fullFolderPathToShortMobilePath(const QString& 
     QString defaultSavePath = qgcApp()->toolbox()->settingsManager()->appSettings()->savePath()->rawValueString();
     if (fullFolderPath.startsWith(defaultSavePath)) {
         int lastDirSepIndex = fullFolderPath.lastIndexOf(QStringLiteral("/"));
-        return qgcApp()->applicationName() + QStringLiteral("/") + fullFolderPath.right(fullFolderPath.length() - lastDirSepIndex);
+        return QCoreApplication::applicationName() + QStringLiteral("/") + fullFolderPath.right(fullFolderPath.length() - lastDirSepIndex);
     } else {
         return fullFolderPath;
     }

--- a/src/QmlControls/QGCGeoBoundingCube.cc
+++ b/src/QmlControls/QGCGeoBoundingCube.cc
@@ -8,7 +8,7 @@
  ****************************************************************************/
 
 #include "QGCGeoBoundingCube.h"
-#include <QDebug>
+#include <QtCore/QDebug>
 #include <cmath>
 
 double QGCGeoBoundingCube::MaxAlt    =  1000000.0;

--- a/src/QmlControls/QGCImageProvider.cc
+++ b/src/QmlControls/QGCImageProvider.cc
@@ -9,8 +9,8 @@
 
 #include "QGCImageProvider.h"
 
-#include <QPainter>
-#include <QFont>
+#include <QtGui/QPainter>
+#include <QtGui/QFont>
 
 QGCImageProvider::QGCImageProvider(QQmlImageProviderBase::ImageType imageType)
     : QQuickImageProvider(imageType)

--- a/src/QmlControls/QGroundControlQmlGlobal.cc
+++ b/src/QmlControls/QGroundControlQmlGlobal.cc
@@ -19,11 +19,12 @@
 #include "GPSManager.h"
 #endif
 #include "QGCPalette.h"
-#include <QSettings>
-#include <QLineF>
 #ifdef QT_DEBUG
 #include "MockLink.h"
 #endif
+
+#include <QtCore/QSettings>
+#include <QtCore/QLineF>
 
 static const char* kQmlGlobalKeyName = "QGCQml";
 
@@ -39,7 +40,7 @@ QGroundControlQmlGlobal::QGroundControlQmlGlobal(QGCApplication* app, QGCToolbox
     : QGCTool               (app, toolbox)
 {
     // We clear the parent on this object since we run into shutdown problems caused by hybrid qml app. Instead we let it leak on shutdown.
-    setParent(nullptr);
+    // setParent(nullptr);
 
     // Load last coordinates and zoom from config file
     QSettings settings;
@@ -200,13 +201,13 @@ void QGroundControlQmlGlobal::stopOneMockLink(void)
 
 void QGroundControlQmlGlobal::setIsVersionCheckEnabled(bool enable)
 {
-    qgcApp()->toolbox()->mavlinkProtocol()->enableVersionCheck(enable);
+    _toolbox->mavlinkProtocol()->enableVersionCheck(enable);
     emit isVersionCheckEnabledChanged(enable);
 }
 
 void QGroundControlQmlGlobal::setMavlinkSystemID(int id)
 {
-    qgcApp()->toolbox()->mavlinkProtocol()->setSystemId(id);
+    _toolbox->mavlinkProtocol()->setSystemId(id);
     emit mavlinkSystemIDChanged(id);
 }
 
@@ -271,7 +272,7 @@ void QGroundControlQmlGlobal::setFlightMapZoom(double zoom)
 
 QString QGroundControlQmlGlobal::qgcVersion(void) const
 {
-    QString versionStr = qgcApp()->applicationVersion();
+    QString versionStr = _app->applicationVersion();
     if(QSysInfo::buildAbi().contains("32"))
     {
         versionStr += QStringLiteral(" %1").arg(tr("32 bit"));
@@ -364,7 +365,7 @@ QString QGroundControlQmlGlobal::telemetryFileExtension() const
 
 QString QGroundControlQmlGlobal::appName()
 {
-    return qgcApp()->applicationName();
+    return _app->applicationName();
 }
 
 void QGroundControlQmlGlobal::deleteAllSettingsNextBoot()

--- a/src/QmlControls/QmlObjectListModel.cc
+++ b/src/QmlControls/QmlObjectListModel.cc
@@ -13,8 +13,8 @@
 
 #include "QmlObjectListModel.h"
 
-#include <QDebug>
-#include <QQmlEngine>
+#include <QtCore/QDebug>
+#include <QtQml/QQmlEngine>
 
 const int QmlObjectListModel::ObjectRole = Qt::UserRole;
 const int QmlObjectListModel::TextRole = Qt::UserRole + 1;

--- a/src/QmlControls/ScreenToolsController.cc
+++ b/src/QmlControls/ScreenToolsController.cc
@@ -13,9 +13,9 @@
 
 #include "ScreenToolsController.h"
 #include "QGCApplication.h"
-#include <QFontDatabase>
-#include <QFontMetrics>
-#include <QInputDevice>
+#include <QtGui/QFontDatabase>
+#include <QtGui/QFontMetrics>
+#include <QtGui/QInputDevice>
 
 #include "SettingsManager.h"
 

--- a/src/QmlControls/TerrainProfile.cc
+++ b/src/QmlControls/TerrainProfile.cc
@@ -15,7 +15,7 @@
 #include "QGCLoggingCategory.h"
 #include "QGCApplication.h"
 
-#include <QSGFlatColorMaterial>
+#include <QtQuick/QSGFlatColorMaterial>
 
 QGC_LOGGING_CATEGORY(TerrainProfileLog, "TerrainProfileLog")
 

--- a/src/QtLocationPlugin/CMakeLists.txt
+++ b/src/QtLocationPlugin/CMakeLists.txt
@@ -1,4 +1,4 @@
-find_package(Qt6 REQUIRED COMPONENTS Core Location Network Positioning Qml Sql Widgets)
+find_package(Qt6 REQUIRED COMPONENTS Core Location Network Positioning Qml Sql)
 
 # QGC_NO_GOOGLE_MAPS
 
@@ -50,7 +50,6 @@ target_compile_definitions(QGCLocation PRIVATE CMAKE_LOCATION_PLUGIN)
 target_link_libraries(QGCLocation
 	PRIVATE
 		Qt6::Positioning
-		Qt6::Widgets
 		Settings
 		Utilities
 	PUBLIC

--- a/src/QtLocationPlugin/QGCMapEngine.cpp
+++ b/src/QtLocationPlugin/QGCMapEngine.cpp
@@ -25,6 +25,7 @@
 
 #include <QtCore/QStandardPaths>
 #include <QtCore/QDir>
+#include <QtCore/qapplicationstatic.h>
 
 Q_DECLARE_METATYPE(QGCMapTask::TaskType)
 Q_DECLARE_METATYPE(QGCTile)
@@ -41,22 +42,17 @@ struct stQGeoTileCacheQGCMapTypes {
 };
 
 //-----------------------------------------------------------------------------
-// Singleton
-static QGCMapEngine* kMapEngine = nullptr;
-QGCMapEngine*
-getQGCMapEngine()
+
+Q_APPLICATION_STATIC(QGCMapEngine, s_mapEngine);
+
+QGCMapEngine* QGCMapEngine::instance()
 {
-    if(!kMapEngine)
-        kMapEngine = new QGCMapEngine();
-    return kMapEngine;
+    return s_mapEngine();
 }
 
-//-----------------------------------------------------------------------------
-void
-destroyMapEngine()
+QGCMapEngine* getQGCMapEngine()
 {
-    delete kMapEngine;
-    kMapEngine = nullptr;
+    return QGCMapEngine::instance();
 }
 
 //-----------------------------------------------------------------------------

--- a/src/QtLocationPlugin/QGCMapEngine.h
+++ b/src/QtLocationPlugin/QGCMapEngine.h
@@ -34,6 +34,8 @@ public:
     QGCMapEngine                ();
     ~QGCMapEngine               ();
 
+    static QGCMapEngine* instance();
+
     void                        init                ();
     void                        addTask             (QGCMapTask *task);
     void                        cacheTile           (const QString& type, int x, int y, int z, const QByteArray& image, const QString& format, qulonglong set = UINT64_MAX);
@@ -85,4 +87,3 @@ private:
 };
 
 extern QGCMapEngine*    getQGCMapEngine();
-extern void             destroyMapEngine();

--- a/src/QtLocationPlugin/QGCTileCacheWorker.cpp
+++ b/src/QtLocationPlugin/QGCTileCacheWorker.cpp
@@ -24,7 +24,7 @@
 #include <QtSql/QSqlQuery>
 #include <QtSql/QSqlError>
 #include <QtCore/QDateTime>
-#include <QtWidgets/QApplication>
+#include <QtCore/QCoreApplication>
 #include <QtCore/QFile>
 #include <QtCore/QSettings>
 #ifndef Q_OS_ANDROID
@@ -369,7 +369,7 @@ QGCCacheWorker::_getTileSets(QGCMapTask* mtask)
             set->setCreationDate(QDateTime::fromSecsSinceEpoch(query.value("date").toUInt()));
             _updateSetTotals(set);
             //-- Object created here must be moved to app thread to be used there
-            set->moveToThread(QApplication::instance()->thread());
+            set->moveToThread(QCoreApplication::instance()->thread());
             task->tileSetFetched(set);
         }
     } else {

--- a/src/Settings/AppSettings.cc
+++ b/src/Settings/AppSettings.cc
@@ -88,7 +88,7 @@ DECLARE_SETTINGGROUP(App, "")
     // Instantiate savePath so we can check for override and setup default path if needed
 
     SettingsFact* savePathFact = qobject_cast<SettingsFact*>(savePath());
-    QString appName = qgcApp()->applicationName();
+    QString appName = QCoreApplication::applicationName();
 #ifdef __mobile__
     // Mobile builds always use the runtime generated location for savePath.
     bool userHasModifiedSavePath = false;

--- a/src/Vehicle/MultiVehicleManager.cc
+++ b/src/Vehicle/MultiVehicleManager.cc
@@ -57,6 +57,8 @@ void MultiVehicleManager::setToolbox(QGCToolbox *toolbox)
     qmlRegisterUncreatableType<Vehicle>            ("QGroundControl.Vehicle",             1, 0, "Vehicle",             "Reference only");
     qmlRegisterUncreatableType<VehicleLinkManager> ("QGroundControl.Vehicle",             1, 0, "VehicleLinkManager",  "Reference only");
 
+    qRegisterMetaType<Vehicle::MavCmdResultFailureCode_t>("MavCmdResultFailureCode_t");
+
     connect(_mavlinkProtocol, &MAVLinkProtocol::vehicleHeartbeatInfo, this, &MultiVehicleManager::_vehicleHeartbeatInfo);
     connect(&_gcsHeartbeatTimer, &QTimer::timeout, this, &MultiVehicleManager::_sendGCSHeartbeat);
 
@@ -127,7 +129,7 @@ void MultiVehicleManager::_vehicleHeartbeatInfo(LinkInterface* link, int vehicle
                                       << vehicleType;
 
     if (vehicleId == _mavlinkProtocol->getSystemId()) {
-        _app->showAppMessage(tr("Warning: A vehicle is using the same system id as %1: %2").arg(qgcApp()->applicationName()).arg(vehicleId));
+        _app->showAppMessage(tr("Warning: A vehicle is using the same system id as %1: %2").arg(QCoreApplication::applicationName()).arg(vehicleId));
     }
 
     Vehicle* vehicle = new Vehicle(link, vehicleId, componentId, (MAV_AUTOPILOT)vehicleFirmwareType, (MAV_TYPE)vehicleType, _firmwarePluginManager, _joystickManager);

--- a/src/VideoManager/VideoManager.h
+++ b/src/VideoManager/VideoManager.h
@@ -10,9 +10,12 @@
 
 #pragma once
 
+#include <QtCore/QSize>
+#include <QtCore/QRunnable>
+#include <QtCore/QLoggingCategory>
+
 #include "QGCToolbox.h"
 #include "SubtitleWriter.h"
-#include <QtCore/QSize>
 
 Q_DECLARE_LOGGING_CATEGORY(VideoManagerLog)
 
@@ -165,4 +168,19 @@ protected:
     QString                 _uvcVideoSourceID;
     bool                    _fullScreen             = false;
     Vehicle*                _activeVehicle          = nullptr;
+};
+
+class FinishVideoInitialization : public QRunnable
+{
+public:
+    explicit FinishVideoInitialization(VideoManager* manager)
+        : _manager(manager)
+    {}
+
+    void run () {
+        _manager->_initVideo();
+    }
+
+private:
+    VideoManager* _manager = nullptr;
 };

--- a/test/QGCTest.pri
+++ b/test/QGCTest.pri
@@ -74,6 +74,7 @@ ReleaseBuild {
         $$PWD/qgcunittest/MultiSignalSpyV2.h \
         $$PWD/qgcunittest/UnitTest.h \
         $$PWD/Terrain/TerrainQueryTest.h \
+        $$PWD/UnitTestList.h \
         $$PWD/Vehicle/FTPManagerTest.h \
         $$PWD/Vehicle/InitialConnectTest.h \
         $$PWD/Vehicle/RequestMessageTest.h \

--- a/test/UnitTestList.cc
+++ b/test/UnitTestList.cc
@@ -173,11 +173,6 @@ int runTests(bool stress, QStringView unitTestOptions)
 	int result = 0;
 
     for (int i=0; i < (stress ? 20 : 1); i++) {
-        if (!qgcApp()->_initForUnitTests()) {
-            result = -1;
-            break;
-        }
-
         // Run the test
         const int failures = UnitTest::run(unitTestOptions);
         if (failures == 0) {

--- a/test/qgcunittest/UnitTest.cc
+++ b/test/qgcunittest/UnitTest.cc
@@ -141,7 +141,7 @@ void UnitTest::cleanup(void)
     // If you have a failure whose stack trace points to this then
     // your test is leaking signals or events. It could cause use-after-free or
     // segmentation faults from wild pointers.
-    qgcApp()->processEvents();
+    QCoreApplication::processEvents();
 }
 
 void UnitTest::setExpectedMessageBox(QMessageBox::StandardButton response)


### PR DESCRIPTION
The state of qgcapp has gotten pretty rough over the years and this is an attempt to start to fix it up. 
- Moves code like the mavlink status and video runner into their respective modules.
- Uses the static instance method of qcoreapplication throughout the app instead of qgcApp() when possible.
- Improves cleanup process of the qgcapp, qmlappengine, toolbox, and mapengine.
- Adds consts where possible
- Removes unused member functions and variables.
- Reduces usage of QtWidgets to prep for switch to QGuiApplication when possible.
- Cleans up instantiation and cleanup of qgcapp in the main function.