### PR TITLE
Vehicle: ignore severity of PX4 preflight messages

### DIFF
--- a/src/Vehicle/Vehicle.cc
+++ b/src/Vehicle/Vehicle.cc
@@ -3997,7 +3997,7 @@ void Vehicle::_textMessageReceived(MAV_COMPONENT componentid, MAV_SEVERITY sever
 
     bool skipSpoken = false;
     const bool ardupilotPrearm = text.startsWith(QStringLiteral("PreArm"));
-    const bool px4Prearm = text.startsWith(QStringLiteral("preflight"), Qt::CaseInsensitive) && (severity >= MAV_SEVERITY::MAV_SEVERITY_CRITICAL);
+    const bool px4Prearm = text.startsWith(QStringLiteral("preflight"), Qt::CaseInsensitive);
     if (ardupilotPrearm || px4Prearm) {
         auto eventData = _events.find(componentid);
         if (eventData != _events.end()) {


### PR DESCRIPTION
### Problem
We had someone change this condition out of confusion downstream and I figured out there is no message with emergency severity containing the string "preflight" in the current PX4 version. I can still check if and where they might have existed on older versions but I'd suggest to remove this since for the events it doesn't make sense to sort the text by severity.

### Solution
Ignore the severity. I think this was added originally such that emergency messages get output as yellow box and spoken even though they had the word "preflight" in it which usually resulted in a transparent box over the map.

### Test Steps
I have not tested the change but went through the existing cases and it shouldn't make a difference with the current version of PX4.

### Checklist:
- [ ] Check what messages ever fulfilled this condition.