### PR TITLE
Remote ID FAA: Operator ID invalid on reboot or app restart

### DIFF
--- a/src/UI/AppSettings/RemoteIDSettings.qml
+++ b/src/UI/AppSettings/RemoteIDSettings.qml
@@ -375,6 +375,10 @@ SettingsPage {
                         }
                         
                         onTextChanged: {
+                            if (!activeFocus) {
+                                return;
+                            }
+
                             operatorIDFact.value = text
                             if (_activeVehicle) {
                                 _remoteIDManager.checkOperatorID(text)

--- a/src/Vehicle/RemoteIDManager.cc
+++ b/src/Vehicle/RemoteIDManager.cc
@@ -66,11 +66,11 @@ RemoteIDManager::RemoteIDManager(Vehicle* vehicle)
     _targetSystem = _vehicle->id();
     _targetComponent = _vehicle->compId();
 
-    if (_settings->operatorIDValid()->rawValue() == true) {
+    if (_settings->operatorIDValid()->rawValue() == true || (_settings->region()->rawValue().toInt() != Region::EU && _settings->operatorID()->rawValue().toString().length() > 0)) {
         // If it was already checked, we can flag this as good to go.
         // We don't do a fresh verification because we don't store the private part of the ID.
         _operatorIDGood = true;
-        operatorIDGoodChanged();
+        emit operatorIDGoodChanged();
     }
 }
 


### PR DESCRIPTION
Description
-----------
1. If in FAA jurisdiction, operator ID will be invalidated on app restart or vehicle reboot (if not correct under EU jurisdiction) because there's a validity check in the constructor which checks if the operator ID is valid under EU jurisdiction even if in FAA.

2. If vehicle is rebooting and you are in the Remote ID app settings page, the quick refresh of the page is detected as a text field change and can be detected as operator ID being changed. Make it so it tracks if the text field is being focused.

Test Steps
-----------
1. Have remote ID enabled
2. Make sure FAA is the jurisdiction and assign an operator ID that would be invalid in EU jurisdiction like "John"
3. Either reboot the vehicle in param page or close app and reopen
4. Witness operator ID stay valid
5. Next, reboot vehicle in param page and go to remote id page as vehicle loads back up
6. Ensure operator id doesn't change

Checklist:
----------
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] [Review Contribution Guidelines](https://github.com/mavlink/qgroundcontrol/blob/master/.github/CONTRIBUTING.md).
- [x] [Review Code of Conduct](https://github.com/mavlink/qgroundcontrol/blob/master/.github/CODE_OF_CONDUCT.md).
- [x] I have tested my changes.

Related Issue
-----------
https://github.com/mavlink/qgroundcontrol/issues/13377


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.