### PR TITLE
Fix incorrect loop variables in _testItemCount test case

### DIFF
--- a/test/MissionManager/SurveyComplexItemTest.cc
+++ b/test/MissionManager/SurveyComplexItemTest.cc
@@ -175,9 +175,9 @@ void SurveyComplexItemTest::_testItemCount(void)
     QList<TestCase_t> rgTestCases;
 
     for (int i=0; i<2; i++) {
-        for (int j=0; i<2; i++) {
-            for (int k=0; i<2; i++) {
-                for (int l=0; i<2; i++) {
+        for (int j=0; j<2; j++) {
+            for (int k=0; k<2; k++) {
+                for (int l=0; l<2; l++) {
                     TestCase_t testCase;
                     testCase.hoverAndCapture =      i;
                     testCase.triggerInTurnAround =  j;


### PR DESCRIPTION
Corrected a logic error in SurveyComplexItemTest::_testItemCount() where all nested for loops used the same loop variable (i). This prevented proper generation of the 16 expected test case combinations. Each loop now uses its intended iterator (i, j, k, l).