### PR TITLE
Add weekly Doxygen API docs CI pipeline

### DIFF
--- a/.github/workflows/doxygen_deploy.yml
+++ b/.github/workflows/doxygen_deploy.yml
@@ -1,0 +1,88 @@
+name: Doxygen API Docs
+
+on:
+  schedule:
+    - cron: '0 4 * * 0'  # Sunday 04:00 UTC
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+env:
+  BRANCH_NAME: ${{ github.ref_name }}
+
+concurrency:
+  group: doxygen-deploy
+  cancel-in-progress: false
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    steps:
+      - name: Harden Runner
+        uses: step-security/harden-runner@v2
+        with:
+          egress-policy: audit
+
+      - name: Checkout
+        uses: actions/checkout@v6
+
+      - name: Install Doxygen and Graphviz
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y doxygen graphviz
+
+      - name: Build Doxygen docs
+        run: doxygen Doxyfile
+
+      - name: Upload artifact
+        uses: actions/upload-artifact@v6
+        with:
+          name: doxygen_build
+          path: docs/api/html/
+          retention-days: 1
+
+  deploy:
+    if: github.repository_owner == 'mavlink'
+    needs: build
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+
+    steps:
+      - name: Harden Runner
+        uses: step-security/harden-runner@v2
+        with:
+          egress-policy: audit
+
+      - name: Download Artifact
+        uses: actions/download-artifact@v7
+        with:
+          name: doxygen_build
+          path: ~/_api_docs
+
+      - name: Checkout API docs repo
+        uses: actions/checkout@v6
+        with:
+          repository: mavlink/api.qgroundcontrol.com
+          token: ${{ secrets.PX4BUILDBOT_ACCESSTOKEN }}
+          path: api.qgroundcontrol.com
+
+      - name: Deploy docs
+        env:
+          BRANCH: ${{ env.BRANCH_NAME }}
+        run: |
+          SAFE_BRANCH="${BRANCH//[^a-zA-Z0-9._-]/_}"
+          rm -rf "api.qgroundcontrol.com/${SAFE_BRANCH}"
+          mkdir -p "api.qgroundcontrol.com/${SAFE_BRANCH}"
+          cp -r ~/_api_docs/* "api.qgroundcontrol.com/${SAFE_BRANCH}/"
+          cd api.qgroundcontrol.com
+          git config user.email "bot@px4.io"
+          git config user.name "PX4BuildBot"
+          git add "${SAFE_BRANCH}"
+          if git diff --cached --quiet; then
+            echo "No documentation changes to deploy."
+            exit 0
+          fi
+          git commit -m "QGC Doxygen API docs update $(date -u +%Y-%m-%d)"
+          git push origin main

--- a/.gitignore
+++ b/.gitignore
@@ -131,6 +131,7 @@ android/local.properties
 node_modules/
 docs/.vitepress/cache/
 docs/.vitepress/dist/
+docs/api/
 
 # Python
 *.pyc

--- a/Doxyfile
+++ b/Doxyfile
@@ -1,0 +1,76 @@
+# Doxyfile for QGroundControl
+
+PROJECT_NAME           = "QGroundControl"
+PROJECT_BRIEF          = "Ground Control Station for MAVLink Drones"
+PROJECT_NUMBER         =
+OUTPUT_DIRECTORY       = docs/api
+
+# Input
+INPUT                  = src
+INPUT_ENCODING         = UTF-8
+FILE_PATTERNS          = *.h *.cc *.cpp *.hpp *.qml *.md
+RECURSIVE              = YES
+EXCLUDE_PATTERNS       = */test/* */libs/* */_deps/* */build/*
+
+# Output formats
+GENERATE_HTML          = YES
+HTML_OUTPUT            = html
+GENERATE_LATEX         = NO
+GENERATE_XML           = NO
+
+# HTML settings
+HTML_COLORSTYLE_HUE    = 220
+HTML_COLORSTYLE_SAT    = 100
+HTML_COLORSTYLE_GAMMA  = 80
+HTML_DYNAMIC_SECTIONS  = YES
+DISABLE_INDEX          = NO
+GENERATE_TREEVIEW      = YES
+FULL_SIDEBAR           = YES
+
+# Extraction settings
+EXTRACT_ALL            = YES
+EXTRACT_PRIVATE        = NO
+EXTRACT_STATIC         = YES
+EXTRACT_LOCAL_CLASSES  = YES
+
+# Source browser
+SOURCE_BROWSER         = YES
+INLINE_SOURCES         = NO
+STRIP_CODE_COMMENTS    = YES
+REFERENCED_BY_RELATION = YES
+REFERENCES_RELATION    = YES
+
+# Diagrams (requires graphviz)
+HAVE_DOT               = YES
+DOT_NUM_THREADS        = 0
+CLASS_DIAGRAMS         = YES
+COLLABORATION_GRAPH    = YES
+GROUP_GRAPHS           = YES
+INCLUDE_GRAPH          = YES
+INCLUDED_BY_GRAPH      = YES
+CALL_GRAPH             = NO
+CALLER_GRAPH           = NO
+GRAPHICAL_HIERARCHY    = YES
+DIRECTORY_GRAPH        = YES
+DOT_IMAGE_FORMAT       = svg
+INTERACTIVE_SVG        = YES
+
+# Preprocessing
+ENABLE_PREPROCESSING   = YES
+MACRO_EXPANSION        = YES
+EXPAND_ONLY_PREDEF     = NO
+PREDEFINED             = Q_OBJECT Q_PROPERTY Q_INVOKABLE Q_SIGNAL Q_SLOT
+
+# Warnings
+QUIET                  = NO
+WARNINGS               = YES
+WARN_IF_UNDOCUMENTED   = NO
+WARN_IF_DOC_ERROR      = YES
+
+# Other
+ALPHABETICAL_INDEX     = YES
+GENERATE_TODOLIST      = YES
+GENERATE_BUGLIST       = YES
+SHOW_USED_FILES        = YES
+SHOW_FILES             = YES
+SHOW_NAMESPACES        = YES


### PR DESCRIPTION
## Summary
Add a GitHub Actions workflow that builds Doxygen API documentation on a weekly schedule (Sunday 04:00 UTC) and deploys it to `mavlink/api.qgroundcontrol.com`. Each branch gets its own subdirectory (e.g. `/master/`, `/Stable_V5_0/`).

Changes:
- New workflow `.github/workflows/doxygen_deploy.yml` with weekly cron + manual dispatch
- Committed `Doxyfile` for reproducible CI builds
- Added `docs/api/` to `.gitignore`

## Prerequisites
- `mavlink/api.qgroundcontrol.com` repo created with GitHub Pages enabled (done)
- `PX4BUILDBOT_ACCESSTOKEN` needs write access to the new repo

## Test plan
- Doxygen builds successfully locally (verified, 239MB output)
- Run workflow via `workflow_dispatch` to validate end-to-end deployment