### PR TITLE
Small GeoFenceManager fixes

### DIFF
--- a/src/MissionManager/GeoFenceManager.cc
+++ b/src/MissionManager/GeoFenceManager.cc
@@ -154,7 +154,7 @@ void GeoFenceManager::_planManagerLoadComplete(bool removeAllRequested)
                 // In the middle of a polygon, but count suddenly changed
                 emit error(BadPolygonItemFormat, tr("GeoFence load: Vertex count change mid-polygon - actual:expected").arg(item->param1()).arg(expectedVertexCount));
                 break;
-            } if (expectedCommand != command) {
+            } else if (expectedCommand != command) {
                 // Command changed before last polygon was completely loaded
                 emit error(BadPolygonItemFormat, tr("GeoFence load: Polygon type changed before last load complete - actual:expected").arg(command).arg(expectedCommand));
                 break;

--- a/src/MissionManager/GeoFenceManager.cc
+++ b/src/MissionManager/GeoFenceManager.cc
@@ -152,11 +152,11 @@ void GeoFenceManager::_planManagerLoadComplete(bool removeAllRequested)
                 expectedCommand = command;
             } else if (expectedVertexCount != item->param1()){
                 // In the middle of a polygon, but count suddenly changed
-                emit error(BadPolygonItemFormat, tr("GeoFence load: Vertex count change mid-polygon - actual:expected").arg(item->param1()).arg(expectedVertexCount));
+                emit error(BadPolygonItemFormat, tr("GeoFence load: Vertex count change mid-polygon - actual:expected") + QString(" %1:%2").arg(item->param1()).arg(expectedVertexCount));
                 break;
             } else if (expectedCommand != command) {
                 // Command changed before last polygon was completely loaded
-                emit error(BadPolygonItemFormat, tr("GeoFence load: Polygon type changed before last load complete - actual:expected").arg(command).arg(expectedCommand));
+                emit error(BadPolygonItemFormat, tr("GeoFence load: Polygon type changed before last load complete - actual:expected") + QString(" %1:%2").arg(command).arg(expectedCommand));
                 break;
             }
             nextPolygon.appendVertex(QGeoCoordinate(item->param5(), item->param6()));


### PR DESCRIPTION
Description
-----------
This PR fixes 2 tiny issues:
1. an unclear `if-else if-else` tree that is written as `if-else if-if(?)`
2. right after that there is an `emit error(BadPolygonItemFormat, [QString])` where the `QString` part promises actual vs expected value but never delivers on this promise. Not wanting to break existing translations I added a `+ QString(" %1:%2")` right before the `.arg(...).arg(...)` to make sure the promised values are printed.

Test Steps
-----------
Visual inspection and successful compilation.

Checklist:
----------
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] [Review Contribution Guidelines](https://github.com/mavlink/qgroundcontrol/blob/master/.github/CONTRIBUTING.md).
- [x] [Review Code of Conduct](https://github.com/mavlink/qgroundcontrol/blob/master/.github/CODE_OF_CONDUCT.md).
- [x] I have tested my changes.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.