### PR TITLE
QtLocationPlugin: Minor Miscellaneous Improvements

### DIFF
--- a/src/QtLocationPlugin/QGCCachedTileSet.cpp
+++ b/src/QtLocationPlugin/QGCCachedTileSet.cpp
@@ -34,8 +34,6 @@
 
 QGC_LOGGING_CATEGORY(QGCCachedTileSetLog, "qgc.qtlocation.qgccachedtileset")
 
-#define TILE_BATCH_SIZE 256
-
 QGCCachedTileSet::QGCCachedTileSet(const QString &name, QObject *parent)
     : QObject(parent)
     , _name(name)
@@ -69,7 +67,7 @@ void QGCCachedTileSet::createDownloadTask()
         _noMoreTiles = false;
     }
 
-    QGCGetTileDownloadListTask* const task = new QGCGetTileDownloadListTask(_id, TILE_BATCH_SIZE);
+    QGCGetTileDownloadListTask* const task = new QGCGetTileDownloadListTask(_id, kTileBatchSize);
     (void) connect(task, &QGCGetTileDownloadListTask::tileListFetched, this, &QGCCachedTileSet::_tileListFetched);
     if (_manager) {
         (void) connect(task, &QGCMapTask::error, _manager, &QGCMapEngineManager::taskError);
@@ -92,7 +90,7 @@ void QGCCachedTileSet::resumeDownloadTask()
 void QGCCachedTileSet::_tileListFetched(const QQueue<QGCTile*> &tiles)
 {
     _batchRequested = false;
-    if (tiles.size() < TILE_BATCH_SIZE) {
+    if (tiles.size() < kTileBatchSize) {
         _noMoreTiles = true;
     }
 
@@ -103,7 +101,7 @@ void QGCCachedTileSet::_tileListFetched(const QQueue<QGCTile*> &tiles)
 
     if (!_networkManager) {
         _networkManager = new QNetworkAccessManager(this);
-#ifndef __mobile__
+#if !defined(Q_OS_IOS) && !defined(Q_OS_ANDROID)
         QNetworkProxy proxy = _networkManager->proxy();
         proxy.setType(QNetworkProxy::DefaultProxy);
         _networkManager->setProxy(proxy);

--- a/src/QtLocationPlugin/QGCCachedTileSet.h
+++ b/src/QtLocationPlugin/QGCCachedTileSet.h
@@ -190,4 +190,6 @@ private:
     QQueue<QGCTile*> _tilesToDownload;
     QGCMapEngineManager *_manager = nullptr;
     QNetworkAccessManager *_networkManager = nullptr;
+
+    static constexpr uint32_t kTileBatchSize = 256;
 };

--- a/src/QtLocationPlugin/QGCMapEngine.cpp
+++ b/src/QtLocationPlugin/QGCMapEngine.cpp
@@ -15,6 +15,7 @@
  *   @author Gus Grubba <gus@auterion.com>
  *
  */
+
 #include "QGCMapEngine.h"
 #include "QGCCachedTileSet.h"
 #include "QGCTileCacheWorker.h"
@@ -23,29 +24,19 @@
 #include "QGCTileSet.h"
 #include "QGCTile.h"
 #include "QGCCacheTile.h"
-#include "QGCApplication.h"
 #include <QGCLoggingCategory.h>
 
 #include <QtCore/qapplicationstatic.h>
-#include <QtCore/QStandardPaths>
-#include <QtCore/QDir>
-
-#define CACHE_PATH_VERSION "300"
 
 QGC_LOGGING_CATEGORY(QGCMapEngineLog, "qgc.qtlocationplugin.qgcmapengine")
 
 Q_DECLARE_METATYPE(QList<QGCTile*>)
 
-Q_APPLICATION_STATIC(QGCMapEngine, s_mapEngine);
+Q_APPLICATION_STATIC(QGCMapEngine, _mapEngine);
 
-QGCMapEngine* getQGCMapEngine()
+QGCMapEngine *getQGCMapEngine()
 {
     return QGCMapEngine::instance();
-}
-
-QGCMapEngine* QGCMapEngine::instance()
-{
-    return s_mapEngine();
 }
 
 QGCMapEngine::QGCMapEngine(QObject *parent)
@@ -54,11 +45,11 @@ QGCMapEngine::QGCMapEngine(QObject *parent)
 {
     // qCDebug(QGCMapEngineLog) << Q_FUNC_INFO << this;
 
-    (void) qRegisterMetaType<QGCMapTask::TaskType>();
-    (void) qRegisterMetaType<QGCTile>();
-    (void) qRegisterMetaType<QList<QGCTile*>>();
-    (void) qRegisterMetaType<QGCTileSet>();
-    (void) qRegisterMetaType<QGCCacheTile>();
+    (void) qRegisterMetaType<QGCMapTask::TaskType>("TaskType");
+    (void) qRegisterMetaType<QGCTile>("QGCTile");
+    (void) qRegisterMetaType<QList<QGCTile*>>("QList<QGCTile*>");
+    (void) qRegisterMetaType<QGCTileSet>("QGCTileSet");
+    (void) qRegisterMetaType<QGCCacheTile>("QGCCacheTile");
 
     (void) connect(m_worker, &QGCCacheWorker::updateTotals, this, &QGCMapEngine::_updateTotals);
 }
@@ -72,91 +63,22 @@ QGCMapEngine::~QGCMapEngine()
     // qCDebug(QGCMapEngineLog) << Q_FUNC_INFO << this;
 }
 
-void QGCMapEngine::init()
+QGCMapEngine *QGCMapEngine::instance()
 {
-    _wipeOldCaches();
+    return _mapEngine();
+}
 
-    // QString cacheDir = QAbstractGeoTileCache::baseCacheDirectory()
-#ifdef __mobile__
-    QString cacheDir = QStandardPaths::writableLocation(QStandardPaths::AppDataLocation);
-#else
-    QString cacheDir = QStandardPaths::writableLocation(QStandardPaths::GenericCacheLocation);
-#endif
-    cacheDir += QStringLiteral("/QGCMapCache" CACHE_PATH_VERSION);
-    if (!QDir::root().mkpath(cacheDir)) {
-        qCWarning(QGCMapEngineLog) << "Could not create mapping disk cache directory:" << cacheDir;
-
-        cacheDir = QDir::homePath() + QStringLiteral("/.qgcmapscache/");
-        if (!QDir::root().mkpath(cacheDir)) {
-            qCWarning(QGCMapEngineLog) << "Could not create mapping disk cache directory:" << cacheDir;
-            cacheDir.clear();
-        }
-    }
-
-    m_cachePath = cacheDir;
-    if (!m_cachePath.isEmpty()) {
-        const QString databaseFilePath(m_cachePath + "/" + QGeoFileTileCacheQGC::getCacheFilename());
-        m_worker->setDatabaseFile(databaseFilePath);
-
-        qCDebug(QGCMapEngineLog) << "Map Cache in:" << databaseFilePath;
-    } else {
-        qCCritical(QGCMapEngineLog) << "Could not find suitable map cache directory.";
-    }
+void QGCMapEngine::init(const QString &databasePath)
+{
+    m_worker->setDatabaseFile(databasePath);
 
     QGCMapTask* const task = new QGCMapTask(QGCMapTask::taskInit);
     (void) addTask(task);
-
-    if (m_cacheWasReset) {
-        qgcApp()->showAppMessage(tr(
-            "The Offline Map Cache database has been upgraded. "
-            "Your old map cache sets have been reset."));
-    }
 }
 
 bool QGCMapEngine::addTask(QGCMapTask *task)
 {
     return m_worker->enqueueTask(task);
-}
-
-bool QGCMapEngine::_wipeDirectory(const QString &dirPath)
-{
-    bool result = true;
-
-    const QDir dir(dirPath);
-    if (dir.exists(dirPath)) {
-        m_cacheWasReset = true;
-
-        const QFileInfoList fileList = dir.entryInfoList(QDir::NoDotAndDotDot | QDir::System | QDir::Hidden | QDir::AllDirs | QDir::Files, QDir::DirsFirst);
-        for (const QFileInfo &info : fileList) {
-            if (info.isDir()) {
-                result = _wipeDirectory(info.absoluteFilePath());
-            } else {
-                result = QFile::remove(info.absoluteFilePath());
-            }
-
-            if (!result) {
-                return result;
-            }
-        }
-        result = dir.rmdir(dirPath);
-    }
-
-    return result;
-}
-
-void QGCMapEngine::_wipeOldCaches()
-{
-    const QStringList oldCaches = {"/QGCMapCache55", "/QGCMapCache100"};
-    for (const QString &cache : oldCaches) {
-        QString oldCacheDir;
-        #ifdef __mobile__
-            oldCacheDir = QStandardPaths::writableLocation(QStandardPaths::AppDataLocation);
-        #else
-            oldCacheDir = QStandardPaths::writableLocation(QStandardPaths::GenericCacheLocation);
-        #endif
-        oldCacheDir += cache;
-        _wipeDirectory(oldCacheDir);
-    }
 }
 
 void QGCMapEngine::_updateTotals(quint32 totaltiles, quint64 totalsize, quint32 defaulttiles, quint64 defaultsize)

--- a/src/QtLocationPlugin/QGCMapEngine.h
+++ b/src/QtLocationPlugin/QGCMapEngine.h
@@ -35,12 +35,10 @@ public:
     QGCMapEngine(QObject *parent = nullptr);
     ~QGCMapEngine();
 
-    void init();
+    void init(const QString &databasePath);
     bool addTask(QGCMapTask *task);
 
-    QString getCachePath() const { return m_cachePath; }
-
-    static QGCMapEngine* instance();
+    static QGCMapEngine *instance();
 
 signals:
     void updateTotals(quint32 totaltiles, quint64 totalsize, quint32 defaulttiles, quint64 defaultsize);
@@ -50,13 +48,8 @@ private slots:
     void _pruned() { m_prunning = false; }
 
 private:
-    bool _wipeDirectory(const QString &dirPath);
-    void _wipeOldCaches();
-
     QGCCacheWorker *m_worker = nullptr;
     bool m_prunning = false;
-    bool m_cacheWasReset = false;
-    QString m_cachePath;
 };
 
-QGCMapEngine* getQGCMapEngine();
+extern QGCMapEngine *getQGCMapEngine();

--- a/src/QtLocationPlugin/QGeoFileTileCacheQGC.cpp
+++ b/src/QtLocationPlugin/QGeoFileTileCacheQGC.cpp
@@ -23,8 +23,12 @@
 
 QGC_LOGGING_CATEGORY(QGeoFileTileCacheQGCLog, "qgc.qtlocationplugin.qgeofiletilecacheqgc")
 
+QString QGeoFileTileCacheQGC::_databaseFilePath;
+QString QGeoFileTileCacheQGC::_cachePath;
+bool QGeoFileTileCacheQGC::_cacheWasReset = false;
+
 QGeoFileTileCacheQGC::QGeoFileTileCacheQGC(const QVariantMap &parameters, QObject *parent)
-    : QGeoFileTileCache(_getCachePath(parameters), parent)
+    : QGeoFileTileCache(baseCacheDirectory(), parent)
 {
     // qCDebug(QGeoFileTileCacheQGCLog) << Q_FUNC_INFO << this;
 
@@ -35,38 +39,22 @@ QGeoFileTileCacheQGC::QGeoFileTileCacheQGC(const QVariantMap &parameters, QObjec
     setCostStrategyTexture(QGeoFileTileCache::ByteSize);
     setMinTextureUsage(_getDefaultMinTexture());
     setExtraTextureUsage(_getDefaultExtraTexture() - minTextureUsage());
+
+    static std::once_flag cacheInit;
+    std::call_once(cacheInit, [this]() {
+        _initCache();
+    });
+
+    directory_ = _getCachePath(parameters);
 }
 
 QGeoFileTileCacheQGC::~QGeoFileTileCacheQGC()
 {
+#ifdef QT_DEBUG
     // printStats();
+#endif
 
     // qCDebug(QGeoFileTileCacheQGCLog) << Q_FUNC_INFO << this;
-}
-
-QString QGeoFileTileCacheQGC::_getCachePath(const QVariantMap &parameters)
-{
-    QString cacheDir;
-    if (parameters.contains(QStringLiteral("mapping.cache.directory"))) {
-        cacheDir = parameters.value(QStringLiteral("mapping.cache.directory")).toString();
-    } else {
-        cacheDir = getQGCMapEngine()->getCachePath() + QLatin1String("/providers");
-        if (!QFileInfo::exists(cacheDir)) {
-            if (!QDir::root().mkpath(cacheDir)) {
-                qCWarning(QGeoFileTileCacheQGCLog) << "Could not create mapping disk cache directory:" << cacheDir;
-                cacheDir = QDir::homePath() + QStringLiteral("/.qgcmapscache/");
-            }
-        }
-    }
-
-    if (!QFileInfo::exists(cacheDir)) {
-        if (!QDir::root().mkpath(cacheDir)) {
-            qCWarning(QGeoFileTileCacheQGCLog) << "Could not create mapping disk cache directory:" << cacheDir;
-            cacheDir.clear();
-        }
-    }
-
-    return cacheDir;
 }
 
 uint32_t QGeoFileTileCacheQGC::_getMemLimit(const QVariantMap &parameters)
@@ -130,4 +118,107 @@ QGCFetchTileTask* QGeoFileTileCacheQGC::createFetchTileTask(const QString &type,
     const QString hash = UrlFactory::getTileHash(type, x, y, z);
     QGCFetchTileTask* const task = new QGCFetchTileTask(hash);
     return task;
+}
+
+QString QGeoFileTileCacheQGC::_getCachePath(const QVariantMap &parameters)
+{
+    QString cacheDir;
+    if (parameters.contains(QStringLiteral("mapping.cache.directory"))) {
+        cacheDir = parameters.value(QStringLiteral("mapping.cache.directory")).toString();
+    } else {
+        cacheDir = _cachePath + QLatin1String("/providers");
+        if (!QFileInfo::exists(cacheDir)) {
+            if (!QDir::root().mkpath(cacheDir)) {
+                qCWarning(QGeoFileTileCacheQGCLog) << "Could not create mapping disk cache directory:" << cacheDir;
+                cacheDir = QDir::homePath() + QStringLiteral("/.qgcmapscache/");
+            }
+        }
+    }
+
+    if (!QFileInfo::exists(cacheDir)) {
+        if (!QDir::root().mkpath(cacheDir)) {
+            qCWarning(QGeoFileTileCacheQGCLog) << "Could not create mapping disk cache directory:" << cacheDir;
+            cacheDir.clear();
+        }
+    }
+
+    return cacheDir;
+}
+
+bool QGeoFileTileCacheQGC::_wipeDirectory(const QString &dirPath)
+{
+    bool result = true;
+
+    const QDir dir(dirPath);
+    if (dir.exists(dirPath)) {
+        _cacheWasReset = true;
+
+        const QFileInfoList fileList = dir.entryInfoList(QDir::NoDotAndDotDot | QDir::System | QDir::Hidden | QDir::AllDirs | QDir::Files, QDir::DirsFirst);
+        for (const QFileInfo &info : fileList) {
+            if (info.isDir()) {
+                result = _wipeDirectory(info.absoluteFilePath());
+            } else {
+                result = QFile::remove(info.absoluteFilePath());
+            }
+
+            if (!result) {
+                return result;
+            }
+        }
+        result = dir.rmdir(dirPath);
+    }
+
+    return result;
+}
+
+void QGeoFileTileCacheQGC::_wipeOldCaches()
+{
+    const QStringList oldCaches = {"/QGCMapCache55", "/QGCMapCache100"};
+    for (const QString &cache : oldCaches) {
+        QString oldCacheDir;
+        #if defined(Q_OS_ANDROID) || defined(Q_OS_IOS)
+            oldCacheDir = QStandardPaths::writableLocation(QStandardPaths::AppDataLocation);
+        #else
+            oldCacheDir = QStandardPaths::writableLocation(QStandardPaths::GenericCacheLocation);
+        #endif
+        oldCacheDir += cache;
+        _wipeDirectory(oldCacheDir);
+    }
+}
+
+void QGeoFileTileCacheQGC::_initCache()
+{
+    _wipeOldCaches();
+
+    // QString cacheDir = QAbstractGeoTileCache::baseCacheDirectory()
+#if defined(Q_OS_ANDROID) || defined(Q_OS_IOS)
+    QString cacheDir = QStandardPaths::writableLocation(QStandardPaths::AppDataLocation);
+#else
+    QString cacheDir = QStandardPaths::writableLocation(QStandardPaths::GenericCacheLocation);
+#endif
+    cacheDir += QStringLiteral("/QGCMapCache") + QString(kCachePathVersion);
+    if (!QDir::root().mkpath(cacheDir)) {
+        qCWarning(QGeoFileTileCacheQGCLog) << "Could not create mapping disk cache directory:" << cacheDir;
+
+        cacheDir = QDir::homePath() + QStringLiteral("/.qgcmapscache/");
+        if (!QDir::root().mkpath(cacheDir)) {
+            qCWarning(QGeoFileTileCacheQGCLog) << "Could not create mapping disk cache directory:" << cacheDir;
+            cacheDir.clear();
+        }
+    }
+
+    _cachePath = cacheDir;
+    if (!_cachePath.isEmpty()) {
+        _databaseFilePath = QString(_cachePath + QStringLiteral("/qgcMapCache.db"));
+
+        qCDebug(QGeoFileTileCacheQGCLog) << "Map Cache in:" << _databaseFilePath;
+    } else {
+        qCCritical(QGeoFileTileCacheQGCLog) << "Could not find suitable map cache directory.";
+    }
+
+    if (_cacheWasReset) {
+        qgcApp()->showAppMessage(tr(
+            "The Offline Map Cache database has been upgraded. "
+            "Your old map cache sets have been reset."));
+    }
 }

--- a/src/QtLocationPlugin/QGeoFileTileCacheQGC.h
+++ b/src/QtLocationPlugin/QGeoFileTileCacheQGC.h
@@ -27,20 +27,31 @@ public:
     static quint32 getMaxDiskCacheSetting();
     static void cacheTile(const QString &type, int x, int y, int z, const QByteArray &image, const QString &format, qulonglong set = UINT64_MAX);
     static void cacheTile(const QString &type, const QString &hash, const QByteArray &image, const QString &format, qulonglong set = UINT64_MAX);
-    static QGCFetchTileTask* createFetchTileTask (const QString &type, int x, int y, int z);
-    static QString getCacheFilename() { return QStringLiteral("qgcMapCache.db"); }
+    static QGCFetchTileTask *createFetchTileTask(const QString &type, int x, int y, int z);
+    static QString getDatabaseFilePath() { return _databaseFilePath; }
+    static QString getCachePath() { return _cachePath; }
 
 private:
     // QString tileSpecToFilename(const QGeoTileSpec &spec, const QString &format, const QString &directory) const final;
     // QGeoTileSpec filenameToTileSpec(const QString &filename) const final;
 
+    static void _initCache();
+    static bool _wipeDirectory(const QString &dirPath);
+    static void _wipeOldCaches();
+
     static QString _getCachePath(const QVariantMap &parameters);
     static uint32_t _getMemLimit(const QVariantMap &Parameters);
 
     static uint32_t _getDefaultMaxMemLimit() { return (3 * pow(1024, 2)); }
-    static uint32_t _getDefaultMaxDiskCache() { return 0; /*(50 * pow(1024, 2));*/ }
+    static uint32_t _getDefaultMaxDiskCache() { return 0; } // (50 * pow(1024, 2));
     static uint32_t _getDefaultExtraTexture() { return (6 * pow(1024, 2)); }
     static uint32_t _getDefaultMinTexture() { return 0; }
 
     static quint32 _getMaxMemCacheSetting();
+
+    static QString _databaseFilePath;
+    static QString _cachePath;
+    static bool _cacheWasReset;
+
+    static constexpr const char *kCachePathVersion = "300";
 };

--- a/src/QtLocationPlugin/QGeoMapReplyQGC.cpp
+++ b/src/QtLocationPlugin/QGeoMapReplyQGC.cpp
@@ -79,7 +79,7 @@ void QGeoTiledMapReplyQGC::_networkReplyFinished()
 {
     QNetworkReply* const reply = qobject_cast<QNetworkReply*>(sender());
     if (!reply) {
-        setError(QGeoTiledMapReply::UnknownError, QStringLiteral("Unexpected Error"));
+        setError(QGeoTiledMapReply::UnknownError, tr("Unexpected Error"));
         return;
     }
     reply->deleteLater();
@@ -89,7 +89,7 @@ void QGeoTiledMapReplyQGC::_networkReplyFinished()
     }
 
     if (!reply->isOpen()) {
-        setError(QGeoTiledMapReply::ParseError, QStringLiteral("Empty Reply"));
+        setError(QGeoTiledMapReply::ParseError, tr("Empty Reply"));
         return;
     }
 
@@ -101,7 +101,7 @@ void QGeoTiledMapReplyQGC::_networkReplyFinished()
 
     QByteArray image = reply->readAll();
     if (image.isEmpty()) {
-        setError(QGeoTiledMapReply::ParseError, QStringLiteral("Image is Empty"));
+        setError(QGeoTiledMapReply::ParseError, tr("Image is Empty"));
         return;
     }
 
@@ -109,7 +109,7 @@ void QGeoTiledMapReplyQGC::_networkReplyFinished()
     Q_CHECK_PTR(mapProvider);
 
     if (mapProvider->isBingProvider() && (image == _bingNoTileImage)) {
-        setError(QGeoTiledMapReply::CommunicationError, QStringLiteral("Bing Tile Above Zoom Level"));
+        setError(QGeoTiledMapReply::CommunicationError, tr("Bing Tile Above Zoom Level"));
         return;
     }
 
@@ -117,7 +117,7 @@ void QGeoTiledMapReplyQGC::_networkReplyFinished()
         const SharedElevationProvider elevationProvider = std::dynamic_pointer_cast<const ElevationProvider>(mapProvider);
         image = elevationProvider->serialize(image);
         if (image.isEmpty()) {
-            setError(QGeoTiledMapReply::ParseError, QStringLiteral("Failed to Serialize Terrain Tile"));
+            setError(QGeoTiledMapReply::ParseError, tr("Failed to Serialize Terrain Tile"));
             return;
         }
     }
