### PR TITLE
Standard methods for parsing available flight mode for PX4 and APM

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -553,4 +553,12 @@ elseif(MACOS)
     install(SCRIPT "${CMAKE_SOURCE_DIR}/cmake/CreateMacDMG.cmake")
 endif()
 
+## Enforce Handling of All Enum Cases
+
+if(WIN32)
+    add_compile_options(/w44265 /we44265)
+else()
+    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wswitch -Werror=switch")
+endif()
+
 include(printSummary)

--- a/custom-example/src/FirmwarePlugin/CustomFirmwarePlugin.cc
+++ b/custom-example/src/FirmwarePlugin/CustomFirmwarePlugin.cc
@@ -59,43 +59,86 @@ bool CustomFirmwarePlugin::hasGimbal(Vehicle* /*vehicle*/, bool& rollSupported, 
 
 void CustomFirmwarePlugin::updateAvailableFlightModes(FlightModeList modeList)
 {
-    _availableFlightModeList.clear();
-    for(auto mode: modeList){
 
+    for(auto &mode: modeList){
+        PX4CustomMode::Mode cMode = static_cast<PX4CustomMode::Mode>(mode.custom_mode);
         // Update Multi Rotor
-        switch (mode.custom_mode) {
-        case PX4CustomMode::POSCTL_ORBIT:
-            mode.multiRotor = false;
-            break;
-        default:
+        switch (cMode) {
+        case PX4CustomMode::MANUAL            :
+        case PX4CustomMode::STABILIZED        :
+        case PX4CustomMode::ACRO              :
+        case PX4CustomMode::RATTITUDE         :
+        case PX4CustomMode::ALTCTL            :
+        case PX4CustomMode::OFFBOARD          :
+        case PX4CustomMode::SIMPLE            :
+        case PX4CustomMode::POSCTL_POSCTL     :
+        case PX4CustomMode::AUTO_LOITER       :
+        case PX4CustomMode::AUTO_MISSION      :
+        case PX4CustomMode::AUTO_RTL          :
+        case PX4CustomMode::AUTO_FOLLOW_TARGET:
+        case PX4CustomMode::AUTO_LAND         :
+        case PX4CustomMode::AUTO_PRECLAND     :
+        case PX4CustomMode::AUTO_READY        :
+        case PX4CustomMode::AUTO_RTGS         :
+        case PX4CustomMode::AUTO_TAKEOFF      :
             mode.multiRotor = true;
+            break;
+        case PX4CustomMode::POSCTL_ORBIT      :
+            mode.multiRotor = false;
             break;
         }
 
         // Update Fixed Wing
-        switch (mode.custom_mode){
-        case PX4CustomMode::OFFBOARD:
-        case PX4CustomMode::SIMPLE:
-        case PX4CustomMode::POSCTL_ORBIT:
+        switch (cMode){
+        case PX4CustomMode::OFFBOARD          :
+        case PX4CustomMode::SIMPLE            :
+        case PX4CustomMode::POSCTL_ORBIT      :
         case PX4CustomMode::AUTO_FOLLOW_TARGET:
-        case PX4CustomMode::AUTO_PRECLAND:
+        case PX4CustomMode::AUTO_PRECLAND     :
             mode.fixedWing = false;
             break;
-        default:
+        case PX4CustomMode::MANUAL            :
+        case PX4CustomMode::STABILIZED        :
+        case PX4CustomMode::ACRO              :
+        case PX4CustomMode::RATTITUDE         :
+        case PX4CustomMode::ALTCTL            :
+        case PX4CustomMode::POSCTL_POSCTL     :
+        case PX4CustomMode::AUTO_LOITER       :
+        case PX4CustomMode::AUTO_MISSION      :
+        case PX4CustomMode::AUTO_RTL          :
+        case PX4CustomMode::AUTO_LAND         :
+        case PX4CustomMode::AUTO_READY        :
+        case PX4CustomMode::AUTO_RTGS         :
+        case PX4CustomMode::AUTO_TAKEOFF      :
             mode.fixedWing = true;
+            break;
         }
 
         // Update CanBeSet
-        switch (mode.custom_mode){
+        switch (cMode){
         case PX4CustomMode::AUTO_LOITER:
         case PX4CustomMode::AUTO_RTL:
         case PX4CustomMode::AUTO_MISSION:
             mode.canBeSet = true;
             break;
-        default:
+        case PX4CustomMode::OFFBOARD          :
+        case PX4CustomMode::SIMPLE            :
+        case PX4CustomMode::POSCTL_ORBIT      :
+        case PX4CustomMode::AUTO_FOLLOW_TARGET:
+        case PX4CustomMode::AUTO_PRECLAND     :
+        case PX4CustomMode::MANUAL            :
+        case PX4CustomMode::STABILIZED        :
+        case PX4CustomMode::ACRO              :
+        case PX4CustomMode::RATTITUDE         :
+        case PX4CustomMode::ALTCTL            :
+        case PX4CustomMode::POSCTL_POSCTL     :
+        case PX4CustomMode::AUTO_LAND         :
+        case PX4CustomMode::AUTO_READY        :
+        case PX4CustomMode::AUTO_RTGS         :
+        case PX4CustomMode::AUTO_TAKEOFF      :
             mode.canBeSet = false;
+            break;
         }
-
-        _updateModeMappings(mode);
     }
+    _updateModeMappings(modeList);
 }

--- a/custom-example/src/FirmwarePlugin/CustomFirmwarePlugin.h
+++ b/custom-example/src/FirmwarePlugin/CustomFirmwarePlugin.h
@@ -29,6 +29,7 @@ public:
     AutoPilotPlugin*    autopilotPlugin (Vehicle* vehicle) final;
     const QVariantList& toolIndicators  (const Vehicle* vehicle) final;
     bool                hasGimbal       (Vehicle* vehicle, bool& rollSupported, bool& pitchSupported, bool& yawSupported) final;
+    void                updateAvailableFlightModes      (FlightModeList modeList) override;
 
 private:
     QVariantList _toolIndicatorList;

--- a/src/AutoPilotPlugins/APM/APMSubMotorComponent.qml
+++ b/src/AutoPilotPlugins/APM/APMSubMotorComponent.qml
@@ -28,7 +28,7 @@ SetupPage {
 
     property int neutralValue: 50;
     property int _lastIndex: 0;
-    property bool canRunManualTest: controller.vehicle.flightMode !== 'Motor Detection' && controller.vehicle.armed && motorPage.visible && setupView.visible
+    property bool canRunManualTest: controller.vehicle.flightMode !== controller.vehicle.motorDetectionFlightMode && controller.vehicle.armed && motorPage.visible && setupView.visible
     property var shouldRunManualTest: false // Does the operator intend to run the motor test?
 
     APMSubMotorComponentController {
@@ -237,10 +237,10 @@ SetupPage {
                     QGCButton {
                         id: startAutoDetection
                         text: "Auto-Detect Directions"
-                        enabled: controller.vehicle.flightMode !== 'Motor Detection'
+                        enabled: controller.vehicle.flightMode !== controller.vehicle.motorDetectionFlightMode
 
                         onClicked: function() {
-                            controller.vehicle.flightMode = "Motor Detection"
+                            controller.vehicle.flightMode = controller.vehicle.motorDetectionFlightMode
                             controller.vehicle.armed = true
                         }
                     }

--- a/src/AutoPilotPlugins/APM/APMSubMotorComponentController.cc
+++ b/src/AutoPilotPlugins/APM/APMSubMotorComponentController.cc
@@ -22,7 +22,7 @@ void APMSubMotorComponentController::handleNewMessages(int uasid, int componenti
     Q_UNUSED(uasid);
     Q_UNUSED(componentid);
     Q_UNUSED(severity);
-    if (_vehicle->flightMode() == "Motor Detection"
+    if (_vehicle->flightMode() == _vehicle->motorDetectionFlightMode()
         && (text.toLower().contains("thruster") || text.toLower().contains("motor"))) {
         _motorDetectionMessages += text + QStringLiteral("\n");
         emit motorDetectionMessagesChanged();

--- a/src/Comms/MockLink/MockLink.cc
+++ b/src/Comms/MockLink/MockLink.cc
@@ -99,10 +99,7 @@ MockLink::MockLink(SharedLinkConfigurationPtr& config)
 
     QObject::connect(this, &MockLink::writeBytesQueuedSignal, this, &MockLink::_writeBytesQueued, Qt::QueuedConnection);
 
-    union px4_custom_mode   px4_cm;
-    px4_cm.data = 0;
-    px4_cm.main_mode = PX4_CUSTOM_MAIN_MODE_MANUAL;
-    _mavCustomMode = px4_cm.data;
+    _mavCustomMode = PX4CustomMode::MANUAL;
 
     _mockLinkFTP = new MockLinkFTP(_vehicleSystemId, _vehicleComponentId, this);
 

--- a/src/FirmwarePlugin/APM/APMFirmwarePlugin.cc
+++ b/src/FirmwarePlugin/APM/APMFirmwarePlugin.cc
@@ -57,11 +57,11 @@ APMFirmwarePlugin::APMFirmwarePlugin(void)
     });
 
     updateAvailableFlightModes({
-        // Mode Name          , SM, Custom Mode           CanBeSet  adv    FW      MR
-        { _guidedFlightMode   , 0, APMCustomMode::GUIDED,    true , true , false , true },
-        { _rtlFlightMode      , 0, APMCustomMode::RTL,       true , true , false , true },
-        { _smartRtlFlightMode , 0, APMCustomMode::SMART_RTL, true , true , false , true },
-        { _autoFlightMode     , 0, APMCustomMode::AUTO,      true , true , false , true },
+        // Mode Name          , Custom Mode            CanBeSet  adv
+        { _guidedFlightMode   , APMCustomMode::GUIDED,    true , true },
+        { _rtlFlightMode      , APMCustomMode::RTL,       true , true },
+        { _smartRtlFlightMode , APMCustomMode::SMART_RTL, true , true },
+        { _autoFlightMode     , APMCustomMode::AUTO,      true , true },
     });
 
     qmlRegisterType<APMFlightModesComponentController>  ("QGroundControl.Controllers", 1, 0, "APMFlightModesComponentController");

--- a/src/FirmwarePlugin/APM/APMFirmwarePlugin.cc
+++ b/src/FirmwarePlugin/APM/APMFirmwarePlugin.cc
@@ -41,32 +41,29 @@
 
 QGC_LOGGING_CATEGORY(APMFirmwarePluginLog, "APMFirmwarePluginLog")
 
-/*
- * @brief APMCustomMode encapsulates the custom modes for APM
- */
-APMCustomMode::APMCustomMode(uint32_t mode, bool settable) :
-    _mode(mode),
-    _settable(settable)
-{
-}
-
-void APMCustomMode::setEnumToStringMapping(const QMap<uint32_t, QString>& enumToString)
-{
-    _enumToString = enumToString;
-}
-
-QString APMCustomMode::modeString() const
-{
-    QString mode = _enumToString.value(modeAsInt());
-    if (mode.isEmpty()) {
-        mode = "mode" + QString::number(modeAsInt());
-    }
-    return mode;
-}
 
 APMFirmwarePlugin::APMFirmwarePlugin(void)
     : _coaxialMotors(false)
+    , _guidedFlightMode     (tr("Guided"))
+    , _rtlFlightMode        (tr("RTL"))
+    , _smartRtlFlightMode   (tr("Smart RTL"))
+    , _autoFlightMode       (tr("Auto"))
 {
+    _setModeEnumToModeStringMapping({
+        { APMCustomMode::GUIDED,        _guidedFlightMode   },
+        { APMCustomMode::RTL,           _rtlFlightMode      },
+        { APMCustomMode::SMART_RTL,     _smartRtlFlightMode },
+        { APMCustomMode::AUTO,          _autoFlightMode     },
+    });
+
+    updateAvailableFlightModes({
+        // Mode Name          , SM, Custom Mode           CanBeSet  adv    FW      MR
+        { _guidedFlightMode   , 0, APMCustomMode::GUIDED,    true , true , false , true },
+        { _rtlFlightMode      , 0, APMCustomMode::RTL,       true , true , false , true },
+        { _smartRtlFlightMode , 0, APMCustomMode::SMART_RTL, true , true , false , true },
+        { _autoFlightMode     , 0, APMCustomMode::AUTO,      true , true , false , true },
+    });
+
     qmlRegisterType<APMFlightModesComponentController>  ("QGroundControl.Controllers", 1, 0, "APMFlightModesComponentController");
     qmlRegisterType<APMAirframeComponentController>     ("QGroundControl.Controllers", 1, 0, "APMAirframeComponentController");
     qmlRegisterType<APMSensorsComponentController>      ("QGroundControl.Controllers", 1, 0, "APMSensorsComponentController");
@@ -106,9 +103,9 @@ QStringList APMFirmwarePlugin::flightModes(Vehicle* vehicle)
 {
     Q_UNUSED(vehicle)
     QStringList flightModesList;
-    foreach (const APMCustomMode& customMode, _supportedModes) {
-        if (customMode.canBeSet()) {
-            flightModesList << customMode.modeString();
+    for (auto &mode : _availableFlightModeList) {
+        if (mode.canBeSet){
+            flightModesList += mode.mode_name;
         }
     }
     return flightModesList;
@@ -119,11 +116,7 @@ QString APMFirmwarePlugin::flightMode(uint8_t base_mode, uint32_t custom_mode) c
     QString flightMode = "Unknown";
 
     if (base_mode & MAV_MODE_FLAG_CUSTOM_MODE_ENABLED) {
-        foreach (const APMCustomMode& customMode, _supportedModes) {
-            if (customMode.modeAsInt() == custom_mode) {
-                flightMode = customMode.modeString();
-            }
-        }
+        return _modeEnumToString.value(custom_mode, flightMode);
     }
     return flightMode;
 }
@@ -135,10 +128,10 @@ bool APMFirmwarePlugin::setFlightMode(const QString& flightMode, uint8_t* base_m
 
     bool found = false;
 
-    foreach(const APMCustomMode& mode, _supportedModes) {
-        if (flightMode.compare(mode.modeString(), Qt::CaseInsensitive) == 0) {
+    for (auto &mode: _availableFlightModeList){
+        if(flightMode.compare(mode.mode_name, Qt::CaseInsensitive) == 0){
             *base_mode = MAV_MODE_FLAG_CUSTOM_MODE_ENABLED;
-            *custom_mode = mode.modeAsInt();
+            *custom_mode = mode.custom_mode;
             found = true;
             break;
         }
@@ -670,7 +663,32 @@ const QVariantList& APMFirmwarePlugin::toolIndicators(const Vehicle* vehicle)
 
 bool APMFirmwarePlugin::isGuidedMode(const Vehicle* vehicle) const
 {
-    return vehicle->flightMode() == "Guided";
+    return vehicle->flightMode() == guidedFlightMode();
+}
+
+QString APMFirmwarePlugin::gotoFlightMode() const
+{
+    return guidedFlightMode();
+}
+
+QString APMFirmwarePlugin::rtlFlightMode() const
+{
+    return _modeEnumToString.value(_convertToCustomFlightModeEnum(APMCustomMode::RTL), _rtlFlightMode);
+}
+
+QString APMFirmwarePlugin::smartRTLFlightMode() const
+{
+    return _modeEnumToString.value(_convertToCustomFlightModeEnum(APMCustomMode::SMART_RTL), _smartRtlFlightMode);
+}
+
+QString APMFirmwarePlugin::missionFlightMode() const
+{
+    return _modeEnumToString.value(_convertToCustomFlightModeEnum(APMCustomMode::AUTO), _autoFlightMode);
+}
+
+QString APMFirmwarePlugin::guidedFlightMode() const
+{
+    return _modeEnumToString.value(_convertToCustomFlightModeEnum(APMCustomMode::GUIDED), _guidedFlightMode);
 }
 
 void APMFirmwarePlugin::_soloVideoHandshake(void)
@@ -751,7 +769,7 @@ QString APMFirmwarePlugin::_internalParameterMetaDataFile(const Vehicle* vehicle
 void APMFirmwarePlugin::setGuidedMode(Vehicle* vehicle, bool guidedMode)
 {
     if (guidedMode) {
-        _setFlightModeAndValidate(vehicle, "Guided");
+        _setFlightModeAndValidate(vehicle, guidedFlightMode());
     } else {
         pauseVehicle(vehicle);
     }
@@ -993,7 +1011,7 @@ bool APMFirmwarePlugin::_guidedModeTakeoff(Vehicle* vehicle, double altitudeRel)
         takeoffAltRel = altitudeRel;
     }
 
-    if (!_setFlightModeAndValidate(vehicle, "Guided")) {
+    if (!_setFlightModeAndValidate(vehicle, guidedFlightMode())) {
         qgcApp()->showAppMessage(tr("Unable to takeoff: Vehicle failed to change to Guided mode."));
         return false;
     }
@@ -1016,7 +1034,7 @@ void APMFirmwarePlugin::startMission(Vehicle* vehicle)
 {
     if (vehicle->flying()) {
         // Vehicle already in the air, we just need to switch to auto
-        if (!_setFlightModeAndValidate(vehicle, "Auto")) {
+        if (!_setFlightModeAndValidate(vehicle, missionFlightMode())) {
             qgcApp()->showAppMessage(tr("Unable to start mission: Vehicle failed to change to Auto mode."));
         }
         return;
@@ -1027,12 +1045,12 @@ void APMFirmwarePlugin::startMission(Vehicle* vehicle)
         // In Ardupilot for vtols and airplanes we need to set the mode to auto and then arm, otherwise if arming in guided
         // If the vehicle has tilt rotors, it will arm them in forward flight position, being dangerous.
         if (vehicle->fixedWing()) {
-            if (!_setFlightModeAndValidate(vehicle, "Auto")) {
+            if (!_setFlightModeAndValidate(vehicle, missionFlightMode())) {
                 qgcApp()->showAppMessage(tr("Unable to start mission: Vehicle failed to change to Auto mode."));
                 return;
             }
         } else {
-            if (!_setFlightModeAndValidate(vehicle, "Guided")) {
+            if (!_setFlightModeAndValidate(vehicle, guidedFlightMode())) {
                 qgcApp()->showAppMessage(tr("Unable to start mission: Vehicle failed to change to Guided mode."));
                 return;
             }

--- a/src/FirmwarePlugin/APM/APMFirmwarePlugin.h
+++ b/src/FirmwarePlugin/APM/APMFirmwarePlugin.h
@@ -19,21 +19,14 @@
 
 Q_DECLARE_LOGGING_CATEGORY(APMFirmwarePluginLog)
 
-class APMCustomMode
+struct APMCustomMode
 {
-public:
-    APMCustomMode(uint32_t mode, bool settable);
-    uint32_t modeAsInt() const { return _mode; }
-    bool canBeSet() const { return _settable; }
-    QString modeString() const;
-
-protected:
-    void setEnumToStringMapping(const QMap<uint32_t,QString>& enumToString);
-
-private:
-    uint32_t               _mode;
-    bool                   _settable;
-    QMap<uint32_t,QString> _enumToString;
+    enum Mode : uint32_t {
+        AUTO        = 3,
+        GUIDED      = 4,
+        RTL         = 6,
+        SMART_RTL   = 21
+    };
 };
 
 /// This is the base class for all stack specific APM firmware plugins
@@ -59,10 +52,11 @@ public:
     bool                setFlightMode                   (const QString& flightMode, uint8_t* base_mode, uint32_t* custom_mode) override;
     bool MAV_CMD_DO_SET_MODE_is_supported() const override { return true; }
     bool                isGuidedMode                    (const Vehicle* vehicle) const override;
-    QString             gotoFlightMode                  (void) const override { return QStringLiteral("Guided"); }
-    QString             rtlFlightMode                   (void) const override { return QString("RTL"); }
-    QString             smartRTLFlightMode              (void) const override { return QString("Smart RTL"); }
-    QString             missionFlightMode               (void) const override { return QString("Auto"); }
+    QString             gotoFlightMode                  (void) const override;
+    QString             rtlFlightMode                   (void) const override;
+    QString             smartRTLFlightMode              (void) const override;
+    QString             missionFlightMode               (void) const override;
+    virtual QString     guidedFlightMode                (void) const;
     void                pauseVehicle                    (Vehicle* vehicle) override;
     void                guidedModeRTL                   (Vehicle* vehicle, bool smartRTL) override;
     void                guidedModeChangeAltitude        (Vehicle* vehicle, double altitudeChange, bool pauseVehicle) override;
@@ -109,6 +103,12 @@ protected:
     static void _setBaroAltOffset(Vehicle* vehicle, qreal offset);
 
     bool                _coaxialMotors;
+
+
+    QString     _guidedFlightMode  ;
+    QString     _rtlFlightMode     ;
+    QString     _smartRtlFlightMode;
+    QString     _autoFlightMode    ;
 
 private slots:
     void _artooSocketError(QAbstractSocket::SocketError socketError);

--- a/src/FirmwarePlugin/APM/ArduCopterFirmwarePlugin.cc
+++ b/src/FirmwarePlugin/APM/ArduCopterFirmwarePlugin.cc
@@ -18,68 +18,92 @@
 bool ArduCopterFirmwarePlugin::_remapParamNameIntialized = false;
 FirmwarePlugin::remapParamNameMajorVersionMap_t ArduCopterFirmwarePlugin::_remapParamName;
 
-APMCopterMode::APMCopterMode(uint32_t mode, bool settable) :
-    APMCustomMode(mode, settable)
-{
-    setEnumToStringMapping({
-        { STABILIZE,    "Stabilize"},
-        { ACRO,         "Acro"},
-        { ALT_HOLD,     "Altitude Hold"},
-        { AUTO,         "Auto"},
-        { GUIDED,       "Guided"},
-        { LOITER,       "Loiter"},
-        { RTL,          "RTL"},
-        { CIRCLE,       "Circle"},
-        { LAND,         "Land"},
-        { DRIFT,        "Drift"},
-        { SPORT,        "Sport"},
-        { FLIP,         "Flip"},
-        { AUTOTUNE,     "Autotune"},
-        { POS_HOLD,     "Position Hold"},
-        { BRAKE,        "Brake"},
-        { THROW,        "Throw"},
-        { AVOID_ADSB,   "Avoid ADSB"},
-        { GUIDED_NOGPS, "Guided No GPS"},
-        { SMART_RTL,    "Smart RTL"},
-        { FLOWHOLD,     "Flow Hold" },
-        { FOLLOW,       "Follow" },
-        { ZIGZAG,       "ZigZag" },
-        { SYSTEMID,     "SystemID" },
-        { AUTOROTATE,   "AutoRotate" },
-        { AUTO_RTL,     "AutoRTL" },
-        { TURTLE,       "Turtle" },
-    });
-}
 
 ArduCopterFirmwarePlugin::ArduCopterFirmwarePlugin(void)
+    : _stabilizeFlightMode      (tr("Stabilize"))
+    , _acroFlightMode           (tr("Acro"))
+    , _altHoldFlightMode        (tr("Altitude Hold"))
+    , _autoFlightMode           (tr("Auto"))
+    , _guidedFlightMode         (tr("Guided"))
+    , _loiterFlightMode         (tr("Loiter"))
+    , _rtlFlightMode            (tr("RTL"))
+    , _circleFlightMode         (tr("Circle"))
+    , _landFlightMode           (tr("Land"))
+    , _driftFlightMode          (tr("Drift"))
+    , _sportFlightMode          (tr("Sport"))
+    , _flipFlightMode           (tr("Flip"))
+    , _autotuneFlightMode       (tr("Autotune"))
+    , _posHoldFlightMode        (tr("Position Hold"))
+    , _brakeFlightMode          (tr("Brake"))
+    , _throwFlightMode          (tr("Throw"))
+    , _avoidADSBFlightMode      (tr("Avoid ADSB"))
+    , _guidedNoGPSFlightMode    (tr("Guided No GPS"))
+    , _smartRtlFlightMode       (tr("Smart RTL"))
+    , _flowHoldFlightMode       (tr("Flow Hold"))
+    , _followFlightMode         (tr("Follow"))
+    , _zigzagFlightMode         (tr("ZigZag"))
+    , _systemIDFlightMode       (tr("SystemID"))
+    , _autoRotateFlightMode     (tr("AutoRotate"))
+    , _autoRTLFlightMode        (tr("AutoRTL"))
+    , _turtleFlightMode         (tr("Turtle"))
 {
-    setSupportedModes({
-        APMCopterMode(APMCopterMode::STABILIZE,     true),
-        APMCopterMode(APMCopterMode::ACRO,          true),
-        APMCopterMode(APMCopterMode::ALT_HOLD,      true),
-        APMCopterMode(APMCopterMode::AUTO,          true),
-        APMCopterMode(APMCopterMode::GUIDED,        true),
-        APMCopterMode(APMCopterMode::LOITER,        true),
-        APMCopterMode(APMCopterMode::RTL,           true),
-        APMCopterMode(APMCopterMode::CIRCLE,        true),
-        APMCopterMode(APMCopterMode::LAND,          true),
-        APMCopterMode(APMCopterMode::DRIFT,         true),
-        APMCopterMode(APMCopterMode::SPORT,         true),
-        APMCopterMode(APMCopterMode::FLIP,          true),
-        APMCopterMode(APMCopterMode::AUTOTUNE,      true),
-        APMCopterMode(APMCopterMode::POS_HOLD,      true),
-        APMCopterMode(APMCopterMode::BRAKE,         true),
-        APMCopterMode(APMCopterMode::THROW,         true),
-        APMCopterMode(APMCopterMode::AVOID_ADSB,    true),
-        APMCopterMode(APMCopterMode::GUIDED_NOGPS,  true),
-        APMCopterMode(APMCopterMode::SMART_RTL,     true),
-        APMCopterMode(APMCopterMode::FLOWHOLD,      true),
-        APMCopterMode(APMCopterMode::FOLLOW,        true),
-        APMCopterMode(APMCopterMode::ZIGZAG,        true),
-        APMCopterMode(APMCopterMode::SYSTEMID,      true),
-        APMCopterMode(APMCopterMode::AUTOROTATE,    true),
-        APMCopterMode(APMCopterMode::AUTO_RTL,      true),
-        APMCopterMode(APMCopterMode::TURTLE,        true),
+    _setModeEnumToModeStringMapping({
+        { APMCopterMode::STABILIZE,    _stabilizeFlightMode     },
+        { APMCopterMode::ACRO,         _acroFlightMode          },
+        { APMCopterMode::ALT_HOLD,     _altHoldFlightMode       },
+        { APMCopterMode::AUTO,         _autoFlightMode          },
+        { APMCopterMode::GUIDED,       _guidedFlightMode        },
+        { APMCopterMode::LOITER,       _loiterFlightMode        },
+        { APMCopterMode::RTL,          _rtlFlightMode           },
+        { APMCopterMode::CIRCLE,       _circleFlightMode        },
+        { APMCopterMode::LAND,         _landFlightMode          },
+        { APMCopterMode::DRIFT,        _driftFlightMode         },
+        { APMCopterMode::SPORT,        _sportFlightMode         },
+        { APMCopterMode::FLIP,         _flipFlightMode          },
+        { APMCopterMode::AUTOTUNE,     _autotuneFlightMode      },
+        { APMCopterMode::POS_HOLD,     _posHoldFlightMode       },
+        { APMCopterMode::BRAKE,        _brakeFlightMode         },
+        { APMCopterMode::THROW,        _throwFlightMode         },
+        { APMCopterMode::AVOID_ADSB,   _avoidADSBFlightMode     },
+        { APMCopterMode::GUIDED_NOGPS, _guidedNoGPSFlightMode   },
+        { APMCopterMode::SMART_RTL,    _smartRtlFlightMode      },
+        { APMCopterMode::FLOWHOLD,     _flowHoldFlightMode      },
+        { APMCopterMode::FOLLOW,       _followFlightMode        },
+        { APMCopterMode::ZIGZAG,       _zigzagFlightMode        },
+        { APMCopterMode::SYSTEMID,     _systemIDFlightMode      },
+        { APMCopterMode::AUTOROTATE,   _autoRotateFlightMode    },
+        { APMCopterMode::AUTO_RTL,     _autoRTLFlightMode       },
+        { APMCopterMode::TURTLE,       _turtleFlightMode        },
+    });
+
+    updateAvailableFlightModes({
+        // Mode Name             ,SM, Custom Mode                CanBeSet  adv    FW      MR
+        { _stabilizeFlightMode   , 0, APMCopterMode::STABILIZE,     true , true , false , true },
+        { _acroFlightMode        , 0, APMCopterMode::ACRO,          true , true , false , true },
+        { _altHoldFlightMode     , 0, APMCopterMode::ALT_HOLD,      true , true , false , true },
+        { _autoFlightMode        , 0, APMCopterMode::AUTO,          true , true , false , true },
+        { _guidedFlightMode      , 0, APMCopterMode::GUIDED,        true , true , false , true },
+        { _loiterFlightMode      , 0, APMCopterMode::LOITER,        true , true , false , true },
+        { _rtlFlightMode         , 0, APMCopterMode::RTL,           true , true , false , true },
+        { _circleFlightMode      , 0, APMCopterMode::CIRCLE,        true , true , false , true },
+        { _landFlightMode        , 0, APMCopterMode::LAND,          true , true , false , true },
+        { _driftFlightMode       , 0, APMCopterMode::DRIFT,         true , true , false , true },
+        { _sportFlightMode       , 0, APMCopterMode::SPORT,         true , true , false , true },
+        { _flipFlightMode        , 0, APMCopterMode::FLIP,          true , true , false , true },
+        { _autotuneFlightMode    , 0, APMCopterMode::AUTOTUNE,      true , true , false , true },
+        { _posHoldFlightMode     , 0, APMCopterMode::POS_HOLD,      true , true , false , true },
+        { _brakeFlightMode       , 0, APMCopterMode::BRAKE,         true , true , false , true },
+        { _throwFlightMode       , 0, APMCopterMode::THROW,         true , true , false , true },
+        { _avoidADSBFlightMode   , 0, APMCopterMode::AVOID_ADSB,    true , true , false , true },
+        { _guidedNoGPSFlightMode , 0, APMCopterMode::GUIDED_NOGPS,  true , true , false , true },
+        { _smartRtlFlightMode    , 0, APMCopterMode::SMART_RTL,     true , true , false , true },
+        { _flowHoldFlightMode    , 0, APMCopterMode::FLOWHOLD,      true , true , false , true },
+        { _followFlightMode      , 0, APMCopterMode::FOLLOW,        true , true , false , true },
+        { _zigzagFlightMode      , 0, APMCopterMode::ZIGZAG,        true , true , false , true },
+        { _systemIDFlightMode    , 0, APMCopterMode::SYSTEMID,      true , true , false , true },
+        { _autoRotateFlightMode  , 0, APMCopterMode::AUTOROTATE,    true , true , false , true },
+        { _autoRTLFlightMode     , 0, APMCopterMode::AUTO_RTL,      true , true , false , true },
+        { _turtleFlightMode      , 0, APMCopterMode::TURTLE,        true , true , false , true },
     });
 
     if (!_remapParamNameIntialized) {
@@ -121,7 +145,7 @@ int ArduCopterFirmwarePlugin::remapParamNameHigestMinorVersionNumber(int majorVe
 
 void ArduCopterFirmwarePlugin::guidedModeLand(Vehicle* vehicle)
 {
-    _setFlightModeAndValidate(vehicle, "Land");
+    _setFlightModeAndValidate(vehicle, landFlightMode());
 }
 
 bool ArduCopterFirmwarePlugin::multiRotorCoaxialMotors(Vehicle* vehicle)
@@ -133,4 +157,55 @@ bool ArduCopterFirmwarePlugin::multiRotorCoaxialMotors(Vehicle* vehicle)
 bool ArduCopterFirmwarePlugin::multiRotorXConfig(Vehicle* vehicle)
 {
     return vehicle->parameterManager()->getParameter(ParameterManager::defaultComponentId, "FRAME")->rawValue().toInt() != 0;
+}
+
+QString ArduCopterFirmwarePlugin::pauseFlightMode() const
+{
+    return _modeEnumToString.value(APMCopterMode::BRAKE, _brakeFlightMode);
+}
+
+QString ArduCopterFirmwarePlugin::landFlightMode() const
+{
+    return _modeEnumToString.value(APMCopterMode::LAND, _landFlightMode);
+}
+
+QString ArduCopterFirmwarePlugin::takeControlFlightMode() const
+{
+    return _modeEnumToString.value(APMCopterMode::LOITER, _loiterFlightMode);
+}
+
+QString ArduCopterFirmwarePlugin::followFlightMode() const
+{
+    return _modeEnumToString.value(APMCopterMode::FOLLOW, _followFlightMode);
+}
+
+QString ArduCopterFirmwarePlugin::gotoFlightMode() const
+{
+    return guidedFlightMode();
+}
+
+void ArduCopterFirmwarePlugin::updateAvailableFlightModes(FlightModeList modeList)
+{
+    _availableFlightModeList.clear();
+    for(auto mode: modeList){
+        mode.fixedWing = false;
+        mode.multiRotor = true;
+        _updateModeMappings(mode);
+    }
+
+}
+
+uint32_t ArduCopterFirmwarePlugin::_convertToCustomFlightModeEnum(uint32_t val) const
+{
+    switch (val) {
+    case APMCustomMode::AUTO:
+        return APMCopterMode::AUTO;
+    case APMCustomMode::GUIDED:
+        return APMCopterMode::GUIDED;
+    case APMCustomMode::RTL:
+        return APMCopterMode::RTL;
+    case APMCustomMode::SMART_RTL:
+        return APMCopterMode::SMART_RTL;
+    }
+    return UINT32_MAX;
 }

--- a/src/FirmwarePlugin/APM/ArduCopterFirmwarePlugin.cc
+++ b/src/FirmwarePlugin/APM/ArduCopterFirmwarePlugin.cc
@@ -77,33 +77,33 @@ ArduCopterFirmwarePlugin::ArduCopterFirmwarePlugin(void)
     });
 
     updateAvailableFlightModes({
-        // Mode Name             ,SM, Custom Mode                CanBeSet  adv    FW      MR
-        { _stabilizeFlightMode   , 0, APMCopterMode::STABILIZE,     true , true , false , true },
-        { _acroFlightMode        , 0, APMCopterMode::ACRO,          true , true , false , true },
-        { _altHoldFlightMode     , 0, APMCopterMode::ALT_HOLD,      true , true , false , true },
-        { _autoFlightMode        , 0, APMCopterMode::AUTO,          true , true , false , true },
-        { _guidedFlightMode      , 0, APMCopterMode::GUIDED,        true , true , false , true },
-        { _loiterFlightMode      , 0, APMCopterMode::LOITER,        true , true , false , true },
-        { _rtlFlightMode         , 0, APMCopterMode::RTL,           true , true , false , true },
-        { _circleFlightMode      , 0, APMCopterMode::CIRCLE,        true , true , false , true },
-        { _landFlightMode        , 0, APMCopterMode::LAND,          true , true , false , true },
-        { _driftFlightMode       , 0, APMCopterMode::DRIFT,         true , true , false , true },
-        { _sportFlightMode       , 0, APMCopterMode::SPORT,         true , true , false , true },
-        { _flipFlightMode        , 0, APMCopterMode::FLIP,          true , true , false , true },
-        { _autotuneFlightMode    , 0, APMCopterMode::AUTOTUNE,      true , true , false , true },
-        { _posHoldFlightMode     , 0, APMCopterMode::POS_HOLD,      true , true , false , true },
-        { _brakeFlightMode       , 0, APMCopterMode::BRAKE,         true , true , false , true },
-        { _throwFlightMode       , 0, APMCopterMode::THROW,         true , true , false , true },
-        { _avoidADSBFlightMode   , 0, APMCopterMode::AVOID_ADSB,    true , true , false , true },
-        { _guidedNoGPSFlightMode , 0, APMCopterMode::GUIDED_NOGPS,  true , true , false , true },
-        { _smartRtlFlightMode    , 0, APMCopterMode::SMART_RTL,     true , true , false , true },
-        { _flowHoldFlightMode    , 0, APMCopterMode::FLOWHOLD,      true , true , false , true },
-        { _followFlightMode      , 0, APMCopterMode::FOLLOW,        true , true , false , true },
-        { _zigzagFlightMode      , 0, APMCopterMode::ZIGZAG,        true , true , false , true },
-        { _systemIDFlightMode    , 0, APMCopterMode::SYSTEMID,      true , true , false , true },
-        { _autoRotateFlightMode  , 0, APMCopterMode::AUTOROTATE,    true , true , false , true },
-        { _autoRTLFlightMode     , 0, APMCopterMode::AUTO_RTL,      true , true , false , true },
-        { _turtleFlightMode      , 0, APMCopterMode::TURTLE,        true , true , false , true },
+        // Mode Name             , Custom Mode                CanBeSet  adv
+        { _stabilizeFlightMode   , APMCopterMode::STABILIZE,     true , true },
+        { _acroFlightMode        , APMCopterMode::ACRO,          true , true },
+        { _altHoldFlightMode     , APMCopterMode::ALT_HOLD,      true , true },
+        { _autoFlightMode        , APMCopterMode::AUTO,          true , true },
+        { _guidedFlightMode      , APMCopterMode::GUIDED,        true , true },
+        { _loiterFlightMode      , APMCopterMode::LOITER,        true , true },
+        { _rtlFlightMode         , APMCopterMode::RTL,           true , true },
+        { _circleFlightMode      , APMCopterMode::CIRCLE,        true , true },
+        { _landFlightMode        , APMCopterMode::LAND,          true , true },
+        { _driftFlightMode       , APMCopterMode::DRIFT,         true , true },
+        { _sportFlightMode       , APMCopterMode::SPORT,         true , true },
+        { _flipFlightMode        , APMCopterMode::FLIP,          true , true },
+        { _autotuneFlightMode    , APMCopterMode::AUTOTUNE,      true , true },
+        { _posHoldFlightMode     , APMCopterMode::POS_HOLD,      true , true },
+        { _brakeFlightMode       , APMCopterMode::BRAKE,         true , true },
+        { _throwFlightMode       , APMCopterMode::THROW,         true , true },
+        { _avoidADSBFlightMode   , APMCopterMode::AVOID_ADSB,    true , true },
+        { _guidedNoGPSFlightMode , APMCopterMode::GUIDED_NOGPS,  true , true },
+        { _smartRtlFlightMode    , APMCopterMode::SMART_RTL,     true , true },
+        { _flowHoldFlightMode    , APMCopterMode::FLOWHOLD,      true , true },
+        { _followFlightMode      , APMCopterMode::FOLLOW,        true , true },
+        { _zigzagFlightMode      , APMCopterMode::ZIGZAG,        true , true },
+        { _systemIDFlightMode    , APMCopterMode::SYSTEMID,      true , true },
+        { _autoRotateFlightMode  , APMCopterMode::AUTOROTATE,    true , true },
+        { _autoRTLFlightMode     , APMCopterMode::AUTO_RTL,      true , true },
+        { _turtleFlightMode      , APMCopterMode::TURTLE,        true , true },
     });
 
     if (!_remapParamNameIntialized) {
@@ -184,14 +184,24 @@ QString ArduCopterFirmwarePlugin::gotoFlightMode() const
     return guidedFlightMode();
 }
 
+QString ArduCopterFirmwarePlugin::takeOffFlightMode() const
+{
+    return guidedFlightMode();
+}
+
+QString ArduCopterFirmwarePlugin::stabilizedFlightMode() const
+{
+    return _modeEnumToString.value(APMCopterMode::STABILIZE, _stabilizeFlightMode);
+}
+
 void ArduCopterFirmwarePlugin::updateAvailableFlightModes(FlightModeList modeList)
 {
-    _availableFlightModeList.clear();
-    for(auto mode: modeList){
+    for(auto &mode: modeList){
         mode.fixedWing = false;
         mode.multiRotor = true;
-        _updateModeMappings(mode);
     }
+
+    _updateModeMappings(modeList);
 
 }
 

--- a/src/FirmwarePlugin/APM/ArduCopterFirmwarePlugin.h
+++ b/src/FirmwarePlugin/APM/ArduCopterFirmwarePlugin.h
@@ -69,6 +69,8 @@ public:
     QString takeControlFlightMode               (void) const override;
     QString followFlightMode                    (void) const override;
     QString gotoFlightMode                      (void) const override;
+    QString takeOffFlightMode                   (void) const override;
+    QString stabilizedFlightMode                (void) const override;
     QString autoDisarmParameter                 (Vehicle* vehicle) override { Q_UNUSED(vehicle); return QStringLiteral("DISARM_DELAY"); }
     bool    supportsSmartRTL                    (void) const override { return true; }
 

--- a/src/FirmwarePlugin/APM/ArduCopterFirmwarePlugin.h
+++ b/src/FirmwarePlugin/APM/ArduCopterFirmwarePlugin.h
@@ -15,10 +15,9 @@
 
 #include "APMFirmwarePlugin.h"
 
-class APMCopterMode : public APMCustomMode
+struct APMCopterMode
 {
-public:
-    enum Mode {
+    enum Mode : uint32_t{
         STABILIZE   = 0,   // hold level position
         ACRO        = 1,   // rate control
         ALT_HOLD    = 2,   // AUTO control
@@ -49,8 +48,6 @@ public:
         AUTO_RTL    = 27,
         TURTLE      = 28,
     };
-
-    APMCopterMode(uint32_t mode, bool settable);
 };
 
 class ArduCopterFirmwarePlugin : public APMFirmwarePlugin
@@ -67,12 +64,45 @@ public:
     bool    multiRotorCoaxialMotors             (Vehicle* vehicle) final;
     bool    multiRotorXConfig                   (Vehicle* vehicle) final;
     QString offlineEditingParamFile             (Vehicle* vehicle) final { Q_UNUSED(vehicle); return QStringLiteral(":/FirmwarePlugin/APM/Copter.OfflineEditing.params"); }
-    QString pauseFlightMode                     (void) const override { return QStringLiteral("Brake"); }
-    QString landFlightMode                      (void) const override { return QStringLiteral("Land"); }
-    QString takeControlFlightMode               (void) const override { return QStringLiteral("Loiter"); }
-    QString followFlightMode                    (void) const override { return QStringLiteral("Follow"); }
+    QString pauseFlightMode                     (void) const override;
+    QString landFlightMode                      (void) const override;
+    QString takeControlFlightMode               (void) const override;
+    QString followFlightMode                    (void) const override;
+    QString gotoFlightMode                      (void) const override;
     QString autoDisarmParameter                 (Vehicle* vehicle) override { Q_UNUSED(vehicle); return QStringLiteral("DISARM_DELAY"); }
     bool    supportsSmartRTL                    (void) const override { return true; }
+
+    void    updateAvailableFlightModes          (FlightModeList modeList) final;
+protected:
+    uint32_t    _convertToCustomFlightModeEnum(uint32_t val) const override;
+
+
+    QString     _stabilizeFlightMode;
+    QString     _acroFlightMode;
+    QString     _altHoldFlightMode;
+    QString     _autoFlightMode;
+    QString     _guidedFlightMode;
+    QString     _loiterFlightMode;
+    QString     _rtlFlightMode;
+    QString     _circleFlightMode;
+    QString     _landFlightMode;
+    QString     _driftFlightMode;
+    QString     _sportFlightMode;
+    QString     _flipFlightMode;
+    QString     _autotuneFlightMode;
+    QString     _posHoldFlightMode;
+    QString     _brakeFlightMode;
+    QString     _throwFlightMode;
+    QString     _avoidADSBFlightMode;
+    QString     _guidedNoGPSFlightMode;
+    QString     _smartRtlFlightMode;
+    QString     _flowHoldFlightMode;
+    QString     _followFlightMode;
+    QString     _zigzagFlightMode;
+    QString     _systemIDFlightMode;
+    QString     _autoRotateFlightMode;
+    QString     _autoRTLFlightMode;
+    QString     _turtleFlightMode;
 
 private:
     static bool _remapParamNameIntialized;

--- a/src/FirmwarePlugin/APM/ArduPlaneFirmwarePlugin.cc
+++ b/src/FirmwarePlugin/APM/ArduPlaneFirmwarePlugin.cc
@@ -13,64 +13,85 @@
 bool ArduPlaneFirmwarePlugin::_remapParamNameIntialized = false;
 FirmwarePlugin::remapParamNameMajorVersionMap_t ArduPlaneFirmwarePlugin::_remapParamName;
 
-APMPlaneMode::APMPlaneMode(uint32_t mode, bool settable)
-    : APMCustomMode(mode, settable)
-{
-    setEnumToStringMapping({ 
-        { MANUAL,           "Manual" },
-        { CIRCLE,           "Circle" },
-        { STABILIZE,        "Stabilize" },
-        { TRAINING,         "Training" },
-        { ACRO,             "Acro" },
-        { FLY_BY_WIRE_A,    "FBW A" },
-        { FLY_BY_WIRE_B,    "FBW B" },
-        { CRUISE,           "Cruise" },
-        { AUTOTUNE,         "Autotune" },
-        { AUTO,             "Auto" },
-        { RTL,              "RTL" },
-        { LOITER,           "Loiter" },
-        { TAKEOFF,          "Takeoff" },
-        { AVOID_ADSB,       "Avoid ADSB" },
-        { GUIDED,           "Guided" },
-        { INITIALIZING,     "Initializing" },
-        { QSTABILIZE,       "QuadPlane Stabilize" },
-        { QHOVER,           "QuadPlane Hover" },
-        { QLOITER,          "QuadPlane Loiter" },
-        { QLAND,            "QuadPlane Land" },
-        { QRTL,             "QuadPlane RTL" },
-        { QAUTOTUNE,        "QuadPlane AutoTune" },
-        { QACRO,            "QuadPlane Acro" },
-        { THERMAL,          "Thermal"},
-    });
-}
-
 ArduPlaneFirmwarePlugin::ArduPlaneFirmwarePlugin(void)
+    : _manualFlightMode      (tr("Manual"))
+    , _circleFlightMode      (tr("Circle"))
+    , _stabilizeFlightMode   (tr("Stabilize"))
+    , _trainingFlightMode    (tr("Training"))
+    , _acroFlightMode        (tr("Acro"))
+    , _flyByWireAFlightMode  (tr("FBW A"))
+    , _flyByWireBFlightMode  (tr("FBW B"))
+    , _cruiseFlightMode      (tr("Cruise"))
+    , _autoTuneFlightMode    (tr("Autotune"))
+    , _autoFlightMode        (tr("Auto"))
+    , _rtlFlightMode         (tr("RTL"))
+    , _loiterFlightMode      (tr("Loiter"))
+    , _takeoffFlightMode     (tr("Takeoff"))
+    , _avoidADSBFlightMode   (tr("Avoid ADSB"))
+    , _guidedFlightMode      (tr("Guided"))
+    , _initializingFlightMode(tr("Initializing"))
+    , _qStabilizeFlightMode  (tr("QuadPlane Stabilize"))
+    , _qHoverFlightMode      (tr("QuadPlane Hover"))
+    , _qLoiterFlightMode     (tr("QuadPlane Loiter"))
+    , _qLandFlightMode       (tr("QuadPlane Land"))
+    , _qRTLFlightMode        (tr("QuadPlane RTL"))
+    , _qAutotuneFlightMode   (tr("QuadPlane AutoTune"))
+    , _qAcroFlightMode       (tr("QuadPlane Acro"))
+    , _thermalFlightMode     (tr("Thermal"))
 {
-    setSupportedModes({
-        APMPlaneMode(APMPlaneMode::MANUAL,          true),
-        APMPlaneMode(APMPlaneMode::CIRCLE,          true),
-        APMPlaneMode(APMPlaneMode::STABILIZE,       true),
-        APMPlaneMode(APMPlaneMode::TRAINING,        true),
-        APMPlaneMode(APMPlaneMode::ACRO,            true),
-        APMPlaneMode(APMPlaneMode::FLY_BY_WIRE_A,   true),
-        APMPlaneMode(APMPlaneMode::FLY_BY_WIRE_B,   true),
-        APMPlaneMode(APMPlaneMode::CRUISE,          true),
-        APMPlaneMode(APMPlaneMode::AUTOTUNE,        true),
-        APMPlaneMode(APMPlaneMode::AUTO,            true),
-        APMPlaneMode(APMPlaneMode::RTL,             true),
-        APMPlaneMode(APMPlaneMode::LOITER,          true),
-        APMPlaneMode(APMPlaneMode::TAKEOFF,         true),
-        APMPlaneMode(APMPlaneMode::AVOID_ADSB,      false),
-        APMPlaneMode(APMPlaneMode::GUIDED,          true),
-        APMPlaneMode(APMPlaneMode::INITIALIZING,    false),
-        APMPlaneMode(APMPlaneMode::QSTABILIZE,      true),
-        APMPlaneMode(APMPlaneMode::QHOVER,          true),
-        APMPlaneMode(APMPlaneMode::QLOITER,         true),
-        APMPlaneMode(APMPlaneMode::QLAND,           true),
-        APMPlaneMode(APMPlaneMode::QRTL,            true),
-        APMPlaneMode(APMPlaneMode::QAUTOTUNE,       true),
-        APMPlaneMode(APMPlaneMode::QACRO,           true),
-        APMPlaneMode(APMPlaneMode::THERMAL,         true),
+    _setModeEnumToModeStringMapping({
+        {APMPlaneMode::MANUAL        , _manualFlightMode      },
+        {APMPlaneMode::CIRCLE        , _circleFlightMode      },
+        {APMPlaneMode::STABILIZE     , _stabilizeFlightMode   },
+        {APMPlaneMode::TRAINING      , _trainingFlightMode    },
+        {APMPlaneMode::ACRO          , _acroFlightMode        },
+        {APMPlaneMode::FLY_BY_WIRE_A , _flyByWireAFlightMode  },
+        {APMPlaneMode::FLY_BY_WIRE_B , _flyByWireBFlightMode  },
+        {APMPlaneMode::CRUISE        , _cruiseFlightMode      },
+        {APMPlaneMode::AUTOTUNE      , _autoTuneFlightMode    },
+        {APMPlaneMode::AUTO          , _autoFlightMode        },
+        {APMPlaneMode::RTL           , _rtlFlightMode         },
+        {APMPlaneMode::LOITER        , _loiterFlightMode      },
+        {APMPlaneMode::TAKEOFF       , _takeoffFlightMode     },
+        {APMPlaneMode::AVOID_ADSB    , _avoidADSBFlightMode   },
+        {APMPlaneMode::GUIDED        , _guidedFlightMode      },
+        {APMPlaneMode::INITIALIZING  , _initializingFlightMode},
+        {APMPlaneMode::QSTABILIZE    , _qStabilizeFlightMode  },
+        {APMPlaneMode::QHOVER        , _qHoverFlightMode      },
+        {APMPlaneMode::QLOITER       , _qLoiterFlightMode     },
+        {APMPlaneMode::QLAND         , _qLandFlightMode       },
+        {APMPlaneMode::QRTL          , _qRTLFlightMode        },
+        {APMPlaneMode::QAUTOTUNE     , _qAutotuneFlightMode   },
+        {APMPlaneMode::QACRO         , _qAcroFlightMode       },
+        {APMPlaneMode::THERMAL       , _thermalFlightMode     },
+    });
+
+    updateAvailableFlightModes({
+        // Mode Name             ,  SM, Custom Mode                CanBeSet  adv    FW      MR
+        { _manualFlightMode       , 0 , APMPlaneMode::MANUAL        , true , true , true , true},
+        { _circleFlightMode       , 0 , APMPlaneMode::CIRCLE        , true , true , true , true},
+        { _stabilizeFlightMode    , 0 , APMPlaneMode::STABILIZE     , true , true , true , true},
+        { _trainingFlightMode     , 0 , APMPlaneMode::TRAINING      , true , true , true , true},
+        { _acroFlightMode         , 0 , APMPlaneMode::ACRO          , true , true , true , true},
+        { _flyByWireAFlightMode   , 0 , APMPlaneMode::FLY_BY_WIRE_A , true , true , true , true},
+        { _flyByWireBFlightMode   , 0 , APMPlaneMode::FLY_BY_WIRE_B , true , true , true , true},
+        { _cruiseFlightMode       , 0 , APMPlaneMode::CRUISE        , true , true , true , true},
+        { _autoTuneFlightMode     , 0 , APMPlaneMode::AUTOTUNE      , true , true , true , true},
+        { _autoFlightMode         , 0 , APMPlaneMode::AUTO          , true , true , true , true},
+        { _rtlFlightMode          , 0 , APMPlaneMode::RTL           , true , true , true , true},
+        { _loiterFlightMode       , 0 , APMPlaneMode::LOITER        , true , true , true , true},
+        { _takeoffFlightMode      , 0 , APMPlaneMode::TAKEOFF       , true , true , true , true},
+        { _avoidADSBFlightMode    , 0 , APMPlaneMode::AVOID_ADSB    , true , true , true , true},
+        { _guidedFlightMode       , 0 , APMPlaneMode::GUIDED        , true , true , true , true},
+        { _initializingFlightMode , 0 , APMPlaneMode::INITIALIZING  , true , true , true , true},
+        { _qStabilizeFlightMode   , 0 , APMPlaneMode::QSTABILIZE    , true , true , true , true},
+        { _qHoverFlightMode       , 0 , APMPlaneMode::QHOVER        , true , true , true , true},
+        { _qLoiterFlightMode      , 0 , APMPlaneMode::QLOITER       , true , true , true , true},
+        { _qLandFlightMode        , 0 , APMPlaneMode::QLAND         , true , true , true , true},
+        { _qRTLFlightMode         , 0 , APMPlaneMode::QRTL          , true , true , true , true},
+        { _qAutotuneFlightMode    , 0 , APMPlaneMode::QAUTOTUNE     , true , true , true , true},
+        { _qAcroFlightMode        , 0 , APMPlaneMode::QACRO         , true , true , true , true},
+        { _thermalFlightMode      , 0 , APMPlaneMode::THERMAL       , true , true , true , true},
     });
 
     if (!_remapParamNameIntialized) {
@@ -87,4 +108,29 @@ int ArduPlaneFirmwarePlugin::remapParamNameHigestMinorVersionNumber(int majorVer
 {
     // Remapping supports up to 3.10
     return majorVersionNumber == 3 ? 10 : Vehicle::versionNotSetValue;
+}
+
+void ArduPlaneFirmwarePlugin::updateAvailableFlightModes(FlightModeList modeList)
+{
+    _availableFlightModeList.clear();
+    for(auto mode: modeList){
+        mode.fixedWing = true;
+        mode.multiRotor = true;
+        _updateModeMappings(mode);
+    }
+}
+
+uint32_t ArduPlaneFirmwarePlugin::_convertToCustomFlightModeEnum(uint32_t val) const
+{
+    switch (val) {
+    case APMCustomMode::AUTO:
+        return APMPlaneMode::AUTO;
+    case APMCustomMode::GUIDED:
+        return APMPlaneMode::GUIDED;
+    case APMCustomMode::RTL:
+        return APMPlaneMode::RTL;
+    case APMCustomMode::SMART_RTL:
+        return APMPlaneMode::RTL;
+    }
+    return UINT32_MAX;
 }

--- a/src/FirmwarePlugin/APM/ArduPlaneFirmwarePlugin.cc
+++ b/src/FirmwarePlugin/APM/ArduPlaneFirmwarePlugin.cc
@@ -67,31 +67,31 @@ ArduPlaneFirmwarePlugin::ArduPlaneFirmwarePlugin(void)
     });
 
     updateAvailableFlightModes({
-        // Mode Name             ,  SM, Custom Mode                CanBeSet  adv    FW      MR
-        { _manualFlightMode       , 0 , APMPlaneMode::MANUAL        , true , true , true , true},
-        { _circleFlightMode       , 0 , APMPlaneMode::CIRCLE        , true , true , true , true},
-        { _stabilizeFlightMode    , 0 , APMPlaneMode::STABILIZE     , true , true , true , true},
-        { _trainingFlightMode     , 0 , APMPlaneMode::TRAINING      , true , true , true , true},
-        { _acroFlightMode         , 0 , APMPlaneMode::ACRO          , true , true , true , true},
-        { _flyByWireAFlightMode   , 0 , APMPlaneMode::FLY_BY_WIRE_A , true , true , true , true},
-        { _flyByWireBFlightMode   , 0 , APMPlaneMode::FLY_BY_WIRE_B , true , true , true , true},
-        { _cruiseFlightMode       , 0 , APMPlaneMode::CRUISE        , true , true , true , true},
-        { _autoTuneFlightMode     , 0 , APMPlaneMode::AUTOTUNE      , true , true , true , true},
-        { _autoFlightMode         , 0 , APMPlaneMode::AUTO          , true , true , true , true},
-        { _rtlFlightMode          , 0 , APMPlaneMode::RTL           , true , true , true , true},
-        { _loiterFlightMode       , 0 , APMPlaneMode::LOITER        , true , true , true , true},
-        { _takeoffFlightMode      , 0 , APMPlaneMode::TAKEOFF       , true , true , true , true},
-        { _avoidADSBFlightMode    , 0 , APMPlaneMode::AVOID_ADSB    , true , true , true , true},
-        { _guidedFlightMode       , 0 , APMPlaneMode::GUIDED        , true , true , true , true},
-        { _initializingFlightMode , 0 , APMPlaneMode::INITIALIZING  , true , true , true , true},
-        { _qStabilizeFlightMode   , 0 , APMPlaneMode::QSTABILIZE    , true , true , true , true},
-        { _qHoverFlightMode       , 0 , APMPlaneMode::QHOVER        , true , true , true , true},
-        { _qLoiterFlightMode      , 0 , APMPlaneMode::QLOITER       , true , true , true , true},
-        { _qLandFlightMode        , 0 , APMPlaneMode::QLAND         , true , true , true , true},
-        { _qRTLFlightMode         , 0 , APMPlaneMode::QRTL          , true , true , true , true},
-        { _qAutotuneFlightMode    , 0 , APMPlaneMode::QAUTOTUNE     , true , true , true , true},
-        { _qAcroFlightMode        , 0 , APMPlaneMode::QACRO         , true , true , true , true},
-        { _thermalFlightMode      , 0 , APMPlaneMode::THERMAL       , true , true , true , true},
+        // Mode Name              , Custom Mode                CanBeSet  adv
+        { _manualFlightMode       , APMPlaneMode::MANUAL        , true , true },
+        { _circleFlightMode       , APMPlaneMode::CIRCLE        , true , true },
+        { _stabilizeFlightMode    , APMPlaneMode::STABILIZE     , true , true },
+        { _trainingFlightMode     , APMPlaneMode::TRAINING      , true , true },
+        { _acroFlightMode         , APMPlaneMode::ACRO          , true , true },
+        { _flyByWireAFlightMode   , APMPlaneMode::FLY_BY_WIRE_A , true , true },
+        { _flyByWireBFlightMode   , APMPlaneMode::FLY_BY_WIRE_B , true , true },
+        { _cruiseFlightMode       , APMPlaneMode::CRUISE        , true , true },
+        { _autoTuneFlightMode     , APMPlaneMode::AUTOTUNE      , true , true },
+        { _autoFlightMode         , APMPlaneMode::AUTO          , true , true },
+        { _rtlFlightMode          , APMPlaneMode::RTL           , true , true },
+        { _loiterFlightMode       , APMPlaneMode::LOITER        , true , true },
+        { _takeoffFlightMode      , APMPlaneMode::TAKEOFF       , true , true },
+        { _avoidADSBFlightMode    , APMPlaneMode::AVOID_ADSB    , true , true },
+        { _guidedFlightMode       , APMPlaneMode::GUIDED        , true , true },
+        { _initializingFlightMode , APMPlaneMode::INITIALIZING  , true , true },
+        { _qStabilizeFlightMode   , APMPlaneMode::QSTABILIZE    , true , true },
+        { _qHoverFlightMode       , APMPlaneMode::QHOVER        , true , true },
+        { _qLoiterFlightMode      , APMPlaneMode::QLOITER       , true , true },
+        { _qLandFlightMode        , APMPlaneMode::QLAND         , true , true },
+        { _qRTLFlightMode         , APMPlaneMode::QRTL          , true , true },
+        { _qAutotuneFlightMode    , APMPlaneMode::QAUTOTUNE     , true , true },
+        { _qAcroFlightMode        , APMPlaneMode::QACRO         , true , true },
+        { _thermalFlightMode      , APMPlaneMode::THERMAL       , true , true },
     });
 
     if (!_remapParamNameIntialized) {
@@ -110,14 +110,19 @@ int ArduPlaneFirmwarePlugin::remapParamNameHigestMinorVersionNumber(int majorVer
     return majorVersionNumber == 3 ? 10 : Vehicle::versionNotSetValue;
 }
 
+QString ArduPlaneFirmwarePlugin::stabilizedFlightMode() const
+{
+    return _modeEnumToString.value(APMPlaneMode::STABILIZE, _stabilizeFlightMode);
+}
+
 void ArduPlaneFirmwarePlugin::updateAvailableFlightModes(FlightModeList modeList)
 {
-    _availableFlightModeList.clear();
-    for(auto mode: modeList){
+    for(auto &mode: modeList){
         mode.fixedWing = true;
         mode.multiRotor = true;
-        _updateModeMappings(mode);
     }
+
+    _updateModeMappings(modeList);
 }
 
 uint32_t ArduPlaneFirmwarePlugin::_convertToCustomFlightModeEnum(uint32_t val) const

--- a/src/FirmwarePlugin/APM/ArduPlaneFirmwarePlugin.h
+++ b/src/FirmwarePlugin/APM/ArduPlaneFirmwarePlugin.h
@@ -60,6 +60,7 @@ public:
     int     remapParamNameHigestMinorVersionNumber  (int majorVersionNumber) const final;    
     const FirmwarePlugin::remapParamNameMajorVersionMap_t& paramNameRemapMajorVersionMap(void) const final { return _remapParamName; }
 
+    QString stabilizedFlightMode                    (void) const override;
     void    updateAvailableFlightModes              (FlightModeList modeList) final;
 
 protected:

--- a/src/FirmwarePlugin/APM/ArduPlaneFirmwarePlugin.h
+++ b/src/FirmwarePlugin/APM/ArduPlaneFirmwarePlugin.h
@@ -15,10 +15,9 @@
 
 #include "APMFirmwarePlugin.h"
 
-class APMPlaneMode: public APMCustomMode
+struct APMPlaneMode
 {
-public:
-    enum Mode {
+    enum Mode : uint32_t {
         MANUAL        = 0,
         CIRCLE        = 1,
         STABILIZE     = 2,
@@ -45,8 +44,6 @@ public:
         QACRO         = 23,
         THERMAL       = 24,
     };
-
-    APMPlaneMode(uint32_t mode, bool settable);
 };
 
 class ArduPlaneFirmwarePlugin : public APMFirmwarePlugin
@@ -63,6 +60,36 @@ public:
     int     remapParamNameHigestMinorVersionNumber  (int majorVersionNumber) const final;    
     const FirmwarePlugin::remapParamNameMajorVersionMap_t& paramNameRemapMajorVersionMap(void) const final { return _remapParamName; }
 
+    void    updateAvailableFlightModes              (FlightModeList modeList) final;
+
+protected:
+    uint32_t    _convertToCustomFlightModeEnum(uint32_t val) const override;
+
+
+    QString     _manualFlightMode       ;
+    QString     _circleFlightMode       ;
+    QString     _stabilizeFlightMode    ;
+    QString     _trainingFlightMode     ;
+    QString     _acroFlightMode         ;
+    QString     _flyByWireAFlightMode   ;
+    QString     _flyByWireBFlightMode   ;
+    QString     _cruiseFlightMode       ;
+    QString     _autoTuneFlightMode     ;
+    QString     _autoFlightMode         ;
+    QString     _rtlFlightMode          ;
+    QString     _loiterFlightMode       ;
+    QString     _takeoffFlightMode      ;
+    QString     _avoidADSBFlightMode    ;
+    QString     _guidedFlightMode       ;
+    QString     _initializingFlightMode ;
+    QString     _qStabilizeFlightMode   ;
+    QString     _qHoverFlightMode       ;
+    QString     _qLoiterFlightMode      ;
+    QString     _qLandFlightMode        ;
+    QString     _qRTLFlightMode         ;
+    QString     _qAutotuneFlightMode    ;
+    QString     _qAcroFlightMode        ;
+    QString     _thermalFlightMode      ;
 private:
     static bool _remapParamNameIntialized;
     static FirmwarePlugin::remapParamNameMajorVersionMap_t  _remapParamName;

--- a/src/FirmwarePlugin/APM/ArduRoverFirmwarePlugin.cc
+++ b/src/FirmwarePlugin/APM/ArduRoverFirmwarePlugin.cc
@@ -50,22 +50,22 @@ ArduRoverFirmwarePlugin::ArduRoverFirmwarePlugin(void)
     });
 
     updateAvailableFlightModes({
-        // Mode Name              , SM, Custom Mode                CanBeSet  adv    FW      MR
-        { _manualFlightMode       , 0 , APMRoverMode::MANUAL       , true , true , false , true},
-        { _acroFlightMode         , 0 , APMRoverMode::ACRO         , true , true , false , true},
-        { _learningFlightMode     , 0 , APMRoverMode::LEARNING     , true , true , false , true},
-        { _steeringFlightMode     , 0 , APMRoverMode::STEERING     , true , true , false , true},
-        { _holdFlightMode         , 0 , APMRoverMode::HOLD         , true , true , false , true},
-        { _loiterFlightMode       , 0 , APMRoverMode::LOITER       , true , true , false , true},
-        { _followFlightMode       , 0 , APMRoverMode::FOLLOW       , true , true , false , true},
-        { _simpleFlightMode       , 0 , APMRoverMode::SIMPLE       , true , true , false , true},
-        { _dockFlightMode         , 0 , APMRoverMode::DOCK         , true , true , false , true},
-        { _circleFlightMode       , 0 , APMRoverMode::CIRCLE       , true , true , false , true},
-        { _autoFlightMode         , 0 , APMRoverMode::AUTO         , true , true , false , true},
-        { _rtlFlightMode          , 0 , APMRoverMode::RTL          , true , true , false , true},
-        { _smartRtlFlightMode     , 0 , APMRoverMode::SMART_RTL    , true , true , false , true},
-        { _guidedFlightMode       , 0 , APMRoverMode::GUIDED       , true , true , false , true},
-        { _initializingFlightMode , 0 , APMRoverMode::INITIALIZING , true , true , false , true},
+        // Mode Name              , Custom Mode                CanBeSet  adv
+        { _manualFlightMode       , APMRoverMode::MANUAL       , true , true},
+        { _acroFlightMode         , APMRoverMode::ACRO         , true , true},
+        { _learningFlightMode     , APMRoverMode::LEARNING     , true , true},
+        { _steeringFlightMode     , APMRoverMode::STEERING     , true , true},
+        { _holdFlightMode         , APMRoverMode::HOLD         , true , true},
+        { _loiterFlightMode       , APMRoverMode::LOITER       , true , true},
+        { _followFlightMode       , APMRoverMode::FOLLOW       , true , true},
+        { _simpleFlightMode       , APMRoverMode::SIMPLE       , true , true},
+        { _dockFlightMode         , APMRoverMode::DOCK         , true , true},
+        { _circleFlightMode       , APMRoverMode::CIRCLE       , true , true},
+        { _autoFlightMode         , APMRoverMode::AUTO         , true , true},
+        { _rtlFlightMode          , APMRoverMode::RTL          , true , true},
+        { _smartRtlFlightMode     , APMRoverMode::SMART_RTL    , true , true},
+        { _guidedFlightMode       , APMRoverMode::GUIDED       , true , true},
+        { _initializingFlightMode , APMRoverMode::INITIALIZING , true , true},
     });
 
     if (!_remapParamNameIntialized) {
@@ -94,14 +94,19 @@ bool ArduRoverFirmwarePlugin::supportsNegativeThrust(Vehicle* /*vehicle*/)
     return true;
 }
 
+QString ArduRoverFirmwarePlugin::stabilizedFlightMode() const
+{
+    return _modeEnumToString.value(APMRoverMode::MANUAL, _manualFlightMode);
+}
+
 void ArduRoverFirmwarePlugin::updateAvailableFlightModes(FlightModeList modeList)
 {
-    _availableFlightModeList.clear();
-    for(auto mode: modeList){
+    for(auto &mode: modeList){
         mode.fixedWing = false;
         mode.multiRotor = true;
-        _updateModeMappings(mode);
     }
+
+    _updateModeMappings(modeList);
 }
 
 uint32_t ArduRoverFirmwarePlugin::_convertToCustomFlightModeEnum(uint32_t val) const

--- a/src/FirmwarePlugin/APM/ArduRoverFirmwarePlugin.cc
+++ b/src/FirmwarePlugin/APM/ArduRoverFirmwarePlugin.cc
@@ -14,46 +14,58 @@
 bool ArduRoverFirmwarePlugin::_remapParamNameIntialized = false;
 FirmwarePlugin::remapParamNameMajorVersionMap_t ArduRoverFirmwarePlugin::_remapParamName;
 
-APMRoverMode::APMRoverMode(uint32_t mode, bool settable)
-    : APMCustomMode(mode, settable)
-{
-    setEnumToStringMapping({
-        {MANUAL,         "Manual"},
-        {ACRO,           "Acro"},
-        {LEARNING,       "Learning"},
-        {STEERING,       "Steering"},
-        {HOLD,           "Hold"},
-        {LOITER,         "Loiter"},
-        {FOLLOW,         "Follow"},
-        {SIMPLE,         "Simple"},
-        {DOCK,           "Dock"},
-        {CIRCLE,         "Circle"},
-        {AUTO,           "Auto"},
-        {RTL,            "RTL"},
-        {SMART_RTL,      "Smart RTL"},
-        {GUIDED,         "Guided"},
-        {INITIALIZING,   "Initializing"},
-    });
-}
-
 ArduRoverFirmwarePlugin::ArduRoverFirmwarePlugin(void)
+    : _manualFlightMode         (tr("Manual"))
+    , _acroFlightMode           (tr("Acro"))
+    , _learningFlightMode       (tr("Learning"))
+    , _steeringFlightMode       (tr("Steering"))
+    , _holdFlightMode           (tr("Hold"))
+    , _loiterFlightMode         (tr("Loiter"))
+    , _followFlightMode         (tr("Follow"))
+    , _simpleFlightMode         (tr("Simple"))
+    , _dockFlightMode           (tr("Dock"))
+    , _circleFlightMode         (tr("Circle"))
+    , _autoFlightMode           (tr("Auto"))
+    , _rtlFlightMode            (tr("RTL"))
+    , _smartRtlFlightMode       (tr("Smart RTL"))
+    , _guidedFlightMode         (tr("Guided"))
+    , _initializingFlightMode   (tr("Initializing"))
 {
-    setSupportedModes({
-        APMRoverMode(APMRoverMode::MANUAL       ,true),
-        APMRoverMode(APMRoverMode::ACRO         ,true),
-        APMRoverMode(APMRoverMode::LEARNING     ,false),
-        APMRoverMode(APMRoverMode::STEERING     ,true),
-        APMRoverMode(APMRoverMode::HOLD         ,true),
-        APMRoverMode(APMRoverMode::LOITER       ,true),
-        APMRoverMode(APMRoverMode::FOLLOW       ,true),
-        APMRoverMode(APMRoverMode::SIMPLE       ,true),
-        APMRoverMode(APMRoverMode::DOCK         ,true),
-        APMRoverMode(APMRoverMode::CIRCLE       ,true),
-        APMRoverMode(APMRoverMode::AUTO         ,true),
-        APMRoverMode(APMRoverMode::RTL          ,true),
-        APMRoverMode(APMRoverMode::SMART_RTL    ,true),
-        APMRoverMode(APMRoverMode::GUIDED       ,true),
-        APMRoverMode(APMRoverMode::INITIALIZING ,false),
+    _setModeEnumToModeStringMapping({
+        {APMRoverMode::MANUAL       , _manualFlightMode      },
+        {APMRoverMode::ACRO         , _acroFlightMode        },
+        {APMRoverMode::LEARNING     , _learningFlightMode    },
+        {APMRoverMode::STEERING     , _steeringFlightMode    },
+        {APMRoverMode::HOLD         , _holdFlightMode        },
+        {APMRoverMode::LOITER       , _loiterFlightMode      },
+        {APMRoverMode::FOLLOW       , _followFlightMode      },
+        {APMRoverMode::SIMPLE       , _simpleFlightMode      },
+        {APMRoverMode::DOCK         , _dockFlightMode        },
+        {APMRoverMode::CIRCLE       , _circleFlightMode      },
+        {APMRoverMode::AUTO         , _autoFlightMode        },
+        {APMRoverMode::RTL          , _rtlFlightMode         },
+        {APMRoverMode::SMART_RTL    , _smartRtlFlightMode    },
+        {APMRoverMode::GUIDED       , _guidedFlightMode      },
+        {APMRoverMode::INITIALIZING , _initializingFlightMode},
+    });
+
+    updateAvailableFlightModes({
+        // Mode Name              , SM, Custom Mode                CanBeSet  adv    FW      MR
+        { _manualFlightMode       , 0 , APMRoverMode::MANUAL       , true , true , false , true},
+        { _acroFlightMode         , 0 , APMRoverMode::ACRO         , true , true , false , true},
+        { _learningFlightMode     , 0 , APMRoverMode::LEARNING     , true , true , false , true},
+        { _steeringFlightMode     , 0 , APMRoverMode::STEERING     , true , true , false , true},
+        { _holdFlightMode         , 0 , APMRoverMode::HOLD         , true , true , false , true},
+        { _loiterFlightMode       , 0 , APMRoverMode::LOITER       , true , true , false , true},
+        { _followFlightMode       , 0 , APMRoverMode::FOLLOW       , true , true , false , true},
+        { _simpleFlightMode       , 0 , APMRoverMode::SIMPLE       , true , true , false , true},
+        { _dockFlightMode         , 0 , APMRoverMode::DOCK         , true , true , false , true},
+        { _circleFlightMode       , 0 , APMRoverMode::CIRCLE       , true , true , false , true},
+        { _autoFlightMode         , 0 , APMRoverMode::AUTO         , true , true , false , true},
+        { _rtlFlightMode          , 0 , APMRoverMode::RTL          , true , true , false , true},
+        { _smartRtlFlightMode     , 0 , APMRoverMode::SMART_RTL    , true , true , false , true},
+        { _guidedFlightMode       , 0 , APMRoverMode::GUIDED       , true , true , false , true},
+        { _initializingFlightMode , 0 , APMRoverMode::INITIALIZING , true , true , false , true},
     });
 
     if (!_remapParamNameIntialized) {
@@ -80,4 +92,29 @@ void ArduRoverFirmwarePlugin::guidedModeChangeAltitude(Vehicle* /*vehicle*/, dou
 bool ArduRoverFirmwarePlugin::supportsNegativeThrust(Vehicle* /*vehicle*/)
 {
     return true;
+}
+
+void ArduRoverFirmwarePlugin::updateAvailableFlightModes(FlightModeList modeList)
+{
+    _availableFlightModeList.clear();
+    for(auto mode: modeList){
+        mode.fixedWing = false;
+        mode.multiRotor = true;
+        _updateModeMappings(mode);
+    }
+}
+
+uint32_t ArduRoverFirmwarePlugin::_convertToCustomFlightModeEnum(uint32_t val) const
+{
+    switch (val) {
+    case APMCustomMode::AUTO:
+        return APMRoverMode::AUTO;
+    case APMCustomMode::GUIDED:
+        return APMRoverMode::GUIDED;
+    case APMCustomMode::RTL:
+        return APMRoverMode::RTL;
+    case APMCustomMode::SMART_RTL:
+        return APMRoverMode::SMART_RTL;
+    }
+    return UINT32_MAX;
 }

--- a/src/FirmwarePlugin/APM/ArduRoverFirmwarePlugin.h
+++ b/src/FirmwarePlugin/APM/ArduRoverFirmwarePlugin.h
@@ -53,6 +53,7 @@ public:
     bool    supportsSmartRTL                        (void) const override { return true; }
     QString offlineEditingParamFile                 (Vehicle* vehicle) override { Q_UNUSED(vehicle); return QStringLiteral(":/FirmwarePlugin/APM/Rover.OfflineEditing.params"); }
 
+    QString stabilizedFlightMode                    (void) const override;
     void    updateAvailableFlightModes              (FlightModeList modeList) final;
 
 protected:

--- a/src/FirmwarePlugin/APM/ArduRoverFirmwarePlugin.h
+++ b/src/FirmwarePlugin/APM/ArduRoverFirmwarePlugin.h
@@ -15,10 +15,9 @@
 
 #include "APMFirmwarePlugin.h"
 
-class APMRoverMode : public APMCustomMode
+struct APMRoverMode
 {
-public:
-    enum Mode {
+    enum Mode : uint32_t{
         MANUAL          = 0,
         ACRO            = 1,
         LEARNING        = 2, // Deprecated
@@ -33,10 +32,8 @@ public:
         RTL             = 11,
         SMART_RTL       = 12,
         GUIDED          = 15,
-        INITIALIZING    = 16,
+        INITIALIZING    = 16
     };
-
-    APMRoverMode(uint32_t mode, bool settable);
 };
 
 class ArduRoverFirmwarePlugin : public APMFirmwarePlugin
@@ -55,6 +52,28 @@ public:
     bool    supportsNegativeThrust                  (Vehicle *) final;
     bool    supportsSmartRTL                        (void) const override { return true; }
     QString offlineEditingParamFile                 (Vehicle* vehicle) override { Q_UNUSED(vehicle); return QStringLiteral(":/FirmwarePlugin/APM/Rover.OfflineEditing.params"); }
+
+    void    updateAvailableFlightModes              (FlightModeList modeList) final;
+
+protected:
+    uint32_t    _convertToCustomFlightModeEnum(uint32_t val) const override;
+
+
+    QString     _manualFlightMode       ;
+    QString     _acroFlightMode         ;
+    QString     _learningFlightMode     ;
+    QString     _steeringFlightMode     ;
+    QString     _holdFlightMode         ;
+    QString     _loiterFlightMode       ;
+    QString     _followFlightMode       ;
+    QString     _simpleFlightMode       ;
+    QString     _dockFlightMode         ;
+    QString     _circleFlightMode       ;
+    QString     _autoFlightMode         ;
+    QString     _rtlFlightMode          ;
+    QString     _smartRtlFlightMode     ;
+    QString     _guidedFlightMode       ;
+    QString     _initializingFlightMode ;
 
 private:
     static bool _remapParamNameIntialized;

--- a/src/FirmwarePlugin/APM/ArduSubFirmwarePlugin.cc
+++ b/src/FirmwarePlugin/APM/ArduSubFirmwarePlugin.cc
@@ -39,39 +39,47 @@
 bool ArduSubFirmwarePlugin::_remapParamNameIntialized = false;
 FirmwarePlugin::remapParamNameMajorVersionMap_t ArduSubFirmwarePlugin::_remapParamName;
 
-APMSubMode::APMSubMode(uint32_t mode, bool settable) :
-    APMCustomMode(mode, settable)
+ArduSubFirmwarePlugin::ArduSubFirmwarePlugin(void)
+    : _infoFactGroup(this)
+    , _manualFlightMode         (tr("Manual"))
+    , _stabilizeFlightMode      (tr("Stabilize"))
+    , _acroFlightMode           (tr("Acro"))
+    , _altHoldFlightMode        (tr("Depth Hold"))
+    , _autoFlightMode           (tr("Auto"))
+    , _guidedFlightMode         (tr("Guided"))
+    , _circleFlightMode         (tr("Circle"))
+    , _surfaceFlightMode        (tr("Surface"))
+    , _posHoldFlightMode        (tr("Position Hold"))
+    , _motorDetectionFlightMode (tr("Motor Detection"))
+    , _surftrakFlightMode       (tr("Surftrak"))
 {
-    setEnumToStringMapping({
-        {MANUAL, "Manual"},
-        {STABILIZE, "Stabilize"},
-        {ACRO, "Acro"},
-        {ALT_HOLD,  "Depth Hold"},
-        {AUTO, "Auto"},
-        {GUIDED, "Guided"},
-        {CIRCLE, "Circle"},
-        {SURFACE, "Surface"},
-        {POSHOLD, "Position Hold"},
-        {MOTORDETECTION, "Motor Detection"},
-        {SURFTRAK, "Surftrak"},
+    _setModeEnumToModeStringMapping({
+        { APMSubMode::MANUAL            , _manualFlightMode        },
+        { APMSubMode::STABILIZE         , _stabilizeFlightMode     },
+        { APMSubMode::ACRO              , _acroFlightMode          },
+        { APMSubMode::ALT_HOLD          , _altHoldFlightMode       },
+        { APMSubMode::AUTO              , _autoFlightMode          },
+        { APMSubMode::GUIDED            , _guidedFlightMode        },
+        { APMSubMode::CIRCLE            , _circleFlightMode        },
+        { APMSubMode::SURFACE           , _surfaceFlightMode       },
+        { APMSubMode::POSHOLD           , _posHoldFlightMode       },
+        { APMSubMode::MOTORDETECTION    , _motorDetectionFlightMode},
+        { APMSubMode::SURFTRAK          , _surftrakFlightMode      },
     });
-}
 
-ArduSubFirmwarePlugin::ArduSubFirmwarePlugin(void):
-    _infoFactGroup(this)
-{
-    setSupportedModes({
-        APMSubMode(APMSubMode::MANUAL ,true),
-        APMSubMode(APMSubMode::STABILIZE ,true),
-        APMSubMode(APMSubMode::ACRO ,true),
-        APMSubMode(APMSubMode::ALT_HOLD  ,true),
-        APMSubMode(APMSubMode::AUTO ,true),
-        APMSubMode(APMSubMode::GUIDED ,true),
-        APMSubMode(APMSubMode::CIRCLE ,true),
-        APMSubMode(APMSubMode::SURFACE ,false),
-        APMSubMode(APMSubMode::POSHOLD ,true),
-        APMSubMode(APMSubMode::MOTORDETECTION, false),
-        APMSubMode(APMSubMode::SURFTRAK, true),
+    updateAvailableFlightModes({
+        // Mode Name                , SM, Custom Mode                  CanBeSet  adv    FW      MR
+        { _manualFlightMode         , 0 , APMSubMode::MANUAL            , true , true , false , true},
+        { _stabilizeFlightMode      , 0 , APMSubMode::STABILIZE         , true , true , false , true},
+        { _acroFlightMode           , 0 , APMSubMode::ACRO              , true , true , false , true},
+        { _altHoldFlightMode        , 0 , APMSubMode::ALT_HOLD          , true , true , false , true},
+        { _autoFlightMode           , 0 , APMSubMode::AUTO              , true , true , false , true},
+        { _guidedFlightMode         , 0 , APMSubMode::GUIDED            , true , true , false , true},
+        { _circleFlightMode         , 0 , APMSubMode::CIRCLE            , true , true , false , true},
+        { _surfaceFlightMode        , 0 , APMSubMode::SURFACE           , true , true , false , true},
+        { _posHoldFlightMode        , 0 , APMSubMode::POSHOLD           , true , true , false , true},
+        { _motorDetectionFlightMode , 0 , APMSubMode::MOTORDETECTION    , true , true , false , true},
+        { _surftrakFlightMode       , 0 , APMSubMode::SURFTRAK          , true , true , false , true},
     });
 
     if (!_remapParamNameIntialized) {
@@ -344,4 +352,25 @@ void ArduSubFirmwarePlugin::adjustMetaData(MAV_TYPE vehicleType, FactMetaData* m
     if (_factRenameMap.contains(metaData->name())) {
         metaData->setShortDescription(QString(_factRenameMap[metaData->name()]));
     }
+}
+
+void ArduSubFirmwarePlugin::updateAvailableFlightModes(FlightModeList modeList)
+{
+    _availableFlightModeList.clear();
+    for(auto mode: modeList){
+        mode.fixedWing = false;
+        mode.multiRotor = true;
+        _updateModeMappings(mode);
+    }
+}
+
+uint32_t ArduSubFirmwarePlugin::_convertToCustomFlightModeEnum(uint32_t val) const
+{
+    switch (val) {
+    case APMCustomMode::AUTO:
+        return APMSubMode::AUTO;
+    case APMCustomMode::GUIDED:
+        return APMSubMode::GUIDED;
+    }
+    return UINT32_MAX;
 }

--- a/src/FirmwarePlugin/APM/ArduSubFirmwarePlugin.cc
+++ b/src/FirmwarePlugin/APM/ArduSubFirmwarePlugin.cc
@@ -68,18 +68,18 @@ ArduSubFirmwarePlugin::ArduSubFirmwarePlugin(void)
     });
 
     updateAvailableFlightModes({
-        // Mode Name                , SM, Custom Mode                  CanBeSet  adv    FW      MR
-        { _manualFlightMode         , 0 , APMSubMode::MANUAL            , true , true , false , true},
-        { _stabilizeFlightMode      , 0 , APMSubMode::STABILIZE         , true , true , false , true},
-        { _acroFlightMode           , 0 , APMSubMode::ACRO              , true , true , false , true},
-        { _altHoldFlightMode        , 0 , APMSubMode::ALT_HOLD          , true , true , false , true},
-        { _autoFlightMode           , 0 , APMSubMode::AUTO              , true , true , false , true},
-        { _guidedFlightMode         , 0 , APMSubMode::GUIDED            , true , true , false , true},
-        { _circleFlightMode         , 0 , APMSubMode::CIRCLE            , true , true , false , true},
-        { _surfaceFlightMode        , 0 , APMSubMode::SURFACE           , true , true , false , true},
-        { _posHoldFlightMode        , 0 , APMSubMode::POSHOLD           , true , true , false , true},
-        { _motorDetectionFlightMode , 0 , APMSubMode::MOTORDETECTION    , true , true , false , true},
-        { _surftrakFlightMode       , 0 , APMSubMode::SURFTRAK          , true , true , false , true},
+        // Mode Name                , Custom Mode                  CanBeSet  adv
+        { _manualFlightMode         , APMSubMode::MANUAL            , true , true },
+        { _stabilizeFlightMode      , APMSubMode::STABILIZE         , true , true },
+        { _acroFlightMode           , APMSubMode::ACRO              , true , true },
+        { _altHoldFlightMode        , APMSubMode::ALT_HOLD          , true , true },
+        { _autoFlightMode           , APMSubMode::AUTO              , true , true },
+        { _guidedFlightMode         , APMSubMode::GUIDED            , true , true },
+        { _circleFlightMode         , APMSubMode::CIRCLE            , true , true },
+        { _surfaceFlightMode        , APMSubMode::SURFACE           , true , true },
+        { _posHoldFlightMode        , APMSubMode::POSHOLD           , true , true },
+        { _motorDetectionFlightMode , APMSubMode::MOTORDETECTION    , true , true },
+        { _surftrakFlightMode       , APMSubMode::SURFTRAK          , true , true },
     });
 
     if (!_remapParamNameIntialized) {
@@ -354,14 +354,24 @@ void ArduSubFirmwarePlugin::adjustMetaData(MAV_TYPE vehicleType, FactMetaData* m
     }
 }
 
+QString ArduSubFirmwarePlugin::stabilizedFlightMode() const
+{
+    return _modeEnumToString.value(APMSubMode::STABILIZE, _stabilizeFlightMode);
+}
+
+QString ArduSubFirmwarePlugin::motorDetectionFlightMode() const
+{
+    return _modeEnumToString.value(APMSubMode::MOTORDETECTION, _motorDetectionFlightMode);
+}
+
 void ArduSubFirmwarePlugin::updateAvailableFlightModes(FlightModeList modeList)
 {
-    _availableFlightModeList.clear();
-    for(auto mode: modeList){
+    for(auto &mode: modeList){
         mode.fixedWing = false;
         mode.multiRotor = true;
-        _updateModeMappings(mode);
     }
+
+    _updateModeMappings(modeList);
 }
 
 uint32_t ArduSubFirmwarePlugin::_convertToCustomFlightModeEnum(uint32_t val) const

--- a/src/FirmwarePlugin/APM/ArduSubFirmwarePlugin.h
+++ b/src/FirmwarePlugin/APM/ArduSubFirmwarePlugin.h
@@ -152,7 +152,9 @@ public:
     virtual QMap<QString, FactGroup*>* factGroups(void) final;
     void adjustMetaData(MAV_TYPE vehicleType, FactMetaData* metaData) override final;
 
-    void updateAvailableFlightModes(FlightModeList modeList) final;
+    QString stabilizedFlightMode                (void) const override;
+    QString motorDetectionFlightMode            (void) const override;
+    void    updateAvailableFlightModes          (FlightModeList modeList) final;
 
 protected:
     uint32_t    _convertToCustomFlightModeEnum(uint32_t val) const override;

--- a/src/FirmwarePlugin/APM/ArduSubFirmwarePlugin.h
+++ b/src/FirmwarePlugin/APM/ArduSubFirmwarePlugin.h
@@ -87,10 +87,9 @@ private:
     Fact            _rangefinderTargetFact;
 };
 
-class APMSubMode : public APMCustomMode
+struct APMSubMode
 {
-public:
-    enum Mode {
+    enum Mode : uint32_t{
         STABILIZE         = 0,   // Hold level position
         ACRO              = 1,   // Manual angular rate, throttle
         ALT_HOLD          = 2,   // Depth hold
@@ -114,8 +113,6 @@ public:
         MOTORDETECTION    = 20,
         SURFTRAK          = 21,  // Surface (seafloor) tracking, aka hold range
     };
-
-    APMSubMode(uint32_t mode, bool settable);
 };
 
 class ArduSubFirmwarePlugin : public APMFirmwarePlugin
@@ -155,6 +152,23 @@ public:
     virtual QMap<QString, FactGroup*>* factGroups(void) final;
     void adjustMetaData(MAV_TYPE vehicleType, FactMetaData* metaData) override final;
 
+    void updateAvailableFlightModes(FlightModeList modeList) final;
+
+protected:
+    uint32_t    _convertToCustomFlightModeEnum(uint32_t val) const override;
+
+
+    QString     _manualFlightMode           ;
+    QString     _stabilizeFlightMode        ;
+    QString     _acroFlightMode             ;
+    QString     _altHoldFlightMode          ;
+    QString     _autoFlightMode             ;
+    QString     _guidedFlightMode           ;
+    QString     _circleFlightMode           ;
+    QString     _surfaceFlightMode          ;
+    QString     _posHoldFlightMode          ;
+    QString     _motorDetectionFlightMode   ;
+    QString     _surftrakFlightMode         ;
 
 private:
     QVariantList _toolIndicators;

--- a/src/FirmwarePlugin/FirmwarePlugin.cc
+++ b/src/FirmwarePlugin/FirmwarePlugin.cc
@@ -72,7 +72,7 @@ QString FirmwarePlugin::flightMode(uint8_t base_mode, uint32_t custom_mode) cons
     if (base_mode == 0) {
         flightMode = "PreFlight";
     } else if (base_mode & MAV_MODE_FLAG_CUSTOM_MODE_ENABLED) {
-        flightMode = QString("Custom:0x%1").arg(custom_mode, 0, 16);
+        flightMode = _modeEnumToString.value(custom_mode, QString("Custom:0x%1").arg(custom_mode, 0, 16));
     } else {
         for (size_t i=0; i<sizeof(rgBit2Name)/sizeof(rgBit2Name[0]); i++) {
             if (base_mode & rgBit2Name[i].baseModeBit) {
@@ -570,11 +570,7 @@ Autotune* FirmwarePlugin::createAutotune(Vehicle *vehicle)
 
 void FirmwarePlugin::updateAvailableFlightModes(FlightModeList modeList)
 {
-    _availableFlightModeList.clear();
-
-    for(auto mode: modeList){
-        _updateModeMappings(mode);
-    }
+    _updateModeMappings(modeList);
 }
 
 void FirmwarePlugin::_setModeEnumToModeStringMapping(FlightModeCustomModeMap enumToString)
@@ -582,17 +578,22 @@ void FirmwarePlugin::_setModeEnumToModeStringMapping(FlightModeCustomModeMap enu
     _modeEnumToString = enumToString;
 }
 
-void FirmwarePlugin::_updateModeMappings(FirmwareFlightMode &mode){
-    // Get Presaved Mode String, if mode is not present then take Custom Mode Name
+void FirmwarePlugin::_updateModeMappings(FlightModeList &modeList){
 
-    QString nModeName = mode.mode_name;
-    if(_modeEnumToString.contains(mode.custom_mode)){
-        nModeName = _modeEnumToString[mode.custom_mode];
+    _availableFlightModeList.clear();
+
+    for(auto &mode:modeList){
+        // Get Presaved Mode String, if mode is not present then take Custom Mode Name
+
+        QString nModeName = mode.mode_name;
+        if(_modeEnumToString.contains(mode.custom_mode)){
+            nModeName = _modeEnumToString[mode.custom_mode];
+        }
+        else{
+            // Mode Is New for QGC
+            _modeEnumToString[mode.custom_mode] = nModeName;
+        }
+        mode.mode_name = nModeName;
+        _availableFlightModeList += mode;
     }
-    else{
-        // Mode Is New for QGC
-        _modeEnumToString[mode.custom_mode] = nModeName;
-    }
-    mode.mode_name = nModeName;
-    _availableFlightModeList += mode;
 }

--- a/src/FirmwarePlugin/FirmwarePlugin.cc
+++ b/src/FirmwarePlugin/FirmwarePlugin.cc
@@ -567,3 +567,32 @@ Autotune* FirmwarePlugin::createAutotune(Vehicle *vehicle)
 {
     return new Autotune(vehicle);
 }
+
+void FirmwarePlugin::updateAvailableFlightModes(FlightModeList modeList)
+{
+    _availableFlightModeList.clear();
+
+    for(auto mode: modeList){
+        _updateModeMappings(mode);
+    }
+}
+
+void FirmwarePlugin::_setModeEnumToModeStringMapping(FlightModeCustomModeMap enumToString)
+{
+    _modeEnumToString = enumToString;
+}
+
+void FirmwarePlugin::_updateModeMappings(FirmwareFlightMode &mode){
+    // Get Presaved Mode String, if mode is not present then take Custom Mode Name
+
+    QString nModeName = mode.mode_name;
+    if(_modeEnumToString.contains(mode.custom_mode)){
+        nModeName = _modeEnumToString[mode.custom_mode];
+    }
+    else{
+        // Mode Is New for QGC
+        _modeEnumToString[mode.custom_mode] = nModeName;
+    }
+    mode.mode_name = nModeName;
+    _availableFlightModeList += mode;
+}

--- a/src/FirmwarePlugin/FirmwarePlugin.h
+++ b/src/FirmwarePlugin/FirmwarePlugin.h
@@ -28,6 +28,20 @@ class Autotune;
 class LinkInterface;
 class FactGroup;
 
+
+struct FirmwareFlightMode
+{
+    QString     mode_name       = "Unknown";
+    uint8_t     standard_mode   = UINT8_MAX;
+    uint32_t    custom_mode     = UINT32_MAX;
+    bool        canBeSet        = false;
+    bool        advanced        = false;
+    bool        fixedWing       = false;
+    bool        multiRotor      = true;
+};
+
+typedef QList<FirmwareFlightMode>         FlightModeList;
+typedef QMap<uint32_t,QString>            FlightModeCustomModeMap;
 /// This is the base class for Firmware specific plugins
 ///
 /// The FirmwarePlugin class represents the methods and objects which are specific to a certain Firmware flight stack.
@@ -357,6 +371,9 @@ public:
     /// Creates Autotune object.
     virtual Autotune* createAutotune(Vehicle *vehicle);
 
+    /// Update Available flight modes recieved from vehicle
+    virtual void updateAvailableFlightModes(FlightModeList modeList);
+
 signals:
     void toolIndicatorsChanged(void);
     void modeIndicatorsChanged(void);
@@ -378,6 +395,18 @@ protected:
 
     // Returns regex QString to extract version information from text
     virtual QString _versionRegex() { return QString(); }
+
+    // Set Custom Mode mapping to Flight Mode String
+    void             _setModeEnumToModeStringMapping(FlightModeCustomModeMap enumToString);
+
+    // Convert Base enum to Derived class Enums
+    virtual uint32_t _convertToCustomFlightModeEnum(uint32_t val) const { return val;}
+
+    // Update internal mappings for a specific mode
+    void             _updateModeMappings(FirmwareFlightMode &mode);
+
+    FlightModeList              _availableFlightModeList;
+    FlightModeCustomModeMap     _modeEnumToString;
 
 protected:
     QVariantList _toolIndicatorList;

--- a/src/FirmwarePlugin/FirmwarePlugin.h
+++ b/src/FirmwarePlugin/FirmwarePlugin.h
@@ -38,6 +38,31 @@ struct FirmwareFlightMode
     bool        advanced        = false;
     bool        fixedWing       = false;
     bool        multiRotor      = true;
+
+    FirmwareFlightMode(QString mName, uint32_t cMode, bool cbs = false, bool adv = false)
+        : mode_name     (mName)
+        , standard_mode (0)
+        , custom_mode   (cMode)
+        , canBeSet      (cbs)
+        , advanced      (adv)
+        , fixedWing     (false)
+        , multiRotor    (true)
+    {
+    }
+
+    FirmwareFlightMode(QString mName, uint8_t sMode, uint32_t cMode,
+                       bool cbs = false, bool adv = false,
+                       bool fWing = false, bool mRotor = true
+    )
+        : mode_name     (mName)
+        , standard_mode (sMode)
+        , custom_mode   (cMode)
+        , canBeSet      (cbs)
+        , advanced      (adv)
+        , fixedWing     (fWing)
+        , multiRotor    (mRotor)
+    {
+    }
 };
 
 typedef QList<FirmwareFlightMode>         FlightModeList;
@@ -130,6 +155,15 @@ public:
 
     /// Returns the flight mode for Land
     virtual QString landFlightMode(void) const { return QString(); }
+
+    /// Returns the flight mode for TakeOff
+    virtual QString takeOffFlightMode(void) const { return QString(); }
+
+    /// Returns the flight mode for Motor Detection
+    virtual QString motorDetectionFlightMode(void) const { return QString(); }
+
+    /// Returns the flight mode for Stabilized
+    virtual QString stabilizedFlightMode(void) const { return QString(); }
 
     /// Returns the flight mode to use when the operator wants to take back control from autonomouse flight.
     virtual QString takeControlFlightMode(void) const { return QString(); }
@@ -402,8 +436,8 @@ protected:
     // Convert Base enum to Derived class Enums
     virtual uint32_t _convertToCustomFlightModeEnum(uint32_t val) const { return val;}
 
-    // Update internal mappings for a specific mode
-    void             _updateModeMappings(FirmwareFlightMode &mode);
+    // Update internal mappings for a list of flight modes
+    void             _updateModeMappings(FlightModeList &modeList);
 
     FlightModeList              _availableFlightModeList;
     FlightModeCustomModeMap     _modeEnumToString;

--- a/src/FirmwarePlugin/PX4/PX4FirmwarePlugin.cc
+++ b/src/FirmwarePlugin/PX4/PX4FirmwarePlugin.cc
@@ -56,73 +56,48 @@ PX4FirmwarePlugin::PX4FirmwarePlugin()
     qmlRegisterType<SensorsComponentController>         ("QGroundControl.Controllers", 1, 0, "SensorsComponentController");
     qmlRegisterType<PowerComponentController>           ("QGroundControl.Controllers", 1, 0, "PowerComponentController");
 
-    struct Modes2Name {
-        uint8_t     main_mode;
-        uint8_t     sub_mode;
-        bool        canBeSet;   ///< true: Vehicle can be set to this flight mode
-        bool        fixedWing;  /// fixed wing compatible
-        bool        multiRotor;  /// multi rotor compatible
-    };
+    _setModeEnumToModeStringMapping({
+        { PX4CustomMode::MANUAL             ,    _manualFlightMode      },
+        { PX4CustomMode::STABILIZED         ,    _stabilizedFlightMode  },
+        { PX4CustomMode::ACRO               ,    _acroFlightMode        },
+        { PX4CustomMode::RATTITUDE          ,    _rattitudeFlightMode   },
+        { PX4CustomMode::ALTCTL             ,    _altCtlFlightMode      },
+        { PX4CustomMode::OFFBOARD           ,    _offboardFlightMode    },
+        { PX4CustomMode::SIMPLE             ,    _simpleFlightMode      },
+        { PX4CustomMode::POSCTL_POSCTL      ,    _posCtlFlightMode      },
+        { PX4CustomMode::POSCTL_ORBIT       ,    _orbitFlightMode       },
+        { PX4CustomMode::AUTO_LOITER        ,    _holdFlightMode        },
+        { PX4CustomMode::AUTO_MISSION       ,    _missionFlightMode     },
+        { PX4CustomMode::AUTO_RTL           ,    _rtlFlightMode         },
+        { PX4CustomMode::AUTO_FOLLOW_TARGET ,    _followMeFlightMode    },
+        { PX4CustomMode::AUTO_LAND          ,    _landingFlightMode     },
+        { PX4CustomMode::AUTO_PRECLAND      ,    _preclandFlightMode    },
+        { PX4CustomMode::AUTO_READY         ,    _readyFlightMode       },
+        { PX4CustomMode::AUTO_RTGS          ,    _rtgsFlightMode        },
+        { PX4CustomMode::AUTO_TAKEOFF       ,    _takeoffFlightMode     },
+    });
 
-    static const struct Modes2Name rgModes2Name[] = {
-        //main_mode                         sub_mode                                canBeSet  FW      MC
-        { PX4_CUSTOM_MAIN_MODE_MANUAL,      0,                                      true,   true,   true },
-        { PX4_CUSTOM_MAIN_MODE_STABILIZED,  0,                                      true,   true,   true },
-        { PX4_CUSTOM_MAIN_MODE_ACRO,        0,                                      true,   true,   true },
-        { PX4_CUSTOM_MAIN_MODE_RATTITUDE,   0,                                      true,   true,   true },
-        { PX4_CUSTOM_MAIN_MODE_ALTCTL,      0,                                      true,   true,   true },
-        { PX4_CUSTOM_MAIN_MODE_OFFBOARD,    0,                                      true,   false,  true },
-        { PX4_CUSTOM_MAIN_MODE_SIMPLE,      0,                                      false,  false,  true },
-        { PX4_CUSTOM_MAIN_MODE_POSCTL,      PX4_CUSTOM_SUB_MODE_POSCTL_POSCTL,      true,   true,   true },
-        { PX4_CUSTOM_MAIN_MODE_POSCTL,      PX4_CUSTOM_SUB_MODE_POSCTL_ORBIT,       false,  false,   false },
-        { PX4_CUSTOM_MAIN_MODE_AUTO,        PX4_CUSTOM_SUB_MODE_AUTO_LOITER,        true,   true,   true },
-        { PX4_CUSTOM_MAIN_MODE_AUTO,        PX4_CUSTOM_SUB_MODE_AUTO_MISSION,       true,   true,   true },
-        { PX4_CUSTOM_MAIN_MODE_AUTO,        PX4_CUSTOM_SUB_MODE_AUTO_RTL,           true,   true,   true },
-        { PX4_CUSTOM_MAIN_MODE_AUTO,        PX4_CUSTOM_SUB_MODE_AUTO_FOLLOW_TARGET, true,   false,  true },
-        { PX4_CUSTOM_MAIN_MODE_AUTO,        PX4_CUSTOM_SUB_MODE_AUTO_LAND,          false,  true,   true },
-        { PX4_CUSTOM_MAIN_MODE_AUTO,        PX4_CUSTOM_SUB_MODE_AUTO_PRECLAND,      true,  false,  true },
-        { PX4_CUSTOM_MAIN_MODE_AUTO,        PX4_CUSTOM_SUB_MODE_AUTO_READY,         false,  true,   true },
-        { PX4_CUSTOM_MAIN_MODE_AUTO,        PX4_CUSTOM_SUB_MODE_AUTO_RTGS,          false,  true,   true },
-        { PX4_CUSTOM_MAIN_MODE_AUTO,        PX4_CUSTOM_SUB_MODE_AUTO_TAKEOFF,       false,  true,   true },
-    };
-
-    // Must be in same order as above structure
-    const QString* rgModeNames[] = {
-        &_manualFlightMode,
-        &_stabilizedFlightMode,
-        &_acroFlightMode,
-        &_rattitudeFlightMode,
-        &_altCtlFlightMode,
-        &_offboardFlightMode,
-        &_simpleFlightMode,
-        &_posCtlFlightMode,
-        &_orbitFlightMode,
-        &_holdFlightMode,
-        &_missionFlightMode,
-        &_rtlFlightMode,
-        &_followMeFlightMode,
-        &_landingFlightMode,
-        &_preclandFlightMode,
-        &_readyFlightMode,
-        &_rtgsFlightMode,
-        &_takeoffFlightMode,
-    };
-
-    // Convert static information to dynamic list. This allows for plugin override class to manipulate list.
-    for (size_t i=0; i<sizeof(rgModes2Name)/sizeof(rgModes2Name[0]); i++) {
-        const struct Modes2Name* pModes2Name = &rgModes2Name[i];
-
-        FlightModeInfo_t info;
-
-        info.main_mode =    pModes2Name->main_mode;
-        info.sub_mode =     pModes2Name->sub_mode;
-        info.name =         rgModeNames[i];
-        info.canBeSet =     pModes2Name->canBeSet;
-        info.fixedWing =    pModes2Name->fixedWing;
-        info.multiRotor =   pModes2Name->multiRotor;
-
-        _flightModeInfoList.append(info);
-    }
+    updateAvailableFlightModes({
+        // Mode Name            ,SM, Custom Mode                      CanBeSet  adv    FW      MR
+        { _manualFlightMode     , 0, PX4CustomMode::MANUAL            , true ,  true , true  , true  },
+        { _stabilizedFlightMode , 0, PX4CustomMode::STABILIZED        , true ,  true , true  , true  },
+        { _acroFlightMode       , 0, PX4CustomMode::ACRO              , true ,  true , true  , true  },
+        { _rattitudeFlightMode  , 0, PX4CustomMode::RATTITUDE         , true ,  false, true  , true  },
+        { _altCtlFlightMode     , 0, PX4CustomMode::ALTCTL            , true ,  false, true  , true  },
+        { _offboardFlightMode   , 0, PX4CustomMode::OFFBOARD          , true ,  true , false , true  },
+        { _simpleFlightMode     , 0, PX4CustomMode::SIMPLE            , false,  false, false , true  },
+        { _posCtlFlightMode     , 0, PX4CustomMode::POSCTL_POSCTL     , true ,  false, true  , true  },
+        { _orbitFlightMode      , 0, PX4CustomMode::POSCTL_ORBIT      , false,  true , false , false },
+        { _holdFlightMode       , 0, PX4CustomMode::AUTO_LOITER       , true ,  true , true  , true  },
+        { _missionFlightMode    , 0, PX4CustomMode::AUTO_MISSION      , true ,  true , true  , true  },
+        { _rtlFlightMode        , 0, PX4CustomMode::AUTO_RTL          , true ,  true , true  , true  },
+        { _followMeFlightMode   , 0, PX4CustomMode::AUTO_FOLLOW_TARGET, true ,  false, false , true  },
+        { _landingFlightMode    , 0, PX4CustomMode::AUTO_LAND         , false,  true , true  , true  },
+        { _preclandFlightMode   , 0, PX4CustomMode::AUTO_PRECLAND     , true ,  true , false , true  },
+        { _readyFlightMode      , 0, PX4CustomMode::AUTO_READY        , false,  false, true  , true  },
+        { _rtgsFlightMode       , 0, PX4CustomMode::AUTO_RTGS         , false,  false, true  , true  },
+        { _takeoffFlightMode    , 0, PX4CustomMode::AUTO_TAKEOFF      , false,  false, true  , true  },
+    });
 }
 
 PX4FirmwarePlugin::~PX4FirmwarePlugin()
@@ -143,23 +118,22 @@ QList<VehicleComponent*> PX4FirmwarePlugin::componentsForVehicle(AutoPilotPlugin
 
 QStringList PX4FirmwarePlugin::flightModes(Vehicle* vehicle)
 {
-    QStringList flightModes;
+    QStringList flightModesList;
 
-    foreach (const FlightModeInfo_t& info, _flightModeInfoList) {
-        if (info.canBeSet) {
-            bool fw = (vehicle->fixedWing() && info.fixedWing);
-            bool mc = (vehicle->multiRotor() && info.multiRotor);
+    for (auto mode : _availableFlightModeList) {
+        if (mode.canBeSet){
+            bool fw = (vehicle->fixedWing() && mode.fixedWing);
+            bool mc = (vehicle->multiRotor() && mode.multiRotor);
 
             // show all modes for generic, vtol, etc
             bool other = !vehicle->fixedWing() && !vehicle->multiRotor();
-
             if (fw || mc || other) {
-                flightModes += *info.name;
+                flightModesList += mode.mode_name;
             }
         }
     }
 
-    return flightModes;
+    return flightModesList;
 }
 
 QString PX4FirmwarePlugin::flightMode(uint8_t base_mode, uint32_t custom_mode) const
@@ -167,22 +141,7 @@ QString PX4FirmwarePlugin::flightMode(uint8_t base_mode, uint32_t custom_mode) c
     QString flightMode = "Unknown";
 
     if (base_mode & MAV_MODE_FLAG_CUSTOM_MODE_ENABLED) {
-        union px4_custom_mode px4_mode;
-        px4_mode.data = custom_mode;
-
-        bool found = false;
-        foreach (const FlightModeInfo_t& info, _flightModeInfoList) {
-            if (info.main_mode == px4_mode.main_mode && info.sub_mode == px4_mode.sub_mode) {
-                flightMode = *info.name;
-                found = true;
-                break;
-            }
-        }
-
-        if (!found) {
-            qWarning() << "Unknown flight mode" << custom_mode;
-            return tr("Unknown %1:%2").arg(base_mode).arg(custom_mode);
-        }
+        return _modeEnumToString.value(custom_mode, tr("Unknown %1:%2").arg(base_mode).arg(custom_mode));
     }
 
     return flightMode;
@@ -194,17 +153,11 @@ bool PX4FirmwarePlugin::setFlightMode(const QString& flightMode, uint8_t* base_m
     *custom_mode = 0;
 
     bool found = false;
-    foreach (const FlightModeInfo_t& info, _flightModeInfoList) {
-        if (flightMode.compare(*info.name, Qt::CaseInsensitive) == 0) {
-            union px4_custom_mode px4_mode;
 
-            px4_mode.data = 0;
-            px4_mode.main_mode = info.main_mode;
-            px4_mode.sub_mode = info.sub_mode;
-
+    for (auto &mode: _availableFlightModeList){
+        if(flightMode.compare(mode.mode_name, Qt::CaseInsensitive) == 0){
             *base_mode = MAV_MODE_FLAG_CUSTOM_MODE_ENABLED;
-            *custom_mode = px4_mode.data;
-
+            *custom_mode = mode.custom_mode;
             found = true;
             break;
         }
@@ -788,4 +741,36 @@ const QVariantList& PX4FirmwarePlugin::toolIndicators(const Vehicle* vehicle)
     }
 
     return _toolIndicatorList;
+}
+
+void PX4FirmwarePlugin::updateAvailableFlightModes(FlightModeList modeList)
+{
+    _availableFlightModeList.clear();
+    for(auto mode: modeList){
+
+        // Update Multi Rotor
+        switch (mode.custom_mode) {
+        case PX4CustomMode::POSCTL_ORBIT:
+            mode.multiRotor = false;
+            break;
+        default:
+            mode.multiRotor = true;
+            break;
+        }
+
+        // Update Fixed Wing
+        switch (mode.custom_mode){
+        case PX4CustomMode::OFFBOARD:
+        case PX4CustomMode::SIMPLE:
+        case PX4CustomMode::POSCTL_ORBIT:
+        case PX4CustomMode::AUTO_FOLLOW_TARGET:
+        case PX4CustomMode::AUTO_PRECLAND:
+            mode.fixedWing = false;
+            break;
+        default:
+            mode.fixedWing = true;
+        }
+
+        _updateModeMappings(mode);
+    }
 }

--- a/src/FirmwarePlugin/PX4/PX4FirmwarePlugin.cc
+++ b/src/FirmwarePlugin/PX4/PX4FirmwarePlugin.cc
@@ -78,25 +78,25 @@ PX4FirmwarePlugin::PX4FirmwarePlugin()
     });
 
     updateAvailableFlightModes({
-        // Mode Name            ,SM, Custom Mode                      CanBeSet  adv    FW      MR
-        { _manualFlightMode     , 0, PX4CustomMode::MANUAL            , true ,  true , true  , true  },
-        { _stabilizedFlightMode , 0, PX4CustomMode::STABILIZED        , true ,  true , true  , true  },
-        { _acroFlightMode       , 0, PX4CustomMode::ACRO              , true ,  true , true  , true  },
-        { _rattitudeFlightMode  , 0, PX4CustomMode::RATTITUDE         , true ,  false, true  , true  },
-        { _altCtlFlightMode     , 0, PX4CustomMode::ALTCTL            , true ,  false, true  , true  },
-        { _offboardFlightMode   , 0, PX4CustomMode::OFFBOARD          , true ,  true , false , true  },
-        { _simpleFlightMode     , 0, PX4CustomMode::SIMPLE            , false,  false, false , true  },
-        { _posCtlFlightMode     , 0, PX4CustomMode::POSCTL_POSCTL     , true ,  false, true  , true  },
-        { _orbitFlightMode      , 0, PX4CustomMode::POSCTL_ORBIT      , false,  true , false , false },
-        { _holdFlightMode       , 0, PX4CustomMode::AUTO_LOITER       , true ,  true , true  , true  },
-        { _missionFlightMode    , 0, PX4CustomMode::AUTO_MISSION      , true ,  true , true  , true  },
-        { _rtlFlightMode        , 0, PX4CustomMode::AUTO_RTL          , true ,  true , true  , true  },
-        { _followMeFlightMode   , 0, PX4CustomMode::AUTO_FOLLOW_TARGET, true ,  false, false , true  },
-        { _landingFlightMode    , 0, PX4CustomMode::AUTO_LAND         , false,  true , true  , true  },
-        { _preclandFlightMode   , 0, PX4CustomMode::AUTO_PRECLAND     , true ,  true , false , true  },
-        { _readyFlightMode      , 0, PX4CustomMode::AUTO_READY        , false,  false, true  , true  },
-        { _rtgsFlightMode       , 0, PX4CustomMode::AUTO_RTGS         , false,  false, true  , true  },
-        { _takeoffFlightMode    , 0, PX4CustomMode::AUTO_TAKEOFF      , false,  false, true  , true  },
+        // Mode Name            , Custom Mode                      CanBeSet  adv
+        { _manualFlightMode     , PX4CustomMode::MANUAL            , true ,  true },
+        { _stabilizedFlightMode , PX4CustomMode::STABILIZED        , true ,  true },
+        { _acroFlightMode       , PX4CustomMode::ACRO              , true ,  true },
+        { _rattitudeFlightMode  , PX4CustomMode::RATTITUDE         , true ,  false},
+        { _altCtlFlightMode     , PX4CustomMode::ALTCTL            , true ,  false},
+        { _offboardFlightMode   , PX4CustomMode::OFFBOARD          , true ,  true },
+        { _simpleFlightMode     , PX4CustomMode::SIMPLE            , false,  false},
+        { _posCtlFlightMode     , PX4CustomMode::POSCTL_POSCTL     , true ,  false},
+        { _orbitFlightMode      , PX4CustomMode::POSCTL_ORBIT      , false,  true },
+        { _holdFlightMode       , PX4CustomMode::AUTO_LOITER       , true ,  true },
+        { _missionFlightMode    , PX4CustomMode::AUTO_MISSION      , true ,  true },
+        { _rtlFlightMode        , PX4CustomMode::AUTO_RTL          , true ,  true },
+        { _followMeFlightMode   , PX4CustomMode::AUTO_FOLLOW_TARGET, true ,  false},
+        { _landingFlightMode    , PX4CustomMode::AUTO_LAND         , false,  true },
+        { _preclandFlightMode   , PX4CustomMode::AUTO_PRECLAND     , true ,  true },
+        { _readyFlightMode      , PX4CustomMode::AUTO_READY        , false,  false},
+        { _rtgsFlightMode       , PX4CustomMode::AUTO_RTGS         , false,  false},
+        { _takeoffFlightMode    , PX4CustomMode::AUTO_TAKEOFF      , false,  false},
     });
 }
 
@@ -120,7 +120,7 @@ QStringList PX4FirmwarePlugin::flightModes(Vehicle* vehicle)
 {
     QStringList flightModesList;
 
-    for (auto mode : _availableFlightModeList) {
+    for (auto &mode : _availableFlightModeList) {
         if (mode.canBeSet){
             bool fw = (vehicle->fixedWing() && mode.fixedWing);
             bool mc = (vehicle->multiRotor() && mode.multiRotor);
@@ -588,10 +588,55 @@ void PX4FirmwarePlugin::startMission(Vehicle* vehicle)
 void PX4FirmwarePlugin::setGuidedMode(Vehicle* vehicle, bool guidedMode)
 {
     if (guidedMode) {
-        _setFlightModeAndValidate(vehicle, _holdFlightMode);
+        _setFlightModeAndValidate(vehicle, gotoFlightMode());
     } else {
         pauseVehicle(vehicle);
     }
+}
+
+QString PX4FirmwarePlugin::pauseFlightMode() const
+{
+    return _modeEnumToString.value(PX4CustomMode::AUTO_LOITER, _holdFlightMode);
+}
+
+QString PX4FirmwarePlugin::missionFlightMode() const
+{
+    return _modeEnumToString.value(PX4CustomMode::AUTO_MISSION, _missionFlightMode);
+}
+
+QString PX4FirmwarePlugin::rtlFlightMode() const
+{
+    return _modeEnumToString.value(PX4CustomMode::AUTO_RTL, _rtlFlightMode);
+}
+
+QString PX4FirmwarePlugin::landFlightMode() const
+{
+    return _modeEnumToString.value(PX4CustomMode::AUTO_LAND, _landingFlightMode);
+}
+
+QString PX4FirmwarePlugin::takeControlFlightMode() const
+{
+    return _modeEnumToString.value(PX4CustomMode::MANUAL, _manualFlightMode);
+}
+
+QString PX4FirmwarePlugin::gotoFlightMode() const
+{
+    return _modeEnumToString.value(PX4CustomMode::AUTO_LOITER, _holdFlightMode);
+}
+
+QString PX4FirmwarePlugin::followFlightMode() const
+{
+    return _modeEnumToString.value(PX4CustomMode::AUTO_FOLLOW_TARGET, _followMeFlightMode);
+}
+
+QString PX4FirmwarePlugin::takeOffFlightMode() const
+{
+    return _modeEnumToString.value(PX4CustomMode::AUTO_TAKEOFF, _takeoffFlightMode);
+}
+
+QString PX4FirmwarePlugin::stabilizedFlightMode() const
+{
+    return _modeEnumToString.value(PX4CustomMode::STABILIZED, _stabilizedFlightMode);
 }
 
 bool PX4FirmwarePlugin::isGuidedMode(const Vehicle* vehicle) const
@@ -745,32 +790,60 @@ const QVariantList& PX4FirmwarePlugin::toolIndicators(const Vehicle* vehicle)
 
 void PX4FirmwarePlugin::updateAvailableFlightModes(FlightModeList modeList)
 {
-    _availableFlightModeList.clear();
-    for(auto mode: modeList){
+    for(auto &mode: modeList){
+        PX4CustomMode::Mode cMode = static_cast<PX4CustomMode::Mode>(mode.custom_mode);
 
         // Update Multi Rotor
-        switch (mode.custom_mode) {
-        case PX4CustomMode::POSCTL_ORBIT:
-            mode.multiRotor = false;
-            break;
-        default:
+        switch (cMode) {
+        case PX4CustomMode::MANUAL            :
+        case PX4CustomMode::STABILIZED        :
+        case PX4CustomMode::ACRO              :
+        case PX4CustomMode::RATTITUDE         :
+        case PX4CustomMode::ALTCTL            :
+        case PX4CustomMode::OFFBOARD          :
+        case PX4CustomMode::SIMPLE            :
+        case PX4CustomMode::POSCTL_POSCTL     :
+        case PX4CustomMode::AUTO_LOITER       :
+        case PX4CustomMode::AUTO_MISSION      :
+        case PX4CustomMode::AUTO_RTL          :
+        case PX4CustomMode::AUTO_FOLLOW_TARGET:
+        case PX4CustomMode::AUTO_LAND         :
+        case PX4CustomMode::AUTO_PRECLAND     :
+        case PX4CustomMode::AUTO_READY        :
+        case PX4CustomMode::AUTO_RTGS         :
+        case PX4CustomMode::AUTO_TAKEOFF      :
             mode.multiRotor = true;
+            break;
+        case PX4CustomMode::POSCTL_ORBIT      :
+            mode.multiRotor = false;
             break;
         }
 
         // Update Fixed Wing
-        switch (mode.custom_mode){
-        case PX4CustomMode::OFFBOARD:
-        case PX4CustomMode::SIMPLE:
-        case PX4CustomMode::POSCTL_ORBIT:
+        switch (cMode){
+        case PX4CustomMode::OFFBOARD          :
+        case PX4CustomMode::SIMPLE            :
+        case PX4CustomMode::POSCTL_ORBIT      :
         case PX4CustomMode::AUTO_FOLLOW_TARGET:
-        case PX4CustomMode::AUTO_PRECLAND:
+        case PX4CustomMode::AUTO_PRECLAND     :
             mode.fixedWing = false;
             break;
-        default:
+        case PX4CustomMode::MANUAL            :
+        case PX4CustomMode::STABILIZED        :
+        case PX4CustomMode::ACRO              :
+        case PX4CustomMode::RATTITUDE         :
+        case PX4CustomMode::ALTCTL            :
+        case PX4CustomMode::POSCTL_POSCTL     :
+        case PX4CustomMode::AUTO_LOITER       :
+        case PX4CustomMode::AUTO_MISSION      :
+        case PX4CustomMode::AUTO_RTL          :
+        case PX4CustomMode::AUTO_LAND         :
+        case PX4CustomMode::AUTO_READY        :
+        case PX4CustomMode::AUTO_RTGS         :
+        case PX4CustomMode::AUTO_TAKEOFF      :
             mode.fixedWing = true;
+            break;
         }
-
-        _updateModeMappings(mode);
     }
+    _updateModeMappings(modeList);
 }

--- a/src/FirmwarePlugin/PX4/PX4FirmwarePlugin.h
+++ b/src/FirmwarePlugin/PX4/PX4FirmwarePlugin.h
@@ -34,13 +34,15 @@ public:
     QString             flightMode                      (uint8_t base_mode, uint32_t custom_mode) const override;
     bool                setFlightMode                   (const QString& flightMode, uint8_t* base_mode, uint32_t* custom_mode) override;
     void                setGuidedMode                   (Vehicle* vehicle, bool guidedMode) override;
-    QString             pauseFlightMode                 (void) const override { return _holdFlightMode; }
-    QString             missionFlightMode               (void) const override { return _missionFlightMode; }
-    QString             rtlFlightMode                   (void) const override { return _rtlFlightMode; }
-    QString             landFlightMode                  (void) const override { return _landingFlightMode; }
-    QString             takeControlFlightMode           (void) const override { return _manualFlightMode; }
-    QString             gotoFlightMode                  (void) const override { return _holdFlightMode; }
-    QString             followFlightMode                (void) const override { return _followMeFlightMode; };
+    QString             pauseFlightMode                 (void) const override;
+    QString             missionFlightMode               (void) const override;
+    QString             rtlFlightMode                   (void) const override;
+    QString             landFlightMode                  (void) const override;
+    QString             takeControlFlightMode           (void) const override;
+    QString             gotoFlightMode                  (void) const override;
+    QString             followFlightMode                (void) const override;
+    QString             takeOffFlightMode               (void) const override;
+    QString             stabilizedFlightMode            (void) const override;
     void                pauseVehicle                    (Vehicle* vehicle) override;
     void                guidedModeRTL                   (Vehicle* vehicle, bool smartRTL) override;
     void                guidedModeLand                  (Vehicle* vehicle) override;

--- a/src/FirmwarePlugin/PX4/PX4FirmwarePlugin.h
+++ b/src/FirmwarePlugin/PX4/PX4FirmwarePlugin.h
@@ -76,20 +76,9 @@ public:
     QVariant            mainStatusIndicatorContentItem  (const Vehicle* vehicle) const override;
     const QVariantList& toolIndicators                  (const Vehicle* vehicle) override;
 
+    void                updateAvailableFlightModes      (FlightModeList modeList) override;
+
 protected:
-    typedef struct {
-        uint8_t         main_mode;
-        uint8_t         sub_mode;
-        const QString*  name;       ///< Name for flight mode
-        bool            canBeSet;   ///< true: Vehicle can be set to this flight mode
-        bool            fixedWing;  /// fixed wing compatible
-        bool            multiRotor; /// multi rotor compatible
-    } FlightModeInfo_t;
-
-    QList<FlightModeInfo_t> _flightModeInfoList;
-
-    // Use these constants to set flight modes using setFlightMode method. Don't use hardcoded string names since the
-    // names may change.
 
     // If plugin superclass wants to change a mode name, then set a new name for the flight mode in the superclass constructor
     QString _manualFlightMode;

--- a/src/FirmwarePlugin/PX4/px4_custom_mode.h
+++ b/src/FirmwarePlugin/PX4/px4_custom_mode.h
@@ -81,17 +81,40 @@ enum PX4_CUSTOM_SUB_MODE_POSCTL {
 };
 
 union px4_custom_mode {
-	struct {
-		uint16_t reserved;
-		uint8_t main_mode;
-		uint8_t sub_mode;
-	};
-	uint32_t data;
-	float data_float;
-	struct {
-		uint16_t reserved_hl;
-		uint16_t custom_mode_hl;
-	};
+    struct {
+        uint16_t reserved;
+        uint8_t main_mode;
+        uint8_t sub_mode;
+    };
+    uint32_t data;
+    float data_float;
+    struct {
+        uint16_t reserved_hl;
+        uint16_t custom_mode_hl;
+    };
+};
+
+struct PX4CustomMode{
+    enum Mode : uint32_t{
+        MANUAL              = PX4_CUSTOM_MAIN_MODE_MANUAL       <<16,
+        STABILIZED          = PX4_CUSTOM_MAIN_MODE_STABILIZED   <<16,
+        ACRO                = PX4_CUSTOM_MAIN_MODE_ACRO         <<16,
+        RATTITUDE           = PX4_CUSTOM_MAIN_MODE_RATTITUDE    <<16,
+        ALTCTL              = PX4_CUSTOM_MAIN_MODE_ALTCTL       <<16,
+        OFFBOARD            = PX4_CUSTOM_MAIN_MODE_OFFBOARD     <<16,
+        SIMPLE              = PX4_CUSTOM_MAIN_MODE_SIMPLE       <<16,
+        POSCTL_POSCTL       = PX4_CUSTOM_MAIN_MODE_POSCTL       <<16 | (PX4_CUSTOM_SUB_MODE_POSCTL_POSCTL      << 24 ),
+        POSCTL_ORBIT        = PX4_CUSTOM_MAIN_MODE_POSCTL       <<16 | (PX4_CUSTOM_SUB_MODE_POSCTL_ORBIT       << 24 ),
+        AUTO_LOITER         = PX4_CUSTOM_MAIN_MODE_AUTO         <<16 | (PX4_CUSTOM_SUB_MODE_AUTO_LOITER        << 24 ),
+        AUTO_MISSION        = PX4_CUSTOM_MAIN_MODE_AUTO         <<16 | (PX4_CUSTOM_SUB_MODE_AUTO_MISSION       << 24 ),
+        AUTO_RTL            = PX4_CUSTOM_MAIN_MODE_AUTO         <<16 | (PX4_CUSTOM_SUB_MODE_AUTO_RTL           << 24 ),
+        AUTO_FOLLOW_TARGET  = PX4_CUSTOM_MAIN_MODE_AUTO         <<16 | (PX4_CUSTOM_SUB_MODE_AUTO_FOLLOW_TARGET << 24 ),
+        AUTO_LAND           = PX4_CUSTOM_MAIN_MODE_AUTO         <<16 | (PX4_CUSTOM_SUB_MODE_AUTO_LAND          << 24 ),
+        AUTO_PRECLAND       = PX4_CUSTOM_MAIN_MODE_AUTO         <<16 | (PX4_CUSTOM_SUB_MODE_AUTO_PRECLAND      << 24 ),
+        AUTO_READY          = PX4_CUSTOM_MAIN_MODE_AUTO         <<16 | (PX4_CUSTOM_SUB_MODE_AUTO_READY         << 24 ),
+        AUTO_RTGS           = PX4_CUSTOM_MAIN_MODE_AUTO         <<16 | (PX4_CUSTOM_SUB_MODE_AUTO_RTGS          << 24 ),
+        AUTO_TAKEOFF        = PX4_CUSTOM_MAIN_MODE_AUTO         <<16 | (PX4_CUSTOM_SUB_MODE_AUTO_TAKEOFF       << 24 ),
+    };
 };
 
 #endif /* PX4_CUSTOM_MODE_H_ */

--- a/src/QmlControls/PIDTuning.qml
+++ b/src/QmlControls/PIDTuning.qml
@@ -258,7 +258,7 @@ RowLayout {
                         dataTimer.running = !dataTimer.running
                         _last_t = 0
                         if (showAutoModeChange && autoModeChange.checked) {
-                            globals.activeVehicle.flightMode = dataTimer.running ? "Stabilized" : globals.activeVehicle.pauseFlightMode
+                            globals.activeVehicle.flightMode = dataTimer.running ? globals.activeVehicle.stabilizedFlightMode : globals.activeVehicle.pauseFlightMode
                         }
                     }
                 }

--- a/src/Vehicle/StandardModes.cc
+++ b/src/Vehicle/StandardModes.cc
@@ -80,6 +80,16 @@ void StandardModes::gotMessage(MAV_RESULT result, const mavlink_message_t &messa
 
         _nextModes[availableModes.custom_mode] = Mode{name, availableModes.standard_mode, advanced, cannotBeSet};
 
+        _modeList += FirmwareFlightMode{
+            name,
+            availableModes.standard_mode,
+            availableModes.custom_mode,
+            !cannotBeSet,
+            advanced,
+            false,
+            false
+        };
+
         if (availableModes.mode_index >= availableModes.number_modes) { // We are done
             qCDebug(StandardModesLog) << "Completed, num modes:" << _nextModes.size();
             _modes = _nextModes;
@@ -87,6 +97,7 @@ void StandardModes::gotMessage(MAV_RESULT result, const mavlink_message_t &messa
             _hasModes = true;
             emit modesUpdated();
             emit requestCompleted();
+            _vehicle->firmwarePlugin()->updateAvailableFlightModes(_modeList);
 
         } else {
             requestMode(availableModes.mode_index + 1);

--- a/src/Vehicle/StandardModes.h
+++ b/src/Vehicle/StandardModes.h
@@ -10,6 +10,7 @@
 #pragma once
 
 #include "MAVLinkLib.h"
+#include "FirmwarePlugin.h"
 
 #include <QtCore/QObject>
 #include <QtCore/QString>
@@ -67,5 +68,6 @@ private:
     int _lastSeq{-1};
 
     QMap<uint32_t, Mode> _modes; ///< key is custom_mode
+    FlightModeList       _modeList;
 };
 

--- a/src/Vehicle/Vehicle.cc
+++ b/src/Vehicle/Vehicle.cc
@@ -1264,7 +1264,7 @@ void Vehicle::setEventsMetadata(uint8_t compid, const QString& metadataJsonFileN
 
     // get the mode group for some well-known flight modes
     int modeGroups[2]{-1, -1};
-    const QString modes[2]{"Takeoff", "Mission"};
+    const QString modes[2]{_firmwarePlugin->takeOffFlightMode(), _firmwarePlugin->missionFlightMode()};
     for (size_t i = 0; i < sizeof(modeGroups)/sizeof(modeGroups[0]); ++i) {
         uint8_t     base_mode;
         uint32_t    custom_mode;
@@ -3199,6 +3199,16 @@ QString Vehicle::takeControlFlightMode() const
 QString Vehicle::followFlightMode() const
 {
     return _firmwarePlugin->followFlightMode();
+}
+
+QString Vehicle::motorDetectionFlightMode() const
+{
+    return _firmwarePlugin->motorDetectionFlightMode();
+}
+
+QString Vehicle::stabilizedFlightMode() const
+{
+    return _firmwarePlugin->stabilizedFlightMode();
 }
 
 QString Vehicle::vehicleImageOpaque() const

--- a/src/Vehicle/Vehicle.cc
+++ b/src/Vehicle/Vehicle.cc
@@ -1613,26 +1613,16 @@ bool Vehicle::flightModeSetAvailable()
 
 QStringList Vehicle::flightModes()
 {
-	if (_standardModes->supported()) {
-		return _standardModes->flightModes();
-	}
     return _firmwarePlugin->flightModes(this);
 }
 
 QString Vehicle::flightMode() const
 {
-    if (_standardModes->supported()) {
-        return _standardModes->flightMode(_custom_mode);
-    }
     return _firmwarePlugin->flightMode(_base_mode, _custom_mode);
 }
 
 bool Vehicle::setFlightModeCustom(const QString& flightMode, uint8_t* base_mode, uint32_t* custom_mode)
 {
-    if (_standardModes->supported()) {
-        *base_mode = MAV_MODE_FLAG_CUSTOM_MODE_ENABLED;
-        return _standardModes->setFlightMode(flightMode, custom_mode);
-    }
     return _firmwarePlugin->setFlightMode(flightMode, base_mode, custom_mode);
 }
 

--- a/src/Vehicle/Vehicle.h
+++ b/src/Vehicle/Vehicle.h
@@ -186,6 +186,8 @@ public:
     Q_PROPERTY(QString              landFlightMode              READ landFlightMode                                                 CONSTANT)
     Q_PROPERTY(QString              takeControlFlightMode       READ takeControlFlightMode                                          CONSTANT)
     Q_PROPERTY(QString              followFlightMode            READ followFlightMode                                               CONSTANT)
+    Q_PROPERTY(QString              motorDetectionFlightMode    READ motorDetectionFlightMode                                       CONSTANT)
+    Q_PROPERTY(QString              stabilizedFlightMode        READ stabilizedFlightMode                                           CONSTANT)
     Q_PROPERTY(QString              firmwareTypeString          READ firmwareTypeString                                             NOTIFY firmwareTypeChanged)
     Q_PROPERTY(QString              vehicleTypeString           READ vehicleTypeString                                              NOTIFY vehicleTypeChanged)
     Q_PROPERTY(QString              vehicleImageOpaque          READ vehicleImageOpaque                                             CONSTANT)
@@ -551,6 +553,8 @@ public:
     QString         landFlightMode              () const;
     QString         takeControlFlightMode       () const;
     QString         followFlightMode            () const;
+    QString         motorDetectionFlightMode    () const;
+    QString         stabilizedFlightMode        () const;
     double          defaultCruiseSpeed          () const { return _defaultCruiseSpeed; }
     double          defaultHoverSpeed           () const { return _defaultHoverSpeed; }
     QString         firmwareTypeString          () const;


### PR DESCRIPTION
Update APM and PX4 flight mode parsing methods


Description
-----------
- Removed use of direct strings to change flight mode.
- Case-sensitive issues in flight mode in APM.
- Internal Mapping to flight mode names.
- QGC Custom Build support has also been added.
- Add New Modes discovered via Available Mode packets received from the flight controller.



Related Issue
-----------
https://github.com/mavlink/qgroundcontrol/pull/12191
https://github.com/mavlink/qgroundcontrol/issues/12128
