### PR TITLE
JoystickSDL: Show non-gamepad axes and only show gamepad axes if they are valid

### DIFF
--- a/src/Joystick/JoystickSDL.cc
+++ b/src/Joystick/JoystickSDL.cc
@@ -18,8 +18,10 @@
 
 QGC_LOGGING_CATEGORY(JoystickSDLLog, "qgc.joystick.joysticksdl")
 
-JoystickSDL::JoystickSDL(const QString &name, int axisCount, int buttonCount, int hatCount, int instanceId, bool isGamepad, QObject *parent)
-    : Joystick(name, axisCount, buttonCount, hatCount, parent)
+JoystickSDL::JoystickSDL(const QString &name, QList<int> gamepadAxes, QList<int> nonGamepadAxes, int buttonCount, int hatCount, int instanceId, bool isGamepad, QObject *parent)
+    : Joystick(name, gamepadAxes.length() + nonGamepadAxes.length(), buttonCount, hatCount, parent)
+    , _gamepadAxes(gamepadAxes)
+    , _nonGamepadAxes(nonGamepadAxes)
     , _isGamepad(isGamepad)
     , _instanceId(instanceId)
 {
@@ -75,13 +77,57 @@ QMap<QString, Joystick*> JoystickSDL::discover()
             continue;
         }
 
+        QList<int> gamepadAxes;
+        QSet<int> joyAxesMappedToGamepad;
+
+        if (SDL_IsGamepad(jid)) {
+            auto tmpGamepad = SDL_OpenGamepad(jid);
+            if (!tmpGamepad) {
+                qCWarning(JoystickSDLLog) << "Failed to open gamepad" << jid << SDL_GetError();
+                continue;
+            }
+
+            // Determine if this gamepad axis is one we should show to the user
+            for (int i = 0; i < SDL_GAMEPAD_AXIS_COUNT; i++) {
+                if (SDL_GamepadHasAxis(tmpGamepad, static_cast<SDL_GamepadAxis>(i))) {
+                    gamepadAxes.append(i);
+                }
+            }
+
+            // If a sdlJoystick axis is mapped to a sdlGamepad axis, then the axis is represented
+            // by both the sdlJoystick interface and the sdlGamepad interface. If this is the case,
+            // We'll only show the sdlGamepad interface version of the axis to the user.
+            int count = 0;
+            SDL_GamepadBinding **bindings = SDL_GetGamepadBindings(tmpGamepad, &count);
+            if (bindings) {
+                for (int i = 0; i < count; ++i) {
+                    SDL_GamepadBinding *binding = bindings[i];
+                    if (binding && binding->input_type == SDL_GAMEPAD_BINDTYPE_AXIS && binding->output_type == SDL_GAMEPAD_BINDTYPE_AXIS) {
+                        joyAxesMappedToGamepad.insert(binding->input.axis.axis);
+                    }
+                }
+                SDL_free(bindings);
+            } else {
+                qCWarning(JoystickSDLLog) << "Failed to get bindings for" << name << "error:" << SDL_GetError();
+            }
+
+            SDL_CloseGamepad(tmpGamepad);
+        }
+
         SDL_Joystick *tmpJoy = SDL_OpenJoystick(jid);
         if (!tmpJoy) {
             qCWarning(JoystickSDLLog) << "Failed to open joystick" << jid << SDL_GetError();
             continue;
         }
 
+        QList<int> nonGamepadAxes;
         const int axisCount = SDL_GetNumJoystickAxes(tmpJoy);
+        for (int i = 0; i < axisCount; i++) {
+            if (!joyAxesMappedToGamepad.contains(i)) {
+                nonGamepadAxes.append(i);
+            }
+        }
+
         const int buttonCount = SDL_GetNumJoystickButtons(tmpJoy);
         const int hatCount = SDL_GetNumJoystickHats(tmpJoy);
         SDL_CloseJoystick(tmpJoy);
