### PR TITLE
Support ArduPilot 4.7 parameter renames

### DIFF
--- a/src/AutoPilotPlugins/APM/APMFlightModesComponent.qml
+++ b/src/AutoPilotPlugins/APM/APMFlightModesComponent.qml
@@ -204,7 +204,7 @@ SetupPage {
                                 FactComboBox {
                                     id:         optCombo
                                     width:      ScreenTools.defaultFontPixelWidth * 15
-                                    fact:       controller.getParameterFact(-1, "r.RC" + index + "_OPTION")
+                                    fact:       controller.getParameterFact(-1, "RC" + index + "_OPTION")
                                     indexModel: false
                                 }
                             }

--- a/src/AutoPilotPlugins/APM/APMFollowComponent.qml
+++ b/src/AutoPilotPlugins/APM/APMFollowComponent.qml
@@ -368,7 +368,7 @@ SetupPage {
                             transform: Rotation {
                                 origin.x:       vehicleIcon.width  / 2
                                 origin.y:       vehicleIcon.height / 2
-                                angle:          _roverFirmware ? 0 :
+                                angle:          _roverFirmware || !_followYawBehavior ? 0 :
                                                                  (_followYawBehavior.rawValue == _followYawBehaviorNone ?
                                                                       0 :
                                                                       (_followYawBehavior.rawValue == _followYawBehaviorFace ?

--- a/src/AutoPilotPlugins/APM/APMPowerComponent.qml
+++ b/src/AutoPilotPlugins/APM/APMPowerComponent.qml
@@ -111,8 +111,8 @@ SetupPage {
                         anchors.left:       parent.left
                         sourceComponent:    _batt1FullSettings.visible ? powerSetupComponent : undefined
 
-                        property Fact armVoltMin:       controller.getParameterFact(-1, "r.BATT_ARM_VOLT", false /* reportMissing */)
-                        property Fact battAmpPerVolt:   controller.getParameterFact(-1, "r.BATT_AMP_PERVLT", false /* reportMissing */)
+                        property Fact armVoltMin:       controller.getParameterFact(-1, "BATT_ARM_VOLT", false /* reportMissing */)
+                        property Fact battAmpPerVolt:   controller.getParameterFact(-1, "BATT_AMP_PERVLT", false /* reportMissing */)
                         property Fact battAmpOffset:    controller.getParameterFact(-1, "BATT_AMP_OFFSET", false /* reportMissing */)
                         property Fact battCapacity:     controller.getParameterFact(-1, "BATT_CAPACITY", false /* reportMissing */)
                         property Fact battCurrPin:      controller.getParameterFact(-1, "BATT_CURR_PIN", false /* reportMissing */)
@@ -198,8 +198,8 @@ SetupPage {
                         anchors.left:       parent.left
                         sourceComponent:    batt2FullSettings.visible ? powerSetupComponent : undefined
 
-                        property Fact armVoltMin:       controller.getParameterFact(-1, "r.BATT2_ARM_VOLT", false /* reportMissing */)
-                        property Fact battAmpPerVolt:   controller.getParameterFact(-1, "r.BATT2_AMP_PERVLT", false /* reportMissing */)
+                        property Fact armVoltMin:       controller.getParameterFact(-1, "BATT2_ARM_VOLT", false /* reportMissing */)
+                        property Fact battAmpPerVolt:   controller.getParameterFact(-1, "BATT2_AMP_PERVLT", false /* reportMissing */)
                         property Fact battAmpOffset:    controller.getParameterFact(-1, "BATT2_AMP_OFFSET", false /* reportMissing */)
                         property Fact battCapacity:     controller.getParameterFact(-1, "BATT2_CAPACITY", false /* reportMissing */)
                         property Fact battCurrPin:      controller.getParameterFact(-1, "BATT2_CURR_PIN", false /* reportMissing */)

--- a/src/AutoPilotPlugins/APM/APMSafetyComponent.qml
+++ b/src/AutoPilotPlugins/APM/APMSafetyComponent.qml
@@ -325,9 +325,9 @@ SetupPage {
                     spacing: _margins / 2
 
                     property Fact _failsafeGCSEnable:               controller.getParameterFact(-1, "FS_GCS_ENABLE")
-                    property Fact _failsafeBattLowAct:              controller.getParameterFact(-1, "r.BATT_FS_LOW_ACT", false /* reportMissing */)
-                    property Fact _failsafeBattMah:                 controller.getParameterFact(-1, "r.BATT_LOW_MAH", false /* reportMissing */)
-                    property Fact _failsafeBattVoltage:             controller.getParameterFact(-1, "r.BATT_LOW_VOLT", false /* reportMissing */)
+                    property Fact _failsafeBattLowAct:              controller.getParameterFact(-1, "BATT_FS_LOW_ACT", false /* reportMissing */)
+                    property Fact _failsafeBattMah:                 controller.getParameterFact(-1, "BATT_LOW_MAH", false /* reportMissing */)
+                    property Fact _failsafeBattVoltage:             controller.getParameterFact(-1, "BATT_LOW_VOLT", false /* reportMissing */)
                     property Fact _failsafeThrEnable:               controller.getParameterFact(-1, "FS_THR_ENABLE")
                     property Fact _failsafeThrValue:                controller.getParameterFact(-1, "FS_THR_VALUE")
 
@@ -524,10 +524,12 @@ SetupPage {
                 Column {
                     spacing: _margins / 2
 
-                    property Fact _landSpeedFact:   controller.getParameterFact(-1, "LAND_SPEED")
-                    property Fact _rtlAltFact:      controller.getParameterFact(-1, "RTL_ALT")
+                    property Fact _landSpeedFact:   controller.getParameterFact(-1, "LAND_SPD_MS")
+                    property Fact _rtlAltFact:      controller.getParameterFact(-1, "RTL_ALT_M")
                     property Fact _rtlLoitTimeFact: controller.getParameterFact(-1, "RTL_LOIT_TIME")
-                    property Fact _rtlAltFinalFact: controller.getParameterFact(-1, "RTL_ALT_FINAL")
+                    property Fact _rtlAltFinalFact: controller.getParameterFact(-1, "RTL_ALT_FINAL_M")
+                    // RTL_ALT_M (4.7+) is in meters, RTL_ALT (pre-4.7) is in centimeters
+                    property bool _rtlAltIsMeters:  controller.parameterExists(-1, "noremap.RTL_ALT_M")
 
                     QGCLabel {
                         id:             rtlLabel
@@ -575,7 +577,8 @@ SetupPage {
                             text:               qsTr("Return at specified altitude:")
                             checked:            _rtlAltFact.value != 0
 
-                            onClicked: _rtlAltFact.value = 1500
+                            // RTL_ALT_M (4.7+) is in meters, RTL_ALT (pre-4.7) is in centimeters
+                            onClicked: _rtlAltFact.value = _rtlAltIsMeters ? 15 : 1500
                         }
 
                         FactTextField {
@@ -651,7 +654,7 @@ SetupPage {
                 Column {
                     spacing: _margins / 2
 
-                    property Fact _rtlAltFact: controller.getParameterFact(-1, "r.RTL_ALTITUDE")
+                    property Fact _rtlAltFact: controller.getParameterFact(-1, "RTL_ALTITUDE")
 
                     QGCLabel {
                         text:           qsTr("Return to Launch")

--- a/src/AutoPilotPlugins/APM/APMSafetyComponentSub.qml
+++ b/src/AutoPilotPlugins/APM/APMSafetyComponentSub.qml
@@ -24,7 +24,7 @@ SetupPage {
             property bool _firmware34:       globals.activeVehicle.versionCompare(3, 5, 0) < 0
 
             // Enable/Action parameters
-            property Fact _failsafeBatteryEnable:     controller.getParameterFact(-1, "r.BATT_FS_LOW_ACT", false)
+            property Fact _failsafeBatteryEnable:     controller.getParameterFact(-1, "BATT_FS_LOW_ACT", false)
             property Fact _failsafeEKFEnable:         controller.getParameterFact(-1, "FS_EKF_ACTION")
             property Fact _failsafeGCSEnable:         controller.getParameterFact(-1, "FS_GCS_ENABLE")
             property Fact _failsafeLeakEnable:        controller.getParameterFact(-1, "FS_LEAK_ENABLE")
@@ -39,9 +39,9 @@ SetupPage {
             property Fact _failsafeLeakPin:              controller.getParameterFact(-1, "LEAK1_PIN")
             property Fact _failsafeLeakLogic:            controller.getParameterFact(-1, "LEAK1_LOGIC")
             property Fact _failsafeEKFThreshold:         controller.getParameterFact(-1, "FS_EKF_THRESH")
-            property Fact _failsafeBatteryVoltage:       controller.getParameterFact(-1, "r.BATT_LOW_VOLT", false)
-            property Fact _failsafeBatteryCapacity:      controller.getParameterFact(-1, "r.BATT_LOW_MAH", false)
-            property bool _batteryDetected:              controller.parameterExists(-1, "r.BATT_LOW_MAH")
+            property Fact _failsafeBatteryVoltage:       controller.getParameterFact(-1, "BATT_LOW_VOLT", false)
+            property Fact _failsafeBatteryCapacity:      controller.getParameterFact(-1, "BATT_LOW_MAH", false)
+            property bool _batteryDetected:              controller.parameterExists(-1, "BATT_LOW_MAH")
 
             // Older firmwares use ARMING_CHECK. Newer firmwares use ARMING_SKIPCHK.
             property Fact _armingCheck:     controller.getParameterFact(-1, "ARMING_CHECK", false /* reportMissing */)

--- a/src/AutoPilotPlugins/APM/APMSafetyComponentSummary.qml
+++ b/src/AutoPilotPlugins/APM/APMSafetyComponentSummary.qml
@@ -23,7 +23,7 @@ Item {
     property bool _batt1MonitorEnabled:     _batt1Monitor.rawValue !== 0
     property bool _batt2MonitorEnabled:     _batt2MonitorAvailable && _batt2Monitor.rawValue !== 0
 
-    property Fact _batt1FSLowAct:           controller.getParameterFact(-1, "r.BATT_FS_LOW_ACT", false /* reportMissing */)
+    property Fact _batt1FSLowAct:           controller.getParameterFact(-1, "BATT_FS_LOW_ACT", false /* reportMissing */)
     property Fact _batt1FSCritAct:          controller.getParameterFact(-1, "BATT_FS_CRT_ACT", false /* reportMissing */)
     property Fact _batt2FSLowAct:           controller.getParameterFact(-1, "BATT2_FS_LOW_ACT", false /* reportMissing */)
     property Fact _batt2FSCritAct:          controller.getParameterFact(-1, "BATT2_FS_CRT_ACT", false /* reportMissing */)
@@ -150,7 +150,7 @@ Item {
             valueText:  fact ? (fact.value == 0 ? qsTr("current") : fact.valueString + " " + fact.units) : ""
             visible:    controller.vehicle.multiRotor
 
-            property Fact fact: controller.getParameterFact(-1, "RTL_ALT", false /* reportMissing */)
+            property Fact fact: controller.getParameterFact(-1, "RTL_ALT_M", false /* reportMissing */)
         }
 
         VehicleSummaryRow {
@@ -158,7 +158,7 @@ Item {
             valueText:  fact ? (fact.value < 0 ? qsTr("current") : fact.valueString + " " + fact.units) : ""
             visible:    controller.vehicle.fixedWing
 
-            property Fact fact: controller.getParameterFact(-1, "r.RTL_ALTITUDE", false /* reportMissing */)
+            property Fact fact: controller.getParameterFact(-1, "RTL_ALTITUDE", false /* reportMissing */)
         }
     }
 }

--- a/src/AutoPilotPlugins/APM/APMSafetyComponentSummarySub.qml
+++ b/src/AutoPilotPlugins/APM/APMSafetyComponentSummarySub.qml
@@ -13,7 +13,7 @@ Item {
     FactPanelController { id: controller; }
 
     // Enable/Action parameters
-    property Fact _failsafeBatteryEnable:     controller.getParameterFact(-1, "r.BATT_FS_LOW_ACT", false)
+    property Fact _failsafeBatteryEnable:     controller.getParameterFact(-1, "BATT_FS_LOW_ACT", false)
     property Fact _failsafeEKFEnable:         controller.getParameterFact(-1, "FS_EKF_ACTION")
     property Fact _failsafeGCSEnable:         controller.getParameterFact(-1, "FS_GCS_ENABLE")
     property Fact _failsafeLeakEnable:        controller.getParameterFact(-1, "FS_LEAK_ENABLE")
@@ -28,8 +28,8 @@ Item {
     property Fact _failsafeLeakPin:              controller.getParameterFact(-1, "LEAK1_PIN")
     property Fact _failsafeLeakLogic:            controller.getParameterFact(-1, "LEAK1_LOGIC")
     property Fact _failsafeEKFThreshold:         controller.getParameterFact(-1, "FS_EKF_THRESH")
-    property Fact _failsafeBatteryVoltage:       controller.getParameterFact(-1, "r.BATT_LOW_VOLT", false)
-    property Fact _failsafeBatteryCapacity:      controller.getParameterFact(-1, "r.BATT_LOW_MAH", false)
+    property Fact _failsafeBatteryVoltage:       controller.getParameterFact(-1, "BATT_LOW_VOLT", false)
+    property Fact _failsafeBatteryCapacity:      controller.getParameterFact(-1, "BATT_LOW_MAH", false)
 
     // Older firmwares use ARMING_CHECK. Newer firmwares use ARMING_SKIPCHK.
     property Fact _armingCheck:     controller.getParameterFact(-1, "ARMING_CHECK", false /* reportMissing */)

--- a/src/AutoPilotPlugins/APM/APMTuningComponentCopter.qml
+++ b/src/AutoPilotPlugins/APM/APMTuningComponentCopter.qml
@@ -24,17 +24,17 @@ SetupPage {
             property Fact _rateRollI:           controller.getParameterFact(-1, "ATC_RAT_RLL_I")
             property Fact _ratePitchP:          controller.getParameterFact(-1, "ATC_RAT_PIT_P")
             property Fact _ratePitchI:          controller.getParameterFact(-1, "ATC_RAT_PIT_I")
-            property Fact _rateClimbP:          controller.getParameterFact(-1, "PSC_ACCZ_P")
-            property Fact _rateClimbI:          controller.getParameterFact(-1, "PSC_ACCZ_I")
+            property Fact _rateClimbP:          controller.getParameterFact(-1, "PSC_D_ACC_P")
+            property Fact _rateClimbI:          controller.getParameterFact(-1, "PSC_D_ACC_I")
             property Fact _motSpinArm:          controller.getParameterFact(-1, "MOT_SPIN_ARM")
             property Fact _motSpinMin:          controller.getParameterFact(-1, "MOT_SPIN_MIN")
 
-            property Fact _ch7Opt:  controller.getParameterFact(-1, "r.RC7_OPTION")
-            property Fact _ch8Opt:  controller.getParameterFact(-1, "r.RC8_OPTION")
-            property Fact _ch9Opt:  controller.getParameterFact(-1, "r.RC9_OPTION")
-            property Fact _ch10Opt: controller.getParameterFact(-1, "r.RC10_OPTION")
-            property Fact _ch11Opt: controller.getParameterFact(-1, "r.RC11_OPTION")
-            property Fact _ch12Opt: controller.getParameterFact(-1, "r.RC12_OPTION")
+            property Fact _ch7Opt:  controller.getParameterFact(-1, "RC7_OPTION")
+            property Fact _ch8Opt:  controller.getParameterFact(-1, "RC8_OPTION")
+            property Fact _ch9Opt:  controller.getParameterFact(-1, "RC9_OPTION")
+            property Fact _ch10Opt: controller.getParameterFact(-1, "RC10_OPTION")
+            property Fact _ch11Opt: controller.getParameterFact(-1, "RC11_OPTION")
+            property Fact _ch12Opt: controller.getParameterFact(-1, "RC12_OPTION")
 
             readonly property int   _firstOptionChannel:    7
             readonly property int   _lastOptionChannel:     12
@@ -59,7 +59,7 @@ SetupPage {
             function calcAutoTuneChannel() {
                 _autoTuneSwitchChannelIndex = 0
                 for (var channel=_firstOptionChannel; channel<=_lastOptionChannel; channel++) {
-                    var optionFact = controller.getParameterFact(-1, "r.RC" + channel + "_OPTION")
+                    var optionFact = controller.getParameterFact(-1, "RC" + channel + "_OPTION")
                     if (optionFact.value == _autoTuneOption) {
                         _autoTuneSwitchChannelIndex = channel - _firstOptionChannel + 1
                         break
@@ -71,7 +71,7 @@ SetupPage {
             function setChannelAutoTuneOption(channel) {
                 // First clear any previous settings for AutTune
                 for (var optionChannel=_firstOptionChannel; optionChannel<=_lastOptionChannel; optionChannel++) {
-                    var optionFact = controller.getParameterFact(-1, "r.RC" + optionChannel + "_OPTION")
+                    var optionFact = controller.getParameterFact(-1, "RC" + optionChannel + "_OPTION")
                     if (optionFact.value == _autoTuneOption) {
                         optionFact.value = 0
                     }
@@ -79,7 +79,7 @@ SetupPage {
 
                 // Now set the function into the new channel
                 if (channel != 0) {
-                    var optionFact = controller.getParameterFact(-1, "r.RC" + channel + "_OPTION")
+                    var optionFact = controller.getParameterFact(-1, "RC" + channel + "_OPTION")
                     optionFact.value = _autoTuneOption
                 }
             }
@@ -239,14 +239,14 @@ SetupPage {
                                     id:                     tuneMinField
                                     textField.validator:    DoubleValidator {bottom: 0; top: 32767;}
                                     label:                  qsTr("Min:")
-                                    fact:                   controller.getParameterFact(-1, "r.TUNE_MIN")
+                                    fact:                   controller.getParameterFact(-1, "TUNE_MIN")
                                 }
 
                                 LabelledFactTextField {
                                     id:                     tuneMaxField
                                     textField.validator:    DoubleValidator {bottom: 0; top: 32767;}
                                     label:                  qsTr("Max:")
-                                    fact:                   controller.getParameterFact(-1, "r.TUNE_MAX")
+                                    fact:                   controller.getParameterFact(-1, "TUNE_MAX")
                                 }
                             }
                         }

--- a/src/AutoPilotPlugins/APM/APMTuningComponentSub.qml
+++ b/src/AutoPilotPlugins/APM/APMTuningComponentSub.qml
@@ -100,17 +100,20 @@ SetupPage {
                         anchors.top:        parent.top
                         spacing:            _margins*1.5
 
-                        FactTextFieldSlider2 { fact: controller.getParameterFact(-1, "r.PSC_POSXY_P") }
-                        FactTextFieldSlider2 { fact: controller.getParameterFact(-1, "r.PSC_POSZ_P") }
-                        FactTextFieldSlider2 { fact: controller.getParameterFact(-1, "r.PSC_VELXY_P") }
-                        FactTextFieldSlider2 { fact: controller.getParameterFact(-1, "r.PSC_VELXY_I") }
-                        FactTextFieldSlider2 { fact: controller.getParameterFact(-1, "r.PSC_VELXY_IMAX") }
-                        FactTextFieldSlider2 { fact: controller.getParameterFact(-1, "r.PSC_VELZ_P") }
-                        FactTextFieldSlider2 { fact: controller.getParameterFact(-1, "r.PSC_ACCZ_D") }
-                        FactTextFieldSlider2 { fact: controller.getParameterFact(-1, "r.PSC_ACCZ_FILT") }
-                        FactTextFieldSlider2 { fact: controller.getParameterFact(-1, "r.PSC_ACCZ_I") }
-                        FactTextFieldSlider2 { fact: controller.getParameterFact(-1, "r.PSC_ACCZ_IMAX") }
-                        FactTextFieldSlider2 { fact: controller.getParameterFact(-1, "r.PSC_ACCZ_P") }
+                        FactTextFieldSlider2 { fact: controller.getParameterFact(-1, "PSC_POSXY_P") }
+                        FactTextFieldSlider2 { fact: controller.getParameterFact(-1, "PSC_POSZ_P") }
+                        FactTextFieldSlider2 { fact: controller.getParameterFact(-1, "PSC_VELXY_P") }
+                        FactTextFieldSlider2 { fact: controller.getParameterFact(-1, "PSC_VELXY_I") }
+                        FactTextFieldSlider2 { fact: controller.getParameterFact(-1, "PSC_VELXY_IMAX") }
+                        FactTextFieldSlider2 { fact: controller.getParameterFact(-1, "PSC_VELZ_P") }
+                        FactTextFieldSlider2 { fact: controller.getParameterFact(-1, "PSC_ACCZ_D") }
+                        FactTextFieldSlider2 {
+                            visible: controller.parameterExists(-1, "PSC_ACCZ_FILT")
+                            fact:    visible ? controller.getParameterFact(-1, "PSC_ACCZ_FILT") : null
+                        }
+                        FactTextFieldSlider2 { fact: controller.getParameterFact(-1, "PSC_ACCZ_I") }
+                        FactTextFieldSlider2 { fact: controller.getParameterFact(-1, "PSC_ACCZ_IMAX") }
+                        FactTextFieldSlider2 { fact: controller.getParameterFact(-1, "PSC_ACCZ_P") }
 
                     } // Column - VEL parameters
                 }
@@ -123,19 +126,19 @@ SetupPage {
                         anchors.top:        parent.top
                         spacing:            _margins*1.5
 
-                        FactTextFieldSlider2 { fact: controller.getParameterFact(-1, "r.PSC_POSXY_P") }
-                        FactTextFieldSlider2 { fact: controller.getParameterFact(-1, "r.PSC_POSZ_P") }
-                        FactTextFieldSlider2 { fact: controller.getParameterFact(-1, "r.PSC_VELXY_P") }
-                        FactTextFieldSlider2 { fact: controller.getParameterFact(-1, "r.PSC_VELXY_I") }
-                        FactTextFieldSlider2 { fact: controller.getParameterFact(-1, "r.PSC_VELXY_IMAX") }
-                        FactTextFieldSlider2 { fact: controller.getParameterFact(-1, "r.PSC_VELZ_P") }
-                        FactTextFieldSlider2 { fact: controller.getParameterFact(-1, "r.PSC_ACCZ_D") }
-                        FactTextFieldSlider2 { fact: controller.getParameterFact(-1, "r.PSC_ACCZ_FLTD") }
-                        FactTextFieldSlider2 { fact: controller.getParameterFact(-1, "r.PSC_ACCZ_FLTE") }
-                        FactTextFieldSlider2 { fact: controller.getParameterFact(-1, "r.PSC_ACCZ_FLTT") }
-                        FactTextFieldSlider2 { fact: controller.getParameterFact(-1, "r.PSC_ACCZ_I") }
-                        FactTextFieldSlider2 { fact: controller.getParameterFact(-1, "r.PSC_ACCZ_IMAX") }
-                        FactTextFieldSlider2 { fact: controller.getParameterFact(-1, "r.PSC_ACCZ_P") }
+                        FactTextFieldSlider2 { fact: controller.getParameterFact(-1, "PSC_NE_POS_P") }
+                        FactTextFieldSlider2 { fact: controller.getParameterFact(-1, "PSC_D_POS_P") }
+                        FactTextFieldSlider2 { fact: controller.getParameterFact(-1, "PSC_NE_VEL_P") }
+                        FactTextFieldSlider2 { fact: controller.getParameterFact(-1, "PSC_NE_VEL_I") }
+                        FactTextFieldSlider2 { fact: controller.getParameterFact(-1, "PSC_NE_VEL_IMAX") }
+                        FactTextFieldSlider2 { fact: controller.getParameterFact(-1, "PSC_D_VEL_P") }
+                        FactTextFieldSlider2 { fact: controller.getParameterFact(-1, "PSC_D_ACC_D") }
+                        FactTextFieldSlider2 { fact: controller.getParameterFact(-1, "PSC_D_ACC_FLTD") }
+                        FactTextFieldSlider2 { fact: controller.getParameterFact(-1, "PSC_D_ACC_FLTE") }
+                        FactTextFieldSlider2 { fact: controller.getParameterFact(-1, "PSC_D_ACC_FLTT") }
+                        FactTextFieldSlider2 { fact: controller.getParameterFact(-1, "PSC_D_ACC_I") }
+                        FactTextFieldSlider2 { fact: controller.getParameterFact(-1, "PSC_D_ACC_IMAX") }
+                        FactTextFieldSlider2 { fact: controller.getParameterFact(-1, "PSC_D_ACC_P") }
 
                     } // Column - VEL parameters
                 }
@@ -191,12 +194,12 @@ SetupPage {
                         anchors.top:        parent.top
                         spacing:            _margins*1.5
 
-                        FactTextFieldSlider2 { fact: controller.getParameterFact(-1, "WPNAV_ACCEL") }
-                        FactTextFieldSlider2 { fact: controller.getParameterFact(-1, "WPNAV_ACCEL_Z") }
-                        FactTextFieldSlider2 { fact: controller.getParameterFact(-1, "WPNAV_RADIUS") }
-                        FactTextFieldSlider2 { fact: controller.getParameterFact(-1, "WPNAV_SPEED") }
-                        FactTextFieldSlider2 { fact: controller.getParameterFact(-1, "WPNAV_SPEED_DN") }
-                        FactTextFieldSlider2 { fact: controller.getParameterFact(-1, "WPNAV_SPEED_UP") }
+                        FactTextFieldSlider2 { fact: controller.getParameterFact(-1, "WP_ACC") }
+                        FactTextFieldSlider2 { fact: controller.getParameterFact(-1, "WP_ACC_Z") }
+                        FactTextFieldSlider2 { fact: controller.getParameterFact(-1, "WP_RADIUS_M") }
+                        FactTextFieldSlider2 { fact: controller.getParameterFact(-1, "WP_SPD") }
+                        FactTextFieldSlider2 { fact: controller.getParameterFact(-1, "WP_SPD_DN") }
+                        FactTextFieldSlider2 { fact: controller.getParameterFact(-1, "WP_SPD_UP") }
                         FactTextFieldSlider2 { fact: controller.getParameterFact(-1, "LOIT_SPEED") }
                         FactTextFieldSlider2 { fact: controller.getParameterFact(-1, "LOIT_ACC_MAX") }
                         FactTextFieldSlider2 { fact: controller.getParameterFact(-1, "LOIT_ANG_MAX") }

--- a/src/FactSystem/ParameterManager.cc
+++ b/src/FactSystem/ParameterManager.cc
@@ -1283,9 +1283,9 @@ void ParameterManager::_paramRequestListTimeout()
 
 QString ParameterManager::_remapParamNameToVersion(const QString &paramName) const
 {
-    if (!paramName.startsWith(QStringLiteral("r."))) {
-        // No version mapping wanted
-        return paramName;
+    static const QString noRemapPrefix = QStringLiteral("noremap.");
+    if (paramName.startsWith(noRemapPrefix)) {
+        return paramName.mid(noRemapPrefix.length());
     }
 
     const int majorVersion = _vehicle->firmwareMajorVersion();
@@ -1293,21 +1293,21 @@ QString ParameterManager::_remapParamNameToVersion(const QString &paramName) con
 
     qCDebug(ParameterManagerLog) << "_remapParamNameToVersion" << paramName << majorVersion << minorVersion;
 
-    QString mappedParamName = paramName.right(paramName.length() - 2);
     if (majorVersion == Vehicle::versionNotSetValue) {
         // Vehicle version unknown
-        return mappedParamName;
+        return paramName;
     }
 
     const FirmwarePlugin::remapParamNameMajorVersionMap_t &majorVersionRemap = _vehicle->firmwarePlugin()->paramNameRemapMajorVersionMap();
     if (!majorVersionRemap.contains(majorVersion)) {
         // No mapping for this major version
         qCDebug(ParameterManagerLog) << "_remapParamNameToVersion: no major version mapping";
-        return mappedParamName;
+        return paramName;
     }
 
     const FirmwarePlugin::remapParamNameMinorVersionRemapMap_t &remapMinorVersion = majorVersionRemap[majorVersion];
     // We must map backwards from the highest known minor version to one above the vehicle's minor version
+    QString mappedParamName = paramName;
     for (int currentMinorVersion = _vehicle->firmwarePlugin()->remapParamNameHigestMinorVersionNumber(majorVersion); currentMinorVersion>minorVersion; currentMinorVersion--) {
         if (remapMinorVersion.contains(currentMinorVersion)) {
             const FirmwarePlugin::remapParamNameMap_t &remap = remapMinorVersion[currentMinorVersion];

--- a/src/FactSystem/ParameterManager.h
+++ b/src/FactSystem/ParameterManager.h
@@ -133,7 +133,14 @@ private:
     void _tryCacheHashLoad(int vehicleId, int componentId, const QVariant &hashValue);
     void _loadMetaData();
     void _clearMetaData();
-    /// Remap a parameter from one firmware version to another
+    /// Remap a parameter name from the newest firmware version to the version running on the vehicle.
+    /// All parameter names are walked backwards through the FirmwarePlugin remap tables from the
+    /// highest known minor version down to the vehicle's actual version. Names not found in any
+    /// remap table pass through unchanged.
+    ///
+    /// Names prefixed with "noremap." bypass remapping entirely — the prefix is stripped and the
+    /// bare name is used as-is. This is needed when code must distinguish old vs new parameter
+    /// names for unit conversion (e.g. checking whether WPNAV_SPEED exists vs WP_SPD).
     QString _remapParamNameToVersion(const QString &paramName) const;
     bool _fillMavlinkParamUnion(FactMetaData::ValueType_t valueType, const QVariant &rawValue, mavlink_param_union_t &paramUnion) const;
     bool _mavlinkParamUnionToVariant(const mavlink_param_union_t &paramUnion, QVariant &outValue) const;

--- a/src/FirmwarePlugin/APM/APMFirmwarePlugin.cc
+++ b/src/FirmwarePlugin/APM/APMFirmwarePlugin.cc
@@ -912,18 +912,28 @@ void APMFirmwarePlugin::guidedModeChangeAltitude(Vehicle *vehicle, double altitu
 
 bool APMFirmwarePlugin::mulirotorSpeedLimitsAvailable(Vehicle *vehicle) const
 {
-    return vehicle->parameterManager()->parameterExists(ParameterManager::defaultComponentId, "WPNAV_SPEED");
+    // Use noremap. to bypass remap and check for specific parameter names directly,
+    // since the old and new parameters have different units.
+    return vehicle->parameterManager()->parameterExists(ParameterManager::defaultComponentId, QStringLiteral("noremap.WP_SPD"))
+        || vehicle->parameterManager()->parameterExists(ParameterManager::defaultComponentId, QStringLiteral("noremap.WPNAV_SPEED"));
 }
 
-double APMFirmwarePlugin::maximumHorizontalSpeedMultirotor(Vehicle *vehicle) const
+double APMFirmwarePlugin::maximumHorizontalSpeedMultirotorMetersSecond(Vehicle *vehicle) const
 {
-    const QString speedParam("WPNAV_SPEED");
+    // Use noremap. to bypass remap and check for specific parameter names directly,
+    // since the old and new parameters have different units.
 
-    if (vehicle->parameterManager()->parameterExists(ParameterManager::defaultComponentId, speedParam)) {
-        return vehicle->parameterManager()->getParameter(ParameterManager::defaultComponentId, speedParam)->rawValue().toDouble() * 0.01;  // note cm/s -> m/s
+    // 4.7+: WP_SPD is in m/s
+    if (vehicle->parameterManager()->parameterExists(ParameterManager::defaultComponentId, QStringLiteral("noremap.WP_SPD"))) {
+        return vehicle->parameterManager()->getParameter(ParameterManager::defaultComponentId, QStringLiteral("noremap.WP_SPD"))->rawValue().toDouble();
     }
 
-    return FirmwarePlugin::maximumHorizontalSpeedMultirotor(vehicle);
+    // pre-4.7: WPNAV_SPEED is in cm/s
+    if (vehicle->parameterManager()->parameterExists(ParameterManager::defaultComponentId, QStringLiteral("noremap.WPNAV_SPEED"))) {
+        return vehicle->parameterManager()->getParameter(ParameterManager::defaultComponentId, QStringLiteral("noremap.WPNAV_SPEED"))->rawValue().toDouble() * 0.01;
+    }
+
+    return FirmwarePlugin::maximumHorizontalSpeedMultirotorMetersSecond(vehicle);
 }
 
 void APMFirmwarePlugin::guidedModeChangeGroundSpeedMetersSecond(Vehicle *vehicle, double groundspeed) const
@@ -985,11 +995,28 @@ void APMFirmwarePlugin::guidedModeChangeHeading(Vehicle *vehicle, const QGeoCoor
 double APMFirmwarePlugin::minimumTakeoffAltitudeMeters(Vehicle* vehicle) const
 {
     double minTakeoffAlt = 0;
-    const QString takeoffAltParam(vehicle->vtol() ? QStringLiteral("Q_RTL_ALT") : QStringLiteral("PILOT_TKOFF_ALT"));
-    const float paramDivisor = vehicle->vtol() ? 1.0 : 100.0; // PILOT_TAKEOFF_ALT is in centimeters
 
-    if (vehicle->parameterManager()->parameterExists(ParameterManager::defaultComponentId, takeoffAltParam)) {
-        minTakeoffAlt = vehicle->parameterManager()->getParameter(ParameterManager::defaultComponentId, takeoffAltParam)->rawValue().toDouble() / static_cast<double>(paramDivisor);
+    // Use noremap. to bypass remap and check for specific parameter names directly,
+    // since the old and new parameters have different units.
+
+    if (vehicle->vtol()) {
+        // 4.7+: Q_PILOT_TKO_ALT_M (meters)
+        if (vehicle->parameterManager()->parameterExists(ParameterManager::defaultComponentId, QStringLiteral("noremap.Q_PILOT_TKO_ALT_M"))) {
+            minTakeoffAlt = vehicle->parameterManager()->getParameter(ParameterManager::defaultComponentId, QStringLiteral("noremap.Q_PILOT_TKO_ALT_M"))->rawValue().toDouble();
+        } else if (vehicle->parameterManager()->parameterExists(ParameterManager::defaultComponentId, QStringLiteral("noremap.Q_PILOT_TKOFF_ALT"))) {
+            // pre-4.7: Q_PILOT_TKOFF_ALT (centimeters)
+            minTakeoffAlt = vehicle->parameterManager()->getParameter(ParameterManager::defaultComponentId, QStringLiteral("noremap.Q_PILOT_TKOFF_ALT"))->rawValue().toDouble() / 100.0;
+        } else if (vehicle->parameterManager()->parameterExists(ParameterManager::defaultComponentId, QStringLiteral("Q_RTL_ALT"))) {
+            minTakeoffAlt = vehicle->parameterManager()->getParameter(ParameterManager::defaultComponentId, QStringLiteral("Q_RTL_ALT"))->rawValue().toDouble();
+        }
+    } else {
+        // 4.7+: PILOT_TKO_ALT_M (meters)
+        if (vehicle->parameterManager()->parameterExists(ParameterManager::defaultComponentId, QStringLiteral("noremap.PILOT_TKO_ALT_M"))) {
+            minTakeoffAlt = vehicle->parameterManager()->getParameter(ParameterManager::defaultComponentId, QStringLiteral("noremap.PILOT_TKO_ALT_M"))->rawValue().toDouble();
+        } else if (vehicle->parameterManager()->parameterExists(ParameterManager::defaultComponentId, QStringLiteral("noremap.PILOT_TKOFF_ALT"))) {
+            // pre-4.7: PILOT_TKOFF_ALT (centimeters)
+            minTakeoffAlt = vehicle->parameterManager()->getParameter(ParameterManager::defaultComponentId, QStringLiteral("noremap.PILOT_TKOFF_ALT"))->rawValue().toDouble() / 100.0;
+        }
     }
 
     if (minTakeoffAlt == 0) {
@@ -1232,7 +1259,7 @@ QMutex &APMFirmwarePlugin::_reencodeMavlinkChannelMutex()
 
 double APMFirmwarePlugin::maximumEquivalentAirspeed(Vehicle *vehicle) const
 {
-    const QString airspeedMax("r.AIRSPEED_MAX");
+    const QString airspeedMax("AIRSPEED_MAX");
 
     if (vehicle->parameterManager()->parameterExists(ParameterManager::defaultComponentId, airspeedMax)) {
         return vehicle->parameterManager()->getParameter(ParameterManager::defaultComponentId, airspeedMax)->rawValue().toDouble();
@@ -1243,7 +1270,7 @@ double APMFirmwarePlugin::maximumEquivalentAirspeed(Vehicle *vehicle) const
 
 double APMFirmwarePlugin::minimumEquivalentAirspeed(Vehicle *vehicle) const
 {
-    const QString airspeedMin("r.AIRSPEED_MIN");
+    const QString airspeedMin("AIRSPEED_MIN");
 
     if (vehicle->parameterManager()->parameterExists(ParameterManager::defaultComponentId, airspeedMin)) {
         return vehicle->parameterManager()->getParameter(ParameterManager::defaultComponentId, airspeedMin)->rawValue().toDouble();
@@ -1254,8 +1281,8 @@ double APMFirmwarePlugin::minimumEquivalentAirspeed(Vehicle *vehicle) const
 
 bool APMFirmwarePlugin::fixedWingAirSpeedLimitsAvailable(Vehicle *vehicle) const
 {
-    return vehicle->parameterManager()->parameterExists(ParameterManager::defaultComponentId, "r.AIRSPEED_MIN") &&
-           vehicle->parameterManager()->parameterExists(ParameterManager::defaultComponentId, "r.AIRSPEED_MAX");
+    return vehicle->parameterManager()->parameterExists(ParameterManager::defaultComponentId, "AIRSPEED_MIN") &&
+           vehicle->parameterManager()->parameterExists(ParameterManager::defaultComponentId, "AIRSPEED_MAX");
 }
 
 void APMFirmwarePlugin::guidedModeChangeEquivalentAirspeedMetersSecond(Vehicle *vehicle, double airspeed_equiv) const

--- a/src/FirmwarePlugin/APM/APMFirmwarePlugin.h
+++ b/src/FirmwarePlugin/APM/APMFirmwarePlugin.h
@@ -73,7 +73,7 @@ public:
 
     // support for changing speed in Copter guide mode:
     bool mulirotorSpeedLimitsAvailable(Vehicle *vehicle) const override;
-    double maximumHorizontalSpeedMultirotor(Vehicle *vehicle) const override;
+    double maximumHorizontalSpeedMultirotorMetersSecond(Vehicle *vehicle) const override;
     void guidedModeChangeGroundSpeedMetersSecond(Vehicle *vehicle, double speed) const override;
 
     static QPair<QMetaObject::Connection,QMetaObject::Connection> startCompensatingBaro(Vehicle *vehicle);

--- a/src/FirmwarePlugin/APM/APMFlightModeIndicator.qml
+++ b/src/FirmwarePlugin/APM/APMFlightModeIndicator.qml
@@ -12,7 +12,9 @@ SettingsGroupLayout {
     visible:                activeVehicle.multiRotor
 
     property var activeVehicle: QGroundControl.multiVehicleManager.activeVehicle
-    property Fact rtlAltFact: controller.getParameterFact(-1, "RTL_ALT")
+    property Fact rtlAltFact: controller.getParameterFact(-1, "RTL_ALT_M")
+    // RTL_ALT_M (4.7+) is in meters, RTL_ALT (pre-4.7) is in centimeters
+    property bool _rtlAltIsMeters: controller.parameterExists(-1, "noremap.RTL_ALT_M")
 
     FactPanelController { id: controller }
 
@@ -45,7 +47,8 @@ SettingsGroupLayout {
                 if (index === 0) {
                     rtlAltFact.rawValue = 0
                 } else {
-                    rtlAltFact.rawValue = 1500
+                    // RTL_ALT_M (4.7+) is in meters, RTL_ALT (pre-4.7) is in centimeters
+                    rtlAltFact.rawValue = _rtlAltIsMeters ? 15 : 1500
                 }
             }
 

--- a/src/FirmwarePlugin/APM/ArduCopterFirmwarePlugin.cc
+++ b/src/FirmwarePlugin/APM/ArduCopterFirmwarePlugin.cc
@@ -74,6 +74,92 @@ ArduCopterFirmwarePlugin::ArduCopterFirmwarePlugin(QObject *parent)
         remapV4_0["TUNE_MIN"] = QStringLiteral("TUNE_LOW");
         remapV4_0["TUNE_MAX"] = QStringLiteral("TUNE_HIGH");
 
+        // ArduPilot 4.7: massive parameter rename and SI unit conversion
+        FirmwarePlugin::remapParamNameMap_t &remapV4_7 = _remapParamName[4][7];
+
+        // Position controller: PSC_VELXY_* -> PSC_NE_VEL_*
+        remapV4_7["PSC_NE_VEL_P"]    = QStringLiteral("PSC_VELXY_P");
+        remapV4_7["PSC_NE_VEL_I"]    = QStringLiteral("PSC_VELXY_I");
+        remapV4_7["PSC_NE_VEL_D"]    = QStringLiteral("PSC_VELXY_D");
+        remapV4_7["PSC_NE_VEL_IMAX"] = QStringLiteral("PSC_VELXY_IMAX");
+        remapV4_7["PSC_NE_VEL_FLTE"] = QStringLiteral("PSC_VELXY_FLTE");
+        remapV4_7["PSC_NE_VEL_FLTD"] = QStringLiteral("PSC_VELXY_FLTD");
+        remapV4_7["PSC_NE_VEL_FF"]   = QStringLiteral("PSC_VELXY_FF");
+
+        // Position controller: PSC_VELZ_* -> PSC_D_VEL_*
+        remapV4_7["PSC_D_VEL_P"]     = QStringLiteral("PSC_VELZ_P");
+        remapV4_7["PSC_D_VEL_I"]     = QStringLiteral("PSC_VELZ_I");
+        remapV4_7["PSC_D_VEL_D"]     = QStringLiteral("PSC_VELZ_D");
+        remapV4_7["PSC_D_VEL_IMAX"]  = QStringLiteral("PSC_VELZ_IMAX");
+        remapV4_7["PSC_D_VEL_FLTE"]  = QStringLiteral("PSC_VELZ_FLTE");
+        remapV4_7["PSC_D_VEL_FF"]    = QStringLiteral("PSC_VELZ_FF");
+
+        // Position controller: PSC_ACCZ_* -> PSC_D_ACC_*
+        remapV4_7["PSC_D_ACC_P"]     = QStringLiteral("PSC_ACCZ_P");
+        remapV4_7["PSC_D_ACC_I"]     = QStringLiteral("PSC_ACCZ_I");
+        remapV4_7["PSC_D_ACC_D"]     = QStringLiteral("PSC_ACCZ_D");
+        remapV4_7["PSC_D_ACC_IMAX"]  = QStringLiteral("PSC_ACCZ_IMAX");
+        remapV4_7["PSC_D_ACC_FLTD"]  = QStringLiteral("PSC_ACCZ_FLTD");
+        remapV4_7["PSC_D_ACC_FLTE"]  = QStringLiteral("PSC_ACCZ_FLTE");
+        remapV4_7["PSC_D_ACC_FLTT"]  = QStringLiteral("PSC_ACCZ_FLTT");
+        remapV4_7["PSC_D_ACC_FF"]    = QStringLiteral("PSC_ACCZ_FF");
+        remapV4_7["PSC_D_ACC_SMAX"]  = QStringLiteral("PSC_ACCZ_SMAX");
+
+        // Position controller: PSC_POSXY_P -> PSC_NE_POS_P (simply renamed)
+        remapV4_7["PSC_NE_POS_P"]    = QStringLiteral("PSC_POSXY_P");
+
+        // Position controller: PSC_POSZ_P -> PSC_D_POS_P (simply renamed)
+        remapV4_7["PSC_D_POS_P"]     = QStringLiteral("PSC_POSZ_P");
+
+        // Waypoint navigation: WPNAV_* -> WP_*
+        remapV4_7["WP_ACC"]          = QStringLiteral("WPNAV_ACCEL");
+        remapV4_7["WP_ACC_CNR"]      = QStringLiteral("WPNAV_ACCEL_C");
+        remapV4_7["WP_ACC_Z"]        = QStringLiteral("WPNAV_ACCEL_Z");
+        remapV4_7["WP_RADIUS_M"]     = QStringLiteral("WPNAV_RADIUS");
+        remapV4_7["WP_SPD"]          = QStringLiteral("WPNAV_SPEED");
+        remapV4_7["WP_SPD_DN"]       = QStringLiteral("WPNAV_SPEED_DN");
+        remapV4_7["WP_SPD_UP"]       = QStringLiteral("WPNAV_SPEED_UP");
+
+        // RTL parameters
+        remapV4_7["RTL_ALT_M"]       = QStringLiteral("RTL_ALT");
+        remapV4_7["RTL_SPEED_MS"]    = QStringLiteral("RTL_SPEED");
+        remapV4_7["RTL_ALT_FINAL_M"] = QStringLiteral("RTL_ALT_FINAL");
+        remapV4_7["RTL_CLIMB_MIN_M"] = QStringLiteral("RTL_CLIMB_MIN");
+
+        // Landing parameters
+        remapV4_7["LAND_SPD_MS"]     = QStringLiteral("LAND_SPEED");
+        remapV4_7["LAND_SPD_HIGH_MS"]= QStringLiteral("LAND_SPEED_HIGH");
+        remapV4_7["LAND_ALT_LOW_M"]  = QStringLiteral("LAND_ALT_LOW");
+
+        // Loiter parameters
+        remapV4_7["LOIT_SPEED_MS"]   = QStringLiteral("LOIT_SPEED");
+        remapV4_7["LOIT_ACC_MAX_M"]  = QStringLiteral("LOIT_ACC_MAX");
+        remapV4_7["LOIT_BRK_ACC_M"]  = QStringLiteral("LOIT_BRK_ACCEL");
+        remapV4_7["LOIT_BRK_JRK_M"] = QStringLiteral("LOIT_BRK_JERK");
+
+        // Pilot parameters
+        remapV4_7["PILOT_ACC_Z"]     = QStringLiteral("PILOT_ACCEL_Z");
+        remapV4_7["PILOT_SPD_UP"]    = QStringLiteral("PILOT_SPEED_UP");
+        remapV4_7["PILOT_SPD_DN"]    = QStringLiteral("PILOT_SPEED_DN");
+        remapV4_7["PILOT_TKO_ALT_M"] = QStringLiteral("PILOT_TKOFF_ALT");
+
+        // Attitude controller
+        remapV4_7["ATC_ANGLE_MAX"]   = QStringLiteral("ANGLE_MAX");
+        remapV4_7["ATC_ACC_R_MAX"]   = QStringLiteral("ATC_ACCEL_R_MAX");
+        remapV4_7["ATC_ACC_P_MAX"]   = QStringLiteral("ATC_ACCEL_P_MAX");
+        remapV4_7["ATC_ACC_Y_MAX"]   = QStringLiteral("ATC_ACCEL_Y_MAX");
+        remapV4_7["ATC_RATE_WPY_MAX"]= QStringLiteral("ATC_SLEW_YAW");
+
+        // Circle
+        remapV4_7["CIRCLE_RADIUS_M"] = QStringLiteral("CIRCLE_RADIUS");
+
+        // PosHold
+        remapV4_7["PHLD_BRK_ANGLE"]  = QStringLiteral("PHLD_BRAKE_ANGLE");
+        remapV4_7["PHLD_BRK_RATE"]   = QStringLiteral("PHLD_BRAKE_RATE");
+
+        // EKF
+        remapV4_7["EK3_FLOW_MAX"]    = QStringLiteral("EK3_MAX_FLOW");
+
         _remapParamNameIntialized = true;
     }
 }
@@ -85,7 +171,7 @@ ArduCopterFirmwarePlugin::~ArduCopterFirmwarePlugin()
 
 int ArduCopterFirmwarePlugin::remapParamNameHigestMinorVersionNumber(int majorVersionNumber) const
 {
-    return ((majorVersionNumber == 4) ? 0 : Vehicle::versionNotSetValue);
+    return ((majorVersionNumber == 4) ? 7 : Vehicle::versionNotSetValue);
 }
 
 bool ArduCopterFirmwarePlugin::multiRotorXConfig(Vehicle *vehicle) const

--- a/src/FirmwarePlugin/APM/ArduPlaneFirmwarePlugin.cc
+++ b/src/FirmwarePlugin/APM/ArduPlaneFirmwarePlugin.cc
@@ -76,6 +76,70 @@ ArduPlaneFirmwarePlugin::ArduPlaneFirmwarePlugin(QObject *parent)
         remapV4_5["RTL_ALTITUDE"] = QStringLiteral("ALT_HOLD_RTL");
         // LAND_SPEED is only used in a Copter component
 
+        // ArduPilot 4.7: QuadPlane parameter renames and SI unit conversion
+        FirmwarePlugin::remapParamNameMap_t &remapV4_7 = _remapParamName[4][7];
+
+        // Attitude controller
+        remapV4_7["Q_A_ANGLE_MAX"]       = QStringLiteral("Q_ANGLE_MAX");
+        remapV4_7["Q_A_ACC_R_MAX"]       = QStringLiteral("Q_A_ACCEL_R_MAX");
+        remapV4_7["Q_A_ACC_P_MAX"]       = QStringLiteral("Q_A_ACCEL_P_MAX");
+        remapV4_7["Q_A_ACC_Y_MAX"]       = QStringLiteral("Q_A_ACCEL_Y_MAX");
+        remapV4_7["Q_A_RATE_WPY_MAX"]    = QStringLiteral("Q_A_SLEW_YAW");
+
+        // Loiter
+        remapV4_7["Q_LOIT_SPEED_MS"]     = QStringLiteral("Q_LOIT_SPEED");
+        remapV4_7["Q_LOIT_ACC_MAX_M"]    = QStringLiteral("Q_LOIT_ACC_MAX");
+        remapV4_7["Q_LOIT_BRK_ACC_M"]    = QStringLiteral("Q_LOIT_BRK_ACCEL");
+        remapV4_7["Q_LOIT_BRK_JRK_M"]    = QStringLiteral("Q_LOIT_BRK_JERK");
+
+        // Pilot
+        remapV4_7["Q_PILOT_SPD_UP"]      = QStringLiteral("Q_PILOT_SPEED_UP");
+        remapV4_7["Q_PILOT_SPD_DN"]      = QStringLiteral("Q_PILOT_SPEED_DN");
+        remapV4_7["Q_PILOT_TKO_ALT_M"]   = QStringLiteral("Q_PILOT_TKOFF_ALT");
+
+        // Position controller: Q_P_VELXY_* -> Q_P_NE_VEL_*
+        remapV4_7["Q_P_NE_VEL_P"]        = QStringLiteral("Q_P_VELXY_P");
+        remapV4_7["Q_P_NE_VEL_I"]        = QStringLiteral("Q_P_VELXY_I");
+        remapV4_7["Q_P_NE_VEL_D"]        = QStringLiteral("Q_P_VELXY_D");
+        remapV4_7["Q_P_NE_VEL_IMAX"]     = QStringLiteral("Q_P_VELXY_IMAX");
+        remapV4_7["Q_P_NE_VEL_FLTE"]     = QStringLiteral("Q_P_VELXY_FLTE");
+        remapV4_7["Q_P_NE_VEL_FLTD"]     = QStringLiteral("Q_P_VELXY_FLTD");
+        remapV4_7["Q_P_NE_VEL_FF"]       = QStringLiteral("Q_P_VELXY_FF");
+
+        // Position controller: Q_P_VELZ_* -> Q_P_D_VEL_*
+        remapV4_7["Q_P_D_VEL_P"]         = QStringLiteral("Q_P_VELZ_P");
+        remapV4_7["Q_P_D_VEL_I"]         = QStringLiteral("Q_P_VELZ_I");
+        remapV4_7["Q_P_D_VEL_D"]         = QStringLiteral("Q_P_VELZ_D");
+        remapV4_7["Q_P_D_VEL_IMAX"]      = QStringLiteral("Q_P_VELZ_IMAX");
+        remapV4_7["Q_P_D_VEL_FLTE"]      = QStringLiteral("Q_P_VELZ_FLTE");
+        remapV4_7["Q_P_D_VEL_FF"]        = QStringLiteral("Q_P_VELZ_FF");
+
+        // Position controller: Q_P_ACCZ_* -> Q_P_D_ACC_*
+        remapV4_7["Q_P_D_ACC_P"]         = QStringLiteral("Q_P_ACCZ_P");
+        remapV4_7["Q_P_D_ACC_I"]         = QStringLiteral("Q_P_ACCZ_I");
+        remapV4_7["Q_P_D_ACC_D"]         = QStringLiteral("Q_P_ACCZ_D");
+        remapV4_7["Q_P_D_ACC_IMAX"]      = QStringLiteral("Q_P_ACCZ_IMAX");
+        remapV4_7["Q_P_D_ACC_FLTD"]      = QStringLiteral("Q_P_ACCZ_FLTD");
+        remapV4_7["Q_P_D_ACC_FLTE"]      = QStringLiteral("Q_P_ACCZ_FLTE");
+        remapV4_7["Q_P_D_ACC_FLTT"]      = QStringLiteral("Q_P_ACCZ_FLTT");
+        remapV4_7["Q_P_D_ACC_FF"]        = QStringLiteral("Q_P_ACCZ_FF");
+        remapV4_7["Q_P_D_ACC_SMAX"]      = QStringLiteral("Q_P_ACCZ_SMAX");
+
+        // Waypoint navigation
+        remapV4_7["Q_WP_ACC"]            = QStringLiteral("Q_WP_ACCEL");
+        remapV4_7["Q_WP_ACC_CNR"]        = QStringLiteral("Q_WP_ACCEL_C");
+        remapV4_7["Q_WP_ACC_Z"]          = QStringLiteral("Q_WP_ACCEL_Z");
+        remapV4_7["Q_WP_RADIUS_M"]       = QStringLiteral("Q_WP_RADIUS");
+        remapV4_7["Q_WP_SPD"]            = QStringLiteral("Q_WP_SPEED");
+        remapV4_7["Q_WP_SPD_DN"]         = QStringLiteral("Q_WP_SPEED_DN");
+        remapV4_7["Q_WP_SPD_UP"]         = QStringLiteral("Q_WP_SPEED_UP");
+
+        // EKF
+        remapV4_7["EK3_FLOW_MAX"]        = QStringLiteral("EK3_MAX_FLOW");
+
+        // Common
+        remapV4_7["ARMING_SKIPCHK"]      = QStringLiteral("ARMING_CHECK");
+
         _remapParamNameIntialized = true;
     }
 }
@@ -87,8 +151,7 @@ ArduPlaneFirmwarePlugin::~ArduPlaneFirmwarePlugin()
 
 int ArduPlaneFirmwarePlugin::remapParamNameHigestMinorVersionNumber(int majorVersionNumber) const
 {
-    // Remapping supports up to 4.5
-    return ((majorVersionNumber == 4) ? 5 : Vehicle::versionNotSetValue);
+    return ((majorVersionNumber == 4) ? 7 : Vehicle::versionNotSetValue);
 }
 
 QString ArduPlaneFirmwarePlugin::takeOffFlightMode() const

--- a/src/FirmwarePlugin/APM/ArduRoverFirmwarePlugin.cc
+++ b/src/FirmwarePlugin/APM/ArduRoverFirmwarePlugin.cc
@@ -47,6 +47,15 @@ ArduRoverFirmwarePlugin::ArduRoverFirmwarePlugin(QObject *parent)
     updateAvailableFlightModes(availableFlightModes);
 
     if (!_remapParamNameIntialized) {
+        // ArduPilot 4.7: parameter renames and SI unit conversion
+        FirmwarePlugin::remapParamNameMap_t &remapV4_7 = _remapParamName[4][7];
+
+        // EKF
+        remapV4_7["EK3_FLOW_MAX"]    = QStringLiteral("EK3_MAX_FLOW");
+
+        // Common
+        remapV4_7["ARMING_SKIPCHK"]  = QStringLiteral("ARMING_CHECK");
+
         _remapParamNameIntialized = true;
     }
 }
@@ -56,10 +65,9 @@ ArduRoverFirmwarePlugin::~ArduRoverFirmwarePlugin()
 
 }
 
-int ArduRoverFirmwarePlugin::remapParamNameHigestMinorVersionNumber(int /*majorVersionNumber*/) const
+int ArduRoverFirmwarePlugin::remapParamNameHigestMinorVersionNumber(int majorVersionNumber) const
 {
-    // Remapping not supported
-    return Vehicle::versionNotSetValue;
+    return ((majorVersionNumber == 4) ? 7 : Vehicle::versionNotSetValue);
 }
 
 void ArduRoverFirmwarePlugin::guidedModeChangeAltitude(Vehicle* /*vehicle*/, double /*altitudeChange*/, bool /*pauseVehicle*/)

--- a/src/FirmwarePlugin/APM/ArduSubFirmwarePlugin.cc
+++ b/src/FirmwarePlugin/APM/ArduSubFirmwarePlugin.cc
@@ -125,6 +125,67 @@ ArduSubFirmwarePlugin::ArduSubFirmwarePlugin(QObject *parent)
     updateAvailableFlightModes(availableFlightModes);
 
     if (!_remapParamNameIntialized) {
+        // ArduPilot 4.7: parameter renames and SI unit conversion
+        FirmwarePlugin::remapParamNameMap_t &remapV4_7 = _remapParamName[4][7];
+
+        // Position controller: PSC_VELXY_* -> PSC_NE_VEL_*
+        remapV4_7["PSC_NE_VEL_P"]    = QStringLiteral("PSC_VELXY_P");
+        remapV4_7["PSC_NE_VEL_I"]    = QStringLiteral("PSC_VELXY_I");
+        remapV4_7["PSC_NE_VEL_D"]    = QStringLiteral("PSC_VELXY_D");
+        remapV4_7["PSC_NE_VEL_IMAX"] = QStringLiteral("PSC_VELXY_IMAX");
+        remapV4_7["PSC_NE_VEL_FLTE"] = QStringLiteral("PSC_VELXY_FLTE");
+        remapV4_7["PSC_NE_VEL_FLTD"] = QStringLiteral("PSC_VELXY_FLTD");
+        remapV4_7["PSC_NE_VEL_FF"]   = QStringLiteral("PSC_VELXY_FF");
+
+        // Position controller: PSC_VELZ_* -> PSC_D_VEL_*
+        remapV4_7["PSC_D_VEL_P"]     = QStringLiteral("PSC_VELZ_P");
+        remapV4_7["PSC_D_VEL_I"]     = QStringLiteral("PSC_VELZ_I");
+        remapV4_7["PSC_D_VEL_D"]     = QStringLiteral("PSC_VELZ_D");
+        remapV4_7["PSC_D_VEL_IMAX"]  = QStringLiteral("PSC_VELZ_IMAX");
+        remapV4_7["PSC_D_VEL_FLTE"]  = QStringLiteral("PSC_VELZ_FLTE");
+        remapV4_7["PSC_D_VEL_FF"]    = QStringLiteral("PSC_VELZ_FF");
+
+        // Position controller: PSC_ACCZ_* -> PSC_D_ACC_*
+        remapV4_7["PSC_D_ACC_P"]     = QStringLiteral("PSC_ACCZ_P");
+        remapV4_7["PSC_D_ACC_I"]     = QStringLiteral("PSC_ACCZ_I");
+        remapV4_7["PSC_D_ACC_D"]     = QStringLiteral("PSC_ACCZ_D");
+        remapV4_7["PSC_D_ACC_IMAX"]  = QStringLiteral("PSC_ACCZ_IMAX");
+        remapV4_7["PSC_D_ACC_FLTD"]  = QStringLiteral("PSC_ACCZ_FLTD");
+        remapV4_7["PSC_D_ACC_FLTE"]  = QStringLiteral("PSC_ACCZ_FLTE");
+        remapV4_7["PSC_D_ACC_FLTT"]  = QStringLiteral("PSC_ACCZ_FLTT");
+        remapV4_7["PSC_D_ACC_FF"]    = QStringLiteral("PSC_ACCZ_FF");
+        remapV4_7["PSC_D_ACC_SMAX"]  = QStringLiteral("PSC_ACCZ_SMAX");
+
+        // Position controller: PSC_POSXY_P -> PSC_NE_POS_P
+        remapV4_7["PSC_NE_POS_P"]    = QStringLiteral("PSC_POSXY_P");
+
+        // Position controller: PSC_POSZ_P -> PSC_D_POS_P
+        remapV4_7["PSC_D_POS_P"]     = QStringLiteral("PSC_POSZ_P");
+
+        // Waypoint navigation: WPNAV_* -> WP_*
+        remapV4_7["WP_ACC"]          = QStringLiteral("WPNAV_ACCEL");
+        remapV4_7["WP_ACC_CNR"]      = QStringLiteral("WPNAV_ACCEL_C");
+        remapV4_7["WP_ACC_Z"]        = QStringLiteral("WPNAV_ACCEL_Z");
+        remapV4_7["WP_RADIUS_M"]     = QStringLiteral("WPNAV_RADIUS");
+        remapV4_7["WP_SPD"]          = QStringLiteral("WPNAV_SPEED");
+        remapV4_7["WP_SPD_DN"]       = QStringLiteral("WPNAV_SPEED_DN");
+        remapV4_7["WP_SPD_UP"]       = QStringLiteral("WPNAV_SPEED_UP");
+
+        // Attitude controller
+        remapV4_7["ATC_ACC_R_MAX"]   = QStringLiteral("ATC_ACCEL_R_MAX");
+        remapV4_7["ATC_ACC_P_MAX"]   = QStringLiteral("ATC_ACCEL_P_MAX");
+        remapV4_7["ATC_ACC_Y_MAX"]   = QStringLiteral("ATC_ACCEL_Y_MAX");
+        remapV4_7["ATC_RATE_WPY_MAX"]= QStringLiteral("ATC_SLEW_YAW");
+
+        // Circle
+        remapV4_7["CIRCLE_RADIUS_M"] = QStringLiteral("CIRCLE_RADIUS");
+
+        // EKF
+        remapV4_7["EK3_FLOW_MAX"]    = QStringLiteral("EK3_MAX_FLOW");
+
+        // Common
+        remapV4_7["ARMING_SKIPCHK"]  = QStringLiteral("ARMING_CHECK");
+
         _remapParamNameIntialized = true;
     }
 
@@ -142,10 +203,9 @@ ArduSubFirmwarePlugin::~ArduSubFirmwarePlugin()
 
 }
 
-int ArduSubFirmwarePlugin::remapParamNameHigestMinorVersionNumber(int /*majorVersionNumber*/) const
+int ArduSubFirmwarePlugin::remapParamNameHigestMinorVersionNumber(int majorVersionNumber) const
 {
-    // Remapping not supported
-    return Vehicle::versionNotSetValue;
+    return ((majorVersionNumber == 4) ? 7 : Vehicle::versionNotSetValue);
 }
 
 void ArduSubFirmwarePlugin::initializeStreamRates(Vehicle *vehicle)

--- a/src/FirmwarePlugin/FirmwarePlugin.h
+++ b/src/FirmwarePlugin/FirmwarePlugin.h
@@ -8,10 +8,10 @@
 #include "QGCMAVLink.h"
 #include "FollowMe.h"
 #include "FactMetaData.h"
+#include "Vehicle.h"
 
 class VehicleComponent;
 class AutoPilotPlugin;
-class Vehicle;
 class MavlinkCameraControlInterface;
 class QGCCameraManager;
 class Autotune;
@@ -82,14 +82,27 @@ public:
         GuidedTakeoffCapability =   1 << 7, ///< Vehicle supports guided takeoff
     };
 
-    /// Maps from on parameter name to another
-    ///     key:    parameter name to translate from
-    ///     value:  mapped parameter name
+    /// Parameter name remapping support:
+    /// When firmware renames a parameter across versions, callers should use the *newest* (current)
+    /// parameter name. ParameterManager::_remapParamNameToVersion() walks the remap tables backwards
+    /// from the highest known minor version down to the vehicle's actual firmware version, translating
+    /// new names to old names at each step. If the name is not found in any remap table it passes
+    /// through unchanged, so remapping is always safe to run.
+    ///
+    /// To bypass remapping (e.g. when checking parameterExists for a specific old or new name to
+    /// decide which unit conversion to apply), prefix the name with "noremap.".
+    ///
+    /// Remap table entries map new_name -> old_name for the version in which the rename occurred.
+    /// For example: remapV4_0["TUNE_MIN"] = "TUNE_LOW" means TUNE_LOW was renamed to TUNE_MIN in 4.0.
+
+    /// Maps from one parameter name to another (new_name -> old_name for a given version)
+    ///     key:    current (new) parameter name
+    ///     value:  previous (old) parameter name
     typedef QMap<QString, QString> remapParamNameMap_t;
 
     /// Maps from firmware minor version to remapParamNameMap_t entry
-    ///     key:    firmware minor version
-    ///     value:  remapParamNameMap_t entry
+    ///     key:    firmware minor version in which the rename(s) occurred
+    ///     value:  remapParamNameMap_t with new->old mappings for that version
     typedef QMap<int, remapParamNameMap_t> remapParamNameMinorVersionRemapMap_t;
 
     /// Maps from firmware major version number to remapParamNameMinorVersionRemapMap_t entry
@@ -184,7 +197,7 @@ public:
     virtual double minimumTakeoffAltitudeMeters(Vehicle* /*vehicle*/) const { return 3.048; }
 
     /// @return The maximum horizontal groundspeed for a multirotor.
-    virtual double maximumHorizontalSpeedMultirotor(Vehicle* /*vehicle*/) const { return NAN; }
+    virtual double maximumHorizontalSpeedMultirotorMetersSecond(Vehicle* /*vehicle*/) const { return NAN; }
 
     /// @return The maximum equivalent airspeed setpoint.
     virtual double maximumEquivalentAirspeed(Vehicle* /*vehicle*/) const { return NAN; }
@@ -306,10 +319,13 @@ public:
     virtual QString missionCommandOverrides(QGCMAVLink::VehicleClass_t vehicleClass) const;
 
     /// Returns the mapping structure which is used to map from one parameter name to another based on firmware version.
+    /// See remapParamNameMap_t for details on how remapping works.
     virtual const remapParamNameMajorVersionMap_t &paramNameRemapMajorVersionMap() const;
 
-    /// Returns the highest major version number that is known to the remap for this specified major version.
-    virtual int remapParamNameHigestMinorVersionNumber(int /*majorVersionNumber*/) const { return 0; }
+    /// Returns the highest minor version number that has remap entries for the specified major version.
+    /// The remap logic iterates backwards from this version down to the vehicle's actual minor version.
+    /// Return Vehicle::versionNotSetValue if remapping is not supported for the given major version.
+    virtual int remapParamNameHigestMinorVersionNumber(int /*majorVersionNumber*/) const { return Vehicle::versionNotSetValue; }
 
     /// @return true: Motors are coaxial like an X8 config, false: Quadcopter for example
     virtual bool multiRotorCoaxialMotors(Vehicle* /*vehicle*/) const { return false; }

--- a/src/FirmwarePlugin/PX4/PX4FirmwarePlugin.cc
+++ b/src/FirmwarePlugin/PX4/PX4FirmwarePlugin.cc
@@ -343,7 +343,7 @@ void PX4FirmwarePlugin::guidedModeTakeoff(Vehicle* vehicle, double takeoffAltRel
         static_cast<float>(takeoffAltAMSL));    // AMSL altitude
 }
 
-double PX4FirmwarePlugin::maximumHorizontalSpeedMultirotor(Vehicle* vehicle) const
+double PX4FirmwarePlugin::maximumHorizontalSpeedMultirotorMetersSecond(Vehicle* vehicle) const
 {
     QString speedParam("MPC_XY_VEL_MAX");
 
@@ -351,7 +351,7 @@ double PX4FirmwarePlugin::maximumHorizontalSpeedMultirotor(Vehicle* vehicle) con
         return vehicle->parameterManager()->getParameter(ParameterManager::defaultComponentId, speedParam)->rawValue().toDouble();
     }
 
-    return FirmwarePlugin::maximumHorizontalSpeedMultirotor(vehicle);
+    return FirmwarePlugin::maximumHorizontalSpeedMultirotorMetersSecond(vehicle);
 }
 
 double PX4FirmwarePlugin::maximumEquivalentAirspeed(Vehicle* vehicle) const

--- a/src/FirmwarePlugin/PX4/PX4FirmwarePlugin.h
+++ b/src/FirmwarePlugin/PX4/PX4FirmwarePlugin.h
@@ -37,7 +37,7 @@ public:
     void                guidedModeRTL                   (Vehicle* vehicle, bool smartRTL) const override;
     void                guidedModeLand                  (Vehicle* vehicle) const override;
     void                guidedModeTakeoff               (Vehicle* vehicle, double takeoffAltRel) const override;
-    double              maximumHorizontalSpeedMultirotor(Vehicle* vehicle) const override;
+    double              maximumHorizontalSpeedMultirotorMetersSecond(Vehicle* vehicle) const override;
     double              maximumEquivalentAirspeed(Vehicle* vehicle) const override;
     double              minimumEquivalentAirspeed(Vehicle* vehicle) const override;
     bool                mulirotorSpeedLimitsAvailable(Vehicle* vehicle) const override;

--- a/src/FlyView/GuidedActionsController.qml
+++ b/src/FlyView/GuidedActionsController.qml
@@ -218,8 +218,8 @@ Item {
                 guidedValueSlider.setupSlider(
                     GuidedValueSlider.SliderType.Speed,
                     _unitsConversion.metersSecondToAppSettingsSpeedUnits(0.1).toFixed(1),
-                    _unitsConversion.metersSecondToAppSettingsSpeedUnits(_activeVehicle.maximumHorizontalSpeedMultirotor()).toFixed(1),
-                    _unitsConversion.metersSecondToAppSettingsSpeedUnits(_activeVehicle.maximumHorizontalSpeedMultirotor()/2).toFixed(1),
+                    _unitsConversion.metersSecondToAppSettingsSpeedUnits(_activeVehicle.maximumHorizontalSpeedMultirotorMetersSecond()).toFixed(1),
+                    _unitsConversion.metersSecondToAppSettingsSpeedUnits(_activeVehicle.maximumHorizontalSpeedMultirotorMetersSecond()/2).toFixed(1),
                     qsTr("Speed"))
             } else {
                 console.error("setupSlider called for inapproproate change speed action", _vehicleInFwdFlight, _activeVehicle.haveMRSpeedLimits)

--- a/src/Vehicle/Vehicle.cc
+++ b/src/Vehicle/Vehicle.cc
@@ -1997,9 +1997,9 @@ double Vehicle::minimumTakeoffAltitudeMeters()
     return _firmwarePlugin->minimumTakeoffAltitudeMeters(this);
 }
 
-double Vehicle::maximumHorizontalSpeedMultirotor()
+double Vehicle::maximumHorizontalSpeedMultirotorMetersSecond()
 {
-    return _firmwarePlugin->maximumHorizontalSpeedMultirotor(this);
+    return _firmwarePlugin->maximumHorizontalSpeedMultirotorMetersSecond(this);
 }
 
 

--- a/src/Vehicle/Vehicle.h
+++ b/src/Vehicle/Vehicle.h
@@ -290,7 +290,7 @@ public:
     Q_INVOKABLE double minimumTakeoffAltitudeMeters();
 
     /// @return Maximum horizontal speed multirotor.
-    Q_INVOKABLE double maximumHorizontalSpeedMultirotor();
+    Q_INVOKABLE double maximumHorizontalSpeedMultirotorMetersSecond();
 
     /// @return Maximum equivalent airspeed.
     Q_INVOKABLE double maximumEquivalentAirspeed();


### PR DESCRIPTION
## Summary

ArduPilot 4.7 renames many parameters to new names with SI units (e.g. `WPNAV_SPEED` cm/s → `WP_SPD` m/s, `RTL_ALT` centimeters → `RTL_ALT_M` meters). This PR adds full remap support so QGC works with both old and new firmware versions.

## Changes

### Parameter Remap System
- **Always-on remap**: All parameter names are now remapped by default (no more `r.` prefix required)
- **`noremap.` bypass**: New prefix to skip remapping when code needs to distinguish old vs new names for unit conversion
- Add 4.7 remap tables for **Copter** (~86 entries), **Plane** (~64 entries), **Rover**, and **Sub** (~61 entries)

### QML Updates
- Update all APM setup/tuning QML files to use new 4.7 parameter names
- Use `noremap.`-based parameter existence checks (instead of `versionCompare`) for RTL altitude defaults — correctly handles unknown firmware version
- Handle removed `PSC_ACCZ_FILT` parameter gracefully (conditional visibility)
- Fix null dereference in `APMFollowComponent.qml` for `_followYawBehavior`

### C++ Changes
- Rename `maximumHorizontalSpeedMultirotor` → `maximumHorizontalSpeedMultirotorMetersSecond` for clarity
- Use `noremap.` in speed/takeoff altitude functions to detect firmware version and apply correct unit conversion
- Enhanced documentation in `FirmwarePlugin.h` and `ParameterManager.h`

## Testing
- Tested with ArduCopter 4.7 SITL
- Verified parameter display and editing in Safety, Tuning, and Flight Mode setup pages
- Verified RTL altitude default values use correct units

Fixes #14079