### PR TITLE
Convert ESC_STATUS handling to FactGroupListModel

### DIFF
--- a/src/FactSystem/FactGroupListModel.cc
+++ b/src/FactSystem/FactGroupListModel.cc
@@ -19,11 +19,18 @@ FactGroupListModel::FactGroupListModel(const char* factGroupNamePrefix, QObject*
 
 void FactGroupListModel::handleMessageForFactGroupCreation(Vehicle *vehicle, const mavlink_message_t &message)
 {
-    uint32_t id = 0;
+    QList<uint32_t> ids;
 
-    if (_shouldHandleMessage(message, id)) {
-        _findOrAddFactGroupById(vehicle, id);
+    if (_shouldHandleMessage(message, ids)) {
+        for (const uint32_t id : ids) {
+            _findOrAddFactGroupById(vehicle, id);
+        }
     }
+}
+
+QString FactGroupListModel::_factGroupNameWithId(uint32_t id) const
+{
+    return QStringLiteral("%1%2").arg(_factGroupNamePrefix).arg(id);
 }
 
 FactGroupWithId *FactGroupListModel::_findOrAddFactGroupById(Vehicle *vehicle, uint32_t id)
@@ -43,7 +50,7 @@ FactGroupWithId *FactGroupListModel::_findOrAddFactGroupById(Vehicle *vehicle, u
 
     auto *const newGroup = _createFactGroupWithId(id);
     insert(i, newGroup);
-    vehicle->_addFactGroup(newGroup, QStringLiteral("%1%2").arg(_factGroupNamePrefix).arg(id));
+    vehicle->_addFactGroup(newGroup, _factGroupNameWithId(id));
 
     return newGroup;
 }

--- a/src/FactSystem/FactGroupListModel.h
+++ b/src/FactSystem/FactGroupListModel.h
@@ -29,11 +29,11 @@ public:
     void handleMessageForFactGroupCreation(Vehicle *vehicle, const mavlink_message_t &message);
 
 protected:
-    virtual bool _shouldHandleMessage(const mavlink_message_t &message, uint32_t &id) const = 0;
+    virtual bool _shouldHandleMessage(const mavlink_message_t &message, QList<uint32_t> &ids) const = 0;
     virtual FactGroupWithId *_createFactGroupWithId(uint32_t id) = 0;
 
     FactGroupWithId *_findOrAddFactGroupById(Vehicle *vehicle, uint32_t id);
-
+    QString _factGroupNameWithId(uint32_t id) const;;
 
     const char* _factGroupNamePrefix;
 };

--- a/src/FactSystem/FactGroupListModel.h
+++ b/src/FactSystem/FactGroupListModel.h
@@ -33,7 +33,7 @@ protected:
     virtual FactGroupWithId *_createFactGroupWithId(uint32_t id) = 0;
 
     FactGroupWithId *_findOrAddFactGroupById(Vehicle *vehicle, uint32_t id);
-    QString _factGroupNameWithId(uint32_t id) const;;
+    QString _factGroupNameWithId(uint32_t id) const;
 
     const char* _factGroupNamePrefix;
 };

--- a/src/FactSystem/FactMetaData.cc
+++ b/src/FactSystem/FactMetaData.cc
@@ -25,6 +25,7 @@ const FactMetaData::BuiltInTranslation_s FactMetaData::_rgBuiltInTranslations[] 
     { "rad",            "deg",  FactMetaData::_radiansToDegrees,                        FactMetaData::_degreesToRadians },
     { "gimbal-degrees", "deg",  FactMetaData::_mavlinkGimbalDegreesToUserGimbalDegrees, FactMetaData::_userGimbalDegreesToMavlinkGimbalDegrees },
     { "norm",           "%",    FactMetaData::_normToPercent,                           FactMetaData::_percentToNorm },
+    { "centi-celsius",  "C",    FactMetaData::_centiCelsiusToCelsius,                   FactMetaData::_celsiusToCentiCelsius },
 };
 
 // Translations driven by app settings
