### PR TITLE
PlanView: Fix mission item editor fields missing for Qt 6.10 and single-category items

### DIFF
--- a/src/FactSystem/FactControls/FactTextFieldSlider.qml
+++ b/src/FactSystem/FactControls/FactTextFieldSlider.qml
@@ -18,6 +18,7 @@ Rectangle {
     property alias textFieldShowHelp:       factTextField.textFieldShowHelp
     property alias textField:               factTextField
     property alias enableCheckBoxChecked:   enableCheckbox.checked
+    property bool  warnOnUserMinMaxInvalid: true  ///< true: warn if userMin/userMax are invalid, false: no warning
 
     property bool   showEnableCheckbox: false ///< true: show enable/disable checkbox, false: hide
     property bool   allowUsingMinMax:   false ///< true: fall back to fact.min/max when userMin/Max not set
@@ -52,7 +53,7 @@ Rectangle {
 
     Component.onCompleted: {
         _loadComplete = true
-        if (!allowUsingMinMax && sliderMin === undefined && sliderMax === undefined && (fact.userMin === undefined || fact.userMax === undefined)) {
+        if (warnOnUserMinMaxInvalid && !allowUsingMinMax && sliderMin === undefined && sliderMax === undefined && (fact.userMin === undefined || fact.userMax === undefined)) {
             console.warn("FactTextFieldSlider: userMin/userMax not set for", fact.name)
         }
     }

--- a/src/MissionManager/MavCmdInfoFixedWing.json
+++ b/src/MissionManager/MavCmdInfoFixedWing.json
@@ -26,7 +26,9 @@
                 "label":            "Pitch",
                 "units":            "deg",
                 "default":          15,
-                "decimalPlaces":    2
+                "decimalPlaces":    2,
+                "userMin":          0,
+                "userMax":          45
             }
         }
     ]

