### PR TITLE
Android: Fix Checking Storage Permissions

### DIFF
--- a/android/src/AndroidInit.cpp
+++ b/android/src/AndroidInit.cpp
@@ -141,8 +141,6 @@ jint JNI_OnLoad(JavaVM* vm, void* reserved)
 
     JoystickAndroid::setNativeMethods();
 
-    AndroidInterface::checkStoragePermissions();
-
     QNativeInterface::QAndroidApplication::hideSplashScreen(333);
 
     return JNI_VERSION_1_6;

--- a/src/main.cc
+++ b/src/main.cc
@@ -21,6 +21,10 @@
     #include "RunGuard.h"
 #endif
 
+#ifdef Q_OS_ANDROID
+    #include "AndroidInterface.h"
+#endif
+
 #ifdef QT_DEBUG
 
 #include "CmdLineOptParser.h"
@@ -208,6 +212,10 @@ int main(int argc, char *argv[])
     } else
 #endif
     {
+        #ifdef Q_OS_ANDROID
+            AndroidInterface::checkStoragePermissions();
+        #endif
+
         exitCode = app.exec();
     }
 


### PR DESCRIPTION
If storage permissions are denied, then it gets stuck in the splashscreen.