### PR TITLE
Add NXP MR-Tropic board ID

### DIFF
--- a/src/Vehicle/VehicleSetup/FirmwareUpgradeController.cc
+++ b/src/Vehicle/VehicleSetup/FirmwareUpgradeController.cc
@@ -68,6 +68,7 @@ static QMap<int, QString> px4_board_name_map {
     {28, "nxp_fmuk66-v3_default"},
     {30, "nxp_fmuk66-e_default"},
     {31, "nxp_fmurt1062-v1_default"},
+    {37, "nxp_mr-tropic_default"},
     {85, "freefly_can-rtk-gps_default"},
     {120, "cubepilot_cubeyellow_default"},
     {136, "mro_x21-777_default"},


### PR DESCRIPTION
Adds mapping to download firmware from server to flash using the px4 bootloader.

Test Steps
-----------
tested on NXP MR-VMU-Tropic hardware, using firmware upgrade tab.
