### PR TITLE
Docs: Update Release Version to v4.4

### DIFF
--- a/docs/.vitepress/config.mjs
+++ b/docs/.vitepress/config.mjs
@@ -159,8 +159,8 @@ export default defineConfig({
             link: "https://docs.qgroundcontrol.com/master/en/",
           },
           {
-            text: "v4.3",
-            link: "https://docs.qgroundcontrol.com/Stable_V4.3/en/",
+            text: "v4.4",
+            link: "https://docs.qgroundcontrol.com/Stable_V4.4/en/",
           },
         ],
       },


### PR DESCRIPTION
Website currently shows 4.3 instead of 4.4, not sure if this is the correct way to update this or not.