### PR TITLE
CMake: Add QGroundControl QML Module

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -501,6 +501,13 @@ target_precompile_headers(${CMAKE_PROJECT_NAME}
         <QtCore/QTimer>
 )
 
+qt_add_qml_module(${CMAKE_PROJECT_NAME}
+    URI QGroundControl
+    VERSION 1.0
+    RESOURCE_PREFIX /qml
+    NO_PLUGIN
+)
+
 add_subdirectory(src)
 if(QGC_BUILD_TESTING)
     add_subdirectory(test)

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -1,9 +1,3 @@
-# qt_add_qml_module(QGC
-#     URI QGroundControl
-#     VERSION 1.0
-#     IMPORT_PATH ${QT_QML_OUTPUT_DIRECTORY}
-# )
-
 target_sources(${CMAKE_PROJECT_NAME}
     PRIVATE
         main.cc
@@ -51,12 +45,14 @@ target_link_libraries(${CMAKE_PROJECT_NAME}
         AppSettingsModule
         AutoPilotPluginsCommonModule
         FactControlsModule
+        FactSystemModule
         FlightDisplayModule
         FlightMapModule
         MainWindowModule
         QGroundControlControlsModule
         ScreenToolsModule
         ToolbarModule
+        VehicleModule
         VehicleSetupModule
 )
 

--- a/src/FactSystem/CMakeLists.txt
+++ b/src/FactSystem/CMakeLists.txt
@@ -16,4 +16,13 @@ target_sources(${CMAKE_PROJECT_NAME}
 
 target_include_directories(${CMAKE_PROJECT_NAME} PRIVATE ${CMAKE_CURRENT_SOURCE_DIR})
 
+qt_add_library(FactSystemModule STATIC)
+
+qt_add_qml_module(FactSystemModule
+    URI QGroundControl.FactSystem
+    VERSION 1.0
+    RESOURCE_PREFIX /qml
+    NO_PLUGIN # Required by Qt 6.6.3. TODO: Remove when no longer supported.
+)
+
 add_subdirectory(FactControls)

--- a/src/QmlControls/QGroundControl/FactSystem/qmldir
+++ b/src/QmlControls/QGroundControl/FactSystem/qmldir
@@ -1,1 +1,0 @@
-Module QGroundControl.FactSystem

--- a/src/QmlControls/QGroundControl/Vehicle/qmldir
+++ b/src/QmlControls/QGroundControl/Vehicle/qmldir
@@ -1,1 +1,0 @@
-Module QGroundControl.Vehicle

--- a/src/Vehicle/CMakeLists.txt
+++ b/src/Vehicle/CMakeLists.txt
@@ -28,6 +28,15 @@ target_sources(${CMAKE_PROJECT_NAME}
 
 target_include_directories(${CMAKE_PROJECT_NAME} PRIVATE ${CMAKE_CURRENT_SOURCE_DIR})
 
+qt_add_library(VehicleModule STATIC)
+
+qt_add_qml_module(VehicleModule
+    URI QGroundControl.Vehicle
+    VERSION 1.0
+    RESOURCE_PREFIX /qml
+    NO_PLUGIN # Required by Qt 6.6.3. TODO: Remove when no longer supported.
+)
+
 add_subdirectory(Actuators)
 add_subdirectory(ComponentInformation)
 add_subdirectory(FactGroups)


### PR DESCRIPTION
Resolves the warning about a missing QGroundControl module