### PR TITLE
Validation fixes

### DIFF
--- a/src/PlanView/MissionItemEditor.qml
+++ b/src/PlanView/MissionItemEditor.qml
@@ -60,8 +60,10 @@ Rectangle {
         MouseArea {
             anchors.fill:   parent
             onClicked: {
-                currentItemScope.focus = true
-                _root.clicked()
+                if (mainWindow.allowViewSwitch()) {
+                    currentItemScope.focus = true
+                    _root.clicked()
+                }
             }
         }
     }

--- a/src/PlanView/PlanView.qml
+++ b/src/PlanView/PlanView.qml
@@ -371,6 +371,9 @@ Item {
             onMapClicked: (mouse) => {
                 // Take focus to close any previous editing
                 editorMap.focus = true
+                if (!mainWindow.allowViewSwitch()) {
+                    return
+                }
                 var coordinate = editorMap.toCoordinate(Qt.point(mouse.x, mouse.y), false /* clipToViewPort */)
                 coordinate.latitude = coordinate.latitude.toFixed(_decimalPlaces)
                 coordinate.longitude = coordinate.longitude.toFixed(_decimalPlaces)

--- a/src/QmlControls/QGCPopupDialog.qml
+++ b/src/QmlControls/QGCPopupDialog.qml
@@ -66,6 +66,7 @@ Popup {
     property real   _contentMargin:     ScreenTools.defaultFontPixelHeight / 2
     property bool   _acceptAllowed:     acceptButton.visible
     property bool   _rejectAllowed:     rejectButton.visible
+    property int    _previousValidationErrorCount: 0
 
     background: QGCMouseArea {
         width:  mainWindow.width
@@ -84,8 +85,13 @@ Popup {
         contentChildren[contentChildren.length - 1].parent = dialogContentParent
     }
 
-    onAboutToShow: setupDialogButtons(buttons)
+    onAboutToShow: {
+        _previousValidationErrorCount = globals.validationErrorCount
+        setupDialogButtons(buttons)
+    }
+
     onClosed: {
+        globals.validationErrorCount = _previousValidationErrorCount
         Qt.inputMethod.hide()
         if (destroyOnClose) {
             root.destroy()
@@ -93,7 +99,7 @@ Popup {
     }
 
     function _accept() {
-        if (_acceptAllowed && mainWindow.allowViewSwitch()) {
+        if (_acceptAllowed && mainWindow.allowViewSwitch(_previousValidationErrorCount)) {
             accepted()
             if (preventClose) {
                 preventClose = false
@@ -105,7 +111,7 @@ Popup {
 
     function _reject() {
         // Dialogs with cancel button are allowed to close with validation errors
-        if (_rejectAllowed && ((buttons & Dialog.Cancel) || mainWindow.allowViewSwitch())) {
+        if (_rejectAllowed && ((buttons & Dialog.Cancel) || mainWindow.allowViewSwitch(_previousValidationErrorCount))) {
             rejected()
             if (preventClose) {
                 preventClose = false

--- a/src/QmlControls/ToolStripHoverButton.qml
+++ b/src/QmlControls/ToolStripHoverButton.qml
@@ -44,14 +44,18 @@ Button {
     onCheckedChanged: toolStripAction.checked = checked
 
     onClicked: {
-        dropPanel.hide()
-        if (!toolStripAction.dropPanelComponent) {
-            toolStripAction.triggered(this)
-        } else if (checked) {
-            var panelEdgeTopPoint = mapToItem(_root, width, 0)
-            dropPanel.show(panelEdgeTopPoint, toolStripAction.dropPanelComponent, this)
-            checked = true
-            control.dropped(index)
+        if (mainWindow.allowViewSwitch()) {
+            dropPanel.hide()
+            if (!toolStripAction.dropPanelComponent) {
+                toolStripAction.triggered(this)
+            } else if (checked) {
+                var panelEdgeTopPoint = mapToItem(_root, width, 0)
+                dropPanel.show(panelEdgeTopPoint, toolStripAction.dropPanelComponent, this)
+                checked = true
+                control.dropped(index)
+            }
+        } else if (checkable) {
+            checked = !checked
         }
     }
 

--- a/src/UI/MainRootWindow.qml
+++ b/src/UI/MainRootWindow.qml
@@ -111,12 +111,12 @@ ApplicationWindow {
     //-- Global Scope Functions
 
     // This function is used to prevent view switching if there are validation errors
-    function allowViewSwitch() {
+    function allowViewSwitch(previousValidationErrorCount = 0) {
         // Run validation on active focus control to ensure it is valid before switching views
         if (mainWindow.activeFocusControl instanceof QGCTextField) {
             mainWindow.activeFocusControl.onEditingFinished()
         }
-        return globals.validationErrorCount === 0
+        return globals.validationErrorCount <= previousValidationErrorCount
     }
 
     function showPlanView() {


### PR DESCRIPTION
* Fix #12246
* When dialogs popup validation errors can stack up. Fix dialog handling when there are already validation errors in the ui displaying the dialog
* Added a few more view switch checks to prevent moving away when validation errors exist