### PR TITLE
Fix crash on startup for older Android devices

### DIFF
--- a/android/src/org/mavlink/qgroundcontrol/QGCUsbSerialManager.java
+++ b/android/src/org/mavlink/qgroundcontrol/QGCUsbSerialManager.java
@@ -106,13 +106,15 @@ public class QGCUsbSerialManager {
         filter.addAction(BluetoothDevice.ACTION_ACL_CONNECTED);
         filter.addAction(BluetoothDevice.ACTION_ACL_DISCONNECTED);
 
-        int flags = 0;
-        if (android.os.Build.VERSION.SDK_INT >= android.os.Build.VERSION_CODES.TIRAMISU) {
-            flags = Context.RECEIVER_NOT_EXPORTED;
-        }
-
         try {
-            context.registerReceiver(usbReceiver, filter, flags);
+            if (android.os.Build.VERSION.SDK_INT >=
+                android.os.Build.VERSION_CODES.TIRAMISU) {
+                int flags = Context.RECEIVER_NOT_EXPORTED;
+                context.registerReceiver(usbReceiver, filter, flags);
+            } else {
+                context.registerReceiver(usbReceiver, filter);
+            }
+
             QGCLogger.i(TAG, "BroadcastReceiver registered successfully.");
         } catch (Exception e) {
             QGCLogger.e(TAG, "Failed to register BroadcastReceiver", e);


### PR DESCRIPTION
# Fix crash on startup for older Android devices

Description
-----------
The overload to the registerReceiver method with a flags parameter was introduced in API level 26 (Android 8.0), which leads to an instant crash on startup on devices running older versions of Android. Adjusted the implementation to use the previous signature of registerReceiver on devices with API levels below 26.

Checklist:
----------
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [X] [Review Contribution Guidelines](https://github.com/mavlink/qgroundcontrol/blob/master/.github/CONTRIBUTING.md).
- [X] [Review Code of Conduct](https://github.com/mavlink/qgroundcontrol/blob/master/.github/CODE_OF_CONDUCT.md).
- [X] I have tested my changes.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.