### PR TITLE
Added Ubuntu apt package in download_and_install.md

### DIFF
--- a/docs/en/qgc-user-guide/getting_started/download_and_install.md
+++ b/docs/en/qgc-user-guide/getting_started/download_and_install.md
@@ -66,6 +66,7 @@ Before installing _QGroundControl_ for the first time:
    sudo apt install gstreamer1.0-plugins-bad gstreamer1.0-libav gstreamer1.0-gl -y
    sudo apt install libfuse2 -y
    sudo apt install libxcb-xinerama0 libxkbcommon-x11-0 libxcb-cursor-dev -y
+   sudo apt install libpulse-mainloop-glib0 -y
    ```
    <!-- Note, remove install of libqt5gui5 https://github.com/mavlink/qgroundcontrol/issues/10176 fixed -->
 1. Logout and login again to enable the change to user permissions.


### PR DESCRIPTION
Added Ubuntu apt package in download_and_install.md

Description
-----------
Added an additional apt package installation step as part of the Ubuntu setup.

Test Steps
-----------
I performed these steps using Windows Subsystem for Linux (WSL).
Installed the required apt packages following the [Ubuntu installation steps](https://docs.qgroundcontrol.com/master/en/qgc-user-guide/getting_started/download_and_install.html#ubuntu).
Attempted to run QGroundControl:
`./QGroundControl.AppImage`
Encountered this error:
`/tmp/.mount_QGrounfEIV46/QGroundControl: error while loading shared libraries: libpulse-mainloop-glib.so.0: cannot open shared object file: No such file or directory`
Installing an additional apt package fixed it:
`sudo apt install libpulse-mainloop-glib0`

Checklist:
----------
- [x] [Review Contribution Guidelines](https://github.com/mavlink/qgroundcontrol/blob/master/.github/CONTRIBUTING.md).
- [x] [Review Code of Conduct](https://github.com/mavlink/qgroundcontrol/blob/master/.github/CODE_OF_CONDUCT.md).
- [x] I have tested my changes.

Related Issue
-----------
N/A