### PR TITLE
CMake: Remove Extra QML Modules

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -207,7 +207,6 @@ qt_add_qml_module(${CMAKE_PROJECT_NAME}
         QtQuick.Controls
         QtQuick.Dialogs
         QtQuick.Layouts
-        QtQuick.Window
 )
 
 add_subdirectory(src)

--- a/CodingStyle.qml
+++ b/CodingStyle.qml
@@ -12,7 +12,7 @@ import QtQuick
 import QtQuick.Controls
 
 import QGroundControl
-import QGroundControl.ScreenTools
+
 import QGroundControl.Controls
 
 

--- a/custom-example/res/Custom/Widgets/CustomAttitudeWidget.qml
+++ b/custom-example/res/Custom/Widgets/CustomAttitudeWidget.qml
@@ -13,7 +13,7 @@ import QtQuick
 
 import QGroundControl
 import QGroundControl.Controls
-import QGroundControl.ScreenTools
+
 
 import QGroundControl.FlightMap
 import Qt5Compat.GraphicalEffects

--- a/custom-example/res/Custom/Widgets/CustomIconButton.qml
+++ b/custom-example/res/Custom/Widgets/CustomIconButton.qml
@@ -15,7 +15,7 @@ import QtQuick.Controls
 import QGroundControl
 import QGroundControl.Controls
 
