### PR TITLE
Fix MAVLink message bounds validation vulnerabilities

### DIFF
--- a/src/MAVLink/ImageProtocolManager.cc
+++ b/src/MAVLink/ImageProtocolManager.cc
@@ -1,6 +1,8 @@
 #include "ImageProtocolManager.h"
 #include "QGCLoggingCategory.h"
 
+#include <cstring>
+
 QGC_LOGGING_CATEGORY(ImageProtocolManagerLog, "MAVLink.ImageProtocolManager")
 
 ImageProtocolManager::ImageProtocolManager(QObject *parent)
@@ -49,6 +51,27 @@ void ImageProtocolManager::mavlinkMessageReceived(const mavlink_message_t &messa
         _imageBytes.clear();
         mavlink_msg_data_transmission_handshake_decode(&message, &_imageHandshake);
         qCDebug(ImageProtocolManagerLog) << QStringLiteral("DATA_TRANSMISSION_HANDSHAKE: type(%1) width(%2) height (%3)").arg(_imageHandshake.type).arg(_imageHandshake.width).arg(_imageHandshake.height);
+
+        // Validate handshake fields to prevent out-of-bounds writes on subsequent ENCAPSULATED_DATA
+        static constexpr uint32_t kMaxImageSize = 1u * 1024u * 1024u; // 1 MB upper bound (optical flow images are typically small grayscale frames)
+        if (_imageHandshake.size == 0 || _imageHandshake.payload == 0 || _imageHandshake.packets == 0) {
+            qCWarning(ImageProtocolManagerLog) << "DATA_TRANSMISSION_HANDSHAKE: Invalid field(s) - size:" << _imageHandshake.size
+                                               << "payload:" << _imageHandshake.payload << "packets:" << _imageHandshake.packets;
+            _imageHandshake = {};
+            break;
+        }
+        if (_imageHandshake.size > kMaxImageSize) {
+            qCWarning(ImageProtocolManagerLog) << "DATA_TRANSMISSION_HANDSHAKE: Image size exceeds limit. size:" << _imageHandshake.size;
+            _imageHandshake = {};
+            break;
+        }
+        if (_imageHandshake.payload > sizeof(mavlink_encapsulated_data_t::data)) {
+            qCWarning(ImageProtocolManagerLog) << "DATA_TRANSMISSION_HANDSHAKE: payload exceeds ENCAPSULATED_DATA data field size. payload:" << _imageHandshake.payload;
+            _imageHandshake = {};
+            break;
+        }
+
+        _imageBytes.resize(_imageHandshake.size, '\0');
         break;
     }
     case MAVLINK_MSG_ID_ENCAPSULATED_DATA:
