### PR TITLE
Vehicle: Move Generic Code to MAVLink Module

### DIFF
--- a/src/AutoPilotPlugins/APM/APMSensorsComponent.qml
+++ b/src/AutoPilotPlugins/APM/APMSensorsComponent.qml
@@ -22,6 +22,7 @@ import QGroundControl.ScreenTools
 import QGroundControl.Controllers
 import QGroundControl.ArduPilot
 import QGroundControl.QGCPositionManager
+import MAVLink
 
 SetupPage {
     id:             sensorsPage
@@ -166,8 +167,8 @@ SetupPage {
 
                 onCalibrationComplete: {
                     switch (calType) {
-                    case APMSensorsComponentController.CalTypeAccel:
-                    case APMSensorsComponentController.CalTypeOnboardCompass:
+                    case MAVLink.CalibrationAccel:
+                    case MAVLink.CalibrationMag:
                         _singleCompassSettingsComponentShowPriority = true
                         postOnboardCompassCalibrationComponent.createObject(mainWindow).open()
                         break

--- a/src/AutoPilotPlugins/APM/APMSensorsComponentController.h
+++ b/src/AutoPilotPlugins/APM/APMSensorsComponentController.h
@@ -10,7 +10,7 @@
 #pragma once
 
 #include "FactPanelController.h"
-#include "MAVLinkLib.h"
+#include "QGCMAVLink.h"
 
 #include <QtQuick/QQuickItem>
 #include <QtCore/QObject>
@@ -95,18 +95,6 @@ public:
     bool compassSetupNeeded (void) const;
     bool accelSetupNeeded   (void) const;
 
-    typedef enum {
-        CalTypeAccel,
-        CalTypeGyro,
-        CalTypeOnboardCompass,
-        CalTypeLevelHorizon,
-        CalTypeCompassMot,
-        CalTypePressure,
-        CalTypeAccelFast,
-        CalTypeNone
-    } CalType_t;
-    Q_ENUM(CalType_t)
-
     bool compass1CalSucceeded(void) const { return _rgCompassCalSucceeded[0]; }
     bool compass2CalSucceeded(void) const { return _rgCompassCalSucceeded[1]; }
     bool compass3CalSucceeded(void) const { return _rgCompassCalSucceeded[2]; }
@@ -125,7 +113,7 @@ signals:
     void resetStatusTextArea                    (void);
     void waitingForCancelChanged                (void);
     void setupNeededChanged                     (void);
-    void calibrationComplete                    (CalType_t calType);
+    void calibrationComplete                    (QGCMAVLink::CalibrationType calType);
     void compass1CalSucceededChanged            (bool compass1CalSucceeded);
     void compass2CalSucceededChanged            (bool compass2CalSucceeded);
     void compass3CalSucceededChanged            (bool compass3CalSucceeded);
@@ -172,7 +160,7 @@ private:
     
     bool _showOrientationCalArea;
     
-    CalType_t _calTypeInProgress;
+    QGCMAVLink::CalibrationType _calTypeInProgress;
 
     uint8_t _rgCompassCalProgress[3];
     bool    _rgCompassCalComplete[3];

--- a/src/AutoPilotPlugins/Common/RadioComponentController.cc
+++ b/src/AutoPilotPlugins/Common/RadioComponentController.cc
@@ -800,7 +800,7 @@ void RadioComponentController::_startCalibration(void)
     _resetInternalCalibrationValues();
 
     // Let the mav known we are starting calibration. This should turn off motors and so forth.
-    _vehicle->startCalibration(Vehicle::CalibrationRadio);
+    _vehicle->startCalibration(QGCMAVLink::CalibrationRadio);
 
     _nextButton->setProperty("text", tr("Next"));
     _cancelButton->setEnabled(true);
@@ -1025,7 +1025,7 @@ void RadioComponentController::_signalAllAttitudeValueChanges(void)
 
 void RadioComponentController::copyTrims(void)
 {
-    _vehicle->startCalibration(Vehicle::CalibrationCopyTrims);
+    _vehicle->startCalibration(QGCMAVLink::CalibrationCopyTrims);
 }
 
 bool RadioComponentController::_px4Vehicle(void) const

--- a/src/AutoPilotPlugins/PX4/PowerComponentController.cc
+++ b/src/AutoPilotPlugins/PX4/PowerComponentController.cc
@@ -19,7 +19,7 @@ void PowerComponentController::calibrateEsc(void)
 {
     _warningMessages.clear();
     connect(_vehicle, &Vehicle::textMessageReceived, this, &PowerComponentController::_handleVehicleTextMessage);
-    _vehicle->startCalibration(Vehicle::CalibrationEsc);
+    _vehicle->startCalibration(QGCMAVLink::CalibrationEsc);
 }
 
 void PowerComponentController::startBusConfigureActuators(void)

--- a/src/AutoPilotPlugins/PX4/SensorsComponentController.cc
+++ b/src/AutoPilotPlugins/PX4/SensorsComponentController.cc
@@ -196,31 +196,31 @@ void SensorsComponentController::_stopCalibration(SensorsComponentController::St
 void SensorsComponentController::calibrateGyro(void)
 {
     _startLogCalibration();
-    _vehicle->startCalibration(Vehicle::CalibrationGyro);
+    _vehicle->startCalibration(QGCMAVLink::CalibrationGyro);
 }
 
 void SensorsComponentController::calibrateCompass(void)
 {
     _startLogCalibration();
-    _vehicle->startCalibration(Vehicle::CalibrationMag);
+    _vehicle->startCalibration(QGCMAVLink::CalibrationMag);
 }
 
 void SensorsComponentController::calibrateAccel(void)
 {
     _startLogCalibration();
-    _vehicle->startCalibration(Vehicle::CalibrationAccel);
+    _vehicle->startCalibration(QGCMAVLink::CalibrationAccel);
 }
 
 void SensorsComponentController::calibrateLevel(void)
 {
     _startLogCalibration();
-    _vehicle->startCalibration(Vehicle::CalibrationLevel);
+    _vehicle->startCalibration(QGCMAVLink::CalibrationLevel);
 }
 
 void SensorsComponentController::calibrateAirspeed(void)
 {
     _startLogCalibration();
-    _vehicle->startCalibration(Vehicle::CalibrationPX4Airspeed);
+    _vehicle->startCalibration(QGCMAVLink::CalibrationPX4Airspeed);
 }
 
 void SensorsComponentController::_handleUASTextMessage(int uasId, int compId, int severity, QString text)

--- a/src/MAVLink/ImageProtocolManager.h
+++ b/src/MAVLink/ImageProtocolManager.h
@@ -13,8 +13,8 @@
 
 #include <QtCore/QObject>
 #include <QtCore/QByteArray>
-#include <QtGui/QImage>
 #include <QtCore/QLoggingCategory>
+#include <QtGui/QImage>
 
 Q_DECLARE_LOGGING_CATEGORY(ImageProtocolManagerLog)
 

--- a/src/MAVLink/MAVLinkFTP.h
+++ b/src/MAVLink/MAVLinkFTP.h
@@ -10,8 +10,11 @@
 #pragma once
 
 #include <QtCore/QString>
+#include <QtCore/QLoggingCategory>
 
 #include "MAVLinkLib.h"
+
+Q_DECLARE_LOGGING_CATEGORY(MavlinkFTPLog)
 
 class MavlinkFTP {
 public:

--- a/src/MAVLink/MAVLinkStreamConfig.h
+++ b/src/MAVLink/MAVLinkStreamConfig.h
@@ -10,6 +10,9 @@
 #pragma once
 
 #include <QtCore/QVector>
+#include <QtCore/QLoggingCategory>
+
+Q_DECLARE_LOGGING_CATEGORY(MAVLinkStreamConfigLog)
 
 /**
  * @class MAVLinkStreamConfig

--- a/src/MAVLink/QGCMAVLink.h
+++ b/src/MAVLink/QGCMAVLink.h
@@ -12,12 +12,18 @@
 #include <QtCore/QObject>
 #include <QtCore/QString>
 #include <QtCore/QList>
+#include <QtCore/QLoggingCategory>
+#include <QtQmlIntegration/QtQmlIntegration>
 
 #include "MAVLinkLib.h"
+
+Q_DECLARE_LOGGING_CATEGORY(QGCMAVLinkLog)
 
 class QGCMAVLink : public QObject
 {
     Q_OBJECT
+    QML_ELEMENT
+    QML_UNCREATABLE("")
 
 public:
     // Creating an instance of QGCMAVLink is only meant to be used for the Qml Singleton
@@ -62,6 +68,10 @@ public:
 
     static QString                  mavResultToString           (MAV_RESULT result);
     static QString                  mavSysStatusSensorToString  (MAV_SYS_STATUS_SENSOR sysStatusSensor);
+    static QString                  mavTypeToString             (MAV_TYPE mavType);
+    static QString                  firmwareVersionTypeToString (FIRMWARE_VERSION_TYPE firmwareVersionType);
+    static int                      motorCount                  (MAV_TYPE mavType, uint8_t frameType = 0);
+    static uint32_t                 highLatencyFailuresToMavSysStatus(mavlink_high_latency2_t& highLatency2);
 
     // Expose mavlink enums to Qml. I've tried various way to make this work without duping, but haven't found anything that works.
 
@@ -86,4 +96,60 @@ public:
        MAV_BATTERY_CHARGE_STATE_CHARGING=7, /* Battery is charging. | */
     };
     Q_ENUM(MAV_BATTERY_CHARGE_STATE)
+
+    /// Sensor bits from sensors*Bits properties
+    enum MavlinkSysStatus {
+        SysStatusSensor3dGyro =                 MAV_SYS_STATUS_SENSOR_3D_GYRO,
+        SysStatusSensor3dAccel =                MAV_SYS_STATUS_SENSOR_3D_ACCEL,
+        SysStatusSensor3dMag =                  MAV_SYS_STATUS_SENSOR_3D_MAG,
+        SysStatusSensorAbsolutePressure =       MAV_SYS_STATUS_SENSOR_ABSOLUTE_PRESSURE,
+        SysStatusSensorDifferentialPressure =   MAV_SYS_STATUS_SENSOR_DIFFERENTIAL_PRESSURE,
+        SysStatusSensorGPS =                    MAV_SYS_STATUS_SENSOR_GPS,
+        SysStatusSensorOpticalFlow =            MAV_SYS_STATUS_SENSOR_OPTICAL_FLOW,
+        SysStatusSensorVisionPosition =         MAV_SYS_STATUS_SENSOR_VISION_POSITION,
+        SysStatusSensorLaserPosition =          MAV_SYS_STATUS_SENSOR_LASER_POSITION,
+        SysStatusSensorExternalGroundTruth =    MAV_SYS_STATUS_SENSOR_EXTERNAL_GROUND_TRUTH,
+        SysStatusSensorAngularRateControl =     MAV_SYS_STATUS_SENSOR_ANGULAR_RATE_CONTROL,
+        SysStatusSensorAttitudeStabilization =  MAV_SYS_STATUS_SENSOR_ATTITUDE_STABILIZATION,
+        SysStatusSensorYawPosition =            MAV_SYS_STATUS_SENSOR_YAW_POSITION,
+        SysStatusSensorZAltitudeControl =       MAV_SYS_STATUS_SENSOR_Z_ALTITUDE_CONTROL,
+        SysStatusSensorXYPositionControl =      MAV_SYS_STATUS_SENSOR_XY_POSITION_CONTROL,
+        SysStatusSensorMotorOutputs =           MAV_SYS_STATUS_SENSOR_MOTOR_OUTPUTS,
+        SysStatusSensorRCReceiver =             MAV_SYS_STATUS_SENSOR_RC_RECEIVER,
+        SysStatusSensor3dGyro2 =                MAV_SYS_STATUS_SENSOR_3D_GYRO2,
+        SysStatusSensor3dAccel2 =               MAV_SYS_STATUS_SENSOR_3D_ACCEL2,
+        SysStatusSensor3dMag2 =                 MAV_SYS_STATUS_SENSOR_3D_MAG2,
+        SysStatusSensorGeoFence =               MAV_SYS_STATUS_GEOFENCE,
+        SysStatusSensorAHRS =                   MAV_SYS_STATUS_AHRS,
+        SysStatusSensorTerrain =                MAV_SYS_STATUS_TERRAIN,
+        SysStatusSensorReverseMotor =           MAV_SYS_STATUS_REVERSE_MOTOR,
+        SysStatusSensorLogging =                MAV_SYS_STATUS_LOGGING,
+        SysStatusSensorBattery =                MAV_SYS_STATUS_SENSOR_BATTERY,
+    };
+    Q_ENUM(MavlinkSysStatus)
+
+    enum GRIPPER_OPTIONS {
+        Gripper_release = GRIPPER_ACTION_RELEASE,
+        Gripper_grab    = GRIPPER_ACTION_GRAB,
+        Invalid_option  = GRIPPER_ACTIONS_ENUM_END,
+    };
+    Q_ENUM(GRIPPER_OPTIONS)
+
+    enum CalibrationType {
+        CalibrationNone,
+        CalibrationRadio,
+        CalibrationGyro,
+        CalibrationMag,
+        CalibrationAccel,
+        CalibrationLevel,
+        CalibrationEsc,
+        CalibrationCopyTrims,
+        CalibrationAPMCompassMot,
+        CalibrationAPMPressureAirspeed,
+        CalibrationAPMPreFlight,
+        CalibrationPX4Airspeed,
+        CalibrationPX4Pressure,
+        CalibrationAPMAccelSimple,
+    };
+    Q_ENUM(CalibrationType)
 };

--- a/src/MAVLink/SysStatusSensorInfo.h
+++ b/src/MAVLink/SysStatusSensorInfo.h
@@ -13,6 +13,9 @@
 
 #include <QtCore/QMap>
 #include <QtCore/QObject>
+#include <QtCore/QLoggingCategory>
+
+Q_DECLARE_LOGGING_CATEGORY(SysStatusSensorInfoLog)
 
 /// Class which represents sensor info from the SYS_STATUS mavlink message
 class SysStatusSensorInfo : public QObject

--- a/src/Vehicle/Vehicle.h
+++ b/src/Vehicle/Vehicle.h
@@ -133,37 +133,6 @@ public:
 
     ~Vehicle();
 
-    /// Sensor bits from sensors*Bits properties
-    enum MavlinkSysStatus {
-        SysStatusSensor3dGyro =                 MAV_SYS_STATUS_SENSOR_3D_GYRO,
-        SysStatusSensor3dAccel =                MAV_SYS_STATUS_SENSOR_3D_ACCEL,
-        SysStatusSensor3dMag =                  MAV_SYS_STATUS_SENSOR_3D_MAG,
-        SysStatusSensorAbsolutePressure =       MAV_SYS_STATUS_SENSOR_ABSOLUTE_PRESSURE,
-        SysStatusSensorDifferentialPressure =   MAV_SYS_STATUS_SENSOR_DIFFERENTIAL_PRESSURE,
-        SysStatusSensorGPS =                    MAV_SYS_STATUS_SENSOR_GPS,
-        SysStatusSensorOpticalFlow =            MAV_SYS_STATUS_SENSOR_OPTICAL_FLOW,
-        SysStatusSensorVisionPosition =         MAV_SYS_STATUS_SENSOR_VISION_POSITION,
-        SysStatusSensorLaserPosition =          MAV_SYS_STATUS_SENSOR_LASER_POSITION,
-        SysStatusSensorExternalGroundTruth =    MAV_SYS_STATUS_SENSOR_EXTERNAL_GROUND_TRUTH,
-        SysStatusSensorAngularRateControl =     MAV_SYS_STATUS_SENSOR_ANGULAR_RATE_CONTROL,
-        SysStatusSensorAttitudeStabilization =  MAV_SYS_STATUS_SENSOR_ATTITUDE_STABILIZATION,
-        SysStatusSensorYawPosition =            MAV_SYS_STATUS_SENSOR_YAW_POSITION,
-        SysStatusSensorZAltitudeControl =       MAV_SYS_STATUS_SENSOR_Z_ALTITUDE_CONTROL,
-        SysStatusSensorXYPositionControl =      MAV_SYS_STATUS_SENSOR_XY_POSITION_CONTROL,
-        SysStatusSensorMotorOutputs =           MAV_SYS_STATUS_SENSOR_MOTOR_OUTPUTS,
-        SysStatusSensorRCReceiver =             MAV_SYS_STATUS_SENSOR_RC_RECEIVER,
-        SysStatusSensor3dGyro2 =                MAV_SYS_STATUS_SENSOR_3D_GYRO2,
-        SysStatusSensor3dAccel2 =               MAV_SYS_STATUS_SENSOR_3D_ACCEL2,
-        SysStatusSensor3dMag2 =                 MAV_SYS_STATUS_SENSOR_3D_MAG2,
-        SysStatusSensorGeoFence =               MAV_SYS_STATUS_GEOFENCE,
-        SysStatusSensorAHRS =                   MAV_SYS_STATUS_AHRS,
-        SysStatusSensorTerrain =                MAV_SYS_STATUS_TERRAIN,
-        SysStatusSensorReverseMotor =           MAV_SYS_STATUS_REVERSE_MOTOR,
-        SysStatusSensorLogging =                MAV_SYS_STATUS_LOGGING,
-        SysStatusSensorBattery =                MAV_SYS_STATUS_SENSOR_BATTERY,
-    };
-    Q_ENUM(MavlinkSysStatus)
-
     enum CheckList {
         CheckListNotSetup = 0,
         CheckListPassed,
@@ -519,7 +488,6 @@ public:
     MAV_AUTOPILOT firmwareType() const { return _firmwareType; }
     MAV_TYPE vehicleType() const { return _vehicleType; }
     QGCMAVLink::VehicleClass_t vehicleClass(void) const { return QGCMAVLink::vehicleClass(_vehicleType); }
-    Q_INVOKABLE QString vehicleTypeName() const;
     Q_INVOKABLE QString vehicleClassInternalName() const;
 
     /// Sends a message to the specified link
@@ -556,16 +524,8 @@ public:
      * @param gripperAction Gripper action to trigger
     */
 
-    enum    GRIPPER_OPTIONS
-    {
-    Gripper_release = GRIPPER_ACTION_RELEASE,
-    Gripper_grab    = GRIPPER_ACTION_GRAB,
-    Invalid_option  = GRIPPER_ACTIONS_ENUM_END,
-    };
-    Q_ENUM(GRIPPER_OPTIONS)
-
     void setGripperAction(GRIPPER_ACTIONS gripperAction);
-    Q_INVOKABLE void sendGripperAction(GRIPPER_OPTIONS gripperOption);
+    Q_INVOKABLE void sendGripperAction(QGCMAVLink::GRIPPER_OPTIONS gripperOption);
 
     void pairRX(int rxType, int rxSubType);
 
@@ -667,7 +627,7 @@ public:
     bool            readyToFly                  () const{ return _readyToFly; }
     bool            allSensorsHealthy           () const{ return _allSensorsHealthy; }
     QObject*        sysStatusSensorInfo         () { return &_sysStatusSensorInfo; }
-    bool            requiresGpsFix              () const { return static_cast<bool>(_onboardControlSensorsPresent & SysStatusSensorGPS); }
+    bool            requiresGpsFix              () const { return static_cast<bool>(_onboardControlSensorsPresent & QGCMAVLink::SysStatusSensorGPS); }
     bool            hilMode                     () const { return _base_mode & MAV_MODE_FLAG_HIL_ENABLED; }
     Actuators*      actuators                   () const { return _actuators; }
 
@@ -675,23 +635,7 @@ public:
     /// @return the maximum version
     unsigned        maxProtoVersion         () const { return _maxProtoVersion; }
 
-    enum CalibrationType {
-        CalibrationRadio,
-        CalibrationGyro,
-        CalibrationMag,
-        CalibrationAccel,
-        CalibrationLevel,
-        CalibrationEsc,
-        CalibrationCopyTrims,
-        CalibrationAPMCompassMot,
-        CalibrationAPMPressureAirspeed,
-        CalibrationAPMPreFlight,
-        CalibrationPX4Airspeed,
-        CalibrationPX4Pressure,
-        CalibrationAPMAccelSimple,
-    };
-
-    void startCalibration   (CalibrationType calType);
+    void startCalibration   (QGCMAVLink::CalibrationType calType);
     void stopCalibration    (bool showError);
 
     void startUAVCANBusConfig(void);


### PR DESCRIPTION
This is generic mavlink code and doesn't have to belong to a vehicle type.