### PR TITLE
Emit dirtyChanged only if change has occurred

### DIFF
--- a/src/MissionManager/PlanMasterController.cc
+++ b/src/MissionManager/PlanMasterController.cc
@@ -59,9 +59,10 @@ PlanMasterController::PlanMasterController(MAV_AUTOPILOT firmwareType, MAV_TYPE 
 
 void PlanMasterController::_commonInit(void)
 {
-    connect(&_missionController,    &MissionController::dirtyChanged,               this, &PlanMasterController::dirtyChanged);
-    connect(&_geoFenceController,   &GeoFenceController::dirtyChanged,              this, &PlanMasterController::dirtyChanged);
-    connect(&_rallyPointController, &RallyPointController::dirtyChanged,            this, &PlanMasterController::dirtyChanged);
+    _previousOverallDirty = dirty();
+    connect(&_missionController,    &MissionController::dirtyChanged,               this, &PlanMasterController::_updateOverallDirty);
+    connect(&_geoFenceController,   &GeoFenceController::dirtyChanged,              this, &PlanMasterController::_updateOverallDirty);
+    connect(&_rallyPointController, &RallyPointController::dirtyChanged,            this, &PlanMasterController::_updateOverallDirty);
 
     connect(&_missionController,    &MissionController::containsItemsChanged,       this, &PlanMasterController::containsItemsChanged);
     connect(&_geoFenceController,   &GeoFenceController::containsItemsChanged,      this, &PlanMasterController::containsItemsChanged);
@@ -607,6 +608,14 @@ bool PlanMasterController::isEmpty(void) const
     return _missionController.isEmpty() &&
             _geoFenceController.isEmpty() &&
             _rallyPointController.isEmpty();
+}
+
+void PlanMasterController::_updateOverallDirty(void)
+{
+    if(_previousOverallDirty != dirty()){
+        _previousOverallDirty = dirty();
+        emit dirtyChanged(_previousOverallDirty);
+    }    
 }
 
 void PlanMasterController::_updatePlanCreatorsList(void)

--- a/src/MissionManager/PlanMasterController.h
+++ b/src/MissionManager/PlanMasterController.h
@@ -131,6 +131,7 @@ private slots:
     void _sendMissionComplete       (void);
     void _sendGeoFenceComplete      (void);
     void _sendRallyPointsComplete   (void);
+    void _updateOverallDirty        (void);
     void _updatePlanCreatorsList    (void);
 
 private:
@@ -151,5 +152,6 @@ private:
     bool                    _sendRallyPoints =          false;
     QString                 _currentPlanFile;
     bool                    _deleteWhenSendCompleted =  false;
+    bool                    _previousOverallDirty =     false;
     QmlObjectListModel*     _planCreators =             nullptr;
 };


### PR DESCRIPTION
This `PlanMasterController.dirtyChanged(val)` signal was being emmitted at times when no change in `PlanMasterController.dirty()` actually occured. In a profiling test I did, two thirds of the time the signal was emitted the property whose value was signalled to have changed did not actually have a change. 

For operators this means more resources are taken on their device. For myself as a programmer, the issue caused pain because I was debugging by following signal trails and I wasted some time following false signals.

Also, the parameter value of the dependency signals was inappropriately being passed as the parameter of the emitted signal. ex. if `MissionController::dirtyChanged(false)` was called that would cause `PlanMasterController::dirtyChanged(false)` to be emitted, even though the value of `PlanMasterController.dirty()` may actually be `true`

## Steps to reproduce
0. Checkout the appropriate commit
 * To test QGC master, use this commit. It is QGC master with some extra stuff for profiling dirtyChanged signal emition
https://github.com/gillamkid/qgroundcontrol/commit/e471dd90c40eece85bbb3a27c0d82eaee785ad75
 * To test this PR, use this commit. It is this PR's commit with some extra stuff for profiling dirtyChanged signal emition
https://github.com/gillamkid/qgroundcontrol/commit/b998b458c653e628942c5f5754873f53dff92514

1. run the repro steps outlined on this PR: https://github.com/mavlink/qgroundcontrol/pull/12584
2. after running the repro steps, you can see the following if you look at what the print statements put in the console output
 * for master
     - every time `Download` is clicked, each instance of  `PlanMasterController` emits `dirtyChanged` 6 times, where 4 of those times there is no actual change in the value of `PlanMasterController.dirty()`
     - if you start QGC when a plan is already loaded on the vehicle, there is an occurance where `PlanMasterController.dirtyChanged(val)` is emitted where `val` != the current `PlanMasterController.dirty` value
 * for this PR
     - every time `Download` is clicked, each instance of  `PlanMasterController` emits `dirtyChanged` 2 times, where every time there is an acutal change in the value of `PlanMasterController.dirty()`
     - every time `PlanMasterController.dirtyChanged(val)` is emitted, `val` equals the current `PlanMasterController.dirty` value

## Sponsor
This contribution was sponsored by [Firestorm](https://www.launchfirestorm.com/)
![654d4f9476ff2a38f37e9ab9_firestorm-homepage-share-img-2](https://github.com/user-attachments/assets/bc1a2c95-b33d-4a2d-af35-4d2d8651d0a2)