### PR TITLE
ArduPilot: Safety page - real time throttle PWM display for failsafe status

### DIFF
--- a/src/AutoPilotPlugins/APM/APMFlightModesComponentController.cc
+++ b/src/AutoPilotPlugins/APM/APMFlightModesComponentController.cc
@@ -50,7 +50,7 @@ APMFlightModesComponentController::APMFlightModesComponentController(QObject *pa
         _rgChannelOptionEnabled.append(QVariant(false));
     }
 
-    (void) connect(_vehicle, &Vehicle::rcChannelsChanged, this, &APMFlightModesComponentController::channelValuesChanged);
+    (void) connect(_vehicle, &Vehicle::rcChannelsClampedChanged, this, &APMFlightModesComponentController::channelValuesChanged);
 }
 
 void APMFlightModesComponentController::channelValuesChanged(QVector<int> channelValues)

--- a/src/AutoPilotPlugins/APM/APMSafetyComponent.qml
+++ b/src/AutoPilotPlugins/APM/APMSafetyComponent.qml
@@ -35,6 +35,25 @@ SetupPage {
 
             QGCPalette { id: qgcPal; colorGroupEnabled: true }
 
+            RCChannelMonitorController {
+                id: rcMonitor
+                clampValues: false
+            }
+
+            // Throttle channel PWM tracking (RCMAP_THROTTLE is 1-indexed)
+            property Fact _rcmapThrottle: controller.getParameterFact(-1, "RCMAP_THROTTLE")
+            property int  _zeroBasedThrottleChannel: _rcmapThrottle.rawValue - 1
+            property int  _throttlePwm: -1
+
+            Connections {
+                target: rcMonitor
+                function onChannelValueChanged(channel, rcValue) {
+                    if (channel === _zeroBasedThrottleChannel) {
+                        _throttlePwm = rcValue
+                    }
+                }
+            }
+
             APMBatteryParams {
                 id:           battParams
                 controller:   _controller
@@ -220,6 +239,22 @@ SetupPage {
             }
 
             // ----- Component definitions -----
+
+            Component {
+                id: throttlePwmStatusComponent
+
+                QGCLabel {
+                    property Fact thrThreshold
+
+                    font.pointSize:   ScreenTools.smallFontPointSize
+                    property bool hasData: _throttlePwm >= 0
+                    property bool fsActive: hasData && _throttlePwm < thrThreshold.rawValue
+                    text: hasData
+                          ? qsTr("Current throttle PWM: %1 (%2)").arg(_throttlePwm).arg(fsActive ? qsTr("failsafe active") : qsTr("failsafe inactive"))
+                          : qsTr("Current throttle PWM: waiting for data")
+                    color: fsActive ? qgcPal.warningText : qgcPal.text
+                }
+            }
 
             Component {
                 id: batteryFailsafeComponent
@@ -732,22 +767,34 @@ SetupPage {
                     ColumnLayout {
                         spacing: _margins
 
-                        RowLayout {
+                        ColumnLayout {
                             Layout.fillWidth: true
+                            spacing: 0
 
-                            QGCCheckBox {
-                                id:                 throttleEnableCheckBox
-                                text:               qsTr("Throttle PWM threshold")
-                                checked:            _failsafeThrEnable.value === 1
-                                Layout.fillWidth:   true
+                            RowLayout {
+                                Layout.fillWidth: true
 
-                                onClicked: _failsafeThrEnable.value = (checked ? 1 : 0)
+                                QGCCheckBox {
+                                    id:                 throttleEnableCheckBox
+                                    text:               qsTr("Throttle PWM threshold")
+                                    checked:            _failsafeThrEnable.value === 1
+                                    Layout.fillWidth:   true
+
+                                    onClicked: _failsafeThrEnable.value = (checked ? 1 : 0)
+                                }
+
+                                FactTextField {
+                                    fact:               _failsafeThrValue
+                                    showUnits:          true
+                                    enabled:            throttleEnableCheckBox.checked
+                                }
                             }
 
-                            FactTextField {
-                                fact:               _failsafeThrValue
-                                showUnits:          true
-                                enabled:            throttleEnableCheckBox.checked
+                            Loader {
+                                Layout.fillWidth:   true
+                                visible:            throttleEnableCheckBox.checked
+                                sourceComponent:    throttlePwmStatusComponent
+                                onLoaded: item.thrThreshold = _failsafeThrValue
                             }
                         }
 
@@ -827,6 +874,13 @@ SetupPage {
                             textFieldShowUnits: true
                             Layout.fillWidth:   true
                             visible:            _thrEnabled
+                        }
+
+                        Loader {
+                            Layout.fillWidth:   true
+                            visible:            _thrEnabled
+                            sourceComponent:    throttlePwmStatusComponent
+                            onLoaded: item.thrThreshold = _failsafeThrValue
                         }
 
                         ColumnLayout {
@@ -957,6 +1011,13 @@ SetupPage {
                             textFieldShowUnits: true
                             Layout.fillWidth:   true
                             visible:            _thrEnabled
+                        }
+
+                        Loader {
+                            Layout.fillWidth:   true
+                            visible:            _thrEnabled
+                            sourceComponent:    throttlePwmStatusComponent
+                            onLoaded: item.thrThreshold = _failsafeThrValue
                         }
 
                         LabelledFactTextField {

--- a/src/AutoPilotPlugins/Common/RadioComponentController.cc
+++ b/src/AutoPilotPlugins/Common/RadioComponentController.cc
@@ -56,7 +56,7 @@ RadioComponentController::~RadioComponentController()
 void RadioComponentController::start(void)
 {
     RemoteControlCalibrationController::start();
-    (void) connect(_vehicle, &Vehicle::rcChannelsChanged, this, &RemoteControlCalibrationController::rawChannelValuesChanged);
+    (void) connect(_vehicle, &Vehicle::rcChannelsClampedChanged, this, &RemoteControlCalibrationController::_clampedChannelValuesChanged);
 
 }
 

--- a/src/AutoPilotPlugins/PX4/PX4SimpleFlightModesController.cc
+++ b/src/AutoPilotPlugins/PX4/PX4SimpleFlightModesController.cc
@@ -15,10 +15,10 @@ PX4SimpleFlightModesController::PX4SimpleFlightModesController(void)
         return;
     }
 
-    connect(_vehicle, &Vehicle::rcChannelsChanged, this, &PX4SimpleFlightModesController::channelValuesChanged);
+    connect(_vehicle, &Vehicle::rcChannelsClampedChanged, this, &PX4SimpleFlightModesController::channelValuesChanged);
 }
 
-/// Connected to Vehicle::rcChannelsChanged signal
+/// Connected to Vehicle::rcChannelsClampedChanged signal
 void PX4SimpleFlightModesController::channelValuesChanged(QVector<int> pwmValues)
 {
     int channelCount = pwmValues.size();

--- a/src/QmlControls/RCChannelMonitorController.cc
+++ b/src/QmlControls/RCChannelMonitorController.cc
@@ -9,12 +9,32 @@ RCChannelMonitorController::RCChannelMonitorController(QObject *parent)
 {
     // qCDebug(RCChannelMonitorControllerLog) << Q_FUNC_INFO << this;
 
-    (void) connect(_vehicle, &Vehicle::rcChannelsChanged, this, &RCChannelMonitorController::channelValuesChanged);
+    _connectToSignal();
 }
 
 RCChannelMonitorController::~RCChannelMonitorController()
 {
     // qCDebug(RCChannelMonitorControllerLog) << Q_FUNC_INFO << this;
+}
+
+void RCChannelMonitorController::setClampValues(bool clamp)
+{
+    if (_clampValues != clamp) {
+        _clampValues = clamp;
+        _connectToSignal();
+        emit clampValuesChanged();
+    }
+}
+
+void RCChannelMonitorController::_connectToSignal()
+{
+    disconnect(_vehicle, &Vehicle::rcChannelsClampedChanged, this, &RCChannelMonitorController::channelValuesChanged);
+    disconnect(_vehicle, &Vehicle::rcChannelsRawChanged, this, &RCChannelMonitorController::channelValuesChanged);
+    if (_clampValues) {
+        (void) connect(_vehicle, &Vehicle::rcChannelsClampedChanged, this, &RCChannelMonitorController::channelValuesChanged);
+    } else {
+        (void) connect(_vehicle, &Vehicle::rcChannelsRawChanged, this, &RCChannelMonitorController::channelValuesChanged);
+    }
 }
 
 void RCChannelMonitorController::channelValuesChanged(QVector<int> pwmValues)

--- a/src/QmlControls/RCChannelMonitorController.h
+++ b/src/QmlControls/RCChannelMonitorController.h
@@ -13,20 +13,27 @@ class RCChannelMonitorController : public FactPanelController
     Q_OBJECT
     QML_ELEMENT
     Q_PROPERTY(int channelCount READ channelCount NOTIFY channelCountChanged)
+    Q_PROPERTY(bool clampValues READ clampValues WRITE setClampValues NOTIFY clampValuesChanged)
 
 public:
     explicit RCChannelMonitorController(QObject *parent = nullptr);
     ~RCChannelMonitorController();
 
     int channelCount() const { return _chanCount; }
+    bool clampValues() const { return _clampValues; }
+    void setClampValues(bool clamp);
 
 signals:
     void channelCountChanged(int channelCount);
     void channelValueChanged(int channel, int rcValue);
+    void clampValuesChanged();
 
 private slots:
     void channelValuesChanged(QVector<int> pwmValues);
 
 private:
+    void _connectToSignal();
+
     int _chanCount = 0;
+    bool _clampValues = true;
 };

--- a/src/Vehicle/Vehicle.cc
+++ b/src/Vehicle/Vehicle.cc
@@ -1556,14 +1556,15 @@ void Vehicle::_handleRCChannels(mavlink_message_t& message)
     }
 
     QVector<int> channelValues(validChannelCount);
+    QVector<int> clampedValues(validChannelCount);
     for (int channelIndex = 0; channelIndex < validChannelCount; ++channelIndex) {
-        int channelValue = rawChannelValues[channelIndex];
-        // Radio cal can only handle pwm values in the 1000:2000 range, so constrain to that
-        channelValues[channelIndex] = std::min(std::max(channelValue, 1000), 2000);
+        channelValues[channelIndex] = rawChannelValues[channelIndex];
+        clampedValues[channelIndex] = std::clamp(channelValues[channelIndex], 1000, 2000);
     }
 
     emit remoteControlRSSIChanged(channels.rssi);
-    emit rcChannelsChanged(channelValues);
+    emit rcChannelsRawChanged(channelValues);
+    emit rcChannelsClampedChanged(clampedValues);
 }
 
 bool Vehicle::sendMessageOnLinkThreadSafe(LinkInterface* link, mavlink_message_t message)

--- a/src/Vehicle/Vehicle.h
+++ b/src/Vehicle/Vehicle.h
@@ -837,9 +837,13 @@ signals:
     void vehicleUIDChanged              ();
     void loadProgressChanged            (float value);
 
-    /// New RC channel values coming from RC_CHANNELS message
-    ///     @param channelValues The current values for rc channels
-    void rcChannelsChanged(QVector<int> channelValues);
+    /// Raw RC channel values coming from RC_CHANNELS message
+    ///     @param channelValues The current raw values for rc channels
+    void rcChannelsRawChanged(QVector<int> channelValues);
+
+    /// Filtered RC channel values coming from RC_CHANNELS message: clamped 1000:2000
+    ///     @param channelValues The clamped values for rc channels
+    void rcChannelsClampedChanged(QVector<int> channelValues);
 
     /// New SERVO output values coming from SERVO_OUTPUT_RAW message
     ///     @param servoValues The current servo output values in microseconds (0-15 -> SERVO1..SERVO16). Invalid values are -1.

--- a/src/Vehicle/VehicleSetup/JoystickConfigController.cc
+++ b/src/Vehicle/VehicleSetup/JoystickConfigController.cc
@@ -60,7 +60,7 @@ void JoystickConfigController::_setJoystick(Joystick* joystick)
 
     _joystick = joystick;
     _readStoredCalibrationValues();
-    connect(_joystick, &Joystick::rawChannelValuesChanged, this, &JoystickConfigController::rawChannelValuesChanged);
+    connect(_joystick, &Joystick::rawChannelValuesChanged, this, &JoystickConfigController::_rawChannelValuesChanged);
 
     // Connect to settings changes to emit extension enabled signals
     connect(_joystick->settings()->enableManualControlPitchExtension(), &Fact::rawValueChanged, this, [this]() {

--- a/src/Vehicle/VehicleSetup/RemoteControlCalibrationController.cc
+++ b/src/Vehicle/VehicleSetup/RemoteControlCalibrationController.cc
@@ -389,7 +389,7 @@ void RemoteControlCalibrationController::_setupCurrentState()
     _nextButton->setEnabled(state.nextButtonFn != nullptr);
 }
 
-void RemoteControlCalibrationController::rawChannelValuesChanged(QVector<int> channelValues)
+void RemoteControlCalibrationController::_processChannelValues(QVector<int> channelValues)
 {
     auto channelCount = channelValues.size();
     if (channelCount > _chanMax) {

--- a/src/Vehicle/VehicleSetup/RemoteControlCalibrationController.h
+++ b/src/Vehicle/VehicleSetup/RemoteControlCalibrationController.h
@@ -258,9 +258,8 @@ signals:
     void calibrationCompleted();
 
 public slots:
-    /// Super class must call this when the raw channel values change
-    ///     @param channelValues The current channel values
-    void rawChannelValuesChanged(QVector<int> channelValues);
+    void _rawChannelValuesChanged(QVector<int> channelValues) { _processChannelValues(channelValues); }
+    void _clampedChannelValuesChanged(QVector<int> channelValues) { _processChannelValues(channelValues); }
 
 protected:
     /// A set of information associated with a radio channel.
@@ -300,6 +299,8 @@ protected:
     virtual bool _stickFunctionEnabled(StickFunction stickFunction); ///< Returns true if the stick function is enabled
 
 private:
+    void _processChannelValues(QVector<int> channelValues);
+
     virtual void _saveStoredCalibrationValues() = 0; ///< Super class must implement to save stored calibration values
     virtual void _readStoredCalibrationValues() = 0; ///< Super class must implement to read stored calibration values
 


### PR DESCRIPTION
## Summary

Split the single `rcChannelsChanged` signal into two distinct signals:
- **`rcChannelsRawChanged`** — unclamped values direct from RC_CHANNELS MAVLink message
- **`rcChannelsClampedChanged`** — values clamped to 1000–2000 PWM range

Add a `clampValues` property to `RCChannelMonitorController` (default: `true`) so QML consumers can choose which signal to use.

## Changes

### Vehicle signal layer
- Rename `rcChannelsChanged` → `rcChannelsRawChanged`
- Add `rcChannelsClampedChanged` signal with `std::clamp(value, 1000, 2000)`
- Both signals emitted from `_handleRCChannels`

### RCChannelMonitorController
- Add `Q_PROPERTY(bool clampValues)` — when `true` connects to clamped signal, when `false` connects to raw
- Fix disconnect to use PMF-style (old SLOT-string disconnect silently failed due to Qt6 QVector/QList alias mismatch)

### RemoteControlCalibrationController
- Split single `rawChannelValuesChanged` slot into `_rawChannelValuesChanged` and `_clampedChannelValuesChanged`, both forwarding to private `_processChannelValues`

### Consumer updates
- `RadioComponentController` → `rcChannelsClampedChanged` / `_clampedChannelValuesChanged`
- `JoystickConfigController` → `Joystick::rawChannelValuesChanged` / `_rawChannelValuesChanged`
- `APMFlightModesComponentController` → `rcChannelsClampedChanged`
- `PX4SimpleFlightModesController` → `rcChannelsClampedChanged`

### APM Safety Component
- Add real-time throttle PWM display with failsafe active/inactive status
- Reusable `throttlePwmStatusComponent` used by copter, plane, and rover throttle failsafe sections
- Uses `clampValues: false` to show actual unclamped PWM for failsafe threshold comparison
