### PR TITLE
Fix QML undefined property assignment warnings

### DIFF
--- a/custom-example/res/Custom/Widgets/CustomAttitudeWidget.qml
+++ b/custom-example/res/Custom/Widgets/CustomAttitudeWidget.qml
@@ -13,8 +13,8 @@ Item {
     property real size
     property bool showHeading:  false
 
-    property real _rollAngle:   vehicle ? vehicle.roll.rawValue  : 0
-    property real _pitchAngle:  vehicle ? vehicle.pitch.rawValue : 0
+    property real _rollAngle:   vehicle?.roll?.rawValue ?? 0
+    property real _pitchAngle:  vehicle?.pitch?.rawValue ?? 0
 
     width:  size
     height: size
@@ -118,7 +118,7 @@ Item {
         color:                      "white"
         visible:                    showHeading
         font.pointSize:             ScreenTools.smallFontPointSize
-        property string _headingString: vehicle ? vehicle.heading.rawValue.toFixed(0) : "OFF"
+        property string _headingString: vehicle?.heading?.rawValue?.toFixed(0) ?? "OFF"
         property string _headingString2: _headingString.length  === 1 ? "0" + _headingString  : _headingString
         property string _headingString3: _headingString2.length === 2 ? "0" + _headingString2 : _headingString2
     }

--- a/custom-example/src/FlyViewCustomLayer.qml
+++ b/custom-example/src/FlyViewCustomLayer.qml
@@ -19,11 +19,11 @@ Item {
     property real   _indicatorsHeight:      ScreenTools.defaultFontPixelHeight
     property var    _sepColor:              qgcPal.globalTheme === QGCPalette.Light ? Qt.rgba(0,0,0,0.5) : Qt.rgba(1,1,1,0.5)
     property color  _indicatorsColor:       qgcPal.text
-    property bool   _isVehicleGps:          _activeVehicle ? _activeVehicle.gps.count.rawValue > 1 && _activeVehicle.gps.hdop.rawValue < 1.4 : false
-    property string _altitude:              _activeVehicle ? (isNaN(_activeVehicle.altitudeRelative.value) ? "0.0" : _activeVehicle.altitudeRelative.value.toFixed(1)) + ' ' + _activeVehicle.altitudeRelative.units : "0.0"
+    property bool   _isVehicleGps:          (_activeVehicle?.gps?.count?.rawValue ?? 0) > 1 && (_activeVehicle?.gps?.hdop?.rawValue ?? 99) < 1.4
+    property string _altitude:              _activeVehicle?.altitudeRelative ? (isNaN(_activeVehicle.altitudeRelative.value) ? "0.0" : _activeVehicle.altitudeRelative.value.toFixed(1)) + ' ' + _activeVehicle.altitudeRelative.units : "0.0"
     property string _distanceStr:           isNaN(_distance) ? "0" : _distance.toFixed(0) + ' ' + QGroundControl.unitsConversion.appSettingsHorizontalDistanceUnitsString
-    property real   _heading:               _activeVehicle   ? _activeVehicle.heading.rawValue : 0
-    property real   _distance:              _activeVehicle ? _activeVehicle.distanceToHome.rawValue : 0
+    property real   _heading:               _activeVehicle?.heading?.rawValue ?? 0
+    property real   _distance:              _activeVehicle?.distanceToHome?.rawValue ?? 0
     property string _messageTitle:          ""
     property string _messageText:           ""
     property real   _toolsMargin:           ScreenTools.defaultFontPixelWidth * 0.75

--- a/src/AnalyzeView/VibrationPage.qml
+++ b/src/AnalyzeView/VibrationPage.qml
@@ -14,13 +14,13 @@ AnalyzePage {
     allowPopout:        true
 
     property var    _activeVehicle: QGroundControl.multiVehicleManager.activeVehicle ? QGroundControl.multiVehicleManager.activeVehicle : QGroundControl.multiVehicleManager.offlineEditingVehicle
-    property bool   _available:     !isNaN(_activeVehicle.vibration.xAxis.rawValue)
+    property bool   _available:     !isNaN(_activeVehicle?.vibration?.xAxis?.rawValue ?? NaN)
     property real   _margins:       ScreenTools.defaultFontPixelWidth / 2
     property real   _barWidth:      ScreenTools.defaultFontPixelWidth * 7
     property real   _barHeight:     ScreenTools.defaultFontPixelHeight * 10
-    property real   _xValue:        _activeVehicle.vibration.xAxis.rawValue
-    property real   _yValue:        _activeVehicle.vibration.yAxis.rawValue
-    property real   _zValue:        _activeVehicle.vibration.zAxis.rawValue
+    property real   _xValue:        _activeVehicle?.vibration?.xAxis?.rawValue ?? 0
+    property real   _yValue:        _activeVehicle?.vibration?.yAxis?.rawValue ?? 0
+    property real   _zValue:        _activeVehicle?.vibration?.zAxis?.rawValue ?? 0
 
     readonly property real _barMinimum:     0.0
     readonly property real _barMaximum:     90.0
@@ -186,15 +186,15 @@ AnalyzePage {
                 }
 
                 QGCLabel {
-                    text: qsTr("Accel 1: %1").arg(_activeVehicle.vibration.clipCount1.rawValue)
+                    text: qsTr("Accel 1: %1").arg(_activeVehicle?.vibration?.clipCount1?.rawValue ?? 0)
                 }
 
                 QGCLabel {
-                    text: qsTr("Accel 2: %1").arg(_activeVehicle.vibration.clipCount2.rawValue)
+                    text: qsTr("Accel 2: %1").arg(_activeVehicle?.vibration?.clipCount2?.rawValue ?? 0)
                 }
 
                 QGCLabel {
-                    text: qsTr("Accel 3: %1").arg(_activeVehicle.vibration.clipCount3.rawValue)
+                    text: qsTr("Accel 3: %1").arg(_activeVehicle?.vibration?.clipCount3?.rawValue ?? 0)
                 }
             }
 

--- a/src/FlightMap/MapItems/ProximityRadarMapView.qml
+++ b/src/FlightMap/MapItems/ProximityRadarMapView.qml
@@ -12,7 +12,7 @@ MapQuickItem {
 
     property var    vehicle                                                         /// Vehicle object, undefined for ADSB vehicle
     property var    map
-    property double heading:    vehicle ? vehicle.heading.value : Number.NaN    ///< Vehicle heading, NAN for none
+    property double heading:    vehicle?.heading?.value ?? Number.NaN    ///< Vehicle heading, NAN for none
 
     anchorPoint.x:  vehicleItem.width  / 2
     anchorPoint.y:  vehicleItem.height / 2

--- a/src/FlightMap/MapItems/QGCMapCircleVisuals.qml
+++ b/src/FlightMap/MapItems/QGCMapCircleVisuals.qml
@@ -21,7 +21,7 @@ Item {
     property color  borderColor:              QGroundControl.globalPalette.mapMissionTrajectory
     property bool   centerDragHandleVisible:  true
     property bool   radiusLabelVisible:       false
-    property real   _radius:                  mapCircle ? mapCircle.radius.rawValue : 0
+    property real   _radius:                  mapCircle?.radius?.rawValue ?? 0
 
     property var    _circleComponent
     property var    _topRotationIndicatorComponent

--- a/src/FlightMap/MapItems/VehicleMapItem.qml
+++ b/src/FlightMap/MapItems/VehicleMapItem.qml
@@ -14,7 +14,7 @@ MapQuickItem {
     property var    map
     property double altitude:       Number.NaN                                      ///< NAN to not show
     property string callsign:       ""                                              ///< Vehicle callsign
-    property double heading:        vehicle ? vehicle.heading.value : Number.NaN    ///< Vehicle heading, NAN for none
+    property double heading:        vehicle?.heading?.value ?? Number.NaN    ///< Vehicle heading, NAN for none
     property real   size:           ScreenTools.defaultFontPixelHeight * 3          /// Default size for icon, most usage overrides this
     property bool   alert:          false                                           /// Collision alert
 

--- a/src/FlightMap/Widgets/IntegratedCompassAttitude.qml
+++ b/src/FlightMap/Widgets/IntegratedCompassAttitude.qml
@@ -27,13 +27,13 @@ Item {
     IntegratedAttitudeIndicator {
         id:                     rollIndicator
         x:                      -_totalAttitudeSize
-        attitudeAngleDegrees:   vehicle ? vehicle.roll.rawValue : 0
+        attitudeAngleDegrees:   vehicle?.roll?.rawValue ?? 0
         compassRadius:          control.compassRadius
     }
 
     IntegratedAttitudeIndicator {
         x:                      -_totalAttitudeSize
-        attitudeAngleDegrees:   vehicle ? vehicle.pitch.rawValue : 0
+        attitudeAngleDegrees:   vehicle?.pitch?.rawValue ?? 0
         compassRadius:          control.compassRadius
         attitudeSize:           control.attitudeSize
         attitudeSpacing:        control.attitudeSpacing

--- a/src/FlightMap/Widgets/QGCAttitudeWidget.qml
+++ b/src/FlightMap/Widgets/QGCAttitudeWidget.qml
@@ -12,8 +12,8 @@ Item {
     property real size
     property bool showHeading:  false
 
-    property real _rollAngle:   vehicle ? vehicle.roll.rawValue  : 0
-    property real _pitchAngle:  vehicle ? vehicle.pitch.rawValue : 0
+    property real _rollAngle:   vehicle?.roll?.rawValue ?? 0
+    property real _pitchAngle:  vehicle?.pitch?.rawValue ?? 0
 
     width:  size
     height: size
@@ -120,7 +120,7 @@ Item {
         color:                      "white"
         visible:                    showHeading
 
-        property string _headingString: vehicle ? vehicle.heading.rawValue.toFixed(0) : "OFF"
+        property string _headingString: vehicle?.heading?.rawValue?.toFixed(0) ?? "OFF"
         property string _headingString2: _headingString.length === 1 ? "0" + _headingString : _headingString
         property string _headingString3: _headingString2.length === 2 ? "0" + _headingString2 : _headingString2
     }

--- a/src/FlyView/ObstacleDistanceOverlay.qml
+++ b/src/FlyView/ObstacleDistanceOverlay.qml
@@ -53,7 +53,7 @@ Canvas {
             return
 
         _offsetDeg = _activeVehicle.objectAvoidance.angleOffset
-        _heading = _activeVehicle.heading.value
+        _heading = _activeVehicle?.heading?.value ?? 0
         _maxRadiusMeters = _activeVehicle.objectAvoidance.maxDistance / 100
         _rangesLen = 360.0 / _incrementDeg
         if (_rangesLen > _ranges.length)

--- a/src/FlyView/PreFlightBatteryCheck.qml
+++ b/src/FlyView/PreFlightBatteryCheck.qml
@@ -16,7 +16,7 @@ PreFlightCheckButton {
     property int    failurePercent:                 40
     property bool   allowFailurePercentOverride:    false
     property var    _batteryGroup:                  globals.activeVehicle && globals.activeVehicle.batteries.count ? globals.activeVehicle.batteries.get(0) : undefined
-    property var    _batteryValue:                  _batteryGroup ? _batteryGroup.percentRemaining.value : 0
+    property var    _batteryValue:                  _batteryGroup?.percentRemaining?.value ?? 0
     property var    _batPercentRemaining:           isNaN(_batteryValue) ? 0 : _batteryValue
     property bool   _batLow:                        _batPercentRemaining < failurePercent
 }

--- a/src/FlyView/PreFlightGPSCheck.qml
+++ b/src/FlyView/PreFlightGPSCheck.qml
@@ -14,8 +14,8 @@ PreFlightCheckButton {
     property bool   allowOverrideSatCount:  false   ///< true: sat count above failureSatCount reguired to pass, false: user can click past satCount <= failureSetCount
     property int    failureSatCount:        -1      ///< -1 indicates no sat count check
 
-    property bool   _3dLock:                globals.activeVehicle ? globals.activeVehicle.gps.lock.rawValue >= 3 : false
-    property int    _satCount:              globals.activeVehicle ? globals.activeVehicle.gps.count.rawValue : 0
+    property bool   _3dLock:                (globals.activeVehicle?.gps?.lock?.rawValue ?? 0) >= 3
+    property int    _satCount:              globals.activeVehicle?.gps?.count?.rawValue ?? 0
     property bool   _3dLockFailure:         !_3dLock
     property bool   _satCountFailure:       failureSatCount !== -1 && _satCount <= failureSatCount
     property string _satCountFailureText:   allowOverrideSatCount ? qsTr("Warning - Sat count below %1.").arg(failureSatCount + 1) : qsTr("Waiting for sat count above %1.").arg(failureSatCount)

--- a/src/FlyView/ProximityRadarValues.qml
+++ b/src/FlyView/ProximityRadarValues.qml
@@ -8,24 +8,24 @@ QtObject {
 
     signal rotationValueChanged ///< Signalled when any available rotation value changes
 
-    property real   rotationNoneValue:      _distanceSensors ? _distanceSensors.rotationNone.value : NaN
-    property real   rotationYaw45Value:     _distanceSensors ? _distanceSensors.rotationYaw45.value : NaN
-    property real   rotationYaw90Value:     _distanceSensors ? _distanceSensors.rotationYaw90.value : NaN
-    property real   rotationYaw135Value:    _distanceSensors ? _distanceSensors.rotationYaw135.value : NaN
-    property real   rotationYaw180Value:    _distanceSensors ? _distanceSensors.rotationYaw180.value : NaN
-    property real   rotationYaw225Value:    _distanceSensors ? _distanceSensors.rotationYaw225.value : NaN
-    property real   rotationYaw270Value:    _distanceSensors ? _distanceSensors.rotationYaw270.value : NaN
-    property real   rotationYaw315Value:    _distanceSensors ? _distanceSensors.rotationYaw315.value : NaN
-    property real   maxDistance:            _distanceSensors ? _distanceSensors.maxDistance.value : NaN
+    property real   rotationNoneValue:      _distanceSensors?.rotationNone?.value ?? NaN
+    property real   rotationYaw45Value:     _distanceSensors?.rotationYaw45?.value ?? NaN
+    property real   rotationYaw90Value:     _distanceSensors?.rotationYaw90?.value ?? NaN
+    property real   rotationYaw135Value:    _distanceSensors?.rotationYaw135?.value ?? NaN
+    property real   rotationYaw180Value:    _distanceSensors?.rotationYaw180?.value ?? NaN
+    property real   rotationYaw225Value:    _distanceSensors?.rotationYaw225?.value ?? NaN
+    property real   rotationYaw270Value:    _distanceSensors?.rotationYaw270?.value ?? NaN
+    property real   rotationYaw315Value:    _distanceSensors?.rotationYaw315?.value ?? NaN
+    property real   maxDistance:            _distanceSensors?.maxDistance?.value ?? NaN
 
-    property string rotationNoneValueString:    _distanceSensors ? _distanceSensors.rotationNone.valueString : _noValueStr
-    property string rotationYaw45ValueString:   _distanceSensors ? _distanceSensors.rotationYaw45.valueString : _noValueStr
-    property string rotationYaw90ValueString:   _distanceSensors ? _distanceSensors.rotationYaw90.valueString : _noValueStr
-    property string rotationYaw135ValueString:  _distanceSensors ? _distanceSensors.rotationYaw135.valueString : _noValueStr
-    property string rotationYaw180ValueString:  _distanceSensors ? _distanceSensors.rotationYaw180.valueString : _noValueStr
-    property string rotationYaw225ValueString:  _distanceSensors ? _distanceSensors.rotationYaw225.valueString : _noValueStr
-    property string rotationYaw270ValueString:  _distanceSensors ? _distanceSensors.rotationYaw270.valueString : _noValueStr
-    property string rotationYaw315ValueString:  _distanceSensors ? _distanceSensors.rotationYaw315.valueString : _noValueStr
+    property string rotationNoneValueString:    _distanceSensors?.rotationNone?.valueString ?? _noValueStr
+    property string rotationYaw45ValueString:   _distanceSensors?.rotationYaw45?.valueString ?? _noValueStr
+    property string rotationYaw90ValueString:   _distanceSensors?.rotationYaw90?.valueString ?? _noValueStr
+    property string rotationYaw135ValueString:  _distanceSensors?.rotationYaw135?.valueString ?? _noValueStr
+    property string rotationYaw180ValueString:  _distanceSensors?.rotationYaw180?.valueString ?? _noValueStr
+    property string rotationYaw225ValueString:  _distanceSensors?.rotationYaw225?.valueString ?? _noValueStr
+    property string rotationYaw270ValueString:  _distanceSensors?.rotationYaw270?.valueString ?? _noValueStr
+    property string rotationYaw315ValueString:  _distanceSensors?.rotationYaw315?.valueString ?? _noValueStr
 
     property var    rgRotationValues:           [ rotationNoneValue, rotationYaw45Value, rotationYaw90Value, rotationYaw135Value, rotationYaw180Value, rotationYaw225Value, rotationYaw270Value, rotationYaw315Value ]
     property var    rgRotationValueStrings:     [ rotationNoneValueString, rotationYaw45ValueString, rotationYaw90ValueString, rotationYaw135ValueString, rotationYaw180ValueString, rotationYaw225ValueString, rotationYaw270ValueString, rotationYaw315ValueString ]

--- a/src/FlyView/TerrainProgress.qml
+++ b/src/FlyView/TerrainProgress.qml
@@ -13,9 +13,9 @@ Rectangle {
 
     property var    _activeVehicle: QGroundControl.multiVehicleManager.activeVehicle
     property real   _margins:       ScreenTools.defaultFontPixelWidth / 2
-    property real   _totalBlocks:   _activeVehicle ? _activeVehicle.terrain.blocksPending.rawValue + _activeVehicle.terrain.blocksLoaded.rawValue : 0
-    property real   _blocksLoaded:  _activeVehicle ? _activeVehicle.terrain.blocksLoaded.rawValue : 0
-    property real   _blocksPending: _activeVehicle ? _activeVehicle.terrain.blocksPending.rawValue : 0
+    property real   _totalBlocks:   (_activeVehicle?.terrain?.blocksPending?.rawValue ?? 0) + (_activeVehicle?.terrain?.blocksLoaded?.rawValue ?? 0)
+    property real   _blocksLoaded:  _activeVehicle?.terrain?.blocksLoaded?.rawValue ?? 0
+    property real   _blocksPending: _activeVehicle?.terrain?.blocksPending?.rawValue ?? 0
     property real   _pctComplete:   _activeVehicle && _totalBlocks ? _blocksLoaded / _totalBlocks : 0
 
     on_BlocksPendingChanged: {

--- a/src/QmlControls/GPSIndicator.qml
+++ b/src/QmlControls/GPSIndicator.qml
@@ -45,7 +45,7 @@ Item {
                 source:             "/qmlimages/Gps.svg"
                 fillMode:           Image.PreserveAspectFit
                 sourceSize.height:  height
-                opacity:            (_activeVehicle && _activeVehicle.gps.count.value >= 0) ? 1 : 0.5
+                opacity:            ((_activeVehicle?.gps?.count?.value ?? -1) >= 0) ? 1 : 0.5
                 color:              qgcPal.windowTransparentText
             }
         }
@@ -53,19 +53,19 @@ Item {
         Column {
             id:                     gpsValuesColumn
             anchors.verticalCenter: parent.verticalCenter
-            visible:                _activeVehicle && !isNaN(_activeVehicle.gps.hdop.value)
+            visible:                _activeVehicle && !isNaN(_activeVehicle?.gps?.hdop?.value ?? NaN)
             spacing:                0
 
             QGCLabel {
                 anchors.horizontalCenter:   hdopValue.horizontalCenter
                 color:              qgcPal.windowTransparentText
-                text:               _activeVehicle ? _activeVehicle.gps.count.valueString : ""
+                text:               _activeVehicle?.gps?.count?.valueString ?? ""
             }
 
             QGCLabel {
                 id:     hdopValue
                 color:  qgcPal.windowTransparentText
-                text:   _activeVehicle ? _activeVehicle.gps.hdop.value.toFixed(1) : ""
+                text:   _activeVehicle?.gps?.hdop?.value?.toFixed(1) ?? ""
             }
         }
     }

--- a/src/QmlControls/GPSIndicatorPage.qml
+++ b/src/QmlControls/GPSIndicatorPage.qml
@@ -65,27 +65,27 @@ ToolIndicatorPage {
 
                 LabelledLabel {
                     label:      qsTr("Satellites")
-                    labelText:  activeVehicle ? activeVehicle.gps.count.valueString : na
+                    labelText:  activeVehicle?.gps?.count?.valueString ?? na
                 }
 
                 LabelledLabel {
                     label:      qsTr("GPS Lock")
-                    labelText:  activeVehicle ? activeVehicle.gps.lock.enumStringValue : na
+                    labelText:  activeVehicle?.gps?.lock?.enumStringValue ?? na
                 }
 
                 LabelledLabel {
                     label:      qsTr("HDOP")
-                    labelText:  activeVehicle ? activeVehicle.gps.hdop.valueString : valueNA
+                    labelText:  activeVehicle?.gps?.hdop?.valueString ?? valueNA
                 }
 
                 LabelledLabel {
                     label:      qsTr("VDOP")
-                    labelText:  activeVehicle ? activeVehicle.gps.vdop.valueString : valueNA
+                    labelText:  activeVehicle?.gps?.vdop?.valueString ?? valueNA
                 }
 
                 LabelledLabel {
                     label:      qsTr("Course Over Ground")
-                    labelText:  activeVehicle ? activeVehicle.gps.courseOverGround.valueString : valueNA
+                    labelText:  activeVehicle?.gps?.courseOverGround?.valueString ?? valueNA
                 }
             }
 

--- a/src/QmlControls/OfflineMapEditor.qml
+++ b/src/QmlControls/OfflineMapEditor.qml
@@ -55,7 +55,7 @@ FlightMap {
     readonly property real maxZoomLevel:    20
     readonly property real sliderTouchArea: ScreenTools.defaultFontPixelWidth * (ScreenTools.isTinyScreen ? 5 : (ScreenTools.isMobile ? 6 : 3))
 
-    readonly property int _maxTilesForDownload: _settings ? _settings.maxTilesForDownload.rawValue : 0
+    readonly property int _maxTilesForDownload: _settings?.maxTilesForDownload?.rawValue ?? 0
 
     QGCPalette { id: qgcPal }
 

--- a/src/UI/toolbar/GimbalIndicator.qml
+++ b/src/UI/toolbar/GimbalIndicator.qml
@@ -60,7 +60,7 @@ Item {
                 id:                     gimbalIdLabel
                 anchors.horizontalCenter: parent.horizontalCenter
                 font.pointSize:         ScreenTools.smallFontPointSize
-                text:                   activeGimbal ? activeGimbal.deviceId.rawValue : ""
+                text:                   activeGimbal?.deviceId?.rawValue ?? ""
                 color:                  qgcPal.windowTransparentText
                 visible:                multiGimbalSetup
             }

--- a/src/Viewer3D/Viewer3DQml/Drones/DroneModelDjiF450.qml
+++ b/src/Viewer3D/Viewer3DQml/Drones/DroneModelDjiF450.qml
@@ -10,12 +10,12 @@ Node{
     property double altitudeBias: 0
     property var gpsRef: QtPositioning.coordinate(0, 0, 0)
 
-    property double roll:        vehicle ? vehicle.roll.value : 0
-    property double pitch:        vehicle ? vehicle.pitch.value : 0
-    property double heading:        vehicle ? vehicle.heading.value : 0
+    property double roll:        vehicle?.roll?.value ?? 0
+    property double pitch:        vehicle?.pitch?.value ?? 0
+    property double heading:        vehicle?.heading?.value ?? 0
 
     property double pose_y: (geo2Enu.localCoordinate.y)?(geo2Enu.localCoordinate.y * 10) : (0)
-    property double pose_z: (vehicle.altitudeRelative.value)?((vehicle.altitudeRelative.value + altitudeBias) * 10 ): (0)
+    property double pose_z: (vehicle?.altitudeRelative?.value) ? ((vehicle.altitudeRelative.value + altitudeBias) * 10) : 0
     property double pose_x: (geo2Enu.localCoordinate.x)? (geo2Enu.localCoordinate.x * 10) : (0)
 
     property int _poseAnimationDuration: 200


### PR DESCRIPTION
Replace ternary null-guards with optional chaining for nested Fact property access

Follow up from https://github.com/mavlink/qgroundcontrol/pull/13866

Needs to be fully tested