### PR TITLE
ci: gate remaining cache saves on PRs

### DIFF
--- a/.github/actions/cache/action.yml
+++ b/.github/actions/cache/action.yml
@@ -57,10 +57,10 @@ runs:
           --target "${{ inputs.target }}" \
           --conf "${GITHUB_WORKSPACE}/tools/configs/ccache.conf"
 
-    - name: Cache ccache binary (Linux)
+    - name: Restore ccache binary (Linux)
       if: runner.os == 'Linux'
       id: ccache-binary
-      uses: actions/cache@v5
+      uses: actions/cache/restore@v5
       with:
         path: /usr/local/bin/ccache
         key: ccache-binary-${{ steps.ccache-config.outputs.version }}-linux-${{ steps.ccache-config.outputs.arch }}
@@ -72,6 +72,13 @@ runs:
         python3 "${GITHUB_WORKSPACE}/.github/scripts/ccache_helper.py" install \
           --version "${{ steps.ccache-config.outputs.version }}" \
           --arch "${{ steps.ccache-config.outputs.arch }}"
+
+    - name: Save ccache binary (Linux)
+      if: runner.os == 'Linux' && steps.cache-policy.outputs.save == 'true' && steps.ccache-binary.outputs.cache-hit != 'true'
+      uses: actions/cache/save@v5
+      with:
+        path: /usr/local/bin/ccache
+        key: ${{ steps.ccache-binary.outputs.cache-primary-key }}
 
     - name: Install ccache (macOS)
       if: runner.os == 'macOS'
@@ -88,10 +95,10 @@ runs:
       shell: bash
       run: python3 "${GITHUB_WORKSPACE}/.github/scripts/ccache_helper.py" windows-config --host "${{ inputs.host }}" --target "${{ inputs.target }}"
 
-    - name: Cache ccache binary (Windows)
+    - name: Restore ccache binary (Windows)
       if: runner.os == 'Windows'
       id: ccache-binary-win
-      uses: actions/cache@v5
+      uses: actions/cache/restore@v5
       with:
         path: ${{ runner.temp }}/ccache-${{ steps.ccache-config.outputs.version }}-windows-${{ steps.win-ccache.outputs.arch }}/ccache.exe
         key: ccache-binary-${{ steps.ccache-config.outputs.version }}-windows-${{ steps.win-ccache.outputs.arch }}
@@ -109,6 +116,13 @@ runs:
           --arch "${CCACHE_ARCH}" \
           --sha256 "${CCACHE_WIN_SHA256}" \
           --runner-temp "${RUNNER_TEMP//\\//}"
+
+    - name: Save ccache binary (Windows)
+      if: runner.os == 'Windows' && steps.cache-policy.outputs.save == 'true' && steps.ccache-binary-win.outputs.cache-hit != 'true'
+      uses: actions/cache/save@v5
+      with:
+        path: ${{ runner.temp }}/ccache-${{ steps.ccache-config.outputs.version }}-windows-${{ steps.win-ccache.outputs.arch }}/ccache.exe
+        key: ${{ steps.ccache-binary-win.outputs.cache-primary-key }}
 
     - name: Add ccache to PATH (Windows)
       if: runner.os == 'Windows'

--- a/.github/actions/install-dependencies/action.yml
+++ b/.github/actions/install-dependencies/action.yml
@@ -72,12 +72,23 @@ runs:
       shell: bash
       run: python3 "${GITHUB_WORKSPACE}/.github/scripts/install_dependencies_helper.py" enable-universe
 
-    - name: Cache and install apt packages (Linux)
-      if: runner.os == 'Linux'
+    # cache-apt-pkgs-action has no save toggle; skip it on PRs to avoid cache churn.
+    - name: Cache and install apt packages (Linux, non-PR)
+      if: runner.os == 'Linux' && github.event_name != 'pull_request' && github.event_name != 'pull_request_target'
       uses: awalsh128/cache-apt-pkgs-action@v1.6.0
       with:
         packages: ${{ steps.linux-deps.outputs.packages }}
         version: linux-deps-v2-${{ hashFiles('tools/setup/install_dependencies.py', '.github/build-config.json', '.github/actions/install-dependencies/action.yml') }}
+
+    - name: Install apt packages (Linux, PR)
+      if: runner.os == 'Linux' && (github.event_name == 'pull_request' || github.event_name == 'pull_request_target')
+      shell: bash
+      env:
+        APT_PACKAGES: ${{ steps.linux-deps.outputs.packages }}
+      run: |
+        sudo apt-get -o Acquire::Retries=3 update -qq
+        # shellcheck disable=SC2086
+        sudo apt-get -o Acquire::Retries=3 install -y --no-install-recommends $APT_PACKAGES
 
     - name: Fix apt alternatives after cache restore (Linux)
       if: runner.os == 'Linux'


### PR DESCRIPTION
## Summary

Three cache calls bypassed cc328d27a's PR-save gate; this closes them:

- **ccache binary (Linux/Windows)** in `actions/cache`: was bidirectional `actions/cache@v5` with no policy gate. Split into `restore` + `save`, gating save on `cache-policy.outputs.save`.
- **`awalsh128/cache-apt-pkgs-action`** in `install-dependencies`: action has no save toggle. Skip on `pull_request` / `pull_request_target` and fall back to plain `apt-get install` on PRs.

## Audit

Other cache writers checked: Qt SDK, GStreamer Win/macOS, AVD, pre-commit, lychee, pipx, gradle (qt-android), CPM, build-results baselines, custom-build ccache — all already gated. The `cache-apt-pkgs-action` callers in `gstreamer/action.yml`, `analysis.yml`, `doxygen_deploy.yml` are reachable only via `workflow_dispatch`/`schedule`, not PR. Small `setup-node`/`setup-uv` caches save on PRs but are tiny and lockfile-pinned — left alone.