### PR TITLE
Vehicle setup UI improvements

### DIFF
--- a/src/AutoPilotPlugins/APM/APMAutoPilotPlugin.cc
+++ b/src/AutoPilotPlugins/APM/APMAutoPilotPlugin.cc
@@ -24,6 +24,9 @@
 #include "Vehicle.h"
 #include "VehicleSupports.h"
 #include "VehicleComponent.h"
+
+#include <algorithm>
+
 #ifdef QT_DEBUG
 #include "APMFollowComponent.h"
 #include "ArduCopterFirmwarePlugin.h"
@@ -162,6 +165,10 @@ const QVariantList &APMAutoPilotPlugin::vehicleComponents()
         } else {
             qCWarning(APMAutoPilotPluginLog) << "Call to vehicleComponents prior to parametersReady";
         }
+
+        std::sort(_components.begin(), _components.end(), [](const QVariant &a, const QVariant &b) {
+            return a.value<VehicleComponent*>()->name().toLower() < b.value<VehicleComponent*>()->name().toLower();
+        });
     }
 
     return _components;

--- a/src/AutoPilotPlugins/PX4/PX4AutoPilotPlugin.cc
+++ b/src/AutoPilotPlugins/PX4/PX4AutoPilotPlugin.cc
@@ -12,6 +12,8 @@
 #include "Actuators.h"
 #include "ActuatorComponent.h"
 
+#include <algorithm>
+
 PX4AutoPilotPlugin::PX4AutoPilotPlugin(Vehicle* vehicle, QObject* parent)
     : AutoPilotPlugin(vehicle, parent)
     , _incorrectParameterVersion(false)
@@ -142,6 +144,10 @@ const QVariantList& PX4AutoPilotPlugin::vehicleComponents(void)
         } else {
             qWarning() << "Internal error";
         }
+
+        std::sort(_components.begin(), _components.end(), [](const QVariant &a, const QVariant &b) {
+            return a.value<VehicleComponent*>()->name().toLower() < b.value<VehicleComponent*>()->name().toLower();
+        });
     }
 
     return _components;

--- a/src/AutoPilotPlugins/PX4/PowerComponent.cc
+++ b/src/AutoPilotPlugins/PX4/PowerComponent.cc
@@ -20,7 +20,7 @@ QString PowerComponent::description(void) const
 
 QString PowerComponent::iconResource(void) const
 {
-    return "/qmlimages/PowerComponentIcon.png";
+    return "/qmlimages/Battery.svg";
 }
 
 bool PowerComponent::requiresSetup(void) const

--- a/src/UI/AppSettings/SettingsPagesModel.qml
+++ b/src/UI/AppSettings/SettingsPagesModel.qml
@@ -33,13 +33,6 @@ ListModel {
     }
 
     ListElement {
-        name: qsTr("Video")
-        url: "qrc:/qml/QGroundControl/AppSettings/VideoSettings.qml"
-        iconUrl: "qrc:/InstrumentValueIcons/camera.svg"
-        pageVisible: function() { return QGroundControl.settingsManager.videoSettings.visible }
-    }
-
-    ListElement {
         name: "Divider"
     }
 
@@ -105,6 +98,13 @@ ListModel {
         url: "qrc:/qml/QGroundControl/AppSettings/TelemetrySettings.qml"
         iconUrl: "qrc:/InstrumentValueIcons/drone.svg"
         pageVisible: function() { return true }
+    }
+
+    ListElement {
+        name: qsTr("Video")
+        url: "qrc:/qml/QGroundControl/AppSettings/VideoSettings.qml"
+        iconUrl: "qrc:/InstrumentValueIcons/camera.svg"
+        pageVisible: function() { return QGroundControl.settingsManager.videoSettings.visible }
     }
 
     ListElement {

--- a/src/Vehicle/VehicleSetup/SetupView.qml
+++ b/src/Vehicle/VehicleSetup/SetupView.qml
@@ -208,7 +208,7 @@ Rectangle {
 
         ColumnLayout {
             id:         buttonColumn
-            spacing:    ScreenTools.defaultFontPixelHeight / 4
+            spacing:    0
 
             ConfigButton {
                 id:                 summaryButton
@@ -220,12 +220,7 @@ Rectangle {
                 onClicked: showSummaryPanel()
             }
 
-            ConfigButton {
-                visible:            _activeVehicle ? _activeVehicle.flowImageIndex > 0 : false
-                text:               qsTr("Optical Flow")
-                Layout.fillWidth:   true
-                onClicked:          showPanel(this, "qrc:/qml/QGroundControl/VehicleSetup/OpticalFlowSensor.qml");
-            }
+            Item { Layout.fillWidth: true; Layout.preferredHeight: ScreenTools.defaultFontPixelHeight / 2 }
 
             Repeater {
                 id:     componentRepeater
@@ -242,6 +237,15 @@ Rectangle {
                     property var componentUrl: modelData
                 }
             }
+
+            ConfigButton {
+                visible:            _activeVehicle ? _activeVehicle.flowImageIndex > 0 : false
+                text:               qsTr("Optical Flow")
+                Layout.fillWidth:   true
+                onClicked:          showPanel(this, "qrc:/qml/QGroundControl/VehicleSetup/OpticalFlowSensor.qml");
+            }
+
+            Item { Layout.fillWidth: true; Layout.preferredHeight: ScreenTools.defaultFontPixelHeight / 2 }
 
             ConfigButton {
                 id:                 parametersButton


### PR DESCRIPTION
## Changes

- **PX4 Power icon**: Changed to `Battery.svg` to match ArduPilot's power component icon
- **Config page list spacing**: Set to `0` to match App Settings sidebar spacing
- **Visual grouping**: Added spacers after Summary and before Parameters/Firmware
- **Alphabetical sorting**: Vehicle components are now sorted alphabetically by name (both PX4 and APM)
- **Optical Flow**: Moved after vehicle components repeater
- **Video settings**: Moved to second group in App Settings