### PR TITLE
Mavlink development dialect

### DIFF
--- a/cmake/CustomOptions.cmake
+++ b/cmake/CustomOptions.cmake
@@ -34,7 +34,7 @@ option(QGC_ENABLE_QT_VIDEOSTREAMING "Enable QtMultimedia Video Backend" OFF) # Q
 
 # MAVLink
 set(QGC_MAVLINK_GIT_REPO "https://github.com/mavlink/c_library_v2.git" CACHE STRING "URL to MAVLink Git Repo")
-set(QGC_MAVLINK_GIT_TAG "b71f061a53941637cbcfc5bcf860f96bc82e0892" CACHE STRING "Tag of MAVLink Git Repo")
+set(QGC_MAVLINK_GIT_TAG "7ea034366ee7f09f3991a5b82f51f0c259023b38" CACHE STRING "Tag of MAVLink Git Repo")
 
 # APM
 option(QGC_DISABLE_APM_MAVLINK "Disable APM Dialect" OFF)

--- a/src/MAVLink/CMakeLists.txt
+++ b/src/MAVLink/CMakeLists.txt
@@ -51,11 +51,13 @@ CPMAddPackage(
     GIT_TAG ${QGC_MAVLINK_GIT_TAG}
 )
 
+# For QGC all dialects means common and development. Though use of development mavlink code should be restricted to debug builds only.
 target_include_directories(MAVLink
     PUBLIC
         ${mavlink_SOURCE_DIR}
         ${mavlink_SOURCE_DIR}/all
         ${mavlink_SOURCE_DIR}/common
+        ${mavlink_SOURCE_DIR}/development
 )
 
 # if(CMAKE_CXX_COMPILER_ID STREQUAL "GNU")


### PR DESCRIPTION
* Related to #12410
* Added back development mavlink dialect
* Bumped mavlink headers to latest

This brings things back to where they were with previous stable