### PR TITLE
New option for Gimbal control, and update gimbal indicator docs

### DIFF
--- a/docs/en/qgc-user-guide/fly_view/fly_view_toolbar.md
+++ b/docs/en/qgc-user-guide/fly_view/fly_view_toolbar.md
@@ -95,7 +95,51 @@ The RC RSSI indicator appears when RC signal information is available. It shows 
 
 ### Gimbal <img src="../../../assets/fly/toolbar/gimbal_indicator.png" alt="Gimbal indicator" style="height: 1.15em; vertical-align: text-bottom;" />
 
-The Gimbal indicator is shown when the vehicle supports the [MAVLink Gimbal Protocol](https://mavlink.io/en/services/gimbal_v2.html). It displays active gimbal status and provides access to gimbal controls and settings.
+The Gimbal indicator appears in the toolbar when the vehicle supports the [MAVLink Gimbal Protocol v2](https://mavlink.io/en/services/gimbal_v2.html). It displays the current gimbal status and provides controls for gimbal operation.
+
+#### Gimbal Status Display
+
+The toolbar indicator shows:
+
+* **Pitch angle** - Current pitch position in degrees
+* **Yaw value** - Either local yaw (relative to vehicle heading) or azimuth (absolute earth frame), depending on settings
+* **Yaw Lock status** - Visual indicator showing whether yaw lock is enabled or disabled
+  * **Yaw Lock (Locked icon)** - Gimbal yaw is locked to earth frame (maintains absolute heading)
+  * **Yaw Follow (Follow icon)** - Gimbal yaw follows vehicle body frame (rotates with vehicle)
+
+#### Gimbal Controls
+
+Clicking the gimbal indicator opens a dropdown panel with the following controls:
+
+##### Quick controls
+
+* **Center** - Points the gimbal forward (0° pitch, 0° yaw relative to vehicle)
+* **Tilt 90** - Points the gimbal straight down (-90° pitch)
+* **Point Home** - Points the gimbal towards the home position
+* **Retract** - Sets gimbal to retracted position. This is not supported by all gimbals.
+* **Yaw Lock/Unlock** - More info below
+* **Gimbal Control Acquisition** - More info below
+
+##### Yaw Lock Mode Toggle
+
+Toggle between two yaw control modes:
+
+* **Yaw Lock** - Gimbal maintains a fixed heading relative to earth/north. When the vehicle rotates, the gimbal counter-rotates to maintain its absolute heading.
+* **Yaw Follow** - Gimbal yaw is relative to the vehicle body. When the vehicle rotates, the gimbal rotates with it.
+
+##### Gimbal Control Acquisition
+
+If the option "Show Acquire/Release control button" is set, a new **Acquire/Release Control** button will appear
+* Click to request control from the current operator, or to release control if we have it.
+* Control is typically needed before sending gimbal commands. If not in control, **it will be requested automatically** when sending other commands.
+
+#### Yaw Lock Behavior with Center and Tilt 90 Commands
+
+By default, the Center and Tilt 90 buttons will also set yaw to follow mode. This is the typical user expectation for these commands.
+
+**Example**: If you're in Yaw Lock mode and press "Center", the gimbal will point forward relative to the vehicle (Yaw Follow mode) rather than maintaining its absolute earth heading.
+
+To change this behaviour and preserve last yaw lock status, you can enable the setting "Preserve yaw lock status on tilt 90 and center commands, don't force yaw follow".
 
 ### VTOL Transitions <img src="../../../assets/fly/toolbar/vtol_indicator.png" alt="VTOL indicator" style="height: 1.15em; vertical-align: text-bottom;" />
 

--- a/docs/en/qgc-user-guide/fly_view/fly_view_toolbar.md
+++ b/docs/en/qgc-user-guide/fly_view/fly_view_toolbar.md
@@ -92,7 +92,51 @@ The RC RSSI indicator appears when RC signal information is available. It shows 
 
 ### Gimbal <img src="../../../assets/fly/toolbar/gimbal_indicator.png" alt="Gimbal indicator" style="height: 1.15em; vertical-align: text-bottom;" />
 
-The Gimbal indicator is shown when the vehicle supports the [MAVLink Gimbal Protocol](https://mavlink.io/en/services/gimbal_v2.html). It displays active gimbal status and provides access to gimbal controls and settings.
+The Gimbal indicator appears in the toolbar when the vehicle supports the [MAVLink Gimbal Protocol v2](https://mavlink.io/en/services/gimbal_v2.html). It displays the current gimbal status and provides controls for gimbal operation.
+
+#### Gimbal Status Display
+
+The toolbar indicator shows:
+
+* **Pitch angle** - Current pitch position in degrees
+* **Yaw value** - Either local yaw (relative to vehicle heading) or azimuth (absolute earth frame), depending on settings
+* **Yaw Lock status** - Visual indicator showing whether yaw lock is enabled or disabled
+  * **Yaw Lock (Locked icon)** - Gimbal yaw is locked to earth frame (maintains absolute heading)
+  * **Yaw Follow (Follow icon)** - Gimbal yaw follows vehicle body frame (rotates with vehicle)
+
+#### Gimbal Controls
+
+Clicking the gimbal indicator opens a dropdown panel with the following controls:
+
+##### Quick controls
+
+* **Center** - Points the gimbal forward (0° pitch, 0° yaw relative to vehicle)
+* **Tilt 90** - Points the gimbal straight down (-90° pitch)
+* **Point Home** - Points the gimbal towards the home position
+* **Retract** - Sets gimbal to retracted position. This is not supported by all gimbals.
+* **Yaw Lock/Unlock** - More info below
+* **Gimbal Control Acquisition** - More info below
+
+##### Yaw Lock Mode Toggle
+
+Toggle between two yaw control modes:
+
+* **Yaw Lock** - Gimbal maintains a fixed heading relative to earth/north. When the vehicle rotates, the gimbal counter-rotates to maintain its absolute heading.
+* **Yaw Follow** - Gimbal yaw is relative to the vehicle body. When the vehicle rotates, the gimbal rotates with it.
+
+##### Gimbal Control Acquisition
+
+If the option "Show Acquire/Release control button" is set, a new **Acquire/Release Control** button will appear
+* Click to request control from the current operator, or to release control if we have it.
+* Control is typically needed before sending gimbal commands. If not in control, **it will be requested automatically** when sending other commands.
+
+#### Yaw Lock Behavior with Center and Tilt 90 Commands
+
+By default, the Center and Tilt 90 buttons will also set yaw to follow mode. This is the typical user expectation for these commands.
+
+**Example**: If you're in Yaw Lock mode and press "Center", the gimbal will point forward relative to the vehicle (Yaw Follow mode) rather than maintaining its absolute earth heading.
+
+To change this behaviour and preserve last yaw lock status, you can enable the setting "Preserve yaw lock status on tilt 90 and center commands, don't force yaw follow".
 
 ### VTOL Transitions <img src="../../../assets/fly/toolbar/vtol_indicator.png" alt="VTOL indicator" style="height: 1.15em; vertical-align: text-bottom;" />
 

--- a/src/Gimbal/GimbalController.cc
+++ b/src/Gimbal/GimbalController.cc
@@ -425,7 +425,32 @@ void GimbalController::centerGimbal()
         qCCritical(GimbalControllerLog) << "gimbalYawStep: active gimbal is nullptr, returning";
         return;
     }
-    sendPitchBodyYaw(0.0, 0.0, true);
+
+    const bool preserveYawLock = SettingsManager::instance()->gimbalControllerSettings()->preserveYawLockOnPositionCommands()->rawValue().toBool();
+    if (preserveYawLock && _activeGimbal->yawLock()) {
+        // Preserve yaw lock: send command in earth frame with yaw lock flag
+        sendPitchAbsoluteYaw(0.0, _vehicle->heading()->rawValue().toFloat(), true);
+    } else {
+        // Default behavior: send command in body frame (yaw follow)
+        sendPitchBodyYaw(0.0, 0.0, true);
+    }
+}
+
+void GimbalController::tilt90Gimbal()
+{
+    if (!_activeGimbal) {
+        qCDebug(GimbalControllerLog) << "tilt90Gimbal: active gimbal is nullptr, returning";
+        return;
+    }
+
+    const bool preserveYawLock = SettingsManager::instance()->gimbalControllerSettings()->preserveYawLockOnPositionCommands()->rawValue().toBool();
+    if (preserveYawLock && _activeGimbal->yawLock()) {
+        // Preserve yaw lock: send command in earth frame with yaw lock flag
+        sendPitchAbsoluteYaw(-90.0, _activeGimbal->absoluteYaw()->rawValue().toFloat(), true);
+    } else {
+        // Default behavior: send command in body frame (yaw follow)
+        sendPitchBodyYaw(-90.0, 0.0, true);
+    }
 }
 
 void GimbalController::gimbalOnScreenControl(float panPct, float tiltPct, bool clickAndPoint, bool clickAndDrag, bool /*rateControl*/, bool /*retract*/, bool /*neutral*/, bool /*yawlock*/)

--- a/src/Gimbal/GimbalController.cc
+++ b/src/Gimbal/GimbalController.cc
@@ -451,7 +451,32 @@ void GimbalController::centerGimbal()
         qCCritical(GimbalControllerLog) << "gimbalYawStep: active gimbal is nullptr, returning";
         return;
     }
-    sendPitchBodyYaw(0.0, 0.0, true);
+
+    const bool preserveYawLock = SettingsManager::instance()->gimbalControllerSettings()->preserveYawLockOnPositionCommands()->rawValue().toBool();
+    if (preserveYawLock && _activeGimbal->yawLock()) {
+        // Preserve yaw lock: send command in earth frame with yaw lock flag
+        sendPitchAbsoluteYaw(0.0, _vehicle->heading()->rawValue().toFloat(), true);
+    } else {
+        // Default behavior: send command in body frame (yaw follow)
+        sendPitchBodyYaw(0.0, 0.0, true);
+    }
+}
+
+void GimbalController::tilt90Gimbal()
+{
+    if (!_activeGimbal) {
+        qCDebug(GimbalControllerLog) << "tilt90Gimbal: active gimbal is nullptr, returning";
+        return;
+    }
+
+    const bool preserveYawLock = SettingsManager::instance()->gimbalControllerSettings()->preserveYawLockOnPositionCommands()->rawValue().toBool();
+    if (preserveYawLock && _activeGimbal->yawLock()) {
+        // Preserve yaw lock: send command in earth frame with yaw lock flag
+        sendPitchAbsoluteYaw(-90.0, _activeGimbal->absoluteYaw()->rawValue().toFloat(), true);
+    } else {
+        // Default behavior: send command in body frame (yaw follow)
+        sendPitchBodyYaw(-90.0, 0.0, true);
+    }
 }
 
 void GimbalController::gimbalOnScreenControl(float panPct, float tiltPct, bool clickAndPoint, bool clickAndDrag, bool /*rateControl*/, bool /*retract*/, bool /*neutral*/, bool /*yawlock*/)

