### PR TITLE
CI: Android Remove Ignore Path

### DIFF
--- a/.github/workflows/android.yml
+++ b/.github/workflows/android.yml
@@ -8,12 +8,10 @@ on:
     tags:
       - 'v*'
     paths-ignore:
-      - 'android/**'
       - 'deploy/**'
       - 'docs/**'
   pull_request:
     paths-ignore:
-      - 'android/**'
       - 'deploy/**'
       - 'docs/**'
       - '.github/workflows/docs_deploy.yml'


### PR DESCRIPTION
CI tests aren't running for android when only the android directory is changed.