### PR TITLE
Rework `Apply New Default Altitude` support

### DIFF
--- a/src/QmlControls/MissionSettingsEditor.qml
+++ b/src/QmlControls/MissionSettingsEditor.qml
@@ -17,6 +17,7 @@ Rectangle {
     property var _masterController: masterController
     property var _missionController: _masterController.missionController
     property var _controllerVehicle: _masterController.controllerVehicle
+    property var _visualItems: _missionController.visualItems
     property bool _vehicleHasHomePosition: _controllerVehicle.homePosition.isValid
     property bool _showCruiseSpeed: !_controllerVehicle.multiRotor
     property bool _showHoverSpeed: _controllerVehicle.multiRotor || _controllerVehicle.vtol
@@ -90,6 +91,36 @@ Rectangle {
             label: qsTr("Waypoints Altitude")
             fact: QGroundControl.settingsManager.appSettings.defaultMissionItemAltitude
         }
+
+        QGCButton {
+            id: applyDefaultAltitudeButton
+            Layout.fillWidth: true
+            text: qsTr("Apply New Altitude")
+            visible: false
+
+            onClicked: mainWindow.showMessageDialog(qsTr("Apply New Altitude"),
+                            qsTr("You have changed the default altitude for mission items. Would you like to apply that altitude to all the items in the current mission?"),
+                            Dialog.Yes | Dialog.No,
+                            function() { applyDefaultAltitudeButton.visible = false; _missionController.applyDefaultMissionAltitude() })
+
+            Connections {
+                target: _appSettings.defaultMissionItemAltitude
+                function onRawValueChanged() {
+                    if (_visualItems.count > 1) {
+                        applyDefaultAltitudeButton.visible = true
+                    }
+                }
+            }
+
+            Connections {
+                target: _visualItems
+                function onCountChanged() {
+                    if (_visualItems.count <= 1) {
+                        applyDefaultAltitudeButton.visible = false
+                    }
+                }
+            }
+    }
 
         FactTextFieldSlider {
             Layout.fillWidth: true

--- a/src/QmlControls/PlanView.qml
+++ b/src/QmlControls/PlanView.qml
@@ -84,18 +84,6 @@ Item {
         planMasterController: _planMasterController
     }
 
-    Connections {
-        target: _appSettings ? _appSettings.defaultMissionItemAltitude : null
-        function onRawValueChanged() {
-            if (_visualItems.count > 1) {
-                mainWindow.showMessageDialog(qsTr("Apply new altitude"),
-                                             qsTr("You have changed the default altitude for mission items. Would you like to apply that altitude to all the items in the current mission?"),
-                                             Dialog.Yes | Dialog.No,
-                                             function() { _missionController.applyDefaultMissionAltitude() })
-            }
-        }
-    }
-
     PlanMasterController {
         id: planMasterController
         flyView: false


### PR DESCRIPTION
* When you change default waypoint altitude after the fact a new button will show up to allow you to apply the new alt to the mission items
* Fix #13799

<img width="248" height="379" alt="Screenshot 2026-01-01 at 8 11 08 PM" src="https://github.com/user-attachments/assets/d0ce1f34-ce54-4e13-a787-018d9084cacf" />
<img width="466" height="122" alt="Screenshot 2026-01-01 at 8 11 16 PM" src="https://github.com/user-attachments/assets/19c1edda-d3cd-425e-a9ef-0ef99870efa4" />
