### PR TITLE
Restore VideoManager and CustomVideoManager support

### DIFF
--- a/custom-example/src/CustomVideoManager.cc
+++ b/custom-example/src/CustomVideoManager.cc
@@ -1,0 +1,39 @@
+/****************************************************************************
+ *
+ *   (c) 2009-2019 QGROUNDCONTROL PROJECT <http://www.qgroundcontrol.org>
+ *
+ * QGroundControl is licensed according to the terms in the file
+ * COPYING.md in the root of the source code directory.
+ *
+ ****************************************************************************/
+
+#include "CustomVideoManager.h"
+#include "MultiVehicleManager.h"
+#include "CustomCameraManager.h"
+#include "CustomCameraControl.h"
+
+//-----------------------------------------------------------------------------
+CustomVideoManager::CustomVideoManager(QGCApplication* app, QGCToolbox* toolbox)
+    : VideoManager(app, toolbox)
+{
+}
+
+//-----------------------------------------------------------------------------
+void
+CustomVideoManager::_updateSettings()
+{
+    if(!_videoSettings || !_videoReceiver)
+        return;
+    //-- Check encoding
+    if(_activeVehicle && _activeVehicle->dynamicCameras()) {
+        CustomCameraControl* pCamera = dynamic_cast<CustomCameraControl*>(_activeVehicle->dynamicCameras()->currentCameraInstance());
+        if(pCamera) {
+            Fact *fact = pCamera->videoEncoding();
+            if (fact) {
+                _videoReceiver->setVideoDecoder(static_cast<VideoReceiver::VideoEncoding>(fact->rawValue().toInt()));
+            }
+        }
+    }
+    VideoManager::_updateSettings();
+}
+

--- a/custom-example/src/CustomVideoManager.h
+++ b/custom-example/src/CustomVideoManager.h
@@ -1,0 +1,28 @@
+/****************************************************************************
+ *
+ *   (c) 2009-2019 QGROUNDCONTROL PROJECT <http://www.qgroundcontrol.org>
+ *
+ * QGroundControl is licensed according to the terms in the file
+ * COPYING.md in the root of the source code directory.
+ *
+ ****************************************************************************/
+
+#pragma once
+
+#include <QObject>
+#include <QTimer>
+#include <QTime>
+#include <QUrl>
+
+#include "VideoManager.h"
+
+class CustomVideoManager : public VideoManager
+{
+    Q_OBJECT
+public:
+    CustomVideoManager      (QGCApplication* app, QGCToolbox* toolbox);
+
+protected:
+    void _updateSettings    ();
+
+};

--- a/src/VideoManager/CMakeLists.txt
+++ b/src/VideoManager/CMakeLists.txt
@@ -1,19 +1,29 @@
-find_package(Qt6 REQUIRED COMPONENTS Core QmlIntegration)
-
-target_sources(QGC
-    PRIVATE
-        SubtitleWriter.cc
-        SubtitleWriter.h
-        VideoManager.cc
-        VideoManager.h
-)
-
 add_subdirectory(VideoReceiver)
 
