### PR TITLE
Airlink: Add missing header file

### DIFF
--- a/src/Comms/AirLink/AirLinkManager.cc
+++ b/src/Comms/AirLink/AirLinkManager.cc
@@ -9,6 +9,7 @@
 
 #include "AirLinkManager.h"
 #include "SettingsManager.h"
+#include "AppSettings.h"
 #include "QGCLoggingCategory.h"
 
 #include <QtCore/qapplicationstatic.h>


### PR DESCRIPTION
This can cause a build to fail on certain custom build setups