### PR TITLE
AudioOutput: Fix queue size and improve thread safety

### DIFF
--- a/src/Audio/AudioOutput.cc
+++ b/src/Audio/AudioOutput.cc
@@ -47,33 +47,6 @@ AudioOutput::AudioOutput(QObject *parent)
     , _engine(new QTextToSpeech(QStringLiteral("none"), this))
 {
     // qCDebug(AudioOutputLog) << Q_FUNC_INFO << this;
-
-    if (!QTextToSpeech::availableEngines().isEmpty()) {
-        if (_engine->setEngine(QString())) {
-            // Autoselect engine by priority
-            qCDebug(AudioOutputLog) << Q_FUNC_INFO << "engine:" << _engine->engine();
-            if (_engine->availableLocales().contains(QLocale("en_US"))) {
-                _engine->setLocale(QLocale("en_US"));
-            }
-
-            (void) connect(this, &AudioOutput::mutedChanged, [this](bool muted) {
-                qCDebug(AudioOutputLog) << Q_FUNC_INFO << "muted:" << muted;
-                (void) QMetaObject::invokeMethod(_engine, "setVolume", Qt::AutoConnection, muted ? 0. : 1.);
-            });
-        }
-    }
-
-#ifdef QT_DEBUG
-    (void) connect(_engine, &QTextToSpeech::stateChanged, [](QTextToSpeech::State state) {
-        qCDebug(AudioOutputLog) << Q_FUNC_INFO << "State:" << state;
-    });
-    (void) connect(_engine, &QTextToSpeech::errorOccurred, [](QTextToSpeech::ErrorReason reason, const QString &errorString) {
-        qCDebug(AudioOutputLog) << Q_FUNC_INFO << "Error: (" << reason << ") " << errorString;
-    });
-    (void) connect(_engine, &QTextToSpeech::volumeChanged, [](double volume) {
-        qCDebug(AudioOutputLog) << Q_FUNC_INFO << "volume:" << volume;
-    });
-#endif
 }
 
 AudioOutput::~AudioOutput()
@@ -90,115 +63,222 @@ void AudioOutput::init(Fact *mutedFact)
 {
     Q_CHECK_PTR(mutedFact);
 
+    if (_initialized) {
+        return;
+    }
+
+    if (QTextToSpeech::availableEngines().isEmpty()) {
+        qCWarning(AudioOutputLog) << "No available QTextToSpeech engines found.";
+        return;
+    }
+
+    // Autoselect engine by priority
+    if (!_engine->setEngine(QString())) {
+        qCWarning(AudioOutputLog) << "Failed to set the TTS engine.";
+        return;
+    }
+
+    (void) connect(_engine, &QTextToSpeech::engineChanged, [this](const QString &engine) {
+        qCDebug(AudioOutputLog) << "TTS Engine set to:" << engine;
+        const QLocale defaultLocale = QLocale("en_US");
+        if (_engine->availableLocales().contains(defaultLocale)) {
+            _engine->setLocale(defaultLocale);
+        }
+    });
+
+    (void) connect(_engine, &QTextToSpeech::aboutToSynthesize, [this](qsizetype id) {
+        qCDebug(AudioOutputLog) << "TTS About To Synthesize ID:" << id;
+        _textQueueSize--;
+        qCDebug(AudioOutputLog) << "Queue Size:" << _textQueueSize;
+    });
+
     (void) connect(mutedFact, &Fact::valueChanged, this, [this](QVariant value) {
         setMuted(value.toBool());
     });
 
+    if (AudioOutputLog().isDebugEnabled()) {
+        (void) connect(_engine, &QTextToSpeech::stateChanged, [this](QTextToSpeech::State state) {
+            qCDebug(AudioOutputLog) << "TTS State changed to:" << state;
+        });
+        (void) connect(_engine, &QTextToSpeech::errorOccurred, [](QTextToSpeech::ErrorReason reason, const QString &errorString) {
+            qCDebug(AudioOutputLog) << "TTS Error occurred. Reason:" << reason << ", Message:" << errorString;
+        });
+        (void) connect(_engine, &QTextToSpeech::localeChanged, [](const QLocale &locale) {
+            qCDebug(AudioOutputLog) << "TTS Locale change to:" << locale;
+        });
+        (void) connect(_engine, &QTextToSpeech::volumeChanged, [](double volume) {
+            qCDebug(AudioOutputLog) << "TTS Volume changed to:" << volume;
+        });
+        (void) connect(_engine, &QTextToSpeech::sayingWord, [](const QString &word, qsizetype id, qsizetype start, qsizetype length) {
+            qCDebug(AudioOutputLog) << "TTS Saying:" << word << "ID:" << id << "Start:" << start << "Length:" << length;
+        });
+    }
+
     setMuted(mutedFact->rawValue().toBool());
+    _initialized = true;
+
+    qCDebug(AudioOutputLog) << "AudioOutput initialized with muted state:" << _muted;
 }
 
