### PR TITLE
Fix mavlink inspector crash

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -94,3 +94,4 @@ docs/.vitepress/dist/
 
 CMakeUserPresets.json
 cpm_modules
+android/.gradle/*

--- a/src/AnalyzeView/MAVLinkInspectorController.cc
+++ b/src/AnalyzeView/MAVLinkInspectorController.cc
@@ -7,310 +7,315 @@
  *
  ****************************************************************************/
 
-#include "MAVLinkInspectorController.h"
-#include "MAVLinkChartController.h"
-#include "MAVLinkMessage.h"
-#include "MAVLinkProtocol.h"
-#include "MAVLinkSystem.h"
-#include "MultiVehicleManager.h"
-#include "QGCApplication.h"
-#include "QGCLoggingCategory.h"
-#include "QmlObjectListModel.h"
-#include "Vehicle.h"
+ #include "MAVLinkInspectorController.h"
+ #include "MAVLinkChartController.h"
+ #include "MAVLinkMessage.h"
+ #include "MAVLinkProtocol.h"
+ #include "MAVLinkSystem.h"
+ #include "MultiVehicleManager.h"
+ #include "QGCApplication.h"
+ #include "QGCLoggingCategory.h"
+ #include "QmlObjectListModel.h"
+ #include "Vehicle.h"
 
-#include <QtQml/QQmlEngine>
+ #include <QtQml/QQmlEngine>
 
-QGC_LOGGING_CATEGORY(MAVLinkInspectorControllerLog, "qgc.analyzeview.mavlinkinspectorcontroller")
+ QGC_LOGGING_CATEGORY(MAVLinkInspectorControllerLog, "qgc.analyzeview.mavlinkinspectorcontroller")
 
-MAVLinkInspectorController::TimeScale_st::TimeScale_st(const QString &label_, uint32_t timeScale_)
-    : label(label_)
-    , timeScale(timeScale_)
-{
+ MAVLinkInspectorController::TimeScale_st::TimeScale_st(const QString &label_, uint32_t timeScale_)
+     : label(label_)
+     , timeScale(timeScale_)
+ {
 
-}
+ }
 
-/*===========================================================================*/
+ /*===========================================================================*/
 
-MAVLinkInspectorController::Range_st::Range_st(const QString &label_, qreal range_)
-    : label(label_)
-    , range(range_)
-{
+ MAVLinkInspectorController::Range_st::Range_st(const QString &label_, qreal range_)
+     : label(label_)
+     , range(range_)
+ {
 
-}
+ }
 
-/*===========================================================================*/
+ /*===========================================================================*/
 
