### PR TITLE
build: PCH coverage, APM param filter, Osm3D split, Viewer3D module sources

### DIFF
--- a/.github/actions/docker/action.yml
+++ b/.github/actions/docker/action.yml
@@ -55,7 +55,7 @@ runs:
         tags: qgc-builder:latest
         load: true
         cache-from: type=gha,scope=${{ inputs.dockerfile }}
-        cache-to: type=gha,mode=max,scope=${{ inputs.dockerfile }}
+        cache-to: ${{ github.event_name != 'pull_request' && format('type=gha,mode=max,scope={0}', inputs.dockerfile) || '' }}
 
     - name: Run Docker build
       if: contains(fromJSON('["Release", "Debug"]'), inputs.build-type)

--- a/.github/actions/install-dependencies/action.yml
+++ b/.github/actions/install-dependencies/action.yml
@@ -22,9 +22,10 @@ inputs:
 runs:
   using: composite
   steps:
-    - name: Cache GStreamer (Windows)
+    - name: Restore GStreamer cache (Windows)
       if: runner.os == 'Windows' && inputs.gstreamer == 'true'
-      uses: actions/cache@v5
+      id: gst-win-cache
+      uses: actions/cache/restore@v5
       with:
         path: C:\gstreamer
         key: gstreamer-windows-${{ inputs.gstreamer-version || hashFiles('.github/build-config.json') }}
@@ -50,6 +51,13 @@ runs:
           if os.environ.get('INPUT_VULKAN') == 'true':
               args.append('--vulkan')
           sys.exit(subprocess.run(args).returncode)
+
+    - name: Save GStreamer cache (Windows)
+      if: runner.os == 'Windows' && inputs.gstreamer == 'true' && github.event_name != 'pull_request' && steps.gst-win-cache.outputs.cache-hit != 'true'
+      uses: actions/cache/save@v5
+      with:
+        path: C:\gstreamer
+        key: ${{ steps.gst-win-cache.outputs.cache-primary-key }}
 
     - name: Get system package list (Linux)
       if: runner.os == 'Linux'
@@ -87,9 +95,10 @@ runs:
       shell: bash
       run: python3 "${GITHUB_WORKSPACE}/.github/scripts/install_dependencies_helper.py" detect-python-version
 
-    - name: Cache pipx and pip downloads (Linux)
+    - name: Restore pipx/pip cache (Linux)
       if: runner.os == 'Linux'
-      uses: actions/cache@v5
+      id: pipx-cache
+      uses: actions/cache/restore@v5
       with:
         path: |
           ~/.cache/pip
@@ -104,6 +113,15 @@ runs:
       shell: bash
       run: python3 tools/setup/install_dependencies.py --platform debian --skip-system-packages
 
+    - name: Save pipx/pip cache (Linux)
+      if: runner.os == 'Linux' && github.event_name != 'pull_request' && steps.pipx-cache.outputs.cache-hit != 'true'
+      uses: actions/cache/save@v5
+      with:
+        path: |
+          ~/.cache/pip
+          ~/.local/pipx
+        key: ${{ steps.pipx-cache.outputs.cache-primary-key }}
+
     - name: Install extra packages (Linux)
       if: runner.os == 'Linux' && inputs.extra-packages != ''
       uses: nick-fields/retry@v3
@@ -117,9 +135,10 @@ runs:
           # shellcheck disable=SC2086
           sudo apt-get install -y $validated
 
-    - name: Cache GStreamer (macOS)
+    - name: Restore GStreamer cache (macOS)
       if: runner.os == 'macOS'
-      uses: actions/cache@v5
+      id: gst-mac-cache
+      uses: actions/cache/restore@v5
       with:
         path: /Library/Frameworks/GStreamer.framework
         key: gstreamer-macos-${{ inputs.gstreamer-version || hashFiles('.github/build-config.json') }}
@@ -132,3 +151,10 @@ runs:
         max_attempts: 3
         command: |
           python3 tools/setup/install_dependencies.py --platform macos
+
+    - name: Save GStreamer cache (macOS)
+      if: runner.os == 'macOS' && github.event_name != 'pull_request' && steps.gst-mac-cache.outputs.cache-hit != 'true'
+      uses: actions/cache/save@v5
+      with:
+        path: /Library/Frameworks/GStreamer.framework
+        key: ${{ steps.gst-mac-cache.outputs.cache-primary-key }}

--- a/.github/actions/qt-android/action.yml
+++ b/.github/actions/qt-android/action.yml
@@ -59,6 +59,7 @@ runs:
         distribution: temurin
         java-version: ${{ inputs.java-version }}
         cache: gradle
+        cache-read-only: ${{ github.event_name == 'pull_request' }}
         cache-dependency-path: |
           **/*.gradle*
           **/gradle-wrapper.properties

--- a/.github/actions/qt-install/action.yml
+++ b/.github/actions/qt-install/action.yml
@@ -52,9 +52,10 @@ runs:
         QT_ARCHIVES: ${{ inputs.archives }}
       run: python3 "${GITHUB_WORKSPACE}/tools/setup/install_qt.py" cache-key --arch "${QT_ARCH}" --modules "${QT_MODULES}" --archives "${QT_ARCHIVES}"
 
-    - name: Restore extracted Qt cache
+    # Full Qt matrix is ~14 GB; only push events save to fit under the 10 GB repo cache cap.
+    - name: Restore Qt cache
       id: qt-cache
-      uses: actions/cache@v5
+      uses: actions/cache/restore@v5
       with:
         path: ${{ inputs.dir }}/Qt/${{ inputs.version }}
         # `runner.os` is implied by `inputs.host` (linux/mac/windows...) so it's omitted.
@@ -81,6 +82,13 @@ runs:
           --outdir "${QT_OUTDIR}" \
           --modules "${QT_MODULES}" \
           --archives "${QT_ARCHIVES}"
+
+    - name: Save Qt cache
+      if: github.event_name != 'pull_request' && steps.qt-cache.outputs.cache-hit != 'true'
+      uses: actions/cache/save@v5
+      with:
+        path: ${{ inputs.dir }}/Qt/${{ inputs.version }}
+        key: ${{ steps.qt-cache.outputs.cache-primary-key }}
 
     - name: Resolve Qt paths (cache hit)
       if: steps.qt-cache.outputs.cache-hit == 'true'

--- a/.github/workflows/android.yml
+++ b/.github/workflows/android.yml
@@ -276,7 +276,7 @@ jobs:
           script: echo "Generated AVD snapshot for cache."
 
       - name: Save AVD cache
-        if: ${{ matrix.emulator && steps.avd-cache.outputs.cache-hit != 'true' && steps.avd-snapshot.outcome == 'success' }}
+        if: ${{ matrix.emulator && github.event_name != 'pull_request' && steps.avd-cache.outputs.cache-hit != 'true' && steps.avd-snapshot.outcome == 'success' }}
         uses: actions/cache/save@v5
         with:
           path: |

--- a/.github/workflows/check-links.yml
+++ b/.github/workflows/check-links.yml
@@ -41,16 +41,16 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v6
 
-      - name: Restore lychee cache (PR from fork)
-        if: github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name != github.repository
+      - name: Restore lychee cache (PR)
+        if: github.event_name == 'pull_request'
         uses: actions/cache/restore@v5
         with:
           path: .lycheecache
           key: cache-lychee-${{ hashFiles('.lychee.toml') }}
           restore-keys: cache-lychee-
 
-      - name: Cache lychee (push or same-repo PR)
-        if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository
+      - name: Cache lychee (push)
+        if: github.event_name != 'pull_request'
         uses: actions/cache@v5
         with:
           path: .lycheecache

--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -45,15 +45,15 @@ jobs:
           groups: precommit
           python-version: '3.12'
 
