### PR TITLE
Fix motor assignment motor click determination

### DIFF
--- a/src/AutoPilotPlugins/PX4/ActuatorComponent.qml
+++ b/src/AutoPilotPlugins/PX4/ActuatorComponent.qml
@@ -153,20 +153,24 @@ SetupPage {
 
                 // actuator image
                 Image {
+                    id:                     actuatorImage
+                    source:                 "image://actuators/geometry"+refreshFlag
+                    sourceSize.width:       imageSize
+                    sourceSize.height:      imageSize
+                    Layout.preferredWidth:  imageSize
+                    Layout.preferredHeight: imageSize
+                    Layout.alignment:       Qt.AlignHCenter
+                    visible:                actuators.isMultirotor
+                    cache:                  false
+
                     property var refreshFlag:         actuators.imageRefreshFlag
                     readonly property real imageSize: 9 * ScreenTools.defaultFontPixelHeight
 
-                    id:                actuatorImage
-                    source:            "image://actuators/geometry"+refreshFlag
-                    sourceSize.width:  Math.max(parent.width, imageSize)
-                    sourceSize.height: imageSize
-                    visible:           actuators.isMultirotor
-                    cache:             false
                     MouseArea {
                         anchors.fill:  parent
                         onClicked: (mouse) => {
                             if (mouse.button == Qt.LeftButton) {
-                                actuators.imageClicked(mouse.x, mouse.y);
+                                actuators.imageClicked(Qt.size(width, height), mouse.x, mouse.y);
                             }
                         }
                     }
@@ -387,7 +391,6 @@ SetupPage {
                                     onButtonClicked: function (button, role) {
                                         switch (button) {
                                         case MessageDialog.Yes:
-                                            console.log(actuators.motorAssignmentActive)
                                             actuators.startMotorAssignment()
                                             break;
                                         }

--- a/src/Vehicle/Actuators/Actuators.cc
+++ b/src/Vehicle/Actuators/Actuators.cc
@@ -33,11 +33,12 @@ Actuators::Actuators(QObject* parent, Vehicle* vehicle)
     connect(&_motorAssignment, &MotorAssignment::onAbort, this, [this]() { highlightActuators(false); });
 }
 
-void Actuators::imageClicked(float x, float y)
+void Actuators::imageClicked(QSizeF displaySize, float x, float y)
 {
     GeometryImage::VehicleGeometryImageProvider* provider = GeometryImage::VehicleGeometryImageProvider::instance();
-    int motorIndex = provider->getHighlightedMotorIndexAtPos(QPointF{ x, y });
-    qCDebug(ActuatorsConfigLog) << "Image clicked:" << x << "," << y << "motor index:" << motorIndex;
+    QPointF clickPosition{ x, y };
+    int motorIndex = provider->getHighlightedMotorIndexAtPos(displaySize, clickPosition);
+    qCDebug(ActuatorsConfigLog) << "Image clicked: position:" << clickPosition << "displaySize:" << displaySize << "motor index:" << motorIndex;
 
     if (_motorAssignment.active()) {
         QList<ActuatorGeometry>& actuators = provider->actuators();

--- a/src/Vehicle/Actuators/Actuators.h
+++ b/src/Vehicle/Actuators/Actuators.h
@@ -40,7 +40,7 @@ public:
     Q_PROPERTY(Mixer::Mixers* mixer                                             READ mixer                     CONSTANT)
     Q_PROPERTY(ActuatorOutputs::ActuatorOutput* selectedActuatorOutput          READ selectedActuatorOutput    NOTIFY selectedActuatorOutputChanged)
 
-    Q_INVOKABLE void imageClicked(float x, float y);
+    Q_INVOKABLE void imageClicked(QSizeF displaySize, float x, float y);
 
     Q_INVOKABLE void selectActuatorOutput(int index);
 

--- a/src/Vehicle/Actuators/GeometryImage.cc
+++ b/src/Vehicle/Actuators/GeometryImage.cc
@@ -164,6 +164,10 @@ void VehicleGeometryImageProvider::drawAxisIndicator(QPainter& p, const QPointF&
 
 QPixmap VehicleGeometryImageProvider::requestPixmap([[maybe_unused]] const QString& id, QSize* size, const QSize& requestedSize)
 {
+    // For some reason even though we specify a sourceSize.width/height for the image the requestSize comes through at twice that size.
+    // Because of that we need to remember the requested size and use it later to scale click positions.
+
+    _imageSize = requestedSize;
     int width = requestedSize.width();
     int height = requestedSize.height();
     if (size)
@@ -394,13 +398,22 @@ VehicleGeometryImageProvider* VehicleGeometryImageProvider::instance()
     return instance;
 }
 
-int VehicleGeometryImageProvider::getHighlightedMotorIndexAtPos(const QPointF &position)
+int VehicleGeometryImageProvider::getHighlightedMotorIndexAtPos(const QSizeF& displaySize, const QPointF &position)
 {
+    // We have to scale the click position to take into account displaySize versus imageSize scaling
+    if (_imageSize.isEmpty()) {
+        qWarning() << "Image size is not set, cannot scale position";
+        return -1;
+    }
+    float scaleX = static_cast<float>(displaySize.width()) / _imageSize.width();
+    float scaleY = static_cast<float>(displaySize.height()) / _imageSize.height();
+    QPointF scaledPosition = QPointF{position.x() / scaleX, position.y() / scaleY};
+
     int foundIdx = -1;
     for (int i = 0; i < _actuatorImagePositions.size(); ++i) {
         if (_actuatorImagePositions[i].type == ActuatorGeometry::Type::Motor) {
             float radius = _actuatorImagePositions[i].radius;
-            if (QLineF{_actuatorImagePositions[i].position, position}.length() < radius) {
+            if (QLineF{_actuatorImagePositions[i].position, scaledPosition}.length() < radius) {
                 // in case of multiple matches (overlaps), be safe and do not return any match
                 if (foundIdx != -1) {
                     return -1;

--- a/src/Vehicle/Actuators/GeometryImage.h
+++ b/src/Vehicle/Actuators/GeometryImage.h
@@ -40,7 +40,7 @@ public:
 
     static VehicleGeometryImageProvider* instance();
 
-    int getHighlightedMotorIndexAtPos(const QPointF& position);
+    int getHighlightedMotorIndexAtPos(const QSizeF& displaySize, const QPointF& position);
 
     QList<ActuatorGeometry>& actuators() { return _actuators; }
 
@@ -52,8 +52,9 @@ private:
 
     QList<ActuatorGeometry> _actuators{};
 
-    QList<ImagePosition> _actuatorImagePositions{}; ///< highlighted actuators image positions
-    QGCPalette           _palette;
+    QSize                   _imageSize;                 ///< size of the image requested, used to scale click positions
+    QList<ImagePosition>    _actuatorImagePositions{};  ///< highlighted actuators image positions
+    QGCPalette              _palette;
 };
 
 } // namespace GeometryImage


### PR DESCRIPTION
* For some reason even though we specify a sourceSize.width/height for the image the requestSize comes through at twice that size. Which in turns throws off the click determination. Seems to be a new thing with Qt 6.8.2. Previous 4.4 Stable requested size would come through as sourceSize.
* Fix #13018