-MAVLinkInspectorController::MAVLinkInspectorController(QObject *parent)
-    : QObject(parent)
-    , _updateFrequencyTimer(new QTimer(this))
-    , _systems(new QmlObjectListModel(this))
-    , _charts(new QmlObjectListModel(this))
-{
-    // qCDebug(MAVLinkInspectorControllerLog) << Q_FUNC_INFO << this;
+ MAVLinkInspectorController::MAVLinkInspectorController(QObject *parent)
+     : QObject(parent)
+     , _updateFrequencyTimer(new QTimer(this))
+     , _systems(new QmlObjectListModel(this))
+     , _charts(new QmlObjectListModel(this))
+ {
+     // qCDebug(MAVLinkInspectorControllerLog) << Q_FUNC_INFO << this;
 
-    MultiVehicleManager *const multiVehicleManager = MultiVehicleManager::instance();
-    (void) connect(multiVehicleManager, &MultiVehicleManager::vehicleAdded,   this, &MAVLinkInspectorController::_vehicleAdded);
-    (void) connect(multiVehicleManager, &MultiVehicleManager::vehicleRemoved, this, &MAVLinkInspectorController::_vehicleRemoved);
-    (void) connect(multiVehicleManager, &MultiVehicleManager::activeVehicleChanged, this, &MAVLinkInspectorController::_setActiveVehicle);
+     MultiVehicleManager *const multiVehicleManager = MultiVehicleManager::instance();
+     (void) connect(multiVehicleManager, &MultiVehicleManager::vehicleAdded,   this, &MAVLinkInspectorController::_vehicleAdded);
+     (void) connect(multiVehicleManager, &MultiVehicleManager::vehicleRemoved, this, &MAVLinkInspectorController::_vehicleRemoved);
+     (void) connect(multiVehicleManager, &MultiVehicleManager::activeVehicleChanged, this, &MAVLinkInspectorController::_setActiveVehicle);
 
-    MAVLinkProtocol *const mavlinkProtocol = MAVLinkProtocol::instance();
-    (void) connect(mavlinkProtocol, &MAVLinkProtocol::messageReceived, this, &MAVLinkInspectorController::_receiveMessage);
-    (void) connect(_updateFrequencyTimer, &QTimer::timeout, this, &MAVLinkInspectorController::_refreshFrequency);
+     MAVLinkProtocol *const mavlinkProtocol = MAVLinkProtocol::instance();
+     (void) connect(mavlinkProtocol, &MAVLinkProtocol::messageReceived, this, &MAVLinkInspectorController::_receiveMessage);
+     (void) connect(_updateFrequencyTimer, &QTimer::timeout, this, &MAVLinkInspectorController::_refreshFrequency);
 
-    _updateFrequencyTimer->setInterval(1000);
-    _updateFrequencyTimer->setSingleShot(false);
-    _updateFrequencyTimer->start();
+     _updateFrequencyTimer->setInterval(1000);
+     _updateFrequencyTimer->setSingleShot(false);
+     _updateFrequencyTimer->start();
 
-    _timeScaleSt.append(new TimeScale_st(tr("5 Sec"),   5 * 1000));
-    _timeScaleSt.append(new TimeScale_st(tr("10 Sec"), 10 * 1000));
-    _timeScaleSt.append(new TimeScale_st(tr("30 Sec"), 30 * 1000));
-    _timeScaleSt.append(new TimeScale_st(tr("60 Sec"), 60 * 1000));
-    emit timeScalesChanged();
+     _timeScaleSt.append(new TimeScale_st(tr("5 Sec"),   5 * 1000));
+     _timeScaleSt.append(new TimeScale_st(tr("10 Sec"), 10 * 1000));
+     _timeScaleSt.append(new TimeScale_st(tr("30 Sec"), 30 * 1000));
+     _timeScaleSt.append(new TimeScale_st(tr("60 Sec"), 60 * 1000));
+     emit timeScalesChanged();
 
-    _rangeSt.append(new Range_st(tr("Auto"),    0));
-    _rangeSt.append(new Range_st(tr("10,000"),  10000));
-    _rangeSt.append(new Range_st(tr("1,000"),   1000));
-    _rangeSt.append(new Range_st(tr("100"),     100));
-    _rangeSt.append(new Range_st(tr("10"),      10));
-    _rangeSt.append(new Range_st(tr("1"),       1));
-    _rangeSt.append(new Range_st(tr("0.1"),     0.1));
-    _rangeSt.append(new Range_st(tr("0.01"),    0.01));
-    _rangeSt.append(new Range_st(tr("0.001"),   0.001));
-    _rangeSt.append(new Range_st(tr("0.0001"),  0.0001));
-    emit rangeListChanged();
-}
+     _rangeSt.append(new Range_st(tr("Auto"),    0));
+     _rangeSt.append(new Range_st(tr("10,000"),  10000));
+     _rangeSt.append(new Range_st(tr("1,000"),   1000));
+     _rangeSt.append(new Range_st(tr("100"),     100));
+     _rangeSt.append(new Range_st(tr("10"),      10));
+     _rangeSt.append(new Range_st(tr("1"),       1));
+     _rangeSt.append(new Range_st(tr("0.1"),     0.1));
+     _rangeSt.append(new Range_st(tr("0.01"),    0.01));
+     _rangeSt.append(new Range_st(tr("0.001"),   0.001));
+     _rangeSt.append(new Range_st(tr("0.0001"),  0.0001));
+     emit rangeListChanged();
+ }
 
