### PR TITLE
Fix issue with cached tile set download cancelation

### DIFF
--- a/src/QtLocationPlugin/QGCCachedTileSet.cpp
+++ b/src/QtLocationPlugin/QGCCachedTileSet.cpp
@@ -61,6 +61,11 @@ QString QGCCachedTileSet::downloadStatus() const
 
 void QGCCachedTileSet::createDownloadTask()
 {
+    if (_cancelPending) {
+        setDownloading(false);
+        return;
+    }
+
     if (!_downloading) {
         setErrorCount(0);
         setDownloading(true);
@@ -82,9 +87,15 @@ void QGCCachedTileSet::createDownloadTask()
 
 void QGCCachedTileSet::resumeDownloadTask()
 {
+    _cancelPending = false;
     QGCUpdateTileDownloadStateTask* const task = new QGCUpdateTileDownloadStateTask(_id, QGCTile::StatePending, "*");
     getQGCMapEngine()->addTask(task);
     createDownloadTask();
+}
+
+void QGCCachedTileSet::cancelDownloadTask()
+{
+    _cancelPending = true;
 }
 
 void QGCCachedTileSet::_tileListFetched(const QQueue<QGCTile*> &tiles)

--- a/src/QtLocationPlugin/QGCCachedTileSet.h
+++ b/src/QtLocationPlugin/QGCCachedTileSet.h
@@ -74,7 +74,7 @@ public:
 
     Q_INVOKABLE void createDownloadTask();
     Q_INVOKABLE void resumeDownloadTask();
-    Q_INVOKABLE void cancelDownloadTask() { setDownloading(false); }
+    Q_INVOKABLE void cancelDownloadTask();
 
     const QString &name() const { return _name; }
     const QString &mapTypeStr() const { return _mapTypeStr; }
@@ -184,6 +184,7 @@ private:
     bool _noMoreTiles = false;
     bool _batchRequested = false;
     bool _selected = false;
+    bool _cancelPending = false;
     QDateTime _creationDate;
 
     QHash<QString, QNetworkReply*> _replies;


### PR DESCRIPTION
Fix issue with cached tile set download cancelation

Description
-----------
Cancel download did not cancel download. It just set "downloading" flag to "false". This fix resolves this issue.

Test Steps
-----------
I have tested it locally, on release build, by starting offline map download and stopping it

Checklist:
----------
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] [Review Contribution Guidelines](https://github.com/mavlink/qgroundcontrol/blob/master/.github/CONTRIBUTING.md).
- [x] [Review Code of Conduct](https://github.com/mavlink/qgroundcontrol/blob/master/.github/CODE_OF_CONDUCT.md).
- [x] I have tested my changes.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.