### PR TITLE
fix: APM duplicate trigger points bug fix

### DIFF
--- a/src/Vehicle/Vehicle.cc
+++ b/src/Vehicle/Vehicle.cc
@@ -767,7 +767,9 @@ void Vehicle::_handleCameraFeedback(const mavlink_message_t& message)
 {
     // If CAMERA_IMAGE_CAPTURED is supported, then CAMERA_FEEDBACK is redundant and should be ignored
     // to avoid duplicate points.
-    if(_cameraImageCapturedMessageAvailable) return;
+    if (_cameraImageCapturedMessageAvailable) {
+        return;
+    }
 
     mavlink_camera_feedback_t feedback;
 
@@ -821,10 +823,12 @@ void Vehicle::_handleCameraImageCaptured(const mavlink_message_t& message)
 
     mavlink_msg_camera_image_captured_decode(&message, &feedback);
 
-    if(!_cameraImageCapturedMessageAvailable) {
+    if (!_cameraImageCapturedMessageAvailable) {
         _cameraImageCapturedMessageAvailable = true;
         // Avoid initial duplicatation in case where first photo has CAMERA_FEEDBACK processed first.
-        if(_cameraTriggerPoints->count() > 0) return;
+        if (_cameraTriggerPoints->count() > 0) {
+            return;
+        }
     }
 
     QGeoCoordinate imageCoordinate((double)feedback.lat / qPow(10.0, 7.0), (double)feedback.lon / qPow(10.0, 7.0), feedback.alt);

--- a/src/Vehicle/Vehicle.cc
+++ b/src/Vehicle/Vehicle.cc
@@ -765,6 +765,10 @@ void Vehicle::_mavlinkMessageReceived(LinkInterface* link, mavlink_message_t mes
 #if !defined(QGC_NO_ARDUPILOT_DIALECT)
 void Vehicle::_handleCameraFeedback(const mavlink_message_t& message)
 {
+    // If CAMERA_IMAGE_CAPTURED is supported, then CAMERA_FEEDBACK is redundant and should be ignored
+    // to avoid duplicate points.
+    if(_cameraImageCapturedMessageAvailable) return;
+
     mavlink_camera_feedback_t feedback;
 
     mavlink_msg_camera_feedback_decode(&message, &feedback);
@@ -816,6 +820,8 @@ void Vehicle::_handleCameraImageCaptured(const mavlink_message_t& message)
     mavlink_camera_image_captured_t feedback;
 
     mavlink_msg_camera_image_captured_decode(&message, &feedback);
+
+    _cameraImageCapturedMessageAvailable = true;
 
     QGeoCoordinate imageCoordinate((double)feedback.lat / qPow(10.0, 7.0), (double)feedback.lon / qPow(10.0, 7.0), feedback.alt);
     qCDebug(VehicleLog) << "_handleCameraFeedback coord:index" << imageCoordinate << feedback.image_index << feedback.capture_result;
@@ -1609,6 +1615,7 @@ void Vehicle::_rallyPointManagerError(int errorCode, const QString& errorMsg)
 
 void Vehicle::_clearCameraTriggerPoints()
 {
+    _cameraImageCapturedMessageAvailable = false;
     _cameraTriggerPoints->clearAndDeleteContents();
 }
 

--- a/src/Vehicle/Vehicle.cc
+++ b/src/Vehicle/Vehicle.cc
@@ -821,7 +821,11 @@ void Vehicle::_handleCameraImageCaptured(const mavlink_message_t& message)
 
     mavlink_msg_camera_image_captured_decode(&message, &feedback);
 
-    _cameraImageCapturedMessageAvailable = true;
+    if(!_cameraImageCapturedMessageAvailable) {
+        _cameraImageCapturedMessageAvailable = true;
+        // Avoid initial duplicatation in case where first photo has CAMERA_FEEDBACK processed first.
+        if(_cameraTriggerPoints->count() > 0) return;
+    }
 
     QGeoCoordinate imageCoordinate((double)feedback.lat / qPow(10.0, 7.0), (double)feedback.lon / qPow(10.0, 7.0), feedback.alt);
     qCDebug(VehicleLog) << "_handleCameraFeedback coord:index" << imageCoordinate << feedback.image_index << feedback.capture_result;

--- a/src/Vehicle/Vehicle.h
+++ b/src/Vehicle/Vehicle.h
@@ -935,6 +935,7 @@ private:
     bool            _gpsRawIntMessageAvailable              = false;
     bool            _gps2RawMessageAvailable                = false;
     bool            _globalPositionIntMessageAvailable      = false;
+    bool            _cameraImageCapturedMessageAvailable    = false;
     double          _defaultCruiseSpeed = qQNaN();
     double          _defaultHoverSpeed = qQNaN();
     bool            _capabilityBitsKnown                    = false;
@@ -1303,7 +1304,7 @@ private:
 
 public:
     HealthAndArmingCheckReport* healthAndArmingCheckReport();
-    
+
     void setEventsMetadata(uint8_t compid, const QString& metadataJsonFileName);
 
 private:


### PR DESCRIPTION
Fixed bug where QGroundControl counts trigger points from both CAMERA_FEEDBACK and CAMERA_IMAGE_CAPTURED at the same time. Now, if a MAVLink Camera is detected, we ignore CAMERA_FEEDBACK messages, as CAMERA_IMAGE_CAPTURED from the MAVLink camera server should be the authoritative source of camera feedback.

## Description
On ArduPilot, when running a mission with a MAVLink camera server running, the autopilot will send CAMERA_FEEDBACK on photo taken and the MAVLink camera server will send CAMERA_IMAGE_CAPTURED. QGroundControl indiscriminately counts both as photo points. So, duplication happens.

## Type of Change
<!-- Put an 'x' in the relevant boxes -->
- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] CI/Build changes
- [ ] Other

## Testing
<!-- Describe the tests you ran and how to reproduce them -->
- [x] Tested locally
- [ ] Added/updated unit tests
- [ ] Tested with simulator (SITL)
- [ ] Tested with hardware

### Platforms Tested
<!-- Check all that apply -->
- [x] Linux
- [ ] Windows
- [ ] macOS
- [ ] Android
- [ ] iOS

### Flight Stacks Tested
<!-- If applicable -->
- [ ] PX4
- [x] ArduPilot

## Screenshots
<!-- If applicable, add screenshots to help explain your changes -->

## Checklist
<!-- Go over all the following points, and put an 'x' in all the boxes that apply -->
- [x] I have read the [Contribution Guidelines](CONTRIBUTING.md)
- [x] I have read the [Code of Conduct](CODE_OF_CONDUCT.md)
- [x] My code follows the project's coding standards
- [ ] I have added tests that prove my fix/feature works
- [ ] New and existing unit tests pass locally

## Related Issues
#14306

---
By submitting this pull request, I confirm that my contribution is made under the terms of the project's dual license (Apache 2.0 and GPL v3).
