### PR TITLE
Fix/telemetry color to hex

### DIFF
--- a/src/QmlControls/InstrumentValueEditDialog.qml
+++ b/src/QmlControls/InstrumentValueEditDialog.qml
@@ -279,7 +279,7 @@ QGCPopupDialog {
                 id:             colorPickerDialog
                 modality:       Qt.ApplicationModal
                 selectedColor:  instrumentValueData.rangeColors.length ? instrumentValueData.rangeColors[colorIndex] : "white"
-                onAccepted:     updateColorValue(colorIndex, color)
+                onAccepted:     updateColorValue(colorIndex, selectedColor)
 
                 property int colorIndex: 0
             }


### PR DESCRIPTION
### Description

Fixes a bug in the telemetry color picker dialog where the wrong color value was passed on acceptance.

Changed the `onAccepted` handler to use `selectedColor` instead of `color` to ensure the correct hex color value is used when updating telemetry colors.

### Changes

- Modified `colorPickerDialog`'s `onAccepted` from:
  ```qml
  onAccepted: updateColorValue(colorIndex, color)

Fixes #13216