### PR TITLE
Tool consistency ui tweaks

### DIFF
--- a/custom-example/src/FlyViewToolStripActionList.qml
+++ b/custom-example/src/FlyViewToolStripActionList.qml
@@ -18,14 +18,6 @@ ToolStripActionList {
     signal displayPreFlightChecklist
 
     model: [
-        ToolStripAction {
-            text:           qsTr("Plan")
-            iconSource:     "/qmlimages/Plan.svg"
-            onTriggered:{
-                mainWindow.showPlanView()
-                viewer3DWindow.close()
-            }
-        },
         PreFlightCheckListShowAction { onTriggered: displayPreFlightChecklist() },
         GuidedActionTakeoff { },
         GuidedActionLand { },

--- a/src/FlightDisplay/FlyViewToolStrip.qml
+++ b/src/FlightDisplay/FlyViewToolStrip.qml
@@ -14,8 +14,7 @@ import QGroundControl.Controls
 import QGroundControl.FlightDisplay
 
 ToolStrip {
-    id:     _root
-    title:  qsTr("Fly")
+    id: _root
 
     signal displayPreFlightChecklist
 

--- a/src/FlightDisplay/FlyViewToolStripActionList.qml
+++ b/src/FlightDisplay/FlyViewToolStripActionList.qml
@@ -19,14 +19,6 @@ ToolStripActionList {
 
     model: [
         ToolStripAction {
-            text:           qsTr("Plan")
-            iconSource:     "/qmlimages/Plan.svg"
-            onTriggered:{
-                mainWindow.showPlanView()
-                viewer3DWindow.close()
-            }
-        },
-        ToolStripAction {
             property bool _is3DViewOpen:            viewer3DWindow.isOpen
             property bool   _viewer3DEnabled:       QGroundControl.settingsManager.viewer3DSettings.enabled.rawValue
 

--- a/src/PlanView/PlanToolBarIndicators.qml
+++ b/src/PlanView/PlanToolBarIndicators.qml
@@ -89,20 +89,44 @@ Item {
         return complete
     }
 
-    GridLayout {
+    RowLayout {
         id:                     missionStats
         anchors.top:            parent.top
         anchors.bottom:         parent.bottom
         anchors.leftMargin:     _margins
         anchors.left:           parent.left
-        columnSpacing:          0
-        columns:                4
+        spacing:                ScreenTools.defaultFontPixelWidth * 2
+
+        QGCButton {
+            id:          uploadButton
+            text:        _controllerDirty ? qsTr("Upload Required") : qsTr("Upload")
+            enabled:     _utmspEnabled ? !_controllerSyncInProgress && UTMSPStateStorage.enableMissionUploadButton : !_controllerSyncInProgress
+            visible:     !_controllerOffline && !_controllerSyncInProgress
+            primary:     _controllerDirty
+            onClicked: {
+                if (_utmspEnabled) {
+                    QGroundControl.utmspManager.utmspVehicle.triggerActivationStatusBar(true);
+                    UTMSPStateStorage.removeFlightPlanState = true
+                    UTMSPStateStorage.indicatorDisplayStatus = true
+                }
+                _planMasterController.upload();
+            }
+
+            PropertyAnimation on opacity {
+                easing.type:    Easing.OutQuart
+                from:           0.5
+                to:             1
+                loops:          Animation.Infinite
+                running:        _controllerDirty && !_controllerSyncInProgress
+                alwaysRunToEnd: true
+                duration:       2000
+            }
+        }
 
         GridLayout {
             columns:                8
             rowSpacing:             _rowSpacing
             columnSpacing:          _labelToValueSpacing
-            Layout.alignment:       Qt.AlignVCenter | Qt.AlignHCenter
 
             QGCLabel {
                 text:               qsTr("Selected Waypoint")
@@ -156,7 +180,6 @@ Item {
             columns:                5
             rowSpacing:             _rowSpacing
             columnSpacing:          _labelToValueSpacing
-            Layout.alignment:       Qt.AlignVCenter | Qt.AlignHCenter
 
             QGCLabel {
                 text:               qsTr("Total Mission")
@@ -192,7 +215,6 @@ Item {
             columns:                3
             rowSpacing:             _rowSpacing
             columnSpacing:          _labelToValueSpacing
-            Layout.alignment:       Qt.AlignVCenter | Qt.AlignHCenter
             visible:                _batteryInfoAvailable
 
             QGCLabel {
@@ -206,34 +228,6 @@ Item {
                 text:                   _batteriesRequiredText
                 font.pointSize:         _dataFontSize
                 Layout.minimumWidth:    _mediumValueWidth
-            }
-
-            Item { width: 1; height: 1 }
-        }
-
-        QGCButton {
-            id:          uploadButton
-            text:        _controllerDirty ? qsTr("Upload Required") : qsTr("Upload")
-            enabled:     _utmspEnabled ? !_controllerSyncInProgress && UTMSPStateStorage.enableMissionUploadButton : !_controllerSyncInProgress
-            visible:     !_controllerOffline && !_controllerSyncInProgress
-            primary:     _controllerDirty
-            onClicked: {
-                if (_utmspEnabled) {
-                    QGroundControl.utmspManager.utmspVehicle.triggerActivationStatusBar(true);
-                    UTMSPStateStorage.removeFlightPlanState = true
-                    UTMSPStateStorage.indicatorDisplayStatus = true
-                }
-                _planMasterController.upload();
-            }
-
-            PropertyAnimation on opacity {
-                easing.type:    Easing.OutQuart
-                from:           0.5
-                to:             1
-                loops:          Animation.Infinite
-                running:        _controllerDirty && !_controllerSyncInProgress
-                alwaysRunToEnd: true
-                duration:       2000
             }
         }
     }

--- a/src/PlanView/PlanView.qml
+++ b/src/PlanView/PlanView.qml
@@ -557,7 +557,6 @@ Item {
             anchors.top:        parent.top
             z:                  QGroundControl.zOrderWidgets
             maxHeight:          parent.height - toolStrip.y
-            title:              qsTr("Plan")
 
             readonly property int flyButtonIndex:       0
             readonly property int fileButtonIndex:      1
@@ -575,11 +574,6 @@ Item {
             ToolStripActionList {
                 id: toolStripActionList
                 model: [
-                    ToolStripAction {
-                        text:           qsTr("Fly")
-                        iconSource:     "/qmlimages/PaperPlane.svg"
-                        onTriggered:    mainWindow.showFlyView()
-                    },
                     ToolStripAction {
                         text:                   qsTr("File")
                         enabled:                !_planMasterController.syncInProgress

--- a/src/UI/MainRootWindow.qml
+++ b/src/UI/MainRootWindow.qml
@@ -123,6 +123,7 @@ ApplicationWindow {
     function showPlanView() {
         flyView.visible = false
         planView.visible = true
+        viewer3DWindow.close()
     }
 
     function showFlyView() {
@@ -143,7 +144,7 @@ ApplicationWindow {
     }
 
     function showVehicleSetupTool(setupPage = "") {
-        showTool(qsTr("Vehicle Setup"), "SetupView.qml", "/qmlimages/Gears.svg")
+        showTool(qsTr("Vehicle Configuration"), "SetupView.qml", "/qmlimages/Gears.svg")
         if (setupPage !== "") {
             toolDrawerLoader.item.showNamedComponentPanel(setupPage)
         }
@@ -306,15 +307,14 @@ ApplicationWindow {
                         spacing:        ScreenTools.defaultFontPixelWidth
 
                         SubMenuButton {
-                            id:                 setupButton
                             height:             toolSelectDialog._toolButtonHeight
                             Layout.fillWidth:   true
-                            text:               qsTr("Vehicle Setup")
-                            imageResource:      "/qmlimages/Gears.svg"
+                            text:               qsTr("Plan Flight")
+                            imageResource:      "/qmlimages/Plan.svg"
                             onClicked: {
                                 if (mainWindow.allowViewSwitch()) {
                                     mainWindow.closeIndicatorDrawer()
-                                    mainWindow.showVehicleSetupTool()
+                                    mainWindow.showPlanView()
                                 }
                             }
                         }
@@ -330,6 +330,20 @@ ApplicationWindow {
                                 if (mainWindow.allowViewSwitch()) {
                                     mainWindow.closeIndicatorDrawer()
                                     mainWindow.showAnalyzeTool()
+                                }
+                            }
+                        }
+
+                        SubMenuButton {
+                            id:                 setupButton
+                            height:             toolSelectDialog._toolButtonHeight
+                            Layout.fillWidth:   true
+                            text:               qsTr("Vehicle Configuration")
+                            imageResource:      "/qmlimages/Gears.svg"
+                            onClicked: {
+                                if (mainWindow.allowViewSwitch()) {
+                                    mainWindow.closeIndicatorDrawer()
+                                    mainWindow.showVehicleSetupTool()
                                 }
                             }
                         }
@@ -468,10 +482,10 @@ ApplicationWindow {
         interactive:    false
         visible:        false
 
-        property alias backIcon:    backIcon.source
-        property alias toolTitle:   toolbarDrawerText.text
+        property var backIcon
+        property string toolTitle
         property alias toolSource:  toolDrawerLoader.source
-        property alias toolIcon:    toolIcon.source
+        property var toolIcon
 
         // Unload the loader only after closed, otherwise we will see a "blank" loader in the meantime
         onClosed: {
@@ -487,51 +501,27 @@ ApplicationWindow {
             color:          qgcPal.toolbarBackground
 
             RowLayout {
+                id:                 toolDrawerToolbarLayout
                 anchors.leftMargin: ScreenTools.defaultFontPixelWidth
                 anchors.left:       parent.left
                 anchors.top:        parent.top
                 anchors.bottom:     parent.bottom
                 spacing:            ScreenTools.defaultFontPixelWidth
 
-                QGCColoredImage {
-                    id:                     backIcon
-                    width:                  ScreenTools.defaultFontPixelHeight * 2
-                    height:                 ScreenTools.defaultFontPixelHeight * 2
-                    fillMode:               Image.PreserveAspectFit
-                    mipmap:                 true
-                    color:                  qgcPal.text
-                }
-
-                QGCLabel {
-                    id:     backTextLabel
-                    text:   qsTr("Back")
-                }
-
                 QGCLabel {
                     font.pointSize: ScreenTools.largeFontPointSize
                     text:           "<"
                 }
 
-                QGCColoredImage {
-                    id:                     toolIcon
-                    width:                  ScreenTools.defaultFontPixelHeight * 2
-                    height:                 ScreenTools.defaultFontPixelHeight * 2
-                    fillMode:               Image.PreserveAspectFit
-                    mipmap:                 true
-                    color:                  qgcPal.text
-                }
-
                 QGCLabel {
                     id:             toolbarDrawerText
+                    text:           qsTr("Exit") + " " + toolDrawer.toolTitle
                     font.pointSize: ScreenTools.largeFontPointSize
                 }
             }
 
             QGCMouseArea {
-                anchors.top:        parent.top
-                anchors.bottom:     parent.bottom
-                x:                  parent.mapFromItem(backIcon, backIcon.x, backIcon.y).x
-                width:              (backTextLabel.x + backTextLabel.width) - backIcon.x
+                anchors.fill: toolDrawerToolbarLayout
                 onClicked: {
                     if (mainWindow.allowViewSwitch()) {
                         toolDrawer.visible = false

--- a/src/UI/toolbar/FlightModeIndicator.qml
+++ b/src/UI/toolbar/FlightModeIndicator.qml
@@ -217,7 +217,7 @@ RowLayout {
 
                 LabelledButton {
                     Layout.fillWidth:   true
-                    label:              qsTr("RC Transmitter Flight Modes")
+                    label:              qsTr("RC Transmitter")
                     buttonText:         qsTr("Configure")
 
                     onClicked: {

--- a/src/UI/toolbar/MainStatusIndicator.qml
+++ b/src/UI/toolbar/MainStatusIndicator.qml
@@ -333,7 +333,7 @@ RowLayout {
                         }
                     }
 
-                    QGCLabel { Layout.fillWidth: true; text: qsTr("Initial Vehicle Setup") }
+                    QGCLabel { Layout.fillWidth: true; text: qsTr("Vehicle Configuration") }
                     QGCButton {
                         text: qsTr("Configure")
                         onClicked: {                            

--- a/src/UI/toolbar/PlanViewToolBar.qml
+++ b/src/UI/toolbar/PlanViewToolBar.qml
@@ -49,18 +49,25 @@ Rectangle {
         anchors.bottom:         parent.bottom
         spacing:                ScreenTools.defaultFontPixelWidth / 2
 
-        QGCToolBarButton {
-            id:                     currentButton
-            Layout.preferredHeight: viewButtonRow.height
-            icon.source:            "/res/QGCLogoFull.svg"
-            logo:                   true
-            onClicked:              mainWindow.showToolSelectDialog()
+        QGCLabel {
+            font.pointSize: ScreenTools.largeFontPointSize
+            text:           "<"
         }
+
+        QGCLabel {
+            text:           qsTr("Exit Plan")
+            font.pointSize: ScreenTools.largeFontPointSize
+        }
+    }
+
+    QGCMouseArea {
+        anchors.fill:   viewButtonRow
+        onClicked:      mainWindow.showFlyView()
     }
 
     QGCFlickable {
         id:                     toolsFlickable
-        anchors.leftMargin:     ScreenTools.defaultFontPixelWidth * ScreenTools.largeFontPointRatio * 1.5
+        //anchors.leftMargin:     ScreenTools.defaultFontPixelWidth * ScreenTools.largeFontPointRatio * 1.5
         anchors.left:           viewButtonRow.right
         anchors.bottomMargin:   1
         anchors.top:            parent.top


### PR DESCRIPTION
* Main view is now just Fly View
* The remainder of the views are "Tools" and have a consistent way of selecting them as well as getting back to Fly view from them
* Fly and Plan buttons are no longer in the left side Toolstrips
* Some other minor user visible naming tweaks

<img width="292" alt="Screenshot 2025-01-20 at 8 37 13 PM" src="https://github.com/user-attachments/assets/3f126060-eec6-4f57-889b-6682fe1f872a" />
<img width="334" alt="Screenshot 2025-01-20 at 8 37 20 PM" src="https://github.com/user-attachments/assets/1168300c-f4b9-4069-8400-d06683d53a72" />
<img width="397" alt="Screenshot 2025-01-20 at 8 37 37 PM" src="https://github.com/user-attachments/assets/01c4c298-061f-4f3f-8627-8f561646c193" />
<img width="309" alt="Screenshot 2025-01-20 at 8 37 46 PM" src="https://github.com/user-attachments/assets/60b3b581-70d0-4183-8389-9dc4ddb2285b" />
