### PR TITLE
VideoManager: Improve Handling of Multiple Receivers

### DIFF
--- a/src/Camera/VehicleCameraControl.cc
+++ b/src/Camera/VehicleCameraControl.cc
@@ -1575,7 +1575,7 @@ VehicleCameraControl::handleCaptureStatus(const mavlink_camera_capture_status_t&
         //-- Capture local image as well
         QString photoPath = SettingsManager::instance()->appSettings()->savePath()->rawValue().toString() + QStringLiteral("/Photo");
         QDir().mkpath(photoPath);
-        photoPath += + "/" + QDateTime::currentDateTime().toString("yyyy-MM-dd_hh.mm.ss.zzz") + ".jpg";
+        photoPath += "/" + QDateTime::currentDateTime().toString("yyyy-MM-dd_hh.mm.ss.zzz") + ".jpg";
         VideoManager::instance()->grabImage(photoPath);
     }
 }

--- a/src/FlightDisplay/FlightDisplayViewVideo.qml
+++ b/src/FlightDisplay/FlightDisplayViewVideo.qml
@@ -121,14 +121,15 @@ Item {
 
                 Connections {
                     target: QGroundControl.videoManager
-                    function onImageFileChanged() {
+                    function onImageFileChanged(filename) {
                         videoContent.grabToImage(function(result) {
-                            if (!result.saveToFile(QGroundControl.videoManager.imageFile)) {
+                            if (!result.saveToFile(filename)) {
                                 console.error('Error capturing video frame');
                             }
                         });
                     }
                 }
+
                 Rectangle {
                     color:  Qt.rgba(1,1,1,0.5)
                     height: parent.height

--- a/src/QGCApplication.cc
+++ b/src/QGCApplication.cc
@@ -342,7 +342,7 @@ void QGCApplication::_initVideo()
 #endif
 
     QGCCorePlugin::instance();  // CorePlugin must be initialized before VideoManager for Video Cleanup
-    VideoManager::instance(); 
+    VideoManager::instance();
     _videoManagerInitialized = true;
 }
 
@@ -352,6 +352,8 @@ void QGCApplication::_initForNormalAppBoot()
 
     QQuickStyle::setStyle("Basic");
     QGCCorePlugin::instance()->init();
+    MAVLinkProtocol::instance()->init();
+    MultiVehicleManager::instance()->init();
     _qmlAppEngine = QGCCorePlugin::instance()->createQmlApplicationEngine(this);
     QObject::connect(_qmlAppEngine, &QQmlApplicationEngine::objectCreationFailed, this, QCoreApplication::quit, Qt::QueuedConnection);
     QGCCorePlugin::instance()->createRootWindow(_qmlAppEngine);
@@ -360,9 +362,7 @@ void QGCApplication::_initForNormalAppBoot()
     FollowMe::instance()->init();
     QGCPositionManager::instance()->init();
     LinkManager::instance()->init();
-    MultiVehicleManager::instance()->init();
-    MAVLinkProtocol::instance()->init();
-    VideoManager::instance()->init();
+    VideoManager::instance()->init(mainRootWindow());
 
     // Image provider for Optical Flow
     _qmlAppEngine->addImageProvider(_qgcImageProviderId, new QGCImageProvider());

--- a/src/QmlControls/InstrumentValueData.cc
+++ b/src/QmlControls/InstrumentValueData.cc
@@ -26,6 +26,7 @@ const QStringList InstrumentValueData::_rangeTypeNames = {
 InstrumentValueData::InstrumentValueData(FactValueGrid* factValueGrid, QObject* parent, Vehicle* vehicle)
     : QObject       (parent)
     , _factValueGrid(factValueGrid)
+    , _vehicle(vehicle)
 {
     connect(factValueGrid, &FactValueGrid::vehicleChanged,      this, &InstrumentValueData::_vehicleChanged);
     _vehicleChanged();
@@ -38,18 +39,17 @@ InstrumentValueData::InstrumentValueData(FactValueGrid* factValueGrid, QObject* 
     connect(this, &InstrumentValueData::rangeIconsChanged,      this, &InstrumentValueData::_updateRanges);
 }
 
-void InstrumentValueData::_vehicleChanged(){
-
-    if(_factValueGrid->vehicle() == nullptr){
-        qCritical() << "InstrumentValueData: vehicle is expected to be not NULL";
-    }
-
+void InstrumentValueData::_vehicleChanged()
+{
     if (_vehicle) {
         disconnect(_vehicle, &Vehicle::factGroupNamesChanged, this, &InstrumentValueData::_lookForMissingFact);
     }
 
-    _vehicle = _factValueGrid->vehicle();
-    connect(_vehicle, &Vehicle::factGroupNamesChanged, this, &InstrumentValueData::_lookForMissingFact);
+    if (!_vehicle) {
+       _vehicle = MultiVehicleManager::instance()->offlineEditingVehicle();
+    }
+
+    (void) connect(_vehicle, &Vehicle::factGroupNamesChanged, this, &InstrumentValueData::_lookForMissingFact);
 
     emit factGroupNamesChanged();
 

--- a/src/Settings/VideoSettings.cc
+++ b/src/Settings/VideoSettings.cc
@@ -16,10 +16,8 @@
 #ifdef QGC_GST_STREAMING
 #include "GStreamer.h"
 #endif
-
 #ifndef QGC_DISABLE_UVC
-#include <QtMultimedia/QMediaDevices>
-#include <QtMultimedia/QCameraDevice>
+#include "UVCReceiver.h"
 #endif
 
 DECLARE_SETTINGGROUP(Video, "Video")
@@ -45,10 +43,7 @@ DECLARE_SETTINGGROUP(Video, "Video")
     #endif
 #endif
 #ifndef QGC_DISABLE_UVC
-    QList<QCameraDevice> videoInputs = QMediaDevices::videoInputs();
-    for (const auto& cameraDevice: videoInputs) {
-        videoSourceList.append(cameraDevice.description());
-    }
+    videoSourceList.append(UVCReceiver::getDeviceNameList());
 #endif
     if (videoSourceList.count() == 0) {
         _noVideo = true;
@@ -232,12 +227,9 @@ bool VideoSettings::streamConfigured(void)
         return true;
     }
 #ifndef QGC_DISABLE_UVC
-    const QList<QCameraDevice> videoInputs = QMediaDevices::videoInputs();
-    for (const auto& cameraDevice: videoInputs) {
-        if(vSource == cameraDevice.description()) {
-            qCDebug(VideoManagerLog) << "Stream configured for UVC";
-            return true;
-        }
+    if (UVCReceiver::enabled() && UVCReceiver::deviceExists(vSource)) {
+        qCDebug(VideoManagerLog) << "Stream configured for UVC";
+        return true;
     }
 #endif
     return false;
@@ -251,7 +243,7 @@ void VideoSettings::_configChanged(QVariant)
 void VideoSettings::_setForceVideoDecodeList()
 {
 #ifdef QGC_GST_STREAMING
-    const QVariantList removeForceVideoDecodeList{
+    static const QList<GStreamer::VideoDecoderOptions> removeForceVideoDecodeList{
 #if defined(Q_OS_ANDROID)
     GStreamer::VideoDecoderOptions::ForceVideoDecoderDirectX3D,
     GStreamer::VideoDecoderOptions::ForceVideoDecoderVideoToolbox,

--- a/src/Vehicle/MultiVehicleManager.cc
+++ b/src/Vehicle/MultiVehicleManager.cc
@@ -43,7 +43,6 @@ Q_APPLICATION_STATIC(MultiVehicleManager, _multiVehicleManagerInstance);
 MultiVehicleManager::MultiVehicleManager(QObject *parent)
     : QObject(parent)
     , _gcsHeartbeatTimer(new QTimer(this))
-    , _offlineEditingVehicle(new Vehicle(Vehicle::MAV_AUTOPILOT_TRACK, Vehicle::MAV_TYPE_TRACK, this))
     , _vehicles(new QmlObjectListModel(this))
     , _selectedVehicles(new QmlObjectListModel(this))
 {
@@ -77,6 +76,8 @@ void MultiVehicleManager::init()
     if (_initialized) {
         return;
     }
+
+    _offlineEditingVehicle = new Vehicle(Vehicle::MAV_AUTOPILOT_TRACK, Vehicle::MAV_TYPE_TRACK, this);
 
     (void) connect(MAVLinkProtocol::instance(), &MAVLinkProtocol::vehicleHeartbeatInfo, this, &MultiVehicleManager::_vehicleHeartbeatInfo);
 

--- a/src/Vehicle/MultiVehicleManager.h
+++ b/src/Vehicle/MultiVehicleManager.h
@@ -80,9 +80,9 @@ private:
     void _setParameterReadyVehicleAvailable(bool parametersReady);
 
     QTimer *_gcsHeartbeatTimer = nullptr;           ///< Timer to emit heartbeats
-    Vehicle *_offlineEditingVehicle = nullptr;      ///< Disconnected vechicle used for offline editing
     QmlObjectListModel *_vehicles = nullptr;
     QmlObjectListModel *_selectedVehicles = nullptr;
+    Vehicle *_offlineEditingVehicle = nullptr;      ///< Disconnected vechicle used for offline editing
     bool _activeVehicleAvailable = false;           ///< true: An active vehicle is available
     bool _parameterReadyVehicleAvailable = false;   ///< true: An active vehicle with ready parameters is available
     Vehicle *_activeVehicle = nullptr;              ///< Currently active vehicle from a ui perspective

--- a/src/Vehicle/Vehicle.cc
+++ b/src/Vehicle/Vehicle.cc
@@ -180,10 +180,6 @@ Vehicle::Vehicle(LinkInterface*             link,
 
     connect(&_orbitTelemetryTimer, &QTimer::timeout, this, &Vehicle::_orbitTelemetryTimeout);
 
-    // Create camera manager instance
-    _cameraManager = _firmwarePlugin->createCameraManager(this);
-    emit cameraManagerChanged();
-
     // Start csv logger
     connect(&_csvLogTimer, &QTimer::timeout, this, &Vehicle::_writeCsvLine);
     _csvLogTimer.start(1000);
@@ -360,6 +356,9 @@ void Vehicle::_commonInit()
     _loadJoystickSettings();
 
     _gimbalController = new GimbalController(this);
+
+    // Create camera manager instance
+    _cameraManager = _firmwarePlugin->createCameraManager(this);
 }
 
 Vehicle::~Vehicle()

--- a/src/VideoManager/SubtitleWriter.cc
+++ b/src/VideoManager/SubtitleWriter.cc
@@ -40,14 +40,14 @@ void SubtitleWriter::startCapturingTelemetry(const QString &videoFile, QSize siz
     _facts.clear();
 
     // Gather the facts currently displayed into _facts
-    FactValueGrid *const grid = new FactValueGrid(nullptr);
+    FactValueGrid *grid = new FactValueGrid();
     (void) grid->setProperty("userSettingsGroup", HorizontalFactValueGrid::telemetryBarUserSettingsGroup);
     (void) grid->setProperty("defaultSettingsGroup", HorizontalFactValueGrid::telemetryBarDefaultSettingsGroup);
     grid->_loadSettings();
     for (int colIndex = 0; colIndex < grid->columns()->count(); colIndex++) {
-        const QmlObjectListModel *const list = grid->columns()->value<const QmlObjectListModel*>(colIndex);
+        const QmlObjectListModel *list = grid->columns()->value<const QmlObjectListModel*>(colIndex);
         for (int rowIndex = 0; rowIndex < list->count(); rowIndex++) {
-            const InstrumentValueData *const value = list->value<InstrumentValueData*>(rowIndex);
+            const InstrumentValueData *value = list->value<InstrumentValueData*>(rowIndex);
             if (value->fact()) {
                 _facts += value->fact();
             }
@@ -119,7 +119,7 @@ void SubtitleWriter::_captureTelemetry()
     QStringList valuesStrings;
 
     // Make a list of "factname:" strings and other with the values, so one can be aligned left and the other right
-    for (const Fact *const fact : std::as_const(_facts)) {
+    for (const Fact *fact : std::as_const(_facts)) {
         valuesStrings << QStringLiteral("%2 %3").arg(fact->cookedValueString(), fact->cookedUnits());
         namesStrings << QStringLiteral("%1:").arg(fact->shortDescription());
     }

--- a/src/VideoManager/VideoReceiver/GStreamer/GstVideoReceiver.cc
+++ b/src/VideoManager/VideoReceiver/GStreamer/GstVideoReceiver.cc
@@ -23,6 +23,7 @@
 
 #include <QtCore/QDateTime>
 #include <QtCore/QUrl>
+#include <QtQuick/QQuickItem>
 
 #include <gst/gst.h>
 
@@ -30,10 +31,11 @@ QGC_LOGGING_CATEGORY(GstVideoReceiverLog, "qgc.videomanager.videoreceiver.gstrea
 
 GstVideoReceiver::GstVideoReceiver(QObject *parent)
     : VideoReceiver(parent)
+    , _worker(new GstVideoWorker(this))
 {
-    // qCDebug(GstVideoReceiverLog) << Q_FUNC_INFO << this;
+    // qCDebug(GstVideoReceiverLog) << this;
 
-    _worker.start();
+    _worker->start();
     (void) connect(&_watchdogTimer, &QTimer::timeout, this, &GstVideoReceiver::_watchdog);
     _watchdogTimer.start(1000);
 }
@@ -41,16 +43,15 @@ GstVideoReceiver::GstVideoReceiver(QObject *parent)
 GstVideoReceiver::~GstVideoReceiver()
 {
     stop();
-    _worker.shutdown();
+    _worker->shutdown();
 
-    // qCDebug(GstVideoReceiverLog) << Q_FUNC_INFO << this;
+    // qCDebug(GstVideoReceiverLog) << this;
 }
 
-void GstVideoReceiver::start(const QString &uri, uint32_t timeout, int buffer)
+void GstVideoReceiver::start(uint32_t timeout)
 {
     if (_needDispatch()) {
-        const QString cachedUri = uri;
-        _worker.dispatch([this, cachedUri, timeout, buffer]() { start(cachedUri, timeout, buffer); });
+        _worker->dispatch([this, timeout]() { start(timeout); });
         return;
     }
 
@@ -60,15 +61,14 @@ void GstVideoReceiver::start(const QString &uri, uint32_t timeout, int buffer)
         return;
     }
 
-    if (uri.isEmpty()) {
+    if (_uri.isEmpty()) {
         qCDebug(GstVideoReceiverLog) << "Failed because URI is not specified";
         _dispatchSignal([this]() { emit onStartComplete(STATUS_INVALID_URL); });
         return;
     }
 
-    _uri = uri;
     _timeout = timeout;
-    _buffer = buffer;
+    _buffer = lowLatency() ? -1 : 0;
 
     qCDebug(GstVideoReceiverLog) << "Starting" << _uri << ", buffer" << _buffer;
 
@@ -96,8 +96,7 @@ void GstVideoReceiver::start(const QString &uri, uint32_t timeout, int buffer)
         _lastSourceFrameTime = 0;
 
         _teeProbeId = gst_pad_add_probe(pad, GST_PAD_PROBE_TYPE_BUFFER, _teeProbe, this, nullptr);
-        gst_object_unref(pad);
-        pad = nullptr;
+        gst_clear_object(&pad);
 
         decoderQueue = gst_element_factory_make("queue", nullptr);
         if (!decoderQueue)  {
@@ -111,7 +110,9 @@ void GstVideoReceiver::start(const QString &uri, uint32_t timeout, int buffer)
             break;
         }
 
-        g_object_set(_decoderValve, "drop", TRUE, nullptr);
+        g_object_set(_decoderValve,
+                     "drop", TRUE,
+                     nullptr);
 
         recorderQueue = gst_element_factory_make("queue", nullptr);
         if (!recorderQueue)  {
@@ -125,7 +126,9 @@ void GstVideoReceiver::start(const QString &uri, uint32_t timeout, int buffer)
             break;
         }
 
-        g_object_set(_recorderValve, "drop", TRUE, nullptr);
+        g_object_set(_recorderValve,
+                     "drop", TRUE,
+                     nullptr);
 
         _pipeline = gst_pipeline_new("receiver");
         if (!_pipeline) {
@@ -133,9 +136,11 @@ void GstVideoReceiver::start(const QString &uri, uint32_t timeout, int buffer)
             break;
         }
 
-        g_object_set(_pipeline, "message-forward", TRUE, nullptr);
+        g_object_set(_pipeline,
+                     "message-forward", TRUE,
+                     nullptr);
 
-        _source = _makeSource(uri);
+        _source = _makeSource(_uri);
         if (!_source) {
             qCCritical(GstVideoReceiverLog) << "_makeSource() failed";
             break;
@@ -146,26 +151,28 @@ void GstVideoReceiver::start(const QString &uri, uint32_t timeout, int buffer)
         pipelineUp = true;
 
         GstPad *srcPad = nullptr;
-
         GstIterator *it = gst_element_iterate_src_pads(_source);
-        if (it) {
-            GValue vpad = G_VALUE_INIT;
-            if (gst_iterator_next(it, &vpad) == GST_ITERATOR_OK) {
+        GValue vpad = G_VALUE_INIT;
+        switch (gst_iterator_next(it, &vpad)) {
+            case GST_ITERATOR_OK:
                 srcPad = GST_PAD(g_value_get_object(&vpad));
-                gst_object_ref(srcPad);
-                g_value_reset(&vpad);
-            }
-
-            gst_iterator_free(it);
-            it = nullptr;
+                (void) gst_object_ref(srcPad);
+                (void) g_value_reset(&vpad);
+                break;
+            case GST_ITERATOR_RESYNC:
+                gst_iterator_resync(it);
+                break;
+            default:
+                break;
         }
+        g_value_unset(&vpad);
+        gst_iterator_free(it);
 
         if (srcPad) {
             _onNewSourcePad(srcPad);
-            gst_object_unref(srcPad);
-            srcPad = nullptr;
+            gst_clear_object(&srcPad);
         } else {
-            g_signal_connect(_source, "pad-added", G_CALLBACK(_onNewPad), this);
+            (void) g_signal_connect(_source, "pad-added", G_CALLBACK(_onNewPad), this);
         }
 
         if (!gst_element_link_many(_tee, decoderQueue, _decoderValve, nullptr)) {
@@ -181,9 +188,8 @@ void GstVideoReceiver::start(const QString &uri, uint32_t timeout, int buffer)
         GstBus *bus = gst_pipeline_get_bus(GST_PIPELINE(_pipeline));
         if (bus) {
             gst_bus_enable_sync_message_emission(bus);
-            g_signal_connect(bus, "sync-message", G_CALLBACK(_onBusMessage), this);
-            gst_object_unref(bus);
-            bus = nullptr;
+            (void) g_signal_connect(bus, "sync-message", G_CALLBACK(_onBusMessage), this);
+            gst_clear_object(&bus);
         }
 
         GST_DEBUG_BIN_TO_DOT_FILE(GST_BIN(_pipeline), GST_DEBUG_GRAPH_SHOW_ALL, "pipeline-initial");
@@ -193,44 +199,17 @@ void GstVideoReceiver::start(const QString &uri, uint32_t timeout, int buffer)
     if (!running) {
         qCCritical(GstVideoReceiverLog) << "Failed";
 
-        // In newer versions, the pipeline will clean up all references that are added to it
         if (_pipeline) {
-            gst_element_set_state(_pipeline, GST_STATE_NULL);
-            gst_object_unref(_pipeline);
-            _pipeline = nullptr;
+            (void) gst_element_set_state(_pipeline, GST_STATE_NULL);
+            gst_clear_object(&_pipeline);
         }
 
-        // If we failed before adding items to the pipeline, then clean up
         if (!pipelineUp) {
-            if (_recorderValve) {
-                gst_object_unref(_recorderValve);
-                _recorderValve = nullptr;
-            }
-
-            if (recorderQueue) {
-                gst_object_unref(recorderQueue);
-                recorderQueue = nullptr;
-            }
-
-            if (_decoderValve) {
-                gst_object_unref(_decoderValve);
-                _decoderValve = nullptr;
-            }
-
-            if (decoderQueue) {
-                gst_object_unref(decoderQueue);
-                decoderQueue = nullptr;
-            }
-
-            if (_tee) {
-                gst_object_unref(_tee);
-                _tee = nullptr;
-            }
-
-            if (_source) {
-                gst_object_unref(_source);
-                _source = nullptr;
-            }
+            gst_clear_object(&_recorderValve);
+            gst_clear_object(&_decoderValve);
+            gst_clear_object(&decoderQueue);
+            gst_clear_object(&_tee);
+            gst_clear_object(&_source);
         }
 
         _dispatchSignal([this]() { emit onStartComplete(STATUS_FAIL); });
@@ -245,7 +224,7 @@ void GstVideoReceiver::start(const QString &uri, uint32_t timeout, int buffer)
 void GstVideoReceiver::stop()
 {
     if (_needDispatch()) {
-        _worker.dispatch([this]() { stop(); });
+        _worker->dispatch([this]() { stop(); });
         return;
     }
 
@@ -269,16 +248,15 @@ void GstVideoReceiver::stop()
         GstBus *bus = gst_pipeline_get_bus(GST_PIPELINE(_pipeline));
         if (bus) {
             gst_bus_disable_sync_message_emission(bus);
-
-            g_signal_handlers_disconnect_by_data(bus, this);
+            (void) g_signal_handlers_disconnect_by_data(bus, this);
 
             gboolean recordingValveClosed = TRUE;
             g_object_get(_recorderValve, "drop", &recordingValveClosed, nullptr);
 
             if (!recordingValveClosed) {
-                gst_element_send_event(_pipeline, gst_event_new_eos());
+                (void) gst_element_send_event(_pipeline, gst_event_new_eos());
 
-                GstMessage *msg = gst_bus_timed_pop_filtered(bus, GST_CLOCK_TIME_NONE, static_cast<GstMessageType>(GST_MESSAGE_EOS | GST_MESSAGE_ERROR));
+                GstMessage *msg = gst_bus_timed_pop_filtered(bus, GST_CLOCK_TIME_NONE, (GstMessageType)(GST_MESSAGE_EOS | GST_MESSAGE_ERROR));
                 if (msg) {
                     switch (GST_MESSAGE_TYPE(msg)) {
                     case GST_MESSAGE_EOS:
@@ -291,20 +269,18 @@ void GstVideoReceiver::stop()
                         break;
                     }
 
-                    gst_message_unref(msg);
-                    msg = nullptr;
+                    gst_clear_message(&msg);
                 } else {
                     qCCritical(GstVideoReceiverLog) << "gst_bus_timed_pop_filtered() failed";
                 }
             }
 
-            gst_object_unref(bus);
-            bus = nullptr;
+            gst_clear_object(&bus);
         } else {
             qCCritical(GstVideoReceiverLog) << "gst_pipeline_get_bus() failed";
         }
 
-        gst_element_set_state(_pipeline, GST_STATE_NULL);
+        (void) gst_element_set_state(_pipeline, GST_STATE_NULL);
 
         // FIXME: check if branch is connected and remove all elements from branch
         if (_fileSink) {
@@ -317,7 +293,7 @@ void GstVideoReceiver::stop()
 
         GST_DEBUG_BIN_TO_DOT_FILE(GST_BIN(_pipeline), GST_DEBUG_GRAPH_SHOW_ALL, "pipeline-stopped");
 
-        gst_object_unref(_pipeline);
+        gst_clear_object(&_pipeline);
         _pipeline = nullptr;
 
         _recorderValve = nullptr;
@@ -349,29 +325,29 @@ void GstVideoReceiver::startDecoding(void *sink)
     }
 
     if (_needDispatch()) {
-        GstElement *videoSink = GST_ELEMENT(sink);
-        // gst_object_ref(videoSink);
-        _worker.dispatch([this, videoSink]() mutable {
-            startDecoding(videoSink);
-            // gst_object_unref(videoSink);
-        });
+        _worker->dispatch([this, sink]() mutable { startDecoding(sink); });
         return;
     }
 
     qCDebug(GstVideoReceiverLog) << "Starting decoding" << _uri;
 
-    if (!_pipeline && _videoSink) {
-        gst_object_unref(_videoSink);
-        _videoSink = nullptr;
+    if (!_widget) {
+        qCDebug(GstVideoReceiverLog) << "Video Widget is NULL" << _uri;
+        _dispatchSignal([this]() { emit onStartDecodingComplete(STATUS_FAIL); });
+        return;
     }
 
-    GstElement *videoSink = GST_ELEMENT(sink);
+    if (!_pipeline) {
+        gst_clear_object(&_videoSink);
+    }
+
     if (_videoSink || _decoding) {
         qCDebug(GstVideoReceiverLog) << "Already decoding!" << _uri;
         _dispatchSignal([this]() { emit onStartDecodingComplete(STATUS_INVALID_STATE); });
         return;
     }
 
+    GstElement *videoSink = GST_ELEMENT(sink);
     GstPad *pad = gst_element_get_static_pad(videoSink, "sink");
     if (!pad) {
         qCCritical(GstVideoReceiverLog) << "Unable to find sink pad of video sink" << _uri;
@@ -383,8 +359,7 @@ void GstVideoReceiver::startDecoding(void *sink)
     _resetVideoSink = true;
 
     _videoSinkProbeId = gst_pad_add_probe(pad, GST_PAD_PROBE_TYPE_BUFFER, _videoSinkProbe, this, nullptr);
-    gst_object_unref(pad);
-    pad = nullptr;
+    gst_clear_object(&pad);
 
     _videoSink = videoSink;
     gst_object_ref(_videoSink);
@@ -402,7 +377,9 @@ void GstVideoReceiver::startDecoding(void *sink)
         return;
     }
 
-    g_object_set(_decoderValve, "drop", FALSE, nullptr);
+    g_object_set(_decoderValve,
+                 "drop", FALSE,
+                 nullptr);
 
     qCDebug(GstVideoReceiverLog) << "Decoding started" << _uri;
 
@@ -412,7 +389,7 @@ void GstVideoReceiver::startDecoding(void *sink)
 void GstVideoReceiver::stopDecoding()
 {
     if (_needDispatch()) {
-        _worker.dispatch([this]() { stopDecoding(); });
+        _worker->dispatch([this]() { stopDecoding(); });
         return;
     }
 
@@ -424,13 +401,15 @@ void GstVideoReceiver::stopDecoding()
         return;
     }
 
-    g_object_set(_decoderValve, "drop", TRUE, nullptr);
+    g_object_set(_decoderValve,
+                 "drop", TRUE,
+                 nullptr);
 
     _removingDecoder = true;
 
     const bool ret = _unlinkBranch(_decoderValve);
 
-    // FIXME: AV: it is much better to emit onStopDecodingComplete() after decoding is really stopped
+    // FIXME: it is much better to emit onStopDecodingComplete() after decoding is really stopped
     // (which happens later due to async design) but as for now it is also not so bad...
     _dispatchSignal([this, ret](){ emit onStopDecodingComplete(ret ? STATUS_OK : STATUS_FAIL); });
 }
@@ -439,7 +418,7 @@ void GstVideoReceiver::startRecording(const QString &videoFile, FILE_FORMAT form
 {
     if (_needDispatch()) {
         const QString cachedVideoFile = videoFile;
-        _worker.dispatch([this, cachedVideoFile, format]() { startRecording(cachedVideoFile, format); });
+        _worker->dispatch([this, cachedVideoFile, format]() { startRecording(cachedVideoFile, format); });
         return;
     }
 
@@ -468,7 +447,7 @@ void GstVideoReceiver::startRecording(const QString &videoFile, FILE_FORMAT form
 
     _removingRecorder = false;
 
-    gst_object_ref(_fileSink);
+    (void) gst_object_ref(_fileSink);
 
     gst_bin_add(GST_BIN(_pipeline), _fileSink);
 
@@ -478,7 +457,7 @@ void GstVideoReceiver::startRecording(const QString &videoFile, FILE_FORMAT form
         return;
     }
 
-    gst_element_sync_state_with_parent(_fileSink);
+    (void) gst_element_sync_state_with_parent(_fileSink);
 
     GST_DEBUG_BIN_TO_DOT_FILE(GST_BIN(_pipeline), GST_DEBUG_GRAPH_SHOW_ALL, "pipeline-with-filesink");
 
@@ -492,12 +471,14 @@ void GstVideoReceiver::startRecording(const QString &videoFile, FILE_FORMAT form
         return;
     }
 
-    gst_pad_add_probe(probepad, GST_PAD_PROBE_TYPE_BUFFER, _keyframeWatch, this, nullptr); // to drop the buffers until key frame is received
-    gst_object_unref(probepad);
-    probepad = nullptr;
+    (void) gst_pad_add_probe(probepad, GST_PAD_PROBE_TYPE_BUFFER, _keyframeWatch, this, nullptr); // to drop the buffers until key frame is received
+    gst_clear_object(&probepad);
 
-    g_object_set(_recorderValve, "drop", FALSE, nullptr);
+    g_object_set(_recorderValve,
+                 "drop", FALSE,
+                 nullptr);
 
+    _recordingOutput = videoFile;
     _recording = true;
     qCDebug(GstVideoReceiverLog) << "Recording started" << _uri;
     _dispatchSignal([this]() {
@@ -509,26 +490,27 @@ void GstVideoReceiver::startRecording(const QString &videoFile, FILE_FORMAT form
 void GstVideoReceiver::stopRecording()
 {
     if (_needDispatch()) {
-        _worker.dispatch([this]() { stopRecording(); });
+        _worker->dispatch([this]() { stopRecording(); });
         return;
     }
 
     qCDebug(GstVideoReceiverLog) << "Stopping recording" << _uri;
 
-    // exit immediately if we are not recording
     if (!_pipeline || !_recording) {
         qCDebug(GstVideoReceiverLog) << "Not recording!" << _uri;
         _dispatchSignal([this]() { emit onStopRecordingComplete(STATUS_INVALID_STATE); });
         return;
     }
 
-    g_object_set(_recorderValve, "drop", TRUE, nullptr);
+    g_object_set(_recorderValve,
+                 "drop", TRUE,
+                 nullptr);
 
     _removingRecorder = true;
 
     const bool ret = _unlinkBranch(_recorderValve);
 
-    // FIXME: AV: it is much better to emit onStopRecordingComplete() after recording is really stopped
+    // FIXME: it is much better to emit onStopRecordingComplete() after recording is really stopped
     // (which happens later due to async design) but as for now it is also not so bad...
     _dispatchSignal([this, ret]() { emit onStopRecordingComplete(ret ? STATUS_OK : STATUS_FAIL); });
 }
@@ -537,17 +519,19 @@ void GstVideoReceiver::takeScreenshot(const QString &imageFile)
 {
     if (_needDispatch()) {
         const QString cachedImageFile = imageFile;
-        _worker.dispatch([this, cachedImageFile]() { takeScreenshot(cachedImageFile); });
+        _worker->dispatch([this, cachedImageFile]() { takeScreenshot(cachedImageFile); });
         return;
     }
 
-    // FIXME: AV: record screenshot here
+    qCDebug(GstVideoReceiverLog) << "taking screenshot" << _uri;
+
+    // FIXME: record screenshot here
     _dispatchSignal([this]() { emit onTakeScreenshotComplete(STATUS_NOT_IMPLEMENTED); });
 }
 
 void GstVideoReceiver::_watchdog()
 {
-    _worker.dispatch([this]() {
+    _worker->dispatch([this]() {
         if (!_pipeline) {
             return;
         }
@@ -607,41 +591,34 @@ gboolean GstVideoReceiver::_filterParserCaps(GstElement *bin, GstPad *pad, GstEl
 
     GstCaps *srcCaps;
     gst_query_parse_caps(query, &srcCaps);
-
     if (!srcCaps || gst_caps_is_any(srcCaps)) {
         return FALSE;
     }
 
     GstCaps *sinkCaps = nullptr;
-    GstCaps *filter;
-
+    GstCaps *filter = nullptr;
     GstStructure *structure = gst_caps_get_structure(srcCaps, 0);
     if (gst_structure_has_name(structure, "video/x-h265")) {
         filter = gst_caps_from_string("video/x-h265");
         if (gst_caps_can_intersect(srcCaps, filter)) {
             sinkCaps = gst_caps_from_string("video/x-h265,stream-format=hvc1");
         }
-        gst_caps_unref(filter);
-        filter = nullptr;
+        gst_clear_caps(&filter);
     } else if (gst_structure_has_name(structure, "video/x-h264")) {
         filter = gst_caps_from_string("video/x-h264");
         if (gst_caps_can_intersect(srcCaps, filter)) {
             sinkCaps = gst_caps_from_string("video/x-h264,stream-format=avc");
         }
-        gst_caps_unref(filter);
-        filter = nullptr;
+        gst_clear_caps(&filter);
     }
 
-    if (!sinkCaps) {
-        return FALSE;
+    if (sinkCaps) {
+        gst_query_set_caps_result(query, sinkCaps);
+        gst_clear_caps(&sinkCaps);
+        return TRUE;
     }
 
-    gst_query_set_caps_result(query, sinkCaps);
-
-    gst_caps_unref(sinkCaps);
-    sinkCaps = nullptr;
-
-    return TRUE;
+    return FALSE;
 }
 
 GstElement *GstVideoReceiver::_makeSource(const QString &input)
@@ -679,7 +656,10 @@ GstElement *GstVideoReceiver::_makeSource(const QString &input)
                 break;
             }
 
-            g_object_set(static_cast<gpointer>(source), "location", input.toUtf8().constData(), "latency", 50, nullptr);
+            g_object_set(source,
+                         "location", input.toUtf8().constData(),
+                         "latency", 25,
+                         nullptr);
         } else if (isTcpMPEGTS) {
             source = gst_element_factory_make("tcpclientsrc", "source");
             if (!source) {
@@ -689,7 +669,10 @@ GstElement *GstVideoReceiver::_makeSource(const QString &input)
 
             const QString host = sourceUrl.host();
             const quint16 port = sourceUrl.port();
-            g_object_set(static_cast<gpointer>(source), "host", host.toUtf8().constData(), "port", port, nullptr);
+            g_object_set(source,
+                         "host", host.toUtf8().constData(),
+                         "port", port,
+                         nullptr);
         } else if (isUdp264 || isUdp265 || isUdpMPEGTS) {
             source = gst_element_factory_make("udpsrc", "source");
             if (!source) {
@@ -698,7 +681,9 @@ GstElement *GstVideoReceiver::_makeSource(const QString &input)
             }
 
             const QString uri = QStringLiteral("udp://%1:%2").arg(sourceUrl.host(), QString::number(sourceUrl.port()));
-            g_object_set(static_cast<gpointer>(source), "uri", uri.toUtf8().constData(), nullptr);
+            g_object_set(source,
+                         "uri", uri.toUtf8().constData(),
+                         nullptr);
 
             GstCaps *caps = nullptr;
             if (isUdp264) {
@@ -716,9 +701,10 @@ GstElement *GstVideoReceiver::_makeSource(const QString &input)
             }
 
             if (caps) {
-                g_object_set(static_cast<gpointer>(source), "caps", caps, nullptr);
-                gst_caps_unref(caps);
-                caps = nullptr;
+                g_object_set(source,
+                             "caps", caps,
+                             nullptr);
+                gst_clear_caps(&caps);
             }
         } else {
             qCDebug(GstVideoReceiverLog) << "URI is not recognized";
@@ -741,7 +727,7 @@ GstElement *GstVideoReceiver::_makeSource(const QString &input)
             break;
         }
 
-        g_signal_connect(parser, "autoplug-query", G_CALLBACK(_filterParserCaps), nullptr);
+        (void) g_signal_connect(parser, "autoplug-query", G_CALLBACK(_filterParserCaps), nullptr);
 
         gst_bin_add_many(GST_BIN(bin), source, parser, nullptr);
 
@@ -754,7 +740,7 @@ GstElement *GstVideoReceiver::_makeSource(const QString &input)
                 break;
             }
 
-            gst_bin_add(GST_BIN(bin), tsdemux);
+            (void) gst_bin_add(GST_BIN(bin), tsdemux);
 
             if (!gst_element_link(source, tsdemux)) {
                 qCCritical(GstVideoReceiverLog) << "gst_element_link() failed";
@@ -766,7 +752,7 @@ GstElement *GstVideoReceiver::_makeSource(const QString &input)
         }
 
         int probeRes = 0;
-        gst_element_foreach_src_pad(source, _padProbe, &probeRes);
+        (void) gst_element_foreach_src_pad(source, _padProbe, &probeRes);
 
         if (probeRes & 1) {
             if ((probeRes & 2) && (_buffer >= 0)) {
@@ -776,7 +762,7 @@ GstElement *GstVideoReceiver::_makeSource(const QString &input)
                     break;
                 }
 
-                gst_bin_add(GST_BIN(bin), buffer);
+                (void) gst_bin_add(GST_BIN(bin), buffer);
 
                 if (!gst_element_link_many(source, buffer, parser, nullptr)) {
                     qCCritical(GstVideoReceiverLog) << "gst_element_link() failed";
@@ -789,10 +775,10 @@ GstElement *GstVideoReceiver::_makeSource(const QString &input)
                 }
             }
         } else {
-            g_signal_connect(source, "pad-added", G_CALLBACK(_linkPad), parser);
+            (void) g_signal_connect(source, "pad-added", G_CALLBACK(_linkPad), parser);
         }
 
-        g_signal_connect(parser, "pad-added", G_CALLBACK(_wrapWithGhostPad), nullptr);
+        (void) g_signal_connect(parser, "pad-added", G_CALLBACK(_wrapWithGhostPad), nullptr);
 
         source = tsdemux = buffer = parser = nullptr;
 
@@ -800,30 +786,11 @@ GstElement *GstVideoReceiver::_makeSource(const QString &input)
         bin = nullptr;
     } while(0);
 
-    if (bin) {
-        gst_object_unref(bin);
-        bin = nullptr;
-    }
-
-    if (parser) {
-        gst_object_unref(parser);
-        parser = nullptr;
-    }
-
-    if (tsdemux) {
-        gst_object_unref(tsdemux);
-        tsdemux = nullptr;
-    }
-
-    if (buffer) {
-        gst_object_unref(buffer);
-        buffer = nullptr;
-    }
-
-    if (source) {
-        gst_object_unref(source);
-        source = nullptr;
-    }
+    gst_clear_object(&bin);
+    gst_clear_object(&parser);
+    gst_clear_object(&tsdemux);
+    gst_clear_object(&buffer);
+    gst_clear_object(&source);
 
     return srcbin;
 }
@@ -849,14 +816,14 @@ GstElement *GstVideoReceiver::_makeFileSink(const QString &videoFile, FILE_FORMA
     bool releaseElements = true;
 
     do {
-        if ((format < FILE_FORMAT_MIN) || (format >= FILE_FORMAT_MAX)) {
+        if (!isValidFileFormat(format)) {
             qCCritical(GstVideoReceiverLog) << "Unsupported file format";
             break;
         }
 
-        mux = gst_element_factory_make(_kFileMux[format - FILE_FORMAT_MIN], nullptr);
+        mux = gst_element_factory_make(_kFileMux[format], nullptr);
         if (!mux) {
-            qCCritical(GstVideoReceiverLog) << "gst_element_factory_make('" << _kFileMux[format - FILE_FORMAT_MIN] << "') failed";
+            qCCritical(GstVideoReceiverLog) << "gst_element_factory_make('" << _kFileMux[format] << "') failed";
             break;
         }
 
@@ -866,7 +833,9 @@ GstElement *GstVideoReceiver::_makeFileSink(const QString &videoFile, FILE_FORMA
             break;
         }
 
-        g_object_set(static_cast<gpointer>(sink), "location", qPrintable(videoFile), nullptr);
+        g_object_set(sink,
+                     "location", qPrintable(videoFile),
+                     nullptr);
 
         bin = gst_bin_new("sinkbin");
         if (!bin) {
@@ -880,7 +849,7 @@ GstElement *GstVideoReceiver::_makeFileSink(const QString &videoFile, FILE_FORMA
             break;
         }
 
-        // FIXME: AV: pad handling is potentially leaking (and other similar places too!)
+        // FIXME: pad handling is potentially leaking (and other similar places too!)
         GstPad *pad = gst_element_request_pad(mux, padTemplate, nullptr, nullptr);
         if (!pad) {
             qCCritical(GstVideoReceiverLog) << "gst_element_request_pad(mux) failed";
@@ -892,11 +861,8 @@ GstElement *GstVideoReceiver::_makeFileSink(const QString &videoFile, FILE_FORMA
         releaseElements = false;
 
         GstPad *ghostpad = gst_ghost_pad_new("sink", pad);
-
-        gst_element_add_pad(bin, ghostpad);
-
-        gst_object_unref(pad);
-        pad = nullptr;
+        (void) gst_element_add_pad(bin, ghostpad);
+        gst_clear_object(&pad);
 
         if (!gst_element_link(mux, sink)) {
             qCCritical(GstVideoReceiverLog) << "gst_element_link() failed";
@@ -908,22 +874,11 @@ GstElement *GstVideoReceiver::_makeFileSink(const QString &videoFile, FILE_FORMA
     } while(0);
 
     if (releaseElements) {
-        if (sink) {
-            gst_object_unref(sink);
-            sink = nullptr;
-        }
-
-        if (mux) {
-            gst_object_unref(mux);
-            mux = nullptr;
-        }
+        gst_clear_object(&sink);
+        gst_clear_object(&mux);
     }
 
-    if (bin) {
-        gst_object_unref(bin);
-        bin = nullptr;
-    }
-
+    gst_clear_object(&bin);
     return fileSink;
 }
 
@@ -941,8 +896,7 @@ void GstVideoReceiver::_onNewSourcePad(GstPad *pad)
         _dispatchSignal([this]() { emit streamingChanged(_streaming); });
     }
 
-    gst_pad_add_probe(pad, GST_PAD_PROBE_TYPE_EVENT_DOWNSTREAM, _eosProbe, this, nullptr);
-
+    (void) gst_pad_add_probe(pad, GST_PAD_PROBE_TYPE_EVENT_DOWNSTREAM, _eosProbe, this, nullptr);
     if (!_videoSink) {
         return;
     }
@@ -954,16 +908,18 @@ void GstVideoReceiver::_onNewSourcePad(GstPad *pad)
         return;
     }
 
-    g_object_set(_decoderValve, "drop", FALSE, nullptr);
+    g_object_set(_decoderValve,
+                 "drop", FALSE,
+                 nullptr);
 
     qCDebug(GstVideoReceiverLog) << "Decoding started" << _uri;
 }
 
 void GstVideoReceiver::_onNewDecoderPad(GstPad *pad)
 {
-    GST_DEBUG_BIN_TO_DOT_FILE(GST_BIN(_pipeline), GST_DEBUG_GRAPH_SHOW_ALL, "pipeline-with-new-decoder-pad");
-
     qCDebug(GstVideoReceiverLog) << "_onNewDecoderPad" << _uri;
+
+    GST_DEBUG_BIN_TO_DOT_FILE(GST_BIN(_pipeline), GST_DEBUG_GRAPH_SHOW_ALL, "pipeline-with-new-decoder-pad");
 
     if (!_addVideoSink(pad)) {
         qCCritical(GstVideoReceiverLog) << "_addVideoSink() failed";
@@ -981,30 +937,25 @@ bool GstVideoReceiver::_addDecoder(GstElement *src)
     GstCaps *caps = gst_pad_query_caps(srcpad, nullptr);
     if (!caps) {
         qCCritical(GstVideoReceiverLog) << "gst_pad_query_caps() failed";
-        gst_object_unref(srcpad);
-        srcpad = nullptr;
+        gst_clear_object(&srcpad);
         return false;
     }
 
-    gst_object_unref(srcpad);
-    srcpad = nullptr;
+    gst_clear_object(&srcpad);
 
     _decoder = _makeDecoder();
     if (!_decoder) {
         qCCritical(GstVideoReceiverLog) << "_makeDecoder() failed";
-        gst_caps_unref(caps);
-        caps = nullptr;
+        gst_clear_caps(&caps);
         return false;
     }
 
-    gst_object_ref(_decoder);
+    (void) gst_object_ref(_decoder);
 
-    gst_caps_unref(caps);
-    caps = nullptr;
+    gst_clear_caps(&caps);
 
-    gst_bin_add(GST_BIN(_pipeline), _decoder);
-
-    gst_element_sync_state_with_parent(_decoder);
+    (void) gst_bin_add(GST_BIN(_pipeline), _decoder);
+    (void) gst_element_sync_state_with_parent(_decoder);
 
     GST_DEBUG_BIN_TO_DOT_FILE(GST_BIN(_pipeline), GST_DEBUG_GRAPH_SHOW_ALL, "pipeline-with-decoder");
 
@@ -1014,28 +965,30 @@ bool GstVideoReceiver::_addDecoder(GstElement *src)
     }
 
     GstPad *srcPad = nullptr;
-
     GstIterator *it = gst_element_iterate_src_pads(_decoder);
-    if (it) {
-        GValue vpad = G_VALUE_INIT;
-        if (gst_iterator_next(it, &vpad) == GST_ITERATOR_OK) {
+    GValue vpad = G_VALUE_INIT;
+    switch (gst_iterator_next(it, &vpad)) {
+        case GST_ITERATOR_OK:
             srcPad = GST_PAD(g_value_get_object(&vpad));
-            gst_object_ref(srcPad);
-            g_value_reset(&vpad);
-        }
-
-        gst_iterator_free(it);
-        it = nullptr;
+            (void) gst_object_ref(srcPad);
+            (void) g_value_reset(&vpad);
+            break;
+        case GST_ITERATOR_RESYNC:
+            gst_iterator_resync(it);
+            break;
+        default:
+            break;
     }
+    g_value_unset(&vpad);
+    gst_iterator_free(it);
 
     if (srcPad) {
         _onNewDecoderPad(srcPad);
-        gst_object_unref(srcPad);
-        srcPad = nullptr;
     } else {
-        g_signal_connect(_decoder, "pad-added", G_CALLBACK(_onNewPad), this);
+        (void) g_signal_connect(_decoder, "pad-added", G_CALLBACK(_onNewPad), this);
     }
 
+    gst_clear_object(&srcPad);
     return true;
 }
 
@@ -1043,44 +996,41 @@ bool GstVideoReceiver::_addVideoSink(GstPad *pad)
 {
     GstCaps *caps = gst_pad_query_caps(pad, nullptr);
 
-    gst_object_ref(_videoSink); // gst_bin_add() will steal one reference
-
-    gst_bin_add(GST_BIN(_pipeline), _videoSink);
+    (void) gst_object_ref(_videoSink); // gst_bin_add() will steal one reference
+    (void) gst_bin_add(GST_BIN(_pipeline), _videoSink);
 
     if (!gst_element_link(_decoder, _videoSink)) {
-        gst_bin_remove(GST_BIN(_pipeline), _videoSink);
+        (void) gst_bin_remove(GST_BIN(_pipeline), _videoSink);
         qCCritical(GstVideoReceiverLog) << "Unable to link video sink";
-        if (caps) {
-            gst_caps_unref(caps);
-            caps = nullptr;
-        }
+        gst_clear_caps(&caps);
         return false;
     }
 
-    gst_element_sync_state_with_parent(_videoSink);
+    g_object_set(_videoSink,
+                 "widget", _widget,
+                 "sync", (_buffer >= 0),
+                 NULL);
 
-    g_object_set(_videoSink, "sync", _buffer >= 0, NULL);
+    (void) gst_element_sync_state_with_parent(_videoSink);
 
     GST_DEBUG_BIN_TO_DOT_FILE(GST_BIN(_pipeline), GST_DEBUG_GRAPH_SHOW_ALL, "pipeline-with-videosink");
 
     if (_decoderValve) {
         // Extracting video size from source is more guaranteed
         GstPad *valveSrcPad = gst_element_get_static_pad(_decoderValve, "src");
-        GstCaps *valveSrcPadCaps = gst_pad_query_caps(valveSrcPad, nullptr);
-        GstStructure *s = gst_caps_get_structure(valveSrcPadCaps, 0);
-        if (s) {
+        const GstCaps *valveSrcPadCaps = gst_pad_query_caps(valveSrcPad, nullptr);
+        const GstStructure *structure = gst_caps_get_structure(valveSrcPadCaps, 0);
+        if (structure) {
             gint width, height;
-            gst_structure_get_int(s, "width", &width);
-            gst_structure_get_int(s, "height", &height);
+            (void) gst_structure_get_int(structure, "width", &width);
+            (void) gst_structure_get_int(structure, "height", &height);
             _dispatchSignal([this, width, height]() { emit videoSizeChanged(QSize(width, height)); });
         }
-
-        gst_caps_unref(caps);
-        caps = nullptr;
     } else {
-        _dispatchSignal([this]() { emit videoSizeChanged(QSize(0, 0)); });
+        _dispatchSignal([this]() { emit videoSizeChanged(QSize()); });
     }
 
+    gst_clear_caps(&caps);
     return true;
 }
 
@@ -1114,29 +1064,24 @@ bool GstVideoReceiver::_unlinkBranch(GstElement *from)
 
     GstPad *sink = gst_pad_get_peer(src);
     if (!sink) {
-        gst_object_unref(src);
-        src = nullptr;
+        gst_clear_object(&src);
         qCCritical(GstVideoReceiverLog) << "gst_pad_get_peer() failed";
         return false;
     }
 
     if (!gst_pad_unlink(src, sink)) {
-        gst_object_unref(src);
-        src = nullptr;
-        gst_object_unref(sink);
-        sink = nullptr;
+        gst_clear_object(&src);
+        gst_clear_object(&sink);
         qCCritical(GstVideoReceiverLog) << "gst_pad_unlink() failed";
         return false;
     }
 
-    gst_object_unref(src);
-    src = nullptr;
+    gst_clear_object(&src);
 
     // Send EOS at the beginning of the branch
     const gboolean ret = gst_pad_send_event(sink, gst_event_new_eos());
 
-    gst_object_unref(sink);
-    sink = nullptr;
+    gst_clear_object(&sink);
 
     if (!ret) {
         qCCritical(GstVideoReceiverLog) << "Branch EOS was NOT sent";
@@ -1153,22 +1098,19 @@ void GstVideoReceiver::_shutdownDecodingBranch()
     if (_decoder) {
         GstObject *parent = gst_element_get_parent(_decoder);
         if (parent) {
-            gst_bin_remove(GST_BIN(_pipeline), _decoder);
-            gst_element_set_state(_decoder, GST_STATE_NULL);
-            gst_object_unref(parent);
-            parent = nullptr;
+            (void) gst_bin_remove(GST_BIN(_pipeline), _decoder);
+            (void) gst_element_set_state(_decoder, GST_STATE_NULL);
+            gst_clear_object(&parent);
         }
 
-        gst_object_unref(_decoder);
-        _decoder = nullptr;
+        gst_clear_object(&_decoder);
     }
 
     if (_videoSinkProbeId != 0) {
         GstPad *sinkpad = gst_element_get_static_pad(_videoSink, "sink");
         if (sinkpad) {
             gst_pad_remove_probe(sinkpad, _videoSinkProbeId);
-            gst_object_unref(sinkpad);
-            sinkpad = nullptr;
+            gst_clear_object(&sinkpad);
         }
         _videoSinkProbeId = 0;
     }
@@ -1177,14 +1119,12 @@ void GstVideoReceiver::_shutdownDecodingBranch()
 
     GstObject *parent = gst_element_get_parent(_videoSink);
     if (parent) {
-        gst_bin_remove(GST_BIN(_pipeline), _videoSink);
-        gst_element_set_state(_videoSink, GST_STATE_NULL);
-        gst_object_unref(parent);
-        parent = nullptr;
+        (void) gst_bin_remove(GST_BIN(_pipeline), _videoSink);
+        (void) gst_element_set_state(_videoSink, GST_STATE_NULL);
+        gst_clear_object(&parent);
     }
 
-    gst_object_unref(_videoSink);
-    _videoSink = nullptr;
+    gst_clear_object(&_videoSink);
 
     _removingDecoder = false;
 
@@ -1201,8 +1141,7 @@ void GstVideoReceiver::_shutdownRecordingBranch()
 {
     gst_bin_remove(GST_BIN(_pipeline), _fileSink);
     gst_element_set_state(_fileSink, GST_STATE_NULL);
-    gst_object_unref(_fileSink);
-    _fileSink = nullptr;
+    gst_clear_object(&_fileSink);
 
     _removingRecorder = false;
 
@@ -1217,7 +1156,7 @@ void GstVideoReceiver::_shutdownRecordingBranch()
 
 bool GstVideoReceiver::_needDispatch()
 {
-    return _worker.needDispatch();
+    return _worker->needDispatch();
 }
 
 void GstVideoReceiver::_dispatchSignal(Task emitter)
@@ -1249,50 +1188,46 @@ gboolean GstVideoReceiver::_onBusMessage(GstBus *bus, GstMessage *msg, gpointer 
 
         if (debug) {
             qCDebug(GstVideoReceiverLog) << "GStreamer debug:" << debug;
-            g_free(debug);
-            debug = nullptr;
+            g_clear_pointer(&debug, g_free);
         }
 
         if (error) {
             qCCritical(GstVideoReceiverLog) << "GStreamer error:" << error->message;
-            g_error_free(error);
-            error = nullptr;
+            g_clear_error(&error);
         }
 
-        pThis->_worker.dispatch([pThis]() {
+        pThis->_worker->dispatch([pThis]() {
             qCDebug(GstVideoReceiverLog) << "Stopping because of error";
             pThis->stop();
         });
         break;
     }
     case GST_MESSAGE_EOS:
-        pThis->_worker.dispatch([pThis]() {
+        pThis->_worker->dispatch([pThis]() {
             qCDebug(GstVideoReceiverLog) << "Received EOS";
             pThis->_handleEOS();
         });
         break;
     case GST_MESSAGE_ELEMENT: {
-        const GstStructure *s = gst_message_get_structure (msg);
-
-        if (!gst_structure_has_name(s, "GstBinForwarded")) {
+        const GstStructure *structure = gst_message_get_structure(msg);
+        if (!gst_structure_has_name(structure, "GstBinForwarded")) {
             break;
         }
 
         GstMessage *forward_msg = nullptr;
-        gst_structure_get(s, "message", GST_TYPE_MESSAGE, &forward_msg, NULL);
+        gst_structure_get(structure, "message", GST_TYPE_MESSAGE, &forward_msg, NULL);
         if (!forward_msg) {
             break;
         }
 
         if (GST_MESSAGE_TYPE(forward_msg) == GST_MESSAGE_EOS) {
-            pThis->_worker.dispatch([pThis]() {
+            pThis->_worker->dispatch([pThis]() {
                 qCDebug(GstVideoReceiverLog) << "Received branch EOS";
                 pThis->_handleEOS();
             });
         }
 
-        gst_message_unref(forward_msg);
-        forward_msg = nullptr;
+        gst_clear_message(&forward_msg);
         break;
     }
     default:
@@ -1328,15 +1263,13 @@ void GstVideoReceiver::_wrapWithGhostPad(GstElement *element, GstPad *pad, gpoin
     GstPad *ghostpad = gst_ghost_pad_new(name, pad);
     if (!ghostpad) {
         qCCritical(GstVideoReceiverLog) << "gst_ghost_pad_new() failed";
-        g_free(name);
-        name = nullptr;
+        g_clear_pointer(&name, g_free);
         return;
     }
 
-    g_free(name);
-    name = nullptr;
+    g_clear_pointer(&name, g_free);
 
-    gst_pad_set_active(ghostpad, TRUE);
+    (void) gst_pad_set_active(ghostpad, TRUE);
 
     if (!gst_element_add_pad(GST_ELEMENT_PARENT(element), ghostpad)) {
         qCCritical(GstVideoReceiverLog) << "gst_element_add_pad() failed";
@@ -1355,8 +1288,7 @@ void GstVideoReceiver::_linkPad(GstElement *element, GstPad *pad, gpointer data)
         qCCritical(GstVideoReceiverLog) << "gst_element_link_pads() failed";
     }
 
-    g_free(name);
-    name = nullptr;
+    g_clear_pointer(&name, g_free);
 }
 
 gboolean GstVideoReceiver::_padProbe(GstElement *element, GstPad *pad, gpointer user_data)
@@ -1374,12 +1306,10 @@ gboolean GstVideoReceiver::_padProbe(GstElement *element, GstPad *pad, gpointer 
                 *probeRes |= 2;
             }
 
-            gst_caps_unref(caps);
-            caps = nullptr;
+            gst_clear_caps(&caps);
         }
 
-        gst_caps_unref(filter);
-        filter = nullptr;
+        gst_clear_caps(&filter);
     }
 
     return TRUE;
@@ -1407,28 +1337,29 @@ GstPadProbeReturn GstVideoReceiver::_videoSinkProbe(GstPad *pad, GstPadProbeInfo
         if (pThis->_resetVideoSink) {
             pThis->_resetVideoSink = false;
 
-// FIXME: AV: this makes MPEG2-TS playing smooth but breaks RTSP
-//            gst_pad_send_event(pad, gst_event_new_flush_start());
-//            gst_pad_send_event(pad, gst_event_new_flush_stop(TRUE));
+#if 0 // FIXME: this makes MPEG2-TS playing smooth but breaks RTSP
+           gst_pad_send_event(pad, gst_event_new_flush_start());
+           gst_pad_send_event(pad, gst_event_new_flush_stop(TRUE));
 
-//            GstBuffer* buf;
+           GstBuffer* buf;
 
-//            if ((buf = gst_pad_probe_info_get_buffer(info)) != nullptr) {
-//                GstSegment* seg;
+           if ((buf = gst_pad_probe_info_get_buffer(info)) != nullptr) {
+               GstSegment* seg;
 
-//                if ((seg = gst_segment_new()) != nullptr) {
-//                    gst_segment_init(seg, GST_FORMAT_TIME);
+               if ((seg = gst_segment_new()) != nullptr) {
+                   gst_segment_init(seg, GST_FORMAT_TIME);
 
-//                    seg->start = buf->pts;
+                   seg->start = buf->pts;
 
-//                    gst_pad_send_event(pad, gst_event_new_segment(seg));
+                   gst_pad_send_event(pad, gst_event_new_segment(seg));
 
-//                    gst_segment_free(seg);
-//                    seg = nullptr;
-//                }
+                   gst_segment_free(seg);
+                   seg = nullptr;
+               }
 
-//                gst_pad_set_offset(pad, -static_cast<gint64>(buf->pts));
-//            }
+               gst_pad_set_offset(pad, -static_cast<gint64>(buf->pts));
+           }
+#endif
         }
 
         pThis->_noteVideoSinkFrame();
@@ -1461,7 +1392,8 @@ GstPadProbeReturn GstVideoReceiver::_keyframeWatch(GstPad *pad, GstPadProbeInfo 
     }
 
     GstBuffer *buf = gst_pad_probe_info_get_buffer(info);
-    if (GST_BUFFER_FLAG_IS_SET(buf, GST_BUFFER_FLAG_DELTA_UNIT)) { // wait for a keyframe
+    if (GST_BUFFER_FLAG_IS_SET(buf, GST_BUFFER_FLAG_DELTA_UNIT)) {
+        // wait for a keyframe
         return GST_PAD_PROBE_DROP;
     }
 
@@ -1470,23 +1402,115 @@ GstPadProbeReturn GstVideoReceiver::_keyframeWatch(GstPad *pad, GstPadProbeInfo 
 
     qCDebug(GstVideoReceiverLog) << "Got keyframe, stop dropping buffers";
 
-    GstVideoReceiver *const pThis = static_cast<GstVideoReceiver*>(user_data);
-    pThis->_dispatchSignal([pThis]() { emit pThis->recordingStarted(); });
+    GstVideoReceiver *pThis = static_cast<GstVideoReceiver*>(user_data);
+    pThis->_dispatchSignal([pThis]() { emit pThis->recordingStarted(pThis->recordingOutput()); });
 
     return GST_PAD_PROBE_REMOVE;
 }
+
+// void Streamer::handle_gst_message(GstElement *pipeline, const QString &pipelineType)
+// {
+//   GstBus *bus = gst_element_get_bus(pipeline);
+//   GstMessage *message = gst_bus_pop_filtered(bus, GST_MESSAGE_ANY);
+//   if (message) {
+//     switch (GST_MESSAGE_TYPE(message)) {
+//     case GST_MESSAGE_ERROR: {
+//       GError *error = nullptr;
+//       gst_message_parse_error(message, &error, nullptr);
+//       QString errorMsg = QString("%1 pipeline error: %2").arg(pipelineType, error->message);
+//       emit errorOccurred(errorMsg);
+//       g_clear_error(&error);
+//       break;
+//     }
+//     case GST_MESSAGE_WARNING: {
+//       GError *warning = nullptr;
+//       gst_message_parse_warning(message, &warning, nullptr);
+//       QString warningMsg = QString("%1 pipeline warning: %2").arg(pipelineType, warning->message);
+//       emit errorOccurred(warningMsg);
+//       g_clear_error(&warning);
+//       break;
+//     }
+//     case GST_MESSAGE_EOS: {
+//       QString eosMsg = QString("%1 pipeline reached end of stream.").arg(pipelineType);
+//       emit errorOccurred(eosMsg);
+//       break;
+//     }
+//     case GST_MESSAGE_STATE_CHANGED: {
+//       GstState oldState, newState, pendingState;
+//       gst_message_parse_state_changed(message, &oldState, &newState, &pendingState);
+//       if (GST_MESSAGE_SRC(message) == GST_OBJECT(pipeline)) {
+//         QString stateChangeMsg = QString("%1 pipeline state changed from %2 to %3.").arg(pipelineType, gst_element_state_get_name(oldState), gst_element_state_get_name(newState));
+//       }
+//       break;
+//     }
+//     case GST_MESSAGE_BUFFERING: {
+//       gint percent = 0;
+//       gst_message_parse_buffering(message, &percent);
+//       QString bufferingMsg = QString("%1 pipeline buffering: %2%%").arg(pipelineType).arg(percent);
+//       break;
+//     }
+//     case GST_MESSAGE_STREAM_STATUS: {
+//       GstStreamStatusType streamStatus;
+//       GstElement *owner = nullptr;
+//       gst_message_parse_stream_status(message, &streamStatus, &owner);
+//       const gchar *statusTypeName = get_stream_status_type_name(streamStatus);
+//       QString streamStatusMsg = QString("%1 stream status: %2 for element %3.").arg(pipelineType, statusTypeName, GST_ELEMENT_NAME(owner));
+//       break;
+//     }
+//     case GST_MESSAGE_NEW_CLOCK: {
+//       GstClock *newClock = nullptr;
+//       gst_message_parse_new_clock(message, &newClock);
+//       QString newClockMsg = QString("%1 new clock: %2.").arg(pipelineType, gst_object_get_name(GST_OBJECT(newClock)));
+//       break;
+//     }
+//     case GST_MESSAGE_TAG: {
+//       GstTagList *tags = nullptr;
+//       gst_message_parse_tag(message, &tags);
+//       gchar *tagsStr = gst_tag_list_to_string(tags);
+//       QString tagMsg = QString("%1 tags: %2.").arg(pipelineType).arg(tagsStr);
+//       g_free(tagsStr);
+//       gst_tag_list_unref(tags);
+//       break;
+//     }
+//     case GST_MESSAGE_LATENCY: {
+//       QString latencyMsg = QString("%1 latency message received.").arg(pipelineType);
+//       break;
+//     }
+//     case GST_MESSAGE_ASYNC_DONE: {
+//       QString asyncDoneMsg = QString("%1 async done message received.").arg(pipelineType);
+//       break;
+//     }
+//     case GST_MESSAGE_STREAM_START: {
+//       QString streamStartMsg = QString("%1 stream start message received.").arg(pipelineType);
+//       break;
+//     }
+//     case GST_MESSAGE_QOS: {
+//       GstFormat format;
+//       guint64 processed, dropped;
+//       gst_message_parse_qos_stats(message, &format, &processed, &dropped);
+//       QString qosMsg = QString("%1 QOS message received: processed=%2, dropped=%3.").arg(pipelineType).arg(processed).arg(dropped);
+//       break;
+//     }
+//     default:
+//       qCDebug(GstVideoReceiverLog) << "Unhandled message type: " << GST_MESSAGE_TYPE_NAME(message);
+//       break;
+//     }
+//     gst_message_unref(message);
+//   }
+//   gst_object_unref(bus);
+// }
 
 /*===========================================================================*/
 
 GstVideoWorker::GstVideoWorker(QObject *parent)
     : QThread(parent)
 {
-    // qCDebug(GstVideoReceiverLog) << Q_FUNC_INFO << this;
+    // qCDebug(GstVideoReceiverLog) << this;
 }
 
 GstVideoWorker::~GstVideoWorker()
 {
-    // qCDebug(GstVideoReceiverLog) << Q_FUNC_INFO << this;
+    // qCDebug(GstVideoReceiverLog) << this;
 }
 
 bool GstVideoWorker::needDispatch() const
@@ -1504,12 +1528,10 @@ void GstVideoWorker::dispatch(Task task)
 void GstVideoWorker::shutdown()
 {
     if (needDispatch()) {
-        dispatch([this]() {
-            _shutdown = true;
-        });
-        QThread::wait();
+        dispatch([this]() { _shutdown = true; });
+        (void) QThread::wait(2000);
     } else {
-        QThread::terminate();
+        QThread::quit();
     }
 }
 

--- a/src/VideoManager/VideoReceiver/GStreamer/GstVideoReceiver.h
+++ b/src/VideoManager/VideoReceiver/GStreamer/GstVideoReceiver.h
@@ -18,6 +18,7 @@
 
 #include <glib.h>
 #include <gst/gstelement.h>
+#include <gst/gstpad.h>
 
 #include "VideoReceiver.h"
 
@@ -49,6 +50,8 @@ private:
 
 /*===========================================================================*/
 
+typedef struct _GstElement GstElement;
+
 class GstVideoReceiver : public VideoReceiver
 {
     Q_OBJECT
@@ -58,7 +61,7 @@ public:
     ~GstVideoReceiver();
 
 public slots:
-    void start(const QString &uri, uint32_t timeout, int buffer = 0) override;
+    void start(uint32_t timeout) override;
     void stop() override;
     void startDecoding(void *sink) override;
     void stopDecoding() override;
@@ -102,13 +105,6 @@ private:
     static GstPadProbeReturn _eosProbe(GstPad *pad, GstPadProbeInfo *info, gpointer user_data);
     static GstPadProbeReturn _keyframeWatch(GstPad *pad, GstPadProbeInfo *info, gpointer user_data);
 
-    bool _decoding = false;
-    bool _endOfStream = false;
-    bool _recording = false;
-    bool _removingDecoder = false;
-    bool _removingRecorder = false;
-    bool _resetVideoSink = false;
-    bool _streaming = false;
     GstElement *_decoder = nullptr;
     GstElement *_decoderValve = nullptr;
     GstElement *_fileSink = nullptr;
@@ -117,18 +113,11 @@ private:
     GstElement *_source = nullptr;
     GstElement *_tee = nullptr;
     GstElement *_videoSink = nullptr;
-    GstVideoWorker _worker;
+    GstVideoWorker *_worker = nullptr;
     gulong _teeProbeId = 0;
     gulong _videoSinkProbeId = 0;
-    int _buffer = 0;
-    qint64 _lastSourceFrameTime = 0;
-    qint64 _lastVideoFrameTime = 0;
-    QString _uri;
-    QTimer _watchdogTimer;
-    uint32_t _signalDepth = 0;
-    uint32_t _timeout = 0;
 
-    static constexpr const char *_kFileMux[FILE_FORMAT_MAX - FILE_FORMAT_MIN] = {
+    static constexpr const char *_kFileMux[FILE_FORMAT_MAX + 1] = {
         "matroskamux",
         "qtmux",
         "mp4mux"

--- a/src/VideoManager/VideoReceiver/QtMultimedia/QtMultimediaReceiver.h
+++ b/src/VideoManager/VideoReceiver/QtMultimedia/QtMultimediaReceiver.h
@@ -34,12 +34,13 @@ public:
     explicit QtMultimediaReceiver(QObject *parent = nullptr);
     virtual ~QtMultimediaReceiver();
 
-    static void *createVideoSink(QObject *parent, QQuickItem *widget);
+    static bool enabled();
+    static void *createVideoSink(QQuickItem *widget, QObject *parent = nullptr);
     static void releaseVideoSink(void *sink);
     static VideoReceiver *createVideoReceiver(QObject *parent);
 
 public slots:
-    void start(const QString &uri, uint32_t timeout, int buffer = 0) override;
+    void start(uint32_t timeout) override;
     void stop() override;
     void startDecoding(void *sink) override;
     void stopDecoding() override;

--- a/src/VideoManager/VideoReceiver/QtMultimedia/UVCReceiver.h
+++ b/src/VideoManager/VideoReceiver/QtMultimedia/UVCReceiver.h
@@ -18,6 +18,7 @@ Q_DECLARE_LOGGING_CATEGORY(UVCReceiverLog)
 class QCamera;
 class QImageCapture;
 class QQuickItem;
+class QMediaDevices;
 
 class UVCReceiver : public QtMultimediaReceiver
 {
@@ -27,10 +28,12 @@ public:
     explicit UVCReceiver(QObject *parent = nullptr);
     ~UVCReceiver();
 
-    static QCameraDevice findCameraDevice(const QString &cameraId);
     static bool enabled();
+    static QCameraDevice findCameraDevice(const QString &cameraId);
     static void checkPermission();
     static QString getSourceId();
+    static bool deviceExists(const QString &device);
+    static QStringList getDeviceNameList();
 
 public slots:
     Q_INVOKABLE void adjustAspectRatio();
@@ -38,4 +41,5 @@ public slots:
 private:
     QCamera *_camera = nullptr;
     QImageCapture *_imageCapture = nullptr;
+    QMediaDevices *_mediaDevices = nullptr;
 };

--- a/src/VideoManager/VideoReceiver/VideoReceiver.h
+++ b/src/VideoManager/VideoReceiver/VideoReceiver.h
@@ -11,6 +11,10 @@
 
 #include <QtCore/QObject>
 #include <QtCore/QSize>
+#include <QtCore/QTimer>
+
+class QGCVideoStreamInfo;
+class QQuickItem;
 
 class VideoReceiver : public QObject
 {
@@ -21,32 +25,63 @@ public:
         : QObject(parent)
     {}
 
+    bool isThermal() const { return (_name == QStringLiteral("thermalVideo")); }
+
+    void *sink() { return _sink; }
+    QQuickItem *widget() { return _widget; }
+    QString name() const { return _name; }
+    QString uri() const { return _uri; }
+    bool started() const { return _started; }
+    bool lowLatency() const { return _lowLatency; }
+    QGCVideoStreamInfo *videoStreamInfo() { return _videoStreamInfo; }
+    QString recordingOutput() const { return _recordingOutput; }
+
+    virtual void setSink(void *sink) { if (sink != _sink) { _sink = sink; emit sinkChanged(_sink); } }
+    virtual void setWidget(QQuickItem *widget) { if (widget != _widget) { _widget = widget; emit widgetChanged(_widget); } }
+    void setName(const QString &name) { if (name != _name) { _name = name; emit nameChanged(_name); } }
+    void setUri(const QString &uri) { if (uri != _uri) { _uri = uri; emit uriChanged(_uri); } }
+    void setStarted(bool started) { if (started != _started) { _started = started; emit startedChanged(_started); } }
+    void setLowLatency(bool lowLatency) { if (lowLatency != _lowLatency) { _lowLatency = lowLatency; emit lowLatencyChanged(_lowLatency); } }
+    void setVideoStreamInfo(QGCVideoStreamInfo *videoStreamInfo) { if (videoStreamInfo != _videoStreamInfo) { _videoStreamInfo = videoStreamInfo; emit videoStreamInfoChanged(); } }
+
     // QMediaFormat::FileFormat
     enum FILE_FORMAT {
         FILE_FORMAT_MIN = 0,
         FILE_FORMAT_MKV = FILE_FORMAT_MIN,
         FILE_FORMAT_MOV,
         FILE_FORMAT_MP4,
-        FILE_FORMAT_MAX
+        FILE_FORMAT_MAX = FILE_FORMAT_MP4
     };
     Q_ENUM(FILE_FORMAT)
+    static bool isValidFileFormat(FILE_FORMAT format) { return ((format >= FILE_FORMAT_MIN) && (format <= FILE_FORMAT_MAX)); }
 
     enum STATUS {
-        STATUS_OK = 0,
+        STATUS_MIN = 0,
+        STATUS_OK = STATUS_MIN,
         STATUS_FAIL,
         STATUS_INVALID_STATE,
         STATUS_INVALID_URL,
-        STATUS_NOT_IMPLEMENTED
+        STATUS_NOT_IMPLEMENTED,
+        STATUS_MAX = STATUS_NOT_IMPLEMENTED
     };
     Q_ENUM(STATUS)
+    static bool isValidStatus(STATUS status) { return ((status >= STATUS_MIN) && (status <= STATUS_MAX)); }
 
 signals:
     void timeout();
     void streamingChanged(bool active);
     void decodingChanged(bool active);
     void recordingChanged(bool active);
-    void recordingStarted(void);
+    void recordingStarted(const QString &filename);
     void videoSizeChanged(QSize size);
+
+    void sinkChanged(void *sink);
+    void nameChanged(const QString &name);
+    void uriChanged(const QString &uri);
+    void startedChanged(bool started);
+    void lowLatencyChanged(bool lowLatency);
+    void videoStreamInfoChanged();
+    void widgetChanged(QQuickItem *widget);
 
     void onStartComplete(STATUS status);
     void onStopComplete(STATUS status);
@@ -57,15 +92,43 @@ signals:
     void onTakeScreenshotComplete(STATUS status);
 
 public slots:
-    // buffer:
-    //      -1 - disable buffer and video sync
-    //      0 - default buffer length
-    //      N - buffer length, ms
-    virtual void start(const QString &uri, uint32_t timeout, int buffer = 0) = 0;
+    virtual void start(uint32_t timeout) = 0;
     virtual void stop() = 0;
     virtual void startDecoding(void *sink) = 0;
     virtual void stopDecoding() = 0;
     virtual void startRecording(const QString &videoFile, FILE_FORMAT format) = 0;
     virtual void stopRecording() = 0;
     virtual void takeScreenshot(const QString &imageFile) = 0;
+
+protected:
+    void *_sink = nullptr;
+    QQuickItem *_widget = nullptr;
+    QGCVideoStreamInfo *_videoStreamInfo = nullptr;
+    QString _name;
+    QString _uri;
+    bool _started = false;
+    bool _decoding = false;
+    bool _recording = false;
+    bool _streaming = false;
+    bool _lowLatency = false;
+    bool _resetVideoSink = false;
+    bool _endOfStream = false;
+    bool _removingDecoder = false;
+    bool _removingRecorder = false;
+    // buffer:
+    //      -1 - disable buffer and video sync
+    //      0 - default buffer length
+    //      N - buffer length, ms
+    int _buffer = 0;
+    qint64 _lastSourceFrameTime = 0;
+    qint64 _lastVideoFrameTime = 0;
+    QTimer _watchdogTimer;
+    uint32_t _signalDepth = 0;
+    uint32_t _timeout = 0;
+    QString _recordingOutput;
+
+    // bool _initialized = false;
+    // bool _fullScreen = false;
+    // QSize _videoSize;
+    // QString _imageFile;
 };


### PR DESCRIPTION
Enhanced structure of VideoReceivers and how the VideoManager interacts with them so that it is easier to have multiple simultaneous receivers.
Also includes another fix that was needed after #12634
Following this, each video receiver type needs to be improved/finished and then the implementation in QML needs to be updated.