### PR TITLE
fix(ci): Remove broken auto-merge job for dependabot PRs

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,3 +1,7 @@
+# Dependabot configuration
+# To merge dependabot PRs, comment "@dependabot merge" after CI passes
+# See: https://docs.github.com/en/code-security/dependabot/working-with-dependabot/managing-pull-requests-for-dependency-updates
+
 version: 2
 updates:
   # Monitor GitHub Actions in workflows and all custom actions

--- a/.github/workflows/pr-checks.yml
+++ b/.github/workflows/pr-checks.yml
@@ -102,26 +102,6 @@ jobs:
           repo-token: ${{ secrets.GITHUB_TOKEN }}
           sync-labels: true
 
-  auto-merge:
-    name: Auto-merge Dependabot
-    runs-on: ubuntu-latest
-    if: github.event.action != 'closed' && github.event.pull_request.user.login == 'dependabot[bot]'
-    timeout-minutes: 5
-
-    steps:
-      - name: Fetch Dependabot metadata
-        id: metadata
-        uses: dependabot/fetch-metadata@v2
-        with:
-          github-token: ${{ secrets.GITHUB_TOKEN }}
-
-      - name: Enable auto-merge for patch/minor updates
-        if: steps.metadata.outputs.update-type == 'version-update:semver-patch' || steps.metadata.outputs.update-type == 'version-update:semver-minor'
-        run: gh pr merge --auto --squash "$PR_URL"
-        env:
-          PR_URL: ${{ github.event.pull_request.html_url }}
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-
   cache-cleanup:
     name: Cleanup PR Caches
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Summary
- Remove auto-merge job from pr-checks.yml (fails with protected branch permission error)
- Add usage comment to dependabot.yml explaining `@dependabot merge` workflow

## Problem
The auto-merge job fails with:
```
GraphQL: Pull request User is not authorized for this protected branch (enablePullRequestAutoMerge)
```

This happens because `GITHUB_TOKEN` in dependabot-triggered workflows lacks permissions to enable auto-merge on protected branches.

## Solution
Rather than adding a PAT (security concern) or GitHub App (complexity), rely on the built-in `@dependabot merge` command. Maintainers can comment this on any dependabot PR after CI passes.

Fixes the failing check on #13688