### PR TITLE
EditPositionDialog: refactor and add altitude support

### DIFF
--- a/src/FlyView/FlyViewMap.qml
+++ b/src/FlyView/FlyViewMap.qml
@@ -651,7 +651,7 @@ FlightMap {
                         Layout.fillWidth:   true
                         text:               qsTr("Edit Position")
                         onClicked: {
-                            roiEditPositionDialogFactory.open({ showSetPositionFromVehicle: false })
+                            roiEditPositionDialogFactory.open()
                             roiEditDropPanel.close()
                         }
                     }

--- a/src/PlanView/MissionItemEditor.qml
+++ b/src/PlanView/MissionItemEditor.qml
@@ -74,8 +74,14 @@ Rectangle {
         id: editPositionDialog
 
         EditPositionDialog {
-            coordinate:             missionItem.isSurveyItem ?  missionItem.centerCoordinate : missionItem.coordinate
-            onCoordinateChanged:    missionItem.isSurveyItem ?  missionItem.centerCoordinate = coordinate : missionItem.coordinate = coordinate
+            property bool _editCenterCoordinate: false
+
+            onCoordinateChanged: {
+                if (_editCenterCoordinate)
+                    missionItem.centerCoordinate = coordinate
+                else
+                    missionItem.coordinate = coordinate
+            }
         }
     }
 
@@ -228,7 +234,13 @@ Rectangle {
                         text:               qsTr("Edit position...")
                         enabled:            missionItem.specifiesCoordinate
                         onClicked: {
-                            editPositionDialogFactory.open()
+                            const editCenterCoordinate = missionItem.isSurveyItem
+                            editPositionDialogFactory.open({
+                                _editCenterCoordinate:   editCenterCoordinate,
+                                coordinate:              editCenterCoordinate ? missionItem.centerCoordinate : missionItem.coordinate,
+                                altitudeFact:            !editCenterCoordinate && missionItem.specifiesAltitude ? missionItem.altitude : null,
+                                altitudeFrame:           !editCenterCoordinate && missionItem.specifiesAltitude ? missionItem.altitudeFrame : QGroundControl.AltitudeFrameNone,
+                            })
                             hamburgerMenuDropPanel.close()
                         }
                     }