-MAVLinkInspectorController::~MAVLinkInspectorController()
-{
-    qDeleteAll(_timeScaleSt);
-    qDeleteAll(_rangeSt);
-    _charts->clearAndDeleteContents();
-    _systems->clearAndDeleteContents();
+ MAVLinkInspectorController::~MAVLinkInspectorController()
+ {
+     qDeleteAll(_timeScaleSt);
+     qDeleteAll(_rangeSt);
 
-    // qCDebug(MAVLinkInspectorControllerLog) << Q_FUNC_INFO << this;
-}
+     for (int i = _charts->count() - 1; i >= 0; i--) {
+         auto chartObject = _charts->get(i);
+         MAVLinkChartController* chart = dynamic_cast<MAVLinkChartController*>(chartObject);
+         deleteChart(chart);
+     }
+     _systems->clearAndDeleteContents();
 
-QStringList MAVLinkInspectorController::timeScales()
-{
-    if (_timeScales.isEmpty()) {
-        for (const TimeScale_st *timeScale : _timeScaleSt) {
-            _timeScales << timeScale->label;
-        }
-    }
+     // qCDebug(MAVLinkInspectorControllerLog) << Q_FUNC_INFO << this;
+ }
 
-    return _timeScales;
-}
+ QStringList MAVLinkInspectorController::timeScales()
+ {
+     if (_timeScales.isEmpty()) {
+         for (const TimeScale_st *timeScale : _timeScaleSt) {
+             _timeScales << timeScale->label;
+         }
+     }
 
-QStringList MAVLinkInspectorController::rangeList()
-{
-    if (_rangeList.isEmpty()) {
-        for (const Range_st *range : _rangeSt) {
-            _rangeList << range->label;
-        }
-    }
+     return _timeScales;
+ }
 
-    return _rangeList;
-}
+ QStringList MAVLinkInspectorController::rangeList()
+ {
+     if (_rangeList.isEmpty()) {
+         for (const Range_st *range : _rangeSt) {
+             _rangeList << range->label;
+         }
+     }
 
-void MAVLinkInspectorController::_setActiveVehicle(Vehicle *vehicle)
-{
-    if (vehicle) {
-        QGCMAVLinkSystem *const system = _findVehicle(static_cast<uint8_t>(vehicle->id()));
-        if (system) {
-            _activeSystem = system;
-        } else {
-            _activeSystem = nullptr;
-        }
-    } else {
-        _activeSystem = nullptr;
-    }
+     return _rangeList;
+ }
 
-    emit activeSystemChanged();
-}
+ void MAVLinkInspectorController::_setActiveVehicle(Vehicle *vehicle)
+ {
+     if (vehicle) {
+         QGCMAVLinkSystem *const system = _findVehicle(static_cast<uint8_t>(vehicle->id()));
+         if (system) {
+             _activeSystem = system;
+         } else {
+             _activeSystem = nullptr;
+         }
+     } else {
+         _activeSystem = nullptr;
+     }
 
-QGCMAVLinkSystem *MAVLinkInspectorController::_findVehicle(uint8_t id)
-{
-    for (int i = 0; i < _systems->count(); i++) {
-        QGCMAVLinkSystem *const system = qobject_cast<QGCMAVLinkSystem*>(_systems->get(i));
-        if (system && (system->id() == id)) {
-            return system;
-        }
-    }
+     emit activeSystemChanged();
+ }
 
-    return nullptr;
-}
+ QGCMAVLinkSystem *MAVLinkInspectorController::_findVehicle(uint8_t id)
+ {
+     for (int i = 0; i < _systems->count(); i++) {
+         QGCMAVLinkSystem *const system = qobject_cast<QGCMAVLinkSystem*>(_systems->get(i));
+         if (system && (system->id() == id)) {
+             return system;
+         }
+     }
 
-void MAVLinkInspectorController::_refreshFrequency()
-{
-    for (int i = 0; i < _systems->count(); i++) {
-        QGCMAVLinkSystem *const system = qobject_cast<QGCMAVLinkSystem*>(_systems->get(i));
-        if (!system) {
-            continue;
-        }
+     return nullptr;
+ }
 
-        for (int i = 0; i < system->messages()->count(); i++) {
-            QGCMAVLinkMessage *const msg = qobject_cast<QGCMAVLinkMessage*>(system->messages()->get(i));
-            if (msg) {
-                msg->updateFreq();
-            }
-        }
-    }
-}
+ void MAVLinkInspectorController::_refreshFrequency()
+ {
+     for (int i = 0; i < _systems->count(); i++) {
+         QGCMAVLinkSystem *const system = qobject_cast<QGCMAVLinkSystem*>(_systems->get(i));
+         if (!system) {
+             continue;
+         }
 
-void MAVLinkInspectorController::_vehicleAdded(Vehicle *vehicle)
-{
-    QGCMAVLinkSystem *sys = _findVehicle(static_cast<uint8_t>(vehicle->id()));
+         for (int i = 0; i < system->messages()->count(); i++) {
+             QGCMAVLinkMessage *const msg = qobject_cast<QGCMAVLinkMessage*>(system->messages()->get(i));
+             if (msg) {
+                 msg->updateFreq();
+             }
+         }
+     }
+ }
 
-    if (sys) {
-        sys->messages()->clearAndDeleteContents();
-    } else {
-        sys = new QGCMAVLinkSystem(static_cast<uint8_t>(vehicle->id()), this);
-        _systems->append(sys);
-        _systemNames.append(tr("System %1").arg(vehicle->id()));
+ void MAVLinkInspectorController::_vehicleAdded(Vehicle *vehicle)
+ {
+     QGCMAVLinkSystem *sys = _findVehicle(static_cast<uint8_t>(vehicle->id()));
 
-        (void) connect(vehicle, &Vehicle::mavlinkMsgIntervalsChanged, sys, [sys](uint8_t compid, uint16_t msgId, int32_t rate) {
-            for (int i = 0; i < sys->messages()->count(); i++) {
-                QGCMAVLinkMessage *const msg = qobject_cast<QGCMAVLinkMessage*>(sys->messages()->get(i));
-                if ((msg->compId() == compid) && (msg->id() == msgId)) {
-                    msg->setTargetRateHz(rate);
-                    break;
-                }
-            }
-        });
-    }
+     if (sys) {
+         sys->messages()->clearAndDeleteContents();
+     } else {
+         sys = new QGCMAVLinkSystem(static_cast<uint8_t>(vehicle->id()), this);
+         _systems->append(sys);
+         _systemNames.append(tr("System %1").arg(vehicle->id()));
 
-    emit systemsChanged();
-}
+         (void) connect(vehicle, &Vehicle::mavlinkMsgIntervalsChanged, sys, [sys](uint8_t compid, uint16_t msgId, int32_t rate) {
+             for (int i = 0; i < sys->messages()->count(); i++) {
+                 QGCMAVLinkMessage *const msg = qobject_cast<QGCMAVLinkMessage*>(sys->messages()->get(i));
+                 if ((msg->compId() == compid) && (msg->id() == msgId)) {
+                     msg->setTargetRateHz(rate);
+                     break;
+                 }
+             }
+         });
+     }
 
-void MAVLinkInspectorController::_vehicleRemoved(const Vehicle *vehicle)
-{
-    QGCMAVLinkSystem *const system = _findVehicle(static_cast<uint8_t>(vehicle->id()));
-    if (!system) {
-        return;
-    }
+     emit systemsChanged();
+ }
 
-    system->deleteLater();
-    (void) _systems->removeOne(system);
+ void MAVLinkInspectorController::_vehicleRemoved(const Vehicle *vehicle)
+ {
+     QGCMAVLinkSystem *const system = _findVehicle(static_cast<uint8_t>(vehicle->id()));
+     if (!system) {
+         return;
+     }
 
-    const QString systemName = tr("System %1").arg(vehicle->id());
-    (void) _systemNames.removeOne(systemName);
+     system->deleteLater();
+     (void) _systems->removeOne(system);
 
-    emit systemsChanged();
-}
+     const QString systemName = tr("System %1").arg(vehicle->id());
+     (void) _systemNames.removeOne(systemName);
 
-void MAVLinkInspectorController::_receiveMessage(LinkInterface *link, const mavlink_message_t &message)
-{
-    Q_UNUSED(link);
+     emit systemsChanged();
+ }
 
-    QGCMAVLinkMessage *msg = nullptr;
-    QGCMAVLinkSystem *system = _findVehicle(message.sysid);
+ void MAVLinkInspectorController::_receiveMessage(LinkInterface *link, const mavlink_message_t &message)
+ {
+     Q_UNUSED(link);
 
-    if (!system) {
-        system = new QGCMAVLinkSystem(message.sysid, this);
-        _systems->append(system);
-        _systemNames.append(tr("System %1").arg(message.sysid));
-        emit systemsChanged();
+     QGCMAVLinkMessage *msg = nullptr;
+     QGCMAVLinkSystem *system = _findVehicle(message.sysid);
 
-        if (!_activeSystem) {
-            _activeSystem = system;
-            emit activeSystemChanged();
-        }
-    } else {
-        msg = system->findMessage(message.msgid, message.compid);
-    }
+     if (!system) {
+         system = new QGCMAVLinkSystem(message.sysid, this);
+         _systems->append(system);
+         _systemNames.append(tr("System %1").arg(message.sysid));
+         emit systemsChanged();
 
-    if (!msg) {
-        msg = new QGCMAVLinkMessage(message, this);
-        system->append(msg);
-    } else {
-        msg->update(message);
-    }
-}
+         if (!_activeSystem) {
+             _activeSystem = system;
+             emit activeSystemChanged();
+         }
+     } else {
+         msg = system->findMessage(message.msgid, message.compid);
+     }
 
-MAVLinkChartController *MAVLinkInspectorController::createChart()
-{
-    MAVLinkChartController *const pChart = new MAVLinkChartController(this, _charts->count());
-    QQmlEngine::setObjectOwnership(pChart, QQmlEngine::CppOwnership);
+     if (!msg) {
+         msg = new QGCMAVLinkMessage(message, this);
+         system->append(msg);
+     } else {
+         msg->update(message);
+     }
+ }
 
-    _charts->append(pChart);
-    emit chartsChanged();
+ MAVLinkChartController *MAVLinkInspectorController::createChart(int chartIndex)
+ {
+     MAVLinkChartController *const pChart = new MAVLinkChartController(this, chartIndex);
+     QQmlEngine::setObjectOwnership(pChart, QQmlEngine::CppOwnership);
 
-    return pChart;
-}
+     _charts->append(pChart);
+     emit chartsChanged();
 
-void MAVLinkInspectorController::deleteChart(MAVLinkChartController *chart)
-{
-    if (!chart) {
-        return;
-    }
+     return pChart;
+ }
 
-    bool found = false;
-    for (int i = 0; i < _charts->count(); i++) {
-        MAVLinkChartController *const controller = qobject_cast<MAVLinkChartController*>(_charts->get(i));
-        if (controller && (controller == chart)) {
-            found = true;
-            _charts->removeOne(controller);
-            delete controller;
-            break;
-        }
-    }
+ void MAVLinkInspectorController::deleteChart(MAVLinkChartController *chart)
+ {
+     if (!chart) {
+         return;
+     }
 
-    if (found) {
-        emit chartsChanged();
-    }
-}
+     bool found = false;
+     for (int i = 0; i < _charts->count(); i++) {
+         MAVLinkChartController *const controller = qobject_cast<MAVLinkChartController*>(_charts->get(i));
+         if (controller && (controller == chart)) {
+             found = true;
+             _charts->removeOne(controller);
+             delete controller;
+             break;
+         }
+     }
 
-void MAVLinkInspectorController::setActiveSystem(int systemId)
-{
-    QGCMAVLinkSystem *const system = _findVehicle(systemId);
-    if (system != _activeSystem) {
-        _activeSystem = system;
-        emit activeSystemChanged();
-    }
-}
+     if (found) {
+         emit chartsChanged();
+     }
+ }
 
