### PR TITLE
Vehicle: show critical error messages from all vehicles, prefix with vehicle ID in multi-vehicle

### DIFF
--- a/src/Vehicle/Vehicle.cc
+++ b/src/Vehicle/Vehicle.cc
@@ -3375,9 +3375,12 @@ void Vehicle::_textMessageReceived(MAV_COMPONENT componentid, MAV_SEVERITY sever
 
 void Vehicle::_errorMessageReceived(QString message)
 {
-    if (_isActiveVehicle) {
-        QGC::showCriticalVehicleMessage(message);
+    QString vehicleIdPrefix;
+
+    if (MultiVehicleManager::instance()->vehicles()->count() > 1) {
+        vehicleIdPrefix = tr("Vehicle %1: ").arg(id());
     }
+    QGC::showCriticalVehicleMessage(vehicleIdPrefix + message);
 }
 
 /*---------------------------------------------------------------------------*/


### PR DESCRIPTION
Fixes #14312

`_errorMessageReceived` previously only showed critical vehicle messages when `_isActiveVehicle` was true, silently discarding errors from all non-active vehicles in a multi-vehicle session.

This fix:
- Removes the `_isActiveVehicle` guard so errors from all vehicles are surfaced.
- Adds a `"Vehicle N: "` prefix when more than one vehicle is connected, consistent with the existing `_vehicleIdSpeech()` pattern used elsewhere in this file.