### PR TITLE
Enable WP "Show all values" only in Advanced Mode

### DIFF
--- a/src/PlanView/MissionItemEditor.qml
+++ b/src/PlanView/MissionItemEditor.qml
@@ -227,6 +227,7 @@ Rectangle {
 
                 QGCMenuItem {
                     text:       qsTr("Show all values")
+                    visible:    QGroundControl.corePlugin.showAdvancedUI
                     checkable:  true
                     checked:    missionItem.isSimpleItem ? missionItem.rawEdit : false
                     enabled:    missionItem.isSimpleItem && !_waypointsOnlyMode


### PR DESCRIPTION
# Only show waypoint option "Show all values" in Advanced Mode

Description
-----------
Hides the "Show all values" option found in the mission item editor hamburger menu unless Advanced Mode is on.

Checklist:
----------
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [X] [Review Contribution Guidelines](https://github.com/mavlink/qgroundcontrol/blob/master/.github/CONTRIBUTING.md).
- [X] [Review Code of Conduct](https://github.com/mavlink/qgroundcontrol/blob/master/.github/CODE_OF_CONDUCT.md).
- [X] I have tested my changes.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.