### PR TITLE
Flight mode config no longer warning about not being configured

### DIFF
--- a/src/AutoPilotPlugins/PX4/FlightModesComponent.cc
+++ b/src/AutoPilotPlugins/PX4/FlightModesComponent.cc
@@ -41,33 +41,6 @@ QString FlightModesComponent::iconResource(void) const
     return "/qmlimages/FlightModesComponentIcon.png";
 }
 
-bool FlightModesComponent::requiresSetup(void) const
-{
-    return _vehicle->parameterManager()->getParameter(-1, "COM_RC_IN_MODE")->rawValue().toInt() == 1 ? false : true;
-}
-
-bool FlightModesComponent::setupComplete(void) const
-{
-    if (_vehicle->parameterManager()->getParameter(-1, "COM_RC_IN_MODE")->rawValue().toInt() == 1) {
-        return true;
-    }
-
-    if (_vehicle->parameterManager()->parameterExists(ParameterManager::defaultComponentId, "RC_MAP_FLTMODE") && _vehicle->parameterManager()->getParameter(ParameterManager::defaultComponentId, "RC_MAP_FLTMODE")->rawValue().toInt() != 0) {
-        return true;
-    }
-
-    return false;
-}
-
-QStringList FlightModesComponent::setupCompleteChangedTriggerList(void) const
-{
-    QStringList list;
-
-    list << QStringLiteral("RC_MAP_MODE_SW") << QStringLiteral("RC_MAP_FLTMODE");
-
-    return list;
-}
-
 QUrl FlightModesComponent::setupSource(void) const
 {
     return QUrl::fromUserInput("qrc:/qml/PX4FlightModes.qml");

--- a/src/AutoPilotPlugins/PX4/FlightModesComponent.h
+++ b/src/AutoPilotPlugins/PX4/FlightModesComponent.h
@@ -23,17 +23,15 @@ class FlightModesComponent : public VehicleComponent
 public:
     FlightModesComponent(Vehicle* vehicle, AutoPilotPlugin* autopilot, QObject* parent = nullptr);
     
-    // Virtuals from VehicleComponent
-    virtual QStringList setupCompleteChangedTriggerList(void) const;
-    
-    // Virtuals from VehicleComponent
-    virtual QString name(void) const;
-    virtual QString description(void) const;
-    virtual QString iconResource(void) const;
-    virtual bool requiresSetup(void) const;
-    virtual bool setupComplete(void) const;
-    virtual QUrl setupSource(void) const;
-    virtual QUrl summaryQmlSource(void) const;
+    // Overrides from VehicleComponent
+    QString name(void) const final;
+    QString description(void) const final;
+    QString iconResource(void) const final;
+    QUrl setupSource(void) const final;
+    QUrl summaryQmlSource(void) const final;
+    bool requiresSetup() const final { return false; }
+    bool setupComplete() const final { return true; }
+    QStringList setupCompleteChangedTriggerList() const final { return QStringList(); }
     
 private:
     const QString   _name;


### PR DESCRIPTION
Given the prevalence of things like Joysticks, Android controllers and the fact that you can change flight modes all you want from the QGC ui. It is not longer required to setup flight modes on an RC Transmitter channel.