### PR TITLE
ArduPlane: Add RTL_RADIUS and RTL_AUTOLAND to Flight Safety page

### DIFF
--- a/src/AutoPilotPlugins/APM/VehicleConfig/APMFlightSafety.VehicleConfig.json
+++ b/src/AutoPilotPlugins/APM/VehicleConfig/APMFlightSafety.VehicleConfig.json
@@ -126,6 +126,23 @@
                     "label": "Return altitude",
                     "optional": true,
                     "enableWhen": "_planeRtlAltFact && _planeRtlAltFact.value >= 0"
+                },
+                {
+                    "param": "RTL_RADIUS",
+                    "label": "Loiter radius",
+                    "optional": true
+                },
+                {
+                    "control": "label",
+                    "label": "0 = use Waypoint Loiter Radius (WP_LOITER_RAD), negative = counter-clockwise",
+                    "indent": true,
+                    "smallFont": true
+                },
+                {
+                    "param": "RTL_AUTOLAND",
+                    "label": "Auto land after RTL",
+                    "optional": true,
+                    "control": "combobox"
                 }
             ]
         },

--- a/tools/generators/common/controls.py
+++ b/tools/generators/common/controls.py
@@ -90,6 +90,7 @@ def render_label(
     *,
     text: str = "",
     warning: bool = False,
+    small_font: bool = False,
     tr_context: str = "",
 ) -> str:
     """Render a static ``QGCLabel`` (no fact binding)."""
@@ -98,6 +99,8 @@ def render_label(
     lines.append(f"{indent}    wrapMode: Text.WordWrap")
     lines.append(f"{indent}    Layout.fillWidth: true")
     lines.append(f"{indent}    Layout.preferredWidth: 0")
+    if small_font:
+        lines.append(f"{indent}    font.pointSize: ScreenTools.smallFontPointSize")
     if warning:
         lines.append(f"{indent}    color: qgcPal.warningText")
     lines.append(f"{indent}}}")

--- a/tools/generators/config_qml/page_generator.py
+++ b/tools/generators/config_qml/page_generator.py
@@ -67,6 +67,7 @@ class ControlDef:
     firstEntryIsAll: bool = False                    # bitmask: first entry is "all" toggle
     toggleCheckbox: ToggleCheckboxDef | None = None  # toggleCheckbox: custom checked/onClicked
     indent: bool = False                              # indent control with left margin
+    smallFont: bool = False                           # label: use small font size
 
 
 @dataclass
@@ -168,6 +169,7 @@ def load_page_def(json_path: Path) -> PageDef:
                 firstEntryIsAll=ctrl_data.get("firstEntryIsAll", False),
                 toggleCheckbox=parse_toggle_checkbox(ctrl_data.get("toggleCheckbox")),
                 indent=ctrl_data.get("indent", False),
+                smallFont=ctrl_data.get("smallFont", False),
             ))
         repeat_data = sec_data.get("repeat")
         repeat_def = None
@@ -339,6 +341,7 @@ def _qml_control(ctrl: ControlDef, indent: str, *, indexed: bool = False, dialog
             indent,
             text=ctrl.label,
             warning=ctrl.warning,
+            small_font=ctrl.smallFont,
             tr_context=tr_context,
         )
         if ctrl.showWhen:


### PR DESCRIPTION
## Summary

Add **RTL_RADIUS** (loiter radius) and **RTL_AUTOLAND** (auto land after RTL) to the fixed-wing Return to Launch section of the Flight Safety config page.

Also adds `smallFont` support to the config QML generator's label control, used here for a helper note below RTL_RADIUS explaining that 0 uses WP_LOITER_RAD and negative values mean counter-clockwise.

## Changes

- **APMFlightSafety.VehicleConfig.json**: Add RTL_RADIUS (textfield), helper label (small font, indented), and RTL_AUTOLAND (combobox) to the fixedWing RTL section
- **tools/generators/common/controls.py**: Add `small_font` parameter to `render_label()` — emits `font.pointSize: ScreenTools.smallFontPointSize` when true
- **tools/generators/config_qml/page_generator.py**: Add `smallFont` field to `ControlDef`, wire JSON parsing and label rendering

Closes #14198
