### PR TITLE
FirmwarePlugin: ArduPilot: Add support for changing ground speed for "Go to Location"

### DIFF
--- a/src/FirmwarePlugin/APM/APMFirmwarePlugin.cc
+++ b/src/FirmwarePlugin/APM/APMFirmwarePlugin.cc
@@ -897,6 +897,35 @@ void APMFirmwarePlugin::guidedModeChangeAltitude(Vehicle* vehicle, double altitu
     }
 }
 
+bool APMFirmwarePlugin::mulirotorSpeedLimitsAvailable(Vehicle* vehicle)
+{
+    return vehicle->parameterManager()->parameterExists(FactSystem::defaultComponentId, "WPNAV_SPEED");
+}
+
+double APMFirmwarePlugin::maximumHorizontalSpeedMultirotor(Vehicle* vehicle)
+{
+    QString speedParam("WPNAV_SPEED");
+
+    if (vehicle->parameterManager()->parameterExists(FactSystem::defaultComponentId, speedParam)) {
+        return vehicle->parameterManager()->getParameter(FactSystem::defaultComponentId, speedParam)->rawValue().toDouble() * 0.01;  // note cm/s -> m/s
+    }
+
+    return FirmwarePlugin::maximumHorizontalSpeedMultirotor(vehicle);
+}
+
+void APMFirmwarePlugin::guidedModeChangeGroundSpeedMetersSecond(Vehicle *vehicle, double groundspeed)
+{
+    vehicle->sendMavCommand(
+        vehicle->defaultComponentId(),
+        MAV_CMD_DO_CHANGE_SPEED,
+        true,                                   // show error is fails
+        1,                                     // 0: airspeed, 1: groundspeed
+        static_cast<float>(groundspeed),       // groundspeed setpoint
+        -1,                                   // throttle
+        0,                                    // 0: absolute speed, 1: relative to current
+        NAN, NAN,NAN);                        // param 5-7 unused
+}
+
 void APMFirmwarePlugin::guidedModeTakeoff(Vehicle* vehicle, double altitudeRel)
 {
     _guidedModeTakeoff(vehicle, altitudeRel);

--- a/src/FirmwarePlugin/APM/APMFirmwarePlugin.h
+++ b/src/FirmwarePlugin/APM/APMFirmwarePlugin.h
@@ -87,6 +87,11 @@ public:
     void                guidedModeChangeEquivalentAirspeedMetersSecond(Vehicle* vehicle, double airspeed_equiv) override;
     QVariant            mainStatusIndicatorContentItem  (const Vehicle* vehicle) const override;
 
+    // support for changing speed in Copter guide mode:
+    bool mulirotorSpeedLimitsAvailable(Vehicle* vehicle);
+    double maximumHorizontalSpeedMultirotor(Vehicle* vehicle);
+    void guidedModeChangeGroundSpeedMetersSecond(Vehicle *vehicle, double speed);
+
 protected:
     /// All access to singleton is through stack specific implementation
     APMFirmwarePlugin(void);


### PR DESCRIPTION
Adds methods to the ArduPilot subclass sufficient to activate the existing interface elements.

Tested using ArduCopter in simulation:

![image](https://github.com/mavlink/qgroundcontrol/assets/7077857/af4dcf97-4530-44e5-a7e4-2a3bf72a8a73)

![image](https://github.com/mavlink/qgroundcontrol/assets/7077857/e0a0e7a3-4c7b-4b2d-85bd-1d13a4385932)
