### PR TITLE
Add simple custom build mechanism for custom guided actions

### DIFF
--- a/custom-example/custom.qrc
+++ b/custom-example/custom.qrc
@@ -30,7 +30,9 @@
         <file alias="Custom/Widgets/qmldir">res/Custom/Widgets/qmldir</file>
     </qresource>
     <qresource prefix="/qml">
-        <file alias="QGroundControl/FlightDisplay/FlyViewCustomLayer.qml">res/CustomFlyViewOverlay.qml</file>
+        <file alias="QGroundControl/FlightDisplay/CustomGuidedActionsController.qml">src/CustomGuidedActionsController.qml</file>
+        <file alias="QGroundControl/FlightDisplay/FlyViewCustomLayer.qml">src/FlyViewCustomLayer.qml</file>
+        <file alias="QGroundControl/FlightDisplay/FlyViewToolStripActionList.qml">src/FlyViewToolStripActionList.qml</file>
     </qresource>
     <qresource prefix="/res">
         <file alias="QGCLogoFull.svg">res/QGCLogoFull.svg</file>

--- a/custom-example/qgroundcontrol.exclusion
+++ b/custom-example/qgroundcontrol.exclusion
@@ -1,2 +1,4 @@
+        <file alias="QGroundControl/FlightDisplay/CustomGuidedActionsController.qml">src/FlightDisplay/CustomGuidedActionsController.qml</file>
         <file alias="QGroundControl/FlightDisplay/FlyViewCustomLayer.qml">src/FlightDisplay/FlyViewCustomLayer.qml</file>
+        <file alias="QGroundControl/FlightDisplay/FlyViewToolStripActionList.qml">src/FlightDisplay/FlyViewToolStripActionList.qml</file>
 

--- a/custom-example/qgroundcontrol.qrc
+++ b/custom-example/qgroundcontrol.qrc
@@ -232,7 +232,6 @@
 		<file alias="QGroundControl/FlightDisplay/FlyViewToolBar.qml">../src/UI/toolbar/FlyViewToolBar.qml</file>
 		<file alias="QGroundControl/FlightDisplay/FlyViewToolBarIndicators.qml">../src/UI/toolbar/FlyViewToolBarIndicators.qml</file>
 		<file alias="QGroundControl/FlightDisplay/FlyViewToolStrip.qml">../src/FlightDisplay/FlyViewToolStrip.qml</file>
-		<file alias="QGroundControl/FlightDisplay/FlyViewToolStripActionList.qml">../src/FlightDisplay/FlyViewToolStripActionList.qml</file>
 		<file alias="QGroundControl/FlightDisplay/FlyViewTopRightColumnLayout.qml">../src/FlightDisplay/FlyViewTopRightColumnLayout.qml</file>
 		<file alias="QGroundControl/FlightDisplay/FlyViewVideo.qml">../src/FlightDisplay/FlyViewVideo.qml</file>
 		<file alias="QGroundControl/FlightDisplay/OnScreenGimbalController.qml">../src/FlightDisplay/OnScreenGimbalController.qml</file>

--- a/custom-example/src/CustomGuidedActionsController.qml
+++ b/custom-example/src/CustomGuidedActionsController.qml
@@ -1,0 +1,46 @@
+/****************************************************************************
+ *
+ * (c) 2009-2020 QGROUNDCONTROL PROJECT <http://www.qgroundcontrol.org>
+ *
+ * QGroundControl is licensed according to the terms in the file
+ * COPYING.md in the root of the source code directory.
+ *
+ ****************************************************************************/
+
+// Custom builds can override this file to add custom guided actions.
+
+import QtQml
+
+QtObject {
+    readonly property int actionCustomButton: _guidedController.customActionStart + 0
+
+    readonly property string customButtonTitle: qsTr("Custom")
+
+    readonly property string customButtonMessage: qsTr("Example of a custom action.")
+
+    function customConfirmAction(actionCode, actionData, mapIndicator, confirmDialog) {
+        switch (actionCode) {
+        case actionCustomButton:
+            confirmDialog.hideTrigger = true
+            confirmDialog.title = customButtonTitle
+            confirmDialog.message = customButtonMessage
+            break
+        default:
+            return false // false = action not handled here
+        }
+
+        return true // true = action handled here
+    }
+
+    function customExecuteAction(actionCode, actionData, sliderOutputValue, optionCheckedode) {
+        switch (actionCode) {
+        case actionCustomButton:
+            mainWindow.showMessageDialog("Custom Action", "Custom action executed.")
+            break
+        default:
+            return false // false = action not handled here
+        }
+
+        return true // true = action handled here
+    }
+}

