### PR TITLE
PositionManager: Update Sources

### DIFF
--- a/src/PositionManager/CMakeLists.txt
+++ b/src/PositionManager/CMakeLists.txt
@@ -1,4 +1,4 @@
-find_package(Qt6 REQUIRED COMPONENTS Core Positioning)
+find_package(Qt6 REQUIRED COMPONENTS Core Qml Positioning)
 
 qt_add_library(PositionManager STATIC
     PositionManager.cpp
@@ -9,8 +9,10 @@ qt_add_library(PositionManager STATIC
 
 target_link_libraries(PositionManager
     PRIVATE
+        Qt6::Qml
         Qt6::PositioningPrivate
         API
+        Utilities
         Vehicle
     PUBLIC
         Qt6::Core

--- a/src/PositionManager/PositionManager.h
+++ b/src/PositionManager/PositionManager.h
@@ -9,65 +9,84 @@
 
 #pragma once
 
+#include <QtCore/QLoggingCategory>
+#include <QtPositioning/QGeoCoordinate>
+#include <QtPositioning/QGeoPositionInfo>
+
 #include "QGCToolbox.h"
-#include <QtPositioning/QGeoPositionInfoSource>
 
+Q_DECLARE_LOGGING_CATEGORY(QGCPositionManagerLog)
+
+class QGeoPositionInfoSource;
 class QNmeaPositionInfoSource;
+class QGCCompass;
 
-class QGCPositionManager : public QGCTool {
+class QGCPositionManager : public QGCTool
+{
     Q_OBJECT
 
+    Q_PROPERTY(QGeoCoordinate gcsPosition                   READ gcsPosition                    NOTIFY gcsPositionChanged)
+    Q_PROPERTY(qreal          gcsHeading                    READ gcsHeading                     NOTIFY gcsHeadingChanged)
+    Q_PROPERTY(qreal          gcsPositionHorizontalAccuracy READ gcsPositionHorizontalAccuracy  NOTIFY gcsPositionHorizontalAccuracyChanged)
+
 public:
-    static constexpr size_t MinHorizonalAccuracyMeters = 100;
-    QGCPositionManager(QGCApplication* app, QGCToolbox* toolbox);
+    QGCPositionManager(QGCApplication *app, QGCToolbox *toolbox);
     ~QGCPositionManager();
 
-    Q_PROPERTY(QGeoCoordinate gcsPosition  READ gcsPosition  NOTIFY gcsPositionChanged)
-    Q_PROPERTY(qreal          gcsHeading   READ gcsHeading   NOTIFY gcsHeadingChanged)
-    Q_PROPERTY(qreal          gcsPositionHorizontalAccuracy  READ gcsPositionHorizontalAccuracy
-                                                             NOTIFY gcsPositionHorizontalAccuracyChanged)
+    void setToolbox(QGCToolbox *toolbox) final;
 
     enum QGCPositionSource {
         Simulated,
         InternalGPS,
         Log,
-        NmeaGPS
+        NmeaGPS,
+        ExternalGPS
     };
 
-    QGeoCoordinate      gcsPosition         (void) { return _gcsPosition; }
-    qreal               gcsHeading          (void) const{ return _gcsHeading; }
-    qreal               gcsPositionHorizontalAccuracy(void) const { return _gcsPositionHorizontalAccuracy; }
-    QGeoPositionInfo    geoPositionInfo     (void) const { return _geoPositionInfo; }
-    void                setPositionSource   (QGCPositionSource source);
-    int                 updateInterval      (void) const;
-    void                setNmeaSourceDevice (QIODevice* device);
+    QGeoCoordinate gcsPosition() const { return m_gcsPosition; }
+    qreal gcsHeading() const { return m_gcsHeading; }
+    qreal gcsPositionHorizontalAccuracy() const { return m_gcsPositionHorizontalAccuracy; }
+    QGeoPositionInfo geoPositionInfo() const { return m_geoPositionInfo; }
+    int updateInterval() const { return m_updateInterval; }
 
-    // Overrides from QGCTool
-    void setToolbox(QGCToolbox* toolbox) override;
-
-
-private slots:
-    void _positionUpdated(const QGeoPositionInfo &update);
-    void _error(QGeoPositionInfoSource::Error positioningError);
+    void setNmeaSourceDevice(QIODevice *device);
 
 signals:
     void gcsPositionChanged(QGeoCoordinate gcsPosition);
     void gcsHeadingChanged(qreal gcsHeading);
     void positionInfoUpdated(QGeoPositionInfo update);
-    void gcsPositionHorizontalAccuracyChanged();
+    void gcsPositionHorizontalAccuracyChanged(qreal gcsPositionHorizontalAccuracy);
+
+private slots:
+    void _positionUpdated(const QGeoPositionInfo &update);
 
 private:
-    void _setupPositionSources(QGCToolbox *toolbox);
+    void _setPositionSource(QGCPositionSource source);
+    void _setupPositionSources();
+    void _handlePermissionStatus(Qt::PermissionStatus permissionStatus);
+    void _checkPermission();
+    void _setGCSHeading(qreal newGCSHeading);
+    void _setGCSPosition(const QGeoCoordinate &newGCSPosition);
 
-    int                 _updateInterval =   0;
-    QGeoPositionInfo    _geoPositionInfo;
-    QGeoCoordinate      _gcsPosition;
-    qreal               _gcsHeading =       qQNaN();
-    qreal               _gcsPositionHorizontalAccuracy = std::numeric_limits<qreal>::infinity();
+    bool m_usingPluginSource = false;
+    int m_updateInterval = 0;
 
-    QGeoPositionInfoSource*     _currentSource =        nullptr;
-    QGeoPositionInfoSource*     _defaultSource =        nullptr;
-    QNmeaPositionInfoSource*    _nmeaSource =           nullptr;
-    QGeoPositionInfoSource*     _simulatedSource =      nullptr;
-    bool                        _usingPluginSource =    false;
+    QGeoPositionInfo m_geoPositionInfo;
+    QGeoCoordinate m_gcsPosition;
+    qreal m_gcsHeading = qQNaN();
+    qreal m_gcsPositionHorizontalAccuracy = std::numeric_limits<qreal>::infinity();
+    qreal m_gcsPositionVerticalAccuracy = std::numeric_limits<qreal>::infinity();
+    qreal m_gcsPositionAccuracy = std::numeric_limits<qreal>::infinity();
+    qreal m_gcsDirectionAccuracy = std::numeric_limits<qreal>::infinity();
+
+    QGeoPositionInfoSource *m_currentSource = nullptr;
+    QGeoPositionInfoSource *m_defaultSource = nullptr;
+    QNmeaPositionInfoSource *m_nmeaSource = nullptr;
+    QGeoPositionInfoSource *m_simulatedSource = nullptr;
+
+    QGCCompass *m_compass = nullptr;
+
+    static constexpr qreal s_minHorizonalAccuracyMeters = 100.;
+    static constexpr qreal s_minVerticalAccuracyMeters = 10.;
+    static constexpr qreal s_minDirectionAccuracyDegrees = 30.;
 };

--- a/src/Utilities/CMakeLists.txt
+++ b/src/Utilities/CMakeLists.txt
@@ -55,7 +55,6 @@ endif()
 
 target_link_libraries(Utilities
     PRIVATE
-        Qt6::Bluetooth
         Qt6::Qml
         shp
         FactSystem
@@ -68,8 +67,16 @@ target_link_libraries(Utilities
         Qt6::Gui
         Qt6::Network
         Qt6::Positioning
-                Qt6::Sensors
+        Qt6::Sensors
         Qt6::Xml
 )
+
+if(QGC_ENABLE_BLUETOOTH)
+    target_link_libraries(Utilities
+        PRIVATE
+            Qt6::Bluetooth
+    )
+endif()
+
 
 target_include_directories(Utilities PUBLIC ${CMAKE_CURRENT_SOURCE_DIR})


### PR DESCRIPTION
Preps PositionManager to use more positioning sources. I have another PR coming up that preps the GPS module to use external connected gps's (other than base stations for RTK, which is currently the only GPS type supported) for positioning sources. This adds the ability to use QtSensors compass for the heading, but doesn't enable it yet (although in testing it works and shows up in Qml). Also does general code quality improvements.