### PR TITLE
The json value for AMSLAltAboveTerrain in Plan files should support NaN

### DIFF
--- a/src/MissionManager/SimpleMissionItem.cc
+++ b/src/MissionManager/SimpleMissionItem.cc
@@ -302,7 +302,7 @@ bool SimpleMissionItem::load(const QJsonObject& json, int sequenceNumber, QStrin
             QList<JsonHelper::KeyValidateInfo> keyInfoList = {
                 { _jsonAltitudeModeKey,         QJsonValue::Double, true },
                 { _jsonAltitudeKey,             QJsonValue::Double, true },
-                { _jsonAMSLAltAboveTerrainKey,  QJsonValue::Double, true },
+                { _jsonAMSLAltAboveTerrainKey,  QJsonValue::Null, true },
             };
             if (!JsonHelper::validateKeys(json, keyInfoList, errorString)) {
                 return false;


### PR DESCRIPTION
Now that the JsonHelper validation code is working correctly with respect to Double and Null types it's exposing bugs in the code where the type of double values are incorrectly typed. And then in turn fail validation.