### PR TITLE
PlanView: Fix 'Cannot read property of null' warnings on vehicle connect

### DIFF
--- a/src/FactSystem/FactControls/FactTextFieldSlider.qml
+++ b/src/FactSystem/FactControls/FactTextFieldSlider.qml
@@ -27,7 +27,7 @@ Rectangle {
     radius:         ScreenTools.defaultBorderRadius
 
     property bool _loadComplete:            false
-    property bool _showSlider:              fact.userMin !== undefined && fact.userMax !== undefined
+    property bool _showSlider:              fact && fact.userMin !== undefined && fact.userMax !== undefined
     property color _ftfsBackgroundColor:    Qt.rgba(qgcPal.windowShadeLight.r, qgcPal.windowShadeLight.g, qgcPal.windowShadeLight.b, 0.2)
 
     function updateSliderToClampedValue() {
@@ -97,8 +97,8 @@ Rectangle {
             QGCSlider {
                 id:                 slider
                 Layout.fillWidth:   true
-                from:               control.fact.userMin
-                to:                 control.fact.userMax
+                from:               control.fact ? control.fact.userMin : 0
+                to:                 control.fact ? control.fact.userMax : 1
                 showBoundaryValues: true
 
                 onMoved: {

--- a/src/PlanView/CameraSection.qml
+++ b/src/PlanView/CameraSection.qml
@@ -17,7 +17,7 @@ Column {
 
     spacing: _margin
 
-    property var    _camera:        missionItem.cameraSection
+    property var    _camera:        missionItem ? missionItem.cameraSection : null
     property real   _fieldWidth:    ScreenTools.defaultFontPixelWidth * 16
     property real   _margin:        ScreenTools.defaultFontPixelWidth / 2
 
@@ -38,38 +38,38 @@ Column {
             id:         cameraActionCombo
             width:      parent.width
             label:      qsTr("Action")
-            fact:       _camera.cameraAction
+            fact:       _camera ? _camera.cameraAction : null
             indexModel: false
         }
 
         LabelledFactTextField {
             width:      parent.width
             label:      qsTr("Time")
-            fact:       _camera.cameraPhotoIntervalTime
-            visible:    _camera.cameraAction.rawValue === 1
+            fact:       _camera ? _camera.cameraPhotoIntervalTime : null
+            visible:    _camera ? _camera.cameraAction.rawValue === 1 : false
         }
 
         LabelledFactTextField {
             width:      parent.width
             label:      qsTr("Distance")
-            fact:       _camera.cameraPhotoIntervalDistance
-            visible:    _camera.cameraAction.rawValue === 2
+            fact:       _camera ? _camera.cameraPhotoIntervalDistance : null
+            visible:    _camera ? _camera.cameraAction.rawValue === 2 : false
         }
 
         RowLayout {
             width:      parent.width
             spacing:    ScreenTools.defaultFontPixelWidth
-            visible:    _camera.cameraModeSupported
+            visible:    _camera ? _camera.cameraModeSupported : false
 
             QGCCheckBox {
                 id:                 modeCheckBox
                 text:               qsTr("Mode")
-                checked:            _camera.specifyCameraMode
-                onClicked:          _camera.specifyCameraMode = checked
+                checked:            _camera ? _camera.specifyCameraMode : false
+                onClicked:          { if (_camera) _camera.specifyCameraMode = checked }
             }
 
             FactComboBox {
-                fact:               _camera.cameraMode
+                fact:               _camera ? _camera.cameraMode : null
                 indexModel:         false
                 enabled:            modeCheckBox.checked
                 Layout.fillWidth:   true
@@ -79,21 +79,21 @@ Column {
         QGCCheckBox {
             id:                 gimbalCheckBox
             text:               qsTr("Gimbal")
-            checked:            _camera.specifyGimbal
-            onClicked:          _camera.specifyGimbal = checked
+            checked:            _camera ? _camera.specifyGimbal : false
+            onClicked:          { if (_camera) _camera.specifyGimbal = checked }
         }
 
         FactTextFieldSlider {
             width:          parent.width
             label:          qsTr("Pitch")
-            fact:           _camera.gimbalPitch
+            fact:           _camera ? _camera.gimbalPitch : null
             enabled:        gimbalCheckBox.checked
         }
 
         FactTextFieldSlider {
             width:          parent.width
             label:          qsTr("Yaw")
-            fact:           _camera.gimbalYaw
+            fact:           _camera ? _camera.gimbalYaw : null
             enabled:        gimbalCheckBox.checked
         }
     }

--- a/src/PlanView/MissionItemEditor.qml
+++ b/src/PlanView/MissionItemEditor.qml
@@ -25,14 +25,14 @@ Rectangle {
     border.width:   _readyForSave ? 0 : 2
     border.color:   qgcPal.warningText
 
-    property var    _masterController:          missionItem.masterController
-    property var    _missionController:         _masterController.missionController
-    property bool   _currentItem:               missionItem.isCurrentItem
+    property var    _masterController:          missionItem ? missionItem.masterController : null
+    property var    _missionController:         _masterController ? _masterController.missionController : null
+    property bool   _currentItem:               missionItem ? missionItem.isCurrentItem : false
     property color  _outerTextColor:            _currentItem ? qgcPal.buttonHighlightText : qgcPal.text
-    property bool   _noMissionItemsAdded:       _missionController.visualItems ? _missionController.visualItems.count <= 1 : true
+    property bool   _noMissionItemsAdded:       _missionController && _missionController.visualItems ? _missionController.visualItems.count <= 1 : true
     property real   _sectionSpacer:             ScreenTools.defaultFontPixelWidth / 2  // spacing between section headings
-    property bool   _singleComplexItem:         _missionController.complexMissionItemNames.length === 1
-    property bool   _readyForSave:              missionItem.readyForSaveState === VisualMissionItem.ReadyForSave
+    property bool   _singleComplexItem:         _missionController ? _missionController.complexMissionItemNames.length === 1 : false
+    property bool   _readyForSave:              missionItem ? missionItem.readyForSaveState === VisualMissionItem.ReadyForSave : true
 
     readonly property real  _editFieldWidth:    Math.min(width - _innerMargin * 2, ScreenTools.defaultFontPixelWidth * 12)
     readonly property real  _margin:            ScreenTools.defaultFontPixelWidth / 2
@@ -138,7 +138,7 @@ Rectangle {
             mipmap:                 true
             smooth:                 true
             color:                  qgcPal.buttonHighlightText
-            visible:                _currentItem && missionItem.sequenceNumber !== 0
+            visible:                _currentItem && missionItem && missionItem.sequenceNumber !== 0
             source:                 "/res/TrashDelete.svg"
 
             QGCMouseArea {
@@ -161,7 +161,7 @@ Rectangle {
 
                 property real _padding: ScreenTools.comboBoxPadding
 
-                QGCLabel { text: missionItem.commandName }
+                QGCLabel { text: missionItem ? missionItem.commandName : "" }
 
                 QGCColoredImage {
                     height:             ScreenTools.defaultFontPixelWidth
@@ -203,9 +203,9 @@ Rectangle {
             anchors.verticalCenter: parent.verticalCenter
             width:                  commandPicker.width
             height:                 commandPicker.height
-            visible:                !missionItem.isCurrentItem || !missionItem.isSimpleItem || _waypointsOnlyMode || missionItem.isTakeoffItem
+            visible:                !missionItem || !missionItem.isCurrentItem || !missionItem.isSimpleItem || _waypointsOnlyMode || missionItem.isTakeoffItem
             verticalAlignment:      Text.AlignVCenter
-            text:                   missionItem.commandName
+            text:                   missionItem ? missionItem.commandName : ""
             color:                  _outerTextColor
         }
     }
@@ -308,7 +308,7 @@ Rectangle {
         height:                 _hamburgerSize
         sourceSize.height:      _hamburgerSize
         source:                 "qrc:/qmlimages/Hamburger.svg"
-        visible:                missionItem.isCurrentItem && missionItem.sequenceNumber !== 0
+        visible:                missionItem && missionItem.isCurrentItem && missionItem.sequenceNumber !== 0
         color:                  qgcPal.buttonHighlightText
 
         QGCMouseArea {

--- a/src/PlanView/MissionSettingsEditor.qml
+++ b/src/PlanView/MissionSettingsEditor.qml
@@ -17,8 +17,8 @@ Rectangle {
     required property var missionItem
     required property real availableWidth
 
-    property var _masterController: missionItem.masterController
-    property var _controllerVehicle: _masterController.controllerVehicle
+    property var _masterController: missionItem ? missionItem.masterController : null
+    property var _controllerVehicle: _masterController ? _masterController.controllerVehicle : null
     property bool _waypointsOnlyMode: QGroundControl.corePlugin.options.missionWaypointsOnly
     property bool _showCameraSection: _waypointsOnlyMode || QGroundControl.corePlugin.showAdvancedUI
     property bool _simpleMissionStart: QGroundControl.corePlugin.options.showSimpleMissionStart


### PR DESCRIPTION
## Summary
- Adds null guards to declarative QML bindings in `MissionItemEditor`, `MissionSettingsEditor`, `CameraSection`, and `FactTextFieldSlider`
- When a vehicle connects the mission tree model rebuilds, destroying backing C++ objects while QML delegates still briefly exist — causing cascading "Cannot read property X of null" warnings
- Completes the fix started in 19d3c042 which handled the *creation* path via `setSource()` but missed the *teardown* path

## Test plan
- [ ] Connect a vehicle (real or SITL) and verify no "Cannot read property X of null" warnings in console
- [ ] Open Plan View and verify mission item editors still function correctly
- [ ] Verify camera section controls (gimbal, photo interval, mode) work in mission settings
- [ ] Verify FactTextFieldSlider displays and operates correctly for gimbal pitch/yaw


🤖 Generated with [Claude Code](https://claude.com/claude-code)