### PR TITLE
CMake: Fix Android OpenSSL Dependency

### DIFF
--- a/.github/actions/qt-android/action.yml
+++ b/.github/actions/qt-android/action.yml
@@ -42,7 +42,7 @@ runs:
       uses: nttld/setup-ndk@v1
       id: setup-ndk
       with:
-        ndk-version: r26d
+        ndk-version: r26b
         add-to-path: false
 
     - run: |

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -396,7 +396,8 @@ elseif(ANDROID)
     include(CPM)
     CPMAddPackage(
         NAME android_openssl
-        URL https://github.com/KDAB/android_openssl/archive/refs/heads/master.zip
+        GITHUB_REPOSITORY KDAB/android_openssl
+        GIT_TAG master
     )
     include(${android_openssl_SOURCE_DIR}/android_openssl.cmake)
     add_android_openssl_libraries(${CMAKE_PROJECT_NAME})


### PR DESCRIPTION
Was temporarily unavailable using the other link but seems fine now so this may not be needed...
Also testing the NDK version changing the APK size???