### PR TITLE
Refactor camera tracking and on-screen gimbal support

### DIFF
--- a/src/Camera/MavlinkCameraControlInterface.h
+++ b/src/Camera/MavlinkCameraControlInterface.h
@@ -44,6 +44,8 @@ class MavlinkCameraControlInterface : public FactGroup
     Q_PROPERTY(bool                 hasFocus                READ hasFocus                                           NOTIFY infoChanged)
     Q_PROPERTY(bool                 hasVideoStream          READ hasVideoStream                                     NOTIFY infoChanged)
     Q_PROPERTY(bool                 hasTracking             READ hasTracking                                        NOTIFY infoChanged)
+    Q_PROPERTY(bool                 supportsTrackingPoint   READ supportsTrackingPoint                              NOTIFY infoChanged)
+    Q_PROPERTY(bool                 supportsTrackingRect    READ supportsTrackingRect                               NOTIFY infoChanged)
     Q_PROPERTY(bool                 photosInVideoMode       READ photosInVideoMode                                  NOTIFY infoChanged)
     Q_PROPERTY(bool                 videoInPhotoMode        READ videoInPhotoMode                                   NOTIFY infoChanged)
     Q_PROPERTY(bool                 isBasic                 READ isBasic                                            NOTIFY infoChanged)
@@ -74,10 +76,14 @@ class MavlinkCameraControlInterface : public FactGroup
     Q_PROPERTY(QStringList          streamLabels            READ streamLabels                                       NOTIFY streamLabelsChanged)
     Q_PROPERTY(ThermalViewMode      thermalMode             READ thermalMode            WRITE setThermalMode        NOTIFY thermalModeChanged)
     Q_PROPERTY(double               thermalOpacity          READ thermalOpacity         WRITE setThermalOpacity     NOTIFY thermalOpacityChanged)
+
+    // Camera tracking properties
     Q_PROPERTY(bool                 trackingEnabled         READ trackingEnabled        WRITE setTrackingEnabled    NOTIFY trackingEnabledChanged)
-    Q_PROPERTY(TrackingStatus       trackingStatus          READ trackingStatus                                     CONSTANT)
-    Q_PROPERTY(bool                 trackingImageStatus     READ trackingImageStatus                                NOTIFY trackingImageStatusChanged)
-    Q_PROPERTY(QRectF               trackingImageRect       READ trackingImageRect                                  NOTIFY trackingImageStatusChanged)
+    Q_PROPERTY(bool                 trackingImageIsActive   READ trackingImageIsActive                              NOTIFY trackingImageIsActiveChanged)
+    Q_PROPERTY(bool                 trackingImageIsPoint    READ trackingImageIsPoint                               NOTIFY trackingImageIsPointChanged)
+    Q_PROPERTY(QRectF               trackingImageRect       READ trackingImageRect                                  NOTIFY trackingImageRectChanged)
+    Q_PROPERTY(QPointF              trackingImagePoint      READ trackingImagePoint                                 NOTIFY trackingImagePointChanged)
+    Q_PROPERTY(qreal                trackingImageRadius     READ trackingImageRadius                                NOTIFY trackingImageRadiusChanged)
 
     // These properties are used to determine what controls to show in the UI and are based on both the camera capabilities as well as the video manager status.
     // They are not necessarily directly related to the MAVLink camera capabilities.
@@ -141,14 +147,6 @@ public:
     };
     Q_ENUM(ThermalViewMode)
 
-    enum TrackingStatus {
-        TRACKING_UNKNOWN = 0,
-        TRACKING_SUPPORTED = 1,
-        TRACKING_ENABLED = 2,
-        TRACKING_RECTANGLE = 4,
-        TRACKING_POINT = 8
-    };
-    Q_ENUM(TrackingStatus)
 
     Q_INVOKABLE virtual void setCameraModeVideo() = 0;
     Q_INVOKABLE virtual void setCameraModePhoto() = 0;
@@ -165,8 +163,8 @@ public:
     Q_INVOKABLE virtual void stopZoom() = 0;
     Q_INVOKABLE virtual void stopStream() = 0;
     Q_INVOKABLE virtual void resumeStream() = 0;
-    Q_INVOKABLE virtual void startTracking(QRectF rec) = 0;
-    Q_INVOKABLE virtual void startTracking(QPointF point, double radius) = 0;
+    Q_INVOKABLE virtual void startTrackingRect(QRectF rec) = 0;
+    Q_INVOKABLE virtual void startTrackingPoint(QPointF point, double radius) = 0;
     Q_INVOKABLE virtual void stopTracking() = 0;
 
     virtual int version() const = 0;
@@ -182,6 +180,8 @@ public:
     virtual bool hasZoom() const = 0;
     virtual bool hasFocus() const = 0;
     virtual bool hasTracking() const = 0;
+    virtual bool supportsTrackingPoint() const = 0;
+    virtual bool supportsTrackingRect() const = 0;
     virtual bool hasVideoStream() const = 0;
     virtual bool photosInVideoMode() const = 0;
     virtual bool videoInPhotoMode() const = 0;
@@ -239,10 +239,11 @@ public:
     virtual bool trackingEnabled() const = 0;
     virtual void setTrackingEnabled(bool set) = 0;
 
-    virtual TrackingStatus trackingStatus() const = 0;
-
-    virtual bool trackingImageStatus() const = 0;
+    virtual bool trackingImageIsActive() const = 0;
+    virtual bool trackingImageIsPoint() const = 0;
     virtual QRectF trackingImageRect() const = 0;
+    virtual QPointF trackingImagePoint() const = 0;
+    virtual qreal trackingImageRadius() const = 0;
 
     virtual void factChanged(Fact *pFact) = 0;                              ///< Notify controller a parameter has changed
     virtual bool incomingParameter(Fact *pFact, QVariant &newValue) = 0;    ///< Allow controller to modify or invalidate incoming parameter
@@ -286,7 +287,11 @@ signals:
     void recordTimeChanged();
     void streamLabelsChanged();
     void trackingEnabledChanged();
-    void trackingImageStatusChanged();
+    void trackingImageIsActiveChanged();
+    void trackingImageIsPointChanged();
+    void trackingImageRectChanged();
+    void trackingImagePointChanged();
+    void trackingImageRadiusChanged();
     void thermalModeChanged();
     void thermalOpacityChanged();
     void storageStatusChanged();

--- a/src/Camera/QGCCameraManager.cc
+++ b/src/Camera/QGCCameraManager.cc
@@ -796,8 +796,8 @@ void QGCCameraManager::_handleCameraFovStatus(const mavlink_message_t& message)
     }
 
     auto* settings = SettingsManager::instance()->gimbalControllerSettings();
-    settings->CameraHFov()->setRawValue(fov.hfov);
-    settings->CameraVFov()->setRawValue(vfovDeg);
+    settings->cameraHFov()->setRawValue(fov.hfov);
+    settings->cameraVFov()->setRawValue(vfovDeg);
 }
 
 void QGCCameraManager::_setCurrentZoomLevel(int level)

--- a/src/Camera/SimulatedCameraControl.h
+++ b/src/Camera/SimulatedCameraControl.h
@@ -35,8 +35,8 @@ public:
     void stopStream() override {}
     bool stopTakePhoto() override { return false;}
     void resumeStream() override {}
-    void startTracking(QRectF /*rec*/) override {}
-    void startTracking(QPointF /*point*/, double /*radius*/) override {}
+    void startTrackingRect(QRectF /*rec*/) override {}
+    void startTrackingPoint(QPointF /*point*/, double /*radius*/) override {}
     void stopTracking() override {}
 
     int version() const override { return 0; }
@@ -52,6 +52,8 @@ public:
     bool hasZoom() const override { return false; }
     bool hasFocus() const override { return false; }
     bool hasTracking() const override { return false; }
+    bool supportsTrackingPoint() const override { return false; }
+    bool supportsTrackingRect() const override { return false; }
     bool hasVideoStream() const override;
     bool photosInVideoMode() const override { return true; }
     bool videoInPhotoMode() const override { return false; }
@@ -105,10 +107,11 @@ public:
     bool trackingEnabled() const override { return false; }
     void setTrackingEnabled(bool /*set*/) override {}
 
-    TrackingStatus trackingStatus() const override { return TRACKING_UNKNOWN; }
-
-    bool trackingImageStatus() const override { return false; }
+    bool trackingImageIsActive() const override { return false; }
+    bool trackingImageIsPoint() const override { return false; }
     QRectF trackingImageRect() const override { return QRectF(); }
+    QPointF trackingImagePoint() const override { return QPointF(); }
+    qreal trackingImageRadius() const override { return 0.0; }
 
     void factChanged(Fact* /*pFact*/) override {};
     bool incomingParameter(Fact* /*pFact*/, QVariant& /*newValue*/) override { return false; }

--- a/src/Camera/VehicleCameraControl.cc
+++ b/src/Camera/VehicleCameraControl.cc
@@ -17,6 +17,8 @@
 
 #include <QtNetwork/QNetworkAccessManager>
 #include <QtCore/QDir>
