### PR TITLE
Fix crowdin for docs - download workflow

### DIFF
--- a/.github/workflows/crowdin_download.yml
+++ b/.github/workflows/crowdin_download.yml
@@ -1,0 +1,40 @@
+name: Crowdin - Download Translations
+
+# https://github.com/crowdin/github-action/tree/master
+
+on:
+  workflow_dispatch:
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  synchronize-with-crowdin:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: crowdin action
+        uses: crowdin/github-action@v2
+        with:
+          config: 'docs/crowdin.yml'
+          upload_sources: false
+          upload_translations: false
+          download_translations: true
+          localization_branch_name: l10n_crowdin_docs_translations
+          create_pull_request: true
+          pull_request_title: 'New QGC guide translations (Crowdin)'
+          pull_request_body: 'New QGC guide Crowdin translations by [Crowdin GH Action](https://github.com/crowdin/github-action)'
+          pull_request_base_branch_name: 'main'
+        env:
+          # A classic GitHub Personal Access Token with the 'repo' scope selected (the user should have write access to the repository).
+          GITHUB_TOKEN: ${{ secrets.PX4BUILDBOT_ACCESSTOKEN }}
+
+          # A numeric ID, found at https://crowdin.com/project/<projectName>/tools/api
+          CROWDIN_PROJECT_ID: ${{ secrets.CROWDIN_DOCS_PROJECT_ID }}
+
+          # Visit https://crowdin.com/settings#api-key to create this token
+          CROWDIN_PERSONAL_TOKEN: ${{ secrets.PX4BUILDBOT_CROWDIN_PERSONAL_TOKEN }}

--- a/crowdin_docs.yml
+++ b/crowdin_docs.yml
@@ -1,3 +1,0 @@
-files:
-  - source: /docs/en/**/*.md
-    translation: /docs/%two_letters_code%/**/%original_file_name%

--- a/docs/crowdin.yml
+++ b/docs/crowdin.yml
@@ -1,0 +1,12 @@
+"project_id_env": "CROWDIN_PROJECT_ID"
+"api_token_env": "CROWDIN_PERSONAL_TOKEN"
+"base_path": "../"
+
+"preserve_hierarchy": true
+
+"files": [
+  {
+    "source": "/docs/en/**/*.md",
+    "translation": "/docs/%two_letters_code%/**/%original_file_name%"
+  }
+]


### PR DESCRIPTION
Crowdin currently works for getting QGC strings but not for docs. This is because the default integration only expects one integration and looks for the definition of that file in the root as `crowdin.yml`. 

This uses the GitHub crowdin action to separately manage the docs: https://github.com/crowdin/github-action/tree/master?tab=readme-ov-file#github-crowdin-action-

This is the first part, a test to download any translations into a docs PR. Initially this is an action that has to be manually triggered. We might add support for sync job after.

Note, this uses three access tokens: PX4BUILDBOT_ACCESSTOKEN (already in repo, might not work), CROWDIN_DOCS_PROJECT_ID , PX4BUILDBOT_CROWDIN_PERSONAL_TOKEN 