### PR TITLE
ParameterManager: Converted PARAM_REQUEST_READ support to QGCStateMachine

### DIFF
--- a/src/Comms/MockLink/MockLink.cc
+++ b/src/Comms/MockLink/MockLink.cc
@@ -1022,6 +1022,17 @@ void MockLink::_handleParamRequestRead(const mavlink_message_t &msg)
         return;
     }
 
+    if (_paramRequestReadFailureMode == FailParamRequestReadFirstAttemptNoResponse && _paramRequestReadFailureFirstAttemptPending) {
+        qCDebug(MockLinkLog) << "Param request read failure: first attempt no response" << paramId;
+        _paramRequestReadFailureFirstAttemptPending = false;
+        return;
+    }
+
+    if (_paramRequestReadFailureMode == FailParamRequestReadNoResponse) {
+        qCDebug(MockLinkLog) << "Param request read failure: no response" << paramId;
+        return;
+    }
+
     (void) mavlink_msg_param_value_pack_chan(
         _vehicleSystemId,
         componentId,                                               // component id

--- a/src/Comms/MockLink/MockLink.h
+++ b/src/Comms/MockLink/MockLink.h
@@ -102,6 +102,16 @@ public:
         _paramSetFailureFirstAttemptPending = (mode == FailParamSetFirstAttemptNoAck);
     }
 
+    enum ParamRequestReadFailureMode_t {
+        FailParamRequestReadNone,               ///< Normal behavior
+        FailParamRequestReadNoResponse,         ///< Do not respond to PARAM_REQUEST_READ
+        FailParamRequestReadFirstAttemptNoResponse, ///< Skip response on first attempt, respond to retry
+    };
+    void setParamRequestReadFailureMode(ParamRequestReadFailureMode_t mode) {
+        _paramRequestReadFailureMode = mode;
+        _paramRequestReadFailureFirstAttemptPending = (mode == FailParamRequestReadFirstAttemptNoResponse);
+    }
+
     static MockLink *startPX4MockLink(bool sendStatusText, MockConfiguration::FailureMode_t failureMode = MockConfiguration::FailNone);
     static MockLink *startGenericMockLink(bool sendStatusText, MockConfiguration::FailureMode_t failureMode = MockConfiguration::FailNone);
     static MockLink *startNoInitialConnectMockLink(bool sendStatusText, MockConfiguration::FailureMode_t failureMode = MockConfiguration::FailNone);
@@ -276,6 +286,8 @@ private:
     RequestMessageFailureMode_t _requestMessageFailureMode = FailRequestMessageNone;
     ParamSetFailureMode_t _paramSetFailureMode = FailParamSetNone;
     bool _paramSetFailureFirstAttemptPending = false;
+    ParamRequestReadFailureMode_t _paramRequestReadFailureMode = FailParamRequestReadNone;
+    bool _paramRequestReadFailureFirstAttemptPending = false;
 
     QMap<MAV_CMD, int> _receivedMavCommandCountMap;
     QMap<int, QMap<QString, QVariant>> _mapParamName2Value;

