### PR TITLE
Fix usage of parameterExists

### DIFF
--- a/src/AutoPilotPlugins/PX4/PX4AutoPilotPlugin.cc
+++ b/src/AutoPilotPlugins/PX4/PX4AutoPilotPlugin.cc
@@ -107,7 +107,7 @@ const QVariantList& PX4AutoPilotPlugin::vehicleComponents(void)
                 _tuningComponent->setupTriggerSignals();
                 _components.append(QVariant::fromValue(static_cast<VehicleComponent*>(_tuningComponent)));
 
-                if(_vehicle->parameterManager()->parameterExists(_vehicle->id(), "SYS_VEHICLE_RESP")) {
+                if(_vehicle->parameterManager()->parameterExists(_vehicle->compId(), "SYS_VEHICLE_RESP")) {
                     _flightBehavior = new PX4FlightBehavior(_vehicle, this, this);
                     _flightBehavior->setupTriggerSignals();
                     _components.append(QVariant::fromValue(static_cast<VehicleComponent*>(_flightBehavior)));
@@ -123,7 +123,7 @@ const QVariantList& PX4AutoPilotPlugin::vehicleComponents(void)
                 qWarning() << "Call to vehicleCompenents prior to parametersReady";
             }
 
-            if(_vehicle->parameterManager()->parameterExists(_vehicle->id(), "SLNK_RADIO_CHAN")) {
+            if(_vehicle->parameterManager()->parameterExists(_vehicle->compId(), "SLNK_RADIO_CHAN")) {
                 _syslinkComponent = new SyslinkComponent(_vehicle, this, this);
                 _syslinkComponent->setupTriggerSignals();
                 _components.append(QVariant::fromValue(static_cast<VehicleComponent*>(_syslinkComponent)));

--- a/src/Vehicle/VehicleObjectAvoidance.cc
+++ b/src/Vehicle/VehicleObjectAvoidance.cc
@@ -64,7 +64,7 @@ VehicleObjectAvoidance::update(mavlink_obstacle_distance_t* message)
 bool
 VehicleObjectAvoidance::enabled()
 {
-    uint8_t id = static_cast<uint8_t>(_vehicle->id());
+    uint8_t id = static_cast<uint8_t>(_vehicle->compId());
     if(_vehicle->parameterManager()->parameterExists(id, kColPrevParam)) {
         return _vehicle->parameterManager()->getParameter(id, kColPrevParam)->rawValue().toInt() >= 0;
     }
@@ -75,7 +75,7 @@ VehicleObjectAvoidance::enabled()
 void
 VehicleObjectAvoidance::start(int minDistance)
 {
-    uint8_t id = static_cast<uint8_t>(_vehicle->id());
+    uint8_t id = static_cast<uint8_t>(_vehicle->compId());
     if(_vehicle->parameterManager()->parameterExists(id, kColPrevParam)) {
         _vehicle->parameterManager()->getParameter(id, kColPrevParam)->setRawValue(minDistance);
         emit objectAvoidanceChanged();
@@ -86,7 +86,7 @@ VehicleObjectAvoidance::start(int minDistance)
 void
 VehicleObjectAvoidance::stop()
 {
-    uint8_t id = static_cast<uint8_t>(_vehicle->id());
+    uint8_t id = static_cast<uint8_t>(_vehicle->compId());
     if(_vehicle->parameterManager()->parameterExists(id, kColPrevParam)) {
         _vehicle->parameterManager()->getParameter(id, kColPrevParam)->setRawValue(-1);
         emit objectAvoidanceChanged();


### PR DESCRIPTION
Fixes https://github.com/mavlink/qgroundcontrol/issues/12896

```
    /// Returns true if the specifed parameter exists
    ///     @param componentId: Component id or ParameterManager::defaultComponentId
    ///     @param name: Parameter name
    bool parameterExists(int componentId, const QString &paramName) const;
```