### PR TITLE
Mission bulk displacement

### DIFF
--- a/src/MissionManager/CorridorScanComplexItem.cc
+++ b/src/MissionManager/CorridorScanComplexItem.cc
@@ -154,6 +154,25 @@ bool CorridorScanComplexItem::specifiesCoordinate(void) const
     return _corridorPolyline.count() > 1;
 }
 
+void CorridorScanComplexItem::setCoordinate(const QGeoCoordinate& coordinate)
+{
+    if (!coordinate.isValid() || !_entryCoordinate.isValid() || _corridorPolyline.count() < 2) {
+        return;
+    }
+
+    const double distanceMeters = _entryCoordinate.distanceTo(coordinate);
+    const double azimuthDegrees = _entryCoordinate.azimuthTo(coordinate);
+    const QList<QGeoCoordinate> vertices = _corridorPolyline.coordinateList();
+
+    QList<QGeoCoordinate> translatedVertices;
+    translatedVertices.reserve(vertices.count());
+    for (const QGeoCoordinate& vertex: vertices) {
+        translatedVertices.append(vertex.atDistanceAndAzimuth(distanceMeters, azimuthDegrees));
+    }
+
+    _corridorPolyline.setPath(translatedVertices);
+}
+
 int CorridorScanComplexItem::_calcTransectCount(void) const
 {
     double fullWidth = _corridorWidthFact.rawValue().toDouble();

--- a/src/MissionManager/CorridorScanComplexItem.h
+++ b/src/MissionManager/CorridorScanComplexItem.h
@@ -52,6 +52,7 @@ public:
     QString             commandDescription  (void) const final { return tr("Corridor Scan"); }
     QString             commandName         (void) const final { return tr("Corridor Scan"); }
     QString             abbreviation        (void) const final { return tr("C"); }
+    void                setCoordinate       (const QGeoCoordinate& coordinate) final;
     ReadyForSaveState   readyForSaveState   (void) const final;
     double              additionalTimeDelay (void) const final { return 0; }
 

--- a/src/MissionManager/LandingComplexItem.cc
+++ b/src/MissionManager/LandingComplexItem.cc
@@ -41,6 +41,12 @@ void LandingComplexItem::_init(void)
 
     connect(useLoiterToAlt(),           &Fact::rawValueChanged,                             this, &LandingComplexItem::_recalcFromApproachModeChange);
 
+    connect(this,                       &LandingComplexItem::finalApproachCoordinateChanged,this, &LandingComplexItem::entryCoordinateChanged);
+    connect(this,                       &LandingComplexItem::landingCoordinateChanged,      this, &LandingComplexItem::exitCoordinateChanged);
+
+    // The main coordinate is aliased to the exit (landing point) because that's the core of this complex item and the master for all transformations
+    connect(this,                       &LandingComplexItem::exitCoordinateChanged,         this, &LandingComplexItem::coordinateChanged);
+
     connect(this,                       &LandingComplexItem::finalApproachCoordinateChanged,this, &LandingComplexItem::_recalcFromCoordinateChange);
     connect(this,                       &LandingComplexItem::landingCoordinateChanged,      this, &LandingComplexItem::_recalcFromCoordinateChange);
 
@@ -109,11 +115,9 @@ void LandingComplexItem::setLandingCoordinate(const QGeoCoordinate& coordinate)
     if (coordinate != _landingCoordinate) {
         _landingCoordinate = coordinate;
         if (_landingCoordSet) {
-            emit exitCoordinateChanged(coordinate);
             emit landingCoordinateChanged(coordinate);
         } else {
             _ignoreRecalcSignals = true;
-            emit exitCoordinateChanged(coordinate);
             emit landingCoordinateChanged(coordinate);
             _ignoreRecalcSignals = false;
             _landingCoordSet = true;
@@ -127,7 +131,6 @@ void LandingComplexItem::setFinalApproachCoordinate(const QGeoCoordinate& coordi
 {
     if (coordinate != _finalApproachCoordinate) {
         _finalApproachCoordinate = coordinate;
-        emit coordinateChanged(coordinate);
         emit finalApproachCoordinateChanged(coordinate);
     }
 }
@@ -176,7 +179,6 @@ void LandingComplexItem::_recalcFromHeadingAndDistanceChange(void)
         _ignoreRecalcSignals = true;
         emit slopeStartCoordinateChanged(_slopeStartCoordinate);
         emit finalApproachCoordinateChanged(_finalApproachCoordinate);
-        emit coordinateChanged(_finalApproachCoordinate);
         _calcGlideSlope();
         _ignoreRecalcSignals = false;
     }
@@ -219,7 +221,6 @@ void LandingComplexItem::_recalcFromRadiusChange(void)
 
             _ignoreRecalcSignals = true;
             emit finalApproachCoordinateChanged(_finalApproachCoordinate);
-            emit coordinateChanged(_finalApproachCoordinate);
             _ignoreRecalcSignals = false;
         }
     }
@@ -252,7 +253,6 @@ void LandingComplexItem::_recalcFromApproachModeChange(void)
 
         _ignoreRecalcSignals = true;
         emit finalApproachCoordinateChanged(_finalApproachCoordinate);
-        emit coordinateChanged(_finalApproachCoordinate);
         _calcGlideSlope();
         _ignoreRecalcSignals = false;
     }
@@ -676,7 +676,6 @@ void LandingComplexItem::_updateFinalApproachCoodinateAltitudeFromFact(void)
 {
     _finalApproachCoordinate.setAltitude(finalApproachAltitude()->rawValue().toDouble());
     emit finalApproachCoordinateChanged(_finalApproachCoordinate);
-    emit coordinateChanged(_finalApproachCoordinate);
 }
 
 void LandingComplexItem::_updateLandingCoodinateAltitudeFromFact(void)
@@ -822,7 +821,9 @@ bool LandingComplexItem::_load(const QJsonObject& complexObject, int sequenceNum
     _ignoreRecalcSignals    = false;
 
     _recalcFromCoordinateChange();
-    emit coordinateChanged(this->coordinate());    // This will kick off terrain query
+    // These will kick off terrain query
+    emit finalApproachCoordinateChanged(_finalApproachCoordinate);
+    emit landingCoordinateChanged(_landingCoordinate);
 
     return true;
 }

--- a/src/MissionManager/LandingComplexItem.cc
+++ b/src/MissionManager/LandingComplexItem.cc
@@ -656,6 +656,11 @@ void LandingComplexItem::setSequenceNumber(int sequenceNumber)
     }
 }
 
+double LandingComplexItem::editableAlt() const
+{
+    return finalApproachAltitude()->rawValue().toDouble();
+}
+
 double LandingComplexItem::amslEntryAlt(void) const
 {
     return finalApproachAltitude()->rawValue().toDouble() + (_altitudesAreRelative ? _missionController->plannedHomePosition().altitude() : 0);

--- a/src/MissionManager/LandingComplexItem.h
+++ b/src/MissionManager/LandingComplexItem.h
@@ -89,7 +89,8 @@ public:
     QString             commandDescription          (void) const final { return "Landing Pattern"; }
     QString             commandName                 (void) const final { return "Landing Pattern"; }
     QString             abbreviation                (void) const final { return "L"; }
-    QGeoCoordinate      coordinate                  (void) const final { return _finalApproachCoordinate; }
+    QGeoCoordinate      coordinate                  (void) const final { return exitCoordinate(); }
+    QGeoCoordinate      entryCoordinate             (void) const final { return _finalApproachCoordinate; }
     QGeoCoordinate      exitCoordinate              (void) const final { return _landingCoordinate; }
     int                 sequenceNumber              (void) const final { return _sequenceNumber; }
     double              specifiedFlightSpeed        (void) final { return std::numeric_limits<double>::quiet_NaN(); }

--- a/src/MissionManager/LandingComplexItem.h
+++ b/src/MissionManager/LandingComplexItem.h
@@ -104,6 +104,7 @@ public:
     void                setDirty                    (bool dirty) final;
     void                setCoordinate               (const QGeoCoordinate& coordinate) final;
     void                setSequenceNumber           (int sequenceNumber) final;
+    double              editableAlt                 (void) const final;
     double              amslEntryAlt                (void) const final;
     double              amslExitAlt                 (void) const final;
     double              minAMSLAltitude             (void) const final { return amslExitAlt(); }

--- a/src/MissionManager/MissionController.cc
+++ b/src/MissionManager/MissionController.cc
@@ -26,6 +26,7 @@
 
 #include <QtCore/QJsonArray>
 #include <QtCore/QJsonDocument>
+#include <QtMath>
 
 #define UPDATE_TIMEOUT 5000 ///< How often we check for bounding box changes
 
@@ -2676,6 +2677,139 @@ void MissionController::setCurrentPlanViewSeqNum(int sequenceNumber, bool force)
         emit flyThroughCommandsAllowedChanged();
         emit previousCoordinateChanged();
     }
