### PR TITLE
Fix app name override in custom builds

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -436,7 +436,7 @@ elseif(LINUX)
 endif()
 
 add_compile_definitions(
-    QGC_APP_NAME="${CMAKE_PROJECT_NAME}"
+    QGC_APP_NAME="${QGC_APP_NAME}"
     QGC_ORG_NAME="${QGC_ORG_NAME}"
     QGC_ORG_DOMAIN="${QGC_ORG_DOMAIN}"
     QGC_APP_VERSION_STR="${QGC_APP_VERSION_STR}"


### PR DESCRIPTION
# Fix app name override in custom builds

Description
-----------
Changed the compile definition QGC_APP_NAME from ${CMAKE_PROJECT_NAME} to ${QGC_APP_NAME}, so that the app name will actually get overriden in custom builds. Haven't tested that non-custom builds still work, but according to CustomOptions.cmake in that case ${QGC_APP_NAME} will be the same as the default value of ${CMAKE_PROJECT_NAME}.

Checklist:
----------
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] [Review Contribution Guidelines](https://github.com/mavlink/qgroundcontrol/blob/master/.github/CONTRIBUTING.md).
- [x] [Review Code of Conduct](https://github.com/mavlink/qgroundcontrol/blob/master/.github/CODE_OF_CONDUCT.md).
- [ ] I have tested my changes.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.