### PR TITLE
Disabled video support on MAC - plus other fixes

### DIFF
--- a/cmake/CustomOptions.cmake
+++ b/cmake/CustomOptions.cmake
@@ -19,7 +19,12 @@ option(QGC_UTM_ADAPTER "Enable UTM Adapter" OFF)
 option(QGC_VIEWER3D "Enable Viewer3D" ON) # Qt6Quick3D_FOUND
 
 option(QGC_ENABLE_UVC "Enable UVC Devices" ON) # Qt6Multimedia_FOUND
-option(QGC_ENABLE_GST_VIDEOSTREAMING "Enable GStreamer Video Backend" ON)
+if(APPLE AND NOT IOS)
+    # Still haven't figured out how to package GStreamer with the app.
+    option(QGC_ENABLE_GST_VIDEOSTREAMING "Enable GStreamer Video Backend" OFF)
+else()
+    option(QGC_ENABLE_GST_VIDEOSTREAMING "Enable GStreamer Video Backend" ON)
+endif()
 option(QGC_ENABLE_QT_VIDEOSTREAMING "Enable QtMultimedia Video Backend" OFF) # Qt6Multimedia_FOUND
 
 set(QGC_MAVLINK_GIT_REPO "https://github.com/mavlink/c_library_v2.git" CACHE STRING "URL to MAVLink Git Repo")

--- a/src/MAVLink/StatusTextHandler.cc
+++ b/src/MAVLink/StatusTextHandler.cc
@@ -314,7 +314,8 @@ void StatusTextHandler::_handleStatusText(const mavlink_message_t &message)
 
 void StatusTextHandler::_chunkedStatusTextTimeout()
 {
-    for (auto [compId, chunkedInfo] : m_chunkedStatusTextInfoMap.asKeyValueRange()) {
+    for (auto compId : m_chunkedStatusTextInfoMap.keys()) {
+        auto& chunkedInfo = m_chunkedStatusTextInfoMap[compId];
         (void) chunkedInfo.rgMessageChunks.append(QString());
         _chunkedStatusTextCompleted(compId);
     }

--- a/src/UI/MainRootWindow.qml
+++ b/src/UI/MainRootWindow.qml
@@ -558,7 +558,7 @@ ApplicationWindow {
     //-- Critical Vehicle Message Popup
 
     function showCriticalVehicleMessage(message) {
-        indicatorPopup.close()
+        closeIndicatorDrawer()
         if (criticalVehicleMessagePopup.visible || QGroundControl.videoManager.fullScreen) {
             // We received additional wanring message while an older warning message was still displayed.
             // When the user close the older one drop the message indicator tool so they can see the rest of them.


### PR DESCRIPTION
* Temporarily disable video support on MAC till we can figure out how to make it work
* Fix crash in chunked status text handler
* Fix incorrect call to old popup code