### PR TITLE
CI: Dont Sign Android Windows For Now

### DIFF
--- a/.github/workflows/android-windows.yml
+++ b/.github/workflows/android-windows.yml
@@ -81,7 +81,7 @@ jobs:
               -DQT_ANDROID_ABIS="${{ env.QT_ANDROID_ABIS }}"
               -DQT_ANDROID_BUILD_ALL_ABIS=OFF
               -DQT_HOST_PATH="${{ env.QT_ROOT_DIR }}/../msvc2019_64"
-              -DQT_ANDROID_SIGN_APK=${{ github.ref == 'refs/heads/master' && github.event_name != 'pull_request' && 'ON' || 'OFF' }}
+              -DQT_ANDROID_SIGN_APK=OFF
               -DQT_DEBUG_FIND_PACKAGE=ON
               -DQGC_STABLE_BUILD=${{ github.ref_type == 'tag' || contains(github.ref, 'Stable') && 'ON' || 'OFF' }}
 


### PR DESCRIPTION
There is some issue, probably related to windows vs unix text encoding, that is causing the signing key to be incorrect. Doesn't matter in this case as we are not uploading these builds.