### PR TITLE
fix(AnalyzeView): Fix onboard log download path and refactor controller

### DIFF
--- a/src/AnalyzeView/OnboardLogs/OnboardLogController.cc
+++ b/src/AnalyzeView/OnboardLogs/OnboardLogController.cc
@@ -56,9 +56,9 @@ void OnboardLogController::_downloadToDirectory(const QString &dir)
         _downloadPath += QDir::separator();
     }
 
-    QGCOnboardLogEntry *const log = _getNextSelected();
-    if (log) {
-        log->setStatus(tr("Waiting"));
+    if (!QDir().mkpath(_downloadPath)) {
+        qCWarning(OnboardLogControllerLog) << "Failed to create download directory:" << _downloadPath;
+        return;
     }
 
     _setDownloading(true);
@@ -101,7 +101,7 @@ void OnboardLogController::_findMissingEntries()
         return;
     }
 
-    if (_retries++ > 2) {
+    if (_retries++ > kMaxEntryRetries) {
         for (int i = 0; i < num_logs; i++) {
             QGCOnboardLogEntry *const entry = _logEntriesModel->value<QGCOnboardLogEntry*>(i);
             if (entry && !entry->received()) {
@@ -110,7 +110,7 @@ void OnboardLogController::_findMissingEntries()
         }
 
         _receivedAllEntries();
-        qCWarning(OnboardLogControllerLog) << "Too many errors retreiving log list. Giving up.";
+        qCWarning(OnboardLogControllerLog) << "Too many errors retrieving log list. Giving up.";
         return;
     }
 
@@ -230,59 +230,53 @@ void OnboardLogController::_logData(uint32_t ofs, uint16_t id, uint8_t count, co
         return;
     }
 
-    bool result = false;
-    if (ofs <= _downloadData->entry->size()) {
-        const uint32_t chunk = ofs / OnboardLogDownloadData::kChunkSize;
-        // qCDebug(OnboardLogControllerLog) << "Received data - Offset:" << ofs << "Chunk:" << chunk;
-        if (chunk != _downloadData->current_chunk) {
-            qCWarning(OnboardLogControllerLog) << "Ignored packet for out of order chunk actual:expected" << chunk << _downloadData->current_chunk;
-            return;
-        }
-
-        const uint16_t bin = (ofs - (chunk * OnboardLogDownloadData::kChunkSize)) / MAVLINK_MSG_LOG_DATA_FIELD_DATA_LEN;
-        if (bin >= _downloadData->chunk_table.size()) {
-            qCWarning(OnboardLogControllerLog) << "Out of range bin received";
-        } else {
-            _downloadData->chunk_table.setBit(bin);
-        }
-
-        if (_downloadData->file.pos() != ofs) {
-            if (!_downloadData->file.seek(ofs)) {
-                qCWarning(OnboardLogControllerLog) << "Error while seeking log file offset";
-                return;
-            }
-        }
-
-        if (_downloadData->file.write(reinterpret_cast<const char*>(data), count)) {
-            _downloadData->written += count;
-            _downloadData->rate_bytes += count;
-            _updateDataRate();
-
-            result = true;
-            _retries = 0;
-
-            _timer->start(kTimeOutMs);
-            if (_logComplete()) {
-                _downloadData->entry->setStatus(tr("Downloaded"));
-                _receivedAllData();
-            } else if (_chunkComplete()) {
-                _downloadData->advanceChunk();
-                _requestLogData(_downloadData->ID,
-                                _downloadData->current_chunk * OnboardLogDownloadData::kChunkSize,
-                                _downloadData->chunk_table.size() * MAVLINK_MSG_LOG_DATA_FIELD_DATA_LEN);
-            } else if ((bin < (_downloadData->chunk_table.size() - 1)) && _downloadData->chunk_table.at(bin + 1)) {
-                // Likely to be grabbing fragments and got to the end of a gap
-                _findMissingData();
-            }
-        } else {
-            qCWarning(OnboardLogControllerLog) << "Error while writing log file chunk";
-        }
-    } else {
+    if (ofs > _downloadData->entry->size()) {
         qCWarning(OnboardLogControllerLog) << "Received log offset greater than expected";
+        _abortDownload();
+        return;
     }
 
-    if (!result) {
-        _downloadData->entry->setStatus(tr("Error"));
+    const uint32_t chunk = ofs / OnboardLogDownloadData::kChunkSize;
+    if (chunk != _downloadData->current_chunk) {
+        qCWarning(OnboardLogControllerLog) << "Ignored packet for out of order chunk actual:expected" << chunk << _downloadData->current_chunk;
+        return;
+    }
+
+    const uint16_t bin = (ofs - (chunk * OnboardLogDownloadData::kChunkSize)) / MAVLINK_MSG_LOG_DATA_FIELD_DATA_LEN;
+    if (bin >= _downloadData->chunk_table.size()) {
+        qCWarning(OnboardLogControllerLog) << "Out of range bin received";
+    } else {
+        _downloadData->chunk_table.setBit(bin);
+    }
+
+    if ((_downloadData->file.pos() != ofs) && !_downloadData->file.seek(ofs)) {
+        qCWarning(OnboardLogControllerLog) << "Error while seeking log file offset";
+        _abortDownload();
+        return;
+    }
+
+    if (!_downloadData->file.write(reinterpret_cast<const char*>(data), count)) {
+        qCWarning(OnboardLogControllerLog) << "Error while writing log file chunk";
+        _abortDownload();
+        return;
+    }
+
+    _downloadData->written += count;
+    _downloadData->rate_bytes += count;
+    _updateDataRate();
+    _retries = 0;
+    _timer->start(kTimeOutMs);
+
+    if (_logComplete()) {
+        _downloadData->entry->setStatus(tr("Downloaded"));
+        _receivedAllData();
+    } else if (_chunkComplete()) {
+        _downloadData->advanceChunk();
+        _requestLogData(_downloadData->ID,
+                        _downloadData->current_chunk * OnboardLogDownloadData::kChunkSize,
+                        _downloadData->chunk_table.size() * MAVLINK_MSG_LOG_DATA_FIELD_DATA_LEN);
+    } else if ((bin < (_downloadData->chunk_table.size() - 1)) && _downloadData->chunk_table.at(bin + 1)) {
+        _findMissingData();
     }
 }
 
@@ -297,7 +291,11 @@ void OnboardLogController::_findMissingData()
         _downloadData->advanceChunk();
     }
 
-    _retries++;
+    if (_retries++ > kMaxDataRetries) {
+        qCWarning(OnboardLogControllerLog) << "Too many errors downloading log data. Giving up.";
+        _abortDownload();
+        return;
+    }
 
     _updateDataRate();
 
@@ -330,23 +328,15 @@ void OnboardLogController::_updateDataRate()
         return;
     }
 
-    QString status;
     if (timeThresholdMet) {
-        // Update both rate and size
         const qreal rate = _downloadData->rate_bytes / (_downloadData->elapsed.elapsed() / 1000.0);
         _downloadData->rate_avg = (_downloadData->rate_avg * 0.95) + (rate * 0.05);
         _downloadData->rate_bytes = 0;
-
-        status = QStringLiteral("%1 (%2/s)").arg(qgcApp()->bigSizeToString(_downloadData->written),
-                                                   qgcApp()->bigSizeToString(_downloadData->rate_avg));
         _downloadData->elapsed.start();
-    } else {
-        // Update size only, keep previous rate
-        status = QStringLiteral("%1 (%2/s)").arg(qgcApp()->bigSizeToString(_downloadData->written),
-                                                   qgcApp()->bigSizeToString(_downloadData->rate_avg));
     }
 
-    _downloadData->entry->setStatus(status);
+    _downloadData->entry->setStatus(QStringLiteral("%1 (%2/s)").arg(qgcApp()->bigSizeToString(_downloadData->written),
+                                                                     qgcApp()->bigSizeToString(_downloadData->rate_avg)));
     _downloadData->last_status_written = _downloadData->written;
 }
 
