### PR TITLE
Fix map panning yet again

### DIFF
--- a/src/FlightMap/FlightMap.qml
+++ b/src/FlightMap/FlightMap.qml
@@ -146,27 +146,54 @@ Map {
         property:           "zoomLevel"
     }
 
-    DragHandler {
-        target: null
+    // We specifically do not use a DragHandler for panning. It just causes too many problems if you overlay anything else like a Flickable above it.
+    // Causes all sorts of crazy problems where dragging/scrolling  no longerr works on items above in the hierarchy.
+    // Since we are using a MouseArea we also can't use TapHandler for clicks. So we handle that here as well.
+    MultiPointTouchArea {
+        anchors.fill: parent
+        maximumTouchPoints: 1
+        mouseEnabled: true
 
-        onActiveChanged: {
-            if (active) {
-                mapPanStart()
-            } else {
-                mapPanStop()
+        property bool dragActive: false
+        property real lastMouseX
+        property real lastMouseY
+
+        onPressed: (touchPoints) => {
+            console.log("onPressed", touchPoints[0].x, touchPoints[0].y)
+            lastMouseX = touchPoints[0].x
+            lastMouseY = touchPoints[0].y
+        }
+
+        onGestureStarted: (gesture) => {
+            dragActive = true
+            gesture.grab()
+            mapPanStart()
+        }
+
+        onUpdated: (touchPoints) => {
+            console.log("onUpdated", touchPoints[0].x, touchPoints[0].y, lastMouseX, lastMouseY)
+            if (dragActive) {
+                let deltaX = touchPoints[0].x - lastMouseX
+                let deltaY = touchPoints[0].y - lastMouseY
+                if (Math.abs(deltaX) >= 1.0 || Math.abs(deltaY) >= 1.0) {
+                    _map.pan(lastMouseX - touchPoints[0].x, lastMouseY - touchPoints[0].y)
+                    lastMouseX = touchPoints[0].x
+                    lastMouseY = touchPoints[0].y
+                }
             }
         }
 
-        onActiveTranslationChanged: (delta) => {
-            console.log("onActiveTranslationChanged", delta)
-            _map.pan(-delta.x, -delta.y)
+        onReleased: (touchPoints) => {
+            if (dragActive) {
+                _map.pan(lastMouseX - touchPoints[0].x, lastMouseY - touchPoints[0].y)
+                dragActive = false
+                mapPanStop()
+            } else {
+                mapClicked(Qt.point(touchPoints[0].x, touchPoints[0].y))
+            }
         }
     }
 
-    TapHandler {
-        onTapped: (eventPoint) => mapClicked(eventPoint.position)
-    }
-    
     /// Ground Station location
     MapQuickItem {
         anchorPoint.x:  sourceItem.width / 2


### PR DESCRIPTION
Simplest explanation is that using DragHandler's don't work if you ever overlay any other Qml over it in the hierarchy. Qt bug report list is littered with bug reports of people having similar problems. With only clear as mud responses/excuses/explanations of how to work around it. My take is DragHandler's are broken and shouldn't be used.