### PR TITLE
CMake: Find all packages in root CMakeLists.txt

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -177,7 +177,10 @@ find_package(Qt6
         Xml
     OPTIONAL_COMPONENTS
         LinguistTools
+        MultimediaQuickPrivate
+        Quick3D
         SerialPort
+        WaylandClient
     HINTS
         ${QT_LIBRARY_HINTS}
 )

--- a/src/VideoManager/VideoReceiver/QtMultimedia/CMakeLists.txt
+++ b/src/VideoManager/VideoReceiver/QtMultimedia/CMakeLists.txt
@@ -2,7 +2,7 @@ find_package(Qt6 REQUIRED COMPONENTS Core)
 
 qt_add_library(QtMultimediaReceiver STATIC)
 
-option(QGC_ENABLE_QT_VIDEOSTREAMING "Enable QtMultimedia Video Streaming Backend" ON)
+option(QGC_ENABLE_QT_VIDEOSTREAMING "Enable QtMultimedia Video Streaming Backend" OFF)
 cmake_print_variables(QGC_ENABLE_QT_VIDEOSTREAMING)
 if(NOT QGC_ENABLE_QT_VIDEOSTREAMING)
     return()


### PR DESCRIPTION
Apparently there is an occasional issue for some catching all dependencies if you don't find them all in the root cmakelists. Also, disable QtMultimedia receiver backend by default until it is stable.