### PR TITLE
Do not REQUEST_DATA_STREAMs by default, since it's deprecated

### DIFF
--- a/src/Settings/App.SettingsGroup.json
+++ b/src/Settings/App.SettingsGroup.json
@@ -253,7 +253,7 @@
     "name":                 "apmStartMavlinkStreams",
     "shortDesc":     "Request start of MAVLink telemetry streams (ArduPilot only)",
     "type":                 "bool",
-    "default":         true,
+    "default":         false,
     "qgcRebootRequired":    true
 },
 {


### PR DESCRIPTION
Proof: https://mavlink.io/en/messages/common.html#REQUEST_DATA_STREAM

<!--- Title -->

Description
-----------
MavLink command REQUEST_DATA_STREAM is DEPRECATED: Replaced by MAV_CMD_SET_MESSAGE_INTERVAL. 
So, QGroundControl shouldn't use it by default.

Test Steps
-----------

1. Install QGroundControl on clean machine where it wasn't installed before or wipe QGroundControl saved settings.
2. Go to Application Settings, Telemetry, Stream Rates.
3. See default setting of "Controlled By vehicle" checkbox slider (when it's ON it means REQUEST_DATA_STREAM is disabled).

Checklist:
----------
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] [Review Contribution Guidelines](https://github.com/mavlink/qgroundcontrol/blob/master/.github/CONTRIBUTING.md).
- [x] [Review Code of Conduct](https://github.com/mavlink/qgroundcontrol/blob/master/.github/CODE_OF_CONDUCT.md).
- [x] I have tested my changes.

Related Issue
-----------
#8304 


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.