### PR TITLE
src: AutoPilotPlugins: APMSensorIdDecoder.qml: update baro types

### DIFF
--- a/src/AutoPilotPlugins/APM/APMSensorIdDecoder.qml
+++ b/src/AutoPilotPlugins/APM/APMSensorIdDecoder.qml
@@ -116,10 +116,13 @@ QGCLabel {
         0x0F: 'ICP101XX',
         0x10: 'ICP201XX',
         0x11: 'MS5607',
-        0x12: 'MS5837',
+        0x12: 'MS5837_30BA',
         0x13: 'MS5637',
         0x14: 'BMP390',
-        0x15: 'BMP581'
+        0x15: 'BMP581',
+        0x16: 'SPA06',
+        0x17: 'AUAV',
+        0x18: 'MS5837_02BA'
     }
 
     property var airspeedTypes: {


### PR DESCRIPTION
<!--- Title -->

Description
-----------
<!--- Describe your changes in detail. -->
Updates QGC to recognise the latest supported ArduPilot barometer types, including an updated name for the MS5837 type, which has recently been split into recognising multiple variants.

Test Steps
-----------
<!-- Describe the steps to reproduce. -->
Connect a newly supported barometer type to an ArduPilot autopilot, and see whether QGC reports it correctly.

Checklist:
----------
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] [Review Contribution Guidelines](https://github.com/mavlink/qgroundcontrol/blob/master/.github/CONTRIBUTING.md).
- [x] [Review Code of Conduct](https://github.com/mavlink/qgroundcontrol/blob/master/.github/CODE_OF_CONDUCT.md).
- [ ] I have tested my changes.
    - I haven't built QGC in ages, and given this is just an enum update I don't think it's worth setting up the build system for it

Context
--------
Triggered by [this PR review comment](https://github.com/ArduPilot/ardupilot/pull/29122#issuecomment-3006739987).


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.