### PR TITLE
refactor(gstreamer): Extract logging into GStreamerLogging

### DIFF
--- a/src/VideoManager/VideoReceiver/GStreamer/CMakeLists.txt
+++ b/src/VideoManager/VideoReceiver/GStreamer/CMakeLists.txt
@@ -33,6 +33,8 @@ if(TARGET gstqml6gl)
             GStreamer.h
             GStreamerHelpers.cc
             GStreamerHelpers.h
+            GStreamerLogging.cc
+            GStreamerLogging.h
             GstVideoReceiver.cc
             GstVideoReceiver.h
     )

--- a/src/VideoManager/VideoReceiver/GStreamer/GStreamer.cc
+++ b/src/VideoManager/VideoReceiver/GStreamer/GStreamer.cc
@@ -1,8 +1,8 @@
 #include "GStreamer.h"
 #include "GStreamerHelpers.h"
+#include "GStreamerLogging.h"
 #include "AppSettings.h"
 #include "GstVideoReceiver.h"
-#include "QGCLoggingCategory.h"
 #include "SettingsManager.h"
 #include "VideoSettings.h"
 
@@ -12,10 +12,6 @@
 #include <QtQuick/QQuickItem>
 
 #include <gst/gst.h>
-
-QGC_LOGGING_CATEGORY(GStreamerLog, "Video.GStreamer")
-QGC_LOGGING_CATEGORY(GStreamerDecoderRanksLog, "Video.GStreamerDecoderRanks")
-QGC_LOGGING_CATEGORY_ON(GStreamerAPILog, "Video.GStreamerAPI")
 
 // TODO: Clean These up with Macros or CMake
 G_BEGIN_DECLS
@@ -119,51 +115,6 @@ void _registerPlugins()
 // #endif
 
     GST_PLUGIN_STATIC_REGISTER(qgc);
-}
-
-void _qtGstLog(GstDebugCategory *category,
-               GstDebugLevel level,
-               const gchar *file,
-               const gchar *function,
-               gint line,
-               GObject *object,
-               GstDebugMessage *message,
-               gpointer data)
-{
-    Q_UNUSED(data);
-
-    if (level > gst_debug_category_get_threshold(category)) {
-        return;
-    }
-
-    QMessageLogger log(file, line, function);
-
-    char *object_info = gst_info_strdup_printf("%" GST_PTR_FORMAT, static_cast<void*>(object));
-
-    switch (level) {
-    case GST_LEVEL_ERROR:
-        log.critical(GStreamerAPILog, "%s %s", object_info, gst_debug_message_get(message));
-        break;
-    case GST_LEVEL_WARNING:
-        log.warning(GStreamerAPILog, "%s %s", object_info, gst_debug_message_get(message));
-        break;
-    case GST_LEVEL_FIXME:
-    case GST_LEVEL_INFO:
-        log.info(GStreamerAPILog, "%s %s", object_info, gst_debug_message_get(message));
-        break;
-    case GST_LEVEL_DEBUG:
-#ifdef QT_DEBUG
-    case GST_LEVEL_LOG:
-    case GST_LEVEL_TRACE:
-    case GST_LEVEL_MEMDUMP:
-#endif
-        log.debug(GStreamerAPILog, "%s %s", object_info, gst_debug_message_get(message));
-        break;
-    default:
-        break;
-    }
-
-    g_clear_pointer(&object_info, g_free);
 }
 
 void _setGstEnvVars()
@@ -501,7 +452,7 @@ bool initialize()
     }
 
     gst_debug_remove_log_function(gst_debug_log_default);
-    gst_debug_add_log_function(_qtGstLog, nullptr, nullptr);
+    gst_debug_add_log_function(GStreamer::qtGstLog, nullptr, nullptr);
 
     const QStringList args = QCoreApplication::arguments();
     int gstArgc = args.size();
@@ -525,6 +476,8 @@ bool initialize()
         g_clear_error(&error);
         return false;
     }
+
+    GStreamer::redirectGLibLogging();
 
     const gchar *version = gst_version_string();
     qCDebug(GStreamerLog) << QString("GStreamer Initialized (Version: %1)").arg(version);

--- a/src/VideoManager/VideoReceiver/GStreamer/GStreamer.h
+++ b/src/VideoManager/VideoReceiver/GStreamer/GStreamer.h
@@ -4,6 +4,7 @@
 
 Q_DECLARE_LOGGING_CATEGORY(GStreamerLog)
 Q_DECLARE_LOGGING_CATEGORY(GStreamerAPILog)
+Q_DECLARE_LOGGING_CATEGORY(GStreamerDecoderRanksLog)
 
 class QQuickItem;
 class VideoReceiver;