@@ -125,7 +125,7 @@ void QGeoTiledMapReplyQGC::_networkReplyFinished()
 
     const QString format = mapProvider->getImageFormat(image);
     if (format.isEmpty()) {
-        setError(QGeoTiledMapReply::ParseError, QStringLiteral("Unknown Format"));
+        setError(QGeoTiledMapReply::ParseError, tr("Unknown Format"));
         return;
     }
     setMapImageFormat(format);
@@ -140,7 +140,7 @@ void QGeoTiledMapReplyQGC::_networkReplyError(QNetworkReply::NetworkError error)
     if (error != QNetworkReply::OperationCanceledError) {
         const QNetworkReply* const reply = qobject_cast<const QNetworkReply*>(sender());
         if (!reply) {
-            setError(QGeoTiledMapReply::CommunicationError, QStringLiteral("Invalid Reply"));
+            setError(QGeoTiledMapReply::CommunicationError, tr("Invalid Reply"));
         } else {
             setError(QGeoTiledMapReply::CommunicationError, reply->errorString());
         }
@@ -149,7 +149,6 @@ void QGeoTiledMapReplyQGC::_networkReplyError(QNetworkReply::NetworkError error)
     }
 }
 
-#if QT_CONFIG(ssl)
 void QGeoTiledMapReplyQGC::_networkReplySslErrors(const QList<QSslError> &errors)
 {
     QString errorString;
@@ -164,7 +163,6 @@ void QGeoTiledMapReplyQGC::_networkReplySslErrors(const QList<QSslError> &errors
         setError(QGeoTiledMapReply::CommunicationError, errorString);
     }
 }
