### PR TITLE
Update Mavlink submodule to fix camera settings

### DIFF
--- a/cmake/CustomOptions.cmake
+++ b/cmake/CustomOptions.cmake
@@ -73,7 +73,7 @@ option(QGC_ENABLE_QT_VIDEOSTREAMING "Enable QtMultimedia video backend" OFF)
 # ============================================================================
 
 set(QGC_MAVLINK_GIT_REPO "https://github.com/mavlink/c_library_v2.git" CACHE STRING "MAVLink repository URL")
-set(QGC_MAVLINK_GIT_TAG "a9a10b52a6c87e54676fea22d2936c1b8b733f99" CACHE STRING "MAVLink repository commit/tag")
+set(QGC_MAVLINK_GIT_TAG "9b4f91bb02c1142edf01b14945b36b503be3075b" CACHE STRING "MAVLink repository commit/tag")
 
 # ============================================================================
 # Autopilot Plugin Configuration


### PR DESCRIPTION
Issue Overview
-----------
A few weeks ago, QGC updated its Mavlink git-hash, creating a bug with message encoding (this bug is not present in the 5.0.8 release, but is present in the daily build)

One way the issues manifests is that when I use QGC daily with a PX4 and an Airpixel TAG-E camera, the camera settings page shows "Unknown: 3" after I try changing the value of the TG_EXPMODE parameter
<img width="2962" height="1741" alt="bug1" src="https://github.com/user-attachments/assets/a0b75b7b-d644-4d49-9840-e7608ce6090d" />


This PR fixes the issue

Issue Further details
-----------
When debugging, I added the following temporary prints to `src/Camera/QGCCameraIO.cc`
<img width="2106" height="1311" alt="Screenshot from 2025-11-18 12-48-19" src="https://github.com/user-attachments/assets/f52ed537-ce2c-4d6d-8576-a27eceb48aab" />

This showed that there was a bug in the Mavlink library making so the `param_value` property was not correctly being encoded.
<img width="1758" height="486" alt="fix1" src="https://github.com/user-attachments/assets/114ccfe2-eece-4b71-9578-e246a59eec97" />



Behavior after fix
----------
After the fix made in this PR, the camera settings page successfully can successfully change the camera mode to "A"
<img width="2963" height="1728" alt="fix3" src="https://github.com/user-attachments/assets/ef135000-2659-4f6a-b8a7-f0bfd04adf8b" />

This is because updating the Mavlink git-hash makes so the encode function works properly
<img width="1654" height="349" alt="fix4" src="https://github.com/user-attachments/assets/b7e83c32-b87d-4d91-83c8-7152b5460842" />
