### PR TITLE
Add "Request Gimbal Control" popup

### DIFF
--- a/src/QmlControls/QGCSimpleMessageDialog.qml
+++ b/src/QmlControls/QGCSimpleMessageDialog.qml
@@ -16,10 +16,17 @@ import QGroundControl.ScreenTools
 QGCPopupDialog {
     property alias  text:           label.text
     property var    acceptFunction: null        // Mainly used by MainRootWindow.showMessage to specify accept function in call
+    property var    closeFunction:  null
 
     onAccepted: {
         if (acceptFunction) {
             acceptFunction()
+        }
+    }
+
+    onClosed: {
+        if (closeFunction) {
+            closeFunction()
         }
     }
 

--- a/src/UI/MainRootWindow.qml
+++ b/src/UI/MainRootWindow.qml
@@ -160,8 +160,8 @@ ApplicationWindow {
     //-------------------------------------------------------------------------
     //-- Global simple message dialog
 
-    function showMessageDialog(dialogTitle, dialogText, buttons = Dialog.Ok, acceptFunction = null) {
-        simpleMessageDialogComponent.createObject(mainWindow, { title: dialogTitle, text: dialogText, buttons: buttons, acceptFunction: acceptFunction }).open()
+    function showMessageDialog(dialogTitle, dialogText, buttons = Dialog.Ok, acceptFunction = null, closeFunction = null) {
+        simpleMessageDialogComponent.createObject(mainWindow, { title: dialogTitle, text: dialogText, buttons: buttons, acceptFunction: acceptFunction, closeFunction: closeFunction }).open()
     }
 
     // This variant is only meant to be called by QGCApplication

--- a/src/UI/toolbar/GimbalIndicator.qml
+++ b/src/UI/toolbar/GimbalIndicator.qml
@@ -8,6 +8,7 @@
  ****************************************************************************/
 
 import QtQuick
+import QtQuick.Controls
 import QtQuick.Layouts
 
 import QGroundControl
@@ -405,5 +406,23 @@ Item {
     MouseArea {
         anchors.fill:   parent
         onClicked:      mainWindow.showIndicatorDrawer(gimbalControlsPage, control)
+    }
+
+    Connections {
+        id:                         acquirePopupConnection
+        property bool isPopupOpen:  false
+        target:                     gimbalController
+        onShowAcquireGimbalControlPopup: {
+            if(!acquirePopupConnection.isPopupOpen){
+                acquirePopupConnection.isPopupOpen = true;
+                mainWindow.showMessageDialog(
+                    "Request Gimbal Control?",
+                    "Command not sent. Another user has control of the gimbal.",
+                    Dialog.Yes | Dialog.No,
+                    gimbalController.acquireGimbalControl,
+                    function() { acquirePopupConnection.isPopupOpen = false }
+                )
+            }
+        }
     }
 }


### PR DESCRIPTION
fixes #12328 

If another user was in control of the gimbal, the current logic would stop gimbal commands from being sent out, but not show a "Request Gimbal Control" popup. There was a signal being emitted suggesting  a popup was intended to be shown, but wasn't. Now a popup is indeed shown.

![Screenshot 2025-01-17 200010](https://github.com/user-attachments/assets/995881e2-f593-4360-8d34-2428ee12758e)


## Sponsor
This contribution was sponsored by [Firestorm](https://www.launchfirestorm.com/)
![654d4f9476ff2a38f37e9ab9_firestorm-homepage-share-img-2](https://github.com/user-attachments/assets/bc1a2c95-b33d-4a2d-af35-4d2d8651d0a2)