### PR TITLE
Vehicle: Create Fact Group

### DIFF
--- a/qgroundcontrol.pro
+++ b/qgroundcontrol.pro
@@ -593,6 +593,7 @@ HEADERS += \
     src/Vehicle/TrajectoryPoints.h \
     src/Vehicle/Vehicle.h \
     src/Vehicle/VehicleObjectAvoidance.h \
+    src/Vehicle/FactGroups/VehicleFactGroup.h \
     src/Vehicle/FactGroups/VehicleBatteryFactGroup.h \
     src/Vehicle/FactGroups/VehicleClockFactGroup.h \
     src/Vehicle/FactGroups/VehicleDistanceSensorFactGroup.h \
@@ -866,6 +867,7 @@ SOURCES += \
     src/Vehicle/TrajectoryPoints.cc \
     src/Vehicle/Vehicle.cc \
     src/Vehicle/VehicleObjectAvoidance.cc \
+    src/Vehicle/FactGroups/VehicleFactGroup.cc \
     src/Vehicle/FactGroups/VehicleBatteryFactGroup.cc \
     src/Vehicle/FactGroups/VehicleClockFactGroup.cc \
     src/Vehicle/FactGroups/VehicleDistanceSensorFactGroup.cc \

--- a/src/Vehicle/FactGroups/CMakeLists.txt
+++ b/src/Vehicle/FactGroups/CMakeLists.txt
@@ -19,6 +19,8 @@ qt_add_library(VehicleFactGroups STATIC
     VehicleEstimatorStatusFactGroup.h
     VehicleGeneratorFactGroup.cc
     VehicleGeneratorFactGroup.h
+    VehicleFactGroup.cc
+    VehicleFactGroup.h
     VehicleGPS2FactGroup.cc
     VehicleGPS2FactGroup.h
     VehicleGPSFactGroup.cc

--- a/src/Vehicle/FactGroups/VehicleFactGroup.cc
+++ b/src/Vehicle/FactGroups/VehicleFactGroup.cc
@@ -1,0 +1,241 @@
+/****************************************************************************
+ *
+ * (c) 2009-2020 QGROUNDCONTROL PROJECT <http://www.qgroundcontrol.org>
+ *
+ * QGroundControl is licensed according to the terms in the file
+ * COPYING.md in the root of the source code directory.
+ *
+ ****************************************************************************/
+
+#include "VehicleFactGroup.h"
+#include "Vehicle.h"
+#include "QGC.h"
+
+#include <QtGui/QQuaternion>
+#include <QtGui/QVector3D>
+
+VehicleFactGroup::VehicleFactGroup(QObject* parent)
+    : FactGroup                     (_vehicleUIUpdateRateMSecs, ":/json/Vehicle/VehicleFact.json", parent)
+    , _rollFact                     (0, _rollFactName,                      FactMetaData::valueTypeDouble)
+    , _pitchFact                    (0, _pitchFactName,                     FactMetaData::valueTypeDouble)
+    , _headingFact                  (0, _headingFactName,                   FactMetaData::valueTypeDouble)
+    , _rollRateFact                 (0, _rollRateFactName,                  FactMetaData::valueTypeDouble)
+    , _pitchRateFact                (0, _pitchRateFactName,                 FactMetaData::valueTypeDouble)
+    , _yawRateFact                  (0, _yawRateFactName,                   FactMetaData::valueTypeDouble)
+    , _groundSpeedFact              (0, _groundSpeedFactName,               FactMetaData::valueTypeDouble)
+    , _airSpeedFact                 (0, _airSpeedFactName,                  FactMetaData::valueTypeDouble)
+    , _airSpeedSetpointFact         (0, _airSpeedSetpointFactName,          FactMetaData::valueTypeDouble)
+    , _climbRateFact                (0, _climbRateFactName,                 FactMetaData::valueTypeDouble)
+    , _altitudeRelativeFact         (0, _altitudeRelativeFactName,          FactMetaData::valueTypeDouble)
+    , _altitudeAMSLFact             (0, _altitudeAMSLFactName,              FactMetaData::valueTypeDouble)
+    , _altitudeAboveTerrFact        (0, _altitudeAboveTerrFactName,         FactMetaData::valueTypeDouble)
+    , _altitudeTuningFact           (0, _altitudeTuningFactName,            FactMetaData::valueTypeDouble)
+    , _altitudeTuningSetpointFact   (0, _altitudeTuningSetpointFactName,    FactMetaData::valueTypeDouble)
+    , _xTrackErrorFact              (0, _xTrackErrorFactName,               FactMetaData::valueTypeDouble)
+    , _rangeFinderDistFact          (0, _rangeFinderDistFactName,           FactMetaData::valueTypeFloat)
+    , _flightDistanceFact           (0, _flightDistanceFactName,            FactMetaData::valueTypeDouble)
+    , _flightTimeFact               (0, _flightTimeFactName,                FactMetaData::valueTypeElapsedTimeInSeconds)
+    , _distanceToHomeFact           (0, _distanceToHomeFactName,            FactMetaData::valueTypeDouble)
+    , _timeToHomeFact               (0, _timeToHomeFactName,                FactMetaData::valueTypeDouble)
+    , _missionItemIndexFact         (0, _missionItemIndexFactName,          FactMetaData::valueTypeUint16)
+    , _headingToNextWPFact          (0, _headingToNextWPFactName,           FactMetaData::valueTypeDouble)
+    , _distanceToNextWPFact         (0, _distanceToNextWPFactName,          FactMetaData::valueTypeDouble)
+    , _headingToHomeFact            (0, _headingToHomeFactName,             FactMetaData::valueTypeDouble)
+    , _distanceToGCSFact            (0, _distanceToGCSFactName,             FactMetaData::valueTypeDouble)
+    , _hobbsFact                    (0, _hobbsFactName,                     FactMetaData::valueTypeString)
+    , _throttlePctFact              (0, _throttlePctFactName,               FactMetaData::valueTypeUint16)
+    , _imuTempFact                  (0, _imuTempFactName,                   FactMetaData::valueTypeInt16)
+{
+    _addFact(&_rollFact,                    _rollFactName);
+    _addFact(&_pitchFact,                   _pitchFactName);
+    _addFact(&_headingFact,                 _headingFactName);
+    _addFact(&_rollRateFact,                _rollRateFactName);
+    _addFact(&_pitchRateFact,               _pitchRateFactName);
+    _addFact(&_yawRateFact,                 _yawRateFactName);
+    _addFact(&_groundSpeedFact,             _groundSpeedFactName);
+    _addFact(&_airSpeedFact,                _airSpeedFactName);
+    _addFact(&_airSpeedSetpointFact,        _airSpeedSetpointFactName);
+    _addFact(&_climbRateFact,               _climbRateFactName);
+    _addFact(&_altitudeRelativeFact,        _altitudeRelativeFactName);
+    _addFact(&_altitudeAMSLFact,            _altitudeAMSLFactName);
+    _addFact(&_altitudeAboveTerrFact,       _altitudeAboveTerrFactName);
+    _addFact(&_altitudeTuningFact,          _altitudeTuningFactName);
+    _addFact(&_altitudeTuningSetpointFact,  _altitudeTuningSetpointFactName);
+    _addFact(&_xTrackErrorFact,             _xTrackErrorFactName);
+    _addFact(&_rangeFinderDistFact,         _rangeFinderDistFactName);
+    _addFact(&_flightDistanceFact,          _flightDistanceFactName);
+    _addFact(&_flightTimeFact,              _flightTimeFactName);
+    _addFact(&_distanceToHomeFact,          _distanceToHomeFactName);
+    _addFact(&_timeToHomeFact,              _timeToHomeFactName);
+    _addFact(&_missionItemIndexFact,        _missionItemIndexFactName);
+    _addFact(&_headingToNextWPFact,         _headingToNextWPFactName);
+    _addFact(&_distanceToNextWPFact,        _distanceToNextWPFactName);
+    _addFact(&_headingToHomeFact,           _headingToHomeFactName);
+    _addFact(&_distanceToGCSFact,           _distanceToGCSFactName);
+    _addFact(&_hobbsFact,                   _hobbsFactName);
+    _addFact(&_throttlePctFact,             _throttlePctFactName);
+    _addFact(&_imuTempFact,                 _imuTempFactName);
+
+    _hobbsFact.setRawValue(QVariant(QString("0000:00:00")));
+}
+
+void VehicleFactGroup::handleMessage(Vehicle* vehicle, mavlink_message_t& message)
+{
+    switch (message.msgid) {
+    case MAVLINK_MSG_ID_ATTITUDE:
+        _handleAttitude(vehicle, message);
+        break;
+    case MAVLINK_MSG_ID_ATTITUDE_QUATERNION:
+        _handleAttitudeQuaternion(vehicle, message);
+        break;
+    case MAVLINK_MSG_ID_ALTITUDE:
+        _handleAltitude(message);
+        break;
+    case MAVLINK_MSG_ID_VFR_HUD:
+        _handleVfrHud(message);
+        break;
+    case MAVLINK_MSG_ID_NAV_CONTROLLER_OUTPUT:
+        _handleNavControllerOutput(message);
+        break;
+    case MAVLINK_MSG_ID_RAW_IMU:
+        _handleRawImuTemp(message);
+        break;
+#ifndef NO_ARDUPILOT_DIALECT
+    case MAVLINK_MSG_ID_RANGEFINDER:
+        _handleRangefinder(message);
+        break;
+#endif
+    default:
+        break;
+    }
+}
+
+void VehicleFactGroup::_handleAttitudeWorker(double rollRadians, double pitchRadians, double yawRadians)
+{
+    double roll = QGC::limitAngleToPMPIf(rollRadians);
+    double pitch = QGC::limitAngleToPMPIf(pitchRadians);
+    double yaw = QGC::limitAngleToPMPIf(yawRadians);
+
+    roll = qRadiansToDegrees(roll);
+    pitch = qRadiansToDegrees(pitch);
+    yaw = qRadiansToDegrees(yaw);
+
+    if (yaw < 0.0) {
+        yaw += 360.0;
+    }
+    // truncate to integer so widget never displays 360
+    yaw = trunc(yaw);
+
+    _rollFact.setRawValue(roll);
+    _pitchFact.setRawValue(pitch);
+    _headingFact.setRawValue(yaw);
+}
+
+void VehicleFactGroup::_handleAttitude(Vehicle* vehicle, const mavlink_message_t &message)
+{
+    // only accept the attitude message from the vehicle's flight controller
+    if (message.sysid != vehicle->id() || message.compid != vehicle->compId()) {
+        return;
+    }
+
+    if (_receivingAttitudeQuaternion) {
+        return;
+    }
+
+    mavlink_attitude_t attitude;
+    mavlink_msg_attitude_decode(&message, &attitude);
+
+    _handleAttitudeWorker(attitude.roll, attitude.pitch, attitude.yaw);
+}
+
+void VehicleFactGroup::_handleAltitude(const mavlink_message_t &message)
+{
+    mavlink_altitude_t altitude;
+    mavlink_msg_altitude_decode(&message, &altitude);
+
+    // Data from ALTITUDE message takes precedence over gps messages
+    _altitudeMessageAvailable = true;
+    _altitudeRelativeFact.setRawValue(altitude.altitude_relative);
+    _altitudeAMSLFact.setRawValue(altitude.altitude_amsl);
+}
+
+void VehicleFactGroup::_handleAttitudeQuaternion(Vehicle* vehicle, const mavlink_message_t &message)
+{
+    // only accept the attitude message from the vehicle's flight controller
+    if (message.sysid != vehicle->id() || message.compid != vehicle->compId()) {
+        return;
+    }
+
+    _receivingAttitudeQuaternion = true;
+
+    mavlink_attitude_quaternion_t attitudeQuaternion;
+    mavlink_msg_attitude_quaternion_decode(&message, &attitudeQuaternion);
+
+    QQuaternion quat(attitudeQuaternion.q1, attitudeQuaternion.q2, attitudeQuaternion.q3, attitudeQuaternion.q4);
+    QVector3D rates(attitudeQuaternion.rollspeed, attitudeQuaternion.pitchspeed, attitudeQuaternion.yawspeed);
+    QQuaternion repr_offset(attitudeQuaternion.repr_offset_q[0], attitudeQuaternion.repr_offset_q[1], attitudeQuaternion.repr_offset_q[2], attitudeQuaternion.repr_offset_q[3]);
+
+    // if repr_offset is valid, rotate attitude and rates
+    if (repr_offset.length() >= 0.5f) {
+        quat = quat * repr_offset;
+        rates = repr_offset * rates;
+    }
+
+    float roll, pitch, yaw;
+    float q[] = { quat.scalar(), quat.x(), quat.y(), quat.z() };
+    mavlink_quaternion_to_euler(q, &roll, &pitch, &yaw);
+
+    _handleAttitudeWorker(roll, pitch, yaw);
+
+    _rollRateFact.setRawValue(qRadiansToDegrees(rates[0]));
+    _pitchRateFact.setRawValue(qRadiansToDegrees(rates[1]));
+    _yawRateFact.setRawValue(qRadiansToDegrees(rates[2]));
+}
+
+void VehicleFactGroup::_handleNavControllerOutput(const mavlink_message_t &message)
+{
+    mavlink_nav_controller_output_t navControllerOutput;
+    mavlink_msg_nav_controller_output_decode(&message, &navControllerOutput);
+
+    _altitudeTuningSetpointFact.setRawValue(_altitudeTuningFact.rawValue().toDouble() - navControllerOutput.alt_error);
+    _xTrackErrorFact.setRawValue(navControllerOutput.xtrack_error);
+    _airSpeedSetpointFact.setRawValue(_airSpeedFact.rawValue().toDouble() - navControllerOutput.aspd_error);
+    _distanceToNextWPFact.setRawValue(navControllerOutput.wp_dist);
+}
+
+void VehicleFactGroup::_handleVfrHud(const mavlink_message_t &message)
+{
+    mavlink_vfr_hud_t vfrHud;
+    mavlink_msg_vfr_hud_decode(&message, &vfrHud);
+
+    _airSpeedFact.setRawValue(qIsNaN(vfrHud.airspeed) ? 0 : vfrHud.airspeed);
+    _groundSpeedFact.setRawValue(qIsNaN(vfrHud.groundspeed) ? 0 : vfrHud.groundspeed);
+    _climbRateFact.setRawValue(qIsNaN(vfrHud.climb) ? 0 : vfrHud.climb);
+    _throttlePctFact.setRawValue(static_cast<int16_t>(vfrHud.throttle));
+    if (qIsNaN(_altitudeTuningOffset)) {
+        _altitudeTuningOffset = vfrHud.alt;
+    }
+    _altitudeTuningFact.setRawValue(vfrHud.alt - _altitudeTuningOffset);
+    if (!qIsNaN(vfrHud.groundspeed) && !qIsNaN(_distanceToHomeFact.cookedValue().toDouble())) {
+      _timeToHomeFact.setRawValue(_distanceToHomeFact.cookedValue().toDouble() / vfrHud.groundspeed);
+    }
+}
+
+void VehicleFactGroup::_handleRawImuTemp(const mavlink_message_t &message)
+{
+    mavlink_raw_imu_t imuRaw;
+    mavlink_msg_raw_imu_decode(&message, &imuRaw);
+
+    _imuTempFact.setRawValue(imuRaw.temperature == 0 ? 0 : imuRaw.temperature * 0.01);
+}
+
+#ifndef NO_ARDUPILOT_DIALECT
+void VehicleFactGroup::_handleRangefinder(const mavlink_message_t &message)
+{
+
+    mavlink_rangefinder_t rangefinder;
+    mavlink_msg_rangefinder_decode(&message, &rangefinder);
+
+    _rangeFinderDistFact.setRawValue(qIsNaN(rangefinder.distance) ? 0 : rangefinder.distance);
+}
+#endif

--- a/src/Vehicle/FactGroups/VehicleFactGroup.h
+++ b/src/Vehicle/FactGroups/VehicleFactGroup.h
@@ -1,0 +1,163 @@
+/****************************************************************************
+ *
+ * (c) 2009-2020 QGROUNDCONTROL PROJECT <http://www.qgroundcontrol.org>
+ *
+ * QGroundControl is licensed according to the terms in the file
+ * COPYING.md in the root of the source code directory.
+ *
+ ****************************************************************************/
+
+#pragma once
+
+#include "FactGroup.h"
+#include "MAVLinkLib.h"
+
+class VehicleFactGroup : public FactGroup
+{
+    Q_OBJECT
+
+    Q_PROPERTY(Fact* roll                   READ roll                   CONSTANT)
+    Q_PROPERTY(Fact* pitch                  READ pitch                  CONSTANT)
+    Q_PROPERTY(Fact* heading                READ heading                CONSTANT)
+    Q_PROPERTY(Fact* rollRate               READ rollRate               CONSTANT)
+    Q_PROPERTY(Fact* pitchRate              READ pitchRate              CONSTANT)
+    Q_PROPERTY(Fact* yawRate                READ yawRate                CONSTANT)
+    Q_PROPERTY(Fact* groundSpeed            READ groundSpeed            CONSTANT)
+    Q_PROPERTY(Fact* airSpeed               READ airSpeed               CONSTANT)
+    Q_PROPERTY(Fact* airSpeedSetpoint       READ airSpeedSetpoint       CONSTANT)
+    Q_PROPERTY(Fact* climbRate              READ climbRate              CONSTANT)
+    Q_PROPERTY(Fact* altitudeRelative       READ altitudeRelative       CONSTANT)
+    Q_PROPERTY(Fact* altitudeAMSL           READ altitudeAMSL           CONSTANT)
+    Q_PROPERTY(Fact* altitudeAboveTerr      READ altitudeAboveTerr      CONSTANT)
+    Q_PROPERTY(Fact* altitudeTuning         READ altitudeTuning         CONSTANT)
+    Q_PROPERTY(Fact* altitudeTuningSetpoint READ altitudeTuningSetpoint CONSTANT)
+    Q_PROPERTY(Fact* xTrackError            READ xTrackError            CONSTANT)
+    Q_PROPERTY(Fact* rangeFinderDist        READ rangeFinderDist        CONSTANT)
+    Q_PROPERTY(Fact* flightDistance         READ flightDistance         CONSTANT)
+    Q_PROPERTY(Fact* distanceToHome         READ distanceToHome         CONSTANT)
+    Q_PROPERTY(Fact* timeToHome             READ timeToHome             CONSTANT)
+    Q_PROPERTY(Fact* missionItemIndex       READ missionItemIndex       CONSTANT)
+    Q_PROPERTY(Fact* headingToNextWP        READ headingToNextWP        CONSTANT)
+    Q_PROPERTY(Fact* distanceToNextWP       READ distanceToNextWP       CONSTANT)
+    Q_PROPERTY(Fact* headingToHome          READ headingToHome          CONSTANT)
+    Q_PROPERTY(Fact* distanceToGCS          READ distanceToGCS          CONSTANT)
+    Q_PROPERTY(Fact* hobbs                  READ hobbs                  CONSTANT)
+    Q_PROPERTY(Fact* throttlePct            READ throttlePct            CONSTANT)
+    Q_PROPERTY(Fact* imuTemp                READ imuTemp                CONSTANT)
+
+public:
+    VehicleFactGroup(QObject* parent = nullptr);
+
+    Fact* roll                      () { return &_rollFact; }
+    Fact* pitch                     () { return &_pitchFact; }
+    Fact* heading                   () { return &_headingFact; }
+    Fact* rollRate                  () { return &_rollRateFact; }
+    Fact* pitchRate                 () { return &_pitchRateFact; }
+    Fact* yawRate                   () { return &_yawRateFact; }
+    Fact* airSpeed                  () { return &_airSpeedFact; }
+    Fact* airSpeedSetpoint          () { return &_airSpeedSetpointFact; }
+    Fact* groundSpeed               () { return &_groundSpeedFact; }
+    Fact* climbRate                 () { return &_climbRateFact; }
+    Fact* altitudeRelative          () { return &_altitudeRelativeFact; }
+    Fact* altitudeAMSL              () { return &_altitudeAMSLFact; }
+    Fact* altitudeAboveTerr         () { return &_altitudeAboveTerrFact; }
+    Fact* altitudeTuning            () { return &_altitudeTuningFact; }
+    Fact* altitudeTuningSetpoint    () { return &_altitudeTuningSetpointFact; }
+    Fact* xTrackError               () { return &_xTrackErrorFact; }
+    Fact* rangeFinderDist           () { return &_rangeFinderDistFact; }
+    Fact* flightDistance            () { return &_flightDistanceFact; }
+    Fact* distanceToHome            () { return &_distanceToHomeFact; }
+    Fact* timeToHome                () { return &_timeToHomeFact; }
+    Fact* missionItemIndex          () { return &_missionItemIndexFact; }
+    Fact* headingToNextWP           () { return &_headingToNextWPFact; }
+    Fact* distanceToNextWP          () { return &_distanceToNextWPFact; }
+    Fact* headingToHome             () { return &_headingToHomeFact; }
+    Fact* distanceToGCS             () { return &_distanceToGCSFact; }
+    Fact* hobbs                     () { return &_hobbsFact; }
+    Fact* throttlePct               () { return &_throttlePctFact; }
+    Fact* imuTemp                   () { return &_imuTempFact; }
+
+    void handleMessage(Vehicle* vehicle, mavlink_message_t& message) override;
+
+protected:
+    void _handleAttitude                (Vehicle* vehicle, const mavlink_message_t &message);
+    void _handleAttitudeQuaternion      (Vehicle* vehicle, const mavlink_message_t &message);
+    void _handleAltitude                (const mavlink_message_t &message);
+    void _handleVfrHud                  (const mavlink_message_t &message);
+    void _handleRawImuTemp              (const mavlink_message_t &message);
+    void _handleNavControllerOutput     (const mavlink_message_t &message);
+#ifndef NO_ARDUPILOT_DIALECT
+    void _handleRangefinder             (const mavlink_message_t &message);
+#endif
+
+    const QString _rollFactName =                   QStringLiteral("roll");
+    const QString _pitchFactName =                  QStringLiteral("pitch");
+    const QString _headingFactName =                QStringLiteral("heading");
+    const QString _rollRateFactName =               QStringLiteral("rollRate");
+    const QString _pitchRateFactName =              QStringLiteral("pitchRate");
+    const QString _yawRateFactName =                QStringLiteral("yawRate");
+    const QString _airSpeedFactName =               QStringLiteral("airSpeed");
+    const QString _airSpeedSetpointFactName =       QStringLiteral("airSpeedSetpoint");
+    const QString _xTrackErrorFactName =            QStringLiteral("xTrackError");
+    const QString _rangeFinderDistFactName =        QStringLiteral("rangeFinderDist");
+    const QString _groundSpeedFactName =            QStringLiteral("groundSpeed");
+    const QString _climbRateFactName =              QStringLiteral("climbRate");
+    const QString _altitudeRelativeFactName =       QStringLiteral("altitudeRelative");
+    const QString _altitudeAMSLFactName =           QStringLiteral("altitudeAMSL");
+    const QString _altitudeAboveTerrFactName =      QStringLiteral("altitudeAboveTerr");
+    const QString _altitudeTuningFactName =         QStringLiteral("altitudeTuning");
+    const QString _altitudeTuningSetpointFactName = QStringLiteral("altitudeTuningSetpoint");
+    const QString _flightDistanceFactName =         QStringLiteral("flightDistance");
+    const QString _flightTimeFactName =             QStringLiteral("flightTime");
+    const QString _distanceToHomeFactName =         QStringLiteral("distanceToHome");
+    const QString _timeToHomeFactName =             QStringLiteral("timeToHome");
+    const QString _missionItemIndexFactName =       QStringLiteral("missionItemIndex");
+    const QString _headingToNextWPFactName =        QStringLiteral("headingToNextWP");
+    const QString _distanceToNextWPFactName =       QStringLiteral("distanceToNextWP");
+    const QString _headingToHomeFactName =          QStringLiteral("headingToHome");
+    const QString _distanceToGCSFactName =          QStringLiteral("distanceToGCS");
+    const QString _hobbsFactName =                  QStringLiteral("hobbs");
+    const QString _throttlePctFactName =            QStringLiteral("throttlePct");
+    const QString _imuTempFactName =                QStringLiteral("imuTemp");
+
+    Fact _rollFact;
+    Fact _pitchFact;
+    Fact _headingFact;
+    Fact _rollRateFact;
+    Fact _pitchRateFact;
+    Fact _yawRateFact;
+    Fact _groundSpeedFact;
+    Fact _airSpeedFact;
+    Fact _airSpeedSetpointFact;
+    Fact _climbRateFact;
+    Fact _altitudeRelativeFact;
+    Fact _altitudeAMSLFact;
+    Fact _altitudeAboveTerrFact;
+    Fact _altitudeTuningFact;
+    Fact _altitudeTuningSetpointFact;
+    Fact _xTrackErrorFact;
+    Fact _rangeFinderDistFact;
+    Fact _flightDistanceFact;
+    Fact _flightTimeFact;
+    Fact _distanceToHomeFact;
+    Fact _timeToHomeFact;
+    Fact _missionItemIndexFact;
+    Fact _headingToNextWPFact;
+    Fact _distanceToNextWPFact;
+    Fact _headingToHomeFact;
+    Fact _distanceToGCSFact;
+    Fact _hobbsFact;
+    Fact _throttlePctFact;
+    Fact _imuTempFact;
+
+    float _altitudeTuningOffset = qQNaN(); // altitude offset, so the plotted value is around 0
+
+protected:
+    bool _altitudeMessageAvailable = false;
+
+private:
+    void _handleAttitudeWorker(double rollRadians, double pitchRadians, double yawRadians);
+
+    bool _receivingAttitudeQuaternion = false;
+    static constexpr int _vehicleUIUpdateRateMSecs = 100;
+};

--- a/src/Vehicle/MultiVehicleManager.cc
+++ b/src/Vehicle/MultiVehicleManager.cc
@@ -130,7 +130,7 @@ void MultiVehicleManager::_vehicleHeartbeatInfo(LinkInterface* link, int vehicle
         _app->showAppMessage(tr("Warning: A vehicle is using the same system id as %1: %2").arg(QCoreApplication::applicationName()).arg(vehicleId));
     }
 
-    Vehicle* vehicle = new Vehicle(link, vehicleId, componentId, (MAV_AUTOPILOT)vehicleFirmwareType, (MAV_TYPE)vehicleType, _firmwarePluginManager, _joystickManager);
+    Vehicle* vehicle = new Vehicle(link, vehicleId, componentId, (MAV_AUTOPILOT)vehicleFirmwareType, (MAV_TYPE)vehicleType, _firmwarePluginManager, _joystickManager, this);
     connect(vehicle,                        &Vehicle::requestProtocolVersion,           this, &MultiVehicleManager::_requestProtocolVersion);
     connect(vehicle->vehicleLinkManager(),  &VehicleLinkManager::allLinksRemoved,       this, &MultiVehicleManager::_deleteVehiclePhase1);
     connect(vehicle->parameterManager(),    &ParameterManager::parametersReadyChanged,  this, &MultiVehicleManager::_vehicleParametersReadyChanged);

--- a/src/Vehicle/Vehicle.cc
+++ b/src/Vehicle/Vehicle.cc
@@ -60,8 +60,6 @@
 #endif
 
 #include <QtCore/QDateTime>
-#include <QtGui/QQuaternion>
-#include <QtGui/QVector3D>
 
 QGC_LOGGING_CATEGORY(VehicleLog, "VehicleLog")
 
@@ -80,8 +78,9 @@ Vehicle::Vehicle(LinkInterface*             link,
                  MAV_AUTOPILOT              firmwareType,
                  MAV_TYPE                   vehicleType,
                  FirmwarePluginManager*     firmwarePluginManager,
-                 JoystickManager*           joystickManager)
-    : FactGroup                     (_vehicleUIUpdateRateMSecs, ":/json/Vehicle/VehicleFact.json")
+                 JoystickManager*           joystickManager,
+                 QObject*                   parent)
+    : VehicleFactGroup              (parent)
     , _id                           (vehicleId)
     , _defaultComponentId           (defaultComponentId)
     , _firmwareType                 (firmwareType)
