### PR TITLE
RC Payload power, Fact tooltip and textLink color

### DIFF
--- a/src/AutoPilotPlugins/Common/RadioComponent.qml
+++ b/src/AutoPilotPlugins/Common/RadioComponent.qml
@@ -41,8 +41,8 @@ SetupPage {
                     Repeater {
                         model: QGroundControl.multiVehicleManager.activeVehicle.px4Firmware ?
                                     (QGroundControl.multiVehicleManager.activeVehicle.multiRotor ?
-                                        [ "RC_MAP_AUX1", "RC_MAP_AUX2", "RC_MAP_PARAM1", "RC_MAP_PARAM2", "RC_MAP_PARAM3"] :
-                                        [ "RC_MAP_FLAPS", "RC_MAP_AUX1", "RC_MAP_AUX2", "RC_MAP_PARAM1", "RC_MAP_PARAM2", "RC_MAP_PARAM3"]) :
+                                        [ "RC_MAP_AUX1", "RC_MAP_AUX2", "RC_MAP_PARAM1", "RC_MAP_PARAM2", "RC_MAP_PARAM3", "RC_MAP_PAY_SW"] :
+                                        [ "RC_MAP_FLAPS", "RC_MAP_AUX1", "RC_MAP_AUX2", "RC_MAP_PARAM1", "RC_MAP_PARAM2", "RC_MAP_PARAM3", "RC_MAP_PAY_SW"]) :
                                     0
 
                         LabelledFactComboBox {

--- a/src/AutoPilotPlugins/PX4/ActuatorComponent.qml
+++ b/src/AutoPilotPlugins/PX4/ActuatorComponent.qml
@@ -39,7 +39,7 @@ SetupPage {
                         Layout.fillWidth:       true
                     }
                     QGCLabel {
-                        text:                   "<a href='"+actuators.mixer.helpUrl+"'>?</a>"
+                        text:                   "<a style='color: " + qgcPal.textLink + ";' href='"+actuators.mixer.helpUrl+"'>?</a>"
                         font.pointSize:         ScreenTools.mediumFontPointSize
                         visible:                actuators.mixer.helpUrl
                         textFormat:             Text.RichText

--- a/src/AutoPilotPlugins/PX4/PX4TuningComponentCopterRate.qml
+++ b/src/AutoPilotPlugins/PX4/PX4TuningComponentCopterRate.qml
@@ -12,12 +12,14 @@ ColumnLayout {
     property Fact _airmode:             controller.getParameterFact(-1, "MC_AIRMODE", false)
     property Fact _thrustModelFactor:   controller.getParameterFact(-1, "THR_MDL_FAC", false)
 
+    QGCPalette { id: qgcPal; colorGroupEnabled: enabled }
+
     RowLayout {
         spacing: ScreenTools.defaultFontPixelWidth
 
         QGCLabel {
             textFormat:         Text.RichText
-            text:               qsTr("Airmode (disable during tuning) <b><a href=\"https://docs.px4.io/main/en/config_mc/pid_tuning_guide_multicopter.html#airmode-mixer-saturation\">?</a></b>")
+            text:               qsTr("Airmode (disable during tuning)") + " <b><a style='color: " + qgcPal.textLink + ";' href=\"https://docs.px4.io/main/en/config_mc/pid_tuning_guide_multicopter.html#airmode-mixer-saturation\">?</a></b>"
             onLinkActivated:    (link) => Qt.openUrlExternally(link)
             visible:            _airmode
         }
@@ -34,7 +36,7 @@ ColumnLayout {
 
         QGCLabel {
             textFormat:         Text.RichText
-            text:               qsTr("Thrust curve <b><a href=\"https://docs.px4.io/main/en/config_mc/pid_tuning_guide_multicopter.html#thrust-curve\">?</a></b>")
+            text:               qsTr("Thrust curve") + " <b><a style='color: " + qgcPal.textLink + ";' href=\"https://docs.px4.io/main/en/config_mc/pid_tuning_guide_multicopter.html#thrust-curve\">?</a></b>"
             onLinkActivated:    (link) => Qt.openUrlExternally(link)
             visible:            _thrustModelFactor
         }

--- a/src/FactSystem/FactControls/LabelledFactComboBox.qml
+++ b/src/FactSystem/FactControls/LabelledFactComboBox.qml
@@ -1,4 +1,5 @@
 import QtQuick
+import QtQuick.Controls
 import QtQuick.Layouts
 
 import QGroundControl
@@ -16,9 +17,48 @@ RowLayout {
 
     signal activated(int index)
 
-    QGCLabel {
-        id:                 label
+    Row {
         Layout.fillWidth:   true
+        spacing:            0
+
+        property bool _hasHelp: _comboBox.fact && _comboBox.fact.longDescription
+
+        QGCLabel {
+            id:                 label
+        }
+
+        Text {
+            id:                     helpIndicator
+            text:                   " ?"
+            font.pointSize:         ScreenTools.smallFontPointSize
+            font.bold:              true
+            color:                  qgcPal.textLink
+            visible:                parent._hasHelp
+            anchors.bottom:         label.verticalCenter
+            anchors.bottomMargin:   -2
+
+            QGCPalette { id: qgcPal; colorGroupEnabled: enabled }
+
+            MouseArea {
+                anchors.fill:       parent
+                anchors.margins:    -4
+                hoverEnabled:       true
+                onContainsMouseChanged: {
+                    if (containsMouse) {
+                        toolTip.visible = true
+                    } else {
+                        toolTip.visible = false
+                    }
+                }
+            }
+
+            ToolTip {
+                id:             toolTip
+                text:           _comboBox.fact ? _comboBox.fact.longDescription : ""
+                delay:          300
+                timeout:        10000
+            }
+        }
     }
 
     FactComboBox {

--- a/src/QmlControls/QGCPalette.cc
+++ b/src/QmlControls/QGCPalette.cc
@@ -73,6 +73,7 @@ void QGCPalette::_buildMap()
     DECLARE_QGC_COLOR(statusPendingText,    "#9d9d9d", "#000000", "#707070", "#ffffff")
     DECLARE_QGC_COLOR(toolbarBackground,    "#00ffffff", "#00ffffff", "#00222222", "#00222222")
     DECLARE_QGC_COLOR(groupBorder,          "#bbbbbb", "#3A9BDC", "#707070", "#707070")
+    DECLARE_QGC_COLOR(textLink,             "#1a72ff", "#1a72ff", "#48D6FF", "#48D6FF")
 
     // Colors not affecting by theming
     //                                                      Disabled     Enabled

--- a/src/QmlControls/QGCPalette.h
+++ b/src/QmlControls/QGCPalette.h
@@ -152,6 +152,7 @@ public:
     DEFINE_QGC_COLOR(groupBorder,                   setGroupBorder)
     DEFINE_QGC_COLOR(photoCaptureButtonColor,       setPhotoCaptureButtonColor)
     DEFINE_QGC_COLOR(videoCaptureButtonColor,       setVideoCaptureButtonColor)
+    DEFINE_QGC_COLOR(textLink,                      setTextLink)
 
 #ifdef QGC_UTM_ADAPTER
     DEFINE_QGC_COLOR(switchUTMSP,                    setSwitchUTMSP)

--- a/src/UI/AppSettings/HelpSettings.qml
+++ b/src/UI/AppSettings/HelpSettings.qml
@@ -25,29 +25,29 @@ Rectangle {
 
             QGCLabel { text: qsTr("QGroundControl User Guide") }
             QGCLabel {
-                linkColor:          qgcPal.text
-                text:               "<a href=\"https://docs.qgroundcontrol.com\">https://docs.qgroundcontrol.com</a>"
+                textFormat:         Text.RichText
+                text:               "<a style='color: " + qgcPal.textLink + ";' href=\"https://docs.qgroundcontrol.com\">https://docs.qgroundcontrol.com</a>"
                 onLinkActivated:    (link) => Qt.openUrlExternally(link)
             }
 
             QGCLabel { text: qsTr("PX4 Users Discussion Forum") }
             QGCLabel {
-                linkColor:          qgcPal.text
-                text:               "<a href=\"http://discuss.px4.io/c/qgroundcontrol\">http://discuss.px4.io/c/qgroundcontrol</a>"
+                textFormat:         Text.RichText
+                text:               "<a style='color: " + qgcPal.textLink + ";' href=\"http://discuss.px4.io/c/qgroundcontrol\">http://discuss.px4.io/c/qgroundcontrol</a>"
                 onLinkActivated:    (link) => Qt.openUrlExternally(link)
             }
 
             QGCLabel { text: qsTr("ArduPilot Users Discussion Forum") }
             QGCLabel {
-                linkColor:          qgcPal.text
-                text:               "<a href=\"https://discuss.ardupilot.org/c/ground-control-software/qgroundcontrol\">https://discuss.ardupilot.org/c/ground-control-software/qgroundcontrol</a>"
+                textFormat:         Text.RichText
+                text:               "<a style='color: " + qgcPal.textLink + ";' href=\"https://discuss.ardupilot.org/c/ground-control-software/qgroundcontrol\">https://discuss.ardupilot.org/c/ground-control-software/qgroundcontrol</a>"
                 onLinkActivated:    (link) => Qt.openUrlExternally(link)
             }
 
             QGCLabel { text: qsTr("QGroundControl Discord Channel") }
             QGCLabel {
-                linkColor:          qgcPal.text
-                text:               "<a href=\"https://discord.com/channels/1022170275984457759/1022185820683255908\">https://discord.com/channels/1022170275984457759/1022185820683255908</a>"
+                textFormat:         Text.RichText
+                text:               "<a style='color: " + qgcPal.textLink + ";' href=\"https://discord.com/channels/1022170275984457759/1022185820683255908\">https://discord.com/channels/1022170275984457759/1022185820683255908</a>"
                 onLinkActivated:    (link) => Qt.openUrlExternally(link)
             }
         }


### PR DESCRIPTION
- Added RC payload power switch param (RC_MAP_PAY_SW) to the Radio page
- Added a little tooltip `?` to `LabelledFactComboBox` to show the longDescription on hover
    - Should we add this to all Fact labels? I think it can be a really helpful to have the param descriptions available in the UI, I'm constantly checking https://docs.px4.io/main/en/advanced_config/parameter_reference
- Changed RichText link color from default (dark blue, hard to see) to new textLink color

<img width="901" height="796" alt="Screenshot from 2026-01-13 18-26-03" src="https://github.com/user-attachments/assets/30dd002f-9627-47d7-a2f6-1a02cb6ef1e9" />

<img width="796" height="190" alt="Screenshot from 2026-01-13 18-26-21" src="https://github.com/user-attachments/assets/2fc02de3-3173-4409-97eb-c3fcde343ea9" />

<img width="1039" height="461" alt="Screenshot from 2026-01-13 18-26-36" src="https://github.com/user-attachments/assets/6cb43698-7246-4eb3-8457-8094ad4ef755" />
