### PR TITLE
Allow custom build to override application window icon on Linux

### DIFF
--- a/src/QGCApplication.cc
+++ b/src/QGCApplication.cc
@@ -104,9 +104,6 @@ QGCApplication::QGCApplication(int &argc, char *argv[], bool unitTesting, bool s
     setOrganizationName(QGC_ORG_NAME);
     setOrganizationDomain(QGC_ORG_DOMAIN);
     setApplicationVersion(QString(QGC_APP_VERSION_STR));
-#ifdef Q_OS_LINUX
-    setWindowIcon(QIcon(":/res/qgroundcontrol.ico"));
-#endif
 
     // Set settings format
     QSettings::setDefaultFormat(QSettings::IniFormat);
@@ -273,6 +270,14 @@ void QGCApplication::_initForNormalAppBoot()
 
     // Image provider for Optical Flow
     _qmlAppEngine->addImageProvider(_qgcImageProviderId, new QGCImageProvider());
+
+    // Set the window icon now that custom plugin has a chance to override it
+#ifdef Q_OS_LINUX
+    QUrl windowIcon = QUrl("qrc:/res/qgroundcontrol.ico");
+    windowIcon = _qmlAppEngine->interceptUrl(windowIcon, QQmlAbstractUrlInterceptor::UrlString);
+    // The interceptor needs "qrc:/path" but QIcon expects ":/path"
+    setWindowIcon(QIcon(":" + windowIcon.path()));
+#endif
 
     // Safe to show popup error messages now that main window is created
     _showErrorsInToolbar = true;


### PR DESCRIPTION
<!--- Title -->
Allow custom build to override application window icon on Linux

Description
-----------
<!--- Describe your changes in detail. -->
Moved the call to `setWindowIcon` from constructor to `_initForNormallAppBoot`, so the icon URL can be modified by `CustomPlugin` the same way as all imports from QML are (prefix with `/Custom` if the result of that is defined).

This way the icon resource defined here is used correctly:

https://github.com/mavlink/qgroundcontrol/blob/c5c0fc5bb1e0f76d3ff06f0f4ded173c53c5817b/custom-example/custom.qrc#L36-L38

Test Steps
-----------
<!-- Describe the steps to reproduce. -->
Do custom build according to the instructions:
https://github.com/mavlink/qgroundcontrol/blob/c5c0fc5bb1e0f76d3ff06f0f4ded173c53c5817b/custom-example/README.md?plain=1#L3-L10

**Note:** On one of my setups (Ubuntu 24.04 noble) QGroundControl window always has the application icon unset, including the official v5.0 AppImage. However when tested on other machines (eg. Ubuntu 22.04 jammy) where the stable build has an icon, this change works as expected.

Checklist:
----------
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] [Review Contribution Guidelines](https://github.com/mavlink/qgroundcontrol/blob/master/.github/CONTRIBUTING.md).
- [x] [Review Code of Conduct](https://github.com/mavlink/qgroundcontrol/blob/master/.github/CODE_OF_CONDUCT.md).
- [x] I have tested my changes.

Related Issue
-----------
<!-- If any, please provide issue ID. -->
Didn't find any issues for that specifically, but it is probably because of relatively recent switch to CMake. This may possibly help with #5511.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.