### PR TITLE
GStreamer: Allow Other RTSP Schemes

### DIFF
--- a/cmake/find-modules/FindGStreamer.cmake
+++ b/cmake/find-modules/FindGStreamer.cmake
@@ -186,6 +186,7 @@ find_gstreamer_component(Core gstreamer-1.0)
 find_gstreamer_component(Base gstreamer-base-1.0)
 find_gstreamer_component(Video gstreamer-video-1.0)
 find_gstreamer_component(Gl gstreamer-gl-1.0)
+find_gstreamer_component(Rtsp gstreamer-rtsp-1.0)
 
 if(TARGET PkgConfig::PC_GSTREAMER_GL)
     get_target_property(_qt_incs PkgConfig::PC_GSTREAMER_GL INTERFACE_INCLUDE_DIRECTORIES)
@@ -225,6 +226,7 @@ find_package_handle_standard_args(GStreamer
         GStreamer_Base_FOUND
         GStreamer_Video_FOUND
         GStreamer_Gl_FOUND
+        GStreamer_Rtsp_FOUND
     VERSION_VAR GStreamer_VERSION
     HANDLE_COMPONENTS
 )
@@ -261,6 +263,7 @@ if(GStreamer_FOUND AND NOT TARGET GStreamer::GStreamer)
             GStreamer::Base
             GStreamer::Video
             GStreamer::Gl
+            GStreamer::Rtsp
     )
     # set_target_properties(GStreamer::GStreamer PROPERTIES VERSION ${GStreamer_VERSION})
 

--- a/src/VideoManager/VideoReceiver/GStreamer/CMakeLists.txt
+++ b/src/VideoManager/VideoReceiver/GStreamer/CMakeLists.txt
@@ -20,6 +20,8 @@ target_sources(${CMAKE_PROJECT_NAME}
         gstqgcvideosinkbin.h
         GStreamer.cc
         GStreamer.h
+        GStreamerHelpers.cc
+        GStreamerHelpers.h
         GstVideoReceiver.cc
         GstVideoReceiver.h
 )

--- a/src/VideoManager/VideoReceiver/GStreamer/GStreamerHelpers.cc
+++ b/src/VideoManager/VideoReceiver/GStreamer/GStreamerHelpers.cc
@@ -1,0 +1,36 @@
+/****************************************************************************
+ *
+ * (c) 2009-2024 QGROUNDCONTROL PROJECT <http://www.qgroundcontrol.org>
+ *
+ * QGroundControl is licensed according to the terms in the file
+ * COPYING.md in the root of the source code directory.
+ *
+ ****************************************************************************/
+
+#include "GStreamerHelpers.h"
+
+#include <gst/rtsp/gstrtspurl.h>
+
+namespace GStreamer
+{
+
+gboolean
+is_valid_rtsp_uri(const gchar *uri_str)
+{
+    GstRTSPUrl *url = NULL;
+    GstRTSPResult res;
+
+    if (!gst_uri_is_valid(uri_str)) {
+        return FALSE;
+    }
+
+    res = gst_rtsp_url_parse(uri_str, &url);
+    if ((res != GST_RTSP_OK) || (url == NULL)) {
+        return FALSE;
+    }
+
+    gst_rtsp_url_free(url);
+    return TRUE;
+}
+
+} // namespace GStreamer

--- a/src/VideoManager/VideoReceiver/GStreamer/GStreamerHelpers.h
+++ b/src/VideoManager/VideoReceiver/GStreamer/GStreamerHelpers.h
@@ -1,0 +1,17 @@
+/****************************************************************************
+ *
+ * (c) 2009-2024 QGROUNDCONTROL PROJECT <http://www.qgroundcontrol.org>
+ *
+ * QGroundControl is licensed according to the terms in the file
+ * COPYING.md in the root of the source code directory.
+ *
+ ****************************************************************************/
+
+#pragma once
+
+#include <glib.h>
+
+namespace GStreamer
+{
+    gboolean is_valid_rtsp_uri(const gchar *uri_str);
+}


### PR DESCRIPTION
Fixes #10402

Use GStreamer RTSP functions to verify RTSP URI, which allows other schemes like rtspt.
This means we will now have to directly link to GStreamer RTSP, which should be fine since it was included automatically with the rtsp plugin anyway.