### PR TITLE
Always manually request tracking status when sending TRACKING commands

### DIFF
--- a/src/Camera/VehicleCameraControl.cc
+++ b/src/Camera/VehicleCameraControl.cc
@@ -2378,6 +2378,9 @@ VehicleCameraControl::startTracking(QRectF rec)
                                  static_cast<float>(rec.y()),
                                  static_cast<float>(rec.x() + rec.width()),
                                  static_cast<float>(rec.y() + rec.height()));
+
+        // Request tracking status
+        _requestTrackingStatus();
     }
 }
 
@@ -2400,6 +2403,9 @@ VehicleCameraControl::startTracking(QPointF point, double radius)
                                  static_cast<float>(point.x()),
                                  static_cast<float>(point.y()),
                                  static_cast<float>(radius));
+
+        // Request tracking status
+        _requestTrackingStatus();
     }
 }
 


### PR DESCRIPTION
Description
-----------
This change ensures that tracking status is always requested immediately after sending camera track rectangle or point commands in VehicleCameraControl. Previously, the tracking status request was missing from these operations, which could lead to inconsistent UI state (not getting the red colored rectangle) when the tracking command was sent but the ground control station wasn't receiving updated tracking status information.

This change is part of implementing [visual follow-me](https://github.com/ArduPilot/ardupilot/pull/30941) functionality that requires tracking status updates.

Test Steps
-----------
1. Connect to a vehicle with camera tracking capability, or the onboard tracker
2. Open camera view and initiate rectangle-based tracking by drawing a selection box
3. Verify that tracking status is immediately requested and UI updates appropriately
4. Test point-based tracking by clicking on a target point
5. Verify  that while clicking the tracking button again disables the tracking and the a request message is sent for stop receiving the status message.


https://github.com/user-attachments/assets/1787db54-d8e6-468b-9a14-91506cc6cd88


Checklist:
----------
- [x] [Review Contribution Guidelines](https://github.com/mavlink/qgroundcontrol/blob/master/.github/CONTRIBUTING.md).
- [x] [Review Code of Conduct](https://github.com/mavlink/qgroundcontrol/blob/master/.github/CODE_OF_CONDUCT.md).
- [x] I have tested my changes.

Related Issue
-----------
This change supports the visual follow-me feature implementation in ArduPilot PR: https://github.com/ArduPilot/ardupilot/pull/30941

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.