### PR TITLE
add support for ESP32-based radio

### DIFF
--- a/src/Comms/USBBoardInfo.json
+++ b/src/Comms/USBBoardInfo.json
@@ -1,4 +1,4 @@
-﻿{
+{
     "comment":  "AutoConnect usb board info",
     "version":  1,
     "fileType": "USBBoardInfo",
@@ -56,6 +56,7 @@
 
         { "vendorID": 1027, "productID": 24597,     "boardClass": "SiK Radio",  "name": "SiK Radio",            "comment": "3DR Radio" },
         { "vendorID": 4292, "productID": 60000,     "boardClass": "SiK Radio",  "name": "SiK Radio",            "comment": "SILabs Radio" },
+        { "vendorID": 12346, "productID": 4097,     "boardClass": "SiK Radio",  "name": "DroneBridge Radio",    "comment": "ESP32-based telemetry radio" },
 
         { "vendorID": 5446, "productID": 424,       "boardClass": "RTK GPS",    "name": "U-blox RTK GPS",       "comment": "U-blox RTK GPS (M8P)" },
         { "vendorID": 5446, "productID": 425,       "boardClass": "RTK GPS",    "name": "U-blox RTK GPS",       "comment": "U-blox RTK GPS (F9P)" },


### PR DESCRIPTION
Add support for auto-connection to ESP32-based telemetry radio over UART

Description
-----------
The current list of `USBBoardInfo.json` does not have support for ESP32-based telemetry radios with UART connection. (They are equivalent to a SiK Radio)

Test Steps
-----------
Just end up building QGroundControl with the changes and plug-in the telemetry radio and it automatically connects to it.

Checklist:
----------
- [x] [Review Contribution Guidelines](https://github.com/mavlink/qgroundcontrol/blob/master/.github/CONTRIBUTING.md).
- [x] [Review Code of Conduct](https://github.com/mavlink/qgroundcontrol/blob/master/.github/CODE_OF_CONDUCT.md).
- [x] I have tested my changes.

Related Issue
-----------
N.A


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.