### PR TITLE
Vehicle: Add "heading from" Facts

### DIFF
--- a/src/Vehicle/FactGroups/VehicleFact.json
+++ b/src/Vehicle/FactGroups/VehicleFact.json
@@ -116,6 +116,20 @@
     "units":            "deg"
 },
 {
+    "name":             "headingFromHome",
+    "shortDesc": "Heading from Home",
+    "type":             "double",
+    "decimalPlaces":    0,
+    "units":            "deg"
+},
+{
+    "name":             "headingFromGCS",
+    "shortDesc": "Heading from GCS",
+    "type":             "double",
+    "decimalPlaces":    0,
+    "units":            "deg"
+},
+{
     "name":             "distanceToGCS",
     "shortDesc": "Distance to GCS",
     "type":             "double",

--- a/src/Vehicle/FactGroups/VehicleFactGroup.cc
+++ b/src/Vehicle/FactGroups/VehicleFactGroup.cc
@@ -42,6 +42,8 @@ VehicleFactGroup::VehicleFactGroup(QObject *parent)
     _addFact(&_headingToNextWPFact);
     _addFact(&_distanceToNextWPFact);
     _addFact(&_headingToHomeFact);
+    _addFact(&_headingFromHomeFact);
+    _addFact(&_headingFromGCSFact);
     _addFact(&_distanceToGCSFact);
     _addFact(&_hobbsFact);
     _addFact(&_throttlePctFact);

--- a/src/Vehicle/FactGroups/VehicleFactGroup.h
+++ b/src/Vehicle/FactGroups/VehicleFactGroup.h
@@ -38,6 +38,8 @@ class VehicleFactGroup : public FactGroup
     Q_PROPERTY(Fact *headingToNextWP        READ headingToNextWP        CONSTANT)
     Q_PROPERTY(Fact *distanceToNextWP       READ distanceToNextWP       CONSTANT)
     Q_PROPERTY(Fact *headingToHome          READ headingToHome          CONSTANT)
+    Q_PROPERTY(Fact *headingFromHome        READ headingFromHome        CONSTANT)
+    Q_PROPERTY(Fact *headingFromGCS         READ headingFromGCS         CONSTANT)
     Q_PROPERTY(Fact *distanceToGCS          READ distanceToGCS          CONSTANT)
     Q_PROPERTY(Fact *hobbs                  READ hobbs                  CONSTANT)
     Q_PROPERTY(Fact *throttlePct            READ throttlePct            CONSTANT)
@@ -70,6 +72,8 @@ public:
     Fact *headingToNextWP() { return &_headingToNextWPFact; }
     Fact *distanceToNextWP() { return &_distanceToNextWPFact; }
     Fact *headingToHome() { return &_headingToHomeFact; }
+    Fact *headingFromHome() { return &_headingFromHomeFact; }
+    Fact *headingFromGCS() { return &_headingFromGCSFact; }
     Fact *distanceToGCS() { return &_distanceToGCSFact; }
     Fact *hobbs() { return &_hobbsFact; }
     Fact *throttlePct() { return &_throttlePctFact; }
@@ -113,6 +117,8 @@ protected:
     Fact _headingToNextWPFact = Fact(0, QStringLiteral("headingToNextWP"), FactMetaData::valueTypeDouble);
     Fact _distanceToNextWPFact = Fact(0, QStringLiteral("distanceToNextWP"), FactMetaData::valueTypeDouble);
     Fact _headingToHomeFact = Fact(0, QStringLiteral("headingToHome"), FactMetaData::valueTypeDouble);
+    Fact _headingFromHomeFact = Fact(0, QStringLiteral("headingFromHome"),FactMetaData::valueTypeDouble);
+    Fact _headingFromGCSFact = Fact(0, QStringLiteral("headingFromGCS"),FactMetaData::valueTypeDouble);
     Fact _distanceToGCSFact = Fact(0, QStringLiteral("distanceToGCS"), FactMetaData::valueTypeDouble);
     Fact _hobbsFact = Fact(0, QStringLiteral("hobbs"), FactMetaData::valueTypeString);
     Fact _throttlePctFact = Fact(0, QStringLiteral("throttlePct"), FactMetaData::valueTypeUint16);

--- a/src/Vehicle/Vehicle.h
+++ b/src/Vehicle/Vehicle.h
@@ -933,10 +933,10 @@ private slots:
     void _firstRallyPointLoadComplete       ();
     void _sendMavCommandResponseTimeoutCheck();
     void _clearCameraTriggerPoints          ();
-    void _updateDistanceHeadingToHome       ();
+    void _updateDistanceHeadingHome         ();
     void _updateMissionItemIndex            ();
     void _updateHeadingToNextWP             ();
-    void _updateDistanceToGCS               ();
+    void _updateDistanceHeadingGCS          ();
     void _updateHomepoint                   ();
     void _updateHobbsMeter                  ();
     void _vehicleParamLoaded                (bool ready);


### PR DESCRIPTION
# Vehicle: Add "heading from" Facts

Description
-----------
Added headingFromHome and headingFromGCS Facts, useful to locate vehicles from the operator's perspective.

Checklist:
----------
- [x] [Review Contribution Guidelines](https://github.com/mavlink/qgroundcontrol/blob/master/.github/CONTRIBUTING.md).
- [x] [Review Code of Conduct](https://github.com/mavlink/qgroundcontrol/blob/master/.github/CODE_OF_CONDUCT.md).
- [x] I have tested my changes.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.