### PR TITLE
Added missing include qapplicationstatic.h in MAVLinkProtocol

### DIFF
--- a/src/Comms/MAVLinkProtocol.cc
+++ b/src/Comms/MAVLinkProtocol.cc
@@ -21,6 +21,7 @@
 #include <QtCore/QMetaType>
 #include <QtCore/QSettings>
 #include <QtCore/QStandardPaths>
+#include <QtCore/qapplicationstatic.h>
 
 QGC_LOGGING_CATEGORY(MAVLinkProtocolLog, "qgc.comms.mavlinkprotocol")
 


### PR DESCRIPTION
Added missing include qapplicationstatic.h in MAVLinkProtocol

Description
-----------
There is an issue with building qgroundcontrol after last update

Test Steps
-----------
Build after last update

Checklist:
----------
- [x] [Review Contribution Guidelines](https://github.com/mavlink/qgroundcontrol/blob/master/.github/CONTRIBUTING.md).
- [x] [Review Code of Conduct](https://github.com/mavlink/qgroundcontrol/blob/master/.github/CODE_OF_CONDUCT.md).
- [x] I have tested my changes.

Related Issue
-----------
https://github.com/mavlink/qgroundcontrol/issues/12154


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.