### PR TITLE
feat(Compression): Make BZip2 and LZ4 optional dependencies

### DIFF
--- a/cmake/CustomOptions.cmake
+++ b/cmake/CustomOptions.cmake
@@ -43,6 +43,15 @@ cmake_dependent_option(QGC_ENABLE_COVERAGE "Enable code coverage instrumentation
 option(QGC_UTM_ADAPTER "Enable UTM (Unmanned Traffic Management) Adapter" OFF)
 option(QGC_VIEWER3D "Enable 3D Viewer (requires Qt Quick 3D)" ON)
 
+# ============================================================================
+# Compression Format Options
+# ============================================================================
+# Core formats (gzip, xz, zstd, zip) are always enabled.
+# These optional formats are rarely used in the drone ecosystem.
+
+option(QGC_ENABLE_BZIP2 "Enable BZip2 decompression support" OFF)
+option(QGC_ENABLE_LZ4 "Enable LZ4 decompression support" OFF)
+
 # MAVLink Inspector is disabled by default due to GPL licensing of QtCharts
 # option(QGC_DISABLE_MAVLINK_INSPECTOR "Disable MAVLink Inspector" OFF)
 

--- a/src/Utilities/Compression/CMakeLists.txt
+++ b/src/Utilities/Compression/CMakeLists.txt
@@ -1,7 +1,8 @@
 # ============================================================================
 # Decompression Subsystem
 # Unified decompression using libarchive (decompression-only)
-# Formats: ZIP, GZIP, XZ/LZMA, ZSTD, LZ4, BZip2
+# Core formats: ZIP, GZIP, XZ/LZMA, ZSTD (always enabled)
+# Optional formats: LZ4, BZip2 (controlled by QGC_ENABLE_LZ4, QGC_ENABLE_BZIP2)
 # ============================================================================
 
 target_sources(${CMAKE_PROJECT_NAME}
@@ -78,6 +79,7 @@ CPMAddPackage(
     GITHUB_REPOSITORY tukaani-project/xz
     GIT_TAG v5.8.2
     OPTIONS
+        "BUILD_TESTING OFF"
         "BUILD_SHARED_LIBS OFF"
         "XZ_TOOL_XZ OFF"
         "XZ_TOOL_XZDEC OFF"
@@ -118,6 +120,11 @@ endif()
 # Zstandard (ZSTD) Integration
 # ============================================================================
 
+# Suppress CMake warning about MSVC not being an ASM assembler (CMP0194)
+if(POLICY CMP0194)
+    set(CMAKE_POLICY_DEFAULT_CMP0194 NEW CACHE STRING "" FORCE)
+endif()
+
 CPMAddPackage(
     NAME zstd
     VERSION 1.5.7
@@ -155,38 +162,40 @@ else()
 endif()
 
 # ============================================================================
-# LZ4 Integration (Fast compression)
+# LZ4 Integration (Fast compression) - Optional
 # ============================================================================
 
-CPMAddPackage(
-    NAME lz4
-    VERSION 1.10.0
-    GITHUB_REPOSITORY lz4/lz4
-    GIT_TAG v1.10.0
-    SOURCE_SUBDIR build/cmake
-    OPTIONS
-        "LZ4_BUILD_CLI OFF"
-        "LZ4_BUILD_LEGACY_LZ4C OFF"
-        "BUILD_SHARED_LIBS OFF"
-        "BUILD_STATIC_LIBS ON"
-)
+if(QGC_ENABLE_LZ4)
+    CPMAddPackage(
+        NAME lz4
+        VERSION 1.10.0
+        GITHUB_REPOSITORY lz4/lz4
+        GIT_TAG v1.10.0
+        SOURCE_SUBDIR build/cmake
+        OPTIONS
+            "LZ4_BUILD_CLI OFF"
+            "LZ4_BUILD_LEGACY_LZ4C OFF"
+            "BUILD_SHARED_LIBS OFF"
+            "BUILD_STATIC_LIBS ON"
+    )
 
-if(TARGET lz4_static)
-    # Help libarchive find our LZ4
-    set(LZ4_INCLUDE_DIR "${lz4_SOURCE_DIR}/lib" CACHE PATH "" FORCE)
-    set(LZ4_LIBRARY "lz4_static" CACHE STRING "" FORCE)
-    set(LZ4_LIBRARIES "lz4_static" CACHE STRING "" FORCE)
-    set(LZ4_FOUND TRUE CACHE BOOL "" FORCE)
-    if(NOT TARGET LZ4::LZ4)
-        add_library(LZ4::LZ4 ALIAS lz4_static)
+    if(TARGET lz4_static)
+        # Help libarchive find our LZ4
+        set(LZ4_INCLUDE_DIR "${lz4_SOURCE_DIR}/lib" CACHE PATH "" FORCE)
+        set(LZ4_LIBRARY "lz4_static" CACHE STRING "" FORCE)
+        set(LZ4_LIBRARIES "lz4_static" CACHE STRING "" FORCE)
+        set(LZ4_FOUND TRUE CACHE BOOL "" FORCE)
+        if(NOT TARGET LZ4::LZ4)
+            add_library(LZ4::LZ4 ALIAS lz4_static)
+        endif()
+        message(STATUS "LZ4 support enabled")
+    else()
+        message(FATAL_ERROR "lz4_static target not found")
     endif()
-    message(STATUS "LZ4 support enabled")
-else()
-    message(FATAL_ERROR "lz4_static target not found")
 endif()
 
 # ============================================================================
-# BZip2 Integration (official repo with CMake support)
+# BZip2 Integration (official repo with CMake support) - Optional
 # ============================================================================
 # NOTE: Using commit from master branch because:
 # - Official releases (1.0.8 and earlier) do not include CMakeLists.txt
@@ -194,38 +203,53 @@ endif()
 # - Risk: Commit may become unavailable if repo history is rewritten
 # - TODO: Update to tagged release when bzip2 publishes one with CMake support
 
-CPMAddPackage(
-    NAME bzip2
-    VERSION 1.0.8
-    GIT_REPOSITORY https://gitlab.com/bzip2/bzip2.git
-    GIT_TAG 66c46b8c9436613fd81bc5d03f63a61933a4dcc3
-    OPTIONS
-        "ENABLE_LIB_ONLY ON"
-        "ENABLE_SHARED_LIB OFF"
-        "ENABLE_STATIC_LIB ON"
-        "ENABLE_APP OFF"
-        "ENABLE_DOCS OFF"
-        "ENABLE_EXAMPLES OFF"
-        "ENABLE_TESTS OFF"
-)
+if(QGC_ENABLE_BZIP2)
+    CPMAddPackage(
+        NAME bzip2
+        VERSION 1.0.8
+        GIT_REPOSITORY https://gitlab.com/bzip2/bzip2.git
+        GIT_TAG 66c46b8c9436613fd81bc5d03f63a61933a4dcc3
+        OPTIONS
+            "ENABLE_LIB_ONLY ON"
+            "ENABLE_SHARED_LIB OFF"
+            "ENABLE_STATIC_LIB ON"
+            "ENABLE_APP OFF"
+            "ENABLE_DOCS OFF"
+            "ENABLE_EXAMPLES OFF"
+            "ENABLE_TESTS OFF"
+    )
 
-if(TARGET bz2_static)
-    # Help libarchive/minizip find our BZip2
-    set(BZIP2_INCLUDE_DIR "${bzip2_SOURCE_DIR}" CACHE PATH "" FORCE)
-    set(BZIP2_LIBRARY "bz2_static" CACHE STRING "" FORCE)
-    set(BZIP2_FOUND TRUE CACHE BOOL "" FORCE)
-    set(BZIP2_LIBRARIES "bz2_static" CACHE STRING "" FORCE)
-    if(NOT TARGET BZip2::BZip2)
-        add_library(BZip2::BZip2 ALIAS bz2_static)
+    if(TARGET bz2_static)
+        # Help libarchive/minizip find our BZip2
+        set(BZIP2_INCLUDE_DIR "${bzip2_SOURCE_DIR}" CACHE PATH "" FORCE)
+        set(BZIP2_LIBRARY "bz2_static" CACHE STRING "" FORCE)
+        set(BZIP2_FOUND TRUE CACHE BOOL "" FORCE)
+        set(BZIP2_LIBRARIES "bz2_static" CACHE STRING "" FORCE)
+        if(NOT TARGET BZip2::BZip2)
+            add_library(BZip2::BZip2 ALIAS bz2_static)
+        endif()
+        message(STATUS "BZip2 support enabled")
+    else()
+        message(FATAL_ERROR "bz2_static target not found")
     endif()
-    message(STATUS "BZip2 support enabled")
-else()
-    message(FATAL_ERROR "bz2_static target not found")
 endif()
 
 # ============================================================================
 # libarchive Integration (Full-featured C library)
 # ============================================================================
+
+# Configure optional format support based on QGC options
+if(QGC_ENABLE_BZIP2)
+    set(_LIBARCHIVE_BZIP2 "ON")
+else()
+    set(_LIBARCHIVE_BZIP2 "OFF")
+endif()
+
+if(QGC_ENABLE_LZ4)
+    set(_LIBARCHIVE_LZ4 "ON")
+else()
+    set(_LIBARCHIVE_LZ4 "OFF")
+endif()
 
 CPMAddPackage(
     NAME libarchive
@@ -233,32 +257,52 @@ CPMAddPackage(
     GITHUB_REPOSITORY libarchive/libarchive
     GIT_TAG v3.8.4
     OPTIONS
+        "ENABLE_WERROR OFF"
         "ENABLE_TEST OFF"
         "ENABLE_INSTALL OFF"
+        # Disable CLI tools
         "ENABLE_TAR OFF"
         "ENABLE_CPIO OFF"
         "ENABLE_CAT OFF"
         "ENABLE_UNZIP OFF"
+        # Disable unused features
         "ENABLE_ACL OFF"
         "ENABLE_XATTR OFF"
         "ENABLE_ICONV OFF"
-        "ENABLE_PCRE2POSIX OFF"
-        "ENABLE_LIBXML2 OFF"
-        "ENABLE_EXPAT OFF"
-        "ENABLE_ZLIB ON"
-        "ENABLE_LZMA ON"
-        "ENABLE_BZip2 ON"
-        "ENABLE_ZSTD ON"
-        "ENABLE_LIBB2 OFF"
-        "ENABLE_LZ4 ON"
-        "ENABLE_LIBMD OFF"
+        # Disable crypto (not needed for decompression)
         "ENABLE_OPENSSL OFF"
         "ENABLE_MBEDTLS OFF"
+        "ENABLE_NETTLE OFF"
+        "ENABLE_CNG OFF"
+        "ENABLE_LIBMD OFF"
+        "ENABLE_LIBB2 OFF"
+        # Disable XML/regex (not needed for decompression)
+        "ENABLE_LIBXML2 OFF"
+        "ENABLE_EXPAT OFF"
+        "ENABLE_PCREPOSIX OFF"
+        "ENABLE_PCRE2POSIX OFF"
+        # Skip PCREPOSIX block entirely (has bug: ENABLE_LIBGCC OFF causes fatal error)
+        "POSIX_REGEX_LIB LIBC"
+        # Disable unused compression formats
+        "ENABLE_LZO OFF"
+        "ENABLE_LIBGCC OFF"
+        # Enable required formats
+        "ENABLE_ZLIB ON"
+        "ENABLE_LZMA ON"
+        "ENABLE_ZSTD ON"
+        "ENABLE_BZip2 ${_LIBARCHIVE_BZIP2}"
+        "ENABLE_LZ4 ${_LIBARCHIVE_LZ4}"
 )
 
 if(TARGET archive_static)
     target_link_libraries(${CMAKE_PROJECT_NAME} PRIVATE archive_static)
     target_compile_definitions(${CMAKE_PROJECT_NAME} PRIVATE LIBARCHIVE_STATIC)
+    if(QGC_ENABLE_BZIP2)
+        target_compile_definitions(${CMAKE_PROJECT_NAME} PRIVATE QGC_ENABLE_BZIP2)
+    endif()
+    if(QGC_ENABLE_LZ4)
+        target_compile_definitions(${CMAKE_PROJECT_NAME} PRIVATE QGC_ENABLE_LZ4)
+    endif()
     message(STATUS "libarchive support enabled")
 else()
     message(FATAL_ERROR "libarchive target not found")

--- a/test/Utilities/Compression/CMakeLists.txt
+++ b/test/Utilities/Compression/CMakeLists.txt
@@ -18,14 +18,25 @@ target_include_directories(${CMAKE_PROJECT_NAME} PRIVATE ${CMAKE_CURRENT_SOURCE_
 # ----------------------------------------------------------------------------
 # Test Data Resources
 # ----------------------------------------------------------------------------
+
+# Core test files (always included)
+set(_COMPRESSION_TEST_FILES
+    manifest.json.gz
+    manifest.json.xz
+    manifest.json.zip
+    manifest.json.7z
+    manifest.json.zst
+)
+
+# Optional format test files
+if(QGC_ENABLE_BZIP2)
+    list(APPEND _COMPRESSION_TEST_FILES manifest.json.bz2)
+endif()
+if(QGC_ENABLE_LZ4)
+    list(APPEND _COMPRESSION_TEST_FILES manifest.json.lz4)
+endif()
+
 qt_add_resources(${CMAKE_PROJECT_NAME} "UtilitiesTest_CompressionTest_res"
     PREFIX "/unittest"
-    FILES
-        manifest.json.gz
-        manifest.json.xz
-        manifest.json.zip
-        manifest.json.7z
-        manifest.json.zst
-        manifest.json.bz2
-        manifest.json.lz4
+    FILES ${_COMPRESSION_TEST_FILES}
 )

--- a/test/Utilities/Compression/QGCCompressionTest.cc
+++ b/test/Utilities/Compression/QGCCompressionTest.cc
@@ -2,6 +2,8 @@
 #include "QGCCompression.h"
 #include "QGCCompressionJob.h"
 
+#include <vector>
+
 #include <QtCore/QBuffer>
 #include <QtCore/QCollator>
 #include <QtCore/QDir>
@@ -107,9 +109,11 @@ void QGCCompressionTest::_testFormatDetectionFromContent()
     QCOMPARE(QGCCompression::detectFormatFromFile(":/unittest/manifest.json.zst"),
              QGCCompression::Format::ZSTD);
 
+#ifdef QGC_ENABLE_BZIP2
     // BZ2 compressed file
     QCOMPARE(QGCCompression::detectFormatFromFile(":/unittest/manifest.json.bz2"),
              QGCCompression::Format::BZIP2);
+#endif
 
     // 7z archive
     QCOMPARE(QGCCompression::detectFormatFromFile(":/unittest/manifest.json.7z"),
@@ -569,12 +573,16 @@ void QGCCompressionTest::_testDecompressFromResource()
         const char *name;
     };
 
-    const ResourceTest resources[] = {
+    std::vector<ResourceTest> resources = {
         { ":/unittest/manifest.json.gz",  "manifest_gz.json",  "GZIP" },
         { ":/unittest/manifest.json.xz",  "manifest_xz.json",  "XZ" },
         { ":/unittest/manifest.json.zst", "manifest_zst.json", "ZSTD" },
+#ifdef QGC_ENABLE_BZIP2
         { ":/unittest/manifest.json.bz2", "manifest_bz2.json", "BZip2" },
+#endif
+#ifdef QGC_ENABLE_LZ4
         { ":/unittest/manifest.json.lz4", "manifest_lz4.json", "LZ4" },
+#endif
     };
 
     for (const auto &res : resources) {
@@ -595,12 +603,16 @@ void QGCCompressionTest::_testDecompressData()
         const char *name;
     };
 
-    const ResourceTest resources[] = {
+    std::vector<ResourceTest> resources = {
         { ":/unittest/manifest.json.gz",  "GZIP" },
         { ":/unittest/manifest.json.xz",  "XZ" },
         { ":/unittest/manifest.json.zst", "ZSTD" },
+#ifdef QGC_ENABLE_BZIP2
         { ":/unittest/manifest.json.bz2", "BZip2" },
+#endif
+#ifdef QGC_ENABLE_LZ4
         { ":/unittest/manifest.json.lz4", "LZ4" },
+#endif
     };
 
     for (const auto &res : resources) {

--- a/test/Utilities/Compression/QGCStreamingDecompressionTest.cc
+++ b/test/Utilities/Compression/QGCStreamingDecompressionTest.cc
@@ -109,12 +109,16 @@ void QGCStreamingDecompressionTest::_testDecompressDeviceWithQJsonDocument()
 void QGCStreamingDecompressionTest::_testDecompressDeviceFormats()
 {
     // Test all supported compression formats
-    const QStringList formats = {
+    QStringList formats = {
         ":/unittest/manifest.json.gz",
         ":/unittest/manifest.json.xz",
         ":/unittest/manifest.json.zst",
+#ifdef QGC_ENABLE_BZIP2
         ":/unittest/manifest.json.bz2",
-        ":/unittest/manifest.json.lz4"
+#endif
+#ifdef QGC_ENABLE_LZ4
+        ":/unittest/manifest.json.lz4",
+#endif
     };
 
     for (const QString &format : formats) {


### PR DESCRIPTION
## Summary

- Add CMake options `QGC_ENABLE_BZIP2` and `QGC_ENABLE_LZ4` (both default OFF) to optionally include these compression formats
- These formats are not used by ArduPilot/PX4 firmware or logs, reducing binary size and build complexity when disabled
- Core formats (gzip, xz, zstd, zip) remain always enabled

## Changes

- Add options to `cmake/CustomOptions.cmake`
- Conditionally include bzip2/lz4 CPM packages in `src/Utilities/Compression/CMakeLists.txt`
- Configure libarchive with conditional format support
- Add `QGC_ENABLE_BZIP2`/`QGC_ENABLE_LZ4` compile definitions for C++ code
- Update unit tests with conditional compilation (`#ifdef` guards)
- Fix xz test targets polluting QtCreator by adding `BUILD_TESTING OFF`

## Usage

To enable these optional formats:
```bash
cmake -DQGC_ENABLE_BZIP2=ON -DQGC_ENABLE_LZ4=ON ...
```

## Test plan

- [ ] Build with defaults (bzip2/lz4 disabled) - should succeed
- [ ] Build with `-DQGC_ENABLE_BZIP2=ON -DQGC_ENABLE_LZ4=ON` - should succeed
- [ ] Run unit tests with both configurations
- [ ] Verify bzip2/lz4 test targets no longer appear in QtCreator when disabled