### PR TITLE
Fix Android SD Card permissions for API 30+ (Android 11+) (#13456)

### DIFF
--- a/android/AndroidManifest.xml
+++ b/android/AndroidManifest.xml
@@ -21,6 +21,8 @@
     <!-- Needed for read/write to SD Card Path in AppSettings -->
     <uses-permission android:name="android.permission.WRITE_EXTERNAL_STORAGE" />
     <uses-permission android:name="android.permission.READ_EXTERNAL_STORAGE" />
+    <!-- For Android 11+ (API 30+), MANAGE_EXTERNAL_STORAGE is needed for full SD card access -->
+    <uses-permission android:name="android.permission.MANAGE_EXTERNAL_STORAGE" />
 
     <!-- %%INSERT_FEATURES -->
 


### PR DESCRIPTION
* Initial plan

* Fix Android SD card permissions for API 30+

- Add MANAGE_EXTERNAL_STORAGE permission to manifest for Android 11+ full SD card access
- Replace deprecated QtAndroidPrivate permission APIs with Java-based implementation
- Add proper permission handling for Android 11+ (API 30) and Android 6+ (API 23)
- Fix permission check to open settings for MANAGE_EXTERNAL_STORAGE grant on Android 11+



* Fix QJniObject::callStaticMethod usage for boolean return



* Fix SD card path detection for Android 11+

Use StorageVolume.getDirectory() API for Android 11+ instead of deprecated reflection-based getPath() method. This fixes the "/dev/null" path issue where the reflection method returns invalid paths on newer Android versions.



* Fix Android Activity Name
