### PR TITLE
Fix: GoTo map indicator not deleted on command failure

### DIFF
--- a/src/FirmwarePlugin/APM/APMFirmwarePlugin.cc
+++ b/src/FirmwarePlugin/APM/APMFirmwarePlugin.cc
@@ -779,9 +779,8 @@ static void _MAV_CMD_DO_REPOSITION_ResultHandler(void *resultHandlerData, int /*
     auto *vehicle = data->vehicle;
     auto *instanceData = qobject_cast<APMFirmwarePluginInstanceData*>(vehicle->firmwarePluginInstanceData());
 
-    if (instanceData->MAV_CMD_DO_REPOSITION_supported ||
-        instanceData->MAV_CMD_DO_REPOSITION_unsupported) {
-        // we never change out minds once set
+    if (instanceData->MAV_CMD_DO_REPOSITION_supported || instanceData->MAV_CMD_DO_REPOSITION_unsupported) {
+        emit vehicle->goToWaypointAccepted(ack.result == MAV_RESULT_ACCEPTED);
         goto out;
     }
 
@@ -796,6 +795,7 @@ void APMFirmwarePlugin::guidedModeGotoLocation(Vehicle *vehicle, const QGeoCoord
 {
     if (qIsNaN(vehicle->altitudeRelative()->rawValue().toDouble())) {
         qgcApp()->showAppMessage(QStringLiteral("Unable to go to location, vehicle position not known."));
+        emit vehicle->goToWaypointAccepted(false);
         return;
     }
 
@@ -854,6 +854,7 @@ void APMFirmwarePlugin::guidedModeGotoLocation(Vehicle *vehicle, const QGeoCoord
     QGeoCoordinate coordWithAltitude = gotoCoord;
     coordWithAltitude.setAltitude(vehicle->altitudeRelative()->rawValue().toDouble());
     vehicle->missionManager()->writeArduPilotGuidedMissionItem(coordWithAltitude, false /* altChangeOnly */);
+    emit vehicle->goToWaypointAccepted(true);
 }
 
 void APMFirmwarePlugin::guidedModeRTL(Vehicle *vehicle, bool smartRTL) const

--- a/src/FirmwarePlugin/FirmwarePlugin.cc
+++ b/src/FirmwarePlugin/FirmwarePlugin.cc
@@ -143,10 +143,10 @@ void FirmwarePlugin::guidedModeTakeoff(Vehicle *vehicle, double takeoffAltRel) c
 
 void FirmwarePlugin::guidedModeGotoLocation(Vehicle *vehicle, const QGeoCoordinate &gotoCoord, double forwardFlightLoiterRadius) const
 {
-    Q_UNUSED(vehicle);
     Q_UNUSED(gotoCoord);
     Q_UNUSED(forwardFlightLoiterRadius);
     qgcApp()->showAppMessage(guided_mode_not_supported_by_vehicle);
+    emit vehicle->goToWaypointAccepted(false);
 }
 
 void FirmwarePlugin::guidedModeChangeAltitude(Vehicle*, double, bool pauseVehicle)

--- a/src/FirmwarePlugin/PX4/PX4FirmwarePlugin.cc
+++ b/src/FirmwarePlugin/PX4/PX4FirmwarePlugin.cc
@@ -395,6 +395,7 @@ void PX4FirmwarePlugin::guidedModeGotoLocation(Vehicle* vehicle, const QGeoCoord
 
     if (qIsNaN(vehicle->altitudeAMSL()->rawValue().toDouble())) {
         qgcApp()->showAppMessage(tr("Unable to go to location, vehicle position not known."));
+        emit vehicle->goToWaypointAccepted(false);
         return;
     }
 
@@ -422,6 +423,7 @@ void PX4FirmwarePlugin::guidedModeGotoLocation(Vehicle* vehicle, const QGeoCoord
                                 static_cast<float>(gotoCoord.longitude()),
                                 vehicle->altitudeAMSL()->rawValue().toFloat());
     }
