### PR TITLE
fix: Deduplicate flight mode audio announcements on connect

### DIFF
--- a/src/Vehicle/Vehicle.cc
+++ b/src/Vehicle/Vehicle.cc
@@ -1992,7 +1992,10 @@ QString Vehicle::_vehicleIdSpeech()
 
 void Vehicle::_handleFlightModeChanged(const QString& flightMode)
 {
-    _say(tr("%1 %2 flight mode").arg(_vehicleIdSpeech()).arg(flightMode));
+    if (flightMode != _lastAnnouncedFlightMode) {
+        _lastAnnouncedFlightMode = flightMode;
+        _say(tr("%1 %2 flight mode").arg(_vehicleIdSpeech()).arg(flightMode));
+    }
     emit guidedModeChanged(_firmwarePlugin->isGuidedMode(this));
 }
 

--- a/src/Vehicle/Vehicle.h
+++ b/src/Vehicle/Vehicle.h
@@ -1045,6 +1045,7 @@ void _activeVehicleChanged          (Vehicle* newActiveVehicle);
     uint32_t _custom_mode = 0;  ///< custom_mode from HEARTBEAT
     uint32_t _custom_mode_user_intention = 0;  ///< custom_mode_user_intention from CURRENT_MODE
     bool _has_custom_mode_user_intention = false;
+    QString _lastAnnouncedFlightMode;
 
     /// Used to store a message being sent by sendMessageMultiple
     typedef struct {


### PR DESCRIPTION
## Summary
- During initial vehicle connection, `flightModeChanged` fires 3 times from independent sources (HEARTBEAT handler, `StandardModes::modesUpdated`, and `AVAILABLE_MODES_MONITOR` re-query) even though the flight mode hasn't actually changed
- Track the last announced mode string in `_lastAnnouncedFlightMode` and skip redundant `_say()` calls in `_handleFlightModeChanged`

## Test plan
- [ ] Connect to PX4 MockLink and verify "manual flight mode" is announced only once
- [ ] Change flight mode and verify the new mode is announced
- [ ] Disconnect and reconnect — verify the mode is announced again on reconnect