### PR TITLE
Add Joystick component to Generic autopilot

### DIFF
--- a/src/AutoPilotPlugins/Generic/GenericAutoPilotPlugin.cc
+++ b/src/AutoPilotPlugins/Generic/GenericAutoPilotPlugin.cc
@@ -1,4 +1,5 @@
 #include "GenericAutoPilotPlugin.h"
+#include "JoystickComponent.h"
 
 GenericAutoPilotPlugin::GenericAutoPilotPlugin(Vehicle *vehicle, QObject *parent)
     : AutoPilotPlugin(vehicle, parent)
@@ -8,7 +9,10 @@ GenericAutoPilotPlugin::GenericAutoPilotPlugin(Vehicle *vehicle, QObject *parent
 
 const QVariantList& GenericAutoPilotPlugin::vehicleComponents()
 {
-    static QVariantList emptyList;
-
-    return emptyList;
+    if (_components.isEmpty()) {
+        _joystickComponent = new JoystickComponent(_vehicle, this, this);
+        _joystickComponent->setupTriggerSignals();
+        _components.append(QVariant::fromValue(qobject_cast<VehicleComponent*>(_joystickComponent)));
+    }
+    return _components;
 }

--- a/src/AutoPilotPlugins/Generic/GenericAutoPilotPlugin.h
+++ b/src/AutoPilotPlugins/Generic/GenericAutoPilotPlugin.h
@@ -2,6 +2,8 @@
 
 #include "AutoPilotPlugin.h"
 
+class JoystickComponent;
+
 /// This is the generic implementation of the AutoPilotPlugin class for mavs
 /// we do not have a specific AutoPilotPlugin implementation.
 class GenericAutoPilotPlugin : public AutoPilotPlugin
@@ -13,4 +15,8 @@ public:
 
     const QVariantList &vehicleComponents() final;
     QString prerequisiteSetup(VehicleComponent *component) const final { Q_UNUSED(component); return QString(); }
+
+private:
+    QVariantList _components;
+    JoystickComponent *_joystickComponent = nullptr;
 };


### PR DESCRIPTION
The Joystick calibration component was removed from the Generic autopilot but there's no clear reason why it shouldn't be available since it's a generic feature. This restores the component.

## Description
<!-- Describe your changes in detail. What problem does this solve? -->

## Type of Change
<!-- Put an 'x' in the relevant boxes -->
- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] CI/Build changes
- [ ] Other

## Testing
<!-- Describe the tests you ran and how to reproduce them -->
- [x] Tested locally
- [ ] Added/updated unit tests
- [ ] Tested with simulator (SITL)
- [ ] Tested with hardware

### Platforms Tested
<!-- Check all that apply -->
- [x] Linux
- [ ] Windows
- [ ] macOS
- [ ] Android
- [ ] iOS

### Flight Stacks Tested
<!-- If applicable -->
- [ ] PX4
- [ ] ArduPilot

## Screenshots
<!-- If applicable, add screenshots to help explain your changes -->

## Checklist
<!-- Go over all the following points, and put an 'x' in all the boxes that apply -->
- [x] I have read the [Contribution Guidelines](CONTRIBUTING.md)
- [x] I have read the [Code of Conduct](CODE_OF_CONDUCT.md)
- [x] My code follows the project's coding standards
- [ ] I have added tests that prove my fix/feature works
- [x] New and existing unit tests pass locally

## Related Issues
<!-- Link any related issues using #issue_number -->

---
By submitting this pull request, I confirm that my contribution is made under the terms of the project's dual license (Apache 2.0 and GPL v3).
