### PR TITLE
MissionManager: Pause mission once last waypoint reached if no RTL / land planned in mission

### DIFF
--- a/src/MissionManager/MissionManager.h
+++ b/src/MissionManager/MissionManager.h
@@ -39,6 +39,7 @@ private:
     void _handleHighLatency(const mavlink_message_t& message);
     void _handleHighLatency2(const mavlink_message_t& message);
     void _handleMissionCurrent(const mavlink_message_t& message);
+    void _handleMissionItemReached(const mavlink_message_t& message);
     void _updateMissionIndex(int index);
     void _handleHeartbeat(const mavlink_message_t& message);
 


### PR DESCRIPTION
## Description
Sometimes users may plan missions and intentionally not set a RTL or land point because they want to manually land instead. When using QGC with ArduPilot, if you are on the last mission item and there's no RTL/Land, the vehicle stays in auto mode, but doesn't automatically respond to command to change waypoint to previous waypoint without manually pausing/resuming. This PR is a suggested fix to the issue by tracking the MISSION_ITEM_REACHED message. If the item reached is the last item in the mission and isn't a RTL/Land/Loiter item, and that item is a coordinate item, we send a pause command to the vehicle.

The result of this change is that if you plot out a mission and have just a regular waypoint at the end, the vehicle will go into BRAKE mode at the very end. 

I was considering instead sending a guided mode command to put the vehicle in guided mode, but I figure pausing is probably safer.

Because this changes how missions behave, it should probably be tested on PX4 and different vehicle types than just quad.

## Type of Change
<!-- Put an 'x' in the relevant boxes -->
- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] CI/Build changes
- [ ] Other

## Testing
<!-- Describe the tests you ran and how to reproduce them -->
- [x] Tested locally
- [ ] Added/updated unit tests
- [x] Tested with simulator (SITL)
- [ ] Tested with hardware

### Platforms Tested
<!-- Check all that apply -->
- [x] Linux
- [ ] Windows
- [ ] macOS
- [ ] Android
- [ ] iOS

### Flight Stacks Tested
<!-- If applicable -->
- [ ] PX4
- [x] ArduPilot

## Screenshots
<!-- If applicable, add screenshots to help explain your changes -->

## Checklist
<!-- Go over all the following points, and put an 'x' in all the boxes that apply -->
- [x] I have read the [Contribution Guidelines](CONTRIBUTING.md)
- [x] I have read the [Code of Conduct](CODE_OF_CONDUCT.md)
- [x] My code follows the project's coding standards
- [ ] I have added tests that prove my fix/feature works
- [ ] New and existing unit tests pass locally

## Related Issues
#13927

---
By submitting this pull request, I confirm that my contribution is made under the terms of the project's dual license (Apache 2.0 and GPL v3).