+
+#include <algorithm>
 #include <QtCore/QSettings>
 #include <QtXml/QDomDocument>
 #include <QtXml/QDomNodeList>
@@ -130,15 +132,9 @@ VehicleCameraControl::VehicleCameraControl(const mavlink_camera_information_t *i
     _videoRecordTimeUpdateTimer.setInterval(333);
     connect(&_videoRecordTimeUpdateTimer, &QTimer::timeout, this, &VehicleCameraControl::_recTimerHandler);
 
-    //-- Tracking
-    if(_mavlinkCameraInfo.flags & CAMERA_CAP_FLAGS_HAS_TRACKING_RECTANGLE) {
-        _trackingStatus = static_cast<TrackingStatus>(_trackingStatus | TRACKING_RECTANGLE);
-        _trackingStatus = static_cast<TrackingStatus>(_trackingStatus | TRACKING_SUPPORTED);
-    }
-    if(_mavlinkCameraInfo.flags & CAMERA_CAP_FLAGS_HAS_TRACKING_POINT) {
-        _trackingStatus = static_cast<TrackingStatus>(_trackingStatus | TRACKING_POINT);
-        _trackingStatus = static_cast<TrackingStatus>(_trackingStatus | TRACKING_SUPPORTED);
-    }
+    //-- Tracking capabilities
+    _hasTrackingRectCapability = _mavlinkCameraInfo.flags & CAMERA_CAP_FLAGS_HAS_TRACKING_RECTANGLE;
+    _hasTrackingPointCapability = _mavlinkCameraInfo.flags & CAMERA_CAP_FLAGS_HAS_TRACKING_POINT;
 
     connect(this, &VehicleCameraControl::dataReady, this, &VehicleCameraControl::_dataReady);
 
@@ -1693,35 +1689,56 @@ void VehicleCameraControl::handleTrackingImageStatus(const mavlink_camera_tracki
 
     _trackingImageStatus = trackingImageStatus;
 
-    if (_trackingImageStatus.tracking_status == CAMERA_TRACKING_STATUS_FLAGS_IDLE || !trackingEnabled()) {
-        _trackingImageRect = {};
-        qCDebug(CameraControlLog) << "Tracking off";
-    } else {
-        if (_trackingImageStatus.tracking_mode == CAMERA_TRACKING_MODE_RECTANGLE) {
-            _trackingImageRect = QRectF(QPointF(_trackingImageStatus.rec_top_x, _trackingImageStatus.rec_top_y),
-                                        QPointF(_trackingImageStatus.rec_bottom_x, _trackingImageStatus.rec_bottom_y));
-        } else {
-            float r = _trackingImageStatus.radius;
-            if (qIsNaN(r) || r <= 0 ) {
-                r = 0.05f;
-            }
-            // Bottom is NAN so that we can draw perfect square using video aspect ratio
-            _trackingImageRect = QRectF(QPointF(_trackingImageStatus.point_x - r, _trackingImageStatus.point_y - r),
-                                        QPointF(_trackingImageStatus.point_x + r, NAN));
-        }
-        // get rectangle into [0..1] boundaries
-        _trackingImageRect.setLeft(std::min(std::max(_trackingImageRect.left(), 0.0), 1.0));
-        _trackingImageRect.setTop(std::min(std::max(_trackingImageRect.top(), 0.0), 1.0));
-        _trackingImageRect.setRight(std::min(std::max(_trackingImageRect.right(), 0.0), 1.0));
-        _trackingImageRect.setBottom(std::min(std::max(_trackingImageRect.bottom(), 0.0), 1.0));
+    const bool active = ((_trackingImageStatus.tracking_status & CAMERA_TRACKING_STATUS_FLAGS_ACTIVE) != 0) && trackingEnabled();
+    const bool isPoint = active && (_trackingImageStatus.tracking_mode == CAMERA_TRACKING_MODE_POINT);
 
-        qCDebug(CameraControlLog) << "Tracking Image Status [left:" << _trackingImageRect.left()
-                                  << "top:" << _trackingImageRect.top()
-                                  << "right:" << _trackingImageRect.right()
-                                  << "bottom:" << _trackingImageRect.bottom() << "]";
+    if (!active) {
+        qCDebug(CameraControlLog) << "Tracking off";
+        _trackingImageRect = {};
+        _trackingImagePoint = {};
+        _trackingImageRadius = 0.0;
+    } else if (isPoint) {
+        const QPointF point(std::clamp(static_cast<qreal>(_trackingImageStatus.point_x), 0.0, 1.0),
+                              std::clamp(static_cast<qreal>(_trackingImageStatus.point_y), 0.0, 1.0));
+        qreal radius = static_cast<qreal>(_trackingImageStatus.radius);
+        if (qIsNaN(radius) || radius <= 0) {
+            radius = 0.05;
+        } else {
+            radius = std::clamp(radius, 0.0, 1.0);
+        }
+        qCDebug(CameraControlLog) << "Tracking Point [" << point << "] radius:" << radius;
+        _trackingImageRect = {};
+        if (_trackingImagePoint != point) {
+            _trackingImagePoint = point;
+            emit trackingImagePointChanged();
+        }
+        if (!qFuzzyCompare(_trackingImageRadius, radius)) {
+            _trackingImageRadius = radius;
+            emit trackingImageRadiusChanged();
+        }
+    } else {
+        // Rectangle tracking
+        const QRectF rect = QRectF(QPointF(std::clamp(static_cast<qreal>(_trackingImageStatus.rec_top_x), 0.0, 1.0),
+                                        std::clamp(static_cast<qreal>(_trackingImageStatus.rec_top_y), 0.0, 1.0)),
+                                QPointF(std::clamp(static_cast<qreal>(_trackingImageStatus.rec_bottom_x), 0.0, 1.0),
+                                        std::clamp(static_cast<qreal>(_trackingImageStatus.rec_bottom_y), 0.0, 1.0))).normalized();
+        qCDebug(CameraControlLog) << "Tracking Rect [" << rect << "]";
+        _trackingImagePoint = {};
+        _trackingImageRadius = 0.0;
+        if (_trackingImageRect != rect) {
+            _trackingImageRect = rect;
+            emit trackingImageRectChanged();
+        }
     }
 
-    emit trackingImageStatusChanged();
+    if (_trackingImageIsActive != active) {
+        _trackingImageIsActive = active;
+        emit trackingImageIsActiveChanged();
+    }
+    if (_trackingImageIsPoint != isPoint) {
+        _trackingImageIsPoint = isPoint;
+        emit trackingImageIsPointChanged();
+    }
 }
 
 void VehicleCameraControl::setCurrentStream(int stream)
@@ -2323,16 +2340,23 @@ VehicleCameraControl::mode()
 
 void VehicleCameraControl::setTrackingEnabled(bool set)
 {
-    if(set) {
-        _trackingStatus = static_cast<TrackingStatus>(_trackingStatus | TRACKING_ENABLED);
-    } else {
-        _trackingStatus = static_cast<TrackingStatus>(_trackingStatus & ~TRACKING_ENABLED);
+    if (_trackingEnabled == set) {
+        return;
+    }
+    _trackingEnabled = set;
+    if (!set) {
+        stopTracking();
     }
     emit trackingEnabledChanged();
 }
 
-void VehicleCameraControl::startTracking(QRectF rec)
+void VehicleCameraControl::startTrackingRect(QRectF rec)
 {
+    if (!_hasTrackingRectCapability) {
+        qCCritical(CameraControlLog) << "startTrackingRect called but camera does not have rectangle tracking capability";
+        return;
+    }
+
     qCDebug(CameraControlLog) << "Start Tracking (Rectangle: ["
                               << static_cast<float>(rec.x()) << ", "
                               << static_cast<float>(rec.y()) << "] - ["
@@ -2350,8 +2374,13 @@ void VehicleCameraControl::startTracking(QRectF rec)
     _requestTrackingStatus();
 }
 
-void VehicleCameraControl::startTracking(QPointF point, double radius)
+void VehicleCameraControl::startTrackingPoint(QPointF point, double radius)
 {
+    if (!_hasTrackingPointCapability) {
+        qCCritical(CameraControlLog) << "startTrackingPoint called but camera does not have point tracking capability";
+        return;
+    }
+
     qCDebug(CameraControlLog) << "Start Tracking (Point: ["
                               << static_cast<float>(point.x()) << ", "
                               << static_cast<float>(point.y()) << "], Radius:  "
@@ -2383,8 +2412,18 @@ void VehicleCameraControl::stopTracking()
                              MAVLINK_MSG_ID_CAMERA_TRACKING_IMAGE_STATUS,
                              -1);
 
-    // reset tracking image rectangle
+    // reset tracking state
     _trackingImageRect = {};
+    _trackingImagePoint = {};
+    _trackingImageRadius = 0.0;
+    if (_trackingImageIsActive) {
+        _trackingImageIsActive = false;
+        emit trackingImageIsActiveChanged();
+    }
+    if (_trackingImageIsPoint) {
+        _trackingImageIsPoint = false;
+        emit trackingImageIsPointChanged();
+    }
 }
 
 void VehicleCameraControl::_requestTrackingStatus()

--- a/src/Camera/VehicleCameraControl.h
+++ b/src/Camera/VehicleCameraControl.h
@@ -56,8 +56,8 @@ public:
     Q_INVOKABLE virtual void stopZoom               ();
     Q_INVOKABLE virtual void stopStream             ();
     Q_INVOKABLE virtual void resumeStream           ();
-    Q_INVOKABLE virtual void startTracking          (QRectF rec);
-    Q_INVOKABLE virtual void startTracking          (QPointF point, double radius);
+    Q_INVOKABLE virtual void startTrackingRect      (QRectF rec);
+    Q_INVOKABLE virtual void startTrackingPoint     (QPointF point, double radius);
     Q_INVOKABLE virtual void stopTracking           ();
 
     virtual int         version             () const { return _version; }
@@ -72,7 +72,9 @@ public:
     virtual bool        hasModes            () const { return _mavlinkCameraInfo.flags & CAMERA_CAP_FLAGS_HAS_MODES; }
     virtual bool        hasZoom             () const { return _mavlinkCameraInfo.flags & CAMERA_CAP_FLAGS_HAS_BASIC_ZOOM; }
     virtual bool        hasFocus            () const { return _mavlinkCameraInfo.flags & CAMERA_CAP_FLAGS_HAS_BASIC_FOCUS; }
-    virtual bool        hasTracking         () const { return _trackingStatus & TRACKING_SUPPORTED; }
+    virtual bool        hasTracking         () const { return _hasTrackingRectCapability || _hasTrackingPointCapability; }
+    virtual bool        supportsTrackingPoint() const { return _hasTrackingPointCapability; }
+    virtual bool        supportsTrackingRect () const { return _hasTrackingRectCapability; }
     virtual bool        hasVideoStream      () const { return _mavlinkCameraInfo.flags & CAMERA_CAP_FLAGS_HAS_VIDEO_STREAM; }
     virtual bool        photosInVideoMode   () const { return _mavlinkCameraInfo.flags & CAMERA_CAP_FLAGS_CAN_CAPTURE_IMAGE_IN_VIDEO_MODE; }
     virtual bool        videoInPhotoMode    () const { return _mavlinkCameraInfo.flags & CAMERA_CAP_FLAGS_CAN_CAPTURE_VIDEO_IN_IMAGE_MODE; }
@@ -125,13 +127,14 @@ public:
     virtual void        handleVideoStreamInformation(const mavlink_video_stream_information_t &videoStreamInformation);
     virtual void        handleVideoStreamStatus(const mavlink_video_stream_status_t &videoStreamStatus);
 
-    virtual bool        trackingEnabled     () const { return _trackingStatus & TRACKING_ENABLED; }
+    virtual bool        trackingEnabled     () const { return _trackingEnabled; }
     virtual void        setTrackingEnabled  (bool set);
 
-    virtual TrackingStatus trackingStatus   () const { return _trackingStatus; }
-
-    virtual bool trackingImageStatus() const { return _trackingImageStatus.tracking_status == 1; }
+    virtual bool trackingImageIsActive() const { return _trackingImageIsActive; }
+    virtual bool trackingImageIsPoint() const { return _trackingImageIsPoint; }
     virtual QRectF trackingImageRect() const { return _trackingImageRect; }
+    virtual QPointF trackingImagePoint() const { return _trackingImagePoint; }
+    virtual qreal trackingImageRadius() const { return _trackingImageRadius; }
 
     virtual Fact*   exposureMode        ();
     virtual Fact*   ev                  ();
@@ -293,7 +296,13 @@ protected:
     QStringList                         _streamLabels;
     ThermalViewMode                     _thermalMode        = THERMAL_BLEND;
     double                              _thermalOpacity     = 85.0;
-    TrackingStatus                      _trackingStatus     = TRACKING_UNKNOWN;
-    mavlink_camera_tracking_image_status_t  _trackingImageStatus;
+    bool                                _hasTrackingRectCapability = false;
+    bool                                _hasTrackingPointCapability = false;
+    bool                                _trackingEnabled      = false;
+    bool                                    _trackingImageIsActive = false;
+    bool                                    _trackingImageIsPoint = false;
+    mavlink_camera_tracking_image_status_t  _trackingImageStatus{};
     QRectF                                  _trackingImageRect;
+    QPointF                                 _trackingImagePoint;
+    qreal                                   _trackingImageRadius = 0.0;
 };

--- a/src/Comms/MockLink/MockConfiguration.cc
+++ b/src/Comms/MockLink/MockConfiguration.cc
@@ -92,8 +92,8 @@ void MockConfiguration::loadSettings(QSettings &settings, const QString &root)
     setCameraCanCaptureImageInVideoMode(settings.value(_cameraCanCaptureImageInVideoModeKey, true).toBool());
     setCameraCanCaptureVideoInImageMode(settings.value(_cameraCanCaptureVideoInImageModeKey, false).toBool());
     setCameraHasBasicZoom(settings.value(_cameraHasBasicZoomKey, true).toBool());
-    setCameraHasTrackingPoint(settings.value(_cameraHasTrackingPointKey, false).toBool());
-    setCameraHasTrackingRectangle(settings.value(_cameraHasTrackingRectangleKey, false).toBool());
+    setCameraHasTrackingPoint(settings.value(_cameraHasTrackingPointKey, true).toBool());
+    setCameraHasTrackingRectangle(settings.value(_cameraHasTrackingRectangleKey, true).toBool());
     setGimbalHasRollAxis(settings.value(_gimbalHasRollAxisKey, true).toBool());
     setGimbalHasPitchAxis(settings.value(_gimbalHasPitchAxisKey, true).toBool());
     setGimbalHasYawAxis(settings.value(_gimbalHasYawAxisKey, true).toBool());

--- a/src/Comms/MockLink/MockConfiguration.h
+++ b/src/Comms/MockLink/MockConfiguration.h
@@ -153,8 +153,8 @@ private:
     bool _cameraCanCaptureImageInVideoMode = true;
     bool _cameraCanCaptureVideoInImageMode = false;
     bool _cameraHasBasicZoom = true;
-    bool _cameraHasTrackingPoint = false;
-    bool _cameraHasTrackingRectangle = false;
+    bool _cameraHasTrackingPoint = true;
+    bool _cameraHasTrackingRectangle = true;
 
     // Gimbal capability flags (defaults - all enabled)
     bool _gimbalHasRollAxis = true;

--- a/src/Comms/MockLink/MockLinkCamera.cc
+++ b/src/Comms/MockLink/MockLinkCamera.cc
@@ -5,6 +5,9 @@
 
 #include <QtCore/QDateTime>
 #include <QtCore/QLoggingCategory>
+#include <QtCore/QtMath>
+
+#include <algorithm>
 
 QGC_LOGGING_CATEGORY(MockLinkCameraLog, "Comms.MockLink.MockLinkCamera")
 
@@ -104,6 +107,34 @@ void MockLinkCamera::run10HzTasks()
             qCDebug(MockLinkCameraLog) << "Camera" << cam->compId << "single-shot complete, total:" << cam->imagesCaptured;
             _sendCameraImageCaptured(cam->compId);
             _sendCameraCaptureStatus(cam->compId);
+        }
+
+        // Send periodic tracking image status (with simulated drift)
+        if (cam->trackingMode != CAMERA_TRACKING_MODE_NONE && cam->trackingStatusIntervalUs > 0) {
+            const qint64 intervalMs = (cam->trackingStatusIntervalUs + 999) / 1000;
+            if (cam->trackingStatusLastSentMs == 0 || (now - cam->trackingStatusLastSentMs) >= intervalMs) {
+                // Drift the tracked target in a figure-8 pattern around its anchor
+                const double elapsed = static_cast<double>(now - cam->trackingStartMs) / 1000.0;
+                const float driftX = 0.05f * static_cast<float>(qSin(elapsed * 0.7));
+                const float driftY = 0.05f * static_cast<float>(qSin(elapsed * 1.1));
+
+                if (cam->trackingMode == CAMERA_TRACKING_MODE_POINT) {
+                    cam->trackPointX = std::clamp(cam->trackAnchorX + driftX, 0.0f, 1.0f);
+                    cam->trackPointY = std::clamp(cam->trackAnchorY + driftY, 0.0f, 1.0f);
+                } else {
+                    const float halfW = (cam->trackRecBottomX - cam->trackRecTopX) / 2.0f;
+                    const float halfH = (cam->trackRecBottomY - cam->trackRecTopY) / 2.0f;
+                    const float cx = std::clamp(cam->trackAnchorX + driftX, halfW, 1.0f - halfW);
+                    const float cy = std::clamp(cam->trackAnchorY + driftY, halfH, 1.0f - halfH);
+                    cam->trackRecTopX    = cx - halfW;
+                    cam->trackRecTopY    = cy - halfH;
+                    cam->trackRecBottomX = cx + halfW;
+                    cam->trackRecBottomY = cy + halfH;
+                }
+
+                _sendCameraTrackingImageStatus(cam->compId);
+                cam->trackingStatusLastSentMs = now;
+            }
         }
     }
 }
