### PR TITLE
FlightMap: zoom mouse wheel around cursor position

### DIFF
--- a/src/FlightMap/FlightMap.qml
+++ b/src/FlightMap/FlightMap.qml
@@ -135,14 +135,30 @@ Map {
     }
 
     WheelHandler {
+        id: wheelHandler
         // workaround for QTBUG-87646 / QTBUG-112394 / QTBUG-112432:
         // Magic Mouse pretends to be a trackpad but doesn't work with PinchHandler
         // and we don't yet distinguish mice and trackpads on Wayland either
-        acceptedDevices:    Qt.platform.pluginName === "cocoa" || Qt.platform.pluginName === "wayland" ?
-                                PointerDevice.Mouse | PointerDevice.TouchPad : PointerDevice.Mouse
-        rotationScale:      1 / 120
-        property:           "zoomLevel"
+        acceptedDevices: Qt.platform.pluginName === "cocoa" || Qt.platform.pluginName === "wayland" ? PointerDevice.Mouse | PointerDevice.TouchPad : PointerDevice.Mouse
+        rotationScale: 1 / 120
+        target: null
 
+        property real _lastRotation: 0
+
+        onActiveChanged: {
+            if (!active) {
+                _lastRotation = 0
+            }
+        }
+
+        onRotationChanged: {
+            let delta = rotation - _lastRotation
+            _lastRotation = rotation
+            let mousePos = wheelHandler.point.position
+            let coord = _map.toCoordinate(mousePos, false)
+            _map.zoomLevel = Math.max(_map.zoomLevel + delta, 0)
+            _map.alignCoordinateToPoint(coord, mousePos)
+        }
     }
 
     // We specifically do not use a DragHandler for panning. It just causes too many problems if you overlay anything else like a Flickable above it.


### PR DESCRIPTION
## Summary

Change the WheelHandler in FlightMap to zoom around the current mouse cursor position instead of the map center.

## Changes

- Replace the automatic `property: "zoomLevel"` binding on WheelHandler with manual handling
- On each rotation delta, capture the map coordinate under the cursor, apply the zoom, then call `alignCoordinateToPoint` to keep that coordinate pinned under the cursor
- This matches the existing PinchHandler behavior for pinch-to-zoom

## Testing

- Verified mouse wheel zoom now centers on cursor position on macOS
- Pinch-to-zoom continues to work as before