### PR TITLE
feat(joystick): add step and continuous focus button actions

### DIFF
--- a/src/Camera/MavlinkCameraControlInterface.h
+++ b/src/Camera/MavlinkCameraControlInterface.h
@@ -159,6 +159,9 @@ public:
     Q_INVOKABLE virtual void stepZoom(int direction) = 0;
     Q_INVOKABLE virtual void startZoom(int direction) = 0;
     Q_INVOKABLE virtual void stopZoom() = 0;
+    Q_INVOKABLE virtual void stepFocus(int direction) = 0;
+    Q_INVOKABLE virtual void startFocus(int direction) = 0;
+    Q_INVOKABLE virtual void stopFocus() = 0;
     Q_INVOKABLE virtual void stopStream() = 0;
     Q_INVOKABLE virtual void resumeStream() = 0;
     Q_INVOKABLE virtual void startTrackingRect(QRectF rec) = 0;

--- a/src/Camera/QGCCameraManager.cc
+++ b/src/Camera/QGCCameraManager.cc
@@ -90,6 +90,7 @@ QGCCameraManager::QGCCameraManager(Vehicle *vehicle)
 
     _camerasLostHeartbeatTimer.setSingleShot(false);
     _lastZoomChange.start();
+    _lastFocusChange.start();
     _lastCameraChange.start();
     _camerasLostHeartbeatTimer.start(kHeartbeatTickMs);
 }
