### PR TITLE
MissionManager: Fix VTOL landing item crash

### DIFF
--- a/src/MissionManager/VTOLLandingPattern.FactMetaData.json
+++ b/src/MissionManager/VTOLLandingPattern.FactMetaData.json
@@ -5,7 +5,7 @@
 [
 {
     "name":             "LandingDistance",
-    "shortDesc":        "Distance between landing and approach points.",
+    "shortDesc":        "Distance between approach and land points.",
     "type":             "double",
     "units":            "m",
     "min":              10,


### PR DESCRIPTION
# MissionManager: Fix VTOL landing item crash

Description
-----------
Fixed an application crash when adding VTOL complex landing items caused by missing Fact metadata. Also updated the description of the VTOL LandingDistance Fact for consistency with the fixed-wing version.

Checklist:
----------
- [x] [Review Contribution Guidelines](https://github.com/mavlink/qgroundcontrol/blob/master/.github/CONTRIBUTING.md).
- [x] [Review Code of Conduct](https://github.com/mavlink/qgroundcontrol/blob/master/.github/CODE_OF_CONDUCT.md).
- [x] I have tested my changes.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.