### PR TITLE
Add fallback takeoff support to the Takeoff action

### DIFF
--- a/src/FirmwarePlugin/APM/APMFirmwarePlugin.cc
+++ b/src/FirmwarePlugin/APM/APMFirmwarePlugin.cc
@@ -81,12 +81,15 @@ AutoPilotPlugin* APMFirmwarePlugin::autopilotPlugin(Vehicle *vehicle) const
 bool APMFirmwarePlugin::isCapable(const Vehicle* vehicle, FirmwareCapabilities capabilities) const
 {
     uint32_t available = SetFlightModeCapability | PauseVehicleCapability | GuidedModeCapability | ROIModeCapability;
-    if (vehicle->multiRotor()) {
+    if (vehicle->fixedWing()) {
         available |= TakeoffVehicleCapability;
-        available |= ROIModeCapability;
+    } else if (vehicle->multiRotor()) {
+        available |= TakeoffVehicleCapability;
+        available |= GuidedTakeoffCapability;
         available |= ChangeHeadingCapability;
     } else if (vehicle->vtol()) {
         available |= TakeoffVehicleCapability;
+        available |= GuidedTakeoffCapability;
     } else if (vehicle->sub()) {
         available |= ChangeHeadingCapability;
     }
@@ -1015,6 +1018,26 @@ bool APMFirmwarePlugin::_guidedModeTakeoff(Vehicle *vehicle, double altitudeRel)
     );
 
     return true;
+}
+
+void APMFirmwarePlugin::startTakeoff(Vehicle *vehicle) const
+{
+    if (vehicle->flying()) {
+        qgcApp()->showAppMessage(tr("Unable to start takeoff: Vehicle is already in the air."));
+        return;
+    }
+
+    if (!vehicle->armed()) {
+        if (!_setFlightModeAndValidate(vehicle, takeOffFlightMode())) {
+            qgcApp()->showAppMessage(tr("Unable to start takeoff: Vehicle failed to change to Takeoff mode."));
+            return;
+        }
+
+        if (!_armVehicleAndValidate(vehicle)) {
+            qgcApp()->showAppMessage(tr("Unable to start takeoff: Vehicle failed to arm."));
+            return;
+        }
+    }
 }
 
 void APMFirmwarePlugin::startMission(Vehicle *vehicle) const

--- a/src/FirmwarePlugin/APM/APMFirmwarePlugin.h
+++ b/src/FirmwarePlugin/APM/APMFirmwarePlugin.h
@@ -42,6 +42,7 @@ public:
     void guidedModeTakeoff(Vehicle *vehicle, double altitudeRel) const override;
     void guidedModeGotoLocation(Vehicle *vehicle, const QGeoCoordinate& gotoCoord) const override;
     double minimumTakeoffAltitudeMeters(Vehicle *vehicle) const override;
+    void startTakeoff(Vehicle *vehicle) const override;
     void startMission(Vehicle *vehicle) const override;
     QStringList flightModes(Vehicle *vehicle) const override;
     QString flightMode(uint8_t base_mode, uint32_t custom_mode) const override;

--- a/src/FirmwarePlugin/APM/ArduPlaneFirmwarePlugin.cc
+++ b/src/FirmwarePlugin/APM/ArduPlaneFirmwarePlugin.cc
@@ -103,6 +103,11 @@ int ArduPlaneFirmwarePlugin::remapParamNameHigestMinorVersionNumber(int majorVer
     return ((majorVersionNumber == 4) ? 5 : Vehicle::versionNotSetValue);
 }
 
