### PR TITLE
Plan View: tree view UX improvements

### DIFF
--- a/src/FlyView/GuidedActionsController.qml
+++ b/src/FlyView/GuidedActionsController.qml
@@ -129,7 +129,7 @@ Item {
     property bool showTakeoff:              _guidedActionsEnabled && (_activeVehicle.supports.guidedTakeoffWithAltitude || _activeVehicle.supports.guidedTakeoffWithoutAltitude) && !_vehicleFlying && _canTakeoff
     property bool showLand:                 _guidedActionsEnabled && _activeVehicle.supports.guidedMode && _vehicleArmed && !_activeVehicle.fixedWing && !_vehicleInLandMode
     property bool showStartMission:         _guidedActionsEnabled && _missionAvailable && !_missionActive && !_vehicleFlying && _canStartMission
-    property bool showContinueMission:      _guidedActionsEnabled && _missionAvailable && !_missionActive && _vehicleArmed && _vehicleFlying && (_currentMissionIndex < _missionItemCount - 1)
+    property bool showContinueMission:      _guidedActionsEnabled && _missionAvailable && !_missionActive && _vehicleArmed && _vehicleFlying && (_currentMissionIndex < _visualItemsCount - 1)
     property bool showPause:                _guidedActionsEnabled && _vehicleArmed && _activeVehicle.supports.pauseVehicle && _vehicleFlying && !_vehiclePaused && !_fixedWingOnApproach
     property bool showChangeAlt:            _guidedActionsEnabled && _vehicleFlying && _activeVehicle.supports.guidedMode && _vehicleArmed && !_missionActive
     property bool showChangeLoiterRadius:   _guidedActionsEnabled && _vehicleFlying && _activeVehicle.supports.guidedMode && _vehicleArmed && !_missionActive && _vehicleInFwdFlight && fwdFlightGotoMapCircle.visible
@@ -145,8 +145,8 @@ Item {
     property string changeSpeedTitle:   _vehicleInFwdFlight ? changeAirspeedTitle : changeCruiseSpeedTitle
     property string changeSpeedMessage: _vehicleInFwdFlight ? changeAirspeedMessage : changeCruiseSpeedMessage
 
-    // Note: The '_missionItemCount - 2' is a hack to not trigger resume mission when a mission ends with an RTL item
-    property bool showResumeMission:    _activeVehicle && !_vehicleArmed && _vehicleWasFlying && _missionAvailable && _resumeMissionIndex > 0 && (_resumeMissionIndex < _missionItemCount - 2)
+    // Note: The '_visualItemsCount - 2' is a hack to not trigger resume mission when a mission ends with an RTL item
+    property bool showResumeMission:    _activeVehicle && !_vehicleArmed && _vehicleWasFlying && _missionAvailable && _resumeMissionIndex > 0 && (_resumeMissionIndex < _visualItemsCount - 2)
 
     property bool guidedUIVisible:          confirmDialog.visible
 
@@ -163,7 +163,7 @@ Item {
     property bool   _vehicleInMissionMode:  false
     property bool   _vehicleInRTLMode:      false
     property bool   _vehicleInLandMode:     false
-    property int    _missionItemCount:      missionController.missionItemCount
+    property int    _visualItemsCount:      missionController.visualItems ? missionController.visualItems.count : 0
     property int    _currentMissionIndex:   missionController.currentMissionIndex
     property int    _resumeMissionIndex:    missionController.resumeMissionIndex
     property bool   _hideEmergenyStop:      !_corePluginOptions.flyView.guidedBarShowEmergencyStop
@@ -194,7 +194,7 @@ Item {
 
     function _outputState() {
         if (_isGuidedActionsControllerLogEnabled()) {
-            console.log(qsTr("_activeVehicle(%1) _vehicleArmed(%2) guidedModeSupported(%3) _vehicleFlying(%4) _vehicleWasFlying(%5) _vehicleInRTLMode(%6) pauseVehicleSupported(%7) _vehiclePaused(%8) _flightMode(%9) _missionItemCount(%10) roiSupported(%11) orbitSupported(%12) _missionActive(%13) _hideROI(%14) _hideOrbit(%15)").arg(_activeVehicle ? 1 : 0).arg(_vehicleArmed ? 1 : 0).arg(__guidedModeSupported ? 1 : 0).arg(_vehicleFlying ? 1 : 0).arg(_vehicleWasFlying ? 1 : 0).arg(_vehicleInRTLMode ? 1 : 0).arg(__pauseVehicleSupported ? 1 : 0).arg(_vehiclePaused ? 1 : 0).arg(_flightMode).arg(_missionItemCount).arg(__roiSupported).arg(__orbitSupported).arg(_missionActive).arg(_hideROI).arg(_hideOrbit))
+            console.log(qsTr("_activeVehicle(%1) _vehicleArmed(%2) guidedModeSupported(%3) _vehicleFlying(%4) _vehicleWasFlying(%5) _vehicleInRTLMode(%6) pauseVehicleSupported(%7) _vehiclePaused(%8) _flightMode(%9) _visualItemsCount(%10) roiSupported(%11) orbitSupported(%12) _missionActive(%13) _hideROI(%14) _hideOrbit(%15)").arg(_activeVehicle ? 1 : 0).arg(_vehicleArmed ? 1 : 0).arg(__guidedModeSupported ? 1 : 0).arg(_vehicleFlying ? 1 : 0).arg(_vehicleWasFlying ? 1 : 0).arg(_vehicleInRTLMode ? 1 : 0).arg(__pauseVehicleSupported ? 1 : 0).arg(_vehiclePaused ? 1 : 0).arg(_flightMode).arg(_visualItemsCount).arg(__roiSupported).arg(__orbitSupported).arg(_missionActive).arg(_hideROI).arg(_hideOrbit))
         }
     }
 
@@ -245,7 +245,7 @@ Item {
     on__PauseVehicleSupportedChanged:   _outputState()
     on__RoiSupportedChanged:            _outputState()
     on__OrbitSupportedChanged:          _outputState()
-    on_MissionItemCountChanged:         _outputState()
+    on_VisualItemsCountChanged:         _outputState()
     on_MissionActiveChanged:            _outputState()
 
     on_CurrentMissionIndexChanged: {

--- a/src/MissionManager/MissionController.cc
+++ b/src/MissionManager/MissionController.cc
@@ -1536,7 +1536,6 @@ void MissionController::_initAllVisualItems(void)
 
     connect(_visualItems, &QmlObjectListModel::dirtyChanged, this, &MissionController::_visualItemsDirtyChanged);
     connect(_visualItems, &QmlObjectListModel::countChanged, this, &MissionController::containsItemsChanged);
-    connect(_visualItems, &QmlObjectListModel::countChanged, this, &MissionController::missionItemCountChanged);
 
     // Connect for incremental tree model sync
     connect(_visualItems, &QAbstractItemModel::rowsInserted, this, &MissionController::_syncTreeMissionItemsInserted);
@@ -1562,7 +1561,6 @@ void MissionController::_initAllVisualItems(void)
     emit visualItemsChanged();
     emit containsItemsChanged();
     emit plannedHomePositionChanged(plannedHomePosition());
-    emit missionItemCountChanged();
 
     if (!_flyView) {
         setCurrentPlanViewSeqNum(0, true);
@@ -1582,7 +1580,6 @@ void MissionController::_deinitAllVisualItems(void)
 
     disconnect(_visualItems, &QmlObjectListModel::dirtyChanged, this, &MissionController::_visualItemsDirtyChanged);
     disconnect(_visualItems, &QmlObjectListModel::countChanged, this, &MissionController::containsItemsChanged);
-    disconnect(_visualItems, &QmlObjectListModel::countChanged, this, &MissionController::missionItemCountChanged);
 
     // Disconnect incremental tree model sync
     disconnect(_visualItems, &QAbstractItemModel::rowsInserted, this, &MissionController::_syncTreeMissionItemsInserted);

--- a/src/MissionManager/MissionController.h
+++ b/src/MissionManager/MissionController.h
@@ -66,7 +66,6 @@ public:
     Q_PROPERTY(QGeoCoordinate       previousCoordinate              MEMBER _previousCoordinate          NOTIFY planViewStateChanged)
     Q_PROPERTY(FlightPathSegment*   splitSegment                    MEMBER _splitSegment                NOTIFY splitSegmentChanged)             ///< Segment which show show + split ui element
     Q_PROPERTY(double               progressPct                     READ progressPct                    NOTIFY progressPctChanged)
-    Q_PROPERTY(int                  missionItemCount                READ missionItemCount               NOTIFY missionItemCountChanged)         ///< True mission item command count (only valid in Fly View)
     Q_PROPERTY(int                  currentMissionIndex             READ currentMissionIndex            NOTIFY currentMissionIndexChanged)
     Q_PROPERTY(int                  resumeMissionIndex              READ resumeMissionIndex             NOTIFY resumeMissionIndexChanged)       ///< Returns the item index two which a mission should be resumed. -1 indicates resume mission not available.
     Q_PROPERTY(int                  currentPlanViewSeqNum           READ currentPlanViewSeqNum          NOTIFY planViewStateChanged)
@@ -274,7 +273,6 @@ public:
     double              minAMSLAltitude             (void) const { return _minAMSLAltitude; }
     double              maxAMSLAltitude             (void) const { return _maxAMSLAltitude; }
 
-    int missionItemCount            (void) const { return _visualItems ? _visualItems->count() : 0; }
     int currentMissionIndex         (void) const;
     int resumeMissionIndex          (void) const;
     int currentPlanViewSeqNum       (void) const { return _currentPlanViewSeqNum; }
@@ -332,7 +330,6 @@ signals:
     void planViewStateChanged               (void);  ///< All plan-view properties are recomputed together in setCurrentPlanViewSeqNum, so one signal covers them all
     void takeoffMissionItemChanged          (void);
     void missionBoundingCubeChanged         (void);
-    void missionItemCountChanged            (void);
     void hasLandItemChanged                 (void);
     void multipleLandPatternsAllowedChanged (void);
     void minAMSLAltitudeChanged             (double minAMSLAltitude);

--- a/src/PlanView/MissionItemEditor.qml
+++ b/src/PlanView/MissionItemEditor.qml
@@ -16,6 +16,7 @@ Rectangle {
     signal clicked
     signal remove
     signal selectNextNotReadyItem
+    signal editorExpandedAndLoaded
 
     id:             _root
     height:         _currentItem ? (editorLoader.y + editorLoader.height + _innerMargin) : (topRowLayout.y + topRowLayout.height + _margin)
@@ -351,5 +352,17 @@ Rectangle {
         asynchronous:       true
 
         Component.onCompleted: _root._loadEditor()
+    }
+
+    onHeightChanged: {
+        if (_currentItem && editorLoader.status === Loader.Ready) {
+            _editorHeightSettleTimer.restart()
+        }
+    }
+
+    Timer {
+        id: _editorHeightSettleTimer
+        interval: 100
+        onTriggered: _root.editorExpandedAndLoaded()
     }
 }

--- a/src/PlanView/PlanInfoEditor.qml
+++ b/src/PlanView/PlanInfoEditor.qml
@@ -73,42 +73,32 @@ Rectangle {
             visible: !_root._waypointsOnlyMode
         }
 
-        GridLayout {
+        RowLayout {
             Layout.fillWidth: true
-            columnSpacing: ScreenTools.defaultFontPixelWidth
-            rowSpacing: columnSpacing
-            columns: 2
+            spacing: ScreenTools.defaultFontPixelWidth
             visible: vehicleInfoSectionHeader.visible && vehicleInfoSectionHeader.checked
 
-            QGCLabel {
-                text: qsTr("Firmware")
-                Layout.fillWidth: true
-                visible: _root._multipleFirmware
-            }
             FactComboBox {
                 fact: QGroundControl.settingsManager.appSettings.offlineEditingFirmwareClass
                 indexModel: false
-                Layout.preferredWidth: _root._fieldWidth
+                Layout.fillWidth: true
                 visible: _root._multipleFirmware && _root._allowFWVehicleTypeSelection
             }
             QGCLabel {
                 text: _root._controllerVehicle ? _root._controllerVehicle.firmwareTypeString : ""
+                Layout.fillWidth: true
                 visible: _root._multipleFirmware && !_root._allowFWVehicleTypeSelection
             }
 
-            QGCLabel {
-                text: qsTr("Vehicle")
-                Layout.fillWidth: true
-                visible: _root._multipleVehicleTypes
-            }
             FactComboBox {
                 fact: QGroundControl.settingsManager.appSettings.offlineEditingVehicleClass
                 indexModel: false
-                Layout.preferredWidth: _root._fieldWidth
+                Layout.fillWidth: true
                 visible: _root._multipleVehicleTypes && _root._allowFWVehicleTypeSelection
             }
             QGCLabel {
                 text: _root._controllerVehicle ? _root._controllerVehicle.vehicleTypeString : ""
+                Layout.fillWidth: true
                 visible: _root._multipleVehicleTypes && !_root._allowFWVehicleTypeSelection
             }
         }

--- a/src/PlanView/PlanToolBarIndicators.qml
+++ b/src/PlanView/PlanToolBarIndicators.qml
@@ -12,6 +12,8 @@ RowLayout {
     required property var planMasterController
     property bool showRallyPointsHelp: false
 
+    signal toolbarButtonClicked()
+
     id: root
     spacing: ScreenTools.defaultFontPixelWidth
 
@@ -117,7 +119,7 @@ RowLayout {
         text: qsTr("Open")
         iconSource: "/qmlimages/Plan.svg"
         enabled: !_planMasterController.syncInProgress
-        onClicked: _openButtonClicked()
+        onClicked: { toolbarButtonClicked(); _openButtonClicked() }
     }
 
     QGCButton {
@@ -125,7 +127,7 @@ RowLayout {
         iconSource: "/res/SaveToDisk.svg"
         enabled: !_syncInProgress && _hasPlanItems
         primary: _saveDirty
-        onClicked: _saveButtonClicked()
+        onClicked: { toolbarButtonClicked(); _saveButtonClicked() }
     }
 
     QGCButton {
@@ -135,14 +137,14 @@ RowLayout {
         enabled: !_syncInProgress && _hasPlanItems
         visible: !_syncInProgress
         primary: _uploadDirty
-        onClicked: _uploadClicked()
+        onClicked: { toolbarButtonClicked(); _uploadClicked() }
     }
 
     QGCButton {
         text: qsTr("Clear")
         iconSource: "/res/TrashCan.svg"
         enabled: !_syncInProgress
-        onClicked: _clearClicked()
+        onClicked: { toolbarButtonClicked(); _clearClicked() }
     }
 
     QGCButton {

--- a/src/PlanView/PlanTreeView.qml
+++ b/src/PlanView/PlanTreeView.qml
@@ -43,13 +43,63 @@ TreeView {
     QGCFlickableScrollIndicator { parent: root; orientation: QGCFlickableScrollIndicator.Horizontal }
     QGCFlickableScrollIndicator { parent: root; orientation: QGCFlickableScrollIndicator.Vertical }
 
+    property int _lastMissionItemCount: 0
+
+    Connections {
+        target: root._missionController.visualItems
+        function onCountChanged() {
+            var newCount = _missionController.visualItems ? _missionController.visualItems.count : 0
+            if (newCount > root._lastMissionItemCount) {
+                // First waypoint added — collapse Plan Info and Defaults
+                if (root._lastMissionItemCount <= 1 && newCount > 1) {
+                    var planFileRow = _rowFor(_missionController.planFileGroupIndex)
+                    if (root.isExpanded(planFileRow)) {
+                        root.collapse(planFileRow)
+                    }
+                    var defaultsRow = _rowFor(_missionController.defaultsGroupIndex)
+                    if (root.isExpanded(defaultsRow)) {
+                        root.collapse(defaultsRow)
+                    }
+                }
+                // Expand mission group and scroll to the new item
+                var missionRow = _rowFor(_missionController.missionGroupIndex)
+                if (!root.isExpanded(missionRow)) {
+                    root.expand(missionRow)
+                }
+                // Scroll happens when the editor signals editorExpandedAndLoaded
+            }
+            root._lastMissionItemCount = newCount
+        }
+    }
+
     Connections {
         target: root._missionController
         function onVisualItemsChanged() {
-            // Mission group always expanded after rebuild (clear / load)
             root.collapseRecursively()
-            root.expand(_rowFor(_missionController.missionGroupIndex))
+            if (_missionController.containsItems) {
+                // Non-empty plan: expand mission group
+                root.expand(_rowFor(_missionController.missionGroupIndex))
+            } else {
+                // Empty plan: expand Plan Info and Defaults, scroll to top
+                root.expand(_rowFor(_missionController.planFileGroupIndex))
+                root.expand(_rowFor(_missionController.defaultsGroupIndex))
+                root.contentY = 0
+            }
+            root._lastMissionItemCount = _missionController.visualItems ? _missionController.visualItems.count : 0
             root.editingLayerChangeRequested(root._layerMission)
+        }
+        function onPlanViewStateChanged() {
+            // Current item changed — bring it on-screen if completely off-screen.
+            // Fine-tuned scroll happens later via editorExpandedAndLoaded.
+            var item = _missionController.currentPlanViewItem
+            if (item) {
+                var modelIndex = _missionController.visualItemsTree.indexForObject(item)
+                var row = root.rowAtIndex(modelIndex)
+                if (row >= 0) {
+                    root.forceLayout()
+                    root.positionViewAtRow(row, TableView.Visible)
+                }
+            }
         }
     }
 
@@ -105,6 +155,16 @@ TreeView {
         running: false
         repeat: false
         onTriggered: root.forceLayout()
+    }
+
+    // Called by MissionItemEditor delegates when their editor height has settled.
+    function _scrollToMissionItem(delegateItem) {
+        root.forceLayout()
+        var bottomY = delegateItem.mapToItem(root.contentItem, 0, delegateItem.height).y
+        var neededContentY = bottomY - root.height
+        if (neededContentY > root.contentY) {
+            root.contentY = neededContentY
+        }
     }
 
     delegate: Item {
@@ -225,6 +285,9 @@ TreeView {
                                 break
                             }
                         }
+                    })
+                    item.editorExpandedAndLoaded.connect(function() {
+                        root._scrollToMissionItem(delegateRoot)
                     })
                 }
             }

--- a/src/PlanView/PlanView.qml
+++ b/src/PlanView/PlanView.qml
@@ -47,6 +47,14 @@ Item {
         }
     }
 
+    Connections {
+        target: planToolBar
+        function onToolbarButtonClicked() {
+            _addWaypointOnClick = false
+            _addROIOnClick = false
+        }
+    }
+
     function mapCenter() {
         var coordinate = editorMap.center
         coordinate.latitude  = coordinate.latitude.toFixed(_decimalPlaces)

--- a/src/Settings/App.SettingsGroup.json
+++ b/src/Settings/App.SettingsGroup.json
@@ -7,7 +7,7 @@
     "name":             "offlineEditingFirmwareClass",
     "shortDesc": "Offline editing firmware class",
     "type":             "uint32",
-    "enumStrings":      "ArduPilot,PX4 Pro,Mavlink Generic",
+    "enumStrings":      "ArduPilot,PX4 Pro,MAVLink",
     "enumValues":       "3,12,0",
     "default":     12
 },
@@ -15,7 +15,7 @@
     "name":             "offlineEditingVehicleClass",
     "shortDesc": "Offline editing vehicle class",
     "type":             "uint32",
-    "enumStrings":      "Fixed Wing,Multi-Rotor,VTOL,Rover,Sub,Mavlink Generic",
+    "enumStrings":      "Fixed Wing,Multi-Rotor,VTOL,Rover,Sub,Unknown",
     "enumValues":       "1,2,20,10,12,0",
     "default":     2
 },

--- a/src/UI/toolbar/PlanViewToolBar.qml
+++ b/src/UI/toolbar/PlanViewToolBar.qml
@@ -16,6 +16,8 @@ Rectangle {
     property var planMasterController
     property bool showRallyPointsHelp: false
 
+    signal toolbarButtonClicked()
+
     property var _activeVehicle: QGroundControl.multiVehicleManager.activeVehicle
     property real _controllerProgressPct: planMasterController.missionController.progressPct
 
@@ -55,6 +57,7 @@ Rectangle {
             anchors.bottom: parent.bottom
             planMasterController: _root.planMasterController
             showRallyPointsHelp: _root.showRallyPointsHelp
+            onToolbarButtonClicked: _root.toolbarButtonClicked()
         }
     }
 


### PR DESCRIPTION
## Summary
- Vehicle Info section: place firmware/vehicle combos side by side without labels
- Rename firmware "Mavlink Generic" to "MAVLink" and vehicle "Mavlink Generic" to "Unknown"
- Empty plan state: expand Plan Info and Defaults sections, scroll to top
- First waypoint added: collapse Plan Info/Defaults, expand Mission Items
- Auto-scroll tree view to show newly added or selected mission items with full editor visible
- Toolbar buttons (Open/Save/Upload/Clear) uncheck active toolstrip buttons (Waypoint/ROI)

## Test plan
- [ ] Start Plan View with empty plan — verify Plan Info and Defaults are expanded
- [ ] Add first waypoint — verify Plan Info/Defaults collapse and Mission Items expands
- [ ] Add multiple waypoints — verify tree scrolls to show each new item's full editor
- [ ] Click existing mission item — verify it scrolls into view
- [ ] Click Open/Save/Upload/Clear — verify Waypoint/ROI buttons uncheck
- [ ] Check firmware combo shows "MAVLink" instead of "Mavlink Generic"
- [ ] Check vehicle combo shows "Unknown" instead of "Mavlink Generic"