### PR TITLE
Vehicle: fix actuators page 

### DIFF
--- a/src/Vehicle/Vehicle.h
+++ b/src/Vehicle/Vehicle.h
@@ -82,10 +82,6 @@ class GimbalController;
 #ifdef QGC_UTM_ADAPTER
 class UTMSPVehicle;
 #endif
-#ifndef OPAQUE_PTR_VEHICLE
-    #define OPAQUE_PTR_VEHICLE
-    Q_DECLARE_OPAQUE_POINTER(Actuators*)
-#endif
 
 namespace events {
 namespace parser {
@@ -105,6 +101,7 @@ class Vehicle : public VehicleFactGroup
     Q_MOC_INCLUDE("Autotune.h")
     Q_MOC_INCLUDE("RemoteIDManager.h")
     Q_MOC_INCLUDE("QGCCameraManager.h")
+    Q_MOC_INCLUDE("Actuators/Actuators.h")
 
     friend class InitialConnectStateMachine;
     friend class VehicleLinkManager;


### PR DESCRIPTION
Closes https://github.com/mavlink/qgroundcontrol/issues/11957

**Before**
```
qrc:/qml/ActuatorComponent.qml:206:33: QML Connections: Cannot assign to non-existent property "onHadFailureChanged"
qrc:/qml/ActuatorComponent.qml:36: TypeError: Cannot read property 'groups' of undefined
qrc:/qml/ActuatorComponent.qml:38: TypeError: Cannot read property 'title' of undefined
qrc:/qml/ActuatorComponent.qml:45: TypeError: Cannot read property 'helpUrl' of undefined
qrc:/qml/ActuatorComponent.qml:43: TypeError: Cannot read property 'helpUrl' of undefined
qrc:/qml/ActuatorComponent.qml:57: TypeError: Cannot read property 'groups' of undefined
qrc:/qml/ActuatorComponent.qml:69: TypeError: Cannot read property 'groups' of undefined
qrc:/qml/ActuatorComponent.qml:162:21: Unable to assign [undefined] to bool
qrc:/qml/ActuatorComponent.qml:196: TypeError: Cannot read property 'actuators' of undefined
qrc:/qml/ActuatorComponent.qml:201: TypeError: Cannot read property 'actuators' of undefined
qrc:/qml/ActuatorComponent.qml:205: TypeError: Cannot read property 'hadFailure' of undefined
qrc:/qml/ActuatorComponent.qml:207:37: Unable to assign [undefined] to QObject*
qrc:/qml/ActuatorComponent.qml:243: TypeError: Cannot read property 'allMotorsActuator' of undefined
qrc:/qml/ActuatorComponent.qml:266: TypeError: Cannot read property 'actuators' of undefined
qrc:/qml/ActuatorComponent.qml:284: TypeError: Cannot read property 'count' of undefined
qrc:/qml/ActuatorComponent.qml:327:21: Unable to assign [undefined] to bool
qrc:/qml/ActuatorComponent.qml:363:29: Unable to assign [undefined] to bool
qrc:/qml/ActuatorComponent.qml:370:33: Unable to assign [undefined] to bool
qrc:/qml/ActuatorComponent.qml:369: TypeError: Cannot read property 'groupsVisible' of undefined
qrc:/qml/ActuatorComponent.qml:385:37: Unable to assign [undefined] to QString
qrc:/qml/ActuatorComponent.qml:401:37: Unable to assign [undefined] to QString
qrc:/qml/ActuatorComponent.qml:406:33: Unable to assign [undefined] to bool
qrc:/qml/ActuatorComponent.qml:413:33: Unable to assign [undefined] to bool
qrc:/qml/ActuatorComponent.qml:425: TypeError: Cannot read property 'enableParam' of undefined
qrc:/qml/ActuatorComponent.qml:438: TypeError: Cannot read property 'subgroups' of undefined
qrc:/qml/ActuatorComponent.qml:520: TypeError: Cannot read property 'configParams' of undefined
qrc:/qml/ActuatorComponent.qml:534: TypeError: Cannot read property 'notes' of undefined
```