### PR TITLE
APM Power: add power module presets and sensor calibration improvements

### DIFF
--- a/src/AutoPilotPlugins/APM/APMBatteryParams.qml
+++ b/src/AutoPilotPlugins/APM/APMBatteryParams.qml
@@ -22,16 +22,46 @@ QtObject {
         return "BATT" + String.fromCharCode(65 + index - 9) + "_"
     }
 
+    /// Returns a display label for a 0-based battery index.
+    /// 0: "1", 1: "2", ..., 8: "9", 9: "A", ..., 15: "G"
+    function labelForIndex(index) {
+        if (index <= 8) {
+            return String(index + 1)
+        }
+        return String.fromCharCode(65 + index - 9)
+    }
+
+    /// Returns the number of battery slots whose MONITOR parameter exists.
+    function getBatteryCount() {
+        for (let i = 0; i < 16; i++) {
+            if (!controller.parameterExists(-1, prefixForIndex(i) + "MONITOR")) {
+                return i
+            }
+        }
+        return 16
+    }
+
     property Fact battMonitor: controller.getParameterFact(-1, _prefix + "MONITOR")
     property Fact battCapacity: controller.getParameterFact(-1, _prefix + "CAPACITY", false)
     property Fact battArmVolt: controller.getParameterFact(-1, _prefix + "ARM_VOLT", false)
     property Fact battAmpPerVolt: controller.getParameterFact(-1, _prefix + "AMP_PERVLT", false)
     property Fact battAmpOffset: controller.getParameterFact(-1, _prefix + "AMP_OFFSET", false)
-    property Fact battCurrPin: controller.getParameterFact(-1, _prefix + "CURR_PIN", false)
     property Fact battVoltMult: controller.getParameterFact(-1, _prefix + "VOLT_MULT", false)
-    property Fact battVoltPin: controller.getParameterFact(-1, _prefix + "VOLT_PIN", false)
 
     property bool monitorEnabled: battMonitor.rawValue !== 0
     property bool paramsAvailable: controller.parameterExists(-1, _prefix + "CAPACITY")
     property bool showReboot: monitorEnabled && !paramsAvailable
+
+    // ArduPilot BattMonitor::Type enum values for analog sensor detection
+    readonly property int _monitorAnalogVoltageOnly:                3
+    readonly property int _monitorAnalogVoltageAndCurrent:          4
+    readonly property int _monitorAnalogVoltageSyntheticCurrent:    25
+    readonly property int _monitorAnalogCurrentOnly:                31
+
+    function _isMonitorTypeAnyOf(types) {
+        return monitorEnabled && types.includes(battMonitor.rawValue)
+    }
+
+    readonly property bool hasVoltageSensor: _isMonitorTypeAnyOf([_monitorAnalogVoltageOnly, _monitorAnalogVoltageAndCurrent, _monitorAnalogVoltageSyntheticCurrent])
+    readonly property bool hasCurrentSensor: _isMonitorTypeAnyOf([_monitorAnalogVoltageAndCurrent, _monitorAnalogCurrentOnly])
 }

--- a/src/AutoPilotPlugins/APM/APMPowerComponent.h
+++ b/src/AutoPilotPlugins/APM/APMPowerComponent.h
@@ -13,7 +13,7 @@ public:
 
     QString name() const final { return _name; }
     QString description() const final { return tr("The Power Component is used to setup battery parameters."); }
-    QString iconResource() const final { return QStringLiteral("/qmlimages/PowerComponentIcon.png"); }
+    QString iconResource() const final { return QStringLiteral("/qmlimages/Battery.svg"); }
     bool requiresSetup() const final { return false; }
     bool setupComplete() const final { return true; }
     QUrl setupSource() const final { return QUrl::fromUserInput(QStringLiteral("qrc:/qml/QGroundControl/AutoPilotPlugins/APM/APMPowerComponent.qml")); }

