### PR TITLE
Fix compile error encountered when doing Android x86_64 build

### DIFF
--- a/test/Utilities/Compression/QGCCompressionTest.cc
+++ b/test/Utilities/Compression/QGCCompressionTest.cc
@@ -312,7 +312,7 @@ void QGCCompressionTest::_testListArchiveNaturalSort()
     QStringList expected = {"dir/file3.txt", "dir/file11.txt", "file1.txt", "file2.txt", "file10.txt", "file20.txt"};
 
     // Simulate the sorting done by listArchive (using English locale for cross-platform consistency)
-    QCollator collator(QLocale(QLocale::English));
+    QCollator collator(QLocale(QLocale::English, QLocale::AnyCountry));
     collator.setNumericMode(true);
     collator.setCaseSensitivity(Qt::CaseInsensitive);
     std::sort(unsorted.begin(), unsorted.end(), collator);


### PR DESCRIPTION
## Description
When building locally for an Android emulator (Android x86_64), QGC would fail to build with the following error

<img width="1371" height="103" alt="Screenshot from 2026-01-22 08-32-58" src="https://github.com/user-attachments/assets/aec79d5f-666e-4d2e-b60e-3c8e47767d9f" />

I experienced this both on Windows and Linux. This PR fixes the issue so I can successfully build for my Android emulator.
