### PR TITLE
CI: Prepare for GitHub's Removal of Ubuntu 20.04 Runner

### DIFF
--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -23,7 +23,7 @@ on:
 
 jobs:
   build:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
 
     strategy:
       matrix:
@@ -60,8 +60,8 @@ jobs:
 
       - name: Install Vulkan
         run: |
-          wget -qO - http://packages.lunarg.com/lunarg-signing-key-pub.asc | sudo apt-key add -
-          sudo wget -qO /etc/apt/sources.list.d/lunarg-vulkan-1.3.283-focal.list https://packages.lunarg.com/vulkan/1.3.283/lunarg-vulkan-1.3.283-focal.list
+          wget -qO- https://packages.lunarg.com/lunarg-signing-key-pub.asc | sudo tee /etc/apt/trusted.gpg.d/lunarg.asc
+          sudo wget -qO /etc/apt/sources.list.d/lunarg-vulkan-jammy.list http://packages.lunarg.com/vulkan/lunarg-vulkan-jammy.list
           sudo apt update
           sudo apt install vulkan-sdk
 
@@ -103,61 +103,6 @@ jobs:
 
       # - name: Build GStreamer
       #   uses: ./.github/actions/gstreamer
-
-      - name: Install GStreamer
-        uses: blinemedical/setup-gstreamer@v1
-        with:
-          version: ${{ env.GST_VERSION }}
-          # gstreamerOptions: |
-          #   --buildtype=release
-          #   --wrap-mode=forcefallback
-          #   --strip
-          #   -Dauto_features=disabled
-          #   -Dbase=enabled
-          #   -Ddoc=disabled
-          #   -Dexamples=disabled
-          #   -Dges=disabled
-          #   -Dgpl=enabled
-          #   -Dgst-examples=disabled
-          #   -Dgtk_doc=disabled
-          #   -Dlibav=enabled
-          #   -Dlibnice=disabled
-          #   -Dnls=disabled
-          #   -Dorc=enabled
-          #   -Dpython=disabled
-          #   -Dqt5=disabled
-          #   -Drtsp_server=disabled
-          #   -Dtests=disabled
-          #   -Dgst-plugins-base:app=enabled
-          #   -Dgst-plugins-base:gl=enabled
-          #   -Dgst-plugins-base:gl_api=opengl,gles2
-          #   -Dgst-plugins-base:gl_platform=glx,egl
-          #   -Dgst-plugins-base:gl_winsys=x11,egl,wayland
-          #   -Dgst-plugins-base:playback=enabled
-          #   -Dgst-plugins-base:tcp=enabled
-          #   -Dgst-plugins-base:x11=enabled
-          #   -Dgood=enabled
-          #   -Dgst-plugins-good:isomp4=enabled
-          #   -Dgst-plugins-good:matroska=enabled
-          #   -Dgst-plugins-good:qt-egl=enabled
-          #   -Dgst-plugins-good:qt-method=auto
-          #   -Dgst-plugins-good:qt-wayland=enabled
-          #   -Dgst-plugins-good:qt-x11=enabled
-          #   -Dgst-plugins-good:rtp=enabled
-          #   -Dgst-plugins-good:rtpmanager=enabled
-          #   -Dgst-plugins-good:rtsp=enabled
-          #   -Dgst-plugins-good:udp=enabled
-          #   -Dbad=enabled
-          #   -Dgst-plugins-bad:gl=enabled
-          #   -Dgst-plugins-bad:mpegtsdemux=enabled
-          #   -Dgst-plugins-bad:rtp=enabled
-          #   -Dgst-plugins-bad:sdp=enabled
-          #   -Dgst-plugins-bad:videoparsers=enabled
-          #   -Dgst-plugins-bad:wayland=enabled
-          #   -Dgst-plugins-bad:x11=enabled
-          #   -Dgst-plugins-bad:x265=enabled
-          #   -Dugly=enabled
-          #   -Dgst-plugins-ugly:x264=enabled
 
       - uses: lukka/get-cmake@latest
 

--- a/deploy/docker/Dockerfile-build-ubuntu
+++ b/deploy/docker/Dockerfile-build-ubuntu
@@ -1,4 +1,4 @@
-FROM ubuntu:22.04
+FROM ubuntu:20.04
 
 ARG QT_VERSION=6.6.3
 ARG QT_MODULES="qtcharts qtlocation qtpositioning qtspeech qt5compat qtmultimedia qtserialport qtimageformats qtshadertools qtconnectivity qtquick3d qtsensors"

--- a/tools/setup/install-dependencies-debian.sh
+++ b/tools/setup/install-dependencies-debian.sh
@@ -193,3 +193,12 @@ if apt-cache show libgeographic-dev >/dev/null 2>&1 && apt-cache show libgeograp
 elif apt-cache show libgeographiclib-dev >/dev/null 2>&1 && apt-cache show libgeographiclib-dev 2>/dev/null | grep -q "^Package: libgeographiclib-dev"; then
     DEBIAN_FRONTEND=noninteractive apt-get install -y --quiet libgeographiclib-dev
 fi
+
+# Vulkan
+# Ubuntu 20.04
+# wget -qO - http://packages.lunarg.com/lunarg-signing-key-pub.asc | sudo apt-key add -
+# wget -qO /etc/apt/sources.list.d/lunarg-vulkan-1.3.283-focal.list https://packages.lunarg.com/vulkan/1.3.283/lunarg-vulkan-1.3.283-focal.list
+
+# Ubuntu 22.04
+# wget -qO- https://packages.lunarg.com/lunarg-signing-key-pub.asc | sudo tee /etc/apt/trusted.gpg.d/lunarg.asc
+# wget -qO /etc/apt/sources.list.d/lunarg-vulkan-jammy.list http://packages.lunarg.com/vulkan/lunarg-vulkan-jammy.list


### PR DESCRIPTION
Closes #12176
Use docker for 20.04 since it won't be available for GitHub runners soon