### PR TITLE
ArduPilot: Modernize Safety Component UI and add missing failsafe params

### DIFF
--- a/src/AutoPilotPlugins/APM/APMSafetyComponent.qml
+++ b/src/AutoPilotPlugins/APM/APMSafetyComponent.qml
@@ -16,7 +16,7 @@ SetupPage {
         Flow {
             id:         flowLayout
             width:      availableWidth
-            spacing:    _margins
+            spacing:    ScreenTools.defaultFontPixelHeight
 
             FactPanelController { id: controller; }
 
@@ -47,69 +47,60 @@ SetupPage {
             property Fact _armingCheck: controller.getParameterFact(-1, "ARMING_CHECK", false /* reportMissing */)
             property Fact _armingSkipCheck: controller.getParameterFact(-1, "ARMING_SKIPCHK", false /* reportMissing */)
 
-            property real _margins:         ScreenTools.defaultFontPixelHeight
-            property real _innerMargin:     _margins / 2
+            property real _margins:         ScreenTools.defaultFontPixelWidth / 2
             property bool _showIcon:        !ScreenTools.isTinyScreen
             property bool _roverFirmware:   controller.parameterExists(-1, "MODE1") // This catches all usage of ArduRover firmware vehicle types: Rover, Boat...
-
 
             property string _restartRequired: qsTr("Requires vehicle reboot")
 
             Component {
                 id: batteryFailsafeComponent
 
-                Column {
+                ColumnLayout {
                     spacing: _margins
 
-                    GridLayout {
-                        id:             gridLayout
-                        columnSpacing:  _margins
-                        rowSpacing:     _margins
-                        columns:        2
-                        QGCLabel { text: qsTr("Low action:") }
-                        FactComboBox {
-                            fact:               failsafeBattLowAct
-                            indexModel:         false
-                            Layout.fillWidth:   true
-                        }
+                    LabelledFactComboBox {
+                        label:              qsTr("Low action")
+                        fact:               failsafeBattLowAct
+                        indexModel:         false
+                        Layout.fillWidth:   true
+                    }
 
-                        QGCLabel { text: qsTr("Critical action:") }
-                        FactComboBox {
-                            fact:               failsafeBattCritAct
-                            indexModel:         false
-                            Layout.fillWidth:   true
-                        }
+                    LabelledFactComboBox {
+                        label:              qsTr("Critical action")
+                        fact:               failsafeBattCritAct
+                        indexModel:         false
+                        Layout.fillWidth:   true
+                    }
 
-                        QGCLabel { text: qsTr("Low voltage threshold:") }
-                        FactTextField {
-                            fact:               failsafeBattLowVoltage
-                            showUnits:          true
-                            Layout.fillWidth:   true
-                        }
+                    LabelledFactTextField {
+                        label:              qsTr("Low voltage threshold")
+                        fact:               failsafeBattLowVoltage
+                        textFieldShowUnits: true
+                        Layout.fillWidth:   true
+                    }
 
+                    LabelledFactTextField {
+                        label:              qsTr("Critical voltage threshold")
+                        fact:               failsafeBattCritVoltage
+                        textFieldShowUnits: true
+                        Layout.fillWidth:   true
+                    }
 
-                        QGCLabel { text: qsTr("Critical voltage threshold:") }
-                        FactTextField {
-                            fact:               failsafeBattCritVoltage
-                            showUnits:          true
-                            Layout.fillWidth:   true
-                        }
+                    LabelledFactTextField {
+                        label:              qsTr("Low mAh threshold")
+                        fact:               failsafeBattLowMah
+                        textFieldShowUnits: true
+                        Layout.fillWidth:   true
+                    }
 
-                        QGCLabel { text: qsTr("Low mAh threshold:") }
-                        FactTextField {
-                            fact:               failsafeBattLowMah
-                            showUnits:          true
-                            Layout.fillWidth:   true
-                        }
-
-                        QGCLabel { text: qsTr("Critical mAh threshold:") }
-                        FactTextField {
-                            fact:               failsafeBattCritMah
-                            showUnits:          true
-                            Layout.fillWidth:   true
-                        }
-                    } // GridLayout
-                } // Column
+                    LabelledFactTextField {
+                        label:              qsTr("Critical mAh threshold")
+                        fact:               failsafeBattCritMah
+                        textFieldShowUnits: true
+                        Layout.fillWidth:   true
+                    }
+                }
             }
 
             Component {
@@ -129,123 +120,127 @@ SetupPage {
                 }
             }
 
-            Column {
-                spacing: _margins / 2
+            QGCGroupBox {
+                title:   qsTr("Battery1 Failsafe Triggers")
                 visible: _batt1MonitorEnabled
 
-                QGCLabel {
-                    text:       qsTr("Battery1 Failsafe Triggers")
-                    font.bold:   true
+                Loader {
+                    id:              battery1FailsafeLoader
+                    sourceComponent: _batt1ParamsAvailable ? batteryFailsafeComponent : restartRequiredComponent
+
+                    property Fact battMonitor:              _batt1Monitor
+                    property bool battParamsAvailable:      _batt1ParamsAvailable
+                    property Fact failsafeBattLowAct:       _failsafeBatt1LowAct
+                    property Fact failsafeBattCritAct:      _failsafeBatt1CritAct
+                    property Fact failsafeBattLowMah:       _failsafeBatt1LowMah
+                    property Fact failsafeBattCritMah:      _failsafeBatt1CritMah
+                    property Fact failsafeBattLowVoltage:   _failsafeBatt1LowVoltage
+                    property Fact failsafeBattCritVoltage:  _failsafeBatt1CritVoltage
                 }
+            }
 
-                Rectangle {
-                    width:  battery1FailsafeLoader.x + battery1FailsafeLoader.width + _margins
-                    height: battery1FailsafeLoader.y + battery1FailsafeLoader.height + _margins
-                    color:  qgcPal.windowShade
-
-                    Loader {
-                        id:                 battery1FailsafeLoader
-                        anchors.margins:    _margins
-                        anchors.top:        parent.top
-                        anchors.left:       parent.left
-                        sourceComponent:    _batt1ParamsAvailable ? batteryFailsafeComponent : restartRequiredComponent
-
-                        property Fact battMonitor:              _batt1Monitor
-                        property bool battParamsAvailable:      _batt1ParamsAvailable
-                        property Fact failsafeBattLowAct:       _failsafeBatt1LowAct
-                        property Fact failsafeBattCritAct:      _failsafeBatt1CritAct
-                        property Fact failsafeBattLowMah:       _failsafeBatt1LowMah
-                        property Fact failsafeBattCritMah:      _failsafeBatt1CritMah
-                        property Fact failsafeBattLowVoltage:   _failsafeBatt1LowVoltage
-                        property Fact failsafeBattCritVoltage:  _failsafeBatt1CritVoltage
-                    }
-                } // Rectangle
-            } // Column - Battery Failsafe Settings
-
-
-            Column {
-                spacing: _margins / 2
+            QGCGroupBox {
+                title:   qsTr("Battery2 Failsafe Triggers")
                 visible: _batt2MonitorEnabled
 
-                QGCLabel {
-                    text:       qsTr("Battery2 Failsafe Triggers")
-                    font.bold:   true
+                Loader {
+                    id:              battery2FailsafeLoader
+                    sourceComponent: _batt2ParamsAvailable ? batteryFailsafeComponent : restartRequiredComponent
+
+                    property Fact battMonitor:              _batt2Monitor
+                    property bool battParamsAvailable:      _batt2ParamsAvailable
+                    property Fact failsafeBattLowAct:       _failsafeBatt2LowAct
+                    property Fact failsafeBattCritAct:      _failsafeBatt2CritAct
+                    property Fact failsafeBattLowMah:       _failsafeBatt2LowMah
+                    property Fact failsafeBattCritMah:      _failsafeBatt2CritMah
+                    property Fact failsafeBattLowVoltage:   _failsafeBatt2LowVoltage
+                    property Fact failsafeBattCritVoltage:  _failsafeBatt2CritVoltage
                 }
-
-                Rectangle {
-                    width:  battery2FailsafeLoader.x + battery2FailsafeLoader.width + _margins
-                    height: battery2FailsafeLoader.y + battery2FailsafeLoader.height + _margins
-                    color:  qgcPal.windowShade
-
-                    Loader {
-                        id:                 battery2FailsafeLoader
-                        anchors.margins:    _margins
-                        anchors.top:        parent.top
-                        anchors.left:       parent.left
-                        sourceComponent:    _batt2ParamsAvailable ? batteryFailsafeComponent : restartRequiredComponent
-
-                        property Fact battMonitor:              _batt2Monitor
-                        property bool battParamsAvailable:      _batt2ParamsAvailable
-                        property Fact failsafeBattLowAct:       _failsafeBatt2LowAct
-                        property Fact failsafeBattCritAct:      _failsafeBatt2CritAct
-                        property Fact failsafeBattLowMah:       _failsafeBatt2LowMah
-                        property Fact failsafeBattCritMah:      _failsafeBatt2CritMah
-                        property Fact failsafeBattLowVoltage:   _failsafeBatt2LowVoltage
-                        property Fact failsafeBattCritVoltage:  _failsafeBatt2CritVoltage
-                    }
-                } // Rectangle
-            } // Column - Battery Failsafe Settings
+            }
 
             Component {
                 id: planeGeneralFS
 
-                Column {
-                    spacing: _margins / 2
+                QGCGroupBox {
+                    title: qsTr("Failsafe Triggers")
 
-                    property Fact _failsafeThrEnable:   controller.getParameterFact(-1, "THR_FAILSAFE")
-                    property Fact _failsafeThrValue:    controller.getParameterFact(-1, "THR_FS_VALUE")
-                    property Fact _failsafeGCSEnable:   controller.getParameterFact(-1, "FS_GCS_ENABL")
+                    property Fact _failsafeThrEnable:      controller.getParameterFact(-1, "THR_FAILSAFE")
+                    property Fact _failsafeThrValue:       controller.getParameterFact(-1, "THR_FS_VALUE")
+                    property Fact _failsafeGCSEnable:      controller.getParameterFact(-1, "FS_GCS_ENABL")
+                    property Fact _failsafeShortAction:    controller.getParameterFact(-1, "FS_SHORT_ACTN")
+                    property Fact _failsafeLongAction:     controller.getParameterFact(-1, "FS_LONG_ACTN")
+                    property Fact _failsafeLongTimeout:    controller.getParameterFact(-1, "FS_LONG_TIMEOUT")
+                    property bool _isQuadPlane:            controller.parameterExists(-1, "Q_TRANS_FAIL")
+                    property Fact _transFailTimeout:       controller.getParameterFact(-1, "Q_TRANS_FAIL", false /* reportMissing */)
+                    property Fact _transFailAction:        controller.getParameterFact(-1, "Q_TRANS_FAIL_ACT", false /* reportMissing */)
 
-                    QGCLabel {
-                        text:       qsTr("Failsafe Triggers")
-                        font.bold:   true
-                    }
+                    ColumnLayout {
+                        spacing: _margins
 
-                    Rectangle {
-                        width:  fsColumn.x + fsColumn.width + _margins
-                        height: fsColumn.y + fsColumn.height + _margins
-                        color:  qgcPal.windowShade
+                        LabelledFactComboBox {
+                            label:            qsTr("Ground Station failsafe")
+                            fact:             _failsafeGCSEnable
+                            indexModel:       false
+                            Layout.fillWidth: true
+                        }
 
-                        ColumnLayout {
-                            id:                 fsColumn
-                            anchors.margins:    _margins
-                            anchors.left:       parent.left
-                            anchors.top:        parent.top
-
-                            RowLayout {
-                                QGCCheckBox {
-                                    id:                 throttleEnableCheckBox
-                                    text:               qsTr("Throttle PWM threshold:")
-                                    checked:            _failsafeThrEnable.value === 1
-
-                                    onClicked: _failsafeThrEnable.value = (checked ? 1 : 0)
-                                }
-
-                                FactTextField {
-                                    fact:               _failsafeThrValue
-                                    showUnits:          true
-                                    enabled:            throttleEnableCheckBox.checked
-                                }
-                            }
+                        RowLayout {
+                            Layout.fillWidth: true
 
                             QGCCheckBox {
-                                text:       qsTr("GCS failsafe")
-                                checked:    _failsafeGCSEnable.value != 0
-                                onClicked:  _failsafeGCSEnable.value = checked ? 1 : 0
+                                id:                 throttleEnableCheckBox
+                                text:               qsTr("Throttle PWM threshold")
+                                checked:            _failsafeThrEnable.value === 1
+                                Layout.fillWidth:   true
+
+                                onClicked: _failsafeThrEnable.value = (checked ? 1 : 0)
+                            }
+
+                            FactTextField {
+                                fact:               _failsafeThrValue
+                                showUnits:          true
+                                enabled:            throttleEnableCheckBox.checked
                             }
                         }
-                    } // Rectangle - Failsafe trigger settings
-                } // Column - Failsafe trigger settings
+
+                        LabelledFactComboBox {
+                            label:            qsTr("Short failsafe action")
+                            fact:             _failsafeShortAction
+                            indexModel:       false
+                            Layout.fillWidth: true
+                        }
+
+                        LabelledFactComboBox {
+                            label:            qsTr("Long failsafe action")
+                            fact:             _failsafeLongAction
+                            indexModel:       false
+                            Layout.fillWidth: true
+                        }
+
+                        LabelledFactTextField {
+                            label:              qsTr("Long failsafe timeout")
+                            fact:               _failsafeLongTimeout
+                            textFieldShowUnits: true
+                            Layout.fillWidth:   true
+                        }
+
+                        LabelledFactComboBox {
+                            label:            qsTr("VTOL transition failure action")
+                            fact:             _transFailAction
+                            indexModel:       false
+                            Layout.fillWidth: true
+                            visible:          _isQuadPlane
+                        }
+
+                        LabelledFactTextField {
+                            label:              qsTr("VTOL transition failure timeout")
+                            fact:               _transFailTimeout
+                            textFieldShowUnits: true
+                            Layout.fillWidth:   true
+                            visible:            _isQuadPlane
+                        }
+                    }
+                }
             }
 
             Loader {
@@ -255,63 +250,84 @@ SetupPage {
             Component {
                 id: roverGeneralFS
 
-                Column {
-                    spacing: _margins / 2
+                QGCGroupBox {
+                    title: qsTr("Failsafe Triggers")
 
                     property Fact _failsafeGCSEnable:   controller.getParameterFact(-1, "FS_GCS_ENABLE")
+                    property Fact _failsafeGCSTimeout:  controller.getParameterFact(-1, "FS_GCS_TIMEOUT")
                     property Fact _failsafeThrEnable:   controller.getParameterFact(-1, "FS_THR_ENABLE")
                     property Fact _failsafeThrValue:    controller.getParameterFact(-1, "FS_THR_VALUE")
                     property Fact _failsafeAction:      controller.getParameterFact(-1, "FS_ACTION")
+                    property Fact _failsafeTimeout:     controller.getParameterFact(-1, "FS_TIMEOUT")
                     property Fact _failsafeCrashCheck:  controller.getParameterFact(-1, "FS_CRASH_CHECK")
+                    property Fact _failsafeEkfAction:   controller.getParameterFact(-1, "FS_EKF_ACTION")
+                    property Fact _failsafeEkfThresh:   controller.getParameterFact(-1, "FS_EKF_THRESH")
 
-                    QGCLabel {
-                        id:         failsafeLabel
-                        text:       qsTr("Failsafe Triggers")
-                        font.bold:   true
-                    }
+                    ColumnLayout {
+                        spacing: _margins
 
-                    Rectangle {
-                        id:     failsafeSettings
-                        width:  fsGrid.x + fsGrid.width + _margins
-                        height: fsGrid.y + fsGrid.height + _margins
-                        color:  qgcPal.windowShade
-
-                        GridLayout {
-                            id:                 fsGrid
-                            anchors.margins:    _margins
-                            anchors.left:       parent.left
-                            anchors.top:        parent.top
-                            columns:            2
-
-                            QGCLabel { text: qsTr("Ground Station failsafe:") }
-                            FactComboBox {
-                                Layout.fillWidth:   true
-                                fact:               _failsafeGCSEnable
-                                indexModel:         false
-                            }
-
-                            QGCLabel { text: qsTr("Throttle failsafe:") }
-                            FactComboBox {
-                                Layout.fillWidth:   true
-                                fact:               _failsafeThrEnable
-                                indexModel:         false
-                            }
-
-                            QGCLabel { text: qsTr("PWM threshold:") }
-                            FactTextField {
-                                Layout.fillWidth:   true
-                                fact:               _failsafeThrValue
-                            }
-
-                            QGCLabel { text: qsTr("Failsafe Crash Check:") }
-                            FactComboBox {
-                                Layout.fillWidth:   true
-                                fact:               _failsafeCrashCheck
-                                indexModel:         false
-                            }
+                        LabelledFactComboBox {
+                            label:            qsTr("Ground Station failsafe")
+                            fact:             _failsafeGCSEnable
+                            indexModel:       false
+                            Layout.fillWidth: true
                         }
-                    } // Rectangle - Failsafe Settings
-                } // Column - Failsafe Settings
+
+                        LabelledFactTextField {
+                            label:              qsTr("GCS failsafe timeout")
+                            fact:               _failsafeGCSTimeout
+                            textFieldShowUnits: true
+                            Layout.fillWidth:   true
+                        }
+
+                        LabelledFactComboBox {
+                            label:            qsTr("Throttle failsafe")
+                            fact:             _failsafeThrEnable
+                            indexModel:       false
+                            Layout.fillWidth: true
+                        }
+
+                        LabelledFactTextField {
+                            label:            qsTr("PWM threshold")
+                            fact:             _failsafeThrValue
+                            Layout.fillWidth: true
+                        }
+
+                        LabelledFactComboBox {
+                            label:            qsTr("Failsafe action")
+                            fact:             _failsafeAction
+                            indexModel:       false
+                            Layout.fillWidth: true
+                        }
+
+                        LabelledFactTextField {
+                            label:              qsTr("Failsafe timeout")
+                            fact:               _failsafeTimeout
+                            textFieldShowUnits: true
+                            Layout.fillWidth:   true
+                        }
+
+                        LabelledFactComboBox {
+                            label:            qsTr("Crash check")
+                            fact:             _failsafeCrashCheck
+                            indexModel:       false
+                            Layout.fillWidth: true
+                        }
+
+                        LabelledFactComboBox {
+                            label:            qsTr("EKF failsafe action")
+                            fact:             _failsafeEkfAction
+                            indexModel:       false
+                            Layout.fillWidth: true
+                        }
+
+                        LabelledFactTextField {
+                            label:            qsTr("EKF failsafe threshold")
+                            fact:             _failsafeEkfThresh
+                            Layout.fillWidth: true
+                        }
+                    }
+                }
             }
 
             Loader {
@@ -319,78 +335,141 @@ SetupPage {
             }
 
             Component {
+                id: failsafeOptionsComponent
+
+                QGCGroupBox {
+                    title: qsTr("Failsafe Options")
+
+                    property Fact _failsafeOptions: controller.getParameterFact(-1, "FS_OPTIONS")
+
+                    ColumnLayout {
+                        spacing: _margins
+
+                        FactBitmask {
+                            fact: _failsafeOptions
+                            Layout.preferredWidth:  safetyPage.availableWidth * 0.75
+                        }
+                    }
+                }
+            }
+
+            Loader {
+                sourceComponent: _roverFirmware ? failsafeOptionsComponent : undefined
+            }
+
+            Component {
                 id: copterGeneralFS
 
-                Column {
-                    spacing: _margins / 2
+                QGCGroupBox {
+                    title: qsTr("General Failsafe Triggers")
 
-                    property Fact _failsafeGCSEnable:               controller.getParameterFact(-1, "FS_GCS_ENABLE")
-                    property Fact _failsafeBattLowAct:              controller.getParameterFact(-1, "BATT_FS_LOW_ACT", false /* reportMissing */)
-                    property Fact _failsafeBattMah:                 controller.getParameterFact(-1, "BATT_LOW_MAH", false /* reportMissing */)
-                    property Fact _failsafeBattVoltage:             controller.getParameterFact(-1, "BATT_LOW_VOLT", false /* reportMissing */)
-                    property Fact _failsafeThrEnable:               controller.getParameterFact(-1, "FS_THR_ENABLE")
-                    property Fact _failsafeThrValue:                controller.getParameterFact(-1, "FS_THR_VALUE")
+                    property Fact _failsafeGCSEnable:     controller.getParameterFact(-1, "FS_GCS_ENABLE")
+                    property Fact _failsafeGCSTimeout:    controller.getParameterFact(-1, "FS_GCS_TIMEOUT")
+                    property Fact _failsafeThrEnable:     controller.getParameterFact(-1, "FS_THR_ENABLE")
+                    property Fact _failsafeThrValue:      controller.getParameterFact(-1, "FS_THR_VALUE")
+                    property Fact _failsafeEkfAction:     controller.getParameterFact(-1, "FS_EKF_ACTION")
+                    property Fact _failsafeEkfThresh:     controller.getParameterFact(-1, "FS_EKF_THRESH")
+                    property Fact _failsafeEkfFilt:       controller.getParameterFact(-1, "FS_EKF_FILT")
+                    property Fact _failsafeCrashCheck:    controller.getParameterFact(-1, "FS_CRASH_CHECK")
+                    property Fact _failsafeVibeEnable:    controller.getParameterFact(-1, "FS_VIBE_ENABLE")
+                    property Fact _failsafeDREnable:      controller.getParameterFact(-1, "FS_DR_ENABLE")
+                    property Fact _failsafeDRTimeout:     controller.getParameterFact(-1, "FS_DR_TIMEOUT")
 
-                    QGCLabel {
-                        text:       qsTr("General Failsafe Triggers")
-                        font.bold:   true
+                    ColumnLayout {
+                        spacing: _margins
+
+                        LabelledFactComboBox {
+                            label:            qsTr("Ground Station failsafe")
+                            fact:             _failsafeGCSEnable
+                            indexModel:       false
+                            Layout.fillWidth: true
+                        }
+
+                        LabelledFactTextField {
+                            label:              qsTr("GCS failsafe timeout")
+                            fact:               _failsafeGCSTimeout
+                            textFieldShowUnits: true
+                            Layout.fillWidth:   true
+                        }
+
+                        LabelledFactComboBox {
+                            label:            qsTr("Throttle failsafe")
+                            fact:             _failsafeThrEnable
+                            indexModel:       false
+                            Layout.fillWidth: true
+                        }
+
+                        LabelledFactTextField {
+                            label:              qsTr("PWM threshold")
+                            fact:               _failsafeThrValue
+                            textFieldShowUnits: true
+                            Layout.fillWidth:   true
+                        }
+
+                        LabelledFactComboBox {
+                            label:            qsTr("EKF failsafe action")
+                            fact:             _failsafeEkfAction
+                            indexModel:       false
+                            Layout.fillWidth: true
+                        }
+
+                        LabelledFactTextField {
+                            label:            qsTr("EKF failsafe threshold")
+                            fact:             _failsafeEkfThresh
+                            Layout.fillWidth: true
+                        }
+
+                        LabelledFactTextField {
+                            label:              qsTr("EKF failsafe filter")
+                            fact:               _failsafeEkfFilt
+                            textFieldShowUnits: true
+                            Layout.fillWidth:   true
+                        }
+
+                        LabelledFactComboBox {
+                            label:            qsTr("Crash check")
+                            fact:             _failsafeCrashCheck
+                            indexModel:       false
+                            Layout.fillWidth: true
+                        }
+
+                        LabelledFactComboBox {
+                            label:            qsTr("Vibration failsafe")
+                            fact:             _failsafeVibeEnable
+                            indexModel:       false
+                            Layout.fillWidth: true
+                        }
+
+                        LabelledFactComboBox {
+                            label:            qsTr("Dead reckoning failsafe")
+                            fact:             _failsafeDREnable
+                            indexModel:       false
+                            Layout.fillWidth: true
+                        }
+
+                        LabelledFactTextField {
+                            label:              qsTr("Dead reckoning timeout")
+                            fact:               _failsafeDRTimeout
+                            textFieldShowUnits: true
+                            Layout.fillWidth:   true
+                        }
                     }
-
-                    Rectangle {
-                        width:  generalFailsafeColumn.x + generalFailsafeColumn.width + _margins
-                        height: generalFailsafeColumn.y + generalFailsafeColumn.height + _margins
-                        color:  qgcPal.windowShade
-
-                        Column {
-                            id:                 generalFailsafeColumn
-                            anchors.margins:    _margins
-                            anchors.top:        parent.top
-                            anchors.left:       parent.left
-                            spacing:            _margins
-
-                            GridLayout {
-                                columnSpacing:  _margins
-                                rowSpacing:     _margins
-                                columns:        2
-
-                                QGCLabel { text: qsTr("Ground Station failsafe:") }
-                                FactComboBox {
-                                    fact:               _failsafeGCSEnable
-                                    indexModel:         false
-                                    Layout.fillWidth:   true
-                                }
-
-                                QGCLabel { text: qsTr("Throttle failsafe:") }
-                                QGCComboBox {
-                                    model:              [qsTr("Disabled"), qsTr("Always RTL"),
-                                        qsTr("Continue with Mission in Auto Mode"), qsTr("Always Land")]
-                                    currentIndex:       _failsafeThrEnable.value
-                                    Layout.fillWidth:   true
-
-                                    onActivated: (index) => { _failsafeThrEnable.value = index }
-                                }
-
-                                QGCLabel { text: qsTr("PWM threshold:") }
-                                FactTextField {
-                                    fact:               _failsafeThrValue
-                                    showUnits:          true
-                                    Layout.fillWidth:   true
-                                }
-                            } // GridLayout
-                        } // Column
-                    } // Rectangle - Failsafe Settings
-                } // Column - General Failsafe Settings
+                }
             }
 
             Loader {
                 sourceComponent: controller.vehicle.multiRotor ? copterGeneralFS : undefined
             }
 
+            Loader {
+                sourceComponent: controller.vehicle.multiRotor ? failsafeOptionsComponent : undefined
+            }
+
             Component {
                 id: copterGeoFence
 
-                Column {
-                    spacing: _margins / 2
+                QGCGroupBox {
+                    title: qsTr("GeoFence")
 
                     property Fact _fenceAction: controller.getParameterFact(-1, "FENCE_ACTION")
                     property Fact _fenceAltMax: controller.getParameterFact(-1, "FENCE_ALT_MAX")
@@ -403,35 +482,22 @@ SetupPage {
                     readonly property int _circleFenceBitMask:      2
                     readonly property int _polygonFenceBitMask:     4
 
-                    QGCLabel {
-                        text:           qsTr("GeoFence")
-                        font.bold:      true
-                    }
+                    ColumnLayout {
+                        spacing: ScreenTools.defaultFontPixelHeight / 2
 
-                    Rectangle {
-                        width:  mainLayout.width + (_margins * 2)
-                        height: mainLayout.height + (_margins * 2)
-                        color:  qgcPal.windowShade
+                        FactCheckBox {
+                            id:     enabledCheckBox
+                            text:   qsTr("Enabled")
+                            fact:   _fenceEnable
+                        }
 
                         ColumnLayout {
-                            id:         mainLayout
-                            x:          _margins
-                            y:          _margins
-                            spacing:    ScreenTools.defaultFontPixellHeight / 2
+                            enabled: enabledCheckBox.checked
 
-                            FactCheckBox {
-                                id:     enabledCheckBox
-                                text:   qsTr("Enabled")
-                                fact:   _fenceEnable
-                            }
-
-                            GridLayout {
-                                columns:    2
-                                enabled:    enabledCheckBox.checked
-
+                            RowLayout {
                                 QGCCheckBox {
-                                    text:       qsTr("Maximum Altitude")
-                                    checked:    _fenceType.rawValue & _maxAltitudeFenceBitMask
+                                    text:    qsTr("Maximum Altitude")
+                                    checked: _fenceType.rawValue & _maxAltitudeFenceBitMask
 
                                     onClicked: {
                                         if (checked) {
@@ -445,10 +511,12 @@ SetupPage {
                                 FactTextField {
                                     fact: _fenceAltMax
                                 }
+                            }
 
+                            RowLayout {
                                 QGCCheckBox {
-                                    text:       qsTr("Circle centered on Home")
-                                    checked:    _fenceType.rawValue & _circleFenceBitMask
+                                    text:    qsTr("Circle centered on Home")
+                                    checked: _fenceType.rawValue & _circleFenceBitMask
 
                                     onClicked: {
                                         if (checked) {
@@ -460,58 +528,42 @@ SetupPage {
                                 }
 
                                 FactTextField {
-                                    fact:       _fenceRadius
-                                    showUnits:  true
+                                    fact:      _fenceRadius
+                                    showUnits: true
                                 }
-
-                                QGCCheckBox {
-                                    text:       qsTr("Inclusion/Exclusion Circles+Polygons")
-                                    checked:    _fenceType.rawValue & _polygonFenceBitMask
-
-                                    onClicked: {
-                                        if (checked) {
-                                            _fenceType.rawValue |= _polygonFenceBitMask
-                                        } else {
-                                            _fenceType.value &= ~_polygonFenceBitMask
-                                        }
-                                    }
-                                }
-
-                                Item {
-                                    height: 1
-                                    width:  1
-                                }
-                            } // GridLayout
-
-                            Item {
-                                height: 1
-                                width:  1
                             }
 
-                            GridLayout {
-                                columns: 2
-                                enabled: enabledCheckBox.checked
+                            QGCCheckBox {
+                                text:    qsTr("Inclusion/Exclusion Circles+Polygons")
+                                checked: _fenceType.rawValue & _polygonFenceBitMask
 
-                                QGCLabel {
-                                    text: qsTr("Breach action")
-                                }
-
-                                FactComboBox {
-                                    sizeToContents: true
-                                    fact:           _fenceAction
-                                }
-
-                                QGCLabel {
-                                    text: qsTr("Fence margin")
-                                }
-
-                                FactTextField {
-                                    fact: _fenceMargin
+                                onClicked: {
+                                    if (checked) {
+                                        _fenceType.rawValue |= _polygonFenceBitMask
+                                    } else {
+                                        _fenceType.value &= ~_polygonFenceBitMask
+                                    }
                                 }
                             }
                         }
-                    } // Rectangle - GeoFence Settings
-                } // Column - GeoFence Settings
+
+                        ColumnLayout {
+                            enabled: enabledCheckBox.checked
+
+                            LabelledFactComboBox {
+                                label:            qsTr("Breach action")
+                                fact:             _fenceAction
+                                Layout.fillWidth: true
+                            }
+
+                            LabelledFactTextField {
+                                label:            qsTr("Fence margin")
+                                fact:             _fenceMargin
+                                Layout.fillWidth: true
+                            }
+                        }
+                    }
+                }
             }
 
             Loader {
@@ -521,8 +573,8 @@ SetupPage {
             Component {
                 id: copterRTL
 
-                Column {
-                    spacing: _margins / 2
+                QGCGroupBox {
+                    title: qsTr("Return to Launch")
 
                     property Fact _landSpeedFact:   controller.getParameterFact(-1, "LAND_SPD_MS")
                     property Fact _rtlAltFact:      controller.getParameterFact(-1, "RTL_ALT_M")
@@ -531,117 +583,88 @@ SetupPage {
                     // RTL_ALT_M (4.7+) is in meters, RTL_ALT (pre-4.7) is in centimeters
                     property bool _rtlAltIsMeters:  controller.parameterExists(-1, "noremap.RTL_ALT_M")
 
-                    QGCLabel {
-                        id:             rtlLabel
-                        text:           qsTr("Return to Launch")
-                        font.bold:      true
-                    }
-
-                    Rectangle {
-                        id:     rtlSettings
-                        width:  landSpeedField.x + landSpeedField.width + _margins
-                        height: landSpeedField.y + landSpeedField.height + _margins
-                        color:  qgcPal.windowShade
+                    RowLayout {
+                        spacing: ScreenTools.defaultFontPixelHeight
 
                         QGCColoredImage {
-                            id:                 icon
-                            visible:            _showIcon
-                            anchors.margins:    _margins
-                            anchors.left:       parent.left
-                            anchors.top:        parent.top
-                            height:             ScreenTools.defaultFontPixelWidth * 20
-                            width:              ScreenTools.defaultFontPixelWidth * 20
-                            color:              qgcPal.text
-                            sourceSize.width:   width
-                            mipmap:             true
-                            fillMode:           Image.PreserveAspectFit
-                            source:             "/qmlimages/ReturnToHomeAltitude.svg"
+                            id:                     icon
+                            visible:                _showIcon
+                            Layout.alignment:       Qt.AlignTop
+                            Layout.preferredHeight: ScreenTools.defaultFontPixelWidth * 20
+                            Layout.preferredWidth:  ScreenTools.defaultFontPixelWidth * 20
+                            color:                  qgcPal.text
+                            sourceSize.width:       width
+                            mipmap:                 true
+                            fillMode:               Image.PreserveAspectFit
+                            source:                 "/qmlimages/ReturnToHomeAltitude.svg"
                         }
 
-                        QGCRadioButton {
-                            id:                 returnAtCurrentRadio
-                            anchors.margins:    _innerMargin
-                            anchors.left:       _showIcon ? icon.right : parent.left
-                            anchors.top:        parent.top
-                            text:               qsTr("Return at current altitude")
-                            checked:            _rtlAltFact.value == 0
+                        ColumnLayout {
+                            spacing: _margins
 
-                            onClicked: _rtlAltFact.value = 0
+                            QGCRadioButton {
+                                text:    qsTr("Return at current altitude")
+                                checked: _rtlAltFact.value == 0
+
+                                onClicked: _rtlAltFact.value = 0
+                            }
+
+                            RowLayout {
+                                Layout.fillWidth: true
+                                spacing: _margins
+
+                                QGCRadioButton {
+                                    Layout.fillWidth: true
+                                    text:    qsTr("Return at specified altitude")
+                                    checked: _rtlAltFact.value != 0
+
+                                    // RTL_ALT_M (4.7+) is in meters, RTL_ALT (pre-4.7) is in centimeters
+                                    onClicked: _rtlAltFact.value = _rtlAltIsMeters ? 15 : 1500
+                                }
+
+                                FactTextField {
+                                    fact:      _rtlAltFact
+                                    showUnits: true
+                                    enabled:   _rtlAltFact.value != 0
+                                }
+                            }
+
+                            RowLayout {
+                                Layout.fillWidth: true
+                                spacing: _margins
+
+                                QGCCheckBox {
+                                    id:      homeLoiterCheckbox
+                                    Layout.fillWidth: true
+                                    checked: _rtlLoitTimeFact.value > 0
+                                    text:    qsTr("Loiter above Home for")
+
+                                    onClicked: _rtlLoitTimeFact.value = (checked ? 60 : 0)
+                                }
+
+                                FactTextField {
+                                    fact:      _rtlLoitTimeFact
+                                    showUnits: true
+                                    enabled:   homeLoiterCheckbox.checked
+                                }
+                            }
+
+                            LabelledFactTextField {
+                                label:              qsTr("Final land stage altitude")
+                                fact:               _rtlAltFinalFact
+                                textFieldShowUnits: true
+                                Layout.fillWidth:   true
+                            }
+
+                            LabelledFactTextField {
+                                label:              qsTr("Final land stage descent speed")
+                                fact:               _landSpeedFact
+                                textFieldShowUnits: true
+                                Layout.fillWidth:   true
+                            }
                         }
-
-                        QGCRadioButton {
-                            id:                 returnAltRadio
-                            anchors.topMargin:  _innerMargin
-                            anchors.top:        returnAtCurrentRadio.bottom
-                            anchors.left:       returnAtCurrentRadio.left
-                            text:               qsTr("Return at specified altitude:")
-                            checked:            _rtlAltFact.value != 0
-
-                            // RTL_ALT_M (4.7+) is in meters, RTL_ALT (pre-4.7) is in centimeters
-                            onClicked: _rtlAltFact.value = _rtlAltIsMeters ? 15 : 1500
-                        }
-
-                        FactTextField {
-                            id:                 rltAltField
-                            anchors.leftMargin: _margins
-                            anchors.left:       returnAltRadio.right
-                            anchors.baseline:   returnAltRadio.baseline
-                            fact:               _rtlAltFact
-                            showUnits:          true
-                            enabled:            returnAltRadio.checked
-                        }
-
-                        QGCCheckBox {
-                            id:                 homeLoiterCheckbox
-                            anchors.left:       returnAtCurrentRadio.left
-                            anchors.baseline:   landDelayField.baseline
-                            checked:            _rtlLoitTimeFact.value > 0
-                            text:               qsTr("Loiter above Home for:")
-
-                            onClicked: _rtlLoitTimeFact.value = (checked ? 60 : 0)
-                        }
-
-                        FactTextField {
-                            id:                 landDelayField
-                            anchors.topMargin:  _innerMargin
-                            anchors.left:       rltAltField.left
-                            anchors.top:        rltAltField.bottom
-                            fact:               _rtlLoitTimeFact
-                            showUnits:          true
-                            enabled:            homeLoiterCheckbox.checked === true
-                        }
-
-                        QGCLabel {
-                            anchors.left:       returnAtCurrentRadio.left
-                            anchors.baseline:   rltAltFinalField.baseline
-                            text:               qsTr("Final land stage altitude:")
-                        }
-
-                        FactTextField {
-                            id:                 rltAltFinalField
-                            anchors.topMargin:  _innerMargin
-                            anchors.left:       rltAltField.left
-                            anchors.top:        landDelayField.bottom
-                            fact:               _rtlAltFinalFact
-                            showUnits:          true
-                        }
-
-                        QGCLabel {
-                            anchors.left:       returnAtCurrentRadio.left
-                            anchors.baseline:   landSpeedField.baseline
-                            text:               qsTr("Final land stage descent speed:")
-                        }
-
-                        FactTextField {
-                            id:                 landSpeedField
-                            anchors.topMargin: _innerMargin
-                            anchors.left:       rltAltField.left
-                            anchors.top:        rltAltFinalField.bottom
-                            fact:               _landSpeedFact
-                            showUnits:          true
-                        }
-                    } // Rectangle - RTL Settings
-                } // Column - RTL Settings
+                    }
+                }
             }
 
             Loader {
@@ -651,101 +674,66 @@ SetupPage {
             Component {
                 id: planeRTL
 
-                Column {
-                    spacing: _margins / 2
+                QGCGroupBox {
+                    title: qsTr("Return to Launch")
 
                     property Fact _rtlAltFact: controller.getParameterFact(-1, "RTL_ALTITUDE")
 
-                    QGCLabel {
-                        text:           qsTr("Return to Launch")
-                        font.bold:      true
-                    }
-
-                    Rectangle {
-                        width:  rltAltField.x + rltAltField.width + _margins
-                        height: rltAltField.y + rltAltField.height + _margins
-                        color:  qgcPal.windowShade
+                    ColumnLayout {
+                        spacing: _margins
 
                         QGCRadioButton {
-                            id:                 returnAtCurrentRadio
-                            anchors.margins:    _margins
-                            anchors.left:       parent.left
-                            anchors.top:        parent.top
-                            text:               qsTr("Return at current altitude")
-                            checked:            _rtlAltFact.value < 0
+                            text:    qsTr("Return at current altitude")
+                            checked: _rtlAltFact.value < 0
 
                             onClicked: _rtlAltFact.value = -1
                         }
 
-                        QGCRadioButton {
-                            id:                 returnAltRadio
-                            anchors.topMargin:  _margins / 2
-                            anchors.left:       returnAtCurrentRadio.left
-                            anchors.top:        returnAtCurrentRadio.bottom
-                            text:               qsTr("Return at specified altitude:")
-                            checked:            _rtlAltFact.value >= 0
+                        RowLayout {
+                            spacing: _margins
 
-                            onClicked: _rtlAltFact.value = 10000
-                        }
+                            QGCRadioButton {
+                                text:    qsTr("Return at specified altitude")
+                                checked: _rtlAltFact.value >= 0
 
-                        FactTextField {
-                            id:                 rltAltField
-                            anchors.leftMargin: _margins
-                            anchors.left:       returnAltRadio.right
-                            anchors.baseline:   returnAltRadio.baseline
-                            fact:               _rtlAltFact
-                            showUnits:          true
-                            enabled:            returnAltRadio.checked
+                                onClicked: _rtlAltFact.value = 10000
+                            }
+
+                            FactTextField {
+                                fact:      _rtlAltFact
+                                showUnits: true
+                                enabled:   _rtlAltFact.value >= 0
+                            }
                         }
-                    } // Rectangle - RTL Settings
-                } // Column - RTL Settings
+                    }
+                }
             }
 
             Loader {
                 sourceComponent: controller.vehicle.fixedWing ? planeRTL : undefined
             }
 
-            Column {
-                spacing: _margins / 2
+            QGCGroupBox {
+                title: _armingCheck ? qsTr("Arming Checks") : qsTr("Skip Arming Checks")
 
-                QGCLabel {
-                    text:           _armingCheck ? qsTr("Arming Checks") : qsTr("Skip Arming Checks")
-                    font.bold:      true
-                }
+                ColumnLayout {
+                    spacing: _margins
 
-                Rectangle {
-                    width:  flowLayout.width
-                    height: armingCheckInnerColumn.height + (_margins * 2)
-                    color:  qgcPal.windowShade
-
-                    Column {
-                        id:                 armingCheckInnerColumn
-                        anchors.margins:    _margins
-                        anchors.top:        parent.top
-                        anchors.left:       parent.left
-                        anchors.right:      parent.right
-                        spacing: _margins
-
-                        FactBitmask {
-                            id:                 armingCheckBitmask
-                            anchors.left:       parent.left
-                            anchors.right:      parent.right
-                            firstEntryIsAll:    _armingCheck ? true : false
-                            fact:               _armingCheck ? _armingCheck : _armingSkipCheck
-                        }
-
-                        QGCLabel {
-                            id:             armingCheckWarning
-                            anchors.left:   parent.left
-                            anchors.right:  parent.right
-                            wrapMode:       Text.WordWrap
-                            color:          qgcPal.warningText
-                            text:            qsTr("Warning: Turning off arming checks can lead to loss of Vehicle control.")
-                            visible:        _armingCheck ? _armingCheck.value != 1 : _armingSkipCheck.value != 0
-                        }
+                    FactBitmask {
+                        firstEntryIsAll:    _armingCheck ? true : false
+                        fact:               _armingCheck ? _armingCheck : _armingSkipCheck
+                        Layout.preferredWidth:  safetyPage.availableWidth * 0.75
                     }
-                } // Rectangle - Arming checks
-            } // Column - Arming Checks
-        } // Flow
-    } // Component - safetyPageComponent
-} // SetupView
+
+                    QGCLabel {
+                        wrapMode:           Text.WordWrap
+                        color:              qgcPal.warningText
+                        text:               qsTr("Warning: Turning off arming checks can lead to loss of Vehicle control.")
+                        visible:            _armingCheck ? _armingCheck.value != 1 : _armingSkipCheck.value != 0
+                        Layout.fillWidth:   true
+                    }
+                }
+            }
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- Refactored APMSafetyComponent.qml to use QGCGroupBox, ColumnLayout, and Labelled controls (LabelledFactComboBox, LabelledFactTextField, LabelledComboBox) replacing the legacy Column+QGCLabel+Rectangle and GridLayout patterns
- Added missing ArduPilot failsafe parameters for all vehicle types:
  - **Plane**: FS_SHORT_ACTN, FS_LONG_ACTN, FS_LONG_TIMEOUT, Q_TRANS_FAIL/Q_TRANS_FAIL_ACT (QuadPlane, conditionally shown)
  - **Rover**: FS_GCS_TIMEOUT, FS_TIMEOUT, FS_EKF_ACTION, FS_EKF_THRESH, FS_OPTIONS
  - **Copter**: FS_GCS_TIMEOUT, FS_EKF_ACTION, FS_EKF_THRESH, FS_EKF_FILT, FS_CRASH_CHECK, FS_VIBE_ENABLE, FS_OPTIONS, FS_DR_ENABLE, FS_DR_TIMEOUT
- Upgraded plane GCS failsafe from checkbox to LabelledFactComboBox (FS_GCS_ENABL has 4 values)
- Standardized label naming ("Ground Station failsafe") and parameter ordering across all vehicle types
- Extracted FS_OPTIONS bitmask into a shared "Failsafe Options" QGCGroupBox component reused by rover and copter

Copter example:
![Screenshot 2026-03-22 at 1 49 45 PM](https://github.com/user-attachments/assets/eca55c17-0f12-44e9-a032-61c5bc3be359)

## Test plan
- [X] Verify Battery1/Battery2 failsafe sections render correctly with labelled controls
- [X] Verify plane failsafe section shows all params including QuadPlane-specific ones when connected to a QuadPlane
- [X] Verify rover failsafe section shows all params including new EKF and timeout fields
- [X] Verify copter failsafe section shows all params including EKF, crash, vibration, and dead reckoning
- [X] Verify Failsafe Options bitmask renders correctly in its own section for rover and copter
- [X] Verify GeoFence and Return to Launch sections render correctly
- [X] Verify Arming Checks bitmask renders correctly
- [X] Test on small screens (FactBitmask width constraint)
