### PR TITLE
Fix disappearing loiter circles

### DIFF
--- a/src/PlanView/SimpleItemMapVisual.qml
+++ b/src/PlanView/SimpleItemMapVisual.qml
@@ -97,14 +97,11 @@ Item {
         target: _missionItem.isSimpleItem ? _missionItem : null
 
         onLoiterRadiusChanged: {
-            _loiterVisual.blockSignals = true
-            _loiterVisual.clockwiseRotation = _missionItem.loiterRadius>= 0
-            _loiterVisual.blockSignals = false
-            _loiterVisual.radius.rawValue = Math.abs(_missionItem.loiterRadius)
+            _loiterVisual.handleLoiterRadiusChange()
         }
 
         onCoordinateChanged: {
-            _loiterVisual.coordinate = _missionItem.coordinate
+            _loiterVisual.handleCoordinateChange()
         }
     }
 
@@ -147,6 +144,17 @@ Item {
             property alias radius:            _mapCircle.radius
             property alias clockwiseRotation: _mapCircle.clockwiseRotation
 
+            function handleLoiterRadiusChange() {
+                blockSignals = true
+                clockwiseRotation = _missionItem.loiterRadius>= 0
+                blockSignals = false
+                radius.rawValue = Math.abs(_missionItem.loiterRadius)
+            }
+
+            function handleCoordinateChange() {
+                coordinate = _missionItem.coordinate
+            }
+
             onCoordinateChanged:              _mapCircle.center = coordinate
 
             sourceItem: QGCMapCircleVisuals {
@@ -176,6 +184,11 @@ Item {
                         if(!blockSignals) loiterMapCircleVisuals.updateMissionItem()
                     }
                 }
+            }
+
+            Component.onCompleted: {
+                handleLoiterRadiusChange()
+                handleCoordinateChange()
             }
         }
     }


### PR DESCRIPTION
# Description
When video streaming was enabled, toggling between mini video and full screen video mode would make the circles representing loiter circles on the flight path disappear. This PR fixes that issue.

# Steps to Reproduce
1. open a PX4 plane sim. ex
```
cd PX4-Autopilot
make px4_sitl gazebo-classic_plane_lidar
```
2. Open QGC daily
3. create a mission with a loiter waypoint.
![make-mission](https://github.com/user-attachments/assets/07d3c166-9d56-4cc6-8553-999243f6b090)

4. upload the mission to the vehicle and go to Fly view
![before-toggle](https://github.com/user-attachments/assets/1504bd54-9a5c-45cb-994f-21aa7832dcc3)

5. switch to big video mode
![big-video](https://github.com/user-attachments/assets/a37ebc77-f780-4462-aed4-e1701c29fef5)

6. switch back to Big map mode
![after-toggle](https://github.com/user-attachments/assets/9d78e82a-f08c-40a7-bf06-85aa18359b1d)
Notice how the loiter circle has collapsed. This is the bug that is fixed. With the fix in this PR the loiter circle properly reappears when toggling the video from mini to full screen.

## Sponsor
This contribution was sponsored by [Firestorm](https://www.launchfirestorm.com/)
![654d4f9476ff2a38f37e9ab9_firestorm-homepage-share-img-2](https://github.com/user-attachments/assets/bc1a2c95-b33d-4a2d-af35-4d2d8651d0a2)
