### PR TITLE
Only show displayed modes editor in Advanced Mode

### DIFF
--- a/src/UI/toolbar/FlightModeIndicator.qml
+++ b/src/UI/toolbar/FlightModeIndicator.qml
@@ -178,7 +178,7 @@ RowLayout {
                 visible:                false
 
                 function calcVisible() {
-                    hiddenModesLabel.visible = hiddenFlightModesList.length > 0
+                    hiddenModesLabel.visible = (hiddenFlightModesList.length > 0) && QGroundControl.corePlugin.showAdvancedUI
                 }
             }
         }
@@ -199,10 +199,11 @@ RowLayout {
             }
 
             SettingsGroupLayout {
-                Layout.fillWidth:  true
+                Layout.fillWidth:   true
 
                 RowLayout {
                     Layout.fillWidth:   true
+                    visible:            QGroundControl.corePlugin.showAdvancedUI
                     enabled:            control.allowEditMode
 
                     QGCLabel {


### PR DESCRIPTION
# Only show displayed modes editor in Advanced Mode

Description
-----------
Hides the "Edit Displayed Flight Modes" option found in the expanded mode selector dropdown menu unless Advanced Mode is on. Also hides the "Some Modes Hidden" text below the mode list under the same condition.

When not in advanced mode, a user probably shouldn't have the option to select advanced modes such as Autotune or Circle, or even know that they're hidden.

Checklist:
----------
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [X] [Review Contribution Guidelines](https://github.com/mavlink/qgroundcontrol/blob/master/.github/CONTRIBUTING.md).
- [X] [Review Code of Conduct](https://github.com/mavlink/qgroundcontrol/blob/master/.github/CODE_OF_CONDUCT.md).
- [X] I have tested my changes.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.