### PR TITLE
Turn release debug logging back on

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -148,7 +148,6 @@ if(CMAKE_BUILD_TYPE STREQUAL "Release")
     add_compile_definitions(
         NDEBUG
         QT_NO_DEBUG
-        QT_NO_DEBUG_OUTPUT
     )
 elseif(CMAKE_BUILD_TYPE STREQUAL "Debug")
     include(CTest)


### PR DESCRIPTION
QT_NO_DEBUG_OUTPUT kills the availability of any qDebug logging in Release builds, include categorized logging which is the primary remote debugging tool
