### PR TITLE
VideoManager: Fix GStreamer & UVC Setup

### DIFF
--- a/qgroundcontrol.pro
+++ b/qgroundcontrol.pro
@@ -1232,9 +1232,6 @@ contains (CONFIG, DISABLE_VIDEOSTREAMING) {
     HEADERS += \
         src/VideoManager/VideoReceiver/GStreamer/GLVideoItemStub.h \
         src/VideoManager/VideoReceiver/VideoReceiver.h
-
-    SOURCES += \
-        src/VideoManager/VideoReceiver/GStreamer/GLVideoItemStub.cc
 }
 
 #-------------------------------------------------------------------------------------

--- a/src/API/QGCCorePlugin.cc
+++ b/src/API/QGCCorePlugin.cc
@@ -15,11 +15,12 @@
 #include "SettingsManager.h"
 #include "AppMessages.h"
 #include "QmlObjectListModel.h"
-#include "VideoManager.h"
 #include "JoystickManager.h"
 #if defined(QGC_GST_STREAMING)
 #include "GStreamer.h"
 #endif
+#include "VideoManager.h"
+#include "VideoReceiver.h"
 #include "HorizontalFactValueGrid.h"
 #include "InstrumentValueData.h"
 #include "QGCLoggingCategory.h"

--- a/src/Camera/MavlinkCameraControl.h
+++ b/src/Camera/MavlinkCameraControl.h
@@ -41,8 +41,8 @@ public:
     Q_PROPERTY(qreal        hfov                READ hfov               NOTIFY infoChanged)
     Q_PROPERTY(bool         isThermal           READ isThermal          NOTIFY infoChanged)
 
-    QString uri             () { return QString(_streamInfo.uri);  }
-    QString name            () { return QString(_streamInfo.name); }
+    QString uri             () const { return QString(_streamInfo.uri);  }
+    QString name            () const { return QString(_streamInfo.name); }
     qreal   aspectRatio     () const;
     qreal   hfov            () const{ return _streamInfo.hfov; }
     int     type            () const{ return _streamInfo.type; }

--- a/src/QGCApplication.cc
+++ b/src/QGCApplication.cc
@@ -16,7 +16,6 @@
  *
  */
 
-#include "QmlControls/QGCImageProvider.h"
 #include <QtCore/QFile>
 #include <QtCore/QRegularExpression>
 #include <QtGui/QFontDatabase>
@@ -27,10 +26,6 @@
 #include <QtNetwork/QNetworkProxyFactory>
 #include <QtQml/QQmlContext>
 #include <QtQml/QQmlApplicationEngine>
-
-#if defined(QGC_GST_STREAMING)
-#include "GStreamer.h"
-#endif
 
 #include "QGCConfig.h"
 #include "QGCApplication.h"
@@ -242,16 +237,6 @@ QGCApplication::QGCApplication(int &argc, char* argv[], bool unitTesting)
 
     // Set up our logging filters
     QGCLoggingCategoryRegister::instance()->setFilterRulesFromSettings(loggingOptions);
-
-#if defined(QGC_GST_STREAMING)
-    // Gstreamer debug settings
-    int gstDebugLevel = 0;
-    if (settings.contains(AppSettings::gstDebugLevelName)) {
-        gstDebugLevel = settings.value(AppSettings::gstDebugLevelName).toInt();
-    }
-    // Initialize Video Receiver
-    GStreamer::initialize(argc, argv, gstDebugLevel);
-#endif
 
     // We need to set language as early as possible prior to loading on JSON files.
     setLanguage();

