### PR TITLE
Joystick: fix calibration polling interaction and axis settings persistence

### DIFF
--- a/src/Joystick/Joystick.cc
+++ b/src/Joystick/Joystick.cc
@@ -43,7 +43,7 @@ AssignedButtonAction::AssignedButtonAction(const QString &actionName_, bool repe
     : actionName(actionName_)
     , repeat(repeat_)
 {
-    qCDebug(JoystickLog) << this;
+    qCDebug(JoystickVerboseLog) << this;
 }
 
 AvailableButtonAction::AvailableButtonAction(const QString &actionName_, bool canRepeat_, QObject *parent)
@@ -51,7 +51,7 @@ AvailableButtonAction::AvailableButtonAction(const QString &actionName_, bool ca
     , _actionName(actionName_)
     , _repeat(canRepeat_)
 {
-    qCDebug(JoystickLog) << this;
+    qCDebug(JoystickVerboseLog) << this;
 }
 
 /*===========================================================================*/
@@ -307,6 +307,11 @@ void Joystick::_loadAxisSettings(bool joystickCalibrated, int transmitterMode)
             axisSettings.endGroup();
             continue;
         }
+        if (axisFunction == maxAxisFunction) {
+            // Older code would save unassigned axes with maxAxisFunction, we now skip loading those since that is not a valid function assignment
+            axisSettings.endGroup();
+            continue;
+        }
         _setJoystickAxisForAxisFunction(static_cast<AxisFunction_t>(axisFunction), axis);
 
         axisCalibration.center = axisSettings.value(centerKey, axisCalibration.center).toInt();
@@ -473,6 +478,11 @@ void Joystick::_saveAxisSettings(int transmitterMode)
     const QString reversedKey = QString::fromLatin1(kAxisReversedKey);
 
     for (int axis = 0; axis < _axisCount; axis++) {
+        AxisFunction_t function = _getAxisFunctionForJoystickAxis(axis);
+        if (function == maxAxisFunction) {
+            // No function assigned to axis, nothing to save
+            continue;
+        }
         AxisCalibration_t *const calibration = &_rgCalibration[axis];
         axisSettings.beginGroup(QString::number(axis));
 
@@ -481,7 +491,6 @@ void Joystick::_saveAxisSettings(int transmitterMode)
         axisSettings.setValue(maxKey, calibration->max);
         axisSettings.setValue(deadbandKey, calibration->deadband);
         axisSettings.setValue(reversedKey, calibration->reversed);
-        AxisFunction_t function = _getAxisFunctionForJoystickAxis(axis);
         axisSettings.setValue(functionKey, static_cast<int>(function));
 
         qCDebug(JoystickLog)
@@ -1091,8 +1100,14 @@ void Joystick::_startPollingForVehicle(Vehicle &vehicle)
         return;
     }
 
-    _currentPollingType = PollingForVehicle;
     _pollingVehicle = &vehicle;
+    if (_currentPollingType == PollingForConfiguration) {
+        qCDebug(JoystickLog) << "Delayed start of polling for vehicle. Currently PollingForConfiguration. Vehicle id:"  << _pollingVehicle->id();
+        _previousPollingType = PollingForVehicle;
+    } else {
+        qCDebug(JoystickLog) << "Started joystick polling for vehicle. Vehicle id:"  << _pollingVehicle->id();
+        _currentPollingType = PollingForVehicle;
+    }
 
     _buildAvailableButtonsActionList(_pollingVehicle);
 
@@ -1116,9 +1131,9 @@ void Joystick::_startPollingForVehicle(Vehicle &vehicle)
         (void) connect(this, &Joystick::gimbalYawStop,      gimbal, &GimbalController::gimbalYawStop);
     }
 
-    qDebug(JoystickLog) << "Started joystick polling for vehicle" << _pollingVehicle->id();
-
-    start();
+    if (!isRunning()) {
+        start();
+    }
 }
 
 void Joystick::_startPollingForConfiguration()
@@ -1163,7 +1178,7 @@ void Joystick::_stopPollingForConfiguration()
     }
 }
 
