### PR TITLE
CMake: Turn On Warnings as Errors

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.22.1)
+cmake_minimum_required(VERSION 3.24)
 
 list(APPEND CMAKE_MODULE_PATH
     ${CMAKE_SOURCE_DIR}/cmake
@@ -64,6 +64,7 @@ set(CMAKE_AUTORCC ON)
 set(CMAKE_INCLUDE_CURRENT_DIR OFF)
 set(CMAKE_EXPORT_COMPILE_COMMANDS ON)
 set(CMAKE_POSITION_INDEPENDENT_CODE ON)
+set(CMAKE_COMPILE_WARNING_AS_ERROR ON)
 
 set_property(CACHE CMAKE_BUILD_TYPE PROPERTY STRINGS "Debug;Release")
 if(NOT CMAKE_BUILD_TYPE)
@@ -109,6 +110,12 @@ if(CMAKE_CROSSCOMPILING AND ANDROID)
 endif()
 
 set(BUILD_SHARED_LIBS OFF CACHE BOOL "" FORCE)
+
+if (MSVC)
+    add_compile_options(/W4)
+else()
+    add_compile_options(-Wall -Wextra -Wpedantic)
+endif()
 
 #######################################################
 #               Qt6 Configuration

--- a/src/AnalyzeView/CMakeLists.txt
+++ b/src/AnalyzeView/CMakeLists.txt
@@ -65,6 +65,8 @@ endif()
 
 #===========================================================================#
 
+set(CMAKE_COMPILE_WARNING_AS_ERROR OFF)
+
 set(MINIMUM_EXIV2_VERSION 0.28.2)
 
 if(NOT QGC_BUILD_DEPENDENCIES)
@@ -138,6 +140,8 @@ if(NOT exiv2_FOUND AND NOT LibExiv2_FOUND)
 endif()
 
 target_sources(AnalyzeView PRIVATE ExifParser.cc ExifParser.h)
+
+set(CMAKE_COMPILE_WARNING_AS_ERROR ON)
 
 #===========================================================================#
 


### PR DESCRIPTION
Best way to do this for now until the individual QGC source libraries are removed. Then we can just set this per target or something