### PR TITLE
Add support for read-only parameters

### DIFF
--- a/src/FactSystem/FactMetaData.cc
+++ b/src/FactSystem/FactMetaData.cc
@@ -1387,15 +1387,16 @@ FactMetaData *FactMetaData::createFromJsonObject(const QJsonObject &json, const 
     }
     metaData->setVehicleRebootRequired(rebootRequired);
 
+    bool readOnly = false;
+    if (json.contains(_readOnlyJsonKey)) {
+        readOnly = json[_readOnlyJsonKey].toBool();
+    }
+    metaData->setReadOnly(readOnly);
+
     bool volatileValue = false;
     if (json.contains(_volatileJsonKey)) {
         volatileValue = json[_volatileJsonKey].toBool();
     }
-
-    if (json.contains(_readOnlyJsonKey)) {
-        metaData->setReadOnly(json[_readOnlyJsonKey].toBool());
-    }
-
     metaData->setVolatileValue(volatileValue);
     if (json.contains(_groupJsonKey)) {
         metaData->setGroup(json[_groupJsonKey].toString());

--- a/src/FactSystem/FactMetaData.cc
+++ b/src/FactSystem/FactMetaData.cc
@@ -1485,9 +1485,6 @@ QVariant FactMetaData::cookedMin() const
 void FactMetaData::setVolatileValue(bool bValue)
 {
     _volatile = bValue;
-    if (_volatile) {
-        _readOnly = true;
-    }
 }
 
 QStringList FactMetaData::splitTranslatedList(const QString &translatedList)

--- a/src/FactSystem/FactMetaData.cc
+++ b/src/FactSystem/FactMetaData.cc
@@ -1391,12 +1391,12 @@ FactMetaData *FactMetaData::createFromJsonObject(const QJsonObject &json, const 
     if (json.contains(_volatileJsonKey)) {
         volatileValue = json[_volatileJsonKey].toBool();
     }
-    metaData->setVolatileValue(volatileValue);
 
     if (json.contains(_readOnlyJsonKey)) {
         metaData->setReadOnly(json[_readOnlyJsonKey].toBool());
     }
 
+    metaData->setVolatileValue(volatileValue);
     if (json.contains(_groupJsonKey)) {
         metaData->setGroup(json[_groupJsonKey].toString());
     }

--- a/src/QmlControls/ParameterEditor.qml
+++ b/src/QmlControls/ParameterEditor.qml
@@ -166,6 +166,12 @@ Item {
                     clearTimer.start()
                 }
             }
+
+            QGCCheckBox {
+                text:       qsTr("Hide read-only")
+                checked:    controller.hideReadOnly
+                onClicked:  controller.hideReadOnly = checked
+            }
         }
 
         QGCButton {
@@ -345,7 +351,7 @@ Item {
         delegate: Rectangle {
             implicitWidth:  column === 0 ? ScreenTools.implicitCheckBoxHeight + ScreenTools.defaultFontPixelWidth
                                          : column === 2 ? ScreenTools.defaultFontPixelWidth * 16
-                                                        : label.contentWidth + ScreenTools.defaultFontPixelWidth
+                                                        : nameRow.implicitWidth + ScreenTools.defaultFontPixelWidth
             implicitHeight: label.contentHeight + ScreenTools.defaultFontPixelHeight * 0.5
             color:          row % 2 === 0 ? "transparent" : qgcPal.windowShade
             clip:           true
@@ -383,9 +389,34 @@ Item {
                 onClicked:              controller.toggleFavorite(fact.name)
             }
 
+            Row {
+                id:                     nameRow
+                visible:                column === 1
+                anchors.left:           parent.left
+                anchors.leftMargin:     ScreenTools.defaultFontPixelWidth / 2
+                anchors.verticalCenter: parent.verticalCenter
+                spacing:               lockIcon.visible ? ScreenTools.defaultFontPixelWidth / 3 : 0
+
+                QGCColoredImage {
+                    id:                 lockIcon
+                    visible:            fact.readOnly
+                    source:             "qrc:/InstrumentValueIcons/lock-closed.svg"
+                    color:              qgcPal.text
+                    width:              ScreenTools.defaultFontPixelHeight * 0.8
+                    height:             width
+                    sourceSize.width:   width
+                    anchors.verticalCenter: parent.verticalCenter
+                }
+
+                QGCLabel {
+                    text:               display
+                    anchors.verticalCenter: parent.verticalCenter
+                }
+            }
+
             QGCLabel {
                 id:                 label
-                visible:            column !== 0
+                visible:            column !== 0 && column !== 1
                 anchors.left:       parent.left
                 anchors.leftMargin: ScreenTools.defaultFontPixelWidth / 2
                 anchors.verticalCenter: parent.verticalCenter

--- a/src/QmlControls/ParameterEditor.qml
+++ b/src/QmlControls/ParameterEditor.qml
@@ -350,8 +350,9 @@ Item {
 
         delegate: Rectangle {
             implicitWidth:  column === 0 ? ScreenTools.implicitCheckBoxHeight + ScreenTools.defaultFontPixelWidth
+                                         : column === 1 ? nameRow.implicitWidth + ScreenTools.defaultFontPixelWidth
                                          : column === 2 ? ScreenTools.defaultFontPixelWidth * 16
-                                                        : nameRow.implicitWidth + ScreenTools.defaultFontPixelWidth
+                                                        : label.contentWidth + ScreenTools.defaultFontPixelWidth
             implicitHeight: label.contentHeight + ScreenTools.defaultFontPixelHeight * 0.5
             color:          row % 2 === 0 ? "transparent" : qgcPal.windowShade
             clip:           true
@@ -409,7 +410,7 @@ Item {
                 }
 
                 QGCLabel {
-                    text:               display
+                    text:               column === 1 ? display : ""
                     anchors.verticalCenter: parent.verticalCenter
                 }
             }

--- a/src/QmlControls/ParameterEditor.qml
+++ b/src/QmlControls/ParameterEditor.qml
@@ -398,6 +398,11 @@ Item {
                 anchors.verticalCenter: parent.verticalCenter
                 spacing:               lockIcon.visible ? ScreenTools.defaultFontPixelWidth / 3 : 0
 
+                QGCLabel {
+                    text:               column === 1 ? display : ""
+                    anchors.verticalCenter: parent.verticalCenter
+                }
+
                 QGCColoredImage {
                     id:                 lockIcon
                     visible:            fact.readOnly
@@ -406,11 +411,6 @@ Item {
                     width:              ScreenTools.defaultFontPixelHeight * 0.8
                     height:             width
                     sourceSize.width:   width
-                    anchors.verticalCenter: parent.verticalCenter
-                }
-
-                QGCLabel {
-                    text:               column === 1 ? display : ""
                     anchors.verticalCenter: parent.verticalCenter
                 }
             }

--- a/src/QmlControls/ParameterEditorController.cc
+++ b/src/QmlControls/ParameterEditorController.cc
@@ -166,6 +166,7 @@ ParameterEditorController::ParameterEditorController(QObject *parent)
     connect(this, &ParameterEditorController::searchTextChanged,        this, &ParameterEditorController::_searchTextChanged);
     connect(this, &ParameterEditorController::showModifiedOnlyChanged,  this, &ParameterEditorController::_searchTextChanged);
     connect(this, &ParameterEditorController::showFavoritesOnlyChanged, this, &ParameterEditorController::_searchTextChanged);
+    connect(this, &ParameterEditorController::hideReadOnlyChanged,     this, &ParameterEditorController::_hideReadOnlyChanged);
     connect(&_searchTimer, &QTimer::timeout,                            this, &ParameterEditorController::_performSearch);
     connect(_parameterMgr, &ParameterManager::factAdded,                this, &ParameterEditorController::_factAdded);
 
@@ -184,6 +185,10 @@ void ParameterEditorController::_buildListsForComponent(int compId)
 {
     for (const QString& factName: _parameterMgr->parameterNames(compId)) {
         Fact* fact = _parameterMgr->getParameter(compId, factName);
+
+        if (_hideReadOnly && fact->readOnly()) {
+            continue;
+        }
 
         ParameterEditorCategory* category = nullptr;
         if (_mapCategoryName2Category.contains(fact->category())) {
@@ -262,6 +267,10 @@ void ParameterEditorController::_buildLists(void)
 
 void ParameterEditorController::_factAdded(int compId, Fact* fact)
 {
+    if (_hideReadOnly && fact->readOnly()) {
+        return;
+    }
+
     bool                        inserted = false;
     ParameterEditorCategory*    category = nullptr;
 
@@ -476,6 +485,9 @@ void ParameterEditorController::resetAllToVehicleConfiguration(void)
 
 bool ParameterEditorController::_shouldShow(Fact* fact) const
 {
+    if (_hideReadOnly && fact->readOnly()) {
+        return false;
+    }
     if (_showModifiedOnly) {
         if (!fact->defaultValueAvailable() || fact->valueEqualsDefault()) {
             return false;
@@ -492,6 +504,26 @@ bool ParameterEditorController::_shouldShow(Fact* fact) const
 void ParameterEditorController::_searchTextChanged(void)
 {
     _searchTimer.start();
+}
+
+void ParameterEditorController::_hideReadOnlyChanged(void)
+{
+    _currentCategory = nullptr;
+    _currentGroup = nullptr;
+    _parameters = nullptr;
+    _mapCategoryName2Category.clear();
+    _categories.clearAndDeleteContents();
+    emit parametersChanged();
+
+    _buildLists();
+
+    ParameterEditorCategory* category = _categories.count() ? _categories.value<ParameterEditorCategory*>(0) : nullptr;
+    setCurrentCategory(category);
+
+    // Re-trigger search if active
+    if (!_searchText.isEmpty() || _showModifiedOnly) {
+        _performSearch();
+    }
 }
 
 void ParameterEditorController::_performSearch(void)

--- a/src/QmlControls/ParameterEditorController.cc
+++ b/src/QmlControls/ParameterEditorController.cc
@@ -217,6 +217,13 @@ void ParameterEditorController::_buildListsForComponent(int compId)
 
 void ParameterEditorController::_buildLists(void)
 {
+    _currentCategory = nullptr;
+    _currentGroup = nullptr;
+    _parameters = nullptr;
+    _mapCategoryName2Category.clear();
+    _categories.clearAndDeleteContents();
+    emit parametersChanged();
+
     // Autopilot component should always be first list
     _buildListsForComponent(MAV_COMP_ID_AUTOPILOT1);
 
@@ -508,13 +515,6 @@ void ParameterEditorController::_searchTextChanged(void)
 
 void ParameterEditorController::_hideReadOnlyChanged(void)
 {
-    _currentCategory = nullptr;
-    _currentGroup = nullptr;
-    _parameters = nullptr;
-    _mapCategoryName2Category.clear();
-    _categories.clearAndDeleteContents();
-    emit parametersChanged();
-
     _buildLists();
 
     ParameterEditorCategory* category = _categories.count() ? _categories.value<ParameterEditorCategory*>(0) : nullptr;

--- a/src/QmlControls/ParameterEditorController.h
+++ b/src/QmlControls/ParameterEditorController.h
@@ -132,6 +132,7 @@ class ParameterEditorController : public FactPanelController
     Q_PROPERTY(QAbstractTableModel* parameters              MEMBER _parameters                                          NOTIFY parametersChanged)
     Q_PROPERTY(bool                 showModifiedOnly        MEMBER _showModifiedOnly                                    NOTIFY showModifiedOnlyChanged)
     Q_PROPERTY(bool                 showFavoritesOnly       MEMBER _showFavoritesOnly                                   NOTIFY showFavoritesOnlyChanged)
+    Q_PROPERTY(bool                 hideReadOnly            MEMBER _hideReadOnly                                        NOTIFY hideReadOnlyChanged)
     Q_PROPERTY(QStringList          favoriteParameterNames  READ favoriteParameterNames                                 NOTIFY favoritesChanged)
 
     // These property are related to the diff associated with a load from file
@@ -168,6 +169,7 @@ signals:
     void currentGroupChanged            (void);
     void showModifiedOnlyChanged        (void);
     void showFavoritesOnlyChanged       (void);
+    void hideReadOnlyChanged            (void);
     void favoritesChanged               (void);
     void diffOtherVehicleChanged        (bool diffOtherVehicle);
     void diffMultipleComponentsChanged  (bool diffMultipleComponents);
@@ -177,6 +179,7 @@ private slots:
     void _currentCategoryChanged(void);
     void _currentGroupChanged   (void);
     void _searchTextChanged     (void);
+    void _hideReadOnlyChanged   (void);
     void _buildLists            (void);
     void _buildListsForComponent(int compId);
     void _factAdded             (int compId, Fact* fact);
@@ -195,6 +198,7 @@ private:
     ParameterEditorGroup*       _currentGroup           = nullptr;
     bool                        _showModifiedOnly       = false;
     bool                        _showFavoritesOnly      = false;
+    bool                        _hideReadOnly           = false;
     bool                        _diffOtherVehicle       = false;
     bool                        _diffMultipleComponents = false;
     QSet<QString>               _favoriteNames;

--- a/src/QmlControls/ParameterEditorDialog.qml
+++ b/src/QmlControls/ParameterEditorDialog.qml
@@ -11,7 +11,7 @@ QGCPopupDialog {
     id:         root
     title:      fact.componentId > 0 ? fact.name : qsTr("Value Editor")
 
-    buttons:    Dialog.Save | (validate ? 0 : Dialog.Cancel)
+    buttons:    fact.readOnly ? Dialog.Close : (Dialog.Save | (validate ? 0 : Dialog.Cancel))
 
     property Fact   fact
     property bool   showRCToParam:  false
@@ -79,6 +79,13 @@ QGCPopupDialog {
         spacing:    globals.defaultTextHeight
 
         QGCLabel {
+            Layout.fillWidth:   true
+            wrapMode:           Text.WordWrap
+            text:               qsTr("This parameter is read-only and cannot be modified.")
+            visible:            fact.readOnly
+        }
+
+        QGCLabel {
             id:                 validationError
             Layout.fillWidth:   true
             wrapMode:           Text.WordWrap
@@ -89,6 +96,7 @@ QGCPopupDialog {
         RowLayout {
             id:         editRow
             spacing:    ScreenTools.defaultFontPixelWidth
+            visible:    !fact.readOnly
 
             QGCTextField {
                 id:                 valueField
@@ -137,10 +145,15 @@ QGCPopupDialog {
             }
         }
 
+        QGCLabel {
+            visible:            fact.readOnly
+            text:               qsTr("Value: ") + fact.valueString + (fact.units != "" ? (" " + fact.units) : "")
+        }
+
         Column {
             id:         bitmaskColumn
             spacing:    ScreenTools.defaultFontPixelHeight / 2
-            visible:    fact.bitmaskStrings.length > 0
+            visible:    fact.bitmaskStrings.length > 0 && !fact.readOnly
 
             Repeater {
                 id:     bitmaskRepeater
@@ -207,7 +220,7 @@ QGCPopupDialog {
             wrapMode:   Text.WordWrap
             text:       qsTr("Warning: Modifying values while vehicle is in flight can lead to vehicle instability and possible vehicle loss. ") +
                         qsTr("Make sure you know what you are doing and double-check your values before Save!")
-            visible:    fact.componentId != -1
+            visible:    fact.componentId != -1 && !fact.readOnly
         }
 
         QGCCheckBox {
@@ -219,7 +232,7 @@ QGCPopupDialog {
         QGCCheckBox {
             id:         _advanced
             text:       qsTr("Advanced settings")
-            visible:    showRCToParam || factCombo.visible || bitmaskColumn.visible
+            visible:    !fact.readOnly && (showRCToParam || factCombo.visible || bitmaskColumn.visible)
         }
 
         // Checkbox to allow manual entry of enumerated or bitmask parameters

--- a/src/QmlControls/ParameterEditorDialog.qml
+++ b/src/QmlControls/ParameterEditorDialog.qml
@@ -31,6 +31,7 @@ QGCPopupDialog {
     QGCPalette { id: qgcPal; colorGroupEnabled: true }
 
     onAccepted: {
+        if (fact.readOnly) return
         if (bitmaskColumn.visible && !manualEntry.checked) {
             fact.value = bitmaskValue();
             fact.valueChanged(fact.value)


### PR DESCRIPTION
## Description

This parses the readonly flag for a parameter, so that it's clear in the UI when a param can't be set.

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] CI/Build changes
- [ ] Other

## Testing

- [ ] Tested locally
- [ ] Added/updated unit tests
- [ ] Tested with simulator (SITL)
- [x] Tested with hardware

### Platforms Tested

- [x] Linux
- [ ] Windows
- [ ] macOS
- [ ] Android
- [ ] iOS

### Flight Stacks Tested

- [x] PX4
- [ ] ArduPilot

## Screenshots

<img width="1726" height="705" alt="image" src="https://github.com/user-attachments/assets/23a9a422-9147-4d47-acd9-a89e17f635a1" />

## Checklist

- [x] I have read the [Contribution Guidelines](CONTRIBUTING.md)
- [x] I have read the [Code of Conduct](CODE_OF_CONDUCT.md)
- [x] My code follows the project's coding standards
- [ ] I have added tests that prove my fix/feature works
- [ ] New and existing unit tests pass locally

## Related Issues

Goes together with https://github.com/PX4/PX4-Autopilot/pull/26522.

---
By submitting this pull request, I confirm that my contribution is made under the terms of the project's dual license (Apache 2.0 and GPL v3).
