### PR TITLE
Vehicle: fix REQUEST_MESSAGE ACK ordering and tune ACK timeout

### DIFF
--- a/src/Vehicle/Vehicle.cc
+++ b/src/Vehicle/Vehicle.cc
@@ -2544,7 +2544,7 @@ int Vehicle::_mavCommandResponseCheckTimeoutMSecs()
 int Vehicle::_mavCommandAckTimeoutMSecs()
 {
     // Use shorter ack timeout during unit tests for faster test execution
-    return qgcApp()->runningUnitTests() ? kTestMavCommandAckTimeoutMs : 3000;
+    return qgcApp()->runningUnitTests() ? kTestMavCommandAckTimeoutMs : 1200;
 }
 
 bool Vehicle::_sendMavCommandShouldRetry(MAV_CMD command)
@@ -3028,6 +3028,9 @@ void Vehicle::_waitForMavlinkMessageMessageReceivedHandler(const mavlink_message
         auto resultHandler      = pInfo->resultHandler;
         auto resultHandlerData  = pInfo->resultHandlerData;
 
+        pInfo->messageReceived = true;
+        pInfo->message = message;
+
         const mavlink_message_info_t *info = mavlink_get_message_info_by_id(message.msgid);
         QString msgName = info ? QString(info->name) : QString::number(message.msgid);
         const int activeCount = _requestMessageInfoMap.contains(message.compid) ? _requestMessageInfoMap[message.compid].count() : 0;
@@ -3041,12 +3044,10 @@ void Vehicle::_waitForMavlinkMessageMessageReceivedHandler(const mavlink_message
                     << "queueDepth"
                     << queueDepth;
 
-        if (!pInfo->commandAckReceived) {
-            return;
+        if (pInfo->commandAckReceived) {
+            _removeRequestMessageInfo(message.compid, message.msgid);
+            (*resultHandler)(resultHandlerData, MAV_RESULT_ACCEPTED, RequestMessageNoFailure, message);
         }
-        _removeRequestMessageInfo(message.compid, message.msgid);
-
-        (*resultHandler)(resultHandlerData, MAV_RESULT_ACCEPTED, RequestMessageNoFailure, message);
     } else {
         // We use any incoming message as a trigger to check timeouts on message requests
 
@@ -3087,7 +3088,6 @@ void Vehicle::_requestMessageCmdResultHandler(void* resultHandlerData_, [[maybe_
     auto resultHandler      = requestMessageInfo->resultHandler;
     auto resultHandlerData  = requestMessageInfo->resultHandlerData;
     Vehicle* vehicle        = requestMessageInfo->vehicle;  // QPointer converts to raw pointer, null if Vehicle destroyed
-    auto message [[maybe_unused]]            = requestMessageInfo->message;
 
     // Vehicle was destroyed before callback fired - clean up and return without accessing vehicle
     if (!vehicle) {
@@ -3126,12 +3126,19 @@ void Vehicle::_requestMessageCmdResultHandler(void* resultHandlerData_, [[maybe_
 
         vehicle->_removeRequestMessageInfo(requestMessageInfo->compId, requestMessageInfo->msgId);
 
-        (*resultHandler)(resultHandlerData, static_cast<MAV_RESULT>(ack.result),  requestMessageFailureCode, ackMessage);
+        (*resultHandler)(resultHandlerData, static_cast<MAV_RESULT>(ack.result), requestMessageFailureCode, ackMessage);
 
         return;
     }
 
-    // Now that the request has been acked we start the timer to wait for the message
+    if (requestMessageInfo->messageReceived) {
+        auto message = requestMessageInfo->message;
+        vehicle->_removeRequestMessageInfo(requestMessageInfo->compId, requestMessageInfo->msgId);
+        (*resultHandler)(resultHandlerData, MAV_RESULT_ACCEPTED, RequestMessageNoFailure, message);
+        return;
+    }
+
+    // We have the ack, but we are still waiting for the message. Start the timer to wait for the message
     requestMessageInfo->messageWaitElapsedTimer.start();
 }
 

--- a/src/Vehicle/Vehicle.h
+++ b/src/Vehicle/Vehicle.h
@@ -1149,8 +1149,8 @@ void _activeVehicleChanged          (Vehicle* newActiveVehicle);
         RequestMessageResultHandler resultHandler       = nullptr;
         void*                       resultHandlerData   = nullptr;
         bool                        commandAckReceived  = false;    // We keep track of the ack/message being received since the order in which this will come in is random
-        bool                        messageReceived     = false;    // We only delete the allocated RequestMessageInfo_t when both happen (or the message wait times out)
-        QElapsedTimer               messageWaitElapsedTimer;        // Elapsed time since we started waiting for the message to show up
+        bool                        messageReceived     = false;    // We only delete the allocated RequestMessageInfo_t when both the message is received and we get the ack
+        QElapsedTimer               messageWaitElapsedTimer;        // Elapsed time since we started waiting message to show up
         mavlink_message_t           message;
     } RequestMessageInfo_t;
 


### PR DESCRIPTION
## Summary
- Require COMMAND_ACK before advancing queued MAV_CMD_REQUEST_MESSAGE requests.
- Reduce default MAV command ACK timeout from 3000 ms to 1200 ms for standard links.
- Somewhat related: https://github.com/mavlink/qgroundcontrol/pull/14038

## Why this change was needed
During SITL instrumentation, PX4 showed multiple ACKs pending while QGC had already advanced to subsequent REQUEST_MESSAGE sends.

The root cause was ordering behavior on the QGC side:
- If payload arrived before COMMAND_ACK, QGC removed the in-flight command entry early and advanced the queue.
- That could cause QGC to issue the next REQUEST_MESSAGE while PX4 was still processing or queuing ACKs for the prior one.

This PR makes request progression ACK-gated, which keeps QGC and PX4 sequencing aligned and avoids premature queue advancement.

Additionally, the 3000 ms default ACK wait introduced unnecessary latency on normal telemetry links (USB/UDP/Wi-Fi and typical SiK conditions), making retries sluggish.
Reducing to 1200 ms improves responsiveness while keeping:
- unit-test timeout behavior unchanged, and
- high-latency link timeout behavior unchanged.

## Commit breakdown
1. Vehicle: require COMMAND_ACK before advancing REQUEST_MESSAGE
   - Removes early in-flight removal path when payload arrives before ACK.
   - Keeps progression tied to ACK reception.

2. Vehicle: reduce default MAV_CMD ACK timeout to 1200ms
   - Changes normal-link ACK timeout from 3000 ms to 1200 ms.

## Scope
- File changed: src/Vehicle/Vehicle.cc
- No UI or protocol definition changes.
- No change to high-latency timeout constant or unit-test timeout constants.