@@ -622,6 +623,16 @@ QVariant FactMetaData::_centiDegreesToDegrees(const QVariant &centiDegrees)
 QVariant FactMetaData::_degreesToCentiDegrees(const QVariant &degrees)
 {
     return QVariant(qRound(degrees.toReal() * 100.0));
+}
+
+QVariant FactMetaData::_centiCelsiusToCelsius(const QVariant &centiCelsius)
+{
+    return QVariant(centiCelsius.toReal() / 100.0);
+}
+
+QVariant FactMetaData::_celsiusToCentiCelsius(const QVariant &celsius)
+{
+    return QVariant(qRound(celsius.toReal() * 100.0));
 }
 
 QVariant FactMetaData::_userGimbalDegreesToMavlinkGimbalDegrees(const QVariant &userGimbalDegrees)

--- a/src/FactSystem/FactMetaData.h
+++ b/src/FactSystem/FactMetaData.h
@@ -265,6 +265,8 @@ private:
     static QVariant _radiansToDegrees(const QVariant &radians);
     static QVariant _centiDegreesToDegrees(const QVariant &centiDegrees);
     static QVariant _degreesToCentiDegrees(const QVariant &degrees);
+    static QVariant _centiCelsiusToCelsius(const QVariant &centiCelsius);
+    static QVariant _celsiusToCentiCelsius(const QVariant &celsius);
     static QVariant _userGimbalDegreesToMavlinkGimbalDegrees(const QVariant &userGimbalDegrees);
     static QVariant _mavlinkGimbalDegreesToUserGimbalDegrees(const QVariant &mavlinkGimbalDegrees);
     static QVariant _metersToFeet(const QVariant &meters);

--- a/src/Vehicle/FactGroups/BatteryFact.json
+++ b/src/Vehicle/FactGroups/BatteryFact.json
@@ -6,7 +6,7 @@
 {
     "name":             "id",
     "shortDesc":        "Battery Id",
-    "type":             "uint8"
+    "type":             "uint32"
 },
 {
     "name":             "batteryFunction",

--- a/src/Vehicle/FactGroups/BatteryFactGroupListModel.h
+++ b/src/Vehicle/FactGroups/BatteryFactGroupListModel.h
@@ -22,7 +22,7 @@ public:
 
 protected:
     // Overrides from FactGroupListModel
-    bool _shouldHandleMessage(const mavlink_message_t &message, uint32_t &id) const final;
+    bool _shouldHandleMessage(const mavlink_message_t &message, QList<uint32_t> &ids) const final;
     FactGroupWithId *_createFactGroupWithId(uint32_t id) final;
 };
 

