### PR TITLE
Update FirmwareUpgradeController.cc

### DIFF
--- a/src/VehicleSetup/FirmwareUpgradeController.cc
+++ b/src/VehicleSetup/FirmwareUpgradeController.cc
@@ -99,7 +99,8 @@ static QMap<int, QString> px4_board_name_map {
     {1048, "holybro_kakuteh7_default"},
     {1053, "holybro_kakuteh7v2_default"},
     {1054, "holybro_kakuteh7mini_default"},
-    {1110, "jfb_jfb110_default"},    
+    {1110, "jfb_jfb110_default"},
+    {1123, "siyi_n7_default"},    
 };
 
 uint qHash(const FirmwareUpgradeController::FirmwareIdentifier& firmwareId)


### PR DESCRIPTION
Title:
Add QGC Support for Online PX4 Firmware Upgrade for New Flight Controller

Description:
I have added support for the model 'siyi_n7' flight controller board in the src/VehicleSetup/FirmwareUpgradeController.cc file.

Greetings! I am a member of the development team at Siyi Technology. I am currently seeking to contribute to the online upgrade support for the Siyi N7 flight controller's PX4 firmware. My colleague has communicated with your team via Discord. I appreciate your attention to this commit,thanks!

