### PR TITLE
Fix bug with Popup enter-key handling

### DIFF
--- a/src/QmlControls/QGCPopupDialog.qml
+++ b/src/QmlControls/QGCPopupDialog.qml
@@ -258,7 +258,7 @@ Popup {
                     id:     dialogContentParent
                     focus:  true
 
-                    Keys.onReleased: (event) => {
+                    Keys.onPressed: (event) => {
                         if (event.key === Qt.Key_Escape && rejectAllowed) {
                             _reject()
                             event.accepted = true


### PR DESCRIPTION
# Description

Fix bug with Popup enter-key handling

If the event that triggered a Popup to open was an enter key being pressed, the Popup would immediately close because it would handle the onRelease of the press when it should listen to the onPressed. as with typing, it is expected that key strokes have an affect on press, not on release.

## Sponsor
This contribution was sponsored by [Firestorm](https://www.launchfirestorm.com/)
![654d4f9476ff2a38f37e9ab9_firestorm-homepage-share-img-2](https://github.com/user-attachments/assets/bc1a2c95-b33d-4a2d-af35-4d2d8651d0a2)

## Before (popup that was triggered to open immediately closes)

https://github.com/user-attachments/assets/5bcdae1c-2367-4103-9d6c-c5c7c6a627c1

## After (popup that is meant to be shown is shown until exited)
@

https://github.com/user-attachments/assets/03a290da-a94c-4dac-9521-70f9dcbc9ff6

