### PR TITLE
Force android soft keyboard to close with Done instead of Next

### DIFF
--- a/src/QmlControls/QGCTextField.qml
+++ b/src/QmlControls/QGCTextField.qml
@@ -21,6 +21,7 @@ TextField {
     rightPadding:       _marginPadding + unitsHelpLayout.width
     topPadding:         _marginPadding
     bottomPadding:      _marginPadding
+    EnterKey.type:      Qt.EnterKeyDone
 
     property bool   showUnits:          false
     property bool   showHelp:           false


### PR DESCRIPTION
This mirrors how it worked in 4.4