### PR TITLE
Use icon for terrain button instead of "T"

### DIFF
--- a/custom-example/qgcresources.qrc
+++ b/custom-example/qgcresources.qrc
@@ -45,6 +45,7 @@
 		<file alias="SplashScreen">../resources/SplashScreen.png</file>
 		<file alias="Stop">../resources/Stop.svg</file>
 		<file alias="takeoff.svg">../resources/takeoff.svg</file>
+        <file alias="terrain.svg">resources/terrain.svg</file>
 		<file alias="TrashDelete.svg">../resources/TrashDelete.svg</file>
 		<file alias="waves.svg">../resources/waves.svg</file>
 		<file alias="wind-guru.svg">../resources/wind-guru.svg</file>

--- a/qgcresources.qrc
+++ b/qgcresources.qrc
@@ -46,6 +46,7 @@
         <file alias="SplashScreen">resources/SplashScreen.png</file>
         <file alias="Stop">resources/Stop.svg</file>
         <file alias="takeoff.svg">resources/takeoff.svg</file>
+        <file alias="terrain.svg">resources/terrain.svg</file>
         <file alias="TrashDelete.svg">resources/TrashDelete.svg</file>
         <file alias="waves.svg">resources/waves.svg</file>
         <file alias="wind-guru.svg">resources/wind-guru.svg</file>

--- a/resources/terrain.svg
+++ b/resources/terrain.svg
@@ -1,0 +1,7 @@
+<svg class="svg-icon" style="width:1em;height:1em;vertical-align:middle;fill:currentColor;overflow:hidden" viewBox="0 0 1024 1024" xmlns="http://www.w3.org/2000/svg">
+  <path d="M801.646 386.303 620.16 492.523l-160.854-92.587-169.167 99.49 1.387-95.636 167.78-97.72 160.854 93.866 144.237-79.886s32.313-13.941 49.07 16.36c17.698 32-11.82 49.893-11.82 49.893z" transform="translate(-389.162 -203.608) scale(1.33524)" style="overflow:hidden"/>
+  <path d="m804.456 1448.24-.568-254.312 173.903-99.92 160.853 93.867 329.434-191.645 105.608 106.748.018 345.707" transform="translate(-1076.45 -905.611) scale(1.33524)" style="overflow:hidden"/>
+  <g>
+    <path transform="rotate(15.073 554.968 2503.56) scale(.74528)" d="M448 64 223 317l81 179L496 16 15.88 208 195 289z"/>
+  </g>
+</svg>

--- a/src/FlightMap/MapScale.qml
+++ b/src/FlightMap/MapScale.qml
@@ -190,7 +190,8 @@ Item {
         anchors.bottom:     rightEnd.bottom
         anchors.leftMargin: buttonsOnLeft ? 0 : ScreenTools.defaultFontPixelWidth / 2
         anchors.left:       buttonsOnLeft ? parent.left : rightEnd.right
-        text:               qsTr("T")
+        leftPadding:        topPadding
+        iconSource:         "/res/terrain.svg"
         width:              height
         opacity:            0.75
         visible:            terrainButtonVisible


### PR DESCRIPTION
# Description

Makes so the button used to expand/collapse the terrain panel has an icon instead of the letter "T"

## Sponsor
This contribution was sponsored by [Firestorm](https://www.launchfirestorm.com/)
![654d4f9476ff2a38f37e9ab9_firestorm-homepage-share-img-2](https://github.com/user-attachments/assets/bc1a2c95-b33d-4a2d-af35-4d2d8651d0a2)

# Before
![before-closed](https://github.com/user-attachments/assets/abe554b9-be4e-4f32-ba65-bfe3829357c2)
![before-expanded](https://github.com/user-attachments/assets/fdeb4444-cf70-420e-8c01-303b98f4bc52)

# After
![after-closed](https://github.com/user-attachments/assets/92e4c65f-5257-49e8-bda2-3725558c9dd0)
![after-expanded](https://github.com/user-attachments/assets/9000496c-6118-4ee9-8ceb-087878997bc6)
