### PR TITLE
Fix positioning of Terrain Progress and PhotoVideo control

### DIFF
--- a/src/FlyView/FlyViewTopRightColumnLayout.qml
+++ b/src/FlyView/FlyViewTopRightColumnLayout.qml
@@ -18,11 +18,10 @@ import QGroundControl.FlightMap
 
 
 ColumnLayout {
-    width: _rightPanelWidth
+    spacing: ScreenTools.defaultFontPixelHeight / 2
 
     TerrainProgress {
-        Layout.alignment:       Qt.AlignTop
-        Layout.preferredWidth:  _rightPanelWidth
+        Layout.fillWidth: true
     }
 
     // We use a Loader to load the photoVideoControlComponent only when we have an active vehicle and a camera manager.
@@ -30,7 +29,7 @@ ColumnLayout {
     // to be null all over the place
     Loader {
         id:                 photoVideoControlLoader
-        Layout.alignment:   Qt.AlignTop | Qt.AlignRight
+        Layout.alignment:   Qt.AlignRight
         sourceComponent:    globals.activeVehicle && globals.activeVehicle.cameraManager ? photoVideoControlComponent : undefined
 
         property real rightEdgeCenterInset: visible ? parent.width - x : 0

--- a/src/FlyView/FlyViewWidgetLayer.qml
+++ b/src/FlyView/FlyViewWidgetLayer.qml
@@ -76,7 +76,6 @@ Item {
     FlyViewTopRightColumnLayout {
         id:                 topRightColumnLayout
         anchors.top:        parent.top
-        anchors.bottom:     bottomRightRowLayout.top
         anchors.right:      parent.right
         spacing:            _layoutSpacing
         visible:           !topRightPanel.visible

--- a/src/FlyView/TerrainProgress.qml
+++ b/src/FlyView/TerrainProgress.qml
@@ -17,9 +17,11 @@ import QGroundControl.Controls
 
 
 Rectangle {
+    implicitWidth:  mainLayout.width + (_margins * 2)
     implicitHeight: mainLayout.height + (_margins * 2)
-    visible:        false
     color:          qgcPal.window
+    radius:         ScreenTools.defaultBorderRadius
+    visible:        false
 
     property var    _activeVehicle: QGroundControl.multiVehicleManager.activeVehicle
     property real   _margins:       ScreenTools.defaultFontPixelWidth / 2
@@ -50,7 +52,7 @@ Rectangle {
 
     Timer {
         id:             visibilityTimer
-        interval:       30 * 1000
+        interval:       15 * 1000
         onTriggered:    parent.visible = false
     }
 
@@ -61,7 +63,6 @@ Rectangle {
         anchors.margins:    _margins
         anchors.top:        parent.top
         anchors.left:       parent.left
-        anchors.right:      parent.right
         spacing:            _margins
 
         QGCLabel {


### PR DESCRIPTION
There would be a big vertical space between the two when they should be both stacked at top right