### PR TITLE
Update RTL altitude parameter for ArduPlane 4.5+

### DIFF
--- a/src/AutoPilotPlugins/APM/APMSafetyComponent.qml
+++ b/src/AutoPilotPlugins/APM/APMSafetyComponent.qml
@@ -660,7 +660,13 @@ SetupPage {
                 Column {
                     spacing: _margins / 2
 
-                    property Fact _rtlAltFact: controller.getParameterFact(-1, "ALT_HOLD_RTL")
+                    property Fact _rtlAltFact: {
+                        if (controller.firmwareMajorVersion < 4 || (controller.firmwareMajorVersion === 4 && controller.firmwareMinorVersion < 5)) {
+                            return controller.getParameterFact(-1, "ALT_HOLD_RTL")
+                        } else {
+                            return controller.getParameterFact(-1, "RTL_ALTITUDE")
+                        }
+                    }
 
                     QGCLabel {
                         text:           qsTr("Return to Launch")

--- a/src/AutoPilotPlugins/APM/APMSafetyComponentPlane.qml
+++ b/src/AutoPilotPlugins/APM/APMSafetyComponentPlane.qml
@@ -39,7 +39,13 @@ SetupPage {
             property Fact _failsafeThrValue:    controller.getParameterFact(-1, "THR_FS_VALUE")
             property Fact _failsafeGCSEnable:   controller.getParameterFact(-1, "FS_GCS_ENABL")
 
-            property Fact _rtlAltFact: controller.getParameterFact(-1, "ALT_HOLD_RTL")
+            property Fact _rtlAltFact: {
+                if (controller.firmwareMajorVersion < 4 || (controller.firmwareMajorVersion === 4 && controller.firmwareMinorVersion < 5)) {
+                    return controller.getParameterFact(-1, "ALT_HOLD_RTL")
+                } else {
+                    return controller.getParameterFact(-1, "RTL_ALTITUDE")
+                }
+            }
 
             property real _margins: ScreenTools.defaultFontPixelHeight
 

--- a/src/AutoPilotPlugins/APM/APMSafetyComponentSummaryPlane.qml
+++ b/src/AutoPilotPlugins/APM/APMSafetyComponentSummaryPlane.qml
@@ -18,7 +18,13 @@ Item {
     property Fact _failsafeThrValue:    controller.getParameterFact(-1, "THR_FS_VALUE")
     property Fact _failsafeGCSEnable:   controller.getParameterFact(-1, "FS_GCS_ENABL")
 
-    property Fact _rtlAltFact: controller.getParameterFact(-1, "ALT_HOLD_RTL")
+    property Fact _rtlAltFact: {
+        if (controller.firmwareMajorVersion < 4 || (controller.firmwareMajorVersion === 4 && controller.firmwareMinorVersion < 5)) {
+            return controller.getParameterFact(-1, "ALT_HOLD_RTL")
+        } else {
+            return controller.getParameterFact(-1, "RTL_ALTITUDE")
+        }
+    }
 
     Column {
         anchors.fill:       parent


### PR DESCRIPTION
# Update RTL altitude parameter for ArduPlane 4.5+

Description
-----------
The ALT_HOLD_RTL parameter was removed in ArduPlane 4.5 and replaced with RTL_ALTITUDE. This change caused the Safety Component to display error messages when connecting to vehicles running newer firmware versions.

Added logic to use 'RTL_ALTITUDE' for ArduPilot versions 4.5 and above, while maintaining 'ALT_HOLD_RTL' for older versions.

Checklist:
----------
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [X] [Review Contribution Guidelines](https://github.com/mavlink/qgroundcontrol/blob/master/.github/CONTRIBUTING.md).
- [X] [Review Code of Conduct](https://github.com/mavlink/qgroundcontrol/blob/master/.github/CODE_OF_CONDUCT.md).
- [X] I have tested my changes.

Related Issue
-----------
#11620


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.