### PR TITLE
Fix console warnings shown when adding complex land mission item

### DIFF
--- a/src/PlanView/FWLandingPatternEditor.qml
+++ b/src/PlanView/FWLandingPatternEditor.qml
@@ -69,7 +69,6 @@ Rectangle {
             FactCheckBox {
                 text:       qsTr("Use loiter to altitude")
                 fact:       missionItem.useLoiterToAlt
-                visible:    missionItem.useLoiterToAlt.visible
             }
 
             GridLayout {

--- a/src/PlanView/FWLandingPatternMapVisual.qml
+++ b/src/PlanView/FWLandingPatternMapVisual.qml
@@ -86,7 +86,6 @@ Item {
     function showMouseArea() {
         if (!_mouseArea) {
             _mouseArea = mouseAreaComponent.createObject(map)
-            map.addMapItem(_mouseArea)
         }
     }
 

--- a/src/PlanView/VTOLLandingPatternEditor.qml
+++ b/src/PlanView/VTOLLandingPatternEditor.qml
@@ -69,7 +69,6 @@ Rectangle {
             FactCheckBox {
                 text:       qsTr("Use loiter to altitude")
                 fact:       missionItem.useLoiterToAlt
-                visible:    missionItem.useLoiterToAlt.visible
             }
 
             GridLayout {

--- a/src/PlanView/VTOLLandingPatternMapVisual.qml
+++ b/src/PlanView/VTOLLandingPatternMapVisual.qml
@@ -62,7 +62,6 @@ Item {
     function showMouseArea() {
         if (!_mouseArea) {
             _mouseArea = mouseAreaComponent.createObject(map)
-            map.addMapItem(_mouseArea)
         }
     }
 


### PR DESCRIPTION
# Description

Fix console warnings shown when adding complex land mission item

1. Remove references to non existent useLoiterToAlt.visible property
2. Don't add _mouseArea to the map (the action was failing and isn't necessary)

## Steps to reproduce issue fixed with this PR
1. Run a plane sim
```
cd PX4-Autopilot
make px4_sitl gazebo-classic_plane
```
2. Run QGC master and create a mission with a complex land (use left tool bar to add a "Tokeoff" item and then use the left tool bar to add a "Land" item, which will be a FWComplexLand since a plane is connected to QGC.
3. You should see this warning in the QtCreator log (This PR removes the warning)
![on-create](https://github.com/user-attachments/assets/72a9d9c0-967a-41ae-a180-9bc1e2456b8e)
4. If you upload the mission to the vehicle and restart QGC, there is another warning that appears 
![on-open](https://github.com/user-attachments/assets/dccc4e0f-7950-4cc3-b278-62abdba9952c)

## Steps to test fix
Run the steps in "Steps to reproduce issue" only use this PR's branch. The difference will be the warning messages described will no longer show up. 


## Sponsor
This contribution was sponsored by [Firestorm](https://www.launchfirestorm.com/)
![654d4f9476ff2a38f37e9ab9_firestorm-homepage-share-img-2](https://github.com/user-attachments/assets/bc1a2c95-b33d-4a2d-af35-4d2d8651d0a2)