### PR TITLE
[v4.4] remove CI cache for macOS

### DIFF
--- a/.github/workflows/macos_release.yml
+++ b/.github/workflows/macos_release.yml
@@ -76,29 +76,6 @@ jobs:
             # Verify the links
             ls -la /Library/lib/GStreamer.framework/Versions/1.0/
 
-      - name: Install ccache
-        run:  brew install ccache
-
-      - name: Prepare ccache timestamp
-        id: ccache_cache_timestamp
-        run: echo "name=timestamp::$(date --utc +'%Y-%m-%d-%H\;%M\;%S')" >> $GITHUB_OUTPUT
-
-      - name: ccache cache files
-        uses: actions/cache@v3
-        with:
-          path:         ~/.ccache
-          key:          ${{ runner.os }}-ccache-${{steps.ccache_cache_timestamp.outputs.timestamp}}
-          restore-keys: ${{ runner.os }}-ccache-
-
-      - name: Setup ccache
-        run: |
-            mkdir -p ~/.ccache
-            echo "base_dir = ${GITHUB_WORKSPACE}" > ~/.ccache/ccache.conf
-            echo "compression = true" >> ~/.ccache/ccache.conf
-            echo "compression_level = 5" >> ~/.ccache/ccache.conf
-            ccache -s
-            ccache -z
-
       - name: Create build directory
         run:  mkdir ${{ runner.temp }}/shadow_build_dir
 
@@ -128,9 +105,6 @@ jobs:
             -spec macx-clang \
             QMAKE_APPLE_DEVICE_ARCHS=x86_64
           make -j$JOBS
-
-      - name: ccache post-run
-        run:  ccache -s
 
       - name: Save artifact
         uses: actions/upload-artifact@master

--- a/.github/workflows/macos_release.yml
+++ b/.github/workflows/macos_release.yml
@@ -59,28 +59,21 @@ jobs:
               do sudo installer -verbose -pkg "$package" -target /
             done
 
-            # Clean up and recreate directory structure
-            sudo rm -rf /Library/lib/GStreamer.framework
+            # Create proper framework structure with symlinks
+            sudo rm -rf /Library/lib/GStreamer.framework  # Clean up any existing framework
+            sudo mkdir -p /Library/lib
             sudo mkdir -p /Library/lib/GStreamer.framework/Versions/1.0
-
-            # Create all necessary symlinks
-            sudo ln -sf /Library/Frameworks/GStreamer.framework/Versions/1.0/lib /Library/lib/GStreamer.framework/Versions/1.0/lib
-            sudo ln -sf /Library/Frameworks/GStreamer.framework/Versions/1.0/Headers /Library/lib/GStreamer.framework/Versions/1.0/Headers
-            sudo ln -sf /Library/Frameworks/GStreamer.framework/Versions/1.0/Resources /Library/lib/GStreamer.framework/Versions/1.0/Resources
-            sudo ln -sf /Library/Frameworks/GStreamer.framework/Versions/1.0/GStreamer /Library/lib/GStreamer.framework/Versions/1.0/GStreamer
-
-            # Set Current version symlink
-            sudo ln -sf 1.0 /Library/lib/GStreamer.framework/Versions/Current
-
-            # Create top-level symlinks
+            cd /Library/lib/GStreamer.framework/Versions
+            sudo ln -sf 1.0 Current
             cd /Library/lib/GStreamer.framework
             sudo ln -sf Versions/Current/lib lib
             sudo ln -sf Versions/Current/Headers Headers
             sudo ln -sf Versions/Current/Resources Resources
-            sudo ln -sf Versions/Current/GStreamer GStreamer
 
-            # Verify the structure
-            echo "Verifying framework structure:"
+            # Create the main symlink for the whole framework
+            sudo ln -sf /Library/Frameworks/GStreamer.framework /Library/lib/GStreamer.framework
+
+            # Verify the links
             ls -la /Library/lib/GStreamer.framework/Versions/1.0/
 
       - name: Install ccache


### PR DESCRIPTION
Given it only fails after the first build it might have something to do with the caching, so let's just try to remove it for now.