### PR TITLE
Add video-fit and video-grid-line settings to Video Settings page

### DIFF
--- a/src/UI/AppSettings/VideoSettings.qml
+++ b/src/UI/AppSettings/VideoSettings.qml
@@ -141,4 +141,23 @@ SettingsPage {
             enabled:            _videoSettings.enableStorageLimit.rawValue
         }
     }
+
+    SettingsGroupLayout {
+        Layout.fillWidth: true
+        heading:            qsTr("Fly View")
+
+        FactCheckBoxSlider {
+            Layout.fillWidth:   true
+            text:               qsTr("Video Grid Lines")
+            fact:               _videoSettings.gridLines
+            visible:            fact.visible
+        }
+
+        LabelledFactComboBox {
+            Layout.fillWidth:   true
+            label:              qsTr("Video Screen Fit")
+            fact:               _videoSettings.videoFit
+            visible:            fact.visible
+        }
+    }
 }


### PR DESCRIPTION
Before, these 2 settings could only be changed when a MAVLink Camera was connected (editors for the settings exist in the Camera settings page). This was problematic because in some setups there is a video stream but no MAVLink Camera. Adding the settings to the Video Settings page makes so the settings are editable when there is no MAVLink camera.

<img width="824" height="951" alt="VideoFitSettings" src="https://github.com/user-attachments/assets/7972a06b-67e8-45cf-8708-61611c8682fd" />