-void MAVLinkInspectorController::setMessageInterval(int32_t rate) const
-{
-    if (!_activeSystem) {
-        return;
-    }
+ void MAVLinkInspectorController::setActiveSystem(int systemId)
+ {
+     QGCMAVLinkSystem *const system = _findVehicle(systemId);
+     if (system != _activeSystem) {
+         _activeSystem = system;
+         emit activeSystemChanged();
+     }
+ }
 
-    MultiVehicleManager *const multiVehicleManager = MultiVehicleManager::instance();
-    if (!multiVehicleManager) {
-        return;
-    }
+ void MAVLinkInspectorController::setMessageInterval(int32_t rate) const
+ {
+     if (!_activeSystem) {
+         return;
+     }
 
-    const uint8_t sysId = _selectedSystemID();
-    if (sysId == 0) {
-        return;
-    }
+     MultiVehicleManager *const multiVehicleManager = MultiVehicleManager::instance();
+     if (!multiVehicleManager) {
+         return;
+     }
 
-    Vehicle *const vehicle = multiVehicleManager->getVehicleById(sysId);
-    if (!vehicle) {
-        return;
-    }
+     const uint8_t sysId = _selectedSystemID();
+     if (sysId == 0) {
+         return;
+     }
 
-    const QGCMAVLinkMessage *const msg = _activeSystem->selectedMsg();
-    if (!msg) {
-        return;
-    }
+     Vehicle *const vehicle = multiVehicleManager->getVehicleById(sysId);
+     if (!vehicle) {
+         return;
+     }
 
-    const uint8_t compId = _selectedComponentID();
-    if (compId == 0) {
-        return;
-    }
+     const QGCMAVLinkMessage *const msg = _activeSystem->selectedMsg();
+     if (!msg) {
+         return;
+     }
 
-    // TODO: Make QGCMAVLinkMessage a part of comm and use signals/slots for msg rate changes
-    vehicle->setMessageRate(compId, msg->id(), rate);
-}
+     const uint8_t compId = _selectedComponentID();
+     if (compId == 0) {
+         return;
+     }
 
-uint8_t MAVLinkInspectorController::_selectedSystemID() const
-{
-    return (_activeSystem ? _activeSystem->id() : 0);
-}
+     // TODO: Make QGCMAVLinkMessage a part of comm and use signals/slots for msg rate changes
+     vehicle->setMessageRate(compId, msg->id(), rate);
+ }
 
