### PR TITLE
Fix lupdate JSON path and add weekly schedule

### DIFF
--- a/.github/workflows/lupdate.yml
+++ b/.github/workflows/lupdate.yml
@@ -1,6 +1,8 @@
 name: Update Translations
 
 on:
+  schedule:
+    - cron: '0 3 * * 0'  # Every Sunday at 03:00 UTC
   workflow_dispatch:
 
 concurrency:

--- a/tools/translations/README.md
+++ b/tools/translations/README.md
@@ -10,9 +10,9 @@ Crowdin is configured to automatically sychronize the qgc.ts file once a day. So
 
 Add the new language from the CrowdIn settings as the first step.
 
-### Periodically update the base transation files during the release cycle
+### Periodically update the base translation files during the release cycle
 
-You do this by running the `source tools/translations/qgc-lupdate.sh` script to update the translations files for both Qt and Json. Crowdin will automatically pull these up and submit a pull request back when new translations are available.
+The `lupdate.yml` workflow runs automatically every Sunday to regenerate the `.ts` source files and open a PR with any changes. You can also trigger it manually from the Actions tab or run it locally with `./tools/translations/qgc-lupdate.sh` from the repository root. Crowdin will automatically pull these up and submit a pull request back when new translations are available.
 
 ## C++ and Qml code strings
 

--- a/tools/translations/qgc-lupdate-json.py
+++ b/tools/translations/qgc-lupdate-json.py
@@ -108,7 +108,7 @@ def walkDirectoryTreeForJsonFiles(dir, multiFileLocArray):
             walkDirectoryTreeForJsonFiles(path, multiFileLocArray)
 
 
-def writeJsonTSFile(multiFileLocArray):
+def writeJsonTSFile(output_path, multiFileLocArray):
     ts_root = ET.Element("TS", version="2.1")
 
     for entry in multiFileLocArray:
@@ -146,7 +146,7 @@ def writeJsonTSFile(multiFileLocArray):
             ET.SubElement(message, "source").text = sourceStr
             ET.SubElement(message, "translation", type="unfinished")
 
-    with open("translations/qgc-json.ts", "w", encoding="utf-8") as jsonTSFile:
+    with open(output_path, "w", encoding="utf-8") as jsonTSFile:
         jsonTSFile.write('<?xml version="1.0" encoding="utf-8"?>\n')
         jsonTSFile.write("<!DOCTYPE TS>\n")
         jsonTSFile.write(ET.tostring(ts_root, encoding="unicode"))
@@ -154,9 +154,13 @@ def writeJsonTSFile(multiFileLocArray):
 
 
 def main():
+    # Resolve repo root from script location so CWD doesn't matter
+    script_dir = os.path.dirname(os.path.abspath(__file__))
+    repo_root = os.path.normpath(os.path.join(script_dir, "..", ".."))
+
     multiFileLocArray = []
-    walkDirectoryTreeForJsonFiles("../src", multiFileLocArray)
-    writeJsonTSFile(multiFileLocArray)
+    walkDirectoryTreeForJsonFiles(os.path.join(repo_root, "src"), multiFileLocArray)
+    writeJsonTSFile(os.path.join(repo_root, "translations", "qgc-json.ts"), multiFileLocArray)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary

- Fix `qgc-lupdate-json.py` path bug: `../src` → `src` so it works when called from the repo root via `qgc-lupdate.sh`
- Add weekly cron schedule (Sunday 03:00 UTC) to `lupdate.yml` workflow
- Update translations README to reflect the automated schedule

## Details

The `qgc-lupdate-json.py` script used `../src` as its source directory, which only works when run from `tools/translations/`. Since `qgc-lupdate.sh` (and the CI workflow) run from the repo root, this path was incorrect. Changed to `src` to match.

The `lupdate.yml` workflow previously only supported manual `workflow_dispatch`. Added a weekly schedule so translation source files stay up to date automatically. Crowdin will pick up changes and submit translation PRs as usual.
