### PR TITLE
fix(linux): Check QGC_NO_SYSTEM_GLIB before attempting to fix TTS

### DIFF
--- a/deploy/linux/AppRun
+++ b/deploy/linux/AppRun
@@ -11,30 +11,43 @@ case "$ARCH" in
     *)       MULTIARCH="" ;;
 esac
 
-SYSTEM_GLIB=""
-SYSTEM_GIO=""
-for LIB_PATH in \
-    "/usr/lib/${MULTIARCH}" \
-    "/usr/lib64" \
-    "/usr/lib"; do
-    if [ -f "${LIB_PATH}/libglib-2.0.so.0" ]; then
-        SYSTEM_GLIB="${LIB_PATH}/libglib-2.0.so.0"
-        SYSTEM_GIO="${LIB_PATH}/libgio-2.0.so.0"
-        break
-    fi
-done
+unset GIO_EXTRA_MODULES
+unset GIO_MODULE_DIR
+unset GIO_USE_VFS
 
-# Preload system GLib 2.76+ for TTS compatibility (libspeechd.so.2 dependency)
-# Must also preload system GIO to avoid ABI mismatch with bundled GStreamer GIO plugin
-if [ -n "$SYSTEM_GLIB" ]; then
-    if nm -D "$SYSTEM_GLIB" 2>/dev/null | grep -qm1 g_string_free_and_steal; then
-        GLIB_PRELOAD="${SYSTEM_GLIB}"
-        if [ -f "$SYSTEM_GIO" ]; then
-            GLIB_PRELOAD="${GLIB_PRELOAD}:${SYSTEM_GIO}"
+# Experimental: Use LD_PRELOAD to fix TTS compatibility for different distributions.
+# Set the environment variable QGC_NO_SYSTEM_GLIB=1 to disable, as these changes can
+# cause app crashes on some systems.
+if [ -z "$QGC_NO_SYSTEM_GLIB" ]; then 
+    SYSTEM_GLIB=""
+    SYSTEM_GIO=""
+    for LIB_PATH in \
+        "/usr/lib/${MULTIARCH}" \
+        "/usr/lib64" \
+        "/usr/lib"; do
+        if [ -f "${LIB_PATH}/libglib-2.0.so.0" ]; then
+            SYSTEM_GLIB="${LIB_PATH}/libglib-2.0.so.0"
+            SYSTEM_GIO="${LIB_PATH}/libgio-2.0.so.0"
+            break
         fi
-        export LD_PRELOAD="${GLIB_PRELOAD}${LD_PRELOAD:+:$LD_PRELOAD}"
+    done
+
+    # Preload system GLib 2.76+ for TTS compatibility (libspeechd.so.2 dependency)
+    if [ -n "$SYSTEM_GLIB" ]; then
+        if nm -D "$SYSTEM_GLIB" 2>/dev/null | grep -qm1 g_string_free_and_steal; then
+            export LD_PRELOAD="${SYSTEM_GLIB}${LD_PRELOAD:+:$LD_PRELOAD}"
+        fi
+    fi
+
+    # GIO 2.76+ system modules require symbols missing from bundled GIO - use bundled modules only
+    if [ -n "$SYSTEM_GIO" ] && nm -D "$SYSTEM_GIO" 2>/dev/null | grep -qm1 g_task_set_static_name; then
+        export GIO_MODULE_DIR="${APPDIR}/usr/lib/gio/modules"
+        export GIO_USE_VFS="local"
+    else
+        export GIO_EXTRA_MODULES="${APPDIR}/usr/lib/gio/modules"
     fi
 fi
+
 
 # Use system OpenGL libraries to avoid conflicts with bundled libGLESv2
 # Bundled GLES can conflict with system desktop OpenGL causing "Unrecognized OpenGL version"
@@ -96,17 +109,6 @@ if [ "$XDG_SESSION_TYPE" = "wayland" ]; then
 fi
 
 export GST_REGISTRY_REUSE_PLUGIN_SCANNER="no"
-
-# GIO 2.76+ system modules require symbols missing from bundled GIO - use bundled modules only
-unset GIO_EXTRA_MODULES
-unset GIO_MODULE_DIR
-unset GIO_USE_VFS
-if [ -n "$SYSTEM_GIO" ] && nm -D "$SYSTEM_GIO" 2>/dev/null | grep -qm1 g_task_set_static_name; then
-    export GIO_MODULE_DIR="${APPDIR}/usr/lib/gio/modules"
-    export GIO_USE_VFS="local"
-else
-    export GIO_EXTRA_MODULES="${APPDIR}/usr/lib/gio/modules"
-fi
 
 GST_PLUGIN_DIR="${APPDIR}/usr/lib/gstreamer-1.0"
 GST_SCANNER="${APPDIR}/usr/lib/gstreamer1.0/gstreamer-1.0/gst-plugin-scanner"


### PR DESCRIPTION
The experimental fixes using LD_PRELOAD are a bit unreliable across the many library versions on linux distros. To make the core QGC app more compatible on linux, we provide the environement variable QGC_NO_SYSTEM_GLIB to allow users to run QGC without the experimental TTS fixes.

This commit also consolidates the GIO/GLIB preload logic into one place in the AppRun file, making it easier to understand.

Feel free to provide feedback on this. Hopefully this commit will ease developer burden across platforms  and make QGC more reliable.

## Type of Change
<!-- Put an 'x' in the relevant boxes -->
- [ x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] CI/Build changes
- [ ] Other
boxes -->


## Testing
<!-- Describe the tests you ran and how to reproduce them -->
- [x ] Tested locally
- [ ] Added/updated unit tests
- [ ] Tested with simulator (SITL)
- [ ] Tested with hardware

### Platforms Tested
<!-- Check all that apply -->
- [ x] Linux
- [ ] Windows
- [ ] macOS
- [ ] Android
- [ ] iOS

### Flight Stacks Tested
<!-- If applicable -->
- [ ] PX4
- [ ] ArduPilot

## Screenshots
<!-- If applicable, add screenshots to help explain your changes -->

## Checklist
<!-- Go over all the following points, and put an 'x' in all the boxes that apply -->
- [x ] I have read the [Contribution Guidelines](CONTRIBUTING.md)
- [x ] I have read the [Code of Conduct](CODE_OF_CONDUCT.md)
- [x ] My code follows the project's coding standards
- [ ] I have added tests that prove my fix/feature works
- [ ] New and existing unit tests pass locally

## Related Issues
<!-- Link any related issues using #issue_number -->
#14124

---
By submitting this pull request, I confirm that my contribution is made under the terms of the project's dual license (Apache 2.0 and GPL v3).
