### PR TITLE
Update video fit options

### DIFF
--- a/src/FlightDisplay/FlightDisplayViewVideo.qml
+++ b/src/FlightDisplay/FlightDisplayViewVideo.qml
@@ -38,6 +38,11 @@ Item {
     property bool   _hasZoom:           _camera && _camera.hasZoom
     property int    _fitMode:           QGroundControl.settingsManager.videoSettings.videoFit.rawValue
 
+    property bool   _isMode_FIT_WIDTH:  _fitMode === 0
+    property bool   _isMode_FIT_HEIGHT: _fitMode === 1
+    property bool   _isMode_FILL:       _fitMode === 2
+    property bool   _isMode_NO_CROP:    _fitMode === 3
+
     function getWidth() {
         return videoBackground.getWidth()
     }
@@ -79,20 +84,34 @@ Item {
         color:          "black"
         visible:        QGroundControl.videoManager.decoding
         function getWidth() {
-            //-- Fit Width or Stretch
-            if(_fitMode === 0 || _fitMode === 2) {
-                return parent.width
+            if(_ar != 0.0){
+                if(_isMode_FIT_HEIGHT 
+                        || (_isMode_FILL && (root.width/root.height < _ar))
+                        || (_isMode_NO_CROP && (root.width/root.height > _ar))){
+                    // This return value has different implications depending on the mode
+                    // For FIT_HEIGHT and FILL
+                    //    makes so the video width will be larger than (or equal to) the screen width
+                    // For NO_CROP Mode
+                    //    makes so the video width will be smaller than (or equal to) the screen width
+                    return root.height * _ar
+                }
             }
-            //-- Fit Height
-            return _ar != 0.0 ? parent.height * _ar : parent.width
+            return root.width
         }
         function getHeight() {
-            //-- Fit Height or Stretch
-            if(_fitMode === 1 || _fitMode === 2) {
-                return parent.height
+            if(_ar != 0.0){
+                if(_isMode_FIT_WIDTH 
+                        || (_isMode_FILL && (root.width/root.height > _ar)) 
+                        || (_isMode_NO_CROP && (root.width/root.height < _ar))){
+                    // This return value has different implications depending on the mode
+                    // For FIT_WIDTH and FILL
+                    //    makes so the video height will be larger than (or equal to) the screen height
+                    // For NO_CROP Mode
+                    //    makes so the video height will be smaller than (or equal to) the screen height
+                    return root.width * (1 / _ar)
+                }
             }
-            //-- Fit Width
-            return _ar != 0.0 ? parent.width * (1 / _ar) : parent.height
+            return root.height
         }
         Component {
             id: videoBackgroundComponent

--- a/src/Settings/Video.SettingsGroup.json
+++ b/src/Settings/Video.SettingsGroup.json
@@ -59,8 +59,8 @@
     "shortDesc": "Video Display Fit",
     "longDesc":  "Handle Video Aspect Ratio.",
     "type":             "uint32",
-    "enumStrings":      "Fit Width,Fit Height,Stretch",
-    "enumValues":       "0,1,2",
+    "enumStrings":      "Fit Width,Fit Height,Fill,No Crop",
+    "enumValues":       "0,1,2,3",
     "default":     1
 },
 {


### PR DESCRIPTION
# Description
The pre-existing video fit option "Stretch" would not fill the screen as expected. The grid lines were also not
accurately placed over the video.

"Stretch" is also not a great word to use because it hints the video may be transformed in a way were
its aspectRatio is different from the original, which is not the case.

This PR renames "Stretch" to "Fit" and fixes it so the video fills the screen when in that mode. A new mode was also added called "No Crop" which makes so the entire video is shown (no part of video goes past the bounds of the border of the screen, as would be the case in the other 3 video fit modes if the video width/height aspect ratio does not match the QGC app window width/height aspect ratio

## Issue Before
Steps to reproduce
1. Run a vehicle
```
cd PX4-Autopilot
make px4_sitl gazebo-classic_plane
```
2. Run a GST video stream
```
gst-launch-1.0 videotestsrc ! openh264enc ! rtph264pay config-interval=10 pt=96 ! udpsink host=127.0.0.1 port=5600
```
3. Run QGC. Select on the gear icon close the the red record button to open video settings and put the video in "Stretch" mode
![fit-select-stetch](https://github.com/user-attachments/assets/3e57d989-f7a4-4c45-88a8-93025d265300)
4. Notice how the grid lines are not properly placed over the video and that the video does not fill the screen as one might expect from the name "Stretch"
![fit-before-stretch](https://github.com/user-attachments/assets/91767253-c470-4832-a61f-31ac3a58795b)

## Update with this PR
follow the same steps in the "Steps to Reproduce" section, only select "Fit" (which is the new replacemnt for "Stretch")

As expected, the video now fills the screen and has the grid lines properly placed
![fit-after-stretch](https://github.com/user-attachments/assets/d09ad883-28db-426f-bceb-be67db524054)

Also notice the new mode "No Crop"
![fit-select-no-crop](https://github.com/user-attachments/assets/c3804031-1323-422d-a1ea-3e21c603ff55)

"No Crop" makes so the entire video is shown (no part of video goes past the bounds of the border of the screen, as would be the case in the other 3 video fit modes if the video width/height aspect ratio does not match the QGC app window width/height aspect ratio

ex. "No Crop" when QGC window is very wide
![fit-no-crop-wide-qgc](https://github.com/user-attachments/assets/77c07e30-d319-48b2-b38b-b9075827024d)

ex. "No Crop" when QGC window is very tall
![fint-no-crop-tall-qgc](https://github.com/user-attachments/assets/65b316de-9992-43a2-a1f4-df76fbe96942)

## Sponsor
This contribution was sponsored by [Firestorm](https://www.launchfirestorm.com/)
![654d4f9476ff2a38f37e9ab9_firestorm-homepage-share-img-2](https://github.com/user-attachments/assets/bc1a2c95-b33d-4a2d-af35-4d2d8651d0a2)