### PR TITLE
QtLocationPlugin: Update QGCMapEngineManager

### DIFF
--- a/src/QGCToolbox.cc
+++ b/src/QGCToolbox.cc
@@ -17,7 +17,6 @@
 #include "MAVLinkProtocol.h"
 #include "MissionCommandTree.h"
 #include "MultiVehicleManager.h"
-#include "QGCMapEngineManager.h"
 #include "FollowMe.h"
 #include "PositionManager.h"
 #include "VideoManager.h"
@@ -55,7 +54,6 @@ QGCToolbox::QGCToolbox(QGCApplication* app)
     _mavlinkProtocol        = new MAVLinkProtocol           (app, this);
     _missionCommandTree     = new MissionCommandTree        (app, this);
     _multiVehicleManager    = new MultiVehicleManager       (app, this);
-    _mapEngineManager       = new QGCMapEngineManager       (app, this);
     _qgcPositionManager     = new QGCPositionManager        (app, this);
     _followMe               = new FollowMe                  (app, this);
     _videoManager           = new VideoManager              (app, this);
@@ -85,7 +83,6 @@ void QGCToolbox::setChildToolboxes(void)
     _mavlinkProtocol->setToolbox(this);
     _missionCommandTree->setToolbox(this);
     _multiVehicleManager->setToolbox(this);
-    _mapEngineManager->setToolbox(this);
     _followMe->setToolbox(this);
     _qgcPositionManager->setToolbox(this);
     _videoManager->setToolbox(this);

--- a/src/QGCToolbox.h
+++ b/src/QGCToolbox.h
@@ -21,7 +21,6 @@ class LinkManager;
 class MAVLinkProtocol;
 class MissionCommandTree;
 class MultiVehicleManager;
-class QGCMapEngineManager;
 class QGCApplication;
 class QGCPositionManager;
 class VideoManager;
@@ -49,7 +48,6 @@ public:
     MAVLinkProtocol*            mavlinkProtocol         () { return _mavlinkProtocol; }
     MissionCommandTree*         missionCommandTree      () { return _missionCommandTree; }
     MultiVehicleManager*        multiVehicleManager     () { return _multiVehicleManager; }
-    QGCMapEngineManager*        mapEngineManager        () { return _mapEngineManager; }
     FollowMe*                   followMe                () { return _followMe; }
     QGCPositionManager*         qgcPositionManager      () { return _qgcPositionManager; }
     VideoManager*               videoManager            () { return _videoManager; }
@@ -80,7 +78,6 @@ private:
     MAVLinkProtocol*            _mavlinkProtocol        = nullptr;
     MissionCommandTree*         _missionCommandTree     = nullptr;
     MultiVehicleManager*        _multiVehicleManager    = nullptr;
-    QGCMapEngineManager*        _mapEngineManager       = nullptr;
     FollowMe*                   _followMe               = nullptr;
     QGCPositionManager*         _qgcPositionManager     = nullptr;
     VideoManager*               _videoManager           = nullptr;

--- a/src/QmlControls/QGroundControlQmlGlobal.cc
+++ b/src/QmlControls/QGroundControlQmlGlobal.cc
@@ -15,6 +15,7 @@
 #include "FirmwarePluginManager.h"
 #include "AppSettings.h"
 #include "PositionManager.h"
+#include "QGCMapEngineManager.h"
 #ifndef NO_SERIAL_LINK
 #include "GPSManager.h"
 #endif
@@ -30,7 +31,8 @@ QGeoCoordinate   QGroundControlQmlGlobal::_coord = QGeoCoordinate(0.0,0.0);
 double           QGroundControlQmlGlobal::_zoom = 2;
 
 QGroundControlQmlGlobal::QGroundControlQmlGlobal(QGCApplication* app, QGCToolbox* toolbox)
