### PR TITLE
 MissionManager: Fix landing approach item handling (Stable v5.0)

### DIFF
--- a/src/MissionManager/FixedWingLandingComplexItem.cc
+++ b/src/MissionManager/FixedWingLandingComplexItem.cc
@@ -173,8 +173,8 @@ void FixedWingLandingComplexItem::_updateFlightPathSegmentsDontCallDirectly(void
     _flightPathSegments.beginResetModel();
     _flightPathSegments.clearAndDeleteContents();
     if (useLoiterToAlt()->rawValue().toBool()) {
-        _appendFlightPathSegment(FlightPathSegment::SegmentTypeGeneric, finalApproachCoordinate(), amslEntryAlt(), loiterTangentCoordinate(),  amslEntryAlt()); // Best we can do to simulate loiter circle terrain profile
-        _appendFlightPathSegment(FlightPathSegment::SegmentTypeLand, loiterTangentCoordinate(), amslEntryAlt(), landingCoordinate(),        amslExitAlt());
+        _appendFlightPathSegment(FlightPathSegment::SegmentTypeGeneric, finalApproachCoordinate(), amslEntryAlt(), slopeStartCoordinate(),  amslEntryAlt()); // Best we can do to simulate loiter circle terrain profile
+        _appendFlightPathSegment(FlightPathSegment::SegmentTypeLand, slopeStartCoordinate(), amslEntryAlt(), landingCoordinate(),        amslExitAlt());
     } else {
         _appendFlightPathSegment(FlightPathSegment::SegmentTypeLand, finalApproachCoordinate(), amslEntryAlt(), landingCoordinate(),        amslExitAlt());
     }

--- a/src/MissionManager/LandingComplexItem.cc
+++ b/src/MissionManager/LandingComplexItem.cc
@@ -48,9 +48,10 @@ void LandingComplexItem::_init(void)
     connect(loiterRadius(),             &Fact::valueChanged,                                this, &LandingComplexItem::_recalcFromRadiusChange);
     connect(loiterClockwise(),          &Fact::rawValueChanged,                             this, &LandingComplexItem::_recalcFromRadiusChange);
 
+    connect(useLoiterToAlt(),           &Fact::rawValueChanged,                             this, &LandingComplexItem::_recalcFromApproachModeChange);
+
     connect(this,                       &LandingComplexItem::finalApproachCoordinateChanged,this, &LandingComplexItem::_recalcFromCoordinateChange);
     connect(this,                       &LandingComplexItem::landingCoordinateChanged,      this, &LandingComplexItem::_recalcFromCoordinateChange);
-    connect(useLoiterToAlt(),           &Fact::rawValueChanged,                             this, &LandingComplexItem::_recalcFromCoordinateChange);
 
     connect(finalApproachAltitude(),    &Fact::valueChanged,                                this, &LandingComplexItem::_setDirty);
     connect(useDoChangeSpeed(),         &Fact::valueChanged,                                this, &LandingComplexItem::_setDirty);
@@ -81,10 +82,10 @@ void LandingComplexItem::_init(void)
     connect(this,                       &LandingComplexItem::wizardModeChanged,             this, &LandingComplexItem::readyForSaveStateChanged);
 
     connect(this,                       &LandingComplexItem::finalApproachCoordinateChanged,this, &LandingComplexItem::complexDistanceChanged);
-    connect(this,                       &LandingComplexItem::loiterTangentCoordinateChanged,this, &LandingComplexItem::complexDistanceChanged);
+    connect(this,                       &LandingComplexItem::slopeStartCoordinateChanged,   this, &LandingComplexItem::complexDistanceChanged);
     connect(this,                       &LandingComplexItem::landingCoordinateChanged,      this, &LandingComplexItem::complexDistanceChanged);
 
-    connect(this,                       &LandingComplexItem::loiterTangentCoordinateChanged,this, &LandingComplexItem::_updateFlightPathSegmentsSignal);
+    connect(this,                       &LandingComplexItem::slopeStartCoordinateChanged,   this, &LandingComplexItem::_updateFlightPathSegmentsSignal);
     connect(this,                       &LandingComplexItem::finalApproachCoordinateChanged,this, &LandingComplexItem::_updateFlightPathSegmentsSignal);
     connect(this,                       &LandingComplexItem::landingCoordinateChanged,      this, &LandingComplexItem::_updateFlightPathSegmentsSignal);
     connect(finalApproachAltitude(),    &Fact::valueChanged,                                this, &LandingComplexItem::_updateFlightPathSegmentsSignal);
@@ -109,7 +110,7 @@ void LandingComplexItem::setLandingHeadingToTakeoffHeading()
 
 double LandingComplexItem::complexDistance(void) const
 {
-    return finalApproachCoordinate().distanceTo(loiterTangentCoordinate()) + loiterTangentCoordinate().distanceTo(landingCoordinate());
+    return finalApproachCoordinate().distanceTo(slopeStartCoordinate()) + slopeStartCoordinate().distanceTo(landingCoordinate());
 }
 
 void LandingComplexItem::setLandingCoordinate(const QGeoCoordinate& coordinate)
@@ -159,25 +160,30 @@ void LandingComplexItem::_recalcFromHeadingAndDistanceChange(void)
     //      distance
     //      radius
     // Adjusted:
-    //      loiter
-    //      loiter tangent
-    //      glide slope
+    //      final approach
+    //      slope start
 
     if (!_ignoreRecalcSignals && _landingCoordSet) {
         // These are our known values
-        double radius = loiterRadius()->rawValue().toDouble();
-        double landToTangentDistance = landingDistance()->rawValue().toDouble();
+        double distance = landingDistance()->rawValue().toDouble();
         double heading = landingHeading()->rawValue().toDouble();
 
-        // Heading is from loiter to land, hence +180
-        _loiterTangentCoordinate = _landingCoordinate.atDistanceAndAzimuth(landToTangentDistance, heading + 180);
+        // Heading is from slope start to land, hence +180
+        _slopeStartCoordinate = _landingCoordinate.atDistanceAndAzimuth(distance, heading + 180);
 
-        // Loiter coord is 90 degrees counter clockwise from tangent coord
-        _finalApproachCoordinate = _loiterTangentCoordinate.atDistanceAndAzimuth(radius, heading - 180 + (_loiterClockwise()->rawValue().toBool() ? -90 : 90));
+        if (useLoiterToAlt()->rawValue().toBool()) {
+            double radius = loiterRadius()->rawValue().toDouble();
+
+            // Loiter coord is 90 degrees counter clockwise from tangent coord
+            _finalApproachCoordinate = _slopeStartCoordinate.atDistanceAndAzimuth(radius, heading - 180 + (_loiterClockwise()->rawValue().toBool() ? -90 : 90));
+        } else {
+            _finalApproachCoordinate = _slopeStartCoordinate;
+        }
+
         _finalApproachCoordinate.setAltitude(finalApproachAltitude()->rawValue().toDouble());
 
         _ignoreRecalcSignals = true;
-        emit loiterTangentCoordinateChanged(_loiterTangentCoordinate);
+        emit slopeStartCoordinateChanged(_slopeStartCoordinate);
         emit finalApproachCoordinateChanged(_finalApproachCoordinate);
         emit coordinateChanged(_finalApproachCoordinate);
         _calcGlideSlope();
@@ -189,7 +195,7 @@ void LandingComplexItem::_recalcFromRadiusChange(void)
 {
     // Fixed:
     //      land
-    //      loiter tangent
+    //      slope start
     //      distance
     //      radius
     //      heading
@@ -199,22 +205,22 @@ void LandingComplexItem::_recalcFromRadiusChange(void)
     if (!_ignoreRecalcSignals) {
         // These are our known values
         double radius  = loiterRadius()->rawValue().toDouble();
-        double landToTangentDistance = landingDistance()->rawValue().toDouble();
+        double distance = landingDistance()->rawValue().toDouble();
         double heading = landingHeading()->rawValue().toDouble();
 
         double landToLoiterDistance = _landingCoordinate.distanceTo(_finalApproachCoordinate);
         if (landToLoiterDistance < radius) {
             // Degnenerate case: Move tangent to loiter point
-            _loiterTangentCoordinate = _finalApproachCoordinate;
+            _slopeStartCoordinate = _finalApproachCoordinate;
 
-            double heading = _landingCoordinate.azimuthTo(_loiterTangentCoordinate);
+            double heading = _landingCoordinate.azimuthTo(_slopeStartCoordinate);
 
             _ignoreRecalcSignals = true;
             landingHeading()->setRawValue(heading);
-            emit loiterTangentCoordinateChanged(_loiterTangentCoordinate);
+            emit slopeStartCoordinateChanged(_slopeStartCoordinate);
             _ignoreRecalcSignals = false;
         } else {
-            double landToLoiterDistance = qSqrt(qPow(radius, 2) + qPow(landToTangentDistance, 2));
+            double landToLoiterDistance = qSqrt(qPow(radius, 2) + qPow(distance, 2));
             double angleLoiterToTangent = qRadiansToDegrees(qAsin(radius/landToLoiterDistance)) * (_loiterClockwise()->rawValue().toBool() ? -1 : 1);
 
             _finalApproachCoordinate = _landingCoordinate.atDistanceAndAzimuth(landToLoiterDistance, heading + 180 + angleLoiterToTangent);
@@ -228,43 +234,80 @@ void LandingComplexItem::_recalcFromRadiusChange(void)
     }
 }
 
+void LandingComplexItem::_recalcFromApproachModeChange(void)
+{
+    // Fixed:
+    //      land
+    //      slope start
+    //      heading
+    //      distance
+    // Adjusted:
+    //      final approach
+
+    if (!_ignoreRecalcSignals && _landingCoordSet) {
+        if (useLoiterToAlt()->rawValue().toBool()) {
+            double radius = loiterRadius()->rawValue().toDouble();
+            double offsetAngle =
+                landingHeading()->rawValue().toDouble() - 180 +
+                (_loiterClockwise()->rawValue().toBool() ? -90 : 90);
+
+            _finalApproachCoordinate =
+                _slopeStartCoordinate.atDistanceAndAzimuth(radius, offsetAngle);
+        } else {
+            _finalApproachCoordinate = _slopeStartCoordinate;
+        }
+
+        _finalApproachCoordinate.setAltitude(finalApproachAltitude()->rawValue().toDouble());
+
+        _ignoreRecalcSignals = true;
+        emit finalApproachCoordinateChanged(_finalApproachCoordinate);
+        emit coordinateChanged(_finalApproachCoordinate);
+        _calcGlideSlope();
+        _ignoreRecalcSignals = false;
+    }
+}
+
 void LandingComplexItem::_recalcFromCoordinateChange(void)
 {
     // Fixed:
     //      land
-    //      loiter
+    //      final approach
     //      radius
     // Adjusted:
-    //      loiter tangent
     //      heading
     //      distance
-    //      glide slope
+    //      slope start
 
     if (!_ignoreRecalcSignals && _landingCoordSet) {
-        // These are our known values
-        double radius = loiterRadius()->rawValue().toDouble();
-        double landToLoiterDistance = _landingCoordinate.distanceTo(_finalApproachCoordinate);
-        double landToLoiterHeading = _landingCoordinate.azimuthTo(_finalApproachCoordinate);
+        double distance;
 
-        double landToTangentDistance;
-        if (landToLoiterDistance < radius) {
-            // Degenerate case, set tangent to loiter coordinate
-            _loiterTangentCoordinate = _finalApproachCoordinate;
-            landToTangentDistance = _landingCoordinate.distanceTo(_loiterTangentCoordinate);
+        if (useLoiterToAlt()->rawValue().toBool()) {
+            // These are our known values
+            double radius = loiterRadius()->rawValue().toDouble();
+            double landToLoiterDistance = _landingCoordinate.distanceTo(_finalApproachCoordinate);
+            double landToLoiterHeading = _landingCoordinate.azimuthTo(_finalApproachCoordinate);
+
+            if (landToLoiterDistance < radius) {
+                // Degenerate case: tangent at loiter coordinate
+                _slopeStartCoordinate = _finalApproachCoordinate;
+                distance = _landingCoordinate.distanceTo(_slopeStartCoordinate);
+            } else {
+                // Calculate tangent point using circle geometry
+                double loiterToTangentAngle = qRadiansToDegrees(qAsin(radius/landToLoiterDistance)) * (_loiterClockwise()->rawValue().toBool() ? 1 : -1);
+                distance = qSqrt(qPow(landToLoiterDistance, 2) - qPow(radius, 2));
+                _slopeStartCoordinate = _landingCoordinate.atDistanceAndAzimuth(distance, landToLoiterHeading + loiterToTangentAngle);
+            }
         } else {
-            double loiterToTangentAngle = qRadiansToDegrees(qAsin(radius/landToLoiterDistance)) * (_loiterClockwise()->rawValue().toBool() ? 1 : -1);
-            landToTangentDistance = qSqrt(qPow(landToLoiterDistance, 2) - qPow(radius, 2));
-
-            _loiterTangentCoordinate = _landingCoordinate.atDistanceAndAzimuth(landToTangentDistance, landToLoiterHeading + loiterToTangentAngle);
-
+            _slopeStartCoordinate = _finalApproachCoordinate;
+            distance = _landingCoordinate.distanceTo(_slopeStartCoordinate);
         }
 
-        double heading = _loiterTangentCoordinate.azimuthTo(_landingCoordinate);
+        double heading = _slopeStartCoordinate.azimuthTo(_landingCoordinate);
 
         _ignoreRecalcSignals = true;
         landingHeading()->setRawValue(heading);
-        landingDistance()->setRawValue(landToTangentDistance);
-        emit loiterTangentCoordinateChanged(_loiterTangentCoordinate);
+        landingDistance()->setRawValue(distance);
+        emit slopeStartCoordinateChanged(_slopeStartCoordinate);
         _calcGlideSlope();
         _ignoreRecalcSignals = false;
     }

--- a/src/MissionManager/LandingComplexItem.h
+++ b/src/MissionManager/LandingComplexItem.h
@@ -42,7 +42,7 @@ public:
     Q_PROPERTY(Fact*            stopTakingPhotos        READ    stopTakingPhotos                                                CONSTANT)
     Q_PROPERTY(Fact*            stopTakingVideo         READ    stopTakingVideo                                                 CONSTANT)
     Q_PROPERTY(QGeoCoordinate   finalApproachCoordinate READ    finalApproachCoordinate     WRITE setFinalApproachCoordinate    NOTIFY finalApproachCoordinateChanged)
-    Q_PROPERTY(QGeoCoordinate   loiterTangentCoordinate READ    loiterTangentCoordinate                                         NOTIFY loiterTangentCoordinateChanged)
+    Q_PROPERTY(QGeoCoordinate   slopeStartCoordinate    READ    slopeStartCoordinate                                            NOTIFY slopeStartCoordinateChanged)
     Q_PROPERTY(QGeoCoordinate   landingCoordinate       READ    landingCoordinate           WRITE setLandingCoordinate          NOTIFY landingCoordinateChanged)
     Q_PROPERTY(bool             altitudesAreRelative    READ    altitudesAreRelative        WRITE setAltitudesAreRelative       NOTIFY altitudesAreRelativeChanged)
     Q_PROPERTY(bool             landingCoordSet         READ    landingCoordSet                                                 NOTIFY landingCoordSetChanged)
@@ -77,7 +77,7 @@ public:
     bool            landingCoordSet         (void) const { return _landingCoordSet; }
     QGeoCoordinate  landingCoordinate       (void) const { return _landingCoordinate; }
     QGeoCoordinate  finalApproachCoordinate (void) const { return _finalApproachCoordinate; }
-    QGeoCoordinate  loiterTangentCoordinate (void) const { return _loiterTangentCoordinate; }
+    QGeoCoordinate  slopeStartCoordinate    (void) const { return _slopeStartCoordinate; }
 
     void setLandingCoordinate       (const QGeoCoordinate& coordinate);
     void setFinalApproachCoordinate (const QGeoCoordinate& coordinate);
@@ -131,7 +131,7 @@ public:
 
 signals:
     void finalApproachCoordinateChanged (QGeoCoordinate coordinate);
-    void loiterTangentCoordinateChanged (QGeoCoordinate coordinate);
+    void slopeStartCoordinateChanged    (QGeoCoordinate coordinate);
     void landingCoordinateChanged       (QGeoCoordinate coordinate);
     void landingCoordSetChanged         (bool landingCoordSet);
     void altitudesAreRelativeChanged    (bool altitudesAreRelative);
@@ -176,7 +176,7 @@ protected:
     int             _sequenceNumber             = 0;
     bool            _dirty                      = false;
     QGeoCoordinate  _finalApproachCoordinate;
-    QGeoCoordinate  _loiterTangentCoordinate;
+    QGeoCoordinate  _slopeStartCoordinate;
     QGeoCoordinate  _landingCoordinate;
     bool            _landingCoordSet            = false;
     bool            _ignoreRecalcSignals        = false;
@@ -204,9 +204,10 @@ protected:
 
 private slots:
     void    _recalcFromRadiusChange                         (void);
+    void    _recalcFromApproachModeChange                   (void);
     void    _signalLastSequenceNumberChanged                (void);
     void    _updateFinalApproachCoodinateAltitudeFromFact   (void);
-    void    _updateLandingCoodinateAltitudeFromFact     (void);
+    void    _updateLandingCoodinateAltitudeFromFact         (void);
 
     friend class LandingComplexItemTest;
 };

--- a/src/MissionManager/VTOLLandingComplexItem.cc
+++ b/src/MissionManager/VTOLLandingComplexItem.cc
@@ -143,8 +143,8 @@ void VTOLLandingComplexItem::_updateFlightPathSegmentsDontCallDirectly(void)
     _flightPathSegments.beginResetModel();
     _flightPathSegments.clearAndDeleteContents();
     if (useLoiterToAlt()->rawValue().toBool()) {
-        _appendFlightPathSegment(FlightPathSegment::SegmentTypeGeneric, finalApproachCoordinate(), amslEntryAlt(), loiterTangentCoordinate(),  amslEntryAlt()); // Best we can do to simulate loiter circle terrain profile
-        _appendFlightPathSegment(FlightPathSegment::SegmentTypeGeneric, loiterTangentCoordinate(), amslEntryAlt(), landingCoordinate(),        amslEntryAlt());
+        _appendFlightPathSegment(FlightPathSegment::SegmentTypeGeneric, finalApproachCoordinate(), amslEntryAlt(), slopeStartCoordinate(),  amslEntryAlt()); // Best we can do to simulate loiter circle terrain profile
+        _appendFlightPathSegment(FlightPathSegment::SegmentTypeGeneric, slopeStartCoordinate(), amslEntryAlt(), landingCoordinate(),        amslEntryAlt());
     } else {
         _appendFlightPathSegment(FlightPathSegment::SegmentTypeGeneric, finalApproachCoordinate(), amslEntryAlt(), landingCoordinate(),        amslEntryAlt());
     }

--- a/src/QmlControls/FWLandingPatternEditor.qml
+++ b/src/QmlControls/FWLandingPatternEditor.qml
@@ -41,7 +41,7 @@ Rectangle {
     property string _setToVehicleLocationStr:   qsTr("Set to vehicle location")
     property bool   _showCameraSection:         !_missionVehicle.apmFirmware
     property int    _altitudeMode:              missionItem.altitudesAreRelative ? QGroundControl.AltitudeModeRelative : QGroundControl.AltitudeModeAbsolute
-    property real   _previousLoiterRadius:      0
+
 
     Column {
         id:                 editorColumn
@@ -69,22 +69,6 @@ Rectangle {
             FactCheckBox {
                 text:       qsTr("Use loiter to altitude")
                 fact:       missionItem.useLoiterToAlt
-
-                // When not using loiter to altitude, set radius to 0 to set the
-                // glide slope heading correctly
-                onCheckedChanged: {
-                    if (checked) {
-                        // Restore the previous loiter radius or set the default value
-                        if (_previousLoiterRadius > 0) {
-                            missionItem.loiterRadius.rawValue = _previousLoiterRadius
-                        } else {
-                            missionItem.loiterRadius.rawValue = missionItem.loiterRadius.defaultValue
-                        }
-                    } else {
-                        _previousLoiterRadius = missionItem.loiterRadius.rawValue
-                        missionItem.loiterRadius.rawValue = 0
-                    }
-                }
             }
 
             GridLayout {

--- a/src/QmlControls/FWLandingPatternEditor.qml
+++ b/src/QmlControls/FWLandingPatternEditor.qml
@@ -41,7 +41,7 @@ Rectangle {
     property string _setToVehicleLocationStr:   qsTr("Set to vehicle location")
     property bool   _showCameraSection:         !_missionVehicle.apmFirmware
     property int    _altitudeMode:              missionItem.altitudesAreRelative ? QGroundControl.AltitudeModeRelative : QGroundControl.AltitudeModeAbsolute
-    property real   _previousLoiterRadius:      missionItem.loiterRadius.rawValue
+    property real   _previousLoiterRadius:      0
 
     Column {
         id:                 editorColumn
@@ -70,18 +70,16 @@ Rectangle {
                 text:       qsTr("Use loiter to altitude")
                 fact:       missionItem.useLoiterToAlt
 
-                Component.onCompleted: {
-                    if (!missionItem.useLoiterToAlt.rawValue) {
-                        _previousLoiterRadius = missionItem.loiterRadius.defaultValue
-                    }
-                }
-
                 // When not using loiter to altitude, set radius to 0 to set the
                 // glide slope heading correctly
                 onCheckedChanged: {
                     if (checked) {
-                        // Restore the previous loiter radius
-                        missionItem.loiterRadius.rawValue = _previousLoiterRadius
+                        // Restore the previous loiter radius or set the default value
+                        if (_previousLoiterRadius > 0) {
+                            missionItem.loiterRadius.rawValue = _previousLoiterRadius
+                        } else {
+                            missionItem.loiterRadius.rawValue = missionItem.loiterRadius.defaultValue
+                        }
                     } else {
                         _previousLoiterRadius = missionItem.loiterRadius.rawValue
                         missionItem.loiterRadius.rawValue = 0

--- a/src/QmlControls/FWLandingPatternMapVisual.qml
+++ b/src/QmlControls/FWLandingPatternMapVisual.qml
@@ -43,12 +43,12 @@ Item {
     property real   _landingAltitudeMeters:         _missionItem.landingAltitude.rawValue
     property real   _finalApproachAltitudeMeters:   _missionItem.finalApproachAltitude.rawValue
     property bool   _useLoiterToAlt:                _missionItem.useLoiterToAlt.rawValue
-    property real   _landingAreaBearing:            _missionItem.landingCoordinate.azimuthTo(_useLoiterToAlt ? _missionItem.loiterTangentCoordinate : _missionItem.finalApproachCoordinate)
+    property real   _landingAreaBearing:            _missionItem.landingCoordinate.azimuthTo(_missionItem.slopeStartCoordinate)
 
     function _calcGlideSlopeHeights() {
         var adjacent
         if (_useLoiterToAlt) {
-            adjacent = _missionItem.landingCoordinate.distanceTo(_missionItem.loiterTangentCoordinate)
+            adjacent = _missionItem.landingCoordinate.distanceTo(_missionItem.slopeStartCoordinate)
         } else {
             adjacent = _missionItem.landingCoordinate.distanceTo(_missionItem.finalApproachCoordinate)
         }
@@ -106,7 +106,7 @@ Item {
 
     function _setFlightPath() {
         if (_useLoiterToAlt) {
-            _flightPath = [ _missionItem.loiterTangentCoordinate, _missionItem.landingCoordinate ]
+            _flightPath = [ _missionItem.slopeStartCoordinate, _missionItem.landingCoordinate ]
         } else {
             _flightPath = [ _missionItem.finalApproachCoordinate, _missionItem.landingCoordinate ]
         }
@@ -177,7 +177,7 @@ Item {
             _setFlightPath()
         }
 
-        onLoiterTangentCoordinateChanged: {
+        onSlopeStartCoordinateChanged: {
             _calcGlideSlopeHeights()
             _setFlightPath()
         }
@@ -400,7 +400,7 @@ Item {
             Connections {
                 target:                             _missionItem
                 onLandingCoordinateChanged:         recalc()
-                onLoiterTangentCoordinateChanged:   recalc()
+                onSlopeStartCoordinateChanged:      recalc()
                 onFinalApproachCoordinateChanged:   recalc()
             }
         }
@@ -433,7 +433,7 @@ Item {
             Connections {
                 target:                             _missionItem
                 onLandingCoordinateChanged:         recalc()
-                onLoiterTangentCoordinateChanged:   recalc()
+                onSlopeStartCoordinateChanged:      recalc()
                 onFinalApproachCoordinateChanged:   recalc()
             }
         }
@@ -457,7 +457,7 @@ Item {
                 path = [ ]
                 addCoordinate(_missionItem.landingCoordinate.atDistanceAndAzimuth(hypotenuse, _landingAreaBearing - angleDegrees))
                 addCoordinate(_missionItem.landingCoordinate.atDistanceAndAzimuth(hypotenuse, _landingAreaBearing + angleDegrees))
-                addCoordinate(_useLoiterToAlt ? _missionItem.loiterTangentCoordinate : _missionItem.finalApproachCoordinate)
+                addCoordinate(_useLoiterToAlt ? _missionItem.slopeStartCoordinate : _missionItem.finalApproachCoordinate)
             }
 
             Component.onCompleted: recalc()
@@ -465,7 +465,7 @@ Item {
             Connections {
                 target:                             _missionItem
                 onLandingCoordinateChanged:         recalc()
-                onLoiterTangentCoordinateChanged:   recalc()
+                onSlopeStartCoordinateChanged:      recalc()
                 onFinalApproachCoordinateChanged:   recalc()
             }
 
@@ -502,7 +502,7 @@ Item {
             Connections {
                 target:                             _missionItem
                 onLandingCoordinateChanged:         recalc()
-                onLoiterTangentCoordinateChanged:   recalc()
+                onSlopeStartCoordinateChanged:      recalc()
                 onFinalApproachCoordinateChanged:   recalc()
             }
         }
@@ -525,7 +525,7 @@ Item {
 
             function recalc() {
                 var transitionCoordinate = _missionItem.landingCoordinate.atDistanceAndAzimuth(_landingLengthMeters / 2, _landingAreaBearing)
-                var halfDistance = transitionCoordinate.distanceTo(_useLoiterToAlt ? _missionItem.loiterTangentCoordinate : _missionItem.finalApproachCoordinate) / 2
+                var halfDistance = transitionCoordinate.distanceTo(_useLoiterToAlt ? _missionItem.slopeStartCoordinate : _missionItem.finalApproachCoordinate) / 2
                 var centeredCoordinate = transitionCoordinate.atDistanceAndAzimuth(halfDistance, _landingAreaBearing)
                 var angleIncrement = _landingAreaBearing > 180 ? -90 : 90
                 coordinate = centeredCoordinate.atDistanceAndAzimuth(_landingWidthMeters / 2, _landingAreaBearing + angleIncrement)
@@ -536,7 +536,7 @@ Item {
             Connections {
                 target:                             _missionItem
                 onLandingCoordinateChanged:         recalc()
-                onLoiterTangentCoordinateChanged:   recalc()
+                onSlopeStartCoordinateChanged:      recalc()
                 onFinalApproachCoordinateChanged:   recalc()
             }
 
@@ -555,7 +555,7 @@ Item {
             anchorPoint.y:  0
             z:              QGroundControl.zOrderMapItems
             visible:        _missionItem.isCurrentItem
-            coordinate:     _useLoiterToAlt ? _missionItem.loiterTangentCoordinate : _missionItem.finalApproachCoordinate
+            coordinate:     _missionItem.slopeStartCoordinate
 
             sourceItem: HeightIndicator {
                 map:        _root.map

--- a/src/QmlControls/VTOLLandingPatternMapVisual.qml
+++ b/src/QmlControls/VTOLLandingPatternMapVisual.qml
@@ -36,7 +36,7 @@ Item {
     property var    _loiterPointObject
     property var    _landingPointObject
     property bool   _useLoiterToAlt:            _missionItem.useLoiterToAlt.rawValue
-    property real   _landingAreaBearing:            _missionItem.landingCoordinate.azimuthTo(_useLoiterToAlt ? _missionItem.loiterTangentCoordinate : _missionItem.finalApproachCoordinate)
+    property real   _landingAreaBearing:        _missionItem.landingCoordinate.azimuthTo(_missionItem.slopeStartCoordinate)
 
     function hideItemVisuals() {
         objMgr.destroyObjects()
@@ -81,7 +81,7 @@ Item {
 
     function _setFlightPath() {
         if (_useLoiterToAlt) {
-            _flightPath = [ _missionItem.loiterTangentCoordinate, _missionItem.landingCoordinate ]
+            _flightPath = [ _missionItem.slopeStartCoordinate, _missionItem.landingCoordinate ]
         } else {
             _flightPath = [ _missionItem.finalApproachCoordinate, _missionItem.landingCoordinate ]
         }
@@ -146,7 +146,7 @@ Item {
         }
 
         onLandingCoordinateChanged:         _setFlightPath()
-        onLoiterTangentCoordinateChanged:   _setFlightPath()
+        onSlopeStartCoordinateChanged:      _setFlightPath()
         onFinalApproachCoordinateChanged:   _setFlightPath()
     }
 

--- a/test/MissionManager/LandingComplexItemTest.cc
+++ b/test/MissionManager/LandingComplexItemTest.cc
@@ -23,7 +23,7 @@ const char* SimpleLandingComplexItem::jsonComplexItemTypeValue  = "utSimpleLandi
 LandingComplexItemTest::LandingComplexItemTest(void)
 {    
     rgSignals[finalApproachCoordinateChangedIndex]  = SIGNAL(finalApproachCoordinateChanged(QGeoCoordinate));
-    rgSignals[loiterTangentCoordinateChangedIndex]  = SIGNAL(loiterTangentCoordinateChanged(QGeoCoordinate));
+    rgSignals[slopeStartCoordinateChangedIndex]     = SIGNAL(slopeStartCoordinateChanged(QGeoCoordinate));
     rgSignals[landingCoordinateChangedIndex]        = SIGNAL(landingCoordinateChanged(QGeoCoordinate));
     rgSignals[landingCoordSetChangedIndex]          = SIGNAL(landingCoordSetChanged(bool));
     rgSignals[altitudesAreRelativeChangedIndex]     = SIGNAL(altitudesAreRelativeChanged(bool));
@@ -333,7 +333,7 @@ void LandingComplexItemTest::_validateItem(LandingComplexItem* actualItem, Landi
     QVERIFY(fuzzyCompareLatLon(actualItem->finalApproachCoordinate(),   expectedItem->finalApproachCoordinate()));
     QVERIFY(fuzzyCompareLatLon(actualItem->landingCoordinate(),         expectedItem->landingCoordinate()));
     if (actualItem->useLoiterToAlt()->rawValue().toBool()) {
-        QVERIFY(fuzzyCompareLatLon(actualItem->loiterTangentCoordinate(), expectedItem->loiterTangentCoordinate()));
+        QVERIFY(fuzzyCompareLatLon(actualItem->slopeStartCoordinate(),  expectedItem->slopeStartCoordinate()));
         QCOMPARE(actualItem->loiterRadius()->rawValue().toInt(),        expectedItem->loiterRadius()->rawValue().toInt());
         QCOMPARE(actualItem->loiterClockwise()->rawValue().toBool(),    expectedItem->loiterClockwise()->rawValue().toBool());
     }
@@ -398,8 +398,8 @@ void SimpleLandingComplexItem::_updateFlightPathSegmentsDontCallDirectly(void)
     _flightPathSegments.beginResetModel();
     _flightPathSegments.clearAndDeleteContents();
     if (useLoiterToAlt()->rawValue().toBool()) {
-        _appendFlightPathSegment(FlightPathSegment::SegmentTypeGeneric, finalApproachCoordinate(), amslEntryAlt(), loiterTangentCoordinate(),  amslEntryAlt()); // Best we can do to simulate loiter circle terrain profile
-        _appendFlightPathSegment(FlightPathSegment::SegmentTypeLand, loiterTangentCoordinate(), amslEntryAlt(), landingCoordinate(),        amslExitAlt());
+        _appendFlightPathSegment(FlightPathSegment::SegmentTypeGeneric, finalApproachCoordinate(), amslEntryAlt(), slopeStartCoordinate(),  amslEntryAlt()); // Best we can do to simulate loiter circle terrain profile
+        _appendFlightPathSegment(FlightPathSegment::SegmentTypeLand, slopeStartCoordinate(), amslEntryAlt(), landingCoordinate(),        amslExitAlt());
     } else {
         _appendFlightPathSegment(FlightPathSegment::SegmentTypeLand, finalApproachCoordinate(), amslEntryAlt(), landingCoordinate(),        amslExitAlt());
     }

--- a/test/MissionManager/LandingComplexItemTest.h
+++ b/test/MissionManager/LandingComplexItemTest.h
@@ -38,7 +38,7 @@ private:
 
     enum {
         finalApproachCoordinateChangedIndex = 0,
-        loiterTangentCoordinateChangedIndex,
+        slopeStartCoordinateChangedIndex,
         landingCoordinateChangedIndex,
         landingCoordSetChangedIndex,
         altitudesAreRelativeChangedIndex,
@@ -48,7 +48,7 @@ private:
 
     enum {
         finalApproachCoordinateChangedMask      = 1 << finalApproachCoordinateChangedIndex,
-        loiterTangentCoordinateChangedMask      = 1 << loiterTangentCoordinateChangedIndex,
+        slopeStartCoordinateChangedMask         = 1 << slopeStartCoordinateChangedIndex,
         landingCoordinateChangedMask            = 1 << landingCoordinateChangedIndex,
         landingCoordSetChangedMask              = 1 << landingCoordSetChangedIndex,
         altitudesAreRelativeChangedMask         = 1 << altitudesAreRelativeChangedIndex,


### PR DESCRIPTION
# MissionManager: Fix landing approach item handling

Description
-----------
Updated the LandingComplexItem recalculation logic to properly handle waypoint approach items, fixing several issues with heading calculations and when loading plans, such as the loiter radius being taken into account despite the "Use loiter to altitude" option being disabled. Refactored the relevant areas to unify the naming and logic between waypoint and loiter-based approaches.

This replaces previous GUI-level workarounds (https://github.com/mavlink/qgroundcontrol/commit/ddd97adb7c4485a78faca0e4d4313c58e88dd366, https://github.com/mavlink/qgroundcontrol/commit/e0f6a0ad46a5f6f6e665cdac33fdcaa7bbfef2d7) that partially fixed these heading calculation problems by manipulating the loiter radius. This commit addresses the root cause instead, so it also fixes the issues for VTOL landing sequences, where the GUI workarounds hadn't yet been applied.

Key changes:
- Reverted the now obsolete GUI hacks.
- Updated the coordinate recalculation logic to handle waypoint and loiter approaches as distinct modes, rather than forcing the waypoint approach through the loiter-based architecture.
- Added _recalcFromApproachModeChange method to properly handle switching between loiter and waypoint approach items, instead of using the generic coordinate change handler.
- Renamed "loiter tangent" to "slope start".
- Updated all UI components to remove some explicit approach item-dependant logic which is no longer needed, and to use the new naming.

Checklist:
----------
- [x] [Review Contribution Guidelines](https://github.com/mavlink/qgroundcontrol/blob/master/.github/CONTRIBUTING.md).
- [x] [Review Code of Conduct](https://github.com/mavlink/qgroundcontrol/blob/master/.github/CODE_OF_CONDUCT.md).
- [x] I have tested my changes.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.