### PR TITLE
Adds the ability for Android devices to import .plan files into the storage directory.

### DIFF
--- a/android/src/org/mavlink/qgroundcontrol/QGCActivity.java
+++ b/android/src/org/mavlink/qgroundcontrol/QGCActivity.java
@@ -1,8 +1,17 @@
 package org.mavlink.qgroundcontrol;
 
+import java.io.File;
+import java.io.FileOutputStream;
+import java.io.InputStream;
+import android.app.Activity;
+import android.content.Intent;
 import android.content.Context;
+import android.database.Cursor;
+import android.net.Uri;
 import android.net.wifi.WifiManager;
 import android.os.Bundle;
+import android.provider.OpenableColumns;
+import android.util.Log;
 import android.view.KeyEvent;
 import android.view.MotionEvent;
 
@@ -13,6 +22,9 @@ public class QGCActivity extends QtActivity {
     private static final String MULTICAST_LOCK_TAG = "QGroundControl";
 
     private static volatile QGCActivity m_instance = null;
+
+    private static final int IMPORT_FILE_REQUEST_CODE = 42;
+    private static String s_importDestPath = "";
 
     private WifiManager.MulticastLock m_wifiMulticastLock;
     private volatile QGCStoragePermissionController m_storagePermissionController;
@@ -58,6 +70,27 @@ public class QGCActivity extends QtActivity {
         super.onDestroy();
     }
 
+    @Override
+    protected void onActivityResult(int requestCode, int resultCode, Intent data) {
+        if (requestCode == IMPORT_FILE_REQUEST_CODE) {
+            if (resultCode == Activity.RESULT_OK && data != null) {
+                final Uri uri = data.getData();
+                if (uri != null) {
+                    final String importedPath = copyFileToDestination(uri, s_importDestPath);
+                    onImportResult(importedPath != null ? importedPath : "");
+                } else {
+                    QGCLogger.w(TAG, "onActivityResult: null URI for file import");
+                    onImportResult("");
+                }
+            } else {
+                QGCLogger.i(TAG, "onActivityResult: file import cancelled or no data returned");
+                onImportResult("");
+            }
+            return;
+        }
+        super.onActivityResult(requestCode, resultCode, data);
+    }
+
     /**
      * Sets up a multicast lock to allow multicast packets.
      */
@@ -89,6 +122,115 @@ public class QGCActivity extends QtActivity {
         }
     }
 
