### PR TITLE
QML: Fix Delete All Settings Option

### DIFF
--- a/src/QGCApplication.h
+++ b/src/QGCApplication.h
@@ -52,10 +52,10 @@ public:
     ~QGCApplication();
 
     /// Sets the persistent flag to delete all settings the next time QGroundControl is started.
-    void deleteAllSettingsNextBoot();
+    static void deleteAllSettingsNextBoot();
 
     /// Clears the persistent flag to delete all settings the next time QGroundControl is started.
-    void clearDeleteAllSettingsNextBoot();
+    static void clearDeleteAllSettingsNextBoot();
 
     bool runningUnitTests() const { return _runningUnitTests; }
     bool simpleBootTest() const { return _simpleBootTest; }
@@ -180,7 +180,7 @@ private:
     CompressedSignalList _compressedSignals;
 
     const QString _settingsVersionKey = QStringLiteral("SettingsVersion"); ///< Settings key which hold settings version
-    const QString _deleteAllSettingsKey = QStringLiteral("DeleteAllSettingsNextBoot"); ///< If this settings key is set on boot, all settings will be deleted
+    static constexpr const char *_deleteAllSettingsKey = "DeleteAllSettingsNextBoot"; ///< If this settings key is set on boot, all settings will be deleted
 
     const QString _qgcImageProviderId = QStringLiteral("QGCImages");
 };

--- a/src/QmlControls/QGroundControlQmlGlobal.cc
+++ b/src/QmlControls/QGroundControlQmlGlobal.cc
@@ -313,9 +313,9 @@ void QGroundControlQmlGlobal::setFlightMapZoom(double zoom)
     }
 }
 
-QString QGroundControlQmlGlobal::qgcVersion(void) const
+QString QGroundControlQmlGlobal::qgcVersion(void)
 {
-    QString versionStr = qgcApp()->applicationVersion();
+    QString versionStr = QCoreApplication::applicationVersion();
     if(QSysInfo::buildAbi().contains("32"))
     {
         versionStr += QStringLiteral(" %1").arg(tr("32 bit"));
@@ -398,17 +398,17 @@ QString QGroundControlQmlGlobal::telemetryFileExtension() const
 
 QString QGroundControlQmlGlobal::appName()
 {
-    return qgcApp()->applicationName();
+    return QCoreApplication::applicationName();
 }
 
 void QGroundControlQmlGlobal::deleteAllSettingsNextBoot()
 {
-    qgcApp()->deleteAllSettingsNextBoot();
+    QGCApplication::deleteAllSettingsNextBoot();
 }
 
 void QGroundControlQmlGlobal::clearDeleteAllSettingsNextBoot()
 {
-    qgcApp()->clearDeleteAllSettingsNextBoot();
+    QGCApplication::clearDeleteAllSettingsNextBoot();
 }
 
 QStringList QGroundControlQmlGlobal::loggingCategories()

--- a/src/QmlControls/QGroundControlQmlGlobal.h
+++ b/src/QmlControls/QGroundControlQmlGlobal.h
@@ -130,8 +130,8 @@ public:
     Q_INVOKABLE void    saveBoolGlobalSetting   (const QString& key, bool value);
     Q_INVOKABLE bool    loadBoolGlobalSetting   (const QString& key, bool defaultValue);
 
-    Q_INVOKABLE void    deleteAllSettingsNextBoot       ();
-    Q_INVOKABLE void    clearDeleteAllSettingsNextBoot  ();
+    Q_INVOKABLE static void deleteAllSettingsNextBoot();
+    Q_INVOKABLE static void clearDeleteAllSettingsNextBoot();
 
     Q_INVOKABLE void    startPX4MockLink            (bool sendStatusText);
     Q_INVOKABLE void    startGenericMockLink        (bool sendStatusText);
@@ -160,7 +160,7 @@ public:
 
     // Property accessors
 
-    QString                 appName             ();
+    static QString appName();
     LinkManager*            linkManager         ()  { return _linkManager; }
     MultiVehicleManager*    multiVehicleManager ()  { return _multiVehicleManager; }
     QGCMapEngineManager*    mapEngineManager    ()  { return _mapEngineManager; }
@@ -219,7 +219,7 @@ public:
     QString missionFileExtension    (void) const;
     QString telemetryFileExtension  (void) const;
 
-    QString qgcVersion              (void) const;
+    static QString qgcVersion();
 
 #ifdef QGC_UTM_ADAPTER
     UTMSPManager* utmspManager() {return _utmspManager;}

--- a/src/UI/preferences/GeneralSettings.qml
+++ b/src/UI/preferences/GeneralSettings.qml
@@ -78,6 +78,8 @@ SettingsPage {
             onClicked: {
                 if (checked) {
                     QGroundControl.deleteAllSettingsNextBoot()
+                } else {
+                    QGroundControl.clearDeleteAllSettingsNextBoot()
                 }
             }
         }


### PR DESCRIPTION
Fixes "Clear all settings on next start" option which wouldn't disable after being enabled