@@ -358,6 +348,25 @@ bool OnboardLogController::_chunkComplete() const
 bool OnboardLogController::_logComplete() const
 {
     return (_chunkComplete() && ((_downloadData->current_chunk + 1) == _downloadData->numChunks()));
+}
+
+void OnboardLogController::_abortDownload()
+{
+    _timer->stop();
+
+    if (_downloadData) {
+        _downloadData->entry->setStatus(tr("Error"));
+        if (_downloadData->file.isOpen()) {
+            _downloadData->file.close();
+        }
+        if (_downloadData->file.exists()) {
+            (void) _downloadData->file.remove();
+        }
+        _downloadData.reset();
+    }
+
+    _resetSelection(true);
+    _setDownloading(false);
 }
 
 void OnboardLogController::_receivedAllData()
@@ -415,9 +424,9 @@ bool OnboardLogController::_prepareLogDownload()
 
     bool result = false;
     if (!_downloadData->file.open(QIODevice::WriteOnly)) {
-        qCWarning(OnboardLogControllerLog) << "Failed to create log file:" <<  _downloadData->filename;
+        qCWarning(OnboardLogControllerLog) << "Failed to create log file:" << _downloadData->file.fileName();
     } else if (!_downloadData->file.resize(entry->size())) {
-        qCWarning(OnboardLogControllerLog) << "Failed to allocate space for log file:" <<  _downloadData->filename;
+        qCWarning(OnboardLogControllerLog) << "Failed to allocate space for log file:" << _downloadData->file.fileName();
     } else {
         _downloadData->current_chunk = 0;
         _downloadData->chunk_table = QBitArray(_downloadData->chunkBins(), false);
@@ -498,132 +507,71 @@ void OnboardLogController::_resetSelection(bool canceled)
     emit selectionChanged();
 }
 
