### PR TITLE
Add Unique Flight Modes Only

### DIFF
--- a/src/FirmwarePlugin/APM/ArduCopterFirmwarePlugin.h
+++ b/src/FirmwarePlugin/APM/ArduCopterFirmwarePlugin.h
@@ -74,7 +74,7 @@ public:
     QString autoDisarmParameter                 (Vehicle* vehicle) override { Q_UNUSED(vehicle); return QStringLiteral("DISARM_DELAY"); }
     bool    supportsSmartRTL                    (void) const override { return true; }
 
-    void    updateAvailableFlightModes          (FlightModeList modeList) final;
+    void    updateAvailableFlightModes          (FlightModeList modeList) override;
 protected:
     uint32_t    _convertToCustomFlightModeEnum(uint32_t val) const override;
 

--- a/src/FirmwarePlugin/APM/ArduPlaneFirmwarePlugin.h
+++ b/src/FirmwarePlugin/APM/ArduPlaneFirmwarePlugin.h
@@ -61,7 +61,7 @@ public:
     const FirmwarePlugin::remapParamNameMajorVersionMap_t& paramNameRemapMajorVersionMap(void) const final { return _remapParamName; }
 
     QString stabilizedFlightMode                    (void) const override;
-    void    updateAvailableFlightModes              (FlightModeList modeList) final;
+    void    updateAvailableFlightModes              (FlightModeList modeList) override;
 
 protected:
     uint32_t    _convertToCustomFlightModeEnum(uint32_t val) const override;

--- a/src/FirmwarePlugin/APM/ArduRoverFirmwarePlugin.h
+++ b/src/FirmwarePlugin/APM/ArduRoverFirmwarePlugin.h
@@ -54,7 +54,7 @@ public:
     QString offlineEditingParamFile                 (Vehicle* vehicle) override { Q_UNUSED(vehicle); return QStringLiteral(":/FirmwarePlugin/APM/Rover.OfflineEditing.params"); }
 
     QString stabilizedFlightMode                    (void) const override;
-    void    updateAvailableFlightModes              (FlightModeList modeList) final;
+    void    updateAvailableFlightModes              (FlightModeList modeList) override;
 
 protected:
     uint32_t    _convertToCustomFlightModeEnum(uint32_t val) const override;

--- a/src/FirmwarePlugin/APM/ArduSubFirmwarePlugin.h
+++ b/src/FirmwarePlugin/APM/ArduSubFirmwarePlugin.h
@@ -154,7 +154,7 @@ public:
 
     QString stabilizedFlightMode                (void) const override;
     QString motorDetectionFlightMode            (void) const override;
-    void    updateAvailableFlightModes          (FlightModeList modeList) final;
+    void    updateAvailableFlightModes          (FlightModeList modeList) override;
 
 protected:
     uint32_t    _convertToCustomFlightModeEnum(uint32_t val) const override;

--- a/src/FirmwarePlugin/FirmwarePlugin.cc
+++ b/src/FirmwarePlugin/FirmwarePlugin.cc
@@ -594,6 +594,17 @@ void FirmwarePlugin::_updateModeMappings(FlightModeList &modeList){
             _modeEnumToString[mode.custom_mode] = nModeName;
         }
         mode.mode_name = nModeName;
-        _availableFlightModeList += mode;
+        _addNewFlightMode(mode);
     }
+}
+
+void FirmwarePlugin::_addNewFlightMode(FirmwareFlightMode &mode)
+{
+    for(auto &m:_availableFlightModeList){
+        if(m.custom_mode == mode.custom_mode){
+            // Already Exist
+            return;
+        }
+    }
+    _availableFlightModeList += mode;
 }

--- a/src/FirmwarePlugin/FirmwarePlugin.h
+++ b/src/FirmwarePlugin/FirmwarePlugin.h
@@ -438,6 +438,7 @@ protected:
 
     // Update internal mappings for a list of flight modes
     void             _updateModeMappings(FlightModeList &modeList);
+    void             _addNewFlightMode  (FirmwareFlightMode &mode);
 
     FlightModeList              _availableFlightModeList;
     FlightModeCustomModeMap     _modeEnumToString;


### PR DESCRIPTION
Resolved multiple flight modes in ArduPlane: https://github.com/mavlink/qgroundcontrol/pull/12254#issuecomment-2571379641

Arduplane is sending standard modes twice, thus adding them to the list multiple times.

Also changed from `final` to `override` for better integration in Custom GCS