### PR TITLE
Fix for #11687 (Joystick out of screen) + misclick

### DIFF
--- a/src/FlightDisplay/FlyViewWidgetLayer.qml
+++ b/src/FlightDisplay/FlyViewWidgetLayer.qml
@@ -138,9 +138,23 @@ Item {
         // Width is difficult to access directly hence this hack which may not work in all circumstances
         property real leftEdgeBottomInset:  visible ? bottomEdgeLeftInset + width/18 - ScreenTools.defaultFontPixelHeight*2 : 0
         property real rightEdgeBottomInset: visible ? bottomEdgeRightInset + width/18 - ScreenTools.defaultFontPixelHeight*2 : 0
+        property real rootWidth:            _root.width
+        property var  itemX:                virtualJoystickMultiTouch.x   // real X on screen
+
+        onRootWidthChanged: virtualJoystickMultiTouch.status == Loader.Ready && visible ? virtualJoystickMultiTouch.item.uiTotalWidth = rootWidth : undefined
+        onItemXChanged:     virtualJoystickMultiTouch.status == Loader.Ready && visible ? virtualJoystickMultiTouch.item.uiRealX = itemX : undefined
 
         //Loader status logic
-        onLoaded:           virtualJoystickMultiTouch.visible ?  virtualJoystickMultiTouch.item.calibration = true : virtualJoystickMultiTouch.item.calibration = false
+        onLoaded: {
+            if(virtualJoystickMultiTouch.visible) {
+                virtualJoystickMultiTouch.item.calibration = true 
+                virtualJoystickMultiTouch.item.uiTotalWidth = rootWidth
+                virtualJoystickMultiTouch.item.uiRealX = itemX
+            }
+            else {
+                virtualJoystickMultiTouch.item.calibration = false
+            }
+        }
     }
 
     FlyViewToolStrip {

--- a/src/FlightDisplay/FlyViewWidgetLayer.qml
+++ b/src/FlightDisplay/FlyViewWidgetLayer.qml
@@ -146,12 +146,11 @@ Item {
 
         //Loader status logic
         onLoaded: {
-            if(virtualJoystickMultiTouch.visible) {
+            if (virtualJoystickMultiTouch.visible) {
                 virtualJoystickMultiTouch.item.calibration = true 
                 virtualJoystickMultiTouch.item.uiTotalWidth = rootWidth
                 virtualJoystickMultiTouch.item.uiRealX = itemX
-            }
-            else {
+            } else {
                 virtualJoystickMultiTouch.item.calibration = false
             }
         }

--- a/src/FlightDisplay/VirtualJoystick.qml
+++ b/src/FlightDisplay/VirtualJoystick.qml
@@ -26,6 +26,8 @@ Item {
     property bool  _initialConnectComplete:   _activeVehicle ? _activeVehicle.initialConnectComplete : false
     property real  leftYAxisValue:            autoCenterThrottle ? height / 2 : height
     property var   calibration:               false
+    property var   uiTotalWidth
+    property var   uiRealX
         
     Timer {
         interval:   40  // 25Hz, same as real joystick rate

--- a/src/QmlControls/JoystickThumbPad.qml
+++ b/src/QmlControls/JoystickThumbPad.qml
@@ -111,16 +111,13 @@ Item {
         var isRightJoystick = _joyRoot.x > uiTotalWidth / 2 ? true : false
 
         // Check if new xDelta will make joystick to be beyond screen boundaries or can cause a misclick
-        if ( !limitOffset && isRightJoystick && touchPoints[0].x  <= maxDelta || !limitOffset && !isRightJoystick && touchPoints[0].x >= maxDelta ) {
+        if (!limitOffset && isRightJoystick && touchPoints[0].x  <= maxDelta || !limitOffset && !isRightJoystick && touchPoints[0].x >= maxDelta) {
             xPositionDelta = touchPoints[0].x - _centerXY
-        }
-        else if( limitOffset && !isRightJoystick && touchPoints[0].x >= _centerXY * 0.25 && touchPoints[0].x <= _centerXY * 2 ) { // more offset at the side near to the center
+        } else if (limitOffset && !isRightJoystick && touchPoints[0].x >= _centerXY * 0.25 && touchPoints[0].x <= _centerXY * 2) { // more offset at the side near to the center
             xPositionDelta = touchPoints[0].x - _centerXY
-        }
-        else if( limitOffset && isRightJoystick && touchPoints[0].x >= 0 && touchPoints[0].x <= _centerXY * 1.75 ) {
+        } else if (limitOffset && isRightJoystick && touchPoints[0].x >= 0 && touchPoints[0].x <= _centerXY * 1.75) {
             xPositionDelta = touchPoints[0].x - _centerXY
-        }
-        else {
+        } else {
             return;
         }
 

--- a/src/QmlControls/JoystickThumbPad.qml
+++ b/src/QmlControls/JoystickThumbPad.qml
@@ -105,7 +105,25 @@ Item {
     function thumbDown(touchPoints) {
         // Position the control around the initial thumb position
         _centerXY = _joyRoot.width / 2  // make sure to know the correct center of the item
-        xPositionDelta = touchPoints[0].x - _centerXY
+
+        var limitOffset = uiRealX >= _joyRoot.width / 2 ? true : false // as the joystick become small the UI too so we limit the maxOffset for reCentering joystick to prevent misclicks
+        var maxDelta = _joyRoot.x > uiTotalWidth / 2  ? uiTotalWidth - uiRealX - _joyRoot.x - _centerXY : uiRealX
+        var isRightJoystick = _joyRoot.x > uiTotalWidth / 2 ? true : false
+
+        // Check if new xDelta will make joystick to be beyond screen boundaries or can cause a misclick
+        if ( !limitOffset && isRightJoystick && touchPoints[0].x  <= maxDelta || !limitOffset && !isRightJoystick && touchPoints[0].x >= maxDelta ) {
+            xPositionDelta = touchPoints[0].x - _centerXY
+        }
+        else if( limitOffset && !isRightJoystick && touchPoints[0].x >= _centerXY * 0.25 && touchPoints[0].x <= _centerXY * 2 ) { // more offset at the side near to the center
+            xPositionDelta = touchPoints[0].x - _centerXY
+        }
+        else if( limitOffset && isRightJoystick && touchPoints[0].x >= 0 && touchPoints[0].x <= _centerXY * 1.75 ) {
+            xPositionDelta = touchPoints[0].x - _centerXY
+        }
+        else {
+            return;
+        }
+
         if (yAxisPositiveRangeOnly) {
             yPositionDelta = touchPoints[0].y - stickPositionY
         } else {


### PR DESCRIPTION
Fixes #11687. On large screens, the joystick could appear off-screen. Additionally, the reCenter offset has been improved for small screens. Now, there is more offset on the side that is near the center, as there are no widgets there and is more easy to get there with the thumbs, the offset of the side next to the screen boundaries has been decreased.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.