### PR TITLE
Add support for PARAM_ERROR message

### DIFF
--- a/src/Comms/MockLink/MockLink.cc
+++ b/src/Comms/MockLink/MockLink.cc
@@ -1,5 +1,6 @@
 #include "MockLink.h"
 #include "LinkManager.h"
+#include "MAVLinkProtocol.h"
 #include "MockLinkCamera.h"
 #include "MockLinkFTP.h"
 #include "MockLinkGimbal.h"
@@ -1093,6 +1094,14 @@ void MockLink::_handleParamSet(const mavlink_message_t &msg)
         return;
     }
 
+    if (_paramSetFailureMode == FailParamSetParamError) {
+        qCDebug(MockLinkLog) << "Param set failure: PARAM_ERROR" << paramId;
+        _sendParamError(componentId, paramId,
+                        _mapParamName2Value[componentId].keys().indexOf(paramId),
+                        MAV_PARAM_ERROR_VALUE_OUT_OF_RANGE);
+        return;
+    }
+
     // Normal success path
     _setParamFloatUnionIntoMap(componentId, paramId, request.param_value);
 
@@ -1188,6 +1197,12 @@ void MockLink::_handleParamRequestRead(const mavlink_message_t &msg)
         return;
     }
 
+    if (_paramRequestReadFailureMode == FailParamRequestReadParamError) {
+        qCDebug(MockLinkLog) << "Param request read failure: PARAM_ERROR" << paramId;
+        _sendParamError(componentId, paramId, request.param_index, MAV_PARAM_ERROR_DOES_NOT_EXIST);
+        return;
+    }
+
     (void) mavlink_msg_param_value_pack_chan(
         _vehicleSystemId,
         componentId,                                               // component id
@@ -1198,6 +1213,26 @@ void MockLink::_handleParamRequestRead(const mavlink_message_t &msg)
         _mapParamName2MavParamType[componentId][paramId],          // Parameter type
         _mapParamName2Value[componentId].count(),                  // Total number of parameters
         _mapParamName2Value[componentId].keys().indexOf(paramId)   // Index of this parameter
+    );
+    respondWithMavlinkMessage(responseMsg);
+}
+
+void MockLink::_sendParamError(int componentId, const char *paramId, int16_t paramIndex, uint8_t errorCode)
+{
+    mavlink_message_t responseMsg{};
+    char paramIdBuf[MAVLINK_MSG_PARAM_ERROR_FIELD_PARAM_ID_LEN + 1] = {};
+    (void) strncpy(paramIdBuf, paramId, MAVLINK_MSG_PARAM_ERROR_FIELD_PARAM_ID_LEN);
+
+    (void) mavlink_msg_param_error_pack_chan(
+        _vehicleSystemId,
+        static_cast<uint8_t>(componentId),
+        mavlinkChannel(),
+        &responseMsg,
+        MAVLinkProtocol::instance()->getSystemId(),
+        MAVLinkProtocol::getComponentId(),
+        paramIdBuf,
+        paramIndex,
+        errorCode
     );
     respondWithMavlinkMessage(responseMsg);
 }

--- a/src/Comms/MockLink/MockLink.h
+++ b/src/Comms/MockLink/MockLink.h
@@ -119,6 +119,7 @@ public:
         FailParamSetNone,               ///< Normal behavior
         FailParamSetNoAck,              ///< Do not send PARAM_VALUE ack
         FailParamSetFirstAttemptNoAck,  ///< Skip ack on first attempt, respond to retry
