### PR TITLE
Fix terrain chart colors

### DIFF
--- a/src/PlanView/TerrainStatus.qml
+++ b/src/PlanView/TerrainStatus.qml
@@ -79,9 +79,9 @@ Rectangle {
                     lineVisible:                true
                     labelsFont.family:          ScreenTools.fixedFontFamily
                     labelsFont.pointSize:       ScreenTools.smallFontPointSize
-                    labelsColor:                "white"
+                    labelsColor:                qgcPal.text
                     tickCount:                  5
-                    gridLineColor:              "#44FFFFFF"
+                    gridLineColor:              applyOpacity(qgcPal.text, 0.25)
                 }
 
                 ValueAxis {
@@ -91,9 +91,9 @@ Rectangle {
                     lineVisible:                true
                     labelsFont.family:          ScreenTools.fixedFontFamily
                     labelsFont.pointSize:       ScreenTools.smallFontPointSize
-                    labelsColor:                "white"
+                    labelsColor:                qgcPal.text
                     tickCount:                  4
-                    gridLineColor:              "#44FFFFFF"
+                    gridLineColor:              applyOpacity(qgcPal.text, 0.25)
                 }
 
                 LineSeries {
@@ -127,7 +127,7 @@ Rectangle {
                             id:         simpleItem
                             height:     terrainProfile.height
                             width:      1
-                            color:      "white"
+                            color:      qgcPal.text
                             x:          (object.distanceFromStart * terrainProfile.pixelsPerMeter)
                             visible:    object.isSimpleItem || object.isSingleItem
 
@@ -146,7 +146,7 @@ Rectangle {
                             id:         complexItemEntry
                             height:     terrainProfile.height
                             width:      1
-                            color:      "white"
+                            color:      qgcPal.text
                             x:          (object.distanceFromStart * terrainProfile.pixelsPerMeter)
                             visible:    complexItem.visible
 
@@ -164,7 +164,7 @@ Rectangle {
                             id:         complexItemExit
                             height:     terrainProfile.height
                             width:      1
-                            color:      "white"
+                            color:      qgcPal.text
                             x:          ((object.distanceFromStart + object.complexDistance) * terrainProfile.pixelsPerMeter)
                             visible:    complexItem.visible
 
@@ -203,5 +203,9 @@ Rectangle {
                 }
             }
         }
+    }
+
+    function applyOpacity(colorIn, opacity){
+        return Qt.rgba(colorIn.r, colorIn.g, colorIn.b, opacity)
     }
 }


### PR DESCRIPTION
# Description

When the theme was set to outdoor mode, the terrain chart's lines/labels weren't ledgible colors. This fixes that

## Sponsor
This contribution was sponsored by [Firestorm](https://www.launchfirestorm.com/)
![654d4f9476ff2a38f37e9ab9_firestorm-homepage-share-img-2](https://github.com/user-attachments/assets/bc1a2c95-b33d-4a2d-af35-4d2d8651d0a2)

# Before
![before-terrain-light](https://github.com/user-attachments/assets/ae6f2570-5ac9-4f27-a392-b676b99d0eca)


# After
![after-terrain-light](https://github.com/user-attachments/assets/810ef1da-fcb4-46fe-9062-052b7278436d)

## Note, the indoor view didn't change much at all, but here is a before and after to show it din't get messed up
### Before
![before-terrain-dark](https://github.com/user-attachments/assets/e15374fc-6ed4-44cc-b8e5-7bfb120e69b2)
### After
![after-terrain-dark](https://github.com/user-attachments/assets/abe8d9e3-a745-46f3-be2f-cc585d53dc64)
