### PR TITLE
Create/Use common translated string splitting routine

### DIFF
--- a/src/FactSystem/FactMetaData.cc
+++ b/src/FactSystem/FactMetaData.cc
@@ -1185,7 +1185,7 @@ FactMetaData *FactMetaData::createFromJsonObject(const QJsonObject &json, const 
         foundBitmask = rgDescriptions.count() != 0;
     }
     if (rgDescriptions.isEmpty()) {
-        if (!_parseEnum(json, defineMap, rgDescriptions, rgStringValues, errorString)) {
+        if (!_parseEnum(metaData->_name, json, defineMap, rgDescriptions, rgStringValues, errorString)) {
             qWarning(FactMetaDataLog) << QStringLiteral("FactMetaData::createFromJsonObject _parseEnum for '%1' failed. %2").arg(metaData->name(), errorString);
         }
     }
@@ -1405,7 +1405,17 @@ void FactMetaData::setVolatileValue(bool bValue)
     }
 }
 
-bool FactMetaData::_parseEnum(const QJsonObject &jsonObject, const DefineMap_t &defineMap, QStringList &rgDescriptions, QStringList &rgValues, QString &errorString)
+QStringList FactMetaData::splitTranslatedList(const QString &translatedList)
+{
+    const QRegularExpression splitRegex("[,，、]"); // Note chinese commas for translations which have modified the english comma
+    QStringList valueList = translatedList.split(splitRegex, Qt::SkipEmptyParts);
+    for (QString &value: valueList) {
+        value = value.trimmed();
+    }
+    return valueList;
+}
+
+bool FactMetaData::_parseEnum(const QString& name, const QJsonObject &jsonObject, const DefineMap_t &defineMap, QStringList &rgDescriptions, QStringList &rgValues, QString &errorString)
 {
     rgDescriptions.clear();
     rgValues.clear();
@@ -1417,21 +1427,14 @@ bool FactMetaData::_parseEnum(const QJsonObject &jsonObject, const DefineMap_t &
 
     const QString jsonStrings = jsonObject.value(_enumStringsJsonKey).toString();
     const QString defineMapStrings = defineMap.value(jsonStrings, jsonStrings);
-    const QRegularExpression splitRegex("[,，、]"); // Note chinese commas for translations which have modified the english comma
-    rgDescriptions = defineMapStrings.split(splitRegex, Qt::SkipEmptyParts);
-    for (QString &desc: rgDescriptions) {
-        desc = desc.trimmed();
-    }
+    rgDescriptions = splitTranslatedList(defineMapStrings);
 
     const QString jsonValues = jsonObject.value(_enumValuesJsonKey).toString();
     const QString defineMapValues = defineMap.value(jsonValues, jsonValues);
-    rgValues = defineMapValues.split(splitRegex, Qt::SkipEmptyParts);
-    for (QString &value: rgValues) {
-        value = value.trimmed();
-    }
+    rgValues = splitTranslatedList(defineMapValues); // Never translated but still useful to use common string splitting code
 
     if (rgDescriptions.count() != rgValues.count()) {
-        errorString = QStringLiteral("Enum strings/values count mismatch - strings: '%1'[%2,%3] values: '%4'[%5,%6]").arg(defineMapStrings).arg(rgDescriptions.count()).arg(defineMapStrings.contains(",")).arg(defineMapValues).arg(rgValues.count()).arg(defineMapValues.contains(","));
+        errorString = QStringLiteral("Enum strings/values count mismatch - name: '%1' strings: '%2'[%3] values: '%4'[%5]").arg(name).arg(defineMapStrings).arg(rgDescriptions.count()).arg(defineMapValues).arg(rgValues.count());
         return false;
     }
 

--- a/src/FactSystem/FactMetaData.h
+++ b/src/FactSystem/FactMetaData.h
@@ -115,6 +115,10 @@ public:
     static const QString defaultCategory() { return QString(kDefaultCategory); }
     static const QString defaultGroup() { return QString(kDefaultGroup); }
 
+    // Splits a comma separated list of strings into a QStringList. Taking into account the possibility that
+    // the commas may have been translated to other characters such as chinese commas.
+    static QStringList splitTranslatedList(const QString &translatedList);
+
     int decimalPlaces() const;
     QVariant rawDefaultValue() const;
     QVariant cookedDefaultValue() const { return _rawTranslator(rawDefaultValue()); }
@@ -250,7 +254,7 @@ private:
     bool isInRawMinLimit(const QVariant &variantValue) const;
     bool isInRawMaxLimit(const QVariant &variantValue) const;
 
-    static bool _parseEnum(const QJsonObject &jsonObject, const DefineMap_t &defineMap, QStringList &rgDescriptions, QStringList &rgValues, QString &errorString);
+    static bool _parseEnum(const QString& name, const QJsonObject &jsonObject, const DefineMap_t &defineMap, QStringList &rgDescriptions, QStringList &rgValues, QString &errorString);
     static bool _parseValuesArray(const QJsonObject &jsonObject, QStringList &rgDescriptions, QList<double> &rgValues, QString &errorString);
     static bool _parseBitmaskArray(const QJsonObject &jsonObject, QStringList &rgDescriptions, QList<int> &rgValues, QString &errorString);
 

--- a/src/MissionManager/MissionCommandUIInfo.cc
+++ b/src/MissionManager/MissionCommandUIInfo.cc
@@ -379,7 +379,7 @@ bool MissionCommandUIInfo::loadJsonInfo(const QJsonObject& jsonObject, bool requ
             paramInfo->_param =         i;
             paramInfo->_units =         paramObject.value(_unitsJsonKey).toString();
             paramInfo->_nanUnchanged =  paramObject.value(_nanUnchangedJsonKey).toBool(false);
-            paramInfo->_enumStrings =   paramObject.value(_enumStringsJsonKey).toString().split(",", Qt::SkipEmptyParts);
+            paramInfo->_enumStrings =   FactMetaData::splitTranslatedList(paramObject.value(_enumStringsJsonKey).toString());
 
             // The min and max values are defaulted correctly already, so only set them if a value is present in the JSON.
             if (paramObject.value(_minJsonKey).isDouble()) {
@@ -403,7 +403,7 @@ bool MissionCommandUIInfo::loadJsonInfo(const QJsonObject& jsonObject, bool requ
                 paramInfo->_defaultValue = paramInfo->_nanUnchanged ? std::numeric_limits<double>::quiet_NaN() : 0;
             }
 
-            QStringList enumValues = paramObject.value(_enumValuesJsonKey).toString().split(",", Qt::SkipEmptyParts);
+            QStringList enumValues = FactMetaData::splitTranslatedList(paramObject.value(_enumValuesJsonKey).toString()); //Never translated but still useful to use common string splitting code
             for (const QString &enumValue: enumValues) {
                 bool    convertOk;
                 double  value = enumValue.toDouble(&convertOk);
@@ -417,7 +417,9 @@ bool MissionCommandUIInfo::loadJsonInfo(const QJsonObject& jsonObject, bool requ
                 paramInfo->_enumValues << QVariant(value);
             }
             if (paramInfo->_enumValues.count() != paramInfo->_enumStrings.count()) {
-                internalError = QString("enum strings/values count mismatch, label:'%1' enumStrings:'%2'").arg(paramInfo->_label).arg(paramInfo->_enumStrings.join(","));
+                internalError = QStringLiteral("Enum strings/values count mismatch - label: '%1' strings: '%2'[%3] values: '%4'[%5]")
+                                    .arg(paramInfo->_label).arg(paramObject.value(_enumStringsJsonKey).toString()).arg(paramInfo->_enumStrings.count())
+                                    .arg(paramObject.value(_enumValuesJsonKey).toString()).arg(paramInfo->_enumValues.count());
                 errorString = _loadErrorString(internalError);
                 return false;
             }


### PR DESCRIPTION
* Related to #12980
* Using slash "/" cannot be supported for string splitting since it is a valid character which can be used within a string
* Reviewed all QGC source for other possible locations for translated string splitting usage. Didn't find any.