### PR TITLE
CI: Update Various Deployment Tools Versions

### DIFF
--- a/.github/actions/qt-android/action.yml
+++ b/.github/actions/qt-android/action.yml
@@ -42,7 +42,7 @@ runs:
       uses: nttld/setup-ndk@v1
       id: setup-ndk
       with:
-        ndk-version: r26b
+        ndk-version: r26d
         add-to-path: false
 
     - run: |

--- a/.github/workflows/custom.yml
+++ b/.github/workflows/custom.yml
@@ -73,7 +73,6 @@ jobs:
         uses: jurplel/install-qt-action@v4
         with:
           version: ${{ env.QT_VERSION }}
-          aqtversion: ==3.1.19
           host: windows
           target: desktop
           arch: win64_msvc2022_64

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -63,9 +63,9 @@ jobs:
       - name: Install Compiler
         run: |
           sudo add-apt-repository ppa:ubuntu-toolchain-r/test
-          sudo apt install gcc-11 g++-11
-          sudo update-alternatives --install /usr/bin/gcc gcc /usr/bin/gcc-11 100 --slave /usr/bin/g++ g++ /usr/bin/g++-11 --slave /usr/bin/gcov gcov /usr/bin/gcov-11
-          sudo update-alternatives --set gcc /usr/bin/gcc-11
+          sudo apt install gcc-13 g++-13
+          sudo update-alternatives --install /usr/bin/gcc gcc /usr/bin/gcc-13 100 --slave /usr/bin/g++ g++ /usr/bin/g++-13 --slave /usr/bin/gcov gcov /usr/bin/gcov-13
+          sudo update-alternatives --set gcc /usr/bin/gcc-13
 
       - name: Setup Caching
         uses: ./.github/actions/cache

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -73,7 +73,6 @@ jobs:
         uses: jurplel/install-qt-action@v4
         with:
           version: ${{ env.QT_VERSION }}
-          aqtversion: ==3.1.19
           host: windows
           target: desktop
           arch: win64_msvc2022_64

--- a/android/gradle/wrapper/gradle-wrapper.properties
+++ b/android/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.12-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.12.1-bin.zip
 networkTimeout=10000
 validateDistributionUrl=true
 zipStoreBase=GRADLE_USER_HOME


### PR DESCRIPTION
Trying to silence Android cmake warning
Better support Linux c++20
Use newer aqt on windows