### PR TITLE
Plan: add layer switcher control for Mission/GeoFence/Rally

### DIFF
--- a/src/QmlControls/MissionItemTreeView.qml
+++ b/src/QmlControls/MissionItemTreeView.qml
@@ -26,6 +26,13 @@ TreeView {
     selectionBehavior: TableView.SelectionDisabled
     rowSpacing: 2
 
+    // After collapseRecursively() groups are always at these row indices
+    readonly property int _rowPlanFile: 0
+    readonly property int _rowDefaults: 1
+    readonly property int _rowMission:  2
+    readonly property int _rowFence:    3
+    readonly property int _rowRally:    4
+
     // QGCFlickableScrollIndicator expects parent to have indicatorColor (provided by QGCFlickable/QGCListView)
     property color indicatorColor: qgcPal.text
 
@@ -33,14 +40,6 @@ TreeView {
 
     QGCFlickableScrollIndicator { parent: root; orientation: QGCFlickableScrollIndicator.Horizontal }
     QGCFlickableScrollIndicator { parent: root; orientation: QGCFlickableScrollIndicator.Vertical }
-
-    // After full collapse, top-level group rows are:
-    //   0 = Plan File, 1 = Defaults, 2 = Mission Items, 3 = GeoFence, 4 = Rally Points
-    readonly property int _rowPlanFile: 0
-    readonly property int _rowDefaults: 1
-    readonly property int _rowMission:  2
-    readonly property int _rowFence:    3
-    readonly property int _rowRally:    4
 
     Component.onCompleted: {
         // Expand only Mission Items by default
@@ -80,7 +79,7 @@ TreeView {
         if (targetRow >= 0) {
             root.expand(targetRow)
             root.forceLayout()
-            root.positionViewAtRow(targetRow, Qt.AlignTop)
+            root.positionViewAtRow(targetRow, TableView.AlignTop)
         }
     }
 
@@ -117,7 +116,7 @@ TreeView {
         if (alreadyActive) {
             _editingLayer = -1
             root.forceLayout()
-            root.positionViewAtRow(0, Qt.AlignTop)
+            root.positionViewAtRow(0, TableView.AlignTop)
             return
         }
 
@@ -151,7 +150,7 @@ TreeView {
             // After collapse/expand the view may still be scrolled past the new content.
             // Force layout then scroll so the expanded group header is at the top.
             root.forceLayout()
-            root.positionViewAtRow(targetRow, Qt.AlignTop)
+            root.positionViewAtRow(targetRow, TableView.AlignTop)
         }
     }
 

--- a/src/QmlControls/PlanView.qml
+++ b/src/QmlControls/PlanView.qml
@@ -565,7 +565,7 @@ Item {
                         color:              QGroundControl.globalPalette.buttonHighlightText
                     }
 
-                    MouseArea {
+                    QGCMouseArea {
                         anchors.fill: parent
                         onClicked:    layerSwitcher.toggle()
                     }
@@ -594,7 +594,7 @@ Item {
                             color:              QGroundControl.globalPalette.buttonText
                         }
 
-                        MouseArea {
+                        QGCMouseArea {
                             anchors.fill: parent
                             onClicked:    layerSwitcher.choose(modelData.nodeType)
                         }


### PR DESCRIPTION
## Layer Switching Control

Add an expandable layer switching control to the Plan View map. The control sits to the left of the right panel, top-right corner.

### Behavior
- Only the **active layer icon** is shown (highlighted)
- **Click** to expand the other two layer choices leftward
- **Select a choice** to switch layers — the tree view expands to the corresponding section and the picker collapses
- **Auto-collapse** after 5 seconds if no selection is made
- **Map click** also dismisses the expanded picker

### Changes
- **PlanView.qml** — Layer switcher Item with expand/collapse animation
- **MissionItemTreeView.qml** — Public selectLayer() API (always selects, no toggle)
- **PlanViewRightPanel.qml** — selectLayer() bridge that opens the panel first
- **resources/GeoFence.svg**, **RallyPoint.svg** — New layer icons
- **qgcresources.qrc** — Register new icons

### Screenshot

![LayerSwitching](docs/assets/LayerSwitching.jpg)

