### PR TITLE
Optimize polygon/polyline drag performance with dual-signal architecture

### DIFF
--- a/src/FlightMap/MapItems/QGCMapPolygonVisuals.qml
+++ b/src/FlightMap/MapItems/QGCMapPolygonVisuals.qml
@@ -27,7 +27,6 @@ Item {
     property real   _circleRadius
     property bool   _circleRadiusDrag:          false
     property var    _circleRadiusDragCoord:     QtPositioning.coordinate()
-    property bool   _editCircleRadius:          false
     property string _instructionText:           _polygonToolsText
     property var    _savedVertices:             [ ]
     property bool   _savedCircleMode
@@ -252,7 +251,7 @@ Item {
         QGCMenuItem {
             text:           qsTr("Set radius..." )
             visible:        _circleMode
-            onTriggered:    _editCircleRadius = true
+            onTriggered:    editCircleRadiusDialogFactory.open()
         }
 
         QGCMenuItem {
@@ -274,9 +273,10 @@ Item {
         MapPolygon {
             color:          mapPolygon.showAltColor ? altColor : interiorColor
             opacity:        interiorOpacity
-            border.color:   borderColor
-            border.width:   borderWidth
-            path:           mapPolygon.path
+            visible:        _root.visible
+            border.color:   mapPolygon.vertexDrag ? "orange" : borderColor
+            border.width:   mapPolygon.vertexDrag ? 3 : borderWidth
+            path:           mapPolygon.vertexDrag ? mapPolygon.dragPath : mapPolygon.path
         }
     }
 
@@ -310,17 +310,22 @@ Item {
 
             delegate: Item {
                 property var _edgeLengthHandle
-                property var _vertices:     mapPolygon.path
 
                 function _setHandlePosition() {
+                    var vertices = mapPolygon.vertexDrag ? mapPolygon.dragPath : mapPolygon.path
                     var nextIndex = index + 1
-                    if (nextIndex > _vertices.length - 1) {
+                    if (nextIndex > vertices.length - 1) {
                         nextIndex = 0
                     }
-                    var distance = _vertices[index].distanceTo(_vertices[nextIndex])
-                    var azimuth = _vertices[index].azimuthTo(_vertices[nextIndex])
-                    _edgeLengthHandle.coordinate =_vertices[index].atDistanceAndAzimuth(distance / 3, azimuth)
+                    var distance = vertices[index].distanceTo(vertices[nextIndex])
+                    var azimuth = vertices[index].azimuthTo(vertices[nextIndex])
+                    _edgeLengthHandle.coordinate = vertices[index].atDistanceAndAzimuth(distance / 2, azimuth)
                     _edgeLengthHandle.distance = distance
+                }
+
+                Connections {
+                    target: mapPolygon
+                    function onDragPathChanged() { _setHandlePosition() }
                 }
 
                 Component.onCompleted: {
@@ -346,7 +351,7 @@ Item {
             id:             mapQuickItem
             anchorPoint.x:  sourceItem.width / 2
             anchorPoint.y:  sourceItem.height / 2
-            visible:        !_circleMode
+            visible:        !_circleMode && !_isVertexBeingDragged && !mapPolygon.centerDrag
 
             property int vertexIndex
 
@@ -402,8 +407,8 @@ Item {
             mapControl:     _root.mapControl
             z:              _zorderDragHandle
             visible:        !_circleMode
-            onDragStart:    _isVertexBeingDragged = true
-            onDragStop:     { _isVertexBeingDragged = false; mapPolygon.verifyClockwiseWinding() }
+            onDragStart:    { _isVertexBeingDragged = true; mapPolygon.vertexDrag = true }
+            onDragStop:     { _isVertexBeingDragged = false; mapPolygon.vertexDrag = false; mapPolygon.verifyClockwiseWinding() }
 
             property int polygonVertex
 
@@ -429,6 +434,7 @@ Item {
             anchorPoint.x:  dragHandle.width  * 0.5
             anchorPoint.y:  dragHandle.height * 0.5
             z:              _zorderDragHandle
+            visible:        !_isVertexBeingDragged
             sourceItem: Rectangle {
                 id:             dragHandle
                 width:          ScreenTools.defaultFontPixelHeight * 1.5
@@ -459,7 +465,7 @@ Item {
             anchorPoint.x:  dragHandle.width  / 2
             anchorPoint.y:  dragHandle.height / 2
             z:              _zorderDragHandle
-            visible:        !_circleMode
+            visible:        !_circleMode && !mapPolygon.centerDrag
 
             property int polygonVertex
 
@@ -501,6 +507,56 @@ Item {
                         _visuals[i].destroy()
                     }
                     _visuals = [ ]
+                }
+            }
+        }
+    }
+
+    QGCPopupDialogFactory {
+        id: editCircleRadiusDialogFactory
+
+        dialogComponent: editCircleRadiusDialog
+    }
+
+    Component {
+        id: editCircleRadiusDialog
+
+        QGCPopupDialog {
+            id:         popupDialog
+            title:      qsTr("Set Radius")
+            buttons:    Dialog.Save | Dialog.Cancel
+
+            onAccepted: {
+                const appRadius = Number(radiusField.text)
+                if (!isNaN(appRadius) && appRadius > 0) {
+                    const radiusMeters = QGroundControl.unitsConversion.appSettingsHorizontalDistanceUnitsToMeters(appRadius)
+                    _createCircularPolygon(mapPolygon.center, radiusMeters)
+                } else {
+                    preventClose = true
+                }
+            }
+
+            ColumnLayout {
+                width:      ScreenTools.defaultFontPixelWidth * 30
+                spacing:    ScreenTools.defaultFontPixelHeight
+
+                QGCLabel {
+                    Layout.fillWidth:   true
+                    text:               qsTr("Enter circle radius.")
+                    wrapMode:           Text.WordWrap
+                }
+
+                QGCTextField {
+                    id:                 radiusField
+                    Layout.fillWidth:   true
+                    text:               QGroundControl.unitsConversion.metersToAppSettingsHorizontalDistanceUnits(_circleRadius).toFixed(1)
+                    validator:          DoubleValidator { bottom: 0.1; notation: DoubleValidator.StandardNotation }
+                    inputMethodHints:   Qt.ImhFormattedNumbersOnly
+                }
+
+                QGCLabel {
+                    Layout.fillWidth:   true
+                    text:               QGroundControl.unitsConversion.appSettingsHorizontalDistanceUnitsString
                 }
             }
         }
@@ -554,8 +610,9 @@ Item {
             mapControl:                 _root.mapControl
             z:                          _zorderCenterHandle
             onItemCoordinateChanged:    mapPolygon.center = itemCoordinate
-            onDragStart:                mapPolygon.centerDrag = true
-            onDragStop:                 mapPolygon.centerDrag = false
+            onDragStart:                { mapPolygon.centerDrag = true; mapPolygon.vertexDrag = true }
+            onDragStop:                 { mapPolygon.centerDrag = false; mapPolygon.vertexDrag = false }
+            onClicked:                  if(_root.interactive) menu.popupCenter()
         }
     }
 
@@ -568,7 +625,7 @@ Item {
 
             Component.onCompleted: {
                 dragHandle = centerDragHandle.createObject(mapControl)
-                dragHandle.coordinate = Qt.binding(function() { return mapPolygon.center })
+                dragHandle.coordinate = Qt.binding(function() { return mapPolygon.centerDrag ? mapPolygon.dragCenter : mapPolygon.center })
                 mapControl.addMapItem(dragHandle)
                 dragArea = centerDragAreaComponent.createObject(mapControl, { "itemIndicator": dragHandle, "itemCoordinate": mapPolygon.center })
             }
@@ -655,6 +712,7 @@ Item {
             anchorPoint.x:  dragHandle.width / 2
             anchorPoint.y:  dragHandle.height / 2
             z:              QGroundControl.zOrderMapItems + 2
+            visible:        !mapPolygon.centerDrag
 
             sourceItem: Rectangle {
                 id:         dragHandle
@@ -690,8 +748,19 @@ Item {
 
         MissionItemIndicatorDrag {
             mapControl: _root.mapControl
+            onDragStart: {
+                _circleRadiusDrag = true
+                mapPolygon.vertexDrag = true
+            }
+            onDragStop: {
+                _circleRadiusDrag = false
+                mapPolygon.vertexDrag = false
+            }
 
             onItemCoordinateChanged: {
+                // Keep the handle visually attached to the cursor while radius updates are de-bounced.
+                _circleRadiusDragCoord = itemCoordinate
+
                 var radius = mapPolygon.center.distanceTo(itemCoordinate)
 
                 if (Math.abs(radius - _circleRadius) > 0.1) {

--- a/src/FlightMap/MapItems/QGCMapPolylineVisuals.qml
+++ b/src/FlightMap/MapItems/QGCMapPolylineVisuals.qml
@@ -25,6 +25,8 @@ Item {
     property real   _zorderDragHandle:      QGroundControl.zOrderMapItems + 3   // Highest to prevent splitting when items overlap
     property real   _zorderSplitHandle:     QGroundControl.zOrderMapItems + 2
     property var    _savedVertices:         [ ]
+    property bool   _isVertexBeingDragged:  false
+    property bool   dragging:               _isVertexBeingDragged
 
     readonly property string _corridorToolsText:    qsTr("Polyline Tools")
     readonly property string _traceText:            qsTr("Click in the map to add vertices. Click 'Done Tracing' when finished.")
@@ -37,7 +39,7 @@ Item {
 
     function _addInteractiveVisuals() {
         if (_objMgrInteractiveVisuals.empty) {
-            _objMgrInteractiveVisuals.createObjects([ dragHandlesComponent, splitHandlesComponent, toolbarComponent ], mapControl)
+            _objMgrInteractiveVisuals.createObjects([ dragHandlesComponent, splitHandlesComponent, edgeLengthHandlesComponent, toolbarComponent ], mapControl)
         }
     }
 
@@ -162,9 +164,9 @@ Item {
         id: polylineComponent
 
         MapPolyline {
-            line.width: lineWidth
-            line.color: lineColor
-            path:       mapPolyline.path
+            line.width: mapPolyline.vertexDrag ? 3 : lineWidth
+            line.color: mapPolyline.vertexDrag ? "orange" : lineColor
+            path:       mapPolyline.vertexDrag ? mapPolyline.dragPath : mapPolyline.path
             visible:    _root.visible
             opacity:    _root.opacity
         }
@@ -179,6 +181,7 @@ Item {
             anchorPoint.y:  sourceItem.height / 2
             z:              _zorderSplitHandle
             opacity:        _root.opacity
+            visible:        !mapPolyline.vertexDrag
 
             property int vertexIndex
 
@@ -225,6 +228,71 @@ Item {
         }
     }
 
+    Component {
+        id: edgeLengthHandleComponent
+
+        MapQuickItem {
+            id:             edgeLengthMapItem
+            anchorPoint.x:  sourceItem.width / 2
+            anchorPoint.y:  sourceItem.height / 2
+
+            property int vertexIndex
+            property real distance
+
+            property var _unitsConversion: QGroundControl.unitsConversion
+
+            sourceItem: Text {
+                text:   _unitsConversion.metersToAppSettingsHorizontalDistanceUnits(distance).toFixed(1) + " " +
+                        _unitsConversion.appSettingsHorizontalDistanceUnitsString
+                color:  "white"
+            }
+        }
+    }
+
+    Component {
+        id: edgeLengthHandlesComponent
+
+        Repeater {
+            model: _isVertexBeingDragged ? mapPolyline.path : undefined
+
+            delegate: Item {
+                property var _edgeLengthHandle
+
+                function _setHandlePosition() {
+                    var vertices = mapPolyline.vertexDrag ? mapPolyline.dragPath : mapPolyline.path
+                    var nextIndex = index + 1
+                    if (nextIndex > vertices.length - 1) {
+                        return
+                    }
+                    var distance = vertices[index].distanceTo(vertices[nextIndex])
+                    var azimuth = vertices[index].azimuthTo(vertices[nextIndex])
+                    _edgeLengthHandle.coordinate = vertices[index].atDistanceAndAzimuth(distance / 2, azimuth)
+                    _edgeLengthHandle.distance = distance
+                }
+
+                Connections {
+                    target: mapPolyline
+                    function onDragPathChanged() { _setHandlePosition() }
+                }
+
+                Component.onCompleted: {
+                    if (index + 1 <= mapPolyline.path.length - 1) {
+                        _edgeLengthHandle = edgeLengthHandleComponent.createObject(mapControl)
+                        _edgeLengthHandle.vertexIndex = index
+                        _setHandlePosition()
+                        mapControl.addMapItem(_edgeLengthHandle)
+                    }
+                }
+
+                Component.onDestruction: {
+                    if (_edgeLengthHandle) {
+                        _edgeLengthHandle.destroy()
+                    }
+                }
+            }
+        }
+    }
+
     // Control which is used to drag polygon vertices
     Component {
         id: dragAreaComponent
@@ -234,6 +302,8 @@ Item {
             id:         dragArea
             z:          _zorderDragHandle
             opacity:    _root.opacity
+            onDragStart: { _isVertexBeingDragged = true; mapPolyline.vertexDrag = true }
+            onDragStop:  { _isVertexBeingDragged = false; mapPolyline.vertexDrag = false }
 
             property int polylineVertex
 

--- a/src/PlanView/CorridorScanMapVisual.qml
+++ b/src/PlanView/CorridorScanMapVisual.qml
@@ -10,6 +10,7 @@ import QGroundControl.FlightMap
 /// Corridor Scan Complex Mission Item visuals
 TransectStyleMapVisuals {
     polygonInteractive: false
+    hideMapPolygon:     mapPolylineVisuals.dragging
 
     property bool _currentItem: object.isCurrentItem
 

--- a/src/PlanView/TransectStyleMapVisuals.qml
+++ b/src/PlanView/TransectStyleMapVisuals.qml
@@ -15,10 +15,12 @@ Item {
     property bool   polygonInteractive: true
     property bool   interactive: true
     property var    vehicle
+    property bool   hideMapPolygon: false
 
     property var    _missionItem:               object
     property var    _mapPolygon:                object.surveyAreaPolygon
     property bool   _currentItem:               object.isCurrentItem
+    property bool   _vertexDrag:                _mapPolygon.vertexDrag || hideMapPolygon
     property var    _transectPoints:            _missionItem.visualTransectPoints
     property int    _transectCount:             _transectPoints.length / (_hasTurnaround ? 4 : 2)
     property bool   _hasTurnaround:             _missionItem.turnAroundDistance.rawValue !== 0
@@ -67,6 +69,7 @@ Item {
         interiorColor:      QGroundControl.globalPalette.surveyPolygonInterior
         altColor:           QGroundControl.globalPalette.surveyPolygonTerrainCollision
         interiorOpacity:    0.5 * _root.opacity
+        visible:            !hideMapPolygon
     }
 
     // Full set of transects lines. Shown when item is selected.
@@ -77,7 +80,7 @@ Item {
             line.color: "white"
             line.width: 2
             path:       _transectPoints
-            visible:    _currentItem
+            visible:    _currentItem && !_vertexDrag
             opacity:    _root.opacity
         }
     }
@@ -90,7 +93,7 @@ Item {
             line.color: "white"
             line.width: 2
             path:       _showPartialEntryExit ? [ _transectPoints[0], _transectPoints[1] ] : []
-            visible:    _showPartialEntryExit
+            visible:    _showPartialEntryExit && !_vertexDrag
             opacity:    _root.opacity
         }
     }
@@ -101,7 +104,7 @@ Item {
             line.color: "white"
             line.width: 2
             path:       _showPartialEntryExit ? [ _transectPoints[_lastPointIndex - 1], _transectPoints[_lastPointIndex] ] : []
-            visible:    _showPartialEntryExit
+            visible:    _showPartialEntryExit && !_vertexDrag
             opacity:    _root.opacity
         }
     }
@@ -115,7 +118,7 @@ Item {
             anchorPoint.y:  sourceItem.anchorPointY
             z:              QGroundControl.zOrderMapItems
             coordinate:     _missionItem.coordinate
-            visible:        _missionItem.exitCoordinate.isValid
+            visible:        _missionItem.exitCoordinate.isValid && !_vertexDrag
             opacity:        _root.opacity
 
             sourceItem: MissionItemIndexLabel {
@@ -133,7 +136,7 @@ Item {
             fromCoord:      _transectPoints[_firstTrueTransectIndex]
             toCoord:        _transectPoints[_firstTrueTransectIndex + 1]
             arrowPosition:  1
-            visible:        _currentItem
+            visible:        _currentItem && !_vertexDrag
             opacity:        _root.opacity
         }
     }
@@ -145,7 +148,7 @@ Item {
             fromCoord:      _transectPoints[nextTrueTransectIndex]
             toCoord:        _transectPoints[nextTrueTransectIndex + 1]
             arrowPosition:  1
-            visible:        _currentItem && _transectCount > 3
+            visible:        _currentItem && _transectCount > 3 && !_vertexDrag
             opacity:        _root.opacity
 
             property int nextTrueTransectIndex: _firstTrueTransectIndex + (_hasTurnaround ? 4 : 2)
@@ -159,7 +162,7 @@ Item {
             fromCoord:      _transectPoints[_lastTrueTransectIndex - 1]
             toCoord:        _transectPoints[_lastTrueTransectIndex]
             arrowPosition:  3
-            visible:        _currentItem
+            visible:        _currentItem && !_vertexDrag
             opacity:        _root.opacity
         }
     }
@@ -171,7 +174,7 @@ Item {
             fromCoord:      _transectPoints[prevTrueTransectIndex - 1]
             toCoord:        _transectPoints[prevTrueTransectIndex]
             arrowPosition:  13
-            visible:        _currentItem && _transectCount > 3
+            visible:        _currentItem && _transectCount > 3 && !_vertexDrag
             opacity:        _root.opacity
 
             property int prevTrueTransectIndex: _lastTrueTransectIndex - (_hasTurnaround ? 4 : 2)
@@ -187,7 +190,7 @@ Item {
             anchorPoint.y:  sourceItem.anchorPointY
             z:              QGroundControl.zOrderMapItems
             coordinate:     _missionItem.exitCoordinate
-            visible:        _missionItem.exitCoordinate.isValid
+            visible:        _missionItem.exitCoordinate.isValid && !_vertexDrag
             opacity:        _root.opacity
 
             sourceItem: MissionItemIndexLabel {

--- a/src/QmlControls/QGCMapPolygon.cc
+++ b/src/QmlControls/QGCMapPolygon.cc
@@ -77,7 +77,11 @@ void QGCMapPolygon::clear(void)
     while (_polygonPath.count() > 1) {
         _polygonPath.takeLast();
     }
-    emit pathChanged();
+    if (_vertexDrag) {
+        emit dragPathChanged();
+    } else {
+        emit pathChanged();
+    }
 
     // Although this code should remove the polygon from the map it doesn't. There appears
     // to be a bug in QGCMapPolygon which causes it to not be redrawn if the list is empty. So
@@ -97,14 +101,20 @@ void QGCMapPolygon::adjustVertex(int vertexIndex, const QGeoCoordinate coordinat
     _polygonPath[vertexIndex] = QVariant::fromValue(coordinate);
     _polygonModel.value<QGCQGeoCoordinate*>(vertexIndex)->setCoordinate(coordinate);
     if (!_centerDrag) {
-        // When dragging center we don't signal path changed until all vertices are updated
         if (!_deferredPathChanged) {
-            // Only update the path once per event loop, to prevent lag-spikes
             _deferredPathChanged = true;
-            QTimer::singleShot(0, this, [this]() {
-                emit pathChanged();
-                _deferredPathChanged = false;
-            });
+            if (_vertexDrag) {
+                // During vertex drag only emit the lightweight visual signal
+                QTimer::singleShot(0, this, [this]() {
+                    emit dragPathChanged();
+                    _deferredPathChanged = false;
+                });
+            } else {
+                QTimer::singleShot(0, this, [this]() {
+                    emit pathChanged();
+                    _deferredPathChanged = false;
+                });
+            }
         }
     }
     setDirty(true);
@@ -275,7 +285,11 @@ void QGCMapPolygon::appendVertex(const QGeoCoordinate& coordinate)
         // Only update the path once per event loop, to prevent lag-spikes
         _deferredPathChanged = true;
         QTimer::singleShot(0, this, [this]() {
-            emit pathChanged();
+            if (_vertexDrag) {
+                emit dragPathChanged();
+            } else {
+                emit pathChanged();
+            }
             _deferredPathChanged = false;
         });
     }
@@ -293,7 +307,11 @@ void QGCMapPolygon::appendVertices(const QList<QGeoCoordinate>& coordinates)
     _polygonModel.append(objects);
     endReset();
 
-    emit pathChanged();
+    if (_vertexDrag) {
+        emit dragPathChanged();
+    } else {
+        emit pathChanged();
+    }
 }
 
 void QGCMapPolygon::appendVertices(const QVariantList& varCoords)
@@ -376,28 +394,28 @@ void QGCMapPolygon::setCenter(QGeoCoordinate newCenter)
             adjustVertex(i, newVertex);
         }
 
+        _ignoreCenterUpdates = false;
+        _center = newCenter;
+
         if (_centerDrag) {
-            // When center dragging, signals from adjustVertext are not sent. So we need to signal here when all adjusting is complete.
+            // During center drag emit lightweight visual signals only
             if (!_deferredPathChanged) {
-                // Only update the path once per event loop, to prevent lag-spikes
                 _deferredPathChanged = true;
                 QTimer::singleShot(0, this, [this]() {
-                    emit pathChanged();
+                    emit dragPathChanged();
+                    emit dragCenterChanged(_center);
                     _deferredPathChanged = false;
                 });
             }
-        }
-
-        _ignoreCenterUpdates = false;
-
-        _center = newCenter;
-        if (!_deferredPathChanged) {
-            // Only update the center once per event loop, to prevent lag-spikes
-            _deferredPathChanged = true;
-            QTimer::singleShot(0, this, [this, newCenter]() {
-                emit centerChanged(newCenter);
-                _deferredPathChanged = false;
-            });
+        } else {
+            if (!_deferredPathChanged) {
+                _deferredPathChanged = true;
+                QTimer::singleShot(0, this, [this]() {
+                    emit pathChanged();
+                    emit centerChanged(_center);
+                    _deferredPathChanged = false;
+                });
+            }
         }
     }
 }
@@ -406,7 +424,27 @@ void QGCMapPolygon::setCenterDrag(bool centerDrag)
 {
     if (centerDrag != _centerDrag) {
         _centerDrag = centerDrag;
+        if (!centerDrag) {
+            // Drag ended. Center edits do not use vertexDrag, so emit pathChanged here.
+            // For interactive center drag, setVertexDrag(false) emits pathChanged.
+            if (!_vertexDrag) {
+                emit pathChanged();
+            }
+            emit centerChanged(_center);
+        }
         emit centerDragChanged(centerDrag);
+    }
+}
+
+void QGCMapPolygon::setVertexDrag(bool vertexDrag)
+{
+    if (_vertexDrag != vertexDrag) {
+        _vertexDrag = vertexDrag;
+        if (!vertexDrag) {
+            // Drag ended - signal path changed so downstream can recalculate
+            emit pathChanged();
+        }
+        emit vertexDragChanged(vertexDrag);
     }
 }
 

--- a/src/QmlControls/QGCMapPolygon.h
+++ b/src/QmlControls/QGCMapPolygon.h
@@ -27,11 +27,14 @@ public:
 
     Q_PROPERTY(int                  count           READ count                                  NOTIFY countChanged)
     Q_PROPERTY(QVariantList         path            READ path                                   NOTIFY pathChanged)
+    Q_PROPERTY(QVariantList         dragPath        READ path                                   NOTIFY dragPathChanged)
     Q_PROPERTY(double               area            READ area                                   NOTIFY pathChanged)
     Q_PROPERTY(QmlObjectListModel*  pathModel       READ qmlPathModel                           CONSTANT)
     Q_PROPERTY(bool                 dirty           READ dirty          WRITE setDirty          NOTIFY dirtyChanged)
     Q_PROPERTY(QGeoCoordinate       center          READ center         WRITE setCenter         NOTIFY centerChanged)
+    Q_PROPERTY(QGeoCoordinate       dragCenter      READ center                                 NOTIFY dragCenterChanged)
     Q_PROPERTY(bool                 centerDrag      READ centerDrag     WRITE setCenterDrag     NOTIFY centerDragChanged)
+    Q_PROPERTY(bool                 vertexDrag      READ vertexDrag     WRITE setVertexDrag     NOTIFY vertexDragChanged)
     Q_PROPERTY(bool                 interactive     READ interactive    WRITE setInteractive    NOTIFY interactiveChanged)
     Q_PROPERTY(bool                 isValid         READ isValid                                NOTIFY isValidChanged)
     Q_PROPERTY(bool                 empty           READ empty                                  NOTIFY isEmptyChanged)
@@ -102,6 +105,7 @@ public:
     void            setDirty    (bool dirty);
     QGeoCoordinate  center      (void) const { return _center; }
     bool            centerDrag  (void) const { return _centerDrag; }
+    bool            vertexDrag  (void) const { return _vertexDrag; }
     bool            interactive (void) const { return _interactive; }
     bool            isValid     (void) const { return _polygonModel.count() >= 3; }
     bool            empty       (void) const { return _polygonModel.count() == 0; }
@@ -117,6 +121,7 @@ public:
     void setPath        (const QVariantList& path);
     void setCenter      (QGeoCoordinate newCenter);
     void setCenterDrag  (bool centerDrag);
+    void setVertexDrag  (bool vertexDrag);
     void setInteractive (bool interactive);
     void setTraceMode   (bool traceMode);
     void setShowAltColor(bool showAltColor);
@@ -127,10 +132,13 @@ public:
 signals:
     void countChanged       (int count);
     void pathChanged        (void);
+    void dragPathChanged    (void);
     void dirtyChanged       (bool dirty);
     void cleared            (void);
     void centerChanged      (QGeoCoordinate center);
+    void dragCenterChanged  (QGeoCoordinate center);
     void centerDragChanged  (bool centerDrag);
+    void vertexDragChanged  (bool vertexDrag);
     void interactiveChanged (bool interactive);
     bool isValidChanged     (void);
     bool isEmptyChanged     (void);
@@ -154,6 +162,7 @@ private:
     bool                _dirty =                false;
     QGeoCoordinate      _center;
     bool                _centerDrag =           false;
+    bool                _vertexDrag =           false;
     bool                _ignoreCenterUpdates =  false;
     bool                _interactive =          false;
     bool                _traceMode =            false;

--- a/src/QmlControls/QGCMapPolyline.cc
+++ b/src/QmlControls/QGCMapPolyline.cc
@@ -79,10 +79,18 @@ void QGCMapPolyline::adjustVertex(int vertexIndex, const QGeoCoordinate coordina
     _polylineModel.value<QGCQGeoCoordinate*>(vertexIndex)->setCoordinate(coordinate);
     if (!_deferredPathChanged) {
         _deferredPathChanged = true;
-        QTimer::singleShot(0, this, [this]() {
-            emit pathChanged();
-            _deferredPathChanged = false;
-        });
+        if (_vertexDrag) {
+            // During vertex drag only emit the lightweight visual signal
+            QTimer::singleShot(0, this, [this]() {
+                emit dragPathChanged();
+                _deferredPathChanged = false;
+            });
+        } else {
+            QTimer::singleShot(0, this, [this]() {
+                emit pathChanged();
+                _deferredPathChanged = false;
+            });
+        }
     }
     setDirty(true);
 }
@@ -259,6 +267,18 @@ void QGCMapPolyline::setInteractive(bool interactive)
     if (_interactive != interactive) {
         _interactive = interactive;
         emit interactiveChanged(interactive);
+    }
+}
+
+void QGCMapPolyline::setVertexDrag(bool vertexDrag)
+{
+    if (_vertexDrag != vertexDrag) {
+        _vertexDrag = vertexDrag;
+        if (!vertexDrag) {
+            // Drag ended - signal path changed so downstream can recalculate
+            emit pathChanged();
+        }
+        emit vertexDragChanged(vertexDrag);
     }
 }
 

--- a/src/QmlControls/QGCMapPolyline.h
+++ b/src/QmlControls/QGCMapPolyline.h
@@ -20,9 +20,11 @@ public:
 
     Q_PROPERTY(int                  count       READ count                                  NOTIFY countChanged)
     Q_PROPERTY(QVariantList         path        READ path                                   NOTIFY pathChanged)
+    Q_PROPERTY(QVariantList         dragPath    READ path                                   NOTIFY dragPathChanged)
     Q_PROPERTY(QmlObjectListModel*  pathModel   READ qmlPathModel                           CONSTANT)
     Q_PROPERTY(bool                 dirty       READ dirty          WRITE setDirty          NOTIFY dirtyChanged)
     Q_PROPERTY(bool                 interactive READ interactive    WRITE setInteractive    NOTIFY interactiveChanged)
+    Q_PROPERTY(bool                 vertexDrag  READ vertexDrag     WRITE setVertexDrag     NOTIFY vertexDragChanged)
     Q_PROPERTY(bool                 isValid     READ isValid                                NOTIFY isValidChanged)
     Q_PROPERTY(bool                 empty       READ empty                                  NOTIFY isEmptyChanged)
     Q_PROPERTY(bool                 traceMode   READ traceMode      WRITE setTraceMode      NOTIFY traceModeChanged)
@@ -80,6 +82,7 @@ public:
     bool            dirty       (void) const { return _dirty; }
     void            setDirty    (bool dirty);
     bool            interactive (void) const { return _interactive; }
+    bool            vertexDrag  (void) const { return _vertexDrag; }
     QVariantList    path        (void) const { return _polylinePath; }
     bool            isValid     (void) const { return _polylineModel.count() >= 2; }
     bool            empty       (void) const { return _polylineModel.count() == 0; }
@@ -92,6 +95,7 @@ public:
     void setPath        (const QList<QGeoCoordinate>& path);
     void setPath        (const QVariantList& path);
     void setInteractive (bool interactive);
+    void setVertexDrag  (bool vertexDrag);
     void setTraceMode   (bool traceMode);
     void selectVertex   (int index);
 
@@ -100,9 +104,11 @@ public:
 signals:
     void countChanged       (int count);
     void pathChanged        (void);
+    void dragPathChanged    (void);
     void dirtyChanged       (bool dirty);
     void cleared            (void);
     void interactiveChanged (bool interactive);
+    void vertexDragChanged  (bool vertexDrag);
     void isValidChanged     (void);
     void isEmptyChanged     (void);
     void traceModeChanged   (bool traceMode);
@@ -122,6 +128,7 @@ private:
     bool                _deferredPathChanged = false;
     bool                _dirty;
     bool                _interactive;
+    bool                _vertexDrag = false;
     bool                _traceMode = false;
     int                 _selectedVertexIndex = -1;
 };


### PR DESCRIPTION
Fixes #13011

## Summary

Introduces a dual-signal architecture for `QGCMapPolygon` and `QGCMapPolyline` that emits lightweight `dragPathChanged` signals during interactive vertex/center/radius drag instead of `pathChanged`, deferring expensive downstream recalculations (transect rebuilds, terrain queries) until the drag ends.

## Changes

### C++ (QGCMapPolygon / QGCMapPolyline)
- New `vertexDrag` bool property to indicate an interactive drag is in progress
- New `dragPath` / `dragCenter` Q_PROPERTYs that share the same READ accessor but use separate NOTIFY signals (`dragPathChanged` / `dragCenterChanged`)
- `adjustVertex`, `appendVertex`, `appendVertices`, `clear`, `setCenter` route signals through the appropriate path based on `vertexDrag` state
- `setVertexDrag(false)` emits a final `pathChanged` to trigger recomputation

### QML Visuals
- **QGCMapPolygonVisuals**: orange border during drag, path bound to `dragPath` during drag, hide split/center handles during vertex drag, edge length labels update via `dragPathChanged`, center drag handle bound to `dragCenter`, center click opens context menu, new Set Radius dialog with unit conversion
- **QGCMapPolylineVisuals**: orange line during drag, path bound to `dragPath`, hide split handles, edge length labels during drag
- **TransectStyleMapVisuals**: hide transect lines/arrows/entry+exit points during drag
- **CorridorScanMapVisual**: hide corridor polygon during polyline drag

### Circle mode improvements
- Radius handle hides during center drag
- Radius drag participates in `vertexDrag` state (polygon updates visually during drag)
- Radius handle tracks mouse while polygon rebuild is debounced
- Center handle click opens context menu
- Set Radius menu item opens a working dialog with unit conversion
