### PR TITLE
VTOL preflight checklist missing due to build bug

### DIFF
--- a/src/FlyView/CMakeLists.txt
+++ b/src/FlyView/CMakeLists.txt
@@ -68,5 +68,6 @@ qt_add_qml_module(FlyViewModule
         TerrainProgress.qml
         VehicleWarnings.qml
         VirtualJoystick.qml
+        VTOLChecklist.qml
     NO_PLUGIN
 )


### PR DESCRIPTION

## Description
<!-- Describe your changes in detail. What problem does this solve? -->

### Problem
Preflight checklist UI doesn't work in case of VTOL vehicle class.

### Solution
Add the VTOLChecklist.qml file to the CMakeLists.txt of the FlyView.

Note: should we update this on the Stable_V5.0 branch too? (folder renamed in path: [https://github.com/mavlink/qgroundcontrol/blob/Stable_V5.0/src/FlightDisplay/CMakeLists.txt])

### Testing
I tested it with a Stable_V5.0 custom build using ArduPilot on a PixHawk 6C. However, this fix belongs to the main branch. Excuse me the lack of capacity for proper testing. Thus, I create this pull request as a draft suggestion only.

## Type of Change
<!-- Put an 'x' in the relevant boxes -->
- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] CI/Build changes
- [ ] Other

## Testing
<!-- Describe the tests you ran and how to reproduce them -->
- [ ] Tested locally
- [ ] Added/updated unit tests
- [ ] Tested with simulator (SITL)
- [x] Tested with hardware

### Platforms Tested
<!-- Check all that apply -->
- [ ] Linux
- [ ] Windows
- [ ] macOS
- [x] Android
- [ ] iOS

### Flight Stacks Tested
<!-- If applicable -->
- [ ] PX4
- [x] ArduPilot

## Screenshots
<!-- If applicable, add screenshots to help explain your changes -->

## Checklist
<!-- Go over all the following points, and put an 'x' in all the boxes that apply -->
- [x] I have read the [Contribution Guidelines](CONTRIBUTING.md)
- [x] I have read the [Code of Conduct](CODE_OF_CONDUCT.md)
- [x] My code follows the project's coding standards
- [ ] I have added tests that prove my fix/feature works
- [ ] New and existing unit tests pass locally

## Related Issues
<!-- Link any related issues using #issue_number -->

---
By submitting this pull request, I confirm that my contribution is made under the terms of the project's dual license (Apache 2.0 and GPL v3).
