### PR TITLE
JoystickSDL: Hybrid button read to support both Gamepad and Joystick …

### DIFF
--- a/src/Joystick/CMakeLists.txt
+++ b/src/Joystick/CMakeLists.txt
@@ -72,9 +72,9 @@ endif()
 
 CPMAddPackage(
     NAME SDL3
-    VERSION 3.2.16
+    VERSION 3.2.20
     GITHUB_REPOSITORY libsdl-org/SDL
-    GIT_TAG release-3.2.16
+    GIT_TAG release-3.2.20
     OPTIONS
         "SDL_INSTALL OFF"
         "SDL_UNINSTALL OFF"

--- a/src/Joystick/JoystickSDL.cc
+++ b/src/Joystick/JoystickSDL.cc
@@ -162,15 +162,20 @@ bool JoystickSDL::_update()
 
 bool JoystickSDL::_getButton(int idx) const
 {
-    int button = -1;
-
-    if (_isGamepad) {
-        button = SDL_GetGamepadButton(_sdlGamepad, static_cast<SDL_GamepadButton>(idx));
-    } else {
-        button = SDL_GetJoystickButton(_sdlJoystick, idx);
+    // First try the standardized gamepad set if idx is inside that set
+#ifdef SDL_GAMEPAD_BUTTON_COUNT
+    if (_sdlGamepad && idx >= 0 && idx < SDL_GAMEPAD_BUTTON_COUNT) {
+        if (SDL_GetGamepadButton(_sdlGamepad,
+             static_cast<SDL_GamepadButton>(idx)) == 1) {
+            return true;
+        }
     }
-
-    return (button == 1);
+#endif
+    // Fall back to raw joystick buttons (covers unmapped/extras)
+    if (_sdlJoystick && idx >= 0 && idx < SDL_GetNumJoystickButtons(_sdlJoystick)) {
+        return SDL_GetJoystickButton(_sdlJoystick, idx) == 1;
+    }
+    return false;
 }
 
 int JoystickSDL::_getAxis(int idx) const


### PR DESCRIPTION
Title:
--------
Fix for incomplete button registration when using Radiomaster Zorro (Hybrid Gamepad + Joystick input handling)

Description:
----------------
This change updates the JoystickSDL backend to allow simultaneous reading of both SDL Gamepad and raw Joystick inputs.
Previously, when a device was detected as a Gamepad by SDL (such as the Radiomaster Zorro in USB HID mode), QGroundControl only read button states via SDL_GetGamepadButton. This resulted in some physical buttons not being recognized or mapped in QGroundControl.

By also opening the underlying SDL_Joystick handle for devices detected as Gamepads, and reading buttons via SDL_GetJoystickButton. We ensure that all available button inputs are captured. Even if they are not mapped in SDLs Gamepad mapping database.

This change is especially important for advanced transmitters like the Radiomaster Zorro. Where the default SDL gamepad mapping omits many functional buttons.

Test Steps:
--------------
    Connect a Radiomaster Zorro (or similar transmitter that presents as a USB Gamepad).
    In QGroundControl, open the joystick configuration panel.
    Move sticks and press all buttons on the transmitter.
    Observe that all buttons register correctly in QGroundControl.
    Compare with the behavior before this change, where some buttons were ignored.
    I did use jstest-gtk to test the buttons


Checklist:
----------
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [`x` ] [Review Contribution Guidelines](https://github.com/mavlink/qgroundcontrol/blob/master/.github/CONTRIBUTING.md).
- [ `x`] [Review Code of Conduct](https://github.com/mavlink/qgroundcontrol/blob/master/.github/CODE_OF_CONDUCT.md).
- [ `x`] I have tested my changes.

Related Issue
----------------
No formal GitHub issue was filed, but this resolves a long-standing problem where certain transmitter buttons were not detected when SDL classified the device as a Gamepad.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.