### PR TITLE
Docs: fix container build script command

### DIFF
--- a/docs/en/qgc-dev-guide/getting_started/container.md
+++ b/docs/en/qgc-dev-guide/getting_started/container.md
@@ -16,7 +16,7 @@ The main advantage of using the container is the usage of the `CMake` build syst
 To build the container using the script, run this command in the qgc root directory
 
 ```
-./deploy/docker/run-docker.sh
+./deploy/docker/run-docker-ubuntu.sh
 ```
 ### Manual
 if you want to Build using the container manually, then you first have to build the image.


### PR DESCRIPTION
script name is wrong

<!--- Title -->

Description
-----------
file name in the source is different than in the command

Test Steps
-----------


Checklist:
----------
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] [Review Contribution Guidelines](https://github.com/mavlink/qgroundcontrol/blob/master/.github/CONTRIBUTING.md).
- [x] [Review Code of Conduct](https://github.com/mavlink/qgroundcontrol/blob/master/.github/CODE_OF_CONDUCT.md).
- [x] I have tested my changes.

Related Issue
-----------
<!-- If any, please provide issue ID. -->


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.