### PR TITLE
Joystick:cc: Fix gimbal rate behaviour after commit e38fd4da1b4e54ec1…

### DIFF
--- a/src/Joystick/Joystick.cc
+++ b/src/Joystick/Joystick.cc
@@ -1053,18 +1053,26 @@ void Joystick::_executeButtonAction(const QString &action, bool buttonDown)
     } else if (action == _buttonActionGimbalUp) {
         if (buttonDown) {
             emit gimbalPitchStart(1);
+        } else {
+            emit gimbalPitchStop();
         }
     } else if (action == _buttonActionGimbalDown) {
         if (buttonDown) {
             emit gimbalPitchStart(-1);
+        } else {
+            emit gimbalPitchStop();
         }
     } else if (action == _buttonActionGimbalLeft) {
         if (buttonDown) {
             emit gimbalYawStart(-1);
+        } else {
+            emit gimbalYawStop();
         }
     } else if (action == _buttonActionGimbalRight) {
         if (buttonDown) {
             emit gimbalYawStart(1);
+        } else {
+            emit gimbalYawStop();
         }
     } else if (action == _buttonActionGimbalCenter) {
         if (buttonDown) {


### PR DESCRIPTION
After the refactor done on this commit https://github.com/mavlink/qgroundcontrol/commit/e38fd4da1b4e54ec12ee233d2f4e86ef4c002fa9 we stopped sending the stop commands to gimbal control when releasing joystick buttons, so the functionality was totally broken.

For awareness @HTRamsey 