### PR TITLE
Fix main status indicator mouse areas

### DIFF
--- a/src/UI/toolbar/MainStatusIndicator.qml
+++ b/src/UI/toolbar/MainStatusIndicator.qml
@@ -35,9 +35,12 @@ RowLayout {
     }
 
     QGCLabel {
-        id:             mainStatusLabel
-        text:           mainStatusText()
-        font.pointSize: ScreenTools.largeFontPointSize
+        id:                 mainStatusLabel
+        Layout.fillHeight:  true
+        Layout.preferredWidth: contentWidth + vehicleMessagesIcon.width + control.spacing
+        verticalAlignment:  Text.AlignVCenter
+        text:               mainStatusText()
+        font.pointSize:     ScreenTools.largeFontPointSize
 
         property string _commLostText:      qsTr("Comms Lost")
         property string _readyToFlyText:    qsTr("Ready To Fly")
@@ -112,6 +115,31 @@ RowLayout {
             }
         }
 
+        QGCColoredImage {
+            id:                     vehicleMessagesIcon
+            anchors.verticalCenter: parent.verticalCenter
+            anchors.right:          parent.right
+            width:                  ScreenTools.defaultFontPixelWidth * 2
+            height:                 width
+            source:                 "/res/VehicleMessages.png"
+            color:                  getIconColor()
+            sourceSize.width:       width
+            fillMode:               Image.PreserveAspectFit
+            //visible:                _activeVehicle && _activeVehicle.messageCount > 0// FIXME: Is messageCount check needed?
+
+            function getIconColor() {
+                let iconColor = qgcPal.text
+                if (_activeVehicle) {
+                    if (_activeVehicle.messageTypeWarning) {
+                        iconColor = qgcPal.colorOrange
+                    } else if (_activeVehicle.messageTypeError) {
+                        iconColor = qgcPal.colorRed
+                    }
+                }
+                return iconColor
+            }
+        }
+
         QGCMouseArea {
             anchors.fill:   parent
             onClicked:      dropMainStatusIndicator()
@@ -119,46 +147,20 @@ RowLayout {
     }
 
     QGCLabel {
-        id:             vtolModeLabel
-        text:           _vtolInFWDFlight ? qsTr("FW(vtol)") : qsTr("MR(vtol)")
-        font.pointSize: _vehicleInAir ? ScreenTools.largeFontPointSize : ScreenTools.defaultFontPointSize
-        visible:        _activeVehicle && _activeVehicle.vtol
+        id:                 vtolModeLabel
+        Layout.fillHeight:  true
+        verticalAlignment:  Text.AlignVCenter
+        text:               _vtolInFWDFlight ? qsTr("FW(vtol)") : qsTr("MR(vtol)")
+        font.pointSize:     _vehicleInAir ? ScreenTools.largeFontPointSize : ScreenTools.defaultFontPointSize
+        visible:            _activeVehicle && _activeVehicle.vtol
 
         QGCMouseArea {
-            anchors.fill:   parent
+            anchors.fill: parent
             onClicked: {
                 if (_vehicleInAir) {
                     mainWindow.showIndicatorDrawer(vtolTransitionIndicatorPage)
                 }
             }
-        }
-    }
-
-    QGCColoredImage {
-        id:                     vehicleMessagesIcon
-        source:                 "/res/VehicleMessages.png"
-        color:                  getIconColor()
-        Layout.preferredWidth:  ScreenTools.defaultFontPixelWidth * 2
-        Layout.preferredHeight: width
-        sourceSize.width:       width
-        fillMode:               Image.PreserveAspectFit
-        visible:                _activeVehicle && _activeVehicle.messageCount > 0// FIXME: Is messageCount check needed?
-
-        function getIconColor() {
-            let iconColor = qgcPal.text
-            if (_activeVehicle) {
-                if (_activeVehicle.messageTypeWarning) {
-                    iconColor = qgcPal.colorOrange
-                } else if (_activeVehicle.messageTypeError) {
-                    iconColor = qgcPal.colorRed
-                }
-            }
-            return iconColor
-        }
-
-        QGCMouseArea {
-            anchors.fill:   parent
-            onClicked:      dropMainStatusIndicator()
         }
     }
 


### PR DESCRIPTION
Message icon is in the wrong place when vtol status is displayed. Should be next to main status text:
![Screenshot 2025-04-21 at 11 03 13 AM](https://github.com/user-attachments/assets/ac69f7db-c4b3-4afc-aabe-8eded6937e52)

Touch areas are much too small. Super hard to touch with finger. Also message icon is separate touch area:
![Screenshot 2025-04-21 at 11 03 22 AM](https://github.com/user-attachments/assets/77145937-8f96-4aba-b73c-253f2d6d92d6)

Fixed message icon positioning:
![Screenshot 2025-04-21 at 11 03 52 AM](https://github.com/user-attachments/assets/37bb48a5-ef7d-4956-8835-5a64229ba7d7)

Fixed touch areas to be full toolbar height:
![Screenshot 2025-04-21 at 11 04 02 AM](https://github.com/user-attachments/assets/eb631d99-8293-48c2-93d6-bdf2955a8090)
