### PR TITLE
Settings: rename visible to userVisible, show shortDesc, improve UX

### DIFF
--- a/custom-example/src/CustomPlugin.cc
+++ b/custom-example/src/CustomPlugin.cc
@@ -73,20 +73,20 @@ void CustomPlugin::_addSettingsEntry(const QString &title, const char *qmlFile, 
     );
 }
 
-void CustomPlugin::adjustSettingMetaData(const QString& settingsGroup, FactMetaData& metaData, bool &visible)
+void CustomPlugin::adjustSettingMetaData(const QString& settingsGroup, FactMetaData& metaData, bool &userVisible)
 {
-    QGCCorePlugin::adjustSettingMetaData(settingsGroup, metaData, visible);
+    QGCCorePlugin::adjustSettingMetaData(settingsGroup, metaData, userVisible);
 
     if (settingsGroup == AppSettings::settingsGroup) {
         // This tells QGC than when you are creating Plans while not connected to a vehicle
         // the specific firmware/vehicle the plan is for.
         if (metaData.name() == AppSettings::offlineEditingFirmwareClassName) {
             metaData.setRawDefaultValue(QGCMAVLink::FirmwareClassPX4);
-            visible = false;
+            userVisible = false;
             return;
         } else if (metaData.name() == AppSettings::offlineEditingVehicleClassName) {
             metaData.setRawDefaultValue(QGCMAVLink::VehicleClassMultiRotor);
-            visible = false;
+            userVisible = false;
             return;
         }
     }

--- a/custom-example/src/CustomPlugin.h
+++ b/custom-example/src/CustomPlugin.h
@@ -65,7 +65,7 @@ public:
     void cleanup() final;
     QGCOptions *options() final { return _options; }
     /// This allows you to override/hide QGC Application settings
-    void adjustSettingMetaData(const QString &settingsGroup, FactMetaData &metaData, bool &visible) final;
+    void adjustSettingMetaData(const QString &settingsGroup, FactMetaData &metaData, bool &userVisible) final;
     /// This modifies QGC colors palette to match possible custom corporate branding
     void paletteOverride(const QString &colorName, QGCPalette::PaletteColorInfo_t &colorInfo) final;
     /// We override this so we can get access to QQmlApplicationEngine and use it to register our qml module

--- a/src/API/QGCCorePlugin.cc
+++ b/src/API/QGCCorePlugin.cc
@@ -101,10 +101,10 @@ const QmlObjectListModel *QGCCorePlugin::customMapItems()
     return _emptyCustomMapItems;
 }
 
