### PR TITLE
Select language fixes

### DIFF
--- a/src/FactSystem/FactMetaData.cc
+++ b/src/FactSystem/FactMetaData.cc
@@ -1309,17 +1309,17 @@ FactMetaData* FactMetaData::createFromJsonObject(const QJsonObject& json, QMap<Q
 
     bool foundBitmask = false;
     if (!_parseValuesArray(json, rgDescriptions, rgDoubleValues, errorString)) {
-        qWarning() << QStringLiteral("FactMetaData::createFromJsonObject _parseValueDescriptionArray for %1 failed. %2").arg(metaData->_name).arg(errorString);
+        qWarning() << QStringLiteral("FactMetaData::createFromJsonObject _parseValueDescriptionArray for '%1' failed. %2").arg(metaData->_name).arg(errorString);
     }
     if (rgDescriptions.isEmpty()) {
         if (!_parseBitmaskArray(json, rgDescriptions, rgIntValues, errorString)) {
-            qWarning() << QStringLiteral("FactMetaData::createFromJsonObject _parseBitmaskArray for %1 failed. %2").arg(metaData->_name).arg(errorString);
+            qWarning() << QStringLiteral("FactMetaData::createFromJsonObject _parseBitmaskArray for '%1' failed. %2").arg(metaData->_name).arg(errorString);
         }
         foundBitmask = rgDescriptions.count() != 0;
     }
     if (rgDescriptions.isEmpty()) {
         if (!_parseEnum(json, defineMap, rgDescriptions, rgStringValues, errorString)) {
-            qWarning() << QStringLiteral("FactMetaData::createFromJsonObject _parseEnum for %1 failed. %2").arg(metaData->_name).arg(errorString);
+            qWarning() << QStringLiteral("FactMetaData::createFromJsonObject _parseEnum for '%1' failed. %2").arg(metaData->_name).arg(errorString);
         }
     }
 
@@ -1546,14 +1546,16 @@ bool FactMetaData::_parseEnum(const QJsonObject& jsonObject, DefineMap_t defineM
         return true;
     }
 
-    QString strings = jsonObject.value(_enumStringsJsonKey).toString();
-    rgDescriptions = defineMap.value(strings, strings).split(",", Qt::SkipEmptyParts);
+    QString jsonStrings = jsonObject.value(_enumStringsJsonKey).toString();
+    QString defineMapStrings = defineMap.value(jsonStrings, jsonStrings);
+    rgDescriptions = defineMapStrings.split(",", Qt::SkipEmptyParts);
 
-    QString values = jsonObject.value(_enumValuesJsonKey).toString();
-    rgValues = defineMap.value(values, values).split(",", Qt::SkipEmptyParts);
+    QString jsonValues = jsonObject.value(_enumValuesJsonKey).toString();
+    QString defineMapValues = defineMap.value(jsonValues, jsonValues);
+    rgValues = defineMapValues.split(",", Qt::SkipEmptyParts);
 
     if (rgDescriptions.count() != rgValues.count()) {
-        errorString = QStringLiteral("Enum strings/values count mismatch - strings:values %1:%2").arg(rgDescriptions.count()).arg(rgValues.count());
+        errorString = QStringLiteral("Enum strings/values count mismatch - strings: '%1'[%2,%3] values: '%4'[%5,%6]").arg(defineMapStrings).arg(rgDescriptions.count()).arg(defineMapStrings.contains(",")).arg(defineMapValues).arg(rgValues.count()).arg(defineMapValues.contains(","));
         return false;
     }
 

--- a/src/QGCApplication.cc
+++ b/src/QGCApplication.cc
@@ -268,7 +268,7 @@ void QGCApplication::setLanguage()
     _locale = QLocale::system();
     qCDebug(QGCApplicationLog) << "System reported locale:" << _locale << "; Name" << _locale.name() << "; Preffered (used in maps): " << (QLocale::system().uiLanguages().length() > 0 ? QLocale::system().uiLanguages()[0] : "None");
 
-    QLocale::Language possibleLocale = AppSettings::_qLocaleLanguageID();
+    QLocale::Language possibleLocale = AppSettings::_qLocaleLanguageEarlyAccess();
     if (possibleLocale != QLocale::AnyLanguage) {
         _locale = QLocale(possibleLocale);
     }

--- a/src/Settings/App.SettingsGroup.json
+++ b/src/Settings/App.SettingsGroup.json
@@ -257,13 +257,12 @@
     "qgcRebootRequired":    true
 },
 {
-    "name":         "qLocaleLanguage",
-    "shortDesc":    "Language",
-    "type":         "uint32",
-    "enumStrings":  "System,Azerbaijani (Azerbaijani),български (Bulgarian),中文 (Chinese),Nederlands (Dutch),English,Suomi (Finnish),Français (French),Deutsche (German),Ελληνικά (Greek), עברית (Hebrew),Italiano (Italian),日本語 (Japanese),한국어 (Korean),Norsk (Norwegian),Polskie (Polish),Português (Portuguese),Pусский (Russian),Español (Spanish),Svenska (Swedish),Türk (Turkish)",
-    "enumValues":   "0,12,20,25,30,31,36,37,42,43,48,58,59,66,85,90,91,96,111,114,125",
-    "comment":      "enumValues uses Qt QLocale::Language values",
-    "default":      0
+    "name":                 "qLocaleLanguage",
+    "shortDesc":            "Language",
+    "type":                 "uint32",
+    "default":              0,
+    "qgcRebootRequired":    true,
+    "comment":              "QLocale::Language id. Fact enum metadata is setup in AppSettings code. QGC reboot required in order to load new json translations into FactMetaData."
 },
 {
     "name":             "disableAllPersistence",

--- a/src/Settings/AppSettings.cc
+++ b/src/Settings/AppSettings.cc
@@ -43,19 +43,43 @@ const char* AppSettings::crashDirectory =           QT_TRANSLATE_NOOP("AppSettin
 const char* AppSettings::customActionsDirectory =   QT_TRANSLATE_NOOP("AppSettings", "CustomActions");
 
 // Release languages are 90%+ complete
-QList<int> AppSettings::_rgReleaseLanguages = {
-    QLocale::AnyLanguage,  // System
-    QLocale::Chinese,
+QList<QLocale::Language> AppSettings::_rgReleaseLanguages = {
     QLocale::English,
+    QLocale::Azerbaijani,    
+    QLocale::Chinese,
     QLocale::Japanese,
     QLocale::Korean,
-    QLocale::Azerbaijani,
+    QLocale::Portuguese,
+    QLocale::Russian,
 };
+
 // Partial languages are 40%+ complete
-QList<int> AppSettings::_rgPartialLanguages = {
-    QLocale::German,
-    QLocale::Turkish,
+QList<QLocale::Language> AppSettings::_rgPartialLanguages = {
     QLocale::Ukrainian,
+};
+
+AppSettings::LanguageInfo_t AppSettings::_rgLanguageInfo[] = {
+    { QLocale::AnyLanguage,     "System" },                     // Must be first
+    { QLocale::Azerbaijani,     "Azerbaijani (Azerbaijani)" },
+    { QLocale::Bulgarian,       "български (Bulgarian)" },
+    { QLocale::Chinese,         "中文 (Chinese)" },
+    { QLocale::Dutch,           "Nederlands (Dutch)" },
+    { QLocale::English,         "English" },
+    { QLocale::Finnish,         "Suomi (Finnish)" },
+    { QLocale::French,          "Français (French)" },
+    { QLocale::German,          "Deutsche (German)" },
+    { QLocale::Greek,           "Ελληνικά (Greek)" },
+    { QLocale::Hebrew,          "עברית (Hebrew)" },
+    { QLocale::Italian,         "Italiano (Italian)" },
+    { QLocale::Japanese,        "日本語 (Japanese)" },
+    { QLocale::Korean,          "한국어 (Korean)" },
+    { QLocale::NorwegianBokmal, "Norsk (Norwegian)" },
+    { QLocale::Polish,          "Polskie (Polish)" },
+    { QLocale::Portuguese,      "Português (Portuguese)" },
+    { QLocale::Russian,         "Pусский (Russian)" },
+    { QLocale::Spanish,         "Español (Spanish)" },
+    { QLocale::Swedish,         "Svenska (Swedish)" },
+    { QLocale::Turkish,         "Türk (Turkish)" }
 };
 
 DECLARE_SETTINGGROUP(App, "")
@@ -190,35 +214,39 @@ DECLARE_SETTINGSFACT_NO_FUNC(AppSettings, qLocaleLanguage)
         connect(_qLocaleLanguageFact, &Fact::rawValueChanged, this, &AppSettings::_qLocaleLanguageChanged);
 
         FactMetaData*   metaData            = _qLocaleLanguageFact->metaData();
-        QStringList     rgOriginalStrings   = metaData->enumStrings();
-        QVariantList    rgOriginalValues    = metaData->enumValues();
-        QStringList     rgUpdatedStrings;
-        QVariantList    rgUpdatedValues;
+        QStringList     rgEnumStrings;
+        QVariantList    rgEnumValues;
 
-        // All builds contains released and partial languages
-        for (int i=0; i<rgOriginalStrings.count(); i++) {
-            if (_rgReleaseLanguages.contains(rgOriginalValues[i].toInt())) {
-                rgUpdatedStrings.append(rgOriginalStrings[i]);
-                rgUpdatedValues.append(rgOriginalValues[i]);
+        // System is always an available selection
+        rgEnumStrings.append(_rgLanguageInfo[0].languageName);
+        rgEnumValues.append(_rgLanguageInfo[0].languageId);
+
+        for (const auto& languageInfo: _rgLanguageInfo) {
+            if (_rgReleaseLanguages.contains(languageInfo.languageId)) {
+                rgEnumStrings.append(languageInfo.languageName);
+                rgEnumValues.append(languageInfo.languageId);
             }
         }
-        for (int i=0; i<rgOriginalStrings.count(); i++) {
-            if (_rgPartialLanguages.contains(rgOriginalValues[i].toInt())) {
-                rgUpdatedStrings.append(rgOriginalStrings[i] + AppSettings::tr(" (Partial)"));
-                rgUpdatedValues.append(rgOriginalValues[i].toInt());
+        for (const auto& languageInfo: _rgLanguageInfo) {
+            if (_rgPartialLanguages.contains(languageInfo.languageId)) {
+                rgEnumStrings.append(QString(languageInfo.languageName) + AppSettings::tr(" (Partial)"));
+                rgEnumValues.append(languageInfo.languageId);
             }
         }
 #ifdef DAILY_BUILD
-        // Only daily builds include full set
-        for (int i=0; i<rgOriginalStrings.count(); i++) {
-            int languageId = rgOriginalValues[i].toInt();
-            if (!_rgReleaseLanguages.contains(languageId)  || !_rgPartialLanguages.contains(languageId)) {
-                rgUpdatedStrings.append(rgOriginalStrings[i] + AppSettings::tr(" (Test only)"));
-                rgUpdatedValues.append(rgOriginalValues[i].toInt());
+        // Only daily builds include full set of languages for testing purposes
+        for (const auto& languageInfo: _rgLanguageInfo) {
+            if (!_rgReleaseLanguages.contains(languageInfo.languageId) && !_rgPartialLanguages.contains(languageInfo.languageId)) {
+                rgEnumStrings.append(QString(languageInfo.languageName) + AppSettings::tr(" (Test Only)"));
+                rgEnumValues.append(languageInfo.languageId);
             }
         }
 #endif
-        metaData->setEnumInfo(rgUpdatedStrings, rgUpdatedValues);
+        metaData->setEnumInfo(rgEnumStrings, rgEnumValues);
+
+        if (_qLocaleLanguageFact->enumIndex() == -1) {
+            _qLocaleLanguageFact->setRawValue(QLocale::AnyLanguage);
+        }
     }
     return _qLocaleLanguageFact;
 }
@@ -361,35 +389,25 @@ void AppSettings::firstRunPromptIdsMarkIdAsShown(int id)
     }
 }
 
-/// Hack to provide language settings as early in the boot process as possible. Must be known
-/// prior to loading any json files.
-QLocale::Language AppSettings::_qLocaleLanguageID(void)
+/// Returns the current qLocaleLanguage setting bypassing the standard SettingsGroup path. It also validates
+/// that the value is a supported language. This should only be used by QGCApplication::setLanguage to query 
+/// the language setting as early in the boot process as possible. Specfically prior to any JSON files being 
+/// loaded such that JSON file can be translated. Also since this is a one-off mechanism custom build overrides 
+/// for language are not currently supported.
+QLocale::Language AppSettings::_qLocaleLanguageEarlyAccess(void)
 {
     QSettings settings;
 
-    if (settings.childKeys().contains("language")) {
-        // We need to convert to the new settings key/values
-#if 0
-        // Old vales
-        "enumStrings":      "System,български (Bulgarian),中文 (Chinese),Nederlands (Dutch),English,Suomi (Finnish),Français (French),Deutsche (German),Ελληνικά (Greek), עברית (Hebrew),Italiano (Italian),日本語 (Japanese),한국어 (Korean),Norsk (Norwegian),Polskie (Polish),Português (Portuguese),Pусский (Russian),Español (Spanish),Svenska (Swedish),Türk (Turkish),Azerbaijani (Azerbaijani)",
-        "enumValues":       "0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20",
-#endif
-        static QList<int> rgNewValues = { 0,20,25,30,31,36,37,42,43,48,58,59,66,85,90,91,96,111,114,125,15 };
-
-        int oldValue = settings.value("language").toInt();
-        settings.setValue(qLocaleLanguageName, rgNewValues[oldValue]);
-        settings.remove("language");
-    }
-
-    QLocale::Language id = settings.value(qLocaleLanguageName, QLocale::AnyLanguage).value<QLocale::Language>();
-    if (id == QLocale::AnyLanguage) {
-#ifndef DAILY_BUILD
-        // Stable builds only support released and partial languages
-        if (!_rgReleaseLanguages.contains(id) && _rgPartialLanguages.contains(id)) {
-            id = QLocale::English;
+    // Note that the AppSettings group has no group name
+    QLocale::Language localeLanguage = static_cast<QLocale::Language>(settings.value(qLocaleLanguageName).toInt());
+    for (auto& languageInfo: _rgLanguageInfo) {
+        if (languageInfo.languageId == localeLanguage) {
+            return localeLanguage;
         }
-#endif
     }
 
-    return id;
+    localeLanguage = QLocale::AnyLanguage;
+    settings.setValue(qLocaleLanguageName, localeLanguage);
+
+    return localeLanguage;
 }

--- a/src/Settings/AppSettings.h
+++ b/src/Settings/AppSettings.h
@@ -124,12 +124,6 @@ public:
     static const char* crashDirectory;
     static const char* customActionsDirectory;
 
-    // Returns the current qLocaleLanguage setting bypassing the standard SettingsGroup path. This should only be used
-    // by QGCApplication::setLanguage to query the language setting as early in the boot process as possible.
-    // Specfically prior to any JSON files being loaded such that JSON file can be translated. Also since this
-    // is a one-off mechanism custom build overrides for language are not currently supported.
-    static QLocale::Language _qLocaleLanguageID(void);
-
 signals:
     void savePathsChanged();
 
@@ -139,6 +133,16 @@ private slots:
     void _qLocaleLanguageChanged();
 
 private:
-    static QList<int> _rgReleaseLanguages;
-    static QList<int> _rgPartialLanguages;
+    static QLocale::Language _qLocaleLanguageEarlyAccess(void);
+
+    static QList<QLocale::Language> _rgReleaseLanguages;
+    static QList<QLocale::Language> _rgPartialLanguages;
+
+    typedef struct {
+        QLocale::Language   languageId;
+        const char*         languageName;
+    } LanguageInfo_t;
+    static LanguageInfo_t _rgLanguageInfo[];
+    
+    friend class QGCApplication;
 };

--- a/src/Settings/RemoteID.SettingsGroup.json
+++ b/src/Settings/RemoteID.SettingsGroup.json
@@ -78,7 +78,7 @@
     "name":         "basicIDType",
     "shortDesc":    "Basic ID Type",
     "type":         "uint8",
-    "enumStrings":  "None, SerialNumber(ANSI/CTA-2063), CAA, UTM(RFC4122), Specific",
+    "enumStrings":  "None,SerialNumber(ANSI/CTA-2063),CAA,UTM(RFC4122),Specific",
     "enumValues":   "0,1,2,3,4",
     "default":      2
 },
@@ -86,7 +86,7 @@
     "name":         "basicIDUaType",
     "shortDesc":    "UA type",
     "type":         "uint8",
-    "enumStrings":  "Undefined,Airplane/FixedWing,Helicopter/Multirrotor, Gyroplane, VTOL, Ornithopter, Glider, Kite, Free Ballon, Captive Ballon, Airship, Parachute, Rocket, Tethered powered aircraft, Ground Obstacle, Other",
+    "enumStrings":  "Undefined,Airplane/FixedWing,Helicopter/Multirrotor,Gyroplane,VTOL,Ornithopter,Glider,Kite,Free Ballon,Captive Ballon,Airship,Parachute,Rocket,Tethered powered aircraft,Ground Obstacle,Other",
     "enumValues":   "0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15",
     "default":      0
 },
@@ -153,7 +153,7 @@
     "shortDesc":    "Category EU",
     "longDesc":     "Category of the UAS in the EU region",
     "type":         "uint8",
-    "enumStrings":  "Undeclared,Open, Specific, Certified",
+    "enumStrings":  "Undeclared,Open,Specific,Certified",
     "enumValues":   "0,1,2,3",
     "default":      0
 },
@@ -162,7 +162,7 @@
     "shortDesc":    "Class EU",
     "longDesc":     "Class of the UAS in the EU region",
     "type":         "uint8",
-    "enumStrings":  "Undeclared,Class 0, Class 1, Class 2, Class 3, Class 4, Class 5, Class 6",
+    "enumStrings":  "Undeclared,Class 0,Class 1,Class 2,Class 3,Class 4,Class 5,Class 6",
     "enumValues":   "0,1,2,3,4,5,6,7",
     "default":      0
 }


### PR DESCRIPTION
There were multiple problem here all star6ing from the fact the we had QLocale::Language ids stored in a json file. This is now set up in code such so that things don't get screwed up. Also added much more validation along the way that the right things are happening.

While testing this I discovered a number of problems with the Chinese json translations where the enum commands which changed to a Chinese char. Hence the string split for them was failing. Luckily most had already been fixed up in Crowdin and I just approved them And then fixed the missing ones.

Closes  #11541