### PR TITLE
RC Calibration: improve error messages for insufficient channels

### DIFF
--- a/src/Vehicle/VehicleSetup/RemoteControlCalibration.qml
+++ b/src/Vehicle/VehicleSetup/RemoteControlCalibration.qml
@@ -228,11 +228,16 @@ ColumnLayout {
             onClicked: {
                 if (text === qsTr("Calibrate")) {
                     if (controller.channelCount < controller.minChannelCount) {
-                        QGroundControl.showMessageDialog(root, qsTr("Remote Not Ready"),
-                                                        controller.channelCount == 0 ? qsTr("Please turn on remote.") :
-                                                                                    (controller.channelCount < controller.minChannelCount ?
-                                                                                            qsTr("%1 channels or more are needed to fly.").arg(controller.minChannelCount) :
-                                                                                            qsTr("Ready to calibrate.")))
+                        let errorMessage = ""
+                        let title = ""
+                        if (controller.joystickMode) {
+                            title = qsTr("Joystick Not Ready")
+                            errorMessage = qsTr("%1 axes or more are needed to fly. Joystick is reporting %2 axes.").arg(controller.minChannelCount).arg(controller.channelCount)
+                        } else {
+                            title = qsTr("Not Ready")
+                            errorMessage = controller.channelCount === 0 ? qsTr("Please turn on RC transmitter.") : qsTr("%1 channels or more are needed to fly.").arg(controller.minChannelCount)
+                        }
+                        QGroundControl.showMessageDialog(root, title, errorMessage)
                         return
                     } else if (!controller.joystickMode) {
                         QGroundControl.showMessageDialog(root, qsTr("Zero Trims"),


### PR DESCRIPTION
## Summary

* Improves error messages in the RC Calibration dialog when the channel count is below the minimum required to fly.
* Related to #14058

## Changes

- Distinguish between joystick and RC transmitter modes with separate error messages:
  - **Joystick mode**: Reports the required vs actual stick count (e.g. "4 sticks or more are needed to fly. Joystick is reporting 2 sticks.")
  - **RC transmitter mode**: Prompts to turn on the transmitter when 0 channels are detected, otherwise reports the required channel count
- Use clearer dialog titles: "Joystick Not Supported" vs "Not Ready"
