### PR TITLE
ParameterManager: Use new state machine support for PARAM_SET support

### DIFF
--- a/.github/actions/qt-android/action.yml
+++ b/.github/actions/qt-android/action.yml
@@ -77,7 +77,7 @@ runs:
         target: desktop
         arch: ${{ inputs.arch }}
         dir: ${{ runner.temp }}
-        modules: qtcharts qtlocation qtpositioning qtspeech qt5compat qtmultimedia qtserialport qtimageformats qtshadertools qtconnectivity qtquick3d qtsensors
+        modules: qtcharts qtlocation qtpositioning qtspeech qt5compat qtmultimedia qtserialport qtimageformats qtshadertools qtconnectivity qtquick3d qtsensors qtscxml
         setup-python: false
         cache: true
 
@@ -90,7 +90,7 @@ runs:
         target: android
         arch: android_arm64_v8a
         dir: ${{ runner.temp }}
-        modules: qtcharts qtlocation qtpositioning qtspeech qt5compat qtmultimedia qtserialport qtimageformats qtshadertools qtconnectivity qtquick3d qtsensors
+        modules: qtcharts qtlocation qtpositioning qtspeech qt5compat qtmultimedia qtserialport qtimageformats qtshadertools qtconnectivity qtquick3d qtsensors qtscxml
         setup-python: false
         cache: true
 
@@ -103,7 +103,7 @@ runs:
         target: android
         arch: android_armv7
         dir: ${{ runner.temp }}
-        modules: qtcharts qtlocation qtpositioning qtspeech qt5compat qtmultimedia qtserialport qtimageformats qtshadertools qtconnectivity qtquick3d qtsensors
+        modules: qtcharts qtlocation qtpositioning qtspeech qt5compat qtmultimedia qtserialport qtimageformats qtshadertools qtconnectivity qtquick3d qtsensors qtscxml
         setup-python: false
         cache: true
 
@@ -116,7 +116,7 @@ runs:
         target: android
         arch: android_x86_64
         dir: ${{ runner.temp }}
-        modules: qtcharts qtlocation qtpositioning qtspeech qt5compat qtmultimedia qtserialport qtimageformats qtshadertools qtconnectivity qtquick3d qtsensors
+        modules: qtcharts qtlocation qtpositioning qtspeech qt5compat qtmultimedia qtserialport qtimageformats qtshadertools qtconnectivity qtquick3d qtsensors qtscxml
         setup-python: false
         cache: true
 
@@ -129,6 +129,6 @@ runs:
         target: android
         arch: android_x86
         dir: ${{ runner.temp }}
-        modules: qtcharts qtlocation qtpositioning qtspeech qt5compat qtmultimedia qtserialport qtimageformats qtshadertools qtconnectivity qtquick3d qtsensors
+        modules: qtcharts qtlocation qtpositioning qtspeech qt5compat qtmultimedia qtserialport qtimageformats qtshadertools qtconnectivity qtquick3d qtsensors qtscxml
         setup-python: false
         cache: true

--- a/.github/workflows/custom.yml
+++ b/.github/workflows/custom.yml
@@ -74,7 +74,7 @@ jobs:
           target: desktop
           arch: win64_msvc2022_64
           dir: ${{ runner.temp }}
-          modules: qtcharts qtlocation qtpositioning qtspeech qt5compat qtmultimedia qtserialport qtimageformats qtshadertools qtconnectivity qtquick3d qtsensors
+          modules: qtcharts qtlocation qtpositioning qtspeech qt5compat qtmultimedia qtserialport qtimageformats qtshadertools qtconnectivity qtquick3d qtsensors qtscxml
           setup-python: false
           cache: true
 

--- a/.github/workflows/ios.yml
+++ b/.github/workflows/ios.yml
@@ -56,7 +56,7 @@ jobs:
           target: desktop
           arch: clang_64
           dir: ${{ runner.temp }}
-          modules: qtcharts qtlocation qtpositioning qtspeech qt5compat qtmultimedia qtserialport qtimageformats qtshadertools qtconnectivity qtquick3d qtsensors
+          modules: qtcharts qtlocation qtpositioning qtspeech qt5compat qtmultimedia qtserialport qtimageformats qtshadertools qtconnectivity qtquick3d qtsensors qtscxml
           setup-python: false
           cache: true
 

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -88,7 +88,7 @@ jobs:
           target: desktop
           arch: ${{ matrix.arch }}
           dir: ${{ runner.temp }}
-          modules: qtcharts qtlocation qtpositioning qtspeech qt5compat qtmultimedia qtserialport qtimageformats qtshadertools qtconnectivity qtquick3d qtsensors
+          modules: qtcharts qtlocation qtpositioning qtspeech qt5compat qtmultimedia qtserialport qtimageformats qtshadertools qtconnectivity qtquick3d qtsensors qtscxml
           setup-python: false
           cache: true
 

--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -72,7 +72,7 @@ jobs:
           target: desktop
           arch: clang_64
           dir: ${{ runner.temp }}
-          modules: qtcharts qtlocation qtpositioning qtspeech qt5compat qtmultimedia qtserialport qtimageformats qtshadertools qtconnectivity qtquick3d qtsensors
+          modules: qtcharts qtlocation qtpositioning qtspeech qt5compat qtmultimedia qtserialport qtimageformats qtshadertools qtconnectivity qtquick3d qtsensors qtscxml
           setup-python: false
           cache: true
 

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -93,7 +93,7 @@ jobs:
           target: desktop
           arch: ${{ matrix.arch }}
           dir: ${{ runner.temp }}
