### PR TITLE
fix: Android video hardware decoder selection issue

### DIFF
--- a/src/VideoManager/VideoReceiver/GStreamer/GStreamerHelpers.cc
+++ b/src/VideoManager/VideoReceiver/GStreamer/GStreamerHelpers.cc
@@ -41,6 +41,17 @@ bool is_hardware_decoder_factory(GstElementFactory *factory)
         return false;
     }
 
+    const gchar *factoryName = gst_plugin_feature_get_name(GST_PLUGIN_FEATURE(factory));
+    if (!factoryName) {
+        return false;
+    }
+
+    // Exclude Android software decoders (OMXGoogle / C2Android)
+    QString name = QString::fromUtf8(factoryName).toLower();
+    if (name.startsWith("amcviddec-omxgoogle") || name.startsWith("amcviddec-c2android")) {
+        return false;
+    }
+
     const auto containsHardware = [](const gchar *value) {
         return value && (g_strrstr(value, "Hardware") != nullptr || g_strrstr(value, "hardware") != nullptr);
     };
@@ -51,11 +62,6 @@ bool is_hardware_decoder_factory(GstElementFactory *factory)
 
     if (containsHardware(gst_element_factory_get_klass(factory))) {
         return true;
-    }
-
-    const gchar *factoryName = gst_plugin_feature_get_name(GST_PLUGIN_FEATURE(factory));
-    if (!factoryName) {
-        return false;
     }
 
     const QString nameLower = QString::fromUtf8(factoryName).toLower();


### PR DESCRIPTION
Exclude Android software decoders (OMXGoogle / C2Android) and set software decoder rank to GST_RANK_NONE. Prioritize actual hardware decoders so decodebin3 automatically selects them on Android devices.

<!--- Title -->

Description
-----------
<!--- Describe your changes in detail. -->

Since QGroundControl v5.0, GStreamer 1.22.12 is used.  
Simply increasing the priority of hardware decoders is not enough to ensure their selection. It is also necessary to set the software decoders' rank to GST_RANK_NONE and fix the decoder detection logic.  
With these changes, the system can correctly select and use hardware decoders for video playback.

Previously, in version v4.4.5 (using GStreamer 1.18.1), simply raising the hardware decoder priority was sufficient for the system to choose hardware decoders.

Key changes in this PR:
- Exclude Android software decoders (OMXGoogle / C2Android)
- Set software decoder ranks (avdec_*, vp8dec, vp9dec, etc.) to GST_RANK_NONE
- Prioritize actual hardware decoders so that decodebin3 automatically selects them

Test Steps
-----------
<!-- Describe the steps to reproduce. -->
1. Run QGroundControl on an Android device.
2. Play a video stream and select:
   `Video -> Settings -> Force video decoder priority -> Force hardware decoder`.
3. Enable logging to capture video-related logs.
4. Restart QGroundControl and load the video content.
5. Save the logs and check the following key entries to verify that a hardware decoder is selected.  
   > Note: The example below is for reference only; actual log entries may vary depending on the device.
```yaml
9.617 Decodebin3 selected codec:rank - "androidmedia" / amcviddec-c2imxavcdecoder - Codec/Decoder/Video/Hardware (HW) : 257 - Video.GstVideoReceiver - (GstVideoReceiver::_logDecodebin3SelectedCodec:946)
9.692 Video "videoContent" resized. New resolution: 1280 x 720 - Video.VideoManager - (VideoManager::_initVideoReceiver(VideoReceiver *, QQuickWindow *)::(anonymous class)::operator():771)
```
6. Confirm from the logs that the correct hardware decoder is selected.
7. Verify that video playback works correctly and that performance is improved.

Checklist:
----------
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] [Review Contribution Guidelines](https://github.com/mavlink/qgroundcontrol/blob/master/.github/CONTRIBUTING.md).
- [x] [Review Code of Conduct](https://github.com/mavlink/qgroundcontrol/blob/master/.github/CODE_OF_CONDUCT.md).
- [x] I have tested my changes.

Related Issue
-----------
<!-- If any, please provide issue ID. -->

Fixes or continues work from #13545 (Android hardware decoder selection was not resolved)