### PR TITLE
feat(UI): Add grid styling to Parameter Editor table

### DIFF
--- a/src/QmlControls/ParameterEditor.qml
+++ b/src/QmlControls/ParameterEditor.qml
@@ -164,7 +164,6 @@ Item {
                 text:       qsTr("Show modified only")
                 checked:    controller.showModifiedOnly
                 onClicked:  controller.showModifiedOnly = checked
-                visible:    QGroundControl.multiVehicleManager.activeVehicle.px4Firmware
             }
         }
 
@@ -237,15 +236,72 @@ Item {
         }
     }
 
+    HorizontalHeaderView {
+        id:                 headerView
+        anchors.left:       tableView.left
+        anchors.right:      tableView.right
+        anchors.top:        header.bottom
+        syncView:           tableView
+        clip:               true
+
+        delegate: Rectangle {
+            implicitWidth:  headerLabel.contentWidth + ScreenTools.defaultFontPixelWidth
+            implicitHeight: headerLabel.contentHeight + ScreenTools.defaultFontPixelHeight * 0.5
+            color:          qgcPal.windowShade
+
+            QGCLabel {
+                id:                     headerLabel
+                anchors.left:           parent.left
+                anchors.leftMargin:     ScreenTools.defaultFontPixelWidth / 2
+                anchors.verticalCenter: parent.verticalCenter
+                text:                   display
+                font.bold:              true
+            }
+
+            // Top border
+            Rectangle {
+                anchors.top:    parent.top
+                width:          parent.width
+                height:         1
+                color:          qgcPal.groupBorder
+            }
+
+            // Left border
+            Rectangle {
+                anchors.left:   parent.left
+                height:         parent.height
+                width:          1
+                color:          qgcPal.groupBorder
+            }
+
+            // Right border (last column only)
+            Rectangle {
+                anchors.right:  parent.right
+                height:         parent.height
+                width:          1
+                color:          qgcPal.groupBorder
+                visible:        column == 2
+            }
+
+            // Bottom border
+            Rectangle {
+                anchors.bottom: parent.bottom
+                width:          parent.width
+                height:         1
+                color:          qgcPal.groupBorder
+            }
+        }
+    }
+
     TableView {
         id:                 tableView
         anchors.leftMargin: ScreenTools.defaultFontPixelWidth
-        anchors.top:        header.bottom
+        anchors.top:        headerView.bottom
         anchors.bottom:     parent.bottom
         anchors.left:       _searchFilter ? parent.left : groupScroll.right
         anchors.right:      parent.right
-        columnSpacing:      ScreenTools.defaultFontPixelWidth
-        rowSpacing:         ScreenTools.defaultFontPixelHeight / 4
+        columnSpacing:      0
+        rowSpacing:         0
         model:              controller.parameters
         contentWidth:       width
         clip:               true
@@ -265,26 +321,48 @@ Item {
             forceLayoutTimer.start()
         }
 
-        delegate: Item {
-            implicitWidth:  label.contentWidth
-            implicitHeight: label.contentHeight
+        delegate: Rectangle {
+            implicitWidth:  column == 1 ? ScreenTools.defaultFontPixelWidth * 16 : label.contentWidth + ScreenTools.defaultFontPixelWidth
+            implicitHeight: label.contentHeight + ScreenTools.defaultFontPixelHeight * 0.5
+            color:          row % 2 === 0 ? "transparent" : qgcPal.windowShade
             clip:           true
+
+            // Bottom grid line
+            Rectangle {
+                anchors.bottom: parent.bottom
+                width:          parent.width
+                height:         1
+                color:          qgcPal.groupBorder
+            }
+
+            // Left grid line
+            Rectangle {
+                anchors.left:   parent.left
+                height:         parent.height
+                width:          1
+                color:          qgcPal.groupBorder
+            }
+
+            // Right grid line (last column only)
+            Rectangle {
+                anchors.right:  parent.right
+                height:         parent.height
+                width:          1
+                color:          qgcPal.groupBorder
+                visible:        column == 2
+            }
 
             QGCLabel {
                 id:                 label
+                anchors.left:       parent.left
+                anchors.leftMargin: ScreenTools.defaultFontPixelWidth / 2
+                anchors.verticalCenter: parent.verticalCenter
                 width:              column == 1 ? ScreenTools.defaultFontPixelWidth * 15 : contentWidth
                 text:               column == 1 ? col1String() : display
-                color:              column == 1 ? col1Color() : qgcPal.text
+                color:              column == 1 && fact.defaultValueAvailable && !fact.valueEqualsDefault ? qgcPal.modifiedParamValue : qgcPal.text
+                font.bold:          column == 1 && fact.defaultValueAvailable && !fact.valueEqualsDefault
                 maximumLineCount:   1
                 elide:              column == 1 ? Text.ElideRight : Text.ElideNone
-
-                Component.onCompleted: {
-                    return
-                    if (tableView.columnWidth(column) < width) {
-                        console.log("setColumnWidth", column, width)
-                        tableView.setColumnWidth(column, width)
-                    }
-                }
 
                 function col1String() {
                     if (fact.enumStrings.length === 0) {
@@ -294,14 +372,6 @@ Item {
                         return fact.selectedBitmaskStrings.join(',')
                     }
                     return fact.enumStringValue
-                }
-
-                function col1Color() {
-                    if (fact.defaultValueAvailable) {
-                        return fact.valueEqualsDefault ? qgcPal.text : qgcPal.warningText
-                    } else {
-                        return qgcPal.text
-                    }
                 }
             }
 

--- a/src/QmlControls/ParameterEditorController.cc
+++ b/src/QmlControls/ParameterEditorController.cc
@@ -51,6 +51,20 @@ QVariant ParameterTableModel::data(const QModelIndex &index, int role) const
     }
 }
 
+QVariant ParameterTableModel::headerData(int section, Qt::Orientation orientation, int role) const
+{
+    if (orientation != Qt::Horizontal || role != Qt::DisplayRole) {
+        return QVariant();
+    }
+
+    switch (section) {
+    case NameColumn:        return tr("Name");
+    case ValueColumn:       return tr("Value");
+    case DescriptionColumn: return tr("Description");
+    default:                return QVariant();
+    }
+}
+
 QHash<int, QByteArray> ParameterTableModel::roleNames() const
 {
     return {

--- a/src/QmlControls/ParameterEditorController.h
+++ b/src/QmlControls/ParameterEditorController.h
@@ -45,6 +45,7 @@ public:
     int         rowCount    (const QModelIndex & parent = QModelIndex()) const override;
     int         columnCount (const QModelIndex &parent = QModelIndex()) const override;
     QVariant    data        (const QModelIndex & index, int role = Qt::DisplayRole) const override;
+    QVariant    headerData  (int section, Qt::Orientation orientation, int role = Qt::DisplayRole) const override;
     QHash<int, QByteArray> roleNames(void) const override;
 
     signals:

--- a/src/QmlControls/QGCPalette.cc
+++ b/src/QmlControls/QGCPalette.cc
@@ -72,6 +72,7 @@ void QGCPalette::_buildMap()
     DECLARE_QGC_COLOR(statusPendingText,    "#9d9d9d", "#000000", "#707070", "#ffffff")
     DECLARE_QGC_COLOR(toolbarBackground,    "#00ffffff", "#00ffffff", "#00222222", "#00222222")
     DECLARE_QGC_COLOR(groupBorder,          "#bbbbbb", "#3A9BDC", "#707070", "#707070")
+    DECLARE_QGC_COLOR(modifiedParamValue,   "#bf7539", "#bf7539", "#de8500", "#de8500")
 
     // Colors not affecting by theming
     //                                                      Disabled     Enabled

--- a/src/QmlControls/QGCPalette.h
+++ b/src/QmlControls/QGCPalette.h
@@ -149,6 +149,7 @@ public:
     DEFINE_QGC_COLOR(toolStripFGColor,              setToolStripFGColor)
     DEFINE_QGC_COLOR(toolStripHoverColor,           setToolStripHoverColor)
     DEFINE_QGC_COLOR(groupBorder,                   setGroupBorder)
+    DEFINE_QGC_COLOR(modifiedParamValue,            setModifiedParamValue)
     DEFINE_QGC_COLOR(photoCaptureButtonColor,       setPhotoCaptureButtonColor)
     DEFINE_QGC_COLOR(videoCaptureButtonColor,       setVideoCaptureButtonColor)
 


### PR DESCRIPTION
## Summary
- Add column headers (Name, Value, Description) via `HorizontalHeaderView`
- Add grid lines with borders and alternating row background colors
- Highlight modified parameter values with an orange color (`modifiedParamValue` palette color)
- Remove PX4-only gate on "Show modified only" checkbox so it works for all firmware types

<img width="772" height="699" alt="Screenshot 2026-03-21 at 6 51 30 PM" src="https://github.com/user-attachments/assets/6b81a95a-db29-4961-8b28-f43b13e06f7c" />
