### PR TITLE
Standard Modes: Update the UI after receiving available modes

### DIFF
--- a/src/Vehicle/Vehicle.cc
+++ b/src/Vehicle/Vehicle.cc
@@ -287,6 +287,11 @@ void Vehicle::_commonInit(LinkInterface* link)
     }
 
     connect(_standardModes, &StandardModes::modesUpdated, this, &Vehicle::flightModesChanged);
+    // Re-emit flightModeChanged after available modes mapping updates so UI refreshes
+    // the human-readable mode name even if HEARTBEAT arrived earlier.
+    connect(_standardModes, &StandardModes::modesUpdated, this, [this]() {
+        emit flightModeChanged(flightMode());
+    });
 
     _parameterManager = new ParameterManager(this);
     connect(_parameterManager, &ParameterManager::parametersReadyChanged, this, &Vehicle::_parametersReady);


### PR DESCRIPTION
<!--- Title -->

Description
-----------
This makes sure the UI gets updated after we have received the available modes even if the heartbeat was received prior to it. I wasn't sure this was the proper fix, but from the discussion in #13535 it seems like it is.

I have tested that this changes fixes the issue for my use case, but didn't test this change with a wider set of autopilots.

Test Steps
-----------
<!-- Describe the steps to reproduce. -->

Checklist:
----------
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] [Review Contribution Guidelines](https://github.com/mavlink/qgroundcontrol/blob/master/.github/CONTRIBUTING.md).
- [x] [Review Code of Conduct](https://github.com/mavlink/qgroundcontrol/blob/master/.github/CODE_OF_CONDUCT.md).
- [x] I have tested my changes.

Related Issue
-----------

Fixes #13535


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.