### PR TITLE
Fix broken support links

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -7,7 +7,7 @@ assignees: ''
 
 ---
 
-The following template is for Issue/Bug reporting only. https://docs.qgroundcontrol.com/en/Support/Support.html#github-issues
+The following template is for Issue/Bug reporting only. https://docs.qgroundcontrol.com/en/support/support.html#github-issues
 
 For questions about how to use or build QGC see: http://qgroundcontrol.com/#resources
 
@@ -39,6 +39,6 @@ When posting bug reports, include the following information
 Provide further details about your issue/bug.
 
 ## Log Files and Screenshots
-- [QGC Console Logs](https://docs.qgroundcontrol.com/en/Support/Support.html#reporting-bugs)
+- [QGC Console Logs](https://docs.qgroundcontrol.com/en/settings_view/console_logging.html)
 - Autopilot logs when available (post a link).
 - Screenshots of QGC to help identify the current issue/bug behavior.

--- a/README.md
+++ b/README.md
@@ -16,6 +16,6 @@ Key Links:
 * [Website](http://qgroundcontrol.com) (qgroundcontrol.com)
 * [User Manual](https://docs.qgroundcontrol.com/en/)
 * [Developer Guide](https://dev.qgroundcontrol.com/en/)
-* [Discussion/Support](https://docs.qgroundcontrol.com/en/Support/Support.html)
+* [Discussion/Support](https://docs.qgroundcontrol.com/en/support/support.html)
 * [Contributing](https://dev.qgroundcontrol.com/en/contribute/)
 * [License](https://github.com/mavlink/qgroundcontrol/blob/master/COPYING.md)

--- a/deploy/installer/README.md
+++ b/deploy/installer/README.md
@@ -16,6 +16,6 @@ Key Links:
 * [Website](http://qgroundcontrol.com) (qgroundcontrol.com)
 * [User Manual](https://docs.qgroundcontrol.com/en/)
 * [Developer Guide](https://dev.qgroundcontrol.com/en/)
-* [Discussion/Support](https://docs.qgroundcontrol.com/en/Support/Support.html)
+* [Discussion/Support](https://docs.qgroundcontrol.com/en/support/support.html)
 * [Contributing](https://dev.qgroundcontrol.com/en/contribute/)
 * [License](https://github.com/mavlink/qgroundcontrol/blob/master/COPYING.md)


### PR DESCRIPTION
[](url)<!--- Title -->

Description
-----------
I noticed the "Discussion/Support" link in the root README.md had an outdated link. I fixed all occurances of the outdated link. 


https://github.com/user-attachments/assets/e2cf9ffd-069b-4af1-ae9f-3d30020b74b2

There was also a broken link should have been a link to a different page. In this video I show a fix for the broken link, and then the actual link that it is changed to in this PR (the "Console Logging" page instead of the "Reporting Bugs" page)

https://github.com/user-attachments/assets/3bc708b0-d752-4b33-8287-4e44721f8bd0

