### PR TITLE
Android: Fix white bar by enabling immersive fullscreen (API 30+)

### DIFF
--- a/src/UI/MainWindow.qml
+++ b/src/UI/MainWindow.qml
@@ -27,9 +27,8 @@ ApplicationWindow {
     id:             mainWindow
     visible:        true
 
-    flags: Qt.platform.os === "android"
-        ? Qt.Window | Qt.ExpandedClientAreaHint
-        : Qt.Window
+    flags: Qt.Window | Qt.ExpandedClientAreaHint | Qt.NoTitleBarBackgroundHint
+    
     property bool   _utmspSendActTrigger
 
     Component.onCompleted: {


### PR DESCRIPTION
Android: Fix white bar by enabling immersive fullscreen (API 30+)

After upgrading to Qt 6.10 / NDK 27, Android stopped applying immersive
flags, causing visible white bars (system nav/status areas) below the Qt window on tablets.

<img width="1600" height="1000" alt="image" src="https://github.com/user-attachments/assets/b722e234-9a12-4e4c-b352-235bd054cad2" />


This patch restores true fullscreen behavior on Android 11+ using the
WindowInsetsController API.

Changes:
- Added QGCActivity.goImmersive() with WindowInsetsController.hide()
- Called goImmersive() from onCreate() and onWindowFocusChanged()
- Applies only on API >= 30

Result: QGroundControl launches in proper immersive fullscreen mode on
Android.
![WhatsApp Image 2025-11-09 at 12 21 17_76fb24df](https://github.com/user-attachments/assets/fbf44ed5-d420-4020-8c65-60703cf3665c)

Test: Samsung s7 fe and samsung a63
Further: on Samsung a63 test there is a white gap in the camera area I dont know its on purpose or not but this commit fix the issue on the tablet 

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.