### PR TITLE
Fix centering of inner circle in PhotoVideoControl

### DIFF
--- a/src/FlightMap/Widgets/PhotoVideoControl.qml
+++ b/src/FlightMap/Widgets/PhotoVideoControl.qml
@@ -165,7 +165,13 @@ Rectangle {
                     border.width:       3
 
                     Rectangle {
-                        anchors.centerIn:   parent
+                        // anchors.centerIn snaps to integer coordinates, which
+                        // depending on DPI can throw the centering off.
+                        // Setting alignWhenCentered to false avoids this issue.
+                        anchors {
+                            centerIn:           parent
+                            alignWhenCentered:  false
+                        }
                         width:              parent.width * (_isShootingInCurrentMode ? 0.5 : 0.75)
                         height:             width
                         radius:             _isShootingInCurrentMode ? 0 : width * 0.5


### PR DESCRIPTION
# Fix centering of inner circle in PhotoVideoControl

Description
-----------
The inner circle in the PhotoVideoControl widget was not always perfectly centered due to a bug in Qt's anchors.centerIn property (QTBUG-95224) which causes it to return integer positions instead of subpixel values.

Implemented a workaround by manually calculating the center position, ensuring exact centering regardless of parent and child dimensions and DPI scaling.

This fix should be reverted once QGC moves to Qt 6.8.1 or higher, where the underlying Qt bug has been resolved.

Related Qt bug: https://bugreports.qt.io/browse/QTBUG-95224

Qt fix commit: https://github.com/qt/qtdeclarative/commit/fd23a222efe189607eebd5c6782ca73eafa7080c

Checklist:
----------
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [X] [Review Contribution Guidelines](https://github.com/mavlink/qgroundcontrol/blob/master/.github/CONTRIBUTING.md).
- [X] [Review Code of Conduct](https://github.com/mavlink/qgroundcontrol/blob/master/.github/CODE_OF_CONDUCT.md).
- [X] I have tested my changes.

Related Issue
-----------
#10046


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.