+    /**
+     * Copies a file identified by a content URI to the specified destination directory.
+     *
+     * @param uri     Content URI of the source file returned by ACTION_OPEN_DOCUMENT.
+     * @param destDir Fully-qualified path of the destination directory.
+     * @return Fully-qualified path of the copied file, or null on failure.
+     */
+    private String copyFileToDestination(final Uri uri, final String destDir) {
+        String displayName = "";
+        try (Cursor cursor = getContentResolver().query(uri, null, null, null, null)) {
+            if (cursor != null && cursor.moveToFirst()) {
+                final int nameIndex = cursor.getColumnIndex(OpenableColumns.DISPLAY_NAME);
+                if (nameIndex >= 0) {
+                    displayName = cursor.getString(nameIndex);                    
+                    displayName = sanitizeFilename(displayName);
+                }
+            }
+        } catch (Exception e) {
+            QGCLogger.e(TAG, "Failed to query display name for URI: " + uri, e);
+        }
+
+        if (displayName.isEmpty()) {
+            QGCLogger.e(TAG, "copyFileToDestination: can't get exact file name");
+            return null;
+        }
+
+        if (destDir == null || destDir.isEmpty()) {
+            QGCLogger.e(TAG, "copyFileToDestination: destination directory is empty");
+            return null;
+        }
+
+        if (!isValidImportFileName(displayName)) {
+            QGCLogger.w(TAG, "Rejected non-.plan file: " + displayName);
+            return null;
+        }
+
+        final File destDirectory = new File(destDir);
+        if (!destDirectory.exists()) {
+            QGCLogger.e(TAG, "Destination directory does not exist: " + destDir);
+            return null;
+        }
+        File destFile;
+        try {
+            destFile = resolveDestFile(destDirectory, displayName);
+        }  catch (Exception e) {
+            QGCLogger.e(TAG, "failed to get filename for: " + displayName, e);
+            return null;
+        }
+        try (InputStream is = getContentResolver().openInputStream(uri);
+            FileOutputStream fos = new FileOutputStream(destFile)) {
+            final byte[] buffer = new byte[8192];
+            int bytesRead;
+            while ((bytesRead = is.read(buffer)) != -1) {
+                fos.write(buffer, 0, bytesRead);
+            }
+            QGCLogger.i(TAG, "File imported successfully to: " + destFile.getAbsolutePath());
+            return destFile.getAbsolutePath();
+        } catch (Exception e) {
+            QGCLogger.e(TAG, "Failed to copy file to destination", e);
+            return null;
+        }
+    }
+
+    /**
+     * sanitize file name.
+     */
+    static String sanitizeFilename(String displayName) {
+        String[] badCharacters = new String[] { "..", "/" };
+        String[] segments = displayName.split("/");
+        String fileName = segments[segments.length - 1];
+        for (String suspString : badCharacters) {
+            fileName = fileName.replace(suspString, "_");
+        }
+        return fileName;
+    }
+
+    /**
+     * Returns a File inside destDir whose path does not yet exist.
+     */
+    static File resolveDestFile(final File destDir, final String displayName) {
+        File candidate = new File(destDir, displayName);
+        if (!candidate.exists()) {
+            return candidate;
+        }
+
+        final int dotIndex = displayName.lastIndexOf('.');
+        final String base = (dotIndex >= 0) ? displayName.substring(0, dotIndex) : displayName;
+        final String ext  = (dotIndex >= 0) ? displayName.substring(dotIndex)    : "";
+
+        for (int i = 1; i <= Integer.MAX_VALUE; i++) {
+            candidate = new File(destDir, base + "_" + i + ext);
+            if (!candidate.exists()) {
+                return candidate;
+            }
+        }
+        throw new IllegalStateException("resolveDestFile: no free filename found under " + destDir);
+    }
+
+    /**
+     * Returns true when is a valid mission-file name that may be imported.
+     * A valid name is non-null, non-empty, and ends with the .plan extension
+     */
+    public static boolean isValidImportFileName(final String displayName) {
+        if (displayName == null || displayName.isEmpty()) {
+            return false;
+        }
+        return displayName.toLowerCase(java.util.Locale.ROOT).endsWith(".plan");
+    }
+
     public static String getSDCardPath() {
         final QGCActivity activity = m_instance;
         if (activity == null) {
@@ -118,6 +260,26 @@ public class QGCActivity extends QtActivity {
             activity.m_storagePermissionController = new QGCStoragePermissionController(activity);
         }
         return activity.m_storagePermissionController.checkStoragePermissions();
+    }
+
+    /**
+     * Opens Android's native file picker using ACTION_OPEN_DOCUMENT.
+     * The selected file will be copied to the provided destination directory.
+     *
+     * @param destPath Fully-qualified path of the destination Missions directory.
+     */
+    public static void openFileImportDialog(final String destPath) {
+        if (m_instance == null) {
+            QGCLogger.e(TAG, "Activity instance is null");
+            return;
+        }
+        s_importDestPath = (destPath != null) ? destPath : "";
+        m_instance.runOnUiThread(() -> {
+            final Intent intent = new Intent(Intent.ACTION_OPEN_DOCUMENT);
+            intent.addCategory(Intent.CATEGORY_OPENABLE);
+            intent.setType("*/*");
+            m_instance.startActivityForResult(intent, IMPORT_FILE_REQUEST_CODE);
+        });
     }
 
     @Override
@@ -153,4 +315,5 @@ public class QGCActivity extends QtActivity {
     public native void qgcLogDebug(final String message);
     public native void qgcLogWarning(final String message);
     public native void nativeStoragePermissionsResult(boolean granted);
+    public native void onImportResult(final String filePath);
 }

--- a/android/src/test/java/org/mavlink/qgroundcontrol/QGCActivityTest.java
+++ b/android/src/test/java/org/mavlink/qgroundcontrol/QGCActivityTest.java
@@ -1,0 +1,166 @@
+package org.mavlink.qgroundcontrol;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
+
+import java.io.File;
+import java.io.IOException;
+import java.lang.reflect.Method;
+import java.lang.reflect.Modifier;
+import java.nio.file.Files;
+
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+
+/**
+ * Unit tests for {@link QGCActivity} helpers that can be exercised without a
+ * running Android runtime.
+ */
+public class QGCActivityTest {
+
+    // -----------------------------------------------------------------------
+    // isValidImportFileName  (covers the copyFileToDestination file-name gate)
+    // -----------------------------------------------------------------------
+
+    @Test
+    public void isValidImportFileName_returnsTrueForLowerCasePlanExtension() {
+        assertTrue(QGCActivity.isValidImportFileName("mission.plan"));
+    }
+
+    @Test
+    public void isValidImportFileName_isCaseInsensitive() {
+        assertTrue(QGCActivity.isValidImportFileName("MISSION.PLAN"));
+        assertTrue(QGCActivity.isValidImportFileName("Mission.Plan"));
+        assertTrue(QGCActivity.isValidImportFileName("test.PLAN"));
+    }
+
+    @Test
+    public void isValidImportFileName_acceptsNamesWithSpacesAndSpecialChars() {
+        assertTrue(QGCActivity.isValidImportFileName("my mission (v2).plan"));
+        assertTrue(QGCActivity.isValidImportFileName("survey_grid.plan"));
+    }
+
+    @Test
+    public void isValidImportFileName_returnsFalseForWrongExtension() {
+        assertFalse(QGCActivity.isValidImportFileName("mission.kml"));
+        assertFalse(QGCActivity.isValidImportFileName("mission.json"));
+        assertFalse(QGCActivity.isValidImportFileName("mission.waypoints"));
+        assertFalse(QGCActivity.isValidImportFileName("mission"));
+    }
+
+    @Test
+    public void isValidImportFileName_returnsFalseForEmptyName() {
+        assertFalse(QGCActivity.isValidImportFileName(""));
+    }
+
+    @Test
+    public void isValidImportFileName_returnsFalseForNullName() {
+        assertFalse(QGCActivity.isValidImportFileName(null));
+    }
+
+    @Test
+    public void isValidImportFileName_returnsFalseForPlanAsPrefix() {
+        // ".plan" must be the suffix, not just appear somewhere in the name.
+        assertFalse(QGCActivity.isValidImportFileName("plan.kml"));
+        assertFalse(QGCActivity.isValidImportFileName("mission.plan.bak"));
+    }
+
+    // -----------------------------------------------------------------------
+    // resolveDestFile — unique-name resolution with _1, _2, … suffixes
+    // -----------------------------------------------------------------------
+
+    @Test
+    public void resolveDestFile_returnsSameNameWhenFileDoesNotExist() throws IOException {
+        final File tmpDir = Files.createTempDirectory("qgc_test").toFile();
+        try {
+            final File result = QGCActivity.resolveDestFile(tmpDir, "mission.plan");
+            assertNotNull(result);
+            assertEquals("mission.plan", result.getName());
+        } finally {
+            tmpDir.delete();
+        }
+    }
+
+    @Test
+    public void resolveDestFile_appendsSuffix1WhenOriginalExists() throws IOException {
+        final File tmpDir = Files.createTempDirectory("qgc_test").toFile();
+        try {
+            assertTrue(new File(tmpDir, "mission.plan").createNewFile());
+            final File result = QGCActivity.resolveDestFile(tmpDir, "mission.plan");
+            assertNotNull(result);
+            assertEquals("mission_1.plan", result.getName());
+        } finally {
+            final File[] files = tmpDir.listFiles();
+            if (files != null) { for (File f : files) f.delete(); }
+            tmpDir.delete();
+        }
+    }
+
+    @Test
+    public void resolveDestFile_appendsSuffix2WhenSuffix1AlsoExists() throws IOException {
+        final File tmpDir = Files.createTempDirectory("qgc_test").toFile();
+        try {
+            assertTrue(new File(tmpDir, "mission.plan").createNewFile());
+            assertTrue(new File(tmpDir, "mission_1.plan").createNewFile());
+            final File result = QGCActivity.resolveDestFile(tmpDir, "mission.plan");
+            assertNotNull(result);
+            assertEquals("mission_2.plan", result.getName());
+        } finally {
+            final File[] files = tmpDir.listFiles();
+            if (files != null) { for (File f : files) f.delete(); }
+            tmpDir.delete();
+        }
+    }
+
+    @Test
+    public void resolveDestFile_handlesNameWithoutExtension() throws IOException {
+        final File tmpDir = Files.createTempDirectory("qgc_test").toFile();
+        try {
+            assertTrue(new File(tmpDir, "noext").createNewFile());
+            final File result = QGCActivity.resolveDestFile(tmpDir, "noext");
+            assertNotNull(result);
+            assertEquals("noext_1", result.getName());
+        } finally {
+            final File[] files = tmpDir.listFiles();
+            if (files != null) { for (File f : files) f.delete(); }
+            tmpDir.delete();
+        }
+    }
+
+    @Test
+    public void resolveDestFile_skipsMultipleExistingVariants() throws IOException {
+        final File tmpDir = Files.createTempDirectory("qgc_test").toFile();
+        try {
+            assertTrue(new File(tmpDir, "survey.plan").createNewFile());
+            assertTrue(new File(tmpDir, "survey_1.plan").createNewFile());
+            assertTrue(new File(tmpDir, "survey_2.plan").createNewFile());
+            assertTrue(new File(tmpDir, "survey_3.plan").createNewFile());
+            final File result = QGCActivity.resolveDestFile(tmpDir, "survey.plan");
+            assertNotNull(result);
+            assertEquals("survey_4.plan", result.getName());
+        } finally {
+            final File[] files = tmpDir.listFiles();
+            if (files != null) { for (File f : files) f.delete(); }
+            tmpDir.delete();
+        }
+    }
+
+    // -----------------------------------------------------------------------
+    // jniOnImportResult — verifies the onImportResult JNI bridge declaration
+    // -----------------------------------------------------------------------
+
+    @Test
+    public void onImportResult_isPublicNativeAndTakesStringReturnsVoid() throws NoSuchMethodException {
+        final Method method = QGCActivity.class.getDeclaredMethod("onImportResult", String.class);
+
+        assertTrue("onImportResult must be public",
+                Modifier.isPublic(method.getModifiers()));
+        assertTrue("onImportResult must be native (jniOnImportResult JNI bridge)",
+                Modifier.isNative(method.getModifiers()));
+        assertEquals("onImportResult must return void",
+                void.class, method.getReturnType());
+    }
+}

--- a/src/Android/AndroidInterface.cc
+++ b/src/Android/AndroidInterface.cc
@@ -22,6 +22,8 @@ QGC_LOGGING_CATEGORY(AndroidInterfaceLog, "Android.AndroidInterface")
 
 namespace AndroidInterface {
 
+static std::function<void(const QString&)> s_importCallback;
+
 static void jniLogDebug(JNIEnv*, jobject, jstring message)
 {
     qCDebug(AndroidInterfaceLog) << QJniObject(message).toString();
@@ -84,6 +86,19 @@ static void jniStoragePermissionsResult(JNIEnv*, jobject, jboolean granted)
         Qt::QueuedConnection);
 }
 
+static void jniOnImportResult(JNIEnv* env, jobject, jstring filePathA)
+{
+    const char* const filePathCStr = env->GetStringUTFChars(filePathA, nullptr);
+    const QString filePath = QString::fromUtf8(filePathCStr);
+    env->ReleaseStringUTFChars(filePathA, filePathCStr);
+    (void)QJniEnvironment::checkAndClearExceptions(env);
+    auto callback = std::move(s_importCallback);
+    if (!callback) {
+        return;
+    }
+    callback(filePath);
+}
+
 void setNativeMethods()
 {
     qCDebug(AndroidInterfaceLog) << "Registering Native Functions";
@@ -91,7 +106,8 @@ void setNativeMethods()
     const JNINativeMethod javaMethods[]{
         {"qgcLogDebug", "(Ljava/lang/String;)V", reinterpret_cast<void*>(jniLogDebug)},
         {"qgcLogWarning", "(Ljava/lang/String;)V", reinterpret_cast<void*>(jniLogWarning)},
-        {"nativeStoragePermissionsResult", "(Z)V", reinterpret_cast<void*>(jniStoragePermissionsResult)}};
+        {"nativeStoragePermissionsResult", "(Z)V", reinterpret_cast<void*>(jniStoragePermissionsResult)},
+        {"onImportResult", "(Ljava/lang/String;)V", reinterpret_cast<void*>(jniOnImportResult)}};
 
     QJniEnvironment env;
     if (!env.registerNativeMethods(kJniQGCActivityClassName, javaMethods, std::size(javaMethods))) {
@@ -140,6 +156,27 @@ QString getSDCardPath()
     }
 
     return result.toString();
+}
+
+void openFileImportDialog(const QString& destPath, std::function<void(const QString&)> callback)
+{
+    s_importCallback = std::move(callback);
+
+    const QJniObject jDestPath = QJniObject::fromString(destPath);
+    QJniObject::callStaticMethod<void>(
+        kJniQGCActivityClassName,
+        "openFileImportDialog",
+        "(Ljava/lang/String;)V",
+        jDestPath.object<jstring>());
+
+    QJniEnvironment env;
+    if (env.checkAndClearExceptions()) {
+        qCWarning(AndroidInterfaceLog) << "Exception in openFileImportDialog";
+        if (s_importCallback) {
+            auto cb = std::move(s_importCallback);
+            cb(QString());
+        }
+    }
 }
 
 static QSharedPointer<QLocks::QLockBase> s_partialWakeLock;

