### PR TITLE
Ready Arm status added in MockLink for remote ID

### DIFF
--- a/src/Comms/MockLink/MockLink.cc
+++ b/src/Comms/MockLink/MockLink.cc
@@ -237,6 +237,7 @@ void MockLink::_run1HzTasks(void)
             _sendBatteryStatus();
             _sendSysStatus();
             _sendADSBVehicles();
+            _sendRemoteIDArmStatus();
             if (!qgcApp()->runningUnitTests()) {
                 // Sending RC Channels during unit test breaks RC tests which does it's own RC simulation
                 _sendRCChannels();
@@ -1866,6 +1867,18 @@ void MockLink::_sendGeneralMetaData(void)
                                              100,                        // general_metadata_file_crc
                                              metaDataURI);
     respondWithMavlinkMessage(responseMsg);
+}
+
+void MockLink::_sendRemoteIDArmStatus()
+{
+    mavlink_message_t   msg;
+    QString err = "No Error";
+    mavlink_msg_open_drone_id_arm_status_pack(_vehicleSystemId,
+                                              MAV_COMP_ID_ODID_TXRX_1,
+                                              &msg,
+                                              MAV_ODID_ARM_STATUS_GOOD_TO_ARM,
+                                              err.toStdString().c_str());
+    respondWithMavlinkMessage(msg);
 }
 
 void MockLink::simulateConnectionRemoved(void)

--- a/src/Comms/MockLink/MockLink.h
+++ b/src/Comms/MockLink/MockLink.h
@@ -257,6 +257,7 @@ private:
     void _sendADSBVehicles              (void);
     void _moveADSBVehicle               (int vehicleIndex);
     void _sendGeneralMetaData           (void);
+    void _sendRemoteIDArmStatus         (void);
 
     static MockLink* _startMockLinkWorker(QString configName, MAV_AUTOPILOT firmwareType, MAV_TYPE vehicleType, bool sendStatusText, MockConfiguration::FailureMode_t failureMode);
     static MockLink* _startMockLink(MockConfiguration* mockConfig);


### PR DESCRIPTION
# Remote ID Arm Status added in Mocklink 

Description
-----------
Support for remote ID in mock link added to test remote ID UI and other features

Test Steps
-----------
Application Settings -> Mock Link -> Choose any vehicle 

FlyView Page -> Remote ID should be visible

Checklist:
----------

- [x] [Review Contribution Guidelines](https://github.com/mavlink/qgroundcontrol/blob/master/.github/CONTRIBUTING.md).
- [x] [Review Code of Conduct](https://github.com/mavlink/qgroundcontrol/blob/master/.github/CODE_OF_CONDUCT.md).
- [x] I have tested my changes.

Related Issue
-----------
https://github.com/mavlink/qgroundcontrol/issues/12048
