### PR TITLE
feat(APM): Support up to 16 batteries in Power setup page

### DIFF
--- a/src/AutoPilotPlugins/APM/APMBatteryParams.qml
+++ b/src/AutoPilotPlugins/APM/APMBatteryParams.qml
@@ -1,0 +1,37 @@
+import QtQuick
+
+import QGroundControl
+
+/// Manages access to ArduPilot battery parameters for a given battery index.
+/// ArduPilot battery parameter prefixes: BATT_, BATT2_, ..., BATT9_, BATTA_, ..., BATTG_
+QtObject {
+    required property var controller
+    required property int batteryIndex
+
+    readonly property string _prefix: prefixForIndex(batteryIndex)
+
+    /// Returns the parameter prefix for a 0-based battery index.
+    /// 0: "BATT_", 1: "BATT2_", ..., 8: "BATT9_", 9: "BATTA_", ..., 15: "BATTG_"
+    function prefixForIndex(index) {
+        if (index === 0) {
+            return "BATT_"
+        }
+        if (index <= 8) {
+            return "BATT" + (index + 1) + "_"
+        }
+        return "BATT" + String.fromCharCode(65 + index - 9) + "_"
+    }
+
+    property Fact battMonitor: controller.getParameterFact(-1, _prefix + "MONITOR")
+    property Fact battCapacity: controller.getParameterFact(-1, _prefix + "CAPACITY", false)
+    property Fact battArmVolt: controller.getParameterFact(-1, _prefix + "ARM_VOLT", false)
+    property Fact battAmpPerVolt: controller.getParameterFact(-1, _prefix + "AMP_PERVLT", false)
+    property Fact battAmpOffset: controller.getParameterFact(-1, _prefix + "AMP_OFFSET", false)
+    property Fact battCurrPin: controller.getParameterFact(-1, _prefix + "CURR_PIN", false)
+    property Fact battVoltMult: controller.getParameterFact(-1, _prefix + "VOLT_MULT", false)
+    property Fact battVoltPin: controller.getParameterFact(-1, _prefix + "VOLT_PIN", false)
+
+    property bool monitorEnabled: battMonitor.rawValue !== 0
+    property bool paramsAvailable: controller.parameterExists(-1, _prefix + "CAPACITY")
+    property bool showReboot: monitorEnabled && !paramsAvailable
+}

