### PR TITLE
QtLocationPlugin: Update QGeoMapReplyQGC

### DIFF
--- a/src/QtLocationPlugin/BingMapProvider.h
+++ b/src/QtLocationPlugin/BingMapProvider.h
@@ -31,6 +31,12 @@ private:
     const QString _mapTypeId;
     const QString _mapUrl = QStringLiteral("http://ecn.t%1.tiles.virtualearth.net/tiles/%2%3.%4?g=%5&mkt=%6");
     const QString _versionBingMaps = QStringLiteral("2981");
+
+    /*QUrl m_url;
+    const QString m_scheme = QStringLiteral("http");
+    const QString m_host = QStringLiteral("ecn.t%1.tiles.virtualearth.net");
+    const QString m_path = QStringLiteral("tiles/%1%2.%3");
+    const QUrlQuery m_query = QStringLiteral("g=%1&mkt=%2");*/
 };
 
 class BingRoadMapProvider : public BingMapProvider

--- a/src/QtLocationPlugin/ElevationMapProvider.cpp
+++ b/src/QtLocationPlugin/ElevationMapProvider.cpp
@@ -56,3 +56,8 @@ QGCTileSet CopernicusElevationProvider::getTileCount(int zoom, double topleftLon
 
     return set;
 }
+
+QByteArray CopernicusElevationProvider::serialize(const QByteArray &image) const
+{
+    return TerrainTile::serializeFromAirMapJson(image);
+}

--- a/src/QtLocationPlugin/ElevationMapProvider.h
+++ b/src/QtLocationPlugin/ElevationMapProvider.h
@@ -18,6 +18,7 @@ protected:
 
 public:
     bool isElevationProvider() const final { return true; }
+    virtual QByteArray serialize(const QByteArray &image) const = 0;
 };
 
 class CopernicusElevationProvider : public ElevationProvider
@@ -38,8 +39,10 @@ public:
                             double topleftLat, double bottomRightLon,
                             double bottomRightLat) const final;
 
-    static constexpr const char* kProviderKey = "Copernicus Elevation";
-    static constexpr const char* kProviderNotice = "© Airbus Defence and Space GmbH";
+    QByteArray serialize(const QByteArray &image) const final;
+
+    static constexpr const char *kProviderKey = "Copernicus Elevation";
+    static constexpr const char *kProviderNotice = "© Airbus Defence and Space GmbH";
 
 private:
     QString _getURL(int x, int y, int zoom) const final;

--- a/src/QtLocationPlugin/EsriMapProvider.cpp
+++ b/src/QtLocationPlugin/EsriMapProvider.cpp
@@ -11,21 +11,9 @@
 #include "QGCApplication.h"
 #include "SettingsManager.h"
 
-#include <QtNetwork/QNetworkRequest>
-
-QNetworkRequest EsriMapProvider::getTileURL(int x, int y, int zoom) const
+QByteArray EsriMapProvider::getToken() const
 {
-    QNetworkRequest request;
-    const QString url = _getURL(x, y, zoom);
-    if (url.isEmpty()) {
-        return request;
-    }
-    request.setUrl(QUrl(url));
-    request.setRawHeader(QByteArrayLiteral("Accept"), QByteArrayLiteral("*/*"));
-    const QByteArray token = qgcApp()->toolbox()->settingsManager()->appSettings()->esriToken()->rawValue().toString().toLatin1();
-    request.setRawHeader(QByteArrayLiteral("User-Agent"), QByteArrayLiteral("Qt Location based application"));
-    request.setRawHeader(QByteArrayLiteral("User-Token"), token);
-    return request;
+    return qgcApp()->toolbox()->settingsManager()->appSettings()->esriToken()->rawValue().toString().toUtf8();
 }
 
 QString EsriMapProvider::_getURL(int x, int y, int zoom) const

--- a/src/QtLocationPlugin/EsriMapProvider.h
+++ b/src/QtLocationPlugin/EsriMapProvider.h
@@ -24,7 +24,7 @@ protected:
         , _mapTypeId(mapTypeId) {}
 
 public:
-    QNetworkRequest getTileURL(int x, int y, int zoom) const final;
+    QByteArray getToken() const final;
 
 private:
     QString _getURL(int x, int y, int zoom) const final;

--- a/src/QtLocationPlugin/MapProvider.cpp
+++ b/src/QtLocationPlugin/MapProvider.cpp
@@ -11,7 +11,6 @@
 #include <QGCLoggingCategory.h>
 
 #include <QtCore/QLocale>
-#include <QtNetwork/QNetworkRequest>
 
 QGC_LOGGING_CATEGORY(MapProviderLog, "qgc.qtlocationplugin.mapprovider")
 
@@ -40,18 +39,9 @@ MapProvider::~MapProvider()
     // qCDebug(MapProviderLog) << Q_FUNC_INFO << this << _mapId;
 }
 
-QNetworkRequest MapProvider::getTileURL(int x, int y, int zoom) const
+QUrl MapProvider::getTileURL(int x, int y, int zoom) const
 {
-    QNetworkRequest request;
-    const QString url = _getURL(x, y, zoom);
-    if (url.isEmpty()) {
-        return request;
-    }
-    request.setUrl(QUrl(url));
-    request.setRawHeader(QByteArrayLiteral("Accept"), QByteArrayLiteral("*/*"));
-    request.setRawHeader(QByteArrayLiteral("Referrer"), _referrer.toUtf8());
-    request.setRawHeader(QByteArrayLiteral("User-Agent"), QByteArrayLiteral("Qt Location based application"));
-    return request;
+    return QUrl(_getURL(x, y, zoom));
 }
 
 QString MapProvider::getImageFormat(QByteArrayView image) const

--- a/src/QtLocationPlugin/MapProvider.h
+++ b/src/QtLocationPlugin/MapProvider.h
@@ -34,16 +34,18 @@ Q_DECLARE_LOGGING_CATEGORY(MapProviderLog)
     CustomMap = 100
 };*/
 
