### PR TITLE
Separate tile cache database logic into QGCTileCacheDatabase

### DIFF
--- a/src/QtLocationPlugin/CMakeLists.txt
+++ b/src/QtLocationPlugin/CMakeLists.txt
@@ -34,6 +34,9 @@ qt_add_plugin(QGCLocation
     QGCMapUrlEngine.cpp
     QGCMapUrlEngine.h
     QGCTile.h
+    QGCTileCacheDatabase.cpp
+    QGCTileCacheDatabase.h
+    QGCTileCacheTypes.h
     QGCTileCacheWorker.cpp
     QGCTileCacheWorker.h
     QGCTileSet.h

--- a/src/QtLocationPlugin/QGCCacheTile.h
+++ b/src/QtLocationPlugin/QGCCacheTile.h
@@ -18,11 +18,11 @@ struct QGCCacheTile
         , hash(hash_)
     {}
 
-    const quint64 tileSet = 0;
-    const QString hash;
-    const QByteArray img;
-    const QString format;
-    const QString type;
+    quint64 tileSet;
+    QString hash;
+    QByteArray img;
+    QString format;
+    QString type;
 };
 Q_DECLARE_METATYPE(QGCCacheTile)
 Q_DECLARE_METATYPE(QGCCacheTile*)

--- a/src/QtLocationPlugin/QGCCachedTileSet.h
+++ b/src/QtLocationPlugin/QGCCachedTileSet.h
@@ -3,6 +3,7 @@
 #include <QtCore/QDateTime>
 #include <QtCore/QHash>
 #include <QtCore/QLoggingCategory>
+#include <QtCore/QMutex>
 #include <QtCore/QObject>
 #include <QtCore/QQueue>
 #include <QtCore/QString>
@@ -10,7 +11,7 @@
 
 Q_DECLARE_LOGGING_CATEGORY(QGCCachedTileSetLog)
 
-class QGCTile;
+struct QGCTile;
 class QGCMapEngineManager;
 class QNetworkAccessManager;
 
@@ -170,6 +171,7 @@ private:
     QDateTime _creationDate;
 
     QHash<QString, QNetworkReply*> _replies;
+    QMutex _repliesMutex;
     QQueue<QGCTile*> _tilesToDownload;
     QGCMapEngineManager *_manager = nullptr;
     QNetworkAccessManager *_networkManager = nullptr;

--- a/src/QtLocationPlugin/QGCMapEngine.cpp
+++ b/src/QtLocationPlugin/QGCMapEngine.cpp
@@ -72,6 +72,9 @@ void QGCMapEngine::init(const QString &databasePath)
 
 bool QGCMapEngine::addTask(QGCMapTask *task)
 {
+    // DirectConnection is intentional: the worker thread uses a custom loop (not
+    // an event loop), so queued connections would never be delivered. The queue
+    // is mutex-protected in enqueueTask, so calling from the main thread is safe.
     bool result = false;
     (void) QMetaObject::invokeMethod(m_worker, &QGCCacheWorker::enqueueTask, Qt::DirectConnection, qReturnArg(result), task);
     return result;

--- a/src/QtLocationPlugin/QGCMapEngineManager.cc
+++ b/src/QtLocationPlugin/QGCMapEngineManager.cc
@@ -393,22 +393,36 @@ bool QGCMapEngineManager::exportSets(const QString &path)
         return false;
     }
 
-    QList<QGCCachedTileSet*> sets;
+    QList<TileSetRecord> records;
 
     for (qsizetype i = 0; i < _tileSets->count(); i++) {
         QGCCachedTileSet* const set = qobject_cast<QGCCachedTileSet*>(_tileSets->get(i));
-        if (set->selected()) {
-            sets.append(set);
+        if (set && set->selected()) {
+            TileSetRecord rec;
+            rec.setID = set->id();
+            rec.name = set->name();
+            rec.mapTypeStr = set->mapTypeStr();
+            rec.topleftLat = set->topleftLat();
+            rec.topleftLon = set->topleftLon();
+            rec.bottomRightLat = set->bottomRightLat();
+            rec.bottomRightLon = set->bottomRightLon();
+            rec.minZoom = set->minZoom();
+            rec.maxZoom = set->maxZoom();
+            rec.type = UrlFactory::getQtMapIdFromProviderType(set->type());
+            rec.numTiles = set->totalTileCount();
+            rec.defaultSet = set->defaultSet();
+            rec.date = set->creationDate().toSecsSinceEpoch();
+            records.append(rec);
         }
     }
 
-    if (sets.isEmpty()) {
+    if (records.isEmpty()) {
         return false;
     }
 
     setImportAction(ImportAction::ActionExporting);
 
-    QGCExportTileTask *task = new QGCExportTileTask(sets, path);
+    QGCExportTileTask *task = new QGCExportTileTask(records, path);
     (void) connect(task, &QGCExportTileTask::actionCompleted, this, &QGCMapEngineManager::_actionCompleted);
     (void) connect(task, &QGCExportTileTask::actionProgress, this, &QGCMapEngineManager::_actionProgressHandler);
     (void) connect(task, &QGCMapTask::error, this, &QGCMapEngineManager::taskError);
@@ -439,8 +453,6 @@ QString QGCMapEngineManager::getUniqueName() const
             return name;
         }
     }
-
-    return QString("");
 }
 
 QStringList QGCMapEngineManager::mapList()

--- a/src/QtLocationPlugin/QGCMapTasks.h
+++ b/src/QtLocationPlugin/QGCMapTasks.h
@@ -6,6 +6,7 @@
 
 #include "QGCCacheTile.h"
 #include "QGCCachedTileSet.h"
+#include "QGCTileCacheTypes.h"
 #include "QGCTile.h"
 
 class QGCMapTask : public QObject
@@ -315,14 +316,14 @@ class QGCExportTileTask : public QGCMapTask
     Q_OBJECT
 
 public:
-    explicit QGCExportTileTask(const QList<QGCCachedTileSet*> &sets, const QString &path, QObject *parent = nullptr)
+    explicit QGCExportTileTask(const QList<TileSetRecord> &sets, const QString &path, QObject *parent = nullptr)
         : QGCMapTask(TaskType::taskExport, parent)
         , m_sets(sets)
         , m_path(path)
     {}
     ~QGCExportTileTask() = default;
 
-    QList<QGCCachedTileSet*> sets() const { return m_sets; }
+    const QList<TileSetRecord> &sets() const { return m_sets; }
     QString path() const { return m_path; }
 
     void setExportCompleted()
@@ -340,7 +341,7 @@ signals:
     void actionProgress(int percentage);
 
 private:
-    const QList<QGCCachedTileSet*> m_sets;
+    const QList<TileSetRecord> m_sets;
     const QString m_path;
 };
 

