### PR TITLE
fix(signing): handle SETUP_SIGNING rejection to prevent communication loss

### DIFF
--- a/src/Vehicle/Vehicle.cc
+++ b/src/Vehicle/Vehicle.cc
@@ -142,6 +142,11 @@ Vehicle::Vehicle(LinkInterface*             link,
     _prearmErrorTimer.setInterval(_prearmErrorTimeoutMSecs);
     _prearmErrorTimer.setSingleShot(true);
 
+    // Signing confirmation timer
+    _signingConfirmationTimer.setSingleShot(true);
+    _signingConfirmationTimer.setInterval(kSigningConfirmationTimeoutMs);
+    connect(&_signingConfirmationTimer, &QTimer::timeout, this, &Vehicle::_signingConfirmationTimeout);
+
     // Send MAV_CMD ack timer
     _mavCommandResponseCheckTimer.setSingleShot(false);
     _mavCommandResponseCheckTimer.setInterval(_mavCommandResponseCheckTimeoutMSecs());
@@ -1431,6 +1436,11 @@ void Vehicle::_handleHeartbeat(mavlink_message_t& message)
         if (previousFlightMode != flightMode()) {
             emit flightModeChanged(flightMode());
         }
+    }
+
+    // A heartbeat from the vehicle while signing setup is pending means the vehicle accepted
+    if (_isSigningPending()) {
+        _confirmSigningSetup();
     }
 }
 
@@ -4548,6 +4558,14 @@ void Vehicle::_textMessageReceived(MAV_COMPONENT componentid, MAV_SEVERITY sever
         return;
     }
 
+    // Detect signing rejection from vehicle while a signing change is pending
+    if (_isSigningPending() && severity <= MAV_SEVERITY_WARNING) {
+        const QString lower = text.toLower();
+        if (lower.contains(QStringLiteral("signing")) && (lower.contains(QStringLiteral("reject")) || lower.contains(QStringLiteral("denied")) || lower.contains(QStringLiteral("fail")))) {
+            _cancelPendingSigning(tr("Vehicle rejected signing request: %1").arg(text));
+        }
+    }
+
     bool skipSpoken = false;
     const bool ardupilotPrearm = text.startsWith(QStringLiteral("PreArm"));
     const bool px4Prearm = text.startsWith(QStringLiteral("preflight"), Qt::CaseInsensitive) && (severity >= MAV_SEVERITY::MAV_SEVERITY_CRITICAL);
@@ -4622,23 +4640,24 @@ void Vehicle::sendSetupSigning(int keyIndex)
 
     MAVLinkSigning::createSetupSigning(channel, target_system, keyBytes, setup_signing);
 
-    // Also configure signing on our channel with this key so outgoing packets are signed
-    if (!MAVLinkSigning::initSigning(channel, keyBytes, MAVLinkSigning::insecureConnectionAcceptUnsignedCallback)) {
-        qCCritical(VehicleLog) << "Internal error: failed to initialize signing on channel" << channel;
-        return;
-    }
-
-    _mavlinkSigning = true;
-    _mavlinkSigningKeyName = MAVLinkSigningKeys::instance()->keyNameAt(keyIndex);
-    emit mavlinkSigningChanged();
-
     mavlink_message_t msg;
     (void) mavlink_msg_setup_signing_encode_chan(MAVLinkProtocol::instance()->getSystemId(), MAVLinkProtocol::getComponentId(), channel, &msg, &setup_signing);
 
-    // Since we don't get an ack back that the message was received send twice to try to make sure it makes it to the vehicle
+    // Send the SETUP_SIGNING message FIRST (unsigned) before enabling local signing.
+    // This avoids the bug where if the vehicle rejects the key, QGC would already be
+    // signing with a key the vehicle does not have, causing communication loss.
     for (uint8_t i = 0; i < 2; ++i) {
         sendMessageOnLinkThreadSafe(sharedLink.get(), msg);
     }
+
+    // Store pending state and wait for vehicle confirmation (heartbeat) or rejection (STATUSTEXT)
+    _pendingSigningKeyIndex = keyIndex;
+    _pendingSigningKeyBytes = keyBytes;
+    _pendingSigningChannel = channel;
+    _pendingSigningDisable = false;
+    _signingConfirmationTimer.start();
+
+    qCDebug(VehicleLog) << "SETUP_SIGNING sent, waiting for vehicle confirmation";
 }
 
 void Vehicle::sendDisableSigning()
@@ -4662,16 +4681,94 @@ void Vehicle::sendDisableSigning()
     mavlink_message_t msg;
     (void) mavlink_msg_setup_signing_encode_chan(MAVLinkProtocol::instance()->getSystemId(), MAVLinkProtocol::getComponentId(), channel, &msg, &setup_signing);
 
+    // Send disable while still signed (vehicle needs to verify the signed message)
     for (uint8_t i = 0; i < 2; ++i) {
         sendMessageOnLinkThreadSafe(sharedLink.get(), msg);
     }
 
