### PR TITLE
fix: prevent plan view exit when validation errors exist

### DIFF
--- a/src/QmlControls/PlanViewToolBar.qml
+++ b/src/QmlControls/PlanViewToolBar.qml
@@ -62,7 +62,11 @@ Rectangle {
 
     QGCMouseArea {
         anchors.fill:   viewButtonRow
-        onClicked:      mainWindow.showFlyView()
+        onClicked:      {
+            if (mainWindow.allowViewSwitch()) {
+                mainWindow.showFlyView()
+            }
+        }
     }
 
     QGCFlickable {


### PR DESCRIPTION
In the original implementation, when there are validation errors, clicking the "Exit Plan" button to switch to the Flyview view results in being unable to switch to other views within Flyview, making it appear as though the button is unresponsive or the application has malfunctioned.
