### PR TITLE
Added a new option to advanced serial settings to force DTL low for E…

### DIFF
--- a/src/Comms/SerialLink.cc
+++ b/src/Comms/SerialLink.cc
@@ -75,6 +75,7 @@ void SerialConfiguration::copyFrom(const LinkConfiguration *source)
     setPortName(serialSource->portName());
     setPortDisplayName(serialSource->portDisplayName());
     setUsbDirect(serialSource->usbDirect());
+    setdtrForceLow(serialSource->dtrForceLow());
 }
 
 void SerialConfiguration::loadSettings(QSettings &settings, const QString &root)
@@ -88,6 +89,7 @@ void SerialConfiguration::loadSettings(QSettings &settings, const QString &root)
     setParity(static_cast<QSerialPort::Parity>(settings.value("parity", _parity).toInt()));
     setPortName(settings.value("portName", _portName).toString());
     setPortDisplayName(settings.value("portDisplayName", _portDisplayName).toString());
+    setdtrForceLow(settings.value("dtrForceLow", _dtrForceLow).toBool());
 
     settings.endGroup();
 }
@@ -103,6 +105,7 @@ void SerialConfiguration::saveSettings(QSettings &settings, const QString &root)
     settings.setValue("parity", _parity);
     settings.setValue("portName", _portName);
     settings.setValue("portDisplayName", _portDisplayName);
+    settings.setValue("dtrForceLow", _dtrForceLow);
 
     settings.endGroup();
 }
@@ -312,7 +315,7 @@ void SerialWorker::_onPortConnected()
 {
     qCDebug(SerialLinkLog) << "Port connected:" << _port->portName();
 
-    _port->setDataTerminalReady(true);
+    _port->setDataTerminalReady(_serialConfig->dtrForceLow() ? false : true);
     _port->setBaudRate(_serialConfig->baud());
     _port->setDataBits(static_cast<QSerialPort::DataBits>(_serialConfig->dataBits()));
     _port->setFlowControl(static_cast<QSerialPort::FlowControl>(_serialConfig->flowControl()));

--- a/src/Comms/SerialLink.h
+++ b/src/Comms/SerialLink.h
@@ -39,6 +39,7 @@ class SerialConfiguration : public LinkConfiguration
     Q_PROPERTY(QString                  portName        READ portName        WRITE setPortName    NOTIFY portNameChanged)
     Q_PROPERTY(QString                  portDisplayName READ portDisplayName                      NOTIFY portDisplayNameChanged)
     Q_PROPERTY(bool                     usbDirect       READ usbDirect       WRITE setUsbDirect   NOTIFY usbDirectChanged)
+    Q_PROPERTY(bool                     dtrForceLow     READ dtrForceLow     WRITE setdtrForceLow NOTIFY dtrForceLowChanged)
 
 public:
     explicit SerialConfiguration(const QString &name, QObject *parent = nullptr);
@@ -76,6 +77,9 @@ public:
     bool usbDirect() const { return _usbDirect; }
     void setUsbDirect(bool usbDirect) { if (usbDirect != _usbDirect) { _usbDirect = usbDirect; emit usbDirectChanged(); } }
 
+    bool dtrForceLow() const { return _dtrForceLow; }
+    void setdtrForceLow(bool dtrForceLow) { if (dtrForceLow != _dtrForceLow) { _dtrForceLow = dtrForceLow; emit dtrForceLowChanged(); } }
+
     static QStringList supportedBaudRates();
     static QString cleanPortDisplayName(const QString &name);
 
@@ -88,6 +92,7 @@ signals:
     void portNameChanged();
     void portDisplayNameChanged();
     void usbDirectChanged();
+    void dtrForceLowChanged();
 
 private:
     qint32 _baud = QSerialPort::Baud57600;
@@ -98,6 +103,7 @@ private:
     QString _portName;
     QString _portDisplayName;
     bool _usbDirect = false;
+    bool _dtrForceLow = false;
 };
 
 /*===========================================================================*/

--- a/src/UI/AppSettings/SerialSettings.qml
+++ b/src/UI/AppSettings/SerialSettings.qml
@@ -116,6 +116,13 @@ ColumnLayout {
             onCheckedChanged:   subEditConfig.flowControl = checked ? 1 : 0
         }
 
+        QGCCheckBox {
+            Layout.columnSpan:  2
+            text:               qsTr("Force DTR Low")
+            checked:            subEditConfig ? subEditConfig.dtrForceLow : false
+            onCheckedChanged:   { if (subEditConfig) subEditConfig.dtrForceLow = checked }
+        }
+
         QGCLabel { text: qsTr("Parity") }
         QGCComboBox {
             Layout.preferredWidth:  _secondColumnWidth


### PR DESCRIPTION
# Add configurable DTR setting to prevent ESP32 reset on serial connection

## Description

QGroundControl's serial link implementation currently sets DTR high immediately after opening the port, which triggers a reset on ESP32 devices using USB serial chips (e.g., CP210x, CH340). This causes the ESP32 to reboot and lock up during telemetry connection.

This change adds a new "Force DTR Low" checkbox in the Serial Link advanced settings that allows users to force DTR low on port for devices that require it (like ESP32). Defaults unchecked for backward compatibility.

Changes:

- Added `dtrForceLow` property to `SerialConfiguration` class (defaults `false`)
- Modified `SerialWorker::_onPortConnected()` to set DTR based on configuration
- Added checkbox UI in `SerialSettings.qml`
- Implemented persistence in settings

## Test Steps

1. Configure a serial link with an ESP32 device
2. Enable Advanced Settings, check "Force DTR Low"
3. Connect the link - ESP32 should not reset nor lock up
4. Verify telemetry communication works
5. Test with checkbox unchecked (default) - ensure existing non-ESP autopilot devices still work

## Checklist:

- [x] [Review Contribution Guidelines](https://github.com/mavlink/qgroundcontrol/blob/master/.github/CONTRIBUTING.md).
- [x] [Review Code of Conduct](https://github.com/mavlink/qgroundcontrol/blob/master/.github/CODE_OF_CONDUCT.md).
- [x] I have tested my changes (with an ESP32 TX, but I dont have other autopilots / telem modems to test with)

## Related Issue

None

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