+        FailParamSetParamError,         ///< Respond with PARAM_ERROR (VALUE_OUT_OF_RANGE) instead of PARAM_VALUE
     };
     void setParamSetFailureMode(ParamSetFailureMode_t mode) {
         _paramSetFailureMode = mode;
@@ -129,6 +130,7 @@ public:
         FailParamRequestReadNone,               ///< Normal behavior
         FailParamRequestReadNoResponse,         ///< Do not respond to PARAM_REQUEST_READ
         FailParamRequestReadFirstAttemptNoResponse, ///< Skip response on first attempt, respond to retry
+        FailParamRequestReadParamError,         ///< Respond with PARAM_ERROR (DOES_NOT_EXIST) instead of PARAM_VALUE
     };
     void setParamRequestReadFailureMode(ParamRequestReadFailureMode_t mode) {
         _paramRequestReadFailureMode = mode;
@@ -217,6 +219,7 @@ private:
     void _handleLogRequestData(const mavlink_message_t &msg);
     void _handleParamMapRC(const mavlink_message_t &msg);
     void _handleSetupSigning(const mavlink_message_t &msg);
+    void _sendParamError(int componentId, const char *paramId, int16_t paramIndex, uint8_t errorCode);
     void _handleRequestMessage(const mavlink_command_long_t &request, bool &accepted, bool &noAck);
     void _handleRequestMessageAutopilotVersion(const mavlink_command_long_t &request, bool &accepted);
     void _handleRequestMessageDebug(const mavlink_command_long_t &request, bool &accepted, bool &noAck);

--- a/src/FactSystem/ParameterManager.cc
+++ b/src/FactSystem/ParameterManager.cc
@@ -339,17 +339,31 @@ void ParameterManager::_mavlinkParamSet(int componentId, const QString &paramNam
         }
     };
 
+    auto checkForParamError = [componentId, paramName](const mavlink_message_t &message) -> bool {
+        if (message.compid != componentId) {
+            return false;
+        }
+
+        mavlink_param_error_t paramError{};
+        mavlink_msg_param_error_decode(&message, &paramError);
+
+        char paramId[MAVLINK_MSG_PARAM_ERROR_FIELD_PARAM_ID_LEN + 1] = {};
+        (void) strncpy(paramId, paramError.param_id, MAVLINK_MSG_PARAM_ERROR_FIELD_PARAM_ID_LEN);
+
+        return QString(paramId) == paramName;
+    };
+
     // State Machine:
     //  Send PARAM_SET - 2 retries after initial attempt
     //  Increment pending write count
-    //  Wait for PARAM_VALUE ack
+    //  Wait for PARAM_VALUE ack or PARAM_ERROR rejection
     //  Decrement pending write count
     //
     //  timeout:
     //      Decrement pending write count
     //      Back up to PARAM_SET for retries
     //
-    //  error:
+    //  error (PARAM_ERROR or retries exhausted):
     //      Refresh parameter from vehicle
     //      Notify user of failure
 
