### PR TITLE
APM: Fix canBeSet=false for non-user-selectable flight modes

### DIFF
--- a/src/FirmwarePlugin/APM/ArduPlaneFirmwarePlugin.cc
+++ b/src/FirmwarePlugin/APM/ArduPlaneFirmwarePlugin.cc
@@ -54,7 +54,7 @@ ArduPlaneFirmwarePlugin::ArduPlaneFirmwarePlugin(QObject *parent)
         { _takeoffFlightMode      , APMPlaneMode::TAKEOFF       , true , true },
         { _avoidADSBFlightMode    , APMPlaneMode::AVOID_ADSB    , true , true },
         { _guidedFlightMode       , APMPlaneMode::GUIDED        , true , true },
-        { _initializingFlightMode , APMPlaneMode::INITIALIZING  , true , true },
+        { _initializingFlightMode , APMPlaneMode::INITIALIZING  , false, true },
         { _qStabilizeFlightMode   , APMPlaneMode::QSTABILIZE    , true , true },
         { _qHoverFlightMode       , APMPlaneMode::QHOVER        , true , true },
         { _qLoiterFlightMode      , APMPlaneMode::QLOITER       , true , true },

--- a/src/FirmwarePlugin/APM/ArduRoverFirmwarePlugin.cc
+++ b/src/FirmwarePlugin/APM/ArduRoverFirmwarePlugin.cc
@@ -30,7 +30,7 @@ ArduRoverFirmwarePlugin::ArduRoverFirmwarePlugin(QObject *parent)
         // Mode Name              , Custom Mode                CanBeSet  adv
         { _manualFlightMode       , APMRoverMode::MANUAL       , true , true},
         { _acroFlightMode         , APMRoverMode::ACRO         , true , true},
-        { _learningFlightMode     , APMRoverMode::LEARNING     , true , true},
+        { _learningFlightMode     , APMRoverMode::LEARNING     , false, true},
         { _steeringFlightMode     , APMRoverMode::STEERING     , true , true},
         { _holdFlightMode         , APMRoverMode::HOLD         , true , true},
         { _loiterFlightMode       , APMRoverMode::LOITER       , true , true},
@@ -42,7 +42,7 @@ ArduRoverFirmwarePlugin::ArduRoverFirmwarePlugin(QObject *parent)
         { _rtlFlightMode          , APMRoverMode::RTL          , true , true},
         { _smartRtlFlightMode     , APMRoverMode::SMART_RTL    , true , true},
         { _guidedFlightMode       , APMRoverMode::GUIDED       , true , true},
-        { _initializingFlightMode , APMRoverMode::INITIALIZING , true , true},
+        { _initializingFlightMode , APMRoverMode::INITIALIZING , false, true},
     };
     updateAvailableFlightModes(availableFlightModes);
 

--- a/src/FirmwarePlugin/APM/ArduSubFirmwarePlugin.cc
+++ b/src/FirmwarePlugin/APM/ArduSubFirmwarePlugin.cc
@@ -119,7 +119,7 @@ ArduSubFirmwarePlugin::ArduSubFirmwarePlugin(QObject *parent)
         { _circleFlightMode         , APMSubMode::CIRCLE            , true , true },
         { _surfaceFlightMode        , APMSubMode::SURFACE           , true , true },
         { _posHoldFlightMode        , APMSubMode::POSHOLD           , true , true },
-        { _motorDetectionFlightMode , APMSubMode::MOTORDETECTION    , true , true },
+        { _motorDetectionFlightMode , APMSubMode::MOTORDETECTION    , false, true },
         { _surftrakFlightMode       , APMSubMode::SURFTRAK          , true , true },
     };
     updateAvailableFlightModes(availableFlightModes);


### PR DESCRIPTION
## Summary

- `INITIALIZING` (ArduPlane, ArduRover), `LEARNING` (ArduRover), and `MOTORDETECTION` (ArduSub) are internal/autonomous modes that cannot be meaningfully commanded by the user
- These were incorrectly marked `canBeSet=true`, causing them to appear in the flight modes menu
- Mark them `canBeSet=false` so `Vehicle::flightModes()` filters them out of the UI
- Related to https://github.com/ArduPilot/ardupilot/issues/31761