--- a/src/Gimbal/GimbalController.h
+++ b/src/Gimbal/GimbalController.h
@@ -54,6 +54,7 @@ public slots:
     // These slots are conected with joysticks for button control
     void gimbalYawLock(bool yawLock) { setGimbalYawLock(yawLock); }
     Q_INVOKABLE void centerGimbal();
+    Q_INVOKABLE void tilt90Gimbal();
     void gimbalPitchStart(int direction);
     void gimbalYawStart(int direction);
     void gimbalPitchStop();

--- a/src/Gimbal/GimbalController.h
+++ b/src/Gimbal/GimbalController.h
@@ -52,6 +52,7 @@ public slots:
     // These slots are conected with joysticks for button control
     void gimbalYawLock(bool yawLock) { setGimbalYawLock(yawLock); }
     Q_INVOKABLE void centerGimbal();
+    Q_INVOKABLE void tilt90Gimbal();
     void gimbalPitchStart(int direction);
     void gimbalYawStart(int direction);
     void gimbalPitchStop();

--- a/src/Settings/GimbalController.SettingsGroup.json
+++ b/src/Settings/GimbalController.SettingsGroup.json
@@ -75,6 +75,13 @@
     "type":              "uint32",
     "default":           60,
     "units":             "deg/s"
+},
+{
+    "name":              "preserveYawLockOnPositionCommands",
+    "shortDesc":         "Preserve yaw lock state when using position commands",
+    "longDesc":          "When enabled, gimbal position commands will maintain the current yaw lock state instead of automatically switching to yaw follow mode.",
+    "type":              "bool",
+    "default":           true
 }
 ]
 }