--- a/src/VideoManager/VideoReceiver/GStreamer/GStreamerLogging.cc
+++ b/src/VideoManager/VideoReceiver/GStreamer/GStreamerLogging.cc
@@ -1,0 +1,127 @@
+#include "GStreamer.h"
+#include "GStreamerLogging.h"
+#include "QGCLoggingCategory.h"
+
+#include <QtCore/QString>
+
+#include <atomic>
+#include <memory>
+
+QGC_LOGGING_CATEGORY(GStreamerLog, "Video.GStreamer")
+QGC_LOGGING_CATEGORY(GStreamerDecoderRanksLog, "Video.GStreamerDecoderRanks")
+QGC_LOGGING_CATEGORY_ON(GStreamerAPILog, "Video.GStreamerAPI")
+
+namespace {
+
+std::atomic_bool g_externalPluginLoaderFailed {false};
+
+void glib_print_handler(const gchar *string)
+{
+    qCInfo(GStreamerLog) << string;
+}
+
+void glib_printerr_handler(const gchar *string)
+{
+    qCWarning(GStreamerLog) << string;
+}
+
+void glib_log_handler(const gchar *log_domain, GLogLevelFlags log_level,
+                      const gchar *message, gpointer user_data)
+{
+    Q_UNUSED(user_data);
+    const QString domain = log_domain ? QString::fromUtf8(log_domain) : QStringLiteral("GLib");
+    const QString msg = QString::fromUtf8(message);
+
+    if (msg.contains(QStringLiteral("External plugin loader failed"), Qt::CaseInsensitive)) {
+        g_externalPluginLoaderFailed.store(true);
+    }
+
+    switch (log_level & G_LOG_LEVEL_MASK) {
+    case G_LOG_LEVEL_ERROR:
+    case G_LOG_LEVEL_CRITICAL:
+        qCCritical(GStreamerLog) << domain << msg;
+        break;
+    case G_LOG_LEVEL_WARNING:
+        qCWarning(GStreamerLog) << domain << msg;
+        break;
+    case G_LOG_LEVEL_MESSAGE:
+    case G_LOG_LEVEL_INFO:
+        qCInfo(GStreamerLog) << domain << msg;
+        break;
+    case G_LOG_LEVEL_DEBUG:
+    default:
+        qCDebug(GStreamerLog) << domain << msg;
+        break;
+    }
+}
+
+} // anonymous namespace
+
+namespace GStreamer
+{
+
+void resetExternalPluginLoaderFailure()
+{
+    g_externalPluginLoaderFailed.store(false);
+}
+
+bool didExternalPluginLoaderFail()
+{
+    return g_externalPluginLoaderFailed.load();
+}
+
+void redirectGLibLogging()
+{
+    g_set_print_handler(glib_print_handler);
+    g_set_printerr_handler(glib_printerr_handler);
+    g_log_set_default_handler(glib_log_handler, nullptr);
+}
+
+void qtGstLog(GstDebugCategory *category,
+              GstDebugLevel level,
+              const gchar *file,
+              const gchar *function,
+              gint line,
+              GObject *object,
+              GstDebugMessage *message,
+              gpointer data)
+{
+    Q_UNUSED(data);
+
+    if (level > gst_debug_category_get_threshold(category)) {
+        return;
+    }
+
+    QMessageLogger log(file, line, function);
+
+    struct GFree { void operator()(gchar *p) const { g_free(p); } };
+    const std::unique_ptr<gchar, GFree> object_info(
+        gst_info_strdup_printf("%" GST_PTR_FORMAT, object));
+
+    switch (level) {
+    case GST_LEVEL_ERROR:
+        log.critical(GStreamerAPILog, "%s %s", object_info.get(), gst_debug_message_get(message));
+        break;
+    case GST_LEVEL_WARNING:
+        log.warning(GStreamerAPILog, "%s %s", object_info.get(), gst_debug_message_get(message));
+        break;
+    case GST_LEVEL_FIXME:
+    case GST_LEVEL_INFO:
+        log.info(GStreamerAPILog, "%s %s", object_info.get(), gst_debug_message_get(message));
+        break;
+    case GST_LEVEL_DEBUG:
+#ifdef QT_DEBUG
+    // In release builds LOG/TRACE/MEMDUMP are intentionally dropped to reduce
+    // noise. Only debug builds route these verbose levels through Qt logging.
+    case GST_LEVEL_LOG:
+    case GST_LEVEL_TRACE:
+    case GST_LEVEL_MEMDUMP:
+#endif
+        log.debug(GStreamerAPILog, "%s %s", object_info.get(), gst_debug_message_get(message));
+        break;
+    default:
+        break;
+    }
+}
+
+} // namespace GStreamer

--- a/src/VideoManager/VideoReceiver/GStreamer/GStreamerLogging.h
+++ b/src/VideoManager/VideoReceiver/GStreamer/GStreamerLogging.h
@@ -1,0 +1,24 @@
+#pragma once
+
+#include <QtCore/QLoggingCategory>
+
+#include <gst/gst.h>
+
+// Logging categories are declared in GStreamer.h (the lightweight public header).
+// This header is for internal GStreamer code that needs the full gst/gst.h types.
+
+namespace GStreamer
+{
+    void redirectGLibLogging();
+    void resetExternalPluginLoaderFailure();
+    bool didExternalPluginLoaderFail();
+
+    void qtGstLog(GstDebugCategory *category,
+                  GstDebugLevel level,
+                  const gchar *file,
+                  const gchar *function,
+                  gint line,
+                  GObject *object,
+                  GstDebugMessage *message,
+                  gpointer data);
+}


### PR DESCRIPTION
## Summary

- Extracts GLib log handlers, GStreamer debug log function (`qtGstLog`), and `QGC_LOGGING_CATEGORY` definitions from `GStreamer.cc` into dedicated `GStreamerLogging.cc/h` files
- Adds `GStreamer::redirectGLibLogging()` call after `gst_init_check` to route GLib/GStreamer log output through Qt logging categories
- Adds `Q_DECLARE_LOGGING_CATEGORY(GStreamerDecoderRanksLog)` to the public `GStreamer.h` header (no `gst/gst.h` dependency)
- Detects "External plugin loader failed" messages from GLib and exposes the state via `didExternalPluginLoaderFail()`

## Motivation

`GStreamer.cc` mixes initialization, plugin management, codec ranking, and logging concerns. Extracting logging into its own translation unit improves readability and makes it easier to reuse log routing (e.g., from helper modules) without pulling in the full initialization header.

## Test plan

- [ ] Build on Linux, macOS, Windows, Android, iOS
- [ ] Verify GStreamer log output appears in Qt logging categories (`Video.GStreamer`, `Video.GStreamerAPI`)
- [ ] Verify GLib warnings/errors are routed through `GStreamerLog`