### PR TITLE
GuidedActions: fix incorrect slider value conversion

### DIFF
--- a/src/FlightDisplay/GuidedValueSlider.qml
+++ b/src/FlightDisplay/GuidedValueSlider.qml
@@ -98,7 +98,7 @@ Item {
     }
 
     function getOutputValue() {
-        return _clampedSliderValue(_sliderValue)
+        return _sliderValue
     }
 
     DeadMouseArea {


### PR DESCRIPTION
Description
-----------
The floating point value got converted to a string, which in turn broke arithmetic in GuidedActionsController (e.g. `Vehicle::guidedModeOrbit` always received NAN as altitude).

Checklist:
----------
- [x] [Review Contribution Guidelines](https://github.com/mavlink/qgroundcontrol/blob/master/.github/CONTRIBUTING.md).
- [x] [Review Code of Conduct](https://github.com/mavlink/qgroundcontrol/blob/master/.github/CODE_OF_CONDUCT.md).
- [x] I have tested my changes.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.