### PR TITLE
RemoteID: add note that Fixed only works in EU

### DIFF
--- a/src/Settings/RemoteID.SettingsGroup.json
+++ b/src/Settings/RemoteID.SettingsGroup.json
@@ -111,7 +111,7 @@
     "shortDesc":    "Location Type",
     "longDesc":     "Operator location Type",
     "type":         "uint8",
-    "enumStrings":  "Takeoff(Not Supported),Live GNNS, Fixed",
+    "enumStrings":  "Takeoff(Not Supported),Live GNNS, Fixed (not for FAA)",
     "enumValues":   "0,1,2",
     "default":      1
 },


### PR DESCRIPTION
It is very confusing when the "Fixed" option just seemingly doesn't work when you select it. Therefore, we should at least add this note.

Closes https://github.com/mavlink/qgroundcontrol/issues/11673.