### PR TITLE
fix: Modify Video GStreamer library linking for MSVC

### DIFF
--- a/src/VideoManager/VideoReceiver/GStreamer/CMakeLists.txt
+++ b/src/VideoManager/VideoReceiver/GStreamer/CMakeLists.txt
@@ -33,7 +33,11 @@ endif()
 # ============================================================================
 
 if(TARGET gstqml6gl)
-    target_link_libraries(${CMAKE_PROJECT_NAME} PRIVATE gstqml6gl)
+    if(MSVC)
+        target_link_libraries(${CMAKE_PROJECT_NAME} PRIVATE -WHOLEARCHIVE:$<TARGET_FILE:gstqml6gl>)
+    else()
+        target_link_libraries(${CMAKE_PROJECT_NAME} PRIVATE gstqml6gl)
+    endif()
 
     target_sources(${CMAKE_PROJECT_NAME}
         PRIVATE


### PR DESCRIPTION
Modify Video GStreamer library linking for MSVC

Description
-----------
Compatible with Windows GStreamer MSVC compilation

Checklist:
----------
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] [Review Contribution Guidelines](https://github.com/mavlink/qgroundcontrol/blob/master/.github/CONTRIBUTING.md).
- [x] [Review Code of Conduct](https://github.com/mavlink/qgroundcontrol/blob/master/.github/CODE_OF_CONDUCT.md).
- [x] I have tested my changes.



By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.