### PR TITLE
Battery Indicator: Display lowest state battery only by default

### DIFF
--- a/src/QmlControls/BatteryIndicator.qml
+++ b/src/QmlControls/BatteryIndicator.qml
@@ -12,10 +12,6 @@ import QtQuick.Layouts
 
 import QGroundControl
 import QGroundControl.Controls
-
-
-
-
 import QGroundControl.FactControls
 
 //-------------------------------------------------------------------------
@@ -26,8 +22,9 @@ Item {
     anchors.bottom: parent.bottom
     width:          batteryIndicatorRow.width
 
-    property bool       showIndicator:      true
-    property bool       waitForParameters:  true   // UI won't show until parameters are ready
+    property bool       showIndicator:      _activeVehicle && _activeVehicle.batteries.count > 0
+    property bool       waitForParameters:  true    // UI won't show until parameters are ready
+    property Component  expandedPageComponent
 
     property var    _activeVehicle:     QGroundControl.multiVehicleManager.activeVehicle
     property var    _batterySettings:   QGroundControl.settingsManager.batteryIndicatorSettings
@@ -35,35 +32,169 @@ Item {
     property bool   _showPercentage:    _indicatorDisplay.rawValue === 0
     property bool   _showVoltage:       _indicatorDisplay.rawValue === 1
     property bool   _showBoth:          _indicatorDisplay.rawValue === 2
+    property int    _lowestBatteryId:   -1      // -1: show all batteries, otherwise show only battery with this id
 
     // Properties to hold the thresholds
     property int threshold1: _batterySettings.threshold1.rawValue
-    property int threshold2: _batterySettings.threshold2.rawValue  
+    property int threshold2: _batterySettings.threshold2.rawValue
 
-    QGCPalette { id: qgcPal } 
+    function _recalcLowestBatteryIdFromVoltage() {
+        if (_activeVehicle) {
+            // If there is only one battery then it is the lowest
+            if (_activeVehicle.batteries.count === 1) {
+                _lowestBatteryId = _activeVehicle.batteries.get(0).id.rawValue
+                return
+            }
 
-    Row {
+            // If we have valid voltage for all batteries we use that to determine lowest battery
+            let allHaveVoltage = true
+            for (var i = 0; i < _activeVehicle.batteries.count; i++) {
+                let battery = _activeVehicle.batteries.get(i)
+                if (isNaN(battery.voltage.rawValue)) {
+                    allHaveVoltage = false
+                    break
+                }
+            }
+            if (allHaveVoltage) {
+                let lowestBattery = _activeVehicle.batteries.get(0)
+                let lowestBatteryId = lowestBattery.id.rawValue
+                for (var i = 1; i < _activeVehicle.batteries.count; i++) {
+                    let battery = _activeVehicle.batteries.get(i)
+                    if (battery.voltage.rawValue < lowestBattery.voltage.rawValue) {
+                        lowestBattery = battery
+                        lowestBatteryId = battery.id.rawValue
+                    }
+                }
+                _lowestBatteryId = lowestBatteryId
+                return
+            }
+        }
+
+        // Couldn't determine lowest battery, show all
+        _lowestBatteryId = -1
+    }
+
+    function _recalcLowestBatteryIdFromPercentage() {
+        if (_activeVehicle) {
+            // If there is only one battery then it is the lowest
+            if (_activeVehicle.batteries.count === 1) {
+                _lowestBatteryId = _activeVehicle.batteries.get(0).id.rawValue
+                return
+            }
+
+            // If we have valid percentage for all batteries we use that to determine lowest battery
+            let allHavePercentage = true
+            for (var i = 0; i < _activeVehicle.batteries.count; i++) {
+                let battery = _activeVehicle.batteries.get(i)
+                if (isNaN(battery.percentRemaining.rawValue)) {
+                    allHavePercentage = false
+                    break
+                }
+            }
+            if (allHavePercentage) {
+                let lowestBattery = _activeVehicle.batteries.get(0)
+                let lowestBatteryId = lowestBattery.id.rawValue
+                for (var i = 1; i < _activeVehicle.batteries.count; i++) {
+                    let battery = _activeVehicle.batteries.get(i)
+                    if (battery.percentRemaining.rawValue < lowestBattery.percentRemaining.rawValue) {
+                        lowestBattery = battery
+                        lowestBatteryId = battery.id.rawValue
+                    }
+                }
+                _lowestBatteryId = lowestBatteryId
+                return
+            }
+        }
+
+        // Couldn't determine lowest battery, show all
+        _lowestBatteryId = -1
+    }
+
+    function _recalcLowestBatteryIdFromChargeState() {
+        if (_activeVehicle) {
+            // If there is only one battery then it is the lowest
+            if (_activeVehicle.batteries.count === 1) {
+                _lowestBatteryId = _activeVehicle.batteries.get(0).id.rawValue
+                return
+            }
+
+            // If we have valid chargeState for all batteries we use that to determine lowest battery
+            let allHaveChargeState = true
+            for (var i = 0; i < _activeVehicle.batteries.count; i++) {
+                let battery = _activeVehicle.batteries.get(i)
+                if (battery.chargeState.rawValue === MAVLink.MAV_BATTERY_CHARGE_STATE_UNDEFINED) {
+                    allHaveChargeState = false
+                    break
+                }
+            }
+            if (allHaveChargeState) {
+                let lowestBattery = _activeVehicle.batteries.get(0)
+                let lowestBatteryId = lowestBattery.id.rawValue
+                for (var i = 1; i < _activeVehicle.batteries.count; i++) {
+                    let battery = _activeVehicle.batteries.get(i)
+                    if (battery.chargeState.rawValue > lowestBattery.chargeState.rawValue) {
+                        lowestBattery = battery
+                        lowestBatteryId = battery.id.rawValue
+                    }
+                }
+                _lowestBatteryId = lowestBatteryId
+                return
+            }
+        }
+
+        // Couldn't determine lowest battery, show all
+        _lowestBatteryId = -1
+    }
+
+    function _recalcLowestBatteryId() {
+        if (!_activeVehicle || _activeVehicle.batteries.count === 0) {
+            _lowestBatteryId = -1
+            return
+        }
+        if (_batterySettings.valueDisplay.rawValue === 0) {
+            // User wants percentage display so use that if available
+            _recalcLowestBatteryIdFromPercentage()
+        } else if (_batterySettings.valueDisplay.rawValue === 1) {
+            // User wants voltage display so use that if available
+            _recalcLowestBatteryIdFromVoltage()
+        }
+        // If we still dont have a lowest battery id then try charge state
+        if (_lowestBatteryId === -1) {
+            _recalcLowestBatteryIdFromChargeState()
+        }
+    }
+
+    Component.onCompleted: _recalcLowestBatteryId()
+
+    Connections {
+        target: _activeVehicle ? _activeVehicle.batteries : null
+        function onCountChanged() {_recalcLowestBatteryId() }
+    }
+
+    QGCPalette { id: qgcPal }
+
+    RowLayout {
         id:             batteryIndicatorRow
         anchors.top:    parent.top
         anchors.bottom: parent.bottom
+        spacing:        ScreenTools.defaultFontPixelWidth / 2
 
         Repeater {
             model: _activeVehicle ? _activeVehicle.batteries : 0
 
             Loader {
-                anchors.top:        parent.top
-                anchors.bottom:     parent.bottom
+                Layout.fillHeight:  true
                 sourceComponent:    batteryVisual
+                visible:            control._lowestBatteryId === -1 || object.id.rawValue === control._lowestBatteryId || !control._batterySettings.consolidateMultipleBatteries.rawValue
 
                 property var battery: object
             }
         }
     }
+
     MouseArea {
         anchors.fill:   parent
-        onClicked: {
-            mainWindow.showIndicatorDrawer(batteryPopup, control)
-        }
+        onClicked:      mainWindow.showIndicatorDrawer(batteryPopup, control)
     }
 
     Component {
@@ -81,8 +212,8 @@ Item {
         id: batteryVisual
 
         Row {
-            anchors.top:    parent.top
-            anchors.bottom: parent.bottom
+            Layout.fillHeight:  true
+            spacing:            ScreenTools.defaultFontPixelWidth / 4
 
             function getBatteryColor() {
                 switch (battery.chargeState.rawValue) {
@@ -157,6 +288,34 @@ Item {
                     return battery.chargeState.enumStringValue
                 }
                 return qsTr("n/a")
+            }
+
+            Timer {
+                id:         debounceRecalcTimer
+                interval:   50
+                running:    false
+                repeat:     false
+                onTriggered: {
+                    control._recalcLowestBatteryId()
+                }
+            }
+            Connections {
+                target: battery.percentRemaining
+                function onRawValueChanged() {
+                    debounceRecalcTimer.restart()
+                }
+            }
+            Connections {
+                target: battery.voltage
+                function onRawValueChanged() {
+                    debounceRecalcTimer.restart()
+                }
+            }
+            Connections {
+                target: battery.chargeState
+                function onRawValueChanged() {
+                    debounceRecalcTimer.restart()
+                }
             }
 
             QGCColoredImage {
@@ -292,13 +451,17 @@ Item {
                 heading:            qsTr("Battery Display")
                 Layout.fillWidth:   true
 
-                LabelledFactComboBox {
-                    id:             editModeCheckBox
-                    label:          qsTr("Value")
-                    fact:           _fact
-                    visible:        _fact,visible
+                FactCheckBoxSlider {
+                    Layout.fillWidth:   true
+                    fact:               _batterySettings.consolidateMultipleBatteries
+                    text:               qsTr("Only show battery with lowest charge")
+                    visible:            fact.visible
+                }
 
-                    property Fact _fact: QGroundControl.settingsManager.batteryIndicatorSettings.valueDisplay
+                LabelledFactComboBox {
+                    label:      qsTr("Value")
+                    fact:       _batterySettings.valueDisplay
+                    visible:    fact.visible
                 }
 
                 ColumnLayout {

--- a/src/Settings/BatteryIndicator.SettingsGroup.json
+++ b/src/Settings/BatteryIndicator.SettingsGroup.json
@@ -23,6 +23,12 @@
             "type": "uint32",
             "default": 60,
             "units": "%"
+        },
+        {
+            "name": "consolidateMultipleBatteries",
+            "shortDesc": "Consolidate multiple battery readings",
+            "type": "bool",
+            "default": true
         }
     ]
 }

--- a/src/Settings/BatteryIndicatorSettings.cc
+++ b/src/Settings/BatteryIndicatorSettings.cc
@@ -16,6 +16,7 @@ DECLARE_SETTINGGROUP(BatteryIndicator, "BatteryIndicator")
 }
 
 DECLARE_SETTINGSFACT(BatteryIndicatorSettings, valueDisplay)
+DECLARE_SETTINGSFACT(BatteryIndicatorSettings, consolidateMultipleBatteries)
 
 DECLARE_SETTINGSFACT_NO_FUNC(BatteryIndicatorSettings, threshold1)
 {

--- a/src/Settings/BatteryIndicatorSettings.h
+++ b/src/Settings/BatteryIndicatorSettings.h
@@ -26,6 +26,7 @@ public:
     DEFINE_SETTINGFACT(valueDisplay)            // Battery value display mode
     DEFINE_SETTINGFACT(threshold1)              // First threshold for battery level
     DEFINE_SETTINGFACT(threshold2)              // Second threshold for battery level
+    DEFINE_SETTINGFACT(consolidateMultipleBatteries)
 
     Q_INVOKABLE void setThreshold1(int value);  // Set threshold1 with validation
     Q_INVOKABLE void setThreshold2(int value);  // Set threshold2 with validation


### PR DESCRIPTION
* By default in a multi-battery situation only the lowest state battery is shown in the toolbar. Change the setting to always show multiple.
* Full battery status for all batteries continues to be available in the dropdown.
* When deciding which battery to show the users value display is taking into account:
  * Voltage: If voltage is available from all batteries then lowest voltage wins
  * Percentage: If percentage is available from all batteries then lowest percentage wins
  * Otherwise if charge state is available from all batteries the lowest charge state wins
  * Otherwise we don't have enough info to determine lowest state and we fall back to showing all batteries

![Screenshot 2025-10-10 at 1 33 12 PM](https://github.com/user-attachments/assets/77f67ce5-98be-473e-8fbd-9a2f524a37c8)
