### PR TITLE
Make checklist remember place after closing

### DIFF
--- a/src/FlightDisplay/MultiRotorChecklist.qml
+++ b/src/FlightDisplay/MultiRotorChecklist.qml
@@ -26,7 +26,17 @@ Item {
 
             PreFlightCheckButton {
                 name:           qsTr("Hardware")
-                manualText:     qsTr("Props mounted and secured?")
+                manualText:     globals.activeVehicle ? (globals.activeVehicle.checkListItem1 ? "" :  qsTr("Props mounted and secured?")) : qsTr("Props mounted and secured?")
+                telemetryFailure: globals.activeVehicle ? (globals.activeVehicle.checkListItem1 ? false : true) : true
+                telemetryTextFailure: qsTr("Props mounted and secured?")
+                allowTelemetryFailureOverride: true
+                onClicked: {
+                    if (manualText !== "") {
+                        // User is confirming a manual check
+                        _manualState = (_manualState === _statePassed) ? _statePending : _statePassed
+                        globals.activeVehicle.checkListItem1 = true
+                    }
+                }
             }
 
             PreFlightBatteryCheck {
@@ -51,12 +61,32 @@ Item {
 
             PreFlightCheckButton {
                 name:            qsTr("Motors")
-                manualText:      qsTr("Propellers free? Then throttle up gently. Working properly?")
+                manualText:      globals.activeVehicle ? (globals.activeVehicle.checkListItem2 ? "" :  qsTr("Propellers free? Then throttle up gently. Working properly?")) : qsTr("Propellers free? Then throttle up gently. Working properly?")
+                telemetryFailure: globals.activeVehicle ? (globals.activeVehicle.checkListItem2 ? false : true) : true
+                telemetryTextFailure: qsTr("Propellers free? Then throttle up gently. Working properly?")
+                allowTelemetryFailureOverride: true
+                onClicked: {
+                    if (manualText !== "") {
+                        // User is confirming a manual check
+                        _manualState = (_manualState === _statePassed) ? _statePending : _statePassed
+                        globals.activeVehicle.checkListItem2 = true
+                    }
+                }
             }
 
             PreFlightCheckButton {
                 name:           qsTr("Mission")
-                manualText:     qsTr("Please confirm mission is valid (waypoints valid, no terrain collision).")
+                manualText:     globals.activeVehicle ? (globals.activeVehicle.checkListItem3 ? "" :  qsTr("Please confirm mission is valid (waypoints valid, no terrain collision).")) : qsTr("Please confirm mission is valid (waypoints valid, no terrain collision).")
+                telemetryFailure: globals.activeVehicle ? (globals.activeVehicle.checkListItem3 ? false : true) : true
+                telemetryTextFailure: qsTr("Please confirm mission is valid (waypoints valid, no terrain collision).")
+                allowTelemetryFailureOverride: true
+                onClicked: {
+                    if (manualText !== "") {
+                        // User is confirming a manual check
+                        _manualState = (_manualState === _statePassed) ? _statePending : _statePassed
+                        globals.activeVehicle.checkListItem3 = true
+                    }
+                }
             }
 
             PreFlightSoundCheck {
@@ -69,17 +99,47 @@ Item {
             // Check list item group 2 - Final checks before launch
             PreFlightCheckButton {
                 name:           qsTr("Payload")
-                manualText:     qsTr("Configured and started? Payload lid closed?")
+                manualText:     globals.activeVehicle ? (globals.activeVehicle.checkListItem4 ? "" :  qsTr("Configured and started? Payload lid closed?")) : qsTr("Configured and started? Payload lid closed?")
+                telemetryFailure: globals.activeVehicle ? (globals.activeVehicle.checkListItem4 ? false : true) : true
+                telemetryTextFailure: qsTr("Configured and started? Payload lid closed?")
+                allowTelemetryFailureOverride: true
+                onClicked: {
+                    if (manualText !== "") {
+                        // User is confirming a manual check
+                        _manualState = (_manualState === _statePassed) ? _statePending : _statePassed
+                        globals.activeVehicle.checkListItem4 = true
+                    }
+                }
             }
 
             PreFlightCheckButton {
                 name:           qsTr("Wind & weather")
-                manualText:     qsTr("OK for your platform?")
+                manualText:     globals.activeVehicle ? (globals.activeVehicle.checkListItem5 ? "" :  qsTr("OK for your platform?")) : qsTr("OK for your platform?")
+                telemetryFailure: globals.activeVehicle ? (globals.activeVehicle.checkListItem5 ? false : true) : true
+                telemetryTextFailure: qsTr("OK for your platform?")
+                allowTelemetryFailureOverride: true
+                onClicked: {
+                    if (manualText !== "") {
+                        // User is confirming a manual check
+                        _manualState = (_manualState === _statePassed) ? _statePending : _statePassed
+                        globals.activeVehicle.checkListItem5 = true
+                    }
+                }
             }
 
             PreFlightCheckButton {
                 name:           qsTr("Flight area")
-                manualText:     qsTr("Launch area and path free of obstacles/people?")
+                manualText:      globals.activeVehicle ? (globals.activeVehicle.checkListItem6 ? "" :  qsTr("Launch area and path free of obstacles/people?")) : qsTr("Launch area and path free of obstacles/people?")
+                telemetryFailure: globals.activeVehicle ? (globals.activeVehicle.checkListItem6 ? false : true) : true
+                telemetryTextFailure: qsTr("Launch area and path free of obstacles/people?")
+                allowTelemetryFailureOverride: true
+                onClicked: {
+                    if (manualText !== "") {
+                        // User is confirming a manual check
+                        _manualState = (_manualState === _statePassed) ? _statePending : _statePassed
+                        globals.activeVehicle.checkListItem6 = true
+                    }
+                }
             }
         }
     }

--- a/src/FlightDisplay/PreFlightCheckList.qml
+++ b/src/FlightDisplay/PreFlightCheckList.qml
@@ -66,6 +66,30 @@ ColumnLayout {
                 break
             }
         }
+        
+        if (allPassed) {
+            globals.activeVehicle.checkListItem1 = false
+            globals.activeVehicle.checkListItem2 = false
+            globals.activeVehicle.checkListItem3 = false
+            globals.activeVehicle.checkListItem4 = false
+            globals.activeVehicle.checkListItem5 = false
+            globals.activeVehicle.checkListItem6 = false
+            globals.activeVehicle.checkListItem7 = false
+            globals.activeVehicle.checkListItem8 = false
+            globals.activeVehicle.checkListItem9 = false
+            globals.activeVehicle.checkListItem10 = false
+            globals.activeVehicle.checkListItem11 = false
+            globals.activeVehicle.checkListItem12 = false
+            globals.activeVehicle.checkListItem13 = false
+            globals.activeVehicle.checkListItem14 = false
+            globals.activeVehicle.checkListItem15 = false
+            globals.activeVehicle.checkListItem16 = false
+            globals.activeVehicle.checkListItem17 = false
+            globals.activeVehicle.checkListItem18 = false
+            globals.activeVehicle.checkListItem19 = false
+            globals.activeVehicle.checkListItem20 = false
+            globals.activeVehicle.checkListItem21 = false
+        }
         allChecksPassed = allPassed;
     }
 
@@ -138,12 +162,39 @@ ColumnLayout {
             width:              1.2 * ScreenTools.defaultFontPixelHeight
             height:             1.2 * ScreenTools.defaultFontPixelHeight
             Layout.alignment:   Qt.AlignVCenter
-            onClicked:          checkListRepeater.model.reset()
+            onClicked: {
+                resetCheckListItem()
+                checkListRepeater.model.reset()
+            }
 
             QGCColoredImage {
                 source:         "/qmlimages/MapSyncBlack.svg"
                 color:          qgcPal.buttonText
                 anchors.fill:   parent
+            }
+
+            function resetCheckListItem() {
+                globals.activeVehicle.checkListItem1 = false
+                globals.activeVehicle.checkListItem2 = false
+                globals.activeVehicle.checkListItem3 = false
+                globals.activeVehicle.checkListItem4 = false
+                globals.activeVehicle.checkListItem5 = false
+                globals.activeVehicle.checkListItem6 = false
+                globals.activeVehicle.checkListItem7 = false
+                globals.activeVehicle.checkListItem8 = false
+                globals.activeVehicle.checkListItem9 = false
+                globals.activeVehicle.checkListItem10 = false
+                globals.activeVehicle.checkListItem11 = false
+                globals.activeVehicle.checkListItem12 = false
+                globals.activeVehicle.checkListItem13 = false
+                globals.activeVehicle.checkListItem14 = false
+                globals.activeVehicle.checkListItem15 = false
+                globals.activeVehicle.checkListItem16 = false
+                globals.activeVehicle.checkListItem17 = false
+                globals.activeVehicle.checkListItem18 = false
+                globals.activeVehicle.checkListItem19 = false
+                globals.activeVehicle.checkListItem20 = false
+                globals.activeVehicle.checkListItem21 = false
             }
         }
     }

