### PR TITLE
Fix light/dark toggle button on "Palette Test" page

### DIFF
--- a/test/QmlControls/QmlTest.qml
+++ b/test/QmlControls/QmlTest.qml
@@ -12,6 +12,8 @@ Rectangle {
     anchors.margins:    ScreenTools.defaultFontPixelWidth
     color:              "white"
 
+    QGCPalette { id: qgcPal }
+
     property var palette:           QGCPalette { colorGroupEnabled: true }
     property var enabledPalette:    QGCPalette { colorGroupEnabled: true }
     property var disabledPalette:   QGCPalette { colorGroupEnabled: false }
@@ -237,16 +239,16 @@ Rectangle {
                 anchors.verticalCenter: parent.verticalCenter
                 QGCRadioButton {
                     text:       qsTr("Light")
-                    checked:    _root.qgcPal.globalTheme === QGCPalette.Light
+                    checked:    qgcPal.globalTheme === QGCPalette.Light
                     onClicked: {
-                        _root.qgcPal.globalTheme = QGCPalette.Light
+                        qgcPal.globalTheme = QGCPalette.Light
                     }
                 }
                 QGCRadioButton {
                     text:       qsTr("Dark")
-                    checked:    _root.qgcPal.globalTheme === QGCPalette.Dark
+                    checked:    qgcPal.globalTheme === QGCPalette.Dark
                     onClicked: {
-                        _root.qgcPal.globalTheme = QGCPalette.Dark
+                        qgcPal.globalTheme = QGCPalette.Dark
                     }
                 }
             }


### PR DESCRIPTION
before
![before-light-mode](https://github.com/user-attachments/assets/cc5251f5-8a01-4556-8890-af8b2c154ad2)

after
![after-light-dark](https://github.com/user-attachments/assets/a00c60b2-2fa2-4404-afc8-158f05ef913d)
