### PR TITLE
feat(AnalyzeView): add Onboard Logs (FTP) tab using @MAV_LOG

### DIFF
--- a/src/API/QGCCorePlugin.cc
+++ b/src/API/QGCCorePlugin.cc
@@ -67,6 +67,11 @@ const QVariantList &QGCCorePlugin::analyzePages()
             QUrl::fromUserInput(QStringLiteral("qrc:/qmlimages/OnboardLogIcon.svg")),
             nullptr, true /* requiresVehicle */)),
         QVariant::fromValue(new QmlComponentInfo(
+            tr("Onboard Logs (FTP)"),
+            QUrl::fromUserInput(QStringLiteral("qrc:/qml/QGroundControl/AnalyzeView/OnboardLogsFtp/OnboardLogFtpPage.qml")),
+            QUrl::fromUserInput(QStringLiteral("qrc:/qmlimages/OnboardLogIcon.svg")),
+            nullptr, true /* requiresVehicle */)),
+        QVariant::fromValue(new QmlComponentInfo(
             tr("GeoTag Images"),
             QUrl::fromUserInput(QStringLiteral("qrc:/qml/QGroundControl/AnalyzeView/GeoTag/GeoTagPage.qml")),
             QUrl::fromUserInput(QStringLiteral("qrc:/qml/QGroundControl/AnalyzeView/GeoTag/GeoTagIcon.svg")))),

--- a/src/AnalyzeView/CMakeLists.txt
+++ b/src/AnalyzeView/CMakeLists.txt
@@ -7,6 +7,7 @@ add_subdirectory(GeoTag)
 add_subdirectory(MAVLinkConsole)
 add_subdirectory(MAVLinkInspector)
 add_subdirectory(OnboardLogs)
