### PR TITLE
APMSensorIdDecoder: fix ID order for IIM42653

### DIFF
--- a/src/FirmwarePlugin/APM/APMSensorIdDecoder.qml
+++ b/src/FirmwarePlugin/APM/APMSensorIdDecoder.qml
@@ -89,12 +89,12 @@ QGCLabel {
         0x35: 'INS_ICM42605',
         0x36: 'INS_ICM40605',
         0x37: 'INS_IIM42652',
-        0x38: 'INS_IIM42653',
-        0x39: 'BMI270',
-        0x3A: 'INS_BMI085',
-        0x3B: 'INS_ICM42670',
-        0x3C: 'INS_ICM45686',
-        0x3D: 'INS_SCHA63T'
+        0x38: 'BMI270',
+        0x39: 'INS_BMI085',
+        0x3A: 'INS_ICM42670',
+        0x3B: 'INS_ICM45686',
+        0x3C: 'INS_SCHA63T',
+        0x3D: 'INS_IIM42653'
     }
 
     property var baroTypes: {


### PR DESCRIPTION
Moved INS_IIM42653 to the end of the devid list

I jumped the gun with https://github.com/mavlink/qgroundcontrol/pull/11995

Pending https://github.com/ArduPilot/ardupilot/pull/28383