### PR TITLE
Fix memory leak which happens when loading a new plan

### DIFF
--- a/src/MissionManager/MissionController.cc
+++ b/src/MissionManager/MissionController.cc
@@ -153,6 +153,7 @@ void MissionController::_newMissionItemsAvailableFromVehicle(bool removeAllReque
         //      - The initial automatic load from a vehicle completed and the current editor is empty
 
         _deinitAllVisualItems();
+        _visualItems->clearAndDeleteContents();
         _visualItems->deleteLater();
         _visualItems  = nullptr;
         _settingsItem = nullptr;


### PR DESCRIPTION
I noticed while debugging that if I put a print statement in TakeoffMissionItem's destructor it wouldn't be called when I downloaded a new mission from the vehicle. Its because there was a memory leak and the unused TakeoffMissionItem was never deleted. This PR fixes that memory leak. 

## Sponsor
This contribution was sponsored by [Firestorm](https://www.launchfirestorm.com/)
![654d4f9476ff2a38f37e9ab9_firestorm-homepage-share-img-2](https://github.com/user-attachments/assets/bc1a2c95-b33d-4a2d-af35-4d2d8651d0a2)