--- a/src/QmlControls/PreFlightCheckModel.qml
+++ b/src/QmlControls/PreFlightCheckModel.qml
@@ -37,6 +37,18 @@ ObjectModel {
         return true
     }
 
-    Component.onCompleted: reset()
-
+    Component.onCompleted: {
+        reset()
+        for (var i = 0; i < _root.count; i++) {
+            var group = _root.get(i)
+            if (group.passed) {
+                group._checked = false
+                group.enabled = true
+            } else {
+                group._checked = true
+                group.enabled = true
+                return
+            }            
+        }
+    }
 }

--- a/src/Vehicle/Vehicle.h
+++ b/src/Vehicle/Vehicle.h
@@ -223,6 +223,27 @@ public:
     Q_PROPERTY(bool                 requiresGpsFix              READ requiresGpsFix                                                 NOTIFY requiresGpsFixChanged)
     Q_PROPERTY(double               loadProgress                READ loadProgress                                                   NOTIFY loadProgressChanged)
     Q_PROPERTY(bool                 initialConnectComplete      READ isInitialConnectComplete                                       NOTIFY initialConnectComplete)
+    Q_PROPERTY(bool                 checkListItem1              READ checkListItem1             WRITE setCheckListItem1)
+    Q_PROPERTY(bool                 checkListItem2              READ checkListItem2             WRITE setCheckListItem2)
+    Q_PROPERTY(bool                 checkListItem3              READ checkListItem3             WRITE setCheckListItem3)
+    Q_PROPERTY(bool                 checkListItem4              READ checkListItem4             WRITE setCheckListItem4)
+    Q_PROPERTY(bool                 checkListItem5              READ checkListItem5             WRITE setCheckListItem5)
+    Q_PROPERTY(bool                 checkListItem6              READ checkListItem6             WRITE setCheckListItem6)
+    Q_PROPERTY(bool                 checkListItem7              READ checkListItem7             WRITE setCheckListItem7)
+    Q_PROPERTY(bool                 checkListItem8              READ checkListItem8             WRITE setCheckListItem8)
+    Q_PROPERTY(bool                 checkListItem9              READ checkListItem9             WRITE setCheckListItem9)
+    Q_PROPERTY(bool                 checkListItem10             READ checkListItem10            WRITE setCheckListItem10)
+    Q_PROPERTY(bool                 checkListItem11             READ checkListItem11            WRITE setCheckListItem11)
+    Q_PROPERTY(bool                 checkListItem12             READ checkListItem12            WRITE setCheckListItem12)
+    Q_PROPERTY(bool                 checkListItem13             READ checkListItem13            WRITE setCheckListItem13)
+    Q_PROPERTY(bool                 checkListItem14             READ checkListItem14            WRITE setCheckListItem14)
+    Q_PROPERTY(bool                 checkListItem15             READ checkListItem15            WRITE setCheckListItem15)
+    Q_PROPERTY(bool                 checkListItem16             READ checkListItem16            WRITE setCheckListItem16)
+    Q_PROPERTY(bool                 checkListItem17             READ checkListItem17            WRITE setCheckListItem17)
+    Q_PROPERTY(bool                 checkListItem18             READ checkListItem18            WRITE setCheckListItem18)
+    Q_PROPERTY(bool                 checkListItem19             READ checkListItem19            WRITE setCheckListItem19)
+    Q_PROPERTY(bool                 checkListItem20             READ checkListItem20            WRITE setCheckListItem20)
+    Q_PROPERTY(bool                 checkListItem21             READ checkListItem21            WRITE setCheckListItem21)
 
     // The following properties relate to Orbit status
     Q_PROPERTY(bool             orbitActive     READ orbitActive        NOTIFY orbitActiveChanged)
