### PR TITLE
flight modes: px4: remove RC_DZ params

### DIFF
--- a/src/AutoPilotPlugins/PX4/PX4SimpleFlightModesController.cc
+++ b/src/AutoPilotPlugins/PX4/PX4SimpleFlightModesController.cc
@@ -135,7 +135,7 @@ void PX4SimpleFlightModesController::channelValuesChanged(QVector<int> pwmValues
             calibrated_value = (channelValue - pwmTrim) / (float)(pwmTrim - pwmMin);
 
         } else {
-            /* in the configured dead zone, output zero */
+            /* at the trim position, output zero */
             calibrated_value = 0.0f;
         }
 

--- a/src/AutoPilotPlugins/PX4/PX4SimpleFlightModesController.cc
+++ b/src/AutoPilotPlugins/PX4/PX4SimpleFlightModesController.cc
@@ -100,18 +100,6 @@ void PX4SimpleFlightModesController::channelValuesChanged(QVector<int> pwmValues
 
     int pwmTrim = pFact->rawValue().toInt();
 
-    pFact = getParameterFact(-1, QString("RC%1_DZ").arg(flightModeChannel + 1));
-    if(!pFact) {
-#if defined _MSC_VER
-        qCritical() << QString("RC%1_DZ").arg(flightModeChannel + 1) << "Fact is NULL in" << __FILE__ << __LINE__;
-#else
-        qCritical() << QString("RC%1_DZ").arg(flightModeChannel + 1) << " Fact is NULL in" << __func__ << __FILE__ << __LINE__;
-#endif
-        return;
-    }
-
-    int pwmDz = pFact->rawValue().toInt();
-
     if (flightModeChannel < 0 || flightModeChannel > channelCount) {
         return;
     }
@@ -140,13 +128,11 @@ void PX4SimpleFlightModesController::channelValuesChanged(QVector<int> pwmValues
 
         float calibrated_value;
 
-        if (channelValue > (pwmTrim + pwmDz)) {
-            calibrated_value = (channelValue - pwmTrim - pwmDz) / (float)(
-                          pwmMax - pwmTrim - pwmDz);
+        if (channelValue > pwmTrim) {
+            calibrated_value = (channelValue - pwmTrim) / (float)(pwmMax - pwmTrim);
 
-        } else if (channelValue < (pwmTrim - pwmDz)) {
-            calibrated_value = (channelValue - pwmTrim + pwmDz) / (float)(
-                          pwmTrim - pwmMin - pwmDz);
+        } else if (channelValue < pwmTrim) {
+            calibrated_value = (channelValue - pwmTrim) / (float)(pwmTrim - pwmMin);
 
         } else {
             /* in the configured dead zone, output zero */


### PR DESCRIPTION
I noticed while on the Flight Modes page the console was spamming a warning
```
   122.770 Warning: Missing parameter: 1 "RC6_DZ" - FactSystem.FactPanelController - (FactPanelController::_reportMissingParameter:40)
   122.770 Critical: "RC6_DZ"  Fact is NULL in channelValuesChanged /home/jake/code/jake/qgroundcontrol/src/AutoPilotPlugins/PX4/PX4SimpleFlightModesController.cc 108 - default - (PX4SimpleFlightModesController::channelValuesChanged:108)
   122.825 Warning: Missing parameter: 1 "RC6_DZ" - FactSystem.FactPanelController - (FactPanelController::_reportMissingParameter:40)
   122.825 Critical: "RC6_DZ"  Fact is NULL in channelValuesChanged /home/jake/code/jake/qgroundcontrol/src/AutoPilotPlugins/PX4/PX4SimpleFlightModesController.cc 108 - default - (PX4SimpleFlightModesController::channelValuesChanged:108)
   122.871 Warning: Missing parameter: 1 "RC6_DZ" - FactSystem.FactPanelController - (FactPanelController::_reportMissingParameter:40)
   122.871 Critical: "RC6_DZ"  Fact is NULL in channelValuesChanged /home/jake/code/jake/qgroundcontrol/src/AutoPilotPlugins/PX4/PX4SimpleFlightModesController.cc 108 - default - (PX4SimpleFlightModesController::channelValuesChanged:108)

```

This also fixes the mode/channel highlighting due to the early return from this error.

RC_DZ params have been removed since https://github.com/PX4/PX4-Autopilot/pull/25502