--- a/src/Vehicle/FactGroups/CMakeLists.txt
+++ b/src/Vehicle/FactGroups/CMakeLists.txt
@@ -2,6 +2,8 @@ target_sources(${CMAKE_PROJECT_NAME}
     PRIVATE
         BatteryFactGroupListModel.cc
         BatteryFactGroupListModel.h
+        EscStatusFactGroupListModel.cc
+        EscStatusFactGroupListModel.h
         TerrainFactGroup.cc
         TerrainFactGroup.h
         VehicleClockFactGroup.cc
@@ -10,8 +12,6 @@ target_sources(${CMAKE_PROJECT_NAME}
         VehicleDistanceSensorFactGroup.h
         VehicleEFIFactGroup.cc
         VehicleEFIFactGroup.h
-        VehicleEscStatusFactGroup.cc
-        VehicleEscStatusFactGroup.h
         VehicleEstimatorStatusFactGroup.cc
         VehicleEstimatorStatusFactGroup.h
         VehicleGeneratorFactGroup.cc

--- a/src/Vehicle/FactGroups/EscStatusFactGroup.json
+++ b/src/Vehicle/FactGroups/EscStatusFactGroup.json
@@ -4,41 +4,19 @@
     "QGC.MetaData.Facts":
 [
 {
-    "name":             "index",
-    "shortDesc":        "Index Of The First ESC In This Message",
-    "type":             "uint8",
-    "default":          0
+    "name":             "id",
+    "shortDesc":        "ESC index",
+    "type":             "uint32"
 },
 {
-    "name":             "rpmFirst",
+    "name":             "rpm",
     "shortDesc":        "Rotation Per Minute",
     "type":             "float",
     "decimalPlaces":    2,
     "default":          null
 },
 {
-    "name":             "rpmSecond",
-    "shortDesc":        "Rotation Per Minute",
-    "type":             "float",
-    "decimalPlaces":    2,
-    "default":          null
-},
-{
-    "name":             "rpmThird",
-    "shortDesc":        "Rotation Per Minute",
-    "type":             "float",
-    "decimalPlaces":    2,
-    "default":          null
-},
-{
-    "name":             "rpmFourth",
-    "shortDesc":        "Rotation Per Minute",
-    "type":             "float",
-    "decimalPlaces":    2,
-    "default":          null
-},
-{
-    "name":             "currentFirst",
+    "name":             "current",
     "shortDesc":        "Current",
     "type":             "float",
     "decimalPlaces":    2,
@@ -47,31 +25,7 @@
 
 },
 {
-    "name":             "currentSecond",
-    "shortDesc":        "Current",
-    "type":             "float",
-    "decimalPlaces":    2,
-    "default":          null,
-    "units":            "A"
-},
-{
-    "name":             "currentThird",
-    "shortDesc":        "Current",
-    "type":             "float",
-    "decimalPlaces":    2,
-    "default":          null,
-    "units":            "A"
-},
-{
-    "name":             "currentFourth",
-    "shortDesc":        "Current",
-    "type":             "float",
-    "decimalPlaces":    2,
-    "default":          null,
-    "units":            "A"
-},
-{
-    "name":             "voltageFirst",
+    "name":             "voltage",
     "shortDesc":        "Voltage",
     "type":             "float",
     "decimalPlaces":    2,
@@ -79,28 +33,73 @@
     "units":            "v"
 },
 {
-    "name":             "voltageSecond",
-    "shortDesc":        "Voltage",
-    "type":             "float",
-    "decimalPlaces":    2,
-    "default":          null,
-    "units":            "v"
+    "name":             "Count",
+    "shortDesc":        "Total number of ESCs",
+    "type":             "uint8",
+    "default":          0
 },
 {
-    "name":             "voltageThird",
-    "shortDesc":        "Voltage",
-    "type":             "float",
-    "decimalPlaces":    2,
-    "default":          null,
-    "units":            "v"
+    "name":             "connectionType",
+    "shortDesc":        "ESC protocol",
+    "type":             "uint8",
+    "default":          0,
+    "enumStrings":      "PPM,Serial Bus,One Shot,I2C,CAN-Bus,DShot",
+    "enumValues":       "0,1,2,3,4,5"
 },
 {
-    "name":             "voltageFourth",
-    "shortDesc":        "Voltage",
-    "type":             "float",
-    "decimalPlaces":    2,
-    "default":          null,
-    "units":            "v"
+    "name":             "info",
+    "shortDesc":        "Online/Offline status",
+    "type":             "uint8",
+    "default":          0
+},
+{
+    "name":             "failureFlags",
+    "shortDesc":        "Failure flags",
+    "type":             "uint16",
+    "default":          0,
+      "bitmask": [
+        {
+          "index": 0,
+          "description": "Over current failure"
+        },
+        {
+          "index": 1,
+          "description": "Over voltage failure"
+        },
+        {
+          "index": 2,
+          "description": "Over temperature failure"
+        },
+        {
+          "index": 3,
+          "description": "Over RPM failure"
+        },
+        {
+          "index": 4,
+          "description": "Inconsistent command failure"
+        },
+        {
+          "index": 5,
+          "description": "Motor stuck failure"
+        },
+        {
+          "index": 6,
+          "description": "Generic ESC failure"
+        }
+      ]
+},
+{
+    "name":             "temperature",
+    "shortDesc":        "Temperature",
+    "type":             "int16",
+    "default":          0,
+    "units":            "centi-celsius"
+},
+{
+    "name":             "errorCount",
+    "shortDesc":        "Error Count",
+    "type":             "uint32",
+    "default":          0
 }
 ]
 }

--- a/src/Vehicle/FactGroups/EscStatusFactGroupListModel.cc
+++ b/src/Vehicle/FactGroups/EscStatusFactGroupListModel.cc
@@ -1,0 +1,142 @@
+/****************************************************************************
+ *
+ * (c) 2009-2024 QGROUNDCONTROL PROJECT <http://www.qgroundcontrol.org>
+ *
+ * QGroundControl is licensed according to the terms in the file
+ * COPYING.md in the root of the source code directory.
+ *
+ ****************************************************************************/
+
+#include "EscStatusFactGroupListModel.h"
+#include "QGCMAVLink.h"
+
+EscStatusFactGroupListModel::EscStatusFactGroupListModel(QObject* parent)
+    : FactGroupListModel("escStatus", parent)
+{
+
+}
+
+bool EscStatusFactGroupListModel::_shouldHandleMessage(const mavlink_message_t &message, QList<uint32_t> &ids) const
+{
+    bool shouldHandle = false;
+    uint32_t firstIndex;
+
+    ids.clear();
+
+    switch (message.msgid) {
+    case MAVLINK_MSG_ID_ESC_INFO:
+    {
+        mavlink_esc_status_t escStatus{};
+        mavlink_msg_esc_status_decode(&message, &escStatus);
+        firstIndex = escStatus.index;
+        shouldHandle = true;
+    }
+        break;
+    case MAVLINK_MSG_ID_ESC_STATUS:
+    {
+        mavlink_esc_status_t escStatus{};
+        mavlink_msg_esc_status_decode(&message, &escStatus);
+        firstIndex = escStatus.index;
+        shouldHandle = true;
+    }
+        break;
+    default:
+        shouldHandle = false; // Not a message we care about
+        break;
+    }
+
+    if (shouldHandle) {
+        for (uint32_t index = firstIndex; index <= firstIndex + 3; index++) {
+            ids.append(index);
+        }
+    }
+
+    return shouldHandle;
+}
+
+FactGroupWithId *EscStatusFactGroupListModel::_createFactGroupWithId(uint32_t id)
+{
+    return new EscStatusFactGroup(id, this);
+}
+
+EscStatusFactGroup::EscStatusFactGroup(uint32_t escIndex, QObject *parent)
+    : FactGroupWithId(1000, QStringLiteral(":/json/Vehicle/EscStatusFactGroup.json"), parent)
+{
+    _addFact(&_rpmFact);
+    _addFact(&_currentFact);
+    _addFact(&_voltageFact);
+    _addFact(&_countFact);
+    _addFact(&_connectionTypeFact);
+    _addFact(&_infoFact);
+    _addFact(&_failureFlagsFact);
+    _addFact(&_errorCountFact);
+    _addFact(&_temperatureFact);
+
+    _idFact.setRawValue(escIndex);
+    _rpmFact.setRawValue(0);
+    _currentFact.setRawValue(0);
+    _voltageFact.setRawValue(0);
+    _countFact.setRawValue(0);
+    _connectionTypeFact.setRawValue(0);
+    _infoFact.setRawValue(0);
+    _failureFlagsFact.setRawValue(0);
+    _errorCountFact.setRawValue(0);
+    _temperatureFact.setRawValue(0);
+}
+
+void EscStatusFactGroup::handleMessage(Vehicle *vehicle, const mavlink_message_t &message)
+{
+    switch (message.msgid) {
+    case MAVLINK_MSG_ID_ESC_INFO:
+        _handleEscStatus(vehicle, message);
+        break;
+    case MAVLINK_MSG_ID_ESC_STATUS:
+        _handleEscInfo(vehicle, message);
+        break;
+    default:
+        break;
+    }
+}
+
+void EscStatusFactGroup::_handleEscInfo(Vehicle *vehicle, const mavlink_message_t &message)
+{
+    mavlink_esc_info_t escInfo{};
+    mavlink_msg_esc_info_decode(&message, &escInfo);
+
+    uint8_t index = _idFact.rawValue().toUInt();
+
+    if (escInfo.index != index) {
+        // Disregard ESC info messages which are not targeted at this ESC index
+        return;
+    }
+
+    index %= 4; // Convert to 0-based index for the arrays in escInfo
+    _countFact.setRawValue(escInfo.count);
+    _connectionTypeFact.setRawValue(escInfo.connection_type);
+    _infoFact.setRawValue(escInfo.info);
+    _failureFlagsFact.setRawValue(escInfo.failure_flags[index]);
+    _errorCountFact.setRawValue(escInfo.error_count[index]);
+    _temperatureFact.setRawValue(escInfo.temperature[index]);
+
+    _setTelemetryAvailable(true);
+}
+
+void EscStatusFactGroup::_handleEscStatus(Vehicle *vehicle, const mavlink_message_t &message)
+{
+    mavlink_esc_status_t escStatus{};
+    mavlink_msg_esc_status_decode(&message, &escStatus);
+
+    uint8_t index = _idFact.rawValue().toUInt();
+
+    if (escStatus.index != index) {
+        // Disregard ESC info messages which are not targeted at this ESC index
+        return;
+    }
+
+    index %= 4; // Convert to 0-based index for the arrays in escInfo
+    _rpmFact.setRawValue(escStatus.rpm[index]);
+    _currentFact.setRawValue(escStatus.current[index]);
+    _voltageFact.setRawValue(escStatus.voltage[index]);
+
+    _setTelemetryAvailable(true);
+}

--- a/src/Vehicle/FactGroups/EscStatusFactGroupListModel.cc
+++ b/src/Vehicle/FactGroups/EscStatusFactGroupListModel.cc
@@ -105,7 +105,7 @@ void EscStatusFactGroup::_handleEscInfo(Vehicle *vehicle, const mavlink_message_
 
     uint8_t index = _idFact.rawValue().toUInt();
 
-    if (escInfo.index != index) {
+    if (index < escInfo.index || index >= escInfo.index + 4) {
         // Disregard ESC info messages which are not targeted at this ESC index
         return;
     }
@@ -128,7 +128,7 @@ void EscStatusFactGroup::_handleEscStatus(Vehicle *vehicle, const mavlink_messag
 
     uint8_t index = _idFact.rawValue().toUInt();
 
-    if (escStatus.index != index) {
+    if (index < escStatus.index || index >= escStatus.index + 4) {
         // Disregard ESC info messages which are not targeted at this ESC index
         return;
     }

--- a/src/Vehicle/FactGroups/EscStatusFactGroupListModel.cc
+++ b/src/Vehicle/FactGroups/EscStatusFactGroupListModel.cc
@@ -88,10 +88,10 @@ void EscStatusFactGroup::handleMessage(Vehicle *vehicle, const mavlink_message_t
 {
     switch (message.msgid) {
     case MAVLINK_MSG_ID_ESC_INFO:
-        _handleEscStatus(vehicle, message);
+        _handleEscInfo(vehicle, message);
         break;
     case MAVLINK_MSG_ID_ESC_STATUS:
-        _handleEscInfo(vehicle, message);
+        _handleEscStatus(vehicle, message);
         break;
     default:
         break;

--- a/src/Vehicle/FactGroups/EscStatusFactGroupListModel.h
+++ b/src/Vehicle/FactGroups/EscStatusFactGroupListModel.h
@@ -1,0 +1,72 @@
+/****************************************************************************
+ *
+ * (c) 2009-2024 QGROUNDCONTROL PROJECT <http://www.qgroundcontrol.org>
+ *
+ * QGroundControl is licensed according to the terms in the file
+ * COPYING.md in the root of the source code directory.
+ *
+ ****************************************************************************/
+
+#pragma once
+
+#include "FactGroupListModel.h"
+
+class EscStatusFactGroupListModel : public FactGroupListModel
+{
+    Q_OBJECT
+    QML_ELEMENT
+    QML_UNCREATABLE("")
+
+public:
+    explicit EscStatusFactGroupListModel(QObject* parent = nullptr);
+
+protected:
+    // Overrides from FactGroupListModel
+    bool _shouldHandleMessage(const mavlink_message_t &message, QList<uint32_t> &ids) const final;
+    FactGroupWithId *_createFactGroupWithId(uint32_t id) final;
+};
+
+class EscStatusFactGroup : public FactGroupWithId
+{
+    Q_OBJECT
+
+    Q_PROPERTY(Fact *rpm            READ rpm            CONSTANT)
+    Q_PROPERTY(Fact *current        READ current        CONSTANT)
+    Q_PROPERTY(Fact *voltage        READ voltage        CONSTANT)
+    Q_PROPERTY(Fact *count          READ count          CONSTANT)
+    Q_PROPERTY(Fact *connectionType READ connectionType CONSTANT)
+    Q_PROPERTY(Fact *info           READ info           CONSTANT)
+    Q_PROPERTY(Fact *failureFlags   READ failureFlags   CONSTANT)
+    Q_PROPERTY(Fact *errorCount     READ errorCount     CONSTANT)
+    Q_PROPERTY(Fact *temperature    READ temperature    CONSTANT)
+
+public:
+    explicit EscStatusFactGroup(uint32_t escIndex, QObject *parent = nullptr);
+
+    Fact *rpm() { return &_rpmFact; }
+    Fact *current() { return &_currentFact; }
+    Fact *voltage() { return &_voltageFact; }
+    Fact *count() { return &_countFact; }
+    Fact *connectionType() { return &_connectionTypeFact; }
+    Fact *info() { return &_infoFact; }
+    Fact *failureFlags() { return &_failureFlagsFact; }
+    Fact *errorCount() { return &_errorCountFact; }
+    Fact *temperature() { return &_temperatureFact; }
+
+    // Overrides from FactGroup
+    void handleMessage(Vehicle *vehicle, const mavlink_message_t &message) final;
+
+private:
+    void _handleEscInfo(Vehicle *vehicle, const mavlink_message_t &message);
+    void _handleEscStatus(Vehicle *vehicle, const mavlink_message_t &message);
+
+    Fact _rpmFact =             Fact(0, QStringLiteral("rpm"),              FactMetaData::valueTypeInt32);
+    Fact _currentFact =         Fact(0, QStringLiteral("current"),          FactMetaData::valueTypeInt32);
+    Fact _voltageFact =         Fact(0, QStringLiteral("voltage"),          FactMetaData::valueTypeInt32);
+    Fact _countFact =           Fact(0, QStringLiteral("count"),            FactMetaData::valueTypeUint8);
+    Fact _connectionTypeFact =  Fact(0, QStringLiteral("connectionType"),   FactMetaData::valueTypeUint8);
+    Fact _infoFact =            Fact(0, QStringLiteral("info"),             FactMetaData::valueTypeUint8);
+    Fact _failureFlagsFact =    Fact(0, QStringLiteral("failureFlags"),     FactMetaData::valueTypeUint16);
+    Fact _errorCountFact =      Fact(0, QStringLiteral("errorCount"),       FactMetaData::valueTypeUint32);
+    Fact _temperatureFact =     Fact(0, QStringLiteral("temperature"),      FactMetaData::valueTypeInt16);
+};

--- a/src/Vehicle/Vehicle.cc
+++ b/src/Vehicle/Vehicle.cc
@@ -109,7 +109,6 @@ Vehicle::Vehicle(LinkInterface*             link,
     , _distanceSensorFactGroup      (this)
     , _localPositionFactGroup       (this)
     , _localPositionSetpointFactGroup(this)
-    , _escStatusFactGroup           (this)
     , _estimatorStatusFactGroup     (this)
     , _hygrometerFactGroup          (this)
     , _generatorFactGroup           (this)
@@ -330,7 +329,6 @@ void Vehicle::_commonInit()
     _addFactGroup(&_distanceSensorFactGroup,    _distanceSensorFactGroupName);
     _addFactGroup(&_localPositionFactGroup,     _localPositionFactGroupName);
     _addFactGroup(&_localPositionSetpointFactGroup,_localPositionSetpointFactGroupName);
-    _addFactGroup(&_escStatusFactGroup,         _escStatusFactGroupName);
     _addFactGroup(&_estimatorStatusFactGroup,   _estimatorStatusFactGroupName);
     _addFactGroup(&_hygrometerFactGroup,        _hygrometerFactGroupName);
     _addFactGroup(&_generatorFactGroup,         _generatorFactGroupName);
@@ -520,6 +518,7 @@ void Vehicle::_mavlinkMessageReceived(LinkInterface* link, mavlink_message_t mes
 
     // Handle creation of dynamic fact group lists
     _batteryFactGroupListModel.handleMessageForFactGroupCreation(this, message);
+    _escStatusFactGroupListModel.handleMessageForFactGroupCreation(this, message);
 
     // Let the fact groups take a whack at the mavlink traffic
     for (FactGroup* factGroup : factGroups()) {

--- a/src/Vehicle/Vehicle.h
+++ b/src/Vehicle/Vehicle.h
@@ -32,7 +32,6 @@
 #include "VehicleClockFactGroup.h"
 #include "VehicleDistanceSensorFactGroup.h"
 #include "VehicleEFIFactGroup.h"
-#include "VehicleEscStatusFactGroup.h"
 #include "VehicleEstimatorStatusFactGroup.h"
 #include "VehicleGeneratorFactGroup.h"
 #include "VehicleGPS2FactGroup.h"
@@ -47,6 +46,7 @@
 #include "VehicleWindFactGroup.h"
 #include "GimbalController.h"
 #include "BatteryFactGroupListModel.h"
+#include "EscStatusFactGroupListModel.h"
 
 class Actuators;
 class AutoPilotPlugin;
@@ -264,7 +264,6 @@ public:
     Q_PROPERTY(FactGroup*           temperature     READ temperatureFactGroup       CONSTANT)
     Q_PROPERTY(FactGroup*           clock           READ clockFactGroup             CONSTANT)
     Q_PROPERTY(FactGroup*           setpoint        READ setpointFactGroup          CONSTANT)
-    Q_PROPERTY(FactGroup*           escStatus       READ escStatusFactGroup         CONSTANT)
     Q_PROPERTY(FactGroup*           estimatorStatus READ estimatorStatusFactGroup   CONSTANT)
     Q_PROPERTY(FactGroup*           terrain         READ terrainFactGroup           CONSTANT)
     Q_PROPERTY(FactGroup*           distanceSensors READ distanceSensorFactGroup    CONSTANT)
@@ -273,9 +272,12 @@ public:
     Q_PROPERTY(FactGroup*           hygrometer      READ hygrometerFactGroup        CONSTANT)
     Q_PROPERTY(FactGroup*           generator       READ generatorFactGroup         CONSTANT)
     Q_PROPERTY(FactGroup*           efi             READ efiFactGroup               CONSTANT)
-    Q_PROPERTY(QmlObjectListModel*  batteries       READ batteries                  CONSTANT)
     Q_PROPERTY(Actuators*           actuators       READ actuators                  CONSTANT)
     Q_PROPERTY(HealthAndArmingCheckReport* healthAndArmingCheckReport READ healthAndArmingCheckReport CONSTANT)
+
+    // Dynamic FactGroupListModel properties
+    Q_PROPERTY(QmlObjectListModel*  batteries       READ batteries                  CONSTANT)
+    Q_PROPERTY(QmlObjectListModel*  escs            READ escs                       CONSTANT)
 
     Q_PROPERTY(int      firmwareMajorVersion        READ firmwareMajorVersion       NOTIFY firmwareVersionChanged)
     Q_PROPERTY(int      firmwareMinorVersion        READ firmwareMinorVersion       NOTIFY firmwareVersionChanged)
@@ -607,14 +609,15 @@ public:
     FactGroup* distanceSensorFactGroup      () { return &_distanceSensorFactGroup; }
     FactGroup* localPositionFactGroup       () { return &_localPositionFactGroup; }
     FactGroup* localPositionSetpointFactGroup() { return &_localPositionSetpointFactGroup; }
-    FactGroup* escStatusFactGroup           () { return &_escStatusFactGroup; }
     FactGroup* estimatorStatusFactGroup     () { return &_estimatorStatusFactGroup; }
     FactGroup* terrainFactGroup             () { return &_terrainFactGroup; }
     FactGroup* hygrometerFactGroup          () { return &_hygrometerFactGroup; }
     FactGroup* generatorFactGroup           () { return &_generatorFactGroup; }
     FactGroup* efiFactGroup                 () { return &_efiFactGroup; }
     FactGroup* rpmFactGroup                 () { return &_rpmFactGroup; }
+
     QmlObjectListModel* batteries           () { return &_batteryFactGroupListModel; }
+    QmlObjectListModel* escs                () { return &_escStatusFactGroupListModel; }
 
     MissionManager*                 missionManager      () { return _missionManager; }
     GeoFenceManager*                geoFenceManager     () { return _geoFenceManager; }
@@ -1248,7 +1251,6 @@ private:
     const QString _distanceSensorFactGroupName =     QStringLiteral("distanceSensor");
     const QString _localPositionFactGroupName =      QStringLiteral("localPosition");
     const QString _localPositionSetpointFactGroupName = QStringLiteral("localPositionSetpoint");
-    const QString _escStatusFactGroupName =          QStringLiteral("escStatus");
     const QString _estimatorStatusFactGroupName =    QStringLiteral("estimatorStatus");
     const QString _terrainFactGroupName =            QStringLiteral("terrain");
     const QString _hygrometerFactGroupName =         QStringLiteral("hygrometer");
@@ -1267,7 +1269,6 @@ private:
     VehicleDistanceSensorFactGroup  _distanceSensorFactGroup;
     VehicleLocalPositionFactGroup   _localPositionFactGroup;
     VehicleLocalPositionSetpointFactGroup _localPositionSetpointFactGroup;
-    VehicleEscStatusFactGroup       _escStatusFactGroup;
     VehicleEstimatorStatusFactGroup _estimatorStatusFactGroup;
     VehicleHygrometerFactGroup      _hygrometerFactGroup;
     VehicleGeneratorFactGroup       _generatorFactGroup;
@@ -1277,6 +1278,7 @@ private:
 
     // Dynamic FactGroups
     BatteryFactGroupListModel       _batteryFactGroupListModel;
+    EscStatusFactGroupListModel     _escStatusFactGroupListModel;
 
     TerrainProtocolHandler* _terrainProtocolHandler = nullptr;
 


### PR DESCRIPTION
* Modify FactGroupListModel support for single message which requires the additioan of multiple dynamic id-based FactGroups
* Add support for conversion of Centi-Celsuis value to Celsuis through the user of the new "centi-celscius" units support
* Convert ESC_STATUS handling to FactGroupListModel
* Update Battery FactGroup to new _shouldHandleMessage signature as well as fixing bugs with respect to targeting data to the right FactGroups.