### PR TITLE
Disable Unit Testing on qmake

### DIFF
--- a/qgroundcontrol.pro
+++ b/qgroundcontrol.pro
@@ -1345,4 +1345,4 @@ else {
        src/UTMSP/dummy/utmsp_dummy.qrc
 }
 
-include(test/QGCTest.pri)
+# include(test/QGCTest.pri)

--- a/test/QGCTest.pri
+++ b/test/QGCTest.pri
@@ -29,7 +29,9 @@ ReleaseBuild {
         $$PWD/Terrain \
         $$PWD/UI \
         $$PWD/Utilities/Compression \
-        $$PWD/Vehicle
+        $$PWD/Vehicle \
+        $$PWD/Vehicle/Components \
+        $$PWD
 
     HEADERS += \
         #$$PWD/AnalyzeView/LogDownloadTest.h \


### PR DESCRIPTION
Since qmake is deprecated, disable unit testing so we can edit tests easier under cmake.