### PR TITLE
MissionController: remove dead legacy .mission file loader code

### DIFF
--- a/src/MissionManager/MissionController.cc
+++ b/src/MissionManager/MissionController.cc
@@ -399,7 +399,6 @@ VisualMissionItem* MissionController::insertROIMissionItem(QGeoCoordinate coordi
         simpleItem->setCommand(MAV_CMD_DO_SET_ROI)  ;
         simpleItem->missionItem().setParam1(MAV_ROI_LOCATION);
     }
-    _recalcROISpecialVisuals();
     return simpleItem;
 }
 
@@ -411,7 +410,6 @@ VisualMissionItem* MissionController::insertCancelROIMissionItem(int visualItemI
         simpleItem->setCommand(MAV_CMD_DO_SET_ROI)  ;
         simpleItem->missionItem().setParam1(MAV_ROI_NONE);
     }
-    _recalcROISpecialVisuals();
     return simpleItem;
 }
 
@@ -633,108 +631,6 @@ void MissionController::removeAll(void)
     _allItemsRemoved();
 }
 
-bool MissionController::_loadJsonMissionFileV1(const QJsonObject& json, QmlObjectListModel* visualItems, QString& errorString)
-{
-    // Validate root object keys
-    QList<JsonHelper::KeyValidateInfo> rootKeyInfoList = {
-        { _jsonPlannedHomePositionKey,      QJsonValue::Object, true },
-        { _jsonItemsKey,                    QJsonValue::Array,  true },
-        { _jsonMavAutopilotKey,             QJsonValue::Double, false },
-        { _jsonComplexItemsKey,             QJsonValue::Array,  true },
-    };
-    if (!JsonHelper::validateKeys(json, rootKeyInfoList, errorString)) {
-        return false;
-    }
-
-    setGlobalAltitudeFrame(QGroundControlQmlGlobal::AltitudeFrameMixed);
-
-    // Read complex items
-    QList<SurveyComplexItem*> surveyItems;
-    QJsonArray complexArray(json[_jsonComplexItemsKey].toArray());
-    qCDebug(MissionControllerLog) << "Json load: complex item count" << complexArray.count();
-    for (int i=0; i<complexArray.count(); i++) {
-        const QJsonValue& itemValue = complexArray[i];
-
-        if (!itemValue.isObject()) {
-            errorString = QStringLiteral("Mission item is not an object");
-            return false;
-        }
-
-        SurveyComplexItem* item = new SurveyComplexItem(_masterController, _flyView, QString() /* kmlOrShpFile */);
-        const QJsonObject itemObject = itemValue.toObject();
-        if (item->load(itemObject, itemObject["id"].toInt(), errorString)) {
-            surveyItems.append(item);
-        } else {
-            return false;
-        }
-    }
-
-    // Read simple items, interspersing complex items into the full list
-
-    int nextSimpleItemIndex= 0;
-    int nextComplexItemIndex= 0;
-    int nextSequenceNumber = 1; // Start with 1 since home is in 0
-    QJsonArray itemArray(json[_jsonItemsKey].toArray());
-
-    MissionSettingsItem* settingsItem = _addMissionSettings(visualItems);
-    if (json.contains(_jsonPlannedHomePositionKey)) {
-        SimpleMissionItem* item = new SimpleMissionItem(_masterController, _flyView, true /* forLoad */);
-        if (item->load(json[_jsonPlannedHomePositionKey].toObject(), 0, errorString)) {
-            settingsItem->setCoordinate(item->coordinate());
-            item->deleteLater();
-        } else {
-            return false;
-        }
-    }
-
-    qCDebug(MissionControllerLog) << "Json load: simple item loop start simpleItemCount:ComplexItemCount" << itemArray.count() << surveyItems.count();
-    do {
-        qCDebug(MissionControllerLog) << "Json load: simple item loop nextSimpleItemIndex:nextComplexItemIndex:nextSequenceNumber" << nextSimpleItemIndex << nextComplexItemIndex << nextSequenceNumber;
-
-        // If there is a complex item that should be next in sequence add it in
-        if (nextComplexItemIndex < surveyItems.count()) {
-            SurveyComplexItem* complexItem = surveyItems[nextComplexItemIndex];
-
-            if (complexItem->sequenceNumber() == nextSequenceNumber) {
-                qCDebug(MissionControllerLog) << "Json load: injecting complex item expectedSequence:actualSequence:" << nextSequenceNumber << complexItem->sequenceNumber();
-                visualItems->append(complexItem);
-                nextSequenceNumber = complexItem->lastSequenceNumber() + 1;
-                nextComplexItemIndex++;
-                continue;
-            }
-        }
-
-        // Add the next available simple item
-        if (nextSimpleItemIndex < itemArray.count()) {
-            const QJsonValue& itemValue = itemArray[nextSimpleItemIndex++];
-
-            if (!itemValue.isObject()) {
-                errorString = QStringLiteral("Mission item is not an object");
-                return false;
-            }
-
-            const QJsonObject itemObject = itemValue.toObject();
-            SimpleMissionItem* item = new SimpleMissionItem(_masterController, _flyView, true /* forLoad */);
-            if (item->load(itemObject, itemObject["id"].toInt(), errorString)) {
-                if (TakeoffMissionItem::isTakeoffCommand(item->mavCommand())) {
-                    // This needs to be a TakeoffMissionItem
-                    TakeoffMissionItem* takeoffItem = new TakeoffMissionItem(_masterController, _flyView, settingsItem, true /* forLoad */);
-                    takeoffItem->load(itemObject, itemObject["id"].toInt(), errorString);
-                    item->deleteLater();
-                    item = takeoffItem;
-                }
-                qCDebug(MissionControllerLog) << "Json load: adding simple item expectedSequence:actualSequence" << nextSequenceNumber << item->sequenceNumber();
-                nextSequenceNumber = item->lastSequenceNumber() + 1;
-                visualItems->append(item);
-            } else {
-                return false;
-            }
-        }
-    } while (nextSimpleItemIndex < itemArray.count() || nextComplexItemIndex < surveyItems.count());
-
-    return true;
-}
-
 bool MissionController::_loadJsonMissionFileV2(const QJsonObject& json, QmlObjectListModel* visualItems, QString& errorString)
 {
     // Validate root object keys
@@ -924,19 +820,6 @@ bool MissionController::_loadJsonMissionFileV2(const QJsonObject& json, QmlObjec
     }
 
     return true;
-}
-
-bool MissionController::_loadItemsFromJson(const QJsonObject& json, QmlObjectListModel* visualItems, QString& errorString)
-{
-    int fileVersion;
-    JsonHelper::validateExternalQGCJsonFile(json,
-                                            _jsonFileTypeValue,    // expected file type
-                                            2,                     // minimum supported version
-                                            2,                     // maximum supported version
-                                            fileVersion,
-                                            errorString);
-
-    return _loadJsonMissionFileV2(json, visualItems, errorString);
 }
 
 bool MissionController::_loadTextMissionFile(QTextStream& stream, QmlObjectListModel* visualItems, QString& errorString)
