### PR TITLE
Joystick: Gamepad Button Fix

### DIFF
--- a/src/Joystick/JoystickSDL.cc
+++ b/src/Joystick/JoystickSDL.cc
@@ -211,9 +211,7 @@ bool JoystickSDL::_getButton(int idx) const
 {
     // First try the standardized gamepad set if idx is inside that set
     if (_sdlGamepad && (idx >= 0) && (idx < SDL_GAMEPAD_BUTTON_COUNT)) {
-        if (SDL_GetGamepadButton(_sdlGamepad, static_cast<SDL_GamepadButton>(idx))) {
-            return true;
-        }
+        return SDL_GetGamepadButton(_sdlGamepad, static_cast<SDL_GamepadButton>(idx));
     }
 
     // Fall back to raw joystick buttons (covers unmapped/extras)


### PR DESCRIPTION
Should return false if not pressed
Think this actually conflicts with the getHat stuff since the indices are (maybe?) different for the dpad of gamepad & hat of joystick?