@@ -807,6 +828,50 @@ public:
     CheckList   checkListState          () { return _checkListState; }
     void        setCheckListState       (CheckList cl)  { _checkListState = cl; emit checkListStateChanged(); }
 
+    bool checkListItem1                 () { return _checkListItem1; }
+    bool checkListItem2                 () { return _checkListItem2; }
+    bool checkListItem3                 () { return _checkListItem3; }
+    bool checkListItem4                 () { return _checkListItem4; }
+    bool checkListItem5                 () { return _checkListItem5; }
+    bool checkListItem6                 () { return _checkListItem6; }
+    bool checkListItem7                 () { return _checkListItem7; }
+    bool checkListItem8                 () { return _checkListItem8; }
+    bool checkListItem9                 () { return _checkListItem9; }
+    bool checkListItem10                () { return _checkListItem10; }
+    bool checkListItem11                () { return _checkListItem11; }
+    bool checkListItem12                () { return _checkListItem12; }
+    bool checkListItem13                () { return _checkListItem13; }
+    bool checkListItem14                () { return _checkListItem14; }
+    bool checkListItem15                () { return _checkListItem15; }
+    bool checkListItem16                () { return _checkListItem16; }
+    bool checkListItem17                () { return _checkListItem17; }
+    bool checkListItem18                () { return _checkListItem18; }
+    bool checkListItem19                () { return _checkListItem19; }
+    bool checkListItem20                () { return _checkListItem20; }
+    bool checkListItem21                () { return _checkListItem21; }
+
+    void setCheckListItem1              (bool value){ _checkListItem1 = value; }
+    void setCheckListItem2              (bool value){ _checkListItem2 = value; }
+    void setCheckListItem3              (bool value){ _checkListItem3 = value; }
+    void setCheckListItem4              (bool value){ _checkListItem4 = value; }
+    void setCheckListItem5              (bool value){ _checkListItem5 = value; }
+    void setCheckListItem6              (bool value){ _checkListItem6 = value; }
+    void setCheckListItem7              (bool value){ _checkListItem7 = value; }
+    void setCheckListItem8              (bool value){ _checkListItem8 = value; }
+    void setCheckListItem9              (bool value){ _checkListItem9 = value; }
+    void setCheckListItem10             (bool value){ _checkListItem10 = value; }
+    void setCheckListItem11             (bool value){ _checkListItem11 = value; }
+    void setCheckListItem12             (bool value){ _checkListItem12 = value; }
+    void setCheckListItem13             (bool value){ _checkListItem13 = value; }
+    void setCheckListItem14             (bool value){ _checkListItem14 = value; }
+    void setCheckListItem15             (bool value){ _checkListItem15 = value; }
+    void setCheckListItem16             (bool value){ _checkListItem16 = value; }
+    void setCheckListItem17             (bool value){ _checkListItem17 = value; }
+    void setCheckListItem18             (bool value){ _checkListItem18 = value; }
+    void setCheckListItem19             (bool value){ _checkListItem19 = value; }
+    void setCheckListItem20             (bool value){ _checkListItem20 = value; }
+    void setCheckListItem21             (bool value){ _checkListItem21 = value; }
+
     double loadProgress                 () const { return _loadProgress; }
 
     void setEventsMetadata(uint8_t compid, const QString& metadataJsonFileName);
