### PR TITLE
QGCTabBar: filter non-button children from ButtonGroup

### DIFF
--- a/src/QmlControls/QGCTabBar.qml
+++ b/src/QmlControls/QGCTabBar.qml
@@ -15,43 +15,66 @@ RowLayout {
     spacing: 0
 
     property bool _preventCurrentIndexBindingLoop: false
+    property var _buttons: []
+
+    function _updateButtons() {
+        let btns = []
+        for (var i = 0; i < control.children.length; i++) {
+            if (control.children[i].hasOwnProperty("checkable")) {
+                btns.push(control.children[i])
+            }
+        }
+        _buttons = btns
+        buttonGroup.buttons = _buttons
+        _selectCurrentIndexButton()
+    }
 
     function _selectCurrentIndexButton() {
-        if (control.children.length > 0) {
-            _preventCurrentIndexBindingLoop = true
-            if (control.currentIndex == -1) {
-                // No tab selected, select none
-                for (var i = 0; i < control.children.length; i++) {
-                    control.children[i].checked = false
-                }
+        if (_buttons.length === 0) return
+
+        _preventCurrentIndexBindingLoop = true
+
+        if (control.currentIndex === -1) {
+            for (var i = 0; i < _buttons.length; i++) {
+                _buttons[i].checked = false
+            }
+        } else {
+            let index = Math.min(Math.max(control.currentIndex, 0), _buttons.length - 1)
+            if (_buttons[index].visible) {
+                _buttons[index].checked = true
             } else {
-                let filteredCurrentIndex = Math.min(Math.max(control.currentIndex, 0), control.children.length - 1)
-                if (control.children[filteredCurrentIndex].visible) {
-                    control.children[filteredCurrentIndex].checked = true
-                } else {
-                    // We select the first visible tab if the current index is not visible
-                    for (var j = 0; j < control.children.length; j++) {
-                        if (control.children[j].visible) {
-                            control.children[j].checked = true
-                            break
-                        }
+                // Select the first visible tab if the current index is not visible
+                index = -1
+                for (var j = 0; j < _buttons.length; j++) {
+                    if (_buttons[j].visible) {
+                        _buttons[j].checked = true
+                        index = j
+                        break
                     }
                 }
             }
-            _preventCurrentIndexBindingLoop = false
+            // Sync currentIndex to the actually-selected button so it never remains stale
+            if (control.currentIndex !== index) {
+                control.currentIndex = index
+            }
         }
+
+        _preventCurrentIndexBindingLoop = false
     }
 
-    Component.onCompleted: _selectCurrentIndexButton()
+    Component.onCompleted: _updateButtons()
+    onChildrenChanged: _updateButtons()
     onCurrentIndexChanged: _selectCurrentIndexButton()
     onVisibleChildrenChanged: _selectCurrentIndexButton()
 
     ButtonGroup {
-        buttons: control.children
+        id: buttonGroup
 
         onCheckedButtonChanged: {
-            for (var i = 0; i < control.children.length; i++) {
-                if (control.children[i] === checkedButton) {
+            if (control._preventCurrentIndexBindingLoop) return
+
+            for (var i = 0; i < control._buttons.length; i++) {
+                if (control._buttons[i] === checkedButton) {
                     control.currentIndex = i
                     break
                 }


### PR DESCRIPTION
## Summary

Fixes `ButtonGroup` errors in `QGCTabBar` when a `Repeater` or other non-button items are among the `RowLayout` children. Filters `control.children` to only include items with a `checkable` property before assigning to `ButtonGroup`.

**This is a replacement for #13953** with an additional fix for the array mutation pattern (builds the filtered array locally before assigning to ensure QML change notifications fire correctly).

Fixes #13936

## Changes

- Build filtered `_buttons` array containing only checkable children and assign to `ButtonGroup`
- Use `_buttons` instead of `control.children` for all index/selection logic
- Guard `onCheckedButtonChanged` against binding loops
- Re-sync on `onChildrenChanged` and `onVisibleChildrenChanged`

## Testing

- Verified tabs work correctly with and without `Repeater` children
- No `ButtonGroup` warnings in console output
