### PR TITLE
fix(ci): Quote ai-inference input values to prevent YAML parse errors

### DIFF
--- a/.github/workflows/pr-checks.yml
+++ b/.github/workflows/pr-checks.yml
@@ -131,9 +131,9 @@ jobs:
           prompt-file: .github/prompts/pr-title-suggestion.prompt.yml
           max-tokens: 100
           input: |
-            current_title: ${{ steps.sanitize.outputs.title }}
-            pr_body: ${{ steps.sanitize.outputs.body }}
-            changed_files: ${{ steps.sanitize.outputs.files }}
+            current_title: ${{ toJson(steps.sanitize.outputs.title) }}
+            pr_body: ${{ toJson(steps.sanitize.outputs.body) }}
+            changed_files: ${{ toJson(steps.sanitize.outputs.files) }}
 
       - name: Comment title suggestion
         if: steps.title_check.outcome == 'failure' && github.event.pull_request.user.type != 'Bot' && steps.suggest.outputs.response
@@ -347,9 +347,9 @@ jobs:
           prompt-file: .github/prompts/pr-release-label.prompt.yml
           max-tokens: 50
           input: |
-            current_title: ${{ steps.sanitize.outputs.title }}
-            pr_body: ${{ steps.sanitize.outputs.body }}
-            changed_files: ${{ steps.sanitize.outputs.files }}
+            current_title: ${{ toJson(steps.sanitize.outputs.title) }}
+            pr_body: ${{ toJson(steps.sanitize.outputs.body) }}
+            changed_files: ${{ toJson(steps.sanitize.outputs.files) }}
 
       - name: Apply release note label
         if: steps.existing.outputs.has_label == 'false' && steps.classify.outputs.response


### PR DESCRIPTION
## Summary
- Quote template variable values in `actions/ai-inference` input blocks so that PR titles/bodies containing colons (e.g. `feat(UI): ...`) don't break the YAML parser
- Fixes both the release-label and title-suggestion AI classification steps

## Test plan
- [x] Confirmed root cause from [PR #14179](https://github.com/mavlink/qgroundcontrol/pull/14179) CI logs: `Failed to parse template variables: bad indentation of a mapping entry`
- [ ] Verify the release-label job successfully classifies PRs with colons in their titles

🤖 Generated with [Claude Code](https://claude.com/claude-code)