--- a/src/Settings/CMakeLists.txt
+++ b/src/Settings/CMakeLists.txt
@@ -51,6 +51,8 @@ target_link_libraries(Settings
         API
         QmlControls
         Vehicle
+        VideoManager
+        VideoReceiver
     PUBLIC
         Qt6::Core
         Qt6::Qml

--- a/src/Settings/VideoSettings.cc
+++ b/src/Settings/VideoSettings.cc
@@ -27,23 +27,16 @@ DECLARE_SETTINGGROUP(Video, "Video")
     QVariantList videoSourceList;
 #ifdef QGC_GST_STREAMING
     videoSourceList.append(videoSourceRTSP);
-#ifndef NO_UDP_VIDEO
     videoSourceList.append(videoSourceUDPH264);
     videoSourceList.append(videoSourceUDPH265);
-#endif
     videoSourceList.append(videoSourceTCP);
     videoSourceList.append(videoSourceMPEGTS);
     videoSourceList.append(videoSource3DRSolo);
     videoSourceList.append(videoSourceParrotDiscovery);
     videoSourceList.append(videoSourceYuneecMantisG);
-#endif
-
-#ifdef QGC_HERELINK_AIRUNIT_VIDEO
     videoSourceList.append(videoSourceHerelinkAirUnit);
-#else
     videoSourceList.append(videoSourceHerelinkHotspot);
 #endif
-
 #ifndef QGC_DISABLE_UVC
     QList<QCameraDevice> videoInputs = QMediaDevices::videoInputs();
     for (const auto& cameraDevice: videoInputs) {
@@ -179,9 +172,6 @@ DECLARE_SETTINGSFACT_NO_FUNC(VideoSettings, tcpUrl)
 
 bool VideoSettings::streamConfigured(void)
 {
-#if !defined(QGC_GST_STREAMING)
-    return false;
-#endif
     //-- First, check if it's autoconfigured
     if(qgcApp()->toolbox()->videoManager()->autoStreamConfigured()) {
         qCDebug(VideoManagerLog) << "Stream auto configured";
@@ -222,6 +212,15 @@ bool VideoSettings::streamConfigured(void)
         qCDebug(VideoManagerLog) << "Stream configured for Herelink Hotspot";
         return true;
     }
+#ifndef QGC_DISABLE_UVC
+    const QList<QCameraDevice> videoInputs = QMediaDevices::videoInputs();
+    for (const auto& cameraDevice: videoInputs) {
+        if(vSource == cameraDevice.description()) {
+            qCDebug(VideoManagerLog) << "Stream configured for UVC";
+            return true;
+        }
+    }
+#endif
     return false;
 }
 

--- a/src/Vehicle/CMakeLists.txt
+++ b/src/Vehicle/CMakeLists.txt
@@ -46,6 +46,7 @@ target_link_libraries(Vehicle
         MockLink
         Utilities
         UTMSP
+        VideoManager
     PUBLIC
         Qt6::Core
         Qt6::Gui

--- a/src/VideoManager/CMakeLists.txt
+++ b/src/VideoManager/CMakeLists.txt
@@ -15,6 +15,7 @@ target_link_libraries(VideoManager
         Camera
         FactSystem
         QmlControls
+        QtMultimediaReceiver
         Settings
         Utilities
         Vehicle
@@ -22,8 +23,6 @@ target_link_libraries(VideoManager
         Qt6::Core
         GStreamerReceiver
         QGC
-        QtMultimediaReceiver
-        VideoReceiver
 )
 
 target_include_directories(VideoManager PUBLIC ${CMAKE_CURRENT_SOURCE_DIR})

--- a/src/VideoManager/SubtitleWriter.cc
+++ b/src/VideoManager/SubtitleWriter.cc
@@ -26,13 +26,22 @@
 #include <QtCore/QDateTime>
 #include <QtCore/QString>
 #include <QtCore/QFileInfo>
+#include <QtCore/QTimer>
 
-QGC_LOGGING_CATEGORY(SubtitleWriterLog, "SubtitleWriterLog")
+QGC_LOGGING_CATEGORY(SubtitleWriterLog, "qgc.videomanager.subtitlewriter")
 
 SubtitleWriter::SubtitleWriter(QObject* parent)
     : QObject(parent)
+    , _timer(new QTimer(this))
 {
-    connect(&_timer, &QTimer::timeout, this, &SubtitleWriter::_captureTelemetry);
+    // qCDebug(SubtitleWriterLog) << Q_FUNC_INFO << this;
+
+    (void) connect(_timer, &QTimer::timeout, this, &SubtitleWriter::_captureTelemetry);
+}
+
+SubtitleWriter::~SubtitleWriter()
+{
+    // qCDebug(SubtitleWriterLog) << Q_FUNC_INFO << this;
 }
 
 void SubtitleWriter::startCapturingTelemetry(const QString& videoFile)
@@ -91,13 +100,13 @@ void SubtitleWriter::startCapturingTelemetry(const QString& videoFile)
     // TODO: Find a good way to input title
     //stream << QStringLiteral("Dialogue: 0,0:00:00.00,999:00:00.00,Default,,0,0,0,,{\\pos(5,35)}%1\n");
 
-    _timer.start(1000/_sampleRate);
+    _timer->start(1000/_sampleRate);
 }
 
 void SubtitleWriter::stopCapturingTelemetry()
 {
     qCDebug(SubtitleWriterLog) << "Stopping writing";
-    _timer.stop();
+    _timer->stop();
     _file.close();
 }
 

--- a/src/VideoManager/SubtitleWriter.h
+++ b/src/VideoManager/SubtitleWriter.h
@@ -17,12 +17,12 @@
 #pragma once
 
 #include <QtCore/QObject>
-#include <QtCore/QTimer>
 #include <QtCore/QTime>
 #include <QtCore/QFile>
 #include <QtCore/QLoggingCategory>
 
 class Fact;
+class QTimer;
 
 Q_DECLARE_LOGGING_CATEGORY(SubtitleWriterLog)
 
@@ -32,10 +32,10 @@ class SubtitleWriter : public QObject
 
 public:
     explicit SubtitleWriter(QObject* parent = nullptr);
-    ~SubtitleWriter() = default;
+    ~SubtitleWriter();
 
     // starts capturing vehicle telemetry.
-    void startCapturingTelemetry(const QString& videoFile);
+    void startCapturingTelemetry(const QString &videoFile);
     void stopCapturingTelemetry();
 
 private slots:
@@ -43,7 +43,7 @@ private slots:
     void _captureTelemetry();
 
 private:
-    QTimer _timer;
+    QTimer* _timer = nullptr;
     QList<Fact*> _facts;
     QTime _lastEndTime;
     QFile _file;

--- a/src/VideoManager/VideoReceiver/GStreamer/CMakeLists.txt
+++ b/src/VideoManager/VideoReceiver/GStreamer/CMakeLists.txt
@@ -9,7 +9,6 @@ message(STATUS "Building GStreamer VideoReceiver")
 find_package(Qt6 REQUIRED COMPONENTS Core Quick)
 
 qt_add_library(GStreamerReceiver STATIC
-    GLVideoItemStub.cc
     GLVideoItemStub.h
     gstqgc.c
     gstqgcvideosinkbin.c

--- a/src/VideoManager/VideoReceiver/GStreamer/GLVideoItemStub.cc
+++ b/src/VideoManager/VideoReceiver/GStreamer/GLVideoItemStub.cc
@@ -1,9 +1,0 @@
-#include "GLVideoItemStub.h"
-
-GLVideoItemStub::GLVideoItemStub()
-{
-}
-
-GLVideoItemStub::~GLVideoItemStub()
-{
-}

--- a/src/VideoManager/VideoReceiver/GStreamer/GLVideoItemStub.h
+++ b/src/VideoManager/VideoReceiver/GStreamer/GLVideoItemStub.h
@@ -7,11 +7,6 @@ class GLVideoItemStub : public QQuickItem
     Q_OBJECT
 
 public:
-    GLVideoItemStub();
-    ~GLVideoItemStub();
-
-protected:
-
-private:
-
+    GLVideoItemStub() = default;
+    ~GLVideoItemStub() = default;
 };


### PR DESCRIPTION
VideoManager had some issues that this addresses. For example, you could not use a UVC device without gstreamer being enabled despite the fact that UVC doesn't use gstreamer. Also the handling of multiple video receivers was never finished and this resolves some of the unfinished work. One particular issue is that the entire video manager was essentially disabled without gstreamer, which makes it impossible to use for custom builds that provide a video sink from a different source (They could override the VideoManager but that is unecessary).