### PR TITLE
Plan Creator: Add vehicle class filtering and template UI

### DIFF
--- a/src/API/QGCCorePlugin.cc
+++ b/src/API/QGCCorePlugin.cc
@@ -19,6 +19,11 @@
 #endif
 #include "SettingsManager.h"
 #include "VideoReceiver.h"
+#include "SurveyPlanCreator.h"
+#include "CorridorScanPlanCreator.h"
+#include "StructureScanPlanCreator.h"
+#include "BlankPlanCreator.h"
+#include "PlanMasterController.h"
 
 #ifdef QGC_CUSTOM_BUILD
 #include CUSTOMHEADER
@@ -360,4 +365,14 @@ void QGCCorePlugin::_setShowAdvancedUI(bool show)
         _showAdvancedUI = show;
         emit showAdvancedUIChanged(show);
     }
+}
+
+QList<PlanCreator*> QGCCorePlugin::planCreators(PlanMasterController *planMasterController)
+{
+    return {
+        new SurveyPlanCreator(planMasterController),
+        new CorridorScanPlanCreator(planMasterController),
+        new StructureScanPlanCreator(planMasterController),
+        new BlankPlanCreator(planMasterController),
+    };
 }

--- a/src/API/QGCCorePlugin.h
+++ b/src/API/QGCCorePlugin.h
@@ -8,6 +8,7 @@
 
 class FactMetaData;
 class LinkInterface;
+class PlanCreator;
 class PlanMasterController;
 class QFile;
 class QGCOptions;
@@ -137,6 +138,12 @@ public:
     /// @param complexMissionItemNames Default set of complex items
     /// @return Complex items to be made available to user
     virtual QStringList complexMissionItemNames(Vehicle *vehicle, const QStringList &complexMissionItemNames) { Q_UNUSED(vehicle); return complexMissionItemNames; }
+
+    /// Returns the list of plan creators to show when creating a new plan.
+    /// Custom builds can override to provide their own set of plan creators.
+    /// @param planMasterController The plan master controller for the plan being created
+    /// @return Plan creators to show. Caller takes ownership.
+    virtual QList<PlanCreator*> planCreators(PlanMasterController *planMasterController);
 
     /// Returns the standard list of first run prompt ids for possible display. Actual display is based on the
     /// current AppSettings::firstRunPromptIds value. The order of this list also determines the order the prompts

--- a/src/MissionManager/BlankPlanCreator.cc
+++ b/src/MissionManager/BlankPlanCreator.cc
@@ -1,10 +1,10 @@
 #include "BlankPlanCreator.h"
 #include "PlanMasterController.h"
+#include "QGCMAVLink.h"
 
-BlankPlanCreator::BlankPlanCreator(PlanMasterController* planMasterController, QObject* parent)
-    : PlanCreator(planMasterController, tr("No Template"), QStringLiteral("/qmlimages/PlanCreator/BlankPlanCreator.png"), parent)
+BlankPlanCreator::BlankPlanCreator(PlanMasterController* planMasterController)
+    : PlanCreator(planMasterController, tr("No Template"), QStringLiteral("/qmlimages/PlanCreator/BlankPlanCreator.png"), QGCMAVLink::allVehicleClasses(), true)
 {
-    _blankPlan = true;
 }
 
 void BlankPlanCreator::createPlan(const QGeoCoordinate& /*mapCenterCoord*/)

--- a/src/MissionManager/BlankPlanCreator.h
+++ b/src/MissionManager/BlankPlanCreator.h
@@ -7,7 +7,7 @@ class BlankPlanCreator : public PlanCreator
     Q_OBJECT
 
 public:
-    BlankPlanCreator(PlanMasterController* planMasterController, QObject* parent = nullptr);
+    BlankPlanCreator(PlanMasterController* planMasterController);
 
     Q_INVOKABLE void createPlan(const QGeoCoordinate& mapCenterCoord) final;
 };

--- a/src/MissionManager/CorridorScanPlanCreator.cc
+++ b/src/MissionManager/CorridorScanPlanCreator.cc
@@ -1,9 +1,10 @@
 #include "CorridorScanPlanCreator.h"
 #include "PlanMasterController.h"
+#include "QGCMAVLink.h"
 #include "CorridorScanComplexItem.h"
 
-CorridorScanPlanCreator::CorridorScanPlanCreator(PlanMasterController* planMasterController, QObject* parent)
-    : PlanCreator(planMasterController, CorridorScanComplexItem::name, QStringLiteral("/qmlimages/PlanCreator/CorridorScanPlanCreator.png"), parent)
+CorridorScanPlanCreator::CorridorScanPlanCreator(PlanMasterController* planMasterController)
+    : PlanCreator(planMasterController, CorridorScanComplexItem::name, QStringLiteral("/qmlimages/PlanCreator/CorridorScanPlanCreator.png"), QGCMAVLink::allVehicleClasses())
 {
 
 }

--- a/src/MissionManager/CorridorScanPlanCreator.h
+++ b/src/MissionManager/CorridorScanPlanCreator.h
@@ -7,7 +7,7 @@ class CorridorScanPlanCreator : public PlanCreator
     Q_OBJECT
 
 public:
-    CorridorScanPlanCreator(PlanMasterController* planMasterController, QObject* parent = nullptr);
+    CorridorScanPlanCreator(PlanMasterController* planMasterController);
 
     Q_INVOKABLE void createPlan(const QGeoCoordinate& mapCenterCoord) final;
 };

--- a/src/MissionManager/PlanCreator.cc
+++ b/src/MissionManager/PlanCreator.cc
@@ -1,12 +1,19 @@
 #include "PlanCreator.h"
 #include "PlanMasterController.h"
 
-PlanCreator::PlanCreator(PlanMasterController* planMasterController, QString name, QString imageResource, QObject* parent)
-    : QObject               (parent)
-    , _planMasterController (planMasterController)
-    , _missionController    (planMasterController->missionController())
-    , _name                 (name)
-    , _imageResource        (imageResource)
+PlanCreator::PlanCreator(PlanMasterController* planMasterController, QString name, QString imageResource, QList<QGCMAVLinkTypes::VehicleClass_t> supportedVehicleClasses, bool blankPlan)
+    : QObject                   (planMasterController)
+    , _planMasterController     (planMasterController)
+    , _missionController        (planMasterController->missionController())
+    , _name                     (name)
+    , _imageResource            (imageResource)
+    , _blankPlan                (blankPlan)
+    , _supportedVehicleClasses  (supportedVehicleClasses)
 {
 
+}
+
+bool PlanCreator::supportsVehicleClass(QGCMAVLinkTypes::VehicleClass_t vehicleClass) const
+{
+    return _supportedVehicleClasses.contains(vehicleClass);
 }

