### PR TITLE
Rework logging categories to double level of hierarchy

### DIFF
--- a/custom-example/src/CustomPlugin.cc
+++ b/custom-example/src/CustomPlugin.cc
@@ -19,7 +19,7 @@
 #include <QtQml/QQmlApplicationEngine>
 #include <QtQml/QQmlFile>
 
-QGC_LOGGING_CATEGORY(CustomLog, "gcs.custom.customplugin")
+QGC_LOGGING_CATEGORY(CustomLog, "Custom.CustomPlugin")
 
 Q_APPLICATION_STATIC(CustomPlugin, _customPluginInstance);
 

--- a/src/ADSB/ADSBTCPLink.cc
+++ b/src/ADSB/ADSBTCPLink.cc
@@ -14,7 +14,7 @@
 #include <QtCore/QTimer>
 #include <QtNetwork/QTcpSocket>
 
-QGC_LOGGING_CATEGORY(ADSBTCPLinkLog, "qgc.adsb.adsbtcplink")
+QGC_LOGGING_CATEGORY(ADSBTCPLinkLog, "ADSB.ADSBTCPLink")
 
 ADSBTCPLink::ADSBTCPLink(const QHostAddress &hostAddress, quint16 port, QObject *parent)
     : QObject(parent)

--- a/src/ADSB/ADSBVehicle.cc
+++ b/src/ADSB/ADSBVehicle.cc
@@ -13,7 +13,7 @@
 
 #include <QtCore/QtNumeric>
 
-QGC_LOGGING_CATEGORY(ADSBVehicleLog, "qgc.adsb.adsbvehicle")
+QGC_LOGGING_CATEGORY(ADSBVehicleLog, "ADSB.ADSBVehicle")
 
 ADSBVehicle::ADSBVehicle(const ADSB::VehicleInfo_t &vehicleInfo, QObject *parent)
     : QObject(parent)

--- a/src/ADSB/ADSBVehicleManager.cc
+++ b/src/ADSB/ADSBVehicleManager.cc
@@ -20,7 +20,7 @@
 #include <QtCore/QTimer>
 #include <qassert.h>
 
-QGC_LOGGING_CATEGORY(ADSBVehicleManagerLog, "qgc.adsb.adsbvehiclemanager")
+QGC_LOGGING_CATEGORY(ADSBVehicleManagerLog, "ADSB.ADSBVehicleManager")
 
 Q_APPLICATION_STATIC(ADSBVehicleManager, _adsbVehicleManager, SettingsManager::instance()->adsbVehicleManagerSettings());
 

--- a/src/API/QGCCorePlugin.cc
+++ b/src/API/QGCCorePlugin.cc
@@ -40,7 +40,7 @@
 #include <QtQml/QQmlContext>
 #include <QtQuick/QQuickItem>
 
-QGC_LOGGING_CATEGORY(QGCCorePluginLog, "qgc.api.qgccoreplugin");
+QGC_LOGGING_CATEGORY(QGCCorePluginLog, "API.QGCCorePlugin");
 
 #ifndef QGC_CUSTOM_BUILD
 Q_APPLICATION_STATIC(QGCCorePlugin, _qgcCorePluginInstance);

--- a/src/API/QGCOptions.cc
+++ b/src/API/QGCOptions.cc
@@ -10,7 +10,7 @@
 #include "QGCOptions.h"
 #include "QGCLoggingCategory.h"
 
-QGC_LOGGING_CATEGORY(QGCFlyViewOptionsLog, "qgc.api.qgcflyviewoptions");
+QGC_LOGGING_CATEGORY(QGCFlyViewOptionsLog, "API.QGCFlyViewOptions");
 
 QGCFlyViewOptions::QGCFlyViewOptions(QGCOptions *options, QObject *parent)
     : QObject(parent)
@@ -26,7 +26,7 @@ QGCFlyViewOptions::~QGCFlyViewOptions()
 
 /*===========================================================================*/
 
-QGC_LOGGING_CATEGORY(QGCOptionsLog, "qgc.api.qgcoptions");
+QGC_LOGGING_CATEGORY(QGCOptionsLog, "API.QGCOptions");
 
 QGCOptions::QGCOptions(QObject *parent)
     : QObject(parent)

--- a/src/API/QmlComponentInfo.cc
+++ b/src/API/QmlComponentInfo.cc
@@ -10,7 +10,7 @@
 #include "QmlComponentInfo.h"
 #include "QGCLoggingCategory.h"
 
-QGC_LOGGING_CATEGORY(QmlComponentInfoLog, "qgc.api.qmlcomponentinfo");
+QGC_LOGGING_CATEGORY(QmlComponentInfoLog, "API.QmlComponentInfo");
 
 QmlComponentInfo::QmlComponentInfo(const QString &title, QUrl url, QUrl icon, QObject *parent)
     : QObject(parent)

--- a/src/AnalyzeView/ExifParser.cc
+++ b/src/AnalyzeView/ExifParser.cc
@@ -14,7 +14,7 @@
 #include <QtCore/QDateTime>
 #include <QtCore/QtEndian>
 
