### PR TITLE
fix(linux): Add Wayland platform plugins for Qt 6.10 AppImage builds

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -329,10 +329,9 @@ qt_import_plugins(${CMAKE_PROJECT_NAME}
 if(LINUX)
     qt_import_plugins(${CMAKE_PROJECT_NAME}
         INCLUDE
-            Qt6::QWaylandIntegrationPlugin      # Wayland support
+            Qt6::QWaylandIntegrationPlugin      # Wayland support (libqwayland.so)
             Qt6::QXcbIntegrationPlugin          # X11 support
             Qt6::QEglFSIntegrationPlugin        # Embedded GL support
-            Qt6::QWaylandEglPlatformIntegrationPlugin
     )
 endif()
 

--- a/cmake/install/Install.cmake
+++ b/cmake/install/Install.cmake
@@ -23,12 +23,18 @@ install(
 # Qt Deployment Script Generation
 # ----------------------------------------------------------------------------
 set(deploy_tool_options_arg "")
+set(deploy_include_plugins "")
 
 if(MACOS OR WIN32)
     list(APPEND deploy_tool_options_arg "-qmldir=${CMAKE_SOURCE_DIR}")
     if(MACOS)
         list(APPEND deploy_tool_options_arg "-appstore-compliant")
     endif()
+endif()
+
+if(LINUX)
+    # Qt 6.10+ renamed wayland platform plugin to libqwayland.so
+    set(deploy_include_plugins INCLUDE_PLUGINS qwayland)
 endif()
 
 qt_generate_deploy_qml_app_script(
@@ -38,6 +44,7 @@ qt_generate_deploy_qml_app_script(
     NO_UNSUPPORTED_PLATFORM_ERROR
     DEPLOY_USER_QML_MODULES_ON_UNSUPPORTED_PLATFORM
     DEPLOY_TOOL_OPTIONS ${deploy_tool_options_arg}
+    ${deploy_include_plugins}
 )
 
 install(SCRIPT ${deploy_script})

--- a/deploy/linux/appimagecraft.yml
+++ b/deploy/linux/appimagecraft.yml
@@ -18,7 +18,7 @@ appimage:
     plugins:
       - qt
     raw_environment:
-      QML_SOURCES_PATHS: "\"$PROJECT_ROOT\"/src/qmlcomponents/"
+      QML_SOURCES_PATHS: "\"$PROJECT_ROOT\"/src"
     environment:
-      EXTRA_PLATFORM_PLUGINS: "libqwayland-egl.so;libqwayland-generic.so"
-      EXTRA_QT_PLUGINS: "waylandcompositor"
+      # Qt 6.10+ renamed wayland plugins: libqwayland-egl.so/libqwayland-generic.so -> libqwayland.so
+      EXTRA_PLATFORM_PLUGINS: "libqwayland.so"


### PR DESCRIPTION
## Summary

Fixes #13855

Qt 6.10 renamed Wayland platform plugins:
- **Old**: `libqwayland-egl.so`, `libqwayland-generic.so`
- **New**: `libqwayland.so`

This caused Wayland plugins to be missing from AppImage builds.

## Changes

### CMakeLists.txt
- Remove non-existent `Qt6::QWaylandEglPlatformIntegrationPlugin` (was causing CMake warning)

### cmake/install/Install.cmake
- Add `INCLUDE_PLUGINS qwayland` to ensure the Wayland platform plugin is deployed

### deploy/linux/appimagecraft.yml
- Update library name to Qt 6.10 convention (not currently used but kept consistent)

## Test Plan

- [ ] Build AppImage on Linux with Qt 6.10+
- [ ] Verify AppImage contains `plugins/platforms/libqwayland.so`
- [ ] Test AppImage launches correctly on Wayland session
- [ ] Test AppImage still works on X11 session