### PR TITLE
Fix "Change Airspeed" guided action

### DIFF
--- a/src/FirmwarePlugin/APM/APMFirmwarePlugin.cc
+++ b/src/FirmwarePlugin/APM/APMFirmwarePlugin.cc
@@ -1203,7 +1203,7 @@ QMutex& APMFirmwarePlugin::_reencodeMavlinkChannelMutex()
 
 double APMFirmwarePlugin::maximumEquivalentAirspeed(Vehicle* vehicle)
 {
-    QString airspeedMax("ARSPD_FBW_MAX");
+    QString airspeedMax("r.AIRSPEED_MAX");
 
     if (vehicle->parameterManager()->parameterExists(ParameterManager::defaultComponentId, airspeedMax)) {
         return vehicle->parameterManager()->getParameter(ParameterManager::defaultComponentId, airspeedMax)->rawValue().toDouble();
@@ -1214,7 +1214,7 @@ double APMFirmwarePlugin::maximumEquivalentAirspeed(Vehicle* vehicle)
 
 double APMFirmwarePlugin::minimumEquivalentAirspeed(Vehicle* vehicle)
 {
-    QString airspeedMin("ARSPD_FBW_MIN");
+    QString airspeedMin("r.AIRSPEED_MIN");
 
     if (vehicle->parameterManager()->parameterExists(ParameterManager::defaultComponentId, airspeedMin)) {
         return vehicle->parameterManager()->getParameter(ParameterManager::defaultComponentId, airspeedMin)->rawValue().toDouble();
@@ -1225,8 +1225,8 @@ double APMFirmwarePlugin::minimumEquivalentAirspeed(Vehicle* vehicle)
 
 bool APMFirmwarePlugin::fixedWingAirSpeedLimitsAvailable(Vehicle* vehicle)
 {
-    return vehicle->parameterManager()->parameterExists(ParameterManager::defaultComponentId, "ARSPD_FBW_MIN") &&
-           vehicle->parameterManager()->parameterExists(ParameterManager::defaultComponentId, "ARSPD_FBW_MAX");
+    return vehicle->parameterManager()->parameterExists(ParameterManager::defaultComponentId, "r.AIRSPEED_MIN") &&
+           vehicle->parameterManager()->parameterExists(ParameterManager::defaultComponentId, "r.AIRSPEED_MAX");
 }
 
 void APMFirmwarePlugin::guidedModeChangeEquivalentAirspeedMetersSecond(Vehicle* vehicle, double airspeed_equiv)

--- a/src/FirmwarePlugin/APM/ArduPlaneFirmwarePlugin.cc
+++ b/src/FirmwarePlugin/APM/ArduPlaneFirmwarePlugin.cc
@@ -104,8 +104,13 @@ ArduPlaneFirmwarePlugin::ArduPlaneFirmwarePlugin(void)
     if (!_remapParamNameIntialized) {
         FirmwarePlugin::remapParamNameMap_t& remapV3_10 = _remapParamName[3][10];
 
-        remapV3_10["BATT_ARM_VOLT"] =    QStringLiteral("ARMING_VOLT_MIN");
-        remapV3_10["BATT2_ARM_VOLT"] =   QStringLiteral("ARMING_VOLT2_MIN");
+        remapV3_10["BATT_ARM_VOLT"] =   QStringLiteral("ARMING_VOLT_MIN");
+        remapV3_10["BATT2_ARM_VOLT"] =  QStringLiteral("ARMING_VOLT2_MIN");
+
+        FirmwarePlugin::remapParamNameMap_t& remapV4_5 = _remapParamName[4][5];
+
+        remapV4_5["AIRSPEED_MIN"] =     QStringLiteral("ARSPD_FBW_MIN");
+        remapV4_5["AIRSPEED_MAX"] =     QStringLiteral("ARSPD_FBW_MAX");
 
         _remapParamNameIntialized = true;
     }
@@ -113,8 +118,8 @@ ArduPlaneFirmwarePlugin::ArduPlaneFirmwarePlugin(void)
 
 int ArduPlaneFirmwarePlugin::remapParamNameHigestMinorVersionNumber(int majorVersionNumber) const
 {
-    // Remapping supports up to 3.10
-    return majorVersionNumber == 3 ? 10 : Vehicle::versionNotSetValue;
+    // Remapping supports up to 4.5
+    return majorVersionNumber == 4 ? 5 : Vehicle::versionNotSetValue;
 }
 
 QString ArduPlaneFirmwarePlugin::stabilizedFlightMode() const

--- a/src/FlightDisplay/GuidedActionsController.qml
+++ b/src/FlightDisplay/GuidedActionsController.qml
@@ -231,7 +231,7 @@ Item {
                     GuidedValueSlider.SliderType.Speed,
                     _unitsConversion.metersSecondToAppSettingsSpeedUnits(_activeVehicle.minimumEquivalentAirspeed()).toFixed(1),
                     _unitsConversion.metersSecondToAppSettingsSpeedUnits(_activeVehicle.maximumEquivalentAirspeed()).toFixed(1),
-                    _unitsConversion.metersSecondToAppSettingsSpeedUnits(_activeVehicle.minimumEquivalentAirspeed()).toFixed(1),
+                    _unitsConversion.metersSecondToAppSettingsSpeedUnits(_activeVehicle.airSpeed.rawValue),
                     qsTr("Airspeed"))
             } else if (!_fixedWing && _activeVehicle.haveMRSpeedLimits) {
                 guidedValueSlider.setupSlider(


### PR DESCRIPTION
# Fix "Change Airspeed" guided action

Description
-----------
This PR restores the "Change Airspeed" Guided mode action for ArduPilot fixed-wing aircraft, which was inadvertently disabled due to changes in ArduPilot's parameter names. Additionally, it updates the airspeed slider's default value to the current airspeed, for consistency with the "Change Altitude" action.

### [Support new APM airspeed limits parameter names](https://github.com/mavlink/qgroundcontrol/commit/5b49f49615e24a965685d1e241a609352206cef4):
Added support for updated maximum and minimum airspeed parameter names in ArduPilot. This restores the "Change Airspeed" Guided mode action. Compatibility with the previous parameter names has been maintained.

### [Set airspeed slider default to current airspeed](https://github.com/mavlink/qgroundcontrol/commit/d6e57dfca0ffe14b4c3b4bd7a666191275118705):
Made the default value of the airspeed slider in the "Change Airspeed" Guided mode action match the current airspeed, to match the behavior of the "Change Altitude" action.

Checklist:
----------
- [X] [Review Contribution Guidelines](https://github.com/mavlink/qgroundcontrol/blob/master/.github/CONTRIBUTING.md).
- [X] [Review Code of Conduct](https://github.com/mavlink/qgroundcontrol/blob/master/.github/CODE_OF_CONDUCT.md).
- [X] I have tested my changes.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.