### PR TITLE
feat(UI): Add tabbed views and favorites to Parameter Editor

### DIFF
--- a/src/QmlControls/ParameterEditor.qml
+++ b/src/QmlControls/ParameterEditor.qml
@@ -13,12 +13,14 @@ Item {
     property Fact   _editorDialogFact: Fact { }
     property int    _rowHeight:         ScreenTools.defaultFontPixelHeight * 2
     property int    _rowWidth:          10 // Dynamic adjusted at runtime
-    property bool   _searchFilter:      searchText.text.trim() != "" || controller.showModifiedOnly  ///< true: showing results of search
+    property bool   _searchFilter:      searchText.text.trim() != "" || controller.showModifiedOnly || controller.showFavoritesOnly  ///< true: showing results of search
     property var    _searchResults      ///< List of parameter names from search results
     property var    _activeVehicle:     QGroundControl.multiVehicleManager.activeVehicle
     property bool   _showRCToParam:     _activeVehicle.px4Firmware
     property var    _appSettings:       QGroundControl.settingsManager.appSettings
     property var    _controller:        controller
+    property var    _favorites:         controller.favoriteParameterNames
+    property real   _margins:           ScreenTools.defaultFontPixelHeight / 2
 
     ParameterEditorController {
         id: controller
@@ -70,6 +72,11 @@ Item {
                 fileDialog.title =          qsTr("Save Parameters")
                 fileDialog.openForSave()
             }
+        }
+        QGCMenuSeparator { }
+        QGCMenuItem {
+            text:           qsTr("Clear all favorites")
+            onTriggered:    controller.clearAllFavorites()
         }
         QGCMenuSeparator { visible: _showRCToParam }
         QGCMenuItem {
@@ -159,12 +166,6 @@ Item {
                     clearTimer.start()
                 }
             }
-
-            QGCCheckBox {
-                text:       qsTr("Show modified only")
-                checked:    controller.showModifiedOnly
-                onClicked:  controller.showModifiedOnly = checked
-            }
         }
 
         QGCButton {
@@ -174,11 +175,29 @@ Item {
         }
     }
 
