### PR TITLE
Joystick: Fix SDL Closing

### DIFF
--- a/src/Joystick/Joystick.cc
+++ b/src/Joystick/Joystick.cc
@@ -113,6 +113,8 @@ Joystick::Joystick(const QString& name, int axisCount, int buttonCount, int hatC
     , _multiVehicleManager  (multiVehicleManager)
     , _customActionManager  (qgcApp()->toolbox()->settingsManager()->customMavlinkActionsSettings()->joystickActionsFile())
 {
+    // qCDebug(JoystickLog) << Q_FUNC_INFO << this;
+
     qRegisterMetaType<GRIPPER_ACTIONS>();
 
     _rgAxisValues   = new int[static_cast<size_t>(_axisCount)];
@@ -152,6 +154,8 @@ Joystick::~Joystick()
             _buttonActionArray[button]->deleteLater();
         }
     }
+
+    // qCDebug(JoystickLog) << Q_FUNC_INFO << this;
 }
 
 void Joystick::_setDefaultCalibration(void) {

--- a/src/Joystick/JoystickManager.cc
+++ b/src/Joystick/JoystickManager.cc
@@ -33,16 +33,19 @@ JoystickManager::JoystickManager(QGCApplication* app, QGCToolbox* toolbox)
     , _activeJoystick(nullptr)
     , _multiVehicleManager(nullptr)
 {
+    // qCDebug(JoystickManagerLog) << Q_FUNC_INFO << this;
 }
 
-JoystickManager::~JoystickManager() {
+JoystickManager::~JoystickManager()
+{
     QMap<QString, Joystick*>::iterator i;
     for (i = _name2JoystickMap.begin(); i != _name2JoystickMap.end(); ++i) {
         qCDebug(JoystickManagerLog) << "Releasing joystick:" << i.key();
         i.value()->stop();
         delete i.value();
     }
-    qDebug() << "Done";
+
+    // qCDebug(JoystickManagerLog) << Q_FUNC_INFO << this;
 }
 
 void JoystickManager::setToolbox(QGCToolbox *toolbox)

--- a/src/Joystick/JoystickSDL.h
+++ b/src/Joystick/JoystickSDL.h
@@ -25,6 +25,7 @@ class JoystickSDL : public Joystick
 {
 public:
     JoystickSDL(const QString& name, int axisCount, int buttonCount, int hatCount, int index, bool isGameController, MultiVehicleManager* multiVehicleManager);
+    ~JoystickSDL();
 
     static QMap<QString, Joystick*> discover(MultiVehicleManager* _multiVehicleManager); 
     static bool init(void);


### PR DESCRIPTION
- Enable proper closing of SDL Joysticks (disabled due to crashes during closing).
- Fix double updating of SDL joysticks each loop of thread.
- Disable SDL Joystick Events if subsystem failed to initialize (probably redundant but whatever).