-      - name: Restore pre-commit cache (PR from fork)
-        if: github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name != github.repository
+      - name: Restore pre-commit cache (PR)
+        if: github.event_name == 'pull_request'
         uses: actions/cache/restore@v5
         with:
           path: ~/.cache/pre-commit
           key: pre-commit-3|${{ env.pythonLocation }}|${{ hashFiles('.pre-commit-config.yaml') }}
 
-      - name: Cache pre-commit hooks (push or same-repo PR)
-        if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository
+      - name: Cache pre-commit hooks (push)
+        if: github.event_name != 'pull_request'
         uses: actions/cache@v5
         with:
           path: ~/.cache/pre-commit

--- a/cmake/find-modules/FindQGCGStreamer.cmake
+++ b/cmake/find-modules/FindQGCGStreamer.cmake
@@ -445,14 +445,19 @@ macro(_qgc_discover_ios_sdk)
         message(FATAL_ERROR "GStreamer for iOS can only be built on macOS")
     endif()
 
+    # ── User-supplied root ────────────────────────────────────────────────────
     if(NOT DEFINED GStreamer_ROOT_DIR)
-        if(EXISTS "/Library/Developer/GStreamer/iPhone.sdk/GStreamer.framework")
+        # Check well-known system install locations (framework and xcframework).
+        if(EXISTS "/Library/Developer/GStreamer/iPhone.sdk/GStreamer.xcframework")
+            set(_gst_ios_system_xcfw "/Library/Developer/GStreamer/iPhone.sdk/GStreamer.xcframework")
+        elseif(EXISTS "/Library/Developer/GStreamer/iPhone.sdk/GStreamer.framework")
             set(GSTREAMER_FRAMEWORK_PATH "/Library/Developer/GStreamer/iPhone.sdk/GStreamer.framework")
             set(GStreamer_ROOT_DIR "${GSTREAMER_FRAMEWORK_PATH}/Versions/1.0")
         endif()
     endif()
 
-    if(NOT DEFINED GStreamer_ROOT_DIR OR NOT EXISTS "${GStreamer_ROOT_DIR}")
+    # ── Auto-download / expand ────────────────────────────────────────────────
+    if((NOT DEFINED GStreamer_ROOT_DIR OR NOT EXISTS "${GStreamer_ROOT_DIR}") AND NOT DEFINED _gst_ios_system_xcfw)
         if(CPM_SOURCE_CACHE)
             set(_gst_ios_cache_dir "${CPM_SOURCE_CACHE}/gstreamer-ios-${GStreamer_FIND_VERSION}")
         else()
@@ -463,10 +468,9 @@ macro(_qgc_discover_ios_sdk)
         gstreamer_download_sdk(ios ${GStreamer_FIND_VERSION}
             "gstreamer-ios.pkg" "${_gst_ios_cache_dir}" _gst_ios_pkg)
 
