### PR TITLE
fix: VehicleCameraControl firmwareVersion is backwards from MAVLink spec and doesn't include dev

### DIFF
--- a/src/Camera/VehicleCameraControl.cc
+++ b/src/Camera/VehicleCameraControl.cc
@@ -260,10 +260,17 @@ MavlinkCameraControlInterface::CapturePhotosState VehicleCameraControl::captureP
 
 QString VehicleCameraControl::firmwareVersion() const
 {
-    int major = (_mavlinkCameraInfo.firmware_version >> 24) & 0xFF;
-    int minor = (_mavlinkCameraInfo.firmware_version >> 16) & 0xFF;
-    int build = _mavlinkCameraInfo.firmware_version & 0xFFFF;
-    return QString::asprintf("%d.%d.%d", major, minor, build);
+    if (_mavlinkCameraInfo.firmware_version == 0) {
+        return {};
+    }
+    int major = (_mavlinkCameraInfo.firmware_version)       & 0xFF;
+    int minor = (_mavlinkCameraInfo.firmware_version >> 8)  & 0xFF;
+    int patch = (_mavlinkCameraInfo.firmware_version >> 16) & 0xFF;
+    int dev   = (_mavlinkCameraInfo.firmware_version >> 24) & 0xFF;
+    if (dev != 0) {
+        return QString::asprintf("%d.%d.%d.%d", major, minor, patch, dev);
+    }
+    return QString::asprintf("%d.%d.%d", major, minor, patch);
 }
 
 QString VehicleCameraControl::recordTimeStr() const


### PR DESCRIPTION
## Description
According to MAVLink spec for CAMERA_INFORMATION, Version of the camera firmware, encoded as: (Dev & 0xff) << 24 + (Patch & 0xff) << 16 + (Minor & 0xff) << 8 + (Major & 0xff). Use 0 if not known. 

When viewing the version of my camera server in a custom QGC, I noticed the firmware version was reversed. This is because it isn't following the MAVLink spec correctly.

As a note, I made the intentional choice to make dev optional, because not everyone uses it. Even in the MAVSDK camera server example, they don't use dev and instead just do "1.0.0".

## Type of Change
<!-- Put an 'x' in the relevant boxes -->
- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] CI/Build changes
- [ ] Other

## Testing
<!-- Describe the tests you ran and how to reproduce them -->
- [x] Tested locally
- [ ] Added/updated unit tests
- [ ] Tested with simulator (SITL)
- [ ] Tested with hardware

### Platforms Tested
<!-- Check all that apply -->
- [x] Linux
- [ ] Windows
- [ ] macOS
- [ ] Android
- [ ] iOS

### Flight Stacks Tested
<!-- If applicable -->
- [ ] PX4
- [ ] ArduPilot

## Screenshots
<!-- If applicable, add screenshots to help explain your changes -->

## Checklist
<!-- Go over all the following points, and put an 'x' in all the boxes that apply -->
- [x] I have read the [Contribution Guidelines](CONTRIBUTING.md)
- [x] I have read the [Code of Conduct](CODE_OF_CONDUCT.md)
- [x] My code follows the project's coding standards
- [] I have added tests that prove my fix/feature works
- [x] New and existing unit tests pass locally

## Related Issues
<!-- Link any related issues using #issue_number -->

---
By submitting this pull request, I confirm that my contribution is made under the terms of the project's dual license (Apache 2.0 and GPL v3).
