### PR TITLE
Check for null usbManager to prevent debug spew from availableDevices…

### DIFF
--- a/android/src/org/mavlink/qgroundcontrol/QGCUsbSerialManager.java
+++ b/android/src/org/mavlink/qgroundcontrol/QGCUsbSerialManager.java
@@ -60,6 +60,10 @@ public class QGCUsbSerialManager {
         }
 
         usbManager = (UsbManager) context.getSystemService(Context.USB_SERVICE);
+        if (usbManager == null) {
+            QGCLogger.e(TAG, "Failed to get UsbManager");
+            return;
+        }
         setupUsbPermissionIntent(context);
         registerUsbReceiver(context);
         usbSerialProber = UsbSerialProber.getDefaultProber();
@@ -412,6 +416,10 @@ public class QGCUsbSerialManager {
      */
     public static String[] availableDevicesInfo() {
         // updateCurrentDrivers();
+
+        if (usbManager == null) {
+            return null;
+        }
 
         if (usbManager.getDeviceList().size() < 1) {
             return null;


### PR DESCRIPTION
Makes logging output useless due to continuous log out