-        # Multiple anchor files — Info.plist is a symlink in the iOS framework
-        # and pkgutil --expand-full doesn't always preserve it intact. gst.h
-        # and the framework binary are real files inside Payload trees.
+        # Anchors that prove the expansion is complete for either SDK layout.
         set(_gst_ios_anchor_globs
+            "${_gst_ios_expanded}/*/GStreamer.xcframework/Info.plist"
             "${_gst_ios_expanded}/*/GStreamer.framework/Headers/gst/gst.h"
             "${_gst_ios_expanded}/*/GStreamer.framework/Versions/1.0/Headers/gst/gst.h"
             "${_gst_ios_expanded}/*/GStreamer.framework/GStreamer"
@@ -502,50 +506,127 @@ macro(_qgc_discover_ios_sdk)
             _qgc_validate_expanded_pkg("${_gst_ios_expanded}" "iOS")
         endif()
 
-        # iOS pkg internal layout has shifted across releases; try several anchors.
-        set(_anchor_hit "")
-        foreach(_glob IN LISTS _gst_ios_anchor_globs)
-            file(GLOB_RECURSE _anchor_hit "${_glob}")
-            if(_anchor_hit)
-                break()
-            endif()
-        endforeach()
+        # ── xcframework detection (GStreamer 1.28+) ───────────────────────────
+        # Check xcframework first; fall through to .framework for older SDKs.
+        file(GLOB_RECURSE _xcfw_info_plists LIST_DIRECTORIES false
+            "${_gst_ios_expanded}/*/GStreamer.xcframework/Info.plist"
+            "${_gst_ios_expanded}/GStreamer.xcframework/Info.plist"
+        )
+        if(NOT _xcfw_info_plists)
+            # Broader walk in case the pkg nests the xcframework further.
+            file(GLOB_RECURSE _all_dirs LIST_DIRECTORIES true "${_gst_ios_expanded}/*")
+            foreach(_d IN LISTS _all_dirs)
+                if(IS_DIRECTORY "${_d}" AND _d MATCHES "/GStreamer\.xcframework$")
+                    if(EXISTS "${_d}/Info.plist")
+                        list(APPEND _xcfw_info_plists "${_d}/Info.plist")
+                        break()
+                    endif()
+                endif()
+            endforeach()
+        endif()
 
-        if(_anchor_hit)
-            list(GET _anchor_hit 0 _anchor_first)
-            # Walk parents up to the .framework directory.
-            set(_walk "${_anchor_first}")
-            while(_walk AND NOT _walk MATCHES "GStreamer\\.framework$")
-                cmake_path(GET _walk PARENT_PATH _walk)
-                if(_walk STREQUAL "/" OR _walk STREQUAL "")
+        if(_xcfw_info_plists)
+            list(GET _xcfw_info_plists 0 _xcfw_info_first)
+            cmake_path(GET _xcfw_info_first PARENT_PATH _gst_ios_system_xcfw)
+        else()
+            # ── .framework fallback (pre-1.28 SDK) ───────────────────────────
+            # Older SDK versions ship GStreamer.framework; try anchors first.
+            set(_anchor_hit "")
+            foreach(_glob IN LISTS _gst_ios_anchor_globs)
+                file(GLOB_RECURSE _anchor_hit "${_glob}")
+                if(_anchor_hit)
                     break()
                 endif()
-            endwhile()
-            if(_walk MATCHES "GStreamer\\.framework$")
-                set(GSTREAMER_FRAMEWORK_PATH "${_walk}")
+            endforeach()
+
+            if(_anchor_hit)
+                list(GET _anchor_hit 0 _anchor_first)
+                set(_walk "${_anchor_first}")
+                while(_walk AND NOT _walk MATCHES "GStreamer\.framework$")
+                    cmake_path(GET _walk PARENT_PATH _walk)
+                    if(_walk STREQUAL "/" OR _walk STREQUAL "")
+                        break()
+                    endif()
+                endwhile()
+                if(_walk MATCHES "GStreamer\.framework$")
+                    set(GSTREAMER_FRAMEWORK_PATH "${_walk}")
+                endif()
             endif()
-        endif()
 
-        if(NOT GSTREAMER_FRAMEWORK_PATH)
-            file(GLOB _top_entries LIST_DIRECTORIES true "${_gst_ios_expanded}/*")
-            file(GLOB_RECURSE _all_frameworks LIST_DIRECTORIES true
-                "${_gst_ios_expanded}/*.framework")
-            file(GLOB_RECURSE _all_in_expanded "${_gst_ios_expanded}/*")
-            list(LENGTH _all_in_expanded _n)
-            string(REPLACE ";" "\n  " _top_entries_str "${_top_entries}")
-            string(REPLACE ";" "\n  " _all_frameworks_str "${_all_frameworks}")
-            message(FATAL_ERROR
-                "Could not locate GStreamer.framework in expanded iOS SDK at"
-                " '${_gst_ios_expanded}' (${_n} entries). The .pkg layout may"
-                " have changed; check the pkgutil --expand-full output.\n"
-                "Top-level entries:\n  ${_top_entries_str}\n"
-                "All *.framework directories:\n  ${_all_frameworks_str}")
-        endif()
+            if(NOT GSTREAMER_FRAMEWORK_PATH)
+                file(GLOB_RECURSE _all_dirs LIST_DIRECTORIES true "${_gst_ios_expanded}/*")
+                foreach(_d IN LISTS _all_dirs)
+                    if(IS_DIRECTORY "${_d}" AND _d MATCHES "/GStreamer\.framework$")
+                        if(EXISTS "${_d}/Headers" OR EXISTS "${_d}/Versions/1.0/Headers")
+                            set(GSTREAMER_FRAMEWORK_PATH "${_d}")
+                            break()
+                        elseif(NOT GSTREAMER_FRAMEWORK_PATH)
+                            set(GSTREAMER_FRAMEWORK_PATH "${_d}")
+                        endif()
+                    endif()
+                endforeach()
+            endif()
 
-        set(GStreamer_ROOT_DIR "${GSTREAMER_FRAMEWORK_PATH}/Versions/1.0")
+            if(NOT GSTREAMER_FRAMEWORK_PATH)
+                file(GLOB _top_entries LIST_DIRECTORIES true "${_gst_ios_expanded}/*")
+                file(GLOB_RECURSE _all_frameworks LIST_DIRECTORIES true
+                    "${_gst_ios_expanded}/*.framework")
+                file(GLOB_RECURSE _all_xcframeworks LIST_DIRECTORIES true
+                    "${_gst_ios_expanded}/*.xcframework")
+                file(GLOB_RECURSE _all_in_expanded "${_gst_ios_expanded}/*")
+                list(LENGTH _all_in_expanded _n)
+                string(REPLACE ";" "\n  " _top_entries_str "${_top_entries}")
+                string(REPLACE ";" "\n  " _all_frameworks_str "${_all_frameworks}")
+                string(REPLACE ";" "\n  " _all_xcframeworks_str "${_all_xcframeworks}")
+                message(FATAL_ERROR
+                    "Could not locate GStreamer.xcframework or GStreamer.framework in expanded iOS SDK at"
+                    " '${_gst_ios_expanded}' (${_n} entries). The .pkg layout may"
+                    " have changed; check the pkgutil --expand-full output.\n"
+                    "Top-level entries:\n  ${_top_entries_str}\n"
+                    "All *.framework directories:\n  ${_all_frameworks_str}\n"
+                    "All *.xcframework directories:\n  ${_all_xcframeworks_str}")
+            endif()
+
+            set(GStreamer_ROOT_DIR "${GSTREAMER_FRAMEWORK_PATH}/Versions/1.0")
+        endif()
         set(GStreamer_AUTO_DOWNLOADED TRUE)
     endif()
 
+    # ── xcframework path: pick the right slice ────────────────────────────────
+    if(DEFINED _gst_ios_system_xcfw)
+        set(GStreamer_USE_XCFRAMEWORK ON)
+
+        # Select slice based on sysroot: iphoneos=device, iphonesimulator=simulator.
+        if(CMAKE_OSX_SYSROOT MATCHES "iphonesimulator")
+            set(_xcfw_slice "ios-arm64_x86_64-simulator")
+        else()
+            set(_xcfw_slice "ios-arm64")
+        endif()
+
+        set(_xcfw_slice_dir "${_gst_ios_system_xcfw}/${_xcfw_slice}")
+        if(NOT EXISTS "${_xcfw_slice_dir}")
+            message(FATAL_ERROR
+                "GStreamer xcframework slice '${_xcfw_slice}' not found in ${_gst_ios_system_xcfw}.
+"
+                "Available slices: check ${_gst_ios_system_xcfw}/Info.plist AvailableLibraries.")
+        endif()
+
+        # Synthetic path vars so guards and consumers have consistent variables.
+        # xcframework has no lib/ or lib/gstreamer-1.0/ — all code is in libGStreamer.a.
+        set(GStreamer_ROOT_DIR       "${_xcfw_slice_dir}")
+        set(GSTREAMER_XCFRAMEWORK_PATH "${_gst_ios_system_xcfw}")
+        set(GSTREAMER_XCFRAMEWORK_LIB  "${_xcfw_slice_dir}/libGStreamer.a")
+        set(GSTREAMER_INCLUDE_PATH  "${_xcfw_slice_dir}/Headers")
+        # GSTREAMER_LIB_PATH and GSTREAMER_PLUGIN_PATH are synthetic — they point
+        # to the slice dir itself because there is no lib/ subdirectory in an xcframework.
+        set(GSTREAMER_LIB_PATH    "${_xcfw_slice_dir}")
+        set(GSTREAMER_PLUGIN_PATH "${_xcfw_slice_dir}")
+
+        _gst_normalize_and_validate_root()
+        return()
+    endif()
+
+    # ── Classic .framework path ───────────────────────────────────────────────
     _gst_normalize_and_validate_root()
 
     set(GStreamer_USE_FRAMEWORK ON)
@@ -554,6 +635,23 @@ macro(_qgc_discover_ios_sdk)
         cmake_path(NORMAL_PATH GSTREAMER_FRAMEWORK_PATH)
     endif()
     _gst_set_standard_paths(INCLUDE_PATH "${GSTREAMER_FRAMEWORK_PATH}/Headers")
+
+    # Cerbero iOS framework lays out libraries under Versions/1.0/lib but the
+    # framework root also exposes Libraries -> Versions/Current/lib symlinks;
+    # if the default ${GStreamer_ROOT_DIR}/lib doesn't exist, try alternatives.
+    if(NOT EXISTS "${GSTREAMER_LIB_PATH}")
+        foreach(_cand IN ITEMS
+            "${GStreamer_ROOT_DIR}/Libraries"
+            "${GSTREAMER_FRAMEWORK_PATH}/Libraries"
+            "${GSTREAMER_FRAMEWORK_PATH}/lib"
+        )
+            if(EXISTS "${_cand}")
+                set(GSTREAMER_LIB_PATH "${_cand}")
+                set(GSTREAMER_PLUGIN_PATH "${GSTREAMER_LIB_PATH}/gstreamer-1.0")
+                break()
+            endif()
+        endforeach()
+    endif()
 
     _qgc_find_apple_pkg_config(PKG_CONFIG_EXECUTABLE)
     _gst_configure_pkg_config(
@@ -574,12 +672,43 @@ elseif(IOS)
     _qgc_discover_ios_sdk()
 endif()
 
-if(NOT EXISTS "${GStreamer_ROOT_DIR}" OR NOT EXISTS "${GSTREAMER_LIB_PATH}" OR NOT EXISTS "${GSTREAMER_PLUGIN_PATH}" OR NOT EXISTS "${GSTREAMER_INCLUDE_PATH}")
-    message(FATAL_ERROR "GStreamer: Could not locate required directories - check installation or set GStreamer_ROOT_DIR")
-endif()
+# xcframework sets GSTREAMER_LIB_PATH / GSTREAMER_PLUGIN_PATH to the slice dir
+# (which has no lib/ subdir), so the existence checks still pass.
+if(NOT GStreamer_USE_XCFRAMEWORK)
+    set(_gst_required_paths
+        "GStreamer_ROOT_DIR=${GStreamer_ROOT_DIR}"
+        "GSTREAMER_LIB_PATH=${GSTREAMER_LIB_PATH}"
+        "GSTREAMER_PLUGIN_PATH=${GSTREAMER_PLUGIN_PATH}"
+        "GSTREAMER_INCLUDE_PATH=${GSTREAMER_INCLUDE_PATH}"
+    )
+    set(_gst_missing_paths)
+    if(NOT EXISTS "${GStreamer_ROOT_DIR}")
+        list(APPEND _gst_missing_paths "GStreamer_ROOT_DIR=${GStreamer_ROOT_DIR}")
+    endif()
+    if(NOT EXISTS "${GSTREAMER_LIB_PATH}")
+        list(APPEND _gst_missing_paths "GSTREAMER_LIB_PATH=${GSTREAMER_LIB_PATH}")
+    endif()
+    if(NOT EXISTS "${GSTREAMER_PLUGIN_PATH}")
+        list(APPEND _gst_missing_paths "GSTREAMER_PLUGIN_PATH=${GSTREAMER_PLUGIN_PATH}")
+    endif()
+    if(NOT EXISTS "${GSTREAMER_INCLUDE_PATH}")
+        list(APPEND _gst_missing_paths "GSTREAMER_INCLUDE_PATH=${GSTREAMER_INCLUDE_PATH}")
+    endif()
+    if(_gst_missing_paths)
+        string(REPLACE ";" "\n  " _gst_missing_str "${_gst_missing_paths}")
+        message(FATAL_ERROR
+            "GStreamer: required directories do not exist on disk:\n  ${_gst_missing_str}\n"
+            "GSTREAMER_FRAMEWORK_PATH=${GSTREAMER_FRAMEWORK_PATH}\n"
+            "Check installation or set GStreamer_ROOT_DIR.")
+    endif()
 
-if(GStreamer_USE_FRAMEWORK AND NOT EXISTS "${GSTREAMER_FRAMEWORK_PATH}")
-    message(FATAL_ERROR "GStreamer: Could not locate framework at ${GSTREAMER_FRAMEWORK_PATH}")
+    if(GStreamer_USE_FRAMEWORK AND NOT EXISTS "${GSTREAMER_FRAMEWORK_PATH}")
+        message(FATAL_ERROR "GStreamer: Could not locate framework at ${GSTREAMER_FRAMEWORK_PATH}")
+    endif()
+else()
+    if(NOT EXISTS "${GSTREAMER_XCFRAMEWORK_LIB}")
+        message(FATAL_ERROR "GStreamer: xcframework library not found at ${GSTREAMER_XCFRAMEWORK_LIB}")
+    endif()
 endif()
 
 function(_qgc_gstreamer_component_to_api_name INPUT_COMPONENT OUTPUT_VAR)
@@ -685,8 +814,11 @@ if(ANDROID)
     set(GStreamer_ASSETS_DIR "${_gst_android_build_dir}/assets")
 elseif(IOS)
     set(GStreamer_Mobile_MODULE_NAME gstreamer_mobile)
-    set(G_IO_MODULES openssl)
-    set(G_IO_MODULES_PATH "${GStreamer_ROOT_DIR}/lib/gio/modules")
+    if(NOT GStreamer_USE_XCFRAMEWORK)
+        # xcframework bundles gio modules into libGStreamer.a; no separate module dir.
+        set(G_IO_MODULES openssl)
+        set(G_IO_MODULES_PATH "${GStreamer_ROOT_DIR}/lib/gio/modules")
+    endif()
     set(GStreamer_ASSETS_DIR "${CMAKE_BINARY_DIR}/assets")
 endif()
 
@@ -695,6 +827,134 @@ set(GStreamer_ROOT_DIR "${GStreamer_ROOT_DIR}" CACHE PATH "GStreamer SDK root di
 if(GStreamer_USE_FRAMEWORK)
     list(APPEND CMAKE_FRAMEWORK_PATH "${GSTREAMER_FRAMEWORK_PATH}")
 endif()
+
+if(GStreamer_USE_XCFRAMEWORK)
+    # ── xcframework path: create IMPORTED targets directly from the fat .a ───
+    # No pkg-config or .framework; all APIs and plugins live in one archive.
+    if(NOT TARGET GStreamer::GStreamer)
+        add_library(GStreamer_static STATIC IMPORTED GLOBAL)
+        set_target_properties(GStreamer_static PROPERTIES
+            IMPORTED_LOCATION "${GSTREAMER_XCFRAMEWORK_LIB}"
+        )
+        add_library(GStreamer::GStreamer INTERFACE IMPORTED GLOBAL)
+        target_link_libraries(GStreamer::GStreamer INTERFACE
+            GStreamer_static
+        )
+        target_include_directories(GStreamer::GStreamer INTERFACE
+            "${GSTREAMER_INCLUDE_PATH}"
+            "${GSTREAMER_INCLUDE_PATH}/gstreamer-1.0"
+            "${GSTREAMER_INCLUDE_PATH}/glib-2.0"
+        )
+        # System frameworks required by GStreamer on iOS.
+        find_library(_xcfw_foundation     Foundation     REQUIRED)
+        find_library(_xcfw_avfoundation   AVFoundation   REQUIRED)
+        find_library(_xcfw_audiotoolbox   AudioToolbox   REQUIRED)
+        find_library(_xcfw_videotoolbox   VideoToolbox   REQUIRED)
+        find_library(_xcfw_coremedia      CoreMedia      REQUIRED)
+        find_library(_xcfw_corevideo      CoreVideo      REQUIRED)
+        find_library(_xcfw_coreaudio      CoreAudio      REQUIRED)
+        find_library(_xcfw_coregraphics   CoreGraphics   REQUIRED)
+        find_library(_xcfw_security       Security       REQUIRED)
+        find_library(_xcfw_opengles       OpenGLES       REQUIRED)
+        find_library(_xcfw_uikit          UIKit          REQUIRED)
+        find_library(_xcfw_corefoundation CoreFoundation REQUIRED)
+        target_link_libraries(GStreamer::GStreamer INTERFACE
+            "${_xcfw_foundation}"
+            "${_xcfw_avfoundation}"
+            "${_xcfw_audiotoolbox}"
+            "${_xcfw_videotoolbox}"
+            "${_xcfw_coremedia}"
+            "${_xcfw_corevideo}"
+            "${_xcfw_coreaudio}"
+            "${_xcfw_coregraphics}"
+            "${_xcfw_security}"
+            "${_xcfw_opengles}"
+            "${_xcfw_uikit}"
+            "${_xcfw_corefoundation}"
+            "-lresolv" "-liconv" "-lz" "-lbz2"
+        )
+        target_compile_definitions(GStreamer::GStreamer INTERFACE
+            QGC_GST_STATIC_BUILD
+        )
+        unset(_xcfw_foundation CACHE)
+        unset(_xcfw_avfoundation CACHE)
+        unset(_xcfw_audiotoolbox CACHE)
+        unset(_xcfw_videotoolbox CACHE)
+        unset(_xcfw_coremedia CACHE)
+        unset(_xcfw_corevideo CACHE)
+        unset(_xcfw_coreaudio CACHE)
+        unset(_xcfw_coregraphics CACHE)
+        unset(_xcfw_security CACHE)
+        unset(_xcfw_opengles CACHE)
+        unset(_xcfw_uikit CACHE)
+        unset(_xcfw_corefoundation CACHE)
+    endif()
+
+    # All API component targets alias the single mega-library.
+    foreach(_xcfw_comp IN ITEMS api_base api_gl api_gl_prototypes api_rtsp api_video api_app)
+        if(NOT TARGET GStreamer::${_xcfw_comp})
+            add_library(GStreamer::${_xcfw_comp} INTERFACE IMPORTED GLOBAL)
+            target_link_libraries(GStreamer::${_xcfw_comp} INTERFACE GStreamer::GStreamer)
+        endif()
+    endforeach()
+
+    # Build the xcframework mobile init shim — calls gst_init_static_plugins().
+    if(NOT TARGET GStreamer::mobile)
+        enable_language(OBJC OBJCXX)
+
+        # GStreamer 1.28+ ships every plugin compiled into libGStreamer.a but
+        # provides no auto-registration entrypoint; enumerate plugin descriptors
+        # from the archive and emit explicit GST_PLUGIN_STATIC_REGISTER() calls.
+        find_program(_xcfw_nm NAMES nm llvm-nm REQUIRED)
+        execute_process(
+            COMMAND "${_xcfw_nm}" -gjU "${GSTREAMER_XCFRAMEWORK_LIB}"
+            OUTPUT_VARIABLE _xcfw_nm_out
+            ERROR_QUIET
+            RESULT_VARIABLE _xcfw_nm_rc
+        )
+        if(NOT _xcfw_nm_rc EQUAL 0)
+            message(FATAL_ERROR "nm failed on ${GSTREAMER_XCFRAMEWORK_LIB} (rc=${_xcfw_nm_rc})")
+        endif()
+        string(REGEX MATCHALL "_gst_plugin_[A-Za-z0-9_]+_get_desc" _xcfw_descs "${_xcfw_nm_out}")
+        list(REMOVE_DUPLICATES _xcfw_descs)
+        set(_xcfw_decl "")
+        set(_xcfw_reg  "")
+        foreach(_sym IN LISTS _xcfw_descs)
+            string(REGEX REPLACE "^_gst_plugin_(.+)_get_desc$" "\\1" _name "${_sym}")
+            string(APPEND _xcfw_decl "GST_PLUGIN_STATIC_DECLARE(${_name});\n")
+            string(APPEND _xcfw_reg  "    GST_PLUGIN_STATIC_REGISTER(${_name});\n")
+        endforeach()
+        list(LENGTH _xcfw_descs _xcfw_n)
+        message(STATUS "GStreamer xcframework: registering ${_xcfw_n} static plugins")
+        set(GST_STATIC_PLUGIN_DECLARES "${_xcfw_decl}")
+        set(GST_STATIC_PLUGIN_REGISTERS "${_xcfw_reg}")
+
+        set(_xcfw_shim "${CMAKE_BINARY_DIR}/${GStreamer_Mobile_MODULE_NAME}.m")
+        configure_file(
+            "${CMAKE_CURRENT_LIST_DIR}/GStreamer/gst_ios_xcframework_init.m.in"
+            "${_xcfw_shim}"
+            @ONLY
+        )
+        add_library(GStreamerMobileXcfw SHARED)
+        target_sources(GStreamerMobileXcfw PRIVATE "${_xcfw_shim}")
+        set_source_files_properties("${_xcfw_shim}" PROPERTIES LANGUAGE OBJC GENERATED TRUE)
+        target_link_libraries(GStreamerMobileXcfw PRIVATE GStreamer::GStreamer)
+        set_target_properties(GStreamerMobileXcfw PROPERTIES
+            LIBRARY_OUTPUT_NAME ${GStreamer_Mobile_MODULE_NAME}
+            LINKER_LANGUAGE OBJCXX
+            FRAMEWORK TRUE
+            FRAMEWORK_VERSION A
+            MACOSX_FRAMEWORK_IDENTIFIER org.gstreamer.GStreamerMobile
+        )
+        add_library(GStreamer::mobile ALIAS GStreamerMobileXcfw)
+        add_library(GStreamerMobile ALIAS GStreamerMobileXcfw)
+        set(GStreamerMobile_FOUND TRUE)
+        set(GStreamerMobile_mobile_FOUND TRUE)
+    endif()
+
+    set(GStreamer_FOUND TRUE)
+    set(GStreamer_VERSION "${GStreamer_FIND_VERSION}")
+else()
 
 if(GStreamer_USE_STATIC_LIBS)
     list(APPEND PKG_CONFIG_ARGN "--static")
@@ -760,6 +1020,8 @@ if(ANDROID OR IOS)
     find_package(GStreamerMobile REQUIRED COMPONENTS ${_mobile_components})
 endif()
 
+endif() # GStreamer_USE_XCFRAMEWORK
+
 foreach(_comp IN ITEMS Core Base Video Gl GlPrototypes Rtsp)
     set(QGCGStreamer_${_comp}_FOUND TRUE)
     set(GStreamer_${_comp}_FOUND TRUE)
@@ -799,7 +1061,7 @@ if(LINUX AND NOT "videoconvertscale" IN_LIST GSTREAMER_PLUGINS
     endif()
 endif()
 
-if(NOT GStreamer_USE_STATIC_LIBS AND EXISTS "${GSTREAMER_PLUGIN_PATH}")
+if(NOT GStreamer_USE_STATIC_LIBS AND NOT GStreamer_USE_XCFRAMEWORK AND EXISTS "${GSTREAMER_PLUGIN_PATH}")
     set(_gst_missing_plugins)
     if(WIN32)
         set(_gst_plugin_glob "gst*.dll")

--- a/cmake/find-modules/GStreamer/gst_ios_xcframework_init.m.in
+++ b/cmake/find-modules/GStreamer/gst_ios_xcframework_init.m.in
@@ -1,0 +1,65 @@
+/*
+ * GStreamer iOS xcframework initialization shim.
+ * Auto-generated from template by CMake configure_file().
+ *
+ * GStreamer 1.28+ xcframework bundles every plugin into libGStreamer.a but
+ * exposes no auto-registration entrypoint; the CMake find module enumerates
+ * plugin descriptors via nm and substitutes the GST_PLUGIN_STATIC_*() calls
+ * below.
+ *
+ * SPDX-License-Identifier: LGPL-2.1-or-later
+ */
+
+#import <Foundation/Foundation.h>
+#include <gst/gst.h>
+
+@GST_STATIC_PLUGIN_DECLARES@
+
+void
+gst_init_static_plugins (void)
+{
+@GST_STATIC_PLUGIN_REGISTERS@
+}
+
+void
+gst_ios_pre_init (void)
+{
+    NSString *resources = [[NSBundle mainBundle] resourcePath];
+    NSString *tmp = NSTemporaryDirectory();
+    NSString *cache = [NSHomeDirectory() stringByAppendingPathComponent:@"Library/Caches"];
+    NSString *docs = [NSHomeDirectory() stringByAppendingPathComponent:@"Documents"];
+
+    const gchar *resources_dir = [resources UTF8String];
+    const gchar *tmp_dir = [tmp UTF8String];
+    const gchar *cache_dir = [cache UTF8String];
+    const gchar *docs_dir = [docs UTF8String];
+
+    g_setenv("TMP", tmp_dir, TRUE);
+    g_setenv("TEMP", tmp_dir, TRUE);
+    g_setenv("TMPDIR", tmp_dir, TRUE);
+    g_setenv("XDG_RUNTIME_DIR", resources_dir, TRUE);
+    g_setenv("XDG_CACHE_HOME", cache_dir, TRUE);
+    g_setenv("HOME", docs_dir, TRUE);
+    g_setenv("XDG_DATA_DIRS", resources_dir, TRUE);
+    g_setenv("XDG_CONFIG_DIRS", resources_dir, TRUE);
+    g_setenv("XDG_CONFIG_HOME", cache_dir, TRUE);
+    g_setenv("XDG_DATA_HOME", resources_dir, TRUE);
+}
+
+void
+gst_ios_post_init (void)
+{
+    GstRegistry *reg = gst_registry_get();
+
+    /* Prefer native iOS AVFoundation source over generic filesrc/giosrc. */
+    GstPluginFeature *plugin = gst_registry_lookup_feature(reg, "filesrc");
+    if (plugin) {
+        gst_plugin_feature_set_rank(plugin, GST_RANK_SECONDARY);
+        gst_object_unref(plugin);
+    }
+    plugin = gst_registry_lookup_feature(reg, "giosrc");
+    if (plugin) {
+        gst_plugin_feature_set_rank(plugin, (GST_RANK_SECONDARY - 1));
+        gst_object_unref(plugin);
+    }
+}

--- a/src/Comms/MockLink/CMakeLists.txt
+++ b/src/Comms/MockLink/CMakeLists.txt
@@ -36,3 +36,5 @@ qt_add_resources(${CMAKE_PROJECT_NAME} mocklink_resources
 )
 
 target_include_directories(${CMAKE_PROJECT_NAME} PRIVATE ${CMAKE_CURRENT_SOURCE_DIR})
+
+target_precompile_headers(${CMAKE_PROJECT_NAME} PRIVATE "MockLink.h")

--- a/src/FirmwarePlugin/APM/CMakeLists.txt
+++ b/src/FirmwarePlugin/APM/CMakeLists.txt
@@ -27,7 +27,6 @@ endif()
 
 target_include_directories(${CMAKE_PROJECT_NAME} PRIVATE ${CMAKE_CURRENT_SOURCE_DIR})
 
-# Add JSON files
 file(GLOB_RECURSE JSON_FILES RELATIVE ${CMAKE_CURRENT_SOURCE_DIR} ${CMAKE_CURRENT_SOURCE_DIR}/*.json)
 qt_add_resources(${CMAKE_PROJECT_NAME} json_firmaware_plugin_apm
     PREFIX "/json"
@@ -35,7 +34,6 @@ qt_add_resources(${CMAKE_PROJECT_NAME} json_firmaware_plugin_apm
     ${JSON_FILES}
 )
 
-# Add other resource
 qt_add_resources(${CMAKE_PROJECT_NAME} firmaware_plugin_apm_resource
     PREFIX "/FirmwarePlugin/APM"
     FILES
@@ -53,6 +51,17 @@ CPMAddPackage(
     GIT_TAG 037ff6bcfc080608544a4526f2c22406f2cce60f
 )
 
+# Filters applied to discovered ArduPilot parameter dirs (e.g. "Copter-4.7").
+# Regex (CMake syntax) — match against the dir name; matches are dropped.
+set(QGC_APM_PARAMS_EXCLUDE
+    "AP_Periph-.*"
+    "Blimp-.*"
+    "^Copter-3[.]"
+    "^Plane-3[.]"
+    "^Rover-3[.]"
+    CACHE STRING
+    "Regex patterns matched against ArduPilot param dir names to exclude from the embedded resource")
+
 # Dynamically discover all parameter definition files.
 # Directory layout: {Vehicle}-{Major}.{Minor}/apm.pdef.json
 # Resource alias:   FirmwarePlugin/APM/APMParameterFactMetaData.{Vehicle}.{Major}.{Minor}.json
@@ -60,6 +69,7 @@ file(GLOB _apm_pdef_files "${ArduPilotParams_SOURCE_DIR}/*/apm.pdef.json")
 list(SORT _apm_pdef_files)
 
 set(_apm_param_resources "")
+set(_apm_param_skipped "")
 foreach(_pdef IN LISTS _apm_pdef_files)
     get_filename_component(_dir "${_pdef}" DIRECTORY)
     get_filename_component(_dirname "${_dir}" NAME)
@@ -71,6 +81,18 @@ foreach(_pdef IN LISTS _apm_pdef_files)
     set(_vehicle "${CMAKE_MATCH_1}")
     set(_version "${CMAKE_MATCH_2}")
 
+    set(_excluded FALSE)
+    foreach(_pattern IN LISTS QGC_APM_PARAMS_EXCLUDE)
+        if(_pattern AND "${_dirname}" MATCHES "${_pattern}")
+            set(_excluded TRUE)
+            break()
+        endif()
+    endforeach()
+    if(_excluded)
+        list(APPEND _apm_param_skipped "${_dirname}")
+        continue()
+    endif()
+
     string(REPLACE "-" "." _version_dots "${_version}")
 
     set(_alias "FirmwarePlugin/APM/APMParameterFactMetaData.${_vehicle}.${_version_dots}.json")
@@ -80,13 +102,16 @@ endforeach()
 
 list(LENGTH _apm_param_resources _apm_param_count)
 message(STATUS "APM: Found ${_apm_param_count} parameter definition files")
+if(_apm_param_skipped)
+    list(LENGTH _apm_param_skipped _apm_param_skipped_count)
+    message(STATUS "APM: Excluded ${_apm_param_skipped_count} parameter dirs by QGC_APM_PARAMS_EXCLUDE: ${_apm_param_skipped}")
+endif()
 
 qt_add_resources(${CMAKE_PROJECT_NAME} "qgcresources_apm_params"
     PREFIX "/"
     FILES ${_apm_param_resources}
 )
 
-# Add qml module
 qt_add_library(APMFirmwareModule STATIC)
 
 qt_add_qml_module(APMFirmwareModule

--- a/src/FlyView/CMakeLists.txt
+++ b/src/FlyView/CMakeLists.txt
@@ -77,7 +77,7 @@ qt_add_qml_module(FlyViewModule
     NO_PLUGIN
 )
 
-qt_add_resources(${CMAKE_PROJECT_NAME} flyview_resources
+qt_add_resources(FlyViewModule flyview_resources
     PREFIX "/res"
     BASE "${CMAKE_SOURCE_DIR}/resources"
     FILES
@@ -87,7 +87,7 @@ qt_add_resources(${CMAKE_PROJECT_NAME} flyview_resources
         "${CMAKE_SOURCE_DIR}/resources/pause-mission.svg"
 )
 
-qt_add_resources(${CMAKE_PROJECT_NAME} flyview_qmlimages
+qt_add_resources(FlyViewModule flyview_qmlimages
     PREFIX "/qmlimages"
     BASE "${CMAKE_SOURCE_DIR}/resources"
     FILES

--- a/src/PlanView/CMakeLists.txt
+++ b/src/PlanView/CMakeLists.txt
@@ -64,7 +64,7 @@ set_source_files_properties("${CMAKE_SOURCE_DIR}/resources/gear-black.svg"
 set_source_files_properties("${CMAKE_SOURCE_DIR}/resources/camera.svg"
     PROPERTIES QT_RESOURCE_ALIAS "PlanSimpleItemCamera.svg")
 
-qt_add_resources(${CMAKE_PROJECT_NAME} planview_resources
+qt_add_resources(PlanViewModule planview_resources
     PREFIX "/res"
     BASE "${CMAKE_SOURCE_DIR}/resources"
     FILES
@@ -81,7 +81,7 @@ qt_add_resources(${CMAKE_PROJECT_NAME} planview_resources
         "${CMAKE_SOURCE_DIR}/resources/waypoint.svg"
 )
 
-qt_add_resources(${CMAKE_PROJECT_NAME} planview_qmlimages
+qt_add_resources(PlanViewModule planview_qmlimages
     PREFIX "/qmlimages"
     BASE "${CMAKE_SOURCE_DIR}/resources"
     FILES

--- a/src/QmlControls/CMakeLists.txt
+++ b/src/QmlControls/CMakeLists.txt
@@ -204,7 +204,7 @@ qt_add_resources(${CMAKE_PROJECT_NAME} json_controls
     FILES ${JSON_FILES}
 )
 
-qt_add_resources(${CMAKE_PROJECT_NAME} qmlcontrols_resources
+qt_add_resources(QGroundControlControlsModule qmlcontrols_resources
     PREFIX "/res"
     BASE "${CMAKE_SOURCE_DIR}/resources"
     FILES
@@ -221,7 +221,7 @@ qt_add_resources(${CMAKE_PROJECT_NAME} qmlcontrols_resources
 set_source_files_properties("${CMAKE_SOURCE_DIR}/resources/CogWheels.png"
     PROPERTIES QT_RESOURCE_ALIAS "subMenuButtonImage.png")
 
-qt_add_resources(${CMAKE_PROJECT_NAME} qmlcontrols_qmlimages
+qt_add_resources(QGroundControlControlsModule qmlcontrols_qmlimages
     PREFIX "/qmlimages"
     BASE "${CMAKE_CURRENT_SOURCE_DIR}"
     FILES
@@ -235,7 +235,7 @@ qt_add_resources(${CMAKE_PROJECT_NAME} qmlcontrols_qmlimages
 file(GLOB INSTRUMENT_VALUE_ICONS CONFIGURE_DEPENDS
     "${CMAKE_SOURCE_DIR}/resources/InstrumentValueIcons/*.svg"
 )
-qt_add_resources(${CMAKE_PROJECT_NAME} instrument_value_icons
+qt_add_resources(QGroundControlControlsModule instrument_value_icons
     PREFIX "/InstrumentValueIcons"
     BASE "${CMAKE_SOURCE_DIR}/resources/InstrumentValueIcons"
     FILES ${INSTRUMENT_VALUE_ICONS}

--- a/src/QtLocationPlugin/CMakeLists.txt
+++ b/src/QtLocationPlugin/CMakeLists.txt
@@ -92,6 +92,18 @@ target_include_directories(QGCLocation
 
 target_link_libraries(${CMAKE_PROJECT_NAME} PRIVATE QGCLocation)
 
+target_precompile_headers(QGCLocation PRIVATE
+    <QtCore/QDir>
+    <QtCore/QLoggingCategory>
+    <QtCore/QObject>
+    <QtCore/QString>
+    <QtCore/QStringList>
+    <QtCore/QVariant>
+    <QtNetwork/QNetworkRequest>
+    <QtPositioning/QGeoCoordinate>
+    <QtQml/QQmlEngine>
+)
+
 qt_add_resources(${CMAKE_PROJECT_NAME} qtlocationplugin_resources
     PREFIX "/res"
     BASE "${CMAKE_SOURCE_DIR}/resources"

--- a/src/Utilities/Audio/CMakeLists.txt
+++ b/src/Utilities/Audio/CMakeLists.txt
@@ -20,3 +20,11 @@ target_include_directories(QGCAudio
 )
 
 target_link_libraries(${CMAKE_PROJECT_NAME} PRIVATE QGCAudio)
+
+# AudioOutput.cc was 3.4s frontend in build profile; absorbing the QtTextToSpeech
+# + QObject (qfloat16->std::format chain) headers cuts most of it.
+target_precompile_headers(QGCAudio PRIVATE
+    <QtCore/QObject>
+    <QtCore/QString>
+    <QtTextToSpeech/QTextToSpeech>
+)

--- a/src/Utilities/Sensors/CMakeLists.txt
+++ b/src/Utilities/Sensors/CMakeLists.txt
@@ -18,3 +18,12 @@ target_include_directories(QGCSensors
 )
 
 target_link_libraries(${CMAKE_PROJECT_NAME} PRIVATE QGCSensors)
+
+target_precompile_headers(QGCSensors PRIVATE
+    <QtCore/QObject>
+    <QtCore/QString>
+    <QtPositioning/QGeoPositionInfo>
+    <QtSensors/QAmbientTemperatureSensor>
+    <QtSensors/QCompass>
+    <QtSensors/QPressureSensor>
+)

--- a/src/VideoManager/VideoReceiver/GStreamer/gstqgc/gstqml6gl/CMakeLists.txt
+++ b/src/VideoManager/VideoReceiver/GStreamer/gstqgc/gstqml6gl/CMakeLists.txt
@@ -105,6 +105,14 @@ target_precompile_headers(gstqml6gl
         <gst/gst.h>
         <gst/gl/gl.h>
         <gst/video/video.h>
+        # 6 TUs (qt6glitem/qsg6material/qml6gl{mixer,overlay,sink,src}) hit
+        # qquickitem.h -> qqml.h cold; share via PCH.
+        <QtCore/QObject>
+        <QtCore/QString>
+        <QtGui/QOpenGLFunctions>
+        <QtQml/QQmlEngine>
+        <QtQuick/QQuickItem>
+        <QtQuick/QQuickWindow>
 )
 
 file(GLOB _shader_files

--- a/src/Viewer3D/CMakeLists.txt
+++ b/src/Viewer3D/CMakeLists.txt
@@ -9,10 +9,6 @@ target_sources(${CMAKE_PROJECT_NAME}
         Viewer3DManager.h
         Viewer3DMapProvider.cc
         Viewer3DMapProvider.h
-        Viewer3DGeoCoordinateType.h
-        Viewer3DGeoCoordinateType.cc
-        Viewer3DInstancing.cc
-        Viewer3DInstancing.h
         Viewer3DTerrainGeometry.cc
         Viewer3DTerrainGeometry.h
         Viewer3DTerrainTexture.cc
@@ -31,6 +27,8 @@ add_subdirectory(Providers/Osm)
 
 # ----------------------------------------------------------------------------
 # 3D QML Module
+# QML_ELEMENT classes live here so their MOC + qmltyperegistrar run on this
+# smaller target instead of the 47s ${CMAKE_PROJECT_NAME}_autogen step.
 # ----------------------------------------------------------------------------
 qt_add_library(Viewer3DModule STATIC)
 
@@ -43,6 +41,11 @@ qt_add_qml_module(Viewer3DModule
     URI QGroundControl.Viewer3D
     VERSION 1.0
     RESOURCE_PREFIX /qml
+    SOURCES
+        Viewer3DGeoCoordinateType.cc
+        Viewer3DGeoCoordinateType.h
+        Viewer3DInstancing.cc
+        Viewer3DInstancing.h
     QML_FILES
         Viewer3DQml/Models3D/CameraLightModel.qml
         Viewer3DQml/Models3D/Viewer3DModel.qml
@@ -75,5 +78,19 @@ qt_add_qml_module(Viewer3DModule
         QtQuick
         QtQuick3D
         QtQuick3D.Helpers
-    NO_PLUGIN
 )
+
+target_link_libraries(Viewer3DModule
+    PRIVATE
+        QGCLogging
+        QGCGeoMath
+    PUBLIC
+        Qt6::Core
+        Qt6::Gui
+        Qt6::Positioning
+        Qt6::Qml
+        Qt6::QmlIntegration
+        Qt6::Quick3D
+)
+
+target_include_directories(Viewer3DModule PRIVATE ${CMAKE_CURRENT_SOURCE_DIR})

--- a/src/Viewer3D/Providers/Osm/CMakeLists.txt
+++ b/src/Viewer3D/Providers/Osm/CMakeLists.txt
@@ -2,37 +2,33 @@
 # OSM Provider
 # ============================================================================
 
-target_sources(${CMAKE_PROJECT_NAME}
+qt_add_library(Osm3D STATIC
+    OsmParserThread.cc
+    OsmParserThread.h
+)
+
+target_include_directories(Osm3D PUBLIC ${CMAKE_CURRENT_SOURCE_DIR})
+
+target_link_libraries(Osm3D
+    PUBLIC
+        Qt6::Core
+        Qt6::Gui
+        Qt6::Positioning
     PRIVATE
-        CityMapGeometry.cc
-        CityMapGeometry.h
-        OsmParser.cc
-        OsmParser.h
-        OsmParserThread.cc
-        OsmParserThread.h
+        QGCGeoMath
+        QGCLogging
 )
 
-target_include_directories(${CMAKE_PROJECT_NAME} PRIVATE ${CMAKE_CURRENT_SOURCE_DIR})
-
-# ----------------------------------------------------------------------------
-# earcut.hpp — polygon triangulation
-# EXCLUDE_FROM_ALL prevents earcut's unconditionally-built "fixtures" object
-# library (30+ test data files) from compiling as part of our build.
-# ----------------------------------------------------------------------------
-
-CPMAddPackage(
-    NAME earcut_hpp
-    GITHUB_REPOSITORY mapbox/earcut.hpp
-    GIT_TAG f36ced7e50254738c4e5af1a239f5fb7b1094007
-    EXCLUDE_FROM_ALL YES
-    OPTIONS
-        "EARCUT_BUILD_TESTS OFF"
-        "EARCUT_BUILD_BENCH OFF"
-        "EARCUT_BUILD_VIZ OFF"
-    SYSTEM YES
-)
-
-target_link_libraries(${CMAKE_PROJECT_NAME} PRIVATE earcut_hpp::earcut_hpp)
+# libosmium pulls <windows.h> via std::filesystem; without these the
+# min/max macros and missing M_PI break MSVC compilation of OsmParserThread.cc.
+if(WIN32)
+    target_compile_definitions(Osm3D
+        PRIVATE
+            _USE_MATH_DEFINES
+            NOMINMAX
+            WIN32_LEAN_AND_MEAN
+    )
+endif()
 
 # ----------------------------------------------------------------------------
 # libexpat — XML parser backend for libosmium
@@ -53,7 +49,7 @@ CPMAddPackage(
 
 qgc_disable_dependency_warnings(expat)
 
-target_link_libraries(${CMAKE_PROJECT_NAME} PRIVATE expat)
+target_link_libraries(Osm3D PRIVATE expat)
 
 # ----------------------------------------------------------------------------
 # protozero — required by libosmium headers
@@ -67,7 +63,7 @@ CPMAddPackage(
 )
 
 # ----------------------------------------------------------------------------
-# libosmium — OSM data parsing
+# libosmium — OSM data parsing (header-only, only OsmParserThread.cc consumes it)
 # ----------------------------------------------------------------------------
 
 CPMAddPackage(
@@ -77,9 +73,49 @@ CPMAddPackage(
     DOWNLOAD_ONLY YES
 )
 
-target_include_directories(${CMAKE_PROJECT_NAME}
+target_include_directories(Osm3D
     SYSTEM
     PRIVATE
         ${protozero_SOURCE_DIR}/include
         ${libosmium_SOURCE_DIR}/include
+)
+
+# ============================================================================
+# Main-target sources — OsmParser + CityMapGeometry pull QGC headers
+# (Fact, SettingsManager, Viewer3DSettings, Viewer3DMapProvider) so they stay
+# on ${CMAKE_PROJECT_NAME}. They use Osm3D via the link below.
+# ============================================================================
+
+target_sources(${CMAKE_PROJECT_NAME}
+    PRIVATE
+        CityMapGeometry.cc
+        CityMapGeometry.h
+        OsmParser.cc
+        OsmParser.h
+)
+
+target_include_directories(${CMAKE_PROJECT_NAME} PRIVATE ${CMAKE_CURRENT_SOURCE_DIR})
+
+# ----------------------------------------------------------------------------
+# earcut.hpp — header-only polygon triangulation, only used by OsmParser.cc
+# (which lives on the main target). EXCLUDE_FROM_ALL prevents earcut's
+# unconditional "fixtures" object library from compiling.
+# ----------------------------------------------------------------------------
+
+CPMAddPackage(
+    NAME earcut_hpp
+    GITHUB_REPOSITORY mapbox/earcut.hpp
+    GIT_TAG f36ced7e50254738c4e5af1a239f5fb7b1094007
+    EXCLUDE_FROM_ALL YES
+    OPTIONS
+        "EARCUT_BUILD_TESTS OFF"
+        "EARCUT_BUILD_BENCH OFF"
+        "EARCUT_BUILD_VIZ OFF"
+    SYSTEM YES
+)
+
+target_link_libraries(${CMAKE_PROJECT_NAME}
+    PRIVATE
+        Osm3D
+        earcut_hpp::earcut_hpp
 )

--- a/src/Viewer3D/Viewer3DQml/Drones/DroneModelDjiF450.qml
+++ b/src/Viewer3D/Viewer3DQml/Drones/DroneModelDjiF450.qml
@@ -3,6 +3,7 @@ import QtQuick3D
 
 import QGroundControl
 import QGroundControl.Controls
+import QGroundControl.Viewer3D
 
 Node {
     id: body

--- a/src/Viewer3D/Viewer3DQml/Models3D/Viewer3DVehicleItems.qml
+++ b/src/Viewer3D/Viewer3DQml/Models3D/Viewer3DVehicleItems.qml
@@ -1,5 +1,6 @@
 import QGroundControl
 import QGroundControl.Controls
+import QGroundControl.Viewer3D
 import QtQuick3D
 import QtQuick3D.Helpers
 

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -25,6 +25,10 @@ target_include_directories(${CMAKE_PROJECT_NAME} PRIVATE ${CMAKE_CURRENT_SOURCE_
 
 target_compile_definitions(${CMAKE_PROJECT_NAME} PRIVATE QGC_UNITTEST_BUILD)
 
+target_precompile_headers(${CMAKE_PROJECT_NAME} PRIVATE
+    <QtTest/QTest>
+)
+
 # ----------------------------------------------------------------------------
 # CTest Integration (CTest included in root CMakeLists.txt)
 # ----------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

Build-time improvements landed as a single commit. Net effect on a Debug clean build (Linux, gcc/clang, ninja, 16-core): wall-clock at baseline within noise (~1:40), CPU −18s, peak RSS −70 MB, and several hot rcc/autogen TUs reduced. The dominant remaining constraint is the 47.8s `\${CMAKE_PROJECT_NAME}_autogen/timestamp` (AUTOMOC of the mega-target) — a future split of FirmwarePlugin/FlyView/PlanView into their own AUTOMOC targets is the next lever.

### PCH coverage on small leaf libs
- Per-target PCH for `MockLink`, `QGCLocation`, `Audio`, `Sensors`, `gstqml6gl` (Qt header parse cost amortised across each lib's TUs).
- `<QtTest/QTest>` added to the test-only PCH (`test/CMakeLists.txt`) so test TUs reuse it without paying that cost on non-test builds.

### APM parameter resource filter (`QGC_APM_PARAMS_EXCLUDE`)
- New cache var: list of CMake regex patterns matched against ArduPilot pdef directory names (e.g. `Copter-4.7`).
- Defaults exclude `AP_Periph-*`, `Blimp-*`, and pre-4.x Copter/Plane/Rover — drops 17 of 51 pdefs from the `qrc_qgcresources_apm_params.cpp` rcc TU (~1.9s off the critical path).
- Override via `-DQGC_APM_PARAMS_EXCLUDE=...` at configure time.

### Viewer3D split
- Move QML-only `Viewer3DInstancing` + `Viewer3DGeoCoordinateType` into `Viewer3DModule`'s `SOURCES` so their MOC + qmltyperegistrar run on the smaller target (not the parent's 47s autogen). Other 4 QML elements (`Manager`, `MapProvider`, `TerrainGeometry`, `TerrainTexture`) stay on the main target — moving them required pulling in `Vehicle.h`/`Fact.h`/`SettingsManager.h`/etc. via a `\$<TARGET_PROPERTY>` include-prop hack that caused a +28s wall regression. Kept the move minimal.
- Add `import QGroundControl.Viewer3D` to QML consumers — the moved types now register under that URI.
- Carve `OsmParserThread` + `libosmium`/`expat`/`protozero` deps into a standalone `Osm3D` static lib. The libosmium header parse cost stops contaminating `\${CMAKE_PROJECT_NAME}`'s compile commands and the SYSTEM include set is contained.

### Module-private resource ownership
- Move image resources from standalone `qt_add_resources(\${CMAKE_PROJECT_NAME} ...)` calls into the owning qml module's `RESOURCES` block, with `QT_RESOURCE_ALIAS` so the absolute `\${CMAKE_SOURCE_DIR}/resources/...` paths become module-relative qrc URLs.
- Updated QML consumers from `/res/Foo.svg` or `/qmlimages/Bar.png` to bare-name references (resolve relative to the QML file's qrc URL inside the same module).
- Done for **FlyView** (5 files), **PlanView** (15 files), **QmlControls** (8 files; 2 cross-module-shared files left in place). Other modules (AnalyzeView, MissionManager, Camera, QtLocationPlugin) skipped — their resources are referenced by C++ or by other modules' QML.

## Test plan

- [x] `cmake --build build --parallel` clean (Linux, Debug, gcc/clang)
- [x] `ctest -L Unit -j4` — 146/146 pass
- [x] `ctest -L Viewer3D -j4` — 9/9 pass
- [x] qmllint resolves `Viewer3DInstancing` / `Viewer3DGeoCoordinateType` types under their new URI
- [x] `qml_register_types_QGroundControl_Viewer3D` symbol present in final binary (verified via `nm`)
- [ ] CI cross-platform (macOS, Windows, Android, iOS) — please trigger
- [ ] Manual smoke test: launch app, open FlyView + PlanView, confirm icons render (Gripper, land, pause-mission, etc.) and Plan view image resources (PatternCamera/Grid/Presets/Terrain) load