### PR TITLE
Fix Loiter (time) mission command for ArduPlane

### DIFF
--- a/src/FirmwarePlugin/APM/APM-MavCmdInfoFixedWing.json
+++ b/src/FirmwarePlugin/APM/APM-MavCmdInfoFixedWing.json
@@ -10,6 +10,11 @@
             "paramRemove":  "1,3,4"
         },
         {
+            "id":           19,
+            "comment":      "MAV_CMD_NAV_LOITER_TIME",
+            "paramRemove":  "2,3"
+        },
+        {
             "id":           21,
             "comment":      "MAV_CMD_NAV_LAND",
             "paramRemove":  "4"

--- a/src/MissionManager/SimpleMissionItem.cc
+++ b/src/MissionManager/SimpleMissionItem.cc
@@ -537,6 +537,18 @@ bool SimpleMissionItem::isLoiterItem() const
 
 bool SimpleMissionItem::showLoiterRadius() const
 {
+    const MissionCommandUIInfo *uiInfo =
+        MissionCommandTree::instance()->getUIInfo(
+            _controllerVehicle, _previousVTOLMode, MAV_CMD_NAV_LOITER_TIME);
+    bool showUI;
+    uiInfo->getParamInfo(3, showUI);
+
+    if (isLoiterItem() && command() == MAV_CMD_NAV_LOITER_TIME && !showUI) {
+        // Don't show the radius of MAV_CMD_NAV_LOITER_TIME items if the
+        // firmware doesn't support specifying it
+        return false;
+    }
+
     return specifiesCoordinate() && (_controllerVehicle->fixedWing() || _controllerVehicle->vtol()) && isLoiterItem();
 }
 


### PR DESCRIPTION
# Fix Loiter (time) mission command for ArduPlane

Description
-----------
ArduPlane does not support the radius or heading required parameters in the MAV_CMD_NAV_LOITER_TIME command, [as seen in the source code](https://github.com/ArduPilot/ardupilot/blob/1f51cb395e0453b87c2f94a807b848ca2bda9718/libraries/AP_Mission/AP_Mission.cpp#L1129-L1133).

Marked those parameters as removed in APM-MavCmdInfoFixedWing.json and updated the loiter radius visibility to not show for ArduPlane Loiter (time) mission items.

Checklist:
----------
- [X] [Review Contribution Guidelines](https://github.com/mavlink/qgroundcontrol/blob/master/.github/CONTRIBUTING.md).
- [X] [Review Code of Conduct](https://github.com/mavlink/qgroundcontrol/blob/master/.github/CODE_OF_CONDUCT.md).
- [X] I have tested my changes.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.