### PR TITLE
Mavlink: Change to allow V1 heartbeats without notify

### DIFF
--- a/src/Comms/MAVLinkProtocol.cc
+++ b/src/Comms/MAVLinkProtocol.cc
@@ -110,7 +110,10 @@ void MAVLinkProtocol::receiveBytes(LinkInterface *link, const QByteArray &data)
             continue;
         }
 
-        if (status.flags & MAVLINK_STATUS_FLAG_IN_MAVLINK1) {
+        // It's ok to get v1 HEARTBEAT messages on a v2 link:
+        //  PX4 defaults to sending V1 then switches to V2 after receiving a V2 message from GCS
+        //  ArduPilot always sends both versions
+        if (message.msgid != MAVLINK_MSG_ID_HEARTBEAT && (status.flags & MAVLINK_STATUS_FLAG_IN_MAVLINK1)) {
             link->reportMavlinkV1Traffic();
             continue;
         }


### PR DESCRIPTION
* PX4 defaults to sending a V1 heartbeat adn then switches to V2 when QGC sends V2 traffic
* ArduPilot always continuously sends both V1 and V2 heartbeats