### PR TITLE
Terrain: Fix TerrainQuery crash

### DIFF
--- a/src/Terrain/TerrainQuery.cc
+++ b/src/Terrain/TerrainQuery.cc
@@ -80,7 +80,6 @@ void TerrainAtCoordinateBatchManager::_sendNextBatch()
 
     // Convert coordinates to point strings for json query
     QList<QGeoCoordinate> coords;
-    int requestQueueAdded = 0;
     while (!_requestQueue.isEmpty()) {
         const QueuedRequestInfo_t requestInfo = _requestQueue.dequeue();
         const SentRequestInfo_t sentRequestInfo = {
@@ -90,13 +89,11 @@ void TerrainAtCoordinateBatchManager::_sendNextBatch()
         };
         (void) _sentRequests.append(sentRequestInfo);
         coords += requestInfo.coordinates;
-        requestQueueAdded++;
         if (coords.count() > 50) {
             break;
         }
     }
 
-    (void) _requestQueue.append(_requestQueue.mid(requestQueueAdded));
     qCDebug(TerrainQueryLog) << Q_FUNC_INFO << "requesting next batch _state:_requestQueue.count:_sentRequests.count" << _stateToString(_state) << _requestQueue.count() << _sentRequests.count();
 
     _state = TerrainQuery::State::Downloading;
@@ -223,9 +220,9 @@ void TerrainAtCoordinateQuery::signalTerrainData(bool success, const QList<doubl
 /*===========================================================================*/
 
 TerrainPathQuery::TerrainPathQuery(bool autoDelete, QObject *parent)
-   : QObject(parent)
-   , _autoDelete(autoDelete)
-   , _terrainQuery(new TerrainOfflineQuery(this))
+    : QObject(parent)
+    , _autoDelete(autoDelete)
+    , _terrainQuery(new TerrainOfflineQuery(this))
 {
     // qCDebug(TerrainQueryLog) << Q_FUNC_INFO << this;
 

--- a/src/Terrain/TerrainQuery.h
+++ b/src/Terrain/TerrainQuery.h
@@ -11,6 +11,7 @@
 
 #include <QtCore/QLoggingCategory>
 #include <QtCore/QObject>
+#include <QtCore/QPointer>
 #include <QtCore/QQueue>
 #include <QtCore/QVariant>
 #include <QtPositioning/QGeoCoordinate>
@@ -49,18 +50,16 @@ public:
 
 private slots:
     void _sendNextBatch();
-    void _queryObjectDestroyed(QObject *elevationProvider);
     void _coordinateHeights(bool success, const QList<double> &heights);
 
 private:
     struct QueuedRequestInfo_t {
-        TerrainAtCoordinateQuery *terrainAtCoordinateQuery;
+        QPointer<TerrainAtCoordinateQuery> terrainAtCoordinateQuery;
         QList<QGeoCoordinate> coordinates;
     };
 
     struct SentRequestInfo_t {
-        TerrainAtCoordinateQuery *terrainAtCoordinateQuery;
-        bool queryObjectDestroyed;
+        QPointer<TerrainAtCoordinateQuery> terrainAtCoordinateQuery;
         qsizetype cCoord;
     };
 


### PR DESCRIPTION
# Terrain: Fix TerrainQuery crash

Description
-----------
This fixes a use-after-free crash caused by improper raw pointer usage in TerrainQuery.

Key changes:
- Replace raw TerrainAtCoordinateQuery pointers with QPointer to automatically track object lifetime.
- Remove manual destroyed signal handling and related cleanup code.

In addition to this, some no-op logic has been removed.

Test Steps
-----------
Connect a real APM vehicle with a mission of around 300 waypoints. The application will often crash after loading the mission and drawing the plan.

Checklist:
----------
- [x] [Review Contribution Guidelines](https://github.com/mavlink/qgroundcontrol/blob/master/.github/CONTRIBUTING.md).
- [x] [Review Code of Conduct](https://github.com/mavlink/qgroundcontrol/blob/master/.github/CODE_OF_CONDUCT.md).
- [x] I have tested my changes.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.