### PR TITLE
Prevent a NPE when starting up

### DIFF
--- a/src/Vehicle/Actuators/ActuatorTesting.cc
+++ b/src/Vehicle/Actuators/ActuatorTesting.cc
@@ -31,7 +31,11 @@ ActuatorTest::~ActuatorTest()
 void ActuatorTest::updateFunctions(const QList<Actuator*> &actuators)
 {
     _actuators->clearAndDeleteContents();
-    _allMotorsActuator->deleteLater();
+
+    if (_allMotorsActuator) {
+      _allMotorsActuator->deleteLater();
+    }
+
     _allMotorsActuator = nullptr;
 
     Actuator* motorActuator{nullptr};


### PR DESCRIPTION
On first startup a null pointer is dereferenced, this protects against that.

```
Thread 1 "QGroundControl" received signal SIGSEGV, Segmentation fault.
0x00007ffff4b93889 in QObject::deleteLater() () from /usr/lib/libQt6Core.so.6

(gdb) bt
#0  0x00007ffff4b93889 in QObject::deleteLater() () from /usr/lib/libQt6Core.so.6
#1  0x0000555555d51c4e in ActuatorTesting::ActuatorTest::updateFunctions (this=0x55555db54490, actuators=...)
    at /project/source/src/Vehicle/Actuators/ActuatorTesting.cc:34
#2  0x0000555555d1f843 in Actuators::parametersChanged (this=0x55555db54430) at /project/source/src/Vehicle/Actuators/Actuators.cc:241

```