+#define MAX_MAP_ZOOM 23.0
 static constexpr const quint32 AVERAGE_TILE_SIZE = 13652;
 
-class QNetworkRequest;
-
+// TODO: Inherit from QGeoMapType
 class MapProvider
 {
 public:
     MapProvider(const QString &mapName, const QString &referrer, const QString &imageFormat, quint32 averageSize = AVERAGE_TILE_SIZE,
                 QGeoMapType::MapStyle mapStyle = QGeoMapType::CustomMap);
     virtual ~MapProvider();
+
+    QUrl getTileURL(int x, int y, int zoom) const;
 
     QString getImageFormat(QByteArrayView image) const;
 
@@ -53,8 +55,8 @@ public:
     QGeoMapType::MapStyle getMapStyle() const { return _mapStyle; }
     const QString& getMapName() const { return _mapName; }
     int getMapId() const { return _mapId; }
-
-    virtual QNetworkRequest getTileURL(int x, int y, int zoom) const;
+    const QString& getReferrer() const { return _referrer; }
+    virtual QByteArray getToken() const { return QByteArray(); }
 
     virtual int long2tileX(double lon, int z) const;
     virtual int lat2tileY(double lat, int z) const;

--- a/src/QtLocationPlugin/QGCCachedTileSet.cpp
+++ b/src/QtLocationPlugin/QGCCachedTileSet.cpp
@@ -246,7 +246,8 @@ void QGCCachedTileSet::_prepareDownload()
         if(_tilesToDownload.count()) {
             QGCTile* tile = _tilesToDownload.first();
             _tilesToDownload.removeFirst();
-            QNetworkRequest request = UrlFactory::getTileURL(tile->type(), tile->x(), tile->y(), tile->z());
+            const int mapId = UrlFactory::getQtMapIdFromProviderType(tile->type());
+            QNetworkRequest request = QGeoTileFetcherQGC::getNetworkRequest(mapId, tile->x(), tile->y(), tile->z());
             request.setAttribute(QNetworkRequest::User, tile->hash());
 #if !defined(__mobile__)
             QNetworkProxy proxy = _networkManager->proxy();

--- a/src/QtLocationPlugin/QGCMapUrlEngine.cpp
+++ b/src/QtLocationPlugin/QGCMapUrlEngine.cpp
@@ -95,24 +95,24 @@ QString UrlFactory::getImageFormat(QStringView type, QByteArrayView image)
     return QStringLiteral("");
 }
 
-QNetworkRequest UrlFactory::getTileURL(int qtMapId, int x, int y, int zoom)
+QUrl UrlFactory::getTileURL(int qtMapId, int x, int y, int zoom)
 {
     const SharedMapProvider provider = getMapProviderFromQtMapId(qtMapId);
     if (provider) {
         return provider->getTileURL(x, y, zoom);
     }
 
-    return QNetworkRequest(QUrl());
+    return QUrl();
 }
 
-QNetworkRequest UrlFactory::getTileURL(QStringView type, int x, int y, int zoom)
+QUrl UrlFactory::getTileURL(QStringView type, int x, int y, int zoom)
 {
     const SharedMapProvider provider = getMapProviderFromProviderType(type);
     if (provider) {
         return provider->getTileURL(x, y, zoom);
     }
 
-    return QNetworkRequest(QUrl());
+    return QUrl();
 }
 
 quint32 UrlFactory::averageSizeForType(QStringView type)

--- a/src/QtLocationPlugin/QGCMapUrlEngine.h
+++ b/src/QtLocationPlugin/QGCMapUrlEngine.h
@@ -20,11 +20,9 @@
 #include <QtCore/QObject>
 #include <QtCore/QByteArrayView>
 #include <QtCore/QStringView>
-#include <QtNetwork/QNetworkRequest>
-
-#define MAX_MAP_ZOOM (23.0)
 
 class MapProvider;
+class ElevationProvider;
 
 class UrlFactory
 {
@@ -32,8 +30,8 @@ public:
     static QString getImageFormat(QStringView type, QByteArrayView image);
     static QString getImageFormat(int qtMapId, QByteArrayView image);
 
-    static QNetworkRequest getTileURL(QStringView type, int x, int y, int zoom);
-    static QNetworkRequest getTileURL(int qtMapId, int x, int y, int zoom);
+    static QUrl getTileURL(QStringView type, int x, int y, int zoom);
+    static QUrl getTileURL(int qtMapId, int x, int y, int zoom);
 
     static quint32 averageSizeForType(QStringView type);
 
@@ -58,11 +56,9 @@ public:
     static QString tileHashToType(QStringView tileHash);
     static QString getTileHash(QStringView type, int x, int y, int z);
 
-    static constexpr const char* kCopernicusElevationProviderKey = "Copernicus Elevation";
-    static constexpr const char* kCopernicusElevationProviderNotice = "© Airbus Defence and Space GmbH";
-
 private:
     static const QList<std::shared_ptr<const MapProvider>> _providers;
 };
 
 typedef std::shared_ptr<const MapProvider> SharedMapProvider;
+typedef std::shared_ptr<const ElevationProvider> SharedElevationProvider;

--- a/src/QtLocationPlugin/QGeoMapReplyQGC.cpp
+++ b/src/QtLocationPlugin/QGeoMapReplyQGC.cpp
@@ -1,253 +1,201 @@
-/****************************************************************************
-**
-** Copyright (C) 2013 Aaron McCarthy <mccarthy.aaron@gmail.com>
-** Contact: http://www.qt-project.org/legal
-**
-** This file is part of the QtLocation module of the Qt Toolkit.
-**
-** $QT_BEGIN_LICENSE:LGPL$
-** Commercial License Usage
-** Licensees holding valid commercial Qt licenses may use this file in
-** accordance with the commercial license agreement provided with the
-** Software or, alternatively, in accordance with the terms contained in
-** a written agreement between you and Digia.  For licensing terms and
-** conditions see http://qt.digia.com/licensing.  For further information
-** use the contact form at http://qt.digia.com/contact-us.
-**
-** GNU Lesser General Public License Usage
-** Alternatively, this file may be used under the terms of the GNU Lesser
-** General Public License version 2.1 as published by the Free Software
-** Foundation and appearing in the file LICENSE.LGPL included in the
-** packaging of this file.  Please review the following information to
-** ensure the GNU Lesser General Public License version 2.1 requirements
-** will be met: http://www.gnu.org/licenses/old-licenses/lgpl-2.1.html.
-**
-** In addition, as a special exception, Digia gives you certain additional
-** rights.  These rights are described in the Digia Qt LGPL Exception
-** version 1.1, included in the file LGPL_EXCEPTION.txt in this package.
-**
-** GNU General Public License Usage
-** Alternatively, this file may be used under the terms of the GNU
-** General Public License version 3.0 as published by the Free Software
-** Foundation and appearing in the file LICENSE.GPL included in the
-** packaging of this file.  Please review the following information to
-** ensure the GNU General Public License version 3.0 requirements will be
-** met: http://www.gnu.org/copyleft/gpl.html.
-**
-**
-** $QT_END_LICENSE$
-**
-** 2015.4.4
-** Adapted for use with QGroundControl
-**
-** Gus Grubba <gus@auterion.com>
-**
-****************************************************************************/
-
 #include "QGeoMapReplyQGC.h"
-#include "QGCMapEngine.h"
-#include "QGeoFileTileCacheQGC.h"
-#include "TerrainTile.h"
-#include "MapProvider.h"
-#include "QGCMapUrlEngine.h"
-#include "DeviceInfo.h"
 
+#include "ElevationMapProvider.h"
+#include "MapProvider.h"
+#include "QGCMapEngine.h"
+#include "QGCMapUrlEngine.h"
+#include "QGeoFileTileCacheQGC.h"
+
+#include <DeviceInfo.h>
+#include <QGCFileDownload.h>
+#include <QGCLoggingCategory.h>
+
+#include <QtCore/QFile>
 #include <QtLocation/private/qgeotilespec_p.h>
 #include <QtNetwork/QNetworkAccessManager>
-#include <QtCore/QFile>
-#include <QtNetwork/QNetworkProxy>
+#include <QtNetwork/QSslError>
 
-int         QGeoTiledMapReplyQGC::_requestCount = 0;
-QByteArray  QGeoTiledMapReplyQGC::_bingNoTileImage;
+QGC_LOGGING_CATEGORY(QGeoTiledMapReplyQGCLog, "qgc.qtlocationplugin.qgeomapreplyqgc")
 
-//-----------------------------------------------------------------------------
+QByteArray QGeoTiledMapReplyQGC::_bingNoTileImage;
+QByteArray QGeoTiledMapReplyQGC::_badTile;
+
 QGeoTiledMapReplyQGC::QGeoTiledMapReplyQGC(QNetworkAccessManager *networkManager, const QNetworkRequest &request, const QGeoTileSpec &spec, QObject *parent)
     : QGeoTiledMapReply(spec, parent)
-    , _reply(nullptr)
-    , _request(request)
     , _networkManager(networkManager)
+    , _request(request)
 {
-    if (_bingNoTileImage.length() == 0) {
-        QFile file(":/res/BingNoTileBytes.dat");
-        file.open(QFile::ReadOnly);
-        _bingNoTileImage = file.readAll();
-        file.close();
-    }
-    if(_request.url().isEmpty()) {
-        if(!_badMapbox.size()) {
-            QFile b(":/res/notile.png");
-            if(b.open(QFile::ReadOnly))
-                _badMapbox = b.readAll();
-        }
-        setMapImageData(_badMapbox);
+    // qCDebug(QGeoTiledMapReplyQGCLog) << Q_FUNC_INFO << this;
+
+    _initDataFromResources();
+
+    (void) connect(this, &QGeoTiledMapReplyQGC::errorOccurred, this, [this](QGeoTiledMapReply::Error error, const QString &errorString) {
+        qCWarning(QGeoTiledMapReplyQGCLog) << error << errorString;
+        setMapImageData(_badTile);
         setMapImageFormat("png");
-        setFinished(true);
         setCached(false);
-    } else {
-        QGCFetchTileTask* task = QGeoFileTileCacheQGC::createFetchTileTask(UrlFactory::getProviderTypeFromQtMapId(spec.mapId()), spec.x(), spec.y(), spec.zoom());
-        connect(task, &QGCFetchTileTask::tileFetched, this, &QGeoTiledMapReplyQGC::cacheReply);
-        connect(task, &QGCMapTask::error, this, &QGeoTiledMapReplyQGC::cacheError);
-        (void) getQGCMapEngine()->addTask(task);
-    }
+    }, Qt::AutoConnection);
+
+    QGCFetchTileTask* const task = QGeoFileTileCacheQGC::createFetchTileTask(UrlFactory::getProviderTypeFromQtMapId(spec.mapId()), spec.x(), spec.y(), spec.zoom());
+    (void) connect(task, &QGCFetchTileTask::tileFetched, this, &QGeoTiledMapReplyQGC::_cacheReply);
+    (void) connect(task, &QGCMapTask::error, this, &QGeoTiledMapReplyQGC::_cacheError);
+    getQGCMapEngine()->addTask(task);
 }
 
-//-----------------------------------------------------------------------------
 QGeoTiledMapReplyQGC::~QGeoTiledMapReplyQGC()
 {
-    _clearReply();
+    // qCDebug(QGeoTiledMapReplyQGCLog) << Q_FUNC_INFO << this;
 }
 
-//-----------------------------------------------------------------------------
-void
-QGeoTiledMapReplyQGC::_clearReply()
+void QGeoTiledMapReplyQGC::_initDataFromResources()
 {
-    _timer.stop();
-    if (_reply) {
-        _reply->deleteLater();
-        _reply = nullptr;
-        _requestCount--;
-    }
-}
-
-//-----------------------------------------------------------------------------
-void
-QGeoTiledMapReplyQGC::abort()
-{
-    _timer.stop();
-    if (_reply)
-        _reply->abort();
-    emit aborted();
-}
-
-//-----------------------------------------------------------------------------
-void
-QGeoTiledMapReplyQGC::networkReplyFinished()
-{
-    _timer.stop();
-    if (!_reply) {
-        emit aborted();
-        return;
-    }
-    if (_reply->error() != QNetworkReply::NoError) {
-        emit aborted();
-        return;
-    }
-    QByteArray a = _reply->readAll();
-    QString format = UrlFactory::getImageFormat(tileSpec().mapId(), a);
-    //-- Test for a specialized, elevation data (not map tile)
-    if( UrlFactory::isElevation(tileSpec().mapId())){
-        a = TerrainTile::serializeFromAirMapJson(a);
-        //-- Cache it if valid
-        if(!a.isEmpty()) {
-            QGeoFileTileCacheQGC::cacheTile(
-                UrlFactory::getProviderTypeFromQtMapId(
-                    tileSpec().mapId()),
-                tileSpec().x(), tileSpec().y(), tileSpec().zoom(), a, format);
+    if (_bingNoTileImage.isEmpty()) {
+        QFile file("://res/BingNoTileBytes.dat");
+        if (file.open(QFile::ReadOnly)) {
+            _bingNoTileImage = file.readAll();
+            file.close();
         }
-        emit terrainDone(a, QNetworkReply::NoError);
-    } else {
-        const SharedMapProvider mapProvider = UrlFactory::getMapProviderFromQtMapId(tileSpec().mapId());
-        if (mapProvider && mapProvider->isBingProvider() && a.size() && _bingNoTileImage.size() && a == _bingNoTileImage) {
-            // Bing doesn't return an error if you request a tile above supported zoom level
-            // It instead returns an image of a missing tile graphic. We need to detect that
-            // and error out so Qt will deal with zooming correctly even if it doesn't have the tile.
-            // This allows us to zoom up to level 23 even though the tiles don't actually exist
-            setError(QGeoTiledMapReply::CommunicationError, "Bing tile above zoom level");
+    }
+
+    if (_badTile.isEmpty()) {
+        QFile file("://res/images/notile.png");
+        if (file.open(QFile::ReadOnly)) {
+            _badTile = file.readAll();
+            file.close();
+        }
+    }
+}
+
+void QGeoTiledMapReplyQGC::_networkReplyFinished()
+{
+    QNetworkReply* const reply = qobject_cast<QNetworkReply*>(sender());
+    if (!reply) {
+        setError(QGeoTiledMapReply::UnknownError, QStringLiteral("Unexpected Error"));
+        return;
+    }
+    reply->deleteLater();
+
+    if (reply->error() != QNetworkReply::NoError) {
+        return;
+    }
+
+    if (!reply->isOpen()) {
+        setError(QGeoTiledMapReply::ParseError, QStringLiteral("Empty Reply"));
+        return;
+    }
+
+    const int statusCode = reply->attribute(QNetworkRequest::HttpStatusCodeAttribute).toInt();
+    if ((statusCode < HTTP_Response::SUCCESS_OK) || (statusCode >= HTTP_Response::REDIRECTION_MULTIPLE_CHOICES)) {
+        setError(QGeoTiledMapReply::CommunicationError, reply->attribute(QNetworkRequest::HttpReasonPhraseAttribute).toString());
+        return;
+    }
+
+    QByteArray image = reply->readAll();
+    if (image.isEmpty()) {
+        setError(QGeoTiledMapReply::ParseError, QStringLiteral("Image is Empty"));
+        return;
+    }
+
+    const SharedMapProvider mapProvider = UrlFactory::getMapProviderFromQtMapId(tileSpec().mapId());
+    Q_CHECK_PTR(mapProvider);
+
+    if (mapProvider->isBingProvider() && (image == _bingNoTileImage)) {
+        setError(QGeoTiledMapReply::CommunicationError, QStringLiteral("Bing Tile Above Zoom Level"));
+        return;
+    }
+
+    if (mapProvider->isElevationProvider()) {
+        const SharedElevationProvider elevationProvider = std::dynamic_pointer_cast<const ElevationProvider>(mapProvider);
+        image = elevationProvider->serialize(image);
+        if (image.isEmpty()) {
+            setError(QGeoTiledMapReply::ParseError, QStringLiteral("Failed to Serialize Terrain Tile"));
+            return;
+        }
+    }
+    setMapImageData(image);
+
+    const QString format = mapProvider->getImageFormat(image);
+    if (format.isEmpty()) {
+        setError(QGeoTiledMapReply::ParseError, QStringLiteral("Unknown Format"));
+        return;
+    }
+    setMapImageFormat(format);
+
+    QGeoFileTileCacheQGC::cacheTile(mapProvider->getMapName(), tileSpec().x(), tileSpec().y(), tileSpec().zoom(), image, format);
+
+    setFinished(true);
+}
+
+void QGeoTiledMapReplyQGC::_networkReplyError(QNetworkReply::NetworkError error)
+{
+    if (error != QNetworkReply::OperationCanceledError) {
+        const QNetworkReply* const reply = qobject_cast<const QNetworkReply*>(sender());
+        if (!reply) {
+            setError(QGeoTiledMapReply::CommunicationError, QStringLiteral("Invalid Reply"));
         } else {
-            //-- This is a map tile. Process and cache it if valid.
-            setMapImageData(a);
-            if(!format.isEmpty()) {
-                setMapImageFormat(format);
-                QGeoFileTileCacheQGC::cacheTile(UrlFactory::getProviderTypeFromQtMapId(tileSpec().mapId()), tileSpec().x(), tileSpec().y(), tileSpec().zoom(), a, format);
-            }
+            setError(QGeoTiledMapReply::CommunicationError, reply->errorString());
         }
+    } else {
         setFinished(true);
     }
-    _clearReply();
 }
 
-//-----------------------------------------------------------------------------
-void
-QGeoTiledMapReplyQGC::networkReplyError(QNetworkReply::NetworkError error)
+#if QT_CONFIG(ssl)
+void QGeoTiledMapReplyQGC::_networkReplySslErrors(const QList<QSslError> &errors)
 {
-    _timer.stop();
-    if (!_reply) {
-        return;
-    }
-    //-- Test for a specialized, elevation data (not map tile)
-    if( UrlFactory::isElevation(tileSpec().mapId())){
-        emit terrainDone(QByteArray(), error);
-    } else {
-        //-- Regular map tile
-        if (error != QNetworkReply::OperationCanceledError) {
-            qWarning() << "Fetch tile error:" << _reply->errorString();
-            setError(QGeoTiledMapReply::CommunicationError, _reply->errorString());
+    QString errorString;
+    for (const QSslError &error : errors) {
+        if (!errorString.isEmpty()) {
+            (void) errorString.append('\n');
         }
-        setFinished(true);
+        (void) errorString.append(error.errorString());
     }
-    _clearReply();
-}
 
-//-----------------------------------------------------------------------------
-void
-QGeoTiledMapReplyQGC::cacheError(QGCMapTask::TaskType type, QString /*errorString*/)
-{
-    if(!QGCDeviceInfo::isInternetAvailable()) {
-        if( UrlFactory::isElevation(tileSpec().mapId())){
-            emit terrainDone(QByteArray(), QNetworkReply::NetworkSessionFailedError);
-        } else {
-            setError(QGeoTiledMapReply::CommunicationError, "Network not available");
-            setFinished(true);
-        }
-    } else {
-        if(type != QGCMapTask::taskFetchTile) {
-            qWarning() << "QGeoTiledMapReplyQGC::cacheError() for wrong task";
-        }
-        //-- Tile not in cache. Get it off the Internet.
-#if !defined(__mobile__)
-        QNetworkProxy proxy = _networkManager->proxy();
-        QNetworkProxy tProxy;
-        tProxy.setType(QNetworkProxy::DefaultProxy);
-        _networkManager->setProxy(tProxy);
+    if (!errorString.isEmpty()) {
+        setError(QGeoTiledMapReply::CommunicationError, errorString);
+    }
+}
 #endif
-        _reply = _networkManager->get(_request);
-        _reply->setParent(nullptr);
-        connect(_reply, &QNetworkReply::finished, this, &QGeoTiledMapReplyQGC::networkReplyFinished);
-        connect(_reply, &QNetworkReply::errorOccurred, this, &QGeoTiledMapReplyQGC::networkReplyError);
-#if !defined(__mobile__)
-        _networkManager->setProxy(proxy);
-#endif
-        //- Wait for an answer up to 10 seconds
-        connect(&_timer, &QTimer::timeout, this, &QGeoTiledMapReplyQGC::timeout);
-        _timer.setSingleShot(true);
-        _timer.start(10000);
-        _requestCount++;
-    }
-}
 
-//-----------------------------------------------------------------------------
-void
-QGeoTiledMapReplyQGC::cacheReply(QGCCacheTile* tile)
+void QGeoTiledMapReplyQGC::_cacheReply(QGCCacheTile *tile)
 {
-    //-- Test for a specialized, elevation data (not map tile)
-    if( UrlFactory::isElevation(tileSpec().mapId())){
-        emit terrainDone(tile->img(), QNetworkReply::NoError);
-    } else {
-        //-- Regular map tile
+    if (tile) {
         setMapImageData(tile->img());
         setMapImageFormat(tile->format());
-        setFinished(true);
         setCached(true);
+        setFinished(true);
+        delete tile;
+    } else {
+        setError(QGeoTiledMapReply::UnknownError, QStringLiteral("Invalid Cache Tile"));
     }
-    delete tile;
 }
 
-//-----------------------------------------------------------------------------
-void
-QGeoTiledMapReplyQGC::timeout()
+void QGeoTiledMapReplyQGC::_cacheError(QGCMapTask::TaskType type, QStringView errorString)
 {
-    if(_reply) {
-        _reply->abort();
+    Q_UNUSED(errorString);
+
+    Q_ASSERT(type == QGCMapTask::taskFetchTile);
+
+    if (!QGCDeviceInfo::isInternetAvailable()) {
+        setError(QGeoTiledMapReply::CommunicationError, QStringLiteral("Network Not Available"));
+        return;
     }
-    emit aborted();
+
+    _request.setOriginatingObject(this);
+
+    QNetworkReply* const reply = _networkManager->get(_request);
+    reply->setParent(this);
+    QGCFileDownload::setIgnoreSSLErrorsIfNeeded(*reply);
+
+    (void) connect(reply, &QNetworkReply::finished, this, &QGeoTiledMapReplyQGC::_networkReplyFinished);
+    (void) connect(reply, &QNetworkReply::errorOccurred, this, &QGeoTiledMapReplyQGC::_networkReplyError);
+#if QT_CONFIG(ssl)
+    (void) connect(reply, &QNetworkReply::sslErrors, this, &QGeoTiledMapReplyQGC::_networkReplySslErrors);
+#endif
+    (void) connect(this, &QGeoTiledMapReplyQGC::aborted, reply, &QNetworkReply::abort);
+}
+
+void QGeoTiledMapReplyQGC::abort()
+{
+    QGeoTiledMapReply::abort();
 }

--- a/src/QtLocationPlugin/QGeoServiceProviderPluginQGC.cpp
+++ b/src/QtLocationPlugin/QGeoServiceProviderPluginQGC.cpp
@@ -47,6 +47,7 @@ QGeoMappingManagerEngine* QGeoServiceProviderFactoryQGC::createMappingManagerEng
     if (errorString) {
         *errorString = "";
     }
+    // TODO: m_engine->networkAccessManager();
     return new QGeoTiledMappingManagerEngineQGC(parameters, error, errorString);
 }
 

--- a/src/QtLocationPlugin/QGeoTileFetcherQGC.cpp
+++ b/src/QtLocationPlugin/QGeoTileFetcherQGC.cpp
@@ -5,10 +5,11 @@
 #include "MapProvider.h"
 #include <QGCLoggingCategory.h>
 
-#include <QtNetwork/QNetworkRequest>
 // #include <QtNetwork/QNetworkDiskCache>
-#include <QtLocation/private/qgeotilespec_p.h>
+#include <QtNetwork/QNetworkProxy>
+#include <QtNetwork/QNetworkRequest>
 #include <QtLocation/private/qgeotiledmappingmanagerengine_p.h>
+#include <QtLocation/private/qgeotilespec_p.h>
 
 QGC_LOGGING_CATEGORY(QGeoTileFetcherQGCLog, "qgc.qtlocationplugin.qgeotilefetcherqgc")
 
@@ -17,6 +18,8 @@ QGeoTileFetcherQGC::QGeoTileFetcherQGC(QNetworkAccessManager *networkManager, co
     , m_networkManager(networkManager)
     // , m_diskCache(new QNetworkDiskCache(this))
 {
+    Q_CHECK_PTR(networkManager);
+
     // qCDebug(QGeoTileFetcherQGCLog) << Q_FUNC_INFO << this;
 
     // TODO: Allow useragent override again
@@ -24,11 +27,17 @@ QGeoTileFetcherQGC::QGeoTileFetcherQGC(QNetworkAccessManager *networkManager, co
         setUserAgent(parameters.value(QStringLiteral("useragent")).toString().toLatin1());
     }*/
 
-    /*if (networkManager) {
-        m_diskCache->setCacheDirectory(directory() + "/Downloads");
-        m_diskCache->setMaximumCacheSize(static_cast<qint64>(_getDefaultMaxDiskCache()));
-        networkManager->setCache(m_diskCache);
-    }*/
+#ifndef __mobile__
+    QNetworkProxy proxy = m_networkManager->proxy();
+    proxy.setType(QNetworkProxy::DefaultProxy);
+    m_networkManager->setProxy(proxy);
+#endif
+
+    /*m_networkManager->setTransferTimeout(10000);
+    m_networkManager->setAutoDeleteReplies(true);
+    m_diskCache->setCacheDirectory(directory() + "/Downloads");
+    m_diskCache->setMaximumCacheSize(static_cast<qint64>(_getDefaultMaxDiskCache()));
+    m_networkManager->setCache(m_diskCache);*/
 }
 
 QGeoTileFetcherQGC::~QGeoTileFetcherQGC()
@@ -47,7 +56,7 @@ QGeoTiledMapReply* QGeoTileFetcherQGC::getTileImage(const QGeoTileSpec &spec)
         return nullptr;
     }*/
 
-    const QNetworkRequest request = provider->getTileURL(spec.x(), spec.y(), spec.zoom());
+    const QNetworkRequest request = getNetworkRequest(spec.mapId(), spec.x(), spec.y(), spec.zoom());
     if (request.url().isEmpty()) {
         return nullptr;
     }
@@ -87,4 +96,32 @@ void QGeoTileFetcherQGC::handleReply(QGeoTiledMapReply *reply, const QGeoTileSpe
     } else {
         emit tileError(spec, reply->errorString());
     }
+}
+
+QNetworkRequest QGeoTileFetcherQGC::getNetworkRequest(int mapId, int x, int y, int zoom)
+{
+    const SharedMapProvider mapProvider = UrlFactory::getMapProviderFromQtMapId(mapId);
+
+    QNetworkRequest request;
+    request.setUrl(mapProvider->getTileURL(x, y, zoom));
+    request.setRawHeader(QByteArrayLiteral("Accept"), QByteArrayLiteral("*/*"));
+    request.setHeader(QNetworkRequest::UserAgentHeader, s_userAgent);
+    const QByteArray referrer = mapProvider->getReferrer().toUtf8();
+    if (!referrer.isEmpty()) {
+        request.setRawHeader(QByteArrayLiteral("Referrer"), referrer);
+    }
+    const QByteArray token = mapProvider->getToken();
+    if (!token.isEmpty()) {
+        request.setRawHeader(QByteArrayLiteral("User-Token"), token);
+    }
+    // request.setOriginatingObject(this);
+    request.setAttribute(QNetworkRequest::CacheLoadControlAttribute, QNetworkRequest::PreferCache);
+    request.setAttribute(QNetworkRequest::BackgroundRequestAttribute, true);
+    request.setAttribute(QNetworkRequest::CacheSaveControlAttribute, true);
+    request.setAttribute(QNetworkRequest::DoNotBufferUploadDataAttribute, false);
+    // request.setAttribute(QNetworkRequest::AutoDeleteReplyOnFinishAttribute, true);
+    request.setPriority(QNetworkRequest::NormalPriority);
+    request.setTransferTimeout(10000);
+
+    return request;
 }

--- a/src/QtLocationPlugin/QGeoTileFetcherQGC.h
+++ b/src/QtLocationPlugin/QGeoTileFetcherQGC.h
@@ -20,6 +20,9 @@ public:
     QGeoTileFetcherQGC(QNetworkAccessManager *networkManager, const QVariantMap &parameters, QGeoTiledMappingManagerEngineQGC *parent = nullptr);
     ~QGeoTileFetcherQGC();
 
+    static QNetworkRequest getNetworkRequest(int mapId, int x, int y, int zoom);
+    /* Note: QNetworkAccessManager queues the requests it receives. The number of requests executed in parallel is dependent on the protocol.
+     * Currently, for the HTTP protocol on desktop platforms, 6 requests are executed in parallel for one host/port combination. */
     static uint32_t concurrentDownloads(const QString &type) { Q_UNUSED(type); return 6; }
 
 private:
@@ -39,6 +42,7 @@ private:
 #elif defined Q_OS_ANDROID
     static constexpr const char* s_userAgent = "Mozilla/5.0 (Android 13; Tablet; rv:68.0) Gecko/68.0 Firefox/112.0";
 #elif defined Q_OS_LINUX
+    // TODO: Detect Wayland vs X11
     static constexpr const char* s_userAgent = "Mozilla/5.0 (X11; Linux x86_64; rv:109.0) Gecko/20100101 Firefox/112.0";
 #else
     static constexpr const char* s_userAgent = "Qt Location based application";

--- a/src/Terrain/TerrainTileManager.cc
+++ b/src/Terrain/TerrainTileManager.cc
@@ -10,15 +10,16 @@
 #include "TerrainTileManager.h"
 #include "TerrainQuery.h"
 #include "TerrainQueryAirMap.h"
-#include "QGCMapEngine.h"
-#include "QGeoMapReplyQGC.h"
-#include "QGCMapUrlEngine.h"
-#include "ElevationMapProvider.h"
-#include "QGCLoggingCategory.h"
+#include <QGeoTileFetcherQGC.h>
+#include <QGeoMapReplyQGC.h>
+#include <QGCMapUrlEngine.h>
+#include <ElevationMapProvider.h>
+#include <QGCLoggingCategory.h>
 
-#include <QtNetwork/QNetworkRequest>
-#include <QtNetwork/QNetworkReply>
 #include <QtLocation/private/qgeotilespec_p.h>
+#include <QtNetwork/QNetworkProxy>
+#include <QtNetwork/QNetworkReply>
+#include <QtNetwork/QNetworkRequest>
 
 QGC_LOGGING_CATEGORY(TerrainTileManagerLog, "qgc.terrain.terraintilemanager")
 
@@ -31,9 +32,22 @@ TerrainTileManager* TerrainTileManager::instance(void)
     return s_terrainTileManager();
 }
 
-TerrainTileManager::TerrainTileManager(void)
+TerrainTileManager::TerrainTileManager(QObject *parent)
+    : QObject(parent)
+    , _networkManager(new QNetworkAccessManager(this))
 {
+    // qCDebug(TerrainTileManagerLog) << Q_FUNC_INFO << this;
 
+#ifndef __mobile__
+    QNetworkProxy proxy = _networkManager->proxy();
+    proxy.setType(QNetworkProxy::DefaultProxy);
+    _networkManager->setProxy(proxy);
+#endif
+}
+
+TerrainTileManager::~TerrainTileManager()
+{
+    // qCDebug(TerrainTileManagerLog) << Q_FUNC_INFO << this;
 }
 
 void TerrainTileManager::addCoordinateQuery(TerrainOfflineAirMapQuery* terrainQueryInterface, const QList<QGeoCoordinate>& coordinates)
@@ -144,18 +158,15 @@ bool TerrainTileManager::getAltitudesForCoordinates(const QList<QGeoCoordinate>&
             altitudes.push_back(elevation);
         } else {
             if (_state != State::Downloading) {
-                QNetworkRequest request = UrlFactory::getTileURL(
-                    kMapType, UrlFactory::long2tileX(kMapType, coordinate.longitude(), 1),
-                    UrlFactory::lat2tileY(kMapType, coordinate.latitude(), 1),
-                    1);
-                qCDebug(TerrainTileManagerLog) << "TerrainTileManager::getAltitudesForCoordinates query from database" << request.url();
+                const SharedMapProvider provider = UrlFactory::getMapProviderFromProviderType(kMapType);
                 QGeoTileSpec spec;
-                spec.setX(UrlFactory::long2tileX(kMapType, coordinate.longitude(), 1));
-                spec.setY(UrlFactory::lat2tileY(kMapType, coordinate.latitude(), 1));
+                spec.setX(provider->long2tileX(coordinate.longitude(), 1));
+                spec.setY(provider->lat2tileY(coordinate.latitude(), 1));
                 spec.setZoom(1);
-                spec.setMapId(UrlFactory::getQtMapIdFromProviderType(kMapType));
-                QGeoTiledMapReplyQGC* reply = new QGeoTiledMapReplyQGC(&_networkManager, request, spec);
-                connect(reply, &QGeoTiledMapReplyQGC::terrainDone, this, &TerrainTileManager::_terrainDone);
+                spec.setMapId(provider->getMapId());
+                const QNetworkRequest request = QGeoTileFetcherQGC::getNetworkRequest(spec.mapId(), spec.x(), spec.y(), spec.zoom());
+                QGeoTiledMapReplyQGC * const reply = new QGeoTiledMapReplyQGC(_networkManager, request, spec);
+                (void) connect(reply, &QGeoTiledMapReplyQGC::finished, this, &TerrainTileManager::_terrainDone);
                 _state = State::Downloading;
             }
             _tilesMutex.unlock();
@@ -182,7 +193,7 @@ void TerrainTileManager::_tileFailed(void)
     _requestQueue.clear();
 }
 
-void TerrainTileManager::_terrainDone(QByteArray responseBytes, QNetworkReply::NetworkError error)
+void TerrainTileManager::_terrainDone()
 {
     QGeoTiledMapReplyQGC* reply = qobject_cast<QGeoTiledMapReplyQGC*>(QObject::sender());
     _state = State::Idle;
@@ -191,26 +202,26 @@ void TerrainTileManager::_terrainDone(QByteArray responseBytes, QNetworkReply::N
         qCWarning(TerrainTileManagerLog) << "Elevation tile fetched but invalid reply data type.";
         return;
     }
+    reply->deleteLater();
 
     // remove from download queue
-    QGeoTileSpec spec = reply->tileSpec();
-    QString hash = UrlFactory::getTileHash(kMapType, spec.x(), spec.y(), spec.zoom());
+    const QByteArray responseBytes = reply->mapImageData();
+    const QGeoTileSpec spec = reply->tileSpec();
+    const QString hash = UrlFactory::getTileHash(kMapType, spec.x(), spec.y(), spec.zoom());
 
     // handle potential errors
-    if (error != QNetworkReply::NoError) {
-        qCWarning(TerrainTileManagerLog) << "Elevation tile fetching returned error (" << error << ")";
+    if (reply->error() != QGeoTiledMapReplyQGC::NoError) {
+        qCWarning(TerrainTileManagerLog) << "Elevation tile fetching returned error (" << reply->error() << ")";
         _tileFailed();
-        reply->deleteLater();
         return;
     }
     if (responseBytes.isEmpty()) {
         qCWarning(TerrainTileManagerLog) << "Error in fetching elevation tile. Empty response.";
         _tileFailed();
-        reply->deleteLater();
         return;
     }
 
-    qCDebug(TerrainTileManagerLog) << "Received some bytes of terrain data: " << responseBytes.size();
+    qCDebug(TerrainTileManagerLog) << "Received some bytes of terrain data:" << responseBytes.size();
 
     TerrainTile* terrainTile = new TerrainTile(responseBytes);
     if (terrainTile->isValid()) {
@@ -225,7 +236,6 @@ void TerrainTileManager::_terrainDone(QByteArray responseBytes, QNetworkReply::N
         delete terrainTile;
         qCWarning(TerrainTileManagerLog) << "Received invalid tile";
     }
-    reply->deleteLater();
 
     // now try to query the data again
     for (int i = _requestQueue.count() - 1; i >= 0; i--) {
@@ -258,14 +268,17 @@ void TerrainTileManager::_terrainDone(QByteArray responseBytes, QNetworkReply::N
     }
 }
 
-QString TerrainTileManager::_getTileHash(const QGeoCoordinate& coordinate)
+QString TerrainTileManager::_getTileHash(const QGeoCoordinate &coordinate)
 {
-    QString ret = UrlFactory::getTileHash(
-        kMapType,
-        UrlFactory::long2tileX(kMapType, coordinate.longitude(), 1),
-        UrlFactory::lat2tileY(kMapType, coordinate.latitude(), 1),
-        1);
-    qCDebug(TerrainQueryVerboseLog) << "Computing unique tile hash for " << coordinate << ret;
+    const SharedMapProvider provider = UrlFactory::getMapProviderFromProviderType(kMapType);
 
-    return ret;
+    const QString result = UrlFactory::getTileHash(
+        provider->getMapName(),
+        provider->long2tileX(coordinate.longitude(), 1),
+        provider->lat2tileY(coordinate.latitude(), 1),
+        1
+    );
+
+    qCDebug(TerrainQueryVerboseLog) << "Computing unique tile hash for" << coordinate << result;
+    return result;
 }

--- a/src/Terrain/TerrainTileManager.h
+++ b/src/Terrain/TerrainTileManager.h
@@ -27,7 +27,8 @@ class TerrainTileManager : public QObject {
     Q_OBJECT
 
 public:
-    TerrainTileManager(void);
+    TerrainTileManager(QObject *parent = nullptr);
+    ~TerrainTileManager();
 
     void addCoordinateQuery         (TerrainOfflineAirMapQuery* terrainQueryInterface, const QList<QGeoCoordinate>& coordinates);
     void addPathQuery               (TerrainOfflineAirMapQuery* terrainQueryInterface, const QGeoCoordinate& startPoint, const QGeoCoordinate& endPoint);
@@ -37,7 +38,7 @@ public:
     static QList<QGeoCoordinate> pathQueryToCoords(const QGeoCoordinate& fromCoord, const QGeoCoordinate& toCoord, double& distanceBetween, double& finalDistanceBetween);
 
 private slots:
-    void _terrainDone(QByteArray responseBytes, QNetworkReply::NetworkError error);
+    void _terrainDone();
 
 private:
     enum class State {
@@ -64,7 +65,7 @@ private:
 
     QList<QueuedRequestInfo_t>  _requestQueue;
     State                       _state = State::Idle;
-    QNetworkAccessManager       _networkManager;
+    QNetworkAccessManager*      _networkManager = nullptr;
 
     QMutex                      _tilesMutex;
     QHash<QString, TerrainTile> _tiles;

--- a/src/Viewer3D/Viewer3DTileReply.cc
+++ b/src/Viewer3D/Viewer3DTileReply.cc
@@ -1,13 +1,13 @@
 #include "Viewer3DTileReply.h"
 
-#include "QGCMapEngine.h"
-#include "MapProvider.h"
-#include "QGCMapUrlEngine.h"
+#include <MapProvider.h>
+#include <QGCMapUrlEngine.h>
+#include <QGeoTileFetcherQGC.h>
 
 #include <QtCore/QFile>
+#include <QtCore/QTimer>
 #include <QtNetwork/QNetworkAccessManager>
 #include <QtNetwork/QNetworkReply>
-#include <QtCore/QTimer>
 
 QByteArray  Viewer3DTileReply::_bingNoTileImage;
 
@@ -47,7 +47,7 @@ Viewer3DTileReply::~Viewer3DTileReply()
 
 void Viewer3DTileReply::prepareDownload()
 {
-    QNetworkRequest request = UrlFactory::getTileURL(_mapId, _tile.x, _tile.y, _tile.zoomLevel);
+    const QNetworkRequest request = QGeoTileFetcherQGC::getNetworkRequest(_mapId, _tile.x, _tile.y, _tile.zoomLevel);
     _reply = _networkManager->get(request);
     connect(_reply, &QNetworkReply::finished, this, &Viewer3DTileReply::requestFinished);
     connect(_reply, &QNetworkReply::errorOccurred, this, &Viewer3DTileReply::requestError);


### PR DESCRIPTION
Updates the QGeoMapReplyQGC implementation to be more agnostic to the being used for altitude and tiles, and create the network requests in the tilefetcher instead of the map providers