--- a/src/MissionManager/PlanCreator.h
+++ b/src/MissionManager/PlanCreator.h
@@ -1,8 +1,11 @@
 #pragma once
 
+#include <QtCore/QList>
 #include <QtCore/QObject>
 #include <QtCore/QString>
 #include <QtPositioning/QGeoCoordinate>
+
+#include "QGCMAVLinkTypes.h"
 
 class PlanMasterController;
 class MissionController;
@@ -13,7 +16,8 @@ class PlanCreator : public QObject
     Q_OBJECT
 
 public:
-    PlanCreator(PlanMasterController* planMasterController, QString name, QString imageResource, QObject* parent = nullptr);
+    /// @param planMasterController also used as the QObject parent
+    PlanCreator(PlanMasterController* planMasterController, QString name, QString imageResource, QList<QGCMAVLinkTypes::VehicleClass_t> supportedVehicleClasses, bool blankPlan = false);
 
     Q_PROPERTY(QString  name            MEMBER _name            CONSTANT)
     Q_PROPERTY(QString  imageResource   MEMBER _imageResource   CONSTANT)
@@ -21,10 +25,16 @@ public:
 
     Q_INVOKABLE virtual void createPlan(const QGeoCoordinate& mapCenterCoord) = 0;
 
+    /// Returns true if this creator supports the given vehicle class
+    bool supportsVehicleClass(QGCMAVLinkTypes::VehicleClass_t vehicleClass) const;
+
 protected:
-    PlanMasterController*   _planMasterController;
-    MissionController*      _missionController;
-    QString                 _name;
-    QString                 _imageResource;
-    bool                    _blankPlan = false;
+    PlanMasterController* _planMasterController;
+    MissionController* _missionController;
+
+private:
+    QString _name;
+    QString _imageResource;
+    bool _blankPlan = false;
+    QList<QGCMAVLinkTypes::VehicleClass_t> _supportedVehicleClasses;
 };

--- a/src/MissionManager/PlanMasterController.cc
+++ b/src/MissionManager/PlanMasterController.cc
@@ -9,10 +9,7 @@
 #include "JsonParsing.h"
 #include "MissionManager.h"
 #include "KMLPlanDomDocument.h"
-#include "SurveyPlanCreator.h"
-#include "StructureScanPlanCreator.h"
-#include "CorridorScanPlanCreator.h"
-#include "BlankPlanCreator.h"
+#include "PlanCreator.h"
 #include "QmlObjectListModel.h"
 #include "GeoFenceManager.h"
 #include "RallyPointManager.h"
@@ -40,7 +37,7 @@ PlanMasterController::PlanMasterController(QObject* parent)
     _commonInit();
 }
 
-#ifdef QT_DEBUG
+#ifdef QGC_UNITTEST_BUILD
 PlanMasterController::PlanMasterController(MAV_AUTOPILOT firmwareType, MAV_TYPE vehicleType, QObject* parent)
     : QObject               (parent)
     , _multiVehicleMgr      (MultiVehicleManager::instance())
@@ -64,9 +61,7 @@ void PlanMasterController::_commonInit(void)
     connect(&_geoFenceController,   &GeoFenceController::containsItemsChanged,      this, &PlanMasterController::containsItemsChanged);
     connect(&_rallyPointController, &RallyPointController::containsItemsChanged,    this, &PlanMasterController::containsItemsChanged);
 
-    connect(&_missionController,    &MissionController::containsItemsChanged,       this, &PlanMasterController::_updateReadyForPlanCreation);
-    connect(&_geoFenceController,   &GeoFenceController::containsItemsChanged,      this, &PlanMasterController::_updateReadyForPlanCreation);
-    connect(&_rallyPointController, &RallyPointController::containsItemsChanged,    this, &PlanMasterController::_updateReadyForPlanCreation);
+    connect(this, &PlanMasterController::containsItemsChanged, this, &PlanMasterController::_updateShowCreateFromTemplate);
 
     connect(&_missionController,    &MissionController::syncInProgressChanged,      this, &PlanMasterController::syncInProgressChanged);
     connect(&_geoFenceController,   &GeoFenceController::syncInProgressChanged,     this, &PlanMasterController::syncInProgressChanged);
@@ -554,7 +549,7 @@ void PlanMasterController::removeAll(void)
     if (_offline) {
         _clearFileNames();
     }
-    setManualCreation(false);
+    setUserSelectedManualCreation(false);
 }
 
 void PlanMasterController::removeAllFromVehicle(void)
@@ -572,7 +567,7 @@ void PlanMasterController::removeAllFromVehicle(void)
     } else {
         qCCritical(PlanMasterControllerLog) << "PlanMasterController::removeAllFromVehicle called while offline";
     }
-    setManualCreation(false);
+    setUserSelectedManualCreation(false);
 }
 
 bool PlanMasterController::containsItems(void) const
@@ -580,12 +575,18 @@ bool PlanMasterController::containsItems(void) const
     return _missionController.containsItems() || _geoFenceController.containsItems() || _rallyPointController.containsItems();
 }
 
