### PR TITLE
Section header position

### DIFF
--- a/src/PlanView/StructureScanEditor.qml
+++ b/src/PlanView/StructureScanEditor.qml
@@ -1,7 +1,6 @@
 import QtQuick
 import QtQuick.Controls
 import QtQuick.Dialogs
-import QtQuick.Extras
 import QtQuick.Layouts
 
 import QGroundControl

--- a/src/QmlControls/SectionHeader.qml
+++ b/src/QmlControls/SectionHeader.qml
@@ -6,9 +6,10 @@ import QGroundControl.ScreenTools
 import QGroundControl.Palette
 
 CheckBox {
-    id:         control
-    focusPolicy: Qt.ClickFocus
-    checked:    true
+    id:             control
+    focusPolicy:    Qt.ClickFocus
+    checked:        true
+    leftPadding:    0
 
     property var            color:          qgcPal.text
     property bool           showSpacer:     true


### PR DESCRIPTION
Section header wasn't left-aligned correctly.

Before and after:
<img width="243" alt="Screenshot 2025-02-16 at 10 46 07 AM" src="https://github.com/user-attachments/assets/bc6d0dba-5356-48c3-9405-85640c4c40b2" /><img width="243" alt="Screenshot 2025-02-16 at 10 45 31 AM" src="https://github.com/user-attachments/assets/a5a11a2d-b09a-4de1-b4e4-13a34ab617a7" />
