### PR TITLE
ArduPilot: ESC Config Page, restructure Power Config

### DIFF
--- a/src/AutoPilotPlugins/APM/APMAutoPilotPlugin.cc
+++ b/src/AutoPilotPlugins/APM/APMAutoPilotPlugin.cc
@@ -6,6 +6,7 @@
 #include "APMLightsComponent.h"
 #include "APMMotorComponent.h"
 #include "APMServoComponent.h"
+#include "APMESCComponent.h"
 #include "APMPowerComponent.h"
 #include "APMRadioComponent.h"
 #include "APMRemoteSupportComponent.h"
@@ -77,6 +78,10 @@ const QVariantList &APMAutoPilotPlugin::vehicleComponents()
             _powerComponent = new APMPowerComponent(_vehicle, this);
             _powerComponent->setupTriggerSignals();
             _components.append(QVariant::fromValue(qobject_cast<VehicleComponent*>(_powerComponent)));
+
+            _escComponent = new APMESCComponent(_vehicle, this);
+            _escComponent->setupTriggerSignals();
+            _components.append(QVariant::fromValue(qobject_cast<VehicleComponent*>(_escComponent)));
 
             if (!_vehicle->sub() || (_vehicle->sub() && (_vehicle->versionCompare(3, 5, 3) >= 0))) {
                 _motorComponent = new APMMotorComponent(_vehicle, this);
@@ -170,6 +175,8 @@ QString APMAutoPilotPlugin::prerequisiteSetup(VehicleComponent *component) const
     } else if (qobject_cast<const APMRadioComponent*>(component)) {
         requiresAirframeCheck = true;
     } else if (qobject_cast<const APMPowerComponent*>(component)) {
+        requiresAirframeCheck = true;
+    } else if (qobject_cast<const APMESCComponent*>(component)) {
         requiresAirframeCheck = true;
     } else if (qobject_cast<const APMSafetyComponent*>(component)) {
         requiresAirframeCheck = true;

--- a/src/AutoPilotPlugins/APM/APMAutoPilotPlugin.h
+++ b/src/AutoPilotPlugins/APM/APMAutoPilotPlugin.h
@@ -9,6 +9,7 @@ class APMRadioComponent;
 class APMTuningComponent;
 class APMSafetyComponent;
 class APMSensorsComponent;
+class APMESCComponent;
 class APMPowerComponent;
 class APMMotorComponent;
 class APMGimbalComponent;
@@ -46,6 +47,7 @@ protected:
     APMFlightModesComponent *_flightModesComponent = nullptr;
     APMServoComponent *_servoComponent = nullptr;
     APMPowerComponent *_powerComponent = nullptr;
+    APMESCComponent *_escComponent = nullptr;
     APMMotorComponent *_motorComponent = nullptr;
     APMRadioComponent *_radioComponent = nullptr;
     APMSafetyComponent *_safetyComponent = nullptr;

--- a/src/AutoPilotPlugins/APM/APMESCComponent.cc
+++ b/src/AutoPilotPlugins/APM/APMESCComponent.cc
@@ -1,0 +1,7 @@
+#include "APMESCComponent.h"
+
+APMESCComponent::APMESCComponent(Vehicle *vehicle, AutoPilotPlugin *autopilot, QObject *parent)
+    : VehicleComponent(vehicle, autopilot, AutoPilotPlugin::KnownESCVehicleComponent, parent)
+{
+
+}

--- a/src/AutoPilotPlugins/APM/APMESCComponent.h
+++ b/src/AutoPilotPlugins/APM/APMESCComponent.h
@@ -1,0 +1,25 @@
+#pragma once
+
+#include "VehicleComponent.h"
+
+class APMESCComponent : public VehicleComponent
+{
+    Q_OBJECT
+
+public:
+    APMESCComponent(Vehicle *vehicle, AutoPilotPlugin *autopilot, QObject *parent = nullptr);
+
+    QStringList setupCompleteChangedTriggerList() const final { return QStringList(); }
+
+    QString name() const final { return _name; }
+    QString description() const final { return tr("The ESC Component is used to configure and calibrate Electronic Speed Controllers."); }
+    QString iconResource() const final { return QStringLiteral("/qmlimages/EscIndicator.svg"); }
+    bool requiresSetup() const final { return false; }
+    bool setupComplete() const final { return true; }
+    QUrl setupSource() const final { return QUrl::fromUserInput(QStringLiteral("qrc:/qml/QGroundControl/AutoPilotPlugins/APM/APMESCComponent.qml")); }
+    QUrl summaryQmlSource() const final { return QUrl::fromUserInput(QStringLiteral("qrc:/qml/QGroundControl/AutoPilotPlugins/APM/APMESCComponentSummary.qml")); }
+    bool allowSetupWhileArmed() const final { return true; }
+
+private:
+    const QString _name = tr("ESC");
+};

--- a/src/AutoPilotPlugins/APM/APMESCComponent.qml
+++ b/src/AutoPilotPlugins/APM/APMESCComponent.qml
@@ -1,0 +1,166 @@
+import QtQuick
+import QtQuick.Controls
+import QtQuick.Layouts
+
+import QGroundControl
+import QGroundControl.FactControls
+import QGroundControl.Controls
+
+SetupPage {
+    id: escPage
+    pageComponent: escPageComponent
+
+    FactPanelController {
+        id: controller
+    }
+
+    Component {
+        id: escPageComponent
+
+        ColumnLayout {
+            width: availableWidth
+            spacing: _margins
+
+            // ESC Configuration properties - supports both MOT_* (Copter/Rover/Sub) and Q_M_* (QuadPlane) prefixes
+            property bool _isQuadPlane: !controller.parameterExists(-1, "MOT_PWM_TYPE") && controller.parameterExists(-1, "Q_M_PWM_TYPE")
+            property string _escPrefix: _isQuadPlane ? "Q_M_" : "MOT_"
+
+            property bool _motPwmTypeAvailable: controller.parameterExists(-1, _escPrefix + "PWM_TYPE")
+            property bool _motPwmMinAvailable: controller.parameterExists(-1, _escPrefix + "PWM_MIN")
+            property bool _motPwmMaxAvailable: controller.parameterExists(-1, _escPrefix + "PWM_MAX")
+            property bool _motSpinArmAvailable: controller.parameterExists(-1, _escPrefix + "SPIN_ARM")
+            property bool _motSpinMinAvailable: controller.parameterExists(-1, _escPrefix + "SPIN_MIN")
+            property bool _motSpinMaxAvailable: controller.parameterExists(-1, _escPrefix + "SPIN_MAX")
+            property bool _servoDshotEscAvailable: controller.parameterExists(-1, "SERVO_DSHOT_ESC")
+            property bool _servoDshotRateAvailable: controller.parameterExists(-1, "SERVO_DSHOT_RATE")
+
+            property Fact _motPwmType: controller.getParameterFact(-1, _escPrefix + "PWM_TYPE", false /* reportMissing */)
+            property Fact _motPwmMin: controller.getParameterFact(-1, _escPrefix + "PWM_MIN", false /* reportMissing */)
+            property Fact _motPwmMax: controller.getParameterFact(-1, _escPrefix + "PWM_MAX", false /* reportMissing */)
+            property Fact _motSpinArm: controller.getParameterFact(-1, _escPrefix + "SPIN_ARM", false /* reportMissing */)
+            property Fact _motSpinMin: controller.getParameterFact(-1, _escPrefix + "SPIN_MIN", false /* reportMissing */)
+            property Fact _motSpinMax: controller.getParameterFact(-1, _escPrefix + "SPIN_MAX", false /* reportMissing */)
+            property Fact _servoDshotEsc: controller.getParameterFact(-1, "SERVO_DSHOT_ESC", false /* reportMissing */)
+            property Fact _servoDshotRate: controller.getParameterFact(-1, "SERVO_DSHOT_RATE", false /* reportMissing */)
+
+            property bool _isDshot: _motPwmTypeAvailable && _motPwmType && _motPwmType.rawValue >= 4
+
+            property string _escCalParam: _isQuadPlane ? "Q_ESC_CAL" : "ESC_CALIBRATION"
+            property bool _escCalibrationAvailable: controller.parameterExists(-1, _escCalParam)
+            property Fact _escCalibration: controller.getParameterFact(-1, _escCalParam, false /* reportMissing */)
+
+            property string _restartRequired: qsTr("Requires vehicle reboot")
+            property real _fieldWidth: ScreenTools.defaultFontPixelWidth * 15
+
+            QGCPalette { id: qgcPal; colorGroupEnabled: true }
+
+            QGCGroupBox {
+                title: qsTr("Configuration")
+                visible: _motPwmTypeAvailable
+
+                ColumnLayout {
+                    spacing: _margins
+
+                    LabelledFactComboBox {
+                        label: qsTr("Output type")
+                        fact: _motPwmType
+                        indexModel: false
+                    }
+
+                    QGCLabel {
+                        text: _restartRequired
+                        font.pointSize: ScreenTools.smallFontPointSize
+                    }
+
+                    LabelledFactTextField {
+                        label: qsTr("Output PWM min")
+                        fact: _motPwmMin
+                        textFieldPreferredWidth: _fieldWidth
+                        visible: _motPwmMinAvailable
+                    }
+
+                    LabelledFactTextField {
+                        label: qsTr("Output PWM max")
+                        fact: _motPwmMax
+                        textFieldPreferredWidth: _fieldWidth
+                        visible: _motPwmMaxAvailable
+                    }
+
+                    LabelledFactTextField {
+                        label: qsTr("Spin when armed")
+                        fact: _motSpinArm
+                        textFieldPreferredWidth: _fieldWidth
+                        visible: _motSpinArmAvailable
+                    }
+
+                    LabelledFactTextField {
+                        label: qsTr("Spin minimum")
+                        fact: _motSpinMin
+                        textFieldPreferredWidth: _fieldWidth
+                        visible: _motSpinMinAvailable
+                    }
+
+                    LabelledFactTextField {
+                        label: qsTr("Spin maximum")
+                        fact: _motSpinMax
+                        textFieldPreferredWidth: _fieldWidth
+                        visible: _motSpinMaxAvailable
+                    }
+
+                    // DShot settings - visible when a DShot protocol is selected
+                    LabelledFactComboBox {
+                        label: qsTr("DShot ESC type")
+                        fact: _servoDshotEsc
+                        indexModel: false
+                        visible: _isDshot && _servoDshotEscAvailable
+                    }
+
+                    LabelledFactComboBox {
+                        label: qsTr("DShot output rate")
+                        fact: _servoDshotRate
+                        indexModel: false
+                        visible: _isDshot && _servoDshotRateAvailable
+                    }
+                }
+            }
+
+            QGCGroupBox {
+                title: qsTr("Calibration")
+                visible: _escCalibrationAvailable
+
+                ColumnLayout {
+                    spacing: _margins
+
+                    QGCLabel {
+                        text: qsTr("WARNING: Remove props prior to calibration!")
+                        color: qgcPal.warningText
+                    }
+
+                    RowLayout {
+                        spacing: _margins
+
+                        QGCButton {
+                            text: qsTr("Calibrate")
+                            enabled: _escCalibration && _escCalibration.rawValue === 0
+                            onClicked: if(_escCalibration) _escCalibration.rawValue = 3
+                        }
+
+                        ColumnLayout {
+                            enabled: _escCalibration && _escCalibration.rawValue === 3
+                            QGCLabel { text: _escCalibration ? (_escCalibration.rawValue === 3 ? qsTr("Now perform these steps:") : qsTr("Click Calibrate to start, then:")) : "" }
+                            QGCLabel { text: qsTr("- Disconnect USB and battery so flight controller powers down") }
+                            QGCLabel { text: qsTr("- Connect the battery") }
+                            QGCLabel { text: qsTr("- The arming tone will be played (if the vehicle has a buzzer attached)") }
+                            QGCLabel { text: qsTr("- If using a flight controller with a safety button press it until it displays solid red") }
+                            QGCLabel { text: qsTr("- You will hear a musical tone then two beeps") }
+                            QGCLabel { text: qsTr("- A few seconds later you should hear a number of beeps (one for each battery cell you're using)") }
+                            QGCLabel { text: qsTr("- And finally a single long beep indicating the end points have been set and the ESC is calibrated") }
+                            QGCLabel { text: qsTr("- Disconnect the battery and power up again normally") }
+                        }
+                    }
+                }
+            }
+        } // ColumnLayout
+    } // Component - escPageComponent
+
+} // SetupPage

--- a/src/AutoPilotPlugins/APM/APMESCComponentSummary.qml
+++ b/src/AutoPilotPlugins/APM/APMESCComponentSummary.qml
@@ -1,0 +1,50 @@
+import QtQuick
+import QtQuick.Controls
+import QtQuick.Layouts
+
+import QGroundControl
+import QGroundControl.FactControls
+import QGroundControl.Controls
+
+Item {
+    implicitWidth: mainLayout.implicitWidth
+    implicitHeight: mainLayout.implicitHeight
+    width: parent.width
+
+    FactPanelController { id: controller; }
+
+    property bool _isQuadPlane: !controller.parameterExists(-1, "MOT_PWM_TYPE") && controller.parameterExists(-1, "Q_M_PWM_TYPE")
+    property string _escPrefix: _isQuadPlane ? "Q_M_" : "MOT_"
+
+    property bool _motPwmTypeAvailable: controller.parameterExists(-1, _escPrefix + "PWM_TYPE")
+    property Fact _motPwmType: controller.getParameterFact(-1, _escPrefix + "PWM_TYPE", false /* reportMissing */)
+
+    property bool _isDshot: _motPwmTypeAvailable && _motPwmType && _motPwmType.rawValue >= 4
+    property bool _servoDshotEscAvailable: controller.parameterExists(-1, "SERVO_DSHOT_ESC")
+    property Fact _servoDshotEsc: controller.getParameterFact(-1, "SERVO_DSHOT_ESC", false /* reportMissing */)
+    property bool _servoDshotRateAvailable: controller.parameterExists(-1, "SERVO_DSHOT_RATE")
+    property Fact _servoDshotRate: controller.getParameterFact(-1, "SERVO_DSHOT_RATE", false /* reportMissing */)
+
+    ColumnLayout {
+        id: mainLayout
+        spacing: 0
+
+        VehicleSummaryRow {
+            labelText: qsTr("Output type")
+            valueText: _motPwmTypeAvailable ? _motPwmType.enumStringValue : ""
+            visible: _motPwmTypeAvailable
+        }
+
+        VehicleSummaryRow {
+            labelText: qsTr("DShot ESC type")
+            valueText: _servoDshotEscAvailable ? _servoDshotEsc.enumStringValue : ""
+            visible: _isDshot && _servoDshotEscAvailable
+        }
+
+        VehicleSummaryRow {
+            labelText: qsTr("DShot output rate")
+            valueText: _servoDshotRateAvailable ? _servoDshotRate.enumStringValue : ""
+            visible: _isDshot && _servoDshotRateAvailable
+        }
+    }
+}

--- a/src/AutoPilotPlugins/APM/APMPowerComponent.qml
+++ b/src/AutoPilotPlugins/APM/APMPowerComponent.qml
@@ -18,7 +18,7 @@ SetupPage {
     Component {
         id: powerPageComponent
 
-        Flow {
+        ColumnLayout {
             id:         flowLayout
             width:      availableWidth
             spacing:    _margins
@@ -32,27 +32,35 @@ SetupPage {
             property bool _batt2ParamsAvailable:    controller.parameterExists(-1, "BATT2_CAPACITY")
             property bool _showBatt1Reboot:         _batt1MonitorEnabled && !_batt1ParamsAvailable
             property bool _showBatt2Reboot:         _batt2MonitorEnabled && !_batt2ParamsAvailable
-            property bool _escCalibrationAvailable: controller.parameterExists(-1, "ESC_CALIBRATION")
-            property Fact _escCalibration:          controller.getParameterFact(-1, "ESC_CALIBRATION", false /* reportMissing */)
-
             property string _restartRequired: qsTr("Requires vehicle reboot")
 
-            QGCPalette { id: ggcPal; colorGroupEnabled: true }
+            QGCPalette { id: qgcPal; colorGroupEnabled: true }
 
-            // Battery1 Monitor settings only - used when only monitor param is available
+            // Battery section with tab bar
             Column {
                 spacing: _margins / 2
-                visible: !_batt1MonitorEnabled || !_batt1ParamsAvailable
 
                 QGCLabel {
-                    text:       qsTr("Battery 1")
-                    font.bold:   true
+                    text:       qsTr("Battery")
+                    font.bold:  true
                 }
 
+                QGCTabBar {
+                    id: batteryTabBar
+
+                    QGCTabButton { text: qsTr("Battery 1") }
+                    QGCTabButton {
+                        text:       qsTr("Battery 2")
+                        visible:    _batt2MonitorAvailable
+                    }
+                }
+
+                // Battery 1 - Monitor only
                 Rectangle {
                     width:  batt1Column.x + batt1Column.width + _margins
                     height: batt1Column.y + batt1Column.height + _margins
-                    color:  ggcPal.windowShade
+                    color:  qgcPal.windowShade
+                    visible: batteryTabBar.currentIndex === 0 && (!_batt1MonitorEnabled || !_batt1ParamsAvailable)
 
                     ColumnLayout {
                         id:                 batt1Column
@@ -62,12 +70,10 @@ SetupPage {
                         spacing:            ScreenTools.defaultFontPixelWidth
 
                         RowLayout {
-                            id:                 batt1MonitorRow
                             spacing:            ScreenTools.defaultFontPixelWidth
 
-                            QGCLabel { text: qsTr("Battery1 monitor:") }
+                            QGCLabel { text: qsTr("Battery monitor") }
                             FactComboBox {
-                                id:         monitor1Combo
                                 fact:       _batt1Monitor
                                 indexModel: false
                                 sizeToContents: true
@@ -86,30 +92,21 @@ SetupPage {
                         }
                     }
                 }
-            }
 
-            // Battery 1 settings
-            Column {
-                id:         _batt1FullSettings
-                spacing:    _margins / 2
-                visible:    _batt1MonitorEnabled && _batt1ParamsAvailable
-
-                QGCLabel {
-                    text:       qsTr("Battery 1")
-                    font.bold:   true
-                }
-
+                // Battery 1 - Full settings
                 Rectangle {
-                    width:  battery1Loader.x + battery1Loader.width + _margins
-                    height: battery1Loader.y + battery1Loader.height + _margins
-                    color:  ggcPal.windowShade
+                    id:      batt1FullSettingsRect
+                    width:   battery1Loader.x + battery1Loader.width + _margins
+                    height:  battery1Loader.y + battery1Loader.height + _margins
+                    color:   qgcPal.windowShade
+                    visible: batteryTabBar.currentIndex === 0 && _batt1MonitorEnabled && _batt1ParamsAvailable
 
                     Loader {
                         id:                 battery1Loader
                         anchors.margins:    _margins
                         anchors.top:        parent.top
                         anchors.left:       parent.left
-                        sourceComponent:    _batt1FullSettings.visible ? powerSetupComponent : undefined
+                        sourceComponent:    batt1FullSettingsRect.visible ? powerSetupComponent : undefined
 
                         property Fact armVoltMin:       controller.getParameterFact(-1, "BATT_ARM_VOLT", false /* reportMissing */)
                         property Fact battAmpPerVolt:   controller.getParameterFact(-1, "BATT_AMP_PERVLT", false /* reportMissing */)
@@ -119,27 +116,18 @@ SetupPage {
                         property Fact battMonitor:      controller.getParameterFact(-1, "BATT_MONITOR", false /* reportMissing */)
                         property Fact battVoltMult:     controller.getParameterFact(-1, "BATT_VOLT_MULT", false /* reportMissing */)
                         property Fact battVoltPin:      controller.getParameterFact(-1, "BATT_VOLT_PIN", false /* reportMissing */)
-                        property FactGroup  _batteryFactGroup:  _batt1FullSettings.visible ? controller.vehicle.getFactGroup("battery0") : null
+                        property FactGroup  _batteryFactGroup:  batt1FullSettingsRect.visible ? controller.vehicle.getFactGroup("battery0") : null
                         property Fact vehicleVoltage:   _batteryFactGroup ? _batteryFactGroup.voltage : null
                         property Fact vehicleCurrent:   _batteryFactGroup ? _batteryFactGroup.current : null
                     }
                 }
-            }
 
-            // Battery2 Monitor settings only - used when only monitor param is available
-            Column {
-                spacing: _margins / 2
-                visible: !_batt2MonitorEnabled || !_batt2ParamsAvailable
-
-                QGCLabel {
-                    text:       qsTr("Battery 2")
-                    font.bold:   true
-                }
-
+                // Battery 2 - Monitor only
                 Rectangle {
                     width:  batt2Column.x + batt2Column.width + _margins
                     height: batt2Column.y + batt2Column.height + _margins
-                    color:  ggcPal.windowShade
+                    color:  qgcPal.windowShade
+                    visible: batteryTabBar.currentIndex === 1 && (!_batt2MonitorEnabled || !_batt2ParamsAvailable)
 
                     ColumnLayout {
                         id:                 batt2Column
@@ -149,12 +137,10 @@ SetupPage {
                         spacing:            ScreenTools.defaultFontPixelWidth
 
                         RowLayout {
-                            id:                 batt2MonitorRow
                             spacing:            ScreenTools.defaultFontPixelWidth
 
-                            QGCLabel { text: qsTr("Battery2 monitor:") }
+                            QGCLabel { text: qsTr("Battery monitor") }
                             FactComboBox {
-                                id:         monitor2Combo
                                 fact:       _batt2Monitor
                                 indexModel: false
                                 sizeToContents: true
@@ -173,30 +159,21 @@ SetupPage {
                         }
                     }
                 }
-            }
 
-            // Battery 2 settings - Used when full params are available
-            Column {
-                id:         batt2FullSettings
-                spacing:    _margins / 2
-                visible:    _batt2MonitorEnabled && _batt2ParamsAvailable
-
-                QGCLabel {
-                    text:       qsTr("Battery 2")
-                    font.bold:   true
-                }
-
+                // Battery 2 - Full settings
                 Rectangle {
-                    width:  battery2Loader.x + battery2Loader.width + _margins
-                    height: battery2Loader.y + battery2Loader.height + _margins
-                    color:  ggcPal.windowShade
+                    id:      batt2FullSettingsRect
+                    width:   battery2Loader.x + battery2Loader.width + _margins
+                    height:  battery2Loader.y + battery2Loader.height + _margins
+                    color:   qgcPal.windowShade
+                    visible: batteryTabBar.currentIndex === 1 && _batt2MonitorEnabled && _batt2ParamsAvailable
 
                     Loader {
                         id:                 battery2Loader
                         anchors.margins:    _margins
                         anchors.top:        parent.top
                         anchors.left:       parent.left
-                        sourceComponent:    batt2FullSettings.visible ? powerSetupComponent : undefined
+                        sourceComponent:    batt2FullSettingsRect.visible ? powerSetupComponent : undefined
 
                         property Fact armVoltMin:       controller.getParameterFact(-1, "BATT2_ARM_VOLT", false /* reportMissing */)
                         property Fact battAmpPerVolt:   controller.getParameterFact(-1, "BATT2_AMP_PERVLT", false /* reportMissing */)
@@ -206,68 +183,14 @@ SetupPage {
                         property Fact battMonitor:      controller.getParameterFact(-1, "BATT2_MONITOR", false /* reportMissing */)
                         property Fact battVoltMult:     controller.getParameterFact(-1, "BATT2_VOLT_MULT", false /* reportMissing */)
                         property Fact battVoltPin:      controller.getParameterFact(-1, "BATT2_VOLT_PIN", false /* reportMissing */)
-                        property FactGroup  _batteryFactGroup:  batt2FullSettings.visible ? controller.vehicle.getFactGroup("battery1") : null
+                        property FactGroup  _batteryFactGroup:  batt2FullSettingsRect.visible ? controller.vehicle.getFactGroup("battery1") : null
                         property Fact vehicleVoltage:   _batteryFactGroup ? _batteryFactGroup.voltage : null
                         property Fact vehicleCurrent:   _batteryFactGroup ? _batteryFactGroup.current : null
                     }
                 }
             }
 
-            Column {
-                spacing:    _margins / 2
-                visible:    _escCalibrationAvailable
-
-                QGCLabel {
-                    text:       qsTr("ESC Calibration")
-                    font.bold:   true
-                }
-
-                Rectangle {
-                    width:  escCalibrationHolder.x + escCalibrationHolder.width + _margins
-                    height: escCalibrationHolder.y + escCalibrationHolder.height + _margins
-                    color:  ggcPal.windowShade
-
-                    Column {
-                        id:         escCalibrationHolder
-                        x:          _margins
-                        y:          _margins
-                        spacing:    _margins
-
-                        Column {
-                            spacing: _margins
-
-                            QGCLabel {
-                                text:   qsTr("WARNING: Remove props prior to calibration!")
-                                color:  qgcPal.warningText
-                            }
-
-                            Row {
-                                spacing: _margins
-
-                                QGCButton {
-                                    text: qsTr("Calibrate")
-                                    enabled:    _escCalibration && _escCalibration.rawValue === 0
-                                    onClicked:  if(_escCalibration) _escCalibration.rawValue = 3
-                                }
-
-                                Column {
-                                    enabled: _escCalibration && _escCalibration.rawValue === 3
-                                    QGCLabel { text:   _escCalibration ? (_escCalibration.rawValue === 3 ? qsTr("Now perform these steps:") : qsTr("Click Calibrate to start, then:")) : "" }
-                                    QGCLabel { text:   qsTr("- Disconnect USB and battery so flight controller powers down") }
-                                    QGCLabel { text:   qsTr("- Connect the battery") }
-                                    QGCLabel { text:   qsTr("- The arming tone will be played (if the vehicle has a buzzer attached)") }
-                                    QGCLabel { text:   qsTr("- If using a flight controller with a safety button press it until it displays solid red") }
-                                    QGCLabel { text:   qsTr("- You will hear a musical tone then two beeps") }
-                                    QGCLabel { text:   qsTr("- A few seconds later you should hear a number of beeps (one for each battery cell you're using)") }
-                                    QGCLabel { text:   qsTr("- And finally a single long beep indicating the end points have been set and the ESC is calibrated") }
-                                    QGCLabel { text:   qsTr("- Disconnect the battery and power up again normally") }
-                                }
-                            }
-                        }
-                    }
-                }
-            }
-        } // Flow
+        } // ColumnLayout
     } // Component - powerPageComponent
 
     Component {
@@ -295,8 +218,6 @@ SetupPage {
                 }
                 sensorCombo.currentIndex = sensorModel.count - 1
             }
-
-            QGCPalette { id: qgcPal; colorGroupEnabled: true }
 
             ListModel {
                 id: sensorModel

--- a/src/AutoPilotPlugins/APM/CMakeLists.txt
+++ b/src/AutoPilotPlugins/APM/CMakeLists.txt
@@ -10,6 +10,8 @@ target_sources(${CMAKE_PROJECT_NAME}
         APMAirframeComponentController.cc
         APMAirframeComponentController.h
         APMAutoPilotPlugin.cc
+        APMESCComponent.cc
+        APMESCComponent.h
         APMAutoPilotPlugin.h
         APMFlightModesComponent.cc
         APMFlightModesComponent.h
@@ -63,6 +65,8 @@ qt_add_qml_module(AutoPilotPluginsAPMModule
     QML_FILES
         APMAirframeComponent.qml
         APMAirframeComponentSummary.qml
+        APMESCComponent.qml
+        APMESCComponentSummary.qml
         APMFlightModesComponent.qml
         APMFlightModesComponentSummary.qml
         APMFollowComponent.qml

--- a/src/AutoPilotPlugins/AutoPilotPlugin.h
+++ b/src/AutoPilotPlugins/AutoPilotPlugin.h
@@ -36,6 +36,7 @@ public:
         KnownSafetyVehicleComponent,
         KnownPowerVehicleComponent,
         KnownJoystickVehicleComponent,
+        KnownESCVehicleComponent,
         UnknownVehicleComponent // Firmware specific vehicle components
     };
     Q_ENUM(KnownVehicleComponent)


### PR DESCRIPTION
## Summary
- Extract ESC Configuration and Calibration sections from `APMPowerComponent.qml` into a new standalone `APMESCComponent` setup page with its own summary, registered as a `KnownESCVehicleComponent`
- Support both `MOT_*` (Copter/Rover/Sub) and `Q_M_*` (QuadPlane) param prefixes, including `Q_ESC_CAL` for QuadPlane calibration
- Replace separate Battery 1/Battery 2 sections in the Power page with a `QGCTabBar` for switching between them
- Fix `ggcPal` typo and remove duplicate `QGCPalette` declaration

Config:
![Screenshot 2026-03-22 at 10 21 07 AM](https://github.com/user-attachments/assets/ff1632db-f183-42a1-ab3a-12efdb80f131)

Summary:
![Screenshot 2026-03-22 at 10 20 58 AM](https://github.com/user-attachments/assets/f0617feb-6f0a-4bfa-8c44-9bdc0d22984d)
