### PR TITLE
ci(windows): Switch to actively maintained MSVC setup action

### DIFF
--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -129,7 +129,7 @@ jobs:
           modules: ${{ steps.config.outputs.qt_modules }}
 
       - name: Set up MSVC environment
-        uses: ilammy/msvc-dev-cmd@v1
+        uses: TheMrMilchmann/setup-msvc-dev@v4
         with:
           arch: ${{ (matrix.arch == 'win64_msvc2022_64' && 'x64') || (matrix.arch == 'win64_msvc2022_arm64' && 'arm64') || 'amd64_arm64' }}
 


### PR DESCRIPTION
## Summary
- Replace `ilammy/msvc-dev-cmd@v1` with `TheMrMilchmann/setup-msvc-dev@v4`

## Why
The current action (`ilammy/msvc-dev-cmd`) hasn't been updated since January 2024 and uses the deprecated Node 16 runtime. GitHub will eventually stop supporting Node 16 actions.

`TheMrMilchmann/setup-msvc-dev` is an actively maintained fork with:
- **Node 24 runtime** (future-proof)
- **Better error reporting** (silent failures fixed in v2.0.2)
- **Regular releases** through September 2025
- **Drop-in API compatibility** (same inputs)

| Aspect | ilammy/msvc-dev-cmd | TheMrMilchmann/setup-msvc-dev |
|--------|---------------------|-------------------------------|
| Last Release | v1.13.0 (Jan 2024) | v4.0.0 (Sept 2025) |
| Node Runtime | Node 16 (deprecated) | Node 24 |
| Open Issues | 16 | Fewer, actively triaged |

## Test plan
- [ ] Windows x64 build passes
- [ ] Windows ARM64 cross-compile passes