### PR TITLE
Comms: Fix Extra Comma in BoardInfo json

### DIFF
--- a/src/Comms/USBBoardInfo.json
+++ b/src/Comms/USBBoardInfo.json
@@ -106,6 +106,6 @@
         { "regExp": "^Hex/ProfiCNC$",   "boardClass": "Pixhawk" },
         { "regExp": "^Holybro$",        "boardClass": "Pixhawk" },
         { "regExp": "^mRo$",            "boardClass": "Pixhawk" },
-        { "regExp": "^3DR$",            "boardClass": "Pixhawk" },
+        { "regExp": "^3DR$",            "boardClass": "Pixhawk" }
     ]
 }


### PR DESCRIPTION
Unable to parse board info json: "object is missing after a comma"