--- a/custom-example/src/FlyViewCustomLayer.qml
+++ b/custom-example/src/FlyViewCustomLayer.qml
@@ -95,11 +95,11 @@ Item {
         id:                         compassBar
         height:                     ScreenTools.defaultFontPixelHeight * 1.5
         width:                      ScreenTools.defaultFontPixelWidth  * 50
+        anchors.bottom:             parent.bottom
+        anchors.bottomMargin:       _toolsMargin
         color:                      "#DEDEDE"
         radius:                     2
         clip:                       true
-        anchors.top:                headingIndicator.bottom
-        anchors.topMargin:          -headingIndicator.height / 2
         anchors.horizontalCenter:   parent.horizontalCenter
         Repeater {
             model: 720
@@ -137,8 +137,8 @@ Item {
         height:                     ScreenTools.defaultFontPixelHeight
         width:                      ScreenTools.defaultFontPixelWidth * 4
         color:                      qgcPal.windowShadeDark
-        anchors.top:                parent.top
-        anchors.topMargin:          _toolsMargin
+        anchors.top:                compassBar.top
+        anchors.topMargin:          -headingIndicator.height / 2
         anchors.horizontalCenter:   parent.horizontalCenter
         QGCLabel {
             text:                   _heading

--- a/custom-example/src/FlyViewToolStripActionList.qml
+++ b/custom-example/src/FlyViewToolStripActionList.qml
@@ -1,0 +1,43 @@
+/****************************************************************************
+ *
+ * (c) 2009-2020 QGROUNDCONTROL PROJECT <http://www.qgroundcontrol.org>
+ *
+ * QGroundControl is licensed according to the terms in the file
+ * COPYING.md in the root of the source code directory.
+ *
+ ****************************************************************************/
+
+import QtQml.Models
+
+import QGroundControl
+import QGroundControl.Controls
+
+ToolStripActionList {
+    id: _root
+
+    signal displayPreFlightChecklist
+
+    model: [
+        ToolStripAction {
+            text:           qsTr("Plan")
+            iconSource:     "/qmlimages/Plan.svg"
+            onTriggered:{
+                mainWindow.showPlanView()
+                viewer3DWindow.close()
+            }
+        },
+        PreFlightCheckListShowAction { onTriggered: displayPreFlightChecklist() },
+        GuidedActionTakeoff { },
+        GuidedActionLand { },
+        GuidedActionRTL { },
+        GuidedActionPause { },
+        GuidedActionActionList { },
+        GuidedToolStripAction {
+            text:       _guidedController._customController.customButtonTitle
+            iconSource: "/res/gear-white.svg"
+            visible:    true
+            enabled:    true
+            actionID:   _guidedController._customController.actionCustomButton
+}
+    ]
+}

--- a/qgroundcontrol.qrc
+++ b/qgroundcontrol.qrc
@@ -222,6 +222,7 @@
         <file alias="QGroundControl/FactControls/LabelledFactTextField.qml">src/FactSystem/FactControls/LabelledFactTextField.qml</file>
         <file alias="QGroundControl/FactControls/LabelledFactSlider.qml">src/FactSystem/FactControls/LabelledFactSlider.qml</file>
         <file alias="QGroundControl/FactControls/qmldir">src/QmlControls/QGroundControl/FactControls/qmldir</file>
+        <file alias="QGroundControl/FlightDisplay/CustomGuidedActionsController.qml">src/FlightDisplay/CustomGuidedActionsController.qml</file>
         <file alias="QGroundControl/FlightDisplay/FlightDisplayViewVideo.qml">src/FlightDisplay/FlightDisplayViewVideo.qml</file>
         <file alias="QGroundControl/FlightDisplay/FlyView.qml">src/FlightDisplay/FlyView.qml</file>
         <file alias="QGroundControl/FlightDisplay/FlyViewBottomRightRowLayout.qml">src/FlightDisplay/FlyViewBottomRightRowLayout.qml</file>

--- a/src/FlightDisplay/CustomGuidedActionsController.qml
+++ b/src/FlightDisplay/CustomGuidedActionsController.qml
@@ -1,0 +1,22 @@
+/****************************************************************************
+ *
+ * (c) 2009-2020 QGROUNDCONTROL PROJECT <http://www.qgroundcontrol.org>
+ *
+ * QGroundControl is licensed according to the terms in the file
+ * COPYING.md in the root of the source code directory.
+ *
+ ****************************************************************************/
+
+// Custom builds can override this file to add custom guided actions.
+
+import QtQml
+
+QtObject {
+    function customConfirmAction(actionCode, actionData, mapIndicator, confirmDialog) {
+        return false // false = action not handled here
+    }
+
+    function customExecuteAction(actionCode, actionData, sliderOutputValue, optionCheckedode) {
+        return false // false = action not handled here
+    }
+}

--- a/src/QmlControls/QGroundControl/FlightDisplay/qmldir
+++ b/src/QmlControls/QGroundControl/FlightDisplay/qmldir
@@ -1,5 +1,6 @@
 Module QGroundControl.FlightDisplay
 
+CustomGuidedActionsController   1.0 CustomGuidedActionsController.qml
 FlyView                         1.0 FlyView.qml
 FlyViewBottomRightRowLayout     1.0 FlyViewBottomRightRowLayout.qml
 FlyViewCustomLayer              1.0 FlyViewCustomLayer.qml


### PR DESCRIPTION
<img width="692" alt="Screenshot 2024-12-18 at 8 58 29 PM" src="https://github.com/user-attachments/assets/ef584793-94d7-4611-b8a0-81d33eeee705" />

* Custom builds can override CustomGuidedActionsController.qml resource to add custom guided actions. This way y ou don't need to fully override the huge GuidedActionsController.qml file. Which is much more prone to causing problems when you update to new upstream qgc sources.
* Added example custom button to custom-example version of QGC
* At some point I'd like to do something much more sophisticated than this which also prevents the need to override FlyViewToolStripActionList.qml. But for now this is a step in a cleaner direction.