+QString ArduPlaneFirmwarePlugin::takeOffFlightMode() const
+{
+    return _modeEnumToString.value(APMPlaneMode::TAKEOFF, _takeoffFlightMode);
+}
+
 QString ArduPlaneFirmwarePlugin::stabilizedFlightMode() const
 {
     return _modeEnumToString.value(APMPlaneMode::STABILIZE, _stabilizeFlightMode);

--- a/src/FirmwarePlugin/APM/ArduPlaneFirmwarePlugin.h
+++ b/src/FirmwarePlugin/APM/ArduPlaneFirmwarePlugin.h
@@ -57,7 +57,7 @@ public:
     QString autoDisarmParameter(Vehicle *vehicle) const override { Q_UNUSED(vehicle); return QStringLiteral("LAND_DISARMDELAY"); }
     int remapParamNameHigestMinorVersionNumber(int majorVersionNumber) const override;
     const FirmwarePlugin::remapParamNameMajorVersionMap_t &paramNameRemapMajorVersionMap() const override { return _remapParamName; }
-
+    QString takeOffFlightMode() const override;
     QString stabilizedFlightMode() const override;
     void updateAvailableFlightModes(FlightModeList &modeList) override;
 

--- a/src/FirmwarePlugin/FirmwarePlugin.cc
+++ b/src/FirmwarePlugin/FirmwarePlugin.cc
@@ -182,6 +182,12 @@ void FirmwarePlugin::guidedModeChangeHeading(Vehicle *vehicle, const QGeoCoordin
     qgcApp()->showAppMessage(guided_mode_not_supported_by_vehicle);
 }
 
+void FirmwarePlugin::startTakeoff(Vehicle*) const
+{
+    // Not supported by generic vehicle
+    qgcApp()->showAppMessage(guided_mode_not_supported_by_vehicle);
+}
+
 void FirmwarePlugin::startMission(Vehicle*) const
 {
     qgcApp()->showAppMessage(guided_mode_not_supported_by_vehicle);

--- a/src/FirmwarePlugin/FirmwarePlugin.h
+++ b/src/FirmwarePlugin/FirmwarePlugin.h
@@ -85,9 +85,10 @@ public:
         PauseVehicleCapability =    1 << 1, ///< Vehicle supports pausing at current location
         GuidedModeCapability =      1 << 2, ///< Vehicle supports guided mode commands
         OrbitModeCapability =       1 << 3, ///< Vehicle supports orbit mode
-        TakeoffVehicleCapability =  1 << 4, ///< Vehicle supports guided takeoff
+        TakeoffVehicleCapability =  1 << 4, ///< Vehicle supports taking off
         ROIModeCapability =         1 << 5, ///< Vehicle supports ROI (both in Fly guided mode and from Plan creation)
         ChangeHeadingCapability =   1 << 6, ///< Vehicle supports changing heading at current location
+        GuidedTakeoffCapability =   1 << 7, ///< Vehicle supports guided takeoff
     };
 
     /// Maps from on parameter name to another
@@ -182,7 +183,7 @@ public:
     /// Command vehicle to land at current location
     virtual void guidedModeLand(Vehicle *vehicle) const;
 
-    /// Command vehicle to takeoff from current location to a firmware specific height.
+    /// Command vehicle to takeoff from current location to the specified height.
     virtual void guidedModeTakeoff(Vehicle *vehicle, double takeoffAltRel) const;
 
     /// Command vehicle to rotate towards specified location.
@@ -208,6 +209,9 @@ public:
 
     /// @return Return true if we have received the airspeed limits for fixed wing.
     virtual bool fixedWingAirSpeedLimitsAvailable(Vehicle* /*vehicle*/) const { return false; }
+
+    /// Command the vehicle to start a takeoff
+    virtual void startTakeoff(Vehicle *vehicle) const;
 
     /// Command the vehicle to start the mission
     virtual void startMission(Vehicle *vehicle) const;

--- a/src/FirmwarePlugin/PX4/PX4FirmwarePlugin.cc
+++ b/src/FirmwarePlugin/PX4/PX4FirmwarePlugin.cc
@@ -170,7 +170,10 @@ bool PX4FirmwarePlugin::isCapable(const Vehicle *vehicle, FirmwareCapabilities c
         available |= ROIModeCapability | ChangeHeadingCapability;
     }
     if (vehicle->multiRotor() || vehicle->vtol()) {
-        available |= TakeoffVehicleCapability | OrbitModeCapability;
+        available |= TakeoffVehicleCapability | GuidedTakeoffCapability | OrbitModeCapability;
+    }
+    if (vehicle->fixedWing()) {
+        available |= TakeoffVehicleCapability;
     }
     return (capabilities & available) == capabilities;
 }