@@ -614,9 +615,12 @@ void QGCCameraManager::_activeJoystickChanged(Joystick *joystick)
 {
     qCDebug(CameraManagerLog) << "Joystick changed";
     if (_activeJoystick) {
-        (void) disconnect(_activeJoystick, &Joystick::stepZoom,            this, &QGCCameraManager::_stepZoom);
-        (void) disconnect(_activeJoystick, &Joystick::startContinuousZoom, this, &QGCCameraManager::_startZoom);
-        (void) disconnect(_activeJoystick, &Joystick::stopContinuousZoom,  this, &QGCCameraManager::_stopZoom);
+        (void) disconnect(_activeJoystick, &Joystick::stepZoom,             this, &QGCCameraManager::_stepZoom);
+        (void) disconnect(_activeJoystick, &Joystick::startContinuousZoom,  this, &QGCCameraManager::_startZoom);
+        (void) disconnect(_activeJoystick, &Joystick::stopContinuousZoom,   this, &QGCCameraManager::_stopZoom);
+        (void) disconnect(_activeJoystick, &Joystick::stepFocus,            this, &QGCCameraManager::_stepFocus);
+        (void) disconnect(_activeJoystick, &Joystick::startContinuousFocus, this, &QGCCameraManager::_startFocus);
+        (void) disconnect(_activeJoystick, &Joystick::stopContinuousFocus,  this, &QGCCameraManager::_stopFocus);
         (void) disconnect(_activeJoystick, &Joystick::stepCamera,          this, &QGCCameraManager::_stepCamera);
         (void) disconnect(_activeJoystick, &Joystick::stepStream,          this, &QGCCameraManager::_stepStream);
         (void) disconnect(_activeJoystick, &Joystick::triggerCamera,       this, &QGCCameraManager::_triggerCamera);
@@ -628,9 +632,12 @@ void QGCCameraManager::_activeJoystickChanged(Joystick *joystick)
     _activeJoystick = joystick;
 
     if (_activeJoystick) {
-        (void) connect(_activeJoystick, &Joystick::stepZoom,            this, &QGCCameraManager::_stepZoom, Qt::UniqueConnection);
-        (void) connect(_activeJoystick, &Joystick::startContinuousZoom, this, &QGCCameraManager::_startZoom, Qt::UniqueConnection);
-        (void) connect(_activeJoystick, &Joystick::stopContinuousZoom,  this, &QGCCameraManager::_stopZoom, Qt::UniqueConnection);
+        (void) connect(_activeJoystick, &Joystick::stepZoom,             this, &QGCCameraManager::_stepZoom, Qt::UniqueConnection);
+        (void) connect(_activeJoystick, &Joystick::startContinuousZoom,  this, &QGCCameraManager::_startZoom, Qt::UniqueConnection);
+        (void) connect(_activeJoystick, &Joystick::stopContinuousZoom,   this, &QGCCameraManager::_stopZoom, Qt::UniqueConnection);
+        (void) connect(_activeJoystick, &Joystick::stepFocus,            this, &QGCCameraManager::_stepFocus, Qt::UniqueConnection);
+        (void) connect(_activeJoystick, &Joystick::startContinuousFocus, this, &QGCCameraManager::_startFocus, Qt::UniqueConnection);
+        (void) connect(_activeJoystick, &Joystick::stopContinuousFocus,  this, &QGCCameraManager::_stopFocus, Qt::UniqueConnection);
         (void) connect(_activeJoystick, &Joystick::stepCamera,          this, &QGCCameraManager::_stepCamera, Qt::UniqueConnection);
         (void) connect(_activeJoystick, &Joystick::stepStream,          this, &QGCCameraManager::_stepStream, Qt::UniqueConnection);
         (void) connect(_activeJoystick, &Joystick::triggerCamera,       this, &QGCCameraManager::_triggerCamera, Qt::UniqueConnection);
@@ -699,6 +706,36 @@ void QGCCameraManager::_stopZoom()
     MavlinkCameraControlInterface *pCamera = currentCameraInstance();
     if (pCamera) {
         pCamera->stopZoom();
+    }
+}
+
+void QGCCameraManager::_stepFocus(int direction)
+{
+    if (_lastFocusChange.elapsed() > 40) {
+        _lastFocusChange.start();
+        qCDebug(CameraManagerLog) << "Step Camera Focus" << direction;
+        MavlinkCameraControlInterface *pCamera = currentCameraInstance();
+        if (pCamera) {
+            pCamera->stepFocus(direction);
+        }
+    }
+}
+
+void QGCCameraManager::_startFocus(int direction)
+{
+    qCDebug(CameraManagerLog) << "Start Camera Focus" << direction;
+    MavlinkCameraControlInterface *pCamera = currentCameraInstance();
+    if (pCamera) {
+        pCamera->startFocus(direction);
+    }
+}
+
+void QGCCameraManager::_stopFocus()
+{
+    qCDebug(CameraManagerLog) << "Stop Camera Focus";
+    MavlinkCameraControlInterface *pCamera = currentCameraInstance();
+    if (pCamera) {
+        pCamera->stopFocus();
     }
 }
 

--- a/src/Camera/QGCCameraManager.h
+++ b/src/Camera/QGCCameraManager.h
@@ -97,6 +97,9 @@ protected slots:
     void _stepZoom(int direction);
     void _startZoom(int direction);
     void _stopZoom();
+    void _stepFocus(int direction);
+    void _startFocus(int direction);
+    void _stopFocus();
     void _stepCamera(int direction);
     void _stepStream(int direction);
     void _checkForLostCameras();
@@ -135,6 +138,7 @@ private:
     QStringList _cameraLabels;
     int _currentCameraIndex = 0;
     QElapsedTimer _lastZoomChange;
+    QElapsedTimer _lastFocusChange;
     QElapsedTimer _lastCameraChange;
     QTimer _camerasLostHeartbeatTimer;
     QMap<QString, CameraStruct*> _cameraInfoRequest;

--- a/src/Camera/SimulatedCameraControl.h
+++ b/src/Camera/SimulatedCameraControl.h
@@ -32,6 +32,9 @@ public:
     void stepZoom(int /*direction*/) override {}
     void startZoom(int /*direction*/) override {}
     void stopZoom() override {}
+    void stepFocus(int /*direction*/) override {}
+    void startFocus(int /*direction*/) override {}
+    void stopFocus() override {}
     void stopStream() override {}
     bool stopTakePhoto() override { return false;}
     void resumeStream() override {}

--- a/src/Camera/VehicleCameraControl.cc
+++ b/src/Camera/VehicleCameraControl.cc
@@ -669,6 +669,45 @@ void VehicleCameraControl::stopZoom()
     }
 }
 