-void QGCCorePlugin::adjustSettingMetaData(const QString &settingsGroup, FactMetaData &metaData, bool &visible)
+void QGCCorePlugin::adjustSettingMetaData(const QString &settingsGroup, FactMetaData &metaData, bool &userVisible)
 {
 #ifdef Q_OS_ANDROID
-    Q_UNUSED(visible);
+    Q_UNUSED(userVisible);
 #endif
 
     if (settingsGroup == AppSettings::settingsGroup) {
@@ -126,7 +126,7 @@ void QGCCorePlugin::adjustSettingMetaData(const QString &settingsGroup, FactMeta
 #endif
 #ifndef Q_OS_ANDROID
         else if (metaData.name() == AppSettings::androidDontSaveToSDCardName) {
-            visible = false;
+            userVisible = false;
             return;
         }
 #endif

--- a/src/API/QGCCorePlugin.h
+++ b/src/API/QGCCorePlugin.h
@@ -70,9 +70,9 @@ public:
     /// Allows the core plugin to override the meta data before the fact is created.
     ///     @param settingsGroup - QSettings group which contains this item
     ///     @param metaData - MetaData for setting fact
-    ///     @param visible - true: Setting should be visible in ui, false: Setting should not be shown in ui (default value will be used as value)
-    /// If not overridden, metaData and visible are left unchanged.
-    virtual void adjustSettingMetaData(const QString &settingsGroup, FactMetaData &metaData, bool &visible);
+    ///     @param userVisible - true: Setting should be visible in ui, false: Setting should not be shown in ui (default value will be used as value)
+    /// If not overridden, metaData and userVisible are left unchanged.
+    virtual void adjustSettingMetaData(const QString &settingsGroup, FactMetaData &metaData, bool &userVisible);
 
     /// @return The message to show to the user when they are prompted to confirm turning on advanced ui.
     virtual QString showAdvancedUIMessage() const;

--- a/src/AutoPilotPlugins/APM/APMRemoteSupportComponent.qml
+++ b/src/AutoPilotPlugins/APM/APMRemoteSupportComponent.qml
@@ -23,7 +23,7 @@ SetupPage {
                 rowSpacing:             ScreenTools.defaultFontPixelWidth
 
                 QGCLabel {
-                    visible:            QGroundControl.settingsManager.mavlinkSettings.forwardMavlinkAPMSupportHostName.visible
+                    visible:            QGroundControl.settingsManager.mavlinkSettings.forwardMavlinkAPMSupportHostName.userVisible
                     text:               qsTr("Host name:")
                 }
                 FactTextField {

--- a/src/FactSystem/SettingsFact.cc
+++ b/src/FactSystem/SettingsFact.cc
@@ -26,7 +26,7 @@ SettingsFact::SettingsFact(const QString &settingsGroup, FactMetaData *metaData,
     }
 
     // Allow core plugin a chance to override the default value
-    SettingsManager::adjustSettingMetaData(settingsGroup, *metaData, _visible);
+    SettingsManager::adjustSettingMetaData(settingsGroup, *metaData, _userVisible);
     setMetaData(metaData);
 
     if (metaData->defaultValueAvailable()) {
@@ -36,7 +36,7 @@ SettingsFact::SettingsFact(const QString &settingsGroup, FactMetaData *metaData,
         if (qgcApp()->runningUnitTests()) {
             // Don't use saved settings
             resolvedValue = rawDefaultValue;
-        } else if (_visible) {
+        } else if (_userVisible) {
             QVariant typedValue;
             QString errorString;
             (void) metaData->convertAndValidateRaw(settings.value(_name, rawDefaultValue), true /* conertOnly */, typedValue, errorString);

--- a/src/FactSystem/SettingsFact.h
+++ b/src/FactSystem/SettingsFact.h
@@ -12,8 +12,10 @@ Q_DECLARE_LOGGING_CATEGORY(SettingsFactLog)
 class SettingsFact : public Fact
 {
     Q_OBJECT
-    Q_PROPERTY(bool visible MEMBER _visible CONSTANT)
-    Q_PROPERTY(bool userVisible MEMBER _visible CONSTANT)
+    /// Whether this setting should be shown in the UI. When false the setting is
+    /// hidden from the user and its value is forced to the default. Controlled by
+    /// QGCCorePlugin::adjustSettingMetaData and settings-override JSON files.
+    Q_PROPERTY(bool userVisible MEMBER _userVisible CONSTANT)
 
 public:
     explicit SettingsFact(QObject *parent = nullptr);
@@ -24,12 +26,12 @@ public:
     const SettingsFact &operator=(const SettingsFact &other);
 
     // Must be called before any references to fact
-    void setVisible(bool visible) { _visible = visible; }
+    void setUserVisible(bool userVisible) { _userVisible = userVisible; }
 
 private slots:
     void _rawValueChanged(const QVariant &value);
 
 private:
     QString _settingsGroup;
-    bool _visible = true;
+    bool _userVisible = true;
 };

--- a/src/QmlControls/AppLogging.qml
+++ b/src/QmlControls/AppLogging.qml
@@ -100,7 +100,7 @@ Item {
                 anchors.leftMargin:     ScreenTools.defaultFontPixelWidth
                 anchors.verticalCenter: gstCombo.verticalCenter
                 text:                   qsTr("GStreamer Debug Level")
-                visible:                QGroundControl.settingsManager.appSettings.gstDebugLevel.visible
+                visible:                QGroundControl.settingsManager.appSettings.gstDebugLevel.userVisible
             }
 
             FactComboBox {
@@ -109,7 +109,7 @@ Item {
                 anchors.leftMargin: ScreenTools.defaultFontPixelWidth / 2
                 anchors.bottom:     parent.bottom
                 fact:               QGroundControl.settingsManager.appSettings.gstDebugLevel
-                visible:            QGroundControl.settingsManager.appSettings.gstDebugLevel.visible
+                visible:            QGroundControl.settingsManager.appSettings.gstDebugLevel.userVisible
                 sizeToContents:     true
             }
 

--- a/src/QmlControls/AppSettings.qml
+++ b/src/QmlControls/AppSettings.qml
@@ -105,7 +105,7 @@ Rectangle {
         // Find and select the default page
         var targetUrl = globals.commingFromRIDIndicator
             ? "qrc:/qml/QGroundControl/AppSettings/RemoteIDSettings.qml"
-            : "qrc:/qml/QGroundControl/AppSettings/AppSettings.qml"
+            : "qrc:/qml/QGroundControl/AppSettings/GeneralSettings.qml"
         globals.commingFromRIDIndicator = false
 
         for (var i = 0; i < settingsPagesModel.count; i++) {
@@ -217,9 +217,13 @@ Rectangle {
                         onClicked: {
                             if (mainWindow.allowViewSwitch()) {
                                 settingsView._navigateTo(index, -1)
-                                // Auto-expand when selecting a page
-                                if (hasMultipleSections && !isExpanded) {
-                                    settingsView._setExpanded(index, true)
+                                if (hasMultipleSections) {
+                                    // Toggle expand/collapse when re-clicking the same page
+                                    if (isSelected && isExpanded) {
+                                        settingsView._setExpanded(index, false)
+                                    } else if (!isExpanded) {
+                                        settingsView._setExpanded(index, true)
+                                    }
                                 }
                             }
                         }
@@ -228,7 +232,11 @@ Rectangle {
                             if (!mainWindow.allowViewSwitch()) {
                                 return
                             }
-                            settingsView._setExpanded(index, !isExpanded)
+                            var expanding = !isExpanded
+                            settingsView._setExpanded(index, expanding)
+                            if (!expanding && isSelected) {
+                                settingsView._navigateTo(index, -1)
+                            }
                         }
                     }
 

--- a/src/Settings/ADSBVehicleManager.SettingsGroup.json
+++ b/src/Settings/ADSBVehicleManager.SettingsGroup.json
@@ -4,7 +4,7 @@
     "QGC.MetaData.Facts": [
         {
             "name": "adsbServerConnectEnabled",
-            "shortDesc": "Connect to ADSB SBS server",
+            "shortDesc": "Enable connection to an ADS-B SBS-1 server to receive nearby aircraft tracking data.",
             "longDesc": "Connect to ADSB SBS-1 server using specified address/port",
             "type": "bool",
             "default": false,
@@ -13,7 +13,7 @@
         },
         {
             "name": "adsbServerHostAddress",
-            "shortDesc": "Host address",
+            "shortDesc": "IP address or hostname of the ADS-B SBS-1 server to connect to.",
             "type": "string",
             "default": "127.0.0.1",
             "label": "Host address",
@@ -21,7 +21,7 @@
         },
         {
             "name": "adsbServerPort",
-            "shortDesc": "Server port",
+            "shortDesc": "Network port number on which the ADS-B SBS-1 server is listening.",
             "type": "string",
             "default": 30003,
             "label": "Server port",

--- a/src/Settings/APMMavlinkStreamRate.SettingsGroup.json
+++ b/src/Settings/APMMavlinkStreamRate.SettingsGroup.json
@@ -9,7 +9,7 @@
     "QGC.MetaData.Facts": [
         {
             "name": "streamRateRawSensors",
-            "shortDesc": "Stream rate for MAVLink Raw Sensors telemetry stream.",
+            "shortDesc": "Frequency (Hz) for receiving raw sensor data from ArduPilot vehicles.",
             "type": "int32",
             "enumStrings": "QGC.MetaData.Defines.StreamRateEnumStrings",
             "enumValues": "QGC.MetaData.Defines.StreamRateEnumValues",
@@ -19,7 +19,7 @@
         },
         {
             "name": "streamRateExtendedStatus",
-            "shortDesc": "Stream rate for MAVLink Extended Status telemetry stream.",
+            "shortDesc": "Frequency (Hz) for receiving extended status data from ArduPilot vehicles.",
             "type": "int32",
             "enumStrings": "QGC.MetaData.Defines.StreamRateEnumStrings",
             "enumValues": "QGC.MetaData.Defines.StreamRateEnumValues",
@@ -29,7 +29,7 @@
         },
         {
             "name": "streamRateRCChannels",
-            "shortDesc": "Stream rate for MAVLink RC Channels telemetry stream.",
+            "shortDesc": "Frequency (Hz) for receiving RC channel data from ArduPilot vehicles.",
             "type": "int32",
             "enumStrings": "QGC.MetaData.Defines.StreamRateEnumStrings",
             "enumValues": "QGC.MetaData.Defines.StreamRateEnumValues",
@@ -39,7 +39,7 @@
         },
         {
             "name": "streamRatePosition",
-            "shortDesc": "Stream rate for MAVLink Position telemetry stream.",
+            "shortDesc": "Frequency (Hz) for receiving vehicle position data from ArduPilot vehicles.",
             "type": "int32",
             "enumStrings": "QGC.MetaData.Defines.StreamRateEnumStrings",
             "enumValues": "QGC.MetaData.Defines.StreamRateEnumValues",
@@ -49,7 +49,7 @@
         },
         {
             "name": "streamRateExtra1",
-            "shortDesc": "Stream rate for MAVLink Extra1 telemetry stream.",
+            "shortDesc": "Frequency (Hz) for receiving extra1 telemetry from ArduPilot vehicles.",
             "type": "int32",
             "enumStrings": "QGC.MetaData.Defines.StreamRateEnumStrings",
             "enumValues": "QGC.MetaData.Defines.StreamRateEnumValues",
@@ -59,7 +59,7 @@
         },
         {
             "name": "streamRateExtra2",
-            "shortDesc": "Stream rate for MAVLink Extra2 telemetry stream.",
+            "shortDesc": "Frequency (Hz) for receiving extra2 telemetry from ArduPilot vehicles.",
             "type": "int32",
             "enumStrings": "QGC.MetaData.Defines.StreamRateEnumStrings",
             "enumValues": "QGC.MetaData.Defines.StreamRateEnumValues",
@@ -69,7 +69,7 @@
         },
         {
             "name": "streamRateExtra3",
-            "shortDesc": "Stream rate for MAVLink Extra3 telemetry stream.",
+            "shortDesc": "Frequency (Hz) for receiving extra3 telemetry from ArduPilot vehicles.",
             "type": "int32",
             "enumStrings": "QGC.MetaData.Defines.StreamRateEnumStrings",
             "enumValues": "QGC.MetaData.Defines.StreamRateEnumValues",

--- a/src/Settings/App.SettingsGroup.json
+++ b/src/Settings/App.SettingsGroup.json
@@ -77,7 +77,7 @@
         },
         {
             "name": "defaultMissionItemAltitude",
-            "shortDesc": "Default value for altitude",
+            "shortDesc": "Default altitude automatically assigned to new waypoints during mission planning.",
             "longDesc": "This value specifies the default altitude for new items added to a mission.",
             "type": "double",
             "default": 50.0,
@@ -100,7 +100,7 @@
         },
         {
             "name": "audioVolume",
-            "shortDesc": "Audio output volume",
+            "shortDesc": "Controls the volume level for audio alerts and notifications.",
             "longDesc": "Sets the audio output volume percentage.",
             "type": "double",
             "default": 100.0,
@@ -114,7 +114,7 @@
         },
         {
             "name": "virtualJoystick",
-            "shortDesc": "Show virtual joystick",
+            "shortDesc": "Displays an on-screen virtual joystick in the Fly view for manual vehicle control.",
             "longDesc": "If this option is enabled the virtual joystick will be shown on the Fly view.",
             "type": "bool",
             "default": false,
@@ -123,7 +123,7 @@
         },
         {
             "name": "virtualJoystickAutoCenterThrottle",
-            "shortDesc": "Auto-Center Throttle",
+            "shortDesc": "Returns the throttle stick to center when released instead of holding position.",
             "longDesc": "If enabled the throttle stick will snap back to center when released.",
             "type": "bool",
             "default": true,
@@ -132,7 +132,7 @@
         },
         {
             "name": "virtualJoystickLeftHandedMode",
-            "shortDesc": "Left Handed Mode",
+            "shortDesc": "Swaps the virtual joystick layout so throttle/yaw is on the left.",
             "longDesc": "If this option is enabled the virtual joystick layout will be reversed",
             "type": "bool",
             "default": false,
@@ -141,7 +141,7 @@
         },
         {
             "name": "gstDebugLevel",
-            "shortDesc": "Video streaming debug",
+            "shortDesc": "Sets the verbosity of video streaming debug logging. Requires restart.",
             "longDesc": "Sets the environment variable GST_DEBUG for all pipeline elements on boot.",
             "type": "uint8",
             "enumStrings": "Disabled,Error,Warning,FixMe,Info,Debug,Log,Trace",
@@ -153,7 +153,7 @@
         },
         {
             "name": "useChecklist",
-            "shortDesc": "Use preflight checklist",
+            "shortDesc": "Enables the preflight checklist to help verify system status before flight.",
             "longDesc": "If this option is enabled the preflight checklist will be used.",
             "type": "bool",
             "default": false,
@@ -162,7 +162,7 @@
         },
         {
             "name": "enforceChecklist",
-            "shortDesc": "Preflight checklist must pass before arming",
+            "shortDesc": "Prevents the vehicle from arming until all preflight checklist items pass.",
             "longDesc": "If this option is enabled the preflight checklist must pass before arming.",
             "type": "bool",
             "default": false,
@@ -171,7 +171,7 @@
         },
         {
             "name": "enableMultiVehiclePanel",
-            "shortDesc": "Enable Multi-Vehicle Panel",
+            "shortDesc": "Shows a panel for managing multiple connected vehicles simultaneously.",
             "longDesc": "Enable Multi-Vehicle Panel when multiple vehicles are connected.",
             "type": "bool",
             "default": true,
@@ -180,7 +180,7 @@
         },
         {
             "name": "uiScalePercent",
-            "shortDesc": "UI scale percentage",
+            "shortDesc": "Scales the entire user interface including fonts and controls.",
             "longDesc": "Scales the entire user interface relative to the platform default. 100% is the default size.",
             "type": "uint32",
             "units": "%",
@@ -192,7 +192,7 @@
         },
         {
             "name": "indoorPalette",
-            "shortDesc": "Application color scheme",
+            "shortDesc": "Switches between light and dark color schemes for different lighting conditions.",
             "longDesc": "The color scheme for the user interface.",
             "type": "uint32",
             "enumStrings": "Indoor,Outdoor",
@@ -203,7 +203,7 @@
         },
         {
             "name": "savePath",
-            "shortDesc": "Application save directory",
+            "shortDesc": "Directory where mission files, logs, and other application data are saved.",
             "longDesc": "Directory to which all data files are saved/loaded from",
             "type": "string",
             "default": "",
@@ -221,7 +221,7 @@
         },
         {
             "name": "tiandituToken",
-            "shortDesc": "Access token to TianDiTu maps",
+            "shortDesc": "Personal API token for accessing TianDiTu map tiles.",
             "longDesc": "Your personal access token for TianDiTu maps",
             "type": "string",
             "default": "",
@@ -230,7 +230,7 @@
         },
         {
             "name": "mapboxToken",
-            "shortDesc": "Access token to Mapbox maps",
+            "shortDesc": "Personal API token for accessing Mapbox map tiles and styling.",
             "longDesc": "Your personal access token for Mapbox maps",
             "type": "string",
             "default": "",
@@ -239,7 +239,7 @@
         },
         {
             "name": "mapboxAccount",
-            "shortDesc": "Account name for Mapbox maps",
+            "shortDesc": "Mapbox account username for accessing account-specific map resources.",
             "longDesc": "Your personal account name for Mapbox maps",
             "type": "string",
             "default": "",
@@ -248,7 +248,7 @@
         },
         {
             "name": "mapboxStyle",
-            "shortDesc": "Map style ID",
+            "shortDesc": "Mapbox map design style ID controlling the appearance of map tiles.",
             "longDesc": "Map design style ID for Mapbox maps",
             "type": "string",
             "default": "",
@@ -257,7 +257,7 @@
         },
         {
             "name": "esriToken",
-            "shortDesc": "Access token to Esri maps",
+            "shortDesc": "Personal API token for accessing Esri map services.",
             "longDesc": "Your personal access token for Esri maps",
             "type": "string",
             "default": "",
@@ -266,7 +266,7 @@
         },
         {
             "name": "customURL",
-            "shortDesc": "Custom Map URL",
+            "shortDesc": "URL pattern with {x}, {y}, {z} substitutions for a custom map tile server.",
             "longDesc": "URL for X Y Z map with {x} {y} {z} or {zoom} substitutions. Eg: https://basemaps.linz.govt.nz/v1/tiles/aerial/EPSG:3857/{z}/{x}/{y}.png?api=d01ev80nqcjxddfvc6amyvkk1ka",
             "type": "string",
             "default": "",
@@ -275,7 +275,7 @@
         },
         {
             "name": "vworldToken",
-            "shortDesc": "VWorld Token",
+            "shortDesc": "Personal API token for accessing VWorld map tiles.",
             "longDesc": "Your personal access token for VWorld maps",
             "type": "string",
             "default": "",
@@ -284,7 +284,7 @@
         },
         {
             "name": "openaipToken",
-            "shortDesc": "OpenAIP API Key",
+            "shortDesc": "Personal API key for displaying OpenAIP airspace and aeronautical data.",
             "longDesc": "Your personal API key for OpenAIP aviation maps. Get one at https://www.openaip.net",
             "type": "string",
             "default": "",
@@ -293,7 +293,7 @@
         },
         {
             "name": "followTarget",
-            "shortDesc": "Stream GCS' coordinates to Autopilot",
+            "shortDesc": "Streams the ground station GPS location to the vehicle for Follow Me mode.",
             "type": "uint32",
             "enumStrings": "Never,Always,When in Follow Me Flight Mode",
             "enumValues": "0,1,2",
@@ -303,7 +303,7 @@
         },
         {
             "name": "qLocaleLanguage",
-            "shortDesc": "Language",
+            "shortDesc": "Determines the language used for the application interface. Requires restart.",
             "type": "uint32",
             "default": 0,
             "qgcRebootRequired": true,
@@ -313,7 +313,7 @@
         },
         {
             "name": "clearSettingsNextBoot",
-            "shortDesc": "Clear all settings on next start",
+            "shortDesc": "Resets all application preferences to their defaults on the next launch.",
             "longDesc": "When enabled, all application settings will be reset to defaults on the next start.",
             "type": "bool",
             "default": false,

--- a/src/Settings/AppSettings.cc
+++ b/src/Settings/AppSettings.cc
@@ -94,7 +94,7 @@ DECLARE_SETTINGGROUP(App, "")
         }
         savePathFact->setRawValue(QDir(rootDirPath).filePath(appName));
     #endif
-    savePathFact->setVisible(false);
+    savePathFact->setUserVisible(false);
 #else
         QDir rootDir;
         if (qgcApp()->runningUnitTests() || qgcApp()->simpleBootTest()) {

--- a/src/Settings/AutoConnect.SettingsGroup.json
+++ b/src/Settings/AutoConnect.SettingsGroup.json
@@ -4,7 +4,7 @@
     "QGC.MetaData.Facts": [
         {
             "name": "autoConnectUDP",
-            "shortDesc": "Automatically open a connection over UDP",
+            "shortDesc": "Automatically connect to vehicles detected on UDP network connections.",
             "longDesc": "If this option is enabled GroundControl will automatically connect to a vehicle which is detected on a UDP communication link.",
             "type": "bool",
             "default": true,
@@ -13,7 +13,7 @@
         },
         {
             "name": "autoConnectPixhawk",
-            "shortDesc": "Automatically connect to a Pixhawk board",
+            "shortDesc": "Automatically connect to Pixhawk autopilots detected on USB.",
             "longDesc": "If this option is enabled GroundControl will automatically connect to a Pixhawk board which is connected via USB.",
             "type": "bool",
             "default": true,
@@ -22,7 +22,7 @@
         },
         {
             "name": "autoConnectSiKRadio",
-            "shortDesc": "Automatically connect to a SiK Radio",
+            "shortDesc": "Automatically connect to SiK radio modules detected on serial/USB.",
             "longDesc": "If this option is enabled GroundControl will automatically connect to a vehicle which is detected on a SiK Radio communication link.",
             "type": "bool",
             "default": true,
@@ -31,7 +31,7 @@
         },
         {
             "name": "autoConnectRTKGPS",
-            "shortDesc": "Automatically connect to an RTK GPS",
+            "shortDesc": "Automatically connect to RTK GPS receivers detected on USB.",
             "longDesc": "If this option is enabled GroundControl will automatically connect to an RTK GPS which is connected via USB.",
             "type": "bool",
             "default": true,
@@ -40,7 +40,7 @@
         },
         {
             "name": "autoConnectLibrePilot",
-            "shortDesc": "Automatically connect to a LibrePilot",
+            "shortDesc": "Automatically connect to LibrePilot autopilots detected on USB.",
             "longDesc": "If this option is enabled GroundControl will automatically connect to a LibrePilot board which is connected via USB.",
             "type": "bool",
             "default": true,

--- a/src/Settings/AutoConnectSettings.cc
+++ b/src/Settings/AutoConnectSettings.cc
@@ -35,7 +35,7 @@ DECLARE_SETTINGSFACT_NO_FUNC(AutoConnectSettings, autoConnectPixhawk)
     if (!_autoConnectPixhawkFact) {
         _autoConnectPixhawkFact = _createSettingsFact(autoConnectPixhawkName);
 #ifdef Q_OS_IOS
-        _autoConnectPixhawkFact->setVisible(false);
+        _autoConnectPixhawkFact->setUserVisible(false);
 #endif
     }
     return _autoConnectPixhawkFact;
@@ -46,7 +46,7 @@ DECLARE_SETTINGSFACT_NO_FUNC(AutoConnectSettings, autoConnectSiKRadio)
     if (!_autoConnectSiKRadioFact) {
         _autoConnectSiKRadioFact = _createSettingsFact(autoConnectSiKRadioName);
 #ifdef Q_OS_IOS
-        _autoConnectSiKRadioFact->setVisible(false);
+        _autoConnectSiKRadioFact->setUserVisible(false);
 #endif
     }
     return _autoConnectSiKRadioFact;
@@ -57,7 +57,7 @@ DECLARE_SETTINGSFACT_NO_FUNC(AutoConnectSettings, autoConnectRTKGPS)
     if (!_autoConnectRTKGPSFact) {
         _autoConnectRTKGPSFact = _createSettingsFact(autoConnectRTKGPSName);
 #ifdef Q_OS_IOS
-        _autoConnectRTKGPSFact->setVisible(false);
+        _autoConnectRTKGPSFact->setUserVisible(false);
 #endif
     }
     return _autoConnectRTKGPSFact;
@@ -68,7 +68,7 @@ DECLARE_SETTINGSFACT_NO_FUNC(AutoConnectSettings, autoConnectLibrePilot)
     if (!_autoConnectLibrePilotFact) {
         _autoConnectLibrePilotFact = _createSettingsFact(autoConnectLibrePilotName);
 #ifdef Q_OS_IOS
-        _autoConnectLibrePilotFact->setVisible(false);
+        _autoConnectLibrePilotFact->setUserVisible(false);
 #endif
     }
     return _autoConnectLibrePilotFact;
@@ -79,7 +79,7 @@ DECLARE_SETTINGSFACT_NO_FUNC(AutoConnectSettings, autoConnectNmeaPort)
     if (!_autoConnectNmeaPortFact) {
         _autoConnectNmeaPortFact = _createSettingsFact(autoConnectNmeaPortName);
 #ifdef Q_OS_IOS
-        _autoConnectNmeaPortFact->setVisible(false);
+        _autoConnectNmeaPortFact->setUserVisible(false);
 #endif
     }
     return _autoConnectNmeaPortFact;
@@ -90,7 +90,7 @@ DECLARE_SETTINGSFACT_NO_FUNC(AutoConnectSettings, autoConnectNmeaBaud)
     if (!_autoConnectNmeaBaudFact) {
         _autoConnectNmeaBaudFact = _createSettingsFact(autoConnectNmeaBaudName);
 #ifdef Q_OS_IOS
-        _autoConnectNmeaBaudFact->setVisible(false);
+        _autoConnectNmeaBaudFact->setUserVisible(false);
 #endif
     }
     return _autoConnectNmeaBaudFact;

--- a/src/Settings/FlyView.SettingsGroup.json
+++ b/src/Settings/FlyView.SettingsGroup.json
@@ -4,7 +4,7 @@
     "QGC.MetaData.Facts": [
         {
             "name": "guidedMinimumAltitude",
-            "shortDesc": "Minimum altitude for guided actions altitude slider.",
+            "shortDesc": "Minimum altitude allowed for guided mode actions like takeoff and altitude changes.",
             "type": "double",
             "units": "m",
             "default": 2,
@@ -13,7 +13,7 @@
         },
         {
             "name": "guidedMaximumAltitude",
-            "shortDesc": "Maximum altitude for guided actions altitude slider.",
+            "shortDesc": "Maximum altitude allowed for guided mode actions like takeoff and altitude changes.",
             "type": "double",
             "units": "m",
             "default": 121.92,
@@ -22,7 +22,7 @@
         },
         {
             "name": "showLogReplayStatusBar",
-            "shortDesc": "Show/Hide Log Replay status bar",
+            "shortDesc": "Show the playback control bar during telemetry log replay.",
             "type": "bool",
             "default": false,
             "label": "Show Telemetry Log Replay Status Bar",
@@ -30,7 +30,7 @@
         },
         {
             "name": "showAdditionalIndicatorsCompass",
-            "shortDesc": "Show additional heading indicators on Compass",
+            "shortDesc": "Display additional heading reference indicators on the compass.",
             "type": "bool",
             "default": false,
             "label": "Show additional heading indicators on Compass",
@@ -38,7 +38,7 @@
         },
         {
             "name": "lockNoseUpCompass",
-            "shortDesc": "Lock Compass Nose-Up",
+            "shortDesc": "Always show north pointing up on the compass instead of rotating with vehicle heading.",
             "type": "bool",
             "default": false,
             "label": "Lock Compass Nose-Up",
@@ -46,7 +46,7 @@
         },
         {
             "name": "keepMapCenteredOnVehicle",
-            "shortDesc": "Keep map centered on vehicle",
+            "shortDesc": "Automatically pan the map to keep the vehicle centered on screen during flight.",
             "type": "bool",
             "default": false,
             "label": "Keep Map Centered On Vehicle",
@@ -54,7 +54,7 @@
         },
         {
             "name": "showSimpleCameraControl",
-            "shortDesc": "Show controls for camera triggering using MAV_CMD_DO_DIGICAM_CONTROL.",
+            "shortDesc": "Display simple camera trigger controls using MAVLink DIGICAM_CONTROL commands.",
             "type": "bool",
             "default": false,
             "label": "Show simple camera controls (DIGICAM_CONTROL)",
@@ -69,7 +69,7 @@
         },
         {
             "name": "maxGoToLocationDistance",
-            "shortDesc": "Maximum distance allowed for Go To Location.",
+            "shortDesc": "Maximum allowed distance for go-to-location commands from the vehicle.",
             "type": "double",
             "units": "m",
             "default": 1000,
@@ -79,7 +79,7 @@
         },
         {
             "name": "forwardFlightGoToLocationLoiterRad",
-            "shortDesc": "Loiter radius for orbiting the Go To Location during forward flight. This only applies if the firmware supports a radius in MAV_CMD_DO_REPOSITION commands.",
+            "shortDesc": "Loiter radius when circling a go-to destination during fixed-wing flight.",
             "type": "double",
             "units": "m",
             "default": 80,
@@ -89,7 +89,7 @@
         },
         {
             "name": "goToLocationRequiresConfirmInGuided",
-            "shortDesc": "Require slide confirmation for Go To Location when the vehicle is already in Guided mode.",
+            "shortDesc": "Require explicit confirmation for go-to-location commands while in Guided mode.",
             "type": "bool",
             "default": true,
             "label": "Require Confirmation for Go To Location in Guided Mode",
@@ -97,7 +97,7 @@
         },
         {
             "name": "updateHomePosition",
-            "shortDesc": "Send updated GCS' home position to autopilot in case of change of the home position",
+            "shortDesc": "Automatically update the vehicle return-to-home position from the GCS GPS location.",
             "type": "bool",
             "default": false,
             "label": "Update return to home position based on device location",
@@ -105,7 +105,7 @@
         },
         {
             "name": "instrumentQmlFile2",
-            "shortDesc": "Qml file for instrument panel",
+            "shortDesc": "Select the instrument panel display style for the Fly view.",
             "type": "string",
             "enumStrings": "Integrated Compass & Attitude,Horizontal Compass & Attitude,Large Vertical",
             "enumValues": "qrc:/qml/QGroundControl/FlightMap/Widgets/IntegratedCompassAttitude.qml,qrc:/qml/QGroundControl/FlightMap/Widgets/HorizontalCompassAttitude.qml,qrc:/qml/QGroundControl/FlightMap/Widgets/VerticalCompassAttitude.qml",
@@ -131,7 +131,7 @@
         },
         {
             "name": "enableAutomaticMissionPopups",
-            "shortDesc": "Enable automatic mission start/resume popups",
+            "shortDesc": "Automatically show mission start and resume confirmation dialogs.",
             "type": "bool",
             "default": true,
             "label": "Enable automatic mission start/resume popups",

--- a/src/Settings/Maps.SettingsGroup.json
+++ b/src/Settings/Maps.SettingsGroup.json
@@ -4,7 +4,7 @@
     "QGC.MetaData.Facts": [
         {
             "name": "maxCacheDiskSize",
-            "shortDesc": "Max disk cache",
+            "shortDesc": "Maximum disk space in megabytes for caching downloaded map tiles.",
             "type": "Uint32",
             "units": "MB",
             "min": 1,
@@ -15,7 +15,7 @@
         },
         {
             "name": "maxCacheMemorySize",
-            "shortDesc": "Max memory cache",
+            "shortDesc": "Maximum RAM in megabytes for caching map tiles in memory.",
             "type": "Uint32",
             "units": "MB",
             "min": 1,

--- a/src/Settings/Mavlink.SettingsGroup.json
+++ b/src/Settings/Mavlink.SettingsGroup.json
@@ -4,7 +4,7 @@
     "QGC.MetaData.Facts": [
         {
             "name": "telemetrySave",
-            "shortDesc": "Save telemetry Log after each flight",
+            "shortDesc": "Automatically save a telemetry log file after each flight completes.",
             "longDesc": "If this option is enabled a telemetry will be saved after each flight completes.",
             "type": "bool",
             "default": true,
@@ -13,7 +13,7 @@
         },
         {
             "name": "telemetrySaveNotArmed",
-            "shortDesc": "Save telemetry log even if vehicle was not armed",
+            "shortDesc": "Also save telemetry logs from sessions where the vehicle was never armed.",
             "longDesc": "If this option is enabled a telemtry log will be saved even if vehicle was never armed.",
             "type": "bool",
             "default": false,
@@ -22,7 +22,7 @@
         },
         {
             "name": "apmStartMavlinkStreams",
-            "shortDesc": "Request start of MAVLink telemetry streams (ArduPilot only)",
+            "shortDesc": "Request ArduPilot to begin sending MAVLink telemetry streams on connect.",
             "type": "bool",
             "default": true,
             "qgcRebootRequired": true,
@@ -31,7 +31,7 @@
         },
         {
             "name": "saveCsvTelemetry",
-            "shortDesc": "Save CSV Telementry Logs",
+            "shortDesc": "Save all vehicle parameters to CSV files at 1 Hz during flight.",
             "longDesc": "If this option is enabled, all Facts will be written to a CSV file with a 1 Hertz frequency.",
             "type": "bool",
             "default": false,
@@ -40,7 +40,7 @@
         },
         {
             "name": "forwardMavlink",
-            "shortDesc": "Enable mavlink forwarding",
+            "shortDesc": "Forward all MAVLink messages to an external address for other ground stations.",
             "longDesc": "Enable mavlink forwarding",
             "type": "bool",
             "default": false,
@@ -49,7 +49,7 @@
         },
         {
             "name": "forwardMavlinkHostName",
-            "shortDesc": "Host name",
+            "shortDesc": "Network address and port to forward MAVLink messages to (e.g. localhost:14445).",
             "longDesc": "Host name to forward mavlink to. i.e: localhost:14445",
             "type": "string",
             "default": "localhost:14445",
@@ -67,7 +67,7 @@
         },
         {
             "name": "sendGCSHeartbeat",
-            "shortDesc": "Send GCS Heartbeat",
+            "shortDesc": "Periodically transmit heartbeat messages to inform vehicles that QGC is connected.",
             "type": "bool",
             "default": true,
             "label": "Emit heartbeat",
@@ -75,7 +75,7 @@
         },
         {
             "name": "gcsMavlinkSystemID",
-            "shortDesc": "GCS MAVLink System ID",
+            "shortDesc": "MAVLink system identifier (1-255) for this ground station.",
             "type": "uint32",
             "default": 255,
             "min": 1,
@@ -85,7 +85,7 @@
         },
         {
             "name": "noInitialDownloadWhenFlying",
-            "shortDesc": "Skip param/plan download on connect if flying",
+            "shortDesc": "Skip downloading parameters and missions when connecting to a vehicle already in flight.",
             "longDesc": "When enabled, parameter and mission plan downloads are skipped when connecting to a vehicle that is already flying. This prevents bandwidth-heavy transfers from disrupting an active flight.",
             "type": "bool",
             "default": false,

--- a/src/Settings/NTRIP.SettingsGroup.json
+++ b/src/Settings/NTRIP.SettingsGroup.json
@@ -48,7 +48,7 @@
         },
         {
             "name": "ntripWhitelist",
-            "shortDesc": "RTCM Message Filter",
+            "shortDesc": "Comma-separated RTCM message IDs to forward. Leave blank for all messages.",
             "longDesc": "Comma-separated RTCM message IDs to forward (e.g. 1005,1077,1087). Leave blank for all messages.",
             "type": "string",
             "default": "",
@@ -65,7 +65,7 @@
         },
         {
             "name": "ntripUdpForwardEnabled",
-            "shortDesc": "UDP forward RTCM data",
+            "shortDesc": "Forward received RTCM correction data to another application via UDP.",
             "longDesc": "Forward received RTCM correction data via UDP to the specified address and port",
             "type": "bool",
             "default": false,
@@ -74,7 +74,7 @@
         },
         {
             "name": "ntripUdpTargetAddress",
-            "shortDesc": "UDP target address",
+            "shortDesc": "IP address to forward RTCM correction data to.",
             "longDesc": "IP address to forward RTCM data to via UDP",
             "type": "string",
             "default": "",
@@ -83,7 +83,7 @@
         },
         {
             "name": "ntripUdpTargetPort",
-            "shortDesc": "UDP target port",
+            "shortDesc": "Port number for forwarding RTCM correction data via UDP.",
             "longDesc": "Port to forward RTCM data to via UDP",
             "type": "uint16",
             "default": 0,

--- a/src/Settings/PlanView.SettingsGroup.json
+++ b/src/Settings/PlanView.SettingsGroup.json
@@ -18,7 +18,7 @@
         },
         {
             "name": "takeoffItemNotRequired",
-            "shortDesc": "Allow missions to not require a takeoff item",
+            "shortDesc": "Allow missions to begin without a dedicated takeoff waypoint.",
             "type": "bool",
             "default": false,
             "label": "Missions do not require takeoff item",
@@ -26,7 +26,7 @@
         },
         {
             "name": "allowMultipleLandingPatterns",
-            "shortDesc": "Allow configuring multiple landing sequences if the firmware supports it. The first one will be used for the mission, but in the event of an RTL, the one that is closest will be used instead.",
+            "shortDesc": "Enable creating multiple landing sequences for Return-to-Launch contingency selection.",
             "type": "bool",
             "default": true,
             "label": "Allow configuring multiple landing sequences",
@@ -34,7 +34,7 @@
         },
         {
             "name": "useConditionGate",
-            "shortDesc": "Use MAV_CMD_CONDITION_GATE for pattern generation",
+            "shortDesc": "Use MAV_CMD_CONDITION_GATE for mission pattern transitions instead of standard waypoints.",
             "type": "bool",
             "default": false,
             "label": "Use MAV_CMD_CONDITION_GATE for pattern generation",
@@ -49,7 +49,7 @@
         },
         {
             "name": "vtolTransitionDistance",
-            "shortDesc": "Amount of distance required for vehicle to complete a transition",
+            "shortDesc": "Distance required for VTOL vehicles to complete altitude and speed transitions.",
             "type": "double",
             "default": 300.0,
             "units": "m",

--- a/src/Settings/RemoteID.SettingsGroup.json
+++ b/src/Settings/RemoteID.SettingsGroup.json
@@ -4,7 +4,7 @@
     "QGC.MetaData.Facts": [
         {
             "name": "operatorID",
-            "shortDesc": "Operator ID",
+            "shortDesc": "Pilot registration code or identification number (max 20 characters).",
             "longDesc": "Operator ID. Maximum 20 characters.",
             "type": "string",
             "default": "",
@@ -21,7 +21,7 @@
         },
         {
             "name": "operatorIDType",
-            "shortDesc": "Operator ID type",
+            "shortDesc": "Format of the operator ID (currently CAA only).",
             "type": "uint8",
             "enumStrings": "CAA",
             "enumValues": "0",
@@ -31,7 +31,7 @@
         },
         {
             "name": "sendOperatorID",
-            "shortDesc": "Send Operator ID",
+            "shortDesc": "Broadcast the operator identification information via Remote ID.",
             "longDesc": "When enabled, sends operator ID message",
             "type": "bool",
             "default": false,
@@ -40,7 +40,7 @@
         },
         {
             "name": "selfIDFree",
-            "shortDesc": "Flight Purpose",
+            "shortDesc": "Flight purpose description to broadcast (max 23 characters).",
             "longDesc": "Optional plain text for operator to specify operations data (Free Text). Maximum 23 characters.",
             "type": "string",
             "default": "",
@@ -49,7 +49,7 @@
         },
         {
             "name": "selfIDEmergency",
-            "shortDesc": "Emergency Text",
+            "shortDesc": "Emergency status text to broadcast (max 23 characters).",
             "longDesc": "Optional plain text for operator to specify operations data (Emergency Text). Maximum 23 characters.",
             "type": "string",
             "default": "Pilot Emergency Status",
@@ -58,7 +58,7 @@
         },
         {
             "name": "selfIDExtended",
-            "shortDesc": "Extended Status",
+            "shortDesc": "Extended operational status information to broadcast (max 23 characters).",
             "longDesc": "Optional plain text for operator to specify operations data (Extended Text). Maximum 23 characters.",
             "type": "string",
             "default": "",
@@ -67,7 +67,7 @@
         },
         {
             "name": "selfIDType",
-            "shortDesc": "Self ID type",
+            "shortDesc": "Type of self-ID message to broadcast (flight purpose, emergency, or extended).",
             "type": "uint8",
             "enumStrings": "Flight Purpose,Emergency,Extended Status",
             "enumValues": "0,1,2",
@@ -77,7 +77,7 @@
         },
         {
             "name": "sendSelfID",
-            "shortDesc": "Send Self ID",
+            "shortDesc": "Broadcast flight purpose or emergency status information via Remote ID.",
             "longDesc": "When enabled, sends self ID message",
             "type": "bool",
             "default": false,
@@ -86,7 +86,7 @@
         },
         {
             "name": "basicID",
-            "shortDesc": "Basic ID",
+            "shortDesc": "Drone serial number or registration code to transmit (max 20 characters).",
             "type": "string",
             "default": "",
             "label": "Basic ID",
@@ -94,7 +94,7 @@
         },
         {
             "name": "basicIDType",
-            "shortDesc": "Basic ID Type",
+            "shortDesc": "Format of the drone ID (CAA registration, serial number, or UTM assigned).",
             "type": "uint8",
             "enumStrings": "None,SerialNumber (ANSI/CTA-2063),CAA,UTM (RFC4122),Specific",
             "enumValues": "0,1,2,3,4",
@@ -104,7 +104,7 @@
         },
         {
             "name": "basicIDUaType",
-            "shortDesc": "UA type",
+            "shortDesc": "Classification of the unmanned aircraft (multirotor, fixed-wing, etc.).",
             "type": "uint8",
             "enumStrings": "Undefined,Airplane/FixedWing,Helicopter/Multirrotor,Gyroplane,VTOL,Ornithopter,Glider,Kite,Free Ballon,Captive Ballon,Airship,Parachute,Rocket,Tethered powered aircraft,Ground Obstacle,Other",
             "enumValues": "0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15",
@@ -114,7 +114,7 @@
         },
         {
             "name": "sendBasicID",
-            "shortDesc": "Send Basic ID",
+            "shortDesc": "Broadcast the drone identification information via Remote ID.",
             "longDesc": "When enabled, sends basic ID message",
             "type": "bool",
             "default": false,
@@ -123,7 +123,7 @@
         },
         {
             "name": "region",
-            "shortDesc": "Region of operation",
+            "shortDesc": "Regulatory region for Remote ID compliance (FAA or EU).",
             "longDesc": "The region of operation the mission will take place in",
             "type": "uint8",
             "enumStrings": "FAA,EU",
@@ -134,7 +134,7 @@
         },
         {
             "name": "locationType",
-            "shortDesc": "Location Type",
+            "shortDesc": "Source for operator location data (live GNSS or fixed coordinates).",
             "longDesc": "Operator location Type",
             "type": "uint8",
             "enumStrings": "Takeoff(Not Supported),Live GNNS, Fixed (not for FAA)",
@@ -145,7 +145,7 @@
         },
         {
             "name": "latitudeFixed",
-            "shortDesc": "Latitude Fixed",
+            "shortDesc": "Fixed latitude for operator location when not using live GNSS.",
             "longDesc": "Fixed latitude to send on SYSTEM message",
             "type": "double",
             "minValue": "-90",
@@ -157,7 +157,7 @@
         },
         {
             "name": "longitudeFixed",
-            "shortDesc": "Longitude Fixed",
+            "shortDesc": "Fixed longitude for operator location when not using live GNSS.",
             "longDesc": "Fixed Longitude to send on SYSTEM message",
             "type": "double",
             "minValue": "-180",
@@ -169,7 +169,7 @@
         },
         {
             "name": "altitudeFixed",
-            "shortDesc": "Altitude Fixed",
+            "shortDesc": "Fixed altitude for operator location when not using live GNSS.",
             "longDesc": "Fixed Altitude to send on SYSTEM message",
             "type": "double",
             "decimalPlaces": 7,
@@ -179,7 +179,7 @@
         },
         {
             "name": "classificationType",
-            "shortDesc": "Classification Type",
+            "shortDesc": "Classification standard to use for Remote ID (undeclared or EU).",
             "longDesc": "Classification Type of UAS",
             "type": "uint8",
             "enumStrings": "Undeclared,EU",
@@ -190,7 +190,7 @@
         },
         {
             "name": "categoryEU",
-            "shortDesc": "Category",
+            "shortDesc": "EU classification category for the UAS (Open, Specific, or Certified).",
             "longDesc": "Category of the UAS in the EU region",
             "type": "uint8",
             "enumStrings": "Undeclared,Open,Specific,Certified",
@@ -201,7 +201,7 @@
         },
         {
             "name": "classEU",
-            "shortDesc": "Class",
+            "shortDesc": "EU equipment class designation (Class 0 through Class 6).",
             "longDesc": "Class of the UAS in the EU region",
             "type": "uint8",
             "enumStrings": "Undeclared,Class 0,Class 1,Class 2,Class 3,Class 4,Class 5,Class 6",

--- a/src/Settings/SettingsGroup.cc
+++ b/src/Settings/SettingsGroup.cc
@@ -5,7 +5,7 @@
 
 SettingsGroup::SettingsGroup(const QString& name, const QString& settingsGroup, QObject* parent)
     : QObject       (parent)
-    , _visible      (QGCCorePlugin::instance()->overrideSettingsGroupVisibility(name))
+    , _userVisible  (QGCCorePlugin::instance()->overrideSettingsGroupVisibility(name))
     , _name         (name)
     , _settingsGroup(settingsGroup)
 {

--- a/src/Settings/SettingsGroup.h
+++ b/src/Settings/SettingsGroup.h
@@ -36,8 +36,9 @@
         Fact* NAME(); \
         static const char* NAME ## Name;
 
-/// Provides access to group of settings. The group is named and has a visible property associated with it which can control whether the group
-/// is shown in the UI.
+/// Provides access to group of settings. The group is named and has a userVisible
+/// property that controls whether the entire group is shown in the UI.
+/// Custom builds can hide groups via QGCCorePlugin::overrideSettingsGroupVisibility.
 class SettingsGroup : public QObject
 {
     Q_OBJECT
@@ -47,20 +48,22 @@ public:
     /// @param settingsGroup Group to place settings in for QSettings::beingGroup
     SettingsGroup(const QString &name, const QString &settingsGroup, QObject* parent = nullptr);
 
-    Q_PROPERTY(bool visible READ visible WRITE setVisible NOTIFY visibleChanged)
+    /// Whether this settings group should be shown in the UI. Custom builds can
+    /// override this via QGCCorePlugin::overrideSettingsGroupVisibility.
+    Q_PROPERTY(bool userVisible READ userVisible WRITE setUserVisible NOTIFY userVisibleChanged)
 
-    virtual bool    visible             () { return _visible; }
-    virtual void    setVisible          (bool vis) { _visible = vis; emit visibleChanged(); }
+    virtual bool    userVisible         () { return _userVisible; }
+    virtual void    setUserVisible      (bool vis) { _userVisible = vis; emit userVisibleChanged(); }
 
     QString settingsGroup() const { return _settingsGroup; }
 
 signals:
-    void            visibleChanged      ();
+    void            userVisibleChanged  ();
 
 protected:
     SettingsFact* _createSettingsFact(const QString& factName);
 
-    bool _visible;
+    bool _userVisible;
     QString _name;
     QString _settingsGroup;
 

--- a/src/Settings/SettingsManager.cc
+++ b/src/Settings/SettingsManager.cc
@@ -206,9 +206,9 @@ void SettingsManager::_loadSettingsFiles()
     }
 }
 
-void SettingsManager::adjustSettingMetaData(const QString &settingsGroup, FactMetaData &metaData, bool &visible)
+void SettingsManager::adjustSettingMetaData(const QString &settingsGroup, FactMetaData &metaData, bool &userVisible)
 {
-    visible = true; // By default all settings are visible
+    userVisible = true; // By default all settings are visible
 
     SettingsManager *settingsManager = SettingsManager::instance();
     if (!settingsManager) {
@@ -234,11 +234,11 @@ void SettingsManager::adjustSettingMetaData(const QString &settingsGroup, FactMe
             for (const QString &metaDataName : settingOverrideJsonObject.keys()) {
                 if (metaDataName == kJsonVisibleKey) {
                     qCDebug(SettingsManagerLog) << "  Setting visibility to" << settingOverrideJsonObject[kJsonVisibleKey].toBool();
-                    visible = settingOverrideJsonObject[kJsonVisibleKey].toBool();
+                    userVisible = settingOverrideJsonObject[kJsonVisibleKey].toBool();
                 } else if (metaDataName == kJsonForceRawValueKey) {
                     qCDebug(SettingsManagerLog) << "  Setting forceRawValue to" << settingOverrideJsonObject[kJsonForceRawValueKey];
                     metaData.setRawDefaultValue(settingOverrideJsonObject[kJsonForceRawValueKey].toVariant());
-                    visible = false;
+                    userVisible = false;
                 } else if (metaDataName == FactMetaData::_defaultValueJsonKey) {
                     qCDebug(SettingsManagerLog) << "  Setting default to" << overrideMetaData->rawDefaultValue();
                     metaData.setRawDefaultValue(overrideMetaData->rawDefaultValue());
@@ -269,5 +269,5 @@ void SettingsManager::adjustSettingMetaData(const QString &settingsGroup, FactMe
     }
 
     // Give QGCCorePlugin a whack at it too
-    QGCCorePlugin::instance()->adjustSettingMetaData(settingsGroup, metaData, visible);
+    QGCCorePlugin::instance()->adjustSettingMetaData(settingsGroup, metaData, userVisible);
 }

--- a/src/Settings/SettingsManager.h
+++ b/src/Settings/SettingsManager.h
@@ -98,8 +98,8 @@ public:
     /// Allows for overriding the meta data before the fact is created.
     ///     @param settingsGroup - QSettings group which contains this item
     ///     @param metaData - MetaData for setting fact
-    ///     @param visible - true: Setting should be visible in ui, false: Setting should not be shown in ui (default value will be used as value)
-    static void adjustSettingMetaData(const QString &settingsGroup, FactMetaData &metaData, bool &visible);
+    ///     @param userVisible - true: Setting should be visible in ui, false: Setting should not be shown in ui (default value will be used as value)
+    static void adjustSettingMetaData(const QString &settingsGroup, FactMetaData &metaData, bool &userVisible);
 
     ADSBVehicleManagerSettings *adsbVehicleManagerSettings() const;
 #ifndef QGC_NO_ARDUPILOT_DIALECT

--- a/src/Settings/UnitsSettings.cc
+++ b/src/Settings/UnitsSettings.cc
@@ -16,7 +16,7 @@ DECLARE_SETTINGSFACT_NO_FUNC(UnitsSettings, horizontalDistanceUnits)
         FactMetaData* metaData = new FactMetaData(FactMetaData::valueTypeUint32, this);
         metaData->setName(horizontalDistanceUnitsName);
         metaData->setLabel(UnitsSettings::tr("Horizontal Distance"));
-        metaData->setShortDescription(UnitsSettings::tr("Horizontal Distance"));
+        metaData->setShortDescription(UnitsSettings::tr("Display unit for horizontal distances and ranges."));
         metaData->setEnumInfo(enumStrings, enumValues);
 
         HorizontalDistanceUnits defaultHorizontalDistanceUnit = HorizontalDistanceUnitsMeters;
@@ -48,7 +48,7 @@ DECLARE_SETTINGSFACT_NO_FUNC(UnitsSettings, verticalDistanceUnits)
         FactMetaData* metaData = new FactMetaData(FactMetaData::valueTypeUint32, this);
         metaData->setName(verticalDistanceUnitsName);
         metaData->setLabel(UnitsSettings::tr("Vertical Distance"));
-        metaData->setShortDescription(UnitsSettings::tr("Vertical Distance"));
+        metaData->setShortDescription(UnitsSettings::tr("Display unit for altitudes and vertical heights."));
         metaData->setEnumInfo(enumStrings, enumValues);
         VerticalDistanceUnits defaultVerticalAltitudeUnit = VerticalDistanceUnitsMeters;
         switch(QLocale::system().measurementSystem()) {
@@ -84,7 +84,7 @@ DECLARE_SETTINGSFACT_NO_FUNC(UnitsSettings, areaUnits)
         FactMetaData* metaData = new FactMetaData(FactMetaData::valueTypeUint32, this);
         metaData->setName(areaUnitsName);
         metaData->setLabel(UnitsSettings::tr("Area"));
-        metaData->setShortDescription(UnitsSettings::tr("Area"));
+        metaData->setShortDescription(UnitsSettings::tr("Display unit for area measurements."));
         metaData->setEnumInfo(enumStrings, enumValues);
 
         AreaUnits defaultAreaUnit = AreaUnitsSquareMeters;
@@ -120,7 +120,7 @@ DECLARE_SETTINGSFACT_NO_FUNC(UnitsSettings, speedUnits)
         FactMetaData* metaData = new FactMetaData(FactMetaData::valueTypeUint32, this);
         metaData->setName(speedUnitsName);
         metaData->setLabel(UnitsSettings::tr("Speed"));
-        metaData->setShortDescription(UnitsSettings::tr("Speed"));
+        metaData->setShortDescription(UnitsSettings::tr("Display unit for speed and velocity values."));
         metaData->setEnumInfo(enumStrings, enumValues);
 
         SpeedUnits defaultSpeedUnit = SpeedUnitsMetersPerSecond;
@@ -151,7 +151,7 @@ DECLARE_SETTINGSFACT_NO_FUNC(UnitsSettings, temperatureUnits)
         FactMetaData* metaData = new FactMetaData(FactMetaData::valueTypeUint32, this);
         metaData->setName(temperatureUnitsName);
         metaData->setLabel(UnitsSettings::tr("Temperature"));
-        metaData->setShortDescription(UnitsSettings::tr("Temperature"));
+        metaData->setShortDescription(UnitsSettings::tr("Display unit for temperature readings."));
         metaData->setEnumInfo(enumStrings, enumValues);
 
         TemperatureUnits defaultTemperatureUnit = TemperatureUnitsCelsius;

--- a/src/Settings/Video.SettingsGroup.json
+++ b/src/Settings/Video.SettingsGroup.json
@@ -4,7 +4,7 @@
     "QGC.MetaData.Facts": [
         {
             "name": "videoSource",
-            "shortDesc": "Video source",
+            "shortDesc": "Source for video stream (UDP, TCP, RTSP, or connected USB camera).",
             "longDesc": "Source for video. UDP, TCP, RTSP and UVC Cameras may be supported depending on Vehicle and ground station version.",
             "type": "string",
             "default": "",
@@ -13,7 +13,7 @@
         },
         {
             "name": "udpUrl",
-            "shortDesc": "Video UDP Url",
+            "shortDesc": "Network address and port for UDP video stream (e.g. 0.0.0.0:5600).",
             "longDesc": "UDP url address and port to bind to for video stream. Example: 0.0.0.0:5600",
             "type": "string",
             "default": "0.0.0.0:5600",
@@ -22,7 +22,7 @@
         },
         {
             "name": "rtspUrl",
-            "shortDesc": "Video RTSP Url",
+            "shortDesc": "Network address for RTSP video stream (e.g. rtsp://192.168.42.1:554/live).",
             "longDesc": "RTSP url address and port to bind to for video stream. Example: rtsp://192.168.42.1:554/live",
             "type": "string",
             "default": "",
@@ -31,7 +31,7 @@
         },
         {
             "name": "tcpUrl",
-            "shortDesc": "Video TCP Url",
+            "shortDesc": "Network address and port for TCP video stream (e.g. 192.168.143.200:3001).",
             "longDesc": "TCP url address and port to bind to for video stream. Example: 192.168.143.200:3001",
             "type": "string",
             "default": "",
@@ -48,7 +48,7 @@
         },
         {
             "name": "aspectRatio",
-            "shortDesc": "Video Aspect Ratio",
+            "shortDesc": "Video frame aspect ratio as width divided by height. Use 0 to auto-detect.",
             "longDesc": "Video Aspect Ratio (width / height). Use 0.0 to ignore it.",
             "type": "float",
             "decimalPlaces": 6,
@@ -84,7 +84,7 @@
         },
         {
             "name": "recordingFormat",
-            "shortDesc": "Video Recording Format",
+            "shortDesc": "File format for saved video recordings.",
             "longDesc": "Video recording file format.",
             "type": "uint32",
             "enumStrings": "mp4,mov,mkv",
@@ -95,7 +95,7 @@
         },
         {
             "name": "maxVideoSize",
-            "shortDesc": "Max Video Storage Usage",
+            "shortDesc": "Maximum disk space available for video recording storage.",
             "longDesc": "Maximum amount of disk space used by video recording.",
             "type": "uint32",
             "min": 100,
@@ -107,7 +107,7 @@
         },
         {
             "name": "enableStorageLimit",
-            "shortDesc": "Enable/Disable Limits on Storage Usage",
+            "shortDesc": "Automatically delete oldest recordings when the storage limit is exceeded.",
             "longDesc": "When enabled, old video files will be auto-deleted when the total size of QGC-recorded video exceeds the maximum video storage usage.",
             "type": "bool",
             "default": false,
@@ -135,7 +135,7 @@
         },
         {
             "name": "disableWhenDisarmed",
-            "shortDesc": "Video Stream Disnabled When Armed",
+            "shortDesc": "Disables the video stream when the vehicle is disarmed to save bandwidth.",
             "longDesc": "Disable Video Stream when disarmed.",
             "type": "bool",
             "default": false,
@@ -144,7 +144,7 @@
         },
         {
             "name": "lowLatencyMode",
-            "shortDesc": "Tweaks video for lower latency",
+            "shortDesc": "Reduce video latency by approximately 200ms using optimized streaming settings.",
             "longDesc": "If this option is enabled, the rtpjitterbuffer is removed and the video sink is set to assynchronous mode, reducing the latency by about 200 ms.",
             "type": "bool",
             "default": false,
@@ -153,7 +153,7 @@
         },
         {
             "name": "forceVideoDecoder",
-            "shortDesc": "Force video decoder priority",
+            "shortDesc": "Override automatic video decoder selection to force a specific decoding method.",
             "longDesc": "Force the change of prioritization between video decode methods, allowing the user to force some video hardware decode plugins if necessary.",
             "type": "uint32",
             "enumStrings": "Default,Force software decoder,Force hardware decoder,Force NVIDIA decoder,Force VA-API decoder,Force DirectX3D 11 decoder,Force VideoToolbox decoder,Force Intel decoder,Force Vulkan decoder",

--- a/src/Settings/VideoSettings.cc
+++ b/src/Settings/VideoSettings.cc
@@ -42,7 +42,7 @@ DECLARE_SETTINGGROUP(Video, "Video")
     if (videoSourceList.count() == 0) {
         _noVideo = true;
         videoSourceList.append(videoSourceNoVideo);
-        setVisible(false);
+        setUserVisible(false);
     } else {
         videoSourceList.insert(0, videoDisabled);
     }
@@ -102,7 +102,7 @@ DECLARE_SETTINGSFACT_NO_FUNC(VideoSettings, forceVideoDecoder)
     if (!_forceVideoDecoderFact) {
         _forceVideoDecoderFact = _createSettingsFact(forceVideoDecoderName);
 
-        _forceVideoDecoderFact->setVisible(kGstEnabled);
+        _forceVideoDecoderFact->setUserVisible(kGstEnabled);
 
         connect(_forceVideoDecoderFact, &Fact::valueChanged, this, &VideoSettings::_configChanged);
     }
@@ -114,7 +114,7 @@ DECLARE_SETTINGSFACT_NO_FUNC(VideoSettings, lowLatencyMode)
     if (!_lowLatencyModeFact) {
         _lowLatencyModeFact = _createSettingsFact(lowLatencyModeName);
 
-        _lowLatencyModeFact->setVisible(kGstEnabled);
+        _lowLatencyModeFact->setUserVisible(kGstEnabled);
 
         connect(_lowLatencyModeFact, &Fact::valueChanged, this, &VideoSettings::_configChanged);
     }
@@ -126,7 +126,7 @@ DECLARE_SETTINGSFACT_NO_FUNC(VideoSettings, rtspTimeout)
     if (!_rtspTimeoutFact) {
         _rtspTimeoutFact = _createSettingsFact(rtspTimeoutName);
 
-        _rtspTimeoutFact->setVisible(kGstEnabled);
+        _rtspTimeoutFact->setUserVisible(kGstEnabled);
 
         connect(_rtspTimeoutFact, &Fact::valueChanged, this, &VideoSettings::_configChanged);
     }

--- a/src/Settings/Viewer3D.SettingsGroup.json
+++ b/src/Settings/Viewer3D.SettingsGroup.json
@@ -4,7 +4,7 @@
     "QGC.MetaData.Facts": [
         {
             "name": "enabled",
-            "shortDesc": "Enable the 3D viewer",
+            "shortDesc": "Enable 3D terrain and building visualization alongside the 2D map.",
             "type": "bool",
             "default": false,
             "label": "Enable the 3D viewer",
@@ -12,7 +12,7 @@
         },
         {
             "name": "mapProvider",
-            "shortDesc": "3D map data provider",
+            "shortDesc": "Data source for 3D map terrain and building information.",
             "type": "uint32",
             "enumStrings": "OpenStreetMap",
             "enumValues": "0",
@@ -22,7 +22,7 @@
         },
         {
             "name": "osmFilePath",
-            "shortDesc": "Path to the OSM file for the 3D viewer.",
+            "shortDesc": "Path to an offline OpenStreetMap file for 3D terrain rendering.",
             "type": "string",
             "default": "",
             "label": "Path to the OSM file for the 3D viewer.",
@@ -30,7 +30,7 @@
         },
         {
             "name": "buildingLevelHeight",
-            "shortDesc": "Average Height for each level of the buildings",
+            "shortDesc": "Average floor-to-floor height in meters used for 3D building visualization.",
             "type": "double",
             "units": "m",
             "min": 0.5,
@@ -41,7 +41,7 @@
         },
         {
             "name": "altitudeBias",
-            "shortDesc": "Altitude bias for vehicles in the 3D View",
+            "shortDesc": "Vertical offset in meters for vehicle rendering in the 3D viewer.",
             "type": "double",
             "units": "m",
             "min": -1000,

--- a/src/UI/AppSettings/CMakeLists.txt
+++ b/src/UI/AppSettings/CMakeLists.txt
@@ -18,17 +18,17 @@ file(GLOB _settings_metadata "${SETTINGS_METADATA_DIR}/*.SettingsGroup.json")
 
 # Generated QML outputs (must match what generate_pages.py produces)
 set(_generated_qml_names
-    ADSBVehicleManagerSettings.qml
-    AppSettings.qml
+    ADSBServerSettings.qml
+    CommLinksSettings.qml
     FlyViewSettings.qml
-    LinkSettings.qml
-    MapSettings.qml
-    MavlinkSettings.qml
+    GeneralSettings.qml
+    MapsSettings.qml
     NTRIPSettings.qml
     PlanViewSettings.qml
     PX4LogTransferSettings.qml
     RemoteIDSettings.qml
     SettingsPagesModel.qml
+    TelemetrySettings.qml
     VideoSettings.qml
     Viewer3DSettings.qml
 )

--- a/src/UI/AppSettings/NmeaGpsSettings.qml
+++ b/src/UI/AppSettings/NmeaGpsSettings.qml
@@ -7,7 +7,7 @@ import QGroundControl.FactControls
 
 SettingsGroupLayout {
     heading: qsTr("NMEA GPS")
-    visible: QGroundControl.settingsManager.autoConnectSettings.autoConnectNmeaPort.visible && QGroundControl.settingsManager.autoConnectSettings.autoConnectNmeaBaud.visible
+    visible: QGroundControl.settingsManager.autoConnectSettings.autoConnectNmeaPort.userVisible && QGroundControl.settingsManager.autoConnectSettings.autoConnectNmeaBaud.userVisible
 
     LabelledComboBox {
         id: nmeaPortCombo

--- a/src/UI/AppSettings/NtripConnectionStatus.qml
+++ b/src/UI/AppSettings/NtripConnectionStatus.qml
@@ -5,12 +5,11 @@ import QtQuick.Layouts
 import QGroundControl
 import QGroundControl.Controls
 import QGroundControl.FactControls
-import QGroundControl.Palette
 
 SettingsGroupLayout {
     Layout.fillWidth:   true
     heading:            qsTr("Connection")
-    visible:            _ntrip.visible
+    visible:            _ntrip.userVisible
 
     QGCPalette { id: qgcPal }
 

--- a/src/UI/AppSettings/NtripMountpointBrowser.qml
+++ b/src/UI/AppSettings/NtripMountpointBrowser.qml
@@ -5,12 +5,11 @@ import QtQuick.Layouts
 import QGroundControl
 import QGroundControl.Controls
 import QGroundControl.FactControls
-import QGroundControl.Palette
 
 SettingsGroupLayout {
     Layout.fillWidth:   true
     heading:            qsTr("Mountpoint")
-    visible:            _ntrip.ntripMountpoint.visible
+    visible:            _ntrip.ntripMountpoint.userVisible
 
     QGCPalette { id: qgcPal }
 

--- a/src/UI/AppSettings/NtripServerSettings.qml
+++ b/src/UI/AppSettings/NtripServerSettings.qml
@@ -9,8 +9,8 @@ import QGroundControl.FactControls
 SettingsGroupLayout {
     Layout.fillWidth:   true
     heading:            qsTr("Server")
-    visible:            _ntrip.ntripServerHostAddress.visible || _ntrip.ntripServerPort.visible ||
-                        _ntrip.ntripUsername.visible || _ntrip.ntripPassword.visible
+    visible:            _ntrip.ntripServerHostAddress.userVisible || _ntrip.ntripServerPort.userVisible ||
+                        _ntrip.ntripUsername.userVisible || _ntrip.ntripPassword.userVisible
 
     property var  _ntrip:       QGroundControl.settingsManager.ntripSettings
     property bool _isActive:    _ntrip.ntripServerConnectEnabled.rawValue
@@ -20,7 +20,7 @@ SettingsGroupLayout {
         Layout.fillWidth:           true
         textFieldPreferredWidth:    _textFieldWidth
         fact:               _ntrip.ntripServerHostAddress
-        visible:            fact.visible
+        visible:            fact.userVisible
         enabled:            !_isActive
     }
 
@@ -28,7 +28,7 @@ SettingsGroupLayout {
         Layout.fillWidth:           true
         textFieldPreferredWidth:    _textFieldWidth
         fact:               _ntrip.ntripServerPort
-        visible:            fact.visible
+        visible:            fact.userVisible
         enabled:            !_isActive
     }
 
@@ -37,13 +37,13 @@ SettingsGroupLayout {
         textFieldPreferredWidth:    _textFieldWidth
         label:              fact.shortDescription
         fact:               _ntrip.ntripUsername
-        visible:            fact.visible
+        visible:            fact.userVisible
         enabled:            !_isActive
     }
 
     RowLayout {
         Layout.fillWidth:   true
-        visible:            _ntrip.ntripPassword.visible
+        visible:            _ntrip.ntripPassword.userVisible
         spacing:            ScreenTools.defaultFontPixelWidth * 0.5
 
         LabelledFactTextField {
@@ -69,7 +69,7 @@ SettingsGroupLayout {
         Layout.fillWidth:   true
         text:               fact.shortDescription
         fact:               _ntrip.ntripUseTls
-        visible:            fact.visible
+        visible:            fact.userVisible
         enabled:            !_isActive
     }
 }

--- a/src/UI/AppSettings/RemoteIDGpsLocation.qml
+++ b/src/UI/AppSettings/RemoteIDGpsLocation.qml
@@ -9,8 +9,8 @@ SettingsGroupLayout {
     heading:            qsTr("NMEA External GPS")
     Layout.fillWidth:   true
     visible:            !ScreenTools.isMobile
-                        && QGroundControl.settingsManager.autoConnectSettings.autoConnectNmeaPort.visible
-                        && QGroundControl.settingsManager.autoConnectSettings.autoConnectNmeaBaud.visible
+                        && QGroundControl.settingsManager.autoConnectSettings.autoConnectNmeaPort.userVisible
+                        && QGroundControl.settingsManager.autoConnectSettings.autoConnectNmeaBaud.userVisible
                         && _locationType !== RemoteIDSettings.LocationType.TAKEOFF
 
     property int    _locationType:    QGroundControl.settingsManager.remoteIDSettings.locationType.value

--- a/src/UI/AppSettings/pages/CommLinks.SettingsUI.json
+++ b/src/UI/AppSettings/pages/CommLinks.SettingsUI.json
@@ -3,7 +3,7 @@
     "groups": [
         {
             "heading": "AutoConnect",
-            "showWhen": "QGroundControl.settingsManager.autoConnectSettings.visible",
+            "showWhen": "QGroundControl.settingsManager.autoConnectSettings.userVisible",
             "controls": [
                 {
                     "setting": "autoConnectSettings.autoConnectPixhawk"

--- a/src/UI/AppSettings/pages/FlyView.SettingsUI.json
+++ b/src/UI/AppSettings/pages/FlyView.SettingsUI.json
@@ -15,7 +15,7 @@
                 },
                 {
                     "setting": "appSettings.enforceChecklist",
-                    "showWhen": "hasChecklist && QGroundControl.settingsManager.appSettings.useChecklist.visible",
+                    "showWhen": "hasChecklist && QGroundControl.settingsManager.appSettings.useChecklist.userVisible",
                     "enableWhen": "useChecklistValue"
                 },
                 {

--- a/src/UI/AppSettings/pages/General.SettingsUI.json
+++ b/src/UI/AppSettings/pages/General.SettingsUI.json
@@ -49,7 +49,7 @@
         },
         {
             "heading": "Units",
-            "showWhen": "QGroundControl.settingsManager.unitsSettings.visible",
+            "showWhen": "QGroundControl.settingsManager.unitsSettings.userVisible",
             "controls": [
                 {
                     "setting": "unitsSettings.horizontalDistanceUnits",

--- a/src/UI/AppSettings/pages/SettingsPages.json
+++ b/src/UI/AppSettings/pages/SettingsPages.json
@@ -3,7 +3,7 @@
     "pages": [
         {
             "name": "General",
-            "qml": "AppSettings.qml",
+            "qml": "GeneralSettings.qml",
             "icon": "qrc:/res/QGCLogoWhite.svg",
             "pageDefinition": "General.SettingsUI.json"
         },
@@ -18,7 +18,7 @@
             "qml": "Viewer3DSettings.qml",
             "icon": "qrc:/qml/QGroundControl/Viewer3D/City3DMapIcon.svg",
             "pageDefinition": "Viewer3D.SettingsUI.json",
-            "visible": "QGroundControl.settingsManager.viewer3DSettings.visible"
+            "visible": "QGroundControl.settingsManager.viewer3DSettings.userVisible"
         },
         {
             "name": "Plan View",
@@ -31,13 +31,13 @@
         },
         {
             "name": "ADSB Server",
-            "qml": "ADSBVehicleManagerSettings.qml",
+            "qml": "ADSBServerSettings.qml",
             "icon": "qrc:/InstrumentValueIcons/airplane.svg",
             "pageDefinition": "ADSBVehicleManager.SettingsUI.json"
         },
         {
             "name": "Comm Links",
-            "qml": "LinkSettings.qml",
+            "qml": "CommLinksSettings.qml",
             "icon": "qrc:/InstrumentValueIcons/usb.svg",
             "pageDefinition": "CommLinks.SettingsUI.json"
         },
@@ -48,7 +48,7 @@
         },
         {
             "name": "Maps",
-            "qml": "MapSettings.qml",
+            "qml": "MapsSettings.qml",
             "icon": "qrc:/InstrumentValueIcons/globe.svg",
             "pageDefinition": "Maps.SettingsUI.json"
         },
@@ -74,7 +74,7 @@
         },
         {
             "name": "Telemetry",
-            "qml": "MavlinkSettings.qml",
+            "qml": "TelemetrySettings.qml",
             "icon": "qrc:/InstrumentValueIcons/drone.svg",
             "pageDefinition": "Telemetry.SettingsUI.json"
         },
@@ -83,7 +83,7 @@
             "qml": "VideoSettings.qml",
             "icon": "qrc:/InstrumentValueIcons/camera.svg",
             "pageDefinition": "Video.SettingsUI.json",
-            "visible": "QGroundControl.settingsManager.videoSettings.visible"
+            "visible": "QGroundControl.settingsManager.videoSettings.userVisible"
         },
         {
             "divider": true

--- a/src/UI/FirstRunPromptDialogs/UnitsFirstRunPrompt.qml
+++ b/src/UI/FirstRunPromptDialogs/UnitsFirstRunPrompt.qml
@@ -18,7 +18,7 @@ FirstRunPrompt {
     Component.onCompleted: {
         var cVisibleFacts = 0
         for (var i=0; i<_rgFacts.length; i++) {
-            if (_rgFacts[i].visible) {
+            if (_rgFacts[i].userVisible) {
                 cVisibleFacts++
             }
         }
@@ -30,19 +30,19 @@ FirstRunPrompt {
         unitComboBoxRepeater.model = 0
         unitComboBoxRepeater.model = _rgFacts.length
 
-        if (_unitsSettings.horizontalDistanceUnits.visible) {
+        if (_unitsSettings.horizontalDistanceUnits.userVisible) {
             _unitsSettings.horizontalDistanceUnits.value = metric ? UnitsSettings.HorizontalDistanceUnitsMeters : UnitsSettings.HorizontalDistanceUnitsFeet
         }
-        if (_unitsSettings.verticalDistanceUnits.visible) {
+        if (_unitsSettings.verticalDistanceUnits.userVisible) {
             _unitsSettings.verticalDistanceUnits.value = metric ? UnitsSettings.VerticalDistanceUnitsMeters : UnitsSettings.VerticalDistanceUnitsFeet
         }
-        if (_unitsSettings.areaUnits.visible) {
+        if (_unitsSettings.areaUnits.userVisible) {
             _unitsSettings.areaUnits.value = metric ? UnitsSettings.AreaUnitsSquareMeters : UnitsSettings.AreaUnitsSquareFeet
         }
-        if (_unitsSettings.speedUnits.visible) {
+        if (_unitsSettings.speedUnits.userVisible) {
             _unitsSettings.speedUnits.value = metric ? UnitsSettings.SpeedUnitsMetersPerSecond : UnitsSettings.SpeedUnitsFeetPerSecond
         }
-        if (_unitsSettings.temperatureUnits.visible) {
+        if (_unitsSettings.temperatureUnits.userVisible) {
             _unitsSettings.temperatureUnits.value = metric ? UnitsSettings.TemperatureUnitsCelsius : UnitsSettings.TemperatureUnitsFarenheit
         }
     }
@@ -79,7 +79,7 @@ FirstRunPrompt {
                     model: _rgFacts.length
                     QGCLabel {
                         text:       _rgLabels[index]
-                        visible:    _rgFacts[index].visible
+                        visible:    _rgFacts[index].userVisible
                     }
                 }
 
@@ -99,7 +99,7 @@ FirstRunPrompt {
                         sizeToContents:     true
                         fact:               _rgFacts[index]
                         indexModel:         false
-                        visible:            _rgFacts[index].visible
+                        visible:            _rgFacts[index].userVisible
                     }
                 }
             }

--- a/src/UI/toolbar/BatteryIndicator.qml
+++ b/src/UI/toolbar/BatteryIndicator.qml
@@ -447,13 +447,13 @@ Item {
                     Layout.fillWidth:   true
                     fact:               _batterySettings.consolidateMultipleBatteries
                     text:               qsTr("Only show battery with lowest charge")
-                    visible:            fact.visible
+                    visible:            fact.userVisible
                 }
 
                 LabelledFactComboBox {
                     label:      qsTr("Value")
                     fact:       _batterySettings.valueDisplay
-                    visible:    fact.visible
+                    visible:    fact.userVisible
                 }
 
                 ColumnLayout {
@@ -490,7 +490,7 @@ Item {
                                 fact: _batterySettings.threshold1
                                 implicitWidth: ScreenTools.defaultFontPixelWidth * 6
                                 height: ScreenTools.defaultFontPixelHeight * 1.5
-                                enabled: fact.visible
+                                enabled: fact.userVisible
                                 onEditingFinished: {
                                     // Validate and set the new threshold value
                                     _batterySettings.setThreshold1(parseInt(text));
@@ -512,7 +512,7 @@ Item {
                                 fact: _batterySettings.threshold2
                                 implicitWidth: ScreenTools.defaultFontPixelWidth * 6
                                 height: ScreenTools.defaultFontPixelHeight * 1.5
-                                enabled: fact.visible
+                                enabled: fact.userVisible
                                 onEditingFinished: {
                                     // Validate and set the new threshold value
                                     _batterySettings.setThreshold2(parseInt(text));

--- a/src/UI/toolbar/GPSIndicatorPage.qml
+++ b/src/UI/toolbar/GPSIndicatorPage.qml
@@ -156,7 +156,7 @@ ToolIndicatorPage {
                 Layout.fillWidth:   true
                 text:               qsTr("AutoConnect")
                 fact:               QGroundControl.settingsManager.autoConnectSettings.autoConnectRTKGPS
-                visible:            fact.visible
+                visible:            fact.userVisible
             }
 
             GridLayout {
@@ -168,7 +168,7 @@ ToolIndicatorPage {
                 FactComboBox {
                     Layout.fillWidth:   true
                     fact:               QGroundControl.settingsManager.rtkSettings.baseReceiverManufacturers
-                    visible:            QGroundControl.settingsManager.rtkSettings.baseReceiverManufacturers.visible
+                    visible:            QGroundControl.settingsManager.rtkSettings.baseReceiverManufacturers.userVisible
                 }
             }
 
@@ -196,7 +196,7 @@ ToolIndicatorPage {
                 majorTickStepSize:      0.1
                 visible:                (
                     useFixedPosition == BaseModeDefinition.BaseSurveyIn
-                    && rtkSettings.surveyInAccuracyLimit.visible
+                    && rtkSettings.surveyInAccuracyLimit.userVisible
                     && (settingsDisplayId & _ublox)
                 )
             }
@@ -209,7 +209,7 @@ ToolIndicatorPage {
                 majorTickStepSize:      10
                 visible:                (
                     useFixedPosition == BaseModeDefinition.BaseSurveyIn
-                    && rtkSettings.surveyInMinObservationDuration.visible
+                    && rtkSettings.surveyInMinObservationDuration.userVisible
                     && (settingsDisplayId & (_ublox | _femtomes | _trimble))
                 )
             }

--- a/src/UI/toolbar/GimbalIndicator.qml
+++ b/src/UI/toolbar/GimbalIndicator.qml
@@ -284,7 +284,7 @@ Item {
                 LabelledFactTextField {
                     label:      qsTr("Joystick buttons speed:")
                     fact:       _gimbalControllerSettings.joystickButtonsSpeed
-                    enabled:    joystickButtonsAvailable && _gimbalControllerSettings.visible
+                    enabled:    joystickButtonsAvailable && _gimbalControllerSettings.userVisible
                 }
 
                 FactCheckBoxSlider {

--- a/src/UI/toolbar/MainStatusIndicatorOfflinePage.qml
+++ b/src/UI/toolbar/MainStatusIndicatorOfflinePage.qml
@@ -71,7 +71,7 @@ ToolIndicatorPage {
 
             SettingsGroupLayout {
                 heading:        qsTr("AutoConnect")
-                visible:        autoConnectSettings.visible
+                visible:        autoConnectSettings.userVisible
 
                 Repeater {
                     id: autoConnectRepeater

--- a/src/UI/toolbar/RemoteIDIndicatorPage.qml
+++ b/src/UI/toolbar/RemoteIDIndicatorPage.qml
@@ -338,7 +338,7 @@ ToolIndicatorPage {
                             id:                 sendSelfIDSlider
                             text:               qsTr("Broadcast")
                             fact:               _fact
-                            visible:            _fact.visible
+                            visible:            _fact.userVisible
                             Layout.fillWidth:   true
 
                             property Fact _fact: remoteIDSettings.sendSelfID
@@ -358,7 +358,7 @@ ToolIndicatorPage {
                         label:              qsTr("Broadcast Message")
                         fact:               _fact
                         indexModel:         false
-                        visible:            _fact.visible
+                        visible:            _fact.userVisible
                         enabled:            sendSelfIDSlider._fact.rawValue
                         Layout.fillWidth:   true
 
@@ -368,7 +368,7 @@ ToolIndicatorPage {
                     LabelledFactTextField {
                         label:                      _fact.shortDescription
                         fact:                       _fact
-                        visible:                    _fact.visible
+                        visible:                    _fact.userVisible
                         enabled:                     sendSelfIDSlider._fact.rawValue
                         textField.maximumLength:    23
                         Layout.fillWidth:           true
@@ -380,7 +380,7 @@ ToolIndicatorPage {
                     LabelledFactTextField {
                         label:                      _fact.shortDescription
                         fact:                       _fact
-                        visible:                    _fact.visible
+                        visible:                    _fact.userVisible
                         enabled:                    sendSelfIDSlider._fact.rawValue
                         textField.maximumLength:    23
                         Layout.fillWidth:           true
@@ -392,7 +392,7 @@ ToolIndicatorPage {
                     LabelledFactTextField {
                         label:                      _fact.shortDescription
                         fact:                       _fact
-                        visible:                    _fact.visible
+                        visible:                    _fact.userVisible
                         textField.maximumLength:    23
                         Layout.fillWidth:           true
                         textFieldPreferredWidth:    textFieldWidth

--- a/src/Vehicle/VehicleSetup/JoystickComponentSettings.qml
+++ b/src/Vehicle/VehicleSetup/JoystickComponentSettings.qml
@@ -26,14 +26,14 @@ ColumnLayout {
             Layout.fillWidth: true
             text: qsTr("Center stick is zero throttle")
             fact: _joystickSettings.throttleModeCenterZero
-            visible: fact.visible
+            visible: fact.userVisible
         }
 
         FactCheckBoxSlider {
             Layout.fillWidth: true
             text: qsTr("Spring loaded throttle smoothing")
             fact: _joystickSettings.throttleSmoothing
-            visible: fact.visible && _joystickSettings.throttleModeCenterZero.rawValue
+            visible: fact.userVisible && _joystickSettings.throttleModeCenterZero.rawValue
         }
 
         FactTextFieldSlider {
@@ -46,7 +46,7 @@ ColumnLayout {
             Layout.fillWidth: true
             text: qsTr("Negative Thrust")
             fact: _joystickSettings.negativeThrust
-            visible: globals.activeVehicle.supports.negativeThrust && fact.visible
+            visible: globals.activeVehicle.supports.negativeThrust && fact.userVisible
         }
 
         QGCCheckBoxSlider {
@@ -65,21 +65,21 @@ ColumnLayout {
             Layout.fillWidth: true
             text: qsTr("Circle Correction")
             fact: _joystickSettings.circleCorrection
-            visible: fact.visible
+            visible: fact.userVisible
         }
 
         FactTextFieldSlider {
             Layout.fillWidth: true
             label: fact.shortDescription
             fact: _joystickSettings.axisFrequencyHz
-            visible: fact.visible
+            visible: fact.userVisible
         }
 
         FactTextFieldSlider {
             Layout.fillWidth: true
             label: fact.shortDescription
             fact: _joystickSettings.buttonFrequencyHz
-            visible: fact.visible
+            visible: fact.userVisible
         }
 
         ColumnLayout {
@@ -90,7 +90,7 @@ ColumnLayout {
             FactCheckBoxSlider {
                 text: qsTr("Deadband")
                 fact: _joystickSettings.useDeadband
-                visible: fact.visible
+                visible: fact.userVisible
             }
 
             QGCLabel{
@@ -105,56 +105,56 @@ ColumnLayout {
             Layout.fillWidth: true
             text: qsTr("MANUAL_CONTROL Pitch Extension")
             fact: _joystickSettings.enableManualControlPitchExtension
-            visible: fact.visible
+            visible: fact.userVisible
         }
 
         FactCheckBoxSlider {
             Layout.fillWidth: true
             text: qsTr("MANUAL_CONTROL Roll Extension")
             fact: _joystickSettings.enableManualControlRollExtension
-            visible: fact.visible
+            visible: fact.userVisible
         }
 
         FactCheckBoxSlider {
             Layout.fillWidth: true
             text: qsTr("MANUAL_CONTROL Aux1")
             fact: _joystickSettings.enableManualControlAux1
-            visible: fact.visible
+            visible: fact.userVisible
         }
 
         FactCheckBoxSlider {
             Layout.fillWidth: true
             text: qsTr("MANUAL_CONTROL Aux2")
             fact: _joystickSettings.enableManualControlAux2
-            visible: fact.visible
+            visible: fact.userVisible
         }
 
         FactCheckBoxSlider {
             Layout.fillWidth: true
             text: qsTr("MANUAL_CONTROL Aux3")
             fact: _joystickSettings.enableManualControlAux3
-            visible: fact.visible
+            visible: fact.userVisible
         }
 
         FactCheckBoxSlider {
             Layout.fillWidth: true
             text: qsTr("MANUAL_CONTROL Aux4")
             fact: _joystickSettings.enableManualControlAux4
-            visible: fact.visible
+            visible: fact.userVisible
         }
 
         FactCheckBoxSlider {
             Layout.fillWidth: true
             text: qsTr("MANUAL_CONTROL Aux5")
             fact: _joystickSettings.enableManualControlAux5
-            visible: fact.visible
+            visible: fact.userVisible
         }
 
         FactCheckBoxSlider {
             Layout.fillWidth: true
             text: qsTr("MANUAL_CONTROL Aux6")
             fact: _joystickSettings.enableManualControlAux6
-            visible: fact.visible
+            visible: fact.userVisible
         }
     }
 }

--- a/tools/generators/settings_qml/page_generator.py
+++ b/tools/generators/settings_qml/page_generator.py
@@ -190,28 +190,58 @@ def _split_translated_list(csv: str) -> list[str]:
 
 
 def _get_fact_search_terms(setting: str, settings_dir: Path) -> list[str]:
-    """Get search terms for a fact from its keywords."""
+    """Get search terms for a fact from its label, shortDesc, and keywords."""
     meta = _load_settings_metadata(settings_dir)
     fact = meta.get(setting, {})
+    terms: list[str] = []
+    # Include label and shortDesc so users can search by visible text
+    for field in ("label", "shortDesc"):
+        val = fact.get(field, "")
+        if val:
+            terms.append(val.lower())
     kw_str = fact.get("keywords", "")
-    if not kw_str:
-        return []
-    return [kw.lower() for kw in _split_translated_list(kw_str)]
+    if kw_str:
+        terms.extend(kw.lower() for kw in _split_translated_list(kw_str))
+    return terms
 
 
 # --------------------------------------------------------------------------- #
 # QML generation
 # --------------------------------------------------------------------------- #
 
+def _wrap_with_description(control_qml: str, fact_ref: str, vis_expr: str, indent: str) -> str:
+    """Wrap a control's QML in a ColumnLayout that appends a shortDescription label."""
+    wrapper_lines = [
+        f"{indent}ColumnLayout {{",
+        f"{indent}    Layout.fillWidth: true",
+        f"{indent}    spacing: ScreenTools.defaultFontPixelHeight / 4",
+        f"{indent}    visible: {vis_expr}",
+        f"",
+    ]
+    # Indent the inner control QML by one extra level
+    for line in control_qml.splitlines():
+        wrapper_lines.append(f"    {line}" if line.strip() else line)
+    wrapper_lines.append(f"")
+    wrapper_lines.append(f"{indent}    QGCLabel {{")
+    wrapper_lines.append(f"{indent}        Layout.fillWidth: true")
+    wrapper_lines.append(f"{indent}        text: {fact_ref}.shortDescription")
+    wrapper_lines.append(f"{indent}        visible: text !== \"\"")
+    wrapper_lines.append(f"{indent}        font.pointSize: ScreenTools.smallFontPointSize")
+    wrapper_lines.append(f"{indent}        wrapMode: Text.WordWrap")
+    wrapper_lines.append(f"{indent}    }}")
+    wrapper_lines.append(f"{indent}}}")
+    return "\n".join(wrapper_lines)
+
+
 def _qml_control(ctrl: ControlDef, settings_dir: Path) -> str:
     """Generate QML for a single control."""
     indent = "        "
     fact_ref = f"QGroundControl.settingsManager.{ctrl.setting}"
 
-    def _vis_line() -> str:
+    def _vis_expr() -> str:
         if ctrl.showWhen:
-            return f"{indent}    visible: ({ctrl.showWhen}) && fact.userVisible"
-        return f"{indent}    visible: fact.userVisible"
+            return f"({ctrl.showWhen}) && {fact_ref}.userVisible"
+        return f"{fact_ref}.userVisible"
 
     def _enabled_line() -> str:
         if ctrl.enableWhen:
@@ -230,19 +260,10 @@ def _qml_control(ctrl: ControlDef, settings_dir: Path) -> str:
             lines.append(f"{indent}RowLayout {{")
             lines.append(f"{indent}    Layout.fillWidth: true")
             lines.append(f"{indent}    spacing: ScreenTools.defaultFontPixelWidth")
-            if ctrl.showWhen:
-                lines.append(f"{indent}    visible: ({ctrl.showWhen}) && {fact_ref}.userVisible")
-            else:
-                lines.append(f"{indent}    visible: {fact_ref}.userVisible")
         lines.append(f"{inner_indent}FactTextFieldSlider {{")
         lines.append(f"{inner_indent}    Layout.fillWidth: true")
         lines.append(f"{inner_indent}{label_line}")
         lines.append(f"{inner_indent}    fact: {fact_ref}")
-        if not has_button:
-            if ctrl.showWhen:
-                lines.append(f"{inner_indent}    visible: ({ctrl.showWhen}) && fact.userVisible")
-            else:
-                lines.append(f"{inner_indent}    visible: fact.userVisible")
         if ctrl.enableCheckbox:
             lines.append(f"{inner_indent}    showEnableCheckbox: true")
             if ctrl.enableCheckbox.get("checked"):
@@ -261,31 +282,32 @@ def _qml_control(ctrl: ControlDef, settings_dir: Path) -> str:
                 lines.append(f'{inner_indent}    enabled: {btn["enabled"]}')
             lines.append(f'{inner_indent}}}')
             lines.append(f"{indent}}}")
-        return "\n".join(lines)
+        control_qml = "\n".join(lines)
+        return _wrap_with_description(control_qml, fact_ref, _vis_expr(), indent)
     elif ctrl.control == "browse":
         label_line = f'    label: qsTr("{ctrl.label}")' if ctrl.label else "    label: fact.label"
         enabled = _enabled_line()
-        return (
+        control_qml = (
             f"{indent}LabelledFactBrowse {{\n"
             f"{indent}    Layout.fillWidth: true\n"
             f"{indent}{label_line}\n"
             f"{indent}    fact: {fact_ref}\n"
-            f"{_vis_line()}\n"
             f"{enabled}"
             f"{indent}}}"
         )
+        return _wrap_with_description(control_qml, fact_ref, _vis_expr(), indent)
     elif ctrl.control == "scaler":
         label_line = f'    label: qsTr("{ctrl.label}")' if ctrl.label else "    label: fact.label"
         enabled = _enabled_line()
-        return (
+        control_qml = (
             f"{indent}LabelledFactIncrementer {{\n"
             f"{indent}    Layout.fillWidth: true\n"
             f"{indent}{label_line}\n"
             f"{indent}    fact: {fact_ref}\n"
-            f"{_vis_line()}\n"
             f"{enabled}"
             f"{indent}}}"
         )
+        return _wrap_with_description(control_qml, fact_ref, _vis_expr(), indent)
     elif ctrl.control == "checkbox":
         use_checkbox = True
         use_combobox = False
@@ -305,27 +327,27 @@ def _qml_control(ctrl: ControlDef, settings_dir: Path) -> str:
 
     if use_checkbox:
         label_line = f'    text: qsTr("{ctrl.label}")' if ctrl.label else "    text: fact.label"
-        return (
+        control_qml = (
             f"{indent}FactCheckBoxSlider {{\n"
             f"{indent}    Layout.fillWidth: true\n"
             f"{indent}{label_line}\n"
             f"{indent}    fact: {fact_ref}\n"
-            f"{_vis_line()}\n"
             f"{enabled}"
             f"{indent}}}"
         )
+        return _wrap_with_description(control_qml, fact_ref, _vis_expr(), indent)
     elif use_combobox:
         label_line = f'    label: qsTr("{ctrl.label}")' if ctrl.label else "    label: fact.label"
-        return (
+        control_qml = (
             f"{indent}LabelledFactComboBox {{\n"
             f"{indent}    Layout.fillWidth: true\n"
             f"{indent}{label_line}\n"
             f"{indent}    fact: {fact_ref}\n"
             f"{indent}    indexModel: false\n"
-            f"{_vis_line()}\n"
             f"{enabled}"
             f"{indent}}}"
         )
+        return _wrap_with_description(control_qml, fact_ref, _vis_expr(), indent)
     else:
         label_line = f'    label: qsTr("{ctrl.label}")' if ctrl.label else "    label: fact.label"
         fact_type = _get_fact_type(ctrl.setting, settings_dir)
@@ -334,7 +356,6 @@ def _qml_control(ctrl: ControlDef, settings_dir: Path) -> str:
             f"{indent}    Layout.fillWidth: true",
             f"{indent}{label_line}",
             f"{indent}    fact: {fact_ref}",
-            _vis_line(),
         ]
         if ctrl.enableWhen:
             lines.append(f"{indent}    enabled: {ctrl.enableWhen}")
@@ -343,7 +364,8 @@ def _qml_control(ctrl: ControlDef, settings_dir: Path) -> str:
         if ctrl.placeholder:
             lines.append(f'{indent}    textField.placeholderText: qsTr("{ctrl.placeholder}")')
         lines.append(f"{indent}}}")
-        return "\n".join(lines)
+        control_qml = "\n".join(lines)
+        return _wrap_with_description(control_qml, fact_ref, _vis_expr(), indent)
 
 
 def _qml_missing_placeholder(description: str) -> str:

--- a/tools/tests/test_settings_qml_generator.py
+++ b/tools/tests/test_settings_qml_generator.py
@@ -287,7 +287,7 @@ class TestGeneratePageQml:
         ])
         qml = generate_page_qml(page, settings_dir)
         assert "(x === 1)" in qml
-        assert "fact.userVisible" in qml
+        assert "appSettings.enableFeature.userVisible" in qml
 
     def test_enableWhen_on_control(self, settings_dir: Path):
         page = PageDef(groups=[


### PR DESCRIPTION
## Summary

- **Rename visible to userVisible**: Renames SettingsFact::visible and SettingsGroup::visible properties to userVisible across C++, QML, and JSON. Clarifies intent and eliminates the duplicate Q_PROPERTY on SettingsFact.

- **Show setting descriptions**: Generated settings pages now display shortDescription text below each control, giving users context about what each setting does.

- **Improved search**: Settings search index now includes label and shortDesc so users can find settings by visible text.

- **Rewritten shortDesc values**: All 106 shortDesc entries across 12 SettingsGroup.json files and UnitsSettings.cc rewritten to be informative user-facing sentences.

- **Sidebar collapse/expand fix**: Clicking an already-expanded group now collapses it. Collapsing the selected group resets the section filter.

- **Consistent generated page names**: Renamed generated QML output files to match display names (e.g. AppSettings.qml to GeneralSettings.qml).

- **Bugfixes**: Removed invalid import QGroundControl.Palette from NTRIP QML files.