@@ -344,11 +375,63 @@ bool MockLinkCamera::_handleCameraCommand(const mavlink_command_long_t &request,
         return true;
 
     case MAV_CMD_CAMERA_TRACK_POINT:
+        if (cam->capFlags & CAMERA_CAP_FLAGS_HAS_TRACKING_POINT) {
+            cam->trackingMode    = CAMERA_TRACKING_MODE_POINT;
+            cam->trackPointX     = request.param1;
+            cam->trackPointY     = request.param2;
+            cam->trackRadius     = request.param3;
+            cam->trackAnchorX    = request.param1;
+            cam->trackAnchorY    = request.param2;
+            cam->trackingStartMs = QDateTime::currentMSecsSinceEpoch();
+            qCDebug(MockLinkCameraLog) << "Camera" << targetCompId << "tracking point"
+                                       << cam->trackPointX << cam->trackPointY << "radius" << cam->trackRadius;
+            _sendCommandAck(targetCompId, request.command, MAV_RESULT_ACCEPTED);
+        } else {
+            _sendCommandAck(targetCompId, request.command, MAV_RESULT_DENIED);
+        }
+        return true;
+
     case MAV_CMD_CAMERA_TRACK_RECTANGLE:
+        if (cam->capFlags & CAMERA_CAP_FLAGS_HAS_TRACKING_RECTANGLE) {
+            cam->trackingMode      = CAMERA_TRACKING_MODE_RECTANGLE;
+            cam->trackRecTopX      = request.param1;
+            cam->trackRecTopY      = request.param2;
+            cam->trackRecBottomX   = request.param3;
+            cam->trackRecBottomY   = request.param4;
+            cam->trackAnchorX      = (request.param1 + request.param3) / 2.0f;
+            cam->trackAnchorY      = (request.param2 + request.param4) / 2.0f;
+            cam->trackingStartMs   = QDateTime::currentMSecsSinceEpoch();
+            qCDebug(MockLinkCameraLog) << "Camera" << targetCompId << "tracking rectangle"
+                                       << cam->trackRecTopX << cam->trackRecTopY
+                                       << "->" << cam->trackRecBottomX << cam->trackRecBottomY;
+            _sendCommandAck(targetCompId, request.command, MAV_RESULT_ACCEPTED);
+        } else {
+            _sendCommandAck(targetCompId, request.command, MAV_RESULT_DENIED);
+        }
+        return true;
+
     case MAV_CMD_CAMERA_STOP_TRACKING:
-        qCDebug(MockLinkCameraLog) << "Camera" << targetCompId << "tracking command" << request.command;
+        cam->trackingMode = CAMERA_TRACKING_MODE_NONE;
+        cam->trackingStatusIntervalUs = -1;
+        cam->trackingStatusLastSentMs = 0;
+        qCDebug(MockLinkCameraLog) << "Camera" << targetCompId << "tracking stopped";
         _sendCommandAck(targetCompId, request.command, MAV_RESULT_ACCEPTED);
         return true;
+
+    case MAV_CMD_SET_MESSAGE_INTERVAL:
+    {
+        const int msgId = static_cast<int>(request.param1);
+        if (msgId == MAVLINK_MSG_ID_CAMERA_TRACKING_IMAGE_STATUS) {
+            cam->trackingStatusIntervalUs = static_cast<qint64>(request.param2);
+            cam->trackingStatusLastSentMs = 0;
+            qCDebug(MockLinkCameraLog) << "Camera" << targetCompId
+                                       << "tracking status interval" << cam->trackingStatusIntervalUs << "us";
+            _sendCommandAck(targetCompId, request.command, MAV_RESULT_ACCEPTED);
+            return true;
+        }
+        _sendCommandAck(targetCompId, request.command, MAV_RESULT_UNSUPPORTED);
+        return true;
+    }
 
     default:
         break;
@@ -648,6 +731,33 @@ void MockLinkCamera::_sendVideoStreamStatus(uint8_t compId, uint8_t streamId)
     _mockLink->respondWithMavlinkMessage(msg);
 
     qCDebug(MockLinkCameraLog) << "Sent VIDEO_STREAM_STATUS for compId:" << compId << "stream:" << streamId;
+}
+
+void MockLinkCamera::_sendCameraTrackingImageStatus(uint8_t compId)
+{
+    const CameraState *cam = _findCamera(compId);
+    if (!cam || cam->trackingMode == CAMERA_TRACKING_MODE_NONE) {
+        return;
+    }
+
+    mavlink_message_t msg{};
+    (void) mavlink_msg_camera_tracking_image_status_pack_chan(
+        _mockLink->vehicleId(),
+        compId,
+        _mockLink->mavlinkChannel(),
+        &msg,
+        CAMERA_TRACKING_STATUS_FLAGS_ACTIVE,    // tracking_status
+        cam->trackingMode,                      // tracking_mode
+        CAMERA_TRACKING_TARGET_DATA_EMBEDDED,   // target_data
+        cam->trackPointX,                       // point_x
+        cam->trackPointY,                       // point_y
+        cam->trackRadius,                       // radius
+        cam->trackRecTopX,                      // rec_top_x
+        cam->trackRecTopY,                      // rec_top_y
+        cam->trackRecBottomX,                   // rec_bottom_x
+        cam->trackRecBottomY,                   // rec_bottom_y
+        0);                                     // camera_device_id
+    _mockLink->respondWithMavlinkMessage(msg);
 }
 
 void MockLinkCamera::_sendCommandAck(uint8_t compId, uint16_t command, uint8_t result, int requestedMsgId)

