### PR TITLE
Enforce log hygiene in all unit tests

### DIFF
--- a/src/FirmwarePlugin/PX4/PX4FirmwarePlugin.cc
+++ b/src/FirmwarePlugin/PX4/PX4FirmwarePlugin.cc
@@ -2,15 +2,17 @@
 #include "PX4ParameterMetaData.h"
 #include "QGCApplication.h"
 #include "PX4AutoPilotPlugin.h"
+#include "QGCLoggingCategory.h"
 #include "SettingsManager.h"
 #include "PlanViewSettings.h"
 #include "ParameterManager.h"
 #include "Vehicle.h"
 
-#include <QDebug>
 #include <QString>
 
 #include "px4_custom_mode.h"
+
+QGC_LOGGING_CATEGORY(PX4FirmwarePluginLog, "FirmwarePlugin.PX4FirmwarePlugin")
 
 PX4FirmwarePluginInstanceData::PX4FirmwarePluginInstanceData(QObject* parent)
     : FirmwarePluginInstanceData(parent)
@@ -141,7 +143,7 @@ bool PX4FirmwarePlugin::setFlightMode(const QString& flightMode, uint8_t* base_m
     }
 
     if (!found) {
-        qWarning() << "Unknown flight Mode" << flightMode;
+        qCWarning(PX4FirmwarePluginLog) << "Unknown flight Mode" << flightMode;
     }
 
     return found;
@@ -182,7 +184,7 @@ FactMetaData* PX4FirmwarePlugin::_getMetaDataForFact(QObject* parameterMetaData,
     if (px4MetaData) {
         return px4MetaData->getMetaDataForFact(name, vehicleType, type);
     } else {
-        qWarning() << "Internal error: pointer passed to PX4FirmwarePlugin::getMetaDataForFact not PX4ParameterMetaData";
+        qCWarning(PX4FirmwarePluginLog) << "Internal error: pointer passed to PX4FirmwarePlugin::getMetaDataForFact not PX4ParameterMetaData";
     }
 
     return nullptr;
@@ -260,7 +262,7 @@ QString PX4FirmwarePlugin::missionCommandOverrides(QGCMAVLink::VehicleClass_t ve
     case QGCMAVLink::VehicleClassRoverBoat:
         return QStringLiteral(":/json/PX4-MavCmdInfoRover.json");
     default:
-        qWarning() << "PX4FirmwarePlugin::missionCommandOverrides called with bad VehicleClass_t:" << vehicleClass;
+        qCWarning(PX4FirmwarePluginLog) << "PX4FirmwarePlugin::missionCommandOverrides called with bad VehicleClass_t:" << vehicleClass;
         return QString();
     }
 }
