### PR TITLE
Fix mission start arrows

### DIFF
--- a/src/QmlControls/SectionHeader.qml
+++ b/src/QmlControls/SectionHeader.qml
@@ -43,7 +43,7 @@ CheckBox {
                 height:                 width
                 source:                 "/qmlimages/arrow-down.png"
                 color:                  qgcPal.text
-                visible:                !control.checked
+                visible:                true
             }
         }
 

--- a/src/QmlControls/SectionHeader.qml
+++ b/src/QmlControls/SectionHeader.qml
@@ -31,19 +31,37 @@ CheckBox {
             visible:                control.showSpacer
         }
 
-        QGCLabel {
-            text:               control.text
-            color:              control.color
-            Layout.fillWidth:   true
+        RowLayout {
+            Layout.fillWidth: true
+            spacing: ScreenTools.defaultFontPixelWidth
+
+            QGCLabel {
+                text:               control.text
+                color:              control.color
+                Layout.fillWidth:   true
+            }
 
             QGCColoredImage {
-                anchors.right:          parent.right
+                id: arrowIcon
                 anchors.verticalCenter: parent.verticalCenter
-                width:                  parent.height / 2
+                width:                  ScreenTools.defaultFontPixelHeight / 2
                 height:                 width
                 source:                 "/qmlimages/arrow-down.png"
                 color:                  qgcPal.text
-                visible:                true
+                rotation:               control.checked ? 0 : -90
+
+                smooth: false  // Prevents unwanted blurring
+                antialiasing: false  // Ensures sharp edges
+                layer.enabled: true  // Helps avoid transparency artifacts
+                layer.smooth: false
+                layer.textureSize: Qt.size(width, height)
+
+                Behavior on rotation {
+                    NumberAnimation {
+                        duration: 120
+                        easing.type: Easing.InOutQuad
+                    }
+                }
             }
         }
 
@@ -55,4 +73,4 @@ CheckBox {
     }
 
     indicator: Item {}
-}
+} 


### PR DESCRIPTION

## **Fix Disappearing Collapse Arrow and Align Rotation with UI Standards**

### **Description**  
This PR fixes an issue where the **collapse arrows** in the Camera, Vehicle Info, and Launch Postition sections in Mission Start would disappear when expanding sections. Additionally, it updates the arrow behavior to follow standard UI practices, where:  
- **Collapsed (default)** → Arrow **points right (-90°)**.  
- **Expanded** → Arrow **points down (0°)**.  

This is consistent with UI/UX conventions in applications like **VS Code**, where collapse/expand arrows follow the **right → down transition**.

#### **Before the UI change**
![Screenshot 2025-02-12 142143](https://github.com/user-attachments/assets/fd1c9e3f-1cd0-4905-85bd-b69ab1cb8a10)

#### **After the UI change**  
![Screenshot 2025-02-12 135051](https://github.com/user-attachments/assets/817f6a96-5c03-45b6-b8d9-1f80f75a835b)

---

### **Test Steps**  
To verify this fix:  
1. Open **QGroundControl**.
2. Click **Q** in top left corner.
3. Click **Plan Flight**.
1. Open **Mission Start** on right side of screen.  
4. Click the collapse arrow to the **Camera** section → Arrow should smoothly rotate **right → down**.  
5. Click again to **collapse** → Arrow should rotate **down → right** and remain visible.  

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution under the terms of your choice.  