### PR TITLE
Fix parameter name conversion from mavlink

### DIFF
--- a/src/Camera/QGCCameraIO.cc
+++ b/src/Camera/QGCCameraIO.cc
@@ -316,7 +316,13 @@ QGCCameraParamIO::_valueFromMessage(const char* value, uint8_t param_type)
             var = QVariant(static_cast<qulonglong>(u.param_int64));
             break;
         case MAV_PARAM_EXT_TYPE_CUSTOM:
-            var = QVariant(QByteArray(value, MAVLINK_MSG_PARAM_EXT_SET_FIELD_PARAM_VALUE_LEN));
+        {
+            // This will null terminate the name string
+            char strValueWithNull[MAVLINK_MSG_PARAM_EXT_SET_FIELD_PARAM_VALUE_LEN + 1] = {};
+            (void) strncpy(strValueWithNull, value, MAVLINK_MSG_PARAM_EXT_SET_FIELD_PARAM_VALUE_LEN);
+            const QString strValue(strValueWithNull);
+            var = QVariant(strValue);
+        }
             break;
         default:
             var = QVariant(0);

--- a/src/Camera/VehicleCameraControl.cc
+++ b/src/Camera/VehicleCameraControl.cc
@@ -1183,8 +1183,10 @@ VehicleCameraControl::_requestAllParameters()
 QString
 VehicleCameraControl::_getParamName(const char* param_id)
 {
-    QByteArray bytes(param_id, MAVLINK_MSG_PARAM_VALUE_FIELD_PARAM_ID_LEN);
-    QString parameterName(bytes);
+    // This will null terminate the name string
+    char parameterNameWithNull[MAVLINK_MSG_PARAM_VALUE_FIELD_PARAM_ID_LEN + 1] = {};
+    (void) strncpy(parameterNameWithNull, param_id, MAVLINK_MSG_PARAM_VALUE_FIELD_PARAM_ID_LEN);
+    const QString parameterName(parameterNameWithNull);
     return parameterName;
 }
 


### PR DESCRIPTION
* Previous code was failing with new 6.8. Switch to same code which is used in ParameterManager.
* Fix #12953 (hopefully!)