### PR TITLE
PlanMasterControllerTest: add download dirty-flag scenarios

### DIFF
--- a/test/MissionManager/PlanMasterControllerTest.cc
+++ b/test/MissionManager/PlanMasterControllerTest.cc
@@ -70,10 +70,10 @@ void PlanMasterControllerTest::_testDirtyFlagsMatrix_data()
 {
     // Dirty-state transition matrix ("unchanged" means preserve prior value):
     //
-    // | State \ Action | Upload OK | Clear | SaveDirty=true | Load plan | Save file OK | Clear save-dirty |
-    // |----------------|-----------|-------|----------------|-----------|--------------|------------------|
-    // | dirtyForSave   | unchanged | false | true           | false     | false        | false            |
-    // | dirtyForUpload | false     | false | true           | true      | unchanged    | unchanged        |
+    // | State \ Action | Upload OK | Clear | SaveDirty=true | Load plan | Save file OK | Clear save-dirty | Download w/ items | Download empty |
+    // |----------------|-----------|-------|----------------|-----------|--------------|------------------|-------------------|----------------|
+    // | dirtyForSave   | unchanged | false | true           | false     | false        | false            | true              | false          |
+    // | dirtyForUpload | false     | false | true           | true      | unchanged    | unchanged        | false             | false          |
 
     // Data columns:
     //  - scenario: DirtyScenario enum value selecting which action path to execute
@@ -106,6 +106,8 @@ void PlanMasterControllerTest::_testDirtyFlagsMatrix_data()
         { SaveFalseOnSuccessfulLoad,          "save false on successful load",       DirtyStateFalse,     DirtyStateTrue },
         { ClearSaveDirtyPreservesUploadTrue,  "clear save dirty keeps upload true",  DirtyStateFalse,     DirtyStateUnchanged },
         { ClearSaveDirtyPreservesUploadFalse, "clear save dirty keeps upload false", DirtyStateFalse,     DirtyStateUnchanged },
+        { DownloadWithItemsDirtyForSave,      "download with items marks save dirty",DirtyStateTrue,      DirtyStateFalse },
+        { DownloadEmptyNotDirtyForSave,       "download empty keeps save clean",     DirtyStateFalse,     DirtyStateFalse },
     };
 
     const QList<DirtyState> initialStates = {
@@ -150,6 +152,11 @@ void PlanMasterControllerTest::_testDirtyFlagsMatrix()
 
     QVERIFY(initialDirtyForSave != DirtyStateUnchanged);
     QVERIFY(initialDirtyForUpload != DirtyStateUnchanged);
+
+    // Pre-load items for scenarios that need containsItems() == true
+    if (scenario == DownloadWithItemsDirtyForSave) {
+        _masterController->loadFromFile(":/unittest/MissionPlanner.waypoints");
+    }
 
     const auto dirtyStateToBool = [](int state) -> bool {
         switch (state) {
@@ -213,6 +220,18 @@ void PlanMasterControllerTest::_testDirtyFlagsMatrix()
     case ClearSaveDirtyPreservesUploadFalse:
         _masterController->_setDirtyForSave(false);
         break;
+    case DownloadWithItemsDirtyForSave: {
+        QVERIFY(_masterController->containsItems());
+        const bool invoked = QMetaObject::invokeMethod(_masterController, "_loadRallyPointsComplete", Qt::DirectConnection);
+        QVERIFY(invoked);
+        break;
+    }
+    case DownloadEmptyNotDirtyForSave: {
+        QVERIFY(!_masterController->containsItems());
+        const bool invoked = QMetaObject::invokeMethod(_masterController, "_loadRallyPointsComplete", Qt::DirectConnection);
+        QVERIFY(invoked);
+        break;
+    }
     }
 
     const auto resolveExpected = [](int expectedState, bool unchangedValue) -> bool {

--- a/test/MissionManager/PlanMasterControllerTest.h
+++ b/test/MissionManager/PlanMasterControllerTest.h
@@ -40,6 +40,8 @@ private:
         SaveFalseOnSuccessfulLoad,
         ClearSaveDirtyPreservesUploadTrue,
         ClearSaveDirtyPreservesUploadFalse,
+        DownloadWithItemsDirtyForSave,
+        DownloadEmptyNotDirtyForSave,
     };
 
     enum DirtyState {


### PR DESCRIPTION
Adds download dirty-flag test scenarios to `PlanMasterControllerTest` that would have caught the bug fixed in #14128.

Two new scenarios in the dirty-flags matrix:
- **DownloadWithItemsDirtyForSave** — invokes `_loadRallyPointsComplete` when items are present; expects `dirtyForSave=true`, `dirtyForUpload=false`
- **DownloadEmptyNotDirtyForSave** — invokes `_loadRallyPointsComplete` with an empty plan; expects `dirtyForSave=false`, `dirtyForUpload=false`

These are exercised across all 4 initial-state permutations (save×upload × true/false), adding 8 new data-driven test rows.
