### PR TITLE
Add Close Application Button in Select Tool Menu for Touch-Only Devices

### DIFF
--- a/src/UI/MainRootWindow.qml
+++ b/src/UI/MainRootWindow.qml
@@ -334,6 +334,18 @@ ApplicationWindow {
                             }
                         }
 
+                        SubMenuButton {
+                            id:                 closeButton
+                            height:             toolSelectDialog._toolButtonHeight
+                            Layout.fillWidth:   true
+                            text:               qsTr("Close QGroundControl")
+                            onClicked: {
+                                if (mainWindow.allowViewSwitch()) {
+                                    mainWindow.finishCloseProcess()
+                                }
+                            }
+                        }
+
                         ColumnLayout {
                             width:                  innerLayout.width
                             spacing:                0


### PR DESCRIPTION
This commit introduces a "Close Application" button to the Select Tool menu in QGroundControl. The addition addresses the need for an accessible close option on touch-only devices that lack a physical keyboard (e.g., Steam Deck). By integrating this button directly into the interface, users can easily exit the application without requiring keyboard input, improving usability on mobile and handheld platforms.

<!--- Title -->

Description
-----------
<!--- Describe your changes in detail. -->

Test Steps
-----------
<!-- Describe the steps to reproduce. -->

Checklist:
----------
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [ ] [Review Contribution Guidelines](https://github.com/mavlink/qgroundcontrol/blob/master/.github/CONTRIBUTING.md).
- [ ] [Review Code of Conduct](https://github.com/mavlink/qgroundcontrol/blob/master/.github/CODE_OF_CONDUCT.md).
- [ ] I have tested my changes.

Related Issue
-----------
<!-- If any, please provide issue ID. -->


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.