### PR TITLE
QML SettingsGroupLayout: Fix dividers visibility

### DIFF
--- a/src/QmlControls/SettingsGroupLayout.qml
+++ b/src/QmlControls/SettingsGroupLayout.qml
@@ -24,6 +24,17 @@ ColumnLayout {
     property bool   showBorder:         true
 
     property real _margins: ScreenTools.defaultFontPixelHeight / 2
+    property int _visibleItemCount: _countVisibleItems()
+
+    function _countVisibleItems() {
+        var count = 0
+        for (var i = 0; i < _contentLayout.children.length; i++) {
+            if (_contentLayout.children[i].visible) {
+                count++
+            }
+        }
+        return count
+    }
 
     ColumnLayout {
         Layout.leftMargin:  _margins
@@ -57,7 +68,7 @@ ColumnLayout {
         radius:             ScreenTools.defaultFontPixelHeight / 2
 
         Repeater {
-            model: showDividers? _contentLayout.children.length : 0
+            model: showDividers ? _contentLayout.children.length : 0
 
             Rectangle {
                 x:                  showBorder ? _margins : 0
@@ -65,9 +76,9 @@ ColumnLayout {
                 width:              parent.width - (showBorder ? _margins * 2 : 0)
                 height:             1
                 color:              QGroundControl.globalPalette.groupBorder
-                visible:            _contentItem.visible && 
-                                        _contentItem.width !== 0 && _contentItem.height !== 0 &&
-                                        index < _contentLayout.children.length - 1
+                visible:            _contentItem.visible && _contentItem.width > 0 && _contentItem.height > 0 &&
+                                    _visibleItemCount > 1 && (index < _contentLayout.children.length - 1) &&
+                                    _contentLayout.children[index + 1].visible
 
                 property var _contentItem: _contentLayout.children[index]
             }


### PR DESCRIPTION
<!--- Title -->

Description
-----------
<!--- Describe your changes in detail. -->
Before:
<img width="762" height="255" alt="Screenshot 2025-07-30 at 17 12 42" src="https://github.com/user-attachments/assets/fc297169-acf0-425d-a6f5-0b80d009fb85" />

After:
<img width="725" height="262" alt="Screenshot 2025-07-30 at 17 21 57" src="https://github.com/user-attachments/assets/705b60d0-8e07-47db-8ce9-dadfd1ed7a74" />

Test Steps
-----------
<!-- Describe the steps to reproduce. -->

Checklist:
----------
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] [Review Contribution Guidelines](https://github.com/mavlink/qgroundcontrol/blob/master/.github/CONTRIBUTING.md).
- [x] [Review Code of Conduct](https://github.com/mavlink/qgroundcontrol/blob/master/.github/CODE_OF_CONDUCT.md).
- [x] I have tested my changes.

Related Issue
-----------
<!-- If any, please provide issue ID. -->


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.