+    QGCTabBar {
+        id:             tabBar
+        anchors.left:   parent.left
+        anchors.right:  parent.right
+        anchors.top:        header.bottom
+        anchors.topMargin:  _margins
+
+        QGCTabButton { text: qsTr("Full List") }
+        QGCTabButton { text: qsTr("Modified") }
+        QGCTabButton { text: qsTr("Favorites") }
+
+        onCurrentIndexChanged: {
+            controller.showModifiedOnly  = (currentIndex === 1)
+            controller.showFavoritesOnly = (currentIndex === 2)
+        }
+    }
+
     /// Group buttons
     QGCFlickable {
         id :                groupScroll
         width:              ScreenTools.defaultFontPixelWidth * 25
-        anchors.top:        header.bottom
+        anchors.top:        tabBar.bottom
+        anchors.topMargin:  _margins
         anchors.bottom:     parent.bottom
         clip:               true
         pixelAligned:       true
@@ -240,12 +259,14 @@ Item {
         id:                 headerView
         anchors.left:       tableView.left
         anchors.right:      tableView.right
-        anchors.top:        header.bottom
+        anchors.top:        tabBar.bottom
+        anchors.topMargin:  _margins
         syncView:           tableView
         clip:               true
 
         delegate: Rectangle {
-            implicitWidth:  headerLabel.contentWidth + ScreenTools.defaultFontPixelWidth
+            implicitWidth:  column === 0 ? ScreenTools.implicitCheckBoxHeight + ScreenTools.defaultFontPixelWidth
+                                         : headerLabel.contentWidth + ScreenTools.defaultFontPixelWidth
             implicitHeight: headerLabel.contentHeight + ScreenTools.defaultFontPixelHeight * 0.5
             color:          qgcPal.windowShade
 
@@ -280,7 +301,7 @@ Item {
                 height:         parent.height
                 width:          1
                 color:          qgcPal.groupBorder
-                visible:        column == 2
+                visible:        column == 3
             }
 
             // Bottom border
@@ -322,7 +343,9 @@ Item {
         }
 
         delegate: Rectangle {
-            implicitWidth:  column == 1 ? ScreenTools.defaultFontPixelWidth * 16 : label.contentWidth + ScreenTools.defaultFontPixelWidth
+            implicitWidth:  column === 0 ? ScreenTools.implicitCheckBoxHeight + ScreenTools.defaultFontPixelWidth
+                                         : column === 2 ? ScreenTools.defaultFontPixelWidth * 16
+                                                        : label.contentWidth + ScreenTools.defaultFontPixelWidth
             implicitHeight: label.contentHeight + ScreenTools.defaultFontPixelHeight * 0.5
             color:          row % 2 === 0 ? "transparent" : qgcPal.windowShade
             clip:           true
@@ -349,20 +372,29 @@ Item {
                 height:         parent.height
                 width:          1
                 color:          qgcPal.groupBorder
-                visible:        column == 2
+                visible:        column == 3
+            }
+
+            QGCCheckBox {
+                visible:                column === 0
+                anchors.centerIn:       parent
+                checked:                _root._favorites.indexOf(fact.name) >= 0
+                z:                      1
+                onClicked:              controller.toggleFavorite(fact.name)
             }
 
             QGCLabel {
                 id:                 label
+                visible:            column !== 0
                 anchors.left:       parent.left
                 anchors.leftMargin: ScreenTools.defaultFontPixelWidth / 2
                 anchors.verticalCenter: parent.verticalCenter
-                width:              column == 1 ? ScreenTools.defaultFontPixelWidth * 15 : contentWidth
-                text:               column == 1 ? col1String() : display
-                color:              column == 1 && fact.defaultValueAvailable && !fact.valueEqualsDefault ? qgcPal.modifiedParamValue : qgcPal.text
-                font.bold:          column == 1 && fact.defaultValueAvailable && !fact.valueEqualsDefault
+                width:              column == 2 ? ScreenTools.defaultFontPixelWidth * 15 : contentWidth
+                text:               column == 2 ? col1String() : display
+                color:              column == 2 && fact.defaultValueAvailable && !fact.valueEqualsDefault ? qgcPal.modifiedParamValue : qgcPal.text
+                font.bold:          column == 2 && fact.defaultValueAvailable && !fact.valueEqualsDefault
                 maximumLineCount:   1
-                elide:              column == 1 ? Text.ElideRight : Text.ElideNone
+                elide:              column == 2 ? Text.ElideRight : Text.ElideNone
 
                 function col1String() {
                     if (fact.enumStrings.length === 0) {
@@ -377,6 +409,7 @@ Item {
 
             QGCMouseArea {
                 anchors.fill: parent
+                visible:      column !== 0
                 onClicked: mouse => {
                     _editorDialogFact = fact
                     editorDialogFactory.open()

--- a/src/QmlControls/ParameterEditorController.cc
+++ b/src/QmlControls/ParameterEditorController.cc
@@ -2,6 +2,7 @@
 #include "QGCApplication.h"
 #include "ParameterManager.h"
 #include "AppSettings.h"
+#include "SettingsManager.h"
 #include "Vehicle.h"
 #include "QGCLoggingCategory.h"
 
@@ -58,6 +59,7 @@ QVariant ParameterTableModel::headerData(int section, Qt::Orientation orientatio
     }
 
     switch (section) {
+    case FavColumn:         return tr("Fav");
     case NameColumn:        return tr("Name");
     case ValueColumn:       return tr("Value");
     case DescriptionColumn: return tr("Description");
@@ -93,6 +95,7 @@ void ParameterTableModel::insert(int row, Fact* fact)
     }
 
     ColumnData colData(_tableViewColCount, QString());
+    colData[FavColumn] = QString();
     colData[NameColumn] = fact->name();
     colData[ValueColumn] = QVariant::fromValue(fact);
     colData[DescriptionColumn] = fact->shortDescription();
@@ -161,8 +164,11 @@ ParameterEditorController::ParameterEditorController(QObject *parent)
     connect(this, &ParameterEditorController::currentGroupChanged,      this, &ParameterEditorController::_currentGroupChanged);
     connect(this, &ParameterEditorController::searchTextChanged,        this, &ParameterEditorController::_searchTextChanged);
     connect(this, &ParameterEditorController::showModifiedOnlyChanged,  this, &ParameterEditorController::_searchTextChanged);
+    connect(this, &ParameterEditorController::showFavoritesOnlyChanged, this, &ParameterEditorController::_searchTextChanged);
     connect(&_searchTimer, &QTimer::timeout,                            this, &ParameterEditorController::_performSearch);
     connect(_parameterMgr, &ParameterManager::factAdded,                this, &ParameterEditorController::_factAdded);
+
+    _loadFavorites();
 
     ParameterEditorCategory* category = _categories.count() ? _categories.value<ParameterEditorCategory*>(0) : nullptr;
     setCurrentCategory(category);
@@ -469,11 +475,17 @@ void ParameterEditorController::resetAllToVehicleConfiguration(void)
 
 bool ParameterEditorController::_shouldShow(Fact* fact) const
 {
-    if (!_showModifiedOnly) {
-        return true;
+    if (_showModifiedOnly) {
+        if (!fact->defaultValueAvailable() || fact->valueEqualsDefault()) {
+            return false;
+        }
     }
-
-    return fact->defaultValueAvailable() && !fact->valueEqualsDefault();
+    if (_showFavoritesOnly) {
+        if (!_favoriteNames.contains(fact->name())) {
+            return false;
+        }
+    }
+    return true;
 }
 
 void ParameterEditorController::_searchTextChanged(void)
@@ -487,7 +499,7 @@ void ParameterEditorController::_performSearch(void)
 
     QStringList rgSearchStrings = _searchText.split(' ', Qt::SkipEmptyParts);
 
-    if (rgSearchStrings.isEmpty() && !_showModifiedOnly) {
+    if (rgSearchStrings.isEmpty() && !_showModifiedOnly && !_showFavoritesOnly) {
         ParameterEditorCategory* category = _categories.count() ? _categories.value<ParameterEditorCategory*>(0) : nullptr;
         setCurrentCategory(category);
         _searchParameters.clear();
@@ -502,31 +514,33 @@ void ParameterEditorController::_performSearch(void)
         _searchParameters.beginReset();
         _searchParameters.clear();
 
-        for (const QString &paraName: _parameterMgr->parameterNames(_vehicle->defaultComponentId())) {
-            Fact* fact = _parameterMgr->getParameter(_vehicle->defaultComponentId(), paraName);
-            bool matched = _shouldShow(fact);
-            // All of the search items must match in order for the parameter to be added to the list
-            if (matched) {
-                for (int i = 0; i < rgSearchStrings.size(); ++i) {
-                    const QRegularExpression &re = regexList.at(i);
-                    if (re.isValid()) {
-                        if (!fact->name().contains(re) &&
-                                !fact->shortDescription().contains(re) &&
-                                !fact->longDescription().contains(re)) {
-                            matched = false;
-                        }
-                    } else {
-                        const QString &searchItem = rgSearchStrings.at(i);
-                        if (!fact->name().contains(searchItem, Qt::CaseInsensitive) &&
-                                !fact->shortDescription().contains(searchItem, Qt::CaseInsensitive) &&
-                                !fact->longDescription().contains(searchItem, Qt::CaseInsensitive)) {
-                            matched = false;
+        for (int compId : _parameterMgr->componentIds()) {
+            for (const QString &paraName: _parameterMgr->parameterNames(compId)) {
+                Fact* fact = _parameterMgr->getParameter(compId, paraName);
+                bool matched = _shouldShow(fact);
+                // All of the search items must match in order for the parameter to be added to the list
+                if (matched) {
+                    for (int i = 0; i < rgSearchStrings.size(); ++i) {
+                        const QRegularExpression &re = regexList.at(i);
+                        if (re.isValid()) {
+                            if (!fact->name().contains(re) &&
+                                    !fact->shortDescription().contains(re) &&
+                                    !fact->longDescription().contains(re)) {
+                                matched = false;
+                            }
+                        } else {
+                            const QString &searchItem = rgSearchStrings.at(i);
+                            if (!fact->name().contains(searchItem, Qt::CaseInsensitive) &&
+                                    !fact->shortDescription().contains(searchItem, Qt::CaseInsensitive) &&
+                                    !fact->longDescription().contains(searchItem, Qt::CaseInsensitive)) {
+                                matched = false;
+                            }
                         }
                     }
                 }
-            }
-            if (matched) {
-                _searchParameters.append(fact);
+                if (matched) {
+                    _searchParameters.append(fact);
+                }
             }
         }
 
@@ -576,4 +590,57 @@ void ParameterEditorController::setCurrentGroup(QObject* currentGroup)
         _currentGroup = group;
         emit currentGroupChanged();
     }
+}
+
+QStringList ParameterEditorController::favoriteParameterNames(void) const
+{
+    QStringList list(_favoriteNames.begin(), _favoriteNames.end());
+    list.sort();
+    return list;
+}
+
+void ParameterEditorController::toggleFavorite(const QString& paramName)
+{
+    if (_favoriteNames.contains(paramName)) {
+        _favoriteNames.remove(paramName);
+    } else {
+        _favoriteNames.insert(paramName);
+    }
+    _saveFavorites();
+    emit favoritesChanged();
+
+    if (_showFavoritesOnly) {
+        _performSearch();
+    }
+}
+
+bool ParameterEditorController::isFavorite(const QString& paramName) const
+{
+    return _favoriteNames.contains(paramName);
+}
+
+void ParameterEditorController::clearAllFavorites(void)
+{
+    _favoriteNames.clear();
+    _saveFavorites();
+    emit favoritesChanged();
+
+    if (_showFavoritesOnly) {
+        _performSearch();
+    }
+}
+
+void ParameterEditorController::_loadFavorites()
+{
+    Fact* fact = SettingsManager::instance()->appSettings()->favoriteParameters();
+    const QStringList list = fact->rawValue().toString().split(",", Qt::SkipEmptyParts);
+    _favoriteNames = QSet<QString>(list.begin(), list.end());
+}
+
+void ParameterEditorController::_saveFavorites()
+{
+    QStringList list(_favoriteNames.begin(), _favoriteNames.end());
+    list.sort();
+    Fact* fact = SettingsManager::instance()->appSettings()->favoriteParameters();
+    fact->setRawValue(list.join(","));
 }

--- a/src/QmlControls/ParameterEditorController.h
+++ b/src/QmlControls/ParameterEditorController.h
@@ -2,6 +2,7 @@
 
 #include <QtCore/QLoggingCategory>
 #include <QtCore/QObject>
+#include <QtCore/QSet>
 #include <QtQmlIntegration/QtQmlIntegration>
 
 #include "FactPanelController.h"
@@ -27,7 +28,8 @@ public:
     };
 
     enum {
-        NameColumn = 0,
+        FavColumn = 0,
+        NameColumn,
         ValueColumn,
         DescriptionColumn,
     };
@@ -54,7 +56,7 @@ public:
 private:
     bool _isResetting() const { return _resetNestingCount > 0; }
 
-    int                 _tableViewColCount = 3;
+    int                 _tableViewColCount = 4;
     QList<ColumnData>   _tableData;
     uint                _resetNestingCount = 0;
 };
@@ -132,6 +134,8 @@ class ParameterEditorController : public FactPanelController
     Q_PROPERTY(QObject*             currentGroup            READ currentGroup               WRITE setCurrentGroup       NOTIFY currentGroupChanged)
     Q_PROPERTY(QAbstractTableModel* parameters              MEMBER _parameters                                          NOTIFY parametersChanged)
     Q_PROPERTY(bool                 showModifiedOnly        MEMBER _showModifiedOnly                                    NOTIFY showModifiedOnlyChanged)
+    Q_PROPERTY(bool                 showFavoritesOnly       MEMBER _showFavoritesOnly                                   NOTIFY showFavoritesOnlyChanged)
+    Q_PROPERTY(QStringList          favoriteParameterNames  READ favoriteParameterNames                                 NOTIFY favoritesChanged)
 
     // These property are related to the diff associated with a load from file
     Q_PROPERTY(bool                 diffOtherVehicle        MEMBER _diffOtherVehicle                                    NOTIFY diffOtherVehicleChanged)
@@ -149,11 +153,15 @@ public:
     Q_INVOKABLE void refresh                        (void);
     Q_INVOKABLE void resetAllToDefaults             (void);
     Q_INVOKABLE void resetAllToVehicleConfiguration (void);
+    Q_INVOKABLE void toggleFavorite                 (const QString& paramName);
+    Q_INVOKABLE bool isFavorite                     (const QString& paramName) const;
+    Q_INVOKABLE void clearAllFavorites              (void);
 
-    QObject*            currentCategory     (void) { return _currentCategory; }
-    QObject*            currentGroup        (void) { return _currentGroup; }
-    QmlObjectListModel* categories          (void) { return &_categories; }
-    QmlObjectListModel* diffList            (void) { return &_diffList; }
+    QObject*            currentCategory         (void) { return _currentCategory; }
+    QObject*            currentGroup            (void) { return _currentGroup; }
+    QmlObjectListModel* categories              (void) { return &_categories; }
+    QmlObjectListModel* diffList                (void) { return &_diffList; }
+    QStringList         favoriteParameterNames  (void) const;
     void                setCurrentCategory  (QObject* currentCategory);
     void                setCurrentGroup     (QObject* currentGroup);
 
@@ -162,6 +170,8 @@ signals:
     void currentCategoryChanged         (void);
     void currentGroupChanged            (void);
     void showModifiedOnlyChanged        (void);
+    void showFavoritesOnlyChanged       (void);
+    void favoritesChanged               (void);
     void diffOtherVehicleChanged        (bool diffOtherVehicle);
     void diffMultipleComponentsChanged  (bool diffMultipleComponents);
     void parametersChanged              (void);
@@ -177,6 +187,8 @@ private slots:
 private:
     bool _shouldShow(Fact *fact) const;
     void _performSearch();
+    void _loadFavorites();
+    void _saveFavorites();
 
 private:
     ParameterManager*           _parameterMgr           = nullptr;
@@ -185,8 +197,10 @@ private:
     ParameterEditorCategory*    _currentCategory        = nullptr;
     ParameterEditorGroup*       _currentGroup           = nullptr;
     bool                        _showModifiedOnly       = false;
+    bool                        _showFavoritesOnly      = false;
     bool                        _diffOtherVehicle       = false;
     bool                        _diffMultipleComponents = false;
+    QSet<QString>               _favoriteNames;
 
     QmlObjectListModel          _categories;
     QmlObjectListModel          _diffList;

--- a/src/Settings/App.SettingsGroup.json
+++ b/src/Settings/App.SettingsGroup.json
@@ -258,6 +258,12 @@
     "shortDesc": "Comma separated list of first run prompt ids which have already been shown.",
     "type":             "string",
     "default":     ""
+},
+{
+    "name":             "favoriteParameters",
+    "shortDesc": "Comma separated list of favorite parameter names.",
+    "type":             "string",
+    "default":     ""
 }
 ]
 }

--- a/src/Settings/AppSettings.cc
+++ b/src/Settings/AppSettings.cc
@@ -142,6 +142,7 @@ DECLARE_SETTINGSFACT(AppSettings, gstDebugLevel)
 DECLARE_SETTINGSFACT(AppSettings, followTarget)
 DECLARE_SETTINGSFACT(AppSettings, disableAllPersistence)
 DECLARE_SETTINGSFACT(AppSettings, firstRunPromptIdsShown)
+DECLARE_SETTINGSFACT(AppSettings, favoriteParameters)
 
 DECLARE_SETTINGSFACT_NO_FUNC(AppSettings, indoorPalette)
 {

--- a/src/Settings/AppSettings.h
+++ b/src/Settings/AppSettings.h
@@ -47,6 +47,7 @@ public:
     DEFINE_SETTINGFACT(qLocaleLanguage)
     DEFINE_SETTINGFACT(disableAllPersistence)
     DEFINE_SETTINGFACT(firstRunPromptIdsShown)
+    DEFINE_SETTINGFACT(favoriteParameters)
 
     Q_PROPERTY(QString missionSavePath          READ missionSavePath            NOTIFY savePathsChanged)
     Q_PROPERTY(QString parameterSavePath        READ parameterSavePath          NOTIFY savePathsChanged)


### PR DESCRIPTION
## Summary
- Replace the "Show modified only" checkbox with a **QGCTabBar** providing three views: **Full List**, **Modified**, and **Favorites**
- Add a **Fav column** with checkboxes to toggle favorite parameters, with grid borders matching existing table styling
- Persist favorites as a comma-separated string via **AppSettings** (`favoriteParameters` SettingsFact)
- Add **"Clear all favorites"** option in the Tools menu

<img width="1069" height="224" alt="Screenshot 2026-03-21 at 9 02 17 PM" src="https://github.com/user-attachments/assets/decb6c49-ed96-4bf3-ad65-f5d6050514e5" />
