### PR TITLE
APM Safety: Modernize failsafe UI with vehicle-specific components

### DIFF
--- a/src/AutoPilotPlugins/APM/APMBatteryParams.qml
+++ b/src/AutoPilotPlugins/APM/APMBatteryParams.qml
@@ -41,12 +41,31 @@ QtObject {
         return 16
     }
 
+    /// Returns how many batteries have MONITOR enabled (rawValue != 0).
+    function getEnabledBatteryCount() {
+        let count = 0
+        let total = getBatteryCount()
+        for (let i = 0; i < total; i++) {
+            let mon = controller.getParameterFact(-1, prefixForIndex(i) + "MONITOR", false)
+            if (mon && mon.rawValue !== 0) count++
+        }
+        return count
+    }
+
     property Fact battMonitor: controller.getParameterFact(-1, _prefix + "MONITOR")
     property Fact battCapacity: controller.getParameterFact(-1, _prefix + "CAPACITY", false)
     property Fact battArmVolt: controller.getParameterFact(-1, _prefix + "ARM_VOLT", false)
     property Fact battAmpPerVolt: controller.getParameterFact(-1, _prefix + "AMP_PERVLT", false)
     property Fact battAmpOffset: controller.getParameterFact(-1, _prefix + "AMP_OFFSET", false)
     property Fact battVoltMult: controller.getParameterFact(-1, _prefix + "VOLT_MULT", false)
+
+    // Failsafe parameters
+    property Fact fsLowAct: controller.getParameterFact(-1, _prefix + "FS_LOW_ACT", false)
+    property Fact fsCritAct: controller.getParameterFact(-1, _prefix + "FS_CRT_ACT", false)
+    property Fact lowMah: controller.getParameterFact(-1, _prefix + "LOW_MAH", false)
+    property Fact critMah: controller.getParameterFact(-1, _prefix + "CRT_MAH", false)
+    property Fact lowVolt: controller.getParameterFact(-1, _prefix + "LOW_VOLT", false)
+    property Fact critVolt: controller.getParameterFact(-1, _prefix + "CRT_VOLT", false)
 
     property bool monitorEnabled: battMonitor.rawValue !== 0
     property bool paramsAvailable: controller.parameterExists(-1, _prefix + "CAPACITY")

--- a/src/AutoPilotPlugins/APM/APMSafetyComponent.qml
+++ b/src/AutoPilotPlugins/APM/APMSafetyComponent.qml
@@ -6,6 +6,17 @@ import QGroundControl
 import QGroundControl.FactControls
 import QGroundControl.Controls
 