-void OnboardLogController::eraseAll()
+template<typename PackFn>
+bool OnboardLogController::_sendMavlinkMessage(PackFn packFn)
 {
     if (!_vehicle) {
         qCWarning(OnboardLogControllerLog) << "Vehicle Unavailable";
-        return;
+        return false;
     }
 
     SharedLinkInterfacePtr sharedLink = _vehicle->vehicleLinkManager()->primaryLink().lock();
     if (!sharedLink) {
         qCWarning(OnboardLogControllerLog) << "Link Unavailable";
-        return;
+        return false;
     }
 
     mavlink_message_t msg{};
-    (void) mavlink_msg_log_erase_pack_chan(
-        MAVLinkProtocol::instance()->getSystemId(),
-        MAVLinkProtocol::getComponentId(),
-        sharedLink->mavlinkChannel(),
-        &msg,
-        _vehicle->id(),
-        _vehicle->defaultComponentId()
-    );
+    packFn(MAVLinkProtocol::instance()->getSystemId(),
+           MAVLinkProtocol::getComponentId(),
+           sharedLink->mavlinkChannel(),
+           &msg,
+           _vehicle->id(),
+           _vehicle->defaultComponentId());
 
     if (!_vehicle->sendMessageOnLinkThreadSafe(sharedLink.get(), msg)) {
         qCWarning(OnboardLogControllerLog) << "Failed to send";
-        return;
+        return false;
     }
 
-    refresh();
+    return true;
+}
+
+void OnboardLogController::eraseAll()
+{
+    if (_sendMavlinkMessage([](uint8_t sysid, uint8_t compid, uint8_t chan, mavlink_message_t *msg, uint8_t tgt_sys, uint8_t tgt_comp) {
+            (void) mavlink_msg_log_erase_pack_chan(sysid, compid, chan, msg, tgt_sys, tgt_comp);
+        })) {
+        refresh();
+    }
 }
 
 void OnboardLogController::_requestLogList(uint32_t start, uint32_t end)
 {
-    if (!_vehicle) {
-        qCWarning(OnboardLogControllerLog) << "Vehicle Unavailable";
-        return;
+    if (_sendMavlinkMessage([start, end](uint8_t sysid, uint8_t compid, uint8_t chan, mavlink_message_t *msg, uint8_t tgt_sys, uint8_t tgt_comp) {
+            (void) mavlink_msg_log_request_list_pack_chan(sysid, compid, chan, msg, tgt_sys, tgt_comp, start, end);
+        })) {
+        qCDebug(OnboardLogControllerLog) << "Request onboard log entry list (" << start << "through" << end << ")";
+        _setListing(true);
+        _timer->start(kRequestLogListTimeoutMs);
     }
-
-    SharedLinkInterfacePtr sharedLink = _vehicle->vehicleLinkManager()->primaryLink().lock();
-    if (!sharedLink) {
-        qCWarning(OnboardLogControllerLog) << "Link Unavailable";
-        return;
-    }
-
-    mavlink_message_t msg{};
-    (void) mavlink_msg_log_request_list_pack_chan(
-        MAVLinkProtocol::instance()->getSystemId(),
-        MAVLinkProtocol::getComponentId(),
-        sharedLink->mavlinkChannel(),
-        &msg,
-        _vehicle->id(),
-        _vehicle->defaultComponentId(),
-        start,
-        end
-    );
-
-    if (!_vehicle->sendMessageOnLinkThreadSafe(sharedLink.get(), msg)) {
-        qCWarning(OnboardLogControllerLog) << "Failed to send";
-        return;
-    }
-
-    qCDebug(OnboardLogControllerLog) << "Request onboard log entry list (" << start << "through" << end << ")";
-    _setListing(true);
-    _timer->start(kRequestLogListTimeoutMs);
 }
 
 void OnboardLogController::_requestLogData(uint16_t id, uint32_t offset, uint32_t count, int retryCount)
 {
-    if (!_vehicle) {
-        qCWarning(OnboardLogControllerLog) << "Vehicle Unavailable";
-        return;
-    }
+    const uint16_t mavId = id + _apmOffset;
+    qCDebug(OnboardLogControllerLog) << "Request log data (id:" << mavId << "offset:" << offset << "size:" << count << "retryCount" << retryCount << ")";
 
-    SharedLinkInterfacePtr sharedLink = _vehicle->vehicleLinkManager()->primaryLink().lock();
-    if (!sharedLink) {
-        qCWarning(OnboardLogControllerLog) << "Link Unavailable";
-        return;
-    }
-
-    id += _apmOffset;
-    qCDebug(OnboardLogControllerLog) << "Request log data (id:" << id << "offset:" << offset << "size:" << count << "retryCount" << retryCount << ")";
-
-    mavlink_message_t msg{};
-    (void) mavlink_msg_log_request_data_pack_chan(
-        MAVLinkProtocol::instance()->getSystemId(),
-        MAVLinkProtocol::getComponentId(),
-        sharedLink->mavlinkChannel(),
-        &msg,
-        _vehicle->id(),
-        _vehicle->defaultComponentId(),
-        id,
-        offset,
-        count
-    );
-
-    if (!_vehicle->sendMessageOnLinkThreadSafe(sharedLink.get(), msg)) {
-        qCWarning(OnboardLogControllerLog) << "Failed to send";
-    }
+    _sendMavlinkMessage([mavId, offset, count](uint8_t sysid, uint8_t compid, uint8_t chan, mavlink_message_t *msg, uint8_t tgt_sys, uint8_t tgt_comp) {
+        (void) mavlink_msg_log_request_data_pack_chan(sysid, compid, chan, msg, tgt_sys, tgt_comp, mavId, offset, count);
+    });
 }
 
 void OnboardLogController::_requestLogEnd()
 {
-    if (!_vehicle) {
-        qCWarning(OnboardLogControllerLog) << "Vehicle Unavailable";
-        return;
-    }
-
-    SharedLinkInterfacePtr sharedLink = _vehicle->vehicleLinkManager()->primaryLink().lock();
-    if (!sharedLink) {
-        qCWarning(OnboardLogControllerLog) << "Link Unavailable";
-        return;
-    }
-
-    mavlink_message_t msg{};
-    (void) mavlink_msg_log_request_end_pack_chan(
-        MAVLinkProtocol::instance()->getSystemId(),
-        MAVLinkProtocol::getComponentId(),
-        sharedLink->mavlinkChannel(),
-        &msg,
-        _vehicle->id(),
-        _vehicle->defaultComponentId()
-    );
-
-    if (!_vehicle->sendMessageOnLinkThreadSafe(sharedLink.get(), msg)) {
-        qCWarning(OnboardLogControllerLog) << "Failed to send";
-    }
+    _sendMavlinkMessage([](uint8_t sysid, uint8_t compid, uint8_t chan, mavlink_message_t *msg, uint8_t tgt_sys, uint8_t tgt_comp) {
+        (void) mavlink_msg_log_request_end_pack_chan(sysid, compid, chan, msg, tgt_sys, tgt_comp);
+    });
 }
 
 void OnboardLogController::_setDownloading(bool active)
@@ -644,34 +592,3 @@ void OnboardLogController::_setListing(bool active)
     }
 }
 
