### PR TITLE
Vehicle: ignore SYS_STATUS unless from autopilot

### DIFF
--- a/src/Vehicle/Vehicle.cc
+++ b/src/Vehicle/Vehicle.cc
@@ -929,6 +929,10 @@ bool Vehicle::_apmArmingNotRequired()
 
 void Vehicle::_handleSysStatus(mavlink_message_t& message)
 {
+    if (message.compid != _defaultComponentId) {
+        return;
+    }
+
     mavlink_sys_status_t sysStatus;
     mavlink_msg_sys_status_decode(&message, &sysStatus);
 


### PR DESCRIPTION
Some MAVLink components (re)use the MAVLink message SYS_STATUS which causes the top right autopilot status to flicker back and forth as messages are arriving.

Therefore, we should ignore the SYS_STATUS message unless it originates from the actual autopilot.

FYI @CraigElder.