### PR TITLE
Utilities: fixup warnings and linking

### DIFF
--- a/qgroundcontrol.pro
+++ b/qgroundcontrol.pro
@@ -258,7 +258,8 @@ QT += \
     texttospeech \
     core-private \
     core5compat \
-    quick3d
+    quick3d \
+    sensors
 
 # Multimedia only used if QVC is enabled
 !contains (DEFINES, QGC_DISABLE_UVC) {

--- a/src/Utilities/DeviceInfo.cc
+++ b/src/Utilities/DeviceInfo.cc
@@ -4,7 +4,7 @@
 #include <QtCore/qapplicationstatic.h>
 #include <QtNetwork/QNetworkInformation>
 #ifdef QGC_ENABLE_BLUETOOTH
-#	include <QtBluetooth/QBluetoothLocalDevice>
+#    include <QtBluetooth/QBluetoothLocalDevice>
 #endif
 
 QGC_LOGGING_CATEGORY(QGCDeviceInfoLog, "qgc.utilities.deviceinfo")
@@ -13,8 +13,8 @@ namespace QGCDeviceInfo
 {
 
 //  TODO:
-//	- reachabilityChanged()
-//	- Allow to select by transportMedium()
+//    - reachabilityChanged()
+//    - Allow to select by transportMedium()
 
 bool isInternetAvailable() {
     if(QNetworkInformation::availableBackends().isEmpty()) return false;
@@ -51,7 +51,7 @@ QGCAmbientTemperature* QGCAmbientTemperature::instance()
 }
 
 QGCAmbientTemperature::QGCAmbientTemperature(QObject* parent)
-	: QObject(parent)
+    : QObject(parent)
     , _ambientTemperature(new QAmbientTemperatureSensor(this))
     , _ambientTemperatureFilter(std::make_shared<QGCAmbientTemperatureFilter>())
 {
@@ -146,11 +146,11 @@ QGCAmbientTemperatureFilter::~QGCAmbientTemperatureFilter()
 
 bool QGCAmbientTemperatureFilter::filter(QAmbientTemperatureReading *reading)
 {
-	if (!reading) {
-		return false;
-	}
+    if (!reading) {
+        return false;
+    }
 
-	const qreal temperature = reading->temperature();
+    const qreal temperature = reading->temperature();
     return ((temperature >= s_minValidTemperatureC) && (temperature <= s_maxValidTemperatureC));
 }
 
@@ -164,7 +164,7 @@ QGCPressure* QGCPressure::instance()
 }
 
 QGCPressure::QGCPressure(QObject* parent)
-	: QObject(parent)
+    : QObject(parent)
     , _pressure(new QPressureSensor(this))
     , _pressureFilter(std::make_shared<QGCPressureFilter>())
 {
@@ -259,21 +259,21 @@ QGCPressureFilter::~QGCPressureFilter()
 
 bool QGCPressureFilter::filter(QPressureReading *reading)
 {
-	if (!reading) {
-		return false;
-	}
+    if (!reading) {
+        return false;
+    }
 
-	const qreal temperature = reading->temperature();
-	if ((temperature < s_minValidTemperatureC) || (temperature > s_maxValidTemperatureC)) {
-		return false;
-	}
+    const qreal temperature = reading->temperature();
+    if ((temperature < s_minValidTemperatureC) || (temperature > s_maxValidTemperatureC)) {
+        return false;
+    }
 
-	const qreal pressure = reading->pressure();
+    const qreal pressure = reading->pressure();
     if ((pressure < s_minValidPressurePa) || (pressure > s_maxValidPressurePa)) {
-		return false;
-	}
+        return false;
+    }
 
-	return true;
+    return true;
 }
 
 }

--- a/src/Utilities/DeviceInfo.h
+++ b/src/Utilities/DeviceInfo.h
@@ -18,7 +18,7 @@ public:
     QGCAmbientTemperatureFilter();
     ~QGCAmbientTemperatureFilter();
 
-	bool filter(QAmbientTemperatureReading *reading) final;
+    bool filter(QAmbientTemperatureReading *reading) final;
 
 private:
     static constexpr const qreal s_minValidTemperatureC = -40.;
@@ -27,15 +27,15 @@ private:
 
 class QGCAmbientTemperature : public QObject
 {
-	Q_OBJECT
+    Q_OBJECT
 
 public:
-	QGCAmbientTemperature(QObject* parent = nullptr);
-	~QGCAmbientTemperature();
+    QGCAmbientTemperature(QObject* parent = nullptr);
+    ~QGCAmbientTemperature();
 
-	static QGCAmbientTemperature* instance();
+    static QGCAmbientTemperature* instance();
 
-	qreal temperature() const { return _temperatureC; }
+    qreal temperature() const { return _temperatureC; }
 
     bool init();
     void quit();
@@ -44,12 +44,12 @@ signals:
     void temperatureUpdated(qreal temperature);
 
 private:
-	std::shared_ptr<QGCAmbientTemperatureFilter> _ambientTemperatureFilter = nullptr;
     QAmbientTemperatureSensor* _ambientTemperature = nullptr;
+    std::shared_ptr<QGCAmbientTemperatureFilter> _ambientTemperatureFilter = nullptr;
 
     QMetaObject::Connection _readingChangedConnection;
 
-	qreal _temperatureC = 0;
+    qreal _temperatureC = 0;
 };
 
 
@@ -59,7 +59,7 @@ public:
     QGCPressureFilter();
     ~QGCPressureFilter();
 
-	bool filter(QPressureReading *reading) final;
+    bool filter(QPressureReading *reading) final;
 
 private:
     static constexpr const qreal s_minValidPressurePa = 45000.;
@@ -71,16 +71,16 @@ private:
 
 class QGCPressure : public QObject
 {
-	Q_OBJECT
+    Q_OBJECT
 
 public:
-	QGCPressure(QObject* parent = nullptr);
-	~QGCPressure();
+    QGCPressure(QObject* parent = nullptr);
+    ~QGCPressure();
 
     static QGCPressure* instance();
 
-	qreal pressure() const { return _pressurePa; }
-	qreal temperature() const { return _temperatureC; }
+    qreal pressure() const { return _pressurePa; }
+    qreal temperature() const { return _temperatureC; }
 
     bool init();
     void quit();
@@ -89,13 +89,13 @@ signals:
     void pressureUpdated(qreal pressure, qreal temperature);
 
 private:
-	std::shared_ptr<QGCPressureFilter> _pressureFilter = nullptr;
     QPressureSensor* _pressure = nullptr;
+    std::shared_ptr<QGCPressureFilter> _pressureFilter = nullptr;
 
     QMetaObject::Connection _readingChangedConnection;
 
-	qreal _temperatureC = 0;
-	qreal _pressurePa = 0;
+    qreal _temperatureC = 0;
+    qreal _pressurePa = 0;
 };
 
 }


### PR DESCRIPTION
This fixes:
- tabs instead of spaces
- reordering of variables
- linking in qmake

Fixup after #11538.