### PR TITLE
Video: Added ability for force hardware decoder usage

### DIFF
--- a/src/Settings/Video.SettingsGroup.json
+++ b/src/Settings/Video.SettingsGroup.json
@@ -128,12 +128,13 @@
 },
 {
     "name":             "forceVideoDecoder",
-    "shortDesc":        "Force specific category of video decode",
+    "shortDesc":        "Force video decoder priority",
     "longDesc":         "Force the change of prioritization between video decode methods, allowing the user to force some video hardware decode plugins if necessary.",
     "type":             "uint32",
-    "enumStrings":      "Default,Force software decoder,Force NVIDIA decoder,Force VA-API decoder,Force DirectX3D 11 decoder,Force VideoToolbox decoder,Force Intel decoder,Force Vulkan decoder",
-    "enumValues":       "0,1,2,3,4,5,6,7",
-    "default":           0
+    "enumStrings":      "Default,Force software decoder,Force hardware decoder,Force NVIDIA decoder,Force VA-API decoder,Force DirectX3D 11 decoder,Force VideoToolbox decoder,Force Intel decoder,Force Vulkan decoder",
+    "enumValues":       "0,1,8,2,3,4,5,6,7",
+    "default":           0,
+    "qgcRebootRequired": true
 }
 ]
 }

--- a/src/UI/AppSettings/VideoSettings.qml
+++ b/src/UI/AppSettings/VideoSettings.qml
@@ -108,7 +108,7 @@ SettingsPage {
 
         LabelledFactComboBox {
             Layout.fillWidth:   true
-            label:              qsTr("Video decode priority")
+            label:              fact.shortDescription
             fact:               _videoSettings.forceVideoDecoder
             visible:            fact.visible
             indexModel:         false

--- a/src/VideoManager/VideoReceiver/GStreamer/GStreamer.h
+++ b/src/VideoManager/VideoReceiver/GStreamer/GStreamer.h
@@ -28,7 +28,8 @@ enum VideoDecoderOptions {
     ForceVideoDecoderDirectX3D,
     ForceVideoDecoderVideoToolbox,
     ForceVideoDecoderIntel,
-    ForceVideoDecoderVulkan
+    ForceVideoDecoderVulkan,
+    ForceVideoDecoderHardware
 };
 
 bool initialize();

--- a/src/VideoManager/VideoReceiver/GStreamer/GStreamerHelpers.cc
+++ b/src/VideoManager/VideoReceiver/GStreamer/GStreamerHelpers.cc
@@ -10,6 +10,8 @@
 #include "GStreamerHelpers.h"
 
 #include <gst/rtsp/gstrtspurl.h>
+#include <QtCore/QString>
+#include <QtCore/QStringList>
 
 namespace GStreamer
 {
@@ -31,6 +33,51 @@ is_valid_rtsp_uri(const gchar *uri_str)
 
     gst_rtsp_url_free(url);
     return TRUE;
+}
+
+bool is_hardware_decoder_factory(GstElementFactory *factory)
+{
+    if (!factory) {
+        return false;
+    }
+
+    const auto containsHardware = [](const gchar *value) {
+        return value && (g_strrstr(value, "Hardware") != nullptr || g_strrstr(value, "hardware") != nullptr);
+    };
+
+    if (containsHardware(gst_element_factory_get_metadata(factory, GST_ELEMENT_METADATA_KLASS))) {
+        return true;
+    }
+
+    if (containsHardware(gst_element_factory_get_klass(factory))) {
+        return true;
+    }
+
+    const gchar *factoryName = gst_plugin_feature_get_name(GST_PLUGIN_FEATURE(factory));
+    if (!factoryName) {
+        return false;
+    }
+
+    const QString nameLower = QString::fromUtf8(factoryName).toLower();
+    static const QStringList kHardwareTags = {
+        QStringLiteral("va"),      // vaapi family
+        QStringLiteral("nv"),      // nvidia nvcodec
+        QStringLiteral("qsv"),     // intel quick sync
+        QStringLiteral("msdk"),    // intel media sdk
+        QStringLiteral("vulkan"),  // vulkan accelerated
+        QStringLiteral("d3d"),     // direct3d
+        QStringLiteral("dxva"),    // directx video accel
+        QStringLiteral("vtdec"),   // apple video toolbox
+        QStringLiteral("metal")    // metal-based decoders
+    };
+
+    for (const QString &tag : kHardwareTags) {
+        if (nameLower.contains(tag)) {
+            return true;
+        }
+    }
+
+    return false;
 }
 
 } // namespace GStreamer

--- a/src/VideoManager/VideoReceiver/GStreamer/GStreamerHelpers.h
+++ b/src/VideoManager/VideoReceiver/GStreamer/GStreamerHelpers.h
@@ -10,8 +10,14 @@
 #pragma once
 
 #include <glib.h>
+// Needed for GstElementFactory
+#include <gst/gst.h>
 
 namespace GStreamer
 {
     gboolean is_valid_rtsp_uri(const gchar *uri_str);
+
+    // Returns true if the given factory likely represents a hardware-accelerated decoder.
+    // Heuristics: checks metadata/klass for "Hardware" and common vendor tags in the factory name.
+    bool is_hardware_decoder_factory(GstElementFactory *factory);
 }


### PR DESCRIPTION
* Added setting to force hardware decoder usage
* Changed forced ranking of software/hardware decoders to walk installed plugins instead of use hardcoded list
* Added Video.GStreamerDecoderRanks category which will log the default decoder priority ranking in rank order
* Added much better logging to various places

Thanks to our AI overlords for dealing with most of this :)