### PR TITLE
Fix PID tuning sliders showing wrong params for each axis

### DIFF
--- a/src/QmlControls/PIDTuning.qml
+++ b/src/QmlControls/PIDTuning.qml
@@ -333,13 +333,16 @@ RowLayout {
                 model: axis
 
                 Repeater {
+                    id: paramRepeater
                     model: axis[index].params
+
+                    property int axisIndex: index
 
                     SettingsGroupLayout {
                         id:                     tuningGroup
                         heading:                title
                         headingDescription:     description
-                        visible:                _currentAxis === index
+                        visible:                _currentAxis === paramRepeater.axisIndex
                         Layout.preferredWidth:  ScreenTools.defaultFontPixelWidth * 40
 
                         FactSlider {


### PR DESCRIPTION
The nested Repeaters in PIDTuning.qml had an index shadowing bug. The inner Repeater's delegate used `index` for the visibility check, but inside the inner Repeater `index` refers to the parameter index rather than the outer axis index. This caused each axis tab to show one wrong parameter from across all axes instead of all parameters for the selected axis.

Store the outer axis index in a property on the inner Repeater and reference that property in the visibility binding.

Fixes #13351