-void OnboardLogController::setCompressLogs(bool compress)
-{
-    if (_compressLogs != compress) {
-        _compressLogs = compress;
-        emit compressLogsChanged();
-    }
-}
-
-bool OnboardLogController::compressLogFile(const QString &logPath)
-{
-    Q_UNUSED(logPath)
-    qCWarning(OnboardLogControllerLog) << "Log compression not yet implemented (decompression-only API)";
-    return false;
-}
-
-void OnboardLogController::cancelCompression()
-{
-    // Not implemented - compression API is decompression-only
-}
-
-void OnboardLogController::_handleCompressionProgress(qreal progress)
-{
-    Q_UNUSED(progress)
-    // Not implemented - compression API is decompression-only
-}
-
-void OnboardLogController::_handleCompressionFinished(bool success)
-{
-    Q_UNUSED(success)
-    // Not implemented - compression API is decompression-only
-}

--- a/src/AnalyzeView/OnboardLogs/OnboardLogController.h
+++ b/src/AnalyzeView/OnboardLogs/OnboardLogController.h
@@ -10,7 +10,6 @@ struct OnboardLogDownloadData;
 class QGCOnboardLogEntry;
 class QmlObjectListModel;
 class QTimer;
-class QThread;
 class Vehicle;
 class OnboardLogDownloadTest;
 