-    : QGCTool               (app, toolbox)
+    : QGCTool(app, toolbox)
+    , _mapEngineManager(QGCMapEngineManager::instance())
 {
     // We clear the parent on this object since we run into shutdown problems caused by hybrid qml app. Instead we let it leak on shutdown.
     // setParent(nullptr);
@@ -73,7 +75,6 @@ void QGroundControlQmlGlobal::setToolbox(QGCToolbox* toolbox)
 
     _linkManager            = toolbox->linkManager();
     _multiVehicleManager    = toolbox->multiVehicleManager();
-    _mapEngineManager       = toolbox->mapEngineManager();
     _qgcPositionManager     = toolbox->qgcPositionManager();
     _missionCommandTree     = toolbox->missionCommandTree();
     _videoManager           = toolbox->videoManager();

--- a/src/QmlControls/QmlObjectListModel.h
+++ b/src/QmlControls/QmlObjectListModel.h
@@ -27,6 +27,7 @@ public:
     Q_PROPERTY(bool dirty READ dirty WRITE setDirty NOTIFY dirtyChanged)
 
     Q_INVOKABLE QObject* get(int index);
+    const QObject *get(int index) const;
 
     // Property accessors
     

--- a/src/QtLocationPlugin/CMakeLists.txt
+++ b/src/QtLocationPlugin/CMakeLists.txt
@@ -53,6 +53,7 @@ endif()
 target_link_libraries(QGCLocation
     PRIVATE
         Qt6::Positioning
+        QGC
         Settings
         Utilities
     PUBLIC
@@ -61,7 +62,6 @@ target_link_libraries(QGCLocation
         Qt6::LocationPrivate
         Qt6::Network
         Qt6::Sql
-        QGC
         QmlControls
 )
 
@@ -71,15 +71,8 @@ target_include_directories(QGCLocation
         QMLControl
 )
 
-set_source_files_properties(QMLControl/OfflineMap.qml
-    PROPERTIES
-        QT_RESOURCE_ALIAS OfflineMap.qml
-)
-
-set_source_files_properties(QMLControl/OfflineMapEditor.qml
-    PROPERTIES
-        QT_RESOURCE_ALIAS OfflineMapEditor.qml
-)
+set_source_files_properties(QMLControl/OfflineMap.qml PROPERTIES QT_RESOURCE_ALIAS OfflineMap.qml)
+set_source_files_properties(QMLControl/OfflineMapEditor.qml PROPERTIES QT_RESOURCE_ALIAS OfflineMapEditor.qml)
 
 # qt_add_qml_module(QGCLocation
 #     URI QGroundControl.QGCLocation

--- a/src/QtLocationPlugin/QMLControl/QGCMapEngineManager.h
+++ b/src/QtLocationPlugin/QMLControl/QGCMapEngineManager.h
@@ -13,23 +13,45 @@
 
 #pragma once
 
-#include "QmlObjectListModel.h"
-#include "QGCToolbox.h"
 #include "QGCTileSet.h"
 #include "QGCMapTasks.h"
 
+// #include <QtQmlIntegration/QtQmlIntegration>
 #include <QtCore/QLoggingCategory>
 
 Q_DECLARE_LOGGING_CATEGORY(QGCMapEngineManagerLog)
 
 class QGCCachedTileSet;
+class QmlObjectListModel;
 
-class QGCMapEngineManager : public QGCTool
+class QGCMapEngineManager : public QObject
 {
     Q_OBJECT
+    // QML_ELEMENT
+    // QML_SINGLETON
+    Q_MOC_INCLUDE("QmlObjectListModel.h")
+    Q_MOC_INCLUDE("QGCCachedTileSet.h")
+
+    Q_PROPERTY(bool                 fetchElevation  MEMBER _fetchElevation                          NOTIFY fetchElevationChanged)
+    Q_PROPERTY(bool                 importReplace   MEMBER _importReplace                           NOTIFY importReplaceChanged)
+    Q_PROPERTY(ImportAction         importAction    READ importAction       WRITE setImportAction   NOTIFY importActionChanged)
+    Q_PROPERTY(int                  actionProgress  READ actionProgress                             NOTIFY actionProgressChanged)
+    Q_PROPERTY(int                  selectedCount   READ selectedCount                              NOTIFY selectedCountChanged)
+    Q_PROPERTY(QmlObjectListModel   *tileSets       READ tileSets                                   NOTIFY tileSetsChanged)
+    Q_PROPERTY(QString              errorMessage    READ errorMessage                               NOTIFY errorMessageChanged)
+    Q_PROPERTY(QString              tileCountStr    READ tileCountStr                               NOTIFY tileCountChanged)
+    Q_PROPERTY(QString              tileSizeStr     READ tileSizeStr                                NOTIFY tileSizeChanged)
+    Q_PROPERTY(QStringList          mapList         READ mapList                                    CONSTANT)
+    Q_PROPERTY(QStringList          mapProviderList READ mapProviderList                            CONSTANT)
+    Q_PROPERTY(quint32              diskSpace       READ diskSpace)
+    Q_PROPERTY(quint32              freeDiskSpace   READ freeDiskSpace                              NOTIFY freeDiskSpaceChanged)
+    Q_PROPERTY(quint64              tileCount       READ tileCount                                  NOTIFY tileCountChanged)
+    Q_PROPERTY(quint64              tileSize        READ tileSize                                   NOTIFY tileSizeChanged)
+
 public:
-    QGCMapEngineManager(QGCApplication* app, QGCToolbox* toolbox);
+    QGCMapEngineManager(QObject *parent = nullptr);
     ~QGCMapEngineManager();
+    static QGCMapEngineManager *instance();
 
     enum ImportAction {
         ActionNone,
@@ -39,110 +61,85 @@ public:
     };
     Q_ENUM(ImportAction)
 
-    Q_PROPERTY(quint64              tileCount       READ    tileCount       NOTIFY tileCountChanged)
-    Q_PROPERTY(QString              tileCountStr    READ    tileCountStr    NOTIFY tileCountChanged)
-    Q_PROPERTY(quint64              tileSize        READ    tileSize        NOTIFY tileSizeChanged)
-    Q_PROPERTY(QString              tileSizeStr     READ    tileSizeStr     NOTIFY tileSizeChanged)
-    Q_PROPERTY(QmlObjectListModel*  tileSets        READ    tileSets        NOTIFY tileSetsChanged)
-    Q_PROPERTY(QStringList          mapList         READ    mapList         CONSTANT)
-    Q_PROPERTY(QStringList          mapProviderList READ    mapProviderList CONSTANT)
-    Q_PROPERTY(QString              errorMessage    READ    errorMessage    NOTIFY  errorMessageChanged)
-    Q_PROPERTY(bool                 fetchElevation  READ    fetchElevation  WRITE   setFetchElevation   NOTIFY  fetchElevationChanged)
-    //-- Disk Space in MB
-    Q_PROPERTY(quint32              freeDiskSpace   READ    freeDiskSpace   NOTIFY  freeDiskSpaceChanged)
-    Q_PROPERTY(quint32              diskSpace       READ    diskSpace       CONSTANT)
-    //-- Tile set export
-    Q_PROPERTY(int                  selectedCount   READ    selectedCount   NOTIFY selectedCountChanged)
-    Q_PROPERTY(int                  actionProgress  READ    actionProgress  NOTIFY actionProgressChanged)
-    Q_PROPERTY(ImportAction         importAction    READ    importAction    WRITE  setImportAction   NOTIFY importActionChanged)
+    Q_INVOKABLE bool exportSets(const QString &path = QString());
+    Q_INVOKABLE bool findName(const QString &name) const;
+    Q_INVOKABLE bool importSets(const QString &path = QString());
+    Q_INVOKABLE QString getUniqueName() const;
+    Q_INVOKABLE void deleteTileSet(QGCCachedTileSet *tileSet);
+    Q_INVOKABLE void loadTileSets();
+    Q_INVOKABLE void renameTileSet(QGCCachedTileSet *tileSet, const QString &newName);
+    Q_INVOKABLE void resetAction() { setImportAction(ActionNone); }
+    Q_INVOKABLE void selectAll();
+    Q_INVOKABLE void selectNone();
+    Q_INVOKABLE void startDownload(const QString &name, const QString &mapType);
+    Q_INVOKABLE void updateForCurrentView(double lon0, double lat0, double lon1, double lat1, int minZoom, int maxZoom, const QString &mapName);
 
-    Q_PROPERTY(bool                 importReplace   READ    importReplace   WRITE   setImportReplace   NOTIFY importReplaceChanged)
+    Q_INVOKABLE static QString loadSetting(const QString &key, const QString &defaultValue);
+    Q_INVOKABLE static QStringList mapTypeList(const QString &provider);
+    Q_INVOKABLE static void saveSetting(const QString &key, const QString &value);
 
-    Q_INVOKABLE void                loadTileSets            ();
-    Q_INVOKABLE void                updateForCurrentView    (double lon0, double lat0, double lon1, double lat1, int minZoom, int maxZoom, const QString& mapName);
-    Q_INVOKABLE void                startDownload           (const QString& name, const QString& mapType);
-    Q_INVOKABLE void                saveSetting             (const QString& key,  const QString& value);
-    Q_INVOKABLE QString             loadSetting             (const QString& key,  const QString& defaultValue);
-    Q_INVOKABLE void                deleteTileSet           (QGCCachedTileSet* tileSet);
-    Q_INVOKABLE void                renameTileSet           (QGCCachedTileSet* tileSet, QString newName);
-    Q_INVOKABLE QString             getUniqueName           ();
-    Q_INVOKABLE bool                findName                (const QString& name);
-    Q_INVOKABLE void                selectAll               ();
-    Q_INVOKABLE void                selectNone              ();
-    Q_INVOKABLE bool                exportSets              (QString path = QString());
-    Q_INVOKABLE bool                importSets              (QString path = QString());
-    Q_INVOKABLE void                resetAction             ();
+    ImportAction importAction() const { return _importAction; }
+    int actionProgress() const { return _actionProgress; }
+    int selectedCount() const;
+    QmlObjectListModel *tileSets() { return _tileSets; }
+    QString errorMessage() const { return _errorMessage; }
+    QString tileCountStr() const;
+    QString tileSizeStr() const;
+    quint64 diskSpace() const { return _diskSpace; }
+    quint64 freeDiskSpace() const { return _freeDiskSpace; }
+    quint64 tileCount() const { return (_imageSet.tileCount + _elevationSet.tileCount); }
+    quint64 tileSize() const { return (_imageSet.tileSize + _elevationSet.tileSize); }
 
-    quint64                         tileCount               () const{ return _imageSet.tileCount + _elevationSet.tileCount; }
-    QString                         tileCountStr            () const;
-    quint64                         tileSize                () const{ return _imageSet.tileSize + _elevationSet.tileSize; }
-    QString                         tileSizeStr             () const;
-    QStringList                     mapList                 ();
-    QStringList                     mapProviderList         ();
-    Q_INVOKABLE QStringList         mapTypeList             (QString provider);
-    QmlObjectListModel*             tileSets                () { return &_tileSets; }
-    QString                         errorMessage            () { return _errorMessage; }
-    bool                            fetchElevation          () const{ return _fetchElevation; }
-    quint64                         freeDiskSpace           () const{ return _freeDiskSpace; }
-    quint64                         diskSpace               () const{ return _diskSpace; }
-    int                             selectedCount           ();
-    int                             actionProgress          () const{ return _actionProgress; }
-    ImportAction                    importAction            () { return _importAction; }
-    bool                            importReplace           () const{ return _importReplace; }
+    void setActionProgress(int percentage) { if (percentage != _actionProgress) { _actionProgress = percentage; emit actionProgressChanged(); } }
+    void setErrorMessage(const QString &error) { if (error != _errorMessage) { _errorMessage = error; emit errorMessageChanged(); } }
+    void setFreeDiskSpace(quint64 diskSpace) { if (diskSpace != _freeDiskSpace) { _freeDiskSpace = diskSpace; emit freeDiskSpaceChanged(); } }
+    void setImportAction(ImportAction action) { if (action != _importAction) { _importAction = action; emit importActionChanged(); } }
 
-    void                            setImportReplace        (bool replace) { _importReplace = replace; emit importReplaceChanged(); }
-    void                            setImportAction         (ImportAction action)  {_importAction = action; emit importActionChanged(); }
-    void                            setErrorMessage         (const QString& error) { _errorMessage = error; emit errorMessageChanged(); }
-    void                            setFetchElevation       (bool fetchElevation) { _fetchElevation = fetchElevation; emit fetchElevationChanged(); }
-
-    // Override from QGCTool
-    void setToolbox(QGCToolbox *toolbox);
+    static QStringList mapList();
+    static QStringList mapProviderList();
 
 signals:
-    void tileCountChanged       ();
-    void tileSizeChanged        ();
-    void tileSetsChanged        ();
-    void maxMemCacheChanged     ();
-    void maxDiskCacheChanged    ();
-    void errorMessageChanged    ();
-    void fetchElevationChanged  ();
-    void freeDiskSpaceChanged   ();
-    void selectedCountChanged   ();
-    void actionProgressChanged  ();
-    void importActionChanged    ();
-    void importReplaceChanged   ();
+    void actionProgressChanged();
+    void errorMessageChanged();
+    void fetchElevationChanged();
+    void freeDiskSpaceChanged();
+    void importActionChanged();
+    void importReplaceChanged();
+    void selectedCountChanged();
+    void tileCountChanged();
+    void tileSetsChanged();
+    void tileSizeChanged();
 
 public slots:
-    void taskError              (QGCMapTask::TaskType type, QString error);
+    void taskError(QGCMapTask::TaskType type, const QString &error);
 
 private slots:
-    void _tileSetSaved          (QGCCachedTileSet* set);
-    void _tileSetFetched        (QGCCachedTileSet* tileSets);
-    void _tileSetDeleted        (quint64 setID);
-    void _updateTotals          (quint32 totaltiles, quint64 totalsize, quint32 defaulttiles, quint64 defaultsize);
-    void _resetCompleted        ();
-    void _actionCompleted       ();
-    void _actionProgressHandler (int percentage);
+    void _actionCompleted();
+    void _actionProgressHandler(int percentage) { setActionProgress(percentage); }
+    void _resetCompleted() { loadTileSets(); }
+    void _tileSetDeleted(quint64 setID);
+    void _tileSetFetched(QGCCachedTileSet *tileSets);
+    void _tileSetSaved(QGCCachedTileSet *set);
+    void _updateTotals(quint32 totaltiles, quint64 totalsize, quint32 defaulttiles, quint64 defaultsize);
 
 private:
-    void _updateDiskFreeSpace   ();
+    void _updateDiskFreeSpace(); 
 
-private:
-    QGCTileSet  _imageSet;
-    QGCTileSet  _elevationSet;
-    double      _topleftLat;
-    double      _topleftLon;
-    double      _bottomRightLat;
-    double      _bottomRightLon;
-    int         _minZoom;
-    int         _maxZoom;
-    quint64     _setID;
-    quint32     _freeDiskSpace;
-    quint32     _diskSpace;
-    QmlObjectListModel _tileSets;
-    QString     _errorMessage;
-    bool        _fetchElevation;
-    int         _actionProgress;
-    ImportAction _importAction;
-    bool        _importReplace;
+    QmlObjectListModel *_tileSets = nullptr;
+    QGCTileSet _imageSet;
+    QGCTileSet _elevationSet;
+    ImportAction _importAction = ActionNone;
+    double _topleftLat = 0.;
+    double _topleftLon = 0.;
+    double _bottomRightLat = 0.;
+    double _bottomRightLon = 0.;
+    int _minZoom = 0;
+    int _maxZoom = 0;
+    int _actionProgress = 0;
+    quint64 _setID = UINT64_MAX;
+    quint32 _freeDiskSpace = 0;
+    quint32 _diskSpace = 0;
+    QString _errorMessage;
+    bool _fetchElevation = true;
+    bool _importReplace = false;
 };


### PR DESCRIPTION
Remove a couple unused signals
Use Application Instance instead of Toolbox for QGCMapEngineManager instance to further separate location plugin from core code & reduce linking/dependencies
Perform code quality maintenance