### PR TITLE
Use correct aspectRation for gst video

### DIFF
--- a/src/FlightDisplay/FlightDisplayViewVideo.qml
+++ b/src/FlightDisplay/FlightDisplayViewVideo.qml
@@ -26,7 +26,9 @@ Item {
 
     property bool useSmallFont: true
 
-    property double _ar:                QGroundControl.videoManager.aspectRatio
+    property double _ar:                QGroundControl.videoManager.gstreamerEnabled
+                                            ? QGroundControl.videoManager.videoSize.width / QGroundControl.videoManager.videoSize.height
+                                            : QGroundControl.videoManager.aspectRatio
     property bool   _showGrid:          QGroundControl.settingsManager.videoSettings.gridLines.rawValue
     property var    _dynamicCameras:    globals.activeVehicle ? globals.activeVehicle.cameraManager : null
     property bool   _connected:         globals.activeVehicle ? !globals.activeVehicle.communicationLost : false


### PR DESCRIPTION
Fixes #11896 

# Description
The wrong ratio was being used for GST video (if the video stream aspect ratio did not match the operator provided aspect ratio). This made so thinngs like grid lines weren't properly placed and also made track point setting inaccurate.

## Sponsor
This contribution was sponsored by [Firestorm](https://www.launchfirestorm.com/)
![654d4f9476ff2a38f37e9ab9_firestorm-homepage-share-img-2](https://github.com/user-attachments/assets/bc1a2c95-b33d-4a2d-af35-4d2d8651d0a2)

# Before
Note how the grid lines are not accurately placed and the video does not fill the width of the screen even though it is in "Fit Width" mode.
![bad-ratio](https://github.com/user-attachments/assets/b511a90d-d2fe-4408-a31f-961151c59c8b)
I generated the sample image using the following command
```
gst-launch-1.0 videotestsrc ! openh264enc ! rtph264pay config-interval=10 pt=96 ! udpsink host=127.0.0.1 port=5600
```
My QGC settings were "Fit Width" in video settings and I made video streaming enabled for h264 port 5600


# After
Note how the grid lines are accurately placed and the video does fill the width of the screen as expected when in "Fit Width" mode.
![good-ratio](https://github.com/user-attachments/assets/c2729e00-c0c4-4a6c-a4b0-6caf85439746)
