### PR TITLE
MockLink: Allow motor setup ui testing

### DIFF
--- a/src/Comms/MockLink/MockLink.cc
+++ b/src/Comms/MockLink/MockLink.cc
@@ -1072,6 +1072,9 @@ void MockLink::_handleCommandLong(const mavlink_message_t &msg)
         _handlePreFlightCalibration(request);
         commandResult = MAV_RESULT_ACCEPTED;
         break;
+    case MAV_CMD_DO_MOTOR_TEST:
+        commandResult = MAV_RESULT_ACCEPTED;
+        break;
     case MAV_CMD_CONTROL_HIGH_LATENCY:
         if (linkConfiguration()->isHighLatency()) {
             _highLatencyTransmissionEnabled = static_cast<int>(request.param1) != 0;


### PR DESCRIPTION
* Related to #12312
* Allows for simple testing of Motor setup page with a real vehicle