### PR TITLE
windows_release.yml: fix broken workflow, use jom 1.1.4 instead of 1.1.3

### DIFF
--- a/.github/workflows/windows_release.yml
+++ b/.github/workflows/windows_release.yml
@@ -52,15 +52,9 @@ jobs:
           setup-python: false
 
       - name: Download JOM
-        uses: suisei-cn/actions-download-file@v1.3.0
-        with:
-          url:    http://download.qt.io/official_releases/jom/jom.zip
-          target: ${{ runner.temp }}\
-
-      - name: Unzip JOM
-        working-directory: ${{ runner.temp }}
-        run:  |
-              7z x jom.zip -ojom
+        run: |
+          curl -L -o ${{ runner.temp }}\jom.zip https://download.qt.io/official_releases/jom/jom_1_1_4.zip
+          7z x ${{ runner.temp }}\jom.zip -o${{ runner.temp }}\jom -y
 
       - name: Download Gstreamer
         uses: suisei-cn/actions-download-file@v1.3.0


### PR DESCRIPTION
After some updates to windows runners around first week of December, windows builds for 4.4.5 were broken.

For Qt  5.15.2 actually jom 1.1.3 is recommended, but the linking process broke completely. After some tests it seems jom 1.1.4 works fine and makes healthy installers. Jom 1.1.4 is supposed to be backwards compatible with 1.1.3, so this should be safe.

Even though we are now on QGC 5, I thought this could be useful for people on 4.4.5 custom forks. As it is a CI only fix no release is needed.

For awareness @julianoes.