--- a/src/Comms/MockLink/MockLinkCamera.h
+++ b/src/Comms/MockLink/MockLinkCamera.h
@@ -57,6 +57,21 @@ public:
         uint8_t  image_status        = ImageCaptureIdle;     ///< ImageCaptureStatus enum
         float    image_interval      = 0.0f;                 ///< Interval between image captures (seconds)
         qint64   singleShotStartMs   = 0;                    ///< Timestamp when single-shot capture started (0 = not active)
+
+        // Tracking state
+        uint8_t  trackingMode        = CAMERA_TRACKING_MODE_NONE; ///< CAMERA_TRACKING_MODE enum
+        float    trackPointX         = 0.0f;
+        float    trackPointY         = 0.0f;
+        float    trackRadius         = 0.0f;
+        float    trackRecTopX        = 0.0f;
+        float    trackRecTopY        = 0.0f;
+        float    trackRecBottomX     = 0.0f;
+        float    trackRecBottomY     = 0.0f;
+        qint64   trackingStatusIntervalUs = -1;               ///< Interval for CAMERA_TRACKING_IMAGE_STATUS (-1 = disabled)
+        qint64   trackingStatusLastSentMs = 0;                ///< Timestamp of last tracking status message
+        qint64   trackingStartMs     = 0;                     ///< Timestamp when tracking was started (for drift animation)
+        float    trackAnchorX        = 0.0f;                  ///< Original center X of tracked target
+        float    trackAnchorY        = 0.0f;                  ///< Original center Y of tracked target
     };
 
     explicit MockLinkCamera(MockLink *mockLink,
@@ -97,6 +112,7 @@ private:
     void _sendCameraImageCaptured(uint8_t compId);
     void _sendVideoStreamInformation(uint8_t compId, uint8_t streamId);
     void _sendVideoStreamStatus(uint8_t compId, uint8_t streamId);
+    void _sendCameraTrackingImageStatus(uint8_t compId);
     void _sendCommandAck(uint8_t compId, uint16_t command, uint8_t result, int requestedMsgId = -1);
 
     CameraState *_findCamera(uint8_t compId);

--- a/src/FlyView/CMakeLists.txt
+++ b/src/FlyView/CMakeLists.txt
@@ -52,6 +52,7 @@ qt_add_qml_module(FlyViewModule
         ObstacleDistanceOverlay.qml
         ObstacleDistanceOverlayMap.qml
         ObstacleDistanceOverlayVideo.qml
+        OnScreenCameraTrackingController.qml
         OnScreenGimbalController.qml
         PreFlightBatteryCheck.qml
         PreFlightCheckList.qml

--- a/src/FlyView/FlyViewVideo.qml
+++ b/src/FlyView/FlyViewVideo.qml
@@ -9,9 +9,6 @@ Item {
     property Item pipView
     property Item pipState: videoPipState
 
-    property int    _track_rec_x:       0
-    property int    _track_rec_y:       0
-
     PipState {
         id:         videoPipState
         pipView:    _root.pipView
@@ -53,7 +50,7 @@ Item {
     QGCLabel {
         text: qsTr("Double-click to exit full screen")
         font.pointSize: ScreenTools.largeFontPointSize
-        visible: QGroundControl.videoManager.fullScreen && flyViewVideoMouseArea.containsMouse
+        visible: QGroundControl.videoManager.fullScreen
         anchors.centerIn: parent
 
         onVisibleChanged: {
@@ -74,159 +71,56 @@ Item {
     OnScreenGimbalController {
         id:                      onScreenGimbalController
         anchors.fill:            parent
-        screenX:                 flyViewVideoMouseArea.mouseX
-        screenY:                 flyViewVideoMouseArea.mouseY
-        cameraTrackingEnabled:   videoStreaming._camera && videoStreaming._camera.trackingEnabled
+        cameraTrackingEnabled:   !!(videoStreaming._camera && videoStreaming._camera.trackingEnabled)
+    }
+
+    OnScreenCameraTrackingController {
+        id:                      cameraTrackingController
+        anchors.fill:            parent
+        camera:                  videoStreaming._camera
+        videoWidth:              videoStreaming.getWidth()
+        videoHeight:             videoStreaming.getHeight()
     }
 
     MouseArea {
         id:                         flyViewVideoMouseArea
         anchors.fill:               parent
         enabled:                    pipState.state === pipState.fullState
-        hoverEnabled:               true
 
-        property double x0:         0
-        property double x1:         0
-        property double y0:         0
-        property double y1:         0
-        property double offset_x:   0
-        property double offset_y:   0
-        property double radius:     20
-        property var trackingROI:   null
-        property var trackingStatus: trackingStatusComponent.createObject(flyViewVideoMouseArea, {})
+        property real _pressX:      0
+        property real _pressY:      0
+        property bool _dragging:    false
+        readonly property real _dragThreshold: 10
 
-        onClicked:       onScreenGimbalController.clickControl()
         onDoubleClicked: QGroundControl.videoManager.fullScreen = !QGroundControl.videoManager.fullScreen
 
-        onPressed:(mouse) => {
-            onScreenGimbalController.pressControl()
-
-            _track_rec_x = mouse.x
-            _track_rec_y = mouse.y
-
-            //create a new rectangle at the wanted position
-            if(videoStreaming._camera) {
-                if (videoStreaming._camera.trackingEnabled) {
-                    trackingROI = trackingROIComponent.createObject(flyViewVideoMouseArea, {
-                        "x": mouse.x,
-                        "y": mouse.y
-                    });
-                }
-            }
+        onPressed: (mouse) => {
+            _pressX = mouse.x
+            _pressY = mouse.y
+            _dragging = false
         }
+
         onPositionChanged: (mouse) => {
-            //on move, update the width of rectangle
-            if (trackingROI !== null) {
-                if (mouse.x < trackingROI.x) {
-                    trackingROI.x = mouse.x
-                    trackingROI.width = Math.abs(mouse.x - _track_rec_x)
-                } else {
-                    trackingROI.width = Math.abs(mouse.x - trackingROI.x)
-                }
-                if (mouse.y < trackingROI.y) {
-                    trackingROI.y = mouse.y
-                    trackingROI.height = Math.abs(mouse.y - _track_rec_y)
-                } else {
-                    trackingROI.height = Math.abs(mouse.y - trackingROI.y)
-                }
+            if (!_dragging && (Math.abs(mouse.x - _pressX) >= _dragThreshold || Math.abs(mouse.y - _pressY) >= _dragThreshold)) {
+                _dragging = true
+                onScreenGimbalController.mouseDragStart(_pressX, _pressY)
+                cameraTrackingController.mouseDragStart(_pressX, _pressY)
+            }
+            if (_dragging) {
+                onScreenGimbalController.mouseDragPositionChanged(mouse.x, mouse.y)
+                cameraTrackingController.mouseDragPositionChanged(mouse.x, mouse.y)
             }
         }
+
         onReleased: (mouse) => {
-            onScreenGimbalController.releaseControl()
-
-            //if there is already a selection, delete it
-            if (trackingROI !== null) {
-                trackingROI.destroy();
+            if (_dragging) {
+                onScreenGimbalController.mouseDragEnd()
+                cameraTrackingController.mouseDragEnd(mouse.x, mouse.y)
+            } else {
+                onScreenGimbalController.mouseClicked(mouse.x, mouse.y)
+                cameraTrackingController.mouseClicked(mouse.x, mouse.y)
             }
-
-            if(videoStreaming._camera) {
-                if (videoStreaming._camera.trackingEnabled) {
-                    // order coordinates --> top/left and bottom/right
-                    x0 = Math.min(_track_rec_x, mouse.x)
-                    x1 = Math.max(_track_rec_x, mouse.x)
-                    y0 = Math.min(_track_rec_y, mouse.y)
-                    y1 = Math.max(_track_rec_y, mouse.y)
-
-                    //calculate offset between video stream rect and background (black stripes)
-                    offset_x = (parent.width - videoStreaming.getWidth()) / 2
-                    offset_y = (parent.height - videoStreaming.getHeight()) / 2
-
-                    //convert absolute coords in background to absolute video stream coords
-                    x0 = x0 - offset_x
-                    x1 = x1 - offset_x
-                    y0 = y0 - offset_y
-                    y1 = y1 - offset_y
-
-                    //convert absolute to relative coordinates and limit range to 0...1
-                    x0 = Math.max(Math.min(x0 / videoStreaming.getWidth(), 1.0), 0.0)
-                    x1 = Math.max(Math.min(x1 / videoStreaming.getWidth(), 1.0), 0.0)
-                    y0 = Math.max(Math.min(y0 / videoStreaming.getHeight(), 1.0), 0.0)
-                    y1 = Math.max(Math.min(y1 / videoStreaming.getHeight(), 1.0), 0.0)
-
-                    //use point message if rectangle is very small
-                    if (Math.abs(_track_rec_x - mouse.x) < 10 && Math.abs(_track_rec_y - mouse.y) < 10) {
-                        var pt  = Qt.point(x0, y0)
-                        videoStreaming._camera.startTracking(pt, radius / videoStreaming.getWidth())
-                    } else {
-                        var rec = Qt.rect(x0, y0, x1 - x0, y1 - y0)
-                        videoStreaming._camera.startTracking(rec)
-                    }
-                    _track_rec_x = 0
-                    _track_rec_y = 0
-                }
-            }
-        }
-
-        Component {
-            id: trackingROIComponent
-
-            Rectangle {
-                color:              Qt.rgba(0.1,0.85,0.1,0.25)
-                border.color:       "green"
-                border.width:       1
-            }
-        }
-
-        Component {
-            id: trackingStatusComponent
-
-            Rectangle {
-                color:              "transparent"
-                border.color:       "red"
-                border.width:       5
-                radius:             5
-            }
-        }
-
-        Timer {
-            id: trackingStatusTimer
-            interval:               50
-            repeat:                 true
-            running:                true
-            onTriggered: {
-                if (videoStreaming._camera) {
-                    if (videoStreaming._camera.trackingEnabled && videoStreaming._camera.trackingImageStatus) {
-                        var margin_hor = (parent.parent.width - videoStreaming.getWidth()) / 2
-                        var margin_ver = (parent.parent.height - videoStreaming.getHeight()) / 2
-                        var left = margin_hor + videoStreaming.getWidth() * videoStreaming._camera.trackingImageRect.left
-                        var top = margin_ver + videoStreaming.getHeight() * videoStreaming._camera.trackingImageRect.top
-                        var right = margin_hor + videoStreaming.getWidth() * videoStreaming._camera.trackingImageRect.right
-                        var bottom = margin_ver + !isNaN(videoStreaming._camera.trackingImageRect.bottom) ? videoStreaming.getHeight() * videoStreaming._camera.trackingImageRect.bottom : top + (right - left)
-                        var width = right - left
-                        var height = bottom - top
-
-                        flyViewVideoMouseArea.trackingStatus.x = left
-                        flyViewVideoMouseArea.trackingStatus.y = top
-                        flyViewVideoMouseArea.trackingStatus.width = width
-                        flyViewVideoMouseArea.trackingStatus.height = height
-                    } else {
-                        flyViewVideoMouseArea.trackingStatus.x = 0
-                        flyViewVideoMouseArea.trackingStatus.y = 0
-                        flyViewVideoMouseArea.trackingStatus.width = 0
-                        flyViewVideoMouseArea.trackingStatus.height = 0
-                    }
-                }
-            }
+            _dragging = false
         }
     }
 

--- a/src/FlyView/OnScreenCameraTrackingController.qml
+++ b/src/FlyView/OnScreenCameraTrackingController.qml
@@ -1,0 +1,150 @@
+import QtQuick
+
+Item {
+    id: rootItem
+
+    required property var  camera
+    required property real videoWidth
+    required property real videoHeight
+
+    // Drag origin in parent coordinates
+    property real _dragStartX: 0
+    property real _dragStartY: 0
+    property bool _dragging: false
+    property real _dragCurrentX: 0
+    property real _dragCurrentY: 0
+
+    readonly property bool _trackingEnabled: camera && camera.trackingEnabled
+    readonly property bool _canTrackPoint: _trackingEnabled && camera.supportsTrackingPoint
+    readonly property bool _canTrackRect: _trackingEnabled && camera.supportsTrackingRect
+
+    function mouseClicked(mouseX, mouseY) {
+        if (!_canTrackPoint) {
+            return
+        }
+        if (videoWidth <= 0 || videoHeight <= 0) {
+            return
+        }
+        // Click = point tracking
+        var marginH = (width - videoWidth) / 2
+        var marginV = (height - videoHeight) / 2
+        var nx = Math.max(Math.min((mouseX - marginH) / videoWidth, 1.0), 0.0)
+        var ny = Math.max(Math.min((mouseY - marginV) / videoHeight, 1.0), 0.0)
+        var pointRadius = 20
+        camera.startTrackingPoint(Qt.point(nx, ny), Math.min(pointRadius / videoWidth, 1.0))
+    }
+
+    function mouseDragStart(mouseX, mouseY) {
+        if (!_canTrackRect) {
+            return
+        }
+        _dragStartX = mouseX
+        _dragStartY = mouseY
+        _dragCurrentX = mouseX
+        _dragCurrentY = mouseY
+        _dragging = true
+    }
+
+    function mouseDragPositionChanged(mouseX, mouseY) {
+        if (!_dragging) {
+            return
+        }
+        _dragCurrentX = mouseX
+        _dragCurrentY = mouseY
+    }
+
+    function mouseDragEnd(mouseX, mouseY) {
+        _dragging = false
+
+        if (!_canTrackRect) {
+            return
+        }
+        if (videoWidth <= 0 || videoHeight <= 0) {
+            return
+        }
+
+        // Order coordinates: top-left and bottom-right
+        var x0 = Math.min(_dragStartX, mouseX)
+        var x1 = Math.max(_dragStartX, mouseX)
+        var y0 = Math.min(_dragStartY, mouseY)
+        var y1 = Math.max(_dragStartY, mouseY)
+
+        // Letterbox margins (black bars when aspect ratio doesn't match)
+        var marginH = (width - videoWidth) / 2
+        var marginV = (height - videoHeight) / 2
+
+        // Convert from view coordinates to video-relative coordinates
+        x0 = x0 - marginH
+        x1 = x1 - marginH
+        y0 = y0 - marginV
+        y1 = y1 - marginV
+
+        // Normalize to 0..1
+        x0 = Math.max(Math.min(x0 / videoWidth, 1.0), 0.0)
+        x1 = Math.max(Math.min(x1 / videoWidth, 1.0), 0.0)
+        y0 = Math.max(Math.min(y0 / videoHeight, 1.0), 0.0)
+        y1 = Math.max(Math.min(y1 / videoHeight, 1.0), 0.0)
+
+        var w = x1 - x0
+        var h = y1 - y0
+
+        // Ignore degenerate rectangles (e.g. mostly-horizontal/vertical drags)
+        if (w < 0.01 || h < 0.01) {
+            _dragStartX = 0
+            _dragStartY = 0
+            return
+        }
+
+        // Drag = rectangle tracking
+        camera.startTrackingRect(Qt.rect(x0, y0, w, h))
+
+        _dragStartX = 0
+        _dragStartY = 0
+    }
+
+    // --- ROI selection overlay (green rectangle while dragging) ---
+    Rectangle {
+        visible: _dragging
+        color: Qt.rgba(0.1, 0.85, 0.1, 0.25)
+        border.color: "green"
+        border.width: 1
+        x: Math.min(_dragStartX, _dragCurrentX)
+        y: Math.min(_dragStartY, _dragCurrentY)
+        width: Math.abs(_dragCurrentX - _dragStartX)
+        height: Math.abs(_dragCurrentY - _dragStartY)
+    }
+
+    // --- Tracking status overlay (red rectangle/circle from camera feedback) ---
+    // Coordinates are normalized to the video frame (0.0–1.0). Convert to screen
+    // pixels by scaling by the displayed video size and offsetting by letterbox margins.
+    readonly property bool _trackingActive: _trackingEnabled && camera.trackingImageIsActive
+    readonly property bool _isPoint: _trackingActive && camera.trackingImageIsPoint
+    readonly property real _marginH: (rootItem.width - videoWidth) / 2
+    readonly property real _marginV: (rootItem.height - videoHeight) / 2
+
+    Rectangle {
+        id: trackingStatusOverlay
+        color: "transparent"
+        border.color: "red"
+        border.width: 5
+        radius: rootItem._isPoint ? width / 2 : 5
+        visible: rootItem._trackingActive
+
+        x: rootItem._trackingActive
+           ? (rootItem._isPoint ? rootItem._marginH + videoWidth  * (camera.trackingImagePoint.x - camera.trackingImageRadius)
+                                : rootItem._marginH + videoWidth  * camera.trackingImageRect.x)
+           : 0
+        y: rootItem._trackingActive
+           ? (rootItem._isPoint ? rootItem._marginV + videoHeight * (camera.trackingImagePoint.y - camera.trackingImageRadius)
+                                : rootItem._marginV + videoHeight * camera.trackingImageRect.y)
+           : 0
+        width: rootItem._trackingActive
+               ? (rootItem._isPoint ? videoWidth * camera.trackingImageRadius * 2
+                                    : videoWidth * camera.trackingImageRect.width)
+               : 0
+        height: rootItem._trackingActive
+                ? (rootItem._isPoint ? width
+                                     : videoHeight * camera.trackingImageRect.height)
+                : 0
+    }
+}

--- a/src/FlyView/OnScreenGimbalController.qml
+++ b/src/FlyView/OnScreenGimbalController.qml
@@ -4,86 +4,70 @@ import QGroundControl
 import QGroundControl.Controls
 
 Item {
-    id:             rootItem
-    anchors.fill:   parent
+    id: rootItem
+    anchors.fill: parent
 
-    property var screenX
-    property var screenY
-    property var screenXrateInitCoocked
-    property var screenYrateInitCoocked
+    required property bool cameraTrackingEnabled
 
-    property var  activeVehicle:                QGroundControl.multiVehicleManager.activeVehicle
-    property var  gimbalController:             activeVehicle ? activeVehicle.gimbalController : undefined
-    property var  activeGimbal:                 gimbalController ? gimbalController.activeGimbal : undefined
-    property bool gimbalAvailable:              activeGimbal != undefined
-    property var  gimbalControllerSettings:     QGroundControl.settingsManager.gimbalControllerSettings
-    property bool cameraTrackingEnabled:        false // Used to ignore clicks when camera tracking operation is active, otherwise it would collide with these gimbal controls
-    property bool shouldProcessClicks:          gimbalControllerSettings.EnableOnScreenControl.value && activeGimbal && !cameraTrackingEnabled ? true : false
+    property var _activeVehicle: QGroundControl.multiVehicleManager.activeVehicle
+    property var _gimbalController: _activeVehicle ? _activeVehicle.gimbalController : undefined
+    property var _activeGimbal: _gimbalController ? _gimbalController.activeGimbal : undefined
+    property bool _gimbalAvailable: _activeGimbal != undefined
+    property var _gimbalControllerSettings: QGroundControl.settingsManager.gimbalControllerSettings
+    property bool _shouldProcessClicks: _gimbalControllerSettings.enableOnScreenControl.value && _activeGimbal && !cameraTrackingEnabled ? true : false
 
-    function clickControl() {
-        if (!shouldProcessClicks) {
+    property real _mouseX: 0
+    property real _mouseY: 0
+    property real _dragStartNormX: 0
+    property real _dragStartNormY: 0
+
+    function _toNormX(mouseX) { return  ((mouseX / width)  * 2) - 1 }
+    function _toNormY(mouseY) { return -((mouseY / height) * 2) + 1 }
+
+    function mouseClicked(mouseX, mouseY) {
+        if (!_shouldProcessClicks) {
             return
         }
-        // If click and slide control, return, it uses press and release
-        if (!gimbalControllerSettings.ControlType.rawValue == 0) {
+        if (_gimbalControllerSettings.clickAndDrag.rawValue) {
             return
         }
-        clickAndPoint(x, y)
-    }
-
-    // Sends a +-(0-1) xy value to vehicle.gimbalController.gimbalOnScreenControl
-    function clickAndPoint() {
-        if (rootItem.gimbalAvailable) {
-            var xCoocked =  ( (screenX / parent.width)  * 2) - 1
-            var yCoocked = -( (screenY / parent.height) * 2) + 1
-            // console.log("X global: " + x + " Y global: " + y)
-            // console.log("X coocked: " + xCoocked + " Y coocked: " + yCoocked)
-            gimbalController.gimbalOnScreenControl(xCoocked, yCoocked, true, false, false)
-        } else {
-            // We should never be here
-            console.log("gimbal not available")
+        if (rootItem._gimbalAvailable) {
+            _gimbalController.gimbalOnScreenControl(_toNormX(mouseX), _toNormY(mouseY), true, false, false)
         }
     }
 
-    function pressControl() {
-        if (!shouldProcessClicks) {
+    function mouseDragStart(mouseX, mouseY) {
+        if (!_shouldProcessClicks) {
             return
         }
-        // If click and point control return, that is handled exclusively on clickAndPoint()
-        if (!gimbalControllerSettings.ControlType.rawValue == 1) {
+        if (!_gimbalControllerSettings.clickAndDrag.rawValue) {
             return
         }
+        _mouseX = mouseX
+        _mouseY = mouseY
+        _dragStartNormX = _toNormX(mouseX)
+        _dragStartNormY = _toNormY(mouseY)
         sendRateTimer.start()
-        screenXrateInitCoocked =  ( ( screenX / parent.width)  * 2) - 1
-        screenYrateInitCoocked = -( ( screenY / parent.height) * 2) + 1
     }
 
-    function releaseControl() {
-        if (!shouldProcessClicks) {
-            return
-        }
-        // If click and point control return, that is handled exclusively on clickAndPoint()
-        if (!gimbalControllerSettings.ControlType.rawValue == 1) {
-            return
-        }
+    function mouseDragPositionChanged(mouseX, mouseY) {
+        _mouseX = mouseX
+        _mouseY = mouseY
+    }
+
+    function mouseDragEnd() {
         sendRateTimer.stop()
-        screenXrateInitCoocked = null
-        screenYrateInitCoocked = null
     }
 
     Timer {
-        id:             sendRateTimer
-        interval:       100
-        repeat:         true
+        id: sendRateTimer
+        interval: 100
+        repeat: true
         onTriggered: {
-            if (rootItem.gimbalAvailable) {
-                var xCoocked =  ( ( screenX / parent.width)  * 2) - 1
-                var yCoocked = -( ( screenY / parent.height) * 2) + 1
-                xCoocked -= screenXrateInitCoocked
-                yCoocked -= screenYrateInitCoocked
-                gimbalController.gimbalOnScreenControl(xCoocked, yCoocked, false, true, true)
-            } else {
-                console.log("gimbal not available")
+            if (rootItem._gimbalAvailable) {
+                var dx = rootItem._toNormX(rootItem._mouseX) - rootItem._dragStartNormX
+                var dy = rootItem._toNormY(rootItem._mouseY) - rootItem._dragStartNormY
+                _gimbalController.gimbalOnScreenControl(dx, dy, false, true, true)
             }
         }
     }

--- a/src/Gimbal/GimbalController.cc
+++ b/src/Gimbal/GimbalController.cc
@@ -39,7 +39,7 @@ void GimbalController::_initialConnectCompleted()
 void GimbalController::setActiveGimbal(Gimbal *gimbal)
 {
     if (!gimbal) {
-        qCDebug(GimbalControllerLog) << "Set active gimbal: attempted to set a nullptr, returning";
+        qCCritical(GimbalControllerLog) << "Set active gimbal: attempted to set a nullptr, returning";
         return;
     }
 
@@ -344,7 +344,7 @@ void GimbalController::_checkComplete(Gimbal &gimbal, GimbalPairId pairId)
 bool GimbalController::_tryGetGimbalControl()
 {
     if (!_activeGimbal) {
-        qCDebug(GimbalControllerLog) << "_tryGetGimbalControl: active gimbal is nullptr, returning";
+        qCCritical(GimbalControllerLog) << "_tryGetGimbalControl: active gimbal is nullptr, returning";
         return false;
     }
 
@@ -375,7 +375,7 @@ bool GimbalController::_yawInVehicleFrame(uint32_t flags)
 void GimbalController::gimbalPitchStart(int direction)
 {
     if (!_activeGimbal) {
-        qCDebug(GimbalControllerLog) << "gimbalPitchStart: active gimbal is nullptr, returning";
+        qCCritical(GimbalControllerLog) << "gimbalPitchStart: active gimbal is nullptr, returning";
         return;
     }
 
@@ -388,7 +388,7 @@ void GimbalController::gimbalPitchStart(int direction)
 void GimbalController::gimbalYawStart(int direction)
 {
     if (!_activeGimbal) {
-        qCDebug(GimbalControllerLog) << "gimbalYawStart: active gimbal is nullptr, returning";
+        qCCritical(GimbalControllerLog) << "gimbalYawStart: active gimbal is nullptr, returning";
         return;
     }
 
@@ -400,7 +400,7 @@ void GimbalController::gimbalYawStart(int direction)
 void GimbalController::gimbalPitchStop()
 {
     if (!_activeGimbal) {
-        qCDebug(GimbalControllerLog) << "gimbalPitchStop: active gimbal is nullptr, returning";
+        qCCritical(GimbalControllerLog) << "gimbalPitchStop: active gimbal is nullptr, returning";
         return;
     }
 
@@ -411,7 +411,7 @@ void GimbalController::gimbalPitchStop()
 void GimbalController::gimbalYawStop()
 {
     if (!_activeGimbal) {
-        qCDebug(GimbalControllerLog) << "gimbalYawStop: active gimbal is nullptr, returning";
+        qCCritical(GimbalControllerLog) << "gimbalYawStop: active gimbal is nullptr, returning";
         return;
     }
 
@@ -422,7 +422,7 @@ void GimbalController::gimbalYawStop()
 void GimbalController::centerGimbal()
 {
     if (!_activeGimbal) {
-        qCDebug(GimbalControllerLog) << "gimbalYawStep: active gimbal is nullptr, returning";
+        qCCritical(GimbalControllerLog) << "gimbalYawStep: active gimbal is nullptr, returning";
         return;
     }
     sendPitchBodyYaw(0.0, 0.0, true);
@@ -433,13 +433,13 @@ void GimbalController::gimbalOnScreenControl(float panPct, float tiltPct, bool c
     // Pan and tilt comes as +-(0-1)
 
     if (!_activeGimbal) {
-        qCDebug(GimbalControllerLog) << "gimbalOnScreenControl: active gimbal is nullptr, returning";
+        qCCritical(GimbalControllerLog) << "gimbalOnScreenControl: active gimbal is nullptr, returning";
         return;
     }
 
     if (clickAndPoint) { // based on FOV
-        const float hFov = SettingsManager::instance()->gimbalControllerSettings()->CameraHFov()->rawValue().toFloat();
-        const float vFov = SettingsManager::instance()->gimbalControllerSettings()->CameraVFov()->rawValue().toFloat();
+        const float hFov = SettingsManager::instance()->gimbalControllerSettings()->cameraHFov()->rawValue().toFloat();
+        const float vFov = SettingsManager::instance()->gimbalControllerSettings()->cameraVFov()->rawValue().toFloat();
 
         const float panIncDesired = panPct * hFov * 0.5f;
         const float tiltIncDesired = tiltPct * vFov * 0.5f;
@@ -456,7 +456,7 @@ void GimbalController::gimbalOnScreenControl(float panPct, float tiltPct, bool c
         // Should send rate commands, but it seems for some reason it is not working on AP side.
         // Pitch works ok but yaw doesn't stop, it keeps like inertia, like if it was buffering the messages.
         // So we do a workaround with angle targets
-        const float maxSpeed = SettingsManager::instance()->gimbalControllerSettings()->CameraSlideSpeed()->rawValue().toFloat();
+        const float maxSpeed = SettingsManager::instance()->gimbalControllerSettings()->cameraSlideSpeed()->rawValue().toFloat();
 
         const float panIncDesired = panPct * maxSpeed * 0.1f;
         const float tiltIncDesired = tiltPct * maxSpeed * 0.1f;
@@ -686,7 +686,7 @@ void GimbalController::sendPitchYawFlags(uint32_t flags)
 void GimbalController::acquireGimbalControl()
 {
     if (!_activeGimbal) {
-        qCDebug(GimbalControllerLog) << "acquireGimbalControl: active gimbal is nullptr, returning";
+        qCCritical(GimbalControllerLog) << "acquireGimbalControl: active gimbal is nullptr, returning";
         return;
     }
 
@@ -706,7 +706,7 @@ void GimbalController::acquireGimbalControl()
 void GimbalController::releaseGimbalControl()
 {
     if (!_activeGimbal) {
-        qCDebug(GimbalControllerLog) << "releaseGimbalControl: active gimbal is nullptr, returning";
+        qCCritical(GimbalControllerLog) << "releaseGimbalControl: active gimbal is nullptr, returning";
         return;
     }
 

--- a/src/Settings/GimbalController.SettingsGroup.json
+++ b/src/Settings/GimbalController.SettingsGroup.json
@@ -4,35 +4,33 @@
     "QGC.MetaData.Facts":
 [
 {
-    "name":              "EnableOnScreenControl",
+    "name":              "enableOnScreenControl",
     "shortDesc":         "Enable on Screen Camera Control",
     "type":              "bool",
     "default":           false
 },
 {
-    "name":              "ControlType",
-    "shortDesc":         "Type of on-screen control",
-    "type":              "uint32",
-    "enumStrings":       "Click to point, Click and drag",
-    "enumValues":        "0, 1",
-    "default":           0
+    "name":              "clickAndDrag",
+    "shortDesc":         "Use click and drag control instead of click to point",
+    "type":              "bool",
+    "default":           false
 },
 {
-    "name":              "CameraVFov",
+    "name":              "cameraVFov",
     "shortDesc":         "Vertical camera field of view",
     "type":              "uint32",
     "default":           80,
     "units":             "deg"
 },
 {
-    "name":              "CameraHFov",
+    "name":              "cameraHFov",
     "shortDesc":         "Horizontal camera field of view",
     "type":              "uint32",
     "default":           80,
     "units":             "deg"
 },
 {
-    "name":              "CameraSlideSpeed",
+    "name":              "cameraSlideSpeed",
     "shortDesc":         "Maximum gimbal speed on click and drag (deg/sec)",
     "type":              "uint32",
     "default":           30,

--- a/src/Settings/GimbalControllerSettings.cc
+++ b/src/Settings/GimbalControllerSettings.cc
@@ -2,13 +2,31 @@
 
 DECLARE_SETTINGGROUP(GimbalController, "GimbalController")
 {
+    // Setting names were changed from PascalCase to camelCase
+    // Migrate old settings to new names
+    QSettings settings;
+    settings.beginGroup(_name);
+    static const QMap<QString, QString> renamedKeys = {
+        { "EnableOnScreenControl", "enableOnScreenControl" },
+        { "ControlType",           "clickAndDrag" },
+        { "CameraVFov",            "cameraVFov" },
+        { "CameraHFov",            "cameraHFov" },
+        { "CameraSlideSpeed",      "cameraSlideSpeed" },
+    };
+    for (auto it = renamedKeys.constBegin(); it != renamedKeys.constEnd(); ++it) {
+        if (settings.contains(it.key())) {
+            settings.setValue(it.value(), settings.value(it.key()));
+            settings.remove(it.key());
+        }
+    }
+    settings.endGroup();
 }
 
-DECLARE_SETTINGSFACT(GimbalControllerSettings, EnableOnScreenControl)
-DECLARE_SETTINGSFACT(GimbalControllerSettings, ControlType)
-DECLARE_SETTINGSFACT(GimbalControllerSettings, CameraVFov)
-DECLARE_SETTINGSFACT(GimbalControllerSettings, CameraHFov)
-DECLARE_SETTINGSFACT(GimbalControllerSettings, CameraSlideSpeed)
+DECLARE_SETTINGSFACT(GimbalControllerSettings, enableOnScreenControl)
+DECLARE_SETTINGSFACT(GimbalControllerSettings, clickAndDrag)
+DECLARE_SETTINGSFACT(GimbalControllerSettings, cameraVFov)
+DECLARE_SETTINGSFACT(GimbalControllerSettings, cameraHFov)
+DECLARE_SETTINGSFACT(GimbalControllerSettings, cameraSlideSpeed)
 DECLARE_SETTINGSFACT(GimbalControllerSettings, showAzimuthIndicatorOnMap)
 DECLARE_SETTINGSFACT(GimbalControllerSettings, toolbarIndicatorShowAzimuth)
 DECLARE_SETTINGSFACT(GimbalControllerSettings, toolbarIndicatorShowAcquireReleaseControl)

--- a/src/Settings/GimbalControllerSettings.h
+++ b/src/Settings/GimbalControllerSettings.h
@@ -13,11 +13,11 @@ public:
     GimbalControllerSettings(QObject* parent = nullptr);
     DEFINE_SETTING_NAME_GROUP()
 
-    DEFINE_SETTINGFACT(EnableOnScreenControl)
-    DEFINE_SETTINGFACT(ControlType)
-    DEFINE_SETTINGFACT(CameraVFov)
-    DEFINE_SETTINGFACT(CameraHFov)
-    DEFINE_SETTINGFACT(CameraSlideSpeed)
+    DEFINE_SETTINGFACT(enableOnScreenControl)
+    DEFINE_SETTINGFACT(clickAndDrag)
+    DEFINE_SETTINGFACT(cameraVFov)
+    DEFINE_SETTINGFACT(cameraHFov)
+    DEFINE_SETTINGFACT(cameraSlideSpeed)
     DEFINE_SETTINGFACT(showAzimuthIndicatorOnMap)
     DEFINE_SETTINGFACT(toolbarIndicatorShowAzimuth)
     DEFINE_SETTINGFACT(toolbarIndicatorShowAcquireReleaseControl)

--- a/src/UI/toolbar/GimbalIndicator.qml
+++ b/src/UI/toolbar/GimbalIndicator.qml
@@ -235,31 +235,32 @@ Item {
                     id:                 enableOnScreenControlCheckbox
                     Layout.fillWidth:   true
                     text:               qsTr("Enabled")
-                    fact:               _gimbalControllerSettings.EnableOnScreenControl
+                    fact:               _gimbalControllerSettings.enableOnScreenControl
                 }
 
-                LabelledFactComboBox {
-                    label:      qsTr("Control type")
-                    fact:       _gimbalControllerSettings.ControlType
-                    visible:    enableOnScreenControlCheckbox.checked
+                FactCheckBoxSlider {
+                    Layout.fillWidth:   true
+                    text:               qsTr("Click and drag")
+                    fact:               _gimbalControllerSettings.clickAndDrag
+                    visible:            enableOnScreenControlCheckbox.checked
                 }
 
                 LabelledFactTextField {
                     label:      qsTr("Horizontal FOV")
-                    fact:       _gimbalControllerSettings.CameraHFov
-                    visible:    enableOnScreenControlCheckbox.checked && _gimbalControllerSettings.ControlType.rawValue === 0
+                    fact:       _gimbalControllerSettings.cameraHFov
+                    visible:    enableOnScreenControlCheckbox.checked && !_gimbalControllerSettings.clickAndDrag.rawValue
                 }
 
                 LabelledFactTextField {
                     label:      qsTr("Vertical FOV")
-                    fact:       _gimbalControllerSettings.CameraVFov
-                    visible:    enableOnScreenControlCheckbox.checked && _gimbalControllerSettings.ControlType.rawValue === 0
+                    fact:       _gimbalControllerSettings.cameraVFov
+                    visible:    enableOnScreenControlCheckbox.checked && !_gimbalControllerSettings.clickAndDrag.rawValue
                 }
 
                 LabelledFactTextField {
                     label:      qsTr("Max speed")
-                    fact:       _gimbalControllerSettings.CameraSlideSpeed
-                    visible:    enableOnScreenControlCheckbox.checked && _gimbalControllerSettings.ControlType.rawValue === 1
+                    fact:       _gimbalControllerSettings.cameraSlideSpeed
+                    visible:    enableOnScreenControlCheckbox.checked && _gimbalControllerSettings.clickAndDrag.rawValue
                 }
             }
 


### PR DESCRIPTION
Relates-to: #13363
Relates-to: #13957

## Summary

Comprehensive refactoring of camera tracking and on-screen gimbal control in FlyView.

## Camera Tracking Interface (C++)

- Remove flawed `TrackingStatus` bitmask enum that incorrectly mixed capabilities with runtime state
- Separate point/rect tracking into distinct properties (`trackingImageIsPoint`, `trackingImagePoint`, `trackingImageRect`, `trackingImageRadius`)
- Rename signals to match property names (`trackingImageIsActiveChanged`, etc.)
- Add `supportsTrackingPoint`/`supportsTrackingRect` Q_PROPERTYs for QML capability checking
- Split `startTracking()` overloads into `startTrackingPoint()`/`startTrackingRect()`
- Add capability guards with `qCCritical` to both methods
- `setTrackingEnabled(false)` now calls `stopTracking()` to properly notify the vehicle
- Change-only signal emissions prevent redundant updates
- Zero-initialize `_trackingImageStatus` struct

## FlyView Mouse Handling (QML)

- Extract camera tracking into new `OnScreenCameraTrackingController.qml`
- Refactor `OnScreenGimbalController` to method-based API (no more bound screen position properties)
- Clean 4-method API: `mouseClicked`/`mouseDragStart`/`mouseDragPositionChanged`/`mouseDragEnd`
- Add click vs drag separation with 10px threshold
- Remove `hoverEnabled` (unnecessary in full-screen mode)
- **Fix**: operator precedence bug in tracking status overlay coordinates
- **Fix**: mode guards bug in gimbal controller (`!value == 0` → proper boolean checks)
- **Fix**: ROI rectangle resize broken on drag direction reversal
- Declarative tracking status overlay (replaces imperative `createObject`/timer)
- Gimbal rate timer unconditionally stopped in `mouseDragEnd` (prevents runaway timer)

## MockLink

- Add tracking simulation with figure-8 drift animation
- Handle `MAV_CMD_CAMERA_TRACK_POINT`, `TRACK_RECTANGLE`, `STOP_TRACKING`
- Handle `MAV_CMD_SET_MESSAGE_INTERVAL` for `CAMERA_TRACKING_IMAGE_STATUS`
- Capability-gated commands (`MAV_RESULT_DENIED` if flag not set)

## Gimbal Settings

- Rename `ControlType` enum to `clickAndDrag` boolean for clarity

## Known Issue

Click vs double-click conflict (first click of double-click sends gimbal command) tracked in #14157.
