### PR TITLE
Gimbal Indicator: Close popup after selecting gimbal command, Only show gimbal command if supported

### DIFF
--- a/src/Gimbal/Gimbal.cc
+++ b/src/Gimbal/Gimbal.cc
@@ -38,9 +38,9 @@ const Gimbal &Gimbal::operator=(const Gimbal &other)
     _requestInformationRetries = other._requestInformationRetries;
     _requestStatusRetries = other._requestStatusRetries;
     _requestAttitudeRetries = other._requestAttitudeRetries;
-    _receivedInformation = other._receivedInformation;
-    _receivedStatus = other._receivedStatus;
-    _receivedAttitude = other._receivedAttitude;
+    _receivedGimbalManagerInformation = other._receivedGimbalManagerInformation;
+    _receivedGimbalManagerStatus = other._receivedGimbalManagerStatus;
+    _receivedGimbalDeviceAttitudeStatus = other._receivedGimbalDeviceAttitudeStatus;
     _isComplete = other._isComplete;
     _retracted = other._retracted;
     _neutral = other._neutral;
@@ -73,4 +73,12 @@ void Gimbal::_initFacts()
     _absoluteYawFact.setRawValue(0.0f);
     _deviceIdFact.setRawValue(0);
     _managerCompidFact.setRawValue(0);
+}
+
+void Gimbal::setCapabilityFlags(uint32_t flags)
+{
+    if (_capabilityFlags != flags) {
+        _capabilityFlags = flags;
+        emit capabilityFlagsChanged();
+    }
 }

--- a/src/Gimbal/Gimbal.h
+++ b/src/Gimbal/Gimbal.h
@@ -12,12 +12,13 @@
 #include <QtCore/QLoggingCategory>
 
 #include "FactGroup.h"
+#include "QGCMAVLink.h"
 
 Q_DECLARE_LOGGING_CATEGORY(GimbalLog)
 
 class GimbalController;
 
