### PR TITLE
Joystick: fix typo in _maxAxisFrequencyHz

### DIFF
--- a/src/Joystick/Joystick.h
+++ b/src/Joystick/Joystick.h
@@ -106,7 +106,7 @@ public:
     Q_PROPERTY(int      throttleMode            READ throttleMode           WRITE setThrottleMode       NOTIFY throttleModeChanged)
     Q_PROPERTY(float    axisFrequencyHz         READ axisFrequencyHz        WRITE setAxisFrequency      NOTIFY axisFrequencyHzChanged)
     Q_PROPERTY(float    minAxisFrequencyHz      MEMBER _minAxisFrequencyHz                              CONSTANT)
-    Q_PROPERTY(float    maxAxisFrequencyHz      MEMBER _minAxisFrequencyHz                              CONSTANT)
+    Q_PROPERTY(float    maxAxisFrequencyHz      MEMBER _maxAxisFrequencyHz                              CONSTANT)
     Q_PROPERTY(float    buttonFrequencyHz       READ buttonFrequencyHz      WRITE setButtonFrequency    NOTIFY buttonFrequencyHzChanged)
     Q_PROPERTY(float    minButtonFrequencyHz    MEMBER _minButtonFrequencyHz                            CONSTANT)
     Q_PROPERTY(float    maxButtonFrequencyHz    MEMBER _maxButtonFrequencyHz                            CONSTANT)


### PR DESCRIPTION
<!--- Title -->

Description
-----------
Fix a trivial typo that prevents changing the joystick axis polling frequency.

Test Steps
-----------
<!-- Describe the steps to reproduce. -->

Checklist:
----------
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [X] [Review Contribution Guidelines](https://github.com/mavlink/qgroundcontrol/blob/master/.github/CONTRIBUTING.md).
- [X] [Review Code of Conduct](https://github.com/mavlink/qgroundcontrol/blob/master/.github/CODE_OF_CONDUCT.md).
- [X] I have tested my changes.

Related Issue
-----------
Fixes #11359


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.