### PR TITLE
Add support for Settings Override Files

### DIFF
--- a/custom-example/src/CustomPlugin.cc
+++ b/custom-example/src/CustomPlugin.cc
@@ -94,23 +94,23 @@ bool CustomPlugin::overrideSettingsGroupVisibility(const QString &name)
     return true;
 }
 
-bool CustomPlugin::adjustSettingMetaData(const QString& settingsGroup, FactMetaData& metaData)
+void CustomPlugin::adjustSettingMetaData(const QString& settingsGroup, FactMetaData& metaData, bool &visible)
 {
-    const bool parentResult = QGCCorePlugin::adjustSettingMetaData(settingsGroup, metaData);
+    QGCCorePlugin::adjustSettingMetaData(settingsGroup, metaData, visible);
 
     if (settingsGroup == AppSettings::settingsGroup) {
         // This tells QGC than when you are creating Plans while not connected to a vehicle
         // the specific firmware/vehicle the plan is for.
         if (metaData.name() == AppSettings::offlineEditingFirmwareClassName) {
             metaData.setRawDefaultValue(QGCMAVLink::FirmwareClassPX4);
-            return false;
+            visible = false;
+            return;
         } else if (metaData.name() == AppSettings::offlineEditingVehicleClassName) {
             metaData.setRawDefaultValue(QGCMAVLink::VehicleClassMultiRotor);
-            return false;
+            visible = false;
+            return;
         }
     }
-
-    return parentResult;
 }
 
 void CustomPlugin::paletteOverride(const QString &colorName, QGCPalette::PaletteColorInfo_t& colorInfo)

--- a/custom-example/src/CustomPlugin.h
+++ b/custom-example/src/CustomPlugin.h
@@ -77,7 +77,7 @@ public:
     QString brandImageOutdoor() const final { return QStringLiteral("/custom/img/dronecode-black.svg"); }
     bool overrideSettingsGroupVisibility(const QString &name) final;
     /// This allows you to override/hide QGC Application settings
-    bool adjustSettingMetaData(const QString &settingsGroup, FactMetaData &metaData) final;
+    void adjustSettingMetaData(const QString &settingsGroup, FactMetaData &metaData, bool &visible) final;
     /// This modifies QGC colors palette to match possible custom corporate branding
     void paletteOverride(const QString &colorName, QGCPalette::PaletteColorInfo_t &colorInfo) final;
     /// We override this so we can get access to QQmlApplicationEngine and use it to register our qml module

--- a/src/API/QGCCorePlugin.cc
+++ b/src/API/QGCCorePlugin.cc
@@ -110,7 +110,7 @@ const QmlObjectListModel *QGCCorePlugin::customMapItems()
     return _emptyCustomMapItems;
 }
 
