### PR TITLE
Revert "fix: `Unable to assign [undefined]` errors"

### DIFF
--- a/src/FlightMap/Widgets/QGCCompassWidget.qml
+++ b/src/FlightMap/Widgets/QGCCompassWidget.qml
@@ -20,11 +20,11 @@ Rectangle {
     property real _defaultSize:                 usedByMultipleVehicleList ? ScreenTools.defaultFontPixelHeight * 3 : ScreenTools.defaultFontPixelHeight * 10
     property real _sizeRatio:                   (usedByMultipleVehicleList || ScreenTools.isTinyScreen) ? (size / _defaultSize) * 0.5 : size / _defaultSize
     property int  _fontSize:                    ScreenTools.defaultFontPointSize * _sizeRatio < 8 ? 8 : ScreenTools.defaultFontPointSize * _sizeRatio
-    property real _heading:                     vehicle?.heading?.rawValue ?? 0
-    property real _headingToHome:               vehicle?.headingToHome?.rawValue ?? NaN
-    property real _groundSpeed:                 vehicle?.groundSpeed?.rawValue ?? 0
-    property real _headingToNextWP:             vehicle?.headingToNextWP?.rawValue ?? NaN
-    property real _courseOverGround:            vehicle?.gps?.courseOverGround?.rawValue ?? 0
+    property real _heading:                     vehicle ? vehicle.heading.rawValue : 0
+    property real _headingToHome:               vehicle ? vehicle.headingToHome.rawValue : 0
+    property real _groundSpeed:                 vehicle ? vehicle.groundSpeed.rawValue : 0
+    property real _headingToNextWP:             vehicle ? vehicle.headingToNextWP.rawValue : 0
+    property real _courseOverGround:            vehicle ? vehicle.gps.courseOverGround.rawValue : 0
     property var  _flyViewSettings:             QGroundControl.settingsManager.flyViewSettings
     property bool _showAdditionalIndicators:    _flyViewSettings.showAdditionalIndicatorsCompass.value && !usedByMultipleVehicleList
     property bool _lockNoseUpCompass:           _flyViewSettings.lockNoseUpCompass.value && !usedByMultipleVehicleList

--- a/src/UI/toolbar/GimbalIndicator.qml
+++ b/src/UI/toolbar/GimbalIndicator.qml
@@ -19,7 +19,7 @@ Item {
     property var    gimbals:                    gimbalController.gimbals
     property var    activeGimbal:               gimbalController.activeGimbal
     property var    multiGimbalSetup:           gimbalController.gimbals.count > 1
-    property bool   joystickButtonsAvailable:   activeVehicle?.joystickEnabled ?? false
+    property bool   joystickButtonsAvailable:   activeVehicle.joystickEnabled
     property bool   showAzimuth:                QGroundControl.settingsManager.gimbalControllerSettings.toolbarIndicatorShowAzimuth.rawValue
 
     property var    margins:                    ScreenTools.defaultFontPixelWidth


### PR DESCRIPTION
Reverts mavlink/qgroundcontrol#13866

I'm reverting this since I have a different global fix for it which doesn't require Qml modification