### PR TITLE
Add yaw in GPS fact

### DIFF
--- a/src/Vehicle/FactGroups/GPSFact.json
+++ b/src/Vehicle/FactGroups/GPSFact.json
@@ -40,6 +40,13 @@
     "units":            "deg"
 },
 {
+    "name":             "yaw",
+    "shortDesc": "Yaw",
+    "type":             "double",
+    "decimalPlaces":    1,
+    "units":            "deg"
+},
+{
     "name":             "lock",
     "shortDesc": "GPS Lock",
     "type":             "uint32",

--- a/src/Vehicle/FactGroups/VehicleGPS2FactGroup.cc
+++ b/src/Vehicle/FactGroups/VehicleGPS2FactGroup.cc
@@ -38,6 +38,7 @@ void VehicleGPS2FactGroup::_handleGps2Raw(const mavlink_message_t &message)
     hdop()->setRawValue((gps2Raw.eph == UINT16_MAX) ? qQNaN() : (gps2Raw.eph / 100.0));
     vdop()->setRawValue((gps2Raw.epv == UINT16_MAX) ? qQNaN() : (gps2Raw.epv / 100.0));
     courseOverGround()->setRawValue((gps2Raw.cog == UINT16_MAX) ? qQNaN() : (gps2Raw.cog / 100.0));
+    yaw()->setRawValue((gps2Raw.yaw == UINT16_MAX) ? qQNaN() : (gps2Raw.yaw / 100.0));
     lock()->setRawValue(gps2Raw.fix_type);
 
     _setTelemetryAvailable(true);

--- a/src/Vehicle/FactGroups/VehicleGPSFactGroup.cc
+++ b/src/Vehicle/FactGroups/VehicleGPSFactGroup.cc
@@ -22,6 +22,7 @@ VehicleGPSFactGroup::VehicleGPSFactGroup(QObject *parent)
     _addFact(&_hdopFact);
     _addFact(&_vdopFact);
     _addFact(&_courseOverGroundFact);
+    _addFact(&_yawFact);
     _addFact(&_lockFact);
     _addFact(&_countFact);
 
@@ -31,6 +32,7 @@ VehicleGPSFactGroup::VehicleGPSFactGroup(QObject *parent)
     _hdopFact.setRawValue(std::numeric_limits<float>::quiet_NaN());
     _vdopFact.setRawValue(std::numeric_limits<float>::quiet_NaN());
     _courseOverGroundFact.setRawValue(std::numeric_limits<float>::quiet_NaN());
+    _yawFact.setRawValue(std::numeric_limits<int16_t>::quiet_NaN());
 }
 
 void VehicleGPSFactGroup::handleMessage(Vehicle *vehicle, const mavlink_message_t &message)
@@ -64,6 +66,7 @@ void VehicleGPSFactGroup::_handleGpsRawInt(const mavlink_message_t &message)
     hdop()->setRawValue((gpsRawInt.eph == UINT16_MAX) ? qQNaN() : (gpsRawInt.eph / 100.0));
     vdop()->setRawValue((gpsRawInt.epv == UINT16_MAX) ? qQNaN() : (gpsRawInt.epv / 100.0));
     courseOverGround()->setRawValue((gpsRawInt.cog == UINT16_MAX) ? qQNaN() : (gpsRawInt.cog / 100.0));
+    yaw()->setRawValue((gpsRawInt.yaw == UINT16_MAX) ? qQNaN() : (gpsRawInt.yaw / 100.0));
     lock()->setRawValue(gpsRawInt.fix_type);
 
     _setTelemetryAvailable(true);

--- a/src/Vehicle/FactGroups/VehicleGPSFactGroup.h
+++ b/src/Vehicle/FactGroups/VehicleGPSFactGroup.h
@@ -20,6 +20,7 @@ class VehicleGPSFactGroup : public FactGroup
     Q_PROPERTY(Fact *hdop               READ hdop               CONSTANT)
     Q_PROPERTY(Fact *vdop               READ vdop               CONSTANT)
     Q_PROPERTY(Fact *courseOverGround   READ courseOverGround   CONSTANT)
+    Q_PROPERTY(Fact *yaw                READ yaw                CONSTANT)
     Q_PROPERTY(Fact *count              READ count              CONSTANT)
     Q_PROPERTY(Fact *lock               READ lock               CONSTANT)
 
@@ -32,6 +33,7 @@ public:
     Fact *hdop() { return &_hdopFact; }
     Fact *vdop() { return &_vdopFact; }
     Fact *courseOverGround() { return &_courseOverGroundFact; }
+    Fact *yaw() { return &_yawFact; }
     Fact *count() { return &_countFact; }
     Fact *lock() { return &_lockFact; }
 
@@ -49,6 +51,7 @@ protected:
     Fact _hdopFact = Fact(0, QStringLiteral("hdop"), FactMetaData::valueTypeDouble);
     Fact _vdopFact = Fact(0, QStringLiteral("vdop"), FactMetaData::valueTypeDouble);
     Fact _courseOverGroundFact = Fact(0, QStringLiteral("courseOverGround"), FactMetaData::valueTypeDouble);
+    Fact _yawFact = Fact(0, QStringLiteral("yaw"), FactMetaData::valueTypeDouble);
     Fact _countFact = Fact(0, QStringLiteral("count"), FactMetaData::valueTypeInt32);
     Fact _lockFact = Fact(0, QStringLiteral("lock"), FactMetaData::valueTypeInt32);
 };

--- a/translations/qgc-json.ts
+++ b/translations/qgc-json.ts
@@ -2449,6 +2449,12 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
+      <extracomment>.QGC.MetaData.Facts[yaw].shortDesc, </extracomment>
+      <location filename="../src/Vehicle/FactGroups/GPSFact.json"/>
+      <source>Yaw</source>
+      <translation type="unfinished">Yaw</translation>
+    </message>
+    <message>
         <extracomment>.QGC.MetaData.Facts[lock].shortDesc, </extracomment>
         <location filename="../src/Vehicle/FactGroups/GPSFact.json"/>
         <source>GPS Lock</source>


### PR DESCRIPTION
Add yaw in GPS fact and displayed it under GPS Status menu

Description
-----------
When using GPS heading along Gyroscope, QGrondControl will only show gyroscope compass, user can't know easily if heading is working correctly or what is his value.
I have added yaw to gps fact and make it displayed under Vehicle GPS Status menu.

The only way before was to open MAVLink inspector and check the value of yaw.
0 will be displayed if GPS do not provide heading and N/A when heading is not available.

![image](https://github.com/user-attachments/assets/a594146b-53c1-4610-a873-f9d6f5c2a9cf)


Test Steps
-----------
Use GPS heading, 

Checklist:
----------
- [x] [Review Contribution Guidelines](https://github.com/mavlink/qgroundcontrol/blob/master/.github/CONTRIBUTING.md).
- [x] [Review Code of Conduct](https://github.com/mavlink/qgroundcontrol/blob/master/.github/CODE_OF_CONDUCT.md).
- [x] I have tested my changes.

Related Issue
-----------


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.