@@ -365,11 +379,20 @@ void ParameterManager::_mavlinkParamSet(int componentId, const QString &paramNam
     auto retryDecPendingWriteCountState = new FunctionState(QStringLiteral("ParameterManager retry decrement pending write count"), stateMachine, [this]() {
         _decrementPendingWriteCount();
     });
-    auto waitAckState = new WaitForMavlinkMessageState(stateMachine, MAVLINK_MSG_ID_PARAM_VALUE, kWaitForParamValueAckMs, checkForCorrectParamValue);
+    auto errorDecPendingWriteCountState = new FunctionState(QStringLiteral("ParameterManager error decrement pending write count"), stateMachine, [this]() {
+        _decrementPendingWriteCount();
+    });
+    auto waitAckState = new WaitForParamResponseState(stateMachine, kWaitForParamValueAckMs, checkForCorrectParamValue, checkForParamError);
     auto paramRefreshState = new FunctionState(QStringLiteral("ParameterManager param refresh"), stateMachine, [this, componentId, paramName]() {
         refreshParameter(componentId, paramName);
     });
-    auto userNotifyState = new ShowAppMessageState(stateMachine, QStringLiteral("Parameter write failed: param: %1 %2").arg(paramName).arg(_vehicleAndComponentString(componentId)));
+    auto userNotifyState = new FunctionState(QStringLiteral("ParameterManager user notify"), stateMachine, [waitAckState, paramName, this, componentId]() {
+        const QString errorDetail = waitAckState->lastParamErrorString();
+        const QString msg = errorDetail.isEmpty()
+            ? QStringLiteral("Parameter write failed: param: %1 %2").arg(paramName, _vehicleAndComponentString(componentId))
+            : QStringLiteral("Parameter write failed: param: %1 %2 - %3").arg(paramName, _vehicleAndComponentString(componentId), errorDetail);
+        qgcApp()->showAppMessage(msg);
+    });
     auto logSuccessState = new FunctionState(QStringLiteral("ParameterManager log success"), stateMachine, [this, componentId, paramName]() {
         qCDebug(ParameterManagerLog) << "Parameter write succeeded: param:" << paramName << _vehicleAndComponentString(componentId);
         emit _paramSetSuccess(componentId, paramName);
@@ -388,12 +411,16 @@ void ParameterManager::_mavlinkParamSet(int componentId, const QString &paramNam
     decPendingWriteCountState->addThisTransition(&QGCState::advance, logSuccessState);
     logSuccessState->addThisTransition          (&QGCState::advance, finalState);
 
-    // Retry transitions
-    waitAckState->addTransition(waitAckState, &WaitForMavlinkMessageState::timeout, retryDecPendingWriteCountState); // Retry on timeout
+    // Retry transitions (timeout path)
+    waitAckState->addTransition(waitAckState, &WaitStateBase::timeout, retryDecPendingWriteCountState);
     retryDecPendingWriteCountState->addThisTransition(&QGCState::advance, sendParamSetState);
 
-    // Error transitions
-    sendParamSetState->addThisTransition(&QGCState::error, logFailureState); // Error is signaled after retries exhausted or internal error
+    // PARAM_ERROR path (definitive rejection - no retries)
+    waitAckState->addThisTransition                     (&QGCState::error, errorDecPendingWriteCountState);
+    errorDecPendingWriteCountState->addThisTransition   (&QGCState::advance, logFailureState);
+
+    // Error transitions (retries exhausted)
+    sendParamSetState->addThisTransition(&QGCState::error, logFailureState);
 
     // Error state branching transitions
     logFailureState->addThisTransition  (&QGCState::advance, userNotifyState);
@@ -880,21 +907,45 @@ void ParameterManager::_mavlinkParamRequestRead(int componentId, const QString &
         return true;
     };
 
+    auto checkForParamError = [componentId, paramName, paramIndex](const mavlink_message_t &message) -> bool {
+        if (message.compid != componentId) {
+            return false;
+        }
+
+        mavlink_param_error_t paramError{};
+        mavlink_msg_param_error_decode(&message, &paramError);
+
+        char paramId[MAVLINK_MSG_PARAM_ERROR_FIELD_PARAM_ID_LEN + 1] = {};
+        (void) strncpy(paramId, paramError.param_id, MAVLINK_MSG_PARAM_ERROR_FIELD_PARAM_ID_LEN);
+
+        if (paramIndex != -1) {
+            return paramError.param_index == paramIndex;
+        } else {
+            return QString(paramId) == paramName;
+        }
+    };
+
     // State Machine:
     //  Send PARAM_REQUEST_READ - 2 retries after initial attempt
-    //  Wait for PARAM_VALUE ack
+    //  Wait for PARAM_VALUE ack or PARAM_ERROR rejection
     //
     //  timeout:
     //      Back up to PARAM_REQUEST_READ for retries
     //
-    //  error:
+    //  error (PARAM_ERROR or retries exhausted):
     //      Notify user of failure
 
     // Create states
     auto stateMachine = new QGCStateMachine(QStringLiteral("PARAM_REQUEST_READ"), vehicle(), this);
     auto sendParamRequestReadState = new SendMavlinkMessageState(stateMachine, paramRequestReadEncoder, kParamRequestReadRetryCount);
-    auto waitAckState = new WaitForMavlinkMessageState(stateMachine, MAVLINK_MSG_ID_PARAM_VALUE, kWaitForParamValueAckMs, checkForCorrectParamValue);
-    auto userNotifyState = new ShowAppMessageState(stateMachine, QStringLiteral("Parameter read failed: param: %1 %2").arg(paramName).arg(_vehicleAndComponentString(componentId)));
+    auto waitAckState = new WaitForParamResponseState(stateMachine, kWaitForParamValueAckMs, checkForCorrectParamValue, checkForParamError);
+    auto userNotifyState = new FunctionState(QStringLiteral("User notify"), stateMachine, [waitAckState, paramName, this, componentId]() {
+        const QString errorDetail = waitAckState->lastParamErrorString();
+        const QString msg = errorDetail.isEmpty()
+            ? QStringLiteral("Parameter read failed: param: %1 %2").arg(paramName, _vehicleAndComponentString(componentId))
+            : QStringLiteral("Parameter read failed: param: %1 %2 - %3").arg(paramName, _vehicleAndComponentString(componentId), errorDetail);
+        qgcApp()->showAppMessage(msg);
+    });
     auto logSuccessState = new FunctionState(QStringLiteral("Log success"), stateMachine, [this, componentId, paramName, paramIndex]() {
         qCDebug(ParameterManagerLog) << "PARAM_REQUEST_READ succeeded: name:" << paramName << "index" << paramIndex << _vehicleAndComponentString(componentId);
         emit _paramRequestReadSuccess(componentId, paramName, paramIndex);
@@ -911,11 +962,14 @@ void ParameterManager::_mavlinkParamRequestRead(int componentId, const QString &
     waitAckState->addThisTransition             (&QGCState::advance, logSuccessState);
     logSuccessState->addThisTransition          (&QGCState::advance, finalState);
 
-    // Retry transitions
-    waitAckState->addTransition(waitAckState, &WaitForMavlinkMessageState::timeout, sendParamRequestReadState); // Retry on timeout
+    // Retry transitions (timeout path)
+    waitAckState->addTransition(waitAckState, &WaitStateBase::timeout, sendParamRequestReadState);
 
-    // Error transitions
-    sendParamRequestReadState->addThisTransition(&QGCState::error, logFailureState); // Error is signaled after retries exhausted or internal error
+    // PARAM_ERROR path (definitive rejection - no retries)
+    waitAckState->addThisTransition(&QGCState::error, logFailureState);
+
+    // Error transitions (retries exhausted)
+    sendParamRequestReadState->addThisTransition(&QGCState::error, logFailureState);
 
     // Error state branching transitions
     if (notifyFailure) {

--- a/src/Utilities/StateMachine/CMakeLists.txt
+++ b/src/Utilities/StateMachine/CMakeLists.txt
@@ -67,6 +67,8 @@ target_sources(${CMAKE_PROJECT_NAME}
         States/SubMachineState.h
         States/WaitForMavlinkMessageState.cc
         States/WaitForMavlinkMessageState.h
+        States/WaitForParamResponseState.cc
+        States/WaitForParamResponseState.h
         States/WaitForSignalState.cc
         States/WaitForSignalState.h
         States/WaitStateBase.cc

--- a/src/Utilities/StateMachine/QGCStateMachine.h
+++ b/src/Utilities/StateMachine/QGCStateMachine.h
@@ -35,6 +35,7 @@
 #include "ProgressState.h"
 #include "RetryableRequestMessageState.h"
 #include "WaitForMavlinkMessageState.h"
+#include "WaitForParamResponseState.h"
 #include "WaitForSignalState.h"
 #include "WaitStateBase.h"
 #include "StateContext.h"

--- a/src/Utilities/StateMachine/States/WaitForParamResponseState.cc
+++ b/src/Utilities/StateMachine/States/WaitForParamResponseState.cc
@@ -1,0 +1,85 @@
+#include "WaitForParamResponseState.h"
+#include "Vehicle.h"
+#include "QGCLoggingCategory.h"
+
+#include <utility>
+
+WaitForParamResponseState::WaitForParamResponseState(QState *parent, int timeoutMsecs,
+                                                     Predicate paramValuePredicate,
+                                                     Predicate paramErrorPredicate)
+    : WaitStateBase(QStringLiteral("WaitForParamResponseState"), parent, timeoutMsecs)
+    , _paramValuePredicate(std::move(paramValuePredicate))
+    , _paramErrorPredicate(std::move(paramErrorPredicate))
+{
+}
+
+void WaitForParamResponseState::connectWaitSignal()
+{
+    connect(vehicle(), &Vehicle::mavlinkMessageReceived, this, &WaitForParamResponseState::_messageReceived, Qt::UniqueConnection);
+}
+
+void WaitForParamResponseState::disconnectWaitSignal()
+{
+    if (vehicle()) {
+        disconnect(vehicle(), &Vehicle::mavlinkMessageReceived, this, &WaitForParamResponseState::_messageReceived);
+    }
+}
+
+void WaitForParamResponseState::_messageReceived(const mavlink_message_t &message)
+{
+    if (message.msgid == MAVLINK_MSG_ID_PARAM_VALUE) {
+        if (_paramValuePredicate && !_paramValuePredicate(message)) {
+            return;
+        }
+
+        qCDebug(QGCStateMachineLog) << "Received PARAM_VALUE" << stateName();
+        waitComplete();
+        return;
+    }
+
+    if (message.msgid == MAVLINK_MSG_ID_PARAM_ERROR) {
+        if (_paramErrorPredicate && !_paramErrorPredicate(message)) {
+            return;
+        }
+
+        mavlink_param_error_t paramError{};
+        mavlink_msg_param_error_decode(&message, &paramError);
+
+        _lastParamError = paramError.error;
+        _lastParamErrorString = _paramErrorToString(paramError.error);
+
+        char paramId[MAVLINK_MSG_PARAM_ERROR_FIELD_PARAM_ID_LEN + 1] = {};
+        (void) strncpy(paramId, paramError.param_id, MAVLINK_MSG_PARAM_ERROR_FIELD_PARAM_ID_LEN);
+
+        qCDebug(QGCStateMachineLog) << "Received PARAM_ERROR for" << paramId
+                                    << "error:" << _lastParamErrorString << stateName();
+        waitFailed();
+        return;
+    }
+}
+
+QString WaitForParamResponseState::_paramErrorToString(uint8_t errorCode)
+{
+    switch (errorCode) {
+    case MAV_PARAM_ERROR_NO_ERROR:
+        return QStringLiteral("No error");
+    case MAV_PARAM_ERROR_DOES_NOT_EXIST:
+        return QStringLiteral("Parameter does not exist");
+    case MAV_PARAM_ERROR_VALUE_OUT_OF_RANGE:
+        return QStringLiteral("Value out of range");
+    case MAV_PARAM_ERROR_PERMISSION_DENIED:
+        return QStringLiteral("Permission denied");
+    case MAV_PARAM_ERROR_COMPONENT_NOT_FOUND:
+        return QStringLiteral("Component not found");
+    case MAV_PARAM_ERROR_READ_ONLY:
+        return QStringLiteral("Parameter is read-only");
+    case MAV_PARAM_ERROR_TYPE_UNSUPPORTED:
+        return QStringLiteral("Parameter type unsupported");
+    case MAV_PARAM_ERROR_TYPE_MISMATCH:
+        return QStringLiteral("Parameter type mismatch");
+    case MAV_PARAM_ERROR_READ_FAIL:
+        return QStringLiteral("Parameter read failed");
+    default:
+        return QStringLiteral("Unknown error (%1)").arg(errorCode);
+    }
+}

--- a/src/Utilities/StateMachine/States/WaitForParamResponseState.h
+++ b/src/Utilities/StateMachine/States/WaitForParamResponseState.h
@@ -1,0 +1,51 @@
+#pragma once
+
+#include "WaitStateBase.h"
+#include "QGCMAVLink.h"
+
+#include <cstdint>
+#include <functional>
+
+class Vehicle;
+
+/// Waits for either PARAM_VALUE (success) or PARAM_ERROR (rejection) from the vehicle.
+/// On PARAM_VALUE matching predicate: calls waitComplete() (emits advance())
+/// On PARAM_ERROR matching predicate: stores error info, calls waitFailed() (emits error())
+/// On timeout: existing timeout() signal fires (for retry path)
+class WaitForParamResponseState : public WaitStateBase
+{
+    Q_OBJECT
+    Q_DISABLE_COPY(WaitForParamResponseState)
+
+public:
+    using Predicate = std::function<bool(const mavlink_message_t &message)>;
+
+    /// @param parent Parent state
+    /// @param timeoutMsecs Timeout in milliseconds to wait for response, 0 to wait forever
+    /// @param paramValuePredicate Predicate to filter PARAM_VALUE messages
+    /// @param paramErrorPredicate Predicate to filter PARAM_ERROR messages
+    WaitForParamResponseState(QState *parent, int timeoutMsecs,
+                              Predicate paramValuePredicate,
+                              Predicate paramErrorPredicate);
+
+    /// @return The last PARAM_ERROR error code received
+    uint8_t lastParamError() const { return _lastParamError; }
+
+    /// @return Human-readable string for the last PARAM_ERROR received
+    QString lastParamErrorString() const { return _lastParamErrorString; }
+
+protected:
+    void connectWaitSignal() override;
+    void disconnectWaitSignal() override;
+
+private slots:
+    void _messageReceived(const mavlink_message_t &message);
+
+private:
+    static QString _paramErrorToString(uint8_t errorCode);
+
+    Predicate _paramValuePredicate;
+    Predicate _paramErrorPredicate;
+    uint8_t _lastParamError = 0;
+    QString _lastParamErrorString;
+};

--- a/test/FactSystem/ParameterManagerTest.cc
+++ b/test/FactSystem/ParameterManagerTest.cc
@@ -182,6 +182,35 @@ void ParameterManagerTest::_paramReadNoResponse()
     _disconnectMockLink();
 }
 
+void ParameterManagerTest::_paramWriteParamError()
+{
+    _setParamWithFailureMode(MockLink::FailParamSetParamError, false /* expectSuccess */);
+}
+
+void ParameterManagerTest::_paramReadParamError()
+{
+    QVERIFY2(!_mockLink, "MockLink already connected");
+    _connectMockLink();
+    QVERIFY(_mockLink);
+    QVERIFY(_vehicle);
+    ParameterManager* const paramManager = _vehicle->parameterManager();
+    QVERIFY(paramManager);
+    _mockLink->setParamRequestReadFailureMode(MockLink::FailParamRequestReadParamError);
+    Fact* const fact = paramManager->getParameter(MAV_COMP_ID_AUTOPILOT1, QStringLiteral("BAT1_V_CHARGED"));
+    QVERIFY(fact);
+    QSignalSpy vehicleUpdatedSpy(fact, &Fact::vehicleUpdated);
+    QSignalSpy paramReadFailureSpy(paramManager, &ParameterManager::_paramRequestReadFailure);
+    QVERIFY(vehicleUpdatedSpy.isValid());
+    QVERIFY(paramReadFailureSpy.isValid());
+    paramManager->refreshParameter(MAV_COMP_ID_AUTOPILOT1, fact->name());
+    // PARAM_ERROR should cause immediate failure - no retries needed, so wait just one ack interval plus buffer
+    const int maxWaitTimeMs = ParameterManager::kWaitForParamValueAckMs + TestTimeout::shortMs();
+    QVERIFY_SIGNAL_WAIT(paramReadFailureSpy, maxWaitTimeMs);
+    QCOMPARE(paramReadFailureSpy.count(), 1);
+    QCOMPARE(vehicleUpdatedSpy.count(), 0);
+    _disconnectMockLink();
+}
+
 void ParameterManagerTest::_setParamWithFailureMode(MockLink::ParamSetFailureMode_t failureMode, bool expectSuccess)
 {
     QVERIFY2(!_mockLink, "MockLink already connected");

--- a/test/FactSystem/ParameterManagerTest.h
+++ b/test/FactSystem/ParameterManagerTest.h
@@ -17,6 +17,8 @@ private slots:
     void _paramWriteNoAckPermanent();
     void _paramReadFirstAttemptNoResponseRetry();
     void _paramReadNoResponse();
+    void _paramWriteParamError();
+    void _paramReadParamError();
     void _FTPnoFailure();
     void _FTPChangeParam();
 


### PR DESCRIPTION
## Description

Allows the vehicle to definitively reject a parameter set or read instead of letting it time out. The new WaitForParamResponseState listens for either PARAM_VALUE (success) or PARAM_ERROR (failure), and the failure toast now includes the human-readable error detail.

Adds MockLink failure modes and unit tests for both the write and read paths.

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] CI/Build changes
- [ ] Other

## Testing

- [x] Tested locally
- [x] Added/updated unit tests
- [x] Tested with simulator (SITL)
- [ ] Tested with hardware

### Platforms Tested

- [x] Linux
- [ ] Windows
- [ ] macOS
- [ ] Android
- [ ] iOS

### Flight Stacks Tested

- [x] PX4
- [ ] ArduPilot

## Screenshots

As an example, I made PX4 answer with a type-mismatch error every time:

<img width="863" height="309" alt="image" src="https://github.com/user-attachments/assets/cfa6e1c6-2d7c-4616-97d1-620b5bb528d4" />


## Checklist

- [x] I have read the [Contribution Guidelines](CONTRIBUTING.md)
- [x I have read the [Code of Conduct](CODE_OF_CONDUCT.md)
- [x] My code follows the project's coding standards
- [x] I have added tests that prove my fix/feature works
- [x] New and existing unit tests pass locally

## Related Issues

Closes https://github.com/mavlink/qgroundcontrol/issues/13549.

https://github.com/mavlink/mavlink/pull/2344
https://github.com/mavlink/mavlink/pull/2358

FYI @hamishwillee 

---
By submitting this pull request, I confirm that my contribution is made under the terms of the project's dual license (Apache 2.0 and GPL v3).