@@ -305,7 +307,7 @@ void PX4FirmwarePlugin::_mavCommandResult(int vehicleId, int component, int comm
 
     auto* vehicle = qobject_cast<Vehicle*>(sender());
     if (!vehicle) {
-        qWarning() << "Dynamic cast failed!";
+        qCWarning(PX4FirmwarePluginLog) << "Dynamic cast failed!";
         return;
     }
 
@@ -433,13 +435,13 @@ static void _pauseVehicleThenChangeAltResultHandler(void* resultHandlerData, int
     if (ack.result != MAV_RESULT_ACCEPTED) {
         switch (failureCode) {
         case Vehicle::MavCmdResultCommandResultOnly:
-            qDebug() << QStringLiteral("MAV_CMD_DO_REPOSITION error(%1)").arg(ack.result);
+            qCDebug(PX4FirmwarePluginLog) << QStringLiteral("MAV_CMD_DO_REPOSITION error(%1)").arg(ack.result);
             break;
         case Vehicle::MavCmdResultFailureNoResponseToCommand:
-            qDebug() << "MAV_CMD_DO_REPOSITION no response from vehicle";
+            qCDebug(PX4FirmwarePluginLog) << "MAV_CMD_DO_REPOSITION no response from vehicle";
             break;
         case Vehicle::MavCmdResultFailureDuplicateCommand:
-            qDebug() << "Internal Error: MAV_CMD_DO_REPOSITION could not be sent due to duplicate command";
+            qCDebug(PX4FirmwarePluginLog) << "Internal Error: MAV_CMD_DO_REPOSITION could not be sent due to duplicate command";
             break;
         }
     }

--- a/src/QmlControls/QGCMapPolygon.cc
+++ b/src/QmlControls/QGCMapPolygon.cc
@@ -4,11 +4,14 @@
 #include "JsonParsing.h"
 #include "QGCQGeoCoordinate.h"
 #include "QGCApplication.h"
+#include "QGCLoggingCategory.h"
 #include "ShapeFileHelper.h"
 #include "KMLDomDocument.h"
 
 #include <QtCore/QLineF>
 #include <QMetaMethod>
+
+QGC_LOGGING_CATEGORY(QGCMapPolygonLog, "QMLControls.QGCMapPolygon")
 
 QGCMapPolygon::QGCMapPolygon(QObject* parent)
     : QObject               (parent)
@@ -311,8 +314,8 @@ void QGCMapPolygon::_polygonModelDirtyChanged(bool dirty)
 
 void QGCMapPolygon::removeVertex(int vertexIndex)
 {
-    if (vertexIndex < 0 && vertexIndex > _polygonPath.length() - 1) {
-        qWarning() << "Call to removePolygonCoordinate with bad vertexIndex:count" << vertexIndex << _polygonPath.length();
+    if (vertexIndex < 0 || vertexIndex >= _polygonPath.length()) {
+        qCWarning(QGCMapPolygonLog) << "Call to removePolygonCoordinate with bad vertexIndex:count" << vertexIndex << _polygonPath.length();
         return;
     }
 
@@ -420,7 +423,7 @@ QGeoCoordinate QGCMapPolygon::vertexCoordinate(int vertex) const
     if (vertex >= 0 && vertex < _polygonPath.count()) {
         return _polygonPath[vertex].value<QGeoCoordinate>();
     } else {
-        qWarning() << "QGCMapPolygon::vertexCoordinate bad vertex requested:count" << vertex << _polygonPath.count();
+        qCWarning(QGCMapPolygonLog) << "QGCMapPolygon::vertexCoordinate bad vertex requested:count" << vertex << _polygonPath.count();
         return QGeoCoordinate();
     }
 }
@@ -487,7 +490,7 @@ void QGCMapPolygon::offset(double distance)
             auto intersect = rgOffsetEdges[prevIndex].intersects(rgOffsetEdges[i], &newVertex);
             if (intersect == QLineF::NoIntersection) {
                 // FIXME: Better error handling?
-                qWarning("Intersection failed");
+                qCWarning(QGCMapPolygonLog, "Intersection failed");
                 return;
             }
             QGeoCoordinate coord;
@@ -649,10 +652,8 @@ void QGCMapPolygon::selectVertex(int index)
     if(-1 <= index && index < count()) {
         _selectedVertexIndex = index;
     } else {
-        if (!qgcApp()->runningUnitTests()) {
-            qWarning() << QString("QGCMapPolygon: Selected vertex index (%1) is out of bounds! "
-                                  "Polygon vertices indexes range is [%2..%3].").arg(index).arg(0).arg(count()-1);
-        }
+        qCWarning(QGCMapPolygonLog) << QString("QGCMapPolygon: Selected vertex index (%1) is out of bounds! "
+                              "Polygon vertices indexes range is [%2..%3].").arg(index).arg(0).arg(count()-1);
         _selectedVertexIndex = -1;   // deselect vertex
     }
 

--- a/src/QmlControls/QGCMapPolyline.cc
+++ b/src/QmlControls/QGCMapPolyline.cc
@@ -4,11 +4,13 @@
 #include "JsonParsing.h"
 #include "QGCQGeoCoordinate.h"
 #include "QGCApplication.h"
-#include "ShapeFileHelper.h"
 #include "QGCLoggingCategory.h"
+#include "ShapeFileHelper.h"
 
 #include <QtCore/QLineF>
 #include <QMetaMethod>
+
+QGC_LOGGING_CATEGORY(QGCMapPolylineLog, "QMLControls.QGCMapPolyline")
 
 QGCMapPolyline::QGCMapPolyline(QObject* parent)
     : QObject               (parent)
@@ -231,7 +233,7 @@ void QGCMapPolyline::appendVertex(const QGeoCoordinate& coordinate)
 void QGCMapPolyline::removeVertex(int vertexIndex)
 {
     if (vertexIndex < 0 || vertexIndex > _polylinePath.length() - 1) {
-        qWarning() << "Call to removeVertex with bad vertexIndex:count" << vertexIndex << _polylinePath.length();
+        qCWarning(QGCMapPolylineLog) << "Call to removeVertex with bad vertexIndex:count" << vertexIndex << _polylinePath.length();
         return;
     }
 
@@ -265,7 +267,7 @@ QGeoCoordinate QGCMapPolyline::vertexCoordinate(int vertex) const
     if (vertex >= 0 && vertex < _polylinePath.count()) {
         return _polylinePath[vertex].value<QGeoCoordinate>();
     } else {
-        qWarning() << "QGCMapPolyline::vertexCoordinate bad vertex requested";
+        qCWarning(QGCMapPolylineLog) << "QGCMapPolyline::vertexCoordinate bad vertex requested";
         return QGeoCoordinate();
     }
 }
@@ -439,10 +441,8 @@ void QGCMapPolyline::selectVertex(int index)
     if(-1 <= index && index < count()) {
         _selectedVertexIndex = index;
     } else {
-        if (!qgcApp()->runningUnitTests()) {
-            qWarning() << QStringLiteral("QGCMapPolyline: Selected vertex index (%1) is out of bounds! "
-                                         "Polyline vertices indexes range is [%2..%3].").arg(index).arg(0).arg(count()-1);
-        }
+        qCWarning(QGCMapPolylineLog) << QStringLiteral("QGCMapPolyline: Selected vertex index (%1) is out of bounds! "
+                                     "Polyline vertices indexes range is [%2..%3].").arg(index).arg(0).arg(count()-1);
         _selectedVertexIndex = -1;   // deselect vertex
     }
 

--- a/src/Utilities/StateMachine/Helpers/StateMachineProfiler.cc
+++ b/src/Utilities/StateMachine/Helpers/StateMachineProfiler.cc
@@ -67,18 +67,23 @@ QString StateMachineProfiler::summary() const
                   return a.totalTimeMs > b.totalTimeMs;
               });
 
-    lines << QStringLiteral("%-30s %8s %10s %10s %10s %10s")
-             .arg("State", "Count", "Total(ms)", "Avg(ms)", "Min(ms)", "Max(ms)");
+    lines << QStringLiteral("%1 %2 %3 %4 %5 %6")
+             .arg("State", -30)
+             .arg("Count", 8)
+             .arg("Total(ms)", 10)
+             .arg("Avg(ms)", 10)
+             .arg("Min(ms)", 10)
+             .arg("Max(ms)", 10);
     lines << QString(80, '-');
 
     for (const auto& p : sortedProfiles) {
-        lines << QStringLiteral("%-30s %8d %10lld %10.1f %10lld %10lld")
-                 .arg(p.name.left(30))
-                 .arg(p.entryCount)
-                 .arg(p.totalTimeMs)
-                 .arg(p.averageTimeMs())
-                 .arg(p.minTimeMs == std::numeric_limits<qint64>::max() ? 0 : p.minTimeMs)
-                 .arg(p.maxTimeMs);
+        lines << QStringLiteral("%1 %2 %3 %4 %5 %6")
+                 .arg(p.name.left(30), -30)
+                 .arg(p.entryCount, 8)
+                 .arg(p.totalTimeMs, 10)
+                 .arg(p.averageTimeMs(), 10, 'f', 1)
+                 .arg(p.minTimeMs == std::numeric_limits<qint64>::max() ? 0 : p.minTimeMs, 10)
+                 .arg(p.maxTimeMs, 10);
     }
 
     return lines.join('\n');

--- a/src/Viewer3D/Providers/Osm/OsmParser.cc
+++ b/src/Viewer3D/Providers/Osm/OsmParser.cc
@@ -21,6 +21,16 @@ OsmParser::OsmParser(QObject *parent)
     connect(_osmParserWorker, &OsmParserThread::fileParsed, this, &OsmParser::_onOsmParserFinished);
 }
 
