### PR TITLE
Reduce moc parse time by 60% with lightweight MAVLink headers

### DIFF
--- a/.github/instructions/forward-declarations.instructions.md
+++ b/.github/instructions/forward-declarations.instructions.md
@@ -1,0 +1,23 @@
+---
+applyTo: "src/**/*.h"
+description: "When performing a code review on C++ headers, check that heavy headers like Vehicle.h and QGCMAVLink.h are not included when a lightweight alternative or forward declaration suffices."
+---
+
+# Forward Declaration Rules for Headers
+
+Prefer forward declarations and lightweight type headers over including full class definitions.
+
+## Vehicle.h
+
+`Vehicle.h` is one of the heaviest headers in the codebase. Most headers that reference `Vehicle` only need:
+- A pointer/reference to Vehicle → `class Vehicle;` forward declaration
+- Vehicle type aliases → `#include "VehicleTypes.h"`
+
+Only include `Vehicle.h` if the header calls Vehicle methods, accesses Vehicle members, or inherits from Vehicle.
+
+## QGCMAVLink.h
+
+`QGCMAVLink.h` combines MAVLink enums, message types, and QGC-specific type aliases. Most headers only need one of these. Use the specific lightweight header instead:
+- `MAVLinkEnums.h` for enum constants
+- `MAVLinkMessageType.h` for `mavlink_message_t`
+- `QGCMAVLinkTypes.h` for `FirmwareClass_t`, `VehicleClass_t`

--- a/.github/instructions/mavlink-includes.instructions.md
+++ b/.github/instructions/mavlink-includes.instructions.md
@@ -1,0 +1,35 @@
+---
+applyTo: "src/**/*.h"
+description: "When performing a code review on C++ headers, enforce the MAVLink lightweight include hierarchy to keep moc parse times fast."
+---
+
+# MAVLink Include Rules for Headers
+
+C++ header files must use the **lightest possible** MAVLink include. Heavy includes in headers slow Qt moc parsing dramatically (~2.5s vs ~8ms per header).
+
+## Include Hierarchy (lightest to heaviest)
+
+| Header | Provides | Preprocessed Lines |
+|--------|----------|--------------------|
+| `MAVLinkEnums.h` | All 253 MAVLink enum typedefs (MAV_CMD, MAV_TYPE, MAV_RESULT, etc.) | ~5,500 |
+| `MAVLinkMessageType.h` | `mavlink_message_t`, `mavlink_channel_t`, base types | ~2,700 |
+| `QGCMAVLinkTypes.h` | `FirmwareClass_t`, `VehicleClass_t`, `maxRcChannels` | ~50 |
+| `VehicleTypes.h` | `MavCmdResultFailureCode_t`, `RequestMessageResultHandlerFailureCode_t` | ~30 |
+| `QGCMAVLink.h` | All of the above combined | ~8,300 |
+| `MAVLinkLib.h` | Full MAVLink with all 387 message pack/unpack headers | ~180,000 |
+
+## Rules
+
+1. **Never include `MAVLinkLib.h` in a `.h` file** unless the header uses specific MAVLink message struct types in its declarations (e.g., `mavlink_command_long_t`, `mavlink_command_ack_t`). Move message struct usage to `.cc` files when possible.
+
+2. **Never include `Vehicle.h` just for type aliases.** Use `VehicleTypes.h` + `class Vehicle;` forward declaration instead, when only `MavCmdResultFailureCode_t` or `RequestMessageResultHandlerFailureCode_t` are needed.
+
+3. **Pick the lightest include that satisfies the header's needs:**
+   - Only enum constants? → `MAVLinkEnums.h`
+   - `mavlink_message_t` in signatures? → `MAVLinkMessageType.h`
+   - Both enums and message type? → `MAVLinkEnums.h` + `MAVLinkMessageType.h` (still lighter than `QGCMAVLink.h`)
+   - `FirmwareClass_t` / `VehicleClass_t`? → `QGCMAVLinkTypes.h`
+
+4. **Headers must be self-contained.** Every type used in a header's declarations must be provided by an explicit `#include`, not by the precompiled header (PCH). The PCH provides `MAVLinkLib.h` for `.cc` files, but moc processes headers independently.
+
+5. **`MAVLinkLib.h` is fine in `.cc` files** — it's provided by the PCH anyway. Only header includes affect moc parse time.

--- a/cmake/GenerateMAVLinkEnums.py
+++ b/cmake/GenerateMAVLinkEnums.py
@@ -1,0 +1,116 @@
+#!/usr/bin/env python3
+"""Extract enum definitions from MAVLink dialect headers into a standalone header.
+
+Usage: python3 GenerateMAVLinkEnums.py <mavlink_include_dir> <output_file>
+
+Example:
+    python3 GenerateMAVLinkEnums.py build/_deps/mavlink-build/include/mavlink build/MAVLinkEnums.h
+"""
+import os
+import sys
+
+def extract_enums(dialect_header_path):
+    """Extract text between '// ENUM DEFINITIONS' and '// MESSAGE DEFINITIONS' markers."""
+    try:
+        with open(dialect_header_path, 'r') as f:
+            lines = f.readlines()
+    except FileNotFoundError:
+        return ""
+
+    in_enums = False
+    enum_lines = []
+    for line in lines:
+        if '// ENUM DEFINITIONS' in line:
+            in_enums = True
+            continue
+        if '// MESSAGE DEFINITIONS' in line:
+            break
+        if in_enums:
+            enum_lines.append(line)
+    return ''.join(enum_lines)
+
+
+def find_dialects(mavlink_dir):
+    """Find all dialect directories that contain a dialect header."""
+    dialects = []
+    for entry in sorted(os.listdir(mavlink_dir)):
+        dialect_dir = os.path.join(mavlink_dir, entry)
+        dialect_header = os.path.join(dialect_dir, f"{entry}.h")
+        if os.path.isdir(dialect_dir) and os.path.isfile(dialect_header):
+            dialects.append((entry, dialect_header))
+    return dialects
+
+
+def main():
+    if len(sys.argv) != 3:
+        print(f"Usage: {sys.argv[0]} <mavlink_include_dir> <output_file>", file=sys.stderr)
+        sys.exit(1)
+
+    mavlink_dir = sys.argv[1]
+    output_file = sys.argv[2]
+
+    if not os.path.isdir(mavlink_dir):
+        print(f"Error: {mavlink_dir} is not a directory", file=sys.stderr)
+        sys.exit(1)
+
+    dialects = find_dialects(mavlink_dir)
+    if not dialects:
+        print(f"Error: no dialect headers found in {mavlink_dir}", file=sys.stderr)
+        sys.exit(1)
+
+    # Build output
+    parts = []
+    parts.append("""\
+#pragma once
+
+/// @file MAVLinkEnums.h
+/// @brief MAVLink enum definitions only - no message pack/unpack code.
+///
+/// AUTO-GENERATED from MAVLink dialect headers during the build.
+/// Do not edit manually. Regenerate via cmake/GenerateMAVLinkEnums.py.
+///
+/// This header provides all MAVLink enum typedefs (~3,700 lines) without
+/// the ~177,000 lines of message pack/encode/decode functions.
+/// Use this in headers that need MAVLink enum types (MAV_CMD, MAV_TYPE, etc.)
+/// but don't need message struct definitions.
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+""")
+
+    for name, path in dialects:
+        enums = extract_enums(path)
+        if enums.strip():
+            parts.append(f"\n// ---- enums from {name}/{name}.h ----\n")
+            parts.append(enums)
+
+    parts.append("""
+#ifdef __cplusplus
+}
+#endif
+""")
+
+    output = ''.join(parts)
+
+    # Ensure output directory exists
+    os.makedirs(os.path.dirname(os.path.abspath(output_file)), exist_ok=True)
+
+    # Only write if content changed (avoid unnecessary rebuilds)
+    if os.path.isfile(output_file):
+        with open(output_file, 'r') as f:
+            if f.read() == output:
+                print(f"MAVLinkEnums.h is up to date ({output_file})")
+                return
+
+    with open(output_file, 'w') as f:
+        f.write(output)
+
+    # Count enums
+    enum_count = output.count('typedef enum')
+    line_count = output.count('\n')
+    print(f"Generated {output_file}: {line_count} lines, {enum_count} enums from {len(dialects)} dialects")
+
+
+if __name__ == '__main__':
+    main()

--- a/src/ADSB/ADSB.h
+++ b/src/ADSB/ADSB.h
@@ -1,6 +1,6 @@
 #pragma once
 
-#include "MAVLinkLib.h"
+#include "MAVLinkEnums.h"
 
 #include <QtCore/QMetaType>
 #include <QtPositioning/QGeoCoordinate>

--- a/src/ADSB/ADSBVehicleManager.cc
+++ b/src/ADSB/ADSBVehicleManager.cc
@@ -1,4 +1,5 @@
 #include "ADSBVehicleManager.h"
+#include "MAVLinkLib.h"
 #include "QGCApplication.h"
 #include "SettingsManager.h"
 #include "ADSBVehicleManagerSettings.h"

--- a/src/ADSB/ADSBVehicleManager.h
+++ b/src/ADSB/ADSBVehicleManager.h
@@ -4,7 +4,7 @@
 #include <QtCore/QObject>
 
 #include "ADSB.h"
-#include "MAVLinkLib.h"
+#include "MAVLinkMessageType.h"
 
 Q_DECLARE_LOGGING_CATEGORY(ADSBVehicleManagerLog)
 

--- a/src/API/QGCCorePlugin.cc
+++ b/src/API/QGCCorePlugin.cc
@@ -3,6 +3,7 @@
 #include "AppSettings.h"
 #include "MavlinkSettings.h"
 #include "FactMetaData.h"
+#include "QGCMAVLink.h"
 #ifdef QGC_GST_STREAMING
 #include "GStreamer.h"
 #endif

