### PR TITLE
Fix: Improve auto stream handling

### DIFF
--- a/src/Camera/QGCCameraManager.cc
+++ b/src/Camera/QGCCameraManager.cc
@@ -365,6 +365,7 @@ QGCCameraManager::_handleVideoStreamInfo(const mavlink_message_t& message)
         mavlink_video_stream_information_t streamInfo;
         mavlink_msg_video_stream_information_decode(&message, &streamInfo);
         pCamera->handleVideoInfo(&streamInfo);
+        emit streamChanged();
     }
 }
 


### PR DESCRIPTION
- Ensure stream info is updated for all video receivers, including thermal streams.
- Update auto-stream configuration logic for reliability when changing video sources or camera settings.
- Motivation: Fixes issue where video stream would not update properly in the UI after switching cameras or stream types.

Cherry Pick #13115