### PR TITLE
MissionController: Fix wrong altitude frame representation when downloading from vehicle for non relative altitude frame

### DIFF
--- a/src/MissionManager/MissionController.cc
+++ b/src/MissionManager/MissionController.cc
@@ -195,6 +195,9 @@ void MissionController::_newMissionItemsAvailableFromVehicle(bool removeAllReque
         _visualItems = newControllerMissionItems;
         _settingsItem = settingsItem;
 
+        // We set Altitude mode to mixed, otherwise if we need a non relative altitude frame we won't be able to change it 
+        setGlobalAltitudeMode(QGroundControlQmlGlobal::AltitudeModeMixed);
+
         MissionController::_scanForAdditionalSettings(_visualItems, _masterController);
 
         _initAllVisualItems();


### PR DESCRIPTION
Set altitude mode to mixed when downloading from vehicle too.

Otherwise mission altitude mode will be set to relative even if all the waypoints are a different frame, and this will bring us 2 issues:

- Individual waypoints frame will be shown as relative, even if they are not, misleading the operator.
- We won't be able to change waypoints altitude mode at all, because in order to do this in mission settings item we need to not have any item in the mission, so we are in a deadlock.

We could always check item by item to first evaluate if we might have all of them with the same frame, and thus apply that frame as global frame in mission controller, but that is probably overkill and when loading from mission files we are taking the same approach anyway, unless having the json "globalPlanAltitudeMode" field set.