### PR TITLE
Fix launch location indicator position for Horizontal Compass layout

### DIFF
--- a/src/FlightMap/Widgets/QGCCompassWidget.qml
+++ b/src/FlightMap/Widgets/QGCCompassWidget.qml
@@ -28,6 +28,7 @@ Rectangle {
     property var  _flyViewSettings:             QGroundControl.settingsManager.flyViewSettings
     property bool _showAdditionalIndicators:    _flyViewSettings.showAdditionalIndicatorsCompass.value && !usedByMultipleVehicleList
     property bool _lockNoseUpCompass:           _flyViewSettings.lockNoseUpCompass.value && !usedByMultipleVehicleList
+    property bool _isCompassAndAttitude:           _flyViewSettings.instrumentQmlFile2.enumIndex == 1
 
     function showCOG(){
         if (_groundSpeed < 0.5) {
@@ -128,7 +129,7 @@ Rectangle {
             transform: Translate {
                 property double _angle: _headingToHome
 
-                x: translateCenterToAngleX(parent.width / 2, _angle)
+                x: translateCenterToAngleX(_isCompassAndAttitude ? parent.width / 4 : parent.width / 2 , _angle)
                 y: translateCenterToAngleY(parent.height / 2, _angle)
             }
         }


### PR DESCRIPTION
When using the "Horizontal Compass & Attitude" instrument panel, the launch location indicator ("L") was rendered using parent.width / 2 as its translation radius, which caused it to appear outside, overlapping the attitude widget.

<img width="425" height="273" alt="image" src="https://github.com/user-attachments/assets/1d49eb60-822e-4f03-83d2-4c3b1c8bfc49" />
<img width="425" height="273" alt="image" src="https://github.com/user-attachments/assets/aeb45be6-b0ad-4d3c-8b12-15f84c8bbab2" />


## Description
<!-- Describe your changes in detail. What problem does this solve? -->

## Type of Change
<!-- Put an 'x' in the relevant boxes -->
- [ X] Bug fix (non-breaking change that fixes an issue)

## Testing
<!-- Describe the tests you ran and how to reproduce them -->
- [ X] Tested locally
- [X ] Tested with simulator (SITL)

### Platforms Tested
<!-- Check all that apply -->
- [x ] Linux


By submitting this pull request, I confirm that my contribution is made under the terms of the project's dual license (Apache 2.0 and GPL v3).