--- a/src/Android/AndroidInterface.h
+++ b/src/Android/AndroidInterface.h
@@ -4,6 +4,8 @@
 #include <QtCore/QLoggingCategory>
 #include <QtCore/QString>
 
+#include <functional>
+
 Q_DECLARE_LOGGING_CATEGORY(AndroidInterfaceLog)
 
 namespace AndroidInterface {
@@ -11,6 +13,7 @@ void setNativeMethods();
 bool checkStoragePermissions();
 QString getSDCardPath();
 void setKeepScreenOn(bool on);
+void openFileImportDialog(const QString& destPath, std::function<void(const QString&)> callback);
 
 constexpr const char* kJniQGCActivityClassName = "org/mavlink/qgroundcontrol/QGCActivity";
 

--- a/src/QmlControls/QGCFileDialog.qml
+++ b/src/QmlControls/QGCFileDialog.qml
@@ -22,6 +22,7 @@ Item {
     signal acceptedForLoad(string file)
     signal acceptedForSave(string file)
     signal rejected
+    signal fileImportedNotify           // Emitted on a successful import so the open dialog can refresh its list.
 
     function openForLoad() {
         _openForLoad = true
@@ -54,6 +55,7 @@ Item {
     property bool   _mobileDlg:     QGroundControl.corePlugin.options.useMobileFileDialog
     property var    _rgExtensions
     property string _mobileShortPath
+    property bool   _importPending: false
 
     Component.onCompleted: {
         _setupFileExtensions()
@@ -88,6 +90,21 @@ Item {
     }
 
     QGCPalette { id: qgcPal; colorGroupEnabled: true }
+
+    Connections {
+        target: QGCFileDialogController
+        enabled: Qt.platform.os === "android" && _root._importPending
+
+        function onFileImported() {
+            _root._importPending = false
+            _root.fileImportedNotify()
+        }
+
+        function onImportFailed(errorMessage) {
+            _root._importPending = false
+            QGroundControl.showMessageDialog(_root, qsTr("Import"), errorMessage)
+        }
+    }
 
     FileDialog {
         id:             fullFileDialog
@@ -129,6 +146,13 @@ Item {
             id:         mobileFileOpenDialog
             title:      _root.title
             buttons:    Dialog.Cancel
+
+            Connections {
+                target: _root
+                function onFileImportedNotify() {
+                    fileRepeater.model = QGCFileDialogController.getFiles(folder, _rgExtensions)
+                }
+            }
 
             Column {
                 id:         fileOpenColumn
@@ -179,6 +203,18 @@ Item {
                 QGCLabel {
                     text:       qsTr("No files")
                     visible:    fileRepeater.model.length === 0
+                }
+
+                QGCButton {
+                    anchors.left:   parent.left
+                    anchors.right:  parent.right
+                    text:           qsTr("Import")
+                    visible:        Qt.platform.os === "android"
+
+                    onClicked: {
+                        _root._importPending = true
+                        QGCFileDialogController.importFromNativePicker()
+                    }
                 }
             }
         }

--- a/src/QmlControls/QGCFileDialogController.cc
+++ b/src/QmlControls/QGCFileDialogController.cc
@@ -5,6 +5,11 @@
 
 #include <QtCore/QDir>
 
+#ifdef Q_OS_ANDROID
+#include <QtCore/QPointer>
+#include "AndroidInterface.h"
+#endif
+
 QGC_LOGGING_CATEGORY(QGCFileDialogControllerLog, "QMLControls.QGCFileDialogController")
 
 QGCFileDialogController::QGCFileDialogController(QObject *parent)
@@ -104,3 +109,50 @@ QString QGCFileDialogController::urlToLocalFile(QUrl url)
 
     return url.toString();
 }
+
+void QGCFileDialogController::importFromNativePicker()
+{
+#ifdef Q_OS_ANDROID
+    const QString missionPath = SettingsManager::instance()->appSettings()->missionSavePath();
+    if (missionPath.isEmpty()) {
+        qCWarning(QGCFileDialogControllerLog) << "Missions save path is empty";
+        emit importFailed(tr("Missions directory is not configured"));
+        return;
+    }
+
+    QDir dir(missionPath);
+    if (!dir.exists()) {
+        qCWarning(QGCFileDialogControllerLog) << "Missions save path does not exist";
+        emit importFailed(tr("Missions save path does not exist"));
+        return;
+    }
+
+    QPointer<QGCFileDialogController> self = this;
+    AndroidInterface::openFileImportDialog(missionPath, [self](const QString& filePath) {
+        if (self) {
+            QMetaObject::invokeMethod(
+                self,
+                [filePath, self]() { self->_handleImportResult(filePath); },
+                Qt::QueuedConnection);
+        }
+    });
+#else
+    qCWarning(QGCFileDialogControllerLog) << Q_FUNC_INFO << "only supported on Android";
+#endif
+}
+
+#ifdef Q_OS_ANDROID
+
+void QGCFileDialogController::_handleImportResult(const QString& filePath)
+{
+    if (filePath.isEmpty()) {
+        qCWarning(QGCFileDialogControllerLog) << "Import failed: empty file path received from Java";
+        emit importFailed(tr("Failed to import file"));
+        return;
+    }
+
+    qCDebug(QGCFileDialogControllerLog) << "File imported successfully to:" << filePath;
+    emit fileImported(filePath);
+}
+
+#endif // Q_OS_ANDROID

--- a/src/QmlControls/QGCFileDialogController.h
+++ b/src/QmlControls/QGCFileDialogController.h
@@ -36,4 +36,22 @@ public:
     /// Returns the standard QGC location portion of a fully qualified folder path.
     /// Example: "/Users/Don/Document/QGroundControl/Missions" returns "QGroundControl/Missions"
     Q_INVOKABLE static QString fullFolderPathToShortMobilePath(const QString &fullFolderPath);
+
+    /// Opens Android's native file picker (ACTION_OPEN_DOCUMENT).
+    /// On non-Android platforms this is a no-op.
+    Q_INVOKABLE void importFromNativePicker();
+
+signals:
+    /// Emitted when the selected file has been successfully imported to the Missions directory.
+    /// @param filePath Fully-qualified path of the imported file in the Missions directory.
+    void fileImported(const QString& filePath);
+
+    /// Emitted when the import operation fails.
+    /// @param errorMessage Human-readable description of the error.
+    void importFailed(const QString& errorMessage);
+
+private:
+#ifdef Q_OS_ANDROID
+    void _handleImportResult(const QString& filePath);
+#endif
 };


### PR DESCRIPTION
## Description
A QGroundControl user on an Android device will be able to select a .plan file from publicly accessible directories. When a file is selected, it will be copied to the Missions directory. If a file with the same name already exists, the new file will be copied with a suffix to avoid overwriting. This feature applies only to Android; the workflow on PC remains unchanged.

## Feature use case
Any third-party app can store a plan file in a public directory. The user then opens QGC and selects this file to import.

## Type of Change
<!-- Put an 'x' in the relevant boxes -->
- [ ] Bug fix (non-breaking change that fixes an issue)
- [X] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] CI/Build changes
- [ ] Other

## Testing
<!-- Describe the tests you ran and how to reproduce them -->
- [X] Tested locally
- [x] Added/updated unit tests
- [X] Tested with simulator (SITL)
- [ ] Tested with hardware

### Platforms Tested
<!-- Check all that apply -->
- [X] Linux
- [ ] Windows
- [ ] macOS
- [ ] Android 9
- [ ] Android 10
- [ ] Android 11
- [X] Android 12
- [ ] Android 13
- [X] Android 14
- [ ] Android 15+
- [ ] iOS

### Flight Stacks Tested
<!-- If applicable -->
- [ ] PX4
- [ ] ArduPilot

## Screenshots
![1](https://github.com/user-attachments/assets/e61c5aaf-4ee6-49c3-81bb-9f0e1dfacff6)
![2](https://github.com/user-attachments/assets/8be23a66-27f4-4466-8566-68fa9145e5e3)
![3](https://github.com/user-attachments/assets/21e6954c-c593-4b7e-8ff5-77554a10d805)

## Checklist
<!-- Go over all the following points, and put an 'x' in all the boxes that apply -->
- [X] I have read the [Contribution Guidelines](CONTRIBUTING.md)
- [X] I have read the [Code of Conduct](CODE_OF_CONDUCT.md)
- [X] My code follows the project's coding standards
- [x] I have added tests that prove my fix/feature works
- [x] New and existing unit tests pass locally

## Related Issues
[https://github.com/mavlink/qgroundcontrol/issues/14064](https://github.com/mavlink/qgroundcontrol/issues/14064)

---
By submitting this pull request, I confirm that my contribution is made under the terms of the project's dual license (Apache 2.0 and GPL v3).
