### PR TITLE
AnalyzeView: Unload vehicle-dependent pages when no vehicle

### DIFF
--- a/src/API/QGCCorePlugin.cc
+++ b/src/API/QGCCorePlugin.cc
@@ -65,7 +65,8 @@ const QVariantList &QGCCorePlugin::analyzePages()
         QVariant::fromValue(new QmlComponentInfo(
             tr("Onboard Logs"),
             QUrl::fromUserInput(QStringLiteral("qrc:/qml/QGroundControl/AnalyzeView/OnboardLogs/OnboardLogPage.qml")),
-            QUrl::fromUserInput(QStringLiteral("qrc:/qmlimages/OnboardLogIcon.svg")))),
+            QUrl::fromUserInput(QStringLiteral("qrc:/qmlimages/OnboardLogIcon.svg")),
+            nullptr, true /* requiresVehicle */)),
         QVariant::fromValue(new QmlComponentInfo(
             tr("GeoTag Images"),
             QUrl::fromUserInput(QStringLiteral("qrc:/qml/QGroundControl/AnalyzeView/GeoTag/GeoTagPage.qml")),
@@ -73,15 +74,18 @@ const QVariantList &QGCCorePlugin::analyzePages()
         QVariant::fromValue(new QmlComponentInfo(
             tr("MAVLink Console"),
             QUrl::fromUserInput(QStringLiteral("qrc:/qml/QGroundControl/AnalyzeView/MAVLinkConsole/MAVLinkConsolePage.qml")),
-            QUrl::fromUserInput(QStringLiteral("qrc:/qmlimages/MAVLinkConsoleIcon.svg")))),
+            QUrl::fromUserInput(QStringLiteral("qrc:/qmlimages/MAVLinkConsoleIcon.svg")),
+            nullptr, true /* requiresVehicle */)),
         QVariant::fromValue(new QmlComponentInfo(
             tr("MAVLink Inspector"),
             QUrl::fromUserInput(QStringLiteral("qrc:/qml/QGroundControl/AnalyzeView/MAVLinkInspector/MAVLinkInspectorPage.qml")),
-            QUrl::fromUserInput(QStringLiteral("qrc:/qmlimages/MAVLinkInspector.svg")))),
+            QUrl::fromUserInput(QStringLiteral("qrc:/qmlimages/MAVLinkInspector.svg")),
+            nullptr, true /* requiresVehicle */)),
         QVariant::fromValue(new QmlComponentInfo(
             tr("Vibration"),
             QUrl::fromUserInput(QStringLiteral("qrc:/qml/QGroundControl/AnalyzeView/Vibration/VibrationPage.qml")),
-            QUrl::fromUserInput(QStringLiteral("qrc:/qmlimages/VibrationPageIcon")))),
+            QUrl::fromUserInput(QStringLiteral("qrc:/qmlimages/VibrationPageIcon")),
+            nullptr, true /* requiresVehicle */)),
     };
 
     return analyzeList;

--- a/src/API/QmlComponentInfo.cc
+++ b/src/API/QmlComponentInfo.cc
@@ -3,11 +3,12 @@
 
 QGC_LOGGING_CATEGORY(QmlComponentInfoLog, "API.QmlComponentInfo");
 
-QmlComponentInfo::QmlComponentInfo(const QString &title, QUrl url, QUrl icon, QObject *parent)
+QmlComponentInfo::QmlComponentInfo(const QString &title, QUrl url, QUrl icon, QObject *parent, bool requiresVehicle)
     : QObject(parent)
     , _title(title)
     , _url(url)
     , _icon(icon)
+    , _requiresVehicle(requiresVehicle)
 {
     // qCDebug(QmlComponentInfoLog) << Q_FUNC_INFO << this;
 }

--- a/src/API/QmlComponentInfo.h
+++ b/src/API/QmlComponentInfo.h
@@ -10,20 +10,23 @@ Q_DECLARE_LOGGING_CATEGORY(QmlComponentInfoLog)
 class QmlComponentInfo : public QObject
 {
     Q_OBJECT
-    Q_PROPERTY(QString  title   READ title  CONSTANT)
-    Q_PROPERTY(QUrl     url     READ url    CONSTANT)
-    Q_PROPERTY(QUrl     icon    READ icon   CONSTANT)
+    Q_PROPERTY(QString  title           READ title          CONSTANT)
+    Q_PROPERTY(QUrl     url             READ url            CONSTANT)
+    Q_PROPERTY(QUrl     icon            READ icon           CONSTANT)
+    Q_PROPERTY(bool     requiresVehicle READ requiresVehicle CONSTANT)
 
 public:
-    QmlComponentInfo(const QString &title, QUrl url, QUrl icon = QUrl(), QObject *parent = nullptr);
+    QmlComponentInfo(const QString &title, QUrl url, QUrl icon = QUrl(), QObject *parent = nullptr, bool requiresVehicle = false);
     ~QmlComponentInfo();
 
     const QString &title() const { return _title; }
     QUrl url() const { return _url; }
     QUrl icon() const { return _icon; }
+    bool requiresVehicle() const { return _requiresVehicle; }
 
 protected:
-    const QString _title; ///< Title for page
-    const QUrl _url;      ///< Qml source code
-    const QUrl _icon;     ///< Icon for page
+    const QString _title;           ///< Title for page
+    const QUrl _url;                ///< Qml source code
+    const QUrl _icon;               ///< Icon for page
+    const bool _requiresVehicle;    ///< Page requires connected vehicle
 };

