### PR TITLE
Add feature: add EFI status properties

### DIFF
--- a/src/Vehicle/FactGroups/EFIFact.json
+++ b/src/Vehicle/FactGroups/EFIFact.json
@@ -117,6 +117,20 @@
     "shortDesc":        "Pt Compensation",
     "type":             "float",
     "decimalPlaces":    1
+},
+{
+    "name":             "ignVoltage",
+    "shortDesc":        "Ignition Voltage",
+    "type":             "float",
+    "decimalPlaces":    1,
+    "units":            "V"
+},
+{
+    "name":             "fuelPressure",
+    "shortDesc":        "Fuel Pressure",
+    "type":             "float",
+    "decimalPlaces":    1,
+    "units":            "kPa"
 }
 ]
 }

--- a/src/Vehicle/FactGroups/VehicleEFIFactGroup.cc
+++ b/src/Vehicle/FactGroups/VehicleEFIFactGroup.cc
@@ -21,6 +21,8 @@ VehicleEFIFactGroup::VehicleEFIFactGroup(QObject *parent)
     _addFact(&_injTimeFact);
     _addFact(&_throttleOutFact);
     _addFact(&_ptCompFact);
+    _addFact(&_ignVoltageFact);
+    _addFact(&_fuelPressureFact);
 
     _healthFact.setRawValue(qQNaN());
     _ecuIndexFact.setRawValue(qQNaN());
@@ -39,6 +41,8 @@ VehicleEFIFactGroup::VehicleEFIFactGroup(QObject *parent)
     _injTimeFact.setRawValue(qQNaN());
     _throttleOutFact.setRawValue(qQNaN());
     _ptCompFact.setRawValue(qQNaN());
+    _ignVoltageFact.setRawValue(qQNaN());
+    _fuelPressureFact.setRawValue(qQNaN());
 }
 
 void VehicleEFIFactGroup::handleMessage(Vehicle *vehicle, const mavlink_message_t &message)
@@ -76,6 +80,8 @@ void VehicleEFIFactGroup::_handleEFIStatus(const mavlink_message_t &message)
     exGasTemp()->setRawValue(efi.exhaust_gas_temperature);
     throttleOut()->setRawValue(efi.throttle_out);
     ptComp()->setRawValue(efi.pt_compensation);
+    ignVoltage()->setRawValue(efi.ignition_voltage);
+    fuelPressure()->setRawValue(efi.fuel_pressure);
 
     _setTelemetryAvailable(true);
 }

--- a/src/Vehicle/FactGroups/VehicleEFIFactGroup.h
+++ b/src/Vehicle/FactGroups/VehicleEFIFactGroup.h
@@ -23,6 +23,7 @@ class VehicleEFIFactGroup : public FactGroup
     Q_PROPERTY(Fact *throttleOut    READ throttleOut    CONSTANT)
     Q_PROPERTY(Fact *ptComp         READ ptComp         CONSTANT)
     Q_PROPERTY(Fact *ignVoltage     READ ignVoltage     CONSTANT)
+    Q_PROPERTY(Fact *fuelPressure   READ fuelPressure   CONSTANT)
 
 public:
     explicit VehicleEFIFactGroup(QObject *parent = nullptr);
@@ -45,6 +46,7 @@ public:
     Fact *throttleOut() { return &_throttleOutFact; }
     Fact *ptComp() { return &_ptCompFact; }
     Fact *ignVoltage() { return &_ignVoltageFact; }
+    Fact *fuelPressure() { return &_fuelPressureFact; }
 
     // Overrides from FactGroup
     void handleMessage(Vehicle *vehicle, const mavlink_message_t &message) final;
@@ -70,4 +72,5 @@ private:
     Fact _throttleOutFact = Fact(0, QStringLiteral("throttleOut"), FactMetaData::valueTypeFloat);
     Fact _ptCompFact = Fact(0, QStringLiteral("ptComp"), FactMetaData::valueTypeFloat);
     Fact _ignVoltageFact = Fact(0, QStringLiteral("ignVoltage"), FactMetaData::valueTypeFloat);
+    Fact _fuelPressureFact = Fact(0, QStringLiteral("fuelPressure"), FactMetaData::valueTypeFloat);
 };


### PR DESCRIPTION
## Description
added EFI status ignition voltage and fuel pressure fields in EFIFact.json, VehicleEFIFactGroup.cc and VehicleEFIFactGroup.h
allows users to display the EFI_STATUS ignition voltage and fuel pressure in the vehicle info widget

## Type of Change
<!-- Put an 'x' in the relevant boxes -->
- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] CI/Build changes
- [ ] Other

## Testing
<!-- Describe the tests you ran and how to reproduce them -->
- [x] Tested locally
- [ ] Added/updated unit tests
- [ ] Tested with simulator (SITL)
- [ ] Tested with hardware

### Platforms Tested
<!-- Check all that apply -->
- [ ] Linux
- [x] Windows
- [ ] macOS
- [ ] Android
- [ ] iOS

### Flight Stacks Tested
<!-- If applicable -->
- [ ] PX4
- [ ] ArduPilot

## Screenshots
<!-- If applicable, add screenshots to help explain your changes -->

## Checklist
<!-- Go over all the following points, and put an 'x' in all the boxes that apply -->
- [x] I have read the [Contribution Guidelines](CONTRIBUTING.md)
- [x] I have read the [Code of Conduct](CODE_OF_CONDUCT.md)
- [x] My code follows the project's coding standards
- [x] I have added tests that prove my fix/feature works
- [ ] New and existing unit tests pass locally

## Related Issues
<!-- Link any related issues using #issue_number -->

---
By submitting this pull request, I confirm that my contribution is made under the terms of the project's dual license (Apache 2.0 and GPL v3).