-#endif
 
 void QGeoTiledMapReplyQGC::_cacheReply(QGCCacheTile *tile)
 {
@@ -175,7 +173,7 @@ void QGeoTiledMapReplyQGC::_cacheReply(QGCCacheTile *tile)
         setFinished(true);
         delete tile;
     } else {
-        setError(QGeoTiledMapReply::UnknownError, QStringLiteral("Invalid Cache Tile"));
+        setError(QGeoTiledMapReply::UnknownError, tr("Invalid Cache Tile"));
     }
 }
 
@@ -186,7 +184,7 @@ void QGeoTiledMapReplyQGC::_cacheError(QGCMapTask::TaskType type, QStringView er
     Q_ASSERT(type == QGCMapTask::taskFetchTile);
 
     if (!QGCDeviceInfo::isInternetAvailable()) {
-        setError(QGeoTiledMapReply::CommunicationError, QStringLiteral("Network Not Available"));
+        setError(QGeoTiledMapReply::CommunicationError, tr("Network Not Available"));
         return;
     }
 
@@ -198,9 +196,7 @@ void QGeoTiledMapReplyQGC::_cacheError(QGCMapTask::TaskType type, QStringView er
 
     (void) connect(reply, &QNetworkReply::finished, this, &QGeoTiledMapReplyQGC::_networkReplyFinished);
     (void) connect(reply, &QNetworkReply::errorOccurred, this, &QGeoTiledMapReplyQGC::_networkReplyError);
-#if QT_CONFIG(ssl)
     (void) connect(reply, &QNetworkReply::sslErrors, this, &QGeoTiledMapReplyQGC::_networkReplySslErrors);
-#endif
     (void) connect(this, &QGeoTiledMapReplyQGC::aborted, reply, &QNetworkReply::abort);
 }
 

--- a/src/QtLocationPlugin/QGeoMapReplyQGC.h
+++ b/src/QtLocationPlugin/QGeoMapReplyQGC.h
@@ -34,9 +34,7 @@ public:
 private slots:
     void _networkReplyFinished();
     void _networkReplyError(QNetworkReply::NetworkError error);
-#if QT_CONFIG(ssl)
     void _networkReplySslErrors(const QList<QSslError> &errors);
-#endif
     void _cacheReply(QGCCacheTile *tile);
     void _cacheError(QGCMapTask::TaskType type, QStringView errorString);
 

--- a/src/QtLocationPlugin/QGeoServiceProviderPluginQGC.cpp
+++ b/src/QtLocationPlugin/QGeoServiceProviderPluginQGC.cpp
@@ -11,6 +11,8 @@
 #include "QGeoTiledMappingManagerEngineQGC.h"
 #include <QGCLoggingCategory.h>
 
+#include <QtQml/QQmlEngine>
+
 QGC_LOGGING_CATEGORY(QGeoServiceProviderFactoryQGCLog, "qgc.qtlocationplugin.qgeoserviceproviderfactoryqgc")
 
 QGeoServiceProviderFactoryQGC::QGeoServiceProviderFactoryQGC(QObject *parent)
@@ -24,7 +26,7 @@ QGeoServiceProviderFactoryQGC::~QGeoServiceProviderFactoryQGC()
     qCDebug(QGeoServiceProviderFactoryQGCLog) << Q_FUNC_INFO << this;
 }
 
