### PR TITLE
Linux: Get Latest CMake & Ninja

### DIFF
--- a/tools/setup/install-dependencies-debian.sh
+++ b/tools/setup/install-dependencies-debian.sh
@@ -47,6 +47,9 @@ apt-get install -y -qq --no-install-recommends \
     wget \
     zsync
 
+pipx ensurepath
+pipx install cmake ninja
+
 # --------------------------------------------------------------------
 # Qt6 compile/runtime dependencies
 # See: https://doc.qt.io/qt-6/linux-requirements.html


### PR DESCRIPTION
Apt doesn't provide a new enough one on Ubuntu 22.04