### PR TITLE
ComponentInformation: improve metadata loading diagnostics

### DIFF
--- a/src/Vehicle/ComponentInformation/CompInfoGeneral.cc
+++ b/src/Vehicle/ComponentInformation/CompInfoGeneral.cc
@@ -1,4 +1,5 @@
 #include "CompInfoGeneral.h"
+#include "ComponentInformationManager.h"
 #include "JsonHelper.h"
 #include "JsonParsing.h"
 #include "QGCLoggingCategory.h"
@@ -72,7 +73,7 @@ void CompInfoGeneral::setJson(const QString& metadataJsonFileName)
         if (uris.uriMetaData.isEmpty() || !uris.crcMetaDataValid) {
             // The CRC is optional for dynamically updated metadata, and once we want to support that this logic needs
             // to be updated.
-            qCDebug(CompInfoGeneralLog) << "Metadata missing fields: type:uri:crcValid" << metadataType <<
+            qCDebug(ComponentInformationManagerLog) << "Metadata missing fields: type:uri:crcValid" << metadataType <<
                     uris.uriMetaData << uris.crcMetaDataValid;
             continue;
         }

--- a/src/Vehicle/ComponentInformation/ComponentInformationManager.cc
+++ b/src/Vehicle/ComponentInformation/ComponentInformationManager.cc
@@ -21,6 +21,7 @@ ComponentInformationManager::ComponentInformationManager(Vehicle *vehicle, QObje
     , _translation(new ComponentInformationTranslation(this, _cachedFileDownload))
 {
     qCDebug(ComponentInformationManagerLog) << this;
+    qCDebug(ComponentInformationManagerLog) << "Cache location:" << QStandardPaths::writableLocation(QStandardPaths::CacheLocation) + QLatin1String("/QGCCompInfoCache");
 
     _compInfoMap[MAV_COMP_ID_AUTOPILOT1][COMP_METADATA_TYPE_GENERAL]    = new CompInfoGeneral   (MAV_COMP_ID_AUTOPILOT1, vehicle, this);
     _compInfoMap[MAV_COMP_ID_AUTOPILOT1][COMP_METADATA_TYPE_PARAMETER]  = new CompInfoParam     (MAV_COMP_ID_AUTOPILOT1, vehicle, this);

--- a/src/Vehicle/ComponentInformation/ComponentInformationTranslation.cc
+++ b/src/Vehicle/ComponentInformation/ComponentInformationTranslation.cc
@@ -19,12 +19,18 @@ ComponentInformationTranslation::ComponentInformationTranslation(QObject* parent
 }
 
 bool ComponentInformationTranslation::downloadAndTranslate(const QString& summaryJsonFile,
-                                                           const QString& toTranslateJsonFile, int maxCacheAgeSec)
+                                                           const QString& toTranslateJsonFile, int maxCacheAgeSec, const QString& componentName)
 {
+    // Metadata is authored in English, no translation needed
+    const QString locale = QLocale::system().name();
+    if (locale.startsWith(QLatin1String("en"))) {
+        qCDebug(ComponentInformationTranslationLog) << "Skipping translation for English locale" << locale << "for" << componentName;
+        return false;
+    }
+
     // Parse summary: find url for current locale
     _toTranslateJsonFile = toTranslateJsonFile;
-    QString locale = QLocale::system().name();
-    QString url = getUrlFromSummaryJson(summaryJsonFile, locale);
+    QString url = getUrlFromSummaryJson(summaryJsonFile, locale, componentName);
     if (url.isEmpty()) {
         return false;
     }
@@ -39,26 +45,26 @@ bool ComponentInformationTranslation::downloadAndTranslate(const QString& summar
     return true;
 }
 
-QString ComponentInformationTranslation::getUrlFromSummaryJson(const QString &summaryJsonFile, const QString &locale)
+QString ComponentInformationTranslation::getUrlFromSummaryJson(const QString &summaryJsonFile, const QString &locale, const QString &componentName)
 {
     QString         errorString;
     QJsonDocument   jsonDoc;
 
     if (!JsonParsing::isJsonFile(summaryJsonFile, jsonDoc, errorString)) {
-        qCWarning(ComponentInformationTranslationLog) << "Metadata translation summary json file open failed:" << errorString;
+        qCWarning(ComponentInformationTranslationLog) << "Metadata translation summary json file open failed for" << componentName << ":" << errorString;
         return "";
     }
     QJsonObject jsonObj = jsonDoc.object();
 
     QJsonObject localeObj = jsonObj[locale].toObject();
     if (localeObj.isEmpty()) {
-        qCWarning(ComponentInformationTranslationLog) << "Locale " << locale << " not found in json";
+        qCWarning(ComponentInformationTranslationLog) << "Locale" << locale << "not found in translation json for" << componentName;
         return "";
     }
 
     QString url = localeObj["url"].toString();
     if (url.isEmpty()) {
-        qCWarning(ComponentInformationTranslationLog) << "Locale " << locale << ": no url set";
+        qCWarning(ComponentInformationTranslationLog) << "Locale" << locale << "has no url in translation json for" << componentName;
     }
     return url;
 }
@@ -98,7 +104,7 @@ void ComponentInformationTranslation::onDownloadCompleted(bool success, const QS
 
 QString ComponentInformationTranslation::translateJsonUsingTS(const QString &toTranslateJsonFile, const QString &tsFile)
 {
-    qCInfo(ComponentInformationTranslationLog) << "Translating" << toTranslateJsonFile << "using" << tsFile;
+    qCDebug(ComponentInformationTranslationLog) << "Translating" << toTranslateJsonFile << "using" << tsFile;
 
     // Open JSON and get the 'translation' object
     QString         errorString;
@@ -200,7 +206,7 @@ QString ComponentInformationTranslation::translateJsonUsingTS(const QString &toT
     translatedFile.write(jsonDoc.toJson());
     translatedFile.close();
 
-    qCInfo(ComponentInformationTranslationLog) << "JSON file" << toTranslateJsonFile << "successfully translated to" << translatedFileName;
+    qCDebug(ComponentInformationTranslationLog) << "JSON file" << toTranslateJsonFile << "successfully translated to" << translatedFileName;
     return translatedFileName;
 }
 

--- a/src/Vehicle/ComponentInformation/ComponentInformationTranslation.h
+++ b/src/Vehicle/ComponentInformation/ComponentInformationTranslation.h
@@ -26,7 +26,7 @@ public:
     ///     @param toTranslateJsonFile json file to be translated
     ///     @param maxCacheAgeSec Maximum age of cached item in seconds
     /// @return true: Asynchronous download has started, false: Download initialization failed
-    bool downloadAndTranslate(const QString& summaryJsonFile, const QString& toTranslateJsonFile, int maxCacheAgeSec);
+    bool downloadAndTranslate(const QString& summaryJsonFile, const QString& toTranslateJsonFile, int maxCacheAgeSec, const QString& componentName);
 
     QString translateJsonUsingTS(const QString& toTranslateJsonFile, const QString& tsFile);
 
@@ -36,7 +36,7 @@ signals:
 private slots:
     void onDownloadCompleted(bool success, const QString &localFile, QString errorMsg, bool fromCache);
 private:
-    QString getUrlFromSummaryJson(const QString& summaryJsonFile, const QString& locale);
+    QString getUrlFromSummaryJson(const QString& summaryJsonFile, const QString& locale, const QString& componentName);
 
     static QJsonObject translate(const QJsonObject& translationObj, const QHash<QString, QString>& translations, QJsonObject doc);
 

--- a/src/Vehicle/ComponentInformation/RequestMetaDataTypeStateMachine.cc
+++ b/src/Vehicle/ComponentInformation/RequestMetaDataTypeStateMachine.cc
@@ -168,14 +168,17 @@ void RequestMetaDataTypeStateMachine::_wireTimeoutHandling()
 
 void RequestMetaDataTypeStateMachine::request(CompInfo* compInfo)
 {
+    _compInfo = compInfo;
     qCDebug(RequestMetaDataTypeStateMachineLog) << Q_FUNC_INFO << typeToString();
 
-    _compInfo = compInfo;
     _jsonMetadataFileName.clear();
     _jsonMetadataTranslatedFileName.clear();
     _jsonTranslationFileName.clear();
     _activeAsyncState = nullptr;
     _activeSkippableState = nullptr;
+    _metadataSource = MetadataSource::None;
+    _metadataUri.clear();
+    _metadataIsFallback = false;
 
     start();
 }
@@ -335,14 +338,17 @@ void RequestMetaDataTypeStateMachine::_requestMetaDataJson()
     const QString uri = compInfo->uriMetaData();
     _jsonMetadataCrcValid = compInfo->crcMetaDataValid();
 
+    qCDebug(ComponentInformationManagerLog) << typeToString() << ": requesting metadata (primary) from" << uri;
+
     _activeAsyncState = _stateRequestMetaDataJson;
     _activeSkippableState = nullptr;
-    _requestFile(fileTag, compInfo->crcMetaDataValid(), uri, _jsonMetadataFileName);
+    _requestFile(fileTag, compInfo->crcMetaDataValid(), uri, _jsonMetadataFileName, true);
 }
 
 void RequestMetaDataTypeStateMachine::_requestMetaDataJsonFallback()
 {
-    qCDebug(RequestMetaDataTypeStateMachineLog) << "Trying fallback download for" << typeToString();
+    qCDebug(ComponentInformationManagerLog) << typeToString() << ": primary failed, requesting metadata (fallback) from" << _compInfo->uriMetaDataFallback();
+    _metadataIsFallback = true;
 
     CompInfo* compInfo = _compInfo;
     const QString fileTag = ComponentInformationManager::_getFileCacheTag(compInfo->type, compInfo->crcMetaDataFallback(), false);
@@ -351,7 +357,7 @@ void RequestMetaDataTypeStateMachine::_requestMetaDataJsonFallback()
 
     _activeAsyncState = nullptr;
     _activeSkippableState = _stateRequestMetaDataJsonFallback;
-    _requestFile(fileTag, compInfo->crcMetaDataFallbackValid(), uri, _jsonMetadataFileName);
+    _requestFile(fileTag, compInfo->crcMetaDataFallbackValid(), uri, _jsonMetadataFileName, true);
 }
 
 void RequestMetaDataTypeStateMachine::_requestTranslationJson()
@@ -359,9 +365,15 @@ void RequestMetaDataTypeStateMachine::_requestTranslationJson()
     CompInfo* compInfo = _compInfo;
     const QString uri = compInfo->uriTranslation();
 
+    if (uri.isEmpty()) {
+        qCDebug(RequestMetaDataTypeStateMachineLog) << "No translation URI for" << typeToString();
+        _stateRequestTranslationJson->complete();
+        return;
+    }
+
     _activeAsyncState = _stateRequestTranslationJson;
     _activeSkippableState = nullptr;
-    _requestFile("", false, uri, _jsonTranslationFileName);
+    _requestFile("", false, uri, _jsonTranslationFileName, false);
 }
 
 void RequestMetaDataTypeStateMachine::_requestTranslate()
@@ -371,7 +383,8 @@ void RequestMetaDataTypeStateMachine::_requestTranslate()
 
     if (!_compMgr->translation()->downloadAndTranslate(_jsonTranslationFileName,
                                                        _jsonMetadataFileName,
-                                                       ComponentInformationManager::cachedFileMaxAgeSec)) {
+                                                       ComponentInformationManager::cachedFileMaxAgeSec,
+                                                       typeToString())) {
         disconnect(_compMgr->translation(), &ComponentInformationTranslation::downloadComplete,
                    this, &RequestMetaDataTypeStateMachine::_downloadAndTranslationComplete);
         qCDebug(RequestMetaDataTypeStateMachineLog) << "downloadAndTranslate() failed";
@@ -394,11 +407,14 @@ void RequestMetaDataTypeStateMachine::_downloadAndTranslationComplete(QString tr
 
 void RequestMetaDataTypeStateMachine::_completeRequest()
 {
-    if (_jsonMetadataTranslatedFileName.isEmpty()) {
-        _compInfo->setJson(_jsonMetadataFileName);
-    } else {
+    const bool success = !_jsonMetadataFileName.isEmpty();
+    const bool translated = !_jsonMetadataTranslatedFileName.isEmpty();
+
+    if (translated) {
         _compInfo->setJson(_jsonMetadataTranslatedFileName);
         QFile(_jsonMetadataTranslatedFileName).remove();
+    } else {
+        _compInfo->setJson(_jsonMetadataFileName);
     }
 
     // If we don't have a CRC we didn't cache the file and need to delete it
@@ -408,9 +424,35 @@ void RequestMetaDataTypeStateMachine::_completeRequest()
     if (!_jsonMetadataCrcValid && !_jsonTranslationFileName.isEmpty()) {
         QFile(_jsonTranslationFileName).remove();
     }
+
+    // Summary log for easy filtering
+    const char* sourceLabel = _metadataIsFallback ? "(fallback)" : "(primary)";
+    if (success) {
+        if (translated) {
+            qCDebug(ComponentInformationManagerLog) << typeToString() << ":" << _metadataSourceToString(_metadataSource)
+                                                    << sourceLabel << "(translated)" << _metadataUri;
+        } else {
+            qCDebug(ComponentInformationManagerLog) << typeToString() << ":" << _metadataSourceToString(_metadataSource)
+                                                    << sourceLabel << _metadataUri;
+        }
+    } else {
+        qCWarning(ComponentInformationManagerLog) << typeToString() << ": failed to load metadata (primary and fallback)"
+                                                  << (_metadataUri.isEmpty() ? _compInfo->uriMetaData() : _metadataUri);
+    }
 }
 
-void RequestMetaDataTypeStateMachine::_requestFile(const QString& cacheFileTag, bool crcValid, const QString& uri, QString& outputFileName)
+const char* RequestMetaDataTypeStateMachine::_metadataSourceToString(MetadataSource source)
+{
+    switch (source) {
+    case MetadataSource::Cache: return "loaded from cache";
+    case MetadataSource::FTP:   return "downloaded via FTP";
+    case MetadataSource::HTTP:  return "downloaded via HTTP";
+    case MetadataSource::None:  return "not available";
+    }
+    return "unknown";
+}
+
+void RequestMetaDataTypeStateMachine::_requestFile(const QString& cacheFileTag, bool crcValid, const QString& uri, QString& outputFileName, bool trackMetadataSource)
 {
     FTPManager* ftpManager = _compInfo->vehicle->ftpManager();
     _currentCacheFileTag = cacheFileTag;
@@ -427,7 +469,7 @@ void RequestMetaDataTypeStateMachine::_requestFile(const QString& cacheFileTag, 
     };
 
     if (!_compInfo->available() || uri.isEmpty()) {
-        qCDebug(RequestMetaDataTypeStateMachineLog) << "Skipping download. Component information not available for" << _currentCacheFileTag;
+        qCDebug(ComponentInformationManagerLog) << typeToString() << ": metadata not available, skipping download";
         completeCurrentState();
         return;
     }
@@ -436,14 +478,28 @@ void RequestMetaDataTypeStateMachine::_requestFile(const QString& cacheFileTag, 
 
     if (!cachedFile.isEmpty()) {
         qCDebug(RequestMetaDataTypeStateMachineLog) << "Using cached file" << cachedFile;
+        if (trackMetadataSource) {
+            _metadataSource = MetadataSource::Cache;
+            _metadataUri = uri;
+        }
         outputFileName = cachedFile;
         completeCurrentState();
         return;
     }
 
+    if (!crcValid) {
+        qCDebug(RequestMetaDataTypeStateMachineLog) << typeToString() << ": CRC not available, cache bypassed";
+    } else {
+        qCDebug(RequestMetaDataTypeStateMachineLog) << typeToString() << ": not found in cache, downloading";
+    }
+
     qCDebug(RequestMetaDataTypeStateMachineLog) << "Downloading json" << uri;
 
     if (_uriIsMAVLinkFTP(uri)) {
+        if (trackMetadataSource) {
+            _metadataSource = MetadataSource::FTP;
+            _metadataUri = uri;
+        }
         connect(ftpManager, &FTPManager::downloadComplete, this, &RequestMetaDataTypeStateMachine::_ftpDownloadComplete);
         if (ftpManager->download(MAV_COMP_ID_AUTOPILOT1, uri, QStandardPaths::writableLocation(QStandardPaths::TempLocation))) {
             _downloadStartTime.start();
@@ -454,6 +510,10 @@ void RequestMetaDataTypeStateMachine::_requestFile(const QString& cacheFileTag, 
             completeCurrentState();
         }
     } else {
+        if (trackMetadataSource) {
+            _metadataSource = MetadataSource::HTTP;
+            _metadataUri = uri;
+        }
         connect(_compMgr->_cachedFileDownload, &QGCCachedFileDownload::finished,
                 this, &RequestMetaDataTypeStateMachine::_httpDownloadComplete);
         if (_compMgr->_cachedFileDownload->download(uri, crcValid ? 0 : ComponentInformationManager::cachedFileMaxAgeSec)) {
@@ -493,8 +553,8 @@ void RequestMetaDataTypeStateMachine::_ftpDownloadComplete(const QString& fileNa
         if (_currentFileName) {
             *_currentFileName = _downloadCompleteJsonWorker(fileName);
         }
-    } else if (qgcApp()->runningUnitTests()) {
-        qCWarning(RequestMetaDataTypeStateMachineLog) << "_ftpDownloadComplete failed filename:errorMsg" << fileName << errorMsg;
+    } else {
+        qCDebug(ComponentInformationManagerLog) << typeToString() << ": FTP download failed:" << errorMsg;
     }
 
     if (_activeAsyncState) {
@@ -529,9 +589,8 @@ void RequestMetaDataTypeStateMachine::_httpDownloadComplete(bool success, const 
         if (_currentFileName) {
             *_currentFileName = _downloadCompleteJsonWorker(localFile);
         }
-    } else if (qgcApp()->runningUnitTests()) {
-        qCWarning(RequestMetaDataTypeStateMachineLog) << "_httpDownloadComplete failed localFile:errorMsg:fromCache"
-                                                      << localFile << errorMsg << fromCache;
+    } else {
+        qCDebug(ComponentInformationManagerLog) << typeToString() << ": HTTP download failed:" << errorMsg;
     }
 
     if (_activeAsyncState) {

--- a/src/Vehicle/ComponentInformation/RequestMetaDataTypeStateMachine.h
+++ b/src/Vehicle/ComponentInformation/RequestMetaDataTypeStateMachine.h
@@ -53,9 +53,17 @@ private:
     bool _shouldSkipTranslation() const;
 
     // Download helpers
-    void _requestFile(const QString& cacheFileTag, bool crcValid, const QString& uri, QString& outputFileName);
+    void _requestFile(const QString& cacheFileTag, bool crcValid, const QString& uri, QString& outputFileName, bool trackMetadataSource);
     QString _downloadCompleteJsonWorker(const QString& jsonFileName);
     static bool _uriIsMAVLinkFTP(const QString& uri);
+
+    enum class MetadataSource {
+        None,
+        Cache,
+        FTP,
+        HTTP,
+    };
+    static const char* _metadataSourceToString(MetadataSource source);
 
     // Message result handlers
     void _handleCompMetadataResult(MAV_RESULT result, const mavlink_message_t& message);
@@ -82,6 +90,9 @@ private:
     bool _currentFileValidCrc = false;
 
     QElapsedTimer _downloadStartTime;
+    MetadataSource _metadataSource = MetadataSource::None;
+    QString _metadataUri;
+    bool _metadataIsFallback = false;
 
     // State pointers
     AsyncFunctionState* _stateRequestCompInfo = nullptr;

--- a/test/Vehicle/ComponentInformation/ComponentInformationTranslationTest.cc
+++ b/test/Vehicle/ComponentInformation/ComponentInformationTranslationTest.cc
@@ -42,6 +42,12 @@ void ComponentInformationTranslationTest::_downloadAndTranslateFromSummary_test(
 {
     const QString summaryPath = tempPath(QStringLiteral("summary.json"));
     const QString locale = QLocale::system().name();
+
+    // Skip test on English locales since translation is intentionally skipped
+    if (locale.startsWith(QLatin1String("en"))) {
+        QSKIP("Translation is skipped for English locales");
+    }
+
     QFile summaryFile(summaryPath);
     QVERIFY(summaryFile.open(QIODevice::WriteOnly | QIODevice::Truncate | QIODevice::Text));
     QTextStream summaryStream(&summaryFile);
@@ -58,7 +64,7 @@ void ComponentInformationTranslationTest::_downloadAndTranslateFromSummary_test(
     QSignalSpy completeSpy(&translation, &ComponentInformationTranslation::downloadComplete);
     QVERIFY(completeSpy.isValid());
 
-    QVERIFY(translation.downloadAndTranslate(summaryPath, QStringLiteral(":/unittest/TranslationTest.json"), 3600));
+    QVERIFY(translation.downloadAndTranslate(summaryPath, QStringLiteral(":/unittest/TranslationTest.json"), 3600, QStringLiteral("TEST")));
     QVERIFY_SIGNAL_WAIT(completeSpy, TestTimeout::mediumMs());
     QCOMPARE(completeSpy.count(), 1);
 
@@ -93,7 +99,7 @@ void ComponentInformationTranslationTest::_downloadAndTranslateMissingLocale_tes
     ComponentInformationTranslation translation(this, &cachedDownloader);
 
     QSignalSpy completeSpy(&translation, &ComponentInformationTranslation::downloadComplete);
-    QVERIFY(!translation.downloadAndTranslate(summaryPath, QStringLiteral(":/unittest/TranslationTest.json"), 3600));
+    QVERIFY(!translation.downloadAndTranslate(summaryPath, QStringLiteral(":/unittest/TranslationTest.json"), 3600, QStringLiteral("TEST")));
     QCOMPARE(completeSpy.count(), 0);
 }
 
@@ -116,7 +122,7 @@ void ComponentInformationTranslationTest::_downloadAndTranslateMissingUrl_test()
     ComponentInformationTranslation translation(this, &cachedDownloader);
 
     QSignalSpy completeSpy(&translation, &ComponentInformationTranslation::downloadComplete);
-    QVERIFY(!translation.downloadAndTranslate(summaryPath, QStringLiteral(":/unittest/TranslationTest.json"), 3600));
+    QVERIFY(!translation.downloadAndTranslate(summaryPath, QStringLiteral(":/unittest/TranslationTest.json"), 3600, QStringLiteral("TEST")));
     QCOMPARE(completeSpy.count(), 0);
 }
 
@@ -132,7 +138,7 @@ void ComponentInformationTranslationTest::_downloadAndTranslateInvalidSummaryJso
     ComponentInformationTranslation translation(this, &cachedDownloader);
 
     QSignalSpy completeSpy(&translation, &ComponentInformationTranslation::downloadComplete);
-    QVERIFY(!translation.downloadAndTranslate(summaryPath, QStringLiteral(":/unittest/TranslationTest.json"), 3600));
+    QVERIFY(!translation.downloadAndTranslate(summaryPath, QStringLiteral(":/unittest/TranslationTest.json"), 3600, QStringLiteral("TEST")));
     QCOMPARE(completeSpy.count(), 0);
 }
 


### PR DESCRIPTION
## Summary

Improve ComponentInformation logging to make it easier to diagnose metadata loading issues during vehicle connection.

## Changes

- **Structured summary log** per metadata type showing source (cache/FTP/HTTP), primary vs fallback, translation status, and URI — all under `ComponentInformationManagerLog`
- **componentName in translation warnings** so it's clear which metadata type a translation failure relates to
- **Skip translation for English locales** since metadata is authored in English
- **Log cache location** on ComponentInformationManager startup
- **Log primary/fallback attempts** and download failures to `ComponentInformationManagerLog`
- **Demote intermediate messages** (CRC checks, cache misses) to `RequestMetaDataTypeStateMachineLog`
- **Replace pointer-identity tracking** with explicit `trackMetadataSource` parameter
- **Track actual URI** used (primary or fallback) for accurate failure reporting
- **Always log download failures** (removed unit-test-only restriction)
- Related to #13861

### Example output
```
ComponentInformation.ComponentInformationManager: Cache location: .../QGCCompInfoCache
ComponentInformation.ComponentInformationManager: COMP_METADATA_TYPE_GENERAL : requesting metadata (primary) from mftp://...
ComponentInformation.ComponentInformationManager: COMP_METADATA_TYPE_GENERAL : downloaded via FTP (primary) mftp://...
ComponentInformation.ComponentInformationManager: COMP_METADATA_TYPE_EVENTS : loaded from cache (primary) (translated) https://...
ComponentInformation.ComponentInformationManager: COMP_METADATA_TYPE_COMMANDS : failed to load metadata (primary and fallback) https://...
```

## Test
- All `ComponentInformation*Test` and `RequestMetaDataTypeStateMachineTest` pass
- Verified with SITL (ArduPilot)