### PR TITLE
Fly View: Show lat/lon of click position

### DIFF
--- a/src/FlightDisplay/FlyViewMap.qml
+++ b/src/FlightDisplay/FlyViewMap.qml
@@ -641,7 +641,13 @@ FlightMap {
                     }
                     globals.guidedControllerFlyView.confirmAction(globals.guidedControllerFlyView.actionSetEstimatorOrigin, mapClickCoord)
                 }
-            }        
+            }
+
+            ColumnLayout {
+                spacing: 0
+                QGCLabel { text: qsTr("Lat: %1").arg(mapClickCoord.latitude.toFixed(6)) }
+                QGCLabel { text: qsTr("Lon: %1").arg(mapClickCoord.longitude.toFixed(6)) }
+            }
         }
     }
 


### PR DESCRIPTION
Fix #8092

Fly View click in map:
<img width="183" alt="Screenshot 2024-07-31 at 10 53 37 AM" src="https://github.com/user-attachments/assets/e8affe28-af0a-4306-b299-baef01024761">