-target_link_libraries(QGC
-    PUBLIC
-        Qt6::Core
-        Qt6::QmlIntegration
+find_package(Qt6 REQUIRED COMPONENTS Core)
+
+qt_add_library(VideoManager STATIC
+    SubtitleWriter.cc
+    SubtitleWriter.h
+    VideoManager.cc
+    VideoManager.h
 )
 
-target_include_directories(QGC PUBLIC ${CMAKE_CURRENT_SOURCE_DIR})
+target_link_libraries(VideoManager
+    PRIVATE
+        API
+        Camera
+        FactSystem
+        QmlControls
+        Settings
+        Utilities
+        Vehicle
+    PUBLIC
+        Qt6::Core
+        GStreamerReceiver
+        QGC
+        QtMultimediaReceiver
+        VideoReceiver
+)
+
+target_include_directories(VideoManager PUBLIC ${CMAKE_CURRENT_SOURCE_DIR})

--- a/src/VideoManager/SubtitleWriter.cc
+++ b/src/VideoManager/SubtitleWriter.cc
@@ -1,6 +1,6 @@
 /****************************************************************************
  *
- * (c) 2009-2024 QGROUNDCONTROL PROJECT <http://www.qgroundcontrol.org>
+ * (c) 2009-2020 QGROUNDCONTROL PROJECT <http://www.qgroundcontrol.org>
  *
  * QGroundControl is licensed according to the terms in the file
  * COPYING.md in the root of the source code directory.
@@ -26,22 +26,13 @@
 #include <QtCore/QDateTime>
 #include <QtCore/QString>
 #include <QtCore/QFileInfo>
-#include <QtCore/QTimer>
 
-QGC_LOGGING_CATEGORY(SubtitleWriterLog, "qgc.videomanager.subtitlewriter")
+QGC_LOGGING_CATEGORY(SubtitleWriterLog, "SubtitleWriterLog")
 
 SubtitleWriter::SubtitleWriter(QObject* parent)
     : QObject(parent)
-    , _timer(new QTimer(this))
 {
-    // qCDebug(SubtitleWriterLog) << Q_FUNC_INFO << this;
-
-    (void) connect(_timer, &QTimer::timeout, this, &SubtitleWriter::_captureTelemetry);
-}
-
-SubtitleWriter::~SubtitleWriter()
-{
-    // qCDebug(SubtitleWriterLog) << Q_FUNC_INFO << this;
+    connect(&_timer, &QTimer::timeout, this, &SubtitleWriter::_captureTelemetry);
 }
 
 void SubtitleWriter::startCapturingTelemetry(const QString& videoFile)
@@ -58,9 +49,7 @@ void SubtitleWriter::startCapturingTelemetry(const QString& videoFile)
         QmlObjectListModel* list = grid->columns()->value<QmlObjectListModel*>(colIndex);
         for (int rowIndex = 0; rowIndex < list->count(); rowIndex++) {
             InstrumentValueData* value = list->value<InstrumentValueData*>(rowIndex);
-            if (value->fact()) {
-                _facts += value->fact();
-            }
+            _facts += value->fact();
         }
     }
     grid->deleteLater();
@@ -102,13 +91,13 @@ void SubtitleWriter::startCapturingTelemetry(const QString& videoFile)
     // TODO: Find a good way to input title
     //stream << QStringLiteral("Dialogue: 0,0:00:00.00,999:00:00.00,Default,,0,0,0,,{\\pos(5,35)}%1\n");
 
-    _timer->start(1000/_sampleRate);
+    _timer.start(1000/_sampleRate);
 }
 
 void SubtitleWriter::stopCapturingTelemetry()
 {
     qCDebug(SubtitleWriterLog) << "Stopping writing";
-    _timer->stop();
+    _timer.stop();
     _file.close();
 }
 
@@ -117,7 +106,7 @@ void SubtitleWriter::_captureTelemetry()
     static const float nRows = 3; // number of rows used for displaying data
     static const int offsetFactor = 700; // Used to simulate a larger resolution and reduce the borders in the layout
 
-    auto *vehicle = MultiVehicleManager::instance()->activeVehicle();
+    auto *vehicle = qgcApp()->toolbox()->multiVehicleManager()->activeVehicle();
 
     if (!vehicle) {
         qCWarning(SubtitleWriterLog) << "Attempting to capture fact data with no active vehicle!";

--- a/src/VideoManager/SubtitleWriter.h
+++ b/src/VideoManager/SubtitleWriter.h
@@ -1,6 +1,6 @@
 /****************************************************************************
  *
- * (c) 2009-2024 QGROUNDCONTROL PROJECT <http://www.qgroundcontrol.org>
+ * (c) 2009-2020 QGROUNDCONTROL PROJECT <http://www.qgroundcontrol.org>
  *
  * QGroundControl is licensed according to the terms in the file
  * COPYING.md in the root of the source code directory.
@@ -17,12 +17,12 @@
 #pragma once
 
 #include <QtCore/QObject>
+#include <QtCore/QTimer>
 #include <QtCore/QTime>
 #include <QtCore/QFile>
 #include <QtCore/QLoggingCategory>
 
 class Fact;
-class QTimer;
 
 Q_DECLARE_LOGGING_CATEGORY(SubtitleWriterLog)
 
@@ -32,10 +32,10 @@ class SubtitleWriter : public QObject
 
 public:
     explicit SubtitleWriter(QObject* parent = nullptr);
-    ~SubtitleWriter();
+    ~SubtitleWriter() = default;
 
     // starts capturing vehicle telemetry.
-    void startCapturingTelemetry(const QString &videoFile);
+    void startCapturingTelemetry(const QString& videoFile);
     void stopCapturingTelemetry();
 
 private slots:
@@ -43,7 +43,7 @@ private slots:
     void _captureTelemetry();
 
 private:
-    QTimer* _timer = nullptr;
+    QTimer _timer;
     QList<Fact*> _facts;
     QTime _lastEndTime;
     QFile _file;

--- a/src/VideoManager/VideoManager.cc
+++ b/src/VideoManager/VideoManager.cc
@@ -1,529 +1,476 @@
 /****************************************************************************
  *
- * (c) 2009-2024 QGROUNDCONTROL PROJECT <http://www.qgroundcontrol.org>
+ * (c) 2009-2020 QGROUNDCONTROL PROJECT <http://www.qgroundcontrol.org>
  *
  * QGroundControl is licensed according to the terms in the file
  * COPYING.md in the root of the source code directory.
  *
  ****************************************************************************/
 
-#include "VideoManager.h"
-#include "MultiVehicleManager.h"
 #include "QGCApplication.h"
-#include "QGCCameraManager.h"
+#include "VideoManager.h"
+#include "QGCToolbox.h"
 #include "QGCCorePlugin.h"
-#include "QGCLoggingCategory.h"
+#include "MultiVehicleManager.h"
 #include "SettingsManager.h"
-#include "AppSettings.h"
-#include "SubtitleWriter.h"
 #include "Vehicle.h"
+#include "QGCCameraManager.h"
+#include "QGCLoggingCategory.h"
+#include <QtQml/QQmlEngine>
 #include "VideoReceiver.h"
-#include "VideoSettings.h"
-#ifdef QGC_GST_STREAMING
+
+#if defined(QGC_GST_STREAMING)
 #include "GStreamer.h"
+#include "VideoSettings.h"
+#include <QtCore/QDir>
 #else
 #include "GLVideoItemStub.h"
 #endif
-#ifdef QGC_QT_STREAMING
-#include "QtMultimediaReceiver.h"
-// #include "UVCReceiver.h"
-#endif
 
 #ifndef QGC_DISABLE_UVC
-#include <QtCore/QPermissions>
-#include <QtMultimedia/QCameraDevice>
 #include <QtMultimedia/QMediaDevices>
+#include <QtMultimedia/QCameraDevice>
+#include <QtCore/QPermissions>
 #include <QtQuick/QQuickWindow>
 #endif
 
-#include <QtCore/qapplicationstatic.h>
-#include <QtCore/QDir>
-#include <QtQml/QQmlEngine>
-#include <QtQuick/QQuickItem>
+QGC_LOGGING_CATEGORY(VideoManagerLog, "VideoManagerLog")
 
-QGC_LOGGING_CATEGORY(VideoManagerLog, "qgc.videomanager.videomanager")
-
-static constexpr const char *kFileExtension[VideoReceiver::FILE_FORMAT_MAX - VideoReceiver::FILE_FORMAT_MIN] = {
+#if defined(QGC_GST_STREAMING)
+static constexpr const char* kFileExtension[VideoReceiver::FILE_FORMAT_MAX - VideoReceiver::FILE_FORMAT_MIN] = {
     "mkv",
     "mov",
     "mp4"
 };
+#endif
 
-Q_APPLICATION_STATIC(VideoManager, _videoManagerInstance);
-
-VideoManager::VideoManager(QObject *parent)
-    : QObject(parent)
-    , _subtitleWriter(new SubtitleWriter(this))
-    , _videoSettings(SettingsManager::instance()->videoSettings())
+//-----------------------------------------------------------------------------
+VideoManager::VideoManager(QGCApplication* app, QGCToolbox* toolbox)
+    : QGCTool(app, toolbox)
 {
-    // qCDebug(VideoManagerLog) << Q_FUNC_INFO << this;
-
-#ifdef QGC_GST_STREAMING
-    GStreamer::initialize();
+#if !defined(QGC_GST_STREAMING)
+    static bool once = false;
+    if (!once) {
+        qmlRegisterType<GLVideoItemStub>("org.freedesktop.gstreamer.Qt6GLVideoItem", 1, 0, "GstGLQt6VideoItem");
+        once = true;
+    }
 #endif
 }
 
+//-----------------------------------------------------------------------------
 VideoManager::~VideoManager()
 {
-    // qCDebug(VideoManagerLog) << Q_FUNC_INFO << this;
+    for (int i = 0; i < 2; i++) {
+        if (_videoReceiver[i] != nullptr) {
+            delete _videoReceiver[i];
+            _videoReceiver[i] = nullptr;
+        }
+#if defined(QGC_GST_STREAMING)
+        if (_videoSink[i] != nullptr) {
+            // FIXME: AV: we need some interaface for video sink with .release() call
+            // Currently VideoManager is destroyed after corePlugin() and we are crashing on app exit
+            // calling qgcApp()->toolbox()->corePlugin()->releaseVideoSink(_videoSink[i]);
+            // As for now let's call GStreamer::releaseVideoSink() directly
+            GStreamer::releaseVideoSink(_videoSink[i]);
+            _videoSink[i] = nullptr;
+        }
+#endif
+    }
 }
 
-VideoManager *VideoManager::instance()
+//-----------------------------------------------------------------------------
+void
+VideoManager::setToolbox(QGCToolbox *toolbox)
 {
-    return _videoManagerInstance();
+   QGCTool::setToolbox(toolbox);
+   QQmlEngine::setObjectOwnership(this, QQmlEngine::CppOwnership);
+   qmlRegisterUncreatableType<VideoManager> ("QGroundControl.VideoManager", 1, 0, "VideoManager", "Reference only");
+   qmlRegisterUncreatableType<VideoReceiver>("QGroundControl",              1, 0, "VideoReceiver","Reference only");
+
+   // TODO: Those connections should be Per Video, not per VideoManager.
+   _videoSettings = toolbox->settingsManager()->videoSettings();
+   QString videoSource = _videoSettings->videoSource()->rawValue().toString();
+   connect(_videoSettings->videoSource(),   &Fact::rawValueChanged, this, &VideoManager::_videoSourceChanged);
+   connect(_videoSettings->udpPort(),       &Fact::rawValueChanged, this, &VideoManager::_udpPortChanged);
+   connect(_videoSettings->rtspUrl(),       &Fact::rawValueChanged, this, &VideoManager::_rtspUrlChanged);
+   connect(_videoSettings->tcpUrl(),        &Fact::rawValueChanged, this, &VideoManager::_tcpUrlChanged);
+   connect(_videoSettings->aspectRatio(),   &Fact::rawValueChanged, this, &VideoManager::_aspectRatioChanged);
+   connect(_videoSettings->lowLatencyMode(),&Fact::rawValueChanged, this, &VideoManager::_lowLatencyModeChanged);
+   MultiVehicleManager *pVehicleMgr = qgcApp()->toolbox()->multiVehicleManager();
+   connect(pVehicleMgr, &MultiVehicleManager::activeVehicleChanged, this, &VideoManager::_setActiveVehicle);
+
+#if defined(QGC_GST_STREAMING)
+    GStreamer::blacklist(static_cast<VideoDecoderOptions>(_videoSettings->forceVideoDecoder()->rawValue().toInt()));
+#ifndef QGC_DISABLE_UVC
+   // If we are using a UVC camera setup the device name
+   _updateUVC();
+#endif
+
+    emit isGStreamerChanged();
+    qCDebug(VideoManagerLog) << "New Video Source:" << videoSource;
+#if defined(QGC_GST_STREAMING)
+    _videoReceiver[0] = toolbox->corePlugin()->createVideoReceiver(this);
+    _videoReceiver[1] = toolbox->corePlugin()->createVideoReceiver(this);
+
+    connect(_videoReceiver[0], &VideoReceiver::streamingChanged, this, [this](bool active){
+        _streaming = active;
+        emit streamingChanged();
+    });
+
+    connect(_videoReceiver[0], &VideoReceiver::onStartComplete, this, [this](VideoReceiver::STATUS status) {
+        qCDebug(VideoManagerLog) << "Video 0 Start complete, status: " << status;
+        if (status == VideoReceiver::STATUS_OK) {
+            _videoStarted[0] = true;
+            if (_videoSink[0] != nullptr) {
+                qCDebug(VideoManagerLog) << "Video 0 start decoding";
+                // It is absolutely ok to have video receiver active (streaming) and decoding not active
+                // It should be handy for cases when you have many streams and want to show only some of them
+                // NOTE that even if decoder did not start it is still possible to record video
+                _videoReceiver[0]->startDecoding(_videoSink[0]);
+            }
+        } else if (status == VideoReceiver::STATUS_INVALID_URL) {
+            // Invalid URL - don't restart
+        } else if (status == VideoReceiver::STATUS_INVALID_STATE) {
+            // Already running
+        } else {
+            _restartVideo(0);
+        }
+    });
+
+    connect(_videoReceiver[0], &VideoReceiver::onStopComplete, this, [this](VideoReceiver::STATUS status) {
+        qCDebug(VideoManagerLog) << "Video 0 Stop complete, status: " << status;
+        _videoStarted[0] = false;
+        if (status == VideoReceiver::STATUS_INVALID_URL) {
+            qCDebug(VideoManagerLog) << "Invalid video URL. Not restarting";
+        } else {
+            _startReceiver(0);
+        }
+    });
+
+    connect(_videoReceiver[0], &VideoReceiver::decodingChanged, this, [this](bool active){
+        qCDebug(VideoManagerLog) << "Video 0 decoding changed, active: " << (active ? "yes" : "no");
+        _decoding = active;
+        emit decodingChanged();
+    });
+
+    connect(_videoReceiver[0], &VideoReceiver::recordingChanged, this, [this](bool active){
+        qCDebug(VideoManagerLog) << "Video 0 recording changed, active: " << (active ? "yes" : "no");
+        _recording = active;
+        if (!active) {
+            _subtitleWriter.stopCapturingTelemetry();
+        }
+        emit recordingChanged();
+    });
+
+    connect(_videoReceiver[0], &VideoReceiver::recordingStarted, this, [this](){
+        qCDebug(VideoManagerLog) << "Video 0 recording started";
+        _subtitleWriter.startCapturingTelemetry(_videoFile);
+    });
+
+    connect(_videoReceiver[0], &VideoReceiver::videoSizeChanged, this, [this](QSize size){
+        qCDebug(VideoManagerLog) << "Video 0 resized. New resolution: " << size.width() << "x" << size.height();
+        _videoSize = ((quint32)size.width() << 16) | (quint32)size.height();
+        emit videoSizeChanged();
+    });
+
+    //connect(_videoReceiver, &VideoReceiver::onTakeScreenshotComplete, this, [this](VideoReceiver::STATUS status){
+    //    if (status == VideoReceiver::STATUS_OK) {
+    //    }
+    //});
+
+    // FIXME: AV: I believe _thermalVideoReceiver should be handled just like _videoReceiver in terms of event
+    // and I expect that it will be changed during multiple video stream activity
+    if (_videoReceiver[1] != nullptr) {
+        connect(_videoReceiver[1], &VideoReceiver::onStartComplete, this, [this](VideoReceiver::STATUS status) {
+            if (status == VideoReceiver::STATUS_OK) {
+                _videoStarted[1] = true;
+                if (_videoSink[1] != nullptr) {
+                    _videoReceiver[1]->startDecoding(_videoSink[1]);
+                }
+            } else if (status == VideoReceiver::STATUS_INVALID_URL) {
+                // Invalid URL - don't restart
+            } else if (status == VideoReceiver::STATUS_INVALID_STATE) {
+                // Already running
+            } else {
+                _restartVideo(1);
+            }
+        });
+
+        connect(_videoReceiver[1], &VideoReceiver::onStopComplete, this, [this](VideoReceiver::STATUS) {
+            _videoStarted[1] = false;
+            _startReceiver(1);
+        });
+    }
+#endif
+    _updateSettings(0);
+    _updateSettings(1);
+    if(isGStreamer()) {
+        startVideo();
+    } else {
+        stopVideo();
+    }
+
+#endif
 }
 
-void VideoManager::registerQmlTypes()
+void VideoManager::_cleanupOldVideos()
 {
-    (void) qmlRegisterUncreatableType<VideoManager>("QGroundControl.VideoManager", 1, 0, "VideoManager", "Reference only");
-    (void) qmlRegisterUncreatableType<VideoReceiver>("QGroundControl", 1, 0, "VideoReceiver","Reference only");
-    #ifndef QGC_GST_STREAMING
-        (void) qmlRegisterType<GLVideoItemStub>("org.freedesktop.gstreamer.Qt6GLVideoItem", 1, 0, "GstGLQt6VideoItem");
-    #endif
+#if defined(QGC_GST_STREAMING)
+    //-- Only perform cleanup if storage limit is enabled
+    if(!_videoSettings->enableStorageLimit()->rawValue().toBool()) {
+        return;
+    }
+    QString savePath = qgcApp()->toolbox()->settingsManager()->appSettings()->videoSavePath();
+    QDir videoDir = QDir(savePath);
+    videoDir.setFilter(QDir::Files | QDir::Readable | QDir::NoSymLinks | QDir::Writable);
+    videoDir.setSorting(QDir::Time);
+
+    QStringList nameFilters;
+
+    for(size_t i = 0; i < sizeof(kFileExtension) / sizeof(kFileExtension[0]); i += 1) {
+        nameFilters << QString("*.") + kFileExtension[i];
+    }
+
+    videoDir.setNameFilters(nameFilters);
+    //-- get the list of videos stored
+    QFileInfoList vidList = videoDir.entryInfoList();
+    if(!vidList.isEmpty()) {
+        uint64_t total   = 0;
+        //-- Settings are stored using MB
+        uint64_t maxSize = _videoSettings->maxVideoSize()->rawValue().toUInt() * 1024 * 1024;
+        //-- Compute total used storage
+        for(int i = 0; i < vidList.size(); i++) {
+            total += vidList[i].size();
+        }
+        //-- Remove old movies until max size is satisfied.
+        while(total >= maxSize && !vidList.isEmpty()) {
+            total -= vidList.last().size();
+            qCDebug(VideoManagerLog) << "Removing old video file:" << vidList.last().filePath();
+            QFile file (vidList.last().filePath());
+            file.remove();
+            vidList.removeLast();
+        }
+    }
+#endif
 }
 
-void VideoManager::init()
+//-----------------------------------------------------------------------------
+void
+VideoManager::startVideo()
 {
-    if (_initialized) {
+    if (qgcApp()->runningUnitTests()) {
         return;
     }
 
-    // TODO: Those connections should be Per Video, not per VideoManager.
-    (void) connect(_videoSettings->videoSource(), &Fact::rawValueChanged, this, &VideoManager::_videoSourceChanged);
-    (void) connect(_videoSettings->udpPort(), &Fact::rawValueChanged, this, &VideoManager::_videoSourceChanged);
-    (void) connect(_videoSettings->rtspUrl(), &Fact::rawValueChanged, this, &VideoManager::_videoSourceChanged);
-    (void) connect(_videoSettings->tcpUrl(), &Fact::rawValueChanged, this, &VideoManager::_videoSourceChanged);
-    (void) connect(_videoSettings->aspectRatio(), &Fact::rawValueChanged, this, &VideoManager::aspectRatioChanged);
-    (void) connect(_videoSettings->lowLatencyMode(), &Fact::rawValueChanged, this, &VideoManager::_lowLatencyModeChanged);
-    (void) connect(MultiVehicleManager::instance(), &MultiVehicleManager::activeVehicleChanged, this, &VideoManager::_setActiveVehicle);
-
-    int index = 0;
-    const QStringList widgetTypes = {"videoContent", "thermalVideo"};
-    Q_ASSERT(widgetTypes.length() <= _videoReceiverData.length());
-    for (VideoReceiverData &videoReceiver : _videoReceiverData) {
-        videoReceiver.index = index++;
-        videoReceiver.receiver = QGCCorePlugin::instance()->createVideoReceiver(this);
-        if (!videoReceiver.receiver) {
-            continue;
-        }
-        videoReceiver.name = widgetTypes[videoReceiver.index];
-
-        (void) connect(videoReceiver.receiver, &VideoReceiver::onStartComplete, this, [this, &videoReceiver](VideoReceiver::STATUS status) {
-            qCDebug(VideoManagerLog) << "Video" << videoReceiver.index << "Start complete, status:" << status;
-            switch (status) {
-            case VideoReceiver::STATUS_OK:
-                videoReceiver.started = true;
-                if (videoReceiver.sink) {
-                    videoReceiver.receiver->startDecoding(videoReceiver.sink);
-                }
-                break;
-            case VideoReceiver::STATUS_INVALID_URL:
-            case VideoReceiver::STATUS_INVALID_STATE:
-                break;
-            default:
-                _restartVideo(videoReceiver.index);
-                break;
-            }
-        });
-
-        (void) connect(videoReceiver.receiver, &VideoReceiver::onStopComplete, this, [this, &videoReceiver](VideoReceiver::STATUS status) {
-            qCDebug(VideoManagerLog) << "Video" << videoReceiver.index << "Stop complete, status:" << status;
-            videoReceiver.started = false;
-            if (status == VideoReceiver::STATUS_INVALID_URL) {
-                qCDebug(VideoManagerLog) << "Invalid video URL. Not restarting";
-            } else {
-                _startReceiver(videoReceiver.index);
-            }
-        });
-
-        // TODO: Create status variables for each receiver in VideoReceiverData
-        (void) connect(videoReceiver.receiver, &VideoReceiver::streamingChanged, this, [this, &videoReceiver](bool active) {
-            qCDebug(VideoManagerLog) << "Video" << videoReceiver.index << "streaming changed, active:" << (active ? "yes" : "no");
-            if (videoReceiver.index == 0) {
-                _streaming = active;
-                emit streamingChanged();
-            }
-        });
-
-        (void) connect(videoReceiver.receiver, &VideoReceiver::decodingChanged, this, [this, &videoReceiver](bool active) {
-            qCDebug(VideoManagerLog) << "Video" << videoReceiver.index << "decoding changed, active:" << (active ? "yes" : "no");
-            if (videoReceiver.index == 0) {
-                _decoding = active;
-                emit decodingChanged();
-            }
-        });
-
-        (void) connect(videoReceiver.receiver, &VideoReceiver::recordingChanged, this, [this, &videoReceiver](bool active) {
-            qCDebug(VideoManagerLog) << "Video" << videoReceiver.index << "recording changed, active:" << (active ? "yes" : "no");
-            if (videoReceiver.index == 0) {
-                _recording = active;
-                if (!active) {
-                    _subtitleWriter->stopCapturingTelemetry();
-                }
-                emit recordingChanged();
-            }
-        });
-
-        (void) connect(videoReceiver.receiver, &VideoReceiver::recordingStarted, this, [this, &videoReceiver]() {
-            qCDebug(VideoManagerLog) << "Video" << videoReceiver.index << "recording started";
-            if (videoReceiver.index == 0) {
-                _subtitleWriter->startCapturingTelemetry(_videoFile);
-            }
-        });
-
-        (void) connect(videoReceiver.receiver, &VideoReceiver::videoSizeChanged, this, [this, &videoReceiver](QSize size) {
-            qCDebug(VideoManagerLog) << "Video" << videoReceiver.index << "resized. New resolution:" << size.width() << "x" << size.height();
-            if (videoReceiver.index == 0) {
-                _videoSize = (static_cast<quint32>(size.width()) << 16) | static_cast<quint32>(size.height());
-                emit videoSizeChanged();
-            }
-        });
-
-        (void) connect(videoReceiver.receiver, &VideoReceiver::onTakeScreenshotComplete, this, [&videoReceiver](VideoReceiver::STATUS status) {
-            if (status == VideoReceiver::STATUS_OK) {
-                qCDebug(VideoManagerLog) << "Video" << videoReceiver.index << "screenshot taken";
-            } else {
-                qCWarning(VideoManagerLog) << "Video" << videoReceiver.index << "screenshot failed";
-            }
-        });
-    }
-
-    _videoSourceChanged();
-
-    startVideo();
-
-    QQuickWindow *const rootWindow = qgcApp()->mainRootWindow();
-    if (rootWindow) {
-        rootWindow->scheduleRenderJob(new FinishVideoInitialization(), QQuickWindow::BeforeSynchronizingStage);
-    }
-
-    _initialized = true;
-}
-
-void VideoManager::cleanup()
-{
-    for (VideoReceiverData &videoReceiver : _videoReceiverData) {
-        QGCCorePlugin::instance()->releaseVideoSink(videoReceiver.sink);
-        delete videoReceiver.receiver;
-        videoReceiver.receiver = nullptr;
-    }
-}
-
-void VideoManager::startVideo()
-{
-    if (!_videoSettings->streamEnabled()->rawValue().toBool() || !hasVideo()) {
+    if(!_videoSettings->streamEnabled()->rawValue().toBool() || !_videoSettings->streamConfigured()) {
         qCDebug(VideoManagerLog) << "Stream not enabled/configured";
         return;
     }
 
-    for (const VideoReceiverData &videoReceiver : _videoReceiverData) {
-        _startReceiver(videoReceiver.index);
-    }
+    _startReceiver(0);
+    _startReceiver(1);
 }
 
-void VideoManager::stopVideo()
+//-----------------------------------------------------------------------------
+void
+VideoManager::stopVideo()
 {
-    for (const VideoReceiverData &videoReceiver : _videoReceiverData) {
-        _stopReceiver(videoReceiver.index);
-    }
-}
-
-void VideoManager::startRecording(const QString &videoFile)
-{
-    const VideoReceiver::FILE_FORMAT fileFormat = static_cast<VideoReceiver::FILE_FORMAT>(_videoSettings->recordingFormat()->rawValue().toInt());
-    if ((fileFormat < VideoReceiver::FILE_FORMAT_MIN) || (fileFormat >= VideoReceiver::FILE_FORMAT_MAX)) {
-        qgcApp()->showAppMessage(tr("Invalid video format defined."));
+    if (qgcApp()->runningUnitTests()) {
         return;
     }
 
+    _stopReceiver(1);
+    _stopReceiver(0);
+}
+
+void
+VideoManager::startRecording(const QString& videoFile)
+{
+    if (qgcApp()->runningUnitTests()) {
+        return;
+    }
+#if defined(QGC_GST_STREAMING)
+    if (!_videoReceiver[0]) {
+        qgcApp()->showAppMessage(tr("Video receiver is not ready."));
+        return;
+    }
+
+    const VideoReceiver::FILE_FORMAT fileFormat = static_cast<VideoReceiver::FILE_FORMAT>(_videoSettings->recordingFormat()->rawValue().toInt());
+
+    if(fileFormat < VideoReceiver::FILE_FORMAT_MIN || fileFormat >= VideoReceiver::FILE_FORMAT_MAX) {
+        qgcApp()->showAppMessage(tr("Invalid video format defined."));
+        return;
+    }
+    QString ext = kFileExtension[fileFormat - VideoReceiver::FILE_FORMAT_MIN];
+
+    //-- Disk usage maintenance
     _cleanupOldVideos();
 
-    const QString savePath = SettingsManager::instance()->appSettings()->videoSavePath();
+    QString savePath = qgcApp()->toolbox()->settingsManager()->appSettings()->videoSavePath();
+
     if (savePath.isEmpty()) {
         qgcApp()->showAppMessage(tr("Unabled to record video. Video save path must be specified in Settings."));
         return;
     }
 
-    const QString videoFileUrl = videoFile.isEmpty() ? QDateTime::currentDateTime().toString("yyyy-MM-dd_hh.mm.ss") : videoFile;
-    const QString ext = kFileExtension[fileFormat - VideoReceiver::FILE_FORMAT_MIN];
+    _videoFile = savePath + "/"
+            + (videoFile.isEmpty() ? QDateTime::currentDateTime().toString("yyyy-MM-dd_hh.mm.ss") : videoFile)
+            + ".";
+    QString videoFile2 = _videoFile + "2." + ext;
+    _videoFile += ext;
 
-    const QString videoFile1 = savePath + "/" + videoFileUrl + "." + ext;
-    const QString videoFile2 = savePath + "/" + videoFileUrl + ".2." + ext;
+    if (_videoReceiver[0] && _videoStarted[0]) {
+        _videoReceiver[0]->startRecording(_videoFile, fileFormat);
+    }
+    if (_videoReceiver[1] && _videoStarted[1]) {
+        _videoReceiver[1]->startRecording(videoFile2, fileFormat);
+    }
 
-    _videoFile = videoFile1;
+#else
+    Q_UNUSED(videoFile)
+#endif
+}
 
-    const QStringList videoFiles = {videoFile1, videoFile2};
-    for (VideoReceiverData &videoReceiver : _videoReceiverData) {
-        if (videoReceiver.receiver && videoReceiver.started) {
-            videoReceiver.receiver->startRecording(videoFiles.at(videoReceiver.index), fileFormat);
-        } else {
-            qCDebug(VideoManagerLog) << "Video receiver is not ready.";
+void
+VideoManager::stopRecording()
+{
+    if (qgcApp()->runningUnitTests()) {
+        return;
+    }
+#if defined(QGC_GST_STREAMING)
+
+    for (int i = 0; i < 2; i++) {
+        if (_videoReceiver[i]) {
+            _videoReceiver[i]->stopRecording();
         }
     }
+#endif
 }
 
-void VideoManager::stopRecording()
+void
+VideoManager::grabImage(const QString& imageFile)
 {
-    for (VideoReceiverData &videoReceiver : _videoReceiverData) {
-        videoReceiver.receiver->stopRecording();
+    if (qgcApp()->runningUnitTests()) {
+        return;
     }
-}
+#if defined(QGC_GST_STREAMING)
+    if (!_videoReceiver[0]) {
+        return;
+    }
 
-void VideoManager::grabImage(const QString &imageFile)
-{
     if (imageFile.isEmpty()) {
-        _imageFile = SettingsManager::instance()->appSettings()->photoSavePath();
-        _imageFile += "/" + QDateTime::currentDateTime().toString("yyyy-MM-dd_hh.mm.ss.zzz") + ".jpg";
+        _imageFile = qgcApp()->toolbox()->settingsManager()->appSettings()->photoSavePath();
+        _imageFile += + "/" + QDateTime::currentDateTime().toString("yyyy-MM-dd_hh.mm.ss.zzz") + ".jpg";
     } else {
         _imageFile = imageFile;
     }
 
     emit imageFileChanged();
 
-    _videoReceiverData[0].receiver->takeScreenshot(_imageFile);
+    _videoReceiver[0]->takeScreenshot(_imageFile);
+#else
+    Q_UNUSED(imageFile)
+#endif
 }
 
-double VideoManager::aspectRatio() const
+//-----------------------------------------------------------------------------
+double VideoManager::aspectRatio()
 {
-    if (_activeVehicle && _activeVehicle->cameraManager()) {
-        const QGCVideoStreamInfo* const pInfo = _activeVehicle->cameraManager()->currentStreamInstance();
-        if (pInfo) {
-            qCDebug(VideoManagerLog) << "Primary AR:" << pInfo->aspectRatio();
+    if(_activeVehicle && _activeVehicle->cameraManager()) {
+        QGCVideoStreamInfo* pInfo = _activeVehicle->cameraManager()->currentStreamInstance();
+        if(pInfo) {
+            qCDebug(VideoManagerLog) << "Primary AR: " << pInfo->aspectRatio();
             return pInfo->aspectRatio();
         }
     }
-
     // FIXME: AV: use _videoReceiver->videoSize() to calculate AR (if AR is not specified in the settings?)
     return _videoSettings->aspectRatio()->rawValue().toDouble();
 }
 
-double VideoManager::thermalAspectRatio() const
+//-----------------------------------------------------------------------------
+double VideoManager::thermalAspectRatio()
 {
-    if (_activeVehicle && _activeVehicle->cameraManager()) {
-        const QGCVideoStreamInfo* const pInfo = _activeVehicle->cameraManager()->thermalStreamInstance();
-        if (pInfo) {
-            qCDebug(VideoManagerLog) << "Thermal AR:" << pInfo->aspectRatio();
+    if(_activeVehicle && _activeVehicle->cameraManager()) {
+        QGCVideoStreamInfo* pInfo = _activeVehicle->cameraManager()->thermalStreamInstance();
+        if(pInfo) {
+            qCDebug(VideoManagerLog) << "Thermal AR: " << pInfo->aspectRatio();
             return pInfo->aspectRatio();
         }
     }
-
     return 1.0;
 }
 
-double VideoManager::hfov() const
+//-----------------------------------------------------------------------------
+double VideoManager::hfov()
 {
-    if (_activeVehicle && _activeVehicle->cameraManager()) {
-        const QGCVideoStreamInfo* const pInfo = _activeVehicle->cameraManager()->currentStreamInstance();
-        if (pInfo) {
+    if(_activeVehicle && _activeVehicle->cameraManager()) {
+        QGCVideoStreamInfo* pInfo = _activeVehicle->cameraManager()->currentStreamInstance();
+        if(pInfo) {
             return pInfo->hfov();
         }
     }
-
     return 1.0;
 }
 
-double VideoManager::thermalHfov() const
+//-----------------------------------------------------------------------------
+double VideoManager::thermalHfov()
 {
-    if (_activeVehicle && _activeVehicle->cameraManager()) {
-        const QGCVideoStreamInfo* const pInfo = _activeVehicle->cameraManager()->thermalStreamInstance();
-        if (pInfo) {
+    if(_activeVehicle && _activeVehicle->cameraManager()) {
+        QGCVideoStreamInfo* pInfo = _activeVehicle->cameraManager()->thermalStreamInstance();
+        if(pInfo) {
             return pInfo->aspectRatio();
         }
     }
-
     return _videoSettings->aspectRatio()->rawValue().toDouble();
 }
 
-bool VideoManager::hasThermal() const
+//-----------------------------------------------------------------------------
+bool
+VideoManager::hasThermal()
 {
-    if (_activeVehicle && _activeVehicle->cameraManager()) {
-        const QGCVideoStreamInfo* const pInfo = _activeVehicle->cameraManager()->thermalStreamInstance();
-        if (pInfo) {
+    if(_activeVehicle && _activeVehicle->cameraManager()) {
+        QGCVideoStreamInfo* pInfo = _activeVehicle->cameraManager()->thermalStreamInstance();
+        if(pInfo) {
             return true;
         }
     }
-
     return false;
 }
 
-bool VideoManager::autoStreamConfigured() const
+//-----------------------------------------------------------------------------
+QString
+VideoManager::imageFile()
 {
-    if (_activeVehicle && _activeVehicle->cameraManager()) {
-        const QGCVideoStreamInfo* const pInfo = _activeVehicle->cameraManager()->currentStreamInstance();
-        if (pInfo) {
+    return _imageFile;
+}
+
+//-----------------------------------------------------------------------------
+bool
+VideoManager::autoStreamConfigured()
+{
+#if defined(QGC_GST_STREAMING)
+    if(_activeVehicle && _activeVehicle->cameraManager()) {
+        QGCVideoStreamInfo* pInfo = _activeVehicle->cameraManager()->currentStreamInstance();
+        if(pInfo) {
             return !pInfo->uri().isEmpty();
         }
     }
-
-    return false;
-}
-
-bool VideoManager::hasVideo() const
-{
-    return (autoStreamConfigured() || _videoSettings->streamConfigured());
-}
-
-bool VideoManager::isStreamSource() const
-{
-    static const QStringList videoSourceList = {
-        VideoSettings::videoSourceUDPH264,
-        VideoSettings::videoSourceUDPH265,
-        VideoSettings::videoSourceRTSP,
-        VideoSettings::videoSourceTCP,
-        VideoSettings::videoSourceMPEGTS,
-        VideoSettings::videoSource3DRSolo,
-        VideoSettings::videoSourceParrotDiscovery,
-        VideoSettings::videoSourceYuneecMantisG,
-        VideoSettings::videoSourceHerelinkAirUnit,
-        VideoSettings::videoSourceHerelinkHotspot,
-    };
-    const QString videoSource = _videoSettings->videoSource()->rawValue().toString();
-    return (videoSourceList.contains(videoSource) || autoStreamConfigured());
-}
-
-bool VideoManager::isUvc() const
-{
-    return (uvcEnabled() && (hasVideo() && !_uvcVideoSourceID.isEmpty()));
-}
-
-bool VideoManager::gstreamerEnabled() const
-{
-#ifdef QGC_GST_STREAMING
-    return true;
-#else
-    return false;
 #endif
+    return false;
 }
 
-bool VideoManager::uvcEnabled() const
+//-----------------------------------------------------------------------------
+void
+VideoManager::_updateUVC()
 {
 #ifndef QGC_DISABLE_UVC
-    return !QMediaDevices::videoInputs().isEmpty();
-#else
-    return false;
-#endif
-}
-
-bool VideoManager::qtmultimediaEnabled() const
-{
-#ifdef QGC_QT_STREAMING
-    return true;
-#else
-    return false;
-#endif
-}
-
-void VideoManager::setfullScreen(bool on)
-{
-    if (on) {
-        if (!_activeVehicle || _activeVehicle->vehicleLinkManager()->communicationLost()) {
-            on = false;
-        }
-    }
-
-    if (on != _fullScreen) {
-        _fullScreen = on;
-        emit fullScreenChanged();
-    }
-}
-
-void VideoManager::_initVideo()
-{
-    QQuickWindow *const root = qgcApp()->mainRootWindow();
-    if (!root) {
-        qCDebug(VideoManagerLog) << "mainRootWindow() failed. No root window";
-        return;
-    }
-
-    for (VideoReceiverData &videoReceiver : _videoReceiverData) {
-        QQuickItem* const widget = root->findChild<QQuickItem*>(videoReceiver.name);
-        if (!widget || !videoReceiver.receiver) {
-            qCDebug(VideoManagerLog) << videoReceiver.name << "receiver disabled";
-            continue;
-        }
-
-        videoReceiver.sink = QGCCorePlugin::instance()->createVideoSink(this, widget);
-        if (!videoReceiver.sink) {
-            qCDebug(VideoManagerLog) << "createVideoSink() failed" << videoReceiver.index;
-            continue;
-        }
-
-        if (videoReceiver.started) {
-            qCDebug(VideoManagerLog) << videoReceiver.name << "receiver start decoding";
-            videoReceiver.receiver->startDecoding(videoReceiver.sink);
-        }
-    }
-}
-
-void VideoManager::_cleanupOldVideos()
-{
-    if (!SettingsManager::instance()->videoSettings()->enableStorageLimit()->rawValue().toBool()) {
-        return;
-    }
-
-    const QString savePath = SettingsManager::instance()->appSettings()->videoSavePath();
-    QDir videoDir = QDir(savePath);
-    videoDir.setFilter(QDir::Files | QDir::Readable | QDir::NoSymLinks | QDir::Writable);
-    videoDir.setSorting(QDir::Time);
-
-    QStringList nameFilters;
-    for (size_t i = 0; i < std::size(kFileExtension); i++) {
-        nameFilters << QStringLiteral("*.") + kFileExtension[i];
-    }
-
-    videoDir.setNameFilters(nameFilters);
-    QFileInfoList vidList = videoDir.entryInfoList();
-    if (vidList.isEmpty()) {
-        return;
-    }
-
-    uint64_t total = 0;
-    for (const QFileInfo &video : vidList) {
-        total += video.size();
-    }
-
-    const uint64_t maxSize = SettingsManager::instance()->videoSettings()->maxVideoSize()->rawValue().toUInt() * qPow(1024, 2);
-    while ((total >= maxSize) && !vidList.isEmpty()) {
-        total -= vidList.last().size();
-        qCDebug(VideoManagerLog) << "Removing old video file:" << vidList.last().filePath();
-        QFile file(vidList.last().filePath());
-        (void) file.remove();
-        vidList.removeLast();
-    }
-}
-
-void VideoManager::_videoSourceChanged()
-{
-    for (const VideoReceiverData &videoReceiver : _videoReceiverData) {
-        (void) _updateSettings(videoReceiver.index);
-    }
-
-    emit hasVideoChanged();
-    emit isStreamSourceChanged();
-    emit isUvcChanged();
-    emit isAutoStreamChanged();
-
-    if (hasVideo()) {
-        _restartAllVideos();
-    } else {
-        stopVideo();
-    }
-
-    qCDebug(VideoManagerLog) << "New Video Source:" << _videoSettings->videoSource()->rawValue().toString();
-}
-
-bool VideoManager::_updateUVC()
-{
-    bool result = false;
-
-#ifndef QGC_DISABLE_UVC
-    const QString oldUvcVideoSrcID = _uvcVideoSourceID;
-    if (!hasVideo() || isStreamSource()) {
+    QString oldUvcVideoSrcID = _uvcVideoSourceID;
+    if (!hasVideo() || isGStreamer()) {
         _uvcVideoSourceID = "";
     } else {
-        const QString videoSource = _videoSettings->videoSource()->rawValue().toString();
-        const QList<QCameraDevice> videoInputs = QMediaDevices::videoInputs();
-        for (const QCameraDevice &cameraDevice: videoInputs) {
+        QString videoSource = _videoSettings->videoSource()->rawValue().toString();
+        auto videoInputs = QMediaDevices::videoInputs();
+        for (const auto& cameraDevice: videoInputs) {
             if (cameraDevice.description() == videoSource) {
                 _uvcVideoSourceID = cameraDevice.description();
                 qCDebug(VideoManagerLog) << "Found USB source:" << _uvcVideoSourceID << " Name:" << videoSource;
@@ -534,291 +481,426 @@ bool VideoManager::_updateUVC()
 
     if (oldUvcVideoSrcID != _uvcVideoSourceID) {
         qCDebug(VideoManagerLog) << "UVC changed from [" << oldUvcVideoSrcID << "] to [" << _uvcVideoSourceID << "]";
-        const QCameraPermission cameraPermission;
-        if (qgcApp()->checkPermission(cameraPermission) == Qt::PermissionStatus::Undetermined) {
-            qgcApp()->requestPermission(cameraPermission, [](const QPermission &permission) {
+#if QT_CONFIG(permissions)
+        QCameraPermission cameraPermission;
+        if (qApp->checkPermission(cameraPermission) == Qt::PermissionStatus::Undetermined) {
+            qApp->requestPermission(cameraPermission, [](const QPermission &permission) {
                 if (permission.status() == Qt::PermissionStatus::Granted) {
                     qgcApp()->showRebootAppMessage(tr("Restart application for changes to take effect."));
                 }
             });
         }
-        result = true;
+#endif
         emit uvcVideoSourceIDChanged();
         emit isUvcChanged();
     }
 #endif
-
-    return result;
 }
 
-bool VideoManager::_updateAutoStream(unsigned id)
+//-----------------------------------------------------------------------------
+void
+VideoManager::_videoSourceChanged()
 {
-    if (!_activeVehicle || !_activeVehicle->cameraManager()) {
-        return false;
+    _updateUVC();
+    _updateSettings(0);
+    emit hasVideoChanged();
+    emit isGStreamerChanged();
+    emit isUvcChanged();
+    emit isAutoStreamChanged();
+    if (hasVideo()) {
+        _restartVideo(0);
+    } else {
+        stopVideo();
     }
-
-    const QGCVideoStreamInfo* const pInfo = _activeVehicle->cameraManager()->currentStreamInstance();
-    if (!pInfo) {
-        return false;
-    }
-
-    bool settingsChanged = false;
-    if (id == 0) {
-        qCDebug(VideoManagerLog) << "Configure primary stream:" << pInfo->uri();
-        switch(pInfo->type()) {
-        case VIDEO_STREAM_TYPE_RTSP:
-            settingsChanged = _updateVideoUri(id, pInfo->uri());
-            if (settingsChanged) {
-                SettingsManager::instance()->videoSettings()->videoSource()->setRawValue(VideoSettings::videoSourceRTSP);
-            }
-            break;
-        case VIDEO_STREAM_TYPE_TCP_MPEG:
-            settingsChanged = _updateVideoUri(id, pInfo->uri());
-            if (settingsChanged) {
-                SettingsManager::instance()->videoSettings()->videoSource()->setRawValue(VideoSettings::videoSourceTCP);
-            }
-            break;
-        case VIDEO_STREAM_TYPE_RTPUDP: {
-            const QString url = pInfo->uri().contains("udp://") ? pInfo->uri() : QStringLiteral("udp://0.0.0.0:%1").arg(pInfo->uri());
-            settingsChanged = _updateVideoUri(id, url);
-            if (settingsChanged) {
-                SettingsManager::instance()->videoSettings()->videoSource()->setRawValue(VideoSettings::videoSourceUDPH264);
-            }
-            break;
-        }
-        case VIDEO_STREAM_TYPE_MPEG_TS:
-            settingsChanged = _updateVideoUri(id, QStringLiteral("mpegts://0.0.0.0:%1").arg(pInfo->uri()));
-            if (settingsChanged) {
-                SettingsManager::instance()->videoSettings()->videoSource()->setRawValue(VideoSettings::videoSourceMPEGTS);
-            }
-            break;
-        default:
-            settingsChanged = _updateVideoUri(id, pInfo->uri());
-            break;
-        }
-    } else if (id == 1) {
-        const QGCVideoStreamInfo* const pTinfo = _activeVehicle->cameraManager()->thermalStreamInstance();
-        if (pTinfo) {
-            qCDebug(VideoManagerLog) << "Configure secondary stream:" << pTinfo->uri();
-            switch(pTinfo->type()) {
-            case VIDEO_STREAM_TYPE_RTSP:
-            case VIDEO_STREAM_TYPE_TCP_MPEG:
-                settingsChanged = _updateVideoUri(id, pTinfo->uri());
-                break;
-            case VIDEO_STREAM_TYPE_RTPUDP:
-                settingsChanged = _updateVideoUri(id, QStringLiteral("udp://0.0.0.0:%1").arg(pTinfo->uri()));
-                break;
-            case VIDEO_STREAM_TYPE_MPEG_TS:
-                settingsChanged = _updateVideoUri(id, QStringLiteral("mpegts://0.0.0.0:%1").arg(pTinfo->uri()));
-                break;
-            default:
-                settingsChanged = _updateVideoUri(id, pTinfo->uri());
-                break;
-            }
-        }
-    }
-
-    return settingsChanged;
 }
 
-bool VideoManager::_updateSettings(unsigned id)
+//-----------------------------------------------------------------------------
+void
+VideoManager::_udpPortChanged()
 {
-    if (!_videoSettings) {
+    _restartVideo(0);
+}
+
+//-----------------------------------------------------------------------------
+void
+VideoManager::_rtspUrlChanged()
+{
+    _restartVideo(0);
+}
+
+//-----------------------------------------------------------------------------
+void
+VideoManager::_tcpUrlChanged()
+{
+    _restartVideo(0);
+}
+
+//-----------------------------------------------------------------------------
+void
+VideoManager::_lowLatencyModeChanged()
+{
+    _restartAllVideos();
+}
+
+//-----------------------------------------------------------------------------
+bool
+VideoManager::hasVideo()
+{
+    if(autoStreamConfigured()) {
+        return true;
+    }
+    QString videoSource = _videoSettings->videoSource()->rawValue().toString();
+    return !videoSource.isEmpty() && videoSource != VideoSettings::videoSourceNoVideo && videoSource != VideoSettings::videoDisabled;
+}
+
+//-----------------------------------------------------------------------------
+bool
+VideoManager::isGStreamer()
+{
+#if defined(QGC_GST_STREAMING)
+    QString videoSource = _videoSettings->videoSource()->rawValue().toString();
+    return videoSource == VideoSettings::videoSourceUDPH264 ||
+            videoSource == VideoSettings::videoSourceUDPH265 ||
+            videoSource == VideoSettings::videoSourceRTSP ||
+            videoSource == VideoSettings::videoSourceTCP ||
+            videoSource == VideoSettings::videoSourceMPEGTS ||
+            videoSource == VideoSettings::videoSource3DRSolo ||
+            videoSource == VideoSettings::videoSourceParrotDiscovery ||
+            videoSource == VideoSettings::videoSourceYuneecMantisG ||
+            videoSource == VideoSettings::videoSourceHerelinkAirUnit ||
+            videoSource == VideoSettings::videoSourceHerelinkHotspot ||
+            autoStreamConfigured();
+#else
+    return false;
+#endif
+}
+
+bool
+VideoManager::isUvc()
+{
+#ifndef QGC_DISABLE_UVC
+    auto isUvc = hasVideo() && !_uvcVideoSourceID.isEmpty();
+    qCDebug(VideoManagerLog) << "Is Video source UVC: " << (isUvc ? "yes" : "no");
+    return isUvc;
+#else
+    return false;
+#endif
+}
+
+//-----------------------------------------------------------------------------
+#ifndef QGC_DISABLE_UVC
+bool
+VideoManager::uvcEnabled()
+{
+    return QMediaDevices::videoInputs().count() > 0;
+}
+#endif
+
+//-----------------------------------------------------------------------------
+void
+VideoManager::setfullScreen(bool f)
+{
+    if(f) {
+        //-- No can do if no vehicle or connection lost
+        if(!_activeVehicle || _activeVehicle->vehicleLinkManager()->communicationLost()) {
+            f = false;
+        }
+    }
+    _fullScreen = f;
+    emit fullScreenChanged();
+}
+
+//-----------------------------------------------------------------------------
+void
+VideoManager::_initVideo()
+{
+#if defined(QGC_GST_STREAMING)
+    QQuickWindow* root = qgcApp()->mainRootWindow();
+
+    if (root == nullptr) {
+        qCDebug(VideoManagerLog) << "mainRootWindow() failed. No root window";
+        return;
+    }
+
+    QQuickItem* widget = root->findChild<QQuickItem*>("videoContent");
+
+    if (widget != nullptr && _videoReceiver[0] != nullptr) {
+        _videoSink[0] = qgcApp()->toolbox()->corePlugin()->createVideoSink(this, widget);
+        if (_videoSink[0] != nullptr) {
+            if (_videoStarted[0]) {
+                _videoReceiver[0]->startDecoding(_videoSink[0]);
+            }
+        } else {
+            qCDebug(VideoManagerLog) << "createVideoSink() failed";
+        }
+    } else {
+        qCDebug(VideoManagerLog) << "video receiver disabled";
+    }
+
+    widget = root->findChild<QQuickItem*>("thermalVideo");
+
+    if (widget != nullptr && _videoReceiver[1] != nullptr) {
+        _videoSink[1] = qgcApp()->toolbox()->corePlugin()->createVideoSink(this, widget);
+        if (_videoSink[1] != nullptr) {
+            if (_videoStarted[1]) {
+                _videoReceiver[1]->startDecoding(_videoSink[1]);
+            }
+        } else {
+            qCDebug(VideoManagerLog) << "createVideoSink() failed";
+        }
+    } else {
+        qCDebug(VideoManagerLog) << "thermal video receiver disabled";
+    }
+#endif
+}
+
+//-----------------------------------------------------------------------------
+bool
+VideoManager::_updateSettings(unsigned id)
+{
+    if(!_videoSettings)
         return false;
-    }
 
-    if (id > (_videoReceiverData.size() - 1)) {
-        qCDebug(VideoManagerLog) << "Unsupported receiver id" << id;
-        return false;
-    }
+    const bool lowLatencyStreaming  =_videoSettings->lowLatencyMode()->rawValue().toBool();
 
-    bool settingsChanged = false;
+    bool settingsChanged = _lowLatencyStreaming[id] != lowLatencyStreaming;
 
-    const bool lowLatencyStreaming = _videoSettings->lowLatencyMode()->rawValue().toBool();
-    if (lowLatencyStreaming != _videoReceiverData[id].lowLatencyStreaming) {
-        _videoReceiverData[id].lowLatencyStreaming = lowLatencyStreaming;
-        settingsChanged = true;
-    }
+    _lowLatencyStreaming[id] = lowLatencyStreaming;
 
-    settingsChanged |= _updateUVC();
+    //-- Auto discovery
 
-    if (_activeVehicle && _activeVehicle->cameraManager()) {
-        const QGCVideoStreamInfo* const pInfo = _activeVehicle->cameraManager()->currentStreamInstance();
-        if (pInfo) {
-            settingsChanged |= _updateAutoStream(id);
+    if(_activeVehicle && _activeVehicle->cameraManager()) {
+        QGCVideoStreamInfo* pInfo = _activeVehicle->cameraManager()->currentStreamInstance();
+        if(pInfo) {
+            if (id == 0) {
+                qCDebug(VideoManagerLog) << "Configure primary stream:" << pInfo->uri();
+                switch(pInfo->type()) {
+                    case VIDEO_STREAM_TYPE_RTSP:
+                        if ((settingsChanged |= _updateVideoUri(id, pInfo->uri()))) {
+                            _toolbox->settingsManager()->videoSettings()->videoSource()->setRawValue(VideoSettings::videoSourceRTSP);
+                        }
+                        break;
+                    case VIDEO_STREAM_TYPE_TCP_MPEG:
+                        if ((settingsChanged |= _updateVideoUri(id, pInfo->uri()))) {
+                            _toolbox->settingsManager()->videoSettings()->videoSource()->setRawValue(VideoSettings::videoSourceTCP);
+                        }
+                        break;
+                    case VIDEO_STREAM_TYPE_RTPUDP:
+                        if ((settingsChanged |= _updateVideoUri(
+                                        id,
+                                        pInfo->uri().contains("udp://")
+                                            ? pInfo->uri() // Specced case
+                                            : QStringLiteral("udp://0.0.0.0:%1").arg(pInfo->uri())))) {
+                            _toolbox->settingsManager()->videoSettings()->videoSource()->setRawValue(VideoSettings::videoSourceUDPH264);
+                        }
+                        break;
+                    case VIDEO_STREAM_TYPE_MPEG_TS_H264:
+                        if ((settingsChanged |= _updateVideoUri(id, QStringLiteral("mpegts://0.0.0.0:%1").arg(pInfo->uri())))) {
+                            _toolbox->settingsManager()->videoSettings()->videoSource()->setRawValue(VideoSettings::videoSourceMPEGTS);
+                        }
+                        break;
+                    default:
+                        settingsChanged |= _updateVideoUri(id, pInfo->uri());
+                        break;
+                }
+            }
+            else if (id == 1) { //-- Thermal stream (if any)
+                QGCVideoStreamInfo* pTinfo = _activeVehicle->cameraManager()->thermalStreamInstance();
+                if (pTinfo) {
+                    qCDebug(VideoManagerLog) << "Configure secondary stream:" << pTinfo->uri();
+                    switch(pTinfo->type()) {
+                        case VIDEO_STREAM_TYPE_RTSP:
+                        case VIDEO_STREAM_TYPE_TCP_MPEG:
+                            settingsChanged |= _updateVideoUri(id, pTinfo->uri());
+                            break;
+                        case VIDEO_STREAM_TYPE_RTPUDP:
+                            settingsChanged |= _updateVideoUri(id, QStringLiteral("udp://0.0.0.0:%1").arg(pTinfo->uri()));
+                            break;
+                        case VIDEO_STREAM_TYPE_MPEG_TS_H264:
+                            settingsChanged |= _updateVideoUri(id, QStringLiteral("mpegts://0.0.0.0:%1").arg(pTinfo->uri()));
+                            break;
+                        default:
+                            settingsChanged |= _updateVideoUri(id, pTinfo->uri());
+                            break;
+                    }
+                }
+            }
             return settingsChanged;
         }
     }
-
-    if (id == 0) {
-        const QString source = _videoSettings->videoSource()->rawValue().toString();
-        if (source == VideoSettings::videoSourceUDPH264) {
-            settingsChanged |= _updateVideoUri(id, QStringLiteral("udp://0.0.0.0:%1").arg(_videoSettings->udpPort()->rawValue().toInt()));
-        } else if (source == VideoSettings::videoSourceUDPH265) {
-            settingsChanged |= _updateVideoUri(id, QStringLiteral("udp265://0.0.0.0:%1").arg(_videoSettings->udpPort()->rawValue().toInt()));
-        } else if (source == VideoSettings::videoSourceMPEGTS) {
-            settingsChanged |= _updateVideoUri(id, QStringLiteral("mpegts://0.0.0.0:%1").arg(_videoSettings->udpPort()->rawValue().toInt()));
-        } else if (source == VideoSettings::videoSourceRTSP) {
-            settingsChanged |= _updateVideoUri(id, _videoSettings->rtspUrl()->rawValue().toString());
-        } else if (source == VideoSettings::videoSourceTCP) {
-            settingsChanged |= _updateVideoUri(id, QStringLiteral("tcp://%1").arg(_videoSettings->tcpUrl()->rawValue().toString()));
-        } else if (source == VideoSettings::videoSource3DRSolo) {
-            settingsChanged |= _updateVideoUri(id, QStringLiteral("udp://0.0.0.0:5600"));
-        } else if (source == VideoSettings::videoSourceParrotDiscovery) {
-            settingsChanged |= _updateVideoUri(id, QStringLiteral("udp://0.0.0.0:8888"));
-        } else if (source == VideoSettings::videoSourceYuneecMantisG) {
-            settingsChanged |= _updateVideoUri(id, QStringLiteral("rtsp://192.168.42.1:554/live"));
-        } else if (source == VideoSettings::videoSourceHerelinkAirUnit) {
-            settingsChanged |= _updateVideoUri(id, QStringLiteral("rtsp://192.168.0.10:8554/H264Video"));
-        } else if (source == VideoSettings::videoSourceHerelinkHotspot) {
-            settingsChanged |= _updateVideoUri(id, QStringLiteral("rtsp://192.168.43.1:8554/fpv_stream"));
-        } else if (source == VideoSettings::videoDisabled || source == VideoSettings::videoSourceNoVideo) {
-            settingsChanged |= _updateVideoUri(id, "");
-        } else {
-            settingsChanged |= _updateVideoUri(id, "");
-            if (!isUvc()) {
-                qCCritical(VideoManagerLog) << "Video source URI \"" << source << "\" is not supported. Please add support!";
-            }
+    QString source = _videoSettings->videoSource()->rawValue().toString();
+    if (source == VideoSettings::videoSourceUDPH264)
+        settingsChanged |= _updateVideoUri(0, QStringLiteral("udp://0.0.0.0:%1").arg(_videoSettings->udpPort()->rawValue().toInt()));
+    else if (source == VideoSettings::videoSourceUDPH265)
+        settingsChanged |= _updateVideoUri(0, QStringLiteral("udp265://0.0.0.0:%1").arg(_videoSettings->udpPort()->rawValue().toInt()));
+    else if (source == VideoSettings::videoSourceMPEGTS)
+        settingsChanged |= _updateVideoUri(0, QStringLiteral("mpegts://0.0.0.0:%1").arg(_videoSettings->udpPort()->rawValue().toInt()));
+    else if (source == VideoSettings::videoSourceRTSP)
+        settingsChanged |= _updateVideoUri(0, _videoSettings->rtspUrl()->rawValue().toString());
+    else if (source == VideoSettings::videoSourceTCP)
+        settingsChanged |= _updateVideoUri(0, QStringLiteral("tcp://%1").arg(_videoSettings->tcpUrl()->rawValue().toString()));
+    else if (source == VideoSettings::videoSource3DRSolo)
+        settingsChanged |= _updateVideoUri(0, QStringLiteral("udp://0.0.0.0:5600"));
+    else if (source == VideoSettings::videoSourceParrotDiscovery)
+        settingsChanged |= _updateVideoUri(0, QStringLiteral("udp://0.0.0.0:8888"));
+    else if (source == VideoSettings::videoSourceYuneecMantisG)
+        settingsChanged |= _updateVideoUri(0, QStringLiteral("rtsp://192.168.42.1:554/live"));
+    else if (source == VideoSettings::videoSourceHerelinkAirUnit)
+        settingsChanged |= _updateVideoUri(0, QStringLiteral("rtsp://192.168.0.10:8554/H264Video"));
+    else if (source == VideoSettings::videoSourceHerelinkHotspot)
+        settingsChanged |= _updateVideoUri(0, QStringLiteral("rtsp://192.168.43.1:8554/fpv_stream"));
+    else if (source == VideoSettings::videoDisabled || source == VideoSettings::videoSourceNoVideo)
+        settingsChanged |= _updateVideoUri(0, "");
+    else {
+        settingsChanged |= _updateVideoUri(0, "");
+        if (!isUvc()) {
+            qCCritical(VideoManagerLog)
+                << "Video source URI \"" << source << "\" is not supported. Please add support!";
         }
     }
 
     return settingsChanged;
 }
 
-bool VideoManager::_updateVideoUri(unsigned id, const QString &uri)
+//-----------------------------------------------------------------------------
+bool
+VideoManager::_updateVideoUri(unsigned id, const QString& uri)
 {
-    if (id > (_videoReceiverData.size() - 1)) {
-        qCDebug(VideoManagerLog) << "Unsupported receiver id" << id;
+    if (uri == _videoUri[id]) {
         return false;
     }
 
-    if (uri == _videoReceiverData[id].uri) {
-        return false;
-    }
-
-    qCDebug(VideoManagerLog) << "New Video URI" << uri;
-
-    _videoReceiverData[id].uri = uri;
+    _videoUri[id] = uri;
 
     return true;
 }
 
-void VideoManager::_restartVideo(unsigned id)
+//-----------------------------------------------------------------------------
+void
+VideoManager::_restartVideo(unsigned id)
 {
-    if (id > (_videoReceiverData.size() - 1)) {
-        qCDebug(VideoManagerLog) << "Unsupported receiver id" << id;
+#if !defined(QGC_GST_STREAMING)
+    Q_UNUSED(id);
+#endif
+
+    if (qgcApp()->runningUnitTests()) {
         return;
     }
 
-    qCDebug(VideoManagerLog) << "Restart video streaming" << id;
+#if defined(QGC_GST_STREAMING)
+    bool oldLowLatencyStreaming = _lowLatencyStreaming[id];
+    QString oldUri = _videoUri[id];
+    _updateSettings(id);
+    bool newLowLatencyStreaming = _lowLatencyStreaming[id];
+    QString newUri = _videoUri[id];
+    qCDebug(VideoManagerLog) << "New Video URI " << newUri;
+    // FIXME: AV: use _updateSettings() result to check if settings were changed
+    if (_videoStarted[id] && oldUri == newUri && oldLowLatencyStreaming == newLowLatencyStreaming) {
+        qCDebug(VideoManagerLog) << "No sense to restart video streaming, skipped"  << id;
+        return;
+    }
 
-    if (_videoReceiverData[id].started) {
+    qCDebug(VideoManagerLog) << "Restart video streaming"  << id;
+
+    if (_videoStarted[id]) {
         _stopReceiver(id);
+    } else {
+        _startReceiver(id);
     }
-
-    _startReceiver(id);
+#endif
 }
 
-void VideoManager::_restartAllVideos()
+//-----------------------------------------------------------------------------
+void
+VideoManager::_restartAllVideos()
 {
-    for (const VideoReceiverData &videoReceiver : _videoReceiverData) {
-        _restartVideo(videoReceiver.index);
-    }
+    _restartVideo(0);
+    _restartVideo(1);
 }
 
-void VideoManager::_startReceiver(unsigned id)
+//----------------------------------------------------------------------------------------
+void
+VideoManager::_startReceiver(unsigned id)
 {
-    if (id > (_videoReceiverData.size() - 1)) {
-        qCDebug(VideoManagerLog) << "Unsupported receiver id" << id;
-        return;
-    }
-
-    if (!_videoReceiverData[id].receiver) {
-        qCDebug(VideoManagerLog) << "VideoReceiver is NULL" << id;
-        return;
-    }
-
-    if (_videoReceiverData[id].uri.isEmpty()) {
-        qCDebug(VideoManagerLog) << "VideoUri is NULL" << id;
-        return;
-    }
-
+#if defined(QGC_GST_STREAMING)
     const QString source = _videoSettings->videoSource()->rawValue().toString();
     const unsigned rtsptimeout = _videoSettings->rtspTimeout()->rawValue().toUInt();
     /* The gstreamer rtsp source will switch to tcp if udp is not available after 5 seconds.
        So we should allow for some negotiation time for rtsp */
-    const unsigned timeout = (source == VideoSettings::videoSourceRTSP ? rtsptimeout : 3);
+    const unsigned timeout = (source == VideoSettings::videoSourceRTSP ? rtsptimeout : 2 );
 
-    _videoReceiverData[id].receiver->start(_videoReceiverData[id].uri, timeout, _videoReceiverData[id].lowLatencyStreaming ? -1 : 0);
-}
-
-void VideoManager::_stopReceiver(unsigned id)
-{
-    if (id > (_videoReceiverData.size() - 1)) {
+    if (id > 1) {
         qCDebug(VideoManagerLog) << "Unsupported receiver id" << id;
-        return;
-    }
-
-    if (_videoReceiverData[id].receiver == nullptr) {
-        qCDebug(VideoManagerLog) << "VideoReceiver is NULL" << id;
-        return;
-    }
-
-    _videoReceiverData[id].receiver->stop();
-}
-
-void VideoManager::_setActiveVehicle(Vehicle *vehicle)
-{
-    if (_activeVehicle) {
-        (void) disconnect(_activeVehicle->vehicleLinkManager(), &VehicleLinkManager::communicationLostChanged, this, &VideoManager::_communicationLostChanged);
-        if (_activeVehicle->cameraManager()) {
-            MavlinkCameraControl *const pCamera = _activeVehicle->cameraManager()->currentCameraInstance();
-            if (pCamera) {
-                pCamera->stopStream();
-            }
-            (void) disconnect(_activeVehicle->cameraManager(), &QGCCameraManager::streamChanged, this, &VideoManager::_restartAllVideos);
+    } else if (_videoReceiver[id] != nullptr/* && _videoSink[id] != nullptr*/) {
+        if (!_videoUri[id].isEmpty()) {
+            _videoReceiver[id]->start(_videoUri[id], timeout, _lowLatencyStreaming[id] ? -1 : 0);
         }
     }
+#else
+    Q_UNUSED(id);
+#endif
+}
 
+//----------------------------------------------------------------------------------------
+void
+VideoManager::_stopReceiver(unsigned id)
+{
+#if defined(QGC_GST_STREAMING)
+    if (id > 1) {
+        qCDebug(VideoManagerLog) << "Unsupported receiver id" << id;
+    } else if (_videoReceiver[id] != nullptr) {
+        _videoReceiver[id]->stop();
+    }
+#else
+    Q_UNUSED(id);
+#endif
+}
+
+//----------------------------------------------------------------------------------------
+void
+VideoManager::_setActiveVehicle(Vehicle* vehicle)
+{
+    if(_activeVehicle) {
+        disconnect(_activeVehicle->vehicleLinkManager(), &VehicleLinkManager::communicationLostChanged, this, &VideoManager::_communicationLostChanged);
+        if(_activeVehicle->cameraManager()) {
+            auto pCamera = _activeVehicle->cameraManager()->currentCameraInstance();
+            if(pCamera) {
+                pCamera->stopStream();
+            }
+            disconnect(_activeVehicle->cameraManager(), &QGCCameraManager::streamChanged, this, &VideoManager::_restartAllVideos);
+        }
+    }
     _activeVehicle = vehicle;
-    if (_activeVehicle) {
-        (void) connect(_activeVehicle->vehicleLinkManager(), &VehicleLinkManager::communicationLostChanged, this, &VideoManager::_communicationLostChanged);
-        if (_activeVehicle->cameraManager()) {
-            (void) connect(_activeVehicle->cameraManager(), &QGCCameraManager::streamChanged, this, &VideoManager::_restartAllVideos);
-            MavlinkCameraControl *const pCamera = _activeVehicle->cameraManager()->currentCameraInstance();
-            if (pCamera) {
+    if(_activeVehicle) {
+        connect(_activeVehicle->vehicleLinkManager(), &VehicleLinkManager::communicationLostChanged, this, &VideoManager::_communicationLostChanged);
+        if(_activeVehicle->cameraManager()) {
+            connect(_activeVehicle->cameraManager(), &QGCCameraManager::streamChanged, this, &VideoManager::_restartAllVideos);
+            auto pCamera = _activeVehicle->cameraManager()->currentCameraInstance();
+            if(pCamera) {
                 pCamera->resumeStream();
             }
         }
     } else {
+        //-- Disable full screen video if vehicle is gone
         setfullScreen(false);
     }
-
     emit autoStreamConfiguredChanged();
     _restartAllVideos();
 }
 
-void VideoManager::_communicationLostChanged(bool connectionLost)
+//----------------------------------------------------------------------------------------
+void
+VideoManager::_communicationLostChanged(bool connectionLost)
 {
-    if (connectionLost) {
+    if(connectionLost) {
+        //-- Disable full screen video if connection is lost
         setfullScreen(false);
     }
 }
 
-/*===========================================================================*/
-
-FinishVideoInitialization::FinishVideoInitialization()
-    : QRunnable()
+//----------------------------------------------------------------------------------------
+void
+VideoManager::_aspectRatioChanged()
 {
-    // qCDebug(VideoManagerLog) << Q_FUNC_INFO << this;
-}
-
-FinishVideoInitialization::~FinishVideoInitialization()
-{
-    // qCDebug(VideoManagerLog) << Q_FUNC_INFO << this;
-}
-
-void FinishVideoInitialization::run()
-{
-    VideoManager::instance()->_initVideo();
+    emit aspectRatioChanged();
 }

--- a/src/VideoManager/VideoManager.h
+++ b/src/VideoManager/VideoManager.h
@@ -1,163 +1,186 @@
 /****************************************************************************
  *
- * (c) 2009-2024 QGROUNDCONTROL PROJECT <http://www.qgroundcontrol.org>
+ * (c) 2009-2020 QGROUNDCONTROL PROJECT <http://www.qgroundcontrol.org>
  *
  * QGroundControl is licensed according to the terms in the file
  * COPYING.md in the root of the source code directory.
  *
  ****************************************************************************/
 
+
 #pragma once
 
-#include <QtCore/QLoggingCategory>
-#include <QtCore/QObject>
-#include <QtCore/QRunnable>
 #include <QtCore/QSize>
-#include <QtQmlIntegration/QtQmlIntegration>
+#include <QtCore/QRunnable>
+#include <QtCore/QLoggingCategory>
+
+#include "QGCToolbox.h"
+#include "SubtitleWriter.h"
 
 Q_DECLARE_LOGGING_CATEGORY(VideoManagerLog)
 
-#define MAX_VIDEO_RECEIVERS 2
-
-class FinishVideoInitialization;
-class SubtitleWriter;
-class Vehicle;
-class VideoReceiver;
 class VideoSettings;
+class Vehicle;
+class Joystick;
+class VideoReceiver;
 
-class VideoManager : public QObject
+class VideoManager : public QGCTool
 {
     Q_OBJECT
-    // QML_ELEMENT
-    // QML_UNCREATABLE("")
-    Q_MOC_INCLUDE("Vehicle.h")
-    Q_PROPERTY(bool     gstreamerEnabled        READ gstreamerEnabled                           CONSTANT)
-    Q_PROPERTY(bool     qtmultimediaEnabled     READ qtmultimediaEnabled                        CONSTANT)
-    Q_PROPERTY(bool     uvcEnabled              READ uvcEnabled                                 CONSTANT)
-    Q_PROPERTY(bool     autoStreamConfigured    READ autoStreamConfigured                       NOTIFY autoStreamConfiguredChanged)
-    Q_PROPERTY(bool     decoding                READ decoding                                   NOTIFY decodingChanged)
-    Q_PROPERTY(bool     fullScreen              READ fullScreen             WRITE setfullScreen NOTIFY fullScreenChanged)
-    Q_PROPERTY(bool     hasThermal              READ hasThermal                                 NOTIFY decodingChanged)
-    Q_PROPERTY(bool     hasVideo                READ hasVideo                                   NOTIFY hasVideoChanged)
-    Q_PROPERTY(bool     isStreamSource          READ isStreamSource                             NOTIFY isStreamSourceChanged)
-    Q_PROPERTY(bool     isUvc                   READ isUvc                                      NOTIFY isUvcChanged)
-    Q_PROPERTY(bool     recording               READ recording                                  NOTIFY recordingChanged)
-    Q_PROPERTY(bool     streaming               READ streaming                                  NOTIFY streamingChanged)
-    Q_PROPERTY(double   aspectRatio             READ aspectRatio                                NOTIFY aspectRatioChanged)
-    Q_PROPERTY(double   hfov                    READ hfov                                       NOTIFY aspectRatioChanged)
-    Q_PROPERTY(double   thermalAspectRatio      READ thermalAspectRatio                         NOTIFY aspectRatioChanged)
-    Q_PROPERTY(double   thermalHfov             READ thermalHfov                                NOTIFY aspectRatioChanged)
-    Q_PROPERTY(QSize    videoSize               READ videoSize                                  NOTIFY videoSizeChanged)
-    Q_PROPERTY(QString  imageFile               READ imageFile                                  NOTIFY imageFileChanged)
-    Q_PROPERTY(QString  uvcVideoSourceID        READ uvcVideoSourceID                           NOTIFY uvcVideoSourceIDChanged)
-
-    friend class FinishVideoInitialization;
+    Q_MOC_INCLUDE("VideoReceiver.h")
 
 public:
-    explicit VideoManager(QObject *parent = nullptr);
-    ~VideoManager();
+    VideoManager    (QGCApplication* app, QGCToolbox* toolbox);
+    virtual ~VideoManager   ();
 
-    /// Gets the singleton instance of VideoManager.
-    ///     @return The singleton instance.
-    static VideoManager *instance();
-    static void registerQmlTypes();
+    Q_PROPERTY(bool             hasVideo                READ    hasVideo                                    NOTIFY hasVideoChanged)
+    Q_PROPERTY(bool             isGStreamer             READ    isGStreamer                                 NOTIFY isGStreamerChanged)
+    Q_PROPERTY(bool             isUvc                   READ    isUvc                                       NOTIFY isUvcChanged)
+    Q_PROPERTY(QString          uvcVideoSourceID        READ    uvcVideoSourceID                            NOTIFY uvcVideoSourceIDChanged)
+    Q_PROPERTY(bool             uvcEnabled              READ    uvcEnabled                                  CONSTANT)
+    Q_PROPERTY(bool             fullScreen              READ    fullScreen      WRITE   setfullScreen       NOTIFY fullScreenChanged)
+    Q_PROPERTY(VideoReceiver*   videoReceiver           READ    videoReceiver                               CONSTANT)
+    Q_PROPERTY(VideoReceiver*   thermalVideoReceiver    READ    thermalVideoReceiver                        CONSTANT)
+    Q_PROPERTY(double           aspectRatio             READ    aspectRatio                                 NOTIFY aspectRatioChanged)
+    Q_PROPERTY(double           thermalAspectRatio      READ    thermalAspectRatio                          NOTIFY aspectRatioChanged)
+    Q_PROPERTY(double           hfov                    READ    hfov                                        NOTIFY aspectRatioChanged)
+    Q_PROPERTY(double           thermalHfov             READ    thermalHfov                                 NOTIFY aspectRatioChanged)
+    Q_PROPERTY(bool             autoStreamConfigured    READ    autoStreamConfigured                        NOTIFY autoStreamConfiguredChanged)
+    Q_PROPERTY(bool             hasThermal              READ    hasThermal                                  NOTIFY decodingChanged)
+    Q_PROPERTY(QString          imageFile               READ    imageFile                                   NOTIFY imageFileChanged)
+    Q_PROPERTY(bool             streaming               READ    streaming                                   NOTIFY streamingChanged)
+    Q_PROPERTY(bool             decoding                READ    decoding                                    NOTIFY decodingChanged)
+    Q_PROPERTY(bool             recording               READ    recording                                   NOTIFY recordingChanged)
+    Q_PROPERTY(QSize            videoSize               READ    videoSize                                   NOTIFY videoSizeChanged)
 
-    Q_INVOKABLE void grabImage(const QString &imageFile = QString());
-    Q_INVOKABLE void startRecording(const QString &videoFile = QString());
-    Q_INVOKABLE void startVideo();
-    Q_INVOKABLE void stopRecording();
-    Q_INVOKABLE void stopVideo();
+    virtual bool        hasVideo            ();
+    virtual bool        isGStreamer         ();
+    virtual bool        isUvc               ();
+    virtual bool        fullScreen          () { return _fullScreen; }
+    virtual QString     uvcVideoSourceID    () { return _uvcVideoSourceID; }
+    virtual double      aspectRatio         ();
+    virtual double      thermalAspectRatio  ();
+    virtual double      hfov                ();
+    virtual double      thermalHfov         ();
+    virtual bool        autoStreamConfigured();
+    virtual bool        hasThermal          ();
+    virtual QString     imageFile           ();
 
-    void init();
-    void cleanup();
-    bool autoStreamConfigured() const;
-    bool decoding() const { return _decoding; }
-    bool fullScreen() const { return _fullScreen; }
-    bool gstreamerEnabled() const;
-    bool hasThermal() const;
-    bool hasVideo() const;
-    bool isStreamSource() const;
-    bool isUvc() const;
-    bool qtmultimediaEnabled() const;
-    bool recording() const { return _recording; }
-    bool streaming() const { return _streaming; }
-    bool uvcEnabled() const;
-    double aspectRatio() const;
-    double hfov() const;
-    double thermalAspectRatio() const;
-    double thermalHfov() const;
-    QSize videoSize() const { return QSize((_videoSize >> 16) & 0xFFFF, _videoSize & 0xFFFF); }
-    QString imageFile() const { return _imageFile; }
-    QString uvcVideoSourceID() const { return _uvcVideoSourceID; }
-    void setfullScreen(bool on);
+    bool streaming(void) {
+        return _streaming;
+    }
+
+    bool decoding(void) {
+        return _decoding;
+    }
+
+    bool recording(void) {
+        return _recording;
+    }
+
+    QSize videoSize(void) {
+        const quint32 size = _videoSize;
+        return QSize((size >> 16) & 0xFFFF, size & 0xFFFF);
+    }
+
+// FIXME: AV: they should be removed after finishing multiple video stream support
+// new arcitecture does not assume direct access to video receiver from QML side, even if it works for now
+    virtual VideoReceiver*  videoReceiver           () { return _videoReceiver[0]; }
+    virtual VideoReceiver*  thermalVideoReceiver    () { return _videoReceiver[1]; }
+
+#if defined(QGC_DISABLE_UVC)
+    virtual bool        uvcEnabled          () { return false; }
+#else
+    virtual bool        uvcEnabled          ();
+#endif
+
+    virtual void        setfullScreen       (bool f);
+
+    // Override from QGCTool
+    virtual void        setToolbox          (QGCToolbox *toolbox);
+
+    Q_INVOKABLE void startVideo     ();
+    Q_INVOKABLE void stopVideo      ();
+
+    Q_INVOKABLE void startRecording (const QString& videoFile = QString());
+    Q_INVOKABLE void stopRecording  ();
+
+    Q_INVOKABLE void grabImage(const QString& imageFile = QString());
 
 signals:
-    void aspectRatioChanged();
+    void hasVideoChanged            ();
+    void isGStreamerChanged         ();
+    void isUvcChanged               ();
+    void uvcVideoSourceIDChanged    ();
+    void fullScreenChanged          ();
+    void isAutoStreamChanged        ();
+    void aspectRatioChanged         ();
     void autoStreamConfiguredChanged();
-    void decodingChanged();
-    void fullScreenChanged();
-    void hasVideoChanged();
-    void imageFileChanged();
-    void isAutoStreamChanged();
-    void isStreamSourceChanged();
-    void isUvcChanged();
-    void recordingChanged();
-    void recordingStarted();
-    void streamingChanged();
-    void uvcVideoSourceIDChanged();
-    void videoSizeChanged();
+    void imageFileChanged           ();
+    void streamingChanged           ();
+    void decodingChanged            ();
+    void recordingChanged           ();
+    void recordingStarted           ();
+    void videoSizeChanged           ();
 
-private slots:
-    bool _updateUVC();
-    void _communicationLostChanged(bool communicationLost);
-    void _lowLatencyModeChanged() { _restartAllVideos(); }
-    void _setActiveVehicle(Vehicle *vehicle);
-    void _videoSourceChanged();
+protected slots:
+    void _videoSourceChanged        ();
+    void _udpPortChanged            ();
+    void _rtspUrlChanged            ();
+    void _tcpUrlChanged             ();
+    void _lowLatencyModeChanged     ();
+    void _updateUVC                 ();
+    void _setActiveVehicle          (Vehicle* vehicle);
+    void _aspectRatioChanged        ();
+    void _communicationLostChanged  (bool communicationLost);
 
-private:
-    bool _updateAutoStream(unsigned id);
-    bool _updateSettings(unsigned id);
-    bool _updateVideoUri(unsigned id, const QString &uri);
-    void _initVideo();
-    void _restartAllVideos();
-    void _restartVideo(unsigned id);
-    void _startReceiver(unsigned id);
-    void _stopReceiver(unsigned id);
-    static void _cleanupOldVideos();
+protected:
+    friend class FinishVideoInitialization;
 
-    struct VideoReceiverData {
-        VideoReceiver *receiver = nullptr;
-        void *sink = nullptr;
-        QString uri;
-        bool started = false;
-        bool lowLatencyStreaming = false;
-        size_t index = 0;
-        QString name;
-    };
-    QList<VideoReceiverData> _videoReceiverData = QList<VideoReceiverData>(MAX_VIDEO_RECEIVERS);
+    void _initVideo                 ();
+    bool _updateSettings            (unsigned id);
+    bool _updateVideoUri            (unsigned id, const QString& uri);
+    void _cleanupOldVideos          ();
+    void _restartAllVideos          ();
+    void _restartVideo              (unsigned id);
+    void _startReceiver             (unsigned id);
+    void _stopReceiver              (unsigned id);
 
-    SubtitleWriter *_subtitleWriter = nullptr;
-
-    bool _initialized = false;
-    bool _fullScreen = false;
-    QAtomicInteger<bool> _decoding = false;
-    QAtomicInteger<bool> _recording = false;
-    QAtomicInteger<bool> _streaming = false;
-    QAtomicInteger<quint32> _videoSize = 0;
-    QString _imageFile;
-    QString _uvcVideoSourceID;
-    QString _videoFile;
-    Vehicle *_activeVehicle = nullptr;
-    VideoSettings *_videoSettings = nullptr;
+protected:
+    QString                 _videoFile;
+    QString                 _imageFile;
+    SubtitleWriter          _subtitleWriter;
+    VideoReceiver*          _videoReceiver[2]       = { nullptr, nullptr };
+    void*                   _videoSink[2]           = { nullptr, nullptr };
+    QString                 _videoUri[2];
+    // FIXME: AV: _videoStarted seems to be access from 3 different threads, from time to time
+    // 1) Video Receiver thread
+    // 2) Video Manager/main app thread
+    // 3) Qt rendering thread (during video sink creation process which should happen in this thread)
+    // It works for now but...
+    bool                    _videoStarted[2]        = { false, false };
+    bool                    _lowLatencyStreaming[2] = { false, false };
+    QAtomicInteger<bool>    _streaming              = false;
+    QAtomicInteger<bool>    _decoding               = false;
+    QAtomicInteger<bool>    _recording              = false;
+    QAtomicInteger<quint32> _videoSize              = 0;
+    VideoSettings*          _videoSettings          = nullptr;
+    QString                 _uvcVideoSourceID;
+    bool                    _fullScreen             = false;
+    Vehicle*                _activeVehicle          = nullptr;
 };
-
-/*===========================================================================*/
 
 class FinishVideoInitialization : public QRunnable
 {
 public:
-    explicit FinishVideoInitialization();
-    ~FinishVideoInitialization();
+    explicit FinishVideoInitialization(VideoManager* manager)
+        : _manager(manager)
+    {}
 
-    void run() final;
+    void run () {
+        _manager->_initVideo();
+    }
+
+private:
+    VideoManager* _manager = nullptr;
 };

--- a/src/VideoManager/VideoReceiver/CMakeLists.txt
+++ b/src/VideoManager/VideoReceiver/CMakeLists.txt
@@ -1,10 +1,13 @@
 find_package(Qt6 REQUIRED COMPONENTS Core)
 
-target_sources(QGC PRIVATE VideoReceiver.h)
+qt_add_library(VideoReceiver STATIC VideoReceiver.h)
 
-target_link_libraries(QGC PUBLIC Qt6::Core)
+target_link_libraries(VideoReceiver
+    PUBLIC
+        Qt6::Core
+)
 
-target_include_directories(QGC PUBLIC ${CMAKE_CURRENT_SOURCE_DIR})
+target_include_directories(VideoReceiver PUBLIC ${CMAKE_CURRENT_SOURCE_DIR})
 
 add_subdirectory(GStreamer)
 add_subdirectory(QtMultimedia)

--- a/src/VideoManager/VideoReceiver/GStreamer/CMakeLists.txt
+++ b/src/VideoManager/VideoReceiver/GStreamer/CMakeLists.txt
@@ -1,47 +1,46 @@
+add_subdirectory(${CMAKE_SOURCE_DIR}/libs/qmlglsink qmlglsink.build)
+
+if(NOT GST_QT6_PLUGIN_FOUND)
+    return()
+endif()
+
+message(STATUS "Building GStreamer VideoReceiver")
+
 find_package(Qt6 REQUIRED COMPONENTS Core Quick)
 
-target_sources(QGC PRIVATE GLVideoItemStub.h)
-
-target_link_libraries(QGC PUBLIC Qt6::Quick)
-
-target_include_directories(QGC PUBLIC ${CMAKE_CURRENT_SOURCE_DIR})
-
-if(NOT QGC_ENABLE_GST_VIDEOSTREAMING)
-    return()
-endif()
-
-add_subdirectory(gstqml6gl)
-
-if(NOT TARGET gstqml6gl)
-    return()
-endif()
-
-target_sources(QGC
-    PRIVATE
-        gstqgc.cc
-        gstqgcelement.cc
-        gstqgcelements.h
-        gstqgcvideosinkbin.cc
-        gstqgcvideosinkbin.h
-        GStreamer.cc
-        GStreamer.h
-        GstVideoReceiver.cc
-        GstVideoReceiver.h
+qt_add_library(GStreamerReceiver STATIC
+    GLVideoItemStub.cc
+    GLVideoItemStub.h
+    gstqgc.c
+    gstqgcvideosinkbin.c
+    GStreamer.cc
+    GStreamer.h
+    GstVideoReceiver.cc
+    GstVideoReceiver.h
 )
 
 if(IOS)
-    target_sources(QGC
+    target_sources(GStreamerReceiver
         PRIVATE
-            gst_ios_init.m
             gst_ios_init.h
+            gst_ios_init.m
     )
 endif()
 
-target_link_libraries(QGC
+target_link_libraries(GStreamerReceiver
     PRIVATE
-        gstqml6gl
+        Qt6::Quick
+        Utilities
     PUBLIC
         Qt6::Core
+        qmlglsink
+        Settings
+        VideoReceiver
 )
 
-target_compile_definitions(QGC PUBLIC QGC_GST_STREAMING)
+target_include_directories(GStreamerReceiver PUBLIC ${CMAKE_CURRENT_SOURCE_DIR})
+
+target_compile_definitions(GStreamerReceiver PUBLIC QGC_GST_STREAMING)
+if(CMAKE_BUILD_TYPE STREQUAL "Release")
+    target_compile_definitions(GStreamerReceiver PRIVATE QGC_INSTALL_RELEASE)
+endif()

--- a/src/VideoManager/VideoReceiver/GStreamer/GLVideoItemStub.cc
+++ b/src/VideoManager/VideoReceiver/GStreamer/GLVideoItemStub.cc
@@ -1,0 +1,9 @@
+#include "GLVideoItemStub.h"
+
+GLVideoItemStub::GLVideoItemStub()
+{
+}
+
+GLVideoItemStub::~GLVideoItemStub()
+{
+}

--- a/src/VideoManager/VideoReceiver/GStreamer/GLVideoItemStub.h
+++ b/src/VideoManager/VideoReceiver/GStreamer/GLVideoItemStub.h
@@ -1,12 +1,3 @@
-/****************************************************************************
- *
- * (c) 2009-2024 QGROUNDCONTROL PROJECT <http://www.qgroundcontrol.org>
- *
- * QGroundControl is licensed according to the terms in the file
- * COPYING.md in the root of the source code directory.
- *
- ****************************************************************************/
-
 #pragma once
 
 #include <QtQuick/QQuickItem>
@@ -14,9 +5,13 @@
 class GLVideoItemStub : public QQuickItem
 {
     Q_OBJECT
-    // QML_NAMED_ELEMENT(GstGLQt6VideoItem)
 
 public:
-    GLVideoItemStub(QQuickItem *parent = nullptr) :
-        QQuickItem(parent) {}
+    GLVideoItemStub();
+    ~GLVideoItemStub();
+
+protected:
+
+private:
+
 };

--- a/src/VideoManager/VideoReceiver/GStreamer/GStreamer.cc
+++ b/src/VideoManager/VideoReceiver/GStreamer/GStreamer.cc
@@ -1,64 +1,36 @@
 /****************************************************************************
  *
- * (c) 2009-2024 QGROUNDCONTROL PROJECT <http://www.qgroundcontrol.org>
+ * (c) 2009-2023 QGROUNDCONTROL PROJECT <http://www.qgroundcontrol.org>
  *
  * QGroundControl is licensed according to the terms in the file
  * COPYING.md in the root of the source code directory.
  *
  ****************************************************************************/
 
+
+/**
+ * @file
+ *   @brief QGC Video Streaming Initialization
+ *   @author Gus Grubba <gus@auterion.com>
+ */
+
 #include "GStreamer.h"
 #include "GstVideoReceiver.h"
-#include "SettingsManager.h"
-#include "AppSettings.h"
-#include "VideoSettings.h"
 #include "QGCLoggingCategory.h"
-#ifdef Q_OS_IOS
-#include "gst_ios_init.h"
-#endif
 
-#include <QtCore/QCoreApplication>
-#include <QtCore/QSettings>
-#include <QtQuick/QQuickItem>
+#include <QtCore/QDebug>
 
-QGC_LOGGING_CATEGORY(GStreamerLog, "qgc.videomanager.videoreceiver.gstreamer")
-QGC_LOGGING_CATEGORY(GStreamerAPILog, "qgc.videomanager.videoreceiver.gstreamer.api")
+QGC_LOGGING_CATEGORY(GStreamerLog, "GStreamerLog")
+QGC_LOGGING_CATEGORY(GStreamerAPILog, "GStreamerAPILog")
 
-G_BEGIN_DECLS
-#ifdef QGC_GST_STATIC_BUILD
-GST_PLUGIN_STATIC_DECLARE(coreelements);
-GST_PLUGIN_STATIC_DECLARE(playback);
-GST_PLUGIN_STATIC_DECLARE(libav);
-GST_PLUGIN_STATIC_DECLARE(rtp);
-GST_PLUGIN_STATIC_DECLARE(rtsp);
-GST_PLUGIN_STATIC_DECLARE(udp);
-GST_PLUGIN_STATIC_DECLARE(videoparsersbad);
-GST_PLUGIN_STATIC_DECLARE(x264);
-GST_PLUGIN_STATIC_DECLARE(rtpmanager);
-GST_PLUGIN_STATIC_DECLARE(isomp4);
-GST_PLUGIN_STATIC_DECLARE(matroska);
-GST_PLUGIN_STATIC_DECLARE(mpegtsdemux);
-GST_PLUGIN_STATIC_DECLARE(opengl);
-GST_PLUGIN_STATIC_DECLARE(tcp);
-GST_PLUGIN_STATIC_DECLARE(app);
-#ifdef Q_OS_ANDROID
-GST_PLUGIN_STATIC_DECLARE(androidmedia);
-#elif defined(Q_OS_IOS)
-GST_PLUGIN_STATIC_DECLARE(applemedia);
-#endif
-#endif
-GST_PLUGIN_STATIC_DECLARE(qml6);
-GST_PLUGIN_STATIC_DECLARE(qgc);
-G_END_DECLS
-
-static void qt_gst_log(GstDebugCategory *category,
-                       GstDebugLevel level,
-                       const gchar *file,
-                       const gchar *function,
-                       gint line,
-                       GObject *object,
-                       GstDebugMessage *message,
-                       gpointer data)
+static void qt_gst_log(GstDebugCategory * category,
+                       GstDebugLevel      level,
+                       const gchar      * file,
+                       const gchar      * function,
+                       gint               line,
+                       GObject          * object,
+                       GstDebugMessage  * message,
+                       gpointer           data)
 {
     Q_UNUSED(data);
 
@@ -68,7 +40,7 @@ static void qt_gst_log(GstDebugCategory *category,
 
     QMessageLogger log(file, line, function);
 
-    char *object_info = gst_info_strdup_printf("%" GST_PTR_FORMAT, static_cast<void*>(object));
+    char* object_info = gst_info_strdup_printf("%" GST_PTR_FORMAT, static_cast<void*>(object));
 
     switch (level) {
     default:
@@ -94,43 +66,157 @@ static void qt_gst_log(GstDebugCategory *category,
     object_info = nullptr;
 }
 
-static void _qgcputenv(const QString &key, const QString &root, const QString &path = "")
-{
-    const QByteArray keyArray = key.toLocal8Bit();
-    const QByteArray valueArray = (root + path).toLocal8Bit();
-    (void) qputenv(keyArray, valueArray);
-}
-
-static void _setGstEnvVars()
-{
-    const QString currentDir = QCoreApplication::applicationDirPath();
-    qCDebug(GStreamerLog) << "App Directory:" << currentDir;
-
-#if defined(Q_OS_MACOS) && defined(QGC_GST_MACOS_FRAMEWORK)
-    _qgcputenv("GST_REGISTRY_REUSE_PLUGIN_SCANNER", "no");
-    _qgcputenv("GST_PLUGIN_SCANNER", currentDir, "/../Frameworks/GStreamer.framework/Versions/1.0/libexec/gstreamer-1.0/gst-plugin-scanner");
-    _qgcputenv("GST_PTP_HELPER_1_0", currentDir, "/../Frameworks/GStreamer.framework/Versions/1.0/libexec/gstreamer-1.0/gst-ptp-helper");
-    _qgcputenv("GIO_EXTRA_MODULES", currentDir, "/../Frameworks/GStreamer.framework/Versions/1.0/lib/gio/modules");
-    _qgcputenv("GST_PLUGIN_SYSTEM_PATH_1_0", currentDir, "/../Frameworks/GStreamer.framework/Versions/1.0/lib/gstreamer-1.0"); // PlugIns/gstreamer
-    _qgcputenv("GST_PLUGIN_SYSTEM_PATH", currentDir, "/../Frameworks/GStreamer.framework/Versions/1.0/lib/gstreamer-1.0");
-    _qgcputenv("GST_PLUGIN_PATH_1_0", currentDir, "/../Frameworks/GStreamer.framework/Versions/1.0/lib/gstreamer-1.0");
-    _qgcputenv("GST_PLUGIN_PATH", currentDir, "/../Frameworks/GStreamer.framework/Versions/1.0/lib/gstreamer-1.0");
-    _qgcputenv("GTK_PATH", currentDir, "/../Frameworks/GStreamer.framework/Versions/1.0");
-#elif defined(Q_OS_WIN)
-    _qgcputenv("GST_REGISTRY_REUSE_PLUGIN_SCANNER", "no");
-    _qgcputenv("GST_PLUGIN_SCANNER", currentDir, "/../libexec/gstreamer-1.0/gst-plugin-scanner");
-    _qgcputenv("GST_PTP_HELPER_1_0", currentDir, "/../libexec/gstreamer-1.0/gst-ptp-helper");
-    _qgcputenv("GIO_EXTRA_MODULES", currentDir, "/../lib/gio/modules");
-    _qgcputenv("GST_PLUGIN_SYSTEM_PATH_1_0", currentDir, "/../lib/gstreamer-1.0");
-    _qgcputenv("GST_PLUGIN_SYSTEM_PATH", currentDir, "/../lib/gstreamer-1.0");
-    _qgcputenv("GST_PLUGIN_PATH_1_0", currentDir, "/../lib/gstreamer-1.0");
-    _qgcputenv("GST_PLUGIN_PATH", currentDir, "/../lib/gstreamer-1.0");
+#if defined(Q_OS_IOS)
+#include "gst_ios_init.h"
 #endif
+
+#include "VideoReceiver.h"
+
+G_BEGIN_DECLS
+// The static plugins we use
+#if defined(Q_OS_ANDROID) || defined(Q_OS_IOS)
+    GST_PLUGIN_STATIC_DECLARE(coreelements);
+    GST_PLUGIN_STATIC_DECLARE(playback);
+    GST_PLUGIN_STATIC_DECLARE(libav);
+    GST_PLUGIN_STATIC_DECLARE(rtp);
+    GST_PLUGIN_STATIC_DECLARE(rtsp);
+    GST_PLUGIN_STATIC_DECLARE(udp);
+    GST_PLUGIN_STATIC_DECLARE(videoparsersbad);
+    GST_PLUGIN_STATIC_DECLARE(x264);
+    GST_PLUGIN_STATIC_DECLARE(rtpmanager);
+    GST_PLUGIN_STATIC_DECLARE(isomp4);
+    GST_PLUGIN_STATIC_DECLARE(matroska);
+    GST_PLUGIN_STATIC_DECLARE(mpegtsdemux);
+    GST_PLUGIN_STATIC_DECLARE(opengl);
+    GST_PLUGIN_STATIC_DECLARE(tcp);
+#if defined(Q_OS_ANDROID)
+    GST_PLUGIN_STATIC_DECLARE(androidmedia);
+#elif defined(Q_OS_IOS)
+    GST_PLUGIN_STATIC_DECLARE(applemedia);
+#endif
+#endif
+    GST_PLUGIN_STATIC_DECLARE(qml6);
+    GST_PLUGIN_STATIC_DECLARE(qgc);
+G_END_DECLS
+
+#if (defined(Q_OS_MAC) && defined(QGC_INSTALL_RELEASE)) || defined(Q_OS_WIN) || defined(Q_OS_LINUX)
+static void qgcputenv(const QString& key, const QString& root, const QString& path)
+{
+    const QString value = root + path;
+    qputenv(key.toStdString().c_str(), QByteArray(value.toStdString().c_str()));
+}
+#endif
+
+void
+GStreamer::blacklist(VideoDecoderOptions option)
+{
+    GstRegistry* registry = gst_registry_get();
+
+    if (registry == nullptr) {
+        qCCritical(GStreamerLog) << "Failed to get gstreamer registry.";
+        return;
+    }
+
+    auto changeRank = [registry](const char* featureName, uint16_t rank) {
+        GstPluginFeature* feature = gst_registry_lookup_feature(registry, featureName);
+        if (feature == nullptr) {
+            qCDebug(GStreamerLog) << "Failed to change ranking of feature. Featuer does not exist:" << featureName;
+            return;
+        }
+
+        qCDebug(GStreamerLog) << "Changing feature (" << featureName << ") to use rank:" << rank;
+        gst_plugin_feature_set_rank(feature, rank);
+        gst_registry_add_feature(registry, feature);
+        gst_object_unref(feature);
+    };
+
+    // Set rank for specific features
+    changeRank("bcmdec", GST_RANK_NONE);
+
+    switch (option) {
+        case ForceVideoDecoderDefault:
+            break;
+        case ForceVideoDecoderSoftware:
+            for(auto name : {"avdec_h264", "avdec_h265"}) {
+                changeRank(name, GST_RANK_PRIMARY + 1);
+            }
+            break;
+        case ForceVideoDecoderVAAPI:
+            for(auto name : {"vaapimpeg2dec", "vaapimpeg4dec", "vaapih263dec", "vaapih264dec", "vaapih265dec", "vaapivc1dec"}) {
+                changeRank(name, GST_RANK_PRIMARY + 1);
+            }
+            break;
+        case ForceVideoDecoderNVIDIA:
+            for(auto name : {"nvh265dec", "nvh265sldec", "nvh264dec", "nvh264sldec"}) {
+                changeRank(name, GST_RANK_PRIMARY + 1);
+            }
+            break;
+        case ForceVideoDecoderDirectX3D:
+            for(auto name : {"d3d11vp9dec", "d3d11h265dec", "d3d11h264dec"}) {
+                changeRank(name, GST_RANK_PRIMARY + 1);
+            }
+            break;
+        case ForceVideoDecoderVideoToolbox:
+            changeRank("vtdec", GST_RANK_PRIMARY + 1);
+            break;
+        default:
+            qCWarning(GStreamerLog) << "Can't handle decode option:" << option;
+    }
 }
 
-static void _registerPlugins()
+void
+GStreamer::initialize(int argc, char* argv[], int debuglevel)
 {
-#ifdef QGC_GST_STATIC_BUILD
+    qRegisterMetaType<VideoReceiver::STATUS>("STATUS");
+
+#ifdef Q_OS_MAC
+    #ifdef QGC_INSTALL_RELEASE
+        QString currentDir = QCoreApplication::applicationDirPath();
+        qgcputenv("GST_PLUGIN_SCANNER",           currentDir, "/../Frameworks/GStreamer.framework/Versions/1.0/libexec/gstreamer-1.0/gst-plugin-scanner");
+        qgcputenv("GTK_PATH",                     currentDir, "/../Frameworks/GStreamer.framework/Versions/Current");
+        qgcputenv("GIO_EXTRA_MODULES",            currentDir, "/../Frameworks/GStreamer.framework/Versions/Current/lib/gio/modules");
+        qgcputenv("GST_PLUGIN_SYSTEM_PATH_1_0",   currentDir, "/../Frameworks/GStreamer.framework/Versions/Current/lib/gstreamer-1.0");
+        qgcputenv("GST_PLUGIN_SYSTEM_PATH",       currentDir, "/../Frameworks/GStreamer.framework/Versions/Current/lib/gstreamer-1.0");
+        qgcputenv("GST_PLUGIN_PATH_1_0",          currentDir, "/../Frameworks/GStreamer.framework/Versions/Current/lib/gstreamer-1.0");
+        qgcputenv("GST_PLUGIN_PATH",              currentDir, "/../Frameworks/GStreamer.framework/Versions/Current/lib/gstreamer-1.0");
+    #endif
+#elif defined(Q_OS_WIN)
+    QString currentDir = QCoreApplication::applicationDirPath();
+    qgcputenv("GST_PLUGIN_PATH", currentDir, "/gstreamer-plugins");
+#elif defined(Q_OS_LINUX)
+    const QString currentDir = QCoreApplication::applicationDirPath();
+    qgcputenv("GST_REGISTRY_REUSE_PLUGIN_SCANNER", "no", "");
+    qgcputenv("GST_PLUGIN_SCANNER", "/usr/lib/x86_64-linux-gnu", "/gstreamer1.0/gstreamer-1.0/gst-plugin-scanner");
+    qgcputenv("GST_PTP_HELPER_1_0", "/usr/lib/x86_64-linux-gnu", "/gstreamer1.0/gstreamer-1.0/gst-ptp-helper");
+    qgcputenv("GTK_PATH", "/usr", "");
+    qgcputenv("GIO_EXTRA_MODULES", "/usr/lib/x86_64-linux-gnu", "/gio/modules");
+    qgcputenv("GST_PLUGIN_SYSTEM_PATH_1_0", "/usr/lib/x86_64-linux-gnu", "/gstreamer-1.0");
+    qgcputenv("GST_PLUGIN_SYSTEM_PATH", "/usr/lib/x86_64-linux-gnu", "/gstreamer-1.0");
+    qgcputenv("GST_PLUGIN_PATH_1_0", currentDir, "../lib");
+    qgcputenv("GST_PLUGIN_PATH", currentDir, "../lib");
+#endif
+
+    //-- If gstreamer debugging is not configured via environment then use internal QT logging
+    if (qEnvironmentVariableIsEmpty("GST_DEBUG")) {
+        gst_debug_set_default_threshold(static_cast<GstDebugLevel>(debuglevel));
+        gst_debug_remove_log_function(gst_debug_log_default);
+        gst_debug_add_log_function(qt_gst_log, nullptr, nullptr);
+    }
+
+    // Initialize GStreamer
+#if defined(Q_OS_IOS)
+    //-- iOS specific initialization
+    gst_ios_pre_init();
+#endif
+
+    GError* error = nullptr;
+    if (!gst_init_check(&argc, &argv, &error)) {
+        qCCritical(GStreamerLog) << "gst_init_check() failed: " << error->message;
+        g_error_free(error);
+    }
+
+    // The static plugins we use
+#if defined(Q_OS_ANDROID) || defined(Q_OS_IOS)
     GST_PLUGIN_STATIC_REGISTER(coreelements);
     GST_PLUGIN_STATIC_REGISTER(playback);
     GST_PLUGIN_STATIC_REGISTER(libav);
@@ -145,131 +231,30 @@ static void _registerPlugins()
     GST_PLUGIN_STATIC_REGISTER(mpegtsdemux);
     GST_PLUGIN_STATIC_REGISTER(opengl);
     GST_PLUGIN_STATIC_REGISTER(tcp);
-    GST_PLUGIN_STATIC_REGISTER(app);
-#ifdef Q_OS_ANDROID
+
+#if defined(Q_OS_ANDROID)
     GST_PLUGIN_STATIC_REGISTER(androidmedia);
 #elif defined(Q_OS_IOS)
     GST_PLUGIN_STATIC_REGISTER(applemedia);
 #endif
 #endif
-}
 
-namespace GStreamer
-{
-
-void initialize()
-{
-    (void) qRegisterMetaType<VideoReceiver::STATUS>("STATUS");
-
-    _setGstEnvVars();
-
-    if (qEnvironmentVariableIsEmpty("GST_DEBUG")) {
-        int gstDebugLevel = 0;
-        QSettings settings;
-        if (settings.contains(AppSettings::gstDebugLevelName)) {
-            gstDebugLevel = settings.value(AppSettings::gstDebugLevelName).toInt();
-        }
-        gst_debug_set_default_threshold(static_cast<GstDebugLevel>(gstDebugLevel));
-        gst_debug_remove_log_function(gst_debug_log_default);
-        gst_debug_add_log_function(qt_gst_log, nullptr, nullptr);
-    }
-
-#ifdef Q_OS_IOS
-    gst_ios_pre_init();
-#endif
-
-    const QStringList args = QCoreApplication::arguments();
-    int argc = args.size();
-    QList<QByteArray> argList;
-    argList.reserve(argc);
-
-    char **argv = new char*[argc];
-    for (int i = 0; i < argc; i++) {
-        (void) argList.append(args[i].toUtf8());
-        argv[i] = argList[i].data();
-    }
-
-    GError *error = nullptr;
-    if (!gst_init_check(&argc, &argv, &error)) {
-        qCCritical(GStreamerLog) << Q_FUNC_INFO << error->message;
-        g_error_free(error);
-    }
-    delete[] argv;
-
-    _registerPlugins();
-
-#ifdef Q_OS_IOS
+#if defined(Q_OS_IOS)
     gst_ios_post_init();
 #endif
 
     GST_PLUGIN_STATIC_REGISTER(qml6);
     GST_PLUGIN_STATIC_REGISTER(qgc);
-
-    blacklist(static_cast<GStreamer::VideoDecoderOptions>(SettingsManager::instance()->videoSettings()->forceVideoDecoder()->rawValue().toInt()));
 }
 
-void blacklist(VideoDecoderOptions option)
-{
-    GstRegistry *const registry = gst_registry_get();
-
-    if (!registry) {
-        qCCritical(GStreamerLog) << "Failed to get gstreamer registry.";
-        return;
-    }
-
-    const auto changeRank = [registry](const char *featureName, uint16_t rank) {
-        GstPluginFeature *const feature = gst_registry_lookup_feature(registry, featureName);
-        if (!feature) {
-            qCDebug(GStreamerLog) << "Failed to change ranking of feature. Featuer does not exist:" << featureName;
-            return;
-        }
-
-        qCDebug(GStreamerLog) << "Changing feature (" << featureName << ") to use rank:" << rank;
-        gst_plugin_feature_set_rank(feature, rank);
-        (void) gst_registry_add_feature(registry, feature);
-        gst_object_unref(feature);
-    };
-
-    changeRank("bcmdec", GST_RANK_NONE);
-
-    switch (option) {
-    case ForceVideoDecoderDefault:
-        break;
-    case ForceVideoDecoderSoftware:
-        for (const char *name : {"avdec_h264", "avdec_h265"}) {
-            changeRank(name, GST_RANK_PRIMARY + 1);
-        }
-        break;
-    case ForceVideoDecoderVAAPI:
-        for (const char *name : {"vaapimpeg2dec", "vaapimpeg4dec", "vaapih263dec", "vaapih264dec", "vaapih265dec", "vaapivc1dec"}) {
-            changeRank(name, GST_RANK_PRIMARY + 1);
-        }
-        break;
-    case ForceVideoDecoderNVIDIA:
-        for (const char *name : {"nvh265dec", "nvh265sldec", "nvh264dec", "nvh264sldec"}) {
-            changeRank(name, GST_RANK_PRIMARY + 1);
-        }
-        break;
-    case ForceVideoDecoderDirectX3D:
-        for (const char *name : {"d3d11vp9dec", "d3d11h265dec", "d3d11h264dec"}) {
-            changeRank(name, GST_RANK_PRIMARY + 1);
-        }
-        break;
-    case ForceVideoDecoderVideoToolbox:
-        changeRank("vtdec", GST_RANK_PRIMARY + 1);
-        break;
-    default:
-        qCWarning(GStreamerLog) << "Can't handle decode option:" << option;
-        break;
-    }
-}
-
-void *createVideoSink(QObject *parent, QQuickItem *widget)
+void*
+GStreamer::createVideoSink(QObject* parent, QQuickItem* widget)
 {
     Q_UNUSED(parent)
 
-    GstElement *const sink = gst_element_factory_make("qgcvideosinkbin", NULL);
-    if (sink) {
+    GstElement* sink;
+
+    if ((sink = gst_element_factory_make("qgcvideosinkbin", nullptr)) != nullptr) {
         g_object_set(sink, "widget", widget, NULL);
     } else {
         qCCritical(GStreamerLog) << "gst_element_factory_make('qgcvideosinkbin') failed";
@@ -278,16 +263,17 @@ void *createVideoSink(QObject *parent, QQuickItem *widget)
     return sink;
 }
 
-void releaseVideoSink(void *sink)
+void
+GStreamer::releaseVideoSink(void* sink)
 {
-    if (sink) {
+    if (sink != nullptr) {
         gst_object_unref(GST_ELEMENT(sink));
     }
 }
 
-VideoReceiver *createVideoReceiver(QObject *parent)
+VideoReceiver*
+GStreamer::createVideoReceiver(QObject* parent)
 {
-    return new GstVideoReceiver(parent);
+    Q_UNUSED(parent)
+    return new GstVideoReceiver(nullptr);
 }
-
-} // namespace GStreamer

--- a/src/VideoManager/VideoReceiver/GStreamer/GStreamer.h
+++ b/src/VideoManager/VideoReceiver/GStreamer/GStreamer.h
@@ -1,36 +1,20 @@
-/****************************************************************************
- *
- * (c) 2009-2024 QGROUNDCONTROL PROJECT <http://www.qgroundcontrol.org>
- *
- * QGroundControl is licensed according to the terms in the file
- * COPYING.md in the root of the source code directory.
- *
- ****************************************************************************/
-
 #pragma once
 
 #include <QtCore/QLoggingCategory>
+#include <QtQuick/QQuickItem>
+
+#include "Settings/VideoDecoderOptions.h"
 
 Q_DECLARE_LOGGING_CATEGORY(GStreamerLog)
 Q_DECLARE_LOGGING_CATEGORY(GStreamerAPILog)
 
 class VideoReceiver;
-class QQuickItem;
 
-namespace GStreamer
-{
-enum VideoDecoderOptions {
-    ForceVideoDecoderDefault = 0,
-    ForceVideoDecoderSoftware,
-    ForceVideoDecoderNVIDIA,
-    ForceVideoDecoderVAAPI,
-    ForceVideoDecoderDirectX3D,
-    ForceVideoDecoderVideoToolbox,
-};
-
-void initialize();
-void blacklist(VideoDecoderOptions option);
-void *createVideoSink(QObject *parent, QQuickItem *widget);
-void releaseVideoSink(void *sink);
-VideoReceiver *createVideoReceiver(QObject *parent = nullptr);
+class GStreamer {
+public:
+    static void blacklist(VideoDecoderOptions option);
+    static void initialize(int argc, char* argv[], int debuglevel);
+    static void* createVideoSink(QObject* parent, QQuickItem* widget);
+    static void releaseVideoSink(void* sink);
+    static VideoReceiver* createVideoReceiver(QObject* parent);
 };

--- a/src/VideoManager/VideoReceiver/GStreamer/GstVideoReceiver.cc
+++ b/src/VideoManager/VideoReceiver/GStreamer/GstVideoReceiver.cc
@@ -1,6 +1,6 @@
 /****************************************************************************
  *
- * (c) 2009-2024 QGROUNDCONTROL PROJECT <http://www.qgroundcontrol.org>
+ * (c) 2009-2020 QGROUNDCONTROL PROJECT <http://www.qgroundcontrol.org>
  *
  * QGroundControl is licensed according to the terms in the file
  * COPYING.md in the root of the source code directory.

--- a/src/VideoManager/VideoReceiver/GStreamer/GstVideoReceiver.h
+++ b/src/VideoManager/VideoReceiver/GStreamer/GstVideoReceiver.h
@@ -1,6 +1,6 @@
 /****************************************************************************
  *
- * (c) 2009-2024 QGROUNDCONTROL PROJECT <http://www.qgroundcontrol.org>
+ * (c) 2009-2020 QGROUNDCONTROL PROJECT <http://www.qgroundcontrol.org>
  *
  * QGroundControl is licensed according to the terms in the file
  * COPYING.md in the root of the source code directory.

--- a/src/VideoManager/VideoReceiver/GStreamer/README.md
+++ b/src/VideoManager/VideoReceiver/GStreamer/README.md
@@ -5,7 +5,7 @@
 For supported platforms, QGroundControl implements an UDP RTP and RSTP video streaming receiver in its Main Flight Display. It uses GStreamer and a stripped down version of QtGstreamer. We've standardized on **GStreamer 1.18.1**. It has been reliable and we will be using it until a good reason to change it surfaces. Newer versions of GStreamer may break the build as some dependent libraries may change.
 To build video streaming support, you will need to install the GStreamer development packages for the desired target platform.
 
-If you do have the proper GStreamer development libraries installed where QGC looks for it, the QGC build system will automatically use it and build video streaming support. If you would like to disable GStreamer video streaming support, set the **QGC_ENABLE_GST_VIDEOSTREAMING** CMake option to **OFF**.
+If you do have the proper GStreamer development libraries installed where QGC looks for it, the QGC build system will automatically use it and build video streaming support. If you would like to disable video streaming support, you can add **DISABLE_VIDEOSTREAMING** to the **DEFINES** build variable.
 
 ### Gstreamer logs
 
@@ -16,45 +16,36 @@ For cases, when it is need to have more control over gstreamer logging than is a
 For the time being, the RTP UDP pipeline is somewhat hardcoded, using h.264 or h.265. It's best to use a camera capable of hardware encoding either h.264 (such as the Logitech C920) or h.265. On the sender end, for RTP (UDP Streaming) you would run something like this:
 
 h.264
-
 ```
 gst-launch-1.0 uvch264src initial-bitrate=1000000 average-bitrate=1000000 iframe-period=1000 device=/dev/video0 name=src auto-start=true src.vidsrc ! video/x-h264,width=1920,height=1080,framerate=24/1 ! h264parse ! rtph264pay ! udpsink host=xxx.xxx.xxx.xxx port=5600
 ```
 
 h.265
-
 ```
 ffmpeg -f v4l2 -i /dev/video1 -pix_fmt yuv420p -c:v libx265 -preset ultrafast -x265-params crf=23 -strict experimental -f rtp udp://xxx.xxx.xxx.xxx:5600
 ```
 
 Where xxx.xxx.xxx.xxx is the IP address where QGC is running.
 
-To test using a test source on localhost, you can run this command:
 
+To test using a test source on localhost, you can run this command:
 ```
 gst-launch-1.0 videotestsrc pattern=ball ! video/x-raw,width=640,height=480 ! x264enc ! rtph264pay ! udpsink host=127.0.0.1 port=5600
 ```
-
 Or this one:
-
 ```
 gst-launch-1.0 videotestsrc ! video/x-raw,width=640,height=480 ! videoconvert ! x264enc ! rtph264pay ! udpsink host=127.0.0.1 port=5600
 ```
 
 On the receiving end, if you want to test it from the command line, you can use something like:
-
 ```
 gst-launch-1.0 udpsrc port=5600 caps='application/x-rtp, media=(string)video, clock-rate=(int)90000, encoding-name=(string)H264' ! rtpjitterbuffer ! rtph264depay ! h264parse ! avdec_h264 ! autovideosink fps-update-interval=1000 sync=false
 ```
-
 Or this one:
-
 ```
 gst-launch-1.0 udpsrc port=5600 ! application/x-rtp ! rtpjitterbuffer ! rtph264depay ! avdec_h264 ! videoconvert ! autovideosink
 ```
-
 Or this one, note that removing rtpjitterbuffer would reduce video latency as low latency mode is doing:
-
 ```
 gst-launch-1.0 udpsrc port=5600 caps='application/x-rtp, media=(string)video, clock-rate=(int)90000, encoding-name=(string)H264' ! rtpjitterbuffer ! parsebin ! decodebin ! autovideosink fps-update-interval=1000 sync=false
 ```
@@ -66,15 +57,12 @@ QGC also supports RTSP, TCP-MPEG2 and MPEG-TS (h.264) pipelines.
 ### Linux
 
 Use apt-get to install GStreamer 1.0
-
 ```
 list=$(apt-cache --names-only search ^gstreamer1.0-* | awk '{ print $1 }' | sed -e /-doc/d | grep -v gstreamer1.0-hybris)
 ```
-
 ```
 sudo apt-get install $list
 ```
-
 ```
 sudo apt-get install libgstreamer-plugins-base1.0-dev
 sudo apt-get install libgstreamer-plugins-bad1.0-dev 
@@ -87,14 +75,12 @@ The build system is setup to use pkgconfig and it will find the necessary header
 Download the gstreamer framework from here: http://gstreamer.freedesktop.org/data/pkg/osx. Supported version is 1.18.6. QGC may work with newer version, but it is untested.
 
 You need two packages:
-
 - [gstreamer-1.0-devel-1.18.6-x86_64.pkg](https://gstreamer.freedesktop.org/data/pkg/osx/1.18.6/gstreamer-1.0-devel-1.18.6-x86_64.pkg)
 - [gstreamer-1.0-1.18.6-x86_64.pkg](https://gstreamer.freedesktop.org/data/pkg/osx/1.18.6/gstreamer-1.0-1.18.6-x86_64.pkg)
 
 The installer places them under /Library/Frameworks/GStreamer.framework, which is where the QGC build system will look for it. That's all that is needed. When you build QGC and it finds the gstreamer framework, it automatically builds video streaming support.
 
 :point_right: To run gstreamer commands from the command line, you can add the path to find them (either in ~/.profile or ~/.bashrc):
-
 ```
 export PATH=$PATH:/Library/Frameworks/GStreamer.framework/Commands
 ```
@@ -107,31 +93,32 @@ The installer places them under ~/Library/Developer/GStreamer/iPhone.sdk/GStream
 
 ### Android
 
-An appropriate version of GStreamer will be automatically downloaded as part of the CMake configure step.
+Download the gstreamer from here: [gstreamer-1.0-android-universal-1.18.5.tar.xz](https://gstreamer.freedesktop.org/data/pkg/android/1.18.5/gstreamer-1.0-android-universal-1.18.5.tar.xz)
 
-#### Important Note for Windows Users
-
-During the build process for Android on Windows, to ensure support for UNIX-like symbolic links when not using elevated privileges, **Developer Mode** must be enabled. Without enabling Developer Mode, you may encounter linking issues with the automatically downloaded prebuilt version of GStreamer.
-
-To enable Developer Mode:
-
-1. Open the **Settings** app on Windows.
-2. Go to **System** > **For developers**.
-3. Enable **Developer Mode** by toggling the switch.
-
+Create a directory named "gstreamer-1.0-android-universal-1.18.5" under the root qgroundcontrol directory (the same directory qgroundcontrol.pro is located). Extract the downloaded archive under this directory. That's where the build system will look for it. Make sure your archive tool doesn't create any additional top level directories. The structure after extracting the archive should look like this:
+```
+qgroundcontrol
+├── gstreamer-1.0-android-universal-1.18.5
+│   │
+│   ├──armv7
+│   │   ├── bin
+│   │   ├── etc
+│   │   ├── include
+│   │   ├── lib
+│   │   └── share
+│   ├──x86
+```
 ### Windows
 
 Download the gstreamer framework from here: http://gstreamer.freedesktop.org/data/pkg/windows. Supported version is 1.18.1. QGC may work with newer version, but it is untested.
 
 You need two packages:
 
-#### 32-Bit:
-
+#### 32-Bit: 
 - [gstreamer-1.0-devel-msvc-x86-1.18.1.msi](https://gstreamer.freedesktop.org/data/pkg/windows/1.18.1/msvc/gstreamer-1.0-devel-msvc-x86-1.18.1.msi)
 - [gstreamer-1.0-msvc-x86-1.18.1.msi](https://gstreamer.freedesktop.org/data/pkg/windows/1.18.1/msvc/gstreamer-1.0-msvc-x86-1.18.1.msi)
 
-#### 64-Bit:
-
+#### 64-Bit: 
 - [gstreamer-1.0-devel-msvc-x86_64-1.18.1.msi](https://gstreamer.freedesktop.org/data/pkg/windows/1.18.1/msvc/gstreamer-1.0-devel-msvc-x86_64-1.18.1.msi)
 - [gstreamer-1.0-msvc-x86_64-1.18.1.msi](https://gstreamer.freedesktop.org/data/pkg/windows/1.18.1/msvc/gstreamer-1.0-msvc-x86_64-1.18.1.msi)
 

--- a/src/VideoManager/VideoReceiver/GStreamer/gst_ios_init.h
+++ b/src/VideoManager/VideoReceiver/GStreamer/gst_ios_init.h
@@ -1,12 +1,3 @@
-/****************************************************************************
- *
- * (c) 2009-2024 QGROUNDCONTROL PROJECT <http://www.qgroundcontrol.org>
- *
- * QGroundControl is licensed according to the terms in the file
- * COPYING.md in the root of the source code directory.
- *
- ****************************************************************************/
-
 #pragma once
 
 #include <gst/gst.h>

--- a/src/VideoManager/VideoReceiver/GStreamer/gst_ios_init.m
+++ b/src/VideoManager/VideoReceiver/GStreamer/gst_ios_init.m
@@ -22,61 +22,59 @@ G_END_DECLS
 
 void gst_ios_pre_init(void)
 {
-    const NSString *const resources = [[NSBundle mainBundle] resourcePath];
-    const NSString *const tmp = NSTemporaryDirectory();
-    const NSString *const cache = [NSHomeDirectory() stringByAppendingPathComponent:@"Library/Caches"];
-    const NSString *const docs = [NSHomeDirectory() stringByAppendingPathComponent:@"Documents"];
+  NSString *resources = [[NSBundle mainBundle] resourcePath];
+  NSString *tmp = NSTemporaryDirectory();
+  NSString *cache = [NSHomeDirectory() stringByAppendingPathComponent:@"Library/Caches"];
+  NSString *docs = [NSHomeDirectory() stringByAppendingPathComponent:@"Documents"];
+    
+  const gchar *resources_dir = [resources UTF8String];
+  const gchar *tmp_dir = [tmp UTF8String];
+  const gchar *cache_dir = [cache UTF8String];
+  const gchar *docs_dir = [docs UTF8String];
+  gchar *ca_certificates;
+    
+  g_setenv ("TMP", tmp_dir, TRUE);
+  g_setenv ("TEMP", tmp_dir, TRUE);
+  g_setenv ("TMPDIR", tmp_dir, TRUE);
+  g_setenv ("XDG_RUNTIME_DIR", resources_dir, TRUE);
+  g_setenv ("XDG_CACHE_HOME", cache_dir, TRUE);
+    
+  g_setenv ("HOME", docs_dir, TRUE);
+  g_setenv ("XDG_DATA_DIRS", resources_dir, TRUE);
+  g_setenv ("XDG_CONFIG_DIRS", resources_dir, TRUE);
+  g_setenv ("XDG_CONFIG_HOME", cache_dir, TRUE);
+  g_setenv ("XDG_DATA_HOME", resources_dir, TRUE);
+  g_setenv ("FONTCONFIG_PATH", resources_dir, TRUE);
 
-    const gchar *const resources_dir = [resources UTF8String];
-    const gchar *const tmp_dir = [tmp UTF8String];
-    const gchar *const cache_dir = [cache UTF8String];
-    const gchar *const docs_dir = [docs UTF8String];
-
-    g_setenv("TMP", tmp_dir, TRUE);
-    g_setenv("TEMP", tmp_dir, TRUE);
-    g_setenv("TMPDIR", tmp_dir, TRUE);
-    g_setenv("XDG_RUNTIME_DIR", resources_dir, TRUE);
-    g_setenv("XDG_CACHE_HOME", cache_dir, TRUE);
-
-    g_setenv("HOME", docs_dir, TRUE);
-    g_setenv("XDG_DATA_DIRS", resources_dir, TRUE);
-    g_setenv("XDG_CONFIG_DIRS", resources_dir, TRUE);
-    g_setenv("XDG_CONFIG_HOME", cache_dir, TRUE);
-    g_setenv("XDG_DATA_HOME", resources_dir, TRUE);
-    g_setenv("FONTCONFIG_PATH", resources_dir, TRUE);
-
-    gchar *const ca_certificates = g_build_filename(resources_dir, "ssl", "certs", "ca-certificates.crt", NULL);
-    g_setenv("CA_CERTIFICATES", ca_certificates, TRUE);
-    g_free(ca_certificates);
+  ca_certificates = g_build_filename (resources_dir, "ssl", "certs", "ca-certificates.crt", NULL);
+  g_setenv ("CA_CERTIFICATES", ca_certificates, TRUE);
+  g_free (ca_certificates);
 }
 
-void gst_ios_post_init()
+void gst_ios_post_init(void)
 {
-    GstPluginFeature *plugin;
-    GstRegistry *reg;
-    /* Lower the ranks of filesrc and giosrc so iosavassetsrc is
-     * tried first in gst_element_make_from_uri() for file:// */
+  GstPluginFeature *plugin;
+  GstRegistry *reg;
+  /* Lower the ranks of filesrc and giosrc so iosavassetsrc is
+   * tried first in gst_element_make_from_uri() for file:// */
 
-    #if defined(GST_IOS_GIO_MODULE_GNUTLS)
-        GST_G_IO_MODULE_LOAD(gnutls);
-    #endif
+#if defined(GST_IOS_GIO_MODULE_GNUTLS)
+    GST_G_IO_MODULE_LOAD(gnutls);
+#endif
 
-    reg = gst_registry_get();
-    plugin = gst_registry_lookup_feature(reg, "filesrc");
-    if (plugin) {
-        gst_plugin_feature_set_rank(plugin, GST_RANK_SECONDARY);
-    }
-    plugin = gst_registry_lookup_feature(reg, "giosrc");
-    if (plugin) {
-        gst_plugin_feature_set_rank(plugin, GST_RANK_SECONDARY-1);
-    }
-    if (!gst_registry_lookup_feature(reg, "vtdec_hw")) {
-        /* Usually there is no vtdec_hw plugin on iOS - in that case
-        * we are increasing vtdec rank since VideoToolbox on iOS
-        * tries to use hardware implementation first */
-        plugin = gst_registry_lookup_feature(reg, "vtdec");
-        if (plugin) {
-            gst_plugin_feature_set_rank(plugin, GST_RANK_PRIMARY + 1);
-        }
+  reg = gst_registry_get();
+  plugin = gst_registry_lookup_feature(reg, "filesrc");
+  if (plugin)
+    gst_plugin_feature_set_rank(plugin, GST_RANK_SECONDARY);
+  plugin = gst_registry_lookup_feature(reg, "giosrc");
+  if (plugin)
+    gst_plugin_feature_set_rank(plugin, GST_RANK_SECONDARY-1);
+  if (!gst_registry_lookup_feature(reg, "vtdec_hw")) {
+    /* Usually there is no vtdec_hw plugin on iOS - in that case
+     * we are increasing vtdec rank since VideoToolbox on iOS
+     * tries to use hardware implementation first */
+    plugin = gst_registry_lookup_feature(reg, "vtdec");
+    if (plugin)
+      gst_plugin_feature_set_rank(plugin, GST_RANK_PRIMARY + 1);
     }
 }

--- a/src/VideoManager/VideoReceiver/GStreamer/gstqgc.c
+++ b/src/VideoManager/VideoReceiver/GStreamer/gstqgc.c
@@ -1,0 +1,40 @@
+/****************************************************************************
+ *
+ * (c) 2009-2020 QGROUNDCONTROL PROJECT <http://www.qgroundcontrol.org>
+ *
+ * QGroundControl is licensed according to the terms in the file
+ * COPYING.md in the root of the source code directory.
+ *
+ ****************************************************************************/
+
+/**
+ * @file
+ *   @brief GStreamer plugin for QGC's Video Receiver
+ *   @author Andrew Voznyts <andrew.voznytsa@gmail.com>
+ *   @author Tomaz Canabrava <tcanabrava@kde.org>
+ */
+
+#include <gst/gst.h>
+
+gboolean gst_qgc_video_sink_bin_plugin_init(GstPlugin *plugin);
+
+static gboolean
+plugin_init(GstPlugin* plugin)
+{
+    if (!gst_qgc_video_sink_bin_plugin_init(plugin)) {
+        return FALSE;
+    }
+
+    return TRUE;
+}
+
+#define PACKAGE            "QGC Video Receiver"
+#define PACKAGE_VERSION    "current"
+#define GST_LICENSE        "LGPL"
+#define GST_PACKAGE_NAME   "GStreamer plugin for QGC's Video Receiver"
+#define GST_PACKAGE_ORIGIN "http://qgroundcontrol.com/"
+
+GST_PLUGIN_DEFINE (GST_VERSION_MAJOR, GST_VERSION_MINOR,
+    qgc, "QGC Video Receiver plugin",
+    plugin_init, PACKAGE_VERSION,
+    GST_LICENSE, GST_PACKAGE_NAME, GST_PACKAGE_ORIGIN)

--- a/src/VideoManager/VideoReceiver/GStreamer/gstqgcvideosinkbin.c
+++ b/src/VideoManager/VideoReceiver/GStreamer/gstqgcvideosinkbin.c
@@ -1,0 +1,394 @@
+/****************************************************************************
+ *
+ * (c) 2009-2020 QGROUNDCONTROL PROJECT <http://www.qgroundcontrol.org>
+ *
+ * QGroundControl is licensed according to the terms in the file
+ * COPYING.md in the root of the source code directory.
+ *
+ ****************************************************************************/
+
+/**
+ * @file
+ *   @brief GStreamer plugin for QGC's Video Receiver
+ *   @author Andrew Voznyts <andrew.voznytsa@gmail.com>
+ *   @author Tomaz Canabrava <tcanabrava@kde.org>
+ */
+
+#include <glib-object.h>
+#include <gst/gst.h>
+#include <qglobal.h>
+
+GST_DEBUG_CATEGORY_STATIC(gst_qgc_video_sink_bin_debug);
+#define GST_CAT_DEFAULT gst_qgc_video_sink_bin_debug
+
+typedef struct _GstQgcVideoSinkElement GstQgcVideoSinkElement;
+
+typedef struct _GstQgcVideoSinkBin {
+    GstBin bin;
+    GstElement* glupload;
+    GstElement* qmlglsink;
+} GstQgcVideoSinkBin;
+
+typedef struct _GstQgcVideoSinkBinClass {
+    GstBinClass parent_class;
+} GstQgcVideoSinkBinClass;
+
+#define GST_TYPE_VIDEO_SINK_BIN (_vsb_get_type())
+#define GST_QGC_VIDEO_SINK_BIN_CAST(obj) ((GstQgcVideoSinkBin *)(obj))
+#define GST_QGC_VIDEO_SINK_BIN(obj) (G_TYPE_CHECK_INSTANCE_CAST((obj), GST_TYPE_VIDEO_SINK_BIN, GstQgcVideoSinkBin))
+#define GST_QGC_VIDEO_SINK_BIN_CLASS(klass) (G_TYPE_CHECK_CLASS_CAST((klass), GST_TYPE_VIDEO_SINK_BIN, GstQgcVideoSinkBinClass))
+#define GST_IS_VIDEO_SINK_BIN(obj) (G_TYPE_CHECK_INSTANCE_TYPE((obj), GST_TYPE_VIDEO_SINK_BIN))
+#define GST_IS_VIDEO_SINK_BIN_CLASS(klass) (G_TYPE_CHECK_CLASS_TYPE((klass), GST_TYPE_VIDEO_SINK_BIN))
+
+enum {
+    PROP_0,
+    PROP_ENABLE_LAST_SAMPLE,
+    PROP_LAST_SAMPLE,
+    PROP_WIDGET,
+    PROP_FORCE_ASPECT_RATIO,
+    PROP_PIXEL_ASPECT_RATIO,
+    PROP_SYNC,
+};
+
+#define PROP_ENABLE_LAST_SAMPLE_NAME    "enable-last-sample"
+#define PROP_LAST_SAMPLE_NAME           "last-sample"
+#define PROP_WIDGET_NAME                "widget"
+#define PROP_FORCE_ASPECT_RATIO_NAME    "force-aspect-ratio"
+#define PROP_PIXEL_ASPECT_RATIO_NAME    "pixel-aspect-ratio"
+#define PROP_SYNC_NAME                  "sync"
+
+#define DEFAULT_ENABLE_LAST_SAMPLE TRUE
+#define DEFAULT_FORCE_ASPECT_RATIO TRUE
+#define DEFAULT_PAR_N 0
+#define DEFAULT_PAR_D 1
+#define DEFAULT_SYNC TRUE
+
+static GstBinClass *parent_class;
+
+static void _vsb_init(GTypeInstance *instanceData, void *vsbVoid);
+static void _vsb_dispose(GObject *object);
+static void _vsb_get_property(GObject *object, guint prop_id, GValue *value, GParamSpec *pspec);
+static void _vsb_set_property(GObject *object, guint prop_id, const GValue *value, GParamSpec *pspec);
+static GType _vsb_get_type(void);
+static void _vsb_class_init(void *klass, void *classData);
+
+static gboolean
+_vsb_sink_pad_query(GstPad* pad, GstObject* parent, GstQuery* query)
+{
+    GstQgcVideoSinkBin *vsb;
+    GstElement* element;
+    
+    vsb = GST_QGC_VIDEO_SINK_BIN(parent);
+
+    switch (GST_QUERY_TYPE(query)) {
+    case GST_QUERY_CAPS:
+        element = vsb->glupload;
+        break;
+    case GST_QUERY_CONTEXT:
+        element = vsb->qmlglsink;
+        break;
+    default:
+        return gst_pad_query_default (pad, parent, query);
+    }
+
+    if (element == NULL) {
+        GST_ERROR_OBJECT(vsb, "No element found");
+        return FALSE;
+    }
+
+    GstPad* sinkpad = gst_element_get_static_pad(element, "sink");
+
+    if (sinkpad == NULL) {
+        GST_ERROR_OBJECT(vsb, "No sink pad found");
+        return FALSE;
+    }
+
+    const gboolean ret = gst_pad_query(sinkpad, query);
+
+    gst_object_unref(sinkpad);
+    sinkpad = NULL;
+
+    return ret;
+}
+
+static void
+_vsb_init(GTypeInstance *instanceData, void *vsbVoid)
+{
+    Q_UNUSED(vsbVoid);
+
+    GstQgcVideoSinkBin *vsb;
+    vsb = (GstQgcVideoSinkBin *)instanceData;
+
+    gboolean initialized        = FALSE;
+    GstElement* glcolorconvert  = NULL;
+    GstPad* pad                 = NULL;
+
+    do {
+        if ((vsb->glupload = gst_element_factory_make("glupload", NULL)) == NULL) {
+            GST_ERROR_OBJECT(vsb, "gst_element_factory_make('glupload') failed");
+            break;
+        }
+
+        if ((vsb->qmlglsink = gst_element_factory_make("qml6glsink", NULL)) == NULL) {
+            GST_ERROR_OBJECT(vsb, "gst_element_factory_make('qml6glsink') failed");
+            break;
+        }
+
+        if ((glcolorconvert = gst_element_factory_make("glcolorconvert", NULL)) == NULL) {
+            GST_ERROR_OBJECT(vsb, "gst_element_factory_make('glcolorconvert' failed)");
+            break;
+        }
+
+        if ((pad = gst_element_get_static_pad(vsb->glupload, "sink")) == NULL) {
+            GST_ERROR_OBJECT(vsb, "gst_element_get_static_pad(glupload, 'sink') failed");
+            break;
+        }
+
+        gst_object_ref(vsb->glupload);
+        gst_object_ref(vsb->qmlglsink);
+
+        gst_bin_add_many(GST_BIN(vsb), vsb->glupload, glcolorconvert, vsb->qmlglsink, NULL);
+
+        gboolean ret = gst_element_link_many(vsb->glupload, glcolorconvert, vsb->qmlglsink, NULL);
+
+        glcolorconvert = NULL;
+
+        if (!ret) {
+            GST_ERROR_OBJECT(vsb, "gst_element_link_many() failed");
+            break;
+        }
+
+        GstPad* ghostpad;
+
+        if ((ghostpad = gst_ghost_pad_new("sink", pad)) == NULL) {
+            GST_ERROR_OBJECT(vsb, "gst_ghost_pad_new('sink') failed");
+            break;
+        }
+
+        gst_pad_set_query_function(ghostpad, _vsb_sink_pad_query);
+
+        if (!gst_element_add_pad(GST_ELEMENT(vsb), ghostpad)) {
+            GST_ERROR_OBJECT(vsb, "gst_element_add_pad() failed");
+            break;
+        }
+
+        initialized = TRUE;
+    } while(0);
+
+    if (pad != NULL) {
+        gst_object_unref(pad);
+        pad = NULL;
+    }
+
+    if (glcolorconvert != NULL) {
+        gst_object_unref(glcolorconvert);
+        glcolorconvert = NULL;
+    }
+
+    if (!initialized) {
+        if (vsb->qmlglsink != NULL) {
+            gst_object_unref(vsb->qmlglsink);
+            vsb->qmlglsink = NULL;
+        }
+
+        if (vsb->glupload != NULL) {
+            gst_object_unref(vsb->glupload);
+            vsb->glupload = NULL;
+        }
+    }
+}
+
+static void
+_vsb_dispose(GObject *object)
+{
+    GstQgcVideoSinkBin *vsb;
+
+    vsb = GST_QGC_VIDEO_SINK_BIN(object);
+
+    if (vsb->qmlglsink != NULL) {
+        gst_object_unref(vsb->qmlglsink);
+        vsb->qmlglsink = NULL;
+    }
+
+    if (vsb->glupload != NULL) {
+        gst_object_unref(vsb->glupload);
+        vsb->glupload = NULL;
+    }
+
+    G_OBJECT_CLASS(parent_class)->dispose(object);
+}
+
+static void
+_vsb_get_property(GObject *object, guint prop_id, GValue *value, GParamSpec *pspec)
+{
+    GstQgcVideoSinkBin *vsb;
+
+    vsb = GST_QGC_VIDEO_SINK_BIN(object);
+
+    switch (prop_id) {
+    case PROP_ENABLE_LAST_SAMPLE:
+        do {
+            gboolean enable = FALSE;
+            g_object_get(G_OBJECT(vsb->qmlglsink), PROP_ENABLE_LAST_SAMPLE_NAME, &enable, NULL);
+            g_value_set_boolean(value, enable);
+        } while(0);
+        break;
+    case PROP_LAST_SAMPLE:
+        do {
+            GstSample *sample = NULL;
+            g_object_get(G_OBJECT(vsb->qmlglsink), PROP_LAST_SAMPLE_NAME, &sample, NULL);
+            gst_value_set_sample(value, sample);
+            if (sample != NULL) {
+                gst_sample_unref(sample);
+                sample = NULL;
+            }
+        } while(0);
+        break;
+    case PROP_WIDGET:
+        do {
+            gpointer widget = NULL;
+            g_object_get(G_OBJECT(vsb->qmlglsink), PROP_WIDGET_NAME, &widget, NULL);
+            g_value_set_pointer(value, widget);
+        } while(0);
+        break;
+    case PROP_FORCE_ASPECT_RATIO:
+        do {
+            gboolean enable = FALSE;
+            g_object_get(G_OBJECT(vsb->qmlglsink), PROP_FORCE_ASPECT_RATIO_NAME, &enable, NULL);
+            g_value_set_boolean(value, enable);
+        } while(0);
+        break;
+    case PROP_PIXEL_ASPECT_RATIO:
+        do {
+            gint num = 0, den = 1;
+            g_object_get(G_OBJECT(vsb->qmlglsink), PROP_PIXEL_ASPECT_RATIO_NAME, &num, &den, NULL);
+            gst_value_set_fraction(value, num, den);
+        } while(0);
+        break;
+    case PROP_SYNC:
+        do {
+            gboolean enable = FALSE;
+            g_object_get(G_OBJECT(vsb->qmlglsink), PROP_SYNC_NAME, &enable, NULL);
+            g_value_set_boolean(value, enable);
+        } while(0);
+        break;
+    default:
+        G_OBJECT_WARN_INVALID_PROPERTY_ID(object, prop_id, pspec);
+        break;
+    }
+}
+
+static void
+_vsb_set_property(GObject *object, guint prop_id, const GValue *value, GParamSpec *pspec)
+{
+    GstQgcVideoSinkBin *vsb;
+
+    vsb = GST_QGC_VIDEO_SINK_BIN(object);
+
+    switch (prop_id) {
+    case PROP_ENABLE_LAST_SAMPLE:
+        g_object_set(G_OBJECT(vsb->qmlglsink), PROP_ENABLE_LAST_SAMPLE_NAME, g_value_get_boolean(value), NULL);
+        break;
+    case PROP_WIDGET:
+        g_object_set(G_OBJECT(vsb->qmlglsink), PROP_WIDGET_NAME, g_value_get_pointer(value), NULL);
+        break;
+    case PROP_FORCE_ASPECT_RATIO:
+        g_object_set(G_OBJECT(vsb->qmlglsink), PROP_FORCE_ASPECT_RATIO_NAME, g_value_get_boolean(value), NULL);
+        break;
+    case PROP_PIXEL_ASPECT_RATIO:
+        g_object_set(G_OBJECT(vsb->qmlglsink), PROP_PIXEL_ASPECT_RATIO_NAME, gst_value_get_fraction_numerator(value), gst_value_get_fraction_denominator(value), NULL);
+        break;
+    case PROP_SYNC:
+        g_object_set(G_OBJECT(vsb->qmlglsink), PROP_SYNC_NAME, g_value_get_boolean(value), NULL);
+        break;
+    default:
+        G_OBJECT_WARN_INVALID_PROPERTY_ID(object, prop_id, pspec);
+        break;
+    }
+}
+
+static GType
+_vsb_get_type(void)
+{
+    static GType _vsb_type = 0;
+
+    if (!_vsb_type) {
+        static const GTypeInfo _vsb_info = {
+            sizeof(GstQgcVideoSinkBinClass),
+            NULL,
+            NULL,
+            (GClassInitFunc)_vsb_class_init,
+            NULL,
+            NULL,
+            sizeof(GstQgcVideoSinkBin),
+            0,
+            (GInstanceInitFunc)_vsb_init,
+            NULL};
+
+        _vsb_type = g_type_register_static(GST_TYPE_BIN, "GstQgcVideoSinkBin", &_vsb_info, (GTypeFlags)0);
+    }
+
+    return _vsb_type;
+}
+
+static void
+_vsb_class_init(void *klass, void *classData)
+{
+    Q_UNUSED(classData);
+
+    GObjectClass *gobject_klass;
+    GstElementClass *gstelement_klass;
+
+    gobject_klass = (GObjectClass *)klass;
+    gstelement_klass = (GstElementClass *)klass;
+
+    parent_class = g_type_class_peek_parent(klass);
+
+    gobject_klass->dispose = _vsb_dispose;
+    gobject_klass->get_property = _vsb_get_property;
+    gobject_klass->set_property = _vsb_set_property;
+
+    g_object_class_install_property(gobject_klass, PROP_ENABLE_LAST_SAMPLE,
+        g_param_spec_boolean(PROP_ENABLE_LAST_SAMPLE_NAME, "Enable Last Buffer",
+            "Enable the last-sample property", DEFAULT_ENABLE_LAST_SAMPLE,
+            (GParamFlags)(G_PARAM_READWRITE | G_PARAM_STATIC_STRINGS)));
+
+    g_object_class_install_property(gobject_klass, PROP_LAST_SAMPLE,
+        g_param_spec_boxed(PROP_LAST_SAMPLE_NAME, "Last Sample",
+            "The last sample received in the sink", GST_TYPE_SAMPLE,
+            (GParamFlags)(G_PARAM_READABLE | G_PARAM_STATIC_STRINGS)));
+
+    g_object_class_install_property(gobject_klass, PROP_WIDGET,
+        g_param_spec_pointer(PROP_WIDGET_NAME, "QQuickItem",
+            "The QQuickItem to place in the object hierarchy",
+            (GParamFlags)(G_PARAM_READWRITE | G_PARAM_STATIC_STRINGS)));
+
+    g_object_class_install_property(gobject_klass, PROP_FORCE_ASPECT_RATIO,
+        g_param_spec_boolean(PROP_FORCE_ASPECT_RATIO_NAME, "Force aspect ratio",
+            "When enabled, scaling will respect original aspect ratio",
+            DEFAULT_FORCE_ASPECT_RATIO,
+            (GParamFlags)(G_PARAM_READWRITE | G_PARAM_STATIC_STRINGS)));
+
+    g_object_class_install_property(gobject_klass, PROP_PIXEL_ASPECT_RATIO,
+        gst_param_spec_fraction(PROP_PIXEL_ASPECT_RATIO_NAME, "Pixel Aspect Ratio",
+            "The pixel aspect ratio of the device", DEFAULT_PAR_N, DEFAULT_PAR_D,
+            G_MAXINT, 1, 1, 1,
+            (GParamFlags)(G_PARAM_READWRITE | G_PARAM_STATIC_STRINGS)));
+
+    g_object_class_install_property(gobject_klass, PROP_SYNC,
+        g_param_spec_boolean(PROP_SYNC_NAME, "Sync",
+            "Sync on the clock", DEFAULT_SYNC,
+            (GParamFlags)(G_PARAM_READWRITE | G_PARAM_STATIC_STRINGS)));
+
+    gst_element_class_set_static_metadata(gstelement_klass,
+        "QGC Video Sink Bin", "Sink/Video/Bin",
+        "Video rendering for QGC",
+        "Andrew Voznytsa <andrew.voznytsa@gmail.com>, Tomaz Canabrava <tcanabrava@kde.org>");
+}
+
+gboolean
+gst_qgc_video_sink_bin_plugin_init(GstPlugin *plugin)
+{
+    GST_DEBUG_CATEGORY_INIT(gst_qgc_video_sink_bin_debug, "qgcvideosinkbin", 0, "QGC Video Sink Bin");
+    return gst_element_register(plugin, "qgcvideosinkbin", GST_RANK_NONE, GST_TYPE_VIDEO_SINK_BIN);
+}

--- a/src/VideoManager/VideoReceiver/QtMultimedia/CMakeLists.txt
+++ b/src/VideoManager/VideoReceiver/QtMultimedia/CMakeLists.txt
@@ -1,37 +1,33 @@
-find_package(Qt6 REQUIRED COMPONENTS Core)
+find_package(Qt6 REQUIRED COMPONENTS Core Multimedia QmlIntegration Quick)
 
-if(NOT QGC_ENABLE_QT_VIDEOSTREAMING)
-    return()
-endif()
+# MultimediaQuickPrivate
 
-find_package(Qt6 REQUIRED COMPONENTS Multimedia MultimediaQuickPrivate Quick)
-
-target_sources(QGC
-    PRIVATE
-        QtMultimediaReceiver.cc
-        QtMultimediaReceiver.h
+qt_add_library(QtMultimediaReceiver STATIC
+    QtMultimediaReceiver.cc
+    QtMultimediaReceiver.h
 )
 
-target_link_libraries(QGC
+target_link_libraries(QtMultimediaReceiver
     PRIVATE
-        Qt6::MultimediaQuickPrivate
+        # Qt6::MultimediaPrivate
         Qt6::Quick
+        Utilities
     PUBLIC
         Qt6::Core
         Qt6::Multimedia
+        Qt6::QmlIntegration
+        VideoReceiver
 )
 
-target_include_directories(QGC PUBLIC ${CMAKE_CURRENT_SOURCE_DIR})
+target_include_directories(QtMultimediaReceiver PUBLIC ${CMAKE_CURRENT_SOURCE_DIR})
 
-target_compile_definitions(QGC PUBLIC QGC_QT_STREAMING)
-
-if(NOT QGC_ENABLE_UVC)
-    target_compile_definitions(QGC PUBLIC QGC_DISABLE_UVC)
-    return()
+option(QGC_DISABLE_UVC "Disable UVC Devices" OFF)
+if(QGC_DISABLE_UVC)
+    target_compile_definitions(QtMultimediaReceiver PUBLIC QGC_DISABLE_UVC)
+else()
+    target_sources(QtMultimediaReceiver
+        PRIVATE
+            UVCReceiver.cc
+            UVCReceiver.h
+    )
 endif()
-
-target_sources(QGC
-    PRIVATE
-        UVCReceiver.cc
-        UVCReceiver.h
-)

--- a/src/VideoManager/VideoReceiver/QtMultimedia/QtMultimediaReceiver.h
+++ b/src/VideoManager/VideoReceiver/QtMultimedia/QtMultimediaReceiver.h
@@ -1,17 +1,9 @@
-/****************************************************************************
- *
- * (c) 2009-2024 QGROUNDCONTROL PROJECT <http://www.qgroundcontrol.org>
- *
- * QGroundControl is licensed according to the terms in the file
- * COPYING.md in the root of the source code directory.
- *
- ****************************************************************************/
-
 #pragma once
 
 #include <QtCore/QString>
 #include <QtCore/QMetaObject>
 #include <QtCore/QLoggingCategory>
+#include <QtQmlIntegration/QtQmlIntegration>
 
 #include "VideoReceiver.h"
 
@@ -24,38 +16,40 @@ class QMediaRecorder;
 class QRhi;
 class QTimer;
 class QQuickItem;
-class QQuickVideoOutput;
 
 class QtMultimediaReceiver : public VideoReceiver
 {
     Q_OBJECT
+    QML_ELEMENT
+    QML_UNCREATABLE("")
 
 public:
     explicit QtMultimediaReceiver(QObject *parent = nullptr);
     virtual ~QtMultimediaReceiver();
 
-    static void *createVideoSink(QObject *parent, QQuickItem *widget);
+    static void* createVideoSink(QObject *parent);
     static void releaseVideoSink(void *sink);
-    static VideoReceiver *createVideoReceiver(QObject *parent);
+    static VideoReceiver* createVideoReceiver(QObject *parent);
 
 public slots:
     void start(const QString &uri, unsigned timeout, int buffer = 0) override;
     void stop() override;
     void startDecoding(void *sink) override;
     void stopDecoding() override;
-    void startRecording(const QString &videoFile, VideoReceiver::FILE_FORMAT format) override;
+    void startRecording(const QString &videoFile, FILE_FORMAT format) override;
     void stopRecording() override;
     void takeScreenshot(const QString &imageFile) override;
 
 protected:
-    QMediaPlayer *_mediaPlayer = nullptr;
-    QVideoSink *_videoSink = nullptr;
-    QMediaCaptureSession *_captureSession = nullptr;
-    QMediaRecorder *_mediaRecorder = nullptr;
-    QMetaObject::Connection _videoSizeUpdater;
-    QMetaObject::Connection _videoFrameUpdater;
-    QTimer *_frameTimer = nullptr;
-    QRhi *_rhi = nullptr;
-    const QIODevice *_streamDevice;
-    QQuickVideoOutput *_videoOutput = nullptr;
+    QMediaPlayer* m_mediaPlayer = nullptr;
+    QVideoSink* m_videoSink = nullptr;
+    QMediaCaptureSession* m_captureSession = nullptr;
+    QMediaRecorder* m_mediaRecorder = nullptr;
+    QMetaObject::Connection m_videoSizeUpdater;
+    QMetaObject::Connection m_videoFrameUpdater;
+    QTimer* m_frameTimer = nullptr;
+    QRhi* m_rhi = nullptr;
+    const QIODevice * m_streamDevice;
+    QQuickItem* m_videoOutput = nullptr;
+    // QQuickVideoOutput* m_videoOutput = nullptr;
 };

--- a/src/VideoManager/VideoReceiver/QtMultimedia/UVCReceiver.h
+++ b/src/VideoManager/VideoReceiver/QtMultimedia/UVCReceiver.h
@@ -1,12 +1,3 @@
-/****************************************************************************
- *
- * (c) 2009-2024 QGROUNDCONTROL PROJECT <http://www.qgroundcontrol.org>
- *
- * QGroundControl is licensed according to the terms in the file
- * COPYING.md in the root of the source code directory.
- *
- ****************************************************************************/
-
 #pragma once
 
 #include <QtMultimedia/QCameraDevice>
@@ -22,20 +13,30 @@ class QQuickItem;
 class UVCReceiver : public QtMultimediaReceiver
 {
     Q_OBJECT
+    QML_ELEMENT
+    QML_UNCREATABLE("")
 
 public:
-    explicit UVCReceiver(QObject *parent = nullptr);
+    explicit UVCReceiver(QObject* parent = nullptr);
     ~UVCReceiver();
 
     bool enabled();
     QCameraDevice findCameraDevice(const QString &cameraId);
 
 public slots:
-    Q_INVOKABLE void adjustAspectRatio();
+    void start(const QString& uri, unsigned timeout, int buffer = 0) final;
+    void stop() final;
+    void startDecoding(void* sink) final;
+    void stopDecoding() final;
+    void startRecording(const QString& videoFile, FILE_FORMAT format) final;
+    void stopRecording() final;
+    void takeScreenshot(const QString& imageFile) final;
+
+    Q_INVOKABLE void adjustAspectRatio(qreal height);
 
 private:
     void _checkPermission();
 
-    QCamera *_camera = nullptr;
-    QImageCapture *_imageCapture = nullptr;
+    QCamera* m_camera = nullptr;
+	QImageCapture* m_imageCapture = nullptr;
 };

--- a/src/VideoManager/VideoReceiver/VideoReceiver.h
+++ b/src/VideoManager/VideoReceiver/VideoReceiver.h
@@ -1,6 +1,6 @@
 /****************************************************************************
  *
- * (c) 2009-2024 QGROUNDCONTROL PROJECT <http://www.qgroundcontrol.org>
+ * (c) 2009-2020 QGROUNDCONTROL PROJECT <http://www.qgroundcontrol.org>
  *
  * QGroundControl is licensed according to the terms in the file
  * COPYING.md in the root of the source code directory.

--- a/src/VideoManager/VideoReceiver/VideoReceiver.pri
+++ b/src/VideoManager/VideoReceiver/VideoReceiver.pri
@@ -1,0 +1,167 @@
+################################################################################
+#
+# (c) 2009-2020 QGROUNDCONTROL PROJECT <http://www.qgroundcontrol.org>
+#
+# QGroundControl is licensed according to the terms in the file
+# COPYING.md in the root of the source code directory.
+#
+################################################################################
+
+#
+#-- Depends on gstreamer, which can be found at: http://gstreamer.freedesktop.org/download/
+#
+
+LinuxBuild {
+    UseWayland {
+        QT += waylandclient
+    }
+    CONFIG += link_pkgconfig
+    packagesExist(gstreamer-1.0) {
+        PKGCONFIG   += gstreamer-1.0 gstreamer-video-1.0 gstreamer-gl-1.0 egl
+        CONFIG      += VideoEnabled
+    }
+} else:MacBuild {
+    #- gstreamer framework installed by the gstreamer devel installer
+    GST_ROOT = /Library/Frameworks/GStreamer.framework
+    exists($$GST_ROOT) {
+        CONFIG      += VideoEnabled
+        INCLUDEPATH += $$GST_ROOT/Headers
+        LIBS        += -F/Library/Frameworks -framework GStreamer
+        QMAKE_LIBDIR += $$GST_ROOT/Versions/1.0/lib/
+    }
+} else:iOSBuild {
+    #- gstreamer framework installed by the gstreamer iOS SDK installer (default to home directory)
+    GST_ROOT = $$(HOME)/Library/Developer/GStreamer/iPhone.sdk/GStreamer.framework
+    exists($$GST_ROOT) {
+        CONFIG      += VideoEnabled
+        INCLUDEPATH += $$GST_ROOT/Headers
+        LIBS        += -F$$(HOME)/Library/Developer/GStreamer/iPhone.sdk -framework GStreamer -framework AVFoundation -framework CoreMedia -framework CoreVideo -framework VideoToolbox -liconv -lresolv
+    }
+} else:WindowsBuild {
+    #- gstreamer installed by default under c:/gstreamer
+    GST_ROOT = c:/gstreamer/1.0/msvc_x86_64
+
+    !exists($$GST_ROOT) {
+        # In GitHub actions windows runner installation is on D drive, so try there as well
+        GST_ROOT = d:/gstreamer/1.0/msvc_x86_64
+    }
+
+    exists($$GST_ROOT) {
+        CONFIG      += VideoEnabled
+
+        LIBS        += -L$$GST_ROOT/lib -lgstreamer-1.0 -lgstgl-1.0 -lgstvideo-1.0 -lgstbase-1.0
+        LIBS        += -lglib-2.0 -lintl -lgobject-2.0
+
+        INCLUDEPATH += \
+            $$GST_ROOT/include \
+            $$GST_ROOT/include/gstreamer-1.0 \
+            $$GST_ROOT/include/glib-2.0 \
+            $$GST_ROOT/lib/gstreamer-1.0/include \
+            $$GST_ROOT/lib/glib-2.0/include
+
+        DESTDIR_WIN = $$replace(DESTDIR, "/", "\\")
+        GST_ROOT_WIN = $$replace(GST_ROOT, "/", "\\")
+
+        # Copy main GStreamer runtime files
+        QMAKE_POST_LINK += $$escape_expand(\\n) xcopy \"$$GST_ROOT_WIN\\bin\*.dll\" \"$$DESTDIR_WIN\" /S/Y $$escape_expand(\\n)
+        QMAKE_POST_LINK += xcopy \"$$GST_ROOT_WIN\\bin\*.\" \"$$DESTDIR_WIN\" /S/Y $$escape_expand(\\n)
+
+        # Copy GStreamer plugins
+        QMAKE_POST_LINK += $$escape_expand(\\n) xcopy \"$$GST_ROOT_WIN\\lib\\gstreamer-1.0\\*.dll\" \"$$DESTDIR_WIN\\gstreamer-plugins\\\" /Y $$escape_expand(\\n)
+    }
+} else:AndroidBuild {
+    GST_VERSION = 1.22.11
+    #- gstreamer assumed to be installed in $$PWD/../../gstreamer-1.0-android-universal-$$GST_VERSION/***
+    ANDROID_GST_ROOT = $$PWD/../../gstreamer-1.0-android-universal-$$GST_VERSION
+    contains(ANDROID_TARGET_ARCH, armeabi-v7a) {
+        GST_ROOT = $$ANDROID_GST_ROOT/armv7
+    } else:contains(ANDROID_TARGET_ARCH, arm64-v8a) {
+        GST_ROOT = $$ANDROID_GST_ROOT/arm64
+    } else:contains(ANDROID_TARGET_ARCH, x86_64) {
+        GST_ROOT = $$ANDROID_GST_ROOT/x86_64
+    } else {
+        message(Unknown ANDROID_TARGET_ARCH $$ANDROID_TARGET_ARCH)
+        GST_ROOT = $$ANDROID_GST_ROOT/x86
+    }
+    exists($$GST_ROOT) {
+        QMAKE_CXXFLAGS  += -pthread
+        CONFIG          += VideoEnabled
+
+        # We want to link these plugins statically
+        LIBS += -L$$GST_ROOT/lib/gstreamer-1.0 \
+            -lgstvideo-1.0 \
+            -lgstcoreelements \
+            -lgstplayback \
+            -lgstudp \
+            -lgstrtp \
+            -lgstrtsp \
+            -lgstx264 \
+            -lgstlibav \
+            -lgstsdpelem \
+            -lgstvideoparsersbad \
+            -lgstrtpmanager \
+            -lgstisomp4 \
+            -lgstmatroska \
+            -lgstmpegtsdemux \
+            -lgstandroidmedia \
+            -lgstopengl \
+            -lgsttcp
+
+        # Rest of GStreamer dependencies
+        LIBS += -L$$GST_ROOT/lib \
+            -lgraphene-1.0 -ljpeg -lpng16 \
+            -lgstfft-1.0 -lm  \
+            -lgstnet-1.0 -lgio-2.0 \
+            -lgstphotography-1.0 -lgstgl-1.0 -lEGL \
+            -lgstaudio-1.0 -lgstcodecparsers-1.0 -lgstbase-1.0 \
+            -lgstreamer-1.0 -lgstrtp-1.0 -lgstpbutils-1.0 -lgstrtsp-1.0 -lgsttag-1.0 \
+            -lgstvideo-1.0 -lavformat -lavcodec -lavutil -lx264 -lavfilter -lswresample \
+            -lgstriff-1.0 -lgstcontroller-1.0 -lgstapp-1.0 \
+            -lgstsdp-1.0 -lbz2 -lgobject-2.0 -lgstmpegts-1.0 \
+            -Wl,--export-dynamic -lgmodule-2.0 -pthread -lglib-2.0 -lorc-0.4 -liconv -lffi -lintl \
+
+        INCLUDEPATH += \
+            $$GST_ROOT/include/gstreamer-1.0 \
+            $$GST_ROOT/lib/gstreamer-1.0/include \
+            $$GST_ROOT/include/glib-2.0 \
+            $$GST_ROOT/lib/glib-2.0/include
+    }
+}
+
+VideoEnabled {
+
+    message("Including support for video streaming")
+
+    DEFINES += \
+        QGC_GST_STREAMING
+
+    INCLUDEPATH += \
+        $$PWD
+        $$PWD/GStreamer \
+        $$PWD/QtMultimedia
+
+    iOSBuild {
+        OBJECTIVE_SOURCES += \
+            $$PWD/gst_ios_init.m
+    }
+
+    HEADERS += \
+        $$PWD/GStreamer/GStreamer.h \
+        $$PWD/GStreamer/GstVideoReceiver.h \
+        $$PWD/VideoReceiver.h
+
+    SOURCES += \
+        $$PWD/GStreamer/gstqgcvideosinkbin.c \
+        $$PWD/GStreamer/gstqgc.c \
+        $$PWD/GStreamer/GStreamer.cc \
+        $$PWD/GStreamer/GstVideoReceiver.cc
+
+    include($$PWD/../../../qmlglsink.pri)
+} else {
+    LinuxBuild|MacBuild|iOSBuild|WindowsBuild|AndroidBuild {
+        message("Skipping support for video streaming (GStreamer libraries not installed)")
+        message("Installation instructions here: https://github.com/mavlink/qgroundcontrol/blob/master/src/VideoManager/VideoReceiver/GStreamer/README.md")
+    } else {
+        message("Skipping support for video streaming (Unsupported platform)")
+    }
+}


### PR DESCRIPTION
## Description

This pull request restores:

- `src/VideoManager/` from commit [`f2d69ad7e`](https://github.com/mavlink/qgroundcontrol/commit/f2d69ad7e)
- `custom-example/CustomVideoManager.{cc,h}` from commit [`931b2c55f`](https://github.com/mavlink/qgroundcontrol/commit/931b2c55f)

These files were previously removed or restructured. They are required for downstream or custom development needs (e.g., integration of a custom video backend).

## Test Steps

- Ensure project builds correctly.
- CustomVideoManager and restored GStreamer components can be used/modified as needed.

## Checklist
- [x] Review Contribution Guidelines
- [x] Review Code of Conduct
- [x] I have tested my changes
