### PR TITLE
Improve preflight checklist usability

### DIFF
--- a/src/FlightDisplay/FlyViewWidgetLayer.qml
+++ b/src/FlightDisplay/FlyViewWidgetLayer.qml
@@ -166,8 +166,12 @@ Item {
         maxHeight:              parent.height - y - parentToolInsets.bottomEdgeLeftInset - _toolsMargin
         visible:                !QGroundControl.videoManager.fullScreen
 
-        onDisplayPreFlightChecklist: preFlightChecklistPopup.createObject(mainWindow).open()
-
+        onDisplayPreFlightChecklist: {
+            if (!preFlightChecklistLoader.active) {
+                preFlightChecklistLoader.active = true
+            }
+            preFlightChecklistLoader.item.open()
+        }
 
         property real topEdgeLeftInset:     visible ? y + height : 0
         property real leftEdgeTopInset:     visible ? x + width : 0
@@ -193,6 +197,12 @@ Item {
         visible:            !ScreenTools.isTinyScreen && QGroundControl.corePlugin.options.flyView.showMapScale && !isViewer3DOpen && mapControl.pipState.state === mapControl.pipState.fullState
 
         property real topEdgeCenterInset: visible ? y + height : 0
+    }
+
+    Loader {
+        id: preFlightChecklistLoader
+        sourceComponent: preFlightChecklistPopup
+        active: false
     }
 
     Component {

--- a/src/QmlControls/PreFlightCheckButton.qml
+++ b/src/QmlControls/PreFlightCheckButton.qml
@@ -107,9 +107,9 @@ QGCButton {
             _telemetryState = _statePassed
             return
         }
-        if (manualText !== "" && _manualState !== _statePassed) {
+        if (manualText !== "") {
             // User is confirming a manual check
-            _manualState = _statePassed
+            _manualState = (_manualState === _statePassed) ? _statePending : _statePassed
         }
     }
 


### PR DESCRIPTION
# Improve preflight checklist usability

Description
-----------
- When performing the preflight checklist, it is often necessary to close it at certain steps to complete some of the checks. However, when it got closed and reopened, its state was lost and all completed checks had to be manually re-checked. This commit wraps the checklist component in a loader, so that once its first opened, it stays loaded and keeps its state.
- Made it possible to set manual checklist buttons back to the pending state, so that in case of an accidental click, the check can be undone without resetting the entire checklist and having to go through it again.

Checklist:
----------
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [X] [Review Contribution Guidelines](https://github.com/mavlink/qgroundcontrol/blob/master/.github/CONTRIBUTING.md).
- [X] [Review Code of Conduct](https://github.com/mavlink/qgroundcontrol/blob/master/.github/CODE_OF_CONDUCT.md).
- [X] I have tested my changes.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.