### PR TITLE
CI: Continue if error on collecting dependencies

### DIFF
--- a/.github/workflows/android-windows.yml
+++ b/.github/workflows/android-windows.yml
@@ -55,6 +55,7 @@ jobs:
         run: |
           choco install --no-progress ninja pkgconfiglite -y
           choco install --no-progress cmake --installargs 'ADD_CMAKE_TO_PATH=System' --apply-install-arguments-to-dependencies
+        continue-on-error: true
 
       # - name: Set Up sccache
       #   uses: mozilla-actions/sccache-action@v0.0.5

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -54,6 +54,7 @@ jobs:
         run: |
           choco install --no-progress ninja pkgconfiglite -y
           choco install --no-progress cmake --installargs 'ADD_CMAKE_TO_PATH=System' --apply-install-arguments-to-dependencies
+        continue-on-error: true
 
       - name: Install Vulkan
         working-directory: ${{ runner.temp }}


### PR DESCRIPTION
Often fails here, even though this step may not even be necessary