@@ -94,35 +93,7 @@ Vehicle::Vehicle(LinkInterface*             link,
     , _joystickManager              (joystickManager)
     , _trajectoryPoints             (new TrajectoryPoints(this, this))
     , _mavlinkStreamConfig          (std::bind(&Vehicle::_setMessageInterval, this, std::placeholders::_1, std::placeholders::_2))
-    , _rollFact                     (0, _rollFactName,              FactMetaData::valueTypeDouble)
-    , _pitchFact                    (0, _pitchFactName,             FactMetaData::valueTypeDouble)
-    , _headingFact                  (0, _headingFactName,           FactMetaData::valueTypeDouble)
-    , _rollRateFact                 (0, _rollRateFactName,          FactMetaData::valueTypeDouble)
-    , _pitchRateFact                (0, _pitchRateFactName,         FactMetaData::valueTypeDouble)
-    , _yawRateFact                  (0, _yawRateFactName,           FactMetaData::valueTypeDouble)
-    , _groundSpeedFact              (0, _groundSpeedFactName,       FactMetaData::valueTypeDouble)
-    , _airSpeedFact                 (0, _airSpeedFactName,          FactMetaData::valueTypeDouble)
-    , _airSpeedSetpointFact         (0, _airSpeedSetpointFactName,  FactMetaData::valueTypeDouble)
-    , _climbRateFact                (0, _climbRateFactName,         FactMetaData::valueTypeDouble)
-    , _altitudeRelativeFact         (0, _altitudeRelativeFactName,  FactMetaData::valueTypeDouble)
-    , _altitudeAMSLFact             (0, _altitudeAMSLFactName,      FactMetaData::valueTypeDouble)
-    , _altitudeAboveTerrFact        (0, _altitudeAboveTerrFactName, FactMetaData::valueTypeDouble)
-    , _altitudeTuningFact           (0, _altitudeTuningFactName,    FactMetaData::valueTypeDouble)
-    , _altitudeTuningSetpointFact   (0, _altitudeTuningSetpointFactName, FactMetaData::valueTypeDouble)
-    , _xTrackErrorFact              (0, _xTrackErrorFactName,       FactMetaData::valueTypeDouble)
-    , _rangeFinderDistFact          (0, _rangeFinderDistFactName,   FactMetaData::valueTypeFloat)
-    , _flightDistanceFact           (0, _flightDistanceFactName,    FactMetaData::valueTypeDouble)
-    , _flightTimeFact               (0, _flightTimeFactName,        FactMetaData::valueTypeElapsedTimeInSeconds)
-    , _distanceToHomeFact           (0, _distanceToHomeFactName,    FactMetaData::valueTypeDouble)
-    , _timeToHomeFact               (0, _timeToHomeFactName,        FactMetaData::valueTypeDouble)
-    , _missionItemIndexFact         (0, _missionItemIndexFactName,  FactMetaData::valueTypeUint16)
-    , _headingToNextWPFact          (0, _headingToNextWPFactName,   FactMetaData::valueTypeDouble)
-    , _distanceToNextWPFact         (0, _distanceToNextWPFactName,  FactMetaData::valueTypeDouble)
-    , _headingToHomeFact            (0, _headingToHomeFactName,     FactMetaData::valueTypeDouble)
-    , _distanceToGCSFact            (0, _distanceToGCSFactName,     FactMetaData::valueTypeDouble)
-    , _hobbsFact                    (0, _hobbsFactName,             FactMetaData::valueTypeString)
-    , _throttlePctFact              (0, _throttlePctFactName,       FactMetaData::valueTypeUint16)
-    , _imuTempFact                  (0, _imuTempFactName,           FactMetaData::valueTypeInt16)
+    , _vehicleFactGroup             (this)
     , _gpsFactGroup                 (this)
     , _gps2FactGroup                (this)
     , _windFactGroup                (this)
@@ -229,7 +200,7 @@ Vehicle::Vehicle(MAV_AUTOPILOT              firmwareType,
                  MAV_TYPE                   vehicleType,
                  FirmwarePluginManager*     firmwarePluginManager,
                  QObject*                   parent)
-    : FactGroup                         (_vehicleUIUpdateRateMSecs, ":/json/Vehicle/VehicleFact.json", parent)
+    : VehicleFactGroup                  (parent)
     , _id                               (0)
     , _defaultComponentId               (MAV_COMP_ID_ALL)
     , _offlineEditingVehicle            (true)
@@ -246,34 +217,7 @@ Vehicle::Vehicle(MAV_AUTOPILOT              firmwareType,
     , _firmwarePluginManager            (firmwarePluginManager)
     , _trajectoryPoints                 (new TrajectoryPoints(this, this))
     , _mavlinkStreamConfig              (std::bind(&Vehicle::_setMessageInterval, this, std::placeholders::_1, std::placeholders::_2))
-    , _rollFact                         (0, _rollFactName,              FactMetaData::valueTypeDouble)
-    , _pitchFact                        (0, _pitchFactName,             FactMetaData::valueTypeDouble)
-    , _headingFact                      (0, _headingFactName,           FactMetaData::valueTypeDouble)
-    , _rollRateFact                     (0, _rollRateFactName,          FactMetaData::valueTypeDouble)
-    , _pitchRateFact                    (0, _pitchRateFactName,         FactMetaData::valueTypeDouble)
-    , _yawRateFact                      (0, _yawRateFactName,           FactMetaData::valueTypeDouble)
-    , _groundSpeedFact                  (0, _groundSpeedFactName,       FactMetaData::valueTypeDouble)
-    , _airSpeedFact                     (0, _airSpeedFactName,          FactMetaData::valueTypeDouble)
-    , _airSpeedSetpointFact             (0, _airSpeedSetpointFactName,  FactMetaData::valueTypeDouble)
-    , _climbRateFact                    (0, _climbRateFactName,         FactMetaData::valueTypeDouble)
-    , _altitudeRelativeFact             (0, _altitudeRelativeFactName,  FactMetaData::valueTypeDouble)
-    , _altitudeAMSLFact                 (0, _altitudeAMSLFactName,      FactMetaData::valueTypeDouble)
-    , _altitudeAboveTerrFact            (0, _altitudeAboveTerrFactName, FactMetaData::valueTypeDouble)
-    , _altitudeTuningFact               (0, _altitudeTuningFactName,    FactMetaData::valueTypeDouble)
-    , _altitudeTuningSetpointFact       (0, _altitudeTuningSetpointFactName, FactMetaData::valueTypeDouble)
-    , _xTrackErrorFact                  (0, _xTrackErrorFactName,       FactMetaData::valueTypeDouble)
-    , _rangeFinderDistFact              (0, _rangeFinderDistFactName,   FactMetaData::valueTypeFloat)
-    , _flightDistanceFact               (0, _flightDistanceFactName,    FactMetaData::valueTypeDouble)
-    , _flightTimeFact                   (0, _flightTimeFactName,        FactMetaData::valueTypeElapsedTimeInSeconds)
-    , _distanceToHomeFact               (0, _distanceToHomeFactName,    FactMetaData::valueTypeDouble)
-    , _missionItemIndexFact             (0, _missionItemIndexFactName,  FactMetaData::valueTypeUint16)
-    , _headingToNextWPFact              (0, _headingToNextWPFactName,   FactMetaData::valueTypeDouble)
-    , _distanceToNextWPFact             (0, _distanceToNextWPFactName,  FactMetaData::valueTypeDouble)
-    , _headingToHomeFact                (0, _headingToHomeFactName,     FactMetaData::valueTypeDouble)
-    , _distanceToGCSFact                (0, _distanceToGCSFactName,     FactMetaData::valueTypeDouble)
-    , _hobbsFact                        (0, _hobbsFactName,             FactMetaData::valueTypeString)
-    , _throttlePctFact                  (0, _throttlePctFactName,       FactMetaData::valueTypeUint16)
-    , _imuTempFact                      (0, _imuTempFactName,           FactMetaData::valueTypeInt16)
+    , _vehicleFactGroup                 (this)
     , _gpsFactGroup                     (this)
     , _gps2FactGroup                    (this)
     , _windFactGroup                    (this)
@@ -383,40 +327,7 @@ void Vehicle::_commonInit()
 
     _createStatusTextHandler();
 
-    // Build FactGroup object model
-
-    _addFact(&_rollFact,                _rollFactName);
-    _addFact(&_pitchFact,               _pitchFactName);
-    _addFact(&_headingFact,             _headingFactName);
-    _addFact(&_rollRateFact,            _rollRateFactName);
-    _addFact(&_pitchRateFact,           _pitchRateFactName);
-    _addFact(&_yawRateFact,             _yawRateFactName);
-    _addFact(&_groundSpeedFact,         _groundSpeedFactName);
-    _addFact(&_airSpeedFact,            _airSpeedFactName);
-    _addFact(&_airSpeedSetpointFact,    _airSpeedSetpointFactName);
-    _addFact(&_climbRateFact,           _climbRateFactName);
-    _addFact(&_altitudeRelativeFact,    _altitudeRelativeFactName);
-    _addFact(&_altitudeAMSLFact,        _altitudeAMSLFactName);
-    _addFact(&_altitudeAboveTerrFact,   _altitudeAboveTerrFactName);
-    _addFact(&_altitudeTuningFact,       _altitudeTuningFactName);
-    _addFact(&_altitudeTuningSetpointFact, _altitudeTuningSetpointFactName);
-    _addFact(&_xTrackErrorFact,         _xTrackErrorFactName);
-    _addFact(&_rangeFinderDistFact,     _rangeFinderDistFactName);
-    _addFact(&_flightDistanceFact,      _flightDistanceFactName);
-    _addFact(&_flightTimeFact,          _flightTimeFactName);
-    _addFact(&_distanceToHomeFact,      _distanceToHomeFactName);
-    _addFact(&_timeToHomeFact,          _timeToHomeFactName);
-    _addFact(&_missionItemIndexFact,    _missionItemIndexFactName);
-    _addFact(&_headingToNextWPFact,     _headingToNextWPFactName);
-    _addFact(&_distanceToNextWPFact,    _distanceToNextWPFactName);
-    _addFact(&_headingToHomeFact,       _headingToHomeFactName);
-    _addFact(&_distanceToGCSFact,       _distanceToGCSFactName);
-    _addFact(&_throttlePctFact,         _throttlePctFactName);
-    _addFact(&_imuTempFact,             _imuTempFactName);
-
-    _hobbsFact.setRawValue(QVariant(QString("0000:00:00")));
-    _addFact(&_hobbsFact,               _hobbsFactName);
-
+    // _addFactGroup(_vehicleFactGroup,            _vehicleFactGroupName);
     _addFactGroup(&_gpsFactGroup,               _gpsFactGroupName);
     _addFactGroup(&_gps2FactGroup,              _gps2FactGroupName);
     _addFactGroup(&_windFactGroup,              _windFactGroupName);
@@ -610,6 +521,8 @@ void Vehicle::_mavlinkMessageReceived(LinkInterface* link, mavlink_message_t mes
         factGroup->handleMessage(this, message);
     }
 
+    this->handleMessage(this, message);
+
     switch (message.msgid) {
     case MAVLINK_MSG_ID_HOME_POSITION:
         _handleHomePosition(message);
@@ -629,18 +542,6 @@ void Vehicle::_mavlinkMessageReceived(LinkInterface* link, mavlink_message_t mes
     case MAVLINK_MSG_ID_SYS_STATUS:
         _handleSysStatus(message);
         break;
-    case MAVLINK_MSG_ID_RAW_IMU:
-        _handleRawImuTemp(message);
-        break;
-    case MAVLINK_MSG_ID_SCALED_IMU:
-        emit mavlinkScaledImu1(message);
-        break;
-    case MAVLINK_MSG_ID_SCALED_IMU2:
-        emit mavlinkScaledImu2(message);
-        break;
-    case MAVLINK_MSG_ID_SCALED_IMU3:
-        emit mavlinkScaledImu3(message);
-        break;
     case MAVLINK_MSG_ID_EXTENDED_SYS_STATE:
         _handleExtendedSysState(message);
         break;
@@ -659,15 +560,6 @@ void Vehicle::_mavlinkMessageReceived(LinkInterface* link, mavlink_message_t mes
     case MAVLINK_MSG_ID_GLOBAL_POSITION_INT:
         _handleGlobalPositionInt(message);
         break;
-    case MAVLINK_MSG_ID_ALTITUDE:
-        _handleAltitude(message);
-        break;
-    case MAVLINK_MSG_ID_VFR_HUD:
-        _handleVfrHud(message);
-        break;
-    case MAVLINK_MSG_ID_NAV_CONTROLLER_OUTPUT:
-        _handleNavControllerOutput(message);
-        break;
     case MAVLINK_MSG_ID_CAMERA_IMAGE_CAPTURED:
         _handleCameraImageCaptured(message);
         break;
@@ -679,12 +571,6 @@ void Vehicle::_mavlinkMessageReceived(LinkInterface* link, mavlink_message_t mes
         break;
     case MAVLINK_MSG_ID_HIGH_LATENCY2:
         _handleHighLatency2(message);
-        break;
-    case MAVLINK_MSG_ID_ATTITUDE:
-        _handleAttitude(message);
-        break;
-    case MAVLINK_MSG_ID_ATTITUDE_QUATERNION:
-        _handleAttitudeQuaternion(message);
         break;
     case MAVLINK_MSG_ID_STATUSTEXT:
         m_statusTextHandler->mavlinkMessageReceived(message);
@@ -744,9 +630,6 @@ void Vehicle::_mavlinkMessageReceived(LinkInterface* link, mavlink_message_t mes
     case MAVLINK_MSG_ID_CAMERA_FEEDBACK:
         _handleCameraFeedback(message);
         break;
-    case MAVLINK_MSG_ID_RANGEFINDER:
-        _handleRangefinder(message);
-        break;
 #endif
     case MAVLINK_MSG_ID_LOG_ENTRY:
     {
@@ -784,14 +667,6 @@ void Vehicle::_handleCameraFeedback(const mavlink_message_t& message)
     QGeoCoordinate imageCoordinate((double)feedback.lat / qPow(10.0, 7.0), (double)feedback.lng / qPow(10.0, 7.0), feedback.alt_msl);
     qCDebug(VehicleLog) << "_handleCameraFeedback coord:index" << imageCoordinate << feedback.img_idx;
     _cameraTriggerPoints.append(new QGCQGeoCoordinate(imageCoordinate, this));
-}
-
-void Vehicle::_handleRangefinder(mavlink_message_t& message)
-{
-
-    mavlink_rangefinder_t rangefinder;
-    mavlink_msg_rangefinder_decode(&message, &rangefinder);
-    _rangeFinderDistFact.setRawValue(qIsNaN(rangefinder.distance) ? 0 : rangefinder.distance);
 }
 #endif
 
@@ -844,108 +719,7 @@ void Vehicle::_handleCameraImageCaptured(const mavlink_message_t& message)
     }
 }
 
-void Vehicle::_handleVfrHud(mavlink_message_t& message)
-{
-    mavlink_vfr_hud_t vfrHud;
-    mavlink_msg_vfr_hud_decode(&message, &vfrHud);
-
-    _airSpeedFact.setRawValue(qIsNaN(vfrHud.airspeed) ? 0 : vfrHud.airspeed);
-    _groundSpeedFact.setRawValue(qIsNaN(vfrHud.groundspeed) ? 0 : vfrHud.groundspeed);
-    _climbRateFact.setRawValue(qIsNaN(vfrHud.climb) ? 0 : vfrHud.climb);
-    _throttlePctFact.setRawValue(static_cast<int16_t>(vfrHud.throttle));
-    if (qIsNaN(_altitudeTuningOffset)) {
-        _altitudeTuningOffset = vfrHud.alt;
-    }
-    _altitudeTuningFact.setRawValue(vfrHud.alt - _altitudeTuningOffset);
-    if (!qIsNaN(vfrHud.groundspeed) && !qIsNaN(_distanceToHomeFact.cookedValue().toDouble())) {
-      _timeToHomeFact.setRawValue(_distanceToHomeFact.cookedValue().toDouble() / vfrHud.groundspeed);
-    }
-}
-
-void Vehicle::_handleNavControllerOutput(mavlink_message_t& message)
-{
-    mavlink_nav_controller_output_t navControllerOutput;
-    mavlink_msg_nav_controller_output_decode(&message, &navControllerOutput);
-
-    _altitudeTuningSetpointFact.setRawValue(_altitudeTuningFact.rawValue().toDouble() - navControllerOutput.alt_error);
-    _xTrackErrorFact.setRawValue(navControllerOutput.xtrack_error);
-    _airSpeedSetpointFact.setRawValue(_airSpeedFact.rawValue().toDouble() - navControllerOutput.aspd_error);
-    _distanceToNextWPFact.setRawValue(navControllerOutput.wp_dist);
-}
-
-void Vehicle::_handleAttitudeWorker(double rollRadians, double pitchRadians, double yawRadians)
-{
-    double roll, pitch, yaw;
-
-    roll = QGC::limitAngleToPMPIf(rollRadians);
-    pitch = QGC::limitAngleToPMPIf(pitchRadians);
-    yaw = QGC::limitAngleToPMPIf(yawRadians);
-
-    roll = qRadiansToDegrees(roll);
-    pitch = qRadiansToDegrees(pitch);
-    yaw = qRadiansToDegrees(yaw);
-
-    if (yaw < 0.0) {
-        yaw += 360.0;
-    }
-    // truncate to integer so widget never displays 360
-    yaw = trunc(yaw);
-
-    _rollFact.setRawValue(roll);
-    _pitchFact.setRawValue(pitch);
-    _headingFact.setRawValue(yaw);
-}
-
-void Vehicle::_handleAttitude(mavlink_message_t& message)
-{
-    // only accept the attitude message from the vehicle's flight controller
-    if (message.sysid != _id || message.compid != _compID) {
-        return;
-    }
-
-    if (_receivingAttitudeQuaternion) {
-        return;
-    }
-
-    mavlink_attitude_t attitude;
-    mavlink_msg_attitude_decode(&message, &attitude);
-
-    _handleAttitudeWorker(attitude.roll, attitude.pitch, attitude.yaw);
-}
-
-void Vehicle::_handleAttitudeQuaternion(mavlink_message_t& message)
-{
-    // only accept the attitude message from the vehicle's flight controller
-    if (message.sysid != _id || message.compid != _compID) {
-        return;
-    }
-
-    _receivingAttitudeQuaternion = true;
-
-    mavlink_attitude_quaternion_t attitudeQuaternion;
-    mavlink_msg_attitude_quaternion_decode(&message, &attitudeQuaternion);
-
-    QQuaternion quat(attitudeQuaternion.q1, attitudeQuaternion.q2, attitudeQuaternion.q3, attitudeQuaternion.q4);
-    QVector3D rates(attitudeQuaternion.rollspeed, attitudeQuaternion.pitchspeed, attitudeQuaternion.yawspeed);
-    QQuaternion repr_offset(attitudeQuaternion.repr_offset_q[0], attitudeQuaternion.repr_offset_q[1], attitudeQuaternion.repr_offset_q[2], attitudeQuaternion.repr_offset_q[3]);
-
-    // if repr_offset is valid, rotate attitude and rates
-    if (repr_offset.length() >= 0.5f) {
-        quat = quat * repr_offset;
-        rates = repr_offset * rates;
-    }
-
-    float roll, pitch, yaw;
-    float q[] = { quat.scalar(), quat.x(), quat.y(), quat.z() };
-    mavlink_quaternion_to_euler(q, &roll, &pitch, &yaw);
-
-    _handleAttitudeWorker(roll, pitch, yaw);
-
-    rollRate()->setRawValue(qRadiansToDegrees(rates[0]));
-    pitchRate()->setRawValue(qRadiansToDegrees(rates[1]));
-    yawRate()->setRawValue(qRadiansToDegrees(rates[2]));
-}
-
+// TODO: VehicleFactGroup
 void Vehicle::_handleGpsRawInt(mavlink_message_t& message)
 {
     mavlink_gps_raw_int_t gpsRawInt;
@@ -967,6 +741,7 @@ void Vehicle::_handleGpsRawInt(mavlink_message_t& message)
     }
 }
 
+// TODO: VehicleFactGroup
 void Vehicle::_handleGlobalPositionInt(mavlink_message_t& message)
 {
     mavlink_global_position_int_t globalPositionInt;
@@ -991,6 +766,7 @@ void Vehicle::_handleGlobalPositionInt(mavlink_message_t& message)
     }
 }
 
+// TODO: VehicleFactGroup
 void Vehicle::_handleHighLatency(mavlink_message_t& message)
 {
     mavlink_high_latency_t highLatency;
@@ -1037,6 +813,7 @@ void Vehicle::_handleHighLatency(mavlink_message_t& message)
     _altitudeAMSLFact.setRawValue(coordinate.altitude);
 }
 
+// TODO: VehicleFactGroup
 void Vehicle::_handleHighLatency2(mavlink_message_t& message)
 {
     mavlink_high_latency2_t highLatency2;
@@ -1079,17 +856,6 @@ void Vehicle::_handleHighLatency2(mavlink_message_t& message)
         _onboardControlSensorsPresent = newOnboardControlSensorsEnabled;
         _onboardControlSensorsUnhealthy = 0;
     }
-}
-
-void Vehicle::_handleAltitude(mavlink_message_t& message)
-{
-    mavlink_altitude_t altitude;
-    mavlink_msg_altitude_decode(&message, &altitude);
-
-    // Data from ALTITUDE message takes precedence over gps messages
-    _altitudeMessageAvailable = true;
-    _altitudeRelativeFact.setRawValue(altitude.altitude_relative);
-    _altitudeAMSLFact.setRawValue(altitude.altitude_amsl);
 }
 
 void Vehicle::_setCapabilities(uint64_t capabilityBits)
@@ -3501,17 +3267,6 @@ void Vehicle::_handleADSBVehicle(const mavlink_message_t& message)
 
         _toolbox->adsbVehicleManager()->adsbVehicleUpdate(vehicleInfo);
     }
-}
-
-void Vehicle::_handleRawImuTemp(mavlink_message_t& message)
-{
-    // This is used by compass calibration
-    emit mavlinkRawImu(message);
-    
-    mavlink_raw_imu_t imuRaw;
-    mavlink_msg_raw_imu_decode(&message, &imuRaw);
-
-    _imuTempFact.setRawValue(imuRaw.temperature == 0 ? 0 : imuRaw.temperature * 0.01);
 }
 
 void Vehicle::_updateDistanceHeadingToHome()