+// Parameters that share the same name across vehicle types but have different metadata:
+//   FS_THR_ENABLE   — Copter (8 values, 0-7) vs Rover (3 values, 0-2)                      [split: copterThrottleFailsafe / roverThrottleFailsafe]
+//   FS_GCS_ENABLE   — Copter (8 values, 0-7) vs Rover (3 values, 0-2)                      [split: copterGcsFailsafe / roverGcsFailsafe]
+//   FS_OPTIONS      — Copter (6 bitmask bits, 0-5) vs Rover (1 bitmask bit, 0 only)        [handled inline per component; Plane has no FS_OPTIONS]
+//   FS_EKF_ACTION   — Copter (Report/Land/AltHold/LandAlways) vs Rover (Disabled/Hold/Report) [split: copterEkfFailsafe / roverEkfFailsafe]
+//   FS_EKF_THRESH   — Copter adds "0: Disabled"; Plane/Rover do not                        [split: copterEkfFailsafe / roverEkfFailsafe]
+//   FS_CRASH_CHECK  — Copter (0/1) vs Rover (0/1/2 adds HoldAndDisarm)                     [split: copterGeneralFS / roverGeneralFS]
+//   FENCE_ACTION    — All 3 vehicle types have completely different action sets              [copter-only: copterGeoFence]
+//   BATT_FS_LOW_ACT — All 3 vehicle types have different action sets                        [shared: batteryFailsafeComponent — uses combo from firmware metadata]
+//   BATT_FS_CRT_ACT — All 3 vehicle types have different action sets                        [shared: batteryFailsafeComponent — uses combo from firmware metadata]
+
 SetupPage {
     id:             safetyPage
     pageComponent:  safetyPageComponent
@@ -18,30 +29,20 @@ SetupPage {
             width:      availableWidth
             spacing:    ScreenTools.defaultFontPixelHeight
 
+            property var _controller: controller
+
             FactPanelController { id: controller; }
 
             QGCPalette { id: qgcPal; colorGroupEnabled: true }
 
-            property Fact _batt1Monitor:                    controller.getParameterFact(-1, "BATT_MONITOR")
-            property Fact _batt2Monitor:                    controller.getParameterFact(-1, "BATT2_MONITOR", false /* reportMissing */)
-            property bool _batt2MonitorAvailable:           controller.parameterExists(-1, "BATT2_MONITOR")
-            property bool _batt1MonitorEnabled:             _batt1Monitor.rawValue !== 0
-            property bool _batt2MonitorEnabled:             _batt2MonitorAvailable ? _batt2Monitor.rawValue !== 0 : false
-            property bool _batt1ParamsAvailable:            controller.parameterExists(-1, "BATT_CAPACITY")
-            property bool _batt2ParamsAvailable:            controller.parameterExists(-1, "BATT2_CAPACITY")
+            APMBatteryParams {
+                id:           battParams
+                controller:   _controller
+                batteryIndex: 0
+            }
 
-            property Fact _failsafeBatt1LowAct:             controller.getParameterFact(-1, "BATT_FS_LOW_ACT", false /* reportMissing */)
-            property Fact _failsafeBatt2LowAct:             controller.getParameterFact(-1, "BATT2_FS_LOW_ACT", false /* reportMissing */)
-            property Fact _failsafeBatt1CritAct:            controller.getParameterFact(-1, "BATT_FS_CRT_ACT", false /* reportMissing */)
-            property Fact _failsafeBatt2CritAct:            controller.getParameterFact(-1, "BATT2_FS_CRT_ACT", false /* reportMissing */)
-            property Fact _failsafeBatt1LowMah:             controller.getParameterFact(-1, "BATT_LOW_MAH", false /* reportMissing */)
-            property Fact _failsafeBatt2LowMah:             controller.getParameterFact(-1, "BATT2_LOW_MAH", false /* reportMissing */)
-            property Fact _failsafeBatt1CritMah:            controller.getParameterFact(-1, "BATT_CRT_MAH", false /* reportMissing */)
-            property Fact _failsafeBatt2CritMah:            controller.getParameterFact(-1, "BATT2_CRT_MAH", false /* reportMissing */)
-            property Fact _failsafeBatt1LowVoltage:         controller.getParameterFact(-1, "BATT_LOW_VOLT", false /* reportMissing */)
-            property Fact _failsafeBatt2LowVoltage:         controller.getParameterFact(-1, "BATT2_LOW_VOLT", false /* reportMissing */)
-            property Fact _failsafeBatt1CritVoltage:        controller.getParameterFact(-1, "BATT_CRT_VOLT", false /* reportMissing */)
-            property Fact _failsafeBatt2CritVoltage:        controller.getParameterFact(-1, "BATT2_CRT_VOLT", false /* reportMissing */)
+            property int  _batteryCount:        battParams.getBatteryCount()
+            property int  _enabledBatteryCount:  battParams.getEnabledBatteryCount()
 
             // Older firmwares use ARMING_CHECK. Newer firmwares use ARMING_SKIPCHK.
             property Fact _armingCheck: controller.getParameterFact(-1, "ARMING_CHECK", false /* reportMissing */)
@@ -53,6 +54,172 @@ SetupPage {
             property bool _roverFirmware:   controller.parameterExists(-1, "MODE1") // This catches all usage of ArduRover firmware vehicle types: Rover, Boat...
 
             property string _restartRequired: qsTr("Requires vehicle reboot")
+
+            // FS_OPTIONS bitmask constants (from ArduCopter FailsafeOption enum)
+            readonly property int _fsOptionRCContinueAuto:       1   // Bit 0: Continue in Auto on RC/Throttle failsafe
+            readonly property int _fsOptionGCSContinueAuto:      2   // Bit 1: Continue in Auto on GCS failsafe
+            readonly property int _fsOptionRCContinueGuided:     4   // Bit 2: Continue in Guided on RC/Throttle failsafe
+            readonly property int _fsOptionContinueLanding:      8   // Bit 3: Continue if landing on any failsafe
+            readonly property int _fsOptionGCSContinuePilot:     16  // Bit 4: Continue in pilot control on GCS failsafe
+            readonly property int _fsOptionReleaseGripper:       32  // Bit 5: Release gripper on any failsafe
+
+            property bool _fsOptionsAvailable: controller.parameterExists(-1, "FS_OPTIONS")
+            property Fact _fsOptions:          controller.getParameterFact(-1, "FS_OPTIONS", false /* reportMissing */)
+
+            // FS_THR_ENABLE value constants (from ArduCopter)
+            readonly property int _fsThrDisabled:                    0
+            readonly property int _fsThrEnabledAlwaysRTL:            1
+            readonly property int _fsThrEnabledAlwaysLand:           3
+            readonly property int _fsThrEnabledAlwaysSmartRTLOrRTL:  4
+            readonly property int _fsThrEnabledAlwaysSmartRTLOrLand: 5
+            readonly property int _fsThrEnabledAutoDoLandOrRTL:      6
+            readonly property int _fsThrEnabledAlwaysBrakeOrLand:    7
+
+            // FS_DR_ENABLE value constants (from ArduCopter)
+            readonly property int _fsDrDisabled:                    0
+            readonly property int _fsDrLand:                        1
+            readonly property int _fsDrRTL:                         2
+            readonly property int _fsDrSmartRTLOrRTL:               3
+            readonly property int _fsDrSmartRTLOrLand:              4
+            readonly property int _fsDrAutoDoLandOrRTL:             6
+
+            // FS_GCS_ENABLE value constants (from ArduCopter)
+            readonly property int _fsGcsDisabled:                   0
+            readonly property int _fsGcsRTL:                        1
+            readonly property int _fsGcsSmartRTLOrRTL:              3
+            readonly property int _fsGcsSmartRTLOrLand:             4
+            readonly property int _fsGcsLand:                       5
+            readonly property int _fsGcsAutoDoLandOrRTL:            6
+            readonly property int _fsGcsBrakeOrLand:                7
+
+            // ----- Loaders (display order) -----
+
+            Loader {
+                sourceComponent: controller.vehicle.multiRotor ? copterRTL : undefined
+            }
+
+            Loader {
+                sourceComponent: controller.vehicle.fixedWing ? planeRTL : undefined
+            }
+
+            Repeater {
+                model: _batteryCount
+
+                QGCGroupBox {
+                    required property int index
+
+                    APMBatteryParams {
+                        id:           _batt
+                        controller:   _controller
+                        batteryIndex: index
+                    }
+
+                    title:   _enabledBatteryCount > 1
+                                ? qsTr("Battery %1 Failsafe").arg(battParams.labelForIndex(index))
+                                : qsTr("Battery Failsafe")
+                    visible: _batt.monitorEnabled
+
+                    Loader {
+                        sourceComponent: _batt.paramsAvailable ? batteryFailsafeComponent : restartRequiredComponent
+
+                        property Fact failsafeBattLowAct:      _batt.fsLowAct
+                        property Fact failsafeBattCritAct:     _batt.fsCritAct
+                        property Fact failsafeBattLowMah:      _batt.lowMah
+                        property Fact failsafeBattCritMah:     _batt.critMah
+                        property Fact failsafeBattLowVoltage:  _batt.lowVolt
+                        property Fact failsafeBattCritVoltage: _batt.critVolt
+                    }
+                }
+            }
+
+            Loader {
+                sourceComponent: controller.vehicle.multiRotor ? copterGcsFailsafe : undefined
+            }
+
+            Loader {
+                sourceComponent: controller.vehicle.fixedWing ? planeGcsFailsafe : undefined
+            }
+
+            Loader {
+                sourceComponent: _roverFirmware ? roverGcsFailsafe : undefined
+            }
+
+            Loader {
+                sourceComponent: controller.vehicle.fixedWing ? planeGeneralFS : undefined
+            }
+
+            Loader {
+                sourceComponent: controller.vehicle.multiRotor ? rcFailsafeComponent : undefined
+            }
+
+            Loader {
+                sourceComponent: controller.vehicle.multiRotor ? copterThrottleFailsafe : undefined
+            }
+
+            Loader {
+                sourceComponent: _roverFirmware ? roverThrottleFailsafe : undefined
+            }
+
+            Loader {
+                sourceComponent: controller.vehicle.multiRotor ? copterEkfFailsafe : undefined
+            }
+
+            Loader {
+                sourceComponent: _roverFirmware ? roverEkfFailsafe : undefined
+            }
+
+            Loader {
+                sourceComponent: (controller.vehicle.multiRotor && controller.parameterExists(-1, "FS_DR_ENABLE")) ? deadReckoningFailsafeComponent : undefined
+            }
+
+            Loader {
+                sourceComponent: controller.vehicle.multiRotor ? copterGeneralFS : undefined
+            }
+
+            Loader {
+                sourceComponent: _roverFirmware ? roverGeneralFS : undefined
+            }
+
+            Loader {
+                sourceComponent: controller.vehicle.multiRotor ? copterGeoFence : undefined
+            }
+
+            QGCGroupBox {
+                id:    armingChecksGroupBox
+                title: _armingCheck ? qsTr("Arming Checks") : qsTr("Skip Arming Checks")
+
+                property bool _hasSkippedChecks: _armingCheck ? _armingCheck.value != 1 : _armingSkipCheck.value != 0
+                property bool _allowEditing: false
+
+                ColumnLayout {
+                    spacing: _margins
+
+                    QGCLabel {
+                        wrapMode:           Text.WordWrap
+                        color:              qgcPal.warningText
+                        text:               qsTr("Warning: Skipping arming checks can lead to loss of Vehicle control.")
+                        Layout.fillWidth:   true
+                    }
+
+                    QGCCheckBoxSlider {
+                        Layout.fillWidth:   true
+                        text:               qsTr("Allow changes")
+                        checked:            armingChecksGroupBox._hasSkippedChecks || armingChecksGroupBox._allowEditing
+                        enabled:            !armingChecksGroupBox._hasSkippedChecks
+
+                        onClicked: armingChecksGroupBox._allowEditing = checked
+                    }
+
+                    FactBitmask {
+                        firstEntryIsAll:        _armingCheck ? true : false
+                        fact:                   _armingCheck ? _armingCheck : _armingSkipCheck
+                        Layout.preferredWidth:  safetyPage.availableWidth * 0.75
+                        visible:                armingChecksGroupBox._hasSkippedChecks || armingChecksGroupBox._allowEditing
+                    }
+                }
+            }
+
+            // ----- Component definitions -----
 
             Component {
                 id: batteryFailsafeComponent
@@ -121,472 +288,6 @@ SetupPage {
                         onClicked:  controller.vehicle.rebootVehicle()
                     }
                 }
-            }
-
-            QGCGroupBox {
-                title:   qsTr("Battery1 Failsafe Triggers")
-                visible: _batt1MonitorEnabled
-
-                Loader {
-                    id:              battery1FailsafeLoader
-                    sourceComponent: _batt1ParamsAvailable ? batteryFailsafeComponent : restartRequiredComponent
-
-                    property Fact battMonitor:              _batt1Monitor
-                    property bool battParamsAvailable:      _batt1ParamsAvailable
-                    property Fact failsafeBattLowAct:       _failsafeBatt1LowAct
-                    property Fact failsafeBattCritAct:      _failsafeBatt1CritAct
-                    property Fact failsafeBattLowMah:       _failsafeBatt1LowMah
-                    property Fact failsafeBattCritMah:      _failsafeBatt1CritMah
-                    property Fact failsafeBattLowVoltage:   _failsafeBatt1LowVoltage
-                    property Fact failsafeBattCritVoltage:  _failsafeBatt1CritVoltage
-                }
-            }
-
-            QGCGroupBox {
-                title:   qsTr("Battery2 Failsafe Triggers")
-                visible: _batt2MonitorEnabled
-
-                Loader {
-                    id:              battery2FailsafeLoader
-                    sourceComponent: _batt2ParamsAvailable ? batteryFailsafeComponent : restartRequiredComponent
-
-                    property Fact battMonitor:              _batt2Monitor
-                    property bool battParamsAvailable:      _batt2ParamsAvailable
-                    property Fact failsafeBattLowAct:       _failsafeBatt2LowAct
-                    property Fact failsafeBattCritAct:      _failsafeBatt2CritAct
-                    property Fact failsafeBattLowMah:       _failsafeBatt2LowMah
-                    property Fact failsafeBattCritMah:      _failsafeBatt2CritMah
-                    property Fact failsafeBattLowVoltage:   _failsafeBatt2LowVoltage
-                    property Fact failsafeBattCritVoltage:  _failsafeBatt2CritVoltage
-                }
-            }
-
-            Component {
-                id: planeGeneralFS
-
-                QGCGroupBox {
-                    title: qsTr("Failsafe Triggers")
-
-                    property Fact _failsafeThrEnable:      controller.getParameterFact(-1, "THR_FAILSAFE")
-                    property Fact _failsafeThrValue:       controller.getParameterFact(-1, "THR_FS_VALUE")
-                    property Fact _failsafeGCSEnable:      controller.getParameterFact(-1, "FS_GCS_ENABL")
-                    property Fact _failsafeShortAction:    controller.getParameterFact(-1, "FS_SHORT_ACTN")
-                    property Fact _failsafeLongAction:     controller.getParameterFact(-1, "FS_LONG_ACTN")
-                    property Fact _failsafeLongTimeout:    controller.getParameterFact(-1, "FS_LONG_TIMEOUT")
-                    property bool _isQuadPlane:            controller.parameterExists(-1, "Q_TRANS_FAIL")
-                    property Fact _transFailTimeout:       controller.getParameterFact(-1, "Q_TRANS_FAIL", false /* reportMissing */)
-                    property Fact _transFailAction:        controller.getParameterFact(-1, "Q_TRANS_FAIL_ACT", false /* reportMissing */)
-
-                    ColumnLayout {
-                        spacing: _margins
-
-                        LabelledFactComboBox {
-                            label:            qsTr("Ground Station failsafe")
-                            fact:             _failsafeGCSEnable
-                            indexModel:       false
-                            comboBoxPreferredWidth: _comboWidth
-                            Layout.fillWidth: true
-                        }
-
-                        RowLayout {
-                            Layout.fillWidth: true
-
-                            QGCCheckBox {
-                                id:                 throttleEnableCheckBox
-                                text:               qsTr("Throttle PWM threshold")
-                                checked:            _failsafeThrEnable.value === 1
-                                Layout.fillWidth:   true
-
-                                onClicked: _failsafeThrEnable.value = (checked ? 1 : 0)
-                            }
-
-                            FactTextField {
-                                fact:               _failsafeThrValue
-                                showUnits:          true
-                                enabled:            throttleEnableCheckBox.checked
-                            }
-                        }
-
-                        LabelledFactComboBox {
-                            label:            qsTr("Short failsafe action")
-                            fact:             _failsafeShortAction
-                            indexModel:       false
-                            comboBoxPreferredWidth: _comboWidth
-                            Layout.fillWidth: true
-                        }
-
-                        LabelledFactComboBox {
-                            label:            qsTr("Long failsafe action")
-                            fact:             _failsafeLongAction
-                            indexModel:       false
-                            comboBoxPreferredWidth: _comboWidth
-                            Layout.fillWidth: true
-                        }
-
-                        LabelledFactTextField {
-                            label:              qsTr("Long failsafe timeout")
-                            fact:               _failsafeLongTimeout
-                            textFieldShowUnits: true
-                            Layout.fillWidth:   true
-                        }
-
-                        LabelledFactComboBox {
-                            label:            qsTr("VTOL transition failure action")
-                            fact:             _transFailAction
-                            indexModel:       false
-                            comboBoxPreferredWidth: _comboWidth
-                            Layout.fillWidth: true
-                            visible:          _isQuadPlane
-                        }
-
-                        LabelledFactTextField {
-                            label:              qsTr("VTOL transition failure timeout")
-                            fact:               _transFailTimeout
-                            textFieldShowUnits: true
-                            Layout.fillWidth:   true
-                            visible:            _isQuadPlane
-                        }
-                    }
-                }
-            }
-
-            Loader {
-                sourceComponent: controller.vehicle.fixedWing ? planeGeneralFS : undefined
-            }
-
-            Component {
-                id: roverGeneralFS
-
-                QGCGroupBox {
-                    title: qsTr("Failsafe Triggers")
-
-                    property Fact _failsafeGCSEnable:   controller.getParameterFact(-1, "FS_GCS_ENABLE")
-                    property Fact _failsafeGCSTimeout:  controller.getParameterFact(-1, "FS_GCS_TIMEOUT")
-                    property Fact _failsafeThrEnable:   controller.getParameterFact(-1, "FS_THR_ENABLE")
-                    property Fact _failsafeThrValue:    controller.getParameterFact(-1, "FS_THR_VALUE")
-                    property Fact _failsafeAction:      controller.getParameterFact(-1, "FS_ACTION")
-                    property Fact _failsafeTimeout:     controller.getParameterFact(-1, "FS_TIMEOUT")
-                    property Fact _failsafeCrashCheck:  controller.getParameterFact(-1, "FS_CRASH_CHECK")
-                    property Fact _failsafeEkfAction:   controller.getParameterFact(-1, "FS_EKF_ACTION")
-                    property Fact _failsafeEkfThresh:   controller.getParameterFact(-1, "FS_EKF_THRESH")
-
-                    ColumnLayout {
-                        spacing: _margins
-
-                        LabelledFactComboBox {
-                            label:            qsTr("Ground Station failsafe")
-                            fact:             _failsafeGCSEnable
-                            indexModel:       false
-                            comboBoxPreferredWidth: _comboWidth
-                            Layout.fillWidth: true
-                        }
-
-                        LabelledFactTextField {
-                            label:              qsTr("GCS failsafe timeout")
-                            fact:               _failsafeGCSTimeout
-                            textFieldShowUnits: true
-                            Layout.fillWidth:   true
-                        }
-
-                        LabelledFactComboBox {
-                            label:            qsTr("Throttle failsafe")
-                            fact:             _failsafeThrEnable
-                            indexModel:       false
-                            comboBoxPreferredWidth: _comboWidth
-                            Layout.fillWidth: true
-                        }
-
-                        LabelledFactTextField {
-                            label:            qsTr("PWM threshold")
-                            fact:             _failsafeThrValue
-                            Layout.fillWidth: true
-                        }
-
-                        LabelledFactComboBox {
-                            label:            qsTr("Failsafe action")
-                            fact:             _failsafeAction
-                            indexModel:       false
-                            comboBoxPreferredWidth: _comboWidth
-                            Layout.fillWidth: true
-                        }
-
-                        LabelledFactTextField {
-                            label:              qsTr("Failsafe timeout")
-                            fact:               _failsafeTimeout
-                            textFieldShowUnits: true
-                            Layout.fillWidth:   true
-                        }
-
-                        LabelledFactComboBox {
-                            label:            qsTr("Crash check")
-                            fact:             _failsafeCrashCheck
-                            indexModel:       false
-                            comboBoxPreferredWidth: _comboWidth
-                            Layout.fillWidth: true
-                        }
-
-                        LabelledFactComboBox {
-                            label:            qsTr("EKF failsafe action")
-                            fact:             _failsafeEkfAction
-                            indexModel:       false
-                            comboBoxPreferredWidth: _comboWidth
-                            Layout.fillWidth: true
-                        }
-
-                        LabelledFactTextField {
-                            label:            qsTr("EKF failsafe threshold")
-                            fact:             _failsafeEkfThresh
-                            Layout.fillWidth: true
-                        }
-                    }
-                }
-            }
-
-            Loader {
-                sourceComponent: _roverFirmware ? roverGeneralFS : undefined
-            }
-
-            Component {
-                id: failsafeOptionsComponent
-
-                QGCGroupBox {
-                    title: qsTr("Failsafe Options")
-
-                    property Fact _failsafeOptions: controller.getParameterFact(-1, "FS_OPTIONS")
-
-                    ColumnLayout {
-                        spacing: _margins
-
-                        FactBitmask {
-                            fact: _failsafeOptions
-                            Layout.preferredWidth:  safetyPage.availableWidth * 0.75
-                        }
-                    }
-                }
-            }
-
-            Loader {
-                sourceComponent: _roverFirmware ? failsafeOptionsComponent : undefined
-            }
-
-            Component {
-                id: copterGeneralFS
-
-                QGCGroupBox {
-                    title: qsTr("General Failsafe Triggers")
-
-                    property Fact _failsafeGCSEnable:     controller.getParameterFact(-1, "FS_GCS_ENABLE")
-                    property Fact _failsafeGCSTimeout:    controller.getParameterFact(-1, "FS_GCS_TIMEOUT")
-                    property Fact _failsafeThrEnable:     controller.getParameterFact(-1, "FS_THR_ENABLE")
-                    property Fact _failsafeThrValue:      controller.getParameterFact(-1, "FS_THR_VALUE")
-                    property Fact _failsafeEkfAction:     controller.getParameterFact(-1, "FS_EKF_ACTION")
-                    property Fact _failsafeEkfThresh:     controller.getParameterFact(-1, "FS_EKF_THRESH")
-                    property Fact _failsafeEkfFilt:       controller.getParameterFact(-1, "FS_EKF_FILT")
-                    property Fact _failsafeCrashCheck:    controller.getParameterFact(-1, "FS_CRASH_CHECK")
-                    property Fact _failsafeVibeEnable:    controller.getParameterFact(-1, "FS_VIBE_ENABLE")
-                    property Fact _failsafeDREnable:      controller.getParameterFact(-1, "FS_DR_ENABLE")
-                    property Fact _failsafeDRTimeout:     controller.getParameterFact(-1, "FS_DR_TIMEOUT")
-
-                    ColumnLayout {
-                        spacing: _margins
-
-                        LabelledFactComboBox {
-                            label:            qsTr("Ground Station failsafe")
-                            fact:             _failsafeGCSEnable
-                            indexModel:       false
-                            comboBoxPreferredWidth: _comboWidth
-                            Layout.fillWidth: true
-                        }
-
-                        LabelledFactTextField {
-                            label:              qsTr("GCS failsafe timeout")
-                            fact:               _failsafeGCSTimeout
-                            textFieldShowUnits: true
-                            Layout.fillWidth:   true
-                        }
-
-                        LabelledFactComboBox {
-                            label:            qsTr("Throttle failsafe")
-                            fact:             _failsafeThrEnable
-                            indexModel:       false
-                            comboBoxPreferredWidth: _comboWidth
-                            Layout.fillWidth: true
-                        }
-
-                        LabelledFactTextField {
-                            label:              qsTr("PWM threshold")
-                            fact:               _failsafeThrValue
-                            textFieldShowUnits: true
-                            Layout.fillWidth:   true
-                        }
-
-                        LabelledFactComboBox {
-                            label:            qsTr("EKF failsafe action")
-                            fact:             _failsafeEkfAction
-                            indexModel:       false
-                            comboBoxPreferredWidth: _comboWidth
-                            Layout.fillWidth: true
-                        }
-
-                        LabelledFactTextField {
-                            label:            qsTr("EKF failsafe threshold")
-                            fact:             _failsafeEkfThresh
-                            Layout.fillWidth: true
-                        }
-
-                        LabelledFactTextField {
-                            label:              qsTr("EKF failsafe filter")
-                            fact:               _failsafeEkfFilt
-                            textFieldShowUnits: true
-                            Layout.fillWidth:   true
-                        }
-
-                        LabelledFactComboBox {
-                            label:            qsTr("Crash check")
-                            fact:             _failsafeCrashCheck
-                            indexModel:       false
-                            comboBoxPreferredWidth: _comboWidth
-                            Layout.fillWidth: true
-                        }
-
-                        LabelledFactComboBox {
-                            label:            qsTr("Vibration failsafe")
-                            fact:             _failsafeVibeEnable
-                            indexModel:       false
-                            comboBoxPreferredWidth: _comboWidth
-                            Layout.fillWidth: true
-                        }
-
-                        LabelledFactComboBox {
-                            label:            qsTr("Dead reckoning failsafe")
-                            fact:             _failsafeDREnable
-                            indexModel:       false
-                            comboBoxPreferredWidth: _comboWidth
-                            Layout.fillWidth: true
-                        }
-
-                        LabelledFactTextField {
-                            label:              qsTr("Dead reckoning timeout")
-                            fact:               _failsafeDRTimeout
-                            textFieldShowUnits: true
-                            Layout.fillWidth:   true
-                        }
-                    }
-                }
-            }
-
-            Loader {
-                sourceComponent: controller.vehicle.multiRotor ? copterGeneralFS : undefined
-            }
-
-            Loader {
-                sourceComponent: controller.vehicle.multiRotor ? failsafeOptionsComponent : undefined
-            }
-
-            Component {
-                id: copterGeoFence
-
-                QGCGroupBox {
-                    title: qsTr("GeoFence")
-
-                    property Fact _fenceAction: controller.getParameterFact(-1, "FENCE_ACTION")
-                    property Fact _fenceAltMax: controller.getParameterFact(-1, "FENCE_ALT_MAX")
-                    property Fact _fenceEnable: controller.getParameterFact(-1, "FENCE_ENABLE")
-                    property Fact _fenceMargin: controller.getParameterFact(-1, "FENCE_MARGIN")
-                    property Fact _fenceRadius: controller.getParameterFact(-1, "FENCE_RADIUS")
-                    property Fact _fenceType:   controller.getParameterFact(-1, "FENCE_TYPE")
-
-                    readonly property int _maxAltitudeFenceBitMask: 1
-                    readonly property int _circleFenceBitMask:      2
-                    readonly property int _polygonFenceBitMask:     4
-
-                    ColumnLayout {
-                        spacing: ScreenTools.defaultFontPixelHeight / 2
-
-                        FactCheckBox {
-                            id:     enabledCheckBox
-                            text:   qsTr("Enabled")
-                            fact:   _fenceEnable
-                        }
-
-                        ColumnLayout {
-                            enabled: enabledCheckBox.checked
-
-                            RowLayout {
-                                QGCCheckBox {
-                                    text:    qsTr("Maximum Altitude")
-                                    checked: _fenceType.rawValue & _maxAltitudeFenceBitMask
-
-                                    onClicked: {
-                                        if (checked) {
-                                            _fenceType.rawValue |= _maxAltitudeFenceBitMask
-                                        } else {
-                                            _fenceType.value &= ~_maxAltitudeFenceBitMask
-                                        }
-                                    }
-                                }
-
-                                FactTextField {
-                                    fact: _fenceAltMax
-                                }
-                            }
-
-                            RowLayout {
-                                QGCCheckBox {
-                                    text:    qsTr("Circle centered on Home")
-                                    checked: _fenceType.rawValue & _circleFenceBitMask
-
-                                    onClicked: {
-                                        if (checked) {
-                                            _fenceType.rawValue |= _circleFenceBitMask
-                                        } else {
-                                            _fenceType.value &= ~_circleFenceBitMask
-                                        }
-                                    }
-                                }
-
-                                FactTextField {
-                                    fact:      _fenceRadius
-                                    showUnits: true
-                                }
-                            }
-
-                            QGCCheckBox {
-                                text:    qsTr("Inclusion/Exclusion Circles+Polygons")
-                                checked: _fenceType.rawValue & _polygonFenceBitMask
-
-                                onClicked: {
-                                    if (checked) {
-                                        _fenceType.rawValue |= _polygonFenceBitMask
-                                    } else {
-                                        _fenceType.value &= ~_polygonFenceBitMask
-                                    }
-                                }
-                            }
-                        }
-
-                        ColumnLayout {
-                            enabled: enabledCheckBox.checked
-
-                            LabelledFactComboBox {
-                                label:            qsTr("Breach action")
-                                fact:             _fenceAction
-                                comboBoxPreferredWidth: _comboWidth
-                                Layout.fillWidth: true
-                            }
-
-                            LabelledFactTextField {
-                                label:            qsTr("Fence margin")
-                                fact:             _fenceMargin
-                                Layout.fillWidth: true
-                            }
-                        }
-                    }
-                }
-            }
-
-            Loader {
-                sourceComponent: controller.vehicle.multiRotor ? copterGeoFence : undefined
             }
 
             Component {
@@ -686,10 +387,6 @@ SetupPage {
                 }
             }
 
-            Loader {
-                sourceComponent: controller.vehicle.multiRotor ? copterRTL : undefined
-            }
-
             Component {
                 id: planeRTL
 
@@ -728,28 +425,1070 @@ SetupPage {
                 }
             }
 
-            Loader {
-                sourceComponent: controller.vehicle.fixedWing ? planeRTL : undefined
+            Component {
+                id: copterGcsFailsafe
+
+                QGCGroupBox {
+                    title: qsTr("Ground Station Failsafe")
+
+                    property Fact _gcsEnable:  controller.getParameterFact(-1, "FS_GCS_ENABLE")
+                    property Fact _gcsTimeout: controller.getParameterFact(-1, "FS_GCS_TIMEOUT")
+                    property bool _gcsEnabled: _gcsEnable.rawValue !== _fsGcsDisabled
+
+                    ColumnLayout {
+                        spacing: _margins
+
+                        QGCCheckBoxSlider {
+                            Layout.fillWidth:   true
+                            text:               qsTr("Enabled")
+                            checked:            _gcsEnabled
+
+                            onClicked: {
+                                if (checked) {
+                                    _gcsEnable.rawValue = _fsGcsRTL
+                                } else {
+                                    _gcsEnable.rawValue = _fsGcsDisabled
+                                }
+                            }
+                        }
+
+                        LabelledFactTextField {
+                            label:              qsTr("Timeout")
+                            fact:               _gcsTimeout
+                            textFieldShowUnits: true
+                            Layout.fillWidth:   true
+                            visible:            _gcsEnabled
+                        }
+
+                        ColumnLayout {
+                            spacing: 0
+                            visible: _gcsEnabled
+
+                            QGCLabel { text: qsTr("Action:") }
+
+                            QGCRadioButton {
+                                text:      qsTr("RTL")
+                                checked:   _gcsEnable.rawValue === _fsGcsRTL
+                                onClicked: _gcsEnable.rawValue = _fsGcsRTL
+                            }
+
+                            QGCRadioButton {
+                                text:      qsTr("Land")
+                                checked:   _gcsEnable.rawValue === _fsGcsLand
+                                onClicked: _gcsEnable.rawValue = _fsGcsLand
+                            }
+
+                            QGCRadioButton {
+                                text:      qsTr("SmartRTL or RTL")
+                                checked:   _gcsEnable.rawValue === _fsGcsSmartRTLOrRTL
+                                onClicked: _gcsEnable.rawValue = _fsGcsSmartRTLOrRTL
+                            }
+
+                            QGCRadioButton {
+                                text:      qsTr("SmartRTL or Land")
+                                checked:   _gcsEnable.rawValue === _fsGcsSmartRTLOrLand
+                                onClicked: _gcsEnable.rawValue = _fsGcsSmartRTLOrLand
+                            }
+
+                            QGCRadioButton {
+                                text:      qsTr("Auto DO_LAND_START or RTL")
+                                checked:   _gcsEnable.rawValue === _fsGcsAutoDoLandOrRTL
+                                onClicked: _gcsEnable.rawValue = _fsGcsAutoDoLandOrRTL
+                            }
+
+                            QGCRadioButton {
+                                text:      qsTr("Brake or Land")
+                                checked:   _gcsEnable.rawValue === _fsGcsBrakeOrLand
+                                onClicked: _gcsEnable.rawValue = _fsGcsBrakeOrLand
+                            }
+                        }
+
+                        QGCLabel {
+                            text:    qsTr("Ignore failsafe if:")
+                            visible: _fsOptionsAvailable && _gcsEnabled
+                        }
+
+                        ColumnLayout {
+                            Layout.fillWidth:   true
+                            Layout.leftMargin:  ScreenTools.defaultFontPixelWidth * 2
+                            spacing:            _margins
+                            visible:            _fsOptionsAvailable && _gcsEnabled
+
+                            FactBitMaskCheckBoxSlider {
+                                Layout.fillWidth:   true
+                                text:               qsTr("In Auto mode")
+                                fact:               _fsOptions
+                                bitMask:            _fsOptionGCSContinueAuto
+                            }
+
+                            FactBitMaskCheckBoxSlider {
+                                Layout.fillWidth:   true
+                                text:               qsTr("In pilot control")
+                                fact:               _fsOptions
+                                bitMask:            _fsOptionGCSContinuePilot
+                            }
+                        }
+                    }
+                }
             }
 
-            QGCGroupBox {
-                title: _armingCheck ? qsTr("Arming Checks") : qsTr("Skip Arming Checks")
+            Component {
+                id: planeGcsFailsafe
 
-                ColumnLayout {
-                    spacing: _margins
+                QGCGroupBox {
+                    title: qsTr("Ground Station Failsafe")
 
-                    FactBitmask {
-                        firstEntryIsAll:    _armingCheck ? true : false
-                        fact:               _armingCheck ? _armingCheck : _armingSkipCheck
-                        Layout.preferredWidth:  safetyPage.availableWidth * 0.75
+                    // Plane: 0=Disabled, 1=Heartbeat, 2=Heartbeat+REMRSSI, 3=Heartbeat+AUTO
+                    readonly property int _planeGcsDisabled:            0
+                    readonly property int _planeGcsHeartbeat:           1
+                    readonly property int _planeGcsHeartbeatAndRemRSSI: 2
+                    readonly property int _planeGcsHeartbeatAndAuto:    3
+
+                    property Fact _gcsEnable:  controller.getParameterFact(-1, "FS_GCS_ENABL")
+                    property bool _gcsEnabled: _gcsEnable.rawValue !== _planeGcsDisabled
+
+                    ColumnLayout {
+                        spacing: _margins
+
+                        QGCCheckBoxSlider {
+                            Layout.fillWidth:   true
+                            text:               qsTr("Enabled")
+                            checked:            _gcsEnabled
+
+                            onClicked: {
+                                if (checked) {
+                                    _gcsEnable.rawValue = _planeGcsHeartbeat
+                                } else {
+                                    _gcsEnable.rawValue = _planeGcsDisabled
+                                }
+                            }
+                        }
+
+                        ColumnLayout {
+                            spacing: 0
+                            visible: _gcsEnabled
+
+                            QGCLabel { text: qsTr("Trigger:") }
+
+                            QGCRadioButton {
+                                text:      qsTr("Heartbeat")
+                                checked:   _gcsEnable.rawValue === _planeGcsHeartbeat
+                                onClicked: _gcsEnable.rawValue = _planeGcsHeartbeat
+                            }
+
+                            QGCRadioButton {
+                                text:      qsTr("Heartbeat and Remote RSSI")
+                                checked:   _gcsEnable.rawValue === _planeGcsHeartbeatAndRemRSSI
+                                onClicked: _gcsEnable.rawValue = _planeGcsHeartbeatAndRemRSSI
+                            }
+
+                            QGCRadioButton {
+                                text:      qsTr("Heartbeat and AUTO")
+                                checked:   _gcsEnable.rawValue === _planeGcsHeartbeatAndAuto
+                                onClicked: _gcsEnable.rawValue = _planeGcsHeartbeatAndAuto
+                            }
+                        }
                     }
+                }
+            }
 
-                    QGCLabel {
-                        wrapMode:           Text.WordWrap
-                        color:              qgcPal.warningText
-                        text:               qsTr("Warning: Turning off arming checks can lead to loss of Vehicle control.")
-                        visible:            _armingCheck ? _armingCheck.value != 1 : _armingSkipCheck.value != 0
-                        Layout.fillWidth:   true
+            Component {
+                id: roverGcsFailsafe
+
+                QGCGroupBox {
+                    title: qsTr("Ground Station Failsafe")
+
+                    // Rover: 0=Disabled, 1=Enabled, 2=Enabled Continue with Mission in Auto
+                    readonly property int _roverGcsDisabled:             0
+                    readonly property int _roverGcsEnabled:              1
+                    readonly property int _roverGcsContinueAutoMission:  2
+
+                    property Fact _gcsEnable:  controller.getParameterFact(-1, "FS_GCS_ENABLE")
+                    property Fact _gcsTimeout: controller.getParameterFact(-1, "FS_GCS_TIMEOUT")
+                    property bool _gcsEnabled: _gcsEnable.rawValue !== _roverGcsDisabled
+
+                    ColumnLayout {
+                        spacing: _margins
+
+                        QGCCheckBoxSlider {
+                            Layout.fillWidth:   true
+                            text:               qsTr("Enabled")
+                            checked:            _gcsEnabled
+
+                            onClicked: {
+                                if (checked) {
+                                    _gcsEnable.rawValue = _roverGcsEnabled
+                                } else {
+                                    _gcsEnable.rawValue = _roverGcsDisabled
+                                }
+                            }
+                        }
+
+                        LabelledFactTextField {
+                            label:              qsTr("Timeout")
+                            fact:               _gcsTimeout
+                            textFieldShowUnits: true
+                            Layout.fillWidth:   true
+                            visible:            _gcsEnabled
+                        }
+
+                        QGCLabel {
+                            text:    qsTr("Ignore failsafe if:")
+                            visible: _gcsEnabled
+                        }
+
+                        ColumnLayout {
+                            Layout.fillWidth:   true
+                            Layout.leftMargin:  ScreenTools.defaultFontPixelWidth * 2
+                            spacing:            _margins
+                            visible:            _gcsEnabled
+
+                            QGCCheckBoxSlider {
+                                Layout.fillWidth:   true
+                                text:               qsTr("In Auto mode")
+                                checked:            _gcsEnable.rawValue === _roverGcsContinueAutoMission
+
+                                onClicked: {
+                                    _gcsEnable.rawValue = checked ? _roverGcsContinueAutoMission : _roverGcsEnabled
+                                }
+                            }
+
+                            FactBitMaskCheckBoxSlider {
+                                Layout.fillWidth:   true
+                                text:               qsTr("In Hold mode")
+                                visible:            _fsOptionsAvailable
+                                fact:               _fsOptions
+                                bitMask:            1  // Rover FS_OPTIONS bit 0
+                            }
+                        }
+                    }
+                }
+            }
+
+            Component {
+                id: rcFailsafeComponent
+
+                QGCGroupBox {
+                    title: qsTr("RC Failsafe")
+
+                    ColumnLayout {
+                        spacing: _margins
+
+                        QGCLabel {
+                            text: qsTr("Always enabled")
+                        }
+
+                        QGCLabel {
+                            text:    qsTr("Ignore failsafe if:")
+                            visible: _fsOptionsAvailable
+                        }
+
+                        ColumnLayout {
+                            Layout.fillWidth:   true
+                            Layout.leftMargin:  ScreenTools.defaultFontPixelWidth * 2
+                            spacing:            _margins
+                            visible:            _fsOptionsAvailable
+
+                            FactBitMaskCheckBoxSlider {
+                                Layout.fillWidth:   true
+                                text:               qsTr("In Auto mode")
+                                fact:               _fsOptions
+                                bitMask:            _fsOptionRCContinueAuto
+                            }
+
+                            FactBitMaskCheckBoxSlider {
+                                Layout.fillWidth:   true
+                                text:               qsTr("In Guided mode")
+                                fact:               _fsOptions
+                                bitMask:            _fsOptionRCContinueGuided
+                            }
+
+                            FactBitMaskCheckBoxSlider {
+                                Layout.fillWidth:   true
+                                text:               qsTr("Landing")
+                                fact:               _fsOptions
+                                bitMask:            _fsOptionContinueLanding
+                            }
+                        }
+                    }
+                }
+            }
+
+            Component {
+                id: planeGeneralFS
+
+                QGCGroupBox {
+                    title: qsTr("Failsafe Triggers")
+
+                    property Fact _failsafeThrEnable:      controller.getParameterFact(-1, "THR_FAILSAFE")
+                    property Fact _failsafeThrValue:       controller.getParameterFact(-1, "THR_FS_VALUE")
+                    property Fact _failsafeShortAction:    controller.getParameterFact(-1, "FS_SHORT_ACTN")
+                    property Fact _failsafeLongAction:     controller.getParameterFact(-1, "FS_LONG_ACTN")
+                    property Fact _failsafeLongTimeout:    controller.getParameterFact(-1, "FS_LONG_TIMEOUT")
+                    property bool _isQuadPlane:            controller.parameterExists(-1, "Q_TRANS_FAIL")
+                    property Fact _transFailTimeout:       controller.getParameterFact(-1, "Q_TRANS_FAIL", false /* reportMissing */)
+                    property Fact _transFailAction:        controller.getParameterFact(-1, "Q_TRANS_FAIL_ACT", false /* reportMissing */)
+
+                    ColumnLayout {
+                        spacing: _margins
+
+                        RowLayout {
+                            Layout.fillWidth: true
+
+                            QGCCheckBox {
+                                id:                 throttleEnableCheckBox
+                                text:               qsTr("Throttle PWM threshold")
+                                checked:            _failsafeThrEnable.value === 1
+                                Layout.fillWidth:   true
+
+                                onClicked: _failsafeThrEnable.value = (checked ? 1 : 0)
+                            }
+
+                            FactTextField {
+                                fact:               _failsafeThrValue
+                                showUnits:          true
+                                enabled:            throttleEnableCheckBox.checked
+                            }
+                        }
+
+                        LabelledFactComboBox {
+                            label:            qsTr("Short failsafe action")
+                            fact:             _failsafeShortAction
+                            indexModel:       false
+                            comboBoxPreferredWidth: _comboWidth
+                            Layout.fillWidth: true
+                        }
+
+                        LabelledFactComboBox {
+                            label:            qsTr("Long failsafe action")
+                            fact:             _failsafeLongAction
+                            indexModel:       false
+                            comboBoxPreferredWidth: _comboWidth
+                            Layout.fillWidth: true
+                        }
+
+                        LabelledFactTextField {
+                            label:              qsTr("Long failsafe timeout")
+                            fact:               _failsafeLongTimeout
+                            textFieldShowUnits: true
+                            Layout.fillWidth:   true
+                        }
+
+                        LabelledFactComboBox {
+                            label:            qsTr("VTOL transition failure action")
+                            fact:             _transFailAction
+                            indexModel:       false
+                            comboBoxPreferredWidth: _comboWidth
+                            Layout.fillWidth: true
+                            visible:          _isQuadPlane
+                        }
+
+                        LabelledFactTextField {
+                            label:              qsTr("VTOL transition failure timeout")
+                            fact:               _transFailTimeout
+                            textFieldShowUnits: true
+                            Layout.fillWidth:   true
+                            visible:            _isQuadPlane
+                        }
+                    }
+                }
+            }
+
+            Component {
+                id: copterThrottleFailsafe
+
+                QGCGroupBox {
+                    title: qsTr("Throttle Failsafe")
+
+                    property Fact _failsafeThrEnable:   controller.getParameterFact(-1, "FS_THR_ENABLE")
+                    property Fact _failsafeThrValue:    controller.getParameterFact(-1, "FS_THR_VALUE")
+                    property bool _thrEnabled:          _failsafeThrEnable.rawValue !== _fsThrDisabled
+
+                    ColumnLayout {
+                        spacing: _margins
+
+                        QGCCheckBoxSlider {
+                            Layout.fillWidth:   true
+                            text:               qsTr("Enabled")
+                            checked:            _thrEnabled
+
+                            onClicked: {
+                                if (checked) {
+                                    _failsafeThrEnable.rawValue = _fsThrEnabledAlwaysRTL
+                                } else {
+                                    _failsafeThrEnable.rawValue = _fsThrDisabled
+                                }
+                            }
+                        }
+
+                        LabelledFactTextField {
+                            label:              qsTr("PWM threshold")
+                            fact:               _failsafeThrValue
+                            textFieldShowUnits: true
+                            Layout.fillWidth:   true
+                            visible:            _thrEnabled
+                        }
+
+                        ColumnLayout {
+                            spacing: 0
+                            visible: _thrEnabled
+
+                            QGCLabel { text: qsTr("Action:") }
+
+                            QGCRadioButton {
+                                text:      qsTr("Always RTL")
+                                checked:   _failsafeThrEnable.rawValue === _fsThrEnabledAlwaysRTL
+                                onClicked: _failsafeThrEnable.rawValue = _fsThrEnabledAlwaysRTL
+                            }
+
+                            QGCRadioButton {
+                                text:      qsTr("Always Land")
+                                checked:   _failsafeThrEnable.rawValue === _fsThrEnabledAlwaysLand
+                                onClicked: _failsafeThrEnable.rawValue = _fsThrEnabledAlwaysLand
+                            }
+
+                            QGCRadioButton {
+                                text:      qsTr("Always SmartRTL or RTL")
+                                checked:   _failsafeThrEnable.rawValue === _fsThrEnabledAlwaysSmartRTLOrRTL
+                                onClicked: _failsafeThrEnable.rawValue = _fsThrEnabledAlwaysSmartRTLOrRTL
+                            }
+
+                            QGCRadioButton {
+                                text:      qsTr("Always SmartRTL or Land")
+                                checked:   _failsafeThrEnable.rawValue === _fsThrEnabledAlwaysSmartRTLOrLand
+                                onClicked: _failsafeThrEnable.rawValue = _fsThrEnabledAlwaysSmartRTLOrLand
+                            }
+
+                            QGCRadioButton {
+                                text:      qsTr("Auto DO_LAND_START or RTL")
+                                checked:   _failsafeThrEnable.rawValue === _fsThrEnabledAutoDoLandOrRTL
+                                onClicked: _failsafeThrEnable.rawValue = _fsThrEnabledAutoDoLandOrRTL
+                            }
+
+                            QGCRadioButton {
+                                text:      qsTr("Always Brake or Land")
+                                checked:   _failsafeThrEnable.rawValue === _fsThrEnabledAlwaysBrakeOrLand
+                                onClicked: _failsafeThrEnable.rawValue = _fsThrEnabledAlwaysBrakeOrLand
+                            }
+                        }
+
+                        QGCLabel {
+                            text:    qsTr("Ignore failsafe if:")
+                            visible: _fsOptionsAvailable && _thrEnabled
+                        }
+
+                        ColumnLayout {
+                            Layout.fillWidth:   true
+                            Layout.leftMargin:  ScreenTools.defaultFontPixelWidth * 2
+                            spacing:            _margins
+                            visible:            _fsOptionsAvailable && _thrEnabled
+
+                            FactBitMaskCheckBoxSlider {
+                                Layout.fillWidth:   true
+                                text:               qsTr("In Auto mode")
+                                fact:               _fsOptions
+                                bitMask:            _fsOptionRCContinueAuto
+                            }
+
+                            FactBitMaskCheckBoxSlider {
+                                Layout.fillWidth:   true
+                                text:               qsTr("In Guided mode")
+                                fact:               _fsOptions
+                                bitMask:            _fsOptionRCContinueGuided
+                            }
+
+                            FactBitMaskCheckBoxSlider {
+                                Layout.fillWidth:   true
+                                text:               qsTr("Landing")
+                                fact:               _fsOptions
+                                bitMask:            _fsOptionContinueLanding
+                            }
+                        }
+                    }
+                }
+            }
+
+            Component {
+                id: roverThrottleFailsafe
+
+                QGCGroupBox {
+                    title: qsTr("Throttle Failsafe")
+
+                    // Rover: 0=Disabled, 1=Enabled, 2=Continue with Mission in Auto
+                    readonly property int _roverThrDisabled:             0
+                    readonly property int _roverThrEnabled:              1
+                    readonly property int _roverThrContinueAutoMission:  2
+
+                    // Rover FS_ACTION value constants
+                    readonly property int _roverActionNothing:           0
+                    readonly property int _roverActionRTL:               1
+                    readonly property int _roverActionHold:              2
+                    readonly property int _roverActionSmartRTLOrRTL:     3
+                    readonly property int _roverActionSmartRTLOrHold:    4
+                    readonly property int _roverActionTerminate:         5
+                    readonly property int _roverActionLoiterOrHold:      6
+
+                    property Fact _failsafeThrEnable: controller.getParameterFact(-1, "FS_THR_ENABLE")
+                    property Fact _failsafeThrValue:  controller.getParameterFact(-1, "FS_THR_VALUE")
+                    property Fact _failsafeAction:    controller.getParameterFact(-1, "FS_ACTION")
+                    property Fact _failsafeTimeout:   controller.getParameterFact(-1, "FS_TIMEOUT")
+                    property bool _thrEnabled:        _failsafeThrEnable.rawValue !== _roverThrDisabled
+
+                    ColumnLayout {
+                        spacing: _margins
+
+                        QGCCheckBoxSlider {
+                            Layout.fillWidth:   true
+                            text:               qsTr("Enabled")
+                            checked:            _thrEnabled
+
+                            onClicked: {
+                                if (checked) {
+                                    _failsafeThrEnable.rawValue = _roverThrEnabled
+                                } else {
+                                    _failsafeThrEnable.rawValue = _roverThrDisabled
+                                }
+                            }
+                        }
+
+                        LabelledFactTextField {
+                            label:              qsTr("PWM threshold")
+                            fact:               _failsafeThrValue
+                            textFieldShowUnits: true
+                            Layout.fillWidth:   true
+                            visible:            _thrEnabled
+                        }
+
+                        LabelledFactTextField {
+                            label:              qsTr("Timeout")
+                            fact:               _failsafeTimeout
+                            textFieldShowUnits: true
+                            Layout.fillWidth:   true
+                            visible:            _thrEnabled
+                        }
+
+                        ColumnLayout {
+                            spacing: 0
+                            visible: _thrEnabled
+
+                            QGCLabel { text: qsTr("Action:") }
+
+                            QGCRadioButton {
+                                text:      qsTr("Nothing")
+                                checked:   _failsafeAction.rawValue === _roverActionNothing
+                                onClicked: _failsafeAction.rawValue = _roverActionNothing
+                            }
+
+                            QGCRadioButton {
+                                text:      qsTr("RTL")
+                                checked:   _failsafeAction.rawValue === _roverActionRTL
+                                onClicked: _failsafeAction.rawValue = _roverActionRTL
+                            }
+
+                            QGCRadioButton {
+                                text:      qsTr("Hold")
+                                checked:   _failsafeAction.rawValue === _roverActionHold
+                                onClicked: _failsafeAction.rawValue = _roverActionHold
+                            }
+
+                            QGCRadioButton {
+                                text:      qsTr("SmartRTL or RTL")
+                                checked:   _failsafeAction.rawValue === _roverActionSmartRTLOrRTL
+                                onClicked: _failsafeAction.rawValue = _roverActionSmartRTLOrRTL
+                            }
+
+                            QGCRadioButton {
+                                text:      qsTr("SmartRTL or Hold")
+                                checked:   _failsafeAction.rawValue === _roverActionSmartRTLOrHold
+                                onClicked: _failsafeAction.rawValue = _roverActionSmartRTLOrHold
+                            }
+
+                            QGCRadioButton {
+                                text:      qsTr("Terminate")
+                                checked:   _failsafeAction.rawValue === _roverActionTerminate
+                                onClicked: _failsafeAction.rawValue = _roverActionTerminate
+                            }
+
+                            QGCRadioButton {
+                                text:      qsTr("Loiter or Hold")
+                                checked:   _failsafeAction.rawValue === _roverActionLoiterOrHold
+                                onClicked: _failsafeAction.rawValue = _roverActionLoiterOrHold
+                            }
+                        }
+
+                        QGCLabel {
+                            text:    qsTr("Ignore failsafe if:")
+                            visible: _thrEnabled
+                        }
+
+                        ColumnLayout {
+                            Layout.fillWidth:   true
+                            Layout.leftMargin:  ScreenTools.defaultFontPixelWidth * 2
+                            spacing:            _margins
+                            visible:            _thrEnabled
+
+                            QGCCheckBoxSlider {
+                                Layout.fillWidth:   true
+                                text:               qsTr("In Auto mode")
+                                checked:            _failsafeThrEnable.rawValue === _roverThrContinueAutoMission
+
+                                onClicked: {
+                                    _failsafeThrEnable.rawValue = checked ? _roverThrContinueAutoMission : _roverThrEnabled
+                                }
+                            }
+
+                            FactBitMaskCheckBoxSlider {
+                                Layout.fillWidth:   true
+                                text:               qsTr("In Hold mode")
+                                visible:            _fsOptionsAvailable
+                                fact:               _fsOptions
+                                bitMask:            1  // Rover FS_OPTIONS bit 0
+                            }
+                        }
+                    }
+                }
+            }
+
+            // FS_EKF_ACTION: Copter (0=Report,1=Land,2=AltHold,3=LandAlways) vs Rover (0=Disabled,1=Hold,2=ReportOnly)
+            Component {
+                id: copterEkfFailsafe
+
+                QGCGroupBox {
+                    title: qsTr("EKF Failsafe")
+
+                    // Copter FS_EKF_ACTION value constants
+                    readonly property int _fsEkfReportOnly:     0
+                    readonly property int _fsEkfLandIfNoPos:    1
+                    readonly property int _fsEkfAltHoldIfNoPos: 2
+                    readonly property int _fsEkfLandAlways:     3
+
+                    property Fact _failsafeEkfAction:   controller.getParameterFact(-1, "FS_EKF_ACTION")
+                    property Fact _failsafeEkfThresh:   controller.getParameterFact(-1, "FS_EKF_THRESH")
+                    property Fact _failsafeEkfFilt:     controller.getParameterFact(-1, "FS_EKF_FILT", false /* reportMissing */)
+                    property bool _ekfEnabled:          _failsafeEkfAction.rawValue !== _fsEkfReportOnly
+
+                    ColumnLayout {
+                        spacing: _margins
+
+                        QGCCheckBoxSlider {
+                            Layout.fillWidth:   true
+                            text:               qsTr("Enabled")
+                            checked:            _ekfEnabled
+
+                            onClicked: {
+                                if (checked) {
+                                    _failsafeEkfAction.rawValue = _fsEkfLandIfNoPos
+                                } else {
+                                    _failsafeEkfAction.rawValue = _fsEkfReportOnly
+                                }
+                            }
+                        }
+
+                        LabelledFactTextField {
+                            label:            qsTr("Threshold")
+                            fact:             _failsafeEkfThresh
+                            Layout.fillWidth: true
+                            visible:          _ekfEnabled
+                        }
+
+                        LabelledFactTextField {
+                            label:              qsTr("Filter")
+                            fact:               _failsafeEkfFilt
+                            textFieldShowUnits: true
+                            Layout.fillWidth:   true
+                            visible:            _ekfEnabled
+                        }
+
+                        ColumnLayout {
+                            spacing: 0
+                            visible: _ekfEnabled
+
+                            QGCLabel { text: qsTr("Action:") }
+
+                            QGCRadioButton {
+                                text:      qsTr("Land if position required")
+                                checked:   _failsafeEkfAction.rawValue === _fsEkfLandIfNoPos
+                                onClicked: _failsafeEkfAction.rawValue = _fsEkfLandIfNoPos
+                            }
+
+                            QGCRadioButton {
+                                text:      qsTr("AltHold if position required")
+                                checked:   _failsafeEkfAction.rawValue === _fsEkfAltHoldIfNoPos
+                                onClicked: _failsafeEkfAction.rawValue = _fsEkfAltHoldIfNoPos
+                            }
+
+                            QGCRadioButton {
+                                text:      qsTr("Land from all modes")
+                                checked:   _failsafeEkfAction.rawValue === _fsEkfLandAlways
+                                onClicked: _failsafeEkfAction.rawValue = _fsEkfLandAlways
+                            }
+                        }
+
+                        QGCLabel {
+                            text:    qsTr("Ignore failsafe if:")
+                            visible: _fsOptionsAvailable && _ekfEnabled
+                        }
+
+                        ColumnLayout {
+                            Layout.fillWidth:   true
+                            Layout.leftMargin:  ScreenTools.defaultFontPixelWidth * 2
+                            spacing:            _margins
+                            visible:            _fsOptionsAvailable && _ekfEnabled
+
+                            FactBitMaskCheckBoxSlider {
+                                Layout.fillWidth:   true
+                                text:               qsTr("Landing")
+                                fact:               _fsOptions
+                                bitMask:            _fsOptionContinueLanding
+                            }
+                        }
+                    }
+                }
+            }
+
+            Component {
+                id: roverEkfFailsafe
+
+                QGCGroupBox {
+                    title: qsTr("EKF Failsafe")
+
+                    // Rover FS_EKF_ACTION value constants
+                    readonly property int _roverEkfDisabled:   0
+                    readonly property int _roverEkfHold:       1
+                    readonly property int _roverEkfReportOnly: 2
+
+                    property Fact _failsafeEkfAction:   controller.getParameterFact(-1, "FS_EKF_ACTION")
+                    property Fact _failsafeEkfThresh:   controller.getParameterFact(-1, "FS_EKF_THRESH")
+                    property bool _ekfEnabled:          _failsafeEkfAction.rawValue !== _roverEkfDisabled
+
+                    ColumnLayout {
+                        spacing: _margins
+
+                        QGCCheckBoxSlider {
+                            Layout.fillWidth:   true
+                            text:               qsTr("Enabled")
+                            checked:            _ekfEnabled
+
+                            onClicked: {
+                                if (checked) {
+                                    _failsafeEkfAction.rawValue = _roverEkfHold
+                                } else {
+                                    _failsafeEkfAction.rawValue = _roverEkfDisabled
+                                }
+                            }
+                        }
+
+                        LabelledFactTextField {
+                            label:            qsTr("Threshold")
+                            fact:             _failsafeEkfThresh
+                            Layout.fillWidth: true
+                            visible:          _ekfEnabled
+                        }
+
+                        ColumnLayout {
+                            spacing: 0
+                            visible: _ekfEnabled
+
+                            QGCLabel { text: qsTr("Action:") }
+
+                            QGCRadioButton {
+                                text:      qsTr("Hold")
+                                checked:   _failsafeEkfAction.rawValue === _roverEkfHold
+                                onClicked: _failsafeEkfAction.rawValue = _roverEkfHold
+                            }
+
+                            QGCRadioButton {
+                                text:      qsTr("Report only")
+                                checked:   _failsafeEkfAction.rawValue === _roverEkfReportOnly
+                                onClicked: _failsafeEkfAction.rawValue = _roverEkfReportOnly
+                            }
+                        }
+                    }
+                }
+            }
+
+            Component {
+                id: deadReckoningFailsafeComponent
+
+                QGCGroupBox {
+                    title: qsTr("Dead Reckoning Failsafe")
+
+                    property Fact _failsafeDREnable:    controller.getParameterFact(-1, "FS_DR_ENABLE")
+                    property Fact _failsafeDRTimeout:   controller.getParameterFact(-1, "FS_DR_TIMEOUT")
+                    property bool _drEnabled:           _failsafeDREnable.rawValue !== _fsDrDisabled
+
+                    ColumnLayout {
+                        spacing: _margins
+
+                        QGCCheckBoxSlider {
+                            Layout.fillWidth:   true
+                            text:               qsTr("Enabled")
+                            checked:            _drEnabled
+
+                            onClicked: {
+                                if (checked) {
+                                    _failsafeDREnable.rawValue = _fsDrLand
+                                } else {
+                                    _failsafeDREnable.rawValue = _fsDrDisabled
+                                }
+                            }
+                        }
+
+                        LabelledFactTextField {
+                            label:              qsTr("Timeout")
+                            fact:               _failsafeDRTimeout
+                            textFieldShowUnits: true
+                            Layout.fillWidth:   true
+                            visible:            _drEnabled
+                        }
+
+                        ColumnLayout {
+                            spacing: 0
+                            visible: _drEnabled
+
+                            QGCLabel { text: qsTr("Action:") }
+
+                            QGCRadioButton {
+                                text:      qsTr("Land")
+                                checked:   _failsafeDREnable.rawValue === _fsDrLand
+                                onClicked: _failsafeDREnable.rawValue = _fsDrLand
+                            }
+
+                            QGCRadioButton {
+                                text:      qsTr("RTL")
+                                checked:   _failsafeDREnable.rawValue === _fsDrRTL
+                                onClicked: _failsafeDREnable.rawValue = _fsDrRTL
+                            }
+
+                            QGCRadioButton {
+                                text:      qsTr("SmartRTL or RTL")
+                                checked:   _failsafeDREnable.rawValue === _fsDrSmartRTLOrRTL
+                                onClicked: _failsafeDREnable.rawValue = _fsDrSmartRTLOrRTL
+                            }
+
+                            QGCRadioButton {
+                                text:      qsTr("SmartRTL or Land")
+                                checked:   _failsafeDREnable.rawValue === _fsDrSmartRTLOrLand
+                                onClicked: _failsafeDREnable.rawValue = _fsDrSmartRTLOrLand
+                            }
+
+                            QGCRadioButton {
+                                text:      qsTr("Auto Land/Return or RTL")
+                                checked:   _failsafeDREnable.rawValue === _fsDrAutoDoLandOrRTL
+                                onClicked: _failsafeDREnable.rawValue = _fsDrAutoDoLandOrRTL
+                            }
+                        }
+
+                        QGCLabel {
+                            text:    qsTr("Ignore failsafe if:")
+                            visible: _fsOptionsAvailable && _drEnabled
+                        }
+
+                        ColumnLayout {
+                            Layout.fillWidth:   true
+                            Layout.leftMargin:  ScreenTools.defaultFontPixelWidth * 2
+                            spacing:            _margins
+                            visible:            _fsOptionsAvailable && _drEnabled
+
+                            FactBitMaskCheckBoxSlider {
+                                Layout.fillWidth:   true
+                                text:               qsTr("Landing")
+                                fact:               _fsOptions
+                                bitMask:            _fsOptionContinueLanding
+                            }
+                        }
+                    }
+                }
+            }
+
+            // FS_CRASH_CHECK: Copter (0=Disabled,1=Enabled) vs Rover (0=Disabled,1=Hold,2=HoldAndDisarm)
+            Component {
+                id: copterGeneralFS
+
+                QGCGroupBox {
+                    title: qsTr("Other Failsafe Options")
+
+                    property Fact _failsafeCrashCheck:  controller.getParameterFact(-1, "FS_CRASH_CHECK")
+                    property Fact _failsafeVibeEnable:  controller.getParameterFact(-1, "FS_VIBE_ENABLE", false /* reportMissing */)
+
+                    ColumnLayout {
+                        spacing: _margins
+
+                        FactCheckBoxSlider {
+                            Layout.fillWidth:   true
+                            text:               qsTr("Crash check failsafe")
+                            fact:               _failsafeCrashCheck
+                        }
+
+                        FactCheckBoxSlider {
+                            Layout.fillWidth:   true
+                            text:               qsTr("Vibration failsafe")
+                            fact:               _failsafeVibeEnable
+                        }
+
+                        FactBitMaskCheckBoxSlider {
+                            Layout.fillWidth:   true
+                            text:               qsTr("Release gripper on any failsafe")
+                            visible:            _fsOptionsAvailable
+                            fact:               _fsOptions
+                            bitMask:            _fsOptionReleaseGripper
+                        }
+                    }
+                }
+            }
+
+            Component {
+                id: roverGeneralFS
+
+                QGCGroupBox {
+                    title: qsTr("Other Failsafe Options")
+
+                    // Rover FS_CRASH_CHECK value constants
+                    readonly property int _roverCrashDisabled:       0
+                    readonly property int _roverCrashHold:           1
+                    readonly property int _roverCrashHoldAndDisarm:  2
+
+                    property Fact _failsafeCrashCheck:  controller.getParameterFact(-1, "FS_CRASH_CHECK")
+                    property bool _crashEnabled:        _failsafeCrashCheck.rawValue !== _roverCrashDisabled
+
+                    ColumnLayout {
+                        spacing: _margins
+
+                        QGCCheckBoxSlider {
+                            Layout.fillWidth:   true
+                            text:               qsTr("Crash check failsafe")
+                            checked:            _crashEnabled
+
+                            onClicked: {
+                                if (checked) {
+                                    _failsafeCrashCheck.rawValue = _roverCrashHold
+                                } else {
+                                    _failsafeCrashCheck.rawValue = _roverCrashDisabled
+                                }
+                            }
+                        }
+
+                        ColumnLayout {
+                            spacing: 0
+                            visible: _crashEnabled
+
+                            QGCLabel { text: qsTr("Action:") }
+
+                            QGCRadioButton {
+                                text:      qsTr("Hold")
+                                checked:   _failsafeCrashCheck.rawValue === _roverCrashHold
+                                onClicked: _failsafeCrashCheck.rawValue = _roverCrashHold
+                            }
+
+                            QGCRadioButton {
+                                text:      qsTr("Hold and Disarm")
+                                checked:   _failsafeCrashCheck.rawValue === _roverCrashHoldAndDisarm
+                                onClicked: _failsafeCrashCheck.rawValue = _roverCrashHoldAndDisarm
+                            }
+                        }
+                    }
+                }
+            }
+
+            Component {
+                id: copterGeoFence
+
+                QGCGroupBox {
+                    title: qsTr("GeoFence")
+
+                    property Fact _fenceAction: controller.getParameterFact(-1, "FENCE_ACTION")
+                    property Fact _fenceAltMax: controller.getParameterFact(-1, "FENCE_ALT_MAX")
+                    property Fact _fenceEnable: controller.getParameterFact(-1, "FENCE_ENABLE")
+                    property Fact _fenceMargin: controller.getParameterFact(-1, "FENCE_MARGIN")
+                    property Fact _fenceRadius: controller.getParameterFact(-1, "FENCE_RADIUS")
+                    property Fact _fenceType:   controller.getParameterFact(-1, "FENCE_TYPE")
+
+                    readonly property int _maxAltitudeFenceBitMask: 1
+                    readonly property int _circleFenceBitMask:      2
+                    readonly property int _polygonFenceBitMask:     4
+
+                    ColumnLayout {
+                        spacing: _margins
+
+                        FactCheckBoxSlider {
+                            id:               enabledSlider
+                            Layout.fillWidth: true
+                            text:             qsTr("Enabled")
+                            fact:             _fenceEnable
+                        }
+
+                        ColumnLayout {
+                            visible: enabledSlider.checked
+
+                            RowLayout {
+                                QGCCheckBox {
+                                    text:    qsTr("Maximum Altitude")
+                                    checked: _fenceType.rawValue & _maxAltitudeFenceBitMask
+
+                                    onClicked: {
+                                        if (checked) {
+                                            _fenceType.rawValue |= _maxAltitudeFenceBitMask
+                                        } else {
+                                            _fenceType.rawValue &= ~_maxAltitudeFenceBitMask
+                                        }
+                                    }
+                                }
+
+                                FactTextField {
+                                    fact: _fenceAltMax
+                                }
+                            }
+
+                            RowLayout {
+                                QGCCheckBox {
+                                    text:    qsTr("Circle centered on Home")
+                                    checked: _fenceType.rawValue & _circleFenceBitMask
+
+                                    onClicked: {
+                                        if (checked) {
+                                            _fenceType.rawValue |= _circleFenceBitMask
+                                        } else {
+                                            _fenceType.rawValue &= ~_circleFenceBitMask
+                                        }
+                                    }
+                                }
+
+                                FactTextField {
+                                    fact:      _fenceRadius
+                                    showUnits: true
+                                }
+                            }
+
+                            QGCCheckBox {
+                                text:    qsTr("Inclusion/Exclusion Circles+Polygons")
+                                checked: _fenceType.rawValue & _polygonFenceBitMask
+
+                                onClicked: {
+                                    if (checked) {
+                                        _fenceType.rawValue |= _polygonFenceBitMask
+                                    } else {
+                                        _fenceType.rawValue &= ~_polygonFenceBitMask
+                                    }
+                                }
+                            }
+                        }
+
+                        ColumnLayout {
+                            visible: enabledSlider.checked
+
+                            LabelledFactComboBox {
+                                label:            qsTr("Breach action")
+                                fact:             _fenceAction
+                                comboBoxPreferredWidth: _comboWidth
+                                Layout.fillWidth: true
+                            }
+
+                            LabelledFactTextField {
+                                label:            qsTr("Fence margin")
+                                fact:             _fenceMargin
+                                Layout.fillWidth: true
+                            }
+                        }
                     }
                 }
             }

--- a/src/FactSystem/FactControls/CMakeLists.txt
+++ b/src/FactSystem/FactControls/CMakeLists.txt
@@ -14,6 +14,7 @@ qt_add_qml_module(FactControlsModule
     RESOURCE_PREFIX /qml
     QML_FILES
         AltitudeFactTextField.qml
+        FactBitMaskCheckBoxSlider.qml
         FactBitmask.qml
         FactCheckBox.qml
         FactCheckBoxSlider.qml

--- a/src/FactSystem/FactControls/FactBitMaskCheckBoxSlider.qml
+++ b/src/FactSystem/FactControls/FactBitMaskCheckBoxSlider.qml
@@ -1,0 +1,35 @@
+import QtQuick
+
+import QGroundControl
+import QGroundControl.Controls
+
+/// Toggle slider bound to a single bit within a Fact's bitmask rawValue.
+/// The slider stays in sync with the Fact and sets/clears the specified bit on click.
+///
+/// Example:
+///     FactBitMaskCheckBoxSlider {
+///         text:    qsTr("Continue in Auto mode")
+///         fact:    _fsOptions
+///         bitMask: 2   // bit 1
+///     }
+QGCCheckBoxSlider {
+    id: control
+
+    property Fact   fact:    Fact { }
+    property int    bitMask: 0
+
+    checked: fact && (fact.rawValue & bitMask)
+
+    Connections {
+        target: fact
+        function onRawValueChanged() { control.checked = fact.rawValue & control.bitMask }
+    }
+
+    onClicked: {
+        if (checked) {
+            fact.rawValue |= bitMask
+        } else {
+            fact.rawValue &= ~bitMask
+        }
+    }
+}

--- a/src/FactSystem/FactControls/FactCheckBoxSlider.qml
+++ b/src/FactSystem/FactControls/FactCheckBoxSlider.qml
@@ -7,8 +7,10 @@ import QGroundControl.Controls
 QGCCheckBoxSlider {
     property Fact fact: Fact { }
 
-    property var checkedValue:   fact.typeIsBool ? true : 1
-    property var uncheckedValue: fact.typeIsBool ? false : 0
+    property var checkedValue:   _typeIsBool ? true : 1
+    property var uncheckedValue: _typeIsBool ? false : 0
+
+    property var _typeIsBool: fact ? fact.typeIsBool : false
 
     Binding on checked {
         value: fact ?

--- a/src/FactSystem/FactControls/LabelledFactTextField.qml
+++ b/src/FactSystem/FactControls/LabelledFactTextField.qml
@@ -6,7 +6,7 @@ import QGroundControl.Controls
 import QGroundControl.FactControls
 
 RowLayout {
-    property string label:                   fact.shortDescription
+    property string label:                   fact ? fact.shortDescription : ""
     property alias  fact:                    _factTextField.fact
     property real   textFieldPreferredWidth: -1
     property alias  textFieldUnitsLabel:     _factTextField.unitsLabel


### PR DESCRIPTION
## Summary

Refactors APMSafetyComponent.qml failsafe sections to use consistent slider/radio button patterns and splits shared components into vehicle-specific variants where parameter metadata differs across Copter, Plane, and Rover.

## New Reusable Control

- **FactBitMaskCheckBoxSlider**: Toggle slider bound to a single bit in a Fact's bitmask rawValue

## APMBatteryParams Extensions

- Failsafe Facts: `fsLowAct`, `fsCritAct`, `lowMah`, `critMah`, `lowVolt`, `critVolt`
- Utility functions: `getEnabledBatteryCount()`, `getBatteryCount()`, `prefixForIndex()`, `labelForIndex()`

## Split Components

Parameters with the same name but different metadata per vehicle type are now handled by separate components:

| Parameter | Copter | Plane | Rover |
|-----------|--------|-------|-------|
| `FS_THR_ENABLE` | copterThrottleFailsafe (0-7) | — | roverThrottleFailsafe (0-2) |
| `FS_GCS_ENABLE` | copterGcsFailsafe (0-7) | planeGcsFailsafe (`FS_GCS_ENABL`, 0-3) | roverGcsFailsafe (0-2) |
| `FS_EKF_ACTION` | copterEkfFailsafe (Report/Land/AltHold/LandAlways) | — | roverEkfFailsafe (Disabled/Hold/Report) |
| `FS_CRASH_CHECK` | copterGeneralFS (0/1) | — | roverGeneralFS (0/1/2) |
| `FS_OPTIONS` | 6 bitmask bits (0-5), copter-only | — | 1 bitmask bit (0 only) |

## Common UI Pattern

Each failsafe section follows a consistent pattern:
1. **Enabled slider** — hides all settings when disabled
2. **Parameter fields** — PWM threshold, timeout, etc.
3. **Radio buttons** — action selection (replaces combo boxes)
4. **Ignore failsafe if:** — bitmask sliders for override conditions

## Additional Improvements

- Dynamic multi-battery failsafe using Repeater (supports up to 16 batteries)
- RC Failsafe section (copter-only, always enabled + ignore-if sliders)
- Dead Reckoning as standalone section with full pattern
- GeoFence: enabled slider with hide-when-disabled
- Arming checks: warning text + Allow slider guard before editing
- FS_OPTIONS bits distributed to relevant failsafe sections
- Fixed GeoFence `.value` vs `.rawValue` inconsistency
- Fixed gripper bitmask visibility (copter-only FS_OPTIONS bit 5 was visible for rover)