### PR TITLE
Correct path to debian (nee ubuntu) installation script

### DIFF
--- a/deploy/vagrant/Vagrantfile
+++ b/deploy/vagrant/Vagrantfile
@@ -76,7 +76,7 @@ Vagrant.configure(2) do |config|
      sudo DEBIAN_FRONTEND=noninteractive apt-get -y -o Dpkg::Options::="--force-confdef" -o Dpkg::Options::="--force-confold" install %{apt_pkgs}
 
      # use common package installation:
-     /usr/bin/env bash /vagrant/tools/setup/ubuntu.sh
+     /usr/bin/env bash /vagrant/tools/setup/install-dependencies-debian.sh
 
      sudo systemctl set-default graphical.target
 

--- a/docs/en/qgc-dev-guide/getting_started/index.md
+++ b/docs/en/qgc-dev-guide/getting_started/index.md
@@ -103,7 +103,7 @@ To see a complete list of all available components in the installer _Select Comp
 
 1. Install Additional Packages (Platform Specific)
 
-   - **Ubuntu:** `bash ./qgroundcontrol/tools/setup/ubuntu.sh`
+   - **Ubuntu:** `bash ./qgroundcontrol/tools/setup/install-dependencies-debian.sh
    - **Fedora:** `sudo dnf install speech-dispatcher SDL2-devel SDL2 systemd-devel patchelf`
    - **Arch Linux:** `pacman -Sy speech-dispatcher patchelf`
    - **OSX** [Setup](https://doc.qt.io/qt-6/macos.html)


### PR DESCRIPTION
4594c382639a32dac3a74a7f32f8f1b59f2476d9 failed to update the Vagrantfile for the changed location of the install script.

This updates the Vagrantfile and a random document which also references it.

The Vagrant machine comes up after this change and successfully builds QGC for me.
