### PR TITLE
CMake: Update Exiv2 & SDL2

### DIFF
--- a/src/AnalyzeView/CMakeLists.txt
+++ b/src/AnalyzeView/CMakeLists.txt
@@ -125,7 +125,7 @@ endif()
 
 CPMAddPackage(
     NAME exiv2
-    VERSION 0.28.3
+    VERSION 0.28.4
     GITHUB_REPOSITORY Exiv2/exiv2
     OPTIONS
         "EXIV2_ENABLE_XMP ${_EXIV2_ENABLE_XMP}"

--- a/src/Joystick/CMakeLists.txt
+++ b/src/Joystick/CMakeLists.txt
@@ -79,9 +79,9 @@ endif()
 
 CPMAddPackage(
     NAME SDL2
-    VERSION 2.30.11
+    VERSION 2.32.0
     GITHUB_REPOSITORY libsdl-org/SDL
-    GIT_TAG release-2.30.11
+    GIT_TAG release-2.32.0
     OPTIONS
         "SDL2_DISABLE_INSTALL ON"
         "SDL2_DISABLE_INSTALL ON"


### PR DESCRIPTION
Exiv2 has some build fixes & this is probably the last SDL2 version before SDL3