### PR TITLE
Camera: try to make discovery more robust

### DIFF
--- a/src/Camera/QGCCameraManager.cc
+++ b/src/Camera/QGCCameraManager.cc
@@ -97,7 +97,8 @@ void QGCCameraManager::_vehicleReady(bool ready)
 
 void QGCCameraManager::_mavlinkMessageReceived(const mavlink_message_t& message)
 {
-    //-- Only pay attention to camera components, as identified by their compId
+    //-- Only pay attention to the camera components, as identified by their compId,
+    //   as well as the autopilot, as it might have a non-MAVLink camera connected.
     if(message.sysid == _vehicle->id() && (message.compid == MAV_COMP_ID_AUTOPILOT1 ||
         (message.compid >= MAV_COMP_ID_CAMERA && message.compid <= MAV_COMP_ID_CAMERA6))) {
         switch (message.msgid) {

--- a/src/Camera/QGCCameraManager.cc
+++ b/src/Camera/QGCCameraManager.cc
@@ -157,6 +157,17 @@ void QGCCameraManager::_handleHeartbeat(const mavlink_message_t &message)
             if (pInfo->infoReceived) {
                 //-- We have it. Just update the heartbeat timeout
                 pInfo->lastHeartbeat.start();
+            } else {
+                //-- Camera info not received yet. Check if camera was silent and is now back
+                if (pInfo->lastHeartbeat.elapsed() > 5000) {
+                    qCDebug(CameraManagerLog) << "Camera" << message.compid << "reappeared after being silent. Resetting retry count and requesting info.";
+                    pInfo->retryCount = 0;  // Reset retry count for fresh attempts
+                    pInfo->lastHeartbeat.start();
+                    _requestCameraInfo(pInfo);
+                } else {
+                    //-- Just update heartbeat
+                    pInfo->lastHeartbeat.start();
+                }
             }
         } else {
             qWarning() << Q_FUNC_INFO << "_cameraInfoRequest[" << sCompID << "] is null";

--- a/src/Camera/QGCCameraManager.h
+++ b/src/Camera/QGCCameraManager.h
@@ -65,6 +65,7 @@ public:
         bool        infoReceived    = false;
         uint8_t     compID          = 0;
         Vehicle*    vehicle         = nullptr;
+        int         retryCount      = 0;
     };
 
 signals:

--- a/src/Camera/QGCCameraManager.h
+++ b/src/Camera/QGCCameraManager.h
@@ -69,6 +69,7 @@ public:
         uint8_t     compID          = 0;
         Vehicle*    vehicle         = nullptr;
         int         retryCount      = 0;
+        QTimer*     backoffTimer    = nullptr;
     };
 
 signals:

--- a/src/Camera/QGCCameraManager.h
+++ b/src/Camera/QGCCameraManager.h
@@ -57,6 +57,9 @@ public:
     /// Returns a list of CameraMetaData objects for available cameras on the vehicle.
     virtual const QVariantList &cameraList();
 
+    // Helper method for static functions to access vehicle
+    Vehicle* vehicle() const { return _vehicle; }
+
     // This is public to avoid some circular include problems caused by statics
     class CameraStruct : public QObject {
     public:

--- a/src/Camera/VehicleCameraControl.cc
+++ b/src/Camera/VehicleCameraControl.cc
@@ -165,6 +165,14 @@ VehicleCameraControl::VehicleCameraControl(const mavlink_camera_information_t *i
 //-----------------------------------------------------------------------------
 VehicleCameraControl::~VehicleCameraControl()
 {
+    // Stop all timers to prevent them from firing during or after destruction
+    _captureStatusTimer.stop();
+    _recTimer.stop();
+    _streamInfoTimer.stop();
+    _streamStatusTimer.stop();
+    _cameraSettingsTimer.stop();
+    _storageInfoTimer.stop();
+
     delete _netManager;
     _netManager = nullptr;
 }

--- a/src/Camera/VehicleCameraControl.h
+++ b/src/Camera/VehicleCameraControl.h
@@ -232,6 +232,8 @@ protected slots:
     virtual void    _paramDone              ();
     virtual void    _streamInfoTimeout      ();
     virtual void    _streamStatusTimeout    ();
+    virtual void    _cameraSettingsTimeout  ();
+    virtual void    _storageInfoTimeout     ();
     virtual void    _recTimerHandler        ();
     virtual void    _checkForVideoStreams   ();
 
@@ -306,6 +308,8 @@ protected:
     int                                 _expectedCount      = 1;
     QTimer                              _streamInfoTimer;
     QTimer                              _streamStatusTimer;
+    QTimer                              _cameraSettingsTimer;
+    QTimer                              _storageInfoTimer;
     QmlObjectListModel                  _streams;
     QStringList                         _streamLabels;
     ThermalViewMode                     _thermalMode        = THERMAL_BLEND;

--- a/src/Vehicle/Vehicle.cc
+++ b/src/Vehicle/Vehicle.cc
@@ -381,9 +381,7 @@ Vehicle::~Vehicle()
 
 void Vehicle::prepareDelete()
 {
-#if 0
-    // I believe this should no longer be needed with new PhtoVideoControl implmenentation.
-    // Leaving in for now, just in case it need to come back.
+    // Clean up camera manager to stop all timers and prevent crashes during destruction
     if(_cameraManager) {
         // because of _cameraManager QML bindings check for nullptr won't work in the binding pipeline
         // the dangling pointer access will cause a runtime fault
@@ -391,9 +389,8 @@ void Vehicle::prepareDelete()
         _cameraManager = nullptr;
         delete tmpCameras;
         emit cameraManagerChanged();
-        qApp->processEvents();
+        // Note: Removed qApp->processEvents() to prevent MAVLink crashes during destruction
     }
-#endif
 }
 
 void Vehicle::deleteCameraManager()


### PR DESCRIPTION
This is an attempt to fix some of the corner cases trying to discover cameras, namely:

- Implement missing retries for CAMERA_INFORMATION, us old specific commands and REQUEST_MESSAGE.
- Try to simplify CameraControl::_initWhenReady a bit.
- Fix _requestStreamInfo() and _requestStreamStatus() using wrong retry variable.
- Add a few missing timers.

I haven't been able to properly test each and every retry mechanism used but overall this consistently initializes correctly for my case when it previously does not.