### PR TITLE
Fix build without gstreamer or without Qt6 gstreamer plugin

### DIFF
--- a/src/VideoManager/VideoReceiver/GStreamer/CMakeLists.txt
+++ b/src/VideoManager/VideoReceiver/GStreamer/CMakeLists.txt
@@ -1,12 +1,26 @@
 add_subdirectory(${CMAKE_SOURCE_DIR}/libs/qmlglsink qmlglsink.build)
 
+find_package(Qt6 REQUIRED COMPONENTS Core Quick)
+
 if(NOT GST_QT6_PLUGIN_FOUND)
+    qt_add_library(GStreamerReceiver STATIC
+        GLVideoItemStub.h
+    )
+
+    target_link_libraries(GStreamerReceiver
+        PRIVATE
+            Qt6::Quick
+            Utilities
+        PUBLIC
+            Qt6::Core
+    )
+
+    target_include_directories(GStreamerReceiver PUBLIC ${CMAKE_CURRENT_SOURCE_DIR})
+
     return()
 endif()
 
 message(STATUS "Building GStreamer VideoReceiver")
-
-find_package(Qt6 REQUIRED COMPONENTS Core Quick)
 
 qt_add_library(GStreamerReceiver STATIC
     GLVideoItemStub.h

--- a/src/VideoManager/VideoReceiver/GStreamer/CMakeLists.txt
+++ b/src/VideoManager/VideoReceiver/GStreamer/CMakeLists.txt
@@ -10,7 +10,6 @@ if(NOT GST_QT6_PLUGIN_FOUND)
     target_link_libraries(GStreamerReceiver
         PRIVATE
             Qt6::Quick
-            Utilities
         PUBLIC
             Qt6::Core
     )


### PR DESCRIPTION
VideoReceiver: provide GLVideoItemStub.h in public library interface if gstreamer is missing or Qt6 plugin wasn't found

Description
-----------
Currently, build is failing due to GLVideoItemStub.h being included in VideoManager.cc:
```
#ifdef QGC_GST_STREAMING
#include "GStreamer.h"
#include "VideoDecoderOptions.h"
#else
#include "GLVideoItemStub.h"
#endif
```
This header file is expected to be provided by VideoReceiver::GStreamer library. However, this library is not built at all due to early return statement in its CMakeLists.txt:
```
if(NOT GST_QT6_PLUGIN_FOUND)
    return()
endif()
```
I have fixed it by still building this library (with a single GLVideoItemStub.h) file.

Test Steps
-----------
I have tested it by successfully building and launching QGroundControl without gstreamer in Windows, in Release configuration.

Checklist:
----------
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] [Review Contribution Guidelines](https://github.com/mavlink/qgroundcontrol/blob/master/.github/CONTRIBUTING.md).
- [x] [Review Code of Conduct](https://github.com/mavlink/qgroundcontrol/blob/master/.github/CODE_OF_CONDUCT.md).
- [x] I have tested my changes.

Related Issue
-----------
<!-- If any, please provide issue ID. -->


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.