### PR TITLE
Update GeographicLib and expand QGCGeo geodesic utilities

### DIFF
--- a/src/Terrain/TerrainTileManager.cc
+++ b/src/Terrain/TerrainTileManager.cc
@@ -8,6 +8,7 @@
 #include "SettingsManager.h"
 #include "FlightMapSettings.h"
 #include "QGCLoggingCategory.h"
+#include "QGCGeo.h"
 
 #include <QtLocation/private/qgeotilespec_p.h>
 #include <QtNetwork/QNetworkAccessManager>
@@ -159,31 +160,21 @@ void TerrainTileManager::addPathQuery(TerrainQueryInterface *terrainQueryInterfa
 
 QList<QGeoCoordinate> TerrainTileManager::_pathQueryToCoords(const QGeoCoordinate &fromCoord, const QGeoCoordinate &toCoord, double &distanceBetween, double &finalDistanceBetween)
 {
-    const double lat = fromCoord.latitude();
-    const double lon = fromCoord.longitude();
-    const int steps = qCeil(toCoord.distanceTo(fromCoord) / TerrainTileCopernicus::kTileValueSpacingMeters); // TODO: get spacing from terrainQueryInterface
-    const double latDiff = toCoord.latitude() - lat;
-    const double lonDiff = toCoord.longitude() - lon;
+    const double totalDistance = QGCGeo::geodesicDistance(fromCoord, toCoord);
+    // TODO: get spacing from terrainQueryInterface
+    const int numPoints = qMax(2, qCeil(totalDistance / TerrainTileCopernicus::kTileValueSpacingMeters) + 1);
 
-    QList<QGeoCoordinate> coordinates;
-    if (steps == 0) {
-        (void) coordinates.append(fromCoord);
-        (void) coordinates.append(toCoord);
-        distanceBetween = finalDistanceBetween = coordinates[0].distanceTo(coordinates[1]);
+    QList<QGeoCoordinate> coordinates = QGCGeo::interpolatePath(fromCoord, toCoord, numPoints);
+
+    if (coordinates.size() >= 2) {
+        distanceBetween = QGCGeo::geodesicDistance(coordinates[0], coordinates[1]);
+        finalDistanceBetween = QGCGeo::geodesicDistance(coordinates[coordinates.size() - 2], coordinates.last());
     } else {
-        for (int i = 0; i <= steps; i++) {
-            const double latStep = lat + ((latDiff * static_cast<double>(i)) / static_cast<double>(steps));
-            const double lonStep = lon + ((lonDiff * static_cast<double>(i)) / static_cast<double>(steps));
-            (void) coordinates.append(QGeoCoordinate(latStep, lonStep));
-        }
-
-        // We always have one too many and we always want the last one to be the endpoint
-        coordinates.last() = toCoord;
-        distanceBetween = coordinates[0].distanceTo(coordinates[1]);
-        finalDistanceBetween = coordinates[coordinates.count() - 2].distanceTo(coordinates.last());
+        distanceBetween = finalDistanceBetween = totalDistance;
     }
 
-    qCDebug(TerrainTileManagerLog) << "fromCoord:toCoord:distanceBetween:finalDisanceBetween:coordCount" << fromCoord << toCoord << distanceBetween << finalDistanceBetween << coordinates.count();
+    qCDebug(TerrainTileManagerLog) << "fromCoord:toCoord:distanceBetween:finalDistanceBetween:coordCount"
+                                   << fromCoord << toCoord << distanceBetween << finalDistanceBetween << coordinates.count();
 
     return coordinates;
 }

--- a/src/Utilities/Geo/CMakeLists.txt
+++ b/src/Utilities/Geo/CMakeLists.txt
@@ -27,9 +27,9 @@ target_include_directories(${CMAKE_PROJECT_NAME} PRIVATE ${CMAKE_CURRENT_SOURCE_
 
 CPMAddPackage(
     NAME geographiclib
-    VERSION 2.5
+    VERSION 2.7
     GITHUB_REPOSITORY geographiclib/geographiclib
-    GIT_TAG r2.5
+    GIT_TAG r2.7
     OPTIONS
         "BUILD_BOTH_LIBS OFF"
         "BUILD_DOCUMENTATION OFF"
@@ -48,9 +48,6 @@ CPMAddPackage(
         "EXAMPLEDIR OFF"
     PATCHES geographiclib.patch
 )
-
-# Suppress MSVC warnings in GeographicLib
-target_compile_options(GeographicLib_STATIC PRIVATE $<$<CXX_COMPILER_ID:MSVC>:/wd9025>)
 
 target_link_libraries(${CMAKE_PROJECT_NAME} PRIVATE GeographicLib::GeographicLib)
 

--- a/src/Utilities/Geo/QGCGeo.cc
+++ b/src/Utilities/Geo/QGCGeo.cc
@@ -1,87 +1,149 @@
-// TODO: Use GeoCoords from GeographicLib?
+/****************************************************************************
+ *
+ * (c) 2009-2024 QGROUNDCONTROL PROJECT <http://www.qgroundcontrol.org>
+ *
+ * QGroundControl is licensed according to the terms in the file
+ * COPYING.md in the root of the source code directory.
+ *
+ ****************************************************************************/
 
 #include "QGCGeo.h"
 #include "QGCLoggingCategory.h"
 
 #include <QtCore/QString>
-#include <QtCore/QtMath>
 
-#include <GeographicLib/Constants.hpp>
+#include <cmath>
+
 #include <GeographicLib/Geocentric.hpp>
+#include <GeographicLib/Geodesic.hpp>
+#include <GeographicLib/GeodesicLine.hpp>
 #include <GeographicLib/LocalCartesian.hpp>
 #include <GeographicLib/MGRS.hpp>
+#include <GeographicLib/PolygonArea.hpp>
 #include <GeographicLib/UTMUPS.hpp>
 
-#include <limits>
-
 QGC_LOGGING_CATEGORY(QGCGeoLog, "Utilities.QGCGeo")
-
-namespace
-{
-    constexpr double epsilon = std::numeric_limits<double>::epsilon();
-}
 
 namespace QGCGeo
 {
 
+// ============================================================================
+// NED (North-East-Down) Local Tangent Plane
+// ============================================================================
+
 void convertGeoToNed(const QGeoCoordinate &coord, const QGeoCoordinate &origin, double &x, double &y, double &z)
 {
     if (coord == origin) {
-        // Prevent NaNs in calculation
-        x = y = z = 0;
+        x = y = z = 0.0;
         return;
     }
 
-    const double lat_rad = qDegreesToRadians(coord.latitude());
-    const double lon_rad = qDegreesToRadians(coord.longitude());
+    // Handle NaN altitude (QGeoCoordinate without altitude set)
+    const double originAlt = std::isnan(origin.altitude()) ? 0.0 : origin.altitude();
+    const double coordAlt = std::isnan(coord.altitude()) ? 0.0 : coord.altitude();
 
-    const double ref_lon_rad = qDegreesToRadians(origin.longitude());
-    const double ref_lat_rad = qDegreesToRadians(origin.latitude());
+    double east, north, up;
+    GeographicLib::LocalCartesian ltp(origin.latitude(), origin.longitude(), originAlt,
+                                      GeographicLib::Geocentric::WGS84());
+    ltp.Forward(coord.latitude(), coord.longitude(), coordAlt, east, north, up);
 
-    const double sin_lat = sin(lat_rad);
-    const double cos_lat = cos(lat_rad);
-    const double cos_d_lon = cos(lon_rad - ref_lon_rad);
-
-    const double ref_sin_lat = sin(ref_lat_rad);
-    const double ref_cos_lat = cos(ref_lat_rad);
-
-    const double c = acos(ref_sin_lat * sin_lat + ref_cos_lat * cos_lat * cos_d_lon);
-    const double k = (fabs(c) < epsilon) ? 1.0 : (c / sin(c));
-
-    x = k * (ref_cos_lat * sin_lat - ref_sin_lat * cos_lat * cos_d_lon) * GeographicLib::Constants::WGS84_a();
-    y = k * cos_lat * sin(lon_rad - ref_lon_rad) * GeographicLib::Constants::WGS84_a();
-    z = -(coord.altitude() - origin.altitude());
+    // Convert ENU to NED
+    x = north;
+    y = east;
+    z = -up;
 }
 
 void convertNedToGeo(double x, double y, double z, const QGeoCoordinate &origin, QGeoCoordinate &coord)
 {
-    const double x_rad = x / GeographicLib::Constants::WGS84_a();
-    const double y_rad = y / GeographicLib::Constants::WGS84_a();
-    const double c = sqrt(x_rad * x_rad + y_rad * y_rad);
-    const double sin_c = sin(c);
-    const double cos_c = cos(c);
+    // Convert NED to ENU
+    const double east = y;
+    const double north = x;
+    const double up = -z;
 
-    const double ref_lon_rad = qDegreesToRadians(origin.longitude());
-    const double ref_lat_rad = qDegreesToRadians(origin.latitude());
+    // Handle NaN altitude
+    const double originAlt = std::isnan(origin.altitude()) ? 0.0 : origin.altitude();
 
-    const double ref_sin_lat = sin(ref_lat_rad);
-    const double ref_cos_lat = cos(ref_lat_rad);
+    double lat, lon, alt;
+    GeographicLib::LocalCartesian ltp(origin.latitude(), origin.longitude(), originAlt,
+                                      GeographicLib::Geocentric::WGS84());
+    ltp.Reverse(east, north, up, lat, lon, alt);
 
-    double lat_rad;
-    double lon_rad;
-
-    if (fabs(c) > epsilon) {
-        lat_rad = asin(cos_c * ref_sin_lat + (x_rad * sin_c * ref_cos_lat) / c);
-        lon_rad = (ref_lon_rad + atan2(y_rad * sin_c, c * ref_cos_lat * cos_c - x_rad * ref_sin_lat * sin_c));
-    } else {
-        lat_rad = ref_lat_rad;
-        lon_rad = ref_lon_rad;
-    }
-
-    coord.setLatitude(qRadiansToDegrees(lat_rad));
-    coord.setLongitude(qRadiansToDegrees(lon_rad));
-    coord.setAltitude(-z + origin.altitude());
+    coord.setLatitude(lat);
+    coord.setLongitude(lon);
+    coord.setAltitude(alt);
 }
+
+// ============================================================================
+// ENU (East-North-Up) Local Tangent Plane
+// ============================================================================
+
+QVector3D convertGpsToEnu(const QGeoCoordinate &coord, const QGeoCoordinate &ref)
+{
+    double x, y, z;
+    GeographicLib::LocalCartesian ltp(ref.latitude(), ref.longitude(), ref.altitude(),
+                                      GeographicLib::Geocentric::WGS84());
+    ltp.Forward(coord.latitude(), coord.longitude(), coord.altitude(), x, y, z);
+    return QVector3D(x, y, z);
+}
+
+QGeoCoordinate convertEnuToGps(const QVector3D &enu, const QGeoCoordinate &ref)
+{
+    double lat, lon, alt;
+    GeographicLib::LocalCartesian ltp(ref.latitude(), ref.longitude(), ref.altitude(),
+                                      GeographicLib::Geocentric::WGS84());
+    ltp.Reverse(enu.x(), enu.y(), enu.z(), lat, lon, alt);
+    return QGeoCoordinate(lat, lon, alt);
+}
+
+// ============================================================================
+// ECEF (Earth-Centered Earth-Fixed)
+// ============================================================================
+
+QVector3D convertGeodeticToEcef(const QGeoCoordinate &coord)
+{
+    double x, y, z;
+    GeographicLib::Geocentric::WGS84().Forward(coord.latitude(), coord.longitude(), coord.altitude(), x, y, z);
+    return QVector3D(x, y, z);
+}
+
+QGeoCoordinate convertEcefToGeodetic(const QVector3D &ecef)
+{
+    double lat, lon, alt;
+    GeographicLib::Geocentric::WGS84().Reverse(ecef.x(), ecef.y(), ecef.z(), lat, lon, alt);
+    return QGeoCoordinate(lat, lon, alt);
+}
+
+QVector3D convertEcefToEnu(const QVector3D &ecef, const QGeoCoordinate &ref)
+{
+    // ECEF -> Geodetic
+    double lat, lon, h;
+    GeographicLib::Geocentric::WGS84().Reverse(ecef.x(), ecef.y(), ecef.z(), lat, lon, h);
+
+    // Geodetic -> ENU
+    double x, y, z;
+    GeographicLib::LocalCartesian ltp(ref.latitude(), ref.longitude(), ref.altitude(),
+                                      GeographicLib::Geocentric::WGS84());
+    ltp.Forward(lat, lon, h, x, y, z);
+    return QVector3D(x, y, z);
+}
+
+QVector3D convertEnuToEcef(const QVector3D &enu, const QGeoCoordinate &ref)
+{
+    // ENU -> Geodetic
+    double lat, lon, h;
+    GeographicLib::LocalCartesian ltp(ref.latitude(), ref.longitude(), ref.altitude(),
+                                      GeographicLib::Geocentric::WGS84());
+    ltp.Reverse(enu.x(), enu.y(), enu.z(), lat, lon, h);
+
+    // Geodetic -> ECEF
+    double x, y, z;
+    GeographicLib::Geocentric::WGS84().Forward(lat, lon, h, x, y, z);
+    return QVector3D(x, y, z);
+}
+
+// ============================================================================
+// UTM (Universal Transverse Mercator)
+// ============================================================================
 
 int convertGeoToUTM(const QGeoCoordinate &coord, double &easting, double &northing)
 {
@@ -90,7 +152,7 @@ int convertGeoToUTM(const QGeoCoordinate &coord, double &easting, double &northi
         bool northp;
         GeographicLib::UTMUPS::Forward(coord.latitude(), coord.longitude(), zone, northp, easting, northing);
         return zone;
-    } catch(const GeographicLib::GeographicErr &e) {
+    } catch (const GeographicLib::GeographicErr &e) {
         qCDebug(QGCGeoLog) << e.what();
         return 0;
     }
@@ -98,145 +160,208 @@ int convertGeoToUTM(const QGeoCoordinate &coord, double &easting, double &northi
 
 bool convertUTMToGeo(double easting, double northing, int zone, bool southhemi, QGeoCoordinate &coord)
 {
-    double lat, lon;
-
     try {
+        double lat, lon;
         GeographicLib::UTMUPS::Reverse(zone, !southhemi, easting, northing, lat, lon);
-    } catch(const GeographicLib::GeographicErr &e) {
+        coord.setLatitude(lat);
+        coord.setLongitude(lon);
+        return true;
+    } catch (const GeographicLib::GeographicErr &e) {
         qCDebug(QGCGeoLog) << e.what();
         return false;
     }
-
-    coord.setLatitude(lat);
-    coord.setLongitude(lon);
-
-    return true;
 }
+
+// ============================================================================
+// MGRS (Military Grid Reference System)
+// ============================================================================
 
 QString convertGeoToMGRS(const QGeoCoordinate &coord)
 {
-    std::string mgrs;
-
     try {
         int zone;
         bool northp;
         double x, y;
         GeographicLib::UTMUPS::Forward(coord.latitude(), coord.longitude(), zone, northp, x, y);
+
+        std::string mgrs;
         GeographicLib::MGRS::Forward(zone, northp, x, y, coord.latitude(), 5, mgrs);
-    } catch(const GeographicLib::GeographicErr &e) {
-        qCDebug(QGCGeoLog) << e.what();
-        mgrs = "";
-    }
 
-    const QString qstr = QString::fromStdString(mgrs);
-    for (int i = qstr.length() - 1; i >= 0; i--) {
-        if (!qstr.at(i).isDigit()) {
-            const int l = (qstr.length() - i) / 2;
-            return (qstr.left(i + 1) + " " + qstr.mid(i + 1, l) + " " + qstr.mid(i + 1 + l));
+        // Format with spaces: "32TMT6588647092" -> "32TMT 65886 47092"
+        const QString qstr = QString::fromStdString(mgrs);
+        for (int i = qstr.length() - 1; i >= 0; i--) {
+            if (!qstr.at(i).isDigit()) {
+                const int numLen = (qstr.length() - i - 1) / 2;
+                return qstr.left(i + 1) + " " + qstr.mid(i + 1, numLen) + " " + qstr.mid(i + 1 + numLen);
+            }
         }
+        return qstr;
+    } catch (const GeographicLib::GeographicErr &e) {
+        qCDebug(QGCGeoLog) << e.what();
+        return QString();
     }
-
-    return qstr;
 }
 
 bool convertMGRSToGeo(const QString &mgrs, QGeoCoordinate &coord)
 {
-    double lat, lon;
-
     try {
         int zone, prec;
         bool northp;
         double x, y;
         GeographicLib::MGRS::Reverse(mgrs.simplified().replace(" ", "").toStdString(), zone, northp, x, y, prec);
+
+        double lat, lon;
         GeographicLib::UTMUPS::Reverse(zone, northp, x, y, lat, lon);
-    } catch(const GeographicLib::GeographicErr &e) {
+
+        coord.setLatitude(lat);
+        coord.setLongitude(lon);
+        return true;
+    } catch (const GeographicLib::GeographicErr &e) {
         qCDebug(QGCGeoLog) << e.what();
         return false;
     }
-
-    coord.setLatitude(lat);
-    coord.setLongitude(lon);
-
-    return true;
 }
 
-QVector3D convertGeodeticToEcef(const QGeoCoordinate &llh)
+// ============================================================================
+// Geodesic Calculations (Great Circle on Ellipsoid)
+// ============================================================================
+
+double geodesicDistance(const QGeoCoordinate &from, const QGeoCoordinate &to)
 {
-    double x, y, z;
-    GeographicLib::Geocentric::WGS84().Forward(
-        llh.latitude(), llh.longitude(), llh.altitude(),
-        x, y, z);
-
-    const QVector3D out_point(x, y, z);
-    return out_point;
+    double distance;
+    GeographicLib::Geodesic::WGS84().Inverse(from.latitude(), from.longitude(),
+                                             to.latitude(), to.longitude(), distance);
+    return distance;
 }
 
-QGeoCoordinate convertEcefToGeodetic(const QVector3D &ecef)
+double geodesicAzimuth(const QGeoCoordinate &from, const QGeoCoordinate &to)
 {
-    double lat, lon, alt;
-    GeographicLib::Geocentric::WGS84().Reverse(
-        ecef.x(), ecef.y(), ecef.z(),
-        lat, lon, alt);
+    double distance, azimuth1, azimuth2;
+    GeographicLib::Geodesic::WGS84().Inverse(from.latitude(), from.longitude(),
+                                             to.latitude(), to.longitude(), distance, azimuth1, azimuth2);
 
-    const QGeoCoordinate out_point(lat, lon, alt);
-    return out_point;
+    // Normalize to [0, 360)
+    if (azimuth1 < 0.0) {
+        azimuth1 += 360.0;
+    }
+    return azimuth1;
 }
 
-QVector3D convertEcefToEnu(const QVector3D &ecef, const QGeoCoordinate &ref)
+QGeoCoordinate geodesicDestination(const QGeoCoordinate &from, double azimuth, double distance)
 {
-    double lat, lon, h;
-    GeographicLib::Geocentric::WGS84().Reverse(
-        ecef.x(), ecef.y(), ecef.z(), lat, lon, h);
-
-    double x, y, z;
-    GeographicLib::LocalCartesian(ref.latitude(),
-                                  ref.longitude(),
-                                  ref.altitude(),
-                                  GeographicLib::Geocentric::WGS84())
-        .Forward(lat, lon, h, x, y, z);
-
-    const QVector3D out_point(x, y, z);
-    return out_point;
+    double lat, lon;
+    GeographicLib::Geodesic::WGS84().Direct(from.latitude(), from.longitude(), azimuth, distance, lat, lon);
+    return QGeoCoordinate(lat, lon, from.altitude());
 }
 
-QVector3D convertEnuToEcef(const QVector3D &enu, const QGeoCoordinate &ref)
+// ============================================================================
+// Path and Polygon Calculations
+// ============================================================================
+
+double pathLength(const QList<QGeoCoordinate> &path)
 {
-    double lat, lon, h;
-    GeographicLib::LocalCartesian(ref.latitude(),
-                                  ref.longitude(),
-                                  ref.altitude(),
-                                  GeographicLib::Geocentric::WGS84())
-        .Reverse(enu.x(), enu.y(), enu.z(), lat, lon, h);
+    if (path.size() < 2) {
+        return 0.0;
+    }
 
-    double x, y, z;
-    GeographicLib::Geocentric::WGS84().Forward(lat, lon, h, x, y, z);
-
-    const QVector3D out_point(x, y, z);
-    return out_point;
+    double totalLength = 0.0;
+    for (int i = 1; i < path.size(); ++i) {
+        totalLength += geodesicDistance(path[i - 1], path[i]);
+    }
+    return totalLength;
 }
 
-QVector3D convertGpsToEnu(const QGeoCoordinate &llh, const QGeoCoordinate &ref)
+double polygonArea(const QList<QGeoCoordinate> &polygon)
 {
-    double x, y, z;
-    GeographicLib::LocalCartesian(
-        ref.latitude(), ref.longitude(), ref.altitude(),
-        GeographicLib::Geocentric::WGS84()
-    ).Forward(llh.latitude(), llh.longitude(), llh.altitude(), x, y, z);
+    if (polygon.size() < 3) {
+        return 0.0;
+    }
 
-    const QVector3D out_point(x, y, z);
-    return out_point;
+    GeographicLib::PolygonArea poly(GeographicLib::Geodesic::WGS84());
+    for (const QGeoCoordinate &coord : polygon) {
+        poly.AddPoint(coord.latitude(), coord.longitude());
+    }
+
+    double perimeter, area;
+    poly.Compute(false, true, perimeter, area);
+    return qAbs(area);
 }
 
-QGeoCoordinate convertEnuToGps(const QVector3D &enu, const QGeoCoordinate &ref)
+double polygonPerimeter(const QList<QGeoCoordinate> &polygon)
 {
-    double lat, lon, alt;
-    GeographicLib::LocalCartesian(
-        ref.latitude(), ref.longitude(), ref.altitude(),
-        GeographicLib::Geocentric::WGS84()
-    ).Reverse(enu.x(), enu.y(), enu.z(), lat, lon, alt);
+    if (polygon.size() < 2) {
+        return 0.0;
+    }
 
-    const QGeoCoordinate out_point(lat, lon, alt);
-    return out_point;
+    GeographicLib::PolygonArea poly(GeographicLib::Geodesic::WGS84());
+    for (const QGeoCoordinate &coord : polygon) {
+        poly.AddPoint(coord.latitude(), coord.longitude());
+    }
+
+    double perimeter, area;
+    poly.Compute(false, true, perimeter, area);
+    return perimeter;
 }
 
+QList<QGeoCoordinate> interpolatePath(const QGeoCoordinate &from, const QGeoCoordinate &to, int numPoints)
+{
+    QList<QGeoCoordinate> result;
+
+    if (numPoints < 2) {
+        numPoints = 2;
+    }
+
+    if (from == to) {
+        for (int i = 0; i < numPoints; ++i) {
+            result.append(from);
+        }
+        return result;
+    }
+
+    // Create GeodesicLine for efficient multi-point interpolation
+    const GeographicLib::GeodesicLine line = GeographicLib::Geodesic::WGS84().InverseLine(
+        from.latitude(), from.longitude(), to.latitude(), to.longitude());
+
+    const double totalDistance = line.Distance();
+    const double altDiff = to.altitude() - from.altitude();
+
+    for (int i = 0; i < numPoints; ++i) {
+        const double fraction = static_cast<double>(i) / (numPoints - 1);
+        const double distance = totalDistance * fraction;
+
+        double lat, lon;
+        line.Position(distance, lat, lon);
+
+        const double alt = from.altitude() + altDiff * fraction;
+        result.append(QGeoCoordinate(lat, lon, alt));
+    }
+
+    return result;
 }
+
+QGeoCoordinate interpolateAtDistance(const QGeoCoordinate &from, const QGeoCoordinate &to, double distance)
+{
+    if (from == to || distance <= 0.0) {
+        return from;
+    }
+
+    const GeographicLib::GeodesicLine line = GeographicLib::Geodesic::WGS84().InverseLine(
+        from.latitude(), from.longitude(), to.latitude(), to.longitude());
+
+    const double totalDistance = line.Distance();
+
+    if (distance >= totalDistance) {
+        return to;
+    }
+
+    double lat, lon;
+    line.Position(distance, lat, lon);
+
+    // Linear altitude interpolation
+    const double fraction = distance / totalDistance;
+    const double alt = from.altitude() + (to.altitude() - from.altitude()) * fraction;
+
+    return QGeoCoordinate(lat, lon, alt);
+}
+
+} // namespace QGCGeo

--- a/src/Utilities/Geo/QGCGeo.h
+++ b/src/Utilities/Geo/QGCGeo.h
@@ -1,4 +1,26 @@
+/****************************************************************************
+ *
+ * (c) 2009-2024 QGROUNDCONTROL PROJECT <http://www.qgroundcontrol.org>
+ *
+ * QGroundControl is licensed according to the terms in the file
+ * COPYING.md in the root of the source code directory.
+ *
+ ****************************************************************************/
+
 #pragma once
+
+/// @file
+/// @brief Geographic coordinate conversion utilities using GeographicLib.
+///
+/// Provides coordinate transformations between various reference frames:
+/// - Geodetic (lat/lon/alt) - WGS84 ellipsoid
+/// - NED (North/East/Down) - Local tangent plane
+/// - ENU (East/North/Up) - Local tangent plane
+/// - ECEF (Earth-Centered Earth-Fixed) - Cartesian
+/// - UTM (Universal Transverse Mercator)
+/// - MGRS (Military Grid Reference System)
+///
+/// All conversions use the WGS84 ellipsoid model for accuracy.
 
 #include <QtCore/QLoggingCategory>
 #include <QtGui/QVector3D>
@@ -9,101 +31,164 @@ Q_DECLARE_LOGGING_CATEGORY(QGCGeoLog)
 namespace QGCGeo
 {
 
-/**
- * @brief Project a geodetic coordinate on to local tangential plane (LTP) as coordinate with East,
- * North, and Down components in meters.
- * @param[in] coord Geodetic coordinate to project onto LTP.
- * @param[in] origin Geoedetic origin for LTP projection.
- * @param[out] x North component of coordinate in local plane.
- * @param[out] y East component of coordinate in local plane.
- * @param[out] z Down component of coordinate in local plane.
- */
+// ============================================================================
+// NED (North-East-Down) Local Tangent Plane
+// ============================================================================
+
+/// Convert geodetic coordinate to NED (North-East-Down) relative to origin.
+/// @param coord Geodetic coordinate to convert.
+/// @param origin Reference point for local tangent plane.
+/// @param[out] x North component in meters.
+/// @param[out] y East component in meters.
+/// @param[out] z Down component in meters (positive = below origin).
 void convertGeoToNed(const QGeoCoordinate &coord, const QGeoCoordinate &origin, double &x, double &y, double &z);
 
-/**
- * @brief Transform a local (East, North, and Down) coordinate into a geodetic coordinate.
- * @param[in] x North component of local coordinate in meters.
- * @param[in] x East component of local coordinate in meters.
- * @param[in] x Down component of local coordinate in meters.
- * @param[in] origin Geoedetic origin for LTP.
- * @param[out] coord Geodetic coordinate to hold result.
- */
+/// Convert NED (North-East-Down) coordinate to geodetic.
+/// @param x North component in meters.
+/// @param y East component in meters.
+/// @param z Down component in meters (positive = below origin).
+/// @param origin Reference point for local tangent plane.
+/// @param[out] coord Resulting geodetic coordinate.
 void convertNedToGeo(double x, double y, double z, const QGeoCoordinate &origin, QGeoCoordinate &coord);
 
-// LatLonToUTMXY
-// Converts a latitude/longitude pair to x and y coordinates in the
-// Universal Transverse Mercator projection.
-//
-// Inputs:
-//   lat - Latitude of the point, in radians.
-//   lon - Longitude of the point, in radians.
-//   zone - UTM zone to be used for calculating values for x and y.
-//          If zone is less than 1 or greater than 60, the routine
-//          will determine the appropriate zone from the value of lon.
-//
-// Outputs:
-//   x - The x coordinate (easting) of the computed point. (in meters)
-//   y - The y coordinate (northing) of the computed point. (in meters)
-//
-// Returns:
-//   The UTM zone used for calculating the values of x and y.
-//   If conversion failed the function returns 0
-int convertGeoToUTM(const QGeoCoordinate& coord, double &easting, double &northing);
+// ============================================================================
+// ENU (East-North-Up) Local Tangent Plane
+// ============================================================================
 
-// UTMXYToLatLon
-//
-// Converts x and y coordinates in the Universal Transverse Mercator//   The UTM zone parameter should be in the range [1,60].
+/// Convert geodetic coordinate to ENU (East-North-Up) relative to reference.
+/// @param coord Geodetic coordinate to convert.
+/// @param ref Reference point for local tangent plane.
+/// @return ENU vector in meters (x=East, y=North, z=Up).
+/// @note Uses float precision (QVector3D). For high precision, use NED functions.
+QVector3D convertGpsToEnu(const QGeoCoordinate &coord, const QGeoCoordinate &ref);
 
-// projection to a latitude/longitude pair.
-//
-// Inputs:
-// x - The easting of the point, in meters.
-// y - The northing of the point, in meters.
-// zone - The UTM zone in which the point lies.
-// southhemi - True if the point is in the southern hemisphere;
-//               false otherwise.
-//
-// Outputs:
-// lat - The latitude of the point, in radians.
-// lon - The longitude of the point, in radians.
-//
-// Returns:
-// The function returns true if conversion succeeded.
-bool convertUTMToGeo(double easting, double northing, int zone, bool southhemi, QGeoCoordinate &coord);
+/// Convert ENU (East-North-Up) coordinate to geodetic.
+/// @param enu ENU vector in meters (x=East, y=North, z=Up).
+/// @param ref Reference point for local tangent plane.
+/// @return Geodetic coordinate.
+QGeoCoordinate convertEnuToGps(const QVector3D &enu, const QGeoCoordinate &ref);
 
-// Converts a latitude/longitude pair to MGRS string
-//
-// Inputs:
-//   coord - Latitude, Longiture coordinate
-//
-// Returns:
-//   The MGRS coordinate string
-//   If conversion fails the function returns empty string
-QString convertGeoToMGRS(const QGeoCoordinate &coord);
+// ============================================================================
+// ECEF (Earth-Centered Earth-Fixed)
+// ============================================================================
 
-// Converts MGRS string to a latitude/longitude pair.
-//
-// Inputs:
-// mgrs - MGRS coordinate string
-//
-// Outputs:
-// lat - The latitude of the point, in radians.
-// lon - The longitude of the point, in radians.
-//
-// Returns:
-// The function returns true if conversion succeeded.
-bool convertMGRSToGeo(const QString &mgrs, QGeoCoordinate &coord);
+/// Convert geodetic coordinate to ECEF (Earth-Centered Earth-Fixed).
+/// @param coord Geodetic coordinate (lat/lon/alt).
+/// @return ECEF vector in meters.
+/// @note Uses float precision (QVector3D). Large coordinates may lose precision.
+QVector3D convertGeodeticToEcef(const QGeoCoordinate &coord);
 
-QVector3D convertGeodeticToEcef(const QGeoCoordinate &llh);
+/// Convert ECEF (Earth-Centered Earth-Fixed) to geodetic coordinate.
+/// @param ecef ECEF vector in meters.
+/// @return Geodetic coordinate (lat/lon/alt).
+QGeoCoordinate convertEcefToGeodetic(const QVector3D &ecef);
 
-QGeoCoordinate convertEcefToGeodetic(const QVector3D &xyz);
-
+/// Convert ECEF to ENU relative to a reference point.
+/// @param ecef ECEF vector in meters.
+/// @param ref Reference point for local tangent plane.
+/// @return ENU vector in meters.
 QVector3D convertEcefToEnu(const QVector3D &ecef, const QGeoCoordinate &ref);
 
+/// Convert ENU to ECEF relative to a reference point.
+/// @param enu ENU vector in meters.
+/// @param ref Reference point for local tangent plane.
+/// @return ECEF vector in meters.
 QVector3D convertEnuToEcef(const QVector3D &enu, const QGeoCoordinate &ref);
 
-QVector3D convertGpsToEnu(const QGeoCoordinate &llh, const QGeoCoordinate &ref);
+// ============================================================================
+// UTM (Universal Transverse Mercator)
+// ============================================================================
 
-QGeoCoordinate convertEnuToGps(const QVector3D &enu, const QGeoCoordinate &ref);
+/// Convert geodetic coordinate to UTM.
+/// @param coord Geodetic coordinate to convert.
+/// @param[out] easting UTM easting in meters.
+/// @param[out] northing UTM northing in meters.
+/// @return UTM zone (1-60), or 0 on failure.
+int convertGeoToUTM(const QGeoCoordinate &coord, double &easting, double &northing);
+
+/// Convert UTM to geodetic coordinate.
+/// @param easting UTM easting in meters.
+/// @param northing UTM northing in meters.
+/// @param zone UTM zone (1-60).
+/// @param southhemi True if southern hemisphere.
+/// @param[out] coord Resulting geodetic coordinate (altitude = 0).
+/// @return True on success, false on failure.
+bool convertUTMToGeo(double easting, double northing, int zone, bool southhemi, QGeoCoordinate &coord);
+
+// ============================================================================
+// MGRS (Military Grid Reference System)
+// ============================================================================
+
+/// Convert geodetic coordinate to MGRS string.
+/// @param coord Geodetic coordinate to convert.
+/// @return MGRS string (e.g., "32TMT 65886 47092"), or empty string on failure.
+QString convertGeoToMGRS(const QGeoCoordinate &coord);
+
+/// Convert MGRS string to geodetic coordinate.
+/// @param mgrs MGRS string (spaces optional, e.g., "32TMT6588647092" or "32T MT 65886 47092").
+/// @param[out] coord Resulting geodetic coordinate (altitude = 0).
+/// @return True on success, false on failure.
+bool convertMGRSToGeo(const QString &mgrs, QGeoCoordinate &coord);
+
+// ============================================================================
+// Geodesic Calculations (Great Circle on Ellipsoid)
+// ============================================================================
+
+/// Calculate geodesic distance between two coordinates using WGS84 ellipsoid.
+/// @param from Starting coordinate.
+/// @param to Ending coordinate.
+/// @return Distance in meters.
+/// @note More accurate than QGeoCoordinate::distanceTo() which uses spherical approximation.
+double geodesicDistance(const QGeoCoordinate &from, const QGeoCoordinate &to);
+
+/// Calculate geodesic azimuth (bearing) from one coordinate to another using WGS84 ellipsoid.
+/// @param from Starting coordinate.
+/// @param to Ending coordinate.
+/// @return Forward azimuth in degrees [0, 360), clockwise from north.
+/// @note More accurate than QGeoCoordinate::azimuthTo() which uses spherical approximation.
+double geodesicAzimuth(const QGeoCoordinate &from, const QGeoCoordinate &to);
+
+/// Calculate destination coordinate given start point, azimuth, and distance using WGS84 ellipsoid.
+/// @param from Starting coordinate.
+/// @param azimuth Forward azimuth in degrees, clockwise from north.
+/// @param distance Distance in meters.
+/// @return Destination coordinate (altitude copied from start).
+QGeoCoordinate geodesicDestination(const QGeoCoordinate &from, double azimuth, double distance);
+
+// ============================================================================
+// Path and Polygon Calculations
+// ============================================================================
+
+/// Calculate total geodesic length of a path using WGS84 ellipsoid.
+/// @param path List of coordinates defining the path.
+/// @return Total path length in meters, or 0 if fewer than 2 points.
+double pathLength(const QList<QGeoCoordinate> &path);
+
+/// Calculate geodesic area of a polygon using WGS84 ellipsoid.
+/// @param polygon List of coordinates defining the polygon vertices (automatically closed).
+/// @return Absolute area in square meters, or 0 if fewer than 3 points.
+/// @note More accurate than planar projection methods, especially for large polygons.
+double polygonArea(const QList<QGeoCoordinate> &polygon);
+
+/// Calculate geodesic perimeter of a polygon using WGS84 ellipsoid.
+/// @param polygon List of coordinates defining the polygon vertices (automatically closed).
+/// @return Perimeter in meters, or 0 if fewer than 2 points.
+double polygonPerimeter(const QList<QGeoCoordinate> &polygon);
+
+/// Interpolate evenly-spaced points along a geodesic path using WGS84 ellipsoid.
+/// @param from Starting coordinate.
+/// @param to Ending coordinate.
+/// @param numPoints Number of points to generate (must be >= 2).
+/// @return List of coordinates including start and end points, evenly spaced along the geodesic.
+/// @note Uses GeodesicLine internally for efficiency. Altitude is linearly interpolated.
+QList<QGeoCoordinate> interpolatePath(const QGeoCoordinate &from, const QGeoCoordinate &to, int numPoints);
+
+/// Get the coordinate at a specific distance along a geodesic path using WGS84 ellipsoid.
+/// @param from Starting coordinate.
+/// @param to Ending coordinate.
+/// @param distance Distance from start in meters (clamped to path length).
+/// @return Coordinate at the specified distance along the geodesic. Altitude is linearly interpolated.
+/// @note Useful for midpoint: interpolateAtDistance(from, to, geodesicDistance(from, to) / 2)
+QGeoCoordinate interpolateAtDistance(const QGeoCoordinate &from, const QGeoCoordinate &to, double distance);
 
 } // namespace QGCGeo

--- a/src/Utilities/Geo/geographiclib.patch
+++ b/src/Utilities/Geo/geographiclib.patch
@@ -1,25 +1,25 @@
 diff --git a/CMakeLists.txt b/CMakeLists.txt
-index 40d0b206..738d6c83 100644
+index 14b58cb..feb2de7 100644
 --- a/CMakeLists.txt
 +++ b/CMakeLists.txt
-@@ -452,32 +452,32 @@ if (WIN32)
+@@ -454,32 +454,32 @@ if (WIN32)
  endif ()
-
+ 
  # The list of tools (to be installed into, e.g., /usr/local/bin)
 -set (TOOLS CartConvert ConicProj GeodesicProj GeoConvert GeodSolve
 -  GeoidEval Gravity IntersectTool MagneticField Planimeter RhumbSolve
--  TransverseMercatorProj)
+-  TransverseMercatorProj Cart3Convert Conformal3Proj Geod3Solve)
 +# set (TOOLS CartConvert ConicProj GeodesicProj GeoConvert GeodSolve
 +#   GeoidEval Gravity IntersectTool MagneticField Planimeter RhumbSolve
-+#   TransverseMercatorProj)
++#   TransverseMercatorProj Cart3Convert Conformal3Proj Geod3Solve)
  # The list of scripts (to be installed into, e.g., /usr/local/sbin)
 -set (SCRIPTS geographiclib-get-geoids geographiclib-get-gravity
 -  geographiclib-get-magnetic)
 +# set (SCRIPTS geographiclib-get-geoids geographiclib-get-gravity
 +#   geographiclib-get-magnetic)
-
+ 
  set_property (GLOBAL PROPERTY USE_FOLDERS ON)
-
+ 
  # The list of subdirectories to process
  add_subdirectory (src)
  add_subdirectory (include/GeographicLib)
@@ -50,6 +50,6 @@ index 40d0b206..738d6c83 100644
 +# if (NOT RELEASE)
 +#   add_subdirectory (develop)
 +# endif ()
-
+ 
  # make exampleprograms does a fresh cmake configuration and so uses
  # find_package to find the just-built version of GeographicLib (via the

--- a/test/Utilities/Geo/GeoTest.cc
+++ b/test/Utilities/Geo/GeoTest.cc
@@ -6,6 +6,7 @@
 #include "GeoTest.h"
 #include "QGCGeo.h"
 
+#include <QtGui/QVector3D>
 #include <QtTest/QTest>
 
 static bool compareDoubles(double actual, double expected, double epsilon = 0.00001)
@@ -17,16 +18,17 @@ void GeoTest::_convertGeoToNed_test()
 {
     const QGeoCoordinate coord(47.364869, 8.594398, 0.0);
 
-    const double expectedX = -1282.58731618;
-    const double expectedY = 3490.85591324;
-    const double expectedZ = 0.;
+    // Expected values from WGS84 ellipsoidal model (LocalCartesian)
+    const double expectedX = -1280.954612;
+    const double expectedY = 3497.196961;
+    const double expectedZ = 1.085830;
 
     double x = 0., y = 0., z = 0.;
     QGCGeo::convertGeoToNed(coord, m_origin, x, y, z);
 
-    QVERIFY(compareDoubles(x, expectedX));
-    QVERIFY(compareDoubles(y, expectedY));
-    QVERIFY(compareDoubles(z, expectedZ));
+    QVERIFY(compareDoubles(x, expectedX, 0.01));
+    QVERIFY(compareDoubles(y, expectedY, 0.01));
+    QVERIFY(compareDoubles(z, expectedZ, 0.01));
 }
 
 void GeoTest::_convertGeoToNedAtOrigin_test()
@@ -48,17 +50,18 @@ void GeoTest::_convertGeoToNedAtOrigin_test()
 
 void GeoTest::_convertNedToGeo_test()
 {
-    const double x = -1282.58731618;
-    const double y = 3490.85591324;
-    const double z = 0.;
+    // Use values from WGS84 ellipsoidal model
+    const double x = -1280.954612;
+    const double y = 3497.196961;
+    const double z = 1.085830;
 
     QGeoCoordinate coord(0,0,0);
     QGCGeo::convertNedToGeo(x, y, z, m_origin, coord);
 
     QVERIFY(coord.isValid());
-    QVERIFY(compareDoubles(coord.latitude(), 47.364869));
-    QVERIFY(compareDoubles(coord.longitude(), 8.594398));
-    QVERIFY(compareDoubles(coord.altitude(), 0.0));
+    QVERIFY(compareDoubles(coord.latitude(), 47.364869, 0.00001));
+    QVERIFY(compareDoubles(coord.longitude(), 8.594398, 0.00001));
+    QVERIFY(compareDoubles(coord.altitude(), 0.0, 0.01));
 }
 
 void GeoTest::_convertNedToGeoAtOrigin_test()
@@ -127,4 +130,287 @@ void GeoTest::_convertMGRSToGeo_test()
     QVERIFY(compareDoubles(coord.latitude(), m_origin.latitude()));
     QVERIFY(compareDoubles(coord.longitude(), m_origin.longitude()));
     QVERIFY(compareDoubles(coord.altitude(), m_origin.altitude()));
+}
+
+void GeoTest::_convertGeodeticToEcef_test()
+{
+    const QGeoCoordinate coord(m_origin.latitude(), m_origin.longitude(), 100.0);
+
+    const QVector3D ecef = QGCGeo::convertGeodeticToEcef(coord);
+
+    // ECEF coordinates for ETH campus at 100m altitude
+    QVERIFY(compareDoubles(ecef.x(), 4278990.18, 1.0));
+    QVERIFY(compareDoubles(ecef.y(), 643172.29, 1.0));
+    QVERIFY(compareDoubles(ecef.z(), 4670276.60, 1.0));
+}
+
+void GeoTest::_convertEcefToGeodetic_test()
+{
+    const QVector3D ecef(4278990.18, 643172.29, 4670276.60);
+
+    const QGeoCoordinate coord = QGCGeo::convertEcefToGeodetic(ecef);
+
+    QVERIFY(coord.isValid());
+    QVERIFY(compareDoubles(coord.latitude(), m_origin.latitude(), 0.0001));
+    QVERIFY(compareDoubles(coord.longitude(), m_origin.longitude(), 0.0001));
+    QVERIFY(compareDoubles(coord.altitude(), 100.0, 1.0));
+}
+
+void GeoTest::_convertGpsToEnu_test()
+{
+    const QGeoCoordinate coord(47.364869, 8.594398, 50.0);
+
+    const QVector3D enu = QGCGeo::convertGpsToEnu(coord, m_origin);
+
+    // ENU: East, North, Up (WGS84 ellipsoidal)
+    QVERIFY(compareDoubles(enu.x(), 3497.22, 1.0));   // East
+    QVERIFY(compareDoubles(enu.y(), -1280.96, 1.0));  // North
+    QVERIFY(compareDoubles(enu.z(), 48.91, 0.1));     // Up (ellipsoidal height)
+}
+
+void GeoTest::_convertEnuToGps_test()
+{
+    const QVector3D enu(3497.22, -1280.96, 48.91);
+
+    const QGeoCoordinate coord = QGCGeo::convertEnuToGps(enu, m_origin);
+
+    QVERIFY(coord.isValid());
+    QVERIFY(compareDoubles(coord.latitude(), 47.364869, 0.0001));
+    QVERIFY(compareDoubles(coord.longitude(), 8.594398, 0.0001));
+    QVERIFY(compareDoubles(coord.altitude(), 50.0, 0.2));
+}
+
+void GeoTest::_convertEcefToEnu_test()
+{
+    // Convert a known geodetic point to ECEF first
+    const QGeoCoordinate coord(47.364869, 8.594398, 50.0);
+    const QVector3D ecef = QGCGeo::convertGeodeticToEcef(coord);
+
+    // Then convert ECEF to ENU relative to origin
+    const QVector3D enu = QGCGeo::convertEcefToEnu(ecef, m_origin);
+
+    // Note: QVector3D uses float, so ECEF round-trips have reduced precision
+    QVERIFY(compareDoubles(enu.x(), 3497.22, 2.0));   // East
+    QVERIFY(compareDoubles(enu.y(), -1280.96, 2.0));  // North
+    QVERIFY(compareDoubles(enu.z(), 48.91, 1.0));     // Up
+}
+
+void GeoTest::_convertEnuToEcef_test()
+{
+    const QVector3D enu(3497.22, -1280.96, 48.91);
+
+    const QVector3D ecef = QGCGeo::convertEnuToEcef(enu, m_origin);
+
+    // Convert back to geodetic to verify
+    // Note: QVector3D uses float, so ECEF round-trips have reduced precision
+    const QGeoCoordinate coord = QGCGeo::convertEcefToGeodetic(ecef);
+
+    QVERIFY(coord.isValid());
+    QVERIFY(compareDoubles(coord.latitude(), 47.364869, 0.001));
+    QVERIFY(compareDoubles(coord.longitude(), 8.594398, 0.001));
+    QVERIFY(compareDoubles(coord.altitude(), 50.0, 1.0));
+}
+
+void GeoTest::_geodesicDistance_test()
+{
+    // Test distance from ETH Zurich to Eiffel Tower (Paris)
+    const QGeoCoordinate zurich(47.3764, 8.5481, 0.0);
+    const QGeoCoordinate paris(48.8584, 2.2945, 0.0);
+
+    const double distance = QGCGeo::geodesicDistance(zurich, paris);
+
+    // Geodesic distance is approximately 493.7 km
+    QVERIFY(compareDoubles(distance, 493739.0, 100.0));
+
+    // Compare with Qt's spherical approximation to show difference
+    const double qtDistance = zurich.distanceTo(paris);
+    // Qt uses spherical model, should be slightly different
+    QVERIFY(qAbs(distance - qtDistance) < 2000.0); // Within 2km for this distance
+}
+
+void GeoTest::_geodesicAzimuth_test()
+{
+    // Test azimuth from ETH Zurich heading northwest to Paris
+    const QGeoCoordinate zurich(47.3764, 8.5481, 0.0);
+    const QGeoCoordinate paris(48.8584, 2.2945, 0.0);
+
+    const double azimuth = QGCGeo::geodesicAzimuth(zurich, paris);
+
+    // Azimuth is approximately 291.8 degrees (northwest)
+    QVERIFY(compareDoubles(azimuth, 291.8, 1.0));
+
+    // Test due north
+    const QGeoCoordinate north(48.3764, 8.5481, 0.0);
+    const double northAzimuth = QGCGeo::geodesicAzimuth(zurich, north);
+    QVERIFY(compareDoubles(northAzimuth, 0.0, 0.1));
+
+    // Test due east
+    const QGeoCoordinate east(47.3764, 9.5481, 0.0);
+    const double eastAzimuth = QGCGeo::geodesicAzimuth(zurich, east);
+    QVERIFY(compareDoubles(eastAzimuth, 90.0, 1.0));
+}
+
+void GeoTest::_geodesicDestination_test()
+{
+    const QGeoCoordinate start(47.3764, 8.5481, 100.0);
+
+    // Go 1000m north
+    const QGeoCoordinate northDest = QGCGeo::geodesicDestination(start, 0.0, 1000.0);
+    QVERIFY(northDest.isValid());
+    QVERIFY(northDest.latitude() > start.latitude());
+    QVERIFY(compareDoubles(northDest.longitude(), start.longitude(), 0.0001));
+    QVERIFY(compareDoubles(northDest.altitude(), start.altitude(), 0.01));
+
+    // Go 1000m east
+    const QGeoCoordinate eastDest = QGCGeo::geodesicDestination(start, 90.0, 1000.0);
+    QVERIFY(eastDest.isValid());
+    QVERIFY(compareDoubles(eastDest.latitude(), start.latitude(), 0.001));
+    QVERIFY(eastDest.longitude() > start.longitude());
+}
+
+void GeoTest::_geodesicRoundTrip_test()
+{
+    // Verify that destination + inverse gives back original distance/azimuth
+    const QGeoCoordinate start(47.3764, 8.5481, 0.0);
+    const double originalAzimuth = 45.0;
+    const double originalDistance = 5000.0;
+
+    // Calculate destination
+    const QGeoCoordinate dest = QGCGeo::geodesicDestination(start, originalAzimuth, originalDistance);
+
+    // Calculate distance and azimuth back
+    const double calculatedDistance = QGCGeo::geodesicDistance(start, dest);
+    const double calculatedAzimuth = QGCGeo::geodesicAzimuth(start, dest);
+
+    QVERIFY(compareDoubles(calculatedDistance, originalDistance, 0.01));
+    QVERIFY(compareDoubles(calculatedAzimuth, originalAzimuth, 0.0001));
+}
+
+void GeoTest::_pathLength_test()
+{
+    // Empty and single-point paths
+    QCOMPARE(QGCGeo::pathLength({}), 0.0);
+    QCOMPARE(QGCGeo::pathLength({m_origin}), 0.0);
+
+    // Simple path: origin -> 1km north -> 1km east
+    const QGeoCoordinate north = QGCGeo::geodesicDestination(m_origin, 0.0, 1000.0);
+    const QGeoCoordinate northEast = QGCGeo::geodesicDestination(north, 90.0, 1000.0);
+
+    const QList<QGeoCoordinate> path = {m_origin, north, northEast};
+    const double length = QGCGeo::pathLength(path);
+
+    // Should be approximately 2000m
+    QVERIFY(compareDoubles(length, 2000.0, 1.0));
+}
+
+void GeoTest::_polygonArea_test()
+{
+    // Fewer than 3 points
+    QCOMPARE(QGCGeo::polygonArea({}), 0.0);
+    QCOMPARE(QGCGeo::polygonArea({m_origin}), 0.0);
+    QCOMPARE(QGCGeo::polygonArea({m_origin, m_origin}), 0.0);
+
+    // Create a roughly 1km x 1km square
+    const QGeoCoordinate sw = m_origin;
+    const QGeoCoordinate nw = QGCGeo::geodesicDestination(sw, 0.0, 1000.0);
+    const QGeoCoordinate ne = QGCGeo::geodesicDestination(nw, 90.0, 1000.0);
+    const QGeoCoordinate se = QGCGeo::geodesicDestination(sw, 90.0, 1000.0);
+
+    const QList<QGeoCoordinate> square = {sw, nw, ne, se};
+    const double area = QGCGeo::polygonArea(square);
+
+    // Should be approximately 1,000,000 m² (1 km²)
+    QVERIFY(compareDoubles(area, 1000000.0, 1000.0)); // Within 0.1%
+}
+
+void GeoTest::_polygonPerimeter_test()
+{
+    // Fewer than 2 points
+    QCOMPARE(QGCGeo::polygonPerimeter({}), 0.0);
+    QCOMPARE(QGCGeo::polygonPerimeter({m_origin}), 0.0);
+
+    // Create a roughly 1km x 1km square
+    const QGeoCoordinate sw = m_origin;
+    const QGeoCoordinate nw = QGCGeo::geodesicDestination(sw, 0.0, 1000.0);
+    const QGeoCoordinate ne = QGCGeo::geodesicDestination(nw, 90.0, 1000.0);
+    const QGeoCoordinate se = QGCGeo::geodesicDestination(sw, 90.0, 1000.0);
+
+    const QList<QGeoCoordinate> square = {sw, nw, ne, se};
+    const double perimeter = QGCGeo::polygonPerimeter(square);
+
+    // Should be approximately 4000m
+    QVERIFY(compareDoubles(perimeter, 4000.0, 1.0));
+}
+
+void GeoTest::_interpolatePath_test()
+{
+    // Test with same start and end
+    const auto samePoints = QGCGeo::interpolatePath(m_origin, m_origin, 5);
+    QCOMPARE(samePoints.size(), 5);
+    for (const auto &coord : samePoints) {
+        QCOMPARE(coord, m_origin);
+    }
+
+    // Test with 2 points (minimum)
+    const QGeoCoordinate dest = QGCGeo::geodesicDestination(m_origin, 45.0, 10000.0);
+    const auto twoPoints = QGCGeo::interpolatePath(m_origin, dest, 2);
+    QCOMPARE(twoPoints.size(), 2);
+    QVERIFY(compareDoubles(twoPoints.first().latitude(), m_origin.latitude()));
+    QVERIFY(compareDoubles(twoPoints.first().longitude(), m_origin.longitude()));
+    QVERIFY(compareDoubles(twoPoints.last().latitude(), dest.latitude()));
+    QVERIFY(compareDoubles(twoPoints.last().longitude(), dest.longitude()));
+
+    // Test with 11 points (10 segments of 1000m each)
+    const QGeoCoordinate end = QGCGeo::geodesicDestination(m_origin, 0.0, 10000.0);
+    const auto elevenPoints = QGCGeo::interpolatePath(m_origin, end, 11);
+    QCOMPARE(elevenPoints.size(), 11);
+
+    // Each segment should be approximately 1000m
+    for (int i = 1; i < elevenPoints.size(); ++i) {
+        const double segmentDist = QGCGeo::geodesicDistance(elevenPoints[i - 1], elevenPoints[i]);
+        QVERIFY(compareDoubles(segmentDist, 1000.0, 0.1));
+    }
+
+    // Total path length should be 10000m
+    const double totalLen = QGCGeo::pathLength(elevenPoints);
+    QVERIFY(compareDoubles(totalLen, 10000.0, 0.1));
+
+    // Test altitude interpolation
+    const QGeoCoordinate startAlt(m_origin.latitude(), m_origin.longitude(), 100.0);
+    const QGeoCoordinate endAlt(end.latitude(), end.longitude(), 200.0);
+    const auto altPoints = QGCGeo::interpolatePath(startAlt, endAlt, 11);
+    QVERIFY(compareDoubles(altPoints[0].altitude(), 100.0, 0.01));
+    QVERIFY(compareDoubles(altPoints[5].altitude(), 150.0, 0.01));
+    QVERIFY(compareDoubles(altPoints[10].altitude(), 200.0, 0.01));
+}
+
+void GeoTest::_interpolateAtDistance_test()
+{
+    // Test at distance 0
+    const QGeoCoordinate dest = QGCGeo::geodesicDestination(m_origin, 0.0, 5000.0);
+    const auto atZero = QGCGeo::interpolateAtDistance(m_origin, dest, 0.0);
+    QVERIFY(compareDoubles(atZero.latitude(), m_origin.latitude()));
+    QVERIFY(compareDoubles(atZero.longitude(), m_origin.longitude()));
+
+    // Test at distance beyond end (should clamp to end)
+    const auto beyondEnd = QGCGeo::interpolateAtDistance(m_origin, dest, 10000.0);
+    QVERIFY(compareDoubles(beyondEnd.latitude(), dest.latitude()));
+    QVERIFY(compareDoubles(beyondEnd.longitude(), dest.longitude()));
+
+    // Test midpoint
+    const auto midpoint = QGCGeo::interpolateAtDistance(m_origin, dest, 2500.0);
+    const double distToMid = QGCGeo::geodesicDistance(m_origin, midpoint);
+    const double distFromMid = QGCGeo::geodesicDistance(midpoint, dest);
+    QVERIFY(compareDoubles(distToMid, 2500.0, 0.1));
+    QVERIFY(compareDoubles(distFromMid, 2500.0, 0.1));
+
+    // Test altitude interpolation at midpoint
+    const QGeoCoordinate startAlt(m_origin.latitude(), m_origin.longitude(), 0.0);
+    const QGeoCoordinate endAlt(dest.latitude(), dest.longitude(), 100.0);
+    const auto midAlt = QGCGeo::interpolateAtDistance(startAlt, endAlt, 2500.0);
+    QVERIFY(compareDoubles(midAlt.altitude(), 50.0, 0.1));
+
+    // Test same start and end
+    const auto same = QGCGeo::interpolateAtDistance(m_origin, m_origin, 100.0);
+    QCOMPARE(same, m_origin);
 }

--- a/test/Utilities/Geo/GeoTest.h
+++ b/test/Utilities/Geo/GeoTest.h
@@ -27,6 +27,25 @@ private slots:
     void _convertGeoToMGRS_test(void);
     void _convertMGRSToGeo_test(void);
 
+    void _convertGeodeticToEcef_test(void);
+    void _convertEcefToGeodetic_test(void);
+    void _convertGpsToEnu_test(void);
+    void _convertEnuToGps_test(void);
+    void _convertEcefToEnu_test(void);
+    void _convertEnuToEcef_test(void);
+
+    void _geodesicDistance_test(void);
+    void _geodesicAzimuth_test(void);
+    void _geodesicDestination_test(void);
+    void _geodesicRoundTrip_test(void);
+
+    void _pathLength_test(void);
+    void _polygonArea_test(void);
+    void _polygonPerimeter_test(void);
+
+    void _interpolatePath_test(void);
+    void _interpolateAtDistance_test(void);
+
 private:
      /// Use ETH campus (47.3764° N, 8.5481° E)
     const QGeoCoordinate m_origin{47.3764, 8.5481, 0.0};


### PR DESCRIPTION
## Summary
- Update GeographicLib from r2.5 to r2.7
- Refactor NED conversions to use LocalCartesian for improved accuracy
- Add geodesic calculation functions using WGS84 ellipsoid
- Update TerrainTileManager to use geodesic path interpolation

## New QGCGeo Functions

| Category | Functions |
|----------|-----------|
| Point-to-point | `geodesicDistance`, `geodesicAzimuth`, `geodesicDestination` |
| Path/Polygon | `pathLength`, `polygonArea`, `polygonPerimeter` |
| Interpolation | `interpolatePath`, `interpolateAtDistance` |

These provide more accurate calculations than Qt's spherical approximations, especially for:
- Longer paths (>50km)
- High-latitude operations
- East-West routes

## TerrainTileManager Update
Replaced linear lat/lon interpolation with geodesic interpolation for terrain path queries. This ensures terrain samples are taken along the actual flight path rather than a rhumb line approximation.

## Test plan
- [x] All 25 GeoTest unit tests pass
- [x] All 5 TerrainQueryTest unit tests pass
- [x] Build succeeds on Linux