### PR TITLE
Use MAV_CMD_DO_SET_MISSION_CURRENT for APMFirmwarePlugin

### DIFF
--- a/src/FirmwarePlugin/APM/APMFirmwarePlugin.h
+++ b/src/FirmwarePlugin/APM/APMFirmwarePlugin.h
@@ -152,6 +152,20 @@ class APMFirmwarePluginInstanceData : public FirmwarePluginInstanceData
 
 public:
 
+    // anyVersionSupportsCommand returns
+    // CommandSupportedResult::SUPPORTED if any version of the
+    // firmware has supported cmd.  It return UNSUPPORTED if no
+    // version ever has.  It returns UNKNOWN if that information is
+    // not known.
+    CommandSupportedResult anyVersionSupportsCommand(MAV_CMD cmd) const override {
+        switch (cmd) {
+        case MAV_CMD_DO_SET_MISSION_CURRENT:
+            return CommandSupportedResult::SUPPORTED;
+        default:
+            return CommandSupportedResult::UNKNOWN;
+        }
+    }
+
     QTime lastBatteryStatusTime;
     QTime lastHomePositionTime;
 

--- a/src/FirmwarePlugin/APM/APMFirmwarePlugin.h
+++ b/src/FirmwarePlugin/APM/APMFirmwarePlugin.h
@@ -144,16 +144,13 @@ private:
     static QMutex&          _reencodeMavlinkChannelMutex();
 };
 
-class APMFirmwarePluginInstanceData : public QObject
+class APMFirmwarePluginInstanceData : public FirmwarePluginInstanceData
 {
     Q_OBJECT
 
-public:
-    APMFirmwarePluginInstanceData(QObject* parent = nullptr)
-        : QObject(parent)
-    {
+    using FirmwarePluginInstanceData::FirmwarePluginInstanceData;
 
-    }
+public:
 
     QTime lastBatteryStatusTime;
     QTime lastHomePositionTime;

--- a/src/FirmwarePlugin/FirmwarePlugin.h
+++ b/src/FirmwarePlugin/FirmwarePlugin.h
@@ -455,4 +455,32 @@ public:
 
     using QObject::QObject;
 
+    // support for detecting whether the firmware a vehicle is running
+    // supports a given MAV_CMD:
+    enum class CommandSupportedResult : uint8_t {
+        SUPPORTED = 23,
+        UNSUPPORTED = 24,
+        UNKNOWN = 25,
+    };
+    // anyVersionSupportsCommand returns true if any version of the
+    // firmware has supported cmd.  Used so that extra round-trips to
+    // the autopilot to probe for command support are not required.
+    virtual CommandSupportedResult anyVersionSupportsCommand(MAV_CMD cmd) const {
+        return CommandSupportedResult::UNKNOWN;
+    }
+
+    // support for detecting whether the firmware a vehicle is running
+    // supports a given MAV_CMD:
+    void setCommandSupported(MAV_CMD cmd, CommandSupportedResult status) {
+        MAV_CMD_supported[cmd] = status;
+    }
+    CommandSupportedResult getCommandSupported(MAV_CMD cmd) const {
+        if (anyVersionSupportsCommand(cmd) == CommandSupportedResult::UNSUPPORTED) {
+            return CommandSupportedResult::UNSUPPORTED;
+        }
+        return MAV_CMD_supported.value(cmd, CommandSupportedResult::UNKNOWN);
+    }
+
+private:
+    QMap<MAV_CMD, CommandSupportedResult> MAV_CMD_supported;
 };

--- a/src/FirmwarePlugin/FirmwarePlugin.h
+++ b/src/FirmwarePlugin/FirmwarePlugin.h
@@ -446,3 +446,13 @@ protected:
     QVariantList _toolIndicatorList;
     QVariantList _modeIndicatorList;
 };
+
+class FirmwarePluginInstanceData : public QObject
+{
+    Q_OBJECT
+
+public:
+
+    using QObject::QObject;
+
+};

--- a/src/FirmwarePlugin/PX4/PX4FirmwarePlugin.cc
+++ b/src/FirmwarePlugin/PX4/PX4FirmwarePlugin.cc
@@ -25,7 +25,7 @@
 #include "px4_custom_mode.h"
 
 PX4FirmwarePluginInstanceData::PX4FirmwarePluginInstanceData(QObject* parent)
-    : QObject(parent)
+    : FirmwarePluginInstanceData(parent)
     , versionNotified(false)
 {
 

--- a/src/FirmwarePlugin/PX4/PX4FirmwarePlugin.h
+++ b/src/FirmwarePlugin/PX4/PX4FirmwarePlugin.h
@@ -115,7 +115,7 @@ private:
     // Vehicle specific data should go into PX4FirmwarePluginInstanceData
 };
 
-class PX4FirmwarePluginInstanceData : public QObject
+class PX4FirmwarePluginInstanceData : public FirmwarePluginInstanceData
 {
     Q_OBJECT
 

--- a/src/FirmwarePlugin/PX4/PX4FirmwarePlugin.h
+++ b/src/FirmwarePlugin/PX4/PX4FirmwarePlugin.h
@@ -122,5 +122,19 @@ class PX4FirmwarePluginInstanceData : public FirmwarePluginInstanceData
 public:
     PX4FirmwarePluginInstanceData(QObject* parent = nullptr);
 
+    // anyVersionSupportsCommand returns
+    // CommandSupportedResult::SUPPORTED if any version of the
+    // firmware has supported cmd.  It return UNSUPPORTED if no
+    // version ever has.  It returns UNKNOWN if that information is
+    // not known.
+    CommandSupportedResult anyVersionSupportsCommand(MAV_CMD cmd) const override {
+        switch (cmd) {
+        case MAV_CMD_DO_SET_MISSION_CURRENT:
+            return CommandSupportedResult::UNSUPPORTED;
+        default:
+            return CommandSupportedResult::UNKNOWN;
+        }
+    }
+
     bool versionNotified;  ///< true: user notified over version issue
 };

