### PR TITLE
QGCTabBar/Button: Add separators between unselected tab buttons

### DIFF
--- a/src/QmlControls/QGCTabBar.qml
+++ b/src/QmlControls/QGCTabBar.qml
@@ -29,6 +29,24 @@ RowLayout {
         _selectCurrentIndexButton()
     }
 
+    function _updateSeparators() {
+        for (var i = 0; i < _buttons.length; i++) {
+            if (!_buttons[i].visible || _buttons[i].checked) {
+                _buttons[i]._showSeparator = false
+                continue
+            }
+            // Find the next visible button
+            var nextVisible = null
+            for (var j = i + 1; j < _buttons.length; j++) {
+                if (_buttons[j].visible) {
+                    nextVisible = _buttons[j]
+                    break
+                }
+            }
+            _buttons[i]._showSeparator = nextVisible !== null && !nextVisible.checked
+        }
+    }
+
     function _selectCurrentIndexButton() {
         if (_buttons.length === 0) return
 
@@ -60,6 +78,7 @@ RowLayout {
         }
 
         _preventCurrentIndexBindingLoop = false
+        _updateSeparators()
     }
 
     Component.onCompleted: _updateButtons()

--- a/src/QmlControls/QGCTabButton.qml
+++ b/src/QmlControls/QGCTabButton.qml
@@ -24,6 +24,7 @@ Button {
     property real backRadius: ScreenTools.defaultBorderRadius
     property real heightFactor: 0.5
 
+    property bool _showSeparator: false
     property bool _showHighlight: enabled && (pressed | checked)
     property int _horizontalPadding: ScreenTools.defaultFontPixelWidth
     property int _verticalPadding: Math.round(ScreenTools.defaultFontPixelHeight * heightFactor)
@@ -39,6 +40,19 @@ Button {
         border.width: showBorder ? 1 : 0
         border.color: qgcPal.buttonBorder
         color: _showHighlight ? qgcPal.buttonHighlight : qgcPal.button
+
+        Rectangle {
+            anchors.right: parent.right
+            anchors.top: parent.top
+            anchors.bottom: parent.bottom
+            anchors.topMargin: _vertMargin
+            anchors.bottomMargin: _vertMargin
+            width: 1
+            color: Qt.darker(qgcPal.buttonText, 1.5)
+            visible: control._showSeparator
+
+            property real _vertMargin: ScreenTools.defaultFontPixelHeight * 0.25
+        }
     }
 
     contentItem: Item {


### PR DESCRIPTION
## Summary
- Show a 1px vertical separator between adjacent unselected QGCTabButtons for better visual distinction
- Separators automatically hide next to the selected tab and next to hidden tabs
- QGCTabBar manages separator visibility; QGCTabButton renders the line

Before:
![Screenshot 2026-03-22 at 8 48 31 AM](https://github.com/user-attachments/assets/52bbbd8a-6b82-41f7-afab-80a5b67e309e)

After:
![Screenshot 2026-03-22 at 8 47 59 AM](https://github.com/user-attachments/assets/531881d7-b686-448a-85a6-c89566919431)


## Test plan
- [ ] Open any view using QGCTabBar (e.g. Vehicle Setup, Parameter Editor)
- [ ] Verify separators appear between unselected tabs
- [ ] Click different tabs — separators adjacent to the selected tab should disappear
- [ ] If any tab is hidden, verify separators still display correctly between remaining visible tabs
- [ ] Check both light and dark themes