### PR TITLE
Add motor interlock aux function to joystick button options

### DIFF
--- a/src/Joystick/Joystick.cc
+++ b/src/Joystick/Joystick.cc
@@ -693,6 +693,8 @@ void Joystick::startPolling(Vehicle* vehicle)
             (void) disconnect(this, &Joystick::gripperAction, _activeVehicle, &Vehicle::setGripperAction);
             (void) disconnect(this, &Joystick::landingGearDeploy, _activeVehicle, &Vehicle::landingGearDeploy);
             (void) disconnect(this, &Joystick::landingGearRetract, _activeVehicle, &Vehicle::landingGearRetract);
+            (void) disconnect(this, &Joystick::motorInterlockEnable, _activeVehicle, &Vehicle::motorInterlockEnable);
+            (void) disconnect(this, &Joystick::motorInterlockDisable, _activeVehicle, &Vehicle::motorInterlockDisable);
             (void) disconnect(_activeVehicle, &Vehicle::flightModesChanged, this, &Joystick::_flightModesChanged);
         }
 
@@ -723,6 +725,8 @@ void Joystick::startPolling(Vehicle* vehicle)
             (void) connect(this, &Joystick::gripperAction, _activeVehicle, &Vehicle::setGripperAction);
             (void) connect(this, &Joystick::landingGearDeploy, _activeVehicle, &Vehicle::landingGearDeploy);
             (void) connect(this, &Joystick::landingGearRetract, _activeVehicle, &Vehicle::landingGearRetract);
+            (void) connect(this, &Joystick::motorInterlockEnable, _activeVehicle, &Vehicle::motorInterlockEnable);
+            (void) connect(this, &Joystick::motorInterlockDisable, _activeVehicle, &Vehicle::motorInterlockDisable);
             (void) connect(_activeVehicle, &Vehicle::flightModesChanged, this, &Joystick::_flightModesChanged);
         }
     }
@@ -753,6 +757,8 @@ void Joystick::stopPolling()
         (void) disconnect(this, &Joystick::gripperAction, _activeVehicle, &Vehicle::setGripperAction);
         (void) disconnect(this, &Joystick::landingGearDeploy, _activeVehicle, &Vehicle::landingGearDeploy);
         (void) disconnect(this, &Joystick::landingGearRetract, _activeVehicle, &Vehicle::landingGearRetract);
+        (void) disconnect(this, &Joystick::motorInterlockEnable, _activeVehicle, &Vehicle::motorInterlockEnable);
+        (void) disconnect(this, &Joystick::motorInterlockDisable, _activeVehicle, &Vehicle::motorInterlockDisable);
         (void) disconnect(_activeVehicle, &Vehicle::flightModesChanged, this, &Joystick::_flightModesChanged);
         _activeVehicle = nullptr;
     }
@@ -1106,6 +1112,14 @@ void Joystick::_executeButtonAction(const QString &action, bool buttonDown)
         if (buttonDown) {
             emit landingGearRetract();
         }
+    } else if (action == _buttonActionMotorInterlockEnable) {
+        if (buttonDown) {
+            emit motorInterlockEnable();
+        }
+    } else if (action == _buttonActionMotorInterlockDisable) {
+        if (buttonDown) {
+            emit motorInterlockDisable();
+        }
     } else {
         if (buttonDown && _activeVehicle) {
             emit unknownAction(action);
@@ -1196,6 +1210,8 @@ void Joystick::_buildActionList(Vehicle *activeVehicle)
     _assignableButtonActions->append(new AssignableButtonAction(_buttonActionGripperRelease));
     _assignableButtonActions->append(new AssignableButtonAction(_buttonActionLandingGearDeploy));
     _assignableButtonActions->append(new AssignableButtonAction(_buttonActionLandingGearRetract));
+    _assignableButtonActions->append(new AssignableButtonAction(_buttonActionMotorInterlockEnable));
+    _assignableButtonActions->append(new AssignableButtonAction(_buttonActionMotorInterlockDisable));
 
     const auto customActions = QGCCorePlugin::instance()->joystickActions();
     for (const auto &action : customActions) {

--- a/src/Joystick/Joystick.h
+++ b/src/Joystick/Joystick.h
@@ -221,6 +221,8 @@ signals:
     void gripperAction(GRIPPER_ACTIONS gripperAction);
     void landingGearDeploy();
     void landingGearRetract();
+    void motorInterlockEnable();
+    void motorInterlockDisable();
     void unknownAction(const QString &action);
 
 protected:
@@ -363,4 +365,6 @@ private:
     static constexpr const char *_buttonActionGripperRelease =     QT_TR_NOOP("Gripper Open");
     static constexpr const char *_buttonActionLandingGearDeploy=   QT_TR_NOOP("Landing gear deploy");
     static constexpr const char *_buttonActionLandingGearRetract=  QT_TR_NOOP("Landing gear retract");
+    static constexpr const char *_buttonActionMotorInterlockEnable=   QT_TR_NOOP("Motor Interlock enable");
+    static constexpr const char *_buttonActionMotorInterlockDisable=  QT_TR_NOOP("Motor Interlock disable");
 };

--- a/src/Vehicle/Vehicle.cc
+++ b/src/Vehicle/Vehicle.cc
@@ -2333,6 +2333,26 @@ void Vehicle::landingGearRetract()
                 1.0f);      // up
 }
 
+void Vehicle::motorInterlockEnable()
+{
+    sendMavCommand(
+                defaultComponentId(),
+                MAV_CMD_DO_AUX_FUNCTION,
+                true,       // show error if fails
+                32,       // motor interlock
+                2);      // Enabled
+}
+
+void Vehicle::motorInterlockDisable()
+{
+    sendMavCommand(
+                defaultComponentId(),
+                MAV_CMD_DO_AUX_FUNCTION,
+                true,       // show error if fails
+                32,       // motor interlock
+                0);      // Disabled
+}
+
 void Vehicle::setCurrentMissionSequence(int seq)
 {
     if (!_firmwarePlugin->sendHomePositionToVehicle()) {

--- a/src/Vehicle/Vehicle.h
+++ b/src/Vehicle/Vehicle.h
@@ -357,6 +357,12 @@ public:
     /// Command vichecle to retract landing gear
     Q_INVOKABLE void landingGearRetract();
 
+    /// Command vehicle to Enable Motor Interlock
+    Q_INVOKABLE void motorInterlockEnable();
+
+    /// Command vehicle to Disable Motor Interlock
+    Q_INVOKABLE void motorInterlockDisable();
+
     Q_INVOKABLE void startMission();
 
     /// Alter the current mission item on the vehicle


### PR DESCRIPTION
Add motor interlock aux function to joystick button options

Description
This PR adds the motor interlock feature of Ardupilot to the options for button actions in the joystick. It uses the mavlink aux function command ardupilot to enable and disable the motor interlock.

Test Steps
-----------
Start an helicopter simulation in ardupilot. Add motor interlock enable as an action on one button and motor interlock disable as an action on a separate button.  Press the motor interlock disable button to allow arming. Arm the heli and use the motor interlock enable button to spool up the rotor. 

Checklist:
----------
- [x] [Review Contribution Guidelines](https://github.com/mavlink/qgroundcontrol/blob/master/.github/CONTRIBUTING.md).
- [x] [Review Code of Conduct](https://github.com/mavlink/qgroundcontrol/blob/master/.github/CODE_OF_CONDUCT.md).
- [ ] I have tested my changes.

Related Issue
-----------
None 


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.