### PR TITLE
Fix radius reset when editing FW Landing Patterns

### DIFF
--- a/src/PlanView/FWLandingPatternEditor.qml
+++ b/src/PlanView/FWLandingPatternEditor.qml
@@ -41,7 +41,7 @@ Rectangle {
     property string _setToVehicleLocationStr:   qsTr("Set to vehicle location")
     property bool   _showCameraSection:         !_missionVehicle.apmFirmware
     property int    _altitudeMode:              missionItem.altitudesAreRelative ? QGroundControl.AltitudeModeRelative : QGroundControl.AltitudeModeAbsolute
-    property real   _previousLoiterRadius:      0
+    property real   _previousLoiterRadius:      missionItem.loiterRadius.rawValue
 
     Column {
         id:                 editorColumn
@@ -70,16 +70,18 @@ Rectangle {
                 text:       qsTr("Use loiter to altitude")
                 fact:       missionItem.useLoiterToAlt
 
+                Component.onCompleted: {
+                    if (!missionItem.useLoiterToAlt.rawValue) {
+                        _previousLoiterRadius = missionItem.loiterRadius.defaultValue
+                    }
+                }
+
                 // When not using loiter to altitude, set radius to 0 to set the
                 // glide slope heading correctly
                 onCheckedChanged: {
                     if (checked) {
-                        // Restore the previous loiter radius or set the default value
-                        if (_previousLoiterRadius > 0) {
-                            missionItem.loiterRadius.rawValue = _previousLoiterRadius
-                        } else {
-                            missionItem.loiterRadius.rawValue = missionItem.loiterRadius.defaultValue
-                        }
+                        // Restore the previous loiter radius
+                        missionItem.loiterRadius.rawValue = _previousLoiterRadius
                     } else {
                         _previousLoiterRadius = missionItem.loiterRadius.rawValue
                         missionItem.loiterRadius.rawValue = 0


### PR DESCRIPTION
# Fix radius reset when editing FW Landing Patterns

Description
-----------
Resolved an issue where the loiter radius of a fixed-wing Landing Pattern would revert back to its default value when starting to edit the mission item.

Checklist:
----------
- [X] [Review Contribution Guidelines](https://github.com/mavlink/qgroundcontrol/blob/master/.github/CONTRIBUTING.md).
- [X] [Review Code of Conduct](https://github.com/mavlink/qgroundcontrol/blob/master/.github/CODE_OF_CONDUCT.md).
- [X] I have tested my changes.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.