@@ -95,7 +141,8 @@ QMap<QString, Joystick*> JoystickSDL::discover()
         }
 
         current[name] = new JoystickSDL(name,
-                                        qMax(0, axisCount),
+                                        gamepadAxes,
+                                        nonGamepadAxes,
                                         qMax(0, buttonCount),
                                         qMax(0, hatCount),
                                         jid,
@@ -183,7 +230,12 @@ int JoystickSDL::_getAxis(int idx) const
     int axis = -1;
 
     if (_isGamepad) {
-        axis = SDL_GetGamepadAxis(_sdlGamepad, static_cast<SDL_GamepadAxis>(idx));
+        if (idx < _gamepadAxes.length()) {
+            axis = SDL_GetGamepadAxis(_sdlGamepad, static_cast<SDL_GamepadAxis>(_gamepadAxes[idx]));
+        }
+        else {
+            axis = SDL_GetJoystickAxis(_sdlJoystick, _nonGamepadAxes[idx - _gamepadAxes.length()]);
+        }
     } else {
         axis = SDL_GetJoystickAxis(_sdlJoystick, idx);
     }

--- a/src/Joystick/JoystickSDL.h
+++ b/src/Joystick/JoystickSDL.h
@@ -24,7 +24,7 @@ Q_DECLARE_LOGGING_CATEGORY(JoystickSDLLog)
 class JoystickSDL : public Joystick
 {
 public:
-    explicit JoystickSDL(const QString &name, int axisCount, int buttonCount, int hatCount, int instanceId, bool isGamepad, QObject *parent = nullptr);
+    explicit JoystickSDL(const QString &name, QList<int> gamepadAxes, QList<int> nonGamepadAxes, int buttonCount, int hatCount, int instanceId, bool isGamepad, QObject *parent = nullptr);
     ~JoystickSDL() override;
 
     int instanceId() const { return _instanceId; }
@@ -46,6 +46,8 @@ private:
 
     static void _loadGamepadMappings();
 
+    QList<int> _gamepadAxes;
+    QList<int> _nonGamepadAxes;
     bool _isGamepad = false;
     int _instanceId = -1;
 


### PR DESCRIPTION
Issue
-----

Currently `QGC` assumes `numGapepadAxes == numJoystickAxes`, which cannot be assumed. `numGamepadAxes` can be less than, equal to, or greater than `numJoystickAxes`.

`QGC` is also assuming a `joystickAxisId` represents the same axis as a `gamepadAxisId`. This cannot be assumed

ex. A gamepad may map buttons to a gamepad axes, so even if `numJoystickAxes == 0` there may still be a gamepad axis

ex. With the SDL gamepad interface, a controller can only have 2 joysticks. Some devices that support the SDL gamepad interface have more than 2 joysticks (ex. UXV SRoC or Steam Controller). The SDL joystick interface supports more than 2 joysticks. A  joystick axis may not map to be a gamepad axis.  

Before
-------
<img width="862" height="1101" alt="beforeJoystickUXV" src="https://github.com/user-attachments/assets/99a85d5c-9430-4ec5-8ee0-46f12c651a06" />

After
-----
<img width="862" height="1101" alt="afterJoystickUxv" src="https://github.com/user-attachments/assets/24348f43-bee3-4b36-a589-c0eb9e4d24ad" />

Steps to Reproduce
---------------------
1. open QGC
2. connect to a vehicle
3. connect a controller which supports the SDL gamepad interface but has more than 2 joysticks (ex. Steam Controller or this [Linux virtual UXV SRoC](https://github.com/gillamkid/linux_virtual_joystick) )
4. Go to `menu -> vehicle configuration -> Joystick -> configuration`
5. If using `QGC Daily`, there will be a joystick on the controller which will not be mapped to an axis in the configurator (moving the joystick has no affect on any of the axis output displays). With the change made in this PR, all joysticks should have a visible affect on an axis in the joystick configuration page.

Comments
------------
Most controllers do not have the issues fixed with this PR because they are true gamepads and don't have any axes not mapped/represented in the SDL gamepad interface.  I tested with a couple popular controllers (x-box 360 controller and a 8bitDo Ultimate C bluetooth controller) and they had no hidden axes. The QGC joystick configuration page for these controllers will have no visible difference before and after this PR

Build Environment
--------------------
I did the development/testing for this PR on Ubuntu 24.04