### PR TITLE
ActuatorComponent: Fix deprecated signal parameter injection

### DIFF
--- a/src/AutoPilotPlugins/PX4/ActuatorComponent.qml
+++ b/src/AutoPilotPlugins/PX4/ActuatorComponent.qml
@@ -251,7 +251,7 @@ SetupPage {
                                 ActuatorSlider {
                                     channel:       actuators.actuatorTest.allMotorsActuator
                                     rightPadding:  ScreenTools.defaultFontPixelWidth * 3
-                                    onActuatorValueChanged: {
+                                    onActuatorValueChanged: (value, sliderValue) => {
                                         stopTimer();
                                         for (var channelIdx=0; channelIdx<sliderRepeater.count; channelIdx++) {
                                             var channelSlider = sliderRepeater.itemAt(channelIdx);
@@ -304,8 +304,8 @@ SetupPage {
                                                     text:           object.label
                                                     onTriggered:    object.trigger()
                                                 }
-                                                onObjectAdded:      actionMenu.insertItem(index, object)
-                                                onObjectRemoved:    actionMenu.removeItem(object)
+                                                onObjectAdded:      (index, object) => actionMenu.insertItem(index, object)
+                                                onObjectRemoved:    (index, object) => actionMenu.removeItem(object)
                                             }
                                         }
                                     }


### PR DESCRIPTION
### Problem
Qt6 deprecated implicit parameter injection into signal handlers. ActuatorComponent.qml uses this pattern in Instantiator.onObjectAdded (implicit index), Instantiator.onObjectRemoved (implicit object), and ActuatorSlider.onActuatorValueChanged (implicit sliderValue), producing console warnings at runtime.                                                                                       
                                                                                                                                                                                                           
### Solution 
Use arrow functions with formal parameters.