### PR TITLE
Various Landing Pattern fixes and add final approach speed

### DIFF
--- a/src/FactSystem/FactControls/FactCheckBox.qml
+++ b/src/FactSystem/FactControls/FactCheckBox.qml
@@ -14,8 +14,8 @@ QGCCheckBox {
     Binding on checkState {
         value: fact ?
                    (fact.typeIsBool ?
-                        (fact.value === false ? Qt.Unchecked : Qt.Checked) :
-                        (fact.value === 0 ? Qt.Unchecked : Qt.Checked)) :
+                        (fact.value ? Qt.Checked : Qt.Unchecked) :
+                        (fact.value !== 0 ? Qt.Checked : Qt.Unchecked)) :
                    Qt.Unchecked
     }
 

--- a/src/MissionManager/FWLandingPattern.FactMetaData.json
+++ b/src/MissionManager/FWLandingPattern.FactMetaData.json
@@ -31,6 +31,21 @@
     "default":          40.0
 },
 {
+    "name":             "UseDoChangeSpeed",
+    "shortDesc":        "Command a specific speed for the approach, useful for reducing energy before the glide slope.",
+    "type":             "bool",
+    "default":          false
+},
+{
+    "name":             "FinalApproachSpeed",
+    "shortDesc":        "Speed to perform the approach at.",
+    "type":             "double",
+    "units":            "m/s",
+    "min":              0.0,
+    "decimalPlaces":    1,
+    "default":          9.0
+},
+{
     "name":             "LoiterRadius",
     "shortDesc":        "Loiter radius.",
     "type":             "double",

--- a/src/MissionManager/FixedWingLandingComplexItem.cc
+++ b/src/MissionManager/FixedWingLandingComplexItem.cc
@@ -139,7 +139,8 @@ bool FixedWingLandingComplexItem::_isValidLandItem(const MissionItem& missionIte
 {
     if (missionItem.command() != MAV_CMD_NAV_LAND ||
             !(missionItem.frame() == MAV_FRAME_GLOBAL_RELATIVE_ALT || missionItem.frame() == MAV_FRAME_GLOBAL) ||
-            missionItem.param1() != 0 || missionItem.param2() != 0 || missionItem.param3() != 0 || missionItem.param4() != 0) {
+            // ArduPilot automatically sets param4 to 1, so we have to allow for it.
+            missionItem.param1() != 0 || missionItem.param2() != 0 || missionItem.param3() != 0 || (missionItem.param4() != 0 && missionItem.param4() != 1)) {
         return false;
     } else {
         return true;

--- a/src/MissionManager/FixedWingLandingComplexItem.cc
+++ b/src/MissionManager/FixedWingLandingComplexItem.cc
@@ -26,6 +26,8 @@ FixedWingLandingComplexItem::FixedWingLandingComplexItem(PlanMasterController* m
     , _metaDataMap              (FactMetaData::createMapFromJsonFile(QStringLiteral(":/json/FWLandingPattern.FactMetaData.json"), this))
     , _landingDistanceFact      (settingsGroup, _metaDataMap[finalApproachToLandDistanceName])
     , _finalApproachAltitudeFact(settingsGroup, _metaDataMap[finalApproachAltitudeName])
+    , _useDoChangeSpeedFact     (settingsGroup, _metaDataMap[useDoChangeSpeedName])
+    , _finalApproachSpeedFact   (settingsGroup, _metaDataMap[finalApproachSpeedName])
     , _loiterRadiusFact         (settingsGroup, _metaDataMap[loiterRadiusName])
     , _loiterClockwiseFact      (settingsGroup, _metaDataMap[loiterClockwiseName])
     , _landingHeadingFact       (settingsGroup, _metaDataMap[landingHeadingName])

--- a/src/MissionManager/FixedWingLandingComplexItem.h
+++ b/src/MissionManager/FixedWingLandingComplexItem.h
@@ -65,6 +65,8 @@ private:
 
     // Overrides from LandingComplexItem
     const Fact*     _finalApproachAltitude  (void) const final { return &_finalApproachAltitudeFact; }
+    const Fact*     _useDoChangeSpeed       (void) const final { return &_useDoChangeSpeedFact; }
+    const Fact*     _finalApproachSpeed     (void) const final { return &_finalApproachSpeedFact; }
     const Fact*     _loiterRadius           (void) const final { return &_loiterRadiusFact; }
     const Fact*     _loiterClockwise        (void) const final { return &_loiterClockwiseFact; }
     const Fact*     _landingAltitude        (void) const final { return &_landingAltitudeFact; }
@@ -80,6 +82,8 @@ private:
 
     Fact            _landingDistanceFact;
     Fact            _finalApproachAltitudeFact;
+    Fact            _useDoChangeSpeedFact;
+    Fact            _finalApproachSpeedFact;
     Fact            _loiterRadiusFact;
     Fact            _loiterClockwiseFact;
     Fact            _landingHeadingFact;

--- a/src/MissionManager/LandingComplexItem.cc
+++ b/src/MissionManager/LandingComplexItem.cc
@@ -388,14 +388,19 @@ bool LandingComplexItem::_scanForItem(QmlObjectListModel* visualItems, bool flyV
     MissionItem& missionItemFinalApproach = item->missionItem();
     if (missionItemFinalApproach.command() == MAV_CMD_NAV_LOITER_TO_ALT) {
         if (missionItemFinalApproach.frame() != landPointFrame ||
-                missionItemFinalApproach.param1() != 1.0 || missionItemFinalApproach.param3() != 0 || missionItemFinalApproach.param4() != 1.0) {
+            (masterController->managerVehicle()->apmFirmware()
+             // APM automatically changes the value of param1 to 1, so when sending a plan it will
+             // be 0, and when downloading it, the value will be 1
+             ? missionItemFinalApproach.param1() != 0.0 && missionItemFinalApproach.param1() != 1.0
+             : missionItemFinalApproach.param1() != 1.0) ||
+            missionItemFinalApproach.param3() != 0 || missionItemFinalApproach.param4() != 1.0) {
             return false;
         }
     } else if (missionItemFinalApproach.command() == MAV_CMD_NAV_WAYPOINT) {
         if (missionItemFinalApproach.frame() != landPointFrame ||
-                missionItemFinalApproach.param1() != 0 || missionItemFinalApproach.param2() != 0 || missionItemFinalApproach.param3() != 0 ||
-                !qIsNaN(missionItemFinalApproach.param4()) ||
-                qIsNaN(missionItemFinalApproach.param5()) || qIsNaN(missionItemFinalApproach.param6()) || qIsNaN(missionItemFinalApproach.param6())) {
+            missionItemFinalApproach.param1() != 0 || missionItemFinalApproach.param2() != 0 || missionItemFinalApproach.param3() != 0 ||
+            (!masterController->managerVehicle()->apmFirmware() && !qIsNaN(missionItemFinalApproach.param4())) ||
+            qIsNaN(missionItemFinalApproach.param5()) || qIsNaN(missionItemFinalApproach.param6()) || qIsNaN(missionItemFinalApproach.param6())) {
             return false;
         }
         useLoiterToAlt = false;
@@ -425,9 +430,8 @@ bool LandingComplexItem::_scanForItem(QmlObjectListModel* visualItems, bool flyV
     }
     MissionItem& missionItemDoLandStart = item->missionItem();
     if (missionItemDoLandStart.command() != MAV_CMD_DO_LAND_START ||
-            missionItemDoLandStart.frame() != MAV_FRAME_MISSION ||
-            missionItemDoLandStart.param1() != 0 || missionItemDoLandStart.param2() != 0 || missionItemDoLandStart.param3() != 0 || missionItemDoLandStart.param4() != 0 ||
-            missionItemDoLandStart.param5() != 0 || missionItemDoLandStart.param6() != 0 || missionItemDoLandStart.param7() != 0) {
+        missionItemDoLandStart.param1() != 0 || missionItemDoLandStart.param2() != 0 || missionItemDoLandStart.param3() != 0 || missionItemDoLandStart.param4() != 0 ||
+        missionItemDoLandStart.param5() != 0 || missionItemDoLandStart.param6() != 0 || missionItemDoLandStart.param7() != 0) {
         return false;
     }
 

--- a/src/MissionManager/LandingComplexItem.h
+++ b/src/MissionManager/LandingComplexItem.h
@@ -31,6 +31,8 @@ public:
     LandingComplexItem(PlanMasterController* masterController, bool flyView);
 
     Q_PROPERTY(Fact*            finalApproachAltitude   READ    finalApproachAltitude                                           CONSTANT)
+    Q_PROPERTY(Fact*            useDoChangeSpeed        READ    useDoChangeSpeed                                                CONSTANT)
+    Q_PROPERTY(Fact*            finalApproachSpeed      READ    finalApproachSpeed                                              CONSTANT)
     Q_PROPERTY(Fact*            loiterRadius            READ    loiterRadius                                                    CONSTANT)
     Q_PROPERTY(Fact*            landingAltitude         READ    landingAltitude                                                 CONSTANT)
     Q_PROPERTY(Fact*            landingHeading          READ    landingHeading                                                  CONSTANT)
@@ -48,6 +50,8 @@ public:
     Q_INVOKABLE void setLandingHeadingToTakeoffHeading();
 
     const Fact* finalApproachAltitude   (void) const { return _finalApproachAltitude(); }
+    const Fact* useDoChangeSpeed        (void) const { return _useDoChangeSpeed(); }
+    const Fact* finalApproachSpeed      (void) const { return _finalApproachSpeed(); }
     const Fact* loiterRadius            (void) const { return _loiterRadius(); }
     const Fact* loiterClockwise         (void) const { return _loiterClockwise(); }
     const Fact* landingAltitude         (void) const { return _landingAltitude(); }
@@ -58,6 +62,8 @@ public:
     const Fact* stopTakingVideo         (void) const { return _stopTakingVideo(); }
 
     Fact* finalApproachAltitude (void) { return const_cast<Fact*>(const_cast<const LandingComplexItem*>(this)->_finalApproachAltitude()); };
+    Fact* useDoChangeSpeed      (void) { return const_cast<Fact*>(const_cast<const LandingComplexItem*>(this)->_useDoChangeSpeed()); };
+    Fact* finalApproachSpeed    (void) { return const_cast<Fact*>(const_cast<const LandingComplexItem*>(this)->_finalApproachSpeed()); };
     Fact* loiterRadius          (void) { return const_cast<Fact*>(const_cast<const LandingComplexItem*>(this)->_loiterRadius()); };
     Fact* loiterClockwise       (void) { return const_cast<Fact*>(const_cast<const LandingComplexItem*>(this)->_loiterClockwise()); };
     Fact* landingAltitude       (void) { return const_cast<Fact*>(const_cast<const LandingComplexItem*>(this)->_landingAltitude()); };
@@ -110,15 +116,17 @@ public:
     double              minAMSLAltitude             (void) const final { return amslExitAlt(); }
     double              maxAMSLAltitude             (void) const final { return amslEntryAlt(); }
 
-    static constexpr const char* finalApproachToLandDistanceName = "LandingDistance";
-    static constexpr const char* landingHeadingName              = "LandingHeading";
-    static constexpr const char* finalApproachAltitudeName       = "FinalApproachAltitude";
-    static constexpr const char* loiterRadiusName                = "LoiterRadius";
-    static constexpr const char* loiterClockwiseName             = "LoiterClockwise";
-    static constexpr const char* landingAltitudeName             = "LandingAltitude";
-    static constexpr const char* useLoiterToAltName              = "UseLoiterToAlt";
-    static constexpr const char* stopTakingPhotosName            = "StopTakingPhotos";
-    static constexpr const char* stopTakingVideoName             = "StopTakingVideo";
+    static constexpr const char* finalApproachToLandDistanceName    = "LandingDistance";
+    static constexpr const char* landingHeadingName                 = "LandingHeading";
+    static constexpr const char* finalApproachAltitudeName          = "FinalApproachAltitude";
+    static constexpr const char* useDoChangeSpeedName               = "UseDoChangeSpeed";
+    static constexpr const char* finalApproachSpeedName             = "FinalApproachSpeed";
+    static constexpr const char* loiterRadiusName                   = "LoiterRadius";
+    static constexpr const char* loiterClockwiseName                = "LoiterClockwise";
+    static constexpr const char* landingAltitudeName                = "LandingAltitude";
+    static constexpr const char* useLoiterToAltName                 = "UseLoiterToAlt";
+    static constexpr const char* stopTakingPhotosName               = "StopTakingPhotos";
+    static constexpr const char* stopTakingVideoName                = "StopTakingVideo";
 
 signals:
     void finalApproachCoordinateChanged (QGeoCoordinate coordinate);
@@ -137,6 +145,8 @@ protected slots:
 
 protected:
     virtual const Fact*     _finalApproachAltitude  (void) const = 0;
+    virtual const Fact*     _useDoChangeSpeed       (void) const = 0;
+    virtual const Fact*     _finalApproachSpeed     (void) const = 0;
     virtual const Fact*     _loiterRadius           (void) const = 0;
     virtual const Fact*     _loiterClockwise        (void) const = 0;
     virtual const Fact*     _landingAltitude        (void) const = 0;
@@ -151,6 +161,7 @@ protected:
     void            _init                   (void);
     QPointF         _rotatePoint            (const QPointF& point, const QPointF& origin, double angle);
     MissionItem*    _createDoLandStartItem  (int seqNum, QObject* parent);
+    MissionItem*    _createDoChangeSpeedItem(int speedType, int speedValue, int throttlePercentage, int seqNum, QObject* parent);
     MissionItem*    _createFinalApproachItem(int seqNum, QObject* parent);
     QJsonObject     _save                   (void);
     bool            _load                   (const QJsonObject& complexObject, int sequenceNumber, const QString& jsonComplexItemTypeValue, bool useDeprecatedRelAltKeys, QString& errorString);
@@ -178,14 +189,16 @@ protected:
     // the new support for using either a loiter or just a waypoint as the approach entry point.
     static constexpr const char* _jsonDeprecatedLoiterCoordinateKey          = "loiterCoordinate";
 
-    static constexpr const char* _jsonFinalApproachCoordinateKey = "landingApproachCoordinate";
-    static constexpr const char* _jsonLoiterRadiusKey            = "loiterRadius";
-    static constexpr const char* _jsonLoiterClockwiseKey         = "loiterClockwise";
-    static constexpr const char* _jsonLandingCoordinateKey       = "landCoordinate";
-    static constexpr const char* _jsonAltitudesAreRelativeKey    = "altitudesAreRelative";
-    static constexpr const char* _jsonUseLoiterToAltKey          = "useLoiterToAlt";
-    static constexpr const char* _jsonStopTakingPhotosKey        = "stopTakingPhotos";
-    static constexpr const char* _jsonStopTakingVideoKey         = "stopVideoPhotos";
+    static constexpr const char* _jsonFinalApproachCoordinateKey    = "landingApproachCoordinate";
+    static constexpr const char* _jsonUseDoChangeSpeedKey           = "useDoChangeSpeed";
+    static constexpr const char* _jsonFinalApproachSpeedKey         = "finalApproachSpeed";
+    static constexpr const char* _jsonLoiterRadiusKey               = "loiterRadius";
+    static constexpr const char* _jsonLoiterClockwiseKey            = "loiterClockwise";
+    static constexpr const char* _jsonLandingCoordinateKey          = "landCoordinate";
+    static constexpr const char* _jsonAltitudesAreRelativeKey       = "altitudesAreRelative";
+    static constexpr const char* _jsonUseLoiterToAltKey             = "useLoiterToAlt";
+    static constexpr const char* _jsonStopTakingPhotosKey           = "stopTakingPhotos";
+    static constexpr const char* _jsonStopTakingVideoKey            = "stopVideoPhotos";
 
 private slots:
     void    _recalcFromRadiusChange                         (void);

--- a/src/MissionManager/VTOLLandingComplexItem.cc
+++ b/src/MissionManager/VTOLLandingComplexItem.cc
@@ -109,7 +109,7 @@ void VTOLLandingComplexItem::_calcGlideSlope(void)
 
 bool VTOLLandingComplexItem::_isValidLandItem(const MissionItem& missionItem)
 {
-    if (missionItem.command() != MAV_CMD_NAV_LAND ||
+    if (missionItem.command() != MAV_CMD_NAV_VTOL_LAND ||
             !(missionItem.frame() == MAV_FRAME_GLOBAL_RELATIVE_ALT || missionItem.frame() == MAV_FRAME_GLOBAL) ||
             missionItem.param1() != 0 || missionItem.param2() != 0 || missionItem.param3() != 0 || !qIsNaN(missionItem.param4())) {
         return false;

--- a/src/MissionManager/VTOLLandingComplexItem.cc
+++ b/src/MissionManager/VTOLLandingComplexItem.cc
@@ -29,6 +29,8 @@ VTOLLandingComplexItem::VTOLLandingComplexItem(PlanMasterController* masterContr
     , _metaDataMap              (FactMetaData::createMapFromJsonFile(QStringLiteral(":/json/VTOLLandingPattern.FactMetaData.json"), this))
     , _landingDistanceFact      (settingsGroup, _metaDataMap[finalApproachToLandDistanceName])
     , _finalApproachAltitudeFact(settingsGroup, _metaDataMap[finalApproachAltitudeName])
+    , _useDoChangeSpeedFact     (settingsGroup, _metaDataMap[useDoChangeSpeedName])
+    , _finalApproachSpeedFact   (settingsGroup, _metaDataMap[finalApproachSpeedName])
     , _loiterRadiusFact         (settingsGroup, _metaDataMap[loiterRadiusName])
     , _loiterClockwiseFact      (settingsGroup, _metaDataMap[loiterClockwiseName])
     , _landingHeadingFact       (settingsGroup, _metaDataMap[landingHeadingName])

--- a/src/MissionManager/VTOLLandingComplexItem.h
+++ b/src/MissionManager/VTOLLandingComplexItem.h
@@ -52,6 +52,8 @@ private:
 
     // Overrides from LandingComplexItem
     const Fact*     _finalApproachAltitude  (void) const final { return &_finalApproachAltitudeFact; }
+    const Fact*     _useDoChangeSpeed       (void) const final { return &_useDoChangeSpeedFact; }
+    const Fact*     _finalApproachSpeed     (void) const final { return &_finalApproachSpeedFact; }
     const Fact*     _loiterRadius           (void) const final { return &_loiterRadiusFact; }
     const Fact*     _loiterClockwise        (void) const final { return &_loiterClockwiseFact; }
     const Fact*     _landingAltitude        (void) const final { return &_landingAltitudeFact; }
@@ -67,6 +69,8 @@ private:
 
     Fact            _landingDistanceFact;
     Fact            _finalApproachAltitudeFact;
+    Fact            _useDoChangeSpeedFact;
+    Fact            _finalApproachSpeedFact;
     Fact            _loiterRadiusFact;
     Fact            _loiterClockwiseFact;
     Fact            _landingHeadingFact;

--- a/src/PlanView/FWLandingPatternEditor.qml
+++ b/src/PlanView/FWLandingPatternEditor.qml
@@ -100,6 +100,18 @@ Rectangle {
                     altitudeMode:       _altitudeMode
                 }
 
+                FactCheckBox {
+                    id:         flightSpeedCheckbox
+                    text:       qsTr("Flight Speed")
+                    fact:       missionItem.useDoChangeSpeed
+                }
+
+                FactTextField {
+                    Layout.fillWidth:   true
+                    fact:               missionItem.finalApproachSpeed
+                    enabled:            flightSpeedCheckbox.checked
+                }
+
                 QGCLabel {
                     text:       qsTr("Radius")
                     visible:    missionItem.useLoiterToAlt.rawValue

--- a/src/PlanView/FWLandingPatternEditor.qml
+++ b/src/PlanView/FWLandingPatternEditor.qml
@@ -32,16 +32,16 @@ Rectangle {
     //property real   availableWidth    ///< Width for control
     //property var    missionItem       ///< Mission Item for editor
 
-    property var    _masterControler:               masterController
-    property var    _missionController:             _masterControler.missionController
-    property var    _missionVehicle:                _masterControler.controllerVehicle
+    property var    _masterControler:           masterController
+    property var    _missionController:         _masterControler.missionController
+    property var    _missionVehicle:            _masterControler.controllerVehicle
     property real   _margin:                    ScreenTools.defaultFontPixelWidth / 2
     property real   _spacer:                    ScreenTools.defaultFontPixelWidth / 2
     property string _setToVehicleHeadingStr:    qsTr("Set to vehicle heading")
     property string _setToVehicleLocationStr:   qsTr("Set to vehicle location")
     property bool   _showCameraSection:         !_missionVehicle.apmFirmware
     property int    _altitudeMode:              missionItem.altitudesAreRelative ? QGroundControl.AltitudeModeRelative : QGroundControl.AltitudeModeAbsolute
-
+    property real   _previousLoiterRadius:      0
 
     Column {
         id:                 editorColumn
@@ -69,6 +69,22 @@ Rectangle {
             FactCheckBox {
                 text:       qsTr("Use loiter to altitude")
                 fact:       missionItem.useLoiterToAlt
+
+                // When not using loiter to altitude, set radius to 0 to set the
+                // glide slope heading correctly
+                onCheckedChanged: {
+                    if (checked) {
+                        // Restore the previous loiter radius or set the default value
+                        if (_previousLoiterRadius > 0) {
+                            missionItem.loiterRadius.rawValue = _previousLoiterRadius
+                        } else {
+                            missionItem.loiterRadius.rawValue = missionItem.loiterRadius.defaultValue
+                        }
+                    } else {
+                        _previousLoiterRadius = missionItem.loiterRadius.rawValue
+                        missionItem.loiterRadius.rawValue = 0
+                    }
+                }
             }
 
             GridLayout {

--- a/test/MissionManager/LandingComplexItemTest.cc
+++ b/test/MissionManager/LandingComplexItemTest.cc
@@ -77,6 +77,8 @@ void LandingComplexItemTest::_testDirty(void)
     // These facts should set dirty when changed
     QList<Fact*> rgFacts;
     rgFacts << _item->finalApproachAltitude()
+            << _item->useDoChangeSpeed()
+            << _item->finalApproachSpeed()
             << _item->landingHeading()
             << _item->loiterRadius()
             << _item->loiterClockwise()
@@ -318,6 +320,8 @@ void LandingComplexItemTest::_validateItem(LandingComplexItem* actualItem, Landi
     QCOMPARE(actualItem->stopTakingVideo()->rawValue().toBool(),        expectedItem->stopTakingVideo()->rawValue().toBool());
     QCOMPARE(actualItem->useLoiterToAlt()->rawValue().toBool(),         expectedItem->useLoiterToAlt()->rawValue().toBool());
     QCOMPARE(actualItem->finalApproachAltitude()->rawValue().toInt(),   expectedItem->finalApproachAltitude()->rawValue().toInt());
+    QCOMPARE(actualItem->useDoChangeSpeed()->rawValue().toBool(),       expectedItem->useDoChangeSpeed()->rawValue().toBool());
+    QCOMPARE(actualItem->finalApproachSpeed()->rawValue().toInt(),      expectedItem->finalApproachSpeed()->rawValue().toInt());
     QCOMPARE(actualItem->landingAltitude()->rawValue().toInt(),         expectedItem->landingAltitude()->rawValue().toInt());
     QCOMPARE(actualItem->landingHeading()->rawValue().toInt(),          expectedItem->landingHeading()->rawValue().toInt());
     QCOMPARE(actualItem->landingDistance()->rawValue().toInt(),         expectedItem->landingDistance()->rawValue().toInt());
@@ -338,6 +342,8 @@ SimpleLandingComplexItem::SimpleLandingComplexItem(PlanMasterController* masterC
     , _metaDataMap              (FactMetaData::createMapFromJsonFile(QStringLiteral(":/json/VTOLLandingPattern.FactMetaData.json"), this))
     , _landingDistanceFact      (settingsGroup, _metaDataMap[finalApproachToLandDistanceName])
     , _finalApproachAltitudeFact(settingsGroup, _metaDataMap[finalApproachAltitudeName])
+    , _useDoChangeSpeedFact     (settingsGroup, _metaDataMap[useDoChangeSpeedName])
+    , _finalApproachSpeedFact   (settingsGroup, _metaDataMap[finalApproachSpeedName])
     , _loiterRadiusFact         (settingsGroup, _metaDataMap[loiterRadiusName])
     , _loiterClockwiseFact      (settingsGroup, _metaDataMap[loiterClockwiseName])
     , _landingHeadingFact       (settingsGroup, _metaDataMap[landingHeadingName])

--- a/test/MissionManager/LandingComplexItemTest.h
+++ b/test/MissionManager/LandingComplexItemTest.h
@@ -97,6 +97,8 @@ private:
 
     // Overrides from LandingComplexItem
     const Fact*     _finalApproachAltitude  (void) const final { return &_finalApproachAltitudeFact; }
+    const Fact*     _useDoChangeSpeed       (void) const final { return &_useDoChangeSpeedFact; }
+    const Fact*     _finalApproachSpeed     (void) const final { return &_finalApproachSpeedFact; }
     const Fact*     _loiterRadius           (void) const final { return &_loiterRadiusFact; }
     const Fact*     _loiterClockwise        (void) const final { return &_loiterClockwiseFact; }
     const Fact*     _landingAltitude        (void) const final { return &_landingAltitudeFact; }
@@ -112,6 +114,8 @@ private:
 
     Fact            _landingDistanceFact;
     Fact            _finalApproachAltitudeFact;
+    Fact            _useDoChangeSpeedFact;
+    Fact            _finalApproachSpeedFact;
     Fact            _loiterRadiusFact;
     Fact            _loiterClockwiseFact;
     Fact            _landingHeadingFact;


### PR DESCRIPTION
# Various Landing Pattern fixes and add final approach speed

Description
-----------
### [Fix landing item scanning for ArduPilot fixed wing](https://github.com/mavlink/qgroundcontrol/commit/10374feaf0549b187a78d7754530b6b4acd0b909):

Addressed issues with scanning and interpreting landing sequences for fixed wing ArduPilot aircraft. Previously, landing sequences uploaded to ArduPilot fixed wing aircraft and then downloaded back weren't being reinterpreted as QGC LandingComplexItems. The system to detect a landing sequence and translate it back to a LandingComplexItem wasn't working correctly due to multiple assumptions about mission item parameters that weren't accurate for ArduPilot.

The changes include adjusting parameter checks for NAV_LAND, NAV_LOITER_TO_ALT, NAV_WAYPOINT, and DO_LAND_START commands to align with ArduPilot's implementation, without modifying the existing logic for other firmwares.

### [Fix waypoint glide slope heading calculations](https://github.com/mavlink/qgroundcontrol/commit/a7d3240d47bf28e557ddf0a3664893c49c3b82fa):

When not using the "Use loiter to altitude" option in the Landing Pattern mission item, the heading of the glide slope still took into account the old loiter radius. Adjusted the QML code to change the loiter radius to 0 in landing patterns that use a waypoint as the approach start, which in turns lead to correct heading calculations.

Ideally, the _recalcFromHeadingAndDistanceChange, _recalcFromRadiusChange and _recalcFromCoordinateChange should be refactored to account for the fact that a landing pattern can use a waypoint instead of a loiter. However, this fix works just as well and is much simpler.

### [Fix boolean Fact interpretation in QGCCheckBox](https://github.com/mavlink/qgroundcontrol/commit/27d1ad0c20500ebb33c04d615c768d61666013bb):

Addressed an issue where the values of boolean Facts where the QVariant was of type int were not being correctly interpreted to drive the checked status of the QGCCheckBox. This was a problem with boolean Facts loaded from JSON where the default was "false", in which case the checkbox didn't work correctly.

### [Add final approach speed to the Landing Pattern](https://github.com/mavlink/qgroundcontrol/commit/cda7b95dd601acbd98a9091178c72fb1eaf93c0a):

Introduced an option for setting an airspeed for the final approach in the Landing Pattern editor, almost identical to the one found in standard waypoints, for the purposes of energy management before the glide slope.

It works by inserting a DO_CHANGE_SPEED mission element right after the DO_LAND_START, in such a way that the speed is also changed in the event of an RTL. The option is unchecked by default.

### [Fix VTOL landing item scanning for PX4](https://github.com/mavlink/qgroundcontrol/commit/a8f6c0080604107b8109f64948f5b0f35ebd0d57):

Fixes #12266 (fix by @anaam-wingxpand).

Checklist:
----------
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [X] [Review Contribution Guidelines](https://github.com/mavlink/qgroundcontrol/blob/master/.github/CONTRIBUTING.md).
- [X] [Review Code of Conduct](https://github.com/mavlink/qgroundcontrol/blob/master/.github/CODE_OF_CONDUCT.md).
- [X] I have tested my changes.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.