### PR TITLE
MissionManager: increment take photo sequence

### DIFF
--- a/src/MissionManager/CameraSection.cc
+++ b/src/MissionManager/CameraSection.cc
@@ -31,6 +31,7 @@ CameraSection::CameraSection(PlanMasterController* masterController, QObject* pa
     , _cameraPhotoIntervalDistanceFact  (0, _cameraPhotoIntervalDistanceName,   FactMetaData::valueTypeDouble)
     , _cameraPhotoIntervalTimeFact      (0, _cameraPhotoIntervalTimeName,       FactMetaData::valueTypeUint32)
     , _cameraModeFact                   (0, _cameraModeName,                    FactMetaData::valueTypeUint32)
+    , _takePhotoSequence                (0)
     , _dirty                            (false)
 {
     if (_metaDataMap.isEmpty()) {
@@ -200,7 +201,7 @@ void CameraSection::appendSectionItems(QList<MissionItem*>& items, QObject* miss
                                    0,                           // Reserved (Set to 0)
                                    0,                           // Interval (none)
                                    1,                           // Take 1 photo
-                                   0,                           // No sequence number specified
+                                   _takePhotoSequence++,        // Increasing sequence number
                                    qQNaN(), qQNaN(), qQNaN(),   // reserved
                                    true,                        // autoContinue
                                    false,                       // isCurrentItem

--- a/src/MissionManager/CameraSection.h
+++ b/src/MissionManager/CameraSection.h
@@ -123,6 +123,7 @@ private:
     Fact    _cameraPhotoIntervalDistanceFact;
     Fact    _cameraPhotoIntervalTimeFact;
     Fact    _cameraModeFact;
+    int     _takePhotoSequence;
     bool    _dirty;
 
     static QMap<QString, FactMetaData*> _metaDataMap;


### PR DESCRIPTION
For a big survey mission it is nice if the images have sequence numbers. Also, this can prevent double captures when a command is re-transmitted somwhere in the chain.