### PR TITLE
Remove PX4 Obstacle Avoidance (deprecated)

### DIFF
--- a/src/AutoPilotPlugins/PX4/SafetyComponent.qml
+++ b/src/AutoPilotPlugins/PX4/SafetyComponent.qml
@@ -48,7 +48,6 @@ SetupPage {
             property Fact _dlLossAction:        controller.getParameterFact(-1, "NAV_DLL_ACT")
             property Fact _disarmLandDelay:     controller.getParameterFact(-1, "COM_DISARM_LAND")
             property Fact _collisionPrevention: controller.getParameterFact(-1, "CP_DIST")
-            property Fact _objectAvoidance:     controller.getParameterFact(-1, "COM_OBS_AVOID")
             property Fact _landSpeedMC:         controller.getParameterFact(-1, "MPC_LAND_SPEED", false)
             property bool _hitlAvailable:       controller.parameterExists(-1, hitlParam)
             property Fact _hitlEnabled:         controller.getParameterFact(-1, hitlParam, false)
@@ -172,23 +171,6 @@ SetupPage {
                                         _collisionPrevention.value = index > 0 ? 5 : -1
                                         console.log('Collision prevention enabled: ' + _collisionPrevention.value)
                                         showObstacleDistanceOverlayCheckBox.checked = _collisionPrevention.value > 0
-                                    }
-                                }
-                            }
-
-                            QGCLabel {
-                                text:               qsTr("Obstacle Avoidance:")
-                                Layout.fillWidth:   true
-                            }
-                            QGCComboBox {
-                                model:              [qsTr("Disabled"), qsTr("Enabled")]
-                                enabled:            _objectAvoidance && _collisionPrevention.rawValue > 0
-                                Layout.minimumWidth:_editFieldWidth
-                                Layout.fillWidth:   true
-                                currentIndex:       _objectAvoidance ? (_objectAvoidance.value === 0 ? 0 : 1) : 0
-                                onActivated: (index) => {
-                                    if(_objectAvoidance) {
-                                        _objectAvoidance.value = index > 0 ? 1 : 0
                                     }
                                 }
                             }

--- a/src/Comms/MockLink/MockLink.Parameter.MetaData.json
+++ b/src/Comms/MockLink/MockLink.Parameter.MetaData.json
@@ -6689,13 +6689,6 @@
       "longDesc": "If set to 1 incoming HIL GPS messages are parsed."
     },
     {
-      "name": "COM_OBS_AVOID",
-      "type": "Int32",
-      "default": 0,
-      "group": "Mission",
-      "shortDesc": "Flag to enable obstacle avoidance"
-    },
-    {
       "name": "COM_TAKEOFF_ACT",
       "type": "Int32",
       "default": 0,

--- a/src/FirmwarePlugin/PX4/PX4ParameterFactMetaData.xml
+++ b/src/FirmwarePlugin/PX4/PX4ParameterFactMetaData.xml
@@ -10864,9 +10864,6 @@
         <value code="7">Disarm</value>
       </values>
     </parameter>
-    <parameter name="COM_OBS_AVOID" default="0" type="INT32" boolean="true">
-      <short_desc>Flag to enable obstacle avoidance</short_desc>
-    </parameter>
     <parameter name="COM_OF_LOSS_T" default="1.0" type="FLOAT">
       <short_desc>Time-out to wait when offboard connection is lost before triggering offboard lost action</short_desc>
       <long_desc>See COM_OBL_RC_ACT to configure action.</long_desc>


### PR DESCRIPTION
Remove COM_OBS_AVOID parameter and associated menu item since PX4 no longer supports Obstacle Avoidance. PX4 still supports Collision Prevention, which is supported in QGC via the (misnamed) `VehicleObjectAvoidance` class.

I thought that **src/FirmwarePlugin/PX4/PX4ParameterFactMetaData.xml** was autogenerated? I'm not sure where or how, if so, we should add a header to the file which says something like `DO NOT MANUALLY EDIT, AUTOGENERATED BY...`