### PR TITLE
Plan toolbar: add currentPlanFileName property and improve toolbar UX

### DIFF
--- a/src/MissionManager/PlanMasterController.h
+++ b/src/MissionManager/PlanMasterController.h
@@ -1,5 +1,6 @@
 #pragma once
 
+#include <QtCore/QFileInfo>
 #include <QtCore/QObject>
 #include <QtCore/QLoggingCategory>
 #include <QtQmlIntegration/QtQmlIntegration>
@@ -52,7 +53,8 @@ public:
     Q_PROPERTY(bool                     dirtyForUpload          READ dirtyForUpload                         NOTIFY dirtyForUploadChanged)   ///< true: Unsent changes are present, false: no changes since last upload/download sync
     Q_PROPERTY(QString                  fileExtension           READ fileExtension                          CONSTANT)                       ///< File extension for missions
     Q_PROPERTY(QString                  kmlFileExtension        READ kmlFileExtension                       CONSTANT)
-    Q_PROPERTY(QString                  currentPlanFile         READ currentPlanFile                        NOTIFY currentPlanFileChanged)
+    Q_PROPERTY(QString                  currentPlanFile         READ currentPlanFile                        NOTIFY currentPlanFileChanged)  ///< Fully qualified path, empty if not yet saved
+    Q_PROPERTY(QString                  currentPlanFileName     READ currentPlanFileName                    NOTIFY currentPlanFileChanged)  ///< File name only, no path or extension
     Q_PROPERTY(QStringList              loadNameFilters         READ loadNameFilters                        CONSTANT)                       ///< File filter list loading plan files
     Q_PROPERTY(QStringList              saveNameFilters         READ saveNameFilters                        CONSTANT)                       ///< File filter list saving plan files
     Q_PROPERTY(QmlObjectListModel*      planCreators            MEMBER _planCreators                        NOTIFY planCreatorsChanged)
@@ -104,7 +106,8 @@ public:
     bool        dirtyForUpload  (void) const { return _dirtyForUpload; }
     QString     fileExtension   (void) const;
     QString     kmlFileExtension(void) const;
-    QString     currentPlanFile (void) const { return _currentPlanFile; }
+    QString     currentPlanFile     (void) const { return _currentPlanFile; }
+    QString     currentPlanFileName (void) const { return QFileInfo(_currentPlanFile).completeBaseName(); }
     QStringList loadNameFilters (void) const;
     QStringList saveNameFilters (void) const;
     bool        isEmpty         (void) const;

--- a/src/QmlControls/PlanToolBarIndicators.qml
+++ b/src/QmlControls/PlanToolBarIndicators.qml
@@ -106,7 +106,7 @@ RowLayout {
     }
 
     QGCButton {
-        text: _planMasterController.currentPlanFile === "" ? qsTr("Save As") : qsTr("Save")
+        text: _planMasterController.currentPlanFile === "" ? qsTr("Save As") : _planMasterController.currentPlanFileName
         iconSource: "/res/SaveToDisk.svg"
         enabled: !_syncInProgress && _hasPlanItems
         primary: _saveDirty
@@ -166,7 +166,7 @@ RowLayout {
                     QGCButton {
                         Layout.fillWidth: true
                         text: qsTr("Download")
-                        enabled: !_syncInProgress
+                        enabled: !_syncInProgress && !_controllerOffline
                         visible: !_syncInProgress
 
                         onClicked: {


### PR DESCRIPTION
## Changes

### PlanMasterController
- Add `currentPlanFileName` property that returns just the base file name (no path, no extension) using `QFileInfo::completeBaseName()`
- Notifies via the existing `currentPlanFileChanged` signal — no extra plumbing needed

### PlanToolBarIndicators
- Save button label now shows the plan file name when a file is loaded, or **Save As** when none is set
- Download button in the hamburger menu is now disabled when no vehicle is connected (`!_controllerOffline`)
