### PR TITLE
Hardware: Add support for JFB110

### DIFF
--- a/src/Comms/USBBoardInfo.json
+++ b/src/Comms/USBBoardInfo.json
@@ -40,6 +40,8 @@
 
         { "vendorID": 11694, "productID": 0,        "boardClass": "Pixhawk",    "name": "CubePilot" },
 
+        { "vendorID": 2702,  "productID": 110,      "boardClass": "Pixhawk",    "name": "JFB JFB110" },
+
         { "vendorID": 13735, "productID": 1,        "boardClass": "Pixhawk",    "name": "ThePeach FCC-K1" },
         { "vendorID": 13735, "productID": 2,        "boardClass": "Pixhawk",    "name": "ThePeach FCC-R1" },
 
@@ -86,6 +88,8 @@
         { "regExp": "^PX4 BL ASC v1.x$",    "boardClass": "Pixhawk" },
         { "regExp": "^PX4 FMU",             "boardClass": "Pixhawk" },
         { "regExp": "^PX4 Crazyflie v2.0",  "boardClass": "Pixhawk" },
+        { "regExp": "^JFB JFB110$",         "boardClass": "Pixhawk" },
+        { "regExp": "^JFB BL JFB110$",      "boardClass": "Pixhawk" },
         { "regExp": "^Crazyflie BL",        "boardClass": "Pixhawk" },
         { "regExp": "^PX4 OmnibusF4SD",     "boardClass": "Pixhawk" },
         { "regExp": "^fmuv[2345]$",         "boardClass": "Pixhawk" },

--- a/src/VehicleSetup/FirmwareUpgradeController.cc
+++ b/src/VehicleSetup/FirmwareUpgradeController.cc
@@ -99,6 +99,7 @@ static QMap<int, QString> px4_board_name_map {
     {1048, "holybro_kakuteh7_default"},
     {1053, "holybro_kakuteh7v2_default"},
     {1054, "holybro_kakuteh7mini_default"},
+    {1110, "jfb_jfb110_default"},    
 };
 
 uint qHash(const FirmwareUpgradeController::FirmwareIdentifier& firmwareId)


### PR DESCRIPTION
This adds support for the new JFB110 board of Japan Aviation Electronics Industry Ltd.

sorry, I closed PR by mistake, so I'll post it again.
