### PR TITLE
MAVLink Inspector, show all selected fields in the chart

### DIFF
--- a/src/AnalyzeView/MAVLinkMessage.cc
+++ b/src/AnalyzeView/MAVLinkMessage.cc
@@ -108,7 +108,7 @@ void QGCMAVLinkMessage::update(const mavlink_message_t &message)
     _count++;
     _message = message;
 
-    if (_selected) {
+    if (_selected || _fieldSelected) {
         // Don't update field info unless selected to reduce perf hit of message processing
         _updateFields();
     }


### PR DESCRIPTION
Description
-----------
Currently, if I select `ATTITUDE.roll`, the data is displayed on the chart. However, if I switch to another message (e.g., `RAW_IMU`), the `ATTITUDE.roll` data stops rendering. It would be more intuitive if all selected fields (even from different messages) were shown on the chart simultaneously.

![Screenshot from 2025-01-18 12-40-02](https://github.com/user-attachments/assets/15134e6a-935e-47ca-aaf6-53a38a164954)

For example, I want to investigate the correlation between `ATTITUDE.roll` and `RAW_IMU.xacc`.

I investigated why this approach was implemented and couldn't find a specific reason preventing us from displaying multiple fields from different messages simultaneously.

Test Steps
-----------
- Make sure QGC is connected to a drone that is  in flight
- Go to MAVLink Inspector
- Select ATTITUDE.roll 
- Switch to another message (For example RAW_IMU)
- Observer that ATTITUDE.roll is still rendered on the chart

Checklist:
----------

- [x] [Review Contribution Guidelines](https://github.com/mavlink/qgroundcontrol/blob/master/.github/CONTRIBUTING.md).
- [x] [Review Code of Conduct](https://github.com/mavlink/qgroundcontrol/blob/master/.github/CODE_OF_CONDUCT.md).
- [x] I have tested my changes.

Related Issue
-----------
<!-- If any, please provide issue ID. -->


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.