### PR TITLE
fix: update shields.io release badge to current endpoint

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 
 <p align="center">
   <a href="https://github.com/mavlink/QGroundControl/releases">
-    <img src="https://img.shields.io/github/release/mavlink/QGroundControl.svg" alt="Latest Release">
+    <img src="https://img.shields.io/github/v/release/mavlink/QGroundControl" alt="Latest Release">
   </a>
 </p>
 


### PR DESCRIPTION
The old /github/release/ shields.io endpoint is deprecated and returns an "invalid" badge.

Updated to /github/v/release/ which correctly resolves the latest release (currently v5.0.8).