--- a/src/AnalyzeView/MAVLinkInspector/MAVLinkInspectorController.h
+++ b/src/AnalyzeView/MAVLinkInspector/MAVLinkInspectorController.h
@@ -5,7 +5,7 @@
 #include <QtCore/QString>
 #include <QtQmlIntegration/QtQmlIntegration>
 
-#include "MAVLinkLib.h"
+#include "MAVLinkMessageType.h"
 
 Q_DECLARE_LOGGING_CATEGORY(MAVLinkInspectorControllerLog)
 

--- a/src/AnalyzeView/MAVLinkInspector/MAVLinkMessage.cc
+++ b/src/AnalyzeView/MAVLinkInspector/MAVLinkMessage.cc
@@ -1,4 +1,5 @@
 #include "MAVLinkMessage.h"
+#include "MAVLinkLib.h"
 #include "MAVLinkMessageField.h"
 #include "QGCLoggingCategory.h"
 #include "QmlObjectListModel.h"

--- a/src/AnalyzeView/MAVLinkInspector/MAVLinkMessage.h
+++ b/src/AnalyzeView/MAVLinkInspector/MAVLinkMessage.h
@@ -5,7 +5,7 @@
 #include <QtCore/QLoggingCategory>
 #include <QtQmlIntegration/QtQmlIntegration>
 
-#include "MAVLinkLib.h"
+#include "MAVLinkMessageType.h"
 
 class QmlObjectListModel;
 

--- a/src/AutoPilotPlugins/APM/APMFlightModesComponentController.h
+++ b/src/AutoPilotPlugins/APM/APMFlightModesComponentController.h
@@ -5,7 +5,7 @@
 #include <QtQmlIntegration/QtQmlIntegration>
 
 #include "FactPanelController.h"
-#include "QGCMAVLink.h"
+#include "QGCMAVLinkTypes.h"
 
 /// MVC Controller for FlightModesComponent.qml.
 class APMFlightModesComponentController : public FactPanelController
@@ -57,7 +57,7 @@ private:
     Fact *_superSimpleModeFact = nullptr;
     const bool _simpleModesSupported = false;
     int _activeFlightMode = 0;
-    int _channelCount = QGCMAVLink::maxRcChannels;
+    int _channelCount = QGCMAVLinkTypes::maxRcChannels;
     int _simpleMode = SimpleModeStandard;
     QString _modeChannelParam;
     QString _modeParamPrefix;

--- a/src/AutoPilotPlugins/Common/ESP8266ComponentController.h
+++ b/src/AutoPilotPlugins/Common/ESP8266ComponentController.h
@@ -5,7 +5,7 @@
 #include <QtQmlIntegration/QtQmlIntegration>
 
 #include "FactPanelController.h"
-#include "MAVLinkLib.h"
+#include "MAVLinkEnums.h"
 
 Q_DECLARE_LOGGING_CATEGORY(ESP8266ComponentControllerLog)
 

--- a/src/AutoPilotPlugins/PX4/ActuatorComponent.cc
+++ b/src/AutoPilotPlugins/PX4/ActuatorComponent.cc
@@ -2,6 +2,7 @@
 #include "QGCApplication.h"
 #include "GeometryImage.h"
 #include "Actuators/Actuators.h"
+#include "Vehicle.h"
 
 #include <QtQml/QQmlApplicationEngine>
 

--- a/src/AutoPilotPlugins/PX4/PX4SimpleFlightModesController.h
+++ b/src/AutoPilotPlugins/PX4/PX4SimpleFlightModesController.h
@@ -4,7 +4,6 @@
 #include <QtQmlIntegration/QtQmlIntegration>
 
 #include "FactPanelController.h"
-#include "QGCMAVLink.h"
 
 /// MVC Controller for PX4SimpleFlightModes.qml
 class PX4SimpleFlightModesController : public FactPanelController

--- a/src/Camera/QGCCameraManager.cc
+++ b/src/Camera/QGCCameraManager.cc
@@ -3,11 +3,13 @@
 #include "FirmwarePlugin.h"
 #include "Joystick.h"
 #include "JoystickManager.h"
+#include "MAVLinkLib.h"
 #include "MavlinkCameraControlInterface.h"
 #include "MultiVehicleManager.h"
 #include "QGCLoggingCategory.h"
 #include "QGCVideoStreamInfo.h"
 #include "SimulatedCameraControl.h"
+#include "Vehicle.h"
 
 #include <cmath>
 #include "GimbalControllerSettings.h"

--- a/src/Camera/QGCCameraManager.h
+++ b/src/Camera/QGCCameraManager.h
@@ -9,9 +9,10 @@
 #include <QtCore/QVariantList>
 #include <QtQmlIntegration/QtQmlIntegration>
 
-#include "MAVLinkLib.h"
+#include "MAVLinkMessageType.h"
 #include "QmlObjectListModel.h"
-#include "Vehicle.h"
+
+class Vehicle;
 
 Q_DECLARE_LOGGING_CATEGORY(CameraManagerLog)
 
@@ -54,7 +55,7 @@ public:
         int retryCount = 0;
         QElapsedTimer lastHeartbeat;
         QTimer backoffTimer;
-        QPointer<Vehicle> vehicle;
+        Vehicle* vehicle;           ///< Raw pointer is safe: CameraStruct is owned by QGCCameraManager which is a child of Vehicle
         QPointer<QGCCameraManager> manager;
 
     private:
@@ -128,7 +129,7 @@ private:
     void _addCameraControlToLists(MavlinkCameraControlInterface* cameraControl);
     void _handleCameraFovStatus(const mavlink_message_t& message);
 
-    QPointer<Vehicle> _vehicle;
+    Vehicle* _vehicle;              ///< Raw pointer is safe: QGCCameraManager is a QObject child of Vehicle, so Vehicle always outlives us
     QPointer<SimulatedCameraControl> _simulatedCameraControl;
     QPointer<Joystick> _activeJoystick;
     bool _vehicleReadyState = false;

--- a/src/Comms/MAVLinkProtocol.h
+++ b/src/Comms/MAVLinkProtocol.h
@@ -6,7 +6,8 @@
 #include <QtCore/QString>
 
 #include "LinkInterface.h"
-#include "MAVLinkLib.h"
+#include "MAVLinkEnums.h"
+#include "MAVLinkMessageType.h"
 
 class QFile;
 

--- a/src/Comms/MockLink/MockConfiguration.h
+++ b/src/Comms/MockLink/MockConfiguration.h
@@ -3,7 +3,7 @@
 #include "LinkConfiguration.h"
 
 #include <QtCore/QLoggingCategory>
-#include "MAVLinkLib.h"
+#include "MAVLinkEnums.h"
 
 Q_DECLARE_LOGGING_CATEGORY(MockConfigurationLog)
 

--- a/src/FactSystem/FactGroup.h
+++ b/src/FactSystem/FactGroup.h
@@ -8,7 +8,7 @@
 #include <QtQmlIntegration/QtQmlIntegration>
 
 #include "Fact.h"
-#include "MAVLinkLib.h"
+#include "MAVLinkMessageType.h"
 
 class Vehicle;
 

--- a/src/FactSystem/FactGroupListModel.h
+++ b/src/FactSystem/FactGroupListModel.h
@@ -1,7 +1,7 @@
 #pragma once
 
 #include "QmlObjectListModel.h"
-#include "QGCMAVLink.h"
+#include "MAVLinkMessageType.h"
 #include "FactGroupWithId.h"
 
 #include <QList>

--- a/src/FactSystem/ParameterManager.h
+++ b/src/FactSystem/ParameterManager.h
@@ -10,7 +10,8 @@
 
 #include "Fact.h"
 #include "FactMetaData.h"
-#include "MAVLinkLib.h"
+#include "MAVLinkEnums.h"
+#include "MAVLinkMessageType.h"
 
 Q_DECLARE_LOGGING_CATEGORY(ParameterManagerLog)
 Q_DECLARE_LOGGING_CATEGORY(ParameterManagerVerbose1Log)

--- a/src/FirmwarePlugin/APM/APMParameterMetaData.h
+++ b/src/FirmwarePlugin/APM/APMParameterMetaData.h
@@ -5,7 +5,7 @@
 #include <QtCore/QObject>
 #include <QtCore/QXmlStreamReader>
 
-#include "MAVLinkLib.h"
+#include "MAVLinkEnums.h"
 #include "FactMetaData.h"
 
 Q_DECLARE_LOGGING_CATEGORY(APMParameterMetaDataLog)

--- a/src/FirmwarePlugin/FirmwarePlugin.cc
+++ b/src/FirmwarePlugin/FirmwarePlugin.cc
@@ -7,6 +7,7 @@
 #include "QGCCameraManager.h"
 #include "QGCFileDownload.h"
 #include "QGCLoggingCategory.h"
+#include "Vehicle.h"
 #include "VehicleCameraControl.h"
 #include "VehicleComponent.h"
 

--- a/src/FirmwarePlugin/FirmwarePlugin.h
+++ b/src/FirmwarePlugin/FirmwarePlugin.h
@@ -8,7 +8,9 @@
 #include "QGCMAVLink.h"
 #include "FollowMe.h"
 #include "FactMetaData.h"
-#include "Vehicle.h"
+#include "VehicleTypes.h"
+
+class Vehicle;
 
 class VehicleComponent;
 class AutoPilotPlugin;
@@ -324,8 +326,8 @@ public:
 
     /// Returns the highest minor version number that has remap entries for the specified major version.
     /// The remap logic iterates backwards from this version down to the vehicle's actual minor version.