--- a/src/Vehicle/Vehicle.h
+++ b/src/Vehicle/Vehicle.h
@@ -26,8 +26,8 @@
 #include "SysStatusSensorInfo.h"
 #include "VehicleLinkManager.h"
 
-#include "FactGroup.h"
 #include "TerrainFactGroup.h"
+#include "VehicleFactGroup.h"
 #include "VehicleClockFactGroup.h"
 #include "VehicleDistanceSensorFactGroup.h"
 #include "VehicleEFIFactGroup.h"
@@ -93,7 +93,7 @@ class ParsedEvent;
 
 Q_DECLARE_LOGGING_CATEGORY(VehicleLog)
 
-class Vehicle : public FactGroup
+class Vehicle : public VehicleFactGroup
 {
     Q_OBJECT
     Q_MOC_INCLUDE("AutoPilotPlugin.h")
@@ -119,7 +119,8 @@ public:
             MAV_AUTOPILOT           firmwareType,
             MAV_TYPE                vehicleType,
             FirmwarePluginManager*  firmwarePluginManager,
-            JoystickManager*        joystickManager);
+            JoystickManager*        joystickManager,
+            QObject*                parent = nullptr);
 
     // Pass these into the offline constructor to create an offline vehicle which tracks the offline vehicle settings
     static const MAV_AUTOPILOT    MAV_AUTOPILOT_TRACK = static_cast<MAV_AUTOPILOT>(-1);