--- a/src/QmlControls/EditPositionDialog.qml
+++ b/src/QmlControls/EditPositionDialog.qml
@@ -12,8 +12,9 @@ QGCPopupDialog {
     title:      qsTr("Edit Position")
     buttons:    Dialog.Close
 
-    property alias coordinate:                  controller.coordinate
-    property bool  showSetPositionFromVehicle:  true
+    property alias coordinate:      controller.coordinate
+    property var    altitudeFact:   null
+    property int    altitudeFrame:  QGroundControl.AltitudeFrameNone
 
     property real _margin:          ScreenTools.defaultFontPixelWidth / 2
     property real _textFieldWidth:  ScreenTools.defaultFontPixelWidth * 20
@@ -21,6 +22,12 @@ QGCPopupDialog {
     property bool _showUTM:         coordinateSystemCombo.comboBox.currentIndex === 1
     property bool _showMGRS:        coordinateSystemCombo.comboBox.currentIndex === 2
     property bool _showVehicle:     coordinateSystemCombo.comboBox.currentIndex === 3
+    property bool _supportsAltitude: altitudeFact !== null
+
+    function _isFiniteAltitude(value) {
+        const numericValue = Number(value)
+        return !isNaN(numericValue) && isFinite(numericValue)
+    }
 
     TransformPositionController {
         id: controller
@@ -35,7 +42,7 @@ QGCPopupDialog {
             id:                 coordinateSystemCombo
             Layout.fillWidth:   true
             label:              qsTr("Coordinate System")
-            model:              showSetPositionFromVehicle && globals.activeVehicle ?
+            model:              globals.activeVehicle ?
                                     [ qsTr("Geographic"), qsTr("Universal Transverse Mercator"), qsTr("Military Grid Reference"), qsTr("Vehicle Position") ] :
                                     [ qsTr("Geographic"), qsTr("Universal Transverse Mercator"), qsTr("Military Grid Reference") ]
         }
@@ -54,16 +61,6 @@ QGCPopupDialog {
             textFieldPreferredWidth: _textFieldWidth
             Layout.fillWidth:   true
             visible:            _showGeographic
-        }
-
-        LabelledButton {
-            label:               qsTr("Set position")
-            buttonText:          qsTr("Move")
-            visible:             _showGeographic
-            onClicked: {
-                controller.setFromGeo()
-                root.close()
-            }
         }
 
         LabelledFactTextField {
@@ -98,16 +95,6 @@ QGCPopupDialog {
             visible:            _showUTM
         }
 
-        LabelledButton {
-            label:               qsTr("Set position")
-            buttonText:          qsTr("Move")
-            visible:             _showUTM
-            onClicked: {
-                controller.setFromUTM()
-                root.close()
-            }
-        }
-
         LabelledFactTextField {
             label:              qsTr("MGRS")
             fact:               controller.mgrs
@@ -116,22 +103,82 @@ QGCPopupDialog {
             Layout.fillWidth:   true
         }
 
-        LabelledButton {
-            label:               qsTr("Set position")
-            buttonText:          qsTr("Move")
-            visible:             _showMGRS
-            onClicked: {
-                controller.setFromMGRS()
-                root.close()
-            }
+        LabelledLabel {
+            label:              qsTr("Latitude")
+            labelText:          globals.activeVehicle ? globals.activeVehicle.coordinate.latitude.toFixed(7) : ""
+            Layout.fillWidth:   true
+            visible:            _showVehicle
+        }
+
+        LabelledLabel {
+            label:              qsTr("Longitude")
+            labelText:          globals.activeVehicle ? globals.activeVehicle.coordinate.longitude.toFixed(7) : ""
+            Layout.fillWidth:   true
+            visible:            _showVehicle
+        }
+
+        LabelledLabel {
+            label:              qsTr("Alt (AMSL)")
+            labelText:          globals.activeVehicle ? globals.activeVehicle.altitudeAMSL.valueString + " " + globals.activeVehicle.altitudeAMSL.units : ""
+            Layout.fillWidth:   true
+            visible:            _showVehicle && _supportsAltitude && altitudeFrame === QGroundControl.AltitudeFrameAbsolute
+        }
+
+        LabelledLabel {
+            label:              qsTr("Alt (Rel)")
+            labelText:          globals.activeVehicle ? globals.activeVehicle.altitudeRelative.valueString + " " + globals.activeVehicle.altitudeRelative.units : ""
+            Layout.fillWidth:   true
+            visible:            _showVehicle && _supportsAltitude && altitudeFrame === QGroundControl.AltitudeFrameRelative
+        }
+
+        LabelledLabel {
+            label:              qsTr("Alt (AGL)")
+            labelText:          globals.activeVehicle ? globals.activeVehicle.altitudeAboveTerr.valueString + " " + globals.activeVehicle.altitudeAboveTerr.units : ""
+            Layout.fillWidth:   true
+            visible:            _showVehicle && _supportsAltitude && (altitudeFrame === QGroundControl.AltitudeFrameTerrain || altitudeFrame === QGroundControl.AltitudeFrameCalcAboveTerrain)
+        }
+
+        QGCCheckBox {
+            id:         setPositionCheckBox
+            text:       qsTr("Set position from vehicle")
+            checked:    true
+            visible:    _showVehicle
+        }
+
+        QGCCheckBox {
+            id:         setAltitudeCheckBox
+            text:       qsTr("Set altitude from vehicle")
+            checked:    false
+            visible:    _showVehicle && _supportsAltitude
         }
 
         LabelledButton {
             label:               qsTr("Set position")
             buttonText:          qsTr("Move")
-            visible:             _showVehicle
             onClicked: {
-                controller.setFromVehicle()
+                if (_showGeographic)
+                    controller.setFromGeo()
+                else if (_showUTM)
+                    controller.setFromUTM()
+                else if (_showMGRS)
+                    controller.setFromMGRS()
+                else if (_showVehicle) {
+                    if (setPositionCheckBox.checked)
+                        controller.setFromVehicle()
+                    if (setAltitudeCheckBox.checked && _supportsAltitude && globals.activeVehicle) {
+                        let sourceAltitude = NaN
+
+                        if (altitudeFrame === QGroundControl.AltitudeFrameRelative)
+                            sourceAltitude = globals.activeVehicle.altitudeRelative.rawValue
+                        else if (altitudeFrame === QGroundControl.AltitudeFrameAbsolute)
+                            sourceAltitude = globals.activeVehicle.altitudeAMSL.rawValue
+                        else if (altitudeFrame === QGroundControl.AltitudeFrameTerrain || altitudeFrame === QGroundControl.AltitudeFrameCalcAboveTerrain)
+                            sourceAltitude = globals.activeVehicle.altitudeAboveTerr.rawValue
+
+                        if (_isFiniteAltitude(sourceAltitude))
+                            altitudeFact.rawValue = sourceAltitude
+                    }
+                }
                 root.close()
             }
         }


### PR DESCRIPTION
## Summary

Refactors EditPositionDialog to support setting mission item altitude from vehicle telemetry, with frame-aware altitude source selection.

Fixes #13926

## Changes

### EditPositionDialog.qml
- Replace `showSetPositionFromVehicle` with `altitudeFact` and `altitudeFrame` properties
- Show vehicle altitude matching the mission item's altitude frame (AMSL, Relative, AGL)
- Add separate checkboxes for setting position and altitude from vehicle
- Consolidate per-tab Move buttons into a single button
- Guard against writing NaN/invalid vehicle altitude into mission items
- Hide vehicle altitude display when altitude editing is not supported

### MissionItemEditor.qml
- Resolve `isSurveyItem` at button-click time instead of in declarative bindings, eliminating Qt non-bindable property warnings
- Pass altitude fact and frame to EditPositionDialog when opening

### FlyViewMap.qml
- Remove obsolete `showSetPositionFromVehicle` parameter from ROI edit dialog