@@ -24,9 +23,6 @@ class OnboardLogController : public QObject
     Q_PROPERTY(QmlObjectListModel *model          READ _getModel            CONSTANT)
     Q_PROPERTY(bool               requestingList  READ _getRequestingList   NOTIFY requestingListChanged)
     Q_PROPERTY(bool               downloadingLogs READ _getDownloadingLogs  NOTIFY downloadingLogsChanged)
-    Q_PROPERTY(bool               compressLogs    READ compressLogs         WRITE setCompressLogs NOTIFY compressLogsChanged)
-    Q_PROPERTY(bool               compressing     READ compressing          NOTIFY compressingChanged)
-    Q_PROPERTY(float              compressionProgress READ compressionProgress NOTIFY compressionProgressChanged)
 
     friend class OnboardLogDownloadTest;
 
@@ -39,33 +35,16 @@ public:
     Q_INVOKABLE void eraseAll();
     Q_INVOKABLE void cancel();
 
-    bool compressLogs() const { return _compressLogs; }
-    void setCompressLogs(bool compress);
-    bool compressing() const { return _compressing; }
-    float compressionProgress() const { return _compressionProgress; }
-
-    /// Compress a single log file
-    Q_INVOKABLE bool compressLogFile(const QString &logPath);
-
-    /// Cancel compression
-    Q_INVOKABLE void cancelCompression();
-
 signals:
     void requestingListChanged();
     void downloadingLogsChanged();
     void selectionChanged();
-    void compressLogsChanged();
-    void compressingChanged();
-    void compressionProgressChanged();
-    void compressionComplete(const QString &outputPath, const QString &error);
 
 private slots:
     void _setActiveVehicle(Vehicle *vehicle);
     void _logEntry(uint32_t time_utc, uint32_t size, uint16_t id, uint16_t num_logs, uint16_t last_log_num);
     void _logData(uint32_t ofs, uint16_t id, uint8_t count, const uint8_t *data);
     void _processDownload();
-    void _handleCompressionProgress(qreal progress);
-    void _handleCompressionFinished(bool success);
 
 private:
     QmlObjectListModel *_getModel() const { return _logEntriesModel; }
@@ -79,6 +58,7 @@ private:
     void _downloadToDirectory(const QString &dir);
     void _findMissingData();
     void _findMissingEntries();
+    void _abortDownload();
     void _receivedAllData();
     void _receivedAllEntries();
     void _requestLogData(uint16_t id, uint32_t offset, uint32_t count, int retryCount = 0);
@@ -91,6 +71,9 @@ private:
 
     QGCOnboardLogEntry *_getNextSelected() const;
 
+    template<typename PackFn>
+    bool _sendMavlinkMessage(PackFn packFn);
+
     QTimer *_timer = nullptr;
     QmlObjectListModel *_logEntriesModel = nullptr;
 
@@ -101,11 +84,10 @@ private:
     std::unique_ptr<OnboardLogDownloadData> _downloadData;
     QString _downloadPath;
     Vehicle *_vehicle = nullptr;
-    bool _compressLogs = false;
-    bool _compressing = false;
-    float _compressionProgress = 0.0F;
 
     static constexpr uint32_t kTimeOutMs = 500;
     static constexpr uint32_t kGUIRateMs = 500; ///< Update download rate twice per second
     static constexpr uint32_t kRequestLogListTimeoutMs = 5000;
+    static constexpr int kMaxEntryRetries = 2;
+    static constexpr int kMaxDataRetries = 5;
 };