-          modules: qtcharts qtlocation qtpositioning qtspeech qt5compat qtmultimedia qtserialport qtimageformats qtshadertools qtconnectivity qtquick3d qtsensors
+          modules: qtcharts qtlocation qtpositioning qtspeech qt5compat qtmultimedia qtserialport qtimageformats qtshadertools qtconnectivity qtquick3d qtsensors qtscxml
           setup-python: false
           cache: true
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -178,6 +178,7 @@ find_package(Qt6
         TextToSpeech
         Widgets
         Xml
+        StateMachine
     OPTIONAL_COMPONENTS
         Bluetooth
         MultimediaQuickPrivate

--- a/deploy/vagrant/Vagrantfile
+++ b/deploy/vagrant/Vagrantfile
@@ -94,7 +94,7 @@ Vagrant.configure(2) do |config|
      version="6.10.0"
      host="linux"
      target="desktop"
-     modules="qtcharts qtlocation qtpositioning qtspeech qt5compat qtmultimedia qtserialport qtimageformats qtshadertools qtconnectivity qtquick3d qtsensors"
+     modules="qtcharts qtlocation qtpositioning qtspeech qt5compat qtmultimedia qtserialport qtimageformats qtshadertools qtconnectivity qtquick3d qtsensors qtscxml"
      su - vagrant -c "rm -rf ${dir}"
      su - vagrant -c "mkdir -p ${dir}"
      su - vagrant -c "python3 -m aqt install-qt -O ${dir} ${host} ${target} ${version} -m ${modules}"

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -109,6 +109,7 @@ target_link_libraries(${CMAKE_PROJECT_NAME}
         Qt6::TextToSpeech
         Qt6::Widgets
         Qt6::Xml
+        Qt6::StateMachine
 
         # Qt6 QML/Quick
         Qt6::Qml

--- a/src/Comms/MockLink/MockLink.h
+++ b/src/Comms/MockLink/MockLink.h
@@ -92,6 +92,16 @@ public:
     };
     void setRequestMessageFailureMode(RequestMessageFailureMode_t failureMode) { _requestMessageFailureMode = failureMode; }
 
+    enum ParamSetFailureMode_t {
+        FailParamSetNone,               ///< Normal behavior
+        FailParamSetNoAck,              ///< Do not send PARAM_VALUE ack
+        FailParamSetFirstAttemptNoAck,  ///< Skip ack on first attempt, respond to retry
+    };
+    void setParamSetFailureMode(ParamSetFailureMode_t mode) {
+        _paramSetFailureMode = mode;
+        _paramSetFailureFirstAttemptPending = (mode == FailParamSetFirstAttemptNoAck);
+    }
+
     static MockLink *startPX4MockLink(bool sendStatusText, MockConfiguration::FailureMode_t failureMode = MockConfiguration::FailNone);
     static MockLink *startGenericMockLink(bool sendStatusText, MockConfiguration::FailureMode_t failureMode = MockConfiguration::FailNone);
     static MockLink *startNoInitialConnectMockLink(bool sendStatusText, MockConfiguration::FailureMode_t failureMode = MockConfiguration::FailNone);
@@ -264,6 +274,8 @@ private:
     bool _sendGimbalDeviceAttitudeStatusNow = false;
 
     RequestMessageFailureMode_t _requestMessageFailureMode = FailRequestMessageNone;
+    ParamSetFailureMode_t _paramSetFailureMode = FailParamSetNone;
+    bool _paramSetFailureFirstAttemptPending = false;
 
     QMap<MAV_CMD, int> _receivedMavCommandCountMap;
     QMap<int, QMap<QString, QVariant>> _mapParamName2Value;

--- a/src/FactSystem/ParameterManager.cc
+++ b/src/FactSystem/ParameterManager.cc
@@ -19,6 +19,8 @@
 #include "QGCApplication.h"
 #include "QGCLoggingCategory.h"
 #include "Vehicle.h"
+#include "QGCStateMachine.h"
+#include "MultiVehicleManager.h"
 
 #include <QtCore/QEasingCurve>
 #include <QtCore/QFile>
@@ -79,9 +81,6 @@ void ParameterManager::_updateProgressBar()
     for (const int compId: _waitingReadParamNameMap.keys()) {
         waitingReadParamNameCount += _waitingReadParamNameMap[compId].count();
     }
-    for (const int compId: _waitingWriteParamNameMap.keys()) {
-        waitingWriteParamCount += _waitingWriteParamNameMap[compId].count();
-    }
 
     if (waitingReadParamIndexCount == 0) {
         if (_readParamIndexProgressActive) {
@@ -92,21 +91,6 @@ void ParameterManager::_updateProgressBar()
     } else {
         _readParamIndexProgressActive = true;
         _setLoadProgress(static_cast<double>(_totalParamCount - waitingReadParamIndexCount) / static_cast<double>(_totalParamCount));
-        return;
-    }
-
-    if (waitingWriteParamCount == 0) {
-        if (_writeParamProgressActive) {
-            _writeParamProgressActive = false;
-            _waitingWriteParamBatchCount = 0;
-            _setLoadProgress(0.0);
-            emit pendingWritesChanged(false);
-            return;
-        }
-    } else {
-        _writeParamProgressActive = true;
-        _setLoadProgress(static_cast<double>(qMax(_waitingWriteParamBatchCount - waitingWriteParamCount, 1)) / static_cast<double>(_waitingWriteParamBatchCount + 1));
-        emit pendingWritesChanged(true);
         return;
     }
 
@@ -144,32 +128,8 @@ void ParameterManager::mavlinkMessageReceived(const mavlink_message_t &message)
         paramUnion.type = param_value.param_type;
 
         QVariant parameterValue;
-
-        switch (paramUnion.type) {
-        case MAV_PARAM_TYPE_REAL32:
-            parameterValue = QVariant(paramUnion.param_float);
-            break;
-        case MAV_PARAM_TYPE_UINT8:
-            parameterValue = QVariant(paramUnion.param_uint8);
-            break;
-        case MAV_PARAM_TYPE_INT8:
-            parameterValue = QVariant(paramUnion.param_int8);
-            break;
-        case MAV_PARAM_TYPE_UINT16:
-            parameterValue = QVariant(paramUnion.param_uint16);
-            break;
-        case MAV_PARAM_TYPE_INT16:
-            parameterValue = QVariant(paramUnion.param_int16);
-            break;
-        case MAV_PARAM_TYPE_UINT32:
-            parameterValue = QVariant(paramUnion.param_uint32);
-            break;
-        case MAV_PARAM_TYPE_INT32:
-            parameterValue = QVariant(paramUnion.param_int32);
-            break;
-        default:
-            qCCritical(ParameterManagerLog) << "ParameterManager::_handleParamValue - unsupported MAV_PARAM_TYPE" << paramUnion.type;
-            break;
+        if (!_mavlinkParamUnionToVariant(paramUnion, parameterValue)) {
+            return;
         }
 
         _handleParamValue(message.compid, parameterName, param_value.param_count, param_value.param_index, static_cast<MAV_PARAM_TYPE>(param_value.param_type), parameterValue);
@@ -241,14 +201,12 @@ void ParameterManager::_handleParamValue(int componentId, const QString &paramet
 
         // The read and write waiting lists for this component are initialized the empty
         _waitingReadParamNameMap[componentId] = QMap<QString, int>();
-        _waitingWriteParamNameMap[componentId] = QMap<QString, int>();
 
         qCDebug(ParameterManagerLog) << _logVehiclePrefix(componentId) << "Seeing component for first time - paramcount:" << parameterCount;
     }
 
     if (!_waitingReadParamIndexMap[componentId].contains(parameterIndex) &&
-            !_waitingReadParamNameMap[componentId].contains(parameterName) &&
-            !_waitingWriteParamNameMap[componentId].contains(parameterName)) {
+            !_waitingReadParamNameMap[componentId].contains(parameterName)) {
         qCDebug(ParameterManagerVerbose1Log) << _logVehiclePrefix(componentId) << "Unrequested param update" << parameterName;
     }
 
@@ -260,15 +218,11 @@ void ParameterManager::_handleParamValue(int componentId, const QString &paramet
     }
 
     (void) _waitingReadParamNameMap[componentId].remove(parameterName);
-    (void) _waitingWriteParamNameMap[componentId].remove(parameterName);
     if (!_waitingReadParamIndexMap[componentId].isEmpty()) {
         qCDebug(ParameterManagerVerbose2Log) << _logVehiclePrefix(componentId) << "_waitingReadParamIndexMap:" << _waitingReadParamIndexMap[componentId];
     }
     if (!_waitingReadParamNameMap[componentId].isEmpty()) {
         qCDebug(ParameterManagerVerbose2Log) << _logVehiclePrefix(componentId) << "_waitingReadParamNameMap" << _waitingReadParamNameMap[componentId];
-    }
-    if (!_waitingWriteParamNameMap[componentId].isEmpty()) {
-        qCDebug(ParameterManagerVerbose2Log) << _logVehiclePrefix(componentId) << "_waitingWriteParamNameMap" << _waitingWriteParamNameMap[componentId];
     }
 
     // Track how many parameters we are still waiting for
@@ -288,13 +242,6 @@ void ParameterManager::_handleParamValue(int componentId, const QString &paramet
     }
     if (waitingReadParamNameCount) {
         qCDebug(ParameterManagerVerbose1Log) << _logVehiclePrefix(componentId) << "waitingReadParamNameCount:" << waitingReadParamNameCount;
-    }
-
-    for (const int waitingComponentId: _waitingWriteParamNameMap.keys()) {
-        waitingWriteParamNameCount += _waitingWriteParamNameMap[waitingComponentId].count();
-    }
-    if (waitingWriteParamNameCount) {
-        qCDebug(ParameterManagerVerbose1Log) << _logVehiclePrefix(componentId) << "waitingWriteParamNameCount:" << waitingWriteParamNameCount;
     }
 
     const int readWaitingParamCount = waitingReadParamIndexCount + waitingReadParamNameCount;
@@ -352,24 +299,227 @@ void ParameterManager::_handleParamValue(int componentId, const QString &paramet
     qCDebug(ParameterManagerVerbose1Log) << _logVehiclePrefix(componentId) << "_parameterUpdate complete";
 }
 
-void ParameterManager::_factRawValueUpdateWorker(int componentId, const QString &name, FactMetaData::ValueType_t valueType, const QVariant &rawValue)
+QString ParameterManager::_vehicleAndComponentString(int componentId) const
 {
-    if (_waitingWriteParamNameMap.contains(componentId)) {
-        if (_waitingWriteParamNameMap[componentId].contains(name)) {
-            (void) _waitingWriteParamNameMap[componentId].remove(name);
-        } else {
-            _waitingWriteParamBatchCount++;
-        }
-        _waitingWriteParamNameMap[componentId][name] = 0; // Add new entry and set retry count
-        _updateProgressBar();
-        _waitingParamTimeoutTimer.start();
-        _saveRequired = true;
-    } else {
-        qCWarning(ParameterManagerLog) << "Internal error ParameterManager::_factValueUpdateWorker: component id not found" << componentId;
+    // If there are multiple vehicles include the vehicle id for disambiguation
+    QString vehicleIdStr;
+    if (MultiVehicleManager::instance()->vehicles()->count() > 1) {
+        vehicleIdStr = QStringLiteral("veh: %1").arg(_vehicle->id());
     }
 
-    _sendParamSetToVehicle(componentId, name, valueType, rawValue);
-    qCDebug(ParameterManagerLog) << _logVehiclePrefix(componentId) << "Update parameter (_waitingParamTimeoutTimer started) - compId:name:rawValue" << componentId << name << rawValue;
+    // IF we have parameters for multiple components include the component id for disambiguation
+    QString componentIdStr;
+    if (_mapCompId2FactMap.keys().count() > 1) {
+        componentIdStr = QStringLiteral("comp: %1").arg(componentId);
+    }
+
+    if (!vehicleIdStr.isEmpty() && !componentIdStr.isEmpty()) {
+        return vehicleIdStr + QStringLiteral(" ") + componentIdStr;
+    } else if (!vehicleIdStr.isEmpty()) {
+        return vehicleIdStr;
+    } else if (!componentIdStr.isEmpty()) {
+        return componentIdStr;
+    } else {
+        return QString();
+    }
+}
+
+void ParameterManager::_factRawValueUpdateWorker(int componentId, const QString &paramName, FactMetaData::ValueType_t valueType, const QVariant &rawValue)
+{
+    auto paramSetEncoder = [this, componentId, paramName, valueType, rawValue](uint8_t systemId, uint8_t channel, mavlink_message_t *message) -> void {
+        mavlink_param_set_t param_set{};
+        param_set.param_type = factTypeToMavType(valueType);
+
+        mavlink_param_union_t union_value{};
+        if (!_fillMavlinkParamUnion(valueType, rawValue, union_value)) {
+            return;
+        }
+
+        param_set.param_value = union_value.param_float;
+        param_set.target_system = static_cast<uint8_t>(_vehicle->id());
+        param_set.target_component = static_cast<uint8_t>(componentId);
+
+        (void) strncpy(param_set.param_id, paramName.toStdString().c_str(), sizeof(param_set.param_id));
+
+        (void) mavlink_msg_param_set_encode_chan(
+                    MAVLinkProtocol::instance()->getSystemId(),
+                    MAVLinkProtocol::getComponentId(),
+                    channel,
+                    message,
+                    &param_set);
+    };
+
+    auto checkForCorrectParamValue = [this, componentId, paramName, rawValue](const mavlink_message_t &message) -> bool {
+        if (message.msgid != MAVLINK_MSG_ID_PARAM_VALUE) {
+            return false;
+        }
+        if (message.compid != componentId) {
+            return false;
+        }
+
+        mavlink_param_value_t param_value{};
+        mavlink_msg_param_value_decode(&message, &param_value);
+
+        // This will null terminate the name string
+        char parameterNameWithNull[MAVLINK_MSG_PARAM_VALUE_FIELD_PARAM_ID_LEN + 1] = {};
+        (void) strncpy(parameterNameWithNull, param_value.param_id, MAVLINK_MSG_PARAM_VALUE_FIELD_PARAM_ID_LEN);
+        const QString parameterName(parameterNameWithNull);
+
+        if (parameterName != paramName) {
+            return false;
+        }
+
+        // Check that the value matches what we expect within tolerance, if it doesn't match then this message is not for us
+        QVariant receivedValue;
+        mavlink_param_union_t param_union;
+        param_union.param_float = param_value.param_value;
+        param_union.type = param_value.param_type;
+        if (!_mavlinkParamUnionToVariant(param_union, receivedValue)) {
+            return false;
+        }
+        if (rawValue.typeId() != receivedValue.typeId()) {
+            qCWarning(ParameterManagerLog) << "QVariant type mismatch on PARAM_VALUE ack for" << paramName << ": expected type" << rawValue.typeId() << "got type" << receivedValue.typeId();
+            return false;
+        }
+        if (param_value.param_type == MAV_PARAM_TYPE_REAL32) {
+            // Float comparison must be fuzzy
+            return QGC::fuzzyCompare(rawValue.toFloat(), receivedValue.toFloat());
+        } else {
+            return receivedValue == rawValue;
+        }
+    };
+
+    // State Machine:
+    //  Send PARAM_SET - 2 retries after initial attempt
+    //  Increment pending write count
+    //  Wait for PARAM_VALUE ack
+    //  Decrement pending write count
+    //
+    //  timeout:
+    //      Decrement pending write count
+    //      Back up to PARAM_SET for retries
+    //
+    //  error:
+    //      Refresh parameter from vehicle
+    //      Notify user of failure
+
+    // Create states
+    auto stateMachine = new QGCStateMachine(QStringLiteral("ParameterManager PARAM_SET"), vehicle(), this);
+    auto sendParamSetState = new SendMavlinkMessageState(stateMachine, paramSetEncoder, kParamSetRetryCount);
+    auto incPendingWriteCountState = new FunctionState(QStringLiteral("ParameterManager increment pending write count"), stateMachine, [this]() {
+        _incrementPendingWriteCount();
+    });
+    auto decPendingWriteCountState = new FunctionState(QStringLiteral("ParameterManager decrement pending write count"), stateMachine, [this]() {
+        _decrementPendingWriteCount();
+    });
+    auto retryDecPendingWriteCountState = new FunctionState(QStringLiteral("ParameterManager retry decrement pending write count"), stateMachine, [this]() {
+        _decrementPendingWriteCount();
+    });
+    auto waitAckState = new WaitForMavlinkMessageState(stateMachine, MAVLINK_MSG_ID_PARAM_VALUE, kParamSetWaitForParamValueAckMs, checkForCorrectParamValue);
+    auto paramRefreshState = new FunctionState(QStringLiteral("ParameterManager param refresh"), stateMachine, [this, componentId, paramName]() {
+        refreshParameter(componentId, paramName);
+    });
+    auto userNotifyState = new ShowAppMessageState(stateMachine, QStringLiteral("Parameter Write Failed: param: %1 %2").arg(paramName).arg(_vehicleAndComponentString(componentId)));
+    auto logSuccessState = new FunctionState(QStringLiteral("ParameterManager log success"), stateMachine, [this, componentId, paramName]() {
+        qCDebug(ParameterManagerLog) << "Parameter write succeeded: param:" << paramName << _vehicleAndComponentString(componentId);
+    });
+    auto logFailureState = new FunctionState(QStringLiteral("ParameterManager log failure"), stateMachine, [this, componentId, paramName]() {
+        qCDebug(ParameterManagerLog) << "Parameter write failed: param:" << paramName << _vehicleAndComponentString(componentId);
+    });
+    auto finalState = new QGCFinalState(stateMachine);
+
+    // Successful state machine transitions
+    stateMachine->setInitialState(sendParamSetState);
+    sendParamSetState->addThisTransition        (&QGCState::advance, incPendingWriteCountState);
+    incPendingWriteCountState->addThisTransition(&QGCState::advance, waitAckState);
+    waitAckState->addThisTransition             (&QGCState::advance, decPendingWriteCountState);
+    decPendingWriteCountState->addThisTransition(&QGCState::advance, logSuccessState);
+    logSuccessState->addThisTransition          (&QGCState::advance, finalState);
+
+    // Retry transitions
+    waitAckState->addTransition(waitAckState, &WaitForMavlinkMessageState::timeout, retryDecPendingWriteCountState); // Retry on timeout
+    retryDecPendingWriteCountState->addThisTransition(&QGCState::advance, sendParamSetState);
+
+    // Error transitions
+    sendParamSetState->addThisTransition(&QGCState::error, logFailureState); // Error is signaled after retries exhausted or internal error
+
+    // Error state branching transitions
+    logFailureState->addThisTransition  (&QGCState::advance, userNotifyState);
+    userNotifyState->addThisTransition  (&QGCState::advance, paramRefreshState);
+    paramRefreshState->addThisTransition(&QGCState::advance, finalState);
+
+    qCDebug(ParameterManagerLog) << "Starting state machine for PARAM_SET on: " << paramName << _vehicleAndComponentString(componentId);
+    stateMachine->start();
+}
+
+bool ParameterManager::_fillMavlinkParamUnion(FactMetaData::ValueType_t valueType, const QVariant &rawValue, mavlink_param_union_t &paramUnion) const
+{
+    bool ok = false;
+
+    switch (valueType) {
+    case FactMetaData::valueTypeUint8:
+        paramUnion.param_uint8 = static_cast<uint8_t>(rawValue.toUInt(&ok));
+        break;
+    case FactMetaData::valueTypeInt8:
+        paramUnion.param_int8 = static_cast<int8_t>(rawValue.toInt(&ok));
+        break;
+    case FactMetaData::valueTypeUint16:
+        paramUnion.param_uint16 = static_cast<uint16_t>(rawValue.toUInt(&ok));
+        break;
+    case FactMetaData::valueTypeInt16:
+        paramUnion.param_int16 = static_cast<int16_t>(rawValue.toInt(&ok));
+        break;
+    case FactMetaData::valueTypeUint32:
+        paramUnion.param_uint32 = static_cast<uint32_t>(rawValue.toUInt(&ok));
+        break;
+    case FactMetaData::valueTypeFloat:
+        paramUnion.param_float = rawValue.toFloat(&ok);
+        break;
+    case FactMetaData::valueTypeInt32:
+        paramUnion.param_int32 = static_cast<int32_t>(rawValue.toInt(&ok));
+        break;
+    default:
+        qCCritical(ParameterManagerLog) << "Internal Error: Unsupported fact value type" << valueType;
+        paramUnion.param_int32 = static_cast<int32_t>(rawValue.toInt(&ok));
+        break;
+    }
+
+    if (!ok) {
+        qCCritical(ParameterManagerLog) << "Fact Failed to Convert to Param Type:" << valueType;
+        return false;
+    }
+
+    return true;
+}
+
+bool ParameterManager::_mavlinkParamUnionToVariant(const mavlink_param_union_t &paramUnion, QVariant &outValue) const
+{
+    switch (paramUnion.type) {
+    case MAV_PARAM_TYPE_REAL32:
+        outValue = QVariant(paramUnion.param_float);
+        return true;
+    case MAV_PARAM_TYPE_UINT8:
+        outValue = QVariant(paramUnion.param_uint8);
+        return true;
+    case MAV_PARAM_TYPE_INT8:
+        outValue = QVariant(paramUnion.param_int8);
+        return true;
+    case MAV_PARAM_TYPE_UINT16:
+        outValue = QVariant(paramUnion.param_uint16);
+        return true;
+    case MAV_PARAM_TYPE_INT16:
+        outValue = QVariant(paramUnion.param_int16);
+        return true;
+    case MAV_PARAM_TYPE_UINT32:
+        outValue = QVariant(paramUnion.param_uint32);
+        return true;
+    case MAV_PARAM_TYPE_INT32:
+        outValue = QVariant(paramUnion.param_int32);
+        return true;
+    default:
+        qCCritical(ParameterManagerLog) << "ParameterManager::_mavlinkParamUnionToVariant - unsupported MAV_PARAM_TYPE" << paramUnion.type;
+        return false;
+    }
 }
 
 void ParameterManager::_factRawValueUpdated(const QVariant &rawValue)
@@ -666,29 +816,6 @@ void ParameterManager::_waitingParamTimeout()
     constexpr int maxBatchSize = 10;
     int batchCount = 0;
     if (!paramsRequested) {
-        for (const int componentId: _waitingWriteParamNameMap.keys()) {
-            for (const QString &paramName: _waitingWriteParamNameMap[componentId].keys()) {
-                paramsRequested = true;
-                _waitingWriteParamNameMap[componentId][paramName]++;   // Bump retry count
-                if (_waitingWriteParamNameMap[componentId][paramName] <= _maxReadWriteRetry) {
-                    const Fact *const fact = getParameter(componentId, paramName);
-                    _sendParamSetToVehicle(componentId, paramName, fact->type(), fact->rawValue());
-                    qCDebug(ParameterManagerLog) << _logVehiclePrefix(componentId) << "Write resend for (paramName:" << paramName << "retryCount:" << _waitingWriteParamNameMap[componentId][paramName] << ")";
-                    if (++batchCount > maxBatchSize) {
-                        goto Out;
-                    }
-                } else {
-                    // Exceeded max retry count, notify user
-                    _waitingWriteParamNameMap[componentId].remove(paramName);
-                    const QString errorMsg = tr("Parameter write failed: veh:%1 comp:%2 param:%3").arg(_vehicle->id()).arg(componentId).arg(paramName);
-                    qCDebug(ParameterManagerLog) << errorMsg;
-                    qgcApp()->showAppMessage(errorMsg);
-                }
-            }
-        }
-    }
-
-    if (!paramsRequested) {
         for (const int componentId: _waitingReadParamNameMap.keys()) {
             for (const QString &paramName: _waitingReadParamNameMap[componentId].keys()) {
                 paramsRequested = true;
@@ -736,65 +863,6 @@ void ParameterManager::_readParameterRaw(int componentId, const QString &paramNa
                                                     componentId,                    // Target component id
                                                     fixedParamName,                 // Named parameter being requested
                                                     paramIndex);                    // Parameter index being requested, -1 for named
-    (void) _vehicle->sendMessageOnLinkThreadSafe(sharedLink.get(), msg);
-}
-
-void ParameterManager::_sendParamSetToVehicle(int componentId, const QString &paramName, FactMetaData::ValueType_t valueType, const QVariant &value) const
-{
-    const SharedLinkInterfacePtr sharedLink = _vehicle->vehicleLinkManager()->primaryLink().lock();
-    if (!sharedLink) {
-        return;
-    }
-
-    mavlink_param_set_t p{};
-    p.param_type = factTypeToMavType(valueType);
-
-    mavlink_param_union_t union_value{};
-
-    bool ok = false;
-    switch (valueType) {
-    case FactMetaData::valueTypeUint8:
-        union_value.param_uint8 = static_cast<uint8_t>(value.toUInt(&ok));
-        break;
-    case FactMetaData::valueTypeInt8:
-        union_value.param_int8 = static_cast<int8_t>(value.toInt(&ok));
-        break;
-    case FactMetaData::valueTypeUint16:
-        union_value.param_uint16 = static_cast<uint16_t>(value.toUInt(&ok));
-        break;
-    case FactMetaData::valueTypeInt16:
-        union_value.param_int16 = static_cast<int16_t>(value.toInt(&ok));
-        break;
-    case FactMetaData::valueTypeUint32:
-        union_value.param_uint32 = static_cast<uint32_t>(value.toUInt(&ok));
-        break;
-    case FactMetaData::valueTypeFloat:
-        union_value.param_float = value.toFloat(&ok);
-        break;
-    default:
-        qCCritical(ParameterManagerLog) << "Unsupported fact value type" << valueType;
-    case FactMetaData::valueTypeInt32:
-        union_value.param_int32 = static_cast<int32_t>(value.toInt(&ok));
-        break;
-    }
-
-    if (!ok) {
-        qCCritical(ParameterManagerLog) << "Fact Failed to Convert to Param Type:" << value;
-        return;
-    }
-
-    p.param_value = union_value.param_float;
-    p.target_system = static_cast<uint8_t>(_vehicle->id());
-    p.target_component = static_cast<uint8_t>(componentId);
-
-    (void) strncpy(p.param_id, paramName.toStdString().c_str(), sizeof(p.param_id));
-
-    mavlink_message_t msg{};
-    (void) mavlink_msg_param_set_encode_chan(MAVLinkProtocol::instance()->getSystemId(),
-                                             MAVLinkProtocol::getComponentId(),
-                                             sharedLink->mavlinkChannel(),
-                                             &msg,
-                                             &p);
     (void) _vehicle->sendMessageOnLinkThreadSafe(sharedLink.get(), msg);
 }
 
@@ -1318,13 +1386,7 @@ QList<int> ParameterManager::componentIds() const
 
 bool ParameterManager::pendingWrites() const
 {
-    for (const int compId: _waitingWriteParamNameMap.keys()) {
-        if (!_waitingWriteParamNameMap[compId].isEmpty()) {
-            return true;
-        }
-    }
-
-    return false;
+    return _pendingWritesCount > 0;
 }
 
 Vehicle *ParameterManager::vehicle()
@@ -1514,6 +1576,7 @@ bool ParameterManager::_parseParamFile(const QString& filename)
         }
         fact->containerSetRawValue(parameterValue);
     }
+
 Success:
     file.close();
     /* Create empty waiting lists as we have all parameters */
@@ -1521,7 +1584,6 @@ Success:
     _totalParamCount += num_params;
     _waitingReadParamIndexMap[componentId] = QMap<int, int>();
     _waitingReadParamNameMap[componentId] = QMap<QString, int>();
-    _waitingWriteParamNameMap[componentId] = QMap<QString, int>();
     _checkInitialLoadComplete();
     _setLoadProgress(0.0);
     return true;
@@ -1529,4 +1591,25 @@ Success:
 Error:
     file.close();
     return false;
+}
+
+void ParameterManager::_incrementPendingWriteCount()
+{
+    _pendingWritesCount++;
+    if (_pendingWritesCount == 1) {
+        emit pendingWritesChanged(true);
+    }
+}
+
+void ParameterManager::_decrementPendingWriteCount()
+{
+    if (_pendingWritesCount == 0) {
+        qCWarning(ParameterManagerLog) << "Internal Error: _pendingWriteCount == 0";
+        return;
+    }
+
+    _pendingWritesCount--;
+    if (_pendingWritesCount == 0) {
+        emit pendingWritesChanged(false);
+    }
 }

--- a/src/QGCApplication.cc
+++ b/src/QGCApplication.cc
@@ -405,7 +405,8 @@ void QGCApplication::showAppMessage(const QString &message, const QString &title
         QMetaObject::invokeMethod(rootQmlObject, "_showMessageDialog", Q_RETURN_ARG(QVariant, varReturn), Q_ARG(QVariant, dialogTitle), Q_ARG(QVariant, varMessage));
     } else if (runningUnitTests()) {
         // Unit tests can run without UI
-        qCDebug(QGCApplicationLog) << "QGCApplication::showAppMessage unittest title:message" << dialogTitle << message;
+        // We don't use a logging category to make it easier to debug unit tests
+        qDebug() << "QGCApplication::showAppMessage unittest title:message" << dialogTitle << message;
     } else {
         // UI isn't ready yet
         _delayedAppMessages.append(QPair<QString, QString>(dialogTitle, message));

--- a/src/Utilities/CMakeLists.txt
+++ b/src/Utilities/CMakeLists.txt
@@ -66,3 +66,4 @@ target_include_directories(${CMAKE_PROJECT_NAME}
 add_subdirectory(Audio)
 add_subdirectory(Compression)
 add_subdirectory(Geo)
+add_subdirectory(StateMachine)

--- a/src/Utilities/QGC.cc
+++ b/src/Utilities/QGC.cc
@@ -126,4 +126,39 @@ bool fuzzyCompare(double value1, double value2)
     }
 }
 
+bool fuzzyCompare(double value1, double value2, double tolerance)
+{
+    if (qIsNaN(value1) && qIsNaN(value2)) {
+        return true;
+    } else if (qIsNaN(value1) || qIsNaN(value2)) {
+        return false;
+    } else {
+        return fabs(value1 - value2) <= tolerance;
+    }
+}
+
+bool fuzzyCompare(float value1, float value2)
+{
+    if (qIsNaN(value1) && qIsNaN(value2)) {
+        return true;
+    } else if (qIsNaN(value1) || qIsNaN(value2)) {
+        return false;
+    } else if (value1 == value2) {
+        return true;
+    } else {
+        return qFuzzyCompare(value1, value2);
+    }
+}
+
+bool fuzzyCompare(float value1, float value2, float tolerance)
+{
+    if (qIsNaN(value1) && qIsNaN(value2)) {
+        return true;
+    } else if (qIsNaN(value1) || qIsNaN(value2)) {
+        return false;
+    } else {
+        return fabsf(value1 - value2) <= tolerance;
+    }
+}
+
 }

--- a/src/Utilities/QGC.h
+++ b/src/Utilities/QGC.h
@@ -18,6 +18,9 @@ namespace QGC
 
     /// Returns true if the two values are equal or close. Correctly handles 0 and NaN values.
     bool fuzzyCompare(double value1, double value2);
+    bool fuzzyCompare(float value1, float value2);
+    bool fuzzyCompare(double value1, double value2, double tolerance);
+    bool fuzzyCompare(float value1, float value2, float tolerance);
 
     quint32 crc32(const quint8 *src, unsigned len, unsigned state);
 }

--- a/src/Utilities/StateMachine/CMakeLists.txt
+++ b/src/Utilities/StateMachine/CMakeLists.txt
@@ -1,0 +1,27 @@
+# ============================================================================
+# State Machine Subsystem
+# ============================================================================
+
+target_sources(${CMAKE_PROJECT_NAME}
+    PRIVATE
+        QGCFinalState.cc
+        QGCFinalState.h
+        QGCState.cc
+        QGCState.h
+        QGCStateMachine.cc
+        QGCStateMachine.h
+        DelayState.cc
+        DelayState.h
+        FunctionState.cc
+        FunctionState.h
+        SendMavlinkCommandState.cc
+        SendMavlinkCommandState.h
+        SendMavlinkMessageState.cc
+        SendMavlinkMessageState.h
+        ShowAppMessageState.cc
+        ShowAppMessageState.h
+        WaitForMavlinkMessageState.cc
+        WaitForMavlinkMessageState.h
+)
+
+target_include_directories(${CMAKE_PROJECT_NAME} PRIVATE ${CMAKE_CURRENT_SOURCE_DIR})

--- a/src/Utilities/StateMachine/DelayState.cc
+++ b/src/Utilities/StateMachine/DelayState.cc
@@ -1,0 +1,30 @@
+/****************************************************************************
+ *
+ * (c) 2009-2024 QGROUNDCONTROL PROJECT <http://www.qgroundcontrol.org>
+ *
+ * QGroundControl is licensed according to the terms in the file
+ * COPYING.md in the root of the source code directory.
+ *
+ ****************************************************************************/
+
+#include "DelayState.h"
+
+DelayState::DelayState(QState* parentState, int delayMsecs)
+    : QGCState("DelayState", parentState)
+{
+    _delayTimer.setSingleShot(true);
+    _delayTimer.setInterval(delayMsecs);
+
+    connect(&_delayTimer, &QTimer::timeout, this, &DelayState::delayComplete);
+
+    connect(this, &QState::entered, this, [this, delayMsecs] () 
+        { 
+            qCDebug(QGCStateMachineLog) << QStringLiteral("Starting delay for %1 secs").arg(delayMsecs / 1000.0) << " - " << Q_FUNC_INFO;
+            _delayTimer.start();
+        });
+
+    connect(this, &QGCState::exited, this, [this] () 
+        { 
+            _delayTimer.stop();
+        });
+}

--- a/src/Utilities/StateMachine/DelayState.h
+++ b/src/Utilities/StateMachine/DelayState.h
@@ -1,0 +1,29 @@
+/****************************************************************************
+ *
+ * (c) 2009-2024 QGROUNDCONTROL PROJECT <http://www.qgroundcontrol.org>
+ *
+ * QGroundControl is licensed according to the terms in the file
+ * COPYING.md in the root of the source code directory.
+ *
+ ****************************************************************************/
+
+#pragma once
+
+#include "QGCState.h"
+
+#include <QTimer>
+
+/// Delays that state machine for the specified time in milliseconds
+class DelayState : public QGCState
+{
+    Q_OBJECT
+
+public:
+    DelayState(QState* parentState, int delayMsecs);
+
+signals:
+    void delayComplete();
+
+private:
+    QTimer _delayTimer;
+};

--- a/src/Utilities/StateMachine/FunctionState.cc
+++ b/src/Utilities/StateMachine/FunctionState.cc
@@ -1,0 +1,23 @@
+/****************************************************************************
+ *
+ * (c) 2009-2024 QGROUNDCONTROL PROJECT <http://www.qgroundcontrol.org>
+ *
+ * QGroundControl is licensed according to the terms in the file
+ * COPYING.md in the root of the source code directory.
+ *
+ ****************************************************************************/
+
+#include "FunctionState.h"
+
+#include <QTimer>
+
+/// Executes a function when the state is entered
+FunctionState::FunctionState(const QString& stateName, QState* parentState, std::function<void()> function)
+    : QGCState   (stateName, parentState)
+    , _function     (function)
+{
+    connect(this, &QState::entered, this, [this] () {
+        _function();
+        emit advance();
+    });
+}

--- a/src/Utilities/StateMachine/FunctionState.h
+++ b/src/Utilities/StateMachine/FunctionState.h
@@ -1,0 +1,25 @@
+/****************************************************************************
+ *
+ * (c) 2009-2024 QGROUNDCONTROL PROJECT <http://www.qgroundcontrol.org>
+ *
+ * QGroundControl is licensed according to the terms in the file
+ * COPYING.md in the root of the source code directory.
+ *
+ ****************************************************************************/
+
+#pragma once
+
+#include "QGCState.h"
+
+#include <functional>
+
+class FunctionState : public QGCState
+{
+    Q_OBJECT
+
+public:
+    FunctionState(const QString& stateName, QState* parentState, std::function<void()>);
+
+private:
+    std::function<void()> _function;
+};

--- a/src/Utilities/StateMachine/QGCFinalState.cc
+++ b/src/Utilities/StateMachine/QGCFinalState.cc
@@ -1,0 +1,22 @@
+/****************************************************************************
+ *
+ * (c) 2009-2024 QGROUNDCONTROL PROJECT <http://www.qgroundcontrol.org>
+ *
+ * QGroundControl is licensed according to the terms in the file
+ * COPYING.md in the root of the source code directory.
+ *
+ ****************************************************************************/
+
+#include "QGCFinalState.h"
+#include "QGCState.h"
+
+QGCFinalState::QGCFinalState(QState* parent)
+    : QFinalState(parent)
+{
+    connect(this, &QFinalState::entered, this, [this] () {
+        qCDebug(QGCStateMachineLog) << "Entered Final State";
+    });
+    connect(this, &QState::exited, this, [this] () {
+        qCDebug(QGCStateMachineLog) << "Exited Final State";
+    });
+}

--- a/src/Utilities/StateMachine/QGCFinalState.h
+++ b/src/Utilities/StateMachine/QGCFinalState.h
@@ -1,0 +1,22 @@
+/****************************************************************************
+ *
+ * (c) 2009-2024 QGROUNDCONTROL PROJECT <http://www.qgroundcontrol.org>
+ *
+ * QGroundControl is licensed according to the terms in the file
+ * COPYING.md in the root of the source code directory.
+ *
+ ****************************************************************************/
+
+ #pragma once
+
+#include <QFinalState>
+
+/// Final state for a QGCStateMachine
+///     Same as QFinalState but with logging
+class QGCFinalState : public QFinalState
+{
+    Q_OBJECT
+
+public:
+    QGCFinalState(QState* parent = nullptr);
+};

--- a/src/Utilities/StateMachine/QGCState.cc
+++ b/src/Utilities/StateMachine/QGCState.cc
@@ -1,0 +1,36 @@
+/****************************************************************************
+ *
+ * (c) 2009-2024 QGROUNDCONTROL PROJECT <http://www.qgroundcontrol.org>
+ *
+ * QGroundControl is licensed according to the terms in the file
+ * COPYING.md in the root of the source code directory.
+ *
+ ****************************************************************************/
+
+#include "QGCStateMachine.h"
+#include "QGCLoggingCategory.h"
+
+QGC_LOGGING_CATEGORY(QGCStateMachineLog, "Utilities.QGCStateMachine")
+
+QGCState::QGCState(const QString& stateName, QState* parentState) 
+    : QState(QState::ExclusiveStates, parentState)
+{
+    setObjectName(stateName);
+
+    connect(this, &QState::entered, this, [this] () {
+        qCDebug(QGCStateMachineLog) << "Entered state" << objectName() << " - " << Q_FUNC_INFO;
+    });
+    connect(this, &QState::exited, this, [this] () {
+        qCDebug(QGCStateMachineLog) << "Exited state" << objectName() << " - " << Q_FUNC_INFO;
+    });
+}
+
+QGCStateMachine* QGCState::machine() 
+{ 
+    return qobject_cast<QGCStateMachine*>(QState::machine()); 
+}
+
+Vehicle *QGCState::vehicle() 
+{ 
+    return machine()->vehicle(); 
+}

--- a/src/Utilities/StateMachine/QGCState.h
+++ b/src/Utilities/StateMachine/QGCState.h
@@ -1,0 +1,40 @@
+/****************************************************************************
+ *
+ * (c) 2009-2024 QGROUNDCONTROL PROJECT <http://www.qgroundcontrol.org>
+ *
+ * QGroundControl is licensed according to the terms in the file
+ * COPYING.md in the root of the source code directory.
+ *
+ ****************************************************************************/
+
+#pragma once
+
+#include <QState>
+#include <QString>
+#include <QLoggingCategory>
+
+Q_DECLARE_LOGGING_CATEGORY(QGCStateMachineLog)
+
+class QGCStateMachine;
+class Vehicle;
+
+/// Base class for all QGroundControl state machine states
+class QGCState : public QState
+{
+    Q_OBJECT
+
+public:
+    QGCState(const QString& stateName, QState* parentState);
+
+    /// Simpler version of QState::addTransition which assumes the sender is this
+    template <typename PointerToMemberFunction> QSignalTransition *addThisTransition(PointerToMemberFunction signal, QAbstractState *target)
+        { return QState::addTransition(this, signal, target); };
+
+    QGCStateMachine* machine();
+    Vehicle *vehicle();
+    QString stateName() const { return objectName(); }
+
+signals:
+    void advance();     ///< Signal to indicate state is complete and machine should advance to next state
+    void error();       ///< Signal to indicate an error has occurred
+};

--- a/src/Utilities/StateMachine/QGCStateMachine.cc
+++ b/src/Utilities/StateMachine/QGCStateMachine.cc
@@ -1,0 +1,33 @@
+/****************************************************************************
+ *
+ * (c) 2009-2024 QGROUNDCONTROL PROJECT <http://www.qgroundcontrol.org>
+ *
+ * QGroundControl is licensed according to the terms in the file
+ * COPYING.md in the root of the source code directory.
+ *
+ ****************************************************************************/
+
+#include "QGCStateMachine.h"
+#include "QGCApplication.h"
+#include "AudioOutput.h"
+#include "MultiVehicleManager.h"
+#include "Vehicle.h"
+#include "AudioOutput.h"
+
+#include <QFinalState>
+
+QGCStateMachine::QGCStateMachine(const QString& machineName, Vehicle *vehicle, QObject* parent)
+    : QStateMachine (parent)
+    , _vehicle      (vehicle)
+{
+    setObjectName(machineName);
+
+    connect(this, &QGCStateMachine::started, this, [this] () {
+        qCDebug(QGCStateMachineLog) << "State machine started:" << objectName();
+    });
+    connect(this, &QGCStateMachine::stopped, this, [this] () {
+        qCDebug(QGCStateMachineLog) << "State machine finished:" << objectName();
+    });
+
+    connect(this, &QGCStateMachine::stopped, this, [this] () { this->deleteLater(); });
+}

--- a/src/Utilities/StateMachine/QGCStateMachine.h
+++ b/src/Utilities/StateMachine/QGCStateMachine.h
@@ -1,0 +1,43 @@
+/****************************************************************************
+ *
+ * (c) 2009-2024 QGROUNDCONTROL PROJECT <http://www.qgroundcontrol.org>
+ *
+ * QGroundControl is licensed according to the terms in the file
+ * COPYING.md in the root of the source code directory.
+ *
+ ****************************************************************************/
+
+#pragma once
+
+#include "DelayState.h"
+#include "FunctionState.h"
+#include "SendMavlinkCommandState.h"
+#include "SendMavlinkMessageState.h"
+#include "WaitForMavlinkMessageState.h"
+#include "ShowAppMessageState.h"
+#include "QGCFinalState.h"
+
+#include <QStateMachine>
+#include <QFinalState>
+#include <QString>
+
+#include <functional>
+
+class Vehicle;
+
+/// QGroundControl specific state machine
+class QGCStateMachine : public QStateMachine
+{
+    Q_OBJECT
+public:
+    QGCStateMachine(const QString& machineName, Vehicle* vehicle, QObject* parent = nullptr);
+
+    Vehicle *vehicle() const { return _vehicle; }
+
+signals:
+    void error();
+
+private:
+    Vehicle *_vehicle = nullptr;
+};
+

--- a/src/Utilities/StateMachine/SendMavlinkCommandState.cc
+++ b/src/Utilities/StateMachine/SendMavlinkCommandState.cc
@@ -1,0 +1,104 @@
+/****************************************************************************
+ *
+ * (c) 2009-2024 QGROUNDCONTROL PROJECT <http://www.qgroundcontrol.org>
+ *
+ * QGroundControl is licensed according to the terms in the file
+ * COPYING.md in the root of the source code directory.
+ *
+ ****************************************************************************/
+
+#include "SendMavlinkCommandState.h"
+#include "MultiVehicleManager.h"
+#include "MissionCommandTree.h"
+#include "Vehicle.h"
+
+SendMavlinkCommandState::SendMavlinkCommandState(QState* parentState, MAV_CMD command, double param1, double param2, double param3, double param4, double param5, double param6, double param7)
+    : QGCState("SendMavlinkCommandState", parentState)
+{
+    setup(command, param1, param2, param3, param4, param5, param6, param7);
+}
+
+SendMavlinkCommandState::SendMavlinkCommandState(QState* parentState)
+    : QGCState("SendMavlinkCommandState", parentState)
+{
+
+}
+
+void SendMavlinkCommandState::setup(MAV_CMD command, double param1, double param2, double param3, double param4, double param5, double param6, double param7)
+{
+    _command = command;
+    _param1 = param1;
+    _param2 = param2;
+    _param3 = param3;
+    _param4 = param4;
+    _param5 = param5;
+    _param6 = param6;
+    _param7 = param7;
+
+    connect(this, &QState::entered, this, [this] () 
+        { 
+            qCDebug(QGCStateMachineLog) << QStringLiteral("Sending %1 command").arg(MissionCommandTree::instance()->friendlyName(_command)) << " - " << Q_FUNC_INFO;
+            _sendMavlinkCommand();
+        });
+
+    connect(this, &QState::exited, this, &SendMavlinkCommandState::_disconnectAll);
+}
+
+void SendMavlinkCommandState::_sendMavlinkCommand()
+{
+    connect(vehicle(), &Vehicle::mavCommandResult, this, &SendMavlinkCommandState::_mavCommandResult);
+    vehicle()->sendMavCommand(MAV_COMP_ID_AUTOPILOT1,
+                                _command,
+                                false /* showError */,
+                                static_cast<float>(_param1),
+                                static_cast<float>(_param2),
+                                static_cast<float>(_param3),
+                                static_cast<float>(_param4),
+                                static_cast<float>(_param5),
+                                static_cast<float>(_param6),
+                                static_cast<float>(_param7));
+}
+
+void SendMavlinkCommandState::_mavCommandResult(int vehicleId, int targetComponent, int command, int ackResult, int failureCode)
+{
+    Q_UNUSED(vehicleId);
+    Q_UNUSED(targetComponent);
+
+    Vehicle* senderVehicle = dynamic_cast<Vehicle*>(sender());
+    if (!senderVehicle) {
+        qWarning() << "Vehicle dynamic cast on sender() failed!" << " - " << Q_FUNC_INFO;
+        return;
+    }
+    if (senderVehicle != vehicle()) {
+        qCWarning(QGCStateMachineLog) << "Received mavCommandResult from unexpected vehicle" << " - " << Q_FUNC_INFO;
+        return;
+    }
+    if (command != _command) {
+        qCWarning(QGCStateMachineLog) << "Received mavCommandResult for unexpected command - expected:actual" << _command << command << " - " << Q_FUNC_INFO;
+        return;
+    }
+
+    _disconnectAll();
+
+    QString commandName = MissionCommandTree::instance()->friendlyName(_command);
+
+    if (failureCode == Vehicle::MavCmdResultFailureNoResponseToCommand) {
+        qCDebug(QGCStateMachineLog) << QStringLiteral("%1 Command - No response from vehicle").arg(commandName);
+        emit error();
+    } else if (failureCode == Vehicle::MavCmdResultFailureDuplicateCommand) {
+        qCWarning(QGCStateMachineLog) << QStringLiteral("%1 Command - Duplicate command pending").arg(commandName);
+        emit error();
+    } else if (ackResult != MAV_RESULT_ACCEPTED) {
+        qCWarning(QGCStateMachineLog) << QStringLiteral("%1 Command failed = ack.result: %2").arg(commandName).arg(ackResult);
+        emit error();
+    } else {
+        // MAV_RESULT_ACCEPTED
+        qCDebug(QGCStateMachineLog) << QStringLiteral("%1 Command succeeded").arg(commandName);
+        emit advance();
+    }
+}
+
+void SendMavlinkCommandState::_disconnectAll()
+{
+    disconnect(vehicle(), &Vehicle::mavCommandResult, this, &SendMavlinkCommandState::_mavCommandResult);
+}

--- a/src/Utilities/StateMachine/SendMavlinkCommandState.h
+++ b/src/Utilities/StateMachine/SendMavlinkCommandState.h
@@ -1,0 +1,46 @@
+/****************************************************************************
+ *
+ * (c) 2009-2024 QGROUNDCONTROL PROJECT <http://www.qgroundcontrol.org>
+ *
+ * QGroundControl is licensed according to the terms in the file
+ * COPYING.md in the root of the source code directory.
+ *
+ ****************************************************************************/
+
+#pragma once
+
+#include "QGCState.h"
+#include "QGCMAVLink.h"
+
+class Vehicle;
+
+/// Sends the specified MAVLink command to the vehicle
+class SendMavlinkCommandState : public QGCState
+{
+    Q_OBJECT
+
+public:
+    SendMavlinkCommandState(QState* parent, MAV_CMD command, double param1 = 0.0, double param2 = 0.0, double param3 = 0.0, double param4 = 0.0, double param5 = 0.0, double param6 = 0.0, double param7 = 0.0);
+    SendMavlinkCommandState(QState* parent);
+
+    void setup(MAV_CMD command, double param1 = 0.0, double param2 = 0.0, double param3 = 0.0, double param4 = 0.0, double param5 = 0.0, double param6 = 0.0, double param7 = 0.0);
+    
+signals:
+    void success();
+
+private slots:
+    void _mavCommandResult(int vehicleId, int targetComponent, int command, int ackResult, int failureCode);
+    void _disconnectAll();
+
+private:
+    void _sendMavlinkCommand();
+
+    MAV_CMD     _command;
+    double      _param1 = 0.0;
+    double      _param2 = 0.0;
+    double      _param3 = 0.0;
+    double      _param4 = 0.0;
+    double      _param5 = 0.0;
+    double      _param6 = 0.0;
+    double      _param7 = 0.0;
+};

--- a/src/Utilities/StateMachine/SendMavlinkMessageState.cc
+++ b/src/Utilities/StateMachine/SendMavlinkMessageState.cc
@@ -1,0 +1,60 @@
+/****************************************************************************
+ *
+ * (c) 2009-2024 QGROUNDCONTROL PROJECT <http://www.qgroundcontrol.org>
+ *
+ * QGroundControl is licensed according to the terms in the file
+ * COPYING.md in the root of the source code directory.
+ *
+ ****************************************************************************/
+
+#include "SendMavlinkMessageState.h"
+#include "MAVLinkProtocol.h"
+#include "MultiVehicleManager.h"
+#include "Vehicle.h"
+#include "VehicleLinkManager.h"
+#include "QGCLoggingCategory.h"
+
+SendMavlinkMessageState::SendMavlinkMessageState(QState *parent, MessageEncoder encoder, int retryCount)
+    : QGCState(QStringLiteral("SendMavlinkMessageState"), parent)
+    , _encoder(std::move(encoder))
+    , _retryCount(retryCount)
+{
+    connect(this, &QState::entered, this, &SendMavlinkMessageState::_sendMessage);
+}
+
+void SendMavlinkMessageState::_sendMessage()
+{
+    if (++_runCount > _retryCount + 1  /* +1 for initial attempt */) {
+        qCDebug(QGCStateMachineLog) << stateName() << "Exceeded maximum retries";
+        emit error();
+        return;
+    }
+
+    if (!_encoder) {
+        qCDebug(QGCStateMachineLog) << stateName() << "No MAVLink message encoder configured";
+        emit error();
+        return;
+    }
+
+    SharedLinkInterfacePtr sharedLink = vehicle()->vehicleLinkManager()->primaryLink().lock();
+    if (!sharedLink) {
+        qCWarning(QGCStateMachineLog) << stateName() << "No active link available to send MAVLink message";
+        emit error();
+        return;
+    }
+
+    mavlink_message_t message{};
+
+    const uint8_t systemId = MAVLinkProtocol::instance()->getSystemId();
+    const uint8_t componentId = MAVLinkProtocol::getComponentId();
+    const uint8_t channel = sharedLink->mavlinkChannel();
+
+    _encoder(systemId, channel, &message);
+    if (!vehicle()->sendMessageOnLinkThreadSafe(sharedLink.get(), message)) {
+        qCWarning(QGCStateMachineLog) << stateName() << "Failed to send MAVLink message";
+        emit error();
+        return;
+    }
+
+    emit advance();
+}

--- a/src/Utilities/StateMachine/SendMavlinkMessageState.h
+++ b/src/Utilities/StateMachine/SendMavlinkMessageState.h
@@ -1,0 +1,39 @@
+/****************************************************************************
+ *
+ * (c) 2009-2024 QGROUNDCONTROL PROJECT <http://www.qgroundcontrol.org>
+ *
+ * QGroundControl is licensed according to the terms in the file
+ * COPYING.md in the root of the source code directory.
+ *
+ ****************************************************************************/
+
+#pragma once
+
+#include "QGCState.h"
+#include "QGCMAVLink.h"
+
+#include <cstdint>
+#include <functional>
+
+class Vehicle;
+
+/// Sends the specified MAVLink message to the vehicle
+class SendMavlinkMessageState : public QGCState
+{
+    Q_OBJECT
+
+public:
+    using MessageEncoder = std::function<void (uint8_t systemId, uint8_t channel, mavlink_message_t *message)>;
+
+    /// @param encoder Function which encodes the MAVLink message to send
+    /// @param retryCount Number of times to retry sending the message on failure
+    SendMavlinkMessageState(QState *parent, MessageEncoder encoder, int retryCount);
+
+private slots:
+    void _sendMessage();
+
+private:
+    MessageEncoder _encoder;
+    int _retryCount = 0;
+    int _runCount = 0;
+};

--- a/src/Utilities/StateMachine/ShowAppMessageState.cc
+++ b/src/Utilities/StateMachine/ShowAppMessageState.cc
@@ -1,0 +1,22 @@
+/****************************************************************************
+ *
+ * (c) 2009-2024 QGROUNDCONTROL PROJECT <http://www.qgroundcontrol.org>
+ *
+ * QGroundControl is licensed according to the terms in the file
+ * COPYING.md in the root of the source code directory.
+ *
+ ****************************************************************************/
+
+#include "ShowAppMessageState.h"
+#include "QGCApplication.h"
+
+ShowAppMessageState::ShowAppMessageState(QState* parentState, const QString& appMessage)
+    : QGCState("ShowAppMessageState", parentState)
+    , _appMessage(appMessage)
+{
+    connect(this, &QState::entered, this, [this] () {
+        qCDebug(QGCStateMachineLog) << _appMessage;
+        qgcApp()->showAppMessage(_appMessage);
+        emit advance();
+    });
+}

--- a/src/Utilities/StateMachine/ShowAppMessageState.h
+++ b/src/Utilities/StateMachine/ShowAppMessageState.h
@@ -1,0 +1,27 @@
+/****************************************************************************
+ *
+ * (c) 2009-2024 QGROUNDCONTROL PROJECT <http://www.qgroundcontrol.org>
+ *
+ * QGroundControl is licensed according to the terms in the file
+ * COPYING.md in the root of the source code directory.
+ *
+ ****************************************************************************/
+
+#pragma once
+
+#include "QGCState.h"
+
+#include <QString>
+
+/// Display an application message to the user
+
+class ShowAppMessageState : public QGCState
+{
+    Q_OBJECT
+
+public:
+    ShowAppMessageState(QState* parentState, const QString& appMessage);
+
+private:
+    QString _appMessage;
+};

--- a/src/Utilities/StateMachine/WaitForMavlinkMessageState.cc
+++ b/src/Utilities/StateMachine/WaitForMavlinkMessageState.cc
@@ -1,0 +1,70 @@
+/****************************************************************************
+ *
+ * (c) 2009-2024 QGROUNDCONTROL PROJECT <http://www.qgroundcontrol.org>
+ *
+ * QGroundControl is licensed according to the terms in the file
+ * COPYING.md in the root of the source code directory.
+ *
+ ****************************************************************************/
+
+#include "WaitForMavlinkMessageState.h"
+
+#include "MultiVehicleManager.h"
+#include "Vehicle.h"
+
+#include "QGCLoggingCategory.h"
+
+#include <QString>
+#include <utility>
+WaitForMavlinkMessageState::WaitForMavlinkMessageState(QState *parent, uint32_t messageId, int timeoutMsecs, Predicate predicate)
+    : QGCState(QStringLiteral("WaitForMavlinkMessageState"), parent)
+    , _messageId(messageId)
+    , _predicate(std::move(predicate))
+    , _timeoutMsecs(timeoutMsecs > 0 ? timeoutMsecs : 0)
+{
+    connect(this, &QState::entered, this, &WaitForMavlinkMessageState::_onEntered);
+    connect(this, &QState::exited, this, &WaitForMavlinkMessageState::_onExited);
+    _timeoutTimer.setSingleShot(true);
+    connect(&_timeoutTimer, &QTimer::timeout, this, &WaitForMavlinkMessageState::_onTimeout);
+}
+
+void WaitForMavlinkMessageState::_onEntered()
+{
+    connect(vehicle(), &Vehicle::mavlinkMessageReceived, this, &WaitForMavlinkMessageState::_messageReceived, Qt::UniqueConnection);
+
+    if (_timeoutMsecs > 0) {
+        _timeoutTimer.start(_timeoutMsecs);
+    }
+}
+
+void WaitForMavlinkMessageState::_onExited()
+{
+    disconnect(vehicle(), &Vehicle::mavlinkMessageReceived, this, &WaitForMavlinkMessageState::_messageReceived);
+
+    _timeoutTimer.stop();
+}
+
+void WaitForMavlinkMessageState::_messageReceived(const mavlink_message_t &message)
+{
+    if (message.msgid != _messageId) {
+        return;
+    }
+    if (_predicate && !_predicate(message)) {
+        return;
+    }
+
+    qCDebug(QGCStateMachineLog) << stateName() << "received expected message id" << _messageId;
+
+    disconnect(vehicle(), &Vehicle::mavlinkMessageReceived, this, &WaitForMavlinkMessageState::_messageReceived);
+    _timeoutTimer.stop();
+
+    emit advance();
+}
+
+void WaitForMavlinkMessageState::_onTimeout()
+{
+    qCDebug(QGCStateMachineLog) << stateName() << "timeout waiting for message id" << _messageId;
+    disconnect(vehicle(), &Vehicle::mavlinkMessageReceived, this, &WaitForMavlinkMessageState::_messageReceived);
+
+    emit timeout();
+}

--- a/src/Utilities/StateMachine/WaitForMavlinkMessageState.h
+++ b/src/Utilities/StateMachine/WaitForMavlinkMessageState.h
@@ -1,0 +1,51 @@
+/****************************************************************************
+ *
+ * (c) 2009-2024 QGROUNDCONTROL PROJECT <http://www.qgroundcontrol.org>
+ *
+ * QGroundControl is licensed according to the terms in the file
+ * COPYING.md in the root of the source code directory.
+ *
+ ****************************************************************************/
+
+#pragma once
+
+#include "QGCState.h"
+#include "QGCMAVLink.h"
+
+#include <QtCore/QTimer>
+
+#include <cstdint>
+#include <functional>
+
+class Vehicle;
+
+/// Waits for the specified MAVLink message from the vehicle
+///     signals timeout() - if the message is not received within the specified timeout period
+class WaitForMavlinkMessageState : public QGCState
+{
+    Q_OBJECT
+
+public:
+    using Predicate = std::function<bool(const mavlink_message_t &message)>;
+
+    /// @param messageId MAVLink message ID to wait for
+    /// @param timeoutMsecs Timeout in milliseconds to wait for message, 0 to wait forever
+    /// @param predicate Optional predicate which further filters received messages
+    WaitForMavlinkMessageState(QState *parent, uint32_t messageId, int timeoutMsecs, Predicate predicate = Predicate());
+
+signals:
+    void timeout();
+
+private slots:
+    void _onEntered();
+    void _onExited();
+    void _messageReceived(const mavlink_message_t &message);
+    void _onTimeout();
+
+private:
+    uint32_t _messageId = 0U;
+    Predicate _predicate;
+    Vehicle *_vehicle = nullptr;
+    int _timeoutMsecs = 0;
+    QTimer _timeoutTimer;
+};

--- a/src/main.cc
+++ b/src/main.cc
@@ -31,6 +31,15 @@
 
 int main(int argc, char *argv[])
 {
+#if 0
+    // Useful for debugging specific unit tests
+    char argument1[] = "--unittest:ParameterManagerTest";
+    char argument2[] = "--logging:FactSystem.ParameterManager,Utilities.QGCStateMachine";
+    char *newArgv[] = { argv[0], argument1, argument2 };
+    argc = 3;
+    argv = newArgv;
+#endif
+
 #if defined(Q_OS_LINUX) && !defined(Q_OS_ANDROID)
     if (::getuid() == 0) {
         const QApplication errorApp(argc, argv);

--- a/test/FactSystem/ParameterManagerTest.cc
+++ b/test/FactSystem/ParameterManagerTest.cc
@@ -13,9 +13,14 @@
 #include "Vehicle.h"
 #include "ParameterManager.h"
 #include "MockLinkFTP.h"
+#include "QGC.h"
 
+#include <QtCore/QElapsedTimer>
 #include <QtTest/QTest>
 #include <QtTest/QSignalSpy>
+
+#include <cmath>
+#include <limits>
 
 /// Test failure modes which should still lead to param load success
 void ParameterManagerTest::_noFailureWorker(MockConfiguration::FailureMode_t failureMode)
@@ -129,6 +134,132 @@ void ParameterManagerTest::_requestListMissingParamFail(void)
     // We should get a parameters ready signal, but Vehicle should indicate missing params
     QCOMPARE(spyParamsReady.wait(40000), true);
     QCOMPARE(vehicle->parameterManager()->missingParameters(), true);
+}
+
+void ParameterManagerTest::_paramWriteNoAckRetry(void)
+{
+    _setParamWithFailureMode(MockLink::FailParamSetFirstAttemptNoAck, true /* expectSuccess */);
+}
+
+void ParameterManagerTest::_paramWriteNoAckPermanent(void)
+{
+    _setParamWithFailureMode(MockLink::FailParamSetNoAck, false /* expectSuccess */);
+}
+
+void ParameterManagerTest::_setParamWithFailureMode(MockLink::ParamSetFailureMode_t failureMode, bool expectSuccess)
+{
+    Q_ASSERT(!_mockLink);
+
+    // Bring up a clean mock vehicle for each run
+    _connectMockLink();
+    QVERIFY(_mockLink);
+    QVERIFY(_vehicle);
+
+    _mockLink->setParamSetFailureMode(failureMode);
+
+    MultiVehicleManager* vehicleMgr = MultiVehicleManager::instance();
+    QVERIFY(vehicleMgr);
+    ParameterManager *const paramManager = _vehicle->parameterManager();
+    QVERIFY(paramManager);
+    QVERIFY(!_vehicle->parameterManager()->pendingWrites());
+
+    // Use a parameter that exists in the mock PX4 set and has floating point range
+    Fact *const fact = paramManager->getParameter(MAV_COMP_ID_AUTOPILOT1, QStringLiteral("BAT1_V_CHARGED"));
+    QVERIFY(fact);
+    QSignalSpy rawValueChangedSpy(fact, &Fact::rawValueChanged);
+
+    const QVariant originalValue = fact->rawValue();
+    const double originalDouble = originalValue.toDouble();
+
+    const FactMetaData *const metaData = fact->metaData();
+    const double minValue = (metaData && metaData->rawMin().isValid()) ? metaData->rawMin().toDouble() : -std::numeric_limits<double>::infinity();
+    const double maxValue = (metaData && metaData->rawMax().isValid()) ? metaData->rawMax().toDouble() : std::numeric_limits<double>::infinity();
+    const double step = 0.1;
+
+    auto adjustedValue = [&](double candidate) -> double {
+        if (candidate > maxValue) {
+            candidate = originalDouble - step;
+        }
+        if (candidate < minValue) {
+            candidate = originalDouble + step;
+        }
+        if (qFuzzyCompare(candidate + 1.0, originalDouble + 1.0)) {
+            candidate = originalDouble + (step * 2.0);
+        }
+        if (candidate > maxValue) {
+            candidate = originalDouble - (step * 2.0);
+        }
+        if (candidate < minValue) {
+            candidate = originalDouble;
+        }
+        return candidate;
+    };
+
+    const double newValueDouble = adjustedValue(originalDouble + step);
+    QVERIFY(!qFuzzyCompare(newValueDouble + 1.0, originalDouble + 1.0));
+    const QVariant newValue(newValueDouble);
+
+    QSignalSpy pendingSpy(paramManager, &ParameterManager::pendingWritesChanged);
+    QVERIFY(pendingSpy.isValid());
+
+    fact->setRawValue(newValue);
+
+    // We should see pendingWrites go to true and then back to false
+
+    bool sawPendingTrue = false;
+    bool sawPendingFalse = false;
+    int processedCount = 0;
+    QElapsedTimer waitTimer;
+    waitTimer.start();
+
+    while ((!sawPendingTrue || !sawPendingFalse) && waitTimer.elapsed() < 20000) {
+        (void) pendingSpy.wait(500);
+        while (processedCount < pendingSpy.count()) {
+            const QList<QVariant> arguments = pendingSpy.at(processedCount++);
+            QCOMPARE(arguments.count(), 1);
+            const bool isPending = arguments.at(0).toBool();
+            if (isPending) {
+                sawPendingTrue = true;
+            } else {
+                sawPendingFalse = true;
+            }
+        }
+    }
+
+    QVERIFY2(sawPendingTrue, "Expected pendingWritesChanged(true) signal");
+    QVERIFY2(sawPendingFalse, "Expected pendingWritesChanged(false) signal");
+
+    // We should get two rawValueChanged signals if unsuccessful (one for the set, one for the refresh)
+    // We should get one rawValueChanged signal if successful (just the set)
+
+    bool rawValueChangedCountMatches = false;
+    rawValueChangedSpy.wait(ParameterManager::kParamSetWaitForParamValueAckMs * ParameterManager::kParamSetRetryCount + 500);
+    if (expectSuccess) {
+        QCOMPARE(rawValueChangedSpy.count(), 1);
+    } else {
+        QVERIFY(rawValueChangedSpy.count() == 1 || rawValueChangedSpy.count() == 2);
+    }
+
+    // The first signal is the change we made, so we start checking from there
+    QVERIFY(QGC::fuzzyCompare(rawValueChangedSpy[0][0].toDouble(), newValueDouble, 0.00001));
+
+    if (!expectSuccess) {
+        // If the write failed the second signal should be the value reverting to original
+        if (rawValueChangedSpy.count() == 1) {
+            // Wait a bit longer for the refresh to come in
+            rawValueChangedSpy.wait(1000);
+        }
+        QCOMPARE(rawValueChangedSpy.count(), 2);
+        QVERIFY(QGC::fuzzyCompare(rawValueChangedSpy[1][0].toDouble(), originalDouble, 0.00001));
+
+        // We should have also alerted the user of the failure
+        // Note that we can't easily check for the ShowAppMessageState usage here due to the
+        // complexity of the state machine and timing of the signals.
+    }
+
+    _mockLink->setParamSetFailureMode(MockLink::FailParamSetNone);
+
+    _disconnectMockLink();
 }
 
 #if 0

--- a/test/FactSystem/ParameterManagerTest.h
+++ b/test/FactSystem/ParameterManagerTest.h
@@ -11,6 +11,7 @@
 
 #include "UnitTest.h"
 #include "MockConfiguration.h"
+#include "MockLink.h"
 
 class ParameterManagerTest : public UnitTest
 {
@@ -21,10 +22,13 @@ private slots:
     void _requestListNoResponse(void);
     void _requestListMissingParamSuccess(void);
     void _requestListMissingParamFail(void);
+    void _paramWriteNoAckRetry(void);
+    void _paramWriteNoAckPermanent(void);
     // void _FTPnoFailure(void);
     // void _FTPChangeParam(void);
 
 
 private:
     void _noFailureWorker(MockConfiguration::FailureMode_t failureMode);
+    void _setParamWithFailureMode(MockLink::ParamSetFailureMode_t failureMode, bool expectSuccess);
 };

--- a/tools/setup/install-qt-debian.sh
+++ b/tools/setup/install-qt-debian.sh
@@ -9,7 +9,7 @@ QT_TARGET="${QT_TARGET:-desktop}"
 QT_ARCH="${QT_ARCH:-linux_gcc_64}"
 QT_ARCH_DIR="${QT_ARCH_DIR:-gcc_64}"
 QT_ROOT_DIR="${QT_ROOT_DIR:-${QT_PATH}/${QT_VERSION}/${QT_ARCH_DIR}}"
-QT_MODULES="${QT_MODULES:-qtcharts qtlocation qtpositioning qtspeech qt5compat qtmultimedia qtserialport qtimageformats qtshadertools qtconnectivity qtquick3d qtsensors}"
+QT_MODULES="${QT_MODULES:-qtcharts qtlocation qtpositioning qtspeech qt5compat qtmultimedia qtserialport qtimageformats qtshadertools qtconnectivity qtquick3d qtsensors qtscxml}"
 
 echo "QT_VERSION $QT_VERSION"
 echo "QT_PATH $QT_PATH"

--- a/tools/setup/install-qt-macos.sh
+++ b/tools/setup/install-qt-macos.sh
@@ -6,7 +6,7 @@ QT_PATH="${QT_PATH:-/opt/Qt}"
 QT_HOST="${QT_HOST:-mac}"
 QT_TARGET="${QT_TARGET:-desktop}"
 QT_ARCH="${QT_ARCH:-mac}"
-QT_MODULES="${QT_MODULES:-qtcharts qtlocation qtpositioning qtspeech qt5compat qtmultimedia qtserialport qtimageformats qtshadertools qtconnectivity qtquick3d qtsensors}"
+QT_MODULES="${QT_MODULES:-qtcharts qtlocation qtpositioning qtspeech qt5compat qtmultimedia qtserialport qtimageformats qtshadertools qtconnectivity qtquick3d qtsensors qtscxml}"
 
 set -e
 

--- a/tools/setup/install-qt-windows.ps1
+++ b/tools/setup/install-qt-windows.ps1
@@ -17,7 +17,7 @@ $QT_HOST    = $env:QT_HOST         -or 'windows'
 $QT_TARGET  = $env:QT_TARGET       -or 'desktop'
 # Windows arch must be one of: win64_msvc2017_64, win64_msvc2019_64, win64_mingw81, etc. :contentReference[oaicite:0]{index=0}
 $QT_ARCH    = $env:QT_ARCH         -or 'win64_msvc2022_64'
-$QT_MODULES = $env:QT_MODULES      -or 'qtcharts qtlocation qtpositioning qtspeech qt5compat qtmultimedia qtserialport qtimageformats qtshadertools qtconnectivity qtquick3d qtsensors'
+$QT_MODULES = $env:QT_MODULES      -or 'qtcharts qtlocation qtpositioning qtspeech qt5compat qtmultimedia qtserialport qtimageformats qtshadertools qtconnectivity qtquick3d qtsensors qtscxml'
 
 Write-Host "Using:"
 Write-Host "  QT_VERSION    = $QT_VERSION"


### PR DESCRIPTION
* Initial commit of new QGCStateMachine support
* Converted PARAM_SET implementation to use new state machine
* Updated MockLink with new failure modes for PARAM_SET
* Added new ParameterManager units test for PARAM_SET testing
* Added float and tolerance based fuzzyCompare to QGC namespace

<!--- Title -->

Description
-----------
<!--- Describe your changes in detail. -->

Test Steps
-----------
<!-- Describe the steps to reproduce. -->

Checklist:
----------
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [ ] [Review Contribution Guidelines](https://github.com/mavlink/qgroundcontrol/blob/master/.github/CONTRIBUTING.md).
- [ ] [Review Code of Conduct](https://github.com/mavlink/qgroundcontrol/blob/master/.github/CODE_OF_CONDUCT.md).
- [ ] I have tested my changes.

Related Issue
-----------
<!-- If any, please provide issue ID. -->


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.