### PR TITLE
Note about fuse errors in docker

### DIFF
--- a/docs/en/qgc-dev-guide/getting_started/container.md
+++ b/docs/en/qgc-dev-guide/getting_started/container.md
@@ -57,6 +57,15 @@ docker run --rm -v ${PWD}:/project/source -v ${PWD}/build:/project/build qgc-ubu
 ```
 
 ::: info
+If you get fuse-related errors, you might need to add `--cap-add SYS_ADMIN --device /dev/fuse --security-opt apparmor:unconfined` options to the docker invocation command. Like this:
+
+```
+docker run --rm -v ${PWD}:/project/source -v ${PWD}/build:/project/build --cap-add SYS_ADMIN --device /dev/fuse --security-opt apparmor:unconfined qgc-ubuntu-docker
+```
+
+:::
+
+::: info
 If using the script to build the Linux image on a Windows host, you would need to reference the PWD differently.
 On Windows the docker command is:
 

--- a/docs/en/qgc-dev-guide/getting_started/container.md
+++ b/docs/en/qgc-dev-guide/getting_started/container.md
@@ -57,11 +57,7 @@ docker run --rm -v ${PWD}:/project/source -v ${PWD}/build:/project/build qgc-ubu
 ```
 
 ::: info
-If you get fuse-related errors, you might need to add `--cap-add SYS_ADMIN --device /dev/fuse --security-opt apparmor:unconfined` options to the docker invocation command. Like this:
-
-```
-docker run --rm -v ${PWD}:/project/source -v ${PWD}/build:/project/build --cap-add SYS_ADMIN --device /dev/fuse --security-opt apparmor:unconfined qgc-ubuntu-docker
-```
+For up to date docker command and options reference relevant run-script in `deploy/docker`, for example [run-docker-ubuntu.sh](https://github.com/mavlink/qgroundcontrol/blob/master/deploy/docker/run-docker-ubuntu.sh#L16).
 
 :::
 


### PR DESCRIPTION
Documentation note about fuse in docker

Description
-----------
Some users encounter an error about fuse unable to mount a device during AppImage assembly. Note describes command line options necessary for solving this issue.

Test Steps
-----------
None.

Checklist:
----------
- [x] [Review Contribution Guidelines](https://github.com/mavlink/qgroundcontrol/blob/master/.github/CONTRIBUTING.md).
- [x] [Review Code of Conduct](https://github.com/mavlink/qgroundcontrol/blob/master/.github/CODE_OF_CONDUCT.md).
- [x] I have tested my changes.

Related Issue
-----------
#11565 

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.