### PR TITLE
Sizing Fixes (buttons, popups, etc)

### DIFF
--- a/src/QmlControls/QGCButton.qml
+++ b/src/QmlControls/QGCButton.qml
@@ -32,7 +32,7 @@ Button {
 
     property bool   _showHighlight:     enabled && (pressed | hovered | checked)
 
-    property int _horizontalPadding:    ScreenTools.defaultFontPixelWidth
+    property int _horizontalPadding:    ScreenTools.defaultFontPixelWidth * 2
     property int _verticalPadding:      Math.round(ScreenTools.defaultFontPixelHeight * heightFactor)
 
     QGCPalette { id: qgcPal; colorGroupEnabled: enabled }

--- a/src/QmlControls/QGCPopupDialog.qml
+++ b/src/QmlControls/QGCPopupDialog.qml
@@ -57,6 +57,8 @@ Popup {
     property var    dialogProperties
     property bool   destroyOnClose:         true
     property bool   preventClose:           false
+    
+    readonly property real headerMinWidth: titleLable.implicitWidth + rejectButton.width + acceptButton.width + titleRowLayout.spacing * 2
 
     signal accepted
     signal rejected
@@ -214,6 +216,7 @@ Popup {
             spacing:                _contentMargin
 
             QGCLabel {
+                id: titleLable
                 Layout.fillWidth:   true
                 text:               root.title
                 font.pointSize:     ScreenTools.mediumFontPointSize
@@ -221,14 +224,16 @@ Popup {
             }
 
             QGCButton {
-                id:         rejectButton
-                onClicked:  _reject()
+                id:                     rejectButton
+                onClicked:              _reject()
+                Layout.preferredWidth:  height * 1.5
             }
 
             QGCButton {
-                id:         acceptButton
-                primary:    true
-                onClicked:  _accept()
+                id:                     acceptButton
+                primary:                true
+                onClicked:              _accept()
+                Layout.preferredWidth:  height * 1.5
             }
         }
 

--- a/src/QmlControls/QGCSimpleMessageDialog.qml
+++ b/src/QmlControls/QGCSimpleMessageDialog.qml
@@ -26,7 +26,7 @@ QGCPopupDialog {
     ColumnLayout {
         QGCLabel {
             id:                     label
-            Layout.maximumWidth:    mainWindow.width / (ScreenTools.isMobile ? 2 : 3)
+            Layout.preferredWidth:  Math.max(mainWindow.width / (ScreenTools.isMobile ? 2 : 3), headerMinWidth)
             wrapMode:               Text.WordWrap
         }
     }

--- a/src/UI/preferences/GeneralSettings.qml
+++ b/src/UI/preferences/GeneralSettings.qml
@@ -97,7 +97,7 @@ SettingsPage {
                 spacing: ScreenTools.defaultFontPixelWidth * 2
 
                 QGCButton {
-                    width:                  height
+                    Layout.preferredWidth:  height
                     height:                 baseFontEdit.height * 1.5
                     text:                   "-"
                     onClicked: {
@@ -114,7 +114,7 @@ SettingsPage {
                 }
 
                 QGCButton {
-                    width:                  height
+                    Layout.preferredWidth:  height
                     height:                 baseFontEdit.height * 1.5
                     text:                   "+"
                     onClicked: {
@@ -188,14 +188,17 @@ SettingsPage {
                 Layout.fillWidth:   true
                 spacing:            0
 
-                QGCLabel { text: qsTr("Indoor Image") }
+                QGCLabel { 
+                    Layout.fillWidth:   true
+                    text:               qsTr("Indoor Image") 
+                }
                 QGCLabel { 
                     Layout.fillWidth:   true
                     font.pointSize:     ScreenTools.smallFontPointSize
                     text:               _userBrandImageIndoor.valueString.replace("file:///", "") 
                     elide:              Text.ElideMiddle
                     visible:            _userBrandImageIndoor.valueString.length > 0
-                    }
+                }
             }
 
             QGCButton {
@@ -221,14 +224,17 @@ SettingsPage {
                 Layout.fillWidth:   true
                 spacing:            0
 
-                QGCLabel { text: qsTr("Outdoor Image") }
+                QGCLabel { 
+                    Layout.fillWidth:   true
+                    text:               qsTr("Outdoor Image") 
+                }
                 QGCLabel { 
                     Layout.fillWidth:   true
                     font.pointSize:     ScreenTools.smallFontPointSize
                     text:               _userBrandImageOutdoor.valueString.replace("file:///", "") 
                     elide:              Text.ElideMiddle
                     visible:            _userBrandImageOutdoor.valueString.length > 0
-                    }
+                }
             }
 
             QGCButton {


### PR DESCRIPTION
# Description
Fixes a couple sizing bugs and makes button sizing/spacing look better

## Sponsor
This contribution was sponsored by [Firestorm](https://www.launchfirestorm.com/)
![654d4f9476ff2a38f37e9ab9_firestorm-homepage-share-img-2](https://github.com/user-attachments/assets/bc1a2c95-b33d-4a2d-af35-4d2d8651d0a2)

## fix 1 - exit confirm popup
![before-exit](https://github.com/user-attachments/assets/8a775ca5-a335-4887-9f79-f96dfcb0f7d2)
![after-exit](https://github.com/user-attachments/assets/8dcfe0fe-bad0-48ba-aa36-68788a996571)

## fix 2 - scaling buttons (also notice new button padding)
![before-scaling](https://github.com/user-attachments/assets/302f1cf7-d9f0-4ad3-811f-63761a84a95a)
![after-scaling](https://github.com/user-attachments/assets/d78ffbde-c24f-4225-bf01-4e28c768951a)

## fix 3 - indoor/outdoor brand image button alignment when no path is selected
![before-brand](https://github.com/user-attachments/assets/eb12ba4c-6e0e-44da-abd9-15bb091c1f3a)
![after-brand](https://github.com/user-attachments/assets/b9fab7a4-1ab8-4151-8e11-b1b1e690b807)

## inspiration for new button padding/sizes - google material design
i gave buttons larger left/right padding and minimum sizes in accordance with the Google material design 2 design doc
![Screenshot from 2024-09-06 16-12-02](https://github.com/user-attachments/assets/02ae240f-28c1-4f28-9436-3af79f874d47)
