### PR TITLE
Clean up handling of vehicle and camera manager coming/going

### DIFF
--- a/src/FlightDisplay/FlyViewTopRightColumnLayout.qml
+++ b/src/FlightDisplay/FlyViewTopRightColumnLayout.qml
@@ -25,13 +25,13 @@ ColumnLayout {
         Layout.preferredWidth:  _rightPanelWidth
     }
 
-    // We use a Loader to load the photoVideoControlComponent only when the active vehicle is not null
+    // We use a Loader to load the photoVideoControlComponent only when we have an active vehicle and a camera manager.
     // This make it easier to implement PhotoVideoControl without having to check for the mavlink camera
     // to be null all over the place
     Loader {
         id:                 photoVideoControlLoader
         Layout.alignment:   Qt.AlignTop | Qt.AlignRight
-        sourceComponent:    globals.activeVehicle ? photoVideoControlComponent : undefined
+        sourceComponent:    globals.activeVehicle && globals.activeVehicle.cameraManager ? photoVideoControlComponent : undefined
 
         property real rightEdgeCenterInset: visible ? parent.width - x : 0
 

--- a/src/Vehicle/MultiVehicleManager.cc
+++ b/src/Vehicle/MultiVehicleManager.cc
@@ -200,7 +200,6 @@ void MultiVehicleManager::_deleteVehiclePhase1(Vehicle *vehicle)
     _setActiveVehicleAvailable(false);
     _setParameterReadyVehicleAvailable(false);
     emit vehicleRemoved(vehicle);
-    vehicle->prepareDelete();
 
 #if defined(Q_OS_ANDROID) || defined (Q_OS_IOS)
     if (_vehicles->count() == 0) {

--- a/src/Vehicle/Vehicle.cc
+++ b/src/Vehicle/Vehicle.cc
@@ -375,12 +375,15 @@ Vehicle::~Vehicle()
     _autopilotPlugin = nullptr;
 }
 
-void Vehicle::prepareDelete()
+void Vehicle::_deleteCameraManager()
 {
-
+    if(_cameraManager) {
+        delete _cameraManager;
+        _cameraManager = nullptr;
+    }
 }
 
-void Vehicle::deleteGimbalController()
+void Vehicle::_deleteGimbalController()
 {
     if (_gimbalController) {
         delete _gimbalController;

--- a/src/Vehicle/Vehicle.h
+++ b/src/Vehicle/Vehicle.h
@@ -999,6 +999,10 @@ private:
 
     static void _rebootCommandResultHandler(void* resultHandlerData, int compId, const mavlink_command_ack_t& ack, MavCmdResultFailureCode_t failureCode);
 
+    // The following two methods should only be called by unit tests
+    void _deleteGimbalController();
+    void _deleteCameraManager();
+
     int     _id;                    ///< Mavlink system id
     int     _defaultComponentId;
     bool    _offlineEditingVehicle = false; ///< true: This Vehicle is a "disconnected" vehicle for ui use while offline editing

--- a/test/Vehicle/RequestMessageTest.cc
+++ b/test/Vehicle/RequestMessageTest.cc
@@ -40,10 +40,10 @@ void RequestMessageTest::_testCaseWorker(TestCase_t& testCase)
     Vehicle*                vehicle     = vehicleMgr->activeVehicle();
     
     // Gimbal controller sends message requests when receiving heartbeats, trying to find a gimbal, and it messes with this test so we disable it
-    vehicle->deleteGimbalController();
+    vehicle->_deleteGimbalController();
 
     // Camera manager also messes with it.
-    vehicle->stopCameraManager();
+    vehicle->_deleteCameraManager();
 
     _mockLink->clearReceivedMavCommandCounts();
     _mockLink->setRequestMessageFailureMode(testCase.failureMode);


### PR DESCRIPTION
* Replacement for #13302 
* Remove Vehicle::prepareDelete for camera manager. Should not be needed with appropriate Loader usage on PhotoVideoControl
* Move deleteGimbalController/deleteCameraManager to private methods with friend class access for RequestMessageTest