### PR TITLE
fix default path for qt-cmake for source build

### DIFF
--- a/docs/en/qgc-dev-guide/getting_started/index.md
+++ b/docs/en/qgc-dev-guide/getting_started/index.md
@@ -137,7 +137,7 @@ Example commands to build a default QGC and run it afterwards:
 1. Configure:
 
    ```sh
-	/Qt/6.8.2/gcc_64/bin/qt-cmake -B build -G Ninja -DCMAKE_BUILD_TYPE=Debug
+   ~/Qt/6.8.2/gcc_64/bin/qt-cmake -B build -G Ninja -DCMAKE_BUILD_TYPE=Debug
    ```
 
    Change the directory for qt-cmake to match your install location for Qt and the kit you want to use.


### PR DESCRIPTION
<!--- Title -->

Description
-----------
By default the qt installation go into the users home folder. This fixes the command to take the default qt installation path.

Test Steps
-----------
1. Go to cloned qgroundcontrol folder
2. Run **~/Qt/6.8.2/gcc_64/bin/qt-cmake -B build -G Ninja -DCMAKE_BUILD_TYPE=Debug**

Checklist:
----------
- [x] [Review Contribution Guidelines](https://github.com/mavlink/qgroundcontrol/blob/master/.github/CONTRIBUTING.md).
- [x] [Review Code of Conduct](https://github.com/mavlink/qgroundcontrol/blob/master/.github/CODE_OF_CONDUCT.md).
- [x] I have tested my changes.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.