### PR TITLE
FactMetaData: Trim enum strings of leading/tailing whitespace

### DIFF
--- a/src/FactSystem/FactMetaData.cc
+++ b/src/FactSystem/FactMetaData.cc
@@ -1464,10 +1464,16 @@ bool FactMetaData::_parseEnum(const QJsonObject& jsonObject, DefineMap_t defineM
     QString jsonStrings = jsonObject.value(_enumStringsJsonKey).toString();
     QString defineMapStrings = defineMap.value(jsonStrings, jsonStrings);
     rgDescriptions = defineMapStrings.split(",", Qt::SkipEmptyParts);
+    for (auto& desc: rgDescriptions) {
+        desc = desc.trimmed();
+    }
 
     QString jsonValues = jsonObject.value(_enumValuesJsonKey).toString();
     QString defineMapValues = defineMap.value(jsonValues, jsonValues);
     rgValues = defineMapValues.split(",", Qt::SkipEmptyParts);
+    for (auto& value: rgValues) {
+        value = value.trimmed();
+    }
 
     if (rgDescriptions.count() != rgValues.count()) {
         errorString = QStringLiteral("Enum strings/values count mismatch - strings: '%1'[%2,%3] values: '%4'[%5,%6]").arg(defineMapStrings).arg(rgDescriptions.count()).arg(defineMapStrings.contains(",")).arg(defineMapValues).arg(rgValues.count()).arg(defineMapValues.contains(","));

--- a/src/QmlControls/InstrumentValueEditDialog.qml
+++ b/src/QmlControls/InstrumentValueEditDialog.qml
@@ -55,10 +55,10 @@ QGCPopupDialog {
                     heading: qsTr("Telemetry")
 
                     LabelledComboBox {
-                        id:             factGroupCombo
-                        label:          qsTr("Group")
-                        model:          instrumentValueData.factGroupNames
-                        currentIndex:   comboBox.find(instrumentValueData.factGroupName)
+                        id:                     factGroupCombo
+                        label:                  qsTr("Group")
+                        model:                  instrumentValueData.factGroupNames
+                        Component.onCompleted:  currentIndex = comboBox.find(instrumentValueData.factGroupName)
                         onActivated: (index) => {
                             instrumentValueData.setFact(currentText, "")
                             instrumentValueData.icon = ""
@@ -74,7 +74,7 @@ QGCPopupDialog {
                         id:                     factNamesCombo
                         label:                  qsTr("Value")
                         model:                  instrumentValueData.factValueNames
-                        currentIndex:           comboBox.find(instrumentValueData.factName)
+                        Component.onCompleted:  currentIndex = comboBox.find(instrumentValueData.factName)
                         onActivated: (index) => {
                             instrumentValueData.setFact(instrumentValueData.factGroupName, currentText)
                             instrumentValueData.icon = ""


### PR DESCRIPTION
`enumStrings` and `enumValues` are not supposed to have leading/trailing whitespace on individual values. They should look like this `"foo,bar,baz"`. But when these are translated in Crowdin, translators have a tendency to change them to `"foo, bar, baz"` which leads the incorrect/bad ui. To prevent this they are now stripped of leading/trailing whitespace when the json is loaded.