### PR TITLE
More work on Mavlink Signing

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -8,6 +8,7 @@ Note: This file only contains high level features or important fixes.
 * You can select between multiple instruments by clicking on the instrument conntrol on a desktop build or press and hold on mobile builds
 * Support for Fly View and Joystick custom mavlink actions has changed. Both the name and formation of the command file is different now. Go to QGC docs to understand how it works now.
 * Support for setting individual Mavlink message rates in the Mavlink Inspector.
+* Support for Mavlink 2 signing
 
 ## 4.1
 

--- a/qgroundcontrol.pro
+++ b/qgroundcontrol.pro
@@ -779,7 +779,7 @@ SOURCES += \
     src/PositionManager/SimulatedPosition.cc \
     src/Geo/QGCGeo.cc \
     src/Utilities/QGC.cc \
-    src/Utilities/DeviceInfo.cc \
+    src/Utilities/QGCDeviceInfo.cc \
     src/QGCApplication.cc \
     src/Utilities/QGCCachedFileDownload.cc \
     src/Utilities/QGCFileDownload.cc \

--- a/src/AnalyzeView/LogDownloadController.cc
+++ b/src/AnalyzeView/LogDownloadController.cc
@@ -386,9 +386,8 @@ void
 LogDownloadController::_requestLogData(uint16_t id, uint32_t offset, uint32_t count, int retryCount)
 {
     if (_vehicle) {
-        WeakLinkInterfacePtr weakLink = _vehicle->vehicleLinkManager()->primaryLink();
-        if (!weakLink.expired()) {
-            SharedLinkInterfacePtr sharedLink = weakLink.lock();
+        SharedLinkInterfacePtr sharedLink = _vehicle->vehicleLinkManager()->primaryLink().lock();
+        if (sharedLink) {
 
             //-- APM "Fix"
             id += _apmOneBased;
@@ -422,10 +421,8 @@ LogDownloadController::_requestLogList(uint32_t start, uint32_t end)
     if(_vehicle) {
         qCDebug(LogDownloadControllerLog) << "Request log entry list (" << start << "through" << end << ")";
         _setListing(true);
-        WeakLinkInterfacePtr weakLink = _vehicle->vehicleLinkManager()->primaryLink();
-        if (!weakLink.expired()) {
-            SharedLinkInterfacePtr sharedLink = weakLink.lock();
-
+        SharedLinkInterfacePtr sharedLink = _vehicle->vehicleLinkManager()->primaryLink().lock();
+        if (sharedLink) {
             mavlink_message_t msg;
             mavlink_msg_log_request_list_pack_chan(
                         qgcApp()->toolbox()->mavlinkProtocol()->getSystemId(),
@@ -595,10 +592,8 @@ void
 LogDownloadController::eraseAll(void)
 {
     if(_vehicle) {
-        WeakLinkInterfacePtr weakLink = _vehicle->vehicleLinkManager()->primaryLink();
-        if (!weakLink.expired()) {
-            SharedLinkInterfacePtr sharedLink = weakLink.lock();
-
+        SharedLinkInterfacePtr sharedLink = _vehicle->vehicleLinkManager()->primaryLink().lock();
+        if (sharedLink) {
             mavlink_message_t msg;
             mavlink_msg_log_erase_pack_chan(
                         qgcApp()->toolbox()->mavlinkProtocol()->getSystemId(),

--- a/src/AutoPilotPlugins/APM/APMSensorsComponentController.cc
+++ b/src/AutoPilotPlugins/APM/APMSensorsComponentController.cc
@@ -458,10 +458,9 @@ void APMSensorsComponentController::cancelCalibration(void)
 
 void APMSensorsComponentController::nextClicked(void)
 {
-    WeakLinkInterfacePtr weakLink = _vehicle->vehicleLinkManager()->primaryLink();
-    if (!weakLink.expired()) {
+    SharedLinkInterfacePtr sharedLink = _vehicle->vehicleLinkManager()->primaryLink().lock();
+    if (sharedLink) {
         mavlink_message_t       msg;
-        SharedLinkInterfacePtr  sharedLink = weakLink.lock();
 
         mavlink_msg_command_ack_pack_chan(qgcApp()->toolbox()->mavlinkProtocol()->getSystemId(),
                                           qgcApp()->toolbox()->mavlinkProtocol()->getComponentId(),
@@ -494,12 +493,11 @@ bool APMSensorsComponentController::accelSetupNeeded(void) const
 
 bool APMSensorsComponentController::usingUDPLink(void)
 {
-    WeakLinkInterfacePtr weakLink = _vehicle->vehicleLinkManager()->primaryLink();
-    if (weakLink.expired()) {
-        return false;
-    } else {
-        SharedLinkInterfacePtr sharedLink = weakLink.lock();
+    SharedLinkInterfacePtr sharedLink = _vehicle->vehicleLinkManager()->primaryLink().lock();
+    if (sharedLink) {
         return sharedLink->linkConfiguration()->type() == LinkConfiguration::TypeUdp;
+    } else {
+        return false;
     }
 }
 

--- a/src/AutoPilotPlugins/PX4/SensorsComponentController.cc
+++ b/src/AutoPilotPlugins/PX4/SensorsComponentController.cc
@@ -64,12 +64,11 @@ SensorsComponentController::SensorsComponentController(void)
 
 bool SensorsComponentController::usingUDPLink(void)
 {
-    WeakLinkInterfacePtr weakLink = _vehicle->vehicleLinkManager()->primaryLink();
-    if (weakLink.expired()) {
-        return false;
-    } else {
-        SharedLinkInterfacePtr sharedLink = weakLink.lock();
+    SharedLinkInterfacePtr sharedLink = _vehicle->vehicleLinkManager()->primaryLink().lock();
+    if (sharedLink) {
         return sharedLink->linkConfiguration()->type() == LinkConfiguration::TypeUdp;
+    } else {
+        return false;
     }
 }
 

--- a/src/Camera/QGCCameraIO.cc
+++ b/src/Camera/QGCCameraIO.cc
@@ -140,10 +140,8 @@ QGCCameraParamIO::sendParameter(bool updateUI)
 void
 QGCCameraParamIO::_sendParameter()
 {
-    WeakLinkInterfacePtr weakLink = _vehicle->vehicleLinkManager()->primaryLink();
-    if (!weakLink.expired()) {
-        SharedLinkInterfacePtr sharedLink = weakLink.lock();
-
+    SharedLinkInterfacePtr sharedLink = _vehicle->vehicleLinkManager()->primaryLink().lock();
+    if (sharedLink) {
         mavlink_param_ext_set_t p;
         memset(&p, 0, sizeof(mavlink_param_ext_set_t));
         param_ext_union_t   union_value;
@@ -364,10 +362,8 @@ QGCCameraParamIO::paramRequest(bool reset)
         _forceUIUpdate  = true;
     }
     qCDebug(CameraIOLog) << "Request parameter:" << _fact->name();
-    WeakLinkInterfacePtr weakLink = _vehicle->vehicleLinkManager()->primaryLink();
-    if (!weakLink.expired()) {
-        SharedLinkInterfacePtr sharedLink = weakLink.lock();
-
+    SharedLinkInterfacePtr sharedLink = _vehicle->vehicleLinkManager()->primaryLink().lock();
+    if (sharedLink) {
         char param_id[MAVLINK_MSG_PARAM_EXT_REQUEST_READ_FIELD_PARAM_ID_LEN + 1];
         memset(param_id, 0, sizeof(param_id));
         strncpy(param_id, _fact->name().toStdString().c_str(), MAVLINK_MSG_PARAM_EXT_REQUEST_READ_FIELD_PARAM_ID_LEN);

--- a/src/Camera/VehicleCameraControl.cc
+++ b/src/Camera/VehicleCameraControl.cc
@@ -1144,10 +1144,8 @@ VehicleCameraControl::_requestAllParameters()
             qCritical() << "QGCParamIO is NULL" << paramName;
         }
     }
-    WeakLinkInterfacePtr weakLink = _vehicle->vehicleLinkManager()->primaryLink();
-    if (!weakLink.expired()) {
-        SharedLinkInterfacePtr sharedLink = weakLink.lock();
-
+    SharedLinkInterfacePtr sharedLink = _vehicle->vehicleLinkManager()->primaryLink().lock();
+    if (sharedLink) {
         MAVLinkProtocol* mavlink = qgcApp()->toolbox()->mavlinkProtocol();
         mavlink_message_t msg;
         mavlink_msg_param_ext_request_list_pack_chan(

--- a/src/Comms/BluetoothLink.cc
+++ b/src/Comms/BluetoothLink.cc
@@ -8,7 +8,7 @@
  ****************************************************************************/
 
 #include "BluetoothLink.h"
-#include "DeviceInfo.h"
+#include "QGCDeviceInfo.h"
 
 #include <QtBluetooth/QBluetoothDeviceDiscoveryAgent>
 #include <QtBluetooth/QBluetoothSocket>

--- a/src/Comms/LinkInterface.h
+++ b/src/Comms/LinkInterface.h
@@ -34,6 +34,7 @@ public:
 
     virtual bool isConnected() const = 0;
     virtual bool isLogReplay() { return false; }
+    virtual bool isSecureConnection() { return false; } ///< Returns true if the connection is secure (e.g. USB, wired ethernet)
 
     SharedLinkConfigurationPtr linkConfiguration() { return m_config; }
     uint8_t mavlinkChannel() const;
@@ -44,6 +45,8 @@ public:
     void writeBytesThreadSafe(const char *bytes, int length);
     void addVehicleReference() { ++m_vehicleReferenceCount; }
     void removeVehicleReference();
+    bool initMavlinkSigning();
+    void setSigningSignatureFailure(bool failure);
 
 signals:
     void bytesReceived(LinkInterface *link, const QByteArray &data);
@@ -78,6 +81,7 @@ private:
     bool m_decodedFirstMavlinkPacket = false;
     bool m_isPX4Flow = false;
     int m_vehicleReferenceCount = 0;
+    bool _signingSignatureFailure = false;
 };
 
 typedef std::shared_ptr<LinkInterface> SharedLinkInterfacePtr;

--- a/src/Comms/LinkManager.h
+++ b/src/Comms/LinkManager.h
@@ -103,6 +103,9 @@ public:
     /// Returns pointer to the mavlink support forwarding link, or nullptr if it does not exist
     SharedLinkInterfacePtr mavlinkForwardingSupportLink();
 
+    /// Re-initilize the mavlink signing for all links. Used when the signing key changes.
+    void resetMavlinkSigning();
+
     void disconnectAll(void);
 
 #ifdef QT_DEBUG
@@ -125,6 +128,8 @@ public:
     SharedLinkInterfacePtr sharedLinkInterfacePointerForLink(LinkInterface* link, bool ignoreNull=false);
 
     bool containsLink(LinkInterface* link);
+
+    static bool isLinkUSBDirect(LinkInterface* link);
 
     SharedLinkConfigurationPtr addConfiguration(LinkConfiguration* config);
 
@@ -154,7 +159,7 @@ private:
     bool                                _connectionsSuspended;                      ///< true: all new connections should not be allowed
     QString                             _connectionsSuspendedReason;                ///< User visible reason for suspension
     QTimer                              _portListTimer;
-    uint32_t                            _mavlinkChannelsUsedBitMask;
+    uint32_t                            m_mavlinkChannelsUsedBitMask;
 
     AutoConnectSettings*                _autoConnectSettings;
     MAVLinkProtocol*                    _mavlinkProtocol;

--- a/src/Comms/LogReplayLink.h
+++ b/src/Comms/LogReplayLink.h
@@ -118,7 +118,7 @@ private:
     LogReplayLinkConfiguration* _logReplayConfig;
 
     bool    _connected;
-    uint8_t _mavlinkChannel;
+    uint8_t m_mavlinkChannel;
     QTimer  _readTickTimer;      ///< Timer which signals a read of next log record
 
     QString _errorTitle; ///< Title for communicatorError signals

--- a/src/Comms/SerialLink.cc
+++ b/src/Comms/SerialLink.cc
@@ -275,6 +275,11 @@ void SerialLink::_emitLinkError(const QString& errorMsg)
     emit communicationError(tr("Link Error"), msg.arg(m_config->name()).arg(errorMsg));
 }
 
+bool SerialLink::isSecureConnection()
+{
+    return _serialConfig && _serialConfig->usbDirect();
+}
+
 //--------------------------------------------------------------------------
 //-- SerialConfiguration
 

--- a/src/Comms/SerialLink.h
+++ b/src/Comms/SerialLink.h
@@ -108,8 +108,9 @@ public:
     virtual ~SerialLink();
 
     // LinkInterface overrides
-    bool isConnected(void) const override;
-    void disconnect (void) override;
+    bool isConnected        (void) const override;
+    void disconnect         (void) override;
+    bool isSecureConnection (void) override;
 
     /// Don't even think of calling this method!
     QSerialPort* _hackAccessToPort(void) { return _port; }
@@ -124,7 +125,6 @@ private slots:
     void _readBytes     (void);
 
 private:
-
     // LinkInterface overrides
     bool _connect(void) override;
 
@@ -141,5 +141,4 @@ private:
     QMutex                  _stoppMutex;                    ///< Mutex for accessing _stopp
     QByteArray              _transmitBuffer;                ///< An internal buffer for receiving data from member functions and actually transmitting them via the serial port.
     SerialConfiguration*    _serialConfig       = nullptr;
-
 };

--- a/src/Comms/TCPLink.cc
+++ b/src/Comms/TCPLink.cc
@@ -8,6 +8,7 @@
  ****************************************************************************/
 
 #include "TCPLink.h"
+#include "QGCDeviceInfo.h"
 
 #include <QtCore/QList>
 #include <QtNetwork/QTcpSocket>
@@ -145,6 +146,11 @@ void TCPLink::_socketError(QAbstractSocket::SocketError socketError)
 bool TCPLink::isConnected() const
 {
     return _socketIsConnected;
+}
+
+bool TCPLink::isSecureConnection()
+{
+    return QGCDeviceInfo::isNetworkEthernet();
 }
 
 //--------------------------------------------------------------------------

--- a/src/Comms/TCPLink.h
+++ b/src/Comms/TCPLink.h
@@ -71,8 +71,9 @@ public:
     void        signalBytesWritten  (void);
 
     // LinkInterface overrides
-    bool isConnected(void) const override;
-    void disconnect (void) override;
+    bool isConnected        (void) const override;
+    void disconnect         (void) override;
+    bool isSecureConnection (void) override;
 
 private slots:
     void _socketError   (QAbstractSocket::SocketError socketError);

--- a/src/Comms/UDPLink.cc
+++ b/src/Comms/UDPLink.cc
@@ -11,6 +11,7 @@
 #include "QGCApplication.h"
 #include "SettingsManager.h"
 #include "AutoConnectSettings.h"
+#include "QGCDeviceInfo.h"
 
 #include <QtCore/QList>
 #include <QtCore/QMutexLocker>
@@ -302,6 +303,11 @@ void UDPLink::_deregisterZeroconf()
         _dnssServiceRef = NULL;
     }
 #endif
+}
+
+bool UDPLink::isSecureConnection()
+{
+    return QGCDeviceInfo::isNetworkEthernet();
 }
 
 //--------------------------------------------------------------------------

--- a/src/Comms/UDPLink.h
+++ b/src/Comms/UDPLink.h
@@ -98,8 +98,9 @@ public:
     virtual ~UDPLink();
 
     // LinkInterface overrides
-    bool isConnected(void) const override;
-    void disconnect (void) override;
+    bool isConnected        (void) const override;
+    void disconnect         (void) override;
+    bool isSecureConnection (void) override;
 
     // QThread overrides
     void run(void) override;

--- a/src/FactSystem/ParameterManager.h
+++ b/src/FactSystem/ParameterManager.h
@@ -38,14 +38,14 @@ public:
     /// @param uas Uas which this set of facts is associated with
     ParameterManager(Vehicle* vehicle);
 
-    Q_PROPERTY(bool     parametersReady     READ parametersReady    NOTIFY parametersReadyChanged)      ///< true: Parameters are ready for use
-    Q_PROPERTY(bool     missingParameters   READ missingParameters  NOTIFY missingParametersChanged)    ///< true: Parameters are missing from firmware response, false: all parameters received from firmware
-    Q_PROPERTY(double   loadProgress        READ loadProgress       NOTIFY loadProgressChanged)
-    Q_PROPERTY(bool     pendingWrites       READ pendingWrites      NOTIFY pendingWritesChanged)        ///< true: There are still pending write updates against the vehicle
+    Q_PROPERTY(bool     parameterLoadComplete   READ parameterLoadComplete  NOTIFY parameterLoadCompleteChanged)    ///< true: Parameter load complete, still might have missing parameters though
+    Q_PROPERTY(bool     missingParameters       READ missingParameters      NOTIFY missingParametersChanged)        ///< true: Parameters are missing from firmware response, false: all parameters received from firmware
+    Q_PROPERTY(double   loadProgress            READ loadProgress           NOTIFY loadProgressChanged)
+    Q_PROPERTY(bool     pendingWrites           READ pendingWrites          NOTIFY pendingWritesChanged)        ///< true: There are still pending write updates against the vehicle
 
-    bool parametersReady    (void) const { return _parametersReady; }
-    bool missingParameters  (void) const { return _missingParameters; }
-    double loadProgress     (void) const { return _loadProgress; }
+    bool parameterLoadComplete   (void) const { return _parameterLoadComplete; }
+    bool missingParameters      (void) const { return _missingParameters; }
+    double loadProgress         (void) const { return _loadProgress; }
 
     /// @return Directory of parameter caches
     static QDir parameterCacheDir();
@@ -98,11 +98,11 @@ public:
     static constexpr int defaultComponentId = -1;
 
 signals:
-    void parametersReadyChanged     (bool parametersReady);
-    void missingParametersChanged   (bool missingParameters);
-    void loadProgressChanged        (float value);
-    void pendingWritesChanged       (bool pendingWrites);
-    void factAdded                  (int componentId, Fact* fact);
+    void parameterLoadCompleteChanged   (bool parameterLoadComplete);
+    void missingParametersChanged       (bool missingParameters);
+    void loadProgressChanged            (float value);
+    void pendingWritesChanged           (bool pendingWrites);
+    void factAdded                      (int componentId, Fact* fact);
 
 private slots:
     void    _factRawValueUpdated                (const QVariant& rawValue);
@@ -139,8 +139,8 @@ private:
     QMap<int /* comp id */, QMap<QString /* parameter name */, Fact*>> _mapCompId2FactMap;
 
     double      _loadProgress;                  ///< Parameter load progess, [0.0,1.0]
-    bool        _parametersReady;               ///< true: parameter load complete
-    bool        _missingParameters;             ///< true: parameter missing from initial load
+    bool        _parameterLoadComplete;         ///< true: parameter load complete
+    bool        _missingParameters;             ///< true: parameters missing from initial load
     bool        _initialLoadComplete;           ///< true: Initial load of all parameters complete, whether successful or not
     bool        _waitingForDefaultComponent;    ///< true: last chance wait for default component params
     bool        _saveRequired;                  ///< true: _saveToEEPROM should be called

--- a/src/FirmwarePlugin/APM/APMFirmwarePlugin.cc
+++ b/src/FirmwarePlugin/APM/APMFirmwarePlugin.cc
@@ -31,7 +31,7 @@
 #include <StatusTextHandler.h>
 #include "MAVLinkProtocol.h"
 #include "QGCLoggingCategory.h"
-#include <DeviceInfo.h>
+#include "QGCDeviceInfo.h"
 
 #include <QtNetwork/QTcpSocket>
 #include <QtCore/QRegularExpression>

--- a/src/FirmwarePlugin/FirmwarePlugin.cc
+++ b/src/FirmwarePlugin/FirmwarePlugin.cc
@@ -1113,11 +1113,10 @@ QString FirmwarePlugin::gotoFlightMode(void) const
 
 void FirmwarePlugin::sendGCSMotionReport(Vehicle* vehicle, FollowMe::GCSMotionReport& motionReport, uint8_t estimationCapabilities)
 {
-    WeakLinkInterfacePtr weakLink = vehicle->vehicleLinkManager()->primaryLink();
-    if (!weakLink.expired()) {
+    SharedLinkInterfacePtr sharedLink = vehicle->vehicleLinkManager()->primaryLink().lock();
+    if (sharedLink) {
         MAVLinkProtocol*        mavlinkProtocol = qgcApp()->toolbox()->mavlinkProtocol();
         mavlink_follow_target_t follow_target   = {};
-        SharedLinkInterfacePtr  sharedLink      = weakLink.lock();
 
         follow_target.timestamp =           qgcApp()->msecsSinceBoot();
         follow_target.est_capabilities =    estimationCapabilities;

--- a/src/GPS/RTCMMavlink.cc
+++ b/src/GPS/RTCMMavlink.cc
@@ -64,11 +64,10 @@ void RTCMMavlink::sendMessageToVehicle(const mavlink_gps_rtcm_data_t& msg)
     MAVLinkProtocol* mavlinkProtocol = _toolbox.mavlinkProtocol();
     for (int i = 0; i < vehicles.count(); i++) {
         Vehicle*                vehicle     = qobject_cast<Vehicle*>(vehicles[i]);
-        WeakLinkInterfacePtr    weakLink    = vehicle->vehicleLinkManager()->primaryLink();
+        SharedLinkInterfacePtr  sharedLink  = vehicle->vehicleLinkManager()->primaryLink().lock();
 
-        if (!weakLink.expired()) {
+        if (sharedLink) {
             mavlink_message_t       message;
-            SharedLinkInterfacePtr  sharedLink = weakLink.lock();
 
             mavlink_msg_gps_rtcm_data_encode_chan(mavlinkProtocol->getSystemId(),
                                                   mavlinkProtocol->getComponentId(),

--- a/src/MAVLink/MAVLinkSigning.cc
+++ b/src/MAVLink/MAVLinkSigning.cc
@@ -1,32 +1,16 @@
 #include "MAVLinkSigning.h"
 #include "QGCMAVLink.h"
-#include <DeviceInfo.h>
+#include "QGCDeviceInfo.h"
 
 #include <QtCore/QDateTime>
 
 namespace
 {
 
-bool _isSigningPacketsAvailable()
-{
-#ifdef MAVLINK_NO_SIGN_PACKET
-    qCDebug(QGCMAVLinkLog) << "MAVLINK_NO_SIGN_PACKET is defined";
-    return false;
-#else
-    return true;
-#endif
-}
-
-mavlink_signing_t* _getChannelSigning(mavlink_channel_t channel)
+mavlink_signing_t* _getChannelSigning(uint8_t channel)
 {
     mavlink_status_t* const status = mavlink_get_channel_status(channel);
     mavlink_signing_t* const signing = status->signing;
-
-    if (!signing) {
-        qCWarning(QGCMAVLinkLog) << "Signing Not Found For Channel Number:" << channel;
-    } else if (signing->link_id != channel) {
-        qCWarning(QGCMAVLinkLog) << "Signing Link ID Does Not Match Channel:" << channel;
-    }
 
     return signing;
 }
@@ -34,20 +18,6 @@ mavlink_signing_t* _getChannelSigning(mavlink_channel_t channel)
 mavlink_channel_t _getMessageChannel(const mavlink_message_t &message)
 {
     return static_cast<mavlink_channel_t>(message.signature[0]);
-}
-
-void _setSigningEnabled(mavlink_signing_t *signing, bool enabled)
-{
-    if (enabled) {
-        signing->flags |= MAVLINK_SIGNING_FLAG_SIGN_OUTGOING;
-    } else {
-        signing->flags &= ~MAVLINK_SIGNING_FLAG_SIGN_OUTGOING;
-    }
-}
-
-bool _getSigningEnabled(const mavlink_signing_t *signing)
-{
-    return (signing->flags & MAVLINK_SIGNING_FLAG_SIGN_OUTGOING);
 }
 
 void _setSigningKey(mavlink_signing_t *signing, QByteArrayView key, bool randomize = false)
@@ -73,49 +43,56 @@ void _setSigningTimestamp(mavlink_signing_t *signing)
     signing->timestamp = signing_timestamp;
 }
 
-bool _defaultAcceptUnsignedCallback(const mavlink_status_t *status, uint32_t message_id)
-{
-    Q_UNUSED(status);
-
-    static const QSet<uint32_t> unsigned_messages({MAVLINK_MSG_ID_RADIO_STATUS});
-
-    return (unsigned_messages.contains(message_id) || QGCDeviceInfo::isNetworkWired());
-}
-
-void _setSigningAcceptUnsignedCallback(mavlink_signing_t *signing, mavlink_accept_unsigned_t callback)
-{
-    if (callback) {
-        signing->accept_unsigned_callback = callback;
-    } else {
-        signing->accept_unsigned_callback = static_cast<mavlink_accept_unsigned_t>(&_defaultAcceptUnsignedCallback);
-    }
-}
-
 } // namespace
 
 namespace MAVLinkSigning
 {
 
+bool secureConnectionAccceptUnsignedCallback(const mavlink_status_t *status, uint32_t message_id)
+{
+    Q_UNUSED(status);
+    Q_UNUSED(message_id);
+
+    return true;
+}
+
+bool insecureConnectionAccceptUnsignedCallback(const mavlink_status_t *status, uint32_t message_id)
+{
+    Q_UNUSED(status);
+
+    static const QSet<uint32_t> unsigned_messages({MAVLINK_MSG_ID_RADIO_STATUS});
+
+    return unsigned_messages.contains(message_id);
+}
+
+/// Initialize the signing for a channel, both incoming and outgoing
+/// If key is empty signing will be turned off for channel
 bool initSigning(mavlink_channel_t channel, QByteArrayView key, mavlink_accept_unsigned_t callback)
 {
-    if (!_isSigningPacketsAvailable()) {
-        qCWarning(QGCMAVLinkLog) << Q_FUNC_INFO << "Signing is Unavailable";
+    if (!key.isEmpty() && !callback) {
+        qWarning() << Q_FUNC_INFO << "callback must be specified";
         return false;
     }
 
-    static mavlink_signing_t s_signing[MAVLINK_COMM_NUM_BUFFERS];
-    static mavlink_signing_streams_t s_signing_streams;
-
     mavlink_status_t* const status = mavlink_get_channel_status(channel);
-    mavlink_signing_t* const signing = &s_signing[channel];
-    status->signing = signing;
-    status->signing_streams = &s_signing_streams;
+    if (key.isEmpty()) {
+        status->signing = nullptr;
+        status->signing_streams = nullptr;
+    } else {
+        static mavlink_signing_t s_signing[MAVLINK_COMM_NUM_BUFFERS];
+        static mavlink_signing_streams_t s_signing_streams;
 
-    _setSigningKey(signing, key);
-    _setSigningTimestamp(signing);
-    signing->link_id = channel;
-    _setSigningAcceptUnsignedCallback(signing, callback);
-    _setSigningEnabled(signing, !key.isEmpty());
+        mavlink_signing_t* const signing = &s_signing[channel];
+        signing->link_id = channel;
+        signing->flags |= MAVLINK_SIGNING_FLAG_SIGN_OUTGOING;
+        signing->accept_unsigned_callback = callback;
+
+        _setSigningKey(signing, key);
+        _setSigningTimestamp(signing);
+
+        status->signing = signing;
+        status->signing_streams = &s_signing_streams;
+    }
 
     return true;
 }
@@ -131,23 +108,19 @@ bool checkSigningLinkId(mavlink_channel_t channel, const mavlink_message_t &mess
     return (signing->link_id == _getMessageChannel(message));
 }
 
-bool createSetupSigning(mavlink_channel_t channel, mavlink_system_t target_system, mavlink_setup_signing_t &setup_signing)
+/// Create a setup signing message for a target system.
+/// Assumes that signing has already been initialized for the channel.
+void createSetupSigning(mavlink_channel_t channel, mavlink_system_t target_system, mavlink_setup_signing_t &setup_signing)
 {
-    const mavlink_signing_t* const signing = _getChannelSigning(channel);
-    if (!signing) {
-        qCWarning(QGCMAVLinkLog) << Q_FUNC_INFO << "Invalid Signing Pointer for Channel:" << channel;
-        return false;
-    }
-
     (void) memset(&setup_signing, 0, sizeof(setup_signing));
     setup_signing.target_system = target_system.sysid;
     setup_signing.target_component = target_system.compid;
-    if (_getSigningEnabled(signing)) {
+
+    const mavlink_signing_t* const signing = _getChannelSigning(channel);
+    if (signing) {
         setup_signing.initial_timestamp = signing->timestamp;
         (void) memcpy(setup_signing.secret_key, signing->secret_key, sizeof(setup_signing.secret_key));
     }
-
-    return true;
 }
 
 } // namespace MAVLinkSigning

--- a/src/MAVLink/MAVLinkSigning.h
+++ b/src/MAVLink/MAVLinkSigning.h
@@ -7,7 +7,9 @@
 
 namespace MAVLinkSigning
 {
-    bool initSigning(mavlink_channel_t channel, QByteArrayView key, mavlink_accept_unsigned_t callback = nullptr);
+    bool secureConnectionAccceptUnsignedCallback(const mavlink_status_t *s0tatus, uint32_t message_id);
+    bool insecureConnectionAccceptUnsignedCallback(const mavlink_status_t *s0tatus, uint32_t message_id);
+    bool initSigning(mavlink_channel_t channel, QByteArrayView key, mavlink_accept_unsigned_t callback);
     bool checkSigningLinkId(mavlink_channel_t channel, const mavlink_message_t &message);
-    bool createSetupSigning(mavlink_channel_t channel, mavlink_system_t target_system, mavlink_setup_signing_t &setup_signing);
+    void createSetupSigning(mavlink_channel_t channel, mavlink_system_t target_system, mavlink_setup_signing_t &setup_signing);
 }; // namespace MAVLinkSigning

--- a/src/MAVLink/QGCMAVLink.h
+++ b/src/MAVLink/QGCMAVLink.h
@@ -70,6 +70,7 @@ public:
 
     static QString                  mavResultToString           (MAV_RESULT result);
     static QString                  mavSysStatusSensorToString  (MAV_SYS_STATUS_SENSOR sysStatusSensor);
+    static QString                  mavAutopilotToString        (MAV_AUTOPILOT mavAutopilot) { return firmwareClassToString(firmwareClass(mavAutopilot)); }
     static QString                  mavTypeToString             (MAV_TYPE mavType);
     static QString                  firmwareVersionTypeToString (FIRMWARE_VERSION_TYPE firmwareVersionType);
     static int                      motorCount                  (MAV_TYPE mavType, uint8_t frameType = 0);

--- a/src/MissionManager/MissionManager.cc
+++ b/src/MissionManager/MissionManager.cc
@@ -40,11 +40,8 @@ void MissionManager::writeArduPilotGuidedMissionItem(const QGeoCoordinate& gotoC
 
     _connectToMavlink();
 
-    WeakLinkInterfacePtr weakLink = _vehicle->vehicleLinkManager()->primaryLink();
-    if (!weakLink.expired()) {
-        SharedLinkInterfacePtr sharedLink = weakLink.lock();
-
-
+    SharedLinkInterfacePtr sharedLink = _vehicle->vehicleLinkManager()->primaryLink().lock();
+    if (sharedLink) {
         mavlink_message_t       messageOut;
         mavlink_mission_item_t  missionItem;
 

--- a/src/MissionManager/PlanManager.cc
+++ b/src/MissionManager/PlanManager.cc
@@ -102,10 +102,9 @@ void PlanManager::_writeMissionCount(void)
 {
     qCDebug(PlanManagerLog) << QStringLiteral("_writeMissionCount %1 count:_retryCount").arg(_planTypeString()) << _writeMissionItems.count() << _retryCount;
 
-    WeakLinkInterfacePtr weakLink = _vehicle->vehicleLinkManager()->primaryLink();
-    if (!weakLink.expired()) {
+    SharedLinkInterfacePtr sharedLink = _vehicle->vehicleLinkManager()->primaryLink().lock();
+    if (sharedLink) {
         mavlink_message_t       message;
-        SharedLinkInterfacePtr  sharedLink = weakLink.lock();
 
         mavlink_msg_mission_count_pack_chan(
             qgcApp()->toolbox()->mavlinkProtocol()->getSystemId(),
@@ -151,11 +150,9 @@ void PlanManager::_requestList(void)
     _itemIndicesToRead.clear();
     _clearMissionItems();
 
-    WeakLinkInterfacePtr weakLink = _vehicle->vehicleLinkManager()->primaryLink();
-    if (!weakLink.expired()) {
+    SharedLinkInterfacePtr  sharedLink = _vehicle->vehicleLinkManager()->primaryLink().lock();
+    if (sharedLink){
         mavlink_message_t       message;
-        SharedLinkInterfacePtr  sharedLink = weakLink.lock();
-
         mavlink_msg_mission_request_list_pack_chan(qgcApp()->toolbox()->mavlinkProtocol()->getSystemId(),
                                                    qgcApp()->toolbox()->mavlinkProtocol()->getComponentId(),
                                                    sharedLink->mavlinkChannel(),
@@ -294,9 +291,8 @@ void PlanManager::_readTransactionComplete(void)
 {
     qCDebug(PlanManagerLog) << "_readTransactionComplete read sequence complete";
     
-    WeakLinkInterfacePtr weakLink = _vehicle->vehicleLinkManager()->primaryLink();
-    if (!weakLink.expired()) {
-        SharedLinkInterfacePtr  sharedLink = weakLink.lock();
+    SharedLinkInterfacePtr sharedLink = _vehicle->vehicleLinkManager()->primaryLink().lock();
+    if (sharedLink) {
         mavlink_message_t       message;
 
         mavlink_msg_mission_ack_pack_chan(
@@ -359,9 +355,8 @@ void PlanManager::_requestNextMissionItem(void)
 
     qCDebug(PlanManagerLog) << QStringLiteral("_requestNextMissionItem %1 sequenceNumber:retry").arg(_planTypeString()) << _itemIndicesToRead[0] << _retryCount;
 
-    WeakLinkInterfacePtr weakLink = _vehicle->vehicleLinkManager()->primaryLink();
-    if (!weakLink.expired()) {
-        SharedLinkInterfacePtr  sharedLink = weakLink.lock();
+    SharedLinkInterfacePtr sharedLink = _vehicle->vehicleLinkManager()->primaryLink().lock();
+    if (sharedLink) {
         mavlink_message_t       message;
 
         mavlink_msg_mission_request_int_pack_chan(qgcApp()->toolbox()->mavlinkProtocol()->getSystemId(),
@@ -529,10 +524,9 @@ void PlanManager::_handleMissionRequest(const mavlink_message_t& message)
     MissionItem* item = _writeMissionItems[missionRequestSeq];
     qCDebug(PlanManagerLog) << QStringLiteral("_handleMissionRequest %1 sequenceNumber:command").arg(_planTypeString()) << missionRequestSeq << item->command();
 
-    WeakLinkInterfacePtr weakLink = _vehicle->vehicleLinkManager()->primaryLink();
-    if (!weakLink.expired()) {
+    SharedLinkInterfacePtr sharedLink = _vehicle->vehicleLinkManager()->primaryLink().lock();
+    if (sharedLink) {
         mavlink_message_t       messageOut;
-        SharedLinkInterfacePtr  sharedLink = weakLink.lock();
 
         mavlink_msg_mission_item_int_pack_chan(qgcApp()->toolbox()->mavlinkProtocol()->getSystemId(),
                                                qgcApp()->toolbox()->mavlinkProtocol()->getComponentId(),
@@ -880,10 +874,9 @@ void PlanManager::_removeAllWorker(void)
 
     _connectToMavlink();
 
-    WeakLinkInterfacePtr weakLink = _vehicle->vehicleLinkManager()->primaryLink();
-    if (!weakLink.expired()) {
+    SharedLinkInterfacePtr sharedLink = _vehicle->vehicleLinkManager()->primaryLink().lock();
+    if (sharedLink) {
         mavlink_message_t       message;
-        SharedLinkInterfacePtr  sharedLink = weakLink.lock();
 
         mavlink_msg_mission_clear_all_pack_chan(qgcApp()->toolbox()->mavlinkProtocol()->getSystemId(),
                                                 qgcApp()->toolbox()->mavlinkProtocol()->getComponentId(),

--- a/src/MissionManager/PlanMasterController.cc
+++ b/src/MissionManager/PlanMasterController.cc
@@ -200,16 +200,15 @@ void PlanMasterController::_activeVehicleChanged(Vehicle* activeVehicle)
 
 void PlanMasterController::loadFromVehicle(void)
 {
-    WeakLinkInterfacePtr weakLink = _managerVehicle->vehicleLinkManager()->primaryLink();
-    if (weakLink.expired()) {
-        // Vehicle is shutting down
-        return;
-    } else {
-        SharedLinkInterfacePtr sharedLink = weakLink.lock();
+    SharedLinkInterfacePtr sharedLink = _managerVehicle->vehicleLinkManager()->primaryLink().lock();
+    if (sharedLink) {
         if (sharedLink->linkConfiguration()->isHighLatency()) {
             qgcApp()->showAppMessage(tr("Download not supported on high latency links."));
             return;
         }
+    } else {
+        // Vehicle is shutting down
+        return;
     }
 
     if (offline()) {
@@ -305,16 +304,15 @@ void PlanMasterController::_sendRallyPointsComplete(void)
 
 void PlanMasterController::sendToVehicle(void)
 {
-    WeakLinkInterfacePtr weakLink = _managerVehicle->vehicleLinkManager()->primaryLink();
-    if (weakLink.expired()) {
-        // Vehicle is shutting down
-        return;
-    } else {
-        SharedLinkInterfacePtr sharedLink = weakLink.lock();
+    SharedLinkInterfacePtr sharedLink = _managerVehicle->vehicleLinkManager()->primaryLink().lock();
+    if (sharedLink) {
         if (sharedLink->linkConfiguration()->isHighLatency()) {
             qgcApp()->showAppMessage(tr("Upload not supported on high latency links."));
             return;
         }
+    } else {
+        // Vehicle is shutting down
+        return;
     }
 
     if (offline()) {

--- a/src/PositionManager/PositionManager.cpp
+++ b/src/PositionManager/PositionManager.cpp
@@ -11,7 +11,7 @@
 #include "QGCApplication.h"
 #include "QGCCorePlugin.h"
 #include "SimulatedPosition.h"
-#include <DeviceInfo.h>
+#include "QGCDeviceInfo.h"
 #include <QGCLoggingCategory.h>
 
 #include <QtCore/QPermissions>

--- a/src/QmlControls/QGroundControlQmlGlobal.cc
+++ b/src/QmlControls/QGroundControlQmlGlobal.cc
@@ -122,57 +122,33 @@ bool QGroundControlQmlGlobal::loadBoolGlobalSetting (const QString& key, bool de
     return settings.value(key, defaultValue).toBool();
 }
 
-void QGroundControlQmlGlobal::startPX4MockLink(bool sendStatusText)
+void QGroundControlQmlGlobal::startMockLink(MockLinkType mockLinkType, bool sendStatusText, bool isSecureConnection)
 {
 #ifdef QT_DEBUG
-    MockLink::startPX4MockLink(sendStatusText);
+    switch (mockLinkType) {
+    case MockLinkTypePX4:
+        MockLink::startMockLink(MAV_AUTOPILOT_PX4, MAV_TYPE_QUADROTOR, sendStatusText, isSecureConnection);
+        break;
+    case MockLinkTypeGeneric:
+        MockLink::startMockLink(MAV_AUTOPILOT_PX4, MAV_TYPE_GENERIC, sendStatusText, isSecureConnection);
+        break;
+    case MockLinkTypeArduCopter:
+        MockLink::startMockLink(MAV_AUTOPILOT_ARDUPILOTMEGA, MAV_TYPE_QUADROTOR, sendStatusText, isSecureConnection);
+        break;
+    case MockLinkTypeArduPlane:
+        MockLink::startMockLink(MAV_AUTOPILOT_ARDUPILOTMEGA, MAV_TYPE_FIXED_WING, sendStatusText, isSecureConnection);
+        break;
+    case MockLinkTypeArduSub:
+        MockLink::startMockLink(MAV_AUTOPILOT_ARDUPILOTMEGA, MAV_TYPE_SUBMARINE, sendStatusText, isSecureConnection);
+        break;
+    case MockLinkTypeArduRover:
+        MockLink::startMockLink(MAV_AUTOPILOT_ARDUPILOTMEGA, MAV_TYPE_GROUND_ROVER, sendStatusText, isSecureConnection);
+        break;
+    }
 #else
+    Q_UNUSED(mockLinkType);
     Q_UNUSED(sendStatusText);
-#endif
-}
-
-void QGroundControlQmlGlobal::startGenericMockLink(bool sendStatusText)
-{
-#ifdef QT_DEBUG
-    MockLink::startGenericMockLink(sendStatusText);
-#else
-    Q_UNUSED(sendStatusText);
-#endif
-}
-
-void QGroundControlQmlGlobal::startAPMArduCopterMockLink(bool sendStatusText)
-{
-#ifdef QT_DEBUG
-    MockLink::startAPMArduCopterMockLink(sendStatusText);
-#else
-    Q_UNUSED(sendStatusText);
-#endif
-}
-
-void QGroundControlQmlGlobal::startAPMArduPlaneMockLink(bool sendStatusText)
-{
-#ifdef QT_DEBUG
-    MockLink::startAPMArduPlaneMockLink(sendStatusText);
-#else
-    Q_UNUSED(sendStatusText);
-#endif
-}
-
-void QGroundControlQmlGlobal::startAPMArduSubMockLink(bool sendStatusText)
-{
-#ifdef QT_DEBUG
-    MockLink::startAPMArduSubMockLink(sendStatusText);
-#else
-    Q_UNUSED(sendStatusText);
-#endif
-}
-
-void QGroundControlQmlGlobal::startAPMArduRoverMockLink(bool sendStatusText)
-{
-#ifdef QT_DEBUG
-    MockLink::startAPMArduRoverMockLink(sendStatusText);
-#else
-    Q_UNUSED(sendStatusText);
+    Q_UNUSED(isSecureConnection);
 #endif
 }
 

--- a/src/QmlControls/QGroundControlQmlGlobal.h
+++ b/src/QmlControls/QGroundControlQmlGlobal.h
@@ -140,13 +140,18 @@ public:
     Q_INVOKABLE void    deleteAllSettingsNextBoot       ();
     Q_INVOKABLE void    clearDeleteAllSettingsNextBoot  ();
 
-    Q_INVOKABLE void    startPX4MockLink            (bool sendStatusText);
-    Q_INVOKABLE void    startGenericMockLink        (bool sendStatusText);
-    Q_INVOKABLE void    startAPMArduCopterMockLink  (bool sendStatusText);
-    Q_INVOKABLE void    startAPMArduPlaneMockLink   (bool sendStatusText);
-    Q_INVOKABLE void    startAPMArduSubMockLink     (bool sendStatusText);
-    Q_INVOKABLE void    startAPMArduRoverMockLink   (bool sendStatusText);
-    Q_INVOKABLE void    stopOneMockLink             (void);
+    enum MockLinkType {
+        MockLinkTypeGeneric,
+        MockLinkTypePX4,
+        MockLinkTypeArduCopter,
+        MockLinkTypeArduPlane,
+        MockLinkTypeArduSub,
+        MockLinkTypeArduRover
+    };
+    Q_ENUM(MockLinkType)
+
+    Q_INVOKABLE void    startMockLink   (MockLinkType mockLinkType, bool sendStatusText, bool isSecureConnection);
+    Q_INVOKABLE void    stopOneMockLink (void);
 
     /// Returns the list of available logging category names.
     Q_INVOKABLE QStringList loggingCategories(void) const { return QGCLoggingCategoryRegister::instance()->registeredCategories(); }

--- a/src/QtLocationPlugin/QGeoMapReplyQGC.cpp
+++ b/src/QtLocationPlugin/QGeoMapReplyQGC.cpp
@@ -5,8 +5,8 @@
 #include "QGCMapEngine.h"
 #include "QGCMapUrlEngine.h"
 #include "QGeoFileTileCacheQGC.h"
+#include "QGCDeviceInfo.h"
 
-#include <DeviceInfo.h>
 #include <QGCFileDownload.h>
 #include <QGCLoggingCategory.h>
 

--- a/src/Settings/App.SettingsGroup.json
+++ b/src/Settings/App.SettingsGroup.json
@@ -326,16 +326,10 @@
     "default": ""
 },
 {
-    "name":      "mavlink2Signing",
-    "shortDesc": "Use MAVLink 2.0 Signing",
-    "type":      "bool",
-    "default":   false
-},
-{
-    "name":      "mavlink2SigningKey",
-    "shortDesc": "MAVLink 2.0 signing key",
-    "type":      "string",
-    "default":   ""
+    "name":             "mavlink2SigningKey",
+    "shortDesc":        "MAVLink 2.0 signing key",
+    "type":             "string",
+    "default":          ""
 }
 ]
 }

--- a/src/Settings/AppSettings.cc
+++ b/src/Settings/AppSettings.cc
@@ -11,6 +11,8 @@
 #include "QGCPalette.h"
 #include "QGCApplication.h"
 #include "QGCMAVLink.h"
+#include "QGCToolbox.h"
+#include "LinkManager.h"
 
 #ifdef Q_OS_ANDROID
 #include "AndroidInterface.h"
@@ -176,8 +178,6 @@ DECLARE_SETTINGSFACT(AppSettings, forwardMavlinkHostName)
 DECLARE_SETTINGSFACT(AppSettings, forwardMavlinkAPMSupportHostName)
 DECLARE_SETTINGSFACT(AppSettings, loginAirLink)
 DECLARE_SETTINGSFACT(AppSettings, passAirLink)
-DECLARE_SETTINGSFACT(AppSettings, mavlink2Signing)
-DECLARE_SETTINGSFACT(AppSettings, mavlink2SigningKey)
 
 DECLARE_SETTINGSFACT_NO_FUNC(AppSettings, indoorPalette)
 {
@@ -232,6 +232,15 @@ DECLARE_SETTINGSFACT_NO_FUNC(AppSettings, qLocaleLanguage)
     return _qLocaleLanguageFact;
 }
 
+DECLARE_SETTINGSFACT_NO_FUNC(AppSettings, mavlink2SigningKey)
+{
+    if (!_mavlink2SigningKeyFact) {
+        _mavlink2SigningKeyFact = _createSettingsFact(mavlink2SigningKeyName);
+        connect(_mavlink2SigningKeyFact, &Fact::rawValueChanged, this, &AppSettings::_mavlink2SigningKeyChanged);
+    }
+    return _mavlink2SigningKeyFact;
+}
+
 void AppSettings::_qLocaleLanguageChanged()
 {
     qgcApp()->setLanguage();
@@ -258,6 +267,11 @@ void AppSettings::_checkSavePathDirectories(void)
 void AppSettings::_indoorPaletteChanged(void)
 {
     QGCPalette::setGlobalTheme(indoorPalette()->rawValue().toBool() ? QGCPalette::Dark : QGCPalette::Light);
+}
+
+void AppSettings::_mavlink2SigningKeyChanged(void)
+{
+    qgcApp()->toolbox()->linkManager()->resetMavlinkSigning();
 }
 
 QString AppSettings::missionSavePath(void)

--- a/src/Settings/AppSettings.h
+++ b/src/Settings/AppSettings.h
@@ -63,7 +63,6 @@ public:
     DEFINE_SETTINGFACT(forwardMavlinkAPMSupportHostName)
     DEFINE_SETTINGFACT(loginAirLink)
     DEFINE_SETTINGFACT(passAirLink)
-    DEFINE_SETTINGFACT(mavlink2Signing)
     DEFINE_SETTINGFACT(mavlink2SigningKey)
 
     // Although this is a global setting it only affects ArduPilot vehicle since PX4 automatically starts the stream from the vehicle side
@@ -132,6 +131,7 @@ private slots:
     void _indoorPaletteChanged();
     void _checkSavePathDirectories();
     void _qLocaleLanguageChanged();
+    void _mavlink2SigningKeyChanged();
 
 private:
     static QLocale::Language _qLocaleLanguageEarlyAccess(void);

--- a/src/UI/preferences/TelemetrySettings.qml
+++ b/src/UI/preferences/TelemetrySettings.qml
@@ -67,22 +67,48 @@ SettingsPage {
             checked:            QGroundControl.isVersionCheckEnabled
             onClicked:          QGroundControl.isVersionCheckEnabled = checked
         }
+    }
 
-        FactCheckBoxSlider {
-            id:                 mavlinkSigningCheckBox
-            Layout.fillWidth:   true
-            text:               qsTr("MAVLink 2 Signing")
-            fact:               _appSettings.mavlink2Signing
-            visible:            fact.visible
+    SettingsGroupLayout {
+        id:                 mavlink2SigningGroup
+        Layout.fillWidth:   true
+        heading:            qsTr("MAVLink 2 Signing")
+        headingDescription: qsTr("Signing keys should only be sent to the vehicle over secure links.")
+        visible:            _mavlink2SigningKey.visible
+
+        property Fact _mavlink2SigningKey: _appSettings.mavlink2SigningKey
+
+        Connections {
+            target:             mavlink2SigningGroup._mavlink2SigningKey
+            onRawValueChanged:  sendToVehiclePrompt.visible = true
         }
 
-        LabelledFactTextField {
-            Layout.fillWidth:           true
-            textFieldPreferredWidth:    ScreenTools.defaultFontPixelWidth * 32
-            label:                      qsTr("MAVLink 2 Signing Key")
-            fact:                       _appSettings.mavlink2SigningKey
-            visible:                    fact.visible
-            // enabled:                    mavlinkSigningCheckBox.checked
+        RowLayout {
+            spacing: ScreenTools.defaultFontPixelWidth
+
+            LabelledFactTextField {
+                Layout.fillWidth:           true
+                textFieldPreferredWidth:    ScreenTools.defaultFontPixelWidth * 32
+                label:                      qsTr("Key")
+                fact:                       mavlink2SigningGroup._mavlink2SigningKey
+            }
+
+            QGCButton {
+                text:       qsTr("Send to Vehicle")
+                enabled:    _activeVehicle
+
+                onClicked: {
+                    sendToVehiclePrompt.visible = false
+                    _activeVehicle.sendSetupSigning()
+                }
+            }
+        }
+
+        QGCLabel {
+            id:                 sendToVehiclePrompt
+            Layout.fillWidth:   true
+            text:               qsTr("Signing key has changed. Don't forget to send to Vehicle(s) if needed.")
+            visible:            false
         }
     }
 

--- a/src/Utilities/CMakeLists.txt
+++ b/src/Utilities/CMakeLists.txt
@@ -3,8 +3,8 @@ add_subdirectory(Compression)
 find_package(Qt6 REQUIRED COMPONENTS Bluetooth Core Gui Network Positioning Sensors Qml Xml)
 
 qt_add_library(Utilities STATIC
-    DeviceInfo.cc
-    DeviceInfo.h
+    QGCDeviceInfo.cc
+    QGCDeviceInfo.h
     JsonHelper.cc
     JsonHelper.h
     KMLDomDocument.cc

--- a/src/Utilities/QGCDeviceInfo.cc
+++ b/src/Utilities/QGCDeviceInfo.cc
@@ -1,4 +1,4 @@
-#include "DeviceInfo.h"
+#include "QGCDeviceInfo.h"
 #include <QGCLoggingCategory.h>
 
 #include <QtCore/qapplicationstatic.h>
@@ -33,7 +33,7 @@ bool isInternetAvailable()
     return (reachability == QNetworkInformation::Reachability::Online);
 }
 
-bool isNetworkWired()
+bool isNetworkEthernet()
 {
     if(QNetworkInformation::availableBackends().isEmpty()) return false;
 

--- a/src/Utilities/QGCDeviceInfo.h
+++ b/src/Utilities/QGCDeviceInfo.h
@@ -13,7 +13,7 @@ namespace QGCDeviceInfo
 
 bool isInternetAvailable();
 bool isBluetoothAvailable();
-bool isNetworkWired();
+bool isNetworkEthernet();
 
 ////////////////////////////////////////////////////////////////////
 

--- a/src/Vehicle/Components/ComponentInformationManager.cc
+++ b/src/Vehicle/Components/ComponentInformationManager.cc
@@ -254,18 +254,14 @@ void RequestMetaDataTypeStateMachine::_stateRequestCompInfo(StateMachine* stateM
 {
     RequestMetaDataTypeStateMachine*    requestMachine  = static_cast<RequestMetaDataTypeStateMachine*>(stateMachine);
     Vehicle*                            vehicle         = requestMachine->_compMgr->vehicle();
-    WeakLinkInterfacePtr                weakLink        = vehicle->vehicleLinkManager()->primaryLink();
 
     if (requestMachine->_compInfo->type != COMP_METADATA_TYPE_GENERAL) {
         requestMachine->advance();
         return;
     }
 
-    if (weakLink.expired()) {
-        qCDebug(ComponentInformationManagerLog) << QStringLiteral("_stateRequestCompInfo Skipping component information %1 request due to no primary link").arg(requestMachine->typeToString());
-        stateMachine->advance();
-    } else {
-        SharedLinkInterfacePtr sharedLink = weakLink.lock();
+    SharedLinkInterfacePtr sharedLink = vehicle->vehicleLinkManager()->primaryLink().lock();
+    if (sharedLink) {
         if (sharedLink->linkConfiguration()->isHighLatency() || sharedLink->isPX4Flow() || sharedLink->isLogReplay()) {
             qCDebug(ComponentInformationManagerLog) << QStringLiteral("_stateRequestCompInfo Skipping component information %1 request due to link type").arg(requestMachine->typeToString());
             stateMachine->advance();
@@ -277,6 +273,9 @@ void RequestMetaDataTypeStateMachine::_stateRequestCompInfo(StateMachine* stateM
                         MAV_COMP_ID_AUTOPILOT1,
                         MAVLINK_MSG_ID_COMPONENT_METADATA);
         }
+    } else {
+        qCDebug(ComponentInformationManagerLog) << QStringLiteral("_stateRequestCompInfo Skipping component information %1 request due to no primary link").arg(requestMachine->typeToString());
+        stateMachine->advance();
     }
 }
 
@@ -284,7 +283,6 @@ void RequestMetaDataTypeStateMachine::_stateRequestCompInfoDeprecated(StateMachi
 {
     RequestMetaDataTypeStateMachine*    requestMachine  = static_cast<RequestMetaDataTypeStateMachine*>(stateMachine);
     Vehicle*                            vehicle         = requestMachine->_compMgr->vehicle();
-    WeakLinkInterfacePtr                weakLink        = vehicle->vehicleLinkManager()->primaryLink();
 
     if (requestMachine->_compInfo->type != COMP_METADATA_TYPE_GENERAL) {
         requestMachine->advance();
@@ -296,11 +294,8 @@ void RequestMetaDataTypeStateMachine::_stateRequestCompInfoDeprecated(StateMachi
         return;
     }
 
-    if (weakLink.expired()) {
-        qCDebug(ComponentInformationManagerLog) << QStringLiteral("_stateRequestCompInfo Skipping component information %1 request due to no primary link").arg(requestMachine->typeToString());
-        stateMachine->advance();
-    } else {
-        SharedLinkInterfacePtr sharedLink = weakLink.lock();
+    SharedLinkInterfacePtr sharedLink = vehicle->vehicleLinkManager()->primaryLink().lock();
+    if (sharedLink) {
         if (sharedLink->linkConfiguration()->isHighLatency() || sharedLink->isPX4Flow() || sharedLink->isLogReplay()) {
             qCDebug(ComponentInformationManagerLog) << QStringLiteral("_stateRequestCompInfo Skipping component information %1 request due to link type").arg(requestMachine->typeToString());
             stateMachine->advance();
@@ -312,6 +307,9 @@ void RequestMetaDataTypeStateMachine::_stateRequestCompInfoDeprecated(StateMachi
                         MAV_COMP_ID_AUTOPILOT1,
                         MAVLINK_MSG_ID_COMPONENT_INFORMATION);
         }
+    } else {
+        qCDebug(ComponentInformationManagerLog) << QStringLiteral("_stateRequestCompInfo Skipping component information %1 request due to no primary link").arg(requestMachine->typeToString());
+        stateMachine->advance();
     }
 }
 

--- a/src/Vehicle/RemoteIDManager.cc
+++ b/src/Vehicle/RemoteIDManager.cc
@@ -191,8 +191,7 @@ void RemoteIDManager::_sendMessages()
 
 void RemoteIDManager::_sendSelfIDMsg()
 {
-    WeakLinkInterfacePtr weakLink = _vehicle->vehicleLinkManager()->primaryLink();
-    SharedLinkInterfacePtr sharedLink = weakLink.lock();
+    SharedLinkInterfacePtr sharedLink = _vehicle->vehicleLinkManager()->primaryLink().lock();
 
     if (sharedLink) {
         mavlink_message_t msg;

--- a/src/Vehicle/TerrainProtocolHandler.cc
+++ b/src/Vehicle/TerrainProtocolHandler.cc
@@ -139,10 +139,9 @@ void TerrainProtocolHandler::_sendTerrainData(const QGeoCoordinate& swCorner, ui
                 terrainData[altIndex++] = static_cast<int16_t>(altitude);
             }
 
-            WeakLinkInterfacePtr weakLink = _vehicle->vehicleLinkManager()->primaryLink();
-            if (!weakLink.expired()) {
+            SharedLinkInterfacePtr sharedLink = _vehicle->vehicleLinkManager()->primaryLink().lock();
+            if (sharedLink) {
                 mavlink_message_t       msg;
-                SharedLinkInterfacePtr  sharedLink = weakLink.lock();
 
                 mavlink_msg_terrain_data_pack_chan(
                             qgcApp()->toolbox()->mavlinkProtocol()->getSystemId(),

--- a/src/Vehicle/Vehicle.cc
+++ b/src/Vehicle/Vehicle.cc
@@ -48,7 +48,7 @@
 #include "VehicleObjectAvoidance.h"
 #include "VideoManager.h"
 #include "VideoSettings.h"
-#include <DeviceInfo.h>
+#include "QGCDeviceInfo.h"
 #include <StatusTextHandler.h>
 #include <MAVLinkSigning.h>
 
@@ -164,7 +164,7 @@ Vehicle::Vehicle(LinkInterface*             link,
 
     // Send MAV_CMD ack timer
     _mavCommandResponseCheckTimer.setSingleShot(false);
-    _mavCommandResponseCheckTimer.setInterval(_mavCommandResponseCheckTimeoutMSecs);
+    _mavCommandResponseCheckTimer.setInterval(qgcApp()->runningUnitTests() ? 100 : _mavCommandResponseCheckTimeoutMSecs);
     _mavCommandResponseCheckTimer.start();
     connect(&_mavCommandResponseCheckTimer, &QTimer::timeout, this, &Vehicle::_sendMavCommandResponseTimeoutCheck);
 
@@ -325,8 +325,6 @@ void Vehicle::_commonInit()
     connect(_toolbox->corePlugin(), &QGCCorePlugin::showAdvancedUIChanged, this, &Vehicle::flightModesChanged);
 
     connect(_imageProtocolManager, &ImageProtocolManager::imageReady, this, &Vehicle::_imageProtocolImageReady);
-
-    (void) connect(_settingsManager->appSettings()->mavlink2Signing(), &Fact::rawValueChanged, this, &Vehicle::_sendSetupSigning);
 
     _createStatusTextHandler();
 
@@ -494,12 +492,6 @@ void Vehicle::_mavlinkMessageReceived(LinkInterface* link, mavlink_message_t mes
             if(packet_lost_count)
                 emit messagesLostChanged();
         }
-    }
-    // TODO: Set Signing AppSetting Based on First Message?
-    const bool mavlinkSigning = message.incompat_flags & MAVLINK_IFLAG_SIGNED;
-    if (mavlinkSigning != _mavlinkSigning) {
-        _mavlinkSigning = mavlinkSigning;
-        emit mavlinkSigningChanged();
     }
 
     // Give the plugin a change to adjust the message contents
@@ -2781,7 +2773,7 @@ void Vehicle::requestMessage(RequestMessageResultHandler resultHandler, void* re
     pInfo->resultHandler        = resultHandler;
     pInfo->resultHandlerData    = resultHandlerData;
 
-    _waitForMavlinkMessage(_requestMessageWaitForMessageResultHandler, pInfo, pInfo->msgId, 1000);
+    _waitForMavlinkMessage(_requestMessageWaitForMessageResultHandler, pInfo, pInfo->msgId, qgcApp()->runningUnitTests() ? 100 : 1000);
 
     Vehicle::MavCmdAckHandlerInfo_t handlerInfo = {};
     handlerInfo.resultHandler       = _requestMessageCmdResultHandler;
@@ -4075,7 +4067,7 @@ void Vehicle::_errorMessageReceived(QString message)
 /*                                 Signing                                   */
 /*===========================================================================*/
 
-void Vehicle::_sendSetupSigning()
+void Vehicle::sendSetupSigning()
 {
     SharedLinkInterfacePtr sharedLink = vehicleLinkManager()->primaryLink().lock();
     if (!sharedLink) {
@@ -4084,17 +4076,6 @@ void Vehicle::_sendSetupSigning()
     }
 
     const mavlink_channel_t channel = static_cast<mavlink_channel_t>(sharedLink->mavlinkChannel());
-    const bool enabled = _settingsManager->appSettings()->mavlink2Signing()->rawValue().toBool();
-
-    QByteArray secret_key("");
-    if (enabled) {
-        secret_key = _settingsManager->appSettings()->mavlink2SigningKey()->rawValue().toByteArray();
-    }
-
-    if (!MAVLinkSigning::initSigning(channel, secret_key, nullptr)) {
-        qCDebug(VehicleLog) << Q_FUNC_INFO << "Failed To Init Signing";
-        return;
-    }
 
     mavlink_setup_signing_t setup_signing;
 
@@ -4102,18 +4083,14 @@ void Vehicle::_sendSetupSigning()
     target_system.sysid = id();
     target_system.compid = defaultComponentId();
 
-    if (!MAVLinkSigning::createSetupSigning(channel, target_system, setup_signing)) {
-        qCDebug(VehicleLog) << Q_FUNC_INFO << "Failed To Create Setup Signing Message";
-        return;
-    }
+    MAVLinkSigning::createSetupSigning(channel, target_system, setup_signing);
 
     mavlink_message_t msg;
     (void) mavlink_msg_setup_signing_encode_chan(_mavlink->getSystemId(), _mavlink->getComponentId(), channel, &msg, &setup_signing);
 
+    // Since we don't get an ack back that the message was received send twice to try to make sure it makes it to the vehicle
     for (uint8_t i = 0; i < 2; ++i) {
-        if (!sendMessageOnLinkThreadSafe(sharedLink.get(), msg)) {
-            qCDebug(VehicleLog) << Q_FUNC_INFO << "Failed To Send on Link";
-        }
+        sendMessageOnLinkThreadSafe(sharedLink.get(), msg);
     }
 }
 

--- a/src/Vehicle/Vehicle.h
+++ b/src/Vehicle/Vehicle.h
@@ -421,6 +421,8 @@ public:
     /// Save the joystick enable setting to the settings group
     Q_INVOKABLE void saveJoystickSettings(void);
 
+    Q_INVOKABLE void sendSetupSigning();
+
     bool    isInitialConnectComplete() const;
     bool    guidedModeSupported     () const;
     bool    pauseVehicleSupported   () const;
@@ -939,7 +941,6 @@ private slots:
     void _doSetHomeTerrainReceived          (bool success, QList<double> heights);
     void _updateAltAboveTerrain             ();
     void _altitudeAboveTerrainReceived      (bool sucess, QList<double> heights);
-    void _sendSetupSigning                  ();
 
 private:
     void _loadJoystickSettings          ();

--- a/src/Vehicle/VehicleLinkManager.cc
+++ b/src/Vehicle/VehicleLinkManager.cc
@@ -245,17 +245,11 @@ SharedLinkInterfacePtr VehicleLinkManager::_bestActivePrimaryLink(void)
     // Best choice is a USB connection
     for (const LinkInfo_t& linkInfo: _rgLinkInfo) {
         if (!linkInfo.commLost) {
-            SharedLinkInterfacePtr  link        = linkInfo.link;
-            SerialLink*             serialLink  = qobject_cast<SerialLink*>(link.get());
-            if (serialLink) {
-                SharedLinkConfigurationPtr config = serialLink->linkConfiguration();
-                if (config) {
-                    SerialConfiguration* serialConfig = qobject_cast<SerialConfiguration*>(config.get());
-                    if (serialConfig && serialConfig->usbDirect()) {
-                        return link;
-                    }
-                }
-            }
+            SharedLinkInterfacePtr link = linkInfo.link;
+            auto linkInterface = link.get();
+            if (linkInterface && LinkManager::isLinkUSBDirect(linkInterface)) {
+                return link;
+            } 
         }
     }
 #endif

--- a/test/AnalyzeView/LogDownloadTest.cc
+++ b/test/AnalyzeView/LogDownloadTest.cc
@@ -23,7 +23,7 @@ LogDownloadTest::LogDownloadTest(void)
 void LogDownloadTest::downloadTest(void)
 {
 
-    _connectMockLink(MAV_AUTOPILOT_PX4);
+    _connectMockLink(MAV_AUTOPILOT_PX4, MAV_TYPE_QUADROTOR);
 
     LogDownloadController* controller = new LogDownloadController();
 

--- a/test/AnalyzeView/MavlinkLogTest.cc
+++ b/test/AnalyzeView/MavlinkLogTest.cc
@@ -124,7 +124,7 @@ void MavlinkLogTest::_bootLogDetectionZeroLength_test(void)
 
 void MavlinkLogTest::_connectLogWorker(bool arm)
 {
-    _connectMockLink();
+    _connectMockLink(MAV_AUTOPILOT_PX4, MAV_TYPE_QUADROTOR);
 
     QDir logSaveDir;
     

--- a/test/FactSystem/FactSystemTestBase.cc
+++ b/test/FactSystem/FactSystemTestBase.cc
@@ -31,7 +31,7 @@ void FactSystemTestBase::_init(MAV_AUTOPILOT autopilot)
 {
     UnitTest::init();
 
-    _connectMockLink(autopilot);
+    _connectMockLink(autopilot, MAV_TYPE_QUADROTOR);
 
     _plugin = qgcApp()->toolbox()->multiVehicleManager()->activeVehicle()->autopilotPlugin();
     Q_ASSERT(_plugin);

--- a/test/FactSystem/ParameterManagerTest.cc
+++ b/test/FactSystem/ParameterManagerTest.cc
@@ -20,14 +20,17 @@
 /// Test failure modes which should still lead to param load success
 void ParameterManagerTest::_noFailureWorker(MockConfiguration::FailureMode_t failureMode)
 {
-    Q_ASSERT(!_mockLink);
-    _mockLink = MockLink::startPX4MockLink(false, failureMode);
-
     MultiVehicleManager* vehicleMgr = qgcApp()->toolbox()->multiVehicleManager();
     QVERIFY(vehicleMgr);
 
-    // Wait for the Vehicle to get created
     QSignalSpy spyVehicle(vehicleMgr, SIGNAL(activeVehicleAvailableChanged(bool)));
+    QSignalSpy spyParamsReady(vehicleMgr, SIGNAL(parameterReadyVehicleAvailableChanged(bool)));
+
+    Q_ASSERT(!_mockLink);
+    _mockLink = MockLink::startMockLink(MAV_AUTOPILOT_PX4, MAV_TYPE_QUADROTOR, false /* sendStatusText */, false /* isSecureConnection */, QString() /* signingKey */, failureMode);
+    QVERIFY(_mockLink);
+
+    // Wait for the Vehicle to get created
     QCOMPARE(spyVehicle.wait(5000), true);
     QCOMPARE(spyVehicle.count(), 1);
     QList<QVariant> arguments = spyVehicle.takeFirst();
@@ -45,7 +48,6 @@ void ParameterManagerTest::_noFailureWorker(MockConfiguration::FailureMode_t fai
     QVERIFY(arguments.at(0).toFloat() > 0.0f);
 
     // When param load is complete we get the param ready signal
-    QSignalSpy spyParamsReady(vehicleMgr, SIGNAL(parameterReadyVehicleAvailableChanged(bool)));
     QCOMPARE(spyParamsReady.wait(60000), true);
     arguments = spyParamsReady.takeFirst();
     QCOMPARE(arguments.count(), 1);
@@ -71,17 +73,20 @@ void ParameterManagerTest::_requestListMissingParamSuccess(void)
 // Test no response to param_request_list
 void ParameterManagerTest::_requestListNoResponse(void)
 {
+    MultiVehicleManager* vehicleMgr = qgcApp()->toolbox()->multiVehicleManager();
+    QVERIFY(vehicleMgr);
+
+    QSignalSpy spyVehicle(vehicleMgr, SIGNAL(activeVehicleAvailableChanged(bool)));
+    QSignalSpy spyParamsReady(vehicleMgr, SIGNAL(parameterReadyVehicleAvailableChanged(bool)));
+
     // Will pop error about request failure
     setExpectedMessageBox(QMessageBox::Ok);
 
     Q_ASSERT(!_mockLink);
-    _mockLink = MockLink::startPX4MockLink(false, MockConfiguration::FailParamNoReponseToRequestList);
-
-    MultiVehicleManager* vehicleMgr = qgcApp()->toolbox()->multiVehicleManager();
-    QVERIFY(vehicleMgr);
+    _mockLink = MockLink::startMockLink(MAV_AUTOPILOT_PX4, MAV_TYPE_QUADROTOR, false /* sendStatusText */, false /* isSecureConnection */, QString() /* signingKey */, MockConfiguration::FailParamNoReponseToRequestList);
+    QVERIFY(_mockLink);
 
     // Wait for the Vehicle to get created
-    QSignalSpy spyVehicle(vehicleMgr, SIGNAL(activeVehicleAvailableChanged(bool)));
     QCOMPARE(spyVehicle.wait(5000), true);
     QCOMPARE(spyVehicle.count(), 1);
     QList<QVariant> arguments = spyVehicle.takeFirst();
@@ -91,12 +96,15 @@ void ParameterManagerTest::_requestListNoResponse(void)
     Vehicle* vehicle = vehicleMgr->activeVehicle();
     QVERIFY(vehicle);
 
-    QSignalSpy spyParamsReady(vehicleMgr, SIGNAL(parameterReadyVehicleAvailableChanged(bool)));
     QSignalSpy spyProgress(vehicle->parameterManager(), SIGNAL(loadProgressChanged(float)));
 
-    // We should not get any progress bar updates, nor a parameter ready signal
-    QCOMPARE(spyProgress.wait(500), false);
-    QCOMPARE(spyParamsReady.wait(40000), false);
+    // We should still get parameterReadyVehicleAvailableChanged but it should be false to signal not loaded
+    QCOMPARE(spyParamsReady.wait(40000), true);
+    QCOMPARE(spyParamsReady.count(), 1);
+    QCOMPARE(spyProgress.count(), 0);
+    arguments = spyParamsReady.takeFirst();
+    QCOMPARE(arguments.count(), 1);
+    QCOMPARE(arguments.at(0).toBool(), false);
 
     // User should have been notified
     checkExpectedMessageBox();
@@ -109,14 +117,17 @@ void ParameterManagerTest::_requestListMissingParamFail(void)
     // Will pop error about missing params
     setExpectedMessageBox(QMessageBox::Ok);
 
-    Q_ASSERT(!_mockLink);
-    _mockLink = MockLink::startPX4MockLink(false, MockConfiguration::FailMissingParamOnAllRequests);
-
     MultiVehicleManager* vehicleMgr = qgcApp()->toolbox()->multiVehicleManager();
     QVERIFY(vehicleMgr);
 
-    // Wait for the Vehicle to get created
     QSignalSpy spyVehicle(vehicleMgr, SIGNAL(activeVehicleAvailableChanged(bool)));
+    QSignalSpy spyParamsReady(vehicleMgr, SIGNAL(parameterReadyVehicleAvailableChanged(bool)));
+
+    Q_ASSERT(!_mockLink);
+    _mockLink = MockLink::startMockLink(MAV_AUTOPILOT_PX4, MAV_TYPE_QUADROTOR, false /* sendStatusText */, false /* isSecureConnection */, QString() /* signingKey */, MockConfiguration::FailMissingParamOnAllRequests);
+    QVERIFY(_mockLink);
+
+    // Wait for the Vehicle to get created
     QCOMPARE(spyVehicle.wait(5000), true);
     QCOMPARE(spyVehicle.count(), 1);
     QList<QVariant> arguments = spyVehicle.takeFirst();
@@ -126,7 +137,6 @@ void ParameterManagerTest::_requestListMissingParamFail(void)
     Vehicle* vehicle = vehicleMgr->activeVehicle();
     QVERIFY(vehicle);
 
-    QSignalSpy spyParamsReady(vehicleMgr, SIGNAL(parameterReadyVehicleAvailableChanged(bool)));
     QSignalSpy spyProgress(vehicle->parameterManager(), SIGNAL(loadProgressChanged(float)));
 
     // We will get progress bar updates, since it will fail after getting partially through the request
@@ -136,7 +146,12 @@ void ParameterManagerTest::_requestListMissingParamFail(void)
     QVERIFY(arguments.at(0).toFloat() > 0.0f);
 
     // We should get a parameters ready signal, but Vehicle should indicate missing params
-    QCOMPARE(spyParamsReady.wait(40000), true);
+    if (!spyParamsReady.count()) {
+        QCOMPARE(spyParamsReady.wait(40000), true);
+    }
+    arguments = spyParamsReady.takeFirst();
+    QCOMPARE(arguments.count(), 1);
+    QCOMPARE(arguments.at(0).toBool(), false);
     QCOMPARE(vehicle->parameterManager()->missingParameters(), true);
 
     // User should have been notified
@@ -145,29 +160,25 @@ void ParameterManagerTest::_requestListMissingParamFail(void)
 
 void ParameterManagerTest::_FTPnoFailure()
 {
-    Q_ASSERT(!_mockLink);
-    _mockLink = MockLink::startAPMArduPlaneMockLink(false, MockConfiguration::FailParamNoReponseToRequestList);
-    _mockLink->mockLinkFTP()->enableBinParamFile(true);
     MultiVehicleManager* vehicleMgr = qgcApp()->toolbox()->multiVehicleManager();
     QVERIFY(vehicleMgr);
 
-    // Wait for the Vehicle to get created
-    QSignalSpy spyVehicle(vehicleMgr, SIGNAL(activeVehicleAvailableChanged(bool)));
-    // When param load is complete we get the param ready signal
     QSignalSpy spyParamsReady(vehicleMgr, SIGNAL(parameterReadyVehicleAvailableChanged(bool)));
-    QCOMPARE(spyVehicle.wait(5000), true);
-    QCOMPARE(spyVehicle.count(), 1);
-    QList<QVariant> arguments = spyVehicle.takeFirst();
+
+    Q_ASSERT(!_mockLink);
+    _mockLink = MockLink::startMockLink(MAV_AUTOPILOT_ARDUPILOTMEGA, MAV_TYPE_FIXED_WING, false /* sendStatusText */, false /* isSecureConnection */, QString() /* signingKey */, MockConfiguration::FailParamNoReponseToRequestList);
+    QVERIFY(_mockLink);
+    _mockLink->mockLinkFTP()->enableBinParamFile(true);
+
+    // When param load is complete we get the param ready signal
+    QCOMPARE(spyParamsReady.wait(5000), true);
+    QCOMPARE(spyParamsReady.count(), 1);
+    auto arguments = spyParamsReady.takeFirst();
     QCOMPARE(arguments.count(), 1);
-    QCOMPARE(arguments.at(0).toBool(), true);
+    QCOMPARE(arguments.at(0).toBool(), false);
+
     Vehicle* vehicle = vehicleMgr->activeVehicle();
     QVERIFY(vehicle);
-
-    spyParamsReady.wait(5000);
-    QCOMPARE(spyParamsReady.count(), 1);
-    arguments = spyParamsReady.takeFirst();
-    QCOMPARE(arguments.count(), 1);
-    QCOMPARE(arguments.at(0).toBool(), true);
 
     // Request all parameters again and check the progress bar. The initial parameterdownload
     // is so fast that I cannot connect to the loadprogress early enough.
@@ -178,6 +189,7 @@ void ParameterManagerTest::_FTPnoFailure()
     arguments = spyProgress.takeFirst();
     QCOMPARE(arguments.count(), 1);
     QVERIFY(arguments.at(0).toFloat() > 0.0f);
+
     // Progress should have been set back to 0
     arguments = spyProgress.takeLast();
     QCOMPARE(arguments.count(), 1);
@@ -186,32 +198,27 @@ void ParameterManagerTest::_FTPnoFailure()
 
 void ParameterManagerTest::_FTPChangeParam()
 {
-    Q_ASSERT(!_mockLink);
-    _mockLink = MockLink::startAPMArduPlaneMockLink(false, MockConfiguration::FailParamNoReponseToRequestList);
-    _mockLink->mockLinkFTP()->enableBinParamFile(true);
     MultiVehicleManager* vehicleMgr = qgcApp()->toolbox()->multiVehicleManager();
     QVERIFY(vehicleMgr);
 
-    // Wait for the Vehicle to get created
     QSignalSpy spyVehicle(vehicleMgr, SIGNAL(activeVehicleAvailableChanged(bool)));
-    // When param load is complete we get the param ready signal
     QSignalSpy spyParamsReady(vehicleMgr, SIGNAL(parameterReadyVehicleAvailableChanged(bool)));
-    QCOMPARE(spyVehicle.wait(5000), true);
-    QCOMPARE(spyVehicle.count(), 1);
-    QList<QVariant> arguments = spyVehicle.takeFirst();
-    QCOMPARE(arguments.count(), 1);
-    QCOMPARE(arguments.at(0).toBool(), true);
-    Vehicle* vehicle = vehicleMgr->activeVehicle();
-    QVERIFY(vehicle);
 
-    if (spyParamsReady.count() == 0)
-        spyParamsReady.wait(5000);
+    Q_ASSERT(!_mockLink);
+    _mockLink = MockLink::startMockLink(MAV_AUTOPILOT_ARDUPILOTMEGA, MAV_TYPE_FIXED_WING, false /* sendStatusText */, false /* isSecureConnection */, QString() /* signingKey */, MockConfiguration::FailParamNoReponseToRequestList);
+    QVERIFY(_mockLink);
+    _mockLink->mockLinkFTP()->enableBinParamFile(true);
+
+    // When param load is complete we get the param ready signal
+    QCOMPARE(spyParamsReady.wait(5000), true);
     QCOMPARE(spyParamsReady.count(), 1);
-    arguments = spyParamsReady.takeFirst();
+    auto arguments = spyParamsReady.takeFirst();
     QCOMPARE(arguments.count(), 1);
     QCOMPARE(arguments.at(0).toBool(), true);
 
     // Now try to change a parameter and check the progress
+    Vehicle* vehicle = vehicleMgr->activeVehicle();
+    QVERIFY(vehicle);
     QSignalSpy spyProgress(vehicle->parameterManager(), SIGNAL(loadProgressChanged(float)));
     Fact* fact = vehicle->parameterManager()->getParameter(MAV_COMP_ID_AUTOPILOT1, "THR_MIN");
     QVERIFY(fact);

--- a/test/FactSystem/ParameterManagerTest.h
+++ b/test/FactSystem/ParameterManagerTest.h
@@ -26,7 +26,6 @@ private slots:
     void _FTPnoFailure(void);
     void _FTPChangeParam(void);
 
-
 private:
     void _noFailureWorker(MockConfiguration::FailureMode_t failureMode);
 };

--- a/test/MAVLink/SigningTest.cc
+++ b/test/MAVLink/SigningTest.cc
@@ -9,22 +9,44 @@
 
 #include "SigningTest.h"
 #include "MAVLinkSigning.h"
+#include "QGCApplication.h"
+#include "QGCToolbox.h"
+#include "SettingsManager.h"
+#include "AppSettings.h"
+#include "MultiVehicleManager.h"
 
 #include <QtTest/QTest>
+#include <QtTest/QSignalSpy>
+
+SigningTest::SigningTest()
+    : _multiVehicleMgr(qgcApp()->toolbox()->multiVehicleManager())
+{
+
+}
 
 void SigningTest::_testInitSigning()
 {
-    QVERIFY(MAVLinkSigning::initSigning(MAVLINK_COMM_0, "secret_key", nullptr));
     const mavlink_status_t *status = mavlink_get_channel_status(MAVLINK_COMM_0);
-    const mavlink_signing_t *signing = status->signing;
-    QVERIFY(memcmp(signing->secret_key, QCryptographicHash::hash("secret_key", QCryptographicHash::Sha256), sizeof(signing->secret_key)) == 0);
-    QVERIFY(MAVLinkSigning::initSigning(MAVLINK_COMM_0, QByteArrayView("1", 32), nullptr));
-    QVERIFY(memcmp(signing->secret_key, QCryptographicHash::hash(QByteArrayView("1", 32), QCryptographicHash::Sha256), sizeof(signing->secret_key)) == 0);
+
+    QVERIFY(!MAVLinkSigning::initSigning(MAVLINK_COMM_0, "secret_key", nullptr));
+
     QVERIFY(MAVLinkSigning::initSigning(MAVLINK_COMM_0, QByteArrayView(), nullptr));
+    QVERIFY(!status->signing);
+
+    QVERIFY(MAVLinkSigning::initSigning(MAVLINK_COMM_0, "secret_key", &MAVLinkSigning::insecureConnectionAccceptUnsignedCallback));
+    QVERIFY(status->signing);
+    QVERIFY(status->signing->link_id == MAVLINK_COMM_0);
+    QVERIFY(status->signing->flags & MAVLINK_SIGNING_FLAG_SIGN_OUTGOING);
+    QVERIFY(status->signing->accept_unsigned_callback == &MAVLinkSigning::insecureConnectionAccceptUnsignedCallback);
+    QVERIFY(memcmp(status->signing->secret_key, QCryptographicHash::hash("secret_key", QCryptographicHash::Sha256), sizeof(status->signing->secret_key)) == 0);
+
+    QVERIFY(MAVLinkSigning::initSigning(MAVLINK_COMM_0, QByteArrayView("1", 32), &MAVLinkSigning::insecureConnectionAccceptUnsignedCallback));
+    QVERIFY(memcmp(status->signing->secret_key, QCryptographicHash::hash(QByteArrayView("1", 32), QCryptographicHash::Sha256), sizeof(status->signing->secret_key)) == 0);
 }
 
 void SigningTest::_testCheckSigningLinkId()
 {
+    QVERIFY(MAVLinkSigning::initSigning(MAVLINK_COMM_0, "secret_key", &MAVLinkSigning::insecureConnectionAccceptUnsignedCallback));
     const mavlink_heartbeat_t heartbeat = {0};
     mavlink_message_t message;
     (void) mavlink_msg_heartbeat_encode_chan(1, MAV_COMP_ID_USER1, MAVLINK_COMM_0, &message, &heartbeat);
@@ -33,12 +55,114 @@ void SigningTest::_testCheckSigningLinkId()
 
 void SigningTest::_testCreateSetupSigning()
 {
-    QVERIFY(MAVLinkSigning::initSigning(MAVLINK_COMM_0, "secret_key", nullptr));
+    QVERIFY(MAVLinkSigning::initSigning(MAVLINK_COMM_0, "secret_key", &MAVLinkSigning::secureConnectionAccceptUnsignedCallback));
     const mavlink_system_t target_system = {1, MAV_COMP_ID_AUTOPILOT1};
     mavlink_setup_signing_t setup_signing;
-    const bool result = MAVLinkSigning::createSetupSigning(MAVLINK_COMM_0, target_system, setup_signing);
-    QVERIFY(result);
+    MAVLinkSigning::createSetupSigning(MAVLINK_COMM_0, target_system, setup_signing);
     QVERIFY(setup_signing.initial_timestamp != 0);
     QCOMPARE(setup_signing.target_system, target_system.sysid);
     QCOMPARE(setup_signing.target_component, target_system.compid);
+}
+
+void SigningTest::_testDenyUnsignedMessages()
+{
+    QSignalSpy spyParamsReady(_multiVehicleMgr, SIGNAL(parameterReadyVehicleAvailableChanged(bool)));
+
+    // Start a MockLink with signing enabled for incoming traffic. But QGC side of pipe is not setup for signing.
+    Q_ASSERT(!_mockLink);
+    _mockLink = MockLink::startMockLink(MAV_AUTOPILOT_PX4, MAV_TYPE_QUADROTOR, false /* sendStatusText */, false /* isSecureConnection */, "SigningKey");
+    QVERIFY(_mockLink);
+
+    // Signing should not be enabled for QGC outgoing traffic
+    const mavlink_status_t *status = mavlink_get_channel_status(_mockLink->mavlinkChannel());
+    const mavlink_signing_t *signing = status->signing;
+    QVERIFY(!signing);
+
+    // Parameters should not download
+    QCOMPARE(spyParamsReady.wait(60000), true);
+    auto arguments = spyParamsReady.takeFirst();
+    QCOMPARE(arguments.count(), 1);
+    QCOMPARE(arguments.at(0).toBool(), false);
+}
+
+void SigningTest::_testBadSignature()
+{
+    QSignalSpy spyParamsReady(_multiVehicleMgr, SIGNAL(parameterReadyVehicleAvailableChanged(bool)));
+
+    // Setup QGC with a signing key which is different than the vehicle signing key
+    auto appSettings = qgcApp()->toolbox()->settingsManager()->appSettings();
+    appSettings->mavlink2SigningKey()->setRawValue("QGCSigningKey");
+
+    // Start a Vehicle with signing enabled for incoming traffic.
+    _mockLink = MockLink::startMockLink(MAV_AUTOPILOT_PX4, MAV_TYPE_QUADROTOR, false /* sendStatusText */, false /* isSecureConnection */, "MockLinkSigningKey");
+    QVERIFY(_mockLink);
+    QSignalSpy spyLastSigningStatusChanged(_mockLink, SIGNAL(lastSigningStatusChanged(int)));
+
+    // Signing should be enabled on outgoing QGC side
+    const mavlink_status_t *status = mavlink_get_channel_status(_mockLink->mavlinkChannel());
+    const mavlink_signing_t *signing = status->signing;
+    QVERIFY(signing);
+
+    // Parameters should not download
+    QCOMPARE(spyParamsReady.wait(60000), true);
+    auto arguments = spyParamsReady.takeFirst();
+    QCOMPARE(arguments.count(), 1);
+    QCOMPARE(arguments.at(0).toBool(), false);
+
+    // Put signing key back to default
+    appSettings->mavlink2SigningKey()->setRawValue("");
+}
+
+void SigningTest::_testGoodSignatures()
+{
+    QString signingKey("SigningKey");
+
+    QSignalSpy spyActiveVehicleChanged(qgcApp()->toolbox()->multiVehicleManager(), &MultiVehicleManager::activeVehicleChanged);
+
+    // Setup QGC with the same signing key as the vehicle
+    auto appSettings = qgcApp()->toolbox()->settingsManager()->appSettings();
+    appSettings->mavlink2SigningKey()->setRawValue(signingKey);
+
+    // Start a Vehicle with signing enabled for incoming traffic.
+    _mockLink = MockLink::startMockLink(MAV_AUTOPILOT_PX4, MAV_TYPE_QUADROTOR, false /* sendStatusText */, false /* isSecureConnection */, signingKey);
+    QVERIFY(_mockLink);
+
+    // Signing should be enabled on outgoing QGC side
+    const mavlink_status_t *status = mavlink_get_channel_status(_mockLink->mavlinkChannel());
+    const mavlink_signing_t *signing = status->signing;
+    QVERIFY(signing);
+
+    // Wait for the Vehicle to get created
+    QCOMPARE(spyActiveVehicleChanged.wait(10000), true);
+    _vehicle = qgcApp()->toolbox()->multiVehicleManager()->activeVehicle();
+    QVERIFY(_vehicle);
+
+    // Put signing key back to default
+    appSettings->mavlink2SigningKey()->setRawValue("");
+}
+
+void SigningTest::_testNoSigning()
+{
+    // Setup QGC with no signing key
+    auto appSettings = qgcApp()->toolbox()->settingsManager()->appSettings();
+    appSettings->mavlink2SigningKey()->setRawValue("");
+
+    // Start a Vehicle with no signing
+    _mockLink = MockLink::startMockLink(MAV_AUTOPILOT_PX4, MAV_TYPE_QUADROTOR, false /* sendStatusText */, false /* isSecureConnection */, "");
+    QVERIFY(_mockLink);
+
+    const mavlink_status_t *status = mavlink_get_channel_status(_mockLink->mavlinkChannel());
+    const mavlink_signing_t *signing = status->signing;
+    QVERIFY(!signing);
+
+    QSignalSpy spyMockLink(_mockLink, SIGNAL(lastSigningStatusChanged(int)));
+
+    // Vehicle should still be created
+    auto multiVehicleMgr = qgcApp()->toolbox()->multiVehicleManager();
+    QSignalSpy spyVehicle(multiVehicleMgr, &MultiVehicleManager::activeVehicleChanged);
+    QCOMPARE(spyVehicle.wait(5000), true);
+    QCOMPARE(spyVehicle.count(), 1);
+
+    // MockLink shouldn't report signing status changes, since no signing is enabled
+    QCOMPARE(spyMockLink.count(), 0);
 }

--- a/test/MAVLink/SigningTest.h
+++ b/test/MAVLink/SigningTest.h
@@ -10,16 +10,24 @@
 #pragma once
 
 #include "UnitTest.h"
+#include "MultiVehicleManager.h"
 
 class SigningTest : public UnitTest
 {
     Q_OBJECT
 
 public:
-    SigningTest() = default;
+    SigningTest();
 
 private slots:
     void _testInitSigning();
     void _testCheckSigningLinkId();
     void _testCreateSetupSigning();
+    void _testDenyUnsignedMessages();
+    void _testGoodSignatures();
+    void _testNoSigning();
+    void _testBadSignature();
+
+private:
+    MultiVehicleManager* _multiVehicleMgr = nullptr;
 };

--- a/test/MissionManager/CameraCalcTest.cc
+++ b/test/MissionManager/CameraCalcTest.cc
@@ -35,6 +35,8 @@ void CameraCalcTest::init(void)
 
 void CameraCalcTest::cleanup(void)
 {
+    UnitTest::cleanup();
+    
     delete _masterController;
     delete _cameraCalc;
     delete _multiSpy;

--- a/test/MissionManager/MissionControllerManagerTest.cc
+++ b/test/MissionManager/MissionControllerManagerTest.cc
@@ -29,7 +29,7 @@ void MissionControllerManagerTest::cleanup(void)
 
 void MissionControllerManagerTest::_initForFirmwareType(MAV_AUTOPILOT firmwareType)
 {
-    _connectMockLink(firmwareType);
+    _connectMockLink(firmwareType, MAV_TYPE_QUADROTOR);
     
     // Wait for the Mission Manager to finish it's initial load
     

--- a/test/MissionManager/MissionControllerTest.cc
+++ b/test/MissionManager/MissionControllerTest.cc
@@ -173,7 +173,7 @@ void MissionControllerTest::_testGimbalRecalc(void)
     item->cameraSection()->setSpecifyGimbal(true);
     item->cameraSection()->gimbalYaw()->setRawValue(0.0);
     qgcApp()->toolbox()->settingsManager()->planViewSettings()->showGimbalOnlyWhenSet()->setRawValue(false);
-    QTest::qWait(100); // Recalcs in MissionController are queued to remove dups. Allow return to main message loop.
+    QTest::qWait(1000); // Recalcs in MissionController are queued to remove dups. Allow return to main message loop.
     for (int i=1; i<_missionController->visualItems()->count(); i++) {
         //qDebug() << i;
         VisualMissionItem* visualItem = _missionController->visualItems()->value<VisualMissionItem*>(i);

--- a/test/MissionManager/PlanMasterControllerTest.cc
+++ b/test/MissionManager/PlanMasterControllerTest.cc
@@ -70,7 +70,7 @@ void PlanMasterControllerTest::_testActiveVehicleChanged(void) {
     spyMissionManager.clearSignal("error");
     QVERIFY(spyMissionManager.checkNoSignals());
 
-    _connectMockLink(MAV_AUTOPILOT_PX4);
+    _connectMockLink(MAV_AUTOPILOT_PX4, MAV_TYPE_QUADROTOR);
     auto masterControllerMgrVehicleChanged = spyMasterController.signalNameToMask("managerVehicleChanged");
     QVERIFY(spyMasterController.checkSignalByMask(masterControllerMgrVehicleChanged));
 

--- a/test/MissionManager/QGCMapPolygonTest.cc
+++ b/test/MissionManager/QGCMapPolygonTest.cc
@@ -47,6 +47,7 @@ void QGCMapPolygonTest::init(void)
 
 void QGCMapPolygonTest::cleanup(void)
 {
+    UnitTest::cleanup();
     delete _mapPolygon;
     delete _multiSpyPolygon;
     delete _multiSpyModel;

--- a/test/MissionManager/QGCMapPolylineTest.cc
+++ b/test/MissionManager/QGCMapPolylineTest.cc
@@ -46,6 +46,7 @@ void QGCMapPolylineTest::init(void)
 
 void QGCMapPolylineTest::cleanup(void)
 {
+    UnitTest::cleanup();
     delete _mapPolyline;
     delete _multiSpyPolyline;
     delete _multiSpyModel;

--- a/test/UI/preferences/MockLink.qml
+++ b/test/UI/preferences/MockLink.qml
@@ -42,39 +42,43 @@ Rectangle {
                 id:             sendStatusText
                 text:           qsTr("Send status text + voice")
             }
+            QGCCheckBox {
+                id:             isSecureConnection
+                text:           qsTr("Simulate secure connection")
+            }
             QGCButton {
                 text:               qsTr("PX4 Vehicle")
                 Layout.fillWidth:   true
-                onClicked:          QGroundControl.startPX4MockLink(sendStatusText.checked)
+                onClicked:          QGroundControl.startMockLink(QGroundControl.MockLinkTypePX4, sendStatusText.checked, isSecureConnection.checked)
             }
             QGCButton {
                 text:               qsTr("APM ArduCopter Vehicle")
                 visible:            QGroundControl.hasAPMSupport
                 Layout.fillWidth:   true
-                onClicked:          QGroundControl.startAPMArduCopterMockLink(sendStatusText.checked)
+                onClicked:          QGroundControl.startMockLink(QGroundControl.MockLinkTypeArduCopter, sendStatusText.checked, isSecureConnection.checked)
             }
             QGCButton {
                 text:               qsTr("APM ArduPlane Vehicle")
                 visible:            QGroundControl.hasAPMSupport
                 Layout.fillWidth:   true
-                onClicked:          QGroundControl.startAPMArduPlaneMockLink(sendStatusText.checked)
+                onClicked:          QGroundControl.startMockLink(QGroundControl.MockLinkTypeArduPlane, sendStatusText.checked, isSecureConnection.checked)
             }
             QGCButton {
                 text:               qsTr("APM ArduSub Vehicle")
                 visible:            QGroundControl.hasAPMSupport
                 Layout.fillWidth:   true
-                onClicked:          QGroundControl.startAPMArduSubMockLink(sendStatusText.checked)
+                onClicked:          QGroundControl.startMockLink(QGroundControl.MockLinkTypeArduSub, sendStatusText.checked, isSecureConnection.checked)
             }
             QGCButton {
                 text:               qsTr("APM ArduRover Vehicle")
                 visible:            QGroundControl.hasAPMSupport
                 Layout.fillWidth:   true
-                onClicked:          QGroundControl.startAPMArduRoverMockLink(sendStatusText.checked)
+                onClicked:          QGroundControl.startMockLink(QGroundControl.MockLinkTypeArduRover, sendStatusText.checked, isSecureConnection.checked)
             }
             QGCButton {
                 text:               qsTr("Generic Vehicle")
                 Layout.fillWidth:   true
-                onClicked:          QGroundControl.startGenericMockLink(sendStatusText.checked)
+                onClicked:          QGroundControl.startMockLink(QGroundControl.MockLinkTypeGeneric, sendStatusText.checked, isSecureConnection.checked)
             }
             QGCButton {
                 text:               qsTr("Stop One MockLink")

--- a/test/UI/preferences/MockLinkSettings.qml
+++ b/test/UI/preferences/MockLinkSettings.qml
@@ -45,6 +45,8 @@ GridLayout {
             break
         }
         subEditConfig.sendStatus = sendStatus.checked
+        subEditConfig.isSecureConnection = isSecureConnection.checked
+        subEditConfig.signingKey = signingKey.text
         subEditConfig.incrementVehicleId = incrementVehicleId.checked
     }
 
@@ -75,12 +77,26 @@ GridLayout {
     }
 
     QGCCheckBox {
+        id:                 isSecureConnection
+        Layout.columnSpan:  2
+        text:               qsTr("Simulate Secure Connection")
+        checked:            subEditConfig.isSecureConnection
+    }
+
+    QGCCheckBox {
         id:                 incrementVehicleId
         Layout.columnSpan:  2
         text:               qsTr("Increment Vehicle Id")
         checked:            subEditConfig.incrementVehicleId
     }
 
+    QGCLabel { text: qsTr("Signing Key") }
+    QGCTextField {
+        id:                     signingKey
+        Layout.preferredWidth:  _secondColumnWidth
+        text:                   subEditConfig.signingKey
+    }
+    
     QGCLabel { text: qsTr("Firmware") }
     QGCComboBox {
         id:                     firmwareTypeCombo

--- a/test/Vehicle/FTPManagerTest.cc
+++ b/test/Vehicle/FTPManagerTest.cc
@@ -22,14 +22,9 @@ const FTPManagerTest::TestCase_t FTPManagerTest::_rgTestCases[] = {
     {  "/general.json" },
 };
 
-void FTPManagerTest::cleanup(void)
-{
-    _disconnectMockLink();
-}
-
 void FTPManagerTest::_testCaseWorker(const TestCase_t& testCase)
 {
-    _connectMockLinkNoInitialConnectSequence();
+    _connectMockLinkNoInitialConnectSequenceWait();
 
     MultiVehicleManager*    vehicleMgr  = qgcApp()->toolbox()->multiVehicleManager();
     Vehicle*                vehicle     = vehicleMgr->activeVehicle();
@@ -51,7 +46,7 @@ void FTPManagerTest::_testCaseWorker(const TestCase_t& testCase)
 
 void FTPManagerTest::_sizeTestCaseWorker(int fileSize)
 {
-    _connectMockLinkNoInitialConnectSequence();
+    _connectMockLinkNoInitialConnectSequenceWait();
 
     FTPManager* ftpManager  = _vehicle->ftpManager();
     QString     filename    = QStringLiteral("%1%2").arg(MockLinkFTP::sizeFilenamePrefix).arg(fileSize);
@@ -102,7 +97,7 @@ void FTPManagerTest::_performTestCases(void)
 
 void FTPManagerTest::_testLostPackets(void)
 {
-    _connectMockLinkNoInitialConnectSequence();
+    _connectMockLinkNoInitialConnectSequenceWait();
 
     FTPManager* ftpManager  = _vehicle->ftpManager();
     int         fileSize    = 4 * 1024;
@@ -144,7 +139,7 @@ void FTPManagerTest::_verifyFileSizeAndDelete(const QString& filename, int expec
 
 void FTPManagerTest::_testListDirectory(void)
 {
-    _connectMockLinkNoInitialConnectSequence();
+    _connectMockLinkNoInitialConnectSequenceWait();
 
     MultiVehicleManager*    vehicleMgr  = qgcApp()->toolbox()->multiVehicleManager();
     Vehicle*                vehicle     = vehicleMgr->activeVehicle();
@@ -161,13 +156,11 @@ void FTPManagerTest::_testListDirectory(void)
     QList<QVariant> arguments = spyListDirectoryComplete.takeFirst();
     qDebug() << arguments[0];
     QCOMPARE(arguments[0].toStringList().count(), 6);
-
-    _disconnectMockLink();
 }
 
 void FTPManagerTest::_testListDirectoryNoResponse(void)
 {
-    _connectMockLinkNoInitialConnectSequence();
+    _connectMockLinkNoInitialConnectSequenceWait();
 
     MultiVehicleManager*    vehicleMgr  = qgcApp()->toolbox()->multiVehicleManager();
     Vehicle*                vehicle     = vehicleMgr->activeVehicle();
@@ -184,13 +177,11 @@ void FTPManagerTest::_testListDirectoryNoResponse(void)
     QList<QVariant> arguments = spyListDirectoryComplete.takeFirst();
     QCOMPARE(arguments[0].toStringList().count(), 0);
     QVERIFY(!arguments[1].toString().isEmpty());
-
-    _disconnectMockLink();
 }
 
 void FTPManagerTest::_testListDirectoryNakResponse(void)
 {
-    _connectMockLinkNoInitialConnectSequence();
+    _connectMockLinkNoInitialConnectSequenceWait();
 
     MultiVehicleManager*    vehicleMgr  = qgcApp()->toolbox()->multiVehicleManager();
     Vehicle*                vehicle     = vehicleMgr->activeVehicle();
@@ -207,13 +198,11 @@ void FTPManagerTest::_testListDirectoryNakResponse(void)
     QList<QVariant> arguments = spyListDirectoryComplete.takeFirst();
     QCOMPARE(arguments[0].toStringList().count(), 0);
     QVERIFY(!arguments[1].toString().isEmpty());
-
-    _disconnectMockLink();
 }
 
 void FTPManagerTest::_testListDirectoryNoSecondResponse(void)
 {
-    _connectMockLinkNoInitialConnectSequence();
+    _connectMockLinkNoInitialConnectSequenceWait();
 
     MultiVehicleManager*    vehicleMgr  = qgcApp()->toolbox()->multiVehicleManager();
     Vehicle*                vehicle     = vehicleMgr->activeVehicle();
@@ -230,13 +219,11 @@ void FTPManagerTest::_testListDirectoryNoSecondResponse(void)
     QList<QVariant> arguments = spyListDirectoryComplete.takeFirst();
     QCOMPARE(arguments[0].toStringList().count(), 0);
     QVERIFY(!arguments[1].toString().isEmpty());
-
-    _disconnectMockLink();
 }
 
 void FTPManagerTest::_testListDirectoryNoSecondResponseAllowRetry(void)
 {
-    _connectMockLinkNoInitialConnectSequence();
+    _connectMockLinkNoInitialConnectSequenceWait();
 
     MultiVehicleManager*    vehicleMgr  = qgcApp()->toolbox()->multiVehicleManager();
     Vehicle*                vehicle     = vehicleMgr->activeVehicle();
@@ -253,13 +240,11 @@ void FTPManagerTest::_testListDirectoryNoSecondResponseAllowRetry(void)
     QList<QVariant> arguments = spyListDirectoryComplete.takeFirst();
     qDebug() << arguments[0];
     QCOMPARE(arguments[0].toStringList().count(), 6);
-
-    _disconnectMockLink();
 }
 
 void FTPManagerTest::_testListDirectoryNakSecondResponse(void)
 {
-    _connectMockLinkNoInitialConnectSequence();
+    _connectMockLinkNoInitialConnectSequenceWait();
 
     MultiVehicleManager*    vehicleMgr  = qgcApp()->toolbox()->multiVehicleManager();
     Vehicle*                vehicle     = vehicleMgr->activeVehicle();
@@ -276,13 +261,11 @@ void FTPManagerTest::_testListDirectoryNakSecondResponse(void)
     QList<QVariant> arguments = spyListDirectoryComplete.takeFirst();
     QCOMPARE(arguments[0].toStringList().count(), 0);
     QVERIFY(!arguments[1].toString().isEmpty());
-
-    _disconnectMockLink();
 }
 
 void FTPManagerTest::_testListDirectoryBadSequence(void)
 {
-    _connectMockLinkNoInitialConnectSequence();
+    _connectMockLinkNoInitialConnectSequenceWait();
 
     MultiVehicleManager*    vehicleMgr  = qgcApp()->toolbox()->multiVehicleManager();
     Vehicle*                vehicle     = vehicleMgr->activeVehicle();
@@ -299,6 +282,4 @@ void FTPManagerTest::_testListDirectoryBadSequence(void)
     QList<QVariant> arguments = spyListDirectoryComplete.takeFirst();
     QCOMPARE(arguments[0].toStringList().count(), 0);
     QVERIFY(!arguments[1].toString().isEmpty());
-
-    _disconnectMockLink();
 }

--- a/test/Vehicle/FTPManagerTest.h
+++ b/test/Vehicle/FTPManagerTest.h
@@ -25,9 +25,6 @@ private slots:
     void _testListDirectoryNakSecondResponse            (void);
     void _testListDirectoryBadSequence                  (void);
 
-    // Overrides from UnitTest
-    void cleanup(void) override;
-
 private:
     void _performSizeBasedTestCases (void);
     void _performTestCases          (void);

--- a/test/Vehicle/RequestMessageTest.cc
+++ b/test/Vehicle/RequestMessageTest.cc
@@ -35,7 +35,7 @@ void RequestMessageTest::_requestMessageResultHandler(void* resultHandlerData, M
 
 void RequestMessageTest::_testCaseWorker(TestCase_t& testCase)
 {
-    _connectMockLinkNoInitialConnectSequence();
+    _connectMockLinkNoInitialConnectSequenceWait();
 
     MultiVehicleManager*    vehicleMgr  = qgcApp()->toolbox()->multiVehicleManager();
     Vehicle*                vehicle     = vehicleMgr->activeVehicle();
@@ -70,7 +70,7 @@ void RequestMessageTest::_performTestCases(void)
 
 void RequestMessageTest::_duplicateCommand(void)
 {
-    _connectMockLinkNoInitialConnectSequence();
+    _connectMockLinkNoInitialConnectSequenceWait();
 
     RequestMessageTest::TestCase_t testCase = {
         MockLink::FailRequestMessageCommandNoResponse, MAV_RESULT_FAILED, Vehicle::RequestMessageFailureDuplicateCommand, 1, false
@@ -116,7 +116,7 @@ void RequestMessageTest::_compIdAllRequestMessageResultHandler(void* resultHandl
 
 void RequestMessageTest::_compIdAllFailure(void)
 {
-    _connectMockLinkNoInitialConnectSequence();
+    _connectMockLinkNoInitialConnectSequenceWait();
 
     RequestMessageTest::TestCase_t testCase = {
         MockLink::FailRequestMessageCommandNoResponse, MAV_RESULT_FAILED, Vehicle::RequestMessageFailureCommandError, 0, false

--- a/test/Vehicle/SendMavCommandWithHandlerTest.cc
+++ b/test/Vehicle/SendMavCommandWithHandlerTest.cc
@@ -58,7 +58,7 @@ void SendMavCommandWithHandlerTest::_mavCmdProgressHandler(void* progressHandler
 
 void SendMavCommandWithHandlerTest::_testCaseWorker(TestCase_t& testCase)
 {
-    _connectMockLinkNoInitialConnectSequence();
+    _connectMockLinkNoInitialConnectSequenceWait();
 
     MultiVehicleManager*    vehicleMgr  = qgcApp()->toolbox()->multiVehicleManager();
     Vehicle*                vehicle     = vehicleMgr->activeVehicle();
@@ -97,7 +97,7 @@ void SendMavCommandWithHandlerTest::_performTestCases(void)
 
 void SendMavCommandWithHandlerTest::_duplicateCommand(void)
 {
-    _connectMockLinkNoInitialConnectSequence();
+    _connectMockLinkNoInitialConnectSequenceWait();
 
     SendMavCommandWithHandlerTest::TestCase_t testCase = {
         MockLink::MAV_CMD_MOCKLINK_NO_RESPONSE, MAV_RESULT_FAILED, 0, Vehicle::MavCmdResultFailureDuplicateCommand, 1
@@ -139,7 +139,7 @@ void SendMavCommandWithHandlerTest::_compIdAllFailureMavCmdResultHandler(void* /
 
 void SendMavCommandWithHandlerTest::_compIdAllFailure(void)
 {
-    _connectMockLinkNoInitialConnectSequence();
+    _connectMockLinkNoInitialConnectSequenceWait();
 
     SendMavCommandWithHandlerTest::TestCase_t testCase = {
         MockLink::MAV_CMD_MOCKLINK_NO_RESPONSE, MAV_RESULT_FAILED, 0, Vehicle::MavCmdResultFailureDuplicateCommand, 0

--- a/test/Vehicle/SendMavCommandWithSignallingTest.cc
+++ b/test/Vehicle/SendMavCommandWithSignallingTest.cc
@@ -26,7 +26,7 @@ SendMavCommandWithSignallingTest::TestCase_t SendMavCommandWithSignallingTest::_
 
 void SendMavCommandWithSignallingTest::_testCaseWorker(TestCase_t& testCase)
 {
-    _connectMockLinkNoInitialConnectSequence();
+    _connectMockLinkNoInitialConnectSequenceWait();
 
     MultiVehicleManager*    vehicleMgr  = qgcApp()->toolbox()->multiVehicleManager();
     Vehicle*                vehicle     = vehicleMgr->activeVehicle();
@@ -61,7 +61,7 @@ void SendMavCommandWithSignallingTest::_performTestCases(void)
 
 void SendMavCommandWithSignallingTest::_duplicateCommand(void)
 {
-    _connectMockLinkNoInitialConnectSequence();
+    _connectMockLinkNoInitialConnectSequenceWait();
 
     MultiVehicleManager*    vehicleMgr  = qgcApp()->toolbox()->multiVehicleManager();
     Vehicle*                vehicle     = vehicleMgr->activeVehicle();

--- a/test/qgcunittest/UnitTest.h
+++ b/test/qgcunittest/UnitTest.h
@@ -109,8 +109,8 @@ protected slots:
     virtual void cleanup(void);
 
 protected:
-    void _connectMockLink(MAV_AUTOPILOT autopilot = MAV_AUTOPILOT_PX4, MockConfiguration::FailureMode_t failureMode = MockConfiguration::FailNone);
-    void _connectMockLinkNoInitialConnectSequence(void) { _connectMockLink(MAV_AUTOPILOT_INVALID); }
+    void _connectMockLink(MAV_AUTOPILOT mavAutopilot, MAV_TYPE mavType, MockConfiguration::FailureMode_t failureMode = MockConfiguration::FailNone);
+    void _connectMockLinkNoInitialConnectSequenceWait(void) { _connectMockLink(MAV_AUTOPILOT_PX4, MAV_TYPE_GENERIC); }
     void _disconnectMockLink(void);
     void _missionItemsEqual(MissionItem& actual, MissionItem& expected);
 
@@ -171,7 +171,6 @@ private:
     // This allows the private calls to the file dialog methods
     friend class QGCQFileDialog;
 
-    void _unitTestCalled(void);
     static QList<UnitTest*>& _testList(void);
 
     // Catch QGCMessageBox calls
@@ -187,7 +186,6 @@ private:
     static enum FileDialogType _fileDialogExpectedType; ///< type of file dialog expected to show
     static int          _missedFileDialogCount;         ///< Count of file dialogs not checked with call to UnitTest::fileDialogWasDisplayed
 
-    bool _unitTestRun   = false;    ///< true: Unit Test was run
     bool _initCalled    = false;    ///< true: UnitTest::_init was called
     bool _cleanupCalled = false;    ///< true: UnitTest::_cleanup was called
     bool _standalone    = false;    ///< true: Only run when requested specifically from command line


### PR DESCRIPTION
Related to #11713 

Changed:
* No enable/disable setting for signing. The existence of a non-empty key enables signing
* Remove support for a custom mavlink build with MAVLINK_NO_SIGN_PACKET turned on. This just adds complexity. If someone wants to build something like this they can modify QGC themselves.
* Signing is initialized on a channel as soon as a link is created. This means any link created gets signing.
* When the signing key is changed in settings all links are updated to new key
* Sending the key to the vehicle is a user initiated action from Telemetry settings. This only sends setup signing. It no longer also does an init since that would have already happened on link create or key change.
* Signing is not turned on for USB and Log Replay connections

Things I still want to do:
* Give the user some notification if signing initialization fails. You'll see a FIXME in the code for this for now
* Give the user some notification on signing failures like signature mismatches. Right now things just fall on the floor on signature mismatch and Vehicles don't get created since you never see a heartbeat.