@@ -1052,6 +1117,28 @@ private:
     bool            _readyToFly                             = false;
     bool            _allSensorsHealthy                      = true;
     bool            _mavlinkSigning                         = false;
+
+    bool _checkListItem1   = false;
+    bool _checkListItem2   = false;
+    bool _checkListItem3   = false;
+    bool _checkListItem4   = false;
+    bool _checkListItem5   = false;
+    bool _checkListItem6   = false;
+    bool _checkListItem7   = false;
+    bool _checkListItem8   = false;
+    bool _checkListItem9   = false;
+    bool _checkListItem10  = false;
+    bool _checkListItem11  = false;
+    bool _checkListItem12  = false;
+    bool _checkListItem13  = false;
+    bool _checkListItem14  = false;
+    bool _checkListItem15  = false;
+    bool _checkListItem16  = false;
+    bool _checkListItem17  = false;
+    bool _checkListItem18  = false;
+    bool _checkListItem19  = false;
+    bool _checkListItem20  = false;
+    bool _checkListItem21  = false;
 
     SysStatusSensorInfo _sysStatusSensorInfo;
 


### PR DESCRIPTION
Make Checklist remember place after closing

Description
-----------
This PR adds support to allow the checklist to hold its place after closing.  This was only applied to the multirotor checklist.  I need help making the code more streamlined.  I don't understand Qt QML and need help.

Test Steps
-----------
connect to a multirotor frametype.  select checklist items as completed.  Close and then reopen the checklist.  the items that were checked completed will remain completed until checklist is completed or reset.

Checklist:
----------
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] [Review Contribution Guidelines](https://github.com/mavlink/qgroundcontrol/blob/master/.github/CONTRIBUTING.md).
- [x] [Review Code of Conduct](https://github.com/mavlink/qgroundcontrol/blob/master/.github/CODE_OF_CONDUCT.md).
- [x] I have tested my changes.

Related Issue
-----------
<!-- If any, please provide issue ID. -->


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.