### PR TITLE
Tool indicator: Put back separator between expanded content

### DIFF
--- a/src/QmlControls/ToolIndicatorPage.qml
+++ b/src/QmlControls/ToolIndicatorPage.qml
@@ -48,6 +48,14 @@ RowLayout {
         property var pageProperties: control.pageProperties
     }
 
+    Rectangle {
+        id:                     divider
+        Layout.preferredWidth:  visible ? 1 : -1
+        Layout.fillHeight:      true
+        color:                  QGroundControl.globalPalette.groupBorder
+        visible:                expanded
+    }
+    
     Loader {
         id:                     expandedItemLoader
         Layout.alignment:       Qt.AlignTop


### PR DESCRIPTION
<img width="570" alt="Screenshot 2025-01-18 at 6 55 24 PM" src="https://github.com/user-attachments/assets/38416897-13b1-4580-b247-fae84401d69e" />
