### PR TITLE
Plan View: Fix polyline/polygon vertex dragging freezing the UI

### DIFF
--- a/src/FlightMap/MapItems/QGCMapPolygonVisuals.qml
+++ b/src/FlightMap/MapItems/QGCMapPolygonVisuals.qml
@@ -673,6 +673,25 @@ Item {
         }
     }
 
+    Timer {
+        id: radiusDragDebounceTimer
+        interval: 0
+        repeat: false
+
+        property var pendingCoord: undefined
+
+        onTriggered: {
+            // re-build the circular polygon only once per event loop
+            if (pendingCoord) {
+                var coord = pendingCoord
+                pendingCoord = undefined
+                var radius = mapPolygon.center.distanceTo(coord)
+                _createCircularPolygon(mapPolygon.center, radius)
+                _lastRadius = radius
+            }
+        }
+    }
+
     Component {
         id: radiusDragAreaComponent
 
@@ -683,13 +702,11 @@ Item {
 
             onItemCoordinateChanged: {
                 var radius = mapPolygon.center.distanceTo(itemCoordinate)
-                // Prevent signalling re-entrancy
-                if (!_circleRadiusDrag && Math.abs(radius - _lastRadius) > 0.1) {
-                    _circleRadiusDrag = true
-                    _createCircularPolygon(mapPolygon.center, radius)
-                    _circleRadiusDragCoord = itemCoordinate
-                    _circleRadiusDrag = false
-                    _lastRadius = radius
+
+                if (Math.abs(radius - _lastRadius) > 0.1) {
+                    // De-bounced circular polygon re-drawing
+                    radiusDragDebounceTimer.pendingCoord = itemCoordinate
+                    radiusDragDebounceTimer.start()
                 }
             }
         }

--- a/src/QmlControls/QGCMapPolygon.h
+++ b/src/QmlControls/QGCMapPolygon.h
@@ -168,4 +168,5 @@ private:
     bool                _traceMode =            false;
     bool                _showAltColor =         false;
     int                 _selectedVertexIndex =  -1;
+    bool                _deferredPathChanged =  false;
 };

--- a/src/QmlControls/QGCMapPolyline.cc
+++ b/src/QmlControls/QGCMapPolyline.cc
@@ -75,8 +75,14 @@ void QGCMapPolyline::clear(void)
 void QGCMapPolyline::adjustVertex(int vertexIndex, const QGeoCoordinate coordinate)
 {
     _polylinePath[vertexIndex] = QVariant::fromValue(coordinate);
-    emit pathChanged();
     _polylineModel.value<QGCQGeoCoordinate*>(vertexIndex)->setCoordinate(coordinate);
+    if (!_deferredPathChanged) {
+        _deferredPathChanged = true;
+        QTimer::singleShot(0, this, [this]() {
+            emit pathChanged();
+            _deferredPathChanged = false;
+        });
+    }
     setDirty(true);
 }
 

--- a/src/QmlControls/QGCMapPolyline.h
+++ b/src/QmlControls/QGCMapPolyline.h
@@ -128,6 +128,7 @@ private:
 
     QVariantList        _polylinePath;
     QmlObjectListModel  _polylineModel;
+    bool                _deferredPathChanged = false;
     bool                _dirty;
     bool                _interactive;
     bool                _resetActive;


### PR DESCRIPTION
<!--- Title -->

Description
-----------
I've noticed that when dragging the vertices of long polylines or large polygons, the UI would often freeze up completely (to the point of "program is not responding") after a few seconds of lag, and only sometimes recover from that state after tens of seconds.
Managed to fix it by debouncing "pathChanged" emissions to occour on every event loop, instead of every frame, which prevents dragging of such polylines/polygons from clogging up the UI code with too many path emissions.

Test Steps
-----------
Try creating Corridor Scan items with many polyline vertices or Survey scans (both basic and circular) covering a large area. Dragging of any polyline/polygon vertex won't cause the UI to freeze up completely, it will at worst lag a bit but always recover when releasing the vertex (unlike before).

Checklist:
----------
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] [Review Contribution Guidelines](https://github.com/mavlink/qgroundcontrol/blob/master/.github/CONTRIBUTING.md).
- [x] [Review Code of Conduct](https://github.com/mavlink/qgroundcontrol/blob/master/.github/CODE_OF_CONDUCT.md).
- [x] I have tested my changes.

Related Issue
-----------
<!-- If any, please provide issue ID. -->
Couldn't find any, but it seems more likely than not that this was reported at some time in the past.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.