### PR TITLE
MR-Tropic support and Bootloader timeout fix for large flash devices.

### DIFF
--- a/src/Comms/USBBoardInfo.json
+++ b/src/Comms/USBBoardInfo.json
@@ -24,6 +24,7 @@
         { "vendorID": 9900, "productID": 1,         "boardClass": "Pixhawk",    "name": "Omnibus F4 SD" },
         { "vendorID": 8137, "productID": 28,        "boardClass": "Pixhawk",    "name": "PX4 FMUK66 v3.x" },
         { "vendorID": 8137, "productID": 36,        "boardClass": "Pixhawk",    "name": "Tropic-Community VMU" },
+        { "vendorID": 8137, "productID": 37,        "boardClass": "Pixhawk",    "name": "MR-TROPIC" },
         { "vendorID": 1155, "productID": 41775,     "boardClass": "Pixhawk",    "name": "PX4 FMU ModalAI FCv1" },
         { "vendorID": 1155, "productID": 41776,     "boardClass": "Pixhawk",    "name": "PX4 FMU ModalAI FCv2" },
         { "vendorID":12642, "productID": 75,        "boardClass": "Pixhawk",    "name": "PX4 DurandalV1" },
@@ -113,6 +114,8 @@
         { "regExp": "^ARK Pi6X.x$",         "boardClass": "Pixhawk" },
         { "regExp": "^ARK BL Pi6X.x$",      "boardClass": "Pixhawk" },
         { "regExp": "^PX4 TROPIC Community","boardClass": "Pixhawk" },
+        { "regExp": "^PX4 MR-TROPIC",       "boardClass": "Pixhawk" },
+        { "regExp": "^PX4 BL MR-TROPIC",    "boardClass": "Pixhawk" },
         { "regExp": "^FT231X USB UART$",    "boardClass": "SiK Radio" },
         { "regExp": "USB UART$",            "boardClass": "SiK Radio",  "androidOnly": true, "comment": "Very broad fallback, too dangerous for non-android" }
     ],

--- a/src/Vehicle/VehicleSetup/Bootloader.cc
+++ b/src/Vehicle/VehicleSetup/Bootloader.cc
@@ -178,8 +178,16 @@ bool Bootloader::initFlashSequence(void)
 
 bool Bootloader::erase(void)
 {
+    uint32_t timeout = _eraseTimeout;
+
+    // If flash size is bigger then 2MB we need to increase timeout
+    if(_boardFlashSize > 2000 * 1024) {
+        // Increase timeout for each 1MB by 4 seconds
+        timeout += (_boardFlashSize / 1e6) * 4000;
+    }
+
     // Erase is slow, need larger timeout
-    if (!_sendCommand(PROTO_CHIP_ERASE, _eraseTimeout)) {
+    if (!_sendCommand(PROTO_CHIP_ERASE, timeout)) {
         _errorString = tr("Erase failed: %1").arg(_errorString);
         return false;
     }


### PR DESCRIPTION
Add MR-Tropic USB device id to USBBoardInfo for flashing and auto-detect.

Furthermore increase the bootloader erase timeout for devices with large flash. When reporting flash size is > 2MB then we increase the timeout since it takes longer to erase such a device.
