### PR TITLE
Use number dashes for invalid value placeholders

### DIFF
--- a/src/FactSystem/Fact.cc
+++ b/src/FactSystem/Fact.cc
@@ -386,14 +386,14 @@ QString Fact::invalidValueString(int decimalPlaces) const {
     case FactMetaData::valueTypeFloat:
     case FactMetaData::valueTypeDouble:
         if (decimalPlaces <= 0) {
-            return QStringLiteral("--");
+            return QStringLiteral("–");
         }
-        return QStringLiteral("--.") +
-               QString(decimalPlaces, QLatin1Char('-'));
+        return QStringLiteral("–.") +
+               QString(decimalPlaces, QChar(u'–'));
     case FactMetaData::valueTypeElapsedTimeInSeconds:
-        return QStringLiteral("--:--:--");
+        return QStringLiteral("––:––:––");
     default:
-        return QStringLiteral("--");
+        return QStringLiteral("–");
     }
 }
 

--- a/src/FlyView/ProximityRadarValues.qml
+++ b/src/FlyView/ProximityRadarValues.qml
@@ -40,7 +40,7 @@ QtObject {
     property var    rgRotationValueStrings:     [ rotationNoneValueString, rotationYaw45ValueString, rotationYaw90ValueString, rotationYaw135ValueString, rotationYaw180ValueString, rotationYaw225ValueString, rotationYaw270ValueString, rotationYaw315ValueString ]
 
     property var    _distanceSensors:       vehicle ? vehicle.distanceSensors : null
-    property string _noValueStr:            qsTr("--.--")
+    property string _noValueStr:            qsTr("–.––")
 
     onRotationNoneValueChanged:     rotationValueChanged()
     onRotationYaw45ValueChanged:    rotationValueChanged()

--- a/src/QmlControls/GPSIndicatorPage.qml
+++ b/src/QmlControls/GPSIndicatorPage.qml
@@ -21,7 +21,7 @@ ToolIndicatorPage {
 
     property var    activeVehicle:      QGroundControl.multiVehicleManager.activeVehicle
     property string na:                 qsTr("N/A", "No data to display")
-    property string valueNA:            qsTr("--.--", "No data to display")
+    property string valueNA:            qsTr("–.––", "No data to display")
     property var    rtkSettings:        QGroundControl.settingsManager.rtkSettings
     property var    useFixedPosition:           rtkSettings.useFixedBasePosition.rawValue
     property var    manufacturer:       rtkSettings.baseReceiverManufacturers.rawValue

--- a/src/QmlControls/InstrumentValueValue.qml
+++ b/src/QmlControls/InstrumentValueValue.qml
@@ -41,7 +41,7 @@ ColumnLayout {
             if (instrumentValueData.fact) {
                 return instrumentValueData.fact.enumOrValueString + (instrumentValueData.showUnits ? " " + instrumentValueData.fact.units : "")
             } else {
-                return qsTr("--")
+                return qsTr("–")
             }
         }
     }

--- a/src/UI/toolbar/EscIndicatorPage.qml
+++ b/src/UI/toolbar/EscIndicatorPage.qml
@@ -20,7 +20,7 @@ ToolIndicatorPage {
 
     property var    activeVehicle:  QGroundControl.multiVehicleManager.activeVehicle
     property string na:             qsTr("N/A", "No data to display")
-    property string valueNA:        qsTr("--", "No data to display")
+    property string valueNA:        qsTr("–", "No data to display")
 
     property var    _escs:          activeVehicle ? activeVehicle.escs : null
     property int    _onlineBitmask: _escs ? _escs.get(0).info.rawValue : 0

--- a/src/Vehicle/FactGroups/BatteryFactGroupListModel.cc
+++ b/src/Vehicle/FactGroups/BatteryFactGroupListModel.cc
@@ -156,7 +156,7 @@ void BatteryFactGroup::_handleBatteryStatus(Vehicle *vehicle, const mavlink_mess
 void BatteryFactGroup::_timeRemainingChanged(const QVariant &value)
 {
     if (qIsNaN(value.toDouble())) {
-        _timeRemainingStrFact.setRawValue("--:--:--");
+        _timeRemainingStrFact.setRawValue("––:––:––");
     } else {
         const int totalSeconds = value.toInt();
         const int hours = totalSeconds / 3600;

--- a/src/Vehicle/FactGroups/VehicleFactGroup.cc
+++ b/src/Vehicle/FactGroups/VehicleFactGroup.cc
@@ -49,7 +49,7 @@ VehicleFactGroup::VehicleFactGroup(QObject *parent)
     _addFact(&_throttlePctFact);
     _addFact(&_imuTempFact);
 
-    _hobbsFact.setRawValue(QStringLiteral("----:--:--"));
+    _hobbsFact.setRawValue(QStringLiteral("––––:––:––"));
 }
 
 void VehicleFactGroup::handleMessage(Vehicle *vehicle, const mavlink_message_t &message)


### PR DESCRIPTION
# Use number dashes for invalid value placeholders

Description
-----------
Replaced hyphens with number/en dashes in Fact::invalidValueString, as well as in all invalid-value placeholder strings. Also changed instances of 2 hyphens into a single en dash. En dashes are visually wider and more uniform with numeric characters, improving readability and preventing confusion with minus signs.

Checklist:
----------
- [X] [Review Contribution Guidelines](https://github.com/mavlink/qgroundcontrol/blob/master/.github/CONTRIBUTING.md).
- [x] [Review Code of Conduct](https://github.com/mavlink/qgroundcontrol/blob/master/.github/CODE_OF_CONDUCT.md).
- [X] I have tested my changes.

Related Issue
-----------
#13698


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
