### PR TITLE
actuators: add center to Actuators::parseJson

### DIFF
--- a/src/Vehicle/Actuators/ActuatorOutputs.h
+++ b/src/Vehicle/Actuators/ActuatorOutputs.h
@@ -55,6 +55,7 @@ public:
         Disarmed,
         Minimum,
         Maximum,
+        Center,
         Failsafe
     };
 

--- a/src/Vehicle/Actuators/Actuators.cc
+++ b/src/Vehicle/Actuators/Actuators.cc
@@ -490,6 +490,8 @@ bool Actuators::parseJson(const QJsonDocument &json)
                     function = ChannelConfig::Function::Minimum;
                 } else if (functionStr == "max") {
                     function = ChannelConfig::Function::Maximum;
+                } else if (functionStr == "center") {
+                    function = ChannelConfig::Function::Center;
                 } else if (functionStr == "failsafe") {
                     function = ChannelConfig::Function::Failsafe;
                 } else if (functionStr != "") {


### PR DESCRIPTION
Noticed warnings in the console
```
     8.434 Warning: Unknown 'function': "center" - Vehicle.ActuatorsConfig - (Actuators::parseJson:496)
     8.434 Warning: Unknown 'function': "center" - Vehicle.ActuatorsConfig - (Actuators::parseJson:496)
     8.434 Warning: Unknown 'function': "center" - Vehicle.ActuatorsConfig - (Actuators::parseJson:496)
```

The PWM_AUX_CENT${i} parameters came in with PX4 in https://github.com/PX4/PX4-Autopilot/pull/25897.

What is odd is we get the warning in QGC, but the UI still works properly. Then what is the purpose of this code?

