### PR TITLE
Make capture button visuals be more like current phone controls

### DIFF
--- a/src/FlightMap/Widgets/PhotoVideoControl.qml
+++ b/src/FlightMap/Widgets/PhotoVideoControl.qml
@@ -35,6 +35,7 @@ Rectangle {
     property bool   _photoCaptureSingleIdle:    _camera.photoCaptureStatus === MavlinkCameraControl.PHOTO_CAPTURE_IDLE
     property bool   _photoCaptureIntervalIdle:  _camera.photoCaptureStatus === MavlinkCameraControl.PHOTO_CAPTURE_INTERVAL_IDLE
     property bool   _photoCaptureIdle:          _photoCaptureSingleIdle || _photoCaptureIntervalIdle
+    property color  _captureButtonColor:       _cameraInPhotoMode ? qgcPal.photoCaptureButtonColor : qgcPal.videoCaptureButtonColor
 
 /*
     // Used for testing camera ui options. Set _camera to testCamera to use.
@@ -74,6 +75,25 @@ Rectangle {
             videoCaptureStatus = MavlinkCameraControl.VIDEO_CAPTURE_STATUS_STOPPED;
             photoCaptureStatus = MavlinkCameraControl.PHOTO_CAPTURE_IDLE;
         }
+
+        function takePhoto() {
+            photoCaptureStatus = MavlinkCameraControl.PHOTO_CAPTURE_IN_PROGRESS;
+            takePhotoTimer.start();
+        }
+
+        function toggleVideoRecording() {
+            if (videoCaptureStatus === MavlinkCameraControl.VIDEO_CAPTURE_STATUS_RUNNING) {
+                videoCaptureStatus = MavlinkCameraControl.VIDEO_CAPTURE_STATUS_STOPPED;
+            } else {
+                videoCaptureStatus = MavlinkCameraControl.VIDEO_CAPTURE_STATUS_RUNNING;
+            }
+        }
+    }
+
+    Timer {
+        id:             takePhotoTimer
+        interval:       500
+        onTriggered:    testCamera.photoCaptureStatus = MavlinkCameraControl.PHOTO_CAPTURE_IDLE
     }
 */
 
@@ -195,25 +215,31 @@ Rectangle {
                 // Take Photo, Start/Stop Video button
                 Rectangle {
                     Layout.alignment:   Qt.AlignHCenter
-                    color:              Qt.rgba(0,0,0,0)
+                    color:              qgcPal.button
                     width:              ScreenTools.defaultFontPixelWidth * 6
                     height:             width
                     radius:             width * 0.5
-                    border.color:       qgcPal.buttonText
-                    border.width:       3
+                    border.width:       1
+                    border.color:       qgcPal.buttonBorder
+
+                   Rectangle {
+                        anchors.centerIn:           parent
+                        anchors.alignWhenCentered:  false // Prevents anchors.centerIn from snapping to integer coordinates, which can throw off centering.
+                        color:                      qgcPal.buttonBorder
+                        width:                      parent.width * 0.75
+                        height:                     width
+                        radius:                     width * 0.5
+                    }
 
                     Rectangle {
-                        // anchors.centerIn snaps to integer coordinates, which
-                        // depending on DPI can throw the centering off.
-                        // Setting alignWhenCentered to false avoids this issue.
-                        anchors {
-                            centerIn:           parent
-                            alignWhenCentered:  false
-                        }
-                        width:              parent.width * (_isShootingInCurrentMode ? 0.5 : 0.75)
-                        height:             width
-                        radius:             _isShootingInCurrentMode ? 0 : width * 0.5
-                        color:              _isShootingInCurrentMode || _canShootInCurrentMode ? qgcPal.colorRed : qgcPal.colorGrey
+                        anchors.centerIn:           parent
+                        anchors.alignWhenCentered:  false // Prevents anchors.centerIn from snapping to integer coordinates, which can throw off centering.
+                        width:                      parent.width * (_isShootingInCurrentMode ? 0.5 : 0.75)
+                        height:                     width
+                        radius:                     _isShootingInCurrentMode ? ScreenTools.defaultFontPixelWidth * 0.5 : width * 0.5
+                        color:                      _captureButtonColor
+                        border.width:               1
+                        border.color:               qgcPal.buttonBorder
 
                         property bool _isShootingInPhotoMode:   _cameraInPhotoMode && _camera.photoCaptureStatus === MavlinkCameraControl.PHOTO_CAPTURE_IN_PROGRESS
                         property bool _isShootingInVideoMode:   (!_cameraInPhotoMode && _camera.videoCaptureStatus === MavlinkCameraControl.VIDEO_CAPTURE_STATUS_RUNNING)
@@ -245,7 +271,7 @@ Rectangle {
                 // Record time / Capture count
                 Rectangle {
                     Layout.alignment:       Qt.AlignHCenter
-                    color:                  _videoCaptureIdle && _photoCaptureIdle ? "transparent" : qgcPal.colorRed
+                    color:                  _videoCaptureIdle && _photoCaptureIdle ? "transparent" : _captureButtonColor
                     Layout.preferredWidth:  (_cameraInVideoMode ? videoRecordTime.width : photoCaptureCount.width) + (_smallMargins * 2)
                     Layout.preferredHeight: (_cameraInVideoMode ? videoRecordTime.height : photoCaptureCount.height)
                     radius:                 _smallMargins

--- a/src/QmlControls/QGCPalette.cc
+++ b/src/QmlControls/QGCPalette.cc
@@ -89,10 +89,12 @@ void QGCPalette::_buildMap()
     DECLARE_QGC_COLOR(groupBorder,          "#bbbbbb", "#bbbbbb", "#707070", "#707070")
 
     // Colors not affecting by theming
-    //                                              Disabled    Enabled
-    DECLARE_QGC_NONTHEMED_COLOR(brandingPurple,     "#4A2C6D", "#4A2C6D")
-    DECLARE_QGC_NONTHEMED_COLOR(brandingBlue,       "#48D6FF", "#6045c5")
-    DECLARE_QGC_NONTHEMED_COLOR(toolStripFGColor,   "#707070", "#ffffff")
+    //                                                      Disabled     Enabled
+    DECLARE_QGC_NONTHEMED_COLOR(brandingPurple,             "#4A2C6D", "#4A2C6D")
+    DECLARE_QGC_NONTHEMED_COLOR(brandingBlue,               "#48D6FF", "#6045c5")
+    DECLARE_QGC_NONTHEMED_COLOR(toolStripFGColor,           "#707070", "#ffffff")
+    DECLARE_QGC_NONTHEMED_COLOR(photoCaptureButtonColor,    "#ffffff", "#ffffff")
+    DECLARE_QGC_NONTHEMED_COLOR(videoCaptureButtonColor,    "#f32836", "#f32836")
 
     // Colors not affecting by theming or enable/disable
     DECLARE_QGC_SINGLE_COLOR(mapWidgetBorderLight,          "#ffffff")

--- a/src/QmlControls/QGCPalette.h
+++ b/src/QmlControls/QGCPalette.h
@@ -160,6 +160,8 @@ public:
     DEFINE_QGC_COLOR(toolStripFGColor,              setToolStripFGColor)
     DEFINE_QGC_COLOR(toolStripHoverColor,           setToolStripHoverColor)
     DEFINE_QGC_COLOR(groupBorder,                   setGroupBorder)
+    DEFINE_QGC_COLOR(photoCaptureButtonColor,       setPhotoCaptureButtonColor)
+    DEFINE_QGC_COLOR(videoCaptureButtonColor,       setVideoCaptureButtonColor)
 
 #ifdef QGC_UTM_ADAPTER
     DEFINE_QGC_COLOR(switchUTMSP,                    setSwitchUTMSP)


### PR DESCRIPTION
* Added capture button palette colors
* Photo uses white coloring by default
* Video uses red coloring by default

Based on #13659