### PR TITLE
QGCCorePlugin: Remove const from all but the simplest methods

### DIFF
--- a/custom-example/qgroundcontrol.qrc
+++ b/custom-example/qgroundcontrol.qrc
@@ -153,8 +153,7 @@
 		<file alias="QGroundControl/Controls/QGCComboBox.qml">../src/QmlControls/QGCComboBox.qml</file>
 		<file alias="QGroundControl/Controls/QGCFileDialog.qml">../src/QmlControls/QGCFileDialog.qml</file>
 		<file alias="QGroundControl/Controls/QGCFlickable.qml">../src/QmlControls/QGCFlickable.qml</file>
-		<file alias="QGroundControl/Controls/QGCFlickableHorizontalIndicator.qml">../src/QmlControls/QGCFlickableHorizontalIndicator.qml</file>
-		<file alias="QGroundControl/Controls/QGCFlickableVerticalIndicator.qml">../src/QmlControls/QGCFlickableVerticalIndicator.qml</file>
+		<file alias="QGroundControl/Controls/QGCFlickableScrollIndicator.qml">../src/QmlControls/QGCFlickableScrollIndicator.qml</file>
 		<file alias="QGroundControl/Controls/QGCGroupBox.qml">../src/QmlControls/QGCGroupBox.qml</file>
 		<file alias="QGroundControl/Controls/QGCLabel.qml">../src/QmlControls/QGCLabel.qml</file>
 		<file alias="QGroundControl/Controls/QGCListView.qml">../src/QmlControls/QGCListView.qml</file>

--- a/custom-example/src/CustomPlugin.cc
+++ b/custom-example/src/CustomPlugin.cc
@@ -103,7 +103,7 @@ void CustomPlugin::_addSettingsEntry(const QString& title, const char* qmlFile, 
                 this)));
 }
 
-QGCOptions* CustomPlugin::options() const
+QGCOptions* CustomPlugin::options()
 {
     return _options;
 }
@@ -118,7 +118,7 @@ QString CustomPlugin::brandImageOutdoor(void) const
     return QStringLiteral("/custom/img/dronecode-black.svg");
 }
 
-bool CustomPlugin::overrideSettingsGroupVisibility(const QString &name) const
+bool CustomPlugin::overrideSettingsGroupVisibility(const QString &name)
 {
     // We have set up our own specific brand imaging. Hide the brand image settings such that the end user
     // can't change it.
@@ -129,7 +129,7 @@ bool CustomPlugin::overrideSettingsGroupVisibility(const QString &name) const
 }
 
 // This allows you to override/hide QGC Application settings