+OsmParser::~OsmParser()
+{
+    // Stop the worker thread's event loop and wait for it to finish.
+    // Once the thread is joined, no events are being processed and
+    // the destructor chain is safe to run from our thread.
+    _osmParserWorker->thread()->quit();
+    _osmParserWorker->thread()->wait();
+    delete _osmParserWorker;
+}
+
 void OsmParser::setGpsRef(const QGeoCoordinate &gpsRef)
 {
     _gpsRefPoint = gpsRef;

--- a/src/Viewer3D/Providers/Osm/OsmParser.h
+++ b/src/Viewer3D/Providers/Osm/OsmParser.h
@@ -22,6 +22,7 @@ class OsmParser : public Viewer3DMapProvider
 
 public:
     explicit OsmParser(QObject *parent = nullptr);
+    ~OsmParser() override;
 
     bool mapLoaded() const override { return _mapLoadedFlag; }
     QGeoCoordinate gpsRef() const override { return _gpsRefPoint; }

--- a/src/Viewer3D/Providers/Osm/OsmParserThread.cc
+++ b/src/Viewer3D/Providers/Osm/OsmParserThread.cc
@@ -214,8 +214,8 @@ void OsmParserThread::BuildingType_t::append(const std::vector<QVector2D> &newPo
 // OsmParserThread
 // ============================================================================
 
-OsmParserThread::OsmParserThread(QObject *parent)
-    : QObject{parent}
+OsmParserThread::OsmParserThread(QObject * /*parent*/)
+    : QObject{nullptr}
     , _workerThread(new QThread())
 {
     connect(this, &OsmParserThread::startThread, this, &OsmParserThread::_parseOsmFile);

--- a/test/QtLocationPlugin/QGCTileCacheDatabaseTest.cc
+++ b/test/QtLocationPlugin/QGCTileCacheDatabaseTest.cc
@@ -2,6 +2,7 @@
 
 #include <QtCore/QDateTime>
 #include <QtCore/QFile>
+#include <QtCore/QRegularExpression>
 #include <QtCore/QSettings>
 #include <QtSql/QSqlDatabase>
 #include <QtSql/QSqlQuery>
@@ -59,6 +60,9 @@ void QGCTileCacheDatabaseTest::_testInitWithValidPath()
 
 void QGCTileCacheDatabaseTest::_testInitWithEmptyPath()
 {
+    // Expected: critical about missing cache directory
+    expectLogMessage(QtCriticalMsg, QRegularExpression("Could not find suitable cache directory"));
+
     const QString emptyPath;
     QGCTileCacheDatabase db(emptyPath);
     QVERIFY(!db.init());

--- a/test/UnitTestFramework/UnitTest.cc
+++ b/test/UnitTestFramework/UnitTest.cc
@@ -668,10 +668,16 @@ void UnitTest::cleanupTestCase()
     }
 }
 
+void UnitTest::expectLogMessage(QtMsgType type, const QRegularExpression &pattern)
+{
+    _expectedLogMessages.append({type, pattern});
+}
+
 void UnitTest::init()
 {
     _initCalled = true;
     _failureContextDumped = false;
+    _expectedLogMessages.clear();
 
     // Start capturing log messages for this test (cleared from previous test)
     QGCLogging::clearCapturedMessages();
@@ -697,6 +703,51 @@ void UnitTest::cleanup()
 
     // Process any lingering events to prevent cross-test contamination
     settleEventLoopForCleanup(3, 0);
+
+    // Fail the test if any uncategorized or critical log messages were captured.
+    // Skip if the test already failed to avoid noisy double-failure reports.
+    if (!QTest::currentTestFailed()) {
+        QString uncategorizedDetails;
+        QString criticalDetails;
+
+        auto isExpected = [this](const CapturedLogMessage &m) {
+            for (const auto &e : _expectedLogMessages) {
+                if (e.type == m.type && e.pattern.match(m.message).hasMatch()) {
+                    return true;
+                }
+            }
+            return false;
+        };
+
+        const auto allMsgs = QGCLogging::capturedMessages();
+        for (const auto &m : allMsgs) {
+            if (isExpected(m)) {
+                continue;
+            }
+            if (m.category.isEmpty() || m.category == QStringLiteral("default")) {
+                const char *level = (m.type == QtDebugMsg)   ? "debug"
+                                  : (m.type == QtWarningMsg) ? "warning"
+                                  : (m.type == QtInfoMsg)    ? "info"
+                                                             : "other";
+                uncategorizedDetails += QStringLiteral("  [%1] %2\n").arg(QLatin1String(level), m.message);
+            }
+            if (m.type == QtCriticalMsg) {
+                criticalDetails += QStringLiteral("  [%1] %2\n").arg(m.category, m.message);
+            }
+        }
+
+        if (!uncategorizedDetails.isEmpty() || !criticalDetails.isEmpty()) {
+            QString msg;
+            if (!uncategorizedDetails.isEmpty()) {
+                msg += QStringLiteral("Uncategorized log messages (use qCDebug/qCWarning with a category):\n%1")
+                           .arg(uncategorizedDetails);
+            }
+            if (!criticalDetails.isEmpty()) {
+                msg += QStringLiteral("Critical log messages:\n%1").arg(criticalDetails);
+            }
+            QFAIL(qPrintable(msg));
+        }
+    }
 }
 
 void UnitTest::dumpFailureContextIfTestFailed(QStringView reason)

--- a/test/UnitTestFramework/UnitTest.h
+++ b/test/UnitTestFramework/UnitTest.h
@@ -4,6 +4,7 @@
 #include <QtCore/QLoggingCategory>
 #include <QtCore/QObject>
 #include <QtCore/QPointer>
+#include <QtCore/QRegularExpression>
 #include <QtCore/QStringView>
 #include <QtCore/QTemporaryDir>
 #include <QtCore/QTemporaryFile>
@@ -436,7 +437,17 @@ protected:
     /// Allows derived fixtures to append state to failure dumps.
     virtual QString failureContextSummary() const;
 
+    /// Declare that a captured log message matching @a pattern at level @a type
+    /// is expected and should not cause a test failure in cleanup().
+    /// Call this before the code that emits the message.
+    void expectLogMessage(QtMsgType type, const QRegularExpression &pattern);
+
 private:
+    struct ExpectedLogMessage {
+        QtMsgType type;
+        QRegularExpression pattern;
+    };
+
     void _cleanupTempFiles();
     void _resetTestState();
 
@@ -445,6 +456,7 @@ private:
 
     QList<QTemporaryFile*> _tempFiles;
     QList<QTemporaryDir*> _tempDirs;
+    QList<ExpectedLogMessage> _expectedLogMessages;
 
     TestLabels _labels;
     bool _unitTestRun = false;

--- a/test/Utilities/Compression/QGCStreamingDecompressionTest.cc
+++ b/test/Utilities/Compression/QGCStreamingDecompressionTest.cc
@@ -4,6 +4,7 @@
 #include <QtCore/QFile>
 #include <QtCore/QJsonDocument>
 #include <QtCore/QJsonObject>
+#include <QtCore/QRegularExpression>
 #include <QtCore/QTextStream>
 
 #include "QGCArchiveFile.h"
@@ -123,6 +124,7 @@ void QGCStreamingDecompressionTest::_testDecompressDeviceErrors()
     // Test writeData returns -1
     QGCDecompressDevice device4(":/unittest/manifest.json.gz");
     QVERIFY(device4.open(QIODevice::ReadOnly));
+    expectLogMessage(QtWarningMsg, QRegularExpression("ReadOnly device"));
     QCOMPARE(device4.write("test", 4), qint64(-1));
     device4.close();
 }
@@ -238,6 +240,7 @@ void QGCStreamingDecompressionTest::_testArchiveFileErrors()
     // Test writeData returns -1
     QGCArchiveFile device4(":/unittest/manifest.json.zip", "manifest.json");
     QVERIFY(device4.open(QIODevice::ReadOnly));
+    expectLogMessage(QtWarningMsg, QRegularExpression("ReadOnly device"));
     QCOMPARE(device4.write("test", 4), qint64(-1));
     device4.close();
 }