@@ -561,6 +564,18 @@ void PX4FirmwarePlugin::guidedModeChangeHeading(Vehicle* vehicle, const QGeoCoor
         radians,                                // change heading
         NAN, NAN, NAN                           // no change lat, lon, alt
     );
+}
+
+void PX4FirmwarePlugin::startTakeoff(Vehicle* vehicle) const
+{
+    if (_setFlightModeAndValidate(vehicle, takeOffFlightMode())) {
+        if (!_armVehicleAndValidate(vehicle)) {
+            qgcApp()->showAppMessage(tr("Unable to start takeoff: Vehicle rejected arming."));
+            return;
+        }
+    } else {
+        qgcApp()->showAppMessage(tr("Unable to start takeoff: Vehicle not changing to %1 flight mode.").arg(takeOffFlightMode()));
+    }
 }
 
 void PX4FirmwarePlugin::startMission(Vehicle* vehicle) const

--- a/src/FirmwarePlugin/PX4/PX4FirmwarePlugin.h
+++ b/src/FirmwarePlugin/PX4/PX4FirmwarePlugin.h
@@ -56,6 +56,7 @@ public:
     void                guidedModeChangeGroundSpeedMetersSecond(Vehicle* vehicle, double groundspeed) const override;
     void                guidedModeChangeEquivalentAirspeedMetersSecond(Vehicle* vehicle, double airspeed_equiv) const override;
     void                guidedModeChangeHeading         (Vehicle* vehicle, const QGeoCoordinate &headingCoord) const override;
+    void                startTakeoff                    (Vehicle* vehicle) const override;
     void                startMission                    (Vehicle* vehicle) const override;
     bool                isGuidedMode                    (const Vehicle* vehicle) const override;
     void                initializeVehicle               (Vehicle* vehicle) override;

