### PR TITLE
Joystick: allow custom plugin to add and handle custom actions

### DIFF
--- a/src/API/QGCCorePlugin.h
+++ b/src/API/QGCCorePlugin.h
@@ -175,6 +175,12 @@ public:
     /// Returns a true if xml definition file of a providen camera name exists, and loads it to file argument, to allow definition files to be loaded from resources
     virtual bool getOfflineCameraDefinitionFile(const QString &cameraName, QFile &file) const { Q_UNUSED(cameraName); Q_UNUSED(file); return false; }
 
+    struct JoystickAction {
+        QString name;
+        bool canRepeat = false;
+    };
+    virtual QList<JoystickAction> joystickActions() const { return {}; }
+
     /// Returns the list of first run prompt ids which need to be displayed according to current settings
     Q_INVOKABLE QVariantList firstRunPromptsToShow() const;
 

--- a/src/Joystick/Joystick.cc
+++ b/src/Joystick/Joystick.cc
@@ -15,6 +15,7 @@
 #include "Vehicle.h"
 #include "MultiVehicleManager.h"
 #include "FirmwarePlugin.h"
+#include "QGCCorePlugin.h"
 #include "QGCLoggingCategory.h"
 #include "GimbalController.h"
 #include "QmlObjectListModel.h"
@@ -1042,6 +1043,7 @@ void Joystick::_executeButtonAction(const QString& action, bool buttonDown)
         if (buttonDown) emit landingGearRetract();
     } else {
         if (buttonDown && _activeVehicle) {
+            emit unknownAction(action);
             for (int i=0; i<_customActionManager.actions()->count(); i++) {
                 auto customAction = _customActionManager.actions()->value<CustomAction*>(i);
                 if (action == customAction->label()) {
@@ -1122,6 +1124,11 @@ void Joystick::_buildActionList(Vehicle* activeVehicle)
     _assignableButtonActions.append(new AssignableButtonAction(this, _buttonActionGripperRelease));
     _assignableButtonActions.append(new AssignableButtonAction(this, _buttonActionLandingGearDeploy));
     _assignableButtonActions.append(new AssignableButtonAction(this, _buttonActionLandingGearRetract));
+
+    const auto customActions = QGCCorePlugin::instance()->joystickActions();
+    for (const auto &action : customActions) {
+        _assignableButtonActions.append(new AssignableButtonAction(this, action.name, action.canRepeat));
+    }
 
     for (int i=0; i<_customActionManager.actions()->count(); i++) {
         auto customAction = _customActionManager.actions()->value<CustomAction*>(i);

--- a/src/Joystick/Joystick.h
+++ b/src/Joystick/Joystick.h
@@ -231,6 +231,7 @@ signals:
     void gripperAction              (GRIPPER_ACTIONS gripperAction);
     void landingGearDeploy          ();
     void landingGearRetract         ();
+    void unknownAction              (const QString &action);
 
 protected:
     void    _setDefaultCalibration  ();


### PR DESCRIPTION
Description
-----------
This allows custom plugin to respond to joystick actions with MAVLink commands whose parameters can change during runtime.

Checklist:
----------
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] [Review Contribution Guidelines](https://github.com/mavlink/qgroundcontrol/blob/master/.github/CONTRIBUTING.md).
- [x] [Review Code of Conduct](https://github.com/mavlink/qgroundcontrol/blob/master/.github/CODE_OF_CONDUCT.md).
- [x] I have tested my changes.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.