### PR TITLE
Restore support for Qt 6.6.3 and Android 7.1

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -198,10 +198,16 @@ if(LINUX)
     find_package(Qt6 ${QT_MINIMUM_VERSION} COMPONENTS WaylandClient)
 endif()
 
+# Set extra standard project setup options for Qt 6.7.0 and above
+set(EXTRA_STANDARD_PROJECT_SETUP_OPTIONS)
+if(QT_VERSION VERSION_GREATER_EQUAL 6.7.0)
+    list(APPEND EXTRA_STANDARD_PROJECT_SETUP_OPTIONS I18N_SOURCE_LANGUAGE en)
+endif()
+
 qt_standard_project_setup(
     REQUIRES ${QGC_QT_MINIMUM_VERSION}
     SUPPORTS_UP_TO ${QGC_QT_MAXIMUM_VERSION}
-    I18N_SOURCE_LANGUAGE en
+    ${EXTRA_STANDARD_PROJECT_SETUP_OPTIONS}
 )
 
 qt_policy(

--- a/android/AndroidManifest.xml
+++ b/android/AndroidManifest.xml
@@ -1,5 +1,6 @@
 <?xml version="1.0"?>
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
+    package="org.mavlink.qgroundcontrol"
     android:installLocation="auto"
     android:versionCode="-- %%INSERT_VERSION_CODE%% --"
     android:versionName="-- %%INSERT_VERSION_NAME%% --">

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -15,7 +15,13 @@ repositories {
     maven { url = 'https://jitpack.io' }
 }
 
-apply plugin: qtGradlePluginType
+if (qtGradlePluginType) {
+    apply plugin: qtGradlePluginType
+} else {
+    // Fall back to the default Android application plugin if qtGradlePluginType
+    // is not available
+    apply plugin: 'com.android.application'
+}
 
 dependencies {
     implementation fileTree(dir: 'libs', include: ['*.jar', '*.aar'])

--- a/cmake/CustomOptions.cmake
+++ b/cmake/CustomOptions.cmake
@@ -46,7 +46,11 @@ option(QGC_DISABLE_PX4_PLUGIN "Disable PX4 Plugin" OFF)
 option(QGC_DISABLE_PX4_PLUGIN_FACTORY "Disable PX4 Plugin Factory" OFF)
 
 # Android
-set(QGC_QT_ANDROID_MIN_SDK_VERSION "28" CACHE STRING "Android Min SDK Version")
+if(QT_VERSION VERSION_GREATER_EQUAL 6.7.0)
+    set(QGC_QT_ANDROID_MIN_SDK_VERSION "28" CACHE STRING "Android Min SDK Version")
+else() # Allow building for Android 7.1 if supported
+    set(QGC_QT_ANDROID_MIN_SDK_VERSION "25" CACHE STRING "Android Min SDK Version")
+endif()
 set(QGC_QT_ANDROID_TARGET_SDK_VERSION "35" CACHE STRING "Android Target SDK Version")
 set(QGC_ANDROID_PACKAGE_NAME "org.mavlink.qgroundcontrol" CACHE STRING "Android Package Name")
 set(QGC_ANDROID_PACKAGE_SOURCE_DIR "${CMAKE_SOURCE_DIR}/android" CACHE PATH "Android Package Path")
@@ -70,7 +74,7 @@ set(QGC_WINDOWS_ICON_PATH "${CMAKE_SOURCE_DIR}/deploy/windows/WindowsQGC.ico" CA
 set(CPM_SOURCE_CACHE ${CMAKE_BINARY_DIR}/cpm_modules CACHE PATH "Directory to download CPM dependencies")
 
 # Qt
-set(QGC_QT_MINIMUM_VERSION "6.8.1" CACHE STRING "Minimum Supported Qt Version")
+set(QGC_QT_MINIMUM_VERSION "6.6.3" CACHE STRING "Minimum Supported Qt Version")
 set(QGC_QT_MAXIMUM_VERSION "6.8.2" CACHE STRING "Maximum Supported Qt Version")
 set(QT_QML_OUTPUT_DIRECTORY "${CMAKE_BINARY_DIR}/qml" CACHE PATH "Install path for QML")
 set(QML_IMPORT_PATH "${QT_QML_OUTPUT_DIRECTORY}" CACHE STRING "Extra QML Import Paths")

--- a/cmake/Install.cmake
+++ b/cmake/Install.cmake
@@ -17,10 +17,16 @@ if(MACOS OR WIN32)
     endif()
 endif()
 
+# Set extra deploy QML app script options for Qt 6.7.0 and above
+set(EXTRA_DEPLOY_QML_APP_SCRIPT_OPTIONS)
+if(QT_VERSION VERSION_GREATER_EQUAL 6.7.0)
+    list(APPEND EXTRA_DEPLOY_QML_APP_SCRIPT_OPTIONS DEPLOY_TOOL_OPTIONS ${deploy_tool_options_arg})
+endif()
+
 qt_generate_deploy_qml_app_script(
     TARGET ${CMAKE_PROJECT_NAME}
     OUTPUT_SCRIPT deploy_script
-    DEPLOY_TOOL_OPTIONS ${deploy_tool_options_arg}
+    ${EXTRA_DEPLOY_QML_APP_SCRIPT_OPTIONS}
     MACOS_BUNDLE_POST_BUILD
     NO_UNSUPPORTED_PLATFORM_ERROR
     DEPLOY_USER_QML_MODULES_ON_UNSUPPORTED_PLATFORM


### PR DESCRIPTION
# Restore support for Qt 6.6.3 and Android 7.1

Description
-----------
Restored support for Qt 6.6.3 while preserving the existing build configuration for the primary supported Qt version (6.8.2). Changed the min. Android SDK version to 25 when the Qt version supports it. This allows targeting Android 7.1-based GCS such as the CubePilot Herelink or the SkyDroid H16.

Key changes:
- Lowered the QGC_QT_MINIMUM_VERSION CMake variable to 6.6.3, the latest Qt version compatible with Android 7.1.
- Disabled the CMake features introduced in Qt versions 6.7 and 6.8 when configuring the project for Qt 6.6.3.
- Updated build.gradle to utilize qtGradlePluginType only when available.
- Reintroduced the "package" attribute in AndroidManifest.xml, which is necessary for Qt 6.6.3 but non-disruptive for the main supported version.

Checklist:
----------
- [X] [Review Contribution Guidelines](https://github.com/mavlink/qgroundcontrol/blob/master/.github/CONTRIBUTING.md).
- [X] [Review Code of Conduct](https://github.com/mavlink/qgroundcontrol/blob/master/.github/CODE_OF_CONDUCT.md).
- [X] I have tested my changes.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.