### PR TITLE
Android: Remove OpenSSL Submodule

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -4,9 +4,6 @@
 [submodule "libs/mavlink/include/mavlink/v2.0"]
 	path = libs/mavlink/include/mavlink/v2.0
 	url = https://github.com/mavlink/c_library_v2.git
-[submodule "libs/OpenSSL/android_openssl"]
-	path = libs/OpenSSL/android_openssl
-	url = https://github.com/KDAB/android_openssl
 [submodule "libs/xz-embedded"]
 	path = libs/xz-embedded
 	url = https://github.com/Auterion/xz-embedded.git


### PR DESCRIPTION
Remove Android OpenSSL submodule as it is not used and it takes up a massive amount of space. Offline builds should just copy the necessary libraries rather than downloading hundreds of MB. This was part of the reason CI builds would run out of space.