### PR TITLE
ULogParser: Add streamed parsing for lower memory usage

### DIFF
--- a/src/AnalyzeView/CMakeLists.txt
+++ b/src/AnalyzeView/CMakeLists.txt
@@ -61,7 +61,7 @@ qt_add_qml_module(AnalyzeViewModule
 CPMAddPackage(
     NAME ulog_cpp
     GITHUB_REPOSITORY PX4/ulog_cpp
-    GIT_TAG main
+    GIT_TAG v1.0.1
 )
 
 # Suppress Clang warnings for ulog_cpp

--- a/src/AnalyzeView/GeoTagWorker.cc
+++ b/src/AnalyzeView/GeoTagWorker.cc
@@ -131,7 +131,7 @@ bool GeoTagWorker::_parseLogs()
     bool parseComplete = false;
     QString errorString;
     if (_logFile.endsWith(".ulg", Qt::CaseSensitive)) {
-        parseComplete = ULogParser::getTagsFromLog(log, _triggerList, errorString);
+        parseComplete = ULogParser::getTagsFromLogStreamed(log, _triggerList, errorString);
     } else {
         parseComplete = PX4LogParser::getTagsFromLog(log, _triggerList);
     }

--- a/src/AnalyzeView/ULogParser.cc
+++ b/src/AnalyzeView/ULogParser.cc
@@ -4,8 +4,13 @@
 #include <QtCore/QByteArray>
 #include <QtCore/QString>
 
+#include <cmath>
+#include <unordered_map>
+
 #include <ulog_cpp/data_container.hpp>
+#include <ulog_cpp/data_handler_interface.hpp>
 #include <ulog_cpp/reader.hpp>
+#include <ulog_cpp/subscription.hpp>
 
 using namespace ulog_cpp;
 
@@ -23,8 +28,8 @@ bool getTagsFromLog(const QByteArray &log, QList<GeoTagWorker::CameraFeedbackPac
 
     if (!data->parsingErrors().empty()) {
         for (const std::string &parsing_error : data->parsingErrors()) {
-            (void) errorMessage.append(parsing_error);
-            (void) errorMessage.append(", ");
+            (void) errorMessage.append(QString::fromStdString(parsing_error));
+            (void) errorMessage.append(QStringLiteral(", "));
         }
     }
 
@@ -61,6 +66,122 @@ bool getTagsFromLog(const QByteArray &log, QList<GeoTagWorker::CameraFeedbackPac
                 qCDebug(ULogParserLog) << Q_FUNC_INFO << exception.what();
             }
         }
+    }
+
+    if (cameraFeedback.isEmpty()) {
+        errorMessage = QStringLiteral("Could not detect camera_capture packets in ULog");
+        return false;
+    }
+
+    return true;
+}
+
+class CameraCaptureHandler : public DataHandlerInterface {
+public:
+    explicit CameraCaptureHandler(QList<GeoTagWorker::CameraFeedbackPacket> &packets, QString &errorMsg);
+
+    void error(const std::string &msg, bool is_recoverable) override;
+    void messageFormat(const MessageFormat &message_format) override;
+    void addLoggedMessage(const AddLoggedMessage &add_logged_message) override;
+    void headerComplete() override;
+    void data(const Data &data) override;
+
+    bool hadFatalError() const { return _hadFatalError; }
+    bool isHeaderComplete() const { return _headerComplete; }
+
+private:
+    QList<GeoTagWorker::CameraFeedbackPacket> &_cameraFeedback;
+    QString &_errorMessage;
+    std::shared_ptr<MessageFormat> _cameraCaptureFormat;
+    std::unordered_map<uint16_t, uint8_t> _cameraCaptureIds;
+    bool _hadFatalError = false;
+    bool _headerComplete = false;
+};
+
+CameraCaptureHandler::CameraCaptureHandler(QList<GeoTagWorker::CameraFeedbackPacket> &packets, QString &errorMsg)
+    : _cameraFeedback(packets)
+    , _errorMessage(errorMsg)
+{
+}
+
+void CameraCaptureHandler::error(const std::string &msg, bool is_recoverable)
+{
+    if (!is_recoverable) {
+        _hadFatalError = true;
+    }
+    (void) _errorMessage.append(QString::fromStdString(msg));
+    (void) _errorMessage.append(QStringLiteral(", "));
+}
+
+void CameraCaptureHandler::messageFormat(const MessageFormat &message_format)
+{
+    if (message_format.name() == "camera_capture") {
+        _cameraCaptureFormat = std::make_shared<MessageFormat>(message_format);
+    }
+}
+
+void CameraCaptureHandler::addLoggedMessage(const AddLoggedMessage &add_logged_message)
+{
+    if (add_logged_message.messageName() == "camera_capture" && _cameraCaptureFormat) {
+        _cameraCaptureIds[add_logged_message.msgId()] = add_logged_message.multiId();
+    }
+}
+
+void CameraCaptureHandler::headerComplete()
+{
+    _headerComplete = true;
+    if (_cameraCaptureFormat) {
+        _cameraCaptureFormat->resolveDefinition({{"camera_capture", _cameraCaptureFormat}});
+    }
+}
+
+void CameraCaptureHandler::data(const Data &data)
+{
+    if (!_headerComplete || !_cameraCaptureFormat) {
+        return;
+    }
+
+    auto it = _cameraCaptureIds.find(data.msgId());
+    if (it == _cameraCaptureIds.end()) {
+        return;
+    }
+
+    TypedDataView sample(data, *_cameraCaptureFormat);
+    GeoTagWorker::CameraFeedbackPacket feedback = {0};
+
+    try {
+        feedback.timestamp = sample.at("timestamp").as<uint64_t>() / 1.0e6;
+        feedback.timestampUTC = sample.at("timestamp_utc").as<uint64_t>() / 1.0e6;
+        feedback.imageSequence = sample.at("seq").as<uint32_t>();
+        feedback.latitude = sample.at("lat").as<double>();
+        feedback.longitude = sample.at("lon").as<double>();
+        feedback.longitude = fmod(180.0 + feedback.longitude, 360.0) - 180.0;
+        feedback.altitude = sample.at("alt").as<float>();
+        feedback.groundDistance = sample.at("ground_distance").as<float>();
+        feedback.captureResult = sample.at("result").as<uint8_t>();
+
+        (void) _cameraFeedback.append(feedback);
+    } catch (const AccessException &exception) {
+        qCDebug(ULogParserLog) << Q_FUNC_INFO << exception.what();
+    }
+}
+
+bool getTagsFromLogStreamed(const QByteArray &log, QList<GeoTagWorker::CameraFeedbackPacket> &cameraFeedback, QString &errorMessage)
+{
+    errorMessage.clear();
+
+    auto handler = std::make_shared<CameraCaptureHandler>(cameraFeedback, errorMessage);
+    Reader parser(handler);
+    parser.readChunk(reinterpret_cast<const uint8_t*>(log.constData()), log.size());
+
+    if (handler->hadFatalError()) {
+        errorMessage = QStringLiteral("Could not parse ULog");
+        return false;
+    }
+
+    if (!handler->isHeaderComplete()) {
+        errorMessage = QStringLiteral("Could not parse ULog header");
+        return false;
     }
 
     if (cameraFeedback.isEmpty()) {

--- a/src/AnalyzeView/ULogParser.h
+++ b/src/AnalyzeView/ULogParser.h
@@ -11,7 +11,11 @@ class QString;
 Q_DECLARE_LOGGING_CATEGORY(ULogParserLog)
 
 namespace ULogParser {
-    /// Get GeoTags from a ULog
+    /// Get GeoTags from a ULog (stores full log in memory)
     ///     @return true if failed, errorMessage set
     bool getTagsFromLog(const QByteArray &log, QList<GeoTagWorker::CameraFeedbackPacket> &cameraFeedback, QString &errorMessage);
+
+    /// Get GeoTags from a ULog using streamed parsing (lower memory usage)
+    ///     @return true if failed, errorMessage set
+    bool getTagsFromLogStreamed(const QByteArray &log, QList<GeoTagWorker::CameraFeedbackPacket> &cameraFeedback, QString &errorMessage);
 } // namespace ULogParser

--- a/test/AnalyzeView/CMakeLists.txt
+++ b/test/AnalyzeView/CMakeLists.txt
@@ -7,16 +7,16 @@ target_sources(${CMAKE_PROJECT_NAME}
     PRIVATE
         ExifParserTest.cc
         ExifParserTest.h
-        # GeoTagControllerTest.cc
-        # GeoTagControllerTest.h
+        GeoTagControllerTest.cc
+        GeoTagControllerTest.h
         LogDownloadTest.cc
         LogDownloadTest.h
         MavlinkLogTest.cc
         MavlinkLogTest.h
         PX4LogParserTest.cc
         PX4LogParserTest.h
-        # ULogParserTest.cc
-        # ULogParserTest.h
+        ULogParserTest.cc
+        ULogParserTest.h
 )
 
 target_include_directories(${CMAKE_PROJECT_NAME} PRIVATE ${CMAKE_CURRENT_SOURCE_DIR})
@@ -29,5 +29,5 @@ qt_add_resources(${CMAKE_PROJECT_NAME} "AnalyzeViewTest_res"
     PREFIX "/unittest"
     FILES
         DSCN0010.jpg
-        # SampleULog.ulg
+        SampleULog.ulg
 )

--- a/test/AnalyzeView/ULogParserTest.cc
+++ b/test/AnalyzeView/ULogParserTest.cc
@@ -4,13 +4,37 @@
 
 #include <QtTest/QTest>
 
+namespace {
+
+QByteArray loadSampleULog()
+{
+    QFile file(":/unittest/SampleULog.ulg");
+    if (!file.open(QIODevice::ReadOnly)) {
+        return QByteArray();
+    }
+    const QByteArray data = file.readAll();
+    file.close();
+    return data;
+}
+
+bool compareFeedbackPackets(const GeoTagWorker::CameraFeedbackPacket &a, const GeoTagWorker::CameraFeedbackPacket &b)
+{
+    return qFuzzyCompare(a.timestamp, b.timestamp) &&
+           qFuzzyCompare(a.timestampUTC, b.timestampUTC) &&
+           a.imageSequence == b.imageSequence &&
+           qFuzzyCompare(a.latitude, b.latitude) &&
+           qFuzzyCompare(a.longitude, b.longitude) &&
+           qFuzzyCompare(a.altitude, b.altitude) &&
+           qFuzzyCompare(a.groundDistance, b.groundDistance) &&
+           a.captureResult == b.captureResult;
+}
+
+} // namespace
+
 void ULogParserTest::_getTagsFromLogTest()
 {
-    QFile file(":/SampleULog.ulg");
-    QVERIFY(file.open(QIODevice::ReadOnly));
-
-    const QByteArray logBuffer = file.readAll();
-    file.close();
+    const QByteArray logBuffer = loadSampleULog();
+    QVERIFY(!logBuffer.isEmpty());
 
     QList<GeoTagWorker::CameraFeedbackPacket> cameraFeedback;
     QString errorMessage;
@@ -19,6 +43,75 @@ void ULogParserTest::_getTagsFromLogTest()
     QVERIFY(!cameraFeedback.isEmpty());
 
     const GeoTagWorker::CameraFeedbackPacket firstCameraFeedback = cameraFeedback.constFirst();
-    // QVERIFY(!qFuzzyIsNull(firstCameraFeedback.timestamp));
     QVERIFY(firstCameraFeedback.imageSequence != 0);
+}
+
+void ULogParserTest::_getTagsFromLogStreamedTest()
+{
+    const QByteArray logBuffer = loadSampleULog();
+    QVERIFY(!logBuffer.isEmpty());
+
+    QList<GeoTagWorker::CameraFeedbackPacket> cameraFeedback;
+    QString errorMessage;
+    QVERIFY(ULogParser::getTagsFromLogStreamed(logBuffer, cameraFeedback, errorMessage));
+    QVERIFY(errorMessage.isEmpty());
+    QVERIFY(!cameraFeedback.isEmpty());
+
+    const GeoTagWorker::CameraFeedbackPacket firstCameraFeedback = cameraFeedback.constFirst();
+    QVERIFY(firstCameraFeedback.imageSequence != 0);
+}
+
+void ULogParserTest::_compareStreamedAndNonStreamedTest()
+{
+    const QByteArray logBuffer = loadSampleULog();
+    QVERIFY(!logBuffer.isEmpty());
+
+    QList<GeoTagWorker::CameraFeedbackPacket> feedbackNonStreamed;
+    QList<GeoTagWorker::CameraFeedbackPacket> feedbackStreamed;
+    QString errorNonStreamed;
+    QString errorStreamed;
+
+    QVERIFY(ULogParser::getTagsFromLog(logBuffer, feedbackNonStreamed, errorNonStreamed));
+    QVERIFY(ULogParser::getTagsFromLogStreamed(logBuffer, feedbackStreamed, errorStreamed));
+
+    QCOMPARE(feedbackStreamed.size(), feedbackNonStreamed.size());
+
+    for (int i = 0; i < feedbackStreamed.size(); ++i) {
+        QVERIFY2(compareFeedbackPackets(feedbackStreamed[i], feedbackNonStreamed[i]),
+                 qPrintable(QStringLiteral("Packet %1 differs between streamed and non-streamed").arg(i)));
+    }
+}
+
+void ULogParserTest::_benchmarkNonStreamed()
+{
+    const QByteArray logBuffer = loadSampleULog();
+    QVERIFY(!logBuffer.isEmpty());
+
+    QList<GeoTagWorker::CameraFeedbackPacket> cameraFeedback;
+    QString errorMessage;
+
+    QBENCHMARK {
+        cameraFeedback.clear();
+        errorMessage.clear();
+        (void) ULogParser::getTagsFromLog(logBuffer, cameraFeedback, errorMessage);
+    }
+
+    QVERIFY(!cameraFeedback.isEmpty());
+}
+
+void ULogParserTest::_benchmarkStreamed()
+{
+    const QByteArray logBuffer = loadSampleULog();
+    QVERIFY(!logBuffer.isEmpty());
+
+    QList<GeoTagWorker::CameraFeedbackPacket> cameraFeedback;
+    QString errorMessage;
+
+    QBENCHMARK {
+        cameraFeedback.clear();
+        errorMessage.clear();
+        (void) ULogParser::getTagsFromLogStreamed(logBuffer, cameraFeedback, errorMessage);
+    }
+
+    QVERIFY(!cameraFeedback.isEmpty());
 }

--- a/test/AnalyzeView/ULogParserTest.h
+++ b/test/AnalyzeView/ULogParserTest.h
@@ -11,4 +11,8 @@ public:
 
 private slots:
     void _getTagsFromLogTest();
+    void _getTagsFromLogStreamedTest();
+    void _compareStreamedAndNonStreamedTest();
+    void _benchmarkNonStreamed();
+    void _benchmarkStreamed();
 };

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -62,11 +62,11 @@ add_qgc_test(ADSBTest)
 
 add_subdirectory(AnalyzeView)
 add_qgc_test(ExifParserTest)
-# add_qgc_test(GeoTagControllerTest)
+add_qgc_test(GeoTagControllerTest)
 add_qgc_test(LogDownloadTest)
 # add_qgc_test(MavlinkLogTest)
 add_qgc_test(PX4LogParserTest)
-# add_qgc_test(ULogParserTest)
+add_qgc_test(ULogParserTest)
 
 add_subdirectory(Camera)
 add_qgc_test(QGCCameraManagerTest)

--- a/test/UnitTestList.cc
+++ b/test/UnitTestList.cc
@@ -7,11 +7,11 @@
 
 // AnalyzeView
 #include "ExifParserTest.h"
-// #include "GeoTagControllerTest.h"
+#include "GeoTagControllerTest.h"
 // #include "MavlinkLogTest.h"
 #include "LogDownloadTest.h"
 #include "PX4LogParserTest.h"
-// #include "ULogParserTest.h"
+#include "ULogParserTest.h"
 
 // AutoPilotPlugins
 // #include "RadioConfigTest.h"
@@ -110,11 +110,11 @@ int QGCUnitTest::runTests(bool stress, const QStringList& unitTests)
 
     // AnalyzeView
     UT_REGISTER_TEST(ExifParserTest)
-    // UT_REGISTER_TEST(GeoTagControllerTest)
+    UT_REGISTER_TEST(GeoTagControllerTest)
     // UT_REGISTER_TEST(MavlinkLogTest)
     UT_REGISTER_TEST(LogDownloadTest)
     UT_REGISTER_TEST(PX4LogParserTest)
-    // UT_REGISTER_TEST(ULogParserTest)
+    UT_REGISTER_TEST(ULogParserTest)
 
     // AutoPilotPlugins
     // UT_REGISTER_TEST(RadioConfigTest)


### PR DESCRIPTION
## Summary
Add streamed parsing to ULogParser to reduce memory usage when processing large ULog files.

## Changes
- Implement streaming/chunked parsing instead of loading entire file into memory
- Reduce peak memory usage for large log files
- Maintain backward compatibility with existing API

## Test plan
- [ ] Parse small ULog files
- [ ] Parse large ULog files (>100MB)
- [ ] Verify memory usage is reduced
- [ ] Verify parsed data matches non-streaming version