### PR TITLE
QtLocationPlugin: Move functions out of QGCMapEngine

### DIFF
--- a/src/AnalyzeView/CMakeLists.txt
+++ b/src/AnalyzeView/CMakeLists.txt
@@ -38,7 +38,6 @@ target_link_libraries(AnalyzeView
         Qt6::Qml
         FactSystem
         QGC
-        QGCLocation
         Settings
         Utilities
         Vehicle

--- a/src/AnalyzeView/LogDownloadController.cc
+++ b/src/AnalyzeView/LogDownloadController.cc
@@ -11,7 +11,6 @@
 #include "MultiVehicleManager.h"
 #include "QGCApplication.h"
 #include "QGCToolbox.h"
-#include "QGCMapEngine.h"
 #include "ParameterManager.h"
 #include "FactSystem.h"
 #include "Vehicle.h"
@@ -224,8 +223,8 @@ void LogDownloadController::_updateDataRate(void)
         _downloadData->rate_bytes = 0;
 
         //-- Update status
-        const QString status = QString("%1 (%2/s)").arg(QGCMapEngine::bigSizeToString(_downloadData->written),
-                                                        QGCMapEngine::bigSizeToString(_downloadData->rate_avg));
+        const QString status = QString("%1 (%2/s)").arg(qgcApp()->bigSizeToString(_downloadData->written),
+                                                        qgcApp()->bigSizeToString(_downloadData->rate_avg));
 
         _downloadData->entry->setStatus(status);
         _downloadData->elapsed.start();

--- a/src/AnalyzeView/LogEntry.cc
+++ b/src/AnalyzeView/LogEntry.cc
@@ -8,7 +8,7 @@
  ****************************************************************************/
 
 #include "LogEntry.h"
-#include "QGCMapEngine.h"
+#include "QGCApplication.h"
 #include "MAVLinkLib.h"
 #include "QGCLoggingCategory.h"
 
@@ -69,5 +69,5 @@ QGCLogEntry::QGCLogEntry(uint logId, const QDateTime& dateTime, uint logSize, bo
 //----------------------------------------------------------------------------------------
 QString QGCLogEntry::sizeStr() const
 {
-    return QGCMapEngine::bigSizeToString(_logSize);
+    return qgcApp()->bigSizeToString(_logSize);
 }

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -83,6 +83,7 @@ target_link_libraries(QGC
         MissionManager
         # PlanView
         PositionManager
+        QGCLocation
         QmlControls
         Settings
         Terrain
@@ -98,7 +99,6 @@ target_link_libraries(QGC
         Qt6::Core
         Qt6::CorePrivate
         Qt6::Widgets
-        QGCLocation
 )
 
 if(QGC_CUSTOM_BUILD)

--- a/src/Camera/CMakeLists.txt
+++ b/src/Camera/CMakeLists.txt
@@ -23,7 +23,6 @@ target_link_libraries(Camera
         Comms
         FirmwarePlugin
         Joystick
-        QGCLocation
         Settings
         Vehicle
         VideoManager

--- a/src/Camera/VehicleCameraControl.cc
+++ b/src/Camera/VehicleCameraControl.cc
@@ -10,7 +10,6 @@
 #include "QGCApplication.h"
 #include "SettingsManager.h"
 #include "VideoManager.h"
-#include "QGCMapEngine.h"
 #include "QGCCameraManager.h"
 #include "FTPManager.h"
 #include "QGCLZMA.h"
@@ -222,7 +221,7 @@ VehicleCameraControl::photoCaptureStatus()
 QString
 VehicleCameraControl::storageFreeStr()
 {
-    return QGCMapEngine::storageFreeSizeToString(static_cast<quint64>(_storageFree));
+    return qgcApp()->bigSizeMBToString(static_cast<quint64>(_storageFree));
 }
 
 //-----------------------------------------------------------------------------
@@ -230,7 +229,7 @@ QString
 VehicleCameraControl::batteryRemainingStr()
 {
     if(_batteryRemaining >= 0) {
-        return QGCMapEngine::numberToString(static_cast<quint64>(_batteryRemaining)) + " %";
+        return qgcApp()->numberToString(static_cast<quint64>(_batteryRemaining)) + " %";
     }
     return "";
 }

--- a/src/QGCApplication.cc
+++ b/src/QGCApplication.cc
@@ -889,3 +889,40 @@ void QGCApplication::shutdown()
     // This is bad, but currently qobject inheritances are incorrect and cause crashes on exit without
     delete _qmlAppEngine;
 }
+
+QString QGCApplication::numberToString(quint64 number)
+{
+    return getCurrentLanguage().toString(number);
+}
+
+QString QGCApplication::bigSizeToString(quint64 size)
+{
+    QString result;
+    const QLocale kLocale = getCurrentLanguage();
+    if (size < 1024) {
+        result = kLocale.toString(size);
+    } else if (size < pow(1024, 2)) {
+        result = kLocale.toString(static_cast<double>(size) / 1024.0, 'f', 1) + "kB";
+    } else if (size < pow(1024, 3)) {
+        result = kLocale.toString(static_cast<double>(size) / pow(1024, 2), 'f', 1) + "MB";
+    } else if (size < pow(1024, 4)) {
+        result = kLocale.toString(static_cast<double>(size) / pow(1024, 3), 'f', 1) + "GB";
+    } else {
+        result = kLocale.toString(static_cast<double>(size) / pow(1024, 4), 'f', 1) + "TB";
+    }
+    return result;
+}
+
+QString QGCApplication::bigSizeMBToString(quint64 size_MB)
+{
+    QString result;
+    const QLocale kLocale = getCurrentLanguage();
+    if (size_MB < 1024) {
+        result = kLocale.toString(static_cast<double>(size_MB) , 'f', 0) + " MB";
+    } else if(size_MB < pow(1024, 2)) {
+        result = kLocale.toString(static_cast<double>(size_MB) / 1024.0, 'f', 1) + " GB";
+    } else {
+        result = kLocale.toString(static_cast<double>(size_MB) / pow(1024, 2), 'f', 2) + " TB";
+    }
+    return result;
+}

--- a/src/QGCApplication.h
+++ b/src/QGCApplication.h
@@ -88,6 +88,9 @@ public:
     void            setLanguage();
     QQuickWindow*   mainRootWindow();
     uint64_t        msecsSinceBoot(void) { return _msecsElapsedTime.elapsed(); }
+    QString         numberToString(quint64 number);
+    QString         bigSizeToString(quint64 size);
+    QString         bigSizeMBToString(quint64 size_MB);
 
     /// Registers the signal such that only the last duplicate signal added is left in the queue.
     void addCompressedSignal(const QMetaMethod & method);

--- a/src/QtLocationPlugin/CMakeLists.txt
+++ b/src/QtLocationPlugin/CMakeLists.txt
@@ -35,6 +35,8 @@ qt_add_plugin(QGCLocation STATIC
     QGeoServiceProviderPluginQGC.h
     QGeoTiledMappingManagerEngineQGC.cpp
     QGeoTiledMappingManagerEngineQGC.h
+    QGeoTiledMapQGC.cpp
+    QGeoTiledMapQGC.h
     QGeoTileFetcherQGC.cpp
     QGeoTileFetcherQGC.h
     QMLControl/QGCMapEngineManager.cc

--- a/src/QtLocationPlugin/QGCLocationPlugin.pri
+++ b/src/QtLocationPlugin/QGCLocationPlugin.pri
@@ -21,6 +21,7 @@ HEADERS += \
     $$PWD/QGeoServiceProviderPluginQGC.h \
     $$PWD/QGeoTileFetcherQGC.h \
     $$PWD/QGeoTiledMappingManagerEngineQGC.h \
+    $$PWD/QGeoTiledMapQGC.h \
     $$PWD/MapProvider.h \
     $$PWD/ElevationMapProvider.h \
     $$PWD/GoogleMapProvider.h \
@@ -40,6 +41,7 @@ SOURCES += \
     $$PWD/QGeoServiceProviderPluginQGC.cpp \
     $$PWD/QGeoTileFetcherQGC.cpp \
     $$PWD/QGeoTiledMappingManagerEngineQGC.cpp \
+    $$PWD/QGeoTiledMapQGC.cpp \
     $$PWD/MapProvider.cpp \
     $$PWD/ElevationMapProvider.cpp \
     $$PWD/GoogleMapProvider.cpp \

--- a/src/QtLocationPlugin/QGCMapEngine.cpp
+++ b/src/QtLocationPlugin/QGCMapEngine.cpp
@@ -59,27 +59,11 @@ QGCMapEngine* getQGCMapEngine()
 QGCMapEngine::QGCMapEngine(QObject* parent)
     : QObject(parent)
     , _worker(new QGCCacheWorker(this))
-#ifdef WE_ARE_KOSHER
-    //-- TODO: Get proper version
-    #if defined Q_OS_MAC
-        , _userAgent("QGroundControl (Macintosh; Intel Mac OS X 10_9_3) AppleWebKit/537.75.14 (KHTML, like Gecko) Version/2.9.0")
-    #elif defined Q_OS_WIN32
-        , _userAgent("QGroundControl (Windows; Windows NT 6.0) (KHTML, like Gecko) Version/2.9.0")
-    #else
-        , _userAgent("QGroundControl (X11; Ubuntu; Linux x86_64) (KHTML, like Gecko) Version/2.9.0")
-    #endif
-#else
-    #if defined Q_OS_MAC
-        , _userAgent("Mozilla/5.0 (Macintosh; Intel Mac OS X 10.6; rv:25.0) Gecko/20100101 Firefox/25.0")
-    #elif defined Q_OS_WIN32
-        , _userAgent("Mozilla/5.0 (Windows NT 6.1; WOW64; rv:31.0) Gecko/20130401 Firefox/31.0")
-    #else
-        , _userAgent("Mozilla/5.0 (X11; Linux i586; rv:31.0) Gecko/20100101 Firefox/31.0")
-    #endif
-#endif
     , _prunning(false)
     , _cacheWasReset(false)
 {
+    // qCDebug(QGeoTiledMappingManagerEngineQGCLog) << Q_FUNC_INFO << this;
+
     qRegisterMetaType<QGCMapTask::TaskType>();
     qRegisterMetaType<QGCTile>();
     qRegisterMetaType<QList<QGCTile*>>();
@@ -92,6 +76,8 @@ QGCMapEngine::~QGCMapEngine()
     (void) disconnect(_worker);
     _worker->quit();
     _worker->wait();
+
+    // qCDebug(QGeoTiledMappingManagerEngineQGCLog) << Q_FUNC_INFO << this;
 }
 
 //-----------------------------------------------------------------------------
@@ -263,41 +249,6 @@ QGCMapEngine::getMaxMemCache()
 }
 
 //-----------------------------------------------------------------------------
-QString
-QGCMapEngine::bigSizeToString(quint64 size)
-{
-    if(size < 1024)
-        return kLocale.toString(size);
-    else if(size < 1024 * 1024)
-        return kLocale.toString(static_cast<double>(size) / 1024.0, 'f', 1) + "kB";
-    else if(size < 1024 * 1024 * 1024)
-        return kLocale.toString(static_cast<double>(size) / (1024.0 * 1024.0), 'f', 1) + "MB";
-    else if(size < 1024.0 * 1024.0 * 1024.0 * 1024.0)
-        return kLocale.toString(static_cast<double>(size) / (1024.0 * 1024.0 * 1024.0), 'f', 1) + "GB";
-    else
-        return kLocale.toString(static_cast<double>(size) / (1024.0 * 1024.0 * 1024.0 * 1024), 'f', 1) + "TB";
-}
-
-//-----------------------------------------------------------------------------
-QString
-QGCMapEngine::storageFreeSizeToString(quint64 size_MB)
-{
-    if(size_MB < 1024)
-        return kLocale.toString(static_cast<double>(size_MB) , 'f', 0) + " MB";
-    else if(size_MB < 1024.0 * 1024.0)
-        return kLocale.toString(static_cast<double>(size_MB) / (1024.0), 'f', 2) + " GB";
-    else
-        return kLocale.toString(static_cast<double>(size_MB) / (1024.0 * 1024), 'f', 2) + " TB";
-}
-
-//-----------------------------------------------------------------------------
-QString
-QGCMapEngine::numberToString(quint64 number)
-{
-    return kLocale.toString(number);
-}
-
-//-----------------------------------------------------------------------------
 void
 QGCMapEngine::_updateTotals(quint32 totaltiles, quint64 totalsize, quint32 defaulttiles, quint64 defaultsize)
 {
@@ -310,23 +261,6 @@ QGCMapEngine::_updateTotals(quint32 totaltiles, quint64 totalsize, quint32 defau
         connect(task, &QGCPruneCacheTask::pruned, this, &QGCMapEngine::_pruned);
         addTask(task);
     }
-}
-//-----------------------------------------------------------------------------
-void
-QGCMapEngine::_pruned()
-{
-    _prunning = false;
-}
-
-//-----------------------------------------------------------------------------
-int
-QGCMapEngine::concurrentDownloads(const QString& type)
-{
-    Q_UNUSED(type);
-    // TODO : We may want different values depending on
-    // the provider here, let it like this as all provider are set to 12
-    // at the moment
-    return 12;
 }
 
 //-----------------------------------------------------------------------------

--- a/src/QtLocationPlugin/QGCMapEngine.h
+++ b/src/QtLocationPlugin/QGCMapEngine.h
@@ -42,8 +42,6 @@ public:
     void                        cacheTile           (const QString& type, const QString& hash, const QByteArray& image, const QString& format, qulonglong set = UINT64_MAX);
     static QGCFetchTileTask*    createFetchTileTask (const QString& type, int x, int y, int z);
     static QStringList          getMapNameList      ();
-    const QString               userAgent           () { return _userAgent; }
-    void                        setUserAgent        (const QString& ua) { _userAgent = ua; }
     static QString              tileHashToType      (const QString& tileHash);
     static QString              getTileHash         (const QString& type, int x, int y, int z);
     static quint32              getMaxDiskCache     ();
@@ -55,14 +53,10 @@ public:
     //-- Tile Math
     static QGCTileSet           getTileCount        (int zoom, double topleftLon, double topleftLat, double bottomRightLon, double bottomRightLat, const QString& mapType);
     static QString              getTypeFromName     (const QString& name);
-    static QString              bigSizeToString     (quint64 size);
-    static QString              storageFreeSizeToString(quint64 size_MB);
-    static QString              numberToString      (quint64 number);
-    static int                  concurrentDownloads (const QString& type);
 
 private slots:
     void _updateTotals          (quint32 totaltiles, quint64 totalsize, quint32 defaulttiles, quint64 defaultsize);
-    void _pruned                ();
+    void _pruned                () { _prunning = false; }
 
 signals:
     void updateTotals           (quint32 totaltiles, quint64 totalsize, quint32 defaulttiles, quint64 defaultsize);
@@ -74,7 +68,6 @@ private:
 
 private:
     QGCCacheWorker*         _worker = nullptr;
-    QString                 _userAgent;
     bool                    _prunning;
     bool                    _cacheWasReset;
     QString                 _cachePath;

--- a/src/QtLocationPlugin/QGCMapTileSet.cpp
+++ b/src/QtLocationPlugin/QGCMapTileSet.cpp
@@ -16,14 +16,17 @@
  *
  */
 
-#include "QGCMapEngine.h"
 #include "QGCMapTileSet.h"
+#include "QGCMapEngine.h"
 #include "QGCMapEngineManager.h"
 #include "QGCFileDownload.h"
+#include "QGeoTileFetcherQGC.h"
 #include "TerrainTile.h"
 #include "QGCMapUrlEngine.h"
-#include "ElevationMapProvider.h"
+#include "QGCMapEngineData.h"
+#include "QGCApplication.h"
 #include "QGCLoggingCategory.h"
+#include "ElevationMapProvider.h"
 
 #include <QtNetwork/QNetworkProxy>
 
@@ -72,49 +75,49 @@ QGCCachedTileSet::~QGCCachedTileSet()
 QString
 QGCCachedTileSet::errorCountStr() const
 {
-    return QGCMapEngine::numberToString(_errorCount);
+    return qgcApp()->numberToString(_errorCount);
 }
 
 //-----------------------------------------------------------------------------
 QString
 QGCCachedTileSet::totalTileCountStr() const
 {
-    return QGCMapEngine::numberToString(_totalTileCount);
+    return qgcApp()->numberToString(_totalTileCount);
 }
 
 //-----------------------------------------------------------------------------
 QString
 QGCCachedTileSet::totalTilesSizeStr() const
 {
-    return QGCMapEngine::bigSizeToString(_totalTileSize);
+    return qgcApp()->bigSizeToString(_totalTileSize);
 }
 
 //-----------------------------------------------------------------------------
 QString
 QGCCachedTileSet::uniqueTileSizeStr() const
 {
-    return QGCMapEngine::bigSizeToString(_uniqueTileSize);
+    return qgcApp()->bigSizeToString(_uniqueTileSize);
 }
 
 //-----------------------------------------------------------------------------
 QString
 QGCCachedTileSet::uniqueTileCountStr() const
 {
-    return QGCMapEngine::numberToString(_uniqueTileCount);
+    return qgcApp()->numberToString(_uniqueTileCount);
 }
 
 //-----------------------------------------------------------------------------
 QString
 QGCCachedTileSet::savedTileCountStr() const
 {
-    return QGCMapEngine::numberToString(_savedTileCount);
+    return qgcApp()->numberToString(_savedTileCount);
 }
 
 //-----------------------------------------------------------------------------
 QString
 QGCCachedTileSet::savedTileSizeStr() const
 {
-    return QGCMapEngine::bigSizeToString(_savedTileSize);
+    return qgcApp()->bigSizeToString(_savedTileSize);
 }
 
 //-----------------------------------------------------------------------------
@@ -238,7 +241,7 @@ void QGCCachedTileSet::_prepareDownload()
         return;
     }
     //-- Prepare queue (QNetworkAccessManager has a limit for concurrent downloads)
-    for(int i = _replies.count(); i < QGCMapEngine::concurrentDownloads(_type); i++) {
+    for(uint32_t i = _replies.count(); i < QGeoTileFetcherQGC::concurrentDownloads(_type); i++) {
         if(_tilesToDownload.count()) {
             QGCTile* tile = _tilesToDownload.first();
             _tilesToDownload.removeFirst();
@@ -261,7 +264,7 @@ void QGCCachedTileSet::_prepareDownload()
 #endif
             delete tile;
             //-- Refill queue if running low
-            if(!_batchRequested && !_noMoreTiles && _tilesToDownload.count() < (QGCMapEngine::concurrentDownloads(_type) * 10)) {
+            if(!_batchRequested && !_noMoreTiles && _tilesToDownload.count() < (QGeoTileFetcherQGC::concurrentDownloads(_type) * 10)) {
                 //-- Request new batch of tiles
                 createDownloadTask();
             }

--- a/src/QtLocationPlugin/QGeoTileFetcherQGC.cpp
+++ b/src/QtLocationPlugin/QGeoTileFetcherQGC.cpp
@@ -1,82 +1,79 @@
-/****************************************************************************
-**
-** Copyright (C) 2013 Aaron McCarthy <mccarthy.aaron@gmail.com>
-** Contact: http://www.qt-project.org/legal
-**
-** This file is part of the QtLocation module of the Qt Toolkit.
-**
-** $QT_BEGIN_LICENSE:LGPL$
-** Commercial License Usage
-** Licensees holding valid commercial Qt licenses may use this file in
-** accordance with the commercial license agreement provided with the
-** Software or, alternatively, in accordance with the terms contained in
-** a written agreement between you and Digia.  For licensing terms and
-** conditions see http://qt.digia.com/licensing.  For further information
-** use the contact form at http://qt.digia.com/contact-us.
-**
-** GNU Lesser General Public License Usage
-** Alternatively, this file may be used under the terms of the GNU Lesser
-** General Public License version 2.1 as published by the Free Software
-** Foundation and appearing in the file LICENSE.LGPL included in the
-** packaging of this file.  Please review the following information to
-** ensure the GNU Lesser General Public License version 2.1 requirements
-** will be met: http://www.gnu.org/licenses/old-licenses/lgpl-2.1.html.
-**
-** In addition, as a special exception, Digia gives you certain additional
-** rights.  These rights are described in the Digia Qt LGPL Exception
-** version 1.1, included in the file LGPL_EXCEPTION.txt in this package.
-**
-** GNU General Public License Usage
-** Alternatively, this file may be used under the terms of the GNU
-** General Public License version 3.0 as published by the Free Software
-** Foundation and appearing in the file LICENSE.GPL included in the
-** packaging of this file.  Please review the following information to
-** ensure the GNU General Public License version 3.0 requirements will be
-** met: http://www.gnu.org/copyleft/gpl.html.
-**
-**
-** $QT_END_LICENSE$
-**
-** 2015.4.4
-** Adapted for use with QGroundControl
-**
-** Gus Grubba <gus@auterion.com>
-**
-****************************************************************************/
-
 #include "QGeoTileFetcherQGC.h"
+#include "QGeoTiledMappingManagerEngineQGC.h"
 #include "QGCMapEngine.h"
 #include "QGeoMapReplyQGC.h"
 #include "QGCMapUrlEngine.h"
+#include "MapProvider.h"
+#include <DeviceInfo.h>
+#include <QGCLoggingCategory.h>
 
 #include <QtNetwork/QNetworkRequest>
 #include <QtLocation/private/qgeotilespec_p.h>
 #include <QtLocation/private/qgeotiledmappingmanagerengine_p.h>
 
-//-----------------------------------------------------------------------------
-QGeoTileFetcherQGC::QGeoTileFetcherQGC(QGeoTiledMappingManagerEngine *parent)
-    : QGeoTileFetcher(parent)
-    , _networkManager(new QNetworkAccessManager(this))
-{
+QGC_LOGGING_CATEGORY(QGeoTileFetcherQGCLog, "qgc.qtlocationplugin.qgeotilefetcherqgc")
 
+QGeoTileFetcherQGC::QGeoTileFetcherQGC(QNetworkAccessManager *networkManager, QGeoTiledMappingManagerEngineQGC *parent)
+    : QGeoTileFetcher(parent)
+    , m_networkManager(networkManager)
+{
+    // qCDebug(QGeoTileFetcherQGCLog) << Q_FUNC_INFO << this;
 }
 
-//-----------------------------------------------------------------------------
 QGeoTileFetcherQGC::~QGeoTileFetcherQGC()
 {
-
+    // qCDebug(QGeoTileFetcherQGCLog) << Q_FUNC_INFO << this;
 }
 
-//-----------------------------------------------------------------------------
-QGeoTiledMapReply*
-QGeoTileFetcherQGC::getTileImage(const QGeoTileSpec &spec)
+QGeoTiledMapReply* QGeoTileFetcherQGC::getTileImage(const QGeoTileSpec &spec)
 {
-    //-- Build URL
-    QNetworkRequest request = UrlFactory::getTileURL(spec.mapId(), spec.x(), spec.y(), spec.zoom());
-    if ( ! request.url().isEmpty() ) {
-        return new QGeoTiledMapReplyQGC(_networkManager, request, spec);
-    }
-    else {
+    const SharedMapProvider provider = UrlFactory::getMapProviderFromQtMapId(spec.mapId());
+    if (!provider) {
         return nullptr;
+    }
+
+    /*if (spec.zoom() > provider->maximumZoomLevel() || spec.zoom() < provider->minimumZoomLevel()) {
+        return nullptr;
+    }*/
+
+    const QNetworkRequest request = provider->getTileURL(spec.x(), spec.y(), spec.zoom());
+    if (request.url().isEmpty()) {
+        return nullptr;
+    }
+
+    return new QGeoTiledMapReplyQGC(m_networkManager, request, spec);
+}
+
+bool QGeoTileFetcherQGC::initialized() const
+{
+    return (m_networkManager != nullptr);
+}
+
+bool QGeoTileFetcherQGC::fetchingEnabled() const
+{
+    return initialized(); // QGCDeviceInfo::isInternetAvailable();
+}
+
+void QGeoTileFetcherQGC::timerEvent(QTimerEvent *event)
+{
+    QGeoTileFetcher::timerEvent(event);
+}
+
+void QGeoTileFetcherQGC::handleReply(QGeoTiledMapReply *reply, const QGeoTileSpec &spec)
+{
+    if (!reply) {
+        return;
+    }
+
+    reply->deleteLater();
+
+    if (!initialized()) {
+        return;
+    }
+
+    if (reply->error() == QGeoTiledMapReply::NoError) {
+        emit tileFinished(spec, reply->mapImageData(), reply->mapImageFormat());
+    } else {
+        emit tileError(spec, reply->errorString());
     }
 }

--- a/src/QtLocationPlugin/QGeoTileFetcherQGC.h
+++ b/src/QtLocationPlugin/QGeoTileFetcherQGC.h
@@ -1,64 +1,44 @@
-/****************************************************************************
-**
-** Copyright (C) 2013 Aaron McCarthy <mccarthy.aaron@gmail.com>
-** Contact: http://www.qt-project.org/legal
-**
-** This file is part of the QtLocation module of the Qt Toolkit.
-**
-** $QT_BEGIN_LICENSE:LGPL$
-** Commercial License Usage
-** Licensees holding valid commercial Qt licenses may use this file in
-** accordance with the commercial license agreement provided with the
-** Software or, alternatively, in accordance with the terms contained in
-** a written agreement between you and Digia.  For licensing terms and
-** conditions see http://qt.digia.com/licensing.  For further information
-** use the contact form at http://qt.digia.com/contact-us.
-**
-** GNU Lesser General Public License Usage
-** Alternatively, this file may be used under the terms of the GNU Lesser
-** General Public License version 2.1 as published by the Free Software
-** Foundation and appearing in the file LICENSE.LGPL included in the
-** packaging of this file.  Please review the following information to
-** ensure the GNU Lesser General Public License version 2.1 requirements
-** will be met: http://www.gnu.org/licenses/old-licenses/lgpl-2.1.html.
-**
-** In addition, as a special exception, Digia gives you certain additional
-** rights.  These rights are described in the Digia Qt LGPL Exception
-** version 1.1, included in the file LGPL_EXCEPTION.txt in this package.
-**
-** GNU General Public License Usage
-** Alternatively, this file may be used under the terms of the GNU
-** General Public License version 3.0 as published by the Free Software
-** Foundation and appearing in the file LICENSE.GPL included in the
-** packaging of this file.  Please review the following information to
-** ensure the GNU General Public License version 3.0 requirements will be
-** met: http://www.gnu.org/copyleft/gpl.html.
-**
-**
-** $QT_END_LICENSE$
-**
-** 2015.4.4
-** Adapted for use with QGroundControl
-**
-** Gus Grubba <gus@auterion.com>
-**
-****************************************************************************/
-
 #pragma once
 
 #include <QtLocation/private/qgeotilefetcher_p.h>
+#include <QtCore/QLoggingCategory>
+#include <QtNetwork/QNetworkRequest>
 
-class QGeoTiledMappingManagerEngine;
+Q_DECLARE_LOGGING_CATEGORY(QGeoTileFetcherQGCLog)
+
+class QGeoTiledMappingManagerEngineQGC;
+class QGeoTiledMapReplyQGC;
+class QGeoTileSpec;
 class QNetworkAccessManager;
 
 class QGeoTileFetcherQGC : public QGeoTileFetcher
 {
     Q_OBJECT
+
 public:
-    explicit QGeoTileFetcherQGC             (QGeoTiledMappingManagerEngine *parent = nullptr);
+    explicit QGeoTileFetcherQGC(QNetworkAccessManager *networkManager, QGeoTiledMappingManagerEngineQGC *parent = nullptr);
     ~QGeoTileFetcherQGC();
+
+    static uint32_t concurrentDownloads(const QString &type) { Q_UNUSED(type); return 6; }
+
 private:
-    QGeoTiledMapReply*      getTileImage    (const QGeoTileSpec &spec);
-private:
-    QNetworkAccessManager*  _networkManager;
+    QGeoTiledMapReply* getTileImage(const QGeoTileSpec &spec) final;
+    bool initialized() const final;
+    bool fetchingEnabled() const final;
+    void timerEvent(QTimerEvent *event) final;
+    void handleReply(QGeoTiledMapReply *reply, const QGeoTileSpec &spec) final;
+
+    QNetworkAccessManager *m_networkManager = nullptr;
+
+#if defined Q_OS_MAC
+    static constexpr const char* s_userAgent = "Mozilla/5.0 (Macintosh; Intel Mac OS X 14.5; rv:125.0) Gecko/20100101 Firefox/125.0";
+#elif defined Q_OS_WIN
+    static constexpr const char* s_userAgent = "Mozilla/5.0 (Windows NT 10.0; Win64; x64; rv:100.0) Gecko/20100101 Firefox/112.0";
+#elif defined Q_OS_ANDROID
+    static constexpr const char* s_userAgent = "Mozilla/5.0 (Android 13; Tablet; rv:68.0) Gecko/68.0 Firefox/112.0";
+#elif defined Q_OS_LINUX
+    static constexpr const char* s_userAgent = "Mozilla/5.0 (X11; Linux x86_64; rv:109.0) Gecko/20100101 Firefox/112.0";
+#else
+    static constexpr const char* s_userAgent = "Qt Location based application";
+#endif
 };

--- a/src/QtLocationPlugin/QGeoTiledMapQGC.cpp
+++ b/src/QtLocationPlugin/QGeoTiledMapQGC.cpp
@@ -1,0 +1,39 @@
+#include "QGeoTiledMapQGC.h"
+#include "QGeoTiledMappingManagerEngineQGC.h"
+#include <QGCLoggingCategory.h>
+
+QGC_LOGGING_CATEGORY(QGeoTiledMapQGCLog, "qgc.qtlocationplugin.qgeotiledmapqgc")
+
+QGeoTiledMapQGC::QGeoTiledMapQGC(QGeoTiledMappingManagerEngineQGC *engine, QObject *parent)
+    : QGeoTiledMap(engine, parent)
+{
+	// qCDebug(QGeoTiledMapQGCLog) << Q_FUNC_INFO << this;
+}
+
+QGeoTiledMapQGC::~QGeoTiledMapQGC()
+{
+    // qCDebug(QGeoTiledMapQGCLog) << Q_FUNC_INFO << this;
+}
+
+QGeoMap::Capabilities QGeoTiledMapQGC::capabilities() const
+{
+    return Capabilities(SupportsVisibleRegion
+                        | SupportsSetBearing
+                        | SupportsAnchoringCoordinate
+                        | SupportsVisibleArea);
+}
+
+/*void QGeoTiledMapQGC::evaluateCopyrights(const QSet<QGeoTileSpec> &visibleTiles)
+{
+    if (visibleTiles.isEmpty()) {
+        return;
+    }
+
+    const QGeoTileSpec tile = *(visibleTiles.constBegin());
+
+    const MapProvider* const provider = getProviderFromQtMapId(tile.mapId());
+
+    if (provider) {
+        emit copyrightsChanged(provider->copyright());
+    }
+}*/

--- a/src/QtLocationPlugin/QGeoTiledMapQGC.h
+++ b/src/QtLocationPlugin/QGeoTiledMapQGC.h
@@ -1,0 +1,22 @@
+#pragma once
+
+#include <QtLocation/private/qgeotiledmap_p.h>
+#include <QtCore/QLoggingCategory>
+
+Q_DECLARE_LOGGING_CATEGORY(QGeoTiledMapQGCLog)
+
+class QGeoTiledMappingManagerEngineQGC;
+
+class QGeoTiledMapQGC : public QGeoTiledMap
+{
+    Q_OBJECT
+
+public:
+    explicit QGeoTiledMapQGC(QGeoTiledMappingManagerEngineQGC *engine, QObject *parent = nullptr);
+    ~QGeoTiledMapQGC();
+
+    QGeoMap::Capabilities capabilities() const final;
+
+private:
+    // void evaluateCopyrights(const QSet<QGeoTileSpec> &visibleTiles) final;
+};

--- a/src/QtLocationPlugin/QGeoTiledMappingManagerEngineQGC.h
+++ b/src/QtLocationPlugin/QGeoTiledMappingManagerEngineQGC.h
@@ -1,72 +1,26 @@
-/****************************************************************************
-**
-** Copyright (C) 2013 Aaron McCarthy <mccarthy.aaron@gmail.com>
-** Contact: http://www.qt-project.org/legal
-**
-** This file is part of the QtLocation module of the Qt Toolkit.
-**
-** $QT_BEGIN_LICENSE:LGPL$
-** Commercial License Usage
-** Licensees holding valid commercial Qt licenses may use this file in
-** accordance with the commercial license agreement provided with the
-** Software or, alternatively, in accordance with the terms contained in
-** a written agreement between you and Digia.  For licensing terms and
-** conditions see http://qt.digia.com/licensing.  For further information
-** use the contact form at http://qt.digia.com/contact-us.
-**
-** GNU Lesser General Public License Usage
-** Alternatively, this file may be used under the terms of the GNU Lesser
-** General Public License version 2.1 as published by the Free Software
-** Foundation and appearing in the file LICENSE.LGPL included in the
-** packaging of this file.  Please review the following information to
-** ensure the GNU Lesser General Public License version 2.1 requirements
-** will be met: http://www.gnu.org/licenses/old-licenses/lgpl-2.1.html.
-**
-** In addition, as a special exception, Digia gives you certain additional
-** rights.  These rights are described in the Digia Qt LGPL Exception
-** version 1.1, included in the file LGPL_EXCEPTION.txt in this package.
-**
-** GNU General Public License Usage
-** Alternatively, this file may be used under the terms of the GNU
-** General Public License version 3.0 as published by the Free Software
-** Foundation and appearing in the file LICENSE.GPL included in the
-** packaging of this file.  Please review the following information to
-** ensure the GNU General Public License version 3.0 requirements will be
-** met: http://www.gnu.org/copyleft/gpl.html.
-**
-**
-** $QT_END_LICENSE$
-**
-** 2015.4.4
-** Adapted for use with QGroundControl
-**
-** Gus Grubba <gus@auterion.com>
-**
-****************************************************************************/
-
 #pragma once
 
 #include <QtLocation/QGeoServiceProvider>
-#include <QtLocation/private/qgeotiledmap_p.h>
 #include <QtLocation/private/qgeotiledmappingmanagerengine_p.h>
+#include <QtCore/QLoggingCategory>
 
-class QGeoTiledMapQGC : public QGeoTiledMap
-{
-    Q_OBJECT
-public:
-    QGeoTiledMapQGC(QGeoTiledMappingManagerEngine *engine, QObject *parent = 0);
-};
+Q_DECLARE_LOGGING_CATEGORY(QGeoTiledMappingManagerEngineQGCLog)
 
-class QGeoTileFetcherQGC;
+class QNetworkAccessManager;
 
 class QGeoTiledMappingManagerEngineQGC : public QGeoTiledMappingManagerEngine
 {
     Q_OBJECT
+
 public:
-    QGeoTiledMappingManagerEngineQGC(const QVariantMap &parameters, QGeoServiceProvider::Error *error, QString *errorString);
+    QGeoTiledMappingManagerEngineQGC(const QVariantMap &parameters, QGeoServiceProvider::Error *error, QString *errorString, QObject *parent = nullptr);
     ~QGeoTiledMappingManagerEngineQGC();
-    QGeoMap *createMap();
+
+    QGeoMap* createMap() final;
+    QNetworkAccessManager* networkManager() const { return m_networkManager; }
 
 private:
+    QNetworkAccessManager *m_networkManager = nullptr;
+
     void _setCache(const QVariantMap &parameters);
 };

--- a/src/QtLocationPlugin/QMLControl/QGCMapEngineManager.cc
+++ b/src/QtLocationPlugin/QMLControl/QGCMapEngineManager.cc
@@ -19,6 +19,7 @@
 #include "QGCMapTileSet.h"
 #include "ElevationMapProvider.h"
 #include "QGCMapEngine.h"
+#include "QGCApplication.h"
 #include "QGCLoggingCategory.h"
 
 #include <QtCore/QSettings>
@@ -102,14 +103,14 @@ QGCMapEngineManager::updateForCurrentView(double lon0, double lat0, double lon1,
 QString
 QGCMapEngineManager::tileCountStr() const
 {
-    return QGCMapEngine::numberToString(_imageSet.tileCount + _elevationSet.tileCount);
+    return qgcApp()->numberToString(_imageSet.tileCount + _elevationSet.tileCount);
 }
 
 //-----------------------------------------------------------------------------
 QString
 QGCMapEngineManager::tileSizeStr() const
 {
-    return QGCMapEngine::bigSizeToString(_imageSet.tileSize + _elevationSet.tileSize);
+    return qgcApp()->bigSizeToString(_imageSet.tileSize + _elevationSet.tileSize);
 }
 
 //-----------------------------------------------------------------------------


### PR DESCRIPTION
Move some functions out of QGCMapEngine to remove unnecessary linking to QGCLocation and to better organize methods with appropriate classes.