### PR TITLE
Vehicle Card Telem Data

### DIFF
--- a/custom-example/qgroundcontrol.qrc
+++ b/custom-example/qgroundcontrol.qrc
@@ -264,6 +264,8 @@
 		<file alias="QGroundControl/FlightMap/CompassHeadingIndicator.qml">../src/FlightMap/Widgets/CompassHeadingIndicator.qml</file>
 		<file alias="QGroundControl/FlightMap/CustomMapItems.qml">../src/FlightMap/MapItems/CustomMapItems.qml</file>
 		<file alias="QGroundControl/FlightMap/FlightMap.qml">../src/FlightMap/FlightMap.qml</file>
+        <file alias="QGroundControl/FlightMap/IntegratedAttitudeIndicator.qml">../src/FlightMap/Widgets/IntegratedAttitudeIndicator.qml</file>
+        <file alias="QGroundControl/FlightMap/IntegratedCompassAttitude.qml">../src/FlightMap/Widgets/IntegratedCompassAttitude.qml</file>
 		<file alias="QGroundControl/FlightMap/MapFitFunctions.qml">../src/FlightMap/Widgets/MapFitFunctions.qml</file>
 		<file alias="QGroundControl/FlightMap/MapScale.qml">../src/FlightMap/MapScale.qml</file>
 		<file alias="QGroundControl/FlightMap/MissionItemIndicator.qml">../src/FlightMap/MapItems/MissionItemIndicator.qml</file>

--- a/qgroundcontrol.qrc
+++ b/qgroundcontrol.qrc
@@ -276,6 +276,8 @@
         <file alias="QGroundControl/FlightMap/CompassHeadingIndicator.qml">src/FlightMap/Widgets/CompassHeadingIndicator.qml</file>
         <file alias="QGroundControl/FlightMap/CustomMapItems.qml">src/FlightMap/MapItems/CustomMapItems.qml</file>
         <file alias="QGroundControl/FlightMap/FlightMap.qml">src/FlightMap/FlightMap.qml</file>
+        <file alias="QGroundControl/FlightMap/IntegratedAttitudeIndicator.qml">src/FlightMap/Widgets/IntegratedAttitudeIndicator.qml</file>
+        <file alias="QGroundControl/FlightMap/IntegratedCompassAttitude.qml">src/FlightMap/Widgets/IntegratedCompassAttitude.qml</file>
         <file alias="QGroundControl/FlightMap/MapFitFunctions.qml">src/FlightMap/Widgets/MapFitFunctions.qml</file>
         <file alias="QGroundControl/FlightMap/MapScale.qml">src/FlightMap/MapScale.qml</file>
         <file alias="QGroundControl/FlightMap/MissionItemIndicator.qml">src/FlightMap/MapItems/MissionItemIndicator.qml</file>

--- a/src/API/QGCCorePlugin.cc
+++ b/src/API/QGCCorePlugin.cc
@@ -154,83 +154,121 @@ QString QGCCorePlugin::showAdvancedUIMessage() const
               "Are you sure you want to enable Advanced Mode?");
 }
 
