### PR TITLE
bugfix: Stop calibration when disconnect battery is received

### DIFF
--- a/src/AutoPilotPlugins/PX4/PowerComponentController.cc
+++ b/src/AutoPilotPlugins/PX4/PowerComponentController.cc
@@ -99,12 +99,12 @@ void PowerComponentController::_handleVehicleTextMessage(int vehicleId, int /* c
     QString failedPrefix("calibration failed: ");
     if (text.startsWith(failedPrefix)) {
         QString failureText = text.right(text.length() - failedPrefix.length());
+        _stopCalibration();
         if (failureText.startsWith("Disconnect battery")) {
             emit disconnectBattery();
             return;
         }
         
-        _stopCalibration();
         emit calibrationFailed(text.right(text.length() - failedPrefix.length()));
         return;
     }


### PR DESCRIPTION
Fixing bug where more popups open when relaunching ESC calibration

Description
-----------

Tested with px4.
Launching ESC calibration without battery status fails the `check_battery_disconnect()` in `src/modules/commander/esc_calibration.cpp` (px4-autopilot)
`Disconnect battery and try again` status is sent.
but QGC does not unsubscribe `_handleVehicleTextMessage` because `_stopCalibration` is not called (early exit)

->  causes stacking of popups the more we run ESC calibration

Test Steps
-----------
Launch ESC calibration without battery status for FC (eg no battery, FC powered by directly).
An error message appears: "Disconnect battery and try again"

Relaunch again
Same error message, this time only a single popup (because `_stopCalibration` unsubscribes `_handleVehicleTextMessage`)

Checklist:
----------
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] [Review Contribution Guidelines](https://github.com/mavlink/qgroundcontrol/blob/master/.github/CONTRIBUTING.md).
- [x] [Review Code of Conduct](https://github.com/mavlink/qgroundcontrol/blob/master/.github/CODE_OF_CONDUCT.md).
- [x] I have tested my changes.

Related Issue
-----------
<!-- If any, please provide issue ID. -->