--- a/src/QtLocationPlugin/QGCMapUrlEngine.cpp
+++ b/src/QtLocationPlugin/QGCMapUrlEngine.cpp
@@ -164,9 +164,8 @@ QGCTileSet UrlFactory::getTileCount(int zoom, double topleftLon, double topleftL
 
 QString UrlFactory::getProviderTypeFromQtMapId(int qtMapId)
 {
-    // Default Set
     if (qtMapId == -1) {
-        return nullptr;
+        return QString();
     }
 
     for (const SharedMapProvider &provider : _providers) {
@@ -176,12 +175,11 @@ QString UrlFactory::getProviderTypeFromQtMapId(int qtMapId)
     }
 
     qCWarning(QGCMapUrlEngineLog) << "map id not found:" << qtMapId;
-    return QString("");
+    return QString();
 }
 
 SharedMapProvider UrlFactory::getMapProviderFromQtMapId(int qtMapId)
 {
-    // Default Set
     if (qtMapId == -1) {
         return nullptr;
     }
@@ -198,6 +196,10 @@ SharedMapProvider UrlFactory::getMapProviderFromQtMapId(int qtMapId)
 
 SharedMapProvider UrlFactory::getMapProviderFromProviderType(QStringView type)
 {
+    if (type.isEmpty()) {
+        return nullptr;
+    }
+
     for (const SharedMapProvider &provider : _providers) {
         if (provider->getMapName() == type) {
             return provider;
@@ -210,6 +212,10 @@ SharedMapProvider UrlFactory::getMapProviderFromProviderType(QStringView type)
 
 int UrlFactory::getQtMapIdFromProviderType(QStringView type)
 {
+    if (type.isEmpty()) {
+        return -1;
+    }
+
     for (const SharedMapProvider &provider : _providers) {
         if (provider->getMapName() == type) {
             return provider->getMapId();
@@ -255,11 +261,16 @@ QString UrlFactory::providerTypeFromHash(int hash)
     return QString("");
 }
 
-// This seems to limit provider name length to less than ~25 chars due to downcasting to int
 int UrlFactory::hashFromProviderType(QStringView type)
 {
-    const auto hash = qHash(type) >> 1;
-    return static_cast<int>(hash);
+    for (const SharedMapProvider &provider : _providers) {
+        if (provider->getMapName() == type) {
+            return provider->getMapId();
+        }
+    }
+
+    qCWarning(QGCMapUrlEngineLog) << "provider not found for type:" << type;
+    return -1;
 }
 
 QString UrlFactory::tileHashToType(QStringView tileHash)

--- a/src/QtLocationPlugin/QGCTile.h
+++ b/src/QtLocationPlugin/QGCTile.h
@@ -18,7 +18,7 @@ struct QGCTile
     int z = 0;
     quint64 tileSet = UINT64_MAX;
     QString hash;
-    QString type = QStringLiteral("Invalid"); // TODO: int?
+    int type = -1;
 };
 Q_DECLARE_METATYPE(QGCTile)
 Q_DECLARE_METATYPE(QGCTile*)

--- a/src/QtLocationPlugin/QGCTileCacheDatabase.cpp
+++ b/src/QtLocationPlugin/QGCTileCacheDatabase.cpp
@@ -1,0 +1,1515 @@
+#include "QGCTileCacheDatabase.h"
+
+#include <QtCore/QCoreApplication>
+#include <QtCore/QDateTime>
+#include <QtCore/QFile>
+#include <QtCore/QFileInfo>
+#include <QtCore/QSettings>
+#include <QtCore/QUuid>
+#include <QtSql/QSqlDatabase>
+#include <QtSql/QSqlError>
+#include <QtSql/QSqlQuery>
+
+#include <atomic>
+
+#include "QGCCacheTile.h"
+#include "QGCLoggingCategory.h"
+#include "QGCMapUrlEngine.h"
+#include "QGCTile.h"
+
+Q_DECLARE_LOGGING_CATEGORY(QGCTileCacheWorkerLog)
+
+class TransactionGuard {
+public:
+    explicit TransactionGuard(QSqlDatabase db) : _db(std::move(db)) {}
+    ~TransactionGuard() { if (_active && !_committed) _db.rollback(); }
+    TransactionGuard(const TransactionGuard &) = delete;
+    TransactionGuard &operator=(const TransactionGuard &) = delete;
+    bool begin() { _active = _db.transaction(); return _active; }
+    bool commit() { if (_active) { _committed = _db.commit(); return _committed; } return false; }
+private:
+    QSqlDatabase _db;
+    bool _committed = false;
+    bool _active = false;
+};
+
+static std::atomic<int> s_exportSessionCounter{0};
+
+struct ScopedExportDB {
+    std::unique_ptr<QSqlDatabase> db;
+    QString session;
+    ScopedExportDB(const QString &path) {
+        session = QStringLiteral("QGeoTileExportSession_%1").arg(s_exportSessionCounter.fetch_add(1));
+        db.reset(new QSqlDatabase(QSqlDatabase::addDatabase("QSQLITE", session)));
+        db->setDatabaseName(path);
+    }
+    ~ScopedExportDB() { db.reset(); QSqlDatabase::removeDatabase(session); }
+    ScopedExportDB(const ScopedExportDB &) = delete;
+    ScopedExportDB &operator=(const ScopedExportDB &) = delete;
+    bool open() { return db->open(); }
+};
+
+static QString placeholders(int n)
+{
+    QString result;
+    result.reserve(n * 2);
+    for (int i = 0; i < n; i++) {
+        if (i > 0) result += QChar(',');
+        result += QChar('?');
+    }
+    return result;
+}
+
+static std::atomic<quint64> s_connectionCounter{0};
+
+QGCTileCacheDatabase::QGCTileCacheDatabase(const QString &databasePath)
+    : _databasePath(databasePath)
+    , _connectionName(QStringLiteral("QGCTileCache_%1").arg(s_connectionCounter.fetch_add(1)))
+{
+}
+
+QGCTileCacheDatabase::~QGCTileCacheDatabase()
+{
+    disconnectDB();
+}
+
+QSqlDatabase QGCTileCacheDatabase::_database() const
+{
+    return QSqlDatabase::database(_connectionName);
+}
+
+QSqlDatabase QGCTileCacheDatabase::database() const
+{
+    return _database();
+}
+
+bool QGCTileCacheDatabase::_ensureConnected() const
+{
+    if (!_connected || !_valid) {
+        qCWarning(QGCTileCacheWorkerLog) << "Database not connected";
+        return false;
+    }
+    return true;
+}
+
+bool QGCTileCacheDatabase::_checkSchemaVersion()
+{
+    QSqlQuery query(_database());
+    if (!query.exec("PRAGMA user_version") || !query.next()) {
+        qCWarning(QGCTileCacheWorkerLog) << "Failed to read schema version";
+        return false;
+    }
+
+    const int version = query.value(0).toInt();
+    if (version == kSchemaVersion) {
+        return true;
+    }
+
+    if (version == 0) {
+        // Either a fresh database or a legacy database created before versioning.
+        // Check for existing data — if Tiles table exists with rows, it's legacy.
+        // Legacy DBs stored map type as text; migration is not supported so the cache is rebuilt.
+        if (query.exec("SELECT COUNT(*) FROM Tiles") && query.next() && query.value(0).toInt() > 0) {
+            qCWarning(QGCTileCacheWorkerLog) << "Legacy database detected (no schema version). Discarding cached tiles and rebuilding.";
+            _defaultSet = kInvalidTileSet;
+            query.exec("DROP TABLE IF EXISTS TilesDownload");
+            query.exec("DROP TABLE IF EXISTS SetTiles");
+            query.exec("DROP TABLE IF EXISTS Tiles");
+            query.exec("DROP TABLE IF EXISTS TileSets");
+        }
+        return true;
+    }
+
+    // Future: handle incremental migrations here (version < kSchemaVersion).
+    qCWarning(QGCTileCacheWorkerLog) << "Unknown schema version" << version << "(expected" << kSchemaVersion << "). Resetting cache.";
+    _defaultSet = kInvalidTileSet;
+    query.exec("DROP TABLE IF EXISTS TilesDownload");
+    query.exec("DROP TABLE IF EXISTS SetTiles");
+    query.exec("DROP TABLE IF EXISTS Tiles");
+    query.exec("DROP TABLE IF EXISTS TileSets");
+    return true;
+}
+
+bool QGCTileCacheDatabase::init()
+{
+    _failed = false;
+    if (!_databasePath.isEmpty()) {
+        qCDebug(QGCTileCacheWorkerLog) << "Mapping cache directory:" << _databasePath;
+        if (connectDB()) {
+            if (!_checkSchemaVersion()) {
+                _failed = true;
+                disconnectDB();
+                return false;
+            }
+            _valid = _createDB(_database());
+            if (!_valid) {
+                _failed = true;
+                (void) QFile::remove(_databasePath);
+            }
+        } else {
+            _failed = true;
+        }
+        disconnectDB();
+    } else {
+        qCCritical(QGCTileCacheWorkerLog) << "Could not find suitable cache directory.";
+        _failed = true;
+    }
+
+    return !_failed;
+}
+
+bool QGCTileCacheDatabase::connectDB()
+{
+    if (_connected) {
+        disconnectDB();
+    }
+
+    QSqlDatabase db = QSqlDatabase::addDatabase("QSQLITE", _connectionName);
+    db.setDatabaseName(_databasePath);
+    _valid = db.open();
+    if (_valid) {
+        QSqlQuery pragma(db);
+        if (!pragma.exec("PRAGMA journal_mode=WAL")) {
+            qCWarning(QGCTileCacheWorkerLog) << "Failed to set WAL journal mode:" << pragma.lastError().text();
+        }
+        if (!pragma.exec("PRAGMA foreign_keys = ON")) {
+            qCWarning(QGCTileCacheWorkerLog) << "Failed to enable foreign keys:" << pragma.lastError().text();
+        }
+        _connected = true;
+    } else {
+        qCCritical(QGCTileCacheWorkerLog) << "Map Cache SQL error (open db):" << db.lastError();
+        QSqlDatabase::removeDatabase(_connectionName);
+    }
+    return _valid;
+}
+
+void QGCTileCacheDatabase::disconnectDB()
+{
+    if (!_connected) {
+        return;
+    }
+    _connected = false;
+
+    if (!QCoreApplication::instance()) {
+        return;
+    }
+
+    {
+        QSqlDatabase db = QSqlDatabase::database(_connectionName, false);
+        if (db.isOpen()) {
+            db.close();
+        }
+    }
+    QSqlDatabase::removeDatabase(_connectionName);
+}
+
+bool QGCTileCacheDatabase::saveTile(const QString &hash, const QString &format, const QByteArray &img, const QString &type, quint64 tileSet)
+{
+    if (!_ensureConnected()) {
+        return false;
+    }
+
+    TransactionGuard txn(_database());
+    if (!txn.begin()) {
+        qCWarning(QGCTileCacheWorkerLog) << "Failed to start transaction for saveTile";
+        return false;
+    }
+
+    QSqlQuery query(_database());
+    if (!query.prepare("INSERT OR IGNORE INTO Tiles(hash, format, tile, size, type, date) VALUES(?, ?, ?, ?, ?, ?)")) {
+        qCWarning(QGCTileCacheWorkerLog) << "Map Cache SQL error (prepare saveTile):" << query.lastError().text();
+        return false;
+    }
+    query.addBindValue(hash);
+    query.addBindValue(format);
+    query.addBindValue(img);
+    query.addBindValue(img.size());
+    query.addBindValue(UrlFactory::getQtMapIdFromProviderType(type));
+    query.addBindValue(QDateTime::currentSecsSinceEpoch());
+    if (!query.exec()) {
+        qCWarning(QGCTileCacheWorkerLog) << "Map Cache SQL error (saveTile INSERT):" << query.lastError().text();
+        return false;
+    }
+
+    if (!query.prepare("SELECT tileID FROM Tiles WHERE hash = ?")) {
+        qCWarning(QGCTileCacheWorkerLog) << "Map Cache SQL error (prepare tile lookup):" << query.lastError().text();
+        return false;
+    }
+    query.addBindValue(hash);
+    if (!query.exec() || !query.next()) {
+        qCWarning(QGCTileCacheWorkerLog) << "Map Cache SQL error (tile lookup):" << query.lastError().text();
+        return false;
+    }
+    const quint64 tileID = query.value(0).toULongLong();
+
+    const quint64 setID = (tileSet == kInvalidTileSet) ? _getDefaultTileSet() : tileSet;
+    if (setID == kInvalidTileSet) {
+        qCWarning(QGCTileCacheWorkerLog) << "Cannot save tile: no valid tile set";
+        return false;
+    }
+    if (!query.prepare("INSERT OR IGNORE INTO SetTiles(tileID, setID) VALUES(?, ?)")) {
+        qCWarning(QGCTileCacheWorkerLog) << "Map Cache SQL error (prepare SetTiles):" << query.lastError().text();
+        return false;
+    }
+    query.addBindValue(tileID);
+    query.addBindValue(setID);
+    if (!query.exec()) {
+        qCWarning(QGCTileCacheWorkerLog) << "Map Cache SQL error (add tile into SetTiles):" << query.lastError().text();
+        return false;
+    }
+
+    if (!txn.commit()) {
+        qCWarning(QGCTileCacheWorkerLog) << "Failed to commit saveTile transaction";
+        return false;
+    }
+
+    qCDebug(QGCTileCacheWorkerLog) << "HASH:" << hash;
+    return true;
+}
+
+std::unique_ptr<QGCCacheTile> QGCTileCacheDatabase::getTile(const QString &hash)
+{
+    if (!_ensureConnected()) {
+        return nullptr;
+    }
+
+    QSqlQuery query(_database());
+    if (!query.prepare("SELECT tile, format, type FROM Tiles WHERE hash = ?")) {
+        return nullptr;
+    }
+    query.addBindValue(hash);
+    if (query.exec() && query.next()) {
+        const QByteArray tileData = query.value(0).toByteArray();
+        const QString format = query.value(1).toString();
+        const QString type = UrlFactory::getProviderTypeFromQtMapId(query.value(2).toInt());
+        qCDebug(QGCTileCacheWorkerLog) << "(Found in DB) HASH:" << hash;
+        return std::make_unique<QGCCacheTile>(hash, tileData, format, type);
+    }
+
+    qCDebug(QGCTileCacheWorkerLog) << "(NOT in DB) HASH:" << hash;
+    return nullptr;
+}
+
+std::optional<quint64> QGCTileCacheDatabase::findTile(const QString &hash)
+{
+    if (!_ensureConnected()) {
+        return std::nullopt;
+    }
+
+    QSqlQuery query(_database());
+    if (!query.prepare("SELECT tileID FROM Tiles WHERE hash = ?")) {
+        return std::nullopt;
+    }
+    query.addBindValue(hash);
+    if (query.exec() && query.next()) {
+        return query.value(0).toULongLong();
+    }
+
+    return std::nullopt;
+}
+
+QList<TileSetRecord> QGCTileCacheDatabase::getTileSets()
+{
+    QList<TileSetRecord> records;
+    if (!_ensureConnected()) {
+        return records;
+    }
+
+    QSqlQuery query(_database());
+    query.setForwardOnly(true);
+    if (!query.exec("SELECT setID, name, typeStr, topleftLat, topleftLon, bottomRightLat, bottomRightLon, "
+                     "minZoom, maxZoom, type, numTiles, defaultSet, date "
+                     "FROM TileSets ORDER BY defaultSet DESC, name ASC")) {
+        return records;
+    }
+
+    while (query.next()) {
+        TileSetRecord rec;
+        rec.setID = query.value(0).toULongLong();
+        rec.name = query.value(1).toString();
+        rec.mapTypeStr = query.value(2).toString();
+        rec.topleftLat = query.value(3).toDouble();
+        rec.topleftLon = query.value(4).toDouble();
+        rec.bottomRightLat = query.value(5).toDouble();
+        rec.bottomRightLon = query.value(6).toDouble();
+        rec.minZoom = query.value(7).toInt();
+        rec.maxZoom = query.value(8).toInt();
+        rec.type = query.value(9).toInt();
+        rec.numTiles = query.value(10).toUInt();
+        rec.defaultSet = (query.value(11).toInt() != 0);
+        rec.date = query.value(12).toULongLong();
+        records.append(rec);
+    }
+
+    return records;
+}
+
+std::optional<quint64> QGCTileCacheDatabase::createTileSet(const QString &name, const QString &mapTypeStr,
+                                                            double topleftLat, double topleftLon,
+                                                            double bottomRightLat, double bottomRightLon,
+                                                            int minZoom, int maxZoom, const QString &type, quint32 numTiles)
+{
+    if (!_ensureConnected()) {
+        return std::nullopt;
+    }
+
+    TransactionGuard txn(_database());
+    if (!txn.begin()) {
+        qCWarning(QGCTileCacheWorkerLog) << "Failed to start transaction for createTileSet";
+        return std::nullopt;
+    }
+
+    QSqlQuery query(_database());
+    if (!query.prepare("INSERT INTO TileSets("
+        "name, typeStr, topleftLat, topleftLon, bottomRightLat, bottomRightLon, minZoom, maxZoom, type, numTiles, date"
+        ") VALUES(?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)")) {
+        qCWarning(QGCTileCacheWorkerLog) << "Map Cache SQL error (prepare createTileSet):" << query.lastError().text();
+        return std::nullopt;
+    }
+    query.addBindValue(name);
+    query.addBindValue(mapTypeStr);
+    query.addBindValue(topleftLat);
+    query.addBindValue(topleftLon);
+    query.addBindValue(bottomRightLat);
+    query.addBindValue(bottomRightLon);
+    query.addBindValue(minZoom);
+    query.addBindValue(maxZoom);
+    query.addBindValue(UrlFactory::getQtMapIdFromProviderType(type));
+    query.addBindValue(numTiles);
+    query.addBindValue(QDateTime::currentSecsSinceEpoch());
+    if (!query.exec()) {
+        qCWarning(QGCTileCacheWorkerLog) << "Map Cache SQL error (add tileSet into TileSets):" << query.lastError().text();
+        return std::nullopt;
+    }
+
+    const quint64 setID = query.lastInsertId().toULongLong();
+
+    // Process tiles in streaming batches to avoid holding all coordinates in memory
+    constexpr int kHashBatchSize = 500;
+    const int mapTypeId = UrlFactory::getQtMapIdFromProviderType(type);
+
+    struct TileCoord { int x, y; QString hash; };
+
+    auto processBatch = [&](const QList<TileCoord> &tiles, int z) -> bool {
+        QHash<QString, quint64> existingTiles;
+        QSqlQuery lookup(_database());
+        lookup.setForwardOnly(true);
+        if (lookup.prepare(QStringLiteral("SELECT hash, tileID FROM Tiles WHERE hash IN (%1)").arg(placeholders(tiles.size())))) {
+            for (const auto &tc : tiles) {
+                lookup.addBindValue(tc.hash);
+            }
+            if (lookup.exec()) {
+                while (lookup.next()) {
+                    existingTiles.insert(lookup.value(0).toString(), lookup.value(1).toULongLong());
+                }
+            }
+        }
+
+        for (const auto &tc : tiles) {
+            auto it = existingTiles.find(tc.hash);
+            if (it != existingTiles.end()) {
+                if (!query.prepare("INSERT OR IGNORE INTO SetTiles(tileID, setID) VALUES(?, ?)")) {
+                    return false;
+                }
+                query.addBindValue(it.value());
+                query.addBindValue(setID);
+                if (!query.exec()) {
+                    qCWarning(QGCTileCacheWorkerLog) << "Map Cache SQL error (add tile into SetTiles):" << query.lastError().text();
+                    return false;
+                }
+            } else {
+                if (!query.prepare("INSERT OR IGNORE INTO TilesDownload(setID, hash, type, x, y, z, state) VALUES(?, ?, ?, ?, ?, ?, ?)")) {
+                    return false;
+                }
+                query.addBindValue(setID);
+                query.addBindValue(tc.hash);
+                query.addBindValue(mapTypeId);
+                query.addBindValue(tc.x);
+                query.addBindValue(tc.y);
+                query.addBindValue(z);
+                query.addBindValue(static_cast<int>(QGCTile::StatePending));
+                if (!query.exec()) {
+                    qCWarning(QGCTileCacheWorkerLog) << "Map Cache SQL error (add tile into TilesDownload):" << query.lastError().text();
+                    return false;
+                }
+            }
+        }
+        return true;
+    };
+
+    for (int z = minZoom; z <= maxZoom; z++) {
+        const QGCTileSet set = UrlFactory::getTileCount(z, topleftLon, topleftLat, bottomRightLon, bottomRightLat, type);
+
+        QList<TileCoord> batch;
+        batch.reserve(kHashBatchSize);
+
+        for (int x = set.tileX0; x <= set.tileX1; x++) {
+            for (int y = set.tileY0; y <= set.tileY1; y++) {
+                batch.append({x, y, UrlFactory::getTileHash(type, x, y, z)});
+
+                if (batch.size() >= kHashBatchSize) {
+                    if (!processBatch(batch, z)) return std::nullopt;
+                    batch.clear();
+                }
+            }
+        }
+
+        if (!batch.isEmpty()) {
+            if (!processBatch(batch, z)) return std::nullopt;
+        }
+    }
+
+    if (!txn.commit()) {
+        qCWarning(QGCTileCacheWorkerLog) << "Failed to commit createTileSet transaction";
+        return std::nullopt;
+    }
+
+    return setID;
+}
+
+bool QGCTileCacheDatabase::deleteTileSet(quint64 id)
+{
+    if (!_ensureConnected()) {
+        return false;
+    }
+
+    TransactionGuard txn(_database());
+    if (!txn.begin()) {
+        qCWarning(QGCTileCacheWorkerLog) << "Failed to start transaction for deleteTileSet";
+        return false;
+    }
+
+    QSqlQuery query(_database());
+
+    // Delete download queue entries first
+    if (!query.prepare("DELETE FROM TilesDownload WHERE setID = ?")) {
+        qCWarning(QGCTileCacheWorkerLog) << "Failed to prepare download delete:" << query.lastError().text();
+        return false;
+    }
+    query.addBindValue(id);
+    if (!query.exec()) {
+        return false;
+    }
+
+    // Find tiles unique to this set (not shared with other sets)
+    // Must collect IDs before deleting SetTiles links
+    QList<quint64> uniqueTileIDs;
+    if (query.prepare(QStringLiteral("SELECT tileID FROM SetTiles WHERE tileID IN (%1)").arg(kUniqueTilesSubquery))) {
+        query.addBindValue(id);
+        if (query.exec()) {
+            while (query.next()) {
+                uniqueTileIDs.append(query.value(0).toULongLong());
+            }
+        }
+    }
+
+    // Remove set-tile links
+    if (!query.prepare("DELETE FROM SetTiles WHERE setID = ?")) {
+        qCWarning(QGCTileCacheWorkerLog) << "Failed to prepare SetTiles delete:" << query.lastError().text();
+        return false;
+    }
+    query.addBindValue(id);
+    if (!query.exec()) {
+        return false;
+    }
+
+    // Delete unique tiles (no longer referenced by any set)
+    if (!uniqueTileIDs.isEmpty()) {
+        if (query.prepare(QStringLiteral("DELETE FROM Tiles WHERE tileID IN (%1)").arg(placeholders(uniqueTileIDs.size())))) {
+            for (const quint64 tileID : uniqueTileIDs) {
+                query.addBindValue(tileID);
+            }
+            if (!query.exec()) {
+                qCWarning(QGCTileCacheWorkerLog) << "Failed to delete unique tiles:" << query.lastError().text();
+                return false;
+            }
+        }
+    }
+
+    // Delete the tile set itself
+    if (!query.prepare("DELETE FROM TileSets WHERE setID = ?")) {
+        qCWarning(QGCTileCacheWorkerLog) << "Failed to prepare TileSets delete:" << query.lastError().text();
+        return false;
+    }
+    query.addBindValue(id);
+    if (!query.exec()) {
+        return false;
+    }
+
+    if (id == _defaultSet) {
+        _defaultSet = kInvalidTileSet;
+    }
+
+    return txn.commit();
+}
+
+bool QGCTileCacheDatabase::renameTileSet(quint64 setID, const QString &newName)
+{
+    if (!_ensureConnected()) {
+        return false;
+    }
+
+    QSqlQuery query(_database());
+    if (!query.prepare("UPDATE TileSets SET name = ? WHERE setID = ?")) {
+        return false;
+    }
+    query.addBindValue(newName);
+    query.addBindValue(setID);
+    return query.exec();
+}
+
+std::optional<quint64> QGCTileCacheDatabase::findTileSetID(const QString &name)
+{
+    if (!_ensureConnected()) {
+        return std::nullopt;
+    }
+
+    QSqlQuery query(_database());
+    if (!query.prepare("SELECT setID FROM TileSets WHERE name = ?")) {
+        return std::nullopt;
+    }
+    query.addBindValue(name);
+    if (query.exec() && query.next()) {
+        return query.value(0).toULongLong();
+    }
+
+    return std::nullopt;
+}
+
+bool QGCTileCacheDatabase::resetDatabase()
+{
+    if (!_ensureConnected()) {
+        return false;
+    }
+
+    _defaultSet = kInvalidTileSet;
+
+    TransactionGuard txn(_database());
+    if (!txn.begin()) {
+        qCWarning(QGCTileCacheWorkerLog) << "Failed to start transaction for resetDatabase";
+        return false;
+    }
+    QSqlQuery query(_database());
+    if (!query.exec("DROP TABLE IF EXISTS TilesDownload") ||
+        !query.exec("DROP TABLE IF EXISTS SetTiles") ||
+        !query.exec("DROP TABLE IF EXISTS Tiles") ||
+        !query.exec("DROP TABLE IF EXISTS TileSets")) {
+        qCWarning(QGCTileCacheWorkerLog) << "Failed to drop tables:" << query.lastError().text();
+        return false;
+    }
+    if (!txn.commit()) {
+        qCWarning(QGCTileCacheWorkerLog) << "Failed to commit table drops in resetDatabase";
+        return false;
+    }
+    _valid = _createDB(_database());
+    return _valid;
+}
+
+QList<QGCTile> QGCTileCacheDatabase::getTileDownloadList(quint64 setID, int count)
+{
+    QList<QGCTile> tiles;
+    if (!_ensureConnected()) {
+        return tiles;
+    }
+
+    TransactionGuard txn(_database());
+    if (!txn.begin()) {
+        qCWarning(QGCTileCacheWorkerLog) << "Failed to start transaction for getTileDownloadList";
+        return tiles;
+    }
+
+    QSqlQuery query(_database());
+    if (!query.prepare("SELECT hash, type, x, y, z FROM TilesDownload WHERE setID = ? AND state = ? LIMIT ?")) {
+        qCWarning(QGCTileCacheWorkerLog) << "Failed to prepare tile download list query:" << query.lastError().text();
+        return tiles;
+    }
+    query.addBindValue(setID);
+    query.addBindValue(static_cast<int>(QGCTile::StatePending));
+    query.addBindValue(count);
+    if (!query.exec()) {
+        return tiles;
+    }
+
+    while (query.next()) {
+        QGCTile tile;
+        tile.hash = query.value(0).toString();
+        tile.type = query.value(1).toInt();
+        tile.x = query.value(2).toInt();
+        tile.y = query.value(3).toInt();
+        tile.z = query.value(4).toInt();
+        tiles.append(std::move(tile));
+    }
+
+    if (!tiles.isEmpty()) {
+        if (query.prepare(QStringLiteral("UPDATE TilesDownload SET state = ? WHERE setID = ? AND hash IN (%1)").arg(placeholders(tiles.size())))) {
+            query.addBindValue(static_cast<int>(QGCTile::StateDownloading));
+            query.addBindValue(setID);
+            for (qsizetype i = 0; i < tiles.size(); i++) {
+                query.addBindValue(tiles[i].hash);
+            }
+            if (!query.exec()) {
+                qCWarning(QGCTileCacheWorkerLog) << "Map Cache SQL error (batch set TilesDownload state):" << query.lastError().text();
+                tiles.clear();
+                return tiles;
+            }
+        }
+    }
+
+    if (!txn.commit()) {
+        qCWarning(QGCTileCacheWorkerLog) << "Failed to commit getTileDownloadList transaction";
+        tiles.clear();
+    }
+
+    return tiles;
+}
+
+bool QGCTileCacheDatabase::updateTileDownloadState(quint64 setID, int state, const QString &hash)
+{
+    if (!_ensureConnected()) {
+        return false;
+    }
+
+    QSqlQuery query(_database());
+    if (state == QGCTile::StateComplete) {
+        if (!query.prepare("DELETE FROM TilesDownload WHERE setID = ? AND hash = ?")) {
+            return false;
+        }
+        query.addBindValue(setID);
+        query.addBindValue(hash);
+    } else {
+        if (!query.prepare("UPDATE TilesDownload SET state = ? WHERE setID = ? AND hash = ?")) {
+            return false;
+        }
+        query.addBindValue(state);
+        query.addBindValue(setID);
+        query.addBindValue(hash);
+    }
+
+    if (!query.exec()) {
+        qCWarning(QGCTileCacheWorkerLog) << "Error:" << query.lastError().text();
+        return false;
+    }
+
+    return true;
+}
+
+bool QGCTileCacheDatabase::updateAllTileDownloadStates(quint64 setID, int state)
+{
+    if (!_ensureConnected()) {
+        return false;
+    }
+
+    QSqlQuery query(_database());
+    if (!query.prepare("UPDATE TilesDownload SET state = ? WHERE setID = ?")) {
+        return false;
+    }
+    query.addBindValue(state);
+    query.addBindValue(setID);
+
+    if (!query.exec()) {
+        qCWarning(QGCTileCacheWorkerLog) << "Error:" << query.lastError().text();
+        return false;
+    }
+
+    return true;
+}
+
+bool QGCTileCacheDatabase::pruneCache(quint64 amount)
+{
+    if (!_ensureConnected()) {
+        return false;
+    }
+
+    quint64 remaining = amount;
+    while (remaining > 0) {
+        QSqlQuery query(_database());
+        query.setForwardOnly(true);
+        if (!query.prepare(QStringLiteral("SELECT tileID, size, hash FROM Tiles WHERE tileID IN (%1) ORDER BY date ASC LIMIT ?").arg(kUniqueTilesSubquery))) {
+            qCWarning(QGCTileCacheWorkerLog) << "Failed to prepare prune query:" << query.lastError().text();
+            return false;
+        }
+        query.addBindValue(_getDefaultTileSet());
+        query.addBindValue(kPruneBatchSize);
+        if (!query.exec()) {
+            return false;
+        }
+
+        QList<quint64> tileIDs;
+        while (query.next() && (remaining > 0)) {
+            tileIDs << query.value(0).toULongLong();
+            const quint64 sz = query.value(1).toULongLong();
+            remaining = (sz >= remaining) ? 0 : remaining - sz;
+            qCDebug(QGCTileCacheWorkerLog) << "HASH:" << query.value(2).toString();
+        }
+
+        if (tileIDs.isEmpty()) {
+            break;
+        }
+
+        TransactionGuard txn(_database());
+        if (!txn.begin()) {
+            return false;
+        }
+
+        if (!_deleteTilesByIDs(tileIDs)) {
+            return false;
+        }
+
+        if (!txn.commit()) {
+            return false;
+        }
+    }
+
+    return true;
+}
+
+void QGCTileCacheDatabase::deleteBingNoTileTiles()
+{
+    if (!_ensureConnected()) {
+        return;
+    }
+
+    QSettings settings;
+    if (settings.value(QLatin1String(kBingNoTileDoneKey), false).toBool()) {
+        return;
+    }
+
+    QFile file(QStringLiteral(":/res/BingNoTileBytes.dat"));
+    if (!file.open(QFile::ReadOnly)) {
+        qCWarning(QGCTileCacheWorkerLog) << "Failed to Open File" << file.fileName() << ":" << file.errorString();
+        return;
+    }
+
+    const QByteArray noTileBytes = file.readAll();
+    file.close();
+
+    QSqlQuery query(_database());
+    query.setForwardOnly(true);
+    if (!query.prepare("SELECT tileID, hash FROM Tiles WHERE LENGTH(tile) = ? AND tile = ?")) {
+        qCWarning(QGCTileCacheWorkerLog) << "Failed to prepare Bing no-tile query";
+        return;
+    }
+    query.addBindValue(noTileBytes.length());
+    query.addBindValue(noTileBytes);
+    if (!query.exec()) {
+        qCWarning(QGCTileCacheWorkerLog) << "query failed";
+        return;
+    }
+
+    QList<quint64> idsToDelete;
+    while (query.next()) {
+        idsToDelete.append(query.value(0).toULongLong());
+        qCDebug(QGCTileCacheWorkerLog) << "HASH:" << query.value(1).toString();
+    }
+
+    if (idsToDelete.isEmpty()) {
+        settings.setValue(QLatin1String(kBingNoTileDoneKey), true);
+        return;
+    }
+
+    TransactionGuard txn(_database());
+    if (!txn.begin()) {
+        return;
+    }
+
+    bool allSucceeded = true;
+    for (qsizetype offset = 0; offset < idsToDelete.size(); offset += kPruneBatchSize) {
+        const qsizetype batchEnd = qMin(offset + static_cast<qsizetype>(kPruneBatchSize), idsToDelete.size());
+        const QList<quint64> batch = idsToDelete.mid(offset, batchEnd - offset);
+        if (!_deleteTilesByIDs(batch)) {
+            allSucceeded = false;
+            break;
+        }
+    }
+
+    if (allSucceeded && txn.commit()) {
+        settings.setValue(QLatin1String(kBingNoTileDoneKey), true);
+    }
+}
+
+TotalsResult QGCTileCacheDatabase::computeTotals()
+{
+    TotalsResult result;
+    if (!_ensureConnected()) {
+        return result;
+    }
+
+    QSqlQuery query(_database());
+
+    if (query.exec("SELECT COUNT(size), SUM(size) FROM Tiles") && query.next()) {
+        result.totalCount = query.value(0).toUInt();
+        result.totalSize = query.value(1).toULongLong();
+    }
+
+    if (!query.prepare(QStringLiteral("SELECT COUNT(size), SUM(size) FROM Tiles WHERE tileID IN (%1)").arg(kUniqueTilesSubquery))) {
+        return result;
+    }
+    query.addBindValue(_getDefaultTileSet());
+    if (query.exec() && query.next()) {
+        result.defaultCount = query.value(0).toUInt();
+        result.defaultSize = query.value(1).toULongLong();
+    }
+
+    return result;
+}
+
+SetTotalsResult QGCTileCacheDatabase::computeSetTotals(quint64 setID, bool isDefault, quint32 totalTileCount, const QString &type)
+{
+    SetTotalsResult result;
+
+    if (isDefault) {
+        TotalsResult totals = computeTotals();
+        result.savedTileCount = totals.totalCount;
+        result.savedTileSize = totals.totalSize;
+        result.totalTileSize = totals.totalSize;
+        result.uniqueTileCount = totals.defaultCount;
+        result.uniqueTileSize = totals.defaultSize;
+        return result;
+    }
+
+    if (!_ensureConnected()) {
+        return result;
+    }
+
+    QSqlQuery subquery(_database());
+    if (!subquery.prepare("SELECT COUNT(size), SUM(size) FROM Tiles A INNER JOIN SetTiles B ON A.tileID = B.tileID WHERE B.setID = ?")) {
+        return result;
+    }
+    subquery.addBindValue(setID);
+    if (!subquery.exec() || !subquery.next()) {
+        return result;
+    }
+
+    result.savedTileCount = subquery.value(0).toUInt();
+    result.savedTileSize = subquery.value(1).toULongLong();
+
+    quint64 avg = UrlFactory::averageSizeForType(type);
+    if (avg == 0) {
+        avg = 4096;
+    }
+    if (totalTileCount <= result.savedTileCount) {
+        result.totalTileSize = result.savedTileSize;
+    } else {
+        if ((result.savedTileCount > 10) && result.savedTileSize) {
+            avg = result.savedTileSize / result.savedTileCount;
+        }
+        result.totalTileSize = avg * totalTileCount;
+    }
+
+    quint32 dbUniqueCount = 0;
+    quint64 dbUniqueSize = 0;
+    if (subquery.prepare(QStringLiteral("SELECT COUNT(size), SUM(size) FROM Tiles WHERE tileID IN (%1)").arg(kUniqueTilesSubquery))) {
+        subquery.addBindValue(setID);
+        if (subquery.exec() && subquery.next()) {
+            dbUniqueCount = subquery.value(0).toUInt();
+            dbUniqueSize = subquery.value(1).toULongLong();
+        }
+    } else {
+        qCWarning(QGCTileCacheWorkerLog) << "Failed to prepare unique tiles query:" << subquery.lastError().text();
+    }
+
+    if (dbUniqueCount > 0) {
+        result.uniqueTileCount = dbUniqueCount;
+        result.uniqueTileSize = dbUniqueSize;
+    } else {
+        const quint32 estimatedCount = (totalTileCount > result.savedTileCount) ? (totalTileCount - result.savedTileCount) : 0;
+        result.uniqueTileCount = estimatedCount;
+        result.uniqueTileSize = estimatedCount * avg;
+    }
+
+    return result;
+}
+
+DatabaseResult QGCTileCacheDatabase::importSetsReplace(const QString &path, ProgressCallback progressCb)
+{
+    DatabaseResult result;
+    if (QFileInfo(path).canonicalFilePath() == QFileInfo(_databasePath).canonicalFilePath()) {
+        result.errorString = "Import path must differ from the active database";
+        return result;
+    }
+    _defaultSet = kInvalidTileSet;
+    disconnectDB();
+    const QString backupPath = _databasePath + QStringLiteral(".bak");
+    (void) QFile::remove(backupPath);
+    const bool hasBackup = QFile::rename(_databasePath, backupPath);
+    if (!hasBackup) {
+        (void) QFile::remove(_databasePath);
+    }
+    if (!QFile::copy(path, _databasePath)) {
+        if (hasBackup) {
+            (void) QFile::rename(backupPath, _databasePath);
+        }
+        result.errorString = "Failed to copy import database";
+        _valid = false;
+        _failed = true;
+        return result;
+    }
+    (void) QFile::remove(backupPath);
+    if (progressCb) progressCb(25);
+    init();
+    if (!_valid) {
+        result.errorString = QStringLiteral("Failed to initialize tile cache database after import");
+    } else {
+        if (progressCb) progressCb(50);
+        connectDB();
+        if (!_valid) {
+            result.errorString = QStringLiteral("Failed to connect to tile cache database after import");
+        }
+    }
+    if (progressCb) progressCb(100);
+    result.success = _valid;
+    return result;
+}
+
+DatabaseResult QGCTileCacheDatabase::importSetsMerge(const QString &path, ProgressCallback progressCb)
+{
+    DatabaseResult result;
+    if (QFileInfo(path).canonicalFilePath() == QFileInfo(_databasePath).canonicalFilePath()) {
+        result.errorString = "Import path must differ from the active database";
+        return result;
+    }
+    if (!_ensureConnected()) {
+        result.errorString = "Database not connected";
+        return result;
+    }
+
+    ScopedExportDB importDB(path);
+    if (!importDB.open()) {
+        result.errorString = "Error opening import database";
+        return result;
+    }
+
+    QSqlQuery query(*importDB.db);
+    quint64 tileCount = 0;
+    int lastProgress = -1;
+    if (query.exec("SELECT COUNT(tileID) FROM Tiles") && query.next()) {
+        tileCount = query.value(0).toULongLong();
+    }
+
+    bool tilesImported = false;
+
+    if (tileCount > 0) {
+        if (query.exec("SELECT * FROM TileSets ORDER BY defaultSet DESC, name ASC")) {
+            quint64 currentCount = 0;
+            while (query.next()) {
+                QString name = query.value("name").toString();
+                const quint64 setID = query.value("setID").toULongLong();
+                const QString mapType = query.value("typeStr").toString();
+                const double topleftLat = query.value("topleftLat").toDouble();
+                const double topleftLon = query.value("topleftLon").toDouble();
+                const double bottomRightLat = query.value("bottomRightLat").toDouble();
+                const double bottomRightLon = query.value("bottomRightLon").toDouble();
+                const int minZoom = query.value("minZoom").toInt();
+                const int maxZoom = query.value("maxZoom").toInt();
+                const int type = query.value("type").toInt();
+                const quint32 numTiles = query.value("numTiles").toUInt();
+                const int defaultSet = query.value("defaultSet").toInt();
+                quint64 insertSetID = _getDefaultTileSet();
+
+                // Wrap each set creation + tile copy in a single transaction
+                TransactionGuard txn(_database());
+                if (!txn.begin()) {
+                    result.errorString = "Failed to start transaction for import set";
+                    break;
+                }
+
+                if (defaultSet == 0) {
+                    name = _deduplicateSetName(name);
+                    QSqlQuery cQuery(_database());
+                    if (!cQuery.prepare("INSERT INTO TileSets("
+                        "name, typeStr, topleftLat, topleftLon, bottomRightLat, bottomRightLon, minZoom, maxZoom, type, numTiles, defaultSet, date"
+                        ") VALUES(?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)")) {
+                        result.errorString = "Error preparing tile set insert";
+                        break;
+                    }
+                    cQuery.addBindValue(name);
+                    cQuery.addBindValue(mapType);
+                    cQuery.addBindValue(topleftLat);
+                    cQuery.addBindValue(topleftLon);
+                    cQuery.addBindValue(bottomRightLat);
+                    cQuery.addBindValue(bottomRightLon);
+                    cQuery.addBindValue(minZoom);
+                    cQuery.addBindValue(maxZoom);
+                    cQuery.addBindValue(type);
+                    cQuery.addBindValue(numTiles);
+                    cQuery.addBindValue(defaultSet);
+                    cQuery.addBindValue(QDateTime::currentSecsSinceEpoch());
+                    if (!cQuery.exec()) {
+                        result.errorString = "Error adding imported tile set to database";
+                        break;
+                    }
+                    insertSetID = cQuery.lastInsertId().toULongLong();
+                }
+
+                quint64 tilesIterated = 0;
+                const quint64 tilesSaved = _copyTilesForSet(*importDB.db, setID, insertSetID,
+                                                             currentCount, tileCount,
+                                                             lastProgress, progressCb,
+                                                             &tilesIterated, false);
+                if (tilesSaved > 0) {
+                    tilesImported = true;
+                    QSqlQuery cQuery(_database());
+                    if (cQuery.prepare("SELECT COUNT(size) FROM Tiles A INNER JOIN SetTiles B ON A.tileID = B.tileID WHERE B.setID = ?")) {
+                        cQuery.addBindValue(insertSetID);
+                        if (cQuery.exec() && cQuery.next()) {
+                            const quint64 count = cQuery.value(0).toULongLong();
+                            if (cQuery.prepare("UPDATE TileSets SET numTiles = ? WHERE setID = ?")) {
+                                cQuery.addBindValue(count);
+                                cQuery.addBindValue(insertSetID);
+                                (void) cQuery.exec();
+                            }
+                        }
+                    }
+                }
+
+                if (!txn.commit()) {
+                    qCWarning(QGCTileCacheWorkerLog) << "Failed to commit import transaction for set:" << name;
+                    continue;
+                }
+
+                if (tilesIterated > tilesSaved) {
+                    const quint64 alreadyExisting = tilesIterated - tilesSaved;
+                    tileCount = (alreadyExisting < tileCount) ? tileCount - alreadyExisting : 0;
+                }
+
+                if ((tilesSaved == 0) && (defaultSet == 0)) {
+                    qCDebug(QGCTileCacheWorkerLog) << "No unique tiles in" << name << "Removing it.";
+                    deleteTileSet(insertSetID);
+                }
+            }
+        } else {
+            result.errorString = "No tile set in database";
+        }
+    }
+
+    if (!tilesImported && result.errorString.isEmpty()) {
+        result.errorString = "No unique tiles in imported database";
+    }
+    result.success = result.errorString.isEmpty();
+    return result;
+}
+
+DatabaseResult QGCTileCacheDatabase::exportSets(const QList<TileSetRecord> &sets, const QString &path, ProgressCallback progressCb)
+{
+    DatabaseResult result;
+    if (!_ensureConnected()) {
+        result.errorString = "Database not connected";
+        return result;
+    }
+    if (QFileInfo(path).canonicalFilePath() == QFileInfo(_databasePath).canonicalFilePath()) {
+        result.errorString = "Export path must differ from the active database";
+        return result;
+    }
+
+    (void) QFile::remove(path);
+    ScopedExportDB exportDB(path);
+    if (!exportDB.open()) {
+        qCCritical(QGCTileCacheWorkerLog) << "Map Cache SQL error (create export database):" << exportDB.db->lastError();
+        result.errorString = "Error opening export database";
+        return result;
+    }
+
+    if (!_createDB(*exportDB.db, false)) {
+        result.errorString = "Error creating export database";
+        return result;
+    }
+
+    quint64 tileCount = 0;
+    quint64 currentCount = 0;
+    int lastProgress = -1;
+    for (const auto &set : sets) {
+        QSqlQuery countQuery(_database());
+        quint64 actualCount = 0;
+        if (countQuery.prepare("SELECT COUNT(*) FROM Tiles T INNER JOIN SetTiles S ON T.tileID = S.tileID WHERE S.setID = ?")) {
+            countQuery.addBindValue(set.setID);
+            if (countQuery.exec() && countQuery.next()) {
+                actualCount = countQuery.value(0).toULongLong();
+            }
+        }
+        tileCount += (actualCount > 0) ? actualCount : set.numTiles;
+    }
+
+    if (tileCount == 0) {
+        tileCount = 1;
+    }
+
+    for (const auto &set : sets) {
+        QSqlQuery query(_database());
+        query.setForwardOnly(true);
+        if (!query.prepare("SELECT T.hash, T.format, T.tile, T.type, T.date FROM Tiles T "
+                           "INNER JOIN SetTiles S ON T.tileID = S.tileID WHERE S.setID = ?")) {
+            qCWarning(QGCTileCacheWorkerLog) << "Failed to prepare tile query for export set" << set.name;
+            continue;
+        }
+        query.addBindValue(set.setID);
+        if (!query.exec()) {
+            qCWarning(QGCTileCacheWorkerLog) << "Failed to query tiles for export set" << set.name;
+            continue;
+        }
+
+        TransactionGuard txn(*exportDB.db);
+        if (!txn.begin()) {
+            qCWarning(QGCTileCacheWorkerLog) << "Failed to start transaction for export set" << set.name;
+            result.errorString = "Failed to start export transaction";
+            break;
+        }
+
+        QSqlQuery exportQuery(*exportDB.db);
+        if (!exportQuery.prepare("INSERT INTO TileSets("
+            "name, typeStr, topleftLat, topleftLon, bottomRightLat, bottomRightLon, minZoom, maxZoom, type, numTiles, defaultSet, date"
+            ") VALUES(?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)")) {
+            result.errorString = "Error preparing tile set insert for export";
+            break;
+        }
+        exportQuery.addBindValue(set.name);
+        exportQuery.addBindValue(set.mapTypeStr);
+        exportQuery.addBindValue(set.topleftLat);
+        exportQuery.addBindValue(set.topleftLon);
+        exportQuery.addBindValue(set.bottomRightLat);
+        exportQuery.addBindValue(set.bottomRightLon);
+        exportQuery.addBindValue(set.minZoom);
+        exportQuery.addBindValue(set.maxZoom);
+        exportQuery.addBindValue(set.type);
+        exportQuery.addBindValue(set.numTiles);
+        exportQuery.addBindValue(set.defaultSet);
+        exportQuery.addBindValue(set.date);
+        if (!exportQuery.exec()) {
+            result.errorString = "Error adding tile set to exported database";
+            break;
+        }
+
+        const quint64 exportSetID = exportQuery.lastInsertId().toULongLong();
+
+        quint64 skippedTiles = 0;
+        while (query.next()) {
+            const QString hash = query.value(0).toString();
+            const QString format = query.value(1).toString();
+            const QByteArray img = query.value(2).toByteArray();
+            const int tileType = query.value(3).toInt();
+            const quint64 tileDate = query.value(4).toULongLong();
+
+            quint64 exportTileID = 0;
+            if (!exportQuery.prepare("INSERT INTO Tiles(hash, format, tile, size, type, date) VALUES(?, ?, ?, ?, ?, ?)")) {
+                qCWarning(QGCTileCacheWorkerLog) << "Failed to prepare tile INSERT for export:" << exportQuery.lastError().text();
+                skippedTiles++;
+                continue;
+            }
+            exportQuery.addBindValue(hash);
+            exportQuery.addBindValue(format);
+            exportQuery.addBindValue(img);
+            exportQuery.addBindValue(img.size());
+            exportQuery.addBindValue(tileType);
+            exportQuery.addBindValue(tileDate);
+            if (exportQuery.exec()) {
+                exportTileID = exportQuery.lastInsertId().toULongLong();
+            } else {
+                QSqlQuery lookup(*exportDB.db);
+                if (lookup.prepare("SELECT tileID FROM Tiles WHERE hash = ?")) {
+                    lookup.addBindValue(hash);
+                    if (lookup.exec() && lookup.next()) {
+                        exportTileID = lookup.value(0).toULongLong();
+                    }
+                }
+            }
+
+            if (exportTileID > 0) {
+                if (exportQuery.prepare("INSERT OR IGNORE INTO SetTiles(tileID, setID) VALUES(?, ?)")) {
+                    exportQuery.addBindValue(exportTileID);
+                    exportQuery.addBindValue(exportSetID);
+                    if (!exportQuery.exec()) {
+                        qCWarning(QGCTileCacheWorkerLog) << "Failed to link tile to set in export:" << exportQuery.lastError().text();
+                    }
+                }
+            } else {
+                skippedTiles++;
+            }
+            currentCount++;
+            if (progressCb) {
+                const int progress = qMin(100, static_cast<int>((static_cast<double>(currentCount) / static_cast<double>(tileCount)) * 100.0));
+                if (lastProgress != progress) {
+                    lastProgress = progress;
+                    progressCb(progress);
+                }
+            }
+        }
+        if (skippedTiles > 0) {
+            qCWarning(QGCTileCacheWorkerLog) << "Skipped" << skippedTiles << "tiles during export of" << set.name;
+        }
+        if (!txn.commit()) {
+            qCWarning(QGCTileCacheWorkerLog) << "Failed to commit export transaction for" << set.name;
+        }
+    }
+
+    result.success = result.errorString.isEmpty();
+    return result;
+}
+
+bool QGCTileCacheDatabase::_createDB(QSqlDatabase db, bool createDefault)
+{
+    QSqlQuery query(db);
+    (void) query.exec("PRAGMA foreign_keys = ON");
+
+    if (!query.exec(
+        "CREATE TABLE IF NOT EXISTS Tiles ("
+        "tileID INTEGER PRIMARY KEY NOT NULL, "
+        "hash TEXT NOT NULL UNIQUE, "
+        "format TEXT NOT NULL, "
+        "tile BLOB NULL, "
+        "size INTEGER, "
+        "type INTEGER, "
+        "date INTEGER DEFAULT 0)"))
+    {
+        qCWarning(QGCTileCacheWorkerLog) << "Map Cache SQL error (create Tiles db):" << query.lastError().text();
+        return false;
+    }
+
+    if (!query.exec(
+        "CREATE TABLE IF NOT EXISTS TileSets ("
+        "setID INTEGER PRIMARY KEY NOT NULL, "
+        "name TEXT NOT NULL UNIQUE, "
+        "typeStr TEXT, "
+        "topleftLat REAL DEFAULT 0.0, "
+        "topleftLon REAL DEFAULT 0.0, "
+        "bottomRightLat REAL DEFAULT 0.0, "
+        "bottomRightLon REAL DEFAULT 0.0, "
+        "minZoom INTEGER DEFAULT 3, "
+        "maxZoom INTEGER DEFAULT 3, "
+        "type INTEGER DEFAULT -1, "
+        "numTiles INTEGER DEFAULT 0, "
+        "defaultSet INTEGER DEFAULT 0, "
+        "date INTEGER DEFAULT 0)"))
+    {
+        qCWarning(QGCTileCacheWorkerLog) << "Map Cache SQL error (create TileSets db):" << query.lastError().text();
+        return false;
+    }
+
+    if (!query.exec(
+        "CREATE TABLE IF NOT EXISTS SetTiles ("
+        "setID INTEGER NOT NULL REFERENCES TileSets(setID) ON DELETE CASCADE, "
+        "tileID INTEGER NOT NULL REFERENCES Tiles(tileID) ON DELETE CASCADE)"))
+    {
+        qCWarning(QGCTileCacheWorkerLog) << "Map Cache SQL error (create SetTiles db):" << query.lastError().text();
+        return false;
+    }
+
+    if (!query.exec(
+        "CREATE TABLE IF NOT EXISTS TilesDownload ("
+        "setID INTEGER NOT NULL REFERENCES TileSets(setID) ON DELETE CASCADE, "
+        "hash TEXT NOT NULL, "
+        "type INTEGER, "
+        "x INTEGER, "
+        "y INTEGER, "
+        "z INTEGER, "
+        "state INTEGER DEFAULT 0)"))
+    {
+        qCWarning(QGCTileCacheWorkerLog) << "Map Cache SQL error (create TilesDownload db):" << query.lastError().text();
+        return false;
+    }
+
+    static const char *indexStatements[] = {
+        "CREATE UNIQUE INDEX IF NOT EXISTS idx_settiles_unique ON SetTiles(tileID, setID)",
+        "CREATE INDEX IF NOT EXISTS idx_settiles_setid ON SetTiles(setID)",
+        "CREATE INDEX IF NOT EXISTS idx_settiles_tileid ON SetTiles(tileID)",
+        "CREATE UNIQUE INDEX IF NOT EXISTS idx_tilesdownload_setid_hash ON TilesDownload(setID, hash)",
+        "CREATE INDEX IF NOT EXISTS idx_tilesdownload_setid_state ON TilesDownload(setID, state)",
+        "CREATE INDEX IF NOT EXISTS idx_tiles_date ON Tiles(date)",
+    };
+    for (const char *sql : indexStatements) {
+        if (!query.exec(QLatin1String(sql))) {
+            qCWarning(QGCTileCacheWorkerLog) << "Failed to create index:" << sql << query.lastError().text();
+        }
+    }
+
+    if (!query.exec(QStringLiteral("PRAGMA user_version = %1").arg(kSchemaVersion))) {
+        qCWarning(QGCTileCacheWorkerLog) << "Failed to set schema version:" << query.lastError().text();
+    }
+
+    if (!createDefault) {
+        return true;
+    }
+
+    if (!query.prepare("SELECT name FROM TileSets WHERE name = ?")) {
+        qCWarning(QGCTileCacheWorkerLog) << "Map Cache SQL error (prepare default set check):" << db.lastError();
+        return false;
+    }
+    query.addBindValue(QStringLiteral("Default Tile Set"));
+    if (!query.exec()) {
+        qCWarning(QGCTileCacheWorkerLog) << "Map Cache SQL error (Looking for default tile set):" << db.lastError();
+        return true;
+    }
+    if (query.next()) {
+        return true;
+    }
+
+    if (!query.prepare("INSERT INTO TileSets(name, defaultSet, date) VALUES(?, ?, ?)")) {
+        qCWarning(QGCTileCacheWorkerLog) << "Map Cache SQL error (prepare default tile set):" << db.lastError();
+        return false;
+    }
+    query.addBindValue(QStringLiteral("Default Tile Set"));
+    query.addBindValue(1);
+    query.addBindValue(QDateTime::currentSecsSinceEpoch());
+    if (!query.exec()) {
+        qCWarning(QGCTileCacheWorkerLog) << "Map Cache SQL error (Creating default tile set):" << db.lastError();
+        return false;
+    }
+
+    return true;
+}
+
+quint64 QGCTileCacheDatabase::_getDefaultTileSet()
+{
+    if (_defaultSet != kInvalidTileSet) {
+        return _defaultSet;
+    }
+
+    if (!_ensureConnected()) {
+        return kInvalidTileSet;
+    }
+
+    QSqlQuery query(_database());
+    if (query.exec("SELECT setID FROM TileSets WHERE defaultSet = 1") && query.next()) {
+        _defaultSet = query.value(0).toULongLong();
+        return _defaultSet;
+    }
+
+    qCWarning(QGCTileCacheWorkerLog) << "Default tile set not found in database";
+    return kInvalidTileSet;
+}
+
+bool QGCTileCacheDatabase::_deleteTilesByIDs(const QList<quint64> &ids)
+{
+    if (ids.isEmpty()) {
+        return true;
+    }
+
+    QSqlQuery query(_database());
+    if (!query.prepare(QStringLiteral("DELETE FROM Tiles WHERE tileID IN (%1)").arg(placeholders(ids.size())))) {
+        return false;
+    }
+    for (const quint64 id : ids) {
+        query.addBindValue(id);
+    }
+    return query.exec();
+}
+
+QString QGCTileCacheDatabase::_deduplicateSetName(const QString &name)
+{
+    if (!findTileSetID(name).has_value()) {
+        return name;
+    }
+
+    QSet<QString> existing;
+    existing.insert(name);
+    QSqlQuery query(_database());
+    QString escaped = name;
+    escaped.replace(QLatin1Char('\\'), QStringLiteral("\\\\"));
+    escaped.replace(QLatin1Char('%'), QStringLiteral("\\%"));
+    escaped.replace(QLatin1Char('_'), QStringLiteral("\\_"));
+    if (query.prepare(QStringLiteral("SELECT name FROM TileSets WHERE name LIKE ? || ' %' ESCAPE '\\'"))) {
+        query.addBindValue(escaped);
+        if (query.exec()) {
+            while (query.next()) {
+                existing.insert(query.value(0).toString());
+            }
+        }
+    }
+
+    for (int i = 1; i <= 9999; i++) {
+        const QString candidate = QStringLiteral("%1 %2").arg(name).arg(i, 4, 10, QChar('0'));
+        if (!existing.contains(candidate)) {
+            return candidate;
+        }
+    }
+
+    return QStringLiteral("%1 %2").arg(name, QUuid::createUuid().toString(QUuid::WithoutBraces).left(8));
+}
+
+quint64 QGCTileCacheDatabase::_copyTilesForSet(QSqlDatabase srcDB, quint64 srcSetID, quint64 dstSetID,
+                                                 quint64 &currentCount, quint64 tileCount,
+                                                 int &lastProgress, ProgressCallback progressCb,
+                                                 quint64 *tilesIteratedOut, bool useTransaction)
+{
+    QSqlQuery subQuery(srcDB);
+    subQuery.setForwardOnly(true);
+    if (!subQuery.prepare("SELECT T.hash, T.format, T.tile, T.type, T.date FROM Tiles T "
+                          "INNER JOIN SetTiles S ON T.tileID = S.tileID WHERE S.setID = ?")) {
+        if (tilesIteratedOut) *tilesIteratedOut = 0;
+        return 0;
+    }
+    subQuery.addBindValue(srcSetID);
+    if (!subQuery.exec()) {
+        if (tilesIteratedOut) *tilesIteratedOut = 0;
+        return 0;
+    }
+
+    quint64 tilesFound = 0;
+    quint64 tilesLinked = 0;
+
+    std::unique_ptr<TransactionGuard> txn;
+    if (useTransaction) {
+        txn = std::make_unique<TransactionGuard>(_database());
+        if (!txn->begin()) {
+            qCWarning(QGCTileCacheWorkerLog) << "Failed to start transaction for merge import";
+            if (tilesIteratedOut) *tilesIteratedOut = 0;
+            return 0;
+        }
+    }
+
+    QSqlQuery cQuery(_database());
+    while (subQuery.next()) {
+        tilesFound++;
+        const QString hash = subQuery.value(0).toString();
+        const QString format = subQuery.value(1).toString();
+        const QByteArray img = subQuery.value(2).toByteArray();
+        const int tileType = subQuery.value(3).toInt();
+        const quint64 tileDate = subQuery.value(4).toULongLong();
+
+        quint64 importTileID = 0;
+        if (cQuery.prepare("INSERT INTO Tiles(hash, format, tile, size, type, date) VALUES(?, ?, ?, ?, ?, ?)")) {
+            cQuery.addBindValue(hash);
+            cQuery.addBindValue(format);
+            cQuery.addBindValue(img);
+            cQuery.addBindValue(img.size());
+            cQuery.addBindValue(tileType);
+            cQuery.addBindValue(tileDate);
+            if (cQuery.exec()) {
+                importTileID = cQuery.lastInsertId().toULongLong();
+            } else {
+                if (cQuery.prepare("SELECT tileID FROM Tiles WHERE hash = ?")) {
+                    cQuery.addBindValue(hash);
+                    if (cQuery.exec() && cQuery.next()) {
+                        importTileID = cQuery.value(0).toULongLong();
+                    }
+                }
+            }
+        }
+
+        if (importTileID > 0) {
+            if (cQuery.prepare("INSERT OR IGNORE INTO SetTiles(tileID, setID) VALUES(?, ?)")) {
+                cQuery.addBindValue(importTileID);
+                cQuery.addBindValue(dstSetID);
+                if (cQuery.exec() && cQuery.numRowsAffected() > 0) {
+                    tilesLinked++;
+                }
+            }
+        }
+
+        currentCount++;
+        if (tileCount > 0 && progressCb) {
+            const int progress = qMin(100, static_cast<int>((static_cast<double>(currentCount) / static_cast<double>(tileCount)) * 100.0));
+            if (lastProgress != progress) {
+                lastProgress = progress;
+                progressCb(progress);
+            }
+        }
+    }
+
+    if (txn && !txn->commit()) {
+        qCWarning(QGCTileCacheWorkerLog) << "Failed to commit merge import transaction";
+        if (tilesIteratedOut) *tilesIteratedOut = tilesFound;
+        return 0;
+    }
+
+    if (tilesIteratedOut) *tilesIteratedOut = tilesFound;
+    return tilesLinked;
+}

--- a/src/QtLocationPlugin/QGCTileCacheDatabase.h
+++ b/src/QtLocationPlugin/QGCTileCacheDatabase.h
@@ -1,0 +1,93 @@
+#pragma once
+
+#include <QtCore/QByteArray>
+#include <QtCore/QString>
+#include <QtSql/QSqlDatabase>
+
+#include <memory>
+#include <optional>
+
+#include "QGCTileCacheTypes.h"
+#include "QGCTile.h"
+
+class QGCCacheTile;
+
+class QGCTileCacheDatabase
+{
+public:
+    static constexpr quint64 kInvalidTileSet = UINT64_MAX;
+    static constexpr int kSchemaVersion = 1;
+
+    explicit QGCTileCacheDatabase(const QString &databasePath);
+    ~QGCTileCacheDatabase();
+
+    bool init();
+    bool connectDB();
+    void disconnectDB();
+
+    bool isValid() const { return _valid; }
+    bool hasFailed() const { return _failed; }
+
+    // Tiles
+    bool saveTile(const QString &hash, const QString &format, const QByteArray &img, const QString &type, quint64 tileSet);
+    std::unique_ptr<QGCCacheTile> getTile(const QString &hash);
+    std::optional<quint64> findTile(const QString &hash);
+
+    // Tile Sets
+    QList<TileSetRecord> getTileSets();
+    std::optional<quint64> createTileSet(const QString &name, const QString &mapTypeStr,
+                                         double topleftLat, double topleftLon,
+                                         double bottomRightLat, double bottomRightLon,
+                                         int minZoom, int maxZoom, const QString &type, quint32 numTiles);
+    bool deleteTileSet(quint64 id);
+    bool renameTileSet(quint64 setID, const QString &newName);
+    std::optional<quint64> findTileSetID(const QString &name);
+    bool resetDatabase();
+
+    // Downloads
+    QList<QGCTile> getTileDownloadList(quint64 setID, int count);
+    bool updateTileDownloadState(quint64 setID, int state, const QString &hash);
+    bool updateAllTileDownloadStates(quint64 setID, int state);
+
+    // Cache
+    bool pruneCache(quint64 amount);
+    void deleteBingNoTileTiles();
+
+    // Stats
+    TotalsResult computeTotals();
+    SetTotalsResult computeSetTotals(quint64 setID, bool isDefault, quint32 totalTileCount, const QString &type);
+
+    // Import/Export
+    DatabaseResult importSetsReplace(const QString &path, ProgressCallback progressCb);
+    DatabaseResult importSetsMerge(const QString &path, ProgressCallback progressCb);
+    DatabaseResult exportSets(const QList<TileSetRecord> &sets, const QString &path, ProgressCallback progressCb);
+
+    // Exposed for unit tests only
+    QSqlDatabase database() const;
+
+    static constexpr const char *kBingNoTileDoneKey = "_deleteBingNoTileTilesDone";
+
+private:
+    bool _ensureConnected() const;
+    QSqlDatabase _database() const;
+    bool _checkSchemaVersion();
+    bool _createDB(QSqlDatabase db, bool createDefault = true);
+    quint64 _getDefaultTileSet();
+    bool _deleteTilesByIDs(const QList<quint64> &ids);
+    QString _deduplicateSetName(const QString &name);
+    quint64 _copyTilesForSet(QSqlDatabase srcDB, quint64 srcSetID, quint64 dstSetID,
+                              quint64 &currentCount, quint64 tileCount,
+                              int &lastProgress, ProgressCallback progressCb,
+                              quint64 *tilesIteratedOut, bool useTransaction = true);
+
+    QString _databasePath;
+    QString _connectionName;
+    quint64 _defaultSet = kInvalidTileSet;
+    bool _connected = false;
+    bool _valid = false;
+    bool _failed = false;
+    static constexpr int kPruneBatchSize = 128;
+    static constexpr const char *kUniqueTilesSubquery =
+        "SELECT A.tileID FROM SetTiles A JOIN SetTiles B ON A.tileID = B.tileID "
+        "WHERE B.setID = ? GROUP BY A.tileID HAVING COUNT(A.tileID) = 1";
+};

--- a/src/QtLocationPlugin/QGCTileCacheTypes.h
+++ b/src/QtLocationPlugin/QGCTileCacheTypes.h
@@ -1,0 +1,43 @@
+#pragma once
+
+#include <QtCore/QString>
+
+#include <functional>
+
+struct TileSetRecord {
+    quint64 setID = 0;
+    QString name;
+    QString mapTypeStr;
+    double topleftLat = 0.;
+    double topleftLon = 0.;
+    double bottomRightLat = 0.;
+    double bottomRightLon = 0.;
+    int minZoom = 3;
+    int maxZoom = 3;
+    int type = -1;
+    quint32 numTiles = 0;
+    bool defaultSet = false;
+    quint64 date = 0;
+};
+
+struct TotalsResult {
+    quint32 totalCount = 0;
+    quint64 totalSize = 0;
+    quint32 defaultCount = 0;
+    quint64 defaultSize = 0;
+};
+
+struct SetTotalsResult {
+    quint32 savedTileCount = 0;
+    quint64 savedTileSize = 0;
+    quint64 totalTileSize = 0;
+    quint32 uniqueTileCount = 0;
+    quint64 uniqueTileSize = 0;
+};
+
+struct DatabaseResult {
+    bool success = false;
+    QString errorString;
+};
+
+using ProgressCallback = std::function<void(int)>;

--- a/src/QtLocationPlugin/QGCTileCacheWorker.cpp
+++ b/src/QtLocationPlugin/QGCTileCacheWorker.cpp
@@ -1,12 +1,8 @@
 #include "QGCTileCacheWorker.h"
+#include "QGCTileCacheDatabase.h"
 
-#include <QtCore/QDateTime>
 #include <QtCore/QCoreApplication>
-#include <QtCore/QFile>
 #include <QtCore/QSettings>
-#include <QtSql/QSqlDatabase>
-#include <QtSql/QSqlQuery>
-#include <QtSql/QSqlError>
 
 #include "QGCCachedTileSet.h"
 #include "QGCLoggingCategory.h"
@@ -21,15 +17,22 @@ QGCCacheWorker::QGCCacheWorker(QObject *parent)
     qCDebug(QGCTileCacheWorkerLog) << this;
 }
 
+// L3: Defensive destructor ensures thread is stopped even if caller forgets
 QGCCacheWorker::~QGCCacheWorker()
 {
+    stop();
+    wait();
     qCDebug(QGCTileCacheWorkerLog) << this;
 }
 
+// C1: Added _taskQueue.clear() — qDeleteAll does not clear the container,
+// leaving dangling pointers that the worker thread would dequeue.
 void QGCCacheWorker::stop()
 {
+    _stopRequested = true;
     QMutexLocker lock(&_taskQueueMutex);
     qDeleteAll(_taskQueue);
+    _taskQueue.clear();
     lock.unlock();
 
     if (isRunning()) {
@@ -39,13 +42,12 @@ void QGCCacheWorker::stop()
 
 bool QGCCacheWorker::enqueueTask(QGCMapTask *task)
 {
-    if (!_valid && (task->type() != QGCMapTask::TaskType::taskInit)) {
+    if (!_dbValid && !isRunning() && (task->type() != QGCMapTask::TaskType::taskInit)) {
         task->setError(tr("Database Not Initialized"));
         task->deleteLater();
         return false;
     }
 
-    // TODO: Prepend Stop Task Instead?
     QMutexLocker lock(&_taskQueueMutex);
     _taskQueue.enqueue(task);
     lock.unlock();
@@ -61,21 +63,35 @@ bool QGCCacheWorker::enqueueTask(QGCMapTask *task)
 
 void QGCCacheWorker::run()
 {
-    if (!_valid && !_failed) {
-        if (!_init()) {
-            qCWarning(QGCTileCacheWorkerLog) << "Failed To Init Database";
-            return;
+    _stopRequested = false;
+    _database = std::make_unique<QGCTileCacheDatabase>(_databasePath);
+
+    if (!_database->init()) {
+        qCWarning(QGCTileCacheWorkerLog) << "Failed To Init Database";
+        _database.reset();
+
+        QMutexLocker lock(&_taskQueueMutex);
+        for (QGCMapTask *orphan : _taskQueue) {
+            orphan->setError(tr("Database Init Failed"));
+            orphan->deleteLater();
+        }
+        _taskQueue.clear();
+        return;
+    }
+
+    if (_database->isValid()) {
+        if (_database->connectDB()) {
+            _database->deleteBingNoTileTiles();
         }
     }
 
-    if (_valid) {
-        if (_connectDB()) {
-            _deleteBingNoTileTiles();
-        }
-    }
+    _dbValid = _database->isValid();
+
+    // M1: Start timer before the loop — hasExpired() on an unstarted timer is UB
+    _updateTimer.start();
 
     QMutexLocker lock(&_taskQueueMutex);
-    while (true) {
+    while (!_stopRequested) {
         if (!_taskQueue.isEmpty()) {
             QGCMapTask* const task = _taskQueue.dequeue();
             lock.unlock();
@@ -85,34 +101,44 @@ void QGCCacheWorker::run()
 
             const qsizetype count = _taskQueue.count();
             if (count > 100) {
-                _updateTimeout = kLongTimeout;
+                _updateTimeout = kLongTimeoutMs;
             } else if (count < 25) {
-                _updateTimeout = kShortTimeout;
+                _updateTimeout = kShortTimeoutMs;
             }
 
             if ((count == 0) || _updateTimer.hasExpired(_updateTimeout)) {
-                if (_valid) {
+                if (_database && _database->isValid()) {
                     lock.unlock();
-                    _updateTotals();
+                    _emitTotals();
                     lock.relock();
                 }
             }
         } else {
             (void) _waitc.wait(lock.mutex(), 5000);
-            if (_taskQueue.isEmpty()) {
-                break;
-            }
         }
     }
+
+    // H1: Drain any tasks enqueued between the break decision and shutdown.
+    // Tasks are main-thread QObjects so deleteLater() posts to the main event loop.
+    for (QGCMapTask *orphan : _taskQueue) {
+        orphan->setError(tr("Worker shutting down"));
+        orphan->deleteLater();
+    }
+    _taskQueue.clear();
     lock.unlock();
 
-    _disconnectDB();
+    _dbValid = false;
+    if (_database) {
+        _database->disconnectDB();
+        _database.reset();
+    }
 }
 
 void QGCCacheWorker::_runTask(QGCMapTask *task)
 {
     switch (task->type()) {
     case QGCMapTask::TaskType::taskInit:
+        // L2: No-op — used only to bootstrap the worker thread
         break;
     case QGCMapTask::TaskType::taskCacheTile:
         _saveTile(task);
@@ -156,135 +182,54 @@ void QGCCacheWorker::_runTask(QGCMapTask *task)
     }
 }
 
-void QGCCacheWorker::_deleteBingNoTileTiles()
+bool QGCCacheWorker::_testTask(QGCMapTask *mtask)
 {
-    static const QString alreadyDoneKey = QStringLiteral("_deleteBingNoTileTilesDone");
-
-    QSettings settings;
-    if (settings.value(alreadyDoneKey, false).toBool()) {
-        return;
-    }
-    settings.setValue(alreadyDoneKey, true);
-
-    // Previously we would store these empty tile graphics in the cache. This prevented the ability to zoom beyong the level
-    // of available tiles. So we need to remove only of these still hanging around to make higher zoom levels work.
-    QFile file(QStringLiteral(":/res/BingNoTileBytes.dat"));
-    if (!file.open(QFile::ReadOnly)) {
-        qCWarning(QGCTileCacheWorkerLog) << "Failed to Open File" << file.fileName() << ":" << file.errorString();
-        return;
+    if (!_database || !_database->isValid()) {
+        mtask->setError("No Cache Database");
+        return false;
     }
 
-    const QByteArray noTileBytes = file.readAll();
-    file.close();
-
-    QSqlQuery query(*_db);
-    QList<quint64> idsToDelete;
-    // Select tiles in default set only, sorted by oldest.
-    QString s = QStringLiteral("SELECT tileID, tile, hash FROM Tiles WHERE LENGTH(tile) = %1").arg(noTileBytes.length());
-    if (!query.exec(s)) {
-        qCWarning(QGCTileCacheWorkerLog) << "query failed";
-        return;
-    }
-
-    while (query.next()) {
-        if (query.value(1).toByteArray() == noTileBytes) {
-            idsToDelete.append(query.value(0).toULongLong());
-            qCDebug(QGCTileCacheWorkerLog) << "HASH:" << query.value(2).toString();
-        }
-    }
-
-    for (const quint64 tileId: idsToDelete) {
-        s = QStringLiteral("DELETE FROM Tiles WHERE tileID = %1").arg(tileId);
-        if (!query.exec(s)) {
-            qCWarning(QGCTileCacheWorkerLog) << "Delete failed";
-        }
-    }
+    return true;
 }
 
-bool QGCCacheWorker::_findTileSetID(const QString &name, quint64 &setID)
+void QGCCacheWorker::_emitTotals()
 {
-    QSqlQuery query(*_db);
-    const QString s = QStringLiteral("SELECT setID FROM TileSets WHERE name = \"%1\"").arg(name);
-    if (query.exec(s) && query.next()) {
-        setID = query.value(0).toULongLong();
-        return true;
-    }
-
-    return false;
+    TotalsResult t = _database->computeTotals();
+    emit updateTotals(t.totalCount, t.totalSize, t.defaultCount, t.defaultSize);
+    _updateTimer.restart();
 }
 
-quint64 QGCCacheWorker::_getDefaultTileSet()
-{
-    if (_defaultSet != UINT64_MAX) {
-        return _defaultSet;
-    }
-
-    QSqlQuery query(*_db);
-    const QString s = QStringLiteral("SELECT setID FROM TileSets WHERE defaultSet = 1");
-    if (query.exec(s) && query.next()) {
-        _defaultSet = query.value(0).toULongLong();
-        return _defaultSet;
-    }
-
-    return 1L;
-}
-
+// M2: Check saveTile return value
 void QGCCacheWorker::_saveTile(QGCMapTask *mtask)
 {
-    if (!_valid) {
-        qCWarning(QGCTileCacheWorkerLog) << "Map Cache SQL error (saveTile() open db):" << _db->lastError();
+    if (!_testTask(mtask)) {
         return;
     }
 
     QGCSaveTileTask *task = static_cast<QGCSaveTileTask*>(mtask);
-    QSqlQuery query(*_db);
-    (void) query.prepare("INSERT INTO Tiles(hash, format, tile, size, type, date) VALUES(?, ?, ?, ?, ?, ?)");
-    query.addBindValue(task->tile()->hash);
-    query.addBindValue(task->tile()->format);
-    query.addBindValue(task->tile()->img);
-    query.addBindValue(task->tile()->img.size());
-    query.addBindValue(task->tile()->type);
-    query.addBindValue(QDateTime::currentSecsSinceEpoch());
-    if (!query.exec()) {
-        // Tile was already there.
-        // QtLocation some times requests the same tile twice in a row. The first is saved, the second is already there.
-        return;
+    if (!_database->saveTile(task->tile()->hash, task->tile()->format,
+                             task->tile()->img, task->tile()->type, task->tile()->tileSet)) {
+        mtask->setError("Error saving tile to cache");
     }
-
-    const quint64 tileID = query.lastInsertId().toULongLong();
-    const quint64 setID = (task->tile()->tileSet == UINT64_MAX) ? _getDefaultTileSet() : task->tile()->tileSet;
-    const QString s = QStringLiteral("INSERT INTO SetTiles(tileID, setID) VALUES(%1, %2)").arg(tileID).arg(setID);
-    (void) query.prepare(s);
-    if (!query.exec()) {
-        qCWarning(QGCTileCacheWorkerLog) << "Map Cache SQL error (add tile into SetTiles):" << query.lastError().text();
-    }
-
-    qCDebug(QGCTileCacheWorkerLog) << "HASH:" << task->tile()->hash;
 }
 
-void QGCCacheWorker::_getTile(QGCMapTask* mtask)
+void QGCCacheWorker::_getTile(QGCMapTask *mtask)
 {
     if (!_testTask(mtask)) {
         return;
     }
 
     QGCFetchTileTask *task = static_cast<QGCFetchTileTask*>(mtask);
-    QSqlQuery query(*_db);
-    const QString s = QStringLiteral("SELECT tile, format, type FROM Tiles WHERE hash = \"%1\"").arg(task->hash());
-    if (query.exec(s) && query.next()) {
-        const QByteArray &arrray = query.value(0).toByteArray();
-        const QString &format = query.value(1).toString();
-        const QString &type = query.value(2).toString();
-        qCDebug(QGCTileCacheWorkerLog) << "(Found in DB) HASH:" << task->hash();
-        QGCCacheTile *tile = new QGCCacheTile(task->hash(), arrray, format, type);
-        task->setTileFetched(tile);
-        return;
+    auto tile = _database->getTile(task->hash());
+    if (tile) {
+        task->setTileFetched(tile.release());
+    } else {
+        task->setError("Tile not in cache database");
     }
-
-    qCDebug(QGCTileCacheWorkerLog) << "(NOT in DB) HASH:" << task->hash();
-    task->setError("Tile not in cache database");
 }
 
+// M4: Empty result is not an error (fresh DB or all sets deleted)
+// M5: Block signals on worker-thread-created QObjects until moveToThread
 void QGCCacheWorker::_getTileSets(QGCMapTask *mtask)
 {
     if (!_testTask(mtask)) {
@@ -292,203 +237,73 @@ void QGCCacheWorker::_getTileSets(QGCMapTask *mtask)
     }
 
     QGCFetchTileSetTask *task = static_cast<QGCFetchTileSetTask*>(mtask);
-    QSqlQuery query(*_db);
-    const QString s = QStringLiteral("SELECT * FROM TileSets ORDER BY defaultSet DESC, name ASC");
-    qCDebug(QGCTileCacheWorkerLog) << s;
-    if (!query.exec(s)) {
-        task->setError("No tile set in database");
-        return;
-    }
+    const QList<TileSetRecord> records = _database->getTileSets();
 
-    while (query.next()) {
-        const QString name = query.value("name").toString();
-        QGCCachedTileSet *set = new QGCCachedTileSet(name);
-        set->setId(query.value("setID").toULongLong());
-        set->setMapTypeStr(query.value("typeStr").toString());
-        set->setTopleftLat(query.value("topleftLat").toDouble());
-        set->setTopleftLon(query.value("topleftLon").toDouble());
-        set->setBottomRightLat(query.value("bottomRightLat").toDouble());
-        set->setBottomRightLon(query.value("bottomRightLon").toDouble());
-        set->setMinZoom(query.value("minZoom").toInt());
-        set->setMaxZoom(query.value("maxZoom").toInt());
-        set->setType(UrlFactory::getProviderTypeFromQtMapId(query.value("type").toInt()));
-        set->setTotalTileCount(query.value("numTiles").toUInt());
-        set->setDefaultSet(query.value("defaultSet").toInt() != 0);
-        set->setCreationDate(QDateTime::fromSecsSinceEpoch(query.value("date").toUInt()));
-        _updateSetTotals(set);
-        // Object created here must be moved to app thread to be used there
+    for (const auto &rec : records) {
+        QGCCachedTileSet *set = new QGCCachedTileSet(rec.name);
+        set->blockSignals(true);
+
+        set->setId(rec.setID);
+        set->setMapTypeStr(rec.mapTypeStr);
+        set->setTopleftLat(rec.topleftLat);
+        set->setTopleftLon(rec.topleftLon);
+        set->setBottomRightLat(rec.bottomRightLat);
+        set->setBottomRightLon(rec.bottomRightLon);
+        set->setMinZoom(rec.minZoom);
+        set->setMaxZoom(rec.maxZoom);
+        set->setType(UrlFactory::getProviderTypeFromQtMapId(rec.type));
+        set->setTotalTileCount(rec.numTiles);
+        set->setDefaultSet(rec.defaultSet);
+        set->setCreationDate(QDateTime::fromSecsSinceEpoch(rec.date));
+
+        const SetTotalsResult totals = _database->computeSetTotals(rec.setID, rec.defaultSet, rec.numTiles, set->type());
+        set->setSavedTileCount(totals.savedTileCount);
+        set->setSavedTileSize(totals.savedTileSize);
+        set->setTotalTileSize(totals.totalTileSize);
+        set->setUniqueTileCount(totals.uniqueTileCount);
+        set->setUniqueTileSize(totals.uniqueTileSize);
+
+        set->blockSignals(false);
         (void) set->moveToThread(QCoreApplication::instance()->thread());
         task->setTileSetFetched(set);
     }
 }
 
-void QGCCacheWorker::_updateSetTotals(QGCCachedTileSet *set)
-{
-    if (set->defaultSet()) {
-        _updateTotals();
-        set->setSavedTileCount(_totalCount);
-        set->setSavedTileSize(_totalSize);
-        set->setTotalTileCount(_defaultCount);
-        set->setTotalTileSize(_defaultSize);
-        return;
-    }
-
-    QSqlQuery subquery(*_db);
-    QString sq = QStringLiteral("SELECT COUNT(size), SUM(size) FROM Tiles A INNER JOIN SetTiles B on A.tileID = B.tileID WHERE B.setID = %1").arg(set->id());
-    qCDebug(QGCTileCacheWorkerLog) << sq;
-    if (!subquery.exec(sq) || !subquery.next()) {
-        return;
-    }
-
-    set->setSavedTileCount(subquery.value(0).toUInt());
-    set->setSavedTileSize(subquery.value(1).toULongLong());
-    qCDebug(QGCTileCacheWorkerLog) << "Set" << set->id() << "Totals:" << set->savedTileCount() << " " << set->savedTileSize() << "Expected: " << set->totalTileCount() << " " << set->totalTilesSize();
-    // Update (estimated) size
-    quint64 avg = UrlFactory::averageSizeForType(set->type());
-    if (set->totalTileCount() <= set->savedTileCount()) {
-        // We're done so the saved size is the total size
-        set->setTotalTileSize(set->savedTileSize());
-    } else {
-        // Otherwise we need to estimate it.
-        if ((set->savedTileCount() > 10) && set->savedTileSize()) {
-            avg = set->savedTileSize() / set->savedTileCount();
-        }
-        set->setTotalTileSize(avg * set->totalTileCount());
-    }
-
-    // Now figure out the count for tiles unique to this set
-    quint32 ucount = 0;
-    quint64 usize = 0;
-    sq = QStringLiteral("SELECT COUNT(size), SUM(size) FROM Tiles WHERE tileID IN (SELECT A.tileID FROM SetTiles A join SetTiles B on A.tileID = B.tileID WHERE B.setID = %1 GROUP by A.tileID HAVING COUNT(A.tileID) = 1)").arg(set->id());
-    if (subquery.exec(sq) && subquery.next()) {
-        // This is only accurate when all tiles are downloaded
-        ucount = subquery.value(0).toUInt();
-        usize = subquery.value(1).toULongLong();
-    }
-
-    // If we haven't downloaded it all, estimate size of unique tiles
-    quint32 expectedUcount = set->totalTileCount() - set->savedTileCount();
-    if (ucount == 0) {
-        usize = expectedUcount * avg;
-    } else {
-        expectedUcount = ucount;
-    }
-    set->setUniqueTileCount(expectedUcount);
-    set->setUniqueTileSize(usize);
-}
-
-void QGCCacheWorker::_updateTotals()
-{
-    QSqlQuery query(*_db);
-    QString s = QStringLiteral("SELECT COUNT(size), SUM(size) FROM Tiles");
-    qCDebug(QGCTileCacheWorkerLog) << s;
-    if (query.exec(s) && query.next()) {
-        _totalCount = query.value(0).toUInt();
-        _totalSize  = query.value(1).toULongLong();
-    }
-
-    s = QStringLiteral("SELECT COUNT(size), SUM(size) FROM Tiles WHERE tileID IN (SELECT A.tileID FROM SetTiles A join SetTiles B on A.tileID = B.tileID WHERE B.setID = %1 GROUP by A.tileID HAVING COUNT(A.tileID) = 1)").arg(_getDefaultTileSet());
-    qCDebug(QGCTileCacheWorkerLog) << s;
-    if (query.exec(s) && query.next()) {
-        _defaultCount = query.value(0).toUInt();
-        _defaultSize = query.value(1).toULongLong();
-    }
-
-    emit updateTotals(_totalCount, _totalSize, _defaultCount, _defaultSize);
-    if (!_updateTimer.isValid()) {
-        _updateTimer.start();
-    } else {
-        (void) _updateTimer.restart();
-    }
-}
-
-quint64 QGCCacheWorker::_findTile(const QString &hash)
-{
-    quint64 tileID = 0;
-
-    QSqlQuery query(*_db);
-    const QString s = QStringLiteral("SELECT tileID FROM Tiles WHERE hash = \"%1\"").arg(hash);
-    if (query.exec(s) && query.next()) {
-        tileID = query.value(0).toULongLong();
-    }
-
-    return tileID;
-}
-
+// H2: Block signals while modifying the tile set from the worker thread.
+// The object is exclusively owned by this task (no concurrent access), but
+// emitting signals from the wrong thread is technically incorrect.
 void QGCCacheWorker::_createTileSet(QGCMapTask *mtask)
 {
-    if (!_valid) {
-        mtask->setError("Error saving tile set");
+    if (!_testTask(mtask)) {
         return;
     }
 
-    // Create Tile Set
     QGCCreateTileSetTask *task = static_cast<QGCCreateTileSetTask*>(mtask);
-    QSqlQuery query(*_db);
-    (void) query.prepare("INSERT INTO TileSets("
-        "name, typeStr, topleftLat, topleftLon, bottomRightLat, bottomRightLon, minZoom, maxZoom, type, numTiles, date"
-        ") VALUES(?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)");
-    query.addBindValue(task->tileSet()->name());
-    query.addBindValue(task->tileSet()->mapTypeStr());
-    query.addBindValue(task->tileSet()->topleftLat());
-    query.addBindValue(task->tileSet()->topleftLon());
-    query.addBindValue(task->tileSet()->bottomRightLat());
-    query.addBindValue(task->tileSet()->bottomRightLon());
-    query.addBindValue(task->tileSet()->minZoom());
-    query.addBindValue(task->tileSet()->maxZoom());
-    query.addBindValue(UrlFactory::getQtMapIdFromProviderType(task->tileSet()->type()));
-    query.addBindValue(task->tileSet()->totalTileCount());
-    query.addBindValue(QDateTime::currentSecsSinceEpoch());
-    if (!query.exec()) {
-        qCWarning(QGCTileCacheWorkerLog) << "Map Cache SQL error (add tileSet into TileSets):" << query.lastError().text();
+    const auto setID = _database->createTileSet(
+        task->tileSet()->name(), task->tileSet()->mapTypeStr(),
+        task->tileSet()->topleftLat(), task->tileSet()->topleftLon(),
+        task->tileSet()->bottomRightLat(), task->tileSet()->bottomRightLon(),
+        task->tileSet()->minZoom(), task->tileSet()->maxZoom(),
+        task->tileSet()->type(), task->tileSet()->totalTileCount());
+
+    if (!setID.has_value()) {
         mtask->setError("Error saving tile set");
         return;
     }
 
-    // Get just created (auto-incremented) setID
-    const quint64 setID = query.lastInsertId().toULongLong();
-    task->tileSet()->setId(setID);
-    // Prepare Download List
-    (void) _db->transaction();
-    for (int z = task->tileSet()->minZoom(); z <= task->tileSet()->maxZoom(); z++) {
-        const QGCTileSet set = UrlFactory::getTileCount(z,
-            task->tileSet()->topleftLon(), task->tileSet()->topleftLat(),
-            task->tileSet()->bottomRightLon(), task->tileSet()->bottomRightLat(), task->tileSet()->type());
-        const QString type = task->tileSet()->type();
-        for (int x = set.tileX0; x <= set.tileX1; x++) {
-            for (int y = set.tileY0; y <= set.tileY1; y++) {
-                // See if tile is already downloaded
-                const QString hash = UrlFactory::getTileHash(type, x, y, z);
-                const quint64 tileID = _findTile(hash);
-                if (tileID == 0) {
-                    // Set to download
-                    (void) query.prepare("INSERT OR IGNORE INTO TilesDownload(setID, hash, type, x, y, z, state) VALUES(?, ?, ?, ?, ? ,? ,?)");
-                    query.addBindValue(setID);
-                    query.addBindValue(hash);
-                    query.addBindValue(UrlFactory::getQtMapIdFromProviderType(type));
-                    query.addBindValue(x);
-                    query.addBindValue(y);
-                    query.addBindValue(z);
-                    query.addBindValue(0);
-                    if (!query.exec()) {
-                        qCWarning(QGCTileCacheWorkerLog) << "Map Cache SQL error (add tile into TilesDownload):" << query.lastError().text();
-                        mtask->setError("Error creating tile set download list");
-                        return;
-                    }
-                } else {
-                    // Tile already in the database. No need to dowload.
-                    const QString s = QStringLiteral("INSERT OR IGNORE INTO SetTiles(tileID, setID) VALUES(%1, %2)").arg(tileID).arg(setID);
-                    (void) query.prepare(s);
-                    if (!query.exec()) {
-                        qCWarning(QGCTileCacheWorkerLog) << "Map Cache SQL error (add tile into SetTiles):" << query.lastError().text();
-                    }
-                    qCDebug(QGCTileCacheWorkerLog) << "Already Cached HASH:" << hash;
-                }
-            }
-        }
-    }
-    (void) _db->commit();
-    _updateSetTotals(task->tileSet());
+    task->tileSet()->blockSignals(true);
+    task->tileSet()->setId(setID.value());
+
+    const SetTotalsResult totals = _database->computeSetTotals(
+        setID.value(), task->tileSet()->defaultSet(),
+        task->tileSet()->totalTileCount(), task->tileSet()->type());
+    task->tileSet()->setSavedTileCount(totals.savedTileCount);
+    task->tileSet()->setSavedTileSize(totals.savedTileSize);
+    task->tileSet()->setTotalTileSize(totals.totalTileSize);
+    task->tileSet()->setUniqueTileCount(totals.uniqueTileCount);
+    task->tileSet()->setUniqueTileSize(totals.uniqueTileSize);
+    task->tileSet()->blockSignals(false);
+
     task->setTileSetSaved();
 }
 
@@ -498,28 +313,11 @@ void QGCCacheWorker::_getTileDownloadList(QGCMapTask *mtask)
         return;
     }
 
-    QQueue<QGCTile*> tiles;
     QGCGetTileDownloadListTask *task = static_cast<QGCGetTileDownloadListTask*>(mtask);
-    QSqlQuery query(*_db);
-    QString s = QStringLiteral("SELECT hash, type, x, y, z FROM TilesDownload WHERE setID = %1 AND state = 0 LIMIT %2").arg(task->setID()).arg(task->count());
-    if (query.exec(s)) {
-        while (query.next()) {
-            QGCTile *tile = new QGCTile;
-            // tile->setTileSet(task->setID());
-            tile->hash = query.value("hash").toString();
-            tile->type = UrlFactory::getProviderTypeFromQtMapId(query.value("type").toInt());
-            tile->x = query.value("x").toInt();
-            tile->y = query.value("y").toInt();
-            tile->z = query.value("z").toInt();
-            tiles.enqueue(tile);
-        }
-
-        for (int i = 0; i < tiles.size(); i++) {
-            s = QStringLiteral("UPDATE TilesDownload SET state = %1 WHERE setID = %2 and hash = \"%3\"").arg(static_cast<int>(QGCTile::StateDownloading)).arg(task->setID()).arg(tiles[i]->hash);
-            if (!query.exec(s)) {
-                qCWarning(QGCTileCacheWorkerLog) << "Map Cache SQL error (set TilesDownload state):" << query.lastError().text();
-            }
-        }
+    const QList<QGCTile> tileValues = _database->getTileDownloadList(task->setID(), task->count());
+    QQueue<QGCTile*> tiles;
+    for (const auto &t : tileValues) {
+        tiles.enqueue(new QGCTile(t));
     }
     task->setTileListFetched(tiles);
 }
@@ -531,21 +329,18 @@ void QGCCacheWorker::_updateTileDownloadState(QGCMapTask *mtask)
     }
 
     QGCUpdateTileDownloadStateTask *task = static_cast<QGCUpdateTileDownloadStateTask*>(mtask);
-    QSqlQuery query(*_db);
-    QString s;
-    if (task->state() == QGCTile::StateComplete) {
-        s = QStringLiteral("DELETE FROM TilesDownload WHERE setID = %1 AND hash = \"%2\"").arg(task->setID()).arg(task->hash());
-    } else if (task->hash() == "*") {
-        s = QStringLiteral("UPDATE TilesDownload SET state = %1 WHERE setID = %2").arg(static_cast<int>(task->state())).arg(task->setID());
+    bool ok;
+    if (task->hash() == QStringLiteral("*")) {
+        ok = _database->updateAllTileDownloadStates(task->setID(), static_cast<int>(task->state()));
     } else {
-        s = QStringLiteral("UPDATE TilesDownload SET state = %1 WHERE setID = %2 AND hash = \"%3\"").arg(static_cast<int>(task->state())).arg(task->setID()).arg(task->hash());
+        ok = _database->updateTileDownloadState(task->setID(), static_cast<int>(task->state()), task->hash());
     }
-
-    if (!query.exec(s)) {
-        qCWarning(QGCTileCacheWorkerLog) << "Error:" << query.lastError().text();
+    if (!ok) {
+        mtask->setError("Error updating tile download state");
     }
 }
 
+// M2: Check return value, don't signal success on failure
 void QGCCacheWorker::_pruneCache(QGCMapTask *mtask)
 {
     if (!_testTask(mtask)) {
@@ -553,32 +348,14 @@ void QGCCacheWorker::_pruneCache(QGCMapTask *mtask)
     }
 
     QGCPruneCacheTask *task = static_cast<QGCPruneCacheTask*>(mtask);
-    QSqlQuery query(*_db);
-    // Select tiles in default set only, sorted by oldest.
-    QString s = QStringLiteral("SELECT tileID, size, hash FROM Tiles WHERE tileID IN (SELECT A.tileID FROM SetTiles A join SetTiles B on A.tileID = B.tileID WHERE B.setID = %1 GROUP by A.tileID HAVING COUNT(A.tileID) = 1) ORDER BY DATE ASC LIMIT 128").arg(_getDefaultTileSet());
-    if (!query.exec(s)) {
+    if (!_database->pruneCache(task->amount())) {
+        mtask->setError("Error pruning cache");
         return;
     }
-
-    QList<quint64> tlist;
-    qint64 amount = static_cast<qint64>(task->amount());
-    while (query.next() && (amount >= 0)) {
-        tlist << query.value(0).toULongLong();
-        amount -= query.value(1).toULongLong();
-        qCDebug(QGCTileCacheWorkerLog) << "HASH:" << query.value(2).toString();
-    }
-
-    while (!tlist.isEmpty()) {
-        s = QStringLiteral("DELETE FROM Tiles WHERE tileID = %1").arg(tlist[0]);
-        tlist.removeFirst();
-        if (!query.exec(s)) {
-            break;
-        }
-    }
-
     task->setPruned();
 }
 
+// M2: Check return value, don't signal success on failure
 void QGCCacheWorker::_deleteTileSet(QGCMapTask *mtask)
 {
     if (!_testTask(mtask)) {
@@ -586,23 +363,12 @@ void QGCCacheWorker::_deleteTileSet(QGCMapTask *mtask)
     }
 
     QGCDeleteTileSetTask *task = static_cast<QGCDeleteTileSetTask*>(mtask);
-    _deleteTileSet(task->setID());
+    if (!_database->deleteTileSet(task->setID())) {
+        mtask->setError("Error deleting tile set");
+        return;
+    }
+    _emitTotals();
     task->setTileSetDeleted();
-}
-
-void QGCCacheWorker::_deleteTileSet(qulonglong id)
-{
-    QSqlQuery query(*_db);
-    // Only delete tiles unique to this set
-    QString  s = QStringLiteral("DELETE FROM Tiles WHERE tileID IN (SELECT A.tileID FROM SetTiles A JOIN SetTiles B ON A.tileID = B.tileID WHERE B.setID = %1 GROUP BY A.tileID HAVING COUNT(A.tileID) = 1)").arg(id);
-    (void) query.exec(s);
-    s = QStringLiteral("DELETE FROM TilesDownload WHERE setID = %1").arg(id);
-    (void) query.exec(s);
-    s = QStringLiteral("DELETE FROM TileSets WHERE setID = %1").arg(id);
-    (void) query.exec(s);
-    s = QStringLiteral("DELETE FROM SetTiles WHERE setID = %1").arg(id);
-    (void) query.exec(s);
-    _updateTotals();
 }
 
 void QGCCacheWorker::_renameTileSet(QGCMapTask *mtask)
@@ -612,13 +378,12 @@ void QGCCacheWorker::_renameTileSet(QGCMapTask *mtask)
     }
 
     QGCRenameTileSetTask *task = static_cast<QGCRenameTileSetTask*>(mtask);
-    QSqlQuery query(*_db);
-    const QString s = QStringLiteral("UPDATE TileSets SET name = \"%1\" WHERE setID = %2").arg(task->newName()).arg(task->setID());
-    if (!query.exec(s)) {
+    if (!_database->renameTileSet(task->setID(), task->newName())) {
         task->setError("Error renaming tile set");
     }
 }
 
+// M2: Check return value, don't signal success on failure
 void QGCCacheWorker::_resetCacheDatabase(QGCMapTask *mtask)
 {
     if (!_testTask(mtask)) {
@@ -626,19 +391,15 @@ void QGCCacheWorker::_resetCacheDatabase(QGCMapTask *mtask)
     }
 
     QGCResetTask *task = static_cast<QGCResetTask*>(mtask);
-    QSqlQuery query(*_db);
-    QString s = QStringLiteral("DROP TABLE Tiles");
-    (void) query.exec(s);
-    s = QStringLiteral("DROP TABLE TileSets");
-    (void) query.exec(s);
-    s = QStringLiteral("DROP TABLE SetTiles");
-    (void) query.exec(s);
-    s = QStringLiteral("DROP TABLE TilesDownload");
-    (void) query.exec(s);
-    _valid = _createDB(*_db);
+    if (!_database->resetDatabase()) {
+        mtask->setError("Error resetting cache database");
+        return;
+    }
+    _dbValid = _database->isValid();
     task->setResetCompleted();
 }
 
+// H4: Don't emit completion on failure
 void QGCCacheWorker::_importSets(QGCMapTask *mtask)
 {
     if (!_testTask(mtask)) {
@@ -646,176 +407,34 @@ void QGCCacheWorker::_importSets(QGCMapTask *mtask)
     }
 
     QGCImportTileTask *task = static_cast<QGCImportTileTask*>(mtask);
-    // If replacing, simply copy over it
+    auto progress = [task](int pct) { task->setProgress(pct); };
+
+    DatabaseResult result;
     if (task->replace()) {
-        // Close and delete old database
-        _disconnectDB();
-        (void) QFile::remove(_databasePath);
-        // Copy given database
-        (void) QFile::copy(task->path(), _databasePath);
-        task->setProgress(25);
-        _init();
-        if (_valid) {
-            task->setProgress(50);
-            _connectDB();
-        }
-        task->setProgress(100);
+        result = _database->importSetsReplace(task->path(), progress);
     } else {
-        // Open imported set
-        QSqlDatabase *dbImport = new QSqlDatabase(QSqlDatabase::addDatabase("QSQLITE", kExportSession));
-        dbImport->setDatabaseName(task->path());
-        dbImport->setConnectOptions("QSQLITE_ENABLE_SHARED_CACHE");
-        if (dbImport->open()) {
-            QSqlQuery query(*dbImport);
-            // Prepare progress report
-            quint64 tileCount = 0;
-            int lastProgress = -1;
-            QString s = QStringLiteral("SELECT COUNT(tileID) FROM Tiles");
-            if (query.exec(s) && query.next()) {
-                // Total number of tiles in imported database
-                tileCount  = query.value(0).toULongLong();
-            }
-
-            if (tileCount > 0) {
-                // Iterate Tile Sets
-                s = QStringLiteral("SELECT * FROM TileSets ORDER BY defaultSet DESC, name ASC");
-                if (query.exec(s)) {
-                    quint64 currentCount = 0;
-                    while (query.next()) {
-                        QString name = query.value("name").toString();
-                        const quint64 setID = query.value("setID").toULongLong();
-                        const QString mapType = query.value("typeStr").toString();
-                        const double topleftLat = query.value("topleftLat").toDouble();
-                        const double topleftLon = query.value("topleftLon").toDouble();
-                        const double bottomRightLat = query.value("bottomRightLat").toDouble();
-                        const double bottomRightLon = query.value("bottomRightLon").toDouble();
-                        const int minZoom = query.value("minZoom").toInt();
-                        const int maxZoom = query.value("maxZoom").toInt();
-                        const int type = query.value("type").toInt();
-                        const quint32 numTiles = query.value("numTiles").toUInt();
-                        const int defaultSet = query.value("defaultSet").toInt();
-                        quint64 insertSetID = _getDefaultTileSet();
-                        // If not default set, create new one
-                        if (defaultSet == 0) {
-                            // Check if we have this tile set already
-                            if (_findTileSetID(name, insertSetID)) {
-                                int testCount = 0;
-                                // Set with this name already exists. Make name unique.
-                                while (true) {
-                                    const QString testName = QString::asprintf("%s %02d", name.toLatin1().constData(), ++testCount);
-                                    if (!_findTileSetID(testName, insertSetID) || (testCount > 99)) {
-                                        name = testName;
-                                        break;
-                                    }
-                                }
-                            }
-                            // Create new set
-                            QSqlQuery cQuery(*_db);
-                            (void) cQuery.prepare("INSERT INTO TileSets("
-                                "name, typeStr, topleftLat, topleftLon, bottomRightLat, bottomRightLon, minZoom, maxZoom, type, numTiles, defaultSet, date"
-                                ") VALUES(?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)");
-                            cQuery.addBindValue(name);
-                            cQuery.addBindValue(mapType);
-                            cQuery.addBindValue(topleftLat);
-                            cQuery.addBindValue(topleftLon);
-                            cQuery.addBindValue(bottomRightLat);
-                            cQuery.addBindValue(bottomRightLon);
-                            cQuery.addBindValue(minZoom);
-                            cQuery.addBindValue(maxZoom);
-                            cQuery.addBindValue(type);
-                            cQuery.addBindValue(numTiles);
-                            cQuery.addBindValue(defaultSet);
-                            cQuery.addBindValue(QDateTime::currentSecsSinceEpoch());
-                            if (!cQuery.exec()) {
-                                task->setError("Error adding imported tile set to database");
-                                break;
-                            } else {
-                                // Get just created (auto-incremented) setID
-                                insertSetID = cQuery.lastInsertId().toULongLong();
-                            }
-                        }
-
-                        // Find set tiles
-                        QSqlQuery cQuery(*_db);
-                        QSqlQuery subQuery(*dbImport);
-                        const QString sb = QStringLiteral("SELECT * FROM Tiles WHERE tileID IN (SELECT A.tileID FROM SetTiles A JOIN SetTiles B ON A.tileID = B.tileID WHERE B.setID = %1 GROUP BY A.tileID HAVING COUNT(A.tileID) = 1)").arg(setID);
-                        if (subQuery.exec(sb)) {
-                            quint64 tilesFound = 0;
-                            quint64 tilesSaved = 0;
-                            (void) _db->transaction();
-                            while (subQuery.next()) {
-                                tilesFound++;
-                                const QString hash = subQuery.value("hash").toString();
-                                const QString format = subQuery.value("format").toString();
-                                const QByteArray img = subQuery.value("tile").toByteArray();
-                                const int type = subQuery.value("type").toInt();
-                                // Save tile
-                                (void) cQuery.prepare("INSERT INTO Tiles(hash, format, tile, size, type, date) VALUES(?, ?, ?, ?, ?, ?)");
-                                cQuery.addBindValue(hash);
-                                cQuery.addBindValue(format);
-                                cQuery.addBindValue(img);
-                                cQuery.addBindValue(img.size());
-                                cQuery.addBindValue(type);
-                                cQuery.addBindValue(QDateTime::currentSecsSinceEpoch());
-                                if (cQuery.exec()) {
-                                    tilesSaved++;
-                                    const quint64 importTileID = cQuery.lastInsertId().toULongLong();
-                                    const QString s2 = QStringLiteral("INSERT INTO SetTiles(tileID, setID) VALUES(%1, %2)").arg(importTileID).arg(insertSetID);
-                                    (void) cQuery.prepare(s2);
-                                    (void) cQuery.exec();
-                                    currentCount++;
-                                    if (tileCount > 0) {
-                                        const int progress = static_cast<int>((static_cast<double>(currentCount) / static_cast<double>(tileCount)) * 100.0);
-                                        // Avoid calling this if (int) progress hasn't changed.
-                                        if (lastProgress != progress) {
-                                            lastProgress = progress;
-                                            task->setProgress(progress);
-                                        }
-                                    }
-                                }
-                            }
-
-                            (void) _db->commit();
-                            if (tilesSaved > 0) {
-                                // Update tile count (if any added)
-                                s = QStringLiteral("SELECT COUNT(size) FROM Tiles A INNER JOIN SetTiles B on A.tileID = B.tileID WHERE B.setID = %1").arg(insertSetID);
-                                if (cQuery.exec(s) && cQuery.next()) {
-                                    const quint64 count = cQuery.value(0).toULongLong();
-                                    s = QStringLiteral("UPDATE TileSets SET numTiles = %1 WHERE setID = %2").arg(count).arg(insertSetID);
-                                    (void) cQuery.exec(s);
-                                }
-                            }
-
-                            const qint64 uniqueTiles = tilesFound - tilesSaved;
-                            if (static_cast<quint64>(uniqueTiles) < tileCount) {
-                                tileCount -= uniqueTiles;
-                            } else {
-                                tileCount = 0;
-                            }
-
-                            // If there was nothing new in this set, remove it.
-                            if ((tilesSaved == 0) && (defaultSet == 0)) {
-                                qCDebug(QGCTileCacheWorkerLog) << "No unique tiles in" << name << "Removing it.";
-                                _deleteTileSet(insertSetID);
-                            }
-                        }
-                    }
-                } else {
-                    task->setError("No tile set in database");
-                }
-            }
-            delete dbImport;
-            QSqlDatabase::removeDatabase(kExportSession);
-            if (tileCount == 0) {
-                task->setError("No unique tiles in imported database");
-            }
-        } else {
-            task->setError("Error opening import database");
-        }
+        result = _database->importSetsMerge(task->path(), progress);
     }
+
+    _dbValid = _database->isValid();
+
+    if (!result.success) {
+        task->setError(result.errorString);
+        return;
+    }
+
+    if (task->replace() && _database->isValid()) {
+        QSettings settings;
+        settings.remove(QLatin1String(QGCTileCacheDatabase::kBingNoTileDoneKey));
+        _database->deleteBingNoTileTiles();
+    }
+
     task->setImportCompleted();
 }
 
+// H3: Records are now snapshotted on the main thread via QGCExportTileTask,
+// eliminating cross-thread reads of live QGCCachedTileSet objects.
+// H4: Don't emit completion on failure
 void QGCCacheWorker::_exportSets(QGCMapTask *mtask)
 {
     if (!_testTask(mtask)) {
@@ -823,240 +442,14 @@ void QGCCacheWorker::_exportSets(QGCMapTask *mtask)
     }
 
     QGCExportTileTask *task = static_cast<QGCExportTileTask*>(mtask);
-    // Delete target if it exists
-    (void) QFile::remove(task->path());
-    // Create exported database
-    QScopedPointer<QSqlDatabase> dbExport(new QSqlDatabase(QSqlDatabase::addDatabase("QSQLITE", kExportSession)));
-    dbExport->setDatabaseName(task->path());
-    dbExport->setConnectOptions("QSQLITE_ENABLE_SHARED_CACHE");
-    if (dbExport->open()) {
-        if (_createDB(*dbExport, false)) {
-            // Prepare progress report
-            quint64 tileCount = 0;
-            quint64 currentCount = 0;
-            for (int i = 0; i < task->sets().count(); i++) {
-                const QGCCachedTileSet *set = task->sets().at(i);
-                // Default set has no unique tiles
-                if (set->defaultSet()) {
-                    tileCount += set->totalTileCount();
-                } else {
-                    tileCount += set->uniqueTileCount();
-                }
-            }
 
-            if (tileCount == 0) {
-                tileCount = 1;
-            }
+    auto progress = [task](int pct) { task->setProgress(pct); };
+    DatabaseResult result = _database->exportSets(task->sets(), task->path(), progress);
 
-            // Iterate sets to save
-            for (int i = 0; i < task->sets().count(); i++) {
-                const QGCCachedTileSet *set = task->sets().at(i);
-                // Create Tile Exported Set
-                QSqlQuery exportQuery(*dbExport);
-                (void) exportQuery.prepare("INSERT INTO TileSets("
-                    "name, typeStr, topleftLat, topleftLon, bottomRightLat, bottomRightLon, minZoom, maxZoom, type, numTiles, defaultSet, date"
-                    ") VALUES(?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)");
-                exportQuery.addBindValue(set->name());
-                exportQuery.addBindValue(set->mapTypeStr());
-                exportQuery.addBindValue(set->topleftLat());
-                exportQuery.addBindValue(set->topleftLon());
-                exportQuery.addBindValue(set->bottomRightLat());
-                exportQuery.addBindValue(set->bottomRightLon());
-                exportQuery.addBindValue(set->minZoom());
-                exportQuery.addBindValue(set->maxZoom());
-                exportQuery.addBindValue(UrlFactory::getQtMapIdFromProviderType(set->type()));
-                exportQuery.addBindValue(set->totalTileCount());
-                exportQuery.addBindValue(set->defaultSet());
-                exportQuery.addBindValue(QDateTime::currentSecsSinceEpoch());
-                if (!exportQuery.exec()) {
-                    task->setError("Error adding tile set to exported database");
-                    break;
-                }
-
-                // Get just created (auto-incremented) setID
-                const quint64 exportSetID = exportQuery.lastInsertId().toULongLong();
-                // Find set tiles
-                QString s = QStringLiteral("SELECT * FROM SetTiles WHERE setID = %1").arg(set->id());
-                QSqlQuery query(*_db);
-                if (!query.exec(s)) {
-                    continue;
-                }
-
-                (void) dbExport->transaction();
-                while (query.next()) {
-                    const quint64 tileID = query.value("tileID").toULongLong();
-                    // Get tile
-                    s = QStringLiteral("SELECT * FROM Tiles WHERE tileID = \"%1\"").arg(tileID);
-                    QSqlQuery subQuery(*_db);
-                    if (!subQuery.exec(s) || !subQuery.next()) {
-                        continue;
-                    }
-
-                    const QString hash = subQuery.value("hash").toString();
-                    const QString format = subQuery.value("format").toString();
-                    const QByteArray img = subQuery.value("tile").toByteArray();
-                    const int type = subQuery.value("type").toInt();
-                    // Save tile
-                    (void) exportQuery.prepare("INSERT INTO Tiles(hash, format, tile, size, type, date) VALUES(?, ?, ?, ?, ?, ?)");
-                    exportQuery.addBindValue(hash);
-                    exportQuery.addBindValue(format);
-                    exportQuery.addBindValue(img);
-                    exportQuery.addBindValue(img.size());
-                    exportQuery.addBindValue(type);
-                    exportQuery.addBindValue(QDateTime::currentSecsSinceEpoch());
-                    if (!exportQuery.exec()) {
-                        continue;
-                    }
-
-                    const quint64 exportTileID = exportQuery.lastInsertId().toULongLong();
-                    s = QStringLiteral("INSERT INTO SetTiles(tileID, setID) VALUES(%1, %2)").arg(exportTileID).arg(exportSetID);
-                    (void) exportQuery.prepare(s);
-                    (void) exportQuery.exec();
-                    currentCount++;
-                    task->setProgress(static_cast<int>((static_cast<double>(currentCount) / static_cast<double>(tileCount)) * 100.0));
-                }
-                (void) dbExport->commit();
-            }
-        } else {
-            task->setError("Error creating export database");
-        }
-    } else {
-        qCCritical(QGCTileCacheWorkerLog) << "Map Cache SQL error (create export database):" << dbExport->lastError();
-        task->setError("Error opening export database");
+    if (!result.success) {
+        task->setError(result.errorString);
+        return;
     }
-    dbExport.reset();
-    QSqlDatabase::removeDatabase(kExportSession);
+
     task->setExportCompleted();
-}
-
-bool QGCCacheWorker::_testTask(QGCMapTask *mtask)
-{
-    if (!_valid) {
-        mtask->setError("No Cache Database");
-        return false;
-    }
-
-    return true;
-}
-
-bool QGCCacheWorker::_init()
-{
-    _failed = false;
-    if (!_databasePath.isEmpty()) {
-        qCDebug(QGCTileCacheWorkerLog) << "Mapping cache directory:" << _databasePath;
-        // Initialize Database
-        if (_connectDB()) {
-            _valid = _createDB(*_db);
-            if (!_valid) {
-                _failed = true;
-            }
-        } else {
-            qCCritical(QGCTileCacheWorkerLog) << "Map Cache SQL error (open db):" << _db->lastError();
-            _failed = true;
-        }
-        _disconnectDB();
-    } else {
-        qCCritical(QGCTileCacheWorkerLog) << "Could not find suitable cache directory.";
-        _failed = true;
-    }
-
-    return !_failed;
-}
-
-bool QGCCacheWorker::_connectDB()
-{
-    (void) _db.reset(new QSqlDatabase(QSqlDatabase::addDatabase("QSQLITE", kSession)));
-    _db->setDatabaseName(_databasePath);
-    _db->setConnectOptions("QSQLITE_ENABLE_SHARED_CACHE");
-    _valid = _db->open();
-    return _valid;
-}
-
-bool QGCCacheWorker::_createDB(QSqlDatabase &db, bool createDefault)
-{
-    bool res = false;
-    QSqlQuery query(db);
-    if (!query.exec(
-        "CREATE TABLE IF NOT EXISTS Tiles ("
-        "tileID INTEGER PRIMARY KEY NOT NULL, "
-        "hash TEXT NOT NULL UNIQUE, "
-        "format TEXT NOT NULL, "
-        "tile BLOB NULL, "
-        "size INTEGER, "
-        "type INTEGER, "
-        "date INTEGER DEFAULT 0)"))
-    {
-        qCWarning(QGCTileCacheWorkerLog) << "Map Cache SQL error (create Tiles db):" << query.lastError().text();
-    } else {
-        (void) query.exec("CREATE INDEX IF NOT EXISTS hash ON Tiles ( hash, size, type ) ");
-        if (!query.exec(
-            "CREATE TABLE IF NOT EXISTS TileSets ("
-            "setID INTEGER PRIMARY KEY NOT NULL, "
-            "name TEXT NOT NULL UNIQUE, "
-            "typeStr TEXT, "
-            "topleftLat REAL DEFAULT 0.0, "
-            "topleftLon REAL DEFAULT 0.0, "
-            "bottomRightLat REAL DEFAULT 0.0, "
-            "bottomRightLon REAL DEFAULT 0.0, "
-            "minZoom INTEGER DEFAULT 3, "
-            "maxZoom INTEGER DEFAULT 3, "
-            "type INTEGER DEFAULT -1, "
-            "numTiles INTEGER DEFAULT 0, "
-            "defaultSet INTEGER DEFAULT 0, "
-            "date INTEGER DEFAULT 0)"))
-        {
-            qCWarning(QGCTileCacheWorkerLog) << "Map Cache SQL error (create TileSets db):" << query.lastError().text();
-        } else if (!query.exec(
-            "CREATE TABLE IF NOT EXISTS SetTiles ("
-            "setID INTEGER, "
-            "tileID INTEGER)")) {
-            qCWarning(QGCTileCacheWorkerLog) << "Map Cache SQL error (create SetTiles db):" << query.lastError().text();
-        } else if (!query.exec(
-            "CREATE TABLE IF NOT EXISTS TilesDownload ("
-            "setID INTEGER, "
-            "hash TEXT NOT NULL UNIQUE, "
-            "type INTEGER, "
-            "x INTEGER, "
-            "y INTEGER, "
-            "z INTEGER, "
-            "state INTEGER DEFAULT 0)")) {
-            qCWarning(QGCTileCacheWorkerLog) << "Map Cache SQL error (create TilesDownload db):" << query.lastError().text();
-        } else {
-            // Database it ready for use
-            res = true;
-        }
-    }
-
-    // Create default tile set
-    if (res && createDefault) {
-        const QString s = QString("SELECT name FROM TileSets WHERE name = \"%1\"").arg("Default Tile Set");
-        if (query.exec(s)) {
-            if (!query.next()) {
-                (void) query.prepare("INSERT INTO TileSets(name, defaultSet, date) VALUES(?, ?, ?)");
-                query.addBindValue("Default Tile Set");
-                query.addBindValue(1);
-                query.addBindValue(QDateTime::currentSecsSinceEpoch());
-                if (!query.exec()) {
-                    qCWarning(QGCTileCacheWorkerLog) << "Map Cache SQL error (Creating default tile set):" << db.lastError();
-                    res = false;
-                }
-            }
-        } else {
-            qCWarning(QGCTileCacheWorkerLog) << "Map Cache SQL error (Looking for default tile set):" << db.lastError();
-        }
-    }
-
-    if (!res) {
-        (void) QFile::remove(_databasePath);
-    }
-
-    return res;
-}
-
-void QGCCacheWorker::_disconnectDB()
-{
-    if (_db) {
-        _db.reset();
-        QSqlDatabase::removeDatabase(kSession);
-    }
 }

--- a/src/QtLocationPlugin/QGCTileSet.h
+++ b/src/QtLocationPlugin/QGCTileSet.h
@@ -7,10 +7,6 @@ struct QGCTileSet
 {
     QGCTileSet &operator+=(const QGCTileSet &other)
     {
-        tileX0 += other.tileX0;
-        tileX1 += other.tileX1;
-        tileY0 += other.tileY0;
-        tileY1 += other.tileY1;
         tileCount += other.tileCount;
         tileSize += other.tileSize;
         return *this;

--- a/src/QtLocationPlugin/QGeoFileTileCacheQGC.cpp
+++ b/src/QtLocationPlugin/QGeoFileTileCacheQGC.cpp
@@ -18,7 +18,7 @@ QGC_LOGGING_CATEGORY(QGeoFileTileCacheQGCLog, "QtLocationPlugin.QGeoFileTileCach
 
 QString QGeoFileTileCacheQGC::_databaseFilePath;
 QString QGeoFileTileCacheQGC::_cachePath;
-bool QGeoFileTileCacheQGC::_cacheWasReset = false;
+std::atomic<bool> QGeoFileTileCacheQGC::_cacheWasReset = false;
 
 QGeoFileTileCacheQGC::QGeoFileTileCacheQGC(const QVariantMap &parameters, QObject *parent)
     : QGeoFileTileCache(baseCacheDirectory(), parent)
@@ -159,7 +159,7 @@ bool QGeoFileTileCacheQGC::_wipeDirectory(const QString &dirPath)
 
 void QGeoFileTileCacheQGC::_wipeOldCaches()
 {
-    const QStringList oldCaches = {"/QGCMapCache55", "/QGCMapCache100"};
+    const QStringList oldCaches = {"/QGCMapCache55", "/QGCMapCache100", "/QGCMapCache300"};
     for (const QString &cache : oldCaches) {
         QString oldCacheDir;
         #if defined(Q_OS_ANDROID) || defined(Q_OS_IOS)
@@ -179,10 +179,11 @@ void QGeoFileTileCacheQGC::_initCache()
     // QString cacheDir = QAbstractGeoTileCache::baseCacheDirectory()
 #if defined(Q_OS_ANDROID) || defined(Q_OS_IOS)
     QString cacheDir = QStandardPaths::writableLocation(QStandardPaths::AppDataLocation);
+    cacheDir += QStringLiteral("/QGCMapCache");
 #else
-    QString cacheDir = QStandardPaths::writableLocation(QStandardPaths::GenericCacheLocation);
+    QString cacheDir = QStandardPaths::writableLocation(QStandardPaths::CacheLocation);
+    cacheDir += QStringLiteral("/QGCMapCache");
 #endif
-    cacheDir += QStringLiteral("/QGCMapCache") + QString(kCachePathVersion);
     if (!QGCFileHelper::ensureDirectoryExists(cacheDir)) {
         qCWarning(QGeoFileTileCacheQGCLog) << "Could not create mapping disk cache directory:" << cacheDir;
 

--- a/src/QtLocationPlugin/QGeoFileTileCacheQGC.h
+++ b/src/QtLocationPlugin/QGeoFileTileCacheQGC.h
@@ -1,5 +1,7 @@
 #pragma once
 
+#include <atomic>
+
 #include <QtCore/QLoggingCategory>
 #include <QtLocation/private/qgeofiletilecache_p.h>
 
@@ -40,9 +42,8 @@ private:
 
     static quint32 _getMaxMemCacheSetting();
 
+    // Initialized once via std::call_once in constructor before worker thread starts
     static QString _databaseFilePath;
     static QString _cachePath;
-    static bool _cacheWasReset;
-
-    static constexpr const char *kCachePathVersion = "300";
+    static std::atomic<bool> _cacheWasReset;
 };

--- a/src/QtLocationPlugin/QGeoTileFetcherQGC.cpp
+++ b/src/QtLocationPlugin/QGeoTileFetcherQGC.cpp
@@ -93,6 +93,9 @@ void QGeoTileFetcherQGC::handleReply(QGeoTiledMapReply *reply, const QGeoTileSpe
 QNetworkRequest QGeoTileFetcherQGC::getNetworkRequest(int mapId, int x, int y, int zoom)
 {
     const SharedMapProvider mapProvider = UrlFactory::getMapProviderFromQtMapId(mapId);
+    if (!mapProvider) {
+        return QNetworkRequest();
+    }
 
     QNetworkRequest request;
     request.setUrl(mapProvider->getTileURL(x, y, zoom));
@@ -105,7 +108,7 @@ QNetworkRequest QGeoTileFetcherQGC::getNetworkRequest(int mapId, int x, int y, i
     request.setHeader(QNetworkRequest::UserAgentHeader, s_userAgent);
     const QByteArray referrer = mapProvider->getReferrer().toUtf8();
     if (!referrer.isEmpty()) {
-        request.setRawHeader(QByteArrayLiteral("Referrer"), referrer);
+        request.setRawHeader(QByteArrayLiteral("Referer"), referrer);
     }
     const QByteArray token = mapProvider->getToken();
     if (!token.isEmpty()) {

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -140,6 +140,17 @@ add_qgc_test(TransectStyleComplexItemTest LABELS Unit MissionManager RESOURCE_LO
 # add_qgc_test(MessageBoxTest LABELS Unit)
 
 # ----------------------------------------------------------------------------
+# QtLocationPlugin
+# ----------------------------------------------------------------------------
+add_subdirectory(QtLocationPlugin)
+add_qgc_test(MapProviderTest LABELS Unit)
+add_qgc_test(QGCCacheWorkerTest LABELS Unit)
+add_qgc_test(QGCCachedTileSetTest LABELS Unit)
+add_qgc_test(QGCTileCacheDatabaseTest LABELS Unit)
+add_qgc_test(QGCTileSetTest LABELS Unit)
+add_qgc_test(UrlFactoryTest LABELS Unit)
+
+# ----------------------------------------------------------------------------
 # Terrain
 # ----------------------------------------------------------------------------
 add_subdirectory(Terrain)

--- a/test/QtLocationPlugin/CMakeLists.txt
+++ b/test/QtLocationPlugin/CMakeLists.txt
@@ -1,0 +1,22 @@
+# ============================================================================
+# QtLocationPlugin Unit Tests
+# Tests for tile cache database operations
+# ============================================================================
+
+target_sources(${CMAKE_PROJECT_NAME}
+    PRIVATE
+        MapProviderTest.cc
+        MapProviderTest.h
+        QGCCachedTileSetTest.cc
+        QGCCachedTileSetTest.h
+        QGCCacheWorkerTest.cc
+        QGCCacheWorkerTest.h
+        QGCTileCacheDatabaseTest.cc
+        QGCTileCacheDatabaseTest.h
+        QGCTileSetTest.cc
+        QGCTileSetTest.h
+        UrlFactoryTest.cc
+        UrlFactoryTest.h
+)
+
+target_include_directories(${CMAKE_PROJECT_NAME} PRIVATE ${CMAKE_CURRENT_SOURCE_DIR})

--- a/test/QtLocationPlugin/MapProviderTest.cc
+++ b/test/QtLocationPlugin/MapProviderTest.cc
@@ -1,0 +1,202 @@
+#include "MapProviderTest.h"
+
+#include "MapProvider.h"
+
+#include <QtCore/QtMath>
+
+class TestableMapProvider : public MapProvider
+{
+public:
+    explicit TestableMapProvider(const QString &name = QStringLiteral("TestProvider"),
+                                const QString &imageFormat = QStringLiteral("png"),
+                                quint32 avgSize = QGC_AVERAGE_TILE_SIZE)
+        : MapProvider(name, QString(), imageFormat, avgSize, QGeoMapType::CustomMap) {}
+
+    using MapProvider::_tileXYToQuadKey;
+    using MapProvider::_getServerNum;
+
+private:
+    QString _getURL(int, int, int) const override { return {}; }
+};
+
+// --- Image format detection ---
+
+void MapProviderTest::_testGetImageFormatPng()
+{
+    TestableMapProvider p;
+    const QByteArray png("\x89\x50\x4E\x47\x0D\x0A\x1A\x0A" "rest_of_data", 20);
+    QCOMPARE(p.getImageFormat(png), QStringLiteral("png"));
+}
+
+void MapProviderTest::_testGetImageFormatJpeg()
+{
+    TestableMapProvider p;
+    const QByteArray jpeg("\xFF\xD8\xFF\xE0" "jpeg_data", 13);
+    QCOMPARE(p.getImageFormat(jpeg), QStringLiteral("jpg"));
+}
+
+void MapProviderTest::_testGetImageFormatGif()
+{
+    TestableMapProvider p;
+    const QByteArray gif("GIF89a_data", 11);
+    QCOMPARE(p.getImageFormat(gif), QStringLiteral("gif"));
+}
+
+void MapProviderTest::_testGetImageFormatFallback()
+{
+    TestableMapProvider p(QStringLiteral("Test"), QStringLiteral("webp"));
+    const QByteArray unknown("RIFF____WEBP", 12);
+    QCOMPARE(p.getImageFormat(unknown), QStringLiteral("webp"));
+}
+
+void MapProviderTest::_testGetImageFormatTooSmall()
+{
+    TestableMapProvider p;
+    QVERIFY(p.getImageFormat(QByteArray("AB")).isEmpty());
+    QVERIFY(p.getImageFormat(QByteArray()).isEmpty());
+}
+
+// --- Web Mercator coordinate math ---
+// Reference: https://wiki.openstreetmap.org/wiki/Slippy_map_tilenames
+
+void MapProviderTest::_testLong2tileXZoom0()
+{
+    TestableMapProvider p;
+    QCOMPARE(p.long2tileX(0.0, 0), 0);
+    QCOMPARE(p.long2tileX(-180.0, 0), 0);
+}
+
+void MapProviderTest::_testLong2tileXZoom1()
+{
+    TestableMapProvider p;
+    // lon=0 at z=1: (0+180)/360 * 2 = 1.0 → floor = 1
+    QCOMPARE(p.long2tileX(0.0, 1), 1);
+    // lon=-180 at z=1: (−180+180)/360 * 2 = 0.0 → floor = 0
+    QCOMPARE(p.long2tileX(-180.0, 1), 0);
+}
+
+void MapProviderTest::_testLong2tileXNegative()
+{
+    TestableMapProvider p;
+    // NYC longitude: floor((-73.9857+180)/360 * 1024) = floor(301.48...) = 301
+    QCOMPARE(p.long2tileX(-73.9857, 10), 301);
+}
+
+void MapProviderTest::_testLong2tileXBoundary180()
+{
+    TestableMapProvider p;
+    // lon just below 180 at z=10: should be 2^10 - 1 = 1023
+    QCOMPARE(p.long2tileX(179.999, 10), 1023);
+}
+
+void MapProviderTest::_testLat2tileYEquator()
+{
+    TestableMapProvider p;
+    // lat=0 at z=1: (1 - log(tan(0) + 1/cos(0))/π) / 2 * 2 = (1 - 0)/2 * 2 = 1
+    QCOMPARE(p.lat2tileY(0.0, 1), 1);
+}
+
+void MapProviderTest::_testLat2tileYNorthern()
+{
+    TestableMapProvider p;
+    // NYC latitude 40.7128 at z=10
+    QCOMPARE(p.lat2tileY(40.7128, 10), 385);
+}
+
+void MapProviderTest::_testLat2tileYPoles()
+{
+    TestableMapProvider p;
+    // Near north pole at z=1 → tile 0
+    QCOMPARE(p.lat2tileY(85.05, 1), 0);
+    // Near south pole at z=1 → tile 1
+    QCOMPARE(p.lat2tileY(-85.05, 1), 1);
+}
+
+// --- Tile count ---
+
+void MapProviderTest::_testGetTileCountSingleTile()
+{
+    TestableMapProvider p;
+    // At z=1, tile (1,1) covers lon=[0,180), lat≈[-85.05,0).
+    // Use a bbox entirely within that tile.
+    const auto set = p.getTileCount(1, 10.0, -10.0, 20.0, -20.0);
+    QCOMPARE(set.tileCount, static_cast<quint64>(1));
+}
+
+void MapProviderTest::_testGetTileCountMultipleTiles()
+{
+    TestableMapProvider p;
+    // z=1: full world = 2x2 = 4 tiles
+    const auto set = p.getTileCount(1, -179.9, 85.0, 179.9, -85.0);
+    QCOMPARE(set.tileCount, static_cast<quint64>(4));
+}
+
+void MapProviderTest::_testGetTileCountSizeMatchesAvg()
+{
+    TestableMapProvider p(QStringLiteral("Test"), QStringLiteral("png"), 5000);
+    const auto set = p.getTileCount(1, -179.9, 85.0, 179.9, -85.0);
+    QCOMPARE(set.tileSize, set.tileCount * static_cast<quint64>(5000));
+}
+
+// --- QuadKey encoding ---
+
+void MapProviderTest::_testQuadKeyLevel1()
+{
+    TestableMapProvider p;
+    QCOMPARE(p._tileXYToQuadKey(0, 0, 1), QStringLiteral("0"));
+    QCOMPARE(p._tileXYToQuadKey(1, 0, 1), QStringLiteral("1"));
+    QCOMPARE(p._tileXYToQuadKey(0, 1, 1), QStringLiteral("2"));
+    QCOMPARE(p._tileXYToQuadKey(1, 1, 1), QStringLiteral("3"));
+}
+
+void MapProviderTest::_testQuadKeyLevel3()
+{
+    TestableMapProvider p;
+    // (3,5,3): level 3, mask=4,2,1
+    // i=3: mask=4; tileX=3 (011), 3&4=0; tileY=5 (101), 5&4=4≠0 → digit='0'+2='2'
+    // i=2: mask=2; 3&2=2≠0 → +1; 5&2=0 → digit='1'
+    // i=1: mask=1; 3&1=1≠0 → +1; 5&1=1≠0 → +2; digit='3'
+    QCOMPARE(p._tileXYToQuadKey(3, 5, 3), QStringLiteral("213"));
+}
+
+void MapProviderTest::_testQuadKeyLevel0()
+{
+    TestableMapProvider p;
+    QCOMPARE(p._tileXYToQuadKey(0, 0, 0), QString());
+}
+
+// --- Server number ---
+
+void MapProviderTest::_testGetServerNumBasic()
+{
+    TestableMapProvider p;
+    // (x + 2*y) % max
+    QCOMPARE(p._getServerNum(0, 0, 4), 0);
+    QCOMPARE(p._getServerNum(1, 0, 4), 1);
+    QCOMPARE(p._getServerNum(0, 1, 4), 2);
+    QCOMPARE(p._getServerNum(1, 1, 4), 3);
+}
+
+void MapProviderTest::_testGetServerNumWrap()
+{
+    TestableMapProvider p;
+    // (5 + 2*3) % 4 = 11 % 4 = 3
+    QCOMPARE(p._getServerNum(5, 3, 4), 3);
+    // max=1 always returns 0
+    QCOMPARE(p._getServerNum(99, 99, 1), 0);
+}
+
+// --- Getters ---
+
+void MapProviderTest::_testGettersReturnConstructorValues()
+{
+    TestableMapProvider p(QStringLiteral("MyMap"), QStringLiteral("jpg"), 7777);
+    QCOMPARE(p.getMapName(), QStringLiteral("MyMap"));
+    QCOMPARE(p.getAverageSize(), static_cast<quint32>(7777));
+    QCOMPARE(p.getMapStyle(), QGeoMapType::CustomMap);
+    QVERIFY(!p.isElevationProvider());
+    QVERIFY(!p.isBingProvider());
+    QVERIFY(p.getMapId() > 0);
+}
+
+UT_REGISTER_TEST(MapProviderTest, TestLabel::Unit)

--- a/test/QtLocationPlugin/MapProviderTest.h
+++ b/test/QtLocationPlugin/MapProviderTest.h
@@ -1,0 +1,31 @@
+#pragma once
+
+#include "UnitTest.h"
+
+class MapProviderTest : public UnitTest
+{
+    Q_OBJECT
+
+private slots:
+    void _testGetImageFormatPng();
+    void _testGetImageFormatJpeg();
+    void _testGetImageFormatGif();
+    void _testGetImageFormatFallback();
+    void _testGetImageFormatTooSmall();
+    void _testLong2tileXZoom0();
+    void _testLong2tileXZoom1();
+    void _testLong2tileXNegative();
+    void _testLong2tileXBoundary180();
+    void _testLat2tileYEquator();
+    void _testLat2tileYNorthern();
+    void _testLat2tileYPoles();
+    void _testGetTileCountSingleTile();
+    void _testGetTileCountMultipleTiles();
+    void _testGetTileCountSizeMatchesAvg();
+    void _testQuadKeyLevel1();
+    void _testQuadKeyLevel3();
+    void _testQuadKeyLevel0();
+    void _testGetServerNumBasic();
+    void _testGetServerNumWrap();
+    void _testGettersReturnConstructorValues();
+};

--- a/test/QtLocationPlugin/QGCCacheWorkerTest.cc
+++ b/test/QtLocationPlugin/QGCCacheWorkerTest.cc
@@ -1,0 +1,310 @@
+#include "QGCCacheWorkerTest.h"
+
+#include <QtCore/QCoreApplication>
+#include <QtTest/QTest>
+
+#include "QGCCacheTile.h"
+#include "QGCCachedTileSet.h"
+#include "QGCMapTasks.h"
+#include "QGCTileCacheWorker.h"
+
+bool QGCCacheWorkerTest::_startWorker(QGCCacheWorker &worker, int timeoutMs)
+{
+    bool totalsReceived = false;
+    auto conn = connect(&worker, &QGCCacheWorker::updateTotals, this, [&]() {
+        totalsReceived = true;
+    }, Qt::QueuedConnection);
+
+    auto *initTask = new QGCMapTask(QGCMapTask::TaskType::taskInit);
+    if (!worker.enqueueTask(initTask)) {
+        disconnect(conn);
+        return false;
+    }
+
+    const bool ok = QTest::qWaitFor([&]() { return totalsReceived; }, timeoutMs);
+    disconnect(conn);
+    return ok;
+}
+
+void QGCCacheWorkerTest::_testStartAndStop()
+{
+    QGCCacheWorker worker;
+    worker.setDatabaseFile(tempPath("start_stop.db"));
+    QVERIFY(!worker.isRunning());
+
+    QVERIFY(_startWorker(worker));
+    QVERIFY(worker.isRunning());
+
+    worker.stop();
+    QVERIFY(worker.wait(5000));
+    QVERIFY(!worker.isRunning());
+}
+
+void QGCCacheWorkerTest::_testEnqueueBeforeInit()
+{
+    QGCCacheWorker worker;
+    worker.setDatabaseFile(tempPath("pre_init.db"));
+
+    auto *task = new QGCFetchTileTask(QStringLiteral("hash"));
+    bool errorReceived = false;
+    connect(task, &QGCMapTask::error, this, [&](QGCMapTask::TaskType, const QString &) {
+        errorReceived = true;
+    });
+    QVERIFY(!worker.enqueueTask(task));
+    QVERIFY(errorReceived);
+    QCoreApplication::processEvents();
+}
+
+void QGCCacheWorkerTest::_testUpdateTotalsOnInit()
+{
+    QGCCacheWorker worker;
+    worker.setDatabaseFile(tempPath("totals.db"));
+
+    quint32 totalTiles = UINT32_MAX;
+    quint64 totalSize = UINT64_MAX;
+    auto conn = connect(&worker, &QGCCacheWorker::updateTotals, this,
+        [&](quint32 tiles, quint64 size, quint32, quint64) {
+            totalTiles = tiles;
+            totalSize = size;
+        }, Qt::QueuedConnection);
+
+    QVERIFY(worker.enqueueTask(new QGCMapTask(QGCMapTask::TaskType::taskInit)));
+    QTRY_VERIFY_WITH_TIMEOUT(totalTiles != UINT32_MAX, 5000);
+    disconnect(conn);
+
+    QCOMPARE(totalTiles, static_cast<quint32>(0));
+    QCOMPARE(totalSize, static_cast<quint64>(0));
+
+    worker.stop();
+    worker.wait(5000);
+}
+
+void QGCCacheWorkerTest::_testSaveAndFetchTile()
+{
+    QGCCacheWorker worker;
+    worker.setDatabaseFile(tempPath("save_fetch.db"));
+    QVERIFY(_startWorker(worker));
+
+    auto *tile = new QGCCacheTile(QStringLiteral("h1"), QByteArray("tile_data"), QStringLiteral("png"), QStringLiteral("T"));
+    QVERIFY(worker.enqueueTask(new QGCSaveTileTask(tile)));
+
+    // Fetch — FIFO guarantees save completes first
+    auto *fetchTask = new QGCFetchTileTask(QStringLiteral("h1"));
+    QGCCacheTile *fetched = nullptr;
+    bool fetchError = false;
+    connect(fetchTask, &QGCFetchTileTask::tileFetched, this, [&](QGCCacheTile *t) {
+        fetched = t;
+    }, Qt::QueuedConnection);
+    connect(fetchTask, &QGCMapTask::error, this, [&](QGCMapTask::TaskType, const QString &) {
+        fetchError = true;
+    }, Qt::QueuedConnection);
+
+    QVERIFY(worker.enqueueTask(fetchTask));
+    QTRY_VERIFY_WITH_TIMEOUT(fetched || fetchError, 5000);
+
+    QVERIFY2(fetched != nullptr, "Expected tile to be fetched");
+    QVERIFY(!fetchError);
+    QCOMPARE(fetched->hash, QStringLiteral("h1"));
+    QCOMPARE(fetched->img, QByteArray("tile_data"));
+    QCOMPARE(fetched->format, QStringLiteral("png"));
+    delete fetched;
+
+    worker.stop();
+    worker.wait(5000);
+}
+
+void QGCCacheWorkerTest::_testFetchTileNotFound()
+{
+    QGCCacheWorker worker;
+    worker.setDatabaseFile(tempPath("not_found.db"));
+    QVERIFY(_startWorker(worker));
+
+    auto *fetchTask = new QGCFetchTileTask(QStringLiteral("nonexistent"));
+    QGCCacheTile *fetched = nullptr;
+    bool fetchError = false;
+    connect(fetchTask, &QGCFetchTileTask::tileFetched, this, [&](QGCCacheTile *t) {
+        fetched = t;
+    }, Qt::QueuedConnection);
+    connect(fetchTask, &QGCMapTask::error, this, [&](QGCMapTask::TaskType, const QString &) {
+        fetchError = true;
+    }, Qt::QueuedConnection);
+
+    QVERIFY(worker.enqueueTask(fetchTask));
+    QTRY_VERIFY_WITH_TIMEOUT(fetched || fetchError, 5000);
+
+    QVERIFY(fetched == nullptr);
+    QVERIFY(fetchError);
+
+    worker.stop();
+    worker.wait(5000);
+}
+
+void QGCCacheWorkerTest::_testFetchTileSets()
+{
+    QGCCacheWorker worker;
+    worker.setDatabaseFile(tempPath("tile_sets.db"));
+    QVERIFY(_startWorker(worker));
+
+    // Wait for updateTotals after the fetch task completes to know all sets were emitted
+    bool taskDone = false;
+    auto totalsConn = connect(&worker, &QGCCacheWorker::updateTotals, this, [&]() {
+        taskDone = true;
+    }, Qt::QueuedConnection);
+
+    QList<QGCCachedTileSet *> sets;
+    auto *fetchTask = new QGCFetchTileSetTask();
+    connect(fetchTask, &QGCFetchTileSetTask::tileSetFetched, this, [&](QGCCachedTileSet *set) {
+        sets.append(set);
+    }, Qt::QueuedConnection);
+
+    QVERIFY(worker.enqueueTask(fetchTask));
+    QTRY_VERIFY_WITH_TIMEOUT(taskDone, 5000);
+    disconnect(totalsConn);
+
+    QCOMPARE(sets.size(), 1);
+    QVERIFY(sets[0]->defaultSet());
+    QCOMPARE(sets[0]->name(), QStringLiteral("Default Tile Set"));
+    qDeleteAll(sets);
+
+    worker.stop();
+    worker.wait(5000);
+}
+
+void QGCCacheWorkerTest::_testCreateAndDeleteTileSet()
+{
+    QGCCacheWorker worker;
+    worker.setDatabaseFile(tempPath("create_delete.db"));
+    QVERIFY(_startWorker(worker));
+
+    auto *tileSet = new QGCCachedTileSet(QStringLiteral("Test Set"));
+    tileSet->setMapTypeStr(QStringLiteral("TestMap"));
+    tileSet->setType(QStringLiteral("T"));
+    tileSet->setTopleftLat(37.0);
+    tileSet->setTopleftLon(-122.0);
+    tileSet->setBottomRightLat(36.0);
+    tileSet->setBottomRightLon(-121.0);
+    tileSet->setMinZoom(5);
+    tileSet->setMaxZoom(5);
+    tileSet->setTotalTileCount(1);
+
+    auto *createTask = new QGCCreateTileSetTask(tileSet);
+    QGCCachedTileSet *savedSet = nullptr;
+    bool createError = false;
+    connect(createTask, &QGCCreateTileSetTask::tileSetSaved, this, [&](QGCCachedTileSet *set) {
+        savedSet = set;
+    }, Qt::QueuedConnection);
+    connect(createTask, &QGCMapTask::error, this, [&](QGCMapTask::TaskType, const QString &) {
+        createError = true;
+    }, Qt::QueuedConnection);
+
+    QVERIFY(worker.enqueueTask(createTask));
+    QTRY_VERIFY_WITH_TIMEOUT(savedSet || createError, 5000);
+    QVERIFY2(savedSet != nullptr, "Expected tile set to be created");
+    QVERIFY(!createError);
+    QVERIFY(savedSet->id() != 0);
+
+    // Delete it
+    const quint64 setID = savedSet->id();
+    auto *deleteTask = new QGCDeleteTileSetTask(setID);
+    quint64 deletedID = 0;
+    connect(deleteTask, &QGCDeleteTileSetTask::tileSetDeleted, this, [&](quint64 id) {
+        deletedID = id;
+    }, Qt::QueuedConnection);
+
+    QVERIFY(worker.enqueueTask(deleteTask));
+    QTRY_VERIFY_WITH_TIMEOUT(deletedID != 0, 5000);
+    QCOMPARE(deletedID, setID);
+
+    delete savedSet;
+
+    worker.stop();
+    worker.wait(5000);
+}
+
+void QGCCacheWorkerTest::_testPruneCache()
+{
+    QGCCacheWorker worker;
+    worker.setDatabaseFile(tempPath("prune.db"));
+    QVERIFY(_startWorker(worker));
+
+    for (int i = 0; i < 10; i++) {
+        auto *tile = new QGCCacheTile(
+            QStringLiteral("pr_%1").arg(i), QByteArray(100, 'P'), QStringLiteral("png"), QStringLiteral("T"));
+        QVERIFY(worker.enqueueTask(new QGCSaveTileTask(tile)));
+    }
+
+    auto *pruneTask = new QGCPruneCacheTask(500);
+    bool pruneDone = false;
+    connect(pruneTask, &QGCPruneCacheTask::pruned, this, [&]() {
+        pruneDone = true;
+    }, Qt::QueuedConnection);
+    QVERIFY(worker.enqueueTask(pruneTask));
+    QTRY_VERIFY_WITH_TIMEOUT(pruneDone, 5000);
+
+    // Trigger totals to verify count decreased
+    quint32 remaining = UINT32_MAX;
+    auto conn = connect(&worker, &QGCCacheWorker::updateTotals, this,
+        [&](quint32 tiles, quint64, quint32, quint64) {
+            remaining = tiles;
+        }, Qt::QueuedConnection);
+    QVERIFY(worker.enqueueTask(new QGCMapTask(QGCMapTask::TaskType::taskInit)));
+    QTRY_VERIFY_WITH_TIMEOUT(remaining != UINT32_MAX, 5000);
+    disconnect(conn);
+
+    QVERIFY2(remaining < 10,
+        qPrintable(QStringLiteral("Expected fewer than 10 tiles after prune, got %1").arg(remaining)));
+
+    worker.stop();
+    worker.wait(5000);
+}
+
+void QGCCacheWorkerTest::_testResetDatabase()
+{
+    QGCCacheWorker worker;
+    worker.setDatabaseFile(tempPath("reset.db"));
+    QVERIFY(_startWorker(worker));
+
+    auto *tile = new QGCCacheTile(QStringLiteral("r1"), QByteArray("data"), QStringLiteral("png"), QStringLiteral("T"));
+    QVERIFY(worker.enqueueTask(new QGCSaveTileTask(tile)));
+
+    auto *resetTask = new QGCResetTask();
+    bool resetDone = false;
+    connect(resetTask, &QGCResetTask::resetCompleted, this, [&]() {
+        resetDone = true;
+    }, Qt::QueuedConnection);
+    QVERIFY(worker.enqueueTask(resetTask));
+    QTRY_VERIFY_WITH_TIMEOUT(resetDone, 5000);
+
+    // Verify saved tile is gone
+    auto *fetchTask = new QGCFetchTileTask(QStringLiteral("r1"));
+    bool fetchError = false;
+    connect(fetchTask, &QGCMapTask::error, this, [&](QGCMapTask::TaskType, const QString &) {
+        fetchError = true;
+    }, Qt::QueuedConnection);
+    QVERIFY(worker.enqueueTask(fetchTask));
+    QTRY_VERIFY_WITH_TIMEOUT(fetchError, 5000);
+
+    QVERIFY(worker.isRunning());
+
+    worker.stop();
+    worker.wait(5000);
+}
+
+void QGCCacheWorkerTest::_testStopWhileProcessing()
+{
+    QGCCacheWorker worker;
+    worker.setDatabaseFile(tempPath("stop_busy.db"));
+    QVERIFY(_startWorker(worker));
+
+    for (int i = 0; i < 100; i++) {
+        auto *tile = new QGCCacheTile(
+            QStringLiteral("stop_%1").arg(i), QByteArray(50, 'S'), QStringLiteral("png"), QStringLiteral("T"));
+        worker.enqueueTask(new QGCSaveTileTask(tile));
+    }
+
+    worker.stop();
+    QVERIFY(worker.wait(5000));
+    QVERIFY(!worker.isRunning());
+}
+
+UT_REGISTER_TEST(QGCCacheWorkerTest, TestLabel::Unit)

--- a/test/QtLocationPlugin/QGCCacheWorkerTest.h
+++ b/test/QtLocationPlugin/QGCCacheWorkerTest.h
@@ -1,0 +1,25 @@
+#pragma once
+
+#include "BaseClasses/TempDirectoryTest.h"
+
+class QGCCacheWorker;
+
+class QGCCacheWorkerTest : public TempDirectoryTest
+{
+    Q_OBJECT
+
+private slots:
+    void _testStartAndStop();
+    void _testEnqueueBeforeInit();
+    void _testUpdateTotalsOnInit();
+    void _testSaveAndFetchTile();
+    void _testFetchTileNotFound();
+    void _testFetchTileSets();
+    void _testCreateAndDeleteTileSet();
+    void _testPruneCache();
+    void _testResetDatabase();
+    void _testStopWhileProcessing();
+
+private:
+    bool _startWorker(QGCCacheWorker &worker, int timeoutMs = 5000);
+};

--- a/test/QtLocationPlugin/QGCCachedTileSetTest.cc
+++ b/test/QtLocationPlugin/QGCCachedTileSetTest.cc
@@ -1,0 +1,268 @@
+#include "QGCCachedTileSetTest.h"
+
+#include <QtTest/QSignalSpy>
+
+#include "QGCCachedTileSet.h"
+
+void QGCCachedTileSetTest::_testConstructorSetsName()
+{
+    QGCCachedTileSet ts(QStringLiteral("MySet"));
+    QCOMPARE(ts.name(), QStringLiteral("MySet"));
+}
+
+void QGCCachedTileSetTest::_testDefaultPropertyValues()
+{
+    QGCCachedTileSet ts(QStringLiteral("test"));
+
+    QCOMPARE(ts.totalTileCount(), 0u);
+    QCOMPARE(ts.totalTilesSize(), quint64(0));
+    QCOMPARE(ts.uniqueTileCount(), 0u);
+    QCOMPARE(ts.uniqueTileSize(), quint64(0));
+    QCOMPARE(ts.savedTileCount(), 0u);
+    QCOMPARE(ts.savedTileSize(), quint64(0));
+    QCOMPARE(ts.errorCount(), 0u);
+
+    QCOMPARE(ts.topleftLat(), 0.);
+    QCOMPARE(ts.topleftLon(), 0.);
+    QCOMPARE(ts.bottomRightLat(), 0.);
+    QCOMPARE(ts.bottomRightLon(), 0.);
+
+    QCOMPARE(ts.minZoom(), 3);
+    QCOMPARE(ts.maxZoom(), 3);
+    QCOMPARE(ts.id(), quint64(0));
+
+    QCOMPARE(ts.type(), QStringLiteral("Invalid"));
+    QVERIFY(ts.mapTypeStr().isEmpty());
+
+    QVERIFY(!ts.defaultSet());
+    QVERIFY(!ts.deleting());
+    QVERIFY(!ts.downloading());
+    QVERIFY(!ts.selected());
+    QVERIFY(!ts.creationDate().isValid());
+
+    QVERIFY(ts.complete());
+}
+
+void QGCCachedTileSetTest::_testSetMapTypeStr()
+{
+    QGCCachedTileSet ts(QStringLiteral("test"));
+    ts.setMapTypeStr(QStringLiteral("Google Satellite"));
+    QCOMPARE(ts.mapTypeStr(), QStringLiteral("Google Satellite"));
+}
+
+void QGCCachedTileSetTest::_testSetCoordinates()
+{
+    QGCCachedTileSet ts(QStringLiteral("test"));
+
+    ts.setTopleftLat(47.5);
+    ts.setTopleftLon(-122.3);
+    ts.setBottomRightLat(47.4);
+    ts.setBottomRightLon(-122.2);
+
+    QCOMPARE(ts.topleftLat(), 47.5);
+    QCOMPARE(ts.topleftLon(), -122.3);
+    QCOMPARE(ts.bottomRightLat(), 47.4);
+    QCOMPARE(ts.bottomRightLon(), -122.2);
+}
+
+void QGCCachedTileSetTest::_testSetZoomAndMetadata()
+{
+    QGCCachedTileSet ts(QStringLiteral("test"));
+
+    ts.setMinZoom(5);
+    ts.setMaxZoom(15);
+    QCOMPARE(ts.minZoom(), 5);
+    QCOMPARE(ts.maxZoom(), 15);
+
+    ts.setId(42);
+    QCOMPARE(ts.id(), quint64(42));
+
+    ts.setType(QStringLiteral("Satellite"));
+    QCOMPARE(ts.type(), QStringLiteral("Satellite"));
+
+    const QDateTime now = QDateTime::currentDateTimeUtc();
+    ts.setCreationDate(now);
+    QCOMPARE(ts.creationDate(), now);
+
+    ts.setDefaultSet(true);
+    QVERIFY(ts.defaultSet());
+}
+
+void QGCCachedTileSetTest::_testSetTotalTileCountEmitsSignal()
+{
+    QGCCachedTileSet ts(QStringLiteral("test"));
+    QSignalSpy spy(&ts, &QGCCachedTileSet::totalTileCountChanged);
+
+    ts.setTotalTileCount(100);
+    QCOMPARE(spy.count(), 1);
+    QCOMPARE(ts.totalTileCount(), 100u);
+}
+
+void QGCCachedTileSetTest::_testSetTotalTileSizeEmitsSignal()
+{
+    QGCCachedTileSet ts(QStringLiteral("test"));
+    QSignalSpy spy(&ts, &QGCCachedTileSet::totalTilesSizeChanged);
+
+    ts.setTotalTileSize(1024 * 1024);
+    QCOMPARE(spy.count(), 1);
+    QCOMPARE(ts.totalTilesSize(), quint64(1024 * 1024));
+}
+
+void QGCCachedTileSetTest::_testSetSavedCountAndSizeEmitSignals()
+{
+    QGCCachedTileSet ts(QStringLiteral("test"));
+    QSignalSpy countSpy(&ts, &QGCCachedTileSet::savedTileCountChanged);
+    QSignalSpy sizeSpy(&ts, &QGCCachedTileSet::savedTileSizeChanged);
+
+    ts.setSavedTileCount(50);
+    QCOMPARE(countSpy.count(), 1);
+    QCOMPARE(ts.savedTileCount(), 50u);
+
+    ts.setSavedTileSize(2048);
+    QCOMPARE(sizeSpy.count(), 1);
+    QCOMPARE(ts.savedTileSize(), quint64(2048));
+}
+
+void QGCCachedTileSetTest::_testSetUniqueCountAndSizeEmitSignals()
+{
+    QGCCachedTileSet ts(QStringLiteral("test"));
+    QSignalSpy countSpy(&ts, &QGCCachedTileSet::uniqueTileCountChanged);
+    QSignalSpy sizeSpy(&ts, &QGCCachedTileSet::uniqueTileSizeChanged);
+
+    ts.setUniqueTileCount(25);
+    QCOMPARE(countSpy.count(), 1);
+    QCOMPARE(ts.uniqueTileCount(), 25u);
+
+    ts.setUniqueTileSize(4096);
+    QCOMPARE(sizeSpy.count(), 1);
+    QCOMPARE(ts.uniqueTileSize(), quint64(4096));
+}
+
+void QGCCachedTileSetTest::_testSetNameEmitsSignal()
+{
+    QGCCachedTileSet ts(QStringLiteral("original"));
+    QSignalSpy spy(&ts, &QGCCachedTileSet::nameChanged);
+
+    ts.setName(QStringLiteral("renamed"));
+    QCOMPARE(spy.count(), 1);
+    QCOMPARE(ts.name(), QStringLiteral("renamed"));
+}
+
+void QGCCachedTileSetTest::_testSetStateEmitsSignals()
+{
+    QGCCachedTileSet ts(QStringLiteral("test"));
+
+    QSignalSpy deletingSpy(&ts, &QGCCachedTileSet::deletingChanged);
+    ts.setDeleting(true);
+    QCOMPARE(deletingSpy.count(), 1);
+    QVERIFY(ts.deleting());
+
+    QSignalSpy downloadingSpy(&ts, &QGCCachedTileSet::downloadingChanged);
+    ts.setDownloading(true);
+    QCOMPARE(downloadingSpy.count(), 1);
+    QVERIFY(ts.downloading());
+
+    QSignalSpy errorSpy(&ts, &QGCCachedTileSet::errorCountChanged);
+    ts.setErrorCount(3);
+    QCOMPARE(errorSpy.count(), 1);
+    QCOMPARE(ts.errorCount(), 3u);
+}
+
+void QGCCachedTileSetTest::_testSetterNoSignalOnSameValue()
+{
+    QGCCachedTileSet ts(QStringLiteral("test"));
+
+    ts.setTotalTileCount(10);
+    ts.setSavedTileCount(5);
+    ts.setTotalTileSize(1000);
+    ts.setSavedTileSize(500);
+    ts.setUniqueTileCount(8);
+    ts.setUniqueTileSize(800);
+    ts.setDeleting(true);
+    ts.setDownloading(true);
+    ts.setErrorCount(2);
+    ts.setName(QStringLiteral("other"));
+    ts.setSelected(true);
+
+    QSignalSpy totalCountSpy(&ts, &QGCCachedTileSet::totalTileCountChanged);
+    QSignalSpy savedCountSpy(&ts, &QGCCachedTileSet::savedTileCountChanged);
+    QSignalSpy totalSizeSpy(&ts, &QGCCachedTileSet::totalTilesSizeChanged);
+    QSignalSpy savedSizeSpy(&ts, &QGCCachedTileSet::savedTileSizeChanged);
+    QSignalSpy uniqueCountSpy(&ts, &QGCCachedTileSet::uniqueTileCountChanged);
+    QSignalSpy uniqueSizeSpy(&ts, &QGCCachedTileSet::uniqueTileSizeChanged);
+    QSignalSpy deletingSpy(&ts, &QGCCachedTileSet::deletingChanged);
+    QSignalSpy downloadingSpy(&ts, &QGCCachedTileSet::downloadingChanged);
+    QSignalSpy errorSpy(&ts, &QGCCachedTileSet::errorCountChanged);
+    QSignalSpy nameSpy(&ts, &QGCCachedTileSet::nameChanged);
+    QSignalSpy selectedSpy(&ts, &QGCCachedTileSet::selectedChanged);
+
+    ts.setTotalTileCount(10);
+    ts.setSavedTileCount(5);
+    ts.setTotalTileSize(1000);
+    ts.setSavedTileSize(500);
+    ts.setUniqueTileCount(8);
+    ts.setUniqueTileSize(800);
+    ts.setDeleting(true);
+    ts.setDownloading(true);
+    ts.setErrorCount(2);
+    ts.setName(QStringLiteral("other"));
+    ts.setSelected(true);
+
+    QCOMPARE(totalCountSpy.count(), 0);
+    QCOMPARE(savedCountSpy.count(), 0);
+    QCOMPARE(totalSizeSpy.count(), 0);
+    QCOMPARE(savedSizeSpy.count(), 0);
+    QCOMPARE(uniqueCountSpy.count(), 0);
+    QCOMPARE(uniqueSizeSpy.count(), 0);
+    QCOMPARE(deletingSpy.count(), 0);
+    QCOMPARE(downloadingSpy.count(), 0);
+    QCOMPARE(errorSpy.count(), 0);
+    QCOMPARE(nameSpy.count(), 0);
+    QCOMPARE(selectedSpy.count(), 0);
+}
+
+void QGCCachedTileSetTest::_testCompleteWhenDefaultSet()
+{
+    QGCCachedTileSet ts(QStringLiteral("test"));
+
+    ts.setTotalTileCount(100);
+    ts.setSavedTileCount(0);
+    QVERIFY(!ts.complete());
+
+    ts.setDefaultSet(true);
+    QVERIFY(ts.complete());
+}
+
+void QGCCachedTileSetTest::_testCompleteWhenAllSaved()
+{
+    QGCCachedTileSet ts(QStringLiteral("test"));
+
+    ts.setTotalTileCount(100);
+    ts.setSavedTileCount(99);
+    QVERIFY(!ts.complete());
+
+    ts.setSavedTileCount(100);
+    QVERIFY(ts.complete());
+
+    ts.setSavedTileCount(101);
+    QVERIFY(ts.complete());
+}
+
+void QGCCachedTileSetTest::_testSetSelectedEmitsSignal()
+{
+    QGCCachedTileSet ts(QStringLiteral("test"));
+    QSignalSpy spy(&ts, &QGCCachedTileSet::selectedChanged);
+
+    ts.setSelected(true);
+    QCOMPARE(spy.count(), 1);
+    QVERIFY(ts.selected());
+
+    ts.setSelected(true);
+    QCOMPARE(spy.count(), 1);
+
+    ts.setSelected(false);
+    QCOMPARE(spy.count(), 2);
+    QVERIFY(!ts.selected());
+}
+
+UT_REGISTER_TEST(QGCCachedTileSetTest, TestLabel::Unit)

--- a/test/QtLocationPlugin/QGCCachedTileSetTest.h
+++ b/test/QtLocationPlugin/QGCCachedTileSetTest.h
@@ -1,0 +1,25 @@
+#pragma once
+
+#include "UnitTest.h"
+
+class QGCCachedTileSetTest : public UnitTest
+{
+    Q_OBJECT
+
+private slots:
+    void _testConstructorSetsName();
+    void _testDefaultPropertyValues();
+    void _testSetMapTypeStr();
+    void _testSetCoordinates();
+    void _testSetZoomAndMetadata();
+    void _testSetTotalTileCountEmitsSignal();
+    void _testSetTotalTileSizeEmitsSignal();
+    void _testSetSavedCountAndSizeEmitSignals();
+    void _testSetUniqueCountAndSizeEmitSignals();
+    void _testSetNameEmitsSignal();
+    void _testSetStateEmitsSignals();
+    void _testSetterNoSignalOnSameValue();
+    void _testCompleteWhenDefaultSet();
+    void _testCompleteWhenAllSaved();
+    void _testSetSelectedEmitsSignal();
+};

--- a/test/QtLocationPlugin/QGCTileCacheDatabaseTest.cc
+++ b/test/QtLocationPlugin/QGCTileCacheDatabaseTest.cc
@@ -1,0 +1,1193 @@
+#include "QGCTileCacheDatabaseTest.h"
+
+#include <QtCore/QDateTime>
+#include <QtCore/QFile>
+#include <QtCore/QSettings>
+#include <QtSql/QSqlDatabase>
+#include <QtSql/QSqlQuery>
+
+#include "QGCCacheTile.h"
+#include "QGCMapUrlEngine.h"
+#include "QGCTile.h"
+#include "QGCTileCacheDatabase.h"
+
+std::unique_ptr<QGCTileCacheDatabase> QGCTileCacheDatabaseTest::_createInitializedDB()
+{
+    auto db = std::make_unique<QGCTileCacheDatabase>(tempPath("tiles.db"));
+    if (!db->init() || !db->connectDB()) {
+        return nullptr;
+    }
+    return db;
+}
+
+void QGCTileCacheDatabaseTest::_insertTileSet(QGCTileCacheDatabase *db, const QString &name, quint64 &outSetID)
+{
+    QSqlQuery query(db->database());
+    QVERIFY(query.prepare("INSERT INTO TileSets(name, date) VALUES(?, ?)"));
+    query.addBindValue(name);
+    query.addBindValue(QDateTime::currentSecsSinceEpoch());
+    QVERIFY(query.exec());
+    outSetID = query.lastInsertId().toULongLong();
+}
+
+void QGCTileCacheDatabaseTest::_insertDownloadRecord(QGCTileCacheDatabase *db, quint64 setID, const QString &hash, int state)
+{
+    QSqlQuery query(db->database());
+    QVERIFY(query.prepare("INSERT OR IGNORE INTO TilesDownload(setID, hash, type, x, y, z, state) VALUES(?, ?, ?, ?, ?, ?, ?)"));
+    query.addBindValue(setID);
+    query.addBindValue(hash);
+    query.addBindValue(0);
+    query.addBindValue(0);
+    query.addBindValue(0);
+    query.addBindValue(1);
+    query.addBindValue(state);
+    QVERIFY(query.exec());
+}
+
+void QGCTileCacheDatabaseTest::_testInitWithValidPath()
+{
+    QGCTileCacheDatabase db(tempPath("tiles.db"));
+    QVERIFY(!db.isValid());
+    QVERIFY(!db.hasFailed());
+
+    QVERIFY(db.init());
+    QVERIFY(db.isValid());
+    QVERIFY(!db.hasFailed());
+}
+
+void QGCTileCacheDatabaseTest::_testInitWithEmptyPath()
+{
+    const QString emptyPath;
+    QGCTileCacheDatabase db(emptyPath);
+    QVERIFY(!db.init());
+    QVERIFY(db.hasFailed());
+    QVERIFY(!db.isValid());
+}
+
+void QGCTileCacheDatabaseTest::_testConnectDisconnect()
+{
+    QGCTileCacheDatabase db(tempPath("tiles.db"));
+    QVERIFY(db.init());
+
+    QVERIFY(db.connectDB());
+    QVERIFY(db.isValid());
+
+    db.disconnectDB();
+
+    QVERIFY(db.connectDB());
+    QVERIFY(db.isValid());
+
+    db.disconnectDB();
+}
+
+void QGCTileCacheDatabaseTest::_testDefaultTileSetCreated()
+{
+    auto db = _createInitializedDB();
+    const auto sets = db->getTileSets();
+    QCOMPARE(sets.size(), 1);
+    QVERIFY(sets[0].defaultSet);
+    QCOMPARE(sets[0].name, QStringLiteral("Default Tile Set"));
+}
+
+void QGCTileCacheDatabaseTest::_testSaveTileAndGetTile()
+{
+    auto db = _createInitializedDB();
+
+    const QString hash = QStringLiteral("test_hash_1234");
+    const QString format = QStringLiteral("png");
+    const QByteArray img("fake_tile_data_bytes");
+    const QStringList providerTypes = UrlFactory::getProviderTypes();
+    QVERIFY(!providerTypes.isEmpty());
+    const QString type = providerTypes.first();
+
+    QVERIFY(db->saveTile(hash, format, img, type, QGCTileCacheDatabase::kInvalidTileSet));
+
+    auto tile = db->getTile(hash);
+    QVERIFY(tile != nullptr);
+    QCOMPARE(tile->hash, hash);
+    QCOMPARE(tile->format, format);
+    QCOMPARE(tile->img, img);
+    QCOMPARE(tile->type, type);
+}
+
+void QGCTileCacheDatabaseTest::_testGetTileNotFound()
+{
+    auto db = _createInitializedDB();
+    auto tile = db->getTile(QStringLiteral("nonexistent_hash"));
+    QVERIFY(tile == nullptr);
+}
+
+void QGCTileCacheDatabaseTest::_testFindTile()
+{
+    auto db = _createInitializedDB();
+
+    const QString hash = QStringLiteral("findme_hash");
+    QVERIFY(db->saveTile(hash, QStringLiteral("png"), QByteArray("data"), QStringLiteral("T"), QGCTileCacheDatabase::kInvalidTileSet));
+
+    const auto id = db->findTile(hash);
+    QVERIFY(id.has_value());
+    QVERIFY(id.value() != 0);
+
+    const auto missing = db->findTile(QStringLiteral("no_such_hash"));
+    QVERIFY(!missing.has_value());
+}
+
+void QGCTileCacheDatabaseTest::_testGetTileSetsMultiple()
+{
+    auto db = _createInitializedDB();
+
+    quint64 customSetID = 0;
+    _insertTileSet(db.get(), QStringLiteral("My Custom Set"), customSetID);
+    QVERIFY(customSetID != 0);
+
+    const auto sets = db->getTileSets();
+    QCOMPARE(sets.size(), 2);
+
+    bool foundDefault = false;
+    bool foundCustom = false;
+    for (const auto &rec : sets) {
+        if (rec.defaultSet) foundDefault = true;
+        if (rec.name == QStringLiteral("My Custom Set")) foundCustom = true;
+    }
+    QVERIFY(foundDefault);
+    QVERIFY(foundCustom);
+}
+
+void QGCTileCacheDatabaseTest::_testRenameTileSet()
+{
+    auto db = _createInitializedDB();
+
+    quint64 setID = 0;
+    _insertTileSet(db.get(), QStringLiteral("Original Name"), setID);
+
+    QVERIFY(db->renameTileSet(setID, QStringLiteral("New Name")));
+
+    const auto foundID = db->findTileSetID(QStringLiteral("New Name"));
+    QVERIFY(foundID.has_value());
+    QCOMPARE(foundID.value(), setID);
+}
+
+void QGCTileCacheDatabaseTest::_testFindTileSetID()
+{
+    auto db = _createInitializedDB();
+
+    const auto foundID = db->findTileSetID(QStringLiteral("Default Tile Set"));
+    QVERIFY(foundID.has_value());
+    QVERIFY(foundID.value() != 0);
+
+    const auto missingID = db->findTileSetID(QStringLiteral("No Such Set"));
+    QVERIFY(!missingID.has_value());
+}
+
+void QGCTileCacheDatabaseTest::_testDeleteTileSet()
+{
+    auto db = _createInitializedDB();
+
+    quint64 setID = 0;
+    _insertTileSet(db.get(), QStringLiteral("ToDelete"), setID);
+    QCOMPARE(db->getTileSets().size(), 2);
+
+    QVERIFY(db->deleteTileSet(setID));
+
+    const auto sets = db->getTileSets();
+    QCOMPARE(sets.size(), 1);
+    QVERIFY(sets[0].defaultSet);
+}
+
+void QGCTileCacheDatabaseTest::_testResetDatabase()
+{
+    auto db = _createInitializedDB();
+
+    QVERIFY(db->saveTile(QStringLiteral("h1"), QStringLiteral("png"), QByteArray("d1"), QStringLiteral("T"), QGCTileCacheDatabase::kInvalidTileSet));
+    QVERIFY(db->findTile(QStringLiteral("h1")).has_value());
+
+    QVERIFY(db->resetDatabase());
+    QVERIFY(db->isValid());
+
+    QVERIFY(!db->findTile(QStringLiteral("h1")).has_value());
+
+    const auto sets = db->getTileSets();
+    QCOMPARE(sets.size(), 1);
+    QVERIFY(sets[0].defaultSet);
+}
+
+void QGCTileCacheDatabaseTest::_testComputeTotals()
+{
+    auto db = _createInitializedDB();
+
+    const QByteArray data10(10, 'A');
+    const QByteArray data20(20, 'B');
+    QVERIFY(db->saveTile(QStringLiteral("ct1"), QStringLiteral("png"), data10, QStringLiteral("T"), QGCTileCacheDatabase::kInvalidTileSet));
+    QVERIFY(db->saveTile(QStringLiteral("ct2"), QStringLiteral("png"), data20, QStringLiteral("T"), QGCTileCacheDatabase::kInvalidTileSet));
+
+    const TotalsResult totals = db->computeTotals();
+    QCOMPARE(totals.totalCount, static_cast<quint32>(2));
+    QCOMPARE(totals.totalSize, static_cast<quint64>(30));
+    QCOMPARE(totals.defaultCount, static_cast<quint32>(2));
+    QCOMPARE(totals.defaultSize, static_cast<quint64>(30));
+}
+
+void QGCTileCacheDatabaseTest::_testComputeSetTotalsDefault()
+{
+    auto db = _createInitializedDB();
+
+    const QByteArray data(15, 'X');
+    QVERIFY(db->saveTile(QStringLiteral("sd1"), QStringLiteral("png"), data, QStringLiteral("T"), QGCTileCacheDatabase::kInvalidTileSet));
+
+    const auto defaultSetID = db->findTileSetID(QStringLiteral("Default Tile Set"));
+    QVERIFY(defaultSetID.has_value());
+
+    const SetTotalsResult result = db->computeSetTotals(defaultSetID.value(), true, 0, QStringLiteral("T"));
+    QCOMPARE(result.savedTileCount, static_cast<quint32>(1));
+    QCOMPARE(result.savedTileSize, static_cast<quint64>(15));
+}
+
+void QGCTileCacheDatabaseTest::_testPruneCache()
+{
+    auto db = _createInitializedDB();
+
+    const QByteArray data(100, 'Z');
+    QVERIFY(db->saveTile(QStringLiteral("pr1"), QStringLiteral("png"), data, QStringLiteral("T"), QGCTileCacheDatabase::kInvalidTileSet));
+    QVERIFY(db->saveTile(QStringLiteral("pr2"), QStringLiteral("png"), data, QStringLiteral("T"), QGCTileCacheDatabase::kInvalidTileSet));
+
+    QVERIFY(db->findTile(QStringLiteral("pr1")).has_value());
+
+    QVERIFY(db->pruneCache(200));
+
+    QVERIFY(!db->findTile(QStringLiteral("pr1")).has_value());
+    QVERIFY(!db->findTile(QStringLiteral("pr2")).has_value());
+}
+
+void QGCTileCacheDatabaseTest::_testUpdateTileDownloadState()
+{
+    auto db = _createInitializedDB();
+
+    const auto defaultSetID = db->findTileSetID(QStringLiteral("Default Tile Set"));
+    QVERIFY(defaultSetID.has_value());
+
+    _insertDownloadRecord(db.get(), defaultSetID.value(), QStringLiteral("dl_hash_1"), QGCTile::StatePending);
+    _insertDownloadRecord(db.get(), defaultSetID.value(), QStringLiteral("dl_hash_2"), QGCTile::StatePending);
+
+    QVERIFY(db->updateTileDownloadState(defaultSetID.value(), QGCTile::StateDownloading, QStringLiteral("dl_hash_1")));
+
+    {
+        QSqlQuery query(db->database());
+        QVERIFY(query.prepare(QStringLiteral("SELECT state FROM TilesDownload WHERE hash = ?")));
+        query.addBindValue(QStringLiteral("dl_hash_1"));
+        QVERIFY(query.exec());
+        QVERIFY(query.next());
+        QCOMPARE(query.value(0).toInt(), static_cast<int>(QGCTile::StateDownloading));
+    }
+
+    QVERIFY(db->updateTileDownloadState(defaultSetID.value(), QGCTile::StateComplete, QStringLiteral("dl_hash_1")));
+
+    {
+        QSqlQuery query(db->database());
+        QVERIFY(query.prepare(QStringLiteral("SELECT COUNT(*) FROM TilesDownload WHERE hash = ?")));
+        query.addBindValue(QStringLiteral("dl_hash_1"));
+        QVERIFY(query.exec());
+        QVERIFY(query.next());
+        QCOMPARE(query.value(0).toInt(), 0);
+    }
+
+    QVERIFY(db->updateAllTileDownloadStates(defaultSetID.value(), QGCTile::StateError));
+
+    {
+        QSqlQuery query(db->database());
+        QVERIFY(query.prepare(QStringLiteral("SELECT state FROM TilesDownload WHERE hash = ?")));
+        query.addBindValue(QStringLiteral("dl_hash_2"));
+        QVERIFY(query.exec());
+        QVERIFY(query.next());
+        QCOMPARE(query.value(0).toInt(), static_cast<int>(QGCTile::StateError));
+    }
+}
+
+void QGCTileCacheDatabaseTest::_testExportImportReplace()
+{
+    auto db = _createInitializedDB();
+
+    const QByteArray data(50, 'E');
+    QVERIFY(db->saveTile(QStringLiteral("exp1"), QStringLiteral("png"), data, QStringLiteral("T"), QGCTileCacheDatabase::kInvalidTileSet));
+    QVERIFY(db->saveTile(QStringLiteral("exp2"), QStringLiteral("png"), data, QStringLiteral("T"), QGCTileCacheDatabase::kInvalidTileSet));
+
+    const auto sets = db->getTileSets();
+    QVERIFY(!sets.isEmpty());
+
+    TileSetRecord defaultRec = sets[0];
+    defaultRec.numTiles = 2;
+
+    const QString exportPath = tempPath("export.db");
+    int lastProgress = 0;
+    auto progressCb = [&lastProgress](int p) { lastProgress = p; };
+
+    const DatabaseResult exportResult = db->exportSets({defaultRec}, exportPath, progressCb);
+    QVERIFY(exportResult.success);
+    QVERIFY(lastProgress > 0);
+
+    db.reset();
+
+    auto db2 = std::make_unique<QGCTileCacheDatabase>(tempPath("tiles2.db"));
+    QVERIFY(db2->init());
+    QVERIFY(db2->connectDB());
+
+    QVERIFY(!db2->findTile(QStringLiteral("exp1")).has_value());
+
+    const DatabaseResult importResult = db2->importSetsReplace(exportPath, nullptr);
+    QVERIFY(importResult.success);
+    QVERIFY(db2->isValid());
+
+    QVERIFY(db2->findTile(QStringLiteral("exp1")).has_value());
+    QVERIFY(db2->findTile(QStringLiteral("exp2")).has_value());
+}
+
+void QGCTileCacheDatabaseTest::_linkTileToSet(QGCTileCacheDatabase *db, quint64 tileID, quint64 setID)
+{
+    QSqlQuery query(db->database());
+    QVERIFY(query.prepare("INSERT OR IGNORE INTO SetTiles(tileID, setID) VALUES(?, ?)"));
+    query.addBindValue(tileID);
+    query.addBindValue(setID);
+    QVERIFY(query.exec());
+}
+
+void QGCTileCacheDatabaseTest::_testGetTileDownloadList()
+{
+    auto db = _createInitializedDB();
+
+    const auto defaultSetID = db->findTileSetID(QStringLiteral("Default Tile Set"));
+    QVERIFY(defaultSetID.has_value());
+
+    _insertDownloadRecord(db.get(), defaultSetID.value(), QStringLiteral("dl_a"), QGCTile::StatePending);
+    _insertDownloadRecord(db.get(), defaultSetID.value(), QStringLiteral("dl_b"), QGCTile::StatePending);
+    _insertDownloadRecord(db.get(), defaultSetID.value(), QStringLiteral("dl_c"), QGCTile::StatePending);
+
+    const QList<QGCTile> tiles = db->getTileDownloadList(defaultSetID.value(), 2);
+    QCOMPARE(tiles.size(), 2);
+
+    QStringList hashes;
+    for (const auto &t : tiles) {
+        hashes.append(t.hash);
+    }
+    QVERIFY(hashes.contains(QStringLiteral("dl_a")));
+    QVERIFY(hashes.contains(QStringLiteral("dl_b")));
+
+    {
+        QSqlQuery query(db->database());
+        QVERIFY(query.exec(QStringLiteral("SELECT state FROM TilesDownload WHERE hash = 'dl_a'")));
+        QVERIFY(query.next());
+        QCOMPARE(query.value(0).toInt(), static_cast<int>(QGCTile::StateDownloading));
+    }
+    {
+        QSqlQuery query(db->database());
+        QVERIFY(query.exec(QStringLiteral("SELECT state FROM TilesDownload WHERE hash = 'dl_b'")));
+        QVERIFY(query.next());
+        QCOMPARE(query.value(0).toInt(), static_cast<int>(QGCTile::StateDownloading));
+    }
+    {
+        QSqlQuery query(db->database());
+        QVERIFY(query.exec(QStringLiteral("SELECT state FROM TilesDownload WHERE hash = 'dl_c'")));
+        QVERIFY(query.next());
+        QCOMPARE(query.value(0).toInt(), static_cast<int>(QGCTile::StatePending));
+    }
+}
+
+void QGCTileCacheDatabaseTest::_testImportSetsMerge()
+{
+    auto dbSrc = _createInitializedDB();
+
+    const QByteArray data(40, 'M');
+    QVERIFY(dbSrc->saveTile(QStringLiteral("exp_m1"), QStringLiteral("png"), data, QStringLiteral("T"), QGCTileCacheDatabase::kInvalidTileSet));
+    QVERIFY(dbSrc->saveTile(QStringLiteral("exp_m2"), QStringLiteral("png"), data, QStringLiteral("T"), QGCTileCacheDatabase::kInvalidTileSet));
+
+    const auto srcSets = dbSrc->getTileSets();
+    QVERIFY(!srcSets.isEmpty());
+    TileSetRecord srcRec = srcSets[0];
+    srcRec.numTiles = 2;
+
+    const QString exportPath = tempPath("merge_export.db");
+    const DatabaseResult exportResult = dbSrc->exportSets({srcRec}, exportPath, nullptr);
+    QVERIFY(exportResult.success);
+    dbSrc.reset();
+
+    auto dbTgt = std::make_unique<QGCTileCacheDatabase>(tempPath("merge_target.db"));
+    QVERIFY(dbTgt->init());
+    QVERIFY(dbTgt->connectDB());
+
+    QVERIFY(dbTgt->saveTile(QStringLiteral("trg_m1"), QStringLiteral("png"), QByteArray(25, 'N'), QStringLiteral("T"), QGCTileCacheDatabase::kInvalidTileSet));
+
+    int lastProgress = 0;
+    auto progressCb = [&lastProgress](int p) { lastProgress = p; };
+
+    const DatabaseResult importResult = dbTgt->importSetsMerge(exportPath, progressCb);
+    QVERIFY(importResult.success);
+    QVERIFY(lastProgress > 0);
+
+    QVERIFY(dbTgt->findTile(QStringLiteral("trg_m1")).has_value());
+    QVERIFY(dbTgt->findTile(QStringLiteral("exp_m1")).has_value());
+    QVERIFY(dbTgt->findTile(QStringLiteral("exp_m2")).has_value());
+}
+
+void QGCTileCacheDatabaseTest::_testComputeSetTotalsNonDefault()
+{
+    auto db = _createInitializedDB();
+
+    quint64 customSetID = 0;
+    _insertTileSet(db.get(), QStringLiteral("Stats Set"), customSetID);
+    QVERIFY(customSetID != 0);
+
+    const QByteArray data20(20, 'A');
+    const QByteArray data30(30, 'B');
+    QVERIFY(db->saveTile(QStringLiteral("st1"), QStringLiteral("png"), data20, QStringLiteral("T"), QGCTileCacheDatabase::kInvalidTileSet));
+    QVERIFY(db->saveTile(QStringLiteral("st2"), QStringLiteral("png"), data30, QStringLiteral("T"), QGCTileCacheDatabase::kInvalidTileSet));
+
+    const auto tile1 = db->findTile(QStringLiteral("st1"));
+    const auto tile2 = db->findTile(QStringLiteral("st2"));
+    QVERIFY(tile1.has_value());
+    QVERIFY(tile2.has_value());
+
+    _linkTileToSet(db.get(), tile1.value(), customSetID);
+    _linkTileToSet(db.get(), tile2.value(), customSetID);
+
+    const SetTotalsResult result = db->computeSetTotals(customSetID, false, 5, QStringLiteral("T"));
+    QCOMPARE(result.savedTileCount, static_cast<quint32>(2));
+    QCOMPARE(result.savedTileSize, static_cast<quint64>(50));
+}
+
+void QGCTileCacheDatabaseTest::_testSaveDuplicateTile()
+{
+    auto db = _createInitializedDB();
+
+    const QByteArray data1(10, 'X');
+    const QByteArray data2(10, 'Y');
+
+    QVERIFY(db->saveTile(QStringLiteral("dup_hash"), QStringLiteral("png"), data1, QStringLiteral("T"), QGCTileCacheDatabase::kInvalidTileSet));
+    // Second save with same hash succeeds (links existing tile to same set via OR IGNORE)
+    QVERIFY(db->saveTile(QStringLiteral("dup_hash"), QStringLiteral("png"), data2, QStringLiteral("T"), QGCTileCacheDatabase::kInvalidTileSet));
+
+    auto tile = db->getTile(QStringLiteral("dup_hash"));
+    QVERIFY(tile != nullptr);
+    QCOMPARE(tile->img, data1);
+}
+
+void QGCTileCacheDatabaseTest::_testOperationsAfterDisconnect()
+{
+    auto db = _createInitializedDB();
+    db->disconnectDB();
+
+    QVERIFY(!db->saveTile(QStringLiteral("x"), QStringLiteral("png"), QByteArray("d"), QStringLiteral("T"), QGCTileCacheDatabase::kInvalidTileSet));
+    QVERIFY(db->getTile(QStringLiteral("x")) == nullptr);
+    QVERIFY(!db->findTile(QStringLiteral("x")).has_value());
+    QVERIFY(db->getTileSets().isEmpty());
+
+    const TotalsResult totals = db->computeTotals();
+    QCOMPARE(totals.totalCount, static_cast<quint32>(0));
+    QCOMPARE(totals.totalSize, static_cast<quint64>(0));
+
+    QVERIFY(!db->pruneCache(100));
+    QVERIFY(!db->resetDatabase());
+}
+
+void QGCTileCacheDatabaseTest::_testPruneCacheCleansSetTiles()
+{
+    auto db = _createInitializedDB();
+
+    const QByteArray data(100, 'P');
+    QVERIFY(db->saveTile(QStringLiteral("ps1"), QStringLiteral("png"), data, QStringLiteral("T"), QGCTileCacheDatabase::kInvalidTileSet));
+    QVERIFY(db->saveTile(QStringLiteral("ps2"), QStringLiteral("png"), data, QStringLiteral("T"), QGCTileCacheDatabase::kInvalidTileSet));
+
+    {
+        QSqlQuery query(db->database());
+        QVERIFY(query.exec(QStringLiteral("SELECT COUNT(*) FROM SetTiles")));
+        QVERIFY(query.next());
+        QVERIFY(query.value(0).toInt() >= 2);
+    }
+
+    QVERIFY(db->pruneCache(200));
+
+    {
+        QSqlQuery query(db->database());
+        QVERIFY(query.exec(QStringLiteral("SELECT COUNT(*) FROM SetTiles")));
+        QVERIFY(query.next());
+        QCOMPARE(query.value(0).toInt(), 0);
+    }
+
+    QVERIFY(!db->findTile(QStringLiteral("ps1")).has_value());
+    QVERIFY(!db->findTile(QStringLiteral("ps2")).has_value());
+}
+
+void QGCTileCacheDatabaseTest::_testDeleteTileSetCleansTiles()
+{
+    auto db = _createInitializedDB();
+
+    quint64 setID = 0;
+    _insertTileSet(db.get(), QStringLiteral("CleanupSet"), setID);
+    QVERIFY(setID != 0);
+
+    QVERIFY(db->saveTile(QStringLiteral("cleanup1"), QStringLiteral("png"), QByteArray(50, 'C'), QStringLiteral("T"), setID));
+
+    QVERIFY(db->findTile(QStringLiteral("cleanup1")).has_value());
+
+    QVERIFY(db->deleteTileSet(setID));
+
+    QVERIFY(!db->findTile(QStringLiteral("cleanup1")).has_value());
+
+    {
+        QSqlQuery query(db->database());
+        QVERIFY(query.prepare(QStringLiteral("SELECT COUNT(*) FROM SetTiles WHERE setID = ?")));
+        query.addBindValue(setID);
+        QVERIFY(query.exec());
+        QVERIFY(query.next());
+        QCOMPARE(query.value(0).toInt(), 0);
+    }
+}
+
+void QGCTileCacheDatabaseTest::_testImportSetsMergeDeduplicatesName()
+{
+    auto dbSrc = _createInitializedDB();
+
+    quint64 customSetID = 0;
+    _insertTileSet(dbSrc.get(), QStringLiteral("SharedName"), customSetID);
+    QVERIFY(customSetID != 0);
+
+    QVERIFY(dbSrc->saveTile(QStringLiteral("dedup_tile1"), QStringLiteral("png"), QByteArray(30, 'D'), QStringLiteral("T"), QGCTileCacheDatabase::kInvalidTileSet));
+    const auto tileID = dbSrc->findTile(QStringLiteral("dedup_tile1"));
+    QVERIFY(tileID.has_value());
+    _linkTileToSet(dbSrc.get(), tileID.value(), customSetID);
+
+    const auto srcSets = dbSrc->getTileSets();
+    TileSetRecord customRec;
+    for (const auto &rec : srcSets) {
+        if (rec.name == QStringLiteral("SharedName")) {
+            customRec = rec;
+            customRec.numTiles = 1;
+            break;
+        }
+    }
+    QVERIFY(customRec.setID != 0);
+
+    const QString exportPath = tempPath("dedup_export.db");
+    const DatabaseResult exportResult = dbSrc->exportSets({customRec}, exportPath, nullptr);
+    QVERIFY(exportResult.success);
+    dbSrc.reset();
+
+    auto dbTgt = std::make_unique<QGCTileCacheDatabase>(tempPath("dedup_target.db"));
+    QVERIFY(dbTgt->init());
+    QVERIFY(dbTgt->connectDB());
+
+    quint64 existingSetID = 0;
+    _insertTileSet(dbTgt.get(), QStringLiteral("SharedName"), existingSetID);
+    QVERIFY(existingSetID != 0);
+
+    const DatabaseResult importResult = dbTgt->importSetsMerge(exportPath, nullptr);
+    QVERIFY(importResult.success);
+
+    const auto targetSets = dbTgt->getTileSets();
+    bool foundOriginal = false;
+    bool foundDeduped = false;
+    for (const auto &rec : targetSets) {
+        if (rec.name == QStringLiteral("SharedName")) foundOriginal = true;
+        if (rec.name == QStringLiteral("SharedName 0001")) foundDeduped = true;
+    }
+    QVERIFY(foundOriginal);
+    QVERIFY(foundDeduped);
+}
+
+void QGCTileCacheDatabaseTest::_testGetTileDownloadListBatch()
+{
+    auto db = _createInitializedDB();
+
+    const auto defaultSetID = db->findTileSetID(QStringLiteral("Default Tile Set"));
+    QVERIFY(defaultSetID.has_value());
+
+    for (int i = 0; i < 10; i++) {
+        _insertDownloadRecord(db.get(), defaultSetID.value(), QStringLiteral("batch_dl_%1").arg(i), QGCTile::StatePending);
+    }
+
+    const QList<QGCTile> tiles = db->getTileDownloadList(defaultSetID.value(), 5);
+    QCOMPARE(tiles.size(), 5);
+
+    {
+        QSqlQuery query(db->database());
+        QVERIFY(query.prepare(QStringLiteral("SELECT COUNT(*) FROM TilesDownload WHERE setID = ? AND state = ?")));
+        query.addBindValue(defaultSetID.value());
+        query.addBindValue(static_cast<int>(QGCTile::StateDownloading));
+        QVERIFY(query.exec());
+        QVERIFY(query.next());
+        QCOMPARE(query.value(0).toInt(), 5);
+    }
+    {
+        QSqlQuery query(db->database());
+        QVERIFY(query.prepare(QStringLiteral("SELECT COUNT(*) FROM TilesDownload WHERE setID = ? AND state = ?")));
+        query.addBindValue(defaultSetID.value());
+        query.addBindValue(static_cast<int>(QGCTile::StatePending));
+        QVERIFY(query.exec());
+        QVERIFY(query.next());
+        QCOMPARE(query.value(0).toInt(), 5);
+    }
+}
+
+void QGCTileCacheDatabaseTest::_testSaveTileLinksToDifferentSet()
+{
+    auto db = _createInitializedDB();
+
+    quint64 setA = 0, setB = 0;
+    _insertTileSet(db.get(), QStringLiteral("SetA"), setA);
+    _insertTileSet(db.get(), QStringLiteral("SetB"), setB);
+
+    const QByteArray data(10, 'A');
+    QVERIFY(db->saveTile(QStringLiteral("shared_hash"), QStringLiteral("png"), data, QStringLiteral("T"), setA));
+    QVERIFY(db->saveTile(QStringLiteral("shared_hash"), QStringLiteral("png"), data, QStringLiteral("T"), setB));
+
+    auto tile = db->getTile(QStringLiteral("shared_hash"));
+    QVERIFY(tile != nullptr);
+    QCOMPARE(tile->img, data);
+
+    const auto tileID = db->findTile(QStringLiteral("shared_hash"));
+    QVERIFY(tileID.has_value());
+
+    {
+        QSqlQuery query(db->database());
+        QVERIFY(query.prepare(QStringLiteral("SELECT COUNT(*) FROM SetTiles WHERE tileID = ?")));
+        query.addBindValue(tileID.value());
+        QVERIFY(query.exec());
+        QVERIFY(query.next());
+        QCOMPARE(query.value(0).toInt(), 2);
+    }
+}
+
+void QGCTileCacheDatabaseTest::_testExportImportNoLingeringConnections()
+{
+    auto db1 = _createInitializedDB();
+
+    const QByteArray data(20, 'L');
+    QVERIFY(db1->saveTile(QStringLiteral("linger1"), QStringLiteral("png"), data, QStringLiteral("T"), QGCTileCacheDatabase::kInvalidTileSet));
+
+    const auto sets = db1->getTileSets();
+    QVERIFY(!sets.isEmpty());
+    TileSetRecord rec = sets[0];
+    rec.numTiles = 1;
+
+    const QString exportPath = tempPath("linger_export.db");
+
+    const DatabaseResult exp1 = db1->exportSets({rec}, exportPath, nullptr);
+    QVERIFY(exp1.success);
+
+    const DatabaseResult exp2 = db1->exportSets({rec}, exportPath, nullptr);
+    QVERIFY(exp2.success);
+
+    auto db2 = std::make_unique<QGCTileCacheDatabase>(tempPath("linger_db2.db"));
+    QVERIFY(db2->init());
+    QVERIFY(db2->connectDB());
+    const DatabaseResult imp1 = db2->importSetsMerge(exportPath, nullptr);
+    QVERIFY(imp1.success);
+
+    auto db3 = std::make_unique<QGCTileCacheDatabase>(tempPath("linger_db3.db"));
+    QVERIFY(db3->init());
+    QVERIFY(db3->connectDB());
+    const DatabaseResult imp2 = db3->importSetsMerge(exportPath, nullptr);
+    QVERIFY(imp2.success);
+}
+
+void QGCTileCacheDatabaseTest::_testCreateTileSet()
+{
+    auto db = _createInitializedDB();
+
+    const QStringList providerTypes = UrlFactory::getProviderTypes();
+    QVERIFY(!providerTypes.isEmpty());
+    const QString providerType = providerTypes.first();
+
+    const auto setID = db->createTileSet(
+        QStringLiteral("Test Set"), QStringLiteral("TestMap"),
+        37.0, -122.0, 36.0, -121.0,
+        5, 5, providerType, 100);
+
+    QVERIFY(setID.has_value());
+    QVERIFY(setID.value() != 0);
+
+    const auto foundID = db->findTileSetID(QStringLiteral("Test Set"));
+    QVERIFY(foundID.has_value());
+    QCOMPARE(foundID.value(), setID.value());
+
+    const auto sets = db->getTileSets();
+    bool found = false;
+    for (const auto &rec : sets) {
+        if (rec.setID == setID.value()) {
+            found = true;
+            QCOMPARE(rec.name, QStringLiteral("Test Set"));
+            QCOMPARE(rec.minZoom, 5);
+            QCOMPARE(rec.maxZoom, 5);
+            break;
+        }
+    }
+    QVERIFY(found);
+}
+
+void QGCTileCacheDatabaseTest::_testDeleteBingNoTileTiles()
+{
+    auto db = _createInitializedDB();
+
+    QFile file(QStringLiteral(":/res/BingNoTileBytes.dat"));
+    if (!file.open(QFile::ReadOnly)) {
+        QSKIP("BingNoTileBytes.dat resource not available");
+    }
+    const QByteArray noTileBytes = file.readAll();
+    file.close();
+    QVERIFY(!noTileBytes.isEmpty());
+
+    QVERIFY(db->saveTile(QStringLiteral("bing_notile_1"), QStringLiteral("png"), noTileBytes, QStringLiteral("T"), QGCTileCacheDatabase::kInvalidTileSet));
+    QVERIFY(db->saveTile(QStringLiteral("normal_tile"), QStringLiteral("png"), QByteArray(50, 'N'), QStringLiteral("T"), QGCTileCacheDatabase::kInvalidTileSet));
+
+    QVERIFY(db->findTile(QStringLiteral("bing_notile_1")).has_value());
+    QVERIFY(db->findTile(QStringLiteral("normal_tile")).has_value());
+
+    QSettings settings;
+    settings.remove(QStringLiteral("_deleteBingNoTileTilesDone"));
+
+    db->deleteBingNoTileTiles();
+
+    QVERIFY(!db->findTile(QStringLiteral("bing_notile_1")).has_value());
+    QVERIFY(db->findTile(QStringLiteral("normal_tile")).has_value());
+}
+
+void QGCTileCacheDatabaseTest::_testDeleteDefaultSetInvalidatesCache()
+{
+    auto db = _createInitializedDB();
+
+    const auto defaultID = db->findTileSetID(QStringLiteral("Default Tile Set"));
+    QVERIFY(defaultID.has_value());
+
+    QVERIFY(db->deleteTileSet(defaultID.value()));
+
+    // After deleting default set, saveTile with kInvalidTileSet should fail gracefully
+    // (no default set to link to), not crash or use stale ID
+    QVERIFY(!db->saveTile(QStringLiteral("orphan"), QStringLiteral("png"), QByteArray(10, 'O'),
+                           QStringLiteral("T"), QGCTileCacheDatabase::kInvalidTileSet));
+}
+
+void QGCTileCacheDatabaseTest::_testPruneCacheMultipleBatches()
+{
+    auto db = _createInitializedDB();
+
+    // Save 200 tiles of 100 bytes each = 20000 bytes total
+    for (int i = 0; i < 200; i++) {
+        QVERIFY(db->saveTile(QStringLiteral("prune_multi_%1").arg(i), QStringLiteral("png"),
+                              QByteArray(100, 'P'), QStringLiteral("T"), QGCTileCacheDatabase::kInvalidTileSet));
+    }
+
+    const TotalsResult before = db->computeTotals();
+    QCOMPARE(before.totalCount, static_cast<quint32>(200));
+
+    // Prune 15000 bytes — requires more than one batch of 128
+    QVERIFY(db->pruneCache(15000));
+
+    const TotalsResult after = db->computeTotals();
+    QVERIFY(after.totalCount < 200);
+    QVERIFY(after.totalSize <= 5000);
+}
+
+void QGCTileCacheDatabaseTest::_testSchemaVersionSetOnFreshDB()
+{
+    auto db = _createInitializedDB();
+
+    QSqlQuery query(db->database());
+    QVERIFY(query.exec("PRAGMA user_version"));
+    QVERIFY(query.next());
+    QCOMPARE(query.value(0).toInt(), QGCTileCacheDatabase::kSchemaVersion);
+}
+
+void QGCTileCacheDatabaseTest::_testSchemaVersionResetsLegacyDB()
+{
+    const QString path = tempPath("legacy.db");
+
+    // Create a legacy database (no user_version set, but has tile data)
+    {
+        QSqlDatabase legacy = QSqlDatabase::addDatabase("QSQLITE", "legacy_setup");
+        legacy.setDatabaseName(path);
+        QVERIFY(legacy.open());
+        QSqlQuery q(legacy);
+        QVERIFY(q.exec("CREATE TABLE Tiles (tileID INTEGER PRIMARY KEY, hash TEXT UNIQUE, format TEXT, tile BLOB, size INTEGER, type INTEGER, date INTEGER)"));
+        QVERIFY(q.exec("CREATE TABLE TileSets (setID INTEGER PRIMARY KEY, name TEXT UNIQUE, typeStr TEXT, topleftLat REAL, topleftLon REAL, bottomRightLat REAL, bottomRightLon REAL, minZoom INTEGER, maxZoom INTEGER, type INTEGER, numTiles INTEGER, defaultSet INTEGER, date INTEGER)"));
+        QVERIFY(q.exec("CREATE TABLE SetTiles (setID INTEGER, tileID INTEGER)"));
+        QVERIFY(q.exec("CREATE TABLE TilesDownload (setID INTEGER, hash TEXT, type INTEGER, x INTEGER, y INTEGER, z INTEGER, state INTEGER)"));
+        QVERIFY(q.exec("INSERT INTO TileSets(name, defaultSet, date) VALUES('Default Tile Set', 1, 0)"));
+        QVERIFY(q.exec("INSERT INTO Tiles(hash, format, tile, size, type, date) VALUES('old_hash', 'png', X'AA', 1, 0, 0)"));
+        QVERIFY(q.exec("INSERT INTO SetTiles(setID, tileID) VALUES(1, 1)"));
+        legacy.close();
+    }
+    QSqlDatabase::removeDatabase("legacy_setup");
+
+    // Open with the versioned code — should detect legacy and reset
+    QGCTileCacheDatabase db(path);
+    QVERIFY(db.init());
+    QVERIFY(db.connectDB());
+
+    // Legacy tile data should be gone
+    QVERIFY(!db.findTile(QStringLiteral("old_hash")).has_value());
+
+    // Schema version should now be set
+    QSqlQuery query(db.database());
+    QVERIFY(query.exec("PRAGMA user_version"));
+    QVERIFY(query.next());
+    QCOMPARE(query.value(0).toInt(), QGCTileCacheDatabase::kSchemaVersion);
+
+    // Default tile set should be recreated
+    const auto sets = db.getTileSets();
+    QCOMPARE(sets.size(), 1);
+    QVERIFY(sets[0].defaultSet);
+}
+
+void QGCTileCacheDatabaseTest::_testSaveTileTypeStoredAsInteger()
+{
+    auto db = _createInitializedDB();
+
+    const QStringList providerTypes = UrlFactory::getProviderTypes();
+    QVERIFY(!providerTypes.isEmpty());
+    const QString type = providerTypes.first();
+    const int expectedMapId = UrlFactory::getQtMapIdFromProviderType(type);
+    QVERIFY(expectedMapId != -1);
+
+    const QString hash = QStringLiteral("type_int_test");
+    QVERIFY(db->saveTile(hash, QStringLiteral("png"), QByteArray("data"), type, QGCTileCacheDatabase::kInvalidTileSet));
+
+    // Verify the raw DB stores the type as an integer mapId, not a string
+    {
+        QSqlQuery query(db->database());
+        QVERIFY(query.prepare("SELECT type FROM Tiles WHERE hash = ?"));
+        query.addBindValue(hash);
+        QVERIFY(query.exec());
+        QVERIFY(query.next());
+        QCOMPARE(query.value(0).toInt(), expectedMapId);
+    }
+
+    // Verify getTile converts the integer back to the provider name string
+    auto tile = db->getTile(hash);
+    QVERIFY(tile != nullptr);
+    QCOMPARE(tile->type, type);
+}
+
+void QGCTileCacheDatabaseTest::_testCreateTileSetTypeStoredAsInteger()
+{
+    auto db = _createInitializedDB();
+
+    const QStringList providerTypes = UrlFactory::getProviderTypes();
+    QVERIFY(!providerTypes.isEmpty());
+    const QString providerType = providerTypes.first();
+    const int expectedMapId = UrlFactory::getQtMapIdFromProviderType(providerType);
+    QVERIFY(expectedMapId != -1);
+
+    const auto setID = db->createTileSet(
+        QStringLiteral("TypeInt Set"), QStringLiteral("TestMap"),
+        37.0, -122.0, 36.0, -121.0,
+        5, 5, providerType, 100);
+    QVERIFY(setID.has_value());
+
+    // Verify TileSets.type stores the integer mapId
+    const auto sets = db->getTileSets();
+    bool found = false;
+    for (const auto &rec : sets) {
+        if (rec.setID == setID.value()) {
+            found = true;
+            QCOMPARE(rec.type, expectedMapId);
+            break;
+        }
+    }
+    QVERIFY(found);
+}
+
+void QGCTileCacheDatabaseTest::_testTablesExist()
+{
+    auto db = _createInitializedDB();
+    QVERIFY(db);
+
+    QSqlQuery query(db->database());
+    QVERIFY(query.exec("SELECT name FROM sqlite_master WHERE type='table' AND name NOT LIKE 'sqlite_%' ORDER BY name"));
+
+    QStringList tables;
+    while (query.next()) {
+        tables << query.value(0).toString();
+    }
+
+    const QStringList expected = {
+        QStringLiteral("SetTiles"),
+        QStringLiteral("Tiles"),
+        QStringLiteral("TilesDownload"),
+        QStringLiteral("TileSets"),
+    };
+    QCOMPARE(tables.size(), expected.size());
+    for (const auto &name : expected) {
+        QVERIFY2(tables.contains(name), qPrintable(QStringLiteral("Missing table: %1").arg(name)));
+    }
+}
+
+void QGCTileCacheDatabaseTest::_testTilesTableColumns()
+{
+    auto db = _createInitializedDB();
+    QVERIFY(db);
+
+    QSqlQuery query(db->database());
+    QVERIFY(query.exec("PRAGMA table_info(Tiles)"));
+
+    struct ColInfo { QString name; QString type; bool notnull; QString dflt; bool pk; };
+    QList<ColInfo> cols;
+    while (query.next()) {
+        cols.append({
+            query.value(1).toString(),
+            query.value(2).toString(),
+            query.value(3).toBool(),
+            query.value(4).toString(),
+            query.value(5).toBool()
+        });
+    }
+
+    QCOMPARE(cols.size(), 7);
+
+    auto findCol = [&](const QString &name) -> const ColInfo* {
+        for (const auto &c : cols) { if (c.name == name) return &c; }
+        return nullptr;
+    };
+
+    const ColInfo *c = findCol(QStringLiteral("tileID"));
+    QVERIFY(c); QCOMPARE(c->type, QStringLiteral("INTEGER")); QVERIFY(c->pk); QVERIFY(c->notnull);
+
+    c = findCol(QStringLiteral("hash"));
+    QVERIFY(c); QCOMPARE(c->type, QStringLiteral("TEXT")); QVERIFY(c->notnull);
+
+    c = findCol(QStringLiteral("format"));
+    QVERIFY(c); QCOMPARE(c->type, QStringLiteral("TEXT")); QVERIFY(c->notnull);
+
+    c = findCol(QStringLiteral("tile"));
+    QVERIFY(c); QCOMPARE(c->type, QStringLiteral("BLOB"));
+
+    c = findCol(QStringLiteral("size"));
+    QVERIFY(c); QCOMPARE(c->type, QStringLiteral("INTEGER"));
+
+    c = findCol(QStringLiteral("type"));
+    QVERIFY(c); QCOMPARE(c->type, QStringLiteral("INTEGER"));
+
+    c = findCol(QStringLiteral("date"));
+    QVERIFY(c); QCOMPARE(c->type, QStringLiteral("INTEGER")); QCOMPARE(c->dflt, QStringLiteral("0"));
+}
+
+void QGCTileCacheDatabaseTest::_testTileSetsTableColumns()
+{
+    auto db = _createInitializedDB();
+    QVERIFY(db);
+
+    QSqlQuery query(db->database());
+    QVERIFY(query.exec("PRAGMA table_info(TileSets)"));
+
+    struct ColInfo { QString name; QString type; bool notnull; QString dflt; bool pk; };
+    QList<ColInfo> cols;
+    while (query.next()) {
+        cols.append({
+            query.value(1).toString(),
+            query.value(2).toString(),
+            query.value(3).toBool(),
+            query.value(4).toString(),
+            query.value(5).toBool()
+        });
+    }
+
+    QCOMPARE(cols.size(), 13);
+
+    auto findCol = [&](const QString &name) -> const ColInfo* {
+        for (const auto &c : cols) { if (c.name == name) return &c; }
+        return nullptr;
+    };
+
+    const ColInfo *c = findCol(QStringLiteral("setID"));
+    QVERIFY(c); QCOMPARE(c->type, QStringLiteral("INTEGER")); QVERIFY(c->pk); QVERIFY(c->notnull);
+
+    c = findCol(QStringLiteral("name"));
+    QVERIFY(c); QCOMPARE(c->type, QStringLiteral("TEXT")); QVERIFY(c->notnull);
+
+    c = findCol(QStringLiteral("typeStr"));
+    QVERIFY(c); QCOMPARE(c->type, QStringLiteral("TEXT"));
+
+    c = findCol(QStringLiteral("topleftLat"));
+    QVERIFY(c); QCOMPARE(c->type, QStringLiteral("REAL")); QCOMPARE(c->dflt, QStringLiteral("0.0"));
+
+    c = findCol(QStringLiteral("topleftLon"));
+    QVERIFY(c); QCOMPARE(c->type, QStringLiteral("REAL")); QCOMPARE(c->dflt, QStringLiteral("0.0"));
+
+    c = findCol(QStringLiteral("bottomRightLat"));
+    QVERIFY(c); QCOMPARE(c->type, QStringLiteral("REAL")); QCOMPARE(c->dflt, QStringLiteral("0.0"));
+
+    c = findCol(QStringLiteral("bottomRightLon"));
+    QVERIFY(c); QCOMPARE(c->type, QStringLiteral("REAL")); QCOMPARE(c->dflt, QStringLiteral("0.0"));
+
+    c = findCol(QStringLiteral("minZoom"));
+    QVERIFY(c); QCOMPARE(c->type, QStringLiteral("INTEGER")); QCOMPARE(c->dflt, QStringLiteral("3"));
+
+    c = findCol(QStringLiteral("maxZoom"));
+    QVERIFY(c); QCOMPARE(c->type, QStringLiteral("INTEGER")); QCOMPARE(c->dflt, QStringLiteral("3"));
+
+    c = findCol(QStringLiteral("type"));
+    QVERIFY(c); QCOMPARE(c->type, QStringLiteral("INTEGER")); QCOMPARE(c->dflt, QStringLiteral("-1"));
+
+    c = findCol(QStringLiteral("numTiles"));
+    QVERIFY(c); QCOMPARE(c->type, QStringLiteral("INTEGER")); QCOMPARE(c->dflt, QStringLiteral("0"));
+
+    c = findCol(QStringLiteral("defaultSet"));
+    QVERIFY(c); QCOMPARE(c->type, QStringLiteral("INTEGER")); QCOMPARE(c->dflt, QStringLiteral("0"));
+
+    c = findCol(QStringLiteral("date"));
+    QVERIFY(c); QCOMPARE(c->type, QStringLiteral("INTEGER")); QCOMPARE(c->dflt, QStringLiteral("0"));
+}
+
+void QGCTileCacheDatabaseTest::_testSetTilesTableColumns()
+{
+    auto db = _createInitializedDB();
+    QVERIFY(db);
+
+    QSqlQuery query(db->database());
+    QVERIFY(query.exec("PRAGMA table_info(SetTiles)"));
+
+    struct ColInfo { QString name; QString type; bool notnull; };
+    QList<ColInfo> cols;
+    while (query.next()) {
+        cols.append({
+            query.value(1).toString(),
+            query.value(2).toString(),
+            query.value(3).toBool()
+        });
+    }
+
+    QCOMPARE(cols.size(), 2);
+
+    QCOMPARE(cols[0].name, QStringLiteral("setID"));
+    QCOMPARE(cols[0].type, QStringLiteral("INTEGER"));
+    QVERIFY(cols[0].notnull);
+
+    QCOMPARE(cols[1].name, QStringLiteral("tileID"));
+    QCOMPARE(cols[1].type, QStringLiteral("INTEGER"));
+    QVERIFY(cols[1].notnull);
+}
+
+void QGCTileCacheDatabaseTest::_testTilesDownloadTableColumns()
+{
+    auto db = _createInitializedDB();
+    QVERIFY(db);
+
+    QSqlQuery query(db->database());
+    QVERIFY(query.exec("PRAGMA table_info(TilesDownload)"));
+
+    struct ColInfo { QString name; QString type; bool notnull; QString dflt; };
+    QList<ColInfo> cols;
+    while (query.next()) {
+        cols.append({
+            query.value(1).toString(),
+            query.value(2).toString(),
+            query.value(3).toBool(),
+            query.value(4).toString()
+        });
+    }
+
+    QCOMPARE(cols.size(), 7);
+
+    auto findCol = [&](const QString &name) -> const ColInfo* {
+        for (const auto &c : cols) { if (c.name == name) return &c; }
+        return nullptr;
+    };
+
+    const ColInfo *c = findCol(QStringLiteral("setID"));
+    QVERIFY(c); QCOMPARE(c->type, QStringLiteral("INTEGER")); QVERIFY(c->notnull);
+
+    c = findCol(QStringLiteral("hash"));
+    QVERIFY(c); QCOMPARE(c->type, QStringLiteral("TEXT")); QVERIFY(c->notnull);
+
+    c = findCol(QStringLiteral("type"));
+    QVERIFY(c); QCOMPARE(c->type, QStringLiteral("INTEGER"));
+
+    c = findCol(QStringLiteral("x"));
+    QVERIFY(c); QCOMPARE(c->type, QStringLiteral("INTEGER"));
+
+    c = findCol(QStringLiteral("y"));
+    QVERIFY(c); QCOMPARE(c->type, QStringLiteral("INTEGER"));
+
+    c = findCol(QStringLiteral("z"));
+    QVERIFY(c); QCOMPARE(c->type, QStringLiteral("INTEGER"));
+
+    c = findCol(QStringLiteral("state"));
+    QVERIFY(c); QCOMPARE(c->type, QStringLiteral("INTEGER")); QCOMPARE(c->dflt, QStringLiteral("0"));
+}
+
+void QGCTileCacheDatabaseTest::_testIndexesExist()
+{
+    auto db = _createInitializedDB();
+    QVERIFY(db);
+
+    QSqlQuery query(db->database());
+    QVERIFY(query.exec("SELECT name FROM sqlite_master WHERE type='index' AND sql IS NOT NULL ORDER BY name"));
+
+    QStringList indexes;
+    while (query.next()) {
+        indexes << query.value(0).toString();
+    }
+
+    const QStringList expected = {
+        QStringLiteral("idx_settiles_setid"),
+        QStringLiteral("idx_settiles_tileid"),
+        QStringLiteral("idx_settiles_unique"),
+        QStringLiteral("idx_tiles_date"),
+        QStringLiteral("idx_tilesdownload_setid_hash"),
+        QStringLiteral("idx_tilesdownload_setid_state"),
+    };
+
+    QCOMPARE(indexes.size(), expected.size());
+    for (const auto &name : expected) {
+        QVERIFY2(indexes.contains(name), qPrintable(QStringLiteral("Missing index: %1").arg(name)));
+    }
+}
+
+void QGCTileCacheDatabaseTest::_testForeignKeyCascadeDelete()
+{
+    auto db = _createInitializedDB();
+    QVERIFY(db);
+
+    const QStringList providerTypes = UrlFactory::getProviderTypes();
+    QVERIFY(!providerTypes.isEmpty());
+    const QString type = providerTypes.first();
+
+    const QString hash = QStringLiteral("fk_cascade_hash");
+    QVERIFY(db->saveTile(hash, QStringLiteral("png"), QByteArray("data"), type, QGCTileCacheDatabase::kInvalidTileSet));
+
+    const auto tileID = db->findTile(hash);
+    QVERIFY(tileID.has_value());
+
+    const auto setID = db->createTileSet(
+        QStringLiteral("CascadeTestSet"), type,
+        10.0, 20.0, 30.0, 40.0, 5, 5, type, 1);
+    QVERIFY(setID.has_value());
+
+    _linkTileToSet(db.get(), tileID.value(), setID.value());
+
+    // Verify the link exists
+    {
+        QSqlQuery query(db->database());
+        QVERIFY(query.prepare("SELECT COUNT(*) FROM SetTiles WHERE setID = ?"));
+        query.addBindValue(setID.value());
+        QVERIFY(query.exec());
+        QVERIFY(query.next());
+        QCOMPARE(query.value(0).toInt(), 1);
+    }
+
+    QVERIFY(db->deleteTileSet(setID.value()));
+
+    // SetTiles rows for the deleted set should be gone (CASCADE)
+    {
+        QSqlQuery query(db->database());
+        QVERIFY(query.prepare("SELECT COUNT(*) FROM SetTiles WHERE setID = ?"));
+        query.addBindValue(setID.value());
+        QVERIFY(query.exec());
+        QVERIFY(query.next());
+        QCOMPARE(query.value(0).toInt(), 0);
+    }
+
+    // Tile itself should still exist (linked to default set)
+    {
+        auto tile = db->getTile(hash);
+        QVERIFY(tile != nullptr);
+    }
+}
+
+UT_REGISTER_TEST(QGCTileCacheDatabaseTest, TestLabel::Unit)

--- a/test/QtLocationPlugin/QGCTileCacheDatabaseTest.h
+++ b/test/QtLocationPlugin/QGCTileCacheDatabaseTest.h
@@ -1,0 +1,63 @@
+#pragma once
+
+#include "BaseClasses/TempDirectoryTest.h"
+
+#include <memory>
+
+class QGCTileCacheDatabase;
+
+class QGCTileCacheDatabaseTest : public TempDirectoryTest
+{
+    Q_OBJECT
+
+private slots:
+    void _testInitWithValidPath();
+    void _testInitWithEmptyPath();
+    void _testConnectDisconnect();
+    void _testDefaultTileSetCreated();
+    void _testSaveTileAndGetTile();
+    void _testGetTileNotFound();
+    void _testFindTile();
+    void _testGetTileSetsMultiple();
+    void _testRenameTileSet();
+    void _testFindTileSetID();
+    void _testDeleteTileSet();
+    void _testResetDatabase();
+    void _testComputeTotals();
+    void _testComputeSetTotalsDefault();
+    void _testPruneCache();
+    void _testUpdateTileDownloadState();
+    void _testExportImportReplace();
+    void _testGetTileDownloadList();
+    void _testImportSetsMerge();
+    void _testComputeSetTotalsNonDefault();
+    void _testSaveDuplicateTile();
+    void _testOperationsAfterDisconnect();
+    void _testPruneCacheCleansSetTiles();
+    void _testDeleteTileSetCleansTiles();
+    void _testImportSetsMergeDeduplicatesName();
+    void _testGetTileDownloadListBatch();
+    void _testSaveTileLinksToDifferentSet();
+    void _testExportImportNoLingeringConnections();
+    void _testCreateTileSet();
+    void _testDeleteBingNoTileTiles();
+    void _testDeleteDefaultSetInvalidatesCache();
+    void _testPruneCacheMultipleBatches();
+    void _testSchemaVersionSetOnFreshDB();
+    void _testSchemaVersionResetsLegacyDB();
+    void _testSaveTileTypeStoredAsInteger();
+    void _testCreateTileSetTypeStoredAsInteger();
+    void _testTablesExist();
+    void _testTilesTableColumns();
+    void _testTileSetsTableColumns();
+    void _testSetTilesTableColumns();
+    void _testTilesDownloadTableColumns();
+    void _testIndexesExist();
+    void _testForeignKeyCascadeDelete();
+
+private:
+    std::unique_ptr<QGCTileCacheDatabase> _createInitializedDB();
+    void _insertTileSet(QGCTileCacheDatabase *db, const QString &name, quint64 &outSetID);
+    void _insertDownloadRecord(QGCTileCacheDatabase *db, quint64 setID, const QString &hash, int state = 0);
+    void _linkTileToSet(QGCTileCacheDatabase *db, quint64 tileID, quint64 setID);
+};

--- a/test/QtLocationPlugin/QGCTileSetTest.cc
+++ b/test/QtLocationPlugin/QGCTileSetTest.cc
@@ -1,0 +1,85 @@
+#include "QGCTileSetTest.h"
+
+#include "QGCTileSet.h"
+
+void QGCTileSetTest::_testDefaultConstruction()
+{
+    QGCTileSet set;
+    QCOMPARE(set.tileX0, 0);
+    QCOMPARE(set.tileX1, 0);
+    QCOMPARE(set.tileY0, 0);
+    QCOMPARE(set.tileY1, 0);
+    QCOMPARE(set.tileCount, static_cast<quint64>(0));
+    QCOMPARE(set.tileSize, static_cast<quint64>(0));
+}
+
+void QGCTileSetTest::_testClear()
+{
+    QGCTileSet set;
+    set.tileX0 = 10;
+    set.tileX1 = 20;
+    set.tileY0 = 30;
+    set.tileY1 = 40;
+    set.tileCount = 100;
+    set.tileSize = 5000;
+
+    set.clear();
+
+    QCOMPARE(set.tileX0, 0);
+    QCOMPARE(set.tileX1, 0);
+    QCOMPARE(set.tileY0, 0);
+    QCOMPARE(set.tileY1, 0);
+    QCOMPARE(set.tileCount, static_cast<quint64>(0));
+    QCOMPARE(set.tileSize, static_cast<quint64>(0));
+}
+
+void QGCTileSetTest::_testPlusEqualsAccumulates()
+{
+    QGCTileSet a;
+    a.tileCount = 10;
+    a.tileSize = 1000;
+
+    QGCTileSet b;
+    b.tileCount = 5;
+    b.tileSize = 500;
+
+    a += b;
+
+    QCOMPARE(a.tileCount, static_cast<quint64>(15));
+    QCOMPARE(a.tileSize, static_cast<quint64>(1500));
+}
+
+void QGCTileSetTest::_testPlusEqualsWithZero()
+{
+    QGCTileSet a;
+    a.tileCount = 42;
+    a.tileSize = 9999;
+
+    a += QGCTileSet();
+
+    QCOMPARE(a.tileCount, static_cast<quint64>(42));
+    QCOMPARE(a.tileSize, static_cast<quint64>(9999));
+}
+
+void QGCTileSetTest::_testPlusEqualsChaining()
+{
+    QGCTileSet a;
+    a.tileCount = 1;
+    a.tileSize = 100;
+
+    QGCTileSet b;
+    b.tileCount = 2;
+    b.tileSize = 200;
+
+    QGCTileSet c;
+    c.tileCount = 3;
+    c.tileSize = 300;
+
+    a += b;
+    a += c;
+
+    QCOMPARE(a.tileCount, static_cast<quint64>(6));
+    QCOMPARE(a.tileSize, static_cast<quint64>(600));
+}
+
+UT_REGISTER_TEST(QGCTileSetTest, TestLabel::Unit)

--- a/test/QtLocationPlugin/QGCTileSetTest.h
+++ b/test/QtLocationPlugin/QGCTileSetTest.h
@@ -1,0 +1,15 @@
+#pragma once
+
+#include "UnitTest.h"
+
+class QGCTileSetTest : public UnitTest
+{
+    Q_OBJECT
+
+private slots:
+    void _testDefaultConstruction();
+    void _testClear();
+    void _testPlusEqualsAccumulates();
+    void _testPlusEqualsWithZero();
+    void _testPlusEqualsChaining();
+};

--- a/test/QtLocationPlugin/UrlFactoryTest.cc
+++ b/test/QtLocationPlugin/UrlFactoryTest.cc
@@ -1,0 +1,281 @@
+#include "UrlFactoryTest.h"
+
+#include "MapProvider.h"
+#include "QGCMapUrlEngine.h"
+
+static const QString kBingRoad = QStringLiteral("Bing Road");
+static const QString kBingSatellite = QStringLiteral("Bing Satellite");
+static const QString kBingHybrid = QStringLiteral("Bing Hybrid");
+static const QString kCopernicus = QStringLiteral("Copernicus");
+
+// --- Provider registry ---
+
+void UrlFactoryTest::_testGetProviderTypesNotEmpty()
+{
+    const QStringList types = UrlFactory::getProviderTypes();
+    QVERIFY(!types.isEmpty());
+}
+
+void UrlFactoryTest::_testGetProviderTypesContainsBing()
+{
+    const QStringList types = UrlFactory::getProviderTypes();
+    QVERIFY(types.contains(kBingRoad));
+    QVERIFY(types.contains(kBingSatellite));
+    QVERIFY(types.contains(kBingHybrid));
+}
+
+void UrlFactoryTest::_testGetElevationProviderTypes()
+{
+    const QStringList elevTypes = UrlFactory::getElevationProviderTypes();
+    QVERIFY(!elevTypes.isEmpty());
+    QVERIFY(elevTypes.contains(kCopernicus));
+
+    const QStringList allTypes = UrlFactory::getProviderTypes();
+    for (const auto &t : elevTypes) {
+        QVERIFY2(allTypes.contains(t),
+                 qPrintable(QStringLiteral("Elevation type '%1' not in allTypes").arg(t)));
+    }
+}
+
+// --- Type <-> MapId roundtrip ---
+
+void UrlFactoryTest::_testMapIdFromProviderTypeValid()
+{
+    const int id = UrlFactory::getQtMapIdFromProviderType(kBingRoad);
+    QVERIFY(id > 0);
+}
+
+void UrlFactoryTest::_testProviderTypeFromMapIdRoundtrip()
+{
+    const QStringList types = UrlFactory::getProviderTypes();
+    for (const auto &type : types) {
+        const int id = UrlFactory::getQtMapIdFromProviderType(type);
+        QVERIFY2(id > 0, qPrintable(QStringLiteral("Bad id for type: %1").arg(type)));
+        const QString recovered = UrlFactory::getProviderTypeFromQtMapId(id);
+        QCOMPARE(recovered, type);
+    }
+}
+
+void UrlFactoryTest::_testMapIdFromEmptyType()
+{
+    QCOMPARE(UrlFactory::getQtMapIdFromProviderType(QString()), -1);
+}
+
+void UrlFactoryTest::_testMapIdFromInvalidType()
+{
+    QCOMPARE(UrlFactory::getQtMapIdFromProviderType(QStringLiteral("Nonexistent")), -1);
+}
+
+void UrlFactoryTest::_testProviderTypeFromInvalidId()
+{
+    QVERIFY(UrlFactory::getProviderTypeFromQtMapId(-1).isEmpty());
+    QVERIFY(UrlFactory::getProviderTypeFromQtMapId(99999).isEmpty());
+}
+
+// --- Hash <-> ProviderType roundtrip ---
+
+void UrlFactoryTest::_testHashFromProviderTypeValid()
+{
+    const int hash = UrlFactory::hashFromProviderType(kBingRoad);
+    const int id = UrlFactory::getQtMapIdFromProviderType(kBingRoad);
+    QCOMPARE(hash, id);
+}
+
+void UrlFactoryTest::_testProviderTypeFromHashRoundtrip()
+{
+    const QStringList types = UrlFactory::getProviderTypes();
+    for (const auto &type : types) {
+        const int hash = UrlFactory::hashFromProviderType(type);
+        QVERIFY2(hash > 0, qPrintable(QStringLiteral("Bad hash for: %1").arg(type)));
+        const QString recovered = UrlFactory::providerTypeFromHash(hash);
+        QCOMPARE(recovered, type);
+    }
+}
+
+void UrlFactoryTest::_testHashFromInvalidType()
+{
+    QCOMPARE(UrlFactory::hashFromProviderType(QString()), -1);
+}
+
+void UrlFactoryTest::_testProviderTypeFromInvalidHash()
+{
+    QVERIFY(UrlFactory::providerTypeFromHash(0).isEmpty());
+}
+
+// --- Tile hash encode/decode ---
+
+void UrlFactoryTest::_testGetTileHashFormat()
+{
+    const QString hash = UrlFactory::getTileHash(kBingRoad, 100, 200, 5);
+    // Format: "%010d%08d%08d%03d" = 10+8+8+3 = 29 chars
+    QCOMPARE(hash.length(), 29);
+}
+
+void UrlFactoryTest::_testTileHashToTypeRoundtrip()
+{
+    const QStringList types = UrlFactory::getProviderTypes();
+    for (const auto &type : types) {
+        const QString hash = UrlFactory::getTileHash(type, 42, 99, 7);
+        const QString recovered = UrlFactory::tileHashToType(hash);
+        QCOMPARE(recovered, type);
+    }
+}
+
+void UrlFactoryTest::_testTileHashToTypeInvalid()
+{
+    QVERIFY(UrlFactory::tileHashToType(QStringLiteral("garbage")).isEmpty());
+}
+
+// --- Image format via facade ---
+
+void UrlFactoryTest::_testGetImageFormatByType()
+{
+    const QByteArray png("\x89\x50\x4E\x47\x0D\x0A\x1A\x0A" "data", 12);
+    QCOMPARE(UrlFactory::getImageFormat(kBingRoad, png), QStringLiteral("png"));
+}
+
+void UrlFactoryTest::_testGetImageFormatByMapId()
+{
+    const int id = UrlFactory::getQtMapIdFromProviderType(kBingRoad);
+    const QByteArray jpeg("\xFF\xD8\xFF\xE0" "data", 8);
+    QCOMPARE(UrlFactory::getImageFormat(id, jpeg), QStringLiteral("jpg"));
+}
+
+void UrlFactoryTest::_testGetImageFormatInvalidInputs()
+{
+    const QByteArray png("\x89\x50\x4E\x47\x0D\x0A\x1A\x0A", 8);
+    QVERIFY(UrlFactory::getImageFormat(QString(), png).isEmpty());
+    QVERIFY(UrlFactory::getImageFormat(-1, png).isEmpty());
+}
+
+// --- averageSizeForType ---
+
+void UrlFactoryTest::_testAverageSizeForKnownProviders()
+{
+    QCOMPARE(UrlFactory::averageSizeForType(kBingRoad), static_cast<quint32>(1297));
+    QCOMPARE(UrlFactory::averageSizeForType(kBingSatellite), static_cast<quint32>(19597));
+    QCOMPARE(UrlFactory::averageSizeForType(kCopernicus), static_cast<quint32>(2786));
+}
+
+void UrlFactoryTest::_testAverageSizeForInvalidType()
+{
+    QCOMPARE(UrlFactory::averageSizeForType(QStringLiteral("Nonexistent")), QGC_AVERAGE_TILE_SIZE);
+}
+
+// --- isElevation ---
+
+void UrlFactoryTest::_testIsElevationTrue()
+{
+    const int id = UrlFactory::getQtMapIdFromProviderType(kCopernicus);
+    QVERIFY(UrlFactory::isElevation(id));
+}
+
+void UrlFactoryTest::_testIsElevationFalse()
+{
+    const int id = UrlFactory::getQtMapIdFromProviderType(kBingRoad);
+    QVERIFY(!UrlFactory::isElevation(id));
+    QVERIFY(!UrlFactory::isElevation(-1));
+}
+
+// --- Coordinate conversion via facade ---
+
+void UrlFactoryTest::_testLong2tileXDelegates()
+{
+    // NYC at z=10
+    QCOMPARE(UrlFactory::long2tileX(kBingRoad, -73.9857, 10), 301);
+}
+
+void UrlFactoryTest::_testLat2tileYDelegates()
+{
+    // NYC at z=10
+    QCOMPARE(UrlFactory::lat2tileY(kBingRoad, 40.7128, 10), 385);
+}
+
+void UrlFactoryTest::_testCoordConversionInvalidType()
+{
+    QCOMPARE(UrlFactory::long2tileX(QString(), -73.9857, 10), 0);
+    QCOMPARE(UrlFactory::lat2tileY(QString(), 40.7128, 10), 0);
+}
+
+// --- Copernicus elevation specifics ---
+
+void UrlFactoryTest::_testCopernicusLong2tileX()
+{
+    // floor((0+180)/0.01) = 18000
+    QCOMPARE(UrlFactory::long2tileX(kCopernicus, 0.0, 1), 18000);
+    // floor((-180+180)/0.01) = 0
+    QCOMPARE(UrlFactory::long2tileX(kCopernicus, -180.0, 1), 0);
+}
+
+void UrlFactoryTest::_testCopernicusLat2tileY()
+{
+    // floor((0+90)/0.01) = 9000
+    QCOMPARE(UrlFactory::lat2tileY(kCopernicus, 0.0, 1), 9000);
+    // floor((-90+90)/0.01) = 0
+    QCOMPARE(UrlFactory::lat2tileY(kCopernicus, -90.0, 1), 0);
+}
+
+void UrlFactoryTest::_testCopernicusTileCount()
+{
+    // Small 0.05° box near origin
+    // Copernicus getTileCount swaps lat semantics: tileY0 = lat2tileY(bottomRightLat), tileY1 = lat2tileY(topleftLat)
+    const auto set = UrlFactory::getTileCount(1, 0.0, 0.05, 0.05, 0.0, kCopernicus);
+    // tileX: floor((0+180)/0.01)=18000 to floor((0.05+180)/0.01)=18005 → 6 tiles
+    // tileY: floor((0+90)/0.01)=9000 to floor((0.05+90)/0.01)=9005 → 6 tiles
+    // total = 6*6 = 36
+    QCOMPARE(set.tileCount, static_cast<quint64>(36));
+}
+
+// --- getTileCount ---
+
+void UrlFactoryTest::_testGetTileCountValid()
+{
+    // z=1 full world via Bing Road
+    const auto set = UrlFactory::getTileCount(1, -179.9, 85.0, 179.9, -85.0, kBingRoad);
+    QVERIFY(set.tileCount > 0);
+    QCOMPARE(set.tileCount, static_cast<quint64>(4));
+}
+
+void UrlFactoryTest::_testGetTileCountInvalidType()
+{
+    const auto set = UrlFactory::getTileCount(10, -73.0, 41.0, -72.0, 40.0, QString());
+    QCOMPARE(set.tileCount, static_cast<quint64>(0));
+    QCOMPARE(set.tileSize, static_cast<quint64>(0));
+}
+
+void UrlFactoryTest::_testGetTileCountZoomClamped()
+{
+    // zoom=0 should be clamped to 1 internally
+    const auto setLow = UrlFactory::getTileCount(0, -179.9, 85.0, 179.9, -85.0, kBingRoad);
+    const auto setOne = UrlFactory::getTileCount(1, -179.9, 85.0, 179.9, -85.0, kBingRoad);
+    QCOMPARE(setLow.tileCount, setOne.tileCount);
+
+    // zoom=99 should be clamped to 23
+    const auto setHigh = UrlFactory::getTileCount(99, 0.0, 0.001, 0.001, 0.0, kBingRoad);
+    const auto set23 = UrlFactory::getTileCount(23, 0.0, 0.001, 0.001, 0.0, kBingRoad);
+    QCOMPARE(setHigh.tileCount, set23.tileCount);
+}
+
+// --- Provider lookup ---
+
+void UrlFactoryTest::_testGetMapProviderValid()
+{
+    const int id = UrlFactory::getQtMapIdFromProviderType(kBingRoad);
+    auto provider = UrlFactory::getMapProviderFromQtMapId(id);
+    QVERIFY(provider != nullptr);
+    QCOMPARE(provider->getMapName(), kBingRoad);
+    QVERIFY(provider->isBingProvider());
+
+    auto byType = UrlFactory::getMapProviderFromProviderType(kBingRoad);
+    QVERIFY(byType != nullptr);
+    QCOMPARE(byType->getMapName(), kBingRoad);
+}
+
+void UrlFactoryTest::_testGetMapProviderInvalid()
+{
+    QVERIFY(UrlFactory::getMapProviderFromQtMapId(-1) == nullptr);
+    QVERIFY(UrlFactory::getMapProviderFromProviderType(QString()) == nullptr);
+    QVERIFY(UrlFactory::getMapProviderFromProviderType(QStringLiteral("Nonexistent")) == nullptr);
+}
+
+UT_REGISTER_TEST(UrlFactoryTest, TestLabel::Unit)

--- a/test/QtLocationPlugin/UrlFactoryTest.h
+++ b/test/QtLocationPlugin/UrlFactoryTest.h
@@ -1,0 +1,43 @@
+#pragma once
+
+#include "UnitTest.h"
+
+class UrlFactoryTest : public UnitTest
+{
+    Q_OBJECT
+
+private slots:
+    void _testGetProviderTypesNotEmpty();
+    void _testGetProviderTypesContainsBing();
+    void _testGetElevationProviderTypes();
+    void _testMapIdFromProviderTypeValid();
+    void _testProviderTypeFromMapIdRoundtrip();
+    void _testMapIdFromEmptyType();
+    void _testMapIdFromInvalidType();
+    void _testProviderTypeFromInvalidId();
+    void _testHashFromProviderTypeValid();
+    void _testProviderTypeFromHashRoundtrip();
+    void _testHashFromInvalidType();
+    void _testProviderTypeFromInvalidHash();
+    void _testGetTileHashFormat();
+    void _testTileHashToTypeRoundtrip();
+    void _testTileHashToTypeInvalid();
+    void _testGetImageFormatByType();
+    void _testGetImageFormatByMapId();
+    void _testGetImageFormatInvalidInputs();
+    void _testAverageSizeForKnownProviders();
+    void _testAverageSizeForInvalidType();
+    void _testIsElevationTrue();
+    void _testIsElevationFalse();
+    void _testLong2tileXDelegates();
+    void _testLat2tileYDelegates();
+    void _testCoordConversionInvalidType();
+    void _testCopernicusLong2tileX();
+    void _testCopernicusLat2tileY();
+    void _testCopernicusTileCount();
+    void _testGetTileCountValid();
+    void _testGetTileCountInvalidType();
+    void _testGetTileCountZoomClamped();
+    void _testGetMapProviderValid();
+    void _testGetMapProviderInvalid();
+};


### PR DESCRIPTION
## Summary
- Extract all SQL/database logic from `QGCTileCacheWorker` into a new `QGCTileCacheDatabase` class, creating a clean separation between threading/task dispatch and data access
- Add `PRAGMA user_version` schema versioning with automatic migration from legacy text-based `type` columns to integer map IDs
- Move tile cache database to `QStandardPaths::CacheLocation` (appropriate for regenerable cache data)
- Apply Qt best practices: connection-name pattern for `QSqlDatabase` (no stored member), `INSERT OR IGNORE` for deduplication, `setForwardOnly(true)` on read-only queries, `std::atomic` for thread-safe export session counter, FK CASCADE for tile deletion
- Fix worker thread idle timeout causing "Database Not Initialized" errors — thread now stays alive until `stop()` is called
- Add early-return guards in `getQtMapIdFromProviderType`/`getMapProviderFromProviderType` for empty type strings (default tile set)
- Add 50 unit tests (38 database + 12 worker) covering CRUD, import/export, schema migration, edge cases, and concurrent access

## Test plan
- [x] `QGCTileCacheDatabaseTest` — 38 tests for all database operations
- [x] `QGCCacheWorkerTest` — 12 tests for worker thread task dispatch
- [x] Manual verification: no "Database Not Initialized" or "type not found" warnings at runtime
- [ ] Verify offline map tile set creation, download, rename, delete
- [ ] Verify import/export of tile sets
- [ ] Verify cache pruning when disk limit exceeded