### PR TITLE
Fix ConfigSection controls not expanding to full width

### DIFF
--- a/src/QmlControls/ConfigSection.qml
+++ b/src/QmlControls/ConfigSection.qml
@@ -32,8 +32,11 @@ ColumnLayout {
 
         RowLayout {
             id: _contentRow
-            x: _margins
             y: _margins
+            anchors.left: parent.left
+            anchors.right: parent.right
+            anchors.leftMargin: _margins
+            anchors.rightMargin: _margins
             spacing: ScreenTools.defaultFontPixelWidth * 2
 
             QGCColoredImage {

--- a/src/Vehicle/VehicleSetup/VehicleConfigView.qml
+++ b/src/Vehicle/VehicleSetup/VehicleConfigView.qml
@@ -290,7 +290,7 @@ Rectangle {
         QGCTextField {
             id:                 searchField
             Layout.fillWidth:   true
-            placeholderText:    qsTr("Search components...")
+            placeholderText:    qsTr("Search configuration...")
             visible:            _fullParameterVehicleAvailable
 
             onTextChanged: {


### PR DESCRIPTION
## Problem

`ConfigSection` controls (GCS Failsafe, RC Failsafe, Throttle Failsafe, etc.) don't expand to the full width of their background rectangle. They are only as wide as the controls within.

## Root Cause

The `RowLayout` inside `ConfigSection.qml` used absolute `x`/`y` positioning. This meant the RowLayout floated at its natural implicit width rather than stretching to fill the parent Rectangle, even though the Rectangle itself had `Layout.fillWidth: true`.

## Fix

- Anchor the RowLayout's left/right edges to its parent Rectangle with margins, so the controls column fills the available width.
- Keep `y` positioning (not top/bottom anchors) so the Rectangle's height remains content-driven via `implicitHeight` without creating a binding loop.
- Update VehicleConfigView search placeholder text from "Search components..." to "Search configuration...".
