### PR TITLE
fix(windows): improve crash handling to prevent process hanging

### DIFF
--- a/src/main.cc
+++ b/src/main.cc
@@ -148,6 +148,16 @@ int main(int argc, char *argv[])
         }
     }
 
+    // Prevent Windows Error Reporting dialog from appearing on crash
+    SetErrorMode(SEM_NOGPFAULTERRORBOX | SEM_FAILCRITICALERRORS | SEM_NOOPENFILEERRORBOX);
+
+    // Also set unhandled exception filter as backup
+    SetUnhandledExceptionFilter([](EXCEPTION_POINTERS* pExceptionInfo) -> LONG {
+        // Force immediate termination without any cleanup
+        TerminateProcess(GetCurrentProcess(), 1);
+        return EXCEPTION_EXECUTE_HANDLER;
+    });
+
 #ifdef QGC_UNITTEST_BUILD
     if (runUnitTests) {
         // Don't pop up Windows Error Reporting dialog when app crashes.


### PR DESCRIPTION
<!--- Title -->

## Description

This PR improves the crash handling mechanism on Windows platform to prevent applications from hanging in the background after crashes, which previously required manual termination through task manager.

**Changes made:**
- Set Windows error mode using `SetErrorMode()` to suppress system error dialogs (`SEM_NOGPFAULTERRORBOX`, `SEM_FAILCRITICALERRORS`, `SEM_NOOPENFILEERRORBOX`)
- Implement `SetUnhandledExceptionFilter()` with `TerminateProcess()` for immediate process termination
- Ensure crashed processes exit cleanly without becoming zombie processes

## Test Steps

1. Build the application with the changes
2. Trigger a crash (e.g., null pointer dereference) 
3. Verify that:
   - No Windows Error Reporting dialog appears
   - Process terminates immediately without hanging
   - No zombie processes remain in task manager
   - Application doesn't require manual termination

**Before:** Crashed applications would hang in background, requiring manual termination via task manager

**After:** Crashed applications terminate immediately and cleanly

## Related Issue

This addresses the issue where crashed applications on Windows would remain as hanging processes that couldn't be terminated by task manager, requiring forced termination through system tools.

**Problem:** Program crashes but hangs in background instead of exiting cleanly
**Solution:** Direct process termination using Windows API without relying on potentially corrupted Qt event loops
