### PR TITLE
test: Only build APM tests if APM is enabled

### DIFF
--- a/test/FactSystem/CMakeLists.txt
+++ b/test/FactSystem/CMakeLists.txt
@@ -5,8 +5,6 @@
 
 target_sources(${CMAKE_PROJECT_NAME}
     PRIVATE
-        APMParameterMetaDataTest.cc
-        APMParameterMetaDataTest.h
         FactGroupTest.cc
         FactGroupTest.h
         FactMetaDataTest.cc
@@ -29,5 +27,13 @@ target_sources(${CMAKE_PROJECT_NAME}
         ParameterManagerTest.h
         ParameterMetaDataTestHelper.h
 )
+
+if(NOT QGC_DISABLE_APM_PLUGIN)
+    target_sources(${CMAKE_PROJECT_NAME}
+        PRIVATE
+            APMParameterMetaDataTest.cc
+            APMParameterMetaDataTest.h
+    )
+endif()
 
 target_include_directories(${CMAKE_PROJECT_NAME} PRIVATE ${CMAKE_CURRENT_SOURCE_DIR})

--- a/test/Vehicle/CMakeLists.txt
+++ b/test/Vehicle/CMakeLists.txt
@@ -17,8 +17,6 @@ target_sources(${CMAKE_PROJECT_NAME}
         InitialConnectPeripheralStartupTest.h
         MAVLinkLogManagerTest.cc
         MAVLinkLogManagerTest.h
-        APMAirframeComponentControllerTest.cc
-        APMAirframeComponentControllerTest.h
         RequestMessageTest.cc
         RequestMessageTest.h
         SendMavCommandWithHandlerTest.cc
@@ -28,6 +26,14 @@ target_sources(${CMAKE_PROJECT_NAME}
         VehicleLinkManagerTest.cc
         VehicleLinkManagerTest.h
 )
+
+if(NOT QGC_DISABLE_APM_PLUGIN)
+    target_sources(${CMAKE_PROJECT_NAME}
+        PRIVATE
+            APMAirframeComponentControllerTest.cc
+            APMAirframeComponentControllerTest.h
+    )
+endif()
 
 target_include_directories(${CMAKE_PROJECT_NAME} PRIVATE ${CMAKE_CURRENT_SOURCE_DIR})
 


### PR DESCRIPTION
## Description

Compilation of QGC fails on master if you use the `custom` folder with default options.
I used `cmake`, on Ubuntu 22, with default options for QGC.

```
/home/ryan/Dev/qgroundcontrol/test/Vehicle/APMAirframeComponentControllerTest.cc:6:10: fatal error: APMAirframeComponentController.h: No such file or directory
    6 | #include "APMAirframeComponentController.h"
      |          ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
compilation terminated.
[685/696] Building CXX object CMakeFiles/Custom-QGroundControl.dir/test/Vehicle/RequestMessageTest.cc.o
ninja: build stopped: subcommand failed.
```

You also see a linker error.
```
mold: error: undefined symbol: CMakeFiles/Custom-QGroundControl.dir/test/FactSystem/APMParameterMetaDataTest.cc.o: APMParameterMetaData::APMParameterMetaData(QObject*)
mold: error: undefined symbol: CMakeFiles/Custom-QGroundControl.dir/test/FactSystem/APMParameterMetaDataTest.cc.o: APMParameterMetaData::~APMParameterMetaData()
mold: error: undefined symbol: CMakeFiles/Custom-QGroundControl.dir/test/FactSystem/APMParameterMetaDataTest.cc.o: APMParameterMetaData::~APMParameterMetaData()
mold: error: undefined symbol: CMakeFiles/Custom-QGroundControl.dir/test/FactSystem/APMParameterMetaDataTest.cc.o: APMParameterMetaData::APMParameterMetaData(QObject*)
mold: error: undefined symbol: CMakeFiles/Custom-QGroundControl.dir/test/FactSystem/APMParameterMetaDataTest.cc.o: APMParameterMetaData::~APMParameterMetaData()
mold: error: undefined symbol: CMakeFiles/Custom-QGroundControl.dir/test/FactSystem/APMParameterMetaDataTest.cc.o: APMParameterMetaData::~APMParameterMetaData()
mold: error: undefined symbol: CMakeFiles/Custom-QGroundControl.dir/test/FactSystem/APMParameterMetaDataTest.cc.o: APMParameterMetaData::APMParameterMetaData(QObject*)
mold: error: undefined symbol: CMakeFiles/Custom-QGroundControl.dir/test/FactSystem/APMParameterMetaDataTest.cc.o: APMParameterMetaData::~APMParameterMetaData()
mold: error: undefined symbol: CMakeFiles/Custom-QGroundControl.dir/test/FactSystem/APMParameterMetaDataTest.cc.o: APMParameterMetaData::~APMParameterMetaData()
mold: error: undefined symbol: CMakeFiles/Custom-QGroundControl.dir/test/FactSystem/APMParameterMetaDataTest.cc.o: APMParameterMetaData::APMParameterMetaData(QObject*)
collect2: error: ld returned 1 exit status
ninja: build stopped: subcommand failed.
```

## Type of Change
<!-- Put an 'x' in the relevant boxes -->
- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] CI/Build changes
- [ ] Other

## Testing
<!-- Describe the tests you ran and how to reproduce them -->
- [x] Tested locally
- [ ] Added/updated unit tests
- [ ] Tested with simulator (SITL)
- [ ] Tested with hardware

```bash
git clone ...
cd qgroundcontrol
cp -r custom-example/  custom/
/home/ryan/Qt/6.10.0/gcc_64/bin/qt-cmake -B build -G Ninja -DCMAKE_BUILD_TYPE=Debug
cmake --build build
```
### Platforms Tested
<!-- Check all that apply -->
- [x] Linux
- [ ] Windows
- [ ] macOS
- [ ] Android
- [ ] iOS

### Flight Stacks Tested
<!-- If applicable -->
- [ ] PX4
- [ ] ArduPilot

## Screenshots

Just clean compilation

## Checklist
<!-- Go over all the following points, and put an 'x' in all the boxes that apply -->
- [x] I have read the [Contribution Guidelines](CONTRIBUTING.md)
- [x] I have read the [Code of Conduct](CODE_OF_CONDUCT.md)
- [x] My code follows the project's coding standards
- [x] I have added tests that prove my fix/feature works
- [x] New and existing unit tests pass locally

## Related Issues

Reported in discord a week ago, confirmed by another user.
https://discord.com/channels/674039678562861068/801596112557441025/1494391120627630090


---
By submitting this pull request, I confirm that my contribution is made under the terms of the project's dual license (Apache 2.0 and GPL v3).