--- a/src/FlightDisplay/GuidedActionsController.qml
+++ b/src/FlightDisplay/GuidedActionsController.qml
@@ -453,7 +453,7 @@ Item {
             confirmDialog.title = takeoffTitle
             confirmDialog.message = takeoffMessage
             confirmDialog.hideTrigger = Qt.binding(function() { return !showTakeoff })
-            guidedValueSlider.visible = true
+            guidedValueSlider.visible = _activeVehicle.guidedTakeoffSupported
             break;
         case actionStartMission:
             showImmediate = false
@@ -596,8 +596,12 @@ Item {
             _activeVehicle.guidedModeLand()
             break
         case actionTakeoff:
-            var valueInMeters = _unitsConversion.appSettingsVerticalDistanceUnitsToMeters(sliderOutputValue)
-            _activeVehicle.guidedModeTakeoff(valueInMeters)
+            if (_activeVehicle.guidedTakeoffSupported) {
+                var valueInMeters = _unitsConversion.appSettingsVerticalDistanceUnitsToMeters(sliderOutputValue)
+                _activeVehicle.guidedModeTakeoff(valueInMeters)
+            } else {
+                _activeVehicle.startTakeoff()
+            }
             break
         case actionResumeMission:
         case actionResumeMissionUploadFail:

--- a/src/Vehicle/Vehicle.cc
+++ b/src/Vehicle/Vehicle.cc
@@ -2040,6 +2040,11 @@ bool Vehicle::takeoffVehicleSupported() const
     return _firmwarePlugin->isCapable(this, FirmwarePlugin::TakeoffVehicleCapability);
 }
 
+bool Vehicle::guidedTakeoffSupported() const
+{
+    return _firmwarePlugin->isCapable(this, FirmwarePlugin::GuidedTakeoffCapability);
+}
+
 bool Vehicle::changeHeadingSupported() const
 {
     return _firmwarePlugin->isCapable(this, FirmwarePlugin::ChangeHeadingCapability);
@@ -2103,6 +2108,12 @@ bool Vehicle::hasGripper()  const
 { 
     return _firmwarePlugin->hasGripper(this);
 }
+
+void Vehicle::startTakeoff()
+{
+    _firmwarePlugin->startTakeoff(this);
+}
+
 
 void Vehicle::startMission()
 {

--- a/src/Vehicle/Vehicle.h
+++ b/src/Vehicle/Vehicle.h
@@ -236,7 +236,8 @@ public:
     Q_PROPERTY(bool     pauseVehicleSupported   READ pauseVehicleSupported                          CONSTANT)                   ///< Pause vehicle command is supported
     Q_PROPERTY(bool     orbitModeSupported      READ orbitModeSupported                             CONSTANT)                   ///< Orbit mode is supported by this vehicle
     Q_PROPERTY(bool     roiModeSupported        READ roiModeSupported                               CONSTANT)                   ///< Orbit mode is supported by this vehicle
-    Q_PROPERTY(bool     takeoffVehicleSupported READ takeoffVehicleSupported                        CONSTANT)                   ///< Guided takeoff supported
+    Q_PROPERTY(bool     takeoffVehicleSupported READ takeoffVehicleSupported                        CONSTANT)                   ///< Takeoff supported
+    Q_PROPERTY(bool     guidedTakeoffSupported  READ guidedTakeoffSupported                         CONSTANT)                   ///< Guided takeoff supported
     Q_PROPERTY(bool     changeHeadingSupported  READ changeHeadingSupported                         CONSTANT)                   ///< Change Heading supported
     Q_PROPERTY(QString  gotoFlightMode          READ gotoFlightMode                                 CONSTANT)                   ///< Flight mode vehicle is in while performing goto
     Q_PROPERTY(bool     haveMRSpeedLimits       READ haveMRSpeedLimits                              NOTIFY haveMRSpeedLimChanged)
@@ -357,6 +358,8 @@ public:
     /// Command vichecle to retract landing gear
     Q_INVOKABLE void landingGearRetract();
 
+    Q_INVOKABLE void startTakeoff();
+
     Q_INVOKABLE void startMission();
 
     /// Alter the current mission item on the vehicle
@@ -417,6 +420,7 @@ public:
     bool    orbitModeSupported      () const;
     bool    roiModeSupported        () const;
     bool    takeoffVehicleSupported () const;
+    bool    guidedTakeoffSupported  () const;
     bool    changeHeadingSupported  () const;
     QString gotoFlightMode          () const;
     bool    hasGripper              () const;


### PR DESCRIPTION
# Add fallback takeoff support to the Takeoff action

Description
-----------
Implemented a fallback for the Takeoff action for vehicles that can take off but lack guided takeoff support. The fallback action switches to the vehicle's takeoff mode and then arms it, similar to how the Start Mission action works.

Key changes:
- Introduced a new GuidedTakeoffCapability flag to distinguish between takeoff capability and guided takeoff support.
- Added startTakeoff method in FirmwarePlugin to switch to takeoff mode and arm the vehicle, similar to startMission.
- Defined the takeoff flight mode for ArduPlane.
- Updated GuidedActionsController to use the original guided takeoff action or this fallback, as appropriate.

Checklist:
----------
- [X] [Review Contribution Guidelines](https://github.com/mavlink/qgroundcontrol/blob/master/.github/CONTRIBUTING.md).
- [X] [Review Code of Conduct](https://github.com/mavlink/qgroundcontrol/blob/master/.github/CODE_OF_CONDUCT.md).
- [X] I have tested my changes.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.