+}
+
+void MissionController::repositionMission(const QGeoCoordinate& newHome,
+                                          bool repositionTakeoffItems,
+                                          bool repositionLandingItems)
+{
+    if (!newHome.isValid()) {
+        qCWarning(MissionControllerLog) << "Cannot reposition mission to an invalid coordinate";
+        return;
+    }
+
+    if (!_settingsItem || !_settingsItem->coordinate().isValid()) {
+        qCWarning(MissionControllerLog) << "Cannot reposition mission while home is invalid";
+        return;
+    }
+
+    const QGeoCoordinate oldHome = _settingsItem->coordinate();
+
+    for (int i = 0; i < _visualItems->count(); ++i) {
+        auto* item = qobject_cast<VisualMissionItem*>(_visualItems->get(i));
+        if (!item || !item->specifiesCoordinate() || item->isStandaloneCoordinate()) {
+            continue;
+        }
+
+        if ((!repositionTakeoffItems && item->isTakeoffItem()) ||
+            (!repositionLandingItems && item->isLandCommand())) {
+            continue;
+        }
+
+        const QGeoCoordinate oldCoord = item->coordinate();
+        if (!oldCoord.isValid()) {
+            continue;
+        }
+
+        const double distanceMeters = oldHome.distanceTo(oldCoord);
+        const double azimuthDegrees = oldHome.azimuthTo(oldCoord);
+
+        QGeoCoordinate newCoord = newHome.atDistanceAndAzimuth(distanceMeters, azimuthDegrees);
+        item->setCoordinate(newCoord);
+    }
+
+    setDirty(true);
+}
+
+void MissionController::offsetMission(double eastMeters,
+                                      double northMeters,
+                                      double upMeters,
+                                      bool offsetTakeoffItems,
+                                      bool offsetLandingItems)
+{
+    if (!_settingsItem || !_settingsItem->coordinate().isValid()) {
+        qCWarning(MissionControllerLog) << "Cannot offset mission while home is invalid";
+        return;
+    }
+
+    if (!qFuzzyIsNull(eastMeters) || !qFuzzyIsNull(northMeters)) {
+        double distanceMeters = qSqrt(eastMeters * eastMeters + northMeters * northMeters);
+        double azimuthDegrees = 0.0;
+        if (!qFuzzyIsNull(distanceMeters)) {
+            const double azimuthRadians = qAtan2(eastMeters, northMeters);
+            azimuthDegrees = qRadiansToDegrees(azimuthRadians);
+        }
+
+        const QGeoCoordinate oldHome = _settingsItem->coordinate();
+        QGeoCoordinate newHome = oldHome.atDistanceAndAzimuth(distanceMeters, azimuthDegrees);
+        repositionMission(newHome, offsetTakeoffItems, offsetLandingItems);
+    }
+
+    if (!qFuzzyIsNull(upMeters)) {
+        for (int i = 0; i < _visualItems->count(); ++i) {
+            auto* item = qobject_cast<VisualMissionItem*>(_visualItems->get(i));
+            if (!item || item == _settingsItem) {
+                continue;
+            }
+
+            if ((!offsetTakeoffItems && item->isTakeoffItem()) ||
+                (!offsetLandingItems && item->isLandCommand())) {
+                continue;
+            }
+
+            if (!item->specifiesCoordinate() && !item->specifiesAltitudeOnly()) {
+                continue;
+            }
+
+            if (!qIsNaN(item->editableAlt())) {
+                item->applyNewAltitude(item->editableAlt() + upMeters);
+            }
+        }
+    }
+}
+
+void MissionController::rotateMission(double degreesCW,
+                                      bool rotateTakeoffItems,
+                                      bool rotateLandingItems)
+{
+    if (qFuzzyIsNull(degreesCW)) {
+        return;
+    }
+
+    if (!_settingsItem || !_settingsItem->coordinate().isValid()) {
+        qCWarning(MissionControllerLog) << "Cannot rotate mission while home is invalid";
+        return;
+    }
+
+    const QGeoCoordinate home = _settingsItem->coordinate();
+
+    for (int i = 0; i < _visualItems->count(); ++i) {
+        auto* item = qobject_cast<VisualMissionItem*>(_visualItems->get(i));
+        if (!item || !item->specifiesCoordinate() || item->isStandaloneCoordinate()) {
+            continue;
+        }
+
+        if ((!rotateTakeoffItems && item->isTakeoffItem()) ||
+            (!rotateLandingItems && item->isLandCommand())) {
+            continue;
+        }
+
+        const QGeoCoordinate oldCoord = item->coordinate();
+        if (!oldCoord.isValid()) {
+            continue;
+        }
+
+        const double distanceMeters = home.distanceTo(oldCoord);
+        if (qFuzzyIsNull(distanceMeters)) {
+            continue;
+        }
+        const double azimuthDegrees = home.azimuthTo(oldCoord);
+
+        QGeoCoordinate newCoord = home.atDistanceAndAzimuth(distanceMeters, azimuthDegrees + degreesCW);
+        item->setCoordinate(newCoord);
+    }
+
+    setDirty(true);
 }
 
 void MissionController::_updateTimeout()

