### PR TITLE
Fix directory name for clarity in fork instructions

### DIFF
--- a/docs/en/qgc-dev-guide/custom_build/fork_repo.md
+++ b/docs/en/qgc-dev-guide/custom_build/fork_repo.md
@@ -4,7 +4,7 @@
 * Copy the `custom_example` directory to a new `custom` directory at the root of the repo.
 * Tweak the source in `custom` directory as needed.
 
-You can also rename the `custom_example` directory to `custom` but that can lead to merge problems when you bring your fork up to date with newer upstream version of regular QGC.
+You can also rename the `custom-example` directory to `custom` but that can lead to merge problems when you bring your fork up to date with newer upstream version of regular QGC.
 
 
 ## Modifying Mainline QGC Source Code


### PR DESCRIPTION
Description
-----------
Corrected the directory name from 'custom_example' to 'custom-example' for clarity on potential merge issues.