@@ -258,35 +259,7 @@ public:
 
     // FactGroup object model properties
 
-    Q_PROPERTY(Fact* roll               READ roll               CONSTANT)
-    Q_PROPERTY(Fact* pitch              READ pitch              CONSTANT)
-    Q_PROPERTY(Fact* heading            READ heading            CONSTANT)
-    Q_PROPERTY(Fact* rollRate           READ rollRate           CONSTANT)
-    Q_PROPERTY(Fact* pitchRate          READ pitchRate          CONSTANT)
-    Q_PROPERTY(Fact* yawRate            READ yawRate            CONSTANT)
-    Q_PROPERTY(Fact* groundSpeed        READ groundSpeed        CONSTANT)
-    Q_PROPERTY(Fact* airSpeed           READ airSpeed           CONSTANT)
-    Q_PROPERTY(Fact* airSpeedSetpoint   READ airSpeedSetpoint   CONSTANT)
-    Q_PROPERTY(Fact* climbRate          READ climbRate          CONSTANT)
-    Q_PROPERTY(Fact* altitudeRelative   READ altitudeRelative   CONSTANT)
-    Q_PROPERTY(Fact* altitudeAMSL       READ altitudeAMSL       CONSTANT)
-    Q_PROPERTY(Fact* altitudeAboveTerr  READ altitudeAboveTerr  CONSTANT)
-    Q_PROPERTY(Fact* altitudeTuning     READ altitudeTuning     CONSTANT)
-    Q_PROPERTY(Fact* altitudeTuningSetpoint READ altitudeTuningSetpoint CONSTANT)
-    Q_PROPERTY(Fact* xTrackError        READ xTrackError        CONSTANT)
-    Q_PROPERTY(Fact* rangeFinderDist    READ rangeFinderDist    CONSTANT)
-    Q_PROPERTY(Fact* flightDistance     READ flightDistance     CONSTANT)
-    Q_PROPERTY(Fact* distanceToHome     READ distanceToHome     CONSTANT)
-    Q_PROPERTY(Fact* timeToHome         READ timeToHome         CONSTANT)
-    Q_PROPERTY(Fact* missionItemIndex   READ missionItemIndex   CONSTANT)
-    Q_PROPERTY(Fact* headingToNextWP    READ headingToNextWP    CONSTANT)
-    Q_PROPERTY(Fact* distanceToNextWP   READ distanceToNextWP   CONSTANT)
-    Q_PROPERTY(Fact* headingToHome      READ headingToHome      CONSTANT)
-    Q_PROPERTY(Fact* distanceToGCS      READ distanceToGCS      CONSTANT)
-    Q_PROPERTY(Fact* hobbs              READ hobbs              CONSTANT)
-    Q_PROPERTY(Fact* throttlePct        READ throttlePct        CONSTANT)
-    Q_PROPERTY(Fact* imuTemp            READ imuTemp            CONSTANT)
-
+    Q_PROPERTY(FactGroup*           vehicle         READ vehicleFactGroup           CONSTANT)
     Q_PROPERTY(FactGroup*           gps             READ gpsFactGroup               CONSTANT)
     Q_PROPERTY(FactGroup*           gps2            READ gps2FactGroup              CONSTANT)
     Q_PROPERTY(FactGroup*           wind            READ windFactGroup              CONSTANT)
