### PR TITLE
Camera: switch to new REQUEST_MESSAGE commands

### DIFF
--- a/src/Camera/QGCCameraManager.cc
+++ b/src/Camera/QGCCameraManager.cc
@@ -78,7 +78,8 @@ void QGCCameraManager::_vehicleReady(bool ready)
 void QGCCameraManager::_mavlinkMessageReceived(const mavlink_message_t& message)
 {
     //-- Only pay attention to camera components, as identified by their compId
-    if(message.sysid == _vehicle->id() && (message.compid >= MAV_COMP_ID_CAMERA && message.compid <= MAV_COMP_ID_CAMERA6)) {
+    if(message.sysid == _vehicle->id() && (message.compid == MAV_COMP_ID_AUTOPILOT1 ||
+        (message.compid >= MAV_COMP_ID_CAMERA && message.compid <= MAV_COMP_ID_CAMERA6))) {
         switch (message.msgid) {
             case MAVLINK_MSG_ID_CAMERA_CAPTURE_STATUS:
                 _handleCaptureStatus(message);

--- a/src/Camera/QGCCameraManager.cc
+++ b/src/Camera/QGCCameraManager.cc
@@ -127,7 +127,7 @@ void QGCCameraManager::_handleHeartbeat(const mavlink_message_t &message)
         pInfo->lastHeartbeat.start();
         _cameraInfoRequest[sCompID] = pInfo;
         //-- Request camera info
-        _requestCameraInfo(message.compid);
+        _requestCameraInfo(message.compid, pInfo->tryCount);
     } else {
         if(_cameraInfoRequest[sCompID]) {
             CameraStruct* pInfo = _cameraInfoRequest[sCompID];
@@ -146,7 +146,7 @@ void QGCCameraManager::_handleHeartbeat(const mavlink_message_t &message)
                     } else {
                         pInfo->tryCount++;
                         //-- Request camera info again.
-                        _requestCameraInfo(message.compid);
+                        _requestCameraInfo(message.compid, pInfo->tryCount);
                     }
                 }
             }
@@ -398,15 +398,25 @@ QGCCameraManager::_handleTrackingImageStatus(const mavlink_message_t& message)
 
 //-----------------------------------------------------------------------------
 void
-QGCCameraManager::_requestCameraInfo(int compID)
+QGCCameraManager::_requestCameraInfo(int compID, int tryCount)
 {
     qCDebug(CameraManagerLog) << "_requestCameraInfo(" << compID << ")";
     if(_vehicle) {
-        _vehicle->sendMavCommand(
-            compID,                                 // target component
-            MAV_CMD_REQUEST_CAMERA_INFORMATION,     // command id
-            false,                                  // showError
-            1);                                     // Do Request
+        // The MAV_CMD_REQUEST_CAMERA_INFORMATION command is deprecated, so we
+        // only fall back to it on the second and every other try.
+        if (tryCount % 2 == 0) {
+            _vehicle->sendMavCommand(
+                compID,                                 // target component
+                MAV_CMD_REQUEST_MESSAGE,                // command id
+                false,                                  // showError
+                MAVLINK_MSG_ID_CAMERA_INFORMATION);     // msgid
+        } else {
+            _vehicle->sendMavCommand(
+                compID,                                 // target component
+                MAV_CMD_REQUEST_CAMERA_INFORMATION,     // command id
+                false,                                  // showError
+                1);                                     // Do Request
+        }
     }
 }
 

--- a/src/Camera/QGCCameraManager.h
+++ b/src/Camera/QGCCameraManager.h
@@ -68,7 +68,7 @@ protected slots:
 
 protected:
     virtual MavlinkCameraControl* _findCamera(int id);
-    virtual void    _requestCameraInfo      (int compID);
+    virtual void    _requestCameraInfo      (int compID, int tryCount);
     virtual void    _handleHeartbeat        (const mavlink_message_t& message);
     virtual void    _handleCameraInfo       (const mavlink_message_t& message);
     virtual void    _handleStorageInfo      (const mavlink_message_t& message);

--- a/src/Camera/VehicleCameraControl.cc
+++ b/src/Camera/VehicleCameraControl.cc
@@ -698,7 +698,7 @@ VehicleCameraControl::_mavCommandResult(int vehicleId, int component, int comman
                 break;
                 case MAV_CMD_IMAGE_START_CAPTURE:
                 case MAV_CMD_IMAGE_STOP_CAPTURE:
-                    if(++_captureInfoRetries < 3) {
+                    if(++_captureInfoRetries < 5) {
                         _captureStatusTimer.start(1000);
                     } else {
                         qCDebug(CameraControlLog) << "Giving up start/stop image capture";
@@ -706,14 +706,14 @@ VehicleCameraControl::_mavCommandResult(int vehicleId, int component, int comman
                     }
                     break;
                 case MAV_CMD_REQUEST_CAMERA_CAPTURE_STATUS:
-                    if(++_captureInfoRetries < 3) {
+                    if(++_captureInfoRetries < 5) {
                         _captureStatusTimer.start(500);
                     } else {
                         qCDebug(CameraControlLog) << "Giving up requesting capture status";
                     }
                     break;
                 case MAV_CMD_REQUEST_STORAGE_INFORMATION:
-                    if(++_storageInfoRetries < 3) {
+                    if(++_storageInfoRetries < 5) {
                         QTimer::singleShot(500, this, &VehicleCameraControl::_requestStorageInfo);
                     } else {
                         qCDebug(CameraControlLog) << "Giving up requesting storage status";
@@ -1413,11 +1413,22 @@ VehicleCameraControl::_requestCameraSettings()
 {
     qCDebug(CameraControlLog) << "_requestCameraSettings()";
     if(_vehicle) {
-        _vehicle->sendMavCommand(
-            _compID,                                // Target component
-            MAV_CMD_REQUEST_CAMERA_SETTINGS,        // command id
-            false,                                  // showError
-            1);                                     // Do Request
+        // Use REQUEST_MESSAGE instead of deprecated REQUEST_CAMERA_SETTINGS
+        // first time and every other time after that.
+
+        if(_cameraSettingsRetries++ % 2 == 0) {
+            _vehicle->sendMavCommand(
+                _compID,                                 // target component
+                MAV_CMD_REQUEST_MESSAGE,                // command id
+                false,                                  // showError
+                MAVLINK_MSG_ID_CAMERA_SETTINGS);        // msgid
+        } else {
+            _vehicle->sendMavCommand(
+                _compID,                                // Target component
+                MAV_CMD_REQUEST_CAMERA_SETTINGS,        // command id
+                false,                                  // showError
+                1);                                     // Do Request
+        }
     }
 }
 
@@ -1427,12 +1438,23 @@ VehicleCameraControl::_requestStorageInfo()
 {
     qCDebug(CameraControlLog) << "_requestStorageInfo()";
     if(_vehicle) {
-        _vehicle->sendMavCommand(
-            _compID,                                // Target component
-            MAV_CMD_REQUEST_STORAGE_INFORMATION,    // command id
-            false,                                  // showError
-            0,                                      // Storage ID (0 for all, 1 for first, 2 for second, etc.)
-            1);                                     // Do Request
+        // Use REQUEST_MESSAGE instead of deprecated REQUEST_CAMERA_SETTINGS
+        // first time and every other time after that.
+        if(_storageInfoRetries++ % 2 == 0) {
+            _vehicle->sendMavCommand(
+                _compID,                                 // target component
+                MAV_CMD_REQUEST_MESSAGE,                // command id
+                false,                                  // showError
+                MAVLINK_MSG_ID_STORAGE_INFORMATION,     // msgid
+                0);                                     // storage ID
+        } else {
+            _vehicle->sendMavCommand(
+                _compID,                                // Target component
+                MAV_CMD_REQUEST_STORAGE_INFORMATION,    // command id
+                false,                                  // showError
+                0,                                      // Storage ID (0 for all, 1 for first, 2 for second, etc.)
+                1);                                     // Do Request
+        }
     }
 }
 
@@ -1570,6 +1592,7 @@ VehicleCameraControl::handleVideoInfo(const mavlink_video_stream_information_t* 
         //-- Done
         qCDebug(CameraControlLog) << "All stream handlers done";
         _streamInfoTimer.stop();
+        _videoStreamInfoRetries = 0;
         emit autoStreamChanged();
         emit _vehicle->cameraManager()->streamChanged();
     }
@@ -1585,6 +1608,7 @@ VehicleCameraControl::handleVideoStatus(const mavlink_video_stream_status_t* vs)
     if(pInfo) {
         pInfo->update(vs);
     }
+    _videoStreamStatusRetries = 0;
 }
 
 //-----------------------------------------------------------------------------
@@ -1735,11 +1759,22 @@ void
 VehicleCameraControl::_requestStreamInfo(uint8_t streamID)
 {
     qCDebug(CameraControlLog) << "Requesting video stream info for:" << streamID;
-    _vehicle->sendMavCommand(
-        _compID,                                            // Target component
-        MAV_CMD_REQUEST_VIDEO_STREAM_INFORMATION,           // Command id
-        false,                                              // ShowError
-        streamID);                                          // Stream ID
+    // By default, try to use new REQUEST_MESSAGE command instead of 
+    // deprecated MAV_CMD_REQUEST_VIDEO_STREAM_INFORMATION.
+    if (_videoStreamStatusRetries % 2 == 0) {
+        _vehicle->sendMavCommand(
+            _compID,                                         // target component
+            MAV_CMD_REQUEST_MESSAGE,                        // command id
+            false,                                          // showError
+            MAVLINK_MSG_ID_VIDEO_STREAM_INFORMATION,        // msgid
+            streamID);                                      // stream ID
+    } else {
+        _vehicle->sendMavCommand(
+            _compID,                                            // Target component
+            MAV_CMD_REQUEST_VIDEO_STREAM_INFORMATION,           // Command id
+            false,                                              // ShowError
+            streamID);                                          // Stream ID
+    }
 }
 
 //-----------------------------------------------------------------------------
@@ -1747,11 +1782,22 @@ void
 VehicleCameraControl::_requestStreamStatus(uint8_t streamID)
 {
     qCDebug(CameraControlLog) << "Requesting video stream status for:" << streamID;
+    // By default, try to use new REQUEST_MESSAGE command instead of
+    // deprecated MAV_CMD_REQUEST_VIDEO_STREAM_INFORMATION.
+    if (_videoStreamInfoRetries % 2 == 0) {
+        _vehicle->sendMavCommand(
+            _compID,                                         // target component
+            MAV_CMD_REQUEST_MESSAGE,                        // command id
+            false,                                          // showError
+            MAVLINK_MSG_ID_VIDEO_STREAM_STATUS,             // msgid
+            streamID);                                      // stream id
+    } else {
     _vehicle->sendMavCommand(
         _compID,                                            // Target component
         MAV_CMD_REQUEST_VIDEO_STREAM_STATUS,                // Command id
         false,                                              // ShowError
         streamID);                                          // Stream ID
+    }
     _streamStatusTimer.start(1000);                         // Wait up to a second for it
 }
 
@@ -1796,11 +1842,11 @@ VehicleCameraControl::_findStream(const QString name)
 
 //-----------------------------------------------------------------------------
 void
-VehicleCameraControl::_streamTimeout()
+VehicleCameraControl::_streamInfoTimeout()
 {
-    _requestCount++;
-    int count = _expectedCount * 3;
-    if(_requestCount > count) {
+    _videoStreamInfoRetries++;
+    int count = _expectedCount * 5;
+    if(_videoStreamInfoRetries > count) {
         qCWarning(CameraControlLog) << "Giving up requesting video stream info";
         _streamInfoTimer.stop();
         //-- If we have at least one stream, work with what we have.
@@ -1823,6 +1869,7 @@ VehicleCameraControl::_streamTimeout()
 void
 VehicleCameraControl::_streamStatusTimeout()
 {
+    _videoStreamStatusRetries++;
     QGCVideoStreamInfo* pStream = currentStreamInstance();
     if(pStream) {
         _requestStreamStatus(static_cast<uint8_t>(pStream->streamID()));
@@ -2145,7 +2192,7 @@ void
 VehicleCameraControl::_checkForVideoStreams()
 {
     if(_info.flags & CAMERA_CAP_FLAGS_HAS_VIDEO_STREAM) {
-        connect(&_streamInfoTimer, &QTimer::timeout, this, &VehicleCameraControl::_streamTimeout);
+        connect(&_streamInfoTimer, &QTimer::timeout, this, &VehicleCameraControl::_streamInfoTimeout);
         _streamInfoTimer.setSingleShot(false);
         connect(&_streamStatusTimer, &QTimer::timeout, this, &VehicleCameraControl::_streamStatusTimeout);
         _streamStatusTimer.setSingleShot(true);

--- a/src/Camera/VehicleCameraControl.cc
+++ b/src/Camera/VehicleCameraControl.cc
@@ -1761,7 +1761,7 @@ VehicleCameraControl::_requestStreamInfo(uint8_t streamID)
     qCDebug(CameraControlLog) << "Requesting video stream info for:" << streamID;
     // By default, try to use new REQUEST_MESSAGE command instead of 
     // deprecated MAV_CMD_REQUEST_VIDEO_STREAM_INFORMATION.
-    if (_videoStreamStatusRetries % 2 == 0) {
+    if (_videoStreamStatusRetries++ % 2 == 0) {
         _vehicle->sendMavCommand(
             _compID,                                         // target component
             MAV_CMD_REQUEST_MESSAGE,                        // command id
@@ -1792,11 +1792,11 @@ VehicleCameraControl::_requestStreamStatus(uint8_t streamID)
             MAVLINK_MSG_ID_VIDEO_STREAM_STATUS,             // msgid
             streamID);                                      // stream id
     } else {
-    _vehicle->sendMavCommand(
-        _compID,                                            // Target component
-        MAV_CMD_REQUEST_VIDEO_STREAM_STATUS,                // Command id
-        false,                                              // ShowError
-        streamID);                                          // Stream ID
+        _vehicle->sendMavCommand(
+            _compID,                                            // Target component
+            MAV_CMD_REQUEST_VIDEO_STREAM_STATUS,                // Command id
+            false,                                              // ShowError
+            streamID);                                          // Stream ID
     }
     _streamStatusTimer.start(1000);                         // Wait up to a second for it
 }
@@ -1869,7 +1869,6 @@ VehicleCameraControl::_streamInfoTimeout()
 void
 VehicleCameraControl::_streamStatusTimeout()
 {
-    _videoStreamStatusRetries++;
     QGCVideoStreamInfo* pStream = currentStreamInstance();
     if(pStream) {
         _requestStreamStatus(static_cast<uint8_t>(pStream->streamID()));

--- a/src/Camera/VehicleCameraControl.h
+++ b/src/Camera/VehicleCameraControl.h
@@ -229,7 +229,7 @@ protected slots:
     virtual void    _mavCommandResult       (int vehicleId, int component, int command, int result, bool noReponseFromVehicle);
     virtual void    _dataReady              (QByteArray data);
     virtual void    _paramDone              ();
-    virtual void    _streamTimeout          ();
+    virtual void    _streamInfoTimeout      ();
     virtual void    _streamStatusTimeout    ();
     virtual void    _recTimerHandler        ();
     virtual void    _checkForVideoStreams   ();
@@ -286,6 +286,7 @@ protected:
     QMap<QString, QStringList>          _originalOptNames;
     QMap<QString, QVariantList>         _originalOptValues;
     QMap<QString, QGCCameraParamIO*>    _paramIO;
+    int                                 _cameraSettingsRetries = 0;
     int                                 _storageInfoRetries = 0;
     int                                 _captureInfoRetries = 0;
     bool                                _resetting          = false;
@@ -296,7 +297,8 @@ protected:
     QMap<QString, QStringList>          _requestUpdates;
     QStringList                         _updatesToRequest;
     //-- Video Streams
-    int                                 _requestCount       = 0;
+    int                                 _videoStreamInfoRetries = 0;
+    int                                 _videoStreamStatusRetries = 0;
     int                                 _currentStream      = 0;
     int                                 _expectedCount      = 1;
     QTimer                              _streamInfoTimer;

--- a/src/Vehicle/Vehicle.cc
+++ b/src/Vehicle/Vehicle.cc
@@ -493,6 +493,14 @@ void Vehicle::prepareDelete()
 #endif
 }
 
+void Vehicle::deleteCameraManager()
+{
+    if(_cameraManager) {
+        delete _cameraManager;
+        _cameraManager = nullptr;
+    }
+}
+
 void Vehicle::_offlineFirmwareTypeSettingChanged(QVariant varFirmwareType)
 {
     _firmwareType = static_cast<MAV_AUTOPILOT>(varFirmwareType.toInt());

--- a/src/Vehicle/Vehicle.h
+++ b/src/Vehicle/Vehicle.h
@@ -838,6 +838,9 @@ public:
     /// Vehicle is about to be deleted
     void prepareDelete();
 
+    /// Delete camera manager, just for testing
+    void deleteCameraManager();
+
     quint64     mavlinkSentCount        () const{ return _mavlinkSentCount; }        /// Calculated total number of messages sent to us
     quint64     mavlinkReceivedCount    () const{ return _mavlinkReceivedCount; }    /// Total number of sucessful messages received
     quint64     mavlinkLossCount        () const{ return _mavlinkLossCount; }        /// Total number of lost messages

--- a/test/Vehicle/RequestMessageTest.cc
+++ b/test/Vehicle/RequestMessageTest.cc
@@ -40,6 +40,9 @@ void RequestMessageTest::_testCaseWorker(TestCase_t& testCase)
     MultiVehicleManager*    vehicleMgr  = qgcApp()->toolbox()->multiVehicleManager();
     Vehicle*                vehicle     = vehicleMgr->activeVehicle();
 
+    // Camera manager also messes with it.
+    vehicle->deleteCameraManager();
+
     _mockLink->clearReceivedMavCommandCounts();
     _mockLink->setRequestMessageFailureMode(testCase.failureMode);
 

--- a/test/Vehicle/SendMavCommandWithSignallingTest.cc
+++ b/test/Vehicle/SendMavCommandWithSignallingTest.cc
@@ -38,6 +38,18 @@ void SendMavCommandWithSignallingTest::_testCaseWorker(TestCase_t& testCase)
 
     QCOMPARE(spyResult.wait(10000), true);
     QList<QVariant> arguments = spyResult.takeFirst();
+
+    // Gimbal controler requests MAVLINK_MSG_ID_GIMBAL_MANAGER_INFORMATION on vehicle connection,
+    // and that messes with this test, as it receives response to that command instead. So if we 
+    // are taking the response to that MAV_CMD_REQUEST_MESSAGE, we discard it and take the next
+    // Also, the camera manager requests MAVLINK_MSG_ID_CAMERA_INFORMATION on vehicle connection,
+    // so we need to ignore that as well.
+    while (arguments.at(2).toInt() == MAV_CMD_REQUEST_MESSAGE || arguments.at(2).toInt() == MAV_CMD_REQUEST_CAMERA_INFORMATION) {
+        qDebug() << "Received response to MAV_CMD_REQUEST_MESSAGE(512), ignoring, waiting for: " << testCase.command;
+        QCOMPARE(spyResult.wait(10000), true);
+        arguments = spyResult.takeFirst();
+    }
+
     QCOMPARE(arguments.count(),                                             5);
     QCOMPARE(arguments.at(0).toInt(),                                       vehicle->id());
     QCOMPARE(arguments.at(1).toInt(),                                       MAV_COMP_ID_AUTOPILOT1);


### PR DESCRIPTION
Description
-----------
The used commands like REQUEST_CAMERA_SETTINGS and REQUEST_CAMERA_INFORMATION are deprecated. Therefore, we should gradually try to move to the new REQUEST_MESSAGE commands.

This commit does so by sending REQUEST_MESSAGE by default but falling back to the previous commands on the second try and every other retry after that.

Test Steps
-----------
Need to test it manually with one of my [camera-manager example](https://github.com/julianoes/siyi-a8-mini-camera-manager).

Checklist:
----------

- [x] [Review Contribution Guidelines](https://github.com/mavlink/qgroundcontrol/blob/master/.github/CONTRIBUTING.md).
- [x] [Review Code of Conduct](https://github.com/mavlink/qgroundcontrol/blob/master/.github/CODE_OF_CONDUCT.md).
- [ ] I have tested my changes.
