### PR TITLE
Make QGCImageProvider not a Tool

### DIFF
--- a/src/QGCApplication.cc
+++ b/src/QGCApplication.cc
@@ -16,6 +16,7 @@
  *
  */
 
+#include "QmlControls/QGCImageProvider.h"
 #include <QtCore/QFile>
 #include <QtCore/QRegularExpression>
 #include <QtGui/QFontDatabase>
@@ -477,8 +478,7 @@ bool QGCApplication::_initForNormalAppBoot()
     toolbox()->corePlugin()->createRootWindow(_qmlAppEngine);
 
     // Image provider for PX4 Flow
-    QQuickImageProvider* pImgProvider = dynamic_cast<QQuickImageProvider*>(qgcApp()->toolbox()->imageProvider());
-    _qmlAppEngine->addImageProvider(QStringLiteral("QGCImages"), pImgProvider);
+    _qmlAppEngine->addImageProvider(qgcImageProviderId, new QGCImageProvider());
 
     QQuickWindow* rootWindow = qgcApp()->mainRootWindow();
 
@@ -948,4 +948,9 @@ bool QGCApplication::event(QEvent *e)
         }
     }
     return QApplication::event(e);
+}
+
+QGCImageProvider* QGCApplication::qgcImageProvider()
+{
+    return dynamic_cast<QGCImageProvider*>(_qmlAppEngine->imageProvider(qgcImageProviderId));
 }

--- a/src/QGCApplication.h
+++ b/src/QGCApplication.h
@@ -27,6 +27,7 @@
 class QQmlApplicationEngine;
 class QGCToolbox;
 class QQuickWindow;
+class QGCImageProvider;
 
 /**
  * @brief The main application and management class.
@@ -115,6 +116,8 @@ public slots:
     /// Show modal application message to the user about the need for a reboot. Multiple messages will be supressed if they occur
     /// one after the other.
     void showRebootAppMessage(const QString& message, const QString& title = QString());
+
+    QGCImageProvider* qgcImageProvider();
 
 signals:
     /// This is connected to MAVLinkProtocol::checkForLostLogFiles. We signal this to ourselves to call the slot
@@ -208,6 +211,8 @@ private:
 
     static const char* _settingsVersionKey;             ///< Settings key which hold settings version
     static const char* _deleteAllSettingsKey;           ///< If this settings key is set on boot, all settings will be deleted
+
+    const QString qgcImageProviderId = QStringLiteral("QGCImages");
 
     /// Unit Test have access to creating and destroying singletons
     friend class UnitTest;

--- a/src/QGCToolbox.cc
+++ b/src/QGCToolbox.cc
@@ -18,7 +18,6 @@
 #include "MAVLinkProtocol.h"
 #include "MissionCommandTree.h"
 #include "MultiVehicleManager.h"
-#include "QGCImageProvider.h"
 #include "UASMessageHandler.h"
 #include "QGCMapEngineManager.h"
 #include "FollowMe.h"
@@ -53,7 +52,6 @@ QGCToolbox::QGCToolbox(QGCApplication* app)
 #ifndef NO_SERIAL_LINK
     _gpsManager             = new GPSManager                (app, this);
 #endif
-    _imageProvider          = new QGCImageProvider          (app, this);
     _joystickManager        = new JoystickManager           (app, this);
     _linkManager            = new LinkManager               (app, this);
     _mavlinkProtocol        = new MAVLinkProtocol           (app, this);
@@ -86,7 +84,6 @@ void QGCToolbox::setChildToolboxes(void)
 #ifndef NO_SERIAL_LINK
     _gpsManager->setToolbox(this);
 #endif
-    _imageProvider->setToolbox(this);
     _joystickManager->setToolbox(this);
     _linkManager->setToolbox(this);
     _mavlinkProtocol->setToolbox(this);

--- a/src/QmlControls/QGCImageProvider.cc
+++ b/src/QmlControls/QGCImageProvider.cc
@@ -12,29 +12,23 @@
 #include <QPainter>
 #include <QFont>
 
-QGCImageProvider::QGCImageProvider(QGCApplication *app, QGCToolbox* toolbox)
-    : QGCTool               (app, toolbox)
-    , QQuickImageProvider   (QQmlImageProviderBase::Image)
+QGCImageProvider::QGCImageProvider(QQmlImageProviderBase::ImageType imageType)
+    : QQuickImageProvider(imageType)
 {
-}
-
-QGCImageProvider::~QGCImageProvider()
-{
-
-}
-
-void QGCImageProvider::setToolbox(QGCToolbox *toolbox)
-{
-   QGCTool::setToolbox(toolbox);
-   //-- Dummy temporary image until something comes along
-   _image = QImage(320, 240, QImage::Format_RGBA8888);
-   _image.fill(Qt::black);
-   QPainter painter(&_image);
+    //-- Dummy temporary image until something comes along
+   m_image = QImage(320, 240, QImage::Format_RGBA8888);
+   m_image.fill(Qt::black);
+   QPainter painter(&m_image);
    QFont f = painter.font();
    f.setPixelSize(20);
    painter.setFont(f);
    painter.setPen(Qt::white);
    painter.drawText(QRectF(0, 0, 320, 240), Qt::AlignCenter, "Waiting...");
+}
+
+QGCImageProvider::~QGCImageProvider()
+{
+
 }
 
 QImage QGCImageProvider::requestImage(const QString & /* image url with vehicle id*/, QSize *, const QSize &)
