### PR TITLE
Fixing channel issue with ELRS Mavlink-rc: number of channels is not set by default

### DIFF
--- a/src/AutoPilotPlugins/Common/RadioComponentController.cc
+++ b/src/AutoPilotPlugins/Common/RadioComponentController.cc
@@ -180,6 +180,16 @@ void RadioComponentController::_setupCurrentState(void)
 /// Connected to Vehicle::rcChannelsChanged signal
 void RadioComponentController::_rcChannelsChanged(int channelCount, int pwmValues[QGCMAVLink::maxRcChannels])
 {
+    // Below is a hack that's needed by ELRS
+    // ELRS is not sending a full RC_CHANNELS packet, only channel update
+    // packets via RC_CHANNELS_RAW, to update the position of the values.
+    // Therefore, the number of channels is not set.
+    if (channelCount == 0) {
+        for (int channel=0; channel<16; channel++) {
+            if (pwmValues[channel] != INT16_MAX) channelCount++;
+        }
+    }
+
     for (int channel=0; channel<channelCount; channel++) {
         int channelValue = pwmValues[channel];
 

--- a/src/Vehicle/Vehicle.cc
+++ b/src/Vehicle/Vehicle.cc
@@ -1452,6 +1452,16 @@ void Vehicle::_handleRCChannels(mavlink_message_t& message)
     };
     int pwmValues[QGCMAVLink::maxRcChannels];
 
+    // Below is a hack that's needed by ELRS
+    // ELRS is not sending a full RC_CHANNELS packet, only channel update
+    // packets via RC_CHANNELS_RAW, to update the position of the values.
+    // Therefore, the number of channels is not set.
+    if (channels.chancount == 0) {
+        for(const auto& channelValue : _rgChannelvalues) {
+            if (*channelValue != UINT16_MAX) channels.chancount++;
+        }
+    }
+
     for (int i=0; i<QGCMAVLink::maxRcChannels; i++) {
         uint16_t channelValue = *_rgChannelvalues[i];
 


### PR DESCRIPTION
## Description 

If you are using ELRS MAVLINK setup as per: https://www.expresslrs.org/software/mavlink/ then the number of channels will never be set. Hence it will remain 0 -- even though there is clearly control data going through. This is because ELRS is not sending a full `RC_CHANNELS` packet, only channel update packets via `RC_CHANNELS_RAW`, to update the position of the values. Therefore, the number of channels is not set.

This ELRS system forwards BOTH the RC and the Mavlink on the same ELRS link. Using one TX and one RX, you get to have both Mavlink and RC. The Mavlink is forwarded via the backpack chip in the TX to the wifi. You can then connect to this wifi and QGC picks it up automatically, via zero-conf (I think! Very cool) and "just works". Which is great. But the RC doesn't SEEM to work, because the number of channels is never set.

TL;DR: `RC_CHANNELS` is never sent, only `RC_CHANNELS_RAW`, so `chancount` is never set.

## Test Steps

* Using RX ELRS 3.5.0 (release version, not experimental)
* Using TX ELRS 3.5.0 (release version, not experimental)
* Using TX ELRS Backpack 1.5.0 (release version, not experimental)
* Using SpeedyBee F405 Wing (full, not mini) board, Serial 1 connected to ELRS receiver, set up as per: https://www.expresslrs.org/software/mavlink/

We get connectivity of Mavlink forwarded via ELRS + backpack in the TX via WiFi, however, the radio channels cannot be calibrated, and it cannot arm, because the number of channels is seen as 0. With this fix, calibration works and the craft can be armed.

## How to Reproduce
Connect as per above. Observe that calibration is not possible, the QGC says there is no controller connected.

Checklist:
----------
- [x] [Review Contribution Guidelines](https://github.com/mavlink/qgroundcontrol/blob/master/.github/CONTRIBUTING.md).
- [x] [Review Code of Conduct](https://github.com/mavlink/qgroundcontrol/blob/master/.github/CODE_OF_CONDUCT.md).
- [x] I have tested my changes.

Related Issue
-----------
<!-- If any, please provide issue ID. -->


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.