### PR TITLE
feat(Serial): Add custom baud rate text field entry

### DIFF
--- a/src/UI/AppSettings/NmeaGpsSettings.qml
+++ b/src/UI/AppSettings/NmeaGpsSettings.qml
@@ -43,24 +43,58 @@ SettingsGroupLayout {
 
     LabelledComboBox {
         id: nmeaBaudCombo
-        visible: (nmeaPortCombo.currentText !== "UDP Port") && (nmeaPortCombo.currentText !== "Disabled")
+        visible: nmeaPortCombo.currentIndex > 1
         label: qsTr("Baudrate")
-        model: QGroundControl.linkManager.serialBaudRates
+
+        readonly property string _customLabel:  qsTr("Custom")
+        readonly property bool   isCustomBaud:  currentText === _customLabel
 
         onActivated: (index) => {
-            if (index !== -1) {
+            if (index !== -1 && !isCustomBaud) {
                 QGroundControl.settingsManager.autoConnectSettings.autoConnectNmeaBaud.value = parseInt(comboBox.textAt(index));
             }
         }
 
         Component.onCompleted: {
-            const index = nmeaBaudCombo.comboBox.find(QGroundControl.settingsManager.autoConnectSettings.autoConnectNmeaBaud.valueString);
-            nmeaBaudCombo.currentIndex = index;
+            var rates = QGroundControl.linkManager.serialBaudRates.slice()
+            rates.push(_customLabel)
+            nmeaBaudCombo.model = rates
+
+            var baud = QGroundControl.settingsManager.autoConnectSettings.autoConnectNmeaBaud.valueString
+            const index = nmeaBaudCombo.comboBox.find(baud);
+            if (index === -1) {
+                nmeaBaudCombo.currentIndex = nmeaBaudCombo.comboBox.count - 1
+                customNmeaBaudField.text = baud
+            } else {
+                nmeaBaudCombo.currentIndex = index;
+            }
+        }
+    }
+
+    RowLayout {
+        visible: nmeaBaudCombo.visible && nmeaBaudCombo.isCustomBaud
+        spacing: ScreenTools.defaultFontPixelWidth
+
+        QGCLabel {
+            text:               qsTr("Custom Baud Rate")
+            Layout.fillWidth:   true
+        }
+        QGCTextField {
+            id:                 customNmeaBaudField
+            numericValuesOnly:  true
+            validator:          IntValidator { bottom: 1 }
+            onEditingFinished: {
+                if (!nmeaBaudCombo.isCustomBaud) return
+                var baud = parseInt(text)
+                if (baud > 0) {
+                    QGroundControl.settingsManager.autoConnectSettings.autoConnectNmeaBaud.value = baud
+                }
+            }
         }
     }
 
     LabelledFactTextField {
-        visible: nmeaPortCombo.currentText === "UDP Port"
+        visible: nmeaPortCombo.currentIndex === 1
         label: qsTr("NMEA stream UDP port")
         fact: QGroundControl.settingsManager.autoConnectSettings.nmeaUdpPort
     }

--- a/src/UI/AppSettings/SerialSettings.qml
+++ b/src/UI/AppSettings/SerialSettings.qml
@@ -9,7 +9,12 @@ ColumnLayout {
     spacing: _rowSpacing
 
     function saveSettings() {
-        // No Need
+        if (baudCombo.isCustomBaud) {
+            var baud = parseInt(customBaudField.text)
+            if (baud > 0) {
+                subEditConfig.baud = baud
+            }
+        }
     }
 
     GridLayout {
@@ -63,24 +68,47 @@ ColumnLayout {
         QGCComboBox {
             id:                     baudCombo
             Layout.preferredWidth:  _secondColumnWidth
-            model:                  QGroundControl.linkManager.serialBaudRates
+
+            readonly property string _customLabel:    qsTr("Custom")
+            readonly property bool   isCustomBaud:    currentText === _customLabel
 
             onActivated: (index) => {
-                if (index != -1) {
-                    subEditConfig.baud = parseInt(QGroundControl.linkManager.serialBaudRates[index])
+                if (index !== -1 && !isCustomBaud) {
+                    subEditConfig.baud = parseInt(currentText)
                 }
             }
 
             Component.onCompleted: {
-                var baud = "57600"
-                if(subEditConfig != null) {
-                    baud = subEditConfig.baud.toString()
-                }
+                var rates = QGroundControl.linkManager.serialBaudRates.slice()
+                rates.push(_customLabel)
+                model = rates
+
+                var baud = subEditConfig ? subEditConfig.baud.toString() : "57600"
                 var index = baudCombo.find(baud)
                 if (index === -1) {
-                    console.warn(qsTr("Baud rate name not in combo box"), baud)
+                    baudCombo.currentIndex = baudCombo.count - 1
+                    customBaudField.text = baud
                 } else {
                     baudCombo.currentIndex = index
+                }
+            }
+        }
+
+        QGCLabel {
+            text:    qsTr("Custom Baud Rate")
+            visible: baudCombo.isCustomBaud
+        }
+        QGCTextField {
+            id:                     customBaudField
+            Layout.preferredWidth:  _secondColumnWidth
+            visible:                baudCombo.isCustomBaud
+            numericValuesOnly:      true
+            validator:              IntValidator { bottom: 1 }
+            onEditingFinished: {
+                if (!baudCombo.isCustomBaud) return
+                var baud = parseInt(text)
+                if (baud > 0) {
+                    subEditConfig.baud = baud
                 }
             }
         }


### PR DESCRIPTION
Add a "Custom" option to the baud rate combo boxes in Serial link settings and NMEA GPS auto-connect settings. When selected, a numeric text field appears allowing entry of an arbitrary baud rate.

Changes:
- Add "Custom" entry to the baud rate combo box in SerialSettings.qml with a numeric text field for custom entry
- Add the same "Custom" baud rate option and numeric text field for NMEA GPS settings in NmeaGpsSettings.qml
- Auto-select "Custom" when the stored baud value is not in the standard list
- Fix pre-existing bug: replace hard-coded English string comparisons in NmeaGpsSettings.qml visibility bindings with locale-safe index-based checks