### PR TITLE
FlyView: Add left margin to MapScale from toolstrip

### DIFF
--- a/src/FlyView/FlyViewMap.qml
+++ b/src/FlyView/FlyViewMap.qml
@@ -775,8 +775,5 @@ FlightMap {
         anchors.top:        parent.top
         mapControl:         _root
         visible:            !ScreenTools.isTinyScreen && QGroundControl.corePlugin.options.flyView.showMapScale && mapControl.pipState.state === mapControl.pipState.windowState
-
-        property real centerInset: visible ? parent.height - y : 0
     }
-
 }

--- a/src/FlyView/FlyViewWidgetLayer.qml
+++ b/src/FlyView/FlyViewWidgetLayer.qml
@@ -166,6 +166,7 @@ Item {
     MapScale {
         id:                 mapScale
         anchors.left:       toolStrip.right
+        anchors.leftMargin: _toolsMargin
         anchors.top:        parent.top
         mapControl:         _mapControl
         autoHide:           true


### PR DESCRIPTION
Adds a left margin (`_toolsMargin`) to the MapScale widget so it has proper spacing from the FlyViewToolStrip instead of being flush against it.

Also removes unused `centerInset` property from the pip-mode MapScale in FlyViewMap.

Fixes #13526