### PR TITLE
RemoteID: Fix EU operator ID validation never running

### DIFF
--- a/src/UI/AppSettings/RemoteIDSettings.qml
+++ b/src/UI/AppSettings/RemoteIDSettings.qml
@@ -371,12 +371,12 @@ SettingsPage {
                         }
 
                         onTextChanged: {
-                            operatorIDFact.value = text
                             if (_activeVehicle) {
                                 _remoteIDManager.checkOperatorID(text)
                             } else {
                                 _offlineVehicle.remoteIDManager.checkOperatorID(text)
                             }
+                            operatorIDFact.value = text
                         }
 
                         onEditingFinished: {


### PR DESCRIPTION
## Description

Fix operator ID validation.

## Type of Change

The QML onTextChanged handler was setting operatorIDFact.value before calling checkOperatorID(), so the C++ validation check comparing input against stored value was always equal, causing validation to be skipped.

## Testing

- [x] Tested locally
- [ ] Added/updated unit tests
- [ ] Tested with simulator (SITL)
- [ ] Tested with hardware

### Platforms Tested

- [x] Linux
- [ ] Windows
- [ ] macOS
- [ ] Android
- [ ] iOS

### Flight Stacks Tested

- [ ] PX4
- [ ] ArduPilot

## Screenshots
<!-- If applicable, add screenshots to help explain your changes -->

## Checklist

- [ ] I have read the [Contribution Guidelines](CONTRIBUTING.md)
- [ ] I have read the [Code of Conduct](CODE_OF_CONDUCT.md)
- [ ] My code follows the project's coding standards
- [ ] I have added tests that prove my fix/feature works
- [ ] New and existing unit tests pass locally

## Related Issues

Closes #11750.

---
By submitting this pull request, I confirm that my contribution is made under the terms of the project's dual license (Apache 2.0 and GPL v3).
