### PR TITLE
Remove enter key to close dialogs

### DIFF
--- a/src/QmlControls/QGCPopupDialog.qml
+++ b/src/QmlControls/QGCPopupDialog.qml
@@ -263,9 +263,6 @@ Popup {
                         if (event.key === Qt.Key_Escape && _rejectAllowed) {
                             _reject()
                             event.accepted = true
-                        } else if (event.key === Qt.Key_Return || event.key === Qt.Key_Enter) {
-                            _accept()
-                            event.accepted = true
                         }
                     }
                 }


### PR DESCRIPTION
This would lead to unexpected dialog close both on desktop and mobile. But much worse on mobile with virtual keyboard. Also I think with the new Qt version something changed with the virtual keyboard simulating an enter key press.

Fix #12426