### PR TITLE
Remote ID: Fix validation

### DIFF
--- a/src/QmlControls/QGCTextField.qml
+++ b/src/QmlControls/QGCTextField.qml
@@ -53,25 +53,31 @@ TextField {
             if (validationError) {
                 validationToolTip.visible = true
             }
+        } else {
+            validationToolTip.visible = false
         }
     }
 
-    function showValidationError(errorString, originalValidValue = undefined) {
+    function showValidationError(errorString, originalValidValue = undefined, preventViewSiwtch = true) {
         validationToolTip.text = errorString
         validationToolTip.originalValidValue = originalValidValue
         validationToolTip.visible = true
         if (!validationError) {
             validationError = true
-            globals.validationErrorCount++
+            if (preventViewSiwtch) {
+                globals.validationErrorCount++
+            }
         }
     }
 
-    function clearValidationError() {
+    function clearValidationError(preventViewSiwtch = true) {
         validationToolTip.visible = false
         validationToolTip.originalValidValue = undefined
         if (validationError) {
             validationError = false
-            globals.validationErrorCount--
+            if (preventViewSiwtch) {
+                globals.validationErrorCount--
+            }
         }
     }
 

--- a/src/QmlControls/QGCTextField.qml
+++ b/src/QmlControls/QGCTextField.qml
@@ -53,31 +53,25 @@ TextField {
             if (validationError) {
                 validationToolTip.visible = true
             }
-        } else {
-            validationToolTip.visible = false
         }
     }
 
-    function showValidationError(errorString, originalValidValue = undefined, preventViewSiwtch = true) {
+    function showValidationError(errorString, originalValidValue = undefined) {
         validationToolTip.text = errorString
         validationToolTip.originalValidValue = originalValidValue
         validationToolTip.visible = true
         if (!validationError) {
             validationError = true
-            if (preventViewSiwtch) {
-                globals.validationErrorCount++
-            }
+            globals.validationErrorCount++
         }
     }
 
-    function clearValidationError(preventViewSiwtch = true) {
+    function clearValidationError() {
         validationToolTip.visible = false
         validationToolTip.originalValidValue = undefined
         if (validationError) {
             validationError = false
-            if (preventViewSiwtch) {
-                globals.validationErrorCount--
-            }
+            globals.validationErrorCount--
         }
     }
 

--- a/src/UI/preferences/RemoteIDSettings.qml
+++ b/src/UI/preferences/RemoteIDSettings.qml
@@ -342,8 +342,6 @@ SettingsPage {
             SettingsGroupLayout {
                 heading:            qsTr("Operator ID")
                 Layout.fillWidth:   true
-                outerBorderColor: (_regionOperation === RemoteIDSettings.RegionOperation.EU || remoteIDSettings.sendOperatorID.value) ?
-                                      (_activeRID && !_remoteIDManager.operatorIDGood ? qgcPal.colorRed : defaultBorderColor) : defaultBorderColor
 
                 FactCheckBoxSlider {
                     text:               qsTr("Broadcast%1").arg(isEURegion ? " (EU Required)" : "")
@@ -375,12 +373,24 @@ SettingsPage {
                     }
 
                     QGCTextField {
+                        id:                     operatorIDTextField
                         Layout.preferredWidth:  textFieldWidth
                         Layout.fillWidth:       true
                         text:                   operatorIDFact.valueString
                         visible:                operatorIDFact.visible
                         maximumLength:          20                  // Maximum defined by Mavlink definition of OPEN_DRONE_ID_OPERATOR_ID message
 
+                        property bool operatorIDInvalid: ((_regionOperation === RemoteIDSettings.RegionOperation.EU || remoteIDSettings.sendOperatorID.value) &&
+                                                            _activeRID && !_remoteIDManager.operatorIDGood)
+
+                        onOperatorIDInvalidChanged: {
+                            if (operatorIDInvalid) {
+                                operatorIDTextField.showValidationError(qsTr("Invalid Operator ID"), operatorIDFact.valueString, false /* preventViewSwitch */)
+                            } else {
+                                operatorIDTextField.clearValidationError(false /* preventViewSwitch */)
+                            }
+                        }
+                        
                         onTextChanged: {
                             operatorIDFact.value = text
                             if (_activeVehicle) {


### PR DESCRIPTION
* Fix #12137
* Use standard validation UI for operator id validation

<img width="345" alt="Screenshot 2024-12-21 at 2 46 42 PM" src="https://github.com/user-attachments/assets/1a3288dd-3cf0-4a09-8e0f-cd1759817350" />
