### PR TITLE
Fix toolbar coloring

### DIFF
--- a/src/QmlControls/BatteryIndicator.qml
+++ b/src/QmlControls/BatteryIndicator.qml
@@ -38,7 +38,9 @@ Item {
 
     // Properties to hold the thresholds
     property int threshold1: _batterySettings.threshold1.rawValue
-    property int threshold2: _batterySettings.threshold2.rawValue   
+    property int threshold2: _batterySettings.threshold2.rawValue  
+
+    QGCPalette { id: qgcPal } 
 
     Row {
         id:             batteryIndicatorRow
@@ -176,7 +178,7 @@ Item {
                 QGCLabel {
                     Layout.alignment:       Qt.AlignHCenter
                     verticalAlignment:      Text.AlignVCenter
-                    color:                  qgcPal.text
+                    color:                  qgcPal.toolbarText
                     text:                   getBatteryPercentageText()
                     font.pointSize:         _showBoth ? ScreenTools.defaultFontPointSize : ScreenTools.mediumFontPointSize
                     visible:                _showBoth || _showPercentage
@@ -185,7 +187,7 @@ Item {
                 QGCLabel {
                     Layout.alignment:       Qt.AlignHCenter
                     font.pointSize:         _showBoth ? ScreenTools.defaultFontPointSize : ScreenTools.mediumFontPointSize
-                    color:                  qgcPal.text
+                    color:                  qgcPal.toolbarText
                     text:                   getBatteryVoltageText()
                     visible:                _showBoth || _showVoltage
                 }

--- a/src/QmlControls/FlightModeIndicator.qml
+++ b/src/QmlControls/FlightModeIndicator.qml
@@ -32,23 +32,26 @@ Item {
     property bool _vtolInFWDFlight: activeVehicle ? activeVehicle.vtolInFwdFlight : false
     property var  _vehicleInAir:    activeVehicle ? activeVehicle.flying || activeVehicle.landing : false
 
+    QGCPalette { id: qgcPal }
+
     RowLayout {
         id:         mainLayout
         spacing:    ScreenTools.defaultFontPixelWidth / 2
 
         QGCColoredImage {
-            id:                     flightModeIcon
-            Layout.preferredWidth:  ScreenTools.defaultFontPixelWidth * 3
-            Layout.preferredHeight: ScreenTools.defaultFontPixelHeight
-            fillMode:               Image.PreserveAspectFit
-            mipmap:                 true
-            color:                  qgcPal.text
-            source:                 "/qmlimages/FlightModesComponentIcon.png"
+            id:         flightModeIcon
+            width:      ScreenTools.defaultFontPixelWidth * 3
+            height:     ScreenTools.defaultFontPixelHeight
+            fillMode:   Image.PreserveAspectFit
+            mipmap:     true
+            color:      qgcPal.toolbarText
+            source:     "/qmlimages/FlightModesComponentIcon.png"
         }
 
         QGCLabel {
             id:                 flightModeLabel
             text:               activeVehicle ? activeVehicle.flightMode : qsTr("N/A", "No data to display")
+            color:          qgcPal.toolbarText
             font.pointSize:     fontPointSize
             Layout.alignment:   Qt.AlignCenter
 

--- a/src/QmlControls/FlyViewToolBar.qml
+++ b/src/QmlControls/FlyViewToolBar.qml
@@ -19,7 +19,7 @@ Rectangle {
     id:     _root
     width:  parent.width
     height: ScreenTools.toolbarHeight
-    color:  "transparent"
+    color:  qgcPal.toolbarBackground
 
     property var    _activeVehicle:     QGroundControl.multiVehicleManager.activeVehicle
     property bool   _communicationLost: _activeVehicle ? _activeVehicle.vehicleLinkManager.communicationLost : false
@@ -37,8 +37,7 @@ Rectangle {
         anchors.right:  parent.right
         anchors.bottom: parent.bottom
         height:         1
-        color:          "black"
-        visible:        qgcPal.globalTheme === QGCPalette.Light
+        color:          qgcPal.toolbarDivider
     }
 
     Rectangle {
@@ -92,14 +91,14 @@ Rectangle {
                 QGCButton {
                     id:                 disconnectButton
                     text:               qsTr("Disconnect")
+                    textColor:          qgcPal.toolbarText
                     onClicked:          _activeVehicle.closeVehicle()
                     visible:            _activeVehicle && _communicationLost
                 }
             }
 
             FlightModeIndicator {
-                Layout.fillHeight:  true
-                visible:            _activeVehicle
+                visible: _activeVehicle
             }
         }
 

--- a/src/QmlControls/GPSIndicator.qml
+++ b/src/QmlControls/GPSIndicator.qml
@@ -13,9 +13,6 @@ import QtQuick.Layouts
 import QGroundControl
 import QGroundControl.Controls
 
-
-
-
 // Used as the base class control for nboth VehicleGPSIndicator and RTKGPSIndicator
 
 Item {
@@ -26,6 +23,8 @@ Item {
 
     property var    _activeVehicle: QGroundControl.multiVehicleManager.activeVehicle
     property bool   _rtkConnected:  QGroundControl.gpsRtk.connected.value
+
+    QGCPalette { id: qgcPal }
 
     Row {
         id:             gpsIndicatorRow
@@ -42,7 +41,7 @@ Item {
                 id:                     gpsLabel
                 rotation:               90
                 text:                   qsTr("RTK")
-                color:                  qgcPal.buttonText
+                color:                  qgcPal.toolbarText
                 anchors.verticalCenter: parent.verticalCenter
                 visible:                _rtkConnected
             }
@@ -56,7 +55,7 @@ Item {
                 fillMode:           Image.PreserveAspectFit
                 sourceSize.height:  height
                 opacity:            (_activeVehicle && _activeVehicle.gps.count.value >= 0) ? 1 : 0.5
-                color:              qgcPal.buttonText
+                color:              qgcPal.toolbarText
             }
         }
 
@@ -68,13 +67,13 @@ Item {
 
             QGCLabel {
                 anchors.horizontalCenter:   hdopValue.horizontalCenter
-                color:              qgcPal.buttonText
+                color:              qgcPal.toolbarText
                 text:               _activeVehicle ? _activeVehicle.gps.count.valueString : ""
             }
 
             QGCLabel {
                 id:     hdopValue
-                color:  qgcPal.buttonText
+                color:  qgcPal.toolbarText
                 text:   _activeVehicle ? _activeVehicle.gps.hdop.value.toFixed(1) : ""
             }
         }

--- a/src/QmlControls/MainStatusIndicator.qml
+++ b/src/QmlControls/MainStatusIndicator.qml
@@ -30,12 +30,15 @@ RowLayout {
         mainWindow.showIndicatorDrawer(overallStatusComponent, control)
     }
 
+    QGCPalette { id: qgcPal }
+
     QGCLabel {
         id:                 mainStatusLabel
         Layout.fillHeight:  true
         Layout.preferredWidth: contentWidth + (vehicleMessagesIcon.visible ? vehicleMessagesIcon.width + control.spacing : 0)
         verticalAlignment:  Text.AlignVCenter
         text:               mainStatusText()
+        color:              qgcPal.toolbarText
         font.pointSize:     ScreenTools.largeFontPointSize
 
         property string _commLostText:      qsTr("Comms Lost")
@@ -139,6 +142,25 @@ RowLayout {
         QGCMouseArea {
             anchors.fill:   parent
             onClicked:      dropMainStatusIndicator()
+        }
+    }
+
+    QGCLabel {
+        id:                 vtolModeLabel
+        Layout.fillHeight:  true
+        verticalAlignment:  Text.AlignVCenter
+        text:               _vtolInFWDFlight ? qsTr("FW(vtol)") : qsTr("MR(vtol)")
+        color:              qgcPal.toolbarText
+        font.pointSize:     _vehicleInAir ? ScreenTools.largeFontPointSize : ScreenTools.defaultFontPointSize
+        visible:            _activeVehicle && _activeVehicle.vtol
+
+        QGCMouseArea {
+            anchors.fill: parent
+            onClicked: {
+                if (_vehicleInAir) {
+                    mainWindow.showIndicatorDrawer(vtolTransitionIndicatorPage)
+                }
+            }
         }
     }
 

--- a/src/QmlControls/QGCPalette.cc
+++ b/src/QmlControls/QGCPalette.cc
@@ -82,7 +82,9 @@ void QGCPalette::_buildMap()
     DECLARE_QGC_COLOR(statusFailedText,     "#9d9d9d", "#000000", "#707070", "#ffffff")
     DECLARE_QGC_COLOR(statusPassedText,     "#9d9d9d", "#000000", "#707070", "#ffffff")
     DECLARE_QGC_COLOR(statusPendingText,    "#9d9d9d", "#000000", "#707070", "#ffffff")
-    DECLARE_QGC_COLOR(toolbarBackground,    "#ffffff", "#ffffff", "#222222", "#222222")
+    DECLARE_QGC_COLOR(toolbarBackground,    "#00ffffff", "#00ffffff", "#00222222", "#00222222")
+    DECLARE_QGC_COLOR(toolbarDivider,       "#00000000", "#00000000", "#00000000", "#00000000")
+    DECLARE_QGC_COLOR(toolbarText,          "#707070", "#ffffff", "#707070", "#ffffff")
     DECLARE_QGC_COLOR(groupBorder,          "#bbbbbb", "#bbbbbb", "#707070", "#707070")
 
     // Colors not affecting by theming

--- a/src/QmlControls/QGCPalette.h
+++ b/src/QmlControls/QGCPalette.h
@@ -154,6 +154,8 @@ public:
     DEFINE_QGC_COLOR(surveyPolygonInterior,         setSurveyPolygonInterior)
     DEFINE_QGC_COLOR(surveyPolygonTerrainCollision, setSurveyPolygonTerrainCollision)
     DEFINE_QGC_COLOR(toolbarBackground,             setToolbarBackground)
+    DEFINE_QGC_COLOR(toolbarDivider,                setToolbarDivider)
+    DEFINE_QGC_COLOR(toolbarText,                   setToolbarText)
     DEFINE_QGC_COLOR(toolStripFGColor,              setToolStripFGColor)
     DEFINE_QGC_COLOR(toolStripHoverColor,           setToolStripHoverColor)
     DEFINE_QGC_COLOR(groupBorder,                   setGroupBorder)

--- a/src/QmlControls/ToolStrip.qml
+++ b/src/QmlControls/ToolStrip.qml
@@ -17,7 +17,7 @@ import QGroundControl.Controls
 
 Rectangle {
     id:         _root
-    color:      qgcPal.toolbarBackground
+    color:      qgcPal.window
     width:      ScreenTools.defaultFontPixelWidth * 8
     height:     Math.min(maxHeight, toolStripColumn.height + (flickable.anchors.margins * 2))
     radius:     ScreenTools.defaultFontPixelWidth / 2

--- a/src/UI/toolbar/EscIndicator.qml
+++ b/src/UI/toolbar/EscIndicator.qml
@@ -66,6 +66,8 @@ Item {
         return _escHealthy ? qgcPal.colorGreen : qgcPal.colorRed
     }
 
+    QGCPalette { id: qgcPal }
+
     Row {
         id:             escIndicatorRow
         anchors.top:    parent.top
@@ -80,7 +82,7 @@ Item {
             source:             "/qmlimages/EscIndicator.svg"
             fillMode:           Image.PreserveAspectFit
             sourceSize.height:  height
-            color:              qgcPal.buttonText
+            color:              qgcPal.toolbarText
         }
 
         Column {
@@ -90,7 +92,7 @@ Item {
 
             QGCLabel {
                 anchors.horizontalCenter:   parent.horizontalCenter
-                color:                      qgcPal.buttonText
+                color:                      qgcPal.toolbarText
                 text:                       _onlineMotorCount.toString()
                 font.pointSize:             ScreenTools.smallFontPointSize
             }

--- a/src/UI/toolbar/GimbalIndicator.qml
+++ b/src/UI/toolbar/GimbalIndicator.qml
@@ -41,6 +41,8 @@ Item {
 
     property var _gimbalControllerSettings: QGroundControl.settingsManager.gimbalControllerSettings
 
+    QGCPalette { id: qgcPal }
+
     Row {
         id:             gimbalIndicatorRow
         anchors.top:    parent.top
@@ -60,7 +62,7 @@ Item {
                 source:                  "/gimbal/payload.png"
                 fillMode:                Image.PreserveAspectFit
                 sourceSize.height:       height
-                color:                   qgcPal.buttonText
+                color:                   qgcPal.toolbarText
 
             }
 
@@ -69,6 +71,7 @@ Item {
                 anchors.horizontalCenter: parent.horizontalCenter
                 font.pointSize:         ScreenTools.smallFontPointSize
                 text:                   activeGimbal ? activeGimbal.deviceId.rawValue : ""
+                color:                  qgcPal.toolbarText
                 visible:                multiGimbalSetup
             }
         }
@@ -87,6 +90,7 @@ Item {
                 text:                   activeGimbal && activeGimbal.retracted ? 
                                             qsTr("Retracted") :
                                             (activeGimbal && activeGimbal.yawLock ? qsTr("Yaw locked") : qsTr("Yaw follow"))
+                color:                  qgcPal.toolbarText
                 Layout.columnSpan:      2
                 Layout.alignment:       Qt.AlignHCenter
             }
@@ -94,6 +98,7 @@ Item {
                 id:             pitchLabel
                 font.pointSize: ScreenTools.smallFontPointSize
                 text:           activeGimbal ? qsTr("P: ") + activeGimbal.absolutePitch.rawValue.toFixed(1) : ""
+                color:          qgcPal.toolbarText
             }
             QGCLabel {
                 id:             panLabel
@@ -103,6 +108,7 @@ Item {
                                         (qsTr("Az: ") + activeGimbal.absoluteYaw.rawValue.toFixed(1)) :
                                         (qsTr("Y: ") + activeGimbal.bodyYaw.rawValue.toFixed(1))) :
                                     ""
+                color:          qgcPal.toolbarText
             }
         }
     }

--- a/src/UI/toolbar/JoystickIndicator.qml
+++ b/src/UI/toolbar/JoystickIndicator.qml
@@ -26,6 +26,8 @@ Item {
     property bool _vehicleIsSub: _activeVehicle && _activeVehicle.sub
     property bool _showJoystickIndicator: QGroundControl.settingsManager.flyViewSettings.showJoystickIndicatorInToolbar.rawValue
 
+    QGCPalette { id: qgcPal }
+
     Component {
         id: joystickInfoPage
 
@@ -70,7 +72,7 @@ Item {
                 if(globals.activeVehicle && joystickManager.activeJoystick) {
                     if(globals.activeVehicle.joystickEnabled) {
                         // Everything ready to use joystick
-                        return qgcPal.buttonText
+                        return qgcPal.toolbarText
                     }
                     // Joystick is not enabled in the joystick configuration page
                     return "yellow"

--- a/src/UI/toolbar/RemoteIDIndicator.qml
+++ b/src/UI/toolbar/RemoteIDIndicator.qml
@@ -96,6 +96,8 @@ Item {
         }
     }
 
+    QGCPalette { id: qgcPal }
+
     QGCColoredImage {
         id:                 remoteIDIcon
         width:              height


### PR DESCRIPTION
* Transparent toolbar coloring not working with Light theme
* Added/use new  QGCPalette values for toolbar ui. This allows custom build to go back to opaque toolbar if desired.