### PR TITLE
Show joystick calibration

### DIFF
--- a/src/Vehicle/VehicleSetup/JoystickConfigGeneral.qml
+++ b/src/Vehicle/VehicleSetup/JoystickConfigGeneral.qml
@@ -13,11 +13,11 @@ import QtQuick.Dialogs
 import QtQuick.Layouts
 
 import QGroundControl
-
+import QGroundControl.Palette
 import QGroundControl.Controls
-
-
-
+import QGroundControl.ScreenTools
+import QGroundControl.Controllers
+import QGroundControl.FactSystem
 import QGroundControl.FactControls
 
 Item {
@@ -152,6 +152,19 @@ Item {
                 width:              axisGrid.width  + (ScreenTools.defaultFontPixelWidth  * 2)
                 height:             axisGrid.height + (ScreenTools.defaultFontPixelHeight * 2)
                 visible:            !_buttonsOnly
+
+                function joyToAxis(v, reversed) {
+                    v = Math.max(-1, Math.min(1, v))
+                    if (reversed) v = -v
+                    return v * 32768.0
+                }
+
+                function joyToThrottleAxis(t) {
+                    t = Math.max(0, Math.min(1, t))
+                    const display = (2 * t - 1)
+                    return display * 32768.0
+                }
+
                 GridLayout {
                     id:                 axisGrid
                     columns:            2
@@ -210,12 +223,12 @@ Item {
                     }
 
                     Connections {
-                        target:             _activeJoystick
+                        target: _activeJoystick
                         onAxisValues: (roll, pitch, yaw, throttle) => {
-                            rollAxis.axisValue      = roll  * 32768.0
-                            pitchAxis.axisValue     = pitch * 32768.0
-                            yawAxis.axisValue       = yaw   * 32768.0
-                            throttleAxis.axisValue  = _activeJoystick.negativeThrust ? throttle * -32768.0 : (-2 * throttle + 1) * 32768.0
+                            rollAxis.axisValue     = axisRect.joyToAxis(roll,     controller.rollAxisReversed)
+                            pitchAxis.axisValue    = axisRect.joyToAxis(pitch,    controller.pitchAxisReversed)
+                            yawAxis.axisValue      = axisRect.joyToAxis(yaw,      controller.yawAxisReversed)
+                            throttleAxis.axisValue = axisRect.joyToThrottleAxis(throttle, controller.throttleAxisReversed, _activeJoystick.negativeThrust)
                         }
                     }
                 }

--- a/src/Vehicle/VehicleSetup/JoystickConfigGeneral.qml
+++ b/src/Vehicle/VehicleSetup/JoystickConfigGeneral.qml
@@ -13,11 +13,9 @@ import QtQuick.Dialogs
 import QtQuick.Layouts
 
 import QGroundControl
-import QGroundControl.Palette
+
 import QGroundControl.Controls
-import QGroundControl.ScreenTools
-import QGroundControl.Controllers
-import QGroundControl.FactSystem
+
 import QGroundControl.FactControls
 
 Item {
@@ -159,10 +157,11 @@ Item {
                     return v * 32768.0
                 }
 
-                function joyToThrottleAxis(t) {
-                    t = Math.max(0, Math.min(1, t))
-                    const display = (2 * t - 1)
-                    return display * 32768.0
+                function joyToThrottleAxis(v, reversed) {
+                    v = Math.max(-1, Math.min(1, v))
+                    v = (2 * v - 1)
+                    if (reversed) v = -v
+                    return v * 32768.0
                 }
 
                 GridLayout {
@@ -225,10 +224,10 @@ Item {
                     Connections {
                         target: _activeJoystick
                         onAxisValues: (roll, pitch, yaw, throttle) => {
-                            rollAxis.axisValue     = axisRect.joyToAxis(roll,     controller.rollAxisReversed)
-                            pitchAxis.axisValue    = axisRect.joyToAxis(pitch,    controller.pitchAxisReversed)
-                            yawAxis.axisValue      = axisRect.joyToAxis(yaw,      controller.yawAxisReversed)
-                            throttleAxis.axisValue = axisRect.joyToThrottleAxis(throttle, controller.throttleAxisReversed, _activeJoystick.negativeThrust)
+                            rollAxis.axisValue     = axisRect.joyToAxis(roll,  controller.rollAxisReversed)
+                            pitchAxis.axisValue    = axisRect.joyToAxis(pitch, controller.pitchAxisReversed)
+                            yawAxis.axisValue      = axisRect.joyToAxis(yaw,   controller.yawAxisReversed)
+                            throttleAxis.axisValue = axisRect.joyToThrottleAxis(throttle, controller.throttleAxisReversed)
                         }
                     }
                 }
@@ -276,5 +275,3 @@ Item {
         }
     }
 }
-
-


### PR DESCRIPTION
<!--- Title -->
Show calibrated joystick axis output in calibration screen
-----------

Description
-----------
This update chnages the joystick calibration UI by displaying real-time calibrated axis output values for Roll, Pitch, Yaw, and Throttle during and after calibration.
It helps verify that calibration is applied correctly.

Key changes
-----------

- Added dynamic axis visualization (AxisMonitor) for each joystick channel.
- Implemented helper functions (joyToAxis, joyToThrottleAxis) to apply clamping and mapping to QGC’s internal range
- Integrated calibration reversal logic so UI reflects post-calibration orientation.
- Updated Connections.onAxisValues to respond immediately to calibration changes.

Test Steps
-----------

- Open Joystick Setup Calibration in QGroundControl.
- Move Roll, Pitch, Yaw, and Throttle sticks after calibration.
- Confirm that each Axis Monitor bar responds smoothly and in the correct direction.
- Toggle Reverse on any axis and ensure the visualization flips 
- Verify that throttle range maps correctly from 0–1 to –32768..32768.

Checklist:
----------
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] [Review Contribution Guidelines](https://github.com/mavlink/qgroundcontrol/blob/master/.github/CONTRIBUTING.md).
- [x] [Review Code of Conduct](https://github.com/mavlink/qgroundcontrol/blob/master/.github/CODE_OF_CONDUCT.md).
- [x] I have tested my changes.

Related Issue
-----------
<!-- If any, please provide issue ID. -->


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.