### PR TITLE
Fix value sliders to be numeric only text felds

### DIFF
--- a/src/FlightDisplay/GuidedValueSlider.qml
+++ b/src/FlightDisplay/GuidedValueSlider.qml
@@ -278,6 +278,7 @@ Item {
             showUnits:          true
             unitsLabel:         valueLabel.unitsString
             visible:            false
+            numericValuesOnly:  true
 
             onEditingFinished: {
                 visible = false

--- a/src/QmlControls/ValueSlider.qml
+++ b/src/QmlControls/ValueSlider.qml
@@ -293,6 +293,7 @@ Control {
                 showUnits:          true
                 unitsLabel:         unitsString
                 visible:            false
+                numericValuesOnly:  true
 
                 onEditingFinished: {
                     visible = false


### PR DESCRIPTION
When you click on the slider value the text field shouldn't show a full keyboard on mobile. Only a numeric keyboard.