### PR TITLE
Comms: SerialLink Threading Changes

### DIFF
--- a/android/libs/qtandroidserialport/qserialport_p.h
+++ b/android/libs/qtandroidserialport/qserialport_p.h
@@ -33,10 +33,14 @@ constexpr qint64 DEFAULT_READ_BUFFER_SIZE = MAX_READ_SIZE;
 constexpr qint64 DEFAULT_WRITE_BUFFER_SIZE = 16 * 1024;
 constexpr int DEFAULT_WRITE_TIMEOUT = 0;
 constexpr int DEFAULT_READ_TIMEOUT = 0;
+constexpr int EMIT_THRESHOLD = 64;
+constexpr int EMIT_INTERVAL_MS = 10;
 
 #ifndef QSERIALPORT_BUFFERSIZE
 #define QSERIALPORT_BUFFERSIZE DEFAULT_WRITE_BUFFER_SIZE
 #endif
+
+class QTimer;
 
 Q_DECLARE_LOGGING_CATEGORY(AndroidSerialPortLog)
 
@@ -132,7 +136,7 @@ private:
     qint64 _writeToPort(const char *data, qint64 maxSize, int timeout = DEFAULT_WRITE_TIMEOUT, bool async = false);
     bool _stopAsyncRead();
     bool _setParameters(qint32 baudRate, QSerialPort::DataBits dataBits, QSerialPort::StopBits stopBits, QSerialPort::Parity parity);
-    bool _writeDataOneShot(int msecs);
+    bool _writeDataOneShot(int msecs = DEFAULT_WRITE_TIMEOUT);
 
     static qint32 _settingFromBaudRate(qint32 baudRate);
     static int _stopBitsToAndroidStopBits(QSerialPort::StopBits stopBits);
@@ -143,6 +147,7 @@ private:
     int _deviceId = INVALID_DEVICE_ID;
     // QString _serialNumber;
 
+    QTimer *_readTimer = nullptr;
     QMutex _readMutex;
     QWaitCondition _readWaitCondition;
 };

--- a/android/src/org/mavlink/qgroundcontrol/QGCUsbSerialManager.java
+++ b/android/src/org/mavlink/qgroundcontrol/QGCUsbSerialManager.java
@@ -144,6 +144,8 @@ public class QGCUsbSerialManager {
                     break;
             }
 
