### PR TITLE
fix(linux): Preload system GIO alongside GLib to prevent GstGIO segfault

### DIFF
--- a/deploy/linux/AppRun
+++ b/deploy/linux/AppRun
@@ -25,9 +25,14 @@ for LIB_PATH in \
 done
 
 # Preload system GLib 2.76+ for TTS compatibility (libspeechd.so.2 dependency)
+# Must also preload system GIO to avoid ABI mismatch with bundled GStreamer GIO plugin
 if [ -n "$SYSTEM_GLIB" ]; then
     if nm -D "$SYSTEM_GLIB" 2>/dev/null | grep -qm1 g_string_free_and_steal; then
-        export LD_PRELOAD="${SYSTEM_GLIB}${LD_PRELOAD:+:$LD_PRELOAD}"
+        GLIB_PRELOAD="${SYSTEM_GLIB}"
+        if [ -f "$SYSTEM_GIO" ]; then
+            GLIB_PRELOAD="${GLIB_PRELOAD}:${SYSTEM_GIO}"
+        fi
+        export LD_PRELOAD="${GLIB_PRELOAD}${LD_PRELOAD:+:$LD_PRELOAD}"
     fi
 fi
 


### PR DESCRIPTION
## Summary
- When system GLib is preloaded via `LD_PRELOAD` for TTS compatibility (`libspeechd.so.2`), the bundled GStreamer `libgstgio.so` plugin segfaults on Debian 13 (GLib 2.84) due to ABI mismatch between system GLib and bundled GIO
- Fix: also preload system GIO so both libraries come from the same system build, maintaining ABI compatibility
- The `SYSTEM_GIO` variable was already being detected but not included in the preload

Closes #14063

## Test plan
- [ ] Run AppImage on Debian 13 ARM64 (Raspberry Pi 5) — should no longer segfault on `libgstgio.so`
- [ ] Run AppImage on Ubuntu 24.04 — verify no regression, TTS still works
- [ ] Run AppImage on older distro with GLib < 2.76 — verify preload is skipped entirely