### PR TITLE
Button and docs fixes

### DIFF
--- a/src/QmlControls/QGCButton.qml
+++ b/src/QmlControls/QGCButton.qml
@@ -50,6 +50,7 @@ Button {
             anchors.fill:   parent
             color:          qgcPal.buttonHighlight
             opacity:        _showHighlight ? 1 : control.enabled && control.hovered ? .2 : 0
+            radius:         parent.radius
         }
     }
 

--- a/src/QmlControls/QGCPopupDialog.qml
+++ b/src/QmlControls/QGCPopupDialog.qml
@@ -226,14 +226,14 @@ Popup {
             QGCButton {
                 id:                     rejectButton
                 onClicked:              _reject()
-                Layout.preferredWidth:  height * 1.5
+                Layout.minimumWidth:    height * 1.5
             }
 
             QGCButton {
                 id:                     acceptButton
                 primary:                true
                 onClicked:              _accept()
-                Layout.preferredWidth:  height * 1.5
+                Layout.minimumWidth:    height * 1.5
             }
         }
 

--- a/src/VideoManager/VideoReceiver/GStreamer/README.md
+++ b/src/VideoManager/VideoReceiver/GStreamer/README.md
@@ -5,7 +5,7 @@
 For supported platforms, QGroundControl implements an UDP RTP and RSTP video streaming receiver in its Main Flight Display. It uses GStreamer and a stripped down version of QtGstreamer. We've standardized on **GStreamer 1.18.1**. It has been reliable and we will be using it until a good reason to change it surfaces. Newer versions of GStreamer may break the build as some dependent libraries may change.
 To build video streaming support, you will need to install the GStreamer development packages for the desired target platform.
 
-If you do have the proper GStreamer development libraries installed where QGC looks for it, the QGC build system will automatically use it and build video streaming support. If you would like to disable video streaming support, you can add **DISABLE_VIDEOSTREAMING** to the **DEFINES** build variable.
+If you do have the proper GStreamer development libraries installed where QGC looks for it, the QGC build system will automatically use it and build video streaming support. If you would like to disable GStreamer video streaming support, set the **QGC_ENABLE_GST_VIDEOSTREAMING** CMake option to **OFF**.
 
 ### Gstreamer logs
 


### PR DESCRIPTION
# Description
This PR has 3 commits
1. Fixes hover radius
2. Fix size of some buttons
3. Fix outdated disable-GStreamer docs

## Sponsor
This contribution was sponsored by [Firestorm](https://www.launchfirestorm.com/)
![654d4f9476ff2a38f37e9ab9_firestorm-homepage-share-img-2](https://github.com/user-attachments/assets/bc1a2c95-b33d-4a2d-af35-4d2d8651d0a2)

## fix 1 - Button Hover Radius
![before-btn-radius](https://github.com/user-attachments/assets/111ccc65-13a8-4749-a90f-53b78bac95a3)
![after-btn-radius](https://github.com/user-attachments/assets/a040aa11-ea69-4b22-b639-b56e9f5b179d)

## fix 2 - Popup Button Sizes
![before-min-size](https://github.com/user-attachments/assets/ab63224f-8b0b-4499-8e29-8f46c626d255)
![after-min-size](https://github.com/user-attachments/assets/2e1f2a74-d41f-4861-8b2a-1544e351f650)
