### PR TITLE
Add collapse arrow animation

### DIFF
--- a/src/QmlControls/SectionHeader.qml
+++ b/src/QmlControls/SectionHeader.qml
@@ -43,7 +43,8 @@ CheckBox {
                 height:                 width
                 source:                 "/qmlimages/arrow-down.png"
                 color:                  qgcPal.text
-                visible:                !control.checked
+                rotation:               control.checked ? 0 : 90
+                Behavior on rotation { NumberAnimation { duration: 200 } }
             }
         }
 


### PR DESCRIPTION
# Description

I noticed that this collapse/expand arrow dissappeared when I clicked on it to expand the section. I feel it is more typical of UI for the arrow to point left when collapsed and down when expanded. 

| **Before** | **After** |
|------------|----------|
| ![beforeUIfix](https://github.com/user-attachments/assets/4d22152a-6d3d-4510-bb6d-b89d94d84408) | ![afterUIfix](https://github.com/user-attachments/assets/633aa177-ef6f-4f41-b666-ccc3aa19bbde) |






# Test Steps
1. Open **QGroundControl**.
2. Click **Q** in top left corner.
3. Click **Plan Flight**.
4. Open **Mission Start** on right side of screen.
5. Click the **Vehicle Info** section header to expand it. Collapse/expand arrow should stay visible and rotate to point downwards.
6. Click the **Vehicle Info** section header again to collapse it. Collapse/expand arrow should stay visible and rotate to point left.
