### PR TITLE
Update CMakeList.txt

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -122,6 +122,7 @@ target_link_libraries(${CMAKE_PROJECT_NAME}
         Qt6::LocationPrivate
         Qt6::Positioning
         Qt6::PositioningPrivate
+        Qt6::Sql
 
         # Qt6 Multimedia
         Qt6::Multimedia


### PR DESCRIPTION
Title
cmake(android): Link Qt6::Sql on app target so SQLite driver is packaged

Description
Without linking Qt6::Sql to the main executable, Android builds strip out the sqldrivers/libqsqlite.so plugin.
That causes the map tile cache to fail with “Database Not Initialized” when QGroundControl tries to open its cache database.

Linking Qt6::Sql on the app target ensures the SQLite driver is packaged and restores Offline Map caching on Android.

Test Steps
-To reproduce (before fix):
-Build Android arm64-v8a.
-Launch QGroundControl.
-Observe: Offline Map cache fails with “Database Not Initialized”.
-APK lacks lib/arm64-v8a/sqldrivers/libqsqlite.so.

To verify (after fix):
-Add Qt6::Sql to app target’s link list.
-Rebuild Android (Qt 6.10).
-Launch app → Offline Map cache works.
-APK now contains libqsqlite.so.

Checklist
 I have read the [Contribution Guidelines](https://github.com/mavlink/qgroundcontrol/blob/master/.github/CONTRIBUTING.md)
 I agree to the [Code of Conduct](https://github.com/mavlink/qgroundcontrol/blob/master/.github/CODE_OF_CONDUCT.md)
 I have tested my changes on Android (arm64-v8a, Qt 6.10).