-import QGroundControl.ScreenTools
+
 
 Button {
     id:                             _rootButton

--- a/custom-example/res/Custom/Widgets/CustomOnOffSwitch.qml
+++ b/custom-example/res/Custom/Widgets/CustomOnOffSwitch.qml
@@ -12,7 +12,7 @@
 import QtQuick
 
 
-import QGroundControl.ScreenTools
+import QGroundControl
 import QGroundControl.Controls
 
 Rectangle {

--- a/custom-example/res/Custom/Widgets/CustomQuickButton.qml
+++ b/custom-example/res/Custom/Widgets/CustomQuickButton.qml
@@ -15,7 +15,7 @@ import QtQuick.Controls
 import QGroundControl
 import QGroundControl.Controls
 
-import QGroundControl.ScreenTools
+
 
 Button {
     id:                         control

--- a/custom-example/res/Custom/Widgets/CustomSignalStrength.qml
+++ b/custom-example/res/Custom/Widgets/CustomSignalStrength.qml
@@ -14,7 +14,7 @@ import QtQuick.Controls
 
 import QGroundControl
 import QGroundControl.Controls
-import QGroundControl.ScreenTools
+
 
 
 Item {

--- a/custom-example/res/Custom/Widgets/CustomToolBarButton.qml
+++ b/custom-example/res/Custom/Widgets/CustomToolBarButton.qml
@@ -14,7 +14,7 @@ import QtQuick.Controls
 
 import QGroundControl.Controls
 
-import QGroundControl.ScreenTools
+
 
 Button {
     id:                             button

--- a/custom-example/res/Custom/Widgets/CustomVehicleButton.qml
+++ b/custom-example/res/Custom/Widgets/CustomVehicleButton.qml
@@ -14,7 +14,7 @@ import QtQuick.Controls
 
 import QGroundControl.Controls
 
-import QGroundControl.ScreenTools
+
 
 Button {
     id:                             button

--- a/custom-example/src/FlyViewCustomLayer.qml
+++ b/custom-example/src/FlyViewCustomLayer.qml
@@ -14,7 +14,7 @@ import QtQuick.Layouts
 import QGroundControl
 import QGroundControl.Controls
 
-import QGroundControl.ScreenTools
+
 
 import Custom.Widgets
 

--- a/docs/en/qgc-dev-guide/user_interface_design/font_palette.md
+++ b/docs/en/qgc-dev-guide/user_interface_design/font_palette.md
@@ -3,7 +3,7 @@
 QGC has a standard set of fonts and color palette which should be used by all user interface.
 
 ```
-import QGroundControl.ScreenTools
+import QGroundControl.Controls
 ```
 
 ## QGCPalette

--- a/src/API/QGCCorePlugin.cc
+++ b/src/API/QGCCorePlugin.cc
@@ -266,7 +266,7 @@ QQmlApplicationEngine *QGCCorePlugin::createQmlApplicationEngine(QObject *parent
 
 void QGCCorePlugin::createRootWindow(QQmlApplicationEngine *qmlEngine)
 {
-    qmlEngine->load(QUrl(QStringLiteral("qrc:/qml/QGroundControl/MainWindow/MainWindow.qml")));
+    qmlEngine->load(QUrl(QStringLiteral("qrc:/qml/QGroundControl/MainWindow.qml")));
 }
 
 VideoReceiver *QGCCorePlugin::createVideoReceiver(QObject *parent)

--- a/src/AnalyzeView/AnalyzeView.qml
+++ b/src/AnalyzeView/AnalyzeView.qml
@@ -15,7 +15,7 @@ import QGroundControl
 
 import QGroundControl.Controls
 
-import QGroundControl.ScreenTools
+
 
 Rectangle {
     id:     _root

--- a/src/AnalyzeView/GeoTagPage.qml
+++ b/src/AnalyzeView/GeoTagPage.qml
@@ -14,7 +14,7 @@ import QtQuick.Layouts
 
 import QGroundControl
 import QGroundControl.Controls
-import QGroundControl.ScreenTools
+
 
 
 AnalyzePage {

--- a/src/AnalyzeView/LogDownloadPage.qml
+++ b/src/AnalyzeView/LogDownloadPage.qml
@@ -15,7 +15,7 @@ import Qt.labs.qmlmodels
 import QGroundControl
 import QGroundControl.Controls
 
-import QGroundControl.ScreenTools
+
 
 AnalyzePage {
     id: logDownloadPage

--- a/src/AnalyzeView/MAVLinkConsolePage.qml
+++ b/src/AnalyzeView/MAVLinkConsolePage.qml
@@ -13,7 +13,7 @@ import QtQuick.Layouts
 
 import QGroundControl
 import QGroundControl.Controls
-import QGroundControl.ScreenTools
+
 
 
 AnalyzePage {

--- a/src/AnalyzeView/MAVLinkInspectorPage.qml
+++ b/src/AnalyzeView/MAVLinkInspectorPage.qml
@@ -18,7 +18,7 @@ import QGroundControl
 
 import QGroundControl.Controls
 
-import QGroundControl.ScreenTools
+
 
 AnalyzePage {
     id: root

--- a/src/AnalyzeView/VibrationPage.qml
+++ b/src/AnalyzeView/VibrationPage.qml
@@ -17,7 +17,7 @@ import QGroundControl
 
 import QGroundControl.FactControls
 import QGroundControl.Controls
-import QGroundControl.ScreenTools
+
 
 
 AnalyzePage {

--- a/src/AutoPilotPlugins/APM/APMAirframeComponent.qml
+++ b/src/AutoPilotPlugins/APM/APMAirframeComponent.qml
@@ -19,7 +19,7 @@ import QGroundControl.FactControls
 
 import QGroundControl.Controls
 
-import QGroundControl.ScreenTools
+
 
 SetupPage {
     id:             airframePage

--- a/src/AutoPilotPlugins/APM/APMCameraComponent.qml
+++ b/src/AutoPilotPlugins/APM/APMCameraComponent.qml
@@ -16,7 +16,7 @@ import QGroundControl
 import QGroundControl.FactControls
 
 import QGroundControl.Controls
-import QGroundControl.ScreenTools
+
 
 SetupPage {
     id:             cameraPage

--- a/src/AutoPilotPlugins/APM/APMCameraSubComponent.qml
+++ b/src/AutoPilotPlugins/APM/APMCameraSubComponent.qml
@@ -16,7 +16,7 @@ import QGroundControl
 import QGroundControl.FactControls
 
 import QGroundControl.Controls
-import QGroundControl.ScreenTools
+
 
 
 SetupPage {

--- a/src/AutoPilotPlugins/APM/APMFlightModesComponent.qml
+++ b/src/AutoPilotPlugins/APM/APMFlightModesComponent.qml
@@ -18,7 +18,7 @@ import QGroundControl.FactControls
 
 import QGroundControl.Controls
 
-import QGroundControl.ScreenTools
+
 
 SetupPage {
     id:             flightModePage

--- a/src/AutoPilotPlugins/APM/APMFollowComponent.qml
+++ b/src/AutoPilotPlugins/APM/APMFollowComponent.qml
@@ -18,7 +18,7 @@ import QGroundControl
 import QGroundControl.FactControls
 
 import QGroundControl.Controls
-import QGroundControl.ScreenTools
+
 
 
 SetupPage {

--- a/src/AutoPilotPlugins/APM/APMHeliComponent.qml
+++ b/src/AutoPilotPlugins/APM/APMHeliComponent.qml
@@ -16,7 +16,7 @@ import QGroundControl
 import QGroundControl.FactControls
 
 import QGroundControl.Controls
-import QGroundControl.ScreenTools
+
 
 SetupPage {
     id:             safetyPage

--- a/src/AutoPilotPlugins/APM/APMLightsComponent.qml
+++ b/src/AutoPilotPlugins/APM/APMLightsComponent.qml
@@ -16,7 +16,7 @@ import QGroundControl
 import QGroundControl.FactControls
 
 import QGroundControl.Controls
-import QGroundControl.ScreenTools
+
 
 SetupPage {
     id:                 lightsPage

--- a/src/AutoPilotPlugins/APM/APMPowerComponent.qml
+++ b/src/AutoPilotPlugins/APM/APMPowerComponent.qml
@@ -18,7 +18,7 @@ import QGroundControl
 import QGroundControl.FactControls
 
 import QGroundControl.Controls
-import QGroundControl.ScreenTools
+
 
 SetupPage {
     id:             powerPage

--- a/src/AutoPilotPlugins/APM/APMRemoteSupportComponent.qml
+++ b/src/AutoPilotPlugins/APM/APMRemoteSupportComponent.qml
@@ -13,7 +13,7 @@ import QtQuick.Layouts
 
 import QGroundControl
 import QGroundControl.Controls
-import QGroundControl.ScreenTools
+
 
 import QGroundControl.FactControls
 

--- a/src/AutoPilotPlugins/APM/APMSafetyComponent.qml
+++ b/src/AutoPilotPlugins/APM/APMSafetyComponent.qml
@@ -16,7 +16,7 @@ import QGroundControl
 import QGroundControl.FactControls
 
 import QGroundControl.Controls
-import QGroundControl.ScreenTools
+
 
 SetupPage {
     id:             safetyPage

--- a/src/AutoPilotPlugins/APM/APMSafetyComponentCopter.qml
+++ b/src/AutoPilotPlugins/APM/APMSafetyComponentCopter.qml
@@ -17,7 +17,7 @@ import QGroundControl
 import QGroundControl.FactControls
 
 import QGroundControl.Controls
-import QGroundControl.ScreenTools
+
 
 SetupPage {
     id:             safetyPage

--- a/src/AutoPilotPlugins/APM/APMSafetyComponentPlane.qml
+++ b/src/AutoPilotPlugins/APM/APMSafetyComponentPlane.qml
@@ -16,7 +16,7 @@ import QGroundControl
 import QGroundControl.FactControls
 
 import QGroundControl.Controls
-import QGroundControl.ScreenTools
+
 
 SetupPage {
     id:             safetyPage

--- a/src/AutoPilotPlugins/APM/APMSafetyComponentRover.qml
+++ b/src/AutoPilotPlugins/APM/APMSafetyComponentRover.qml
@@ -16,7 +16,7 @@ import QGroundControl
 import QGroundControl.FactControls
 
 import QGroundControl.Controls
-import QGroundControl.ScreenTools
+
 
 SetupPage {
     id:             safetyPage

--- a/src/AutoPilotPlugins/APM/APMSafetyComponentSub.qml
+++ b/src/AutoPilotPlugins/APM/APMSafetyComponentSub.qml
@@ -16,7 +16,7 @@ import QGroundControl
 import QGroundControl.FactControls
 
 import QGroundControl.Controls
-import QGroundControl.ScreenTools
+
 
 SetupPage {
     id:                 safetyPage

--- a/src/AutoPilotPlugins/APM/APMSensorsComponent.qml
+++ b/src/AutoPilotPlugins/APM/APMSensorsComponent.qml
@@ -18,7 +18,7 @@ import QGroundControl
 import QGroundControl.FactControls
 
 import QGroundControl.Controls
-import QGroundControl.ScreenTools
+
 
 
 SetupPage {

--- a/src/AutoPilotPlugins/APM/APMSubFrameComponent.qml
+++ b/src/AutoPilotPlugins/APM/APMSubFrameComponent.qml
@@ -18,7 +18,7 @@ import QGroundControl
 import QGroundControl.FactControls
 
 import QGroundControl.Controls
-import QGroundControl.ScreenTools
+
 
 
 SetupPage {

--- a/src/AutoPilotPlugins/APM/APMSubMotorComponent.qml
+++ b/src/AutoPilotPlugins/APM/APMSubMotorComponent.qml
@@ -14,7 +14,7 @@ import QtQuick.Dialogs
 import QGroundControl
 import QGroundControl.Controls
 
-import QGroundControl.ScreenTools
+
 
 
 SetupPage {

--- a/src/AutoPilotPlugins/APM/APMTuningComponentCopter.qml
+++ b/src/AutoPilotPlugins/APM/APMTuningComponentCopter.qml
@@ -17,7 +17,7 @@ import QGroundControl
 import QGroundControl.FactControls
 
 import QGroundControl.Controls
-import QGroundControl.ScreenTools
+
 
 
 SetupPage {

--- a/src/AutoPilotPlugins/APM/APMTuningComponentSub.qml
+++ b/src/AutoPilotPlugins/APM/APMTuningComponentSub.qml
@@ -16,7 +16,7 @@ import QGroundControl
 import QGroundControl.FactControls
 
 import QGroundControl.Controls
-import QGroundControl.ScreenTools
+
 
 SetupPage {
     id:             tuningPage

--- a/src/AutoPilotPlugins/Common/ESP8266Component.qml
+++ b/src/AutoPilotPlugins/Common/ESP8266Component.qml
@@ -18,7 +18,7 @@ import QGroundControl
 import QGroundControl.FactControls
 
 import QGroundControl.Controls
-import QGroundControl.ScreenTools
+
 
 
 Item {

--- a/src/AutoPilotPlugins/Common/MotorComponent.qml
+++ b/src/AutoPilotPlugins/Common/MotorComponent.qml
@@ -14,7 +14,7 @@ import QtQuick.Dialogs
 import QGroundControl
 import QGroundControl.Controls
 
-import QGroundControl.ScreenTools
+
 
 SetupPage {
     id:             motorPage

--- a/src/AutoPilotPlugins/Common/RadioComponent.qml
+++ b/src/AutoPilotPlugins/Common/RadioComponent.qml
@@ -16,7 +16,7 @@ import QGroundControl
 
 import QGroundControl.FactControls
 import QGroundControl.Controls
-import QGroundControl.ScreenTools
+
 
 
 

--- a/src/AutoPilotPlugins/Common/SyslinkComponent.qml
+++ b/src/AutoPilotPlugins/Common/SyslinkComponent.qml
@@ -18,7 +18,7 @@ import QGroundControl
 
 import QGroundControl.FactControls
 import QGroundControl.Controls
-import QGroundControl.ScreenTools
+
 
 
 SetupPage {

--- a/src/AutoPilotPlugins/PX4/ActuatorComponent.qml
+++ b/src/AutoPilotPlugins/PX4/ActuatorComponent.qml
@@ -7,7 +7,7 @@ import QGroundControl
 import QGroundControl.Controls
 import QGroundControl.FactControls
 
-import QGroundControl.ScreenTools
+
 import QGroundControl.AutoPilotPlugins.PX4
 
 SetupPage {

--- a/src/AutoPilotPlugins/PX4/ActuatorFact.qml
+++ b/src/AutoPilotPlugins/PX4/ActuatorFact.qml
@@ -5,7 +5,7 @@ import QtQuick.Layouts
 import QGroundControl
 import QGroundControl.Controls
 import QGroundControl.FactControls
-import QGroundControl.ScreenTools
+
 
 Loader {
 	property var fact

--- a/src/AutoPilotPlugins/PX4/ActuatorSlider.qml
+++ b/src/AutoPilotPlugins/PX4/ActuatorSlider.qml
@@ -4,7 +4,7 @@ import QtQuick.Layouts
 
 import QGroundControl
 import QGroundControl.Controls
-import QGroundControl.ScreenTools
+
 
 Column {
     property var channel

--- a/src/AutoPilotPlugins/PX4/AirframeComponent.qml
+++ b/src/AutoPilotPlugins/PX4/AirframeComponent.qml
@@ -18,7 +18,7 @@ import QGroundControl.FactControls
 
 import QGroundControl.Controls
 
-import QGroundControl.ScreenTools
+
 
 SetupPage {
     id:             airframePage

--- a/src/AutoPilotPlugins/PX4/BatteryParams.qml
+++ b/src/AutoPilotPlugins/PX4/BatteryParams.qml
@@ -16,7 +16,7 @@ import QGroundControl
 
 import QGroundControl.FactControls
 import QGroundControl.Controls
-import QGroundControl.ScreenTools
+
 
 
 // Exposes the set of battery parameters taking into account the availability of the parameters.

--- a/src/AutoPilotPlugins/PX4/FlightModesComponentSummary.qml
+++ b/src/AutoPilotPlugins/PX4/FlightModesComponentSummary.qml
@@ -6,7 +6,7 @@ import QGroundControl
 import QGroundControl.FactControls
 import QGroundControl.Controls
 
-import QGroundControl.ScreenTools
+
 
 Item {
     anchors.fill:   parent

--- a/src/AutoPilotPlugins/PX4/PX4FlightBehaviorCopter.qml
+++ b/src/AutoPilotPlugins/PX4/PX4FlightBehaviorCopter.qml
@@ -15,7 +15,7 @@ import QGroundControl
 
 import QGroundControl.Controls
 
-import QGroundControl.ScreenTools
+
 
 SetupPage {
     id:             flightBehavior

--- a/src/AutoPilotPlugins/PX4/PX4FlightModes.qml
+++ b/src/AutoPilotPlugins/PX4/PX4FlightModes.qml
@@ -19,7 +19,7 @@ import QGroundControl.FactControls
 
 import QGroundControl.Controls
 
-import QGroundControl.ScreenTools
+
 
 /// PX4 Flight Mode configuration. This control will load either the Simple or Advanced Flight Mode config
 /// based on current parameter settings.

--- a/src/AutoPilotPlugins/PX4/PX4SimpleFlightModes.qml
+++ b/src/AutoPilotPlugins/PX4/PX4SimpleFlightModes.qml
@@ -17,7 +17,7 @@ import QGroundControl.FactControls
 
 import QGroundControl.Controls
 
-import QGroundControl.ScreenTools
+
 
 Item {
     id: root

--- a/src/AutoPilotPlugins/PX4/PX4TuningComponent.qml
+++ b/src/AutoPilotPlugins/PX4/PX4TuningComponent.qml
@@ -14,7 +14,7 @@ import QtQuick.Layouts
 import QGroundControl
 import QGroundControl.Controls
 
-import QGroundControl.ScreenTools
+
 
 ColumnLayout {
     id:         root

--- a/src/AutoPilotPlugins/PX4/PX4TuningComponentCopterAll.qml
+++ b/src/AutoPilotPlugins/PX4/PX4TuningComponentCopterAll.qml
@@ -14,7 +14,7 @@ import QtQuick.Layouts
 import QGroundControl
 import QGroundControl.Controls
 
-import QGroundControl.ScreenTools
+
 
 PX4TuningComponent {
     model: ListModel {

--- a/src/AutoPilotPlugins/PX4/PX4TuningComponentCopterAttitude.qml
+++ b/src/AutoPilotPlugins/PX4/PX4TuningComponentCopterAttitude.qml
@@ -15,7 +15,7 @@ import QGroundControl
 import QGroundControl.Controls
 
 import QGroundControl.FactControls
-import QGroundControl.ScreenTools
+
 
 
 ColumnLayout {

--- a/src/AutoPilotPlugins/PX4/PX4TuningComponentCopterPosition.qml
+++ b/src/AutoPilotPlugins/PX4/PX4TuningComponentCopterPosition.qml
@@ -15,7 +15,7 @@ import QGroundControl
 import QGroundControl.Controls
 
 import QGroundControl.FactControls
-import QGroundControl.ScreenTools
+
 
 
 ColumnLayout {

--- a/src/AutoPilotPlugins/PX4/PX4TuningComponentCopterRate.qml
+++ b/src/AutoPilotPlugins/PX4/PX4TuningComponentCopterRate.qml
@@ -15,7 +15,7 @@ import QGroundControl
 import QGroundControl.Controls
 
 import QGroundControl.FactControls
-import QGroundControl.ScreenTools
+
 
 
 ColumnLayout {

--- a/src/AutoPilotPlugins/PX4/PX4TuningComponentCopterVelocity.qml
+++ b/src/AutoPilotPlugins/PX4/PX4TuningComponentCopterVelocity.qml
@@ -15,7 +15,7 @@ import QGroundControl
 import QGroundControl.Controls
 
 import QGroundControl.FactControls
-import QGroundControl.ScreenTools
+
 
 
 ColumnLayout {

--- a/src/AutoPilotPlugins/PX4/PX4TuningComponentPlaneAll.qml
+++ b/src/AutoPilotPlugins/PX4/PX4TuningComponentPlaneAll.qml
@@ -14,7 +14,7 @@ import QtQuick.Layouts
 import QGroundControl
 import QGroundControl.Controls
 
-import QGroundControl.ScreenTools
+
 
 PX4TuningComponent {
     model: ListModel {

--- a/src/AutoPilotPlugins/PX4/PX4TuningComponentPlaneAttitude.qml
+++ b/src/AutoPilotPlugins/PX4/PX4TuningComponentPlaneAttitude.qml
@@ -15,7 +15,7 @@ import QGroundControl
 import QGroundControl.Controls
 
 import QGroundControl.FactControls
-import QGroundControl.ScreenTools
+
 
 
 ColumnLayout {

--- a/src/AutoPilotPlugins/PX4/PX4TuningComponentPlaneRate.qml
+++ b/src/AutoPilotPlugins/PX4/PX4TuningComponentPlaneRate.qml
@@ -15,7 +15,7 @@ import QGroundControl
 import QGroundControl.Controls
 
 import QGroundControl.FactControls
-import QGroundControl.ScreenTools
+
 
 
 ColumnLayout {

--- a/src/AutoPilotPlugins/PX4/PX4TuningComponentPlaneTECS.qml
+++ b/src/AutoPilotPlugins/PX4/PX4TuningComponentPlaneTECS.qml
@@ -15,7 +15,7 @@ import QGroundControl
 import QGroundControl.Controls
 
 import QGroundControl.FactControls
-import QGroundControl.ScreenTools
+
 
 
 ColumnLayout {

--- a/src/AutoPilotPlugins/PX4/PX4TuningComponentVTOL.qml
+++ b/src/AutoPilotPlugins/PX4/PX4TuningComponentVTOL.qml
@@ -14,7 +14,7 @@ import QtQuick.Controls
 import QGroundControl
 import QGroundControl.Controls
 
-import QGroundControl.ScreenTools
+
 
 PX4TuningComponent {
     model: ListModel {

--- a/src/AutoPilotPlugins/PX4/PowerComponent.qml
+++ b/src/AutoPilotPlugins/PX4/PowerComponent.qml
@@ -16,7 +16,7 @@ import QGroundControl
 
 import QGroundControl.FactControls
 import QGroundControl.Controls
-import QGroundControl.ScreenTools
+
 
 import QGroundControl.AutoPilotPlugins.PX4
 

--- a/src/AutoPilotPlugins/PX4/SafetyComponent.qml
+++ b/src/AutoPilotPlugins/PX4/SafetyComponent.qml
@@ -16,7 +16,7 @@ import QGroundControl
 
 import QGroundControl.FactControls
 import QGroundControl.Controls
-import QGroundControl.ScreenTools
+
 
 
 SetupPage {

--- a/src/AutoPilotPlugins/PX4/SensorsSetup.qml
+++ b/src/AutoPilotPlugins/PX4/SensorsSetup.qml
@@ -17,7 +17,7 @@ import QGroundControl
 import QGroundControl.FactControls
 
 import QGroundControl.Controls
-import QGroundControl.ScreenTools
+
 
 
 /// Page for sensor calibration. This control is used within the SensorsComponent control and can also be used

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -1,9 +1,13 @@
 qt_add_library(QGroundControlModule STATIC)
 
+set_source_files_properties(UI/MainWindow.qml PROPERTIES QT_RESOURCE_ALIAS MainWindow.qml)
+
 qt_add_qml_module(QGroundControlModule
     URI QGroundControl
     VERSION 1.0
     RESOURCE_PREFIX /qml
+    QML_FILES
+        UI/MainWindow.qml
     IMPORTS
         QGC
     NO_PLUGIN
@@ -90,10 +94,8 @@ target_link_libraries(${CMAKE_PROJECT_NAME}
         FirstRunPromptDialogsModule
         FlightDisplayModule
         FlightMapModule
-        MainWindowModule
         QGroundControlControlsModule
         QGroundControlModule
-        ScreenToolsModule
         ToolbarModule
         UTMSPModule
         VehicleSetupModule

--- a/src/Comms/AirLink/AirLinkSettings.qml
+++ b/src/Comms/AirLink/AirLinkSettings.qml
@@ -17,7 +17,7 @@ import QGroundControl
 import QGroundControl.Controls
 import QGroundControl.FactControls
 
-import QGroundControl.ScreenTools
+
 
 
 ColumnLayout {

--- a/src/FactSystem/FactControls/AltitudeFactTextField.qml
+++ b/src/FactSystem/FactControls/AltitudeFactTextField.qml
@@ -13,7 +13,7 @@ import QtQuick.Layouts
 import QGroundControl
 
 import QGroundControl.Controls
-import QGroundControl.ScreenTools
+
 
 FactTextField {
     unitsLabel:                 fact ? fact.units : ""

--- a/src/FactSystem/FactControls/FactBitmask.qml
+++ b/src/FactSystem/FactControls/FactBitmask.qml
@@ -5,7 +5,7 @@ import QGroundControl
 
 
 import QGroundControl.Controls
-import QGroundControl.ScreenTools
+
 
 Flow {
     spacing: ScreenTools.defaultFontPixelWidth

--- a/src/FactSystem/FactControls/FactTextField.qml
+++ b/src/FactSystem/FactControls/FactTextField.qml
@@ -6,7 +6,7 @@ import QGroundControl
 
 
 import QGroundControl.Controls
-import QGroundControl.ScreenTools
+
 
 QGCTextField {
     id:                 control

--- a/src/FactSystem/FactControls/FactTextFieldSlider.qml
+++ b/src/FactSystem/FactControls/FactTextFieldSlider.qml
@@ -5,7 +5,7 @@ import QtQuick.Layouts
 import QGroundControl
 
 import QGroundControl.Controls
-import QGroundControl.ScreenTools
+
 import QGroundControl.FactControls
 
 

--- a/src/FactSystem/FactControls/FactValueSlider.qml
+++ b/src/FactSystem/FactControls/FactValueSlider.qml
@@ -4,7 +4,7 @@ import QtQuick.Dialogs
 
 import QGroundControl
 
-import QGroundControl.ScreenTools
+
 import QGroundControl.Controls
 
 

--- a/src/FactSystem/FactControls/LabelledFactComboBox.qml
+++ b/src/FactSystem/FactControls/LabelledFactComboBox.qml
@@ -12,7 +12,7 @@ import QtQuick.Layouts
 
 import QGroundControl
 import QGroundControl.Controls
-import QGroundControl.ScreenTools
+
 
 import QGroundControl.FactControls
 

--- a/src/FactSystem/FactControls/LabelledFactTextField.qml
+++ b/src/FactSystem/FactControls/LabelledFactTextField.qml
@@ -12,7 +12,7 @@ import QtQuick.Layouts
 
 import QGroundControl
 import QGroundControl.Controls
-import QGroundControl.ScreenTools
+
 
 import QGroundControl.FactControls
 

--- a/src/FirmwarePlugin/PX4/PX4BatteryIndicator.qml
+++ b/src/FirmwarePlugin/PX4/PX4BatteryIndicator.qml
@@ -13,7 +13,7 @@ import QtQuick.Layouts
 import QGroundControl
 import QGroundControl.Controls
 
-import QGroundControl.ScreenTools
+
 
 
 import QGroundControl.FactControls

--- a/src/FirmwarePlugin/PX4/PX4FlightModeIndicator.qml
+++ b/src/FirmwarePlugin/PX4/PX4FlightModeIndicator.qml
@@ -14,7 +14,7 @@ import QtQuick.Layouts
 import QGroundControl
 import QGroundControl.Controls
 
-import QGroundControl.ScreenTools
+
 
 
 import QGroundControl.FactControls

--- a/src/FirmwarePlugin/PX4/PX4MainStatusIndicatorContentItem.qml
+++ b/src/FirmwarePlugin/PX4/PX4MainStatusIndicatorContentItem.qml
@@ -14,7 +14,7 @@ import QtQuick.Layouts
 import QGroundControl
 import QGroundControl.Controls
 
-import QGroundControl.ScreenTools
+
 
 
 import QGroundControl.FactControls

--- a/src/FlightDisplay/DefaultChecklist.qml
+++ b/src/FlightDisplay/DefaultChecklist.qml
@@ -12,7 +12,7 @@ import QtQuick.Controls
 import QtQml.Models
 
 import QGroundControl
-import QGroundControl.ScreenTools
+
 import QGroundControl.Controls
 import QGroundControl.FlightDisplay
 

--- a/src/FlightDisplay/FixedWingChecklist.qml
+++ b/src/FlightDisplay/FixedWingChecklist.qml
@@ -12,7 +12,7 @@ import QtQuick.Controls
 import QtQml.Models
 
 import QGroundControl
-import QGroundControl.ScreenTools
+
 import QGroundControl.Controls
 import QGroundControl.FlightDisplay
 

--- a/src/FlightDisplay/FlightDisplayViewVideo.qml
+++ b/src/FlightDisplay/FlightDisplayViewVideo.qml
@@ -14,7 +14,7 @@ import QtQuick.Controls
 import QGroundControl
 import QGroundControl.FlightDisplay
 import QGroundControl.FlightMap
-import QGroundControl.ScreenTools
+
 import QGroundControl.Controls
 
 

--- a/src/FlightDisplay/FlyView.qml
+++ b/src/FlightDisplay/FlyView.qml
@@ -24,7 +24,7 @@ import QGroundControl.Controls
 import QGroundControl.FlightDisplay
 import QGroundControl.FlightMap
 
-import QGroundControl.ScreenTools
+
 import QGroundControl.UTMSP
 
 import QGroundControl.Viewer3D

--- a/src/FlightDisplay/FlyViewCustomLayer.qml
+++ b/src/FlightDisplay/FlyViewCustomLayer.qml
@@ -24,7 +24,7 @@ import QGroundControl.Controls
 import QGroundControl.FlightDisplay
 import QGroundControl.FlightMap
 
-import QGroundControl.ScreenTools
+
 
 
 // To implement a custom overlay copy this code to your own control in your custom code source. Then override the

--- a/src/FlightDisplay/FlyViewInsetViewer.qml
+++ b/src/FlightDisplay/FlyViewInsetViewer.qml
@@ -21,7 +21,7 @@ import QGroundControl
 import QGroundControl.Controls
 
 import QGroundControl.FlightDisplay
-import QGroundControl.ScreenTools
+
 import QGroundControl.FlightMap
 
 

--- a/src/FlightDisplay/FlyViewMap.qml
+++ b/src/FlightDisplay/FlyViewMap.qml
@@ -20,7 +20,7 @@ import QGroundControl.Controls
 import QGroundControl.FlightDisplay
 import QGroundControl.FlightMap
 
-import QGroundControl.ScreenTools
+
 
 
 FlightMap {

--- a/src/FlightDisplay/FlyViewMissionCompleteDialog.qml
+++ b/src/FlightDisplay/FlyViewMissionCompleteDialog.qml
@@ -15,7 +15,7 @@ import QtQuick.Layouts
 import QGroundControl
 import QGroundControl.Controls
 
-import QGroundControl.ScreenTools
+
 
 /// Dialog which shows up when a flight completes. Prompts the user for things like whether they should remove the plan from the vehicle.
 Item {

--- a/src/FlightDisplay/FlyViewTopRightColumnLayout.qml
+++ b/src/FlightDisplay/FlyViewTopRightColumnLayout.qml
@@ -15,7 +15,7 @@ import QGroundControl.Controls
 import QGroundControl.FlightDisplay
 import QGroundControl.FlightMap
 
-import QGroundControl.ScreenTools
+
 
 ColumnLayout {
     width: _rightPanelWidth

--- a/src/FlightDisplay/FlyViewTopRightPanel.qml
+++ b/src/FlightDisplay/FlyViewTopRightPanel.qml
@@ -17,7 +17,7 @@ import QGroundControl.Controls
 import QGroundControl.FlightDisplay
 import QGroundControl.FlightMap
 
-import QGroundControl.ScreenTools
+
 
 
 Rectangle {

--- a/src/FlightDisplay/FlyViewVideo.qml
+++ b/src/FlightDisplay/FlyViewVideo.qml
@@ -12,7 +12,7 @@ import QtQuick
 import QGroundControl
 import QGroundControl.Controls
 
-import QGroundControl.ScreenTools
+
 
 Item {
     id: _root

--- a/src/FlightDisplay/FlyViewWidgetLayer.qml
+++ b/src/FlightDisplay/FlyViewWidgetLayer.qml
@@ -20,12 +20,10 @@ import QtQml.Models
 import QGroundControl
 import QGroundControl.Controls
 
-import QGroundControl.Controls
-
 import QGroundControl.FlightDisplay
 import QGroundControl.FlightMap
 
-import QGroundControl.ScreenTools
+
 
 
 // This is the ui overlay layer for the widgets/tools for Fly View

--- a/src/FlightDisplay/GripperMenu.qml
+++ b/src/FlightDisplay/GripperMenu.qml
@@ -7,7 +7,7 @@ import QtPositioning
 import QtQuick.Layouts
 
 import QGroundControl
-import QGroundControl.ScreenTools
+
 import QGroundControl.Controls
 
 

--- a/src/FlightDisplay/GuidedActionConfirm.qml
+++ b/src/FlightDisplay/GuidedActionConfirm.qml
@@ -12,7 +12,7 @@ import QtQuick.Controls
 import QtQuick.Layouts
 
 import QGroundControl
-import QGroundControl.ScreenTools
+
 import QGroundControl.Controls
 
 import QGroundControl.UTMSP

--- a/src/FlightDisplay/GuidedActionsController.qml
+++ b/src/FlightDisplay/GuidedActionsController.qml
@@ -15,7 +15,7 @@ import QtPositioning
 import QtQuick.Layouts
 
 import QGroundControl
-import QGroundControl.ScreenTools
+
 import QGroundControl.Controls
 
 

--- a/src/FlightDisplay/GuidedValueSlider.qml
+++ b/src/FlightDisplay/GuidedValueSlider.qml
@@ -15,7 +15,7 @@ import QGroundControl
 import QGroundControl.Controls
 
 
-import QGroundControl.ScreenTools
+
 
 
 Item {

--- a/src/FlightDisplay/MultiRotorChecklist.qml
+++ b/src/FlightDisplay/MultiRotorChecklist.qml
@@ -12,7 +12,7 @@ import QtQuick.Controls
 import QtQml.Models
 
 import QGroundControl
-import QGroundControl.ScreenTools
+
 import QGroundControl.Controls
 import QGroundControl.FlightDisplay
 

--- a/src/FlightDisplay/MultiVehicleList.qml
+++ b/src/FlightDisplay/MultiVehicleList.qml
@@ -12,7 +12,7 @@ import QtQuick.Controls
 import QtQuick.Layouts
 
 import QGroundControl
-import QGroundControl.ScreenTools
+
 import QGroundControl.Controls
 
 

--- a/src/FlightDisplay/OnScreenGimbalController.qml
+++ b/src/FlightDisplay/OnScreenGimbalController.qml
@@ -12,7 +12,7 @@ import QtQuick
 import QGroundControl
 import QGroundControl.Controls
 
-import QGroundControl.ScreenTools
+
 
 
 Item {

--- a/src/FlightDisplay/PreFlightCheckList.qml
+++ b/src/FlightDisplay/PreFlightCheckList.qml
@@ -13,7 +13,7 @@ import QtQml.Models
 import QtQuick.Layouts
 
 import QGroundControl
-import QGroundControl.ScreenTools
+
 import QGroundControl.Controls
 import QGroundControl.FlightDisplay
 

--- a/src/FlightDisplay/ProximityRadarVideoView.qml
+++ b/src/FlightDisplay/ProximityRadarVideoView.qml
@@ -12,7 +12,7 @@ import QtLocation
 import QtPositioning
 
 import QGroundControl
-import QGroundControl.ScreenTools
+
 
 import QGroundControl.Controls
 import QGroundControl.FlightDisplay

--- a/src/FlightDisplay/RoverChecklist.qml
+++ b/src/FlightDisplay/RoverChecklist.qml
@@ -12,7 +12,7 @@ import QtQuick.Controls
 import QtQml.Models
 
 import QGroundControl
-import QGroundControl.ScreenTools
+
 import QGroundControl.Controls
 import QGroundControl.FlightDisplay
 

--- a/src/FlightDisplay/SubChecklist.qml
+++ b/src/FlightDisplay/SubChecklist.qml
@@ -12,7 +12,7 @@ import QtQuick.Controls
 import QtQml.Models
 
 import QGroundControl
-import QGroundControl.ScreenTools
+
 import QGroundControl.Controls
 import QGroundControl.FlightDisplay
 

--- a/src/FlightDisplay/TelemetryValuesBar.qml
+++ b/src/FlightDisplay/TelemetryValuesBar.qml
@@ -11,7 +11,7 @@ import QtQuick
 import QtQuick.Layouts
 
 import QGroundControl
-import QGroundControl.ScreenTools
+
 
 import QGroundControl.Controls
 

--- a/src/FlightDisplay/TerrainProgress.qml
+++ b/src/FlightDisplay/TerrainProgress.qml
@@ -11,7 +11,7 @@ import QtQuick
 import QtQuick.Layouts
 
 import QGroundControl
-import QGroundControl.ScreenTools
+
 
 import QGroundControl.Controls
 

--- a/src/FlightDisplay/VTOLChecklist.qml
+++ b/src/FlightDisplay/VTOLChecklist.qml
@@ -12,7 +12,7 @@ import QtQuick.Controls
 import QtQml.Models
 
 import QGroundControl
-import QGroundControl.ScreenTools
+
 import QGroundControl.Controls
 import QGroundControl.FlightDisplay
 

--- a/src/FlightDisplay/VehicleWarnings.qml
+++ b/src/FlightDisplay/VehicleWarnings.qml
@@ -10,7 +10,7 @@
 import QtQuick
 
 import QGroundControl
-import QGroundControl.ScreenTools
+
 import QGroundControl.Controls
 
 Rectangle {

--- a/src/FlightDisplay/VirtualJoystick.qml
+++ b/src/FlightDisplay/VirtualJoystick.qml
@@ -11,7 +11,7 @@
 import QtQuick
 
 import QGroundControl
-import QGroundControl.ScreenTools
+
 import QGroundControl.Controls
 
 

--- a/src/FlightMap/FlightMap.qml
+++ b/src/FlightMap/FlightMap.qml
@@ -18,7 +18,7 @@ import QGroundControl
 
 import QGroundControl.Controls
 import QGroundControl.FlightMap
-import QGroundControl.ScreenTools
+
 
 
 

--- a/src/FlightMap/MapItems/CameraTriggerIndicator.qml
+++ b/src/FlightMap/MapItems/CameraTriggerIndicator.qml
@@ -12,7 +12,7 @@ import QtLocation
 import QtQuick.Controls
 
 import QGroundControl
-import QGroundControl.ScreenTools
+
 import QGroundControl.Controls
 
 

--- a/src/FlightMap/MapItems/MapLineArrow.qml
+++ b/src/FlightMap/MapItems/MapLineArrow.qml
@@ -13,7 +13,7 @@ import QtLocation
 import QtPositioning
 
 import QGroundControl
-import QGroundControl.ScreenTools
+
 
 import QGroundControl.Controls
 import QGroundControl.FlightMap

--- a/src/FlightMap/MapItems/MissionItemIndicator.qml
+++ b/src/FlightMap/MapItems/MissionItemIndicator.qml
@@ -12,7 +12,7 @@ import QtQuick
 import QtLocation
 
 import QGroundControl
-import QGroundControl.ScreenTools
+
 import QGroundControl.Controls
 
 

--- a/src/FlightMap/MapItems/MissionItemIndicatorDrag.qml
+++ b/src/FlightMap/MapItems/MissionItemIndicatorDrag.qml
@@ -11,7 +11,7 @@ import QtQuick
 import QtLocation
 
 import QGroundControl
-import QGroundControl.ScreenTools
+
 import QGroundControl.Controls
 
 /// Use to drag a MissionItemIndicator

--- a/src/FlightMap/MapItems/ProximityRadarMapView.qml
+++ b/src/FlightMap/MapItems/ProximityRadarMapView.qml
@@ -12,7 +12,7 @@ import QtLocation
 import QtPositioning
 
 import QGroundControl
-import QGroundControl.ScreenTools
+
 
 import QGroundControl.Controls
 import QGroundControl.FlightDisplay

--- a/src/FlightMap/MapItems/QGCMapCircleVisuals.qml
+++ b/src/FlightMap/MapItems/QGCMapCircleVisuals.qml
@@ -14,7 +14,7 @@ import QtLocation
 import QtPositioning
 
 import QGroundControl
-import QGroundControl.ScreenTools
+
 
 import QGroundControl.Controls
 import QGroundControl.FlightMap

--- a/src/FlightMap/MapItems/QGCMapPolygonVisuals.qml
+++ b/src/FlightMap/MapItems/QGCMapPolygonVisuals.qml
@@ -15,7 +15,7 @@ import QtQuick.Dialogs
 import QtQuick.Layouts
 
 import QGroundControl
-import QGroundControl.ScreenTools
+
 
 import QGroundControl.Controls
 import QGroundControl.FlightMap

--- a/src/FlightMap/MapItems/QGCMapPolylineVisuals.qml
+++ b/src/FlightMap/MapItems/QGCMapPolylineVisuals.qml
@@ -14,7 +14,7 @@ import QtPositioning
 import QtQuick.Dialogs
 
 import QGroundControl
-import QGroundControl.ScreenTools
+
 
 import QGroundControl.Controls
 import QGroundControl.FlightMap

--- a/src/FlightMap/MapItems/SplitIndicator.qml
+++ b/src/FlightMap/MapItems/SplitIndicator.qml
@@ -11,7 +11,7 @@ import QtQuick
 import QtQuick.Controls
 
 import QGroundControl
-import QGroundControl.ScreenTools
+
 import QGroundControl.Controls
 
 Rectangle {

--- a/src/FlightMap/MapItems/VehicleMapItem.qml
+++ b/src/FlightMap/MapItems/VehicleMapItem.qml
@@ -13,7 +13,7 @@ import QtLocation
 import QtPositioning
 
 import QGroundControl
-import QGroundControl.ScreenTools
+
 
 import QGroundControl.Controls
 

--- a/src/FlightMap/MapScale.qml
+++ b/src/FlightMap/MapScale.qml
@@ -12,7 +12,7 @@ import QtQuick.Controls
 
 import QGroundControl
 import QGroundControl.Controls
-import QGroundControl.ScreenTools
+
 
 
 /// Map scale control

--- a/src/FlightMap/Widgets/CenterMapDropButton.qml
+++ b/src/FlightMap/Widgets/CenterMapDropButton.qml
@@ -13,7 +13,7 @@ import QtQuick.Layouts
 import QtPositioning
 
 import QGroundControl
-import QGroundControl.ScreenTools
+
 import QGroundControl.Controls
 
 

--- a/src/FlightMap/Widgets/CenterMapDropPanel.qml
+++ b/src/FlightMap/Widgets/CenterMapDropPanel.qml
@@ -13,7 +13,7 @@ import QtQuick.Layouts
 import QtPositioning
 
 import QGroundControl
-import QGroundControl.ScreenTools
+
 import QGroundControl.Controls
 
 

--- a/src/FlightMap/Widgets/CompassDial.qml
+++ b/src/FlightMap/Widgets/CompassDial.qml
@@ -11,7 +11,7 @@ import QtQuick
 
 import QGroundControl
 import QGroundControl.Controls
-import QGroundControl.ScreenTools
+
 
 
 /// This is the dial background for the compass

--- a/src/FlightMap/Widgets/CompassHeadingIndicator.qml
+++ b/src/FlightMap/Widgets/CompassHeadingIndicator.qml
@@ -11,7 +11,7 @@ import QtQuick
 
 import QGroundControl
 import QGroundControl.Controls
-import QGroundControl.ScreenTools
+
 
 
 

--- a/src/FlightMap/Widgets/HorizontalCompassAttitude.qml
+++ b/src/FlightMap/Widgets/HorizontalCompassAttitude.qml
@@ -11,7 +11,7 @@ import QtQuick
 
 import QGroundControl
 import QGroundControl.Controls
-import QGroundControl.ScreenTools
+
 
 
 Rectangle {

--- a/src/FlightMap/Widgets/IntegratedAttitudeIndicator.qml
+++ b/src/FlightMap/Widgets/IntegratedAttitudeIndicator.qml
@@ -11,7 +11,7 @@ import QtQuick
 
 import QGroundControl
 import QGroundControl.Controls
-import QGroundControl.ScreenTools
+
 import QGroundControl.FlightDisplay
 import QGroundControl.FlightMap
 

--- a/src/FlightMap/Widgets/IntegratedCompassAttitude.qml
+++ b/src/FlightMap/Widgets/IntegratedCompassAttitude.qml
@@ -11,7 +11,7 @@ import QtQuick
 
 import QGroundControl
 import QGroundControl.Controls
-import QGroundControl.ScreenTools
+
 import QGroundControl.FlightDisplay
 import QGroundControl.FlightMap
 

--- a/src/FlightMap/Widgets/PhotoVideoControl.qml
+++ b/src/FlightMap/Widgets/PhotoVideoControl.qml
@@ -14,7 +14,7 @@ import QtQuick.Controls
 import QtQuick.Dialogs
 
 import QGroundControl
-import QGroundControl.ScreenTools
+
 import QGroundControl.Controls
 
 

--- a/src/FlightMap/Widgets/QGCAttitudeWidget.qml
+++ b/src/FlightMap/Widgets/QGCAttitudeWidget.qml
@@ -19,7 +19,7 @@ import QtQuick.Effects
 
 import QGroundControl
 import QGroundControl.Controls
-import QGroundControl.ScreenTools
+
 
 
 Item {

--- a/src/FlightMap/Widgets/QGCCompassWidget.qml
+++ b/src/FlightMap/Widgets/QGCCompassWidget.qml
@@ -11,7 +11,7 @@ import QtQuick
 
 import QGroundControl
 import QGroundControl.Controls
-import QGroundControl.ScreenTools
+
 
 
 

--- a/src/FlightMap/Widgets/QGCPitchIndicator.qml
+++ b/src/FlightMap/Widgets/QGCPitchIndicator.qml
@@ -16,7 +16,7 @@
 
 import QtQuick
 import QGroundControl
-import QGroundControl.ScreenTools
+
 import QGroundControl.Controls
 
 Rectangle {

--- a/src/FlightMap/Widgets/VerticalCompassAttitude.qml
+++ b/src/FlightMap/Widgets/VerticalCompassAttitude.qml
@@ -11,7 +11,7 @@ import QtQuick
 
 import QGroundControl
 import QGroundControl.Controls
-import QGroundControl.ScreenTools
+
 
 import QGroundControl.FlightMap
 

--- a/src/QmlControls/APMSubMotorDisplay.qml
+++ b/src/QmlControls/APMSubMotorDisplay.qml
@@ -1,10 +1,9 @@
 import QtQuick
 
-
-import QGroundControl.ScreenTools
 import QGroundControl
-
+import QGroundControl.Controls
 import QGroundControl.FactControls
+
 Item {
     id: root
 

--- a/src/QmlControls/AltModeDialog.qml
+++ b/src/QmlControls/AltModeDialog.qml
@@ -14,7 +14,7 @@ import QtQuick.Layouts
 
 import QGroundControl
 import QGroundControl.Controls
-import QGroundControl.ScreenTools
+
 
 QGCPopupDialog {
     title:   qsTr("Select Altitude Mode")

--- a/src/QmlControls/AnalyzePage.qml
+++ b/src/QmlControls/AnalyzePage.qml
@@ -13,7 +13,7 @@ import QtQuick.Controls
 import QGroundControl
 
 import QGroundControl.Controls
-import QGroundControl.ScreenTools
+
 
 /// Base view control for all Analyze pages
 Item {

--- a/src/QmlControls/AppMessages.qml
+++ b/src/QmlControls/AppMessages.qml
@@ -18,7 +18,7 @@ import QGroundControl.Controls
 
 import QGroundControl.FactControls
 
-import QGroundControl.ScreenTools
+
 
 Item {
     id:         _root

--- a/src/QmlControls/AppSettings.qml
+++ b/src/QmlControls/AppSettings.qml
@@ -15,7 +15,7 @@ import QtQuick.Layouts
 import QGroundControl
 
 import QGroundControl.Controls
-import QGroundControl.ScreenTools
+
 import QGroundControl.AppSettings
 
 Rectangle {

--- a/src/QmlControls/AutotuneUI.qml
+++ b/src/QmlControls/AutotuneUI.qml
@@ -17,7 +17,7 @@ import QGroundControl.FactControls
 
 
 import QGroundControl.Controls
-import QGroundControl.ScreenTools
+
 
 ColumnLayout {
     spacing: ScreenTools.defaultFontPixelHeight

--- a/src/QmlControls/AxisMonitor.qml
+++ b/src/QmlControls/AxisMonitor.qml
@@ -4,7 +4,7 @@ import QtQuick.Controls
 import QGroundControl
 
 import QGroundControl.Controls
-import QGroundControl.ScreenTools
+
 
 Item {
     property int    axisValue:          0

--- a/src/QmlControls/BatteryIndicator.qml
+++ b/src/QmlControls/BatteryIndicator.qml
@@ -13,7 +13,7 @@ import QtQuick.Layouts
 import QGroundControl
 import QGroundControl.Controls
 
-import QGroundControl.ScreenTools
+
 
 
 import QGroundControl.FactControls

--- a/src/QmlControls/CMakeLists.txt
+++ b/src/QmlControls/CMakeLists.txt
@@ -61,6 +61,10 @@ target_include_directories(${CMAKE_PROJECT_NAME} PRIVATE ${CMAKE_CURRENT_SOURCE_
 
 qt_add_library(QGroundControlControlsModule STATIC)
 
+set_source_files_properties(ScreenTools.qml PROPERTIES
+    QT_QML_SINGLETON_TYPE TRUE
+)
+
 qt_add_qml_module(QGroundControlControlsModule
     URI QGroundControl.Controls
     VERSION 1.0
@@ -228,6 +232,8 @@ qt_add_qml_module(QGroundControlControlsModule
 
         # src/QtLocationPlugin/QMLControl/
         OfflineMapEditor.qml
+
+        ScreenTools.qml
     NO_PLUGIN
 )
 
@@ -237,19 +243,3 @@ qt_add_resources(${CMAKE_PROJECT_NAME} json_controls
     PREFIX "/json"
     FILES ${JSON_FILES}
 )
-
-qt_add_library(ScreenToolsModule STATIC)
-
-set_source_files_properties(ScreenTools.qml PROPERTIES
-    QT_QML_SINGLETON_TYPE TRUE
-)
-
-qt_add_qml_module(ScreenToolsModule
-    URI QGroundControl.ScreenTools
-    VERSION 1.0
-    RESOURCE_PREFIX /qml
-    QML_FILES
-        ScreenTools.qml
-    NO_PLUGIN
-)
-

--- a/src/QmlControls/CameraCalcCamera.qml
+++ b/src/QmlControls/CameraCalcCamera.qml
@@ -3,7 +3,7 @@ import QtQuick.Controls
 import QtQuick.Layouts
 
 import QGroundControl
-import QGroundControl.ScreenTools
+
 import QGroundControl.Controls
 import QGroundControl.FactControls
 

--- a/src/QmlControls/CameraCalcGrid.qml
+++ b/src/QmlControls/CameraCalcGrid.qml
@@ -3,7 +3,7 @@ import QtQuick.Controls
 import QtQuick.Layouts
 
 import QGroundControl
-import QGroundControl.ScreenTools
+
 import QGroundControl.Controls
 import QGroundControl.FactControls
 

--- a/src/QmlControls/CameraSection.qml
+++ b/src/QmlControls/CameraSection.qml
@@ -3,7 +3,7 @@ import QtQuick.Controls
 import QtQuick.Layouts
 
 import QGroundControl
-import QGroundControl.ScreenTools
+
 import QGroundControl.Controls
 import QGroundControl.FactControls
 

--- a/src/QmlControls/CorridorScanEditor.qml
+++ b/src/QmlControls/CorridorScanEditor.qml
@@ -4,7 +4,7 @@ import QtQuick.Dialogs
 import QtQuick.Layouts
 
 import QGroundControl
-import QGroundControl.ScreenTools
+
 
 import QGroundControl.Controls
 import QGroundControl.FactControls

--- a/src/QmlControls/DropButton.qml
+++ b/src/QmlControls/DropButton.qml
@@ -2,7 +2,7 @@ import QtQuick
 import QtQuick.Controls
 
 import QGroundControl
-import QGroundControl.ScreenTools
+import QGroundControl.Controls
 
 
 Item {

--- a/src/QmlControls/DropPanel.qml
+++ b/src/QmlControls/DropPanel.qml
@@ -12,7 +12,7 @@ import QtQuick.Controls
 import QtQuick.Layouts
 
 import QGroundControl
-import QGroundControl.ScreenTools
+import QGroundControl.Controls
 
 
 /// Drop panel that displays positioned next to the specified click position.

--- a/src/QmlControls/EditPositionDialog.qml
+++ b/src/QmlControls/EditPositionDialog.qml
@@ -16,7 +16,7 @@ import QGroundControl
 
 import QGroundControl.Controls
 import QGroundControl.FactControls
-import QGroundControl.ScreenTools
+
 
 
 QGCPopupDialog {

--- a/src/QmlControls/FWLandingPatternEditor.qml
+++ b/src/QmlControls/FWLandingPatternEditor.qml
@@ -13,7 +13,7 @@ import QtQuick.Dialogs
 import QtQuick.Layouts
 
 import QGroundControl
-import QGroundControl.ScreenTools
+
 
 import QGroundControl.Controls
 

--- a/src/QmlControls/FWLandingPatternMapVisual.qml
+++ b/src/QmlControls/FWLandingPatternMapVisual.qml
@@ -14,7 +14,7 @@ import QtPositioning
 import QtQuick.Layouts
 
 import QGroundControl
-import QGroundControl.ScreenTools
+
 
 import QGroundControl.Controls
 import QGroundControl.FlightMap

--- a/src/QmlControls/FactSlider.qml
+++ b/src/QmlControls/FactSlider.qml
@@ -15,7 +15,7 @@ import QGroundControl
 import QGroundControl.Controls
 
 
-import QGroundControl.ScreenTools
+
 
 ValueSlider {
     id:             control

--- a/src/QmlControls/FactSliderPanel.qml
+++ b/src/QmlControls/FactSliderPanel.qml
@@ -17,7 +17,7 @@ import QGroundControl
 import QGroundControl.FactControls
 
 import QGroundControl.Controls
-import QGroundControl.ScreenTools
+
 
 Column {
     /// ListModel must contains elements which look like this:

--- a/src/QmlControls/FileButton.qml
+++ b/src/QmlControls/FileButton.qml
@@ -2,8 +2,8 @@ import QtQuick
 import QtQuick.Controls
 
 import QGroundControl
+import QGroundControl.Controls
 
-import QGroundControl.ScreenTools
 
 /// File Button controls used by QGCFileDialog control
 Rectangle {

--- a/src/QmlControls/FlightModeIndicator.qml
+++ b/src/QmlControls/FlightModeIndicator.qml
@@ -14,7 +14,7 @@ import QtQuick.Layouts
 import QGroundControl
 import QGroundControl.Controls
 
-import QGroundControl.ScreenTools
+
 
 
 import QGroundControl.FactControls

--- a/src/QmlControls/FlightModeMenu.qml
+++ b/src/QmlControls/FlightModeMenu.qml
@@ -12,7 +12,7 @@ import QtQuick.Controls
 
 import QGroundControl
 import QGroundControl.Controls
-import QGroundControl.ScreenTools
+
 
 // Label control whichs pop up a flight mode change menu when clicked
 QGCLabel {

--- a/src/QmlControls/FlightModeMenuIndicator.qml
+++ b/src/QmlControls/FlightModeMenuIndicator.qml
@@ -14,7 +14,7 @@ import QtQuick.Layouts
 import QGroundControl
 import QGroundControl.Controls
 
-import QGroundControl.ScreenTools
+
 
 
 import QGroundControl.FactControls

--- a/src/QmlControls/FlyViewToolBar.qml
+++ b/src/QmlControls/FlyViewToolBar.qml
@@ -16,7 +16,7 @@ import QGroundControl
 import QGroundControl.Controls
 
 
-import QGroundControl.ScreenTools
+
 
 
 Rectangle {

--- a/src/QmlControls/FlyViewToolBarIndicators.qml
+++ b/src/QmlControls/FlyViewToolBarIndicators.qml
@@ -10,7 +10,7 @@
 import QtQuick
 
 import QGroundControl
-import QGroundControl.ScreenTools
+import QGroundControl.Controls
 import QGroundControl.Toolbar
 
 //-------------------------------------------------------------------------

--- a/src/QmlControls/GPSIndicator.qml
+++ b/src/QmlControls/GPSIndicator.qml
@@ -13,7 +13,7 @@ import QtQuick.Layouts
 import QGroundControl
 import QGroundControl.Controls
 
-import QGroundControl.ScreenTools
+
 
 
 // Used as the base class control for nboth VehicleGPSIndicator and RTKGPSIndicator

--- a/src/QmlControls/GPSIndicatorPage.qml
+++ b/src/QmlControls/GPSIndicatorPage.qml
@@ -12,7 +12,6 @@ import QtQuick.Layouts
 
 import QGroundControl
 import QGroundControl.Controls
-import QGroundControl.ScreenTools
 import QGroundControl.FactControls
 
 // This indicator page is used both when showing RTK status only with no vehicle connect and when showing GPS/RTK status with a vehicle connected
@@ -33,7 +32,7 @@ ToolIndicatorPage {
     readonly property var    _ublox:              0b1000
     readonly property var    _all:                0b1111
     property var             settingsDisplayId:     _all
-    
+
     function updateSettingsDisplayId() {
         switch(manufacturer) {
             case 0: // All
@@ -187,7 +186,7 @@ ToolIndicatorPage {
                 label:                  qsTr("Min Duration")
                 fact:                   rtkSettings.surveyInMinObservationDuration
                 majorTickStepSize:      10
-                visible:                ( 
+                visible:                (
                     useFixedPosition == BaseModeDefinition.BaseSurveyIn
                     && rtkSettings.surveyInMinObservationDuration.visible
                     && (settingsDisplayId & (_ublox | _femtomes | _trimble))

--- a/src/QmlControls/GeoFenceEditor.qml
+++ b/src/QmlControls/GeoFenceEditor.qml
@@ -4,7 +4,7 @@ import QtQuick.Layouts
 import QtPositioning
 
 import QGroundControl
-import QGroundControl.ScreenTools
+
 import QGroundControl.Controls
 
 import QGroundControl.FactControls

--- a/src/QmlControls/GeoFenceMapVisuals.qml
+++ b/src/QmlControls/GeoFenceMapVisuals.qml
@@ -13,7 +13,7 @@ import QtLocation
 import QtPositioning
 
 import QGroundControl
-import QGroundControl.ScreenTools
+
 
 import QGroundControl.Controls
 import QGroundControl.FlightMap

--- a/src/QmlControls/HeightIndicator.qml
+++ b/src/QmlControls/HeightIndicator.qml
@@ -3,7 +3,7 @@ import QtQuick.Controls
 import QtQuick.Layouts
 
 import QGroundControl
-import QGroundControl.ScreenTools
+import QGroundControl.Controls
 
 
 ColumnLayout {

--- a/src/QmlControls/HorizontalFactValueGrid.qml
+++ b/src/QmlControls/HorizontalFactValueGrid.qml
@@ -13,7 +13,7 @@ import QtQuick.Controls
 import QtQml
 
 import QGroundControl.Controls
-import QGroundControl.ScreenTools
+
 
 
 import QGroundControl.FlightMap

--- a/src/QmlControls/IndicatorButton.qml
+++ b/src/QmlControls/IndicatorButton.qml
@@ -13,7 +13,7 @@ import QtQuick.Controls
 import QGroundControl
 import QGroundControl.Controls
 
-import QGroundControl.ScreenTools
+
 
 /// Works just like a regular button but it can have a red indicator on the right side displayed
 QGCButton {

--- a/src/QmlControls/InstrumentValueEditDialog.qml
+++ b/src/QmlControls/InstrumentValueEditDialog.qml
@@ -14,7 +14,7 @@ import QtQuick.Controls
 
 import QGroundControl
 import QGroundControl.Controls
-import QGroundControl.ScreenTools
+
 
 import QGroundControl.FactControls
 

--- a/src/QmlControls/InstrumentValueLabel.qml
+++ b/src/QmlControls/InstrumentValueLabel.qml
@@ -13,7 +13,7 @@ import QtQuick.Controls
 
 import QGroundControl
 import QGroundControl.Controls
-import QGroundControl.ScreenTools
+
 
 
 ColumnLayout {

--- a/src/QmlControls/InstrumentValueValue.qml
+++ b/src/QmlControls/InstrumentValueValue.qml
@@ -13,7 +13,7 @@ import QtQuick.Controls
 
 import QGroundControl
 import QGroundControl.Controls
-import QGroundControl.ScreenTools
+
 
 
 ColumnLayout {

--- a/src/QmlControls/JoystickThumbPad.qml
+++ b/src/QmlControls/JoystickThumbPad.qml
@@ -2,8 +2,8 @@ import QtQuick
 import QtQuick.Controls
 
 import QGroundControl
+import QGroundControl.Controls
 
-import QGroundControl.ScreenTools
 
 Item {
     id:             _joyRoot

--- a/src/QmlControls/LabelledButton.qml
+++ b/src/QmlControls/LabelledButton.qml
@@ -12,7 +12,7 @@ import QtQuick.Layouts
 
 import QGroundControl
 import QGroundControl.Controls
-import QGroundControl.ScreenTools
+
 
 RowLayout {
     property alias label:                   _label.text

--- a/src/QmlControls/LabelledComboBox.qml
+++ b/src/QmlControls/LabelledComboBox.qml
@@ -12,7 +12,7 @@ import QtQuick.Layouts
 
 import QGroundControl
 import QGroundControl.Controls
-import QGroundControl.ScreenTools
+
 
 RowLayout {
     property alias label:                   label.text

--- a/src/QmlControls/LabelledLabel.qml
+++ b/src/QmlControls/LabelledLabel.qml
@@ -12,7 +12,7 @@ import QtQuick.Layouts
 
 import QGroundControl
 import QGroundControl.Controls
-import QGroundControl.ScreenTools
+
 
 RowLayout {
     property alias label:                   _labelLabel.text

--- a/src/QmlControls/LabelledSlider.qml
+++ b/src/QmlControls/LabelledSlider.qml
@@ -12,7 +12,7 @@ import QtQuick.Layouts
 
 import QGroundControl
 import QGroundControl.Controls
-import QGroundControl.ScreenTools
+
 
 RowLayout {
     property alias label:                   label.text

--- a/src/QmlControls/LogReplayStatusBar.qml
+++ b/src/QmlControls/LogReplayStatusBar.qml
@@ -4,8 +4,8 @@ import QtQuick.Layouts
 import QtQuick.Dialogs
 
 import QGroundControl
+import QGroundControl.Controls
 
-import QGroundControl.ScreenTools
 
 Rectangle {
     height: visible ? (rowLayout.height + (_margins * 2)) : 0

--- a/src/QmlControls/MAVLinkChart.qml
+++ b/src/QmlControls/MAVLinkChart.qml
@@ -7,7 +7,7 @@ import QGroundControl
 
 import QGroundControl.Controls
 
-import QGroundControl.ScreenTools
+
 
 ChartView {
     id:                 chartView

--- a/src/QmlControls/MAVLinkMessageButton.qml
+++ b/src/QmlControls/MAVLinkMessageButton.qml
@@ -12,8 +12,8 @@ import QtQuick.Controls
 import QtQuick.Layouts
 
 import QGroundControl
+import QGroundControl.Controls
 
-import QGroundControl.ScreenTools
 
 Button {
     id:                 control

--- a/src/QmlControls/MainStatusIndicator.qml
+++ b/src/QmlControls/MainStatusIndicator.qml
@@ -13,7 +13,7 @@ import QtQuick.Layouts
 import QGroundControl
 import QGroundControl.Controls
 
-import QGroundControl.ScreenTools
+
 
 
 

--- a/src/QmlControls/MainStatusIndicatorOfflinePage.qml
+++ b/src/QmlControls/MainStatusIndicatorOfflinePage.qml
@@ -14,7 +14,7 @@ import QtQuick.Layouts
 import QGroundControl
 import QGroundControl.Controls
 
-import QGroundControl.ScreenTools
+
 
 
 import QGroundControl.FactControls

--- a/src/QmlControls/MainWindowSavedState.qml
+++ b/src/QmlControls/MainWindowSavedState.qml
@@ -13,7 +13,7 @@ import QtQuick.Controls
 import QtCore
 
 import QGroundControl
-import QGroundControl.ScreenTools
+import QGroundControl.Controls
 
 Item {
     property Window window

--- a/src/QmlControls/MissionCommandDialog.qml
+++ b/src/QmlControls/MissionCommandDialog.qml
@@ -15,7 +15,7 @@ import QtQuick.Dialogs
 
 import QGroundControl
 import QGroundControl.Controls
-import QGroundControl.ScreenTools
+
 
 
 QGCPopupDialog {

--- a/src/QmlControls/MissionItemEditor.qml
+++ b/src/QmlControls/MissionItemEditor.qml
@@ -5,7 +5,7 @@ import QtQml
 import QtQuick.Layouts
 
 import QGroundControl
-import QGroundControl.ScreenTools
+
 
 import QGroundControl.Controls
 import QGroundControl.FactControls

--- a/src/QmlControls/MissionItemIndexLabel.qml
+++ b/src/QmlControls/MissionItemIndexLabel.qml
@@ -2,7 +2,7 @@ import QtQuick
 import QtQuick.Controls
 
 import QGroundControl
-import QGroundControl.ScreenTools
+import QGroundControl.Controls
 
 
 Canvas {

--- a/src/QmlControls/MissionItemMapVisual.qml
+++ b/src/QmlControls/MissionItemMapVisual.qml
@@ -13,7 +13,7 @@ import QtLocation
 import QtPositioning
 
 import QGroundControl
-import QGroundControl.ScreenTools
+
 
 import QGroundControl.Controls
 

--- a/src/QmlControls/MissionItemStatus.qml
+++ b/src/QmlControls/MissionItemStatus.qml
@@ -12,7 +12,7 @@ import QtQuick.Controls
 import QtQuick.Layouts
 
 import QGroundControl
-import QGroundControl.ScreenTools
+
 import QGroundControl.Controls
 
 

--- a/src/QmlControls/MissionSettingsEditor.qml
+++ b/src/QmlControls/MissionSettingsEditor.qml
@@ -3,7 +3,7 @@ import QtQuick.Controls
 import QtQuick.Layouts
 
 import QGroundControl
-import QGroundControl.ScreenTools
+
 
 import QGroundControl.Controls
 import QGroundControl.FactControls

--- a/src/QmlControls/MvPanelPage.qml
+++ b/src/QmlControls/MvPanelPage.qml
@@ -2,7 +2,7 @@ import QtQuick
 import QtQuick.Controls
 
 import QGroundControl
-import QGroundControl.ScreenTools
+import QGroundControl.Controls
 
 
 Item {

--- a/src/QmlControls/OfflineMapButton.qml
+++ b/src/QmlControls/OfflineMapButton.qml
@@ -11,8 +11,8 @@ import QtQuick
 import QtQuick.Controls
 
 import QGroundControl
+import QGroundControl.Controls
 
-import QGroundControl.ScreenTools
 
 Button {
     id:                 mapButton

--- a/src/QmlControls/OfflineMapEditor.qml
+++ b/src/QmlControls/OfflineMapEditor.qml
@@ -17,7 +17,7 @@ import QtPositioning
 
 import QGroundControl
 import QGroundControl.Controls
-import QGroundControl.ScreenTools
+
 
 import QGroundControl.FlightMap
 

--- a/src/QmlControls/OfflineMapInfo.qml
+++ b/src/QmlControls/OfflineMapInfo.qml
@@ -12,8 +12,8 @@ import QtQuick.Controls
 import QtQuick.Layouts
 
 import QGroundControl
+import QGroundControl.Controls
 
-import QGroundControl.ScreenTools
 
 RowLayout {
     id:                 control

--- a/src/QmlControls/PIDTuning.qml
+++ b/src/QmlControls/PIDTuning.qml
@@ -16,7 +16,7 @@ import QGroundControl
 import QGroundControl.Controls
 
 import QGroundControl.FactControls
-import QGroundControl.ScreenTools
+
 
 
 RowLayout {

--- a/src/QmlControls/ParameterDiffDialog.qml
+++ b/src/QmlControls/ParameterDiffDialog.qml
@@ -14,7 +14,7 @@ import QtQuick.Dialogs
 
 import QGroundControl
 import QGroundControl.Controls
-import QGroundControl.ScreenTools
+
 
 import QGroundControl.FactControls
 

--- a/src/QmlControls/ParameterEditor.qml
+++ b/src/QmlControls/ParameterEditor.qml
@@ -15,7 +15,7 @@ import QtQuick.Layouts
 import QGroundControl
 import QGroundControl.Controls
 
-import QGroundControl.ScreenTools
+
 
 
 import QGroundControl.FactControls

--- a/src/QmlControls/ParameterEditorDialog.qml
+++ b/src/QmlControls/ParameterEditorDialog.qml
@@ -18,7 +18,7 @@ import QGroundControl.Controls
 
 
 import QGroundControl.FactControls
-import QGroundControl.ScreenTools
+
 
 QGCPopupDialog {
     id:         root

--- a/src/QmlControls/PipView.qml
+++ b/src/QmlControls/PipView.qml
@@ -11,7 +11,7 @@ import QtQuick
 import QtQuick.Window
 
 import QGroundControl
-import QGroundControl.ScreenTools
+
 import QGroundControl.Controls
 
 

--- a/src/QmlControls/PlanEditToolbar.qml
+++ b/src/QmlControls/PlanEditToolbar.qml
@@ -12,7 +12,7 @@ import QtQuick.Controls
 import QtQuick.Layouts
 
 import QGroundControl
-import QGroundControl.ScreenTools
+
 import QGroundControl.Controls
 
 

--- a/src/QmlControls/PlanToolBarIndicators.qml
+++ b/src/QmlControls/PlanToolBarIndicators.qml
@@ -4,7 +4,7 @@ import QtQuick.Layouts
 import QtQuick.Dialogs
 
 import QGroundControl
-import QGroundControl.ScreenTools
+
 import QGroundControl.Controls
 import QGroundControl.FactControls
 

--- a/src/QmlControls/PlanView.qml
+++ b/src/QmlControls/PlanView.qml
@@ -17,7 +17,7 @@ import QtQuick.Window
 
 import QGroundControl
 import QGroundControl.FlightMap
-import QGroundControl.ScreenTools
+
 import QGroundControl.Controls
 
 import QGroundControl.FactControls

--- a/src/QmlControls/PlanViewToolBar.qml
+++ b/src/QmlControls/PlanViewToolBar.qml
@@ -16,7 +16,7 @@ import QGroundControl
 import QGroundControl.Controls
 
 
-import QGroundControl.ScreenTools
+
 
 
 Rectangle {

--- a/src/QmlControls/PreFlightCheckButton.qml
+++ b/src/QmlControls/PreFlightCheckButton.qml
@@ -11,8 +11,8 @@ import QtQuick
 import QtQuick.Controls
 
 import QGroundControl
+import QGroundControl.Controls
 
-import QGroundControl.ScreenTools
 
 /// The PreFlightCheckButton supports creating a button which the user then has to verify/click to confirm a check.
 /// It also supports failing the check based on values from within the system: telemetry or QGC app values. These

--- a/src/QmlControls/PreFlightCheckGroup.qml
+++ b/src/QmlControls/PreFlightCheckGroup.qml
@@ -12,7 +12,7 @@ import QtQml.Models
 
 import QGroundControl
 import QGroundControl.Controls
-import QGroundControl.ScreenTools
+
 
 /// A PreFlightCheckGroup manages a set of PreFlightCheckButtons as a single entity.
 Column  {

--- a/src/QmlControls/QGCButton.qml
+++ b/src/QmlControls/QGCButton.qml
@@ -3,8 +3,8 @@ import QtQuick.Controls
 import QtQuick.Layouts
 
 import QGroundControl
+import QGroundControl.Controls
 
-import QGroundControl.ScreenTools
 
 /// Standard push button control:
 ///     If there is both an icon and text the icon will be to the left of the text

--- a/src/QmlControls/QGCCheckBox.qml
+++ b/src/QmlControls/QGCCheckBox.qml
@@ -2,8 +2,8 @@ import QtQuick
 import QtQuick.Controls
 
 import QGroundControl
+import QGroundControl.Controls
 
-import QGroundControl.ScreenTools
 
 CheckBox {
     id:             control

--- a/src/QmlControls/QGCCheckBoxSlider.qml
+++ b/src/QmlControls/QGCCheckBoxSlider.qml
@@ -12,8 +12,8 @@ import QtQuick.Controls
 import QtQuick.Layouts
 
 import QGroundControl
+import QGroundControl.Controls
 
-import QGroundControl.ScreenTools
 
 AbstractButton   {
     id:             control

--- a/src/QmlControls/QGCColoredImage.qml
+++ b/src/QmlControls/QGCColoredImage.qml
@@ -3,6 +3,7 @@ import QtQuick.Controls
 import Qt5Compat.GraphicalEffects
 
 import QGroundControl
+import QGroundControl.Controls
 
 
 Item {

--- a/src/QmlControls/QGCColumnButton.qml
+++ b/src/QmlControls/QGCColumnButton.qml
@@ -3,8 +3,8 @@ import QtQuick.Controls
 import QtQuick.Layouts
 
 import QGroundControl
+import QGroundControl.Controls
 
-import QGroundControl.ScreenTools
 
 QGCButton {
     id:             control     //This is a button rework from DonLakeFlyer's QGCButton that allows to contain a text and an Icon with a column look and the same capabilites

--- a/src/QmlControls/QGCComboBox.qml
+++ b/src/QmlControls/QGCComboBox.qml
@@ -13,7 +13,7 @@ import QtQuick.Controls
 import QtQuick.Templates as T
 
 import QGroundControl
-import QGroundControl.ScreenTools
+
 
 import QGroundControl.Controls
 

--- a/src/QmlControls/QGCDynamicObjectManager.qml
+++ b/src/QmlControls/QGCDynamicObjectManager.qml
@@ -3,7 +3,7 @@ import QtQuick.Controls
 
 import QGroundControl
 
-import QGroundControl.ScreenTools
+
 
 /// Provides a standard set of tools for dynamically create/adding/removing Qml objects
 Item {

--- a/src/QmlControls/QGCFileDialog.qml
+++ b/src/QmlControls/QGCFileDialog.qml
@@ -5,7 +5,7 @@ import QtQuick.Layouts
 import Qt.labs.platform as Labs
 
 import QGroundControl
-import QGroundControl.ScreenTools
+import QGroundControl.Controls
 
 
 

--- a/src/QmlControls/QGCFlickable.qml
+++ b/src/QmlControls/QGCFlickable.qml
@@ -2,8 +2,8 @@ import QtQuick
 import QtQuick.Controls
 
 import QGroundControl
+import QGroundControl.Controls
 
-import QGroundControl.ScreenTools
 
 /// QGC version of Flickable control that shows horizontal/vertial scroll indicators
 Flickable {

--- a/src/QmlControls/QGCFlickableScrollIndicator.qml
+++ b/src/QmlControls/QGCFlickableScrollIndicator.qml
@@ -1,7 +1,7 @@
 import QtQuick
 
 import QGroundControl
-import QGroundControl.ScreenTools
+import QGroundControl.Controls
 
 Rectangle {
     id:         control

--- a/src/QmlControls/QGCGroupBox.qml
+++ b/src/QmlControls/QGCGroupBox.qml
@@ -11,8 +11,8 @@ import QtQuick
 import QtQuick.Controls
 
 import QGroundControl
+import QGroundControl.Controls
 
-import QGroundControl.ScreenTools
 
 GroupBox {
     id: control

--- a/src/QmlControls/QGCLabel.qml
+++ b/src/QmlControls/QGCLabel.qml
@@ -2,8 +2,8 @@ import QtQuick
 import QtQuick.Controls
 
 import QGroundControl
+import QGroundControl.Controls
 
-import QGroundControl.ScreenTools
 
 Text {
     font.pointSize: ScreenTools.defaultFontPointSize

--- a/src/QmlControls/QGCListView.qml
+++ b/src/QmlControls/QGCListView.qml
@@ -1,7 +1,7 @@
 import QtQuick
 
 import QGroundControl
-
+import QGroundControl.Controls
 
 /// QGC version of ListVIew control that shows horizontal/vertial scroll indicators
 ListView {

--- a/src/QmlControls/QGCMarqueeLabel.qml
+++ b/src/QmlControls/QGCMarqueeLabel.qml
@@ -2,8 +2,8 @@ import QtQuick
 import QtQuick.Controls
 
 import QGroundControl
+import QGroundControl.Controls
 
-import QGroundControl.ScreenTools
 
 Item {
     property color  color:          qgcPal.text

--- a/src/QmlControls/QGCMouseArea.qml
+++ b/src/QmlControls/QGCMouseArea.qml
@@ -1,7 +1,7 @@
 import QtQuick
 
 import QGroundControl
-import QGroundControl.ScreenTools
+import QGroundControl.Controls
 
 /// Works just like a regular MouseArea except:
 ///     1) It supports the ability to show touch extents based on QGroundControl.showTouchAreas

--- a/src/QmlControls/QGCMovableItem.qml
+++ b/src/QmlControls/QGCMovableItem.qml
@@ -1,7 +1,8 @@
 import QtQuick
 import QtQuick.Controls
+
 import QGroundControl
-import QGroundControl.ScreenTools
+import QGroundControl.Controls
 
 // This item can be dragged around within its parent.
 // Double click issues a signal the parent can use to

--- a/src/QmlControls/QGCOptionsComboBox.qml
+++ b/src/QmlControls/QGCOptionsComboBox.qml
@@ -16,7 +16,7 @@ import QtQuick.Layouts
 import QGroundControl
 import QGroundControl.Controls
 
-import QGroundControl.ScreenTools
+
 
 ComboBox {
     id:         control

--- a/src/QmlControls/QGCPopupDialog.qml
+++ b/src/QmlControls/QGCPopupDialog.qml
@@ -15,7 +15,7 @@ import QtQuick.Dialogs
 import QGroundControl
 import QGroundControl.Controls
 
-import QGroundControl.ScreenTools
+
 
 // Provides the standard dialog mechanism for QGC. Works 99% like Qml Dialog.
 //

--- a/src/QmlControls/QGCRadioButton.qml
+++ b/src/QmlControls/QGCRadioButton.qml
@@ -2,8 +2,8 @@ import QtQuick
 import QtQuick.Controls
 
 import QGroundControl
+import QGroundControl.Controls
 
-import QGroundControl.ScreenTools
 
 RadioButton {
     id:             control

--- a/src/QmlControls/QGCRoundButton.qml
+++ b/src/QmlControls/QGCRoundButton.qml
@@ -2,7 +2,7 @@ import QtQuick
 import QtQuick.Controls
 
 import QGroundControl
-import QGroundControl.ScreenTools
+import QGroundControl.Controls
 
 
 Item {

--- a/src/QmlControls/QGCSimpleMessageDialog.qml
+++ b/src/QmlControls/QGCSimpleMessageDialog.qml
@@ -12,7 +12,7 @@ import QtQuick.Layouts
 
 import QGroundControl
 import QGroundControl.Controls
-import QGroundControl.ScreenTools
+
 
 QGCPopupDialog {
     property alias  text:           label.text

--- a/src/QmlControls/QGCSlider.qml
+++ b/src/QmlControls/QGCSlider.qml
@@ -11,8 +11,8 @@ import QtQuick
 import QtQuick.Controls
 
 import QGroundControl
+import QGroundControl.Controls
 
-import QGroundControl.ScreenTools
 
 Slider {
     id:             control

--- a/src/QmlControls/QGCSwitch.qml
+++ b/src/QmlControls/QGCSwitch.qml
@@ -13,7 +13,7 @@ import QtQuick.Controls
 import QGroundControl
 
 import QGroundControl.Controls
-import QGroundControl.ScreenTools
+
 
 Switch {
     id: control

--- a/src/QmlControls/QGCTabBar.qml
+++ b/src/QmlControls/QGCTabBar.qml
@@ -4,7 +4,7 @@ import QtQuick.Controls
 import QGroundControl
 
 import QGroundControl.Controls
-import QGroundControl.ScreenTools
+
 
 TabBar {
     background: Rectangle {

--- a/src/QmlControls/QGCTabButton.qml
+++ b/src/QmlControls/QGCTabButton.qml
@@ -11,7 +11,7 @@ import QtQuick
 import QtQuick.Controls
 
 import QGroundControl
-import QGroundControl.ScreenTools
+import QGroundControl.Controls
 
 
 TabButton {

--- a/src/QmlControls/QGCTextField.qml
+++ b/src/QmlControls/QGCTextField.qml
@@ -3,8 +3,8 @@ import QtQuick.Controls
 import QtQuick.Layouts
 
 import QGroundControl
+import QGroundControl.Controls
 
-import QGroundControl.ScreenTools
 
 TextField {
     id:                 control

--- a/src/QmlControls/QGCToolBarButton.qml
+++ b/src/QmlControls/QGCToolBarButton.qml
@@ -13,7 +13,7 @@ import QtQuick.Controls
 import QGroundControl
 import QGroundControl.Controls
 
-import QGroundControl.ScreenTools
+
 
 // Important Note: Toolbar buttons must manage their checked state manually in order to support
 // view switch prevention. This means they can't be checkable or autoExclusive.

--- a/src/QmlControls/RCChannelMonitor.qml
+++ b/src/QmlControls/RCChannelMonitor.qml
@@ -17,7 +17,7 @@ import QGroundControl
 
 import QGroundControl.Controls
 import QGroundControl.FactControls
-import QGroundControl.ScreenTools
+
 
 
 Item {

--- a/src/QmlControls/RCToParamDialog.qml
+++ b/src/QmlControls/RCToParamDialog.qml
@@ -14,7 +14,7 @@ import QtQuick.Dialogs
 
 import QGroundControl
 import QGroundControl.Controls
-import QGroundControl.ScreenTools
+
 
 import QGroundControl.FactControls
 

--- a/src/QmlControls/RallyPointEditorHeader.qml
+++ b/src/QmlControls/RallyPointEditorHeader.qml
@@ -2,7 +2,7 @@ import QtQuick
 import QtQuick.Controls
 
 import QGroundControl
-import QGroundControl.ScreenTools
+
 import QGroundControl.Controls
 
 QGCFlickable {

--- a/src/QmlControls/RallyPointItemEditor.qml
+++ b/src/QmlControls/RallyPointItemEditor.qml
@@ -3,7 +3,7 @@ import QtQuick.Controls
 import QtQuick.Layouts
 
 import QGroundControl
-import QGroundControl.ScreenTools
+
 
 import QGroundControl.Controls
 import QGroundControl.FactControls

--- a/src/QmlControls/RallyPointMapVisuals.qml
+++ b/src/QmlControls/RallyPointMapVisuals.qml
@@ -13,7 +13,7 @@ import QtLocation
 import QtPositioning
 
 import QGroundControl
-import QGroundControl.ScreenTools
+
 
 import QGroundControl.Controls
 import QGroundControl.FlightMap

--- a/src/QmlControls/RemoteIDIndicatorPage.qml
+++ b/src/QmlControls/RemoteIDIndicatorPage.qml
@@ -13,7 +13,7 @@ import QtQuick.Layouts
 import QGroundControl
 import QGroundControl.Controls
 
-import QGroundControl.ScreenTools
+
 
 
 import QGroundControl.FactControls

--- a/src/QmlControls/ScreenTools.qml
+++ b/src/QmlControls/ScreenTools.qml
@@ -16,7 +16,7 @@ import QGroundControl
 
  Usage:
 
-        import QGroundControl.ScreenTools
+        import QGroundControl.Controls
 
         Rectangle {
             anchors.fill:       parent

--- a/src/QmlControls/SectionHeader.qml
+++ b/src/QmlControls/SectionHeader.qml
@@ -3,7 +3,7 @@ import QtQuick.Controls
 import QtQuick.Layouts
 
 import QGroundControl
-import QGroundControl.ScreenTools
+import QGroundControl.Controls
 
 
 CheckBox {

--- a/src/QmlControls/SelectableControl.qml
+++ b/src/QmlControls/SelectableControl.qml
@@ -12,7 +12,7 @@ import QtQuick.Controls
 import QtQuick.Layouts
 
 import QGroundControl
-import QGroundControl.ScreenTools
+import QGroundControl.Controls
 
 
 import QGroundControl.FactControls

--- a/src/QmlControls/SettingsButton.qml
+++ b/src/QmlControls/SettingsButton.qml
@@ -14,7 +14,7 @@ import QtQuick.Layouts
 import QGroundControl
 import QGroundControl.Controls
 
-import QGroundControl.ScreenTools
+
 
 Button {
     id:             control

--- a/src/QmlControls/SettingsGroupLayout.qml
+++ b/src/QmlControls/SettingsGroupLayout.qml
@@ -2,7 +2,7 @@ import QtQuick
 import QtQuick.Layouts
 
 import QGroundControl
-import QGroundControl.ScreenTools
+import QGroundControl.Controls
 
 
 ColumnLayout {

--- a/src/QmlControls/SetupPage.qml
+++ b/src/QmlControls/SetupPage.qml
@@ -17,7 +17,7 @@ import QGroundControl
 import QGroundControl.FactControls
 
 import QGroundControl.Controls
-import QGroundControl.ScreenTools
+
 
 
 /// Base view control for all Setup pages

--- a/src/QmlControls/SimpleItemEditor.qml
+++ b/src/QmlControls/SimpleItemEditor.qml
@@ -3,7 +3,7 @@ import QtQuick.Controls
 import QtQuick.Layouts
 
 import QGroundControl
-import QGroundControl.ScreenTools
+
 
 import QGroundControl.Controls
 import QGroundControl.FactControls

--- a/src/QmlControls/SimpleItemMapVisual.qml
+++ b/src/QmlControls/SimpleItemMapVisual.qml
@@ -13,7 +13,7 @@ import QtLocation
 import QtPositioning
 
 import QGroundControl
-import QGroundControl.ScreenTools
+
 
 import QGroundControl.Controls
 import QGroundControl.FlightMap

--- a/src/QmlControls/SliderSwitch.qml
+++ b/src/QmlControls/SliderSwitch.qml
@@ -2,7 +2,7 @@ import QtQuick
 import QtQuick.Controls
 
 import QGroundControl
-import QGroundControl.ScreenTools
+import QGroundControl.Controls
 
 
 /// The SliderSwitch control implements a sliding switch control similar to the power off

--- a/src/QmlControls/StructureScanEditor.qml
+++ b/src/QmlControls/StructureScanEditor.qml
@@ -4,7 +4,7 @@ import QtQuick.Dialogs
 import QtQuick.Layouts
 
 import QGroundControl
-import QGroundControl.ScreenTools
+
 
 import QGroundControl.Controls
 import QGroundControl.FactControls

--- a/src/QmlControls/StructureScanMapVisual.qml
+++ b/src/QmlControls/StructureScanMapVisual.qml
@@ -13,7 +13,7 @@ import QtLocation
 import QtPositioning
 
 import QGroundControl
-import QGroundControl.ScreenTools
+
 
 import QGroundControl.Controls
 import QGroundControl.FlightMap

--- a/src/QmlControls/SubMenuButton.qml
+++ b/src/QmlControls/SubMenuButton.qml
@@ -2,8 +2,8 @@ import QtQuick
 import QtQuick.Controls
 
 import QGroundControl
+import QGroundControl.Controls
 
-import QGroundControl.ScreenTools
 
 // Important Note: SubMenuButtons must manage their checked state manually in order to support
 // view switch prevention. This means they can't be checkable or autoExclusive.

--- a/src/QmlControls/SurveyItemEditor.qml
+++ b/src/QmlControls/SurveyItemEditor.qml
@@ -4,7 +4,7 @@ import QtQuick.Dialogs
 import QtQuick.Layouts
 
 import QGroundControl
-import QGroundControl.ScreenTools
+
 
 import QGroundControl.Controls
 

--- a/src/QmlControls/SurveyMapVisual.qml
+++ b/src/QmlControls/SurveyMapVisual.qml
@@ -13,7 +13,7 @@ import QtLocation
 import QtPositioning
 
 import QGroundControl
-import QGroundControl.ScreenTools
+
 
 import QGroundControl.Controls
 import QGroundControl.FlightMap

--- a/src/QmlControls/TakeoffItemMapVisual.qml
+++ b/src/QmlControls/TakeoffItemMapVisual.qml
@@ -13,7 +13,7 @@ import QtLocation
 import QtPositioning
 
 import QGroundControl
-import QGroundControl.ScreenTools
+
 
 import QGroundControl.Controls
 import QGroundControl.FlightMap

--- a/src/QmlControls/TerrainStatus.qml
+++ b/src/QmlControls/TerrainStatus.qml
@@ -11,7 +11,7 @@ import QtQuick
 import QtCharts
 
 import QGroundControl
-import QGroundControl.ScreenTools
+
 import QGroundControl.Controls
 
 

--- a/src/QmlControls/ToolIndicatorPage.qml
+++ b/src/QmlControls/ToolIndicatorPage.qml
@@ -11,7 +11,7 @@ import QtQuick
 import QtQuick.Layouts
 
 import QGroundControl
-import QGroundControl.ScreenTools
+import QGroundControl.Controls
 
 // ToolIndicatorPage
 //      The base control for all Toolbar Indicator drop down pages. It supports a normal and expanded view.

--- a/src/QmlControls/ToolStrip.qml
+++ b/src/QmlControls/ToolStrip.qml
@@ -11,7 +11,7 @@ import QtQuick
 import QtQuick.Controls
 
 import QGroundControl
-import QGroundControl.ScreenTools
+
 
 import QGroundControl.Controls
 

--- a/src/QmlControls/ToolStripDropPanel.qml
+++ b/src/QmlControls/ToolStripDropPanel.qml
@@ -11,7 +11,7 @@ import QtQuick
 import QtQuick.Controls
 
 import QGroundControl
-import QGroundControl.ScreenTools
+import QGroundControl.Controls
 
 
 Item {

--- a/src/QmlControls/ToolStripHoverButton.qml
+++ b/src/QmlControls/ToolStripHoverButton.qml
@@ -11,7 +11,7 @@ import QtQuick
 import QtQuick.Controls
 
 import QGroundControl
-import QGroundControl.ScreenTools
+import QGroundControl.Controls
 
 
 Button {

--- a/src/QmlControls/TransectStyleComplexItemEditor.qml
+++ b/src/QmlControls/TransectStyleComplexItemEditor.qml
@@ -4,7 +4,7 @@ import QtQuick.Dialogs
 import QtQuick.Layouts
 
 import QGroundControl
-import QGroundControl.ScreenTools
+
 
 import QGroundControl.Controls
 

--- a/src/QmlControls/TransectStyleComplexItemStats.qml
+++ b/src/QmlControls/TransectStyleComplexItemStats.qml
@@ -2,7 +2,7 @@ import QtQuick
 import QtQuick.Controls
 
 import QGroundControl
-import QGroundControl.ScreenTools
+
 import QGroundControl.Controls
 
 // Statistics section for TransectStyleComplexItems

--- a/src/QmlControls/TransectStyleComplexItemTabBar.qml
+++ b/src/QmlControls/TransectStyleComplexItemTabBar.qml
@@ -1,7 +1,7 @@
 import QtQuick
 
 import QGroundControl
-import QGroundControl.ScreenTools
+
 import QGroundControl.Controls
 
 QGCTabBar {

--- a/src/QmlControls/TransectStyleComplexItemTerrainFollow.qml
+++ b/src/QmlControls/TransectStyleComplexItemTerrainFollow.qml
@@ -3,7 +3,7 @@ import QtQuick.Controls
 import QtQuick.Layouts
 
 import QGroundControl
-import QGroundControl.ScreenTools
+
 import QGroundControl.Controls
 
 import QGroundControl.FactControls

--- a/src/QmlControls/TransectStyleMapVisuals.qml
+++ b/src/QmlControls/TransectStyleMapVisuals.qml
@@ -13,7 +13,7 @@ import QtLocation
 import QtPositioning
 
 import QGroundControl
-import QGroundControl.ScreenTools
+
 
 import QGroundControl.Controls
 import QGroundControl.FlightMap

--- a/src/QmlControls/VTOLLandingPatternEditor.qml
+++ b/src/QmlControls/VTOLLandingPatternEditor.qml
@@ -13,7 +13,7 @@ import QtQuick.Dialogs
 import QtQuick.Layouts
 
 import QGroundControl
-import QGroundControl.ScreenTools
+
 
 import QGroundControl.Controls
 

--- a/src/QmlControls/VTOLLandingPatternMapVisual.qml
+++ b/src/QmlControls/VTOLLandingPatternMapVisual.qml
@@ -14,7 +14,7 @@ import QtPositioning
 import QtQuick.Layouts
 
 import QGroundControl
-import QGroundControl.ScreenTools
+
 
 import QGroundControl.Controls
 import QGroundControl.FlightMap

--- a/src/QmlControls/ValueSlider.qml
+++ b/src/QmlControls/ValueSlider.qml
@@ -16,7 +16,7 @@ import QGroundControl
 import QGroundControl.Controls
 
 
-import QGroundControl.ScreenTools
+
 
 
 Control {

--- a/src/QmlControls/VehicleMessageList.qml
+++ b/src/QmlControls/VehicleMessageList.qml
@@ -15,7 +15,7 @@ import QGroundControl
 import QGroundControl.Controls
 
 
-import QGroundControl.ScreenTools
+
 
 
 TextArea {

--- a/src/QmlControls/VehicleRotationCal.qml
+++ b/src/QmlControls/VehicleRotationCal.qml
@@ -12,8 +12,8 @@ import QtQuick
 import QtQuick.Controls
 
 import QGroundControl
+import QGroundControl.Controls
 
-import QGroundControl.ScreenTools
 
 Rectangle {
     // Indicates whether calibration is valid for this control

--- a/src/UI/AppSettings/BluetoothSettings.qml
+++ b/src/UI/AppSettings/BluetoothSettings.qml
@@ -13,7 +13,7 @@ import QtQuick.Layouts
 
 import QGroundControl
 import QGroundControl.Controls
-import QGroundControl.ScreenTools
+
 
 
 ColumnLayout {

--- a/src/UI/AppSettings/DebugWindow.qml
+++ b/src/UI/AppSettings/DebugWindow.qml
@@ -18,7 +18,7 @@ import QGroundControl
 import QGroundControl.Controls
 
 
-import QGroundControl.ScreenTools
+
 
 Item {
 

--- a/src/UI/AppSettings/FlyViewSettings.qml
+++ b/src/UI/AppSettings/FlyViewSettings.qml
@@ -17,7 +17,7 @@ import QGroundControl
 
 import QGroundControl.FactControls
 import QGroundControl.Controls
-import QGroundControl.ScreenTools
+
 
 
 

--- a/src/UI/AppSettings/GeneralSettings.qml
+++ b/src/UI/AppSettings/GeneralSettings.qml
@@ -17,7 +17,7 @@ import QGroundControl
 
 import QGroundControl.FactControls
 import QGroundControl.Controls
-import QGroundControl.ScreenTools
+
 
 
 

--- a/src/UI/AppSettings/HelpSettings.qml
+++ b/src/UI/AppSettings/HelpSettings.qml
@@ -13,7 +13,7 @@ import QtQuick.Layouts
 import QGroundControl
 import QGroundControl.Controls
 
-import QGroundControl.ScreenTools
+
 
 Rectangle {
     color:          qgcPal.window

--- a/src/UI/AppSettings/LinkSettings.qml
+++ b/src/UI/AppSettings/LinkSettings.qml
@@ -15,7 +15,7 @@ import QtQuick.Layouts
 import QGroundControl
 import QGroundControl.Controls
 import QGroundControl.FactControls
-import QGroundControl.ScreenTools
+
 
 
 SettingsPage {

--- a/src/UI/AppSettings/MapSettings.qml
+++ b/src/UI/AppSettings/MapSettings.qml
@@ -17,7 +17,7 @@ import QGroundControl
 
 import QGroundControl.FactControls
 import QGroundControl.Controls
-import QGroundControl.ScreenTools
+
 import QGroundControl.QGCMapEngineManager
 
 

--- a/src/UI/AppSettings/MockLink.qml
+++ b/src/UI/AppSettings/MockLink.qml
@@ -15,7 +15,7 @@ import QtQuick.Layouts
 import QGroundControl
 import QGroundControl.Controls
 
-import QGroundControl.ScreenTools
+
 
 Rectangle {
     color:          qgcPal.window

--- a/src/UI/AppSettings/MockLinkSettings.qml
+++ b/src/UI/AppSettings/MockLinkSettings.qml
@@ -13,7 +13,7 @@ import QtQuick.Layouts
 
 import QGroundControl
 import QGroundControl.Controls
-import QGroundControl.ScreenTools
+
 
 
 GridLayout {

--- a/src/UI/AppSettings/PX4LogTransferSettings.qml
+++ b/src/UI/AppSettings/PX4LogTransferSettings.qml
@@ -17,7 +17,7 @@ import QGroundControl
 
 import QGroundControl.FactControls
 import QGroundControl.Controls
-import QGroundControl.ScreenTools
+
 
 
 

--- a/src/UI/AppSettings/QmlTest.qml
+++ b/src/UI/AppSettings/QmlTest.qml
@@ -5,7 +5,7 @@ import QtQuick.Layouts
 import QGroundControl
 
 import QGroundControl.Controls
-import QGroundControl.ScreenTools
+
 
 Rectangle {
     id: _root

--- a/src/UI/AppSettings/RemoteIDSettings.qml
+++ b/src/UI/AppSettings/RemoteIDSettings.qml
@@ -16,7 +16,7 @@ import QGroundControl
 
 import QGroundControl.FactControls
 import QGroundControl.Controls
-import QGroundControl.ScreenTools
+
 
 
 

--- a/src/UI/AppSettings/SerialSettings.qml
+++ b/src/UI/AppSettings/SerialSettings.qml
@@ -13,7 +13,7 @@ import QtQuick.Layouts
 
 import QGroundControl
 import QGroundControl.Controls
-import QGroundControl.ScreenTools
+
 
 
 ColumnLayout {

--- a/src/UI/AppSettings/SettingsPage.qml
+++ b/src/UI/AppSettings/SettingsPage.qml
@@ -17,7 +17,7 @@ import QGroundControl
 
 import QGroundControl.FactControls
 import QGroundControl.Controls
-import QGroundControl.ScreenTools
+
 
 
 

--- a/src/UI/AppSettings/SettingsPagesModel.qml
+++ b/src/UI/AppSettings/SettingsPagesModel.qml
@@ -10,7 +10,7 @@
 import QtQml.Models
 
 import QGroundControl
-import QGroundControl.ScreenTools
+import QGroundControl.Controls
 
 ListModel {
     ListElement {

--- a/src/UI/AppSettings/TcpSettings.qml
+++ b/src/UI/AppSettings/TcpSettings.qml
@@ -13,7 +13,7 @@ import QtQuick.Layouts
 
 import QGroundControl
 import QGroundControl.Controls
-import QGroundControl.ScreenTools
+
 
 
 GridLayout {

--- a/src/UI/AppSettings/TelemetrySettings.qml
+++ b/src/UI/AppSettings/TelemetrySettings.qml
@@ -17,7 +17,7 @@ import QGroundControl
 
 import QGroundControl.FactControls
 import QGroundControl.Controls
-import QGroundControl.ScreenTools
+
 
 
 

--- a/src/UI/AppSettings/UdpSettings.qml
+++ b/src/UI/AppSettings/UdpSettings.qml
@@ -13,7 +13,7 @@ import QtQuick.Layouts
 
 import QGroundControl
 import QGroundControl.Controls
-import QGroundControl.ScreenTools
+
 
 
 ColumnLayout {

--- a/src/UI/AppSettings/VideoSettings.qml
+++ b/src/UI/AppSettings/VideoSettings.qml
@@ -16,7 +16,7 @@ import QGroundControl
 
 import QGroundControl.FactControls
 import QGroundControl.Controls
-import QGroundControl.ScreenTools
+
 
 SettingsPage {
     property var    _settingsManager:            QGroundControl.settingsManager

--- a/src/UI/CMakeLists.txt
+++ b/src/UI/CMakeLists.txt
@@ -1,14 +1,3 @@
 add_subdirectory(AppSettings)
 add_subdirectory(FirstRunPromptDialogs)
 add_subdirectory(toolbar)
-
-qt_add_library(MainWindowModule STATIC)
-
-qt_add_qml_module(MainWindowModule
-    URI QGroundControl.MainWindow
-    VERSION 1.0
-    RESOURCE_PREFIX /qml
-    QML_FILES
-        MainWindow.qml
-    NO_PLUGIN
-)

--- a/src/UI/FirstRunPromptDialogs/OfflineVehicleFirstRunPrompt.qml
+++ b/src/UI/FirstRunPromptDialogs/OfflineVehicleFirstRunPrompt.qml
@@ -13,7 +13,7 @@ import QtQuick.Layouts
 import QGroundControl
 
 import QGroundControl.FactControls
-import QGroundControl.ScreenTools
+
 
 import QGroundControl.Controls
 

--- a/src/UI/FirstRunPromptDialogs/UnitsFirstRunPrompt.qml
+++ b/src/UI/FirstRunPromptDialogs/UnitsFirstRunPrompt.qml
@@ -13,7 +13,7 @@ import QtQuick.Layouts
 import QGroundControl
 
 import QGroundControl.FactControls
-import QGroundControl.ScreenTools
+
 
 import QGroundControl.Controls
 

--- a/src/UI/MainWindow.qml
+++ b/src/UI/MainWindow.qml
@@ -17,7 +17,7 @@ import QGroundControl
 
 import QGroundControl.Controls
 import QGroundControl.FactControls
-import QGroundControl.ScreenTools
+
 import QGroundControl.FlightDisplay
 import QGroundControl.FlightMap
 

--- a/src/UI/toolbar/APMBatteryIndicator.qml
+++ b/src/UI/toolbar/APMBatteryIndicator.qml
@@ -13,7 +13,7 @@ import QtQuick.Layouts
 import QGroundControl
 import QGroundControl.Controls
 
-import QGroundControl.ScreenTools
+
 
 
 import QGroundControl.FactControls

--- a/src/UI/toolbar/APMFlightModeIndicator.qml
+++ b/src/UI/toolbar/APMFlightModeIndicator.qml
@@ -14,7 +14,7 @@ import QtQuick.Layouts
 import QGroundControl
 import QGroundControl.Controls
 
-import QGroundControl.ScreenTools
+
 
 
 import QGroundControl.FactControls

--- a/src/UI/toolbar/APMMainStatusIndicatorContentItem.qml
+++ b/src/UI/toolbar/APMMainStatusIndicatorContentItem.qml
@@ -14,7 +14,7 @@ import QtQuick.Layouts
 import QGroundControl
 import QGroundControl.Controls
 
-import QGroundControl.ScreenTools
+
 
 
 import QGroundControl.FactControls

--- a/src/UI/toolbar/APMSupportForwardingIndicator.qml
+++ b/src/UI/toolbar/APMSupportForwardingIndicator.qml
@@ -12,7 +12,7 @@ import QtQuick.Layouts
 
 import QGroundControl
 import QGroundControl.Controls
-import QGroundControl.ScreenTools
+
 
 
 //-------------------------------------------------------------------------

--- a/src/UI/toolbar/ArmedIndicator.qml
+++ b/src/UI/toolbar/ArmedIndicator.qml
@@ -14,7 +14,7 @@ import QtQuick.Layouts
 import QGroundControl
 import QGroundControl.Controls
 
-import QGroundControl.ScreenTools
+
 
 
 //-------------------------------------------------------------------------

--- a/src/UI/toolbar/GCSControlIndicator.qml
+++ b/src/UI/toolbar/GCSControlIndicator.qml
@@ -4,7 +4,7 @@ import QtQuick.Layouts
 import QGroundControl
 import QGroundControl.Controls
 
-import QGroundControl.ScreenTools
+
 
 
 import QGroundControl.FactControls

--- a/src/UI/toolbar/GimbalIndicator.qml
+++ b/src/UI/toolbar/GimbalIndicator.qml
@@ -14,7 +14,7 @@ import QtQuick.Layouts
 import QGroundControl
 import QGroundControl.Controls
 
-import QGroundControl.ScreenTools
+
 
 
 import QGroundControl.FactControls

--- a/src/UI/toolbar/JoystickIndicator.qml
+++ b/src/UI/toolbar/JoystickIndicator.qml
@@ -13,7 +13,7 @@ import QtQuick.Layouts
 import QGroundControl
 import QGroundControl.Controls
 
-import QGroundControl.ScreenTools
+
 
 
 // Joystick Indicator

--- a/src/UI/toolbar/LinkIndicator.qml
+++ b/src/UI/toolbar/LinkIndicator.qml
@@ -13,7 +13,7 @@ import QtQuick.Controls
 import QGroundControl
 import QGroundControl.Controls
 
-import QGroundControl.ScreenTools
+
 
 
 

--- a/src/UI/toolbar/ModeIndicator.qml
+++ b/src/UI/toolbar/ModeIndicator.qml
@@ -14,7 +14,7 @@ import QtQuick.Controls
 import QGroundControl
 import QGroundControl.Controls
 
-import QGroundControl.ScreenTools
+
 
 
 //-------------------------------------------------------------------------

--- a/src/UI/toolbar/MultiVehicleSelector.qml
+++ b/src/UI/toolbar/MultiVehicleSelector.qml
@@ -16,7 +16,7 @@ import QGroundControl
 import QGroundControl.FactControls
 import QGroundControl.Controls
 
-import QGroundControl.ScreenTools
+
 
 
 RowLayout {

--- a/src/UI/toolbar/RCRSSIIndicator.qml
+++ b/src/UI/toolbar/RCRSSIIndicator.qml
@@ -13,7 +13,7 @@ import QtQuick.Layouts
 import QGroundControl
 import QGroundControl.Controls
 
-import QGroundControl.ScreenTools
+
 
 
 //-------------------------------------------------------------------------

--- a/src/UI/toolbar/RTKGPSIndicator.qml
+++ b/src/UI/toolbar/RTKGPSIndicator.qml
@@ -13,7 +13,7 @@ import QtQuick.Layouts
 import QGroundControl
 import QGroundControl.Controls
 
-import QGroundControl.ScreenTools
+
 
 
 GPSIndicator {

--- a/src/UI/toolbar/RemoteIDIndicator.qml
+++ b/src/UI/toolbar/RemoteIDIndicator.qml
@@ -13,7 +13,7 @@ import QtQuick.Layouts
 import QGroundControl
 import QGroundControl.Controls
 
-import QGroundControl.ScreenTools
+
 
 
 //-------------------------------------------------------------------------

--- a/src/UI/toolbar/TelemetryRSSIIndicator.qml
+++ b/src/UI/toolbar/TelemetryRSSIIndicator.qml
@@ -13,7 +13,7 @@ import QtQuick.Layouts
 import QGroundControl
 import QGroundControl.Controls
 
-import QGroundControl.ScreenTools
+
 
 
 //-------------------------------------------------------------------------

--- a/src/UI/toolbar/VehicleGPSIndicator.qml
+++ b/src/UI/toolbar/VehicleGPSIndicator.qml
@@ -13,7 +13,7 @@ import QtQuick.Layouts
 import QGroundControl
 import QGroundControl.Controls
 
-import QGroundControl.ScreenTools
+
 
 
 GPSIndicator {

--- a/src/UTMSP/UTMSPActivationStatusBar.qml
+++ b/src/UTMSP/UTMSPActivationStatusBar.qml
@@ -16,7 +16,7 @@ import QtLocation
 
 import QGroundControl
 import QGroundControl.FlightMap
-import QGroundControl.ScreenTools
+
 import QGroundControl.Controls
 
 import QGroundControl.FactControls

--- a/src/UTMSP/UTMSPAdapterEditor.qml
+++ b/src/UTMSP/UTMSPAdapterEditor.qml
@@ -15,7 +15,7 @@ import QtQuick.Dialogs
 import QtQuick.Layouts
 
 import QGroundControl
-import QGroundControl.ScreenTools
+
 import QGroundControl.Controls
 
 import QGroundControl.FactControls

--- a/src/UTMSP/UTMSPFlightStatusIndicator.qml
+++ b/src/UTMSP/UTMSPFlightStatusIndicator.qml
@@ -16,7 +16,7 @@ import QtLocation
 
 import QGroundControl
 import QGroundControl.FlightMap
-import QGroundControl.ScreenTools
+
 import QGroundControl.Controls
 
 import QGroundControl.FactControls

--- a/src/UTMSP/UTMSPMapPolygonVisuals.qml
+++ b/src/UTMSP/UTMSPMapPolygonVisuals.qml
@@ -15,7 +15,7 @@ import QtQuick.Dialogs
 import QtQuick.Layouts
 
 import QGroundControl
-import QGroundControl.ScreenTools
+
 
 import QGroundControl.Controls
 import QGroundControl.FlightMap

--- a/src/UTMSP/UTMSPMapVisuals.qml
+++ b/src/UTMSP/UTMSPMapVisuals.qml
@@ -13,7 +13,7 @@ import QtLocation
 import QtPositioning
 
 import QGroundControl
-import QGroundControl.ScreenTools
+
 
 import QGroundControl.Controls
 import QGroundControl.FlightMap

--- a/src/UTMSP/UTMSPNotificationSlider.qml
+++ b/src/UTMSP/UTMSPNotificationSlider.qml
@@ -16,7 +16,7 @@ import QtLocation
 
 import QGroundControl
 import QGroundControl.FlightMap
-import QGroundControl.ScreenTools
+
 import QGroundControl.Controls
 
 import QGroundControl.FactControls

--- a/src/Vehicle/VehicleSetup/FirmwareUpgrade.qml
+++ b/src/Vehicle/VehicleSetup/FirmwareUpgrade.qml
@@ -19,7 +19,7 @@ import QGroundControl.Controls
 import QGroundControl.FactControls
 
 
-import QGroundControl.ScreenTools
+
 
 SetupPage {
     id:             firmwarePage

--- a/src/Vehicle/VehicleSetup/JoystickConfig.qml
+++ b/src/Vehicle/VehicleSetup/JoystickConfig.qml
@@ -16,7 +16,7 @@ import QtQuick.Layouts
 import QGroundControl
 
 import QGroundControl.Controls
-import QGroundControl.ScreenTools
+
 
 
 import QGroundControl.FactControls

--- a/src/Vehicle/VehicleSetup/JoystickConfigAdvanced.qml
+++ b/src/Vehicle/VehicleSetup/JoystickConfigAdvanced.qml
@@ -15,7 +15,7 @@ import QtQuick.Layouts
 import QGroundControl
 
 import QGroundControl.Controls
-import QGroundControl.ScreenTools
+
 
 
 import QGroundControl.FactControls

--- a/src/Vehicle/VehicleSetup/JoystickConfigButtons.qml
+++ b/src/Vehicle/VehicleSetup/JoystickConfigButtons.qml
@@ -15,7 +15,7 @@ import QtQuick.Layouts
 import QGroundControl
 
 import QGroundControl.Controls
-import QGroundControl.ScreenTools
+
 
 
 import QGroundControl.FactControls

--- a/src/Vehicle/VehicleSetup/JoystickConfigCalibration.qml
+++ b/src/Vehicle/VehicleSetup/JoystickConfigCalibration.qml
@@ -15,7 +15,7 @@ import QtQuick.Layouts
 import QGroundControl
 
 import QGroundControl.Controls
-import QGroundControl.ScreenTools
+
 
 
 import QGroundControl.FactControls

--- a/src/Vehicle/VehicleSetup/JoystickConfigGeneral.qml
+++ b/src/Vehicle/VehicleSetup/JoystickConfigGeneral.qml
@@ -15,7 +15,7 @@ import QtQuick.Layouts
 import QGroundControl
 
 import QGroundControl.Controls
-import QGroundControl.ScreenTools
+
 
 
 import QGroundControl.FactControls

--- a/src/Vehicle/VehicleSetup/OpticalFlowSensor.qml
+++ b/src/Vehicle/VehicleSetup/OpticalFlowSensor.qml
@@ -14,7 +14,7 @@ import QtQuick.Dialogs
 
 import QGroundControl
 import QGroundControl.Controls
-import QGroundControl.ScreenTools
+
 
 Item {
     QGCLabel {

--- a/src/Vehicle/VehicleSetup/SetupParameterEditor.qml
+++ b/src/Vehicle/VehicleSetup/SetupParameterEditor.qml
@@ -11,8 +11,9 @@
 import QtQuick
 import QtQuick.Controls
 
+import QGroundControl
 import QGroundControl.Controls
-import QGroundControl.ScreenTools
+
 
 
 ParameterEditor {

--- a/src/Vehicle/VehicleSetup/SetupView.qml
+++ b/src/Vehicle/VehicleSetup/SetupView.qml
@@ -14,7 +14,7 @@ import QtQuick.Layouts
 import QGroundControl
 
 import QGroundControl.Controls
-import QGroundControl.ScreenTools
+
 
 
 Rectangle {

--- a/src/Vehicle/VehicleSetup/VehicleSummary.qml
+++ b/src/Vehicle/VehicleSetup/VehicleSummary.qml
@@ -14,7 +14,7 @@ import QtQuick.Controls
 import QGroundControl
 
 import QGroundControl.Controls
-import QGroundControl.ScreenTools
+
 
 
 

--- a/src/Viewer3D/Viewer3DQml/Models3D/Viewer3DModel.qml
+++ b/src/Viewer3D/Viewer3DQml/Models3D/Viewer3DModel.qml
@@ -11,7 +11,6 @@ import QGroundControl
 import QGroundControl.Controls
 import QGroundControl.FlightDisplay
 import QGroundControl.FlightMap
-import QGroundControl.ScreenTools
 import QGroundControl.Viewer3D
 
 View3D {

--- a/src/Viewer3D/Viewer3DQml/Models3D/Viewer3DVehicleItems.qml
+++ b/src/Viewer3D/Viewer3DQml/Models3D/Viewer3DVehicleItems.qml
@@ -11,7 +11,6 @@ import QGroundControl
 import QGroundControl.Controls
 import QGroundControl.FlightDisplay
 import QGroundControl.FlightMap
-import QGroundControl.ScreenTools
 import QGroundControl.Viewer3D
 
 Node {

--- a/src/Viewer3D/Viewer3DQml/Viewer3D.qml
+++ b/src/Viewer3D/Viewer3DQml/Viewer3D.qml
@@ -11,7 +11,6 @@ import QGroundControl
 import QGroundControl.Controls
 import QGroundControl.FlightDisplay
 import QGroundControl.FlightMap
-import QGroundControl.ScreenTools
 import QGroundControl.Viewer3D
 
 Item{

--- a/src/Viewer3D/Viewer3DQml/Viewer3DProgressBar.qml
+++ b/src/Viewer3D/Viewer3DQml/Viewer3DProgressBar.qml
@@ -11,7 +11,6 @@ import QGroundControl
 import QGroundControl.Controls
 import QGroundControl.FlightDisplay
 import QGroundControl.FlightMap
-import QGroundControl.ScreenTools
 import QGroundControl.Viewer3D
 
 Rectangle{

--- a/test/MissionManager/MissionCommandTreeEditorTestWindow.qml
+++ b/test/MissionManager/MissionCommandTreeEditorTestWindow.qml
@@ -16,7 +16,7 @@ import QtQuick.Window
 import QGroundControl
 
 import QGroundControl.Controls
-import QGroundControl.ScreenTools
+
 import QGroundControl.FlightDisplay
 import QGroundControl.FlightMap
 


### PR DESCRIPTION
Reduce imports by putting ScreenTools into QGroundControl.Controls & MainWindow into QGroundControl