### PR TITLE
Fix NTRIP crash on HTTP 4xx/5xx and duplicate connection on startup

### DIFF
--- a/src/GPS/NTRIP.cc
+++ b/src/GPS/NTRIP.cc
@@ -381,13 +381,13 @@ void NTRIPTCPLink::_hardwareConnect()
         QSslSocket* sslSocket = qobject_cast<QSslSocket*>(_socket);
         Q_ASSERT(sslSocket);
 
-        QObject::connect(sslSocket, &QSslSocket::encrypted, this, [this, sendHttpRequest]() {
+        QObject::connect(sslSocket, &QSslSocket::encrypted, this, [sendHttpRequest]() {
             qCDebug(NTRIPLog) << "SPARTN TLS connection established";
             sendHttpRequest();
         }, Qt::DirectConnection);
 
         QObject::connect(sslSocket, QOverload<const QList<QSslError>&>::of(&QSslSocket::sslErrors),
-                         this, [this](const QList<QSslError> &errors) {
+                         this, [](const QList<QSslError> &errors) {
             for (const QSslError &e : errors) {
                 qCWarning(NTRIPLog) << "TLS Error:" << e.errorString();
             }


### PR DESCRIPTION
## Description
Prevent NTRIP successful connection from crashing QGC (at least on OSX).

  - Remove start() call from NTRIPTCPLink constructor — it caused a double connection (constructor + QThread::started), leaking the first socket and triggering 401 from casters that reject duplicate logins                                                 
  - Fix crash in HTTP 4xx/5xx error path: null out _socket before disconnectFromHost() so the synchronous disconnected handler bails via the existing !_socket guard, and use deleteLater() instead of delete to avoid destroying the socket mid-signal-chain
 
  #### Test plan                                                                                                                                                                                                                                                   

  - Connect to an NTRIP caster with valid credentials — should get 200 OK on first attempt
  - Connect with invalid credentials — should show error and retry without crashing

## Type of Change
<!-- Put an 'x' in the relevant boxes -->
- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] CI/Build changes
- [ ] Other

## Testing
<!-- Describe the tests you ran and how to reproduce them -->
- [x] Tested locally
- [ ] Added/updated unit tests
- [ ] Tested with simulator (SITL)
- [x] Tested with hardware

### Platforms Tested
<!-- Check all that apply -->
- [ ] Linux
- [ ] Windows
- [x] macOS
- [ ] Android
- [ ] iOS

### Flight Stacks Tested
<!-- If applicable -->
- [ ] PX4
- [x] ArduPilot

## Screenshots
<!-- If applicable, add screenshots to help explain your changes -->

## Checklist
<!-- Go over all the following points, and put an 'x' in all the boxes that apply -->
- [x] I have read the [Contribution Guidelines](CONTRIBUTING.md)
- [x] I have read the [Code of Conduct](CODE_OF_CONDUCT.md)
- [x] My code follows the project's coding standards
- [ ] I have added tests that prove my fix/feature works
- [ ] New and existing unit tests pass locally

## Related Issues
<!-- Link any related issues using #issue_number -->

---
By submitting this pull request, I confirm that my contribution is made under the terms of the project's dual license (Apache 2.0 and GPL v3).