--- a/src/Vehicle/Vehicle.cc
+++ b/src/Vehicle/Vehicle.cc
@@ -3155,7 +3155,7 @@ void Vehicle::_handleMavlinkLoggingDataAcked(mavlink_message_t& message)
     }
 }
 
-void Vehicle::setFirmwarePluginInstanceData(QObject* firmwarePluginInstanceData)
+void Vehicle::setFirmwarePluginInstanceData(FirmwarePluginInstanceData* firmwarePluginInstanceData)
 {
     firmwarePluginInstanceData->setParent(this);
     _firmwarePluginInstanceData = firmwarePluginInstanceData;

--- a/src/Vehicle/Vehicle.h
+++ b/src/Vehicle/Vehicle.h
@@ -994,6 +994,9 @@ private:
 
     static void _rebootCommandResultHandler(void* resultHandlerData, int compId, const mavlink_command_ack_t& ack, MavCmdResultFailureCode_t failureCode);
 
+    // send mavlink command (deprecated since Aug 2022)
+    Q_INVOKABLE void setCurrentMissionSequenceWithMissionSetCurrent(int seq);
+
     int     _id;                    ///< Mavlink system id
     int     _defaultComponentId;
     bool    _offlineEditingVehicle = false; ///< true: This Vehicle is a "disconnected" vehicle for ui use while offline editing

--- a/src/Vehicle/Vehicle.h
+++ b/src/Vehicle/Vehicle.h
@@ -689,6 +689,14 @@ public:
         int compId, MAV_CMD command, MAV_FRAME frame, 
         float param1 = 0.0f, float param2 = 0.0f, float param3 = 0.0f, float param4 = 0.0f, double param5 = 0.0f, double param6 = 0.0f, float param7 = 0.0f);
 
+    /// Sends the command and calls the fallback lambda function in
+    /// case the command is MAV_RESULT_UNSUPPORTED
+    void sendMavCommandWithLambdaFallback(
+        std::function<void()> lambda,
+        int compId, MAV_CMD command,
+        float param1 = 0.0f, float param2 = 0.0f, float param3 = 0.0f, float param4 = 0.0f, float param5 = 0.0f, float param6 = 0.0f, float param7 = 0.0f);
+
+
     typedef enum {
         RequestMessageNoFailure,
         RequestMessageFailureCommandError,

--- a/src/Vehicle/Vehicle.h
+++ b/src/Vehicle/Vehicle.h
@@ -994,9 +994,6 @@ private:
 
     static void _rebootCommandResultHandler(void* resultHandlerData, int compId, const mavlink_command_ack_t& ack, MavCmdResultFailureCode_t failureCode);
 
-    // send mavlink command (deprecated since Aug 2022)
-    Q_INVOKABLE void setCurrentMissionSequenceWithMissionSetCurrent(int seq);
-
     int     _id;                    ///< Mavlink system id
     int     _defaultComponentId;
     bool    _offlineEditingVehicle = false; ///< true: This Vehicle is a "disconnected" vehicle for ui use while offline editing

--- a/src/Vehicle/Vehicle.h
+++ b/src/Vehicle/Vehicle.h
@@ -745,11 +745,11 @@ public:
     bool xConfigMotors();
 
     /// @return Firmware plugin instance data associated with this Vehicle
-    QObject* firmwarePluginInstanceData() { return _firmwarePluginInstanceData; }
+    class FirmwarePluginInstanceData* firmwarePluginInstanceData() { return _firmwarePluginInstanceData; }
 
     /// Sets the firmware plugin instance data associated with this Vehicle. This object will be parented to the Vehicle
     /// and destroyed when the vehicle goes away.
-    void setFirmwarePluginInstanceData(QObject* firmwarePluginInstanceData);
+    void setFirmwarePluginInstanceData(FirmwarePluginInstanceData* firmwarePluginInstanceData);
 
     QString vehicleImageOpaque  () const;
     QString vehicleImageOutline () const;
@@ -993,7 +993,7 @@ private:
     MAV_AUTOPILOT       _firmwareType;
     MAV_TYPE            _vehicleType;
     FirmwarePlugin*     _firmwarePlugin = nullptr;
-    QObject*            _firmwarePluginInstanceData = nullptr;
+    class FirmwarePluginInstanceData*            _firmwarePluginInstanceData = nullptr;
     AutoPilotPlugin*    _autopilotPlugin = nullptr;
     bool                _soloFirmware = false;
 


### PR DESCRIPTION
Send the mavlink command MAV_CMD_DO_SET_MISSION_CURRENT in place of the old mavlink message MISSION_SET_CURRENT.  If "UNSUPPORTED" is received from the autopilot then send the old mavlink message.

The mavlink command has existed since 2019.

The mavlink message has been deprecated since Aug 2022.

ArduPilot has supported the command since 4.1.0 (2021)


Adds infrastructure which should be reused for (eg.) the DO_REPOSITION code.
