### PR TITLE
remove warning about calibration over wifi

### DIFF
--- a/custom-example/src/CustomPlugin.h
+++ b/custom-example/src/CustomPlugin.h
@@ -49,10 +49,6 @@ public:
 
     // Overrides from QGCOptions
 
-    /// Normal QGC needs to work with an ESP8266 WiFi thing which is remarkably crappy. This in turns causes PX4 Pro calibration to fail
-    /// quite often. There is a warning in regular QGC about this. Overriding the and returning true means that your custom vehicle has
-    /// a reliable WiFi connection so don't show that warning.
-    bool wifiReliableForCalibration() const final { return true; }
     /// Firmware upgrade page is only shown in Advanced Mode.
     bool showFirmwareUpgrade() const final { return _plugin->showAdvancedUI(); }
     QGCFlyViewOptions *flyViewOptions() const final { return _flyViewOptions; }

--- a/src/API/QGCOptions.h
+++ b/src/API/QGCOptions.h
@@ -84,7 +84,6 @@ class QGCOptions : public QObject
     Q_PROPERTY(bool showSensorCalibrationLevel      READ showSensorCalibrationLevel     NOTIFY showSensorCalibrationLevelChanged)
     Q_PROPERTY(bool showSimpleMissionStart          READ showSimpleMissionStart         NOTIFY showSimpleMissionStartChanged)
     Q_PROPERTY(bool useMobileFileDialog             READ useMobileFileDialog            CONSTANT)
-    Q_PROPERTY(bool wifiReliableForCalibration      READ wifiReliableForCalibration     CONSTANT)
     Q_PROPERTY(double toolbarHeightMultiplier       READ toolbarHeightMultiplier        CONSTANT)
     Q_PROPERTY(float devicePixelDensity             READ devicePixelDensity             NOTIFY devicePixelDensityChanged)
     Q_PROPERTY(float devicePixelRatio               READ devicePixelRatio               NOTIFY devicePixelRatioChanged)
@@ -154,8 +153,6 @@ public:
     virtual bool showOfflineMapImport() const { return true; }
     virtual bool showPX4LogTransferOptions() const { return true; }
     virtual bool showSimpleMissionStart() const { return false; }
-
-    virtual bool wifiReliableForCalibration() const { return false; }
 
     /// Desktop builds save the main application size and position on close (and restore it on open)
     virtual bool enableSaveMainWindowPosition() const { return true; }

--- a/src/AutoPilotPlugins/PX4/SensorsSetup.qml
+++ b/src/AutoPilotPlugins/PX4/SensorsSetup.qml
@@ -74,7 +74,6 @@ Item {
     property bool showCompass2Rot: cal_mag2_id.value > 0 && cal_mag2_rot.value >= 0
 
     property bool   _sensorsHaveFixedOrientation:       QGroundControl.corePlugin.options.sensorsHaveFixedOrientation
-    property bool   _wifiReliableForCalibration:        QGroundControl.corePlugin.options.wifiReliableForCalibration
     property int    _buttonWidth:                       ScreenTools.defaultFontPixelWidth * 15
     property string _calMagIdParamFormat:               "CAL_MAG#_ID"
     property string _calMagRotParamFormat:              "CAL_MAG#_ROT"
@@ -170,13 +169,6 @@ Item {
             if (controller.waitingForCancel) {
                 waitForCancelDialogComponent.createObject(mainWindow).open()
             }
-        }
-    }
-
-    Component.onCompleted: {
-        var usingUDP = controller.usingUDPLink()
-        if (usingUDP && !_wifiReliableForCalibration) {
-            mainWindow.showMessageDialog(qsTr("Sensor Calibration"), qsTr("Performing sensor calibration over a WiFi connection is known to be unreliable. You should disconnect and perform calibration using a direct USB connection instead."))
         }
     }
 


### PR DESCRIPTION
I'm not sure if this warning is relevant anymore. It's very common to connect to QGC over the network with mavlink-router running onboard a companion computer. I've never had an issue with calibration over wifi and this warning has caused confusion for some users. 