### PR TITLE
ci: Fix check-links workflow and pr-checks heredoc bug

### DIFF
--- a/.github/workflows/check-links.yml
+++ b/.github/workflows/check-links.yml
@@ -5,12 +5,18 @@ on:
     branches:
       - master
     paths:
-      - 'docs/**'
       - '**.md'
+      - '.lychee.toml'
+      - '!docs/ko/**'
+      - '!docs/tr/**'
+      - '!docs/zh/**'
   pull_request:
     paths:
-      - 'docs/**'
       - '**.md'
+      - '.lychee.toml'
+      - '!docs/ko/**'
+      - '!docs/tr/**'
+      - '!docs/zh/**'
   workflow_dispatch:
 
 concurrency:
@@ -30,23 +36,20 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v6
 
+      - name: Restore lychee cache
+        uses: actions/cache@v5
+        with:
+          path: .lycheecache
+          key: cache-lychee-${{ github.sha }}
+          restore-keys: cache-lychee-
+
       - name: Check links
         uses: lycheeverse/lychee-action@v2
         with:
-          # Config in .lychee.toml, files to check passed as args
-          args: '**/*.md docs/**'
+          args: '--cache --max-cache-age 3d --no-progress **/*.md docs/en/**'
+          lycheeVersion: v0.22.0
+          failIfEmpty: false
           fail: ${{ github.event_name == 'push' && github.ref == 'refs/heads/master' }}
-
-      - name: Add to step summary
-        if: always()
-        run: |
-          echo "## 🔗 Link Check Results" >> "$GITHUB_STEP_SUMMARY"
-          echo "" >> "$GITHUB_STEP_SUMMARY"
-          if [[ -f ./lychee/out.md ]]; then
-            cat ./lychee/out.md >> "$GITHUB_STEP_SUMMARY"
-          else
-            echo "No report generated" >> "$GITHUB_STEP_SUMMARY"
-          fi
 
       - name: Upload report
         uses: actions/upload-artifact@v6
@@ -54,4 +57,5 @@ jobs:
         with:
           name: link-check-report
           path: ./lychee/out.md
+          if-no-files-found: ignore
           retention-days: 7

--- a/.github/workflows/pr-checks.yml
+++ b/.github/workflows/pr-checks.yml
@@ -78,17 +78,17 @@ jobs:
           SAFE_BODY=$(echo "$PR_BODY" | head -c 2000 | tr -d '\r')
           SAFE_FILES=$(echo "$CHANGED_FILES" | head -30)
 
-          # Write to outputs using heredoc for multiline safety
+          # Write to outputs using heredoc with unique delimiters
           {
-            echo "title<<EOF"
+            echo "title<<TITLE_END_7f3a9c2e"
             echo "$SAFE_TITLE"
-            echo "EOF"
-            echo "body<<EOF"
+            echo "TITLE_END_7f3a9c2e"
+            echo "body<<BODY_END_8b4d1e6f"
             echo "$SAFE_BODY"
-            echo "EOF"
-            echo "files<<EOF"
+            echo "BODY_END_8b4d1e6f"
+            echo "files<<FILES_END_2c5a8d9b"
             echo "$SAFE_FILES"
-            echo "EOF"
+            echo "FILES_END_2c5a8d9b"
           } >> "$GITHUB_OUTPUT"
 
       - name: Suggest title with GitHub Models

--- a/.lychee.toml
+++ b/.lychee.toml
@@ -46,6 +46,7 @@ exclude = [
     '^https?://docs\.zubax\.com/',
     '^https?://visionmedia\.github\.com/',
     '^https?://mavlink\.org/',
+    '^https?://gstreamer\.freedesktop\.org/',
 
     # Bot protection (403)
     '^https?://www\.npmjs\.com/',

--- a/docs/en/qgc-dev-guide/command_line_options.md
+++ b/docs/en/qgc-dev-guide/command_line_options.md
@@ -33,7 +33,7 @@ The options/command line arguments are listed in the table below.
 | Option                                                    | Description                                                                                                                          |
 | --------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------ |
 | `--clear-settings`                                        | Clears the app settings (reverts _QGroundControl_ back to default settings).                                                         |
-| `--logging:full`                                          | Turns on full logging. See [Console Logging](../../qgc-user-guide/settings_view/console_logging.md#logging-from-the-command-line). |
+| `--logging:full`                                          | Turns on full logging. See [Console Logging](../qgc-user-guide/settings_view/console_logging.md#logging-from-the-command-line). |
 | `--logging:full,LinkManagerVerboseLog,ParameterLoaderLog` | Turns on full logging and turns off the following listed comma-separated logging options.                                            |
 | `--logging:LinkManagerLog,ParameterLoaderLog`             | Turns on the specified comma separated logging options                                                                               |
 | `--unittest:name`                                         | (Debug builds only) Runs the specified unit test. Leave off `:name` to run all tests.                                                |


### PR DESCRIPTION
## Summary

- Fix check-links workflow failures on master
- Fix pr-checks workflow failing on Dependabot PRs

## Changes

### check-links.yml
- Pin lychee to v0.22.0 for consistent exclude pattern handling
- Only check `docs/en/**` (skip stale translations explicitly)
- Add path exclusions for ko/tr/zh folders
- Add lychee result caching with 3-day expiry

### pr-checks.yml
- Use unique heredoc delimiters (`TITLE_END_7f3a9c2e`, etc.) instead of `EOF`
- Fixes failures when PR body contains literal "EOF" (common in Dependabot PRs)

### .lychee.toml
- Add gstreamer.freedesktop.org to excludes (flaky network)

### docs/en/qgc-dev-guide/command_line_options.md
- Fix relative path `../../` → `../` for console_logging.md link

## Test plan

- [ ] check-links workflow passes on this PR
- [ ] pr-checks workflow passes on this PR