### PR TITLE
Rework + Fix for VirtualJoystick (#11589 & 11511)

### DIFF
--- a/src/FlightDisplay/FlyViewTopRightColumnLayout.qml
+++ b/src/FlightDisplay/FlyViewTopRightColumnLayout.qml
@@ -53,7 +53,7 @@ ColumnLayout {
     // to be null all over the place
     Loader {
         id:                 photoVideoControlLoader
-        Layout.alignment:   Qt.AlignVCenter | Qt.AlignRight
+        Layout.alignment:   Qt.AlignTop | Qt.AlignRight
         sourceComponent:    globals.activeVehicle && _showSingleVehicleUI ? photoVideoControlComponent : undefined
 
         property real rightEdgeCenterInset: visible ? parent.width - x : 0

--- a/src/FlightDisplay/FlyViewWidgetLayer.qml
+++ b/src/FlightDisplay/FlyViewWidgetLayer.qml
@@ -115,25 +115,32 @@ Item {
     Loader {
         id:                         virtualJoystickMultiTouch
         z:                          QGroundControl.zOrderTopMost + 1
-        width:                      parent.width  - (_pipView.width / 2)
+        anchors.right:              parent.right
+        anchors.rightMargin:        anchors.leftMargin
         height:                     Math.min(parent.height * 0.25, ScreenTools.defaultFontPixelWidth * 16)
         visible:                    _virtualJoystickEnabled && !QGroundControl.videoManager.fullScreen && !(_activeVehicle ? _activeVehicle.usingHighLatencyLink : false)
         anchors.bottom:             parent.bottom
-        anchors.bottomMargin:       parentToolInsets.leftEdgeBottomInset + ScreenTools.defaultFontPixelHeight * 2
-        anchors.horizontalCenter:   parent.horizontalCenter
+        anchors.bottomMargin:       bottomLoaderMargin
+        anchors.left:               parent.left   
+        anchors.leftMargin:         ( y > toolStrip.y + toolStrip.height ? toolStrip.width / 2 : toolStrip.width * 1.05 + toolStrip.x) 
         source:                     "qrc:/qml/VirtualJoystick.qml"
         active:                     _virtualJoystickEnabled && !(_activeVehicle ? _activeVehicle.usingHighLatencyLink : false)
 
-        property bool autoCenterThrottle: QGroundControl.settingsManager.appSettings.virtualJoystickAutoCenterThrottle.rawValue
-
+        property real bottomEdgeLeftInset:     parent.height-y
+        property bool autoCenterThrottle:      QGroundControl.settingsManager.appSettings.virtualJoystickAutoCenterThrottle.rawValue
         property bool _virtualJoystickEnabled: QGroundControl.settingsManager.appSettings.virtualJoystick.rawValue
+        property real bottomEdgeRightInset:    parent.height-y
+        property var  _pipViewMargin:          _pipView.visible ? parentToolInsets.bottomEdgeLeftInset + ScreenTools.defaultFontPixelHeight * 2 : 
+                                               bottomRightRowLayout.height + ScreenTools.defaultFontPixelHeight * 1.5
 
-        property real bottomEdgeLeftInset: parent.height-y
-        property real bottomEdgeRightInset: parent.height-y
+        property var  bottomLoaderMargin:      _pipViewMargin >= parent.height / 2 ? parent.height / 2 : _pipViewMargin
 
         // Width is difficult to access directly hence this hack which may not work in all circumstances
-        property real leftEdgeBottomInset: visible ? bottomEdgeLeftInset + width/18 - ScreenTools.defaultFontPixelHeight*2 : 0
+        property real leftEdgeBottomInset:  visible ? bottomEdgeLeftInset + width/18 - ScreenTools.defaultFontPixelHeight*2 : 0
         property real rightEdgeBottomInset: visible ? bottomEdgeRightInset + width/18 - ScreenTools.defaultFontPixelHeight*2 : 0
+
+        //Loader status logic
+        onLoaded:           virtualJoystickMultiTouch.visible ?  virtualJoystickMultiTouch.item.calibration = true : virtualJoystickMultiTouch.item.calibration = false
     }
 
     FlyViewToolStrip {

--- a/src/FlightDisplay/VirtualJoystick.qml
+++ b/src/FlightDisplay/VirtualJoystick.qml
@@ -20,16 +20,47 @@ Item {
     // The following properties must be passed in from the Loader
     // property bool autoCenterThrottle - true: throttle will snap back to center when released
 
-    property var _activeVehicle: QGroundControl.multiVehicleManager.activeVehicle
+    id: virtualJoysticks
 
+    property var   _activeVehicle:            QGroundControl.multiVehicleManager.activeVehicle
+    property bool  _initialConnectComplete:   _activeVehicle ? _activeVehicle.initialConnectComplete : false
+    property real  leftYAxisValue:            autoCenterThrottle ? height / 2 : height
+    property var   calibration:               false
+        
     Timer {
         interval:   40  // 25Hz, same as real joystick rate
-        running:    QGroundControl.settingsManager.appSettings.virtualJoystick.value && _activeVehicle
+        running:    QGroundControl.settingsManager.appSettings.virtualJoystick.value
         repeat:     true
         onTriggered: {
-            if (_activeVehicle) {
+            if (_activeVehicle && _initialConnectComplete) {
                 _activeVehicle.virtualTabletJoystickValue(rightStick.xAxis, rightStick.yAxis, leftStick.xAxis, leftStick.yAxis)
             }
+            leftYAxisValue = leftStick.yAxis // We keep Y axis value from the throttle stick for using it while there is a resize
+        }
+    }
+
+    onHeightChanged:        { keepYAxisWhileChanged() }
+    onWidthChanged:         { keepXAxisWhileChanged() }
+    onCalibrationChanged:   { calibration ? calibrateJoysticks() : undefined }
+
+    function calibrateJoysticks() {
+        if( virtualJoysticks.visible ) {
+        keepXAxisWhileChanged()
+        leftYAxisValue = leftStick.yAxisReCentered() // Keep track of the correct leftYAxisValue while the width is adjusted at first start up
+        }
+    }
+
+    function keepYAxisWhileChanged () {
+        if( virtualJoysticks.visible ) {
+            leftStick.resize( leftYAxisValue )
+            rightStick.reCenter()
+        }
+    }
+
+    function keepXAxisWhileChanged () {
+        if( virtualJoysticks.visible ) {
+            leftStick.reCenter()
+            rightStick.reCenter()
         }
     }
 
@@ -53,5 +84,6 @@ Item {
         anchors.bottom:         parent.bottom
         width:                  parent.height
         height:                 parent.height
+        yAxisReCenter:          true
     }
 }


### PR DESCRIPTION
Closes #11589
Closes #11511

This commit solves two issues (#11589 & 11511) that were related. At startup, the VirtualJoystick show random axis values (#11589). Additionally, resizing the screen caused the joystick to malfunction, potentially leading to dangerous behavior (#11511). Now, the values remain stable during a resize, and at startup, the joystick initializes at the middle or bottom, depending on the selected settings. Also added logic for ReCenter settings changed during flight which could make something similar as issue (#11589) (if ReCenter is deselected while Joysticks are enabled the starting value will be the center position but without auto centering, instead if auto-center is deselected while Joystick aren't enable the starting position will be at bottom).


https://github.com/mavlink/qgroundcontrol/assets/47715559/dd9b7318-ccd7-4125-81dd-014685993e5f

https://github.com/mavlink/qgroundcontrol/assets/47715559/38be004a-880b-4a14-bf3b-23178e347d76