--- a/src/PlanView/MissionItemMapVisualBase.qml
+++ b/src/PlanView/MissionItemMapVisualBase.qml
@@ -19,9 +19,6 @@ Item {
     /// Subclasses must set this to their indicator Component
     property Component indicatorComponent
 
-    /// Exposed so subclasses can drive additional visual loaders alongside the base.
-    property alias _itemVisualLoader: itemVisualLoader
-
     property var _missionItem: object
     property bool _itemVisualShowing: false
     property bool _dragAreaShowing: false
@@ -29,17 +26,11 @@ Item {
     signal clicked(int sequenceNumber)
 
     function hideItemVisuals() {
-        if (_itemVisualShowing) {
-            itemVisualLoader.active = false
-            _itemVisualShowing = false
-        }
+        _hideItemVisuals()
     }
 
     function showItemVisuals() {
-        if (!_itemVisualShowing) {
-            itemVisualLoader.active = true
-            _itemVisualShowing = true
-        }
+        _showItemVisuals()
     }
 
     function hideDragArea() {
@@ -61,6 +52,20 @@ Item {
             showDragArea()
         } else {
             hideDragArea()
+        }
+    }
+
+    function _hideItemVisuals() {
+        if (_itemVisualShowing) {
+            itemVisualLoader.active = false
+            _itemVisualShowing = false
+        }
+    }
+
+    function _showItemVisuals() {
+        if (!_itemVisualShowing) {
+            itemVisualLoader.active = true
+            _itemVisualShowing = true
         }
     }
 

--- a/src/PlanView/SimpleItemEditor.qml
+++ b/src/PlanView/SimpleItemEditor.qml
@@ -93,6 +93,10 @@ Rectangle {
                 Layout.fillWidth: true
                 visible: _multipleTabsVisible()
 
+                property bool showBasicItems:    tabBar.visible ? tabBar.currentIndex === 0 : _basicItemsAvailable
+                property bool showCameraItems:   tabBar.visible ? tabBar.currentIndex === 1 : _cameraAvailable
+                property bool showAdvancedItems: tabBar.visible ? tabBar.currentIndex === 2 : _advancedItemsAvailable
+
                 property bool _basicItemsAvailable: _specifiesAltitude || missionItem.speedSection.available || missionItem.comboboxFacts.count > 0 || missionItem.textFieldFacts.count > 0 || missionItem.nanFacts.count > 0
                 property bool _advancedItemsAvailable: missionItem.comboboxFactsAdvanced.count > 0 || missionItem.textFieldFactsAdvanced.count > 0 || missionItem.nanFactsAdvanced.count > 0
                 property bool _cameraAvailable: missionItem.cameraSection.available
@@ -139,7 +143,7 @@ Rectangle {
             ColumnLayout {
                 Layout.fillWidth: true
                 spacing: _fieldSpacing
-                visible: tabBar.currentIndex === 0
+                visible: tabBar.showBasicItems
 
                 ColumnLayout {
                     Layout.fillWidth: true
@@ -215,6 +219,7 @@ Rectangle {
                         label: object.name
                         fact: object
                         enabled: !object.readOnly
+                        warnOnUserMinMaxInvalid: false
                     }
                 }
 
@@ -227,6 +232,7 @@ Rectangle {
                         fact: object
                         showEnableCheckbox: true
                         enableCheckBoxChecked: !isNaN(object.rawValue)
+                        warnOnUserMinMaxInvalid: false
 
                         onEnableCheckboxClicked: object.rawValue = enableCheckBoxChecked ? 0 : NaN
                     }
@@ -248,7 +254,7 @@ Rectangle {
                 Layout.fillWidth: true
                 showSectionHeader: false
                 missionItem: root.missionItem
-                visible: tabBar.currentIndex === 1
+                visible: tabBar.showCameraItems
 
                 Component.onCompleted: checked = missionItem.cameraSection.settingsSpecified
             }
@@ -256,7 +262,7 @@ Rectangle {
             ColumnLayout {
                 Layout.fillWidth: true
                 spacing: _fieldSpacing
-                visible: tabBar.currentIndex === 2
+                visible: tabBar.showAdvancedItems
 
                 ColumnLayout {
                     Layout.fillWidth: true
@@ -293,6 +299,7 @@ Rectangle {
                         label: object.name
                         fact: object
                         enabled: !object.readOnly
+                        warnOnUserMinMaxInvalid: false
                     }
                 }
 
@@ -305,6 +312,7 @@ Rectangle {
                         fact: object
                         showEnableCheckbox: true
                         enableCheckBoxChecked: !isNaN(object.rawValue)
+                        warnOnUserMinMaxInvalid: false
 
                         onEnableCheckboxClicked: object.rawValue = enableCheckBoxChecked ? 0 : NaN
                     }

--- a/src/PlanView/SimpleItemMapVisual.qml
+++ b/src/PlanView/SimpleItemMapVisual.qml
@@ -15,17 +15,15 @@ MissionItemMapVisualBase {
 
     function hideItemVisuals() {
         if (_itemVisualShowing) {
-            _itemVisualLoader.active = false
+            _hideItemVisuals()
             loiterVisualLoader.active = false
-            _itemVisualShowing = false
         }
     }
 
     function showItemVisuals() {
         if (!_itemVisualShowing) {
-            _itemVisualLoader.active = true
+            _showItemVisuals()
             loiterVisualLoader.active = true
-            _itemVisualShowing = true
         }
     }
 


### PR DESCRIPTION
Fixes #14296
Fixes #14286

## Problem

Two related regressions in the Plan View mission item editor:

### 1. Qt 6.10 QML scoping error (`ReferenceError: itemVisualLoader is not defined`)

Qt 6.10 tightened QML id scoping — ids defined in a parent component file are no longer accessible from child component files. `SimpleItemMapVisual.qml` referenced `itemVisualLoader` (an id in `MissionItemMapVisualBase.qml`), causing a `ReferenceError` that prevented map indicators from rendering for affected item types.

### 2. Mission item editor showing empty box for single-category items

The `SimpleItemEditor` tab visibility logic used `tabBar.currentIndex` comparisons (`visible: tabBar.currentIndex === 0`) to show/hide each section. When only one category of fields exists, the tab bar is hidden (`visible: false`). The section visibility then depended on `Component.onCompleted` setting the correct `currentIndex` before bindings evaluated — a timing-sensitive dependency that failed for items with only advanced facts (e.g. Loiter to Altitude) or only basic facts (e.g. Jump To), resulting in an empty editor panel.

## Fix

**`MissionItemMapVisualBase.qml`**: Introduces private `_hideItemVisuals()`/`_showItemVisuals()` functions that encapsulate `itemVisualLoader` access within the same file. Functions defined on the root item remain accessible from child components in Qt 6.10. The public `hideItemVisuals()`/`showItemVisuals()` methods delegate to them.

**`SimpleItemMapVisual.qml`**: Overrides the public functions to call the private base functions (avoiding the id scoping issue) then manages `loiterVisualLoader` directly.

**`SimpleItemEditor.qml`**: Replaces `currentIndex` comparisons with ternary properties on `tabBar`:
- When `tabBar.visible` (multiple categories present): only the selected tab's section is shown
- When `tabBar.hidden` (single category): that category's section is shown unconditionally, with no dependency on `currentIndex` timing

Also adds `warnOnUserMinMaxInvalid` property to `FactTextFieldSlider` to suppress spurious `userMin/userMax` warnings for mission command facts that intentionally omit slider range metadata, and adds `userMin`/`userMax` to the Fixed Wing Takeoff Pitch parameter.
