### PR TITLE
fix(linux): Fix AppImage GLib/GIO and GStreamer GL compatibility

### DIFF
--- a/deploy/linux/AppRun
+++ b/deploy/linux/AppRun
@@ -31,6 +31,13 @@ if [ -n "$SYSTEM_GLIB" ]; then
     fi
 fi
 
+# Use system OpenGL libraries to avoid conflicts with bundled libGLESv2
+# Bundled GLES can conflict with system desktop OpenGL causing "Unrecognized OpenGL version"
+SYSTEM_LIBDIR="${LIB_PATH:-/usr/lib/${MULTIARCH}}"
+if [ -f "${SYSTEM_LIBDIR}/libEGL.so.1" ]; then
+    export LD_PRELOAD="${SYSTEM_LIBDIR}/libEGL.so.1:${SYSTEM_LIBDIR}/libGLESv2.so.2${LD_PRELOAD:+:$LD_PRELOAD}"
+fi
+
 if [ -n "$MULTIARCH" ]; then
     export LD_LIBRARY_PATH="${APPDIR}/usr/lib:${APPDIR}/usr/lib/gstreamer-1.0:/usr/lib/${MULTIARCH}:/lib/${MULTIARCH}:/usr/lib64:/usr/lib:${LD_LIBRARY_PATH}"
 else

--- a/src/VideoManager/VideoManager.cc
+++ b/src/VideoManager/VideoManager.cc
@@ -97,7 +97,7 @@ void VideoManager::init(QQuickWindow *mainWindow)
 
     (void) connect(this, &VideoManager::autoStreamConfiguredChanged, this, &VideoManager::_videoSourceChanged);
 
-    _mainWindow->scheduleRenderJob(new FinishVideoInitialization(), QQuickWindow::BeforeSynchronizingStage);
+    _mainWindow->scheduleRenderJob(new FinishVideoInitialization(), QQuickWindow::AfterSynchronizingStage);
 
     _initialized = true;
 }
@@ -827,5 +827,5 @@ FinishVideoInitialization::~FinishVideoInitialization()
 void FinishVideoInitialization::run()
 {
     qCDebug(VideoManagerLog) << "FinishVideoInitialization::run";
-    VideoManager::instance()->_initAfterQmlIsReady();
+    QMetaObject::invokeMethod(VideoManager::instance(), &VideoManager::_initAfterQmlIsReady, Qt::QueuedConnection);
 }


### PR DESCRIPTION
## Summary
Fixes two related issues affecting Linux AppImage compatibility:

- **GLib/GIO module compatibility**: Fixes "undefined symbol: g_task_set_static_name" error on systems with GLib 2.76+ where system GIO modules expect newer symbols than bundled GIO provides
- **GStreamer GL initialization**: Fixes "Could not initialize window system" race condition and "Unrecognized OpenGL version" warnings

## Changes

### AppRun (deploy/linux/AppRun)
- Add distro-agnostic GLib/GIO discovery (Debian, Fedora, Arch paths)
- Check libgio (not libglib) for `g_task_set_static_name` symbol
- Use `GIO_MODULE_DIR` to replace system modules when GIO 2.76+ detected
- Fall back to `GIO_EXTRA_MODULES` on older systems
- Set `GIO_USE_VFS=local` to skip D-Bus calls to gvfs
- Add `/usr/lib64/` to `LD_LIBRARY_PATH` for Fedora/RHEL
- **NEW**: Preload system EGL/GLESv2 to avoid conflicts with bundled libGLESv2

### VideoManager.cc
- Use `AfterSynchronizingStage` instead of `BeforeSynchronizingStage` for video initialization
- Use `QueuedConnection` for main thread execution

## Root Cause Analysis

**GIO issue**: `g_task_set_static_name` is in libgio-2.0.so (not libglib). `GIO_EXTRA_MODULES` adds modules but system modules still load and fail. `GIO_MODULE_DIR` replaces the search path entirely.

**GL issue**: Two problems:
1. GStreamer qt6glsink calls `initWinSys()` during `NULL_TO_READY` state transition, which requires the Qt GL context. `BeforeSynchronizingStage` runs before `Qt6GLVideoItem::onSceneGraphInitialized()` completes.
2. AppImage bundles `libGLESv2.so.2` which conflicts with system desktop OpenGL (`libGL.so.1`), causing "Unrecognized OpenGL version" warnings and GL context initialization failures.

## Test plan
- [ ] Test AppImage on Ubuntu 22.04+ (GLib 2.72+)
- [ ] Test AppImage on Fedora 38+ (GLib 2.76+)
- [ ] Verify no "Unrecognized OpenGL version" warnings
- [ ] Verify no "Could not initialize window system" errors
- [ ] Verify video streaming works
- [ ] Verify TTS works (uses GIO modules)