### PR TITLE
Fix MavCmd-Trigger Parachute, Guided Enable, Autotune Enable

### DIFF
--- a/src/MissionManager/MavCmdInfoCommon.json
+++ b/src/MissionManager/MavCmdInfoCommon.json
@@ -360,7 +360,7 @@
             "param1": {
                 "label":            "Enable",
                 "enumStrings":      "On,Off",
-                "enumValues":       "0,1",
+                "enumValues":       "1,0",
                 "default":          1,
                 "decimalPlaces":    0
             }
@@ -1034,7 +1034,7 @@
             "id":                   208,
             "rawName":              "MAV_CMD_DO_PARACHUTE",
             "friendlyName":         "Trigger parachute",
-            "description":          "Enable/Disable geofence.",
+            "description":          "Enable/Disable auto-release or Release a parachute",
             "specifiesCoordinate":  false,
             "friendlyEdit":         true,
             "category":             "Safety",
@@ -1090,7 +1090,7 @@
             "specifiesCoordinate":  false,
             "friendlyEdit":         true,
             "category":             "Advanced",
-            "param2": {
+            "param1": {
                 "label":            "Enable",
                 "enumStrings":      "Enable,Disable",
                 "enumValues":       "1,0",


### PR DESCRIPTION
Fixed Trigger Parachute, Guided Enable, Autotune Enable Commands.

Description
-----------
1. Trigger Parachute

Changed description of Trigger Parachute.

2. Guided Enable

Matched enumStrings and enumValues correctly.
On - 1, Off - 0

3. Autotune Enable

Changed param number. Enable/Disable should be param1 not param2.
param2 -> param1

Test Steps
-----------
<!-- Describe the steps to reproduce. -->

Checklist:
----------
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [ x ] [Review Contribution Guidelines](https://github.com/mavlink/qgroundcontrol/blob/master/.github/CONTRIBUTING.md).
- [ x ] [Review Code of Conduct](https://github.com/mavlink/qgroundcontrol/blob/master/.github/CODE_OF_CONDUCT.md).
- [ x ] I have tested my changes.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.