@@ -61,16 +84,17 @@ void ImageProtocolManager::mavlinkMessageReceived(const mavlink_message_t &messa
         mavlink_encapsulated_data_t encapsulatedData;
         mavlink_msg_encapsulated_data_decode(&message, &encapsulatedData);
 
-        uint32_t bytePosition = encapsulatedData.seqnr * _imageHandshake.payload;
+        const uint32_t bytePosition = static_cast<uint32_t>(encapsulatedData.seqnr) * _imageHandshake.payload;
         if (bytePosition >= _imageHandshake.size) {
             qCWarning(ImageProtocolManagerLog) << "ENCAPSULATED_DATA: seqnr is past end of image size. seqnr:" << encapsulatedData.seqnr << "_imageHandshake.size:" << _imageHandshake.size;
             break;
         }
 
-        for (uint8_t i = 0; i < _imageHandshake.payload; i++) {
-            _imageBytes[bytePosition] = encapsulatedData.data[i];
-            bytePosition++;
-        }
+        // Clamp the number of bytes to copy so we never write past the declared image size
+        const uint32_t bytesRemaining = _imageHandshake.size - bytePosition;
+        const uint32_t bytesToCopy = qMin(static_cast<uint32_t>(_imageHandshake.payload), bytesRemaining);
+
+        (void) memcpy(_imageBytes.data() + bytePosition, encapsulatedData.data, bytesToCopy);
 
         // We use the packets field to track completion
         _imageHandshake.packets--;

--- a/src/Vehicle/FTPManager.cc
+++ b/src/Vehicle/FTPManager.cc
@@ -663,6 +663,12 @@ void FTPManager::_mavlinkMessageReceived(const mavlink_message_t& message)
 
     MavlinkFTP::Request* request = (MavlinkFTP::Request*)&data.payload[0];
 
+    // Reject messages where hdr.size exceeds data array bounds to prevent over-reads
+    if (request->hdr.size > sizeof(request->data)) {
+        qCWarning(FTPManagerLog) << "_mavlinkMessageReceived: hdr.size exceeds data array, discarding." << request->hdr.size;
+        return;
+    }
+
     // Ignore old/reordered packets (handle wrap-around properly)
     uint16_t actualIncomingSeqNumber = request->hdr.seqNumber;
     if ((uint16_t)((_expectedIncomingSeqNumber - 1) - actualIncomingSeqNumber) < (std::numeric_limits<uint16_t>::max()/2)) {

--- a/src/Vehicle/Vehicle.cc
+++ b/src/Vehicle/Vehicle.cc
@@ -605,7 +605,7 @@ void Vehicle::_mavlinkMessageReceived(LinkInterface* link, mavlink_message_t mes
         mavlink_serial_control_t ser;
         mavlink_msg_serial_control_decode(&message, &ser);
         if (static_cast<size_t>(ser.count) > sizeof(ser.data)) {
-            qWarning() << "Invalid count for SERIAL_CONTROL, discarding." << ser.count;
+            qCWarning(VehicleLog) << "Invalid count for SERIAL_CONTROL, discarding." << ser.count;
         } else {
             emit mavlinkSerialControl(ser.device, ser.flags, ser.timeout, ser.baudrate,
                     QByteArray(reinterpret_cast<const char*>(ser.data), ser.count));
@@ -643,7 +643,11 @@ void Vehicle::_mavlinkMessageReceived(LinkInterface* link, mavlink_message_t mes
     {
         mavlink_log_data_t log{};
         mavlink_msg_log_data_decode(&message, &log);
-        emit logData(log.ofs, log.id, log.count, log.data);
+        if (static_cast<size_t>(log.count) > sizeof(log.data)) {
+            qCWarning(VehicleLog) << "Invalid count for LOG_DATA, discarding." << log.count;
+        } else {
+            emit logData(log.ofs, log.id, log.count, log.data);
+        }
         break;
     }
     case MAVLINK_MSG_ID_MESSAGE_INTERVAL:


### PR DESCRIPTION
Harden MAVLink message handlers against malicious or malformed payloads that could trigger out-of-bounds memory access.

Fixes https://github.com/mavlink/qgroundcontrol/security/advisories/GHSA-v5rc-wh3c-c4cw

### ImageProtocolManager (`GHSA-v5rc-wh3c-c4cw`)
- Validate `DATA_TRANSMISSION_HANDSHAKE` fields (`size`, `payload`, `packets`) before allocating the image buffer
- Enforce 1 MB upper bound on image size
- Reject `payload` values exceeding `ENCAPSULATED_DATA` `data[253]` array size
- Pre-allocate image buffer to declared size instead of growing via unchecked indexed writes
- Replace byte-by-byte copy loop with bounds-clamped `memcpy`
- Cast `seqnr` to `uint32_t` before multiplication to prevent overflow

### Vehicle (`LOG_DATA`)
- Add bounds check on `log.count` against `sizeof(log.data)` before emitting the signal, preventing downstream consumers from reading past the 90-byte data array

### FTPManager (`FILE_TRANSFER_PROTOCOL`)
- Validate `hdr.size` against `sizeof(request->data)` at the single message entry point, protecting all downstream handlers (burst read, list directory, fill missing blocks) from reading past the 239-byte data array