@@ -64,11 +58,10 @@ QImage QGCImageProvider::requestImage(const QString & /* image url with vehicle 
     For now, we don't even look at the URL. This will have to be fixed if we're to support multiple
     vehicles transmitting flow images.
 */
-    return _image;
+    return m_image;
 }
 
 void QGCImageProvider::setImage(QImage* pImage, int /* vehicle id*/)
 {
-    _image = pImage->mirrored();
+    m_image = pImage->mirrored();
 }
-

--- a/src/QmlControls/QGCImageProvider.h
+++ b/src/QmlControls/QGCImageProvider.h
@@ -9,30 +9,24 @@
 
 #pragma once
 
-#include "QGCToolbox.h"
-
 #include <QtCore/QObject>
 #include <QtQuick/QQuickImageProvider>
 
 // This is used to expose images from ImageProtocolHandler
-class QGCImageProvider : public QGCTool, public QQuickImageProvider
+class QGCImageProvider : public QQuickImageProvider
 {
 public:
-    QGCImageProvider        (QGCApplication* app, QGCToolbox* toolbox);
-    ~QGCImageProvider       ();
+    QGCImageProvider(QQmlImageProviderBase::ImageType type = QQmlImageProviderBase::ImageType::Image);
+    ~QGCImageProvider();
 
-    void    setImage        (QImage* pImage, int id = 0);
+    void setImage(QImage* pImage, int id = 0);
 
-    // Overrdies from QQuickImageProvider
-    QImage  requestImage    (const QString& id, QSize* size, const QSize& requestedSize) override;
-
-    // Overrides from QGCTool
-    void    setToolbox      (QGCToolbox *toolbox) override;
+    QImage requestImage(const QString& id, QSize* size, const QSize& requestedSize) override;
 
 private:
     //-- TODO: For now this is holding a single image. If you happen to have two
     //   or more vehicles with flow, it will not work. To properly manage that condition
     //   this should be a map between each vehicle and its image. The URL provided
     //   for the image request would contain the vehicle identification.
-    QImage _image;
+    QImage m_image;
 };

--- a/src/Vehicle/Vehicle.cc
+++ b/src/Vehicle/Vehicle.cc
@@ -2476,7 +2476,7 @@ void Vehicle::_sendQGCTimeToVehicle()
 void Vehicle::_imageProtocolImageReady(void)
 {
     QImage img = _imageProtocolManager->getImage();
-    _toolbox->imageProvider()->setImage(&img, _id);
+    qgcApp()->qgcImageProvider()->setImage(&img, _id);
     _flowImageIndex++;
     emit flowImageIndexChanged();
 }


### PR DESCRIPTION
This should be handled entirely by the qmlappengine. There's no reason for it to be in the toolbox.