--- a/src/AnalyzeView/AnalyzeView.qml
+++ b/src/AnalyzeView/AnalyzeView.qml
@@ -15,7 +15,28 @@ Rectangle {
     readonly property real  _defaultTextWidth:      ScreenTools.defaultFontPixelWidth
     readonly property real  _horizontalMargin:      _defaultTextWidth / 2
     readonly property real  _verticalMargin:        _defaultTextHeight / 2
-    readonly property real  _buttonWidth:           _defaultTextWidth * 18
+
+    property var  _activeVehicle: QGroundControl.multiVehicleManager.activeVehicle
+    property var  _currentPage:   null
+
+    function _updatePanelSource() {
+        if (_currentPage) {
+            if (_currentPage.requiresVehicle && !_activeVehicle) {
+                panelLoader.source = ""
+            } else {
+                panelLoader.source = _currentPage.url
+            }
+        }
+    }
+
+    on_ActiveVehicleChanged: {
+        if (_currentPage && _currentPage.requiresVehicle) {
+            panelLoader.source = ""
+            if (_activeVehicle) {
+                Qt.callLater(_updatePanelSource)
+            }
+        }
+    }
 
     // This need to block click event leakage to underlying map.
     DeadMouseArea {
@@ -55,8 +76,9 @@ Rectangle {
                 Component.onCompleted: {
                     if (count > 0) {
                         itemAt(0).checked = true
-                        panelLoader.source = QGroundControl.corePlugin.analyzePages[0].url
-                        panelLoader.title  = QGroundControl.corePlugin.analyzePages[0].title
+                        _currentPage = QGroundControl.corePlugin.analyzePages[0]
+                        panelLoader.title = _currentPage.title
+                        _updatePanelSource()
                     }
                 }
 
@@ -67,9 +89,10 @@ Rectangle {
                     width:              buttonColumn._maxButtonWidth
 
                     onClicked: {
-                        panelLoader.source  = modelData.url
+                        _currentPage        = modelData
                         panelLoader.title   = modelData.title
                         checked             = true
+                        _updatePanelSource()
                     }
                 }
             }
@@ -104,7 +127,13 @@ Rectangle {
 
         Connections {
             target:     panelLoader.item
-            function onPopout() { mainWindow.createWindowedAnalyzePage(panelLoader.title, panelLoader.source) }
+            function onPopout() { mainWindow.createWindowedAnalyzePage(panelLoader.title, panelLoader.source, _currentPage ? _currentPage.requiresVehicle : false) }
         }
+    }
+
+    QGCLabel {
+        anchors.centerIn:   panelLoader
+        text:               qsTr("Requires a connected vehicle")
+        visible:            _currentPage && _currentPage.requiresVehicle && !_activeVehicle
     }
 }

--- a/src/UI/MainWindow.qml
+++ b/src/UI/MainWindow.qml
@@ -608,10 +608,11 @@ ApplicationWindow {
     // to mainWindow. Otherwise if they are rooted to the AnalyzeView itself they will die when the analyze viewSwitch
     // closes.
 
-    function createWindowedAnalyzePage(title, source) {
+    function createWindowedAnalyzePage(title, source, requiresVehicle) {
         var windowedPage = windowedAnalyzePage.createObject(mainWindow)
         windowedPage.title = title
         windowedPage.source = source
+        windowedPage.requiresVehicle = requiresVehicle
     }
 
     Component {
@@ -623,6 +624,16 @@ ApplicationWindow {
             visible:    true
 
             property alias source: loader.source
+            property bool requiresVehicle: false
+
+            Connections {
+                target: QGroundControl.multiVehicleManager
+                function onActiveVehicleChanged() {
+                    if (requiresVehicle) {
+                        close()
+                    }
+                }
+            }
 
             Rectangle {
                 color:          QGroundControl.globalPalette.window
@@ -638,6 +649,7 @@ ApplicationWindow {
             onClosing: {
                 visible = false
                 source = ""
+                Qt.callLater(destroy)
             }
         }
     }


### PR DESCRIPTION
Fixes #13077

- Add `requiresVehicle` property to QmlComponentInfo
- Mark Onboard Logs, MAVLink Console, MAVLink Inspector, and Vibration pages as requiring a connected vehicle
- AnalyzeView shows "Requires a connected vehicle" message when no vehicle is connected and a vehicle-dependent page is selected
- On active vehicle change, vehicle-dependent pages are unloaded and reloaded so controllers get a fresh connection to the new vehicle
- Popout windows for vehicle-dependent pages close on vehicle change
- Fix pre-existing memory leak: popout windows now call destroy() on close
- Remove unused _buttonWidth property from AnalyzeView