### PR TITLE
Advanced mode cleanup

### DIFF
--- a/src/AutoPilotPlugins/AutoPilotPlugin.h
+++ b/src/AutoPilotPlugins/AutoPilotPlugin.h
@@ -55,8 +55,11 @@ public:
     /// Returns the name of the vehicle component which must complete setup prior to this one. Empty string for none.
     Q_INVOKABLE virtual QString prerequisiteSetup(VehicleComponent *component) const = 0;
 
-    Q_INVOKABLE VehicleComponent *findKnownVehicleComponent(KnownVehicleComponent knownVehicleComponent);
+    /// Returns true if the vehicle component is available for the vehicle. Customs build have different components.
     Q_INVOKABLE bool knownVehicleComponentAvailable(KnownVehicleComponent knownVehicleComponent) { return (findKnownVehicleComponent(knownVehicleComponent) != nullptr); }
+
+    /// Returns the VehicleComponent for the knownVehicleComponent. Returns nullptr if not available.
+    Q_INVOKABLE VehicleComponent *findKnownVehicleComponent(KnownVehicleComponent knownVehicleComponent);
 
     bool setupComplete() const { return _setupComplete; }
 

--- a/src/FirmwarePlugin/APM/APMMainStatusIndicatorContentItem.qml
+++ b/src/FirmwarePlugin/APM/APMMainStatusIndicatorContentItem.qml
@@ -25,11 +25,11 @@ ColumnLayout {
     FactPanelController { id: controller }
 
     SettingsGroupLayout {
-        heading:            qsTr("Ground Control Data Link Failsafe")
+        heading:            qsTr("Ground Control Comm Loss Failsafe")
         Layout.fillWidth:   true
 
         LabelledFactComboBox {
-            label:      qsTr("Action")
+            label:      qsTr("Vehicle Action")
             fact:       controller.getParameterFact(-1, "FS_GCS_ENABLE")
             indexModel: false
         }

--- a/src/FirmwarePlugin/PX4/PX4FlightModeIndicator.qml
+++ b/src/FirmwarePlugin/PX4/PX4FlightModeIndicator.qml
@@ -50,15 +50,6 @@ FlightModeIndicator {
                     to:                     fact.maxIsDefaultForType ? QGroundControl.unitsConversion.metersToAppSettingsVerticalDistanceUnits(121.92) : fact.max
                     majorTickStepSize:      10
                 }
-
-                FactSlider {
-                    Layout.fillWidth:       true
-                    label:                  qsTr("Land Descent Rate")
-                    fact:                   mpcLandSpeedFact
-                    to:                     fact.maxIsDefaultForType ? QGroundControl.unitsConversion.metersToAppSettingsVerticalDistanceUnits(4) : fact.max
-                    majorTickStepSize:      0.5
-                    visible:                mpcLandSpeedFact && controller.vehicle && !controller.vehicle.fixedWing
-                }
             }
 
             SettingsGroupLayout {

--- a/src/FirmwarePlugin/PX4/PX4MainStatusIndicatorContentItem.qml
+++ b/src/FirmwarePlugin/PX4/PX4MainStatusIndicatorContentItem.qml
@@ -25,7 +25,7 @@ ColumnLayout {
     FactPanelController { id: controller }
 
     SettingsGroupLayout {
-        heading:            qsTr("Ground Control Data Link Failsafe")
+        heading:            qsTr("Ground Control Comm Loss Failsafe")
         Layout.fillWidth:   true
 
         RowLayout {
@@ -34,7 +34,7 @@ ColumnLayout {
 
             QGCLabel {
                 Layout.fillWidth:   true;
-                text:               qsTr("Action")
+                text:               qsTr("Vehicle Action")
             }
             FactComboBox {
                 id:                     failsafeActionCombo

--- a/src/UI/toolbar/BatteryIndicator.qml
+++ b/src/UI/toolbar/BatteryIndicator.qml
@@ -399,7 +399,8 @@ Item {
             }
 
             SettingsGroupLayout {
-                visible: _activeVehicle.autopilotPlugin.knownVehicleComponentAvailable(AutoPilotPlugin.KnownPowerVehicleComponent)
+                visible: _activeVehicle.autopilotPlugin.knownVehicleComponentAvailable(AutoPilotPlugin.KnownPowerVehicleComponent) &&
+                            QGroundControl.corePlugin.showAdvancedUI
 
                 LabelledButton {
                     label:      qsTr("Vehicle Power")

--- a/src/UI/toolbar/FlightModeIndicator.qml
+++ b/src/UI/toolbar/FlightModeIndicator.qml
@@ -220,7 +220,8 @@ RowLayout {
                     Layout.fillWidth:   true
                     label:              qsTr("Flight Modes")
                     buttonText:         qsTr("Configure")
-                    visible:            _activeVehicle.autopilotPlugin.knownVehicleComponentAvailable(AutoPilotPlugin.KnownFlightModesVehicleComponent)
+                    visible:            _activeVehicle.autopilotPlugin.knownVehicleComponentAvailable(AutoPilotPlugin.KnownFlightModesVehicleComponent) &&
+                                            QGroundControl.corePlugin.showAdvancedUI
 
                     onClicked: {
                         mainWindow.showKnownVehicleComponentConfigPage(AutoPilotPlugin.KnownFlightModesVehicleComponent)

--- a/src/UI/toolbar/MainStatusIndicator.qml
+++ b/src/UI/toolbar/MainStatusIndicator.qml
@@ -346,7 +346,8 @@ RowLayout {
             }
 
             SettingsGroupLayout {
-                Layout.fillWidth: true
+                Layout.fillWidth:   true
+                visible:            QGroundControl.corePlugin.showAdvancedUI
 
                 GridLayout {
                     columns:            2

--- a/src/UI/toolbar/RemoteIDIndicatorPage.qml
+++ b/src/UI/toolbar/RemoteIDIndicatorPage.qml
@@ -403,7 +403,8 @@ ToolIndicatorPage {
                 }
 
                 SettingsGroupLayout {
-                    Layout.fillWidth: true
+                    Layout.fillWidth:   true
+                    visible:            QGroundControl.corePlugin.showAdvancedUI
 
                     RowLayout {
                         Layout.fillWidth: true


### PR DESCRIPTION
* Configure buttons only show in toolbar indicators when in advanced mode
* Better wording for GCS comm lost failsafe
* Removed Land Descent Rate from Flight Mode toolbar expanded indicator