### PR TITLE
Revert "Use QQuaternion instead of mavlink_quaternion_to_euler"

### DIFF
--- a/src/Gimbal/GimbalController.cc
+++ b/src/Gimbal/GimbalController.cc
@@ -16,8 +16,6 @@
 #include "SettingsManager.h"
 #include "Vehicle.h"
 
-#include <QtGui/QQuaternion>
-
 QGC_LOGGING_CATEGORY(GimbalControllerLog, "Gimbal.GimbalController")
 
 GimbalController::GimbalController(Vehicle *vehicle)
@@ -236,25 +234,15 @@ void GimbalController::_handleGimbalDeviceAttitudeStatus(const mavlink_message_t
     gimbal->setYawLock((attitude_status.flags & GIMBAL_DEVICE_FLAGS_YAW_LOCK) > 0);
     gimbal->_neutral = (attitude_status.flags & GIMBAL_DEVICE_FLAGS_NEUTRAL) > 0;
 
-    // Convert from QQuaternion to Euler angles. We specifically don't use mavlink_quaternion_to euler
-    // because that seems to spew NaNs for boundary conditions. Whereas QQuaternion seems to handle things
-    // more cleanly.
-    QQuaternion q(
-        attitude_status.q[0],
-        attitude_status.q[1],
-        attitude_status.q[2],
-        attitude_status.q[3]);
-    auto vector3D = q.toEulerAngles();
-    float roll = vector3D.z();
-    float pitch = vector3D.y();
-    float yaw = vector3D.x();
+    float roll, pitch, yaw;
+    mavlink_quaternion_to_euler(attitude_status.q, &roll, &pitch, &yaw);
 
-    gimbal->setAbsoluteRoll(roll);
-    gimbal->setAbsolutePitch(pitch);
+    gimbal->setAbsoluteRoll(qRadiansToDegrees(roll));
+    gimbal->setAbsolutePitch(qRadiansToDegrees(pitch));
 
     const bool yaw_in_vehicle_frame = _yawInVehicleFrame(attitude_status.flags);
     if (yaw_in_vehicle_frame) {
-        const float bodyYaw = yaw;
+        const float bodyYaw = qRadiansToDegrees(yaw);
         float absoluteYaw = bodyYaw + _vehicle->heading()->rawValue().toFloat();
         if (absoluteYaw > 180.0f) {
             absoluteYaw -= 360.0f;
@@ -264,7 +252,7 @@ void GimbalController::_handleGimbalDeviceAttitudeStatus(const mavlink_message_t
         gimbal->setAbsoluteYaw(absoluteYaw);
 
     } else {
-        const float absoluteYaw = yaw;
+        const float absoluteYaw = qRadiansToDegrees(yaw);
         float bodyYaw = absoluteYaw - _vehicle->heading()->rawValue().toFloat();
         if (bodyYaw < -180.0f) {
             bodyYaw += 360.0f;


### PR DESCRIPTION
## Issue
The recent change to use `QQuaternion` instead of `mavlink_quaternion_to_euler` introduced an error;  gimbal yaw is no longer correctly decoded.

## Proof of Issue
I don't understand the difference between `mavlink_quaternion_to_euler` and `QQuaternion::toEulerAngles()` , but I ran some tests which show that they cannot be interchanged the way they were. Here is the test that I ran.
``` cpp
// here is a sample set of euler roll,pitch/yaw values we'll convert to a quaternion and then back to euler
float origRollDeg = 0.0f;
float origPitchDeg = 30.0f;
float origYawDeg = 45.0f;
qCritical() << "Original Euler angles - roll: " << origRollDeg
            << " pitch: " << origPitchDeg
            << " yaw: " << origYawDeg;

// convert euler roll,pitch,yaw to quaternion using MAVLink's method
float q[4];
mavlink_euler_to_quaternion(
        qDegreesToRadians(origRollDeg),
        qDegreesToRadians(origPitchDeg),
        qDegreesToRadians(origYawDeg),
        q);
qCritical() << "MAVLink encode result - q[0]: " << q[0]<< " q[1]: " << q[1] << " q[2]: " << q[2] << " q[3]: " << q[3];

// convert quaternion back to Euler angles using MAVLink's method: result is correct/expected
float mavlinkRollRad, mavlinkPitchRad, mavlinkYawRad;
mavlink_quaternion_to_euler(q, &mavlinkRollRad, &mavlinkPitchRad, &mavlinkYawRad);
qCritical() << "MAVLink decode result - roll: " << qRadiansToDegrees(mavlinkRollRad)
            << " pitch: " << qRadiansToDegrees(mavlinkPitchRad)
            << " yaw: " << qRadiansToDegrees(mavlinkYawRad);

// convert quaternion back to Euler angles using QQuaternion: result is incorrect/unexpected
QQuaternion qq(
    q[0],
    q[1],
    q[2],
    q[3]);
auto vector3D = qq.toEulerAngles();
float qqRollDeg = vector3D.z();
float qqPitchDeg = vector3D.y();
float qqYawDeg = vector3D.x();
qCritical() << "QQuaternion decode result - roll: " << qqRollDeg
            << " pitch: " << qqPitchDeg
            << " yaw: " << qqYawDeg;
```

The output is the following
```
Original Euler angles - roll:  0  pitch:  30  yaw:  45
MAVLink encode result - q[0]:  0.892399  q[1]:  -0.0990458  q[2]:  0.239118  q[3]:  0.369644
MAVLink decode result - roll:  -2.48753e-07  pitch:  30  yaw:  45
QQuaternion decode result - roll:  40.8934  pitch:  22.2077  yaw:  -20.7048
```

@DonLakeFlyer , you were the one who made the recent change to use `QQuaternion`. I suspect it looked fine in your testing because you likely were testing cases where yaw was 0. If I run the same test as above, only chage `origYawDeg` to be 0, I get the following output:
```
Original Euler angles - roll:  0  pitch:  30  yaw:  0
MAVLink encode result - q[0]:  0.965926  q[1]:  0  q[2]:  0.258819  q[3]:  0
MAVLink decode result - roll:  0  pitch:  30  yaw:  0
QQuaternion decode result - roll:  0  pitch:  30  yaw:  0
```