### PR TITLE
Refactor PlanView TreeView: QPersistentModelIndex, independent expand/collapse, signal-based layer changes

### DIFF
--- a/resources/GeoFence.svg
+++ b/resources/GeoFence.svg
@@ -1,8 +1,8 @@
 <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20">
-    <!-- drone scaled to 68%, left-anchored, vertically centred -->
-    <g transform="scale(0.68) translate(0.5 4.5)">
+    <!-- drone scaled to 82%, left-anchored, vertically centred -->
+    <g transform="scale(0.82) translate(-0.7 2.5)">
         <path d="M12 4h4.27a2 2 0 1 1 0 2h-2.14a9 9 0 0 1 4.84 7.25 2 2 0 1 1-2 .04 7 7 0 0 0-4.97-6V8H8v-.71a7 7 0 0 0-4.96 6 2 2 0 1 1-2-.04A9 9 0 0 1 5.86 6H3.73a2 2 0 1 1 0-2H8V3h4z"/>
     </g>
     <!-- dashed geofence wall, right-anchored, 3 dashes with small gaps -->
-    <path d="M17 2h2.5v4.7h-2.5ZM17 7.7h2.5v4.7h-2.5ZM17 13.4h2.5v4.6h-2.5Z"/>
+    <path d="M18 2h2v4.7h-2ZM18 7.7h2v4.7h-2ZM18 13.4h2v4.6h-2Z"/>
 </svg>

--- a/resources/RallyPoint.svg
+++ b/resources/RallyPoint.svg
@@ -1,3 +1,6 @@
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20">
-    <path fill-rule="evenodd" d="M0 0h2v20h-2Z M3 0h15v11.25h-15Z M6 0h3v2.25h-3Z M12 0h3v2.25h-3Z M3 2.25h3v2.25h-3Z M9 2.25h3v2.25h-3Z M15 2.25h3v2.25h-3Z M6 4.5h3v2.25h-3Z M12 4.5h3v2.25h-3Z M3 6.75h3v2.25h-3Z M9 6.75h3v2.25h-3Z M15 6.75h3v2.25h-3Z M6 9h3v2.25h-3Z M12 9h3v2.25h-3Z"/>
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="-2 -2 24 24">
+    <!-- Pole -->
+    <path d="M0 0h2v20h-2Z" fill="#000000"/>
+    <!-- Triangular banner (1px gap from pole) -->
+    <polygon points="3,0 19,5.5 3,11" fill="#000000"/>
 </svg>