@@ -620,35 +593,7 @@ public:
     void startUAVCANBusConfig(void);
     void stopUAVCANBusConfig(void);
 
-    Fact* roll                              () { return &_rollFact; }
-    Fact* pitch                             () { return &_pitchFact; }
-    Fact* heading                           () { return &_headingFact; }
-    Fact* rollRate                          () { return &_rollRateFact; }
-    Fact* pitchRate                         () { return &_pitchRateFact; }
-    Fact* yawRate                           () { return &_yawRateFact; }
-    Fact* airSpeed                          () { return &_airSpeedFact; }
-    Fact* airSpeedSetpoint                  () { return &_airSpeedSetpointFact; }
-    Fact* groundSpeed                       () { return &_groundSpeedFact; }
-    Fact* climbRate                         () { return &_climbRateFact; }
-    Fact* altitudeRelative                  () { return &_altitudeRelativeFact; }
-    Fact* altitudeAMSL                      () { return &_altitudeAMSLFact; }
-    Fact* altitudeAboveTerr                 () { return &_altitudeAboveTerrFact; }
-    Fact* altitudeTuning                    () { return &_altitudeTuningFact; }
-    Fact* altitudeTuningSetpoint            () { return &_altitudeTuningSetpointFact; }
-    Fact* xTrackError                       () { return &_xTrackErrorFact; }
-    Fact* rangeFinderDist                   () { return &_rangeFinderDistFact; }
-    Fact* flightDistance                    () { return &_flightDistanceFact; }
-    Fact* distanceToHome                    () { return &_distanceToHomeFact; }
-    Fact* timeToHome                        () { return &_timeToHomeFact; }
-    Fact* missionItemIndex                  () { return &_missionItemIndexFact; }
-    Fact* headingToNextWP                   () { return &_headingToNextWPFact; }
-    Fact* distanceToNextWP                  () { return &_distanceToNextWPFact; }
-    Fact* headingToHome                     () { return &_headingToHomeFact; }
-    Fact* distanceToGCS                     () { return &_distanceToGCSFact; }
-    Fact* hobbs                             () { return &_hobbsFact; }
-    Fact* throttlePct                       () { return &_throttlePctFact; }
-    Fact* imuTemp                           () { return &_imuTempFact; }
-
+    FactGroup* vehicleFactGroup             () { return _vehicleFactGroup; }
     FactGroup* gpsFactGroup                 () { return &_gpsFactGroup; }
     FactGroup* gps2FactGroup                () { return &_gps2FactGroup; }
     FactGroup* windFactGroup                () { return &_windFactGroup; }
