### PR TITLE
Add comprehensive logging for Actuators page visibility debugging

### DIFF
--- a/src/Vehicle/Actuators/Actuators.h
+++ b/src/Vehicle/Actuators/Actuators.h
@@ -59,6 +59,8 @@ public:
     bool hasUnsetRequiredFunctions() const { return _hasUnsetRequiredFunctions; }
 
     bool showUi() const;
+    bool isInitialized() const { return _init; }
+    const QString& initializationError() const { return _initError; }
 
     QmlObjectListModel* actuatorActions() { return _actuatorActions; }
 
@@ -102,6 +104,7 @@ private:
     QSet<Fact*> _subscribedFacts{};
     QJsonDocument _jsonMetadata;
     bool _init{false};
+    QString _initError;
     Condition _showUi;
     QmlObjectListModel* _actuatorOutputs = new QmlObjectListModel(this); ///< list of ActuatorOutputs::ActuatorOutput*
     QmlObjectListModel* _actuatorActions = new QmlObjectListModel(this); ///< list of ActuatorActionGroup*

--- a/src/Vehicle/Actuators/Common.h
+++ b/src/Vehicle/Actuators/Common.h
@@ -93,8 +93,10 @@ public:
      * Constructor
      * @param condition generic form: true|false|<param_name><operation><signed integer>
      *                  where: <operation>: [>,>=,==,!=,<,<=]
+     * @param parameterManager parameter manager to resolve parameter names
+     * @param label optional label for debug logging (e.g., "show-ui-if")
      */
-    Condition(const QString& condition, ParameterManager* parameterManager);
+    Condition(const QString& condition, ParameterManager* parameterManager, const QString& label = QString());
 
     bool evaluate() const;
 
@@ -104,6 +106,8 @@ public:
 
 private:
     QString _parameter{};
+    QString _label{};
+    QString _alwaysTrueReason{QStringLiteral("empty/default")};
     Operation _operation{Operation::AlwaysTrue};
     int32_t _value{0};
     Fact* _fact{nullptr};

--- a/src/Vehicle/Actuators/Mixer.cc
+++ b/src/Vehicle/Actuators/Mixer.cc
@@ -395,7 +395,7 @@ void Mixers::reset(const ActuatorTypes& actuatorTypes, const MixerOptions& mixer
     _rules = rules;
     _mixerConditions.clear();
     for (const auto& mixerOption : _mixerOptions) {
-        _mixerConditions.append(Condition(mixerOption.option, _parameterManager));
+        _mixerConditions.append(Condition(mixerOption.option, _parameterManager, "mixer-option"));
     }
     update();
 }


### PR DESCRIPTION
- Add label parameter to Condition class to identify condition types (show-ui-if, show-subgroups-if, etc.)
- Enhanced Condition::evaluate() with detailed logging showing:
  * Parameter names and actual values
  * Comparison operations and results
  * Why conditions pass or fail
- Add single diagnostic log point in PX4AutoPilotPlugin explaining exactly why Actuators page shows or doesn't show
- Add isInitialized() accessor to Actuators class
- Log all condition types: empty/default, literal true/false, and parameter-based

This makes it much easier to debug why the Actuators page may not appear for a vehicle. Enable with: Vehicle.ActuatorsConfig logging turned on.

Related to #13909