### PR TITLE
QtLocationPlugin: Make UrlEngine Static

### DIFF
--- a/src/QmlControls/QGroundControlQmlGlobal.cc
+++ b/src/QmlControls/QGroundControlQmlGlobal.cc
@@ -11,7 +11,7 @@
 #include "QGCApplication.h"
 #include "LinkManager.h"
 #include "MAVLinkProtocol.h"
-#include "QGCMapUrlEngine.h"
+#include "ElevationMapProvider.h"
 #include "FirmwarePluginManager.h"
 #include "AppSettings.h"
 #include "PositionManager.h"
@@ -340,12 +340,12 @@ int QGroundControlQmlGlobal::mavlinkSystemID()
 
 QString QGroundControlQmlGlobal::elevationProviderName()
 {
-    return UrlFactory::kCopernicusElevationProviderKey;
+    return CopernicusElevationProvider::kProviderKey;
 }
 
 QString QGroundControlQmlGlobal::elevationProviderNotice()
 {
-    return UrlFactory::kCopernicusElevationProviderNotice;
+    return CopernicusElevationProvider::kProviderNotice;
 }
 
 QString QGroundControlQmlGlobal::parameterFileExtension() const

--- a/src/QmlControls/QGroundControlQmlGlobal.h
+++ b/src/QmlControls/QGroundControlQmlGlobal.h
@@ -218,8 +218,8 @@ public:
     bool    hasMAVLinkInspector     () { return true; }
 #endif
 
-    QString elevationProviderName   ();
-    QString elevationProviderNotice ();
+    static QString elevationProviderName   ();
+    static QString elevationProviderNotice ();
 
     bool    singleFirmwareSupport   ();
     bool    singleVehicleSupport    ();

--- a/src/QtLocationPlugin/BingMapProvider.cpp
+++ b/src/QtLocationPlugin/BingMapProvider.cpp
@@ -12,5 +12,5 @@
 QString BingMapProvider::_getURL(int x, int y, int zoom) const
 {
     const QString key = _tileXYToQuadKey(x, y, zoom);
-    return _mapUrl.arg(_getServerNum(x, y, 4)).arg(_mapName, key, _imageFormat, _versionBingMaps, _language);
+    return _mapUrl.arg(_getServerNum(x, y, 4)).arg(_mapTypeId, key, _imageFormat, _versionBingMaps, _language);
 }

--- a/src/QtLocationPlugin/BingMapProvider.h
+++ b/src/QtLocationPlugin/BingMapProvider.h
@@ -16,13 +16,11 @@ static constexpr const quint32 AVERAGE_BING_SAT_MAP    = 19597;
 
 class BingMapProvider : public MapProvider
 {
-    Q_OBJECT
-
 protected:
-    BingMapProvider(const QString &mapName, const QString &imageFormat, quint32 averageSize,
-                    QGeoMapType::MapStyle mapType, QObject* parent = nullptr)
-        : MapProvider(QStringLiteral("https://www.bing.com/maps/"), imageFormat, averageSize, mapType, parent)
-        , _mapName(mapName) {}
+    BingMapProvider(const QString &mapName, const QString &mapTypeCode, const QString &imageFormat, quint32 averageSize,
+                    QGeoMapType::MapStyle mapType)
+        : MapProvider(mapName, QStringLiteral("https://www.bing.com/maps/"), imageFormat, averageSize, mapType)
+        , _mapTypeId(mapTypeCode) {}
 
 public:
     bool isBingProvider() const final { return true; }
@@ -30,34 +28,43 @@ public:
 private:
     QString _getURL(int x, int y, int zoom) const final;
 
-    const QString _mapName;
+    const QString _mapTypeId;
     const QString _mapUrl = QStringLiteral("http://ecn.t%1.tiles.virtualearth.net/tiles/%2%3.%4?g=%5&mkt=%6");
     const QString _versionBingMaps = QStringLiteral("2981");
 };
 
 class BingRoadMapProvider : public BingMapProvider
 {
-    Q_OBJECT
-
 public:
-    BingRoadMapProvider(QObject* parent = nullptr)
-        : BingMapProvider(QStringLiteral("r"), QStringLiteral("png"), AVERAGE_BING_STREET_MAP, QGeoMapType::StreetMap, parent) {}
+    BingRoadMapProvider()
+        : BingMapProvider(
+            QStringLiteral("Bing Road"),
+            QStringLiteral("r"),
+            QStringLiteral("png"),
+            AVERAGE_BING_STREET_MAP,
+            QGeoMapType::StreetMap) {}
 };
 
 class BingSatelliteMapProvider : public BingMapProvider
 {
-    Q_OBJECT
-
 public:
-    BingSatelliteMapProvider(QObject* parent = nullptr)
-        : BingMapProvider(QStringLiteral("a"), QStringLiteral("jpg"), AVERAGE_BING_SAT_MAP, QGeoMapType::SatelliteMapDay, parent) {}
+    BingSatelliteMapProvider()
+        : BingMapProvider(
+            QStringLiteral("Bing Satellite"),
+            QStringLiteral("a"),
+            QStringLiteral("jpg"),
+            AVERAGE_BING_SAT_MAP,
+            QGeoMapType::SatelliteMapDay) {}
 };
 
 class BingHybridMapProvider : public BingMapProvider
 {
-    Q_OBJECT
-
 public:
-    BingHybridMapProvider(QObject* parent = nullptr)
-        : BingMapProvider(QStringLiteral("h"), QStringLiteral("jpg"),AVERAGE_BING_SAT_MAP, QGeoMapType::HybridMap, parent) {}
+    BingHybridMapProvider()
+        : BingMapProvider(
+            QStringLiteral("Bing Hybrid"),
+            QStringLiteral("h"),
+            QStringLiteral("jpg"),
+            AVERAGE_BING_SAT_MAP,
+            QGeoMapType::HybridMap) {}
 };

