### PR TITLE
Gillamkid/hover highlight

### DIFF
--- a/src/QmlControls/QGCButton.qml
+++ b/src/QmlControls/QGCButton.qml
@@ -30,7 +30,7 @@ Button {
     property alias wrapMode:            text.wrapMode
     property alias horizontalAlignment: text.horizontalAlignment
 
-    property bool   _showHighlight:     enabled && (pressed | hovered | checked)
+    property bool   _showHighlight:     enabled && (pressed | checked)
 
     property int _horizontalPadding:    ScreenTools.defaultFontPixelWidth
     property int _verticalPadding:      Math.round(ScreenTools.defaultFontPixelHeight * heightFactor)
@@ -44,7 +44,13 @@ Button {
         implicitHeight: ScreenTools.implicitButtonHeight
         border.width:   showBorder ? 1 : 0
         border.color:   qgcPal.buttonBorder
-        color:          _showHighlight ? qgcPal.buttonHighlight : (primary ? qgcPal.primaryButton : qgcPal.button)
+        color:          primary ? qgcPal.primaryButton : qgcPal.button
+
+        Rectangle {
+            anchors.fill:   parent
+            color:          qgcPal.buttonHighlight
+            opacity:        _showHighlight ? 1 : control.enabled && control.hovered ? .2 : 0
+        }
     }
 
     contentItem: RowLayout {

--- a/src/QmlControls/SubMenuButton.qml
+++ b/src/QmlControls/SubMenuButton.qml
@@ -17,6 +17,7 @@ Button {
 
     text:               "Button"  ///< Pass in your own button text
     focusPolicy:    Qt.ClickFocus
+    hoverEnabled:   !ScreenTools.isMobile
 
     implicitHeight: ScreenTools.isTinyScreen ? ScreenTools.defaultFontPixelHeight * 3.5 : ScreenTools.defaultFontPixelHeight * 2.5
     //implicitWidth:  __panel.implicitWidth
@@ -39,9 +40,15 @@ Button {
 
     background: Rectangle {
         id:     innerRect
-        color:  showHighlight ? qgcPal.buttonHighlight : qgcPal.windowShade
+        color:  qgcPal.windowShade
 
         implicitWidth: titleBar.x + titleBar.contentWidth + ScreenTools.defaultFontPixelWidth
+
+        Rectangle {
+            anchors.fill:   parent
+            color:          qgcPal.buttonHighlight
+            opacity:        showHighlight ? 1 : control.enabled && control.hovered ? .2 : 0
+        }
 
         QGCColoredImage {
             id:                     image

--- a/src/QmlControls/SubMenuButton.qml
+++ b/src/QmlControls/SubMenuButton.qml
@@ -59,7 +59,7 @@ Button {
             height:                 ScreenTools.defaultFontPixelHeight * 2
             fillMode:               Image.PreserveAspectFit
             mipmap:                 true
-            color:                  imageColor ? imageColor : (control.setupComplete ? qgcPal.button : "red")
+            color:                  imageColor ? imageColor : (control.setupComplete ? titleBar.color : "red")
             source:                 control.imageResource
             sourceSize:             control.sourceSize
         }

--- a/src/UI/AppSettings.qml
+++ b/src/UI/AppSettings.qml
@@ -99,12 +99,13 @@ Rectangle {
 
                         QGCColoredImage {
                             source: iconUrl
-                            color:  checked || pressed ? qgcPal.buttonHighlightText : qgcPal.buttonText
+                            color:  displayText.color
                             width:  ScreenTools.defaultFontPixelHeight
                             height: ScreenTools.defaultFontPixelHeight
                         }
 
                         QGCLabel {
+                            id:                     displayText
                             Layout.fillWidth:       true
                             text:                   name
                             color:                  checked || pressed ? qgcPal.buttonHighlightText : qgcPal.buttonText

--- a/src/UI/AppSettings.qml
+++ b/src/UI/AppSettings.qml
@@ -83,13 +83,15 @@ Rectangle {
                     Layout.fillWidth:   true
                     text:               name
                     padding:            ScreenTools.defaultFontPixelWidth / 2
+                    hoverEnabled:       !ScreenTools.isMobile
                     autoExclusive:      true
                     icon.source:        iconUrl
                     visible:            pageVisible()
 
                     background: Rectangle {
-                        color:  checked ? qgcPal.buttonHighlight : "transparent"
-                        radius: ScreenTools.defaultFontPixelWidth / 2
+                        color:      qgcPal.buttonHighlight
+                        opacity:    checked || pressed ? 1 : enabled && hovered ? .2 : 0
+                        radius:     ScreenTools.defaultFontPixelWidth / 2
                     }
 
                     contentItem: RowLayout {
@@ -97,7 +99,7 @@ Rectangle {
 
                         QGCColoredImage {
                             source: iconUrl
-                            color:  checked ? qgcPal.buttonHighlightText : qgcPal.buttonText
+                            color:  checked || pressed ? qgcPal.buttonHighlightText : qgcPal.buttonText
                             width:  ScreenTools.defaultFontPixelHeight
                             height: ScreenTools.defaultFontPixelHeight
                         }
@@ -105,7 +107,7 @@ Rectangle {
                         QGCLabel {
                             Layout.fillWidth:       true
                             text:                   name
-                            color:                  checked ? qgcPal.buttonHighlightText : qgcPal.buttonText
+                            color:                  checked || pressed ? qgcPal.buttonHighlightText : qgcPal.buttonText
                             horizontalAlignment:    QGCLabel.AlignLeft
                         }
                     }

--- a/src/UI/MainRootWindow.qml
+++ b/src/UI/MainRootWindow.qml
@@ -300,7 +300,6 @@ ApplicationWindow {
                             height:             toolSelectDialog._toolButtonHeight
                             Layout.fillWidth:   true
                             text:               qsTr("Vehicle Setup")
-                            imageColor:         qgcPal.text
                             imageResource:      "/qmlimages/Gears.svg"
                             onClicked: {
                                 if (!mainWindow.preventViewSwitch()) {
@@ -316,7 +315,6 @@ ApplicationWindow {
                             Layout.fillWidth:   true
                             text:               qsTr("Analyze Tools")
                             imageResource:      "/qmlimages/Analyze.svg"
-                            imageColor:         qgcPal.text
                             visible:            QGroundControl.corePlugin.showAdvancedUI
                             onClicked: {
                                 if (!mainWindow.preventViewSwitch()) {


### PR DESCRIPTION
## I did 2 things in this PR

1. Slightly highlight buttons on hover
* Before buttons would only change color when pressed or checked, but had no visual response when hovered. Now buttons will will have a faint highlight when hovered and a full highlight when pressed or checked

2. Make button icon colors same as text color
    
    Some of the icons where button color (gray), but i changed that so the icon color would be the same as the text color in the button. This is more similar to Google/Apple button design. It is also better for when the color Palette is overwritten with a different color scheme where button where buttonText and buttonHighlight might not look good when mixed together.
    
## before/after QGCButton

https://github.com/user-attachments/assets/adb727fd-c97c-40c4-8d11-d2b9e669c71a

https://github.com/user-attachments/assets/effd78d4-6973-4d3f-a1ad-ffe9541eeef3

## before/after app settings menu

https://github.com/user-attachments/assets/d8d5c23d-05c9-4be7-bdc7-9f95276c804c

https://github.com/user-attachments/assets/c180b997-cde6-4bd7-8f5a-88e5024c2267

## before/after menu buttons

https://github.com/user-attachments/assets/7b54948b-bd19-458c-8022-c46e29e3d555

https://github.com/user-attachments/assets/5e42e054-6f8a-4882-8218-b330e80b6b97

## icon color change justification
make it more similar to google/apple icon buttons

### google icon buttons
![Screenshot from 2024-09-05 09-50-25](https://github.com/user-attachments/assets/c5bc93f0-156c-4ab3-a215-55d70143fbff)

### apple icon buttons
![Screenshot from 2024-09-05 09-49-05](https://github.com/user-attachments/assets/b0160cd6-f40e-49c7-ac97-f31fc4d3a73d)