-void PlanMasterController::_updateReadyForPlanCreation(void)
+void PlanMasterController::_updateShowCreateFromTemplate(void)
 {
-    const bool ready = readyForPlanCreation();
-    if (ready != _readyForPlanCreation) {
-        _readyForPlanCreation = ready;
-        emit readyForPlanCreationChanged();
+    // When the plan becomes empty, always return to template-selection mode regardless
+    // of how the items were removed.
+    if (!containsItems() && _userSelectedManualCreation) {
+        _userSelectedManualCreation = false;
+        emit userSelectedManualCreationChanged();
+    }
+    const bool show = showCreateFromTemplate();
+    if (show != _showCreateFromTemplate) {
+        _showCreateFromTemplate = show;
+        emit showCreateFromTemplateChanged();
     }
 }
 
@@ -783,25 +784,38 @@ void PlanMasterController::_setDirtyStates(bool dirtyForSave, bool dirtyForUploa
 
 void PlanMasterController::_updatePlanCreatorsList(void)
 {
-    if (!_flyView) {
-        if (!_planCreators) {
-            _planCreators = new QmlObjectListModel(this);
-            _planCreators->append(new BlankPlanCreator(this, this));
-            _planCreators->append(new SurveyPlanCreator(this, this));
-            _planCreators->append(new CorridorScanPlanCreator(this, this));
-            emit planCreatorsChanged(_planCreators);
-        }
+    if (_flyView) {
+        return;
+    }
 
-        if (_managerVehicle->fixedWing()) {
-            if (_planCreators->count() == 4) {
-                _planCreators->removeAt(_planCreators->count() - 1);
-            }
+    const auto vehicleClass = _managerVehicle->vehicleClass();
+
+    // Only rebuild if the vehicle class actually changed
+    if (_planCreators && _planCreatorsVehicleClass == vehicleClass) {
+        return;
+    }
+
+    if (!_planCreators) {
+        _planCreators = new QmlObjectListModel(this);
+    } else {
+        _planCreators->clearAndDeleteContents();
+    }
+
+    _planCreatorsVehicleClass = vehicleClass;
+
+    // Allow custom builds to provide their own list of plan creators
+    const QList<PlanCreator*> creators = QGCCorePlugin::instance()->planCreators(this);
+
+    // Filter by vehicle class and add to the model
+    for (PlanCreator* creator : creators) {
+        if (creator->supportsVehicleClass(vehicleClass)) {
+            _planCreators->append(creator);
         } else {
-            if (_planCreators->count() != 4) {
-                _planCreators->append(new StructureScanPlanCreator(this, this));
-            }
+            delete creator;
         }
     }
+
+    emit planCreatorsChanged(_planCreators);
 }
 
 void PlanMasterController::showPlanFromManagerVehicle(void)
@@ -817,11 +831,18 @@ void PlanMasterController::showPlanFromManagerVehicle(void)
     }
 }
 
-void PlanMasterController::setManualCreation(bool manualCreation)
+void PlanMasterController::setUserSelectedManualCreation(bool userSelectedManualCreation)
 {
-    if (_manualCreation != manualCreation) {
-        _manualCreation = manualCreation;
-        emit manualCreationChanged();
+    if (_userSelectedManualCreation != userSelectedManualCreation) {
+        _userSelectedManualCreation = userSelectedManualCreation;
+        emit userSelectedManualCreationChanged();
+        // Update showCreateFromTemplate directly — do not go through _updateShowCreateFromTemplate,
+        // which would immediately auto-clear the flag if the plan happens to be empty right now.
+        const bool show = showCreateFromTemplate();
+        if (show != _showCreateFromTemplate) {
+            _showCreateFromTemplate = show;
+            emit showCreateFromTemplateChanged();
+        }
     }
 }
 

--- a/src/MissionManager/PlanMasterController.h
+++ b/src/MissionManager/PlanMasterController.h
@@ -6,6 +6,7 @@
 #include "MissionController.h"
 #include "GeoFenceController.h"
 #include "RallyPointController.h"
+#include "QGCMAVLinkTypes.h"
 
 class QGCCompressionJob;
 class QmlObjectListModel;
@@ -29,7 +30,7 @@ class PlanMasterController : public QObject
 
 public:
     PlanMasterController(QObject* parent = nullptr);
-#ifdef QT_DEBUG
+#ifdef QGC_UNITTEST_BUILD
     // Used by test code to create master controller with specific firmware/vehicle type
     PlanMasterController(MAV_AUTOPILOT firmwareType, MAV_TYPE vehicleType, QObject* parent = nullptr);
 #endif
@@ -37,27 +38,27 @@ public:
     ~PlanMasterController();
 
     Q_PROPERTY(bool                     flyView                 MEMBER _flyView)
-    Q_PROPERTY(Vehicle*                 controllerVehicle       READ controllerVehicle                      CONSTANT)                       ///< Offline controller vehicle
-    Q_PROPERTY(Vehicle*                 managerVehicle          READ managerVehicle                         NOTIFY managerVehicleChanged)   ///< Either active vehicle or _controllerVehicle if no active vehicle
+    Q_PROPERTY(Vehicle*                 controllerVehicle       READ controllerVehicle                      CONSTANT)                               ///< Offline controller vehicle
+    Q_PROPERTY(Vehicle*                 managerVehicle          READ managerVehicle                         NOTIFY managerVehicleChanged)           ///< Either active vehicle or _controllerVehicle if no active vehicle
     Q_PROPERTY(MissionController*       missionController       READ missionController                      CONSTANT)
     Q_PROPERTY(GeoFenceController*      geoFenceController      READ geoFenceController                     CONSTANT)
     Q_PROPERTY(RallyPointController*    rallyPointController    READ rallyPointController                   CONSTANT)
-    Q_PROPERTY(bool                     offline                 READ offline                                NOTIFY offlineChanged)          ///< true: controller is not connected to an active vehicle
-    Q_PROPERTY(bool                     containsItems           READ containsItems                          NOTIFY containsItemsChanged)    ///< true: Elemement is non-empty
-    Q_PROPERTY(bool                     readyForPlanCreation    READ readyForPlanCreation                   NOTIFY readyForPlanCreationChanged) ///< true: All controllers are empty, UI should show "create new plan" mode
-    Q_PROPERTY(bool                     syncInProgress          READ syncInProgress                         NOTIFY syncInProgressChanged)   ///< true: Information is currently being saved/sent, false: no active save/send in progress
-    Q_PROPERTY(bool                     dirtyForSave            READ dirtyForSave                           NOTIFY dirtyForSaveChanged)     ///< true: Unsaved changes to disk are present, false: no changes since last save to disk
-    Q_PROPERTY(bool                     dirtyForUpload          READ dirtyForUpload                         NOTIFY dirtyForUploadChanged)   ///< true: Unsent changes are present, false: no changes since last upload/download sync
-    Q_PROPERTY(QString                  fileExtension           READ fileExtension                          CONSTANT)                       ///< File extension for missions
+    Q_PROPERTY(bool                     offline                 READ offline                                NOTIFY offlineChanged)                  ///< true: controller is not connected to an active vehicle
+    Q_PROPERTY(bool                     containsItems           READ containsItems                          NOTIFY containsItemsChanged)            ///< true: Elemement is non-empty
+    Q_PROPERTY(bool                     showCreateFromTemplate  READ showCreateFromTemplate                 NOTIFY showCreateFromTemplateChanged)   ///< true: No plan items and not in manual-creation mode; UI should show "create new plan" template selection
+    Q_PROPERTY(bool                     syncInProgress          READ syncInProgress                         NOTIFY syncInProgressChanged)           ///< true: Information is currently being saved/sent, false: no active save/send in progress
+    Q_PROPERTY(bool                     dirtyForSave            READ dirtyForSave                           NOTIFY dirtyForSaveChanged)             ///< true: Unsaved changes to disk are present, false: no changes since last save to disk
+    Q_PROPERTY(bool                     dirtyForUpload          READ dirtyForUpload                         NOTIFY dirtyForUploadChanged)           ///< true: Unsent changes are present, false: no changes since last upload/download sync
+    Q_PROPERTY(QString                  fileExtension           READ fileExtension                          CONSTANT)                               ///< File extension for missions
     Q_PROPERTY(QString                  kmlFileExtension        READ kmlFileExtension                       CONSTANT)
-    Q_PROPERTY(QString                  currentPlanFile         READ currentPlanFile                        NOTIFY currentPlanFileChanged)  ///< Fully qualified path, empty if not yet saved
+    Q_PROPERTY(QString                  currentPlanFile         READ currentPlanFile                        NOTIFY currentPlanFileChanged)          ///< Fully qualified path, empty if not yet saved
     Q_PROPERTY(QString                  currentPlanFileName     READ currentPlanFileName WRITE setCurrentPlanFileName NOTIFY currentPlanFileNameChanged)  ///< Editable base name, no path or extension
-    Q_PROPERTY(QString                  originalPlanFileName    READ originalPlanFileName                   NOTIFY originalPlanFileNameChanged) ///< On-disk name when last loaded/saved
-    Q_PROPERTY(bool                     planFileRenamed         READ planFileRenamed                        NOTIFY planFileRenamedChanged)   ///< true if currentPlanFileName differs from originalPlanFileName
-    Q_PROPERTY(QStringList              loadNameFilters         READ loadNameFilters                        CONSTANT)                       ///< File filter list loading plan files
-    Q_PROPERTY(QStringList              saveNameFilters         READ saveNameFilters                        CONSTANT)                       ///< File filter list saving plan files
-    Q_PROPERTY(QmlObjectListModel*      planCreators            MEMBER _planCreators                        NOTIFY planCreatorsChanged)
-    Q_PROPERTY(bool                     manualCreation          READ manualCreation WRITE setManualCreation NOTIFY manualCreationChanged)   ///< true: User is not using a template to create the plan
+    Q_PROPERTY(QString                  originalPlanFileName    READ originalPlanFileName                   NOTIFY originalPlanFileNameChanged)     ///< On-disk name when last loaded/saved
+    Q_PROPERTY(bool                     planFileRenamed         READ planFileRenamed                        NOTIFY planFileRenamedChanged)          ///< true if currentPlanFileName differs from originalPlanFileName
+    Q_PROPERTY(QStringList              loadNameFilters         READ loadNameFilters                        CONSTANT)                               ///< File filter list loading plan files
+    Q_PROPERTY(QStringList              saveNameFilters         READ saveNameFilters                        CONSTANT)                               ///< File filter list saving plan files
+    Q_PROPERTY(QmlObjectListModel*      planCreators            READ planCreators                           NOTIFY planCreatorsChanged)
+    Q_PROPERTY(bool                     userSelectedManualCreation READ userSelectedManualCreation WRITE setUserSelectedManualCreation NOTIFY userSelectedManualCreationChanged) ///< true: User is not using a template to create the plan
 
     /// Should be called immediately upon Component.onCompleted.
     Q_INVOKABLE void start(void);
@@ -92,84 +93,85 @@ public:
     Q_INVOKABLE bool saveToFile(const QString& filename);
     Q_INVOKABLE void saveToKml(const QString& filename);
 
-    Q_INVOKABLE bool saveWithCurrentName();                 ///< Save using the (possibly renamed) currentPlanFileName
-    Q_INVOKABLE bool resolvedPlanFileExists() const;        ///< true if a file at the renamed path already exists on disk
-    Q_INVOKABLE void removeAll(void);                       ///< Removes all from controller only, synce required to remove from vehicle
-    Q_INVOKABLE void removeAllFromVehicle(void);            ///< Removes all from vehicle and controller
+    Q_INVOKABLE bool saveWithCurrentName(); ///< Save using the (possibly renamed) currentPlanFileName
+    Q_INVOKABLE bool resolvedPlanFileExists() const; ///< true if a file at the renamed path already exists on disk
+    Q_INVOKABLE void removeAll(void); ///< Removes all from controller only, sync required to remove from vehicle
+    Q_INVOKABLE void removeAllFromVehicle(void); ///< Removes all from vehicle and controller
 
-    MissionController*      missionController(void)     { return &_missionController; }
-    GeoFenceController*     geoFenceController(void)    { return &_geoFenceController; }
-    RallyPointController*   rallyPointController(void)  { return &_rallyPointController; }
+    MissionController* missionController(void) { return &_missionController; }
+    GeoFenceController* geoFenceController(void) { return &_geoFenceController; }
+    RallyPointController* rallyPointController(void) { return &_rallyPointController; }
 
-    bool        offline         (void) const { return _offline; }
-    bool        containsItems   (void) const;
-    bool        readyForPlanCreation(void) const { return !containsItems(); }
-    bool        syncInProgress  (void) const;
-    bool        dirtyForSave    (void) const { return _dirtyForSave; }
-    bool        dirtyForUpload  (void) const { return _dirtyForUpload; }
-    QString     fileExtension   (void) const;
-    QString     kmlFileExtension(void) const;
-    QString     currentPlanFile     (void) const { return _currentPlanFile; }
-    QString     currentPlanFileName (void) const { return _currentPlanFileName; }
-    void        setCurrentPlanFileName(const QString& name);
-    QString     originalPlanFileName(void) const { return _originalPlanFileName; }
-    bool        planFileRenamed(void) const;
-    QStringList loadNameFilters (void) const;
-    QStringList saveNameFilters (void) const;
-    bool        isEmpty         (void) const;
-    bool        manualCreation  (void) const { return _manualCreation; }
+    bool offline(void) const { return _offline; }
+    bool containsItems(void) const;
+    bool showCreateFromTemplate(void) const { return !containsItems() && !_userSelectedManualCreation; }
+    bool syncInProgress(void) const;
+    bool dirtyForSave(void) const { return _dirtyForSave; }
+    bool dirtyForUpload(void) const { return _dirtyForUpload; }
+    QString fileExtension(void) const;
+    QString kmlFileExtension(void) const;
+    QString currentPlanFile(void) const { return _currentPlanFile; }
+    QString currentPlanFileName(void) const { return _currentPlanFileName; }
+    void setCurrentPlanFileName(const QString& name);
+    QString originalPlanFileName(void) const { return _originalPlanFileName; }
+    bool planFileRenamed(void) const;
+    QStringList loadNameFilters(void) const;
+    QStringList saveNameFilters(void) const;
+    bool isEmpty(void) const;
+    bool userSelectedManualCreation(void) const { return _userSelectedManualCreation; }
+    QmlObjectListModel* planCreators(void) const { return _planCreators; }
 
-    void        setFlyView(bool flyView) { _flyView = flyView; }
-    void        setManualCreation(bool manualCreation);
+    void setFlyView(bool flyView) { _flyView = flyView; }
+    void setUserSelectedManualCreation(bool userSelectedManualCreation);
 
-    QJsonDocument saveToJson    ();
+    QJsonDocument saveToJson();
 
     Vehicle* controllerVehicle(void) { return _controllerVehicle; }
     Vehicle* managerVehicle(void) { return _managerVehicle; }
 
-    static constexpr int   kPlanFileVersion =            1;
-    static constexpr const char* kPlanFileType =               "Plan";
-    static constexpr const char* kJsonMissionObjectKey =       "mission";
-    static constexpr const char* kJsonGeoFenceObjectKey =      "geoFence";
-    static constexpr const char* kJsonRallyPointsObjectKey =   "rallyPoints";
+    static constexpr int kPlanFileVersion = 1;
+    static constexpr const char* kPlanFileType = "Plan";
+    static constexpr const char* kJsonMissionObjectKey = "mission";
+    static constexpr const char* kJsonGeoFenceObjectKey = "geoFence";
+    static constexpr const char* kJsonRallyPointsObjectKey = "rallyPoints";
 
 signals:
-    void containsItemsChanged               ();
-    void readyForPlanCreationChanged        ();
-    void syncInProgressChanged              (void);
-    void dirtyForSaveChanged                (bool dirtyForSave);
-    void dirtyForUploadChanged              (bool dirtyForUpload);
-    void offlineChanged                     (bool offlineEditing);
-    void currentPlanFileChanged             (void);
-    void currentPlanFileNameChanged         (void);
-    void originalPlanFileNameChanged        (void);
-    void planFileRenamedChanged              (void);
-    void planCreatorsChanged                (QmlObjectListModel* planCreators);
-    void managerVehicleChanged              (Vehicle* managerVehicle);
-    void promptForPlanUsageOnVehicleChange  (void);
-    void manualCreationChanged              ();
+    void containsItemsChanged();
+    void showCreateFromTemplateChanged();
+    void syncInProgressChanged(void);
+    void dirtyForSaveChanged(bool dirtyForSave);
+    void dirtyForUploadChanged(bool dirtyForUpload);
+    void offlineChanged(bool offlineEditing);
+    void currentPlanFileChanged(void);
+    void currentPlanFileNameChanged(void);
+    void originalPlanFileNameChanged(void);
+    void planFileRenamedChanged(void);
+    void planCreatorsChanged(QmlObjectListModel* planCreators);
+    void managerVehicleChanged(Vehicle* managerVehicle);
+    void promptForPlanUsageOnVehicleChange(void);
+    void userSelectedManualCreationChanged();
 
 private slots:
-    void _activeVehicleChanged      (Vehicle* activeVehicle);
-    void _loadMissionComplete       (void);
-    void _loadGeoFenceComplete      (void);
-    void _loadRallyPointsComplete   (void);
-    void _sendMissionComplete       (void);
-    void _sendGeoFenceComplete      (void);
-    void _sendRallyPointsComplete   (void);
-    void _updateOverallDirty        (void);
-    void _updateReadyForPlanCreation (void);
-    void _updatePlanCreatorsList    (void);
-    void _handleExtractionFinished  (bool success);
+    void _activeVehicleChanged(Vehicle* activeVehicle);
+    void _loadMissionComplete(void);
+    void _loadGeoFenceComplete(void);
+    void _loadRallyPointsComplete(void);
+    void _sendMissionComplete(void);
+    void _sendGeoFenceComplete(void);
+    void _sendRallyPointsComplete(void);
+    void _updateOverallDirty(void);
+    void _updateShowCreateFromTemplate(void);
+    void _updatePlanCreatorsList(void);
+    void _handleExtractionFinished(bool success);
 
 private:
-    void _commonInit                (void);
+    void _commonInit(void);
     void _showPlanFromManagerVehicle(void);
     void _setDirtyForSave(bool dirtyForSave);
     void _setDirtyForUpload(bool dirtyForUpload);
     void _setDirtyStates(bool dirtyForSave, bool dirtyForUpload);
     QString _resolvedPlanFilePath() const;
-    void    _clearFileNames();
+    void _clearFileNames();
 
 #ifdef QGC_UNITTEST_BUILD
     // Used by unit tests to set dirty flags for initial state
@@ -177,31 +179,34 @@ private:
     void _setDirtyForUploadUnitTest(bool dirtyForUpload) { _dirtyForUpload = dirtyForUpload; }
 #endif
 
-    MultiVehicleManager*    _multiVehicleMgr =          nullptr;
-    Vehicle*                _controllerVehicle =        nullptr;    ///< Offline controller vehicle
-    Vehicle*                _managerVehicle =           nullptr;    ///< Either active vehicle or _controllerVehicle if none
-    bool                    _flyView =                  true;
-    bool                    _offline =                  true;
-    MissionController       _missionController;
-    GeoFenceController      _geoFenceController;
-    RallyPointController    _rallyPointController;
-    bool                    _loadGeoFence =             false;
-    bool                    _loadRallyPoints =          false;
-    bool                    _sendGeoFence =             false;
-    bool                    _sendRallyPoints =          false;
-    QString                 _currentPlanFile;
+    MultiVehicleManager* _multiVehicleMgr = nullptr;
+    Vehicle* _controllerVehicle = nullptr;    ///< Offline controller vehicle
+    Vehicle* _managerVehicle = nullptr;       ///< Either active vehicle or _controllerVehicle if none
+    bool _flyView = true;
+    bool _offline = true;
+    MissionController _missionController;
+    GeoFenceController _geoFenceController;
+    RallyPointController _rallyPointController;
+    bool _loadGeoFence = false;
+    bool _loadRallyPoints = false;
+    bool _sendGeoFence = false;
+    bool _sendRallyPoints = false;
+    QString _currentPlanFile;
+
     // NOTE: _currentPlanFileName and _originalPlanFileName must be kept in sync
     // with _currentPlanFile across all code paths that modify any of them:
     // loadFromFile, saveToFile, removeAll, removeAllFromVehicle, _clearFileNames.
-    QString                 _currentPlanFileName;
-    QString                 _originalPlanFileName;
-    bool                    _deleteWhenSendCompleted =  false;
-    bool                    _dirtyForSave =             false;
-    bool                    _dirtyForUpload =           false;
-    bool                    _readyForPlanCreation =     true;
-    bool                    _suppressOverallDirtyUpdate = false;
-    QmlObjectListModel*     _planCreators =             nullptr;
-    bool                    _manualCreation =           false;
-    QGCCompressionJob*      _extractionJob =            nullptr;
-    QString                 _extractionOutputDir;
+    QString _currentPlanFileName;
+    QString _originalPlanFileName;
+
+    bool _deleteWhenSendCompleted = false;
+    bool _dirtyForSave = false;
+    bool _dirtyForUpload = false;
+    bool _showCreateFromTemplate = true;
+    bool _suppressOverallDirtyUpdate = false;
+    QmlObjectListModel* _planCreators = nullptr;
+    QGCMAVLinkTypes::VehicleClass_t _planCreatorsVehicleClass = -1;
+    bool _userSelectedManualCreation = false;
+    QGCCompressionJob* _extractionJob = nullptr;
+    QString _extractionOutputDir;
 };

--- a/src/MissionManager/StructureScanPlanCreator.cc
+++ b/src/MissionManager/StructureScanPlanCreator.cc
@@ -1,9 +1,10 @@
 #include "StructureScanPlanCreator.h"
 #include "PlanMasterController.h"
+#include "QGCMAVLink.h"
 #include "StructureScanComplexItem.h"
 
-StructureScanPlanCreator::StructureScanPlanCreator(PlanMasterController* planMasterController, QObject* parent)
-    : PlanCreator(planMasterController, StructureScanComplexItem::name, QStringLiteral("/qmlimages/PlanCreator/StructureScanPlanCreator.png"), parent)
+StructureScanPlanCreator::StructureScanPlanCreator(PlanMasterController* planMasterController)
+    : PlanCreator(planMasterController, StructureScanComplexItem::name, QStringLiteral("/qmlimages/PlanCreator/StructureScanPlanCreator.png"), {QGCMAVLink::VehicleClassMultiRotor, QGCMAVLink::VehicleClassVTOL})
 {
 
 }

--- a/src/MissionManager/StructureScanPlanCreator.h
+++ b/src/MissionManager/StructureScanPlanCreator.h
@@ -7,7 +7,7 @@ class StructureScanPlanCreator : public PlanCreator
     Q_OBJECT
 
 public:
-    StructureScanPlanCreator(PlanMasterController* planMasterController, QObject* parent = nullptr);
+    StructureScanPlanCreator(PlanMasterController* planMasterController);
 
     Q_INVOKABLE void createPlan(const QGeoCoordinate& mapCenterCoord) final;
 };

--- a/src/MissionManager/SurveyPlanCreator.cc
+++ b/src/MissionManager/SurveyPlanCreator.cc
@@ -1,9 +1,10 @@
 #include "SurveyPlanCreator.h"
 #include "PlanMasterController.h"
+#include "QGCMAVLink.h"
 #include "SurveyComplexItem.h"
 
-SurveyPlanCreator::SurveyPlanCreator(PlanMasterController* planMasterController, QObject* parent)
-    : PlanCreator(planMasterController, SurveyComplexItem::name, QStringLiteral("/qmlimages/PlanCreator/SurveyPlanCreator.png"), parent)
+SurveyPlanCreator::SurveyPlanCreator(PlanMasterController* planMasterController)
+    : PlanCreator(planMasterController, SurveyComplexItem::name, QStringLiteral("/qmlimages/PlanCreator/SurveyPlanCreator.png"), QGCMAVLink::allVehicleClasses())
 {
 
 }

--- a/src/MissionManager/SurveyPlanCreator.h
+++ b/src/MissionManager/SurveyPlanCreator.h
@@ -7,7 +7,7 @@ class SurveyPlanCreator : public PlanCreator
     Q_OBJECT
 
 public:
-    SurveyPlanCreator(PlanMasterController* planMasterController, QObject* parent = nullptr);
+    SurveyPlanCreator(PlanMasterController* planMasterController);
 
     Q_INVOKABLE void createPlan(const QGeoCoordinate& mapCenterCoord) final;
 };

