### PR TITLE
APM config pages: UI consistency and bug fixes

### DIFF
--- a/src/AutoPilotPlugins/APM/APMAirframeComponent.qml
+++ b/src/AutoPilotPlugins/APM/APMAirframeComponent.qml
@@ -32,9 +32,9 @@ SetupPage {
             Component.onCompleted:  computeDimensions()
 
             function computeDimensions() {
-                var sw  = 0
-                var rw  = 0
-                var idx = Math.floor(mainColumn.width / (_minW + ScreenTools.defaultFontPixelWidth))
+                let sw  = 0
+                let rw  = 0
+                let idx = Math.floor(mainColumn.width / (_minW + ScreenTools.defaultFontPixelWidth))
                 if(idx < 1) {
                     _boxWidth = mainColumn.width
                     _boxSpace = 0
@@ -170,7 +170,7 @@ SetupPage {
                                     }
 
                                     function selectFrameType() {
-                                        var index = object.frameTypeEnumValues.findIndex(checkFrameType)
+                                        let index = object.frameTypeEnumValues.findIndex(checkFrameType)
                                         if (index == -1 && combo.visible) {
                                             // Frame Class/Type is set to an invalid combination
                                             combo.valid = false

--- a/src/AutoPilotPlugins/APM/APMESCComponent.qml
+++ b/src/AutoPilotPlugins/APM/APMESCComponent.qml
@@ -51,6 +51,7 @@ SetupPage {
 
             property string _restartRequired: qsTr("Requires vehicle reboot")
             property real _fieldWidth: ScreenTools.defaultFontPixelWidth * 15
+            property real _comboWidth: ScreenTools.defaultFontPixelWidth * 30
 
             QGCPalette { id: qgcPal; colorGroupEnabled: true }
 
@@ -65,6 +66,7 @@ SetupPage {
                         label: qsTr("Output type")
                         fact: _motPwmType
                         indexModel: false
+                        comboBoxPreferredWidth: _comboWidth
                     }
 
                     QGCLabel {
@@ -112,6 +114,7 @@ SetupPage {
                         label: qsTr("DShot ESC type")
                         fact: _servoDshotEsc
                         indexModel: false
+                        comboBoxPreferredWidth: _comboWidth
                         visible: _isDshot && _servoDshotEscAvailable
                     }
 
@@ -119,6 +122,7 @@ SetupPage {
                         label: qsTr("DShot output rate")
                         fact: _servoDshotRate
                         indexModel: false
+                        comboBoxPreferredWidth: _comboWidth
                         visible: _isDshot && _servoDshotRateAvailable
                     }
                 }

--- a/src/AutoPilotPlugins/APM/APMFlightModesComponent.qml
+++ b/src/AutoPilotPlugins/APM/APMFlightModesComponent.qml
@@ -15,6 +15,7 @@ SetupPage {
     readonly property var    _pwmStrings:       [ "PWM 0 - 1230", "PWM 1231 - 1360", "PWM 1361 - 1490", "PWM 1491 - 1620", "PWM 1621 - 1749", "PWM 1750 +"]
 
     property real   _margins:                   ScreenTools.defaultFontPixelHeight
+    property real   _comboWidth:                ScreenTools.defaultFontPixelWidth * 30
     property Fact   _nullFact
     property bool   _fltmodeChExists:           controller.parameterExists(-1, _modeChannelParam)
     property Fact   _fltmodeCh:                 _fltmodeChExists ? controller.getParameterFact(-1, _modeChannelParam) : _nullFact
@@ -37,27 +38,11 @@ SetupPage {
             width:      availableWidth
             spacing:     _margins
 
-            Column {
-                spacing: _margins
+            QGCGroupBox {
+                title: qsTr("Flight Mode Settings") + (_fltmodeChExists ? "" : qsTr(" (Channel 5)"))
 
-                QGCLabel {
-                    id:             flightModeLabel
-                    text:           qsTr("Flight Mode Settings") + (_fltmodeChExists ? "" : qsTr(" (Channel 5)"))
-                    font.bold:      true
-                }
-
-                Rectangle {
-                    id:     flightModeSettings
-                    width:  flightModeColumn.width + (_margins * 2)
-                    height: flightModeColumn.height + ScreenTools.defaultFontPixelHeight
-                    color:  qgcPal.windowShade
-
-                    Column {
-                        id:                 flightModeColumn
-                        anchors.margins:    ScreenTools.defaultFontPixelWidth
-                        anchors.left:       parent.left
-                        anchors.top:        parent.top
-                        spacing:            ScreenTools.defaultFontPixelHeight
+                ColumnLayout {
+                    spacing: ScreenTools.defaultFontPixelHeight
 
                         Row {
                             spacing:    _margins
@@ -70,8 +55,9 @@ SetupPage {
                             }
 
                             QGCComboBox {
-                                id:             modeChannelCombo
-                                width:          ScreenTools.defaultFontPixelWidth * 15
+                                id:              modeChannelCombo
+                                sizeToContents:  true
+                                Layout.maximumWidth: _comboWidth
                                 model:          [ qsTr("Not assigned"), qsTr("Channel 1"), qsTr("Channel 2"),
                                     qsTr("Channel 3"),    qsTr("Channel 4"), qsTr("Channel 5"),
                                     qsTr("Channel 6"),    qsTr("Channel 7"), qsTr("Channel 8") ]
@@ -102,7 +88,8 @@ SetupPage {
                                 model:  6
 
                                 FactComboBox {
-                                    Layout.preferredWidth:  ScreenTools.defaultFontPixelWidth * 15
+                                    sizeToContents:         true
+                                    Layout.maximumWidth:    _comboWidth
                                     fact:                   controller.getParameterFact(-1, _modeParamPrefix + index)
                                     indexModel:             false
 
@@ -160,31 +147,14 @@ SetupPage {
                                 onActivated: (index) => { controller.simpleMode = index }
                             }
                         }
-                    } // Column - Flight Modes
-                } // Rectangle - Flight Modes
-            } // Column - Flight Modes
+                } // ColumnLayout
+            } // QGCGroupBox - Flight Modes
 
-            Column {
-                spacing: _margins
+            QGCGroupBox {
+                title: qsTr("Switch Options")
 
-                QGCLabel {
-                    id:                 channelOptionsLabel
-                    text:               qsTr("Switch Options")
-                    font.bold:          true
-                }
-
-                Rectangle {
-                    id:     channelOptionsSettings
-                    width:  channelOptColumn.width + (_margins * 2)
-                    height: channelOptColumn.height + ScreenTools.defaultFontPixelHeight
-                    color:  qgcPal.windowShade
-
-                    Column {
-                        id:                 channelOptColumn
-                        anchors.margins:    ScreenTools.defaultFontPixelWidth
-                        anchors.left:       parent.left
-                        anchors.top:        parent.top
-                        spacing:            ScreenTools.defaultFontPixelHeight
+                ColumnLayout {
+                    spacing: ScreenTools.defaultFontPixelHeight
 
                         Repeater {
                             model: _rcOptionStop - _rcOptionStart + 1
@@ -202,16 +172,16 @@ SetupPage {
                                 }
 
                                 FactComboBox {
-                                    id:         optCombo
-                                    width:      ScreenTools.defaultFontPixelWidth * 15
+                                    id:              optCombo
+                                    sizeToContents:  true
+                                    Layout.maximumWidth: _comboWidth
                                     fact:       controller.getParameterFact(-1, "RC" + index + "_OPTION")
                                     indexModel: false
                                 }
                             }
                         } // Repeater -- Channel options
-                    } // Column - Channel options
-                } // Rectangle - Channel options
-            } // Column - Channel options
+                } // ColumnLayout
+            } // QGCGroupBox - Channel options
         } // Flow
     } // Component - flightModePageComponent
 } // SetupPage

--- a/src/AutoPilotPlugins/APM/APMFollowComponent.qml
+++ b/src/AutoPilotPlugins/APM/APMFollowComponent.qml
@@ -40,6 +40,8 @@ SetupPage {
             property bool _roverFirmware:               controller.roverFirmware
             property bool _showMainSetup:               _followEnabled.rawValue == 1 && _supportedSetup
             property bool _showOffsetsSetup:            _showMainSetup && !_followMaintain
+            property real _textFieldWidth:              ScreenTools.defaultFontPixelWidth * 15
+            property real _comboWidth:                  ScreenTools.defaultFontPixelWidth * 30
 
             readonly property int _followYawBehaviorNone:           0
             readonly property int _followYawBehaviorFace:           1
@@ -52,10 +54,10 @@ SetupPage {
             Component.onCompleted: _setUIFromParams()
 
             function validateSupportedParamSetup() {
-                var followSysIdOk = _followSysId.rawValue == QGroundControl.settingsManager.mavlinkSettings.gcsMavlinkSystemID.rawValue
-                var followOffsetOk = _followOffsetType.rawValue == _followOffsetTypeRelative
-                var followAltOk = true
-                var followYawOk = true
+                let followSysIdOk = _followSysId.rawValue == QGroundControl.settingsManager.mavlinkSettings.gcsMavlinkSystemID.rawValue
+                let followOffsetOk = _followOffsetType.rawValue == _followOffsetTypeRelative
+                let followAltOk = true
+                let followYawOk = true
                 if (!_roverFirmware) {
                     followAltOk = _followAltitudeType.rawValue == _followAltitudeTypeRelative
                     followYawOk = _followYawBehavior.rawValue == _followYawBehaviorNone || _followYawBehavior.rawValue == _followYawBehaviorFace || _followYawBehavior.rawValue == _followYawBehaviorFlight
@@ -77,7 +79,7 @@ SetupPage {
                     controller.height.rawValue = 0
                 } else {
                     followPositionCombo.currentIndex =_followComboSpecifyIndex
-                    var angleRadians = Math.atan2(_followOffsetX.rawValue, _followOffsetY.rawValue)
+                    let angleRadians = Math.atan2(_followOffsetX.rawValue, _followOffsetY.rawValue)
                     if (angleRadians == 0) {
                         controller.distance.rawValue = _followOffsetY.rawValue
                     } else {
@@ -87,8 +89,8 @@ SetupPage {
                 }
                 controller.height.rawValue = -_followOffsetZ.rawValue
                 if (!_roverFirmware) {
-                    var comboIndex = -1
-                    for (var i=0; i<pointVehicleCombo.rgValues.length; i++) {
+                    let comboIndex = -1
+                    for (let i=0; i<pointVehicleCombo.rgValues.length; i++) {
                         if (pointVehicleCombo.rgValues[i] == _followYawBehavior.rawValue) {
                             comboIndex = i
                             break
@@ -120,7 +122,7 @@ SetupPage {
                 if (distance == 0) {
                     _followOffsetX.rawValue = _followOffsetY.rawValue = 0
                 } else {
-                    var angleRadians = _headingToRadians(headingAngleDegrees)
+                    let angleRadians = _headingToRadians(headingAngleDegrees)
                     if (angleRadians == 0) {
                         _followOffsetX.rawValue = 0
                         _followOffsetY.rawValue = distance
@@ -138,8 +140,8 @@ SetupPage {
             }
 
             function _radiansToHeading(radians) {
-                var geometricAngle = QGroundControl.unitsConversion.radiansToDegrees(radians)
-                var headingAngle = 90 - geometricAngle
+                let geometricAngle = QGroundControl.unitsConversion.radiansToDegrees(radians)
+                let headingAngle = 90 - geometricAngle
                 if (headingAngle < 0) {
                     headingAngle += 360
                 } else if (headingAngle > 360) {
@@ -149,7 +151,7 @@ SetupPage {
             }
 
             function _headingToRadians(heading) {
-                var geometricAngle = -(heading - 90)
+                let geometricAngle = -(heading - 90)
                 return QGroundControl.unitsConversion.degreesToRadians(geometricAngle)
             }
 
@@ -182,7 +184,7 @@ SetupPage {
                 onClicked: {
                     if (checked) {
                         _followEnabled.rawValue = 1
-                        var missingParameters = [ "FOLL_DIST_MAX", "FOLL_SYSID", "FOLL_OFS_X", "FOLL_OFS_Y", "FOLL_OFS_Z", "FOLL_OFS_TYPE"  ]
+                        let missingParameters = [ "FOLL_DIST_MAX", "FOLL_SYSID", "FOLL_OFS_X", "FOLL_OFS_Y", "FOLL_OFS_Z", "FOLL_OFS_TYPE"  ]
                         if (!_roverFirmware) {
                             missingParameters.push("FOLL_ALT_TYPE", "FOLL_YAW_BEHAVE")
                         }
@@ -210,7 +212,6 @@ SetupPage {
                     anchors.right:  parent.right
                     text:           qsTr("The vehicle parameters required for follow me are currently set in a way which is not supported. Using follow with this setup may lead to unpredictable/hazardous results.")
                     wrapMode:       Text.WordWrap
-                    onWidthChanged: console.log('width', width)
                 }
 
                 QGCButton {
@@ -224,18 +225,19 @@ SetupPage {
                 spacing:            ScreenTools.defaultFontPixelWidth
                 visible:            _showMainSetup
 
-                ColumnLayout {
-                    Layout.fillWidth:   true
-                    spacing:            ScreenTools.defaultFontPixelWidth
+                QGCGroupBox {
+                    title:            qsTr("Follow Me Settings")
 
                     GridLayout {
-                        Layout.fillWidth:   true
-                        columns:            2
+                        columns:        2
+                        rowSpacing:     ScreenTools.defaultFontPixelWidth
+                        columnSpacing:  ScreenTools.defaultFontPixelWidth
 
                         QGCLabel { text: qsTr("Vehicle Position") }
                         QGCComboBox {
-                            id:                 followPositionCombo
-                            Layout.fillWidth:   true
+                            id:                  followPositionCombo
+                            sizeToContents:      true
+                            Layout.maximumWidth: _comboWidth
                             model:              [ qsTr("Maintain Current Offsets"), qsTr("Specify Offsets")]
 
                             onActivated: (index) => {
@@ -253,8 +255,9 @@ SetupPage {
                             visible:    !_roverFirmware
                         }
                         QGCComboBox {
-                            id:                     pointVehicleCombo
-                            Layout.fillWidth:       true
+                            id:                      pointVehicleCombo
+                            sizeToContents:          true
+                            Layout.maximumWidth:     _comboWidth
                             model:                  rgText
                             visible:                !_roverFirmware
                             onActivated: (index) => { _followYawBehavior.rawValue = rgValues[index] }
@@ -262,43 +265,48 @@ SetupPage {
                             property var rgText:    [ qsTr("Maintain current vehicle orientation"), qsTr("Point at ground station location"), qsTr("Same direction as ground station movement") ]
                             property var rgValues:  [ _followYawBehaviorNone, _followYawBehaviorFace, _followYawBehaviorFlight ]
                         }
-                    }
-
-                    GridLayout {
-                        Layout.fillWidth:   true
-                        columns:            4
-                        visible:            !_followMaintain
 
                         QGCLabel {
                             Layout.columnSpan:  2
                             Layout.alignment:   Qt.AlignHCenter
                             text:               qsTr("Vehicle Offsets")
+                            visible:            !_followMaintain
                         }
 
-                        QGCLabel { text: qsTr("Angle") }
+                        QGCLabel {
+                            text:    qsTr("Angle")
+                            visible: !_followMaintain
+                        }
                         FactTextField {
+                            Layout.preferredWidth: _textFieldWidth
+                            visible:    !_followMaintain
                             fact:       controller.angle
-                            onUpdated:  { console.log("updated"); _setXYOffsetByAngleAndDistance(controller.angle.rawValue, controller.distance.rawValue) }
+                            onUpdated:  _setXYOffsetByAngleAndDistance(controller.angle.rawValue, controller.distance.rawValue)
                         }
 
-                        QGCLabel { text: qsTr("Distance") }
+                        QGCLabel {
+                            text:    qsTr("Distance")
+                            visible: !_followMaintain
+                        }
                         FactTextField {
+                            Layout.preferredWidth: _textFieldWidth
+                            visible:    !_followMaintain
                             fact:       controller.distance
                             onUpdated:  _setXYOffsetByAngleAndDistance(controller.angle.rawValue, controller.distance.rawValue)
                         }
 
                         QGCLabel {
-                            id:         heightLabel
-                            text:       qsTr("Height")
-                            visible:    !_roverFirmware && !_followMaintain
+                            text:    qsTr("Height")
+                            visible: !_roverFirmware && !_followMaintain
                         }
                         FactTextField {
+                            Layout.preferredWidth: _textFieldWidth
+                            visible:    !_roverFirmware && !_followMaintain
                             fact:       controller.height
-                            visible:    heightLabel.visible
                             onUpdated:  _followOffsetZ.rawValue = -controller.height.rawValue
                         }
-                    }
-                }
+                    } // GridLayout
+                } // QGCGroupBox
             }
 
             RowLayout {
@@ -421,8 +429,8 @@ SetupPage {
 
                         onClicked: (mouse) => {
                             // Translate x,y to centered
-                            var x = mouse.x - (width / 2)
-                            var y = (height - mouse.y) - (height / 2)
+                            let x = mouse.x - (width / 2)
+                            let y = (height - mouse.y) - (height / 2)
                             controller.angle.rawValue = _radiansToHeading(Math.atan2(y, x))
                             _setXYOffsetByAngleAndDistance(controller.angle.rawValue, controller.distance.rawValue)
                         }

--- a/src/AutoPilotPlugins/APM/APMGimbalInstance.qml
+++ b/src/AutoPilotPlugins/APM/APMGimbalInstance.qml
@@ -62,12 +62,14 @@ ColumnLayout {
             label: qsTr("Gimbal Type")
             fact: gimbalParams.typeFact
             indexModel: false
+            comboBoxPreferredWidth: ScreenTools.defaultFontPixelWidth * 30
         }
 
         LabelledFactComboBox {
             label: qsTr("Default Mode")
             fact: gimbalParams.defaultModeFact
             indexModel: false
+            comboBoxPreferredWidth: ScreenTools.defaultFontPixelWidth * 30
             visible: fact !== null
         }
     }
@@ -198,13 +200,14 @@ ColumnLayout {
                         LabelledComboBox {
                             id: outputChannelCombo
                             label: modelData.comboLabel
+                            comboBoxPreferredWidth: ScreenTools.defaultFontPixelWidth * 30
                             model: _rcChannelModel()
 
                             Component.onCompleted: {
                                 let maxRcChannel = _rcChannelCount()
-                                for (var rcIndex = 1; rcIndex <= maxRcChannel; rcIndex++) {
-                                    var parameterName = "RC" + rcIndex + "_OPTION"
-                                    var functionFact = _controller.getParameterFact(-1, parameterName)
+                                for (let rcIndex = 1; rcIndex <= maxRcChannel; rcIndex++) {
+                                    let parameterName = "RC" + rcIndex + "_OPTION"
+                                    let functionFact = _controller.getParameterFact(-1, parameterName)
                                     if (functionFact.value == modelData.optionValue) {
                                         currentIndex = rcIndex
                                         return
@@ -304,13 +307,14 @@ ColumnLayout {
                                 Layout.fillWidth: hasStabilizeParam
                                 id: outputChannelCombo
                                 label: qsTr("Output Channel")
+                                comboBoxPreferredWidth: ScreenTools.defaultFontPixelWidth * 30
                                 model: _servoChannelModel()
 
                                 Component.onCompleted: {
                                     let maxServoChannel = _servoChannelCount()
-                                    for (var servoIndex = 1; servoIndex <= maxServoChannel; servoIndex++) {
-                                        var parameterName = "SERVO" + servoIndex + "_FUNCTION"
-                                        var functionFact = _controller.getParameterFact(-1, parameterName)
+                                    for (let servoIndex = 1; servoIndex <= maxServoChannel; servoIndex++) {
+                                        let parameterName = "SERVO" + servoIndex + "_FUNCTION"
+                                        let functionFact = _controller.getParameterFact(-1, parameterName)
                                         if (functionFact.value == modelData.functionValue) {
                                             currentIndex = servoIndex
                                             return

--- a/src/AutoPilotPlugins/APM/APMLightsComponent.qml
+++ b/src/AutoPilotPlugins/APM/APMLightsComponent.qml
@@ -1,5 +1,6 @@
 import QtQuick
 import QtQuick.Controls
+import QtQuick.Layouts
 
 import QGroundControl
 import QGroundControl.FactControls
@@ -36,6 +37,7 @@ SetupPage {
             property Fact _numSteps:            _oldFW ? null : controller.getParameterFact(-1, "JS_LIGHTS_STEPS") // v3.5.2 and up
 
             readonly property real  _margins:                       ScreenTools.defaultFontPixelHeight
+            readonly property real  _comboWidth:                    ScreenTools.defaultFontPixelWidth * 30
             readonly property int   _rcFunctionDisabled:            0
             readonly property int   _rcFunctionRCIN9:               59
             readonly property int   _rcFunctionRCIN10:              60
@@ -52,8 +54,8 @@ SetupPage {
             function calcLightOutValues() {
                 lightsLoader.lights1OutIndex = 0
                 lightsLoader.lights2OutIndex = 0
-                for (var channel=_firstLightsOutChannel; channel<=_lastLightsOutChannel; channel++) {
-                    var functionFact = controller.getParameterFact(-1, "SERVO" + channel + "_FUNCTION")
+                for (let channel=_firstLightsOutChannel; channel<=_lastLightsOutChannel; channel++) {
+                    let functionFact = controller.getParameterFact(-1, "SERVO" + channel + "_FUNCTION")
                     if (functionFact.value == _rcFunctionRCIN9) {
                         lightsLoader.lights1OutIndex = channel - 4
                     } else if (functionFact.value == _rcFunctionRCIN10) {
@@ -64,8 +66,8 @@ SetupPage {
 
             function setRCFunction(channel, rcFunction) {
                 // First clear any previous settings for this function
-                for (var index=_firstLightsOutChannel; index<=_lastLightsOutChannel; index++) {
-                    var functionFact = controller.getParameterFact(-1, "SERVO" + index + "_FUNCTION")
+                for (let index=_firstLightsOutChannel; index<=_lastLightsOutChannel; index++) {
+                    let functionFact = controller.getParameterFact(-1, "SERVO" + index + "_FUNCTION")
                     if (functionFact.value != _rcFunctionDisabled && functionFact.value == rcFunction) {
                         functionFact.value = _rcFunctionDisabled
                     }
@@ -73,16 +75,16 @@ SetupPage {
 
                 // Now set the function into the new channel
                 if (channel != 0) {
-                    var functionFact = controller.getParameterFact(-1, "SERVO" + channel + "_FUNCTION")
+                    let functionFact = controller.getParameterFact(-1, "SERVO" + channel + "_FUNCTION")
                     functionFact.value = rcFunction
                 }
             }
 
             function calcCurrentStep() {
                 if (_oldFW) {
-                    var i = 1
+                    let i = 1
                     for(i; i <= 10; i++) {
-                        var stepSize = (1900-1100)/i
+                        let stepSize = (1900-1100)/i
                         if(_stepSize.value >= stepSize) {
                             _stepSize.value = stepSize;
                             break;
@@ -128,57 +130,40 @@ SetupPage {
                     if(number < 6) {
                         return
                     }
-                    for(var i = 5; i <= number; i++) {
-                        var text = qsTr("Channel ") + i
+                    for(let i = 5; i <= number; i++) {
+                        let text = qsTr("Channel ") + i
                         append({"text": text, "value": i})
                     }
                 }
 
                 Component.onCompleted: {
-                    // Number of main outputs
-                    var baseValue = 8
-                    // Extra outputs
+                    // Number of main outputs plus extra auxiliary outputs
                     // http://ardupilot.org/copter/docs/parameters.html#brd-pwm-count-auxiliary-pin-config
-                    var brd_pwm_count_value = controller.getParameterFact(-1, "BRD_PWM_COUNT").value
-                    update(8 + (brd_pwm_count_value == 7 ? 3 : brd_pwm_count_value))
+                    let totalChannels = _lastLightsOutChannel
+                    if (controller.parameterExists(-1, "BRD_PWM_COUNT")) {
+                        let brd_pwm_count_value = controller.getParameterFact(-1, "BRD_PWM_COUNT").value
+                        totalChannels = 8 + (brd_pwm_count_value == 7 ? 3 : brd_pwm_count_value)
+                    }
+                    update(totalChannels)
                 }
             }
 
             Component {
                 id: lightSettings
 
-                Item {
-                    width:  rectangle.x + rectangle.width
-                    height: rectangle.y + rectangle.height
+                QGCGroupBox {
+                    title: qsTr("Light Output Channels")
 
-                    QGCLabel {
-                        id:             settingsLabel
-                        text:           qsTr("Light Output Channels")
-                        font.bold:      true
-                    }
+                    GridLayout {
+                        columns:        2
+                        rowSpacing:     _margins / 2
+                        columnSpacing:  _margins / 2
 
-                    Rectangle {
-                        id:                 rectangle
-                        anchors.topMargin:  _margins / 2
-                        anchors.top:        settingsLabel.bottom
-                        width:              lights1Combo.x + lights1Combo.width + lightsStepCombo.width + _margins
-                        height:             lights2Combo.y + lights2Combo.height + lightsStepCombo.height + 2*_margins
-                        color:              qgcPal.windowShade
-
-                        QGCLabel {
-                            id:                 lights1Label
-                            anchors.margins:    _margins
-                            anchors.right:      lights1Combo.left
-                            anchors.baseline:   lights1Combo.baseline
-                            text:               qsTr("Lights 1:")
-                        }
-
+                        QGCLabel { text: qsTr("Lights 1") }
                         QGCComboBox {
-                            id:                 lights1Combo
-                            anchors.margins:    _margins
-                            anchors.top:        parent.top
-                            anchors.left:       lightsStepLabel.right
-                            width:              ScreenTools.defaultFontPixelWidth * 15
+                            id:                  lights1Combo
+                            sizeToContents:      true
+                            Layout.maximumWidth: _comboWidth
                             model:              lightsOutModel
                             textRole:           "text"
                             currentIndex:       lights1OutIndex
@@ -186,20 +171,11 @@ SetupPage {
                             onActivated: (index) => { setRCFunction(lightsOutModel.get(index).value, lights1Function) }
                         }
 
-                        QGCLabel {
-                            id:                 lights2Label
-                            anchors.margins:    _margins
-                            anchors.right:      lights2Combo.left
-                            anchors.baseline:   lights2Combo.baseline
-                            text:               qsTr("Lights 2:")
-                        }
-
+                        QGCLabel { text: qsTr("Lights 2") }
                         QGCComboBox {
-                            id:                 lights2Combo
-                            anchors.margins:    _margins
-                            anchors.top:        lights1Combo.bottom
-                            anchors.left:       lightsStepLabel.right
-                            width:              lights1Combo.width
+                            id:                  lights2Combo
+                            sizeToContents:      true
+                            Layout.maximumWidth: _comboWidth
                             model:              lightsOutModel
                             textRole:           "text"
                             currentIndex:       lights2OutIndex
@@ -207,27 +183,18 @@ SetupPage {
                             onActivated: (index) => { setRCFunction(lightsOutModel.get(index).value, lights2Function) }
                         }
 
-                        QGCLabel {
-                            id:                 lightsStepLabel
-                            anchors.margins:    _margins
-                            anchors.left:       parent.left
-                            anchors.baseline:   lightsStepCombo.baseline
-                            text:               qsTr("Brightness Steps:")
-                        }
-
+                        QGCLabel { text: qsTr("Brightness Steps") }
                         QGCComboBox {
-                            id:                 lightsStepCombo
-                            anchors.margins:    _margins
-                            anchors.top:        lights2Combo.bottom
-                            anchors.left:       lightsStepLabel.right
-                            width:              lights2Combo.width
+                            id:                  lightsStepCombo
+                            sizeToContents:      true
+                            Layout.maximumWidth: _comboWidth
                             model:              [1,2,3,4,5,6,7,8,9,10]
                             currentIndex:       lightsSteps-1
 
                             onActivated: (index) => { calcStepSize(index+1) }
                         }
-                    } // Rectangle
-                } // Item
+                    } // GridLayout
+                } // QGCGroupBox
             } // Component - lightSettings
 
             Loader {

--- a/src/AutoPilotPlugins/APM/APMPowerComponent.qml
+++ b/src/AutoPilotPlugins/APM/APMPowerComponent.qml
@@ -72,7 +72,6 @@ SetupPage {
 
                 // Monitor-only view (monitor disabled or params not yet available after enabling)
                 QGCGroupBox {
-                    Layout.fillWidth:       true
                     title:                  qsTr("Battery Monitor")
                     visible:                !battParams.monitorEnabled || !battParams.paramsAvailable
 
@@ -106,7 +105,6 @@ SetupPage {
                 // Full settings view
                 QGCGroupBox {
                     id:                     fullSettingsRect
-                    Layout.fillWidth:       true
                     visible:                battParams.monitorEnabled && battParams.paramsAvailable
 
                     Loader {

--- a/src/AutoPilotPlugins/APM/APMRemoteSupportComponent.qml
+++ b/src/AutoPilotPlugins/APM/APMRemoteSupportComponent.qml
@@ -12,19 +12,12 @@ SetupPage {
     Component {
         id: pageComponent
 
-        Rectangle {
-            id:                 backgroundRectangle
-            width:              availableWidth
-            height:             elementsRow.height * 1.5
-            color:              qgcPal.windowShade
+        QGCGroupBox {
+            title: qsTr("Remote Support")
 
             GridLayout {
                 id:               elementsRow
                 columns:          2
-
-                anchors.left:           parent.left
-                anchors.verticalCenter: parent.verticalCenter
-                anchors.margins:        ScreenTools.defaultFontPixelWidth
 
                 columnSpacing:          ScreenTools.defaultFontPixelWidth
                 rowSpacing:             ScreenTools.defaultFontPixelWidth

--- a/src/AutoPilotPlugins/APM/APMSafetyComponent.qml
+++ b/src/AutoPilotPlugins/APM/APMSafetyComponent.qml
@@ -48,6 +48,7 @@ SetupPage {
             property Fact _armingSkipCheck: controller.getParameterFact(-1, "ARMING_SKIPCHK", false /* reportMissing */)
 
             property real _margins:         ScreenTools.defaultFontPixelWidth / 2
+            property real _comboWidth:      ScreenTools.defaultFontPixelWidth * 30
             property bool _showIcon:        !ScreenTools.isTinyScreen
             property bool _roverFirmware:   controller.parameterExists(-1, "MODE1") // This catches all usage of ArduRover firmware vehicle types: Rover, Boat...
 
@@ -63,6 +64,7 @@ SetupPage {
                         label:              qsTr("Low action")
                         fact:               failsafeBattLowAct
                         indexModel:         false
+                        comboBoxPreferredWidth: _comboWidth
                         Layout.fillWidth:   true
                     }
 
@@ -70,6 +72,7 @@ SetupPage {
                         label:              qsTr("Critical action")
                         fact:               failsafeBattCritAct
                         indexModel:         false
+                        comboBoxPreferredWidth: _comboWidth
                         Layout.fillWidth:   true
                     }
 
@@ -181,6 +184,7 @@ SetupPage {
                             label:            qsTr("Ground Station failsafe")
                             fact:             _failsafeGCSEnable
                             indexModel:       false
+                            comboBoxPreferredWidth: _comboWidth
                             Layout.fillWidth: true
                         }
 
@@ -207,6 +211,7 @@ SetupPage {
                             label:            qsTr("Short failsafe action")
                             fact:             _failsafeShortAction
                             indexModel:       false
+                            comboBoxPreferredWidth: _comboWidth
                             Layout.fillWidth: true
                         }
 
@@ -214,6 +219,7 @@ SetupPage {
                             label:            qsTr("Long failsafe action")
                             fact:             _failsafeLongAction
                             indexModel:       false
+                            comboBoxPreferredWidth: _comboWidth
                             Layout.fillWidth: true
                         }
 
@@ -228,6 +234,7 @@ SetupPage {
                             label:            qsTr("VTOL transition failure action")
                             fact:             _transFailAction
                             indexModel:       false
+                            comboBoxPreferredWidth: _comboWidth
                             Layout.fillWidth: true
                             visible:          _isQuadPlane
                         }
@@ -270,6 +277,7 @@ SetupPage {
                             label:            qsTr("Ground Station failsafe")
                             fact:             _failsafeGCSEnable
                             indexModel:       false
+                            comboBoxPreferredWidth: _comboWidth
                             Layout.fillWidth: true
                         }
 
@@ -284,6 +292,7 @@ SetupPage {
                             label:            qsTr("Throttle failsafe")
                             fact:             _failsafeThrEnable
                             indexModel:       false
+                            comboBoxPreferredWidth: _comboWidth
                             Layout.fillWidth: true
                         }
 
@@ -297,6 +306,7 @@ SetupPage {
                             label:            qsTr("Failsafe action")
                             fact:             _failsafeAction
                             indexModel:       false
+                            comboBoxPreferredWidth: _comboWidth
                             Layout.fillWidth: true
                         }
 
@@ -311,6 +321,7 @@ SetupPage {
                             label:            qsTr("Crash check")
                             fact:             _failsafeCrashCheck
                             indexModel:       false
+                            comboBoxPreferredWidth: _comboWidth
                             Layout.fillWidth: true
                         }
 
@@ -318,6 +329,7 @@ SetupPage {
                             label:            qsTr("EKF failsafe action")
                             fact:             _failsafeEkfAction
                             indexModel:       false
+                            comboBoxPreferredWidth: _comboWidth
                             Layout.fillWidth: true
                         }
 
@@ -382,6 +394,7 @@ SetupPage {
                             label:            qsTr("Ground Station failsafe")
                             fact:             _failsafeGCSEnable
                             indexModel:       false
+                            comboBoxPreferredWidth: _comboWidth
                             Layout.fillWidth: true
                         }
 
@@ -396,6 +409,7 @@ SetupPage {
                             label:            qsTr("Throttle failsafe")
                             fact:             _failsafeThrEnable
                             indexModel:       false
+                            comboBoxPreferredWidth: _comboWidth
                             Layout.fillWidth: true
                         }
 
@@ -410,6 +424,7 @@ SetupPage {
                             label:            qsTr("EKF failsafe action")
                             fact:             _failsafeEkfAction
                             indexModel:       false
+                            comboBoxPreferredWidth: _comboWidth
                             Layout.fillWidth: true
                         }
 
@@ -430,6 +445,7 @@ SetupPage {
                             label:            qsTr("Crash check")
                             fact:             _failsafeCrashCheck
                             indexModel:       false
+                            comboBoxPreferredWidth: _comboWidth
                             Layout.fillWidth: true
                         }
 
@@ -437,6 +453,7 @@ SetupPage {
                             label:            qsTr("Vibration failsafe")
                             fact:             _failsafeVibeEnable
                             indexModel:       false
+                            comboBoxPreferredWidth: _comboWidth
                             Layout.fillWidth: true
                         }
 
@@ -444,6 +461,7 @@ SetupPage {
                             label:            qsTr("Dead reckoning failsafe")
                             fact:             _failsafeDREnable
                             indexModel:       false
+                            comboBoxPreferredWidth: _comboWidth
                             Layout.fillWidth: true
                         }
 
@@ -553,6 +571,7 @@ SetupPage {
                             LabelledFactComboBox {
                                 label:            qsTr("Breach action")
                                 fact:             _fenceAction
+                                comboBoxPreferredWidth: _comboWidth
                                 Layout.fillWidth: true
                             }
 

--- a/src/AutoPilotPlugins/APM/APMSafetyComponentSub.qml
+++ b/src/AutoPilotPlugins/APM/APMSafetyComponentSub.qml
@@ -1,5 +1,6 @@
 import QtQuick
 import QtQuick.Controls
+import QtQuick.Layouts
 
 import QGroundControl
 import QGroundControl.FactControls
@@ -12,14 +13,13 @@ SetupPage {
     Component {
         id: safetyPageComponent
 
-        Flow {
+        ColumnLayout {
             id:         flowLayout
-            width:      availableWidth
             spacing:    _margins
 
             FactPanelController { id: controller; }
 
-            QGCPalette { id: ggcPal; colorGroupEnabled: true }
+            QGCPalette { id: qgcPal; colorGroupEnabled: true }
 
             property bool _firmware34:       globals.activeVehicle.versionCompare(3, 5, 0) < 0
 
@@ -43,342 +43,210 @@ SetupPage {
             property Fact _failsafeBatteryCapacity:      controller.getParameterFact(-1, "BATT_LOW_MAH", false)
             property bool _batteryDetected:              controller.parameterExists(-1, "BATT_LOW_MAH")
 
-            // Older firmwares use ARMING_CHECK. Newer firmwares use ARMING_SKIPCHK.
-            property Fact _armingCheck:     controller.getParameterFact(-1, "ARMING_CHECK", false /* reportMissing */)
-            property Fact _armingSkipCheck: controller.getParameterFact(-1, "ARMING_SKIPCHK", false /* reportMissing */)
+            property Fact _armingCheck:     controller.getParameterFact(-1, "ARMING_CHECK", false)
+            property Fact _armingSkipCheck: controller.getParameterFact(-1, "ARMING_SKIPCHK", false)
 
-            property real _margins:     ScreenTools.defaultFontPixelHeight
-            property bool _showIcon:    !ScreenTools.isTinyScreen
+            property real _margins:         ScreenTools.defaultFontPixelHeight
+            property real _textFieldWidth:  ScreenTools.defaultFontPixelWidth * 15
+            property real _comboWidth:      ScreenTools.defaultFontPixelWidth * 30
 
-            Column {
-                spacing: _margins / 2
+            QGCGroupBox {
+                title:              qsTr("Failsafe Actions")
 
-                QGCLabel {
-                    id:         failsafeLabel
-                    text:       qsTr("Failsafe Actions")
-                    font.bold:   true
-                }
+                GridLayout {
+                    columns:        2
+                    rowSpacing:     _margins / 2
+                    columnSpacing:  _margins / 2
 
-                Rectangle {
-                    id:     failsafeRectangle
-                    width:  flowLayout.width
-                    height: childrenRect.height + _margins
-                    color:  ggcPal.windowShade
-
-                    Column {
-                        anchors.top: failsafeRectangle.top
-                        anchors.left: failsafeRectangle.left
-                        anchors.margins: _margins / 2
-                        property var _labelWidth: ScreenTools.defaultFontPixelWidth * 15
-                        property var _editWidth: ScreenTools.defaultFontPixelWidth * 20
-                        id:     failsafeSettings
-                        spacing: ScreenTools.defaultFontPixelHeight
-
-                        Row {
-                            spacing: _margins / 2
-
-                            QGCLabel {
-                                id:                     gcsEnableLabel
-                                width:                  failsafeSettings._labelWidth
-                                anchors.verticalCenter: gcsEnableCombo.verticalCenter
-                                text:                   qsTr("GCS Heartbeat:")
-                                wrapMode:               Text.Wrap
-                            }
-
-                            FactComboBox {
-                                id:                 gcsEnableCombo
-                                width:              failsafeSettings._editWidth
-                                fact:               _failsafeGCSEnable
-                                indexModel:         false
-                            }
-                        }
-
-                        Row {
-                            spacing: _margins / 2
-
-                            QGCLabel {
-                                id:                     leakEnableLabel
-                                width:                  failsafeSettings._labelWidth
-                                anchors.verticalCenter: leakEnableCombo.verticalCenter
-                                text:                   qsTr("Leak:")
-                                wrapMode:               Text.Wrap
-                            }
-
-                            FactComboBox {
-                                id:                     leakEnableCombo
-                                width:                  failsafeSettings._editWidth
-                                fact:                   _failsafeLeakEnable
-                                indexModel:             false
-                            }
-
-                            QGCLabel {
-                                text:                   qsTr("Detector Pin:")
-                                width:                  failsafeSettings._labelWidth
-                                anchors.verticalCenter: leakEnableCombo.verticalCenter
-                                visible:                leakEnableCombo.currentIndex != 0
-                            }
-
-                            FactComboBox {
-                                width:                  failsafeSettings._editWidth
-                                visible:                leakEnableCombo.currentIndex != 0
-                                anchors.verticalCenter: leakEnableCombo.verticalCenter
-                                fact:                   _failsafeLeakPin
-                                indexModel:             false
-                            }
-
-                            QGCLabel {
-                                text:                   qsTr("Logic when Dry:")
-                                width:                  failsafeSettings._labelWidth
-                                visible:                leakEnableCombo.currentIndex != 0
-                                anchors.verticalCenter: leakEnableCombo.verticalCenter
-                            }
-
-                            FactComboBox {
-                                width:                  failsafeSettings._editWidth
-                                visible:                leakEnableCombo.currentIndex != 0
-                                anchors.verticalCenter: leakEnableCombo.verticalCenter
-                                fact:                   _failsafeLeakLogic
-                                indexModel:             false
-                            }
-                        }
-
-                        Row {
-                            spacing: _margins / 2
-                            visible: !_firmware34
-
-                            QGCLabel {
-                                id:                     batteryEnableLabel
-                                width:                  failsafeSettings._labelWidth
-                                anchors.verticalCenter: batteryEnableCombo.verticalCenter
-                                text:                   qsTr("Battery:")
-                                wrapMode:               Text.Wrap
-                            }
-
-                            FactComboBox {
-                                id:                 batteryEnableCombo
-                                enabled:            _batteryDetected
-                                width:              failsafeSettings._editWidth
-                                fact:               _failsafeBatteryEnable
-                                indexModel:         false
-                            }
-
-                            QGCLabel {
-                                text:                   qsTr("Power module not set up")
-                                width:                  failsafeSettings._labelWidth
-                                color:                  ggcPal.warningText
-                                anchors.verticalCenter: batteryEnableCombo.verticalCenter
-                                visible:                !_batteryDetected
-                            }
-
-                            QGCLabel {
-                                text:                   qsTr("Voltage:")
-                                width:                  failsafeSettings._labelWidth
-                                anchors.verticalCenter: batteryEnableCombo.verticalCenter
-                                visible:                batteryEnableCombo.currentIndex != 0
-                            }
-
-                            FactTextField {
-                                width:                  failsafeSettings._editWidth
-                                anchors.verticalCenter: batteryEnableCombo.verticalCenter
-                                visible:                batteryEnableCombo.currentIndex != 0
-                                fact:                   _failsafeBatteryVoltage
-                            }
-
-                            QGCLabel {
-                                text:                   qsTr("Remaining Capacity:")
-                                width:                  failsafeSettings._labelWidth
-                                anchors.verticalCenter: batteryEnableCombo.verticalCenter
-                                visible:                batteryEnableCombo.currentIndex != 0
-                            }
-
-                            FactTextField {
-                                width:                  failsafeSettings._editWidth
-                                anchors.verticalCenter: batteryEnableCombo.verticalCenter
-                                visible:                batteryEnableCombo.currentIndex != 0
-                                fact:                   _failsafeBatteryCapacity
-                            }
-                        }
-
-                        Row {
-                            spacing: _margins / 2
-                            visible: !_firmware34
-
-                            QGCLabel {
-                                id:                     ekfEnableLabel
-                                width:                  failsafeSettings._labelWidth
-                                anchors.verticalCenter: ekfEnableCombo.verticalCenter
-                                text:                   qsTr("EKF:")
-                                wrapMode:               Text.Wrap
-                            }
-
-                            FactComboBox {
-                                id:                 ekfEnableCombo
-                                width:              failsafeSettings._editWidth
-                                fact:               _failsafeEKFEnable
-                                indexModel:         false
-                            }
-
-                            QGCLabel {
-                                text: "Threshold:"
-                                width:              failsafeSettings._labelWidth
-                                visible:            ekfEnableCombo.currentIndex != 0
-                                anchors.baseline:   ekfEnableCombo.baseline
-                            }
-
-                            FactTextField {
-                                width:              failsafeSettings._editWidth
-                                visible:            ekfEnableCombo.currentIndex != 0
-                                anchors.baseline:   ekfEnableCombo.baseline
-                                fact:               _failsafeEKFThreshold
-                            }
-                        }
-
-                        Row {
-                            spacing: _margins / 2
-                            visible: !_firmware34
-
-                            QGCLabel {
-                                id:                     pilotEnableLabel
-                                width:                  failsafeSettings._labelWidth
-                                anchors.verticalCenter: pilotEnableCombo.verticalCenter
-                                text:                   qsTr("Pilot Input:")
-                                wrapMode:               Text.Wrap
-                            }
-
-                            FactComboBox {
-                                id:                 pilotEnableCombo
-                                width:              failsafeSettings._editWidth
-                                fact:               _failsafePilotEnable
-                                indexModel:         false
-                            }
-
-                            QGCLabel {
-                                text:                   qsTr("Timeout:")
-                                width:                  failsafeSettings._labelWidth
-                                anchors.verticalCenter: pilotEnableCombo.verticalCenter
-                                visible:                pilotEnableCombo.currentIndex != 0
-
-                            }
-
-                            FactTextField {
-                                width:                  failsafeSettings._editWidth
-                                anchors.verticalCenter: pilotEnableCombo.verticalCenter
-                                visible:                pilotEnableCombo.currentIndex != 0
-                                anchors.baseline:       pilotEnableCombo.baseline
-                                fact:                   _failsafePilotTimeout
-                            }
-                        }
-
-                        Row {
-                            spacing: _margins / 2
-
-                            QGCLabel {
-                                id:                     temperatureEnableLabel
-                                width:                  failsafeSettings._labelWidth
-                                anchors.verticalCenter: temperatureEnableCombo.verticalCenter
-                                text:                   qsTr("Internal Temperature:")
-                                wrapMode:               Text.Wrap
-                            }
-
-                            FactComboBox {
-                                id:                 temperatureEnableCombo
-                                width:              failsafeSettings._editWidth
-                                fact:               _failsafeTemperatureEnable
-                                indexModel:         false
-                            }
-
-                            QGCLabel {
-                                text:               qsTr("Threshold:")
-                                width:              failsafeSettings._labelWidth
-                                visible:            temperatureEnableCombo.currentIndex != 0
-                                anchors.baseline:   temperatureEnableCombo.baseline
-                            }
-
-                            FactTextField {
-                                width:              failsafeSettings._editWidth
-                                visible:            temperatureEnableCombo.currentIndex != 0
-                                anchors.baseline:   temperatureEnableCombo.baseline
-                                fact:               _failsafeTemperatureThreshold
-                            }
-                        }
-
-                        Row {
-                            spacing: _margins / 2
-
-                            QGCLabel {
-                                id:                     pressureEnableLabel
-                                width:                  failsafeSettings._labelWidth
-                                anchors.verticalCenter: pressureEnableCombo.verticalCenter
-                                text:                   qsTr("Internal Pressure:")
-                                wrapMode:               Text.Wrap
-                            }
-
-                            FactComboBox {
-                                id:                 pressureEnableCombo
-                                width:              failsafeSettings._editWidth
-                                fact:               _failsafePressureEnable
-                                indexModel:         false
-                            }
-
-                            QGCLabel {
-                                text:               qsTr("Threshold:")
-                                width:              failsafeSettings._labelWidth
-                                visible:            pressureEnableCombo.currentIndex != 0
-                                anchors.baseline:   pressureEnableCombo.baseline
-                            }
-
-                            FactTextField {
-                                width:              failsafeSettings._editWidth
-                                visible:            pressureEnableCombo.currentIndex != 0
-                                anchors.baseline:   pressureEnableCombo.baseline
-                                fact:               _failsafePressureThreshold
-                            }
-                        }
-                    } // Column - Failsafe Settings
-                }// Rectangle - Failsafe Settings
-            } // Column - Failsafe Settings
-
-            Column {
-                spacing: _margins / 2
-
-                QGCLabel {
-                    text:           _armingCheck ? qsTr("Arming Checks") : qsTr("Skip Arming Checks")
-                    font.bold:      true
-                }
-
-                Rectangle {
-                    width:  flowLayout.width
-                    height: armingCheckInnerColumn.height + (_margins * 2)
-                    color:  ggcPal.windowShade
-
-                    Column {
-                        id:                 armingCheckInnerColumn
-                        anchors.margins:    _margins
-                        anchors.top:        parent.top
-                        anchors.left:       parent.left
-                        anchors.right:      parent.right
-                        spacing: _margins
-
-                        FactBitmask {
-                            id:                 armingCheckBitmask
-                            anchors.left:       parent.left
-                            anchors.right:      parent.right
-                            firstEntryIsAll:    _armingCheck ? true : false
-                            fact:               _armingCheck ? _armingCheck : _armingSkipCheck
-                        }
-
-                        QGCLabel {
-                            id:             armingCheckWarning
-                            anchors.left:   parent.left
-                            anchors.right:  parent.right
-                            wrapMode:       Text.WordWrap
-                            color:          qgcPal.warningText
-                            text:            qsTr("Warning: Turning off arming checks can lead to loss of Vehicle control.")
-                            visible:        _armingCheck ? _armingCheck.value != 1 : _armingSkipCheck.value != 0
-                        }
+                    QGCLabel { text: qsTr("GCS Heartbeat") }
+                    FactComboBox {
+                        Layout.maximumWidth: _comboWidth
+                        fact:               _failsafeGCSEnable
+                        indexModel:         false
+                        sizeToContents:     true
                     }
-                } // Rectangle - Arming checks
-            } // Column - Arming Checks
-        } // Flow
+
+                    QGCLabel { text: qsTr("Leak") }
+                    FactComboBox {
+                        id:                  leakEnableCombo
+                        Layout.maximumWidth: _comboWidth
+                        fact:               _failsafeLeakEnable
+                        indexModel:         false
+                        sizeToContents:     true
+                    }
+
+                    QGCLabel {
+                        text:    qsTr("Detector Pin")
+                        visible: leakEnableCombo.currentIndex !== 0
+                    }
+                    FactComboBox {
+                        Layout.maximumWidth: _comboWidth
+                        visible:            leakEnableCombo.currentIndex !== 0
+                        fact:               _failsafeLeakPin
+                        indexModel:         false
+                        sizeToContents:     true
+                    }
+
+                    QGCLabel {
+                        text:    qsTr("Logic when Dry")
+                        visible: leakEnableCombo.currentIndex !== 0
+                    }
+                    FactComboBox {
+                        Layout.maximumWidth: _comboWidth
+                        visible:            leakEnableCombo.currentIndex !== 0
+                        fact:               _failsafeLeakLogic
+                        indexModel:         false
+                        sizeToContents:     true
+                    }
+
+                    QGCLabel {
+                        text:    qsTr("Battery")
+                        visible: !_firmware34
+                    }
+                    FactComboBox {
+                        id:                  batteryEnableCombo
+                        Layout.maximumWidth: _comboWidth
+                        enabled:            _batteryDetected
+                        visible:            !_firmware34
+                        fact:               _failsafeBatteryEnable
+                        indexModel:         false
+                        sizeToContents:     true
+                    }
+
+                    QGCLabel {
+                        Layout.columnSpan:  2
+                        text:               qsTr("Power module not set up")
+                        color:              qgcPal.warningText
+                        visible:            !_firmware34 && !_batteryDetected
+                    }
+
+                    QGCLabel {
+                        text:    qsTr("Voltage")
+                        visible: !_firmware34 && batteryEnableCombo.currentIndex !== 0
+                    }
+                    FactTextField {
+                        Layout.preferredWidth: _textFieldWidth
+                        visible:              !_firmware34 && batteryEnableCombo.currentIndex !== 0
+                        fact:                 _failsafeBatteryVoltage
+                    }
+
+                    QGCLabel {
+                        text:    qsTr("Remaining Capacity")
+                        visible: !_firmware34 && batteryEnableCombo.currentIndex !== 0
+                    }
+                    FactTextField {
+                        Layout.preferredWidth: _textFieldWidth
+                        visible:              !_firmware34 && batteryEnableCombo.currentIndex !== 0
+                        fact:                 _failsafeBatteryCapacity
+                    }
+
+                    QGCLabel {
+                        text:    qsTr("EKF")
+                        visible: !_firmware34
+                    }
+                    FactComboBox {
+                        id:                  ekfEnableCombo
+                        Layout.maximumWidth: _comboWidth
+                        visible:            !_firmware34
+                        fact:               _failsafeEKFEnable
+                        indexModel:         false
+                        sizeToContents:     true
+                    }
+
+                    QGCLabel {
+                        text:    qsTr("Threshold")
+                        visible: !_firmware34 && ekfEnableCombo.currentIndex !== 0
+                    }
+                    FactTextField {
+                        Layout.preferredWidth: _textFieldWidth
+                        visible:              !_firmware34 && ekfEnableCombo.currentIndex !== 0
+                        fact:                 _failsafeEKFThreshold
+                    }
+
+                    QGCLabel {
+                        text:    qsTr("Pilot Input")
+                        visible: !_firmware34
+                    }
+                    FactComboBox {
+                        id:                  pilotEnableCombo
+                        Layout.maximumWidth: _comboWidth
+                        visible:            !_firmware34
+                        fact:               _failsafePilotEnable
+                        indexModel:         false
+                        sizeToContents:     true
+                    }
+
+                    QGCLabel {
+                        text:    qsTr("Timeout")
+                        visible: !_firmware34 && pilotEnableCombo.currentIndex !== 0
+                    }
+                    FactTextField {
+                        Layout.preferredWidth: _textFieldWidth
+                        visible:              !_firmware34 && pilotEnableCombo.currentIndex !== 0
+                        fact:                 _failsafePilotTimeout
+                    }
+
+                    QGCLabel { text: qsTr("Internal Temperature") }
+                    FactComboBox {
+                        id:                  temperatureEnableCombo
+                        Layout.maximumWidth: _comboWidth
+                        fact:               _failsafeTemperatureEnable
+                        indexModel:         false
+                        sizeToContents:     true
+                    }
+
+                    QGCLabel {
+                        text:    qsTr("Threshold")
+                        visible: temperatureEnableCombo.currentIndex !== 0
+                    }
+                    FactTextField {
+                        Layout.preferredWidth: _textFieldWidth
+                        visible:              temperatureEnableCombo.currentIndex !== 0
+                        fact:                 _failsafeTemperatureThreshold
+                    }
+
+                    QGCLabel { text: qsTr("Internal Pressure") }
+                    FactComboBox {
+                        id:                  pressureEnableCombo
+                        Layout.maximumWidth: _comboWidth
+                        fact:               _failsafePressureEnable
+                        indexModel:         false
+                        sizeToContents:     true
+                    }
+
+                    QGCLabel {
+                        text:    qsTr("Threshold")
+                        visible: pressureEnableCombo.currentIndex !== 0
+                    }
+                    FactTextField {
+                        Layout.preferredWidth: _textFieldWidth
+                        visible:              pressureEnableCombo.currentIndex !== 0
+                        fact:                 _failsafePressureThreshold
+                    }
+                } // GridLayout
+            } // QGCGroupBox - Failsafe Actions
+
+            QGCGroupBox {
+                title:              _armingCheck ? qsTr("Arming Checks") : qsTr("Skip Arming Checks")
+
+                ColumnLayout {
+                    spacing:        _margins
+
+                    FactBitmask {
+                        Layout.preferredWidth:  safetyPage.availableWidth * 0.75
+                        firstEntryIsAll:        _armingCheck ? true : false
+                        fact:                   _armingCheck ? _armingCheck : _armingSkipCheck
+                    }
+
+                    QGCLabel {
+                        Layout.fillWidth:   true
+                        wrapMode:           Text.WordWrap
+                        color:              qgcPal.warningText
+                        text:               qsTr("Warning: Turning off arming checks can lead to loss of Vehicle control.")
+                        visible:            _armingCheck ? _armingCheck.value !== 1 : _armingSkipCheck.value !== 0
+                    }
+                }
+            } // QGCGroupBox - Arming Checks
+        } // ColumnLayout
     } // Component - safetyPageComponent
-} // SetupView
+} // SetupPage

--- a/src/AutoPilotPlugins/APM/APMSensorIdDecoder.qml
+++ b/src/AutoPilotPlugins/APM/APMSensorIdDecoder.qml
@@ -128,13 +128,13 @@ QGCLabel {
     }
 
     function decode (device) {
-        var devid = parseInt(device.valueString)
-        var deviceName = device.name
-        var busType = busTypes[devid & 0x07]
-        var bus = (devid >> 3) & 0x1F
-        var address = (devid >> 8) & 0xFF
-        var devtype = (devid >> 16)
-        var decodedDevname;
+        let devid = parseInt(device.valueString)
+        let deviceName = device.name
+        let busType = busTypes[devid & 0x07]
+        let bus = (devid >> 3) & 0x1F
+        let address = (devid >> 8) & 0xFF
+        let devtype = (devid >> 16)
+        let decodedDevname;
 
         if (devid === 0) {
             return ""

--- a/src/AutoPilotPlugins/APM/APMSensorsComponent.qml
+++ b/src/AutoPilotPlugins/APM/APMSensorsComponent.qml
@@ -71,8 +71,8 @@ SetupPage {
             property var    _mapPosition:                    QGroundControl.flightMapPosition
 
             function showOrientationsDialog(calType) {
-                var dialogTitle
-                var dialogButtons = Dialog.Ok
+                let dialogTitle
+                let dialogButtons = Dialog.Ok
                 _showSimpleAccelCalOption = false
 
                 _orientationDialogCalType = calType
@@ -104,9 +104,9 @@ SetupPage {
             }
 
             function compassLabel(index) {
-                var label = qsTr("Compass %1 ").arg(index+1)
-                var addOpenParan = true
-                var addComma = false
+                let label = qsTr("Compass %1 ").arg(index+1)
+                let addOpenParan = true
+                let addComma = false
                 if (sensorParams.compassPrimaryFactAvailable) {
                     label += sensorParams.rgCompassPrimary[index] ? qsTr("(primary") : qsTr("(secondary")
                     addComma = true
@@ -366,8 +366,8 @@ SetupPage {
 
                                 function selectPriorityfromParams() {
                                     currentIndex = 3
-                                    var compassId = sensorParams.rgCompassId[_compassIndex].rawValue
-                                    for (var prioIndex=0; prioIndex<3; prioIndex++) {
+                                    let compassId = sensorParams.rgCompassId[_compassIndex].rawValue
+                                    for (let prioIndex=0; prioIndex<3; prioIndex++) {
                                         console.log(`comparing ${compassId} with ${sensorParams.rgCompassPrio[prioIndex].rawValue} (index ${prioIndex})`)
                                         if (compassId == sensorParams.rgCompassPrio[prioIndex].rawValue) {
                                             currentIndex = prioIndex
@@ -415,7 +415,7 @@ SetupPage {
 
                 QGCPopupDialog {
                     function compassMask () {
-                        var mask = 0
+                        let mask = 0
                         mask |=  (0 + (sensorParams.rgCompassPrio[0].rawValue !== 0)) << 0
                         mask |=  (0 + (sensorParams.rgCompassPrio[1].rawValue !== 0)) << 1
                         mask |=  (0 + (sensorParams.rgCompassPrio[2].rawValue !== 0)) << 2
@@ -429,8 +429,8 @@ SetupPage {
                             if (!northCalibrationCheckBox.checked) {
                                 controller.calibrateCompass()
                             } else {
-                                var lat = parseFloat(northCalLat.text)
-                                var lon = parseFloat(northCalLon.text)
+                                let lat = parseFloat(northCalLat.text)
+                                let lon = parseFloat(northCalLon.text)
                                 if (useMapPositionCheckbox.checked) {
                                     lat = _mapPosition.latitude
                                     lon = _mapPosition.longitude

--- a/src/AutoPilotPlugins/APM/APMTuningComponentCopter.qml
+++ b/src/AutoPilotPlugins/APM/APMTuningComponentCopter.qml
@@ -58,8 +58,8 @@ SetupPage {
             /// to find them and setup the ui accordindly.
             function calcAutoTuneChannel() {
                 _autoTuneSwitchChannelIndex = 0
-                for (var channel=_firstOptionChannel; channel<=_lastOptionChannel; channel++) {
-                    var optionFact = controller.getParameterFact(-1, "RC" + channel + "_OPTION")
+                for (let channel=_firstOptionChannel; channel<=_lastOptionChannel; channel++) {
+                    let optionFact = controller.getParameterFact(-1, "RC" + channel + "_OPTION")
                     if (optionFact.value == _autoTuneOption) {
                         _autoTuneSwitchChannelIndex = channel - _firstOptionChannel + 1
                         break
@@ -70,8 +70,8 @@ SetupPage {
             /// We need to clear AutoTune from any previous channel before setting it to a new one
             function setChannelAutoTuneOption(channel) {
                 // First clear any previous settings for AutTune
-                for (var optionChannel=_firstOptionChannel; optionChannel<=_lastOptionChannel; optionChannel++) {
-                    var optionFact = controller.getParameterFact(-1, "RC" + optionChannel + "_OPTION")
+                for (let optionChannel=_firstOptionChannel; optionChannel<=_lastOptionChannel; optionChannel++) {
+                    let optionFact = controller.getParameterFact(-1, "RC" + optionChannel + "_OPTION")
                     if (optionFact.value == _autoTuneOption) {
                         optionFact.value = 0
                     }
@@ -79,7 +79,7 @@ SetupPage {
 
                 // Now set the function into the new channel
                 if (channel != 0) {
-                    var optionFact = controller.getParameterFact(-1, "RC" + channel + "_OPTION")
+                    let optionFact = controller.getParameterFact(-1, "RC" + channel + "_OPTION")
                     optionFact.value = _autoTuneOption
                 }
             }
@@ -195,18 +195,21 @@ SetupPage {
                                 spacing: _margins
 
                                 QGCLabel { text: qsTr("Axes to AutoTune:") }
-                                FactBitmask { fact: _autoTuneAxes }
+                                FactBitmask {
+                                    fact: _autoTuneAxes
+                                    Layout.preferredWidth: tuningPage.availableWidth * 0.75
+                                }
                             }
 
                             LabelledComboBox {
                                 id:             autoTuneChannelCombo
-                                width:          ScreenTools.defaultFontPixelWidth * 14
+                                comboBoxPreferredWidth: ScreenTools.defaultFontPixelWidth * 30
                                 label:          qsTr("Channel for AutoTune switch:")
                                 model:          [qsTr("None"), qsTr("Channel 7"), qsTr("Channel 8"), qsTr("Channel 9"), qsTr("Channel 10"), qsTr("Channel 11"), qsTr("Channel 12") ]
                                 currentIndex:   _autoTuneSwitchChannelIndex
 
                                 onActivated: (index) => {
-                                    var channel = index
+                                    let channel = index
 
                                     if (channel > 0) {
                                         channel += 6
@@ -226,7 +229,7 @@ SetupPage {
 
                             LabelledFactComboBox {
                                 id:         optCombo
-                                width:      ScreenTools.defaultFontPixelWidth * 15
+                                comboBoxPreferredWidth: ScreenTools.defaultFontPixelWidth * 30
                                 label:      qsTr("RC Channel 6 Option (Tuning):")
                                 fact:       controller.getParameterFact(-1, "TUNE")
                                 indexModel: false

--- a/src/AutoPilotPlugins/APM/APMTuningComponentSub.qml
+++ b/src/AutoPilotPlugins/APM/APMTuningComponentSub.qml
@@ -1,5 +1,6 @@
 import QtQuick
 import QtQuick.Controls
+import QtQuick.Layouts
 
 import QGroundControl
 import QGroundControl.FactControls
@@ -12,7 +13,7 @@ SetupPage {
     Component {
         id: tuningPageComponent
 
-        Column {
+        ColumnLayout {
             width:      availableWidth
             spacing:    _margins
 
@@ -47,21 +48,14 @@ SetupPage {
                 }
             }
 
-            Rectangle {
+            QGCGroupBox {
                 id:                 atcParams
+                Layout.preferredWidth: tuningPage.availableWidth * 0.75
                 visible:            atcButton.checked
-                anchors.left:       parent.left
-                anchors.right:      parent.right
-                height:             posColumn.height + _margins*2
-                color:              qgcPal.windowShade
+                title:              qsTr("Attitude Controller Parameters")
 
                 Column {
                     id:                 posColumn
-                    width:              parent.width/2
-                    anchors.margins:    _margins
-                    anchors.left:       parent.left
-                    anchors.right:      parent.right
-                    anchors.top:        parent.top
                     spacing:            _margins*1.5
 
                     FactTextFieldSlider2 { fact: controller.getParameterFact(-1, "ATC_ANG_PIT_P") }
@@ -80,16 +74,14 @@ SetupPage {
                     FactTextFieldSlider2 { fact: controller.getParameterFact(-1, "ATC_RAT_YAW_IMAX") }
                     FactTextFieldSlider2 { fact: controller.getParameterFact(-1, "ATC_RAT_YAW_D") }
 
-                } // Column - Position Controller Parameters
-            } // Rectangle - Position Controller Parameters
+                } // Column - Attitude Controller Parameters
+            } // QGCGroupBox - Attitude Controller Parameters
 
-            Rectangle {
+            QGCGroupBox {
                 id:                 posParams
+                Layout.preferredWidth: tuningPage.availableWidth * 0.75
                 visible:            posButton.checked
-                anchors.left:       parent.left
-                anchors.right:      parent.right
-                height:             velColumn.height + _margins*2
-                color:              qgcPal.windowShade
+                title:              qsTr("Position Controller Parameters")
 
                 Component {
                     id: velColumnUpTo36
@@ -150,15 +142,13 @@ SetupPage {
 
                     sourceComponent: globals.activeVehicle.versionCompare(3, 6, 0) <= 0 ? velColumnUpTo36 :velColumn40
                 }
-            } // Rectangle - VEL parameters
+            } // QGCGroupBox - Position Controller Parameters
 
-            Rectangle {
+            QGCGroupBox {
                 id:                 navParams
+                Layout.preferredWidth: tuningPage.availableWidth * 0.75
                 visible:            navButton.checked
-                anchors.left:       parent.left
-                anchors.right:      parent.right
-                height:             wpnavColumn.height + _margins*2
-                color:              qgcPal.windowShade
+                title:              qsTr("Waypoint Navigation Parameters")
 
                 // WPNAV parameters up to 3.5
                 Component {
@@ -200,12 +190,30 @@ SetupPage {
                         FactTextFieldSlider2 { fact: controller.getParameterFact(-1, "WP_SPD") }
                         FactTextFieldSlider2 { fact: controller.getParameterFact(-1, "WP_SPD_DN") }
                         FactTextFieldSlider2 { fact: controller.getParameterFact(-1, "WP_SPD_UP") }
-                        FactTextFieldSlider2 { fact: controller.getParameterFact(-1, "LOIT_SPEED") }
-                        FactTextFieldSlider2 { fact: controller.getParameterFact(-1, "LOIT_ACC_MAX") }
-                        FactTextFieldSlider2 { fact: controller.getParameterFact(-1, "LOIT_ANG_MAX") }
-                        FactTextFieldSlider2 { fact: controller.getParameterFact(-1, "LOIT_BRK_ACCEL") }
-                        FactTextFieldSlider2 { fact: controller.getParameterFact(-1, "LOIT_BRK_DELAY") }
-                        FactTextFieldSlider2 { fact: controller.getParameterFact(-1, "LOIT_BRK_JERK") }
+                        FactTextFieldSlider2 {
+                            visible: controller.parameterExists(-1, "LOIT_SPEED")
+                            fact:    visible ? controller.getParameterFact(-1, "LOIT_SPEED") : null
+                        }
+                        FactTextFieldSlider2 {
+                            visible: controller.parameterExists(-1, "LOIT_ACC_MAX")
+                            fact:    visible ? controller.getParameterFact(-1, "LOIT_ACC_MAX") : null
+                        }
+                        FactTextFieldSlider2 {
+                            visible: controller.parameterExists(-1, "LOIT_ANG_MAX")
+                            fact:    visible ? controller.getParameterFact(-1, "LOIT_ANG_MAX") : null
+                        }
+                        FactTextFieldSlider2 {
+                            visible: controller.parameterExists(-1, "LOIT_BRK_ACCEL")
+                            fact:    visible ? controller.getParameterFact(-1, "LOIT_BRK_ACCEL") : null
+                        }
+                        FactTextFieldSlider2 {
+                            visible: controller.parameterExists(-1, "LOIT_BRK_DELAY")
+                            fact:    visible ? controller.getParameterFact(-1, "LOIT_BRK_DELAY") : null
+                        }
+                        FactTextFieldSlider2 {
+                            visible: controller.parameterExists(-1, "LOIT_BRK_JERK")
+                            fact:    visible ? controller.getParameterFact(-1, "LOIT_BRK_JERK") : null
+                        }
                     }
                 }
 
@@ -217,7 +225,7 @@ SetupPage {
 
                     sourceComponent: globals.activeVehicle.versionCompare(3, 6, 0) < 0 ? wpnavColumn35 : wpnavColumn36
                     }
-            } // Rectangle - WPNAV parameters
-        } // Column
+            } // QGCGroupBox - WPNAV parameters
+        } // ColumnLayout
     } // Component
-} // SetupView
+} // SetupPage

--- a/src/FactSystem/FactControls/FactTextFieldSlider2.qml
+++ b/src/FactSystem/FactControls/FactTextFieldSlider2.qml
@@ -117,7 +117,6 @@ Row {
                 id:                 slide
                 width:              parent.width - minLabel.width - maxLabel.width - _margins * 2
                 stepSize:           fact.increment ? Math.max(fact.increment, _minIncrement) : _minIncrement
-                mouseWheelSupport:  false
 
                 onValueChanged: {
                     if (_loadComplete) {


### PR DESCRIPTION
## Summary

Standardize all APM vehicle configuration pages to use consistent UI patterns (QGCGroupBox, standard control widths, sizeToContents combos) and fix several pre-existing bugs found during testing.

## UI Consistency Changes

- **QGCGroupBox**: Replace manual Rectangle+QGCLabel(bold) grouping with QGCGroupBox in 6 files (SafetyComponentSub, FlightModes, Follow, Lights, TuningSub, RemoteSupport)
- **Combo box sizing**: Add `sizeToContents` + `Layout.maximumWidth` to bare FactComboBox/QGCComboBox; add `comboBoxPreferredWidth` to all LabelledFactComboBox/LabelledComboBox instances
- **Text field widths**: Standardize to `ScreenTools.defaultFontPixelWidth * 15`
- **FactBitmask widths**: Set `Layout.preferredWidth` to 75% of available width for consistent bitmask display
- **QGCGroupBox sizing**: Remove `Layout.fillWidth` so group boxes size to their content rather than stretching full page width
- **var → let**: Convert deprecated `var` to `let` across 7 files (60+ instances)

## Bug Fixes

- **FactTextFieldSlider2**: Remove stale `mouseWheelSupport` property reference (property was removed from QGCSlider)
- **APMLightsComponent**: Add `parameterExists` guard for `BRD_PWM_COUNT`; fix fallback channel count so combo selections work when the parameter is absent
- **APMTuningComponentSub**: Add `parameterExists` guards for 6 `LOIT_*` parameters that don't exist in Sub firmware
- **APMFollowComponent**: Remove leftover `console.log` debug line
- **APMTuningComponentSub**: Fix misleading comment on Attitude Controller column
- **APMSafetyComponentSub**: Fix `ggcPal` typo → `qgcPal`

## Files Changed (15)

| File | Changes |
|------|---------|
| APMSafetyComponentSub.qml | Major rewrite: Flow→ColumnLayout, QGCGroupBox, GridLayout |
| APMFlightModesComponent.qml | Rectangle→QGCGroupBox (×2), sizeToContents combos |
| APMFollowComponent.qml | QGCGroupBox, merged GridLayouts, standard widths |
| APMLightsComponent.qml | QGCGroupBox+GridLayout, BRD_PWM_COUNT fix |
| APMTuningComponentSub.qml | QGCGroupBox (×3), LOIT_* param guards |
| APMRemoteSupportComponent.qml | Rectangle→QGCGroupBox |
| APMSafetyComponent.qml | comboBoxPreferredWidth (×18) |
| APMESCComponent.qml | comboBoxPreferredWidth (×3) |
| APMTuningComponentCopter.qml | FactBitmask width, comboBoxPreferredWidth |
| APMGimbalInstance.qml | comboBoxPreferredWidth (×4) |
| APMPowerComponent.qml | Remove Layout.fillWidth from QGCGroupBox (×2) |
| APMAirframeComponent.qml | var→let |
| APMSensorsComponent.qml | var→let |
| APMSensorIdDecoder.qml | var→let |
| FactTextFieldSlider2.qml | Remove stale mouseWheelSupport |

## Testing

Manually tested all APM config pages across Sub, Copter, Plane, and Rover SITL vehicles. All pages load without errors and controls render with consistent sizing.