-void AudioOutput::say(const QString &text, AudioOutput::TextMods textMods)
+void AudioOutput::setMuted(bool muted)
 {
+    if (_muted.exchange(muted) != muted) {
+        (void) QMetaObject::invokeMethod(_engine, "setVolume", Qt::AutoConnection, muted ? 0.0 : 1.0);
+        qCDebug(AudioOutputLog) << "AudioOutput muted state set to:" << muted;
+    }
+}
+
+void AudioOutput::say(const QString &text, TextMods textMods)
+{
+    if (!_initialized) {
+        qCWarning(AudioOutputLog) << "AudioOutput not initialized. Call init() before using say().";
+        return;
+    }
+
     if (_muted) {
         return;
     }
 
     if (!_engine->engineCapabilities().testFlag(QTextToSpeech::Capability::Speak)) {
-        qCWarning(AudioOutputLog) << Q_FUNC_INFO << "Speech Not Supported:" << text;
+        qCWarning(AudioOutputLog) << "Speech Not Supported:" << text;
         return;
     }
 
-    if (_textQueueSize > kMaxTextQueueSize) {
+    if (_textQueueSize >= kMaxTextQueueSize) {
         (void) QMetaObject::invokeMethod(_engine, "stop", Qt::AutoConnection, QTextToSpeech::BoundaryHint::Default);
+        _textQueueSize = 0;
+        qCWarning(AudioOutputLog) << "Text queue exceeded maximum size. Stopped current speech.";
     }
 
-    QString outText = AudioOutput::fixTextMessageForAudio(text);
+    QString outText = _fixTextMessageForAudio(text);
 
-    if (textMods.testFlag(AudioOutput::TextMod::Translate)) {
-        outText = QCoreApplication::translate("AudioOutput", outText.toStdString().c_str());
+    if (textMods.testFlag(TextMod::Translate)) {
+        outText = tr("%1").arg(outText);
     }
 
-    qsizetype index = -1;
-    (void) QMetaObject::invokeMethod(_engine, "enqueue", Qt::AutoConnection, qReturnArg(index), outText);
-    if (index != -1) {
-        _textQueueSize = index;
+    qsizetype index;
+    if (QMetaObject::invokeMethod(_engine, "enqueue", Qt::AutoConnection, qReturnArg(index), outText)) {
+        if (index != -1) {
+            _textQueueSize++;
+            qCDebug(AudioOutputLog) << "Enqueued text with index:" << index << ", Queue Size:" << _textQueueSize;
+        }
+    } else {
+        qCWarning(AudioOutputLog) << "Failed to invoke Enqueue method.";
     }
 }
 
-bool AudioOutput::getMillisecondString(const QString &string, QString &match, int &number)
+QString AudioOutput::_fixTextMessageForAudio(const QString &string)
 {
-    static const QRegularExpression regexp("([0-9]+ms)");
+    QString result = string;
+    result = _replaceAbbreviations(result);
+    result = _replaceNegativeSigns(result);
+    result = _replaceDecimalPoints(result);
+    result = _replaceMeters(result);
+    result = _convertMilliseconds(result);
+    return result;
+}
 
-    bool result = false;
+QString AudioOutput::_replaceAbbreviations(const QString &input)
+{
+    QString output = input;
 
-    for (const QRegularExpressionMatch &tempMatch : regexp.globalMatch(string)) {
-        if (tempMatch.hasMatch()) {
-            match = tempMatch.captured(0);
-            number = tempMatch.captured(0).replace("ms", "").toInt();
-            result = true;
-            break;
+    const QStringList wordList = input.split(' ', Qt::SkipEmptyParts);
+    for (const QString &word : wordList) {
+        const QString upperWord = word.toUpper();
+        if (_textHash.contains(upperWord)) {
+            (void) output.replace(word, _textHash.value(upperWord));
         }
+    }
+
+    return output;
+}
+
+QString AudioOutput::_replaceNegativeSigns(const QString &input)
+{
+    static const QRegularExpression negNumRegex(QStringLiteral("-\\s*(?=\\d)"));
+    Q_ASSERT(negNumRegex.isValid());
+
+    QString output = input;
+    (void) output.replace(negNumRegex, "negative ");
+    return output;
+}
+
+QString AudioOutput::_replaceDecimalPoints(const QString &input)
+{
+    static const QRegularExpression realNumRegex(QStringLiteral("([0-9]+)(\\.)([0-9]+)"));
+    Q_ASSERT(realNumRegex.isValid());
+
+    QString output = input;
+    QRegularExpressionMatch realNumRegexMatch = realNumRegex.match(output);
+    while (realNumRegexMatch.hasMatch()) {
+        if (!realNumRegexMatch.captured(2).isNull()) {
+            (void) output.replace(realNumRegexMatch.capturedStart(2), realNumRegexMatch.capturedEnd(2) - realNumRegexMatch.capturedStart(2), QStringLiteral(" point "));
+        }
+        realNumRegexMatch = realNumRegex.match(output);
+    }
+
+    return output;
+}
+
+QString AudioOutput::_replaceMeters(const QString &input)
+{
+    static const QRegularExpression realNumMeterRegex(QStringLiteral("[0-9]*\\.?[0-9]\\s?(m)([^A-Za-z]|$)"));
+    Q_ASSERT(realNumMeterRegex.isValid());
+
+    QString output = input;
+    QRegularExpressionMatch realNumMeterRegexMatch = realNumMeterRegex.match(output);
+    while (realNumMeterRegexMatch.hasMatch()) {
+        if (!realNumMeterRegexMatch.captured(1).isNull()) {
+            (void) output.replace(realNumMeterRegexMatch.capturedStart(1), realNumMeterRegexMatch.capturedEnd(1) - realNumMeterRegexMatch.capturedStart(1), QStringLiteral(" meters"));
+        }
+        realNumMeterRegexMatch = realNumMeterRegex.match(output);
+    }
+
+    return output;
+}
+
+QString AudioOutput::_convertMilliseconds(const QString &input)
+{
+    QString result = input;
+
+    QString match;
+    int number;
+    if (_getMillisecondString(input, match, number) && (number >= 1000)) {
+        QString newNumber;
+        if (number < 60000) {
+            const int seconds = number / 1000;
+            const int ms = number - (seconds * 1000);
+            newNumber = QStringLiteral("%1 second%2").arg(seconds).arg(seconds > 1 ? "s" : "");
+            if (ms > 0) {
+                (void) newNumber.append(QStringLiteral(" and %1 millisecond").arg(ms));
+            }
+        } else {
+            const int minutes = number / 60000;
+            const int seconds = (number - (minutes * 60000)) / 1000;
+            newNumber = QStringLiteral("%1 minute%2").arg(minutes).arg(minutes > 1 ? "s" : "");
+            if (seconds > 0) {
+                (void) newNumber.append(QStringLiteral(" and %1 second%2").arg(seconds).arg(seconds > 1 ? "s" : ""));
+            }
+        }
+        (void) result.replace(match, newNumber);
     }
 
     return result;
 }
 
-QString AudioOutput::fixTextMessageForAudio(const QString &string)
+bool AudioOutput::_getMillisecondString(const QString &string, QString &match, int &number)
 {
-    QString result = string;
+    static const QRegularExpression msRegex("((?<number>[0-9]+)ms)");
+    Q_ASSERT(msRegex.isValid());
 
-    for (const QString &word: string.split(' ', Qt::SkipEmptyParts)) {
-        if (_textHash.contains(word.toUpper())) {
-            result.replace(word, _textHash.value(word.toUpper()));
-        }
-    }
+    bool result = false;
 
-    // Convert negative numbers
-    static const QRegularExpression negNumRegex(QStringLiteral("(-)[0-9]*\\.?[0-9]"));
-    QRegularExpressionMatch negNumRegexMatch = negNumRegex.match(result);
-    while (negNumRegexMatch.hasMatch()) {
-        if (!negNumRegexMatch.captured(1).isNull()) {
-            result.replace(negNumRegexMatch.capturedStart(1), negNumRegexMatch.capturedEnd(1) - negNumRegexMatch.capturedStart(1), QStringLiteral(" negative "));
-        }
-        negNumRegexMatch = negNumRegex.match(result);
-    }
-
-    // Convert real number with decimal point
-    static const QRegularExpression realNumRegex(QStringLiteral("([0-9]+)(\\.)([0-9]+)"));
-    QRegularExpressionMatch realNumRegexMatch = realNumRegex.match(result);
-    while (realNumRegexMatch.hasMatch()) {
-        if (!realNumRegexMatch.captured(2).isNull()) {
-            result.replace(realNumRegexMatch.capturedStart(2), realNumRegexMatch.capturedEnd(2) - realNumRegexMatch.capturedStart(2), QStringLiteral(" point "));
-        }
-        realNumRegexMatch = realNumRegex.match(result);
-    }
-
-    // Convert meter postfix after real number
-    static const QRegularExpression realNumMeterRegex(QStringLiteral("[0-9]*\\.?[0-9]\\s?(m)([^A-Za-z]|$)"));
-    QRegularExpressionMatch realNumMeterRegexMatch = realNumMeterRegex.match(result);
-    while (realNumMeterRegexMatch.hasMatch()) {
-        if (!realNumMeterRegexMatch.captured(1).isNull()) {
-            result.replace(realNumMeterRegexMatch.capturedStart(1), realNumMeterRegexMatch.capturedEnd(1) - realNumMeterRegexMatch.capturedStart(1), QStringLiteral(" meters"));
-        }
-        realNumMeterRegexMatch = realNumMeterRegex.match(result);
-    }
-
-    QString match;
-    int number;
-    if (getMillisecondString(string, match, number) && (number > 1000)) {
-        QString newNumber;
-        if (number < 60000) {
-            const int seconds = number / 1000;
-            newNumber = QStringLiteral("%1 second%2").arg(seconds).arg(seconds > 1 ? "s" : "");
-        } else {
-            const int minutes = number / 60000;
-            const int seconds = (number - (minutes * 60000)) / 1000;
-            newNumber = QStringLiteral("%1 minute%2").arg(minutes).arg(minutes > 1 ? "s" : "");
-            if (seconds) {
-                (void) newNumber.append(QStringLiteral(" and %1 second%2").arg(seconds).arg(seconds > 1 ? "s" : ""));
-            }
-        }
-        result.replace(match, newNumber);
+    QRegularExpressionMatch regexpMatch = msRegex.match(string);
+    if (regexpMatch.hasMatch()) {
+        match = regexpMatch.captured(0);
+        const QString numberStr = regexpMatch.captured("number");
+        number = numberStr.toInt();
+        result = true;
     }
 
     return result;

--- a/test/Audio/AudioOutputTest.cc
+++ b/test/Audio/AudioOutputTest.cc
@@ -12,23 +12,24 @@
 
 #include <QtTest/QTest>
 
-AudioOutputTest::AudioOutputTest(void)
+void AudioOutputTest::_testSpokenReplacements()
 {
-
-}
-
-void AudioOutputTest::_testSpokenReplacements(void)
-{
-    QString result = AudioOutput::fixTextMessageForAudio(QStringLiteral("-10.5m, -10.5m. -10.5 m"));
-    QCOMPARE(result, QStringLiteral(" negative 10 point 5 meters,  negative 10 point 5 meters.  negative 10 point 5  meters"));
-    result = AudioOutput::fixTextMessageForAudio(QStringLiteral("-10m -10 m"));
-    QCOMPARE(result, QStringLiteral(" negative 10 meters  negative 10  meters"));
-    result = AudioOutput::fixTextMessageForAudio(QStringLiteral("foo -10m -10 m bar"));
-    QCOMPARE(result, QStringLiteral("foo  negative 10 meters  negative 10  meters bar"));
-    result = AudioOutput::fixTextMessageForAudio(QStringLiteral("-foom"));
+    QString result = AudioOutput::_fixTextMessageForAudio(QStringLiteral("-10.5m, -10.5m. -10.5 m"));
+    QCOMPARE(result, QStringLiteral("negative 10 point 5 meters, negative 10 point 5 meters. negative 10 point 5  meters"));
+    result = AudioOutput::_fixTextMessageForAudio(QStringLiteral("-10m -10 m"));
+    QCOMPARE(result, QStringLiteral("negative 10 meters negative 10  meters"));
+    result = AudioOutput::_fixTextMessageForAudio(QStringLiteral("foo -10m -10 m bar"));
+    QCOMPARE(result, QStringLiteral("foo negative 10 meters negative 10  meters bar"));
+    result = AudioOutput::_fixTextMessageForAudio(QStringLiteral("-foom"));
     QCOMPARE(result, QStringLiteral("-foom"));
-    result = AudioOutput::fixTextMessageForAudio(QStringLiteral("10 moo"));
+    result = AudioOutput::_fixTextMessageForAudio(QStringLiteral("10 moo"));
     QCOMPARE(result, QStringLiteral("10 moo"));
-    result = AudioOutput::fixTextMessageForAudio(QStringLiteral("10moo"));
+    result = AudioOutput::_fixTextMessageForAudio(QStringLiteral("10moo"));
     QCOMPARE(result, QStringLiteral("10moo"));
+    result = AudioOutput::_fixTextMessageForAudio(QStringLiteral("10ms"));
+    QCOMPARE(result, QStringLiteral("10ms"));
+    result = AudioOutput::_fixTextMessageForAudio(QStringLiteral("1000ms"));
+    QCOMPARE(result, QStringLiteral("1 second"));
+    result = AudioOutput::_fixTextMessageForAudio(QStringLiteral("1001ms"));
+    QCOMPARE(result, QStringLiteral("1 second and 1 millisecond"));
 }

--- a/test/Audio/AudioOutputTest.h
+++ b/test/Audio/AudioOutputTest.h
@@ -15,9 +15,6 @@ class AudioOutputTest : public UnitTest
 {
     Q_OBJECT
 
-public:
-    AudioOutputTest(void);
-
 private slots:
-    void _testSpokenReplacements(void);
+    void _testSpokenReplacements();
 };


### PR DESCRIPTION
The index of the internal queue doesn't actually decrement as expected based on documentation, so use connections to correct queue size.
Use atomics for thread safety
Remove unnecessary muted signal