### PR TITLE
Request MAVLINK_MSG_ID_EXTENDED_SYS_STATE in APM

### DIFF
--- a/src/FirmwarePlugin/APM/APMFirmwarePlugin.cc
+++ b/src/FirmwarePlugin/APM/APMFirmwarePlugin.cc
@@ -429,12 +429,17 @@ void APMFirmwarePlugin::initializeStreamRates(Vehicle* vehicle)
         }
     }
 
+    // The MAV_CMD_SET_MESSAGE_INTERVAL command is only supported on newer firmwares. So we set showError=false.
+    // Which also means than on older firmwares you may be left with some missing features.
+
     // ArduPilot only sends home position on first boot and then when it arms. It does not stream the position.
     // This means that depending on when QGC connects to the vehicle it may not have home position.
     // This can cause various features to not be available. So we request home position streaming ourselves.
-    // The MAV_CMD_SET_MESSAGE_INTERVAL command is only supported on newer firmwares. So we set showError=false.
-    // Which also means than on older firmwares you may be left with some missing features.
     vehicle->sendMavCommand(MAV_COMP_ID_AUTOPILOT1, MAV_CMD_SET_MESSAGE_INTERVAL, false /* showError */, MAVLINK_MSG_ID_HOME_POSITION, 1000000 /* 1 second interval in usec */);
+
+    // ArduPilot doesn't send MAVLINK_MSG_ID_EXTENDED_SYS_STATE messages unless requested, so we request it to
+    // make the LandAbort action available.
+    vehicle->sendMavCommand(MAV_COMP_ID_AUTOPILOT1, MAV_CMD_SET_MESSAGE_INTERVAL, false /* showError */, MAVLINK_MSG_ID_EXTENDED_SYS_STATE, 1000000 /* 1 second interval in usec */);
 
     instanceData->lastBatteryStatusTime = instanceData->lastHomePositionTime = QTime::currentTime();
 }

--- a/src/Vehicle/Vehicle.cc
+++ b/src/Vehicle/Vehicle.cc
@@ -2578,6 +2578,8 @@ bool Vehicle::_commandCanBeDuplicated(MAV_CMD command)
     switch (command) {
     case MAV_CMD_DO_MOTOR_TEST:
         return true;
+    case MAV_CMD_SET_MESSAGE_INTERVAL:
+        return true;
     default:
         return false;
     }


### PR DESCRIPTION
# Request MAVLINK_MSG_ID_EXTENDED_SYS_STATE in APM

Description
-----------
Requested MAVLINK_MSG_ID_EXTENDED_SYS_STATE messages from ArduPilot, as it does not send them unless explicitly requested. These messages are necessary to enable the Land Abort action, as they tell QGC when the aircraft is performing its landing sequence.

In addition to this, MAV_CMD_SET_MESSAGE_INTERVAL has been allowed to be sent multiple times before an acknowledgment is received, as it is necessary for this and possibly other use cases of the command.

Checklist:
----------
- [X] [Review Contribution Guidelines](https://github.com/mavlink/qgroundcontrol/blob/master/.github/CONTRIBUTING.md).
- [X] [Review Code of Conduct](https://github.com/mavlink/qgroundcontrol/blob/master/.github/CODE_OF_CONDUCT.md).
- [X] I have tested my changes.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.