### PR TITLE
VideoReceiver: Remove references outside of VideoManager

### DIFF
--- a/src/API/CMakeLists.txt
+++ b/src/API/CMakeLists.txt
@@ -18,8 +18,8 @@ target_link_libraries(API
 		Joystick
 		Settings
 		Utilities
-		VideoReceiver
 		VideoManager
+		VideoReceiver
 	PUBLIC
 		Qt6::Core
 		Qt6::Gui

--- a/src/API/QGCCorePlugin.cc
+++ b/src/API/QGCCorePlugin.cc
@@ -19,7 +19,6 @@
 #include "JoystickManager.h"
 #if defined(QGC_GST_STREAMING)
 #include "GStreamer.h"
-#include "VideoReceiver.h"
 #endif
 #include "HorizontalFactValueGrid.h"
 #include "InstrumentValueData.h"

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -92,13 +92,13 @@ target_link_libraries(QGC
 		Vehicle
 		VehicleSetup
 		Viewer3D
+		VideoManager
+		VideoReceiver
 	PUBLIC
 		Qt6::Core
 		Qt6::CorePrivate
 		Qt6::Widgets
-
 		QGCLocation
-		VideoManager
 )
 
 if(QGC_CUSTOM_BUILD)

--- a/src/FlightDisplay/FlightDisplayViewVideo.qml
+++ b/src/FlightDisplay/FlightDisplayViewVideo.qml
@@ -141,8 +141,7 @@ Item {
         Loader {
             // GStreamer is causing crashes on Lenovo laptop OpenGL Intel drivers. In order to workaround this
             // we don't load a QGCVideoBackground object when video is disabled. This prevents any video rendering
-            // code from running. Setting QGCVideoBackground.receiver = null does not work to prevent any
-            // video OpenGL from being generated. Hence the Loader to completely remove it.
+            // code from running. Hence the Loader to completely remove it.
             height:             parent.getHeight()
             width:              parent.getWidth()
             anchors.centerIn:   parent
@@ -187,7 +186,6 @@ Item {
                 id:             thermalVideo
                 objectName:     "thermalVideo"
                 anchors.fill:   parent
-                receiver:       QGroundControl.videoManager.thermalVideoReceiver
                 opacity:        _camera ? (_camera.thermalMode === MavlinkCameraControl.THERMAL_BLEND ? _camera.thermalOpacity / 100 : 1.0) : 0
             }
         }

--- a/src/FlightMap/QGCVideoBackground.qml
+++ b/src/FlightMap/QGCVideoBackground.qml
@@ -20,5 +20,4 @@ import org.freedesktop.gstreamer.Qt6GLVideoItem
 
 GstGLQt6VideoItem {
     id: videoBackground
-    property var receiver
 }

--- a/src/Vehicle/Vehicle.cc
+++ b/src/Vehicle/Vehicle.cc
@@ -48,7 +48,6 @@
 #include "VehicleBatteryFactGroup.h"
 #include "VehicleObjectAvoidance.h"
 #include "VideoManager.h"
-#include "VideoReceiver.h"
 #include "VideoSettings.h"
 #include <DeviceInfo.h>
 
@@ -1481,11 +1480,9 @@ void Vehicle::_updateArmed(bool armed)
             _trajectoryPoints->stop();
             _flightTimerStop();
             // Also handle Video Streaming
-            if(qgcApp()->toolbox()->videoManager()->videoReceiver()) {
-                if(_settingsManager->videoSettings()->disableWhenDisarmed()->rawValue().toBool()) {
-                    _settingsManager->videoSettings()->streamEnabled()->setRawValue(false);
-                    qgcApp()->toolbox()->videoManager()->videoReceiver()->stop();
-                }
+            if(_settingsManager->videoSettings()->disableWhenDisarmed()->rawValue().toBool()) {
+                _settingsManager->videoSettings()->streamEnabled()->setRawValue(false);
+                qgcApp()->toolbox()->videoManager()->stopVideo();
             }
         }
     }


### PR DESCRIPTION
The VideoReceiver(s) should only be handled by the VideoManager for thread safety and in order to better support multiple videoreceivers.
The QGCVideoBackround also doesn't use this property.