### PR TITLE
Fix order of parameters in call to _addTimeDistance when using a RTL waypoint

### DIFF
--- a/src/MissionManager/MissionController.cc
+++ b/src/MissionManager/MissionController.cc
@@ -1743,7 +1743,7 @@ void MissionController::_recalcMissionFlightStatus()
             double hoverTime = distance / _missionFlightStatus.hoverSpeed;
             double cruiseTime = distance / _missionFlightStatus.cruiseSpeed;
             double landTime = qAbs(altDifference) / _appSettings->offlineEditingDescentSpeed()->rawValue().toDouble();
-            _addTimeDistance(_missionFlightStatus.vtolMode == QGCMAVLink::VehicleClassMultiRotor, hoverTime, cruiseTime, distance, landTime, -1);
+            _addTimeDistance(_missionFlightStatus.vtolMode == QGCMAVLink::VehicleClassMultiRotor, hoverTime, cruiseTime, landTime, distance, -1);
         }
     }
 


### PR DESCRIPTION
Fix order of parameters in call to _addTimeDistance when using a RTH waypoint

Description
-----------
This corrects the order of parameters when calling MissionController::_addTimeDistance 
Note that the last 3 parameters are `time`, `distance` and `sequenceNumber` (in that order), and they are used correctly everywhere except where corrected by this PR, where previously they had been ordered `distance`, `time` and `sequenceNumber` (note `time` and `distance` were swapped).

This escaped the compiler because both parameters are `double`.

As a result:
* Before, when creating a route that included a Return To Launch waypoint the "Total Mission" "Distance" shown on top was `-.-`.
  * For some reason this does not happen when downloading the route from the Drone to QGC.
* After the fix, when creating a route that includes a Return To Launch/Home waypoint the "Total Mission" "Distance" shown is the correct value.


Test Steps
-----------
Create a new Plan from scratch in the Plan View:
1. IMPORTANT: Manually add Take Off point
2. Add 2 or 3 waypoints
3. Add a Return to Launch waypoint
4. Observe the "Total Mission" Distance on the top toolstrip

Checklist:
----------
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] [Review Contribution Guidelines](https://github.com/mavlink/qgroundcontrol/blob/master/.github/CONTRIBUTING.md).
- [x] [Review Code of Conduct](https://github.com/mavlink/qgroundcontrol/blob/master/.github/CODE_OF_CONDUCT.md).
- [x] I have tested my changes.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.