### PR TITLE
PX4: Rename RC Loss to RC/Joystick Loss in safety UI

### DIFF
--- a/src/AutoPilotPlugins/PX4/SafetyComponent.qml
+++ b/src/AutoPilotPlugins/PX4/SafetyComponent.qml
@@ -213,7 +213,7 @@ SetupPage {
                 }
 
                 QGCLabel {
-                    text:                   qsTr("RC Loss Failsafe Trigger")
+                    text:                   qsTr("RC/Joystick Loss Failsafe Trigger")
                 }
 
                 Rectangle {
@@ -253,7 +253,7 @@ SetupPage {
                             }
 
                             QGCLabel {
-                                text:               qsTr("RC Loss Timeout:")
+                                text:               qsTr("RC/Joystick Loss Timeout:")
                                 Layout.fillWidth:   true
                             }
                             FactTextField {

--- a/src/AutoPilotPlugins/PX4/SafetyComponentSummary.qml
+++ b/src/AutoPilotPlugins/PX4/SafetyComponentSummary.qml
@@ -33,12 +33,12 @@ Item {
         }
 
         VehicleSummaryRow {
-            labelText: qsTr("RC Loss Failsafe")
+            labelText: qsTr("RC/Joystick Loss Failsafe")
             valueText: rcLossAction ? rcLossAction.enumStringValue : ""
         }
 
         VehicleSummaryRow {
-            labelText: qsTr("RC Loss Timeout")
+            labelText: qsTr("RC/Joystick Loss Timeout")
             valueText: commRCLossFact ? commRCLossFact.valueString + " " + commRCLossFact.units : ""
         }
 


### PR DESCRIPTION
Replaces #14027

## Description

PX4 now centralizes its handling of Joystick and RC controllers, so RC loss is actually loss of all configured manual controllers. This updates the safety component UI labels from "RC Loss" to "RC/Joystick Loss" to reflect that.

## Changes

- `SafetyComponent.qml`: "RC Loss Failsafe Trigger" → "RC/Joystick Loss Failsafe Trigger", "RC Loss Timeout:" → "RC/Joystick Loss Timeout:"
- `SafetyComponentSummary.qml`: "RC Loss Failsafe" → "RC/Joystick Loss Failsafe", "RC Loss Timeout" → "RC/Joystick Loss Timeout"
