### PR TITLE
Plan Mode: Improve Corridor Scan `Rotate Entry Point`

### DIFF
--- a/src/MissionManager/CorridorScanComplexItem.cc
+++ b/src/MissionManager/CorridorScanComplexItem.cc
@@ -178,7 +178,13 @@ void CorridorScanComplexItem::_polylineDirtyChanged(bool dirty)
 
 void CorridorScanComplexItem::rotateEntryPoint(void)
 {
-    _entryPoint++;
+    if (_calcTransectCount() < 2) {
+        // Cycle by 2 indexes when the path only has a single "lane", to prevent having to double click the "rotate entry point" button to invert the scan's direction along the path
+        _entryPoint += 2;
+    } else {
+        _entryPoint++;
+    }
+
     if (_entryPoint > 3) {
         _entryPoint = 0;
     }


### PR DESCRIPTION
<!--- Title -->

Description
-----------
1. ~~Tweaks the survey/scan presets so that they will auto-select the generated complex waypoint first. This cuts down on clicks in most situations where tweaking the takeoff waypoint's position or altitude is not a priority, i.e: because it's already set to the connected drone's position and already uses an acceptable altitude.~~ Will be revised and moved to a different PR
2. Tweaks the "Rotate Entry Point" logic of the Corridor Scan waypoint to be more user friendly, since before for scans narrow enough to cover with a single pass, the button would have to be clicked twice to get the expected result of inverting the flight's direction over the defined corridor.

Test Steps
-----------
1. ~~Under Plan Mode > File > Create Plan, try selecting any of the survey/scan presets under different conditions;~~
2. Create a Corridor Scan and tweak its waypoints and "corridor width" to test the behavior of the "Rotate Entry Point" button under different conditions;

Checklist:
----------
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] [Review Contribution Guidelines](https://github.com/mavlink/qgroundcontrol/blob/master/.github/CONTRIBUTING.md).
- [x] [Review Code of Conduct](https://github.com/mavlink/qgroundcontrol/blob/master/.github/CODE_OF_CONDUCT.md).
- [x] I have tested my changes.

Related Issue
-----------
<!-- If any, please provide issue ID. -->
None

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.