### PR TITLE
Fix Mavlink Inspector crash

### DIFF
--- a/src/QmlControls/MAVLinkChart.qml
+++ b/src/QmlControls/MAVLinkChart.qml
@@ -48,6 +48,16 @@ ChartView {
         }
     }
 
+    Connections {
+        target: QGroundControl.multiVehicleManager
+
+        function onVehicleRemoved(vehicle) {
+            // Hack to prevent references to deleted QGCMavlinkSystem fields. https://github.com/mavlink/qgroundcontrol/issues/13077
+            controller.deleteChart(chartController);
+            chartController = null;
+        }
+    }
+
     DateTimeAxis {
         id:                         axisX
         min:                        chartController ? chartController.rangeXMin : new Date()


### PR DESCRIPTION
* Hack fix for #13077
* In reality this code is majorly screwed up with respect to vehicle coming/going. It leaves references to deleted QGCMavlinkSystem objects. Will have to deal with this fully later.