### PR TITLE
QtLocationPlugin: change mapengine lifespan

### DIFF
--- a/src/QtLocationPlugin/QGCMapEngine.cpp
+++ b/src/QtLocationPlugin/QGCMapEngine.cpp
@@ -25,7 +25,6 @@
 
 #include <QtCore/QStandardPaths>
 #include <QtCore/QDir>
-#include <QtCore/qapplicationstatic.h>
 
 Q_DECLARE_METATYPE(QGCMapTask::TaskType)
 Q_DECLARE_METATYPE(QGCTile)
@@ -43,7 +42,7 @@ struct stQGeoTileCacheQGCMapTypes {
 
 //-----------------------------------------------------------------------------
 
-Q_APPLICATION_STATIC(QGCMapEngine, s_mapEngine);
+Q_GLOBAL_STATIC(QGCMapEngine, s_mapEngine);
 
 QGCMapEngine* QGCMapEngine::instance()
 {


### PR DESCRIPTION
Probably this will temporarily fix the test cleanup issue, but it isn't a good permanent solution. The tests should be adjusted instead or mapengine needs to be entirely independent of the qapplication instance. I will come up with a better solution further along in the QtLocationPlugin modifications.