### PR TITLE
Fix Qml signal leaking to underlying map

### DIFF
--- a/src/AnalyzeView/AnalyzeView.qml
+++ b/src/AnalyzeView/AnalyzeView.qml
@@ -30,6 +30,11 @@ Rectangle {
     readonly property real  _verticalMargin:        _defaultTextHeight / 2
     readonly property real  _buttonWidth:           _defaultTextWidth * 18
 
+    // This need to block click event leakage to underlying map.
+    DeadMouseArea {
+        anchors.fill: parent
+    }
+
     GeoTagController {
         id: geoController
     }

--- a/src/QmlControls/AppSettings.qml
+++ b/src/QmlControls/AppSettings.qml
@@ -43,6 +43,11 @@ Rectangle {
         }
     }
 
+    // This need to block click event leakage to underlying map.
+    DeadMouseArea {
+        anchors.fill: parent
+    }
+
     QGCPalette { id: qgcPal }
 
     Component.onCompleted: {

--- a/src/UI/MainWindow.qml
+++ b/src/UI/MainWindow.qml
@@ -475,6 +475,11 @@ ApplicationWindow {
             }
         }
 
+        // This need to block click event leakage to underlying map.
+        DeadMouseArea {
+            anchors.fill: parent
+        }
+
         Rectangle {
             id:             toolDrawerToolbar
             anchors.left:   parent.left

--- a/src/Vehicle/VehicleSetup/SetupView.qml
+++ b/src/Vehicle/VehicleSetup/SetupView.qml
@@ -22,6 +22,11 @@ Rectangle {
     color:  qgcPal.window
     z:      QGroundControl.zOrderTopMost
 
+    // This need to block click event leakage to underlying map.
+    DeadMouseArea {
+        anchors.fill: parent
+    }
+
     QGCPalette { id: qgcPal; colorGroupEnabled: true }
 
     readonly property real      _defaultTextHeight: ScreenTools.defaultFontPixelHeight


### PR DESCRIPTION
Block click event leakage to underlying map

<!--- Title -->
These changes fix 2 bugs:
1. Described here: (https://github.com/mavlink/qgroundcontrol/issues/13277)
2. The same for toolDrawer
<img width="798" height="527" alt="Screenshot 2025-08-12 at 13 24 23" src="https://github.com/user-attachments/assets/8bd86756-ffb9-4799-b2de-4f82c8c5d103" />

-----------
<!--- Describe your changes in detail. -->

Test Steps
-----------
<!-- Describe the steps to reproduce. -->

Checklist:
----------
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] [Review Contribution Guidelines](https://github.com/mavlink/qgroundcontrol/blob/master/.github/CONTRIBUTING.md).
- [x] [Review Code of Conduct](https://github.com/mavlink/qgroundcontrol/blob/master/.github/CODE_OF_CONDUCT.md).
- [x] I have tested my changes.

Related Issue
-----------
Closes #13277


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.