### PR TITLE
Sign, Notarize and Staple Mac app bundle

### DIFF
--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -35,7 +35,6 @@ jobs:
 
     env:
       QT_VERSION: 6.8.3
-      QGC_MACOS_SIGNING_IDENTITY: ${{ secrets.MACOS_SIGNING_IDENTITY }}
 
     steps:
       - name: Checkout repo
@@ -77,39 +76,42 @@ jobs:
           setup-python: false
           cache: true
 
-      - name: Import Code Signing Certificate
-        if: github.event_name != 'pull_request'
-        uses: apple-actions/import-codesign-certs@v5
-        with:
-          p12-file-base64: ${{ secrets.MACOS_SIGNING_CERTS_P12 }}
-          p12-password: ${{ secrets.MACOS_SIGNING_CERTS_PASS }}
-
-      - name: Configure
+      - name: CMake configure
         working-directory: ${{ runner.temp }}/build
         run: ${{ env.QT_ROOT_DIR }}/bin/qt-cmake -S ${{ github.workspace }} -B . -G Ninja
               -DCMAKE_BUILD_TYPE=${{ matrix.BuildType }}
               -DQGC_STABLE_BUILD=${{ github.ref_type == 'tag' || contains(github.ref, 'Stable') && 'ON' || 'OFF' }}
+              -DQGC_MACOS_SIGN_WITH_IDENTITY=${{ github.event_name != 'pull_request' && 'ON' || 'OFF' }}
 
       - name: Build
         working-directory: ${{ runner.temp }}/build
         run: cmake --build . --target all --config ${{ matrix.BuildType }} --parallel
 
       - name: Sanity check dev build executable
-        if: matrix.BuildType == 'Release'
         working-directory: ${{ runner.temp }}/build/Release/QGroundControl.app/Contents/MacOS
         run: ./QGroundControl --simple-boot-test
 
-      - name: Create DMG
+      - name: Import Code Signing Certificate
+        if: github.event_name != 'pull_request'
+        uses: apple-actions/import-codesign-certs@v5
+        with:
+          p12-file-base64: ${{ secrets.MACOS_CERT_P12_BASE64 }}
+          p12-password: ${{ secrets.MACOS_CERT_P12_PASSWORD }}
+
+      - name: Create signed/notarized/stapled app bundle
         working-directory: ${{ runner.temp }}/build
         run: cmake --install . --config ${{ matrix.BuildType }}
+        env:
+          QGC_MACOS_SIGNING_IDENTITY: ${{ secrets.MACOS_SIGNING_IDENTITY }}
+          QGC_MACOS_NOTARIZATION_USERNAME: ${{ secrets.MACOS_NOTARIZATION_USERNAME }}
+          QGC_MACOS_NOTARIZATION_PASSWORD: ${{ secrets.MACOS_NOTARIZATION_PASSWORD }}
+          QGC_MACOS_NOTARIZATION_TEAM_ID: ${{ secrets.MACOS_NOTARIZATION_TEAM_ID }}
 
       - name: Mount DMG
-        if: matrix.BuildType == 'Release'
         working-directory: ${{ runner.temp }}/build
         run: hdiutil attach QGroundControl.dmg
 
       - name: Sanity check DMG executable
-        if: matrix.BuildType == 'Release'
         working-directory: /Volumes/QGroundControl/QGroundControl.app/Contents/MacOS
         run: ./QGroundControl --simple-boot-test
 

