### PR TITLE
Plan: Allow Mission Status panel to use space under ToolStrip

### DIFF
--- a/src/QmlControls/PlanView.qml
+++ b/src/QmlControls/PlanView.qml
@@ -255,7 +255,7 @@ Item {
     }
 
     Item {
-        id: panel
+        id: mainPlanViewArea
         anchors.left: parent.left
         anchors.right: parent.right
         anchors.top: planToolBar.bottom
@@ -561,7 +561,7 @@ Item {
         RowLayout {
             id: missionStatus
             anchors.margins: _toolsMargin
-            anchors.left: toolStrip.right
+            anchors.left: _calcLeftAnchor()
             anchors.right: rightPanel.left
             anchors.bottom: parent.bottom
             spacing: 0
@@ -571,6 +571,15 @@ Item {
 
             function showMissionStatus() {
                 _planViewSettings.showMissionItemStatus.rawValue = true
+            }
+
+            function _calcLeftAnchor() {
+                let bottomOfToolStrip = toolStrip.y + toolStrip.height
+                let largestStatsHeight = Math.max(terrainStatus.height, missionStats.height)
+                if (bottomOfToolStrip + largestStatsHeight > parent.height - missionStatus.anchors.margins) {
+                    return toolStrip.right
+                }
+                return parent.left
             }
 
             function _toggleMissionStatusVisibility() {


### PR DESCRIPTION
* If there is enough room under the tool strip the Mission Status panel will anchor to the left edge of the window
* If not, it will anchor to the right edge of the tool strip

![Screenshot 2025-12-20 at 7 01 24 PM](https://github.com/user-attachments/assets/7c96f7f0-90b1-4174-bc2c-b677ac1557f2)