+void VehicleCameraControl::stepFocus(int direction)
+{
+    qCDebug(VehicleCameraControlLog) << "Camera step focus" << direction;
+    if(_vehicle && hasFocus()) {
+        _vehicle->sendMavCommand(
+            _compID,                                // Target component
+            MAV_CMD_SET_CAMERA_FOCUS,               // Command id
+            false,                                  // ShowError
+            FOCUS_TYPE_STEP,                        // Focus type
+            direction);                             // Direction (-1 in, 1 out)
+    }
+}
+
+void VehicleCameraControl::startFocus(int direction)
+{
+    qCDebug(VehicleCameraControlLog) << "Camera start focus" << direction;
+    if(_vehicle && hasFocus()) {
+        _vehicle->sendMavCommand(
+            _compID,                                // Target component
+            MAV_CMD_SET_CAMERA_FOCUS,               // Command id
+            false,                                  // ShowError
+            FOCUS_TYPE_CONTINUOUS,                  // Focus type
+            direction);                             // Direction (-1 in, 1 out)
+    }
+}
+
+void VehicleCameraControl::stopFocus()
+{
+    qCDebug(VehicleCameraControlLog) << "Camera stop focus";
+    if(_vehicle && hasFocus()) {
+        _vehicle->sendMavCommand(
+            _compID,                                // Target component
+            MAV_CMD_SET_CAMERA_FOCUS,               // Command id
+            false,                                  // ShowError
+            FOCUS_TYPE_CONTINUOUS,                  // Focus type
+            0);                                     // Direction (-1 in, 1 out)
+    }
+}
+
 void VehicleCameraControl::_requestCaptureStatus()
 {
     qCDebug(VehicleCameraControlLog) << "Camera request capture status - retries:" << _cameraCaptureStatusRetries;

--- a/src/Camera/VehicleCameraControl.h
+++ b/src/Camera/VehicleCameraControl.h
@@ -54,6 +54,9 @@ public:
     Q_INVOKABLE void stepZoom               (int direction) override;
     Q_INVOKABLE void startZoom              (int direction) override;
     Q_INVOKABLE void stopZoom               () override;
+    Q_INVOKABLE void stepFocus              (int direction) override;
+    Q_INVOKABLE void startFocus             (int direction) override;
+    Q_INVOKABLE void stopFocus              () override;
     Q_INVOKABLE void stopStream             () override;
     Q_INVOKABLE void resumeStream           () override;
     Q_INVOKABLE void startTrackingRect      (QRectF rec) override;

--- a/src/Joystick/Joystick.cc
+++ b/src/Joystick/Joystick.cc
@@ -1442,6 +1442,14 @@ void Joystick::_executeButtonAction(const QString &action, const ButtonEvent_t b
         { _buttonActionStepZoomIn,              ButtonEventRepeat,          [this]() { emit stepZoom(1); } },
         { _buttonActionStepZoomOut,             ButtonEventDownTransition,  [this]() { emit stepZoom(-1); } },
         { _buttonActionStepZoomOut,             ButtonEventRepeat,          [this]() { emit stepZoom(-1); } },
+        { _buttonActionContinuousFocusIn,       ButtonEventDownTransition,  [this]() { emit startContinuousFocus(1); } },
+        { _buttonActionContinuousFocusIn,       ButtonEventRepeat,          [this]() { emit startContinuousFocus(1); } },
+        { _buttonActionContinuousFocusOut,      ButtonEventDownTransition,  [this]() { emit startContinuousFocus(-1); } },
+        { _buttonActionContinuousFocusOut,      ButtonEventRepeat,          [this]() { emit startContinuousFocus(-1); } },
+        { _buttonActionStepFocusIn,             ButtonEventDownTransition,  [this]() { emit stepFocus(1); } },
+        { _buttonActionStepFocusIn,             ButtonEventRepeat,          [this]() { emit stepFocus(1); } },
+        { _buttonActionStepFocusOut,            ButtonEventDownTransition,  [this]() { emit stepFocus(-1); } },
+        { _buttonActionStepFocusOut,            ButtonEventRepeat,          [this]() { emit stepFocus(-1); } },
         { _buttonActionNextStream,              ButtonEventDownTransition,  [this]() { emit stepStream(1); } },
         { _buttonActionPreviousStream,          ButtonEventDownTransition,  [this]() { emit stepStream(-1); } },
         { _buttonActionNextCamera,              ButtonEventDownTransition,  [this]() { emit stepCamera(1); } },
@@ -1556,6 +1564,10 @@ void Joystick::_buildAvailableButtonsActionList(Vehicle *vehicle)
     _availableButtonActions->append(new AvailableButtonAction(_buttonActionContinuousZoomOut, true));
     _availableButtonActions->append(new AvailableButtonAction(_buttonActionStepZoomIn, true));
     _availableButtonActions->append(new AvailableButtonAction(_buttonActionStepZoomOut, true));
+    _availableButtonActions->append(new AvailableButtonAction(_buttonActionContinuousFocusIn, true));
+    _availableButtonActions->append(new AvailableButtonAction(_buttonActionContinuousFocusOut, true));
+    _availableButtonActions->append(new AvailableButtonAction(_buttonActionStepFocusIn, true));
+    _availableButtonActions->append(new AvailableButtonAction(_buttonActionStepFocusOut, true));
     _availableButtonActions->append(new AvailableButtonAction(_buttonActionNextStream, false));
     _availableButtonActions->append(new AvailableButtonAction(_buttonActionPreviousStream, false));
     _availableButtonActions->append(new AvailableButtonAction(_buttonActionNextCamera, false));

--- a/src/Joystick/Joystick.h
+++ b/src/Joystick/Joystick.h
@@ -333,6 +333,9 @@ signals:
     void startContinuousZoom(int direction);
     void stopContinuousZoom();
     void stepZoom(int direction);
+    void startContinuousFocus(int direction);
+    void stopContinuousFocus();
+    void stepFocus(int direction);
     void stepCamera(int direction);
     void stepStream(int direction);
     void triggerCamera();
@@ -472,6 +475,10 @@ private:
     static constexpr const char *_buttonActionContinuousZoomOut =  QT_TR_NOOP("Continuous Zoom Out");
     static constexpr const char *_buttonActionStepZoomIn =         QT_TR_NOOP("Step Zoom In");
     static constexpr const char *_buttonActionStepZoomOut =        QT_TR_NOOP("Step Zoom Out");
+    static constexpr const char *_buttonActionContinuousFocusIn =  QT_TR_NOOP("Continuous Focus In");
+    static constexpr const char *_buttonActionContinuousFocusOut = QT_TR_NOOP("Continuous Focus Out");
+    static constexpr const char *_buttonActionStepFocusIn =        QT_TR_NOOP("Step Focus In");
+    static constexpr const char *_buttonActionStepFocusOut =       QT_TR_NOOP("Step Focus Out");
     static constexpr const char *_buttonActionNextStream =         QT_TR_NOOP("Next Video Stream");
     static constexpr const char *_buttonActionPreviousStream =     QT_TR_NOOP("Previous Video Stream");
     static constexpr const char *_buttonActionNextCamera =         QT_TR_NOOP("Next Camera");


### PR DESCRIPTION
## Description

Mirrors the existing zoom button-action wiring so an operator can bind joystick buttons to Step Focus In/Out and Continuous Focus In/Out. The actions translate into MAV_CMD_SET_CAMERA_FOCUS with FOCUS_TYPE_STEP or FOCUS_TYPE_CONTINUOUS and are gated on CAMERA_CAP_FLAGS_HAS_BASIC_FOCUS.

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] CI/Build changes
- [ ] Other

## Testing

- [x] Tested locally
- [ ] Added/updated unit tests
- [ ] Tested with simulator (SITL)
- [x] Tested with hardware

### Platforms Tested

- [x] Linux
- [ ] Windows
- [ ] macOS
- [ ] Android
- [ ] iOS

### Flight Stacks Tested

- [ ] PX4
- [ ] ArduPilot

## Screenshots

<img width="724" height="840" alt="image" src="https://github.com/user-attachments/assets/a6fea86a-54e5-468b-8b0e-746a679e983d" />


## Checklist

- [x] I have read the [Contribution Guidelines](CONTRIBUTING.md)
- [x] I have read the [Code of Conduct](CODE_OF_CONDUCT.md)
- [x] My code follows the project's coding standards
- [x] I have added tests that prove my fix/feature works
- [x] New and existing unit tests pass locally

## Related Issues


---
By submitting this pull request, I confirm that my contribution is made under the terms of the project's dual license (Apache 2.0 and GPL v3).
