### PR TITLE
QtLocationPlugin: Add QGeoFileTileCache Implementation

### DIFF
--- a/src/QtLocationPlugin/CMakeLists.txt
+++ b/src/QtLocationPlugin/CMakeLists.txt
@@ -29,6 +29,8 @@ qt_add_plugin(QGCLocation STATIC
     QGCTileCacheWorker.cpp
     QGCTileCacheWorker.h
     QGCTileSet.h
+    QGeoFileTileCacheQGC.cpp
+    QGeoFileTileCacheQGC.h
     QGeoMapReplyQGC.cpp
     QGeoMapReplyQGC.h
     QGeoServiceProviderPluginQGC.cpp

--- a/src/QtLocationPlugin/MapProvider.cpp
+++ b/src/QtLocationPlugin/MapProvider.cpp
@@ -131,3 +131,5 @@ QGCTileSet MapProvider::getTileCount(int zoom, double topleftLon,
     set.tileSize = getAverageSize() * set.tileCount;
     return set;
 }
+
+// Resolution math: https://wiki.openstreetmap.org/wiki/Slippy_map_tilenames#Resolution_and_Scale

--- a/src/QtLocationPlugin/QGCLocationPlugin.pri
+++ b/src/QtLocationPlugin/QGCLocationPlugin.pri
@@ -17,6 +17,7 @@ HEADERS += \
     $$PWD/QGCMapTileSet.h \
     $$PWD/QGCMapUrlEngine.h \
     $$PWD/QGCTileCacheWorker.h \
+    $$PWD/QGeoFileTileCacheQGC.h \
     $$PWD/QGeoMapReplyQGC.h \
     $$PWD/QGeoServiceProviderPluginQGC.h \
     $$PWD/QGeoTileFetcherQGC.h \
@@ -37,6 +38,7 @@ SOURCES += \
     $$PWD/QGCMapTileSet.cpp \
     $$PWD/QGCMapUrlEngine.cpp \
     $$PWD/QGCTileCacheWorker.cpp \
+    $$PWD/QGeoFileTileCacheQGC.cpp \
     $$PWD/QGeoMapReplyQGC.cpp \
     $$PWD/QGeoServiceProviderPluginQGC.cpp \
     $$PWD/QGeoTileFetcherQGC.cpp \

--- a/src/QtLocationPlugin/QGCMapEngine.cpp
+++ b/src/QtLocationPlugin/QGCMapEngine.cpp
@@ -15,260 +15,156 @@
  *   @author Gus Grubba <gus@auterion.com>
  *
  */
-#include "QGCApplication.h"
-#include "AppSettings.h"
-#include "MapsSettings.h"
-#include "SettingsManager.h"
 #include "QGCMapEngine.h"
 #include "QGCMapTileSet.h"
-#include "QGCMapUrlEngine.h"
 #include "QGCTileCacheWorker.h"
+#include "QGeoFileTileCacheQGC.h"
+#include "QGCMapEngineData.h"
+#include "QGCApplication.h"
+#include <QGCLoggingCategory.h>
 
 #include <QtCore/qapplicationstatic.h>
 #include <QtCore/QStandardPaths>
 #include <QtCore/QDir>
 
-Q_DECLARE_METATYPE(QGCMapTask::TaskType)
-Q_DECLARE_METATYPE(QGCTile)
+#define CACHE_PATH_VERSION "300"
+
+QGC_LOGGING_CATEGORY(QGCMapEngineLog, "qgc.qtlocationplugin.qgcmapengine")
+
 Q_DECLARE_METATYPE(QList<QGCTile*>)
 
-static QLocale kLocale;
-
-#define CACHE_PATH_VERSION  "300"
-
-struct stQGeoTileCacheQGCMapTypes {
-    const char* name;
-    QString type;
-};
-
-//-----------------------------------------------------------------------------
-
 Q_APPLICATION_STATIC(QGCMapEngine, s_mapEngine);
-
-QGCMapEngine* QGCMapEngine::instance()
-{
-    return s_mapEngine();
-}
 
 QGCMapEngine* getQGCMapEngine()
 {
     return QGCMapEngine::instance();
 }
 
-//-----------------------------------------------------------------------------
-QGCMapEngine::QGCMapEngine(QObject* parent)
-    : QObject(parent)
-    , _worker(new QGCCacheWorker(this))
-    , _prunning(false)
-    , _cacheWasReset(false)
+QGCMapEngine* QGCMapEngine::instance()
 {
-    // qCDebug(QGeoTiledMappingManagerEngineQGCLog) << Q_FUNC_INFO << this;
-
-    qRegisterMetaType<QGCMapTask::TaskType>();
-    qRegisterMetaType<QGCTile>();
-    qRegisterMetaType<QList<QGCTile*>>();
-    connect(_worker, &QGCCacheWorker::updateTotals,   this, &QGCMapEngine::_updateTotals);
+    return s_mapEngine();
 }
 
-//-----------------------------------------------------------------------------
+QGCMapEngine::QGCMapEngine(QObject *parent)
+    : QObject(parent)
+    , m_worker(new QGCCacheWorker(this))
+{
+    // qCDebug(QGCMapEngineLog) << Q_FUNC_INFO << this;
+
+    (void) qRegisterMetaType<QGCMapTask::TaskType>();
+    (void) qRegisterMetaType<QGCTile>();
+    (void) qRegisterMetaType<QList<QGCTile*>>();
+
+    (void) connect(m_worker, &QGCCacheWorker::updateTotals, this, &QGCMapEngine::_updateTotals);
+}
+
 QGCMapEngine::~QGCMapEngine()
 {
-    (void) disconnect(_worker);
-    _worker->quit();
-    _worker->wait();
+    (void) disconnect(m_worker);
+    m_worker->quit();
+    m_worker->wait();
 
-    // qCDebug(QGeoTiledMappingManagerEngineQGCLog) << Q_FUNC_INFO << this;
+    // qCDebug(QGCMapEngineLog) << Q_FUNC_INFO << this;
 }
 
-//-----------------------------------------------------------------------------
-void
-QGCMapEngine::_checkWipeDirectory(const QString& dirPath)
+void QGCMapEngine::init()
 {
-    QDir dir(dirPath);
-    if (dir.exists(dirPath)) {
-        _cacheWasReset = true;
-        _wipeDirectory(dirPath);
-    }
-}
-
-//-----------------------------------------------------------------------------
-void
-QGCMapEngine::_wipeOldCaches()
-{
-    QString oldCacheDir;
-#ifdef __mobile__
-    oldCacheDir = QStandardPaths::writableLocation(QStandardPaths::AppDataLocation)      + QLatin1String("/QGCMapCache55");
-#else
-    oldCacheDir = QStandardPaths::writableLocation(QStandardPaths::GenericCacheLocation) + QStringLiteral("/QGCMapCache55");
-#endif
-    _checkWipeDirectory(oldCacheDir);
-#ifdef __mobile__
-    oldCacheDir = QStandardPaths::writableLocation(QStandardPaths::AppDataLocation)      + QLatin1String("/QGCMapCache100");
-#else
-    oldCacheDir = QStandardPaths::writableLocation(QStandardPaths::GenericCacheLocation) + QStringLiteral("/QGCMapCache100");
-#endif
-    _checkWipeDirectory(oldCacheDir);
-}
-
-//-----------------------------------------------------------------------------
-void
-QGCMapEngine::init()
-{
-    //-- Delete old style caches (if present)
     _wipeOldCaches();
-    //-- Figure out cache path
+
+    // QString cacheDir = QAbstractGeoTileCache::baseCacheDirectory()
 #ifdef __mobile__
-    QString cacheDir = QStandardPaths::writableLocation(QStandardPaths::AppDataLocation)      + QLatin1String("/QGCMapCache" CACHE_PATH_VERSION);
+    QString cacheDir = QStandardPaths::writableLocation(QStandardPaths::AppDataLocation);
 #else
-    QString cacheDir = QStandardPaths::writableLocation(QStandardPaths::GenericCacheLocation) + QStringLiteral("/QGCMapCache" CACHE_PATH_VERSION);
+    QString cacheDir = QStandardPaths::writableLocation(QStandardPaths::GenericCacheLocation);
 #endif
-    if(!QDir::root().mkpath(cacheDir)) {
-        qWarning() << "Could not create mapping disk cache directory: " << cacheDir;
+    cacheDir += QStringLiteral("/QGCMapCache" CACHE_PATH_VERSION);
+    if (!QDir::root().mkpath(cacheDir)) {
+        qCWarning(QGCMapEngineLog) << "Could not create mapping disk cache directory:" << cacheDir;
+
         cacheDir = QDir::homePath() + QStringLiteral("/.qgcmapscache/");
-        if(!QDir::root().mkpath(cacheDir)) {
-            qWarning() << "Could not create mapping disk cache directory: " << cacheDir;
+        if (!QDir::root().mkpath(cacheDir)) {
+            qCWarning(QGCMapEngineLog) << "Could not create mapping disk cache directory:" << cacheDir;
             cacheDir.clear();
         }
     }
-    _cachePath = cacheDir;
-    if(!_cachePath.isEmpty()) {
-        _cacheFile = kDbFileName;
-        _worker->setDatabaseFile(_cachePath + "/" + _cacheFile);
-        qDebug() << "Map Cache in:" << _cachePath << "/" << _cacheFile;
+
+    m_cachePath = cacheDir;
+    if (!m_cachePath.isEmpty()) {
+        const QString databaseFilePath(m_cachePath + "/" + QGeoFileTileCacheQGC::getCacheFilename());
+        m_worker->setDatabaseFile(databaseFilePath);
+
+        qCDebug(QGCMapEngineLog) << "Map Cache in:" << databaseFilePath;
     } else {
-        qCritical() << "Could not find suitable map cache directory.";
+        qCCritical(QGCMapEngineLog) << "Could not find suitable map cache directory.";
     }
-    QGCMapTask* task = new QGCMapTask(QGCMapTask::taskInit);
-    _worker->enqueueTask(task);
+
+    QGCMapTask* const task = new QGCMapTask(QGCMapTask::taskInit);
+    (void) addTask(task);
+
+    if (m_cacheWasReset) {
+        qgcApp()->showAppMessage(tr(
+            "The Offline Map Cache database has been upgraded. "
+            "Your old map cache sets have been reset."));
+    }
 }
 
-//-----------------------------------------------------------------------------
-bool
-QGCMapEngine::_wipeDirectory(const QString& dirPath)
+bool QGCMapEngine::addTask(QGCMapTask *task)
+{
+    return m_worker->enqueueTask(task);
+}
+
+bool QGCMapEngine::_wipeDirectory(const QString &dirPath)
 {
     bool result = true;
-    QDir dir(dirPath);
+
+    const QDir dir(dirPath);
     if (dir.exists(dirPath)) {
-        Q_FOREACH(QFileInfo info, dir.entryInfoList(QDir::NoDotAndDotDot | QDir::System | QDir::Hidden  | QDir::AllDirs | QDir::Files, QDir::DirsFirst)) {
+        m_cacheWasReset = true;
+
+        const QFileInfoList fileList = dir.entryInfoList(QDir::NoDotAndDotDot | QDir::System | QDir::Hidden | QDir::AllDirs | QDir::Files, QDir::DirsFirst);
+        for (const QFileInfo &info : fileList) {
             if (info.isDir()) {
                 result = _wipeDirectory(info.absoluteFilePath());
             } else {
                 result = QFile::remove(info.absoluteFilePath());
             }
+
             if (!result) {
                 return result;
             }
         }
         result = dir.rmdir(dirPath);
     }
+
     return result;
 }
 
-//-----------------------------------------------------------------------------
-void
-QGCMapEngine::addTask(QGCMapTask* task)
+void QGCMapEngine::_wipeOldCaches()
 {
-    _worker->enqueueTask(task);
-}
-
-//-----------------------------------------------------------------------------
-void
-QGCMapEngine::cacheTile(const QString& type, int x, int y, int z, const QByteArray& image, const QString &format, qulonglong set)
-{
-    QString hash = getTileHash(type, x, y, z);
-    cacheTile(type, hash, image, format, set);
-}
-
-//-----------------------------------------------------------------------------
-void
-QGCMapEngine::cacheTile(const QString& type, const QString& hash, const QByteArray& image, const QString& format, qulonglong set)
-{
-    AppSettings* appSettings = qgcApp()->toolbox()->settingsManager()->appSettings();
-    //-- If we are allowed to persist data, save tile to cache
-    if(!appSettings->disableAllPersistence()->rawValue().toBool()) {
-        QGCSaveTileTask* task = new QGCSaveTileTask(new QGCCacheTile(hash, image, format, type, set));
-        _worker->enqueueTask(task);
+    const QStringList oldCaches = {"/QGCMapCache55", "/QGCMapCache100"};
+    for (const QString &cache : oldCaches) {
+        QString oldCacheDir;
+        #ifdef __mobile__
+            oldCacheDir = QStandardPaths::writableLocation(QStandardPaths::AppDataLocation);
+        #else
+            oldCacheDir = QStandardPaths::writableLocation(QStandardPaths::GenericCacheLocation);
+        #endif
+        oldCacheDir += cache;
+        _wipeDirectory(oldCacheDir);
     }
 }
 
-//-----------------------------------------------------------------------------
-QString
-QGCMapEngine::getTileHash(const QString& type, int x, int y, int z)
-{
-    int hash = UrlFactory::hashFromProviderType(type);
-    return QString::asprintf("%010d%08d%08d%03d", hash, x, y, z);
-}
-
-//-----------------------------------------------------------------------------
-QString
-QGCMapEngine::tileHashToType(const QString& tileHash)
-{
-    int providerHash = tileHash.mid(0,10).toInt();
-    return UrlFactory::providerTypeFromHash(providerHash);
-}
-
-//-----------------------------------------------------------------------------
-	QGCFetchTileTask*
-QGCMapEngine::createFetchTileTask(const QString& type, int x, int y, int z)
-{
-	QString hash = getTileHash(type, x, y, z);
-	QGCFetchTileTask* task = new QGCFetchTileTask(hash);
-	return task;
-}
-
-//-----------------------------------------------------------------------------
-	QGCTileSet
-QGCMapEngine::getTileCount(int zoom, double topleftLon, double topleftLat, double bottomRightLon, double bottomRightLat, const QString& mapType)
-{
-	if(zoom <  1) zoom = 1;
-	if(zoom > MAX_MAP_ZOOM) zoom = MAX_MAP_ZOOM;
-
-    return UrlFactory::getTileCount(zoom, topleftLon, topleftLat, bottomRightLon, bottomRightLat, mapType);
-}
-
-
-//-----------------------------------------------------------------------------
-QStringList
-QGCMapEngine::getMapNameList()
-{
-    return UrlFactory::getProviderTypes();
-}
-
-//-----------------------------------------------------------------------------
-quint32
-QGCMapEngine::getMaxDiskCache()
-{
-    return qgcApp()->toolbox()->settingsManager()->mapsSettings()->maxCacheDiskSize()->rawValue().toUInt();
-}
-
-//-----------------------------------------------------------------------------
-quint32
-QGCMapEngine::getMaxMemCache()
-{
-    return qgcApp()->toolbox()->settingsManager()->mapsSettings()->maxCacheMemorySize()->rawValue().toUInt();
-}
-
-//-----------------------------------------------------------------------------
-void
-QGCMapEngine::_updateTotals(quint32 totaltiles, quint64 totalsize, quint32 defaulttiles, quint64 defaultsize)
+void QGCMapEngine::_updateTotals(quint32 totaltiles, quint64 totalsize, quint32 defaulttiles, quint64 defaultsize)
 {
     emit updateTotals(totaltiles, totalsize, defaulttiles, defaultsize);
-    quint64 maxSize = static_cast<quint64>(getMaxDiskCache()) * 1024L * 1024L;
-    if(!_prunning && defaultsize > maxSize) {
-        //-- Prune Disk Cache
-        _prunning = true;
-        QGCPruneCacheTask* task = new QGCPruneCacheTask(defaultsize - maxSize);
-        connect(task, &QGCPruneCacheTask::pruned, this, &QGCMapEngine::_pruned);
-        addTask(task);
+
+    const quint64 maxSize = static_cast<quint64>(QGeoFileTileCacheQGC::getMaxDiskCacheSetting()) * pow(1024, 2);
+    if (!m_prunning && (defaultsize > maxSize)) {
+        m_prunning = true;
+
+        const quint64 amountToPrune = defaultsize - maxSize;
+        QGCPruneCacheTask* const task = new QGCPruneCacheTask(amountToPrune);
+        (void) connect(task, &QGCPruneCacheTask::pruned, this, &QGCMapEngine::_pruned);
+        (void) addTask(task);
     }
 }
-
-//-----------------------------------------------------------------------------
-QGCCreateTileSetTask::~QGCCreateTileSetTask()
-{
-    //-- If not sent out, delete it
-    if(!_saved && _tileSet)
-        delete _tileSet;
-}
-
-// Resolution math: https://wiki.openstreetmap.org/wiki/Slippy_map_tilenames#Resolution_and_Scale

--- a/src/QtLocationPlugin/QGCMapEngine.h
+++ b/src/QtLocationPlugin/QGCMapEngine.h
@@ -18,62 +18,45 @@
 
 #pragma once
 
-#include "QGCMapEngineData.h"
-#include "QGCTileSet.h"
-
 #include <QtCore/QString>
+#include <QtCore/QObject>
+#include <QtCore/QLoggingCategory>
 
-class UrlFactory;
+Q_DECLARE_LOGGING_CATEGORY(QGCMapEngineLog)
+
+class QGCMapTask;
 class QGCCacheWorker;
 
-//-----------------------------------------------------------------------------
 class QGCMapEngine : public QObject
 {
     Q_OBJECT
+
 public:
-    QGCMapEngine(QObject* parent = nullptr);
-    ~QGCMapEngine               ();
+    QGCMapEngine(QObject *parent = nullptr);
+    ~QGCMapEngine();
+
+    void init();
+    bool addTask(QGCMapTask *task);
+
+    QString getCachePath() const { return m_cachePath; }
 
     static QGCMapEngine* instance();
 
-    void                        init                ();
-    void                        addTask             (QGCMapTask *task);
-    void                        cacheTile           (const QString& type, int x, int y, int z, const QByteArray& image, const QString& format, qulonglong set = UINT64_MAX);
-    void                        cacheTile           (const QString& type, const QString& hash, const QByteArray& image, const QString& format, qulonglong set = UINT64_MAX);
-    static QGCFetchTileTask*    createFetchTileTask (const QString& type, int x, int y, int z);
-    static QStringList          getMapNameList      ();
-    static QString              tileHashToType      (const QString& tileHash);
-    static QString              getTileHash         (const QString& type, int x, int y, int z);
-    static quint32              getMaxDiskCache     ();
-    static quint32              getMaxMemCache      ();
-    const QString               getCachePath        () { return _cachePath; }
-    const QString               getCacheFilename    () { return _cacheFile; }
-    bool                        wasCacheReset       () const{ return _cacheWasReset; }
-
-    //-- Tile Math
-    static QGCTileSet           getTileCount        (int zoom, double topleftLon, double topleftLat, double bottomRightLon, double bottomRightLat, const QString& mapType);
-    static QString              getTypeFromName     (const QString& name);
+signals:
+    void updateTotals(quint32 totaltiles, quint64 totalsize, quint32 defaulttiles, quint64 defaultsize);
 
 private slots:
-    void _updateTotals          (quint32 totaltiles, quint64 totalsize, quint32 defaulttiles, quint64 defaultsize);
-    void _pruned                () { _prunning = false; }
-
-signals:
-    void updateTotals           (quint32 totaltiles, quint64 totalsize, quint32 defaulttiles, quint64 defaultsize);
+    void _updateTotals(quint32 totaltiles, quint64 totalsize, quint32 defaulttiles, quint64 defaultsize);
+    void _pruned() { m_prunning = false; }
 
 private:
-    void _wipeOldCaches         ();
-    void _checkWipeDirectory    (const QString& dirPath);
-    bool _wipeDirectory         (const QString& dirPath);
+    bool _wipeDirectory(const QString &dirPath);
+    void _wipeOldCaches();
 
-private:
-    QGCCacheWorker*         _worker = nullptr;
-    bool                    _prunning;
-    bool                    _cacheWasReset;
-    QString                 _cachePath;
-    QString                 _cacheFile;
-
-    static constexpr const char* kDbFileName = "qgcMapCache.db";
+    QGCCacheWorker *m_worker = nullptr;
+    bool m_prunning = false;
+    bool m_cacheWasReset = false;
+    QString m_cachePath;
 };
 
-extern QGCMapEngine*    getQGCMapEngine();
+QGCMapEngine* getQGCMapEngine();

--- a/src/QtLocationPlugin/QGCMapEngineData.h
+++ b/src/QtLocationPlugin/QGCMapEngineData.h
@@ -20,8 +20,9 @@
 
 #include <QtCore/QObject>
 #include <QtCore/QString>
+#include <QtCore/QMetaType>
 
-class QGCCachedTileSet;
+#include "QGCMapTileSet.h"
 
 //-----------------------------------------------------------------------------
 class QGCTile
@@ -65,6 +66,7 @@ private:
     QString     _hash;
     QString _type;
 };
+Q_DECLARE_METATYPE(QGCTile)
 
 //-----------------------------------------------------------------------------
 class QGCCacheTile : public QObject
@@ -138,6 +140,7 @@ signals:
 private:
     TaskType    _type;
 };
+Q_DECLARE_METATYPE(QGCMapTask::TaskType)
 
 //-----------------------------------------------------------------------------
 class QGCFetchTileSetTask : public QGCMapTask
@@ -168,7 +171,12 @@ public:
         , _saved(false)
     {}
 
-    ~QGCCreateTileSetTask();
+    ~QGCCreateTileSetTask()
+    {
+        //-- If not sent out, delete it
+        if(!_saved && _tileSet)
+            delete _tileSet;
+    }
 
     QGCCachedTileSet*   tileSet () { return _tileSet; }
 

--- a/src/QtLocationPlugin/QGCMapTileSet.h
+++ b/src/QtLocationPlugin/QGCMapTileSet.h
@@ -18,8 +18,6 @@
 
 #pragma once
 
-#include "QGCMapEngineData.h"
-
 #include <QtCore/QObject>
 #include <QtCore/QString>
 #include <QtCore/QDateTime>

--- a/src/QtLocationPlugin/QGCMapUrlEngine.cpp
+++ b/src/QtLocationPlugin/QGCMapUrlEngine.cpp
@@ -255,3 +255,15 @@ int UrlFactory::hashFromProviderType(QStringView type)
 {
     return static_cast<int>(qHash(type) >> 1);
 }
+
+QString UrlFactory::tileHashToType(QStringView tileHash)
+{
+    const int providerHash = tileHash.mid(0,10).toInt();
+    return providerTypeFromHash(providerHash);
+}
+
+QString UrlFactory::getTileHash(QStringView type, int x, int y, int z)
+{
+    const int hash = hashFromProviderType(type);
+    return QString::asprintf("%010d%08d%08d%03d", hash, x, y, z);
+}

--- a/src/QtLocationPlugin/QGCMapUrlEngine.h
+++ b/src/QtLocationPlugin/QGCMapUrlEngine.h
@@ -55,6 +55,8 @@ public:
     static QString providerTypeFromHash(int hash);
 
     static int hashFromProviderType(QStringView type);
+    static QString tileHashToType(QStringView tileHash);
+    static QString getTileHash(QStringView type, int x, int y, int z);
 
     static constexpr const char* kCopernicusElevationProviderKey = "Copernicus Elevation";
     static constexpr const char* kCopernicusElevationProviderNotice = "© Airbus Defence and Space GmbH";

--- a/src/QtLocationPlugin/QGCTileCacheWorker.cpp
+++ b/src/QtLocationPlugin/QGCTileCacheWorker.cpp
@@ -20,6 +20,7 @@
 #include "QGCMapEngine.h"
 #include "QGCMapTileSet.h"
 #include "QGCMapUrlEngine.h"
+#include "QGCMapEngineData.h"
 #include "QGCLoggingCategory.h"
 
 #include <QtSql/QSqlQuery>
@@ -506,14 +507,14 @@ QGCCacheWorker::_createTileSet(QGCMapTask *mtask)
             //-- Prepare Download List
             _db->transaction();
             for(int z = task->tileSet()->minZoom(); z <= task->tileSet()->maxZoom(); z++) {
-                QGCTileSet set = QGCMapEngine::getTileCount(z,
+                QGCTileSet set = UrlFactory::getTileCount(z,
                     task->tileSet()->topleftLon(), task->tileSet()->topleftLat(),
                     task->tileSet()->bottomRightLon(), task->tileSet()->bottomRightLat(), task->tileSet()->type());
                 QString type = task->tileSet()->type();
                 for(int x = set.tileX0; x <= set.tileX1; x++) {
                     for(int y = set.tileY0; y <= set.tileY1; y++) {
                         //-- See if tile is already downloaded
-                        QString hash = QGCMapEngine::getTileHash(type, x, y, z);
+                        QString hash = UrlFactory::getTileHash(type, x, y, z);
                         quint64 tileID = _findTile(hash);
                         if(!tileID) {
                             //-- Set to download

--- a/src/QtLocationPlugin/QGeoFileTileCacheQGC.cpp
+++ b/src/QtLocationPlugin/QGeoFileTileCacheQGC.cpp
@@ -1,0 +1,124 @@
+#include "QGeoFileTileCacheQGC.h"
+#include "QGCMapEngine.h"
+#include "QGCApplication.h"
+#include "QGCToolbox.h"
+#include "SettingsManager.h"
+#include "MapsSettings.h"
+#include "QGCMapUrlEngine.h"
+#include "QGCMapEngineData.h"
+#include <QGCLoggingCategory.h>
+
+#include <QtCore/QStandardPaths>
+#include <QtCore/QLoggingCategory>
+#include <QtCore/QDir>
+
+QGC_LOGGING_CATEGORY(QGeoFileTileCacheQGCLog, "qgc.qtlocationplugin.qgeofiletilecacheqgc")
+
+QGeoFileTileCacheQGC::QGeoFileTileCacheQGC(const QVariantMap &parameters, QObject *parent)
+    : QGeoFileTileCache(_getCachePath(parameters), parent)
+{
+    // qCDebug(QGeoFileTileCacheQGCLog) << Q_FUNC_INFO << this;
+
+    setCostStrategyDisk(QGeoFileTileCache::ByteSize);
+    setMaxDiskUsage(_getDefaultMaxDiskCache());
+    setCostStrategyMemory(QGeoFileTileCache::ByteSize);
+    setMaxMemoryUsage(_getMemLimit(parameters));
+    setCostStrategyTexture(QGeoFileTileCache::ByteSize);
+    setMinTextureUsage(_getDefaultMinTexture());
+    setExtraTextureUsage(_getDefaultExtraTexture() - minTextureUsage());
+}
+
+QGeoFileTileCacheQGC::~QGeoFileTileCacheQGC()
+{
+    // printStats();
+
+    // qCDebug(QGeoFileTileCacheQGCLog) << Q_FUNC_INFO << this;
+}
+
+QString QGeoFileTileCacheQGC::_getCachePath(const QVariantMap &parameters)
+{
+    QString cacheDir;
+    if (parameters.contains(QStringLiteral("mapping.cache.directory"))) {
+        cacheDir = parameters.value(QStringLiteral("mapping.cache.directory")).toString();
+    } else {
+        cacheDir = getQGCMapEngine()->getCachePath() + QLatin1String("/providers");
+        if (!QFileInfo::exists(cacheDir)) {
+            if (!QDir::root().mkpath(cacheDir)) {
+                qCWarning(QGeoFileTileCacheQGCLog) << "Could not create mapping disk cache directory:" << cacheDir;
+                cacheDir = QDir::homePath() + QStringLiteral("/.qgcmapscache/");
+            }
+        }
+    }
+
+    if (!QFileInfo::exists(cacheDir)) {
+        if (!QDir::root().mkpath(cacheDir)) {
+            qCWarning(QGeoFileTileCacheQGCLog) << "Could not create mapping disk cache directory:" << cacheDir;
+            cacheDir.clear();
+        }
+    }
+
+    return cacheDir;
+}
+
+uint32_t QGeoFileTileCacheQGC::_getMemLimit(const QVariantMap &parameters)
+{
+    uint32_t memLimit = 0;
+    if (parameters.contains(QStringLiteral("mapping.cache.memory.size"))) {
+        bool ok = false;
+        memLimit = parameters.value(QStringLiteral("mapping.cache.memory.size")).toString().toUInt(&ok);
+        if (!ok) {
+            memLimit = 0;
+        }
+    }
+
+    if (memLimit == 0) {
+        // Value saved in MB
+        memLimit = _getMaxMemCacheSetting() * pow(1024, 2);
+    }
+    if (memLimit == 0) {
+        memLimit = _getDefaultMaxMemLimit();
+    }
+    // 1MB Minimum Memory Cache Required
+    if (memLimit < pow(1024, 2)) {
+        memLimit = pow(1024, 2);
+    }
+    // MaxMemoryUsage is 32bit Integer, Round down to 1GB
+    if (memLimit > pow(1024, 3)) {
+        memLimit = pow(1024, 3);
+    }
+
+    return memLimit;
+}
+
+quint32 QGeoFileTileCacheQGC::_getMaxMemCacheSetting()
+{
+    return qgcApp()->toolbox()->settingsManager()->mapsSettings()->maxCacheMemorySize()->rawValue().toUInt();
+}
+
+quint32 QGeoFileTileCacheQGC::getMaxDiskCacheSetting()
+{
+    return qgcApp()->toolbox()->settingsManager()->mapsSettings()->maxCacheDiskSize()->rawValue().toUInt();
+}
+
+void QGeoFileTileCacheQGC::cacheTile(const QString &type, int x, int y, int z, const QByteArray &image, const QString &format, qulonglong set)
+{
+    const QString hash = UrlFactory::getTileHash(type, x, y, z);
+    cacheTile(type, hash, image, format, set);
+}
+
+void QGeoFileTileCacheQGC::cacheTile(const QString &type, const QString &hash, const QByteArray &image, const QString &format, qulonglong set)
+{
+    AppSettings* const appSettings = qgcApp()->toolbox()->settingsManager()->appSettings();
+    if (!appSettings->disableAllPersistence()->rawValue().toBool()) {
+        QGCCacheTile* const tile = new QGCCacheTile(hash, image, format, type, set);
+        QGCSaveTileTask* const task = new QGCSaveTileTask(tile);
+        (void) getQGCMapEngine()->addTask(task);
+    }
+}
+
+QGCFetchTileTask* QGeoFileTileCacheQGC::createFetchTileTask(const QString &type, int x, int y, int z)
+{
+    const QString hash = UrlFactory::getTileHash(type, x, y, z);
+    QGCFetchTileTask* const task = new QGCFetchTileTask(hash);
+    return task;
+}

--- a/src/QtLocationPlugin/QGeoFileTileCacheQGC.h
+++ b/src/QtLocationPlugin/QGeoFileTileCacheQGC.h
@@ -1,0 +1,37 @@
+#pragma once
+
+#include <QtLocation/private/qgeofiletilecache_p.h>
+#include <QtCore/QLoggingCategory>
+
+Q_DECLARE_LOGGING_CATEGORY(QGeoFileTileCacheQGCLog)
+
+class QGCFetchTileTask;
+
+class QGeoFileTileCacheQGC : public QGeoFileTileCache
+{
+    Q_OBJECT
+
+public:
+    explicit QGeoFileTileCacheQGC(const QVariantMap &parameters, QObject *parent = nullptr);
+    ~QGeoFileTileCacheQGC();
+
+    static quint32 getMaxDiskCacheSetting();
+    static void cacheTile(const QString &type, int x, int y, int z, const QByteArray &image, const QString &format, qulonglong set = UINT64_MAX);
+    static void cacheTile(const QString &type, const QString &hash, const QByteArray &image, const QString &format, qulonglong set = UINT64_MAX);
+    static QGCFetchTileTask* createFetchTileTask (const QString &type, int x, int y, int z);
+    static QString getCacheFilename() { return QStringLiteral("qgcMapCache.db"); }
+
+private:
+    // QString tileSpecToFilename(const QGeoTileSpec &spec, const QString &format, const QString &directory) const final;
+    // QGeoTileSpec filenameToTileSpec(const QString &filename) const final;
+
+    static QString _getCachePath(const QVariantMap &parameters);
+    static uint32_t _getMemLimit(const QVariantMap &Parameters);
+
+    static uint32_t _getDefaultMaxMemLimit() { return (3 * pow(1024, 2)); }
+    static uint32_t _getDefaultMaxDiskCache() { return 0; /*(50 * pow(1024, 2));*/ }
+    static uint32_t _getDefaultExtraTexture() { return (6 * pow(1024, 2)); }
+    static uint32_t _getDefaultMinTexture() { return 0; }
+
+    static quint32 _getMaxMemCacheSetting();
+};

--- a/src/QtLocationPlugin/QGeoMapReplyQGC.cpp
+++ b/src/QtLocationPlugin/QGeoMapReplyQGC.cpp
@@ -44,8 +44,9 @@
 **
 ****************************************************************************/
 
-#include "QGCMapEngine.h"
 #include "QGeoMapReplyQGC.h"
+#include "QGCMapEngine.h"
+#include "QGeoFileTileCacheQGC.h"
 #include "TerrainTile.h"
 #include "MapProvider.h"
 #include "QGCMapUrlEngine.h"
@@ -83,10 +84,10 @@ QGeoTiledMapReplyQGC::QGeoTiledMapReplyQGC(QNetworkAccessManager *networkManager
         setFinished(true);
         setCached(false);
     } else {
-        QGCFetchTileTask* task = QGCMapEngine::createFetchTileTask(UrlFactory::getProviderTypeFromQtMapId(spec.mapId()), spec.x(), spec.y(), spec.zoom());
+        QGCFetchTileTask* task = QGeoFileTileCacheQGC::createFetchTileTask(UrlFactory::getProviderTypeFromQtMapId(spec.mapId()), spec.x(), spec.y(), spec.zoom());
         connect(task, &QGCFetchTileTask::tileFetched, this, &QGeoTiledMapReplyQGC::cacheReply);
         connect(task, &QGCMapTask::error, this, &QGeoTiledMapReplyQGC::cacheError);
-        getQGCMapEngine()->addTask(task);
+        (void) getQGCMapEngine()->addTask(task);
     }
 }
 
@@ -138,7 +139,7 @@ QGeoTiledMapReplyQGC::networkReplyFinished()
         a = TerrainTile::serializeFromAirMapJson(a);
         //-- Cache it if valid
         if(!a.isEmpty()) {
-            getQGCMapEngine()->cacheTile(
+            QGeoFileTileCacheQGC::cacheTile(
                 UrlFactory::getProviderTypeFromQtMapId(
                     tileSpec().mapId()),
                 tileSpec().x(), tileSpec().y(), tileSpec().zoom(), a, format);
@@ -157,7 +158,7 @@ QGeoTiledMapReplyQGC::networkReplyFinished()
             setMapImageData(a);
             if(!format.isEmpty()) {
                 setMapImageFormat(format);
-                getQGCMapEngine()->cacheTile(UrlFactory::getProviderTypeFromQtMapId(tileSpec().mapId()), tileSpec().x(), tileSpec().y(), tileSpec().zoom(), a, format);
+                QGeoFileTileCacheQGC::cacheTile(UrlFactory::getProviderTypeFromQtMapId(tileSpec().mapId()), tileSpec().x(), tileSpec().y(), tileSpec().zoom(), a, format);
             }
         }
         setFinished(true);

--- a/src/QtLocationPlugin/QGeoTileFetcherQGC.cpp
+++ b/src/QtLocationPlugin/QGeoTileFetcherQGC.cpp
@@ -1,23 +1,34 @@
 #include "QGeoTileFetcherQGC.h"
 #include "QGeoTiledMappingManagerEngineQGC.h"
-#include "QGCMapEngine.h"
 #include "QGeoMapReplyQGC.h"
 #include "QGCMapUrlEngine.h"
 #include "MapProvider.h"
-#include <DeviceInfo.h>
 #include <QGCLoggingCategory.h>
 
 #include <QtNetwork/QNetworkRequest>
+// #include <QtNetwork/QNetworkDiskCache>
 #include <QtLocation/private/qgeotilespec_p.h>
 #include <QtLocation/private/qgeotiledmappingmanagerengine_p.h>
 
 QGC_LOGGING_CATEGORY(QGeoTileFetcherQGCLog, "qgc.qtlocationplugin.qgeotilefetcherqgc")
 
-QGeoTileFetcherQGC::QGeoTileFetcherQGC(QNetworkAccessManager *networkManager, QGeoTiledMappingManagerEngineQGC *parent)
+QGeoTileFetcherQGC::QGeoTileFetcherQGC(QNetworkAccessManager *networkManager, const QVariantMap &parameters, QGeoTiledMappingManagerEngineQGC *parent)
     : QGeoTileFetcher(parent)
     , m_networkManager(networkManager)
+    // , m_diskCache(new QNetworkDiskCache(this))
 {
     // qCDebug(QGeoTileFetcherQGCLog) << Q_FUNC_INFO << this;
+
+    // TODO: Allow useragent override again
+    /*if (parameters.contains(QStringLiteral("useragent"))) {
+        setUserAgent(parameters.value(QStringLiteral("useragent")).toString().toLatin1());
+    }*/
+
+    /*if (networkManager) {
+        m_diskCache->setCacheDirectory(directory() + "/Downloads");
+        m_diskCache->setMaximumCacheSize(static_cast<qint64>(_getDefaultMaxDiskCache()));
+        networkManager->setCache(m_diskCache);
+    }*/
 }
 
 QGeoTileFetcherQGC::~QGeoTileFetcherQGC()
@@ -51,7 +62,7 @@ bool QGeoTileFetcherQGC::initialized() const
 
 bool QGeoTileFetcherQGC::fetchingEnabled() const
 {
-    return initialized(); // QGCDeviceInfo::isInternetAvailable();
+    return initialized();
 }
 
 void QGeoTileFetcherQGC::timerEvent(QTimerEvent *event)

--- a/src/QtLocationPlugin/QGeoTileFetcherQGC.h
+++ b/src/QtLocationPlugin/QGeoTileFetcherQGC.h
@@ -10,13 +10,14 @@ class QGeoTiledMappingManagerEngineQGC;
 class QGeoTiledMapReplyQGC;
 class QGeoTileSpec;
 class QNetworkAccessManager;
+class QNetworkDiskCache;
 
 class QGeoTileFetcherQGC : public QGeoTileFetcher
 {
     Q_OBJECT
 
 public:
-    explicit QGeoTileFetcherQGC(QNetworkAccessManager *networkManager, QGeoTiledMappingManagerEngineQGC *parent = nullptr);
+    QGeoTileFetcherQGC(QNetworkAccessManager *networkManager, const QVariantMap &parameters, QGeoTiledMappingManagerEngineQGC *parent = nullptr);
     ~QGeoTileFetcherQGC();
 
     static uint32_t concurrentDownloads(const QString &type) { Q_UNUSED(type); return 6; }
@@ -29,6 +30,7 @@ private:
     void handleReply(QGeoTiledMapReply *reply, const QGeoTileSpec &spec) final;
 
     QNetworkAccessManager *m_networkManager = nullptr;
+    // QNetworkDiskCache *m_diskCache = nullptr;
 
 #if defined Q_OS_MAC
     static constexpr const char* s_userAgent = "Mozilla/5.0 (Macintosh; Intel Mac OS X 14.5; rv:125.0) Gecko/20100101 Firefox/125.0";

--- a/src/QtLocationPlugin/QGeoTiledMappingManagerEngineQGC.cpp
+++ b/src/QtLocationPlugin/QGeoTiledMappingManagerEngineQGC.cpp
@@ -2,6 +2,7 @@
 #include "QGCApplication.h"
 #include "QGCMapEngine.h"
 #include "QGeoTileFetcherQGC.h"
+#include "QGeoFileTileCacheQGC.h"
 #include "QGeoTiledMapQGC.h"
 #include "QGCMapUrlEngine.h"
 #include "MapProvider.h"
@@ -65,88 +66,26 @@ QGeoTiledMappingManagerEngineQGC::QGeoTiledMappingManagerEngineQGC(const QVarian
     setSupportedMapTypes(mapList);
 
     setCacheHint(QAbstractGeoTileCache::CacheArea::AllCaches);
-    _setCache(parameters);
+    QGeoFileTileCacheQGC* const fileTileCache = new QGeoFileTileCacheQGC(parameters);
+    setTileCache(fileTileCache);
 
     m_prefetchStyle = QGeoTiledMap::PrefetchTwoNeighbourLayers;
 
     *error = QGeoServiceProvider::NoError;
     errorString->clear();
 
-     QGeoTileFetcherQGC* const tileFetcher = new QGeoTileFetcherQGC(m_networkManager, this);
-    // TODO: Allow useragent override again
-    /*if (parameters.contains(QStringLiteral("useragent"))) {
-        tileFetcher()->setUserAgent(parameters.value(QStringLiteral("useragent")).toString().toLatin1());
-    }*/
-    setTileFetcher(tileFetcher); /* Calls engineInitialized */
+    QGeoTileFetcherQGC* const tileFetcher = new QGeoTileFetcherQGC(m_networkManager, parameters, this);
+    setTileFetcher(tileFetcher); // Calls engineInitialized
 }
 
 QGeoTiledMappingManagerEngineQGC::~QGeoTiledMappingManagerEngineQGC()
 {
-    qCDebug(QGeoTiledMappingManagerEngineQGCLog) << Q_FUNC_INFO << this;
+    // qCDebug(QGeoTiledMappingManagerEngineQGCLog) << Q_FUNC_INFO << this;
 }
 
 QGeoMap* QGeoTiledMappingManagerEngineQGC::createMap()
 {
-    QGeoTiledMapQGC* map = new QGeoTiledMapQGC(this, this);
+    QGeoTiledMapQGC* const map = new QGeoTiledMapQGC(this, this);
     map->setPrefetchStyle(m_prefetchStyle);
     return map;
-}
-
-void QGeoTiledMappingManagerEngineQGC::_setCache(const QVariantMap &parameters)
-{
-    if (getQGCMapEngine()->wasCacheReset()) {
-        qgcApp()->showAppMessage(tr("The Offline Map Cache database has been upgraded. "
-                    "Your old map cache sets have been reset."));
-    }
-
-    QString cacheDir;
-    if (parameters.contains(QStringLiteral("mapping.cache.directory"))) {
-        cacheDir = parameters.value(QStringLiteral("mapping.cache.directory")).toString();
-    } else {
-        cacheDir = getQGCMapEngine()->getCachePath();
-        if(!QFileInfo::exists(cacheDir)) {
-            if(!QDir::root().mkpath(cacheDir)) {
-                qWarning() << "Could not create mapping disk cache directory: " << cacheDir;
-                cacheDir = QDir::homePath() + QStringLiteral("/.qgcmapscache/");
-            }
-        }
-    }
-    if(!QFileInfo::exists(cacheDir)) {
-        if(!QDir::root().mkpath(cacheDir)) {
-            qWarning() << "Could not create mapping disk cache directory: " << cacheDir;
-            cacheDir.clear();
-        }
-    }
-    //-- Memory Cache
-    uint32_t memLimit = 0;
-    if (parameters.contains(QStringLiteral("mapping.cache.memory.size"))) {
-      bool ok = false;
-      memLimit = parameters.value(QStringLiteral("mapping.cache.memory.size")).toString().toUInt(&ok);
-      if (!ok) {
-          memLimit = 0;
-      }
-    }
-    if(!memLimit)
-    {
-        //-- Value saved in MB
-        memLimit = QGCMapEngine::getMaxMemCache() * (1024 * 1024);
-    }
-    //-- It won't work with less than 1M of memory cache
-    if(memLimit < 1024 * 1024) {
-        memLimit = 1024 * 1024;
-    }
-    //-- On the other hand, Qt uses signed 32-bit integers. Limit to 1G to round it down (you don't need more than that).
-    if(memLimit > 1024 * 1024 * 1024) {
-        memLimit = 1024 * 1024 * 1024;
-    }
-    //-- Disable Qt's disk cache (sort of)
-    QAbstractGeoTileCache *pTileCache = new QGeoFileTileCache(cacheDir);
-    setTileCache(pTileCache);
-    if(pTileCache) {
-        //-- We're basically telling it to use 100k of disk for cache. It doesn't like
-        //   values smaller than that and I could not find a way to make it NOT cache.
-        //   We handle our own disk caching elsewhere.
-        pTileCache->setMaxDiskUsage(1024 * 100);
-        pTileCache->setMaxMemoryUsage(memLimit);
-    }
 }

--- a/src/QtLocationPlugin/QGeoTiledMappingManagerEngineQGC.h
+++ b/src/QtLocationPlugin/QGeoTiledMappingManagerEngineQGC.h
@@ -21,6 +21,4 @@ public:
 
 private:
     QNetworkAccessManager *m_networkManager = nullptr;
-
-    void _setCache(const QVariantMap &parameters);
 };

--- a/src/Terrain/TerrainTileManager.cc
+++ b/src/Terrain/TerrainTileManager.cc
@@ -194,7 +194,7 @@ void TerrainTileManager::_terrainDone(QByteArray responseBytes, QNetworkReply::N
 
     // remove from download queue
     QGeoTileSpec spec = reply->tileSpec();
-    QString hash = QGCMapEngine::getTileHash(kMapType, spec.x(), spec.y(), spec.zoom());
+    QString hash = UrlFactory::getTileHash(kMapType, spec.x(), spec.y(), spec.zoom());
 
     // handle potential errors
     if (error != QNetworkReply::NoError) {
@@ -260,7 +260,7 @@ void TerrainTileManager::_terrainDone(QByteArray responseBytes, QNetworkReply::N
 
 QString TerrainTileManager::_getTileHash(const QGeoCoordinate& coordinate)
 {
-    QString ret = QGCMapEngine::getTileHash(
+    QString ret = UrlFactory::getTileHash(
         kMapType,
         UrlFactory::long2tileX(kMapType, coordinate.longitude(), 1),
         UrlFactory::lat2tileY(kMapType, coordinate.latitude(), 1),


### PR DESCRIPTION
Provides finer control over the caching and collects most of the cache related functions from the qgcmapengine giving better organization. Remaining qgcmapengine cache functions will be moved later, removing the class entirely. The QGeoTileFetcher/QGeoFileTileCache will be responsible for the TileCacheWorker. Then all mapping/caching related classes will be instantiated through the QGeoServiceProviderPlugin and be completely independent from the rest of the qgcApp making it easier to test independently.