### PR TITLE
CI: Remove Qt Tools Downloads

### DIFF
--- a/.github/workflows/android-macos.yml
+++ b/.github/workflows/android-macos.yml
@@ -65,7 +65,6 @@ jobs:
           dir: ${{ runner.temp }}
           modules: qtcharts qtlocation qtpositioning qtspeech qt5compat qtmultimedia qtserialport qtimageformats qtshadertools qtconnectivity qtquick3d qtsensors
           cache: ${{ github.ref == 'refs/heads/master' && github.event_name != 'pull_request' }}
-          tools: 'tools_cmake'
 
       - name: Install Qt6 for Android (armv7)
         uses: ./install-qt-action/action/

--- a/.github/workflows/android-windows.yml
+++ b/.github/workflows/android-windows.yml
@@ -66,7 +66,6 @@ jobs:
           dir: ${{ runner.temp }}
           modules: qtcharts qtlocation qtpositioning qtspeech qt5compat qtmultimedia qtserialport qtimageformats qtshadertools qtconnectivity qtquick3d qtsensors
           cache: ${{ github.ref == 'refs/heads/master' && github.event_name != 'pull_request' }}
-          tools: 'tools_cmake'
 
       - name: Install Qt6 for Android (armv7)
         uses: ./install-qt-action/action/

--- a/.github/workflows/android.yml
+++ b/.github/workflows/android.yml
@@ -108,7 +108,6 @@ jobs:
           dir: ${{ runner.temp }}
           modules: qtcharts qtlocation qtpositioning qtspeech qt5compat qtmultimedia qtserialport qtimageformats qtshadertools qtconnectivity qtquick3d qtsensors
           cache: ${{ github.ref == 'refs/heads/master' && github.event_name != 'pull_request' }}
-          tools: 'tools_cmake'
 
       - name: Install Qt6 for Android (armv7)
         uses: ./install-qt-action/action/

--- a/.github/workflows/ios.yml
+++ b/.github/workflows/ios.yml
@@ -55,7 +55,6 @@ jobs:
           dir: ${{ runner.temp }}
           modules: qtcharts qtlocation qtpositioning qtspeech qt5compat qtmultimedia qtserialport qtimageformats qtshadertools qtconnectivity qtquick3d qtsensors
           cache: ${{ github.ref == 'refs/heads/master' && github.event_name != 'pull_request' }}
-          tools: 'tools_cmake'
 
       - name: Install Qt6 for iOS
         uses: ./install-qt-action/action/

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -98,7 +98,6 @@ jobs:
           modules: qtcharts qtlocation qtpositioning qtspeech qt5compat qtmultimedia qtserialport qtimageformats qtshadertools qtconnectivity qtquick3d qtsensors
           setup-python: true
           cache: ${{ github.ref == 'refs/heads/master' && github.event_name != 'pull_request' }}
-          tools: 'tools_cmake'
 
     # - name: Build GStreamer
     #   uses: ./.github/actions/gstreamer

--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -81,7 +81,6 @@ jobs:
           modules: qtcharts qtlocation qtpositioning qtspeech qt5compat qtmultimedia qtserialport qtimageformats qtshadertools qtconnectivity qtquick3d qtsensors
           setup-python: true
           cache: ${{ github.ref == 'refs/heads/master' && github.event_name != 'pull_request' }}
-          tools: 'tools_cmake'
 
       - name: Create build directory
         run:  mkdir ${{ runner.temp }}/shadow_build_dir

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -88,7 +88,6 @@ jobs:
           modules: qtcharts qtlocation qtpositioning qtspeech qt5compat qtmultimedia qtserialport qtimageformats qtshadertools qtconnectivity qtquick3d qtsensors
           setup-python: true
           cache: ${{ github.ref == 'refs/heads/master' && github.event_name != 'pull_request' }}
-          tools: 'tools_cmake'
 
       - name: Set up Visual Studio shell
         uses: ilammy/msvc-dev-cmd@v1


### PR DESCRIPTION
Seems like Qt Tools downloads are the most unreliable part, better to just use native installs I guess