-QGC_LOGGING_CATEGORY(ExifParserLog, "qgc.analyzeview.exifparser")
+QGC_LOGGING_CATEGORY(ExifParserLog, "AnalyzeView.ExifParser")
 
 namespace ExifParser
 {

--- a/src/AnalyzeView/GeoTagController.cc
+++ b/src/AnalyzeView/GeoTagController.cc
@@ -16,7 +16,7 @@
 #include <QtCore/QThread>
 #include <QtCore/QUrl>
 
-QGC_LOGGING_CATEGORY(GeoTagControllerLog, "qgc.analyzeview.geotagcontroller")
+QGC_LOGGING_CATEGORY(GeoTagControllerLog, "AnalyzeView.GeoTagController")
 
 GeoTagController::GeoTagController(QObject *parent)
     : QObject(parent)

--- a/src/AnalyzeView/GeoTagWorker.cc
+++ b/src/AnalyzeView/GeoTagWorker.cc
@@ -17,7 +17,7 @@
 
 #include <QtCore/QDir>
 
-QGC_LOGGING_CATEGORY(GeoTagWorkerLog, "qgc.analyzeview.geotagworker")
+QGC_LOGGING_CATEGORY(GeoTagWorkerLog, "AnalyzeView.GeoTagWorker")
 
 GeoTagWorker::GeoTagWorker(QObject *parent)
     : QObject(parent)

--- a/src/AnalyzeView/LogDownloadController.cc
+++ b/src/AnalyzeView/LogDownloadController.cc
@@ -22,7 +22,7 @@
 #include <QtCore/QApplicationStatic>
 #include <QtCore/QTimer>
 
-QGC_LOGGING_CATEGORY(LogDownloadControllerLog, "qgc.analyzeview.logdownloadcontroller")
+QGC_LOGGING_CATEGORY(LogDownloadControllerLog, "AnalyzeView.LogDownloadController")
 
 LogDownloadController::LogDownloadController(QObject *parent)
     : QObject(parent)

--- a/src/AnalyzeView/LogEntry.cc
+++ b/src/AnalyzeView/LogEntry.cc
@@ -13,7 +13,7 @@
 
 #include <QtCore/QtMath>
 
-QGC_LOGGING_CATEGORY(LogEntryLog, "test.analyzeview.logentry")
+QGC_LOGGING_CATEGORY(LogEntryLog, "AnalyzeView.QGCLogEntry")
 
 LogDownloadData::LogDownloadData(QGCLogEntry * const entry)
     : ID(entry->id())

--- a/src/AnalyzeView/MAVLinkChartController.cc
+++ b/src/AnalyzeView/MAVLinkChartController.cc
@@ -18,7 +18,7 @@
 
 Q_DECLARE_METATYPE(QAbstractSeries*)
 
-QGC_LOGGING_CATEGORY(MAVLinkChartControllerLog, "MAVLinkChartControllerLog")
+QGC_LOGGING_CATEGORY(MAVLinkChartControllerLog, "AnalyzeView.MAVLinkChartController")
 
 MAVLinkChartController::MAVLinkChartController(QObject *parent)
     : QObject(parent)

--- a/src/AnalyzeView/MAVLinkConsoleController.cc
+++ b/src/AnalyzeView/MAVLinkConsoleController.cc
@@ -17,7 +17,7 @@
 #include <QtGui/QGuiApplication>
 #include <QtGui/QClipboard>
 
-QGC_LOGGING_CATEGORY(MAVLinkConsoleControllerLog, "qgc.analyzeview.mavlinkconsolecontroller")
+QGC_LOGGING_CATEGORY(MAVLinkConsoleControllerLog, "AnalyzeView.MAVLinkConsoleController")
 
 MAVLinkConsoleController::MAVLinkConsoleController(QObject *parent)
     : QStringListModel(parent)

--- a/src/AnalyzeView/MAVLinkInspectorController.cc
+++ b/src/AnalyzeView/MAVLinkInspectorController.cc
@@ -20,7 +20,7 @@
 
 #include <QtQml/QQmlEngine>
 
-QGC_LOGGING_CATEGORY(MAVLinkInspectorControllerLog, "MAVLinkInspectorControllerLog")
+QGC_LOGGING_CATEGORY(MAVLinkInspectorControllerLog, "AnalyzeView.MAVLinkInspectorController")
 
 MAVLinkInspectorController::TimeScale_st::TimeScale_st(const QString &label_, uint32_t timeScale_)
     : label(label_)

--- a/src/AnalyzeView/MAVLinkMessage.cc
+++ b/src/AnalyzeView/MAVLinkMessage.cc
@@ -14,7 +14,7 @@
 
 #include <QtCore/QTimeZone>
 
-QGC_LOGGING_CATEGORY(MAVLinkMessageLog, "qgc.analyzeview.mavlinkmessage")
+QGC_LOGGING_CATEGORY(MAVLinkMessageLog, "AnalyzeView.MAVLinkMessage")
 
 QGCMAVLinkMessage::QGCMAVLinkMessage(const mavlink_message_t &message, QObject *parent)
     : QObject(parent)

--- a/src/AnalyzeView/MAVLinkMessageField.cc
+++ b/src/AnalyzeView/MAVLinkMessageField.cc
@@ -16,7 +16,7 @@
 #include <QtCharts/QLineSeries>
 #include <QtCharts/QAbstractSeries>
 
-QGC_LOGGING_CATEGORY(MAVLinkMessageFieldLog, "qgc.analyzeview.mavlinkmessagefield")
+QGC_LOGGING_CATEGORY(MAVLinkMessageFieldLog, "AnalyzeView.MAVLinkMessageField")
 
 QGCMAVLinkMessageField::QGCMAVLinkMessageField(const QString &name, const QString &type, QGCMAVLinkMessage *parent)
     : QObject(parent)

--- a/src/AnalyzeView/MAVLinkSystem.cc
+++ b/src/AnalyzeView/MAVLinkSystem.cc
@@ -11,7 +11,7 @@
 #include "MAVLinkMessage.h"
 #include "QGCLoggingCategory.h"
 
-QGC_LOGGING_CATEGORY(MAVLinkSystemLog, "qgc.analyzeview.mavlinksystem")
+QGC_LOGGING_CATEGORY(MAVLinkSystemLog, "AnalyzeView.MAVLinkSystem")
 
 QGCMAVLinkSystem::QGCMAVLinkSystem(quint8 id, QObject *parent)
     : QObject(parent)

--- a/src/AnalyzeView/PX4LogParser.cc
+++ b/src/AnalyzeView/PX4LogParser.cc
@@ -12,7 +12,7 @@
 
 #include <QtCore/QtEndian>
 
-QGC_LOGGING_CATEGORY(PX4LogParserLog, "qgc.analyzeview.px4logparser")
+QGC_LOGGING_CATEGORY(PX4LogParserLog, "AnalyzeView.PX4LogParser")
 
 // general message header
 static constexpr const char header[3] = {static_cast<char>(0xA3), static_cast<char>(0x95), static_cast<char>(0x00)};

--- a/src/AnalyzeView/ULogParser.cc
+++ b/src/AnalyzeView/ULogParser.cc
@@ -18,7 +18,7 @@
 
 using namespace ulog_cpp;
 
-QGC_LOGGING_CATEGORY(ULogParserLog, "qgc.analyzeview.ulogparser")
+QGC_LOGGING_CATEGORY(ULogParserLog, "AnalyzeView.ULogParser")
 
 namespace ULogParser {
 

--- a/src/AutoPilotPlugins/APM/APMAirframeComponentController.cc
+++ b/src/AutoPilotPlugins/APM/APMAirframeComponentController.cc
@@ -23,7 +23,7 @@
 #include <QtGui/QCursor>
 #include <QtGui/QGuiApplication>
 
-QGC_LOGGING_CATEGORY(APMAirframeComponentControllerLog, "qgc.autopilotplugins.apm.apmairframecomponentcontroller")
+QGC_LOGGING_CATEGORY(APMAirframeComponentControllerLog, "AutoPilotPlugins.APMAirframeComponentController")
 
 /*===========================================================================*/
 

--- a/src/AutoPilotPlugins/APM/APMAutoPilotPlugin.cc
+++ b/src/AutoPilotPlugins/APM/APMAutoPilotPlugin.cc
@@ -37,7 +37,7 @@
 #include "SerialLink.h"
 #endif
 
-QGC_LOGGING_CATEGORY(APMAutoPilotPluginLog, "qgc.autopilotplugins.apm.apmautopilotplugin")
+QGC_LOGGING_CATEGORY(APMAutoPilotPluginLog, "AutoPilotPlugins.APM.apmautopilotplugin")
 
 APMAutoPilotPlugin::APMAutoPilotPlugin(Vehicle *vehicle, QObject *parent)
     : AutoPilotPlugin(vehicle, parent)

--- a/src/AutoPilotPlugins/APM/APMSensorsComponentController.cc
+++ b/src/AutoPilotPlugins/APM/APMSensorsComponentController.cc
@@ -18,8 +18,8 @@
 
 #include <QtCore/QVariant>
 
-QGC_LOGGING_CATEGORY(APMSensorsComponentControllerLog, "qgc.autopilotplugins.apm.apmsensorscomponentcontroller")
-QGC_LOGGING_CATEGORY(APMSensorsComponentControllerVerboseLog, "qgc.autopilotplugins.apm.apmsensorscomponentcontroller:verbose")
+QGC_LOGGING_CATEGORY(APMSensorsComponentControllerLog, "AutoPilotPlugins.APMSensorsComponentController")
+QGC_LOGGING_CATEGORY(APMSensorsComponentControllerVerboseLog, "AutoPilotPlugins.APMSensorsComponentController:verbose")
 
 APMSensorsComponentController::APMSensorsComponentController(QObject *parent)
     : FactPanelController(parent)

--- a/src/AutoPilotPlugins/APM/CMakeLists.txt
+++ b/src/AutoPilotPlugins/APM/CMakeLists.txt
@@ -47,7 +47,7 @@ target_include_directories(${CMAKE_PROJECT_NAME} PRIVATE ${CMAKE_CURRENT_SOURCE_
 qt_add_library(AutoPilotPluginsAPMModule STATIC)
 
 qt_add_qml_module(AutoPilotPluginsAPMModule
-    URI QGroundControl.AutoPilotPlugins.APM
+    URI QGroundControl.AutoPilotPlugin.APM
     VERSION 1.0
     RESOURCE_PREFIX /qml
     QML_FILES

--- a/src/AutoPilotPlugins/AutoPilotPlugin.cc
+++ b/src/AutoPilotPlugins/AutoPilotPlugin.cc
@@ -16,7 +16,7 @@
 
 #include <QtCore/QCoreApplication>
 
-QGC_LOGGING_CATEGORY(AutoPilotPluginLog, "qgc.autopilotplugin.autopilotplugin");
+QGC_LOGGING_CATEGORY(AutoPilotPluginLog, "AutoPilotPlugins.AutoPilotPlugin");
 
 AutoPilotPlugin::AutoPilotPlugin(Vehicle *vehicle, QObject *parent)
     : QObject(parent)

--- a/src/AutoPilotPlugins/Common/ESP8266ComponentController.cc
+++ b/src/AutoPilotPlugins/Common/ESP8266ComponentController.cc
@@ -14,7 +14,7 @@
 
 #include <QtNetwork/QHostAddress>
 
-QGC_LOGGING_CATEGORY(ESP8266ComponentControllerLog, "qgc.autopilotplugins.common.esp8266componentcontroller")
+QGC_LOGGING_CATEGORY(ESP8266ComponentControllerLog, "AutoPilotPlugins.ESP8266ComponentController")
 
 #define MAX_RETRIES 5
 

--- a/src/AutoPilotPlugins/Common/RadioComponentController.cc
+++ b/src/AutoPilotPlugins/Common/RadioComponentController.cc
@@ -16,8 +16,8 @@
 
 #include <QtCore/QSettings>
 
-QGC_LOGGING_CATEGORY(RadioComponentControllerLog, "qgc.autopilotplugins.common.radiocomponentcontroller")
-QGC_LOGGING_CATEGORY(RadioComponentControllerVerboseLog, "qgc.autopilotplugins.common.radiocomponentcontroller:verbose")
+QGC_LOGGING_CATEGORY(RadioComponentControllerLog, "AutoPilotPlugins.RadioComponentController")
+QGC_LOGGING_CATEGORY(RadioComponentControllerVerboseLog, "AutoPilotPlugins.RadioComponentController:verbose")
 
 #ifdef QGC_UNITTEST_BUILD
 RadioComponentController* RadioComponentController::_unitTestController = nullptr;

--- a/src/AutoPilotPlugins/Common/SyslinkComponentController.cc
+++ b/src/AutoPilotPlugins/Common/SyslinkComponentController.cc
@@ -11,7 +11,7 @@
 #include "Vehicle.h"
 #include "QGCLoggingCategory.h"
 
-QGC_LOGGING_CATEGORY(SyslinkComponentControllerLog, "qgc.autopilotplugins.common.syslinkcomponentcontroller")
+QGC_LOGGING_CATEGORY(SyslinkComponentControllerLog, "AutoPilotPlugins.SyslinkComponentController")
 
 SyslinkComponentController::SyslinkComponentController(QObject *parent)
     : FactPanelController(parent)

--- a/src/AutoPilotPlugins/PX4/PX4AirframeLoader.cc
+++ b/src/AutoPilotPlugins/PX4/PX4AirframeLoader.cc
@@ -24,7 +24,7 @@
 #include <QtCore/QXmlStreamReader>
 #include <QtCore/QSettings>
 
-QGC_LOGGING_CATEGORY(PX4AirframeLoaderLog, "PX4AirframeLoaderLog")
+QGC_LOGGING_CATEGORY(PX4AirframeLoaderLog, "AutoPilotPlugins.PX4AirframeLoader")
 
 bool PX4AirframeLoader::_airframeMetaDataLoaded = false;
 

--- a/src/AutoPilotPlugins/PX4/SensorsComponentController.cc
+++ b/src/AutoPilotPlugins/PX4/SensorsComponentController.cc
@@ -13,7 +13,7 @@
 #include "Vehicle.h"
 #include "QGCLoggingCategory.h"
 
-QGC_LOGGING_CATEGORY(SensorsComponentControllerLog, "SensorsComponentControllerLog")
+QGC_LOGGING_CATEGORY(SensorsComponentControllerLog, "AutoPilotPlugins.SensorsComponentController")
 
 SensorsComponentController::SensorsComponentController(void)
     : _statusLog                                (nullptr)

--- a/src/AutoPilotPlugins/VehicleComponent.cc
+++ b/src/AutoPilotPlugins/VehicleComponent.cc
@@ -15,7 +15,7 @@
 #include <QtQml/QQmlContext>
 #include <QtQuick/QQuickItem>
 
-QGC_LOGGING_CATEGORY(VehicleComponentLog, "qgc.autopilotplugin.vehiclecomponent");
+QGC_LOGGING_CATEGORY(VehicleComponentLog, "AutoPilotPlugins.VehicleComponent");
 
 VehicleComponent::VehicleComponent(Vehicle *vehicle, AutoPilotPlugin *autopilot, AutoPilotPlugin::KnownVehicleComponent KnownVehicleComponent, QObject *parent)
     : QObject(parent)

--- a/src/Camera/CameraMetaData.cc
+++ b/src/Camera/CameraMetaData.cc
@@ -16,7 +16,7 @@
 #include "JsonHelper.h"
 #include "QGCLoggingCategory.h"
 
-QGC_LOGGING_CATEGORY(CameraMetaDataLog, "qgc.camera.camerametadata")
+QGC_LOGGING_CATEGORY(CameraMetaDataLog, "Camera.CameraMetaData")
 
 CameraMetaData::CameraMetaData(const QString &canonicalName,
                                const QString &brand,

--- a/src/Camera/MavlinkCameraControl.cc
+++ b/src/Camera/MavlinkCameraControl.cc
@@ -10,8 +10,8 @@
 #include "MavlinkCameraControl.h"
 #include "QGCLoggingCategory.h"
 
-QGC_LOGGING_CATEGORY(CameraControlLog, "qgc.camera.mavlinkcameracontrol")
-QGC_LOGGING_CATEGORY(CameraControlVerboseLog, "qgc.camera.mavlinkcameracontrol")
+QGC_LOGGING_CATEGORY(CameraControlLog, "Camera.MavlinkCameraControl")
+QGC_LOGGING_CATEGORY(CameraControlVerboseLog, "Camera.MavlinkCameraControl:verbose")
 
 MavlinkCameraControl::MavlinkCameraControl(Vehicle *vehicle, QObject *parent)
     : FactGroup(0, parent, true /* ignore camel case */)

--- a/src/Camera/QGCCameraIO.cc
+++ b/src/Camera/QGCCameraIO.cc
@@ -14,8 +14,8 @@
 #include "QGCLoggingCategory.h"
 #include "Vehicle.h"
 
-QGC_LOGGING_CATEGORY(QGCCameraParamIOLog, "qgc.camera.qgccameraparamio")
-QGC_LOGGING_CATEGORY(QGCCameraParamIOVerbose, "qgc.camera.qgccameraparamio:verbose")
+QGC_LOGGING_CATEGORY(QGCCameraParamIOLog, "Camera.QGCCameraParamIO")
+QGC_LOGGING_CATEGORY(QGCCameraParamIOVerbose, "Camera.QGCCameraParamIO:verbose")
 
 namespace {
     constexpr int kMaxRetries = 3;

--- a/src/Camera/QGCCameraManager.cc
+++ b/src/Camera/QGCCameraManager.cc
@@ -18,7 +18,7 @@
 #include "QGCVideoStreamInfo.h"
 #include "SimulatedCameraControl.h"
 
-QGC_LOGGING_CATEGORY(CameraManagerLog, "qgc.camera.qgccameramanager")
+QGC_LOGGING_CATEGORY(CameraManagerLog, "Camera.QGCCameraManager")
 
 namespace {
     constexpr int kHeartbeatTickMs = 500;

--- a/src/Camera/QGCVideoStreamInfo.cc
+++ b/src/Camera/QGCVideoStreamInfo.cc
@@ -10,7 +10,7 @@
 #include "QGCVideoStreamInfo.h"
 #include "QGCLoggingCategory.h"
 
-QGC_LOGGING_CATEGORY(QGCVideoStreamInfoLog, "qgc.camera.qgcvideostreaminfo")
+QGC_LOGGING_CATEGORY(QGCVideoStreamInfoLog, "Camera.QGCVideoStreamInfo")
 
 QGCVideoStreamInfo::QGCVideoStreamInfo(const mavlink_video_stream_information_t &info, QObject *parent)
     : QObject(parent)

--- a/src/Camera/SimulatedCameraControl.cc
+++ b/src/Camera/SimulatedCameraControl.cc
@@ -15,7 +15,7 @@
 #include "Vehicle.h"
 #include "VideoManager.h"
 
-QGC_LOGGING_CATEGORY(SimulatedCameraControlLog, "qgc.camera.simulatedcameracontrol")
+QGC_LOGGING_CATEGORY(SimulatedCameraControlLog, "Camera.SimulatedCameraControl")
 
 SimulatedCameraControl::SimulatedCameraControl(Vehicle *vehicle, QObject *parent)
     : MavlinkCameraControl(vehicle, parent)

--- a/src/Comms/AirLink/AirLinkLink.cc
+++ b/src/Comms/AirLink/AirLinkLink.cc
@@ -17,7 +17,7 @@
 #include <QtCore/QTimer>
 #include <QtNetwork/QUdpSocket>
 
-QGC_LOGGING_CATEGORY(AirLinkLinkLog, "qgc.AirLink.AirLinklink");
+QGC_LOGGING_CATEGORY(AirLinkLinkLog, "AirLink.AirLinkLink");
 
 /*===========================================================================*/
 

--- a/src/Comms/AirLink/AirLinkManager.cc
+++ b/src/Comms/AirLink/AirLinkManager.cc
@@ -18,7 +18,7 @@
 #include <QtNetwork/QNetworkReply>
 #include <QtNetwork/QNetworkRequest>
 
-QGC_LOGGING_CATEGORY(AirLinkManagerLog, "qgc.airlink.airlinkmanager");
+QGC_LOGGING_CATEGORY(AirLinkManagerLog, "AirLink.AirLinkManager");
 
 Q_APPLICATION_STATIC(AirLinkManager, _airLinkManager);
 

--- a/src/Comms/BluetoothLink.cc
+++ b/src/Comms/BluetoothLink.cc
@@ -16,7 +16,7 @@
 #include <QtCore/QPermissions>
 #include <QtCore/QThread>
 
-QGC_LOGGING_CATEGORY(BluetoothLinkLog, "qgc.comms.bluetoothlink")
+QGC_LOGGING_CATEGORY(BluetoothLinkLog, "Comms.BluetoothLink")
 
 /*===========================================================================*/
 

--- a/src/Comms/LinkInterface.cc
+++ b/src/Comms/LinkInterface.cc
@@ -17,7 +17,7 @@
 
 #include <QtQml/QQmlEngine>
 
-QGC_LOGGING_CATEGORY(LinkInterfaceLog, "qgc.comms.linkinterface")
+QGC_LOGGING_CATEGORY(LinkInterfaceLog, "Comms.LinkInterface")
 
 LinkInterface::LinkInterface(SharedLinkConfigurationPtr &config, QObject *parent)
     : QObject(parent)

--- a/src/Comms/LinkManager.cc
+++ b/src/Comms/LinkManager.cc
@@ -52,8 +52,8 @@
 #include <QtCore/QApplicationStatic>
 #include <QtCore/QTimer>
 
-QGC_LOGGING_CATEGORY(LinkManagerLog, "qgc.comms.linkmanager")
-QGC_LOGGING_CATEGORY(LinkManagerVerboseLog, "qgc.comms.linkmanager:verbose")
+QGC_LOGGING_CATEGORY(LinkManagerLog, "Comms.LinkManager")
+QGC_LOGGING_CATEGORY(LinkManagerVerboseLog, "Comms.LinkManager:verbose")
 
 Q_APPLICATION_STATIC(LinkManager, _linkManagerInstance);
 

--- a/src/Comms/LogReplayLink.cc
+++ b/src/Comms/LogReplayLink.cc
@@ -18,7 +18,7 @@
 #include <QtCore/QThread>
 #include <QtCore/QTimer>
 
-QGC_LOGGING_CATEGORY(LogReplayLinkLog, "qgc.comms.logreplaylink")
+QGC_LOGGING_CATEGORY(LogReplayLinkLog, "Comms.LogReplayLink")
 
 /*===========================================================================*/
 

--- a/src/Comms/LogReplayLinkController.cc
+++ b/src/Comms/LogReplayLinkController.cc
@@ -10,7 +10,7 @@
 #include "LogReplayLinkController.h"
 #include "QGCLoggingCategory.h"
 
-QGC_LOGGING_CATEGORY(LogReplayLinkControllerLog, "qgc.comms.logreplaylink")
+QGC_LOGGING_CATEGORY(LogReplayLinkControllerLog, "Comms.LogReplayLinkController")
 
 LogReplayLinkController::LogReplayLinkController(QObject *parent)
     : QObject(parent)

--- a/src/Comms/MAVLinkProtocol.cc
+++ b/src/Comms/MAVLinkProtocol.cc
@@ -25,7 +25,7 @@
 #include <QtCore/QSettings>
 #include <QtCore/QStandardPaths>
 
-QGC_LOGGING_CATEGORY(MAVLinkProtocolLog, "qgc.comms.mavlinkprotocol")
+QGC_LOGGING_CATEGORY(MAVLinkProtocolLog, "Comms.MAVLinkProtocol")
 
 Q_APPLICATION_STATIC(MAVLinkProtocol, _mavlinkProtocolInstance);
 

--- a/src/Comms/MockLink/MockConfiguration.cc
+++ b/src/Comms/MockLink/MockConfiguration.cc
@@ -10,7 +10,7 @@
 #include "MockConfiguration.h"
 #include "QGCLoggingCategory.h"
 
-QGC_LOGGING_CATEGORY(MockConfigurationLog, "qgc.comms.mocklink.mockconfiguration")
+QGC_LOGGING_CATEGORY(MockConfigurationLog, "Comms.MockLink.MockConfiguration")
 
 MockConfiguration::MockConfiguration(const QString &name, QObject *parent)
     : LinkConfiguration(name, parent)

--- a/src/Comms/MockLink/MockLink.cc
+++ b/src/Comms/MockLink/MockLink.cc
@@ -22,8 +22,8 @@
 #include <QtCore/QThread>
 #include <QtCore/QTimer>
 
-QGC_LOGGING_CATEGORY(MockLinkLog, "qgc.comms.mocklink.mocklink")
-QGC_LOGGING_CATEGORY(MockLinkVerboseLog, "qgc.comms.mocklink.mocklink:verbose")
+QGC_LOGGING_CATEGORY(MockLinkLog, "Comms.MockLink.MockLink")
+QGC_LOGGING_CATEGORY(MockLinkVerboseLog, "Comms.MockLink.MockLink:verbose")
 
 int MockLink::_nextVehicleSystemId = 128;
 

--- a/src/Comms/MockLink/MockLinkFTP.cc
+++ b/src/Comms/MockLink/MockLinkFTP.cc
@@ -12,7 +12,7 @@
 #include "QGCLoggingCategory.h"
 #include "QGCTemporaryFile.h"
 
-QGC_LOGGING_CATEGORY(MockLinkFTPLog, "MockLinkMissionItemHandlerLog")
+QGC_LOGGING_CATEGORY(MockLinkFTPLog, "Comms.MockLink.MockLinkFTP")
 
 MockLinkFTP::MockLinkFTP(uint8_t systemIdServer, uint8_t componentIdServer, MockLink *mockLink)
     : QObject(mockLink)

--- a/src/Comms/MockLink/MockLinkMissionItemHandler.cc
+++ b/src/Comms/MockLink/MockLinkMissionItemHandler.cc
@@ -13,7 +13,7 @@
 #include "MockLink.h"
 #include "QGCLoggingCategory.h"
 
-QGC_LOGGING_CATEGORY(MockLinkMissionItemHandlerLog, "qgc.comms.mocklink.mocklinkmissionitemhandler")
+QGC_LOGGING_CATEGORY(MockLinkMissionItemHandlerLog, "Comms.MockLink.MockLinkMissionItemHandler")
 
 MockLinkMissionItemHandler::MockLinkMissionItemHandler(MockLink *mockLink)
     : QObject(mockLink)

--- a/src/Comms/QGCSerialPortInfo.cc
+++ b/src/Comms/QGCSerialPortInfo.cc
@@ -17,7 +17,7 @@
 #include <QtCore/QJsonDocument>
 #include <QtCore/QJsonObject>
 
-QGC_LOGGING_CATEGORY(QGCSerialPortInfoLog, "qgc.comms.qgcserialportinfo")
+QGC_LOGGING_CATEGORY(QGCSerialPortInfoLog, "Comms.QGCSerialPortInfo")
 
 bool QGCSerialPortInfo::_jsonLoaded = false;
 bool QGCSerialPortInfo::_jsonDataValid = false;

--- a/src/Comms/SerialLink.cc
+++ b/src/Comms/SerialLink.cc
@@ -14,7 +14,7 @@
 #include <QtCore/QThread>
 #include <QtCore/QTimer>
 
-QGC_LOGGING_CATEGORY(SerialLinkLog, "qgc.comms.seriallink")
+QGC_LOGGING_CATEGORY(SerialLinkLog, "Comms.SerialLink")
 
 namespace {
     constexpr int CONNECT_TIMEOUT_MS = 1000;

--- a/src/Comms/TCPLink.cc
+++ b/src/Comms/TCPLink.cc
@@ -16,7 +16,7 @@
 #include <QtNetwork/QHostInfo>
 #include <QtNetwork/QTcpSocket>
 
-QGC_LOGGING_CATEGORY(TCPLinkLog, "test.comms.tcplink")
+QGC_LOGGING_CATEGORY(TCPLinkLog, "Comms.TCPLink")
 
 namespace {
     constexpr int CONNECT_TIMEOUT_MS = 5000;

--- a/src/Comms/UDPLink.cc
+++ b/src/Comms/UDPLink.cc
@@ -21,7 +21,7 @@
 #include <QtNetwork/QNetworkProxy>
 #include <QtNetwork/QUdpSocket>
 
-QGC_LOGGING_CATEGORY(UDPLinkLog, "qgc.comms.udplink")
+QGC_LOGGING_CATEGORY(UDPLinkLog, "Comms.UDPLink")
 
 namespace {
     constexpr int BUFFER_TRIGGER_SIZE = 10 * 1024;

--- a/src/Comms/UdpIODevice.cc
+++ b/src/Comms/UdpIODevice.cc
@@ -10,7 +10,7 @@
 #include "UdpIODevice.h"
 #include "QGCLoggingCategory.h"
 
-QGC_LOGGING_CATEGORY(UdpIODeviceLog, "qgc.comms.udpiodevice")
+QGC_LOGGING_CATEGORY(UdpIODeviceLog, "Comms.UdpIODevice")
 
 UdpIODevice::UdpIODevice(QObject *parent)
     : QUdpSocket(parent)

--- a/src/FactSystem/Fact.cc
+++ b/src/FactSystem/Fact.cc
@@ -13,7 +13,7 @@
 #include "QGCCorePlugin.h"
 #include "QGCLoggingCategory.h"
 
-QGC_LOGGING_CATEGORY(FactLog, "qgc.factsystem.fact")
+QGC_LOGGING_CATEGORY(FactLog, "FactSystem.Fact")
 
 Fact::Fact(QObject *parent)
     : QObject(parent)

--- a/src/FactSystem/FactControls/FactPanelController.cc
+++ b/src/FactSystem/FactControls/FactPanelController.cc
@@ -17,7 +17,7 @@
 
 #include <QtQml/QQmlEngine>
 
-QGC_LOGGING_CATEGORY(FactPanelControllerLog, "qgc.factsystem.factcontrols.factpanelcontroller")
+QGC_LOGGING_CATEGORY(FactPanelControllerLog, "FactSystem.FactPanelController")
 
 FactPanelController::FactPanelController(QObject *parent)
     : QObject(parent)

--- a/src/FactSystem/FactGroup.cc
+++ b/src/FactSystem/FactGroup.cc
@@ -10,7 +10,7 @@
 #include "FactGroup.h"
 #include "QGCLoggingCategory.h"
 
-QGC_LOGGING_CATEGORY(FactGroupLog, "qgc.factsystem.factgroup")
+QGC_LOGGING_CATEGORY(FactGroupLog, "FactSystem.FactGroup")
 
 FactGroup::FactGroup(int updateRateMsecs, const QString &metaDataFile, QObject *parent, bool ignoreCamelCase)
     : QObject(parent)

--- a/src/FactSystem/FactMetaData.cc
+++ b/src/FactSystem/FactMetaData.cc
@@ -16,7 +16,7 @@
 
 #include <QtCore/QtMath>
 
-QGC_LOGGING_CATEGORY(FactMetaDataLog, "qgc.factsystem.factmetadata")
+QGC_LOGGING_CATEGORY(FactMetaDataLog, "FactSystem.FactMetaData")
 
 // Built in translations for all Facts
 const FactMetaData::BuiltInTranslation_s FactMetaData::_rgBuiltInTranslations[] = {

--- a/src/FactSystem/FactValueSliderListModel.cc
+++ b/src/FactSystem/FactValueSliderListModel.cc
@@ -13,7 +13,7 @@
 
 #include <QtCore/QtMath>
 
-QGC_LOGGING_CATEGORY(FactValueSliderListModelLog, "qgc.factsystem.factvaluesliderlistmodel")
+QGC_LOGGING_CATEGORY(FactValueSliderListModelLog, "FactSystem.FactValueSliderListModel")
 
 FactValueSliderListModel::FactValueSliderListModel(const Fact &fact, QObject *parent)
     : QAbstractListModel(parent)

--- a/src/FactSystem/ParameterManager.cc
+++ b/src/FactSystem/ParameterManager.cc
@@ -25,10 +25,10 @@
 #include <QtCore/QStandardPaths>
 #include <QtCore/QVariantAnimation>
 
-QGC_LOGGING_CATEGORY(ParameterManagerLog, "qgc.factsystem.parametermanager")
-QGC_LOGGING_CATEGORY(ParameterManagerVerbose1Log, "qgc.factsystem.parametermanager1:verbose")
-QGC_LOGGING_CATEGORY(ParameterManagerVerbose2Log, "qgc.factsystem.parametermanager2:verbose")
-QGC_LOGGING_CATEGORY(ParameterManagerDebugCacheFailureLog, "qgc.factsystem.parametermanager.debugcachefailure") // Turn on to debug parameter cache crc misses
+QGC_LOGGING_CATEGORY(ParameterManagerLog, "FactSystem.ParameterManager")
+QGC_LOGGING_CATEGORY(ParameterManagerVerbose1Log, "FactSystem.ParameterManager:verbose1")
+QGC_LOGGING_CATEGORY(ParameterManagerVerbose2Log, "FactSystem.ParameterManager:verbose2")
+QGC_LOGGING_CATEGORY(ParameterManagerDebugCacheFailureLog, "FactSystem.ParameterManager:debugCacheFailure") // Turn on to debug parameter cache crc misses
 
 ParameterManager::ParameterManager(Vehicle *vehicle)
     : QObject(vehicle)

--- a/src/FactSystem/SettingsFact.cc
+++ b/src/FactSystem/SettingsFact.cc
@@ -14,7 +14,7 @@
 
 #include <QtCore/QSettings>
 
-QGC_LOGGING_CATEGORY(SettingsFactLog, "qgc.factsystem.settingsfact")
+QGC_LOGGING_CATEGORY(SettingsFactLog, "FactSystem.SettingsFact")
 
 SettingsFact::SettingsFact(QObject *parent)
     : Fact(parent)

--- a/src/FirmwarePlugin/APM/APMFirmwarePlugin.cc
+++ b/src/FirmwarePlugin/APM/APMFirmwarePlugin.cc
@@ -34,7 +34,7 @@
 #include <QtCore/QRegularExpression>
 #include <QtCore/QRegularExpressionMatch>
 
-QGC_LOGGING_CATEGORY(APMFirmwarePluginLog, "APMFirmwarePluginLog")
+QGC_LOGGING_CATEGORY(APMFirmwarePluginLog, "FirmwarePlugin.APMFirmwarePlugin")
 
 APMFirmwarePlugin::APMFirmwarePlugin(QObject *parent)
     : FirmwarePlugin(parent)

--- a/src/FirmwarePlugin/APM/APMFirmwarePluginFactory.cc
+++ b/src/FirmwarePlugin/APM/APMFirmwarePluginFactory.cc
@@ -14,7 +14,7 @@
 #include "ArduSubFirmwarePlugin.h"
 #include "QGCLoggingCategory.h"
 
-QGC_LOGGING_CATEGORY(APMFirmwarePluginFactoryLog, "qgc.firmwareplugin.apmfirmwarepluginfactory");
+QGC_LOGGING_CATEGORY(APMFirmwarePluginFactoryLog, "FirmwarePlugin.APMFirmwarePluginFactory");
 
 APMFirmwarePluginFactory APMFirmwarePluginFactory(nullptr);
 

--- a/src/FirmwarePlugin/APM/APMParameterMetaData.cc
+++ b/src/FirmwarePlugin/APM/APMParameterMetaData.cc
@@ -15,8 +15,8 @@
 #include <QtCore/QRegularExpressionMatch>
 #include <QtCore/QStack>
 
-QGC_LOGGING_CATEGORY(APMParameterMetaDataLog, "qgc.firmwareplugin.apm.apmparametermetadata")
-QGC_LOGGING_CATEGORY(APMParameterMetaDataVerboseLog, "qgc.firmwareplugin.apm.apmparametermetadata:verbose")
+QGC_LOGGING_CATEGORY(APMParameterMetaDataLog, "FirmwarePlugin.APMParameterMetaData")
+QGC_LOGGING_CATEGORY(APMParameterMetaDataVerboseLog, "FirmwarePlugin.APMParameterMetaData:verbose")
 
 APMParameterMetaData::APMParameterMetaData(QObject *parent)
     : QObject(parent)

--- a/src/FirmwarePlugin/APM/ArduSubFirmwarePlugin.cc
+++ b/src/FirmwarePlugin/APM/ArduSubFirmwarePlugin.cc
@@ -11,7 +11,7 @@
 #include "QGCLoggingCategory.h"
 #include "Vehicle.h"
 
-QGC_LOGGING_CATEGORY(APMSubmarineFactGroupLog, "qgc.firmwareplugin.apm.ardusubfirmwareplugin")
+QGC_LOGGING_CATEGORY(APMSubmarineFactGroupLog, "FirmwarePlugin.ArduSubFirmwarePlugin")
 
 APMSubmarineFactGroup::APMSubmarineFactGroup(QObject *parent)
     : FactGroup(300, QStringLiteral(":/json/Vehicle/SubmarineFact.json"), parent)

--- a/src/FirmwarePlugin/FirmwarePlugin.cc
+++ b/src/FirmwarePlugin/FirmwarePlugin.cc
@@ -22,7 +22,7 @@
 #include <QtCore/QRegularExpression>
 #include <QtCore/QThread>
 
-QGC_LOGGING_CATEGORY(FirmwarePluginLog, "qgc.firmwareplugin.firmwareplugin")
+QGC_LOGGING_CATEGORY(FirmwarePluginLog, "FirmwarePlugin.FirmwarePlugin")
 
 static const QString guided_mode_not_supported_by_vehicle = QObject::tr("Guided mode not supported by Vehicle.");
 

--- a/src/FirmwarePlugin/FirmwarePluginFactory.cc
+++ b/src/FirmwarePlugin/FirmwarePluginFactory.cc
@@ -13,7 +13,7 @@
 
 #include <QtCore/QGlobalStatic>
 
-QGC_LOGGING_CATEGORY(FirmwarePluginFactoryLog, "qgc.firmwareplugin.firmwarepluginfactory");
+QGC_LOGGING_CATEGORY(FirmwarePluginFactoryLog, "FirmwarePlugin.FirmwarePluginFactory");
 
 /*===========================================================================*/
 

--- a/src/FirmwarePlugin/FirmwarePluginManager.cc
+++ b/src/FirmwarePlugin/FirmwarePluginManager.cc
@@ -14,7 +14,7 @@
 
 #include <QtCore/QGlobalStatic>
 
-QGC_LOGGING_CATEGORY(FirmwarePluginManagerLog, "qgc.firmwareplugin.firmwarepluginmanager");
+QGC_LOGGING_CATEGORY(FirmwarePluginManagerLog, "FirmwarePlugin.FirmwarePluginManager");
 
 Q_GLOBAL_STATIC(FirmwarePluginManager, _firmwarePluginManagerInstance);
 

--- a/src/FirmwarePlugin/PX4/PX4ParameterMetaData.cc
+++ b/src/FirmwarePlugin/PX4/PX4ParameterMetaData.cc
@@ -19,7 +19,7 @@
 #include <QtCore/QDebug>
 #include <QtCore/QXmlStreamReader>
 
-QGC_LOGGING_CATEGORY(PX4ParameterMetaDataLog, "PX4ParameterMetaDataLog")
+QGC_LOGGING_CATEGORY(PX4ParameterMetaDataLog, "FirmwarePlugin.PX4ParameterMetaData")
 
 PX4ParameterMetaData::PX4ParameterMetaData(QObject* parent)
     : QObject(parent)

--- a/src/FollowMe/FollowMe.cc
+++ b/src/FollowMe/FollowMe.cc
@@ -18,7 +18,7 @@
 
 #include <QtPositioning/QGeoPositionInfo>
 
-QGC_LOGGING_CATEGORY(FollowMeLog, "qgc.followme")
+QGC_LOGGING_CATEGORY(FollowMeLog, "API.FollowMe")
 
 Q_APPLICATION_STATIC(FollowMe, _followMeInstance);
 

--- a/src/GPS/GPSManager.cc
+++ b/src/GPS/GPSManager.cc
@@ -13,7 +13,7 @@
 
 #include <QtCore/QApplicationStatic>
 
-QGC_LOGGING_CATEGORY(GPSManagerLog, "qgc.gps.gpsmanager")
+QGC_LOGGING_CATEGORY(GPSManagerLog, "GPS.GPSManager")
 
 Q_APPLICATION_STATIC(GPSManager, _gpsManager);
 

--- a/src/GPS/GPSProvider.cc
+++ b/src/GPS/GPSProvider.cc
@@ -24,8 +24,8 @@
 #include <QtSerialPort/QSerialPort>
 #endif
 
-QGC_LOGGING_CATEGORY(GPSProviderLog, "qgc.gps.gpsprovider")
-QGC_LOGGING_CATEGORY(GPSDriversLog, "qgc.gps.drivers")
+QGC_LOGGING_CATEGORY(GPSProviderLog, "GPS.GPSProvider")
+QGC_LOGGING_CATEGORY(GPSDriversLog, "GPS.Drivers")
 
 GPSProvider::GPSProvider(const QString &device, GPSType type, const rtk_data_s &rtkData, const std::atomic_bool &requestStop, QObject *parent)
     : QThread(parent)

--- a/src/GPS/GPSRTKFactGroup.cc
+++ b/src/GPS/GPSRTKFactGroup.cc
@@ -10,7 +10,7 @@
 #include "GPSRTKFactGroup.h"
 #include "QGCLoggingCategory.h"
 
-QGC_LOGGING_CATEGORY(GPSRTKFactGroupLog, "qgc.gps.gpsrtkfactgroup")
+QGC_LOGGING_CATEGORY(GPSRTKFactGroupLog, "GPS.GPSRTKFactGroup")
 
 GPSRTKFactGroup::GPSRTKFactGroup(QObject *parent)
     : FactGroup(1000, QStringLiteral(":/json/Vehicle/GPSRTKFact.json"), parent)

--- a/src/GPS/GPSRtk.cc
+++ b/src/GPS/GPSRtk.cc
@@ -15,7 +15,7 @@
 #include "RTKSettings.h"
 #include "SettingsManager.h"
 
-QGC_LOGGING_CATEGORY(GPSRtkLog, "qgc.gps.gpsrtk")
+QGC_LOGGING_CATEGORY(GPSRtkLog, "GPS.GPSRtk")
 
 GPSRtk::GPSRtk(QObject *parent)
     : QObject(parent)

--- a/src/GPS/RTCMMavlink.cc
+++ b/src/GPS/RTCMMavlink.cc
@@ -13,7 +13,7 @@
 #include "QGCLoggingCategory.h"
 #include "Vehicle.h"
 
-QGC_LOGGING_CATEGORY(RTCMMavlinkLog, "qgc.gps.rtcmmavlink")
+QGC_LOGGING_CATEGORY(RTCMMavlinkLog, "GPS.RTCMMavlink")
 
 RTCMMavlink::RTCMMavlink(QObject *parent)
     : QObject(parent)

--- a/src/Gimbal/Gimbal.cc
+++ b/src/Gimbal/Gimbal.cc
@@ -11,7 +11,7 @@
 #include "GimbalController.h"
 #include "QGCLoggingCategory.h"
 
-QGC_LOGGING_CATEGORY(GimbalLog, "GimbalLog")
+QGC_LOGGING_CATEGORY(GimbalLog, "Gimbal.Gimbal")
 
 Gimbal::Gimbal(GimbalController *parent)
     : FactGroup(1000, QStringLiteral(":/json/Vehicle/GimbalFact.json"), parent)

--- a/src/Gimbal/GimbalController.cc
+++ b/src/Gimbal/GimbalController.cc
@@ -16,7 +16,7 @@
 #include "SettingsManager.h"
 #include "Vehicle.h"
 
-QGC_LOGGING_CATEGORY(GimbalControllerLog, "GimbalControllerLog")
+QGC_LOGGING_CATEGORY(GimbalControllerLog, "Gimbal.GimbalController")
 
 GimbalController::GimbalController(Vehicle *vehicle)
     : QObject(vehicle)

--- a/src/Joystick/Joystick.cc
+++ b/src/Joystick/Joystick.cc
@@ -24,8 +24,8 @@
 #include <QtCore/QSettings>
 #include <QtCore/QThread>
 
-QGC_LOGGING_CATEGORY(JoystickLog, "qgc.joystick.joystick")
-QGC_LOGGING_CATEGORY(JoystickValuesLog, "qgc.joystick.joystickvalues")
+QGC_LOGGING_CATEGORY(JoystickLog, "Joystick.joystick")
+QGC_LOGGING_CATEGORY(JoystickValuesLog, "Joystick.joystickvalues")
 
 /*===========================================================================*/
 

--- a/src/Joystick/JoystickAndroid.cc
+++ b/src/Joystick/JoystickAndroid.cc
@@ -15,7 +15,7 @@
 #include <QtCore/QJniEnvironment>
 #include <QtCore/QJniObject>
 
-QGC_LOGGING_CATEGORY(JoystickAndroidLog, "qgc.joystick.joystickandroid")
+QGC_LOGGING_CATEGORY(JoystickAndroidLog, "Joystick.joystickandroid")
 
 QList<int> JoystickAndroid::_androidBtnList(_androidBtnListCount);
 int JoystickAndroid::ACTION_DOWN = 0;

--- a/src/Joystick/JoystickManager.cc
+++ b/src/Joystick/JoystickManager.cc
@@ -20,7 +20,7 @@
 #include <QtCore/QApplicationStatic>
 #include <QtCore/QSettings>
 
-QGC_LOGGING_CATEGORY(JoystickManagerLog, "qgc.joystick.joystickmanager")
+QGC_LOGGING_CATEGORY(JoystickManagerLog, "Joystick.joystickmanager")
 
 Q_APPLICATION_STATIC(JoystickManager, _joystickManager);
 

--- a/src/Joystick/JoystickSDL.cc
+++ b/src/Joystick/JoystickSDL.cc
@@ -16,7 +16,7 @@
 
 #include <SDL3/SDL.h>
 
-QGC_LOGGING_CATEGORY(JoystickSDLLog, "qgc.joystick.joysticksdl")
+QGC_LOGGING_CATEGORY(JoystickSDLLog, "Joystick.joysticksdl")
 
 JoystickSDL::JoystickSDL(const QString &name, QList<int> gamepadAxes, QList<int> nonGamepadAxes, int buttonCount, int hatCount, int instanceId, bool isGamepad, QObject *parent)
     : Joystick(name, gamepadAxes.length() + nonGamepadAxes.length(), buttonCount, hatCount, parent)

--- a/src/MAVLink/ImageProtocolManager.cc
+++ b/src/MAVLink/ImageProtocolManager.cc
@@ -10,7 +10,7 @@
 #include "ImageProtocolManager.h"
 #include "QGCLoggingCategory.h"
 
-QGC_LOGGING_CATEGORY(ImageProtocolManagerLog, "qgc.mavlink.imageprotocolmanager")
+QGC_LOGGING_CATEGORY(ImageProtocolManagerLog, "MAVLink.ImageProtocolManager")
 
 ImageProtocolManager::ImageProtocolManager(QObject *parent)
     : QObject(parent)

--- a/src/MAVLink/LibEvents/logging.cpp
+++ b/src/MAVLink/LibEvents/logging.cpp
@@ -11,7 +11,7 @@
 
 #include "libevents_includes.h"
 
-QGC_LOGGING_CATEGORY(EventsLog, "EventsLog");
+QGC_LOGGING_CATEGORY(EventsLog, "API.Events")
 
 void qgc_events_parser_debug_printf(const char *fmt, ...) {
     char msg[256];

--- a/src/MAVLink/MAVLinkStreamConfig.cc
+++ b/src/MAVLink/MAVLinkStreamConfig.cc
@@ -11,7 +11,7 @@
 #include "MAVLinkLib.h"
 #include "QGCLoggingCategory.h"
 
-QGC_LOGGING_CATEGORY(MAVLinkStreamConfigLog, "qgc.mavlink.mavlinkstreamconfig")
+QGC_LOGGING_CATEGORY(MAVLinkStreamConfigLog, "MAVLink.MAVLinkStreamConfig")
 
 MAVLinkStreamConfig::MAVLinkStreamConfig(const SetMessageIntervalCb &messageIntervalCb)
     : _messageIntervalCb(messageIntervalCb)

--- a/src/MAVLink/QGCMAVLink.cc
+++ b/src/MAVLink/QGCMAVLink.cc
@@ -10,7 +10,7 @@
 #include "QGCMAVLink.h"
 #include "QGCLoggingCategory.h"
 
-QGC_LOGGING_CATEGORY(QGCMAVLinkLog, "qgc.mavlink.qgcmavlink")
+QGC_LOGGING_CATEGORY(QGCMAVLinkLog, "MAVLink.QGCMAVLink")
 
 const QHash<int, QString> QGCMAVLink::mavlinkCompIdHash {
     { MAV_COMP_ID_CAMERA,   "Camera1" },

--- a/src/MAVLink/StatusTextHandler.cc
+++ b/src/MAVLink/StatusTextHandler.cc
@@ -13,7 +13,7 @@
 #include <QtCore/QTimer>
 #include <QtCore/QDateTime>
 
-QGC_LOGGING_CATEGORY(StatusTextHandlerLog, "qgc.mavlink.statustexthandler")
+QGC_LOGGING_CATEGORY(StatusTextHandlerLog, "MAVLink.StatusTextHandler")
 
 StatusText::StatusText(MAV_COMPONENT componentid, MAV_SEVERITY severity, const QString &text)
     : m_compId(componentid)

--- a/src/MAVLink/SysStatusSensorInfo.cc
+++ b/src/MAVLink/SysStatusSensorInfo.cc
@@ -11,7 +11,7 @@
 #include "QGCLoggingCategory.h"
 #include "QGCMAVLink.h"
 
-QGC_LOGGING_CATEGORY(SysStatusSensorInfoLog, "qgc.mavlink.sysstatussensorinfo")
+QGC_LOGGING_CATEGORY(SysStatusSensorInfoLog, "MAVLink.SysStatusSensorInfo")
 
 SysStatusSensorInfo::SysStatusSensorInfo(QObject *parent)
     : QObject(parent)

--- a/src/MissionManager/CameraSection.cc
+++ b/src/MissionManager/CameraSection.cc
@@ -15,7 +15,7 @@
 #include "Vehicle.h"
 #include "QGCLoggingCategory.h"
 
-QGC_LOGGING_CATEGORY(CameraSectionLog, "CameraSectionLog")
+QGC_LOGGING_CATEGORY(CameraSectionLog, "Plan.CameraSection")
 
 QMap<QString, FactMetaData*> CameraSection::_metaDataMap;
 

--- a/src/MissionManager/CorridorScanComplexItem.cc
+++ b/src/MissionManager/CorridorScanComplexItem.cc
@@ -17,7 +17,7 @@
 
 #include <QtCore/QJsonArray>
 
-QGC_LOGGING_CATEGORY(CorridorScanComplexItemLog, "CorridorScanComplexItemLog")
+QGC_LOGGING_CATEGORY(CorridorScanComplexItemLog, "Plan.CorridorScanComplexItemL")
 
 const QString CorridorScanComplexItem::name(CorridorScanComplexItem::tr("Corridor Scan"));
 

--- a/src/MissionManager/FixedWingLandingComplexItem.cc
+++ b/src/MissionManager/FixedWingLandingComplexItem.cc
@@ -17,7 +17,7 @@
 
 #include <QtCore/QJsonArray>
 
-QGC_LOGGING_CATEGORY(FixedWingLandingComplexItemLog, "FixedWingLandingComplexItemLog")
+QGC_LOGGING_CATEGORY(FixedWingLandingComplexItemLog, "Plan.FixedWingLandingComplexItem")
 
 const QString FixedWingLandingComplexItem::name(FixedWingLandingComplexItem::tr("Fixed Wing Landing"));
 

--- a/src/MissionManager/GeoFenceController.cc
+++ b/src/MissionManager/GeoFenceController.cc
@@ -26,7 +26,7 @@
 #include <QtCore/QJsonArray>
 #include <QtCore/QJsonDocument>
 
-QGC_LOGGING_CATEGORY(GeoFenceControllerLog, "GeoFenceControllerLog")
+QGC_LOGGING_CATEGORY(GeoFenceControllerLog, "PlanManager.GeoFenceController")
 
 QMap<QString, FactMetaData*> GeoFenceController::_metaDataMap;
 

--- a/src/MissionManager/GeoFenceManager.cc
+++ b/src/MissionManager/GeoFenceManager.cc
@@ -12,7 +12,7 @@
 #include "QmlObjectListModel.h"
 #include "QGCLoggingCategory.h"
 
-QGC_LOGGING_CATEGORY(GeoFenceManagerLog, "GeoFenceManagerLog")
+QGC_LOGGING_CATEGORY(GeoFenceManagerLog, "PlanManager.GeoFenceManager")
 
 GeoFenceManager::GeoFenceManager(Vehicle* vehicle)
     : PlanManager       (vehicle, MAV_MISSION_TYPE_FENCE)

--- a/src/MissionManager/LandingComplexItem.cc
+++ b/src/MissionManager/LandingComplexItem.cc
@@ -22,7 +22,7 @@
 #include "Vehicle.h"
 #include "QGCLoggingCategory.h"
 
-QGC_LOGGING_CATEGORY(LandingComplexItemLog, "LandingComplexItemLog")
+QGC_LOGGING_CATEGORY(LandingComplexItemLog, "Plan.LandingComplexItem")
 
 LandingComplexItem::LandingComplexItem(PlanMasterController* masterController, bool flyView)
     : ComplexMissionItem        (masterController, flyView)

--- a/src/MissionManager/MissionCommandTree.cc
+++ b/src/MissionManager/MissionCommandTree.cc
@@ -17,7 +17,7 @@
 
 #include <QtCore/QApplicationStatic>
 
-QGC_LOGGING_CATEGORY(MissionCommandTreeLog, "qgc.missionmanager.missioncommandtree");
+QGC_LOGGING_CATEGORY(MissionCommandTreeLog, "Plan.MissionCommandTree");
 
 Q_APPLICATION_STATIC(MissionCommandTree, _missionCommandTreeInstance);
 

--- a/src/MissionManager/MissionCommandUIInfo.cc
+++ b/src/MissionManager/MissionCommandUIInfo.cc
@@ -12,7 +12,7 @@
 #include "FactMetaData.h"
 #include "QGCLoggingCategory.h"
 
-QGC_LOGGING_CATEGORY(MissionCommandsLog, "MissionCommandsLog")
+QGC_LOGGING_CATEGORY(MissionCommandsLog, "Plan.MissionCommands")
 
 MissionCmdParamInfo::MissionCmdParamInfo(QObject* parent)
     : QObject(parent)

--- a/src/MissionManager/MissionController.cc
+++ b/src/MissionManager/MissionController.cc
@@ -38,7 +38,7 @@
 
 #define UPDATE_TIMEOUT 5000 ///< How often we check for bounding box changes
 
-QGC_LOGGING_CATEGORY(MissionControllerLog, "MissionControllerLog")
+QGC_LOGGING_CATEGORY(MissionControllerLog, "PlanManager.MissionController")
 
 MissionController::MissionController(PlanMasterController* masterController, QObject *parent)
     : PlanElementController (masterController, parent)

--- a/src/MissionManager/MissionManager.cc
+++ b/src/MissionManager/MissionManager.cc
@@ -16,7 +16,7 @@
 #include "MissionCommandUIInfo.h"
 #include "QGCLoggingCategory.h"
 
-QGC_LOGGING_CATEGORY(MissionManagerLog, "MissionManagerLog")
+QGC_LOGGING_CATEGORY(MissionManagerLog, "PlanManager.MissionManager")
 
 MissionManager::MissionManager(Vehicle* vehicle)
     : PlanManager               (vehicle, MAV_MISSION_TYPE_MISSION)

--- a/src/MissionManager/MissionSettingsItem.cc
+++ b/src/MissionManager/MissionSettingsItem.cc
@@ -16,7 +16,7 @@
 
 #include <QtCore/QJsonArray>
 
-QGC_LOGGING_CATEGORY(MissionSettingsItemLog, "MissionSettingsItemLog")
+QGC_LOGGING_CATEGORY(MissionSettingsItemLog, "Plan.MissionSettingsItem")
 
 QMap<QString, FactMetaData*> MissionSettingsItem::_metaDataMap;
 

--- a/src/MissionManager/PlanManager.cc
+++ b/src/MissionManager/PlanManager.cc
@@ -15,7 +15,7 @@
 #include "MissionCommandTree.h"
 #include "QGCLoggingCategory.h"
 
-QGC_LOGGING_CATEGORY(PlanManagerLog, "PlanManagerLog")
+QGC_LOGGING_CATEGORY(PlanManagerLog, "PlanManager.PlanManager")
 
 PlanManager::PlanManager(Vehicle* vehicle, MAV_MISSION_TYPE planType)
     : QObject                   (vehicle)

--- a/src/MissionManager/PlanMasterController.cc
+++ b/src/MissionManager/PlanMasterController.cc
@@ -29,7 +29,7 @@
 #include <QtCore/QJsonDocument>
 #include <QtCore/QFileInfo>
 
-QGC_LOGGING_CATEGORY(PlanMasterControllerLog, "PlanMasterControllerLog")
+QGC_LOGGING_CATEGORY(PlanMasterControllerLog, "PlanManager.PlanMasterController")
 
 PlanMasterController::PlanMasterController(QObject* parent)
     : QObject               (parent)

--- a/src/MissionManager/RallyPointController.cc
+++ b/src/MissionManager/RallyPointController.cc
@@ -20,7 +20,7 @@
 
 #include <QtCore/QJsonArray>
 
-QGC_LOGGING_CATEGORY(RallyPointControllerLog, "RallyPointControllerLog")
+QGC_LOGGING_CATEGORY(RallyPointControllerLog, "PlanManager.RallyPointController")
 
 RallyPointController::RallyPointController(PlanMasterController* masterController, QObject* parent)
     : PlanElementController (masterController, parent)

--- a/src/MissionManager/RallyPointManager.cc
+++ b/src/MissionManager/RallyPointManager.cc
@@ -11,7 +11,7 @@
 #include "Vehicle.h"
 #include "QGCLoggingCategory.h"
 
-QGC_LOGGING_CATEGORY(RallyPointManagerLog, "RallyPointManagerLog")
+QGC_LOGGING_CATEGORY(RallyPointManagerLog, "PlanManager.RallyPointManager")
 
 RallyPointManager::RallyPointManager(Vehicle* vehicle)
     : PlanManager(vehicle, MAV_MISSION_TYPE_RALLY)

--- a/src/MissionManager/StructureScanComplexItem.cc
+++ b/src/MissionManager/StructureScanComplexItem.cc
@@ -20,7 +20,7 @@
 
 #include <QtCore/QJsonArray>
 
-QGC_LOGGING_CATEGORY(StructureScanComplexItemLog, "StructureScanComplexItemLog")
+QGC_LOGGING_CATEGORY(StructureScanComplexItemLog, "Plan.StructureScanComplexItem")
 
 const QString StructureScanComplexItem::name(StructureScanComplexItem::tr("Structure Scan"));
 
@@ -29,7 +29,7 @@ StructureScanComplexItem::StructureScanComplexItem(PlanMasterController* masterC
     , _metaDataMap              (FactMetaData::createMapFromJsonFile(QStringLiteral(":/json/StructureScan.SettingsGroup.json"), this /* QObject parent */))
     , _sequenceNumber           (0)
     , _entryVertex              (0)
-    , _ignoreRecalc             (false)
+, _ignoreRecalc             (false)
     , _scanDistance             (0.0)
     , _cameraShots              (0)
     , _cameraCalc               (masterController, settingsGroup)

--- a/src/MissionManager/SurveyComplexItem.cc
+++ b/src/MissionManager/SurveyComplexItem.cc
@@ -24,7 +24,7 @@
 #include <QtCore/QJsonArray>
 #include <QtCore/QLineF>
 
-QGC_LOGGING_CATEGORY(SurveyComplexItemLog, "SurveyComplexItemLog")
+QGC_LOGGING_CATEGORY(SurveyComplexItemLog, "Plan.SurveyComplexItem")
 
 const QString SurveyComplexItem::name(SurveyComplexItem::tr("Survey"));
 

--- a/src/MissionManager/TransectStyleComplexItem.cc
+++ b/src/MissionManager/TransectStyleComplexItem.cc
@@ -23,7 +23,7 @@
 
 #include <QtCore/QJsonArray>
 
-QGC_LOGGING_CATEGORY(TransectStyleComplexItemLog, "TransectStyleComplexItemLog")
+QGC_LOGGING_CATEGORY(TransectStyleComplexItemLog, "Plan.TransectStyleComplexItem")
 
 TransectStyleComplexItem::TransectStyleComplexItem(PlanMasterController* masterController, bool flyView, QString settingsGroup)
     : ComplexMissionItem                (masterController, flyView)

--- a/src/MissionManager/VTOLLandingComplexItem.cc
+++ b/src/MissionManager/VTOLLandingComplexItem.cc
@@ -20,7 +20,7 @@
 
 #include <QtCore/QJsonArray>
 
-QGC_LOGGING_CATEGORY(VTOLLandingComplexItemLog, "VTOLLandingComplexItemLog")
+QGC_LOGGING_CATEGORY(VTOLLandingComplexItemLog, "Plan.VTOLLandingComplexItem")
 
 const QString VTOLLandingComplexItem::name(VTOLLandingComplexItem::tr("VTOL Landing"));
 

--- a/src/PositionManager/PositionManager.cpp
+++ b/src/PositionManager/PositionManager.cpp
@@ -20,7 +20,7 @@
 #include <QtPositioning/private/qgeopositioninfosource_p.h>
 #include <QtPositioning/QNmeaPositionInfoSource>
 
-QGC_LOGGING_CATEGORY(QGCPositionManagerLog, "qgc.positionmanager.positionmanager")
+QGC_LOGGING_CATEGORY(QGCPositionManagerLog, "PositionManager.QGCPositionManager")
 
 Q_APPLICATION_STATIC(QGCPositionManager, _positionManager);
 

--- a/src/PositionManager/SimulatedPosition.cc
+++ b/src/PositionManager/SimulatedPosition.cc
@@ -16,7 +16,7 @@
 #include <QtCore/QDateTime>
 #include <QtCore/QTimer>
 
-QGC_LOGGING_CATEGORY(SimulatedPositionLog, "qgc.positionmanager.simulatedposition")
+QGC_LOGGING_CATEGORY(SimulatedPositionLog, "PositionManager.SimulatedPosition")
 
 SimulatedPosition::SimulatedPosition(QObject* parent)
     : QGeoPositionInfoSource(parent)

--- a/src/QGCApplication.cc
+++ b/src/QGCApplication.cc
@@ -52,7 +52,7 @@
 #include "SerialLink.h"
 #endif
 
-QGC_LOGGING_CATEGORY(QGCApplicationLog, "qgc.qgcapplication")
+QGC_LOGGING_CATEGORY(QGCApplicationLog, "API.QGCApplication")
 
 QGCApplication::QGCApplication(int &argc, char *argv[], const QGCCommandLineParser::CommandLineParseResult &cli)
     : QApplication(argc, argv)
@@ -143,7 +143,7 @@ QGCApplication::QGCApplication(int &argc, char *argv[], const QGCCommandLinePars
     }
 
     // Set up our logging filters
-    QGCLoggingCategoryRegister::instance()->setFilterRulesFromSettings(loggingOptions);
+    QGCLoggingCategoryManager::instance()->setFilterRulesFromSettings(loggingOptions);
 
     // We need to set language as early as possible prior to loading on JSON files.
     setLanguage();

--- a/src/QmlControls/AppMessages.qml
+++ b/src/QmlControls/AppMessages.qml
@@ -156,96 +156,132 @@ Item {
         id: filtersDialogComponent
 
         QGCPopupDialog {
-            title:      qsTr("Logging categories")
+            title:      qsTr("Logging")
             buttons:    Dialog.Close
 
-            property int enabledCategoryCount: 0
-
-            function clearAllLogging() {
-                var logCategories = QGroundControl.loggingCategories()
-                for (var category of logCategories) {
-                    QGroundControl.setCategoryLoggingOn(category, false)
-                }
-                QGroundControl.updateLoggingFilterRules()
-                categoryRepeater.model = undefined
-                categoryRepeater.model = QGroundControl.loggingCategories()
-                enabledCategoryCount = 0
-                enabledCategoryRepeater.model = undefined
-                enabledCategoryRepeater.model = QGroundControl.loggingCategories()
-            }
-
-            function updateLoggingCategory(logCategory, checked, rebuildCategoryList) {
-                QGroundControl.setCategoryLoggingOn(logCategory, checked)
-                QGroundControl.updateLoggingFilterRules()
-                enabledCategoryCount = 0
-                enabledCategoryRepeater.model = undefined
-                enabledCategoryRepeater.model = QGroundControl.loggingCategories()
-                if (rebuildCategoryList) {
-                    categoryRepeater.model = undefined
-                    categoryRepeater.model = QGroundControl.loggingCategories()
-                }
-            }
-
             ColumnLayout {
-                RowLayout {
-                    spacing: ScreenTools.defaultFontPixelHeight / 2
-                    Layout.alignment: Qt.AlignVCenter
-                    Layout.fillHeight: true
-                    Layout.fillWidth: true
+                SettingsGroupLayout {
+                    heading:            qsTr("Search")
+                    Layout.fillWidth:   true
 
-                    QGCLabel {
-                        text: qsTr("Search:")
-                    }
+                    RowLayout {
+                        Layout.fillWidth:   true
+                        spacing:            ScreenTools.defaultFontPixelHeight / 2
 
-                    QGCTextField {
-                        id: searchText
-                        text: ""
-                        Layout.fillWidth: true
-                        enabled: true
-                    }
+                        QGCTextField {
+                            Layout.fillWidth:   true
+                            id:                 searchText
+                            text:               ""
+                            enabled:            true
+                        }
 
-                    QGCButton {
-                        text:       qsTr("Clear")
-                        onClicked:  searchText.text = ""
-                    }
-                }
-
-                ColumnLayout {
-                    spacing: ScreenTools.defaultFontPixelHeight / 2
-
-                    Repeater {
-                        id:     enabledCategoryRepeater
-                        model:  QGroundControl.loggingCategories()
-
-                        QGCCheckBox {
-                            text:       modelData
-                            visible:    QGroundControl.categoryLoggingOn(modelData)
-                            checked:    QGroundControl.categoryLoggingOn(modelData)
-                            onClicked:  updateLoggingCategory(modelData, checked, true /* rebuildCategoryList */)
-
-                            Component.onCompleted: enabledCategoryCount += checked ? 1 : 0
+                        QGCButton {
+                            text:       qsTr("Clear")
+                            onClicked:  searchText.text = ""
                         }
                     }
+                }
 
-                    QGCButton {
-                        text:       qsTr("Clear All")
-                        visible:    enabledCategoryCount > 0
-                        onClicked:  clearAllLogging()
+                SettingsGroupLayout {
+                    heading:            qsTr("Enabled Categories")
+                    Layout.fillWidth:   true
+
+                    ColumnLayout {
+                        spacing: ScreenTools.defaultFontPixelHeight / 2
+
+                        Repeater {
+                            model: QGroundControl.flatLoggingCategoriesModel()
+
+                            QGCCheckBoxSlider {
+                                Layout.fillWidth:       true
+                                Layout.maximumHeight:   visible ? implicitHeight : 0
+                                text:                   object.fullCategory
+                                visible:                object.enabled
+                                checked:                object.enabled
+                                onClicked:              object.enabled = checked
+                            }
+                        }
+
+                        QGCButton {
+                            text:       qsTr("Disable All")
+                            onClicked:  QGroundControl.disableAllLoggingCategories()
+                        }
                     }
                 }
 
-                ColumnLayout {
-                    spacing: ScreenTools.defaultFontPixelHeight / 2
+                // Hierarchical view of categories, only shown when there is no search filter
+                SettingsGroupLayout {
+                    heading:            qsTr("Categories")
+                    Layout.fillWidth:   true
+                    visible:            searchText.text === ""
 
-                    Repeater {
-                        id:     categoryRepeater
-                        model:  QGroundControl.loggingCategories()
+                    ColumnLayout {
+                        spacing: ScreenTools.defaultFontPixelHeight / 2
 
-                        QGCCheckBox {
-                            text:       modelData
-                            visible:    searchText.text ? text.match(`(${searchText.text})`, "i") : true
-                            checked:    QGroundControl.categoryLoggingOn(modelData)
-                            onClicked:  updateLoggingCategory(modelData, checked, false /* rebuildCategoryList */)
+                        Repeater {
+                            model: QGroundControl.treeLoggingCategoriesModel()
+
+                            ColumnLayout {
+                                spacing: ScreenTools.defaultFontPixelHeight / 2
+
+                                RowLayout {
+                                    spacing:                ScreenTools.defaultFontPixelWidth
+
+                                    QGCLabel {
+                                        Layout.preferredWidth:  ScreenTools.defaultFontPixelWidth
+                                        text:                   object.expanded ? qsTr("-") : qsTr("+")
+                                        horizontalAlignment:    Text.AlignLeft
+                                        visible:                object.children
+
+                                        QGCMouseArea {
+                                            anchors.fill:   parent
+                                            onClicked:      object.expanded = !object.expanded
+                                        }
+                                    }
+
+                                    QGCCheckBoxSlider {
+                                        Layout.fillWidth:   true
+                                        text:               object.shortCategory
+                                        checked:            object.enabled
+                                        onClicked:          object.enabled = checked
+                                    }
+                                }
+
+                                Repeater {
+                                    model: object.expanded ? object.children : undefined
+
+                                    QGCCheckBoxSlider {
+                                        Layout.fillWidth:   true
+                                        text:               "   " + object.shortCategory
+                                        checked:            object.enabled
+                                        onClicked:          object.enabled = checked
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+
+                // Float view of categories, for search results
+                SettingsGroupLayout {
+                    heading:            qsTr("Categories")
+                    Layout.fillWidth:   true
+                    visible:            searchText.text !== ""
+
+                    ColumnLayout {
+                        spacing: ScreenTools.defaultFontPixelHeight / 2
+
+                        Repeater {
+                            model: QGroundControl.flatLoggingCategoriesModel()
+
+                            QGCCheckBoxSlider {
+                                Layout.fillWidth:       true
+                                Layout.maximumHeight:   visible ? implicitHeight : 0
+                                text:                   object.fullCategory
+                                visible:                text.match(`(${searchText.text})`, "i")
+                                checked:                object.enabled
+                                onClicked:              object.enabled = checked
+                            }
                         }
                     }
                 }

--- a/src/QmlControls/EditPositionDialogController.cc
+++ b/src/QmlControls/EditPositionDialogController.cc
@@ -13,7 +13,7 @@
 #include "Vehicle.h"
 #include "QGCLoggingCategory.h"
 
-QGC_LOGGING_CATEGORY(EditPositionDialogControllerLog, "qgc.qmlcontrols.editpositiondialogcontroller")
+QGC_LOGGING_CATEGORY(EditPositionDialogControllerLog, "QMLControls.EditPositionDialogController")
 
 QMap<QString, FactMetaData*> EditPositionDialogController::_metaDataMap;
 

--- a/src/QmlControls/FlightPathSegment.cc
+++ b/src/QmlControls/FlightPathSegment.cc
@@ -11,7 +11,7 @@
 #include "QGC.h"
 #include "QGCLoggingCategory.h"
 
-QGC_LOGGING_CATEGORY(FlightPathSegmentLog, "FlightPathSegmentLog")
+QGC_LOGGING_CATEGORY(FlightPathSegmentLog, "Plan.FlightPathSegment")
 
 FlightPathSegment::FlightPathSegment(SegmentType segmentType, const QGeoCoordinate& coord1, double amslCoord1Alt, const QGeoCoordinate& coord2, double amslCoord2Alt, bool queryTerrainData, QObject* parent)
     : QObject           (parent)

--- a/src/QmlControls/MavlinkAction.cc
+++ b/src/QmlControls/MavlinkAction.cc
@@ -11,7 +11,7 @@
 #include "Vehicle.h"
 #include "QGCLoggingCategory.h"
 
-QGC_LOGGING_CATEGORY(MavlinkActionLog, "qgc.qmlcontrols.mavlinkaction")
+QGC_LOGGING_CATEGORY(MavlinkActionLog, "QMLControls.MavlinkAction")
 
 MavlinkAction::MavlinkAction(QObject *parent)
     : QObject(parent)

--- a/src/QmlControls/MavlinkActionManager.cc
+++ b/src/QmlControls/MavlinkActionManager.cc
@@ -21,7 +21,7 @@
 #include <QtCore/QJsonArray>
 #include <QtQml/QQmlEngine>
 
-QGC_LOGGING_CATEGORY(MavlinkActionManagerLog, "qgc.qmlcontrols.mavlinkactionmanager")
+QGC_LOGGING_CATEGORY(MavlinkActionManagerLog, "QMLControls.MavlinkActionManager")
 
 MavlinkActionManager::MavlinkActionManager(QObject *parent)
     : QObject(parent)

--- a/src/QmlControls/ParameterEditorController.cc
+++ b/src/QmlControls/ParameterEditorController.cc
@@ -14,7 +14,7 @@
 #include "Vehicle.h"
 #include "QGCLoggingCategory.h"
 
-QGC_LOGGING_CATEGORY(ParameterEditorControllerLog, "qgc.qmlcontrols.parametereditorcontroller")
+QGC_LOGGING_CATEGORY(ParameterEditorControllerLog, "QMLControls.ParameterEditorController")
 
 ParameterTableModel::ParameterTableModel(QObject* parent)
     : QAbstractTableModel(parent)

--- a/src/QmlControls/QGCFileDialogController.cc
+++ b/src/QmlControls/QGCFileDialogController.cc
@@ -15,7 +15,7 @@
 
 #include <QtCore/QDir>
 
-QGC_LOGGING_CATEGORY(QGCFileDialogControllerLog, "qgc.qmlcontrols.qgcfiledialogcontroller")
+QGC_LOGGING_CATEGORY(QGCFileDialogControllerLog, "QMLControls.QGCFileDialogController")
 
 QGCFileDialogController::QGCFileDialogController(QObject *parent)
     : QObject(parent)

--- a/src/QmlControls/QGroundControlQmlGlobal.cc
+++ b/src/QmlControls/QGroundControlQmlGlobal.cc
@@ -41,7 +41,7 @@
 #include <QtCore/QSettings>
 #include <QtCore/QLineF>
 
-QGC_LOGGING_CATEGORY(GuidedActionsControllerLog, "GuidedActionsControllerLog")
+QGC_LOGGING_CATEGORY(GuidedActionsControllerLog, "QMLControls.GuidedActionsController")
 
 QGeoCoordinate QGroundControlQmlGlobal::_coord = QGeoCoordinate(0.0,0.0);
 double QGroundControlQmlGlobal::_zoom = 2;
@@ -350,22 +350,27 @@ void QGroundControlQmlGlobal::clearDeleteAllSettingsNextBoot()
     QGCApplication::clearDeleteAllSettingsNextBoot();
 }
 
-QStringList QGroundControlQmlGlobal::loggingCategories()
+QmlObjectListModel *QGroundControlQmlGlobal::treeLoggingCategoriesModel()
 {
-    return QGCLoggingCategoryRegister::instance()->registeredCategories();
+    return QGCLoggingCategoryManager::instance()->treeCategoryModel();
+}
+
+QmlObjectListModel *QGroundControlQmlGlobal::flatLoggingCategoriesModel()
+{
+    return QGCLoggingCategoryManager::instance()->flatCategoryModel();
 }
 
 void QGroundControlQmlGlobal::setCategoryLoggingOn(const QString &category, bool enable)
 {
-    QGCLoggingCategoryRegister::setCategoryLoggingOn(category, enable);
+    QGCLoggingCategoryManager::instance()->setCategoryLoggingOn(category, enable);
 }
 
 bool QGroundControlQmlGlobal::categoryLoggingOn(const QString &category)
 {
-    return QGCLoggingCategoryRegister::categoryLoggingOn(category);
+    return QGCLoggingCategoryManager::categoryLoggingOn(category);
 }
 
-void QGroundControlQmlGlobal::updateLoggingFilterRules()
+void QGroundControlQmlGlobal::disableAllLoggingCategories()
 {
-    QGCLoggingCategoryRegister::instance()->setFilterRulesFromSettings(QString());
+    QGCLoggingCategoryManager::instance()->disableAllCategories();
 }

--- a/src/QmlControls/QGroundControlQmlGlobal.h
+++ b/src/QmlControls/QGroundControlQmlGlobal.h
@@ -32,6 +32,7 @@ class SettingsManager;
 class VideoManager;
 class UTMSPManager;
 class AirLinkManager;
+class QmlObjectListModel;
 
 Q_MOC_INCLUDE("ADSBVehicleManager.h")
 Q_MOC_INCLUDE("FactGroup.h")
@@ -144,8 +145,11 @@ public:
     Q_INVOKABLE void    startAPMArduRoverMockLink   (bool sendStatusText);
     Q_INVOKABLE void    stopOneMockLink             (void);
 
-    /// Returns the list of available logging category names.
-    Q_INVOKABLE static QStringList loggingCategories();
+    /// Returns the hierarchical list of available logging category names.
+    Q_INVOKABLE static QmlObjectListModel *treeLoggingCategoriesModel();
+
+    /// Returns the flat list of available logging category names.
+    Q_INVOKABLE static QmlObjectListModel *flatLoggingCategoriesModel();
 
     /// Turns on/off logging for the specified category. State is saved in app settings.
     Q_INVOKABLE static void setCategoryLoggingOn(const QString &category, bool enable);
@@ -153,8 +157,7 @@ public:
     /// Returns true if logging is turned on for the specified category.
     Q_INVOKABLE static bool categoryLoggingOn(const QString &category);
 
-    /// Updates the logging filter rules after settings have changed
-    Q_INVOKABLE static void updateLoggingFilterRules();
+    Q_INVOKABLE static void disableAllLoggingCategories();
 
     Q_INVOKABLE bool linesIntersect(QPointF xLine1, QPointF yLine1, QPointF xLine2, QPointF yLine2);
 

--- a/src/QmlControls/QmlObjectListModel.cc
+++ b/src/QmlControls/QmlObjectListModel.cc
@@ -13,14 +13,14 @@
 #include <QtCore/QDebug>
 #include <QtQml/QQmlEngine>
 
-QGC_LOGGING_CATEGORY(QmlObjectListModelLog, "QmlObjectListModelLog")
+QGC_LOGGING_CATEGORY(QmlObjectListModelLog, "API.QmlObjectListModel")
 
 QmlObjectListModel::QmlObjectListModel(QObject* parent)
     : QAbstractListModel        (parent)
     , _dirty                    (false)
     , _skipDirtyFirstItem       (false)
 {
-
+    QQmlEngine::setObjectOwnership(this, QQmlEngine::CppOwnership);
 }
 
 QmlObjectListModel::~QmlObjectListModel()

--- a/src/QmlControls/RCChannelMonitorController.cc
+++ b/src/QmlControls/RCChannelMonitorController.cc
@@ -12,7 +12,7 @@
 #include "Vehicle.h"
 #include "QGCLoggingCategory.h"
 
-QGC_LOGGING_CATEGORY(RCChannelMonitorControllerLog, "qgc.qmlcontrols.rcchannelmonitorcontroller")
+QGC_LOGGING_CATEGORY(RCChannelMonitorControllerLog, "QMLControls.RCChannelMonitorController")
 
 RCChannelMonitorController::RCChannelMonitorController(QObject *parent)
     : FactPanelController(parent)

--- a/src/QmlControls/RCToParamDialogController.cc
+++ b/src/QmlControls/RCToParamDialogController.cc
@@ -14,7 +14,7 @@
 #include "QGCLoggingCategory.h"
 #include "Fact.h"
 
-QGC_LOGGING_CATEGORY(RCToParamDialogControllerLog, "qgc.qmlcontrols.rctoparamdialogcontroller")
+QGC_LOGGING_CATEGORY(RCToParamDialogControllerLog, "QMLControls.RCToParamDialogController")
 
 QMap<QString, FactMetaData*> RCToParamDialogController::_metaDataMap;
 

--- a/src/QmlControls/ScreenToolsController.cc
+++ b/src/QmlControls/ScreenToolsController.cc
@@ -26,7 +26,7 @@
 #include <sys/utsname.h>
 #endif
 
-QGC_LOGGING_CATEGORY(ScreenToolsControllerLog, "qgc.qmlcontrols.screentoolscontroller")
+QGC_LOGGING_CATEGORY(ScreenToolsControllerLog, "QMLControls.ScreenToolsController")
 
 ScreenToolsController::ScreenToolsController(QObject *parent)
     : QObject(parent)

--- a/src/QmlControls/TerrainProfile.cc
+++ b/src/QmlControls/TerrainProfile.cc
@@ -17,7 +17,7 @@
 
 #include <QtQuick/QSGFlatColorMaterial>
 
-QGC_LOGGING_CATEGORY(TerrainProfileLog, "TerrainProfileLog")
+QGC_LOGGING_CATEGORY(TerrainProfileLog, "Terrain.TerrainProfile")
 
 TerrainProfile::TerrainProfile(QQuickItem* parent)
     : QQuickItem(parent)

--- a/src/QtLocationPlugin/Providers/MapProvider.cpp
+++ b/src/QtLocationPlugin/Providers/MapProvider.cpp
@@ -12,7 +12,7 @@
 
 #include <QtCore/QLocale>
 
-QGC_LOGGING_CATEGORY(MapProviderLog, "qgc.qtlocationplugin.mapprovider")
+QGC_LOGGING_CATEGORY(MapProviderLog, "QtLocationPlugin.MapProvider")
 
 // QtLocation expects MapIds to start at 1 and be sequential.
 int MapProvider::_mapIdIndex = 1;

--- a/src/QtLocationPlugin/QGCCachedTileSet.cpp
+++ b/src/QtLocationPlugin/QGCCachedTileSet.cpp
@@ -22,7 +22,7 @@
 #include "QGeoFileTileCacheQGC.h"
 #include "QGeoTileFetcherQGC.h"
 
-QGC_LOGGING_CATEGORY(QGCCachedTileSetLog, "qgc.qtlocation.qgccachedtileset")
+QGC_LOGGING_CATEGORY(QGCCachedTileSetLog, "QtLocationPlugin.QGCCachedTileSet")
 
 QGCCachedTileSet::QGCCachedTileSet(const QString &name, QObject *parent)
     : QObject(parent)

--- a/src/QtLocationPlugin/QGCMapEngine.cpp
+++ b/src/QtLocationPlugin/QGCMapEngine.cpp
@@ -20,7 +20,7 @@
 #include "QGCTileSet.h"
 #include "QGeoFileTileCacheQGC.h"
 
-QGC_LOGGING_CATEGORY(QGCMapEngineLog, "qgc.qtlocationplugin.qgcmapengine")
+QGC_LOGGING_CATEGORY(QGCMapEngineLog, "QtLocationPlugin.QGCMapEngine")
 
 Q_APPLICATION_STATIC(QGCMapEngine, _mapEngine);
 

--- a/src/QtLocationPlugin/QGCMapEngineManager.cc
+++ b/src/QtLocationPlugin/QGCMapEngineManager.cc
@@ -28,7 +28,7 @@
 
 using namespace Qt::StringLiterals;
 
-QGC_LOGGING_CATEGORY(QGCMapEngineManagerLog, "qgc.qtlocation.qmlcontrol.qgcmapenginemanagerlog")
+QGC_LOGGING_CATEGORY(QGCMapEngineManagerLog, "QtLocationPlugin.QGCMapEngineManager")
 
 Q_APPLICATION_STATIC(QGCMapEngineManager, _mapEngineManager);
 

--- a/src/QtLocationPlugin/QGCMapUrlEngine.cpp
+++ b/src/QtLocationPlugin/QGCMapUrlEngine.cpp
@@ -19,7 +19,7 @@
 #include "MapboxMapProvider.h"
 #include "QGCLoggingCategory.h"
 
-QGC_LOGGING_CATEGORY(QGCMapUrlEngineLog, "qgc.qtlocationplugin.qgcmapurlengine")
+QGC_LOGGING_CATEGORY(QGCMapUrlEngineLog, "QtLocationPlugin.QGCMapUrlEngine")
 
 const QList<SharedMapProvider> UrlFactory::_providers = {
 #ifndef QGC_NO_GOOGLE_MAPS

--- a/src/QtLocationPlugin/QGCTileCacheWorker.cpp
+++ b/src/QtLocationPlugin/QGCTileCacheWorker.cpp
@@ -22,7 +22,7 @@
 #include "QGCMapTasks.h"
 #include "QGCMapUrlEngine.h"
 
-QGC_LOGGING_CATEGORY(QGCTileCacheWorkerLog, "qgc.qtlocationplugin.qgctilecacheworker")
+QGC_LOGGING_CATEGORY(QGCTileCacheWorkerLog, "QtLocationPlugin.QGCTileCacheWorker")
 
 QGCCacheWorker::QGCCacheWorker(QObject *parent)
     : QThread(parent)

--- a/src/QtLocationPlugin/QGeoFileTileCacheQGC.cpp
+++ b/src/QtLocationPlugin/QGeoFileTileCacheQGC.cpp
@@ -22,7 +22,7 @@
 #include "QGCMapUrlEngine.h"
 #include "SettingsManager.h"
 
-QGC_LOGGING_CATEGORY(QGeoFileTileCacheQGCLog, "qgc.qtlocationplugin.qgeofiletilecacheqgc")
+QGC_LOGGING_CATEGORY(QGeoFileTileCacheQGCLog, "QtLocationPlugin.QGeoFileTileCacheQGC")
 
 QString QGeoFileTileCacheQGC::_databaseFilePath;
 QString QGeoFileTileCacheQGC::_cachePath;

--- a/src/QtLocationPlugin/QGeoMapReplyQGC.cpp
+++ b/src/QtLocationPlugin/QGeoMapReplyQGC.cpp
@@ -23,7 +23,7 @@
 #include "QGCMapUrlEngine.h"
 #include "QGeoFileTileCacheQGC.h"
 
-QGC_LOGGING_CATEGORY(QGeoTiledMapReplyQGCLog, "qgc.qtlocationplugin.qgeomapreplyqgc")
+QGC_LOGGING_CATEGORY(QGeoTiledMapReplyQGCLog, "QtLocationPlugin.QGeoTiledMapReplyQGC")
 
 QByteArray QGeoTiledMapReplyQGC::_bingNoTileImage;
 QByteArray QGeoTiledMapReplyQGC::_badTile;

--- a/src/QtLocationPlugin/QGeoServiceProviderPluginQGC.cpp
+++ b/src/QtLocationPlugin/QGeoServiceProviderPluginQGC.cpp
@@ -15,7 +15,7 @@
 #include "QGCLoggingCategory.h"
 #include "QGeoTiledMappingManagerEngineQGC.h"
 
-QGC_LOGGING_CATEGORY(QGeoServiceProviderFactoryQGCLog, "qgc.qtlocationplugin.qgeoserviceproviderfactoryqgc")
+QGC_LOGGING_CATEGORY(QGeoServiceProviderFactoryQGCLog, "QtLocationPlugin.QGeoServiceProviderFactoryQGC")
 
 QGeoServiceProviderFactoryQGC::QGeoServiceProviderFactoryQGC(QObject *parent)
     : QObject(parent)

--- a/src/QtLocationPlugin/QGeoTileFetcherQGC.cpp
+++ b/src/QtLocationPlugin/QGeoTileFetcherQGC.cpp
@@ -19,7 +19,7 @@
 #include "QGeoMapReplyQGC.h"
 #include "QGeoTiledMappingManagerEngineQGC.h"
 
-QGC_LOGGING_CATEGORY(QGeoTileFetcherQGCLog, "qgc.qtlocationplugin.qgeotilefetcherqgc")
+QGC_LOGGING_CATEGORY(QGeoTileFetcherQGCLog, "QtLocationPlugin.QGeoTileFetcherQGC")
 
 QGeoTileFetcherQGC::QGeoTileFetcherQGC(QNetworkAccessManager *networkManager, const QVariantMap &parameters, QGeoTiledMappingManagerEngineQGC *parent)
     : QGeoTileFetcher(parent)

--- a/src/QtLocationPlugin/QGeoTiledMapQGC.cpp
+++ b/src/QtLocationPlugin/QGeoTiledMapQGC.cpp
@@ -12,7 +12,7 @@
 #include "QGCLoggingCategory.h"
 #include "QGeoTiledMappingManagerEngineQGC.h"
 
-QGC_LOGGING_CATEGORY(QGeoTiledMapQGCLog, "qgc.qtlocationplugin.qgeotiledmapqgc")
+QGC_LOGGING_CATEGORY(QGeoTiledMapQGCLog, "QtLocationPlugin.QGeoTiledMapQGC")
 
 QGeoTiledMapQGC::QGeoTiledMapQGC(QGeoTiledMappingManagerEngineQGC *engine, QObject *parent)
     : QGeoTiledMap(engine, parent)

--- a/src/QtLocationPlugin/QGeoTiledMappingManagerEngineQGC.cpp
+++ b/src/QtLocationPlugin/QGeoTiledMappingManagerEngineQGC.cpp
@@ -32,7 +32,7 @@
 #include "QGeoTiledMapQGC.h"
 #include "QGeoTileFetcherQGC.h"
 
-QGC_LOGGING_CATEGORY(QGeoTiledMappingManagerEngineQGCLog, "qgc.qtlocationplugin.qgeotiledmappingmanagerengineqgc")
+QGC_LOGGING_CATEGORY(QGeoTiledMappingManagerEngineQGCLog, "QtLocationPlugin.QGeoTiledMappingManagerEngineQGC")
 
 QGeoTiledMappingManagerEngineQGC::QGeoTiledMappingManagerEngineQGC(const QVariantMap &parameters, QGeoServiceProvider::Error *error, QString *errorString, QNetworkAccessManager *networkManager, QObject *parent)
     : QGeoTiledMappingManagerEngine(parent)

--- a/src/Settings/SettingsManager.cc
+++ b/src/Settings/SettingsManager.cc
@@ -38,7 +38,7 @@
 #include <QtCore/QApplicationStatic>
 #include <QtQml/qqml.h>
 
-QGC_LOGGING_CATEGORY(SettingsManagerLog, "qgc.settings.settingsmanager")
+QGC_LOGGING_CATEGORY(SettingsManagerLog, "Utilties.SettingsManager")
 
 Q_APPLICATION_STATIC(SettingsManager, _settingsManagerInstance);
 

--- a/src/Terrain/Providers/TerrainQueryCopernicus.cc
+++ b/src/Terrain/Providers/TerrainQueryCopernicus.cc
@@ -24,7 +24,7 @@
 #include <QtNetwork/QSslConfiguration>
 #include <QtPositioning/QGeoCoordinate>
 
-QGC_LOGGING_CATEGORY(TerrainQueryCopernicusLog, "qgc.terrain.terrainquerycopernicus")
+QGC_LOGGING_CATEGORY(TerrainQueryCopernicusLog, "Terrain.TerrainQueryCopernicus")
 
 TerrainQueryCopernicus::TerrainQueryCopernicus(QObject *parent)
     : TerrainOnlineQuery(parent)

--- a/src/Terrain/Providers/TerrainTileCopernicus.cc
+++ b/src/Terrain/Providers/TerrainTileCopernicus.cc
@@ -15,7 +15,7 @@
 #include <QtCore/QJsonObject>
 #include <QtCore/QJsonArray>
 
-QGC_LOGGING_CATEGORY(TerrainTileCopernicusLog, "qgc.terrain.terraintilecopernicus");
+QGC_LOGGING_CATEGORY(TerrainTileCopernicusLog, "Terrain.TerrainTileCopernicus");
 
 TerrainTileCopernicus::TerrainTileCopernicus(const QByteArray &byteArray)
     : TerrainTile(byteArray)

--- a/src/Terrain/TerrainQuery.cc
+++ b/src/Terrain/TerrainQuery.cc
@@ -14,8 +14,8 @@
 
 #include <QtCore/QTimer>
 
-QGC_LOGGING_CATEGORY(TerrainQueryLog, "qgc.terrain.terrainquery")
-QGC_LOGGING_CATEGORY(TerrainQueryVerboseLog, "qgc.terrain.terrainquery.verbose")
+QGC_LOGGING_CATEGORY(TerrainQueryLog, "Terrain.TerrainQuery")
+QGC_LOGGING_CATEGORY(TerrainQueryVerboseLog, "Terrain.TerrainQuery:verbose")
 
 Q_GLOBAL_STATIC(TerrainAtCoordinateBatchManager, _terrainAtCoordinateBatchManager)
 

--- a/src/Terrain/TerrainQueryInterface.cc
+++ b/src/Terrain/TerrainQueryInterface.cc
@@ -15,7 +15,7 @@
 #include <QtNetwork/QNetworkProxy>
 #include <QtPositioning/QGeoCoordinate>
 
-QGC_LOGGING_CATEGORY(TerrainQueryInterfaceLog, "qgc.terrain.terrainqueryinterface")
+QGC_LOGGING_CATEGORY(TerrainQueryInterfaceLog, "Terrain.TerrainQueryInterface")
 
 TerrainQueryInterface::TerrainQueryInterface(QObject *parent)
     : QObject(parent)

--- a/src/Terrain/TerrainTile.cc
+++ b/src/Terrain/TerrainTile.cc
@@ -13,7 +13,7 @@
 #include <QtCore/QtNumeric>
 #include <QtPositioning/QGeoCoordinate>
 
-QGC_LOGGING_CATEGORY(TerrainTileLog, "qgc.terrain.terraintile");
+QGC_LOGGING_CATEGORY(TerrainTileLog, "Terrain.terraintile");
 
 TerrainTile::TerrainTile(const QByteArray &byteArray)
     : _tileInfo(*reinterpret_cast<const TileInfo_t*>(byteArray.constData()))

--- a/src/Terrain/TerrainTileManager.cc
+++ b/src/Terrain/TerrainTileManager.cc
@@ -23,7 +23,7 @@
 #include <QtNetwork/QNetworkProxy>
 #include <QtNetwork/QNetworkRequest>
 
-QGC_LOGGING_CATEGORY(TerrainTileManagerLog, "qgc.terrain.terraintilemanager")
+QGC_LOGGING_CATEGORY(TerrainTileManagerLog, "Terrain.TerrainTileManager")
 
 Q_GLOBAL_STATIC(TerrainTileManager, _terrainTileManager)
 

--- a/src/Utilities/Audio/AudioOutput.cc
+++ b/src/Utilities/Audio/AudioOutput.cc
@@ -16,7 +16,7 @@
 #include <QtCore/QApplicationStatic>
 #include <QtTextToSpeech/QTextToSpeech>
 
-QGC_LOGGING_CATEGORY(AudioOutputLog, "qgc.audio.audiooutput");
+QGC_LOGGING_CATEGORY(AudioOutputLog, "Utilities.AudioOutput");
 // qt.speech.tts.flite
 // qt.speech.tts.android
 

--- a/src/Utilities/Compression/QGCLZMA.cc
+++ b/src/Utilities/Compression/QGCLZMA.cc
@@ -16,7 +16,7 @@
 
 #include <xz.h>
 
-QGC_LOGGING_CATEGORY(QGCLZMALog, "qgc.compression.qgclzma")
+QGC_LOGGING_CATEGORY(QGCLZMALog, "Utilities.Compression.QGCLZMA")
 
 namespace QGCLZMA {
 

--- a/src/Utilities/Compression/QGCZip.cc
+++ b/src/Utilities/Compression/QGCZip.cc
@@ -5,7 +5,7 @@
 #include <QtCore/private/qzipreader_p.h>
 #include <QtCore/private/qzipwriter_p.h>
 
-QGC_LOGGING_CATEGORY(QGCZipLog, "qgc.utilities.compression.qgczip")
+QGC_LOGGING_CATEGORY(QGCZipLog, "Utilities.QGCZip")
 
 namespace QGCZip {
 

--- a/src/Utilities/Compression/QGCZlib.cc
+++ b/src/Utilities/Compression/QGCZlib.cc
@@ -14,7 +14,7 @@
 
 #include <zlib.h>
 
-QGC_LOGGING_CATEGORY(QGCZlibLog, "qgc.compression.qgczlib")
+QGC_LOGGING_CATEGORY(QGCZlibLog, "Utilities.Compression.QGCZlib")
 
 namespace QGCZlib
 {

--- a/src/Utilities/DeviceInfo.cc
+++ b/src/Utilities/DeviceInfo.cc
@@ -16,7 +16,7 @@
 #    include <QtBluetooth/QBluetoothLocalDevice>
 #endif
 
-QGC_LOGGING_CATEGORY(QGCDeviceInfoLog, "qgc.utilities.deviceinfo")
+QGC_LOGGING_CATEGORY(QGCDeviceInfoLog, "Utilities.QGCDeviceInfo")
 
 namespace QGCDeviceInfo
 {

--- a/src/Utilities/FileSystem/QGCCachedFileDownload.cc
+++ b/src/Utilities/FileSystem/QGCCachedFileDownload.cc
@@ -14,7 +14,7 @@
 #include <QtCore/QDateTime>
 #include <QtNetwork/QNetworkDiskCache>
 
-QGC_LOGGING_CATEGORY(QGCCachedFileDownloadLog, "qgc.utilities.qgccachedfiledownload");
+QGC_LOGGING_CATEGORY(QGCCachedFileDownloadLog, "Utilities.QGCCachedFileDownload");
 
 QGCCachedFileDownload::QGCCachedFileDownload(const QString &cacheDirectory, QObject *parent)
     : QObject(parent)

--- a/src/Utilities/FileSystem/QGCFileDownload.cc
+++ b/src/Utilities/FileSystem/QGCFileDownload.cc
@@ -14,7 +14,7 @@
 #include <QtCore/QStandardPaths>
 #include <QtNetwork/QNetworkProxy>
 
-QGC_LOGGING_CATEGORY(QGCFileDownloadLog, "qgc.utilities.qgcfiledownload");
+QGC_LOGGING_CATEGORY(QGCFileDownloadLog, "Utilities.QGCFileDownload");
 
 QGCFileDownload::QGCFileDownload(QObject *parent)
     : QObject(parent)

--- a/src/Utilities/FileSystem/QGCTemporaryFile.cc
+++ b/src/Utilities/FileSystem/QGCTemporaryFile.cc
@@ -14,7 +14,7 @@
 #include <QtCore/QRandomGenerator>
 #include <QtCore/QStandardPaths>
 
-QGC_LOGGING_CATEGORY(QGCTemporaryFileLog, "qgc.utilities.qgctemporaryfile");
+QGC_LOGGING_CATEGORY(QGCTemporaryFileLog, "Utilities.QGCTemporaryFile");
 
 QGCTemporaryFile::QGCTemporaryFile(const QString &fileTemplate, QObject *parent)
     : QFile(parent)

--- a/src/Utilities/Geo/GeoJsonHelper.cc
+++ b/src/Utilities/Geo/GeoJsonHelper.cc
@@ -18,7 +18,7 @@
 #include <QtPositioning/QGeoPath>
 #include <QtPositioning/QGeoPolygon>
 
-QGC_LOGGING_CATEGORY(GeoJsonHelperLog, "qgc.utilities.shape.geojsonhelper")
+QGC_LOGGING_CATEGORY(GeoJsonHelperLog, "Utilities.GeoJsonHelper")
 
 namespace GeoJsonHelper
 {

--- a/src/Utilities/Geo/KMLDomDocument.cc
+++ b/src/Utilities/Geo/KMLDomDocument.cc
@@ -13,7 +13,7 @@
 #include <QtGui/QColor>
 #include <QtPositioning/QGeoCoordinate>
 
-QGC_LOGGING_CATEGORY(KMLDomDocumentLog, "qgc.utilities.geo.kmldomdocument")
+QGC_LOGGING_CATEGORY(KMLDomDocumentLog, "Utilities.KMLDomDocument")
 
 KMLDomDocument::KMLDomDocument(const QString &name)
 {

--- a/src/Utilities/Geo/KMLHelper.cc
+++ b/src/Utilities/Geo/KMLHelper.cc
@@ -13,7 +13,7 @@
 #include <QtCore/QFile>
 #include <QtXml/QDomDocument>
 
-QGC_LOGGING_CATEGORY(KMLHelperLog, "qgc.utilities.geo.kmlhelper")
+QGC_LOGGING_CATEGORY(KMLHelperLog, "Utilities.KMLHelper")
 
 namespace KMLHelper
 {

--- a/src/Utilities/Geo/QGCGeo.cc
+++ b/src/Utilities/Geo/QGCGeo.cc
@@ -23,7 +23,7 @@
 
 #include <limits>
 
-QGC_LOGGING_CATEGORY(QGCGeoLog, "qgc.utilities.geo.qgcgeo")
+QGC_LOGGING_CATEGORY(QGCGeoLog, "Utilities.QGCGeo")
 
 namespace
 {

--- a/src/Utilities/Geo/SHPFileHelper.cc
+++ b/src/Utilities/Geo/SHPFileHelper.cc
@@ -16,7 +16,7 @@
 
 #include "shapefil.h"
 
-QGC_LOGGING_CATEGORY(SHPFileHelperLog, "qgc.utilities.geo.shpfilehelper")
+QGC_LOGGING_CATEGORY(SHPFileHelperLog, "Utilities.SHPFileHelper")
 
 namespace SHPFileHelper
 {

--- a/src/Utilities/Geo/ShapeFileHelper.cc
+++ b/src/Utilities/Geo/ShapeFileHelper.cc
@@ -12,7 +12,7 @@
 #include "SHPFileHelper.h"
 #include "QGCLoggingCategory.h"
 
-QGC_LOGGING_CATEGORY(ShapeFileHelperLog, "qgc.utilities.geo.shapefilehelper")
+QGC_LOGGING_CATEGORY(ShapeFileHelperLog, "Utilities.ShapeFileHelper")
 
 bool ShapeFileHelper::_fileIsKML(const QString &file, QString &errorString)
 {

--- a/src/Utilities/JsonHelper.cc
+++ b/src/Utilities/JsonHelper.cc
@@ -22,7 +22,7 @@
 #include <QtCore/QObject>
 #include <QtCore/QTranslator>
 
-QGC_LOGGING_CATEGORY(JsonHelperLog, "qgc.utilities.jsonhelper")
+QGC_LOGGING_CATEGORY(JsonHelperLog, "Utilities.JsonHelper")
 
 Q_APPLICATION_STATIC(QTranslator, s_jsonTranslator);
 

--- a/src/Utilities/QGCLogging.cc
+++ b/src/Utilities/QGCLogging.cc
@@ -18,7 +18,7 @@
 #include <QtCore/QStringListModel>
 #include <QtCore/QTextStream>
 
-QGC_LOGGING_CATEGORY(QGCLoggingLog, "qgc.utilities.qgclogging")
+QGC_LOGGING_CATEGORY(QGCLoggingLog, "Utilities.QGCLogging")
 
 Q_GLOBAL_STATIC(QGCLogging, _qgcLogging)
 

--- a/src/Utilities/QGCLoggingCategory.cc
+++ b/src/Utilities/QGCLoggingCategory.cc
@@ -12,110 +12,194 @@
 #include <QtCore/QGlobalStatic>
 #include <QtCore/QSettings>
 
-QGC_LOGGING_CATEGORY(QGCLoggingCategoryRegisterLog, "qgc.utilities.qgcloggingcategory")
+QGC_LOGGING_CATEGORY(QGCLoggingCategoryRegisterLog, "Utilities.QGCLoggingCategoryManager")
+QGC_LOGGING_CATEGORY(QGCLoggingCategoryRegisterVerboseLog, "Utilities.QGCLoggingCategoryManager:verbose")
 
-Q_GLOBAL_STATIC(QGCLoggingCategoryRegister, _QGCLoggingCategoryRegisterInstance);
+Q_GLOBAL_STATIC(QGCLoggingCategoryManager, _QGCLoggingCategoryManagerInstance);
 
-static QLoggingCategory::CategoryFilter defaultCategoryFilter = nullptr;
-
-static void qgcCategoryFilter(QLoggingCategory *category)
+QGCLoggingCategoryManager *QGCLoggingCategoryManager::instance()
 {
-    if (defaultCategoryFilter) {
-        defaultCategoryFilter(category);
+    return _QGCLoggingCategoryManagerInstance();
+}
+
+void QGCLoggingCategoryManager::_insertSorted(QmlObjectListModel* model, QGCLoggingCategoryItem* item)
+{
+    for (int i=0; i<model->count(); i++) {
+        auto existingItem = qobject_cast<QGCLoggingCategoryItem*>(model->get(i));
+        if (item->fullCategory < existingItem->fullCategory) {
+            model->insert(i, item);
+            return;
+        }
+    }
+    model->append(item);
+}
+
+void QGCLoggingCategoryManager::registerCategory(const QString &fullCategory) 
+{ 
+    qCDebug(QGCLoggingCategoryRegisterVerboseLog) << "Registering logging full category" << fullCategory;
+
+    QString parentCategory;
+    QString childCategory(fullCategory);
+    auto currentParentModel = &_treeCategoryModel;
+
+    auto hierarchyIndex = fullCategory.indexOf(".");
+    if (hierarchyIndex != -1) {
+        parentCategory = fullCategory.left(hierarchyIndex);
+        childCategory = fullCategory.mid(hierarchyIndex + 1);
+        QString fullParentCategory = parentCategory + ".";
+        qCDebug(QGCLoggingCategoryRegisterVerboseLog) << "  Parent category" << parentCategory << "child category" << childCategory << "full parent category" << fullParentCategory;
+        
+        bool found = false;
+        for (int j=0; j<currentParentModel->count(); j++) {
+            auto item = qobject_cast<QGCLoggingCategoryItem*>(currentParentModel->get(j));
+            if (item->fullCategory == fullParentCategory && item->children) {
+                qCDebug(QGCLoggingCategoryRegisterVerboseLog) << "  Found existing parent full category" << item->fullCategory;
+                currentParentModel = item->children;
+                found = true;
+                break;
+            }
+        }
+        if (!found) {
+            auto newParentItem = new QGCLoggingCategoryItem(parentCategory, fullParentCategory, false /* enabled */, currentParentModel);
+            newParentItem->children = new QmlObjectListModel(newParentItem);
+            _insertSorted(&_flatCategoryModel, newParentItem);
+            _insertSorted(currentParentModel, newParentItem);
+            currentParentModel = newParentItem->children;
+            qCDebug(QGCLoggingCategoryRegisterVerboseLog) << "  New parent full category" << newParentItem->fullCategory;
+        }
     }
 
-    // const QString categoryName = QString(category->categoryName());
-    // if (qstrncmp(category->categoryName(), "qgc.", 4) == 0) {
-        // QGCLoggingCategoryRegister::instance()->registerCategory(category->categoryName());
-        // category->setEnabled(QtDebugMsg, true);
-    // }
+    auto categoryItem = new QGCLoggingCategoryItem(childCategory, fullCategory, false /* enabled */, currentParentModel);
+    _insertSorted(&_flatCategoryModel, categoryItem);
+    _insertSorted(currentParentModel, categoryItem);
+    qCDebug(QGCLoggingCategoryRegisterVerboseLog) << "  New category full category" << categoryItem->fullCategory << "childCategory" << childCategory;
 }
 
-QGCLoggingCategoryRegister *QGCLoggingCategoryRegister::instance()
+void QGCLoggingCategoryManager::setCategoryLoggingOn(const QString &fullCategoryName, bool enable)
 {
-    return _QGCLoggingCategoryRegisterInstance();
+    qCDebug(QGCLoggingCategoryRegisterLog) << "Set category logging" << fullCategoryName << enable;
+    
+    QSettings settings;
+    settings.beginGroup(kFilterRulesSettingsGroup);
+    if (enable) {
+        settings.setValue(fullCategoryName, enable);
+    } else {
+        settings.remove(fullCategoryName);
+    }
+
+    setFilterRulesFromSettings(QString());
 }
 
-QStringList QGCLoggingCategoryRegister::registeredCategories()
-{
-    _registeredCategories.sort();
-    return _registeredCategories;
-}
-
-void QGCLoggingCategoryRegister::setCategoryLoggingOn(const QString &category, bool enable)
+bool QGCLoggingCategoryManager::categoryLoggingOn(const QString &fullCategoryName)
 {
     QSettings settings;
 
     settings.beginGroup(kFilterRulesSettingsGroup);
-    settings.setValue(category, enable);
-
-    settings.endGroup();
+    return settings.value(fullCategoryName, false).toBool();
 }
 
-bool QGCLoggingCategoryRegister::categoryLoggingOn(const QString &category)
+void QGCLoggingCategoryManager::setFilterRulesFromSettings(const QString &commandLineLoggingOptions)
 {
-    QSettings settings;
-
-    settings.beginGroup(kFilterRulesSettingsGroup);
-    return settings.value(category, false).toBool();
-}
-
-void QGCLoggingCategoryRegister::setFilterRulesFromSettings(const QString &commandLineLoggingOptions) const
-{
-    static const QString filterRuleFormat = QStringLiteral("%1.debug=true\n");
-    bool videoAllLogSet = false;
-
     QString filterRules;
-    filterRules += QStringLiteral("*Log.debug=false\n");
-    filterRules += QStringLiteral("qgc.*.debug=false\n");
+    QString filterRuleFormat("%1.debug=true\n");
 
-    // Set up filters defined in settings
-    for (const QString &category : std::as_const(_registeredCategories)) {
-        if (categoryLoggingOn(category)) {
-            filterRules += filterRuleFormat.arg(category);
-            if (category == kVideoAllLogCategory) {
-                videoAllLogSet = true;
+    QSettings settings;
+    settings.beginGroup(kFilterRulesSettingsGroup);
+    for (const QString &fullCategoryName : settings.childKeys()) {
+        QString parentCategory;
+        QString childCategory;
+        _splitFullCategoryName(fullCategoryName, parentCategory, childCategory);
+
+        qCDebug(QGCLoggingCategoryRegisterLog) << "Setting filter rule for saved settings" << fullCategoryName << parentCategory << childCategory << settings.value(fullCategoryName).toBool();
+
+        auto categoryItem = _findLoggingCategory(fullCategoryName);
+        if (categoryItem) {
+            categoryItem->setEnabled(settings.value(fullCategoryName).toBool());
+            if (categoryItem->enabled()) {
+                if (childCategory.isEmpty()) {
+                    // Wildcard parent category
+                    filterRules += filterRuleFormat.arg(fullCategoryName + "*");
+                } else {
+                    filterRules += filterRuleFormat.arg(fullCategoryName);
+                }
             }
+        } else {
+            qCWarning(QGCLoggingCategoryRegisterLog) << "Category not found for saved settings" << fullCategoryName;
         }
     }
 
     // Command line rules take precedence, so they go last in the list
     if (!commandLineLoggingOptions.isEmpty()) {
-        const QStringList logList = commandLineLoggingOptions.split(",");
+        const QStringList categoryList = commandLineLoggingOptions.split(",");
 
-        if (logList[0] == QStringLiteral("full")) {
-            filterRules += QStringLiteral("*Log.debug=true\n");
-            for (const QString &log : logList) {
-                filterRules += filterRuleFormat.arg(log);
-            }
+        if (categoryList[0] == QStringLiteral("full")) {
+            filterRules += filterRuleFormat.arg("*");
         } else {
-            for (const QString &category: logList) {
+            for (const QString &category: categoryList) {
                 filterRules += filterRuleFormat.arg(category);
-                if (category == kVideoAllLogCategory) {
-                    videoAllLogSet = true;
-                }
             }
         }
     }
 
-    if (videoAllLogSet) {
-        filterRules += filterRuleFormat.arg("qgc.videomanager.videomanager");
-        filterRules += filterRuleFormat.arg("qgc.videomanager.subtitlewriter");
-        filterRules += filterRuleFormat.arg("qgc.videomanager.videoreceiver.gstreamer");
-        filterRules += filterRuleFormat.arg("qgc.videomanager.videoreceiver.gstreamer.gstvideoreceiver");
-        filterRules += filterRuleFormat.arg("qgc.videomanager.videoreceiver.qtmultimedia.qtmultimediareceiver");
-        filterRules += filterRuleFormat.arg("qgc.videomanager.videoreceiver.qtmultimedia.uvcreceiver");
-    }
-
-    // Logging from GStreamer library itself controlled by gstreamer debug levels is always turned on
-    filterRules += filterRuleFormat.arg("qgc.videomanager.videoreceiver.gstreamer.api");
-
-    filterRules += QStringLiteral("qt.qml.connections=false");
+    //filterRules += QStringLiteral("qt.qml.connections=false");
 
     qCDebug(QGCLoggingCategoryRegisterLog) << "Filter rules" << filterRules;
-    const QLoggingCategory::CategoryFilter categoryFilter = QLoggingCategory::installFilter(qgcCategoryFilter);
-    if (!defaultCategoryFilter) {
-        defaultCategoryFilter = categoryFilter;
-    }
     QLoggingCategory::setFilterRules(filterRules);
+}
+
+void QGCLoggingCategoryManager::_splitFullCategoryName(const QString &fullCategoryName, QString &parentCategory, QString &childCategory)
+{
+    const int hierarchyIndex = fullCategoryName.indexOf(".");
+    if (hierarchyIndex == -1) {
+        parentCategory = QString();
+        childCategory = fullCategoryName;
+    } else {
+        parentCategory = fullCategoryName.left(hierarchyIndex);
+        childCategory = fullCategoryName.mid(hierarchyIndex + 1);
+    }
+}
+
+void QGCLoggingCategoryManager::disableAllCategories()
+{
+    QSettings settings;
+    settings.beginGroup(kFilterRulesSettingsGroup);
+    settings.remove("");
+
+    for (int i=0; i<_flatCategoryModel.count(); i++) {
+        auto item = qobject_cast<QGCLoggingCategoryItem*>(_flatCategoryModel.get(i));
+        item->setEnabled(false);
+    }
+
+    setFilterRulesFromSettings(QString());
+}
+
+QGCLoggingCategoryItem *QGCLoggingCategoryManager::_findLoggingCategory(const QString &fullCategoryName)
+{
+    for (int i=0; i<_flatCategoryModel.count(); i++) {
+        auto item = qobject_cast<QGCLoggingCategoryItem*>(_flatCategoryModel.get(i));
+        if (item->fullCategory == fullCategoryName) {
+            return item;
+        }
+    }
+
+    return nullptr;
+}
+
+QGCLoggingCategoryItem::QGCLoggingCategoryItem(const QString& _shortCategory, const QString& _fullCategory, bool _enabled, QObject* parent)
+    : QObject(parent)
+    , shortCategory(_shortCategory)
+    , fullCategory(_fullCategory)
+    , _enabled(_enabled)
+{
+    connect(this, &QGCLoggingCategoryItem::enabledChanged, this, [this]() {
+        QGCLoggingCategoryManager::instance()->setCategoryLoggingOn(this->fullCategory, this->_enabled);
+    });
+}
+
+void QGCLoggingCategoryItem::setEnabled(bool enabled)
+{
+    if (enabled != _enabled) {
+        _enabled = enabled;
+        emit enabledChanged();
+    }
 }

--- a/src/Utilities/QGCLoggingCategory.h
+++ b/src/Utilities/QGCLoggingCategory.h
@@ -9,44 +9,63 @@
 
 #pragma once
 
+#include "QmlObjectListModel.h"
+
 #include <QtCore/QLoggingCategory>
 #include <QtCore/QObject>
 #include <QtCore/QStringList>
+#include <QtCore/QMap>
+
+class QGCLoggingCategoryItem;
 
 /// This is a QGC specific replacement for Q_LOGGING_CATEGORY. It will register the category name into a
 /// global list. It's usage is the same as Q_LOGGING_CATEOGRY.
-#define QGC_LOGGING_CATEGORY(name, ...) \
-    static QGCLoggingCategory qgcCategory ## name (__VA_ARGS__); \
-    Q_LOGGING_CATEGORY(name, __VA_ARGS__)
+#define QGC_LOGGING_CATEGORY(name, categoryStr) \
+    static QGCLoggingCategory qgcCategory ## name (categoryStr); \
+    Q_LOGGING_CATEGORY(name, categoryStr, QtWarningMsg)
 
-class QGCLoggingCategoryRegister : public QObject
+#define QGC_LOGGING_CATEGORY_ON(name, categoryStr) \
+    static QGCLoggingCategory qgcCategory ## name (categoryStr); \
+    Q_LOGGING_CATEGORY(name, categoryStr, QtInfoMsg)
+
+class QGCLoggingCategoryManager : public QObject
 {
     Q_GADGET
 
 public:
-    static QGCLoggingCategoryRegister *instance();
+    static QGCLoggingCategoryManager *instance();
 
     /// Registers the specified logging category to the system.
-    void registerCategory(const QString &category) { _registeredCategories << category; }
+    void registerCategory(const QString &category);
 
-    /// Returns the list of available logging category names.
-    Q_INVOKABLE QStringList registeredCategories();
+    /// Returns the hierarchical list of available logging category names.
+    QmlObjectListModel *treeCategoryModel() { return &_treeCategoryModel; }
 
-    /// Turns on/off logging for the specified category. State is saved in app settings.
-    Q_INVOKABLE static void setCategoryLoggingOn(const QString &category, bool enable);
+    /// Returns the flat list of available logging category names.
+    QmlObjectListModel *flatCategoryModel() { return &_flatCategoryModel; }
 
     /// Returns true if logging is turned on for the specified category.
-    Q_INVOKABLE static bool categoryLoggingOn(const QString &category);
+    static bool categoryLoggingOn(const QString &fullCategroryName);
 
     /// Sets the logging filters rules from saved settings.
     ///     @param commandLineLogggingOptions Logging options which were specified on the command line
-    void setFilterRulesFromSettings(const QString &commandLineLoggingOptions) const;
+    void setFilterRulesFromSettings(const QString &commandLineLoggingOptions);
+
+    void disableAllCategories();
+
+public slots:
+    /// Turns on/off logging for the specified category. State is saved in app settings.
+    void setCategoryLoggingOn(const QString &fullCategoryName, bool enable);
 
 private:
-    QStringList _registeredCategories;
+    static void _splitFullCategoryName(const QString &fullCategoryName, QString &parentCategory, QString &childCategory);
+    QGCLoggingCategoryItem *_findLoggingCategory(const QString &fullCategoryName);
+    void _insertSorted(QmlObjectListModel* model, QGCLoggingCategoryItem* item);
+
+    QmlObjectListModel _treeCategoryModel;
+    QmlObjectListModel _flatCategoryModel;
 
     static constexpr const char *kFilterRulesSettingsGroup = "LoggingFilters";
-    static constexpr const char *kVideoAllLogCategory = "VideoAllLog";
 };
 
 /*===========================================================================*/
@@ -54,5 +73,32 @@ private:
 class QGCLoggingCategory
 {
 public:
-    QGCLoggingCategory(const QString &category) { QGCLoggingCategoryRegister::instance()->registerCategory(category); }
+    QGCLoggingCategory(const QString &category) { QGCLoggingCategoryManager::instance()->registerCategory(category); }
+};
+
+class QGCLoggingCategoryItem : public QObject
+{
+    Q_OBJECT
+
+    Q_PROPERTY(QString  shortCategory   MEMBER shortCategory   CONSTANT)
+    Q_PROPERTY(QString  fullCategory    MEMBER fullCategory    CONSTANT)
+    Q_PROPERTY(bool     enabled         READ enabled WRITE setEnabled NOTIFY enabledChanged)
+    Q_PROPERTY(bool     expanded        MEMBER expanded        NOTIFY expandedChanged)
+    Q_PROPERTY(QmlObjectListModel* children MEMBER children CONSTANT)
+
+public:
+    QGCLoggingCategoryItem(const QString& shortCategory, const QString& fullCategory, bool enabled, QObject* parent = nullptr);
+
+    bool enabled() const { return _enabled; }
+    void setEnabled(bool enabled);
+
+    QString shortCategory;
+    QString fullCategory;
+    bool _enabled = false;
+    bool expanded = false;
+    QmlObjectListModel* children = nullptr;
+
+signals:
+    void enabledChanged();
+    void expandedChanged();
 };

--- a/src/Utilities/SignalHandler.cc
+++ b/src/Utilities/SignalHandler.cc
@@ -18,7 +18,7 @@
 
 #include "QGCLoggingCategory.h"
 
-QGC_LOGGING_CATEGORY(SignalHandlerLog, "qgc.utilities.signalhandler")
+QGC_LOGGING_CATEGORY(SignalHandlerLog, "Utilities.SignalHandler")
 
 std::atomic<SignalHandler*> SignalHandler::s_current{nullptr};
 

--- a/src/Utilities/StateMachine.cc
+++ b/src/Utilities/StateMachine.cc
@@ -10,7 +10,7 @@
 #include "StateMachine.h"
 #include "QGCLoggingCategory.h"
 
-QGC_LOGGING_CATEGORY(StateMachineLog, "qgc.utilities.statemachine");
+QGC_LOGGING_CATEGORY(StateMachineLog, "Utilities.StateMachine");
 
 StateMachine::StateMachine(QObject *parent)
     : QObject(parent)

--- a/src/Vehicle/Actuators/Common.cc
+++ b/src/Vehicle/Actuators/Common.cc
@@ -11,7 +11,7 @@
 #include "ParameterManager.h"
 #include "QGCLoggingCategory.h"
 
-QGC_LOGGING_CATEGORY(ActuatorsConfigLog, "ActuatorsConfigLog")
+QGC_LOGGING_CATEGORY(ActuatorsConfigLog, "Vehicle.ActuatorsConfig")
 
 
 void Parameter::parse(const QJsonValue& jsonValue)

--- a/src/Vehicle/ComponentInformation/CompInfoGeneral.cc
+++ b/src/Vehicle/ComponentInformation/CompInfoGeneral.cc
@@ -14,7 +14,7 @@
 #include <QtCore/QJsonDocument>
 #include <QtCore/QJsonArray>
 
-QGC_LOGGING_CATEGORY(CompInfoGeneralLog, "CompInfoGeneralLog")
+QGC_LOGGING_CATEGORY(CompInfoGeneralLog, "ComponentInformation.CompInfoGeneral")
 
 CompInfoGeneral::CompInfoGeneral(uint8_t compId, Vehicle* vehicle, QObject* parent)
     : CompInfo(COMP_METADATA_TYPE_GENERAL, compId, vehicle, parent)

--- a/src/Vehicle/ComponentInformation/CompInfoParam.cc
+++ b/src/Vehicle/ComponentInformation/CompInfoParam.cc
@@ -22,7 +22,7 @@
 #include <QtCore/QRegularExpressionMatch>
 #include <QtCore/QDir>
 
-QGC_LOGGING_CATEGORY(CompInfoParamLog, "CompInfoParamLog")
+QGC_LOGGING_CATEGORY(CompInfoParamLog, "ComponentInformation.CompInfoParam")
 
 CompInfoParam::CompInfoParam(uint8_t compId, Vehicle* vehicle, QObject* parent)
     : CompInfo(COMP_METADATA_TYPE_PARAMETER, compId, vehicle, parent)

--- a/src/Vehicle/ComponentInformation/ComponentInformationCache.cc
+++ b/src/Vehicle/ComponentInformation/ComponentInformationCache.cc
@@ -14,7 +14,7 @@
 #include <QtCore/QDirIterator>
 #include <QtCore/QStandardPaths>
 
-QGC_LOGGING_CATEGORY(ComponentInformationCacheLog, "ComponentInformationCacheLog")
+QGC_LOGGING_CATEGORY(ComponentInformationCacheLog, "ComponentInformation.ComponentInformationCache")
 
 ComponentInformationCache::ComponentInformationCache(const QDir& path, int maxNumFiles)
     : _path(path), _maxNumFiles(maxNumFiles)

--- a/src/Vehicle/ComponentInformation/ComponentInformationManager.cc
+++ b/src/Vehicle/ComponentInformation/ComponentInformationManager.cc
@@ -23,7 +23,7 @@
 
 #include <QtCore/QStandardPaths>
 
-QGC_LOGGING_CATEGORY(ComponentInformationManagerLog, "qgc.vehicle.components.componentinformationmanager")
+QGC_LOGGING_CATEGORY(ComponentInformationManagerLog, "Vehicle.ComponentInformationManager")
 
 ComponentInformationManager::ComponentInformationManager(Vehicle *vehicle, QObject *parent)
     : StateMachine(parent)

--- a/src/Vehicle/ComponentInformation/ComponentInformationTranslation.cc
+++ b/src/Vehicle/ComponentInformation/ComponentInformationTranslation.cc
@@ -20,7 +20,7 @@
 #include <QtCore/QJsonDocument>
 #include <QtCore/QXmlStreamReader>
 
-QGC_LOGGING_CATEGORY(ComponentInformationTranslationLog, "ComponentInformationTranslationLog")
+QGC_LOGGING_CATEGORY(ComponentInformationTranslationLog, "ComponentInformation.ComponentInformationTranslation")
 
 ComponentInformationTranslation::ComponentInformationTranslation(QObject* parent,
                                                                  QGCCachedFileDownload* cachedFileDownload)

--- a/src/Vehicle/FTPManager.cc
+++ b/src/Vehicle/FTPManager.cc
@@ -16,7 +16,7 @@
 #include <QtCore/QFile>
 #include <QtCore/QDir>
 
-QGC_LOGGING_CATEGORY(FTPManagerLog, "FTPManagerLog")
+QGC_LOGGING_CATEGORY(FTPManagerLog, "Vehicle.FTPManager")
 
 FTPManager::FTPManager(Vehicle* vehicle)
     : QObject   (vehicle)

--- a/src/Vehicle/InitialConnectStateMachine.cc
+++ b/src/Vehicle/InitialConnectStateMachine.cc
@@ -20,7 +20,7 @@
 #include "RallyPointManager.h"
 #include "QGCLoggingCategory.h"
 
-QGC_LOGGING_CATEGORY(InitialConnectStateMachineLog, "qgc.vehicle.initialconnectstatemachine")
+QGC_LOGGING_CATEGORY(InitialConnectStateMachineLog, "Vehicle.InitialConnectStateMachine")
 
 InitialConnectStateMachine::InitialConnectStateMachine(Vehicle *vehicle, QObject *parent)
     : StateMachine(parent)

--- a/src/Vehicle/MAVLinkLogManager.cc
+++ b/src/Vehicle/MAVLinkLogManager.cc
@@ -21,7 +21,7 @@
 #include <QtNetwork/QNetworkProxy>
 #include <QtNetwork/QNetworkReply>
 
-QGC_LOGGING_CATEGORY(MAVLinkLogManagerLog, "qgc.vehicle.mavlinklogmanager")
+QGC_LOGGING_CATEGORY(MAVLinkLogManagerLog, "Vehicle.MAVLinkLogManager")
 
 static constexpr const char *kSidecarExtension = ".uploaded";
 

--- a/src/Vehicle/MultiVehicleManager.cc
+++ b/src/Vehicle/MultiVehicleManager.cc
@@ -31,7 +31,7 @@
 #include <QtCore/QApplicationStatic>
 #include <QtCore/QTimer>
 
-QGC_LOGGING_CATEGORY(MultiVehicleManagerLog, "qgc.vehicle.multivehiclemanager")
+QGC_LOGGING_CATEGORY(MultiVehicleManagerLog, "Vehicle.MultiVehicleManager")
 
 Q_APPLICATION_STATIC(MultiVehicleManager, _multiVehicleManagerInstance);
 

--- a/src/Vehicle/RemoteIDManager.cc
+++ b/src/Vehicle/RemoteIDManager.cc
@@ -15,7 +15,7 @@
 #include "MAVLinkProtocol.h"
 #include "QGCLoggingCategory.h"
 
-QGC_LOGGING_CATEGORY(RemoteIDManagerLog, "RemoteIDManagerLog")
+QGC_LOGGING_CATEGORY(RemoteIDManagerLog, "Vehicle.RemoteIDManager")
 
 #define AREA_COUNT 1
 #define AREA_RADIUS 0

--- a/src/Vehicle/StandardModes.cc
+++ b/src/Vehicle/StandardModes.cc
@@ -11,7 +11,7 @@
 #include "Vehicle.h"
 #include "QGCLoggingCategory.h"
 
-QGC_LOGGING_CATEGORY(StandardModesLog, "StandardModesLog")
+QGC_LOGGING_CATEGORY(StandardModesLog, "Vehicle.StandardModes")
 
 static void requestMessageResultHandler(void *resultHandlerData, MAV_RESULT result,
                                         [[maybe_unused]] Vehicle::RequestMessageResultHandlerFailureCode_t failureCode,

--- a/src/Vehicle/TerrainProtocolHandler.cc
+++ b/src/Vehicle/TerrainProtocolHandler.cc
@@ -15,7 +15,7 @@
 
 #include <QtCore/QTimer>
 
-QGC_LOGGING_CATEGORY(TerrainProtocolHandlerLog, "qgc.vehicle.terrainprotocolhandler")
+QGC_LOGGING_CATEGORY(TerrainProtocolHandlerLog, "Vehicle.TerrainProtocolHandler")
 
 TerrainProtocolHandler::TerrainProtocolHandler(Vehicle *vehicle, TerrainFactGroup *terrainFactGroup, QObject *parent)
     : QObject(parent)

--- a/src/Vehicle/Vehicle.cc
+++ b/src/Vehicle/Vehicle.cc
@@ -68,7 +68,7 @@
 
 #include <QtCore/QDateTime>
 
-QGC_LOGGING_CATEGORY(VehicleLog, "VehicleLog")
+QGC_LOGGING_CATEGORY(VehicleLog, "Vehicle.Vehicle")
 
 #define UPDATE_TIMER 50
 #define DEFAULT_LAT  38.965767f

--- a/src/Vehicle/VehicleLinkManager.cc
+++ b/src/Vehicle/VehicleLinkManager.cc
@@ -17,10 +17,10 @@
 #endif
 #include "QGCLoggingCategory.h"
 
-QGC_LOGGING_CATEGORY(VehicleLinkManagerLog, "qgc.vehicle.vehiclelinkmanager")
+QGC_LOGGING_CATEGORY(VehicleLinkManagerLog, "Vehicle.VehicleLinkManager")
 
-VehicleLinkManager::VehicleLinkManager(Vehicle *vehicle)
-    : QObject(vehicle)
+    VehicleLinkManager::VehicleLinkManager(Vehicle *vehicle)
+        : QObject(vehicle)
     , _vehicle(vehicle)
     , _commLostCheckTimer(new QTimer(this))
 {

--- a/src/Vehicle/VehicleSetup/Bootloader.cc
+++ b/src/Vehicle/VehicleSetup/Bootloader.cc
@@ -16,8 +16,8 @@
 #include <QtCore/QFile>
 #include <QtCore/QThread>
 
-QGC_LOGGING_CATEGORY(FirmwareUpgradeLog, "FirmwareUpgradeLog")
-QGC_LOGGING_CATEGORY(FirmwareUpgradeVerboseLog, "FirmwareUpgradeVerboseLog")
+QGC_LOGGING_CATEGORY(FirmwareUpgradeLog, "VehicleSetup.FirmwareUpgrade")
+QGC_LOGGING_CATEGORY(FirmwareUpgradeVerboseLog, "VehicleSetup.FirmwareUpgrade:verbose")
 
 /// This class manages interactions with the bootloader
 Bootloader::Bootloader(bool sikRadio, QObject *parent)
@@ -651,7 +651,7 @@ bool Bootloader::_ihxVerifyBytes(const FirmwareImage* image)
             
             for (int i=0; i<bytesToRead; i++) {
                 if ((uint8_t)imageBytes[bytesIndex + i] != readBuf[i]) {
-                    _errorString = tr("Compare failed: expected(0x%1) actual(0x%2) at address: 0x%3").arg(imageBytes[bytesIndex + i], 2, 16, QLatin1Char('0')).arg(readBuf[i], 2, 16, QLatin1Char('0')).arg(readAddress + i, 8, 16, QLatin1Char('0'));
+                    //_errorString = tr("Compare failed: expected(0x%1) actual(0x%2) at address: 0x%3").arg(imageBytes[bytesIndex + i], 2, 16, QLatin1Char('0')).arg(readBuf[i], 2, 16, QLatin1Char('0')).arg(readAddress + i, 8, 16, QLatin1Char('0'));
                     return false;
                 }
             }

--- a/src/Vehicle/VehicleSetup/JoystickConfigController.cc
+++ b/src/Vehicle/VehicleSetup/JoystickConfigController.cc
@@ -15,7 +15,7 @@
 #include "Vehicle.h"
 #include "QGCLoggingCategory.h"
 
-QGC_LOGGING_CATEGORY(JoystickConfigControllerLog, "JoystickConfigControllerLog")
+QGC_LOGGING_CATEGORY(JoystickConfigControllerLog, "VehicleSetup.JoystickConfigController")
 
 JoystickConfigController::JoystickConfigController(void)
 {

--- a/src/VideoManager/SubtitleWriter.cc
+++ b/src/VideoManager/SubtitleWriter.cc
@@ -19,7 +19,7 @@
 #include <QtCore/QFileInfo>
 #include <QtCore/QString>
 
-QGC_LOGGING_CATEGORY(SubtitleWriterLog, "qgc.videomanager.subtitlewriter")
+QGC_LOGGING_CATEGORY(SubtitleWriterLog, "VideoManager.SubtitleWriter")
 
 SubtitleWriter::SubtitleWriter(QObject *parent)
     : QObject(parent)

--- a/src/VideoManager/VideoManager.cc
+++ b/src/VideoManager/VideoManager.cc
@@ -35,7 +35,7 @@
 #include <QtQuick/QQuickWindow>
 #include <QtCore/QTimer>
 
-QGC_LOGGING_CATEGORY(VideoManagerLog, "qgc.videomanager.videomanager")
+QGC_LOGGING_CATEGORY(VideoManagerLog, "VideoManager.VideoManager")
 
 static constexpr const char *kFileExtension[VideoReceiver::FILE_FORMAT_MAX + 1] = {
     "mkv",

--- a/src/VideoManager/VideoReceiver/GStreamer/GStreamer.cc
+++ b/src/VideoManager/VideoReceiver/GStreamer/GStreamer.cc
@@ -20,8 +20,8 @@
 
 #include <gst/gst.h>
 
-QGC_LOGGING_CATEGORY(GStreamerLog, "qgc.videomanager.videoreceiver.gstreamer")
-QGC_LOGGING_CATEGORY(GStreamerAPILog, "qgc.videomanager.videoreceiver.gstreamer.api")
+QGC_LOGGING_CATEGORY(GStreamerLog, "VideoReceiver.GStreamer")
+QGC_LOGGING_CATEGORY_ON(GStreamerAPILog, "VideoReceiver.GStreamerAPI")
 
 // TODO: Clean These up with Macros or CMake
 G_BEGIN_DECLS

--- a/src/VideoManager/VideoReceiver/GStreamer/GstVideoReceiver.cc
+++ b/src/VideoManager/VideoReceiver/GStreamer/GstVideoReceiver.cc
@@ -27,7 +27,7 @@
 
 #include <gst/gst.h>
 
-QGC_LOGGING_CATEGORY(GstVideoReceiverLog, "qgc.videomanager.videoreceiver.gstreamer.gstvideoreceiver")
+QGC_LOGGING_CATEGORY(GstVideoReceiverLog, "VideoReceiver.GstVideoReceiver")
 
 GstVideoReceiver::GstVideoReceiver(QObject *parent)
     : VideoReceiver(parent)

--- a/src/VideoManager/VideoReceiver/QtMultimedia/QtMultimediaReceiver.cc
+++ b/src/VideoManager/VideoReceiver/QtMultimedia/QtMultimediaReceiver.cc
@@ -21,7 +21,7 @@
 #include <QtQuick/QQuickItem>
 #include <QtQuick/QQuickItemGrabResult>
 
-QGC_LOGGING_CATEGORY(QtMultimediaReceiverLog, "qgc.videomanager.videoreceiver.qtmultimedia.qtmultimediareceiver")
+QGC_LOGGING_CATEGORY(QtMultimediaReceiverLog, "VideoReceiver.QtMultimediaReceiver")
 
 QtMultimediaReceiver::QtMultimediaReceiver(QObject *parent)
     : VideoReceiver(parent)

--- a/src/VideoManager/VideoReceiver/QtMultimedia/UVCReceiver.cc
+++ b/src/VideoManager/VideoReceiver/QtMultimedia/UVCReceiver.cc
@@ -23,7 +23,7 @@
 #include <QtMultimediaQuick/private/qquickvideooutput_p.h>
 #include <QtQuick/QQuickItem>
 
-QGC_LOGGING_CATEGORY(UVCReceiverLog, "qgc.videomanager.videoreceiver.qtmultimedia.uvcreceiver")
+QGC_LOGGING_CATEGORY(UVCReceiverLog, "VideoReceiver.UVCReceiver")
 
 UVCReceiver::UVCReceiver(QObject *parent)
     : QtMultimediaReceiver(parent)

--- a/test/UnitTestList.cc
+++ b/test/UnitTestList.cc
@@ -112,8 +112,6 @@
 // #include "SendMavCommandTest.h"
 // #include "TCPLinkTest.h"
 
-QGC_LOGGING_CATEGORY(UnitTestsLog, "qgc.test.unittestlist")
-
 int QGCUnitTest::runTests(bool stress, const QStringList& unitTests)
 {
     // ADSB

--- a/test/UnitTestList.h
+++ b/test/UnitTestList.h
@@ -12,8 +12,6 @@
 #include <QtCore/QLoggingCategory>
 #include <QtCore/QStringList>
 
-Q_DECLARE_LOGGING_CATEGORY(UnitTestsLog)
-
 namespace QGCUnitTest {
 
 int runTests(bool stress, const QStringList& unitTests);

--- a/test/qgcunittest/UnitTest.cc
+++ b/test/qgcunittest/UnitTest.cc
@@ -22,7 +22,7 @@
 #include <QtTest/QTest>
 #include <QtTest/QSignalSpy>
 
-QGC_LOGGING_CATEGORY(UnitTestLog, "qgc.test.qgcunittest.unittest")
+QGC_LOGGING_CATEGORY(UnitTestLog, "API.UnitTest")
 
 UnitTest::UnitTest(QObject *parent)
     : QObject(parent)


### PR DESCRIPTION
* Support wildcarding of parent hierarchies. Example: Vehicle.*
* Major rework on category naming to better fit new double level model
* Use class names as base category as much as possible to simplify going from source to logging category
* Rework category setting ui dialog for new model

UI samples:
![Screenshot 2025-09-28 at 12 15 05 PM](https://github.com/user-attachments/assets/ed433bfd-183d-43ca-9f07-5fd776c2b27a)
![Screenshot 2025-09-28 at 12 15 20 PM](https://github.com/user-attachments/assets/899644ef-c5d6-4e0a-9576-6cfe95704f83)
![Screenshot 2025-09-28 at 12 15 29 PM](https://github.com/user-attachments/assets/e2525dbe-4839-4dff-b710-405f8ad34990)
