### PR TITLE
Fix CI build for macos by removing cmake installation from brew

### DIFF
--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -16,6 +16,7 @@ on:
       - 'src/**'
       - 'CMakeLists.txt'
       - 'cmake/**'
+      - 'tools/setup/install-dependencies-osx.sh'
 
 # concurrency:
 #   group: ${{ github.workflow }}-${{ github.ref }}

--- a/tools/setup/install-dependencies-osx.sh
+++ b/tools/setup/install-dependencies-osx.sh
@@ -8,7 +8,7 @@ then
 fi
 
 brew update
-brew install cmake ninja ccache git pkgconf create-dmg mold
+brew install ninja ccache git pkgconf create-dmg mold
 
 # Install GStreamer
 GST_URL=https://gstreamer.freedesktop.org/data/pkg/osx


### PR DESCRIPTION
Fix CI build for MacOS by removing cmake installation from brew

Description
-----------
I noticed that recently all the github actions building for MacOS are failing at the moment of `.dmg` file creation. By deeper inspection I have found that in the `Install Dependencies` stage we run `brew install cmake ... create-dmg`. This command fails (see the screenshot from the latest MacOS build action from master attached below) as cmake is already installed from `local/pinned tap`. 
<img width="680" height="168" alt="image" src="https://github.com/user-attachments/assets/a35da607-3be6-499e-a11e-eb6fd5b21921" />


Thus `create-dmg` (as well as some other packages) is not installed leading to cmake trying to install the `create-dmg` in `CreateMacDMG.cmake`, which fails. I haven't checked why the `CPMAddPackage` fails there, but I guess, this is an issue with CMake version 4.4.1.

By removing the `cmake` from `brew install` command, rest of the listed packages get installed, and workflow finishes successfully.


Test Steps
-----------
Trigger MacOS build github action in master branch

Checklist:
----------
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] [Review Contribution Guidelines](https://github.com/mavlink/qgroundcontrol/blob/master/.github/CONTRIBUTING.md).
- [x] [Review Code of Conduct](https://github.com/mavlink/qgroundcontrol/blob/master/.github/CODE_OF_CONDUCT.md).
- [x] I have tested my changes.



By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.