-    /// Return Vehicle::versionNotSetValue if remapping is not supported for the given major version.
-    virtual int remapParamNameHigestMinorVersionNumber(int /*majorVersionNumber*/) const { return Vehicle::versionNotSetValue; }
+    /// Return VehicleTypes::versionNotSetValue if remapping is not supported for the given major version.
+    virtual int remapParamNameHigestMinorVersionNumber(int /*majorVersionNumber*/) const { return VehicleTypes::versionNotSetValue; }
 
     /// @return true: Motors are coaxial like an X8 config, false: Quadcopter for example
     virtual bool multiRotorCoaxialMotors(Vehicle* /*vehicle*/) const { return false; }

--- a/src/FirmwarePlugin/PX4/PX4ParameterMetaData.h
+++ b/src/FirmwarePlugin/PX4/PX4ParameterMetaData.h
@@ -1,7 +1,7 @@
 #pragma once
 
 
-#include "MAVLinkLib.h"
+#include "MAVLinkEnums.h"
 #include "FactMetaData.h"
 
 #include <QtCore/QObject>

--- a/src/Gimbal/Gimbal.h
+++ b/src/Gimbal/Gimbal.h
@@ -3,7 +3,7 @@
 #include <QtCore/QLoggingCategory>
 
 #include "FactGroup.h"
-#include "QGCMAVLink.h"
+#include "MAVLinkEnums.h"
 
 Q_DECLARE_LOGGING_CATEGORY(GimbalLog)
 

--- a/src/Gimbal/GimbalController.cc
+++ b/src/Gimbal/GimbalController.cc
@@ -1,5 +1,6 @@
 #include "GimbalController.h"
 #include "GimbalControllerSettings.h"
+#include "MAVLinkLib.h"
 #include "MAVLinkProtocol.h"
 #include "ParameterManager.h"
 #include "QGCLoggingCategory.h"

--- a/src/Gimbal/GimbalController.h
+++ b/src/Gimbal/GimbalController.h
@@ -5,7 +5,7 @@
 #include <QtQmlIntegration/QtQmlIntegration>
 
 #include "Gimbal.h"
-#include "MAVLinkLib.h"
+#include "MAVLinkMessageType.h"
 
 Q_DECLARE_LOGGING_CATEGORY(GimbalControllerLog)
 

