### PR TITLE
Remove unnecessary test init calls

### DIFF
--- a/test/UnitTestFramework/BaseClasses/VehicleTest.cc
+++ b/test/UnitTestFramework/BaseClasses/VehicleTest.cc
@@ -25,8 +25,6 @@ void VehicleTest::init()
 
     // Initialize vehicle management systems
     MultiVehicleManager::instance()->init();
-    LinkManager::instance()->setConnectionsAllowed();
-    MAVLinkProtocol::deleteTempLogFiles();
 
     _connectMockLink(_autopilotType, _failureMode);
 

--- a/test/Vehicle/InitialConnectPeripheralStartupTest.cc
+++ b/test/Vehicle/InitialConnectPeripheralStartupTest.cc
@@ -13,7 +13,6 @@
 void InitialConnectPeripheralStartupTest::init()
 {
     VehicleTestManualConnect::init();
-    MAVLinkProtocol::deleteTempLogFiles();
 }
 
 void InitialConnectPeripheralStartupTest::_noCameraOrGimbalRequestsBeforeInitialConnectComplete()

--- a/test/Vehicle/InitialConnectTest.cc
+++ b/test/Vehicle/InitialConnectTest.cc
@@ -20,8 +20,6 @@
 void InitialConnectTest::init()
 {
     VehicleTestManualConnect::init();
-    LinkManager::instance()->setConnectionsAllowed();
-    MAVLinkProtocol::deleteTempLogFiles();
 }
 
 void InitialConnectTest::_performTestCases_data()


### PR DESCRIPTION
## Summary
- Remove `LinkManager::setConnectionsAllowed()` calls from `VehicleTest::init()` and `InitialConnectTest::init()` — incorrect usage
- Remove `MAVLinkProtocol::deleteTempLogFiles()` calls from `VehicleTest::init()`, `InitialConnectTest::init()`, and `InitialConnectPeripheralStartupTest::init()` — logging is skipped entirely during unit tests so this is a no-op

## Test plan
- [x] All 23 Vehicle-labeled tests pass (100% pass rate)

🤖 Generated with [Claude Code](https://claude.com/claude-code)