--- a/test/Utilities/StateMachine/QGCStateMachineTest.cc
+++ b/test/Utilities/StateMachine/QGCStateMachineTest.cc
@@ -4,6 +4,7 @@
 #include "QGCStateMachine.h"
 #include "WaitStateBase.h"
 
+#include <QtCore/QRegularExpression>
 #include <QtCore/QTimer>
 #include <QtTest/QSignalSpy>
 #include <QtTest/QTest>
@@ -75,6 +76,9 @@ void QGCStateMachineTest::_testGlobalErrorState()
     });
     machine.setGlobalErrorState(errorState);
 
+    // The async state has no completion connection and no timeout — expected critical
+    expectLogMessage(QtCriticalMsg, QRegularExpression("has no completion connection"));
+
     auto* asyncState = machine.addAsyncFunctionState(QStringLiteral("Async"), [](AsyncFunctionState* state) {
         QTimer::singleShot(50, state, [state]() { state->fail(); });
     });
@@ -140,6 +144,9 @@ void QGCStateMachineTest::_testLocalErrorState()
     auto* localErrorState = new FunctionState(QStringLiteral("LocalError"), &machine, [&localErrorHandled]() {
         localErrorHandled = true;
     });
+
+    // The async state has no completion connection and no timeout — expected critical
+    expectLogMessage(QtCriticalMsg, QRegularExpression("has no completion connection"));
 
     auto* asyncState = new AsyncFunctionState(QStringLiteral("Async"), &machine, [](AsyncFunctionState* state) {
         QTimer::singleShot(50, state, [state]() { state->fail(); });
@@ -319,6 +326,10 @@ void QGCStateMachineTest::_testErrorHandlerFactories()
         auto* errorState = machine.addLogAndContinueErrorState(QStringLiteral("ErrorContinue"), finalState);
         machine.setGlobalErrorState(errorState);
 
+        // Expected: async state critical (no completion connection) + error handler warning
+        expectLogMessage(QtCriticalMsg, QRegularExpression("has no completion connection"));
+        expectLogMessage(QtWarningMsg, QRegularExpression("error handled in"));
+
         auto* failingState = machine.addAsyncFunctionState(QStringLiteral("Failing"), [](AsyncFunctionState* state) {
             QTimer::singleShot(0, state, [state]() { state->fail(); });
         });
@@ -335,6 +346,10 @@ void QGCStateMachineTest::_testErrorHandlerFactories()
 
         auto* errorState = machine.addLogAndStopErrorState(QStringLiteral("ErrorStop"));
         machine.setGlobalErrorState(errorState);
+
+        // Expected: async state critical (no completion connection) + error handler warning
+        expectLogMessage(QtCriticalMsg, QRegularExpression("has no completion connection"));
+        expectLogMessage(QtWarningMsg, QRegularExpression("stopping due to error in"));
 
         auto* failingState = machine.addAsyncFunctionState(QStringLiteral("Failing"), [](AsyncFunctionState* state) {
             QTimer::singleShot(0, state, [state]() { state->fail(); });

--- a/test/Utilities/StateMachine/states/AsyncFunctionStateTest.cc
+++ b/test/Utilities/StateMachine/states/AsyncFunctionStateTest.cc
@@ -1,12 +1,17 @@
 #include "AsyncFunctionStateTest.h"
 #include "StateTestCommon.h"
 
+#include <QtCore/QRegularExpression>
+
 
 void AsyncFunctionStateTest::_testAsyncFunctionState()
 {
     QStateMachine machine;
     bool setupCalled = false;
     AsyncFunctionState* capturedState = nullptr;
+
+    // Expected: async state has no completion connection and no timeout
+    expectLogMessage(QtCriticalMsg, QRegularExpression("has no completion connection"));
 
     auto* asyncState = new AsyncFunctionState(
         QStringLiteral("TestAsync"),
@@ -75,6 +80,9 @@ void AsyncFunctionStateTest::_testErrorTransition()
 {
     QStateMachine machine;
     bool errorHandled = false;
+
+    // Expected: async state has no completion connection and no timeout
+    expectLogMessage(QtCriticalMsg, QRegularExpression("has no completion connection"));
 
     auto* asyncState = new AsyncFunctionState(
         QStringLiteral("TestError"),

--- a/test/Utilities/StateMachine/states/SendMavlinkCommandStateTest.cc
+++ b/test/Utilities/StateMachine/states/SendMavlinkCommandStateTest.cc
@@ -1,6 +1,8 @@
 #include "SendMavlinkCommandStateTest.h"
 #include "StateTestCommon.h"
 
+#include <QtCore/QRegularExpression>
+
 #include "SendMavlinkCommandState.h"
 
 
@@ -39,6 +41,10 @@ void SendMavlinkCommandStateTest::_testDeferredSetup()
 void SendMavlinkCommandStateTest::_testUnconfiguredStateFails()
 {
     QStateMachine machine;
+
+    // Expected: unconfigured state emits critical + Qt warns about null connect
+    expectLogMessage(QtWarningMsg, QRegularExpression("invalid nullptr parameter"));
+    expectLogMessage(QtCriticalMsg, QRegularExpression("SendMavlinkCommandState not configured"));
 
     // Create without configuration
     auto* state = new SendMavlinkCommandState(&machine);

--- a/test/Vehicle/InitialConnectTest.cc
+++ b/test/Vehicle/InitialConnectTest.cc
@@ -13,7 +13,6 @@
 #include "MockLink.h"
 #include "MockLinkMissionItemHandler.h"
 #include "MissionManager.h"
-#include "QGCLogging.h"
 #include "ParameterManager.h"
 #include "RallyPointManager.h"
 #include "StandardModes.h"
@@ -22,50 +21,6 @@
 #include "ComponentInformationManager.h"
 
 #include <QtTest/QTest>
-
-void InitialConnectTest::init()
-{
-    VehicleTestManualConnect::init();
-}
-
-void InitialConnectTest::cleanup()
-{
-    // Disable capture first so no new messages arrive while we analyze
-    QGCLogging::setCaptureEnabled(false);
-
-    QString uncategorizedDetails;
-    QString criticalDetails;
-
-    const auto allMsgs = QGCLogging::capturedMessages();
-    for (const auto &m : allMsgs) {
-        if (m.category.isEmpty() || m.category == QStringLiteral("default")) {
-            const char *level = (m.type == QtDebugMsg)   ? "debug"
-                              : (m.type == QtWarningMsg) ? "warning"
-                              : (m.type == QtInfoMsg)    ? "info"
-                                                         : "other";
-            uncategorizedDetails += QStringLiteral("  [%1] %2\n").arg(QLatin1String(level), m.message);
-        }
-        if (m.type == QtCriticalMsg) {
-            criticalDetails += QStringLiteral("  [%1] %2\n").arg(m.category, m.message);
-        }
-    }
-
-    // Always perform parent cleanup for proper teardown
-    VehicleTestManualConnect::cleanup();
-
-    // Report failures after teardown so test infrastructure stays consistent
-    if (!uncategorizedDetails.isEmpty() || !criticalDetails.isEmpty()) {
-        QString msg;
-        if (!uncategorizedDetails.isEmpty()) {
-            msg += QStringLiteral("Uncategorized log messages (use qCDebug/qCWarning with a category):\n%1")
-                       .arg(uncategorizedDetails);
-        }
-        if (!criticalDetails.isEmpty()) {
-            msg += QStringLiteral("Critical log messages:\n%1").arg(criticalDetails);
-        }
-        QFAIL(qPrintable(msg));
-    }
-}
 
 void InitialConnectTest::_performTestCases_data()
 {

--- a/test/Vehicle/InitialConnectTest.h
+++ b/test/Vehicle/InitialConnectTest.h
@@ -7,8 +7,6 @@ class InitialConnectTest : public VehicleTestManualConnect
     Q_OBJECT
 
 private slots:
-    void init() override;
-    void cleanup() override;
     void _performTestCases_data();
     void _performTestCases();
     void _boardVendorProductId();


### PR DESCRIPTION
## Summary

Moves the log capture enforcement from `InitialConnectTest` into the base `UnitTest::cleanup()` so that **every** test automatically fails if it produces uncategorized or unexpected critical log messages. This catches:

- Raw `qWarning()`/`qDebug()` calls that should use a logging category (`qCWarning`/`qCDebug`)
- Unexpected `qCCritical` messages that may indicate real errors

Tests that intentionally exercise error paths can declare expected messages via the new `expectLogMessage(QtMsgType, QRegularExpression)` API.

## Source fixes uncovered by the new enforcement

| File | Fix |
|------|-----|
| `QGCMapPolygon.cc` / `QGCMapPolyline.cc` | Convert `qWarning` → `qCWarning` with new logging categories; remove `runningUnitTests()` guards |
| `PX4FirmwarePlugin.cc` | Convert `qWarning`/`qDebug` → `qCWarning`/`qCDebug` with new `PX4FirmwarePluginLog` category |
| `StateMachineProfiler.cc` | Fix printf-style format strings incompatible with `QString::arg()` (caused "Argument missing" warnings) |
| `OsmParserThread.cc` | Pass `nullptr` to `QObject` base instead of `parent`, since `moveToThread()` on a parented QObject is forbidden by Qt |
| `OsmParser.cc` / `.h` | Add destructor to properly delete the unparented worker thread object |

## Test fixes

| File | Fix |
|------|-----|
| `InitialConnectTest` | Remove redundant `init()`/`cleanup()` overrides (now in base class) |
| `QGCStateMachineTest`, `AsyncFunctionStateTest`, `SendMavlinkCommandStateTest` | Declare expected critical/warning messages for intentional error-path testing |
| `QGCStreamingDecompressionTest` | Declare expected Qt internal warning for write-on-readonly device |
| `QGCTileCacheDatabaseTest` | Declare expected critical for empty-path initialization |

## Testing

All 155 tests pass.
