### PR TITLE
Fix debug with choosing languages

### DIFF
--- a/src/Settings/App.SettingsGroup.json
+++ b/src/Settings/App.SettingsGroup.json
@@ -261,7 +261,7 @@
     "shortDesc":    "Language",
     "type":         "uint32",
     "enumStrings":  "System,Azerbaijani (Azerbaijani),български (Bulgarian),中文 (Chinese),Nederlands (Dutch),English,Suomi (Finnish),Français (French),Deutsche (German),Ελληνικά (Greek), עברית (Hebrew),Italiano (Italian),日本語 (Japanese),한국어 (Korean),Norsk (Norwegian),Polskie (Polish),Português (Portuguese),Pусский (Russian),Español (Spanish),Svenska (Swedish),Türk (Turkish)",
-    "enumValues":   "0,12,20,25,30,31,36,37,42,43,48,58,59,66,85,90,91,96,111,114,125",
+    "enumValues":   "0,25,45,58,72,75,84,85,94,96,103,119,120,142,209,230,231,239,270,275,298",
     "comment":      "enumValues uses Qt QLocale::Language values",
     "default":      0
 },

--- a/src/Settings/AppSettings.cc
+++ b/src/Settings/AppSettings.cc
@@ -353,7 +353,7 @@ QLocale::Language AppSettings::_qLocaleLanguageID(void)
         "enumStrings":      "System,български (Bulgarian),中文 (Chinese),Nederlands (Dutch),English,Suomi (Finnish),Français (French),Deutsche (German),Ελληνικά (Greek), עברית (Hebrew),Italiano (Italian),日本語 (Japanese),한국어 (Korean),Norsk (Norwegian),Polskie (Polish),Português (Portuguese),Pусский (Russian),Español (Spanish),Svenska (Swedish),Türk (Turkish),Azerbaijani (Azerbaijani)",
         "enumValues":       "0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20",
 #endif
-        static QList<int> rgNewValues = { 0,20,25,30,31,36,37,42,43,48,58,59,66,85,90,91,96,111,114,125,15 };
+        static QList<int> rgNewValues = {0,25,45,58,72,75,84,85,94,96,103,119,120,142,209,230,231,239,270,275,298};
 
         int oldValue = settings.value("language").toInt();
         settings.setValue(qLocaleLanguageName, rgNewValues[oldValue]);


### PR DESCRIPTION
<!--- Title -->
Changing identifiers of languages
Description
-----------
<!--- Describe your changes in detail. -->
This pull request fixes an issue with language selection in the Application settings->General. 
### Changes:
1. Updated `src/Settings/App.SettingsGroup.json` to correct the language identifiers.
2. Modified `src/Settings/AppSettings.cc` to properly handle language selection.

Test Steps
-----------
<!-- Describe the steps to reproduce. -->
Run program, go to Application settings->General, and choose different languages, note respond on Chineese.
Checklist:
----------
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] [Review Contribution Guidelines](https://github.com/mavlink/qgroundcontrol/blob/master/.github/CONTRIBUTING.md).
- [x] [Review Code of Conduct](https://github.com/mavlink/qgroundcontrol/blob/master/.github/CODE_OF_CONDUCT.md).
- [x] I have tested my changes.

Related Issue
-----------
<!-- If any, please provide issue ID. -->
#11570
#11541

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.