### PR TITLE
Geo: Update GeographicLib to 2.5

### DIFF
--- a/src/Geo/CMakeLists.txt
+++ b/src/Geo/CMakeLists.txt
@@ -43,7 +43,7 @@ message(STATUS "Building GeographicLib")
 include(FetchContent)
 FetchContent_Declare(GeographicLib
     GIT_REPOSITORY https://github.com/geographiclib/geographiclib.git
-    GIT_TAG r2.4
+    GIT_TAG r2.5
     GIT_SHALLOW TRUE
 )
 set(BUILD_BOTH_LIBS OFF CACHE INTERNAL "" FORCE)


### PR DESCRIPTION
This included a fix that resolves some warning we were getting with previous versions