### PR TITLE
CustomPlugin: Fix QApplicationStatic for Qt 6.6.3

### DIFF
--- a/custom-example/src/CustomPlugin.cc
+++ b/custom-example/src/CustomPlugin.cc
@@ -17,7 +17,9 @@
 #include "AppSettings.h"
 #include "BrandImageSettings.h"
 
+#if QT_VERSION >= QT_VERSION_CHECK(6, 8, 0)
 #include <QtCore/QApplicationStatic>
+#endif
 #include <QtQml/QQmlApplicationEngine>
 #include <QtQml/QQmlFile>
 


### PR DESCRIPTION
# CustomPlugin: Fix QApplicationStatic for Qt 6.6.3

Description
-----------
Updated the example implementation of the CustomPlugin to include the QtCore/QApplicationStatic header only for Qt versions over 6.8.0, where it was introduced.

Checklist:
----------
- [x] [Review Contribution Guidelines](https://github.com/mavlink/qgroundcontrol/blob/master/.github/CONTRIBUTING.md).
- [x] [Review Code of Conduct](https://github.com/mavlink/qgroundcontrol/blob/master/.github/CODE_OF_CONDUCT.md).
- [x] I have tested my changes.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.