@@ -1189,39 +1072,6 @@ FlightPathSegment* MissionController::_addFlightPathSegment(FlightPathSegmentHas
     _simpleFlightPathSegments.append(segment);
 
     return segment;
-}
-
-void MissionController::_recalcROISpecialVisuals(void)
-{
-    return;
-    VisualMissionItem*  lastCoordinateItem =    qobject_cast<VisualMissionItem*>(_visualItems->get(0));
-    bool                roiActive =             false;
-
-    for (int i=1; i<_visualItems->count(); i++) {
-        VisualMissionItem*  visualItem = qobject_cast<VisualMissionItem*>(_visualItems->get(i));
-        SimpleMissionItem*  simpleItem = qobject_cast<SimpleMissionItem*>(visualItem);
-        VisualItemPair      viPair;
-
-        if (simpleItem) {
-            if (roiActive) {
-                if (_isROICancelItem(simpleItem)) {
-                    roiActive = false;
-                }
-            } else {
-                if (_isROIBeginItem(simpleItem)) {
-                    roiActive = true;
-                }
-            }
-        }
-
-        if (visualItem->specifiesCoordinate() && !visualItem->isStandaloneCoordinate()) {
-            viPair = VisualItemPair(lastCoordinateItem, visualItem);
-            if (_flightPathSegmentHashTable.contains(viPair)) {
-                _flightPathSegmentHashTable[viPair]->setSpecialVisual(roiActive);
-            }
-            lastCoordinateItem = visualItem;
-        }
-    }
 }
 
 void MissionController::_recalcFlightPathSegments(void)

--- a/src/MissionManager/MissionController.h
+++ b/src/MissionManager/MissionController.h
@@ -404,7 +404,6 @@ private:
     void                    _recalcSequence                     (void);
     void                    _recalcChildItems                   (void);
     void                    _recalcAllWithCoordinate            (const QGeoCoordinate& coordinate);
