### PR TITLE
Show airframe ID as vehicle name if vehicle name is not known

### DIFF
--- a/src/AutoPilotPlugins/PX4/AirframeComponentController.cc
+++ b/src/AutoPilotPlugins/PX4/AirframeComponentController.cc
@@ -41,7 +41,7 @@ AirframeComponentController::AirframeComponentController(void) :
     
     bool autostartFound = false;
     _autostartId = getParameterFact(ParameterManager::defaultComponentId, "SYS_AUTOSTART")->rawValue().toInt();
-
+    _currentVehicleName = QString::number(_autostartId); // Temp val. Replaced with actual vehicle name if found
     
     for (int tindex = 0; tindex < AirframeComponentAirframes::get().count(); tindex++) {
 


### PR DESCRIPTION
Description
-----------
If the vehicle airframe details aren't stored in QGC's `AirframeFactMetaData.xml` file, the Vehicle name is left blank. It would be more informative to show the airframe ID when the vehicle name isn't known.

ex. 
Without the changes in this PR, If you use the PX4 SIH sim
```
~/PX4-Autopilot$ make px4_sitl sihsim_quadx
```
you see
<img width="882" height="530" alt="before" src="https://github.com/user-attachments/assets/03638392-d24d-41e6-93e8-20d1a236aca1" />

with the changes in this PR, you will now see `10040` as the vehicle name. This is the airframe ID. A developer who knows about airframe IDs will know the meta data for the vehicle can be manually viewed in the airframe file, in this case `PX4-Autopilot/ROMFS/px4fmu_common/init.d-posix/airframes/10040_sihsim_quadx`
<img width="882" height="530" alt="after" src="https://github.com/user-attachments/assets/2fa3643d-2e53-41ba-8980-3cfad5c63670" />

The vehicle name still shows the normal stuff if the vehicle has a known airframe id. For example, if you run
```
~/PX4-Autopilot$ make px4_sitl gz_x500
```
The changes in this PR do not change how it displays the recognized vehicle's metadata
<img width="882" height="530" alt="same" src="https://github.com/user-attachments/assets/324cfe1c-b485-42a6-b7a4-b1ce8ca8ac01" />
