### PR TITLE
Better cmake support for parallel moc compiles

### DIFF
--- a/cmake/Toolchain.cmake
+++ b/cmake/Toolchain.cmake
@@ -24,6 +24,11 @@ set(CMAKE_AUTOMOC ON)
 set(CMAKE_AUTOUIC ON)
 set(CMAKE_AUTORCC ON)
 
+if(NOT DEFINED CMAKE_AUTOGEN_PARALLEL)
+    cmake_host_system_information(RESULT _nproc QUERY NUMBER_OF_LOGICAL_CORES)
+    set(CMAKE_AUTOGEN_PARALLEL ${_nproc})
+endif()
+
 # ----------------------------------------------------------------------------
 # Build Configuration
 # ----------------------------------------------------------------------------


### PR DESCRIPTION
This was working for for me on OSX. But on Linux the build would stall out with out a single moc at a time. Claude Opus said it was a problem between cmake versions.