-uint8_t MAVLinkInspectorController::_selectedComponentID() const
-{
-    const QGCMAVLinkMessage *const msg = _activeSystem ? _activeSystem->selectedMsg() : nullptr;
-    return (msg ? msg->compId() : 0);
-}
+ uint8_t MAVLinkInspectorController::_selectedSystemID() const
+ {
+     return (_activeSystem ? _activeSystem->id() : 0);
+ }
+
+ uint8_t MAVLinkInspectorController::_selectedComponentID() const
+ {
+     const QGCMAVLinkMessage *const msg = _activeSystem ? _activeSystem->selectedMsg() : nullptr;
+     return (msg ? msg->compId() : 0);
+ }

--- a/src/AnalyzeView/MAVLinkInspectorController.h
+++ b/src/AnalyzeView/MAVLinkInspectorController.h
@@ -62,7 +62,7 @@ public:
     explicit MAVLinkInspectorController(QObject *parent = nullptr);
     ~MAVLinkInspectorController();
 
-    Q_INVOKABLE MAVLinkChartController *createChart();
+    Q_INVOKABLE MAVLinkChartController *createChart(int chartIndex);
     Q_INVOKABLE void deleteChart(MAVLinkChartController *chart);
     Q_INVOKABLE void setActiveSystem(int systemId);
     Q_INVOKABLE void setMessageInterval(int32_t rate) const;

