### PR TITLE
Check if there is a valid _activeVehical to not get a nullpointer exception

### DIFF
--- a/src/Joystick/Joystick.cc
+++ b/src/Joystick/Joystick.cc
@@ -569,7 +569,7 @@ void Joystick::_handleAxis()
             _rgAxisValues[axisIndex] = newAxisValue;
             emit rawAxisValueChanged(axisIndex, newAxisValue);
         }
-        if (_activeVehicle->joystickEnabled() && !_calibrationMode && _calibrated) {
+        if (_activeVehicle && _activeVehicle->joystickEnabled() && !_calibrationMode && _calibrated) {
             int     axis = _rgFunctionAxis[rollFunction];
             float   roll = _adjustRange(_rgAxisValues[axis],    _rgCalibration[axis], _deadband);
 


### PR DESCRIPTION
Check to see if activeVehicle is null as that could cause a null exception when we don't.

Description
-----------
If a null vehicle was given to a joystick on creation the start-pulling function would eventually cause a null exception when it got to the _handleAxis function because we check if _activeVehical has joystickEnabled but not if the _activeVehical null. 

Test Steps
-----------
1. Make a slot that waits for the joystickManager to send out that a new joystick have been connected
2. Make a Vehical that is null
3. Start polling on the newly connected joystick with the null Vehical
Before that, the program would crash because of a null pointer exception. Now it keeps running and allows users to test the joysticks's raw value output if they desire 

Checklist:
----------
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] [Review Contribution Guidelines](https://github.com/mavlink/qgroundcontrol/blob/master/.github/CONTRIBUTING.md).
- [x] [Review Code of Conduct](https://github.com/mavlink/qgroundcontrol/blob/master/.github/CODE_OF_CONDUCT.md).
- [x] I have tested my changes.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.