-class Gimbal : public FactGroup
+class Gimbal : public FactGroup 
 {
     Q_OBJECT
     Q_PROPERTY(Fact     *absoluteRoll           READ absoluteRoll               CONSTANT)
@@ -32,6 +33,8 @@ class Gimbal : public FactGroup
     Q_PROPERTY(bool     retracted               READ retracted                  NOTIFY retractedChanged)
     Q_PROPERTY(bool     gimbalHaveControl       READ gimbalHaveControl          NOTIFY gimbalHaveControlChanged)
     Q_PROPERTY(bool     gimbalOthersHaveControl READ gimbalOthersHaveControl    NOTIFY gimbalOthersHaveControlChanged)
+    Q_PROPERTY(bool     supportsRetract         READ supportsRetract            NOTIFY capabilityFlagsChanged)
+    Q_PROPERTY(bool     supportsYawLock         READ supportsYawLock            NOTIFY capabilityFlagsChanged)
 
     friend class GimbalController;
 
@@ -69,6 +72,10 @@ public:
     void setGimbalHaveControl(bool set) { if (set != _haveControl) { _haveControl = set; emit gimbalHaveControlChanged(); } }
     void setGimbalOthersHaveControl(bool set) { if (set != _othersHaveControl) { _othersHaveControl = set; emit gimbalOthersHaveControlChanged(); } }
 
+    void setCapabilityFlags(uint32_t flags);
+    bool supportsRetract() const { return (_capabilityFlags & GIMBAL_MANAGER_CAP_FLAGS_HAS_RETRACT) != 0; }
+    bool supportsYawLock() const { return (_capabilityFlags & GIMBAL_MANAGER_CAP_FLAGS_HAS_YAW_LOCK) != 0; }
+
 signals:
     void pitchRateChanged();
     void yawRateChanged();
@@ -76,6 +83,7 @@ signals:
     void retractedChanged();
     void gimbalHaveControlChanged();
     void gimbalOthersHaveControlChanged();
+    void capabilityFlagsChanged();
 
 private:
     void _initFacts();
@@ -83,11 +91,12 @@ private:
     unsigned _requestInformationRetries = 3;
     unsigned _requestStatusRetries = 6;
     unsigned _requestAttitudeRetries = 3;
-    bool _receivedInformation = false;
-    bool _receivedStatus = false;
-    bool _receivedAttitude = false;
+    bool _receivedGimbalManagerInformation = false;
+    bool _receivedGimbalManagerStatus = false;
+    bool _receivedGimbalDeviceAttitudeStatus = false;
     bool _isComplete = false;
     bool _neutral = false;
+    uint32_t _capabilityFlags = 0; // GIMBAL_MANAGER_CAP_FLAGS
 
     Fact _absoluteRollFact = Fact(0, QStringLiteral("gimbalRoll"), FactMetaData::valueTypeFloat);
     Fact _absolutePitchFact = Fact(0, QStringLiteral("gimbalPitch"), FactMetaData::valueTypeFloat);

--- a/src/Gimbal/GimbalController.cc
+++ b/src/Gimbal/GimbalController.cc
@@ -87,7 +87,7 @@ void GimbalController::_handleHeartbeat(const mavlink_message_t &message)
     // Note that we are working over potential gimbal managers here, instead of potential gimbals.
     // This is because we address the gimbal manager by compid, but a gimbal device might have an
     // id different than the message compid it comes from. For more information see https://mavlink.io/en/services/gimbal_v2.html
-    if (!gimbalManager.receivedInformation && (gimbalManager.requestGimbalManagerInformationRetries > 0)) {
+    if (!gimbalManager.receivedGimbalManagerInformation && (gimbalManager.requestGimbalManagerInformationRetries > 0)) {
         _requestGimbalInformation(message.compid);
         --gimbalManager.requestGimbalManagerInformationRetries;
     }
@@ -116,16 +116,17 @@ void GimbalController::_handleGimbalManagerInformation(const mavlink_message_t &
     Gimbal *const gimbal = gimbalIt.value();
     gimbal->setManagerCompid(message.compid);
     gimbal->setDeviceId(information.gimbal_device_id);
+    gimbal->setCapabilityFlags(information.cap_flags);
 
-    if (!gimbal->_receivedInformation) {
+    if (!gimbal->_receivedGimbalManagerInformation) {
         qCDebug(GimbalControllerLog) << "gimbal manager with compId:" << message.compid
                            << " is responsible for gimbal device:" << information.gimbal_device_id;
     }
 
-    gimbal->_receivedInformation = true;
+    gimbal->_receivedGimbalManagerInformation = true;
     // It is important to flag our potential gimbal manager as well, so we stop requesting gimbal_manger_information message
     PotentialGimbalManager &gimbalManager = _potentialGimbalManagers[message.compid];
-    gimbalManager.receivedInformation = true;
+    gimbalManager.receivedGimbalManagerInformation = true;
 
     _checkComplete(*gimbal, pairId);
 }
@@ -164,12 +165,12 @@ void GimbalController::_handleGimbalManagerStatus(const mavlink_message_t &messa
     }
 
     // Only log this message once
-    if (!gimbal->_receivedStatus) {
+    if (!gimbal->_receivedGimbalManagerStatus) {
         qCDebug(GimbalControllerLog) << "_handleGimbalManagerStatus: gimbal manager with compId" << message.compid
                                      << "is responsible for gimbal device" << status.gimbal_device_id;
     }
 
-    gimbal->_receivedStatus = true;
+    gimbal->_receivedGimbalManagerStatus = true;
 
     const bool haveControl =
         (status.primary_control_sysid == MAVLinkProtocol::instance()->getSystemId()) &&
@@ -261,7 +262,7 @@ void GimbalController::_handleGimbalDeviceAttitudeStatus(const mavlink_message_t
         gimbal->setAbsoluteYaw(absoluteYaw);
     }
 
-    gimbal->_receivedAttitude = true;
+    gimbal->_receivedGimbalDeviceAttitudeStatus = true;
 
     _checkComplete(*gimbal, pairId);
 }
@@ -285,14 +286,14 @@ void GimbalController::_checkComplete(Gimbal &gimbal, GimbalPairId pairId)
         return;
     }
 
-    if (!gimbal._receivedInformation && gimbal._requestInformationRetries > 0) {
+    if (!gimbal._receivedGimbalManagerInformation && gimbal._requestInformationRetries > 0) {
         _requestGimbalInformation(pairId.managerCompid);
         --gimbal._requestInformationRetries;
     }
     // Limit to 1 second between set message interface requests
     static qint64 lastRequestStatusMessage = 0;
     qint64 now = QDateTime::currentMSecsSinceEpoch();
-    if (!gimbal._receivedStatus && (gimbal._requestStatusRetries > 0) && (now - lastRequestStatusMessage > 1000)) {
+    if (!gimbal._receivedGimbalManagerStatus && (gimbal._requestStatusRetries > 0) && (now - lastRequestStatusMessage > 1000)) {
         lastRequestStatusMessage = now;
         _vehicle->sendMavCommand(pairId.managerCompid,
                                  MAV_CMD_SET_MESSAGE_INTERVAL,
@@ -306,8 +307,8 @@ void GimbalController::_checkComplete(Gimbal &gimbal, GimbalPairId pairId)
                            << ", retries remaining:" << gimbal._requestStatusRetries;
     }
 
-    if (!gimbal._receivedAttitude && (gimbal._requestAttitudeRetries > 0) &&
-        gimbal._receivedInformation && (pairId.deviceId != 0)) {
+    if (!gimbal._receivedGimbalDeviceAttitudeStatus && (gimbal._requestAttitudeRetries > 0) &&
+        gimbal._receivedGimbalManagerInformation && (pairId.deviceId != 0)) {
         // We request the attitude directly from the gimbal device component.
         // We can only do that once we have received the gimbal manager information
         // telling us which gimbal device it is responsible for.
@@ -325,7 +326,7 @@ void GimbalController::_checkComplete(Gimbal &gimbal, GimbalPairId pairId)
         --gimbal._requestAttitudeRetries;
     }
 
-    if (!gimbal._receivedInformation || !gimbal._receivedStatus || !gimbal._receivedAttitude) {
+    if (!gimbal._receivedGimbalManagerInformation || !gimbal._receivedGimbalManagerStatus || !gimbal._receivedGimbalDeviceAttitudeStatus) {
         // Not complete yet.
         return;
     }
@@ -426,7 +427,7 @@ void GimbalController::centerGimbal()
         qCDebug(GimbalControllerLog) << "gimbalYawStep: active gimbal is nullptr, returning";
         return;
     }
-    sendPitchBodyYaw(0.0, 0.0);
+    sendPitchBodyYaw(0.0, 0.0, true);
 }
 
 void GimbalController::gimbalOnScreenControl(float panPct, float tiltPct, bool clickAndPoint, bool clickAndDrag, bool rateControl, bool retract, bool neutral, bool yawlock)
@@ -540,7 +541,7 @@ void GimbalController::sendPitchAbsoluteYaw(float pitch, float yaw, bool showErr
         _activeGimbal->deviceId()->rawValue().toUInt());
 }
 
-void GimbalController::toggleGimbalRetracted(bool set)
+void GimbalController::setGimbalRetract(bool set)
 {
     if (!_tryGetGimbalControl()) {
         return;
@@ -596,7 +597,7 @@ void GimbalController::_rateSenderTimeout()
     sendRate();
 }
 
-void GimbalController::toggleGimbalYawLock(bool set)
+void GimbalController::setGimbalYawLock(bool set)
 {
     if (!_tryGetGimbalControl()) {
         return;

--- a/src/Gimbal/GimbalController.h
+++ b/src/Gimbal/GimbalController.h
@@ -27,8 +27,9 @@ class GimbalController : public QObject
     QML_ELEMENT
     QML_UNCREATABLE("")
     Q_MOC_INCLUDE("QmlObjectListModel.h")
-    Q_PROPERTY(Gimbal *activeGimbal READ activeGimbal WRITE setActiveGimbal NOTIFY activeGimbalChanged)
-    Q_PROPERTY(QmlObjectListModel *gimbals READ gimbals CONSTANT)
+
+    Q_PROPERTY(Gimbal*              activeGimbal    READ activeGimbal WRITE setActiveGimbal NOTIFY activeGimbalChanged)
+    Q_PROPERTY(QmlObjectListModel*  gimbals         READ gimbals                            CONSTANT)
 
 public:
     GimbalController(Vehicle *vehicle);
@@ -43,8 +44,8 @@ public:
     Q_INVOKABLE void gimbalOnScreenControl(float panpct, float tiltpct, bool clickAndPoint, bool clickAndDrag, bool rateControl, bool retract = false, bool neutral = false, bool yawlock = false);
     Q_INVOKABLE void sendPitchBodyYaw(float pitch, float yaw, bool showError = true);
     Q_INVOKABLE void sendPitchAbsoluteYaw(float pitch, float yaw, bool showError = true);
-    Q_INVOKABLE void toggleGimbalRetracted(bool set = false);
-    Q_INVOKABLE void toggleGimbalYawLock(bool set = false);
+    Q_INVOKABLE void setGimbalRetract(bool set);
+    Q_INVOKABLE void setGimbalYawLock(bool set);
     Q_INVOKABLE void acquireGimbalControl();
     Q_INVOKABLE void releaseGimbalControl();
     Q_INVOKABLE void sendRate();
@@ -55,7 +56,7 @@ signals:
 
 public slots:
     // These slots are conected with joysticks for button control
-    void gimbalYawLock(bool yawLock) { toggleGimbalYawLock(yawLock); }
+    void gimbalYawLock(bool yawLock) { setGimbalYawLock(yawLock); }
     Q_INVOKABLE void centerGimbal();
     void gimbalPitchStart(int direction);
     void gimbalYawStart(int direction);
@@ -110,7 +111,7 @@ private:
 
     struct PotentialGimbalManager {
         unsigned requestGimbalManagerInformationRetries = 6;
-        bool receivedInformation = false;
+        bool receivedGimbalManagerInformation = false;
     };
     QMap<uint8_t, PotentialGimbalManager> _potentialGimbalManagers; // key is compid
 

--- a/src/UI/toolbar/GimbalIndicator.qml
+++ b/src/UI/toolbar/GimbalIndicator.qml
@@ -168,38 +168,58 @@ Item {
                 QGCButton {
                     Layout.fillWidth:   true
                     text:               activeGimbal.yawLock ? qsTr("Yaw Follow") : qsTr("Yaw Lock")
-                    onClicked:          gimbalController.toggleGimbalYawLock(!activeGimbal.yawLock)
+                    visible:            activeGimbal.supportsYawLock
+                    onClicked: {
+                        gimbalController.setGimbalYawLock(!activeGimbal.yawLock)
+                        mainWindow.closeIndicatorDrawer()
+                    }
                 }
 
                 QGCButton {
                     Layout.fillWidth:   true
                     text:               qsTr("Center")
-                    onClicked:          gimbalController.centerGimbal()
+                    onClicked: {
+                        gimbalController.centerGimbal()
+                        mainWindow.closeIndicatorDrawer()
+                    }
                 }
 
                 QGCButton {
                     Layout.fillWidth:   true
                     text:               qsTr("Tilt 90")
-                    onClicked:          gimbalController.sendPitchBodyYaw(-90, 0)
+                    onClicked: {
+                        gimbalController.sendPitchBodyYaw(-90, 0)
+                        mainWindow.closeIndicatorDrawer()
+                    }
                 }
 
                 QGCButton {
                     Layout.fillWidth:   true
                     text:               qsTr("Point Home")
-                    onClicked:          activeVehicle.guidedModeROI(activeVehicle.homePosition)
+                    onClicked: {
+                        activeVehicle.guidedModeROI(activeVehicle.homePosition)
+                        mainWindow.closeIndicatorDrawer()
+                    }
                 }
 
                 QGCButton {
                     Layout.fillWidth:   true
                     text:               qsTr("Retract")
-                    onClicked:          gimbalController.toggleGimbalRetracted(true)
+                    visible:            activeGimbal.supportsRetract
+                    onClicked: {
+                        gimbalController.setGimbalRetract(true)
+                        mainWindow.closeIndicatorDrawer()
+                    }
                 }
 
                 QGCButton {
                     Layout.fillWidth:   true
                     text:               activeGimbal.gimbalHaveControl ? qsTr("Release Control") : qsTr("Acquire Control")
                     visible:            _gimbalControllerSettings.toolbarIndicatorShowAcquireReleaseControl.rawValue
-                    onClicked:          activeGimbal.gimbalHaveControl ? gimbalController.releaseGimbalControl() : gimbalController.acquireGimbalControl()
+                    onClicked: {
+                        activeGimbal.gimbalHaveControl ? gimbalController.releaseGimbalControl() : gimbalController.acquireGimbalControl()
+                        mainWindow.closeIndicatorDrawer()
+                    }
                 }
             }
         }


### PR DESCRIPTION
* Yaw follow and Retract only displayed if capability flags indicate support
* Some cleanup in Gimbal and GimbalController to improve readability

<!--- Title -->

Description
-----------
<!--- Describe your changes in detail. -->

Test Steps
-----------
<!-- Describe the steps to reproduce. -->

Checklist:
----------
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [ ] [Review Contribution Guidelines](https://github.com/mavlink/qgroundcontrol/blob/master/.github/CONTRIBUTING.md).
- [ ] [Review Code of Conduct](https://github.com/mavlink/qgroundcontrol/blob/master/.github/CODE_OF_CONDUCT.md).
- [ ] I have tested my changes.

Related Issue
-----------
<!-- If any, please provide issue ID. -->


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.