### PR TITLE
VTOL transition is now handled by Flight Mode Toolbar Indicator

### DIFF
--- a/src/FlightDisplay/GuidedActionsController.qml
+++ b/src/FlightDisplay/GuidedActionsController.qml
@@ -56,7 +56,6 @@ Item {
     readonly property string landAbortTitle:                qsTr("Land Abort")
     readonly property string setWaypointTitle:              qsTr("Set Waypoint")
     readonly property string gotoTitle:                     qsTr("Go To Location")
-    readonly property string vtolTransitionTitle:           qsTr("VTOL Transition")
     readonly property string roiTitle:                      qsTr("ROI")
     readonly property string setHomeTitle:                  qsTr("Set Home")
     readonly property string setEstimatorOriginTitle:       qsTr("Set Estimator origin")
@@ -87,8 +86,6 @@ Item {
     readonly property string landAbortMessage:                  qsTr("Abort the landing sequence.")
     readonly property string pauseMessage:                      qsTr("Pause the vehicle at it's current position, adjusting altitude up or down as needed.")
     readonly property string mvPauseMessage:                    qsTr("Pause selected vehicles at their current position.")
-    readonly property string vtolTransitionFwdMessage:          qsTr("Transition VTOL to fixed wing flight.")
-    readonly property string vtolTransitionMRMessage:           qsTr("Transition VTOL to multi-rotor flight.")
     readonly property string roiMessage:                        qsTr("Make the specified location a Region Of Interest.")
     readonly property string setHomeMessage:                    qsTr("Set vehicle home as the specified location. This will affect Return to Home position")
     readonly property string setEstimatorOriginMessage:         qsTr("Make the specified location the estimator origin.")
@@ -114,21 +111,17 @@ Item {
     readonly property int actionPause:                      17
     readonly property int actionMVPause:                    18
     readonly property int actionMVStartMission:             19
-    readonly property int actionVtolTransitionToFwdFlight:  20
-    readonly property int actionVtolTransitionToMRFlight:   21
-    readonly property int actionROI:                        22
-    readonly property int actionForceArm:                   24
-    readonly property int actionChangeSpeed:                25
-    readonly property int actionGripper:                    26
-    readonly property int actionSetHome:                    27
-    readonly property int actionSetEstimatorOrigin:         28
-    readonly property int actionSetFlightMode:              29
-    readonly property int actionChangeHeading:              30
-    readonly property int actionMVArm:                      31
-    readonly property int actionMVDisarm:                   32
-    readonly property int actionChangeLoiterRadius:         33
-
-
+    readonly property int actionROI:                        20
+    readonly property int actionForceArm:                   21
+    readonly property int actionChangeSpeed:                22
+    readonly property int actionGripper:                    23
+    readonly property int actionSetHome:                    24
+    readonly property int actionSetEstimatorOrigin:         25
+    readonly property int actionSetFlightMode:              26
+    readonly property int actionChangeHeading:              27
+    readonly property int actionMVArm:                      28
+    readonly property int actionMVDisarm:                   29
+    readonly property int actionChangeLoiterRadius:         30
 
     readonly property int customActionStart:                10000 // Custom actions ids should start here so that they don't collide with the built in actions
 
@@ -370,8 +363,6 @@ Item {
         function onArmVehicleRequest() { armVehicleRequest() }
         function onForceArmVehicleRequest() { forceArmVehicleRequest() }
         function onDisarmVehicleRequest() { disarmVehicleRequest() }
-        function onVtolTransitionToFwdFlightRequest() { vtolTransitionToFwdFlightRequest() }
-        function onVtolTransitionToMRFlightRequest() { vtolTransitionToMRFlightRequest() }
     }
 
     function armVehicleRequest() {
@@ -389,14 +380,6 @@ Item {
             confirmAction(actionDisarm)
         }
 
-    }
-
-    function vtolTransitionToFwdFlightRequest() {
-        confirmAction(actionVtolTransitionToFwdFlight)
-    }
-
-    function vtolTransitionToMRFlightRequest() {
-        confirmAction(actionVtolTransitionToMRFlight)
     }
 
     function closeAll() {
@@ -543,16 +526,6 @@ Item {
             confirmDialog.message = mvPauseMessage
             confirmDialog.hideTrigger = true
             break;
-        case actionVtolTransitionToFwdFlight:
-            confirmDialog.title = vtolTransitionTitle
-            confirmDialog.message = vtolTransitionFwdMessage
-            confirmDialog.hideTrigger = true
-            break
-        case actionVtolTransitionToMRFlight:
-            confirmDialog.title = vtolTransitionTitle
-            confirmDialog.message = vtolTransitionMRMessage
-            confirmDialog.hideTrigger = true
-            break
         case actionROI:
             confirmDialog.title = roiTitle
             confirmDialog.message = roiMessage
@@ -696,12 +669,6 @@ Item {
             for (i = 0; i < selectedVehicles.count; i++) {
                 selectedVehicles.get(i).pauseVehicle()
             }
-            break
-        case actionVtolTransitionToFwdFlight:
-            _activeVehicle.vtolInFwdFlight = true
-            break
-        case actionVtolTransitionToMRFlight:
-            _activeVehicle.vtolInFwdFlight = false
             break
         case actionROI:
             _activeVehicle.guidedModeROI(actionData)

--- a/src/QmlControls/MainStatusIndicator.qml
+++ b/src/QmlControls/MainStatusIndicator.qml
@@ -22,8 +22,6 @@ RowLayout {
     spacing:    ScreenTools.defaultFontPixelWidth
 
     property var    _activeVehicle:     QGroundControl.multiVehicleManager.activeVehicle
-    property var    _vehicleInAir:      _activeVehicle ? _activeVehicle.flying || _activeVehicle.landing : false
-    property bool   _vtolInFWDFlight:   _activeVehicle ? _activeVehicle.vtolInFwdFlight : false
     property bool   _armed:             _activeVehicle ? _activeVehicle.armed : false
     property real   _margins:           ScreenTools.defaultFontPixelWidth
     property real   _spacing:           ScreenTools.defaultFontPixelWidth / 2
@@ -143,24 +141,6 @@ RowLayout {
         QGCMouseArea {
             anchors.fill:   parent
             onClicked:      dropMainStatusIndicator()
-        }
-    }
-
-    QGCLabel {
-        id:                 vtolModeLabel
-        Layout.fillHeight:  true
-        verticalAlignment:  Text.AlignVCenter
-        text:               _vtolInFWDFlight ? qsTr("FW(vtol)") : qsTr("MR(vtol)")
-        font.pointSize:     _vehicleInAir ? ScreenTools.largeFontPointSize : ScreenTools.defaultFontPointSize
-        visible:            _activeVehicle && _activeVehicle.vtol
-
-        QGCMouseArea {
-            anchors.fill: parent
-            onClicked: {
-                if (_vehicleInAir) {
-                    mainWindow.showIndicatorDrawer(vtolTransitionIndicatorPage)
-                }
-            }
         }
     }
 
@@ -373,27 +353,6 @@ RowLayout {
                             mainWindow.showVehicleConfig()
                             mainWindow.closeIndicatorDrawer()
                         }
-                    }
-                }
-            }
-        }
-    }
-
-    Component {
-        id: vtolTransitionIndicatorPage
-
-        ToolIndicatorPage {
-            contentComponent: Component {
-                QGCButton {
-                    text: _vtolInFWDFlight ? qsTr("Transition to Multi-Rotor") : qsTr("Transition to Fixed Wing")
-
-                    onClicked: {
-                        if (_vtolInFWDFlight) {
-                            mainWindow.vtolTransitionToMRFlightRequest()
-                        } else {
-                            mainWindow.vtolTransitionToFwdFlightRequest()
-                        }
-                        mainWindow.closeIndicatorDrawer()
                     }
                 }
             }


### PR DESCRIPTION
* FYI: Working my may through a major rework of the toolbar
* VTOL transitions are now handled just like a flight mode change. They are in the flight mode dropdown now and use the same delay button mechanism.

Before - VTOL transition was a separate toolbar indicator which would do transitions through the Guided Actions Controller. Including the old slidy thing to confirm.
![Screenshot 2025-10-10 at 11 01 54 AM](https://github.com/user-attachments/assets/0a74a895-aa0a-4d71-8461-ff064b5d1518)
![Screenshot 2025-10-10 at 11 02 02 AM](https://github.com/user-attachments/assets/9cc333f4-2d94-4d8f-9232-b7ff3ae35a95)

After - VTOL transition handled like a flight mode change:
![Screenshot 2025-10-10 at 11 36 19 AM](https://github.com/user-attachments/assets/f12faafa-1f22-4a0a-9a74-696a362daff8)
![Screenshot 2025-10-10 at 11 36 46 AM](https://github.com/user-attachments/assets/972a5de1-668f-475e-941e-ad0a3475e17b)
