### PR TITLE
PX4: Airframe: fix application crash when selecting Airframe type

### DIFF
--- a/src/AutoPilotPlugins/APM/APMAirframeComponentController.cc
+++ b/src/AutoPilotPlugins/APM/APMAirframeComponentController.cc
@@ -213,7 +213,7 @@ void APMAirframeComponentController::_loadParametersFromDownloadFile(const QStri
 
 void APMAirframeComponentController::loadParameters(const QString& paramFile)
 {
-    QGuiApplication::overrideCursor()->setShape(Qt::WaitCursor);
+    QGuiApplication::setOverrideCursor(QCursor(Qt::WaitCursor));
 
     QString paramFileUrl = QStringLiteral("https://api.github.com/repos/ArduPilot/ardupilot/contents/Tools/Frame_params/%1?ref=master");
 

--- a/src/AutoPilotPlugins/PX4/AirframeComponentController.cc
+++ b/src/AutoPilotPlugins/PX4/AirframeComponentController.cc
@@ -90,7 +90,7 @@ void AirframeComponentController::changeAutostart(void)
 		return;
 	}
 
-    QGuiApplication::overrideCursor()->setShape(Qt::WaitCursor);
+    QGuiApplication::setOverrideCursor(QCursor(Qt::WaitCursor));
     
     Fact* sysAutoStartFact  = getParameterFact(-1, "SYS_AUTOSTART");
     Fact* sysAutoConfigFact = getParameterFact(-1, "SYS_AUTOCONFIG");
@@ -100,7 +100,7 @@ void AirframeComponentController::changeAutostart(void)
     connect(sysAutoStartFact, &Fact::vehicleUpdated, this, &AirframeComponentController::_waitParamWriteSignal);
     connect(sysAutoConfigFact, &Fact::vehicleUpdated, this, &AirframeComponentController::_waitParamWriteSignal);
     
-    // We use forceSetValue to params are sent even if the previous value is that same as the new value
+    // We use forceSetValue to ensure params are sent even if the previous value is that same as the new value
     sysAutoStartFact->forceSetRawValue(_autostartId);
     sysAutoConfigFact->forceSetRawValue(1);
 }


### PR DESCRIPTION
The application will crash when you select an Airframe. This is because the overrideCursor is nullptr
https://doc.qt.io/qt-6/qguiapplication.html#overrideCursor