--- a/src/PlanView/PlanInfoEditor.qml
+++ b/src/PlanView/PlanInfoEditor.qml
@@ -115,7 +115,7 @@ Rectangle {
             Layout.fillWidth: true
             Layout.topMargin: ScreenTools.defaultFontPixelWidth / 2
             spacing: ScreenTools.defaultFontPixelWidth / 2
-            visible: plannedHomePositionSection.checked && _root.planMasterController.readyForPlanCreation
+            visible: plannedHomePositionSection.checked && _root.planMasterController.showCreateFromTemplate
 
             Image {
                 source: "qrc:///qmlimages/MapHome.svg"
@@ -151,15 +151,18 @@ Rectangle {
 
             QGCLabel {
                 text: qsTr("Altitude (AMSL)")
+                font.pointSize: ScreenTools.smallFontPointSize
             }
             FactTextField {
                 fact: _root._settingsItem ? _root._settingsItem.plannedHomePositionAltitude : null
                 Layout.fillWidth: true
+                font.pointSize: ScreenTools.smallFontPointSize
                 visible: _root._settingsItem && _root._settingsItem.terrainQueryFailed
             }
             QGCLabel {
                 text: _root._settingsItem ? _root._settingsItem.plannedHomePositionAltitude.valueString + " " + _root._settingsItem.plannedHomePositionAltitude.units : ""
                 Layout.fillWidth: true
+                font.pointSize: ScreenTools.smallFontPointSize
                 visible: !_root._settingsItem || !_root._settingsItem.terrainQueryFailed
             }
         }
@@ -171,6 +174,38 @@ Rectangle {
             text: qsTr("Actual position/alt set by vehicle at flight time.")
             horizontalAlignment: Text.AlignHCenter
             visible: plannedHomePositionSection.checked && _root.missionController.homePositionSet
+        }
+
+        // ── Plan Templates ──
+        SectionHeader {
+            id: planTemplateSectionHeader
+            Layout.fillWidth: true
+            text: qsTr("Plan Templates")
+            visible: _root.planMasterController.showCreateFromTemplate
+        }
+
+        ColumnLayout {
+            Layout.fillWidth: true
+            spacing: ScreenTools.defaultFontPixelHeight / 2
+            visible: planTemplateSectionHeader.visible && planTemplateSectionHeader.checked
+            enabled: _root.missionController.homePositionSet
+            opacity: enabled ? 1.0 : 0.5
+
+            Repeater {
+                model: _root.planMasterController.planCreators
+
+                QGCButton {
+                    Layout.fillWidth: true
+                    text: object.name
+                    onClicked: {
+                        if (object.blankPlan) {
+                            _root.planMasterController.userSelectedManualCreation = true
+                        } else {
+                            object.createPlan(_root.editorMap.center)
+                        }
+                    }
+                }
+            }
         }
     }
 }

