### PR TITLE
Bump max Qt version to 6.10

### DIFF
--- a/cmake/CustomOptions.cmake
+++ b/cmake/CustomOptions.cmake
@@ -60,7 +60,7 @@ option(QT_ANDROID_SIGN_APK "Enable Signing APK" OFF)
 option(QT_ANDROID_SIGN_AAB "Enable Signing AAB" OFF)
 option(QT_USE_TARGET_ANDROID_BUILD_DIR "Use Target Android Build Dir" OFF)
 set(QGC_QT_MINIMUM_VERSION "6.8.3" CACHE STRING "Minimum Supported Qt Version")
-set(QGC_QT_MAXIMUM_VERSION "6.8.3" CACHE STRING "Maximum Supported Qt Version")
+set(QGC_QT_MAXIMUM_VERSION "6.10.0" CACHE STRING "Maximum Supported Qt Version")
 set(QGC_QT_ANDROID_MIN_SDK_VERSION "28" CACHE STRING "Android Min SDK Version")
 
 # MacOS

--- a/src/Vehicle/VehicleSetup/Bootloader.cc
+++ b/src/Vehicle/VehicleSetup/Bootloader.cc
@@ -651,7 +651,10 @@ bool Bootloader::_ihxVerifyBytes(const FirmwareImage* image)
             
             for (int i=0; i<bytesToRead; i++) {
                 if ((uint8_t)imageBytes[bytesIndex + i] != readBuf[i]) {
-                    //_errorString = tr("Compare failed: expected(0x%1) actual(0x%2) at address: 0x%3").arg(imageBytes[bytesIndex + i], 2, 16, QLatin1Char('0')).arg(readBuf[i], 2, 16, QLatin1Char('0')).arg(readAddress + i, 8, 16, QLatin1Char('0'));
+                    _errorString = tr("Compare failed: expected(0x%1) actual(0x%2) at address: 0x%3")
+                        .arg(static_cast<qulonglong>(static_cast<quint8>(imageBytes[bytesIndex + i])), 2, 16, QLatin1Char('0'))
+                        .arg(static_cast<qulonglong>(static_cast<quint8>(readBuf[i])), 2, 16, QLatin1Char('0'))
+                        .arg(static_cast<qulonglong>(readAddress + i), 8, 16, QLatin1Char('0'));
                     return false;
                 }
             }


### PR DESCRIPTION
This is the smallest necessary change to allow Mac users to build Qt using 6.10. Qt 6.8.3 cannot build on Tahoe Mac OS. Full changes are WIP.