### PR TITLE
Standard modes: Don't filter mode list (for now)

### DIFF
--- a/src/QtLocationPlugin/QGCTileCacheWorker.h
+++ b/src/QtLocationPlugin/QGCTileCacheWorker.h
@@ -16,6 +16,7 @@
 #include <QtCore/QString>
 #include <QtCore/QThread>
 #include <QtCore/QWaitCondition>
+#include <QtCore/QElapsedTimer>
 
 Q_DECLARE_LOGGING_CATEGORY(QGCTileCacheWorkerLog)
 

--- a/src/Vehicle/StandardModes.cc
+++ b/src/Vehicle/StandardModes.cc
@@ -58,18 +58,15 @@ void StandardModes::gotMessage(MAV_RESULT result, const mavlink_message_t &messa
                 break;
             case MAV_STANDARD_MODE_SAFE_RECOVERY:
                 name = "Safe Recovery";
-                cannotBeSet = true; // These are exposed in the UI as separate buttons
                 break;
             case MAV_STANDARD_MODE_MISSION:
                 name = "Mission";
                 break;
             case MAV_STANDARD_MODE_LAND:
                 name = "Land";
-                cannotBeSet = true; // These are exposed in the UI as separate buttons
                 break;
             case MAV_STANDARD_MODE_TAKEOFF:
                 name = "Takeoff";
-                cannotBeSet = true; // These are exposed in the UI as separate buttons
                 break;
         }
 


### PR DESCRIPTION
* Standard Modes: Don't filter mode list. This makes all flight modes available to joystick button actions.
* Simple fix to allow Stable 5.0 to build on Qt 6.10
* Related to #13569
* Cherry picked from Stable