### PR TITLE
add flatpak as a way to install qgc on linux

### DIFF
--- a/docs/en/qgc-user-guide/getting_started/download_and_install.md
+++ b/docs/en/qgc-user-guide/getting_started/download_and_install.md
@@ -49,6 +49,11 @@ QGroundControl continues to not be signed which causes problem on Catalina. To o
 - Right-click the QGC app icon again, Open from the menu. This time you will be presented with the option to Open.
   :::
 
+## Linux Mint, Debian,  {#flatpak}
+
+_QGroundControl_ can be installed/run on linux distributions via [flatpak](https://flathub.org/apps/org.mavlink.qgroundcontrol)
+ (Mint Linux, Debian, Fedora, Suse, etc...)
+
 ## Ubuntu Linux {#ubuntu}
 
 _QGroundControl_ can be installed/run on Ubuntu LTS 20.04 (and later).

--- a/docs/en/qgc-user-guide/getting_started/download_and_install.md
+++ b/docs/en/qgc-user-guide/getting_started/download_and_install.md
@@ -49,7 +49,7 @@ QGroundControl continues to not be signed which causes problem on Catalina. To o
 - Right-click the QGC app icon again, Open from the menu. This time you will be presented with the option to Open.
   :::
 
-## Flatpak  {#flatpak}
+## Flatpak {#flatpak}
 
 _QGroundControl_ can be installed/run on linux distributions via [flatpak](https://flathub.org/apps/org.mavlink.qgroundcontrol)
  (Mint Linux, Debian, Ubuntu, Fedora, Suse, etc...)

--- a/docs/en/qgc-user-guide/getting_started/download_and_install.md
+++ b/docs/en/qgc-user-guide/getting_started/download_and_install.md
@@ -49,10 +49,10 @@ QGroundControl continues to not be signed which causes problem on Catalina. To o
 - Right-click the QGC app icon again, Open from the menu. This time you will be presented with the option to Open.
   :::
 
-## Linux Mint, Debian,  {#flatpak}
+## Flatpak  {#flatpak}
 
 _QGroundControl_ can be installed/run on linux distributions via [flatpak](https://flathub.org/apps/org.mavlink.qgroundcontrol)
- (Mint Linux, Debian, Fedora, Suse, etc...)
+ (Mint Linux, Debian, Ubuntu, Fedora, Suse, etc...)
 
 ## Ubuntu Linux {#ubuntu}
 

--- a/docs/tr/qgc-user-guide/getting_started/download_and_install.md
+++ b/docs/tr/qgc-user-guide/getting_started/download_and_install.md
@@ -50,6 +50,11 @@ QGroundControl continues to not be signed which causes problem on Catalina. To o
 - QGC uygulama ikonuna tekrar sağ tıklayın, menüden Aç'ı seçin. Bu sefer Aç seçeneği de size sunulacaktır.
   :::
 
+## Flatpak {#flatpak}
+
+_QGroundControl_ can be installed/run on linux distributions via [flatpak](https://flathub.org/apps/org.mavlink.qgroundcontrol)
+ (Mint Linux, Debian, Ubuntu, Fedora, Suse, etc...)
+
 ## Ubuntu Linux {#ubuntu}
 
 _QGroundControl_ can be installed/run on Ubuntu LTS 20.04 (and later).

--- a/docs/zh/qgc-user-guide/getting_started/download_and_install.md
+++ b/docs/zh/qgc-user-guide/getting_started/download_and_install.md
@@ -50,6 +50,11 @@ QGroundControl continues to not be signed which causes problem on Catalina. To o
 - 再次右键点击QGC 应用图标，从菜单中选择Open。 这次您会发现有 Open的选项了。 This time you will be presented with the option to Open.
   :::
 
+## Flatpak {#flatpak}
+
+_QGroundControl_ can be installed/run on linux distributions via [flatpak](https://flathub.org/apps/org.mavlink.qgroundcontrol)
+ (Mint Linux, Debian, Ubuntu, Fedora, Suse, etc...)
+
 ## Ubuntu Linux 系统 {#ubuntu}
 
 _QGroundControl_ can be installed/run on Ubuntu LTS 20.04 (and later).


### PR DESCRIPTION
add flatpak as a way to install qgc on linux

Description
-----------
qgc is available on flatpak

Test Steps
-----------

Checklist:
----------
- [x] [Review Contribution Guidelines](https://github.com/mavlink/qgroundcontrol/blob/master/.github/CONTRIBUTING.md).
- [x] [Review Code of Conduct](https://github.com/mavlink/qgroundcontrol/blob/master/.github/CODE_OF_CONDUCT.md).
- [x] I have tested my changes.

Related Issue
-----------
ubuntu is not the only distribution where qgc works


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.