### PR TITLE
Battery: Fix voltages_ext unsupported check

### DIFF
--- a/src/Vehicle/FactGroups/VehicleBatteryFactGroup.cc
+++ b/src/Vehicle/FactGroups/VehicleBatteryFactGroup.cc
@@ -128,7 +128,7 @@ void VehicleBatteryFactGroup::_handleBatteryStatus(Vehicle* vehicle, mavlink_mes
         }
     }
     for (int i=0; i<4; i++) {
-        double cellVoltage = batteryStatus.voltages_ext[i] == UINT16_MAX ? qQNaN() : static_cast<double>(batteryStatus.voltages_ext[i]) / 1000.0;
+        double cellVoltage = batteryStatus.voltages_ext[i] == 0 ? qQNaN() : static_cast<double>(batteryStatus.voltages_ext[i]) / 1000.0;
         if (qIsNaN(cellVoltage)) {
             break;
         }


### PR DESCRIPTION
This was incorrect per mavlink spec. Didn't cause bad total voltage values though. But better to be correct to spec. Just discovered it while working on something else.