@@ -930,11 +875,6 @@ signals:
     /// Remote control RSSI changed  (0% - 100%)
     void remoteControlRSSIChanged       (uint8_t rssi);
 
-    void mavlinkRawImu                  (mavlink_message_t message);
-    void mavlinkScaledImu1              (mavlink_message_t message);
-    void mavlinkScaledImu2              (mavlink_message_t message);
-    void mavlinkScaledImu3              (mavlink_message_t message);
-
     // Mavlink Log Download
     void mavlinkLogData                 (Vehicle* vehicle, uint8_t target_system, uint8_t target_component, uint16_t sequence, uint8_t first_message, QByteArray data, bool acked);
 
@@ -1013,14 +953,8 @@ private:
     void _handleCommandAck              (mavlink_message_t& message);
     void _handleGpsRawInt               (mavlink_message_t& message);
     void _handleGlobalPositionInt       (mavlink_message_t& message);
-    void _handleAltitude                (mavlink_message_t& message);
-    void _handleVfrHud                  (mavlink_message_t& message);
-    void _handleNavControllerOutput     (mavlink_message_t& message);
     void _handleHighLatency             (mavlink_message_t& message);
     void _handleHighLatency2            (mavlink_message_t& message);
-    void _handleAttitudeWorker          (double rollRadians, double pitchRadians, double yawRadians);
-    void _handleAttitude                (mavlink_message_t& message);
-    void _handleAttitudeQuaternion      (mavlink_message_t& message);
     void _handleOrbitExecutionStatus    (const mavlink_message_t& message);
     void _handleGimbalOrientation       (const mavlink_message_t& message);
     void _handleObstacleDistance        (const mavlink_message_t& message);
