### PR TITLE
Improve "Bug report" Issue Template

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -15,14 +15,14 @@ body:
   - type: textarea
     id: description
     attributes:
-      label: Description  **(required)**
+      label: Description
       description: |
         Please describe your issue in detail. Include:
         1. **Expected Behavior** – What you expected to happen.
         2. **Current Behavior** – What actually happened instead.
         3. **Steps To Reproduce** – Step-by-step list of actions to reproduce the issue.
         3. **Additional Details** – Any other context that helps explain the problem.
-      placeholder: |
+      value: |
         **Expected Behavior**
         Describe what you thought should happen here.
 
@@ -44,7 +44,7 @@ body:
     attributes:
       label: System Information
       description: When posting bug reports, include the following information.
-      placeholder: |
+      value: |
         - QGC Version: [e.g. 4.4.0] **(required)**
         - QGC build: [e.g. daily, stable, self-built from source, etc...]
         - Operating System: [e.g. Windows 11, Ubuntu 22.04, macOS 15, iOS 17 ]
@@ -57,7 +57,7 @@ body:
     id: logs-screenshots
     attributes:
       label: Log Files and Screenshots
-      description: Include links to QGC Console Logs, autopilot logs, and screenshots.
+      description: Include links to [QGC Console Logs](https://docs.qgroundcontrol.com/en/settings_view/console_logging.html), autopilot logs, and screenshots.
       placeholder: |
         - [QGC Console Logs](https://docs.qgroundcontrol.com/en/settings_view/console_logging.html)
         - Autopilot logs when available (post a link)


### PR DESCRIPTION
<!--- Title -->

Description
-----------
<!--- Describe your changes in detail. -->
Improves the "Bug report" Issue Template by:
- removing a redundant `**(required)**` (already indicated to the user via a red asterisk)
- turning some placeholder attributes into values, so that the user can reuse that text without having to retype it
- making a helpful link immediately clickable by also putting it in the description

Test Steps
-----------
<!-- Describe the steps to reproduce. -->
Tested it on our fork by committing the changes to master and creating an issue via that template.
Not sure how this could be tested on the main repo without merging into master.

Checklist:
----------
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] [Review Contribution Guidelines](https://github.com/mavlink/qgroundcontrol/blob/master/.github/CONTRIBUTING.md).
- [x] [Review Code of Conduct](https://github.com/mavlink/qgroundcontrol/blob/master/.github/CODE_OF_CONDUCT.md).
- [x] I have tested my changes.

Related Issue
-----------
<!-- If any, please provide issue ID. -->
None.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.