### PR TITLE
Addroid Config Update: index.md

### DIFF
--- a/docs/en/qgc-dev-guide/getting_started/index.md
+++ b/docs/en/qgc-dev-guide/getting_started/index.md
@@ -138,8 +138,9 @@ To see a complete list of all available components in the installer _Select Comp
    - **Ubuntu:** Desktop Qt {{ $frontmatter.qt_version }} GCC 64bit
    - **Windows:** Desktop Qt {{ $frontmatter.qt_version }} MSVC2019 **64bit**
    - **Android:** Android for armeabi-v7a (GCC 4.9, Qt {{ $frontmatter.qt_version }})
-     - JDK11 is required.
+     - JDK17 is required for the latest updated versions. NDK Version: 25.1.8937393
        You can confirm it is being used by reviewing the project setting: **Projects > Manage Kits > Devices > Android (tab) > Android Settings > _JDK location_**.
+	Note: Visit here for more detailed configurations ![android.yml](.github/workflows/android.yml)
 
 1. Build using the "hammer" (or "play") icons:
 

--- a/docs/en/qgc-dev-guide/getting_started/index.md
+++ b/docs/en/qgc-dev-guide/getting_started/index.md
@@ -140,7 +140,7 @@ To see a complete list of all available components in the installer _Select Comp
    - **Android:** Android for armeabi-v7a (GCC 4.9, Qt {{ $frontmatter.qt_version }})
      - JDK17 is required for the latest updated versions. NDK Version: 25.1.8937393
        You can confirm it is being used by reviewing the project setting: **Projects > Manage Kits > Devices > Android (tab) > Android Settings > _JDK location_**.
-	Note: Visit here for more detailed configurations ![android.yml](.github/workflows/android.yml)
+	Note: Visit here for more detailed configurations [android.yml](.github/workflows/android.yml)
 
 1. Build using the "hammer" (or "play") icons:
 


### PR DESCRIPTION
Updated config for android for current versions : Jdk11 has been outdated for QT.6.6.3, and is only recommended for Qt 5.15.2

<!--- Title -->

Description
-----------
<!--- Describe your changes in detail. -->

Test Steps
-----------
<!-- Describe the steps to reproduce. -->

Checklist:
----------
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] [Review Contribution Guidelines](https://github.com/mavlink/qgroundcontrol/blob/master/.github/CONTRIBUTING.md).
- [x] [Review Code of Conduct](https://github.com/mavlink/qgroundcontrol/blob/master/.github/CODE_OF_CONDUCT.md).
- [x] I have tested my changes.

Related Issue
-----------
<!-- If any, please provide issue ID. -->


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.