### PR TITLE
qt6: cmake: add export QT_SELECT=qt6

### DIFF
--- a/docs/en/qgc-dev-guide/getting_started/index.md
+++ b/docs/en/qgc-dev-guide/getting_started/index.md
@@ -133,6 +133,11 @@ Example commands to build a default QGC and run it afterwards:
    cd qgroundcontrol
    ```
 
+1. If you have multiple versions of Qt installed, make sure you select Qt6
+   ```sh
+   export QT_SELECT=qt6
+   ```
+
 1. Configure:
 
    ```sh


### PR DESCRIPTION
If you have multiple versions of Qt installed cmake you need to set this, cmake will find Qt5 first.