### PR TITLE
Settings: Fix Video Decode List for Android

### DIFF
--- a/src/Settings/VideoSettings.cc
+++ b/src/Settings/VideoSettings.cc
@@ -57,19 +57,16 @@ DECLARE_SETTINGGROUP(Video, "Video")
     _nameToMetaDataMap[videoSourceName]->setEnumInfo(videoSourceCookedList, videoSourceList);
 
     const QVariantList removeForceVideoDecodeList{
-#ifdef Q_OS_LINUX
+#if defined(Q_OS_LINUX) && !defined(Q_OS_ANDROID)
         VideoDecoderOptions::ForceVideoDecoderDirectX3D,
         VideoDecoderOptions::ForceVideoDecoderVideoToolbox,
-#endif
-#ifdef Q_OS_WIN
+#elif defined(Q_OS_WIN)
         VideoDecoderOptions::ForceVideoDecoderVAAPI,
         VideoDecoderOptions::ForceVideoDecoderVideoToolbox,
-#endif
-#ifdef Q_OS_MAC
+#elif defined(Q_OS_MAC)
         VideoDecoderOptions::ForceVideoDecoderDirectX3D,
         VideoDecoderOptions::ForceVideoDecoderVAAPI,
-#endif
-#ifdef Q_OS_ANDROID
+#elif defined(Q_OS_ANDROID)
         VideoDecoderOptions::ForceVideoDecoderDirectX3D,
         VideoDecoderOptions::ForceVideoDecoderVideoToolbox,
         VideoDecoderOptions::ForceVideoDecoderVAAPI,


### PR DESCRIPTION
Fixes the following error caused by android also defining Q_OS_LINUX:
W QGroundControl_Daily: Value does not exist in fact: QVariant(int, 5)