### PR TITLE
Fix centering of inner circle in PhotoVideoControl

### DIFF
--- a/src/FlightMap/Widgets/PhotoVideoControl.qml
+++ b/src/FlightMap/Widgets/PhotoVideoControl.qml
@@ -165,7 +165,13 @@ Rectangle {
                     border.width:       3
 
                     Rectangle {
-                        anchors.centerIn:   parent
+                        // anchors.centerIn snaps to integer coordinates, which
+                        // depending on DPI can throw the centering off.
+                        // Setting alignWhenCentered to false avoids this issue.
+                        anchors {
+                            centerIn:           parent
+                            alignWhenCentered:  false
+                        }
                         width:              parent.width * (_isShootingInCurrentMode ? 0.5 : 0.75)
                         height:             width
                         radius:             _isShootingInCurrentMode ? 0 : width * 0.5


### PR DESCRIPTION
The inner circle in the PhotoVideoControl widget was not always perfectly centered due to a bug in Qt's anchors.centerIn property (QTBUG-95224) which causes it to return integer positions instead of subpixel values.

Implemented a workaround by setting alignWhenCentered to false.

Related Qt bug: https://bugreports.qt.io/browse/QTBUG-95224

Qt fix commit:
https://github.com/qt/qtdeclarative/commit/fd23a222efe189607eebd5c6782ca73eafa7080c

Cherry picked from master