### PR TITLE
Fix case-sensitive flight mode comparisons

### DIFF
--- a/src/AutoPilotPlugins/APM/APMSubMotorComponentController.cc
+++ b/src/AutoPilotPlugins/APM/APMSubMotorComponentController.cc
@@ -22,7 +22,7 @@ void APMSubMotorComponentController::handleNewMessages(int uasid, int componenti
     Q_UNUSED(uasid);
     Q_UNUSED(componentid);
     Q_UNUSED(severity);
-    if (_vehicle->flightMode() == "Motor Detection"
+    if (QString::compare(_vehicle->flightMode(), "Motor Detection", Qt::CaseInsensitive) == 0
         && (text.toLower().contains("thruster") || text.toLower().contains("motor"))) {
         _motorDetectionMessages += text + QStringLiteral("\n");
         emit motorDetectionMessagesChanged();

--- a/src/FirmwarePlugin/APM/APMFirmwarePlugin.cc
+++ b/src/FirmwarePlugin/APM/APMFirmwarePlugin.cc
@@ -670,7 +670,7 @@ const QVariantList& APMFirmwarePlugin::toolIndicators(const Vehicle* vehicle)
 
 bool APMFirmwarePlugin::isGuidedMode(const Vehicle* vehicle) const
 {
-    return vehicle->flightMode() == "Guided";
+    return QString::compare(vehicle->flightMode(), "Guided", Qt::CaseInsensitive) == 0;
 }
 
 void APMFirmwarePlugin::_soloVideoHandshake(void)

--- a/src/FirmwarePlugin/FirmwarePlugin.cc
+++ b/src/FirmwarePlugin/FirmwarePlugin.cc
@@ -365,7 +365,7 @@ bool FirmwarePlugin::_armVehicleAndValidate(Vehicle* vehicle)
 
 bool FirmwarePlugin::_setFlightModeAndValidate(Vehicle* vehicle, const QString& flightMode)
 {
-    if (vehicle->flightMode() == flightMode) {
+    if (QString::compare(vehicle->flightMode(), flightMode, Qt::CaseInsensitive) == 0) {
         return true;
     }
 
@@ -377,7 +377,7 @@ bool FirmwarePlugin::_setFlightModeAndValidate(Vehicle* vehicle, const QString& 
 
         // Wait for vehicle to return flight mode
         for (int i=0; i<13; i++) {
-            if (vehicle->flightMode() == flightMode) {
+            if (QString::compare(vehicle->flightMode(), flightMode, Qt::CaseInsensitive) == 0) {
                 flightModeChanged = true;
                 break;
             }

--- a/src/Vehicle/StandardModes.cc
+++ b/src/Vehicle/StandardModes.cc
@@ -175,7 +175,7 @@ QString StandardModes::flightMode(uint32_t custom_mode) const
 bool StandardModes::setFlightMode(const QString &flightMode, uint32_t *custom_mode)
 {
     for (auto iter = _modes.constBegin(); iter != _modes.constEnd(); ++iter) {
-        if (iter->name == flightMode) {
+        if (QString::compare(iter->name, flightMode, Qt::CaseInsensitive) == 0) {
             *custom_mode = iter.key();
             return true;
         }


### PR DESCRIPTION
# Fix case-sensitive flight mode comparisons

Description
-----------
Fixed a bug where the "Start mission" action failed on ArduPilot, displaying an error popup with the message "Unable to start mission: Vehicle failed to change to Auto mode." The issue was caused by case-sensitive comparisons between flight mode strings from the vehicle and the reference strings. Moving away from using strings entirely should be considered.

Replaced direct string comparisons with case-insensitive comparisons using QString::compare() with Qt::CaseInsensitive flag. This fix resolves the immediate issue and also corrects a few other incorrect mode comparisons unrelated to the "Start mission" problem.

Closes #12128 

Checklist:
----------
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [X] [Review Contribution Guidelines](https://github.com/mavlink/qgroundcontrol/blob/master/.github/CONTRIBUTING.md).
- [X] [Review Code of Conduct](https://github.com/mavlink/qgroundcontrol/blob/master/.github/CODE_OF_CONDUCT.md).
- [X] I have tested my changes.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.