### PR TITLE
docs(mavlink.md): add CPM_mavlink_SOURCE variable example

### DIFF
--- a/docs/en/qgc-dev-guide/custom_build/mavlink.md
+++ b/docs/en/qgc-dev-guide/custom_build/mavlink.md
@@ -14,3 +14,9 @@ To modify the version of MAVLink used by QGC:
   - QGC_MAVLINK_GIT_REPO - This is a link to the git repo to use, by default this is a link to https://github.com/mavlink/c_library_v2.
                            You can also [build your own libraries](https://mavlink.io/en/getting_started/generate_libraries.html) using the MAVLink toolchain and upload to your own git repo.
   - QGC_MAVLINK_GIT_TAG - This points to the git tag you would like to use in the chosen repo. This should likely be updated on occasion to use the latest version of MAVLink.
+
+  - You can also set the mavlink directory to a local path by using the CMake variable CPM_mavlink_SOURCE.
+  Just add to [/qgroundcontrol/cmake/CustomOptions.cmake](../../../../cmake/CustomOptions.cmake):
+  ```cmake
+  set(CPM_mavlink_SOURCE "/path/to/your/custom/mavlink")
+  ```


### PR DESCRIPTION
Update MAVLink.md - Remove Unused CMake Variable

Description
-----------
Remove `CPM_mavlink_SOURCE` variable from `mavlink.md` documentation as it is not used anywhere.

Test Steps
-----------
<!-- Describe the steps to reproduce. -->

Checklist:
----------
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] [Review Contribution Guidelines](https://github.com/mavlink/qgroundcontrol/blob/master/.github/CONTRIBUTING.md).
- [x] [Review Code of Conduct](https://github.com/mavlink/qgroundcontrol/blob/master/.github/CODE_OF_CONDUCT.md).
- [x] I have tested my changes.

Related Issue
-----------
<!-- If any, please provide issue ID. -->


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.