### PR TITLE
Fact: Add support for fact not set by default

### DIFF
--- a/src/FactSystem/Fact.h
+++ b/src/FactSystem/Fact.h
@@ -201,7 +201,8 @@ protected:
 
     QString _name;
     int _componentId = -1;
-    QVariant _rawValue; // QVariant::Invalid
+    QVariant _rawValue{0};
+    bool _rawValueIsNotSet = true;
     mutable QRecursiveMutex _rawValueMutex;
     FactMetaData::ValueType_t _type = FactMetaData::valueTypeInt32;
     FactMetaData *_metaData = nullptr;


### PR DESCRIPTION
* Fact defaults rawValue to 0 like before
* Whether Fact has been set or not is tracked in _rawValueIsNotSet bool
* _rawValueIsNotSet is used to determined when to show invalid value string
* This fixes problem where Qml code which directly reference a raw value (not by string) was generating undefined errors. But if you explicitly got after valueString you will get invalid value string support.
* Related to #13890, #13866, #13867