--- a/src/MissionManager/MissionController.cc
+++ b/src/MissionManager/MissionController.cc
@@ -1113,7 +1113,7 @@ void MissionController::save(QJsonObject& json)
 
 void MissionController::_calcPrevWaypointValues(VisualMissionItem* currentItem, VisualMissionItem* prevItem, double* azimuth, double* distance, double* altDifference)
 {
-    QGeoCoordinate  currentCoord =  currentItem->coordinate();
+    QGeoCoordinate  currentCoord =  currentItem->entryCoordinate();
     QGeoCoordinate  prevCoord =     prevItem->exitCoordinate();
 
     // Convert to fixed altitudes
@@ -1125,7 +1125,7 @@ void MissionController::_calcPrevWaypointValues(VisualMissionItem* currentItem, 
 
 double MissionController::_calcDistanceToHome(VisualMissionItem* currentItem, VisualMissionItem* homeItem)
 {
-    QGeoCoordinate  currentCoord =  currentItem->coordinate();
+    QGeoCoordinate  currentCoord =  currentItem->entryCoordinate();
     QGeoCoordinate  homeCoord =     homeItem->exitCoordinate();
     bool            distanceOk =    false;
 
@@ -1141,7 +1141,7 @@ FlightPathSegment* MissionController::_createFlightPathSegmentWorker(VisualItemP
     bool                takeoffStraightUp   = pair.second->isTakeoffItem() && !_controllerVehicle->fixedWing();
 
     QGeoCoordinate      coord1              = pair.first->exitCoordinate();
-    QGeoCoordinate      coord2              = pair.second->coordinate();
+    QGeoCoordinate      coord2              = pair.second->entryCoordinate();
     double              coord2AMSLAlt       = pair.second->amslEntryAlt();
     double              coord1AMSLAlt       = takeoffStraightUp ? coord2AMSLAlt : pair.first->amslExitAlt();
 
@@ -1159,11 +1159,12 @@ FlightPathSegment* MissionController::_createFlightPathSegmentWorker(VisualItemP
     } else {
         connect(pair.first, &VisualMissionItem::amslExitAltChanged, segment, &FlightPathSegment::setCoord1AMSLAlt);
     }
-    connect(pair.first,  &VisualMissionItem::exitCoordinateChanged, segment,    &FlightPathSegment::setCoordinate1);
-    connect(pair.second, &VisualMissionItem::coordinateChanged,     segment,    &FlightPathSegment::setCoordinate2);
-    connect(pair.second, &VisualMissionItem::amslEntryAltChanged,   segment,    &FlightPathSegment::setCoord2AMSLAlt);
+    connect(pair.first,  &VisualMissionItem::exitCoordinateChanged,     segment,    &FlightPathSegment::setCoordinate1);
+    connect(pair.second, &VisualMissionItem::entryCoordinateChanged,    segment,    &FlightPathSegment::setCoordinate2);
+    connect(pair.second, &VisualMissionItem::amslEntryAltChanged,       segment,    &FlightPathSegment::setCoord2AMSLAlt);
 
-    connect(pair.second, &VisualMissionItem::coordinateChanged,         this,       &MissionController::_recalcMissionFlightStatusSignal, Qt::QueuedConnection);
+    connect(pair.second, &VisualMissionItem::entryCoordinateChanged,    this,       &MissionController::_recalcMissionFlightStatusSignal, Qt::QueuedConnection);
+    connect(pair.second, &VisualMissionItem::exitCoordinateChanged,     this,       &MissionController::_recalcMissionFlightStatusSignal, Qt::QueuedConnection);
 
     connect(segment,    &FlightPathSegment::totalDistanceChanged,       this,       &MissionController::recalcTerrainProfile,             Qt::QueuedConnection);
     connect(segment,    &FlightPathSegment::coord1AMSLAltChanged,       this,       &MissionController::_recalcMissionFlightStatusSignal, Qt::QueuedConnection);
@@ -1385,9 +1386,9 @@ void MissionController::_recalcFlightPathSegments(void)
             // Create a new segment. Since this is the fly view there is no need to wire change signals or worry about correct SegmentType
             coordVector = new FlightPathSegment(
                         FlightPathSegment::SegmentTypeGeneric,
-                        lastSegmentVisualItemPair.first->isSimpleItem() ? lastSegmentVisualItemPair.first->coordinate() : lastSegmentVisualItemPair.first->exitCoordinate(),
+                        lastSegmentVisualItemPair.first->isSimpleItem() ? lastSegmentVisualItemPair.first->entryCoordinate() : lastSegmentVisualItemPair.first->exitCoordinate(),
                         lastSegmentVisualItemPair.first->isSimpleItem() ? lastSegmentVisualItemPair.first->amslEntryAlt() : lastSegmentVisualItemPair.first->amslExitAlt(),
-                        lastSegmentVisualItemPair.second->coordinate(),
+                        lastSegmentVisualItemPair.second->entryCoordinate(),
                         lastSegmentVisualItemPair.second->amslEntryAlt(),
                         !_flyView /* queryTerrainData */,
                         this);
@@ -1593,7 +1594,7 @@ void MissionController::_recalcMissionFlightStatus()
                         if (qIsNaN(newVehicleYaw)) {
                             // No specific vehicle yaw set. Current vehicle yaw is determined from flight path segment direction.
                             if (simpleItem != lastFlyThroughVI) {
-                                _missionFlightStatus.vehicleYaw = lastFlyThroughVI->exitCoordinate().azimuthTo(simpleItem->coordinate());
+                                _missionFlightStatus.vehicleYaw = lastFlyThroughVI->exitCoordinate().azimuthTo(simpleItem->entryCoordinate());
                             }
                         } else {
                             _missionFlightStatus.vehicleYaw = newVehicleYaw;
@@ -1954,9 +1955,9 @@ void MissionController::_setPlannedHomePositionFromFirstCoordinate(const QGeoCoo
     for (int i=1; i<_visualItems->count(); i++) {
         VisualMissionItem* item = _visualItems->value<VisualMissionItem*>(i);
 
-        if (item->specifiesCoordinate() && item->coordinate().isValid()) {
+        if (item->specifiesCoordinate() && item->entryCoordinate().isValid()) {
             foundFirstCoordinate = true;
-            firstCoordinate = item->coordinate();
+            firstCoordinate = item->entryCoordinate();
             break;
         }
     }
@@ -2244,17 +2245,17 @@ void MissionController::_centerHomePositionOnMissionItems(QmlObjectListModel *vi
             VisualMissionItem* item = qobject_cast<VisualMissionItem*>(visualItems->get(i));
             if (item->specifiesCoordinate()) {
                 if (firstCoordSet) {
-                    double lat = _normalizeLat(item->coordinate().latitude());
-                    double lon = _normalizeLon(item->coordinate().longitude());
+                    double lat = _normalizeLat(item->entryCoordinate().latitude());
+                    double lon = _normalizeLon(item->entryCoordinate().longitude());
                     north = fmax(north, lat);
                     south = fmin(south, lat);
                     east  = fmax(east, lon);
                     west  = fmin(west, lon);
                 } else {
                     firstCoordSet = true;
-                    north = _normalizeLat(item->coordinate().latitude());
+                    north = _normalizeLat(item->entryCoordinate().latitude());
                     south = north;
-                    east  = _normalizeLon(item->coordinate().longitude());
+                    east  = _normalizeLon(item->entryCoordinate().longitude());
                     west  = east;
                 }
             }
@@ -2728,8 +2729,8 @@ void MissionController::_updateTimeout()
             if(pComplexItem) {
                 QGCGeoBoundingCube bc = pComplexItem->boundingCube();
                 if(bc.isValid()) {
-                    if(!firstCoordinate.isValid() && pComplexItem->coordinate().isValid()) {
-                        firstCoordinate = pComplexItem->coordinate();
+                    if(!firstCoordinate.isValid() && pComplexItem->entryCoordinate().isValid()) {
+                        firstCoordinate = pComplexItem->entryCoordinate();
                     }
                     north  = fmax(north, bc.pointNW.latitude()  + 90.0);
                     south  = fmin(south, bc.pointSE.latitude()  + 90.0);

--- a/src/MissionManager/MissionController.h
+++ b/src/MissionManager/MissionController.h
@@ -4,6 +4,7 @@
 #include <QtCore/QFile>
 #include <QtCore/QLoggingCategory>
 #include <QtCore/QPersistentModelIndex>
+#include <QtPositioning/QGeoCoordinate>
 #include <QtQmlIntegration/QtQmlIntegration>
 
 #include "PlanElementController.h"
@@ -181,6 +182,49 @@ public:
     ///     @param sequenceNumber - index for new item, -1 to clear current item
     ///     @param force - true: reset internals even if specified item is already selected
     Q_INVOKABLE void setCurrentPlanViewSeqNum(int sequenceNumber, bool force);
+
+    /// Repositions all mission items which specify a coordinate around a new
+    /// home coordinate. Requires a valid planned home position; otherwise the
+    /// mission is not modified and a warning is logged.
+    /// @param newHome New coordinate for the home item
+    /// @param repositionTakeoffItems If true, items identified as takeoff items
+    ///                               (isTakeoffItem) will be repositioned
+    /// @param repositionLandingItems If true, items identified as landing items
+    ///                               (isLandCommand) will be repositioned
+    Q_INVOKABLE void repositionMission(const QGeoCoordinate& newHome,
+                                       bool repositionTakeoffItems = true,
+                                       bool repositionLandingItems = true);
+
+    /// Offsets all mission items which specify a coordinate by the specified
+    /// ENU amounts in meters. Home altitude remains unchanged. Requires a valid
+    /// planned home position; otherwise the mission is not modified and a
+    /// warning is logged.
+    /// @param eastMeters Distance to offset items to the east, in meters
+    /// @param northMeters Distance to offset items to the north, in meters
+    /// @param upMeters Distance to offset items upwards, in meters
+    /// @param offsetTakeoffItems If true, items identified as takeoff items
+    ///                           (isTakeoffItem) will be offset
+    /// @param offsetLandingItems If true, items identified as landing items
+    ///                           (isLandCommand) will be offset
+    Q_INVOKABLE void offsetMission(double eastMeters,
+                                   double northMeters,
+                                   double upMeters = 0.0,
+                                   bool offsetTakeoffItems = false,
+                                   bool offsetLandingItems = false);
+
+    /// Rotates all mission items which specify a coordinate around the up axis
+    /// of the home position. Complex items are rotated by moving their
+    /// reference coordinate: their geometry and orientation are not modified.
+    /// Requires a valid planned home position; otherwise the mission is not
+    /// modified and a warning is logged.
+    /// @param degreesCW Angle to rotate items by, in degrees clockwise
+    /// @param rotateTakeoffItems If true, items identified as takeoff items
+    ///                           (isTakeoffItem) will be rotated
+    /// @param rotateLandingItems If true, items identified as landing items
+    ///                           (isLandCommand) will be rotated
+    Q_INVOKABLE void rotateMission(double degreesCW,
+                                   bool rotateTakeoffItems = false,
+                                   bool rotateLandingItems = false);
 
     enum SendToVehiclePreCheckState {
         SendToVehiclePreCheckStateOk,                       // Ok to send plan to vehicle

--- a/src/MissionManager/MissionSettingsItem.cc
+++ b/src/MissionManager/MissionSettingsItem.cc
@@ -41,6 +41,8 @@ MissionSettingsItem::MissionSettingsItem(PlanMasterController* masterController,
     connect(&_cameraSection,    &CameraSection::specifiedGimbalYawChanged,              this, &MissionSettingsItem::specifiedGimbalYawChanged);
     connect(&_cameraSection,    &CameraSection::specifiedGimbalPitchChanged,            this, &MissionSettingsItem::specifiedGimbalPitchChanged);
     connect(&_speedSection,     &SpeedSection::specifiedFlightSpeedChanged,             this, &MissionSettingsItem::specifiedFlightSpeedChanged);
+    connect(this,               &MissionSettingsItem::coordinateChanged,                this, &MissionSettingsItem::entryCoordinateChanged);
+    connect(this,               &MissionSettingsItem::coordinateChanged,                this, &MissionSettingsItem::exitCoordinateChanged);
     connect(this,               &MissionSettingsItem::coordinateChanged,                this, &MissionSettingsItem::_amslEntryAltChanged);
     connect(this,               &MissionSettingsItem::amslEntryAltChanged,              this, &MissionSettingsItem::amslExitAltChanged);
     connect(this,               &MissionSettingsItem::amslEntryAltChanged,              this, &MissionSettingsItem::minAMSLAltitudeChanged);
@@ -176,7 +178,6 @@ void MissionSettingsItem::_setCoordinateWorker(const QGeoCoordinate& coordinate)
     if (_plannedHomePositionCoordinate != coordinate) {
         _plannedHomePositionCoordinate = coordinate;
         emit coordinateChanged(coordinate);
-        emit exitCoordinateChanged(coordinate);
         if (_plannedHomePositionFromVehicle) {
             _plannedHomePositionAltitudeFact.setRawValue(coordinate.altitude());
         }
@@ -252,7 +253,6 @@ void MissionSettingsItem::_updateAltitudeInCoordinate(QVariant value)
         qCDebug(MissionSettingsItemLog) << "MissionSettingsItem::_updateAltitudeInCoordinate" << newAltitude;
         _plannedHomePositionCoordinate.setAltitude(newAltitude);
         emit coordinateChanged(_plannedHomePositionCoordinate);
-        emit exitCoordinateChanged(_plannedHomePositionCoordinate);
     }
 }
 

--- a/src/MissionManager/MissionSettingsItem.h
+++ b/src/MissionManager/MissionSettingsItem.h
@@ -81,6 +81,7 @@ public:
     void            setCoordinate               (const QGeoCoordinate& coordinate) final;   // Should only be called if the end user is moving
     void            setSequenceNumber           (int sequenceNumber) final;
     void            save                        (QJsonArray&  missionItems) final;
+    double          editableAlt                 (void) const final { return _plannedHomePositionAltitudeFact.rawValue().toDouble(); }
     double          amslEntryAlt                (void) const final { return _plannedHomePositionCoordinate.altitude(); }
     double          amslExitAlt                 (void) const final { return amslEntryAlt(); }
     double          minAMSLAltitude             (void) const final { return amslEntryAlt(); }

--- a/src/MissionManager/MissionSettingsItem.h
+++ b/src/MissionManager/MissionSettingsItem.h
@@ -67,7 +67,8 @@ public:
     QString         commandName                 (void) const final { return tr("Initial Camera Settings"); }
     QString         abbreviation                (void) const final;
     QGeoCoordinate  coordinate                  (void) const final { return _plannedHomePositionCoordinate; } // Includes altitude
-    QGeoCoordinate  exitCoordinate              (void) const final { return _plannedHomePositionCoordinate; }
+    QGeoCoordinate  entryCoordinate             (void) const final { return coordinate(); }
+    QGeoCoordinate  exitCoordinate              (void) const final { return coordinate(); }
     int             sequenceNumber              (void) const final { return _sequenceNumber; }
     double          specifiedGimbalYaw          (void) final;
     double          specifiedGimbalPitch        (void) final;

--- a/src/MissionManager/SimpleMissionItem.cc
+++ b/src/MissionManager/SimpleMissionItem.cc
@@ -147,6 +147,7 @@ void SimpleMissionItem::_connectSignals(void)
     connect(&_missionItem._param3Fact,          &Fact::valueChanged,                        this, &SimpleMissionItem::_possibleRadiusChanged);
 
     // Exit coordinate is the same as entrance coordinate
+    connect(this,                               &SimpleMissionItem::coordinateChanged,      this, &SimpleMissionItem::entryCoordinateChanged);
     connect(this,                               &SimpleMissionItem::coordinateChanged,      this, &SimpleMissionItem::exitCoordinateChanged);
 
     // The following changes may also change friendlyEditAllowed

--- a/src/MissionManager/SimpleMissionItem.cc
+++ b/src/MissionManager/SimpleMissionItem.cc
@@ -1105,6 +1105,11 @@ QGeoCoordinate SimpleMissionItem::coordinate(void) const
     }
 }
 
+double SimpleMissionItem::editableAlt() const
+{
+    return _missionItem.param7();
+}
+
 double SimpleMissionItem::amslEntryAlt(void) const
 {
     switch (_altitudeMode) {

--- a/src/MissionManager/SimpleMissionItem.h
+++ b/src/MissionManager/SimpleMissionItem.h
@@ -113,6 +113,7 @@ public:
     QGeoCoordinate  coordinate                  (void) const final;
     QGeoCoordinate  entryCoordinate             (void) const final { return coordinate(); }
     QGeoCoordinate  exitCoordinate              (void) const final { return coordinate(); }
+    double          editableAlt                 (void) const final;
     double          amslEntryAlt                (void) const final;
     double          amslExitAlt                 (void) const final { return amslEntryAlt(); }
     int             sequenceNumber              (void) const final { return _missionItem.sequenceNumber(); }

--- a/src/MissionManager/SimpleMissionItem.h
+++ b/src/MissionManager/SimpleMissionItem.h
@@ -111,6 +111,7 @@ public:
     QString         commandName                 (void) const final;
     QString         abbreviation                (void) const final;
     QGeoCoordinate  coordinate                  (void) const final;
+    QGeoCoordinate  entryCoordinate             (void) const final { return coordinate(); }
     QGeoCoordinate  exitCoordinate              (void) const final { return coordinate(); }
     double          amslEntryAlt                (void) const final;
     double          amslExitAlt                 (void) const final { return amslEntryAlt(); }

--- a/src/MissionManager/StructureScanComplexItem.cc
+++ b/src/MissionManager/StructureScanComplexItem.cc
@@ -74,6 +74,9 @@ StructureScanComplexItem::StructureScanComplexItem(PlanMasterController* masterC
 
     connect(this, &StructureScanComplexItem::wizardModeChanged, this, &StructureScanComplexItem::readyForSaveStateChanged);
 
+    connect(this,               &StructureScanComplexItem::coordinateChanged,       this, &StructureScanComplexItem::entryCoordinateChanged);
+    connect(this,               &StructureScanComplexItem::coordinateChanged,       this, &StructureScanComplexItem::exitCoordinateChanged);
+
     connect(&_entranceAltFact,  &Fact::valueChanged,                                this, &StructureScanComplexItem::_amslEntryAltChanged);
     connect(this,               &StructureScanComplexItem::amslEntryAltChanged,     this, &StructureScanComplexItem::amslExitAltChanged);
 
@@ -270,7 +273,6 @@ void StructureScanComplexItem::_flightPathChanged(void)
                          QGeoCoordinate(south - 90.0, east - 180.0, top)));
 
     emit coordinateChanged(coordinate());
-    emit exitCoordinateChanged(exitCoordinate());
     emit greatestDistanceToChanged();
 
     if (_isIncomplete) {
@@ -491,7 +493,6 @@ QGeoCoordinate StructureScanComplexItem::coordinate(void) const
 void StructureScanComplexItem::_updateCoordinateAltitudes(void)
 {
     emit coordinateChanged(coordinate());
-    emit exitCoordinateChanged(exitCoordinate());
 }
 
 void StructureScanComplexItem::rotateEntryPoint(void)
@@ -501,7 +502,6 @@ void StructureScanComplexItem::rotateEntryPoint(void)
         _entryVertex = 0;
     }
     emit coordinateChanged(coordinate());
-    emit exitCoordinateChanged(exitCoordinate());
 }
 
 void StructureScanComplexItem::_rebuildFlightPolygon(void)
@@ -521,7 +521,6 @@ void StructureScanComplexItem::_rebuildFlightPolygon(void)
     }
 
     emit coordinateChanged(coordinate());
-    emit exitCoordinateChanged(exitCoordinate());
 }
 
 void StructureScanComplexItem::_recalcCameraShots(void)

--- a/src/MissionManager/StructureScanComplexItem.cc
+++ b/src/MissionManager/StructureScanComplexItem.cc
@@ -639,6 +639,11 @@ void StructureScanComplexItem::_updateWizardMode(void)
     }
 }
 
+double StructureScanComplexItem::editableAlt() const
+{
+    return _entranceAltFact.rawValue().toDouble();
+}
+
 double StructureScanComplexItem::amslEntryAlt(void) const
 {
     return _entranceAltFact.rawValue().toDouble() + _missionController->plannedHomePosition().altitude();

--- a/src/MissionManager/StructureScanComplexItem.cc
+++ b/src/MissionManager/StructureScanComplexItem.cc
@@ -468,6 +468,26 @@ void StructureScanComplexItem::applyNewAltitude(double newAltitude)
     _entranceAltFact.setRawValue(newAltitude);
 }
 
+void StructureScanComplexItem::setCoordinate(const QGeoCoordinate& coordinate)
+{
+    const QGeoCoordinate oldCoordinate = this->coordinate();
+    if (!oldCoordinate.isValid() || !coordinate.isValid() || _structurePolygon.count() < 3) {
+        return;
+    }
+
+    const double distanceMeters = oldCoordinate.distanceTo(coordinate);
+    const double azimuthDegrees = oldCoordinate.azimuthTo(coordinate);
+    const QList<QGeoCoordinate> vertices = _structurePolygon.coordinateList();
+
+    QList<QGeoCoordinate> translatedVertices;
+    translatedVertices.reserve(vertices.count());
+    for (const QGeoCoordinate& vertex: vertices) {
+        translatedVertices.append(vertex.atDistanceAndAzimuth(distanceMeters, azimuthDegrees));
+    }
+
+    _structurePolygon.setPath(translatedVertices);
+}
+
 void StructureScanComplexItem::_polygonDirtyChanged(bool dirty)
 {
     if (dirty) {

--- a/src/MissionManager/StructureScanComplexItem.h
+++ b/src/MissionManager/StructureScanComplexItem.h
@@ -70,6 +70,7 @@ public:
     QString             commandName                 (void) const final { return tr("Structure Scan"); }
     QString             abbreviation                (void) const final { return "S"; }
     QGeoCoordinate      coordinate                  (void) const final;
+    QGeoCoordinate      entryCoordinate             (void) const final { return coordinate(); }
     QGeoCoordinate      exitCoordinate              (void) const final { return coordinate(); }
     int                 sequenceNumber              (void) const final { return _sequenceNumber; }
     double              specifiedFlightSpeed        (void) final { return std::numeric_limits<double>::quiet_NaN(); }

--- a/src/MissionManager/StructureScanComplexItem.h
+++ b/src/MissionManager/StructureScanComplexItem.h
@@ -86,6 +86,7 @@ public:
     void                setCoordinate               (const QGeoCoordinate& coordinate) final { Q_UNUSED(coordinate); }
     void                setSequenceNumber           (int sequenceNumber) final;
     void                save                        (QJsonArray&  missionItems) final;
+    double              editableAlt                 (void) const final;
     double              amslEntryAlt                (void) const final;
     double              amslExitAlt                 (void) const final { return amslEntryAlt(); };
     double              minAMSLAltitude             (void) const final;

--- a/src/MissionManager/StructureScanComplexItem.h
+++ b/src/MissionManager/StructureScanComplexItem.h
@@ -83,7 +83,7 @@ public:
     ReadyForSaveState   readyForSaveState           (void) const final;
     bool                exitCoordinateSameAsEntry   (void) const final { return true; }
     void                setDirty                    (bool dirty) final;
-    void                setCoordinate               (const QGeoCoordinate& coordinate) final { Q_UNUSED(coordinate); }
+    void                setCoordinate               (const QGeoCoordinate& coordinate) final;
     void                setSequenceNumber           (int sequenceNumber) final;
     void                save                        (QJsonArray&  missionItems) final;
     double              editableAlt                 (void) const final;

--- a/src/MissionManager/TransectStyleComplexItem.cc
+++ b/src/MissionManager/TransectStyleComplexItem.cc
@@ -87,6 +87,9 @@ TransectStyleComplexItem::TransectStyleComplexItem(PlanMasterController* masterC
 
     connect(&_hoverAndCaptureFact,                      &Fact::rawValueChanged,         this, &TransectStyleComplexItem::_handleHoverAndCaptureEnabled);
 
+    // The main coordinate is aliased to the entry
+    connect(this,                                       &TransectStyleComplexItem::entryCoordinateChanged,      this, &TransectStyleComplexItem::coordinateChanged);
+
     connect(this,                                       &TransectStyleComplexItem::visualTransectPointsChanged, this, &TransectStyleComplexItem::complexDistanceChanged);
     connect(this,                                       &TransectStyleComplexItem::visualTransectPointsChanged, this, &TransectStyleComplexItem::greatestDistanceToChanged);
     connect(this,                                       &TransectStyleComplexItem::wizardModeChanged,           this, &TransectStyleComplexItem::readyForSaveStateChanged);
@@ -227,7 +230,7 @@ bool TransectStyleComplexItem::_load(const QJsonObject& complexObject, bool forP
         if (!JsonHelper::loadGeoCoordinateArray(innerObject[_jsonVisualTransectPointsKey], false /* altitudeRequired */, _visualTransectPoints, errorString)) {
             return false;
         }
-        _coordinate = _visualTransectPoints.count() ? _visualTransectPoints.first().value<QGeoCoordinate>() : QGeoCoordinate();
+        _entryCoordinate = _visualTransectPoints.count() ? _visualTransectPoints.first().value<QGeoCoordinate>() : QGeoCoordinate();
         _exitCoordinate = _visualTransectPoints.count() ? _visualTransectPoints.last().value<QGeoCoordinate>() : QGeoCoordinate();
         _isIncomplete = false;
 
@@ -349,7 +352,7 @@ void TransectStyleComplexItem::_setIfDirty(bool dirty)
 
 void TransectStyleComplexItem::_updateCoordinateAltitudes(void)
 {
-    emit coordinateChanged(coordinate());
+    emit entryCoordinateChanged(entryCoordinate());
     emit exitCoordinateChanged(exitCoordinate());
 }
 
@@ -434,10 +437,9 @@ void TransectStyleComplexItem::_rebuildTransects(void)
                          QGeoCoordinate(south - 90.0, east - 180.0, top)));
     emit visualTransectPointsChanged();
 
-    _coordinate = _visualTransectPoints.count() ? _visualTransectPoints.first().value<QGeoCoordinate>() : QGeoCoordinate();
+    _entryCoordinate = _visualTransectPoints.count() ? _visualTransectPoints.first().value<QGeoCoordinate>() : QGeoCoordinate();
     _exitCoordinate = _visualTransectPoints.count() ? _visualTransectPoints.last().value<QGeoCoordinate>() : QGeoCoordinate();
-    emit coordinateChanged(_coordinate);
-    emit exitCoordinateChanged(_exitCoordinate);
+    _updateCoordinateAltitudes();
 
     if (_isIncomplete) {
         _isIncomplete = false;

--- a/src/MissionManager/TransectStyleComplexItem.cc
+++ b/src/MissionManager/TransectStyleComplexItem.cc
@@ -120,6 +120,25 @@ void TransectStyleComplexItem::setDirty(bool dirty)
     }
 }
 
+void TransectStyleComplexItem::setCoordinate(const QGeoCoordinate& coordinate)
+{
+    if (!coordinate.isValid() || !_entryCoordinate.isValid() || _surveyAreaPolygon.count() < 3) {
+        return;
+    }
+
+    const double distanceMeters = _entryCoordinate.distanceTo(coordinate);
+    const double azimuthDegrees = _entryCoordinate.azimuthTo(coordinate);
+    const QList<QGeoCoordinate> vertices = _surveyAreaPolygon.coordinateList();
+
+    QList<QGeoCoordinate> translatedVertices;
+    translatedVertices.reserve(vertices.count());
+    for (const QGeoCoordinate& vertex: vertices) {
+        translatedVertices.append(vertex.atDistanceAndAzimuth(distanceMeters, azimuthDegrees));
+    }
+
+    _surveyAreaPolygon.setPath(translatedVertices);
+}
+
 void TransectStyleComplexItem::_save(QJsonObject& complexObject)
 {
     QJsonObject innerObject;

--- a/src/MissionManager/TransectStyleComplexItem.cc
+++ b/src/MissionManager/TransectStyleComplexItem.cc
@@ -1322,6 +1322,11 @@ void TransectStyleComplexItem::_recalcComplexDistance(void)
     emit complexDistanceChanged();
 }
 
+double TransectStyleComplexItem::editableAlt() const
+{
+    return _cameraCalc.distanceToSurface()->rawValue().toDouble();
+}
+
 double TransectStyleComplexItem::amslEntryAlt(void) const
 {
     double alt                  = qQNaN();

--- a/src/MissionManager/TransectStyleComplexItem.h
+++ b/src/MissionManager/TransectStyleComplexItem.h
@@ -81,7 +81,8 @@ public:
     bool                isSimpleItem                (void) const final { return false; }
     bool                isStandaloneCoordinate      (void) const final { return false; }
     bool                specifiesAltitudeOnly       (void) const final { return false; }
-    QGeoCoordinate      coordinate                  (void) const final { return _coordinate; }
+    QGeoCoordinate      coordinate                  (void) const final { return entryCoordinate(); }
+    QGeoCoordinate      entryCoordinate             (void) const final { return _entryCoordinate; }
     QGeoCoordinate      exitCoordinate              (void) const final { return _exitCoordinate; }
     int                 sequenceNumber              (void) const final { return _sequenceNumber; }
     double              specifiedFlightSpeed        (void) final { return std::numeric_limits<double>::quiet_NaN(); }
@@ -146,7 +147,7 @@ protected:
     void    _recalcComplexDistance          (void);
 
     int                 _sequenceNumber = 0;
-    QGeoCoordinate      _coordinate;
+    QGeoCoordinate      _entryCoordinate;
     QGeoCoordinate      _exitCoordinate;
     QGCMapPolygon       _surveyAreaPolygon;
 

--- a/src/MissionManager/TransectStyleComplexItem.h
+++ b/src/MissionManager/TransectStyleComplexItem.h
@@ -97,6 +97,7 @@ public:
     void                setDirty                    (bool dirty) final;
     void                setCoordinate               (const QGeoCoordinate& coordinate) final { Q_UNUSED(coordinate); }
     void                setSequenceNumber           (int sequenceNumber) final;
+    double              editableAlt                 (void) const final;
     double              amslEntryAlt                (void) const final;
     double              amslExitAlt                 (void) const final;
     double              minAMSLAltitude             (void) const final;

--- a/src/MissionManager/TransectStyleComplexItem.h
+++ b/src/MissionManager/TransectStyleComplexItem.h
@@ -95,7 +95,7 @@ public:
     QString             abbreviation                (void) const override { return tr("T"); }
     bool                exitCoordinateSameAsEntry   (void) const final { return false; }
     void                setDirty                    (bool dirty) final;
-    void                setCoordinate               (const QGeoCoordinate& coordinate) final { Q_UNUSED(coordinate); }
+    void                setCoordinate               (const QGeoCoordinate& coordinate) override;
     void                setSequenceNumber           (int sequenceNumber) final;
     double              editableAlt                 (void) const final;
     double              amslEntryAlt                (void) const final;

--- a/src/MissionManager/VisualMissionItem.h
+++ b/src/MissionManager/VisualMissionItem.h
@@ -143,6 +143,7 @@ public:
     virtual QGeoCoordinate  coordinate              (void) const = 0;
     virtual QGeoCoordinate  entryCoordinate         (void) const = 0;
     virtual QGeoCoordinate  exitCoordinate          (void) const = 0;
+    virtual double          editableAlt             (void) const = 0;
     virtual double          amslEntryAlt            (void) const = 0;
     virtual double          amslExitAlt             (void) const = 0;
     virtual int             sequenceNumber          (void) const = 0;

--- a/src/MissionManager/VisualMissionItem.h
+++ b/src/MissionManager/VisualMissionItem.h
@@ -42,9 +42,10 @@ public:
     Q_PROPERTY(QGeoCoordinate   coordinate                          READ coordinate                         WRITE setCoordinate             NOTIFY coordinateChanged)                           ///< Does not include altitude
     Q_PROPERTY(double           amslEntryAlt                        READ amslEntryAlt                                                       NOTIFY amslEntryAltChanged)
     Q_PROPERTY(double           terrainAltitude                     READ terrainAltitude                                                    NOTIFY terrainAltitudeChanged)                      ///< The altitude of terrain at the coordinate position, NaN if not known
+    Q_PROPERTY(QGeoCoordinate   entryCoordinate                     READ entryCoordinate                                                    NOTIFY entryCoordinateChanged)                      ///< Does not include altitude
     Q_PROPERTY(QGeoCoordinate   exitCoordinate                      READ exitCoordinate                                                     NOTIFY exitCoordinateChanged)                       ///< Does not include altitude
     Q_PROPERTY(double           amslExitAlt                         READ amslExitAlt                                                        NOTIFY amslExitAltChanged)
-    Q_PROPERTY(bool             exitCoordinateSameAsEntry           READ exitCoordinateSameAsEntry                                          NOTIFY exitCoordinateSameAsEntryChanged)            ///< true: exitCoordinate and coordinate are the same value
+    Q_PROPERTY(bool             exitCoordinateSameAsEntry           READ exitCoordinateSameAsEntry                                          NOTIFY exitCoordinateSameAsEntryChanged)            ///< true: entryCoordinate and exitCoordinate are the same value
     Q_PROPERTY(QString          commandDescription                  READ commandDescription                                                 NOTIFY commandDescriptionChanged)
     Q_PROPERTY(QString          commandName                         READ commandName                                                        NOTIFY commandNameChanged)
     Q_PROPERTY(QString          abbreviation                        READ abbreviation                                                       NOTIFY abbreviationChanged)
@@ -140,6 +141,7 @@ public:
     virtual QString         commandName             (void) const = 0;
     virtual QString         abbreviation            (void) const = 0;
     virtual QGeoCoordinate  coordinate              (void) const = 0;
+    virtual QGeoCoordinate  entryCoordinate         (void) const = 0;
     virtual QGeoCoordinate  exitCoordinate          (void) const = 0;
     virtual double          amslEntryAlt            (void) const = 0;
     virtual double          amslExitAlt             (void) const = 0;
@@ -202,6 +204,7 @@ signals:
     void commandNameChanged             (void);
     void abbreviationChanged            (void);
     void coordinateChanged              (const QGeoCoordinate& coordinate);
+    void entryCoordinateChanged         (const QGeoCoordinate& entryCoordinate);
     void exitCoordinateChanged          (const QGeoCoordinate& exitCoordinate);
     void dirtyChanged                   (bool dirty);
     void distanceChanged                (double distance);

--- a/src/QmlControls/EditPositionDialogController.h
+++ b/src/QmlControls/EditPositionDialogController.h
@@ -13,7 +13,7 @@ class EditPositionDialogController : public QObject
 {
     Q_OBJECT
     QML_ELEMENT
-    Q_PROPERTY(QGeoCoordinate   coordinate  READ coordinate WRITE setCoordinate NOTIFY coordinateChanged)
+    Q_PROPERTY(QGeoCoordinate   coordinate  READ coordinate WRITE setCoordinate NOTIFY coordinateChanged REQUIRED)
     Q_PROPERTY(Fact             *latitude   READ latitude                       CONSTANT)
     Q_PROPERTY(Fact             *longitude  READ longitude                      CONSTANT)
     Q_PROPERTY(Fact             *zone       READ zone                           CONSTANT)

--- a/src/QmlControls/MissionItemEditor.qml
+++ b/src/QmlControls/MissionItemEditor.qml
@@ -308,9 +308,7 @@ Rectangle {
                         text: qsTr("Edit mission position...")
                         enabled: _missionController.plannedHomePosition.isValid
                         onClicked: {
-                            editMissionPositionDialogComponent.createObject(
-                                        mainWindow,
-                                        { coordinate: _missionController.plannedHomePosition }).open()
+                            editMissionPositionDialogComponent.createObject(mainWindow).open()
                             missionStartHamburgerMenuDropPanel.close()
                         }
                     }
@@ -537,6 +535,7 @@ Rectangle {
         EditPositionDialog {
             id: missionEditPositionDialog
 
+            coordinate: _missionController.plannedHomePosition
             onCoordinateChanged: _missionController.repositionMission(coordinate)
         }
     }

--- a/src/QmlControls/MissionItemEditor.qml
+++ b/src/QmlControls/MissionItemEditor.qml
@@ -194,6 +194,7 @@ Rectangle {
 
         DropPanel {
             id: hamburgerMenuDropPanel
+            onClosed: destroy()
 
             sourceComponent: Component {
                 ColumnLayout {
@@ -271,6 +272,275 @@ Rectangle {
         }
     }
 
+    Component {
+        id: missionStartHamburgerMenuDropPanelComponent
+
+        DropPanel {
+            id: missionStartHamburgerMenuDropPanel
+            onClosed: destroy()
+
+            sourceComponent: Component {
+                ColumnLayout {
+                    spacing: ScreenTools.defaultFontPixelHeight / 2
+
+                    QGCButton {
+                        Layout.fillWidth: true
+                        text: qsTr("Offset mission...")
+                        enabled: _missionController.plannedHomePosition.isValid
+                        onClicked: {
+                            offsetMissionDialogComponent.createObject(mainWindow).open()
+                            missionStartHamburgerMenuDropPanel.close()
+                        }
+                    }
+
+                    QGCButton {
+                        Layout.fillWidth: true
+                        text: qsTr("Rotate mission...")
+                        enabled: _missionController.plannedHomePosition.isValid
+                        onClicked: {
+                            rotateMissionDialogComponent.createObject(mainWindow).open()
+                            missionStartHamburgerMenuDropPanel.close()
+                        }
+                    }
+
+                    QGCButton {
+                        Layout.fillWidth: true
+                        text: qsTr("Edit mission position...")
+                        enabled: _missionController.plannedHomePosition.isValid
+                        onClicked: {
+                            editMissionPositionDialogComponent.createObject(
+                                        mainWindow,
+                                        { coordinate: _missionController.plannedHomePosition }).open()
+                            missionStartHamburgerMenuDropPanel.close()
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    Component {
+        id: offsetMissionDialogComponent
+
+        QGCPopupDialog {
+            id: root
+            title: qsTr("Offset Mission")
+            buttons: Dialog.Cancel | Dialog.Ok
+            modal: true
+
+            property real _margin: ScreenTools.defaultFontPixelWidth / 2
+            property real _textFieldWidth: ScreenTools.defaultFontPixelWidth * 20
+            property real _labelWidth: ScreenTools.defaultFontPixelWidth * 14
+
+            ColumnLayout {
+                spacing: _margin
+
+                RowLayout {
+                    spacing: _margin
+                    Layout.fillWidth: true
+
+                    QGCLabel {
+                        text: qsTr("East (m)")
+                        Layout.preferredWidth: _labelWidth
+                        Layout.alignment: Qt.AlignVCenter | Qt.AlignLeft
+                    }
+
+                    QGCTextField {
+                        id: eastField
+                        text: "0"
+                        Layout.preferredWidth: _textFieldWidth
+                        Layout.fillWidth: true
+                        inputMethodHints: Qt.ImhPreferNumbers
+                        validator: DoubleValidator {
+                            notation: DoubleValidator.StandardNotation
+                            locale: Qt.locale()
+                        }
+                    }
+                }
+
+                RowLayout {
+                    spacing: _margin
+                    Layout.fillWidth: true
+
+                    QGCLabel {
+                        text: qsTr("North (m)")
+                        Layout.preferredWidth: _labelWidth
+                        Layout.alignment: Qt.AlignVCenter | Qt.AlignLeft
+                    }
+
+                    QGCTextField {
+                        id: northField
+                        text: "0"
+                        Layout.preferredWidth: _textFieldWidth
+                        Layout.fillWidth: true
+                        inputMethodHints: Qt.ImhPreferNumbers
+                        validator: DoubleValidator {
+                            notation: DoubleValidator.StandardNotation
+                            locale: Qt.locale()
+                        }
+                    }
+                }
+
+                RowLayout {
+                    spacing: _margin
+                    Layout.fillWidth: true
+
+                    QGCLabel {
+                        text: qsTr("Up (m)")
+                        Layout.preferredWidth: _labelWidth
+                        Layout.alignment: Qt.AlignVCenter | Qt.AlignLeft
+                    }
+
+                    QGCTextField {
+                        id: upField
+                        text: "0"
+                        Layout.preferredWidth: _textFieldWidth
+                        Layout.fillWidth: true
+                        inputMethodHints: Qt.ImhPreferNumbers
+                        validator: DoubleValidator {
+                            notation: DoubleValidator.StandardNotation
+                            locale: Qt.locale()
+                        }
+                    }
+                }
+
+                ColumnLayout {
+                    Layout.alignment: Qt.AlignHCenter | Qt.AlignVCenter
+
+                    QGCCheckBox {
+                        id: offsetTakeoffCheck
+                        text: qsTr("Also move takeoff items")
+                        Layout.alignment: Qt.AlignLeft | Qt.AlignVCenter
+                    }
+
+                    QGCCheckBox {
+                        id: offsetLandingCheck
+                        text: qsTr("Also move landing items")
+                        Layout.alignment: Qt.AlignLeft | Qt.AlignVCenter
+                    }
+                }
+
+                QGCLabel {
+                    Layout.fillWidth: true
+                    Layout.maximumWidth: _labelWidth + _textFieldWidth
+
+                    wrapMode: Text.WordWrap
+                    font.pointSize: ScreenTools.smallFontPointSize
+
+                    text: qsTr("Note: Home altitude is not modified.")
+                }
+            }
+
+            onAccepted: {
+                var east = Number.fromLocaleString(Qt.locale(), eastField.text)
+                var north = Number.fromLocaleString(Qt.locale(), northField.text)
+                var up = Number.fromLocaleString(Qt.locale(), upField.text)
+
+                if (isNaN(east)) east = 0
+                if (isNaN(north)) north = 0
+                if (isNaN(up)) up = 0
+
+                _missionController.offsetMission(
+                    east,
+                    north,
+                    up,
+                    offsetTakeoffCheck.checked,
+                    offsetLandingCheck.checked
+                )
+            }
+        }
+    }
+
+    Component {
+        id: rotateMissionDialogComponent
+
+        QGCPopupDialog {
+            id: root
+            title: qsTr("Rotate Mission")
+            buttons: Dialog.Cancel | Dialog.Ok
+            modal: true
+
+            property real _margin: ScreenTools.defaultFontPixelWidth / 2
+            property real _textFieldWidth: ScreenTools.defaultFontPixelWidth * 20
+            property real _labelWidth: ScreenTools.defaultFontPixelWidth * 14
+
+            ColumnLayout {
+                spacing: _margin
+
+                RowLayout {
+                    spacing: _margin
+                    Layout.fillWidth: true
+
+                    QGCLabel {
+                        text: qsTr("Clockwise (°)")
+                        Layout.preferredWidth: _labelWidth
+                        Layout.alignment: Qt.AlignVCenter | Qt.AlignLeft
+                    }
+
+                    QGCTextField {
+                        id: degreesCWField
+                        text: "0"
+                        Layout.preferredWidth: _textFieldWidth
+                        Layout.fillWidth: true
+                        inputMethodHints: Qt.ImhPreferNumbers
+                        validator: DoubleValidator {
+                            notation: DoubleValidator.StandardNotation
+                            locale: Qt.locale()
+                        }
+                    }
+                }
+
+                ColumnLayout {
+                    Layout.alignment: Qt.AlignHCenter | Qt.AlignVCenter
+
+                    QGCCheckBox {
+                        id: rotateTakeoffCheck
+                        text: qsTr("Also move takeoff items")
+                        Layout.alignment: Qt.AlignLeft | Qt.AlignVCenter
+                    }
+
+                    QGCCheckBox {
+                        id: rotateLandingCheck
+                        text: qsTr("Also move landing items")
+                        Layout.alignment: Qt.AlignLeft | Qt.AlignVCenter
+                    }
+                }
+
+                QGCLabel {
+                    Layout.fillWidth: true
+                    Layout.maximumWidth: _labelWidth + _textFieldWidth
+
+                    wrapMode: Text.WordWrap
+                    font.pointSize: ScreenTools.smallFontPointSize
+
+                    text: qsTr("Note: Complex items are rotated by moving their reference coordinate: their geometry and orientation are not changed.")
+                }
+            }
+
+            onAccepted: {
+                var degreesCW = Number.fromLocaleString(Qt.locale(), degreesCWField.text)
+
+                if (isNaN(degreesCW)) degreesCW = 0
+
+                _missionController.rotateMission(
+                    degreesCW,
+                    rotateTakeoffCheck.checked,
+                    rotateLandingCheck.checked
+                )
+            }
+        }
+    }
+
+    Component {
+        id: editMissionPositionDialogComponent
+
+        EditPositionDialog {
+            id: missionEditPositionDialog
+
+            onCoordinateChanged: _missionController.repositionMission(coordinate)
+        }
+    }
+
 
     QGCColoredImage {
         id:                     hamburger
@@ -281,7 +551,7 @@ Rectangle {
         height:                 _hamburgerSize
         sourceSize.height:      _hamburgerSize
         source:                 "qrc:/qmlimages/Hamburger.svg"
-        visible:                missionItem.isCurrentItem && missionItem.sequenceNumber !== 0
+        visible:                missionItem.isCurrentItem
         color:                  qgcPal.buttonHighlightText
 
         QGCMouseArea {
@@ -291,7 +561,11 @@ Rectangle {
                 position = Qt.point(position.x, position.y)
                 // For some strange reason using mainWindow in mapToItem doesn't work, so we use globals.parent instead which also gets us mainWindow
                 position = mapToItem(globals.parent, position)
-                var dropPanel = hamburgerMenuDropPanelComponent.createObject(mainWindow, { clickRect: Qt.rect(position.x, position.y, 0, 0) })
+
+                var panelComponent = (missionItem.sequenceNumber === 0)
+                           ? missionStartHamburgerMenuDropPanelComponent
+                           : hamburgerMenuDropPanelComponent
+                var dropPanel = panelComponent.createObject(mainWindow, { clickRect: Qt.rect(position.x, position.y, 0, 0) })
                 dropPanel.open()
             }
         }

--- a/test/MissionManager/MissionControllerTest.cc
+++ b/test/MissionManager/MissionControllerTest.cc
@@ -12,6 +12,13 @@ using namespace TestFixtures;
 
 MissionControllerTest::~MissionControllerTest() = default;
 
+namespace {
+// Coordinate checks involve geodesic reconstruction so they use 0.5 m. Altitude
+// checks are direct arithmetic, so they use a much tighter 1e-4 m tolerance.
+constexpr double kCoordToleranceMeters = 0.5;
+constexpr double kAltToleranceMeters = 1e-4;
+}  // namespace
+
 void MissionControllerTest::cleanup()
 {
     _masterController.reset();
@@ -185,6 +192,161 @@ void MissionControllerTest::_testVehicleYawRecalc()
             expectedVehicleYaw += wpAngleInc;
         }
     }
+}
+
+void MissionControllerTest::_testMissionReposition()
+{
+    _initForFirmwareType(MAV_AUTOPILOT_PX4);
+
+    MissionSettingsItem* settingsItem = _missionController->visualItems()->value<MissionSettingsItem*>(0);
+    QVERIFY(settingsItem);
+
+    const QGeoCoordinate home = Coord::zurich();
+    settingsItem->setInitialHomePositionFromUser(home);
+
+    const QGeoCoordinate wp1 = home.atDistanceAndAzimuth(150.0, 15.0);
+    const QGeoCoordinate wp2 = home.atDistanceAndAzimuth(320.0, 120.0);
+    _missionController->insertSimpleMissionItem(wp1, 1);
+    _missionController->insertSimpleMissionItem(wp2, 2);
+
+    SimpleMissionItem* item1 = _missionController->visualItems()->value<SimpleMissionItem*>(1);
+    SimpleMissionItem* item2 = _missionController->visualItems()->value<SimpleMissionItem*>(2);
+    QVERIFY(item1);
+    QVERIFY(item2);
+
+    const double oldHomeAlt = settingsItem->editableAlt();
+    const double oldAlt1 = item1->editableAlt();
+    const double oldAlt2 = item2->editableAlt();
+
+    const QGeoCoordinate newHome = home.atDistanceAndAzimuth(200.0, 65.0);
+    const QGeoCoordinate expectedWp1 =
+        newHome.atDistanceAndAzimuth(home.distanceTo(wp1), home.azimuthTo(wp1));
+    const QGeoCoordinate expectedWp2 =
+        newHome.atDistanceAndAzimuth(home.distanceTo(wp2), home.azimuthTo(wp2));
+    _missionController->repositionMission(newHome, true, true);
+    QVERIFY_TRUE_WAIT((settingsItem->coordinate().distanceTo(newHome) <= kCoordToleranceMeters) &&
+                          (item1->coordinate().distanceTo(expectedWp1) <= kCoordToleranceMeters) &&
+                          (item2->coordinate().distanceTo(expectedWp2) <= kCoordToleranceMeters),
+                      TestTimeout::shortMs());
+
+    QCOMPARE_COORDS(settingsItem->coordinate(), newHome, kCoordToleranceMeters);
+    QCOMPARE_COORDS(item1->coordinate(), expectedWp1, kCoordToleranceMeters);
+    QCOMPARE_COORDS(item2->coordinate(), expectedWp2, kCoordToleranceMeters);
+    QCOMPARE_FUZZY(settingsItem->editableAlt(), oldHomeAlt, kAltToleranceMeters);
+    QCOMPARE_FUZZY(item1->editableAlt(), oldAlt1, kAltToleranceMeters);
+    QCOMPARE_FUZZY(item2->editableAlt(), oldAlt2, kAltToleranceMeters);
+}
+
+void MissionControllerTest::_testMissionOffset()
+{
+    _initForFirmwareType(MAV_AUTOPILOT_PX4);
+
+    MissionSettingsItem* settingsItem = _missionController->visualItems()->value<MissionSettingsItem*>(0);
+    QVERIFY(settingsItem);
+
+    const QGeoCoordinate home = Coord::zurich();
+    settingsItem->setInitialHomePositionFromUser(home);
+
+    const QGeoCoordinate wp1 = home.atDistanceAndAzimuth(150.0, 15.0);
+    const QGeoCoordinate wp2 = home.atDistanceAndAzimuth(320.0, 120.0);
+    _missionController->insertSimpleMissionItem(wp1, 1);
+    _missionController->insertSimpleMissionItem(wp2, 2);
+
+    SimpleMissionItem* item1 = _missionController->visualItems()->value<SimpleMissionItem*>(1);
+    SimpleMissionItem* item2 = _missionController->visualItems()->value<SimpleMissionItem*>(2);
+    QVERIFY(item1);
+    QVERIFY(item2);
+
+    const double oldHomeAlt = settingsItem->editableAlt();
+    const double oldAlt1 = item1->editableAlt();
+    const double oldAlt2 = item2->editableAlt();
+
+    _missionController->offsetMission(0.0, 0.0, 12.0, true, true);
+    QVERIFY_TRUE_WAIT(qAbs(settingsItem->editableAlt() - oldHomeAlt) <= kAltToleranceMeters &&
+                          qAbs(item1->editableAlt() - (oldAlt1 + 12.0)) <= kAltToleranceMeters &&
+                          qAbs(item2->editableAlt() - (oldAlt2 + 12.0)) <= kAltToleranceMeters,
+                      TestTimeout::shortMs());
+
+    QCOMPARE_FUZZY(settingsItem->editableAlt(), oldHomeAlt, kAltToleranceMeters);
+    QCOMPARE_FUZZY(item1->editableAlt(), oldAlt1 + 12.0, kAltToleranceMeters);
+    QCOMPARE_FUZZY(item2->editableAlt(), oldAlt2 + 12.0, kAltToleranceMeters);
+}
+
+void MissionControllerTest::_testMissionRotate()
+{
+    _initForFirmwareType(MAV_AUTOPILOT_PX4);
+
+    MissionSettingsItem* settingsItem = _missionController->visualItems()->value<MissionSettingsItem*>(0);
+    QVERIFY(settingsItem);
+
+    const QGeoCoordinate home = Coord::zurich();
+    settingsItem->setInitialHomePositionFromUser(home);
+
+    const QGeoCoordinate wp1 = home.atDistanceAndAzimuth(180.0, 20.0);
+    const QGeoCoordinate wp2 = home.atDistanceAndAzimuth(260.0, 135.0);
+    _missionController->insertSimpleMissionItem(wp1, 1);
+    _missionController->insertSimpleMissionItem(wp2, 2);
+
+    SimpleMissionItem* item1 = _missionController->visualItems()->value<SimpleMissionItem*>(1);
+    SimpleMissionItem* item2 = _missionController->visualItems()->value<SimpleMissionItem*>(2);
+    QVERIFY(item1);
+    QVERIFY(item2);
+
+    const double oldHomeAlt = settingsItem->editableAlt();
+    const double oldAlt1 = item1->editableAlt();
+    const double oldAlt2 = item2->editableAlt();
+
+    const QGeoCoordinate expectedWp1 =
+        home.atDistanceAndAzimuth(home.distanceTo(wp1), home.azimuthTo(wp1) + 90.0);
+    const QGeoCoordinate expectedWp2 =
+        home.atDistanceAndAzimuth(home.distanceTo(wp2), home.azimuthTo(wp2) + 90.0);
+
+    _missionController->rotateMission(90.0, true, true);
+    QVERIFY_TRUE_WAIT((settingsItem->coordinate().distanceTo(home) <= kCoordToleranceMeters) &&
+                          (item1->coordinate().distanceTo(expectedWp1) <= kCoordToleranceMeters) &&
+                          (item2->coordinate().distanceTo(expectedWp2) <= kCoordToleranceMeters),
+                      TestTimeout::shortMs());
+
+    QCOMPARE_COORDS(settingsItem->coordinate(), home, kCoordToleranceMeters);
+    QCOMPARE_COORDS(item1->coordinate(), expectedWp1, kCoordToleranceMeters);
+    QCOMPARE_COORDS(item2->coordinate(), expectedWp2, kCoordToleranceMeters);
+    QCOMPARE_FUZZY(settingsItem->editableAlt(), oldHomeAlt, kAltToleranceMeters);
+    QCOMPARE_FUZZY(item1->editableAlt(), oldAlt1, kAltToleranceMeters);
+    QCOMPARE_FUZZY(item2->editableAlt(), oldAlt2, kAltToleranceMeters);
+}
+
+void MissionControllerTest::_testMissionTransformsInvalidHome()
+{
+    _initForFirmwareType(MAV_AUTOPILOT_PX4);
+
+    MissionSettingsItem* settingsItem =
+        _missionController->visualItems()->value<MissionSettingsItem*>(0);
+    QVERIFY(settingsItem);
+
+    const QGeoCoordinate home = Coord::zurich();
+    settingsItem->setInitialHomePositionFromUser(home);
+
+    const QGeoCoordinate wp1 = home.atDistanceAndAzimuth(180.0, 45.0);
+    _missionController->insertSimpleMissionItem(wp1, 1);
+
+    SimpleMissionItem* item1 = _missionController->visualItems()->value<SimpleMissionItem*>(1);
+    QVERIFY(item1);
+
+    const QGeoCoordinate oldItemCoord = item1->coordinate();
+    const double oldItemAlt = item1->editableAlt();
+
+    settingsItem->setCoordinate(QGeoCoordinate());
+    QVERIFY_TRUE_WAIT(!settingsItem->coordinate().isValid(), TestTimeout::shortMs());
+
+    _missionController->repositionMission(home.atDistanceAndAzimuth(100.0, 0.0), true, true);
+    _missionController->offsetMission(10.0, 5.0, 8.0, true, true);
+    _missionController->rotateMission(45.0, true, true);
+    QVERIFY_TRUE_WAIT((item1->coordinate().distanceTo(oldItemCoord) <= kCoordToleranceMeters) &&
+                          (qAbs(item1->editableAlt() - oldItemAlt) <= kAltToleranceMeters),
+                      TestTimeout::shortMs());
+
+    QCOMPARE_COORDS(item1->coordinate(), oldItemCoord, kCoordToleranceMeters);
+    QCOMPARE_FUZZY(item1->editableAlt(), oldItemAlt, kAltToleranceMeters);
 }
 
 void MissionControllerTest::_testLoadJsonSectionAvailable()

--- a/test/MissionManager/MissionControllerTest.h
+++ b/test/MissionManager/MissionControllerTest.h
@@ -23,6 +23,10 @@ private slots:
     void _testGlobalAltMode();
     void _testGimbalRecalc();
     void _testVehicleYawRecalc();
+    void _testMissionReposition();
+    void _testMissionOffset();
+    void _testMissionRotate();
+    void _testMissionTransformsInvalidHome();
 
     // Parameterized tests - runs once per autopilot type
     UT_PARAMETERIZED_TEST(_testEmptyVehicle);

--- a/test/MissionManager/SimpleMissionItemTest.cc
+++ b/test/MissionManager/SimpleMissionItemTest.cc
@@ -203,14 +203,14 @@ void SimpleMissionItemTest::_testSignals()
     // Check that actually changing coordinate signals correctly
     _simpleItem->setCoordinate(QGeoCoordinate(missionItem.param5() + 1, missionItem.param6(), missionItem.param7()));
     QVERIFY(_spyVisualItem->onlyEmittedOnceByMask(
-        _spyVisualItem->mask("coordinateChanged", "exitCoordinateChanged", "dirtyChanged", "amslEntryAltChanged",
-                             "amslExitAltChanged", "terrainAltitudeChanged")));
+        _spyVisualItem->mask("coordinateChanged", "entryCoordinateChanged", "exitCoordinateChanged", "dirtyChanged",
+                             "amslEntryAltChanged", "amslExitAltChanged", "terrainAltitudeChanged")));
     _spyVisualItem->clearAllSignals();
     _spySimpleItem->clearAllSignals();
     _simpleItem->setCoordinate(QGeoCoordinate(missionItem.param5(), missionItem.param6() + 1, missionItem.param7()));
     QVERIFY(_spyVisualItem->onlyEmittedOnceByMask(
-        _spyVisualItem->mask("coordinateChanged", "exitCoordinateChanged", "dirtyChanged", "amslEntryAltChanged",
-                             "amslExitAltChanged", "terrainAltitudeChanged")));
+        _spyVisualItem->mask("coordinateChanged", "entryCoordinateChanged", "exitCoordinateChanged", "dirtyChanged",
+                             "amslEntryAltChanged", "amslExitAltChanged", "terrainAltitudeChanged")));
     _spyVisualItem->clearAllSignals();
     _spySimpleItem->clearAllSignals();
     // Altitude in coordinate is not used in setCoordinate


### PR DESCRIPTION
## Description
A variety of soft bugfixes and feature additions to enable a few simple mission-wide movement options.

### Make entryCoordinate explicit in VisualMissionItem
Previously, VisualMissionItem::coordinate was implicitly treated as the entry coordinate. This was unsuitable for LandingComplexItem, where the main coordinate is the landing (exit), as it is the master/pivot for user editing and transformations. Because of this, setCoordinate operated on the landing point, while the coordinate getter still returned the final approach (entry).

Introduced an explicit entryCoordinate alongside exitCoordinate, and redefined coordinate to alias either the entry or exit, depending on which is considered the main coordinate for a given VisualMissionItem subclass. For LandingComplexItem, coordinate and exitCoordinate now refer to the landing point, while the final approach is exposed via entryCoordinate.

In addition, Qt signal wiring for these properties has been simplified by using connections set up during object construction, reducing manual signal emissions.

### Add editableAlt getter to VisualMissionItem
Introduced a new editableAlt getter on VisualMissionItem to expose a single source of truth for the primary user-editable altitude across all VisualMissionItem subclasses. This value is intentionally independent of altitude reference-frame (relative, absolute, terrain), as it is intended to be used in conjunction with the likewise frame-agnostic VisualMissionItem::applyNewAltitude method to provide an external interface for generic altitude offsetting.


### Implement setCoordinate for complex scan items

This also fixes a bug where the "Edit position" option in the hamburger menu of Corridor Scan items did nothing.

### Add mission item bulk displacement utilities
Introduced new Q_INVOKABLE helpers on MissionController to transform entire missions, including:
- Repositioning the mission around a new home coordinate
- Offsetting the mission in ENU space
- Rotating the mission around home

Optional flags allow takeoff and landing items to be included or excluded. Repositioning includes them by default, while offset and rotation do not. All operations require a valid planned home position to succeed.

### Add hamburger menu with mission-wide transforms
Added a hamburger menu to the Mission Settings item that provides options to offset, rotate, and reposition the entire mission.

Also ensured DropPanel instances destroy themselves when closed to avoid leaking dynamically-created menus.

### Fix EditPositionDialog init reposition

Opening EditPositionDialog was triggering coordinateChanged during initialization, which then caused mission reposition or item coordinate updates even when nothing actually moved. Ensured initialization does not emit, while keeping explicit user actions behaving the same.

Key changes:
- Make EditPositionDialogController.coordinate REQUIRED
- Do not emit on the initial invalid-to-valid coordinate assignment
- Warn and ignore attempts to set an invalid coordinate
- Route Geo/UTM/MGRS updates through setCoordinate for behaviour centralization
- Set coordinate via QML binding in EditPositionDialog declarations, instead of via createObject property maps (no longer supported)

### Add mission item bulk displacement unit tests

The 2 tests cover a valid transform case (reposition + vertical offset) and an invalid-home no-op case.

## Type of Change
- [X] Bug fix (non-breaking change that fixes an issue)
- [X] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] CI/Build changes
- [ ] Other

## Testing
- [X] Tested locally
- [X] Added/updated unit tests _Note: Just minor updates to keep them working with the new changes, nothing new is tested._ 
- [X] Tested with simulator (SITL)
- [ ] Tested with hardware

### Platforms Tested
- [ ] Linux
- [X] Windows
- [ ] macOS
- [ ] Android
- [ ] iOS

### Flight Stacks Tested
- [ ] PX4
- [ ] ArduPilot

## Screenshots
<img width="241" height="428" alt="imagen" src="https://github.com/user-attachments/assets/9656b791-873e-4c60-8c43-9b8c35281d9f" />
<img width="338" height="269" alt="imagen" src="https://github.com/user-attachments/assets/0bfe05b0-c0c4-4136-9288-8411dd19f6f2" />
<img width="333" height="230" alt="imagen" src="https://github.com/user-attachments/assets/03952e8b-5c35-4819-9a6e-a4a72f266fe2" />


## Checklist
- [X] I have read the [Contribution Guidelines](CONTRIBUTING.md)
- [X] I have read the [Code of Conduct](CODE_OF_CONDUCT.md)
- [X] My code follows the project's coding standards
- [ ] I have added tests that prove my fix/feature works
- [X] New and existing unit tests pass locally
---
By submitting this pull request, I confirm that my contribution is made under the terms of the project's dual license (Apache 2.0 and GPL v3).
