### PR TITLE
Send buttons over 16 via buttons2 in MANUAL_CONTROL

### DIFF
--- a/src/Joystick/Joystick.cc
+++ b/src/Joystick/Joystick.cc
@@ -672,8 +672,9 @@ void Joystick::_handleAxis()
 
     emit axisValues(roll, pitch, yaw, throttle);
 
-    const uint16_t shortButtons = static_cast<uint16_t>(buttonPressedBits & 0xFFFF);
-    _activeVehicle->sendJoystickDataThreadSafe(roll, pitch, yaw, throttle, shortButtons);
+    const uint16_t lowButtons = static_cast<uint16_t>(buttonPressedBits & 0xFFFF);
+    const uint16_t highButtons = static_cast<uint16_t>((buttonPressedBits >> 16) & 0xFFFF);
+    _activeVehicle->sendJoystickDataThreadSafe(roll, pitch, yaw, throttle, lowButtons, highButtons);
 }
 
 void Joystick::startPolling(Vehicle* vehicle)

--- a/src/Vehicle/Vehicle.cc
+++ b/src/Vehicle/Vehicle.cc
@@ -1918,7 +1918,7 @@ void Vehicle::virtualTabletJoystickValue(double roll, double pitch, double yaw, 
                     static_cast<float>(pitch),
                     static_cast<float>(yaw),
                     static_cast<float>(thrust),
-                    0);
+                    0, 0);
     }
 }
 
@@ -3882,7 +3882,7 @@ void Vehicle::clearAllParamMapRC(void)
     }
 }
 
-void Vehicle::sendJoystickDataThreadSafe(float roll, float pitch, float yaw, float thrust, quint16 buttons)
+void Vehicle::sendJoystickDataThreadSafe(float roll, float pitch, float yaw, float thrust, quint16 buttons, quint16 buttons2)
 {
     SharedLinkInterfacePtr sharedLink = vehicleLinkManager()->primaryLink().lock();
     if (!sharedLink) {
@@ -3913,7 +3913,7 @@ void Vehicle::sendJoystickDataThreadSafe(float roll, float pitch, float yaw, flo
         static_cast<int16_t>(newRollCommand),
         static_cast<int16_t>(newThrustCommand),
         static_cast<int16_t>(newYawCommand),
-        buttons, 0,
+        buttons, buttons2,
         0,
         0, 0,
         0, 0, 0, 0, 0, 0

--- a/src/Vehicle/Vehicle.h
+++ b/src/Vehicle/Vehicle.h
@@ -446,7 +446,7 @@ public:
 
     bool joystickEnabled            () const;
     void setJoystickEnabled         (bool enabled);
-    void sendJoystickDataThreadSafe (float roll, float pitch, float yaw, float thrust, quint16 buttons);
+    void sendJoystickDataThreadSafe (float roll, float pitch, float yaw, float thrust, quint16 buttons, quint16 buttons2);
 
     // Property accesors
     int id() const{ return _id; }


### PR DESCRIPTION
<!--- Title -->

Description
-----------

When a joystick has more than 16 buttons, the state of the buttons beyond the first 16 is now sent via the `MANUAL_CONTROL.buttons2` field. This ensures full button state is transmitted for joysticks with extended input capabilities.

Test Steps
-----------

Inspect MAVLink `MANUAL_CONTROL` sent from QGC or received on FC and ensure `buttons2` is properly filled.

Note: The `buttons` field is always `0` in current `master` due to custom joystick config below:

https://github.com/mavlink/qgroundcontrol/blob/f2d676939d79a66dd8081d1cb6023bea39d3e85a/cmake/CustomOptions.cmake#L38

One may want to remove the value before testing it. 

Checklist:
----------
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] [Review Contribution Guidelines](https://github.com/mavlink/qgroundcontrol/blob/master/.github/CONTRIBUTING.md).
- [x] [Review Code of Conduct](https://github.com/mavlink/qgroundcontrol/blob/master/.github/CODE_OF_CONDUCT.md).
- [x] I have tested my changes.

Related Issue
-----------
<!-- If any, please provide issue ID. -->


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.