### PR TITLE
[WIP] Two video streams

### DIFF
--- a/src/FlightDisplay/FlightDisplayViewVideo.qml
+++ b/src/FlightDisplay/FlightDisplayViewVideo.qml
@@ -85,7 +85,7 @@ Item {
         visible:        QGroundControl.videoManager.decoding
         function getWidth() {
             if(_ar != 0.0){
-                if(_isMode_FIT_HEIGHT 
+                if(_isMode_FIT_HEIGHT
                         || (_isMode_FILL && (root.width/root.height < _ar))
                         || (_isMode_NO_CROP && (root.width/root.height > _ar))){
                     // This return value has different implications depending on the mode
@@ -100,8 +100,8 @@ Item {
         }
         function getHeight() {
             if(_ar != 0.0){
-                if(_isMode_FIT_WIDTH 
-                        || (_isMode_FILL && (root.width/root.height > _ar)) 
+                if(_isMode_FIT_WIDTH
+                        || (_isMode_FILL && (root.width/root.height > _ar))
                         || (_isMode_NO_CROP && (root.width/root.height < _ar))){
                     // This return value has different implications depending on the mode
                     // For FIT_WIDTH and FILL
@@ -287,7 +287,7 @@ Item {
                     } else {
                         switchStreamMenuItem.text = qsTr("Switch to primary video stream")
                     }
-                }   
+                }
             }
         }
         //-- Zoom

--- a/src/Settings/Video.SettingsGroup.json
+++ b/src/Settings/Video.SettingsGroup.json
@@ -25,6 +25,34 @@
     "default":     ""
 },
 {
+    "name": "rtspUrlBackup",
+    "shortDesc": "Backup Video RTSP Url",
+    "longDesc": "Backup RTSP url address and port to bind to for video stream. Example: rtsp://192.168.42.1:554/live",
+    "type": "string",
+    "default": ""
+},
+{
+    "name":             "rtspUseAux",
+    "shortDesc": "Enable auxiliary video streams",
+    "longDesc":  "Enable auxiliary RTSP video streams and add possibility to switch between primary and aux ones",
+    "type":             "bool",
+    "default":     false
+},
+{
+    "name":             "rtspUrlAux",
+    "shortDesc": "Video RTSP Url Aux",
+    "longDesc":  "Additional RTSP url address and port to bind to for video stream. Example: rtsp://192.168.42.1:554/live",
+    "type":             "string",
+    "default":     ""
+},
+{
+    "name":             "rtspUrlBackupAux",
+    "shortDesc": "Backup Video RTSP Url Aux",
+    "longDesc":  "Additional backup RTSP url address and port to bind to for video stream. Example: rtsp://192.168.42.1:554/live",
+    "type":             "string",
+    "default":     ""
+},
+{
     "name":             "tcpUrl",
     "shortDesc": "Video TCP Url",
     "longDesc":  "TCP url address and port to bind to for video stream. Example: 192.168.143.200:3001",

--- a/src/Settings/VideoSettings.h
+++ b/src/Settings/VideoSettings.h
@@ -26,6 +26,10 @@ public:
     DEFINE_SETTINGFACT(udpUrl)
     DEFINE_SETTINGFACT(tcpUrl)
     DEFINE_SETTINGFACT(rtspUrl)
+    DEFINE_SETTINGFACT(rtspUrlBackup)
+    DEFINE_SETTINGFACT(rtspUseAux)
+    DEFINE_SETTINGFACT(rtspUrlAux)
+    DEFINE_SETTINGFACT(rtspUrlBackupAux)
     DEFINE_SETTINGFACT(aspectRatio)
     DEFINE_SETTINGFACT(videoFit)
     DEFINE_SETTINGFACT(gridLines)
@@ -48,6 +52,7 @@ public:
     Q_PROPERTY(QString  disabledVideoSource     READ disabledVideoSource    CONSTANT)
 
     bool     streamConfigured       ();
+    bool     auxStreamConfigured    ();
     QString  rtspVideoSource        () { return videoSourceRTSP; }
     QString  udp264VideoSource      () { return videoSourceUDPH264; }
     QString  udp265VideoSource      () { return videoSourceUDPH265; }
@@ -69,14 +74,17 @@ public:
     static constexpr const char* videoSourceHerelinkHotspot   = QT_TRANSLATE_NOOP("VideoSettings", "Herelink Hotspot");
 
 signals:
-    void streamConfiguredChanged    (bool configured);
+    void streamConfiguredChanged(bool configured);
+    void auxStreamConfiguredChanged(bool configured);
 
 private slots:
-    void _configChanged             (QVariant value);
+    void _configChanged(QVariant value);
+    void _auxConfigChanged(QVariant value);
 
 private:
     void _setDefaults               ();
     void _setForceVideoDecodeList();
+    static bool _isConfigured(const Fact* parameter);
 
 private:
     bool _noVideo = false;

--- a/src/UI/AppSettings/VideoSettings.qml
+++ b/src/UI/AppSettings/VideoSettings.qml
@@ -65,6 +65,38 @@ SettingsPage {
 
         LabelledFactTextField {
             Layout.fillWidth:           true
+            textFieldPreferredWidth:    _urlFieldWidth
+            label:                      qsTr("RTSP URL Backup")
+            fact:                       _videoSettings.rtspUrlBackup
+            visible:                    _isRTSP && _videoSettings.rtspUrlBackup.visible
+        }
+
+        FactCheckBoxSlider {
+            id:         auxStreamCheckBox
+            Layout.fillWidth: true
+            text:       fact.shortDescription
+            fact:       _videoSettings.rtspUseAux
+            visible:    fact.visible
+        }
+
+        LabelledFactTextField {
+            Layout.fillWidth:           true
+            textFieldPreferredWidth:    _urlFieldWidth
+            label:                      qsTr("Aux RTSP URL")
+            fact:                       _videoSettings.rtspUrlAux
+            visible:                    _isRTSP && _videoSettings.rtspUrlAux.visible && auxStreamCheckBox.checked
+        }
+
+        LabelledFactTextField {
+            Layout.fillWidth:           true
+            textFieldPreferredWidth:    _urlFieldWidth
+            label:                      qsTr("Aux RTSP URL Backup")
+            fact:                       _videoSettings.rtspUrlBackupAux
+            visible:                    _isRTSP && _videoSettings.rtspUrlBackupAux.visible && auxStreamCheckBox.checked
+        }
+
+        LabelledFactTextField {
+            Layout.fillWidth:           true
             label:                      qsTr("TCP URL")
             textFieldPreferredWidth:    _urlFieldWidth
             fact:                       _videoSettings.tcpUrl

--- a/src/VideoManager/VideoManager.h
+++ b/src/VideoManager/VideoManager.h
@@ -37,6 +37,9 @@ class VideoManager : public QObject
     Q_PROPERTY(bool     autoStreamConfigured    READ autoStreamConfigured                       NOTIFY autoStreamConfiguredChanged)
     Q_PROPERTY(bool     decoding                READ decoding                                   NOTIFY decodingChanged)
     Q_PROPERTY(bool     fullScreen              READ fullScreen             WRITE setfullScreen NOTIFY fullScreenChanged)
+    Q_PROPERTY(bool     hasBackup               READ hasBackup                                  NOTIFY hasVideoChanged)
+    Q_PROPERTY(bool     isPrimaryStream         READ isPrimaryStream            WRITE setStream NOTIFY videoStreamChanged)
+    Q_PROPERTY(bool     hasAuxStream            READ hasAuxStream                               NOTIFY hasAuxStreamChanged)
     Q_PROPERTY(bool     hasThermal              READ hasThermal                                 NOTIFY decodingChanged)
     Q_PROPERTY(bool     hasVideo                READ hasVideo                                   NOTIFY hasVideoChanged)
     Q_PROPERTY(bool     isStreamSource          READ isStreamSource                             NOTIFY isStreamSourceChanged)
@@ -70,6 +73,9 @@ public:
     bool autoStreamConfigured() const;
     bool decoding() const { return _decoding; }
     bool fullScreen() const { return _fullScreen; }
+    bool isPrimaryStream() const;
+    bool hasAuxStream() const;
+    bool hasBackup() const;
     bool hasThermal() const;
     bool hasVideo() const;
     bool isStreamSource() const;
@@ -84,6 +90,7 @@ public:
     QString imageFile() const { return _imageFile; }
     QString uvcVideoSourceID() const { return _uvcVideoSourceID; }
     void setfullScreen(bool on);
+    void setStream(bool primary);
     static bool gstreamerEnabled();
     static bool qtmultimediaEnabled();
     static bool uvcEnabled();
@@ -103,11 +110,14 @@ signals:
     void streamingChanged();
     void uvcVideoSourceIDChanged();
     void videoSizeChanged();
+    void videoStreamChanged();
+    void hasAuxStreamChanged();
 
 private slots:
     void _communicationLostChanged(bool communicationLost);
     void _setActiveVehicle(Vehicle *vehicle);
     void _videoSourceChanged();
+    void _enableAuxStream(bool enable);
 
 private:
     void _initAfterQmlIsReady();
@@ -121,6 +131,7 @@ private:
     void _startReceiver(VideoReceiver *receiver);
     void _stopReceiver(VideoReceiver *receiver);
     static void _cleanupOldVideos();
+    QString _getRtspUrlForReceiver(VideoReceiver *receiver) const;
 
     QList<VideoReceiver*> _videoReceivers;
 
@@ -130,6 +141,8 @@ private:
     bool _initialized = false;
     bool _initAfterQmlIsReadyDone = false;
     bool _fullScreen = false;
+    bool _usesPrimaryVideoStream = true;
+    bool _hasAuxStreamConfigured = false;
     QAtomicInteger<bool> _decoding = false;
     QAtomicInteger<bool> _recording = false;
     QAtomicInteger<bool> _streaming = false;

--- a/src/VideoManager/VideoReceiver/VideoReceiver.h
+++ b/src/VideoManager/VideoReceiver/VideoReceiver.h
@@ -27,6 +27,8 @@ public:
         : QObject(parent)
     {}
 
+    bool isPrimary() const { return (_name == QStringLiteral("videoContent")); }
+    bool isBackup() const { return (_name == QStringLiteral("backupVideo")); }
     bool isThermal() const { return (_name == QStringLiteral("thermalVideo")); }
 
     void *sink() { return _sink; }


### PR DESCRIPTION
[WIP] Two video streams

Description
-----------
You can treat this as a lite alternative to the https://github.com/mavlink/qgroundcontrol/pull/8017 .
To be honest, I don't really know QML, and this is just a small attempt to add the support of 2 video streams to QGC.
Here is what it does:
- it assumes there are 2 cameras, and each of these cameras has an HQ and a LQ videostream;
- an "Enable auxiliary video streams" checkbox has been added to QGC's Video Settings;
- once the "Enable auxiliary video streams" checkbox, you can specify the Cam 1 HQ, Cam 2 LQ, Cam 2 HQ and Cam 1 LQ streams there.

This is work-in-progress and demonstrates the current state. Any hints and contributions are welcome.

Test Steps
-----------
1. Start mediamtx: `./mediamtx`
2. Start video stream 1: `ffmpeg -re -stream_loop -1 -i anim1.mp4 -c copy -f rtsp rtsp://127.0.0.1:8554/stream1`
3. Start video stream 2: `ffmpeg -re -stream_loop -1 -i anim2.mp4 -c copy -f rtsp rtsp://127.0.0.1:8554/stream2`
4. Start QGC and specify the given streams in the Video Settings
5. In QGC's window, right-click the small video and select "Switch to auxiliary video stream"

And here is the problem: currently, the switching between the video streams is very "heavy". This is how the video receivers seem to work. Maybe this can be improved by updating the GStreamer-related code, but I don't have such expertise.

Related Issue
-----------
https://github.com/mavlink/qgroundcontrol/pull/8017


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
