### PR TITLE
fix: window build header

### DIFF
--- a/src/main.cc
+++ b/src/main.cc
@@ -17,6 +17,10 @@
 #include "MavlinkSettings.h"
 #include "Platform.h"
 
+#ifdef Q_OS_WIN
+    #include <windows.h>
+#endif
+
 #if !defined(Q_OS_ANDROID) && !defined(Q_OS_IOS)
     #include <QtWidgets/QMessageBox>
     #include "RunGuard.h"


### PR DESCRIPTION
<!--- Title -->
Fix the issue of missing headers during Windows compilation
Description
-----------
<!--- Describe your changes in detail. -->

Test Steps
-----------
<!-- Describe the steps to reproduce. -->

Checklist:
----------
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [ ] [Review Contribution Guidelines](https://github.com/mavlink/qgroundcontrol/blob/master/.github/CONTRIBUTING.md).
- [ ] [Review Code of Conduct](https://github.com/mavlink/qgroundcontrol/blob/master/.github/CODE_OF_CONDUCT.md).
- [ ] I have tested my changes.

Related Issue
-----------
<!-- If any, please provide issue ID. -->


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.