@@ -1029,11 +963,9 @@ private:
     // ArduPilot dialect messages
 #if !defined(NO_ARDUPILOT_DIALECT)
     void _handleCameraFeedback          (const mavlink_message_t& message);
-    void _handleRangefinder             (mavlink_message_t& message);
 #endif
     void _handleCameraImageCaptured     (const mavlink_message_t& message);
     void _handleADSBVehicle             (const mavlink_message_t& message);
-    void _handleRawImuTemp              (mavlink_message_t& message);
     void _missionManagerError           (int errorCode, const QString& errorMsg);
     void _geoFenceManagerError          (int errorCode, const QString& errorMsg);
     void _rallyPointManagerError        (int errorCode, const QString& errorMsg);
@@ -1096,7 +1028,6 @@ private:
     bool            _gpsRawIntMessageAvailable              = false;
     bool            _gps2RawMessageAvailable                = false;
     bool            _globalPositionIntMessageAvailable      = false;
-    bool            _altitudeMessageAvailable               = false;
     double          _defaultCruiseSpeed = qQNaN();
     double          _defaultHoverSpeed = qQNaN();
     int             _telemetryRRSSI = 0;
@@ -1111,7 +1042,6 @@ private:
     unsigned        _maxProtoVersion                        = 0;
     bool            _capabilityBitsKnown                    = false;
     uint64_t        _capabilityBits                         = 0;
