### PR TITLE
AudioOutput: Review fixes for volume feature

### DIFF
--- a/src/Settings/App.SettingsGroup.json
+++ b/src/Settings/App.SettingsGroup.json
@@ -84,7 +84,7 @@
 {
     "name":      "audioVolume",
     "shortDesc": "Audio output volume",
-    "longDesc":  "Sets the audio output volume percentage. Has no effect if audio is muted.",
+    "longDesc":  "Sets the audio output volume percentage. Set to 0 to mute.",
     "type":      "double",
     "default":   100.0,
     "units":     "%",

--- a/src/UI/AppSettings/GeneralSettings.qml
+++ b/src/UI/AppSettings/GeneralSettings.qml
@@ -48,7 +48,6 @@ SettingsPage {
                 Layout.fillWidth:   true
                 label:              qsTr("Audio Output")
                 fact:               _audioVolume
-                visible:            _audioVolume.visible
                 showEnableCheckbox: true
                 enableCheckBoxChecked: _audioVolume.rawValue > 0.0
 

--- a/src/Utilities/Audio/AudioOutput.cc
+++ b/src/Utilities/Audio/AudioOutput.cc
@@ -7,6 +7,8 @@
 #include <QtCore/QApplicationStatic>
 #include <QtTextToSpeech/QTextToSpeech>
 
+#include <algorithm>
+
 QGC_LOGGING_CATEGORY(AudioOutputLog, "Utilities.AudioOutput");
 // qt.speech.tts.flite
 // qt.speech.tts.android
@@ -84,8 +86,10 @@ void AudioOutput::init(Fact* volumeFact)
         qCDebug(AudioOutputLog) << "Queue Size:" << _textQueueSize;
     });
 
-    (void) connect(volumeFact, &Fact::valueChanged, this, [this](QVariant value) {
-        setVolume(value.toDouble());
+    _volumeFact = volumeFact;
+
+    (void) connect(_volumeFact, &Fact::valueChanged, this, [this]() {
+        _setVolume();
     });
 
     if (AudioOutputLog().isDebugEnabled()) {
@@ -106,31 +110,37 @@ void AudioOutput::init(Fact* volumeFact)
         });
     }
 
-    setVolume(volumeFact->rawValue().toDouble());
     _initialized = true;
+    _setVolume();
 
-    qCDebug(AudioOutputLog) << "AudioOutput initialized with volume:" << _volume.load() * 100.0 << "%";
+    qCDebug(AudioOutputLog) << "AudioOutput initialized with volume:" << _volume() << "%";
 }
 
-void AudioOutput::setVolume(double volume)
+double AudioOutput::_volume() const
 {
-    if (volume < 0.0 || volume > 100.0) {
-        qCWarning(AudioOutputLog) << "Volume must be between 0.0 and 100.0. Given:" << volume;
+    return std::clamp(_volumeFact->rawValue().toDouble(), 0.0, 100.0);
+}
+
+void AudioOutput::_setVolume()
+{
+    const double volume = _volume();
+
+    // qFuzzyCompare fails near zero; adding 1.0 shifts values into a safe range
+    if (qFuzzyCompare(1.0 + volume, 1.0 + _lastVolume)) {
         return;
     }
+    _lastVolume = volume;
 
-    if(volume == 0.0) {
+    if (volume == 0.0) {
         // Prevent any queued text from being spoken once muted
         (void) QMetaObject::invokeMethod(_engine, "stop", Qt::AutoConnection, QTextToSpeech::BoundaryHint::Default);
         _textQueueSize = 0;
     }
 
-    if (_volume.exchange(volume) != volume) {
-        // Must normalize volume to 0.0 - 1.0 for QTextToSpeech
-        const double normalizedVolume = volume / 100.0;
-        (void) QMetaObject::invokeMethod(_engine, "setVolume", Qt::AutoConnection, normalizedVolume);
-        qCDebug(AudioOutputLog) << "AudioOutput volume set to:" << volume << "%";
-    }
+    // Must normalize volume to 0.0 - 1.0 for QTextToSpeech
+    const double normalizedVolume = volume / 100.0;
+    (void) QMetaObject::invokeMethod(_engine, "setVolume", Qt::AutoConnection, normalizedVolume);
+    qCDebug(AudioOutputLog) << "AudioOutput volume set to:" << volume << "%";
 }
 
 void AudioOutput::say(const QString &text, TextMods textMods)
@@ -142,7 +152,7 @@ void AudioOutput::say(const QString &text, TextMods textMods)
         return;
     }
 
-    if (_volume.load() <= 0.0) {
+    if (_volume() <= 0.0) {
         return;
     }
 
@@ -184,7 +194,7 @@ void AudioOutput::testAudioOutput()
     (void) QMetaObject::invokeMethod(_engine, "stop", Qt::AutoConnection, QTextToSpeech::BoundaryHint::Default);
     _textQueueSize = 0;
 
-    const QString testText = tr("Audio test. Volume is %1 percent").arg(_volume.load(), 0, 'f', 1);
+    const QString testText = tr("Audio test. Volume is %1 percent").arg(_volume(), 0, 'f', 1);
     say(testText);
 }
 

--- a/src/Utilities/Audio/AudioOutput.h
+++ b/src/Utilities/Audio/AudioOutput.h
@@ -39,10 +39,6 @@ public:
     /// Initialize the Singleton
     void init(Fact *volumeFact);
 
-    /// Sets the volume of the audio output. 0.0 mutes the audio, 100.0 is maximum volume.
-    ///     @param volume The volume level to set (between 0.0 and 100.0).
-    void setVolume(double volume);
-
     /// Reads the specified text with optional text modifications.
     ///     @param text The text to be read.
     ///     @param textMods The text modifications to apply.
@@ -55,7 +51,14 @@ private:
     QTextToSpeech *_engine = nullptr;
     QAtomicInteger<qsizetype> _textQueueSize = 0;
     bool _initialized = false;
-    std::atomic<double> _volume = 100.0;
+    Fact *_volumeFact = nullptr;
+    double _lastVolume = -1.0;
+
+    /// Returns the current volume (0.0 - 100.0) from the settings Fact.
+    double _volume() const;
+
+    /// Sets the TTS engine volume from the current Fact value.
+    void _setVolume();
 
     static const QHash<QString, QString> _textHash;
 


### PR DESCRIPTION
Follow-up to #14178

Code review fixes for the AudioOutput volume feature:

- **Replace `std::atomic<double>` with direct Fact reference** — `Fact::rawValue()` is already mutex-protected, so the atomic cache was unnecessary complexity. AudioOutput now reads volume directly from the settings Fact.
- **Remove public `setVolume()`** — Volume is now managed internally via `_setVolume()` which reads the Fact value directly when `Fact::valueChanged` fires.
- **Add change deduplication** — `_setVolume()` tracks `_lastVolume` and skips redundant engine calls using `qFuzzyCompare` with the `1.0 +` offset idiom (needed because `qFuzzyCompare` fails near zero).
- **Clamp volume** — `_volume()` clamps to [0.0, 100.0] to guard against invalid Fact values reaching the TTS engine.
- **Fix init log** — Was printing `_volume.load() * 100.0` (doubling the percentage since `_volume` already stored 0-100).
- **Fix `if(` spacing** — `if(volume == 0.0)` to `if (volume == 0.0)` per coding style.
- **Remove redundant `visible`** — Inner `FactTextFieldSlider` had `visible: _audioVolume.visible` duplicating its parent `RowLayout`.
- **Fix inaccurate `longDesc`** — Changed from "Has no effect if audio is muted" (self-contradictory) to "Set to 0 to mute."
