### PR TITLE
Fixed 'Sensors Setup' page not showing GUI

### DIFF
--- a/src/AutoPilotPlugins/APM/APMSensorsComponentController.cc
+++ b/src/AutoPilotPlugins/APM/APMSensorsComponentController.cc
@@ -390,14 +390,12 @@ void APMSensorsComponentController::calibrateGyro(void)
     _vehicle->startCalibration(_calTypeInProgress);
 }
 
-void APMSensorsComponentController::_handleUASTextMessage(int uasId, int compId, int severity, QString text)
+void APMSensorsComponentController::_handleUASTextMessage(int compId, int severity, QString text, QString description)
 {
     Q_UNUSED(compId);
     Q_UNUSED(severity);
+    Q_UNUSED(description);
     
-    if (uasId != _vehicle->id()) {
-        return;
-    }
 
     QString originalMessageText = text;
     text = text.toLower();

--- a/src/AutoPilotPlugins/APM/APMSensorsComponentController.h
+++ b/src/AutoPilotPlugins/APM/APMSensorsComponentController.h
@@ -123,7 +123,7 @@ signals:
     void setAllCalButtonsEnabled                (bool enabled);
 
 private slots:
-    void _handleUASTextMessage  (int uasId, int compId, int severity, QString text);
+    void _handleUASTextMessage  (int compId, int severity, QString text, QString description);
     void _mavlinkMessageReceived(LinkInterface* link, mavlink_message_t message);
     void _mavCommandResult      (int vehicleId, int component, int command, int result, bool noReponseFromVehicle);
 

--- a/src/AutoPilotPlugins/APM/APMSubMotorComponentController.cc
+++ b/src/AutoPilotPlugins/APM/APMSubMotorComponentController.cc
@@ -17,11 +17,11 @@ APMSubMotorComponentController::APMSubMotorComponentController(void)
     connect(_vehicle, &Vehicle::textMessageReceived, this, &APMSubMotorComponentController::handleNewMessages);
 }
 