--- a/src/MAVLink/CMakeLists.txt
+++ b/src/MAVLink/CMakeLists.txt
@@ -10,6 +10,7 @@ target_sources(${CMAKE_PROJECT_NAME}
         MAVLinkFTP.cc
         MAVLinkFTP.h
         MAVLinkLib.h
+        MAVLinkMessageType.h
         MAVLinkSigning.cc
         MAVLinkSigning.h
         MAVLinkSigningKeys.cc
@@ -18,6 +19,7 @@ target_sources(${CMAKE_PROJECT_NAME}
         MAVLinkStreamConfig.h
         QGCMAVLink.cc
         QGCMAVLink.h
+        QGCMAVLinkTypes.h
         StatusTextHandler.cc
         StatusTextHandler.h
         SysStatusSensorInfo.cc
@@ -48,6 +50,25 @@ if(mavlink_ADDED)
             ${mavlink_BINARY_DIR}/include/mavlink
             ${mavlink_BINARY_DIR}/include/mavlink/${QGC_MAVLINK_DIALECT}
     )
+
+    # Generate lightweight MAVLinkEnums.h (enum typedefs only, no message pack/unpack code)
+    find_package(Python3 REQUIRED COMPONENTS Interpreter)
+    set(MAVLINK_ENUMS_OUTPUT "${CMAKE_BINARY_DIR}/MAVLinkEnums.h")
+    add_custom_command(
+        OUTPUT "${MAVLINK_ENUMS_OUTPUT}"
+        COMMAND ${Python3_EXECUTABLE}
+            "${CMAKE_SOURCE_DIR}/cmake/GenerateMAVLinkEnums.py"
+            "${mavlink_BINARY_DIR}/include/mavlink"
+            "${MAVLINK_ENUMS_OUTPUT}"
+        DEPENDS mavlink "${CMAKE_SOURCE_DIR}/cmake/GenerateMAVLinkEnums.py"
+        COMMENT "Generating MAVLinkEnums.h from MAVLink dialect headers"
+        VERBATIM
+    )
+    add_custom_target(mavlink_enums DEPENDS "${MAVLINK_ENUMS_OUTPUT}")
+    add_dependencies(${CMAKE_PROJECT_NAME} mavlink_enums)
+    # Ensure AUTOMOC runs after MAVLinkEnums.h is generated
+    set_property(TARGET ${CMAKE_PROJECT_NAME} APPEND PROPERTY AUTOGEN_TARGET_DEPENDS mavlink_enums)
+    target_include_directories(${CMAKE_PROJECT_NAME} PRIVATE "${CMAKE_BINARY_DIR}")
 endif()
 
 # ----------------------------------------------------------------------------

--- a/src/MAVLink/MAVLinkLib.h
+++ b/src/MAVLink/MAVLinkLib.h
@@ -1,43 +1,6 @@
 #pragma once
 
-#include <stdint.h>
-
-#define HAVE_MAVLINK_CHANNEL_T
-#ifdef HAVE_MAVLINK_CHANNEL_T
-typedef enum : uint8_t {
-    MAVLINK_COMM_0,
-    MAVLINK_COMM_1,
-    MAVLINK_COMM_2,
-    MAVLINK_COMM_3,
-    MAVLINK_COMM_4,
-    MAVLINK_COMM_5,
-    MAVLINK_COMM_6,
-    MAVLINK_COMM_7,
-    MAVLINK_COMM_8,
-    MAVLINK_COMM_9,
-    MAVLINK_COMM_10,
-    MAVLINK_COMM_11,
-    MAVLINK_COMM_12,
-    MAVLINK_COMM_13,
-    MAVLINK_COMM_14,
-    MAVLINK_COMM_15
-} mavlink_channel_t;
-#endif
-
-#define MAVLINK_COMM_NUM_BUFFERS 16
-#define MAVLINK_MAX_SIGNING_STREAMS MAVLINK_COMM_NUM_BUFFERS
-
-#include <mavlink_types.h>
-
-#define MAVLINK_EXTERNAL_RX_STATUS
-#ifdef MAVLINK_EXTERNAL_RX_STATUS
-    extern mavlink_status_t m_mavlink_status[MAVLINK_COMM_NUM_BUFFERS];
-#endif
-
-#define MAVLINK_GET_CHANNEL_STATUS
-#ifdef MAVLINK_GET_CHANNEL_STATUS
-    extern mavlink_status_t* mavlink_get_channel_status(uint8_t chan);
-#endif
+#include "MAVLinkMessageType.h"
 
 // #define MAVLINK_NO_SIGN_PACKET
 // #define MAVLINK_NO_SIGNATURE_CHECK

--- a/src/MAVLink/MAVLinkMessageType.h
+++ b/src/MAVLink/MAVLinkMessageType.h
@@ -1,0 +1,46 @@
+#pragma once
+
+/// Lightweight header providing only MAVLink base types (mavlink_message_t, mavlink_status_t,
+/// mavlink_channel_t, etc.) WITHOUT pulling in the full dialect message definitions.
+///
+/// Use this instead of MAVLinkLib.h in headers that only reference mavlink_message_t in
+/// function signatures. This avoids moc parsing ~118k lines of MAVLink message pack/unpack code.
+
+#include <stdint.h>
+
+#define HAVE_MAVLINK_CHANNEL_T
+#ifdef HAVE_MAVLINK_CHANNEL_T
+typedef enum : uint8_t {
+    MAVLINK_COMM_0,
+    MAVLINK_COMM_1,
+    MAVLINK_COMM_2,
+    MAVLINK_COMM_3,
+    MAVLINK_COMM_4,
+    MAVLINK_COMM_5,
+    MAVLINK_COMM_6,
+    MAVLINK_COMM_7,
+    MAVLINK_COMM_8,
+    MAVLINK_COMM_9,
+    MAVLINK_COMM_10,
+    MAVLINK_COMM_11,
+    MAVLINK_COMM_12,
+    MAVLINK_COMM_13,
+    MAVLINK_COMM_14,
+    MAVLINK_COMM_15
+} mavlink_channel_t;
+#endif
+
+#define MAVLINK_COMM_NUM_BUFFERS 16
+#define MAVLINK_MAX_SIGNING_STREAMS MAVLINK_COMM_NUM_BUFFERS
+
+#include <mavlink_types.h>
+
+#define MAVLINK_EXTERNAL_RX_STATUS
+#ifdef MAVLINK_EXTERNAL_RX_STATUS
+    extern mavlink_status_t m_mavlink_status[MAVLINK_COMM_NUM_BUFFERS];
+#endif
+
+#define MAVLINK_GET_CHANNEL_STATUS
+#ifdef MAVLINK_GET_CHANNEL_STATUS
+    extern mavlink_status_t* mavlink_get_channel_status(uint8_t chan);
+#endif

--- a/src/MAVLink/QGCMAVLink.cc
+++ b/src/MAVLink/QGCMAVLink.cc
@@ -1,4 +1,5 @@
 #include "QGCMAVLink.h"
+#include "MAVLinkLib.h"
 #include "QGCLoggingCategory.h"
 
 QGC_LOGGING_CATEGORY(QGCMAVLinkLog, "MAVLink.QGCMAVLink")

--- a/src/MAVLink/QGCMAVLink.h
+++ b/src/MAVLink/QGCMAVLink.h
@@ -6,14 +6,24 @@
 #include <QtCore/QString>
 #include <QtQmlIntegration/QtQmlIntegration>
 
-#include "MAVLinkLib.h"
+#include "MAVLinkEnums.h"
+#include "MAVLinkMessageType.h"
+#include "QGCMAVLinkTypes.h"
+
+// Forward declare - only used by reference in highLatencyFailuresToMavSysStatus()
+typedef struct __mavlink_high_latency2_t mavlink_high_latency2_t;
+
+// From mavlink_msg_param_ext_set.h - avoids pulling in the full message header
+#ifndef MAVLINK_MSG_PARAM_EXT_SET_FIELD_PARAM_VALUE_LEN
+#define MAVLINK_MSG_PARAM_EXT_SET_FIELD_PARAM_VALUE_LEN 128
+#endif
 
 Q_DECLARE_LOGGING_CATEGORY(QGCMAVLinkLog)
 // Q_DECLARE_METATYPE(mavlink_message_t)
 Q_DECLARE_METATYPE(MAV_TYPE)
 Q_DECLARE_METATYPE(MAV_AUTOPILOT)
 
-class QGCMAVLink : public QObject
+class QGCMAVLink : public QObject, public QGCMAVLinkTypes
 {
     Q_OBJECT
     QML_NAMED_ELEMENT(MAVLink)
@@ -24,8 +34,7 @@ public:
     QGCMAVLink(QObject *parent = nullptr);
     ~QGCMAVLink();
 
-    typedef int FirmwareClass_t;
-    typedef int VehicleClass_t;
+    // FirmwareClass_t, VehicleClass_t, VehicleClassGeneric, maxRcChannels inherited from QGCMAVLinkTypes
 
     static constexpr const FirmwareClass_t FirmwareClassPX4       = MAV_AUTOPILOT_PX4;
     static constexpr const FirmwareClass_t FirmwareClassArduPilot = MAV_AUTOPILOT_ARDUPILOTMEGA;
@@ -38,9 +47,8 @@ public:
     static constexpr const VehicleClass_t VehicleClassSpacecraft  = MAV_TYPE_SPACECRAFT_ORBITER;
     static constexpr const VehicleClass_t VehicleClassMultiRotor  = MAV_TYPE_QUADROTOR;
     static constexpr const VehicleClass_t VehicleClassVTOL        = MAV_TYPE_VTOL_TAILSITTER_QUADROTOR;
-    static constexpr const VehicleClass_t VehicleClassGeneric     = MAV_TYPE_GENERIC;
-
-    static constexpr const uint8_t        maxRcChannels           = 18; // mavlink_rc_channels_t->chancount
+    // VehicleClassGeneric inherited from QGCMAVLinkTypes
+    static_assert(QGCMAVLinkTypes::VehicleClassGeneric == MAV_TYPE_GENERIC, "VehicleClassGeneric value mismatch");
 
     static bool                     isPX4FirmwareClass          (MAV_AUTOPILOT autopilot) { return autopilot == MAV_AUTOPILOT_PX4; }
     static bool                     isArduPilotFirmwareClass    (MAV_AUTOPILOT autopilot) { return autopilot == MAV_AUTOPILOT_ARDUPILOTMEGA; }

--- a/src/MAVLink/QGCMAVLinkTypes.h
+++ b/src/MAVLink/QGCMAVLinkTypes.h
@@ -1,0 +1,18 @@
+#pragma once
+
+/// Lightweight header providing QGCMAVLink type aliases and constants
+/// without pulling in the full MAVLink dialect definitions (~118k preprocessed lines).
+///
+/// Use this instead of QGCMAVLink.h in headers that only reference
+/// FirmwareClass_t, VehicleClass_t, or maxRcChannels.
+
+#include <cstdint>
+
+struct QGCMAVLinkTypes {
+    typedef int FirmwareClass_t;
+    typedef int VehicleClass_t;
+
+    static constexpr VehicleClass_t VehicleClassGeneric = 0; // Must match MAV_TYPE_GENERIC
+
+    static constexpr uint8_t maxRcChannels = 18;
+};

--- a/src/MAVLink/StatusTextHandler.h
+++ b/src/MAVLink/StatusTextHandler.h
@@ -4,7 +4,8 @@
 #include <QtCore/QObject>
 #include <QtCore/QLoggingCategory>
 
-#include "MAVLinkLib.h"
+#include "MAVLinkEnums.h"
+#include "MAVLinkMessageType.h"
 
 Q_DECLARE_LOGGING_CATEGORY(StatusTextHandlerLog)
 

--- a/src/MissionManager/MissionFlightStatus.h
+++ b/src/MissionManager/MissionFlightStatus.h
@@ -1,6 +1,6 @@
 #pragma once
 
-#include "QGCMAVLink.h"
+#include "QGCMAVLinkTypes.h"
 
 struct MissionFlightStatus_t {
     double                      maxTelemetryDistance;
@@ -23,7 +23,7 @@ struct MissionFlightStatus_t {
     double                      gimbalYaw;              ///< NaN signals yaw was never changed
     double                      gimbalPitch;            ///< NaN signals pitch was never changed
     // The following values are the state prior to executing this item
-    QGCMAVLink::VehicleClass_t  vtolMode;               ///< Either VehicleClassFixedWing, VehicleClassMultiRotor, VehicleClassGeneric (mode unknown)
+    QGCMAVLinkTypes::VehicleClass_t  vtolMode;               ///< Either VehicleClassFixedWing, VehicleClassMultiRotor, VehicleClassGeneric (mode unknown)
     double                      cruiseSpeed;
     double                      hoverSpeed;
     double                      vehicleSpeed;           ///< Either cruise or hover speed based on vehicle type and vtol state

--- a/src/MissionManager/VisualMissionItem.h
+++ b/src/MissionManager/VisualMissionItem.h
@@ -7,7 +7,7 @@
 #include <QtQmlIntegration/QtQmlIntegration>
 
 #include "MissionController.h"
-#include "QGCMAVLink.h"
+#include "QGCMAVLinkTypes.h"
 #include "QmlObjectListModel.h"
 
 class MissionItem;
@@ -265,7 +265,7 @@ protected:
     QString                     _editorQml;                                                     ///< Qml resource for editing item
     double                      _missionGimbalYaw           = qQNaN();
     double                      _missionVehicleYaw          = qQNaN();
-    QGCMAVLink::VehicleClass_t  _previousVTOLMode           = QGCMAVLink::VehicleClassGeneric;  ///< Generic == unknown
+    QGCMAVLinkTypes::VehicleClass_t  _previousVTOLMode           = QGCMAVLinkTypes::VehicleClassGeneric;  ///< Generic == unknown
 
     PlanMasterController*   _masterController           = nullptr;
     MissionController*      _missionController          = nullptr;

--- a/src/QmlControls/FactValueGrid.cc
+++ b/src/QmlControls/FactValueGrid.cc
@@ -90,7 +90,7 @@ FactValueGrid::~FactValueGrid()
     _vehicleCardInstanceList.removeAll(this);
 }
 
-QGCMAVLink::VehicleClass_t FactValueGrid::vehicleClass(void) const
+QGCMAVLinkTypes::VehicleClass_t FactValueGrid::vehicleClass(void) const
 {
     return QGCMAVLink::vehicleClass(currentVehicle()->vehicleType());
 }

--- a/src/QmlControls/FactValueGrid.h
+++ b/src/QmlControls/FactValueGrid.h
@@ -5,8 +5,9 @@
 #include <QtQmlIntegration/QtQmlIntegration>
 
 #include "QmlObjectListModel.h"
-#include "QGCMAVLink.h"
-#include "Vehicle.h"
+#include "QGCMAVLinkTypes.h"
+
+class Vehicle;
 
 class InstrumentValueData;
 
@@ -47,7 +48,7 @@ public:
     QString                     settingsGroup           (void) const { return _settingsGroup; }
     FontSize                    fontSize                (void) const { return _fontSize; }
     QStringList                 iconNames               (void) const { return _iconNames; }
-    QGCMAVLink::VehicleClass_t  vehicleClass            (void) const;
+    QGCMAVLinkTypes::VehicleClass_t  vehicleClass            (void) const;
     Vehicle*                    currentVehicle          (void) const { return _specificVehicleForCard ? _specificVehicleForCard : _activeVehicle; }
     Vehicle*                    specificVehicleForCard  (void) const { return _specificVehicleForCard; }
 

--- a/src/QmlControls/MavlinkAction.h
+++ b/src/QmlControls/MavlinkAction.h
@@ -1,6 +1,6 @@
 #pragma once
 
-#include "MAVLinkLib.h"
+#include "MAVLinkEnums.h"
 
 #include <QtCore/QLoggingCategory>
 #include <QtCore/QObject>

--- a/src/QmlControls/RCChannelMonitorController.h
+++ b/src/QmlControls/RCChannelMonitorController.h
@@ -1,7 +1,6 @@
 #pragma once
 
 #include "FactPanelController.h"
-#include "QGCMAVLink.h"
 
 #include <QtCore/QLoggingCategory>
 #include <QtQmlIntegration/QtQmlIntegration>

--- a/src/Settings/APMMavlinkStreamRateSettings.h
+++ b/src/Settings/APMMavlinkStreamRateSettings.h
@@ -3,7 +3,7 @@
 #include <QtQmlIntegration/QtQmlIntegration>
 
 #include "SettingsGroup.h"
-#include "MAVLinkLib.h"
+#include "MAVLinkEnums.h"
 
 class APMMavlinkStreamRateSettings : public SettingsGroup
 {

--- a/src/Utilities/StateMachine/States/RequestMessageState.cc
+++ b/src/Utilities/StateMachine/States/RequestMessageState.cc
@@ -1,5 +1,6 @@
 #include "RequestMessageState.h"
 #include "QGCLoggingCategory.h"
+#include "Vehicle.h"
 #include "VehicleLinkManager.h"
 
 RequestMessageState::RequestMessageState(QState* parent,
@@ -57,7 +58,7 @@ void RequestMessageState::onWaitTimeout()
 
 void RequestMessageState::_resultHandler(void* resultHandlerData,
                                          MAV_RESULT commandResult,
-                                         Vehicle::RequestMessageResultHandlerFailureCode_t failureCode,
+                                         VehicleTypes::RequestMessageResultHandlerFailureCode_t failureCode,
                                          const mavlink_message_t& message)
 {
     auto* state = static_cast<RequestMessageState*>(resultHandlerData);

--- a/src/Utilities/StateMachine/States/RequestMessageState.h
+++ b/src/Utilities/StateMachine/States/RequestMessageState.h
@@ -1,7 +1,11 @@
 #pragma once
 
 #include "WaitStateBase.h"
-#include "Vehicle.h"
+#include "MAVLinkEnums.h"
+#include "MAVLinkMessageType.h"
+#include "VehicleTypes.h"
+
+class Vehicle;
 
 #include <cstdint>
 #include <functional>
@@ -38,7 +42,7 @@ public:
                         float param5 = 0.0f);
 
     /// @return The failure code from the last request attempt
-    Vehicle::RequestMessageResultHandlerFailureCode_t failureCode() const { return _failureCode; }
+    VehicleTypes::RequestMessageResultHandlerFailureCode_t failureCode() const { return _failureCode; }
 
     /// @return The MAV_RESULT from the last request attempt
     MAV_RESULT commandResult() const { return _commandResult; }
@@ -56,7 +60,7 @@ protected:
 private:
     static void _resultHandler(void* resultHandlerData,
                                MAV_RESULT commandResult,
-                               Vehicle::RequestMessageResultHandlerFailureCode_t failureCode,
+                               VehicleTypes::RequestMessageResultHandlerFailureCode_t failureCode,
                                const mavlink_message_t& message);
 
     uint32_t        _messageId;
@@ -68,6 +72,6 @@ private:
     float           _param4;
     float           _param5;
 
-    Vehicle::RequestMessageResultHandlerFailureCode_t _failureCode = Vehicle::RequestMessageNoFailure;
+    VehicleTypes::RequestMessageResultHandlerFailureCode_t _failureCode = VehicleTypes::RequestMessageNoFailure;
     MAV_RESULT _commandResult = MAV_RESULT_ACCEPTED;
 };

--- a/src/Utilities/StateMachine/States/RetryableRequestMessageState.cc
+++ b/src/Utilities/StateMachine/States/RetryableRequestMessageState.cc
@@ -1,5 +1,6 @@
 #include "RetryableRequestMessageState.h"
 #include "QGCStateMachine.h"
+#include "Vehicle.h"
 
 #include <QtCore/QLoggingCategory>
 #include <QtCore/QMetaObject>
@@ -59,7 +60,7 @@ void RetryableRequestMessageState::_sendRequest()
     v->requestMessage(
         [](void* resultHandlerData,
            MAV_RESULT result,
-           Vehicle::RequestMessageResultHandlerFailureCode_t failureCode,
+           VehicleTypes::RequestMessageResultHandlerFailureCode_t failureCode,
            const mavlink_message_t& message) {
             auto* self = static_cast<RetryableRequestMessageState*>(resultHandlerData);
             if (!self->_requestActive) {
@@ -87,20 +88,20 @@ void RetryableRequestMessageState::_queueRetry()
 
 void RetryableRequestMessageState::_handleResult(
     MAV_RESULT result,
-    Vehicle::RequestMessageResultHandlerFailureCode_t failureCode,
+    VehicleTypes::RequestMessageResultHandlerFailureCode_t failureCode,
     const mavlink_message_t& message)
 {
-    Vehicle::RequestMessageResultHandlerFailureCode_t effectiveFailureCode = failureCode;
-    if (failureCode == Vehicle::RequestMessageFailureDuplicate) {
+    VehicleTypes::RequestMessageResultHandlerFailureCode_t effectiveFailureCode = failureCode;
+    if (failureCode == VehicleTypes::RequestMessageFailureDuplicate) {
         // Retryable request flows can re-enter while Vehicle still tracks the prior
         // request as active. Treat duplicate as an in-flight timeout-equivalent.
-        effectiveFailureCode = Vehicle::RequestMessageFailureMessageNotReceived;
+        effectiveFailureCode = VehicleTypes::RequestMessageFailureMessageNotReceived;
     }
 
     _lastResult = result;
     _lastFailureCode = effectiveFailureCode;
 
-    if (effectiveFailureCode == Vehicle::RequestMessageNoFailure) {
+    if (effectiveFailureCode == VehicleTypes::RequestMessageNoFailure) {
         // Success
         qCDebug(QGCStateMachineLog) << stateName() << "Message received successfully";
 
@@ -140,7 +141,7 @@ void RetryableRequestMessageState::onWaitTimeout()
 {
     qCDebug(QGCStateMachineLog) << stateName() << "Timeout waiting for message";
 
-    _lastFailureCode = Vehicle::RequestMessageFailureMessageNotReceived;
+    _lastFailureCode = VehicleTypes::RequestMessageFailureMessageNotReceived;
 
     if (_retryCount < _maxRetries) {
         _retryCount++;

--- a/src/Utilities/StateMachine/States/RetryableRequestMessageState.h
+++ b/src/Utilities/StateMachine/States/RetryableRequestMessageState.h
@@ -1,7 +1,11 @@
 #pragma once
 
 #include "WaitStateBase.h"
-#include "Vehicle.h"
+#include "MAVLinkEnums.h"
+#include "MAVLinkMessageType.h"
+#include "VehicleTypes.h"
+
+class Vehicle;
 
 #include <functional>
 
@@ -29,7 +33,7 @@ class RetryableRequestMessageState : public WaitStateBase
 
 public:
     using MessageHandler = std::function<void(Vehicle* vehicle, const mavlink_message_t& message)>;
-    using FailureHandler = std::function<void(Vehicle::RequestMessageResultHandlerFailureCode_t failureCode, MAV_RESULT result)>;
+    using FailureHandler = std::function<void(VehicleTypes::RequestMessageResultHandlerFailureCode_t failureCode, MAV_RESULT result)>;
     using SkipPredicate = std::function<bool()>;
 
     /// Create a retryable request message state
@@ -59,7 +63,7 @@ public:
     void setFailOnMaxRetries(bool fail) { _failOnMaxRetries = fail; }
 
     /// Get the failure code from the last attempt
-    Vehicle::RequestMessageResultHandlerFailureCode_t lastFailureCode() const { return _lastFailureCode; }
+    VehicleTypes::RequestMessageResultHandlerFailureCode_t lastFailureCode() const { return _lastFailureCode; }
 
     /// Get the MAV_RESULT from the last attempt
     MAV_RESULT lastResult() const { return _lastResult; }
@@ -88,7 +92,7 @@ private:
     void _sendRequest();
     void _queueRetry();
     void _handleResult(MAV_RESULT result,
-                       Vehicle::RequestMessageResultHandlerFailureCode_t failureCode,
+                       VehicleTypes::RequestMessageResultHandlerFailureCode_t failureCode,
                        const mavlink_message_t& message);
 
     uint32_t _messageId;
@@ -102,6 +106,6 @@ private:
 
     bool _requestActive = false;
 
-    Vehicle::RequestMessageResultHandlerFailureCode_t _lastFailureCode = Vehicle::RequestMessageNoFailure;
+    VehicleTypes::RequestMessageResultHandlerFailureCode_t _lastFailureCode = VehicleTypes::RequestMessageNoFailure;
     MAV_RESULT _lastResult = MAV_RESULT_ACCEPTED;
 };

--- a/src/Utilities/StateMachine/States/SendMavlinkMessageState.h
+++ b/src/Utilities/StateMachine/States/SendMavlinkMessageState.h
@@ -1,7 +1,7 @@
 #pragma once
 
 #include "QGCState.h"
-#include "QGCMAVLink.h"
+#include "MAVLinkMessageType.h"
 
 #include <cstdint>
 #include <functional>

--- a/src/Utilities/StateMachine/States/WaitForMavlinkMessageState.h
+++ b/src/Utilities/StateMachine/States/WaitForMavlinkMessageState.h
@@ -1,7 +1,7 @@
 #pragma once
 
 #include "WaitStateBase.h"
-#include "QGCMAVLink.h"
+#include "MAVLinkMessageType.h"
 
 #include <cstdint>
 #include <functional>

--- a/src/Vehicle/Actuators/ActuatorActions.cc
+++ b/src/Vehicle/Actuators/ActuatorActions.cc
@@ -1,5 +1,6 @@
 #include "ActuatorActions.h"
 #include "QGCApplication.h"
+#include "Vehicle.h"
 
 using namespace ActuatorActions;
 
@@ -32,16 +33,16 @@ void Action::trigger()
     sendMavlinkRequest();
 }
 
-void Action::ackHandlerEntry(void* resultHandlerData, int /*compId*/, const mavlink_command_ack_t& ack, Vehicle::MavCmdResultFailureCode_t failureCode)
+void Action::ackHandlerEntry(void* resultHandlerData, int /*compId*/, const mavlink_command_ack_t& ack, VehicleTypes::MavCmdResultFailureCode_t failureCode)
 {
     Action* action = (Action*)resultHandlerData;
     action->ackHandler(static_cast<MAV_RESULT>(ack.result), failureCode);
 }
 
-void Action::ackHandler(MAV_RESULT commandResult, Vehicle::MavCmdResultFailureCode_t failureCode)
+void Action::ackHandler(MAV_RESULT commandResult, VehicleTypes::MavCmdResultFailureCode_t failureCode)
 {
     _commandInProgress = false;
-    if (failureCode != Vehicle::MavCmdResultFailureNoResponseToCommand && commandResult != MAV_RESULT_ACCEPTED) {
+    if (failureCode != VehicleTypes::MavCmdResultFailureNoResponseToCommand && commandResult != MAV_RESULT_ACCEPTED) {
         qgcApp()->showAppMessage(tr("Actuator action command failed"));
     }
 }

--- a/src/Vehicle/Actuators/ActuatorActions.h
+++ b/src/Vehicle/Actuators/ActuatorActions.h
@@ -1,8 +1,11 @@
 #pragma once
 
 #include "Common.h"
-#include "Vehicle.h"
+#include "VehicleTypes.h"
+#include "MAVLinkLib.h"
 #include "QmlObjectListModel.h"
+
+class Vehicle;
 
 #include <QtCore/QObject>
 #include <QtCore/QString>
@@ -39,8 +42,8 @@ public:
     Q_INVOKABLE void trigger();
 
 private:
-    static void ackHandlerEntry(void* resultHandlerData, int compId, const mavlink_command_ack_t& ack, Vehicle::MavCmdResultFailureCode_t failureCode);
-    void ackHandler(MAV_RESULT commandResult, Vehicle::MavCmdResultFailureCode_t failureCode);
+    static void ackHandlerEntry(void* resultHandlerData, int compId, const mavlink_command_ack_t& ack, VehicleTypes::MavCmdResultFailureCode_t failureCode);
+    void ackHandler(MAV_RESULT commandResult, VehicleTypes::MavCmdResultFailureCode_t failureCode);
     void sendMavlinkRequest();
 
     const QString _label;

--- a/src/Vehicle/Actuators/ActuatorTesting.cc
+++ b/src/Vehicle/Actuators/ActuatorTesting.cc
@@ -1,6 +1,7 @@
 #include "ActuatorTesting.h"
 #include "Common.h"
 #include "QGCApplication.h"
+#include "Vehicle.h"
 
 using namespace ActuatorTesting;
 
@@ -110,17 +111,17 @@ void ActuatorTest::setActive(bool active)
     _active = active;
 }
 
-void ActuatorTest::ackHandlerEntry(void* resultHandlerData, int /*compId*/, const mavlink_command_ack_t& ack, Vehicle::MavCmdResultFailureCode_t failureCode)
+void ActuatorTest::ackHandlerEntry(void* resultHandlerData, int /*compId*/, const mavlink_command_ack_t& ack, VehicleTypes::MavCmdResultFailureCode_t failureCode)
 {
     ActuatorTest* actuatorTest = (ActuatorTest*)resultHandlerData;
     actuatorTest->ackHandler(static_cast<MAV_RESULT>(ack.result), failureCode);
 }
 
-void ActuatorTest::ackHandler(MAV_RESULT commandResult, Vehicle::MavCmdResultFailureCode_t failureCode)
+void ActuatorTest::ackHandler(MAV_RESULT commandResult, VehicleTypes::MavCmdResultFailureCode_t failureCode)
 {
     // upon receiving an (n)ack, continuously cycle through the active actuators, one at a time
     _commandInProgress = false;
-    if (failureCode == Vehicle::MavCmdResultFailureNoResponseToCommand) {
+    if (failureCode == VehicleTypes::MavCmdResultFailureNoResponseToCommand) {
         // on timeout, just try the next one
         sendNext();
     } else if (commandResult == MAV_RESULT_ACCEPTED) {

--- a/src/Vehicle/Actuators/ActuatorTesting.h
+++ b/src/Vehicle/Actuators/ActuatorTesting.h
@@ -2,11 +2,13 @@
 
 
 #include "QmlObjectListModel.h"
-#include "Vehicle.h"
+#include "VehicleTypes.h"
 #include "MAVLinkLib.h"
 #include <QtCore/QObject>
 #include <QtCore/QString>
 #include <QtCore/QTimer>
+
+class Vehicle;
 
 namespace ActuatorTesting {
 
@@ -100,8 +102,8 @@ private:
 
     void resetStates();
 
-    static void ackHandlerEntry(void* resultHandlerData, int compId, const mavlink_command_ack_t& ack, Vehicle::MavCmdResultFailureCode_t failureCode);
-    void ackHandler(MAV_RESULT commandResult, Vehicle::MavCmdResultFailureCode_t failureCode);
+    static void ackHandlerEntry(void* resultHandlerData, int compId, const mavlink_command_ack_t& ack, VehicleTypes::MavCmdResultFailureCode_t failureCode);
+    void ackHandler(MAV_RESULT commandResult, VehicleTypes::MavCmdResultFailureCode_t failureCode);
     void sendMavlinkRequest(int function, float value, float timeout);
 
     void sendNext();

--- a/src/Vehicle/Actuators/MotorAssignment.cc
+++ b/src/Vehicle/Actuators/MotorAssignment.cc
@@ -2,6 +2,7 @@
 #include "QGCApplication.h"
 #include "ActuatorOutputs.h"
 #include "QmlObjectListModel.h"
+#include "Vehicle.h"
 
 #include <vector>
 
@@ -188,16 +189,16 @@ void MotorAssignment::spinTimeout()
     spinCurrentMotor();
 }
 
-void MotorAssignment::ackHandlerEntry(void* resultHandlerData, int /*compId*/, const mavlink_command_ack_t& ack, Vehicle::MavCmdResultFailureCode_t failureCode)
+void MotorAssignment::ackHandlerEntry(void* resultHandlerData, int /*compId*/, const mavlink_command_ack_t& ack, VehicleTypes::MavCmdResultFailureCode_t failureCode)
 {
     MotorAssignment* motorAssignment = (MotorAssignment*)resultHandlerData;
     motorAssignment->ackHandler(static_cast<MAV_RESULT>(ack.result), failureCode);
 }
 
-void MotorAssignment::ackHandler(MAV_RESULT commandResult, Vehicle::MavCmdResultFailureCode_t failureCode)
+void MotorAssignment::ackHandler(MAV_RESULT commandResult, VehicleTypes::MavCmdResultFailureCode_t failureCode)
 {
     _commandInProgress = false;
-    if (failureCode != Vehicle::MavCmdResultFailureNoResponseToCommand && commandResult != MAV_RESULT_ACCEPTED) {
+    if (failureCode != VehicleTypes::MavCmdResultFailureNoResponseToCommand && commandResult != MAV_RESULT_ACCEPTED) {
         abort();
         qgcApp()->showAppMessage(tr("Actuator test command failed"));
     }

--- a/src/Vehicle/Actuators/MotorAssignment.h
+++ b/src/Vehicle/Actuators/MotorAssignment.h
@@ -1,12 +1,15 @@
 #pragma once
 
-#include "Vehicle.h"
+#include "VehicleTypes.h"
+#include "MAVLinkLib.h"
 
 #include <QtCore/QObject>
 #include <QtCore/QString>
 #include <QtCore/QTimer>
 
+class Fact;
 class QmlObjectListModel;
+class Vehicle;
 
 /**
  * Handles automatic motor ordering assignment by spinning individual motors, and then having the user
@@ -53,8 +56,8 @@ private:
     static constexpr int _spinTimeoutDefaultSec = 1000;
     static constexpr int _spinTimeoutHighSec = 3000; ///< wait a bit longer after assigning motors, so ESCs can initialize
 
-    static void ackHandlerEntry(void* resultHandlerData, int compId, const mavlink_command_ack_t& ack, Vehicle::MavCmdResultFailureCode_t failureCode);
-    void ackHandler(MAV_RESULT commandResult, Vehicle::MavCmdResultFailureCode_t failureCode);
+    static void ackHandlerEntry(void* resultHandlerData, int compId, const mavlink_command_ack_t& ack, VehicleTypes::MavCmdResultFailureCode_t failureCode);
+    void ackHandler(MAV_RESULT commandResult, VehicleTypes::MavCmdResultFailureCode_t failureCode);
     void sendMavlinkRequest(int function, float value);
 
     enum class State {

--- a/src/Vehicle/Autotune.cpp
+++ b/src/Vehicle/Autotune.cpp
@@ -1,5 +1,6 @@
 #include "Autotune.h"
 #include "QGCApplication.h"
+#include "Vehicle.h"
 
 //-----------------------------------------------------------------------------
 Autotune::Autotune(Vehicle *vehicle) :
@@ -26,7 +27,7 @@ void Autotune::autotuneRequest()
 
 
 //-----------------------------------------------------------------------------
-void Autotune::ackHandler(void* resultHandlerData, int compId, const mavlink_command_ack_t& ack, Vehicle::MavCmdResultFailureCode_t failureCode)
+void Autotune::ackHandler(void* resultHandlerData, int compId, const mavlink_command_ack_t& ack, VehicleTypes::MavCmdResultFailureCode_t failureCode)
 {
     Q_UNUSED(compId);
     Q_UNUSED(failureCode);

--- a/src/Vehicle/Autotune.h
+++ b/src/Vehicle/Autotune.h
@@ -3,8 +3,10 @@
 #include <QtCore/QTimer>
 #include <QtQmlIntegration/QtQmlIntegration>
 
-#include "Vehicle.h"
+#include "VehicleTypes.h"
 #include "MAVLinkLib.h"
+
+class Vehicle;
 
 class Autotune : public QObject
 {
@@ -21,7 +23,7 @@ public:
 
     Q_INVOKABLE void autotuneRequest ();
 
-    static void ackHandler      (void* resultHandlerData,   int compId, const mavlink_command_ack_t& ack, Vehicle::MavCmdResultFailureCode_t failureCode);
+    static void ackHandler      (void* resultHandlerData,   int compId, const mavlink_command_ack_t& ack, VehicleTypes::MavCmdResultFailureCode_t failureCode);
     static void progressHandler (void* progressHandlerData, int compId, const mavlink_command_ack_t& ack);
 
     bool      autotuneInProgress () { return _autotuneInProgress; }

--- a/src/Vehicle/CMakeLists.txt
+++ b/src/Vehicle/CMakeLists.txt
@@ -33,6 +33,7 @@ target_sources(${CMAKE_PROJECT_NAME}
         VehicleObjectAvoidance.h
         VehicleSupports.cc
         VehicleSupports.h
+        VehicleTypes.h
 )
 
 target_include_directories(${CMAKE_PROJECT_NAME} PRIVATE ${CMAKE_CURRENT_SOURCE_DIR})

--- a/src/Vehicle/ComponentInformation/CompInfo.h
+++ b/src/Vehicle/ComponentInformation/CompInfo.h
@@ -1,6 +1,6 @@
 #pragma once
 
-#include "MAVLinkLib.h"
+#include "MAVLinkEnums.h"
 
 #include <QtCore/QObject>
 

--- a/src/Vehicle/ComponentInformation/CompInfoParam.h
+++ b/src/Vehicle/ComponentInformation/CompInfoParam.h
@@ -1,7 +1,7 @@
 #pragma once
 
 #include "CompInfo.h"
-#include "MAVLinkLib.h"
+#include "MAVLinkEnums.h"
 #include "FactMetaData.h"
 
 #include <QtCore/QLoggingCategory>

--- a/src/Vehicle/ComponentInformation/ComponentInformationManager.h
+++ b/src/Vehicle/ComponentInformation/ComponentInformationManager.h
@@ -1,6 +1,6 @@
 #pragma once
 
-#include "MAVLinkLib.h"
+#include "MAVLinkEnums.h"
 #include "QGCStateMachine.h"
 #include "RequestMetaDataTypeStateMachine.h"
 

--- a/src/Vehicle/ComponentInformation/RequestMetaDataTypeStateMachine.cc
+++ b/src/Vehicle/ComponentInformation/RequestMetaDataTypeStateMachine.cc
@@ -306,7 +306,7 @@ void RequestMetaDataTypeStateMachine::_requestCompInfoDeprecated()
     );
 }
 
-void RequestMetaDataTypeStateMachine::_handleCompInfoResult(MAV_RESULT result, Vehicle::RequestMessageResultHandlerFailureCode_t failureCode, const mavlink_message_t& message)
+void RequestMetaDataTypeStateMachine::_handleCompInfoResult(MAV_RESULT result, VehicleTypes::RequestMessageResultHandlerFailureCode_t failureCode, const mavlink_message_t& message)
 {
     if (result == MAV_RESULT_ACCEPTED) {
         mavlink_component_information_t componentInformation;

--- a/src/Vehicle/ComponentInformation/RequestMetaDataTypeStateMachine.h
+++ b/src/Vehicle/ComponentInformation/RequestMetaDataTypeStateMachine.h
@@ -1,7 +1,9 @@
 #pragma once
 
 #include "QGCStateMachine.h"
-#include "MAVLinkLib.h"
+#include "MAVLinkEnums.h"
+#include "MAVLinkMessageType.h"
+#include "VehicleTypes.h"
 
 #include <QtCore/QElapsedTimer>
 #include <QtCore/QLoggingCategory>
@@ -67,7 +69,7 @@ private:
 
     // Message result handlers
     void _handleCompMetadataResult(MAV_RESULT result, const mavlink_message_t& message);
-    void _handleCompInfoResult(MAV_RESULT result, Vehicle::RequestMessageResultHandlerFailureCode_t failureCode, const mavlink_message_t& message);
+    void _handleCompInfoResult(MAV_RESULT result, VehicleTypes::RequestMessageResultHandlerFailureCode_t failureCode, const mavlink_message_t& message);
 
 private slots:
     void _ftpDownloadComplete(const QString& file, const QString& errorMsg);

--- a/src/Vehicle/InitialConnectStateMachine.cc
+++ b/src/Vehicle/InitialConnectStateMachine.cc
@@ -1,4 +1,5 @@
 #include "InitialConnectStateMachine.h"
+#include "MAVLinkLib.h"
 #include "Vehicle.h"
 #include "QGCCorePlugin.h"
 #include "QGCOptions.h"

--- a/src/Vehicle/InitialConnectStateMachine.h
+++ b/src/Vehicle/InitialConnectStateMachine.h
@@ -1,7 +1,7 @@
 #pragma once
 
 #include "QGCStateMachine.h"
-#include "MAVLinkLib.h"
+#include "MAVLinkMessageType.h"
 
 #include <QtCore/QLoggingCategory>
 

--- a/src/Vehicle/RemoteIDManager.cc
+++ b/src/Vehicle/RemoteIDManager.cc
@@ -1,4 +1,5 @@
 #include "RemoteIDManager.h"
+#include "MAVLinkLib.h"
 #include "SettingsManager.h"
 #include "RemoteIDSettings.h"
 #include "PositionManager.h"

--- a/src/Vehicle/RemoteIDManager.h
+++ b/src/Vehicle/RemoteIDManager.h
@@ -7,7 +7,7 @@
 #include <QtPositioning/QGeoPositionInfo>
 #include <QtQmlIntegration/QtQmlIntegration>
 
-#include "MAVLinkLib.h"
+#include "MAVLinkMessageType.h"
 
 Q_DECLARE_LOGGING_CATEGORY(RemoteIDManagerLog)
 

--- a/src/Vehicle/StandardModes.h
+++ b/src/Vehicle/StandardModes.h
@@ -1,7 +1,8 @@
 #pragma once
 
 #include "FirmwarePlugin.h"
-#include "MAVLinkLib.h"
+#include "MAVLinkEnums.h"
+#include "MAVLinkMessageType.h"
 
 #include <QtCore/QObject>
 #include <QtCore/QString>

--- a/src/Vehicle/Vehicle.h
+++ b/src/Vehicle/Vehicle.h
@@ -19,6 +19,7 @@
 #include "SysStatusSensorInfo.h"
 #include "VehicleFactGroup.h"
 #include "VehicleLinkManager.h"
+#include "VehicleTypes.h"
 
 class Actuators;
 class AutoPilotPlugin;
@@ -77,7 +78,7 @@ class ParsedEvent;
 
 Q_DECLARE_LOGGING_CATEGORY(VehicleLog)
 
-class Vehicle : public VehicleFactGroup
+class Vehicle : public VehicleFactGroup, public VehicleTypes
 {
     Q_OBJECT
     QML_ELEMENT
@@ -616,12 +617,6 @@ public:
     /// Same as sendMavCommand but available from Qml.
     Q_INVOKABLE void sendCommand(int compId, int command, bool showError, double param1 = 0.0, double param2 = 0.0, double param3 = 0.0, double param4 = 0.0, double param5 = 0.0, double param6 = 0.0, double param7 = 0.0);
 
-    typedef enum {
-        MavCmdResultCommandResultOnly,          ///< commandResult specifies full success/fail info
-        MavCmdResultFailureNoResponseToCommand, ///< No response from vehicle to command
-        MavCmdResultFailureDuplicateCommand,    ///< Unable to send command since duplicate is already being waited on for response
-    } MavCmdResultFailureCode_t;
-
     static QString mavCmdResultFailureCodeToString(MavCmdResultFailureCode_t failureCode);
 
     /// Callback for sendMavCommandWithHandler which handles MAV_RESULT_IN_PROGRESS acks
@@ -666,14 +661,6 @@ public:
         float param1 = 0.0f, float param2 = 0.0f, float param3 = 0.0f, float param4 = 0.0f, float param5 = 0.0f, float param6 = 0.0f, float param7 = 0.0f);
 
 
-    typedef enum {
-        RequestMessageNoFailure,
-        RequestMessageFailureCommandError,
-        RequestMessageFailureCommandNotAcked,
-        RequestMessageFailureMessageNotReceived,
-        RequestMessageFailureDuplicate,           ///< Exact duplicate request already active or queued for this component/message id
-    } RequestMessageResultHandlerFailureCode_t;
-
     static QString requestMessageResultHandlerFailureCodeToString(RequestMessageResultHandlerFailureCode_t failureCode);
 
     /// Callback for requestMessage
@@ -700,7 +687,7 @@ public:
     QString firmwareVersionTypeString() const;
     void setFirmwareVersion(int majorVersion, int minorVersion, int patchVersion, FIRMWARE_VERSION_TYPE versionType = FIRMWARE_VERSION_TYPE_OFFICIAL);
     void setFirmwareCustomVersion(int majorVersion, int minorVersion, int patchVersion);
-    static const int versionNotSetValue = -1;
+    // versionNotSetValue inherited from VehicleTypes
 
     QString gitHash() const { return _gitHash; }
     quint64 vehicleUID() const { return _uid; }

--- a/src/Vehicle/VehicleLinkManager.cc
+++ b/src/Vehicle/VehicleLinkManager.cc
@@ -1,4 +1,5 @@
 #include "VehicleLinkManager.h"
+#include "MAVLinkLib.h"
 #include "Vehicle.h"
 #include "LinkManager.h"
 #include "QGCApplication.h"

--- a/src/Vehicle/VehicleLinkManager.h
+++ b/src/Vehicle/VehicleLinkManager.h
@@ -7,7 +7,7 @@
 #include <QtQmlIntegration/QtQmlIntegration>
 
 #include "LinkInterface.h"
-#include "MAVLinkLib.h"
+#include "MAVLinkMessageType.h"
 
 Q_DECLARE_LOGGING_CATEGORY(VehicleLinkManagerLog)
 

--- a/src/Vehicle/VehicleTypes.h
+++ b/src/Vehicle/VehicleTypes.h
@@ -1,0 +1,29 @@
+#pragma once
+
+/// @file VehicleTypes.h
+/// Lightweight header containing types extracted from the Vehicle class.
+/// Including this instead of the full Vehicle.h avoids pulling in the 1400+
+/// line Vehicle class and all its transitive includes, which significantly
+/// reduces moc parse time for headers that only need these definitions.
+///
+/// Vehicle inherits from VehicleTypes so that existing code using
+/// Vehicle::MavCmdResultFailureCode_t etc. continues to work unchanged.
+
+struct VehicleTypes
+{
+    typedef enum {
+        MavCmdResultCommandResultOnly,          ///< commandResult specifies full success/fail info
+        MavCmdResultFailureNoResponseToCommand, ///< No response from vehicle to command
+        MavCmdResultFailureDuplicateCommand,    ///< Unable to send command since duplicate is already being waited on for response
+    } MavCmdResultFailureCode_t;
+
+    typedef enum {
+        RequestMessageNoFailure,
+        RequestMessageFailureCommandError,
+        RequestMessageFailureCommandNotAcked,
+        RequestMessageFailureMessageNotReceived,
+        RequestMessageFailureDuplicate,           ///< Exact duplicate request already active or queued for this component/message id
+    } RequestMessageResultHandlerFailureCode_t;
+
+    static const int versionNotSetValue = -1;
+};

--- a/test/MissionManager/MissionCommandTreeEditorTest.cc
+++ b/test/MissionManager/MissionCommandTreeEditorTest.cc
@@ -12,8 +12,8 @@
 #include "SettingsManager.h"
 #include "SimpleMissionItem.h"
 
-void MissionCommandTreeEditorTest::_testEditorsWorker(QGCMAVLink::FirmwareClass_t firmwareClass,
-                                                      QGCMAVLink::VehicleClass_t vehicleClass)
+void MissionCommandTreeEditorTest::_testEditorsWorker(QGCMAVLinkTypes::FirmwareClass_t firmwareClass,
+                                                      QGCMAVLinkTypes::VehicleClass_t vehicleClass)
 {
     QString firmwareClassString = QGCMAVLink::firmwareClassToString(firmwareClass).replace(" ", "");
     QString vehicleClassString = QGCMAVLink::vehicleClassToUserVisibleString(vehicleClass).replace(" ", "");

--- a/test/MissionManager/MissionCommandTreeEditorTest.h
+++ b/test/MissionManager/MissionCommandTreeEditorTest.h
@@ -1,6 +1,6 @@
 #pragma once
 
-#include "QGCMAVLink.h"
+#include "QGCMAVLinkTypes.h"
 #include "UnitTest.h"
 
 /// This unit test is meant to be used stand-alone to generate images for each mission item editor for review
@@ -12,5 +12,5 @@ private slots:
     void testEditors();
 
 private:
-    void _testEditorsWorker(QGCMAVLink::FirmwareClass_t firmwareClass, QGCMAVLink::VehicleClass_t vehicleClass);
+    void _testEditorsWorker(QGCMAVLinkTypes::FirmwareClass_t firmwareClass, QGCMAVLinkTypes::VehicleClass_t vehicleClass);
 };

--- a/test/MissionManager/SimpleMissionItemTest.cc
+++ b/test/MissionManager/SimpleMissionItemTest.cc
@@ -40,13 +40,13 @@ void SimpleMissionItemTest::cleanup()
     _simpleItem = nullptr;
 }
 
-bool SimpleMissionItemTest::_classMatch(QGCMAVLink::VehicleClass_t vehicleClass, QGCMAVLink::VehicleClass_t testClass)
+bool SimpleMissionItemTest::_classMatch(QGCMAVLinkTypes::VehicleClass_t vehicleClass, QGCMAVLinkTypes::VehicleClass_t testClass)
 {
     return vehicleClass == QGCMAVLink::VehicleClassGeneric || vehicleClass == testClass;
 }
 
-void SimpleMissionItemTest::_testEditorFactsWorker(QGCMAVLink::VehicleClass_t vehicleClass,
-                                                   QGCMAVLink::VehicleClass_t vtolMode)
+void SimpleMissionItemTest::_testEditorFactsWorker(QGCMAVLinkTypes::VehicleClass_t vehicleClass,
+                                                   QGCMAVLinkTypes::VehicleClass_t vtolMode)
 {
     TEST_DEBUG(QStringLiteral("vehicleClass:vtolMode %1 %2")
                    .arg(QGCMAVLink::vehicleClassToUserVisibleString(vehicleClass),

--- a/test/MissionManager/SimpleMissionItemTest.h
+++ b/test/MissionManager/SimpleMissionItemTest.h
@@ -1,6 +1,6 @@
 #pragma once
 
-#include "QGCMAVLink.h"
+#include "QGCMAVLinkTypes.h"
 #include "QGroundControlQmlGlobal.h"
 #include "MultiSignalSpy.h"
 #include "VisualMissionItemTest.h"
@@ -31,8 +31,8 @@ private slots:
     void _testCalcAboveTerrainSaveLoad();
 
 private:
-    void _testEditorFactsWorker(QGCMAVLink::VehicleClass_t vehicleClass, QGCMAVLink::VehicleClass_t vtolMode);
-    bool _classMatch(QGCMAVLink::VehicleClass_t vehicleClass, QGCMAVLink::VehicleClass_t testClass);
+    void _testEditorFactsWorker(QGCMAVLinkTypes::VehicleClass_t vehicleClass, QGCMAVLinkTypes::VehicleClass_t vtolMode);
+    bool _classMatch(QGCMAVLinkTypes::VehicleClass_t vehicleClass, QGCMAVLinkTypes::VehicleClass_t testClass);
 
     SimpleMissionItem* _simpleItem = nullptr;
     std::unique_ptr<MultiSignalSpy> _spySimpleItem;

--- a/test/UnitTestFramework/BaseClasses/MissionTest.h
+++ b/test/UnitTestFramework/BaseClasses/MissionTest.h
@@ -1,6 +1,5 @@
 #pragma once
 
-#include "MAVLinkLib.h"
 #include "UnitTest.h"
 #include "VehicleTest.h"
 

--- a/test/Utilities/StateMachine/states/RequestMessageStateTest.cc
+++ b/test/Utilities/StateMachine/states/RequestMessageStateTest.cc
@@ -2,6 +2,7 @@
 #include "StateTestCommon.h"
 
 #include "RequestMessageState.h"
+#include "Vehicle.h"
 
 
 void RequestMessageStateTest::_testStateCreation()

--- a/test/Utilities/StateMachine/states/RetryableRequestMessageStateTest.cc
+++ b/test/Utilities/StateMachine/states/RetryableRequestMessageStateTest.cc
@@ -1,4 +1,5 @@
 #include "RetryableRequestMessageStateTest.h"
+#include "MAVLinkLib.h"
 #include "StateTestCommon.h"
 
 #include "QGCStateMachine.h"

--- a/test/Utilities/StateMachine/states/RetryableRequestMessageStateTest.h
+++ b/test/Utilities/StateMachine/states/RetryableRequestMessageStateTest.h
@@ -1,7 +1,6 @@
 #pragma once
 
 #include "VehicleTestManualConnect.h"
-#include "MAVLinkLib.h"
 #include "Vehicle.h"
 
 /// Tests for RetryableRequestMessageState


### PR DESCRIPTION
## Summary

Replace heavy `MAVLinkLib.h` (~180,000 preprocessed lines) with targeted lightweight headers in files that only need enums or base types. This reduces total moc parse time across all 550 headers by **273 seconds (60%)**.

## Measured Results

| Metric | Before | After | Change |
|--------|--------|-------|--------|
| **Total moc time** | **457.9s** | **184.5s** | **-273s (60%)** |
| Slow headers (>100ms) | 182 | 71 | -111 |
| Fast headers (<20ms) | 367 | 452 | +85 |

Timing methodology: single-pass `moc --output-dep-file /dev/null` across all 550 `.h` files in `src/` and `test/`, using include paths from `compile_commands.json`.

## Approach

The root cause was `MAVLinkLib.h` pulling in all 387 MAVLink message headers (~180k preprocessed lines) through every header that needed even a single MAVLink enum. Most headers only need enums (`MAV_CMD`, `MAV_TYPE`, etc.) or the `mavlink_message_t` base type — not the full message pack/unpack machinery.

### New lightweight headers

| Header | Contents | Preprocessed lines |
|--------|----------|--------------------|
| `MAVLinkEnums.h` (build-generated) | All 253 MAVLink enum typedefs | ~5,500 |
| `MAVLinkMessageType.h` | `mavlink_message_t`, `mavlink_channel_t`, base types | ~2,700 |
| `QGCMAVLinkTypes.h` | `FirmwareClass_t`, `VehicleClass_t`, `maxRcChannels` | ~50 |
| `VehicleTypes.h` | `MavCmdResultFailureCode_t`, `RequestMessageResultHandlerFailureCode_t` | ~30 |

### Header migration

- **25 headers** switched from `MAVLinkLib.h` or `QGCMAVLink.h` to `MAVLinkEnums.h` and/or `MAVLinkMessageType.h`
- **6 headers** switched from `QGCMAVLink.h` to `QGCMAVLinkTypes.h`
- **8 headers** switched from `Vehicle.h` to `VehicleTypes.h` + forward declaration
- **`QGCMAVLink.h`** itself switched from `MAVLinkLib.h` to `MAVLinkEnums.h` + `MAVLinkMessageType.h` (biggest single impact — 18 direct + 61 transitive includers)

### Build-generated `MAVLinkEnums.h`

`cmake/GenerateMAVLinkEnums.py` extracts enum typedef sections from all 19 MAVLink dialect headers (text between `// ENUM DEFINITIONS` and `// MESSAGE DEFINITIONS` markers). The CMake custom command runs after the MAVLink CPM package is fetched and only regenerates when content changes.

### Backward compatibility

`Vehicle` inherits from `VehicleTypes` and `QGCMAVLink` inherits from `QGCMAVLinkTypes`, so all existing code using `Vehicle::MavCmdResultFailureCode_t` or `QGCMAVLink::VehicleClass_t` etc. continues to work unchanged. The PCH still includes `MAVLinkLib.h` for `.cc` file compilation.

## Remaining slow headers

The remaining 71 slow headers all trace back to 16 Tier 3 headers that still need `MAVLinkLib.h` because they use specific message struct types (`mavlink_command_long_t`, `mavlink_file_transfer_protocol_t`, etc.) in their declarations. These could be addressed in a follow-up.
