### PR TITLE
Android: Remove Unneeded USB IDs

### DIFF
--- a/android/src/org/mavlink/qgroundcontrol/QGCUsbId.java
+++ b/android/src/org/mavlink/qgroundcontrol/QGCUsbId.java
@@ -2,40 +2,6 @@ package org.mavlink.qgroundcontrol;
 
 public final class QGCUsbId {
 
-    public static final int VENDOR_FTDI = 0x0403;
-    public static final int FTDI_FT232R = 0x6001;
-    public static final int FTDI_FT2232H = 0x6010;
-    public static final int FTDI_FT4232H = 0x6011;
-    public static final int FTDI_FT232H = 0x6014;
-    public static final int FTDI_FT231X = 0x6015; // same ID for FT230X, FT231X, FT234XD
-
-    public static final int VENDOR_SILABS = 0x10c4;
-    public static final int SILABS_CP2102 = 0xea60; // same ID for CP2101, CP2103, CP2104, CP2109
-    public static final int SILABS_CP2105 = 0xea70;
-    public static final int SILABS_CP2108 = 0xea71;
-
-    public static final int VENDOR_PROLIFIC = 0x067b;
-    public static final int PROLIFIC_PL2303 = 0x2303;   // device type 01, T, HX
-    public static final int PROLIFIC_PL2303GC = 0x23a3; // device type HXN
-    public static final int PROLIFIC_PL2303GB = 0x23b3; // "
-    public static final int PROLIFIC_PL2303GT = 0x23c3; // "
-    public static final int PROLIFIC_PL2303GL = 0x23d3; // "
-    public static final int PROLIFIC_PL2303GE = 0x23e3; // "
-    public static final int PROLIFIC_PL2303GS = 0x23f3; // "
-
-    public static final int VENDOR_GOOGLE = 0x18d1;
-    public static final int GOOGLE_CR50 = 0x5014;
-
-    public static final int VENDOR_QINHENG = 0x1a86;
-    public static final int QINHENG_CH340 = 0x7523;
-    public static final int QINHENG_CH341A = 0x5523;
-
-    public static final int VENDOR_UNISOC = 0x1782;
-    public static final int FIBOCOM_L610 = 0x4D10;
-    public static final int FIBOCOM_L612 = 0x4D12;
-
-    //////////////////////////////////////////////
-
     public static final int VENDOR_PX4 = 0x26AC;
     public static final int DEVICE_PX4FMU_V1 = 0x0010;
     public static final int DEVICE_PX4FMU_V2 = 0x0011;
@@ -49,26 +15,6 @@ public final class QGCUsbId {
     public static final int DEVICE_PX4FMU_V6X = 0x0035;
     public static final int DEVICE_PX4FMU_V6XRT = 0x001D;
     public static final int DEVICE_PX4MINDPX_V2 = 0x0030;
-
-    public static final int VENDOR_ATMEL = 0x03EB;
-    public static final int DEVICE_ATMEL_LUFA_CDC_DEMO_APP = 0x2044;
-
-    public static final int VENDOR_ARDUINO = 0x2341;
-    public static final int DEVICE_ARDUINO_UNO = 0x0001;
-    public static final int DEVICE_ARDUINO_MEGA_2560 = 0x0010;
-    public static final int DEVICE_ARDUINO_SERIAL_ADAPTER = 0x003b;
-    public static final int DEVICE_ARDUINO_MEGA_ADK = 0x003f;
-    public static final int DEVICE_ARDUINO_MEGA_2560_R3 = 0x0042;
-    public static final int DEVICE_ARDUINO_UNO_R3 = 0x0043;
-    public static final int DEVICE_ARDUINO_MEGA_ADK_R3 = 0x0044;
-    public static final int DEVICE_ARDUINO_SERIAL_ADAPTER_R3 = 0x0044;
-    public static final int DEVICE_ARDUINO_LEONARDO = 0x8036;
-
-    public static final int VENDOR_VAN_OOIJEN_TECH = 0x16c0;
-    public static final int DEVICE_VAN_OOIJEN_TECH_TEENSYDUINO_SERIAL = 0x0483;
-
-    public static final int VENDOR_LEAFLABS = 0x1eaf;
-    public static final int DEVICE_LEAFLABS_MAPLE = 0x0004;
 
     public static final int VENDOR_UBLOX = 0x1546;
     public static final int DEVICE_UBLOX_5 = 0x01a5;


### PR DESCRIPTION
These are included in the default UsbId.java from the library