### PR TITLE
Add BoardID for Holybro Kakuteh7mini

### DIFF
--- a/src/VehicleSetup/FirmwareUpgradeController.cc
+++ b/src/VehicleSetup/FirmwareUpgradeController.cc
@@ -87,6 +87,7 @@ static QMap<int, QString> px4_board_name_map {
     {1048, "holybro_kakuteh7_default"},
     {1053, "holybro_kakuteh7v2_default"},
     {1054, "holybro_kakuteh7mini_default"},
+    {1058, "holybro_kakuteh7mini_default"},
     {1110, "jfb_jfb110_default"},
     {1123, "siyi_n7_default"},    
     {1124, "3dr_ctrl-zero-h7-oem-revg_default"},


### PR DESCRIPTION
Add BoardID for Holybro Kakuteh7mini to match the changes in  https://github.com/PX4/PX4-Autopilot/pull/23832 & https://github.com/PX4/PX4-Autopilot/pull/23922, allowing user to be able to flash firmware online in QGC with the new bootloader ID. 
