### PR TITLE
Guided altitude changes use relative alt instead of offset

### DIFF
--- a/src/FirmwarePlugin/APM/APMFirmwarePlugin.cc
+++ b/src/FirmwarePlugin/APM/APMFirmwarePlugin.cc
@@ -838,20 +838,10 @@ void APMFirmwarePlugin::guidedModeRTL(Vehicle* vehicle, bool smartRTL)
     _setFlightModeAndValidate(vehicle, smartRTL ? smartRTLFlightMode() : rtlFlightMode());
 }
 
-void APMFirmwarePlugin::guidedModeChangeAltitude(Vehicle* vehicle, double altitudeChange, bool pauseVehicle)
+void APMFirmwarePlugin::guidedModeChangeAltitudeAMSL(Vehicle* vehicle, double altitudeAMSL, bool pauseVehicle)
 {
-    if (qIsNaN(vehicle->altitudeRelative()->rawValue().toDouble())) {
-        qgcApp()->showAppMessage(tr("Unable to change altitude, vehicle altitude not known."));
-        return;
-    }
-
     if (pauseVehicle && !_setFlightModeAndValidate(vehicle, pauseFlightMode())) {
         qgcApp()->showAppMessage(tr("Unable to pause vehicle."));
-        return;
-    }
-
-    if (abs(altitudeChange) < 0.01) {
-        // This prevents unecessary changes to Guided mode when the users selects pause and doesn't really touch the altitude slider
         return;
     }
 
@@ -866,11 +856,11 @@ void APMFirmwarePlugin::guidedModeChangeAltitude(Vehicle* vehicle, double altitu
 
         cmd.target_system    = static_cast<uint8_t>(vehicle->id());
         cmd.target_component = static_cast<uint8_t>(vehicle->defaultComponentId());
-        cmd.coordinate_frame = MAV_FRAME_LOCAL_OFFSET_NED;
+        cmd.coordinate_frame = MAV_FRAME_LOCAL_NED;
         cmd.type_mask = 0xFFF8; // Only x/y/z valid
         cmd.x = 0.0f;
         cmd.y = 0.0f;
-        cmd.z = static_cast<float>(-(altitudeChange));
+        cmd.z = static_cast<float>(-altitudeAMSL);
 
         MAVLinkProtocol* mavlink = qgcApp()->toolbox()->mavlinkProtocol();
         mavlink_msg_set_position_target_local_ned_encode_chan(

--- a/src/FirmwarePlugin/APM/APMFirmwarePlugin.h
+++ b/src/FirmwarePlugin/APM/APMFirmwarePlugin.h
@@ -65,7 +65,7 @@ public:
     QString             missionFlightMode               (void) const override { return QString("Auto"); }
     void                pauseVehicle                    (Vehicle* vehicle) override;
     void                guidedModeRTL                   (Vehicle* vehicle, bool smartRTL) override;
-    void                guidedModeChangeAltitude        (Vehicle* vehicle, double altitudeChange, bool pauseVehicle) override;
+    void                guidedModeChangeAltitudeAMSL    (Vehicle* vehicle, double altitudeAMSL, bool pauseVehicle) override;
     bool                adjustIncomingMavlinkMessage    (Vehicle* vehicle, mavlink_message_t* message) override;
     void                adjustOutgoingMavlinkMessageThreadSafe(Vehicle* vehicle, LinkInterface* outgoingLink, mavlink_message_t* message) override;
     virtual void        initializeStreamRates           (Vehicle* vehicle);

--- a/src/FirmwarePlugin/APM/ArduRoverFirmwarePlugin.cc
+++ b/src/FirmwarePlugin/APM/ArduRoverFirmwarePlugin.cc
@@ -72,7 +72,7 @@ int ArduRoverFirmwarePlugin::remapParamNameHigestMinorVersionNumber(int majorVer
     return majorVersionNumber == 3 ? 5 : Vehicle::versionNotSetValue;
 }
 
-void ArduRoverFirmwarePlugin::guidedModeChangeAltitude(Vehicle* /*vehicle*/, double /*altitudeChange*/, bool /*pauseVehicle*/)
+void ArduRoverFirmwarePlugin::guidedModeChangeAltitudeAMSL(Vehicle* /*vehicle*/, double /*altitudeAMSL*/, bool /*pauseVehicle*/)
 {
     qgcApp()->showAppMessage(QStringLiteral("Change altitude not supported."));
 }

--- a/src/FirmwarePlugin/APM/ArduRoverFirmwarePlugin.h
+++ b/src/FirmwarePlugin/APM/ArduRoverFirmwarePlugin.h
@@ -49,7 +49,7 @@ public:
     // Overrides from FirmwarePlugin
     QString pauseFlightMode                         (void) const override { return QStringLiteral("Hold"); }
     QString followFlightMode                        (void) const override { return QStringLiteral("Follow"); }
-    void    guidedModeChangeAltitude                (Vehicle* vehicle, double altitudeChange, bool pauseVehicle) final;
+    void    guidedModeChangeAltitudeAMSL            (Vehicle* vehicle, double altitudeAMSL, bool pauseVehicle) final;
     int     remapParamNameHigestMinorVersionNumber  (int majorVersionNumber) const final;
     const   FirmwarePlugin::remapParamNameMajorVersionMap_t& paramNameRemapMajorVersionMap(void) const final { return _remapParamName; }
     bool    supportsNegativeThrust                  (Vehicle *) final;

--- a/src/FirmwarePlugin/FirmwarePlugin.cc
+++ b/src/FirmwarePlugin/FirmwarePlugin.cc
@@ -249,22 +249,20 @@ void FirmwarePlugin::guidedModeGotoLocation(Vehicle* vehicle, const QGeoCoordina
     qgcApp()->showAppMessage(guided_mode_not_supported_by_vehicle);
 }
 
-void FirmwarePlugin::guidedModeChangeAltitude(Vehicle*, double, bool pauseVehicle)
+void FirmwarePlugin::guidedModeChangeAltitudeAMSL(Vehicle*, double, bool pauseVehicle)
 {
     // Not supported by generic vehicle
     Q_UNUSED(pauseVehicle);
     qgcApp()->showAppMessage(guided_mode_not_supported_by_vehicle);
 }
 
-void
-FirmwarePlugin::guidedModeChangeGroundSpeedMetersSecond(Vehicle*, double)
+void FirmwarePlugin::guidedModeChangeGroundSpeedMetersSecond(Vehicle*, double)
 {
     // Not supported by generic vehicle
     qgcApp()->showAppMessage(guided_mode_not_supported_by_vehicle);
 }
 
-void
-FirmwarePlugin::guidedModeChangeEquivalentAirspeedMetersSecond(Vehicle*, double)
+void FirmwarePlugin::guidedModeChangeEquivalentAirspeedMetersSecond(Vehicle*, double)
 {
     // Not supported by generic vehicle
     qgcApp()->showAppMessage(guided_mode_not_supported_by_vehicle);

--- a/src/FirmwarePlugin/FirmwarePlugin.h
+++ b/src/FirmwarePlugin/FirmwarePlugin.h
@@ -172,9 +172,9 @@ public:
     virtual void guidedModeGotoLocation(Vehicle* vehicle, const QGeoCoordinate& gotoCoord);
 
     /// Command vehicle to change altitude
-    ///     @param altitudeChange If > 0, go up by amount specified, if < 0, go down by amount specified
+    ///     @param altitudeAMSL New altitude for vehicle in meters above mean sea level
     ///     @param pauseVehicle true: pause vehicle prior to altitude change
-    virtual void guidedModeChangeAltitude(Vehicle* vehicle, double altitudeChange, bool pauseVehicle);
+    virtual void guidedModeChangeAltitudeAMSL(Vehicle* vehicle, double altitudeAMSL, bool pauseVehicle);
 
         /// Command vehicle to change groundspeed
     ///     @param groundspeed Groundspeed in m/s

--- a/src/FirmwarePlugin/PX4/PX4FirmwarePlugin.cc
+++ b/src/FirmwarePlugin/PX4/PX4FirmwarePlugin.cc
@@ -535,24 +535,12 @@ void PX4FirmwarePlugin::_changeAltAfterPause(void* resultHandlerData, bool pause
     delete pData;
 }
 
-void PX4FirmwarePlugin::guidedModeChangeAltitude(Vehicle* vehicle, double altitudeChange, bool pauseVehicle)
+void PX4FirmwarePlugin::guidedModeChangeAltitudeAMSL(Vehicle* vehicle, double altitudeAMSL, bool pauseVehicle)
 {
-    if (!vehicle->homePosition().isValid()) {
-        qgcApp()->showAppMessage(tr("Unable to change altitude, home position unknown."));
-        return;
-    }
-    if (qIsNaN(vehicle->homePosition().altitude())) {
-        qgcApp()->showAppMessage(tr("Unable to change altitude, home position altitude unknown."));
-        return;
-    }
-
-    double currentAltRel = vehicle->altitudeRelative()->rawValue().toDouble();
-    double newAltRel = currentAltRel + altitudeChange;
-
     PauseVehicleThenChangeAltData_t* resultData = new PauseVehicleThenChangeAltData_t;
     resultData->plugin      = this;
     resultData->vehicle     = vehicle;
-    resultData->newAMSLAlt  = vehicle->homePosition().altitude() + newAltRel;
+    resultData->newAMSLAlt  = altitudeAMSL;
 
     if (pauseVehicle) {
         Vehicle::MavCmdAckHandlerInfo_t handlerInfo = {};

--- a/src/FirmwarePlugin/PX4/PX4FirmwarePlugin.h
+++ b/src/FirmwarePlugin/PX4/PX4FirmwarePlugin.h
@@ -51,7 +51,7 @@ public:
     bool                mulirotorSpeedLimitsAvailable(Vehicle* vehicle) override;
     bool                fixedWingAirSpeedLimitsAvailable(Vehicle* vehicle) override;
     void                guidedModeGotoLocation          (Vehicle* vehicle, const QGeoCoordinate& gotoCoord) override;
-    void                guidedModeChangeAltitude        (Vehicle* vehicle, double altitudeRel, bool pauseVehicle) override;
+    void                guidedModeChangeAltitudeAMSL    (Vehicle* vehicle, double altitudeAMSL, bool pauseVehicle) override;
     void                guidedModeChangeGroundSpeedMetersSecond(Vehicle* vehicle, double groundspeed) override;
     void                guidedModeChangeEquivalentAirspeedMetersSecond(Vehicle* vehicle, double airspeed_equiv) override;
     void                startMission                    (Vehicle* vehicle) override;

--- a/src/FlightDisplay/GuidedActionsController.qml
+++ b/src/FlightDisplay/GuidedActionsController.qml
@@ -588,8 +588,7 @@ Item {
             break
         case actionChangeAlt:
             var valueInMeters = _unitsConversion.appSettingsVerticalDistanceUnitsToMeters(sliderOutputValue)
-            var altitudeChangeInMeters = valueInMeters - _activeVehicle.altitudeRelative.rawValue
-            _activeVehicle.guidedModeChangeAltitude(altitudeChangeInMeters, false /* pauseVehicle */)
+            _activeVehicle.guidedModeChangeAltitudeAMSL(valueInMeters, false /* pauseVehicle */)
             break
         case actionGoto:
             _activeVehicle.guidedModeGotoLocation(actionData)
@@ -606,8 +605,7 @@ Item {
             break
         case actionPause:
             var valueInMeters = _unitsConversion.appSettingsVerticalDistanceUnitsToMeters(sliderOutputValue)
-            var altitudeChangeInMeters = valueInMeters - _activeVehicle.altitudeRelative.rawValue
-            _activeVehicle.guidedModeChangeAltitude(altitudeChangeInMeters, true /* pauseVehicle */)
+            _activeVehicle.guidedModeChangeAltitudeAMSL(valueInMeters, true /* pauseVehicle */)
             break
         case actionMVPause:
             rgVehicle = QGroundControl.multiVehicleManager.vehicles

--- a/src/Vehicle/Vehicle.cc
+++ b/src/Vehicle/Vehicle.cc
@@ -2365,13 +2365,13 @@ void Vehicle::guidedModeGotoLocation(const QGeoCoordinate& gotoCoord)
     _firmwarePlugin->guidedModeGotoLocation(this, gotoCoord);
 }
 
-void Vehicle::guidedModeChangeAltitude(double altitudeChange, bool pauseVehicle)
+void Vehicle::guidedModeChangeAltitudeAMSL(double altitudeAMSL, bool pauseVehicle)
 {
     if (!guidedModeSupported()) {
         qgcApp()->showAppMessage(guided_mode_not_supported_by_vehicle);
         return;
     }
-    _firmwarePlugin->guidedModeChangeAltitude(this, altitudeChange, pauseVehicle);
+    _firmwarePlugin->guidedModeChangeAltitudeAMSL(this, altitudeAMSL, pauseVehicle);
 }
 
 void

--- a/src/Vehicle/Vehicle.h
+++ b/src/Vehicle/Vehicle.h
@@ -349,9 +349,9 @@ public:
     Q_INVOKABLE void guidedModeGotoLocation(const QGeoCoordinate& gotoCoord);
 
     /// Command vehicle to change altitude
-    ///     @param altitudeChange If > 0, go up by amount specified, if < 0, go down by amount specified
+    ///     @param altitudeAMSL New altitude for vehicle in meters above mean sea level
     ///     @param pauseVehicle true: pause vehicle prior to altitude change
-    Q_INVOKABLE void guidedModeChangeAltitude(double altitudeChange, bool pauseVehicle);
+    Q_INVOKABLE void guidedModeChangeAltitudeAMSL(double altitudeAMSL, bool pauseVehicle);
 
     /// Command vehicle to change groundspeed
     ///     @param groundspeed Target horizontal groundspeed


### PR DESCRIPTION
Changed guided altitude change to use relative alt instead of offset from current vehicle altitude. This gives precise positioning even when vehicle is climbing/descending.

@JMare Can you test this with ArduPilot? I looked at ArduPilot source and this "should" work.

Related to discussion  in #11641