### PR TITLE
Fix custom parameters view

### DIFF
--- a/src/QmlControls/ParameterEditorController.cc
+++ b/src/QmlControls/ParameterEditorController.cc
@@ -112,7 +112,7 @@ void ParameterEditorController::_buildLists(void)
             if (group->name == FactMetaData::kDefaultGroup) {
                 if (j != _categories.count() - 1) {
                     category->groups.removeAt(j);
-                    category->groups.append(category);
+                    category->groups.append(group);
                 }
                 break;
             }


### PR DESCRIPTION
Fix custom parameters view

Description
-----------
Fix for a bug that prevents to show custom parameters list

Test Steps
-----------
Remove metadata definition for some parameters from the PX4ParameterFactMetaData.xml. Connect to PX4 autopilot. Try to find removed parameters in the parameters list (custom category).

Checklist:
----------
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] [Review Contribution Guidelines](https://github.com/mavlink/qgroundcontrol/blob/master/.github/CONTRIBUTING.md).
- [x] [Review Code of Conduct](https://github.com/mavlink/qgroundcontrol/blob/master/.github/CODE_OF_CONDUCT.md).
- [x] I have tested my changes.

Related Issue
-----------
<!-- If any, please provide issue ID. -->


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.