### PR TITLE
QtLocationPlugin: Make MapProvider Functions Const

### DIFF
--- a/src/QtLocationPlugin/BingMapProvider.cpp
+++ b/src/QtLocationPlugin/BingMapProvider.cpp
@@ -9,31 +9,8 @@
 
 #include "BingMapProvider.h"
 
-BingMapProvider::BingMapProvider(const QString &imageFormat, const quint32 averageSize,
-                                 const QGeoMapType::MapStyle mapType, QObject* parent)
-    : MapProvider(QStringLiteral("https://www.bing.com/maps/"), imageFormat, averageSize, mapType, parent) {}
-
-static const QString RoadMapUrl = QStringLiteral("http://ecn.t%1.tiles.virtualearth.net/tiles/r%2.png?g=%3&mkt=%4");
-
-QString BingRoadMapProvider::_getURL(const int x, const int y, const int zoom, QNetworkAccessManager* networkManager) {
-    Q_UNUSED(networkManager)
+QString BingMapProvider::_getURL(int x, int y, int zoom) const
+{
     const QString key = _tileXYToQuadKey(x, y, zoom);
-    return RoadMapUrl.arg(QString::number(_getServerNum(x, y, 4)), key, _versionBingMaps, _language);
+    return _mapUrl.arg(_getServerNum(x, y, 4)).arg(_mapName, key, _imageFormat, _versionBingMaps, _language);
 }
-
-static const QString SatteliteMapUrl = QStringLiteral("http://ecn.t%1.tiles.virtualearth.net/tiles/a%2.jpeg?g=%3&mkt=%4");
-
-QString BingSatelliteMapProvider::_getURL(const int x, const int y, const int zoom, QNetworkAccessManager* networkManager) {
-    Q_UNUSED(networkManager)
-    const QString key = _tileXYToQuadKey(x, y, zoom);
-    return SatteliteMapUrl.arg(QString::number(_getServerNum(x, y, 4)) ,key ,_versionBingMaps ,_language);
-}
-
-static const QString HybridMapUrl = QStringLiteral("http://ecn.t%1.tiles.virtualearth.net/tiles/h%2.jpeg?g=%3&mkt=%4");
-
-QString BingHybridMapProvider::_getURL(const int x, const int y, const int zoom, QNetworkAccessManager* networkManager) {
-    Q_UNUSED(networkManager)
-    const QString key = _tileXYToQuadKey(x, y, zoom);
-    return HybridMapUrl.arg(QString::number(_getServerNum(x, y, 4)), key, _versionBingMaps, _language);
-}
-

--- a/src/QtLocationPlugin/BingMapProvider.h
+++ b/src/QtLocationPlugin/BingMapProvider.h
@@ -11,59 +11,53 @@
 
 #include "MapProvider.h"
 
-class BingMapProvider : public MapProvider {
+static constexpr const quint32 AVERAGE_BING_STREET_MAP = 1297;
+static constexpr const quint32 AVERAGE_BING_SAT_MAP    = 19597;
+
+class BingMapProvider : public MapProvider
+{
     Q_OBJECT
 
-public:
-    BingMapProvider(const QString &imageFormat, const quint32 averageSize,
-                    const QGeoMapType::MapStyle mapType, QObject* parent = nullptr);
-
-    ~BingMapProvider() = default;
-
-    bool _isBingProvider() const override { return true; }
-
-
 protected:
-    const QString _versionBingMaps = QStringLiteral("563");
+    BingMapProvider(const QString &mapName, const QString &imageFormat, quint32 averageSize,
+                    QGeoMapType::MapStyle mapType, QObject* parent = nullptr)
+        : MapProvider(QStringLiteral("https://www.bing.com/maps/"), imageFormat, averageSize, mapType, parent)
+        , _mapName(mapName) {}
+
+public:
+    bool isBingProvider() const final { return true; }
+
+private:
+    QString _getURL(int x, int y, int zoom) const final;
+
+    const QString _mapName;
+    const QString _mapUrl = QStringLiteral("http://ecn.t%1.tiles.virtualearth.net/tiles/%2%3.%4?g=%5&mkt=%6");
+    const QString _versionBingMaps = QStringLiteral("2981");
 };
 
-static const quint32 AVERAGE_BING_STREET_MAP = 1297;
-static const quint32 AVERAGE_BING_SAT_MAP    = 19597;
-
-// -----------------------------------------------------------
-// Bing Road Map
-
-class BingRoadMapProvider : public BingMapProvider {
+class BingRoadMapProvider : public BingMapProvider
+{
     Q_OBJECT
 
 public:
     BingRoadMapProvider(QObject* parent = nullptr)
-        : BingMapProvider(QStringLiteral("png"), AVERAGE_BING_STREET_MAP, QGeoMapType::StreetMap, parent) {}
-
-    QString _getURL(const int x, const int y, const int zoom, QNetworkAccessManager* networkManager) override;
+        : BingMapProvider(QStringLiteral("r"), QStringLiteral("png"), AVERAGE_BING_STREET_MAP, QGeoMapType::StreetMap, parent) {}
 };
 
-// -----------------------------------------------------------
-// Bing Satellite Map
-
-class BingSatelliteMapProvider : public BingMapProvider {
+class BingSatelliteMapProvider : public BingMapProvider
+{
     Q_OBJECT
 
 public:
     BingSatelliteMapProvider(QObject* parent = nullptr)
-        : BingMapProvider(QStringLiteral("jpg"), AVERAGE_BING_SAT_MAP, QGeoMapType::SatelliteMapDay, parent) {}
-
-    QString _getURL(const int x, const int y, const int zoom, QNetworkAccessManager* networkManager) override;
+        : BingMapProvider(QStringLiteral("a"), QStringLiteral("jpg"), AVERAGE_BING_SAT_MAP, QGeoMapType::SatelliteMapDay, parent) {}
 };
 
-// -----------------------------------------------------------
-// Bing Hybrid Map
-
-class BingHybridMapProvider : public BingMapProvider {
+class BingHybridMapProvider : public BingMapProvider
+{
     Q_OBJECT
+
 public:
     BingHybridMapProvider(QObject* parent = nullptr)
-        : BingMapProvider(QStringLiteral("jpg"),AVERAGE_BING_SAT_MAP, QGeoMapType::HybridMap, parent) {}
-
-    QString _getURL(const int x, const int y, const int zoom, QNetworkAccessManager* networkManager) override;
+        : BingMapProvider(QStringLiteral("h"), QStringLiteral("jpg"),AVERAGE_BING_SAT_MAP, QGeoMapType::HybridMap, parent) {}
 };

--- a/src/QtLocationPlugin/ElevationMapProvider.cpp
+++ b/src/QtLocationPlugin/ElevationMapProvider.cpp
@@ -1,42 +1,46 @@
+/****************************************************************************
+ *
+ * (c) 2009-2020 QGROUNDCONTROL PROJECT <http://www.qgroundcontrol.org>
+ *
+ * QGroundControl is licensed according to the terms in the file
+ * COPYING.md in the root of the source code directory.
+ *
+ * License for the COPERNICUS dataset hosted on https://terrain-ce.suite.auterion.com/:
+ *
+ * © DLR e.V. 2010-2014 and © Airbus Defence and Space GmbH 2014-2018 provided under
+ * COPERNICUS by the European Union and ESA; all rights reserved.
+ *
+ ****************************************************************************/
+
 #include "ElevationMapProvider.h"
 #include "TerrainTile.h"
 
-/*
-License for the COPERNICUS dataset hosted on https://terrain-ce.suite.auterion.com/:
-
-© DLR e.V. 2010-2014 and © Airbus Defence and Space GmbH 2014-2018 provided under COPERNICUS
-by the European Union and ESA; all rights reserved.
-
-*/
-
-ElevationProvider::ElevationProvider(const QString& imageFormat, quint32 averageSize, QGeoMapType::MapStyle mapType, QObject* parent)
-    : MapProvider(QStringLiteral("https://terrain-ce.suite.auterion.com/"), imageFormat, averageSize, mapType, parent) {}
-
-//-----------------------------------------------------------------------------
-int CopernicusElevationProvider::long2tileX(const double lon, const int z) const {
+int CopernicusElevationProvider::long2tileX(double lon, int z) const
+{
     Q_UNUSED(z)
     return static_cast<int>(floor((lon + 180.0) / TerrainTile::tileSizeDegrees));
 }
 
-//-----------------------------------------------------------------------------
-int CopernicusElevationProvider::lat2tileY(const double lat, const int z) const {
+int CopernicusElevationProvider::lat2tileY(double lat, int z) const
+{
     Q_UNUSED(z)
     return static_cast<int>(floor((lat + 90.0) / TerrainTile::tileSizeDegrees));
 }
 
-QString CopernicusElevationProvider::_getURL(const int x, const int y, const int zoom, QNetworkAccessManager* networkManager) {
-    Q_UNUSED(networkManager)
+QString CopernicusElevationProvider::_getURL(int x, int y, int zoom) const
+{
     Q_UNUSED(zoom)
-    return QString("https://terrain-ce.suite.auterion.com/api/v1/carpet?points=%1,%2,%3,%4")
-        .arg(static_cast<double>(y) * TerrainTile::tileSizeDegrees - 90.0)
-        .arg(static_cast<double>(x) * TerrainTile::tileSizeDegrees - 180.0)
-        .arg(static_cast<double>(y + 1) * TerrainTile::tileSizeDegrees - 90.0)
-        .arg(static_cast<double>(x + 1) * TerrainTile::tileSizeDegrees - 180.0);
+    return QStringLiteral("https://terrain-ce.suite.auterion.com/api/v1/carpet?points=%1,%2,%3,%4")
+        .arg((static_cast<double>(y) * TerrainTile::tileSizeDegrees) - 90.0)
+        .arg((static_cast<double>(x) * TerrainTile::tileSizeDegrees) - 180.0)
+        .arg((static_cast<double>(y + 1) * TerrainTile::tileSizeDegrees) - 90.0)
+        .arg((static_cast<double>(x + 1) * TerrainTile::tileSizeDegrees) - 180.0);
 }
 
-QGCTileSet CopernicusElevationProvider::getTileCount(const int zoom, const double topleftLon,
-                                                 const double topleftLat, const double bottomRightLon,
-                                                 const double bottomRightLat) const {
+QGCTileSet CopernicusElevationProvider::getTileCount(int zoom, double topleftLon,
+                                                     double topleftLat, double bottomRightLon,
+                                                     double bottomRightLat) const
+{
     QGCTileSet set;
     set.tileX0 = long2tileX(topleftLon, zoom);
     set.tileY0 = lat2tileY(bottomRightLat, zoom);

--- a/src/QtLocationPlugin/ElevationMapProvider.h
+++ b/src/QtLocationPlugin/ElevationMapProvider.h
@@ -2,37 +2,37 @@
 
 #include "MapProvider.h"
 
-#include <QtCore/QString>
+static constexpr const quint32 AVERAGE_AIRMAP_ELEV_SIZE = 2786;
 
-static const quint32 AVERAGE_AIRMAP_ELEV_SIZE = 2786;
-
-class ElevationProvider : public MapProvider {
+class ElevationProvider : public MapProvider
+{
     Q_OBJECT
-  public:
-    ElevationProvider(const QString& imageFormat, quint32 averageSize,
-                      QGeoMapType::MapStyle mapType, QObject* parent = nullptr);
 
-    virtual bool _isElevationProvider() const override { return true; }
+protected:
+    ElevationProvider(const QString& imageFormat, quint32 averageSize,
+                      QGeoMapType::MapStyle mapType, QObject* parent = nullptr)
+        : MapProvider(QStringLiteral("https://terrain-ce.suite.auterion.com/"), imageFormat, averageSize, mapType, parent) {}
+
+public:
+    bool isElevationProvider() const final { return true; }
 };
 
-// -----------------------------------------------------------
-// Airmap Elevation
-
-class CopernicusElevationProvider : public ElevationProvider {
+class CopernicusElevationProvider : public ElevationProvider
+{
     Q_OBJECT
-  public:
+
+public:
     CopernicusElevationProvider(QObject* parent = nullptr)
         : ElevationProvider(QStringLiteral("bin"), AVERAGE_AIRMAP_ELEV_SIZE,
                             QGeoMapType::StreetMap, parent) {}
 
-    int long2tileX(const double lon, const int z) const override;
+    int long2tileX(double lon, int z) const final;
+    int lat2tileY(double lat, int z) const final;
 
-    int lat2tileY(const double lat, const int z) const override;
+    QGCTileSet getTileCount(int zoom, double topleftLon,
+                            double topleftLat, double bottomRightLon,
+                            double bottomRightLat) const final;
 
-    QGCTileSet getTileCount(const int zoom, const double topleftLon,
-                            const double topleftLat, const double bottomRightLon,
-                            const double bottomRightLat) const override;
-
-  protected:
-    QString _getURL(const int x, const int y, const int zoom, QNetworkAccessManager* networkManager) override;
+private:
+    QString _getURL(int x, int y, int zoom) const final;
 };

--- a/src/QtLocationPlugin/EsriMapProvider.cpp
+++ b/src/QtLocationPlugin/EsriMapProvider.cpp
@@ -13,13 +13,10 @@
 
 #include <QtNetwork/QNetworkRequest>
 
-EsriMapProvider::EsriMapProvider(const quint32 averageSize, const QGeoMapType::MapStyle mapType, QObject *parent)
-    : MapProvider(QString(), QString(), averageSize, mapType, parent) {}
-
-QNetworkRequest EsriMapProvider::getTileURL(const int x, const int y, const int zoom, QNetworkAccessManager* networkManager) {
-    //-- Build URL
+QNetworkRequest EsriMapProvider::getTileURL(int x, int y, int zoom) const
+{
     QNetworkRequest request;
-    const QString url = _getURL(x, y, zoom, networkManager);
+    const QString url = _getURL(x, y, zoom);
     if (url.isEmpty()) {
         return request;
     }
@@ -31,23 +28,7 @@ QNetworkRequest EsriMapProvider::getTileURL(const int x, const int y, const int 
     return request;
 }
 
-static const QString WorldStreetMapUrl = QStringLiteral("http://services.arcgisonline.com/ArcGIS/rest/services/World_Street_Map/MapServer/tile/%1/%2/%3");
-
-QString EsriWorldStreetMapProvider::_getURL(const int x, const int y, const int zoom, QNetworkAccessManager* networkManager) {
-    Q_UNUSED(networkManager)
-    return WorldStreetMapUrl.arg(zoom).arg(y).arg(x);
-}
-
-static const QString WorldSatelliteMapUrl = QStringLiteral("http://server.arcgisonline.com/ArcGIS/rest/services/World_Imagery/MapServer/tile/%1/%2/%3");
-
-QString EsriWorldSatelliteMapProvider::_getURL(const int x, const int y, const int zoom, QNetworkAccessManager* networkManager) {
-    Q_UNUSED(networkManager)
-    return WorldSatelliteMapUrl.arg(zoom).arg(y).arg(x);
-}
-
-static const QString TerrainMapUrl = QStringLiteral("http://server.arcgisonline.com/ArcGIS/rest/services/World_Terrain_Base/MapServer/tile/%1/%2/%3");
-
-QString EsriTerrainMapProvider::_getURL(const int x, const int y, const int zoom, QNetworkAccessManager* networkManager) {
-    Q_UNUSED(networkManager)
-    return TerrainMapUrl.arg(zoom).arg(y).arg(x);
+QString EsriMapProvider::_getURL(int x, int y, int zoom) const
+{
+    return _mapUrl.arg(_mapName).arg(zoom).arg(y).arg(x);
 }

--- a/src/QtLocationPlugin/EsriMapProvider.h
+++ b/src/QtLocationPlugin/EsriMapProvider.h
@@ -11,41 +11,48 @@
 
 #include "MapProvider.h"
 
-class EsriMapProvider : public MapProvider {
+class EsriMapProvider : public MapProvider
+{
     Q_OBJECT
 
-  public:
-    EsriMapProvider(const quint32 averageSize, const QGeoMapType::MapStyle mapType, QObject* parent = nullptr);
+protected:
+    EsriMapProvider(const QString &mapName, quint32 averageSize, QGeoMapType::MapStyle mapType, QObject* parent = nullptr)
+        : MapProvider(QString(), QString(), averageSize, mapType, parent)
+        , _mapName(mapName) {}
 
-    QNetworkRequest getTileURL(const int x, const int y, const int zoom, QNetworkAccessManager* networkManager) override;
+public:
+    QNetworkRequest getTileURL(int x, int y, int zoom) const final;
+
+private:
+    QString _getURL(int x, int y, int zoom) const final;
+
+    const QString _mapName;
+    const QString _mapUrl = QStringLiteral("http://services.arcgisonline.com/ArcGIS/rest/services/%1/MapServer/tile/%2/%3/%4");
 };
 
-class EsriWorldStreetMapProvider : public EsriMapProvider {
+class EsriWorldStreetMapProvider : public EsriMapProvider
+{
     Q_OBJECT
 
-  public:
+public:
     EsriWorldStreetMapProvider(QObject* parent = nullptr)
-        : EsriMapProvider(AVERAGE_TILE_SIZE, QGeoMapType::StreetMap, parent) {}
-
-    QString _getURL(const int x, const int y, const int zoom, QNetworkAccessManager* networkManager) override;
+        : EsriMapProvider(QStringLiteral("World_Street_Map"), AVERAGE_TILE_SIZE, QGeoMapType::StreetMap, parent) {}
 };
 
-class EsriWorldSatelliteMapProvider : public EsriMapProvider {
+class EsriWorldSatelliteMapProvider : public EsriMapProvider
+{
     Q_OBJECT
 
-  public:
+public:
     EsriWorldSatelliteMapProvider(QObject* parent = nullptr)
-        : EsriMapProvider(AVERAGE_TILE_SIZE, QGeoMapType::SatelliteMapDay, parent) {}
-
-    QString _getURL(const int x, const int y, const int zoom, QNetworkAccessManager* networkManager) override;
+        : EsriMapProvider(QStringLiteral("World_Imagery"), AVERAGE_TILE_SIZE, QGeoMapType::SatelliteMapDay, parent) {}
 };
 
-class EsriTerrainMapProvider : public EsriMapProvider {
+class EsriTerrainMapProvider : public EsriMapProvider
+{
     Q_OBJECT
 
-  public:
+public:
     EsriTerrainMapProvider(QObject* parent = nullptr)
-        : EsriMapProvider(AVERAGE_TILE_SIZE, QGeoMapType::TerrainMap, parent) {}
-
-    QString _getURL(const int x, const int y, const int zoom, QNetworkAccessManager* networkManager) override;
+        : EsriMapProvider(QStringLiteral("World_Terrain_Base"), AVERAGE_TILE_SIZE, QGeoMapType::TerrainMap, parent) {}
 };

--- a/src/QtLocationPlugin/GenericMapProvider.cpp
+++ b/src/QtLocationPlugin/GenericMapProvider.cpp
@@ -11,128 +11,61 @@
 #include "QGCApplication.h"
 #include "SettingsManager.h"
 
-static const QString JapanStdMapUrl = QStringLiteral("https://cyberjapandata.gsi.go.jp/xyz/std/%1/%2/%3.png");
-
-QString JapanStdMapProvider::_getURL(const int x, const int y, const int zoom, QNetworkAccessManager* networkManager) {
-    Q_UNUSED(networkManager)
-    return JapanStdMapUrl.arg(zoom).arg(x).arg(y);
-}
-
-static const QString JapanSeamlessMapUrl = QStringLiteral("https://cyberjapandata.gsi.go.jp/xyz/seamlessphoto/%1/%2/%3.jpg");
-
-QString JapanSeamlessMapProvider::_getURL(const int x, const int y, const int zoom, QNetworkAccessManager* networkManager) {
-    Q_UNUSED(networkManager)
-    return JapanSeamlessMapUrl.arg(zoom).arg(x).arg(y);
-}
-
-static const QString JapanAnaglyphMapUrl = QStringLiteral("https://cyberjapandata.gsi.go.jp/xyz/anaglyphmap_color/%1/%2/%3.png");
-
-QString JapanAnaglyphMapProvider::_getURL(const int x, const int y, const int zoom, QNetworkAccessManager* networkManager) {
-    Q_UNUSED(networkManager)
-    return JapanAnaglyphMapUrl.arg(zoom).arg(x).arg(y);
-}
-
-static const QString JapanSlopeMapUrl = QStringLiteral("https://cyberjapandata.gsi.go.jp/xyz/slopemap/%1/%2/%3.png");
-
-QString JapanSlopeMapProvider::_getURL(const int x, const int y, const int zoom, QNetworkAccessManager* networkManager) {
-    Q_UNUSED(networkManager)
-    return JapanSlopeMapUrl.arg(zoom).arg(x).arg(y);
-}
-
-static const QString JapanReliefMapUrl = QStringLiteral("https://cyberjapandata.gsi.go.jp/xyz/relief/%1/%2/%3.png");
-
-QString JapanReliefMapProvider::_getURL(const int x, const int y, const int zoom, QNetworkAccessManager* networkManager) {
-    Q_UNUSED(networkManager)
-    return JapanReliefMapUrl.arg(zoom).arg(x).arg(y);
-}
-
-static const QString LINZBasemapMapUrl = QStringLiteral("https://basemaps.linz.govt.nz/v1/tiles/aerial/EPSG:3857/%1/%2/%3.png?api=d01ev80nqcjxddfvc6amyvkk1ka");
-
-QString LINZBasemapMapProvider::_getURL(const int x, const int y, const int zoom, QNetworkAccessManager* networkManager) {
-    Q_UNUSED(networkManager)
-    return LINZBasemapMapUrl.arg(zoom).arg(x).arg(y);
-}
-
-QString CustomURLMapProvider::_getURL(const int x, const int y, const int zoom, QNetworkAccessManager* networkManager) {
-    Q_UNUSED(networkManager)
+QString CustomURLMapProvider::_getURL(int x, int y, int zoom) const
+{
     QString url = qgcApp()->toolbox()->settingsManager()->appSettings()->customURL()->rawValue().toString();
-    return url.replace("{x}",QString::number(x)).replace("{y}",QString::number(y)).replace(QRegularExpression("\\{(z|zoom)\\}"),QString::number(zoom));
+    (void) url.replace("{x}", QString::number(x));
+    (void) url.replace("{y}", QString::number(y));
+    static const QRegularExpression zoomRegExp("\\{(z|zoom)\\}");
+    (void) url.replace(zoomRegExp, QString::number(zoom));
+    return url;
 }
 
-static const QString StatkartMapUrl = QStringLiteral("http://opencache.statkart.no/gatekeeper/gk/gk.open_gmaps?layers=topo4&zoom=%1&x=%2&y=%3");
-
-QString StatkartMapProvider::_getURL(const int x, const int y, const int zoom, QNetworkAccessManager* networkManager) {
-    Q_UNUSED(networkManager)
-    return StatkartMapUrl.arg(zoom).arg(x).arg(y);
+QString CyberJapanMapProvider::_getURL(int x, int y, int zoom) const
+{
+    return _mapUrl.arg(_mapName).arg(zoom).arg(x).arg(y).arg(_imageFormat);
 }
 
-static const QString StatkartBaseMapUrl = QStringLiteral("http://opencache.statkart.no/gatekeeper/gk/gk.open_gmaps?layers=norgeskart_bakgrunn&zoom=%1&x=%2&y=%3");
-
-QString StatkartBaseMapProvider::_getURL(const int x, const int y, const int zoom, QNetworkAccessManager* networkManager) {
-    Q_UNUSED(networkManager)
-    return StatkartBaseMapUrl.arg(zoom).arg(x).arg(y);
+QString LINZBasemapMapProvider::_getURL(int x, int y, int zoom) const
+{
+    return _mapUrl.arg(zoom).arg(x).arg(y).arg(_imageFormat);
 }
 
-
-static const QString EniroMapUrl = QStringLiteral("http://map.eniro.com/geowebcache/service/tms1.0.0/map/%1/%2/%3.png");
-
-QString EniroMapProvider::_getURL(const int x, const int y, const int zoom, QNetworkAccessManager* networkManager) {
-    Q_UNUSED(networkManager)
-    return EniroMapUrl.arg(zoom).arg(x).arg((1 << zoom) - 1 - y);
+QString StatkartMapProvider::_getURL(int x, int y, int zoom) const
+{
+    return _mapUrl.arg(_mapName).arg(zoom).arg(x).arg(y);
 }
 
-static const QString MapQuestMapUrl = QStringLiteral("http://otile%1.mqcdn.com/tiles/1.0.0/map/%2/%3/%4.jpg");
-
-QString MapQuestMapMapProvider::_getURL(const int x, const int y, const int zoom, QNetworkAccessManager* networkManager) {
-    Q_UNUSED(networkManager)
-    return MapQuestMapUrl.arg(_getServerNum(x, y, 4)).arg(zoom).arg(x).arg(y);
+QString EniroMapProvider::_getURL(int x, int y, int zoom) const
+{
+    return _mapUrl.arg(zoom).arg(x).arg((1 << zoom) - 1 - y).arg(_imageFormat);
 }
 
-static const QString MapQuestSatUrl = QStringLiteral("http://otile%1.mqcdn.com/tiles/1.0.0/sat/%2/%3/%4.jpg");
-
-QString MapQuestSatMapProvider::_getURL(const int x, const int y, const int zoom, QNetworkAccessManager* networkManager) {
-    Q_UNUSED(networkManager)
-    return MapQuestSatUrl.arg(_getServerNum(x, y, 4)).arg(zoom).arg(x).arg(y);
+QString MapQuestMapProvider::_getURL(int x, int y, int zoom) const
+{
+    return _mapUrl.arg(_getServerNum(x, y, 4)).arg(_mapName).arg(zoom).arg(x).arg(y).arg(_imageFormat);
 }
 
-QString VWorldStreetMapProvider::_getURL(const int x, const int y, const int zoom, QNetworkAccessManager* networkManager) {
-    Q_UNUSED(networkManager)
-    const int gap   = zoom - 6;
-    const int x_min = int(53 * pow(2, gap));
-    const int x_max = int(55 * pow(2, gap) + (2 * gap - 1));
-    const int y_min = int(22 * pow(2, gap));
-    const int y_max = int(26 * pow(2, gap) + (2 * gap - 1));
+QString VWorldMapProvider::_getURL(int x, int y, int zoom) const
+{
+    if ((zoom < 5) || (zoom > 19)) {
+        return QString();
+    }
+
+    const int gap = zoom - 6;
+
+    const int x_min = 53 * pow(2, gap);
+    const int x_max = (55 * pow(2, gap)) + (2 * gap - 1);
+    if ((x < x_min) || (x > x_max)) {
+        return QString();
+    }
+
+    const int y_min = 22 * pow(2, gap);
+    const int y_max = (26 * pow(2, gap)) + (2 * gap - 1);
+    if ((y < y_min) || (y > y_max)) {
+        return QString();
+    }
 
     const QString VWorldMapToken = qgcApp()->toolbox()->settingsManager()->appSettings()->vworldToken()->rawValue().toString();
-
-    if (zoom > 19) {
-        return QString();
-    } else if (zoom > 5 && x >= x_min && x <= x_max && y >= y_min && y <= y_max) {
-        return QString("http://api.vworld.kr/req/wmts/1.0.0/%1/Base/%2/%3/%4.png").arg(VWorldMapToken).arg(zoom).arg(y).arg(x);
-    } else {
-        const QString key = _tileXYToQuadKey(x, y, zoom);
-        return QString(QStringLiteral("http://ecn.t%1.tiles.virtualearth.net/tiles/r%2.png?g=%3&mkt=%4"))
-            .arg(_getServerNum(x, y, 4)).arg(key, _versionBingMaps, _language);
-    }
-}
-
-QString VWorldSatMapProvider::_getURL(const int x, const int y, const int zoom, QNetworkAccessManager* networkManager) {
-    Q_UNUSED(networkManager)
-    const int gap   = zoom - 6;
-    const int x_min = int(53 * pow(2, gap));
-    const int x_max = int(55 * pow(2, gap) + (2 * gap - 1));
-    const int y_min = int(22 * pow(2, gap));
-    const int y_max = int(26 * pow(2, gap) + (2 * gap - 1));
-
-    const QString VWorldMapToken = qgcApp()->toolbox()->settingsManager()->appSettings()->vworldToken()->rawValue().toString();
-
-    if (zoom > 19) {
-        return QString();
-    } else if (zoom > 5 && x >= x_min && x <= x_max && y >= y_min && y <= y_max) {
-        return QString("http://api.vworld.kr/req/wmts/1.0.0/%1/Satellite/%2/%3/%4.jpeg").arg(VWorldMapToken).arg(zoom).arg(y).arg(x);
-    } else {
-        const QString key = _tileXYToQuadKey(x, y, zoom);
-        return QString("http://ecn.t%1.tiles.virtualearth.net/tiles/a%2.jpeg?g=%3&mkt=%4")
-            .arg(_getServerNum(x, y, 4)).arg(key, _versionBingMaps, _language);
-    }
+    return _mapUrl.arg(VWorldMapToken, _mapName).arg(zoom).arg(y).arg(x).arg(_imageFormat);
 }

--- a/src/QtLocationPlugin/GenericMapProvider.h
+++ b/src/QtLocationPlugin/GenericMapProvider.h
@@ -10,148 +10,211 @@
 
 #include "MapProvider.h"
 
-class JapanStdMapProvider : public MapProvider {
+class CustomURLMapProvider : public MapProvider
+{
     Q_OBJECT
-  public:
-    JapanStdMapProvider(QObject* parent = nullptr)
-        : MapProvider(QStringLiteral("https://cyberjapandata.gsi.go.jp/xyz/std"), QStringLiteral("png"),
-                      AVERAGE_TILE_SIZE, QGeoMapType::StreetMap, parent) {}
 
-    QString _getURL(const int x, const int y, const int zoom, QNetworkAccessManager* networkManager) override;
-};
-
-class JapanSeamlessMapProvider : public MapProvider {
-    Q_OBJECT
-  public:
-    JapanSeamlessMapProvider(QObject* parent = nullptr)
-        : MapProvider(QStringLiteral("https://cyberjapandata.gsi.go.jp/xyz/seamlessphoto"), QStringLiteral("jpg"),
-                      AVERAGE_TILE_SIZE, QGeoMapType::StreetMap, parent) {}
-
-    QString _getURL(const int x, const int y, const int zoom, QNetworkAccessManager* networkManager) override;
-};
-
-class JapanAnaglyphMapProvider : public MapProvider {
-    Q_OBJECT
-  public:
-    JapanAnaglyphMapProvider(QObject* parent = nullptr)
-        : MapProvider(QStringLiteral("https://cyberjapandata.gsi.go.jp/xyz/anaglyphmap_color"), QStringLiteral("png"),
-                      AVERAGE_TILE_SIZE, QGeoMapType::StreetMap, parent) {}
-
-    QString _getURL(const int x, const int y, const int zoom, QNetworkAccessManager* networkManager) override;
-};
-
-class JapanSlopeMapProvider : public MapProvider {
-    Q_OBJECT
-  public:
-    JapanSlopeMapProvider(QObject* parent = nullptr)
-        : MapProvider(QStringLiteral("https://cyberjapandata.gsi.go.jp/xyz/slopemap"), QStringLiteral("png"),
-                      AVERAGE_TILE_SIZE, QGeoMapType::StreetMap, parent) {}
-
-    QString _getURL(const int x, const int y, const int zoom, QNetworkAccessManager* networkManager) override;
-};
-
-class JapanReliefMapProvider : public MapProvider {
-    Q_OBJECT
-  public:
-    JapanReliefMapProvider(QObject* parent = nullptr)
-        : MapProvider(QStringLiteral("https://cyberjapandata.gsi.go.jp/xyz/relief"), QStringLiteral("png"),
-                      AVERAGE_TILE_SIZE, QGeoMapType::StreetMap, parent) {}
-
-    QString _getURL(const int x, const int y, const int zoom, QNetworkAccessManager* networkManager) override;
-};
-
-class LINZBasemapMapProvider : public MapProvider {
-    Q_OBJECT
-  public:
-    LINZBasemapMapProvider(QObject* parent = nullptr)
-        : MapProvider(QStringLiteral("https://basemaps.linz.govt.nz/v1/tiles/aerial"), QStringLiteral("png"),
-                      AVERAGE_TILE_SIZE, QGeoMapType::SatelliteMapDay, parent) {}
-
-    QString _getURL(const int x, const int y, const int zoom, QNetworkAccessManager* networkManager) override;
-};
-
-class CustomURLMapProvider : public MapProvider {
-    Q_OBJECT
-  public:
+public:
     CustomURLMapProvider(QObject* parent = nullptr)
         : MapProvider(QStringLiteral(""), QStringLiteral(""),
                       AVERAGE_TILE_SIZE, QGeoMapType::CustomMap, parent) {}
 
-    QString _getURL(const int x, const int y, const int zoom, QNetworkAccessManager* networkManager) override;
+private:
+    QString _getURL(int x, int y, int zoom) const final;
 };
 
-class StatkartMapProvider : public MapProvider {
+class CyberJapanMapProvider : public MapProvider
+{
     Q_OBJECT
-  public:
-    StatkartMapProvider(QObject* parent = nullptr)
+
+protected:
+    CyberJapanMapProvider(const QString &mapName, const QString& imageFormat, QObject* parent = nullptr)
+        : MapProvider(QStringLiteral("https://cyberjapandata.gsi.go.jp/xyz/std"), imageFormat,
+                      AVERAGE_TILE_SIZE, QGeoMapType::StreetMap, parent)
+        , _mapName(mapName) {}
+
+private:
+    QString _getURL(int x, int y, int zoom) const final;
+
+    const QString _mapName;
+    const QString _mapUrl = QStringLiteral("https://cyberjapandata.gsi.go.jp/xyz/%1/%2/%3/%4.%5");
+};
+
+class JapanStdMapProvider : public CyberJapanMapProvider
+{
+    Q_OBJECT
+
+public:
+    JapanStdMapProvider(QObject* parent = nullptr)
+        : CyberJapanMapProvider(QStringLiteral("std"), QStringLiteral("png"), parent) {}
+};
+
+class JapanSeamlessMapProvider : public CyberJapanMapProvider
+{
+    Q_OBJECT
+
+public:
+    JapanSeamlessMapProvider(QObject* parent = nullptr)
+        : CyberJapanMapProvider(QStringLiteral("seamlessphoto"), QStringLiteral("jpg"), parent) {}
+};
+
+class JapanAnaglyphMapProvider : public CyberJapanMapProvider
+{
+    Q_OBJECT
+
+public:
+    JapanAnaglyphMapProvider(QObject* parent = nullptr)
+        : CyberJapanMapProvider(QStringLiteral("anaglyphmap_color"), QStringLiteral("png"), parent) {}
+};
+
+class JapanSlopeMapProvider : public CyberJapanMapProvider
+{
+    Q_OBJECT
+
+public:
+    JapanSlopeMapProvider(QObject* parent = nullptr)
+        : CyberJapanMapProvider(QStringLiteral("slopemap"), QStringLiteral("png"), parent) {}
+};
+
+class JapanReliefMapProvider : public CyberJapanMapProvider
+{
+    Q_OBJECT
+
+public:
+    JapanReliefMapProvider(QObject* parent = nullptr)
+        : CyberJapanMapProvider(QStringLiteral("relief"), QStringLiteral("png"), parent) {}
+};
+
+class LINZBasemapMapProvider : public MapProvider
+{
+    Q_OBJECT
+
+public:
+    LINZBasemapMapProvider(QObject* parent = nullptr)
+        : MapProvider(QStringLiteral("https://basemaps.linz.govt.nz/v1/tiles/aerial"), QStringLiteral("png"),
+                      AVERAGE_TILE_SIZE, QGeoMapType::SatelliteMapDay, parent) {}
+
+private:
+    QString _getURL(int x, int y, int zoom) const final;
+
+    const QString _mapUrl = QStringLiteral("https://basemaps.linz.govt.nz/v1/tiles/aerial/EPSG:3857/%1/%2/%3.%4?api=d01ev80nqcjxddfvc6amyvkk1ka");
+};
+
+class StatkartMapProvider : public MapProvider
+{
+    Q_OBJECT
+
+protected:
+    StatkartMapProvider(const QString &mapName, QObject* parent = nullptr)
         : MapProvider(QStringLiteral("https://norgeskart.no/"), QStringLiteral("png"),
-                      AVERAGE_TILE_SIZE, QGeoMapType::StreetMap, parent) {}
+                      AVERAGE_TILE_SIZE, QGeoMapType::StreetMap, parent)
+        , _mapName(mapName) {}
 
-    QString _getURL(const int x, const int y, const int zoom, QNetworkAccessManager* networkManager) override;
+private:
+    QString _getURL(int x, int y, int zoom) const final;
+
+    const QString _mapName;
+    const QString _mapUrl = QStringLiteral("http://opencache.statkart.no/gatekeeper/gk/gk.open_gmaps?layers=%1&zoom=%2&x=%3&y=%4");
 };
 
-class StatkartBaseMapProvider : public MapProvider {
+class StatkartTopoMapProvider : public StatkartMapProvider
+{
     Q_OBJECT
-  public:
+
+public:
+    StatkartTopoMapProvider(QObject* parent = nullptr)
+        : StatkartMapProvider(QStringLiteral("topo4"), parent) {}
+};
+
+class StatkartBaseMapProvider : public StatkartMapProvider
+{
+    Q_OBJECT
+
+public:
     StatkartBaseMapProvider(QObject* parent = nullptr)
-        : MapProvider(QStringLiteral("https://norgeskart.no/"), QStringLiteral("png"),
-                      AVERAGE_TILE_SIZE, QGeoMapType::StreetMap, parent) {}
-
-    QString _getURL(const int x, const int y, const int zoom, QNetworkAccessManager* networkManager) override;
+        : StatkartMapProvider(QStringLiteral("norgeskart_bakgrunn"), parent) {}
 };
 
-class EniroMapProvider : public MapProvider {
+class EniroMapProvider : public MapProvider
+{
     Q_OBJECT
-  public:
+
+public:
     EniroMapProvider(QObject* parent = nullptr)
         : MapProvider(QStringLiteral("https://www.eniro.se/"), QStringLiteral("png"),
                       AVERAGE_TILE_SIZE, QGeoMapType::StreetMap, parent) {}
 
-    QString _getURL(const int x, const int y, const int zoom, QNetworkAccessManager* networkManager) override;
+private:
+    QString _getURL(int x, int y, int zoom) const final;
+
+    const QString _mapUrl = QStringLiteral("http://map.eniro.com/geowebcache/service/tms1.0.0/map/%1/%2/%3.%4");
 };
 
-class MapQuestMapMapProvider : public MapProvider {
+class MapQuestMapProvider : public MapProvider
+{
     Q_OBJECT
-  public:
+
+protected:
+    MapQuestMapProvider(const QString &mapName, QGeoMapType::MapStyle mapType, QObject* parent = nullptr)
+        : MapProvider(QStringLiteral("https://mapquest.com"), QStringLiteral("jpg"),
+                      AVERAGE_TILE_SIZE, mapType, parent)
+        , _mapName(mapName) {}
+
+private:
+    QString _getURL(int x, int y, int zoom) const final;
+
+    const QString _mapName;
+    const QString _mapUrl = QStringLiteral("http://otile%1.mqcdn.com/tiles/1.0.0/%2/%3/%4/%5.%6");
+};
+
+class MapQuestMapMapProvider : public MapQuestMapProvider
+{
+    Q_OBJECT
+
+public:
     MapQuestMapMapProvider(QObject* parent = nullptr)
-        : MapProvider(QStringLiteral("https://mapquest.com"), QStringLiteral("jpg"),
-                      AVERAGE_TILE_SIZE, QGeoMapType::StreetMap, parent) {}
-
-    QString _getURL(const int x, const int y, const int zoom, QNetworkAccessManager* networkManager) override;
+        : MapQuestMapProvider(QStringLiteral("map"), QGeoMapType::StreetMap, parent) {}
 };
 
-class MapQuestSatMapProvider : public MapProvider {
+class MapQuestSatMapProvider : public MapQuestMapProvider
+{
     Q_OBJECT
-  public:
+
+public:
     MapQuestSatMapProvider(QObject* parent = nullptr)
-        : MapProvider(QStringLiteral("https://mapquest.com"), QStringLiteral("jpg"),
-                      AVERAGE_TILE_SIZE, QGeoMapType::SatelliteMapDay, parent) {}
-
-    QString _getURL(const int x, const int y, const int zoom, QNetworkAccessManager* networkManager) override;
+        : MapQuestMapProvider(QStringLiteral("sat"), QGeoMapType::SatelliteMapDay, parent) {}
 };
 
-class VWorldStreetMapProvider : public MapProvider {
+class VWorldMapProvider : public MapProvider
+{
     Q_OBJECT
-  public:
+
+protected:
+    VWorldMapProvider(const QString &mapName, const QString& imageFormat, quint32 averageSize, QGeoMapType::MapStyle mapStyle, QObject* parent = nullptr)
+        : MapProvider(QStringLiteral("www.vworld.kr"), imageFormat, averageSize, mapStyle, parent)
+        , _mapName(mapName) {}
+
+private:
+    QString _getURL(int x, int y, int zoom) const final;
+
+    const QString _mapName;
+    const QString _mapUrl = QStringLiteral("http://api.vworld.kr/req/wmts/1.0.0/%1/%2/%3/%4/%5.%6");
+};
+
+class VWorldStreetMapProvider : public VWorldMapProvider
+{
+    Q_OBJECT
+
+public:
     VWorldStreetMapProvider(QObject* parent = nullptr)
-        : MapProvider(QStringLiteral("www.vworld.kr"), QStringLiteral("png"),
-                      AVERAGE_TILE_SIZE, QGeoMapType::StreetMap, parent) {}
-
-    QString _getURL(const int x, const int y, const int zoom, QNetworkAccessManager* networkManager) override;
-
-  private:
-    const QString _versionBingMaps = QStringLiteral("563");
+        : VWorldMapProvider(QStringLiteral("Base"), QStringLiteral("png"), AVERAGE_TILE_SIZE, QGeoMapType::StreetMap, parent) {}
 };
 
-class VWorldSatMapProvider : public MapProvider {
+class VWorldSatMapProvider : public VWorldMapProvider
+{
     Q_OBJECT
-  public:
+
+public:
     VWorldSatMapProvider(QObject* parent = nullptr)
-        : MapProvider(QStringLiteral("www.vworld.kr"), QStringLiteral("jpeg"),
-                      AVERAGE_TILE_SIZE, QGeoMapType::SatelliteMapDay, parent) {}
-
-    QString _getURL(const int x, const int y, const int zoom, QNetworkAccessManager* networkManager) override;
-
-  private:
-    const QString _versionBingMaps = QStringLiteral("563");
+        : VWorldMapProvider(QStringLiteral("Satellite"), QStringLiteral("jpeg"), AVERAGE_TILE_SIZE, QGeoMapType::SatelliteMapDay, parent) {}
 };

--- a/src/QtLocationPlugin/GoogleMapProvider.cpp
+++ b/src/QtLocationPlugin/GoogleMapProvider.cpp
@@ -8,224 +8,29 @@
  ****************************************************************************/
 
 #include "GoogleMapProvider.h"
-#include "QGCMapEngine.h"
-#if defined(DEBUG_GOOGLE_MAPS)
-#include <QtCore/QFile>
-#include <QtCore/QStandardPaths>
-#endif
-#include <QtNetwork/QNetworkProxy>
-#include <QtCore/QRegularExpression>
-#include <QtCore/QRegularExpressionMatch>
 
-
-GoogleMapProvider::GoogleMapProvider(const QString &imageFormat, const quint32 averageSize, const QGeoMapType::MapStyle mapType, QObject* parent)
-    : MapProvider(QStringLiteral("https://www.google.com/maps/preview"), imageFormat, averageSize, mapType, parent)
-    , _googleVersionRetrieved(false)
-    , _googleReply(nullptr)
+void GoogleMapProvider::_getSecGoogleWords(int x, int y, QString& sec1, QString& sec2) const
 {
-    // Google version strings
-    _versionGoogleMap       = QStringLiteral("m@354000000");
-    _versionGoogleSatellite = QStringLiteral("692");
-    _versionGoogleLabels    = QStringLiteral("h@336");
-    _versionGoogleTerrain   = QStringLiteral("t@354,r@354000000");
-    _versionGoogleHybrid    = QStringLiteral("y");
-    _secGoogleWord          = QStringLiteral("Galileo");
-}
-
-GoogleMapProvider::~GoogleMapProvider() {
-    if (_googleReply)
-        _googleReply->deleteLater();
-}
-
-//-----------------------------------------------------------------------------
-void GoogleMapProvider::_getSecGoogleWords(const int x, const int y, QString& sec1, QString& sec2) const {
-    sec1       = QStringLiteral(""); // after &x=...
-    sec2       = QStringLiteral(""); // after &zoom=...
-    int seclen = ((x * 3) + y) % 8;
-    sec2       = _secGoogleWord.left(seclen);
-    if (y >= 10000 && y < 100000) {
+    sec1 = QStringLiteral(""); // after &x=...
+    sec2 = QStringLiteral(""); // after &zoom=...
+    const int seclen = ((x * 3) + y) % 8;
+    sec2 = _secGoogleWord.left(seclen);
+    if ((y >= 10000) && (y < 100000)) {
         sec1 = QStringLiteral("&s=");
     }
 }
 
-//-----------------------------------------------------------------------------
-void GoogleMapProvider::_networkReplyError(QNetworkReply::NetworkError error) {
-    qWarning() << "Could not connect to google maps. Error:" << error;
-    if (_googleReply) {
-        _googleReply->deleteLater();
-        _googleReply = nullptr;
-    }
-}
-//-----------------------------------------------------------------------------
-void GoogleMapProvider::_replyDestroyed() {
-    _googleReply = nullptr;
-}
-
-void GoogleMapProvider::_googleVersionCompleted() {
-    if (!_googleReply || (_googleReply->error() != QNetworkReply::NoError)) {
-        qDebug() << "Error collecting Google maps version info";
-        return;
-    }
-    const QString html = QString(_googleReply->readAll());
-
-#if defined(DEBUG_GOOGLE_MAPS)
-    QString filename = QStandardPaths::writableLocation(QStandardPaths::HomeLocation);
-    filename += QStringLiteral("/google.output");
-    QFile file(filename);
-    if (file.open(QIODevice::ReadWrite)) {
-        QTextStream stream(&file);
-        stream << html << endl;
-    }
-#endif
-
-    static const QRegularExpression regMap("\"*https?://mt\\D?\\d..*/vt\\?lyrs=m@(\\d*)", QRegularExpression::CaseInsensitiveOption);
-    const QRegularExpressionMatch matchMap = regMap.match(html);
-    if (matchMap.hasMatch()) {
-        _versionGoogleMap = QString("m@%1").arg(matchMap.captured(1));
-    }
-
-    static const QRegularExpression regSatellite( "\"*https?://khm\\D?\\d.googleapis.com/kh\\?v=(\\d*)", QRegularExpression::CaseInsensitiveOption);
-    const QRegularExpressionMatch matchSatellite = regSatellite.match( html );
-    if (matchSatellite.hasMatch()) {
-        _versionGoogleSatellite = matchSatellite.captured(1);
-    }
-
-    static const QRegularExpression regTerrain( "\"*https?://mt\\D?\\d..*/vt\\?lyrs=t@(\\d*),r@(\\d*)", QRegularExpression::CaseInsensitiveOption);
-    const QRegularExpressionMatch matchTerrain = regTerrain.match(html);
-    if (matchTerrain.hasMatch()) {
-        _versionGoogleTerrain = QString("t@%1,r@%2").arg( matchTerrain.captured(1), matchTerrain.captured(2));
-    }
-
-    _googleReply->deleteLater();
-    _googleReply = nullptr;
-}
-
-void GoogleMapProvider::_tryCorrectGoogleVersions(QNetworkAccessManager* networkManager) {
-    QMutexLocker locker(&_googleVersionMutex);
-    if (_googleVersionRetrieved) {
-        return;
-    }
-    _googleVersionRetrieved = true;
-    if (networkManager) {
-        QNetworkRequest qheader;
-        QNetworkProxy   proxy = networkManager->proxy();
-        QNetworkProxy   tProxy;
-        tProxy.setType(QNetworkProxy::DefaultProxy);
-        networkManager->setProxy(tProxy);
-        QSslConfiguration conf = qheader.sslConfiguration();
-        conf.setPeerVerifyMode(QSslSocket::VerifyNone);
-        qheader.setSslConfiguration(conf);
-        const QString url = QStringLiteral("http://maps.google.com/maps/api/js?v=3.2&sensor=false");
-        qheader.setUrl(QUrl(url));
-        QByteArray ua;
-        ua.append(getQGCMapEngine()->userAgent().toLatin1());
-        qheader.setRawHeader("User-Agent", ua);
-        _googleReply = networkManager->get(qheader);
-        connect(_googleReply, &QNetworkReply::finished, this, &GoogleMapProvider::_googleVersionCompleted);
-        connect(_googleReply, &QNetworkReply::destroyed, this, &GoogleMapProvider::_replyDestroyed);
-        connect(_googleReply, &QNetworkReply::errorOccurred, this, &GoogleMapProvider::_networkReplyError);
-        networkManager->setProxy(proxy);
-    }
-}
-
-QString GoogleStreetMapProvider::_getURL(const int x, const int y, const int zoom, QNetworkAccessManager* networkManager) {
-    // http://mt1.google.com/vt/lyrs=m
-    QString server  = QStringLiteral("mt");
-    QString request = QStringLiteral("vt");
-    QString sec1; // after &x=...
-    QString sec2; // after &zoom=...
+QString GoogleMapProvider::_getURL(int x, int y, int zoom) const
+{
+    QString sec1;
+    QString sec2;
     _getSecGoogleWords(x, y, sec1, sec2);
-    _tryCorrectGoogleVersions(networkManager);
-    return QString(QStringLiteral("http://%1%2.google.com/%3/lyrs=%4&hl=%5&x=%6%7&y=%8&z=%9&s=%10"))
-        .arg(server)
+    return _mapUrl
         .arg(_getServerNum(x, y, 4))
-        .arg(request)
-        .arg(_versionGoogleMap)
-        .arg(_language)
+        .arg(_versionRequest, _version, _language)
         .arg(x)
         .arg(sec1)
         .arg(y)
         .arg(zoom)
-        .arg(sec2);
-}
-
-QString GoogleSatelliteMapProvider::_getURL(const int x, const int y, const int zoom, QNetworkAccessManager* networkManager) {
-    // http://mt1.google.com/vt/lyrs=s
-    QString server  = QStringLiteral("khm");
-    QString request = QStringLiteral("kh");
-    QString sec1; // after &x=...
-    QString sec2; // after &zoom=...
-    _getSecGoogleWords(x, y, sec1, sec2);
-    _tryCorrectGoogleVersions(networkManager);
-    return QString(QStringLiteral("http://%1%2.google.com/%3/v=%4&hl=%5&x=%6%7&y=%8&z=%9&s=%10"))
-        .arg(server)
-        .arg(_getServerNum(x, y, 4))
-        .arg(request)
-        .arg(_versionGoogleSatellite)
-        .arg(_language)
-        .arg(x)
-        .arg(sec1)
-        .arg(y)
-        .arg(zoom)
-        .arg(sec2);
-}
-
-QString GoogleLabelsMapProvider::_getURL(const int x, const int y, const int zoom, QNetworkAccessManager* networkManager) {
-    QString server  = "mts";
-    QString request = "vt";
-    QString sec1; // after &x=...
-    QString sec2; // after &zoom=...
-    _getSecGoogleWords(x, y, sec1, sec2);
-    _tryCorrectGoogleVersions(networkManager);
-    return QString(QStringLiteral("http://%1%2.google.com/%3/lyrs=%4&hl=%5&x=%6%7&y=%8&z=%9&s=%10"))
-        .arg(server)
-        .arg(_getServerNum(x, y, 4))
-        .arg(request)
-        .arg(_versionGoogleLabels)
-        .arg(_language)
-        .arg(x)
-        .arg(sec1)
-        .arg(y)
-        .arg(zoom)
-        .arg(sec2);
-}
-
-QString GoogleTerrainMapProvider::_getURL(const int x, const int y, const int zoom, QNetworkAccessManager* networkManager) {
-    QString server  = QStringLiteral("mt");
-    QString request = QStringLiteral("vt");
-    QString sec1; // after &x=...
-    QString sec2; // after &zoom=...
-    _getSecGoogleWords(x, y, sec1, sec2);
-    _tryCorrectGoogleVersions(networkManager);
-    return QString(QStringLiteral("http://%1%2.google.com/%3/v=%4&hl=%5&x=%6%7&y=%8&z=%9&s=%10"))
-        .arg(server)
-        .arg(_getServerNum(x, y, 4))
-        .arg(request)
-        .arg(_versionGoogleTerrain)
-        .arg(_language)
-        .arg(x)
-        .arg(sec1)
-        .arg(y)
-        .arg(zoom)
-        .arg(sec2);
-}
-
-QString GoogleHybridMapProvider::_getURL(const int x, const int y, const int zoom, QNetworkAccessManager* networkManager) {
-    QString server = QStringLiteral("mt");
-    QString request = QStringLiteral("vt");
-    QString sec1; // after &x=...
-    QString sec2; // after &zoom=...
-    _getSecGoogleWords(x, y, sec1, sec2);
-    _tryCorrectGoogleVersions(networkManager);
-    return QString(QStringLiteral("http://%1%2.google.com/%3/lyrs=%4&hl=%5&x=%6%7&y=%8&z=%9&s=%10"))
-        .arg(server)
-        .arg(_getServerNum(x, y, 4))
-        .arg(request)
-        .arg(_versionGoogleHybrid)
-        .arg(_language)
-        .arg(x)
-        .arg(sec1)
-        .arg(y)
-        .arg(zoom)
-        .arg(sec2);
+        .arg(sec2, _scale);
 }

--- a/src/QtLocationPlugin/GoogleMapProvider.h
+++ b/src/QtLocationPlugin/GoogleMapProvider.h
@@ -11,125 +11,88 @@
 
 #include "MapProvider.h"
 
-#include <QtNetwork/QNetworkReply>
-#include <QtCore/QMutex>
+// h: roads only
+// m: standard roadmap
+// p: terrain
+// r: somehow altered roadmap
+// s: satellite only
+// t: terrain only
+// y: hybrid (s,h)
+// traffic
+// transit
+// bike
+// mt.google.com: mt0, mt1, mt2 mt3
+// size: 256x256
+// maxZoom: 20
 
-class GoogleMapProvider : public MapProvider {
+static constexpr const quint32 AVERAGE_GOOGLE_STREET_MAP  = 4913;
+static constexpr const quint32 AVERAGE_GOOGLE_SAT_MAP     = 56887;
+static constexpr const quint32 AVERAGE_GOOGLE_TERRAIN_MAP = 19391;
+
+class GoogleMapProvider : public MapProvider
+{
     Q_OBJECT
 
-public:
-    GoogleMapProvider(const QString& imageFormat, const quint32 averageSize,
-                      const QGeoMapType::MapStyle _mapType, QObject* parent = nullptr);
-
-    ~GoogleMapProvider();
-
-    // Google Specific private slots
-private slots:
-    void _networkReplyError(QNetworkReply::NetworkError error);
-    void _googleVersionCompleted();
-    void _replyDestroyed();
-
 protected:
-    // Google Specific private methods
-    void _getSecGoogleWords(const int x, const int y, QString& sec1, QString& sec2) const;
-    void _tryCorrectGoogleVersions(QNetworkAccessManager* networkManager);
+    GoogleMapProvider(const QString& versionRequest, const QString& version, const QString& imageFormat, quint32 averageSize,
+                      QGeoMapType::MapStyle mapType, QObject* parent = nullptr)
+        : MapProvider(QStringLiteral("https://www.google.com/maps/preview"), imageFormat, averageSize, mapType, parent)
+        , _versionRequest(versionRequest)
+        , _version(version) {}
 
-    // Google Specific attributes
-    bool           _googleVersionRetrieved;
-    QNetworkReply* _googleReply;
-    QMutex         _googleVersionMutex;
-    QString        _versionGoogleMap;
-    QString        _versionGoogleSatellite;
-    QString        _versionGoogleLabels;
-    QString        _versionGoogleTerrain;
-    QString        _versionGoogleHybrid;
-    QString        _secGoogleWord;
+private:
+    void _getSecGoogleWords(int x, int y, QString& sec1, QString& sec2) const;
+    QString _getURL(int x, int y, int zoom) const final;
+
+    const QString _versionRequest;
+    const QString _version;
+    const QString _mapUrl = QStringLiteral("http://mt%1.google.com/vt/%2=%3&hl=%4&x=%5%6&y=%7&z=%8&s=%9&scale=%10");
+    const QString _secGoogleWord = QStringLiteral("Galileo");
+    const QString _scale = QStringLiteral("1");
 };
 
-// NoMap = 0,
-// StreetMap,
-// SatelliteMapDay,
-// SatelliteMapNight,
-// TerrainMap,
-// HybridMap,
-// TransitMap,
-// GrayStreetMap,
-// PedestrianMap,
-// CarNavigationMap,
-// CycleMap,
-// CustomMap = 100
-
-static const quint32 AVERAGE_GOOGLE_STREET_MAP  = 4913;
-static const quint32 AVERAGE_GOOGLE_SAT_MAP     = 56887;
-static const quint32 AVERAGE_GOOGLE_TERRAIN_MAP = 19391;
-
-// -----------------------------------------------------------
-// Google Street Map
-
-class GoogleStreetMapProvider : public GoogleMapProvider {
+class GoogleStreetMapProvider : public GoogleMapProvider
+{
     Q_OBJECT
 
 public:
     GoogleStreetMapProvider(QObject* parent = nullptr)
-        : GoogleMapProvider(QStringLiteral("png"), AVERAGE_GOOGLE_STREET_MAP, QGeoMapType::StreetMap, parent) {}
-
-protected:
-     QString _getURL(const int x, const int y, const int zoom, QNetworkAccessManager* networkManager) override;
+        : GoogleMapProvider(QStringLiteral("lyrs"), QStringLiteral("m"), QStringLiteral("png"), AVERAGE_GOOGLE_STREET_MAP, QGeoMapType::StreetMap, parent) {}
 };
 
-// -----------------------------------------------------------
-// Google Street Map
-
-class GoogleSatelliteMapProvider : public GoogleMapProvider {
+class GoogleSatelliteMapProvider : public GoogleMapProvider
+{
     Q_OBJECT
 
 public:
     GoogleSatelliteMapProvider(QObject* parent = nullptr)
-        : GoogleMapProvider(QStringLiteral("jpg"), AVERAGE_GOOGLE_SAT_MAP,
+        : GoogleMapProvider(QStringLiteral("lyrs"), QStringLiteral("s"), QStringLiteral("jpg"), AVERAGE_GOOGLE_SAT_MAP,
                             QGeoMapType::SatelliteMapDay, parent) {}
-
-protected:
-    QString _getURL(const int x, const int y, const int zoom, QNetworkAccessManager* networkManager) override;
 };
 
-// -----------------------------------------------------------
-// Google Labels Map
-
-class GoogleLabelsMapProvider : public GoogleMapProvider {
+class GoogleLabelsMapProvider : public GoogleMapProvider
+{
     Q_OBJECT
 
 public:
     GoogleLabelsMapProvider(QObject* parent = nullptr)
-        : GoogleMapProvider(QStringLiteral("png"), AVERAGE_TILE_SIZE, QGeoMapType::CustomMap, parent) {}
-
-protected:
-    QString _getURL(const int x, const int y, const int zoom, QNetworkAccessManager* networkManager) override;
+        : GoogleMapProvider(QStringLiteral("lyrs"), QStringLiteral("h"), QStringLiteral("png"), AVERAGE_TILE_SIZE, QGeoMapType::CustomMap, parent) {}
 };
 
-// -----------------------------------------------------------
-// Google Terrain Map
-
-class GoogleTerrainMapProvider : public GoogleMapProvider {
+class GoogleTerrainMapProvider : public GoogleMapProvider
+{
     Q_OBJECT
 
 public:
     GoogleTerrainMapProvider(QObject* parent = nullptr)
-        : GoogleMapProvider(QStringLiteral("png"), AVERAGE_GOOGLE_TERRAIN_MAP, QGeoMapType::TerrainMap, parent) {}
-
-protected:
-    QString _getURL(const int x, const int y, const int zoom, QNetworkAccessManager* networkManager) override;
+        : GoogleMapProvider(QStringLiteral("v"), QStringLiteral("t,r"), QStringLiteral("png"), AVERAGE_GOOGLE_TERRAIN_MAP, QGeoMapType::TerrainMap, parent) {}
 };
 
-// -----------------------------------------------------------
-// Google Hybrid Map
-
-class GoogleHybridMapProvider : public GoogleMapProvider {
+class GoogleHybridMapProvider : public GoogleMapProvider
+{
     Q_OBJECT
 
 public:
     GoogleHybridMapProvider(QObject* parent = nullptr)
-        : GoogleMapProvider(QStringLiteral("png"), AVERAGE_GOOGLE_SAT_MAP, QGeoMapType::HybridMap, parent) {}
-
-protected:
-    QString _getURL(const int x, const int y, const int zoom, QNetworkAccessManager* networkManager) override;
+        : GoogleMapProvider(QStringLiteral("lyrs"), QStringLiteral("y"), QStringLiteral("png"), AVERAGE_GOOGLE_SAT_MAP, QGeoMapType::HybridMap, parent) {}
 };

--- a/src/QtLocationPlugin/MapProvider.cpp
+++ b/src/QtLocationPlugin/MapProvider.cpp
@@ -8,94 +8,103 @@
  ****************************************************************************/
 
 #include "MapProvider.h"
+#include <QGCLoggingCategory.h>
 
-#include <QtNetwork/QNetworkAccessManager>
+#include <QtCore/QLocale>
 #include <QtNetwork/QNetworkRequest>
 
-MapProvider::MapProvider(
-    const QString &referrer, 
-    const QString &imageFormat,
-    const quint32 averageSize, 
-    const QGeoMapType::MapStyle mapStyle, 
-    QObject* parent)
-    : QObject       (parent)
-    , _referrer     (referrer)
-    , _imageFormat  (imageFormat)
-    , _averageSize  (averageSize)
-    , _mapStyle     (mapStyle)
-{
-    const QStringList langs = QLocale::system().uiLanguages();
-    if (langs.length() > 0) {
-        _language = langs[0];
-    }
-}
+QGC_LOGGING_CATEGORY(MapProviderLog, "qgc.qtlocationplugin.mapprovider")
 
-QNetworkRequest MapProvider::getTileURL(const int x, const int y, const int zoom, QNetworkAccessManager* networkManager) {
-    //-- Build URL
+MapProvider::MapProvider(
+    const QString &referrer,
+    const QString &imageFormat,
+    quint32 averageSize,
+    QGeoMapType::MapStyle mapStyle,
+    QObject* parent)
+    : QObject(parent)
+    , _referrer(referrer)
+    , _imageFormat(imageFormat)
+    , _averageSize(averageSize)
+    , _mapStyle(mapStyle)
+    , _language(!QLocale::system().uiLanguages().isEmpty() ? QLocale::system().uiLanguages().constFirst() : "en") {}
+
+QNetworkRequest MapProvider::getTileURL(int x, int y, int zoom) const
+{
     QNetworkRequest request;
-    const QString url = _getURL(x, y, zoom, networkManager);
+    const QString url = _getURL(x, y, zoom);
     if (url.isEmpty()) {
         return request;
     }
     request.setUrl(QUrl(url));
     request.setRawHeader(QByteArrayLiteral("Accept"), QByteArrayLiteral("*/*"));
     request.setRawHeader(QByteArrayLiteral("Referrer"), _referrer.toUtf8());
-    request.setRawHeader(QByteArrayLiteral("User-Agent"), _userAgent);
+    request.setRawHeader(QByteArrayLiteral("User-Agent"), QByteArrayLiteral("Qt Location based application"));
     return request;
 }
 
-QString MapProvider::getImageFormat(const QByteArray& image) const {
-    QString format;
-    if (image.size() > 2) {
-        if (image.startsWith(reinterpret_cast<const char*>(pngSignature)))
-            format = QStringLiteral("png");
-        else if (image.startsWith(reinterpret_cast<const char*>(jpegSignature)))
-            format = QStringLiteral("jpg");
-        else if (image.startsWith(reinterpret_cast<const char*>(gifSignature)))
-            format = QStringLiteral("gif");
-        else {
-            return _imageFormat;
-        }
+QString MapProvider::getImageFormat(QByteArrayView image) const
+{
+    if (image.size() < 3) {
+        return QString();
     }
-    return format;
+
+    static constexpr QByteArrayView pngSignature("\x89\x50\x4E\x47\x0D\x0A\x1A\x0A");
+    if (image.startsWith(pngSignature)) {
+        return QStringLiteral("png");
+    }
+
+    static constexpr QByteArrayView jpegSignature("\xFF\xD8\xFF");
+    if (image.startsWith(jpegSignature)) {
+        return QStringLiteral("jpg");
+    }
+
+    static constexpr QByteArrayView gifSignature("\x47\x49\x46\x38");
+    if (image.startsWith(gifSignature)) {
+        return QStringLiteral("gif");
+    }
+
+    return _imageFormat;
 }
 
-QString MapProvider::_tileXYToQuadKey(const int tileX, const int tileY, const int levelOfDetail) const {
+QString MapProvider::_tileXYToQuadKey(int tileX, int tileY, int levelOfDetail) const
+{
     QString quadKey;
     for (int i = levelOfDetail; i > 0; i--) {
         char digit = '0';
-        const int  mask  = 1 << (i - 1);
+        const int mask = 1 << (i - 1);
+
         if ((tileX & mask) != 0) {
             digit++;
         }
         if ((tileY & mask) != 0) {
-            digit++;
-            digit++;
+            digit += 2;
         }
-        quadKey.append(digit);
+
+        (void) quadKey.append(digit);
     }
+
     return quadKey;
 }
 
-int MapProvider::_getServerNum(const int x, const int y, const int max) const {
+int MapProvider::_getServerNum(int x, int y, int max) const
+{
     return (x + 2 * y) % max;
 }
 
-int MapProvider::long2tileX(const double lon, const int z) const {
+int MapProvider::long2tileX(double lon, int z) const
+{
     return static_cast<int>(floor((lon + 180.0) / 360.0 * pow(2.0, z)));
 }
 
-//-----------------------------------------------------------------------------
-int MapProvider::lat2tileY(const double lat, const int z) const {
-    return static_cast<int>(floor(
-        (1.0 -
-         log(tan(lat * M_PI / 180.0) + 1.0 / cos(lat * M_PI / 180.0)) / M_PI) /
-        2.0 * pow(2.0, z)));
+int MapProvider::lat2tileY(double lat, int z) const
+{
+    return static_cast<int>(floor((1.0 - log(tan(lat * M_PI / 180.0) + 1.0 / cos(lat * M_PI / 180.0)) / M_PI) / 2.0 * pow(2.0, z)));
 }
 
-QGCTileSet MapProvider::getTileCount(const int zoom, const double topleftLon,
-                                     const double topleftLat, const double bottomRightLon,
-                                     const double bottomRightLat) const {
+QGCTileSet MapProvider::getTileCount(int zoom, double topleftLon,
+                                     double topleftLat, double bottomRightLon,
+                                     double bottomRightLat) const
+{
     QGCTileSet set;
     set.tileX0 = long2tileX(topleftLon, zoom);
     set.tileY0 = lat2tileY(topleftLat, zoom);

--- a/src/QtLocationPlugin/MapProvider.h
+++ b/src/QtLocationPlugin/MapProvider.h
@@ -9,59 +9,69 @@
 
 #pragma once
 
-#include "QGCTileSet.h"
 #include <QtLocation/private/qgeomaptype_p.h>
-
 #include <QtCore/QByteArray>
 #include <QtCore/QString>
+#include <QtCore/QLoggingCategory>
 
-static const unsigned char pngSignature[]  = {0x89, 0x50, 0x4E, 0x47, 0x0D, 0x0A, 0x1A, 0x0A, 0x00};
-static const unsigned char jpegSignature[] = {0xFF, 0xD8, 0xFF, 0x00};
-static const unsigned char gifSignature[]  = {0x47, 0x49, 0x46, 0x38, 0x00};
+#include "QGCTileSet.h"
 
-static const quint32 AVERAGE_TILE_SIZE = 13652;
+Q_DECLARE_LOGGING_CATEGORY(MapProviderLog)
+
+// qgeomaptype_p.h
+/*enum MapStyle {
+    NoMap = 0,
+    StreetMap,
+    SatelliteMapDay,
+    SatelliteMapNight,
+    TerrainMap,
+    HybridMap,
+    TransitMap,
+    GrayStreetMap,
+    PedestrianMap,
+    CarNavigationMap,
+    CycleMap,
+    CustomMap = 100
+};*/
+
+static constexpr const quint32 AVERAGE_TILE_SIZE = 13652;
 
 class QNetworkRequest;
-class QNetworkAccessManager;
 
-class MapProvider : public QObject {
+class MapProvider : public QObject
+{
     Q_OBJECT
 
 public:
-    MapProvider(const QString& referrer, const QString& imageFormat, const quint32 averageSize,
-        const QGeoMapType::MapStyle mapStyle = QGeoMapType::CustomMap, QObject* parent = nullptr);
+    MapProvider(const QString& referrer, const QString& imageFormat, quint32 averageSize = AVERAGE_TILE_SIZE,
+                QGeoMapType::MapStyle mapStyle = QGeoMapType::CustomMap, QObject* parent = nullptr);
 
-    virtual QNetworkRequest getTileURL(const int x, const int y, const int zoom, QNetworkAccessManager* networkManager);
-
-    QString getImageFormat(const QByteArray& image) const;
+    QString getImageFormat(QByteArrayView image) const;
 
     quint32 getAverageSize() const { return _averageSize; }
+    QGeoMapType::MapStyle getMapStyle() const { return _mapStyle; }
 
-    QGeoMapType::MapStyle getMapStyle() { return _mapStyle; }
+    virtual QNetworkRequest getTileURL(int x, int y, int zoom) const;
 
-    virtual int long2tileX(const double lon, const int z) const;
+    virtual int long2tileX(double lon, int z) const;
+    virtual int lat2tileY(double lat, int z) const;
 
-    virtual int lat2tileY(const double lat, const int z) const;
+    virtual bool isElevationProvider() const { return false; }
+    virtual bool isBingProvider() const { return false; }
 
-    virtual bool _isElevationProvider() const { return false; }
-    virtual bool _isBingProvider() const { return false; }
-
-    virtual QGCTileSet getTileCount(const int zoom, const double topleftLon,
-                                     const double topleftLat, const double bottomRightLon,
-                                     const double bottomRightLat) const;
+    virtual QGCTileSet getTileCount(int zoom, double topleftLon,
+                                    double topleftLat, double bottomRightLon,
+                                    double bottomRightLat) const;
 
 protected:
-    QString _tileXYToQuadKey(const int tileX, const int tileY, const int levelOfDetail) const;
-    int _getServerNum(const int x, const int y, const int max) const;
-    // Define the url to Request
-    virtual QString _getURL(const int x, const int y, const int zoom, QNetworkAccessManager* networkManager) = 0;
+    QString _tileXYToQuadKey(int tileX, int tileY, int levelOfDetail) const;
+    int _getServerNum(int x, int y, int max) const;
 
-    // Define Referrer for Request RawHeader
-    QString     _referrer;
-    QString     _imageFormat;
-    quint32     _averageSize;
-    QByteArray  _userAgent;
-    QString     _language;
-    QGeoMapType::MapStyle _mapStyle;
+    virtual QString _getURL(int x, int y, int zoom) const = 0;
 
+    const QString _referrer;
+    const QString _imageFormat;
+    const quint32 _averageSize;
+    const QGeoMapType::MapStyle _mapStyle;
+    const QString _language;
 };

--- a/src/QtLocationPlugin/MapboxMapProvider.cpp
+++ b/src/QtLocationPlugin/MapboxMapProvider.cpp
@@ -2,24 +2,18 @@
 #include "QGCApplication.h"
 #include "SettingsManager.h"
 
-static const QString MapBoxUrl = QStringLiteral("https://api.mapbox.com/styles/v1/mapbox/%1/tiles/%2/%3/%4?access_token=%5");
-static const QString MapBoxUrlCustom = QStringLiteral("https://api.mapbox.com/styles/v1/%1/%2/tiles/256/%3/%4/%5?access_token=%6");
-
-MapboxMapProvider::MapboxMapProvider(const QString &mapName, const quint32 averageSize, const QGeoMapType::MapStyle mapType, QObject* parent)
-    : MapProvider(QStringLiteral("https://www.mapbox.com/"), QStringLiteral("jpg"), averageSize, mapType, parent)
-    , _mapboxName(mapName)
+QString MapboxMapProvider::_getURL(int x, int y, int zoom) const
 {
-}
-
-QString MapboxMapProvider::_getURL(const int x, const int y, const int zoom, QNetworkAccessManager* networkManager) {
-    Q_UNUSED(networkManager)
     const QString mapBoxToken = qgcApp()->toolbox()->settingsManager()->appSettings()->mapboxToken()->rawValue().toString();
     if (!mapBoxToken.isEmpty()) {
-        if (_mapboxName == QString("mapbox.custom")) {
+        if (_mapboxName == QStringLiteral("mapbox.custom")) {
+            static const QString MapBoxUrlCustom = QStringLiteral("https://api.mapbox.com/styles/v1/%1/%2/tiles/256/%3/%4/%5?access_token=%6");
             const QString mapBoxAccount = qgcApp()->toolbox()->settingsManager()->appSettings()->mapboxAccount()->rawValue().toString();
             const QString mapBoxStyle = qgcApp()->toolbox()->settingsManager()->appSettings()->mapboxStyle()->rawValue().toString();
             return MapBoxUrlCustom.arg(mapBoxAccount).arg(mapBoxStyle).arg(zoom).arg(x).arg(y).arg(mapBoxToken);
         }
+
+        static const QString MapBoxUrl = QStringLiteral("https://api.mapbox.com/styles/v1/mapbox/%1/tiles/%2/%3/%4?access_token=%5");
         return MapBoxUrl.arg(_mapboxName).arg(zoom).arg(x).arg(y).arg(mapBoxToken);
     }
     return QString();

--- a/src/QtLocationPlugin/MapboxMapProvider.h
+++ b/src/QtLocationPlugin/MapboxMapProvider.h
@@ -11,22 +11,26 @@
 
 #include "MapProvider.h"
 
-static const quint32 AVERAGE_MAPBOX_SAT_MAP     = 15739;
-static const quint32 AVERAGE_MAPBOX_STREET_MAP  = 5648;
+static constexpr const quint32 AVERAGE_MAPBOX_SAT_MAP     = 15739;
+static constexpr const quint32 AVERAGE_MAPBOX_STREET_MAP  = 5648;
 
-class MapboxMapProvider : public MapProvider {
+class MapboxMapProvider : public MapProvider
+{
     Q_OBJECT
 
-public:
-    MapboxMapProvider(const QString& mapName, const quint32 averageSize, const QGeoMapType::MapStyle mapType, QObject* parent = nullptr);
-
 protected:
-    QString _getURL(const int x, const int y, const int zoom, QNetworkAccessManager* networkManager) override;
+    MapboxMapProvider(const QString& mapName, quint32 averageSize, QGeoMapType::MapStyle mapType, QObject* parent = nullptr)
+        : MapProvider(QStringLiteral("https://www.mapbox.com/"), QStringLiteral("jpg"), averageSize, mapType, parent)
+        , _mapboxName(mapName) {}
 
-    QString _mapboxName;
+private:
+    QString _getURL(int x, int y, int zoom) const final;
+
+    const QString _mapboxName;
 };
 
-class MapboxStreetMapProvider : public MapboxMapProvider {
+class MapboxStreetMapProvider : public MapboxMapProvider
+{
     Q_OBJECT
 
 public:
@@ -35,7 +39,8 @@ public:
                             QGeoMapType::StreetMap, parent) {}
 };
 
-class MapboxLightMapProvider : public MapboxMapProvider {
+class MapboxLightMapProvider : public MapboxMapProvider
+{
     Q_OBJECT
 
 public:
@@ -44,7 +49,8 @@ public:
                             QGeoMapType::CustomMap, parent) {}
 };
 
-class MapboxDarkMapProvider : public MapboxMapProvider {
+class MapboxDarkMapProvider : public MapboxMapProvider
+{
     Q_OBJECT
 
 public:
@@ -53,7 +59,8 @@ public:
                             QGeoMapType::CustomMap, parent) {}
 };
 
-class MapboxSatelliteMapProvider : public MapboxMapProvider {
+class MapboxSatelliteMapProvider : public MapboxMapProvider
+{
     Q_OBJECT
 
 public:
@@ -62,7 +69,8 @@ public:
                             QGeoMapType::SatelliteMapDay, parent) {}
 };
 
-class MapboxHybridMapProvider : public MapboxMapProvider {
+class MapboxHybridMapProvider : public MapboxMapProvider
+{
     Q_OBJECT
 
 public:
@@ -71,7 +79,8 @@ public:
                             QGeoMapType::HybridMap, parent) {}
 };
 
-class MapboxBrightMapProvider : public MapboxMapProvider {
+class MapboxBrightMapProvider : public MapboxMapProvider
+{
     Q_OBJECT
 
 public:
@@ -80,7 +89,8 @@ public:
                             QGeoMapType::CustomMap, parent) {}
 };
 
-class MapboxStreetsBasicMapProvider : public MapboxMapProvider {
+class MapboxStreetsBasicMapProvider : public MapboxMapProvider
+{
     Q_OBJECT
 
 public:
@@ -89,7 +99,8 @@ public:
                             QGeoMapType::StreetMap, parent) {}
 };
 
-class MapboxOutdoorsMapProvider : public MapboxMapProvider {
+class MapboxOutdoorsMapProvider : public MapboxMapProvider
+{
     Q_OBJECT
 
 public:
@@ -98,7 +109,8 @@ public:
                             QGeoMapType::CustomMap, parent) {}
 };
 
-class MapboxCustomMapProvider : public MapboxMapProvider {
+class MapboxCustomMapProvider : public MapboxMapProvider
+{
     Q_OBJECT
 
 public:

--- a/src/QtLocationPlugin/QGCMapTileSet.cpp
+++ b/src/QtLocationPlugin/QGCMapTileSet.cpp
@@ -241,7 +241,7 @@ void QGCCachedTileSet::_prepareDownload()
         if(_tilesToDownload.count()) {
             QGCTile* tile = _tilesToDownload.first();
             _tilesToDownload.removeFirst();
-            QNetworkRequest request = getQGCMapEngine()->urlFactory()->getTileURL(tile->type(), tile->x(), tile->y(), tile->z(), _networkManager);
+            QNetworkRequest request = getQGCMapEngine()->urlFactory()->getTileURL(tile->type(), tile->x(), tile->y(), tile->z());
             request.setAttribute(QNetworkRequest::User, tile->hash());
 #if !defined(__mobile__)
             QNetworkProxy proxy = _networkManager->proxy();

--- a/src/QtLocationPlugin/QGCMapUrlEngine.cpp
+++ b/src/QtLocationPlugin/QGCMapUrlEngine.cpp
@@ -51,7 +51,7 @@ UrlFactory::UrlFactory() :
     _providers.append(ProviderPair("Bing Satellite", new BingSatelliteMapProvider(this)));
     _providers.append(ProviderPair("Bing Hybrid", new BingHybridMapProvider(this)));
 
-    _providers.append(ProviderPair("Statkart Topo", new StatkartMapProvider(this)));
+    _providers.append(ProviderPair("Statkart Topo", new StatkartTopoMapProvider(this)));
     _providers.append(ProviderPair("Statkart Basemap", new StatkartBaseMapProvider(this)));
 
     _providers.append(ProviderPair("Eniro Topo", new EniroMapProvider(this)));
@@ -113,11 +113,11 @@ QString UrlFactory::getImageFormat(const QString& type, const QByteArray& image)
         return "";
     }
 }
-QNetworkRequest UrlFactory::getTileURL(int qtMapId, int x, int y, int zoom, QNetworkAccessManager* networkManager) 
+QNetworkRequest UrlFactory::getTileURL(int qtMapId, int x, int y, int zoom) 
 {
     MapProvider* provider = getMapProviderFromQtMapId(qtMapId);
     if (provider) {
-        return provider->getTileURL(x, y, zoom, networkManager);
+        return provider->getTileURL(x, y, zoom);
     } else {
         qCWarning(QGCMapUrlEngineLog) << "getTileURL : map id not found:" << qtMapId;
         return QNetworkRequest(QUrl());
@@ -125,11 +125,11 @@ QNetworkRequest UrlFactory::getTileURL(int qtMapId, int x, int y, int zoom, QNet
 }
 
 //-----------------------------------------------------------------------------
-QNetworkRequest UrlFactory::getTileURL(const QString& type, int x, int y, int zoom, QNetworkAccessManager* networkManager) 
+QNetworkRequest UrlFactory::getTileURL(const QString& type, int x, int y, int zoom) 
 {
     MapProvider* provider = getMapProviderFromProviderType(type);
     if (provider) {
-        return provider->getTileURL(x, y, zoom, networkManager);
+        return provider->getTileURL(x, y, zoom);
     } else {
         qCWarning(QGCMapUrlEngineLog) << "getTileURL : type not found:" << type;
         return QNetworkRequest(QUrl());
@@ -225,7 +225,7 @@ bool UrlFactory::isElevation(int qtMapId)
 {
     MapProvider* provider = getMapProviderFromQtMapId(qtMapId);
     if (provider) {
-        return provider->_isElevationProvider();
+        return provider->isElevationProvider();
     } else {
         qCWarning(QGCMapUrlEngineLog) << "isElevation : map id not found:" << qtMapId;
         return false;

--- a/src/QtLocationPlugin/QGCMapUrlEngine.h
+++ b/src/QtLocationPlugin/QGCMapUrlEngine.h
@@ -39,8 +39,8 @@ public:
 
     typedef QPair<QString, MapProvider*> ProviderPair;
 
-    QNetworkRequest getTileURL          (const QString& type, int x, int y, int zoom, QNetworkAccessManager* networkManager);
-    QNetworkRequest getTileURL          (int qtMapId, int x, int y, int zoom, QNetworkAccessManager* networkManager);
+    QNetworkRequest getTileURL          (const QString& type, int x, int y, int zoom);
+    QNetworkRequest getTileURL          (int qtMapId, int x, int y, int zoom);
 
     QString         getImageFormat      (const QString& type, const QByteArray& image);
     QString         getImageFormat      (int qtMapId, const QByteArray& image);

--- a/src/QtLocationPlugin/QGeoMapReplyQGC.cpp
+++ b/src/QtLocationPlugin/QGeoMapReplyQGC.cpp
@@ -147,7 +147,7 @@ QGeoTiledMapReplyQGC::networkReplyFinished()
         emit terrainDone(a, QNetworkReply::NoError);
     } else {
         MapProvider* mapProvider = urlFactory->getMapProviderFromQtMapId(tileSpec().mapId());
-        if (mapProvider && mapProvider->_isBingProvider() && a.size() && _bingNoTileImage.size() && a == _bingNoTileImage) {
+        if (mapProvider && mapProvider->isBingProvider() && a.size() && _bingNoTileImage.size() && a == _bingNoTileImage) {
             // Bing doesn't return an error if you request a tile above supported zoom level
             // It instead returns an image of a missing tile graphic. We need to detect that
             // and error out so Qt will deal with zooming correctly even if it doesn't have the tile.

--- a/src/QtLocationPlugin/QGeoTileFetcherQGC.cpp
+++ b/src/QtLocationPlugin/QGeoTileFetcherQGC.cpp
@@ -72,7 +72,7 @@ QGeoTiledMapReply*
 QGeoTileFetcherQGC::getTileImage(const QGeoTileSpec &spec)
 {
     //-- Build URL
-    QNetworkRequest request = getQGCMapEngine()->urlFactory()->getTileURL(spec.mapId(), spec.x(), spec.y(), spec.zoom(), _networkManager);
+    QNetworkRequest request = getQGCMapEngine()->urlFactory()->getTileURL(spec.mapId(), spec.x(), spec.y(), spec.zoom());
     if ( ! request.url().isEmpty() ) {
         return new QGeoTiledMapReplyQGC(_networkManager, request, spec);
     }

--- a/src/Terrain/TerrainTileManager.cc
+++ b/src/Terrain/TerrainTileManager.cc
@@ -146,8 +146,7 @@ bool TerrainTileManager::getAltitudesForCoordinates(const QList<QGeoCoordinate>&
                 QNetworkRequest request = getQGCMapEngine()->urlFactory()->getTileURL(
                     kMapType, getQGCMapEngine()->urlFactory()->long2tileX(kMapType, coordinate.longitude(), 1),
                     getQGCMapEngine()->urlFactory()->lat2tileY(kMapType, coordinate.latitude(), 1),
-                    1,
-                    &_networkManager);
+                    1);
                 qCDebug(TerrainTileManagerLog) << "TerrainTileManager::getAltitudesForCoordinates query from database" << request.url();
                 QGeoTileSpec spec;
                 spec.setX(getQGCMapEngine()->urlFactory()->long2tileX(kMapType, coordinate.longitude(), 1));

--- a/src/Viewer3D/Viewer3DTileReply.cc
+++ b/src/Viewer3D/Viewer3DTileReply.cc
@@ -47,7 +47,7 @@ Viewer3DTileReply::~Viewer3DTileReply()
 
 void Viewer3DTileReply::prepareDownload()
 {
-    QNetworkRequest request = getQGCMapEngine()->urlFactory()->getTileURL(_mapId, _tile.x, _tile.y, _tile.zoomLevel, _networkManager);
+    QNetworkRequest request = getQGCMapEngine()->urlFactory()->getTileURL(_mapId, _tile.x, _tile.y, _tile.zoomLevel);
     _reply = _networkManager->get(request);
     connect(_reply, &QNetworkReply::finished, this, &Viewer3DTileReply::requestFinished);
     connect(_reply, &QNetworkReply::errorOccurred, this, &Viewer3DTileReply::requestError);
@@ -64,7 +64,7 @@ void Viewer3DTileReply::requestFinished()
     disconnect(_reply, &QNetworkReply::errorOccurred, this, &Viewer3DTileReply::requestError);
     disconnect(_timeoutTimer, &QTimer::timeout, this, &Viewer3DTileReply::timeoutTimerEvent);
 
-    if(mapProvider && mapProvider->_isBingProvider() && _tile.data.size() && _tile.data == _bingNoTileImage){
+    if(mapProvider && mapProvider->isBingProvider() && _tile.data.size() && _tile.data == _bingNoTileImage){
         // Bing doesn't return an error if you request a tile above supported zoom level
         // It instead returns an image of a missing tile graphic. We need to detect that
         // and error out so 3D View will deal with zooming correctly even if it doesn't have the tile.


### PR DESCRIPTION
This consolidates the MapProviders to have much less duplicated code and makes them entirely const.

This required removing the google version check and converting the Google Satellite Maps from the Google Maps to Google Quick Maps Services, which don't require version numbers as they default to the latest available. The only reason we might want to log the version number is to keep cached tiles and downloaded tiles on the same version, but currently all downloaded google tiles are stuck forever on an ancient version. The google version check can be re-added at a later dated if desired (maybe in QGeoTileFetcherQGC), but it serves little purpose currently.

The purpose in doing this is such that the entire UrlEngine can then become a static lookup class, without having to pull definitions from the mapengine instance. This should speed up live map functionality a bit and is safer memory wise.

Future option is to add a json file to be read from custom builds to easily add custom maps. Also it would be good to combine these definitions with the QGeoTiledMap class so each map type can easily provide copyrights, QGeoCameraCapabilities, etc.

I've tested on all the available maps that worked for me initially without API keys