### PR TITLE
Bugfix for racy crash on opening bad serial port

### DIFF
--- a/src/Comms/SerialLink.cc
+++ b/src/Comms/SerialLink.cc
@@ -171,8 +171,6 @@ bool SerialLink::_hardwareConnect(QSerialPort::SerialPortError& error, QString& 
 
     _port = new QSerialPort(_serialConfig->portName(), this);
 
-    QObject::connect(_port, &QSerialPort::errorOccurred, this, &SerialLink::linkError);
-    QObject::connect(_port, &QIODevice::readyRead, this, &SerialLink::_readBytes);
 
     // After the bootloader times out, it still can take a second or so for the Pixhawk USB driver to come up and make
     // the port available for open. So we retry a few times to wait for it.
@@ -215,6 +213,9 @@ bool SerialLink::_hardwareConnect(QSerialPort::SerialPortError& error, QString& 
     _port->setParity       (static_cast<QSerialPort::Parity>       (_serialConfig->parity()));
 
     emit connected();
+
+    QObject::connect(_port, &QSerialPort::errorOccurred, this, &SerialLink::linkError);
+    QObject::connect(_port, &QIODevice::readyRead, this, &SerialLink::_readBytes);
 
     qCDebug(SerialLinkLog) << "Connection SeriaLink: " << "with settings" << _serialConfig->portName()
                            << _serialConfig->baud() << _serialConfig->dataBits() << _serialConfig->parity() << _serialConfig->stopBits();


### PR DESCRIPTION
<!--- Title -->
To reproduce: on linux, try to connect to an existing /dev/ttySX that is not a valid serial port (preexisting ttys?)


Crash happens like this:
- Open an existing port that triggers on open a QSerialPort::ResourceError (stock /dev/ttySX on my end)
- Signal QSerialPort::errorOccurred
- Slot SerialLink::linkError
- LinkInterface::_connectionRemoved
- SerialLink::disconnect => set _port = null
- On retry, at [https://github.com/unjambonakap/qgroundcontrol/blob/aacb664bffc2baa47c6f6a8ec9a224149fd06977/src/Comms/SerialLink.cc#L182], crashes because _port == null

-----------
<!--- Describe your changes in detail. -->

Simply moves the connection of signals (readyRead and errorOccurred) until the serial port's configuration is finished.

Note: I'm guessing that should data arrive in between port opening and connection of the readyRead() signal, it does not matter since it's the event loop stuff that triggers the readyRead()