-    void                    _recalcROISpecialVisuals            (void);
     void                    _setupNewVisualItems                (QmlObjectListModel* newItems = nullptr);
     void                    _initAllVisualItems                 (void);
     void                    _deinitAllVisualItems               (void);
@@ -414,8 +413,6 @@ private:
     void                    _calcPrevWaypointValues             (VisualMissionItem* currentItem, VisualMissionItem* prevItem, double* azimuth, double* distance, double* altDifference);
     bool                    _findPreviousAltitude               (int newIndex, double* prevAltitude, QGroundControlQmlGlobal::AltitudeFrame* prevAltFrame);
     MissionSettingsItem*    _addMissionSettings                 (QmlObjectListModel* visualItems);
-    bool                    _loadJsonMissionFile                (const QByteArray& bytes, QmlObjectListModel* visualItems, QString& errorString);
-    bool                    _loadJsonMissionFileV1              (const QJsonObject& json, QmlObjectListModel* visualItems, QString& errorString);
     bool                    _loadJsonMissionFileV2              (const QJsonObject& json, QmlObjectListModel* visualItems, QString& errorString);
     bool                    _loadTextMissionFile                (QTextStream& stream, QmlObjectListModel* visualItems, QString& errorString);
     int                     _nextSequenceNumber                 (void);
@@ -425,7 +422,6 @@ private:
     void                    _addHoverTime                       (double hoverTime, double hoverDistance, int waypointIndex);
     void                    _addCruiseTime                      (double cruiseTime, double cruiseDistance, int wayPointIndex);
     void                    _updateBatteryInfo                  (int waypointIndex);
-    bool                    _loadItemsFromJson                  (const QJsonObject& json, QmlObjectListModel* visualItems, QString& errorString);
     void                    _initLoadedVisualItems              (QmlObjectListModel* loadedVisualItems);
     FlightPathSegment*      _addFlightPathSegment               (FlightPathSegmentHashTable& prevItemPairHashTable, VisualItemPair& pair, bool mavlinkTerrainFrame);
     void                    _addTimeDistance                    (bool vtolInHover, double hoverTime, double cruiseTime, double extraTime, double distance, int seqNum);
@@ -500,7 +496,6 @@ private:
     QGroundControlQmlGlobal::AltitudeFrame _globalAltFrame = QGroundControlQmlGlobal::AltitudeFrameRelative;
 
     static constexpr const char* _settingsGroup =                 "MissionController";
-    static constexpr const char* _jsonFileTypeValue =             "Mission";
     static constexpr const char* _jsonItemsKey =                  "items";
     static constexpr const char* _jsonPlannedHomePositionKey =    "plannedHomePosition";
     static constexpr const char* _jsonFirmwareTypeKey =           "firmwareType";
@@ -509,10 +504,6 @@ private:
     static constexpr const char* _jsonHoverSpeedKey =             "hoverSpeed";
     static constexpr const char* _jsonParamsKey =                 "params";
     static constexpr const char* _jsonGlobalPlanAltitudeModeKey = "globalPlanAltitudeMode";
-
-    // Deprecated V1 format keys
-    static constexpr const char* _jsonComplexItemsKey =           "complexItems";
-    static constexpr const char* _jsonMavAutopilotKey =           "MAV_AUTOPILOT";
 
     static constexpr int   _missionFileVersion =            2;
 };


### PR DESCRIPTION
## Summary

Remove dead methods and constants from MissionController that were only used for the old standalone `.mission` JSON format (V1), which is no longer supported.

## Removed

- **`_loadJsonMissionFileV1()`**: V1 format loader with separate `complexItems` array interleaved by sequence number (~100 lines)
- **`_loadJsonMissionFile()`**: Declared in header but never implemented — stale declaration
- **`_loadItemsFromJson()`**: Defined but never called from anywhere
- **`_recalcROISpecialVisuals()`**: Empty stub that was called but did nothing useful
- **`_jsonFileTypeValue`**, **`_jsonComplexItemsKey`**, **`_jsonMavAutopilotKey`**: Constants only referenced by the removed V1 code

## Not affected

- **`_loadJsonMissionFileV2()`** — actively used by `.plan` files via `PlanMasterController::loadFromFile()` -> `MissionController::load()`
- **`_loadTextMissionFile()`** — actively used for `.waypoints`/`.txt` import
- All file extension constants in `AppSettings` — no `.mission` extension existed

**Net reduction: ~159 lines deleted, 0 added.**
