### PR TITLE
CMake: Add QT_RESOURCE_ALIAS Helper

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -6,6 +6,8 @@ list(APPEND CMAKE_MODULE_PATH
     ${CMAKE_SOURCE_DIR}/cmake/find-modules
 )
 
+include(Helpers)
+
 if(NOT CMAKE_BUILD_TYPE AND NOT CMAKE_CONFIGURATION_TYPES)
     set(CMAKE_BUILD_TYPE Release CACHE STRING "Build type" FORCE)
     set_property(CACHE CMAKE_BUILD_TYPE PROPERTY STRINGS "Debug;Release")
@@ -533,8 +535,11 @@ qt_add_translations(${CMAKE_PROJECT_NAME}
     LUPDATE_OPTIONS -no-obsolete
 )
 
-set_source_files_properties(resources/qtquickcontrols2.conf PROPERTIES QT_RESOURCE_ALIAS qtquickcontrols2.conf)
-set_source_files_properties(${SDL_GAMECONTROLLERDB_PATH} PROPERTIES QT_RESOURCE_ALIAS gamecontrollerdb.txt)
+qgc_set_qt_resource_alias(
+    resources/qtquickcontrols2.conf
+    ${SDL_GAMECONTROLLERDB_PATH}
+)
+
 qt_add_resources(${CMAKE_PROJECT_NAME} "qgcresources_cmake"
     PREFIX "/"
     FILES

--- a/cmake/Helpers.cmake
+++ b/cmake/Helpers.cmake
@@ -1,0 +1,9 @@
+function(qgc_set_qt_resource_alias)
+    foreach(resource_file IN LISTS ARGN)
+        get_filename_component(alias "${resource_file}" NAME)
+        set_source_files_properties(
+            "${resource_file}"
+            PROPERTIES QT_RESOURCE_ALIAS "${alias}"
+        )
+    endforeach()
+endfunction()


### PR DESCRIPTION
Add a simpler way to set a file alias to its base file name for convenience