--- a/src/AutoPilotPlugins/APM/APMPowerComponent.qml
+++ b/src/AutoPilotPlugins/APM/APMPowerComponent.qml
@@ -11,10 +11,10 @@ SetupPage {
     id:             powerPage
     pageComponent:  powerPageComponent
 
-    property var _controller: controller
+    property var _controller: powerModulePresetController
 
-    FactPanelController {
-        id: controller
+    PowerModulePresetController {
+        id: powerModulePresetController
     }
 
     Component {
@@ -24,43 +24,16 @@ SetupPage {
             id:         flowLayout
             spacing:    _margins
 
-            property int _batteryCount: _getBatteryCount()
+            property int _batteryCount: battParams.getBatteryCount()
             property string _restartRequired: qsTr("Requires vehicle reboot")
 
-            // Local copy of prefix logic to avoid circular dependency on battParams during init
-            function _batteryPrefix(index) {
-                if (index === 0) {
-                    return "BATT_"
-                }
-                if (index <= 8) {
-                    return "BATT" + (index + 1) + "_"
-                }
-                return "BATT" + String.fromCharCode(65 + index - 9) + "_"
-            }
-
-            function _getBatteryCount() {
-                for (var i = 0; i < 16; i++) {
-                    if (!controller.parameterExists(-1, _batteryPrefix(i) + "MONITOR")) {
-                        return i
-                    }
-                }
-                return 16
-            }
-
-            function _batteryIndexLabel(index) {
-                if (index <= 8) {
-                    return String(index + 1)
-                }
-                return String.fromCharCode(65 + index - 9)
-            }
-
             function _buildBatteryModel() {
-                var model = []
-                for (var i = 0; i < _batteryCount; i++) {
-                    var prefix = _batteryPrefix(i)
-                    var monitor = controller.getParameterFact(-1, prefix + "MONITOR", false)
-                    var inUse = monitor && monitor.rawValue !== 0
-                    model.push(_batteryIndexLabel(i) + (inUse ? qsTr(" (in use)") : qsTr(" (not used)")))
+                let model = []
+                for (let i = 0; i < _batteryCount; i++) {
+                    let prefix = battParams.prefixForIndex(i)
+                    let monitorFact = powerModulePresetController.getParameterFact(-1, prefix + "MONITOR", false)
+                    let inUse = monitorFact && monitorFact.rawValue !== 0
+                    model.push(battParams.labelForIndex(i) + (inUse ? qsTr(" (in use)") : qsTr(" (not used)")))
                 }
                 return model
             }
@@ -87,7 +60,7 @@ SetupPage {
 
                     QGCComboBox {
                         id:                     batterySelector
-                        Layout.minimumWidth:    ScreenTools.defaultFontPixelWidth * 15
+                        sizeToContents:         true
                         model:                  _buildBatteryModel()
 
                         property int selectedBatteryIndex: 0
@@ -125,7 +98,7 @@ SetupPage {
                         QGCButton {
                             text:       qsTr("Reboot vehicle")
                             visible:    battParams.showReboot
-                            onClicked:  controller.vehicle.rebootVehicle()
+                            onClicked:  powerModulePresetController.vehicle.rebootVehicle()
                         }
                     }
                 }
@@ -134,7 +107,6 @@ SetupPage {
                 QGCGroupBox {
                     id:                     fullSettingsRect
                     Layout.fillWidth:       true
-                    title:                  qsTr("Battery Settings")
                     visible:                battParams.monitorEnabled && battParams.paramsAvailable
 
                     Loader {
@@ -154,13 +126,11 @@ SetupPage {
                         property Fact battAmpPerVolt:   battParams.battAmpPerVolt
                         property Fact battAmpOffset:    battParams.battAmpOffset
                         property Fact battCapacity:     battParams.battCapacity
-                        property Fact battCurrPin:      battParams.battCurrPin
                         property Fact battMonitor:      battParams.battMonitor
                         property Fact battVoltMult:     battParams.battVoltMult
-                        property Fact battVoltPin:      battParams.battVoltPin
-                        property FactGroup  _batteryFactGroup:  fullSettingsRect.visible ? controller.vehicle.getFactGroup("battery" + batterySelector.selectedBatteryIndex) : null
-                        property Fact vehicleVoltage:   _batteryFactGroup ? _batteryFactGroup.voltage : null
-                        property Fact vehicleCurrent:   _batteryFactGroup ? _batteryFactGroup.current : null
+                        property bool hasVoltageSensor: battParams.hasVoltageSensor
+                        property bool hasCurrentSensor: battParams.hasCurrentSensor
+                        property int  batteryIndex:     batterySelector.selectedBatteryIndex
                     }
                 }
             }
@@ -176,15 +146,32 @@ SetupPage {
 
             property real _margins:         ScreenTools.defaultFontPixelHeight / 2
             property bool _showAdvanced:    sensorCombo.currentIndex === sensorModel.count - 1
-            property real _fieldWidth:      ScreenTools.defaultFontPixelWidth * 25
+            property bool _showVoltageCalib: hasVoltageSensor && _showAdvanced
+            property bool _showCurrentCalib: hasCurrentSensor && (_showAdvanced || !hasVoltageSensor)
+            property real _textFieldWidth:  ScreenTools.defaultFontPixelWidth * 15
+            property real _comboWidth:       ScreenTools.defaultFontPixelWidth * 30
 
-            Component.onCompleted: calcSensor()
+            Component.onCompleted: {
+                loadSensorPresets()
+                calcSensor()
+            }
+
+            function loadSensorPresets() {
+                let presets = _controller.powerModulePresets()
+                for (let i = 0; i < presets.length; i++) {
+                    let preset = presets[i]
+                    sensorModel.insert(sensorModel.count - 1,
+                        { text: preset.name, voltMult: preset.voltMult, ampPerVolt: preset.ampPerVolt, ampOffset: preset.ampOffset })
+                }
+            }
 
             function calcSensor() {
-                for (var i=0; i<sensorModel.count - 1; i++) {
-                    if (sensorModel.get(i).voltPin === battVoltPin.value &&
-                            sensorModel.get(i).currPin === battCurrPin.value &&
-                            Math.abs(sensorModel.get(i).voltMult - battVoltMult.value) < 0.001 &&
+                if (!hasVoltageSensor) {
+                    sensorCombo.currentIndex = sensorModel.count - 1
+                    return
+                }
+                for (let i=0; i<sensorModel.count - 1; i++) {
+                    if (Math.abs(sensorModel.get(i).voltMult - battVoltMult.value) < 0.001 &&
                             Math.abs(sensorModel.get(i).ampPerVolt - battAmpPerVolt.value) < 0.0001 &&
                             Math.abs(sensorModel.get(i).ampOffset - battAmpOffset.value) < 0.0001) {
                         sensorCombo.currentIndex = i
@@ -198,55 +185,9 @@ SetupPage {
                 id: sensorModel
 
                 ListElement {
-                    text:       qsTr("Power Module 90A")
-                    voltPin:    2
-                    currPin:    3
-                    voltMult:   10.1
-                    ampPerVolt: 17.0
-                    ampOffset:  0
-                }
-
-                ListElement {
-                    text:       qsTr("Power Module HV")
-                    voltPin:    2
-                    currPin:    3
-                    voltMult:   12.02
-                    ampPerVolt: 39.877
-                    ampOffset:  0
-                }
-
-                ListElement {
-                    text:       qsTr("3DR Iris")
-                    voltPin:    2
-                    currPin:    3
-                    voltMult:   12.02
-                    ampPerVolt: 17.0
-                    ampOffset:  0
-                }
-
-                ListElement {
-                    text:       qsTr("Blue Robotics Power Sense Module")
-                    voltPin:    2
-                    currPin:    3
-                    voltMult:   11.000
-                    ampPerVolt: 37.8788
-                    ampOffset:  0.330
-                }
-
-                ListElement {
-                    text:       qsTr("Navigator w/ Blue Robotics Power Sense Module")
-                    voltPin:    5
-                    currPin:    4
-                    voltMult:   11.000
-                    ampPerVolt: 37.8788
-                    ampOffset:  0.330
-                }
-
-                ListElement {
-                    text:       qsTr("Other")
+                    text:       qsTr("Custom")
                 }
             }
-
 
             GridLayout {
                 columns:        2
@@ -256,38 +197,42 @@ SetupPage {
                 QGCLabel { text: qsTr("Battery monitor") }
 
                 FactComboBox {
-                    id:         monitorCombo
-                    fact:       battMonitor
-                    indexModel: false
-                    sizeToContents: true
+                    id:                     monitorCombo
+                    Layout.maximumWidth:     _comboWidth
+                    fact:                    battMonitor
+                    indexModel:              false
+                    sizeToContents:          true
                 }
 
                 QGCLabel { text: qsTr("Battery capacity") }
 
                 FactTextField {
-                    width:  _fieldWidth
-                    fact:   battCapacity
+                    Layout.preferredWidth:  _textFieldWidth
+                    fact:                   battCapacity
                 }
 
                 QGCLabel { text: qsTr("Minimum arming voltage") }
 
                 FactTextField {
-                    width:  _fieldWidth
-                    fact:   armVoltMin
+                    Layout.preferredWidth:  _textFieldWidth
+                    fact:                   armVoltMin
                 }
 
-                QGCLabel { text: qsTr("Power sensor") }
+                QGCLabel {
+                    text:    qsTr("Power sensor")
+                    visible: hasVoltageSensor
+                }
 
                 QGCComboBox {
                     id:                     sensorCombo
-                    Layout.minimumWidth:    _fieldWidth
+                    Layout.maximumWidth:     _comboWidth
+                    sizeToContents:         true
                     model:                  sensorModel
                     textRole:               "text"
+                    visible:                hasVoltageSensor
 
                     onActivated: (index) => {
                         if (index < sensorModel.count - 1) {
-                            battVoltPin.value = sensorModel.get(index).voltPin
-                            battCurrPin.value = sensorModel.get(index).currPin
                             battVoltMult.value = sensorModel.get(index).voltMult
                             battAmpPerVolt.value = sensorModel.get(index).ampPerVolt
                             battAmpOffset.value = sensorModel.get(index).ampOffset
@@ -296,48 +241,22 @@ SetupPage {
                 }
 
                 QGCLabel {
-                    text:    qsTr("Current pin")
-                    visible: _showAdvanced
-                }
-
-                FactComboBox {
-                    Layout.minimumWidth: _fieldWidth
-                    fact:                battCurrPin
-                    indexModel:          false
-                    visible:             _showAdvanced
-                    sizeToContents:      true
-                }
-
-                QGCLabel {
-                    text:    qsTr("Voltage pin")
-                    visible: _showAdvanced
-                }
-
-                FactComboBox {
-                    Layout.minimumWidth: _fieldWidth
-                    fact:                battVoltPin
-                    indexModel:          false
-                    visible:             _showAdvanced
-                    sizeToContents:      true
-                }
-
-                QGCLabel {
                     text:    qsTr("Voltage multiplier")
-                    visible: _showAdvanced
+                    visible: _showVoltageCalib
                 }
 
                 RowLayout {
-                    visible:    _showAdvanced
+                    visible:    _showVoltageCalib
                     spacing:    _margins
 
                     FactTextField {
-                        width:  _fieldWidth
-                        fact:   battVoltMult
+                        Layout.preferredWidth:  _textFieldWidth
+                        fact:                   battVoltMult
                     }
 
                     QGCButton {
                         text:      qsTr("Calculate")
-                        onClicked: calcVoltageMultiplierDlgFactory.open({ vehicleVoltageFact: vehicleVoltage, battVoltMultFact: battVoltMult })
+                        onClicked: calcVoltageMultiplierDlgFactory.open({ batteryIndex: batteryIndex, battVoltMultFact: battVoltMult })
                     }
                 }
 
@@ -347,26 +266,26 @@ SetupPage {
                     font.pointSize:     ScreenTools.smallFontPointSize
                     wrapMode:           Text.WordWrap
                     text:               qsTr("Adjust this if the reported voltage does not match an external voltmeter reading. Click Calculate to compute a corrected value from a known measurement.")
-                    visible:            _showAdvanced
+                    visible:            _showVoltageCalib
                 }
 
                 QGCLabel {
                     text:    qsTr("Amps per volt")
-                    visible: _showAdvanced
+                    visible: _showCurrentCalib
                 }
 
                 RowLayout {
-                    visible:    _showAdvanced
+                    visible:    _showCurrentCalib
                     spacing:    _margins
 
                     FactTextField {
-                        width:  _fieldWidth
-                        fact:   battAmpPerVolt
+                        Layout.preferredWidth:  _textFieldWidth
+                        fact:                   battAmpPerVolt
                     }
 
                     QGCButton {
                         text:      qsTr("Calculate")
-                        onClicked: calcAmpsPerVoltDlgFactory.open({ vehicleCurrentFact: vehicleCurrent, battAmpPerVoltFact: battAmpPerVolt })
+                        onClicked: calcAmpsPerVoltDlgFactory.open({ batteryIndex: batteryIndex, battAmpPerVoltFact: battAmpPerVolt })
                     }
                 }
 
@@ -376,18 +295,18 @@ SetupPage {
                     font.pointSize:     ScreenTools.smallFontPointSize
                     wrapMode:           Text.WordWrap
                     text:               qsTr("Adjust this if the reported current does not match an external current meter reading. Click Calculate to compute a corrected value from a known measurement.")
-                    visible:            _showAdvanced
+                    visible:            _showCurrentCalib
                 }
 
                 QGCLabel {
                     text:    qsTr("Amps Offset")
-                    visible: _showAdvanced
+                    visible: _showCurrentCalib
                 }
 
                 FactTextField {
-                    width:      _fieldWidth
-                    fact:       battAmpOffset
-                    visible:    _showAdvanced
+                    Layout.preferredWidth:  _textFieldWidth
+                    fact:                   battAmpOffset
+                    visible:                _showCurrentCalib
                 }
 
                 QGCLabel {
@@ -396,7 +315,7 @@ SetupPage {
                     font.pointSize:     ScreenTools.smallFontPointSize
                     wrapMode:           Text.WordWrap
                     text:               qsTr("Set this to the sensor voltage reading when no current is flowing. Corrects for a non-zero current reading at idle.")
-                    visible:            _showAdvanced
+                    visible:            _showCurrentCalib
                 }
 
             } // GridLayout
@@ -416,8 +335,12 @@ SetupPage {
             title:      qsTr("Calculate Voltage Multiplier")
             buttons:    Dialog.Close
 
-            property Fact vehicleVoltageFact
+            property int  batteryIndex
             property Fact battVoltMultFact
+
+            property FactGroup _batteryFactGroup: powerModulePresetController.vehicle.batteries.count > batteryIndex ? powerModulePresetController.vehicle.getFactGroup("battery" + batteryIndex) : null
+            property Fact      _vehicleVoltage:   _batteryFactGroup ? _batteryFactGroup.voltage : null
+            property bool      _hasTelemetry:     _vehicleVoltage && _vehicleVoltage.value !== 0
 
             ColumnLayout {
                 spacing: ScreenTools.defaultFontPixelHeight
@@ -428,6 +351,14 @@ SetupPage {
                     text:                   qsTr("Measure battery voltage using an external voltmeter and enter the value below. Click Calculate to set the new adjusted voltage multiplier.")
                 }
 
+                QGCLabel {
+                    Layout.preferredWidth:  gridLayout.width
+                    wrapMode:               Text.WordWrap
+                    visible:                !_hasTelemetry
+                    text:                   qsTr("Vehicle voltage telemetry is not available. Connect to a vehicle with a powered battery to enable automatic calculation.")
+                    color:                  qgcPal.warningText
+                }
+
                 GridLayout {
                     id:         gridLayout
                     columns:    2
@@ -435,24 +366,34 @@ SetupPage {
                     QGCLabel {
                         text: qsTr("Measured voltage")
                     }
-                    QGCTextField { id: measuredVoltage }
+                    QGCTextField {
+                        id: measuredVoltage
+                        Layout.preferredWidth: ScreenTools.defaultFontPixelWidth * 15
+                    }
 
-                    QGCLabel { text: qsTr("Vehicle voltage") }
-                    FactLabel { fact: vehicleVoltageFact }
+                    QGCLabel {
+                        text:    qsTr("Vehicle voltage")
+                        visible: _hasTelemetry
+                    }
+                    FactLabel {
+                        fact:    _vehicleVoltage
+                        visible: _hasTelemetry
+                    }
 
                     QGCLabel { text: qsTr("Voltage multiplier") }
                     FactLabel { fact: battVoltMultFact }
                 }
 
                 QGCButton {
-                    text: qsTr("Calculate And Set")
+                    text:    qsTr("Calculate And Set")
+                    enabled: _hasTelemetry
 
-                    onClicked:  {
-                        var measuredVoltageValue = parseFloat(measuredVoltage.text)
-                        if (measuredVoltageValue === 0 || isNaN(measuredVoltageValue) || !vehicleVoltageFact || !battVoltMultFact) {
+                    onClicked: {
+                        let measuredVoltageValue = parseFloat(measuredVoltage.text)
+                        if (measuredVoltageValue === 0 || isNaN(measuredVoltageValue)) {
                             return
                         }
-                        var newVoltageMultiplier = (vehicleVoltageFact.value !== 0) ? (measuredVoltageValue * battVoltMultFact.value) / vehicleVoltageFact.value : 0
+                        let newVoltageMultiplier = (measuredVoltageValue * battVoltMultFact.value) / _vehicleVoltage.value
                         if (newVoltageMultiplier > 0) {
                             battVoltMultFact.value = newVoltageMultiplier
                         }
@@ -475,8 +416,12 @@ SetupPage {
             title:      qsTr("Calculate Amps per Volt")
             buttons:    Dialog.Close
 
-            property Fact vehicleCurrentFact
+            property int  batteryIndex
             property Fact battAmpPerVoltFact
+
+            property FactGroup _batteryFactGroup: powerModulePresetController.vehicle.batteries.count > batteryIndex ? powerModulePresetController.vehicle.getFactGroup("battery" + batteryIndex) : null
+            property Fact      _vehicleCurrent:   _batteryFactGroup ? _batteryFactGroup.current : null
+            property bool      _hasTelemetry:     _vehicleCurrent && _vehicleCurrent.value !== 0
 
             ColumnLayout {
                 spacing: ScreenTools.defaultFontPixelHeight
@@ -487,6 +432,14 @@ SetupPage {
                     text:                   qsTr("Measure current draw using an external current meter and enter the value below. Click Calculate to set the new amps per volt value.")
                 }
 
+                QGCLabel {
+                    Layout.preferredWidth:  gridLayout.width
+                    wrapMode:               Text.WordWrap
+                    visible:                !_hasTelemetry
+                    text:                   qsTr("Vehicle current telemetry is not available. Connect to a vehicle with a powered battery to enable automatic calculation.")
+                    color:                  qgcPal.warningText
+                }
+
                 GridLayout {
                     id:         gridLayout
                     columns:    2
@@ -494,24 +447,34 @@ SetupPage {
                     QGCLabel {
                         text: qsTr("Measured current")
                     }
-                    QGCTextField { id: measuredCurrent }
+                    QGCTextField {
+                        id: measuredCurrent
+                        Layout.preferredWidth: ScreenTools.defaultFontPixelWidth * 15
+                    }
 
-                    QGCLabel { text: qsTr("Vehicle current") }
-                    FactLabel { fact: vehicleCurrentFact }
+                    QGCLabel {
+                        text:    qsTr("Vehicle current")
+                        visible: _hasTelemetry
+                    }
+                    FactLabel {
+                        fact:    _vehicleCurrent
+                        visible: _hasTelemetry
+                    }
 
                     QGCLabel { text: qsTr("Amps per volt") }
                     FactLabel { fact: battAmpPerVoltFact }
                 }
 
                 QGCButton {
-                    text: qsTr("Calculate And Set")
+                    text:    qsTr("Calculate And Set")
+                    enabled: _hasTelemetry
 
-                    onClicked:  {
-                        var measuredCurrentValue = parseFloat(measuredCurrent.text)
-                        if (measuredCurrentValue === 0 || isNaN(measuredCurrentValue) || !vehicleCurrentFact || !battAmpPerVoltFact) {
+                    onClicked: {
+                        let measuredCurrentValue = parseFloat(measuredCurrent.text)
+                        if (measuredCurrentValue === 0 || isNaN(measuredCurrentValue)) {
                             return
                         }
-                        var newAmpsPerVolt = (vehicleCurrentFact.value !== 0) ? (measuredCurrentValue * battAmpPerVoltFact.value) / vehicleCurrentFact.value : 0
+                        let newAmpsPerVolt = (measuredCurrentValue * battAmpPerVoltFact.value) / _vehicleCurrent.value
                         if (newAmpsPerVolt !== 0) {
                             battAmpPerVoltFact.value = newAmpsPerVolt
                         }

--- a/src/AutoPilotPlugins/APM/APMPowerComponentSummary.qml
+++ b/src/AutoPilotPlugins/APM/APMPowerComponentSummary.qml
@@ -11,42 +11,44 @@ Item {
     implicitHeight: mainLayout.implicitHeight
     width: parent.width  // grows when Loader is wider than implicitWidth
 
-    FactPanelController { id: controller; }
+    FactPanelController { id: controller }
 
-    property Fact _batt1Monitor:            controller.getParameterFact(-1, "BATT_MONITOR")
-    property Fact _batt2Monitor:            controller.getParameterFact(-1, "BATT2_MONITOR", false /* reportMissing */)
-    property bool _batt2MonitorAvailable:   controller.parameterExists(-1, "BATT2_MONITOR")
-    property bool _batt1MonitorEnabled:     _batt1Monitor.rawValue !== 0
-    property bool _batt2MonitorEnabled:     _batt2MonitorAvailable && _batt2Monitor.rawValue !== 0
-    property Fact _battCapacity:            controller.getParameterFact(-1, "BATT_CAPACITY", false /* reportMissing */)
-    property Fact _batt2Capacity:           controller.getParameterFact(-1, "BATT2_CAPACITY", false /* reportMissing */)
-    property bool _battCapacityAvailable:   controller.parameterExists(-1, "BATT_CAPACITY")
+    APMBatteryParams {
+        id:             battParams
+        controller:     controller
+        batteryIndex:   0
+    }
 
     ColumnLayout {
         id: mainLayout
         spacing: 0
 
-        VehicleSummaryRow {
-            labelText: qsTr("Batt1 monitor")
-            valueText: _batt1Monitor.enumStringValue
-        }
+        Repeater {
+            model: battParams.getBatteryCount()
 
-        VehicleSummaryRow {
-            labelText: qsTr("Batt1 capacity")
-            valueText:  _batt1MonitorEnabled ? _battCapacity.valueString + " " + _battCapacity.units : ""
-            visible:    _batt1MonitorEnabled
-        }
+            delegate: ColumnLayout {
+                required property int index
+                spacing: 0
+                visible: _monitorEnabled
 
-        VehicleSummaryRow {
-            labelText:  qsTr("Batt2 monitor")
-            valueText:  _batt2MonitorAvailable ? _batt2Monitor.enumStringValue : ""
-            visible:    _batt2MonitorAvailable
-        }
+                property string _prefix:            battParams.prefixForIndex(index)
+                property string _label:             battParams.labelForIndex(index)
+                property Fact   _monitor:           controller.getParameterFact(-1, _prefix + "MONITOR")
+                property bool   _monitorEnabled:    _monitor.rawValue !== 0
+                property bool   _capacityAvailable: controller.parameterExists(-1, _prefix + "CAPACITY")
+                property Fact   _capacity:          _capacityAvailable ? controller.getParameterFact(-1, _prefix + "CAPACITY") : null
 
-        VehicleSummaryRow {
-            labelText:  qsTr("Batt2 capacity")
-            valueText:  _batt2MonitorEnabled ? _batt2Capacity.valueString + " " + _batt2Capacity.units : ""
-            visible:    _batt2MonitorEnabled
+                VehicleSummaryRow {
+                    labelText: qsTr("Batt%1 monitor").arg(_label)
+                    valueText: _monitor.enumStringValue
+                }
+
+                VehicleSummaryRow {
+                    labelText: qsTr("Batt%1 capacity").arg(_label)
+                    valueText: _capacity ? _capacity.valueString + " " + _capacity.units : ""
+                    visible:   _capacityAvailable
+                }
+            }
         }
     }
 }

--- a/src/AutoPilotPlugins/Common/CMakeLists.txt
+++ b/src/AutoPilotPlugins/Common/CMakeLists.txt
@@ -15,6 +15,8 @@ target_sources(${CMAKE_PROJECT_NAME}
         MotorComponent.h
         JoystickComponent.cc
         JoystickComponent.h
+        PowerModulePresetController.cc
+        PowerModulePresetController.h
         RadioComponentController.cc
         RadioComponentController.h
         SyslinkComponent.cc
@@ -43,4 +45,12 @@ qt_add_qml_module(AutoPilotPluginsCommonModule
         RadioComponent.qml
         SyslinkComponent.qml
     NO_PLUGIN
+)
+
+# ----------------------------------------------------------------------------
+# Common AutoPilot Plugins Resources
+# ----------------------------------------------------------------------------
+qt_add_resources(${CMAKE_PROJECT_NAME} autopilot_plugin_common_resource
+    PREFIX "/json"
+    FILES PowerModulePresets.json
 )

--- a/src/AutoPilotPlugins/Common/PowerModulePresetController.cc
+++ b/src/AutoPilotPlugins/Common/PowerModulePresetController.cc
@@ -1,0 +1,60 @@
+#include "PowerModulePresetController.h"
+#include "JsonHelper.h"
+#include "QGCLoggingCategory.h"
+
+#include <QtCore/QJsonArray>
+#include <QtCore/QJsonObject>
+
+QGC_LOGGING_CATEGORY(PowerModulePresetControllerLog, "AutoPilotPlugins.PowerModulePresetController")
+
+PowerModulePresetController::PowerModulePresetController(QObject *parent)
+    : FactPanelController(parent)
+{
+}
+
+QVariantList PowerModulePresetController::powerModulePresets() const
+{
+    int version;
+    QString errorString;
+    const QJsonObject root = JsonHelper::openInternalQGCJsonFile(
+        QStringLiteral(":/json/PowerModulePresets.json"),
+        QStringLiteral("PowerModulePresets"), 1, 1, version, errorString);
+    if (root.isEmpty()) {
+        qCCritical(PowerModulePresetControllerLog) << errorString;
+        return {};
+    }
+
+    if (!root.value(QStringLiteral("powerModules")).isArray()) {
+        qCCritical(PowerModulePresetControllerLog) << "Missing or invalid 'powerModules' array";
+        return {};
+    }
+
+    static const QList<JsonHelper::KeyValidateInfo> keyInfo = {
+        { "name",       QJsonValue::String, true },
+        { "voltMult",   QJsonValue::Double, true },
+        { "ampPerVolt", QJsonValue::Double, true },
+        { "ampOffset",  QJsonValue::Double, true },
+    };
+
+    const QJsonArray modules = root.value(QStringLiteral("powerModules")).toArray();
+    QVariantList result;
+    result.reserve(modules.size());
+
+    for (int i = 0; i < modules.size(); ++i) {
+        if (!modules.at(i).isObject()) {
+            qCCritical(PowerModulePresetControllerLog) << "powerModules[" << i << "] is not an object";
+            return {};
+        }
+        const QJsonObject obj = modules.at(i).toObject();
+
+        errorString.clear();
+        if (!JsonHelper::validateKeysStrict(obj, keyInfo, errorString)) {
+            qCCritical(PowerModulePresetControllerLog) << "powerModules[" << i << "]:" << errorString;
+            return {};
+        }
+
+        result.append(obj.toVariantMap());
+    }
+
+    return result;
+}

--- a/src/AutoPilotPlugins/Common/PowerModulePresetController.h
+++ b/src/AutoPilotPlugins/Common/PowerModulePresetController.h
@@ -1,0 +1,21 @@
+#pragma once
+
+#include <QtCore/QLoggingCategory>
+#include <QtCore/QVariantList>
+#include <QtQmlIntegration/QtQmlIntegration>
+
+#include "FactPanelController.h"
+
+Q_DECLARE_LOGGING_CATEGORY(PowerModulePresetControllerLog)
+
+class PowerModulePresetController : public FactPanelController
+{
+    Q_OBJECT
+    QML_ELEMENT
+
+public:
+    explicit PowerModulePresetController(QObject *parent = nullptr);
+    ~PowerModulePresetController() override = default;
+
+    Q_INVOKABLE QVariantList powerModulePresets() const;
+};

--- a/src/AutoPilotPlugins/Common/PowerModulePresets.json
+++ b/src/AutoPilotPlugins/Common/PowerModulePresets.json
@@ -1,0 +1,54 @@
+{
+    "fileType": "PowerModulePresets",
+    "version": 1,
+    "powerModules": [
+        {
+            "name":       "3DR/Pixhawk Power Module",
+            "voltMult":   10.1,
+            "ampPerVolt": 17.0,
+            "ampOffset":  0
+        },
+        {
+            "name":       "Cube HV Power Module",
+            "voltMult":   12.02,
+            "ampPerVolt": 39.877,
+            "ampOffset":  0
+        },
+        {
+            "name":       "CUAV HV PM",
+            "voltMult":   18.0,
+            "ampPerVolt": 24.0,
+            "ampOffset":  0
+        },
+        {
+            "name":       "Holybro PM02/PM06/PM07",
+            "voltMult":   18.182,
+            "ampPerVolt": 36.364,
+            "ampOffset":  0
+        },
+        {
+            "name":       "Holybro PM08",
+            "voltMult":   18.182,
+            "ampPerVolt": 72.0,
+            "ampOffset":  0
+        },
+        {
+            "name":       "Matek H743/H7A3/F765-SE",
+            "voltMult":   21.0,
+            "ampPerVolt": 40.0,
+            "ampOffset":  0
+        },
+        {
+            "name":       "Blue Robotics Power Sense Module",
+            "voltMult":   11.0,
+            "ampPerVolt": 37.8788,
+            "ampOffset":  0.33
+        },
+        {
+            "name":       "Navigator w/ Blue Robotics PSM",
+            "voltMult":   11.0,
+            "ampPerVolt": 37.8788,
+            "ampOffset":  0.33
+        }
+    ]
+}

--- a/src/FactSystem/FactControls/FactComboBox.qml
+++ b/src/FactSystem/FactControls/FactComboBox.qml
@@ -12,15 +12,26 @@ QGCComboBox {
 
     currentIndex: fact ? (indexModel ? fact.value : fact.enumIndex) : 0
 
-    onModelChanged: {
-        // When the model changes, the index gets reset to 0, so make sure to
-        // restore it correctly.
-        // Since enumIndex could trigger a model change, we use callLater() to
-        // avoid an event binding loop (the 2. call will for certain not trigger
-        // another model change)
+    function _updateCurrentIndex() {
         Qt.callLater(function() {
-            currentIndex = fact ? (indexModel ? fact.value : fact.enumIndex) : 0
+            currentIndex = Qt.binding(function() {
+                return fact ? (indexModel ? fact.value : fact.enumIndex) : 0
+            })
         })
+    }
+
+    onModelChanged: {
+        // When the model changes, the index gets reset to 0, so re-establish
+        // the declarative currentIndex binding. callLater() avoids a binding
+        // loop since enumIndex could trigger a model change.
+        _updateCurrentIndex()
+    }
+
+    onFactChanged: {
+        // When the fact changes to a different Fact object with the same
+        // enumStrings, modelChanged does not fire, so the binding must be
+        // re-established here to point at the new Fact.
+        _updateCurrentIndex()
     }
 
     onActivated: (index) => {

--- a/src/QmlControls/QGCComboBox.qml
+++ b/src/QmlControls/QGCComboBox.qml
@@ -45,10 +45,10 @@ T.ComboBox {
     }
 
     function _calcPopupWidth() {
-        if (_onCompleted && sizeToContents && model) {
+        if (_onCompleted && sizeToContents && control.count > 0) {
             _largestTextWidth = 0
-            for (var i = 0; i < model.length; i++){
-                textMetrics.text = control.textRole ? model[i][control.textRole] : model[i]
+            for (let i = 0; i < control.count; i++) {
+                textMetrics.text = control.textAt(i)
                 _largestTextWidth = Math.max(textMetrics.width, _largestTextWidth)
             }
             _popupWidth = _largestTextWidth + itemDelegateMetrics.leftPadding + itemDelegateMetrics.rightPadding
@@ -56,6 +56,7 @@ T.ComboBox {
     }
 
     onModelChanged: _calcPopupWidth()
+    onCountChanged: _calcPopupWidth()
 
     Component.onCompleted: {
         _onCompleted = true
@@ -107,6 +108,7 @@ T.ComboBox {
         text: control.alternateText === "" ? control.currentText : control.alternateText
         font: control.font
         color: qgcPal.buttonText
+        elide: Text.ElideRight
     }
 
     background: Rectangle {

--- a/src/Utilities/JsonHelper.cc
+++ b/src/Utilities/JsonHelper.cc
@@ -6,6 +6,7 @@
 #include <QtCore/QJsonArray>
 #include <QtCore/QJsonParseError>
 #include <QtCore/QObject>
+#include <QtCore/QSet>
 #include <QtCore/QTranslator>
 
 #include "FactMetaData.h"
@@ -363,6 +364,29 @@ bool JsonHelper::validateKeys(const QJsonObject& jsonObject, const QList<JsonHel
     }
 
     return JsonParsing::validateKeyTypes(jsonObject, keyList, typeList, errorString);
+}
+
+bool JsonHelper::validateKeysStrict(const QJsonObject& jsonObject, const QList<JsonHelper::KeyValidateInfo>& keyInfo,
+                                    QString& errorString)
+{
+    if (!validateKeys(jsonObject, keyInfo, errorString)) {
+        return false;
+    }
+
+    QSet<QString> expectedKeys;
+    expectedKeys.reserve(keyInfo.size());
+    for (const KeyValidateInfo &info : keyInfo) {
+        expectedKeys.insert(QLatin1String(info.key));
+    }
+
+    for (const QString &key : jsonObject.keys()) {
+        if (!expectedKeys.contains(key)) {
+            errorString = QStringLiteral("Unknown key: %1").arg(key);
+            return false;
+        }
+    }
+
+    return true;
 }
 
 bool JsonHelper::loadPolygon(const QJsonArray& polygonArray, QmlObjectListModel& list, QObject* parent,

--- a/src/Utilities/JsonHelper.h
+++ b/src/Utilities/JsonHelper.h
@@ -61,6 +61,10 @@ namespace JsonHelper
 
     bool validateKeys(const QJsonObject& jsonObject, const QList<KeyValidateInfo>& keyInfo, QString& errorString);
 
+    /// Validates keys like validateKeys but also rejects any keys not listed in keyInfo.
+    /// @return false: validation failed, errorString set
+    bool validateKeysStrict(const QJsonObject& jsonObject, const QList<KeyValidateInfo>& keyInfo, QString& errorString);
+
     /// Loads a QGeoCoordinate
     ///     Stored as array [ lat, lon, alt ]
     /// @return false: validation failed

--- a/test/Utilities/Parsing/Json/JsonHelperTest.cc
+++ b/test/Utilities/Parsing/Json/JsonHelperTest.cc
@@ -130,6 +130,58 @@ void JsonHelperTest::_validateKeysWrongType_test()
     QVERIFY(!errorString.isEmpty());
 }
 
+void JsonHelperTest::_validateKeysStrictValid_test()
+{
+    const QJsonObject obj = {
+        {"name", "test"},
+        {"count", 42},
+    };
+
+    const QList<JsonHelper::KeyValidateInfo> keyInfo = {
+        {"name", QJsonValue::String, true},
+        {"count", QJsonValue::Double, true},
+    };
+
+    QString errorString;
+    QVERIFY(JsonHelper::validateKeysStrict(obj, keyInfo, errorString));
+    QVERIFY(errorString.isEmpty());
+}
+
+void JsonHelperTest::_validateKeysStrictUnknownKey_test()
+{
+    const QJsonObject obj = {
+        {"name", "test"},
+        {"count", 42},
+        {"extra", true},
+    };
+
+    const QList<JsonHelper::KeyValidateInfo> keyInfo = {
+        {"name", QJsonValue::String, true},
+        {"count", QJsonValue::Double, true},
+    };
+
+    QString errorString;
+    QVERIFY(!JsonHelper::validateKeysStrict(obj, keyInfo, errorString));
+    QVERIFY(errorString.contains("Unknown key"));
+    QVERIFY(errorString.contains("extra"));
+}
+
+void JsonHelperTest::_validateKeysStrictMissingRequired_test()
+{
+    const QJsonObject obj = {
+        {"name", "test"},
+    };
+
+    const QList<JsonHelper::KeyValidateInfo> keyInfo = {
+        {"name", QJsonValue::String, true},
+        {"count", QJsonValue::Double, true},
+    };
+
+    QString errorString;
+    QVERIFY(!JsonHelper::validateKeysStrict(obj, keyInfo, errorString));
+    QVERIFY(!errorString.isEmpty());
+}
+
 void JsonHelperTest::_loadSaveGeoCoordinate_test()
 {
     const QGeoCoordinate original(47.3764, 8.5481);

--- a/test/Utilities/Parsing/Json/JsonHelperTest.h
+++ b/test/Utilities/Parsing/Json/JsonHelperTest.h
@@ -16,6 +16,9 @@ private slots:
     void _validateKeysRequired_test();
     void _validateKeysOptional_test();
     void _validateKeysWrongType_test();
+    void _validateKeysStrictValid_test();
+    void _validateKeysStrictUnknownKey_test();
+    void _validateKeysStrictMissingRequired_test();
     void _loadSaveGeoCoordinate_test();
     void _loadSaveGeoCoordinateWithAltitude_test();
     void _loadSaveGeoCoordinateGeoJson_test();


### PR DESCRIPTION
## Summary
- Add `PowerModulePresetController` that loads power module presets from a JSON resource file, replacing hardcoded `ListElement` entries
- Show voltage/current calibration fields only when the battery monitor type has the corresponding analog sensor, instead of always showing behind a generic "Advanced" toggle
- Move battery telemetry resolution into the Calculate dialogs themselves, with a warning when telemetry is unavailable
- Fix `FactComboBox` stale currentIndex when switching between Facts with identical enum sets
- Fix `QGCComboBox` popup width calculation to work correctly with `ListModel` sources
- Add `JsonHelper::validateKeysStrict` for strict JSON key validation with tests
- Add popular power module presets: 3DR/Pixhawk, Holybro PM08, Matek H743/H7A3

## Test plan
- [X] Connect to vehicle, open Power page — verify battery selector and monitor combo work
- [X] Change battery monitor type to an analog voltage+current type — verify sensor preset combo, voltage multiplier, and amps per volt fields appear
- [X] Change battery monitor type to a non-analog type — verify calibration fields are hidden
- [X] Select different power module presets — verify voltMult/ampPerVolt/ampOffset are applied
- [X] Click Calculate on voltage multiplier — verify telemetry warning appears if no battery telemetry
- [X] Switch between battery slots — verify FactComboBox updates correctly
- [X] Run JsonHelperTest — verify validateKeysStrict tests pass