### PR TITLE
CI: Create Continuous Prerelease

### DIFF
--- a/.github/actions/upload/action.yml
+++ b/.github/actions/upload/action.yml
@@ -43,3 +43,11 @@ runs:
       working-directory: ${{ runner.temp }}/shadow_build_dir/${{ inputs.source }}
       run: aws s3 cp ${{ inputs.artifact_name }} s3://qgroundcontrol/latest/${{ inputs.artifact_name }} --acl public-read
       shell: bash
+
+    - name: Create Continuous Release
+      if: ${{ github.event_name != 'pull_request' && github.ref_name == 'master' && !github.event.pull_request.head.repo.fork }}
+      uses: softprops/action-gh-release@v2
+      with:
+        prerelease: true
+        files: |
+          ${{ runner.temp }}/shadow_build_dir/${{ inputs.source }}/${{ inputs.artifact_name }}


### PR DESCRIPTION
This should upload commits to master to a continuous release making it easy for people to download daily builds