### PR TITLE
Hardware: Add support for 3DR Control Zero H7 OEM Rev G

### DIFF
--- a/src/Comms/USBBoardInfo.json
+++ b/src/Comms/USBBoardInfo.json
@@ -106,5 +106,6 @@
         { "regExp": "^Hex/ProfiCNC$",   "boardClass": "Pixhawk" },
         { "regExp": "^Holybro$",        "boardClass": "Pixhawk" },
         { "regExp": "^mRo$",            "boardClass": "Pixhawk" }
+        { "regExp": "^3DR$",            "boardClass": "Pixhawk" }
     ]
 }

--- a/src/Comms/USBBoardInfo.json
+++ b/src/Comms/USBBoardInfo.json
@@ -105,7 +105,7 @@
         { "regExp": "^ArduPilot$",      "boardClass": "Pixhawk" },
         { "regExp": "^Hex/ProfiCNC$",   "boardClass": "Pixhawk" },
         { "regExp": "^Holybro$",        "boardClass": "Pixhawk" },
-        { "regExp": "^mRo$",            "boardClass": "Pixhawk" }
-        { "regExp": "^3DR$",            "boardClass": "Pixhawk" }
+        { "regExp": "^mRo$",            "boardClass": "Pixhawk" },
+        { "regExp": "^3DR$",            "boardClass": "Pixhawk" },
     ]
 }

--- a/src/VehicleSetup/FirmwareUpgradeController.cc
+++ b/src/VehicleSetup/FirmwareUpgradeController.cc
@@ -88,6 +88,7 @@ static QMap<int, QString> px4_board_name_map {
     {1054, "holybro_kakuteh7mini_default"},
     {1110, "jfb_jfb110_default"},
     {1123, "siyi_n7_default"},    
+    {1124, "3dr_ctrl-zero-h7-oem-revg_default"},
 };
 
 uint qHash(const FirmwareUpgradeController::FirmwareIdentifier& firmwareId)


### PR DESCRIPTION
<!--- Title -->

Description
-----------
<!--- Describe your changes in detail. -->
This addition will help with this new board revision (under 3DR's brand) and the following new 3DR boards being recognized by QGC. 

3DR Control Zero H7 OEM Rev G is a board already working with Ardupilot Repos and a PR for PX4 is soon to be released (no later than this weekend). 