### PR TITLE
APM: Add support for parameter meta data defaults

### DIFF
--- a/src/Comms/MockLink/MockLinkFTP.cc
+++ b/src/Comms/MockLink/MockLinkFTP.cc
@@ -119,7 +119,7 @@ void MockLinkFTP::_openCommand(uint8_t senderSystemId, uint8_t senderComponentId
         tmpFilename = QStringLiteral(":MockLink/Parameter.MetaData.json");
     } else if (path == "/parameter.json.xz") {
         tmpFilename = QStringLiteral(":MockLink/Parameter.MetaData.json.xz");
-    } else if (_BinParamFileEnabled && (path == "@PARAM/param.pck")) {
+    } else if (_BinParamFileEnabled && (path == "@PARAM/param.pck" || path.startsWith("@PARAM/param.pck?"))) {
         tmpFilename = ":MockLink/Arduplane.params.ftp.bin";
     }
 
@@ -142,7 +142,7 @@ void MockLinkFTP::_openCommand(uint8_t senderSystemId, uint8_t senderComponentId
     response.hdr.size = sizeof(uint32_t);
 
     // Ardupilot sends constant wrong file size for parameter file due to dynamic on the fly generation
-    response.openFileLength = ((path == "@PARAM/param.pck") ? qPow(1024, 2) : _currentFile.size());
+    response.openFileLength = ((path == "@PARAM/param.pck" || path.startsWith("@PARAM/param.pck?")) ? qPow(1024, 2) : _currentFile.size());
 
     _sendResponse(senderSystemId, senderComponentId, &response, outgoingSeqNumber);
 }

--- a/src/FactSystem/ParameterManager.cc
+++ b/src/FactSystem/ParameterManager.cc
@@ -608,9 +608,9 @@ void ParameterManager::_startParameterDownload(uint8_t componentId)
         (void) connect(ftpManager, &FTPManager::downloadComplete, this, &ParameterManager::_ftpDownloadComplete);
         _waitingParamTimeoutTimer.stop();
         if (ftpManager->download(MAV_COMP_ID_AUTOPILOT1,
-                                 QStringLiteral("@PARAM/param.pck"),
+                                 QStringLiteral("@PARAM/param.pck?withdefaults=1"),
                                  QStandardPaths::writableLocation(QStandardPaths::TempLocation),
-                                 QStringLiteral(""),
+                                 QStringLiteral("param.pck"),
                                  false /* No filesize check */)) {
             (void) connect(ftpManager, &FTPManager::commandProgress, this, &ParameterManager::_ftpDownloadProgress);
         } else {
@@ -1616,6 +1616,7 @@ bool ParameterManager::_parseParamFile(const QString& filename)
                                              << "flags" << flags;
 
         QVariant parameterValue = 0;
+        QVariant defaultValue;
         switch (static_cast<ap_var_type>(ptype)) {
         qint8 data8;
         qint16 data16;
@@ -1626,6 +1627,7 @@ bool ParameterManager::_parseParamFile(const QString& filename)
             parameterValue = data8;
             if (withdefault) {
                 in >> data8;
+                defaultValue = data8;
             }
             break;
         case AP_PARAM_INT16:
@@ -1633,6 +1635,7 @@ bool ParameterManager::_parseParamFile(const QString& filename)
             parameterValue = data16;
             if (withdefault) {
                 in >> data16;
+                defaultValue = data16;
             }
             break;
         case AP_PARAM_INT32:
@@ -1640,6 +1643,7 @@ bool ParameterManager::_parseParamFile(const QString& filename)
             parameterValue = data32;
             if (withdefault) {
                 in >> data32;
+                defaultValue = data32;
             }
             break;
         case AP_PARAM_FLOAT:
@@ -1648,6 +1652,9 @@ bool ParameterManager::_parseParamFile(const QString& filename)
             parameterValue = dfloat;
             if (withdefault) {
                 in >> data32;
+                float ddefault;
+                (void) memcpy(&ddefault, &data32, 4);
+                defaultValue = ddefault;
             }
             break;
         default:
@@ -1672,6 +1679,9 @@ bool ParameterManager::_parseParamFile(const QString& filename)
         Fact *fact = nullptr;
         if (_mapCompId2FactMap.contains(componentId) && _mapCompId2FactMap[componentId].contains(parameterName)) {
             fact = _mapCompId2FactMap[componentId][parameterName];
+            if (withdefault && defaultValue.isValid()) {
+                fact->metaData()->setRawDefaultValue(defaultValue);
+            }
         } else {
             qCDebug(ParameterManagerVerbose1Log) << _logVehiclePrefix(componentId) << "Adding new fact" << parameterName;
 
@@ -1683,6 +1693,11 @@ bool ParameterManager::_parseParamFile(const QString& filename)
 
             // We need to know when the fact value changes so we can update the vehicle
             (void) connect(fact, &Fact::containerRawValueChanged, this, &ParameterManager::_factRawValueUpdated);
+
+            // Set default before emitting factAdded so QML sees defaultValueAvailable from the start
+            if (withdefault && defaultValue.isValid()) {
+                fact->metaData()->setRawDefaultValue(defaultValue);
+            }
 
             emit factAdded(componentId, fact);
         }

--- a/src/QmlControls/ParameterEditor.qml
+++ b/src/QmlControls/ParameterEditor.qml
@@ -164,7 +164,6 @@ Item {
                 text:       qsTr("Show modified only")
                 checked:    controller.showModifiedOnly
                 onClicked:  controller.showModifiedOnly = checked
-                visible:    QGroundControl.multiVehicleManager.activeVehicle.px4Firmware
             }
         }
 


### PR DESCRIPTION
## Summary
- Requests parameter defaults from ArduPilot firmware by appending `?withdefaults=1` to the MAVFTP `@PARAM/param.pck` path
- Stores the default values via `FactMetaData::setRawDefaultValue()` instead of discarding them during `_parseParamFile()`
- Removes the PX4-only gate on the "Show modified only" checkbox in Parameter Editor

## Details
ArduPilot firmware already supports sending parameter default values inline in the binary `param.pck` format (magic `0x671C`). QGC's parser correctly handled this format but discarded the default bytes. With this change, the existing `Fact::valueEqualsDefault` infrastructure lights up for ArduPilot — warning color highlighting for non-default parameters and the "Show modified only" filter now work for both PX4 and ArduPilot.

Parameters at their default value carry no extra bytes in the binary format, so `withdefaults=1` has minimal overhead for stock vehicles.

## Test plan
- [ ] Connect to ArduPilot SITL, open Parameters — verify "Show modified only" checkbox is visible
- [ ] Change a parameter, verify it shows warning color highlighting
- [ ] Check "Show modified only" — verify only non-default parameters are listed
- [ ] Connect to PX4 SITL — verify existing behavior is unchanged