### PR TITLE
PlanView: Replace map-click/right-click with toolstrip toggle buttons for Waypoint and ROI

### DIFF
--- a/src/QmlControls/PlanToolBarIndicators.qml
+++ b/src/QmlControls/PlanToolBarIndicators.qml
@@ -142,31 +142,6 @@ RowLayout {
         }
     }
 
-    ColumnLayout {
-        Layout.alignment: Qt.AlignVCenter
-        spacing: 0
-
-        QGCLabel {
-            text: _leftClickText()
-            font.pointSize: ScreenTools.smallFontPointSize
-            visible: _editingLayer === _layerMission || _editingLayer === _layerRally
-
-            function _leftClickText() {
-                if (_editingLayer === _layerMission) {
-                    return qsTr("- Click on the map to add Waypoint")
-                } else {
-                    return qsTr("- Click on the map to add Rally Point")
-                }
-            }
-        }
-
-        QGCLabel {
-            text: qsTr("- %1 to add ROI %2").arg(ScreenTools.isMobile ? qsTr("Press and hold") : qsTr("Right click")).arg(_missionController.isROIActive ? qsTr("or Cancel ROI") : "")
-            font.pointSize: ScreenTools.smallFontPointSize
-            visible: _editingLayer === _layerMission && _planMasterController.controllerVehicle.roiModeSupported
-        }
-    }
-
     Component {
         id: hamburgerDropPanelComponent
 


### PR DESCRIPTION
## Summary

Replace direct map-click waypoint insertion and right-click ROI insertion with explicit toolstrip toggle buttons.

## Changes

- **Waypoint toggle button**: Checkable toolstrip button that stays toggled on; each map click adds a waypoint after the current item
- **ROI toggle button**: Checkable toolstrip button that toggles off after a single click; shows insert/cancel dialog when an ROI is already active
- **Remove right-click ROI**: Removed `_mapRightClicked`, `onMapRightClicked`, and `onMapPressAndHold` handlers
- **Mutual exclusivity**: Waypoint and ROI toggles are mutually exclusive (enabling one disables the other)
- **ROI visibility guard**: ROI button only visible when vehicle supports ROI mode
- **Remove toolbar help text**: Removed waypoint/ROI click instruction labels from PlanToolBarIndicators
- **Dead code cleanup**: Removed 18 unused property declarations (button indices, stale properties, unused QGCMapPalette)
- **Memory leak fix**: Added `onClosed: destroy()` to dynamically created ROI DropPanel
- **Comment consistency**: Added standard `globals.parent` explanatory comment

## Files Changed

- `src/QmlControls/PlanView.qml`
- `src/QmlControls/PlanToolBarIndicators.qml`