--- a/src/PlanView/PlanTreeView.qml
+++ b/src/PlanView/PlanTreeView.qml
@@ -27,7 +27,17 @@ TreeView {
     readonly property int _layerMission: 1
     readonly property int _layerFence:   2
     readonly property int _layerRally:   3
-    readonly property bool _createNewPlanMode: planMasterController.readyForPlanCreation
+    readonly property bool _createNewPlanMode: planMasterController.showCreateFromTemplate
+
+    on_CreateNewPlanModeChanged: {
+        if (_createNewPlanMode) {
+            var planFileRow = _rowFor(_missionController.planFileGroupIndex)
+            if (!root.isExpanded(planFileRow)) {
+                root.expand(planFileRow)
+            }
+            root.contentY = 0
+        }
+    }
 
     property var _missionController: planMasterController.missionController
     property var _geoFenceController: planMasterController.geoFenceController

--- a/src/PlanView/PlanView.qml
+++ b/src/PlanView/PlanView.qml
@@ -284,7 +284,7 @@ Item {
 
                 switch (_editingLayer) {
                 case _layerMission:
-                    if (_planMasterController.readyForPlanCreation) {
+                    if (_planMasterController.showCreateFromTemplate) {
                         _missionController.setHomePosition(coordinate)
                     } else if (_addROIOnClick) {
                         _addROIOnClick = false

--- a/test/MissionManager/PlanMasterControllerTest.cc
+++ b/test/MissionManager/PlanMasterControllerTest.cc
@@ -1,6 +1,7 @@
 #include "PlanMasterControllerTest.h"
 
 #include "AppSettings.h"
+#include "SurveyPlanCreator.h"
 #include "MissionManager.h"
 #include "MultiSignalSpy.h"
 #include "MultiVehicleManager.h"
@@ -270,10 +271,6 @@ void PlanMasterControllerTest::_testDirtyFlagsMatrix()
     }
 }
 
-// ===========================================================================
-// File name property tests
-// ===========================================================================
-
 void PlanMasterControllerTest::_testFileNamesSetOnLoad()
 {
     QSignalSpy currentNameSpy(_masterController, &PlanMasterController::currentPlanFileNameChanged);
@@ -460,6 +457,148 @@ void PlanMasterControllerTest::_testSaveUpdatesOriginalFileName()
 
     // Clean up
     QFile::remove(saveFile);
+}
+
+void PlanMasterControllerTest::_testTemplateModeHidesTemplatesOnPlanCreatorSelection()
+{
+    // Initial state: empty plan → templates shown
+    QVERIFY(_masterController->showCreateFromTemplate());
+
+    QSignalSpy spyShow(_masterController, &PlanMasterController::showCreateFromTemplateChanged);
+
+    // User selects a plan creator (e.g. Survey) — adds items to the plan
+    SurveyPlanCreator creator(_masterController);
+    creator.createPlan(QGeoCoordinate(47.0, -122.0));
+
+    QVERIFY(_masterController->containsItems());
+    QVERIFY(!_masterController->showCreateFromTemplate());
+    QCOMPARE(spyShow.count(), 1);
+}
+
+void PlanMasterControllerTest::_testTemplateModeHidesTemplatesOnFileLoad()
+{
+    // Initial state: empty plan, not manual creation → templates shown
+    QVERIFY(_masterController->showCreateFromTemplate());
+
+    QSignalSpy spyShow(_masterController, &PlanMasterController::showCreateFromTemplateChanged);
+
+    _masterController->loadFromFile(":/unittest/MissionPlanner.waypoints");
+
+    QVERIFY(_masterController->containsItems());
+    QVERIFY(!_masterController->showCreateFromTemplate());
+    QCOMPARE(spyShow.count(), 1);
+}
+
+void PlanMasterControllerTest::_testTemplateModeRestoredOnRemoveAll()
+{
+    _masterController->loadFromFile(":/unittest/MissionPlanner.waypoints");
+    QVERIFY(!_masterController->showCreateFromTemplate());
+
+    QSignalSpy spyShow(_masterController, &PlanMasterController::showCreateFromTemplateChanged);
+
+    _masterController->removeAll();
+
+    QVERIFY(!_masterController->containsItems());
+    QVERIFY(_masterController->showCreateFromTemplate());
+    QCOMPARE(spyShow.count(), 1);
+}
+
+void PlanMasterControllerTest::_testTemplateModeRestoredOnIndividualItemRemoval()
+{
+    _masterController->loadFromFile(":/unittest/MissionPlanner.waypoints");
+    QVERIFY(!_masterController->showCreateFromTemplate());
+
+    QSignalSpy spyShow(_masterController, &PlanMasterController::showCreateFromTemplateChanged);
+
+    _masterController->missionController()->removeAll();
+    _masterController->geoFenceController()->removeAll();
+    _masterController->rallyPointController()->removeAll();
+
+    QVERIFY(!_masterController->containsItems());
+    QVERIFY(_masterController->showCreateFromTemplate());
+    QCOMPARE(spyShow.count(), 1);
+}
+
+void PlanMasterControllerTest::_testManualCreationHidesTemplates()
+{
+    // Initial state: empty plan → templates shown
+    QVERIFY(_masterController->showCreateFromTemplate());
+    QVERIFY(!_masterController->userSelectedManualCreation());
+
+    QSignalSpy spyShow(_masterController, &PlanMasterController::showCreateFromTemplateChanged);
+    QSignalSpy spyManual(_masterController, &PlanMasterController::userSelectedManualCreationChanged);
+
+    // User clicks "No Template" — hides templates even though plan is empty
+    _masterController->setUserSelectedManualCreation(true);
+
+    QVERIFY(_masterController->userSelectedManualCreation());
+    QVERIFY(!_masterController->showCreateFromTemplate());
+    QCOMPARE(spyShow.count(), 1);
+    QCOMPARE(spyManual.count(), 1);
+
+    // Setting the same value again should not re-emit
+    _masterController->setUserSelectedManualCreation(true);
+    QCOMPARE(spyShow.count(), 1);
+    QCOMPARE(spyManual.count(), 1);
+}
+
+void PlanMasterControllerTest::_testManualCreationRestoredOnRemoveAll()
+{
+    _masterController->setUserSelectedManualCreation(true);
+    _masterController->loadFromFile(":/unittest/MissionPlanner.waypoints");
+    QVERIFY(!_masterController->showCreateFromTemplate());
+
+    QSignalSpy spyShow(_masterController, &PlanMasterController::showCreateFromTemplateChanged);
+    QSignalSpy spyManual(_masterController, &PlanMasterController::userSelectedManualCreationChanged);
+
+    _masterController->removeAll();
+
+    QVERIFY(!_masterController->containsItems());
+    QVERIFY(!_masterController->userSelectedManualCreation());
+    QVERIFY(_masterController->showCreateFromTemplate());
+    QCOMPARE(spyShow.count(), 1);
+    QCOMPARE(spyManual.count(), 1);
+}
+
+void PlanMasterControllerTest::_testManualCreationRestoredOnIndividualItemRemoval()
+{
+    _masterController->setUserSelectedManualCreation(true);
+    _masterController->loadFromFile(":/unittest/MissionPlanner.waypoints");
+    QVERIFY(!_masterController->showCreateFromTemplate());
+
+    QSignalSpy spyShow(_masterController, &PlanMasterController::showCreateFromTemplateChanged);
+    QSignalSpy spyManual(_masterController, &PlanMasterController::userSelectedManualCreationChanged);
+
+    _masterController->missionController()->removeAll();
+    _masterController->geoFenceController()->removeAll();
+    _masterController->rallyPointController()->removeAll();
+
+    QVERIFY(!_masterController->containsItems());
+    QVERIFY(!_masterController->userSelectedManualCreation());
+    QVERIFY(_masterController->showCreateFromTemplate());
+    QCOMPARE(spyShow.count(), 1);
+    QCOMPARE(spyManual.count(), 1);
+}
+
+void PlanMasterControllerTest::_testPlanCreatorsFiltered()
+{
+    // MultiRotor supports StructureScan — expect all 4 creators
+    PlanMasterController multiRotorController(MAV_AUTOPILOT_PX4, MAV_TYPE_QUADROTOR);
+    multiRotorController.setFlyView(false);
+    multiRotorController.start();
+    QVERIFY(multiRotorController.planCreators() != nullptr);
+    const int multiRotorCount = multiRotorController.planCreators()->count();
+    QVERIFY(multiRotorCount > 0);
+
+    // FixedWing does not support StructureScan — expect one fewer creator
+    PlanMasterController fixedWingController(MAV_AUTOPILOT_PX4, MAV_TYPE_FIXED_WING);
+    fixedWingController.setFlyView(false);
+    fixedWingController.start();
+    QVERIFY(fixedWingController.planCreators() != nullptr);
+    const int fixedWingCount = fixedWingController.planCreators()->count();
+    QVERIFY(fixedWingCount > 0);
+
+    QCOMPARE(fixedWingCount, multiRotorCount - 1);
 }
 
 #include "UnitTest.h"

--- a/test/MissionManager/PlanMasterControllerTest.h
+++ b/test/MissionManager/PlanMasterControllerTest.h
@@ -28,6 +28,19 @@ private slots:
     void _testFileNamesClearedOnRemoveAllFromVehicle();
     void _testSaveUpdatesOriginalFileName();
 
+    // showCreateFromTemplate tests — template selection mode
+    void _testTemplateModeHidesTemplatesOnPlanCreatorSelection();
+    void _testTemplateModeHidesTemplatesOnFileLoad();
+    void _testTemplateModeRestoredOnRemoveAll();
+    void _testTemplateModeRestoredOnIndividualItemRemoval();
+
+    // showCreateFromTemplate tests — manual creation mode
+    void _testManualCreationHidesTemplates();
+    void _testManualCreationRestoredOnRemoveAll();
+    void _testManualCreationRestoredOnIndividualItemRemoval();
+
+    void _testPlanCreatorsFiltered();
+
 private:
     enum DirtyScenario {
         UploadPreservesSaveDirtyTrue,


### PR DESCRIPTION
## Summary

Adds vehicle-class filtering to the Plan Creator system and a new **Plan Templates** UI in the Plan Info editor, replacing the old `readyForPlanCreation` / `manualCreation` properties with a cleaner `showCreateFromTemplate` / `userSelectedManualCreation` model.

## Changes

### PlanCreator base class
- Constructor now takes `supportedVehicleClasses` and `blankPlan`; always parents to `planMasterController` (no separate `parent` parameter)
- `supportsVehicleClass()` filter method
- `_blankPlan` and other metadata fields are `private`; subclasses retain `protected` access to `_planMasterController` and `_missionController`

### Vehicle class filtering
- `QGCCorePlugin::planCreators()` virtual method returns the default creator list — custom builds can override it
- `StructureScanPlanCreator` restricted to MultiRotor and VTOL
- `PlanMasterController` lazy-inits the creator list and only rebuilds when the vehicle class changes
- `planCreators()` public `const` getter; `Q_PROPERTY` uses `READ` instead of `MEMBER`

### Template UI
- **Plan Templates** section added to `PlanInfoEditor` with a button per creator, disabled until home position is set
- Blank ("No Template") button sets `userSelectedManualCreation = true` without calling `removeAll()`, preserving the home position
- Plan Info group auto-expands in `PlanTreeView` when returning to create-new-plan mode

### Property renames
- `readyForPlanCreation` → `showCreateFromTemplate` (true when plan is empty **and** user hasn't selected manual creation)
- `manualCreation` → `userSelectedManualCreation`
- `_userSelectedManualCreation` is auto-cleared when the plan becomes empty (via `_updateShowCreateFromTemplate`)

### Other
- Test-only constructor guarded with `QGC_UNITTEST_BUILD` instead of `QT_DEBUG`

### Unit tests
Two groups of `showCreateFromTemplate` tests:

**Template-selection mode** (`userSelectedManualCreation = false`):
- Hides templates on plan creator selection
- Hides templates on file load
- Restores templates on `removeAll()`
- Restores templates on individual item removal

**Manual-creation mode** (`userSelectedManualCreation = true`):
- Hides templates immediately even on empty plan; no duplicate signals on repeated set
- Restores templates (and clears flag) on `removeAll()`
- Restores templates (and clears flag) on individual item removal
