### PR TITLE
Fix: Prevent events from passing through ValueSlider to the map

### DIFF
--- a/src/QmlControls/ValueSlider.qml
+++ b/src/QmlControls/ValueSlider.qml
@@ -128,6 +128,14 @@ Control {
         colorGroupEnabled:  control.enabled
     }
 
+    // This TapHandler ensures that the slider captures touch and click events,
+    // preventing them from passing through to the underlying map.
+    TapHandler {
+        acceptedButtons: Qt.AllButtons
+        onTapped: control.forceActiveFocus()
+        grabPermissions: PointerHandler.CanTakeOverFromAnything
+    }
+
     background: Item {
         implicitHeight: _majorTickSize + tickValueMargin + ScreenTools.defaultFontPixelHeight + labelOffset
         clip:           true


### PR DESCRIPTION
Fix for https://github.com/mavlink/qgroundcontrol/issues/12453
The previous fix mentioned in this PR https://github.com/mavlink/qgroundcontrol/pull/12464 does not work as expected

