### PR TITLE
Back out concept of raw value not being set

### DIFF
--- a/src/FactSystem/Fact.cc
+++ b/src/FactSystem/Fact.cc
@@ -50,7 +50,6 @@ Fact::Fact(const QString& settingsGroup, FactMetaData *metaData, QObject *parent
             const QVariant defaultValue = metaData->rawDefaultValue();
             QMutexLocker<QRecursiveMutex> locker(&_rawValueMutex);
             _rawValue = defaultValue;
-            _rawValueIsNotSet = false;
         }
     }
 
@@ -89,7 +88,6 @@ const Fact &Fact::operator=(const Fact& other)
     _name = other._name;
     _componentId = other._componentId;
     _rawValue = other._rawValue;
-    _rawValueIsNotSet = other._rawValueIsNotSet;
     _type = other._type;
     _sendValueChangedSignals = other._sendValueChangedSignals;
     _deferredValueChangeSignal = other._deferredValueChangeSignal;
@@ -113,7 +111,6 @@ void Fact::forceSetRawValue(const QVariant &value)
             {
                 QMutexLocker<QRecursiveMutex> locker(&_rawValueMutex);
                 _rawValue = typedValue;
-                _rawValueIsNotSet = false;
             }
 
             const QVariant cooked = _metaData->rawTranslator()(typedValue);
@@ -139,7 +136,6 @@ void Fact::setRawValue(const QVariant &value)
                 QMutexLocker<QRecursiveMutex> locker(&_rawValueMutex);
                 if (typedValue != _rawValue) {
                     _rawValue = typedValue;
-                    _rawValueIsNotSet = false;
                     changed = true;
                 }
             }
@@ -201,7 +197,6 @@ void Fact::containerSetRawValue(const QVariant &value)
         QMutexLocker<QRecursiveMutex> locker(&_rawValueMutex);
         if (_rawValue != value) {
             _rawValue = value;
-            _rawValueIsNotSet = false;
             changed = true;
         }
         currentRaw = _rawValue;
@@ -357,12 +352,6 @@ QStringList Fact::selectedBitmaskStrings() const
 
 QString Fact::_variantToString(const QVariant &variant, int decimalPlaces) const
 {
-    QMutexLocker<QRecursiveMutex> locker(&_rawValueMutex);
-    if (_rawValueIsNotSet) {
-        return invalidValueString(decimalPlaces);
-    }
-    locker.unlock();
-
     QString valueString;
 
     const auto stripNegativeZero = [](QString &candidate) {

--- a/src/FactSystem/Fact.h
+++ b/src/FactSystem/Fact.h
@@ -202,7 +202,6 @@ protected:
     QString _name;
     int _componentId = -1;
     QVariant _rawValue{0};
-    bool _rawValueIsNotSet = true;
     mutable QRecursiveMutex _rawValueMutex;
     FactMetaData::ValueType_t _type = FactMetaData::valueTypeInt32;
     FactMetaData *_metaData = nullptr;

--- a/src/FactSystem/SettingsFact.cc
+++ b/src/FactSystem/SettingsFact.cc
@@ -49,7 +49,6 @@ SettingsFact::SettingsFact(const QString &settingsGroup, FactMetaData *metaData,
 
         QMutexLocker<QRecursiveMutex> locker(&_rawValueMutex);
         _rawValue = resolvedValue;
-        _rawValueIsNotSet = false;
     }
 
     (void) connect(this, &Fact::rawValueChanged, this, &SettingsFact::_rawValueChanged);


### PR DESCRIPTION
* Was causing too many problems in random places which would only be identified if you stumbled across a dusty corner of the QGC qml ui and saw it failing.
* I've already gone through multiple iterations of changing it try to make it work without problems but I just discovered again that it wasn't working in all cases.
* The FactSystem and the way UI is written just isn't set up to handle this.
* Can't afford to play whack-a-mole with it any more. The UI impact on the change isn't worth the impact on having to manually test the entire QGC ui looking for screws-ups.

@rubenp02 FYI