### PR TITLE
Qt version lockdown to 6.8.3

### DIFF
--- a/.github/workflows/android-linux-qt6.6.3.yml
+++ b/.github/workflows/android-linux-qt6.6.3.yml
@@ -74,6 +74,7 @@ jobs:
               -DQT_HOST_PATH="${{ env.QT_ROOT_DIR }}/../gcc_64"
               -DQT_ANDROID_SIGN_APK=${{ github.ref == 'refs/heads/master' && github.event_name != 'pull_request' && 'ON' || 'OFF' }}
               -DQT_DEBUG_FIND_PACKAGE=ON
+              -DQGC_ENABLE_HERELINK=ON
               -DQGC_STABLE_BUILD=${{ github.ref_type == 'tag' || contains(github.ref, 'Stable') && 'ON' || 'OFF' }}
 
       - name: Build

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -159,6 +159,20 @@ endif()
 #               Qt6 Configuration
 #######################################################
 
+# The values specified below are the ONLY supported configurations for this version of QGC. 
+# Change these to something else at your own risk. Anything other than what is specified 
+# here is unsupported so don't expect any help with problems.
+
+if(QGC_ENABLE_HERELINK AND ANDROID)
+    set(QGC_QT_MINIMUM_VERSION "6.6.3" CACHE STRING "Minimum Supported Qt Version")
+    set(QGC_QT_MAXIMUM_VERSION "6.6.3" CACHE STRING "Maximum Supported Qt Version")
+    set(QGC_QT_ANDROID_MIN_SDK_VERSION "25" CACHE STRING "Android Min SDK Version")
+else()
+    set(QGC_QT_MINIMUM_VERSION "6.8.3" CACHE STRING "Minimum Supported Qt Version")
+    set(QGC_QT_MAXIMUM_VERSION "6.8.3" CACHE STRING "Maximum Supported Qt Version")
+    set(QGC_QT_ANDROID_MIN_SDK_VERSION "28" CACHE STRING "Android Min SDK Version")
+endif()
+
 find_package(Qt6
     ${QGC_QT_MINIMUM_VERSION}...${QGC_QT_MAXIMUM_VERSION}
     REQUIRED

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -512,10 +512,12 @@ qt_add_translations(${CMAKE_PROJECT_NAME}
 )
 
 set_source_files_properties(resources/qtquickcontrols2.conf PROPERTIES QT_RESOURCE_ALIAS qtquickcontrols2.conf)
+set_source_files_properties(${SDL_GAMECONTROLLERDB_PATH} PROPERTIES QT_RESOURCE_ALIAS gamecontrollerdb.txt)
 qt_add_resources(${CMAKE_PROJECT_NAME} "qgcresources_cmake"
     PREFIX "/"
     FILES
         resources/qtquickcontrols2.conf
+        ${SDL_GAMECONTROLLERDB_PATH}
 )
 
 # cmake_print_variables(QT_ALL_PLUGIN_TYPES_FOUND_VIA_FIND_PACKAGE)

--- a/cmake/CustomOptions.cmake
+++ b/cmake/CustomOptions.cmake
@@ -1,6 +1,13 @@
 include(CMakeDependentOption)
 # The following options can be overriden by custom builds using the CustomOverrides.cmake file
 
+# Herelink integrated contollers only support Android 7.1. The latest version of Qt which supports this is 6.6.3.
+# Given the fact that normal QGC builds have moved on to 6.8.3 this option provides a workaround to be able to use
+# 6.6.3 and older android sdk. Note that this is likely the last major QGC release to provide this workaround.
+# This option is only available when building for Android. Usage of this option for something other than integrated
+# controllers workaround is not supported and will likely cause issues.
+option(QGC_ENABLE_HERELINK "Enable Herelink Support" OFF)
+
 # App
 set(QGC_APP_NAME "QGroundControl" CACHE STRING "App Name")
 set(QGC_APP_COPYRIGHT "Copyright (c) 2025 QGroundControl. All rights reserved." CACHE STRING "Copyright")
@@ -47,11 +54,6 @@ option(QGC_DISABLE_PX4_PLUGIN "Disable PX4 Plugin" OFF)
 option(QGC_DISABLE_PX4_PLUGIN_FACTORY "Disable PX4 Plugin Factory" OFF)
 
 # Android
-if(Qt6_VERSION VERSION_GREATER_EQUAL 6.7.0)
-    set(QGC_QT_ANDROID_MIN_SDK_VERSION "28" CACHE STRING "Android Min SDK Version")
-else() # Allow building for Android 7.1 if supported
-    set(QGC_QT_ANDROID_MIN_SDK_VERSION "25" CACHE STRING "Android Min SDK Version")
-endif()
 set(QGC_QT_ANDROID_TARGET_SDK_VERSION "35" CACHE STRING "Android Target SDK Version")
 set(QGC_ANDROID_PACKAGE_NAME "${QGC_PACKAGE_NAME}" CACHE STRING "Android Package Name")
 set(QGC_ANDROID_PACKAGE_SOURCE_DIR "${CMAKE_SOURCE_DIR}/android" CACHE PATH "Android Package Path")
@@ -80,8 +82,6 @@ set(CPM_SOURCE_CACHE ${CMAKE_BINARY_DIR}/cpm_modules CACHE PATH "Directory to do
 # set(CPM_USE_NAMED_CACHE_DIRECTORIES ON CACHE BOOL "Use additional directory of package name in cache on the most nested level.")
 
 # Qt
-set(QGC_QT_MINIMUM_VERSION "6.6.3" CACHE STRING "Minimum Supported Qt Version")
-set(QGC_QT_MAXIMUM_VERSION "6.8.3" CACHE STRING "Maximum Supported Qt Version")
 set(QT_QML_OUTPUT_DIRECTORY "${CMAKE_BINARY_DIR}/qml" CACHE PATH "Install path for QML")
 set(QML_IMPORT_PATH "${QT_QML_OUTPUT_DIRECTORY}" CACHE STRING "Extra QML Import Paths")
 option(QML_IMPORT_TRACE "Debug QML Imports" OFF)

--- a/src/Joystick/CMakeLists.txt
+++ b/src/Joystick/CMakeLists.txt
@@ -33,12 +33,7 @@ CPMAddPackage(
     GIT_TAG master
 )
 
-set_source_files_properties(${sdl_gamecontrollerdb_SOURCE_DIR}/gamecontrollerdb.txt PROPERTIES QT_RESOURCE_ALIAS gamecontrollerdb.txt)
-
-qt_add_resources(${CMAKE_PROJECT_NAME} "gamecontrollerdb.txt"
-    PREFIX "/db/mapping/joystick"
-    FILES ${sdl_gamecontrollerdb_SOURCE_DIR}/gamecontrollerdb.txt
-)
+set(SDL_GAMECONTROLLERDB_PATH "${sdl_gamecontrollerdb_SOURCE_DIR}/gamecontrollerdb.txt" CACHE FILEPATH "SDL GameControllerDB Path")
 
 #===========================================================================#
 

--- a/src/Joystick/JoystickSDL.cc
+++ b/src/Joystick/JoystickSDL.cc
@@ -200,7 +200,7 @@ bool JoystickSDL::_getHat(int hat, int i) const
 
 void JoystickSDL::_loadGameControllerMappings()
 {
-    QFile file(QStringLiteral(":/db/mapping/joystick/gamecontrollerdb.txt"));
+    QFile file(QStringLiteral(":/gamecontrollerdb.txt"));
     if (!file.open(QIODevice::ReadOnly | QIODevice::Text)) {
         qCWarning(JoystickSDLLog) << "Couldn't load GameController mapping database.";
         return;


### PR DESCRIPTION
* This is in prep for 5.0 release. Including default support for ranges of Qt versions just causes support nightmares
* Also adds specific support for Herelink option workaround to build against 6.6.3
* Fixes problem with gamecontrollerdb qt_add_resources causing link failures on 6.6.3