### PR TITLE
Fixed collapse arrow disappearing when explanding sections in Mission Start

### DIFF
--- a/src/QmlControls/SectionHeader.qml
+++ b/src/QmlControls/SectionHeader.qml
@@ -43,7 +43,7 @@ CheckBox {
                 height:                 width
                 source:                 "/qmlimages/arrow-down.png"
                 color:                  qgcPal.text
-                visible:                !control.checked
+                visible:                true
             }
         }
 


### PR DESCRIPTION
## Summary
This PR fixes an issue where the collapse arrow would disappear when expanding a section in Mission Start.

## Changes Made
- Ensured the arrow remains visible at all times, consistent with other UI sections.
- Adjusted the `visible` property in `src/sectionHeader.qml`.

## How to Test
- Expand and collapse sections to verify the arrow remains visible.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.