### PR TITLE
Standardize ComponentSummary QML layout pattern

### DIFF
--- a/src/AutoPilotPlugins/APM/APMAirframeComponentSummary.qml
+++ b/src/AutoPilotPlugins/APM/APMAirframeComponentSummary.qml
@@ -1,12 +1,15 @@
 import QtQuick
 import QtQuick.Controls
+import QtQuick.Layouts
 
 import QGroundControl
 import QGroundControl.FactControls
 import QGroundControl.Controls
 
 Item {
-    anchors.fill:       parent
+    implicitWidth: mainLayout.implicitWidth
+    implicitHeight: mainLayout.implicitHeight
+    width: parent.width  // grows when Loader is wider than implicitWidth
 
     APMAirframeComponentController {id: controller; }
 
@@ -14,8 +17,9 @@ Item {
     property Fact _frameType:           controller.getParameterFact(-1, "FRAME_TYPE", false)
     property bool _frameTypeAvailable:  controller.parameterExists(-1, "FRAME_TYPE")
 
-    Column {
-        anchors.fill:       parent
+    ColumnLayout {
+        id: mainLayout
+        spacing: 0
 
         VehicleSummaryRow {
             labelText:  qsTr("Frame Class")

--- a/src/AutoPilotPlugins/APM/APMFlightModesComponentSummary.qml
+++ b/src/AutoPilotPlugins/APM/APMFlightModesComponentSummary.qml
@@ -1,12 +1,15 @@
 import QtQuick
 import QtQuick.Controls
+import QtQuick.Layouts
 
 import QGroundControl
 import QGroundControl.FactControls
 import QGroundControl.Controls
 
 Item {
-    anchors.fill:   parent
+    implicitWidth: mainLayout.implicitWidth
+    implicitHeight: mainLayout.implicitHeight
+    width: parent.width  // grows when Loader is wider than implicitWidth
 
     FactPanelController { id: controller; }
 
@@ -20,8 +23,9 @@ Item {
     property Fact flightMode5: controller.getParameterFact(-1, _roverFirmware ? "MODE5" : "FLTMODE5")
     property Fact flightMode6: controller.getParameterFact(-1, _roverFirmware ? "MODE6" : "FLTMODE6")
 
-    Column {
-        anchors.fill:       parent
+    ColumnLayout {
+        id: mainLayout
+        spacing: 0
 
         VehicleSummaryRow {
             labelText: qsTr("Flight Mode 1")

--- a/src/AutoPilotPlugins/APM/APMFollowComponentSummary.qml
+++ b/src/AutoPilotPlugins/APM/APMFollowComponentSummary.qml
@@ -1,12 +1,15 @@
 import QtQuick
 import QtQuick.Controls
+import QtQuick.Layouts
 
 import QGroundControl
 import QGroundControl.FactControls
 import QGroundControl.Controls
 
 Item {
-    anchors.fill: parent
+    implicitWidth: mainLayout.implicitWidth
+    implicitHeight: mainLayout.implicitHeight
+    width: parent.width  // grows when Loader is wider than implicitWidth
 
     FactPanelController { id: controller }
 
@@ -28,8 +31,9 @@ Item {
         { label: qsTr("Yaw Behavior"),      fact: getFact("FOLL_YAW_BEHAVE"),   visible: followParamsAvailable }
     ]
 
-    Column {
-        anchors.fill: parent
+    ColumnLayout {
+        id: mainLayout
+        spacing: 0
 
         Repeater {
             model: followItems

--- a/src/AutoPilotPlugins/APM/APMLightsComponentSummary.qml
+++ b/src/AutoPilotPlugins/APM/APMLightsComponentSummary.qml
@@ -1,12 +1,15 @@
 import QtQuick
 import QtQuick.Controls
+import QtQuick.Layouts
 
 import QGroundControl
 import QGroundControl.FactControls
 import QGroundControl.Controls
 
 Item {
-    anchors.fill:   parent
+    implicitWidth: mainLayout.implicitWidth
+    implicitHeight: mainLayout.implicitHeight
+    width: parent.width  // grows when Loader is wider than implicitWidth
 
     FactPanelController { id: controller; }
 
@@ -81,8 +84,9 @@ Item {
         property int    lights2Function:         _rcFunctionRCIN10
     }
 
-    Column {
-        anchors.fill:       parent
+    ColumnLayout {
+        id: mainLayout
+        spacing: 0
 
         VehicleSummaryRow {
             labelText:  qsTr("Lights Output 1")

--- a/src/AutoPilotPlugins/APM/APMPowerComponentSummary.qml
+++ b/src/AutoPilotPlugins/APM/APMPowerComponentSummary.qml
@@ -1,12 +1,15 @@
 import QtQuick
 import QtQuick.Controls
+import QtQuick.Layouts
 
 import QGroundControl
 import QGroundControl.FactControls
 import QGroundControl.Controls
 
 Item {
-    anchors.fill:   parent
+    implicitWidth: mainLayout.implicitWidth
+    implicitHeight: mainLayout.implicitHeight
+    width: parent.width  // grows when Loader is wider than implicitWidth
 
     FactPanelController { id: controller; }
 
@@ -19,8 +22,9 @@ Item {
     property Fact _batt2Capacity:           controller.getParameterFact(-1, "BATT2_CAPACITY", false /* reportMissing */)
     property bool _battCapacityAvailable:   controller.parameterExists(-1, "BATT_CAPACITY")
 
-    Column {
-        anchors.fill:       parent
+    ColumnLayout {
+        id: mainLayout
+        spacing: 0
 
         VehicleSummaryRow {
             labelText: qsTr("Batt1 monitor")

--- a/src/AutoPilotPlugins/APM/APMRadioComponentSummary.qml
+++ b/src/AutoPilotPlugins/APM/APMRadioComponentSummary.qml
@@ -1,12 +1,15 @@
 import QtQuick
 import QtQuick.Controls
+import QtQuick.Layouts
 
 import QGroundControl
 import QGroundControl.FactControls
 import QGroundControl.Controls
 
 Item {
-    anchors.fill:   parent
+    implicitWidth: mainLayout.implicitWidth
+    implicitHeight: mainLayout.implicitHeight
+    width: parent.width  // grows when Loader is wider than implicitWidth
 
     FactPanelController { id: controller; }
 
@@ -15,8 +18,9 @@ Item {
     property Fact mapYawFact:       controller.getParameterFact(-1, "RCMAP_YAW")
     property Fact mapThrottleFact:  controller.getParameterFact(-1, "RCMAP_THROTTLE")
 
-    Column {
-        anchors.fill:       parent
+    ColumnLayout {
+        id: mainLayout
+        spacing: 0
 
         VehicleSummaryRow {
             labelText: qsTr("Roll")

--- a/src/AutoPilotPlugins/APM/APMSafetyComponentSummary.qml
+++ b/src/AutoPilotPlugins/APM/APMSafetyComponentSummary.qml
@@ -1,12 +1,15 @@
 import QtQuick
 import QtQuick.Controls
+import QtQuick.Layouts
 
 import QGroundControl
 import QGroundControl.FactControls
 import QGroundControl.Controls
 
 Item {
-    anchors.fill:   parent
+    implicitWidth: mainLayout.implicitWidth
+    implicitHeight: mainLayout.implicitHeight
+    width: parent.width  // grows when Loader is wider than implicitWidth
 
     FactPanelController { id: controller; }
 
@@ -29,8 +32,9 @@ Item {
     property bool _roverFirmware:           controller.parameterExists(-1, "MODE1") // This catches all usage of ArduRover firmware vehicle types: Rover, Boat...
 
 
-    Column {
-        anchors.fill:       parent
+    ColumnLayout {
+        id: mainLayout
+        spacing: 0
 
         VehicleSummaryRow {
             labelText: qsTr("Arming Checks:")

--- a/src/AutoPilotPlugins/APM/APMSensorsComponentSummary.qml
+++ b/src/AutoPilotPlugins/APM/APMSensorsComponentSummary.qml
@@ -11,7 +11,9 @@ import QGroundControl.Controls
 */
 
 Item {
-    anchors.fill:   parent
+    implicitWidth: mainLayout.implicitWidth
+    implicitHeight: mainLayout.implicitHeight
+    width: parent.width  // grows when Loader is wider than implicitWidth
 
     APMSensorsComponentController { id: controller; }
 
@@ -20,8 +22,9 @@ Item {
         factPanelController:    controller
     }
 
-    Column {
-        anchors.fill:       parent
+    ColumnLayout {
+        id: mainLayout
+        spacing: 0
 
         VehicleSummaryRow {
         labelText:  qsTr("Compasses:")
@@ -77,7 +80,7 @@ Item {
             model: sensorParams.rgInsId.length
             APMSensorIdDecoder {
                 fact:          sensorParams.rgInsId[index]
-                anchors.right: parent.right
+                Layout.alignment: Qt.AlignRight
             }
         }
 
@@ -90,7 +93,7 @@ Item {
             model: sensorParams.rgBaroId.length
             APMSensorIdDecoder {
                 fact:          sensorParams.rgBaroId[index]
-                anchors.right: parent.right
+                Layout.alignment: Qt.AlignRight
             }
         }
     }

--- a/src/AutoPilotPlugins/APM/APMSubFrameComponentSummary.qml
+++ b/src/AutoPilotPlugins/APM/APMSubFrameComponentSummary.qml
@@ -1,12 +1,15 @@
 import QtQuick
 import QtQuick.Controls
+import QtQuick.Layouts
 
 import QGroundControl
 import QGroundControl.FactControls
 import QGroundControl.Controls
 
 Item {
-    anchors.fill:   parent
+    implicitWidth: mainLayout.implicitWidth
+    implicitHeight: mainLayout.implicitHeight
+    width: parent.width  // grows when Loader is wider than implicitWidth
 
     FactPanelController { id: controller; }
 
@@ -35,8 +38,10 @@ Item {
         }
     }
 
-    Column {
-        anchors.fill:       parent
+    ColumnLayout {
+        id: mainLayout
+        spacing: 0
+
         VehicleSummaryRow {
             id: nameRow;
             labelText: qsTr("Frame Type")

--- a/src/AutoPilotPlugins/Common/ESP8266ComponentSummary.qml
+++ b/src/AutoPilotPlugins/Common/ESP8266ComponentSummary.qml
@@ -1,12 +1,15 @@
 import QtQuick
 import QtQuick.Controls
+import QtQuick.Layouts
 
 import QGroundControl
 import QGroundControl.FactControls
 import QGroundControl.Controls
 
 Item {
-    anchors.fill:   parent
+    implicitWidth: mainLayout.implicitWidth
+    implicitHeight: mainLayout.implicitHeight
+    width: parent.width  // grows when Loader is wider than implicitWidth
 
     FactPanelController { id: controller; }
 
@@ -21,8 +24,10 @@ Item {
     property Fact uartBaud:         controller.getParameterFact(esp8266.componentID, "UART_BAUDRATE")
     property Fact wifiMode:         controller.getParameterFact(esp8266.componentID, "WIFI_MODE", false) //-- Don't bitch if missing
 
-    Column {
-        anchors.fill:       parent
+    ColumnLayout {
+        id: mainLayout
+        spacing: 0
+
         VehicleSummaryRow {
             labelText: qsTr("Firmware Version")
             valueText: esp8266.version

--- a/src/AutoPilotPlugins/Common/JoystickComponentSummary.qml
+++ b/src/AutoPilotPlugins/Common/JoystickComponentSummary.qml
@@ -1,17 +1,21 @@
 import QtQuick
 import QtQuick.Controls
+import QtQuick.Layouts
 
 import QGroundControl
 import QGroundControl.Controls
 
 Item {
-    anchors.fill: parent
+    implicitWidth: mainLayout.implicitWidth
+    implicitHeight: mainLayout.implicitHeight
+    width: parent.width  // grows when Loader is wider than implicitWidth
 
     readonly property var _activeVehicle: QGroundControl.multiVehicleManager.activeVehicle
     readonly property var _activeJoystick: joystickManager.activeJoystick
 
-    Column {
-        anchors.fill: parent
+    ColumnLayout {
+        id: mainLayout
+        spacing: 0
 
         VehicleSummaryRow {
             labelText: qsTr("Status")

--- a/src/AutoPilotPlugins/PX4/AirframeComponentSummary.qml
+++ b/src/AutoPilotPlugins/PX4/AirframeComponentSummary.qml
@@ -1,12 +1,15 @@
 import QtQuick
 import QtQuick.Controls
+import QtQuick.Layouts
 
 import QGroundControl
 import QGroundControl.FactControls
 import QGroundControl.Controls
 
 Item {
-    anchors.fill:       parent
+    implicitWidth: mainLayout.implicitWidth
+    implicitHeight: mainLayout.implicitHeight
+    width: parent.width  // grows when Loader is wider than implicitWidth
 
     AirframeComponentController { id: controller; }
 
@@ -15,8 +18,10 @@ Item {
 
     property bool autoStartSet: sysAutoStartFact ? (sysAutoStartFact.value !== 0) : false
 
-    Column {
-        anchors.fill:       parent
+    ColumnLayout {
+        id: mainLayout
+        spacing: 0
+
         VehicleSummaryRow {
             labelText: qsTr("System ID")
             valueText: sysIdFact ? sysIdFact.valueString : ""

--- a/src/AutoPilotPlugins/PX4/FlightModesComponentSummary.qml
+++ b/src/AutoPilotPlugins/PX4/FlightModesComponentSummary.qml
@@ -1,20 +1,25 @@
 import QtQuick
 import QtQuick.Controls
+import QtQuick.Layouts
 
 import QGroundControl
 import QGroundControl.FactControls
 import QGroundControl.Controls
 
 Item {
-    anchors.fill:   parent
+    implicitWidth: mainLayout.implicitWidth
+    implicitHeight: mainLayout.implicitHeight
+    width: parent.width  // grows when Loader is wider than implicitWidth
 
     FactPanelController { id: controller; }
 
     property Fact _nullFact
     property Fact _rcMapFltmode:    controller.parameterExists(-1, "RC_MAP_FLTMODE") ? controller.getParameterFact(-1, "RC_MAP_FLTMODE") : _nullFact
 
-	Column {
-		anchors.fill:       parent
+	ColumnLayout {
+		id: mainLayout
+		spacing: 0
+
 		VehicleSummaryRow {
 			labelText: qsTr("Mode switch")
 			valueText: _rcMapFltmode.value === 0 ? qsTr("Setup required") : _rcMapFltmode.enumStringValue

--- a/src/AutoPilotPlugins/PX4/PX4RadioComponentSummary.qml
+++ b/src/AutoPilotPlugins/PX4/PX4RadioComponentSummary.qml
@@ -1,12 +1,15 @@
 import QtQuick
 import QtQuick.Controls
+import QtQuick.Layouts
 
 import QGroundControl
 import QGroundControl.FactControls
 import QGroundControl.Controls
 
 Item {
-    anchors.fill:   parent
+    implicitWidth: mainLayout.implicitWidth
+    implicitHeight: mainLayout.implicitHeight
+    width: parent.width  // grows when Loader is wider than implicitWidth
 
     FactPanelController { id: controller; }
 
@@ -18,8 +21,9 @@ Item {
     property Fact mapAux1Fact:      controller.getParameterFact(-1, "RC_MAP_AUX1")
     property Fact mapAux2Fact:      controller.getParameterFact(-1, "RC_MAP_AUX2")
 
-    Column {
-        anchors.fill:       parent
+    ColumnLayout {
+        id: mainLayout
+        spacing: 0
 
         VehicleSummaryRow {
             labelText: qsTr("Roll")

--- a/src/AutoPilotPlugins/PX4/PowerComponentSummary.qml
+++ b/src/AutoPilotPlugins/PX4/PowerComponentSummary.qml
@@ -1,12 +1,15 @@
 import QtQuick
 import QtQuick.Controls
+import QtQuick.Layouts
 
 import QGroundControl
 import QGroundControl.FactControls
 import QGroundControl.Controls
 
 Item {
-    anchors.fill:   parent
+    implicitWidth: mainLayout.implicitWidth
+    implicitHeight: mainLayout.implicitHeight
+    width: parent.width  // grows when Loader is wider than implicitWidth
 
     property string _naString: qsTr("N/A")
 
@@ -18,8 +21,9 @@ Item {
         batteryIndex:   1
     }
 
-    Column {
-        anchors.fill:       parent
+    ColumnLayout {
+        id: mainLayout
+        spacing: 0
 
         VehicleSummaryRow {
             labelText: qsTr("Battery Source")

--- a/src/AutoPilotPlugins/PX4/SafetyComponentSummary.qml
+++ b/src/AutoPilotPlugins/PX4/SafetyComponentSummary.qml
@@ -1,12 +1,15 @@
 import QtQuick
 import QtQuick.Controls
+import QtQuick.Layouts
 
 import QGroundControl
 import QGroundControl.FactControls
 import QGroundControl.Controls
 
 Item {
-    anchors.fill:   parent
+    implicitWidth: mainLayout.implicitWidth
+    implicitHeight: mainLayout.implicitHeight
+    width: parent.width  // grows when Loader is wider than implicitWidth
 
     FactPanelController { id: controller; }
 
@@ -20,8 +23,9 @@ Item {
     property Fact   _rtlLandDelayFact:  controller.getParameterFact(-1, "RTL_LAND_DELAY")
     property int    _rtlLandDelayValue: _rtlLandDelayFact.value
 
-    Column {
-        anchors.fill:       parent
+    ColumnLayout {
+        id: mainLayout
+        spacing: 0
 
         VehicleSummaryRow {
             labelText: qsTr("Low Battery Failsafe")

--- a/src/AutoPilotPlugins/PX4/SensorsComponentSummary.qml
+++ b/src/AutoPilotPlugins/PX4/SensorsComponentSummary.qml
@@ -1,5 +1,6 @@
 import QtQuick
 import QtQuick.Controls
+import QtQuick.Layouts
 
 import QGroundControl
 import QGroundControl.FactControls
@@ -10,7 +11,9 @@ import QGroundControl.Controls
 */
 
 Item {
-    anchors.fill:   parent
+    implicitWidth: mainLayout.implicitWidth
+    implicitHeight: mainLayout.implicitHeight
+    width: parent.width  // grows when Loader is wider than implicitWidth
 
     FactPanelController { id: controller; }
 
@@ -20,8 +23,9 @@ Item {
     property Fact gyro0IdFact:  controller.getParameterFact(-1, "CAL_GYRO0_ID")
     property Fact accel0IdFact: controller.getParameterFact(-1, "CAL_ACC0_ID")
 
-    Column {
-        anchors.fill:       parent
+    ColumnLayout {
+        id: mainLayout
+        spacing: 0
 
         VehicleSummaryRow {
             labelText: qsTr("Compass 0")

--- a/src/QmlControls/VehicleSummaryRow.qml
+++ b/src/QmlControls/VehicleSummaryRow.qml
@@ -7,22 +7,23 @@ import QGroundControl.Controls
 
 RowLayout {
     id: root
+    Layout.fillWidth: true
+    spacing: ScreenTools.defaultFontPixelHeight
 
     property string labelText: "Label"
     property string valueText: "value"
     property string valueColor: ""
 
-    width: parent.width
+    QGCLabel {
+        id: label
+        Layout.fillWidth: true
+        text: root.labelText
+    }
 
     QGCLabel {
-        id:     label
-        text:   root.labelText
-    }
-    QGCLabel {
-        text:                   root.valueText
-        color:                  root.valueColor !== "" ? root.valueColor : QGroundControl.globalPalette.text
-        elide:                  Text.ElideRight
-        horizontalAlignment:    Text.AlignRight
-        Layout.fillWidth:       true
+        Layout.maximumWidth: ScreenTools.defaultFontPixelWidth * 20
+        text: root.valueText
+        color: root.valueColor !== "" ? root.valueColor : QGroundControl.globalPalette.text
+        elide: Text.ElideRight
     }
 }

--- a/src/Vehicle/VehicleSetup/VehicleSummary.qml
+++ b/src/Vehicle/VehicleSetup/VehicleSummary.qml
@@ -1,5 +1,6 @@
 import QtQuick
 import QtQuick.Controls
+import QtQuick.Layouts
 
 import QGroundControl
 import QGroundControl.Controls
@@ -14,6 +15,7 @@ Rectangle {
     property real _minSummaryW:     ScreenTools.isTinyScreen ? ScreenTools.defaultFontPixelWidth * 28 : ScreenTools.defaultFontPixelWidth * 36
     property real _summaryBoxWidth: _minSummaryW
     property real _summaryBoxSpace: ScreenTools.defaultFontPixelWidth * 2
+    property real _margins:        ScreenTools.defaultFontPixelHeight / 2
 
     function computeSummaryBoxSize() {
         var sw  = 0
@@ -85,52 +87,58 @@ Rectangle {
 
                     // Outer summary item rectangle
                     Rectangle {
-                        width:      _summaryBoxWidth
-                        height:     ScreenTools.defaultFontPixelHeight * 13
-                        color:      qgcPal.windowShade
-                        visible:    modelData.summaryQmlSource.toString() !== ""
+                        width: mainLayout.width + (_margins * 2)
+                        height: mainLayout.height + (_margins * 2)
+                        color: qgcPal.windowShade
+                        visible: modelData.summaryQmlSource.toString() !== ""
                         border.width: 1
                         border.color: qgcPal.text
+
                         Component.onCompleted: {
                             border.color = Qt.rgba(border.color.r, border.color.g, border.color.b, 0.1)
                         }
 
                         readonly property real titleHeight: ScreenTools.defaultFontPixelHeight * 2
 
-                        // Title bar
-                        QGCButton {
-                            id:     titleBar
-                            width:  parent.width
-                            height: titleHeight
-                            text:   capitalizeWords(modelData.name)
+                        ColumnLayout {
+                            id: mainLayout
+                            anchors.margins: _margins
+                            anchors.left: parent.left
+                            anchors.top: parent.top
+                            spacing: ScreenTools.defaultFontPixelHeight / 2
 
-                            // Setup indicator
-                            Rectangle {
-                                anchors.rightMargin:    ScreenTools.defaultFontPixelWidth
-                                anchors.right:          parent.right
-                                anchors.verticalCenter: parent.verticalCenter
-                                width:                  ScreenTools.defaultFontPixelWidth * 1.75
-                                height:                 width
-                                radius:                 width / 2
-                                color:                  modelData.setupComplete ? "#00d932" : "red"
-                                visible:                modelData.requiresSetup && modelData.setupSource !== ""
-                            }
+                            // Title bar
+                            QGCButton {
+                                Layout.fillWidth: true
+                                Layout.preferredHeight: titleHeight
+                                text: capitalizeWords(modelData.name)
 
-                            onClicked : {
-                                //console.log(modelData.setupSource)
-                                if (modelData.setupSource !== "") {
-                                    setupView.showVehicleComponentPanel(modelData)
+                                // Setup indicator
+                                Rectangle {
+                                    anchors.rightMargin:    ScreenTools.defaultFontPixelWidth
+                                    anchors.right:          parent.right
+                                    anchors.verticalCenter: parent.verticalCenter
+                                    width:                  ScreenTools.defaultFontPixelWidth * 1.75
+                                    height:                 width
+                                    radius:                 width / 2
+                                    color:                  modelData.setupComplete ? "#00d932" : "red"
+                                    visible:                modelData.requiresSetup && modelData.setupSource !== ""
+                                }
+
+                                onClicked : {
+                                    if (modelData.setupSource !== "") {
+                                        setupView.showVehicleComponentPanel(modelData)
+                                    }
                                 }
                             }
-                        }
-                        // Summary Qml
-                        Rectangle {
-                            anchors.top:    titleBar.bottom
-                            width:          parent.width
+
+                            // Summary Qml
                             Loader {
-                                anchors.fill:       parent
-                                anchors.margins:    ScreenTools.defaultFontPixelWidth
-                                source:             modelData.summaryQmlSource
+                                id: summaryLoader
+                                Layout.fillWidth: true
+                                Layout.preferredWidth: item ? item.implicitWidth : 0
+                                Layout.preferredHeight: item ? item.implicitHeight : 0
+                                source: modelData.summaryQmlSource
 
                                 property var vehicleComponent: modelData
                             }


### PR DESCRIPTION

![Screenshot 2026-03-12 at 4 17 56 PM](https://github.com/user-attachments/assets/c4bd84ce-2781-4448-8560-934170e0f356)

Related to #12822

Standardize all ComponentSummary QML pages to use a consistent layout pattern:

- Root `Item` uses `implicitWidth`/`implicitHeight` from the `ColumnLayout` and `width: parent.width` for Loader stretching
- Replace old `anchors.fill: parent` + `Column` pattern with `ColumnLayout` (`spacing: 0`)
- Use `VehicleSummaryRow` consistently across all summary pages

**Files updated (17):**
- PX4: PowerComponentSummary, PX4RadioComponentSummary, AirframeComponentSummary, SensorsComponentSummary, FlightModesComponentSummary, SafetyComponentSummary
- APM: APMPowerComponentSummary, APMAirframeComponentSummary, APMRadioComponentSummary, APMSafetyComponentSummary, APMSubFrameComponentSummary, APMFlightModesComponentSummary, APMFollowComponentSummary, APMSensorsComponentSummary, APMLightsComponentSummary
- Common: ESP8266ComponentSummary, JoystickComponentSummary
- Shared: VehicleSummaryRow, VehicleSummary
