### PR TITLE
FlightMap: Fix drawing of very long mission lines (Stable v5.0)

### DIFF
--- a/src/FlightMap/MapItems/MapLineArrow.qml
+++ b/src/FlightMap/MapItems/MapLineArrow.qml
@@ -30,9 +30,9 @@ MapQuickItem {
 
     function _updateArrowDetails() {
         if (fromCoord && fromCoord.isValid && toCoord && toCoord.isValid) {
-            _arrowHeading = fromCoord.azimuthTo(toCoord)
             var lineDistanceQuarter = fromCoord.distanceTo(toCoord) / 4
-            coordinate = fromCoord.atDistanceAndAzimuth(lineDistanceQuarter * arrowPosition, _arrowHeading)
+            coordinate = fromCoord.atDistanceAndAzimuth(lineDistanceQuarter * arrowPosition, fromCoord.azimuthTo(toCoord))
+            _arrowHeading = coordinate.azimuthTo(toCoord) // Account for changing bearing along great circle path
         } else {
             coordinate = QtPositioning.coordinate()
             _arrowHeading = 0

--- a/src/FlightMap/MapItems/MissionLineView.qml
+++ b/src/FlightMap/MapItems/MissionLineView.qml
@@ -24,9 +24,38 @@ MapItemView {
                         "red" :
                         (false/*showSpecialVisual*/ ? "green" : QGroundControl.globalPalette.mapMissionTrajectory)
         z:          QGroundControl.zOrderWaypointLines
-        path:       object && object.coordinate1.isValid && object.coordinate2.isValid ? [ object.coordinate1, object.coordinate2 ] : []
+        path:       _calcMissionLinePath()
 
         property bool _terrainCollision:    object && object.terrainCollision
         property bool _showSpecialVisual:   object && showSpecialVisual && object.specialVisual
+
+        readonly property real _maxSegmentLengthM: 50000 // 50 km
+
+        function _calcMissionLinePath() {
+            if (!object || !object.coordinate1.isValid || !object.coordinate2.isValid) {
+                return []
+            }
+
+            var coord1 = object.coordinate1
+            var coord2 = object.coordinate2
+
+            var distance = coord1.distanceTo(coord2)
+            if (distance <= _maxSegmentLengthM) {
+                return [coord1, coord2]
+            }
+
+            // For longer distances, draw great circle path
+            var pathPoints = [coord1]
+            var numSegments = Math.ceil(distance / _maxSegmentLengthM)
+
+            for (var i = 1; i < numSegments; i++) {
+                var segmentDist = (i * distance) / numSegments
+                var interpolatedCoord = coord1.atDistanceAndAzimuth(segmentDist, coord1.azimuthTo(coord2))
+                pathPoints.push(interpolatedCoord)
+            }
+
+            pathPoints.push(coord2)
+            return pathPoints
+        }
     }
 }


### PR DESCRIPTION
# FlightMap: Fix drawing of very long mission lines

Description
-----------
This fixes a bug where extremely long legs in flight plans were drawn as straight lines on the map, instead of following the great circle path.

Key changes:
- Break down mission legs longer than 50km into smaller segments that follow the great circle path based on accurate geodesic calculations.
- Update leg arrow heading calculation to account for changing bearing along great circle paths.

Before/after
----------
![before-great-circle](https://github.com/user-attachments/assets/f0aaead5-798e-4d0b-8bd6-a5cf5f42c022)
![after-great-circle](https://github.com/user-attachments/assets/abb88741-447a-4da2-92b6-8c2be601ca96)


Checklist:
----------
- [x] [Review Contribution Guidelines](https://github.com/mavlink/qgroundcontrol/blob/master/.github/CONTRIBUTING.md).
- [x] [Review Code of Conduct](https://github.com/mavlink/qgroundcontrol/blob/master/.github/CODE_OF_CONDUCT.md).
- [x] I have tested my changes.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.