--- a/src/AnalyzeView/MAVLinkInspectorPage.qml
+++ b/src/AnalyzeView/MAVLinkInspectorPage.qml
@@ -305,9 +305,9 @@ AnalyzePage {
                                 checked:            object.series !== null && object.chartIndex === 0
                                 onClicked: {
                                     if(checked) {
-                                        chart1.addDimension(object)
+                                        chart1.addDimension(object, 0)
                                     } else {
-                                        chart1.delDimension(object)
+                                        chart1.delDimension(object, 0)
                                     }
                                     updateEnabledStatus(chart1Repeater, curMessage, chart1)
                                     updateEnabledStatus(chart2Repeater, curMessage, chart2)
@@ -325,9 +325,9 @@ AnalyzePage {
                                 checked:            object.series !== null && object.chartIndex === 1
                                 onClicked: {
                                     if(checked) {
-                                        chart2.addDimension(object)
+                                        chart2.addDimension(object, 1)
                                     } else {
-                                        chart2.delDimension(object)
+                                        chart2.delDimension(object, 1)
                                     }
                                     updateEnabledStatus(chart2Repeater, curMessage, chart2)
                                     updateEnabledStatus(chart1Repeater, curMessage, chart1)

--- a/src/QmlControls/MAVLinkChart.qml
+++ b/src/QmlControls/MAVLinkChart.qml
@@ -23,9 +23,9 @@ ChartView {
     property var chartController:   null
     property var seriesColors:      ["#00E04B","#DE8500","#F32836","#BFBFBF","#536DFF","#EECC44"]
 
-    function addDimension(field) {
+    function addDimension(field, chartIndex) {
         if(!chartController) {
-            chartController = controller.createChart()
+            chartController = controller.createChart(chartIndex)
         }
         var color   = chartView.seriesColors[chartView.count]
         var serie   = createSeries(ChartView.SeriesTypeLine, field.label)


### PR DESCRIPTION
Fix MAVLink Inspector crash

Description
-----------
Fixes unexpected crash when charts plotting selected in Mavlink Inspector and user selected some other "Analize Tools" page

Test Steps
-----------
- Connect to vehicle
- Open MAVLink Inspector
- Select MAVLink message ( fe HIGHRES_IMU)
- Plot values in different plots
- Click MAVLink console
- Repeat muiltiple times

Checklist:
----------
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] [Review Contribution Guidelines](https://github.com/mavlink/qgroundcontrol/blob/master/.github/CONTRIBUTING.md).
- [x] [Review Code of Conduct](https://github.com/mavlink/qgroundcontrol/blob/master/.github/CODE_OF_CONDUCT.md).
- [x] I have tested my changes.

Related Issue
-----------
<!-- If any, please provide issue ID. -->


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.