### PR TITLE
Settings: Fix Video Grid Lines

### DIFF
--- a/src/FlightDisplay/FlightDisplayViewVideo.qml
+++ b/src/FlightDisplay/FlightDisplayViewVideo.qml
@@ -27,7 +27,7 @@ Item {
     property bool useSmallFont: true
 
     property double _ar:                QGroundControl.videoManager.aspectRatio
-    property bool   _showGrid:          QGroundControl.settingsManager.videoSettings.gridLines.rawValue > 0
+    property bool   _showGrid:          QGroundControl.settingsManager.videoSettings.gridLines.rawValue
     property var    _dynamicCameras:    globals.activeVehicle ? globals.activeVehicle.cameraManager : null
     property bool   _connected:         globals.activeVehicle ? !globals.activeVehicle.communicationLost : false
     property int    _curCameraIndex:    _dynamicCameras ? _dynamicCameras.currentCamera : 0

--- a/src/Settings/Video.SettingsGroup.json
+++ b/src/Settings/Video.SettingsGroup.json
@@ -48,13 +48,11 @@
     "default":     1.777777
 },
 {
-    "name":             "gridLines",
-    "shortDesc": "Video Grid Lines",
-    "longDesc":  "Displays a grid overlaid over the video view.",
-    "type":             "uint32",
-    "enumStrings":      "Hide,Show",
-    "enumValues":       "1,0",
-    "default":     0
+    "name":         "gridLines",
+    "shortDesc":    "Video Grid Lines",
+    "longDesc":     "Displays a grid overlaid over the video view.",
+    "type":         "bool",
+    "default":      false
 },
 {
     "name":             "videoFit",


### PR DESCRIPTION
The enum values were opposite of how it was used in the code (hide is 1 but 1 enables gridlines). So just switch to a standard bool