### PR TITLE
Mixed modes

### DIFF
--- a/src/PlanView/MissionSettingsEditor.qml
+++ b/src/PlanView/MissionSettingsEditor.qml
@@ -71,7 +71,6 @@ Rectangle {
         MouseArea {
             Layout.preferredWidth:  childrenRect.width
             Layout.preferredHeight: childrenRect.height
-            enabled:                _noMissionItemsAdded
 
             onClicked: {
                 var removeModes = []
@@ -79,12 +78,25 @@ Rectangle {
                 if (!_controllerVehicle.supportsTerrainFrame) {
                     removeModes.push(QGroundControl.AltitudeModeTerrainFrame)
                 }
+                if (!_noMissionItemsAdded) {
+                    if (_missionController.globalAltitudeMode !== QGroundControl.AltitudeModeRelative) {
+                        removeModes.push(QGroundControl.AltitudeModeRelative)
+                    }
+                    if (_missionController.globalAltitudeMode !== QGroundControl.AltitudeModeAbsolute) {
+                        removeModes.push(QGroundControl.AltitudeModeAbsolute)
+                    }
+                    if (_missionController.globalAltitudeMode !== QGroundControl.AltitudeModeCalcAboveTerrain) {
+                        removeModes.push(QGroundControl.AltitudeModeCalcAboveTerrain)
+                    }
+                    if (_missionController.globalAltitudeMode !== QGroundControl.AltitudeModeTerrainFrame) {
+                        removeModes.push(QGroundControl.AltitudeModeTerrainFrame)
+                    }
+                }
                 altModeDialogComponent.createObject(mainWindow, { rgRemoveModes: removeModes, updateAltModeFn: updateFunction }).open()
             }
 
             RowLayout {
                 spacing: ScreenTools.defaultFontPixelWidth
-                enabled: _noMissionItemsAdded
 
                 QGCLabel {
                     id:     altModeLabel

--- a/src/PlanView/PlanView.qml
+++ b/src/PlanView/PlanView.qml
@@ -558,14 +558,13 @@ Item {
             z:                  QGroundControl.zOrderWidgets
             maxHeight:          parent.height - toolStrip.y
 
-            readonly property int flyButtonIndex:       0
-            readonly property int fileButtonIndex:      1
-            readonly property int takeoffButtonIndex:   2
-            readonly property int waypointButtonIndex:  3
-            readonly property int roiButtonIndex:       4
-            readonly property int patternButtonIndex:   5
-            readonly property int landButtonIndex:      6
-            readonly property int centerButtonIndex:    7
+            readonly property int fileButtonIndex:      0
+            readonly property int takeoffButtonIndex:   1
+            readonly property int waypointButtonIndex:  2
+            readonly property int roiButtonIndex:       3
+            readonly property int patternButtonIndex:   4
+            readonly property int landButtonIndex:      5
+            readonly property int centerButtonIndex:    6
 
             property bool _isRallyLayer:    _editingLayer == _layerRallyPoints
             property bool _isMissionLayer:  _editingLayer == _layerMission

--- a/src/QmlControls/ToolStripHoverButton.qml
+++ b/src/QmlControls/ToolStripHoverButton.qml
@@ -131,7 +131,7 @@ Button {
         id:             buttonBkRect
         color:          (control.checked || control.pressed) ?
                             qgcPal.buttonHighlight :
-                            (control.hovered ? qgcPal.toolStripHoverColor : qgcPal.toolbarBackground)
+                            ((control.enabled && control.hovered) ? qgcPal.toolStripHoverColor : qgcPal.toolbarBackground)
         anchors.fill:   parent
     }
 }


### PR DESCRIPTION
* Related to #12657
* Plan now always allows you at a minimum to switch to Mixed Modes altitude even if you have alraedy added items to a plan
* Fixed toolstrip button showing hover highlight when disabled
* Fixed initial display of File Open when going to Plan for first time