### PR TITLE
Make unloaded map tiles dark grey when in indoor mode

### DIFF
--- a/src/FlightMap/FlightMap.qml
+++ b/src/FlightMap/FlightMap.qml
@@ -24,6 +24,7 @@ import QGroundControl.QGCPositionManager
 
 Map {
     id: _map
+    color: indoorPalette ? qgcPal.windowShadeDark : "white"
 
     plugin:     Plugin { name: "QGroundControl" }
     opacity:    0.99 // https://bugreports.qt.io/browse/QTBUG-82185
@@ -37,6 +38,7 @@ Map {
     property bool   firstGCSPositionReceived:       false   ///< true: first gcs position update was responded to
     property bool   firstVehiclePositionReceived:   false   ///< true: first vehicle position update was responded to
     property bool   planView:                       false   ///< true: map being using for Plan view, items should be draggable
+    property bool   indoorPalette:                  QGroundControl.settingsManager.appSettings.indoorPalette.rawValue == 1
 
     readonly property real  maxZoomLevel: 20
 


### PR DESCRIPTION
<!--- Title -->

Description
-----------
One thing I notice is that when in indoor mode, the unloaded tiles are still a bright white color which may be annoying to some. This change makes unloaded tiles a dark grey color.

Test Steps
-----------
1. Load up QGC and observe unloaded tiles in both indoor and outdoor mode

Checklist:
----------
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] [Review Contribution Guidelines](https://github.com/mavlink/qgroundcontrol/blob/master/.github/CONTRIBUTING.md).
- [x] [Review Code of Conduct](https://github.com/mavlink/qgroundcontrol/blob/master/.github/CODE_OF_CONDUCT.md).
- [x] I have tested my changes.

Related Issue
-----------
<!-- If any, please provide issue ID. -->


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.