### PR TITLE
CMake: Add GStreamer Android 32bit Fix

### DIFF
--- a/cmake/find-modules/FindGStreamer.cmake
+++ b/cmake/find-modules/FindGStreamer.cmake
@@ -232,6 +232,9 @@ endif()
 
 if(ANDROID)
     target_link_options(GStreamer::GStreamer INTERFACE "-Wl,-Bsymbolic")
+    if(${ANDROID_ABI} STREQUAL "armeabi-v7a" OR ${ANDROID_ABI} STREQUAL "x86")
+        target_link_options(GStreamer::GStreamer INTERFACE "-Wl,-z,notext")
+    endif()
 endif()
 
 if(QGC_GST_STATIC_BUILD)


### PR DESCRIPTION
I am uncertain if this is required, but it is taken from GStreamer's FindGStreamerMobile