### PR TITLE
Vagrant: use Ubuntu Questing for base image

### DIFF
--- a/deploy/vagrant/Vagrantfile
+++ b/deploy/vagrant/Vagrantfile
@@ -32,7 +32,7 @@ Vagrant.configure(2) do |config|
   config.vm.provider "virtualbox"
   config.vm.provider "vmware_fusion"
 
-  config.vm.box = "ubuntu/jammy64"
+  config.vm.box = "alvistack/ubuntu-25.10"
   config.vm.provider :docker do |docker, override|
     override.vm.box = "tknerr/baseimage-ubuntu-16.04"
   end
@@ -80,6 +80,8 @@ Vagrant.configure(2) do |config|
 
      sudo DEBIAN_FRONTEND=noninteractive apt-get -y -o Dpkg::Options::="--force-confdef" -o Dpkg::Options::="--force-confold" install %{apt_pkgs}
 
+     sudo apt-get install -y python3-pip python3-venv python3-dev
+
      # use common package installation:
      /usr/bin/env bash /vagrant/tools/setup/install-dependencies-debian.sh
 
@@ -89,9 +91,16 @@ Vagrant.configure(2) do |config|
      su - vagrant -c 'cd %{project_root_dir}; git submodule init && git submodule update'
 
      # with reference to https://github.com/jurplel/install-qt-action@v3/blob/master/src/main.ts and .github/workflows/linux_release.yml:
+
+     # create a venv to install packages into:
+     su - vagrant -c 'python3 -m venv --system-site-packages ~vagrant/venv-qgroundcontrol'
+     su - vagrant -c 'echo "VIRTUAL_ENV_DISABLE_PROMPT=1 source /home/vagrant/venv-qgroundcontrol/bin/activate" >>~vagrant/.bashrc'
      echo 'Installing QT'
-     apt-get install -y python3-pip
-     su - vagrant -c "pip3 install --user aqtinstall"
+     sudo apt-get install -y qt6-base-dev-tools
+
+     QT6_FEATURES="charts location positioning speech 5compat multimedia serialport shadertools connectivity quick3d sensors"
+
+     su - vagrant -c "source /home/vagrant/venv-qgroundcontrol/bin/activate; python3 -m pip install --user aqtinstall"
 
      apt-get install -y patchelf
 
@@ -106,6 +115,11 @@ Vagrant.configure(2) do |config|
 
      # appimage requires FUSE, so allow Vagrant to use FUSE:
      perl -pe 's/#user_allow_other/user_allow_other/' -i /etc/fuse.conf
+     # plucky broke fusermount due to apparmor issues
+     # ... so (classily) disable apparmor:
+     systemctl disable apparmor
+     systemctl stop apparmor
+     aa-teardown
 
      # write out a pair of scripts to make rebuilding on the VM easy:
      su - vagrant -c "cat <<CONFIGURE >do-configure.sh
@@ -114,10 +128,12 @@ Vagrant.configure(2) do |config|
 set -e
 set -x
 
-rm -rf /vagrant/shadow_build
-mkdir /vagrant/shadow_build
-cd /vagrant/shadow_build
-time cmake -S /vagrant -B . -G Ninja -DCMAKE_BUILD_TYPE=Release -DQGC_BUILD_TESTING=ON -DQGC_STABLE_BUILD=OFF  # 34s
+# shadow_build in /home to avoid linking problems on vboxfs
+SHADOW_BUILD=\"\\\$HOME/shadow_build\"
+rm -rf \"\\\$SHADOW_BUILD\"
+mkdir \"\\\$SHADOW_BUILD\"
+cd \"\\\$SHADOW_BUILD\"
+time cmake -S /vagrant -B . -G Ninja -DCMAKE_BUILD_TYPE=Release -DQGC_BUILD_TESTING=ON -DQGC_STABLE_BUILD=OFF -DCMAKE_PREFIX_PATH=\\\$HOME/Qt/${version}/gcc_64 # 34s
 CONFIGURE
 "
 
@@ -127,11 +143,16 @@ CONFIGURE
 set -e
 set -x
 
-cd /vagrant/shadow_build
+SHADOW_BUILD=\"\\\$HOME/shadow_build\"
+
+cd \"\\\$SHADOW_BUILD\"
 
 time cmake --build . --target all --config Release  # 75m
 rm -rf AppDir
 time cmake --install . --config Release
+
+rsync --delete -aPH \"\\\$SHADOW_BUILD\" /vagrant/shadow_build
+
 MAKE
 "
 


### PR DESCRIPTION
Jammy doesn't have a recent-enough version of cmake to compile qgc

## Description
`vagrant up` doesn't give you a QGC binary at all as it is outdated

## Type of Change
- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)
- [x] CI/Build changes
- [ ] Other

## Testing
<!-- Describe the tests you ran and how to reproduce them -->
- [x] Tested locally
- [ ] Added/updated unit tests
- [x] Tested with simulator (SITL)
- [x] Tested with hardware

### Platforms Tested
<!-- Check all that apply -->
- [x] Linux
- [ ] Windows
- [ ] macOS
- [ ] Android
- [ ] iOS

### Flight Stacks Tested
<!-- If applicable -->
- [ ] PX4
- [x] ArduPilot
