### PR TITLE
Fix: Improve auto stream handling

### DIFF
--- a/src/Camera/QGCCameraManager.cc
+++ b/src/Camera/QGCCameraManager.cc
@@ -365,6 +365,7 @@ QGCCameraManager::_handleVideoStreamInfo(const mavlink_message_t& message)
         mavlink_video_stream_information_t streamInfo;
         mavlink_msg_video_stream_information_decode(&message, &streamInfo);
         pCamera->handleVideoInfo(&streamInfo);
+        emit streamChanged();
     }
 }
 


### PR DESCRIPTION
Title
Fix: Improve auto stream handling for MAVLink VIDEO_STREAM_INFORMATION (#12373) 

Description

This PR fixes [QGC issue #12373](https://github.com/mavlink/qgroundcontrol/issues/12373), where QGroundControl daily builds failed to automatically load and display the video stream based on the incoming VIDEO_STREAM_INFORMATION MAVLink message, despite receiving a correct URI. The issue manifested as GStreamer-related errors and video stream failures when using automatic stream selection (via MAVLink), while manual URI entry worked fine.

   - Ensure stream info is updated for all video receivers, including thermal streams.
   - Update auto-stream configuration logic for reliability when changing video sources or camera settings.
   - Refactored stream reconfiguration logic so that UI and backend reliably update and activate the video stream when the URI is provided by MAVLink.
   - Fixed: Video stream now reliably appears in the UI after switching cameras, changing stream types, or publishing new VIDEO_STREAM_INFORMATION messages.
   - Changed files: VideoManager.cc and QGCCameraManager.cc

Test Steps

To reproduce:
    - Start a UDP sink pipeline with videotestsrc and mediamtx RTSP server as described in #12373.
    - Publish VIDEO_STREAM_INFORMATION MAVLink messages with a valid URI.
    - Run QGroundControl.
    - Confirm that the video stream appears in the UI without manual URI entry.
    - Switch camera streams or types and confirm the video updates correctly.
    - (I was testing all of it in Docker)

Checklist:

- [x] [Review Contribution Guidelines](https://github.com/mavlink/qgroundcontrol/blob/master/.github/CONTRIBUTING.md).
- [x] [Review Code of Conduct](https://github.com/mavlink/qgroundcontrol/blob/master/.github/CODE_OF_CONDUCT.md).
- [x] I have tested my changes.

Related Issue

Fixes #12373


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.