-void Joystick::_stopAllPolling()
+void Joystick::_stopAllPollingForVehicle()
 {
     if (_pollingVehicle) {
         (void) disconnect(this, nullptr, _pollingVehicle, nullptr);
@@ -1174,13 +1189,15 @@ void Joystick::_stopAllPolling()
         _pollingVehicle = nullptr;
     }
 
-    qCDebug(JoystickLog) << "Stopped all joystick polling";
-
-    _currentPollingType = NotPolling;
     _previousPollingType = NotPolling;
-
-    if (isRunning()) {
-        _exitThread = true;
+    if (_currentPollingType == PollingForConfiguration) {
+        qCDebug(JoystickLog) << "Currently PollingForConfiguration. Delayed stop of polling for vehicle until after configuration polling stopped.";
+    } else {
+        qCDebug(JoystickLog) << "Stopped joystick polling for vehicle.";
+        _currentPollingType = NotPolling;
+        if (isRunning()) {
+            _exitThread = true;
+        }
     }
 }
 

--- a/src/Joystick/Joystick.h
+++ b/src/Joystick/Joystick.h
@@ -402,7 +402,7 @@ private:
     void _startPollingForActiveVehicle();
     void _startPollingForConfiguration();
     void _stopPollingForConfiguration();
-    void _stopAllPolling();
+    void _stopAllPollingForVehicle();
     QString _pollingTypeToString(PollingType pollingType) const;
     PollingType _currentPollingType = NotPolling;
     PollingType _previousPollingType = NotPolling;

--- a/src/Joystick/JoystickManager.cc
+++ b/src/Joystick/JoystickManager.cc
@@ -47,7 +47,7 @@ JoystickManager::JoystickManager(QObject *parent)
             if (_joystickEnabledForVehicle(activeVehicle)) {
                 _activeJoystick->_startPollingForActiveVehicle();
             } else {
-                _activeJoystick->_stopAllPolling();
+                _activeJoystick->_stopAllPollingForVehicle();
             }
         }
         emit activeJoystickEnabledForActiveVehicleChanged();
@@ -123,7 +123,7 @@ void JoystickManager::_checkForAddedOrRemovedJoysticks()
             auto key = it->first;
             auto joystick = it->second;
             qCInfo(JoystickManagerLog) << "Joystick disconnected, releasing:" << key;
-            joystick->_stopAllPolling();
+            joystick->_stopAllPollingForVehicle();
             joystick->stop();
             joystick->deleteLater();
         }
@@ -198,7 +198,7 @@ void JoystickManager::_setActiveJoystick(Joystick *newActiveJoystick)
 
     // Cleanup old active joystick
     if (_activeJoystick) {
-        _activeJoystick->_stopAllPolling();
+        _activeJoystick->_stopAllPollingForVehicle();
         _activeJoystick = nullptr;
         emit activeJoystickChanged(nullptr);
     }
@@ -241,7 +241,7 @@ void JoystickManager::_activeVehicleChanged(Vehicle *activeVehicle)
         return;
     }
 
-    _activeJoystick->_stopAllPolling();
+    _activeJoystick->_stopAllPollingForVehicle();
 
     if (activeVehicle && _joystickEnabledForVehicle(activeVehicle)) {
         if (!_activeJoystick->settings()->calibrated()->rawValue().toBool()) {


### PR DESCRIPTION
Fixes #14090

## Summary

- **Deferred vehicle polling during calibration**: `_startPollingForVehicle()` now detects when configuration polling is active and stores the pending `PollingForVehicle` state in `_previousPollingType` instead of immediately switching. This prevents joystick control input from being sent while the user is in the calibration UI.

- **`_stopAllPolling()` → `_stopAllPollingForVehicle()`**: Renamed to reflect the narrowed scope. When called while `PollingForConfiguration` is active, it clears the pending vehicle state but leaves the thread running for the calibration session.

- **Fix empty axis entries in QSettings**: `_saveAxisSettings()` now guards against axes with no assigned function *before* calling `beginGroup()`, preventing empty groups from being written. These empty entries caused spurious unassigned-axis warnings on the next load.

- **`_loadAxisSettings()` `maxAxisFunction` compat check**: Moved the existing backward-compat skip to before the `_setJoystickAxisForAxisFunction()` call.

- **Reduce log noise**: Construction logs for `AssignedButtonAction` / `AvailableButtonAction` moved to `JoystickVerboseLog`.