-    bool            _receivingAttitudeQuaternion = false;
     CheckList       _checkListState                         = CheckListNotSetup;
     bool            _readyToFlyAvailable                    = false;
     bool            _readyToFly                             = false;
@@ -1308,36 +1238,7 @@ private:
     const QString _settingsGroup =               QStringLiteral("Vehicle%1");        // %1 replaced with mavlink system id
     const QString _joystickEnabledSettingsKey =  QStringLiteral("JoystickEnabled");
 
-    const QString _rollFactName =                QStringLiteral("roll");
-    const QString _pitchFactName =               QStringLiteral("pitch");
-    const QString _headingFactName =             QStringLiteral("heading");
-    const QString _rollRateFactName =             QStringLiteral("rollRate");
-    const QString _pitchRateFactName =           QStringLiteral("pitchRate");
-    const QString _yawRateFactName =             QStringLiteral("yawRate");
-    const QString _airSpeedFactName =            QStringLiteral("airSpeed");
-    const QString _airSpeedSetpointFactName =    QStringLiteral("airSpeedSetpoint");
-    const QString _xTrackErrorFactName =         QStringLiteral("xTrackError");
-    const QString _rangeFinderDistFactName =     QStringLiteral("rangeFinderDist");
-    const QString _groundSpeedFactName =         QStringLiteral("groundSpeed");
-    const QString _climbRateFactName =           QStringLiteral("climbRate");
-    const QString _altitudeRelativeFactName =    QStringLiteral("altitudeRelative");
-    const QString _altitudeAMSLFactName =        QStringLiteral("altitudeAMSL");
-    const QString _altitudeAboveTerrFactName =   QStringLiteral("altitudeAboveTerr");
-    const QString _altitudeTuningFactName =      QStringLiteral("altitudeTuning");
-    const QString _altitudeTuningSetpointFactName = QStringLiteral("altitudeTuningSetpoint");
-    const QString _flightDistanceFactName =      QStringLiteral("flightDistance");
-    const QString _flightTimeFactName =          QStringLiteral("flightTime");
-    const QString _distanceToHomeFactName =      QStringLiteral("distanceToHome");
-    const QString _timeToHomeFactName =          QStringLiteral("timeToHome");
-    const QString _missionItemIndexFactName =    QStringLiteral("missionItemIndex");
-    const QString _headingToNextWPFactName =     QStringLiteral("headingToNextWP");
-    const QString _distanceToNextWPFactName =    QStringLiteral("distanceToNextWP");
-    const QString _headingToHomeFactName =       QStringLiteral("headingToHome");
-    const QString _distanceToGCSFactName =       QStringLiteral("distanceToGCS");
-    const QString _hobbsFactName =               QStringLiteral("hobbs");
-    const QString _throttlePctFactName =         QStringLiteral("throttlePct");
-    const QString _imuTempFactName =             QStringLiteral("imuTemp");
-
+    const QString _vehicleFactGroupName =            QStringLiteral("vehicle");
     const QString _gpsFactGroupName =                QStringLiteral("gps");
     const QString _gps2FactGroupName =               QStringLiteral("gps2");
     const QString _windFactGroupName =               QStringLiteral("wind");
@@ -1355,36 +1256,7 @@ private:
     const QString _generatorFactGroupName =          QStringLiteral("generator");
     const QString _efiFactGroupName =                QStringLiteral("efi");
 
-    Fact _rollFact;
-    Fact _pitchFact;
-    Fact _headingFact;
-    Fact _rollRateFact;
-    Fact _pitchRateFact;
-    Fact _yawRateFact;
-    Fact _groundSpeedFact;
-    Fact _airSpeedFact;
-    Fact _airSpeedSetpointFact;
-    Fact _climbRateFact;
-    Fact _altitudeRelativeFact;
-    Fact _altitudeAMSLFact;
-    Fact _altitudeAboveTerrFact;
-    Fact _altitudeTuningFact;
-    Fact _altitudeTuningSetpointFact;
-    Fact _xTrackErrorFact;
-    Fact _rangeFinderDistFact;
-    Fact _flightDistanceFact;
-    Fact _flightTimeFact;
-    Fact _distanceToHomeFact;
-    Fact _timeToHomeFact;
-    Fact _missionItemIndexFact;
-    Fact _headingToNextWPFact;
-    Fact _distanceToNextWPFact;
-    Fact _headingToHomeFact;
-    Fact _distanceToGCSFact;
-    Fact _hobbsFact;
-    Fact _throttlePctFact;
-    Fact _imuTempFact;
-
+    VehicleFactGroup*               _vehicleFactGroup;
     VehicleGPSFactGroup             _gpsFactGroup;
     VehicleGPS2FactGroup            _gps2FactGroup;
     VehicleWindFactGroup            _windFactGroup;
@@ -1415,8 +1287,6 @@ private:
     Actuators*                      _actuators                  = nullptr;
     RemoteIDManager*                _remoteIDManager            = nullptr;
     StandardModes*                  _standardModes              = nullptr;
-
-    static const int _vehicleUIUpdateRateMSecs      = 100;
 
     // Terrain query members, used to get terrain altitude for doSetHome()
     TerrainAtCoordinateQuery*   _currentDoSetHomeTerrainAtCoordinateQuery = nullptr;


### PR DESCRIPTION
Aggregates remaining Vehicle Facts into their own fact group and makes Vehicle inherit from that factgroup rather than a generic fact group. This should result in the same exact Vehicle class, just with a pseudo separate fact group. Helps clean up Vehicle class a bit. Smaller & easier approach than #11428.

A couple of message handling functions are left in Vehicle for now because they use vehicle signals & private variables, and will require a bit more refactoring.