### PR TITLE
Radio config: Fix sizing for Herelink sized screens

### DIFF
--- a/src/AutoPilotPlugins/Common/RadioComponent.qml
+++ b/src/AutoPilotPlugins/Common/RadioComponent.qml
@@ -349,12 +349,10 @@ SetupPage {
 
                 QGCLabel { text: qsTr("Additional Radio setup:") }
 
-                GridLayout {
+                ColumnLayout {
                     id:                 switchSettingsGrid
                     anchors.left:       parent.left
                     anchors.right:      parent.right
-                    columns:            2
-                    columnSpacing:      ScreenTools.defaultFontPixelWidth
 
                     Repeater {
                         model: QGroundControl.multiVehicleManager.activeVehicle.px4Firmware ?
@@ -363,20 +361,10 @@ SetupPage {
                                         [ "RC_MAP_FLAPS", "RC_MAP_AUX1", "RC_MAP_AUX2", "RC_MAP_PARAM1", "RC_MAP_PARAM2", "RC_MAP_PARAM3"]) :
                                    0
 
-                        RowLayout {
-                            Layout.fillWidth: true
-
-                            property Fact fact: controller.getParameterFact(-1, modelData)
-
-                            QGCLabel {
-                                Layout.fillWidth:   true
-                                text:               fact.shortDescription
-                            }
-                            FactComboBox {
-                                width:      ScreenTools.defaultFontPixelWidth * 15
-                                fact:       parent.fact
-                                indexModel: false
-                            }
+                        LabelledFactComboBox {
+                            label:               fact.shortDescription
+                            fact:                controller.getParameterFact(-1, modelData)
+                            indexModel:          false
                         }
                     }
                 }


### PR DESCRIPTION
* This makes it fit on small screens like Herelink
* Tried supporting dynamic single/double columns based on size but too complicated
* Still clips on Herelink but at least usable

Before:
![Screenshot 2025-06-23 at 11 59 34 AM](https://github.com/user-attachments/assets/7d617ad6-a067-4add-8172-6fa52b05602b)

After:
![Screenshot 2025-06-23 at 11 58 56 AM](https://github.com/user-attachments/assets/c93654f4-65f8-4608-ae1c-063e7417ed4e)
