### PR TITLE
Fix file Load of EntranceAltitude in StructureScanComplexItem.cc

### DIFF
--- a/src/MissionManager/StructureScanComplexItem.cc
+++ b/src/MissionManager/StructureScanComplexItem.cc
@@ -241,7 +241,7 @@ bool StructureScanComplexItem::load(const QJsonObject& complexObject, int sequen
     _layersFact.setRawValue             (complexObject[layersName].toDouble());
     _structureHeightFact.setRawValue    (complexObject[structureHeightName].toDouble());
     _startFromTopFact.setRawValue       (complexObject[startFromTopName].toBool());
-    _entranceAltFact.setRawValue        (complexObject[startFromTopName].toDouble());
+    _entranceAltFact.setRawValue        (complexObject[_entranceAltName].toDouble());
     _gimbalPitchFact.setRawValue        (complexObject[gimbalPitchName].toDouble());
 
     if (!_structurePolygon.loadFromJson(complexObject, true /* required */, errorString)) {


### PR DESCRIPTION
Entrance altitude does not load form File (structure scan)

Description
-----------
Structure Scan Load File, results in a 0 for EntranceAltitude edit box.
Wrong JSON tag being used to lookup the Entrance Altitude.

"_entranceAltName" is the correct JSON string to use. As seen in ::save()

Test Steps
-----------
Create a Structure Scan plan. (I tested with Circle type, but it shouldn't matter).
Edit the "Entrance Altitude" in the Structure scan editor, to a memorable number.
Save this plan to file.
Clear plan.
Load the plan file.
The Entrance Altitude variable will be 0.

(the plan file has the correct value)

Checklist:
----------
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [ X] [Review Contribution Guidelines](https://github.com/mavlink/qgroundcontrol/blob/master/.github/CONTRIBUTING.md).
- [ X] [Review Code of Conduct](https://github.com/mavlink/qgroundcontrol/blob/master/.github/CODE_OF_CONDUCT.md).
- [ X] I have tested my changes.

Related Issue
-----------
<!-- If any, please provide issue ID. -->


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.