-void QGCCorePlugin::factValueGridCreateDefaultSettings(const QString &defaultSettingsGroup)
+void QGCCorePlugin::factValueGridCreateDefaultSettings(FactValueGrid* factValueGrid)
 {
-    HorizontalFactValueGrid *const factValueGrid = new HorizontalFactValueGrid(defaultSettingsGroup);
+    if(factValueGrid->userSettingsGroup() == HorizontalFactValueGrid::vehicleCardUserSettingsGroup){
+        bool includeFWValues = factValueGrid->vehicleClass() == QGCMAVLink::VehicleClassFixedWing || factValueGrid->vehicleClass() == QGCMAVLink::VehicleClassVTOL || factValueGrid->vehicleClass() == QGCMAVLink::VehicleClassAirship;
 
-    const bool includeFWValues = ((factValueGrid->vehicleClass() == QGCMAVLink::VehicleClassFixedWing) || (factValueGrid->vehicleClass() == QGCMAVLink::VehicleClassVTOL) || (factValueGrid->vehicleClass() == QGCMAVLink::VehicleClassAirship));
+        factValueGrid->setFontSize(FactValueGrid::LargeFontSize);
+        factValueGrid->appendColumn();
+        factValueGrid->appendColumn();
 
-    factValueGrid->setFontSize(FactValueGrid::LargeFontSize);
+        int rowIndex = 0;
+        int colIndex = 0;
 
-    (void) factValueGrid->appendColumn();
-    (void) factValueGrid->appendColumn();
-    (void) factValueGrid->appendColumn();
-    if (includeFWValues) {
+        // first cell
+        QmlObjectListModel* column      = factValueGrid->columns()->value<QmlObjectListModel*>(colIndex++);
+        InstrumentValueData* value = column->value<InstrumentValueData*>(rowIndex);
+        value->setFact("Vehicle", "AltitudeRelative");
+        value->setIcon("arrow-thick-up.svg");
+        value->setText(value->fact()->shortDescription());
+        value->setShowUnits(true);
+
+        // second cell
+        column = factValueGrid->columns()->value<QmlObjectListModel*>(colIndex++);
+        value = column->value<InstrumentValueData*>(rowIndex);
+        if (includeFWValues) {
+            value->setFact("Vehicle", "AirSpeed");
+            value->setText("AirSpd");
+            value->setShowUnits(true);
+        }
+        else {
+            value->setFact("Vehicle", "GroundSpeed");
+            value->setIcon("arrow-simple-right.svg");
+            value->setText(value->fact()->shortDescription());
+            value->setShowUnits(true);
+        }
+
+        factValueGrid->saveSettingsForced();
+    }
+    else if(factValueGrid->userSettingsGroup() == HorizontalFactValueGrid::telemetryBarUserSettingsGroup){
+        const bool includeFWValues = ((factValueGrid->vehicleClass() == QGCMAVLink::VehicleClassFixedWing) || (factValueGrid->vehicleClass() == QGCMAVLink::VehicleClassVTOL) || (factValueGrid->vehicleClass() == QGCMAVLink::VehicleClassAirship));
+
+        factValueGrid->setFontSize(FactValueGrid::LargeFontSize);
+
         (void) factValueGrid->appendColumn();
-    }
-    factValueGrid->appendRow();
+        (void) factValueGrid->appendColumn();
+        (void) factValueGrid->appendColumn();
+        if (includeFWValues) {
+            (void) factValueGrid->appendColumn();
+        }
+        factValueGrid->appendRow();
 
-    int rowIndex = 0;
-    QmlObjectListModel *column = factValueGrid->columns()->value<QmlObjectListModel*>(0);
+        int rowIndex = 0;
+        QmlObjectListModel *column = factValueGrid->columns()->value<QmlObjectListModel*>(0);
 
-    InstrumentValueData *value = column->value<InstrumentValueData*>(rowIndex++);
-    value->setFact(QStringLiteral("Vehicle"), QStringLiteral("AltitudeRelative"));
-    value->setIcon(QStringLiteral("arrow-thick-up.svg"));
-    value->setText(value->fact()->shortDescription());
-    value->setShowUnits(true);
+        InstrumentValueData *value = column->value<InstrumentValueData*>(rowIndex++);
+        value->setFact(QStringLiteral("Vehicle"), QStringLiteral("AltitudeRelative"));
+        value->setIcon(QStringLiteral("arrow-thick-up.svg"));
+        value->setText(value->fact()->shortDescription());
+        value->setShowUnits(true);
 
-    value = column->value<InstrumentValueData*>(rowIndex++);
-    value->setFact(QStringLiteral("Vehicle"), QStringLiteral("DistanceToHome"));
-    value->setIcon(QStringLiteral("bookmark copy 3.svg"));
-    value->setText(value->fact()->shortDescription());
-    value->setShowUnits(true);
+        value = column->value<InstrumentValueData*>(rowIndex++);
+        value->setFact(QStringLiteral("Vehicle"), QStringLiteral("DistanceToHome"));
+        value->setIcon(QStringLiteral("bookmark copy 3.svg"));
+        value->setText(value->fact()->shortDescription());
+        value->setShowUnits(true);
 
-    rowIndex = 0;
-    column = factValueGrid->columns()->value<QmlObjectListModel*>(1);
-
-    value = column->value<InstrumentValueData*>(rowIndex++);
-    value->setFact(QStringLiteral("Vehicle"), QStringLiteral("ClimbRate"));
-    value->setIcon(QStringLiteral("arrow-simple-up.svg"));
-    value->setText(value->fact()->shortDescription());
-    value->setShowUnits(true);
-
-    value = column->value<InstrumentValueData*>(rowIndex++);
-    value->setFact(QStringLiteral("Vehicle"), QStringLiteral("GroundSpeed"));
-    value->setIcon(QStringLiteral("arrow-simple-right.svg"));
-    value->setText(value->fact()->shortDescription());
-    value->setShowUnits(true);
-
-    if (includeFWValues) {
         rowIndex = 0;
-        column = factValueGrid->columns()->value<QmlObjectListModel*>(2);
+        column = factValueGrid->columns()->value<QmlObjectListModel*>(1);
 
         value = column->value<InstrumentValueData*>(rowIndex++);
-        value->setFact(QStringLiteral("Vehicle"), QStringLiteral("AirSpeed"));
-        value->setText(QStringLiteral("AirSpd"));
+        value->setFact(QStringLiteral("Vehicle"), QStringLiteral("ClimbRate"));
+        value->setIcon(QStringLiteral("arrow-simple-up.svg"));
+        value->setText(value->fact()->shortDescription());
         value->setShowUnits(true);
 
         value = column->value<InstrumentValueData*>(rowIndex++);
-        value->setFact(QStringLiteral("Vehicle"), QStringLiteral("ThrottlePct"));
-        value->setText(QStringLiteral("Thr"));
+        value->setFact(QStringLiteral("Vehicle"), QStringLiteral("GroundSpeed"));
+        value->setIcon(QStringLiteral("arrow-simple-right.svg"));
+        value->setText(value->fact()->shortDescription());
         value->setShowUnits(true);
+
+        if (includeFWValues) {
+            rowIndex = 0;
+            column = factValueGrid->columns()->value<QmlObjectListModel*>(2);
+
+            value = column->value<InstrumentValueData*>(rowIndex++);
+            value->setFact(QStringLiteral("Vehicle"), QStringLiteral("AirSpeed"));
+            value->setText(QStringLiteral("AirSpd"));
+            value->setShowUnits(true);
+
+            value = column->value<InstrumentValueData*>(rowIndex++);
+            value->setFact(QStringLiteral("Vehicle"), QStringLiteral("ThrottlePct"));
+            value->setText(QStringLiteral("Thr"));
+            value->setShowUnits(true);
+        }
+
+        rowIndex = 0;
+        column = factValueGrid->columns()->value<QmlObjectListModel*>(includeFWValues ? 3 : 2);
+
+        value = column->value<InstrumentValueData*>(rowIndex++);
+        value->setFact(QStringLiteral("Vehicle"), QStringLiteral("FlightTime"));
+        value->setIcon(QStringLiteral("timer.svg"));
+        value->setText(value->fact()->shortDescription());
+        value->setShowUnits(false);
+
+        value = column->value<InstrumentValueData*>(rowIndex++);
+        value->setFact(QStringLiteral("Vehicle"), QStringLiteral("FlightDistance"));
+        value->setIcon(QStringLiteral("travel-walk.svg"));
+        value->setText(value->fact()->shortDescription());
+        value->setShowUnits(true);
+
+        factValueGrid->saveSettingsForced();
     }
-
-    rowIndex = 0;
-    column = factValueGrid->columns()->value<QmlObjectListModel*>(includeFWValues ? 3 : 2);
-
-    value = column->value<InstrumentValueData*>(rowIndex++);
-    value->setFact(QStringLiteral("Vehicle"), QStringLiteral("FlightTime"));
-    value->setIcon(QStringLiteral("timer.svg"));
-    value->setText(value->fact()->shortDescription());
-    value->setShowUnits(false);
-
-    value = column->value<InstrumentValueData*>(rowIndex++);
-    value->setFact(QStringLiteral("Vehicle"), QStringLiteral("FlightDistance"));
-    value->setIcon(QStringLiteral("travel-walk.svg"));
-    value->setText(value->fact()->shortDescription());
-    value->setShowUnits(true);
-
-    factValueGrid->deleteLater();
+    else {
+        qCritical() << "factValueGridCreateDefaultSettings: Unexpected userSettingsGroup: " << factValueGrid->userSettingsGroup();
+    }
 }
 
 QQmlApplicationEngine *QGCCorePlugin::createQmlApplicationEngine(QObject *parent)

--- a/src/API/QGCCorePlugin.h
+++ b/src/API/QGCCorePlugin.h
@@ -27,6 +27,7 @@ class QQuickItem;
 class Vehicle;
 class VideoReceiver;
 class VideoSink;
+class FactValueGrid;
 typedef struct __mavlink_message mavlink_message_t;
 
 Q_DECLARE_LOGGING_CATEGORY(QGCCorePluginLog)
@@ -96,7 +97,7 @@ public:
     /// Allows a plugin to override the specified color name from the palette
     virtual void paletteOverride(const QString &colorName, QGCPalette::PaletteColorInfo_t &colorInfo) { Q_UNUSED(colorName); Q_UNUSED(colorInfo); };
 
-    virtual void factValueGridCreateDefaultSettings(const QString &defaultSettingsGroup);
+    virtual void factValueGridCreateDefaultSettings(FactValueGrid* factValueGrid);
 
     /// Allows the plugin to override or get access to the QmlApplicationEngine to do things like add import
     /// path or stuff things into the context prior to window creation.

--- a/src/FlightDisplay/FlyViewBottomRightRowLayout.qml
+++ b/src/FlightDisplay/FlyViewBottomRightRowLayout.qml
@@ -18,6 +18,10 @@ RowLayout {
     TelemetryValuesBar {
         Layout.alignment:   Qt.AlignBottom
         extraWidth:         instrumentPanel.extraValuesWidth
+
+        valueArea_userSettingsGroup:      valueArea.telemetryBarUserSettingsGroup
+        valueArea_defaultSettingsGroup:   valueArea.telemetryBarDefaultSettingsGroup
+        valueArea_vehicle:                QGroundControl.multiVehicleManager.activeVehicle ? QGroundControl.multiVehicleManager.activeVehicle : QGroundControl.multiVehicleManager.offlineEditingVehicle
     }
 
     FlyViewInstrumentPanel {

--- a/src/FlightDisplay/FlyViewTopRightPanel.qml
+++ b/src/FlightDisplay/FlyViewTopRightPanel.qml
@@ -46,6 +46,10 @@ Rectangle {
 
     QGCPalette { id: qgcPal }
 
+    DeadMouseArea {
+        anchors.fill:       parent
+    }
+
     ColumnLayout {
         id:                 topRightPanelColumnLayout
         anchors.fill:       parent
@@ -67,7 +71,6 @@ Rectangle {
             id:                    multiVehicleList
             Layout.fillWidth:      true
             Layout.fillHeight:     true
-            implicitHeight:        multiVehicleList.innerColumnHeight * vehicles.count - _margins * 3
 
             Rectangle {
                 anchors.fill: parent

--- a/src/FlightDisplay/MultiVehicleList.qml
+++ b/src/FlightDisplay/MultiVehicleList.qml
@@ -20,7 +20,7 @@ import QGroundControl.FlightMap
 
 Item {
     property real   _margin:              ScreenTools.defaultFontPixelWidth / 2
-    property real   _widgetHeight:        ScreenTools.defaultFontPixelHeight * 2
+    property real   _widgetHeight:        ScreenTools.defaultFontPixelHeight * 2.5
     property var    _guidedController:    globals.guidedControllerFlyView
     property var    _activeVehicleColor:  "green"
     property var    _activeVehicle:       QGroundControl.multiVehicleManager.activeVehicle
@@ -141,16 +141,20 @@ Item {
 
             Column {
                 id:                         innerColumn
-                anchors.horizontalCenter:   parent.horizontalCenter
+                anchors.centerIn:           parent
+                spacing:                    _margin
 
                 RowLayout {
                     anchors.horizontalCenter:   parent.horizontalCenter
                     anchors.margins:    _margin
                     spacing:            _margin
 
-                    QGCCompassWidget {
+                    IntegratedCompassAttitude {
                         id: compassWidget
-                        size:                        _widgetHeight
+                        compassRadius:              _widgetHeight / 2 - attitudeSize / 2
+                        compassBorder:              0
+                        attitudeSize:               ScreenTools.defaultFontPixelWidth / 2
+                        attitudeSpacing:            attitudeSize / 2
                         usedByMultipleVehicleList:   true
                         vehicle:                     _vehicle
                     }

--- a/src/FlightDisplay/MultiVehicleList.qml
+++ b/src/FlightDisplay/MultiVehicleList.qml
@@ -26,7 +26,7 @@ Item {
     property var    _activeVehicle:       QGroundControl.multiVehicleManager.activeVehicle
     property var    selectedVehicles:     QGroundControl.multiVehicleManager.selectedVehicles
 
-    property real   innerColumnHeight
+    implicitHeight: vehicleList.contentHeight
 
     function armAvailable() {
         for (var i = 0; i < selectedVehicles.count; i++) {
@@ -126,7 +126,7 @@ Item {
 
         delegate: Rectangle {
             width:          vehicleList.width
-            height:         innerColumn.y + innerColumn.height + _margin
+            height:         innerColumn.height + _margin * 2
             color:          QGroundControl.multiVehicleManager.activeVehicle == _vehicle ? _activeVehicleColor : qgcPal.button
             radius:         _margin
             border.width:   _vehicle && vehicleSelected(_vehicle.id) ? 2 : 0
@@ -134,17 +134,13 @@ Item {
 
             property var    _vehicle:   object
 
-            Rectangle {
-                height:                     parent.height
-                width:                      innerColumn.width
+            Column {
+                id:                         innerColumn
                 anchors.horizontalCenter:   parent.horizontalCenter
-                color:                      "transparent"
 
                 RowLayout {
-                    id:                 innerColumn
                     anchors.margins:    _margin
                     spacing:            _margin
-                    onHeightChanged: {  innerColumnHeight = height + _margin * 2 + spacing * 2  }
 
                     QGCCompassWidget {
                         id: compassWidget

--- a/src/FlightDisplay/MultiVehicleList.qml
+++ b/src/FlightDisplay/MultiVehicleList.qml
@@ -134,11 +134,17 @@ Item {
 
             property var    _vehicle:   object
 
+            QGCMouseArea {
+                anchors.fill:       parent
+                onClicked:          toggleSelect(_vehicle.id)
+            }
+
             Column {
                 id:                         innerColumn
                 anchors.horizontalCenter:   parent.horizontalCenter
 
                 RowLayout {
+                    anchors.horizontalCenter:   parent.horizontalCenter
                     anchors.margins:    _margin
                     spacing:            _margin
 
@@ -189,11 +195,21 @@ Item {
                         }
                     }
                 }
-            }
 
-            QGCMouseArea {
-                anchors.fill:       parent
-                onClicked:          toggleSelect(_vehicle.id)
+                QGCFlickable {
+                    anchors.horizontalCenter:   parent.horizontalCenter
+                    width:          Math.min(contentWidth, vehicleList.width)
+                    height:         control.height
+                    contentWidth:   control.width
+                    contentHeight:  control.height
+
+                    TelemetryValuesBar {
+                        id:                             control
+                        valueArea_userSettingsGroup:    valueArea.vehicleCardUserSettingsGroup
+                        valueArea_defaultSettingsGroup: valueArea.vehicleCardDefaultSettingsGroup
+                        valueArea_vehicle:              _vehicle
+                    }
+                }
             }
         }
     }

--- a/src/FlightDisplay/TelemetryValuesBar.qml
+++ b/src/FlightDisplay/TelemetryValuesBar.qml
@@ -23,6 +23,11 @@ Item {
 
     property real extraWidth: 0 ///< Extra width to add to the background rectangle
 
+    property alias valueArea: valueArea
+    property var valueArea_userSettingsGroup
+    property var valueArea_defaultSettingsGroup
+    property var valueArea_vehicle
+
     Rectangle {
         id:         backgroundRect
         width:      control.width + extraWidth
@@ -59,8 +64,9 @@ Item {
 
         HorizontalFactValueGrid {
             id:                     valueArea
-            userSettingsGroup:      telemetryBarUserSettingsGroup
-            defaultSettingsGroup:   telemetryBarDefaultSettingsGroup
+            userSettingsGroup:      valueArea_userSettingsGroup
+            defaultSettingsGroup:   valueArea_defaultSettingsGroup
+            vehicle:                valueArea_vehicle
         }
     }
 

--- a/src/FlightMap/Widgets/IntegratedAttitudeIndicator.qml
+++ b/src/FlightMap/Widgets/IntegratedAttitudeIndicator.qml
@@ -22,8 +22,8 @@ Item {
     property real compassRadius:        ScreenTools.defaultFontPixelHeight * 6 / 2
     property real attitudeAngleDegrees: 0
 
-    readonly property real attitudeSize:         ScreenTools.defaultFontPixelHeight * 0.75
-    readonly property real attitudeSpacing:      ScreenTools.defaultFontPixelHeight / 4
+    property real attitudeSize:         ScreenTools.defaultFontPixelHeight * 0.75
+    property real attitudeSpacing:      ScreenTools.defaultFontPixelHeight / 4
 
     property real _totalRadius:             compassRadius + attitudeSpacing + attitudeSize
     property real _attitudeRadius:          (width / 2) - (attitudeSize / 2)

--- a/src/FlightMap/Widgets/IntegratedCompassAttitude.qml
+++ b/src/FlightMap/Widgets/IntegratedCompassAttitude.qml
@@ -20,16 +20,17 @@ Item {
     implicitWidth:  (compassRadius * 2) + attitudeSpacing + attitudeSize
     implicitHeight: implicitWidth
 
-    property real attitudeSize:         rollIndicator.attitudeSize
-    property real attitudeSpacing:      rollIndicator.attitudeSpacing
-    property real extraInset:           attitudeSize + attitudeSpacing
-    property real extraValuesWidth:     compassRadius
-    property real defaultCompassRadius: (mainWindow.width * 0.15) / 2
-    property real maxCompassRadius:     ScreenTools.defaultFontPixelHeight * 7 / 2
-    property real compassRadius:        Math.min(defaultCompassRadius, maxCompassRadius)
-    property real compassBorder:        ScreenTools.defaultFontPixelHeight / 2
-    property var  vehicle:              globals.activeVehicle
-    property var  qgcPal:               QGroundControl.globalPalette
+    property alias attitudeSize:                rollIndicator.attitudeSize
+    property alias attitudeSpacing:             rollIndicator.attitudeSpacing
+    property real extraInset:                   attitudeSize + attitudeSpacing
+    property real extraValuesWidth:             compassRadius
+    property real defaultCompassRadius:         (mainWindow.width * 0.15) / 2
+    property real maxCompassRadius:             ScreenTools.defaultFontPixelHeight * 7 / 2
+    property real compassRadius:                Math.min(defaultCompassRadius, maxCompassRadius)
+    property real compassBorder:                ScreenTools.defaultFontPixelHeight / 2
+    property var  vehicle:                      globals.activeVehicle
+    property var  qgcPal:                       QGroundControl.globalPalette
+    property bool usedByMultipleVehicleList:    false
 
     property real _totalAttitudeSize: attitudeSize + attitudeSpacing
 
@@ -44,6 +45,8 @@ Item {
         x:                      -_totalAttitudeSize
         attitudeAngleDegrees:   vehicle ? vehicle.pitch.rawValue : 0
         compassRadius:          control.compassRadius
+        attitudeSize:           control.attitudeSize
+        attitudeSpacing:        control.attitudeSpacing
         transformOrigin:        Item.Center
         rotation:               90
     }
@@ -56,9 +59,10 @@ Item {
         color:  qgcPal.window
 
         QGCCompassWidget {
-            size:               parent.width - compassBorder
-            vehicle:            globals.activeVehicle
-            anchors.centerIn:   parent
+            size:                       parent.width - compassBorder
+            vehicle:                    control.vehicle
+            usedByMultipleVehicleList:  control.usedByMultipleVehicleList
+            anchors.centerIn:           parent
         }
     }
 }

--- a/src/QmlControls/FactValueGrid.h
+++ b/src/QmlControls/FactValueGrid.h
@@ -11,6 +11,7 @@
 
 #include "QmlObjectListModel.h"
 #include "QGCMAVLink.h"
+#include "Vehicle.h"
 
 #include <QtCore/QSettings>
 #include <QtQuick/QQuickItem>
@@ -24,6 +25,7 @@ class FactValueGrid : public QQuickItem
 public:
     FactValueGrid(QQuickItem *parent = nullptr);
     FactValueGrid(const QString& defaultSettingsGroup);
+    ~FactValueGrid();
 
     enum FontSize {
         DefaultFontSize=0,
@@ -50,6 +52,7 @@ public:
     Q_PROPERTY(QStringList          iconNames                       READ iconNames                                          CONSTANT)
     Q_PROPERTY(FontSize             fontSize                        READ fontSize                       WRITE setFontSize   NOTIFY fontSizeChanged)
     Q_PROPERTY(QStringList          fontSizeNames                   MEMBER _fontSizeNames                                   CONSTANT)
+    Q_PROPERTY(Vehicle *            vehicle                         READ vehicle                        WRITE setVehicle    NOTIFY vehicleChanged                   REQUIRED)
 
     Q_INVOKABLE void                resetToDefaults (void);
     Q_INVOKABLE QmlObjectListModel* appendColumn    (void);
@@ -57,18 +60,23 @@ public:
     Q_INVOKABLE void                appendRow       (void);
     Q_INVOKABLE void                deleteLastRow   (void);
 
-    QmlObjectListModel*         columns     (void) const { return _columns; }
-    FontSize                    fontSize    (void) const { return _fontSize; }
-    QStringList                 iconNames   (void) const { return _iconNames; }
-    QGCMAVLink::VehicleClass_t  vehicleClass(void) const { return _vehicleClass; }
+    QmlObjectListModel*         columns             (void) const { return _columns; }
+    QString                     userSettingsGroup   (void) const { return _userSettingsGroup; }
+    FontSize                    fontSize            (void) const { return _fontSize; }
+    QStringList                 iconNames           (void) const { return _iconNames; }
+    QGCMAVLink::VehicleClass_t  vehicleClass        (void) const { return _vehicleClass; }
+    Vehicle*                    vehicle             (void) const { return _vehicle; }
 
     void setFontSize(FontSize fontSize);
+    void setVehicle(Vehicle* vehicle);
 
     // This is only exposed for usage of FactValueGrid to be able to just read the settings and display no ui. For this case
     // create a FactValueGrid object with a null parent. Set the userSettingsGroup/defaultSettingsGroup appropriately and then
     // call _loadSettings. Then after that you can read the settings from the object. You should not change any of the values.
     // Destroy the FactValueGrid object when done.
     void _loadSettings(void);
+
+    void saveSettingsForced(void);
 
     // Override from QQmlParserStatus
     void componentComplete(void) final;
@@ -77,6 +85,7 @@ signals:
     void userSettingsGroupChanged   (const QString& userSettingsGroup);
     void defaultSettingsGroupChanged(const QString& defaultSettingsGroup);
     void fontSizeChanged            (FontSize fontSize);
+    void vehicleChanged             ();
     void columnsChanged             (QmlObjectListModel* model);
     void rowCountChanged            (int rowCount);
 
@@ -90,6 +99,7 @@ protected:
     bool                        _preventSaveSettings    = false;
     QmlObjectListModel*         _columns                = nullptr;
     int                         _rowCount               = 0;
+    Vehicle*                    _vehicle                = nullptr;
 
 private slots:
     void _offlineVehicleTypeChanged(void);
@@ -102,6 +112,7 @@ private:
     QString                 _pascalCase                     (const QString& text);
     void                    _saveValueData                  (QSettings& settings, InstrumentValueData* value);
     void                    _loadValueData                  (QSettings& settings, InstrumentValueData* value);
+    QString                 _settingsKey                    (void);
 
     // These are user facing string for the various enums.
     static       QStringList _iconNames;
@@ -124,6 +135,12 @@ private:
     static constexpr const char* _rangeOpacitiesKey   = "rangeOpacities";
 
     static constexpr const char* _deprecatedGroupKey =  "ValuesWidget";
+
+    // Static list of all instances. Used to notify others when settings have changed.
+    static QList<FactValueGrid*>& instances() {
+        static QList<FactValueGrid*> instanceList;
+        return instanceList;
+    }
 };
 
 QML_DECLARE_TYPE(FactValueGrid)

--- a/src/QmlControls/HorizontalFactValueGrid.cc
+++ b/src/QmlControls/HorizontalFactValueGrid.cc
@@ -9,8 +9,13 @@
 
 #include "HorizontalFactValueGrid.h"
 
+// for activeVehicle telem table
 const QString HorizontalFactValueGrid::telemetryBarUserSettingsGroup    ("TelemetryBarUserSettings");
 const QString HorizontalFactValueGrid::telemetryBarDefaultSettingsGroup ("TelemetryBarDefaultSettings");
+
+// for multi-vehicle list telem tables
+const QString HorizontalFactValueGrid::vehicleCardUserSettingsGroup    ("VehicleCardUserSettings");
+const QString HorizontalFactValueGrid::vehicleCardDefaultSettingsGroup ("VehicleCardDefaultSettings");
 
 HorizontalFactValueGrid::HorizontalFactValueGrid(QQuickItem* parent)
     : FactValueGrid(parent)

--- a/src/QmlControls/HorizontalFactValueGrid.h
+++ b/src/QmlControls/HorizontalFactValueGrid.h
@@ -24,8 +24,14 @@ public:
     Q_PROPERTY(QString telemetryBarDefaultSettingsGroup MEMBER telemetryBarDefaultSettingsGroup CONSTANT)
     Q_PROPERTY(QString telemetryBarUserSettingsGroup    MEMBER telemetryBarUserSettingsGroup    CONSTANT)
 
+    Q_PROPERTY(QString vehicleCardDefaultSettingsGroup  MEMBER vehicleCardDefaultSettingsGroup  CONSTANT)
+    Q_PROPERTY(QString vehicleCardUserSettingsGroup     MEMBER vehicleCardUserSettingsGroup     CONSTANT)
+
     static const QString telemetryBarDefaultSettingsGroup;
     static const QString telemetryBarUserSettingsGroup;
+
+    static const QString vehicleCardDefaultSettingsGroup;
+    static const QString vehicleCardUserSettingsGroup;
 
 private:
     Q_DISABLE_COPY(HorizontalFactValueGrid)

--- a/src/QmlControls/InstrumentValueData.h
+++ b/src/QmlControls/InstrumentValueData.h
@@ -30,7 +30,7 @@ public:
     };
     Q_ENUMS(RangeType)
 
-    explicit InstrumentValueData(FactValueGrid* factValueGrid, QObject* parent);
+    explicit InstrumentValueData(FactValueGrid* factValueGrid, QObject* parent, Vehicle* vehicle);
 
     Q_PROPERTY(FactValueGrid*       factValueGrid       MEMBER _factValueGrid                               CONSTANT)
     Q_PROPERTY(QStringList          factGroupNames      READ    factGroupNames                              NOTIFY factGroupNamesChanged)
@@ -103,7 +103,7 @@ signals:
 private slots:
     void _resetRangeInfo        (void);
     void _updateRanges          (void);
-    void _activeVehicleChanged  (Vehicle* activeVehicle);
+    void _vehicleChanged        (void);
     void _lookForMissingFact    (void);
 
 private:
@@ -114,7 +114,7 @@ private:
     void _setFactWorker         (void);
 
     FactValueGrid*          _factValueGrid =        nullptr;
-    Vehicle*                _activeVehicle =        nullptr;
+    Vehicle*                _vehicle =              nullptr;
     QmlObjectListModel*     _rowModel =             nullptr;
     Fact*                   _fact =                 nullptr;
     QString                 _factName;

--- a/src/QmlControls/QGroundControl/FlightMap/qmldir
+++ b/src/QmlControls/QGroundControl/FlightMap/qmldir
@@ -8,6 +8,8 @@ CenterMapDropButton         1.0 CenterMapDropButton.qml
 CenterMapDropPanel          1.0 CenterMapDropPanel.qml
 CompassDial                 1.0 CompassDial.qml
 CompassHeadingIndicator     1.0 CompassHeadingIndicator.qml
+IntegratedAttitudeIndicator 1.0 IntegratedAttitudeIndicator.qml
+IntegratedCompassAttitude   1.0 IntegratedCompassAttitude.qml
 MapFitFunctions             1.0 MapFitFunctions.qml
 MapLineArrow                1.0 MapLineArrow.qml
 MapScale                    1.0 MapScale.qml


### PR DESCRIPTION
## Feature Description
Operators are now given a customizable Telemetry data table in each vehicle card!

## Importance
This was a request from a flight test team that was using QGC to fly multiple prototype autonomous fixed wing vehicles. When flying the vehicles, altitude/air-speed needs to be monitored for all vehicles at once to avoid stalls/crashes.

## Screenshots
![t1](https://github.com/user-attachments/assets/a58d8f3f-a917-4975-a5dc-44b8416fe4b1)
![t2](https://github.com/user-attachments/assets/86cd736b-9bee-48c1-bd1f-c430d9fd989a)
![t3](https://github.com/user-attachments/assets/b6adedab-5ce1-4c32-9e59-84f887195fbd)
![t4](https://github.com/user-attachments/assets/4e8380f5-cf25-4974-9fab-cab7b5c31c83)

## Steps to Reproduce
I used PX4's mutli vehicle sim while developing/testing
```
# From PX4-Autopilot directory 
./Tools/simulation/gazebo-classic/sitl_multiple_run.sh -m plane -n 2
```

## Sponsor
This contribution was sponsored by [Firestorm](https://www.launchfirestorm.com/)
![654d4f9476ff2a38f37e9ab9_firestorm-homepage-share-img-2](https://github.com/user-attachments/assets/bc1a2c95-b33d-4a2d-af35-4d2d8651d0a2)