### PR TITLE
Linux: Install all GStreamer Plugins into AppImage

### DIFF
--- a/src/VideoManager/VideoReceiver/GStreamer/gstqml6gl/CMakeLists.txt
+++ b/src/VideoManager/VideoReceiver/GStreamer/gstqml6gl/CMakeLists.txt
@@ -29,6 +29,7 @@ target_link_libraries(gstqml6gl
 
 if(LINUX)
     install(DIRECTORY ${GSTREAMER_LIB_PATH}/gstreamer1.0 DESTINATION ${CMAKE_INSTALL_LIBDIR})
+    install(DIRECTORY ${GSTREAMER_PLUGIN_PATH} DESTINATION ${CMAKE_INSTALL_LIBDIR} PATTERN "*/include" EXCLUDE)
     install(CODE "execute_process(COMMAND chmod +x \"${CMAKE_INSTALL_PREFIX}/${CMAKE_INSTALL_LIBDIR}/gstreamer1.0/gstreamer-1.0/gst-plugin-scanner\")")
     install(CODE "execute_process(COMMAND chmod +x \"${CMAKE_INSTALL_PREFIX}/${CMAKE_INSTALL_LIBDIR}/gstreamer1.0/gstreamer-1.0/gst-ptp-helper\")")
     install(DIRECTORY ${GSTREAMER_LIB_PATH}/gio DESTINATION ${CMAKE_INSTALL_LIBDIR})


### PR DESCRIPTION
Installs all of the gstreamer plugins rather than just the ones listed for static linking