### PR TITLE
Fix QML type registration for GPS RTK

### DIFF
--- a/src/QmlControls/GPSIndicatorPage.qml
+++ b/src/QmlControls/GPSIndicatorPage.qml
@@ -12,12 +12,8 @@ import QtQuick.Layouts
 
 import QGroundControl
 import QGroundControl.Controls
-
 import QGroundControl.ScreenTools
-
-
 import QGroundControl.FactControls
-import QGroundControl.SettingsManager 1.0
 
 // This indicator page is used both when showing RTK status only with no vehicle connect and when showing GPS/RTK status with a vehicle connected
 
@@ -159,15 +155,15 @@ ToolIndicatorPage {
             RowLayout {
                 QGCRadioButton {
                     text:       qsTr("Survey-In")
-                    checked:    useFixedPosition == BaseMode.BaseSurveyIn
-                    onClicked:  rtkSettings.useFixedBasePosition.rawValue = BaseMode.BaseSurveyIn
+                    checked:    useFixedPosition == BaseModeDefinition.BaseSurveyIn
+                    onClicked:  rtkSettings.useFixedBasePosition.rawValue = BaseModeDefinition.BaseSurveyIn
                     visible:    settingsDisplayId & _all
                 }
 
                 QGCRadioButton {
                     text: qsTr("Specify position")
-                    checked:    useFixedPosition == BaseMode.BaseFixed
-                    onClicked:  rtkSettings.useFixedBasePosition.rawValue = BaseMode.BaseFixed
+                    checked:    useFixedPosition == BaseModeDefinition.BaseFixed
+                    onClicked:  rtkSettings.useFixedBasePosition.rawValue = BaseModeDefinition.BaseFixed
                     visible:    settingsDisplayId & _all
                 }
             }
@@ -179,7 +175,7 @@ ToolIndicatorPage {
                 fact:                   QGroundControl.settingsManager.rtkSettings.surveyInAccuracyLimit
                 majorTickStepSize:      0.1
                 visible:                (
-                    useFixedPosition == BaseMode.BaseSurveyIn
+                    useFixedPosition == BaseModeDefinition.BaseSurveyIn
                     && rtkSettings.surveyInAccuracyLimit.visible
                     && (settingsDisplayId & _ublox)
                 )
@@ -192,7 +188,7 @@ ToolIndicatorPage {
                 fact:                   rtkSettings.surveyInMinObservationDuration
                 majorTickStepSize:      10
                 visible:                ( 
-                    useFixedPosition == BaseMode.BaseSurveyIn
+                    useFixedPosition == BaseModeDefinition.BaseSurveyIn
                     && rtkSettings.surveyInMinObservationDuration.visible
                     && (settingsDisplayId & (_ublox | _femtomes | _trimble))
                 )
@@ -202,7 +198,7 @@ ToolIndicatorPage {
                 label:                  rtkSettings.fixedBasePositionLatitude.shortDescription
                 fact:                   rtkSettings.fixedBasePositionLatitude
                 visible:                (
-                    useFixedPosition == BaseMode.BaseFixed
+                    useFixedPosition == BaseModeDefinition.BaseFixed
                     && (settingsDisplayId & _all)
                 )
             }
@@ -211,7 +207,7 @@ ToolIndicatorPage {
                 label:              rtkSettings.fixedBasePositionLongitude.shortDescription
                 fact:               rtkSettings.fixedBasePositionLongitude
                 visible:            (
-                    useFixedPosition == BaseMode.BaseFixed
+                    useFixedPosition == BaseModeDefinition.BaseFixed
                     && (settingsDisplayId & _all)
                 )
             }
@@ -220,7 +216,7 @@ ToolIndicatorPage {
                 label:              rtkSettings.fixedBasePositionAltitude.shortDescription
                 fact:               rtkSettings.fixedBasePositionAltitude
                 visible:            (
-                    useFixedPosition == BaseMode.BaseFixed
+                    useFixedPosition == BaseModeDefinition.BaseFixed
                     && (settingsDisplayId & _all)
                 )
             }
@@ -229,7 +225,7 @@ ToolIndicatorPage {
                 label:              rtkSettings.fixedBasePositionAccuracy.shortDescription
                 fact:               rtkSettings.fixedBasePositionAccuracy
                 visible:            (
-                    useFixedPosition == BaseMode.BaseFixed
+                    useFixedPosition == BaseModeDefinition.BaseFixed
                     && (settingsDisplayId & _ublox)
                 )
             }
@@ -237,7 +233,7 @@ ToolIndicatorPage {
             LabelledButton {
                 label:              qsTr("Current Base Position")
                 buttonText:         enabled ? qsTr("Save") : qsTr("Not Yet Valid")
-                visible:            useFixedPosition == BaseMode.BaseFixed
+                visible:            useFixedPosition == BaseModeDefinition.BaseFixed
                 enabled:            QGroundControl.gpsRtk.valid.value
 
                 onClicked: {

--- a/src/Settings/RTKSettings.cc
+++ b/src/Settings/RTKSettings.cc
@@ -8,14 +8,8 @@
  ****************************************************************************/
 
 #include "RTKSettings.h"
-// #include "BaseMode.h" // Removed, definition now in RTKSettings.h
 
-DECLARE_SETTINGGROUP(RTK, "RTK")
-{
-    qmlRegisterUncreatableType<RTKSettings>("QGroundControl.SettingsManager", 1, 0, "RTKSettings", "Reference only"); \
-    qRegisterMetaType<BaseModeDefinition::Mode>("BaseModeDefinition::Mode"); \
-    qmlRegisterUncreatableType<BaseModeDefinition>("QGroundControl.SettingsManager", 1, 0, "BaseMode", "Reference to BaseModeDefinition enum holding class");
-}
+DECLARE_SETTINGGROUP(RTK, "RTK") {}
 
 DECLARE_SETTINGSFACT(RTKSettings, baseReceiverManufacturers)
 DECLARE_SETTINGSFACT(RTKSettings, surveyInAccuracyLimit)

--- a/src/Settings/RTKSettings.h
+++ b/src/Settings/RTKSettings.h
@@ -14,18 +14,20 @@
 #include "SettingsGroup.h"
 #include <QObject>
 
-// Definition of BaseMode moved here
-class BaseModeDefinition {
-    Q_GADGET
+class BaseModeDefinition : public QObject {
+    Q_OBJECT
+    QML_ELEMENT
+    QML_UNCREATABLE("")
+
 public:
     enum class Mode {
         BaseSurveyIn = 0,
-        BaseFixed    = 1
+        BaseFixed    = 1,
     };
     Q_ENUM(Mode)
 
 private:
-    explicit BaseModeDefinition(); // Prevent instantiation
+    explicit BaseModeDefinition(QObject* parent = nullptr) : QObject(parent) {}
 };
 
 class RTKSettings : public SettingsGroup


### PR DESCRIPTION
<!--- Title -->

Description
-----------
Refactor BaseModeDefinition to QObject with QML_UNCREATABLE, using auto type registration instead of manual.

Checklist:
----------
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] [Review Contribution Guidelines](https://github.com/mavlink/qgroundcontrol/blob/master/.github/CONTRIBUTING.md).
- [x] [Review Code of Conduct](https://github.com/mavlink/qgroundcontrol/blob/master/.github/CODE_OF_CONDUCT.md).
- [x] I have tested my changes.

Related Issue
-----------
<!-- If any, please provide issue ID. -->


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.