### PR TITLE
AutoPilotPlugins: Correctly parse messages coming from level horizon calibration

### DIFF
--- a/src/AutoPilotPlugins/PX4/SensorsComponentController.cc
+++ b/src/AutoPilotPlugins/PX4/SensorsComponentController.cc
@@ -229,6 +229,10 @@ void SensorsComponentController::_handleUASTextMessage(int uasId, int compId, in
     if (uasId != _vehicle->id()) {
         return;
     }
+
+    // Needed for level horizon calibration
+    text.replace("&lt;", "<");
+    text.replace("&gt;", ">");
     
     if (text.contains("progress <")) {
         QString percent = text.split("<").last().split(">").first();


### PR DESCRIPTION



<!--- Title -->

Description
-----------
Without this fix, the output from the level horizon calibration would show `[cal] progress &lt;50&gt;` etc, and the progress bar would not update properly.
The below is from our fork of QGC, I saw the same issue on the official QGC app. 

https://github.com/user-attachments/assets/a6422001-b115-442a-a967-1bc5e61f76ce



Test Steps
-----------
I verified that the issue was resolved by adding the two lines in this PR to our fork of QGC.

https://github.com/user-attachments/assets/a181ec23-482b-466d-a4bc-4924fa186766




Checklist:
----------
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] [Review Contribution Guidelines](https://github.com/mavlink/qgroundcontrol/blob/master/.github/CONTRIBUTING.md).
- [x] [Review Code of Conduct](https://github.com/mavlink/qgroundcontrol/blob/master/.github/CODE_OF_CONDUCT.md).
- [x] I have tested my changes.

Related Issue
-----------
<!-- If any, please provide issue ID. -->


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.