### PR TITLE
FlightModeMenu: fix mode list not updating when changed by advanced mode

### DIFF
--- a/src/QmlControls/FlightModeMenu.qml
+++ b/src/QmlControls/FlightModeMenu.qml
@@ -61,6 +61,11 @@ QGCLabel {
         function onActiveVehicleChanged(activeVehicle) { _root.updateFlightModesMenu() }
     }
 
+    Connections {
+        target: currentVehicle
+        function onFlightModesChanged() { _root.updateFlightModesMenu() }
+    }
+
     MouseArea {
         id:                 mouseArea
         visible:            currentVehicle && currentVehicle.flightModeSetAvailable


### PR DESCRIPTION
Description
-----------
If advanced mode changed which flight modes can be set, these changes were not visible in the UI.

Checklist:
----------
- [x] [Review Contribution Guidelines](https://github.com/mavlink/qgroundcontrol/blob/master/.github/CONTRIBUTING.md).
- [x] [Review Code of Conduct](https://github.com/mavlink/qgroundcontrol/blob/master/.github/CODE_OF_CONDUCT.md).
- [x] I have tested my changes.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.