### PR TITLE
Improve flexibility in Android custom builds

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -416,12 +416,38 @@ elseif(ANDROID)
     endif()
     set(ANDROID_VERSION_CODE "${ANDROID_PLATFORM_ARCHITECTURE_CODE}${PROJECT_VERSION_MAJOR}${PROJECT_VERSION_MINOR}")
 
+    if(NOT QGC_CUSTOM_BUILD)
+        set(QGC_ANDROID_PACKAGE_SOURCE_DIR ${CMAKE_SOURCE_DIR}/android)
+    else()
+        set(CUSTOM_ANDROID_DIR "${CMAKE_SOURCE_DIR}/custom/android")
+        if(EXISTS "${CUSTOM_ANDROID_DIR}")
+            file(GLOB CUSTOM_ANDROID_FILES "${CUSTOM_ANDROID_DIR}/*")
+            if(CUSTOM_ANDROID_FILES)
+                message(STATUS "Custom Android package template found. Overlaying custom files...")
+                set(DEFAULT_ANDROID_DIR "${CMAKE_SOURCE_DIR}/android")
+                set(FINAL_ANDROID_DIR "${CMAKE_BINARY_DIR}/custom/android")
+                file(COPY "${DEFAULT_ANDROID_DIR}/." DESTINATION "${FINAL_ANDROID_DIR}")
+                file(COPY "${CUSTOM_ANDROID_DIR}/." DESTINATION "${FINAL_ANDROID_DIR}")
+                set_property(DIRECTORY APPEND PROPERTY CMAKE_CONFIGURE_DEPENDS
+                                "${DEFAULT_ANDROID_DIR}/"
+                                "${CUSTOM_ANDROID_DIR}/"
+                            )
+                set(QGC_ANDROID_PACKAGE_SOURCE_DIR "${FINAL_ANDROID_DIR}" CACHE STRING "Path to a custom Android package template" FORCE)
+                message(STATUS "Android package template path will be set to: ${QGC_ANDROID_PACKAGE_SOURCE_DIR}")
+            else()
+                message(STATUS "Custom Android package template empty. Using default.")
+            endif()
+        else()
+            message(STATUS "No custom Android package template found. Using default.")
+        endif()
+    endif()
+
     set_target_properties(${PROJECT_NAME}
         PROPERTIES
             # QT_ANDROID_ABIS ${ANDROID_ABI}
             QT_ANDROID_MIN_SDK_VERSION 25
             QT_ANDROID_TARGET_SDK_VERSION 35
-            QT_ANDROID_PACKAGE_SOURCE_DIR ${CMAKE_SOURCE_DIR}/android
+            QT_ANDROID_PACKAGE_SOURCE_DIR "${QGC_ANDROID_PACKAGE_SOURCE_DIR}"
             QT_ANDROID_VERSION_NAME ${CMAKE_PROJECT_VERSION}
             QT_ANDROID_VERSION_CODE ${ANDROID_VERSION_CODE}
             # QT_QML_ROOT_PATH ${CMAKE_SOURCE_DIR}

--- a/custom-example/android/AndroidManifest.xml
+++ b/custom-example/android/AndroidManifest.xml
@@ -1,0 +1,109 @@
+<?xml version="1.0"?>
+<manifest xmlns:android="http://schemas.android.com/apk/res/android"
+    package="org.mavlink.qgroundcontrol"
+    android:installLocation="auto"
+    android:versionCode="-- %%INSERT_VERSION_CODE%% --"
+    android:versionName="-- %%INSERT_VERSION_NAME%% --">
+
+    <supports-screens
+        android:anyDensity="true"
+        android:largeScreens="true"
+        android:normalScreens="true"
+        android:smallScreens="true" />
+
+    <!-- %%INSERT_PERMISSIONS -->
+
+    <uses-permission android:name="android.permission.USB_PERMISSION" />
+    <!-- Need MulticastLock to receive broadcast UDP packets -->
+    <uses-permission android:name="android.permission.CHANGE_WIFI_MULTICAST_STATE" />
+    <!-- Needed to keep working while 'asleep' -->
+    <uses-permission android:name="android.permission.WAKE_LOCK" />
+
+    <!-- %%INSERT_FEATURES -->
+
+    <uses-feature android:name="android.hardware.audio.output" android:required="false" />
+    <uses-feature android:name="android.hardware.bluetooth" android:required="false" />
+    <uses-feature android:name="android.hardware.camera.any" android:required="false" />
+    <uses-feature android:name="android.hardware.location" android:required="false" />
+    <uses-feature android:name="android.hardware.location.gps" android:required="false" />
+    <uses-feature android:name="android.hardware.location.network" android:required="false" />
+    <uses-feature android:name="android.hardware.usb.host" android:required="false" />
+    <uses-feature android:name="android.hardware.wifi" android:required="false" />
+
+    <application
+        android:name="org.qtproject.qt.android.bindings.QtApplication"
+        android:hardwareAccelerated="true"
+        android:label="Custom QGroundControl"
+        android:requestLegacyExternalStorage="true"
+        android:allowBackup="true"
+        android:fullBackupOnly="false"
+        android:icon="@drawable/icon"
+        android:usesCleartextTraffic="true"
+        android:networkSecurityConfig="@xml/network_security_config">
+        <!-- android:theme="@style/AppTheme" -->
+
+        <!-- <meta-data android:name="android.app.system_libs_prefix" android:value="/system/lib/" /> -->
+
+        <activity
+            android:name="org.mavlink.qgroundcontrol.QGCActivity"
+            android:configChanges="orientation|uiMode|screenLayout|screenSize|smallestScreenSize|layoutDirection|locale|fontScale|keyboard|keyboardHidden|navigation|mcc|mnc|density"
+            android:label="Custom QGroundControl"
+            android:launchMode="singleTop"
+            android:screenOrientation="sensorLandscape"
+            android:exported="true">
+
+            <intent-filter>
+                <action android:name="android.intent.action.MAIN" />
+                <category android:name="android.intent.category.LAUNCHER" />
+            </intent-filter>
+            <intent-filter>
+                <action android:name="android.hardware.usb.action.USB_DEVICE_ATTACHED" />
+                <action android:name="android.hardware.usb.action.USB_DEVICE_DETACHED" />
+                <action android:name="android.bluetooth.device.action.ACL_CONNECTED" />
+                <action android:name="android.bluetooth.device.action.ACL_DISCONNECTED" />
+                <!-- TODO: CMake configure xml file -->
+                <!-- %%QGC_INSERT_ACTIVITY_INTENT_FILTER -->
+            </intent-filter>
+
+            <!-- %%QGC_INSERT_ACTIVITY_META_DATA -->
+            <meta-data
+                android:name="android.hardware.usb.action.USB_DEVICE_ATTACHED"
+                android:resource="@xml/device_filter" />
+            <meta-data
+                android:name="android.hardware.usb.action.USB_DEVICE_DETACHED"
+                android:resource="@xml/device_filter" />
+
+            <meta-data
+                android:name="android.app.lib_name"
+                android:value="-- %%INSERT_APP_LIB_NAME%% --" />
+            <meta-data
+                android:name="android.app.arguments"
+                android:value="-- %%INSERT_APP_ARGUMENTS%% --" />
+            <meta-data
+                android:name="android.app.extract_android_style"
+                android:value="minimal" />
+            <meta-data
+                android:name="android.app.splash_screen_drawable"
+                android:resource="@drawable/splashscreen" />
+            <!-- <meta-data android:name="android.app.splash_screen_drawable_portrait" -->
+            <!-- <meta-data android:name="android.app.splash_screen_drawable_landscape" -->
+            <meta-data
+                android:name="android.app.splash_screen_sticky"
+                android:value="false" />
+            <!-- <meta-data android:name="android.app.background_running" -->
+            <!-- <meta-data android:name="android.app.trace_location" -->
+        </activity>
+
+        <provider
+            android:name="androidx.core.content.FileProvider"
+            android:authorities="${applicationId}.qtprovider"
+            android:exported="false"
+            android:grantUriPermissions="true">
+            <meta-data
+                android:name="android.support.FILE_PROVIDER_PATHS"
+                android:resource="@xml/qtprovider_paths" />
+        </provider>
+
+    </application>
+
+</manifest>


### PR DESCRIPTION
# Improve flexibility in Android custom builds

Description
-----------
Modified the build system to prioritize files under custom/android/ over android/ for Android deployment in custom builds.

If custom/android/ exists and contains files, these are overlaid onto the default android/ files, creating a combined Android package deployment template in the build directory. This enables customization of any aspect of the Android deployment in custom builds without modifying the upstream android/ directory. Additionally, any changes in either directory will trigger the CMake configuration step in order to update the combined directory.

This change also restores support for the custom Android icons under custom/android/, which had been disabled during the transition to CMake.

Additional note:
New CMake properties for Android deployment (including QT_ANDROID_APP_NAME, QT_ANDROID_APP_ICON, and QT_ANDROID_PACKAGE_NAME) are being added to Qt, which will streamline the more basic aspects of Android deployment customization even further. But this current solution will probably remain useful for cases where more extensive customization is required.

Checklist:
----------
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [X] [Review Contribution Guidelines](https://github.com/mavlink/qgroundcontrol/blob/master/.github/CONTRIBUTING.md).
- [X] [Review Code of Conduct](https://github.com/mavlink/qgroundcontrol/blob/master/.github/CODE_OF_CONDUCT.md).
- [X] I have tested my changes.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.