### PR TITLE
Add for Accton Godwit GA1

### DIFF
--- a/src/Comms/USBBoardInfo.json
+++ b/src/Comms/USBBoardInfo.json
@@ -54,6 +54,8 @@
         { "vendorID": 9900, "productID": 4132,      "boardClass": "Pixhawk",    "name": "mRo Control Zero H7 OEM" },
         { "vendorID": 9900, "productID": 4388,      "boardClass": "Pixhawk",    "name": "3DR Control Zero H7 OEM Rev G" },
 
+        { "vendorID": 2106, "productID": 7120,      "boardClass": "Pixhawk",    "name": "PX4 Accton Godwit GA1" },
+
         { "vendorID": 1027, "productID": 24597,     "boardClass": "SiK Radio",  "name": "SiK Radio",            "comment": "3DR Radio" },
         { "vendorID": 4292, "productID": 60000,     "boardClass": "SiK Radio",  "name": "SiK Radio",            "comment": "SILabs Radio" },
         { "vendorID": 12346, "productID": 4097,     "boardClass": "SiK Radio",  "name": "DroneBridge Radio",    "comment": "ESP32-based telemetry radio" },


### PR DESCRIPTION
<!--- Title -->
Add support for new PX4 board, accton-godwit_ga1

Description
-----------
<!--- Describe your changes in detail. -->
This board is under PX4-Autopilot PR, https://github.com/PX4/PX4-Autopilot/pull/25102
board_id = 7120
USB VID/PID = 0x083A/0x1BD0

Product/board description can be found in our official web site
https://www.accton-iot.com/godwitdoc/en/index.html

Business and supported eMails are also listed
https://www.accton-iot.com/godwit/en/index.html

Test Steps
-----------
<!-- Describe the steps to reproduce. -->
1. GA1 board + accton-godwit_ga1 PX4 firmware
2. Built QGC release on Win 11 as https://docs.qgroundcontrol.com/master/en/qgc-dev-guide/getting_started/
3. Run built QGC and connect to GA1 via USB
4. GA1 can be recognized and connected automatically


Checklist:
----------
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] [Review Contribution Guidelines](https://github.com/mavlink/qgroundcontrol/blob/master/.github/CONTRIBUTING.md).
- [x] [Review Code of Conduct](https://github.com/mavlink/qgroundcontrol/blob/master/.github/CODE_OF_CONDUCT.md).
- [x] I have tested my changes.

Related Issue
-----------
<!-- If any, please provide issue ID. -->
None


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.