### PR TITLE
Revert "Do not REQUEST_DATA_STREAMs by default, since it's deprecated"

### DIFF
--- a/src/Settings/App.SettingsGroup.json
+++ b/src/Settings/App.SettingsGroup.json
@@ -253,7 +253,7 @@
     "name":                 "apmStartMavlinkStreams",
     "shortDesc":     "Request start of MAVLink telemetry streams (ArduPilot only)",
     "type":                 "bool",
-    "default":         false,
+    "default":         true,
     "qgcRebootRequired":    true
 },
 {


### PR DESCRIPTION
Reverts mavlink/qgroundcontrol#11531
Need a better solution due to Copter not initiating streams automatically