### PR TITLE
Add ArduPilot Plane AUTOLAND and LOITER2QLAND modes

### DIFF
--- a/src/FirmwarePlugin/APM/ArduPlaneFirmwarePlugin.cc
+++ b/src/FirmwarePlugin/APM/ArduPlaneFirmwarePlugin.cc
@@ -38,6 +38,8 @@ ArduPlaneFirmwarePlugin::ArduPlaneFirmwarePlugin(void)
     , _qAutotuneFlightMode   (tr("QuadPlane AutoTune"))
     , _qAcroFlightMode       (tr("QuadPlane Acro"))
     , _thermalFlightMode     (tr("Thermal"))
+    , _loiter2qlandFlightMode(tr("Loiter to QLand"))
+    , _autolandFlightMode    (tr("Autoland"))
 {
     _setModeEnumToModeStringMapping({
         {APMPlaneMode::MANUAL        , _manualFlightMode      },
@@ -64,6 +66,9 @@ ArduPlaneFirmwarePlugin::ArduPlaneFirmwarePlugin(void)
         {APMPlaneMode::QAUTOTUNE     , _qAutotuneFlightMode   },
         {APMPlaneMode::QACRO         , _qAcroFlightMode       },
         {APMPlaneMode::THERMAL       , _thermalFlightMode     },
+        {APMPlaneMode::LOITER2QLAND  , _loiter2qlandFlightMode},
+        {APMPlaneMode::AUTOLAND      , _autolandFlightMode    },
+        
     });
 
     updateAvailableFlightModes({
@@ -92,6 +97,8 @@ ArduPlaneFirmwarePlugin::ArduPlaneFirmwarePlugin(void)
         { _qAutotuneFlightMode    , APMPlaneMode::QAUTOTUNE     , true , true },
         { _qAcroFlightMode        , APMPlaneMode::QACRO         , true , true },
         { _thermalFlightMode      , APMPlaneMode::THERMAL       , true , true },
+        { _loiter2qlandFlightMode , APMPlaneMode::LOITER2QLAND  , true , true },
+        { _autolandFlightMode     , APMPlaneMode::AUTOLAND      , true , true },
     });
 
     if (!_remapParamNameIntialized) {

--- a/src/FirmwarePlugin/APM/ArduPlaneFirmwarePlugin.h
+++ b/src/FirmwarePlugin/APM/ArduPlaneFirmwarePlugin.h
@@ -43,6 +43,8 @@ struct APMPlaneMode
         QAUTOTUNE     = 22,
         QACRO         = 23,
         THERMAL       = 24,
+        LOITER2QLAND  = 25,
+        AUTOLAND      = 26,
     };
 };
 
@@ -91,6 +93,8 @@ protected:
     QString     _qAutotuneFlightMode    ;
     QString     _qAcroFlightMode        ;
     QString     _thermalFlightMode      ;
+    QString     _loiter2qlandFlightMode ;
+    QString     _autolandFlightMode     ;
 private:
     static bool _remapParamNameIntialized;
     static FirmwarePlugin::remapParamNameMajorVersionMap_t  _remapParamName;


### PR DESCRIPTION
<!--- Title -->

Description
-----------
Add new ArduPlane flight modes: AUTOLAND,LOITER2QLAND
<!--- Describe your changes in detail. -->
Add the mode to the appropriate files for display and use

Checklist:
----------
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x ] [Review Contribution Guidelines](https://github.com/mavlink/qgroundcontrol/blob/master/.github/CONTRIBUTING.md).
- [x ] [Review Code of Conduct](https://github.com/mavlink/qgroundcontrol/blob/master/.github/CODE_OF_CONDUCT.md).
- [ ] I have tested my changes. 
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.