### PR TITLE
fix(ci): aggregate artifacts from all platform workflows in build-results

### DIFF
--- a/.github/actions/download-all-artifacts/action.yml
+++ b/.github/actions/download-all-artifacts/action.yml
@@ -1,0 +1,47 @@
+name: Download All Platform Artifacts
+description: Download artifacts from all completed platform workflow runs for the same commit
+
+inputs:
+  github-token:
+    description: GitHub token for API access
+    required: true
+
+runs:
+  using: composite
+  steps:
+    - name: Download artifacts from all platform workflows
+      shell: bash
+      env:
+        GH_TOKEN: ${{ inputs.github-token }}
+      run: |
+        HEAD_SHA="${{ github.event.workflow_run.head_sha }}"
+        REPO="${{ github.repository }}"
+
+        if [ -z "$HEAD_SHA" ]; then
+          echo "Error: No head SHA available"
+          exit 1
+        fi
+
+        echo "Finding completed workflow runs for commit ${HEAD_SHA:0:7}..."
+
+        # Get run IDs and names in one query
+        RUNS=$(gh api "repos/${REPO}/actions/runs?head_sha=${HEAD_SHA}&per_page=100" \
+          --jq '.workflow_runs[] | select(.name == "Linux" or .name == "Windows" or .name == "MacOS" or .name == "Android") | select(.status == "completed" and .conclusion == "success") | "\(.id) \(.name)"')
+
+        if [ -z "$RUNS" ]; then
+          echo "No completed workflow runs found"
+          exit 0
+        fi
+
+        mkdir -p artifacts
+
+        echo "$RUNS" | while read -r run_id workflow_name; do
+          echo "Downloading artifacts from ${workflow_name} (run ${run_id})..."
+          gh run download "$run_id" --dir artifacts --repo "$REPO" || echo "  Warning: Some artifacts failed to download"
+        done
+
+        echo "Downloaded artifacts:"
+        find artifacts -type f \( -name "*.apk" -o -name "*.dmg" -o -name "*.exe" -o -name "*.AppImage" \) 2>/dev/null | while read -r f; do
+          SIZE=$(du -h "$f" | cut -f1)
+          echo "  - $(basename "$f"): $SIZE"
+        done

--- a/.github/workflows/build-results.yml
+++ b/.github/workflows/build-results.yml
@@ -27,7 +27,9 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v6
         with:
-          sparse-checkout: .github/scripts/check-sizes.py
+          sparse-checkout: |
+            .github/scripts/check-sizes.py
+            .github/actions/download-all-artifacts
           sparse-checkout-cone-mode: false
 
       - name: Get PR number
@@ -107,14 +109,12 @@ jobs:
             core.setOutput('summary', summary);
             core.setOutput('all_complete', allComplete);
 
-      - name: Download artifacts from triggering workflow
+      - name: Download artifacts from all platform workflows
         if: steps.pr.outputs.result != 'null'
-        uses: actions/download-artifact@v7
         continue-on-error: true
+        uses: ./.github/actions/download-all-artifacts
         with:
-          run-id: ${{ github.event.workflow_run.id }}
           github-token: ${{ secrets.GITHUB_TOKEN }}
-          path: artifacts
 
       - name: Restore baseline sizes
         if: steps.pr.outputs.result != 'null'
@@ -330,16 +330,16 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v6
         with:
-          sparse-checkout: .github/scripts/check-sizes.py
+          sparse-checkout: |
+            .github/scripts/check-sizes.py
+            .github/actions/download-all-artifacts
           sparse-checkout-cone-mode: false
 
-      - name: Download artifacts
-        uses: actions/download-artifact@v7
+      - name: Download artifacts from all platform workflows
         continue-on-error: true
+        uses: ./.github/actions/download-all-artifacts
         with:
-          run-id: ${{ github.event.workflow_run.id }}
           github-token: ${{ secrets.GITHUB_TOKEN }}
-          path: artifacts
 
       - name: Save artifact sizes baseline
         run: |

--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -167,7 +167,3 @@ jobs:
                 body: body
               });
             }
-
-      - name: Fail if pre-commit failed
-        if: steps.pre-commit.outputs.exit_code != '0'
-        run: exit 1


### PR DESCRIPTION
## Summary

- **build-results.yml**: Now downloads artifacts from all completed platform workflows (Linux, Windows, MacOS, Android) instead of just the triggering workflow. This fixes the issue where only Android artifacts were shown when Android completed last.
- **pre-commit.yml**: Makes pre-commit checks informational only - still leaves a comment on PRs but no longer fails the build.

Fixes the artifact sizes display issue reported in #13865 where only Android artifacts were shown with incorrect names.

## Test plan

- [ ] Verify build-results comment shows artifacts from all platforms after all workflows complete
- [ ] Verify pre-commit workflow leaves comment but doesn't fail the build