### PR TITLE
Fly View Toolbar: Add right margin for better visuals when scrolling

### DIFF
--- a/src/UI/toolbar/FlyViewToolBar.qml
+++ b/src/UI/toolbar/FlyViewToolBar.qml
@@ -86,6 +86,7 @@ Rectangle {
     QGCFlickable {
         id:                     toolsFlickable
         anchors.leftMargin:     ScreenTools.defaultFontPixelWidth * ScreenTools.largeFontPointRatio * 1.5
+        anchors.rightMargin:    ScreenTools.defaultFontPixelWidth / 2
         anchors.left:           viewButtonRow.right
         anchors.bottomMargin:   1
         anchors.top:            parent.top


### PR DESCRIPTION
Fix #11562