### PR TITLE
Refactor: Extract vehicle support properties into VehicleSupports class

### DIFF
--- a/src/AutoPilotPlugins/APM/APMAutoPilotPlugin.cc
+++ b/src/AutoPilotPlugins/APM/APMAutoPilotPlugin.cc
@@ -19,6 +19,7 @@
 #include "QGCApplication.h"
 #include "QGCLoggingCategory.h"
 #include "Vehicle.h"
+#include "VehicleSupports.h"
 #include "VehicleComponent.h"
 #ifdef QT_DEBUG
 #include "APMFollowComponent.h"
@@ -55,7 +56,7 @@ const QVariantList &APMAutoPilotPlugin::vehicleComponents()
             _airframeComponent->setupTriggerSignals();
             _components.append(QVariant::fromValue(qobject_cast<VehicleComponent*>(_airframeComponent)));
 
-            if (_vehicle->supportsRadio()) {
+            if (_vehicle->supports()->radio()) {
                 _radioComponent = new APMRadioComponent(_vehicle, this);
                 _radioComponent->setupTriggerSignals();
                 _components.append(QVariant::fromValue(qobject_cast<VehicleComponent*>(_radioComponent)));

--- a/src/AutoPilotPlugins/APM/APMSensorsComponent.qml
+++ b/src/AutoPilotPlugins/APM/APMSensorsComponent.qml
@@ -738,7 +738,7 @@ SetupPage {
                     QGCButton {
                         width:      _buttonWidth
                         text:       qsTr("CompassMot")
-                        visible:    globals.activeVehicle ? globals.activeVehicle.supportsMotorInterference : false
+                        visible:    globals.activeVehicle ? globals.activeVehicle.supports.motorInterference : false
                         onClicked:  compassMotDialogFactory.open()
                     }
 

--- a/src/FlyView/GuidedActionsController.qml
+++ b/src/FlyView/GuidedActionsController.qml
@@ -125,15 +125,15 @@ Item {
     property bool showArm:                  _guidedActionsEnabled && !_vehicleArmed && _canArm
     property bool showForceArm:             _guidedActionsEnabled && !_vehicleArmed
     property bool showDisarm:               _guidedActionsEnabled && _vehicleArmed && !_vehicleFlying
-    property bool showRTL:                  _guidedActionsEnabled && _vehicleArmed && _activeVehicle.guidedModeSupported && _vehicleFlying && !_vehicleInRTLMode
-    property bool showTakeoff:              _guidedActionsEnabled && _activeVehicle.takeoffVehicleSupported && !_vehicleFlying && _canTakeoff
-    property bool showLand:                 _guidedActionsEnabled && _activeVehicle.guidedModeSupported && _vehicleArmed && !_activeVehicle.fixedWing && !_vehicleInLandMode
+    property bool showRTL:                  _guidedActionsEnabled && _vehicleArmed && _activeVehicle.supports.guidedMode && _vehicleFlying && !_vehicleInRTLMode
+    property bool showTakeoff:              _guidedActionsEnabled && (_activeVehicle.supports.guidedTakeoffWithAltitude || _activeVehicle.supports.guidedTakeoffWithoutAltitude) && !_vehicleFlying && _canTakeoff
+    property bool showLand:                 _guidedActionsEnabled && _activeVehicle.supports.guidedMode && _vehicleArmed && !_activeVehicle.fixedWing && !_vehicleInLandMode
     property bool showStartMission:         _guidedActionsEnabled && _missionAvailable && !_missionActive && !_vehicleFlying && _canStartMission
     property bool showContinueMission:      _guidedActionsEnabled && _missionAvailable && !_missionActive && _vehicleArmed && _vehicleFlying && (_currentMissionIndex < _missionItemCount - 1)
-    property bool showPause:                _guidedActionsEnabled && _vehicleArmed && _activeVehicle.pauseVehicleSupported && _vehicleFlying && !_vehiclePaused && !_fixedWingOnApproach
-    property bool showChangeAlt:            _guidedActionsEnabled && _vehicleFlying && _activeVehicle.guidedModeSupported && _vehicleArmed && !_missionActive
-    property bool showChangeLoiterRadius:   _guidedActionsEnabled && _vehicleFlying && _activeVehicle.guidedModeSupported && _vehicleArmed && !_missionActive && _vehicleInFwdFlight && fwdFlightGotoMapCircle.visible
-    property bool showChangeSpeed:          _guidedActionsEnabled && _vehicleFlying && _activeVehicle.guidedModeSupported && _vehicleArmed && !_missionActive && _speedLimitsAvailable
+    property bool showPause:                _guidedActionsEnabled && _vehicleArmed && _activeVehicle.supports.pauseVehicle && _vehicleFlying && !_vehiclePaused && !_fixedWingOnApproach
+    property bool showChangeAlt:            _guidedActionsEnabled && _vehicleFlying && _activeVehicle.supports.guidedMode && _vehicleArmed && !_missionActive
+    property bool showChangeLoiterRadius:   _guidedActionsEnabled && _vehicleFlying && _activeVehicle.supports.guidedMode && _vehicleArmed && !_missionActive && _vehicleInFwdFlight && fwdFlightGotoMapCircle.visible
+    property bool showChangeSpeed:          _guidedActionsEnabled && _vehicleFlying && _activeVehicle.supports.guidedMode && _vehicleArmed && !_missionActive && _speedLimitsAvailable
     property bool showOrbit:                _guidedActionsEnabled && _vehicleFlying && __orbitSupported && !_missionActive && _activeVehicle.homePosition.isValid && !isNaN(_activeVehicle.homePosition.altitude)
     property bool showROI:                  _guidedActionsEnabled && _vehicleFlying && __roiSupported
     property bool showLandAbort:            _guidedActionsEnabled && _vehicleFlying && _fixedWingOnApproach
@@ -176,10 +176,10 @@ Item {
     property bool  _speedLimitsAvailable:   _activeVehicle && ((_vehicleInFwdFlight && _activeVehicle.haveFWSpeedLimits) || (!_vehicleInFwdFlight && _activeVehicle.haveMRSpeedLimits))
 
     // You can turn on log output for GuidedActionsController by turning on GuidedActionsControllerLog category
-    property bool __guidedModeSupported:    _activeVehicle ? _activeVehicle.guidedModeSupported : false
-    property bool __pauseVehicleSupported:  _activeVehicle ? _activeVehicle.pauseVehicleSupported : false
-    property bool __roiSupported:           _activeVehicle ? !_hideROI && _activeVehicle.roiModeSupported : false
-    property bool __orbitSupported:         _activeVehicle ? !_hideOrbit && _activeVehicle.orbitModeSupported : false
+    property bool __guidedModeSupported:    _activeVehicle ? _activeVehicle.supports.guidedMode : false
+    property bool __pauseVehicleSupported:  _activeVehicle ? _activeVehicle.supports.pauseVehicle : false
+    property bool __roiSupported:           _activeVehicle ? !_hideROI && _activeVehicle.supports.roiMode : false
+    property bool __orbitSupported:         _activeVehicle ? !_hideOrbit && _activeVehicle.supports.orbitMode : false
     property bool __flightMode:             _flightMode
 
     // Allow custom builds to add custom actions by overriding CustomGuidedActionsController.qml
@@ -426,7 +426,7 @@ Item {
             confirmDialog.title = takeoffTitle
             confirmDialog.message = takeoffMessage
             confirmDialog.hideTrigger = Qt.binding(function() { return !showTakeoff })
-            guidedValueSlider.visible = _activeVehicle.guidedTakeoffSupported
+            guidedValueSlider.visible = _activeVehicle.supports.guidedTakeoffWithAltitude
             break;
         case actionStartMission:
             showImmediate = false
@@ -461,7 +461,7 @@ Item {
         case actionRTL:
             confirmDialog.title = rtlTitle
             confirmDialog.message = rtlMessage
-            if (_activeVehicle.supportsSmartRTL) {
+            if (_activeVehicle.supports.smartRTL) {
                 confirmDialog.optionText = qsTr("Smart RTL")
                 confirmDialog.optionChecked = false
             }
@@ -560,7 +560,7 @@ Item {
             _activeVehicle.guidedModeLand()
             break
         case actionTakeoff:
-            if (_activeVehicle.guidedTakeoffSupported) {
+            if (_activeVehicle.supports.guidedTakeoffWithAltitude) {
                 var valueInMeters = _unitsConversion.appSettingsVerticalDistanceUnitsToMeters(sliderOutputValue)
                 _activeVehicle.guidedModeTakeoff(valueInMeters)
             } else {

--- a/src/FlyView/MultiVehicleList.qml
+++ b/src/FlyView/MultiVehicleList.qml
@@ -51,7 +51,7 @@ Item {
     function pauseAvailable() {
         for (var i = 0; i < selectedVehicles.count; i++) {
             var vehicle = selectedVehicles.get(i)
-            if (vehicle.armed === true && vehicle.pauseVehicleSupported) {
+            if (vehicle.armed === true && vehicle.supports.pauseVehicle) {
                 return true
             }
         }

--- a/src/Joystick/Joystick.cc
+++ b/src/Joystick/Joystick.cc
@@ -9,6 +9,7 @@
 #include "QmlObjectListModel.h"
 #include "SettingsManager.h"
 #include "Vehicle.h"
+#include "VehicleSupports.h"
 #include "JoystickManager.h"
 #include "MultiVehicleManager.h"
 
@@ -1001,8 +1002,8 @@ void Joystick::_handleAxis()
         }
 
         // Adjust throttle to 0:1 range
-        if (throttleModeCenterZero && vehicle->supportsThrottleModeCenterZero()) {
-            if (!vehicle->supportsNegativeThrust() || !negativeThrust) {
+        if (throttleModeCenterZero && vehicle->supports()->throttleModeCenterZero()) {
+            if (!vehicle->supports()->negativeThrust() || !negativeThrust) {
                 throttle = std::max(0.0f, throttle);
             }
         } else {

--- a/src/MissionManager/MissionController.cc
+++ b/src/MissionManager/MissionController.cc
@@ -1,5 +1,6 @@
 #include "MissionController.h"
 #include "Vehicle.h"
+#include "VehicleSupports.h"
 #include "MissionManager.h"
 #include "FlightPathSegment.h"
 #include "FirmwarePlugin.h"
@@ -2521,7 +2522,7 @@ void MissionController::setCurrentPlanViewSeqNum(int sequenceNumber, bool force)
         _previousCoordinate =           QGeoCoordinate();
 
         bool noItemsAddedYet = _visualItems->count() == 1;
-        if (_masterController->controllerVehicle()->takeoffVehicleSupported() && !_planViewSettings->takeoffItemNotRequired()->rawValue().toBool() && noItemsAddedYet) {
+        if (_masterController->controllerVehicle()->supports()->takeoffMissionCommand() && !_planViewSettings->takeoffItemNotRequired()->rawValue().toBool() && noItemsAddedYet) {
             _onlyInsertTakeoffValid = true;
         }
 

--- a/src/QmlControls/AltModeCombo.qml
+++ b/src/QmlControls/AltModeCombo.qml
@@ -41,7 +41,7 @@ QGCComboBox {
         if (!QGroundControl.corePlugin.options.showMissionAbsoluteAltitude && altitudeMode != QGroundControl.AltitudeModeAbsolute) {
             removeModes.push(QGroundControl.AltitudeModeAbsolute)
         }
-        if (!vehicle.supportsTerrainFrame) {
+        if (!vehicle.supports.terrainFrame) {
             removeModes.push(QGroundControl.AltitudeModeTerrainFrame)
         }
 

--- a/src/QmlControls/MissionItemTreeView.qml
+++ b/src/QmlControls/MissionItemTreeView.qml
@@ -315,7 +315,7 @@ TreeView {
                 Connections {
                     target: defaultsRect._controllerVehicle
                     function onFirmwareTypeChanged() {
-                        if (!defaultsRect._controllerVehicle.supportsTerrainFrame
+                        if (!defaultsRect._controllerVehicle.supports.terrainFrame
                                 && defaultsRect._missionController.globalAltitudeMode === QGroundControl.AltitudeModeTerrainFrame) {
                             defaultsRect._missionController.globalAltitudeMode = QGroundControl.AltitudeModeCalcAboveTerrain
                         }
@@ -345,7 +345,7 @@ TreeView {
                         onClicked: {
                             let removeModes = []
                             let updateFunction = function(altMode) { defaultsRect._missionController.globalAltitudeMode = altMode }
-                            if (!defaultsRect._controllerVehicle.supportsTerrainFrame) {
+                            if (!defaultsRect._controllerVehicle.supports.terrainFrame) {
                                 removeModes.push(QGroundControl.AltitudeModeTerrainFrame)
                             }
                             if (!defaultsRect._noMissionItemsAdded) {

--- a/src/QmlControls/PlanView.qml
+++ b/src/QmlControls/PlanView.qml
@@ -454,7 +454,7 @@ Item {
                         id: roiButton
                         text: qsTr("ROI")
                         iconSource: "/qmlimages/roi.svg"
-                        visible: toolStrip._isMissionLayer && _planMasterController.controllerVehicle.roiModeSupported
+                        visible: toolStrip._isMissionLayer && _planMasterController.controllerVehicle.supports.roiMode
                         checkable: true
                         onTriggered: { _addROIOnClick = !_addROIOnClick; if (_addROIOnClick) _addWaypointOnClick = false }
                     },

--- a/src/QmlControls/TransectStyleComplexItemTerrainFollow.qml
+++ b/src/QmlControls/TransectStyleComplexItemTerrainFollow.qml
@@ -20,7 +20,7 @@ ColumnLayout {
             var removeModes = []
             var updateFunction = function(altMode){ missionItem.cameraCalc.distanceMode = altMode }
             removeModes.push(QGroundControl.AltitudeModeMixed)
-            if (!missionItem.masterController.controllerVehicle.supportsTerrainFrame) {
+            if (!missionItem.masterController.controllerVehicle.supports.terrainFrame) {
                 removeModes.push(QGroundControl.AltitudeModeTerrainFrame)
             }
             if (!QGroundControl.corePlugin.options.showMissionAbsoluteAltitude || !_missionItem.cameraCalc.isManualCamera) {

--- a/src/UI/toolbar/RCRSSIIndicator.qml
+++ b/src/UI/toolbar/RCRSSIIndicator.qml
@@ -12,7 +12,7 @@ Item {
     anchors.top:    parent.top
     anchors.bottom: parent.bottom
 
-    property bool showIndicator: _activeVehicle.supportsRadio && _rcRSSIAvailable
+    property bool showIndicator: _activeVehicle.supports.radio && _rcRSSIAvailable
 
     property var    _activeVehicle:     QGroundControl.multiVehicleManager.activeVehicle
     property bool   _rcRSSIAvailable:   _activeVehicle.rcRSSI > 0 && _activeVehicle.rcRSSI <= 100

--- a/src/Vehicle/CMakeLists.txt
+++ b/src/Vehicle/CMakeLists.txt
@@ -31,6 +31,8 @@ target_sources(${CMAKE_PROJECT_NAME}
         VehicleLinkManager.h
         VehicleObjectAvoidance.cc
         VehicleObjectAvoidance.h
+        VehicleSupports.cc
+        VehicleSupports.h
 )
 
 target_include_directories(${CMAKE_PROJECT_NAME} PRIVATE ${CMAKE_CURRENT_SOURCE_DIR})

--- a/src/Vehicle/Vehicle.cc
+++ b/src/Vehicle/Vehicle.cc
@@ -1,5 +1,6 @@
 #include "Vehicle.h"
 #include "Actuators.h"
+#include "VehicleSupports.h"
 #include "ADSBVehicleManager.h"
 #include "AudioOutput.h"
 #include "AutoPilotPlugin.h"
@@ -342,6 +343,7 @@ void Vehicle::_commonInit(LinkInterface* link)
     }
 
     _gimbalController = new GimbalController(this);
+    _vehicleSupports = new VehicleSupports(this);
 
     _createCameraManager();
 }
@@ -1869,36 +1871,6 @@ bool Vehicle::vtol() const
     return QGCMAVLink::isVTOL(vehicleType());
 }
 
-bool Vehicle::supportsThrottleModeCenterZero() const
-{
-    return _firmwarePlugin->supportsThrottleModeCenterZero();
-}
-
-bool Vehicle::supportsNegativeThrust()
-{
-    return _firmwarePlugin->supportsNegativeThrust(this);
-}
-
-bool Vehicle::supportsRadio() const
-{
-    return _firmwarePlugin->supportsRadio();
-}
-
-bool Vehicle::supportsJSButton() const
-{
-    return _firmwarePlugin->supportsJSButton();
-}
-
-bool Vehicle::supportsMotorInterference() const
-{
-    return _firmwarePlugin->supportsMotorInterference();
-}
-
-bool Vehicle::supportsTerrainFrame() const
-{
-    return !px4Firmware();
-}
-
 QString Vehicle::vehicleTypeString() const
 {
     return QGCMAVLink::mavTypeToString(_vehicleType);
@@ -1951,41 +1923,6 @@ void Vehicle::_setLanding(bool landing)
     }
 }
 
-bool Vehicle::guidedModeSupported() const
-{
-    return _firmwarePlugin->isCapable(this, FirmwarePlugin::GuidedModeCapability);
-}
-
-bool Vehicle::pauseVehicleSupported() const
-{
-    return _firmwarePlugin->isCapable(this, FirmwarePlugin::PauseVehicleCapability);
-}
-
-bool Vehicle::orbitModeSupported() const
-{
-    return _firmwarePlugin->isCapable(this, FirmwarePlugin::OrbitModeCapability);
-}
-
-bool Vehicle::roiModeSupported() const
-{
-    return _firmwarePlugin->isCapable(this, FirmwarePlugin::ROIModeCapability);
-}
-
-bool Vehicle::takeoffVehicleSupported() const
-{
-    return _firmwarePlugin->isCapable(this, FirmwarePlugin::TakeoffVehicleCapability);
-}
-
-bool Vehicle::guidedTakeoffSupported() const
-{
-    return _firmwarePlugin->isCapable(this, FirmwarePlugin::GuidedTakeoffCapability);
-}
-
-bool Vehicle::changeHeadingSupported() const
-{
-    return _firmwarePlugin->isCapable(this, FirmwarePlugin::ChangeHeadingCapability);
-}
-
 QString Vehicle::gotoFlightMode() const
 {
     return _firmwarePlugin->gotoFlightMode();
@@ -1993,7 +1930,7 @@ QString Vehicle::gotoFlightMode() const
 
 void Vehicle::guidedModeRTL(bool smartRTL)
 {
-    if (!guidedModeSupported()) {
+    if (!_vehicleSupports->guidedMode()) {
         qgcApp()->showAppMessage(guided_mode_not_supported_by_vehicle);
         return;
     }
@@ -2002,7 +1939,7 @@ void Vehicle::guidedModeRTL(bool smartRTL)
 
 void Vehicle::guidedModeLand()
 {
-    if (!guidedModeSupported()) {
+    if (!_vehicleSupports->guidedMode()) {
         qgcApp()->showAppMessage(guided_mode_not_supported_by_vehicle);
         return;
     }
@@ -2011,7 +1948,7 @@ void Vehicle::guidedModeLand()
 
 void Vehicle::guidedModeTakeoff(double altitudeRelative)
 {
-    if (!guidedModeSupported()) {
+    if (!_vehicleSupports->guidedMode()) {
         qgcApp()->showAppMessage(guided_mode_not_supported_by_vehicle);
         return;
     }
@@ -2058,7 +1995,7 @@ void Vehicle::startMission()
 
 void Vehicle::guidedModeGotoLocation(const QGeoCoordinate& gotoCoord, double forwardFlightLoiterRadius)
 {
-    if (!guidedModeSupported()) {
+    if (!_vehicleSupports->guidedMode()) {
         qgcApp()->showAppMessage(guided_mode_not_supported_by_vehicle);
         return;
     }
@@ -2075,7 +2012,7 @@ void Vehicle::guidedModeGotoLocation(const QGeoCoordinate& gotoCoord, double for
 
 void Vehicle::guidedModeChangeAltitude(double altitudeChange, bool pauseVehicle)
 {
-    if (!guidedModeSupported()) {
+    if (!_vehicleSupports->guidedMode()) {
         qgcApp()->showAppMessage(guided_mode_not_supported_by_vehicle);
         return;
     }
@@ -2085,7 +2022,7 @@ void Vehicle::guidedModeChangeAltitude(double altitudeChange, bool pauseVehicle)
 void
 Vehicle::guidedModeChangeGroundSpeedMetersSecond(double groundspeed)
 {
-    if (!guidedModeSupported()) {
+    if (!_vehicleSupports->guidedMode()) {
         qgcApp()->showAppMessage(guided_mode_not_supported_by_vehicle);
         return;
     }
@@ -2095,7 +2032,7 @@ Vehicle::guidedModeChangeGroundSpeedMetersSecond(double groundspeed)
 void
 Vehicle::guidedModeChangeEquivalentAirspeedMetersSecond(double airspeed)
 {
-    if (!guidedModeSupported()) {
+    if (!_vehicleSupports->guidedMode()) {
         qgcApp()->showAppMessage(guided_mode_not_supported_by_vehicle);
         return;
     }
@@ -2104,7 +2041,7 @@ Vehicle::guidedModeChangeEquivalentAirspeedMetersSecond(double airspeed)
 
 void Vehicle::guidedModeOrbit(const QGeoCoordinate& centerCoord, double radius, double amslAltitude)
 {
-    if (!orbitModeSupported()) {
+    if (!_vehicleSupports->orbitMode()) {
         qgcApp()->showAppMessage(QStringLiteral("Orbit mode not supported by Vehicle."));
         return;
     }
@@ -2139,7 +2076,7 @@ void Vehicle::guidedModeROI(const QGeoCoordinate& centerCoord)
     if (!centerCoord.isValid()) {
         return;
     }
-    if (!roiModeSupported()) {
+    if (!_vehicleSupports->roiMode()) {
         qgcApp()->showAppMessage(QStringLiteral("ROI mode not supported by Vehicle."));
         return;
     }
@@ -2228,7 +2165,7 @@ void Vehicle::_sendROICommand(const QGeoCoordinate& coord, MAV_FRAME frame, floa
 
 void Vehicle::stopGuidedModeROI()
 {
-    if (!roiModeSupported()) {
+    if (!_vehicleSupports->roiMode()) {
         qgcApp()->showAppMessage(QStringLiteral("ROI mode not supported by Vehicle."));
         return;
     }
@@ -2262,7 +2199,7 @@ void Vehicle::stopGuidedModeROI()
 
 void Vehicle::guidedModeChangeHeading(const QGeoCoordinate &headingCoord)
 {
-    if (!changeHeadingSupported()) {
+    if (!_vehicleSupports->changeHeading()) {
         qgcApp()->showAppMessage(tr("Change Heading not supported by Vehicle."));
         return;
     }
@@ -2272,7 +2209,7 @@ void Vehicle::guidedModeChangeHeading(const QGeoCoordinate &headingCoord)
 
 void Vehicle::pauseVehicle()
 {
-    if (!pauseVehicleSupported()) {
+    if (!_vehicleSupports->pauseVehicle()) {
         qgcApp()->showAppMessage(QStringLiteral("Pause not supported by vehicle."));
         return;
     }
@@ -3514,11 +3451,6 @@ QString Vehicle::rtlFlightMode() const
 QString Vehicle::smartRTLFlightMode() const
 {
     return _firmwarePlugin->smartRTLFlightMode();
-}
-
-bool Vehicle::supportsSmartRTL() const
-{
-    return _firmwarePlugin->supportsSmartRTL();
 }
 
 QString Vehicle::landFlightMode() const

--- a/src/Vehicle/Vehicle.h
+++ b/src/Vehicle/Vehicle.h
@@ -68,6 +68,7 @@ class TerrainAtCoordinateQuery;
 class TerrainProtocolHandler;
 class TrajectoryPoints;
 class VehicleObjectAvoidance;
+class VehicleSupports;
 
 namespace events {
 namespace parser {
@@ -91,6 +92,7 @@ class Vehicle : public VehicleFactGroup
     Q_MOC_INCLUDE("Actuators.h")
     Q_MOC_INCLUDE("MAVLinkLogManager.h")
     Q_MOC_INCLUDE("LinkInterface.h")
+    Q_MOC_INCLUDE("VehicleSupports.h")
 
     friend class InitialConnectStateMachine;
     friend class VehicleLinkManager;
@@ -159,11 +161,7 @@ public:
     Q_PROPERTY(bool                 vtol                        READ vtol                                                           NOTIFY vehicleTypeChanged)
     Q_PROPERTY(bool                 rover                       READ rover                                                          NOTIFY vehicleTypeChanged)
     Q_PROPERTY(bool                 sub                         READ sub                                                            NOTIFY vehicleTypeChanged)
-    Q_PROPERTY(bool        supportsThrottleModeCenterZero       READ supportsThrottleModeCenterZero                                 CONSTANT)
-    Q_PROPERTY(bool                supportsNegativeThrust       READ supportsNegativeThrust                                         CONSTANT)
-    Q_PROPERTY(bool                 supportsJSButton            READ supportsJSButton                                               CONSTANT)
-    Q_PROPERTY(bool                 supportsRadio               READ supportsRadio                                                  CONSTANT)
-    Q_PROPERTY(bool               supportsMotorInterference     READ supportsMotorInterference                                      CONSTANT)
+    Q_PROPERTY(VehicleSupports*     supports                    READ supports                                                       CONSTANT)
     Q_PROPERTY(QString              prearmError                 READ prearmError                WRITE setPrearmError                NOTIFY prearmErrorChanged)
     Q_PROPERTY(int                  motorCount                  READ motorCount                                                     CONSTANT)
     Q_PROPERTY(bool                 coaxialMotors               READ coaxialMotors                                                  CONSTANT)
@@ -179,7 +177,6 @@ public:
     Q_PROPERTY(QString              pauseFlightMode             READ pauseFlightMode                                                CONSTANT)
     Q_PROPERTY(QString              rtlFlightMode               READ rtlFlightMode                                                  CONSTANT)
     Q_PROPERTY(QString              smartRTLFlightMode          READ smartRTLFlightMode                                             CONSTANT)
-    Q_PROPERTY(bool                 supportsSmartRTL            READ supportsSmartRTL                                               CONSTANT)
     Q_PROPERTY(QString              landFlightMode              READ landFlightMode                                                 CONSTANT)
     Q_PROPERTY(QString              takeControlFlightMode       READ takeControlFlightMode                                          CONSTANT)
     Q_PROPERTY(QString              followFlightMode            READ followFlightMode                                               CONSTANT)
@@ -201,7 +198,6 @@ public:
     Q_PROPERTY(QString              hobbsMeter                  READ hobbsMeter                                                     NOTIFY hobbsMeterChanged)
     Q_PROPERTY(bool                 inFwdFlight                 READ inFwdFlight                                                    NOTIFY inFwdFlightChanged)
     Q_PROPERTY(bool                 vtolInFwdFlight             READ vtolInFwdFlight            WRITE setVtolInFwdFlight            NOTIFY vtolInFwdFlightChanged)
-    Q_PROPERTY(bool                 supportsTerrainFrame        READ supportsTerrainFrame                                           NOTIFY firmwareTypeChanged)
     Q_PROPERTY(quint64              mavlinkSentCount            READ mavlinkSentCount                                               NOTIFY mavlinkStatusChanged)
     Q_PROPERTY(quint64              mavlinkReceivedCount        READ mavlinkReceivedCount                                           NOTIFY mavlinkStatusChanged)
     Q_PROPERTY(quint64              mavlinkLossCount            READ mavlinkLossCount                                               NOTIFY mavlinkStatusChanged)
@@ -226,13 +222,6 @@ public:
     Q_PROPERTY(bool     flying                  READ flying                                         NOTIFY flyingChanged)       ///< Vehicle is flying
     Q_PROPERTY(bool     landing                 READ landing                                        NOTIFY landingChanged)      ///< Vehicle is in landing pattern (DO_LAND_START)
     Q_PROPERTY(bool     guidedMode              READ guidedMode                 WRITE setGuidedMode NOTIFY guidedModeChanged)   ///< Vehicle is in Guided mode and can respond to guided commands
-    Q_PROPERTY(bool     guidedModeSupported     READ guidedModeSupported                            CONSTANT)                   ///< Guided mode commands are supported by this vehicle
-    Q_PROPERTY(bool     pauseVehicleSupported   READ pauseVehicleSupported                          CONSTANT)                   ///< Pause vehicle command is supported
-    Q_PROPERTY(bool     orbitModeSupported      READ orbitModeSupported                             CONSTANT)                   ///< Orbit mode is supported by this vehicle
-    Q_PROPERTY(bool     roiModeSupported        READ roiModeSupported                               CONSTANT)                   ///< Orbit mode is supported by this vehicle
-    Q_PROPERTY(bool     takeoffVehicleSupported READ takeoffVehicleSupported                        CONSTANT)                   ///< Takeoff supported
-    Q_PROPERTY(bool     guidedTakeoffSupported  READ guidedTakeoffSupported                         CONSTANT)                   ///< Guided takeoff supported
-    Q_PROPERTY(bool     changeHeadingSupported  READ changeHeadingSupported                         CONSTANT)                   ///< Change Heading supported
     Q_PROPERTY(QString  gotoFlightMode          READ gotoFlightMode                                 CONSTANT)                   ///< Flight mode vehicle is in while performing goto
     Q_PROPERTY(bool     haveMRSpeedLimits       READ haveMRSpeedLimits                              NOTIFY haveMRSpeedLimChanged)
     Q_PROPERTY(bool     haveFWSpeedLimits       READ haveFWSpeedLimits                              NOTIFY haveFWSpeedLimChanged)
@@ -411,14 +400,9 @@ public:
     Q_INVOKABLE QVariant expandedToolbarIndicatorSource(const QString& indicatorName);
 
     bool    isInitialConnectComplete() const;
-    bool    guidedModeSupported     () const;
-    bool    pauseVehicleSupported   () const;
-    bool    orbitModeSupported      () const;
-    bool    roiModeSupported        () const;
-    bool    takeoffVehicleSupported () const;
-    bool    guidedTakeoffSupported  () const;
-    bool    changeHeadingSupported  () const;
     QString gotoFlightMode          () const;
+
+    VehicleSupports* supports() { return _vehicleSupports; }
     bool    hasGripper              () const;
     bool haveMRSpeedLimits() const { return _multirotor_speed_limits_available; }
     bool haveFWSpeedLimits() const { return _fixed_wing_airspeed_limits_available; }
@@ -482,12 +466,7 @@ public:
     bool sub() const;
     bool spacecraft() const;
 
-    bool supportsThrottleModeCenterZero () const;
-    bool supportsNegativeThrust         ();
-    bool supportsRadio                  () const;
-    bool supportsJSButton               () const;
-    bool supportsMotorInterference      () const;
-    bool supportsTerrainFrame           () const;
+
 
     void setGuidedMode(bool guidedMode);
 
@@ -537,7 +516,6 @@ public:
     QString         pauseFlightMode             () const;
     QString         rtlFlightMode               () const;
     QString         smartRTLFlightMode          () const;
-    bool            supportsSmartRTL            () const;
     QString         landFlightMode              () const;
     QString         takeControlFlightMode       () const;
     QString         followFlightMode            () const;
@@ -1050,6 +1028,7 @@ void _activeVehicleChanged          (Vehicle* newActiveVehicle);
     VehicleObjectAvoidance*         _objectAvoidance                = nullptr;
     Autotune*                       _autotune                       = nullptr;
     GimbalController*               _gimbalController               = nullptr;
+    VehicleSupports*                _vehicleSupports                = nullptr;
 
     bool    _armed = false;         ///< true: vehicle is armed
     uint8_t _base_mode = 0;     ///< base_mode from HEARTBEAT

--- a/src/Vehicle/VehicleSetup/JoystickComponentButtons.qml
+++ b/src/Vehicle/VehicleSetup/JoystickComponentButtons.qml
@@ -107,7 +107,7 @@ ColumnLayout {
     /*Column {
         id:         buttonCol
         Layout.fillWidth: true
-        visible:    globals.activeVehicle.supportsJSButton
+        visible:    globals.activeVehicle.supports.jsButton
         spacing:    ScreenTools.defaultFontPixelHeight / 3
 
         Row {
@@ -123,7 +123,7 @@ ColumnLayout {
             }
             QGCLabel {
                 width: ScreenTools.defaultFontPixelWidth * 26
-                visible: globals.activeVehicle.supportsJSButton
+                visible: globals.activeVehicle.supports.jsButton
                 text: qsTr("Shift Function: ")
             }
         }
@@ -133,7 +133,7 @@ ColumnLayout {
 
             Row {
                 spacing: ScreenTools.defaultFontPixelWidth
-                visible: globals.activeVehicle.supportsJSButton
+                visible: globals.activeVehicle.supports.jsButton
                 property var parameterName: `BTN${index}_FUNCTION`
                 property var parameterShiftName: `BTN${index}_SFUNCTION`
                 property bool hasFirmwareSupport: controller.parameterExists(-1, parameterName)
@@ -217,7 +217,7 @@ ColumnLayout {
                     id: repeatCheck
                     text: qsTr("Repeat")
                     enabled: currentAssignableAction && joystick.calibrated && currentAssignableAction.canRepeat
-                    visible: !globals.activeVehicle.supportsJSButton
+                    visible: !globals.activeVehicle.supports.jsButton
 
                     onClicked: {
                         joystick.setButtonRepeat(modelData, checked)

--- a/src/Vehicle/VehicleSetup/JoystickComponentSettings.qml
+++ b/src/Vehicle/VehicleSetup/JoystickComponentSettings.qml
@@ -46,7 +46,7 @@ ColumnLayout {
             Layout.fillWidth: true
             text: qsTr("Negative Thrust")
             fact: _joystickSettings.negativeThrust
-            visible: globals.activeVehicle.supportsNegativeThrust && fact.visible
+            visible: globals.activeVehicle.supports.negativeThrust && fact.visible
         }
 
         QGCCheckBoxSlider {

--- a/src/Vehicle/VehicleSupports.cc
+++ b/src/Vehicle/VehicleSupports.cc
@@ -1,0 +1,88 @@
+#include "VehicleSupports.h"
+
+#include "FirmwarePlugin/FirmwarePlugin.h"
+#include "Vehicle.h"
+
+VehicleSupports::VehicleSupports(Vehicle *vehicle)
+    : QObject(vehicle)
+    , _vehicle(vehicle)
+{
+    connect(_vehicle, &Vehicle::firmwareTypeChanged, this, &VehicleSupports::terrainFrameChanged);
+}
+
+bool VehicleSupports::throttleModeCenterZero() const
+{
+    return _vehicle->firmwarePlugin()->supportsThrottleModeCenterZero();
+}
+
+bool VehicleSupports::negativeThrust() const
+{
+    return _vehicle->firmwarePlugin()->supportsNegativeThrust(_vehicle);
+}
+
+bool VehicleSupports::jsButton() const
+{
+    return _vehicle->firmwarePlugin()->supportsJSButton();
+}
+
+bool VehicleSupports::radio() const
+{
+    return _vehicle->firmwarePlugin()->supportsRadio();
+}
+
+bool VehicleSupports::motorInterference() const
+{
+    return _vehicle->firmwarePlugin()->supportsMotorInterference();
+}
+
+bool VehicleSupports::smartRTL() const
+{
+    return _vehicle->firmwarePlugin()->supportsSmartRTL();
+}
+
+bool VehicleSupports::terrainFrame() const
+{
+    return !_vehicle->px4Firmware();
+}
+
+bool VehicleSupports::guidedMode() const
+{
+    return _vehicle->firmwarePlugin()->isCapable(_vehicle, FirmwarePlugin::GuidedModeCapability);
+}
+
+bool VehicleSupports::pauseVehicle() const
+{
+    return _vehicle->firmwarePlugin()->isCapable(_vehicle, FirmwarePlugin::PauseVehicleCapability);
+}
+
+bool VehicleSupports::orbitMode() const
+{
+    return _vehicle->firmwarePlugin()->isCapable(_vehicle, FirmwarePlugin::OrbitModeCapability);
+}
+
+bool VehicleSupports::roiMode() const
+{
+    return _vehicle->firmwarePlugin()->isCapable(_vehicle, FirmwarePlugin::ROIModeCapability);
+}
+
+bool VehicleSupports::takeoffMissionCommand() const
+{
+    return _vehicle->firmwarePlugin()->isCapable(_vehicle, FirmwarePlugin::TakeoffVehicleCapability);
+}
+
+bool VehicleSupports::guidedTakeoffWithAltitude() const
+{
+    return _vehicle->firmwarePlugin()->isCapable(_vehicle, FirmwarePlugin::GuidedTakeoffCapability);
+}
+
+bool VehicleSupports::guidedTakeoffWithoutAltitude() const
+{
+    auto* fp = _vehicle->firmwarePlugin();
+    return fp->isCapable(_vehicle, FirmwarePlugin::TakeoffVehicleCapability)
+        && !fp->isCapable(_vehicle, FirmwarePlugin::GuidedTakeoffCapability);
+}
+
+bool VehicleSupports::changeHeading() const
+{
+    return _vehicle->firmwarePlugin()->isCapable(_vehicle, FirmwarePlugin::ChangeHeadingCapability);
+}

--- a/src/Vehicle/VehicleSupports.h
+++ b/src/Vehicle/VehicleSupports.h
@@ -1,0 +1,55 @@
+#pragma once
+
+#include <QtCore/QObject>
+#include <QtQmlIntegration/QtQmlIntegration>
+
+class FirmwarePlugin;
+class Vehicle;
+
+class VehicleSupports : public QObject
+{
+    Q_OBJECT
+    QML_ELEMENT
+    QML_UNCREATABLE("")
+
+public:
+    explicit VehicleSupports(Vehicle *vehicle);
+
+    Q_PROPERTY(bool throttleModeCenterZero          READ throttleModeCenterZero         CONSTANT)
+    Q_PROPERTY(bool negativeThrust                  READ negativeThrust                 CONSTANT)
+    Q_PROPERTY(bool jsButton                        READ jsButton                       CONSTANT)
+    Q_PROPERTY(bool radio                           READ radio                          CONSTANT)
+    Q_PROPERTY(bool motorInterference               READ motorInterference              CONSTANT)
+    Q_PROPERTY(bool smartRTL                        READ smartRTL                       CONSTANT)
+    Q_PROPERTY(bool terrainFrame                    READ terrainFrame                   NOTIFY terrainFrameChanged)
+    Q_PROPERTY(bool guidedMode                      READ guidedMode                     CONSTANT)
+    Q_PROPERTY(bool pauseVehicle                    READ pauseVehicle                   CONSTANT)
+    Q_PROPERTY(bool orbitMode                       READ orbitMode                      CONSTANT)
+    Q_PROPERTY(bool roiMode                         READ roiMode                        CONSTANT)
+    Q_PROPERTY(bool takeoffMissionCommand           READ takeoffMissionCommand          CONSTANT)
+    Q_PROPERTY(bool guidedTakeoffWithAltitude       READ guidedTakeoffWithAltitude      CONSTANT)
+    Q_PROPERTY(bool guidedTakeoffWithoutAltitude    READ guidedTakeoffWithoutAltitude   CONSTANT)
+    Q_PROPERTY(bool changeHeading                   READ changeHeading                  CONSTANT)
+
+    bool throttleModeCenterZero() const;
+    bool negativeThrust() const;
+    bool jsButton() const;
+    bool radio() const;
+    bool motorInterference() const;
+    bool smartRTL() const;
+    bool terrainFrame() const;
+    bool guidedMode() const;
+    bool pauseVehicle() const;
+    bool orbitMode() const;
+    bool roiMode() const;
+    bool takeoffMissionCommand() const;
+    bool guidedTakeoffWithAltitude() const;
+    bool guidedTakeoffWithoutAltitude() const;
+    bool changeHeading() const;
+
+signals:
+    void terrainFrameChanged();
+
+private:
+    Vehicle *_vehicle = nullptr;
+};


### PR DESCRIPTION
## Summary

Extract all `supports*` and `*Supported` Q_PROPERTYs from `Vehicle` into a new `VehicleSupports` class, accessible via `vehicle.supports` in QML and `vehicle->supports()` in C++.

## Changes

### New files
- `VehicleSupports.h` / `VehicleSupports.cc` — New QObject-based class holding all vehicle capability/support query properties

### Property renames
| Old (Vehicle) | New (VehicleSupports) |
|---|---|
| `supportsThrottleModeCenterZero` | `supports.throttleModeCenterZero` |
| `supportsNegativeThrust` | `supports.negativeThrust` |
| `supportsJSButton` | `supports.jsButton` |
| `supportsRadio` | `supports.radio` |
| `supportsMotorInterference` | `supports.motorInterference` |
| `supportsSmartRTL` | `supports.smartRTL` |
| `supportsTerrainFrame` | `supports.terrainFrame` |
| `guidedModeSupported` | `supports.guidedMode` |
| `pauseVehicleSupported` | `supports.pauseVehicle` |
| `orbitModeSupported` | `supports.orbitMode` |
| `roiModeSupported` | `supports.roiMode` |
| `changeHeadingSupported` | `supports.changeHeading` |

### Takeoff capability refactoring
Separated mission planning from guided action concerns:
- `takeoffVehicleSupported` → `supports.takeoffMissionCommand` — used only for mission planning (auto-insert takeoff item)
- `guidedTakeoffSupported` → `supports.guidedTakeoffWithAltitude` — guided takeoff with altitude slider
- **New**: `supports.guidedTakeoffWithoutAltitude` — guided takeoff without altitude (e.g. PX4 fixed-wing)
- `GuidedActionsController.qml` now uses only the guided variants for showing the takeoff button
