### PR TITLE
Reset mav command timer on MAV_RESULT_IN_PROGRESS

### DIFF
--- a/src/Vehicle/Vehicle.cc
+++ b/src/Vehicle/Vehicle.cc
@@ -3161,11 +3161,12 @@ void Vehicle::_handleCommandAck(mavlink_message_t& message)
                 // HacK to support PX4 autotune which does not send final result ack and just sends in progress
                 commandEntry = _mavCommandList.takeAt(entryIndex);
             } else {
-                commandEntry = _mavCommandList.at(entryIndex);  // Command has not completed yet, don't remove
+                // Command has not completed yet, don't remove
+                MavCommandListEntry_t& commandEntryRef = _mavCommandList[entryIndex];
+                commandEntryRef.maxTries = 1;         // Vehicle responsed to command so don't retry
+                commandEntryRef.elapsedTimer.start(); // We've heard from vehicle, restart elapsed timer for no ack received timeout
+                commandEntry = commandEntryRef;
             }
-
-            commandEntry.maxTries = 1;              // Vehicle responsed to command so don't retry
-            commandEntry.elapsedTimer.restart();    // We've heard from vehicle, restart elapsed timer for no ack received timeout
 
             if (commandEntry.ackHandlerInfo.progressHandler) {
                 (*commandEntry.ackHandlerInfo.progressHandler)(commandEntry.ackHandlerInfo.progressHandlerData, message.compid, ack);


### PR DESCRIPTION
<!--- Title -->

Description
-----------
Correctly reset the elapsedTimer in the _mavCommandList instead of resetting a temporary copy.

Test Steps
-----------
1. Run any long-running command that sends periodic progress updates.
2. QGC drops the command after 3 seconds anyway.

Checklist:
----------
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] [Review Contribution Guidelines](https://github.com/mavlink/qgroundcontrol/blob/master/.github/CONTRIBUTING.md).
- [x] [Review Code of Conduct](https://github.com/mavlink/qgroundcontrol/blob/master/.github/CODE_OF_CONDUCT.md).
- [x] I have tested my changes.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.