### PR TITLE
fix(AnalyzeView): use full path for deduplicated onboard log downloads

### DIFF
--- a/src/AnalyzeView/OnboardLogs/OnboardLogController.cc
+++ b/src/AnalyzeView/OnboardLogs/OnboardLogController.cc
@@ -409,7 +409,7 @@ bool OnboardLogController::_prepareLogDownload()
         do {
             numDups += 1;
             const QString filename = filename_spl[0] + '_' + QString::number(numDups) + '.' + filename_spl[1];
-            _downloadData->file.setFileName(filename);
+            _downloadData->file.setFileName(_downloadPath + filename);
         } while ( _downloadData->file.exists());
     }
 


### PR DESCRIPTION
## Summary
- When a downloaded onboard log filename already exists, the deduplication loop constructed a new filename without prepending the download directory path, causing files to be written to the working directory instead of the configured save location.

## Test plan
- [ ] Download an onboard log to a configured directory
- [ ] Download the same log again — verify the deduplicated file lands in the same directory, not `~/`

🤖 Generated with [Claude Code](https://claude.com/claude-code)