### PR TITLE
GuidedValueSlider: Rework to fix margin issues and other things

### DIFF
--- a/src/FlightDisplay/FlyView.qml
+++ b/src/FlightDisplay/FlyView.qml
@@ -178,7 +178,6 @@ Item {
         //-- Guided value slider (e.g. altitude)
         GuidedValueSlider {
             id:                 guidedValueSlider
-            anchors.margins:    _toolsMargin
             anchors.right:      parent.right
             anchors.top:        parent.top
             anchors.bottom:     parent.bottom

--- a/src/FlightDisplay/GuidedValueSlider.qml
+++ b/src/FlightDisplay/GuidedValueSlider.qml
@@ -45,7 +45,7 @@ Item {
 
     property real   _majorTickWidth:        ScreenTools.largeFontPixelWidth * 2
     property real   _majorTickPixelHeight:  ScreenTools.largeFontPixelHeight * 2
-    property real   _majorTickValueMargin:  ScreenTools.defaultFontPixelWidth / 2
+    property real   _tickValueRightMargin:  ScreenTools.defaultFontPixelWidth / 2
     property real   _minorTickWidth:        _majorTickWidth / 2
     property real   _sliderValuePerPixel:   _majorTickValueStep / _majorTickPixelHeight
 
@@ -156,7 +156,7 @@ Item {
                         }
 
                         QGCLabel {
-                            anchors.margins:        _majorTickValueMargin
+                            anchors.margins:        _tickValueRightMargin
                             anchors.right:          parent.right
                             anchors.verticalCenter: majorTick.verticalCenter
                             text:                   parent.tickValue
@@ -192,15 +192,20 @@ Item {
         height: indicatorHeight
         clip:   false
 
-        readonly property int maxDigits:    3
+        QGCLabel {
+            id:             maxDigitsTextMeasure
+            text:           "-100"
+            font.pointSize: ScreenTools.largeFontPointSize
+            visible:        false
+        }
 
         property real indicatorValueMargins:    ScreenTools.defaultFontPixelWidth / 2
         property real indicatorHeight:          valueLabel.contentHeight
         property real pointerWidth:             ScreenTools.defaultFontPixelWidth
         property real minIndicatorWidth:        pointerWidth + (indicatorValueMargins * 2) + valueLabel.contentWidth
-        property real maxDigitsWidth:           ScreenTools.largeFontPixelWidth * maxDigits
-        property real intraTickDigitSpacing:    ScreenTools.largeFontPixelWidth
-        property real maxMajorTickDisplayWidth: _majorTickWidth + intraTickDigitSpacing + maxDigitsWidth + _majorTickValueMargin
+        property real maxDigitsWidth:           maxDigitsTextMeasure.contentWidth
+        property real intraTickDigitSpacing:    ScreenTools.defaultFontPixelWidth
+        property real maxMajorTickDisplayWidth: _majorTickWidth + intraTickDigitSpacing + maxDigitsWidth + _tickValueRightMargin
 
         onPaint: {
             var ctx = getContext("2d")

--- a/src/FlightDisplay/GuidedValueSlider.qml
+++ b/src/FlightDisplay/GuidedValueSlider.qml
@@ -199,7 +199,7 @@ Item {
         property real pointerWidth:             ScreenTools.defaultFontPixelWidth
         property real minIndicatorWidth:        pointerWidth + (indicatorValueMargins * 2) + valueLabel.contentWidth
         property real maxDigitsWidth:           ScreenTools.largeFontPixelWidth * maxDigits
-        property real intraTickDigitSpacing:    ScreenTools.defaultFontPixelWidth
+        property real intraTickDigitSpacing:    ScreenTools.largeFontPixelWidth
         property real maxMajorTickDisplayWidth: _majorTickWidth + intraTickDigitSpacing + maxDigitsWidth + _majorTickValueMargin
 
         onPaint: {


### PR DESCRIPTION
Replacement for #12165

While looking at #12165 I discovered other issues and also wanted to rework it so that the code was clearer. So this pull is based on that pull with some additional changes.

Changes:
* The slider is now parented right up to the top/bottom/right edges of window. Previously there was a small margin around it. This could cause problems where you would mistakenly zoom the map when you really wanted to scroll the slider if you were off the edge.
* Mouse events were bleeding through to the map below. So if you happens to scroll over the slider left/right using a track pad the map would zoom below it. There is not a dead mouse area below the control to prevent mouse events from bleeding through controls below it.
* There were various problems with the margins between the ticks and both negative and large positive values. Sometimes the values would overlap with the major ticks. To fix this the margins have been reworked so that there should always be room for a max of three digits (with/without negative)without bumping into the ticks.
* The indicator was not drawing correctly in that the border was not equally sized around the indicator.
* Since the margins are now larger I made the tick marks slightly smaller so that the overall width of the control didn't grow.
* Reworked a number of property names/usage to make the code easier to understand.