### PR TITLE
ci: skip release note labelling for PX4BuildBot PRs

### DIFF
--- a/.github/workflows/release-note-label.yml
+++ b/.github/workflows/release-note-label.yml
@@ -17,7 +17,9 @@ jobs:
   release-label:
     name: Label PR for Release Notes
     runs-on: ubuntu-latest
-    if: github.event.pull_request.user.type != 'Bot'
+    if: >-
+      github.event.pull_request.user.type != 'Bot'
+      && github.event.pull_request.user.login != 'PX4BuildBot'
     timeout-minutes: 5
 
     steps:


### PR DESCRIPTION
The "Label PR for Release Notes" workflow fails on Crowdin translation PRs opened by `PX4BuildBot` with:

> `HttpError: Resource not accessible by integration`

`PX4BuildBot` is a regular GitHub user account (not a GitHub App), so the existing `user.type != 'Bot'` guard doesn't filter it. The job then attempts to write labels with a read-only token and fails.

This adds `PX4BuildBot` to the skip condition so the job is skipped entirely for Crowdin translation PRs.
