### PR TITLE
"Value Display" update

### DIFF
--- a/src/QmlControls/HorizontalFactValueGrid.qml
+++ b/src/QmlControls/HorizontalFactValueGrid.qml
@@ -37,9 +37,10 @@ T.HorizontalFactValueGrid {
 
     ColumnLayout {
         id:         topLayout
-        spacing:    0
+        spacing:    ScreenTools.defaultFontPixelWidth
 
         RowLayout {
+            spacing: parent.spacing
             RowLayout {
                 id:         labelValueColumnLayout
                 spacing:    ScreenTools.defaultFontPixelWidth * 1.25
@@ -110,17 +111,12 @@ T.HorizontalFactValueGrid {
             }
 
             ColumnLayout {
-                Layout.bottomMargin:    1
-                Layout.fillHeight:      true
-                Layout.preferredWidth:  ScreenTools.minTouchPixels / 2
                 spacing:                1
                 visible:                settingsUnlocked
                 enabled:                settingsUnlocked
 
                 QGCButton {
                     Layout.fillHeight:      true
-                    Layout.preferredHeight: ScreenTools.minTouchPixels
-                    Layout.preferredWidth:  parent.width
                     text:                   qsTr("+")
                     enabled:                (_root.width + (2 * (_rowButtonWidth + _margins))) < screen.width
                     onClicked:              appendColumn()
@@ -128,8 +124,6 @@ T.HorizontalFactValueGrid {
 
                 QGCButton {
                     Layout.fillHeight:      true
-                    Layout.preferredHeight: ScreenTools.minTouchPixels
-                    Layout.preferredWidth:  parent.width
                     text:                   qsTr("-")
                     enabled:                _root.columns.count > 1
                     onClicked:              deleteLastColumn()
@@ -138,7 +132,6 @@ T.HorizontalFactValueGrid {
         }
 
         RowLayout {
-            Layout.preferredHeight: ScreenTools.minTouchPixels / 2
             Layout.fillWidth:       true
             spacing:                1
             visible:                settingsUnlocked
@@ -146,7 +139,6 @@ T.HorizontalFactValueGrid {
 
             QGCButton {
                 Layout.fillWidth:       true
-                Layout.preferredHeight: parent.height
                 text:                   qsTr("+")
                 enabled:                (_root.height + (2 * (_rowButtonHeight + _margins))) < (screen.height - ScreenTools.toolbarHeight)
                 onClicked:              appendRow()

--- a/src/QmlControls/InstrumentValueEditDialog.qml
+++ b/src/QmlControls/InstrumentValueEditDialog.qml
@@ -45,173 +45,247 @@ QGCPopupDialog {
     Component {
         id: editorComponent
 
-        GridLayout {
-            rowSpacing:     _margins
-            columnSpacing:  _margins
-            columns:        2
+        SettingsGroupLayout {
+            showBorder: false
 
-            QGCComboBox {
-                id:                     factGroupCombo
+            RowLayout {
                 Layout.fillWidth:       true
-                model:                  instrumentValueData.factGroupNames
-                sizeToContents:         true
-                Component.onCompleted:  currentIndex = find(instrumentValueData.factGroupName)
-                onActivated: (index) => {
-                    instrumentValueData.setFact(currentText, "")
-                    instrumentValueData.icon = ""
-                    instrumentValueData.text = instrumentValueData.fact.shortDescription
+                Layout.minimumWidth:    ScreenTools.defaultFontPixelWidth * 45
+
+                QGCLabel {
+                    Layout.fillWidth:       true
+                    Layout.topMargin:       (factGroupCombo.height - height) / 2
+                    text:                   qsTr("Value") 
                 }
-                Connections {
-                    target: instrumentValueData
-                    onFactGroupNameChanged: factGroupCombo.currentIndex = factGroupCombo.find(instrumentValueData.factGroupName)
+
+                QGCComboBox {
+                    id:                     factGroupCombo
+                    model:                  instrumentValueData.factGroupNames
+                    sizeToContents:         true
+                    Component.onCompleted:  currentIndex = find(instrumentValueData.factGroupName)
+                    onActivated: (index) => {
+                        instrumentValueData.setFact(currentText, "")
+                        instrumentValueData.icon = ""
+                        instrumentValueData.text = instrumentValueData.fact.shortDescription
+                    }
+                    Connections {
+                        target: instrumentValueData
+                        onFactGroupNameChanged: factGroupCombo.currentIndex = factGroupCombo.find(instrumentValueData.factGroupName)
+                    }
+                }
+
+                QGCComboBox {
+                    id:                     factNamesCombo
+                    model:                  instrumentValueData.factValueNames
+                    sizeToContents:         true
+                    Component.onCompleted:  currentIndex = find(instrumentValueData.factName)
+                    onActivated: (index) => {
+                        instrumentValueData.setFact(instrumentValueData.factGroupName, currentText)
+                        instrumentValueData.icon = ""
+                        instrumentValueData.text = instrumentValueData.fact.shortDescription
+                    }
+                    Connections {
+                        target: instrumentValueData
+                        onFactNameChanged: factNamesCombo.currentIndex = factNamesCombo.find(instrumentValueData.factName)
+                    }
                 }
             }
 
-            QGCComboBox {
-                id:                     factNamesCombo
-                Layout.fillWidth:       true
-                model:                  instrumentValueData.factValueNames
-                sizeToContents:         true
-                Component.onCompleted:  currentIndex = find(instrumentValueData.factName)
-                onActivated: (index) => {
-                    instrumentValueData.setFact(instrumentValueData.factGroupName, currentText)
-                    instrumentValueData.icon = ""
-                    instrumentValueData.text = instrumentValueData.fact.shortDescription
+            RowLayout {
+                Layout.fillWidth:   true
+                QGCLabel {
+                    Layout.fillWidth:       true
+                    text:                   qsTr("Label")   
                 }
-                Connections {
-                    target: instrumentValueData
-                    onFactNameChanged: factNamesCombo.currentIndex = factNamesCombo.find(instrumentValueData.factName)
-                }
-            }
+                QGCButton {
+                    id:                     labelVisToggle
 
-            QGCRadioButton {
-                id:                     iconRadio
-                text:                   qsTr("Icon")
-                Component.onCompleted:  checked = instrumentValueData.icon != ""
-                onClicked: {
-                    instrumentValueData.text = ""
-                    instrumentValueData.icon = instrumentValueData.factValueGrid.iconNames[0]
-                    var updateFunction = function(icon){ instrumentValueData.icon = icon }
-                    iconPickerDialog.createObject(mainWindow, { iconNames: instrumentValueData.factValueGrid.iconNames, icon: instrumentValueData.icon, updateIconFunction: updateFunction }).open()
+                    property bool showOptions:  true
+
+                    iconSource:             labelVisToggle.showOptions
+                                                ? "/InstrumentValueIcons/cheveron-down.svg"
+                                                : "/InstrumentValueIcons/cheveron-right.svg"
+                    Layout.preferredWidth:  height
+                    leftPadding:            topPadding
+                    showBorder:             false
+                    backgroundColor:        "transparent"
+                    textColor:              qgcPal.text
+                    onClicked:              labelVisToggle.showOptions = !labelVisToggle.showOptions
                 }
             }
 
-            QGCColoredImage {
-                id:                 valueIcon
-                Layout.alignment:   Qt.AlignHCenter
-                height:             ScreenTools.implicitComboBoxHeight
-                width:              height
-                source:             "/InstrumentValueIcons/" + (instrumentValueData.icon ? instrumentValueData.icon : instrumentValueData.factValueGrid.iconNames[0])
-                sourceSize.height:  height
-                fillMode:           Image.PreserveAspectFit
-                mipmap:             true
-                smooth:             true
-                color:              enabled ? qgcPal.text : qgcPalDisable.text
-                enabled:            iconRadio.checked
-
-                MouseArea {
-                    anchors.fill:   parent
+            RowLayout {
+                visible:            labelVisToggle.showOptions
+                Layout.fillWidth:   true
+                QGCRadioButton {
+                    id:                     iconRadio
+                    text:                   qsTr("Icon")
+                    Layout.leftMargin:      ScreenTools.defaultFontPixelWidth * 4
+                    Layout.fillWidth:       true
+                    Component.onCompleted:  checked = instrumentValueData.icon != ""
                     onClicked: {
-                        var updateFunction = function(icon){ instrumentValueData.icon = icon }
-                        iconPickerDialog.createObject(mainWindow, { iconNames: instrumentValueData.factValueGrid.iconNames, icon: instrumentValueData.icon, updateIconFunction: updateFunction }).open()
+                        instrumentValueData.text = ""
+                        instrumentValueData.icon = instrumentValueData.factValueGrid.iconNames[0]
+                    }
+                    ButtonGroup.group:      labelTypeGroup
+                    ButtonGroup { id: labelTypeGroup }
+                }
+                RowLayout {
+                    id:         iconOptionInputs
+                    Rectangle {
+                        width:      height
+                        height:     changeIconBtn.height
+                        color:      qgcPal.windowShade
+                        opacity:    iconRadio.checked ? 1 : .3
+
+                        QGCColoredImage {
+                            id:                 valueIcon
+                            anchors.centerIn:   parent
+                            height:             ScreenTools.defaultFontPixelHeight
+                            width:              height
+                            source:             "/InstrumentValueIcons/" + (instrumentValueData.icon ? instrumentValueData.icon : instrumentValueData.factValueGrid.iconNames[0])
+                            sourceSize.height:  height
+                            fillMode:           Image.PreserveAspectFit
+                            mipmap:             true
+                            smooth:             true
+                            color:              valueIcon.status === Image.Error ? "red" : qgcPal.text
+                        }
+                    }
+                    QGCButton {
+                        id:         changeIconBtn
+                        text:       qsTr("Change")
+                        enabled:    iconRadio.checked
+                        onClicked: {
+                            var updateFunction = function(icon){ instrumentValueData.icon = icon }
+                            iconPickerDialog.createObject(mainWindow, { iconNames: instrumentValueData.factValueGrid.iconNames, icon: instrumentValueData.icon, updateIconFunction: updateFunction }).open()
+                        }
                     }
                 }
-
-                Rectangle {
-                    anchors.fill:   valueIcon
-                    color:          qgcPal.text
-                    visible:        valueIcon.status === Image.Error
-                }
             }
 
-            QGCRadioButton {
-                id:                     textRadio
-                text:                   qsTr("Text")
-                Component.onCompleted:  checked = instrumentValueData.icon == ""
-                onClicked: {
-                    instrumentValueData.icon = ""
-                    instrumentValueData.text = instrumentValueData.fact ? instrumentValueData.fact.shortDescription : qsTr("Label")
-                }
-            }
-
-            QGCTextField {
-                id:                     labelTextField
-                Layout.fillWidth:       true
-                Layout.preferredWidth:  ScreenTools.defaultFontPixelWidth * 10
-                text:                   instrumentValueData.text
-                enabled:                textRadio.checked
-                onEditingFinished:      instrumentValueData.text = text
-            }
-
-            QGCLabel { text: qsTr("Size") }
-
-            QGCComboBox {
-                id:                 fontSizeCombo
+            RowLayout {
+                visible:            labelVisToggle.showOptions
                 Layout.fillWidth:   true
-                model:              instrumentValueData.factValueGrid.fontSizeNames
-                currentIndex:       instrumentValueData.factValueGrid.fontSize
-                sizeToContents:     true
-                onActivated: (index) => { instrumentValueData.factValueGrid.fontSize = index }
+                QGCRadioButton {
+                    id:                     textRadio
+                    text:                   qsTr("Text")
+                    Layout.fillWidth:       true
+                    Layout.leftMargin:      ScreenTools.defaultFontPixelWidth * 4
+                    ButtonGroup.group:      labelTypeGroup
+                    Component.onCompleted:  checked = instrumentValueData.icon == ""
+                    onClicked: {
+                        instrumentValueData.icon = ""
+                        instrumentValueData.text = instrumentValueData.fact ? instrumentValueData.fact.shortDescription : qsTr("Label")
+                    }
+                }
+                QGCTextField {
+                    enabled:                textRadio.checked
+                    Layout.minimumWidth:    iconOptionInputs.width
+                    text:                   textRadio.checked 
+                                                ? instrumentValueData.text
+                                                : instrumentValueData.fact ? instrumentValueData.fact.shortDescription : qsTr("Label")
+                    onEditingFinished:      instrumentValueData.text = text 
+                }
             }
 
-            QGCCheckBox {
-                Layout.columnSpan:  2
-                text:               qsTr("Show Units")
-                checked:            instrumentValueData.showUnits
-                onClicked:          instrumentValueData.showUnits = checked
-            }
-
-            QGCLabel { text: qsTr("Range") }
-
-            QGCComboBox {
-                id:                 rangeTypeCombo
+            RowLayout {
                 Layout.fillWidth:   true
-                model:              instrumentValueData.rangeTypeNames
-                currentIndex:       instrumentValueData.rangeType
-                sizeToContents:     true
-                onActivated: (index) => { instrumentValueData.rangeType = index }
+                spacing:            ScreenTools.defaultFontPixelWidth * 2
+
+                QGCLabel {
+                    Layout.fillWidth:       true
+                    text:                   qsTr("Size") 
+                }
+
+                QGCComboBox {
+                    id:                 fontSizeCombo
+                    model:              instrumentValueData.factValueGrid.fontSizeNames
+                    currentIndex:       instrumentValueData.factValueGrid.fontSize
+                    sizeToContents:     true
+                    onActivated:        (index) => { instrumentValueData.factValueGrid.fontSize = index }
+                }
             }
 
-            Loader {
-                id:                     rangeLoader
-                Layout.columnSpan:      2
-                Layout.fillWidth:       true
-                Layout.preferredWidth:  item ? item.width : 0
-                Layout.preferredHeight: item ? item.height : 0
+            RowLayout {
+                Layout.fillWidth:   true
+                spacing:            ScreenTools.defaultFontPixelWidth * 2
 
-                property var instrumentValueData: root.instrumentValueData
+                QGCLabel {
+                    Layout.fillWidth:       true
+                    text:                   qsTr("Show Units") 
+                }
 
-                function updateSourceComponent() {
-                    switch (instrumentValueData.rangeType) {
-                    case InstrumentValueData.NoRangeInfo:
-                        sourceComponent = undefined
-                        break
-                    case InstrumentValueData.ColorRange:
-                        sourceComponent = colorRangeDialog
-                        break
-                    case InstrumentValueData.OpacityRange:
-                        sourceComponent = opacityRangeDialog
-                        break
-                    case InstrumentValueData.IconSelectRange:
-                        sourceComponent = iconRangeDialog
-                        break
+                QGCCheckBox {
+                    checked:            instrumentValueData.showUnits
+                    onClicked:          instrumentValueData.showUnits = checked
+                }
+            }
+
+            ColumnLayout {
+                Layout.fillWidth: true
+
+                RowLayout {
+                    Layout.fillWidth:   true
+                    spacing:            ScreenTools.defaultFontPixelWidth * 2
+
+                    QGCLabel {
+                        Layout.fillWidth:       true
+                        text:                   qsTr("Range") 
+                    }
+
+                    QGCComboBox {
+                        id:                 rangeTypeCombo
+                        model:              instrumentValueData.rangeTypeNames
+                        currentIndex:       instrumentValueData.rangeType
+                        sizeToContents:     true
+                        onActivated: (index) => { instrumentValueData.rangeType = index }
                     }
                 }
 
-                Component.onCompleted: {
-                    updateSourceComponent()
-                    if (sourceComponent) {
-                        height = item.childrenRect.height
-                        width = item.childrenRect.width
+                Loader {
+                    id:                     rangeLoader
+                    visible:                sourceComponent
+                    Layout.columnSpan:      2
+                    Layout.alignment:       Qt.AlignHCenter
+                    Layout.margins:         ScreenTools.defaultFontPixelWidth
+                    Layout.preferredWidth:  item ? item.width : 0
+                    Layout.preferredHeight: item ? item.height : 0
+
+                    property var instrumentValueData: root.instrumentValueData
+
+                    function updateSourceComponent() {
+                        switch (instrumentValueData.rangeType) {
+                        case InstrumentValueData.NoRangeInfo:
+                            sourceComponent = undefined
+                            break
+                        case InstrumentValueData.ColorRange:
+                            sourceComponent = colorRangeDialog
+                            break
+                        case InstrumentValueData.OpacityRange:
+                            sourceComponent = opacityRangeDialog
+                            break
+                        case InstrumentValueData.IconSelectRange:
+                            sourceComponent = iconRangeDialog
+                            break
+                        }
                     }
-                }
 
-                Connections {
-                    target:             instrumentValueData
-                    onRangeTypeChanged: rangeLoader.updateSourceComponent()
-                }
+                    Component.onCompleted: {
+                        updateSourceComponent()
+                        if (sourceComponent) {
+                            height = item.childrenRect.height
+                            width = item.childrenRect.width
+                        }
+                    }
 
+                    Connections {
+                        target:             instrumentValueData
+                        onRangeTypeChanged: rangeLoader.updateSourceComponent()
+                    }
+
+                }
             }
+
         }
     }
 

--- a/src/QmlControls/QGCButton.qml
+++ b/src/QmlControls/QGCButton.qml
@@ -29,6 +29,8 @@ Button {
 
     property alias wrapMode:            text.wrapMode
     property alias horizontalAlignment: text.horizontalAlignment
+    property alias backgroundColor:     backRect.color
+    property alias textColor:           text.color
 
     property bool   _showHighlight:     enabled && (pressed | checked)
 

--- a/src/QmlControls/QGCRadioButton.qml
+++ b/src/QmlControls/QGCRadioButton.qml
@@ -42,7 +42,7 @@ RadioButton {
         color:              control.textColor
         opacity:            enabled ? 1.0 : 0.3
         verticalAlignment:  Text.AlignVCenter
-        leftPadding:        control.indicator.width + (_noText ? 0 : ScreenTools.defaultFontPixelWidth * 0.25)
+        leftPadding:        control.indicator.width + (_noText ? 0 : control.leftPadding)
     }
 
 }

--- a/src/QmlControls/SettingsGroupLayout.qml
+++ b/src/QmlControls/SettingsGroupLayout.qml
@@ -18,6 +18,7 @@ ColumnLayout {
     property string heading
     property string headingDescription
     property bool   showDividers:       true
+    property bool   showBorder:         true
 
     property real _margins: ScreenTools.defaultFontPixelHeight / 2
 
@@ -45,20 +46,20 @@ ColumnLayout {
     Rectangle {
         id:                 outerRect
         Layout.fillWidth:   true
-        implicitWidth:      _contentLayout.implicitWidth + (_margins * 2)
-        implicitHeight:     _contentLayout.implicitHeight + (_margins * 2)
+        implicitWidth:      _contentLayout.implicitWidth + (showBorder ? _margins * 2 : 0)
+        implicitHeight:     _contentLayout.implicitHeight + (showBorder ? _margins * 2: 0)
         color:              "transparent"
         border.color:       QGroundControl.globalPalette.groupBorder
-        border.width:       1
+        border.width:       showBorder ? 1 : 0
         radius:             ScreenTools.defaultFontPixelHeight / 2
 
         Repeater {
             model: showDividers? _contentLayout.children.length : 0
 
             Rectangle {
-                x:                  _margins
-                y:                  _contentItem.y + _contentItem.height + _margins + _margins
-                width:              parent.width - (_margins * 2)
+                x:                  showBorder ? _margins : 0
+                y:                  _contentItem.y + _contentItem.height + _margins + (showBorder ? _margins : 0)
+                width:              parent.width - (showBorder ? _margins * 2 : 0)
                 height:             1
                 color:              QGroundControl.globalPalette.groupBorder
                 visible:            _contentItem.visible && 
@@ -71,9 +72,9 @@ ColumnLayout {
  
         ColumnLayout {
             id:                 _contentLayout
-            x:                  _margins
-            y:                  _margins
-            width:              parent.width - (_margins * 2)
+            x:                  showBorder ? _margins : 0
+            y:                  showBorder ? _margins : 0
+            width:              parent.width - (showBorder ? _margins * 2 : 0)
             spacing:            _margins * 2
         }
     }


### PR DESCRIPTION
# Description
This PR has 2 commits
1. Fix button sizes in TelemetryValuesBar
    * In QGC 4.4.2 these buttons look fine, but in the master branch they were super squashed looking
2. Organize "Value Display" so it is more scannable
    * Now it is organized with keys on the left and values/inputs on the right, making the form more intuitive and scannable for first time users.
    * The design of the form is now more similar to other parts of QGC, namely the views seen in "Application Settings"

## Sponsor
This contribution was sponsored by [Firestorm](https://www.launchfirestorm.com/)
![654d4f9476ff2a38f37e9ab9_firestorm-homepage-share-img-2](https://github.com/user-attachments/assets/bc1a2c95-b33d-4a2d-af35-4d2d8651d0a2)

## Before

https://github.com/user-attachments/assets/92304f65-fdee-4206-aab8-cc6e3ed7a0cc

## After

https://github.com/user-attachments/assets/52c2dd33-761a-4f0a-8083-f2ba0afa5228