--- a/src/Settings/GimbalController.SettingsGroup.json
+++ b/src/Settings/GimbalController.SettingsGroup.json
@@ -81,7 +81,7 @@
     "shortDesc":         "Preserve yaw lock state when using position commands",
     "longDesc":          "When enabled, gimbal position commands will maintain the current yaw lock state instead of automatically switching to yaw follow mode.",
     "type":              "bool",
-    "default":           true
+    "default":           false
 }
 ]
 }

--- a/src/Settings/GimbalController.SettingsGroup.json
+++ b/src/Settings/GimbalController.SettingsGroup.json
@@ -85,6 +85,13 @@
             "default": 60,
             "units": "deg/s",
             "label": "Minimum gimbal speed for max zoom (deg/sec)"
+        },
+        {
+            "name": "preserveYawLockOnPositionCommands",
+            "shortDesc": "Preserve yaw lock state when using position commands",
+            "longDesc": "When enabled, gimbal position commands will maintain the current yaw lock state instead of automatically switching to yaw follow mode.",
+            "type": "bool",
+            "default": true
         }
     ]
 }

--- a/src/Settings/GimbalControllerSettings.cc
+++ b/src/Settings/GimbalControllerSettings.cc
@@ -33,3 +33,4 @@ DECLARE_SETTINGSFACT(GimbalControllerSettings, toolbarIndicatorShowAcquireReleas
 DECLARE_SETTINGSFACT(GimbalControllerSettings, joystickButtonsSpeed)
 DECLARE_SETTINGSFACT(GimbalControllerSettings, zoomMaxSpeed)
 DECLARE_SETTINGSFACT(GimbalControllerSettings, zoomMinSpeed)
+DECLARE_SETTINGSFACT(GimbalControllerSettings, preserveYawLockOnPositionCommands)

--- a/src/Settings/GimbalControllerSettings.h
+++ b/src/Settings/GimbalControllerSettings.h
@@ -24,4 +24,5 @@ public:
     DEFINE_SETTINGFACT(joystickButtonsSpeed)
     DEFINE_SETTINGFACT(zoomMaxSpeed)
     DEFINE_SETTINGFACT(zoomMinSpeed)
+    DEFINE_SETTINGFACT(preserveYawLockOnPositionCommands)
 };