-    // Disable signing on the local channel so we stop signing outgoing packets
-    MAVLinkSigning::initSigning(channel, QByteArrayView(), nullptr);
+    // Save current signing state for rollback if the vehicle rejects the disable
+    _previousSigningKeyBytes = _pendingSigningKeyBytes.isEmpty() ? QByteArray() : _pendingSigningKeyBytes;
+    _previousSigningKeyName = _mavlinkSigningKeyName;
 
-    _mavlinkSigning = false;
-    _mavlinkSigningKeyName.clear();
-    emit mavlinkSigningChanged();
+    // Store pending state and wait for vehicle confirmation before disabling local signing
+    _pendingSigningKeyIndex = -1;
+    _pendingSigningKeyBytes.clear();
+    _pendingSigningChannel = channel;
+    _pendingSigningDisable = true;
+    _signingConfirmationTimer.start();
+
+    qCDebug(VehicleLog) << "Disable signing sent, waiting for vehicle confirmation";
+}
+
+bool Vehicle::_isSigningPending() const
+{
+    return _pendingSigningKeyIndex >= 0 || _pendingSigningDisable;
+}
+
+void Vehicle::_confirmSigningSetup()
+{
+    _signingConfirmationTimer.stop();
+
+    if (_pendingSigningDisable) {
+        // Vehicle confirmed disable: now safe to turn off local signing
+        MAVLinkSigning::initSigning(_pendingSigningChannel, QByteArrayView(), nullptr);
+
+        _mavlinkSigning = false;
+        _mavlinkSigningKeyName.clear();
+        _previousSigningKeyBytes.clear();
+        _previousSigningKeyName.clear();
+        emit mavlinkSigningChanged();
+
+        qCDebug(VehicleLog) << "Signing disabled confirmed by vehicle";
+    } else if (_pendingSigningKeyIndex >= 0) {
+        // Vehicle confirmed enable: now safe to enable local signing
+        if (!MAVLinkSigning::initSigning(_pendingSigningChannel, _pendingSigningKeyBytes, MAVLinkSigning::insecureConnectionAcceptUnsignedCallback)) {
+            qCCritical(VehicleLog) << "Internal error: failed to initialize signing on channel" << _pendingSigningChannel;
+        } else {
+            _mavlinkSigning = true;
+            _mavlinkSigningKeyName = MAVLinkSigningKeys::instance()->keyNameAt(_pendingSigningKeyIndex);
+            emit mavlinkSigningChanged();
+
+            qCDebug(VehicleLog) << "Signing setup confirmed by vehicle, key:" << _mavlinkSigningKeyName;
+        }
+    }
+
+    _pendingSigningKeyIndex = -1;
+    _pendingSigningKeyBytes.clear();
+    _pendingSigningDisable = false;
+}
+
+void Vehicle::_cancelPendingSigning(const QString& reason)
+{
+    _signingConfirmationTimer.stop();
+
+    if (_pendingSigningDisable) {
+        // Disable was rejected or timed out: keep current signing state (no change needed,
+        // local signing was never disabled)
+        qCWarning(VehicleLog) << "Signing disable cancelled:" << reason;
+    } else if (_pendingSigningKeyIndex >= 0) {
+        // Enable was rejected or timed out: local signing was never enabled, nothing to undo
+        qCWarning(VehicleLog) << "Signing setup cancelled:" << reason;
+    }
+
+    _pendingSigningKeyIndex = -1;
+    _pendingSigningKeyBytes.clear();
+    _pendingSigningDisable = false;
+    _previousSigningKeyBytes.clear();
+    _previousSigningKeyName.clear();
+
+    qgcApp()->showAppMessage(reason);
+}
+
+void Vehicle::_signingConfirmationTimeout()
+{
+    if (_isSigningPending()) {
+        if (_pendingSigningDisable) {
+            _cancelPendingSigning(tr("Signing disable not confirmed by vehicle (timeout)"));
+        } else {
+            _cancelPendingSigning(tr("Signing setup not confirmed by vehicle (timeout)"));
+        }
+    }
 }
 
 /*---------------------------------------------------------------------------*/

--- a/src/Vehicle/Vehicle.h
+++ b/src/Vehicle/Vehicle.h
@@ -890,6 +890,7 @@ private slots:
     void _sendQGCTimeToVehicle              ();
     void _mavlinkMessageStatus              (int uasId, uint64_t totalSent, uint64_t totalReceived, uint64_t totalLoss, float lossPercent);
     void _orbitTelemetryTimeout             ();
+    void _signingConfirmationTimeout        ();
     void _updateFlightTime                  ();
     void _gotProgressUpdate                 (float progressValue);
     void _doSetHomeTerrainReceived          (bool success, QList<double> heights);
@@ -919,6 +920,9 @@ void _activeVehicleChanged          (Vehicle* newActiveVehicle);
     void _handleGimbalOrientation       (const mavlink_message_t& message);
     void _handleObstacleDistance        (const mavlink_message_t& message);
     void _handleFenceStatus             (const mavlink_message_t& message);
