### PR TITLE
InitialConnectStateMachine: Don't assume capabilities on AUTOPILOT_VERSION if failure requesting

### DIFF
--- a/src/Vehicle/InitialConnectStateMachine.cc
+++ b/src/Vehicle/InitialConnectStateMachine.cc
@@ -173,17 +173,9 @@ void InitialConnectStateMachine::_autopilotVersionRequestMessageHandler(void* re
     }
 
     if (failureCode != Vehicle::RequestMessageNoFailure) {
-        qCDebug(InitialConnectStateMachineLog) << "REQUEST_MESSAGE:AUTOPILOT_VERSION failed. Setting no capabilities";
-        uint64_t assumedCapabilities = 0;
-        if (vehicle->_mavlinkProtocolRequestMaxProtoVersion >= 200) {
-            // Link already running mavlink 2
-            assumedCapabilities |= MAV_PROTOCOL_CAPABILITY_MAVLINK2;
-        }
-        if (vehicle->px4Firmware() || vehicle->apmFirmware()) {
-            // We make some assumptions for known firmware
-            assumedCapabilities |= MAV_PROTOCOL_CAPABILITY_MISSION_INT | MAV_PROTOCOL_CAPABILITY_COMMAND_INT | MAV_PROTOCOL_CAPABILITY_MISSION_FENCE | MAV_PROTOCOL_CAPABILITY_MISSION_RALLY;
-        }
-        vehicle->_setCapabilities(assumedCapabilities);
+        qCDebug(InitialConnectStateMachineLog) << "REQUEST_MESSAGE:AUTOPILOT_VERSION failed. Retrying";
+        _stateRequestAutopilotVersion(connectMachine);
+        return;
     }
 
     connectMachine->advance();


### PR DESCRIPTION
<!--- Title -->

Description
-----------
I was running into an issue on my android system where if I launch the radio while QGC is already running, that initial boot of the radio will cause lag in the connection, and so the initial AUTOPILOT_VERSION request would fail.

QGC will assume some generic default autopilot version if the initial request fails rather than continually retrying. So, that launch will have the version as "Unknown".

Unless there are specific autopilots that do not use AUTOPILOT_VERSION, I think that QGC should probably require it in order to have a successful connection. This PR will continually request it during the connection phase and will not advance the state machine until it successfully gets it, which avoids chance of radio lag causing the connection to not get AUTOPILOT_VERSION successfully. 

Note: This PR is created under the assumption that there are no systems which don't use AUTOPILOT_VERSION. If it turns out that there are systems which don't provide it, we might want to maybe just increase the retries of this specific step or something

Test Steps
-----------
1. Launch QGC on device with radio turned off
2. Turn on radio
3. That initial radio lag of the radio turning on will now simply halt the connection states until we can successfully get AUTOPILOT_VERSION

Checklist:
----------
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] [Review Contribution Guidelines](https://github.com/mavlink/qgroundcontrol/blob/master/.github/CONTRIBUTING.md).
- [x] [Review Code of Conduct](https://github.com/mavlink/qgroundcontrol/blob/master/.github/CODE_OF_CONDUCT.md).
- [x] I have tested my changes.

Related Issue
-----------
https://github.com/mavlink/qgroundcontrol/issues/13551


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.