### PR TITLE
Fix SVG rendering by forcing Tiny12FeaturesOnly

### DIFF
--- a/src/QGCApplication.cc
+++ b/src/QGCApplication.cc
@@ -22,6 +22,7 @@
 #include <QtQuick/QQuickImageProvider>
 #include <QtQuick/QQuickWindow>
 #include <QtQuickControls2/QQuickStyle>
+#include <QtSvg/QSvgRenderer>
 
 #include <QtCore/private/qthread_p.h>
 
@@ -147,6 +148,9 @@ QGCApplication::QGCApplication(int &argc, char *argv[], const QGCCommandLinePars
 
     // We need to set language as early as possible prior to loading on JSON files.
     setLanguage();
+
+    // Force old SVG Tiny 1.2 behavior for compatibility
+    QSvgRenderer::setDefaultOptions(QtSvg::Tiny12FeaturesOnly);
 
 #ifndef QGC_DAILY_BUILD
     _checkForNewVersion();


### PR DESCRIPTION
# Fix SVG rendering by forcing Tiny12FeaturesOnly

Description
-----------
A recent Qt update introduced SVG rendering changes, breaking some icons (notably TrashDelete.svg, a garbage bin icon used in the MissionItemEditor that recently started rendering only its lid).

Fixed by forcing the SVG renderer into the previous Tiny 1.2 mode.

This should be reverted once the new renderer fixes these issues, or all affected SVGs are updated to cope with it.

Checklist:
----------
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [X] [Review Contribution Guidelines](https://github.com/mavlink/qgroundcontrol/blob/master/.github/CONTRIBUTING.md).
- [X] [Review Code of Conduct](https://github.com/mavlink/qgroundcontrol/blob/master/.github/CODE_OF_CONDUCT.md).
- [X] I have tested my changes.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.