--- a/src/MissionManager/MissionController.cc
+++ b/src/MissionManager/MissionController.cc
@@ -1910,36 +1910,50 @@ void MissionController::_onRallyPointsInserted(const QModelIndex& parent, int fi
     auto* rallyController = _masterController->rallyPointController();
     if (!rallyController) return;
 
+    // If this is the first rally point, remove the header marker
+    if (first == 0 && _visualItemsTree.rowCount(_rallyGroupIndex) == 1) {
+        const QModelIndex child = _visualItemsTree.index(0, 0, _rallyGroupIndex);
+        if (_visualItemsTree.data(child, QmlObjectTreeModel::NodeTypeRole).toString() == QStringLiteral("rallyHeader")) {
+            _visualItemsTree.removeItem(child);
+        }
+    }
+
     auto* pts = rallyController->points();
-    // Rally children: index 0 is the rallyHeader marker, rally items start at index 1
     for (int i = first; i <= last; i++) {
-        _visualItemsTree.insertItem(i + 1, (*pts)[i], _rallyGroupIndex, QStringLiteral("rallyItem"));
+        _visualItemsTree.insertItem(i, (*pts)[i], _rallyGroupIndex, QStringLiteral("rallyItem"));
     }
 }
 
 void MissionController::_onRallyPointsAboutToBeRemoved(const QModelIndex& parent, int first, int last)
 {
     Q_UNUSED(parent);
-    // Rally children: index 0 is header marker, rally items start at index 1
     for (int i = last; i >= first; i--) {
-        _visualItemsTree.removeAt(_rallyGroupIndex, i + 1);
+        _visualItemsTree.removeAt(_rallyGroupIndex, i);
+    }
+
+    // If all rally points are being removed, re-add the header marker
+    auto* rallyController = _masterController->rallyPointController();
+    if (rallyController && (rallyController->points()->count() - (last - first + 1)) == 0) {
+        _rallyHeaderMarker.setObjectName(QStringLiteral("rallyHeader"));
+        _visualItemsTree.appendItem(&_rallyHeaderMarker, _rallyGroupIndex, QStringLiteral("rallyHeader"));
     }
 }
 
 void MissionController::_onRallyPointsReset(void)
 {
-    // Remove all rally children except the header marker (index 0)
-    while (_visualItemsTree.rowCount(_rallyGroupIndex) > 1) {
-        _visualItemsTree.removeAt(_rallyGroupIndex, _visualItemsTree.rowCount(_rallyGroupIndex) - 1);
-    }
+    // Remove all rally children
+    _visualItemsTree.removeChildren(_rallyGroupIndex);
 
-    // Repopulate
+    // Repopulate — either rally items or the header marker
     auto* rallyController = _masterController->rallyPointController();
-    if (rallyController) {
+    if (rallyController && rallyController->points()->count() > 0) {
         auto* pts = rallyController->points();
         for (int i = 0; i < pts->count(); i++) {
             _visualItemsTree.appendItem((*pts)[i], _rallyGroupIndex, QStringLiteral("rallyItem"));
         }
+    } else {
+        _rallyHeaderMarker.setObjectName(QStringLiteral("rallyHeader"));
+        _visualItemsTree.appendItem(&_rallyHeaderMarker, _rallyGroupIndex, QStringLiteral("rallyHeader"));
     }
 }
 

--- a/src/MissionManager/MissionController.h
+++ b/src/MissionManager/MissionController.h
@@ -75,6 +75,11 @@ public:
 
     Q_PROPERTY(QmlObjectListModel*  visualItems                     READ visualItems                    NOTIFY visualItemsChanged)
     Q_PROPERTY(QmlObjectTreeModel*  visualItemsTree                 READ visualItemsTree                CONSTANT)                               ///< Tree-structured view of visualItems for TreeView
+    Q_PROPERTY(QPersistentModelIndex planFileGroupIndex              READ planFileGroupIndex              CONSTANT)
+    Q_PROPERTY(QPersistentModelIndex defaultsGroupIndex              READ defaultsGroupIndex              CONSTANT)
+    Q_PROPERTY(QPersistentModelIndex missionGroupIndex               READ missionGroupIndex               CONSTANT)
+    Q_PROPERTY(QPersistentModelIndex fenceGroupIndex                 READ fenceGroupIndex                 CONSTANT)
+    Q_PROPERTY(QPersistentModelIndex rallyGroupIndex                 READ rallyGroupIndex                 CONSTANT)
     Q_PROPERTY(QmlObjectListModel*  simpleFlightPathSegments        READ simpleFlightPathSegments       CONSTANT)                               ///< Used by Plan view only for interactive editing
     Q_PROPERTY(QmlObjectListModel*  directionArrows                 READ directionArrows                CONSTANT)
     Q_PROPERTY(QStringList          complexMissionItemNames         READ complexMissionItemNames        NOTIFY complexMissionItemNamesChanged)
@@ -271,6 +276,11 @@ public:
 
     QmlObjectListModel* visualItems                 (void) { return _visualItems; }
     QmlObjectTreeModel* visualItemsTree             (void) { return &_visualItemsTree; }
+    QPersistentModelIndex planFileGroupIndex         (void) const { return _planFileGroupIndex; }
+    QPersistentModelIndex defaultsGroupIndex         (void) const { return _defaultsGroupIndex; }
+    QPersistentModelIndex missionGroupIndex          (void) const { return _missionGroupIndex; }
+    QPersistentModelIndex fenceGroupIndex            (void) const { return _fenceGroupIndex; }
+    QPersistentModelIndex rallyGroupIndex            (void) const { return _rallyGroupIndex; }
     QmlObjectListModel* simpleFlightPathSegments    (void) { return &_simpleFlightPathSegments; }
     QmlObjectListModel* directionArrows             (void) { return &_directionArrows; }
     QStringList         complexMissionItemNames     (void) const;
@@ -436,7 +446,6 @@ private:
     MissionManager*             _missionManager =               nullptr;
     int                         _missionItemCount =             0;
     QmlObjectListModel*         _visualItems =                  nullptr;
-    QmlObjectTreeModel          _visualItemsTree;
     QPersistentModelIndex       _planFileGroupIndex;            ///< Persistent index for "Plan File" group in tree
     QPersistentModelIndex       _defaultsGroupIndex;            ///< Persistent index for "Defaults" group in tree
     QPersistentModelIndex       _missionGroupIndex;             ///< Persistent index for "Mission Items" group in tree
@@ -451,6 +460,7 @@ private:
     QObject                     _rallyGroupNode;                ///< Group node for "Rally Points" in tree view
     QObject                     _fenceEditorMarker;             ///< Marker child for GeoFenceEditor delegate
     QObject                     _rallyHeaderMarker;             ///< Marker child for RallyPointEditorHeader delegate
+    QmlObjectTreeModel          _visualItemsTree;               // Must be declared after group nodes so it's destroyed first
     MissionSettingsItem*        _settingsItem =                 nullptr;
     PlanViewSettings*           _planViewSettings =             nullptr;
     QmlObjectListModel          _simpleFlightPathSegments;

--- a/src/QmlControls/MissionItemTreeView.qml
+++ b/src/QmlControls/MissionItemTreeView.qml
@@ -14,6 +14,12 @@ TreeView {
     required property var editorMap
     required property var planMasterController
 
+    signal editingLayerChangeRequested(int layer)
+
+    readonly property int _layerMission: 1
+    readonly property int _layerFence:   2
+    readonly property int _layerRally:   3
+
     property var _missionController: planMasterController.missionController
     property var _geoFenceController: planMasterController.geoFenceController
     property var _rallyPointController: planMasterController.rallyPointController
@@ -26,12 +32,8 @@ TreeView {
     selectionBehavior: TableView.SelectionDisabled
     rowSpacing: 2
 
-    // After collapseRecursively() groups are always at these row indices
-    readonly property int _rowPlanFile: 0
-    readonly property int _rowDefaults: 1
-    readonly property int _rowMission:  2
-    readonly property int _rowFence:    3
-    readonly property int _rowRally:    4
+    // Helper: convert a persistent model index to the current visual row
+    function _rowFor(modelIndex) { return root.rowAtIndex(modelIndex) }
 
     // QGCFlickableScrollIndicator expects parent to have indicatorColor (provided by QGCFlickable/QGCListView)
     property color indicatorColor: qgcPal.text
@@ -41,117 +43,49 @@ TreeView {
     QGCFlickableScrollIndicator { parent: root; orientation: QGCFlickableScrollIndicator.Horizontal }
     QGCFlickableScrollIndicator { parent: root; orientation: QGCFlickableScrollIndicator.Vertical }
 
-    Component.onCompleted: {
-        // Expand only Mission Items by default
-        root.expand(_rowMission)
-    }
-
     Connections {
         target: root._missionController
         function onVisualItemsChanged() {
             // Mission group always expanded after rebuild (clear / load)
             root.collapseRecursively()
-            root.expand(_rowMission)
-            _editingLayer = _layerMission
+            root.expand(_rowFor(_missionController.missionGroupIndex))
+            root.editingLayerChangeRequested(root._layerMission)
         }
     }
 
-    // Public API: select a layer and expand its group (no toggle — always selects).
+    // Public API: select a layer and expand its group. Called by the layer tool buttons.
     function selectLayer(nodeType) {
-        root.collapseRecursively()
-
         let targetRow = -1
         switch (nodeType) {
         case "missionGroup":
-            targetRow = _rowMission
-            _editingLayer = _layerMission
+            targetRow = _rowFor(_missionController.missionGroupIndex)
+            editingLayerChangeRequested(_layerMission)
             break
         case "fenceGroup":
-            targetRow = _rowFence
-            _editingLayer = _layerFence
+            targetRow = _rowFor(_missionController.fenceGroupIndex)
+            editingLayerChangeRequested(_layerFence)
             break
         case "rallyGroup":
-            targetRow = _rowRally
-            _editingLayer = _layerRally
+            targetRow = _rowFor(_missionController.rallyGroupIndex)
+            editingLayerChangeRequested(_layerRally)
             break
         }
 
         if (targetRow >= 0) {
-            root.expand(targetRow)
+            if (!root.isExpanded(targetRow))
+                root.expand(targetRow)
             root.forceLayout()
             root.positionViewAtRow(targetRow, TableView.AlignTop)
         }
     }
 
-    // Switching editing layer on group expand — exclusive: only one group expanded at a time.
-    // Clicking an already-expanded group collapses it (toggle behavior).
-    function _expandExclusive(clickedNodeType) {
-        // Check if the clicked group is already expanded
-        let alreadyActive = false
-        switch (clickedNodeType) {
-        case "planFileGroup":
-            alreadyActive = root.isExpanded(_rowPlanFile)
-            break
-        case "defaultsGroup":
-            alreadyActive = root.isExpanded(_rowDefaults)
-            break
-        case "missionGroup":
-            alreadyActive = _editingLayer === _layerMission
-            break
-        case "fenceGroup":
-            alreadyActive = _editingLayer === _layerFence
-            break
-        case "rallyGroup":
-            alreadyActive = _editingLayer === _layerRally
-            break
-        default:
-            alreadyActive = false
-            break
-        }
-
-        // Collapse everything
-        root.collapseRecursively()
-
-        // If the group was already expanded, just leave everything collapsed
-        if (alreadyActive) {
-            _editingLayer = -1
-            root.forceLayout()
-            root.positionViewAtRow(0, TableView.AlignTop)
-            return
-        }
-
-        // Determine target visual row and editing layer from nodeType
-        let targetRow = -1
-        switch (clickedNodeType) {
-        case "planFileGroup":
-            targetRow = _rowPlanFile
-            _editingLayer = -1
-            break
-        case "defaultsGroup":
-            targetRow = _rowDefaults
-            _editingLayer = -1
-            break
-        case "missionGroup":
-            targetRow = _rowMission
-            _editingLayer = _layerMission
-            break
-        case "fenceGroup":
-            targetRow = _rowFence
-            _editingLayer = _layerFence
-            break
-        case "rallyGroup":
-            targetRow = _rowRally
-            _editingLayer = _layerRally
-            break
-        }
-
-        if (targetRow >= 0) {
-            root.expand(targetRow)
-            // After collapse/expand the view may still be scrolled past the new content.
-            // Force layout then scroll so the expanded group header is at the top.
-            root.forceLayout()
-            root.positionViewAtRow(targetRow, TableView.AlignTop)
-        }
+    // Toggle expand/collapse for a group header. Does not affect the editing layer.
+    function _toggleGroup(row) {
+        if (root.isExpanded(row))
+            root.collapse(row)
+        else
+            root.expand(row)
+        root.forceLayout()
     }
 
     // Coalesces multiple delegate height changes into a single forceLayout() call
@@ -178,7 +112,7 @@ TreeView {
         readonly property string nodeType: model.nodeType
 
         implicitWidth: root.width
-        implicitHeight: loader.item ? loader.item.height : 0
+        implicitHeight: loader.item ? loader.item.height : 1
         width: root.width
         height: implicitHeight
 
@@ -243,7 +177,7 @@ TreeView {
 
                 MouseArea {
                     anchors.fill: parent
-                    onClicked: root._expandExclusive(delegateRoot.nodeType)
+                    onClicked: root._toggleGroup(delegateRoot.row)
                 }
             }
         }

--- a/src/QmlControls/PlanToolBarIndicators.qml
+++ b/src/QmlControls/PlanToolBarIndicators.qml
@@ -10,6 +10,7 @@ import QGroundControl.FactControls
 // Toolbar for Plan View
 RowLayout {
     required property var planMasterController
+    property bool showRallyPointsHelp: false
 
     id: root
     spacing: ScreenTools.defaultFontPixelWidth
@@ -154,6 +155,12 @@ RowLayout {
             var dropPanel = hamburgerDropPanelComponent.createObject(mainWindow, { clickRect: Qt.rect(position.x, position.y, 0, 0) })
             dropPanel.open()
         }
+    }
+
+    QGCLabel {
+        text:    qsTr("Click in map to add rally points")
+        visible: root.showRallyPointsHelp
+        Layout.alignment: Qt.AlignVCenter
     }
 
     Component {

--- a/src/QmlControls/PlanView.qml
+++ b/src/QmlControls/PlanView.qml
@@ -217,6 +217,7 @@ Item {
     PlanViewToolBar {
         id: planToolBar
         planMasterController: _planMasterController
+        showRallyPointsHelp: _editingLayer === _layerRally
     }
 
     Item {
@@ -499,6 +500,7 @@ Item {
             width: _rightPanelWidth
             planMasterController: _planMasterController
             editorMap: editorMap
+            onEditingLayerChangeRequested: (layer) => _editingLayer = layer
         }
 
         // Layer switching icons — only active icon visible; click to expand choices leftward

--- a/src/QmlControls/PlanViewRightPanel.qml
+++ b/src/QmlControls/PlanViewRightPanel.qml
@@ -9,6 +9,8 @@ Item {
     required property var editorMap
     required property var planMasterController
 
+    signal editingLayerChangeRequested(int layer)
+
     id: root
 
     property var  _missionController: planMasterController.missionController
@@ -93,6 +95,7 @@ Item {
             anchors.fill:           parent
             editorMap:              root.editorMap
             planMasterController:   root.planMasterController
+            onEditingLayerChangeRequested: (layer) => root.editingLayerChangeRequested(layer)
         }
     }
 

--- a/src/QmlControls/PlanViewToolBar.qml
+++ b/src/QmlControls/PlanViewToolBar.qml
@@ -13,6 +13,7 @@ Rectangle {
     color: qgcPal.toolbarBackground
 
     property var planMasterController
+    property bool showRallyPointsHelp: false
 
     property var _activeVehicle: QGroundControl.multiVehicleManager.activeVehicle
     property real _controllerProgressPct: planMasterController.missionController.progressPct
@@ -52,6 +53,7 @@ Rectangle {
             anchors.top: parent.top
             anchors.bottom: parent.bottom
             planMasterController: _root.planMasterController
+            showRallyPointsHelp: _root.showRallyPointsHelp
         }
     }
 

--- a/src/QmlControls/QmlObjectTreeModel.cc
+++ b/src/QmlControls/QmlObjectTreeModel.cc
@@ -64,7 +64,8 @@ QmlObjectTreeModel::QmlObjectTreeModel(QObject* parent)
 
 QmlObjectTreeModel::~QmlObjectTreeModel()
 {
-    _disconnectSubtree(&_rootNode);
+    // Skip disconnect — objects may already be destroyed during application shutdown.
+    // Just delete the tree nodes.
     _deleteSubtree(&_rootNode, false);
 }
 

--- a/src/QmlControls/RallyPointEditorHeader.qml
+++ b/src/QmlControls/RallyPointEditorHeader.qml
@@ -41,7 +41,7 @@ Rectangle {
             anchors.right:      parent.right
             wrapMode:           Text.WordWrap
             font.pointSize:     ScreenTools.smallFontPointSize
-            text:               qsTr("Rally Points provide alternate landing points when performing a Return to Launch (RTL).\n\nClick on the map to add Rally Points.")
+            text:               qsTr("Rally Points provide alternate landing points when performing a Return to Launch (RTL).")
         }
     }
 }

--- a/test/MissionManager/MissionControllerTest.cc
+++ b/test/MissionManager/MissionControllerTest.cc
@@ -12,6 +12,13 @@ using namespace TestFixtures;
 
 MissionControllerTest::~MissionControllerTest() = default;
 
+namespace {
+// Coordinate checks involve geodesic reconstruction so they use 0.5 m. Altitude
+// checks are direct arithmetic, so they use a much tighter 1e-4 m tolerance.
+constexpr double kCoordToleranceMeters = 0.5;
+constexpr double kAltToleranceMeters = 1e-4;
+}  // namespace
+
 void MissionControllerTest::cleanup()
 {
     _masterController.reset();
@@ -185,6 +192,161 @@ void MissionControllerTest::_testVehicleYawRecalc()
             expectedVehicleYaw += wpAngleInc;
         }
     }
+}
+
+void MissionControllerTest::_testMissionReposition()
+{
+    _initForFirmwareType(MAV_AUTOPILOT_PX4);
+
+    MissionSettingsItem* settingsItem = _missionController->visualItems()->value<MissionSettingsItem*>(0);
+    QVERIFY(settingsItem);
+
+    const QGeoCoordinate home = Coord::zurich();
+    settingsItem->setInitialHomePositionFromUser(home);
+
+    const QGeoCoordinate wp1 = home.atDistanceAndAzimuth(150.0, 15.0);
+    const QGeoCoordinate wp2 = home.atDistanceAndAzimuth(320.0, 120.0);
+    _missionController->insertSimpleMissionItem(wp1, 1);
+    _missionController->insertSimpleMissionItem(wp2, 2);
+
+    SimpleMissionItem* item1 = _missionController->visualItems()->value<SimpleMissionItem*>(1);
+    SimpleMissionItem* item2 = _missionController->visualItems()->value<SimpleMissionItem*>(2);
+    QVERIFY(item1);
+    QVERIFY(item2);
+
+    const double oldHomeAlt = settingsItem->editableAlt();
+    const double oldAlt1 = item1->editableAlt();
+    const double oldAlt2 = item2->editableAlt();
+
+    const QGeoCoordinate newHome = home.atDistanceAndAzimuth(200.0, 65.0);
+    const QGeoCoordinate expectedWp1 =
+        newHome.atDistanceAndAzimuth(home.distanceTo(wp1), home.azimuthTo(wp1));
+    const QGeoCoordinate expectedWp2 =
+        newHome.atDistanceAndAzimuth(home.distanceTo(wp2), home.azimuthTo(wp2));
+    _missionController->repositionMission(newHome, true, true);
+    QVERIFY_TRUE_WAIT((settingsItem->coordinate().distanceTo(newHome) <= kCoordToleranceMeters) &&
+                          (item1->coordinate().distanceTo(expectedWp1) <= kCoordToleranceMeters) &&
+                          (item2->coordinate().distanceTo(expectedWp2) <= kCoordToleranceMeters),
+                      TestTimeout::shortMs());
+
+    QCOMPARE_COORDS(settingsItem->coordinate(), newHome, kCoordToleranceMeters);
+    QCOMPARE_COORDS(item1->coordinate(), expectedWp1, kCoordToleranceMeters);
+    QCOMPARE_COORDS(item2->coordinate(), expectedWp2, kCoordToleranceMeters);
+    QCOMPARE_FUZZY(settingsItem->editableAlt(), oldHomeAlt, kAltToleranceMeters);
+    QCOMPARE_FUZZY(item1->editableAlt(), oldAlt1, kAltToleranceMeters);
+    QCOMPARE_FUZZY(item2->editableAlt(), oldAlt2, kAltToleranceMeters);
+}
+
+void MissionControllerTest::_testMissionOffset()
+{
+    _initForFirmwareType(MAV_AUTOPILOT_PX4);
+
+    MissionSettingsItem* settingsItem = _missionController->visualItems()->value<MissionSettingsItem*>(0);
+    QVERIFY(settingsItem);
+
+    const QGeoCoordinate home = Coord::zurich();
+    settingsItem->setInitialHomePositionFromUser(home);
+
+    const QGeoCoordinate wp1 = home.atDistanceAndAzimuth(150.0, 15.0);
+    const QGeoCoordinate wp2 = home.atDistanceAndAzimuth(320.0, 120.0);
+    _missionController->insertSimpleMissionItem(wp1, 1);
+    _missionController->insertSimpleMissionItem(wp2, 2);
+
+    SimpleMissionItem* item1 = _missionController->visualItems()->value<SimpleMissionItem*>(1);
+    SimpleMissionItem* item2 = _missionController->visualItems()->value<SimpleMissionItem*>(2);
+    QVERIFY(item1);
+    QVERIFY(item2);
+
+    const double oldHomeAlt = settingsItem->editableAlt();
+    const double oldAlt1 = item1->editableAlt();
+    const double oldAlt2 = item2->editableAlt();
+
+    _missionController->offsetMission(0.0, 0.0, 12.0, true, true);
+    QVERIFY_TRUE_WAIT(qAbs(settingsItem->editableAlt() - oldHomeAlt) <= kAltToleranceMeters &&
+                          qAbs(item1->editableAlt() - (oldAlt1 + 12.0)) <= kAltToleranceMeters &&
+                          qAbs(item2->editableAlt() - (oldAlt2 + 12.0)) <= kAltToleranceMeters,
+                      TestTimeout::shortMs());
+
+    QCOMPARE_FUZZY(settingsItem->editableAlt(), oldHomeAlt, kAltToleranceMeters);
+    QCOMPARE_FUZZY(item1->editableAlt(), oldAlt1 + 12.0, kAltToleranceMeters);
+    QCOMPARE_FUZZY(item2->editableAlt(), oldAlt2 + 12.0, kAltToleranceMeters);
+}
+
+void MissionControllerTest::_testMissionRotate()
+{
+    _initForFirmwareType(MAV_AUTOPILOT_PX4);
+
+    MissionSettingsItem* settingsItem = _missionController->visualItems()->value<MissionSettingsItem*>(0);
+    QVERIFY(settingsItem);
+
+    const QGeoCoordinate home = Coord::zurich();
+    settingsItem->setInitialHomePositionFromUser(home);
+
+    const QGeoCoordinate wp1 = home.atDistanceAndAzimuth(180.0, 20.0);
+    const QGeoCoordinate wp2 = home.atDistanceAndAzimuth(260.0, 135.0);
+    _missionController->insertSimpleMissionItem(wp1, 1);
+    _missionController->insertSimpleMissionItem(wp2, 2);
+
+    SimpleMissionItem* item1 = _missionController->visualItems()->value<SimpleMissionItem*>(1);
+    SimpleMissionItem* item2 = _missionController->visualItems()->value<SimpleMissionItem*>(2);
+    QVERIFY(item1);
+    QVERIFY(item2);
+
+    const double oldHomeAlt = settingsItem->editableAlt();
+    const double oldAlt1 = item1->editableAlt();
+    const double oldAlt2 = item2->editableAlt();
+
+    const QGeoCoordinate expectedWp1 =
+        home.atDistanceAndAzimuth(home.distanceTo(wp1), home.azimuthTo(wp1) + 90.0);
+    const QGeoCoordinate expectedWp2 =
+        home.atDistanceAndAzimuth(home.distanceTo(wp2), home.azimuthTo(wp2) + 90.0);
+
+    _missionController->rotateMission(90.0, true, true);
+    QVERIFY_TRUE_WAIT((settingsItem->coordinate().distanceTo(home) <= kCoordToleranceMeters) &&
+                          (item1->coordinate().distanceTo(expectedWp1) <= kCoordToleranceMeters) &&
+                          (item2->coordinate().distanceTo(expectedWp2) <= kCoordToleranceMeters),
+                      TestTimeout::shortMs());
+
+    QCOMPARE_COORDS(settingsItem->coordinate(), home, kCoordToleranceMeters);
+    QCOMPARE_COORDS(item1->coordinate(), expectedWp1, kCoordToleranceMeters);
+    QCOMPARE_COORDS(item2->coordinate(), expectedWp2, kCoordToleranceMeters);
+    QCOMPARE_FUZZY(settingsItem->editableAlt(), oldHomeAlt, kAltToleranceMeters);
+    QCOMPARE_FUZZY(item1->editableAlt(), oldAlt1, kAltToleranceMeters);
+    QCOMPARE_FUZZY(item2->editableAlt(), oldAlt2, kAltToleranceMeters);
+}
+
+void MissionControllerTest::_testMissionTransformsInvalidHome()
+{
+    _initForFirmwareType(MAV_AUTOPILOT_PX4);
+
+    MissionSettingsItem* settingsItem =
+        _missionController->visualItems()->value<MissionSettingsItem*>(0);
+    QVERIFY(settingsItem);
+
+    const QGeoCoordinate home = Coord::zurich();
+    settingsItem->setInitialHomePositionFromUser(home);
+
+    const QGeoCoordinate wp1 = home.atDistanceAndAzimuth(180.0, 45.0);
+    _missionController->insertSimpleMissionItem(wp1, 1);
+
+    SimpleMissionItem* item1 = _missionController->visualItems()->value<SimpleMissionItem*>(1);
+    QVERIFY(item1);
+
+    const QGeoCoordinate oldItemCoord = item1->coordinate();
+    const double oldItemAlt = item1->editableAlt();
+
+    settingsItem->setCoordinate(QGeoCoordinate());
+    QVERIFY_TRUE_WAIT(!settingsItem->coordinate().isValid(), TestTimeout::shortMs());
+
+    _missionController->repositionMission(home.atDistanceAndAzimuth(100.0, 0.0), true, true);
+    _missionController->offsetMission(10.0, 5.0, 8.0, true, true);
+    _missionController->rotateMission(45.0, true, true);
+    QVERIFY_TRUE_WAIT((item1->coordinate().distanceTo(oldItemCoord) <= kCoordToleranceMeters) &&
+                          (qAbs(item1->editableAlt() - oldItemAlt) <= kAltToleranceMeters),
+                      TestTimeout::shortMs());
+
+    QCOMPARE_COORDS(item1->coordinate(), oldItemCoord, kCoordToleranceMeters);
+    QCOMPARE_FUZZY(item1->editableAlt(), oldItemAlt, kAltToleranceMeters);
 }
 
 void MissionControllerTest::_testLoadJsonSectionAvailable()

--- a/test/MissionManager/MissionControllerTest.h
+++ b/test/MissionManager/MissionControllerTest.h
@@ -23,6 +23,10 @@ private slots:
     void _testGlobalAltMode();
     void _testGimbalRecalc();
     void _testVehicleYawRecalc();
+    void _testMissionReposition();
+    void _testMissionOffset();
+    void _testMissionRotate();
+    void _testMissionTransformsInvalidHome();
 
     // Parameterized tests - runs once per autopilot type
     UT_PARAMETERIZED_TEST(_testEmptyVehicle);

--- a/test/MissionManager/MissionControllerTreeTest.cc
+++ b/test/MissionManager/MissionControllerTreeTest.cc
@@ -5,6 +5,7 @@
 #include "MissionSettingsItem.h"
 #include "PlanMasterController.h"
 #include "QmlObjectTreeModel.h"
+#include "RallyPointController.h"
 #include "SettingsManager.h"
 #include "SimpleMissionItem.h"
 #include "TestFixtures.h"
@@ -273,6 +274,99 @@ void MissionControllerTreeTest::_testRecalcChildItemsNoCrash()
     // Verify no crash and tree is still functional
     QVERIFY(tree->index(0, 0, missionGroup).isValid());
     QCOMPARE(tree->rowCount(), kGroupCount);
+}
+
+// ===========================================================================
+// Exposed Q_PROPERTY persistent index getters match tree model indices
+// ===========================================================================
+
+void MissionControllerTreeTest::_testExposedPersistentIndexGettersMatchTree()
+{
+    _initForTest();
+
+    QmlObjectTreeModel* tree = _missionController->visualItemsTree();
+
+    QCOMPARE(QModelIndex(_missionController->planFileGroupIndex()), tree->index(kPlanFileGroupRow, 0));
+    QCOMPARE(QModelIndex(_missionController->defaultsGroupIndex()), tree->index(kDefaultsGroupRow, 0));
+    QCOMPARE(QModelIndex(_missionController->missionGroupIndex()),  tree->index(kMissionGroupRow, 0));
+    QCOMPARE(QModelIndex(_missionController->fenceGroupIndex()),    tree->index(kFenceGroupRow, 0));
+    QCOMPARE(QModelIndex(_missionController->rallyGroupIndex()),    tree->index(kRallyGroupRow, 0));
+}
+
+// ===========================================================================
+// Exposed persistent indexes survive removeAll rebuild
+// ===========================================================================
+
+void MissionControllerTreeTest::_testExposedIndexesSurviveRemoveAll()
+{
+    _initForTest();
+
+    // Insert some waypoints then removeAll to trigger tree rebuild
+    const QList<QGeoCoordinate> waypoints = Coord::waypointPath(Coord::zurich(), 3);
+    for (int i = 0; i < waypoints.count(); ++i) {
+        _missionController->insertSimpleMissionItem(waypoints[i], i + 1);
+    }
+
+    _missionController->removeAll();
+
+    // The CONSTANT Q_PROPERTY persistent indexes must still be valid
+    QVERIFY(_missionController->planFileGroupIndex().isValid());
+    QVERIFY(_missionController->defaultsGroupIndex().isValid());
+    QVERIFY(_missionController->missionGroupIndex().isValid());
+    QVERIFY(_missionController->fenceGroupIndex().isValid());
+    QVERIFY(_missionController->rallyGroupIndex().isValid());
+
+    // They should still point to the correct rows
+    QCOMPARE(_missionController->planFileGroupIndex().row(), kPlanFileGroupRow);
+    QCOMPARE(_missionController->defaultsGroupIndex().row(), kDefaultsGroupRow);
+    QCOMPARE(_missionController->missionGroupIndex().row(),  kMissionGroupRow);
+    QCOMPARE(_missionController->fenceGroupIndex().row(),    kFenceGroupRow);
+    QCOMPARE(_missionController->rallyGroupIndex().row(),    kRallyGroupRow);
+}
+
+// ===========================================================================
+// Rally header appears when no points, disappears when points added, reappears when removed
+// ===========================================================================
+
+void MissionControllerTreeTest::_testRallyHeaderDynamicVisibility()
+{
+    _initForTest();
+
+    QmlObjectTreeModel* tree = _missionController->visualItemsTree();
+    const QPersistentModelIndex rallyGroup(_missionController->rallyGroupIndex());
+    auto* rallyController = _masterController->rallyPointController();
+    QVERIFY(rallyController);
+
+    // Initially: rally group has 1 child — the header marker
+    QCOMPARE(tree->rowCount(rallyGroup), 1);
+    QCOMPARE(tree->data(tree->index(0, 0, rallyGroup), QmlObjectTreeModel::NodeTypeRole).toString(),
+             QStringLiteral("rallyHeader"));
+
+    // Add a rally point → header removed, replaced by rallyItem
+    rallyController->addPoint(QGeoCoordinate(47.3977, 8.5456));
+    QCOMPARE(tree->rowCount(rallyGroup), 1);
+    QCOMPARE(tree->data(tree->index(0, 0, rallyGroup), QmlObjectTreeModel::NodeTypeRole).toString(),
+             QStringLiteral("rallyItem"));
+
+    // Add a second rally point
+    rallyController->addPoint(QGeoCoordinate(47.3980, 8.5460));
+    QCOMPARE(tree->rowCount(rallyGroup), 2);
+    QCOMPARE(tree->data(tree->index(0, 0, rallyGroup), QmlObjectTreeModel::NodeTypeRole).toString(),
+             QStringLiteral("rallyItem"));
+    QCOMPARE(tree->data(tree->index(1, 0, rallyGroup), QmlObjectTreeModel::NodeTypeRole).toString(),
+             QStringLiteral("rallyItem"));
+
+    // Remove the first rally point — still 1 rallyItem, no header
+    rallyController->removePoint(rallyController->points()->get(0));
+    QCOMPARE(tree->rowCount(rallyGroup), 1);
+    QCOMPARE(tree->data(tree->index(0, 0, rallyGroup), QmlObjectTreeModel::NodeTypeRole).toString(),
+             QStringLiteral("rallyItem"));
+
+    // Remove the last rally point → header marker reappears
+    rallyController->removePoint(rallyController->points()->get(0));
+    QCOMPARE(tree->rowCount(rallyGroup), 1);
+    QCOMPARE(tree->data(tree->index(0, 0, rallyGroup), QmlObjectTreeModel::NodeTypeRole).toString(),
+             QStringLiteral("rallyHeader"));
 }
 
 #include "UnitTest.h"

--- a/test/MissionManager/MissionControllerTreeTest.h
+++ b/test/MissionManager/MissionControllerTreeTest.h
@@ -37,6 +37,15 @@ private slots:
     // recalcChildItems is a no-op for tree (no crash)
     void _testRecalcChildItemsNoCrash();
 
+    // Exposed Q_PROPERTY persistent index getters match tree model indices
+    void _testExposedPersistentIndexGettersMatchTree();
+
+    // Exposed persistent indexes survive removeAll rebuild
+    void _testExposedIndexesSurviveRemoveAll();
+
+    // Rally header appears/disappears as rally points are added/removed
+    void _testRallyHeaderDynamicVisibility();
+
 private:
     void _initForTest();
 

--- a/test/QmlControls/QmlObjectTreeModelTest.cc
+++ b/test/QmlControls/QmlObjectTreeModelTest.cc
@@ -680,6 +680,38 @@ void QmlObjectTreeModelTest::_insertNullObject()
     QVERIFY(!model.data(idx, Qt::UserRole).isValid()); // null object → invalid variant
 }
 
+// ---------------------------------------------------------------------------
+// Destructor safety: external objects outlive the model
+// ---------------------------------------------------------------------------
+
+void QmlObjectTreeModelTest::_destructorSafeWithExternalObjects()
+{
+    QObject externalObj;
+    {
+        QmlObjectTreeModel model;
+        model.appendItem(&externalObj, QModelIndex(), QStringLiteral("test"));
+        // model destroyed here — must not crash or double-free externalObj
+    }
+    // externalObj still alive — reaching here means no crash
+    QVERIFY(true);
+}
+
+// ---------------------------------------------------------------------------
+// Destructor safety: objects destroyed before the model (shutdown scenario)
+// ---------------------------------------------------------------------------
+
+void QmlObjectTreeModelTest::_destructorSafeWithDestroyedObjects()
+{
+    QmlObjectTreeModel model;
+    {
+        QObject tempObj;
+        model.appendItem(&tempObj, QModelIndex(), QStringLiteral("test"));
+        // tempObj destroyed here while model still holds a pointer to it
+    }
+    // model destroyed after tempObj — must not crash during ~QmlObjectTreeModel
+    QVERIFY(true);
+}
+
 UT_REGISTER_TEST(QmlObjectTreeModelTest, TestLabel::Unit)
 
 #include "QmlObjectTreeModelTest.moc"

--- a/test/QmlControls/QmlObjectTreeModelTest.h
+++ b/test/QmlControls/QmlObjectTreeModelTest.h
@@ -81,4 +81,10 @@ private slots:
 
     // Null object edge case
     void _insertNullObject();
+
+    // Destructor safe when external objects outlive the model
+    void _destructorSafeWithExternalObjects();
+
+    // Destructor safe when objects destroyed before the model
+    void _destructorSafeWithDestroyedObjects();
 };


### PR DESCRIPTION
## Summary

Refactor the PlanView TreeView to use `QPersistentModelIndex` instead of hardcoded row indices, make group expand/collapse independent, and replace dynamic-scoped property writes with an explicit signal chain.

## Changes

### Core refactor
- **QPersistentModelIndex properties** — Expose stable model indices from `MissionController` (`planFileGroupIndex`, `defaultsGroupIndex`, `missionItemsGroupIndex`, `fenceGroupIndex`, `rallyGroupIndex`) so QML can call `rowAtIndex()` dynamically instead of relying on fragile hardcoded row numbers.
- **Independent expand/collapse** — Groups expand/collapse independently instead of being mutually exclusive.
- **Signal-based layer switching** — Replace dynamic-scoped `_editingLayer` writes with an explicit `editingLayerChangeRequested(int layer)` signal chain: `MissionItemTreeView` → `PlanViewRightPanel` → `PlanView`.

### UI improvements
- **Rally point help text** in `PlanToolBarIndicators`, controlled by `showRallyPointsHelp` bool property that activates when the rally layer is selected.
- **Conditional rally header** — The rally child item in the TreeView only appears when no rally points exist.
- **Redesigned SVGs** — `RallyPoint.svg` (triangular banner) and `GeoFence.svg` (scale/translate adjustments).
- Remove redundant "Click on the map" text from `RallyPointEditorHeader`.

### Bug fixes
- **Shutdown crash fix** — Reorder member declarations so `_visualItemsTree` is destroyed before its child QObjects. Also skip `_disconnectSubtree` in `QmlObjectTreeModel` destructor since objects from other controllers may already be destroyed during shutdown.
- **TreeView warning** — Use `implicitHeight` fallback of `1` instead of `0` to suppress "delegate's implicitHeight needs to be greater than zero" warning.

### Tests
- `MissionControllerTreeTest`: Verify exposed persistent index getters match the tree structure, and survive `removeAll()`.
- `QmlObjectTreeModelTest`: Verify destructor safety with external objects and with already-destroyed objects.
