### PR TITLE
[Docs] Remove gitter/slack links. Add top bar quick download links

### DIFF
--- a/docs/.vitepress/config.mjs
+++ b/docs/.vitepress/config.mjs
@@ -87,6 +87,16 @@ export default defineConfig({
             ariaLabel: "QGC website link",
           },
           {
+            text: "Download QGC (stable)",
+            link: "https://docs.qgroundcontrol.com/master/en/qgc-user-guide/getting_started/download_and_install.html",
+            ariaLabel: "Download stable QGC",
+          },
+          {
+            text: "Download QGC (daily build)",
+            link: "https://docs.qgroundcontrol.com/master/en/qgc-user-guide/releases/daily_builds.html",
+            ariaLabel: "Download stable QGC",
+          },
+          {
             text: "Source Code",
             link: "https://github.com/mavlink/qgroundcontrol",
           },
@@ -139,7 +149,7 @@ export default defineConfig({
       },
       {
         text: "Support",
-        link: "https://docs.qgroundcontrol.com/master/en/support/support.html",
+        link: "https://docs.qgroundcontrol.com/master/en/qgc-user-guide/support/support.html",
       },
       {
         text: "Version",

--- a/docs/en/qgc-user-guide/index.md
+++ b/docs/en/qgc-user-guide/index.md
@@ -1,6 +1,6 @@
 # QGroundControl User Guide
 
-[![Releases](https://img.shields.io/github/release/mavlink/QGroundControl.svg)](https://github.com/mavlink/QGroundControl/releases) [![Discuss](https://img.shields.io/badge/discuss-px4-ff69b4.svg)](http://discuss.px4.io/c/qgroundcontrol/qgroundcontrol-usage) [![Discuss](https://img.shields.io/badge/discuss-ardupilot-ff69b4.svg)](http://discuss.ardupilot.org/c/ground-control-software/qgroundcontrol) [![Gitter](https://badges.gitter.im/Join%20Chat.svg)](https://gitter.im/mavlink/qgroundcontrol?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge&utm_content=badge) [![Slack](../../assets/site/slack.svg)](https://join.slack.com/t/px4/shared_invite/zt-si4xo5qs-R4baYFmMjlrT4rQK5yUnaA)
+[![Releases](https://img.shields.io/github/release/mavlink/QGroundControl.svg)](https://github.com/mavlink/QGroundControl/releases) [![Discuss](https://img.shields.io/badge/discuss-px4-ff69b4.svg)](http://discuss.px4.io/c/qgroundcontrol/qgroundcontrol-usage) [![Discuss](https://img.shields.io/badge/discuss-ardupilot-ff69b4.svg)](http://discuss.ardupilot.org/c/ground-control-software/qgroundcontrol)
 
 _QGroundControl_ provides full flight control and vehicle setup for PX4 or ArduPilot powered vehicles.
 It provides easy and straightforward usage for beginners, while still delivering high end feature support for experienced users.


### PR DESCRIPTION
I've removed the gitter and slack links, which I believe to be defunct.

This also fixes a broken link to support in the top toolbar, and adds links to the download pages in that top bar.



Checklist:
----------

- [x] [Review Contribution Guidelines](https://github.com/mavlink/qgroundcontrol/blob/master/.github/CONTRIBUTING.md).
- [x] [Review Code of Conduct](https://github.com/mavlink/qgroundcontrol/blob/master/.github/CODE_OF_CONDUCT.md).
- [x] I have tested my changes.

