### PR TITLE
Fix so plan is shown as synced if just downloaded from vehicle

### DIFF
--- a/src/MissionManager/MissionController.cc
+++ b/src/MissionManager/MissionController.cc
@@ -61,8 +61,8 @@ MissionController::MissionController(PlanMasterController* masterController, QOb
     connect(this,                                               &MissionController::missionPlannedDistanceChanged,      this, &MissionController::recalcTerrainProfile);
 
     // The follow is used to compress multiple recalc calls in a row to into a single call.
-    connect(this, &MissionController::_recalcMissionFlightStatusSignal, this, &MissionController::_recalcMissionFlightStatus,   Qt::QueuedConnection);
-    connect(this, &MissionController::_recalcFlightPathSegmentsSignal,  this, &MissionController::_recalcFlightPathSegments,    Qt::QueuedConnection);
+    connect(this, &MissionController::_recalcMissionFlightStatusSignal, this, &MissionController::_recalcMissionFlightStatus);
+    connect(this, &MissionController::_recalcFlightPathSegmentsSignal,  this, &MissionController::_recalcFlightPathSegments);
     qgcApp()->addCompressedSignal(QMetaMethod::fromSignal(&MissionController::_recalcMissionFlightStatusSignal));
     qgcApp()->addCompressedSignal(QMetaMethod::fromSignal(&MissionController::_recalcFlightPathSegmentsSignal));
     qgcApp()->addCompressedSignal(QMetaMethod::fromSignal(&MissionController::recalcTerrainProfile));


### PR DESCRIPTION
If a vehicle with a loaded mission was connected to QGC, when QGC would download the mission, the mission would be marked as "dirty" (aka Plan View thinks it has unsaved changes and prompts the operator to upload the changes). The plan should be marked as clean if it was just downloaded. This commit has a fix so download results in the plan being marked clean (aka has no unsaved changes) as  one would expect.

## Step to Reproduce issue 
1. Start a simulator
```
# run this command in the PX4-Autopilot folder
make px4_sitl gazebo
```
2. Download and extract sample plan 
Here is the exact plan I used. There is nothing special about the plan other than it successfully loads to the vehicle. The `.zip` file will need to be extracted for its inner `simpleMission.plan` file to be selected later.
[simpleMission.zip](https://github.com/user-attachments/files/19328121/simpleMission.zip)
3. Open the plan and upload it to the vehicle
![Screenshot from 2025-03-18 14-00-42](https://github.com/user-attachments/assets/28a049cc-0fc7-4d8f-bd34-b83d59588d15)
![Screenshot from 2025-03-18 14-02-11](https://github.com/user-attachments/assets/4b7559c1-b968-4816-ba4a-0dc4984f6c32)
![Screenshot from 2025-03-18 13-49-26](https://github.com/user-attachments/assets/3baa8c3e-4ad3-428c-a954-c8b92301d596)
4. After pressing upload, you will see that Plan View considers itself to be in sync with the vehicle. QGC indicates the plan is in sync by showing the `Upload` button (instead of the `Upload Required` button) and making the left-toolbar button icon hollow (instead of containing an explamation mark).
![noUnsaved](https://github.com/user-attachments/assets/ee63cfd2-b92b-4969-bf38-227c11d7df05)
5. Download the plan just uploaded to the vehicle
![Screenshot from 2025-03-18 12-56-03](https://github.com/user-attachments/assets/06b58ac2-eadf-4b98-ab64-7925715e5456)
6. After download you will see either the reported issue if you are using QGC master or you will see the fixed behavior if you built QGC from this PR. The thing to note is that in this PR doing a download sets the the unsaved changes flag (aka the dirty flag) to false and does not prompt the user to save changes.
![badMaster](https://github.com/user-attachments/assets/a1a93ec2-1be1-4bcd-afa3-c11f4a33d4cc)
![goodPr](https://github.com/user-attachments/assets/56b1de47-b416-41d9-9920-a8f413bbd009)

## Test Environment
I mostly tested using my local Debug build in Ubuntu 22.04 with a gazebo sim. Also tested a release build of Windows with a WSL Ubuntu 20.04 gazebo sim. Behavior was the same in both.

## Sponsor
This contribution was sponsored by [Firestorm](https://www.launchfirestorm.com/)
![654d4f9476ff2a38f37e9ab9_firestorm-homepage-share-img-2](https://github.com/user-attachments/assets/bc1a2c95-b33d-4a2d-af35-4d2d8651d0a2)