### PR TITLE
CMake: Fix Daily Build Version

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -302,6 +302,12 @@ elseif(LINUX)
 
 endif()
 
+if(QGC_STABLE_BUILD)
+    set(APP_VERSION_STR ${REL_VERSION})
+else()
+    set(APP_VERSION_STR ${GIT_BRANCH}-${GIT_HASH})
+endif()
+
 add_compile_definitions(
     QGC_APPLICATION_NAME="QGroundControl"
     QGC_ORG_NAME="QGroundControl.org"

--- a/cmake/Git.cmake
+++ b/cmake/Git.cmake
@@ -22,12 +22,20 @@ endif()
 include(CMakePrintHelpers)
 
 execute_process(
-    COMMAND ${GIT_EXECUTABLE} describe --always --tags
+    COMMAND ${GIT_EXECUTABLE} rev-parse --abbrev-ref @
     WORKING_DIRECTORY ${CMAKE_SOURCE_DIR}
-    OUTPUT_VARIABLE APP_VERSION_STR
+    OUTPUT_VARIABLE GIT_BRANCH
     OUTPUT_STRIP_TRAILING_WHITESPACE
 )
-cmake_print_variables(APP_VERSION_STR)
+cmake_print_variables(GIT_BRANCH)
+
+execute_process(
+    COMMAND ${GIT_EXECUTABLE} rev-parse --short @
+    WORKING_DIRECTORY ${CMAKE_SOURCE_DIR}
+    OUTPUT_VARIABLE GIT_HASH
+    OUTPUT_STRIP_TRAILING_WHITESPACE
+)
+cmake_print_variables(GIT_HASH)
 
 execute_process(
     COMMAND ${GIT_EXECUTABLE} describe --always --abbrev=0


### PR DESCRIPTION
Master daily builds would show up as the previous tag.
Closes #4882