### PR TITLE
Fix switching between a tool and a view

### DIFF
--- a/src/UI/MainWindow.qml
+++ b/src/UI/MainWindow.qml
@@ -116,11 +116,13 @@ ApplicationWindow {
     function showPlanView() {
         flyView.visible = false
         planView.visible = true
+        toolDrawer.visible = false
     }
 
     function showFlyView() {
         flyView.visible = true
         planView.visible = false
+        toolDrawer.visible = false
     }
 
     function showTool(toolTitle, toolSource, toolIcon) {


### PR DESCRIPTION
Changing from Settings to Plan would fail. This is because although the ui now makes everything looks like "Views", allowing you to switch from anything to anything. The code behind the scenes still have the concept of a view and tool