### PR TITLE
Add gimbal support to joystick interface

### DIFF
--- a/src/Joystick/Joystick.cc
+++ b/src/Joystick/Joystick.cc
@@ -608,13 +608,13 @@ void Joystick::_handleAxis()
     axis = _rgFunctionAxis[throttleFunction];
     float throttle = _adjustRange(_rgAxisValues[axis], _rgCalibration[axis], (_throttleMode == ThrottleModeDownZero) ? false :_deadband);
 
-    float gimbalPitch = 0.0f;
+    float gimbalPitch = NAN;
     if (_axisCount > 4) {
         axis = _rgFunctionAxis[gimbalPitchFunction];
         gimbalPitch = _adjustRange(_rgAxisValues[axis], _rgCalibration[axis],_deadband);
     }
 
-    float gimbalYaw = 0.0f;
+    float gimbalYaw = NAN;
     if (_axisCount > 5) {
         axis = _rgFunctionAxis[gimbalYawFunction];
         gimbalYaw = _adjustRange(_rgAxisValues[axis],   _rgCalibration[axis],_deadband);
@@ -674,7 +674,7 @@ void Joystick::_handleAxis()
 
     const uint16_t lowButtons = static_cast<uint16_t>(buttonPressedBits & 0xFFFF);
     const uint16_t highButtons = static_cast<uint16_t>((buttonPressedBits >> 16) & 0xFFFF);
-    _activeVehicle->sendJoystickDataThreadSafe(roll, pitch, yaw, throttle, lowButtons, highButtons);
+    _activeVehicle->sendJoystickDataThreadSafe(roll, pitch, yaw, throttle, lowButtons, highButtons, gimbalPitch, gimbalYaw);
 }
 
 void Joystick::startPolling(Vehicle* vehicle)

--- a/src/Vehicle/Vehicle.h
+++ b/src/Vehicle/Vehicle.h
@@ -445,7 +445,7 @@ public:
 
     bool joystickEnabled            () const;
     void setJoystickEnabled         (bool enabled);
-    void sendJoystickDataThreadSafe (float roll, float pitch, float yaw, float thrust, quint16 buttons, quint16 buttons2);
+    void sendJoystickDataThreadSafe (float roll, float pitch, float yaw, float thrust, quint16 buttons, quint16 buttons2, float gimbalPitch, float gimbalYaw);
 
     // Property accesors
     int id() const{ return _id; }

--- a/src/Vehicle/VehicleSetup/JoystickConfigController.cc
+++ b/src/Vehicle/VehicleSetup/JoystickConfigController.cc
@@ -61,6 +61,10 @@ const JoystickConfigController::stateMachineEntry* JoystickConfigController::_ge
     static constexpr const char* msgPitchDown =           "Move the Pitch stick all the way down and hold it there...";
     static constexpr const char* msgPitchUp =             "Move the Pitch stick all the way up and hold it there...";
     static constexpr const char* msgPitchCenter =         "Allow the Pitch stick to move back to center...";
+    static constexpr const char* msgGimbalPitchUp =       "Move the Gimbal Pitch control all the way up and hold it there...";
+    static constexpr const char* msgGimbalPitchDown =     "Move the Gimbal Pitch control all the way down and hold it there...";
+    static constexpr const char* msgGimbalYawUp =         "Move the Gimbal Yaw control all the way up and hold it there...";
+    static constexpr const char* msgGimbalYawDown =       "Move the Gimbal Yaw control all the way down and hold it there...";
     static constexpr const char* msgComplete =            "All settings have been captured.\nClick Next to enable the joystick.";
 
     static const stateMachineEntry rgStateMachine[] = {
@@ -75,6 +79,10 @@ const JoystickConfigController::stateMachineEntry* JoystickConfigController::_ge
         { Joystick::pitchFunction,          msgPitchUp,         _sticksPitchUp,         &JoystickConfigController::_inputStickDetect,       nullptr,                                         nullptr, 3 },
         { Joystick::pitchFunction,          msgPitchDown,       _sticksPitchDown,       &JoystickConfigController::_inputStickMin,          nullptr,                                         nullptr, 3 },
         { Joystick::pitchFunction,          msgPitchCenter,     _sticksCentered,        &JoystickConfigController::_inputCenterWait,        nullptr,                                         nullptr, 3 },
+        { Joystick::gimbalPitchFunction,    msgGimbalPitchUp,   _sticksCentered,        &JoystickConfigController::_inputStickDetect,       nullptr,                                         nullptr, 4 },
+        { Joystick::gimbalPitchFunction,    msgGimbalPitchDown, _sticksCentered,        &JoystickConfigController::_inputStickMin,          nullptr,                                         nullptr, 4 },
+        { Joystick::gimbalYawFunction,      msgGimbalYawUp,     _sticksCentered,        &JoystickConfigController::_inputStickDetect,       nullptr,                                         nullptr, 5 },
+        { Joystick::gimbalYawFunction,      msgGimbalYawDown,   _sticksCentered,        &JoystickConfigController::_inputStickMin,          nullptr,                                         nullptr, 5 },
         { Joystick::maxFunction,            msgComplete,        _sticksCentered,        nullptr,                                            &JoystickConfigController::_writeCalibration,    nullptr, -1 },
     };
 
@@ -84,7 +92,14 @@ const JoystickConfigController::stateMachineEntry* JoystickConfigController::_ge
 
 void JoystickConfigController::_advanceState()
 {
-    _currentStep++;
+    const stateMachineEntry* state = _getStateMachineEntry(++_currentStep);
+
+    // The state machine includes additional states for optional axes. If those
+    // axes aren't detected, those states should be skipped.
+    while (state->function >= _axisCount && state->function < Joystick::maxFunction) {
+        state = _getStateMachineEntry(++_currentStep);
+    }
+
     _setupCurrentState();
 }
 


### PR DESCRIPTION
Description
-----------

Extend joystick interface to support gimbal pitch and yaw controls on axes 4 and 5. Gimbal values are transmitted via `MANUAL_CONTROL` extension fields with flags indicating axis presence. Gimbal calibration steps are automatically skipped if the axes are not detected on the connected joystick.

Test Steps
-----------

1. Connect a joystick with 4 axes.
2. Open the joystick calibration screen.
3. Verify that only 4 axes are calibrated and that the calibration completes successfully.
4. Connect a joystick with 6 axes.
5. Open the joystick calibration screen again.
6. Verify that, in addition to the 4 main axes, 2 optional axes are also calibrated.
7. Inspect the transmitted MAVLink `MANUAL_CONTROL` message:
8. The optional axes must be sent via the `s` and `t` fields.
9. Their presence must be indicated in the `enabled_extensions` field.

Checklist:
----------
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] [Review Contribution Guidelines](https://github.com/mavlink/qgroundcontrol/blob/master/.github/CONTRIBUTING.md).
- [x] [Review Code of Conduct](https://github.com/mavlink/qgroundcontrol/blob/master/.github/CODE_OF_CONDUCT.md).
- [x] I have tested my changes.

Related Issue
-----------
<!-- If any, please provide issue ID. -->


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.