--- a/cmake/install/SignMacBundle.cmake
+++ b/cmake/install/SignMacBundle.cmake
@@ -1,0 +1,70 @@
+message(STATUS "QGC: Signing Bundle using signing identity")
+if(NOT DEFINED ENV{QGC_MACOS_SIGNING_IDENTITY} OR "$ENV{QGC_MACOS_SIGNING_IDENTITY}" STREQUAL "")
+    message(FATAL_ERROR "QGC: QGC_MACOS_SIGNING_IDENTITY environment variable must be set to sign MacOS bundle")
+endif()
+if(NOT DEFINED ENV{QGC_MACOS_NOTARIZATION_USERNAME} OR "$ENV{QGC_MACOS_NOTARIZATION_USERNAME}" STREQUAL "")
+    message(FATAL_ERROR "QGC: QGC_MACOS_NOTARIZATION_USERNAME environment variable must be set to notarize MacOS bundle")
+endif()
+if(NOT DEFINED ENV{QGC_MACOS_NOTARIZATION_TEAM_ID} OR "$ENV{QGC_MACOS_NOTARIZATION_TEAM_ID}" STREQUAL "")
+    message(FATAL_ERROR "QGC: QGC_MACOS_NOTARIZATION_TEAM_ID environment variable must be set to notarize MacOS bundle")
+endif()
+if(NOT DEFINED ENV{QGC_MACOS_NOTARIZATION_PASSWORD} OR "$ENV{QGC_MACOS_NOTARIZATION_PASSWORD}" STREQUAL "")
+    message(FATAL_ERROR "QGC: QGC_MACOS_NOTARIZATION_PASSWORD environment variable must be set to notarize MacOS bundle")
+endif()
+file(REMOVE ${QGC_STAGING_BUNDLE_PATH}/Contents/Frameworks/GStreamer.framework/Commands)
+file(REMOVE ${QGC_STAGING_BUNDLE_PATH}/Contents/Frameworks/GStreamer.framework/Versions/1.0/Commands)
+execute_process(
+    COMMAND find ${QGC_STAGING_BUNDLE_PATH}/Contents -type f -name "*.dylib" -exec codesign --timestamp --options=runtime --force -s "$ENV{QGC_MACOS_SIGNING_IDENTITY}" "{}" \\;
+    COMMAND_ERROR_IS_FATAL ANY
+)
+execute_process(
+    COMMAND find ${QGC_STAGING_BUNDLE_PATH}/Contents -type f -name "*.so" -exec codesign --timestamp --options=runtime --force -s "$ENV{QGC_MACOS_SIGNING_IDENTITY}" "{}" \\;
+    COMMAND_ERROR_IS_FATAL ANY
+)
+execute_process(
+    COMMAND find ${QGC_STAGING_BUNDLE_PATH}/Contents/Frameworks/GStreamer.framework/Versions/1.0/libexec/gstreamer-1.0 -type f -name "*" -exec codesign --timestamp --options=runtime --force -s "$ENV{QGC_MACOS_SIGNING_IDENTITY}" "{}" \\;
+    COMMAND_ERROR_IS_FATAL ANY
+)
+execute_process(
+    COMMAND codesign --timestamp --options=runtime --force -s "$ENV{QGC_MACOS_SIGNING_IDENTITY}" ${QGC_STAGING_BUNDLE_PATH}/Contents/Frameworks/GStreamer.framework/Versions/1.0/lib/GStreamer
+    COMMAND_ERROR_IS_FATAL ANY
+)
+execute_process(
+    COMMAND codesign --timestamp --options=runtime --force -s "$ENV{QGC_MACOS_SIGNING_IDENTITY}" ${QGC_STAGING_BUNDLE_PATH}/Contents/Frameworks/GStreamer.framework/Versions/1.0/GStreamer
+    COMMAND_ERROR_IS_FATAL ANY
+)
+file(GLOB FRAMEWORK_DIRS ${QGC_STAGING_BUNDLE_PATH}/Contents/Frameworks/*.framework)
+foreach(FRAMEWORK_DIR ${FRAMEWORK_DIRS})
+    if (EXISTS "${FRAMEWORK_DIR}/Versions/1.0")
+        execute_process(
+            COMMAND find ${FRAMEWORK_DIR}/Versions/1.0 -type f -exec codesign --timestamp --options=runtime --force -s "$ENV{QGC_MACOS_SIGNING_IDENTITY}" "{}" \\;
+            COMMAND_ERROR_IS_FATAL ANY
+        )
+    endif()
+    if (EXISTS "${FRAMEWORK_DIR}/Versions/A")
+        execute_process(
+            COMMAND find ${FRAMEWORK_DIR}/Versions/A -type f -exec codesign --timestamp --options=runtime --force -s "$ENV{QGC_MACOS_SIGNING_IDENTITY}" "{}" \\;
+            COMMAND_ERROR_IS_FATAL ANY
+        )
+    endif()
+endforeach()
+execute_process(
+    COMMAND codesign --timestamp --options=runtime --force -s "$ENV{QGC_MACOS_SIGNING_IDENTITY}" ${QGC_STAGING_BUNDLE_PATH}
+    COMMAND_ERROR_IS_FATAL ANY
+)
+message(STATUS "QGC: Archiving Bundle for Notarization upload")
+file(REMOVE qgc_notarization_upload.zip)
+execute_process(
+    COMMAND ditto -c -k --keepParent ${QGC_STAGING_BUNDLE_PATH} qgc_notarization_upload.zip
+    COMMAND_ERROR_IS_FATAL ANY
+)
+message(STATUS "QGC: Notarizing app bundle. This may take a while...")
+execute_process(
+    COMMAND xcrun notarytool submit qgc_notarization_upload.zip --apple-id "$ENV{QGC_MACOS_NOTARIZATION_USERNAME}" --team-id "$ENV{QGC_MACOS_NOTARIZATION_TEAM_ID}" --password "$ENV{QGC_MACOS_NOTARIZATION_PASSWORD}" --wait
+    COMMAND_ERROR_IS_FATAL ANY
+)
+message(STATUS "QGC: Stapling notarization ticket to app bundle")
+execute_process(
+    COMMAND xcrun stapler staple ${QGC_STAGING_BUNDLE_PATH}
+    COMMAND_ERROR_IS_FATAL ANY
+)

--- a/docs/en/qgc-dev-guide/getting_started/index.md
+++ b/docs/en/qgc-dev-guide/getting_started/index.md
@@ -141,6 +141,13 @@ Example commands to build a default QGC and run it afterwards:
    ```
 
    Change the directory for qt-cmake to match your install location for Qt and the kit you want to use.
+   
+   **Mac**: To Sign/Notarize/Staple the QGC app bundle, add `-DQGC_MACOS_SIGN_WITH_IDENTITY=ON` to the configure command line. During the `install` phase the following environment variables will need to be available:
+   
+   * `QGC_MACOS_SIGNING_IDENTITY` - Signing identity for your Developer ID certificate which must be in the keychain
+   * `QGC_MACOS_NOTARIZATION_USERNAME` - Username for your Apple Developer Account
+   * `QGC_MACOS_NOTARIZATION_PASSWORD` - App specific password for Notarization from your Apple Developer Account
+   * `QGC_MACOS_NOTARIZATION_TEAM_ID` - Apple Developer Account Team ID
 
 1. Build
 


### PR DESCRIPTION
Jumping through the Mac security hoops to use QGC is no longer needed