### PR TITLE
Utilities: Add Logging Filter

### DIFF
--- a/src/Utilities/QGCLogging.h
+++ b/src/Utilities/QGCLogging.h
@@ -22,6 +22,7 @@ class QGCLogging : public QStringListModel
 
 public:
     explicit QGCLogging(QObject *parent = nullptr);
+    ~QGCLogging();
 
     /// Get the singleton instance
     static QGCLogging *instance();

--- a/src/Utilities/QGCLoggingCategory.cc
+++ b/src/Utilities/QGCLoggingCategory.cc
@@ -16,6 +16,21 @@ QGC_LOGGING_CATEGORY(QGCLoggingCategoryRegisterLog, "qgc.utilities.qgcloggingcat
 
 Q_GLOBAL_STATIC(QGCLoggingCategoryRegister, _QGCLoggingCategoryRegisterInstance);
 
+static QLoggingCategory::CategoryFilter defaultCategoryFilter = nullptr;
+
+static void qgcCategoryFilter(QLoggingCategory *category)
+{
+    if (defaultCategoryFilter) {
+        defaultCategoryFilter(category);
+    }
+
+    // const QString categoryName = QString(category->categoryName());
+    // if (qstrncmp(category->categoryName(), "qgc.", 4) == 0) {
+        // QGCLoggingCategoryRegister::instance()->registerCategory(category->categoryName());
+        // category->setEnabled(QtDebugMsg, true);
+    // }
+}
+
 QGCLoggingCategoryRegister *QGCLoggingCategoryRegister::instance()
 {
     return _QGCLoggingCategoryRegisterInstance();
@@ -98,5 +113,9 @@ void QGCLoggingCategoryRegister::setFilterRulesFromSettings(const QString &comma
     filterRules += QStringLiteral("qt.qml.connections=false");
 
     qCDebug(QGCLoggingCategoryRegisterLog) << "Filter rules" << filterRules;
+    const QLoggingCategory::CategoryFilter categoryFilter = QLoggingCategory::installFilter(qgcCategoryFilter);
+    if (!defaultCategoryFilter) {
+        defaultCategoryFilter = categoryFilter;
+    }
     QLoggingCategory::setFilterRules(filterRules);
 }


### PR DESCRIPTION
Adds a custom filter function for the logging categories which can allow easier/finer control of the enabled categories.
Also could collect the registered categories here and remove the custom QGCLoggingCategory class.

Fixes a debug output issue too.