### PR TITLE
Use new name for ArduPlane RTL altitude in all Safety components

### DIFF
--- a/src/AutoPilotPlugins/APM/APMSafetyComponent.qml
+++ b/src/AutoPilotPlugins/APM/APMSafetyComponent.qml
@@ -661,13 +661,7 @@ SetupPage {
                 Column {
                     spacing: _margins / 2
 
-                    property Fact _rtlAltFact: {
-                        if (controller.firmwareMajorVersion < 4 || (controller.firmwareMajorVersion === 4 && controller.firmwareMinorVersion < 5)) {
-                            return controller.getParameterFact(-1, "ALT_HOLD_RTL")
-                        } else {
-                            return controller.getParameterFact(-1, "RTL_ALTITUDE")
-                        }
-                    }
+                    property Fact _rtlAltFact: controller.getParameterFact(-1, "r.RTL_ALTITUDE")
 
                     QGCLabel {
                         text:           qsTr("Return to Launch")

--- a/src/AutoPilotPlugins/APM/APMSafetyComponentPlane.qml
+++ b/src/AutoPilotPlugins/APM/APMSafetyComponentPlane.qml
@@ -39,14 +39,7 @@ SetupPage {
             property Fact _failsafeThrEnable:   controller.getParameterFact(-1, "THR_FAILSAFE")
             property Fact _failsafeThrValue:    controller.getParameterFact(-1, "THR_FS_VALUE")
             property Fact _failsafeGCSEnable:   controller.getParameterFact(-1, "FS_GCS_ENABL")
-
-            property Fact _rtlAltFact: {
-                if (controller.firmwareMajorVersion < 4 || (controller.firmwareMajorVersion === 4 && controller.firmwareMinorVersion < 5)) {
-                    return controller.getParameterFact(-1, "ALT_HOLD_RTL")
-                } else {
-                    return controller.getParameterFact(-1, "RTL_ALTITUDE")
-                }
-            }
+            property Fact _rtlAltFact:          controller.getParameterFact(-1, "r.RTL_ALTITUDE")
 
             property real _margins: ScreenTools.defaultFontPixelHeight
 

--- a/src/AutoPilotPlugins/APM/APMSafetyComponentSummary.qml
+++ b/src/AutoPilotPlugins/APM/APMSafetyComponentSummary.qml
@@ -147,7 +147,7 @@ Item {
             valueText:  fact ? (fact.value < 0 ? qsTr("current") : fact.valueString + " " + fact.units) : ""
             visible:    controller.vehicle.fixedWing
 
-            property Fact fact: controller.getParameterFact(-1, "ALT_HOLD_RTL", false /* reportMissing */)
+            property Fact fact: controller.getParameterFact(-1, "r.RTL_ALTITUDE", false /* reportMissing */)
         }
     }
 }

--- a/src/AutoPilotPlugins/APM/APMSafetyComponentSummaryPlane.qml
+++ b/src/AutoPilotPlugins/APM/APMSafetyComponentSummaryPlane.qml
@@ -18,14 +18,7 @@ Item {
     property Fact _failsafeThrEnable:   controller.getParameterFact(-1, "THR_FAILSAFE")
     property Fact _failsafeThrValue:    controller.getParameterFact(-1, "THR_FS_VALUE")
     property Fact _failsafeGCSEnable:   controller.getParameterFact(-1, "FS_GCS_ENABL")
-
-    property Fact _rtlAltFact: {
-        if (controller.firmwareMajorVersion < 4 || (controller.firmwareMajorVersion === 4 && controller.firmwareMinorVersion < 5)) {
-            return controller.getParameterFact(-1, "ALT_HOLD_RTL")
-        } else {
-            return controller.getParameterFact(-1, "RTL_ALTITUDE")
-        }
-    }
+    property Fact _rtlAltFact:          controller.getParameterFact(-1, "r.RTL_ALTITUDE")
 
     Column {
         anchors.fill:       parent

--- a/src/FirmwarePlugin/APM/ArduPlaneFirmwarePlugin.cc
+++ b/src/FirmwarePlugin/APM/ArduPlaneFirmwarePlugin.cc
@@ -82,6 +82,8 @@ ArduPlaneFirmwarePlugin::ArduPlaneFirmwarePlugin(QObject *parent)
 
         remapV4_5["AIRSPEED_MIN"] = QStringLiteral("ARSPD_FBW_MIN");
         remapV4_5["AIRSPEED_MAX"] = QStringLiteral("ARSPD_FBW_MAX");
+        remapV4_5["RTL_ALTITUDE"] = QStringLiteral("ALT_HOLD_RTL");
+        // LAND_SPEED is only used in a Copter component
 
         _remapParamNameIntialized = true;
     }


### PR DESCRIPTION
Description
-----------
Use the correct RTL_ALTITUDE parameter for ArduPlane > 4.5.

Reuses logic introduced to other QML files referencing ALT_HOLD_RTL.
It was originally done in 2db72853b3 PR #12195, but this file wasn't changed then.

Test Steps
-----------
1. Connect ArduPlane 4.6 or newer
2. Open *QGC logo* -> Vehicle Configuration -> Safety
3. Set "Return at specified altitude:" to some positive value
4. Open Summary tab
5. Check the value in "RTL min alt:" row - should be the same as set in step 3, but is missing without this fix

Checklist:
----------
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] [Review Contribution Guidelines](https://github.com/mavlink/qgroundcontrol/blob/master/.github/CONTRIBUTING.md).
- [x] [Review Code of Conduct](https://github.com/mavlink/qgroundcontrol/blob/master/.github/CODE_OF_CONDUCT.md).
- [x] I have tested my changes.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

*Contribution on behalf of @FlyfocusUAV*