--- a/src/Toolbar/GimbalIndicator.qml
+++ b/src/Toolbar/GimbalIndicator.qml
@@ -191,7 +191,7 @@ Item {
                     Layout.fillWidth:   true
                     text:               qsTr("Tilt 90")
                     onClicked: {
-                        gimbalController.sendPitchBodyYaw(-90, 0)
+                        gimbalController.tilt90Gimbal()
                         mainWindow.closeIndicatorDrawer()
                     }
                 }
@@ -310,6 +310,12 @@ Item {
                     Layout.fillWidth:   true
                     text:               qsTr("Show Acquire/Release control button")
                     fact:               _gimbalControllerSettings.toolbarIndicatorShowAcquireReleaseControl
+                }
+
+                FactCheckBoxSlider {
+                    Layout.fillWidth:   true
+                    text:               qsTr("Preserve yaw lock status on tilt 90 and center commands, don't force yaw follow")
+                    fact:               _gimbalControllerSettings.preserveYawLockOnPositionCommands
                 }
             }
         }

--- a/src/UI/toolbar/GimbalIndicator.qml
+++ b/src/UI/toolbar/GimbalIndicator.qml
@@ -184,7 +184,7 @@ Item {
                     Layout.fillWidth:   true
                     text:               qsTr("Tilt 90")
                     onClicked: {
-                        gimbalController.sendPitchBodyYaw(-90, 0)
+                        gimbalController.tilt90Gimbal()
                         mainWindow.closeIndicatorDrawer()
                     }
                 }
@@ -303,6 +303,12 @@ Item {
                     Layout.fillWidth:   true
                     text:               qsTr("Show Acquire/Release control button")
                     fact:               _gimbalControllerSettings.toolbarIndicatorShowAcquireReleaseControl
+                }
+
+                FactCheckBoxSlider {
+                    Layout.fillWidth:   true
+                    text:               qsTr("Preserve yaw lock status on tilt 90 and center commands, don't force yaw follow")
+                    fact:               _gimbalControllerSettings.preserveYawLockOnPositionCommands
                 }
             }
         }


### PR DESCRIPTION
Folowing https://github.com/mavlink/qgroundcontrol/issues/13955#issuecomment-3886154981

For Center and tilt 90 gimbal commands, we were sending setting also the gimbal to follow mode, as that is usually the expected behaviour. We added a new setting now to instead preserve the previous gimbal lock status:
<img width="1370" height="130" alt="Screenshot from 2026-02-18 15-09-08" src="https://github.com/user-attachments/assets/c0ed93b2-a647-4b01-a423-896b5d30e966" />

When this is set, center and tilt 90 will just preserve current gimbal lock/follow status.

Additionally, the top toolbar indicator docs were extended to include some info from this gimbal indicator.

For awareness @DonLakeFlyer.