### PR TITLE
Fix Translations Import Path

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -282,10 +282,10 @@ qt_add_executable(${PROJECT_NAME}
 if(Qt6LinguistTools_FOUND)
     # TODO: Update to new qt_add_translations form in Qt6.7
     file(GLOB TS_SOURCES ${CMAKE_SOURCE_DIR}/translations/qgc_*.ts)
-    set_source_files_properties(${TS_SOURCES} PROPERTIES OUTPUT_LOCATION "${CMAKE_BINARY_DIR}/translations")
+    set_source_files_properties(${TS_SOURCES} PROPERTIES OUTPUT_LOCATION "${CMAKE_BINARY_DIR}/i18n")
     qt_add_translations(${PROJECT_NAME}
         TS_FILES ${TS_SOURCES}
-        RESOURCE_PREFIX "/i18n"
+        RESOURCE_PREFIX "/"
         LUPDATE_OPTIONS -no-obsolete
     )
 endif()


### PR DESCRIPTION
# Description
This recent PR seems to have broken translation file imports. 
https://github.com/mavlink/qgroundcontrol/pull/11912
I'm just reverting it back to what it was before.

## Sponsor
This contribution was sponsored by [Firestorm](https://www.launchfirestorm.com/)
![654d4f9476ff2a38f37e9ab9_firestorm-homepage-share-img-2](https://github.com/user-attachments/assets/bc1a2c95-b33d-4a2d-af35-4d2d8651d0a2)

## Before (bug I'm fixing)
![before-trans](https://github.com/user-attachments/assets/ccbe0b53-b3fd-4497-bbbc-325f59502caa)

## After (this is a revert back to the way it was a few days ago)
![after-trans](https://github.com/user-attachments/assets/c32d0035-738d-4446-afc2-cf30011287d5)
