### PR TITLE
Update USBBoardInfo.json to include 3DR Control Zero OEM G

### DIFF
--- a/src/Comms/USBBoardInfo.json
+++ b/src/Comms/USBBoardInfo.json
@@ -52,6 +52,7 @@
         { "vendorID": 9900, "productID": 4130,      "boardClass": "Pixhawk",    "name": "mRo Control Zero Classic" },
         { "vendorID": 9900, "productID": 4131,      "boardClass": "Pixhawk",    "name": "mRo Control Zero H7" },
         { "vendorID": 9900, "productID": 4132,      "boardClass": "Pixhawk",    "name": "mRo Control Zero H7 OEM" },
+        { "vendorID": 9900, "productID": 4388,      "boardClass": "Pixhawk",    "name": "3DR Control Zero H7 OEM Rev G" },
 
         { "vendorID": 1027, "productID": 24597,     "boardClass": "SiK Radio",  "name": "SiK Radio",            "comment": "3DR Radio" },
         { "vendorID": 4292, "productID": 60000,     "boardClass": "SiK Radio",  "name": "SiK Radio",            "comment": "SILabs Radio" },


### PR DESCRIPTION
<!--- Title -->
Update USBBoardInfo.json to include 3DR Control Zero OEM G

Description
-----------
<!--- Describe your changes in detail. -->

Adding USB PID & VID to recognize the 3DR Control Zero OEM G board.

I have already tested on Linux and Windows.

Test Steps
-----------
<!-- Describe the steps to reproduce. -->
- Connect a board
- Attempt to Autoconnect/Upload Firmware
- The board should be recognized and be able to upload firmware

Checklist:
----------
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [X ] [Review Contribution Guidelines](https://github.com/mavlink/qgroundcontrol/blob/master/.github/CONTRIBUTING.md).
- [ X] [Review Code of Conduct](https://github.com/mavlink/qgroundcontrol/blob/master/.github/CODE_OF_CONDUCT.md).
- [ X] I have tested my changes.

Related Issue
-----------
<!-- If any, please provide issue ID. -->


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.