### PR TITLE
Fix crash when loading parameter which does not currently exist

### DIFF
--- a/src/QmlControls/ParameterEditorController.cc
+++ b/src/QmlControls/ParameterEditorController.cc
@@ -129,7 +129,7 @@ Fact* ParameterTableModel::factAt(int row) const
         return nullptr;
     }
 
-    return _tableData[row][0].value<Fact*>();
+    return _tableData[row][ValueColumn].value<Fact*>();
 }
 
 


### PR DESCRIPTION
Fix #13227