### PR TITLE
Add crsf-bind button

### DIFF
--- a/src/AutoPilotPlugins/Common/RadioComponent.qml
+++ b/src/AutoPilotPlugins/Common/RadioComponent.qml
@@ -389,6 +389,14 @@ SetupPage {
                     }
 
                     QGCButton {
+                        text:       qsTr("CRSF Bind")
+                        onClicked:  mainWindow.showMessageDialog(qsTr("CRSF Bind"),
+                                                                 qsTr("Click Ok to place your CRSF receiver in the bind mode."),
+                                                                 Dialog.Ok | Dialog.Cancel,
+                                                                 function() { controller.crsfBindMode() })
+                    }
+
+                    QGCButton {
                         text:       qsTr("Copy Trims")
                         onClicked:  mainWindow.showMessageDialog(qsTr("Copy Trims"),
                                                                  qsTr("Center your sticks and move throttle all the way down, then press Ok to copy trims. After pressing Ok, reset the trims on your radio back to zero."),

--- a/src/AutoPilotPlugins/Common/RadioComponentController.cc
+++ b/src/AutoPilotPlugins/Common/RadioComponentController.cc
@@ -608,6 +608,11 @@ void RadioComponentController::spektrumBindMode(int mode)
     _vehicle->pairRX(0, mode);
 }
 
+void RadioComponentController::crsfBindMode()
+{
+    _vehicle->pairRX(1, 0);
+}
+
 /// @brief Validates the current settings against the calibration rules resetting values as necessary.
 void RadioComponentController::_validateCalibration(void)
 {

--- a/src/AutoPilotPlugins/Common/RadioComponentController.cc
+++ b/src/AutoPilotPlugins/Common/RadioComponentController.cc
@@ -605,12 +605,12 @@ void RadioComponentController::_setInternalCalibrationValuesFromParameters(void)
 
 void RadioComponentController::spektrumBindMode(int mode)
 {
-    _vehicle->pairRX(0, mode);
+    _vehicle->pairRX(RC_TYPE_SPEKTRUM, mode);
 }
 
 void RadioComponentController::crsfBindMode()
 {
-    _vehicle->pairRX(1, 0);
+    _vehicle->pairRX(RC_TYPE_CRSF, 0);
 }
 
 /// @brief Validates the current settings against the calibration rules resetting values as necessary.

--- a/src/AutoPilotPlugins/Common/RadioComponentController.h
+++ b/src/AutoPilotPlugins/Common/RadioComponentController.h
@@ -76,6 +76,7 @@ public:
     Q_ENUM(BindModes)
 
     Q_INVOKABLE void spektrumBindMode(int mode);
+    Q_INVOKABLE void crsfBindMode(void);
     Q_INVOKABLE void cancelButtonClicked(void);
     Q_INVOKABLE void skipButtonClicked(void);
     Q_INVOKABLE void nextButtonClicked(void);

--- a/src/MAVLink/CMakeLists.txt
+++ b/src/MAVLink/CMakeLists.txt
@@ -36,7 +36,7 @@ target_include_directories(MAVLink PUBLIC ${CMAKE_CURRENT_SOURCE_DIR})
 include(FetchContent)
 FetchContent_Declare(mavlink
         GIT_REPOSITORY https://github.com/mavlink/c_library_v2.git
-        GIT_TAG 052b8579f8aeb941f34cc9896af22cf1f38939b9
+        GIT_TAG 4db2f67156d996eae90ef437a73353468d850407
 )
 FetchContent_MakeAvailable(mavlink)
 


### PR DESCRIPTION
Adds crsf-bind button.
Based on: 
- https://github.com/PX4/PX4-Autopilot/pull/23294
and
- https://github.com/mavlink/mavlink/pull/2162

![image](https://github.com/user-attachments/assets/249652b8-406d-40d4-ac36-902b3c710961)


Test Steps
-----------
The button successfully sets a CRSF (crossfire, ELRS, etc) receiver into bind mode