### PR TITLE
SignalHandler: exit on second Ctrl+C

### DIFF
--- a/src/Utilities/SignalHandler.cc
+++ b/src/Utilities/SignalHandler.cc
@@ -51,12 +51,20 @@ void SignalHandler::_onSigInt()
     _notifierInt->setEnabled(false);
     char b;
     ::read(sigIntFd[1], &b, sizeof(b));
-    qCDebug(SignalHandlerLog) << "Caught SIGINT—shutting down gracefully";
 
-    if (qgcApp() && qgcApp()->mainRootWindow()) {
-        (void) qgcApp()->mainRootWindow()->close();
-        QEvent ev(QEvent::Quit);
-        (void) qgcApp()->event(&ev);
+    _sigIntCount++;
+
+    if (_sigIntCount == 1) {
+        qCDebug(SignalHandlerLog) << "Caught SIGINT—press Ctrl+C again to exit immediately";
+
+        if (qgcApp() && qgcApp()->mainRootWindow()) {
+            (void) qgcApp()->mainRootWindow()->close();
+            QEvent ev(QEvent::Quit);
+            (void) qgcApp()->event(&ev);
+        }
+    } else {
+        qCDebug(SignalHandlerLog) << "Caught second SIGINT—exiting immediately";
+        _exit(0);
     }
 
     _notifierInt->setEnabled(true);

--- a/src/Utilities/SignalHandler.h
+++ b/src/Utilities/SignalHandler.h
@@ -39,4 +39,6 @@ private:
 
     QSocketNotifier *_notifierInt = nullptr;
     QSocketNotifier *_notifierTerm = nullptr;
+
+    int _sigIntCount = 0;
 };


### PR DESCRIPTION
When starting QGC from the console, it is handy to be able to quite it using Ctrl+C. When trying it the first time, it will show the prompt whether I really want to exit. When pressing it a second time, it will now exit - which is very convenient - instead of showing the prompt yet again.

This is essentially fixing #10889 but for v5.