--- a/src/QtLocationPlugin/ElevationMapProvider.cpp
+++ b/src/QtLocationPlugin/ElevationMapProvider.cpp
@@ -30,7 +30,7 @@ int CopernicusElevationProvider::lat2tileY(double lat, int z) const
 QString CopernicusElevationProvider::_getURL(int x, int y, int zoom) const
 {
     Q_UNUSED(zoom)
-    return QStringLiteral("https://terrain-ce.suite.auterion.com/api/v1/carpet?points=%1,%2,%3,%4")
+    return _mapUrl
         .arg((static_cast<double>(y) * TerrainTile::tileSizeDegrees) - 90.0)
         .arg((static_cast<double>(x) * TerrainTile::tileSizeDegrees) - 180.0)
         .arg((static_cast<double>(y + 1) * TerrainTile::tileSizeDegrees) - 90.0)

--- a/src/QtLocationPlugin/ElevationMapProvider.h
+++ b/src/QtLocationPlugin/ElevationMapProvider.h
@@ -2,16 +2,19 @@
 
 #include "MapProvider.h"
 
-static constexpr const quint32 AVERAGE_AIRMAP_ELEV_SIZE = 2786;
+static constexpr const quint32 AVERAGE_COPERNICUS_ELEV_SIZE = 2786;
 
 class ElevationProvider : public MapProvider
 {
-    Q_OBJECT
-
 protected:
-    ElevationProvider(const QString& imageFormat, quint32 averageSize,
-                      QGeoMapType::MapStyle mapType, QObject* parent = nullptr)
-        : MapProvider(QStringLiteral("https://terrain-ce.suite.auterion.com/"), imageFormat, averageSize, mapType, parent) {}
+    ElevationProvider(const QString &mapName, const QString &referrer, const QString &imageFormat, quint32 averageSize,
+                      QGeoMapType::MapStyle mapType)
+        : MapProvider(
+            mapName,
+            referrer,
+            imageFormat,
+            averageSize,
+            mapType) {}
 
 public:
     bool isElevationProvider() const final { return true; }
@@ -19,12 +22,14 @@ public:
 
 class CopernicusElevationProvider : public ElevationProvider
 {
-    Q_OBJECT
-
 public:
-    CopernicusElevationProvider(QObject* parent = nullptr)
-        : ElevationProvider(QStringLiteral("bin"), AVERAGE_AIRMAP_ELEV_SIZE,
-                            QGeoMapType::StreetMap, parent) {}
+    CopernicusElevationProvider()
+        : ElevationProvider(
+            QStringLiteral("Copernicus Elevation"),
+            QStringLiteral("https://terrain-ce.suite.auterion.com/"),
+            QStringLiteral("bin"),
+            AVERAGE_COPERNICUS_ELEV_SIZE,
+            QGeoMapType::StreetMap) {}
 
     int long2tileX(double lon, int z) const final;
     int lat2tileY(double lat, int z) const final;
@@ -33,6 +38,11 @@ public:
                             double topleftLat, double bottomRightLon,
                             double bottomRightLat) const final;
 
+    static constexpr const char* kProviderKey = "Copernicus Elevation";
+    static constexpr const char* kProviderNotice = "© Airbus Defence and Space GmbH";
+
 private:
     QString _getURL(int x, int y, int zoom) const final;
+
+    const QString _mapUrl = QStringLiteral("https://terrain-ce.suite.auterion.com/api/v1/carpet?points=%1,%2,%3,%4");
 };

--- a/src/QtLocationPlugin/EsriMapProvider.cpp
+++ b/src/QtLocationPlugin/EsriMapProvider.cpp
@@ -30,5 +30,5 @@ QNetworkRequest EsriMapProvider::getTileURL(int x, int y, int zoom) const
 
 QString EsriMapProvider::_getURL(int x, int y, int zoom) const
 {
-    return _mapUrl.arg(_mapName).arg(zoom).arg(y).arg(x);
+    return _mapUrl.arg(_mapTypeId).arg(zoom).arg(y).arg(x);
 }

--- a/src/QtLocationPlugin/EsriMapProvider.h
+++ b/src/QtLocationPlugin/EsriMapProvider.h
@@ -13,12 +13,15 @@
 
 class EsriMapProvider : public MapProvider
 {
-    Q_OBJECT
-
 protected:
-    EsriMapProvider(const QString &mapName, quint32 averageSize, QGeoMapType::MapStyle mapType, QObject* parent = nullptr)
-        : MapProvider(QString(), QString(), averageSize, mapType, parent)
-        , _mapName(mapName) {}
+    EsriMapProvider(const QString &mapName, const QString &mapTypeId, quint32 averageSize, QGeoMapType::MapStyle mapType)
+        : MapProvider(
+            mapName,
+            QStringLiteral(""),
+            QStringLiteral(""),
+            averageSize,
+            mapType)
+        , _mapTypeId(mapTypeId) {}
 
 public:
     QNetworkRequest getTileURL(int x, int y, int zoom) const final;
@@ -26,33 +29,39 @@ public:
 private:
     QString _getURL(int x, int y, int zoom) const final;
 
-    const QString _mapName;
+    const QString _mapTypeId;
     const QString _mapUrl = QStringLiteral("http://services.arcgisonline.com/ArcGIS/rest/services/%1/MapServer/tile/%2/%3/%4");
 };
 
 class EsriWorldStreetMapProvider : public EsriMapProvider
 {
-    Q_OBJECT
-
 public:
-    EsriWorldStreetMapProvider(QObject* parent = nullptr)
-        : EsriMapProvider(QStringLiteral("World_Street_Map"), AVERAGE_TILE_SIZE, QGeoMapType::StreetMap, parent) {}
+    EsriWorldStreetMapProvider()
+        : EsriMapProvider(
+            QStringLiteral("Esri World Street"),
+            QStringLiteral("World_Street_Map"),
+            AVERAGE_TILE_SIZE,
+            QGeoMapType::StreetMap) {}
 };
 
 class EsriWorldSatelliteMapProvider : public EsriMapProvider
 {
-    Q_OBJECT
-
 public:
-    EsriWorldSatelliteMapProvider(QObject* parent = nullptr)
-        : EsriMapProvider(QStringLiteral("World_Imagery"), AVERAGE_TILE_SIZE, QGeoMapType::SatelliteMapDay, parent) {}
+    EsriWorldSatelliteMapProvider()
+        : EsriMapProvider(
+            QStringLiteral("Esri World Satellite"),
+            QStringLiteral("World_Imagery"),
+            AVERAGE_TILE_SIZE,
+            QGeoMapType::SatelliteMapDay) {}
 };
 
 class EsriTerrainMapProvider : public EsriMapProvider
 {
-    Q_OBJECT
-
 public:
-    EsriTerrainMapProvider(QObject* parent = nullptr)
-        : EsriMapProvider(QStringLiteral("World_Terrain_Base"), AVERAGE_TILE_SIZE, QGeoMapType::TerrainMap, parent) {}
+    EsriTerrainMapProvider()
+        : EsriMapProvider(
+            QStringLiteral("Esri Terrain"),
+            QStringLiteral("World_Terrain_Base"),
+            AVERAGE_TILE_SIZE,
+            QGeoMapType::TerrainMap) {}
 };

--- a/src/QtLocationPlugin/GenericMapProvider.h
+++ b/src/QtLocationPlugin/GenericMapProvider.h
@@ -12,12 +12,14 @@
 
 class CustomURLMapProvider : public MapProvider
 {
-    Q_OBJECT
-
 public:
-    CustomURLMapProvider(QObject* parent = nullptr)
-        : MapProvider(QStringLiteral(""), QStringLiteral(""),
-                      AVERAGE_TILE_SIZE, QGeoMapType::CustomMap, parent) {}
+    CustomURLMapProvider()
+        : MapProvider(
+            QStringLiteral("CustomURL Custom"),
+            QStringLiteral(""),
+            QStringLiteral(""),
+            AVERAGE_TILE_SIZE,
+            QGeoMapType::CustomMap) {}
 
 private:
     QString _getURL(int x, int y, int zoom) const final;
@@ -25,74 +27,83 @@ private:
 
 class CyberJapanMapProvider : public MapProvider
 {
-    Q_OBJECT
-
 protected:
-    CyberJapanMapProvider(const QString &mapName, const QString& imageFormat, QObject* parent = nullptr)
-        : MapProvider(QStringLiteral("https://cyberjapandata.gsi.go.jp/xyz/std"), imageFormat,
-                      AVERAGE_TILE_SIZE, QGeoMapType::StreetMap, parent)
-        , _mapName(mapName) {}
+    CyberJapanMapProvider(const QString &mapName, const QString &mapTypeId, const QString &imageFormat)
+        : MapProvider(
+            mapName,
+            QStringLiteral("https://cyberjapandata.gsi.go.jp/xyz/std"),
+            imageFormat,
+            AVERAGE_TILE_SIZE,
+            QGeoMapType::StreetMap)
+        , _mapTypeId(mapName) {}
 
 private:
     QString _getURL(int x, int y, int zoom) const final;
 
-    const QString _mapName;
+    const QString _mapTypeId;
     const QString _mapUrl = QStringLiteral("https://cyberjapandata.gsi.go.jp/xyz/%1/%2/%3/%4.%5");
 };
 
 class JapanStdMapProvider : public CyberJapanMapProvider
 {
-    Q_OBJECT
-
 public:
-    JapanStdMapProvider(QObject* parent = nullptr)
-        : CyberJapanMapProvider(QStringLiteral("std"), QStringLiteral("png"), parent) {}
+    JapanStdMapProvider()
+        : CyberJapanMapProvider(
+            QStringLiteral("Japan-GSI Contour"),
+            QStringLiteral("std"),
+            QStringLiteral("png")) {}
 };
 
 class JapanSeamlessMapProvider : public CyberJapanMapProvider
 {
-    Q_OBJECT
-
 public:
-    JapanSeamlessMapProvider(QObject* parent = nullptr)
-        : CyberJapanMapProvider(QStringLiteral("seamlessphoto"), QStringLiteral("jpg"), parent) {}
+    JapanSeamlessMapProvider()
+        : CyberJapanMapProvider(
+            QStringLiteral("Japan-GSI Seamless"),
+            QStringLiteral("seamlessphoto"),
+            QStringLiteral("jpg")) {}
 };
 
 class JapanAnaglyphMapProvider : public CyberJapanMapProvider
 {
-    Q_OBJECT
-
 public:
-    JapanAnaglyphMapProvider(QObject* parent = nullptr)
-        : CyberJapanMapProvider(QStringLiteral("anaglyphmap_color"), QStringLiteral("png"), parent) {}
+    JapanAnaglyphMapProvider()
+        : CyberJapanMapProvider(
+            QStringLiteral("Japan-GSI Anaglyph"),
+            QStringLiteral("anaglyphmap_color"),
+            QStringLiteral("png")) {}
 };
 
 class JapanSlopeMapProvider : public CyberJapanMapProvider
 {
-    Q_OBJECT
-
 public:
-    JapanSlopeMapProvider(QObject* parent = nullptr)
-        : CyberJapanMapProvider(QStringLiteral("slopemap"), QStringLiteral("png"), parent) {}
+    JapanSlopeMapProvider()
+        : CyberJapanMapProvider(
+            QStringLiteral("Japan-GSI Slope"),
+            QStringLiteral("slopemap"),
+            QStringLiteral("png")) {}
 };
 
 class JapanReliefMapProvider : public CyberJapanMapProvider
 {
-    Q_OBJECT
-
 public:
-    JapanReliefMapProvider(QObject* parent = nullptr)
-        : CyberJapanMapProvider(QStringLiteral("relief"), QStringLiteral("png"), parent) {}
+    JapanReliefMapProvider()
+        : CyberJapanMapProvider(
+            QStringLiteral("Japan-GSI Relief"),
+            QStringLiteral("relief"),
+            QStringLiteral("png")) {}
 };
 
 class LINZBasemapMapProvider : public MapProvider
 {
-    Q_OBJECT
-
 public:
-    LINZBasemapMapProvider(QObject* parent = nullptr)
-        : MapProvider(QStringLiteral("https://basemaps.linz.govt.nz/v1/tiles/aerial"), QStringLiteral("png"),
-                      AVERAGE_TILE_SIZE, QGeoMapType::SatelliteMapDay, parent) {}
+    LINZBasemapMapProvider()
+        : MapProvider(
+            QStringLiteral("LINZ Basemap"),
+            QStringLiteral("https://basemaps.linz.govt.nz/v1/tiles/aerial"),
+            QStringLiteral("png"),
+            AVERAGE_TILE_SIZE,
+            QGeoMapType::SatelliteMapDay) {}
 
 private:
     QString _getURL(int x, int y, int zoom) const final;
@@ -102,47 +113,51 @@ private:
 
 class StatkartMapProvider : public MapProvider
 {
-    Q_OBJECT
-
 protected:
-    StatkartMapProvider(const QString &mapName, QObject* parent = nullptr)
-        : MapProvider(QStringLiteral("https://norgeskart.no/"), QStringLiteral("png"),
-                      AVERAGE_TILE_SIZE, QGeoMapType::StreetMap, parent)
-        , _mapName(mapName) {}
+    StatkartMapProvider(const QString &mapName, const QString &mapTypeId)
+        : MapProvider(
+            mapName,
+            QStringLiteral("https://norgeskart.no/"),
+            QStringLiteral("png"),
+            AVERAGE_TILE_SIZE,
+            QGeoMapType::StreetMap)
+        , _mapTypeId(mapName) {}
 
 private:
     QString _getURL(int x, int y, int zoom) const final;
 
-    const QString _mapName;
+    const QString _mapTypeId;
     const QString _mapUrl = QStringLiteral("http://opencache.statkart.no/gatekeeper/gk/gk.open_gmaps?layers=%1&zoom=%2&x=%3&y=%4");
 };
 
 class StatkartTopoMapProvider : public StatkartMapProvider
 {
-    Q_OBJECT
-
 public:
-    StatkartTopoMapProvider(QObject* parent = nullptr)
-        : StatkartMapProvider(QStringLiteral("topo4"), parent) {}
+    StatkartTopoMapProvider()
+        : StatkartMapProvider(
+            QStringLiteral("Statkart Topo"),
+            QStringLiteral("topo4")) {}
 };
 
 class StatkartBaseMapProvider : public StatkartMapProvider
 {
-    Q_OBJECT
-
 public:
-    StatkartBaseMapProvider(QObject* parent = nullptr)
-        : StatkartMapProvider(QStringLiteral("norgeskart_bakgrunn"), parent) {}
+    StatkartBaseMapProvider()
+        : StatkartMapProvider(
+            QStringLiteral("Statkart Basemap"),
+            QStringLiteral("norgeskart_bakgrunn")) {}
 };
 
 class EniroMapProvider : public MapProvider
 {
-    Q_OBJECT
-
 public:
-    EniroMapProvider(QObject* parent = nullptr)
-        : MapProvider(QStringLiteral("https://www.eniro.se/"), QStringLiteral("png"),
-                      AVERAGE_TILE_SIZE, QGeoMapType::StreetMap, parent) {}
+    EniroMapProvider()
+        : MapProvider(
+            QStringLiteral("Eniro Topo"),
+            QStringLiteral("https://www.eniro.se/"),
+            QStringLiteral("png"),
+            AVERAGE_TILE_SIZE,
+            QGeoMapType::StreetMap) {}
 
 private:
     QString _getURL(int x, int y, int zoom) const final;
@@ -152,69 +167,82 @@ private:
 
 class MapQuestMapProvider : public MapProvider
 {
-    Q_OBJECT
-
 protected:
-    MapQuestMapProvider(const QString &mapName, QGeoMapType::MapStyle mapType, QObject* parent = nullptr)
-        : MapProvider(QStringLiteral("https://mapquest.com"), QStringLiteral("jpg"),
-                      AVERAGE_TILE_SIZE, mapType, parent)
-        , _mapName(mapName) {}
+    MapQuestMapProvider(const QString &mapName, const QString &mapTypeId, QGeoMapType::MapStyle mapType)
+        : MapProvider(
+            mapName,
+            QStringLiteral("https://mapquest.com"),
+            QStringLiteral("jpg"),
+            AVERAGE_TILE_SIZE,
+            mapType)
+        , _mapTypeId(mapName) {}
 
 private:
     QString _getURL(int x, int y, int zoom) const final;
 
-    const QString _mapName;
+    const QString _mapTypeId;
     const QString _mapUrl = QStringLiteral("http://otile%1.mqcdn.com/tiles/1.0.0/%2/%3/%4/%5.%6");
 };
 
 class MapQuestMapMapProvider : public MapQuestMapProvider
 {
-    Q_OBJECT
-
 public:
-    MapQuestMapMapProvider(QObject* parent = nullptr)
-        : MapQuestMapProvider(QStringLiteral("map"), QGeoMapType::StreetMap, parent) {}
+    MapQuestMapMapProvider()
+        : MapQuestMapProvider(
+            QStringLiteral("MapQuest Map"),
+            QStringLiteral("map"),
+            QGeoMapType::StreetMap) {}
 };
 
 class MapQuestSatMapProvider : public MapQuestMapProvider
 {
-    Q_OBJECT
-
 public:
-    MapQuestSatMapProvider(QObject* parent = nullptr)
-        : MapQuestMapProvider(QStringLiteral("sat"), QGeoMapType::SatelliteMapDay, parent) {}
+    MapQuestSatMapProvider()
+        : MapQuestMapProvider(
+            QStringLiteral("MapQuest Sat"),
+            QStringLiteral("sat"),
+            QGeoMapType::SatelliteMapDay) {}
 };
 
 class VWorldMapProvider : public MapProvider
 {
-    Q_OBJECT
-
 protected:
-    VWorldMapProvider(const QString &mapName, const QString& imageFormat, quint32 averageSize, QGeoMapType::MapStyle mapStyle, QObject* parent = nullptr)
-        : MapProvider(QStringLiteral("www.vworld.kr"), imageFormat, averageSize, mapStyle, parent)
-        , _mapName(mapName) {}
+    VWorldMapProvider(const QString &mapName, const QString &mapTypeId, const QString &imageFormat, quint32 averageSize, QGeoMapType::MapStyle mapStyle)
+        : MapProvider(
+            mapName,
+            QStringLiteral("www.vworld.kr"),
+            imageFormat,
+            averageSize,
+            mapStyle)
+        , _mapTypeId(mapName) {}
 
 private:
     QString _getURL(int x, int y, int zoom) const final;
 
-    const QString _mapName;
+    const QString _mapTypeId;
     const QString _mapUrl = QStringLiteral("http://api.vworld.kr/req/wmts/1.0.0/%1/%2/%3/%4/%5.%6");
 };
 
 class VWorldStreetMapProvider : public VWorldMapProvider
 {
-    Q_OBJECT
-
 public:
-    VWorldStreetMapProvider(QObject* parent = nullptr)
-        : VWorldMapProvider(QStringLiteral("Base"), QStringLiteral("png"), AVERAGE_TILE_SIZE, QGeoMapType::StreetMap, parent) {}
+    VWorldStreetMapProvider()
+        : VWorldMapProvider(
+            QStringLiteral("VWorld Street Map"),
+            QStringLiteral("Base"),
+            QStringLiteral("png"),
+            AVERAGE_TILE_SIZE,
+            QGeoMapType::StreetMap) {}
 };
 
 class VWorldSatMapProvider : public VWorldMapProvider
 {
-    Q_OBJECT
-
 public:
-    VWorldSatMapProvider(QObject* parent = nullptr)
-        : VWorldMapProvider(QStringLiteral("Satellite"), QStringLiteral("jpeg"), AVERAGE_TILE_SIZE, QGeoMapType::SatelliteMapDay, parent) {}
+    VWorldSatMapProvider()
+        : VWorldMapProvider(
+            QStringLiteral("VWorld Satellite Map"),
+            QStringLiteral("Satellite"),
+            QStringLiteral("jpeg"),
+            AVERAGE_TILE_SIZE,
+            QGeoMapType::SatelliteMapDay) {}
 };

--- a/src/QtLocationPlugin/GoogleMapProvider.h
+++ b/src/QtLocationPlugin/GoogleMapProvider.h
@@ -31,12 +31,15 @@ static constexpr const quint32 AVERAGE_GOOGLE_TERRAIN_MAP = 19391;
 
 class GoogleMapProvider : public MapProvider
 {
-    Q_OBJECT
-
 protected:
-    GoogleMapProvider(const QString& versionRequest, const QString& version, const QString& imageFormat, quint32 averageSize,
-                      QGeoMapType::MapStyle mapType, QObject* parent = nullptr)
-        : MapProvider(QStringLiteral("https://www.google.com/maps/preview"), imageFormat, averageSize, mapType, parent)
+    GoogleMapProvider(const QString &mapName, const QString &versionRequest, const QString &version, const QString &imageFormat, quint32 averageSize,
+                      QGeoMapType::MapStyle mapType)
+        : MapProvider(
+            mapName,
+            QStringLiteral("https://www.google.com/maps/preview"),
+            imageFormat,
+            averageSize,
+            mapType)
         , _versionRequest(versionRequest)
         , _version(version) {}
 
@@ -53,46 +56,65 @@ private:
 
 class GoogleStreetMapProvider : public GoogleMapProvider
 {
-    Q_OBJECT
-
 public:
-    GoogleStreetMapProvider(QObject* parent = nullptr)
-        : GoogleMapProvider(QStringLiteral("lyrs"), QStringLiteral("m"), QStringLiteral("png"), AVERAGE_GOOGLE_STREET_MAP, QGeoMapType::StreetMap, parent) {}
+    GoogleStreetMapProvider()
+        : GoogleMapProvider(
+            QStringLiteral("Google Street Map"),
+            QStringLiteral("lyrs"),
+            QStringLiteral("m"),
+            QStringLiteral("png"),
+            AVERAGE_GOOGLE_STREET_MAP,
+            QGeoMapType::StreetMap) {}
 };
 
 class GoogleSatelliteMapProvider : public GoogleMapProvider
 {
-    Q_OBJECT
-
 public:
-    GoogleSatelliteMapProvider(QObject* parent = nullptr)
-        : GoogleMapProvider(QStringLiteral("lyrs"), QStringLiteral("s"), QStringLiteral("jpg"), AVERAGE_GOOGLE_SAT_MAP,
-                            QGeoMapType::SatelliteMapDay, parent) {}
+    GoogleSatelliteMapProvider()
+        : GoogleMapProvider(
+            QStringLiteral("Google Satellite"),
+            QStringLiteral("lyrs"),
+            QStringLiteral("s"),
+            QStringLiteral("jpg"),
+            AVERAGE_GOOGLE_SAT_MAP,
+            QGeoMapType::SatelliteMapDay) {}
 };
 
 class GoogleLabelsMapProvider : public GoogleMapProvider
 {
-    Q_OBJECT
-
 public:
-    GoogleLabelsMapProvider(QObject* parent = nullptr)
-        : GoogleMapProvider(QStringLiteral("lyrs"), QStringLiteral("h"), QStringLiteral("png"), AVERAGE_TILE_SIZE, QGeoMapType::CustomMap, parent) {}
+    GoogleLabelsMapProvider()
+        : GoogleMapProvider(
+            QStringLiteral("Google Labels"),
+            QStringLiteral("lyrs"),
+            QStringLiteral("h"),
+            QStringLiteral("png"),
+            AVERAGE_TILE_SIZE,
+            QGeoMapType::CustomMap) {}
 };
 
 class GoogleTerrainMapProvider : public GoogleMapProvider
 {
-    Q_OBJECT
-
 public:
-    GoogleTerrainMapProvider(QObject* parent = nullptr)
-        : GoogleMapProvider(QStringLiteral("v"), QStringLiteral("t,r"), QStringLiteral("png"), AVERAGE_GOOGLE_TERRAIN_MAP, QGeoMapType::TerrainMap, parent) {}
+    GoogleTerrainMapProvider()
+        : GoogleMapProvider(
+            QStringLiteral("Google Terrain"),
+            QStringLiteral("v"),
+            QStringLiteral("t,r"),
+            QStringLiteral("png"),
+            AVERAGE_GOOGLE_TERRAIN_MAP,
+            QGeoMapType::TerrainMap) {}
 };
 
 class GoogleHybridMapProvider : public GoogleMapProvider
 {
-    Q_OBJECT
-
 public:
-    GoogleHybridMapProvider(QObject* parent = nullptr)
-        : GoogleMapProvider(QStringLiteral("lyrs"), QStringLiteral("y"), QStringLiteral("png"), AVERAGE_GOOGLE_SAT_MAP, QGeoMapType::HybridMap, parent) {}
+    GoogleHybridMapProvider()
+        : GoogleMapProvider(
+            QStringLiteral("Google Hybrid"),
+            QStringLiteral("lyrs"),
+            QStringLiteral("y"),
+            QStringLiteral("png"),
+            AVERAGE_GOOGLE_SAT_MAP,
+            QGeoMapType::HybridMap) {}
 };

--- a/src/QtLocationPlugin/MapProvider.cpp
+++ b/src/QtLocationPlugin/MapProvider.cpp
@@ -15,18 +15,30 @@
 
 QGC_LOGGING_CATEGORY(MapProviderLog, "qgc.qtlocationplugin.mapprovider")
 
+// QtLocation expects MapIds to start at 1 and be sequential.
+int MapProvider::_mapIdIndex = 1;
+
 MapProvider::MapProvider(
+    const QString &mapName,
     const QString &referrer,
     const QString &imageFormat,
     quint32 averageSize,
-    QGeoMapType::MapStyle mapStyle,
-    QObject* parent)
-    : QObject(parent)
+    QGeoMapType::MapStyle mapStyle)
+    : _mapName(mapName)
     , _referrer(referrer)
     , _imageFormat(imageFormat)
     , _averageSize(averageSize)
     , _mapStyle(mapStyle)
-    , _language(!QLocale::system().uiLanguages().isEmpty() ? QLocale::system().uiLanguages().constFirst() : "en") {}
+    , _language(!QLocale::system().uiLanguages().isEmpty() ? QLocale::system().uiLanguages().constFirst() : "en")
+    , _mapId(_mapIdIndex++)
+{
+    // qCDebug(MapProviderLog) << Q_FUNC_INFO << this << _mapId;
+}
+
+MapProvider::~MapProvider()
+{
+    // qCDebug(MapProviderLog) << Q_FUNC_INFO << this << _mapId;
+}
 
 QNetworkRequest MapProvider::getTileURL(int x, int y, int zoom) const
 {

--- a/src/QtLocationPlugin/MapProvider.h
+++ b/src/QtLocationPlugin/MapProvider.h
@@ -38,18 +38,21 @@ static constexpr const quint32 AVERAGE_TILE_SIZE = 13652;
 
 class QNetworkRequest;
 
-class MapProvider : public QObject
+class MapProvider
 {
-    Q_OBJECT
-
 public:
-    MapProvider(const QString& referrer, const QString& imageFormat, quint32 averageSize = AVERAGE_TILE_SIZE,
-                QGeoMapType::MapStyle mapStyle = QGeoMapType::CustomMap, QObject* parent = nullptr);
+    MapProvider(const QString &mapName, const QString &referrer, const QString &imageFormat, quint32 averageSize = AVERAGE_TILE_SIZE,
+                QGeoMapType::MapStyle mapStyle = QGeoMapType::CustomMap);
+    virtual ~MapProvider();
 
     QString getImageFormat(QByteArrayView image) const;
 
+    // TODO: Download Random Tile And Use That Size Instead?
     quint32 getAverageSize() const { return _averageSize; }
+
     QGeoMapType::MapStyle getMapStyle() const { return _mapStyle; }
+    const QString& getMapName() const { return _mapName; }
+    int getMapId() const { return _mapId; }
 
     virtual QNetworkRequest getTileURL(int x, int y, int zoom) const;
 
@@ -69,9 +72,14 @@ protected:
 
     virtual QString _getURL(int x, int y, int zoom) const = 0;
 
+    const QString _mapName;
     const QString _referrer;
     const QString _imageFormat;
     const quint32 _averageSize;
     const QGeoMapType::MapStyle _mapStyle;
     const QString _language;
+    const int _mapId;
+
+private:
+    static int _mapIdIndex;
 };

--- a/src/QtLocationPlugin/MapboxMapProvider.cpp
+++ b/src/QtLocationPlugin/MapboxMapProvider.cpp
@@ -6,7 +6,7 @@ QString MapboxMapProvider::_getURL(int x, int y, int zoom) const
 {
     const QString mapBoxToken = qgcApp()->toolbox()->settingsManager()->appSettings()->mapboxToken()->rawValue().toString();
     if (!mapBoxToken.isEmpty()) {
-        if (_mapboxName == QStringLiteral("mapbox.custom")) {
+        if (_mapTypeId == QStringLiteral("mapbox.custom")) {
             static const QString MapBoxUrlCustom = QStringLiteral("https://api.mapbox.com/styles/v1/%1/%2/tiles/256/%3/%4/%5?access_token=%6");
             const QString mapBoxAccount = qgcApp()->toolbox()->settingsManager()->appSettings()->mapboxAccount()->rawValue().toString();
             const QString mapBoxStyle = qgcApp()->toolbox()->settingsManager()->appSettings()->mapboxStyle()->rawValue().toString();
@@ -14,7 +14,7 @@ QString MapboxMapProvider::_getURL(int x, int y, int zoom) const
         }
 
         static const QString MapBoxUrl = QStringLiteral("https://api.mapbox.com/styles/v1/mapbox/%1/tiles/%2/%3/%4?access_token=%5");
-        return MapBoxUrl.arg(_mapboxName).arg(zoom).arg(x).arg(y).arg(mapBoxToken);
+        return MapBoxUrl.arg(_mapTypeId).arg(zoom).arg(x).arg(y).arg(mapBoxToken);
     }
     return QString();
 }

--- a/src/QtLocationPlugin/MapboxMapProvider.h
+++ b/src/QtLocationPlugin/MapboxMapProvider.h
@@ -16,105 +16,117 @@ static constexpr const quint32 AVERAGE_MAPBOX_STREET_MAP  = 5648;
 
 class MapboxMapProvider : public MapProvider
 {
-    Q_OBJECT
-
 protected:
-    MapboxMapProvider(const QString& mapName, quint32 averageSize, QGeoMapType::MapStyle mapType, QObject* parent = nullptr)
-        : MapProvider(QStringLiteral("https://www.mapbox.com/"), QStringLiteral("jpg"), averageSize, mapType, parent)
-        , _mapboxName(mapName) {}
+    MapboxMapProvider(const QString &mapName, const QString &mapTypeId, quint32 averageSize, QGeoMapType::MapStyle mapType)
+        : MapProvider(
+            mapName,
+            QStringLiteral("https://www.mapbox.com/"),
+            QStringLiteral("jpg"),
+            averageSize,
+            mapType)
+        , _mapTypeId(mapTypeId) {}
 
 private:
     QString _getURL(int x, int y, int zoom) const final;
 
-    const QString _mapboxName;
+    const QString _mapTypeId;
 };
 
 class MapboxStreetMapProvider : public MapboxMapProvider
 {
-    Q_OBJECT
-
 public:
-    MapboxStreetMapProvider(QObject* parent = nullptr)
-        : MapboxMapProvider(QStringLiteral("streets-v10"), AVERAGE_MAPBOX_STREET_MAP,
-                            QGeoMapType::StreetMap, parent) {}
+    MapboxStreetMapProvider()
+        : MapboxMapProvider(
+            QStringLiteral("Mapbox Streets"),
+            QStringLiteral("streets-v10"),
+            AVERAGE_MAPBOX_STREET_MAP,
+            QGeoMapType::StreetMap) {}
 };
 
 class MapboxLightMapProvider : public MapboxMapProvider
 {
-    Q_OBJECT
-
 public:
-    MapboxLightMapProvider(QObject* parent = nullptr)
-        : MapboxMapProvider(QStringLiteral("light-v9"), AVERAGE_TILE_SIZE,
-                            QGeoMapType::CustomMap, parent) {}
+    MapboxLightMapProvider()
+        : MapboxMapProvider(
+            QStringLiteral("Mapbox Light"),
+            QStringLiteral("light-v9"),
+            AVERAGE_TILE_SIZE,
+            QGeoMapType::CustomMap) {}
 };
 
 class MapboxDarkMapProvider : public MapboxMapProvider
 {
-    Q_OBJECT
-
 public:
-    MapboxDarkMapProvider(QObject* parent = nullptr)
-        : MapboxMapProvider(QStringLiteral("dark-v9"), AVERAGE_TILE_SIZE,
-                            QGeoMapType::CustomMap, parent) {}
+    MapboxDarkMapProvider()
+        : MapboxMapProvider(
+            QStringLiteral("Mapbox Dark"),
+            QStringLiteral("dark-v9"),
+            AVERAGE_TILE_SIZE,
+            QGeoMapType::CustomMap) {}
 };
 
 class MapboxSatelliteMapProvider : public MapboxMapProvider
 {
-    Q_OBJECT
-
 public:
-    MapboxSatelliteMapProvider(QObject* parent = nullptr)
-        : MapboxMapProvider(QStringLiteral("satellite-v9"), AVERAGE_MAPBOX_SAT_MAP,
-                            QGeoMapType::SatelliteMapDay, parent) {}
+    MapboxSatelliteMapProvider()
+        : MapboxMapProvider(
+            QStringLiteral("Mapbox Satellite"),
+            QStringLiteral("satellite-v9"),
+            AVERAGE_MAPBOX_SAT_MAP,
+            QGeoMapType::SatelliteMapDay) {}
 };
 
 class MapboxHybridMapProvider : public MapboxMapProvider
 {
-    Q_OBJECT
-
 public:
-    MapboxHybridMapProvider(QObject* parent = nullptr)
-        : MapboxMapProvider(QStringLiteral("satellite-streets-v10"), AVERAGE_MAPBOX_SAT_MAP,
-                            QGeoMapType::HybridMap, parent) {}
+    MapboxHybridMapProvider()
+        : MapboxMapProvider(
+            QStringLiteral("Mapbox Hybrid"),
+            QStringLiteral("satellite-streets-v10"),
+            AVERAGE_MAPBOX_SAT_MAP,
+            QGeoMapType::HybridMap) {}
 };
 
 class MapboxBrightMapProvider : public MapboxMapProvider
 {
-    Q_OBJECT
-
 public:
-    MapboxBrightMapProvider(QObject* parent = nullptr)
-        : MapboxMapProvider(QStringLiteral("bright-v9"), AVERAGE_TILE_SIZE,
-                            QGeoMapType::CustomMap, parent) {}
+    MapboxBrightMapProvider()
+        : MapboxMapProvider(
+            QStringLiteral("Mapbox Bright"),
+            QStringLiteral("bright-v9"),
+            AVERAGE_TILE_SIZE,
+            QGeoMapType::CustomMap) {}
 };
 
 class MapboxStreetsBasicMapProvider : public MapboxMapProvider
 {
-    Q_OBJECT
-
 public:
-    MapboxStreetsBasicMapProvider(QObject* parent = nullptr)
-        : MapboxMapProvider(QStringLiteral("basic-v9"), AVERAGE_TILE_SIZE,
-                            QGeoMapType::StreetMap, parent) {}
+    MapboxStreetsBasicMapProvider()
+        : MapboxMapProvider(
+            QStringLiteral("Mapbox StreetsBasic"),
+            QStringLiteral("basic-v9"),
+            AVERAGE_TILE_SIZE,
+            QGeoMapType::StreetMap) {}
 };
 
 class MapboxOutdoorsMapProvider : public MapboxMapProvider
 {
-    Q_OBJECT
-
 public:
-    MapboxOutdoorsMapProvider(QObject* parent = nullptr)
-        : MapboxMapProvider(QStringLiteral("outdoors-v10"), AVERAGE_TILE_SIZE,
-                            QGeoMapType::CustomMap, parent) {}
+    MapboxOutdoorsMapProvider()
+        : MapboxMapProvider(
+            QStringLiteral("Mapbox Outdoors"),
+            QStringLiteral("outdoors-v10"),
+            AVERAGE_TILE_SIZE,
+            QGeoMapType::CustomMap) {}
 };
 
 class MapboxCustomMapProvider : public MapboxMapProvider
 {
-    Q_OBJECT
-
 public:
-    MapboxCustomMapProvider(QObject* parent = nullptr)
-        : MapboxMapProvider(QStringLiteral("mapbox.custom"), AVERAGE_TILE_SIZE,
-                            QGeoMapType::CustomMap, parent) {}
+    MapboxCustomMapProvider()
+        : MapboxMapProvider(
+            QStringLiteral("Mapbox Custom"),
+            QStringLiteral("mapbox.custom"),
+            AVERAGE_TILE_SIZE,
+            QGeoMapType::CustomMap) {}
 };

--- a/src/QtLocationPlugin/QGCMapEngine.h
+++ b/src/QtLocationPlugin/QGCMapEngine.h
@@ -19,19 +19,19 @@
 #pragma once
 
 #include "QGCMapEngineData.h"
-#include "QGCTileCacheWorker.h"
 #include "QGCTileSet.h"
 
 #include <QtCore/QString>
 
 class UrlFactory;
+class QGCCacheWorker;
 
 //-----------------------------------------------------------------------------
 class QGCMapEngine : public QObject
 {
     Q_OBJECT
 public:
-    QGCMapEngine                ();
+    QGCMapEngine(QObject* parent = nullptr);
     ~QGCMapEngine               ();
 
     static QGCMapEngine* instance();
@@ -40,21 +40,17 @@ public:
     void                        addTask             (QGCMapTask *task);
     void                        cacheTile           (const QString& type, int x, int y, int z, const QByteArray& image, const QString& format, qulonglong set = UINT64_MAX);
     void                        cacheTile           (const QString& type, const QString& hash, const QByteArray& image, const QString& format, qulonglong set = UINT64_MAX);
-    QGCFetchTileTask*           createFetchTileTask (const QString& type, int x, int y, int z);
-    QStringList                 getMapNameList      ();
+    static QGCFetchTileTask*    createFetchTileTask (const QString& type, int x, int y, int z);
+    static QStringList          getMapNameList      ();
     const QString               userAgent           () { return _userAgent; }
     void                        setUserAgent        (const QString& ua) { _userAgent = ua; }
-    QString                     tileHashToType      (const QString& tileHash);
-    QString                     getTileHash         (const QString& type, int x, int y, int z);
-    quint32                     getMaxDiskCache     ();
-    quint32                     getMaxMemCache      ();
-    void                        setMaxMemCache      (quint32 size);
+    static QString              tileHashToType      (const QString& tileHash);
+    static QString              getTileHash         (const QString& type, int x, int y, int z);
+    static quint32              getMaxDiskCache     ();
+    static quint32              getMaxMemCache      ();
     const QString               getCachePath        () { return _cachePath; }
     const QString               getCacheFilename    () { return _cacheFile; }
-    void                        testInternet        ();
     bool                        wasCacheReset       () const{ return _cacheWasReset; }
-
-    UrlFactory*                 urlFactory          () { return _urlFactory; }
 
     //-- Tile Math
     static QGCTileSet           getTileCount        (int zoom, double topleftLon, double topleftLat, double bottomRightLon, double bottomRightLat, const QString& mapType);
@@ -77,13 +73,12 @@ private:
     bool _wipeDirectory         (const QString& dirPath);
 
 private:
-    QGCCacheWorker          _worker;
-    QString                 _cachePath;
-    QString                 _cacheFile;
-    UrlFactory*             _urlFactory;
+    QGCCacheWorker*         _worker = nullptr;
     QString                 _userAgent;
     bool                    _prunning;
     bool                    _cacheWasReset;
+    QString                 _cachePath;
+    QString                 _cacheFile;
 };
 
 extern QGCMapEngine*    getQGCMapEngine();

--- a/src/QtLocationPlugin/QGCMapTileSet.cpp
+++ b/src/QtLocationPlugin/QGCMapTileSet.cpp
@@ -22,6 +22,7 @@
 #include "QGCFileDownload.h"
 #include "TerrainTile.h"
 #include "QGCMapUrlEngine.h"
+#include "ElevationMapProvider.h"
 #include "QGCLoggingCategory.h"
 
 #include <QtNetwork/QNetworkProxy>
@@ -241,7 +242,7 @@ void QGCCachedTileSet::_prepareDownload()
         if(_tilesToDownload.count()) {
             QGCTile* tile = _tilesToDownload.first();
             _tilesToDownload.removeFirst();
-            QNetworkRequest request = getQGCMapEngine()->urlFactory()->getTileURL(tile->type(), tile->x(), tile->y(), tile->z());
+            QNetworkRequest request = UrlFactory::getTileURL(tile->type(), tile->x(), tile->y(), tile->z());
             request.setAttribute(QNetworkRequest::User, tile->hash());
 #if !defined(__mobile__)
             QNetworkProxy proxy = _networkManager->proxy();
@@ -289,11 +290,11 @@ QGCCachedTileSet::_networkReplyFinished()
             }
             qCDebug(QGCCachedTileSetLog) << "Tile fetched" << hash;
             QByteArray image = reply->readAll();
-            QString type = getQGCMapEngine()->tileHashToType(hash);
-            if (type == UrlFactory::kCopernicusElevationProviderKey) {
+            QString type = QGCMapEngine::tileHashToType(hash);
+            if (type == CopernicusElevationProvider::kProviderKey) {
                 image = TerrainTile::serializeFromAirMapJson(image);
             }
-            QString format = getQGCMapEngine()->urlFactory()->getImageFormat(type, image);
+            QString format = UrlFactory::getImageFormat(type, image);
             if(!format.isEmpty()) {
                 //-- Cache tile
                 getQGCMapEngine()->cacheTile(type, hash, image, format, _id);

--- a/src/QtLocationPlugin/QGCMapUrlEngine.cpp
+++ b/src/QtLocationPlugin/QGCMapUrlEngine.cpp
@@ -14,8 +14,6 @@
  * 2012.
  */
 
-//#define DEBUG_GOOGLE_MAPS
-
 #include "QGCMapUrlEngine.h"
 #include "GoogleMapProvider.h"
 #include "BingMapProvider.h"
@@ -23,238 +21,237 @@
 #include "EsriMapProvider.h"
 #include "MapboxMapProvider.h"
 #include "ElevationMapProvider.h"
-#include "QGCLoggingCategory.h"
+#include <QGCLoggingCategory.h>
 
-QGC_LOGGING_CATEGORY(QGCMapUrlEngineLog, "QGCMapUrlEngineLog")
+QGC_LOGGING_CATEGORY(QGCMapUrlEngineLog, "qgc.qtlocationplugin.qgcmapurlengine")
 
-const char* UrlFactory::kCopernicusElevationProviderKey = "Copernicus Elevation";
-const char* UrlFactory::kCopernicusElevationProviderNotice = "© Airbus Defence and Space GmbH";
-
-//-----------------------------------------------------------------------------
-UrlFactory::UrlFactory() : 
-    _timeout(5 * 1000) 
-{
-
-    // The internal Qt code for map plugins has the concept of a Map Id. These ids must start at 1 and be sequential.
-    // Map Ids are used to identify the map provider to use. Because of this we keep the providers in a simple list
-    // such that the index into the list with the map id - 1.
-
+const QList<SharedMapProvider> UrlFactory::_providers = {
 #ifndef QGC_NO_GOOGLE_MAPS
-    _providers.append(ProviderPair("Google Street Map", new GoogleStreetMapProvider(this)));
-    _providers.append(ProviderPair("Google Satellite", new GoogleSatelliteMapProvider(this)));
-    _providers.append(ProviderPair("Google Terrain", new GoogleTerrainMapProvider(this)));
-    _providers.append(ProviderPair("Google Hybrid", new GoogleHybridMapProvider(this)));
-    _providers.append(ProviderPair("Google Labels", new GoogleLabelsMapProvider(this)));
+    std::make_shared<GoogleStreetMapProvider>(),
+    std::make_shared<GoogleSatelliteMapProvider>(),
+    std::make_shared<GoogleTerrainMapProvider>(),
+    std::make_shared<GoogleHybridMapProvider>(),
+    std::make_shared<GoogleLabelsMapProvider>(),
 #endif
+    std::make_shared<BingRoadMapProvider>(),
+    std::make_shared<BingSatelliteMapProvider>(),
+    std::make_shared<BingHybridMapProvider>(),
 
-    _providers.append(ProviderPair("Bing Road", new BingRoadMapProvider(this)));
-    _providers.append(ProviderPair("Bing Satellite", new BingSatelliteMapProvider(this)));
-    _providers.append(ProviderPair("Bing Hybrid", new BingHybridMapProvider(this)));
+    std::make_shared<StatkartTopoMapProvider>(),
+    std::make_shared<StatkartBaseMapProvider>(),
 
-    _providers.append(ProviderPair("Statkart Topo", new StatkartTopoMapProvider(this)));
-    _providers.append(ProviderPair("Statkart Basemap", new StatkartBaseMapProvider(this)));
+    std::make_shared<EniroMapProvider>(),
 
-    _providers.append(ProviderPair("Eniro Topo", new EniroMapProvider(this)));
+    std::make_shared<EsriWorldStreetMapProvider>(),
+    std::make_shared<EsriWorldSatelliteMapProvider>(),
+    std::make_shared<EsriTerrainMapProvider>(),
 
-    // To be add later on Token entry !
-    //_providers.append(ProviderPair("Esri World Street", new EsriWorldStreetMapProvider(this)));
-    //_providers.append(ProviderPair("Esri World Satellite", new EsriWorldSatelliteMapProvider(this)));
-    //_providers.append(ProviderPair("Esri Terrain", new EsriTerrainMapProvider(this)));
+    std::make_shared<MapboxStreetMapProvider>(),
+    std::make_shared<MapboxLightMapProvider>(),
+    std::make_shared<MapboxDarkMapProvider>(),
+    std::make_shared<MapboxSatelliteMapProvider>(),
+    std::make_shared<MapboxHybridMapProvider>(),
+    std::make_shared<MapboxStreetsBasicMapProvider>(),
+    std::make_shared<MapboxOutdoorsMapProvider>(),
+    std::make_shared<MapboxBrightMapProvider>(),
+    std::make_shared<MapboxCustomMapProvider>(),
 
-    _providers.append(ProviderPair("Mapbox Streets", new MapboxStreetMapProvider(this)));
-    _providers.append(ProviderPair("Mapbox Light", new MapboxLightMapProvider(this)));
-    _providers.append(ProviderPair("Mapbox Dark", new MapboxDarkMapProvider(this)));
-    _providers.append(ProviderPair("Mapbox Satellite", new MapboxSatelliteMapProvider(this)));
-    _providers.append(ProviderPair("Mapbox Hybrid", new MapboxHybridMapProvider(this)));
-    _providers.append(ProviderPair("Mapbox StreetsBasic", new MapboxStreetsBasicMapProvider(this)));
-    _providers.append(ProviderPair("Mapbox Outdoors", new MapboxOutdoorsMapProvider(this)));
-    _providers.append(ProviderPair("Mapbox Bright", new MapboxBrightMapProvider(this)));
-    _providers.append(ProviderPair("Mapbox Custom", new MapboxCustomMapProvider(this)));
+    std::make_shared<MapQuestMapMapProvider>(),
+    std::make_shared<MapQuestSatMapProvider>(),
 
-    //_providers.append(ProviderPair("MapQuest Map", new MapQuestMapMapProvider(this)));
-    //_providers.append(ProviderPair("MapQuest Sat", new MapQuestSatMapProvider(this)));
+    std::make_shared<VWorldStreetMapProvider>(),
+    std::make_shared<VWorldSatMapProvider>(),
 
-    _providers.append(ProviderPair("VWorld Street Map", new VWorldStreetMapProvider(this)));
-    _providers.append(ProviderPair("VWorld Satellite Map", new VWorldSatMapProvider(this)));
+    std::make_shared<CopernicusElevationProvider>(),
 
-    _providers.append(ProviderPair(kCopernicusElevationProviderKey, new CopernicusElevationProvider(this)));
+    std::make_shared<JapanStdMapProvider>(),
+    std::make_shared<JapanSeamlessMapProvider>(),
+    std::make_shared<JapanAnaglyphMapProvider>(),
+    std::make_shared<JapanSlopeMapProvider>(),
+    std::make_shared<JapanReliefMapProvider>(),
 
-    _providers.append(ProviderPair("Japan-GSI Contour", new JapanStdMapProvider(this)));
-    _providers.append(ProviderPair("Japan-GSI Seamless", new JapanSeamlessMapProvider(this)));
-    _providers.append(ProviderPair("Japan-GSI Anaglyph", new JapanAnaglyphMapProvider(this)));
-    _providers.append(ProviderPair("Japan-GSI Slope", new JapanSlopeMapProvider(this)));
-    _providers.append(ProviderPair("Japan-GSI Relief", new JapanReliefMapProvider(this)));
+    std::make_shared<LINZBasemapMapProvider>(),
 
-    _providers.append(ProviderPair("LINZ Basemap", new LINZBasemapMapProvider(this)));
+    std::make_shared<CustomURLMapProvider>()
+};
 
-    _providers.append(ProviderPair("CustomURL Custom", new CustomURLMapProvider(this)));
-}
-
-//-----------------------------------------------------------------------------
-UrlFactory::~UrlFactory() {}
-
-QString UrlFactory::getImageFormat(int qtMapId, const QByteArray& image) {
-    MapProvider* provider = getMapProviderFromQtMapId(qtMapId);
+QString UrlFactory::getImageFormat(int qtMapId, QByteArrayView image)
+{
+    const SharedMapProvider provider = getMapProviderFromQtMapId(qtMapId);
     if (provider) {
         return provider->getImageFormat(image);
-    } else {
-        qCWarning(QGCMapUrlEngineLog) << "getImageFormat : map id not found:" << qtMapId;
-        return "";
     }
+
+    return QStringLiteral("");
 }
 
-//-----------------------------------------------------------------------------
-QString UrlFactory::getImageFormat(const QString& type, const QByteArray& image) {
-    MapProvider* provider =  getMapProviderFromProviderType(type);
+QString UrlFactory::getImageFormat(QStringView type, QByteArrayView image)
+{
+    const SharedMapProvider provider =  getMapProviderFromProviderType(type);
     if (provider) {
         return provider->getImageFormat(image);
-    } else {
-        qCWarning(QGCMapUrlEngineLog) << "getImageFormat : type not found:" << type;
-        return "";
     }
-}
-QNetworkRequest UrlFactory::getTileURL(int qtMapId, int x, int y, int zoom) 
-{
-    MapProvider* provider = getMapProviderFromQtMapId(qtMapId);
-    if (provider) {
-        return provider->getTileURL(x, y, zoom);
-    } else {
-        qCWarning(QGCMapUrlEngineLog) << "getTileURL : map id not found:" << qtMapId;
-        return QNetworkRequest(QUrl());
-    }
+
+    return QStringLiteral("");
 }
 
-//-----------------------------------------------------------------------------
-QNetworkRequest UrlFactory::getTileURL(const QString& type, int x, int y, int zoom) 
+QNetworkRequest UrlFactory::getTileURL(int qtMapId, int x, int y, int zoom)
 {
-    MapProvider* provider = getMapProviderFromProviderType(type);
+    const SharedMapProvider provider = getMapProviderFromQtMapId(qtMapId);
     if (provider) {
         return provider->getTileURL(x, y, zoom);
-    } else {
-        qCWarning(QGCMapUrlEngineLog) << "getTileURL : type not found:" << type;
-        return QNetworkRequest(QUrl());
     }
+
+    return QNetworkRequest(QUrl());
 }
 
-//-----------------------------------------------------------------------------
-quint32 UrlFactory::averageSizeForType(const QString& type) {
-    MapProvider* provider = getMapProviderFromProviderType(type);
+QNetworkRequest UrlFactory::getTileURL(QStringView type, int x, int y, int zoom)
+{
+    const SharedMapProvider provider = getMapProviderFromProviderType(type);
+    if (provider) {
+        return provider->getTileURL(x, y, zoom);
+    }
+
+    return QNetworkRequest(QUrl());
+}
+
+quint32 UrlFactory::averageSizeForType(QStringView type)
+{
+    const SharedMapProvider provider = getMapProviderFromProviderType(type);
     if (provider) {
         return provider->getAverageSize();
-    } else {
-        qCWarning(QGCMapUrlEngineLog) << "UrlFactory::averageSizeForType type not found:" << type;
-        return AVERAGE_TILE_SIZE;
-    }
-}
-
-QString UrlFactory::getProviderTypeFromQtMapId(int qtMapId) {
-    if (qtMapId >= 1 && qtMapId <= _providers.count()) {
-        return _providers.at(qtMapId - 1).first;
-    } else {
-        qCWarning(QGCMapUrlEngineLog) << "getProviderTypeFromQtMapId : map id not found:" << qtMapId;
-        return _providers.at(0).first;
-    }
-}
-
-MapProvider* UrlFactory::getMapProviderFromProviderType(const QString& type)
-{
-    for (qsizetype i=0; i<_providers.count(); i++) {
-        if (_providers.at(i).first == type) {
-            return _providers.at(i).second;
-        }
     }
 
-    return nullptr;
-}
-
-MapProvider* UrlFactory::getMapProviderFromQtMapId(int qtMapId)
-{
-    if (qtMapId >= 1 && qtMapId <= _providers.count()) {
-        return _providers.at(qtMapId - 1).second;
-    } else {
-        return nullptr;
-    }
-}
-
-int UrlFactory::getQtMapIdFromProviderType(const QString& type)
-{
-    for (qsizetype i=0; i<_providers.count(); i++) {
-        if (_providers.at(i).first == type) {
-            return i + 1;
-        }
-    }
-
-    qCWarning(QGCMapUrlEngineLog) << "getQtMapIdFromProviderType : type not found:" << type;
-    return 1;
-}
-
-int UrlFactory::long2tileX(const QString& mapType, double lon, int z)
-{
-    MapProvider* provider = getMapProviderFromProviderType(mapType);
-    if (provider) {
-        return provider->long2tileX(lon, z);
-    } else {
-        qCWarning(QGCMapUrlEngineLog) << "long2tileX : type not found:" << mapType;
-        return 0;
-    }
-}
-
-int UrlFactory::lat2tileY(const QString& mapType, double lat, int z)
-{
-    MapProvider* provider = getMapProviderFromProviderType(mapType);
-    if (provider) {
-        return provider->lat2tileY(lat, z);
-    } else {
-        qCWarning(QGCMapUrlEngineLog) << "lat2tileY : type not found:" << mapType;
-        return 0;
-    }
-}
-
-QGCTileSet UrlFactory::getTileCount(int zoom, double topleftLon, double topleftLat, double bottomRightLon, double bottomRightLat, const QString& mapType)
-{
-    MapProvider* provider = getMapProviderFromProviderType(mapType);
-    if (provider) {
-        return provider->getTileCount(zoom, topleftLon, topleftLat, bottomRightLon, bottomRightLat);
-    } else {
-        qCWarning(QGCMapUrlEngineLog) << "getTileCount : type not found:" << mapType;
-        return QGCTileSet();
-    }
+    return AVERAGE_TILE_SIZE;
 }
 
 bool UrlFactory::isElevation(int qtMapId)
 {
-    MapProvider* provider = getMapProviderFromQtMapId(qtMapId);
+    const SharedMapProvider provider = getMapProviderFromQtMapId(qtMapId);
     if (provider) {
         return provider->isElevationProvider();
-    } else {
-        qCWarning(QGCMapUrlEngineLog) << "isElevation : map id not found:" << qtMapId;
-        return false;
     }
+
+    return false;
+}
+
+int UrlFactory::long2tileX(QStringView mapType, double lon, int z)
+{
+    const SharedMapProvider provider = getMapProviderFromProviderType(mapType);
+    if (provider) {
+        return provider->long2tileX(lon, z);
+    }
+
+    return 0;
+}
+
+int UrlFactory::lat2tileY(QStringView mapType, double lat, int z)
+{
+    const SharedMapProvider provider = getMapProviderFromProviderType(mapType);
+    if (provider) {
+        return provider->lat2tileY(lat, z);
+    }
+
+    return 0;
+}
+
+QGCTileSet UrlFactory::getTileCount(int zoom, double topleftLon, double topleftLat, double bottomRightLon, double bottomRightLat, QStringView mapType)
+{
+    const SharedMapProvider provider = getMapProviderFromProviderType(mapType);
+    if (provider) {
+        // TODO: Check QGeoCameraCapabilities.maximumZoomLevel() and QGeoCameraCapabilities.minimumZoomLevel()
+        if(zoom < 1) {
+            zoom = 1;
+        } else if(zoom > MAX_MAP_ZOOM) {
+            zoom = MAX_MAP_ZOOM;
+        }
+        return provider->getTileCount(zoom, topleftLon, topleftLat, bottomRightLon, bottomRightLat);
+    }
+
+    return QGCTileSet();
+}
+
+QString UrlFactory::getProviderTypeFromQtMapId(int qtMapId)
+{
+    // Default Set
+    if(qtMapId == -1) {
+        return nullptr;
+    }
+
+    for (const SharedMapProvider &provider : _providers) {
+        if (provider->getMapId() == qtMapId) {
+            return provider->getMapName();
+        }
+    }
+
+    qCWarning(QGCMapUrlEngineLog) << Q_FUNC_INFO << "map id not found:" << qtMapId;
+    return QStringLiteral("");
+}
+
+SharedMapProvider UrlFactory::getMapProviderFromQtMapId(int qtMapId)
+{
+    // Default Set
+    if(qtMapId == -1) {
+        return nullptr;
+    }
+
+    for (const SharedMapProvider &provider : _providers) {
+        if (provider->getMapId() == qtMapId) {
+            return provider;
+        }
+    }
+
+    qCWarning(QGCMapUrlEngineLog) << Q_FUNC_INFO << "provider not found from id:" << qtMapId;
+    return nullptr;
+}
+
+SharedMapProvider UrlFactory::getMapProviderFromProviderType(QStringView type)
+{
+    for (const SharedMapProvider &provider : _providers) {
+        if (provider->getMapName() == type) {
+            return provider;
+        }
+    }
+
+    qCWarning(QGCMapUrlEngineLog) << Q_FUNC_INFO << "type not found:" << type;
+    return nullptr;
+}
+
+int UrlFactory::getQtMapIdFromProviderType(QStringView type)
+{
+    for (const SharedMapProvider &provider : _providers) {
+        if (provider->getMapName() == type) {
+            return provider->getMapId();
+        }
+    }
+
+    qCWarning(QGCMapUrlEngineLog) << Q_FUNC_INFO << "type not found:" << type;
+    return -1;
 }
 
 QStringList UrlFactory::getProviderTypes()
 {
     QStringList types;
-    for (qsizetype i=0; i<_providers.count(); i++) {
-        types.append(_providers.at(i).first);
+    for (const SharedMapProvider &provider : _providers) {
+        (void) types.append(provider->getMapName());
     }
 
     return types;
 }
 
-int UrlFactory::hashFromProviderType(const QString& type)
-{
-    return (int)(qHash(type) >> 1);
-}
-
 QString UrlFactory::providerTypeFromHash(int hash)
 {
-    for (qsizetype i=0; i<_providers.count(); i++) {
-        if (int(qHash(_providers.at(i).first) >> 1) == hash) {
-            return _providers.at(i).first;
+    for (const SharedMapProvider &provider : _providers) {
+        if (hashFromProviderType(provider->getMapName()) == hash) {
+            return provider->getMapName();
         }
     }
 
-    qCWarning(QGCMapUrlEngineLog) << "providerTypeFromTileHash : provider not found from hash" << hash;
-    return "";
+    qCWarning(QGCMapUrlEngineLog) << Q_FUNC_INFO << "provider not found from hash:" << hash;
+    return QStringLiteral("");
+}
+
+int UrlFactory::hashFromProviderType(QStringView type)
+{
+    return static_cast<int>(qHash(type) >> 1);
 }

--- a/src/QtLocationPlugin/QGCMapUrlEngine.h
+++ b/src/QtLocationPlugin/QGCMapUrlEngine.h
@@ -17,54 +17,47 @@
 
 #include "QGCTileSet.h"
 
-#include <QtCore/QByteArray>
-#include <QtCore/QString>
 #include <QtCore/QObject>
+#include <QtCore/QByteArrayView>
+#include <QtCore/QStringView>
 #include <QtNetwork/QNetworkRequest>
 
 #define MAX_MAP_ZOOM (23.0)
 
-class QNetworkAccessManager;
 class MapProvider;
 
-class UrlFactory : public QObject {
-    Q_OBJECT
-
+class UrlFactory
+{
 public:
-    static const char* kCopernicusElevationProviderKey;
-    static const char* kCopernicusElevationProviderNotice;
+    static QString getImageFormat(QStringView type, QByteArrayView image);
+    static QString getImageFormat(int qtMapId, QByteArrayView image);
 
-    UrlFactory      ();
-    ~UrlFactory     ();
+    static QNetworkRequest getTileURL(QStringView type, int x, int y, int zoom);
+    static QNetworkRequest getTileURL(int qtMapId, int x, int y, int zoom);
 
-    typedef QPair<QString, MapProvider*> ProviderPair;
+    static quint32 averageSizeForType(QStringView type);
 
-    QNetworkRequest getTileURL          (const QString& type, int x, int y, int zoom);
-    QNetworkRequest getTileURL          (int qtMapId, int x, int y, int zoom);
+    static bool isElevation(int qtMapId);
 
-    QString         getImageFormat      (const QString& type, const QByteArray& image);
-    QString         getImageFormat      (int qtMapId, const QByteArray& image);
+    static int long2tileX(QStringView mapType, double lon, int z);
+    static int lat2tileY(QStringView mapType, double lat, int z);
 
-    quint32  averageSizeForType  (const QString& type);
-
-    int long2tileX(const QString& mapType, double lon, int z);
-    int lat2tileY (const QString& mapType, double lat, int z);
-
-    QStringList     getProviderTypes                ();
-    int             getQtMapIdFromProviderType      (const QString& type);
-    QString         getProviderTypeFromQtMapId      (int qtMapId);
-    MapProvider*    getMapProviderFromQtMapId       (int qtMapId);
-    MapProvider*    getMapProviderFromProviderType  (const QString& type);
-    int             hashFromProviderType            (const QString& type);
-    QString         providerTypeFromHash            (int tileHash);
-
-    QGCTileSet getTileCount(int zoom, double topleftLon, double topleftLat,
+    static QGCTileSet getTileCount(int zoom, double topleftLon, double topleftLat,
                             double bottomRightLon, double bottomRightLat,
-                            const QString& mapType);
+                            QStringView mapType);
 
-    bool isElevation(int qtMapId);
+    static const QList<std::shared_ptr<const MapProvider>>& getProviders() { return _providers; }
+    static QStringList getProviderTypes();
+    static int getQtMapIdFromProviderType(QStringView type);
+    static QString getProviderTypeFromQtMapId(int qtMapId);
+    static std::shared_ptr<const MapProvider> getMapProviderFromQtMapId(int qtMapId);
+    static std::shared_ptr<const MapProvider> getMapProviderFromProviderType(QStringView type);
+    static QString providerTypeFromHash(int hash);
+
+    static int hashFromProviderType(QStringView type);
 
 private:
-    int                   _timeout;
-    QList<ProviderPair>   _providers;
+    static const QList<std::shared_ptr<const MapProvider>> _providers;
 };
+
+typedef std::shared_ptr<const MapProvider> SharedMapProvider;

--- a/src/QtLocationPlugin/QGCTileCacheWorker.cpp
+++ b/src/QtLocationPlugin/QGCTileCacheWorker.cpp
@@ -16,6 +16,7 @@
  *
  */
 
+#include "QGCTileCacheWorker.h"
 #include "QGCMapEngine.h"
 #include "QGCMapTileSet.h"
 #include "QGCMapUrlEngine.h"
@@ -45,8 +46,9 @@ QGC_LOGGING_CATEGORY(QGCTileCacheLog, "QGCTileCacheLog")
 #define SHORT_TIMEOUT       2
 
 //-----------------------------------------------------------------------------
-QGCCacheWorker::QGCCacheWorker()
-    : _db(nullptr)
+QGCCacheWorker::QGCCacheWorker(QObject* parent)
+    : QThread(parent)
+    , _db(nullptr)
     , _valid(false)
     , _failed(false)
     , _defaultSet(UINT64_MAX)
@@ -363,7 +365,7 @@ QGCCacheWorker::_getTileSets(QGCMapTask* mtask)
             set->setBottomRightLon(query.value("bottomRightLon").toDouble());
             set->setMinZoom(query.value("minZoom").toInt());
             set->setMaxZoom(query.value("maxZoom").toInt());
-            set->setType(getQGCMapEngine()->urlFactory()->getProviderTypeFromQtMapId(query.value("type").toInt()));
+            set->setType(UrlFactory::getProviderTypeFromQtMapId(query.value("type").toInt()));
             set->setTotalTileCount(query.value("numTiles").toUInt());
             set->setDefaultSet(query.value("defaultSet").toInt() != 0);
             set->setCreationDate(QDateTime::fromSecsSinceEpoch(query.value("date").toUInt()));
@@ -398,7 +400,7 @@ QGCCacheWorker::_updateSetTotals(QGCCachedTileSet* set)
             set->setSavedTileSize(subquery.value(1).toULongLong());
             qCDebug(QGCTileCacheLog) << "Set" << set->id() << "Totals:" << set->savedTileCount() << " " << set->savedTileSize() << "Expected: " << set->totalTileCount() << " " << set->totalTilesSize();
             //-- Update (estimated) size
-            quint64 avg = getQGCMapEngine()->urlFactory()->averageSizeForType(set->type());
+            quint64 avg = UrlFactory::averageSizeForType(set->type());
             if(set->totalTileCount() <= set->savedTileCount()) {
                 //-- We're done so the saved size is the total size
                 set->setTotalTileSize(set->savedTileSize());
@@ -493,7 +495,7 @@ QGCCacheWorker::_createTileSet(QGCMapTask *mtask)
         query.addBindValue(task->tileSet()->bottomRightLon());
         query.addBindValue(task->tileSet()->minZoom());
         query.addBindValue(task->tileSet()->maxZoom());
-        query.addBindValue(getQGCMapEngine()->urlFactory()->getQtMapIdFromProviderType(task->tileSet()->type()));
+        query.addBindValue(UrlFactory::getQtMapIdFromProviderType(task->tileSet()->type()));
         query.addBindValue(task->tileSet()->totalTileCount());
         query.addBindValue(QDateTime::currentDateTime().toSecsSinceEpoch());
         if(!query.exec()) {
@@ -512,14 +514,14 @@ QGCCacheWorker::_createTileSet(QGCMapTask *mtask)
                 for(int x = set.tileX0; x <= set.tileX1; x++) {
                     for(int y = set.tileY0; y <= set.tileY1; y++) {
                         //-- See if tile is already downloaded
-                        QString hash = getQGCMapEngine()->getTileHash(type, x, y, z);
+                        QString hash = QGCMapEngine::getTileHash(type, x, y, z);
                         quint64 tileID = _findTile(hash);
                         if(!tileID) {
                             //-- Set to download
                             query.prepare("INSERT OR IGNORE INTO TilesDownload(setID, hash, type, x, y, z, state) VALUES(?, ?, ?, ?, ? ,? ,?)");
                             query.addBindValue(setID);
                             query.addBindValue(hash);
-                            query.addBindValue(getQGCMapEngine()->urlFactory()->getQtMapIdFromProviderType(type));
+                            query.addBindValue(UrlFactory::getQtMapIdFromProviderType(type));
                             query.addBindValue(x);
                             query.addBindValue(y);
                             query.addBindValue(z);
@@ -567,7 +569,7 @@ QGCCacheWorker::_getTileDownloadList(QGCMapTask* mtask)
         while(query.next()) {
             QGCTile* tile = new QGCTile;
             tile->setHash(query.value("hash").toString());
-            tile->setType(getQGCMapEngine()->urlFactory()->getProviderTypeFromQtMapId(query.value("type").toInt()));
+            tile->setType(UrlFactory::getProviderTypeFromQtMapId(query.value("type").toInt()));
             tile->setX(query.value("x").toInt());
             tile->setY(query.value("y").toInt());
             tile->setZ(query.value("z").toInt());
@@ -932,7 +934,7 @@ QGCCacheWorker::_exportSets(QGCMapTask* mtask)
                 exportQuery.addBindValue(set->bottomRightLon());
                 exportQuery.addBindValue(set->minZoom());
                 exportQuery.addBindValue(set->maxZoom());
-                exportQuery.addBindValue(getQGCMapEngine()->urlFactory()->getQtMapIdFromProviderType(set->type()));
+                exportQuery.addBindValue(UrlFactory::getQtMapIdFromProviderType(set->type()));
                 exportQuery.addBindValue(set->totalTileCount());
                 exportQuery.addBindValue(set->defaultSet());
                 exportQuery.addBindValue(QDateTime::currentDateTime().toSecsSinceEpoch());

--- a/src/QtLocationPlugin/QGCTileCacheWorker.h
+++ b/src/QtLocationPlugin/QGCTileCacheWorker.h
@@ -36,7 +36,7 @@ class QGCCacheWorker : public QThread
 {
     Q_OBJECT
 public:
-    QGCCacheWorker  ();
+    QGCCacheWorker  (QObject* parent = nullptr);
     ~QGCCacheWorker ();
 
     void    quit            ();

--- a/src/QtLocationPlugin/QGeoMapReplyQGC.cpp
+++ b/src/QtLocationPlugin/QGeoMapReplyQGC.cpp
@@ -83,7 +83,7 @@ QGeoTiledMapReplyQGC::QGeoTiledMapReplyQGC(QNetworkAccessManager *networkManager
         setFinished(true);
         setCached(false);
     } else {
-        QGCFetchTileTask* task = getQGCMapEngine()->createFetchTileTask(getQGCMapEngine()->urlFactory()->getProviderTypeFromQtMapId(spec.mapId()), spec.x(), spec.y(), spec.zoom());
+        QGCFetchTileTask* task = QGCMapEngine::createFetchTileTask(UrlFactory::getProviderTypeFromQtMapId(spec.mapId()), spec.x(), spec.y(), spec.zoom());
         connect(task, &QGCFetchTileTask::tileFetched, this, &QGeoTiledMapReplyQGC::cacheReply);
         connect(task, &QGCMapTask::error, this, &QGeoTiledMapReplyQGC::cacheError);
         getQGCMapEngine()->addTask(task);
@@ -132,21 +132,20 @@ QGeoTiledMapReplyQGC::networkReplyFinished()
         return;
     }
     QByteArray a = _reply->readAll();
-    UrlFactory* urlFactory = getQGCMapEngine()->urlFactory();
-    QString format = urlFactory->getImageFormat(tileSpec().mapId(), a);
+    QString format = UrlFactory::getImageFormat(tileSpec().mapId(), a);
     //-- Test for a specialized, elevation data (not map tile)
-    if( getQGCMapEngine()->urlFactory()->isElevation(tileSpec().mapId())){
+    if( UrlFactory::isElevation(tileSpec().mapId())){
         a = TerrainTile::serializeFromAirMapJson(a);
         //-- Cache it if valid
         if(!a.isEmpty()) {
             getQGCMapEngine()->cacheTile(
-                getQGCMapEngine()->urlFactory()->getProviderTypeFromQtMapId(
+                UrlFactory::getProviderTypeFromQtMapId(
                     tileSpec().mapId()),
                 tileSpec().x(), tileSpec().y(), tileSpec().zoom(), a, format);
         }
         emit terrainDone(a, QNetworkReply::NoError);
     } else {
-        MapProvider* mapProvider = urlFactory->getMapProviderFromQtMapId(tileSpec().mapId());
+        const SharedMapProvider mapProvider = UrlFactory::getMapProviderFromQtMapId(tileSpec().mapId());
         if (mapProvider && mapProvider->isBingProvider() && a.size() && _bingNoTileImage.size() && a == _bingNoTileImage) {
             // Bing doesn't return an error if you request a tile above supported zoom level
             // It instead returns an image of a missing tile graphic. We need to detect that
@@ -158,7 +157,7 @@ QGeoTiledMapReplyQGC::networkReplyFinished()
             setMapImageData(a);
             if(!format.isEmpty()) {
                 setMapImageFormat(format);
-                getQGCMapEngine()->cacheTile(getQGCMapEngine()->urlFactory()->getProviderTypeFromQtMapId(tileSpec().mapId()), tileSpec().x(), tileSpec().y(), tileSpec().zoom(), a, format);
+                getQGCMapEngine()->cacheTile(UrlFactory::getProviderTypeFromQtMapId(tileSpec().mapId()), tileSpec().x(), tileSpec().y(), tileSpec().zoom(), a, format);
             }
         }
         setFinished(true);
@@ -175,7 +174,7 @@ QGeoTiledMapReplyQGC::networkReplyError(QNetworkReply::NetworkError error)
         return;
     }
     //-- Test for a specialized, elevation data (not map tile)
-    if( getQGCMapEngine()->urlFactory()->isElevation(tileSpec().mapId())){
+    if( UrlFactory::isElevation(tileSpec().mapId())){
         emit terrainDone(QByteArray(), error);
     } else {
         //-- Regular map tile
@@ -193,7 +192,7 @@ void
 QGeoTiledMapReplyQGC::cacheError(QGCMapTask::TaskType type, QString /*errorString*/)
 {
     if(!QGCDeviceInfo::isInternetAvailable()) {
-        if( getQGCMapEngine()->urlFactory()->isElevation(tileSpec().mapId())){
+        if( UrlFactory::isElevation(tileSpec().mapId())){
             emit terrainDone(QByteArray(), QNetworkReply::NetworkSessionFailedError);
         } else {
             setError(QGeoTiledMapReply::CommunicationError, "Network not available");
@@ -230,7 +229,7 @@ void
 QGeoTiledMapReplyQGC::cacheReply(QGCCacheTile* tile)
 {
     //-- Test for a specialized, elevation data (not map tile)
-    if( getQGCMapEngine()->urlFactory()->isElevation(tileSpec().mapId())){
+    if( UrlFactory::isElevation(tileSpec().mapId())){
         emit terrainDone(tile->img(), QNetworkReply::NoError);
     } else {
         //-- Regular map tile

--- a/src/QtLocationPlugin/QGeoTileFetcherQGC.cpp
+++ b/src/QtLocationPlugin/QGeoTileFetcherQGC.cpp
@@ -72,7 +72,7 @@ QGeoTiledMapReply*
 QGeoTileFetcherQGC::getTileImage(const QGeoTileSpec &spec)
 {
     //-- Build URL
-    QNetworkRequest request = getQGCMapEngine()->urlFactory()->getTileURL(spec.mapId(), spec.x(), spec.y(), spec.zoom());
+    QNetworkRequest request = UrlFactory::getTileURL(spec.mapId(), spec.x(), spec.y(), spec.zoom());
     if ( ! request.url().isEmpty() ) {
         return new QGeoTiledMapReplyQGC(_networkManager, request, spec);
     }

--- a/src/QtLocationPlugin/QGeoTiledMappingManagerEngineQGC.cpp
+++ b/src/QtLocationPlugin/QGeoTiledMappingManagerEngineQGC.cpp
@@ -79,21 +79,21 @@ QGeoTiledMappingManagerEngineQGC::QGeoTiledMappingManagerEngineQGC(const QVarian
 
     setTileSize(QSize(256, 256));
 
-    #define QGCGEOMAPTYPE(a,b,c,d,e,f)  QGeoMapType(a,b,c,d,e,f,QByteArray("QGroundControl"), cameraCaps)
-
-
-    // Qt Map Ids must start at 1 and are sequential.
-    int qtMapId = 1;
-    auto urlFactory = getQGCMapEngine()->urlFactory();
-    MapProvider* provider = urlFactory->getMapProviderFromQtMapId(qtMapId);
     QList<QGeoMapType> mapList;
-
-    while (provider) {
-        QString providerType = urlFactory->getProviderTypeFromQtMapId(qtMapId);
-        mapList.append(QGCGEOMAPTYPE(provider->getMapStyle(), providerType, providerType, false, false, qtMapId++));
-        provider = urlFactory->getMapProviderFromQtMapId(qtMapId);
+    const QList<SharedMapProvider> providers = UrlFactory::getProviders();
+    for (const SharedMapProvider &provider : providers) {
+        const QGeoMapType map = QGeoMapType(
+            provider->getMapStyle(),
+            provider->getMapName(),
+            provider->getMapName(),
+            false,
+            false,
+            provider->getMapId(),
+            QByteArrayLiteral("QGroundControl"),
+            cameraCapabilities()
+        );
+        (void) mapList.append(map);
     }
-
     setSupportedMapTypes(mapList);
 
     //-- Users (QML code) can define a different user agent
@@ -160,7 +160,7 @@ QGeoTiledMappingManagerEngineQGC::_setCache(const QVariantMap &parameters)
     if(!memLimit)
     {
         //-- Value saved in MB
-        memLimit = getQGCMapEngine()->getMaxMemCache() * (1024 * 1024);
+        memLimit = QGCMapEngine::getMaxMemCache() * (1024 * 1024);
     }
     //-- It won't work with less than 1M of memory cache
     if(memLimit < 1024 * 1024) {

--- a/src/QtLocationPlugin/QMLControl/QGCMapEngineManager.cc
+++ b/src/QtLocationPlugin/QMLControl/QGCMapEngineManager.cc
@@ -17,7 +17,7 @@
 
 #include "QGCMapEngineManager.h"
 #include "QGCMapTileSet.h"
-#include "QGCMapUrlEngine.h"
+#include "ElevationMapProvider.h"
 #include "QGCMapEngine.h"
 #include "QGCLoggingCategory.h"
 
@@ -30,7 +30,7 @@ QGC_LOGGING_CATEGORY(QGCMapEngineManagerLog, "QGCMapEngineManagerLog")
 
 static const char* kQmlOfflineMapKeyName = "QGCOfflineMap";
 
-static const auto kElevationMapType = UrlFactory::kCopernicusElevationProviderKey;
+static const auto kElevationMapType = CopernicusElevationProvider::kProviderKey;
 
 //-----------------------------------------------------------------------------
 QGCMapEngineManager::QGCMapEngineManager(QGCApplication* app, QGCToolbox* toolbox)
@@ -218,16 +218,16 @@ QGCMapEngineManager::loadSetting (const QString& key, const QString& defaultValu
 QStringList
 QGCMapEngineManager::mapList()
 {
-    return getQGCMapEngine()->getMapNameList();
+    return QGCMapEngine::getMapNameList();
 }
 //-----------------------------------------------------------------------------
 QStringList
 QGCMapEngineManager::mapProviderList()
 {
-    QStringList mapList = getQGCMapEngine()->getMapNameList();
+    QStringList mapList = QGCMapEngine::getMapNameList();
 
     // Don't return the Elevations provider. This is not selectable as a map provider by the user.
-    mapList.removeAll(UrlFactory::kCopernicusElevationProviderKey);
+    mapList.removeAll(kElevationMapType);
 
     // Extract Provider name from MapName ( format : "Provider Type")
     mapList.replaceInStrings(QRegularExpression("^([^\\ ]*) (.*)$"),"\\1");
@@ -241,7 +241,7 @@ QStringList
 QGCMapEngineManager::mapTypeList(QString provider)
 {
     // Extract type name from MapName ( format : "Provider Type")
-    QStringList mapList = getQGCMapEngine()->getMapNameList();
+    QStringList mapList = QGCMapEngine::getMapNameList();
     mapList = mapList.filter(QRegularExpression(provider));
     mapList.replaceInStrings(QRegularExpression("^([^\\ ]*) (.*)$"),"\\2");
     mapList.removeDuplicates();

--- a/src/Terrain/TerrainTileManager.cc
+++ b/src/Terrain/TerrainTileManager.cc
@@ -13,6 +13,7 @@
 #include "QGCMapEngine.h"
 #include "QGeoMapReplyQGC.h"
 #include "QGCMapUrlEngine.h"
+#include "ElevationMapProvider.h"
 #include "QGCLoggingCategory.h"
 
 #include <QtNetwork/QNetworkRequest>
@@ -21,7 +22,7 @@
 
 QGC_LOGGING_CATEGORY(TerrainTileManagerLog, "qgc.terrain.terraintilemanager")
 
-static const auto kMapType = UrlFactory::kCopernicusElevationProviderKey;
+static const QString kMapType = CopernicusElevationProvider::kProviderKey;
 
 Q_GLOBAL_STATIC(TerrainTileManager, s_terrainTileManager)
 
@@ -143,16 +144,16 @@ bool TerrainTileManager::getAltitudesForCoordinates(const QList<QGeoCoordinate>&
             altitudes.push_back(elevation);
         } else {
             if (_state != State::Downloading) {
-                QNetworkRequest request = getQGCMapEngine()->urlFactory()->getTileURL(
-                    kMapType, getQGCMapEngine()->urlFactory()->long2tileX(kMapType, coordinate.longitude(), 1),
-                    getQGCMapEngine()->urlFactory()->lat2tileY(kMapType, coordinate.latitude(), 1),
+                QNetworkRequest request = UrlFactory::getTileURL(
+                    kMapType, UrlFactory::long2tileX(kMapType, coordinate.longitude(), 1),
+                    UrlFactory::lat2tileY(kMapType, coordinate.latitude(), 1),
                     1);
                 qCDebug(TerrainTileManagerLog) << "TerrainTileManager::getAltitudesForCoordinates query from database" << request.url();
                 QGeoTileSpec spec;
-                spec.setX(getQGCMapEngine()->urlFactory()->long2tileX(kMapType, coordinate.longitude(), 1));
-                spec.setY(getQGCMapEngine()->urlFactory()->lat2tileY(kMapType, coordinate.latitude(), 1));
+                spec.setX(UrlFactory::long2tileX(kMapType, coordinate.longitude(), 1));
+                spec.setY(UrlFactory::lat2tileY(kMapType, coordinate.latitude(), 1));
                 spec.setZoom(1);
-                spec.setMapId(getQGCMapEngine()->urlFactory()->getQtMapIdFromProviderType(kMapType));
+                spec.setMapId(UrlFactory::getQtMapIdFromProviderType(kMapType));
                 QGeoTiledMapReplyQGC* reply = new QGeoTiledMapReplyQGC(&_networkManager, request, spec);
                 connect(reply, &QGeoTiledMapReplyQGC::terrainDone, this, &TerrainTileManager::_terrainDone);
                 _state = State::Downloading;
@@ -193,7 +194,7 @@ void TerrainTileManager::_terrainDone(QByteArray responseBytes, QNetworkReply::N
 
     // remove from download queue
     QGeoTileSpec spec = reply->tileSpec();
-    QString hash = getQGCMapEngine()->getTileHash(kMapType, spec.x(), spec.y(), spec.zoom());
+    QString hash = QGCMapEngine::getTileHash(kMapType, spec.x(), spec.y(), spec.zoom());
 
     // handle potential errors
     if (error != QNetworkReply::NoError) {
@@ -259,10 +260,10 @@ void TerrainTileManager::_terrainDone(QByteArray responseBytes, QNetworkReply::N
 
 QString TerrainTileManager::_getTileHash(const QGeoCoordinate& coordinate)
 {
-    QString ret = getQGCMapEngine()->getTileHash(
+    QString ret = QGCMapEngine::getTileHash(
         kMapType,
-        getQGCMapEngine()->urlFactory()->long2tileX(kMapType, coordinate.longitude(), 1),
-        getQGCMapEngine()->urlFactory()->lat2tileY(kMapType, coordinate.latitude(), 1),
+        UrlFactory::long2tileX(kMapType, coordinate.longitude(), 1),
+        UrlFactory::lat2tileY(kMapType, coordinate.latitude(), 1),
         1);
     qCDebug(TerrainQueryVerboseLog) << "Computing unique tile hash for " << coordinate << ret;
 

--- a/src/Viewer3D/Viewer3DTerrainTexture.cc
+++ b/src/Viewer3D/Viewer3DTerrainTexture.cc
@@ -70,7 +70,7 @@ void Viewer3DTerrainTexture::mapTypeChangedEvent(void)
     _mapType = _flightMapSettings->mapProvider()->rawValue().toString() + QString(" ");
     _mapType += _flightMapSettings->mapType()->rawValue().toString();
 
-    int mapId = getQGCMapEngine()->urlFactory()->getQtMapIdFromProviderType(_mapType);
+    int mapId = UrlFactory::getQtMapIdFromProviderType(_mapType);
 
     if(mapId == _mapId){
         return;

--- a/src/Viewer3D/Viewer3DTileReply.cc
+++ b/src/Viewer3D/Viewer3DTileReply.cc
@@ -47,7 +47,7 @@ Viewer3DTileReply::~Viewer3DTileReply()
 
 void Viewer3DTileReply::prepareDownload()
 {
-    QNetworkRequest request = getQGCMapEngine()->urlFactory()->getTileURL(_mapId, _tile.x, _tile.y, _tile.zoomLevel);
+    QNetworkRequest request = UrlFactory::getTileURL(_mapId, _tile.x, _tile.y, _tile.zoomLevel);
     _reply = _networkManager->get(request);
     connect(_reply, &QNetworkReply::finished, this, &Viewer3DTileReply::requestFinished);
     connect(_reply, &QNetworkReply::errorOccurred, this, &Viewer3DTileReply::requestError);
@@ -56,8 +56,7 @@ void Viewer3DTileReply::prepareDownload()
 void Viewer3DTileReply::requestFinished()
 {
     _tile.data = _reply->readAll();
-    UrlFactory* urlFactory = getQGCMapEngine()->urlFactory();
-    MapProvider* mapProvider = urlFactory->getMapProviderFromQtMapId(_tile.mapId);
+    const SharedMapProvider mapProvider = UrlFactory::getMapProviderFromQtMapId(_tile.mapId);
     // disconnect(_networkManager, &QNetworkAccessManager::finished, this, &Viewer3DTileReply::requestFinished);
     _timeoutTimer->stop();
     disconnect(_reply, &QNetworkReply::finished, this, &Viewer3DTileReply::requestFinished);


### PR DESCRIPTION
- Adds the provider name and map id to the MapProvider class and removes their QObject inheritance.
- Completely converts the UrlEngine to a static class.
- Re-adds the esri maps to the list as previously they never got added after entering the token despite the comment.