### PR TITLE
CI: Silence Android Toolchain CMake Warnings

### DIFF
--- a/.github/workflows/android-linux-qt6.6.3.yml
+++ b/.github/workflows/android-linux-qt6.6.3.yml
@@ -17,6 +17,7 @@ on:
       - 'android/**'
       - 'CMakeLists.txt'
       - 'cmake/**'
+      - 'translations/*'
 
 # concurrency:
 #   group: ${{ github.workflow }}-${{ github.ref }}
@@ -67,6 +68,7 @@ jobs:
         working-directory: ${{ runner.temp }}/shadow_build_dir
         run: ${{ env.QT_ROOT_DIR }}/bin/qt-cmake -S ${{ github.workspace }} -B . -G Ninja
               -DCMAKE_BUILD_TYPE=${{ matrix.BuildType }}
+              -DCMAKE_WARN_DEPRECATED=FALSE
               -DQT_ANDROID_ABIS="${{ env.QT_ANDROID_ABIS }}"
               -DQT_ANDROID_BUILD_ALL_ABIS=OFF
               -DQT_HOST_PATH="${{ env.QT_ROOT_DIR }}/../gcc_64"

--- a/.github/workflows/android-linux.yml
+++ b/.github/workflows/android-linux.yml
@@ -17,6 +17,7 @@ on:
       - 'android/**'
       - 'CMakeLists.txt'
       - 'cmake/**'
+      - 'translations/*'
 
 # concurrency:
 #   group: ${{ github.workflow }}-${{ github.ref }}
@@ -67,6 +68,7 @@ jobs:
         working-directory: ${{ runner.temp }}/shadow_build_dir
         run: ${{ env.QT_ROOT_DIR }}/bin/qt-cmake -S ${{ github.workspace }} -B . -G Ninja
               -DCMAKE_BUILD_TYPE=${{ matrix.BuildType }}
+              -DCMAKE_WARN_DEPRECATED=FALSE
               -DQT_ANDROID_ABIS="${{ env.QT_ANDROID_ABIS }}"
               -DQT_ANDROID_BUILD_ALL_ABIS=OFF
               -DQT_HOST_PATH="${{ env.QT_ROOT_DIR }}/../gcc_64"

--- a/.github/workflows/android-macos.yml
+++ b/.github/workflows/android-macos.yml
@@ -16,6 +16,7 @@ on:
       - 'src/**'
       - 'android/**'
       - 'CMakeLists.txt'
+      - 'translations/*'
 
 # concurrency:
 #   group: ${{ github.workflow }}-${{ github.ref }}
@@ -66,6 +67,7 @@ jobs:
         working-directory: ${{ runner.temp }}/shadow_build_dir
         run: ${{ env.QT_ROOT_DIR }}/bin/qt-cmake -S ${{ github.workspace }} -B . -G Ninja
               -DCMAKE_BUILD_TYPE=${{ matrix.BuildType }}
+              -DCMAKE_WARN_DEPRECATED=FALSE
               -DQT_ANDROID_ABIS="${{ env.QT_ANDROID_ABIS }}"
               -DQT_ANDROID_BUILD_ALL_ABIS=OFF
               -DQT_HOST_PATH="${{ env.QT_ROOT_DIR }}/../macos"

--- a/.github/workflows/android-windows.yml
+++ b/.github/workflows/android-windows.yml
@@ -17,6 +17,7 @@ on:
       - 'android/**'
       - 'CMakeLists.txt'
       - 'cmake/**'
+      - 'translations/*'
 
 # concurrency:
 #   group: ${{ github.workflow }}-${{ github.ref }}
@@ -72,6 +73,7 @@ jobs:
         working-directory: ${{ runner.temp }}/shadow_build_dir
         run: ${{ env.QT_ROOT_DIR }}/bin/qt-cmake -S ${{ github.workspace }} -B . -G Ninja
               -DCMAKE_BUILD_TYPE=${{ matrix.BuildType }}
+              -DCMAKE_WARN_DEPRECATED=FALSE
               -DQT_ANDROID_ABIS="${{ env.QT_ANDROID_ABIS }}"
               -DQT_ANDROID_BUILD_ALL_ABIS=OFF
               -DQT_HOST_PATH="${{ env.QT_ROOT_DIR }}/../msvc2022_64"


### PR DESCRIPTION
This silences the annoying warnings from the legacy toolchain. Remove later when using a higher NDK version
Also add translations to triggers list