--- a/src/AnalyzeView/OnboardLogs/OnboardLogEntry.cc
+++ b/src/AnalyzeView/OnboardLogs/OnboardLogEntry.cc
@@ -10,12 +10,12 @@ OnboardLogDownloadData::OnboardLogDownloadData(QGCOnboardLogEntry * const logEnt
     : ID(logEntry->id())
     , entry(logEntry)
 {
-    // qCDebug(OnboardLogEntryLog) << Q_FUNC_INFO << this;
+    qCDebug(OnboardLogEntryLog) << this;
 }
 
 OnboardLogDownloadData::~OnboardLogDownloadData()
 {
-    // qCDebug(OnboardLogEntryLog) << Q_FUNC_INFO << this;
+    qCDebug(OnboardLogEntryLog) << this;
 }
 
 void OnboardLogDownloadData::advanceChunk()
@@ -50,12 +50,12 @@ QGCOnboardLogEntry::QGCOnboardLogEntry(uint logId, const QDateTime &dateTime, ui
     , _logTimeUTC(dateTime)
     , _received(received)
 {
-    // qCDebug(OnboardLogEntryLog) << Q_FUNC_INFO << this;
+    qCDebug(OnboardLogEntryLog) << this;
 }
 
 QGCOnboardLogEntry::~QGCOnboardLogEntry()
 {
-    // qCDebug(OnboardLogEntryLog) << Q_FUNC_INFO << this;
+    qCDebug(OnboardLogEntryLog) << this;
 }
 
 QString QGCOnboardLogEntry::sizeStr() const

--- a/src/AnalyzeView/OnboardLogs/OnboardLogPage.qml
+++ b/src/AnalyzeView/OnboardLogs/OnboardLogPage.qml
@@ -1,7 +1,6 @@
 import QtQuick
 import QtQuick.Controls
 import QtQuick.Layouts
-import Qt.labs.qmlmodels
 
 import QGroundControl
 import QGroundControl.Controls
@@ -18,7 +17,11 @@ AnalyzePage {
             width: availableWidth
             height: availableHeight
 
-            Component.onCompleted: OnboardLogController.refresh()
+            Component.onCompleted: {
+                if (QGroundControl.multiVehicleManager.activeVehicle && !QGroundControl.multiVehicleManager.activeVehicle.isOfflineEditingVehicle) {
+                    OnboardLogController.refresh()
+                }
+            }
 
             QGCFlickable {
                 Layout.fillWidth: true
@@ -36,7 +39,12 @@ AnalyzePage {
 
                     QGCCheckBox {
                         id: headerCheckBox
-                        enabled: false
+                        enabled: OnboardLogController.model.count > 0
+                        onClicked: {
+                            for (var i = 0; i < OnboardLogController.model.count; i++) {
+                                OnboardLogController.model.get(i).selected = checked
+                            }
+                        }
                     }
 
                     Repeater {


### PR DESCRIPTION
## Summary

- **Fix download path bug**: Deduplicated filenames were missing the download directory prefix, causing onboard logs to download to the home directory instead of the user-selected path
- **Add data download retry limit**: `_findMissingData` could retry indefinitely; now bounded by `kMaxDataRetries`
- **Fix silent error on seek failure**: File seek failures now properly report "Error" status instead of silently returning
- **Extract MAVLink send helper**: Consolidated repeated vehicle/link null-check and message pack/send boilerplate into a `_sendMavlinkMessage` template
- **Flatten `_logData`**: Replaced deeply nested logic with early returns, removing the `result` flag pattern
- **Remove dead compression API**: Removed unimplemented `compressLogFile`, `cancelCompression`, and related stubs/properties/signals
- **Select-all checkbox**: Header checkbox now toggles selection on all log entries
- **Guard auto-refresh**: Page load no longer calls `refresh()` without an active vehicle
- **Minor**: Fix error log to print actual file path, ensure download directory exists via `mkpath`, name retry constants, fix typo, remove unused QML import, deduplicate status string formatting

## Test plan

- [ ] Connect to vehicle and navigate to Analyze > Onboard Logs
- [ ] Download a log — verify it lands in the selected directory
- [ ] Download the same log again — verify the deduplicated file also lands in the correct directory
- [ ] Use the header checkbox to select/deselect all logs
- [ ] Open the Onboard Logs page without a vehicle connected — verify no spurious warnings in console
- [ ] Cancel a download mid-transfer — verify partial file is cleaned up