### PR TITLE
Camera Manager fixes

### DIFF
--- a/src/Camera/QGCCameraManager.h
+++ b/src/Camera/QGCCameraManager.h
@@ -67,9 +67,6 @@ public:
         Q_DISABLE_COPY_MOVE(CameraStruct)
     };
 
-    void start();
-    void stop();
-    bool requestingEnabled() const { return _requestingEnabled; }
     QmlObjectListModel* cameras() { return &_cameras; }
     const QmlObjectListModel* cameras() const { return &_cameras; }
     QStringList cameraLabels() const { return _cameraLabels; }
@@ -126,7 +123,6 @@ private:
     QPointer<SimulatedCameraControl> _simulatedCameraControl;
     QPointer<Joystick> _activeJoystick;
     bool _vehicleReadyState = false;
-    bool _requestingEnabled = false;
     int _currentTask = 0;
     QmlObjectListModel _cameras;
     QStringList _cameraLabels;

--- a/src/Vehicle/Vehicle.cc
+++ b/src/Vehicle/Vehicle.cc
@@ -4396,13 +4396,6 @@ void Vehicle::_createCameraManager()
     }
 }
 
-void Vehicle::stopCameraManager()
-{
-    if (_cameraManager) {
-        _cameraManager->stop();
-    }
-}
-
 const QVariantList &Vehicle::staticCameraList() const
 {
     if (_cameraManager) {

--- a/src/Vehicle/Vehicle.h
+++ b/src/Vehicle/Vehicle.h
@@ -1470,9 +1470,6 @@ public:
     QGCCameraManager *cameraManager() { return _cameraManager; }
     const QVariantList &staticCameraList() const;
 
-    /// Stop CameraManager requests, just for testing
-    void stopCameraManager();
-
 signals:
     void cameraManagerChanged();
 


### PR DESCRIPTION
* Remove start/stop capability which was added for testing but unused
* Start/Stop capability was causing cameras to never load since start was never called
* Fixed bad QObject::Connect call in _handleCameraInfoRetry which was throwing an assert due to Qt:: UniqueConnection not allowing lambda calls. Unique connection should not be needed given the fact that all signals a disconnected a few lines above.