### PR TITLE
Status text html escaping in wrong place

### DIFF
--- a/src/MAVLink/StatusTextHandler.cc
+++ b/src/MAVLink/StatusTextHandler.cc
@@ -137,9 +137,10 @@ void StatusTextHandler::resetErrorLevelMessages()
     }
 }
 
-void StatusTextHandler::handleTextMessage(MAV_COMPONENT compId, MAV_SEVERITY severity, const QString &text, const QString &description)
+void StatusTextHandler::handleHTMLEscapedTextMessage(MAV_COMPONENT compId, MAV_SEVERITY severity, const QString &text, const QString &description)
 {
     QString htmlText(text);
+
     (void) htmlText.replace("\n", "<br/>");
 
     // TODO: handle text + description separately in the UI
@@ -335,7 +336,7 @@ void StatusTextHandler::_chunkedStatusTextCompleted(MAV_COMPONENT compId)
 
     (void) m_chunkedStatusTextInfoMap.remove(compId);
 
-    emit textMessageReceived(compId, severity, messageText.toHtmlEscaped(), "");
+    emit textMessageReceived(compId, severity, messageText, "");
 }
 
 void StatusTextHandler::_handleTextMessage(uint32_t newCount, MessageType messageType)

--- a/src/MAVLink/StatusTextHandler.h
+++ b/src/MAVLink/StatusTextHandler.h
@@ -57,7 +57,7 @@ public:
     ~StatusTextHandler();
 
     void mavlinkMessageReceived(const mavlink_message_t &message);
-    void handleTextMessage(MAV_COMPONENT componentid, MAV_SEVERITY severity, const QString &text, const QString &description);
+    void handleHTMLEscapedTextMessage(MAV_COMPONENT componentid, MAV_SEVERITY severity, const QString &text, const QString &description);
 
     void clearMessages();
     void resetAllMessages();

--- a/src/Vehicle/Vehicle.cc
+++ b/src/Vehicle/Vehicle.cc
@@ -1227,7 +1227,7 @@ void Vehicle::_handleEvent(uint8_t comp_id, std::unique_ptr<events::parser::Pars
                 return;
             }
 
-            m_statusTextHandler->handleTextMessage(static_cast<MAV_COMPONENT>(comp_id), static_cast<MAV_SEVERITY>(severity), text, QString::fromStdString(description));
+            m_statusTextHandler->handleHTMLEscapedTextMessage(static_cast<MAV_COMPONENT>(comp_id), static_cast<MAV_SEVERITY>(severity), text, QString::fromStdString(description));
         }
     }
 }
@@ -4047,7 +4047,8 @@ void Vehicle::_textMessageReceived(MAV_COMPONENT componentid, MAV_SEVERITY sever
         _say(text);
     }
 
-    m_statusTextHandler->handleTextMessage(componentid, severity, text.toHtmlEscaped(), description);
+    emit textMessageReceived(id(), componentid, severity, text, description);
+    m_statusTextHandler->handleHTMLEscapedTextMessage(componentid, severity, text.toHtmlEscaped(), description);
 }
 
 void Vehicle::_errorMessageReceived(QString message)

--- a/test/MAVLink/StatusTextHandlerTest.cc
+++ b/test/MAVLink/StatusTextHandlerTest.cc
@@ -26,14 +26,14 @@ void StatusTextHandlerTest::_testHandleTextMessage()
 {
     StatusTextHandler* statusTextHandler = new StatusTextHandler(this);
 
-    statusTextHandler->handleTextMessage(MAV_COMP_ID_USER1, MAV_SEVERITY_INFO, "StatusTextHandlerTestInfo", "This is the StatusTextHandlerTestInfo Test");
+    statusTextHandler->handleHTMLEscapedTextMessage(MAV_COMP_ID_USER1, MAV_SEVERITY_INFO, "StatusTextHandlerTestInfo", "This is the StatusTextHandlerTestInfo Test");
     QString messages = statusTextHandler->formattedMessages();
     QVERIFY(!messages.isEmpty());
     QVERIFY(messages.contains("StatusTextHandlerTestInfo"));
     QCOMPARE(statusTextHandler->getNormalCount(), 1);
     QCOMPARE(statusTextHandler->messageCount(), 1);
 
-    statusTextHandler->handleTextMessage(MAV_COMP_ID_USER1, MAV_SEVERITY_WARNING, "StatusTextHandlerTestWarning", "This is the StatusTextHandlerTestWarning Test");
+    statusTextHandler->handleHTMLEscapedTextMessage(MAV_COMP_ID_USER1, MAV_SEVERITY_WARNING, "StatusTextHandlerTestWarning", "This is the StatusTextHandlerTestWarning Test");
     messages = statusTextHandler->formattedMessages();
     QVERIFY(messages.contains("StatusTextHandlerTestInfo"));
     QVERIFY(messages.contains("StatusTextHandlerTestWarning"));


### PR DESCRIPTION
This is a replacement for #11990. I was crazy hard to get my head around all the back and forth of status text between vehicle and StatusTextHandler. So I created the most minimal set of changes I could come up with to fix the problem. I tested it and it works as far as I can tell.

The basic idea is that status text which flows through the system should not be html escaped until the very last place when it needs to be output to a rich text control. This is critical vehicle error popups and the message indicator dropdown. Status text which flows from Vehicle should raw for people connecting to that signaling.

@stepan14511 Can you test as well.