+            updateCurrentDrivers();
+
             try {
                 nativeUpdateAvailableJoysticks();
             } catch (final Exception ex) {
@@ -409,7 +411,7 @@ public class QGCUsbSerialManager {
      * @return An array of device information strings or null if no devices are available.
      */
     public static String[] availableDevicesInfo() {
-        updateCurrentDrivers();
+        // updateCurrentDrivers();
 
         if (usbManager.getDeviceList().size() < 1) {
             return null;

--- a/src/AutoPilotPlugins/APM/APMAutoPilotPlugin.cc
+++ b/src/AutoPilotPlugins/APM/APMAutoPilotPlugin.cc
@@ -204,7 +204,7 @@ void APMAutoPilotPlugin::_checkForBadCubeBlack(void)
     // FIXME: Put back
     for (const QVariant& varLink: _vehicle->links()) {
         SerialLink* serialLink = varLink.value<SerialLink*>();
-        if (serialLink && QSerialPortInfo(*serialLink->_hackAccessToPort()).description().contains(QStringLiteral("CubeBlack"))) {
+        if (serialLink && QSerialPortInfo(*serialLink->port()).description().contains(QStringLiteral("CubeBlack"))) {
             cubeBlackFound = true;
         }
 

--- a/src/Comms/LinkManager.cc
+++ b/src/Comms/LinkManager.cc
@@ -946,7 +946,7 @@ void LinkManager::_updateSerialPorts()
     for (const QGCSerialPortInfo &info: portList) {
         const QString port = info.systemLocation().trimmed();
         _commPortList += port;
-        _commPortDisplayList += SerialConfiguration::cleanPortDisplayname(port);
+        _commPortDisplayList += SerialConfiguration::cleanPortDisplayName(port);
     }
 }
 

--- a/src/Comms/LinkManager.h
+++ b/src/Comms/LinkManager.h
@@ -76,9 +76,6 @@ public:
     void loadLinkConfigurationList();
     void saveLinkConfigurationList();
 
-    /// Suspend automatic confguration updates (during link maintenance for instance)
-    void suspendConfigurationUpdates(bool suspend) { _configUpdateSuspended = suspend; }
-
     /// Sets the flag to suspend the all new connections
     ///     @param reason User visible reason to suspend connections
     void setConnectionsSuspended(const QString &reason) { _connectionsSuspended = true; _connectionsSuspendedReason = reason; }

--- a/src/Comms/QGCSerialPortInfo.h
+++ b/src/Comms/QGCSerialPortInfo.h
@@ -33,12 +33,13 @@ public:
     ~QGCSerialPortInfo();
 
     enum BoardType_t {
-        BoardTypePixhawk,
+        BoardTypePixhawk = 0,
         BoardTypeSiKRadio,
         BoardTypeOpenPilot,
         BoardTypeRTKGPS,
         BoardTypeUnknown
     };
+
     bool getBoardInfo(BoardType_t &boardType, QString &name) const;
 
     /// @return true: we can flash this board type
@@ -55,23 +56,17 @@ public:
     static QList<QGCSerialPortInfo> availablePorts();
 
 private:
+    struct BoardClassString2BoardType_t {
+        const QString classString;
+        const BoardType_t boardType = BoardTypeUnknown;
+    };
+
     static bool _loadJsonData();
     static BoardType_t _boardClassStringToType(const QString &boardClass);
     static QString _boardTypeToString(BoardType_t boardType);
 
     static bool _jsonLoaded;
     static bool _jsonDataValid;
-
-    struct BoardClassString2BoardType_t {
-        const char *classString;
-        BoardType_t boardType;
-    };
-    static constexpr const BoardClassString2BoardType_t _rgBoardClass2BoardType[BoardTypeUnknown] = {
-        { "Pixhawk", QGCSerialPortInfo::BoardTypePixhawk },
-        { "RTK GPS", QGCSerialPortInfo::BoardTypeRTKGPS },
-        { "SiK Radio", QGCSerialPortInfo::BoardTypeSiKRadio },
-        { "OpenPilot", QGCSerialPortInfo::BoardTypeOpenPilot },
-    };
 
     struct BoardInfo_t {
         int vendorId;

--- a/src/Comms/SerialLink.cc
+++ b/src/Comms/SerialLink.cc
@@ -8,410 +8,402 @@
  ****************************************************************************/
 
 #include "SerialLink.h"
-#include "QGC.h"
 #include "QGCLoggingCategory.h"
+#include "QGCSerialPortInfo.h"
 #ifdef Q_OS_ANDROID
-#include "QGCApplication.h"
-#include "LinkManager.h"
 #include "qserialportinfo.h"
 #else
 #include <QtSerialPort/QSerialPortInfo>
 #endif
-#include <QtCore/QCoreApplication>
 #include <QtCore/QSettings>
+#include <QtCore/QTimer>
 
-QGC_LOGGING_CATEGORY(SerialLinkLog, "SerialLinkLog")
+QGC_LOGGING_CATEGORY(SerialLinkLog, "qgc.comms.seriallink")
 
-SerialLink::SerialLink(SharedLinkConfigurationPtr& config)
-    : LinkInterface(config)
-    , _serialConfig(qobject_cast<const SerialConfiguration*>(config.get()))
-{
-    qRegisterMetaType<QSerialPort::SerialPortError>();
-    qCDebug(SerialLinkLog) << "Create SerialLink portName:baud:flowControl:parity:dataButs:stopBits" << _serialConfig->portName() << _serialConfig->baud() << _serialConfig->flowControl()
-                           << _serialConfig->parity() << _serialConfig->dataBits() << _serialConfig->stopBits();
+namespace {
+    constexpr int CONNECT_TIMEOUT_MS = 1000;
+    constexpr int READ_TIMEOUT_MS = 100;
 }
 
-SerialLink::~SerialLink()
+/*===========================================================================*/
+
+SerialConfiguration::SerialConfiguration(const QString &name, QObject *parent)
+    : LinkConfiguration(name, parent)
 {
-    disconnect();
+    // qCDebug(SerialLinkLog) << Q_FUNC_INFO << this;
 }
 
-bool SerialLink::_isBootloader()
+SerialConfiguration::SerialConfiguration(const SerialConfiguration *source, QObject *parent)
+    : LinkConfiguration(source, parent)
 {
-    QList<QSerialPortInfo> portList = QSerialPortInfo::availablePorts();
-    if( portList.count() == 0){
-        return false;
-    }
-    for (const QSerialPortInfo &info: portList)
-    {
-        qCDebug(SerialLinkLog) << "PortName    : " << info.portName() << "Description : " << info.description();
-        qCDebug(SerialLinkLog) << "Manufacturer: " << info.manufacturer();
-        if (info.portName().trimmed() == _serialConfig->portName() &&
-                (info.description().toLower().contains("bootloader") ||
-                 info.description().toLower().contains("px4 bl") ||
-                 info.description().toLower().contains("px4 fmu v1.6"))) {
-            qCDebug(SerialLinkLog) << "BOOTLOADER FOUND";
-            return true;
-        }
-    }
-    // Not found
-    return false;
+    // qCDebug(SerialLinkLog) << Q_FUNC_INFO << this;
+
+    SerialConfiguration::copyFrom(source);
 }
 
-void SerialLink::_writeBytes(const QByteArray &data)
+SerialConfiguration::~SerialConfiguration()
 {
-    if(_port && _port->isOpen()) {
-        emit bytesSent(this, data);
-        _port->write(data);
-    } else {
-        // Error occurred
-        qWarning() << "Serial port not writeable";
-        _emitLinkError(tr("Could not send data - link %1 is disconnected!").arg(_config->name()));
-    }
+    // qCDebug(SerialLinkLog) << Q_FUNC_INFO << this;
 }
 
-void SerialLink::disconnect(void)
+void SerialConfiguration::setPortName(const QString &name)
 {
-    if (_port) {
-        // This prevents stale signals from calling the link after it has been deleted
-        QObject::disconnect(_port, &QIODevice::readyRead, this, &SerialLink::_readBytes);
-        _port->close();
-        _port->deleteLater();
-        _port = nullptr;
-        emit disconnected();
+    const QString portName = name.trimmed();
+    if (portName.isEmpty()) {
+        return;
     }
 
-#ifdef Q_OS_ANDROID
-    LinkManager::instance()->suspendConfigurationUpdates(false);
-#endif
-}
-
-bool SerialLink::_connect(void)
-{
-    qCDebug(SerialLinkLog) << "CONNECT CALLED";
-
-    if (_port) {
-        qCWarning(SerialLinkLog) << "connect called while already connected";
-        return true;
+    if (portName != _portName) {
+        _portName = portName;
+        emit portNameChanged();
     }
 
-#ifdef Q_OS_ANDROID
-    LinkManager::instance()->suspendConfigurationUpdates(true);
-#endif
-
-    QSerialPort::SerialPortError    error;
-    QString                         errorString;
-
-    // Initialize the connection
-    if (!_hardwareConnect(error, errorString)) {
-        if (_config->isAutoConnect()) {
-            // Be careful with spitting out open error related to trying to open a busy port using autoconnect
-            if (error == QSerialPort::PermissionError) {
-                // Device already open, ignore and fail connect
-                return false;
-            }
-        }
-
-        _emitLinkError(tr("Error connecting: Could not create port. %1").arg(errorString));
-        return false;
-    }
-    return true;
-}
-
-/// Performs the actual hardware port connection.
-///     @param[out] error if failed
-///     @param[out] error string if failed
-/// @return success/fail
-bool SerialLink::_hardwareConnect(QSerialPort::SerialPortError& error, QString& errorString)
-{
-    if (_port) {
-        qCDebug(SerialLinkLog) << "SerialLink:" << QString::number((qulonglong)this, 16) << "closing port";
-        _port->close();
-
-        // Wait 50 ms while continuing to run the event queue
-        for (unsigned i = 0; i < 10; i++) {
-            QGC::SLEEP::usleep(5000);
-            QCoreApplication::processEvents(QEventLoop::ExcludeUserInputEvents);
-        }
-        delete _port;
-        _port = nullptr;
-    }
-
-    qCDebug(SerialLinkLog) << "SerialLink: hardwareConnect to " << _serialConfig->portName();
-
-    // If we are in the Pixhawk bootloader code wait for it to timeout
-    if (_isBootloader()) {
-        qCDebug(SerialLinkLog) << "Not connecting to a bootloader, waiting for 2nd chance";
-        const unsigned retry_limit = 12;
-        unsigned retries;
-
-        for (retries = 0; retries < retry_limit; retries++) {
-            if (!_isBootloader()) {
-                // Wait 500 ms while continuing to run the event loop
-                for (unsigned i = 0; i < 100; i++) {
-                    QGC::SLEEP::msleep(5);
-                    QCoreApplication::processEvents(QEventLoop::ExcludeUserInputEvents);
-                }
-                break;
-            }
-
-            // Wait 500 ms while continuing to run the event loop
-            for (unsigned i = 0; i < 100; i++) {
-                QGC::SLEEP::msleep(5);
-                QCoreApplication::processEvents(QEventLoop::ExcludeUserInputEvents);
-            }
-        }
-        // Check limit
-        if (retries == retry_limit) {
-            // bail out
-            qWarning() << "Timeout waiting for something other than booloader";
-            return false;
-        }
-    }
-
-    _port = new QSerialPort(_serialConfig->portName(), this);
-
-
-    // After the bootloader times out, it still can take a second or so for the Pixhawk USB driver to come up and make
-    // the port available for open. So we retry a few times to wait for it.
-#ifdef Q_OS_ANDROID
-    _port->open(QIODevice::ReadWrite);
-#else
-
-    // Try to open the port three times
-    for (int openRetries = 0; openRetries < 3; openRetries++) {
-        if (!_port->open(QIODevice::ReadWrite)) {
-            qCDebug(SerialLinkLog) << "Port open failed, retrying";
-            // Wait 250 ms while continuing to run the event loop
-            for (unsigned i = 0; i < 50; i++) {
-                QGC::SLEEP::msleep(5);
-                QCoreApplication::processEvents(QEventLoop::ExcludeUserInputEvents);
-            }
-            QCoreApplication::processEvents(QEventLoop::ExcludeUserInputEvents);
-        } else {
-            break;
-        }
-    }
-#endif
-    if (!_port->isOpen() ) {
-        qDebug() << "open failed" << _port->errorString() << _port->error() << _config->name() << "autconnect:" << _config->isAutoConnect();
-        error = _port->error();
-        errorString = _port->errorString();
-        _port->close();
-        delete _port;
-        _port = nullptr;
-        return false; // couldn't open serial port
-    }
-
-    _port->setDataTerminalReady(true);
-
-    qCDebug(SerialLinkLog) << "Configuring port";
-    _port->setBaudRate     (_serialConfig->baud());
-    _port->setDataBits     (static_cast<QSerialPort::DataBits>     (_serialConfig->dataBits()));
-    _port->setFlowControl  (static_cast<QSerialPort::FlowControl>  (_serialConfig->flowControl()));
-    _port->setStopBits     (static_cast<QSerialPort::StopBits>     (_serialConfig->stopBits()));
-    _port->setParity       (static_cast<QSerialPort::Parity>       (_serialConfig->parity()));
-
-    emit connected();
-
-    QObject::connect(_port, &QSerialPort::errorOccurred, this, &SerialLink::linkError);
-    QObject::connect(_port, &QIODevice::readyRead, this, &SerialLink::_readBytes);
-
-    qCDebug(SerialLinkLog) << "Connection SeriaLink: " << "with settings" << _serialConfig->portName()
-                           << _serialConfig->baud() << _serialConfig->dataBits() << _serialConfig->parity() << _serialConfig->stopBits();
-
-    return true; // successful connection
-}
-
-void SerialLink::_readBytes(void)
-{
-    if (_port && _port->isOpen()) {
-        qint64 byteCount = _port->bytesAvailable();
-        if (byteCount) {
-            QByteArray buffer;
-            buffer.resize(byteCount);
-            _port->read(buffer.data(), buffer.size());
-            emit bytesReceived(this, buffer);
-        }
-    } else {
-        // Error occurred
-        qWarning() << "Serial port not readable";
-        _emitLinkError(tr("Could not read data - link %1 is disconnected!").arg(_config->name()));
-    }
-}
-
-void SerialLink::linkError(QSerialPort::SerialPortError error)
-{
-    switch (error) {
-    case QSerialPort::NoError:
-        break;
-    case QSerialPort::ResourceError:
-        // This indicates the hardware was pulled from the computer. For example usb cable unplugged.
-        _connectionRemoved();
-        break;
-    default:
-        // You can use the following qDebug output as needed during development. Make sure to comment it back out
-        // when you are done. The reason for this is that this signal is very noisy. For example if you try to
-        // connect to a PixHawk before it is ready to accept the connection it will output a continuous stream
-        // of errors until the Pixhawk responds.
-        // qCDebug(SerialLinkLog) << "SerialLink::linkError" << error;
-        break;
-    }
-}
-
-bool SerialLink::isConnected() const
-{
-    bool isConnected = false;
-
-    if (_port) {
-        isConnected = _port->isOpen();
-    }
-
-    return isConnected;
-}
-
-void SerialLink::_emitLinkError(const QString& errorMsg)
-{
-    QString msg("Error on link %1. %2");
-    qDebug() << errorMsg;
-    emit communicationError(tr("Link Error"), msg.arg(_config->name()).arg(errorMsg));
-}
-
-bool SerialLink::isSecureConnection()
-{
-    return _serialConfig && _serialConfig->usbDirect();
-}
-
-//--------------------------------------------------------------------------
-//-- SerialConfiguration
-
-SerialConfiguration::SerialConfiguration(const QString& name) : LinkConfiguration(name)
-{
-    _baud       = 57600;
-    _flowControl= QSerialPort::NoFlowControl;
-    _parity     = QSerialPort::NoParity;
-    _dataBits   = 8;
-    _stopBits   = 1;
-    _usbDirect  = false;
-}
-
-SerialConfiguration::SerialConfiguration(const SerialConfiguration* copy) : LinkConfiguration(copy)
-{
-    _baud               = copy->baud();
-    _flowControl        = copy->flowControl();
-    _parity             = copy->parity();
-    _dataBits           = copy->dataBits();
-    _stopBits           = copy->stopBits();
-    _portName           = copy->portName();
-    _portDisplayName    = copy->portDisplayName();
-    _usbDirect          = copy->_usbDirect;
+    const QString portDisplayName = cleanPortDisplayName(portName);
+    setPortDisplayName(portDisplayName);
 }
 
 void SerialConfiguration::copyFrom(const LinkConfiguration *source)
 {
+    Q_ASSERT(source);
     LinkConfiguration::copyFrom(source);
-    const SerialConfiguration* ssource = qobject_cast<const SerialConfiguration*>(source);
-    if (ssource) {
-        _baud               = ssource->baud();
-        _flowControl        = ssource->flowControl();
-        _parity             = ssource->parity();
-        _dataBits           = ssource->dataBits();
-        _stopBits           = ssource->stopBits();
-        _portName           = ssource->portName();
-        _portDisplayName    = ssource->portDisplayName();
-        _usbDirect          = ssource->_usbDirect;
-    } else {
-        qWarning() << "Internal error";
-    }
+
+    const SerialConfiguration* const serialSource = qobject_cast<const SerialConfiguration*>(source);
+    Q_ASSERT(serialSource);
+
+    setBaud(serialSource->baud());
+    setDataBits(serialSource->dataBits());
+    setFlowControl(serialSource->flowControl());
+    setStopBits(serialSource->stopBits());
+    setParity(serialSource->parity());
+    setPortName(serialSource->portName());
+    setPortDisplayName(serialSource->portDisplayName());
+    setUsbDirect(serialSource->usbDirect());
 }
 
-void SerialConfiguration::setBaud(int baud)
-{
-    _baud = baud;
-}
-
-void SerialConfiguration::setDataBits(int databits)
-{
-    _dataBits = databits;
-}
-
-void SerialConfiguration::setFlowControl(int flowControl)
-{
-    _flowControl = flowControl;
-}
-
-void SerialConfiguration::setStopBits(int stopBits)
-{
-    _stopBits = stopBits;
-}
-
-void SerialConfiguration::setParity(int parity)
-{
-    _parity = parity;
-}
-
-void SerialConfiguration::setPortName(const QString& portName)
-{
-    // No effect on a running connection
-    QString pname = portName.trimmed();
-    if (!pname.isEmpty() && pname != _portName) {
-        _portName = pname;
-        _portDisplayName = cleanPortDisplayname(pname);
-    }
-}
-
-QString SerialConfiguration::cleanPortDisplayname(const QString name)
-{
-    QString pname = name.trimmed();
-#ifdef Q_OS_WIN
-    pname.replace("\\\\.\\", "");
-#else
-    pname.replace("/dev/cu.", "");
-    pname.replace("/dev/", "");
-#endif
-    return pname;
-}
-
-void SerialConfiguration::saveSettings(QSettings& settings, const QString& root)
+void SerialConfiguration::loadSettings(QSettings &settings, const QString &root)
 {
     settings.beginGroup(root);
-    settings.setValue("baud",           _baud);
-    settings.setValue("dataBits",       _dataBits);
-    settings.setValue("flowControl",    _flowControl);
-    settings.setValue("stopBits",       _stopBits);
-    settings.setValue("parity",         _parity);
-    settings.setValue("portName",       _portName);
-    settings.setValue("portDisplayName",_portDisplayName);
+
+    setBaud(settings.value("baud", _baud).toInt());
+    setDataBits(static_cast<QSerialPort::DataBits>(settings.value("dataBits", _dataBits).toInt()));
+    setFlowControl(static_cast<QSerialPort::FlowControl>(settings.value("flowControl", _flowControl).toInt()));
+    setStopBits(static_cast<QSerialPort::StopBits>(settings.value("stopBits", _stopBits).toInt()));
+    setParity(static_cast<QSerialPort::Parity>(settings.value("parity", _parity).toInt()));
+    setPortName(settings.value("portName", _portName).toString());
+    setPortDisplayName(settings.value("portDisplayName", _portDisplayName).toString());
+
     settings.endGroup();
 }
 
-void SerialConfiguration::loadSettings(QSettings& settings, const QString& root)
+void SerialConfiguration::saveSettings(QSettings &settings, const QString &root)
 {
     settings.beginGroup(root);
-    if(settings.contains("baud"))           _baud           = settings.value("baud").toInt();
-    if(settings.contains("dataBits"))       _dataBits       = settings.value("dataBits").toInt();
-    if(settings.contains("flowControl"))    _flowControl    = settings.value("flowControl").toInt();
-    if(settings.contains("stopBits"))       _stopBits       = settings.value("stopBits").toInt();
-    if(settings.contains("parity"))         _parity         = settings.value("parity").toInt();
-    if(settings.contains("portName"))       _portName       = settings.value("portName").toString();
-    if(settings.contains("portDisplayName"))_portDisplayName= settings.value("portDisplayName").toString();
+
+    settings.setValue("baud", _baud);
+    settings.setValue("dataBits", _dataBits);
+    settings.setValue("flowControl", _flowControl);
+    settings.setValue("stopBits", _stopBits);
+    settings.setValue("parity", _parity);
+    settings.setValue("portName", _portName);
+    settings.setValue("portDisplayName", _portDisplayName);
+
     settings.endGroup();
 }
 
 QStringList SerialConfiguration::supportedBaudRates()
 {
     QStringList supportBaudRateStrings;
-    for (int rate : QSerialPortInfo::standardBaudRates()) {
-        (void) supportBaudRateStrings.append(QString::number(rate));
+
+    const QList<qint32> rates = QSerialPortInfo::standardBaudRates();
+    for (qint32 rate : rates) {
+        supportBaudRateStrings.append(QString::number(rate));
     }
 
     return supportBaudRateStrings;
 }
 
-void SerialConfiguration::setUsbDirect(bool usbDirect)
+QString SerialConfiguration::cleanPortDisplayName(const QString &name)
 {
-    if (_usbDirect != usbDirect) {
-        _usbDirect = usbDirect;
-        emit usbDirectChanged(_usbDirect);
+    const QList<QSerialPortInfo> availablePorts = QSerialPortInfo::availablePorts();
+    for (const QSerialPortInfo &portInfo : availablePorts) {
+        if (portInfo.systemLocation() == name) {
+            return portInfo.portName();
+        }
     }
+
+    return QString();
+}
+
+/*===========================================================================*/
+
+SerialWorker::SerialWorker(const SerialConfiguration *config, QObject *parent)
+    : QObject(parent)
+    , _config(config)
+    , _port(new QSerialPort(this))
+    , _timer(new QTimer(this))
+{
+    // qCDebug(SerialLinkLog) << Q_FUNC_INFO << this;
+
+    (void) qRegisterMetaType<QSerialPort::SerialPortError>("QSerialPort::SerialPortError");
+}
+
+SerialWorker::~SerialWorker()
+{
+    disconnectFromPort();
+
+    // qCDebug(SerialLinkLog) << Q_FUNC_INFO << this;
+}
+
+bool SerialWorker::isConnected() const
+{
+    return _port->isOpen();
+}
+
+void SerialWorker::setupPort()
+{
+    (void) connect(_port, &QSerialPort::aboutToClose, this, &SerialWorker::_onPortDisconnected);
+    (void) connect(_port, &QSerialPort::readyRead, this, &SerialWorker::_onPortReadyRead);
+    // (void) connect(_port, &QSerialPort::bytesWritten, this, &SerialWorker::_onPortBytesWritten);
+    (void) connect(_port, &QSerialPort::errorOccurred, this, &SerialWorker::_onPortErrorOccurred);
+
+    (void) connect(_timer, &QTimer::timeout, this, &SerialWorker::_checkPortAvailability);
+    _timer->start(CONNECT_TIMEOUT_MS);
+}
+
+void SerialWorker::connectToPort()
+{
+    if (isConnected()) {
+        qCWarning(SerialLinkLog) << "Already connected to" << _port->portName();
+        return;
+    }
+
+    _port->setPortName(_config->portName());
+
+    const QGCSerialPortInfo portInfo(*_port);
+    if (portInfo.isBootloader()) {
+        qCWarning(SerialLinkLog) << "Not connecting to bootloader" << _port->portName();
+        emit errorOccurred(tr("Not connecting to a bootloader"));
+        _onPortDisconnected();
+        return;
+    }
+
+    _errorEmitted = false;
+
+    qCDebug(SerialLinkLog) << "Attempting to open port" << _port->portName();
+    if (!_port->open(QIODevice::ReadWrite)) {
+        qCWarning(SerialLinkLog) << "Opening port" << _port->portName() << "failed:" << _port->errorString();
+
+        if (!_errorEmitted) {
+            emit errorOccurred(tr("Could not open port: %1").arg(_port->errorString()));
+            _errorEmitted = true;
+        }
+
+        _onPortDisconnected();
+        return;
+    }
+
+    _onPortConnected();
+}
+
+void SerialWorker::disconnectFromPort()
+{
+    if (!isConnected()) {
+        qCDebug(SerialLinkLog) << "Already disconnected from port:" << _port->portName();
+        return;
+    }
+
+    qCDebug(SerialLinkLog) << "Attempting to close port:" << _port->portName();
+    _port->close();
+}
+
+void SerialWorker::writeData(const QByteArray &data)
+{
+    if (data.isEmpty()) {
+        emit errorOccurred(tr("Data to Send is Empty"));
+        return;
+    }
+
+    if (!isConnected()) {
+        emit errorOccurred(tr("Port is not Connected"));
+        return;
+    }
+
+    if (!_port->isWritable()) {
+        emit errorOccurred(tr("Port is not Writable"));
+        return;
+    }
+
+    qint64 totalBytesWritten = 0;
+    while (totalBytesWritten < data.size()) {
+        const qint64 bytesWritten = _port->write(data.constData() + totalBytesWritten, data.size() - totalBytesWritten);
+        if (bytesWritten == -1) {
+            emit errorOccurred(tr("Could Not Send Data - Write Failed: %1").arg(_port->errorString()));
+            return;
+        } else if (bytesWritten == 0) {
+            emit errorOccurred(tr("Could Not Send Data - Write Returned 0 Bytes"));
+            return;
+        }
+        totalBytesWritten += bytesWritten;
+    }
+
+    const QByteArray sent = data.first(totalBytesWritten);
+    emit dataSent(sent);
+}
+
+void SerialWorker::_onPortConnected()
+{
+    qCDebug(SerialLinkLog) << "Port connected:" << _port->portName();
+
+    _port->setDataTerminalReady(true);
+    _port->setBaudRate(_config->baud());
+    _port->setDataBits(static_cast<QSerialPort::DataBits>(_config->dataBits()));
+    _port->setFlowControl(static_cast<QSerialPort::FlowControl>(_config->flowControl()));
+    _port->setStopBits(static_cast<QSerialPort::StopBits>(_config->stopBits()));
+    _port->setParity(static_cast<QSerialPort::Parity>(_config->parity()));
+
+    _errorEmitted = false;
+    emit connected();
+}
+
+void SerialWorker::_onPortDisconnected()
+{
+    qCDebug(SerialLinkLog) << "Port disconnected:" << _port->portName();
+    _errorEmitted = false;
+    emit disconnected();
+}
+
+void SerialWorker::_onPortReadyRead()
+{
+    const QByteArray data = _port->readAll();
+    if (!data.isEmpty()) {
+        // qCDebug(SerialLinkLog) << "_onPortReadyRead:" << data.size();
+        emit dataReceived(data);
+    }
+}
+
+void SerialWorker::_onPortBytesWritten(qint64 bytes) const
+{
+    qCDebug(SerialLinkLog) << _port->portName() << "Wrote" << bytes << "bytes";
+}
+
+void SerialWorker::_onPortErrorOccurred(QSerialPort::SerialPortError portError)
+{
+    if (portError == QSerialPort::NoError) {
+        qCDebug(SerialLinkLog) << "About to open port" << _port->portName();
+        return;
+    } /* else if (error == QSerialPort::ResourceError) {
+        serialPort->close();
+    }*/
+
+    const QString errorString = _port->errorString();
+
+    if (!_errorEmitted) {
+        qCWarning(SerialLinkLog) << "Port error:" << portError << errorString;
+        emit errorOccurred(errorString);
+        _errorEmitted = true;
+    }
+}
+
+void SerialWorker::_checkPortAvailability()
+{
+    if (!isConnected()) {
+        return;
+    }
+
+    bool portExists = false;
+    const auto availablePorts = QSerialPortInfo::availablePorts();
+    for (const QSerialPortInfo &info : availablePorts) {
+        if (info.portName() == _config->portDisplayName()) {
+            portExists = true;
+            break;
+        }
+    }
+
+    if (!portExists) {
+        _port->close();
+    }
+}
+
+/*===========================================================================*/
+
+SerialLink::SerialLink(SharedLinkConfigurationPtr &config, QObject *parent)
+    : LinkInterface(config, parent)
+    , _serialConfig(qobject_cast<const SerialConfiguration*>(config.get()))
+    , _worker(new SerialWorker(_serialConfig))
+    , _workerThread(new QThread(this))
+{
+    // qCDebug(SerialLinkLog) << Q_FUNC_INFO << this;
+
+    _workerThread->setObjectName(QStringLiteral("Serial_%1").arg(_serialConfig->name()));
+
+    _worker->moveToThread(_workerThread);
+
+    (void) connect(_workerThread, &QThread::started, _worker, &SerialWorker::setupPort);
+    (void) connect(_workerThread, &QThread::finished, _worker, &QObject::deleteLater);
+
+    (void) connect(_worker, &SerialWorker::connected, this, &SerialLink::_onConnected, Qt::QueuedConnection);
+    (void) connect(_worker, &SerialWorker::disconnected, this, &SerialLink::_onDisconnected, Qt::QueuedConnection);
+    (void) connect(_worker, &SerialWorker::dataReceived, this, &SerialLink::_onDataReceived, Qt::QueuedConnection);
+    (void) connect(_worker, &SerialWorker::dataSent, this, &SerialLink::_onDataSent, Qt::QueuedConnection);
+    (void) connect(_worker, &SerialWorker::errorOccurred, this, &SerialLink::_onErrorOccurred, Qt::QueuedConnection);
+
+    _workerThread->start();
+}
+
+SerialLink::~SerialLink()
+{
+    SerialLink::disconnect();
+
+    _workerThread->quit();
+    if (!_workerThread->wait()) {
+        qCWarning(SerialLinkLog) << "Failed to wait for Serial Thread to close";
+    }
+
+    // qCDebug(SerialLinkLog) << Q_FUNC_INFO << this;
+}
+
+bool SerialLink::isConnected() const
+{
+    return _worker->isConnected();
+}
+
+bool SerialLink::_connect()
+{
+    return QMetaObject::invokeMethod(_worker, "connectToPort", Qt::QueuedConnection);
+}
+
+void SerialLink::disconnect()
+{
+    (void) QMetaObject::invokeMethod(_worker, "disconnectFromPort", Qt::QueuedConnection);
+}
+
+void SerialLink::_onConnected()
+{
+    emit connected();
+}
+
+void SerialLink::_onDisconnected()
+{
+    emit disconnected();
+}
+
+void SerialLink::_onErrorOccurred(const QString &errorString)
+{
+    qCWarning(SerialLinkLog) << "Communication error:" << errorString;
+    emit communicationError(tr("Serial Link Error"), tr("Link %1: (Port: %2) %3").arg(_serialConfig->name(), _serialConfig->portName(), errorString));
+}
+
+void SerialLink::_onDataReceived(const QByteArray &data)
+{
+    emit bytesReceived(this, data);
+}
+
+void SerialLink::_onDataSent(const QByteArray &data)
+{
+    emit bytesSent(this, data);
+}
+
+void SerialLink::_writeBytes(const QByteArray &data)
+{
+    (void) QMetaObject::invokeMethod(_worker, "writeData", Qt::QueuedConnection, Q_ARG(QByteArray, data));
 }

--- a/src/Comms/SerialLink.h
+++ b/src/Comms/SerialLink.h
@@ -9,136 +9,168 @@
 
 #pragma once
 
-#include "LinkConfiguration.h"
-#include "LinkInterface.h"
-
-#include <QtCore/QMutex>
+#include <QtCore/QLoggingCategory>
 #include <QtCore/QString>
-#include <QtCore/QMetaType>
+
 #ifdef Q_OS_ANDROID
 #include "qserialport.h"
 #else
 #include <QtSerialPort/QSerialPort>
 #endif
-#include <QtCore/QLoggingCategory>
+
+#include "LinkConfiguration.h"
+#include "LinkInterface.h"
+
+class QThread;
+class QTimer;
 
 Q_DECLARE_LOGGING_CATEGORY(SerialLinkLog)
 
-// We use QSerialPort::SerialPortError in a signal so we must declare it as a meta type
-Q_DECLARE_METATYPE(QSerialPort::SerialPortError)
+/*===========================================================================*/
 
-class LinkManager;
-
-/// SerialLink configuration
 class SerialConfiguration : public LinkConfiguration
+{
+    Q_OBJECT
+    Q_PROPERTY(qint32                   baud            READ baud            WRITE setBaud        NOTIFY baudChanged)
+    Q_PROPERTY(QSerialPort::DataBits    dataBits        READ dataBits        WRITE setDataBits    NOTIFY dataBitsChanged)
+    Q_PROPERTY(QSerialPort::FlowControl flowControl     READ flowControl     WRITE setFlowControl NOTIFY flowControlChanged)
+    Q_PROPERTY(QSerialPort::StopBits    stopBits        READ stopBits        WRITE setStopBits    NOTIFY stopBitsChanged)
+    Q_PROPERTY(QSerialPort::Parity      parity          READ parity          WRITE setParity      NOTIFY parityChanged)
+    Q_PROPERTY(QString                  portName        READ portName        WRITE setPortName    NOTIFY portNameChanged)
+    Q_PROPERTY(QString                  portDisplayName READ portDisplayName                      NOTIFY portDisplayNameChanged)
+    Q_PROPERTY(bool                     usbDirect       READ usbDirect       WRITE setUsbDirect   NOTIFY usbDirectChanged)
+
+public:
+    explicit SerialConfiguration(const QString &name, QObject *parent = nullptr);
+    explicit SerialConfiguration(const SerialConfiguration *copy, QObject *parent = nullptr);
+    virtual ~SerialConfiguration();
+
+    LinkType type() const override { return LinkConfiguration::TypeSerial; }
+    void copyFrom(const LinkConfiguration *source) override;
+    void loadSettings(QSettings &settings, const QString &root) override;
+    void saveSettings(QSettings &settings, const QString &root) override;
+    QString settingsURL() override { return QStringLiteral("SerialSettings.qml"); }
+    QString settingsTitle() override { return tr("Serial Link Settings"); }
+
+    qint32 baud() const { return _baud; }
+    void setBaud(qint32 baud) { if (baud != _baud) { _baud = baud; emit baudChanged(); } }
+
+    QSerialPort::DataBits dataBits() const { return _dataBits; }
+    void setDataBits(QSerialPort::DataBits databits) { if (databits != _dataBits) { _dataBits = databits; emit dataBitsChanged(); } }
+
+    QSerialPort::FlowControl flowControl() const { return _flowControl; }
+    void setFlowControl(QSerialPort::FlowControl flowControl) { if (flowControl != _flowControl) { _flowControl = flowControl; emit flowControlChanged(); } }
+
+    QSerialPort::StopBits stopBits() const { return _stopBits; }
+    void setStopBits(QSerialPort::StopBits stopBits) { if (stopBits != _stopBits) { _stopBits = stopBits; emit stopBitsChanged(); } }
+
+    QSerialPort::Parity parity() const { return _parity; }
+    void setParity(QSerialPort::Parity parity) { if (parity != _parity) { _parity = parity; emit parityChanged(); } }
+
+    QString portName() const { return _portName; }
+    void setPortName(const QString &name);
+
+    QString portDisplayName() const { return _portDisplayName; }
+    void setPortDisplayName(const QString &portDisplayName) { if (portDisplayName != _portDisplayName) { _portDisplayName = portDisplayName; emit portDisplayNameChanged(); } }
+
+    bool usbDirect() const { return _usbDirect; }
+    void setUsbDirect(bool usbDirect) { if (usbDirect != _usbDirect) { _usbDirect = usbDirect; emit usbDirectChanged(); } }
+
+    static QStringList supportedBaudRates();
+    static QString cleanPortDisplayName(const QString &name);
+
+signals:
+    void baudChanged();
+    void dataBitsChanged();
+    void flowControlChanged();
+    void stopBitsChanged();
+    void parityChanged();
+    void portNameChanged();
+    void portDisplayNameChanged();
+    void usbDirectChanged();
+
+private:
+    qint32 _baud = QSerialPort::Baud57600;
+    QSerialPort::DataBits _dataBits = QSerialPort::Data8;
+    QSerialPort::FlowControl _flowControl = QSerialPort::NoFlowControl;
+    QSerialPort::StopBits _stopBits = QSerialPort::OneStop;
+    QSerialPort::Parity _parity = QSerialPort::NoParity;
+    QString _portName;
+    QString _portDisplayName;
+    bool _usbDirect = false;
+};
+
+/*===========================================================================*/
+
+class SerialWorker : public QObject
 {
     Q_OBJECT
 
 public:
+    explicit SerialWorker(const SerialConfiguration *config, QObject *parent = nullptr);
+    ~SerialWorker();
 
-    SerialConfiguration(const QString& name);
-    SerialConfiguration(const SerialConfiguration* copy);
-
-    Q_PROPERTY(int      baud            READ baud               WRITE setBaud               NOTIFY baudChanged)
-    Q_PROPERTY(int      dataBits        READ dataBits           WRITE setDataBits           NOTIFY dataBitsChanged)
-    Q_PROPERTY(int      flowControl     READ flowControl        WRITE setFlowControl        NOTIFY flowControlChanged)
-    Q_PROPERTY(int      stopBits        READ stopBits           WRITE setStopBits           NOTIFY stopBitsChanged)
-    Q_PROPERTY(int      parity          READ parity             WRITE setParity             NOTIFY parityChanged)
-    Q_PROPERTY(QString  portName        READ portName           WRITE setPortName           NOTIFY portNameChanged)
-    Q_PROPERTY(QString  portDisplayName READ portDisplayName                                NOTIFY portDisplayNameChanged)
-    Q_PROPERTY(bool     usbDirect       READ usbDirect          WRITE setUsbDirect          NOTIFY usbDirectChanged)        ///< true: direct usb connection to board
-
-    int  baud() const        { return _baud; }
-    int  dataBits() const    { return _dataBits; }
-    int  flowControl() const { return _flowControl; }    ///< QSerialPort Enums
-    int  stopBits() const    { return _stopBits; }
-    int  parity() const      { return _parity; }         ///< QSerialPort Enums
-    bool usbDirect() const   { return _usbDirect; }
-
-    const QString portName          () const { return _portName; }
-    const QString portDisplayName   () const { return _portDisplayName; }
-
-    void setBaud            (int baud);
-    void setDataBits        (int databits);
-    void setFlowControl     (int flowControl);          ///< QSerialPort Enums
-    void setStopBits        (int stopBits);
-    void setParity          (int parity);               ///< QSerialPort Enums
-    void setPortName        (const QString& portName);
-    void setUsbDirect       (bool usbDirect);
-
-    static QStringList supportedBaudRates();
-    static QString cleanPortDisplayname(const QString name);
-
-    /// From LinkConfiguration
-    LinkType    type            () const override { return LinkConfiguration::TypeSerial; }
-    void        copyFrom        (const LinkConfiguration* source) override;
-    void        loadSettings    (QSettings& settings, const QString& root) override;
-    void        saveSettings    (QSettings& settings, const QString& root) override;
-    void        updateSettings  ();
-    QString     settingsURL     () override { return "SerialSettings.qml"; }
-    QString     settingsTitle   () override { return tr("Serial Link Settings"); }
+    bool isConnected() const;
+    const QSerialPort *port() const { return _port; }
 
 signals:
-    void baudChanged            ();
-    void dataBitsChanged        ();
-    void flowControlChanged     ();
-    void stopBitsChanged        ();
-    void parityChanged          ();
-    void portNameChanged        ();
-    void portDisplayNameChanged ();
-    void usbDirectChanged       (bool usbDirect);
+    void connected();
+    void disconnected();
+    void dataReceived(const QByteArray &data);
+    void dataSent(const QByteArray &data);
+    void errorOccurred(const QString &errorString);
+
+public slots:
+    void setupPort();
+    void connectToPort();
+    void disconnectFromPort();
+    void writeData(const QByteArray &data);
+
+private slots:
+    void _onPortConnected();
+    void _onPortDisconnected();
+    void _onPortReadyRead();
+    void _onPortBytesWritten(qint64 bytes) const;
+    void _onPortErrorOccurred(QSerialPort::SerialPortError portError);
+    void _checkPortAvailability();
 
 private:
-    int _baud;
-    int _dataBits;
-    int _flowControl;
-    int _stopBits;
-    int _parity;
-    QString _portName;
-    QString _portDisplayName;
-    bool _usbDirect;
+    const SerialConfiguration *_config = nullptr;
+    QSerialPort *_port = nullptr;
+    QTimer *_timer = nullptr;
+    bool _errorEmitted = false;
 };
+
+/*===========================================================================*/
 
 class SerialLink : public LinkInterface
 {
     Q_OBJECT
 
 public:
-    SerialLink(SharedLinkConfigurationPtr& config);
+    explicit SerialLink(SharedLinkConfigurationPtr &config, QObject *parent = nullptr);
     virtual ~SerialLink();
 
-    // LinkInterface overrides
-    bool isConnected        (void) const override;
-    void disconnect         (void) override;
-    bool isSecureConnection (void) override;
+    bool isConnected() const override;
+    bool isSecureConnection() override { return _serialConfig->usbDirect(); }
 
-    /// Don't even think of calling this method!
-    QSerialPort* _hackAccessToPort(void) { return _port; }
-
-private slots:
-    void _writeBytes(const QByteArray &data) override;
+    const QSerialPort *port() const { return _worker->port(); }
 
 public slots:
-    void linkError(QSerialPort::SerialPortError error);
+    void disconnect() override;
 
 private slots:
-    void _readBytes     (void);
+    void _onConnected();
+    void _onDisconnected();
+    void _onDataReceived(const QByteArray &data);
+    void _onDataSent(const QByteArray &data);
+    void _onErrorOccurred(const QString &errorString);
 
 private:
-    // LinkInterface overrides
-    bool _connect(void) override;
+    bool _connect() override;
+    void _writeBytes(const QByteArray &data) override;
 
-    void _emitLinkError     (const QString& errorMsg);
-    bool _hardwareConnect   (QSerialPort::SerialPortError& error, QString& errorString);
-    bool _isBootloader      (void);
-
-    QSerialPort*            _port               = nullptr;
-    quint64                 _bytesRead          = 0;
-    int                     _timeout;
-    QMutex                  _dataMutex;                     ///< Mutex for reading data from _port
-    QMutex                  _writeMutex;                    ///< Mutex for accessing the _transmitBuffer.
-    volatile bool           _stopp              = false;
-    QMutex                  _stoppMutex;                    ///< Mutex for accessing _stopp
-    QByteArray              _transmitBuffer;                ///< An internal buffer for receiving data from member functions and actually transmitting them via the serial port.
-    const SerialConfiguration*    _serialConfig       = nullptr;
+    const SerialConfiguration *_serialConfig = nullptr;
+    SerialWorker *_worker = nullptr;
+    QThread *_workerThread = nullptr;
 };


### PR DESCRIPTION
Related to https://github.com/mavlink/qgroundcontrol/issues/11598
fixes #11849
The QThread inheritance will have to be removed after the remaining links are fixed
Tested by turning all streams to 100Hz and letting it run for a while:
![image](https://github.com/user-attachments/assets/a1188580-7984-41dd-add8-c39d854b50ac)
