### PR TITLE
Add validation guards to tree controls and toast notification

### DIFF
--- a/src/PlanView/PlanTreeView.qml
+++ b/src/PlanView/PlanTreeView.qml
@@ -130,11 +130,13 @@ TreeView {
     }
 
     // Toggle expand/collapse for a group header. Does not affect the editing layer.
+    // Caller is responsible for calling allowViewSwitch() before invoking this.
     function _toggleGroup(row) {
-        if (root.isExpanded(row))
+        if (root.isExpanded(row)) {
             root.collapse(row)
-        else
+        } else {
             root.expand(row)
+        }
         root.forceLayout()
     }
 
@@ -349,7 +351,12 @@ TreeView {
 
                 MouseArea {
                     anchors.fill: parent
-                    onClicked: root._toggleGroup(delegateRoot.row)
+                    onClicked: {
+                        if (!mainWindow.allowViewSwitch()) {
+                            return
+                        }
+                        root._toggleGroup(delegateRoot.row)
+                    }
                 }
             }
         }

--- a/src/PlanView/RallyPointItemEditor.qml
+++ b/src/PlanView/RallyPointItemEditor.qml
@@ -56,7 +56,11 @@ Rectangle {
         anchors.bottom: titleLayout.bottom
         anchors.left: titleLayout.left
         anchors.right: titleLayout.right
-        onClicked: controller.currentRallyPoint = rallyPoint
+        onClicked: {
+            if (mainWindow.allowViewSwitch()) {
+                controller.currentRallyPoint = rallyPoint
+            }
+        }
     }
 
     QGCMouseArea {
@@ -64,7 +68,11 @@ Rectangle {
         anchors.bottom: selectMouseArea.bottom
         anchors.right: selectMouseArea.right
         width: height
-        onClicked: controller.removePoint(rallyPoint)
+        onClicked: {
+            if (mainWindow.allowViewSwitch()) {
+                controller.removePoint(rallyPoint)
+            }
+        }
     }
 
     Rectangle {

--- a/src/QmlControls/AppSettings.qml
+++ b/src/QmlControls/AppSettings.qml
@@ -225,6 +225,9 @@ Rectangle {
                         }
 
                         onToggleExpand: {
+                            if (!mainWindow.allowViewSwitch()) {
+                                return
+                            }
                             settingsView._setExpanded(index, !isExpanded)
                         }
                     }

--- a/src/UI/MainWindow.qml
+++ b/src/UI/MainWindow.qml
@@ -95,12 +95,19 @@ ApplicationWindow {
     //-- Global Scope Functions
 
     // This function is used to prevent view switching if there are validation errors
-    function allowViewSwitch(previousValidationErrorCount = 0) {
+    function allowViewSwitch(previousValidationErrorCount = 0, showErrorOnDisallow = true) {
         // Run validation on active focus control to ensure it is valid before switching views
         if (mainWindow.activeFocusControl instanceof FactTextField) {
             mainWindow.activeFocusControl._onEditingFinished()
         }
-        return globals.validationErrorCount <= previousValidationErrorCount
+        var allowed = globals.validationErrorCount <= previousValidationErrorCount
+        if (!allowed && showErrorOnDisallow) {
+            if (validationErrorToast.visible) {
+                validationErrorToast.close()
+            }
+            validationErrorToast.open()
+        }
+        return allowed
     }
 
     function showPlanView() {
@@ -311,6 +318,26 @@ ApplicationWindow {
     function showToolSelectDialog() {
         if (mainWindow.allowViewSwitch()) {
             mainWindow.showIndicatorDrawer(toolSelectComponent, null)
+        }
+    }
+
+    // Toast notification shown when a view switch is blocked by a validation error
+    ToolTip {
+        id:             validationErrorToast
+        x:              (mainWindow.width - width) / 2
+        y:              mainWindow.height - height - ScreenTools.defaultFontPixelHeight * 3
+        timeout:        3000
+        closePolicy:    Popup.NoAutoClose
+        text:           qsTr("Please correct the invalid value before continuing")
+
+        background: Rectangle {
+            color:  qgcPal.alertBackground
+            radius: ScreenTools.defaultFontPixelWidth / 2
+        }
+
+        contentItem: QGCLabel {
+            text:   validationErrorToast.text
+            color:  qgcPal.alertText
         }
     }
 


### PR DESCRIPTION
Fixes #14225

## Changes

Adds `allowViewSwitch()` validation guards to tree control interactions that were missing them, preventing users from navigating away from invalid field values. Also adds a user-facing toast notification when navigation is blocked.

### PlanTreeView
- Group header clicks now call `allowViewSwitch()` before expand/collapse, triggering validation on any focused FactTextField

### RallyPointItemEditor
- Select click gated on `allowViewSwitch()` (matches existing MissionItemEditor pattern)
- Delete click gated on `allowViewSwitch()` to prevent destroying an editor with an active validation error (which would leave `validationErrorCount` permanently incremented)

### AppSettings
- `onToggleExpand` gated on `allowViewSwitch()` for both expand and collapse

### MainWindow
- `allowViewSwitch()` gains optional `showErrorOnDisallow` param (default `true`)
- When blocked, shows a 3-second auto-dismissing toast: "Please correct the invalid value before continuing"
- Toast uses `qgcPal.alertBackground` / `qgcPal.alertText` palette colors
- Toast restarts timeout on repeated blocked attempts
- Toast uses `NoAutoClose` close policy so outside clicks don't dismiss it