--- a/src/AutoPilotPlugins/APM/APMPowerComponent.qml
+++ b/src/AutoPilotPlugins/APM/APMPowerComponent.qml
@@ -11,8 +11,10 @@ SetupPage {
     id:             powerPage
     pageComponent:  powerPageComponent
 
+    property var _controller: controller
+
     FactPanelController {
-        id:         controller
+        id: controller
     }
 
     Component {
@@ -20,170 +22,143 @@ SetupPage {
 
         ColumnLayout {
             id:         flowLayout
-            width:      availableWidth
             spacing:    _margins
 
-            property Fact _batt1Monitor:            controller.getParameterFact(-1, "BATT_MONITOR")
-            property Fact _batt2Monitor:            controller.getParameterFact(-1, "BATT2_MONITOR", false /* reportMissing */)
-            property bool _batt2MonitorAvailable:   controller.parameterExists(-1, "BATT2_MONITOR")
-            property bool _batt1MonitorEnabled:     _batt1Monitor.rawValue !== 0
-            property bool _batt2MonitorEnabled:     _batt2MonitorAvailable && _batt2Monitor.rawValue !== 0
-            property bool _batt1ParamsAvailable:    controller.parameterExists(-1, "BATT_CAPACITY")
-            property bool _batt2ParamsAvailable:    controller.parameterExists(-1, "BATT2_CAPACITY")
-            property bool _showBatt1Reboot:         _batt1MonitorEnabled && !_batt1ParamsAvailable
-            property bool _showBatt2Reboot:         _batt2MonitorEnabled && !_batt2ParamsAvailable
+            property int _batteryCount: _getBatteryCount()
             property string _restartRequired: qsTr("Requires vehicle reboot")
+
+            // Local copy of prefix logic to avoid circular dependency on battParams during init
+            function _batteryPrefix(index) {
+                if (index === 0) {
+                    return "BATT_"
+                }
+                if (index <= 8) {
+                    return "BATT" + (index + 1) + "_"
+                }
+                return "BATT" + String.fromCharCode(65 + index - 9) + "_"
+            }
+
+            function _getBatteryCount() {
+                for (var i = 0; i < 16; i++) {
+                    if (!controller.parameterExists(-1, _batteryPrefix(i) + "MONITOR")) {
+                        return i
+                    }
+                }
+                return 16
+            }
+
+            function _batteryIndexLabel(index) {
+                if (index <= 8) {
+                    return String(index + 1)
+                }
+                return String.fromCharCode(65 + index - 9)
+            }
+
+            function _buildBatteryModel() {
+                var model = []
+                for (var i = 0; i < _batteryCount; i++) {
+                    var prefix = _batteryPrefix(i)
+                    var monitor = controller.getParameterFact(-1, prefix + "MONITOR", false)
+                    var inUse = monitor && monitor.rawValue !== 0
+                    model.push(_batteryIndexLabel(i) + (inUse ? qsTr(" (in use)") : qsTr(" (not used)")))
+                }
+                return model
+            }
 
             QGCPalette { id: qgcPal; colorGroupEnabled: true }
 
-            // Battery section with tab bar
-            Column {
+            APMBatteryParams {
+                id:             battParams
+                controller:     _controller
+                batteryIndex:   batterySelector.selectedBatteryIndex
+            }
+
+            // Battery selector
+            ColumnLayout {
                 spacing: _margins / 2
 
-                QGCLabel {
-                    text:       qsTr("Battery")
-                    font.bold:  true
-                }
+                RowLayout {
+                    spacing: ScreenTools.defaultFontPixelWidth
 
-                QGCTabBar {
-                    id: batteryTabBar
+                    QGCLabel {
+                        text:       qsTr("Battery")
+                        font.bold:  true
+                    }
 
-                    QGCTabButton { text: qsTr("Battery 1") }
-                    QGCTabButton {
-                        text:       qsTr("Battery 2")
-                        visible:    _batt2MonitorAvailable
+                    QGCComboBox {
+                        id:                     batterySelector
+                        Layout.minimumWidth:    ScreenTools.defaultFontPixelWidth * 15
+                        model:                  _buildBatteryModel()
+
+                        property int selectedBatteryIndex: 0
+
+                        onActivated: (index) => { selectedBatteryIndex = index }
+                        onModelChanged: Qt.callLater(function() { currentIndex = selectedBatteryIndex })
                     }
                 }
 
-                // Battery 1 - Monitor only
-                Rectangle {
-                    width:  batt1Column.x + batt1Column.width + _margins
-                    height: batt1Column.y + batt1Column.height + _margins
-                    color:  qgcPal.windowShade
-                    visible: batteryTabBar.currentIndex === 0 && (!_batt1MonitorEnabled || !_batt1ParamsAvailable)
+                // Monitor-only view (monitor disabled or params not yet available after enabling)
+                QGCGroupBox {
+                    Layout.fillWidth:       true
+                    title:                  qsTr("Battery Monitor")
+                    visible:                !battParams.monitorEnabled || !battParams.paramsAvailable
 
                     ColumnLayout {
-                        id:                 batt1Column
-                        anchors.margins:    _margins
-                        anchors.top:        parent.top
-                        anchors.left:       parent.left
-                        spacing:            ScreenTools.defaultFontPixelWidth
+                        spacing: ScreenTools.defaultFontPixelWidth
 
                         RowLayout {
-                            spacing:            ScreenTools.defaultFontPixelWidth
+                            spacing: ScreenTools.defaultFontPixelWidth
 
                             QGCLabel { text: qsTr("Battery monitor") }
                             FactComboBox {
-                                fact:       _batt1Monitor
-                                indexModel: false
+                                fact:           battParams.battMonitor
+                                indexModel:     false
                                 sizeToContents: true
                             }
                         }
 
                         QGCLabel {
                             text:       _restartRequired
-                            visible:    _showBatt1Reboot
+                            visible:    battParams.showReboot
                         }
 
                         QGCButton {
                             text:       qsTr("Reboot vehicle")
-                            visible:    _showBatt1Reboot
+                            visible:    battParams.showReboot
                             onClicked:  controller.vehicle.rebootVehicle()
                         }
                     }
                 }
 
-                // Battery 1 - Full settings
-                Rectangle {
-                    id:      batt1FullSettingsRect
-                    width:   battery1Loader.x + battery1Loader.width + _margins
-                    height:  battery1Loader.y + battery1Loader.height + _margins
-                    color:   qgcPal.windowShade
-                    visible: batteryTabBar.currentIndex === 0 && _batt1MonitorEnabled && _batt1ParamsAvailable
+                // Full settings view
+                QGCGroupBox {
+                    id:                     fullSettingsRect
+                    Layout.fillWidth:       true
+                    title:                  qsTr("Battery Settings")
+                    visible:                battParams.monitorEnabled && battParams.paramsAvailable
 
                     Loader {
-                        id:                 battery1Loader
-                        anchors.margins:    _margins
-                        anchors.top:        parent.top
-                        anchors.left:       parent.left
-                        sourceComponent:    batt1FullSettingsRect.visible ? powerSetupComponent : undefined
+                        id:                 batterySettingsLoader
+                        sourceComponent:    fullSettingsRect.visible ? powerSetupComponent : undefined
 
-                        property Fact armVoltMin:       controller.getParameterFact(-1, "BATT_ARM_VOLT", false /* reportMissing */)
-                        property Fact battAmpPerVolt:   controller.getParameterFact(-1, "BATT_AMP_PERVLT", false /* reportMissing */)
-                        property Fact battAmpOffset:    controller.getParameterFact(-1, "BATT_AMP_OFFSET", false /* reportMissing */)
-                        property Fact battCapacity:     controller.getParameterFact(-1, "BATT_CAPACITY", false /* reportMissing */)
-                        property Fact battCurrPin:      controller.getParameterFact(-1, "BATT_CURR_PIN", false /* reportMissing */)
-                        property Fact battMonitor:      controller.getParameterFact(-1, "BATT_MONITOR", false /* reportMissing */)
-                        property Fact battVoltMult:     controller.getParameterFact(-1, "BATT_VOLT_MULT", false /* reportMissing */)
-                        property Fact battVoltPin:      controller.getParameterFact(-1, "BATT_VOLT_PIN", false /* reportMissing */)
-                        property FactGroup  _batteryFactGroup:  batt1FullSettingsRect.visible ? controller.vehicle.getFactGroup("battery0") : null
-                        property Fact vehicleVoltage:   _batteryFactGroup ? _batteryFactGroup.voltage : null
-                        property Fact vehicleCurrent:   _batteryFactGroup ? _batteryFactGroup.current : null
-                    }
-                }
-
-                // Battery 2 - Monitor only
-                Rectangle {
-                    width:  batt2Column.x + batt2Column.width + _margins
-                    height: batt2Column.y + batt2Column.height + _margins
-                    color:  qgcPal.windowShade
-                    visible: batteryTabBar.currentIndex === 1 && (!_batt2MonitorEnabled || !_batt2ParamsAvailable)
-
-                    ColumnLayout {
-                        id:                 batt2Column
-                        anchors.margins:    _margins
-                        anchors.top:        parent.top
-                        anchors.left:       parent.left
-                        spacing:            ScreenTools.defaultFontPixelWidth
-
-                        RowLayout {
-                            spacing:            ScreenTools.defaultFontPixelWidth
-
-                            QGCLabel { text: qsTr("Battery monitor") }
-                            FactComboBox {
-                                fact:       _batt2Monitor
-                                indexModel: false
-                                sizeToContents: true
+                        // Force reload when battery selection changes so calcSensor re-runs
+                        property int _batteryIndex: batterySelector.selectedBatteryIndex
+                        on_BatteryIndexChanged: {
+                            if (fullSettingsRect.visible) {
+                                sourceComponent = undefined
+                                sourceComponent = powerSetupComponent
                             }
                         }
 
-                        QGCLabel {
-                            text:       _restartRequired
-                            visible:    _showBatt2Reboot
-                        }
-
-                        QGCButton {
-                            text:       qsTr("Reboot vehicle")
-                            visible:    _showBatt2Reboot
-                            onClicked:  controller.vehicle.rebootVehicle()
-                        }
-                    }
-                }
-
-                // Battery 2 - Full settings
-                Rectangle {
-                    id:      batt2FullSettingsRect
-                    width:   battery2Loader.x + battery2Loader.width + _margins
-                    height:  battery2Loader.y + battery2Loader.height + _margins
-                    color:   qgcPal.windowShade
-                    visible: batteryTabBar.currentIndex === 1 && _batt2MonitorEnabled && _batt2ParamsAvailable
-
-                    Loader {
-                        id:                 battery2Loader
-                        anchors.margins:    _margins
-                        anchors.top:        parent.top
-                        anchors.left:       parent.left
-                        sourceComponent:    batt2FullSettingsRect.visible ? powerSetupComponent : undefined
-
-                        property Fact armVoltMin:       controller.getParameterFact(-1, "BATT2_ARM_VOLT", false /* reportMissing */)
-                        property Fact battAmpPerVolt:   controller.getParameterFact(-1, "BATT2_AMP_PERVLT", false /* reportMissing */)
-                        property Fact battAmpOffset:    controller.getParameterFact(-1, "BATT2_AMP_OFFSET", false /* reportMissing */)
-                        property Fact battCapacity:     controller.getParameterFact(-1, "BATT2_CAPACITY", false /* reportMissing */)
-                        property Fact battCurrPin:      controller.getParameterFact(-1, "BATT2_CURR_PIN", false /* reportMissing */)
-                        property Fact battMonitor:      controller.getParameterFact(-1, "BATT2_MONITOR", false /* reportMissing */)
-                        property Fact battVoltMult:     controller.getParameterFact(-1, "BATT2_VOLT_MULT", false /* reportMissing */)
-                        property Fact battVoltPin:      controller.getParameterFact(-1, "BATT2_VOLT_PIN", false /* reportMissing */)
-                        property FactGroup  _batteryFactGroup:  batt2FullSettingsRect.visible ? controller.vehicle.getFactGroup("battery1") : null
+                        property Fact armVoltMin:       battParams.battArmVolt
+                        property Fact battAmpPerVolt:   battParams.battAmpPerVolt
+                        property Fact battAmpOffset:    battParams.battAmpOffset
+                        property Fact battCapacity:     battParams.battCapacity
+                        property Fact battCurrPin:      battParams.battCurrPin
+                        property Fact battMonitor:      battParams.battMonitor
+                        property Fact battVoltMult:     battParams.battVoltMult
+                        property Fact battVoltPin:      battParams.battVoltPin
+                        property FactGroup  _batteryFactGroup:  fullSettingsRect.visible ? controller.vehicle.getFactGroup("battery" + batterySelector.selectedBatteryIndex) : null
                         property Fact vehicleVoltage:   _batteryFactGroup ? _batteryFactGroup.voltage : null
                         property Fact vehicleCurrent:   _batteryFactGroup ? _batteryFactGroup.current : null
                     }
@@ -274,11 +249,11 @@ SetupPage {
 
 
             GridLayout {
-                columns:        3
+                columns:        2
                 rowSpacing:     _margins
                 columnSpacing:  _margins
 
-                QGCLabel { text: qsTr("Battery monitor:") }
+                QGCLabel { text: qsTr("Battery monitor") }
 
                 FactComboBox {
                     id:         monitorCombo
@@ -287,35 +262,21 @@ SetupPage {
                     sizeToContents: true
                 }
 
-                QGCLabel {
-                    Layout.row:     1
-                    Layout.column:  0
-                    text:           qsTr("Battery capacity:")
-                }
+                QGCLabel { text: qsTr("Battery capacity") }
 
                 FactTextField {
-                    id:     capacityField
                     width:  _fieldWidth
                     fact:   battCapacity
                 }
 
-                QGCLabel {
-                    Layout.row:     2
-                    Layout.column:  0
-                    text:           qsTr("Minimum arming voltage:")
-                }
+                QGCLabel { text: qsTr("Minimum arming voltage") }
 
                 FactTextField {
-                    id:     armVoltField
                     width:  _fieldWidth
                     fact:   armVoltMin
                 }
 
-                QGCLabel {
-                    Layout.row:     3
-                    Layout.column:  0
-                    text:           qsTr("Power sensor:")
-                }
+                QGCLabel { text: qsTr("Power sensor") }
 
                 QGCComboBox {
                     id:                     sensorCombo
@@ -330,99 +291,97 @@ SetupPage {
                             battVoltMult.value = sensorModel.get(index).voltMult
                             battAmpPerVolt.value = sensorModel.get(index).ampPerVolt
                             battAmpOffset.value = sensorModel.get(index).ampOffset
-                        } else {
-
                         }
                     }
                 }
 
                 QGCLabel {
-                    Layout.row:     4
-                    Layout.column:  0
-                    text:           qsTr("Current pin:")
-                    visible:        _showAdvanced
+                    text:    qsTr("Current pin")
+                    visible: _showAdvanced
                 }
 
                 FactComboBox {
-                    Layout.minimumWidth:    _fieldWidth
-                    fact:                   battCurrPin
-                    indexModel:             false
-                    visible:                _showAdvanced
-                    sizeToContents:         true
+                    Layout.minimumWidth: _fieldWidth
+                    fact:                battCurrPin
+                    indexModel:          false
+                    visible:             _showAdvanced
+                    sizeToContents:      true
                 }
 
                 QGCLabel {
-                    Layout.row:     5
-                    Layout.column:  0
-                    text:           qsTr("Voltage pin:")
-                    visible:        _showAdvanced
+                    text:    qsTr("Voltage pin")
+                    visible: _showAdvanced
                 }
 
                 FactComboBox {
-                    Layout.minimumWidth:    _fieldWidth
-                    fact:                   battVoltPin
-                    indexModel:             false
-                    visible:                _showAdvanced
-                    sizeToContents:         true
+                    Layout.minimumWidth: _fieldWidth
+                    fact:                battVoltPin
+                    indexModel:          false
+                    visible:             _showAdvanced
+                    sizeToContents:      true
                 }
 
                 QGCLabel {
-                    Layout.row:     6
-                    Layout.column:  0
-                    text:           qsTr("Voltage multiplier:")
-                    visible:        _showAdvanced
+                    text:    qsTr("Voltage multiplier")
+                    visible: _showAdvanced
                 }
 
-                FactTextField {
-                    width:      _fieldWidth
-                    fact:       battVoltMult
+                RowLayout {
                     visible:    _showAdvanced
-                }
+                    spacing:    _margins
 
-                QGCButton {
-                    text:       qsTr("Calculate")
-                    visible:    _showAdvanced
-                    onClicked:  calcVoltageMultiplierDlgFactory.open({ vehicleVoltageFact: vehicleVoltage, battVoltMultFact: battVoltMult })
+                    FactTextField {
+                        width:  _fieldWidth
+                        fact:   battVoltMult
+                    }
+
+                    QGCButton {
+                        text:      qsTr("Calculate")
+                        onClicked: calcVoltageMultiplierDlgFactory.open({ vehicleVoltageFact: vehicleVoltage, battVoltMultFact: battVoltMult })
+                    }
                 }
 
                 QGCLabel {
-                    Layout.columnSpan:  3
+                    Layout.columnSpan:  2
                     Layout.fillWidth:   true
                     font.pointSize:     ScreenTools.smallFontPointSize
                     wrapMode:           Text.WordWrap
-                    text:               qsTr("If the battery voltage reported by the vehicle is largely different than the voltage read externally using a voltmeter you can adjust the voltage multiplier value to correct this. Click the Calculate button for help with calculating a new value.")
+                    text:               qsTr("Adjust this if the reported voltage does not match an external voltmeter reading. Click Calculate to compute a corrected value from a known measurement.")
                     visible:            _showAdvanced
                 }
 
                 QGCLabel {
-                    text:       qsTr("Amps per volt:")
-                    visible:    _showAdvanced
+                    text:    qsTr("Amps per volt")
+                    visible: _showAdvanced
                 }
 
-                FactTextField {
-                    width:      _fieldWidth
-                    fact:       battAmpPerVolt
+                RowLayout {
                     visible:    _showAdvanced
-                }
+                    spacing:    _margins
 
-                QGCButton {
-                    text:       qsTr("Calculate")
-                    visible:    _showAdvanced
-                    onClicked:  calcAmpsPerVoltDlgFactory.open({ vehicleCurrentFact: vehicleCurrent, battAmpPerVoltFact: battAmpPerVolt })
+                    FactTextField {
+                        width:  _fieldWidth
+                        fact:   battAmpPerVolt
+                    }
+
+                    QGCButton {
+                        text:      qsTr("Calculate")
+                        onClicked: calcAmpsPerVoltDlgFactory.open({ vehicleCurrentFact: vehicleCurrent, battAmpPerVoltFact: battAmpPerVolt })
+                    }
                 }
 
                 QGCLabel {
-                    Layout.columnSpan:  3
+                    Layout.columnSpan:  2
                     Layout.fillWidth:   true
                     font.pointSize:     ScreenTools.smallFontPointSize
                     wrapMode:           Text.WordWrap
-                    text:               qsTr("If the current draw reported by the vehicle is largely different than the current read externally using a current meter you can adjust the amps per volt value to correct this. Click the Calculate button for help with calculating a new value.")
+                    text:               qsTr("Adjust this if the reported current does not match an external current meter reading. Click Calculate to compute a corrected value from a known measurement.")
                     visible:            _showAdvanced
                 }
 
                 QGCLabel {
-                    text:       qsTr("Amps Offset:")
-                    visible:    _showAdvanced
+                    text:    qsTr("Amps Offset")
+                    visible: _showAdvanced
                 }
 
                 FactTextField {
@@ -432,11 +391,11 @@ SetupPage {
                 }
 
                 QGCLabel {
-                    Layout.columnSpan:  3
+                    Layout.columnSpan:  2
                     Layout.fillWidth:   true
                     font.pointSize:     ScreenTools.smallFontPointSize
                     wrapMode:           Text.WordWrap
-                    text:               qsTr("If the vehicle reports a high current read when there is little or no current going through it, adjust the Amps Offset. It should be equal to the voltage reported by the sensor when the current is zero.")
+                    text:               qsTr("Set this to the sensor voltage reading when no current is flowing. Corrects for a non-zero current reading at idle.")
                     visible:            _showAdvanced
                 }
 
@@ -474,14 +433,14 @@ SetupPage {
                     columns:    2
 
                     QGCLabel {
-                        text: qsTr("Measured voltage:")
+                        text: qsTr("Measured voltage")
                     }
                     QGCTextField { id: measuredVoltage }
 
-                    QGCLabel { text: qsTr("Vehicle voltage:") }
+                    QGCLabel { text: qsTr("Vehicle voltage") }
                     FactLabel { fact: vehicleVoltageFact }
 
-                    QGCLabel { text: qsTr("Voltage multiplier:") }
+                    QGCLabel { text: qsTr("Voltage multiplier") }
                     FactLabel { fact: battVoltMultFact }
                 }
 
@@ -533,14 +492,14 @@ SetupPage {
                     columns:    2
 
                     QGCLabel {
-                        text: qsTr("Measured current:")
+                        text: qsTr("Measured current")
                     }
                     QGCTextField { id: measuredCurrent }
 
-                    QGCLabel { text: qsTr("Vehicle current:") }
+                    QGCLabel { text: qsTr("Vehicle current") }
                     FactLabel { fact: vehicleCurrentFact }
 
-                    QGCLabel { text: qsTr("Amps per volt:") }
+                    QGCLabel { text: qsTr("Amps per volt") }
                     FactLabel { fact: battAmpPerVoltFact }
                 }
 

--- a/src/AutoPilotPlugins/APM/CMakeLists.txt
+++ b/src/AutoPilotPlugins/APM/CMakeLists.txt
@@ -65,6 +65,7 @@ qt_add_qml_module(AutoPilotPluginsAPMModule
     QML_FILES
         APMAirframeComponent.qml
         APMAirframeComponentSummary.qml
+        APMBatteryParams.qml
         APMESCComponent.qml
         APMESCComponentSummary.qml
         APMFlightModesComponent.qml


### PR DESCRIPTION
## Summary
- ArduPilot 4.7+ supports battery params from BATT_ through BATT9_ and BATTA_ through BATTG_ (up to 16 batteries). The Power setup page previously only supported Battery 1 and Battery 2 with a hardcoded tab bar.
- Add `APMBatteryParams.qml` to encapsulate the battery prefix naming scheme and parameter access for any battery index.
- Replace the tab bar with a combo box selector that auto-detects available batteries by probing MONITOR params, showing each battery's index (1-9, A-G) and in-use status.
- UI cleanup: use QGCGroupBox, 2-column GridLayout, inline Calculate buttons in RowLayouts, tighten help text, remove trailing colons from labels.

## Test plan
- [ ] Connect to ArduPilot vehicle (or MockLink) and open Vehicle Setup > Power
- [ ] Verify battery selector combo shows all available batteries with correct in-use/not-used status
- [ ] Select different batteries and verify parameters load correctly
- [ ] Change a battery's MONITOR value and verify the combo label updates
- [ ] Verify Calculate dialogs for voltage multiplier and amps per volt still work
- [ ] Verify reboot prompt appears when enabling a monitor that requires param reload