-bool CustomPlugin::adjustSettingMetaData(const QString& settingsGroup, FactMetaData& metaData) const
+bool CustomPlugin::adjustSettingMetaData(const QString& settingsGroup, FactMetaData& metaData)
 {
     bool parentResult = QGCCorePlugin::adjustSettingMetaData(settingsGroup, metaData);
 
@@ -149,7 +149,7 @@ bool CustomPlugin::adjustSettingMetaData(const QString& settingsGroup, FactMetaD
 }
 
 // This modifies QGC colors palette to match possible custom corporate branding
-void CustomPlugin::paletteOverride(const QString &colorName, QGCPalette::PaletteColorInfo_t& colorInfo) const
+void CustomPlugin::paletteOverride(const QString &colorName, QGCPalette::PaletteColorInfo_t& colorInfo)
 {
     if (colorName == QStringLiteral("window")) {
         colorInfo[QGCPalette::Dark][QGCPalette::ColorGroupEnabled]   = QColor("#212529");
@@ -340,7 +340,7 @@ void CustomPlugin::paletteOverride(const QString &colorName, QGCPalette::Palette
 }
 
 // We override this so we can get access to QQmlApplicationEngine and use it to register our qml module
-QQmlApplicationEngine* CustomPlugin::createQmlApplicationEngine(QObject* parent) const
+QQmlApplicationEngine* CustomPlugin::createQmlApplicationEngine(QObject* parent)
 {
     QQmlApplicationEngine* qmlEngine = QGCCorePlugin::createQmlApplicationEngine(parent);
     qmlEngine->addImportPath("qrc:/Custom/Widgets");

--- a/custom-example/src/CustomPlugin.h
+++ b/custom-example/src/CustomPlugin.h
@@ -59,13 +59,13 @@ public:
     static QGCCorePlugin *instance();
 
     // Overrides from QGCCorePlugin
-    QGCOptions*             options                         (void) const final;
+    QGCOptions*             options                         (void) final;
     QString                 brandImageIndoor                (void) const final;
     QString                 brandImageOutdoor               (void) const final;
-    bool                    overrideSettingsGroupVisibility (const QString &name) const final;
-    bool                    adjustSettingMetaData           (const QString& settingsGroup, FactMetaData& metaData) const final;
-    void                    paletteOverride                 (const QString &colorName, QGCPalette::PaletteColorInfo_t& colorInfo) const final;
-    QQmlApplicationEngine*  createQmlApplicationEngine      (QObject* parent) const final;
+    bool                    overrideSettingsGroupVisibility (const QString &name) final;
+    bool                    adjustSettingMetaData           (const QString& settingsGroup, FactMetaData& metaData) final;
+    void                    paletteOverride                 (const QString &colorName, QGCPalette::PaletteColorInfo_t& colorInfo) final;
+    QQmlApplicationEngine*  createQmlApplicationEngine      (QObject* parent) final;
 
 private slots:
     void _advancedChanged(bool advanced);

--- a/src/API/QGCCorePlugin.cc
+++ b/src/API/QGCCorePlugin.cc
@@ -74,7 +74,7 @@ void QGCCorePlugin::registerQmlTypes()
     (void) qmlRegisterUncreatableType<QGCFlyViewOptions>("QGroundControl", 1, 0, "QGCFlyViewOptions", QStringLiteral("Reference only"));
 }
 
-const QVariantList &QGCCorePlugin::analyzePages() const
+const QVariantList &QGCCorePlugin::analyzePages()
 {
     static const QVariantList analyzeList = {
         QVariant::fromValue(new QmlComponentInfo(
@@ -116,7 +116,7 @@ const QmlObjectListModel *QGCCorePlugin::customMapItems()
     return _emptyCustomMapItems;
 }
 
-bool QGCCorePlugin::adjustSettingMetaData(const QString &settingsGroup, FactMetaData &metaData) const
+bool QGCCorePlugin::adjustSettingMetaData(const QString &settingsGroup, FactMetaData &metaData)
 {
     if (settingsGroup == AppSettings::settingsGroup) {
         if (metaData.name() == AppSettings::indoorPaletteName) {
@@ -153,7 +153,7 @@ QString QGCCorePlugin::showAdvancedUIMessage() const
               "Are you sure you want to enable Advanced Mode?");
 }
 
-void QGCCorePlugin::factValueGridCreateDefaultSettings(const QString &defaultSettingsGroup) const
+void QGCCorePlugin::factValueGridCreateDefaultSettings(const QString &defaultSettingsGroup)
 {
     HorizontalFactValueGrid *const factValueGrid = new HorizontalFactValueGrid(defaultSettingsGroup);
 
@@ -232,7 +232,7 @@ void QGCCorePlugin::factValueGridCreateDefaultSettings(const QString &defaultSet
     factValueGrid->deleteLater();
 }
 
-QQmlApplicationEngine *QGCCorePlugin::createQmlApplicationEngine(QObject *parent) const
+QQmlApplicationEngine *QGCCorePlugin::createQmlApplicationEngine(QObject *parent)
 {
     QQmlApplicationEngine *const qmlEngine = new QQmlApplicationEngine(parent);
     qmlEngine->addImportPath(QStringLiteral("qrc:/qml"));
@@ -242,12 +242,12 @@ QQmlApplicationEngine *QGCCorePlugin::createQmlApplicationEngine(QObject *parent
     return qmlEngine;
 }
 
-void QGCCorePlugin::createRootWindow(QQmlApplicationEngine *qmlEngine) const
+void QGCCorePlugin::createRootWindow(QQmlApplicationEngine *qmlEngine)
 {
     qmlEngine->load(QUrl(QStringLiteral("qrc:/qml/MainRootWindow.qml")));
 }
 
-VideoReceiver *QGCCorePlugin::createVideoReceiver(QObject *parent) const
+VideoReceiver *QGCCorePlugin::createVideoReceiver(QObject *parent)
 {
 #ifdef QGC_GST_STREAMING
     return GStreamer::createVideoReceiver(parent);
@@ -258,7 +258,7 @@ VideoReceiver *QGCCorePlugin::createVideoReceiver(QObject *parent) const
 #endif
 }
 
-void *QGCCorePlugin::createVideoSink(QObject *parent, QQuickItem *widget) const
+void *QGCCorePlugin::createVideoSink(QObject *parent, QQuickItem *widget)
 {
 #ifdef QGC_GST_STREAMING
     return GStreamer::createVideoSink(parent, widget);
@@ -271,7 +271,7 @@ void *QGCCorePlugin::createVideoSink(QObject *parent, QQuickItem *widget) const
 #endif
 }
 
-void QGCCorePlugin::releaseVideoSink(void *sink) const
+void QGCCorePlugin::releaseVideoSink(void *sink)
 {
 #ifdef QGC_GST_STREAMING
     GStreamer::releaseVideoSink(sink);
@@ -282,7 +282,7 @@ void QGCCorePlugin::releaseVideoSink(void *sink) const
 #endif
 }
 
-const QVariantList &QGCCorePlugin::toolBarIndicators() const
+const QVariantList &QGCCorePlugin::toolBarIndicators()
 {
     static const QVariantList toolBarIndicatorList = QVariantList(
         {
@@ -293,7 +293,7 @@ const QVariantList &QGCCorePlugin::toolBarIndicators() const
     return toolBarIndicatorList;
 }
 
-QVariantList QGCCorePlugin::firstRunPromptsToShow() const
+QVariantList QGCCorePlugin::firstRunPromptsToShow()
 {
     QList<int> rgIdsToShow;
 

--- a/src/API/QGCCorePlugin.h
+++ b/src/API/QGCCorePlugin.h
@@ -60,11 +60,11 @@ public:
 
     /// The list of pages/buttons under the Analyze Menu
     /// @return A list of QmlPageInfo
-    virtual const QVariantList &analyzePages() const;
+    virtual const QVariantList &analyzePages();
 
     /// The default settings panel to show
     /// @return The settings index
-    virtual int defaultSettings() const { return 0; }
+    virtual int defaultSettings() { return 0; }
 
     /// Global options
     /// @return An instance of QGCOptions
@@ -73,13 +73,13 @@ public:
     /// Allows the core plugin to override the visibility for a settings group
     ///     @param name - SettingsGroup name
     /// @return true: Show settings ui, false: Hide settings ui
-    virtual bool overrideSettingsGroupVisibility(const QString &name) const { Q_UNUSED(name); return true; }
+    virtual bool overrideSettingsGroupVisibility(const QString &name) { Q_UNUSED(name); return true; }
 
     /// Allows the core plugin to override the setting meta data before the setting fact is created.
     ///     @param settingsGroup - QSettings group which contains this item
     ///     @param metaData - MetaData for setting fact
     /// @return true: Setting should be visible in ui, false: Setting should not be shown in ui
-    virtual bool adjustSettingMetaData(const QString &settingsGroup, FactMetaData &metaData) const;
+    virtual bool adjustSettingMetaData(const QString &settingsGroup, FactMetaData &metaData);
 
     /// Return the resource file which contains the brand image for for Indoor theme.
     virtual QString brandImageIndoor() const { return QString(); }
@@ -91,48 +91,48 @@ public:
     virtual QString showAdvancedUIMessage() const;
 
     /// @return An instance of an alternate position source (or NULL if not available)
-    virtual QGeoPositionInfoSource *createPositionSource(QObject *parent) const { Q_UNUSED(parent); return nullptr; }
+    virtual QGeoPositionInfoSource *createPositionSource(QObject *parent) { Q_UNUSED(parent); return nullptr; }
 
     /// Allows a plugin to override the specified color name from the palette
-    virtual void paletteOverride(const QString &colorName, QGCPalette::PaletteColorInfo_t &colorInfo) const { Q_UNUSED(colorName); Q_UNUSED(colorInfo); };
+    virtual void paletteOverride(const QString &colorName, QGCPalette::PaletteColorInfo_t &colorInfo) { Q_UNUSED(colorName); Q_UNUSED(colorInfo); };
 
-    virtual void factValueGridCreateDefaultSettings(const QString &defaultSettingsGroup) const;
+    virtual void factValueGridCreateDefaultSettings(const QString &defaultSettingsGroup);
 
     /// Allows the plugin to override or get access to the QmlApplicationEngine to do things like add import
     /// path or stuff things into the context prior to window creation.
-    virtual QQmlApplicationEngine *createQmlApplicationEngine(QObject *parent) const;
+    virtual QQmlApplicationEngine *createQmlApplicationEngine(QObject *parent);
 
     /// Allows the plugin to override the creation of the root (native) window.
-    virtual void createRootWindow(QQmlApplicationEngine *qmlEngine) const;
+    virtual void createRootWindow(QQmlApplicationEngine *qmlEngine);
 
     /// Allows the plugin to override the creation of VideoReceiver.
-    virtual VideoReceiver *createVideoReceiver(QObject *parent) const;
+    virtual VideoReceiver *createVideoReceiver(QObject *parent);
     /// Allows the plugin to override the creation of VideoSink.
-    virtual void *createVideoSink(QObject *parent, QQuickItem *widget) const;
+    virtual void *createVideoSink(QObject *parent, QQuickItem *widget);
     /// Allows the plugin to override the release of VideoSink.
-    virtual void releaseVideoSink(void *sink) const;
+    virtual void releaseVideoSink(void *sink);
 
     /// Allows the plugin to see all mavlink traffic to a vehicle
     /// @return true: Allow vehicle to continue processing, false: Vehicle should not process message
-    virtual bool mavlinkMessage(Vehicle *vehicle, LinkInterface *link, const mavlink_message_t &message) const { Q_UNUSED(vehicle); Q_UNUSED(link); Q_UNUSED(message); return true; }
+    virtual bool mavlinkMessage(Vehicle *vehicle, LinkInterface *link, const mavlink_message_t &message) { Q_UNUSED(vehicle); Q_UNUSED(link); Q_UNUSED(message); return true; }
 
     /// Allows custom builds to add custom items to the FlightMap. Objects put into QmlObjectListModel should derive from QmlComponentInfo and set the url property.
     virtual const QmlObjectListModel *customMapItems();
 
     /// Allows custom builds to add custom items to the plan file before the document is created.
-    virtual void preSaveToJson(PlanMasterController *pController, QJsonObject &json) const { Q_UNUSED(pController); Q_UNUSED(json); }
+    virtual void preSaveToJson(PlanMasterController *pController, QJsonObject &json) { Q_UNUSED(pController); Q_UNUSED(json); }
     /// Allows custom builds to add custom items to the plan file after the document is created.
-    virtual void postSaveToJson(PlanMasterController *pController, QJsonObject &json) const { Q_UNUSED(pController); Q_UNUSED(json); }
+    virtual void postSaveToJson(PlanMasterController *pController, QJsonObject &json) { Q_UNUSED(pController); Q_UNUSED(json); }
 
     /// Allows custom builds to add custom items to the mission section of the plan file before the item is created.
-    virtual void preSaveToMissionJson(PlanMasterController *pController, QJsonObject &missionJson) const { Q_UNUSED(pController); Q_UNUSED(missionJson); }
+    virtual void preSaveToMissionJson(PlanMasterController *pController, QJsonObject &missionJson) { Q_UNUSED(pController); Q_UNUSED(missionJson); }
     /// Allows custom builds to add custom items to the mission section of the plan file after the item is created.
-    virtual void postSaveToMissionJson(PlanMasterController *pController, QJsonObject &missionJson) const { Q_UNUSED(pController); Q_UNUSED(missionJson); }
+    virtual void postSaveToMissionJson(PlanMasterController *pController, QJsonObject &missionJson) { Q_UNUSED(pController); Q_UNUSED(missionJson); }
 
     /// Allows custom builds to load custom items from the plan file before the document is parsed.
-    virtual void preLoadFromJson(PlanMasterController *pController, QJsonObject &json) const { Q_UNUSED(pController); Q_UNUSED(json); }
+    virtual void preLoadFromJson(PlanMasterController *pController, QJsonObject &json) { Q_UNUSED(pController); Q_UNUSED(json); }
     /// Allows custom builds to load custom items from the plan file after the document is parsed.
-    virtual void postLoadFromJson(PlanMasterController *pController, QJsonObject &json) const { Q_UNUSED(pController); Q_UNUSED(json); }
+    virtual void postLoadFromJson(PlanMasterController *pController, QJsonObject &json) { Q_UNUSED(pController); Q_UNUSED(json); }
 
     /// Returns the url to download the stable version check file. Return QString() to indicate no version check should be performed.
     /// Default QGC mainline implemenentation returns QGC Stable file location. Default QGC custom build code returns QString().
@@ -153,36 +153,36 @@ public:
     /// Returns the complex mission items to display in the Plan UI
     /// @param complexMissionItemNames Default set of complex items
     /// @return Complex items to be made available to user
-    virtual QStringList complexMissionItemNames(Vehicle *vehicle, const QStringList &complexMissionItemNames) const { Q_UNUSED(vehicle); return complexMissionItemNames; }
+    virtual QStringList complexMissionItemNames(Vehicle *vehicle, const QStringList &complexMissionItemNames) { Q_UNUSED(vehicle); return complexMissionItemNames; }
 
     /// Returns the standard list of first run prompt ids for possible display. Actual display is based on the
     /// current AppSettings::firstRunPromptIds value. The order of this list also determines the order the prompts
     /// will be displayed in.
-    virtual QList<int> firstRunPromptStdIds() const { return QList<int>({ kUnitsFirstRunPromptId, kOfflineVehicleFirstRunPromptId }); }
+    virtual QList<int> firstRunPromptStdIds() { return QList<int>({ kUnitsFirstRunPromptId, kOfflineVehicleFirstRunPromptId }); }
 
     /// Returns the custom build list of first run prompt ids for possible display. Actual display is based on the
     /// current AppSettings::firstRunPromptIds value. The order of this list also determines the order the prompts
     /// will be displayed in.
-    virtual QList<int> firstRunPromptCustomIds() const { return QList<int>(); }
+    virtual QList<int> firstRunPromptCustomIds() { return QList<int>(); }
 
     /// Returns the resource which contains the specified first run prompt for display
     Q_INVOKABLE virtual QString firstRunPromptResource(int id) const;
 
     /// Returns the list of toolbar indicators which are not related to a vehicle
     /// @return A list of QUrl with the indicators
-    virtual const QVariantList &toolBarIndicators() const;
+    virtual const QVariantList &toolBarIndicators();
 
     /// Returns a true if xml definition file of a providen camera name exists, and loads it to file argument, to allow definition files to be loaded from resources
-    virtual bool getOfflineCameraDefinitionFile(const QString &cameraName, QFile &file) const { Q_UNUSED(cameraName); Q_UNUSED(file); return false; }
+    virtual bool getOfflineCameraDefinitionFile(const QString &cameraName, QFile &file) { Q_UNUSED(cameraName); Q_UNUSED(file); return false; }
 
     struct JoystickAction {
         QString name;
         bool canRepeat = false;
     };
-    virtual QList<JoystickAction> joystickActions() const { return {}; }
+    virtual QList<JoystickAction> joystickActions() { return {}; }
 
     /// Returns the list of first run prompt ids which need to be displayed according to current settings
-    Q_INVOKABLE QVariantList firstRunPromptsToShow() const;
+    Q_INVOKABLE QVariantList firstRunPromptsToShow();
 
     bool showTouchAreas() const { return _showTouchAreas; }
     bool showAdvancedUI() const { return _showAdvancedUI; }


### PR DESCRIPTION
Adding these was causing all sorts of problems in custom build implementations