### PR TITLE
Comms: Don't force disconnect autconnect links on failed setup

### DIFF
--- a/src/Comms/LinkManager.cc
+++ b/src/Comms/LinkManager.cc
@@ -280,7 +280,7 @@ void LinkManager::saveLinkConfigurationList()
             continue;
         }
 
-        if (linkConfig->isDynamic()) {
+        if (!linkConfig->isDynamic()) {
             continue;
         }
 
@@ -394,6 +394,8 @@ void LinkManager::_addUDPAutoConnectLink()
     qCDebug(LinkManagerLog) << "New auto-connect UDP port added";
     UDPConfiguration* const udpConfig = new UDPConfiguration(_defaultUDPLinkName);
     udpConfig->setDynamic(true);
+    // FIXME: Default UDPConfiguration is set up for autoconnect
+    // udpConfig->setAutoConnect(true);
     SharedLinkConfigurationPtr config = addConfiguration(udpConfig);
     createConnectedLink(config);
 }

--- a/src/Comms/SerialLink.h
+++ b/src/Comms/SerialLink.h
@@ -135,7 +135,7 @@ private slots:
     void _checkPortAvailability();
 
 private:
-    const SerialConfiguration *_config = nullptr;
+    const SerialConfiguration *_serialConfig = nullptr;
     QSerialPort *_port = nullptr;
     QTimer *_timer = nullptr;
     bool _errorEmitted = false;

--- a/src/Comms/UDPLink.h
+++ b/src/Comms/UDPLink.h
@@ -145,6 +145,7 @@ private:
     QMutex _sessionTargetsMutex;
     QList<std::shared_ptr<UDPClient>> _sessionTargets;
     bool _isConnected = false;
+    bool _errorEmitted = false;
     QSet<QHostAddress> _localAddresses;
 
     static const QHostAddress _multicastGroup;


### PR DESCRIPTION
This will cause continuous errors on autoconnect. So, only emit if not an autoconnect link