+    emit vehicle->goToWaypointAccepted(true);
 }
 
 typedef struct {

--- a/src/FlyView/FlyViewMap.qml
+++ b/src/FlyView/FlyViewMap.qml
@@ -443,6 +443,19 @@ FlightMap {
 
         property bool inGotoFlightMode: _activeVehicle ? _activeVehicle.flightMode === _activeVehicle.gotoFlightMode : false
 
+        Connections {
+            target: _activeVehicle
+
+            function onGoToWaypointAccepted(accepted) {
+                if (accepted) {
+                    gotoLocationItem._commitCoordinate()
+                    fwdFlightGotoMapCircle.actionConfirmed()
+                } else {
+                    gotoLocationItem.actionCancelled()
+                }
+            }
+        }
+
         property var _committedCoordinate: null
 
         onInGotoFlightModeChanged: {
@@ -462,12 +475,8 @@ FlightMap {
         }
 
         function actionConfirmed() {
-            _commitCoordinate()
-
-            // Commit the new radius which possibly changed
-            fwdFlightGotoMapCircle.actionConfirmed()
-
-            // We leave the indicator visible. The handling for onInGuidedModeChanged will hide it.
+            // Intentionally empty. Required by GuidedActionConfirm which calls actionConfirmed() on the map indicator.
+            // The actual commit logic is handled in onGoToWaypointAccepted when the vehicle accepts the command.
         }
 
         function actionCancelled() {
@@ -681,8 +690,7 @@ FlightMap {
                             gotoLocationItem.show(mapClickCoord)
 
                             if ((_activeVehicle.flightMode == _activeVehicle.gotoFlightMode) && !_flyViewSettings.goToLocationRequiresConfirmInGuided.value) {
-                                globals.guidedControllerFlyView.executeAction(globals.guidedControllerFlyView.actionGoto, mapClickCoord, gotoLocationItem)
-                                gotoLocationItem.actionConfirmed() // Still need to call this to commit the new coordinate and radius
+                                globals.guidedControllerFlyView.executeAction(globals.guidedControllerFlyView.actionGoto, mapClickCoord, null)
                             } else {
                                 globals.guidedControllerFlyView.confirmAction(globals.guidedControllerFlyView.actionGoto, mapClickCoord, gotoLocationItem)
                             }

--- a/src/Vehicle/Vehicle.cc
+++ b/src/Vehicle/Vehicle.cc
@@ -2034,14 +2034,17 @@ void Vehicle::guidedModeGotoLocation(const QGeoCoordinate& gotoCoord, double for
 {
     if (!_vehicleSupports->guidedMode()) {
         qgcApp()->showAppMessage(guided_mode_not_supported_by_vehicle);
+        emit goToWaypointAccepted(false);
         return;
     }
     if (!coordinate().isValid()) {
+        emit goToWaypointAccepted(false);
         return;
     }
     double maxDistance = SettingsManager::instance()->flyViewSettings()->maxGoToLocationDistance()->rawValue().toDouble();
     if (coordinate().distanceTo(gotoCoord) > maxDistance) {
         qgcApp()->showAppMessage(QString("New location is too far. Must be less than %1 %2.").arg(qRound(FactMetaData::metersToAppSettingsHorizontalDistanceUnits(maxDistance).toDouble())).arg(FactMetaData::appSettingsHorizontalDistanceUnitsString()));
+        emit goToWaypointAccepted(false);
         return;
     }
     _firmwarePlugin->guidedModeGotoLocation(this, gotoCoord, forwardFlightLoiterRadius);

--- a/src/Vehicle/Vehicle.h
+++ b/src/Vehicle/Vehicle.h
@@ -829,7 +829,7 @@ signals:
     void haveMRSpeedLimChanged          ();
     void haveFWSpeedLimChanged          ();
     void hasGripperChanged              ();
-
+    void goToWaypointAccepted           (bool accepted);
     void firmwareVersionChanged         ();
     void firmwareCustomVersionChanged   ();
     void gitHashChanged                 (QString hash);


### PR DESCRIPTION
When the GoTo action failed (e.g. destination too far, unsupported command, coordinate not valid), the map indicator remained at the confirmed position instead of being deleted.

## Description
Offers a fix for #12834 second task:

>
-  When the Go To action fails after confirmation (for example, when the destination is too far) the map item doesn't reflect this (it remains at the confirmed position).
>

## Type of Change
<!-- Put an 'x' in the relevant boxes -->
- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] CI/Build changes
- [ ] Other

## Testing
<!-- Describe the tests you ran and how to reproduce them -->
- [x] Tested locally
- [ ] Added/updated unit tests
- [x] Tested with simulator (SITL)
- [ ] Tested with hardware

### Platforms Tested
<!-- Check all that apply -->
- [x] Linux
- [ ] Windows
- [ ] macOS
- [ ] Android
- [ ] iOS

### Flight Stacks Tested
<!-- If applicable -->
- [ ] PX4
- [x] ArduPilot

---
By submitting this pull request, I confirm that my contribution is made under the terms of the project's dual license (Apache 2.0 and GPL v3).