-QGeoCodingManagerEngine* QGeoServiceProviderFactoryQGC::createGeocodingManagerEngine(
+QGeoCodingManagerEngine *QGeoServiceProviderFactoryQGC::createGeocodingManagerEngine(
    const QVariantMap &parameters, QGeoServiceProvider::Error *error, QString *errorString) const
 {
     Q_UNUSED(parameters);
@@ -34,10 +36,11 @@ QGeoCodingManagerEngine* QGeoServiceProviderFactoryQGC::createGeocodingManagerEn
     if (errorString) {
         *errorString = "Geocoding Not Supported";
     }
+
     return nullptr;
 }
 
-QGeoMappingManagerEngine* QGeoServiceProviderFactoryQGC::createMappingManagerEngine(
+QGeoMappingManagerEngine *QGeoServiceProviderFactoryQGC::createMappingManagerEngine(
    const QVariantMap &parameters, QGeoServiceProvider::Error *error, QString *errorString) const
 {
     if (error) {
@@ -46,11 +49,16 @@ QGeoMappingManagerEngine* QGeoServiceProviderFactoryQGC::createMappingManagerEng
     if (errorString) {
         *errorString = "";
     }
-    // TODO: m_engine->networkAccessManager();
-    return new QGeoTiledMappingManagerEngineQGC(parameters, error, errorString);
+
+    QNetworkAccessManager *networkManager = nullptr;
+    if (m_engine) {
+        networkManager = m_engine->networkAccessManager();
+    }
+
+    return new QGeoTiledMappingManagerEngineQGC(parameters, error, errorString, networkManager, nullptr);
 }
 
-QGeoRoutingManagerEngine* QGeoServiceProviderFactoryQGC::createRoutingManagerEngine(
+QGeoRoutingManagerEngine *QGeoServiceProviderFactoryQGC::createRoutingManagerEngine(
    const QVariantMap &parameters, QGeoServiceProvider::Error *error, QString *errorString) const
 {
     Q_UNUSED(parameters);
@@ -60,10 +68,11 @@ QGeoRoutingManagerEngine* QGeoServiceProviderFactoryQGC::createRoutingManagerEng
     if (errorString) {
         *errorString = "Routing Not Supported";
     }
+
     return nullptr;
 }
 
-QPlaceManagerEngine* QGeoServiceProviderFactoryQGC::createPlaceManagerEngine(
+QPlaceManagerEngine *QGeoServiceProviderFactoryQGC::createPlaceManagerEngine(
    const QVariantMap &parameters, QGeoServiceProvider::Error *error, QString *errorString) const
 {
     Q_UNUSED(parameters);
@@ -73,5 +82,6 @@ QPlaceManagerEngine* QGeoServiceProviderFactoryQGC::createPlaceManagerEngine(
     if (errorString) {
         *errorString = "Place Not Supported";
     }
+
     return nullptr;
 }

--- a/src/QtLocationPlugin/QGeoServiceProviderPluginQGC.h
+++ b/src/QtLocationPlugin/QGeoServiceProviderPluginQGC.h
@@ -34,5 +34,5 @@ public:
     void setQmlEngine(QQmlEngine* engine) final { m_engine = engine; }
 
 private:
-    QQmlEngine* m_engine = nullptr;
+    QQmlEngine *m_engine = nullptr;
 };

--- a/src/QtLocationPlugin/QGeoTileFetcherQGC.cpp
+++ b/src/QtLocationPlugin/QGeoTileFetcherQGC.cpp
@@ -14,8 +14,6 @@
 #include "MapProvider.h"
 #include <QGCLoggingCategory.h>
 
-// #include <QtNetwork/QNetworkDiskCache>
-#include <QtNetwork/QNetworkProxy>
 #include <QtNetwork/QNetworkRequest>
 #include <QtLocation/private/qgeotiledmappingmanagerengine_p.h>
 #include <QtLocation/private/qgeotilespec_p.h>
@@ -25,7 +23,6 @@ QGC_LOGGING_CATEGORY(QGeoTileFetcherQGCLog, "qgc.qtlocationplugin.qgeotilefetche
 QGeoTileFetcherQGC::QGeoTileFetcherQGC(QNetworkAccessManager *networkManager, const QVariantMap &parameters, QGeoTiledMappingManagerEngineQGC *parent)
     : QGeoTileFetcher(parent)
     , m_networkManager(networkManager)
-    // , m_diskCache(new QNetworkDiskCache(this))
 {
     Q_CHECK_PTR(networkManager);
 
@@ -35,18 +32,6 @@ QGeoTileFetcherQGC::QGeoTileFetcherQGC(QNetworkAccessManager *networkManager, co
     /*if (parameters.contains(QStringLiteral("useragent"))) {
         setUserAgent(parameters.value(QStringLiteral("useragent")).toString().toLatin1());
     }*/
-
-#ifndef __mobile__
-    QNetworkProxy proxy = m_networkManager->proxy();
-    proxy.setType(QNetworkProxy::DefaultProxy);
-    m_networkManager->setProxy(proxy);
-#endif
-
-    /*m_networkManager->setTransferTimeout(10000);
-    m_networkManager->setAutoDeleteReplies(true);
-    m_diskCache->setCacheDirectory(directory() + "/Downloads");
-    m_diskCache->setMaximumCacheSize(static_cast<qint64>(_getDefaultMaxDiskCache()));
-    m_networkManager->setCache(m_diskCache);*/
 }
 
 QGeoTileFetcherQGC::~QGeoTileFetcherQGC()

--- a/src/QtLocationPlugin/QGeoTileFetcherQGC.h
+++ b/src/QtLocationPlugin/QGeoTileFetcherQGC.h
@@ -19,7 +19,6 @@ class QGeoTiledMappingManagerEngineQGC;
 class QGeoTiledMapReplyQGC;
 class QGeoTileSpec;
 class QNetworkAccessManager;
-class QNetworkDiskCache;
 
 class QGeoTileFetcherQGC : public QGeoTileFetcher
 {
@@ -42,7 +41,6 @@ private:
     void handleReply(QGeoTiledMapReply *reply, const QGeoTileSpec &spec) final;
 
     QNetworkAccessManager *m_networkManager = nullptr;
-    // QNetworkDiskCache *m_diskCache = nullptr;
 
 #if defined Q_OS_MAC
     static constexpr const char* s_userAgent = "Mozilla/5.0 (Macintosh; Intel Mac OS X 14.5; rv:125.0) Gecko/20100101 Firefox/125.0";

--- a/src/QtLocationPlugin/QGeoTiledMapQGC.cpp
+++ b/src/QtLocationPlugin/QGeoTiledMapQGC.cpp
@@ -27,7 +27,6 @@ QGeoTiledMapQGC::~QGeoTiledMapQGC()
 QGeoMap::Capabilities QGeoTiledMapQGC::capabilities() const
 {
     return Capabilities(SupportsVisibleRegion
-                        | SupportsSetBearing
                         | SupportsAnchoringCoordinate
                         | SupportsVisibleArea);
 }

--- a/src/QtLocationPlugin/QGeoTiledMappingManagerEngineQGC.cpp
+++ b/src/QtLocationPlugin/QGeoTiledMappingManagerEngineQGC.cpp
@@ -20,25 +20,23 @@
 
 #include <QtCore/QDir>
 #include <QtNetwork/QNetworkAccessManager>
+#include <QtNetwork/QNetworkDiskCache>
+#include <QtNetwork/QNetworkProxy>
 #include <QtLocation/private/qgeocameracapabilities_p.h>
 #include <QtLocation/private/qgeomaptype_p.h>
 #include <QtLocation/private/qgeotiledmap_p.h>
 #include <QtLocation/private/qgeofiletilecache_p.h>
 
-#define TILE_VERSION 1
-
 QGC_LOGGING_CATEGORY(QGeoTiledMappingManagerEngineQGCLog, "qgc.qtlocationplugin.qgeotiledmappingmanagerengineqgc")
 
-QGeoTiledMappingManagerEngineQGC::QGeoTiledMappingManagerEngineQGC(const QVariantMap &parameters, QGeoServiceProvider::Error *error, QString *errorString, QObject *parent)
+QGeoTiledMappingManagerEngineQGC::QGeoTiledMappingManagerEngineQGC(const QVariantMap &parameters, QGeoServiceProvider::Error *error, QString *errorString, QNetworkAccessManager *networkManager, QObject *parent)
     : QGeoTiledMappingManagerEngine(parent)
-    , m_networkManager(new QNetworkAccessManager(this))
+    , m_networkManager(networkManager)
 {
     // qCDebug(QGeoTiledMappingManagerEngineQGCLog) << Q_FUNC_INFO << this;
 
     // TODO: Better way to get current language without qgcApp()?
     setLocale(qgcApp()->getCurrentLanguage());
-
-    getQGCMapEngine()->init();
 
     QGeoCameraCapabilities cameraCaps;
     cameraCaps.setTileSize(256);
@@ -54,7 +52,7 @@ QGeoTiledMappingManagerEngineQGC::QGeoTiledMappingManagerEngineQGC(const QVarian
     cameraCaps.setOverzoomEnabled(true);
     setCameraCapabilities(cameraCaps);
 
-    setTileVersion(TILE_VERSION);
+    setTileVersion(kTileVersion);
     setTileSize(QSize(256, 256));
 
     QList<QGeoMapType> mapList;
@@ -78,13 +76,35 @@ QGeoTiledMappingManagerEngineQGC::QGeoTiledMappingManagerEngineQGC(const QVarian
     QGeoFileTileCacheQGC* const fileTileCache = new QGeoFileTileCacheQGC(parameters);
     setTileCache(fileTileCache);
 
+    // MapEngine must be init after fileTileCache
+    static std::once_flag mapEngineInit;
+    std::call_once(mapEngineInit, [fileTileCache]() {
+        getQGCMapEngine()->init(fileTileCache->getDatabaseFilePath());
+    });
+
     m_prefetchStyle = QGeoTiledMap::PrefetchTwoNeighbourLayers;
+
+    if (!m_networkManager) {
+        m_networkManager = new QNetworkAccessManager(this);
+        #if !defined(Q_OS_ANDROID) && !defined(Q_OS_IOS)
+            QNetworkProxy proxy = m_networkManager->proxy();
+            proxy.setType(QNetworkProxy::DefaultProxy);
+            m_networkManager->setProxy(proxy);
+        #endif
+        m_networkManager->setTransferTimeout(10000);
+        // m_networkManager->setAutoDeleteReplies(true);
+        QNetworkDiskCache *const diskCache = new QNetworkDiskCache(this);
+        diskCache->setCacheDirectory(fileTileCache->getCachePath() + "/Downloads");
+        const qint64 maxCacheSize = (50 * pow(1024, 2)); // fileTileCache->getMaxDiskCache()
+        diskCache->setMaximumCacheSize(maxCacheSize);
+        m_networkManager->setCache(diskCache);
+    }
+
+    QGeoTileFetcherQGC* const tileFetcher = new QGeoTileFetcherQGC(m_networkManager, parameters, this);
 
     *error = QGeoServiceProvider::NoError;
     errorString->clear();
-
-    QGeoTileFetcherQGC* const tileFetcher = new QGeoTileFetcherQGC(m_networkManager, parameters, this);
-    setTileFetcher(tileFetcher); // Calls engineInitialized
+    setTileFetcher(tileFetcher); // Calls engineInitialized()
 }
 
 QGeoTiledMappingManagerEngineQGC::~QGeoTiledMappingManagerEngineQGC()
@@ -92,7 +112,7 @@ QGeoTiledMappingManagerEngineQGC::~QGeoTiledMappingManagerEngineQGC()
     // qCDebug(QGeoTiledMappingManagerEngineQGCLog) << Q_FUNC_INFO << this;
 }
 
-QGeoMap* QGeoTiledMappingManagerEngineQGC::createMap()
+QGeoMap *QGeoTiledMappingManagerEngineQGC::createMap()
 {
     QGeoTiledMapQGC* const map = new QGeoTiledMapQGC(this, this);
     map->setPrefetchStyle(m_prefetchStyle);

--- a/src/QtLocationPlugin/QGeoTiledMappingManagerEngineQGC.h
+++ b/src/QtLocationPlugin/QGeoTiledMappingManagerEngineQGC.h
@@ -22,7 +22,7 @@ class QGeoTiledMappingManagerEngineQGC : public QGeoTiledMappingManagerEngine
     Q_OBJECT
 
 public:
-    QGeoTiledMappingManagerEngineQGC(const QVariantMap &parameters, QGeoServiceProvider::Error *error, QString *errorString, QObject *parent = nullptr);
+    QGeoTiledMappingManagerEngineQGC(const QVariantMap &parameters, QGeoServiceProvider::Error *error, QString *errorString, QNetworkAccessManager *networkManager = nullptr, QObject *parent = nullptr);
     ~QGeoTiledMappingManagerEngineQGC();
 
     QGeoMap* createMap() final;
@@ -30,4 +30,6 @@ public:
 
 private:
     QNetworkAccessManager *m_networkManager = nullptr;
+
+    static constexpr int kTileVersion = 1;
 };

--- a/src/QtLocationPlugin/QMLControl/QGCMapEngineManager.h
+++ b/src/QtLocationPlugin/QMLControl/QGCMapEngineManager.h
@@ -43,8 +43,6 @@ class QGCMapEngineManager : public QObject
     Q_PROPERTY(QString              tileSizeStr     READ tileSizeStr                                NOTIFY tileSizeChanged)
     Q_PROPERTY(QStringList          mapList         READ mapList                                    CONSTANT)
     Q_PROPERTY(QStringList          mapProviderList READ mapProviderList                            CONSTANT)
-    Q_PROPERTY(quint32              diskSpace       READ diskSpace)
-    Q_PROPERTY(quint32              freeDiskSpace   READ freeDiskSpace                              NOTIFY freeDiskSpaceChanged)
     Q_PROPERTY(quint64              tileCount       READ tileCount                                  NOTIFY tileCountChanged)
     Q_PROPERTY(quint64              tileSize        READ tileSize                                   NOTIFY tileSizeChanged)
 
@@ -85,14 +83,11 @@ public:
     QString errorMessage() const { return _errorMessage; }
     QString tileCountStr() const;
     QString tileSizeStr() const;
-    quint64 diskSpace() const { return _diskSpace; }
-    quint64 freeDiskSpace() const { return _freeDiskSpace; }
     quint64 tileCount() const { return (_imageSet.tileCount + _elevationSet.tileCount); }
     quint64 tileSize() const { return (_imageSet.tileSize + _elevationSet.tileSize); }
 
     void setActionProgress(int percentage) { if (percentage != _actionProgress) { _actionProgress = percentage; emit actionProgressChanged(); } }
     void setErrorMessage(const QString &error) { if (error != _errorMessage) { _errorMessage = error; emit errorMessageChanged(); } }
-    void setFreeDiskSpace(quint64 diskSpace) { if (diskSpace != _freeDiskSpace) { _freeDiskSpace = diskSpace; emit freeDiskSpaceChanged(); } }
     void setImportAction(ImportAction action) { if (action != _importAction) { _importAction = action; emit importActionChanged(); } }
 
     static QStringList mapList();
@@ -123,8 +118,6 @@ private slots:
     void _updateTotals(quint32 totaltiles, quint64 totalsize, quint32 defaulttiles, quint64 defaultsize);
 
 private:
-    void _updateDiskFreeSpace(); 
-
     QmlObjectListModel *_tileSets = nullptr;
     QGCTileSet _imageSet;
     QGCTileSet _elevationSet;
@@ -137,8 +130,6 @@ private:
     int _maxZoom = 0;
     int _actionProgress = 0;
     quint64 _setID = UINT64_MAX;
-    quint32 _freeDiskSpace = 0;
-    quint32 _diskSpace = 0;
     QString _errorMessage;
     bool _fetchElevation = true;
     bool _importReplace = false;


### PR DESCRIPTION
- Move remaining file caching related stuff to QGeoFileTileCacheQGC to prep converting QGCMapEngine to a better threadWorker handler for  QGCCacheWorker
- Reduce total count of QNetworkAccessManager's, which each create a new thread per instance
- Translate output errors
- Network caching