### PR TITLE
fix(ci): Fix YAML syntax error in check-links workflow

### DIFF
--- a/.github/workflows/check-links.yml
+++ b/.github/workflows/check-links.yml
@@ -30,7 +30,7 @@ jobs:
         uses: lycheeverse/lychee-action@v2
         with:
           # Config in .lychee.toml, files to check passed as args
-          args: '**/*.md' 'docs/**'
+          args: '**/*.md docs/**'
           fail: ${{ github.event_name == 'push' && github.ref == 'refs/heads/master' }}
 
       - name: Add to step summary


### PR DESCRIPTION
## Summary
- Fix invalid YAML syntax in check-links.yml that was causing workflow file parsing errors

## Root Cause
Line 33 had two separate quoted strings (`'**/*.md' 'docs/**'`) which is invalid YAML. Combined into a single quoted string with space-separated patterns.

## Test Plan
- [x] Validated YAML syntax locally with Python yaml parser
- [ ] CI check-links workflow should now run successfully