### PR TITLE
fix(ci): Prevent PR builds from saving caches

### DIFF
--- a/.github/actions/cache/action.yml
+++ b/.github/actions/cache/action.yml
@@ -73,7 +73,7 @@ runs:
       if: runner.os == 'Windows' && inputs.target != 'android' && inputs.host != 'windows_arm64'
       uses: mozilla-actions/sccache-action@v0.0.9
 
-    - run: echo "SCCACHE_GHA_ENABLED=true" >> "$GITHUB_ENV"
+    - run: echo "SCCACHE_GHA_ENABLED=${{ inputs.save-cache == 'true' && 'true' || 'false' }}" >> "$GITHUB_ENV"
       if: runner.os == 'Windows' && inputs.target != 'android' && inputs.host != 'windows_arm64'
       shell: bash
 
@@ -95,9 +95,17 @@ runs:
       run: mkdir -p "${{ inputs.cpm-modules }}"
       shell: bash
 
-    - name: Cache CPM Modules
-      if: inputs.cpm-modules != ''
+    - name: Cache CPM Modules (restore and save)
+      if: inputs.cpm-modules != '' && inputs.save-cache == 'true'
       uses: actions/cache@v5
+      with:
+        path: ${{ inputs.cpm-modules }}
+        key: ${{ github.workflow }}-cpm-modules-${{ hashFiles('**/CMakeLists.txt', '**/*.cmake') }}
+        restore-keys: ${{ github.workflow }}-cpm-modules-
+
+    - name: Cache CPM Modules (restore only)
+      if: inputs.cpm-modules != '' && inputs.save-cache != 'true'
+      uses: actions/cache/restore@v5
       with:
         path: ${{ inputs.cpm-modules }}
         key: ${{ github.workflow }}-cpm-modules-${{ hashFiles('**/CMakeLists.txt', '**/*.cmake') }}

--- a/.github/workflows/check-links.yml
+++ b/.github/workflows/check-links.yml
@@ -36,11 +36,24 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v6
 
-      - name: Restore lychee cache
+      - name: Get cache date
+        id: cache-date
+        run: echo "date=$(date -u '+%Y-%m-%d')" >> "$GITHUB_OUTPUT"
+
+      - name: Restore lychee cache (PR)
+        if: github.event_name == 'pull_request'
+        uses: actions/cache/restore@v5
+        with:
+          path: .lycheecache
+          key: cache-lychee-${{ steps.cache-date.outputs.date }}
+          restore-keys: cache-lychee-
+
+      - name: Cache lychee (push)
+        if: github.event_name != 'pull_request'
         uses: actions/cache@v5
         with:
           path: .lycheecache
-          key: cache-lychee-${{ github.sha }}
+          key: cache-lychee-${{ steps.cache-date.outputs.date }}
           restore-keys: cache-lychee-
 
       - name: Check links

--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -52,7 +52,15 @@ jobs:
           python -m pip install pre-commit
           python -m pip freeze --local
 
-      - name: Cache pre-commit hooks
+      - name: Restore pre-commit cache (PR)
+        if: github.event_name == 'pull_request'
+        uses: actions/cache/restore@v5
+        with:
+          path: ~/.cache/pre-commit
+          key: pre-commit-3|${{ env.pythonLocation }}|${{ hashFiles('.pre-commit-config.yaml') }}
+
+      - name: Cache pre-commit hooks (push)
+        if: github.event_name != 'pull_request'
         uses: actions/cache@v5
         with:
           path: ~/.cache/pre-commit


### PR DESCRIPTION
## Summary
- PR builds were filling the 10GB GitHub Actions cache quota, causing all master branch caches to be evicted
- Master builds then had cache misses, resulting in longer build times

## Changes
- **sccache**: Disable GHA integration on PRs (`SCCACHE_GHA_ENABLED=false`)
- **CPM modules**: Use `actions/cache/restore` on PRs (restore-only)
- **check-links**: Use daily cache key instead of per-commit, restore-only on PRs
- **pre-commit**: Use restore-only on PRs

## Cache behavior after fix

| Event | Build Cache | CPM | sccache GHA | Lychee | Pre-commit |
|-------|-------------|-----|-------------|--------|------------|
| Push to master | Save | Save | Enabled | Save | Save |
| Pull request | Restore | Restore | Disabled | Restore | Restore |

## Test plan
- [ ] Verify PR builds restore caches but don't save new ones
- [ ] Verify push to master saves caches
- [ ] Monitor cache usage to confirm master caches persist