-bool QGCCorePlugin::adjustSettingMetaData(const QString &settingsGroup, FactMetaData &metaData)
+void QGCCorePlugin::adjustSettingMetaData(const QString &settingsGroup, FactMetaData &metaData, bool &visible)
 {
     if (settingsGroup == AppSettings::settingsGroup) {
         if (metaData.name() == AppSettings::indoorPaletteName) {
@@ -121,22 +121,21 @@ bool QGCCorePlugin::adjustSettingMetaData(const QString &settingsGroup, FactMeta
             outdoorPalette = 1;
 #endif
             metaData.setRawDefaultValue(outdoorPalette);
-            return true;
+            return;
         }
 #if defined(Q_OS_ANDROID) || defined(Q_OS_IOS)
         else if (metaData.name() == MavlinkSettings::telemetrySaveName) {
             metaData.setRawDefaultValue(false);
-            return true;
+            return;
         }
 #endif
 #ifndef Q_OS_ANDROID
         else if (metaData.name() == AppSettings::androidDontSaveToSDCardName) {
-            return false;
+            visible = false;
+            return;
         }
 #endif
     }
-
-    return true;
 }
 
 QString QGCCorePlugin::showAdvancedUIMessage() const

--- a/src/API/QGCCorePlugin.h
+++ b/src/API/QGCCorePlugin.h
@@ -78,11 +78,12 @@ public:
     /// @return true: Show settings ui, false: Hide settings ui
     virtual bool overrideSettingsGroupVisibility(const QString &name) { Q_UNUSED(name); return true; }
 
-    /// Allows the core plugin to override the setting meta data before the setting fact is created.
+    /// Allows the core plugin to override the meta data before the fact is created.
     ///     @param settingsGroup - QSettings group which contains this item
     ///     @param metaData - MetaData for setting fact
-    /// @return true: Setting should be visible in ui, false: Setting should not be shown in ui
-    virtual bool adjustSettingMetaData(const QString &settingsGroup, FactMetaData &metaData);
+    ///     @param visible - true: Setting should be visible in ui, false: Setting should not be shown in ui (default value will be used as value)
+    /// If not overridden, metaData and visible are left unchanged.
+    virtual void adjustSettingMetaData(const QString &settingsGroup, FactMetaData &metaData, bool &visible);
 
     /// Return the resource file which contains the brand image for for Indoor theme.
     virtual QString brandImageIndoor() const { return QString(); }

--- a/src/FactSystem/Fact.cc
+++ b/src/FactSystem/Fact.cc
@@ -12,6 +12,7 @@
 #include "QGCApplication.h"
 #include "QGCCorePlugin.h"
 #include "QGCLoggingCategory.h"
+#include "SettingsManager.h"
 
 QGC_LOGGING_CATEGORY(FactLog, "FactSystem.Fact")
 
@@ -48,8 +49,16 @@ Fact::Fact(const QString& settingsGroup, FactMetaData *metaData, QObject *parent
 {
     // qCDebug(FactLog) << Q_FUNC_INFO << this;
 
-    QGCCorePlugin::instance()->adjustSettingMetaData(settingsGroup, *metaData);
+    bool visible = true;
+    SettingsManager::adjustSettingMetaData(settingsGroup, *metaData, visible);
     setMetaData(metaData, true /* setDefaultFromMetaData */);
+
+    if (!qgcApp()->runningUnitTests()) {
+        if (metaData->defaultValueAvailable() && !visible) {
+            // If setting is not visible, we force to default value
+            _rawValue = metaData->rawDefaultValue();
+        }
+    }
 
     _init();
 }

--- a/src/FactSystem/Fact.h
+++ b/src/FactSystem/Fact.h
@@ -71,7 +71,7 @@ public:
     explicit Fact(int componentId, const QString &name, FactMetaData::ValueType_t type, QObject *parent = nullptr);
     explicit Fact(const Fact &other, QObject *parent = nullptr);
 
-    /// Creates a Fact using the name and type from metaData. Also calls QGCCorePlugin::adjustSettingsMetaData allowing
+    /// Creates a Fact using the name and type from metaData. Also calls SettingsManager::adjustSettingMetaData allowing
     /// custom builds to override the metadata.
     explicit Fact(const QString &settingsGroup, FactMetaData *metaData, QObject *parent = nullptr);
     virtual ~Fact();

--- a/src/FactSystem/FactMetaData.h
+++ b/src/FactSystem/FactMetaData.h
@@ -19,6 +19,8 @@
 
 Q_DECLARE_LOGGING_CATEGORY(FactMetaDataLog)
 
+class SettingsManager;
+
 /// Holds the meta data associated with a Fact. This is kept in a separate object from the Fact itself
 /// since you may have multiple instances of the same Fact. But there is only ever one FactMetaData
 /// instance or each Fact.
@@ -26,6 +28,9 @@ class FactMetaData : public QObject
 {
     Q_OBJECT
     QML_ELEMENT
+
+    friend class SettingsManager;
+    
 public:
     enum ValueType_t {
         valueTypeUint8,

--- a/src/FactSystem/SettingsFact.cc
+++ b/src/FactSystem/SettingsFact.cc
@@ -11,6 +11,7 @@
 #include "QGCApplication.h"
 #include "QGCCorePlugin.h"
 #include "QGCLoggingCategory.h"
+#include "SettingsManager.h"
 
 #include <QtCore/QSettings>
 
@@ -34,7 +35,7 @@ SettingsFact::SettingsFact(const QString &settingsGroup, FactMetaData *metaData,
     }
 
     // Allow core plugin a chance to override the default value
-    _visible = QGCCorePlugin::instance()->adjustSettingMetaData(settingsGroup, *metaData);
+    SettingsManager::adjustSettingMetaData(settingsGroup, *metaData, _visible);
     setMetaData(metaData);
 
     if (metaData->defaultValueAvailable()) {
@@ -49,7 +50,7 @@ SettingsFact::SettingsFact(const QString &settingsGroup, FactMetaData *metaData,
             _rawValue = typedValue;
         } else {
             // Setting is not visible, force to default value always
-            settings.setValue(_name, rawDefaultValue);
+            // Note that we specifically do not save this back to QSettings such that a Settings Override file change is not a permanent change
             _rawValue = rawDefaultValue;
         }
     }

--- a/src/Settings/AppSettings.cc
+++ b/src/Settings/AppSettings.cc
@@ -65,28 +65,6 @@ DECLARE_SETTINGGROUP(App, "")
 {
     QGCPalette::setGlobalTheme(indoorPalette()->rawValue().toBool() ? QGCPalette::Dark : QGCPalette::Light);
 
-    QSettings settings;
-
-    // These two "type" keys were changed to "class" values
-    static const char* deprecatedFirmwareTypeKey    = "offlineEditingFirmwareType";
-    static const char* deprecatedVehicleTypeKey     = "offlineEditingVehicleType";
-    if (settings.contains(deprecatedFirmwareTypeKey)) {
-        settings.setValue(deprecatedFirmwareTypeKey, QGCMAVLink::firmwareClass(static_cast<MAV_AUTOPILOT>(settings.value(deprecatedFirmwareTypeKey).toInt())));
-    }
-    if (settings.contains(deprecatedVehicleTypeKey)) {
-        settings.setValue(deprecatedVehicleTypeKey, QGCMAVLink::vehicleClass(static_cast<MAV_TYPE>(settings.value(deprecatedVehicleTypeKey).toInt())));
-    }
-
-    QStringList deprecatedKeyNames  = { "virtualJoystickCentralized",           "offlineEditingFirmwareType",   "offlineEditingVehicleType" };
-    QStringList newKeyNames         = { "virtualJoystickAutoCenterThrottle",    "offlineEditingFirmwareClass",  "offlineEditingVehicleClass" };
-    settings.beginGroup(_settingsGroup);
-    for (int i=0; i<deprecatedKeyNames.count(); i++) {
-        if (settings.contains(deprecatedKeyNames[i])) {
-            settings.setValue(newKeyNames[i], settings.value(deprecatedKeyNames[i]));
-            settings.remove(deprecatedKeyNames[i]);
-        }
-    }
-
     // Instantiate savePath so we can check for override and setup default path if needed
 
     SettingsFact* savePathFact = qobject_cast<SettingsFact*>(savePath());
@@ -242,7 +220,23 @@ void AppSettings::_checkSavePathDirectories(void)
         savePathDir.mkdir(photoDirectory);
         savePathDir.mkdir(crashDirectory);
         savePathDir.mkdir(mavlinkActionsDirectory);
+        savePathDir.mkdir(settingsDirectory);
     }
+}
+
+QString AppSettings::_childSavePath(const char* directory)
+{
+    const QString rootPath = savePath()->rawValue().toString();
+    if (rootPath.isEmpty()) {
+        return QString();
+    }
+
+    const QDir rootDir(rootPath);
+    if (!rootDir.exists()) {
+        return QString();
+    }
+
+    return rootDir.filePath(directory);
 }
 
 void AppSettings::_indoorPaletteChanged(void)
@@ -252,82 +246,47 @@ void AppSettings::_indoorPaletteChanged(void)
 
 QString AppSettings::missionSavePath(void)
 {
-    QString path = savePath()->rawValue().toString();
-    if (!path.isEmpty() && QDir(path).exists()) {
-        QDir dir(path);
-        return dir.filePath(missionDirectory);
-    }
-    return QString();
+    return _childSavePath(missionDirectory);
 }
 
 QString AppSettings::parameterSavePath(void)
 {
-    QString path = savePath()->rawValue().toString();
-    if (!path.isEmpty() && QDir(path).exists()) {
-        QDir dir(path);
-        return dir.filePath(parameterDirectory);
-    }
-    return QString();
+    return _childSavePath(parameterDirectory);
 }
 
 QString AppSettings::telemetrySavePath(void)
 {
-    QString path = savePath()->rawValue().toString();
-    if (!path.isEmpty() && QDir(path).exists()) {
-        QDir dir(path);
-        return dir.filePath(telemetryDirectory);
-    }
-    return QString();
+    return _childSavePath(telemetryDirectory);
 }
 
 QString AppSettings::logSavePath(void)
 {
-    QString path = savePath()->rawValue().toString();
-    if (!path.isEmpty() && QDir(path).exists()) {
-        QDir dir(path);
-        return dir.filePath(logDirectory);
-    }
-    return QString();
+    return _childSavePath(logDirectory);
 }
 
 QString AppSettings::videoSavePath(void)
 {
-    QString path = savePath()->rawValue().toString();
-    if (!path.isEmpty() && QDir(path).exists()) {
-        QDir dir(path);
-        return dir.filePath(videoDirectory);
-    }
-    return QString();
+    return _childSavePath(videoDirectory);
 }
 
 QString AppSettings::photoSavePath(void)
 {
-    QString path = savePath()->rawValue().toString();
-    if (!path.isEmpty() && QDir(path).exists()) {
-        QDir dir(path);
-        return dir.filePath(photoDirectory);
-    }
-    return QString();
+    return _childSavePath(photoDirectory);
 }
 
 QString AppSettings::crashSavePath(void)
 {
-    QString path = savePath()->rawValue().toString();
-    if (!path.isEmpty() && QDir(path).exists()) {
-        QDir dir(path);
-        return dir.filePath(crashDirectory);
-    }
-    return QString();
+    return _childSavePath(crashDirectory);
 }
 
 QString AppSettings::mavlinkActionsSavePath(void)
 {
-    QString path = savePath()->rawValue().toString();
-    if (!path.isEmpty() && QDir(path).exists()) {
-        QDir dir(path);
-        return dir.filePath(mavlinkActionsDirectory);
-    }
-    return QString();
+    return _childSavePath(mavlinkActionsDirectory);
+}
+
+QString AppSettings::settingsSavePath(void)
+{
+    return _childSavePath(settingsDirectory);
 }
 
 QList<int> AppSettings::firstRunPromptsIdsVariantToList(const QVariant& firstRunPromptIds)

--- a/src/Settings/AppSettings.h
+++ b/src/Settings/AppSettings.h
@@ -68,7 +68,8 @@ public:
     Q_PROPERTY(QString videoSavePath            READ videoSavePath              NOTIFY savePathsChanged)
     Q_PROPERTY(QString photoSavePath            READ photoSavePath              NOTIFY savePathsChanged)
     Q_PROPERTY(QString crashSavePath            READ crashSavePath              NOTIFY savePathsChanged)
-    Q_PROPERTY(QString mavlinkActionsSavePath    READ mavlinkActionsSavePath      NOTIFY savePathsChanged)
+    Q_PROPERTY(QString mavlinkActionsSavePath   READ mavlinkActionsSavePath     NOTIFY savePathsChanged)
+    Q_PROPERTY(QString settingsSavePath         READ settingsSavePath           NOTIFY savePathsChanged)
 
     Q_PROPERTY(QString planFileExtension        MEMBER planFileExtension        CONSTANT)
     Q_PROPERTY(QString missionFileExtension     MEMBER missionFileExtension     CONSTANT)
@@ -79,6 +80,8 @@ public:
     Q_PROPERTY(QString shpFileExtension         MEMBER shpFileExtension         CONSTANT)
     Q_PROPERTY(QString logFileExtension         MEMBER logFileExtension         CONSTANT)
     Q_PROPERTY(QString tilesetFileExtension     MEMBER tilesetFileExtension     CONSTANT)
+    Q_PROPERTY(QString settingsFileExtension    MEMBER settingsFileExtension    CONSTANT)
+
 
     QString missionSavePath       ();
     QString parameterSavePath     ();
@@ -87,7 +90,8 @@ public:
     QString videoSavePath         ();
     QString photoSavePath         ();
     QString crashSavePath         ();
-    QString mavlinkActionsSavePath ();
+    QString mavlinkActionsSavePath();
+    QString settingsSavePath      ();
 
     // Helper methods for working with firstRunPromptIds QVariant settings string list
     static QList<int> firstRunPromptsIdsVariantToList   (const QVariant& firstRunPromptIds);
@@ -106,6 +110,7 @@ public:
     static constexpr const char* shpFileExtension =         "shp";
     static constexpr const char* logFileExtension =         "ulg";
     static constexpr const char* tilesetFileExtension =     "qgctiledb";
+    static constexpr const char* settingsFileExtension =    "settings";
 
     // Child directories of savePath for specific file types
     static constexpr const char* parameterDirectory =       QT_TRANSLATE_NOOP("AppSettings", "Parameters");
@@ -116,6 +121,7 @@ public:
     static constexpr const char* photoDirectory =           QT_TRANSLATE_NOOP("AppSettings", "Photo");
     static constexpr const char* crashDirectory =           QT_TRANSLATE_NOOP("AppSettings", "CrashLogs");
     static constexpr const char* mavlinkActionsDirectory =  QT_TRANSLATE_NOOP("AppSettings", "MavlinkActions");
+    static constexpr const char* settingsDirectory =        QT_TRANSLATE_NOOP("AppSettings", "Settings");
 
 signals:
     void savePathsChanged();
@@ -130,6 +136,8 @@ private:
 
     static QList<QLocale::Language> _rgReleaseLanguages;
     static QList<QLocale::Language> _rgPartialLanguages;
+
+    QString _childSavePath(const char* directory);
 
     typedef struct {
         QLocale::Language   languageId;

--- a/src/Settings/SettingsManager.cc
+++ b/src/Settings/SettingsManager.cc
@@ -34,6 +34,9 @@
 #ifdef QGC_VIEWER3D
 #include "Viewer3DSettings.h"
 #endif
+#include "JsonHelper.h"
+#include "QGCCorePlugin.h"
+#include "QGCApplication.h"
 
 #include <QtCore/QApplicationStatic>
 #include <QtQml/qqml.h>
@@ -62,11 +65,9 @@ void SettingsManager::init()
 {
     _unitsSettings = new UnitsSettings(this); // Must be first since AppSettings references it
 
-    _adsbVehicleManagerSettings = new ADSBVehicleManagerSettings(this);
-#ifndef QGC_NO_ARDUPILOT_DIALECT
-    _apmMavlinkStreamRateSettings = new APMMavlinkStreamRateSettings(this);
-#endif
     _appSettings = new AppSettings(this);
+    _loadSettingsFiles();
+
     _autoConnectSettings = new AutoConnectSettings(this);
     _batteryIndicatorSettings = new BatteryIndicatorSettings(this);
     _brandImageSettings = new BrandImageSettings(this);
@@ -85,6 +86,10 @@ void SettingsManager::init()
     _mavlinkSettings = new MavlinkSettings(this);
 #ifdef QGC_VIEWER3D
     _viewer3DSettings = new Viewer3DSettings(this);
+#endif
+    _adsbVehicleManagerSettings = new ADSBVehicleManagerSettings(this);
+#ifndef QGC_NO_ARDUPILOT_DIALECT
+    _apmMavlinkStreamRateSettings = new APMMavlinkStreamRateSettings(this);
 #endif
 }
 
@@ -113,3 +118,160 @@ MavlinkSettings *SettingsManager::mavlinkSettings() const { return _mavlinkSetti
 #ifdef QGC_VIEWER3D
 Viewer3DSettings *SettingsManager::viewer3DSettings() const { return _viewer3DSettings; }
 #endif
+
+void SettingsManager::_loadSettingsFiles()
+{
+    // Settings files can be found in the settingsSavePath() directory
+    // Settings files are json files which end in the settingsFileExtension extension
+    // The format for a settings file is:
+    // {
+    //      "version": 1,
+    //      "fileType": "Settings",
+    //      "groups": {
+    //          "groupName": {
+    //              "settingName": {
+    //                  "forceRawValue": <value>, // Forces the rawValue for this setting to the specific value
+    //                  any FactMetaData json keys except for name and type,
+    //                  ...
+    //          },
+    //          "groupName": {
+    //              ...
+    //          }
+    //      }
+    // }
+
+    QDir settingsDir(_appSettings->settingsSavePath());
+    if (!settingsDir.exists()) {
+        qCWarning(SettingsManagerLog) << "Settings directory does not exist:" << settingsDir.absolutePath();
+        return;
+    }
+
+    QStringList settingsFiles = settingsDir.entryList(QStringList() << QString("*.%1").arg(_appSettings->settingsFileExtension), QDir::Files);
+    for (const QString &fileName : settingsFiles) {
+        QFileInfo fileInfo(settingsDir, fileName);
+        if (!fileInfo.isFile()) continue;
+
+        // Load the settings file
+        qCDebug(SettingsManagerLog) << "Loading settings file:" << fileInfo.absoluteFilePath();
+
+        QJsonDocument jsonDoc;
+        QString errorString;
+        if (!JsonHelper::isJsonFile(fileInfo.absoluteFilePath(), jsonDoc, errorString)) {
+            qCWarning(SettingsManagerLog) << "Failed to load settings file:" << fileInfo.absoluteFilePath() << errorString;
+            continue;
+        }
+
+        QJsonObject jsonObject = jsonDoc.object();
+
+        // Validate the settings file
+        int version;
+        if (!JsonHelper::validateInternalQGCJsonFile(jsonObject, "Settings", 1, 1, version, errorString)) {
+            qCWarning(SettingsManagerLog) << "Settings file failed validation:" << fileInfo.absoluteFilePath() << errorString;
+            continue;
+        }
+
+        // Validate the remainder of the file
+
+        // groups key is an object
+        static const QList<JsonHelper::KeyValidateInfo> keyInfoList = {
+            { kJsonGroupsObjectKey, QJsonValue::Object, true },
+        };
+        if (!JsonHelper::validateKeys(jsonObject, keyInfoList, errorString)) {
+            qCWarning(SettingsManagerLog) << "Settings file incorrect format:" << fileInfo.absoluteFilePath() << errorString;
+            continue;
+        }
+
+        auto groupsObject = jsonObject[kJsonGroupsObjectKey].toObject();
+        for (const QString &groupName : groupsObject.keys()) {
+            qCDebug(SettingsManagerLog) << "  Loading settings group:" << groupName;
+
+            const QJsonValue &groupValue = groupsObject[groupName];
+            if (!groupValue.isObject()) {
+                qCWarning(SettingsManagerLog) << "Settings file incorrect format, group is not an object:" << fileInfo.absoluteFilePath()
+                                            << groupName;
+                continue;
+            }
+
+            auto groupObject = groupValue.toObject();
+            for (const QString &settingName : groupObject.keys()) {
+                qCDebug(SettingsManagerLog) << "  Loading settings:" << groupName << settingName;
+
+                if (!groupObject[settingName].isObject()) {
+                    qCWarning(SettingsManagerLog) << "Settings file incorrect format, setting is not an object:" << fileInfo.absoluteFilePath() 
+                                                << groupName << settingName;
+                    continue;
+                }
+
+                // Store the setting overrides. Note that last one wins if there are multiple settings files with the same setting.
+                QJsonObject metaDataObject = groupObject[settingName].toObject();
+                _settingsFileOverrides[groupName][settingName] = metaDataObject;
+            }
+        }
+    }
+}
+
+void SettingsManager::adjustSettingMetaData(const QString &settingsGroup, FactMetaData &metaData, bool &visible)
+{
+    visible = true; // By default all settings are visible
+
+    SettingsManager *settingsManager = SettingsManager::instance();
+    if (!settingsManager) {
+        qCWarning(SettingsManagerLog) << "SettingsManager instance not available";
+        return;
+    }
+
+    if (!qgcApp()->runningUnitTests()) {
+        // Apply settings file overrides
+        const auto &groupOverrides = settingsManager->_settingsFileOverrides;
+        if (groupOverrides.contains(settingsGroup) && groupOverrides[settingsGroup].contains(metaData.name())) {
+            QJsonObject settingOverrideJsonObject = groupOverrides[settingsGroup][metaData.name()];
+
+            // We need to stuff in name and type so settingOverrideJsonObject can parse properly
+            settingOverrideJsonObject["name"] = metaData.name();
+            settingOverrideJsonObject["type"] = FactMetaData::typeToString(metaData.type());
+
+            qCDebug(SettingsManagerLog) << "Applying settings file override for" << settingsGroup << metaData.name();
+
+            QScopedPointer<FactMetaData> overrideMetaData(FactMetaData::createFromJsonObject(settingOverrideJsonObject, {}, nullptr));
+
+            // Apply overrides
+            for (const QString &metaDataName : settingOverrideJsonObject.keys()) {
+                if (metaDataName == kJsonVisibleKey) {
+                    qCDebug(SettingsManagerLog) << "  Setting visibility to" << settingOverrideJsonObject[kJsonVisibleKey].toBool();
+                    visible = settingOverrideJsonObject[kJsonVisibleKey].toBool();
+                } else if (metaDataName == kJsonForceRawValueKey) {
+                    qCDebug(SettingsManagerLog) << "  Setting forceRawValue to" << settingOverrideJsonObject[kJsonForceRawValueKey];
+                    metaData.setRawDefaultValue(settingOverrideJsonObject[kJsonForceRawValueKey].toVariant());
+                    visible = false;
+                } else if (metaDataName == FactMetaData::_defaultValueJsonKey) {
+                    qCDebug(SettingsManagerLog) << "  Setting default to" << overrideMetaData->rawDefaultValue();
+                    metaData.setRawDefaultValue(overrideMetaData->rawDefaultValue());
+                } else if (metaDataName == FactMetaData::_minJsonKey) {
+                    qCDebug(SettingsManagerLog) << "  Setting min to" << overrideMetaData->rawMin();
+                    metaData.setRawMin(overrideMetaData->rawMin());
+                } else if (metaDataName == FactMetaData::_maxJsonKey) {
+                    qCDebug(SettingsManagerLog) << "  Setting max to" << overrideMetaData->rawMax();
+                    metaData.setRawMax(overrideMetaData->rawMax());
+                } else if (metaDataName == FactMetaData::_decimalPlacesJsonKey) {
+                    qCDebug(SettingsManagerLog) << "  Setting decimalPlaces to" << overrideMetaData->decimalPlaces();
+                    metaData.setDecimalPlaces(overrideMetaData->decimalPlaces());
+                } else if (metaDataName == FactMetaData::_enumValuesJsonKey) {
+                    qCDebug(SettingsManagerLog) << "  Setting enumInfo to" << overrideMetaData->enumValues() << overrideMetaData->enumStrings();
+                    metaData.setEnumInfo(overrideMetaData->enumStrings(), overrideMetaData->enumValues());
+                } else if (metaDataName == FactMetaData::_enumBitmaskArrayJsonKey) {
+                    qCDebug(SettingsManagerLog) << "  Setting bitmaskInfo to" << overrideMetaData->bitmaskValues() << overrideMetaData->bitmaskStrings();
+                    metaData.setBitmaskInfo(overrideMetaData->bitmaskStrings(), overrideMetaData->bitmaskValues());
+                } else if (metaDataName == FactMetaData::_longDescriptionJsonKey) {
+                    qCDebug(SettingsManagerLog) << "  Setting longDesc to" << overrideMetaData->longDescription();
+                    metaData.setLongDescription(overrideMetaData->longDescription());
+                } else if (metaDataName == FactMetaData::_shortDescriptionJsonKey) {
+                    qCDebug(SettingsManagerLog) << "  Setting shortDesc to" << overrideMetaData->shortDescription();
+                    metaData.setShortDescription(overrideMetaData->shortDescription());
+                }
+            }
+        }
+    }
+
+    // Give QGCCorePlugin a whack at it too
+    QGCCorePlugin::instance()->adjustSettingMetaData(settingsGroup, metaData, visible);
+}

--- a/src/Settings/SettingsManager.h
+++ b/src/Settings/SettingsManager.h
@@ -12,6 +12,8 @@
 #include <QtCore/QLoggingCategory>
 #include <QtCore/QObject>
 #include <QtQmlIntegration/QtQmlIntegration>
+#include <QtCore/QJsonObject>
+#include <QtCore/QMap>
 
 class ADSBVehicleManagerSettings;
 class APMMavlinkStreamRateSettings;
@@ -34,6 +36,7 @@ class UnitsSettings;
 class VideoSettings;
 class Viewer3DSettings;
 class MavlinkSettings;
+class FactMetaData;
 
 Q_DECLARE_LOGGING_CATEGORY(SettingsManagerLog)
 
@@ -102,6 +105,12 @@ public:
 
     void init();
 
+    /// Allows for overriding the meta data before the fact is created.
+    ///     @param settingsGroup - QSettings group which contains this item
+    ///     @param metaData - MetaData for setting fact
+    ///     @param visible - true: Setting should be visible in ui, false: Setting should not be shown in ui (default value will be used as value)
+    static void adjustSettingMetaData(const QString &settingsGroup, FactMetaData &metaData, bool &visible);
+
     ADSBVehicleManagerSettings *adsbVehicleManagerSettings() const;
 #ifndef QGC_NO_ARDUPILOT_DIALECT
     APMMavlinkStreamRateSettings *apmMavlinkStreamRateSettings() const;
@@ -129,6 +138,8 @@ public:
 #endif
 
 private:
+    void _loadSettingsFiles();
+
     ADSBVehicleManagerSettings *_adsbVehicleManagerSettings = nullptr;
 #ifndef QGC_NO_ARDUPILOT_DIALECT
     APMMavlinkStreamRateSettings *_apmMavlinkStreamRateSettings = nullptr;
@@ -154,4 +165,12 @@ private:
 #ifdef QGC_VIEWER3D
     Viewer3DSettings *_viewer3DSettings = nullptr;
 #endif
+
+    QMap<QString, QMap<QString, QJsonObject>> _settingsFileOverrides;   // groupName:settingName:metaDataObject
+
+    static constexpr int kSettingsFileVersion = 1;
+    static constexpr const char* kSettingsFileType = "Settings";
+    static constexpr const char* kJsonGroupsObjectKey = "groups";
+    static constexpr const char* kJsonVisibleKey = "visible";
+    static constexpr const char* kJsonForceRawValueKey = "forceRawValue";
 };

--- a/src/Utilities/JsonHelper.h
+++ b/src/Utilities/JsonHelper.h
@@ -57,7 +57,6 @@ namespace JsonHelper
     /// Validates the standard parts of a internal QGC json file (FactMetaData, ...):
     ///     jsonFileTypeKey - Required and checked to be equal to expectedFileType
     ///     jsonVersionKey - Required and checked to be below supportedMajorVersion, supportedMinorVersion
-    ///     jsonGroundStationKey - Required and checked to be string type
     /// @return false: validation failed, errorString set
     bool validateInternalQGCJsonFile(const QJsonObject &jsonObject,      ///< json object to validate
                                      const QString &expectedFileType,    ///< correct file type for file


### PR DESCRIPTION
This allows you to place json files with the .settings extension in the new QGC Settings directory (this new directory sits alongside the other standard dirs: Missions, Telemetry and so forth). This can be used to override the FactMetaData for settings as well as the raw value. This is a major work in progress that will continue to be added to.

See the example for file format:
* groups - List of Settings Groups you want to override
* The json object for each specific setting group is a list of settings to override
* The json object for a specific setting contains the meta data to override. Just like normal settings json metadata.
  * It also allows for a new key - `forceRawValue` - This is used to force an override of the value for the setting
  * All of the other FactMetaData json keys can be modeified as well like `min`, `max`, ... if you want to adjust metadata

Example usage: The Siyi UniRC7 controller currently requires you to create a manual UDP comm link in order for it to connect. This is a real PITA. By dropping the following settings override file into the QGC Settings directory it will connect automatically without needing a manual comm link. You can name it anything you want as long as it has the `.settings` extension:

```
{
    "version": 1,
    "fileType": "Settings",
    "groups": {
        "AutoConnect": {
            "udpListenPort": {
                "forceRawValue": 0
            },
            "udpTargetHostIP": {
                "forceRawValue": "192.168.144.20"
            },
            "udpTargetHostPort": {
                "forceRawValue": 19856
            }
        }
    }
}
```