### PR TITLE
Fix LandingComplexItems hamburger menu options

### DIFF
--- a/src/MissionManager/FixedWingLandingComplexItem.cc
+++ b/src/MissionManager/FixedWingLandingComplexItem.cc
@@ -135,16 +135,6 @@ void FixedWingLandingComplexItem::_calcGlideSlope(void)
     _glideSlopeFact.setRawValue(qRadiansToDegrees(qAtan(landingAltDifference / landingDistance)));
 }
 
-void FixedWingLandingComplexItem::moveLandingPosition(const QGeoCoordinate& coordinate)
-{
-    double savedHeading = landingHeading()->rawValue().toDouble();
-    double savedDistance = landingDistance()->rawValue().toDouble();
-
-    setLandingCoordinate(coordinate);
-    landingHeading()->setRawValue(savedHeading);
-    landingDistance()->setRawValue(savedDistance);
-}
-
 bool FixedWingLandingComplexItem::_isValidLandItem(const MissionItem& missionItem)
 {
     if (missionItem.command() != MAV_CMD_NAV_LAND ||

--- a/src/MissionManager/FixedWingLandingComplexItem.h
+++ b/src/MissionManager/FixedWingLandingComplexItem.h
@@ -31,8 +31,6 @@ public:
     Q_PROPERTY(Fact*            valueSetIsDistance      READ    valueSetIsDistance                                          CONSTANT)
     Q_PROPERTY(Fact*            glideSlope              READ    glideSlope                                                  CONSTANT)
 
-    Q_INVOKABLE void moveLandingPosition(const QGeoCoordinate& coordinate); // Maintains the current landing distance and heading
-
     Fact*           glideSlope              (void) { return &_glideSlopeFact; }
     Fact*           valueSetIsDistance      (void) { return &_valueSetIsDistanceFact; }
 

--- a/src/MissionManager/LandingComplexItem.cc
+++ b/src/MissionManager/LandingComplexItem.cc
@@ -643,6 +643,19 @@ void LandingComplexItem::_setDirty(void)
     setDirty(true);
 }
 
+void LandingComplexItem::setCoordinate(const QGeoCoordinate& coordinate) {
+    if (!_landingCoordSet) {
+        setLandingCoordinate(coordinate);
+        return;
+    }
+
+    // Move entire complex item, preserving heading and distance
+    _ignoreRecalcSignals = true;
+    setLandingCoordinate(coordinate);
+    _ignoreRecalcSignals = false;
+    _recalcFromHeadingAndDistanceChange();
+}
+
 void LandingComplexItem::setSequenceNumber(int sequenceNumber)
 {
     if (_sequenceNumber != sequenceNumber) {

--- a/src/MissionManager/LandingComplexItem.h
+++ b/src/MissionManager/LandingComplexItem.h
@@ -110,7 +110,7 @@ public:
     ReadyForSaveState   readyForSaveState           (void) const final;
     bool                exitCoordinateSameAsEntry   (void) const final { return false; }
     void                setDirty                    (bool dirty) final;
-    void                setCoordinate               (const QGeoCoordinate& coordinate) final { setFinalApproachCoordinate(coordinate); }
+    void                setCoordinate               (const QGeoCoordinate& coordinate) final;
     void                setSequenceNumber           (int sequenceNumber) final;
     double              amslEntryAlt                (void) const final;
     double              amslExitAlt                 (void) const final;

--- a/src/QmlControls/FWLandingPatternMapVisual.qml
+++ b/src/QmlControls/FWLandingPatternMapVisual.qml
@@ -246,7 +246,7 @@ Item {
             itemCoordinate: _missionItem.landingCoordinate
             visible:        _root.interactive
 
-            onItemCoordinateChanged: _missionItem.moveLandingPosition(itemCoordinate)
+            onItemCoordinateChanged: _missionItem.coordinate = itemCoordinate
         }
     }
 


### PR DESCRIPTION
# Fix LandingComplexItems hamburger menu options

Description
-----------
Fixed an issue where the movement options in the MissionItemEditor's hamburger menu for both fixed wing and VTOL LandingComplexItems only moved the approach primitive instead of the entire complex item. This happened because LandingComplexItem::setCoordinate method only repositioned the approach item.

Modified LandingComplexItem::setCoordinate to take over the functionality previously handled by the fixed-wing-only moveLandingPosition method. The relevant logic has also been updated to avoid unnecessary recalculations.

Other movement behaviors have been verified to be correct and remain unchanged for both fixed wing and VTOL. In summary:
- FW landing patterns:
    - Drag land primitive on map: Moves entire pattern (no change)
    - Hamburger menu item movement options: Moves approach primitive only (before), moves entire pattern (after)
    - Landing point -> Set to vehicle location: Moves land primitive only (no change)
- VTOL landing patterns:
    - Drag land primitive on map: Moves land primitive only (no change)
    - Hamburger menu item movement options: Moves approach primitive only (before), moves entire pattern (after)
    - Landing point -> Set to vehicle location: Moves land primitive only (no change)

Checklist:
----------
- [X] [Review Contribution Guidelines](https://github.com/mavlink/qgroundcontrol/blob/master/.github/CONTRIBUTING.md).
- [X] [Review Code of Conduct](https://github.com/mavlink/qgroundcontrol/blob/master/.github/CODE_OF_CONDUCT.md).
- [X] I have tested my changes.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.