### PR TITLE
Utilities: Fix decompression of firmware downloads

### DIFF
--- a/src/Utilities/Compression/QGCZlib.h
+++ b/src/Utilities/Compression/QGCZlib.h
@@ -14,9 +14,11 @@
 
 Q_DECLARE_LOGGING_CATEGORY(QGCZlibLog)
 
-namespace QGCZlib {
+namespace QGCZlib
+{
     /// Decompresses the specified file to the specified directory
     ///     @param gzippedFileName      Fully qualified path to gzip file
     ///     @param decompressedFilename Fully qualified path to for file to decompress to
+    /// @return bool Success
     bool inflateGzipFile(const QString &gzippedFileName, const QString &decompressedFilename);
-} // namespace QGCZlib
+}


### PR DESCRIPTION
Return value of -5/Z_BUF_ERROR originally broke the while loop, but should really continue. Caused by larger file downloads