### PR TITLE
Make camera shoot/record button prettier

### DIFF
--- a/src/FlightMap/Widgets/PhotoVideoControl.qml
+++ b/src/FlightMap/Widgets/PhotoVideoControl.qml
@@ -199,8 +199,21 @@ Rectangle {
                     width:              ScreenTools.defaultFontPixelWidth * 6
                     height:             width
                     radius:             width * 0.5
-                    border.color:       qgcPal.buttonText
-                    border.width:       3
+                    border.color:       Qt.rgba(0,0,0,.2)
+                    border.width:       width * 0.1
+
+                    Rectangle {
+                        anchors {
+                            centerIn:           parent
+                            alignWhenCentered:  false
+                        }
+                        color:              Qt.rgba(0,0,0,0)
+                        width:              parent.width - 1
+                        height:             width
+                        radius:             width * 0.5
+                        border.color:       "white"
+                        border.width:       parent.border.width - 1
+                    }
 
                     Rectangle {
                         // anchors.centerIn snaps to integer coordinates, which
@@ -210,10 +223,12 @@ Rectangle {
                             centerIn:           parent
                             alignWhenCentered:  false
                         }
-                        width:              parent.width * (_isShootingInCurrentMode ? 0.5 : 0.75)
+                        width:              parent.width * (_isShootingInPhotoMode ? 0.6 : (_isShootingInVideoMode ? 0.4 : 0.75))
                         height:             width
-                        radius:             _isShootingInCurrentMode ? 0 : width * 0.5
-                        color:              _isShootingInCurrentMode || _canShootInCurrentMode ? qgcPal.colorRed : qgcPal.colorGrey
+                        radius:             _isShootingInVideoMode ? 0 : width * 0.5
+                        color:              _isShootingInCurrentMode || _canShootInCurrentMode ? (_cameraInVideoMode ? "#f32836" : "white") : qgcPal.colorGrey
+                        border.color:       Qt.rgba(0,0,0,.2)
+                        border.width:       .5
 
                         property bool _isShootingInPhotoMode:   _cameraInPhotoMode && _camera.photoCaptureStatus === MavlinkCameraControl.PHOTO_CAPTURE_IN_PROGRESS
                         property bool _isShootingInVideoMode:   (!_cameraInPhotoMode && _camera.videoCaptureStatus === MavlinkCameraControl.VIDEO_CAPTURE_STATUS_RUNNING)
@@ -245,7 +260,7 @@ Rectangle {
                 // Record time / Capture count
                 Rectangle {
                     Layout.alignment:       Qt.AlignHCenter
-                    color:                  _videoCaptureIdle && _photoCaptureIdle ? "transparent" : qgcPal.colorRed
+                    color:                  _videoCaptureIdle && _photoCaptureIdle ? "transparent" : "#f32836"
                     Layout.preferredWidth:  (_cameraInVideoMode ? videoRecordTime.width : photoCaptureCount.width) + (_smallMargins * 2)
                     Layout.preferredHeight: (_cameraInVideoMode ? videoRecordTime.height : photoCaptureCount.height)
                     radius:                 _smallMargins


### PR DESCRIPTION
What I didn't like
-----------
The photo capture button was red. I felt this was a bit misleading and it would be more intuitive if the trigger button was white in photo mode and only red when in video mode (this is the behavior of most camera apps). 

What I changed
----------------

I changed the coloring/shading of the capture button. I used the iPad camera app as a reference (example of what typical capture/record buttons look like)

| button type | iPad | QGC Old Outdoor | QGC Old Indoor | QGC New Outdoor | QGC New Indoor |
| :------ | :---: | -------------------: |--------------------|----------------------|--------------------|
| camera mode - not clicked   | <img width="261" height="557" alt="Screenshot from 2025-11-20 13-11-56" src="https://github.com/user-attachments/assets/512eb59e-f04d-48ec-8dc2-6b4e9e3f7636" />   |<img width="261" height="557" alt="Screenshot from 2025-11-20 13-49-55" src="https://github.com/user-attachments/assets/de38a2ef-0f98-4d44-bb26-539d28a40b22" /> | <img width="261" height="557" alt="Screenshot from 2025-11-20 12-52-37" src="https://github.com/user-attachments/assets/c6d12211-5363-4e7f-afa0-0ed4ac565f60" /> | <img width="261" height="557" alt="Screenshot from 2025-11-20 14-15-10" src="https://github.com/user-attachments/assets/ffa9fcd1-adf7-4488-8598-ba5e6840b6df" /> |<img width="261" height="557" alt="Screenshot from 2025-11-20 12-18-00" src="https://github.com/user-attachments/assets/e547a4e5-026f-4b74-ac63-5e5d579fbe89" />  |
| camera mode - clicked   | <img width="261" height="557" alt="Screenshot from 2025-11-20 13-11-43" src="https://github.com/user-attachments/assets/5c45f40d-aac2-470e-8b53-138ade32cd7f" />   | <img width="261" height="557" alt="Screenshot from 2025-11-20 13-51-10" src="https://github.com/user-attachments/assets/74ff192f-5083-4203-b299-b21dbc00590d" /> | <img width="261" height="557" alt="Screenshot from 2025-11-20 13-52-24" src="https://github.com/user-attachments/assets/82f42aa8-be1a-46da-9580-1d6490a07129" /> | <img width="261" height="557" alt="Screenshot from 2025-11-20 14-15-19" src="https://github.com/user-attachments/assets/e1e09660-f4fe-4812-98ef-1920a7c2929d" />  | <img width="261" height="557" alt="Screenshot from 2025-11-20 14-33-22" src="https://github.com/user-attachments/assets/4b0db33e-9843-4272-b878-b453b16770d9" /> |
| video mode - not clicked   | <img width="261" height="557" alt="Screenshot from 2025-11-20 13-11-47" src="https://github.com/user-attachments/assets/9c69d4cb-7e4d-4e27-aefc-6b804cda9d28" />   | <img width="261" height="557" alt="Screenshot from 2025-11-20 12-53-51" src="https://github.com/user-attachments/assets/c04e2d79-f14a-4a26-89f4-2cfaf58668a3" /> | <img width="261" height="557" alt="Screenshot from 2025-11-20 13-53-57" src="https://github.com/user-attachments/assets/3c54db99-e57a-473e-b53c-e71400ce5701" /> |<img width="261" height="557" alt="Screenshot from 2025-11-20 14-10-00" src="https://github.com/user-attachments/assets/40aae149-ce1b-4723-a6fe-239aee4f3a5c" />|<img width="261" height="557" alt="Screenshot from 2025-11-20 12-18-16" src="https://github.com/user-attachments/assets/ec38c647-032d-4697-a8b5-716138b4cb3c" />  |
| video mode - clicked     | <img width="261" height="557" alt="Screenshot from 2025-11-20 13-11-50" src="https://github.com/user-attachments/assets/787dc604-8c5b-4c31-9290-a7d9dc5ee7eb" /> | <img width="261" height="557" alt="Screenshot from 2025-11-20 12-54-03" src="https://github.com/user-attachments/assets/6cd292d4-bead-4390-aaff-05337aca0ed1" /> |<img width="261" height="557" alt="Screenshot from 2025-11-20 12-52-26" src="https://github.com/user-attachments/assets/492f4698-83c2-4180-9957-8200b9f97af7" />  | <img width="261" height="557" alt="Screenshot from 2025-11-20 14-10-08" src="https://github.com/user-attachments/assets/6cd828e7-8be9-46a0-962e-4e2fcb41d08c" />|<img width="261" height="557" alt="Screenshot from 2025-11-20 14-13-37" src="https://github.com/user-attachments/assets/20af9947-a00f-4e6a-a950-aee97cb03357" />