+    void _confirmSigningSetup           ();
+    void _cancelPendingSigning          (const QString& reason);
+    bool _isSigningPending              () const;
     void _handleEvent(uint8_t comp_id, std::unique_ptr<events::parser::ParsedEvent> event);
     // ArduPilot dialect messages
 #if !defined(QGC_NO_ARDUPILOT_DIALECT)
@@ -1010,6 +1014,16 @@ void _activeVehicleChanged          (Vehicle* newActiveVehicle);
     bool            _allSensorsHealthy                      = true;
     bool            _mavlinkSigning                         = false;
     QString         _mavlinkSigningKeyName;
+
+    // Signing confirmation state: defer local signing changes until vehicle confirms
+    int             _pendingSigningKeyIndex                  = -1;
+    QByteArray      _pendingSigningKeyBytes;
+    mavlink_channel_t _pendingSigningChannel                 = {};
+    QTimer          _signingConfirmationTimer;
+    bool            _pendingSigningDisable                   = false;
+    QByteArray      _previousSigningKeyBytes;                ///< For rollback on disable failure
+    QString         _previousSigningKeyName;
+    static constexpr int kSigningConfirmationTimeoutMs       = 3000;
 
     SysStatusSensorInfo _sysStatusSensorInfo;
 

--- a/test/MAVLink/MockLinkSigningTest.cc
+++ b/test/MAVLink/MockLinkSigningTest.cc
@@ -55,8 +55,8 @@ void MockLinkSigningTest::_testSendSetupSigning()
     QVERIFY_TRUE_WAIT(mockLink()->receivedMavlinkMessageCount(MAVLINK_MSG_ID_SETUP_SIGNING) >= 2, TestTimeout::mediumMs());
     QVERIFY(mockLink()->signingEnabled());
 
-    // Verify the signal was emitted and the vehicle tracks the active key name
-    QVERIFY(signingChangedSpy.count() > 0);
+    // Wait for vehicle to confirm signing via heartbeat (deferred confirmation flow)
+    QVERIFY_TRUE_WAIT(signingChangedSpy.count() > 0, TestTimeout::mediumMs());
     QCOMPARE(vehicle()->mavlinkSigningKeyName(), QStringLiteral("TestKey"));
 }
 
@@ -73,7 +73,7 @@ void MockLinkSigningTest::_testSendDisableSigning()
 
     vehicle()->sendSetupSigning(0);
     QVERIFY_TRUE_WAIT(mockLink()->signingEnabled(), TestTimeout::mediumMs());
-    QVERIFY(signingChangedSpy.count() > 0);
+    QVERIFY_TRUE_WAIT(signingChangedSpy.count() > 0, TestTimeout::mediumMs());
 
     // Now disable signing
     signingChangedSpy.clear();
@@ -84,8 +84,8 @@ void MockLinkSigningTest::_testSendDisableSigning()
     QVERIFY_TRUE_WAIT(mockLink()->receivedMavlinkMessageCount(MAVLINK_MSG_ID_SETUP_SIGNING) >= 2, TestTimeout::mediumMs());
     QVERIFY(!mockLink()->signingEnabled());
 
-    // Verify the signal was emitted and the vehicle cleared the active key name
-    QVERIFY(signingChangedSpy.count() > 0);
+    // Wait for vehicle to confirm disable via heartbeat (deferred confirmation flow)
+    QVERIFY_TRUE_WAIT(signingChangedSpy.count() > 0, TestTimeout::mediumMs());
     QVERIFY(vehicle()->mavlinkSigningKeyName().isEmpty());
 }
 


### PR DESCRIPTION
## Summary

- Defers local signing activation until the vehicle confirms it accepted the SETUP_SIGNING message
- Sends SETUP_SIGNING unsigned first, then waits up to 3 seconds for a heartbeat (confirmation) or STATUSTEXT (rejection)
- On timeout or rejection: cancels the pending signing change and notifies the user via app message
- Same confirmation pattern applied to disable signing: keeps local signing active until vehicle confirms the disable
- Previously, QGC enabled local signing before sending SETUP_SIGNING, so if the vehicle rejected the key, QGC would be stuck signing with a key the vehicle does not have, causing total communication loss

## Test plan

- [ ] Enable signing with a key the vehicle accepts: verify QGC enables local signing after heartbeat is received
- [ ] Enable signing with a key the vehicle rejects: verify QGC shows rejection message and does not enable local signing
- [ ] Enable signing when vehicle is unreachable (no heartbeat): verify 3-second timeout fires and user is notified
- [ ] Disable signing on a vehicle that accepts: verify local signing is disabled after heartbeat
- [ ] Disable signing on a vehicle that rejects: verify local signing remains active (rollback)
- [ ] Verify normal heartbeat processing is unaffected when no signing operation is pending

Fixes #14250