--- a/src/QmlControls/ParameterEditorController.cc
+++ b/src/QmlControls/ParameterEditorController.cc
@@ -345,7 +345,7 @@ void ParameterEditorController::sendDiff(void)
 
         if (paramDiff->load) {
             if (paramDiff->noVehicleValue) {
-                _parameterMgr->_factRawValueUpdateWorker(paramDiff->componentId, paramDiff->name, paramDiff->valueType, paramDiff->fileValueVar);
+                _parameterMgr->_mavlinkParamSet(paramDiff->componentId, paramDiff->name, paramDiff->valueType, paramDiff->fileValueVar);
             } else {
                 Fact* fact = _parameterMgr->getParameter(paramDiff->componentId, paramDiff->name);
                 fact->setRawValue(paramDiff->fileValueVar);

--- a/src/Utilities/StateMachine/DelayState.cc
+++ b/src/Utilities/StateMachine/DelayState.cc
@@ -19,7 +19,7 @@ DelayState::DelayState(QState* parentState, int delayMsecs)
 
     connect(this, &QState::entered, this, [this, delayMsecs] () 
         { 
-            qCDebug(QGCStateMachineLog) << QStringLiteral("Starting delay for %1 secs").arg(delayMsecs / 1000.0) << " - " << Q_FUNC_INFO;
+            qCDebug(QGCStateMachineLog) << stateName() << QStringLiteral("Starting delay for %1 secs").arg(delayMsecs / 1000.0) << " - " << Q_FUNC_INFO;
             _delayTimer.start();
         });
 

--- a/src/Utilities/StateMachine/QGCFinalState.cc
+++ b/src/Utilities/StateMachine/QGCFinalState.cc
@@ -9,14 +9,15 @@
 
 #include "QGCFinalState.h"
 #include "QGCState.h"
+#include "QGCStateMachine.h"
 
 QGCFinalState::QGCFinalState(QState* parent)
     : QFinalState(parent)
 {
     connect(this, &QFinalState::entered, this, [this] () {
-        qCDebug(QGCStateMachineLog) << "Entered Final State";
+        qCDebug(QGCStateMachineLog) << "Entered Final State" << qobject_cast<QGCStateMachine*>(this->machine())->machineName();
     });
     connect(this, &QState::exited, this, [this] () {
-        qCDebug(QGCStateMachineLog) << "Exited Final State";
+        qCDebug(QGCStateMachineLog) << "Exited Final State" << qobject_cast<QGCStateMachine*>(this->machine())->machineName();
     });
 }

--- a/src/Utilities/StateMachine/QGCState.cc
+++ b/src/Utilities/StateMachine/QGCState.cc
@@ -18,14 +18,14 @@ QGCState::QGCState(const QString& stateName, QState* parentState)
     setObjectName(stateName);
 
     connect(this, &QState::entered, this, [this] () {
-        qCDebug(QGCStateMachineLog) << "Entered state" << objectName() << " - " << Q_FUNC_INFO;
+        qCDebug(QGCStateMachineLog) << "Entered" << this->stateName();
     });
     connect(this, &QState::exited, this, [this] () {
-        qCDebug(QGCStateMachineLog) << "Exited state" << objectName() << " - " << Q_FUNC_INFO;
+        qCDebug(QGCStateMachineLog) << "Exited" << this->stateName();
     });
 }
 
-QGCStateMachine* QGCState::machine() 
+QGCStateMachine* QGCState::machine() const
 { 
     return qobject_cast<QGCStateMachine*>(QState::machine()); 
 }
@@ -33,4 +33,13 @@ QGCStateMachine* QGCState::machine()
 Vehicle *QGCState::vehicle() 
 { 
     return machine()->vehicle(); 
+}
+
+QString QGCState::stateName() const 
+{
+    if (machine()) {
+        return QStringLiteral("%1:%2").arg(objectName(), machine()->machineName());
+    } else {
+        return objectName();
+    }
 }

--- a/src/Utilities/StateMachine/QGCState.h
+++ b/src/Utilities/StateMachine/QGCState.h
@@ -30,9 +30,9 @@ public:
     template <typename PointerToMemberFunction> QSignalTransition *addThisTransition(PointerToMemberFunction signal, QAbstractState *target)
         { return QState::addTransition(this, signal, target); };
 
-    QGCStateMachine* machine();
+    QGCStateMachine* machine() const;
     Vehicle *vehicle();
-    QString stateName() const { return objectName(); }
+    QString stateName() const;
 
 signals:
     void advance();     ///< Signal to indicate state is complete and machine should advance to next state

--- a/src/Utilities/StateMachine/QGCStateMachine.h
+++ b/src/Utilities/StateMachine/QGCStateMachine.h
@@ -33,6 +33,7 @@ public:
     QGCStateMachine(const QString& machineName, Vehicle* vehicle, QObject* parent = nullptr);
 
     Vehicle *vehicle() const { return _vehicle; }
+    QString machineName() const { return objectName(); }
 
 signals:
     void error();

--- a/src/Utilities/StateMachine/SendMavlinkMessageState.cc
+++ b/src/Utilities/StateMachine/SendMavlinkMessageState.cc
@@ -25,20 +25,20 @@ SendMavlinkMessageState::SendMavlinkMessageState(QState *parent, MessageEncoder 
 void SendMavlinkMessageState::_sendMessage()
 {
     if (++_runCount > _retryCount + 1  /* +1 for initial attempt */) {
-        qCDebug(QGCStateMachineLog) << stateName() << "Exceeded maximum retries";
+        qCDebug(QGCStateMachineLog) << "Exceeded maximum retries" << stateName();
         emit error();
         return;
     }
 
     if (!_encoder) {
-        qCDebug(QGCStateMachineLog) << stateName() << "No MAVLink message encoder configured";
+        qCDebug(QGCStateMachineLog) << "No MAVLink message encoder configured" << stateName();
         emit error();
         return;
     }
 
     SharedLinkInterfacePtr sharedLink = vehicle()->vehicleLinkManager()->primaryLink().lock();
     if (!sharedLink) {
-        qCWarning(QGCStateMachineLog) << stateName() << "No active link available to send MAVLink message";
+        qCWarning(QGCStateMachineLog) << "No active link available to send MAVLink message" << stateName();
         emit error();
         return;
     }
@@ -51,7 +51,7 @@ void SendMavlinkMessageState::_sendMessage()
 
     _encoder(systemId, channel, &message);
     if (!vehicle()->sendMessageOnLinkThreadSafe(sharedLink.get(), message)) {
-        qCWarning(QGCStateMachineLog) << stateName() << "Failed to send MAVLink message";
+        qCWarning(QGCStateMachineLog) << "Failed to send MAVLink message" << stateName();
         emit error();
         return;
     }

--- a/src/Utilities/StateMachine/ShowAppMessageState.cc
+++ b/src/Utilities/StateMachine/ShowAppMessageState.cc
@@ -15,7 +15,7 @@ ShowAppMessageState::ShowAppMessageState(QState* parentState, const QString& app
     , _appMessage(appMessage)
 {
     connect(this, &QState::entered, this, [this] () {
-        qCDebug(QGCStateMachineLog) << _appMessage;
+        qCDebug(QGCStateMachineLog) << _appMessage << stateName();
         qgcApp()->showAppMessage(_appMessage);
         emit advance();
     });

--- a/src/Utilities/StateMachine/WaitForMavlinkMessageState.cc
+++ b/src/Utilities/StateMachine/WaitForMavlinkMessageState.cc
@@ -53,7 +53,7 @@ void WaitForMavlinkMessageState::_messageReceived(const mavlink_message_t &messa
         return;
     }
 
-    qCDebug(QGCStateMachineLog) << stateName() << "received expected message id" << _messageId;
+    qCDebug(QGCStateMachineLog) << "Received expected message id" << _messageId << stateName();
 
     disconnect(vehicle(), &Vehicle::mavlinkMessageReceived, this, &WaitForMavlinkMessageState::_messageReceived);
     _timeoutTimer.stop();
@@ -63,7 +63,7 @@ void WaitForMavlinkMessageState::_messageReceived(const mavlink_message_t &messa
 
 void WaitForMavlinkMessageState::_onTimeout()
 {
-    qCDebug(QGCStateMachineLog) << stateName() << "timeout waiting for message id" << _messageId;
+    qCDebug(QGCStateMachineLog) << "Timeout waiting for message id" << _messageId << stateName();
     disconnect(vehicle(), &Vehicle::mavlinkMessageReceived, this, &WaitForMavlinkMessageState::_messageReceived);
 
     emit timeout();

--- a/test/FactSystem/ParameterManagerTest.h
+++ b/test/FactSystem/ParameterManagerTest.h
@@ -24,6 +24,8 @@ private slots:
     void _requestListMissingParamFail(void);
     void _paramWriteNoAckRetry(void);
     void _paramWriteNoAckPermanent(void);
+    void _paramReadFirstAttemptNoResponseRetry(void);
+    void _paramReadNoResponse(void);
     // void _FTPnoFailure(void);
     // void _FTPChangeParam(void);
 


### PR DESCRIPTION
* Converted PARAM_REQUEST_READ support to QGCStateMachine
* Fixed up QGCStateMachine logging to be more readable
* Add unit tests for new PARAM_REQUEST_READ support