### PR TITLE
Fix PX4 log upload auto-upload state inconsistency

### DIFF
--- a/src/UI/AppSettings/PX4LogUploadSettings.qml
+++ b/src/UI/AppSettings/PX4LogUploadSettings.qml
@@ -26,6 +26,7 @@ SettingsGroupLayout {
         _mavlinkLogManager.uploadURL     = urlField.text
         if (autoUploadCheck.checked && _mavlinkLogManager.emailAddress === "") {
             autoUploadCheck.checked = false
+            _mavlinkLogManager.enableAutoUpload = false
         } else {
             _mavlinkLogManager.enableAutoUpload = autoUploadCheck.checked
         }
@@ -198,8 +199,9 @@ SettingsGroupLayout {
         checked: _mavlinkLogManager ? _mavlinkLogManager.enableAutoUpload : false
         enabled: !_disableDataPersistence
         onClicked: {
+            const wantsAutoUpload = checked
             saveItems()
-            if (checked && _mavlinkLogManager.emailAddress === "")
+            if (wantsAutoUpload && _mavlinkLogManager && _mavlinkLogManager.emailAddress === "")
                 emptyEmailDialog.open()
         }
     }


### PR DESCRIPTION
Partial fix for #14218 (item 4).

## Problem

In `PX4LogUploadSettings.qml`, `saveItems()` unchecks `autoUploadCheck` when the email address is empty, but never sets `_mavlinkLogManager.enableAutoUpload = false`. This leaves the backend auto-upload enabled while the UI shows it disabled.

## Fix

Add `_mavlinkLogManager.enableAutoUpload = false` in the empty-email branch so the manager state stays in sync with the checkbox.
