### PR TITLE
PlanManager: Increase Timeouts for Mission Transfer

### DIFF
--- a/src/Comms/UDPLink.cc
+++ b/src/Comms/UDPLink.cc
@@ -328,10 +328,7 @@ void UDPWorker::connectLink()
     qCDebug(UDPLinkLog) << "Attempting to join multicast group:" << _multicastGroup.toString();
     const bool joinSuccess = _socket->joinMulticastGroup(_multicastGroup);
     if (!joinSuccess) {
-        emit errorOccurred(tr("Failed to join multicast group"));
         qCWarning(UDPLinkLog) << "Failed to join multicast group" << _multicastGroup.toString();
-        _onSocketDisconnected();
-        return;
     }
 
 #ifdef QGC_ZEROCONF_ENABLED

--- a/src/MissionManager/PlanManager.cc
+++ b/src/MissionManager/PlanManager.cc
@@ -247,18 +247,19 @@ void PlanManager::_startAckTimeout(AckType_t ack)
     switch (ack) {
     case AckMissionItem:
         // We are actively trying to get the mission item, so we don't want to wait as long.
-        _ackTimeoutTimer->setInterval(_retryTimeoutMilliseconds);
+        _ackTimeoutTimer->setInterval(_retryTimeoutDefaultMilliseconds);
+        break;
+    case AckMissionRequest:
+        _ackTimeoutTimer->setInterval(_ackTimeoutMissionRequestMilliseconds);
         break;
     case AckNone:
         // FALLTHROUGH
     case AckMissionCount:
         // FALLTHROUGH
-    case AckMissionRequest:
-        // FALLTHROUGH
     case AckMissionClearAll:
         // FALLTHROUGH
     case AckGuidedItem:
-        _ackTimeoutTimer->setInterval(_ackTimeoutMilliseconds);
+        _ackTimeoutTimer->setInterval(_ackTimeoutDefaultMilliseconds);
         break;
     }
 

--- a/src/MissionManager/PlanManager.h
+++ b/src/MissionManager/PlanManager.h
@@ -68,9 +68,12 @@ public:
 
     // These values are public so the unit test can set appropriate signal wait times
     // When passively waiting for a mission process, use a longer timeout.
-    static const int _ackTimeoutMilliseconds = 1500;
+    static const int _ackTimeoutDefaultMilliseconds = 1500;
+    // When uploading a mission plan, use a longer timeout to cope with low
+    // bandwidth links, i.e. ELRS 900Mhz.
+    static const int _ackTimeoutMissionRequestMilliseconds = 2500;
     // When actively retrying to request mission items, use a shorter timeout instead.
-    static const int _retryTimeoutMilliseconds = 250;
+    static const int _retryTimeoutDefaultMilliseconds = 1500;
     static const int _maxRetryCount = 5;
 
 signals:

--- a/test/MissionManager/MissionControllerManagerTest.h
+++ b/test/MissionManager/MissionControllerManagerTest.h
@@ -72,7 +72,7 @@ protected:
     static const size_t _cMissionManagerSignals = maxSignalIndex;
     const char*         _rgMissionManagerSignals[_cMissionManagerSignals];
 
-    static const int _missionManagerSignalWaitTime = MissionManager::_ackTimeoutMilliseconds * MissionManager::_maxRetryCount * 2;
+    static const int _missionManagerSignalWaitTime = MissionManager::_ackTimeoutDefaultMilliseconds * MissionManager::_maxRetryCount * 2;
 };
 
 #endif


### PR DESCRIPTION
PlanManager: Increase Timeouts for Mission Transfer

Description
-----------
This patch fixes runtime issues with Mission Upload/Download when the vehicle connection is based on a 900MHz ELRS System. (See [Mavlink via ELRS feature](https://www.expresslrs.org/software/mavlink/).)

Two timeouts in PlanManager are increased.

The initial timeout is increased to cope with a delay when writing a Mission to the Flight Controller,
i.e. the Flight Controller needs some time to process Way-Points, Fences, Rally-Points etc. and this is enough to trigger the previously used timeout value. It is observed when initially starting the Mission Upload and when consecutively Fences and Rally-Points are written, regardless if there are any to be written.

The repeat timeout is increased to counter mix-up of requests resulting in sequence errors, i.e. when downloading the mission from the remote vehicle, QGroundControl already requested the item X+1 when the delayed response to this item X is received.

Test Steps
-----------
Test requires a PC or an arbitrary device running QGroundControl,
a 900MHz ELRS System running the Mavlink Connection and a Flight Controller with Ardupilot.

- Prepare the PC and enable an Access-Point for the ELRS backpack to connect to.
- Switch on the ELRS TX System and connect the ELRS BackPack to the Access-Point.
- Switch on the Flight Controller together with the ELRS RX System.
- Start QGroundControl.
- Watch QGroundControl connect to the remote vehicle and progress past the Mission Download (validates the repeat timeout).
- Go to Mission Plan, create a random mission and upload to remote vehicle. Mission Upload does complete without error (validates the initial timeout).

ELRS Hardware is somewhat standardized, so it should not matter what Manufacturer is used.
I use a Radiomaster TX12MK2 Handset together with a Radiomaster Bandit Transmitter and a BetaFPV SuperD Receiver.

Checklist:
----------
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [X] [Review Contribution Guidelines](https://github.com/mavlink/qgroundcontrol/blob/master/.github/CONTRIBUTING.md).
- [X] [Review Code of Conduct](https://github.com/mavlink/qgroundcontrol/blob/master/.github/CODE_OF_CONDUCT.md).
- [X] I have tested my changes.

Related Issue
-----------
Fixes https://github.com/mavlink/qgroundcontrol/issues/12076


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.