### PR TITLE
Autoconnect: Filter out secondary composite ports from autoconnect

### DIFF
--- a/src/Comms/LinkManager.cc
+++ b/src/Comms/LinkManager.cc
@@ -789,7 +789,6 @@ void LinkManager::_filterCompositePorts(QList<QGCSerialPortInfo> &portList)
 {
     typedef QPair<quint16, quint16> VidPidPair_t;
 
-    QList<QGCSerialPortInfo>        list;
     QMap<VidPidPair_t, QStringList> seenSerialNumbers;
 
     for (auto it = portList.begin(); it != portList.end();) {

--- a/src/Comms/LinkManager.h
+++ b/src/Comms/LinkManager.h
@@ -186,6 +186,7 @@ private:
     bool _allowAutoConnectToBoard(QGCSerialPortInfo::BoardType_t boardType) const;
     void _addSerialAutoConnectLink();
     bool _portAlreadyConnected(const QString &portName) const;
+    void _filterCompositePorts(QList<QGCSerialPortInfo> &portList);
 
     UdpIODevice *_nmeaSocket = nullptr;
     QMap<QString, int> _autoconnectPortWaitList;   ///< key: QGCSerialPortInfo::systemLocation, value: wait count

--- a/src/Comms/SerialLink.cc
+++ b/src/Comms/SerialLink.cc
@@ -197,15 +197,13 @@ void SerialWorker::connectToPort()
     if (!_port->open(QIODevice::ReadWrite)) {
         qCWarning(SerialLinkLog) << "Opening port" << _port->portName() << "failed:" << _port->errorString();
 
-        if (!_errorEmitted) {
+        // If auto-connect is enabled, we don't want to emit an error for PermissionError from devices already in use
+        if (!_errorEmitted && (!_serialConfig->isAutoConnect() || _port->error() != QSerialPort::PermissionError)) {
             emit errorOccurred(tr("Could not open port: %1").arg(_port->errorString()));
             _errorEmitted = true;
         }
 
-        // Disconnecting here on autoconnect will cause continuous error popups
-        if (!_serialConfig->isAutoConnect()) {
-            _onPortDisconnected();
-        }
+        _onPortDisconnected();
 
         return;
     }


### PR DESCRIPTION
* Fix for #12893
* These changes should bring the basically code back to how 4.4 worked
* The secondary ports from a composite device are not made available to autoconnect
* The list of ports available to manual connections is the full un-filtered list. This differs from 4.4 which filtered the manual connect list as well.
* Fixed SerialLink to not pop PermissionError errors on autoconnect links

So far I've tested Mac and Windows for correct behavior on:
* Eating PermissionError's
* USB cable pull and reconnect. Note: On Windows, same as before, usb cable pull doesn't automatically close link,. You need to disconnect manually.
* Autoconnect to a composite device like Cube Orange running Ardupilot works

This can still cause failures on autoconnect to composite devices line Cube Orange. But it is basically the same failures that occurred with 4.4. Linux seems to be the OS which causes the most grief. In those cases you will need to turn off Autoconnect and manual connect to the right port.