### PR TITLE
Fix unit system change in the units FirstRunPrompt

### DIFF
--- a/src/FirstRunPromptDialogs/UnitsFirstRunPrompt.qml
+++ b/src/FirstRunPromptDialogs/UnitsFirstRunPrompt.qml
@@ -38,6 +38,10 @@ FirstRunPrompt {
     }
 
     function changeSystemOfUnits(metric) {
+        // Hack to force reload the ComboBoxes, otherwise they don't update
+        unitComboBoxRepeater.model = 0
+        unitComboBoxRepeater.model = _rgFacts.length
+
         if (_unitsSettings.horizontalDistanceUnits.visible) {
             _unitsSettings.horizontalDistanceUnits.value = metric ? UnitsSettings.HorizontalDistanceUnitsMeters : UnitsSettings.HorizontalDistanceUnitsFeet
         }
@@ -100,6 +104,7 @@ FirstRunPrompt {
                 }
 
                 Repeater {
+                    id: unitComboBoxRepeater
                     model: _rgFacts.length
                     FactComboBox {
                         Layout.fillWidth:   true


### PR DESCRIPTION
# Fix unit system change in the units FirstRunPrompt

Description
-----------
When changing unit system, the individual unit ComboBoxes weren't updating to reflect it. Fixed by forcing a model reload.

Checklist:
----------
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [X] [Review Contribution Guidelines](https://github.com/mavlink/qgroundcontrol/blob/master/.github/CONTRIBUTING.md).
- [X] [Review Code of Conduct](https://github.com/mavlink/qgroundcontrol/blob/master/.github/CODE_OF_CONDUCT.md).
- [X] I have tested my changes.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.