### PR TITLE
Add unit test for VehicleCameraControl capability flag mapping

### DIFF
--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -81,6 +81,7 @@ add_qgc_test(MavlinkLogTest LABELS Integration AnalyzeView Vehicle RESOURCE_LOCK
 # ----------------------------------------------------------------------------
 add_subdirectory(Camera)
 add_qgc_test(QGCCameraManagerTest LABELS Integration Vehicle RESOURCE_LOCK MockLink)
+add_qgc_test(VehicleCameraControlTest LABELS Integration Vehicle RESOURCE_LOCK MockLink)
 add_qgc_test(QGCVideoStreamInfoTest LABELS Unit Camera)
 add_qgc_test(VideoManagerTest LABELS Unit)
 

--- a/test/Camera/CMakeLists.txt
+++ b/test/Camera/CMakeLists.txt
@@ -7,6 +7,8 @@ target_sources(${CMAKE_PROJECT_NAME}
     PRIVATE
         QGCCameraManagerTest.cc
         QGCCameraManagerTest.h
+        VehicleCameraControlTest.cc
+        VehicleCameraControlTest.h
         QGCVideoStreamInfoTest.cc
         QGCVideoStreamInfoTest.h
         VideoManagerTest.cc

--- a/test/Camera/VehicleCameraControlTest.cc
+++ b/test/Camera/VehicleCameraControlTest.cc
@@ -1,0 +1,185 @@
+#include "VehicleCameraControlTest.h"
+
+#include <QtTest/QSignalSpy>
+#include <QtTest/QTest>
+
+#include "LinkManager.h"
+#include "MavlinkCameraControl.h"
+#include "MockConfiguration.h"
+#include "MockLink.h"
+#include "MultiVehicleManager.h"
+#include "QGCCameraManager.h"
+#include "Vehicle.h"
+
+void VehicleCameraControlTest::initTestCase()
+{
+    UnitTest::initTestCase();
+    MultiVehicleManager::instance()->init();
+}
+
+void VehicleCameraControlTest::init()
+{
+    UnitTest::init();
+    _mockLink = nullptr;
+    _vehicle = nullptr;
+}
+
+void VehicleCameraControlTest::cleanup()
+{
+    if (_mockLink) {
+        QSignalSpy spyDisconnect(MultiVehicleManager::instance(), &MultiVehicleManager::activeVehicleChanged);
+        _mockLink->disconnect();
+        _mockLink = nullptr;
+
+        if (_vehicle) {
+            UnitTest::waitForSignal(spyDisconnect, TestTimeout::longMs(), QStringLiteral("activeVehicleChanged"));
+        }
+        _vehicle = nullptr;
+
+        UnitTest::settleEventLoopForCleanup();
+    }
+
+    dumpFailureContextIfTestFailed(QStringLiteral("cleanup"));
+    UnitTest::cleanup();
+}
+
+void VehicleCameraControlTest::_testCameraCapFlags_data()
+{
+    // MockConfiguration camera flags
+    QTest::addColumn<bool>("captureVideo");
+    QTest::addColumn<bool>("captureImage");
+    QTest::addColumn<bool>("hasModes");
+    QTest::addColumn<bool>("hasVideoStream");
+    QTest::addColumn<bool>("canCaptureImageInVideoMode");
+    QTest::addColumn<bool>("canCaptureVideoInImageMode");
+    QTest::addColumn<bool>("hasBasicZoom");
+    QTest::addColumn<bool>("hasTrackingPoint");
+    QTest::addColumn<bool>("hasTrackingRectangle");
+
+    // Expected VehicleCameraControl properties
+    QTest::addColumn<bool>("expectedCapturesVideo");
+    QTest::addColumn<bool>("expectedCapturesPhotos");
+    QTest::addColumn<bool>("expectedHasModes");
+    QTest::addColumn<bool>("expectedHasZoom");
+    QTest::addColumn<bool>("expectedHasVideoStream");
+    QTest::addColumn<bool>("expectedPhotosInVideoMode");
+    QTest::addColumn<bool>("expectedVideoInPhotoMode");
+    QTest::addColumn<bool>("expectedHasTracking");
+
+    // Note: xCapVid and xCapImg (capturesVideo/capturesPhotos) are "virtual" capabilities that account for
+    // local gstreamer support. When a camera has a video stream (HAS_VIDEO_STREAM), QGC can locally record
+    // video via gstreamer and screen-grab photos from the stream, even if the camera itself doesn't support
+    // native video recording or photo capture. See "video-stream-only" and "stream-no-native-capture" rows.
+
+    //                                       capVid   capImg   modes    stream   imgInVid vidInImg zoom     trkPt    trkRect   xCapVid  xCapImg  xModes   xZoom    xStream  xImgVid  xVidImg  xTrack
+    QTest::newRow("all-caps")                << true  << true  << true  << true  << true  << true  << true  << true  << true   << true  << true  << true  << true  << true  << true  << true  << true;
+    QTest::newRow("no-caps")                 << false << false << false << false << false << false << false << false << false  << false << false << false << false << false << false << false << false;
+    QTest::newRow("photo-only")              << false << true  << false << false << false << false << false << false << false  << false << true  << false << false << false << false << false << false;
+    QTest::newRow("video-only")              << true  << false << false << false << false << false << false << false << false  << true  << false << false << false << false << false << false << false;
+    QTest::newRow("video-stream-only")       << false << false << false << true  << false << false << false << false << false  << true  << true  << false << false << true  << false << false << false;
+    QTest::newRow("modes-zoom")              << false << true  << true  << false << false << false << true  << false << false  << false << true  << true  << true  << false << false << false << false;
+    QTest::newRow("tracking-point")          << false << true  << false << false << false << false << false << true  << false  << false << true  << false << false << false << false << false << true;
+    QTest::newRow("tracking-rect")           << false << true  << false << false << false << false << false << false << true   << false << true  << false << false << false << false << false << true;
+    QTest::newRow("tracking-both")           << false << true  << false << false << false << false << false << true  << true   << false << true  << false << false << false << false << false << true;
+    QTest::newRow("image-in-video")          << true  << true  << true  << false << true  << false << false << false << false  << true  << true  << true  << false << false << true  << false << false;
+    QTest::newRow("video-in-image")          << true  << true  << true  << false << false << true  << false << false << false  << true  << true  << true  << false << false << false << true  << false;
+    QTest::newRow("stream-no-native-capture")<< false << false << false << true  << false << false << false << false << false  << true  << true  << false << false << true  << false << false << false;
+    QTest::newRow("stream-plus-photo")       << false << true  << false << true  << false << false << false << false << false  << true  << true  << false << false << true  << false << false << false;
+}
+
+void VehicleCameraControlTest::_testCameraCapFlags()
+{
+    // Fetch test data
+    QFETCH(bool, captureVideo);
+    QFETCH(bool, captureImage);
+    QFETCH(bool, hasModes);
+    QFETCH(bool, hasVideoStream);
+    QFETCH(bool, canCaptureImageInVideoMode);
+    QFETCH(bool, canCaptureVideoInImageMode);
+    QFETCH(bool, hasBasicZoom);
+    QFETCH(bool, hasTrackingPoint);
+    QFETCH(bool, hasTrackingRectangle);
+
+    QFETCH(bool, expectedCapturesVideo);
+    QFETCH(bool, expectedCapturesPhotos);
+    QFETCH(bool, expectedHasModes);
+    QFETCH(bool, expectedHasZoom);
+    QFETCH(bool, expectedHasVideoStream);
+    QFETCH(bool, expectedPhotosInVideoMode);
+    QFETCH(bool, expectedVideoInPhotoMode);
+    QFETCH(bool, expectedHasTracking);
+
+    // Create MockConfiguration with camera enabled and custom flags
+    auto* mockConfig = new MockConfiguration(QStringLiteral("CameraCapFlagsTest"));
+    mockConfig->setFirmwareType(MAV_AUTOPILOT_PX4);
+    mockConfig->setVehicleType(MAV_TYPE_QUADROTOR);
+    mockConfig->setDynamic(true);
+    mockConfig->setEnableCamera(true);
+    mockConfig->setCameraCaptureVideo(captureVideo);
+    mockConfig->setCameraCaptureImage(captureImage);
+    mockConfig->setCameraHasModes(hasModes);
+    mockConfig->setCameraHasVideoStream(hasVideoStream);
+    mockConfig->setCameraCanCaptureImageInVideoMode(canCaptureImageInVideoMode);
+    mockConfig->setCameraCanCaptureVideoInImageMode(canCaptureVideoInImageMode);
+    mockConfig->setCameraHasBasicZoom(hasBasicZoom);
+    mockConfig->setCameraHasTrackingPoint(hasTrackingPoint);
+    mockConfig->setCameraHasTrackingRectangle(hasTrackingRectangle);
+
+    // Connect MockLink
+    QSignalSpy spyVehicle(MultiVehicleManager::instance(), &MultiVehicleManager::activeVehicleChanged);
+    QVERIFY(spyVehicle.isValid());
+
+    SharedLinkConfigurationPtr linkConfig = LinkManager::instance()->addConfiguration(mockConfig);
+    QVERIFY(LinkManager::instance()->createConnectedLink(linkConfig));
+
+    QVERIFY2(UnitTest::waitForSignal(spyVehicle, TestTimeout::longMs(), QStringLiteral("activeVehicleChanged")),
+             "Timeout waiting for vehicle connection");
+
+    _vehicle = MultiVehicleManager::instance()->activeVehicle();
+    QVERIFY(_vehicle);
+
+    _mockLink = qobject_cast<MockLink*>(linkConfig->link());
+    QVERIFY(_mockLink);
+
+    // Wait for initial connect sequence to complete
+    if (!_vehicle->isInitialConnectComplete()) {
+        QSignalSpy spyConnect(_vehicle, &Vehicle::initialConnectComplete);
+        QVERIFY(spyConnect.isValid());
+        QVERIFY2(UnitTest::waitForSignal(spyConnect, TestTimeout::longMs(), QStringLiteral("initialConnectComplete")),
+                 "Timeout waiting for initial connect");
+    }
+
+    // Wait for camera manager to discover cameras
+    QGCCameraManager* cameraManager = _vehicle->cameraManager();
+    QVERIFY(cameraManager);
+
+    // MockLinkCamera creates two cameras; wait for both to be discovered
+    QVERIFY_TRUE_WAIT(cameraManager->cameras()->count() >= 2, TestTimeout::longMs());
+
+    // Find Camera 1 (MAV_COMP_ID_CAMERA) which has our configured flags.
+    // Camera 2 (MAV_COMP_ID_CAMERA2) is always photo-only and not what we're testing.
+    MavlinkCameraControl* camera = nullptr;
+    for (int i = 0; i < cameraManager->cameras()->count(); i++) {
+        auto* cam = qobject_cast<MavlinkCameraControl*>(cameraManager->cameras()->get(i));
+        if (cam && cam->compID() == MAV_COMP_ID_CAMERA) {
+            camera = cam;
+            break;
+        }
+    }
+    QVERIFY2(camera, "Camera 1 (MAV_COMP_ID_CAMERA) not found in camera list");
+
+    // Verify capability properties match expected values
+    QCOMPARE(camera->capturesVideo(),     expectedCapturesVideo);
+    QCOMPARE(camera->capturesPhotos(),    expectedCapturesPhotos);
+    QCOMPARE(camera->hasModes(),          expectedHasModes);
+    QCOMPARE(camera->hasZoom(),           expectedHasZoom);
+    QCOMPARE(camera->hasVideoStream(),    expectedHasVideoStream);
+    QCOMPARE(camera->photosInVideoMode(), expectedPhotosInVideoMode);
+    QCOMPARE(camera->videoInPhotoMode(),  expectedVideoInPhotoMode);
+    QCOMPARE(camera->hasTracking(),       expectedHasTracking);
+
+    // hasFocus is always false since MockLinkCamera doesn't support CAMERA_CAP_FLAGS_HAS_BASIC_FOCUS
+    QCOMPARE(camera->hasFocus(), false);
+}
+
+UT_REGISTER_TEST(VehicleCameraControlTest, TestLabel::Integration, TestLabel::Vehicle)

--- a/test/Camera/VehicleCameraControlTest.h
+++ b/test/Camera/VehicleCameraControlTest.h
@@ -1,0 +1,22 @@
+#pragma once
+
+#include "UnitTest.h"
+
+class MockLink;
+class Vehicle;
+
+class VehicleCameraControlTest : public UnitTest
+{
+    Q_OBJECT
+
+private slots:
+    void initTestCase() override;
+    void init() override;
+    void cleanup() override;
+
+    UT_PARAMETERIZED_TEST(_testCameraCapFlags);
+
+private:
+    MockLink* _mockLink = nullptr;
+    Vehicle* _vehicle = nullptr;
+};


### PR DESCRIPTION
## Summary
- Adds a data-driven test (`VehicleCameraControlTest`) that verifies all combinations of `CAMERA_CAP_FLAGS` flow correctly from MockLink through `CAMERA_INFORMATION` messages to the `VehicleCameraControl` Q_PROPERTY accessors
- Covers 13 flag combinations including the virtual `capturesVideo`/`capturesPhotos` properties that account for local gstreamer recording and screen-grab capabilities when a video stream is present
- Tests `hasModes`, `hasZoom`, `hasFocus`, `hasVideoStream`, `hasTracking`, `photosInVideoMode`, `videoInPhotoMode`, `capturesVideo`, and `capturesPhotos`

## Test plan
- [x] All 13 data rows pass locally (15/15 including init/cleanup)
- [ ] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)