### PR TITLE
Fix app logging crashing/hanging/generally strange behavior

### DIFF
--- a/src/Utilities/QGCLogging.cc
+++ b/src/Utilities/QGCLogging.cc
@@ -90,10 +90,8 @@ void QGCLogging::_threadsafeLog(const QString &message)
 {
     // Notify view of new row
     const int line = rowCount();
-    beginInsertRows(QModelIndex(), line, line);
     (void) QStringListModel::insertRows(line, 1);
     (void) setData(index(line, 0), message, Qt::DisplayRole);
-    endInsertRows();
 
     // Trim old entries to cap memory usage
     static constexpr const int kMaxLogRows = kMaxLogFileSize / 100;


### PR DESCRIPTION
Repro:
* Turn on Video logging
* Set to a udp stream which doesn't exist
* Go to Application - Logging
* Turn off Show Latest
* Scroll up and down randomly through the logs

Eventually what will happen is that you'll start getting recursive warnings from AppLogging.qml which don't make much sense. And then at some point you'll just get blank log messsages. And then after that QGC will just hang.

Calls to beginInsertRows/endInsertRows were added around the call to insertRows. Not sure why these were added. These two method are only supposed to be used when you are creating your own AbstractItemModel based class. You use beginInsertRows/endInsertRows inside your own implementation of the insertRows method. Which is a pure virtual in AbstractItemModel.. See QmlObjectListModel source for implementation of insertRows override. If you are just calling insertRows on an existing list model class you don't use them.