### PR TITLE
Unset SDL_GAMECONTROLLERCONFIG value

### DIFF
--- a/cmake/CustomOptions.cmake
+++ b/cmake/CustomOptions.cmake
@@ -35,7 +35,7 @@ cmake_dependent_option(QGC_CUSTOM_GST_PACKAGE "Enable Using QGC Provided Custom 
 option(QGC_ENABLE_QT_VIDEOSTREAMING "Enable QtMultimedia Video Backend" OFF) # Qt6Multimedia_FOUND
 
 # Joystick
-set(SDL_GAMECONTROLLERCONFIG "0300000009120000544f000011010000,OpenTX Radiomaster TX16S Joystick,leftx:a3,lefty:a2,rightx:a0,righty:a1,platform:Linux" CACHE STRING "Custom SDL Joystick Mappings")
+# set(SDL_GAMECONTROLLERCONFIG "0300000009120000544f000011010000,OpenTX Radiomaster TX16S Joystick,leftx:a3,lefty:a2,rightx:a0,righty:a1,platform:Linux" CACHE STRING "Custom SDL Joystick Mappings")
 
 # MAVLink
 set(QGC_MAVLINK_GIT_REPO "https://github.com/mavlink/c_library_v2.git" CACHE STRING "URL to MAVLink Git Repo")


### PR DESCRIPTION
Description
-----------

The current `SDL_GAMECONTROLLERCONFIG` parameter lacks button mappings, resulting in buttons not being detected on any joystick matching its GUID. This GUID corresponds to OpenTX Radiomaster TX12 MKII, despite the joystick name in the configuration indicating it should apply to TX16S.

The origin of this GUID is unclear, but since it incorrectly matches a different device and causes button input failures that were previously absent, it is preferable to comment out this value.

This change restores expected behavior and aligns with the stable branch, where the parameter was also disabled.

Test Steps
-----------

- Run QGC.
- Navigate to Joystick setup screen.
- Click on buttons and switch toggles.
- See buttons and toggles are picked up (i.e., pressed buttons are highlighted).

Checklist:
----------
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] [Review Contribution Guidelines](https://github.com/mavlink/qgroundcontrol/blob/master/.github/CONTRIBUTING.md).
- [x] [Review Code of Conduct](https://github.com/mavlink/qgroundcontrol/blob/master/.github/CODE_OF_CONDUCT.md).
- [x] I have tested my changes.

Related Issue
-----------
<!-- If any, please provide issue ID. -->


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.