### PR TITLE
Tune PID tuning layout sizing

### DIFF
--- a/src/AutoPilotPlugins/APM/APMAdvancedTuningCopterComponent.qml
+++ b/src/AutoPilotPlugins/APM/APMAdvancedTuningCopterComponent.qml
@@ -19,7 +19,9 @@ SetupPage {
             FactPanelController { id: controller }
 
             PIDTuning {
-                Layout.fillWidth: true
+                id: pidTuning
+                availableWidth:     pidTuningPage.availableWidth
+                availableHeight:    pidTuningPage.availableHeight - pidTuning.y
 
                 property var roll: QtObject {
                     property string name: qsTr("Roll")

--- a/src/QmlControls/PIDTuning.qml
+++ b/src/QmlControls/PIDTuning.qml
@@ -170,6 +170,7 @@ RowLayout {
 
     Column {
         id:                 leftPanel
+        Layout.fillWidth:   true
         Layout.alignment:   Qt.AlignTop
         spacing:            ScreenTools.defaultFontPixelHeight / 4
         clip:               true // chart has redraw problems


### PR DESCRIPTION
## Summary
- replace APM copter PID tuning embedding from layout-only width fill to explicit PIDTuning size bindings
- pass availableWidth/availableHeight through to PIDTuning in the APM tuning component
- allow both PIDTuning panels to participate in RowLayout width distribution

## Testing
- not run (QML-only layout change)