-void APMSubMotorComponentController::handleNewMessages(int uasid, int componentid, int severity, QString text)
+void APMSubMotorComponentController::handleNewMessages(int componentid, int severity, QString text, QString description)
 {
-    Q_UNUSED(uasid);
     Q_UNUSED(componentid);
     Q_UNUSED(severity);
+    Q_UNUSED(description);
     if (_vehicle->flightMode() == "Motor Detection"
         && (text.toLower().contains("thruster") || text.toLower().contains("motor"))) {
         _motorDetectionMessages += text + QStringLiteral("\n");

--- a/src/AutoPilotPlugins/APM/APMSubMotorComponentController.h
+++ b/src/AutoPilotPlugins/APM/APMSubMotorComponentController.h
@@ -26,7 +26,7 @@ signals:
     void motorDetectionMessagesChanged();
 
 private slots:
-    void handleNewMessages(int uasid, int componentid, int severity, QString text);
+    void handleNewMessages(int compId, int severity, QString text, QString description);
 
 private:
     QString _motorDetectionMessages;

--- a/src/AutoPilotPlugins/PX4/PowerComponentController.cc
+++ b/src/AutoPilotPlugins/PX4/PowerComponentController.cc
@@ -45,11 +45,11 @@ void PowerComponentController::_stopBusConfig(void)
     _stopCalibration();
 }
 
-void PowerComponentController::_handleVehicleTextMessage(int vehicleId, int /* compId */, int /* severity */, QString text)
+void PowerComponentController::_handleVehicleTextMessage(int compId, int severity, QString text, QString description)
 {
-    if (vehicleId != _vehicle->id()) {
-        return;
-    }
+    Q_UNUSED(compId);
+    Q_UNUSED(severity);
+    Q_UNUSED(description);
     
     // All calibration messages start with [cal]
     QString calPrefix("[cal] ");

--- a/src/AutoPilotPlugins/PX4/PowerComponentController.h
+++ b/src/AutoPilotPlugins/PX4/PowerComponentController.h
@@ -38,7 +38,7 @@ signals:
     void calibrationSuccess(const QStringList& warningMessages);
     
 private slots:
-    void _handleVehicleTextMessage(int vehicleId, int compId, int severity, QString text);
+    void _handleVehicleTextMessage(int compId, int severity, QString text, QString description);
     
 private:
     void _stopCalibration(void);

--- a/src/AutoPilotPlugins/PX4/SensorsComponentController.cc
+++ b/src/AutoPilotPlugins/PX4/SensorsComponentController.cc
@@ -221,7 +221,7 @@ void SensorsComponentController::calibrateAirspeed(void)
     _vehicle->startCalibration(QGCMAVLink::CalibrationPX4Airspeed);
 }
 
-void SensorsComponentController::_handleUASTextMessage(int uasId, int compId, int severity, QString text)
+void SensorsComponentController::_handleUASTextMessage(int uasId, int compId, int severity, QString text, QString description)
 {
     Q_UNUSED(compId);
     Q_UNUSED(severity);
@@ -230,8 +230,8 @@ void SensorsComponentController::_handleUASTextMessage(int uasId, int compId, in
         return;
     }
     
-    if (text.contains("progress <")) {
-        QString percent = text.split("<").last().split(">").first();
+    if (text.contains("[cal] progress &lt;")) {
+        QString percent = text.split("&lt;").last().split("&gt;").first();
         bool ok;
         int p = percent.toInt(&ok);
         if (ok) {

--- a/src/AutoPilotPlugins/PX4/SensorsComponentController.cc
+++ b/src/AutoPilotPlugins/PX4/SensorsComponentController.cc
@@ -221,15 +221,11 @@ void SensorsComponentController::calibrateAirspeed(void)
     _vehicle->startCalibration(QGCMAVLink::CalibrationPX4Airspeed);
 }
 
-void SensorsComponentController::_handleUASTextMessage(int uasId, int compId, int severity, QString text, QString description)
+void SensorsComponentController::_handleUASTextMessage(int compId, int severity, QString text, QString description)
 {
     Q_UNUSED(compId);
     Q_UNUSED(severity);
     Q_UNUSED(description);
-    
-    if (uasId != _vehicle->id()) {
-        return;
-    }
     
     if (text.contains("[cal] progress &lt;")) {
         QString percent = text.split("&lt;").last().split("&gt;").first();

--- a/src/AutoPilotPlugins/PX4/SensorsComponentController.cc
+++ b/src/AutoPilotPlugins/PX4/SensorsComponentController.cc
@@ -225,6 +225,7 @@ void SensorsComponentController::_handleUASTextMessage(int uasId, int compId, in
 {
     Q_UNUSED(compId);
     Q_UNUSED(severity);
+    Q_UNUSED(description);
     
     if (uasId != _vehicle->id()) {
         return;

--- a/src/AutoPilotPlugins/PX4/SensorsComponentController.h
+++ b/src/AutoPilotPlugins/PX4/SensorsComponentController.h
@@ -93,7 +93,7 @@ signals:
     void magCalComplete(void);
 
 private slots:
-    void _handleUASTextMessage(int uasId, int compId, int severity, QString text);
+    void _handleUASTextMessage(int uasId, int compId, int severity, QString text, QString description);
     void _handleParametersReset(bool success);
     
 private:

--- a/src/AutoPilotPlugins/PX4/SensorsComponentController.h
+++ b/src/AutoPilotPlugins/PX4/SensorsComponentController.h
@@ -93,7 +93,7 @@ signals:
     void magCalComplete(void);
 
 private slots:
-    void _handleUASTextMessage(int uasId, int compId, int severity, QString text, QString description);
+    void _handleUASTextMessage(int compId, int severity, QString text, QString description);
     void _handleParametersReset(bool success);
     
 private:

--- a/src/Vehicle/Vehicle.cc
+++ b/src/Vehicle/Vehicle.cc
@@ -4012,7 +4012,7 @@ void Vehicle::_textMessageReceived(MAV_COMPONENT componentid, MAV_SEVERITY sever
         qCDebug(VehicleLog) << "Dropping message (expected as event):" << text;
         return;
     }
-    emit textMessageReceived(id(), static_cast<int>(componentid), static_cast<int>(componentid), text, description);
+    emit textMessageReceived(id(), componentid, severity, text, description);
 
     bool skipSpoken = false;
     const bool ardupilotPrearm = text.startsWith(QStringLiteral("PreArm"));

--- a/src/Vehicle/Vehicle.cc
+++ b/src/Vehicle/Vehicle.cc
@@ -4012,6 +4012,7 @@ void Vehicle::_textMessageReceived(MAV_COMPONENT componentid, MAV_SEVERITY sever
         qCDebug(VehicleLog) << "Dropping message (expected as event):" << text;
         return;
     }
+    emit textMessageReceived(id(), static_cast<int>(componentid), static_cast<int>(componentid), text, description);
 
     bool skipSpoken = false;
     const bool ardupilotPrearm = text.startsWith(QStringLiteral("PreArm"));

--- a/src/Vehicle/Vehicle.cc
+++ b/src/Vehicle/Vehicle.cc
@@ -4002,6 +4002,7 @@ void Vehicle::_createStatusTextHandler()
     (void) connect(m_statusTextHandler, &StatusTextHandler::messageCountChanged, this, &Vehicle::messageCountChanged);
     (void) connect(m_statusTextHandler, &StatusTextHandler::newFormattedMessage, this, &Vehicle::newFormattedMessage);
     (void) connect(m_statusTextHandler, &StatusTextHandler::textMessageReceived, this, &Vehicle::_textMessageReceived);
+    (void) connect(m_statusTextHandler, &StatusTextHandler::textMessageReceived, this, &Vehicle::textMessageReceived);
     (void) connect(m_statusTextHandler, &StatusTextHandler::newErrorMessage, this, &Vehicle::_errorMessageReceived);
 }
 
@@ -4012,7 +4013,6 @@ void Vehicle::_textMessageReceived(MAV_COMPONENT componentid, MAV_SEVERITY sever
         qCDebug(VehicleLog) << "Dropping message (expected as event):" << text;
         return;
     }
-    emit textMessageReceived(id(), componentid, severity, text, description);
 
     bool skipSpoken = false;
     const bool ardupilotPrearm = text.startsWith(QStringLiteral("PreArm"));

--- a/src/Vehicle/Vehicle.h
+++ b/src/Vehicle/Vehicle.h
@@ -1339,7 +1339,7 @@ public:
     // StatusTextHandler* statusTextHandler() { return m_statusTextHandler; }
 
 signals:
-    void textMessageReceived(int sysid, int componentid, int severity, QString text, QString description);
+    void textMessageReceived(MAV_COMPONENT componentid, MAV_SEVERITY severity, QString text, QString description);
 
     void messagesReceivedChanged();
     void messagesSentChanged();


### PR DESCRIPTION
Fixed Vehicle Setup -> Sensors page for PX4 not showing GUI, made to help user with calibration.

Description
-----------
Used to be:
![image](https://github.com/user-attachments/assets/a0e4d314-399b-42d1-bef9-6b6db2130659)
Now it works correctly:
![image](https://github.com/user-attachments/assets/f076d982-8259-449f-bdb3-2c3be4ad9c1f)


Test Steps
-----------
Go to Vehicle Setup -> Sensors. Start, for example, accelerometer calibration and you will see no changes in the right part of the screen. Now it works the same way, as it does in the stable verison (correctly).

Related Issue
-----------
There might be the same issue with others autopilots. I don't not have ability to check.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.