### PR TITLE
APM: fix uavcan compass name

### DIFF
--- a/src/FirmwarePlugin/APM/APMSensorIdDecoder.qml
+++ b/src/FirmwarePlugin/APM/APMSensorIdDecoder.qml
@@ -148,9 +148,9 @@ QGCLabel {
             return ""
         }
         if (deviceName.startsWith('COMPASS')) {
-            if (busType === 3 && devtype === 1) {
+            if (busType === 'UAVCAN') {
                 decodedDevname = 'UAVCAN'
-            } else if (busType === 6 && devtype === 1) {
+            } else if (busType === 'EAHRS') {
                 decodedDevname = 'EAHRS'
             } else {
                 decodedDevname = compassTypes[devtype] || '?'


### PR DESCRIPTION
`busType` is a string, so the existing logic has never worked. This bug resulted in the compass being reported as
```
HMC5883_OLD(UAVCAN0)
```
With the fixed logic it is now
```
UAVCAN(UAVCAN0)
```
The DroneCAN MagneticFieldStrength2 message only has a `uint8 id` which is used for sensor instance reporting. There is no mechanism to report device type of the magnetometer sensor (eg ii2smdc, hmc5883, etc)