+add_subdirectory(OnboardLogsFtp)
 
 target_sources(${CMAKE_PROJECT_NAME}
     PRIVATE
@@ -31,6 +32,7 @@ qt_add_qml_module(AnalyzeViewModule
         MAVLinkInspector/MAVLinkMessageButton.qml
         MAVLinkInspector/MAVLinkInspectorPage.qml
         OnboardLogs/OnboardLogPage.qml
+        OnboardLogsFtp/OnboardLogFtpPage.qml
         Vibration/VibrationPage.qml
     NO_PLUGIN
 )

--- a/src/AnalyzeView/OnboardLogsFtp/CMakeLists.txt
+++ b/src/AnalyzeView/OnboardLogsFtp/CMakeLists.txt
@@ -1,0 +1,14 @@
+# ============================================================================
+# Onboard Logs FTP Module
+# Onboard log list and download via MAVLink FTP (@MAV_LOG)
+# ============================================================================
+
+target_sources(${CMAKE_PROJECT_NAME}
+    PRIVATE
+        OnboardLogFtpController.cc
+        OnboardLogFtpController.h
+        OnboardLogFtpEntry.cc
+        OnboardLogFtpEntry.h
+)
+
+target_include_directories(${CMAKE_PROJECT_NAME} PRIVATE ${CMAKE_CURRENT_SOURCE_DIR})

--- a/src/AnalyzeView/OnboardLogsFtp/OnboardLogFtpController.cc
+++ b/src/AnalyzeView/OnboardLogsFtp/OnboardLogFtpController.cc
@@ -1,0 +1,456 @@
+#include "OnboardLogFtpController.h"
+#include "AppSettings.h"
+#include "FTPManager.h"
+#include "MultiVehicleManager.h"
+#include "OnboardLogFtpEntry.h"
+#include "QGC.h"
+#include "QGCLoggingCategory.h"
+#include "QmlObjectListModel.h"
+#include "SettingsManager.h"
+#include "Vehicle.h"
+#include "VehicleLinkManager.h"
+
+#include <QtCore/QDateTime>
+#include <QtCore/QDir>
+#include <QtCore/QFile>
+#include <QtCore/QTimeZone>
+
+QGC_LOGGING_CATEGORY(OnboardLogFtpControllerLog, "AnalyzeView.OnboardLogFtpController")
+
+// MAVLink FTP defines "@MAV_LOG" as the virtual log directory.
+// Older firmware that doesn't implement the alias requires the physical path
+// instead — which is firmware-specific.
+static constexpr const char *kMavlinkLogRoot = "@MAV_LOG";
+static constexpr const char *kPx4LogRootFallback = "/fs/microsd/log";
+static constexpr const char *kApmLogRootFallback = "/APM/LOGS";
+
+OnboardLogFtpController::OnboardLogFtpController(QObject *parent)
+    : QObject(parent)
+    , _logEntriesModel(new QmlObjectListModel(this))
+{
+    qCDebug(OnboardLogFtpControllerLog) << this;
+
+    (void) connect(MultiVehicleManager::instance(), &MultiVehicleManager::activeVehicleChanged, this, &OnboardLogFtpController::_setActiveVehicle);
+    _setActiveVehicle(MultiVehicleManager::instance()->activeVehicle());
+}
+
+OnboardLogFtpController::~OnboardLogFtpController()
+{
+    qCDebug(OnboardLogFtpControllerLog) << this;
+}
+
+void OnboardLogFtpController::_setActiveVehicle(Vehicle *vehicle)
+{
+    if (vehicle == _vehicle) {
+        return;
+    }
+
+    if (_vehicle) {
+        _logEntriesModel->clearAndDeleteContents();
+        FTPManager *const ftp = _vehicle->ftpManager();
+        (void) disconnect(ftp, &FTPManager::listDirectoryComplete, this, &OnboardLogFtpController::_listDirComplete);
+        (void) disconnect(ftp, &FTPManager::downloadComplete,      this, &OnboardLogFtpController::_downloadComplete);
+        (void) disconnect(ftp, &FTPManager::commandProgress,       this, &OnboardLogFtpController::_downloadProgress);
+
+        _listState = Idle;
+        _dirsToList.clear();
+        _logIdCounter = 0;
+        _downloadQueue.clear();
+        _currentDownloadEntry = nullptr;
+    }
+
+    _vehicle = vehicle;
+}
+
+void OnboardLogFtpController::refresh()
+{
+    _logEntriesModel->clearAndDeleteContents();
+
+    if (!_vehicle) {
+        qCWarning(OnboardLogFtpControllerLog) << "refresh: no active vehicle";
+        return;
+    }
+
+    if (!_vehicle->capabilitiesKnown() || !(_vehicle->capabilityBits() & MAV_PROTOCOL_CAPABILITY_FTP)) {
+        qCWarning(OnboardLogFtpControllerLog) << "refresh: vehicle does not advertise MAV_PROTOCOL_CAPABILITY_FTP"
+            << "(capsKnown:" << _vehicle->capabilitiesKnown() << ")";
+        return;
+    }
+
+    _startListing();
+}
+
+void OnboardLogFtpController::_startListing()
+{
+    _dirsToList.clear();
+    _logIdCounter = 0;
+    _logRoot = QString::fromLatin1(kMavlinkLogRoot);
+    _triedFallbackRoot = false;
+
+    FTPManager *const ftp = _vehicle->ftpManager();
+    (void) disconnect(ftp, &FTPManager::listDirectoryComplete, this, &OnboardLogFtpController::_listDirComplete);
+    (void) connect(ftp, &FTPManager::listDirectoryComplete, this, &OnboardLogFtpController::_listDirComplete);
+
+    _setListing(true);
+    _listRoot();
+}
+
+void OnboardLogFtpController::_listRoot()
+{
+    _listState = ListingRoot;
+
+    qCDebug(OnboardLogFtpControllerLog) << "listing root" << _logRoot;
+
+    if (!_vehicle->ftpManager()->listDirectory(MAV_COMP_ID_AUTOPILOT1, _logRoot)) {
+        qCWarning(OnboardLogFtpControllerLog) << "failed to start root listing for" << _logRoot;
+        _finishListing();
+    }
+}
+
+void OnboardLogFtpController::_listDirComplete(const QStringList &dirList, const QString &errorMsg)
+{
+    if (!errorMsg.isEmpty()) {
+        if (_listState == ListingRoot && !_triedFallbackRoot && _vehicle) {
+            const char *fallback = nullptr;
+            if (_vehicle->px4Firmware()) {
+                fallback = kPx4LogRootFallback;
+            } else if (_vehicle->apmFirmware()) {
+                fallback = kApmLogRootFallback;
+            }
+
+            if (fallback) {
+                qCDebug(OnboardLogFtpControllerLog) << "root listing of" << _logRoot << "failed (" << errorMsg
+                    << "), falling back to" << fallback;
+                _triedFallbackRoot = true;
+                _logRoot = QString::fromLatin1(fallback);
+                _listRoot();
+                return;
+            }
+        }
+
+        qCWarning(OnboardLogFtpControllerLog) << "listing error:" << errorMsg;
+        _finishListing();
+        return;
+    }
+
+    if (_listState == ListingRoot) {
+        // The root listing may contain log files directly (flat layout, e.g. @MAV_LOG)
+        // and/or date subdirectories to descend into (PX4 fallback /fs/microsd/log).
+        const uint flatLogs = _processFileEntries(dirList, QString());
+
+        for (const QString &entry : dirList) {
+            if (entry.startsWith(QLatin1Char('D'))) {
+                const QString dirName = entry.mid(1);
+                if (!dirName.isEmpty()) {
+                    _dirsToList.append(dirName);
+                }
+            }
+        }
+
+        _dirsToList.sort();
+        qCDebug(OnboardLogFtpControllerLog) << "root listing of" << _logRoot
+            << "found" << flatLogs << "flat logs and" << _dirsToList.size() << "subdirectories";
+
+        _listState = ListingSubdir;
+        _listNextSubdir();
+        return;
+    }
+
+    const QString currentDir = _dirsToList.isEmpty() ? QString() : _dirsToList.first();
+    const uint logsFoundInDir = _processFileEntries(dirList, currentDir);
+
+    qCDebug(OnboardLogFtpControllerLog) << currentDir << "->" << logsFoundInDir << "logs";
+
+    if (!_dirsToList.isEmpty()) {
+        _dirsToList.removeFirst();
+    }
+
+    _listNextSubdir();
+}
+
+uint OnboardLogFtpController::_processFileEntries(const QStringList &dirList, const QString &subdir)
+{
+    const QDate dirDate = subdir.isEmpty() ? QDate() : QDate::fromString(subdir, QStringLiteral("yyyy-MM-dd"));
+    uint logsFound = 0;
+
+    for (const QString &entry : dirList) {
+        if (!entry.startsWith(QLatin1Char('F'))) {
+            continue;
+        }
+
+        const QString fileInfo = entry.mid(1);
+        const int tabIdx = fileInfo.indexOf(QLatin1Char('\t'));
+        if (tabIdx < 0) {
+            continue;
+        }
+
+        const QString fileName = fileInfo.left(tabIdx);
+        const QString sizeStr = fileInfo.mid(tabIdx + 1);
+
+        if (!fileName.endsWith(QStringLiteral(".ulg"), Qt::CaseInsensitive) &&
+            !fileName.endsWith(QStringLiteral(".bin"), Qt::CaseInsensitive)) {
+            continue;
+        }
+
+        bool sizeOk = false;
+        const uint fileSize = sizeStr.toUInt(&sizeOk);
+        if (!sizeOk) {
+            continue;
+        }
+
+        QDateTime dateTime;
+        if (dirDate.isValid()) {
+            const QString baseName = fileName.left(fileName.lastIndexOf(QLatin1Char('.')));
+            const QTime fileTime = QTime::fromString(baseName, QStringLiteral("HH_mm_ss"));
+            if (fileTime.isValid()) {
+                dateTime = QDateTime(dirDate, fileTime, QTimeZone::UTC);
+            } else {
+                dateTime = QDateTime(dirDate, QTime(), QTimeZone::UTC);
+            }
+        }
+
+        const QString ftpPath = subdir.isEmpty()
+            ? (_logRoot + QStringLiteral("/") + fileName)
+            : (_logRoot + QStringLiteral("/") + subdir + QStringLiteral("/") + fileName);
+
+        QGCOnboardLogFtpEntry *const logEntry = new QGCOnboardLogFtpEntry(_logIdCounter++, dateTime, fileSize, true, this);
+        logEntry->setFtpPath(ftpPath);
+        logEntry->setStatus(tr("Available"));
+        _logEntriesModel->append(logEntry);
+        logsFound++;
+    }
+
+    return logsFound;
+}
+
+void OnboardLogFtpController::_listNextSubdir()
+{
+    if (_dirsToList.isEmpty()) {
+        qCDebug(OnboardLogFtpControllerLog) << "listing complete, found" << _logEntriesModel->count() << "logs";
+        _finishListing();
+        return;
+    }
+
+    const QString subdir = _dirsToList.first();
+    const QString path = _logRoot + QStringLiteral("/") + subdir;
+
+    qCDebug(OnboardLogFtpControllerLog) << "listing subdir" << path;
+
+    if (!_vehicle->ftpManager()->listDirectory(MAV_COMP_ID_AUTOPILOT1, path)) {
+        qCWarning(OnboardLogFtpControllerLog) << "failed to list subdir" << path;
+        _dirsToList.removeFirst();
+        _listNextSubdir();
+    }
+}
+
+void OnboardLogFtpController::_finishListing()
+{
+    _listState = Idle;
+    _setListing(false);
+}
+
+void OnboardLogFtpController::download(const QString &path)
+{
+    const QString dir = path.isEmpty() ? SettingsManager::instance()->appSettings()->logSavePath() : path;
+    _downloadToDirectory(dir);
+}
+
+void OnboardLogFtpController::_downloadToDirectory(const QString &dir)
+{
+    _downloadPath = dir;
+    if (_downloadPath.isEmpty()) {
+        return;
+    }
+
+    if (!_downloadPath.endsWith(QDir::separator())) {
+        _downloadPath += QDir::separator();
+    }
+
+    _downloadQueue.clear();
+    const int numLogs = _logEntriesModel->count();
+    for (int i = 0; i < numLogs; i++) {
+        QGCOnboardLogFtpEntry *const entry = _logEntriesModel->value<QGCOnboardLogFtpEntry*>(i);
+        if (entry && entry->selected() && !entry->ftpPath().isEmpty()) {
+            entry->setStatus(tr("Waiting"));
+            _downloadQueue.enqueue(entry);
+        }
+    }
+
+    if (_downloadQueue.isEmpty()) {
+        qCWarning(OnboardLogFtpControllerLog) << "no selected logs have FTP paths for download";
+        return;
+    }
+
+    qCDebug(OnboardLogFtpControllerLog) << "queued" << _downloadQueue.size() << "logs for download to" << _downloadPath;
+    _setDownloading(true);
+
+    _downloadEntry(_downloadQueue.dequeue());
+}
+
+void OnboardLogFtpController::_downloadEntry(QGCOnboardLogFtpEntry *entry)
+{
+    if (!entry || !_vehicle) {
+        return;
+    }
+
+    entry->setSelected(false);
+    emit selectionChanged();
+
+    _currentDownloadEntry = entry;
+    _downloadBytesAtLastUpdate = 0;
+    _downloadRateAvg = 0.;
+    _downloadElapsed.start();
+
+    entry->setStatus(tr("Downloading"));
+
+    QString localFilename;
+    if (entry->time().isValid() && entry->time().date().year() >= 2010) {
+        localFilename = entry->time().toString(QStringLiteral("yyyy-M-d-hh-mm-ss")) + QStringLiteral(".ulg");
+    } else {
+        localFilename = QStringLiteral("log_") + QString::number(entry->id()) + QStringLiteral(".ulg");
+    }
+
+    if (QFile::exists(_downloadPath + localFilename)) {
+        const QStringList parts = localFilename.split(QLatin1Char('.'));
+        uint numDups = 0;
+        do {
+            numDups++;
+            localFilename = parts[0] + QStringLiteral("_") + QString::number(numDups) + QStringLiteral(".") + parts[1];
+        } while (QFile::exists(_downloadPath + localFilename));
+    }
+
+    FTPManager *const ftp = _vehicle->ftpManager();
+    (void) disconnect(ftp, &FTPManager::downloadComplete, this, &OnboardLogFtpController::_downloadComplete);
+    (void) disconnect(ftp, &FTPManager::commandProgress,  this, &OnboardLogFtpController::_downloadProgress);
+    (void) connect(ftp, &FTPManager::downloadComplete, this, &OnboardLogFtpController::_downloadComplete);
+    (void) connect(ftp, &FTPManager::commandProgress,  this, &OnboardLogFtpController::_downloadProgress);
+
+    qCDebug(OnboardLogFtpControllerLog) << "downloading" << entry->ftpPath() << "to" << _downloadPath + localFilename;
+
+    if (!ftp->download(MAV_COMP_ID_AUTOPILOT1, entry->ftpPath(), _downloadPath, localFilename, true)) {
+        qCWarning(OnboardLogFtpControllerLog) << "failed to start download for" << entry->ftpPath();
+        entry->setStatus(tr("Error"));
+        _currentDownloadEntry = nullptr;
+
+        if (!_downloadQueue.isEmpty()) {
+            _downloadEntry(_downloadQueue.dequeue());
+        } else {
+            _setDownloading(false);
+        }
+    }
+}
+
+void OnboardLogFtpController::_downloadComplete(const QString &file, const QString &errorMsg)
+{
+    if (!_currentDownloadEntry) {
+        return;
+    }
+
+    if (errorMsg.isEmpty()) {
+        _currentDownloadEntry->setStatus(tr("Downloaded"));
+        qCDebug(OnboardLogFtpControllerLog) << "download complete" << file;
+    } else {
+        _currentDownloadEntry->setStatus(tr("Error"));
+        qCWarning(OnboardLogFtpControllerLog) << "download error:" << errorMsg;
+    }
+
+    _currentDownloadEntry = nullptr;
+
+    if (!_downloadQueue.isEmpty()) {
+        _downloadEntry(_downloadQueue.dequeue());
+    } else {
+        _setDownloading(false);
+    }
+}
+
+void OnboardLogFtpController::_downloadProgress(float value)
+{
+    if (!_currentDownloadEntry) {
+        return;
+    }
+
+    if (_downloadElapsed.elapsed() < kGUIRateMs) {
+        return;
+    }
+
+    const size_t totalBytes = static_cast<size_t>(static_cast<qreal>(_currentDownloadEntry->size()) * static_cast<qreal>(value));
+    const size_t bytesSinceLastUpdate = totalBytes - _downloadBytesAtLastUpdate;
+    const qreal elapsedSec = _downloadElapsed.elapsed() / 1000.0;
+    const qreal rate = (elapsedSec > 0) ? (bytesSinceLastUpdate / elapsedSec) : 0;
+    _downloadRateAvg = (_downloadRateAvg * 0.95) + (rate * 0.05);
+    _downloadBytesAtLastUpdate = totalBytes;
+    _downloadElapsed.start();
+
+    const QString status = QStringLiteral("%1 (%2/s)").arg(
+        QGC::bigSizeToString(totalBytes),
+        QGC::bigSizeToString(_downloadRateAvg));
+
+    _currentDownloadEntry->setStatus(status);
+}
+
+void OnboardLogFtpController::cancel()
+{
+    if (!_vehicle) {
+        return;
+    }
+
+    if (_requestingLogEntries) {
+        _vehicle->ftpManager()->cancelListDirectory();
+        _dirsToList.clear();
+        _finishListing();
+    }
+
+    if (_downloadingLogs) {
+        _vehicle->ftpManager()->cancelDownload();
+        if (_currentDownloadEntry) {
+            _currentDownloadEntry->setStatus(tr("Canceled"));
+            _currentDownloadEntry = nullptr;
+        }
+        _downloadQueue.clear();
+    }
+
+    _resetSelection(true);
+    _setDownloading(false);
+}
+
+void OnboardLogFtpController::_resetSelection(bool canceled)
+{
+    const int numLogs = _logEntriesModel->count();
+    for (int i = 0; i < numLogs; i++) {
+        QGCOnboardLogFtpEntry *const entry = _logEntriesModel->value<QGCOnboardLogFtpEntry*>(i);
+        if (!entry) {
+            continue;
+        }
+
+        if (entry->selected()) {
+            if (canceled) {
+                entry->setStatus(tr("Canceled"));
+            }
+            entry->setSelected(false);
+        }
+    }
+
+    emit selectionChanged();
+}
+
+void OnboardLogFtpController::_setDownloading(bool active)
+{
+    if (_downloadingLogs != active) {
+        _downloadingLogs = active;
+        if (_vehicle) {
+            _vehicle->vehicleLinkManager()->setCommunicationLostEnabled(!active);
+        }
+        emit downloadingLogsChanged();
+    }
+}
+
+void OnboardLogFtpController::_setListing(bool active)
+{
+    if (_requestingLogEntries != active) {
+        _requestingLogEntries = active;
+        if (_vehicle) {
+            _vehicle->vehicleLinkManager()->setCommunicationLostEnabled(!active);
+        }
+        emit requestingListChanged();
+    }
+}

--- a/src/AnalyzeView/OnboardLogsFtp/OnboardLogFtpController.h
+++ b/src/AnalyzeView/OnboardLogsFtp/OnboardLogFtpController.h
@@ -1,0 +1,83 @@
+#pragma once
+
+#include <QtCore/QElapsedTimer>
+#include <QtCore/QLoggingCategory>
+#include <QtCore/QObject>
+#include <QtCore/QQueue>
+#include <QtQmlIntegration/QtQmlIntegration>
+
+Q_DECLARE_LOGGING_CATEGORY(OnboardLogFtpControllerLog)
+
+class QGCOnboardLogFtpEntry;
+class QmlObjectListModel;
+class Vehicle;
+
+class OnboardLogFtpController : public QObject
+{
+    Q_OBJECT
+    QML_ELEMENT
+    QML_SINGLETON
+    Q_MOC_INCLUDE("Vehicle.h")
+    Q_MOC_INCLUDE("QmlObjectListModel.h")
+    Q_PROPERTY(QmlObjectListModel *model          READ _getModel            CONSTANT)
+    Q_PROPERTY(bool               requestingList  READ _getRequestingList   NOTIFY requestingListChanged)
+    Q_PROPERTY(bool               downloadingLogs READ _getDownloadingLogs  NOTIFY downloadingLogsChanged)
+
+public:
+    explicit OnboardLogFtpController(QObject *parent = nullptr);
+    ~OnboardLogFtpController();
+
+    Q_INVOKABLE void refresh();
+    Q_INVOKABLE void download(const QString &path = QString());
+    Q_INVOKABLE void cancel();
+
+signals:
+    void requestingListChanged();
+    void downloadingLogsChanged();
+    void selectionChanged();
+
+private slots:
+    void _setActiveVehicle(Vehicle *vehicle);
+    void _listDirComplete(const QStringList &dirList, const QString &errorMsg);
+    void _downloadComplete(const QString &file, const QString &errorMsg);
+    void _downloadProgress(float value);
+
+private:
+    enum ListState { Idle, ListingRoot, ListingSubdir };
+
+    QmlObjectListModel *_getModel() const { return _logEntriesModel; }
+    bool _getRequestingList() const { return _requestingLogEntries; }
+    bool _getDownloadingLogs() const { return _downloadingLogs; }
+
+    void _startListing();
+    void _listRoot();
+    void _listNextSubdir();
+    uint _processFileEntries(const QStringList &dirList, const QString &subdir);
+    void _downloadEntry(QGCOnboardLogFtpEntry *entry);
+    void _downloadToDirectory(const QString &dir);
+    void _resetSelection(bool canceled = false);
+    void _setDownloading(bool active);
+    void _setListing(bool active);
+    void _finishListing();
+
+    QmlObjectListModel *_logEntriesModel = nullptr;
+    Vehicle *_vehicle = nullptr;
+
+    bool _requestingLogEntries = false;
+    bool _downloadingLogs = false;
+
+    ListState _listState = Idle;
+    QString _logRoot;
+    bool _triedFallbackRoot = false;
+    QStringList _dirsToList;
+    uint _logIdCounter = 0;
+
+    QQueue<QGCOnboardLogFtpEntry*> _downloadQueue;
+    QGCOnboardLogFtpEntry *_currentDownloadEntry = nullptr;
+    QString _downloadPath;
+    QElapsedTimer _downloadElapsed;
+    size_t _downloadBytesAtLastUpdate = 0;
+    qreal _downloadRateAvg = 0.;
+
+    static constexpr uint32_t kGUIRateMs = 17;
+};

--- a/src/AnalyzeView/OnboardLogsFtp/OnboardLogFtpEntry.cc
+++ b/src/AnalyzeView/OnboardLogsFtp/OnboardLogFtpEntry.cc
@@ -1,0 +1,23 @@
+#include "OnboardLogFtpEntry.h"
+#include "QGC.h"
+#include "QGCLoggingCategory.h"
+
+QGC_LOGGING_CATEGORY(OnboardLogFtpEntryLog, "AnalyzeView.QGCOnboardLogFtpEntry")
+
+QGCOnboardLogFtpEntry::QGCOnboardLogFtpEntry(uint logId, const QDateTime &dateTime, uint logSize, bool received, QObject *parent)
+    : QObject(parent)
+    , _logID(logId)
+    , _logSize(logSize)
+    , _logTimeUTC(dateTime)
+    , _received(received)
+{
+}
+
+QGCOnboardLogFtpEntry::~QGCOnboardLogFtpEntry()
+{
+}
+
+QString QGCOnboardLogFtpEntry::sizeStr() const
+{
+    return QGC::bigSizeToString(_logSize);
+}

--- a/src/AnalyzeView/OnboardLogsFtp/OnboardLogFtpEntry.h
+++ b/src/AnalyzeView/OnboardLogsFtp/OnboardLogFtpEntry.h
@@ -1,0 +1,57 @@
+#pragma once
+
+#include <QtCore/QDateTime>
+#include <QtCore/QLoggingCategory>
+#include <QtCore/QObject>
+#include <QtCore/QString>
+
+class QGCOnboardLogFtpEntry;
+
+Q_DECLARE_LOGGING_CATEGORY(OnboardLogFtpEntryLog)
+
+class QGCOnboardLogFtpEntry : public QObject
+{
+    Q_OBJECT
+
+    Q_PROPERTY(uint         id          READ id                             NOTIFY idChanged)
+    Q_PROPERTY(QDateTime    time        READ time                           NOTIFY timeChanged)
+    Q_PROPERTY(uint         size        READ size                           NOTIFY sizeChanged)
+    Q_PROPERTY(QString      sizeStr     READ sizeStr                        NOTIFY sizeChanged)
+    Q_PROPERTY(bool         received    READ received                       NOTIFY receivedChanged)
+    Q_PROPERTY(bool         selected    READ selected   WRITE setSelected   NOTIFY selectedChanged)
+    Q_PROPERTY(QString      status      READ status                         NOTIFY statusChanged)
+
+public:
+    explicit QGCOnboardLogFtpEntry(uint logId, const QDateTime &dateTime = QDateTime(), uint logSize = 0, bool received = false, QObject *parent = nullptr);
+    ~QGCOnboardLogFtpEntry();
+
+    uint id() const { return _logID; }
+    uint size() const { return _logSize; }
+    QString sizeStr() const;
+    QDateTime time() const { return _logTimeUTC; }
+    bool received() const { return _received; }
+    bool selected() const { return _selected; }
+    QString status() const { return _status; }
+    QString ftpPath() const { return _ftpPath; }
+
+    void setSelected(bool sel) { if (sel != _selected) { _selected = sel; emit selectedChanged(); } }
+    void setStatus(const QString &stat) { if (stat != _status) { _status = stat; emit statusChanged(); } }
+    void setFtpPath(const QString &path) { _ftpPath = path; }
+
+signals:
+    void idChanged();
+    void timeChanged();
+    void sizeChanged();
+    void receivedChanged();
+    void selectedChanged();
+    void statusChanged();
+
+private:
+    uint _logID = 0;
+    uint _logSize = 0;
+    QDateTime _logTimeUTC;
+    bool _received = false;
+    bool _selected = false;
+    QString _status = QStringLiteral("Pending");
+    QString _ftpPath;
+};

--- a/src/AnalyzeView/OnboardLogsFtp/OnboardLogFtpPage.qml
+++ b/src/AnalyzeView/OnboardLogsFtp/OnboardLogFtpPage.qml
@@ -1,0 +1,166 @@
+import QtQuick
+import QtQuick.Controls
+import QtQuick.Layouts
+import Qt.labs.qmlmodels
+
+import QGroundControl
+import QGroundControl.Controls
+
+AnalyzePage {
+    id: onboardLogFtpPage
+    pageComponent: pageComponent
+    pageDescription: qsTr("Onboard Logs (FTP) lists log files on the vehicle's SD card via MAVLink FTP. Click Refresh to query the vehicle.")
+
+    Component {
+        id: pageComponent
+
+        RowLayout {
+            width: availableWidth
+            height: availableHeight
+
+            QGCFlickable {
+                Layout.fillWidth: true
+                Layout.fillHeight: true
+                contentWidth: gridLayout.width
+                contentHeight: gridLayout.height
+
+                GridLayout {
+                    id: gridLayout
+                    rows: OnboardLogFtpController.model.count + 1
+                    columns: 5
+                    flow: GridLayout.TopToBottom
+                    columnSpacing: ScreenTools.defaultFontPixelWidth
+                    rowSpacing: 0
+
+                    QGCCheckBox {
+                        id: headerCheckBox
+                        enabled: false
+                    }
+
+                    Repeater {
+                        model: OnboardLogFtpController.model
+
+                        QGCCheckBox {
+                            Binding on checkState {
+                                value: object.selected ? Qt.Checked : Qt.Unchecked
+                            }
+
+                            onClicked: object.selected = checked
+                        }
+                    }
+
+                    QGCLabel { text: qsTr("Id") }
+
+                    Repeater {
+                        model: OnboardLogFtpController.model
+
+                        QGCLabel { text: object.id }
+                    }
+
+                    QGCLabel { text: qsTr("Date") }
+
+                    Repeater {
+                        model: OnboardLogFtpController.model
+
+                        QGCLabel {
+                            text: {
+                                if (!object.received) {
+                                    return ""
+                                }
+
+                                if (object.time.getUTCFullYear() < 2010) {
+                                    return qsTr("Date Unknown")
+                                }
+
+                                return object.time.toLocaleString(undefined)
+                            }
+                        }
+                    }
+
+                    QGCLabel { text: qsTr("Size") }
+
+                    Repeater {
+                        model: OnboardLogFtpController.model
+
+                        QGCLabel { text: object.sizeStr }
+                    }
+
+                    QGCLabel { text: qsTr("Status") }
+
+                    Repeater {
+                        model: OnboardLogFtpController.model
+
+                        QGCLabel { text: object.status }
+                    }
+                }
+            }
+
+            ColumnLayout {
+                spacing: ScreenTools.defaultFontPixelWidth
+                Layout.alignment: Qt.AlignTop
+                Layout.fillWidth: false
+
+                QGCButton {
+                    Layout.fillWidth: true
+                    enabled: !OnboardLogFtpController.requestingList && !OnboardLogFtpController.downloadingLogs
+                    text: qsTr("Refresh")
+
+                    onClicked: {
+                        if (!QGroundControl.multiVehicleManager.activeVehicle || QGroundControl.multiVehicleManager.activeVehicle.isOfflineEditingVehicle) {
+                            QGroundControl.showMessageDialog(onboardLogFtpPage, qsTr("Log Refresh"), qsTr("You must be connected to a vehicle in order to download logs."))
+                            return
+                        }
+
+                        OnboardLogFtpController.refresh()
+                    }
+                }
+
+                QGCButton {
+                    Layout.fillWidth: true
+                    enabled: !OnboardLogFtpController.requestingList && !OnboardLogFtpController.downloadingLogs
+                    text: qsTr("Download")
+
+                    onClicked: {
+                        var logsSelected = false
+                        for (var i = 0; i < OnboardLogFtpController.model.count; i++) {
+                            if (OnboardLogFtpController.model.get(i).selected) {
+                                logsSelected = true
+                                break
+                            }
+                        }
+
+                        if (!logsSelected) {
+                            QGroundControl.showMessageDialog(onboardLogFtpPage, qsTr("Log Download"), qsTr("You must select at least one log file to download."))
+                            return
+                        }
+
+                        if (ScreenTools.isMobile) {
+                            OnboardLogFtpController.download()
+                            return
+                        }
+
+                        fileDialog.title = qsTr("Select save directory")
+                        fileDialog.folder = QGroundControl.settingsManager.appSettings.logSavePath
+                        fileDialog.selectFolder = true
+                        fileDialog.openForLoad()
+                    }
+
+                    QGCFileDialog {
+                        id: fileDialog
+                        onAcceptedForLoad: (file) => {
+                            OnboardLogFtpController.download(file)
+                            close()
+                        }
+                    }
+                }
+
+                QGCButton {
+                    Layout.fillWidth: true
+                    text: qsTr("Cancel")
+                    enabled: OnboardLogFtpController.requestingList || OnboardLogFtpController.downloadingLogs
+                    onClicked: OnboardLogFtpController.cancel()
+                }
+            }
+        }
+    }
+}


### PR DESCRIPTION
#13996 rebased and improved, changes:

- Show legacy and FTP tab side to side
- Implement `@MAV_LOG` FTP path

FYI @dakejahl 

## Description

Adds a separate "Onboard Logs (FTP)" tab next to the existing "Onboard Logs" tab. The new tab uses the MAVLink FTP protocol exclusively (no auto-detect or silent fallback to the legacy LOG_REQUEST path).

Listing logic tries the MAVLink-standard "@MAV_LOG" virtual directory first and falls back to a firmware-specific physical path on failure: /fs/microsd/log for PX4, /APM/LOGS for ArduPilot. Both flat (root-level files) and hierarchical (date-subdirectory) layouts are supported, so it works regardless of which root the firmware exposes.

The new module lives in src/AnalyzeView/OnboardLogsFtp/ with its own entry class (QGCOnboardLogFtpEntry, adds an ftpPath field) and controller (OnboardLogFtpController), keeping the legacy OnboardLogController untouched.

Known limitation: MAVLink FTP's ListDirectory format only carries name+size, so files without a date in their filename (e.g. ArduPilot's sequential 00000001.BIN) show "Date Unknown".

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] CI/Build changes
- [ ] Other

## Testing

- [x] Tested locally
- [ ] Added/updated unit tests
- [ ] Tested with simulator (SITL)
- [ ] Tested with hardware

### Platforms Tested

- [x] Linux
- [ ] Windows
- [ ] macOS
- [ ] Android
- [ ] iOS

### Flight Stacks Tested

- [x] PX4
- [x] ArduPilot

## Checklist

- [x] I have read the [Contribution Guidelines](CONTRIBUTING.md)
- [x] I have read the [Code of Conduct](CODE_OF_CONDUCT.md)
- [x] My code follows the project's coding standards
- [ ] I have added tests that prove my fix/feature works
- [ ] New and existing unit tests pass locally

## Related Issues

- Replaces #13996.
- Based on specification in https://github.com/mavlink/mavlink-devguide/pull/668.
- PX4 implementation of `@MAV_LOG`: https://github.com/PX4/PX4-Autopilot/pull/26233
- ArduPilot implementation of `@MAV_LOG`: https://github.com/ArduPilot/ardupilot/pull/32860



---
By submitting this pull request, I confirm that my contribution is made under the terms of the project's dual license (Apache 2.0 and GPL v3).