### PR TITLE
VideoManager: Fix Initial URI Change Signal

### DIFF
--- a/src/VideoManager/VideoManager.cc
+++ b/src/VideoManager/VideoManager.cc
@@ -464,7 +464,7 @@ bool VideoManager::_updateVideoUri(VideoReceiver *receiver, const QString &uri)
         return false;
     }
 
-    if (uri == receiver->uri()) {
+    if ((uri == receiver->uri()) && !receiver->uri().isNull()) {
         return false;
     }
 


### PR DESCRIPTION
Fix #12817
VideoReceiver uri is initially null, but the equality check is still true, so the changed signal wouldn't get emitted the first time