### PR TITLE
MissionController.cc: fix bug current mission item not clearing:

### DIFF
--- a/src/MissionManager/MissionController.cc
+++ b/src/MissionManager/MissionController.cc
@@ -2473,6 +2473,8 @@ void MissionController::setCurrentPlanViewSeqNum(int sequenceNumber, bool force)
                 }
             } else {
                 pVI->setIsCurrentItem(false);
+                // Child items will always be later in the mission sequence, so this should be correct, to be sure the HasCurrentChildItem is cleared
+                pVI->setHasCurrentChildItem(false);
             }
         }
 


### PR DESCRIPTION
In plan view, when selecting a mission item which is a child item ( on the right mission item view flickable for example ), the child item gets set as current item, and thus the parent gets highlighted in the map, as expected.

However, from there, when selecting a different current mission item, the previous highlighted ( parent of the previous selected mission item ) does not get cleared. If repeating this process, we end up with a lot of falsely highlighted items on the map.

This happens because we were forgetting to clear the hasCurrentChildItem property. This commit fixes this.