### PR TITLE
Joystick: replace polling type state machine with PollingFlags bitmask

### DIFF
--- a/src/Joystick/Joystick.cc
+++ b/src/Joystick/Joystick.cc
@@ -160,7 +160,7 @@ Joystick::Joystick(const QString &name, int axisCount, int buttonCount, int hatC
 
 Joystick::~Joystick()
 {
-    _exitThread = true;
+    _exitPollingThread = true;
     if (isRunning()) {
         if (QThread::currentThread() == this) {
             qCWarning(JoystickLog) << "Skipping wait() on joystick thread";
@@ -663,7 +663,7 @@ void Joystick::run()
             }
         }
 
-        while (!_exitThread) {
+        while (!_exitPollingThread) {
             if (!_update()) {
                 qCWarning(JoystickLog) << "Joystick disconnected or update failed:" << _name;
                 updateFailed = true;
@@ -686,7 +686,7 @@ void Joystick::run()
         _close();
     }
 
-    if ((openFailed || updateFailed) && !_exitThread) {
+    if ((openFailed || updateFailed) && !_exitPollingThread) {
         qCDebug(JoystickLog) << "Triggering joystick rescan after failure";
         QMetaObject::invokeMethod(JoystickManager::instance(), "_checkForAddedOrRemovedJoysticks", Qt::QueuedConnection);
     }
@@ -741,14 +741,14 @@ void Joystick::_updateButtonEventStates(QVector<ButtonEvent_t> &buttonEventState
 
 void Joystick::_handleButtons()
 {
-    if (_currentPollingType == NotPolling) {
+    if (_pollingFlags == PollingNone) {
         qCWarning(JoystickLog) << "Internal Error: Joystick not polling!";
         return;
     }
 
     _updateButtonEventStates(_buttonEventStates);
 
-    if (_currentPollingType == PollingForConfiguration) {
+    if (_pollingFlags.testFlag(PollingForConfiguration)) {
         for (int buttonIndex = 0; buttonIndex < _totalButtonCount; buttonIndex++) {
             if (_buttonEventStates[buttonIndex] == ButtonEventDownTransition) {
                 qCDebug(JoystickLog) << "Button pressed - button" << buttonIndex;
@@ -758,7 +758,7 @@ void Joystick::_handleButtons()
                 emit rawButtonPressedChanged(buttonIndex, false);
             }
         }
-    } else if (_currentPollingType == PollingForVehicle) {
+    } else if (_pollingFlags.testFlag(PollingForVehicle)) {
         Vehicle *const vehicle = _pollingVehicle;
         if (!vehicle) {
             qCWarning(JoystickLog) << "Internal Error: No vehicle for joystick!";
@@ -902,12 +902,12 @@ void Joystick::_handleAxis()
 
     _axisElapsedTimer.start();
 
-    if (_currentPollingType == NotPolling) {
+    if (_pollingFlags == PollingNone) {
         qCWarning(JoystickLog) << "Internal Error: Joystick not polling!";
         return;
     }
 
-    if (_currentPollingType == PollingForConfiguration) {
+    if (_pollingFlags.testFlag(PollingForConfiguration)) {
         // Signal the axis values to Joystick Config/Cal. Axes in Joystick terminology are the same as Channels in
         // RemoteControlCalibrationController terminology.
         QVector<int> channelValues(_axisCount);
@@ -915,7 +915,7 @@ void Joystick::_handleAxis()
             channelValues[axisIndex] = _getAxisValue(axisIndex);
         }
         emit rawChannelValuesChanged(channelValues);
-    } else if (_currentPollingType == PollingForVehicle) {
+    } else if (_pollingFlags.testFlag(PollingForVehicle)) {
         Vehicle *const vehicle = _pollingVehicle;
         if (!vehicle) {
             qCWarning(JoystickLog) << "Internal Error: No vehicle for joystick!";
@@ -1108,27 +1108,14 @@ void Joystick::_startPollingForActiveVehicle()
 
 void Joystick::_startPollingForVehicle(Vehicle &vehicle)
 {
-    if (_currentPollingType == PollingForVehicle) {
+    qCDebug(JoystickLog) << "Starting joystick polling for vehicle. Vehicle id:" << vehicle.id() << "Current flags:" << _pollingFlagsToString(_pollingFlags);
+
+    if (_pollingFlags.testFlag(PollingForVehicle)) {
         qCWarning(JoystickLog) << "Internal Error: Joystick already polling for vehicle!";
-        return;
-    }
-    if (_previousPollingType != NotPolling) {
-        qCWarning(JoystickLog) << "Internal Error: Joystick previous polling type not None:" << _pollingTypeToString(_previousPollingType);
-        return;
-    }
-    if (_currentPollingType == NotPolling && isRunning()) {
-        qCWarning(JoystickLog) << "Internal Error: Joystick polling should not be running!";
         return;
     }
 
     _pollingVehicle = &vehicle;
-    if (_currentPollingType == PollingForConfiguration) {
-        qCDebug(JoystickLog) << "Delayed start of polling for vehicle. Currently PollingForConfiguration. Vehicle id:"  << _pollingVehicle->id();
-        _previousPollingType = PollingForVehicle;
-    } else {
-        qCDebug(JoystickLog) << "Started joystick polling for vehicle. Vehicle id:"  << _pollingVehicle->id();
-        _currentPollingType = PollingForVehicle;
-    }
 
     _buildAvailableButtonsActionList(_pollingVehicle);
 
@@ -1152,90 +1139,131 @@ void Joystick::_startPollingForVehicle(Vehicle &vehicle)
         (void) connect(this, &Joystick::gimbalYawStop,      gimbal, &GimbalController::gimbalYawStop);
     }
 
-    if (!isRunning()) {
-        start();
-    }
+    _pollingFlags |= PollingForVehicle;
+    _startPollingThread();
 }
 
 void Joystick::_startPollingForConfiguration()
 {
-    if (_currentPollingType == PollingForConfiguration) {
+    qCDebug(JoystickLog) << "Starting joystick polling for configuration. Current flags:" << _pollingFlagsToString(_pollingFlags);
+
+    if (_pollingFlags.testFlag(PollingForConfiguration)) {
         qCWarning(JoystickLog) << "Internal Error: Joystick already polling for configuration!";
         return;
     }
-    if (_previousPollingType != NotPolling) {
-        qCWarning(JoystickLog) << "Internal Error: Joystick previous polling type not None:" << _pollingTypeToString(_previousPollingType);
-        return;
-    }
 
-    qCDebug(JoystickLog) << "Started joystick polling for configuration. Saved previous polling type:" << _pollingTypeToString(_currentPollingType);
-
-    _previousPollingType = _currentPollingType;
-    _currentPollingType = PollingForConfiguration;
-
-    if (!isRunning()) {
-        start();
-    }
+    _pollingFlags |= PollingForConfiguration;
+    _startPollingThread();
 }
 
 void Joystick::_stopPollingForConfiguration()
 {
-    if (_currentPollingType != PollingForConfiguration) {
+    qCDebug(JoystickLog) << "Stopping joystick polling for configuration. Current flags:" << _pollingFlagsToString(_pollingFlags);
+
+    if (!_pollingFlags.testFlag(PollingForConfiguration)) {
         qCWarning(JoystickLog) << "Internal Error: Joystick not polling for configuration!";
         return;
     }
+
     if (!isRunning()) {
-        qCWarning(JoystickLog) << "Internal Error: Joystick polling not running!";
-        return;
+        qCWarning(JoystickLog) << "Internal Error: Joystick polling thread not running!";
     }
 
-    qCDebug(JoystickLog) << "Stopped joystick polling for configuration. Restored previous polling type:" << _pollingTypeToString(_previousPollingType);
+    const PollingFlags remainingFlags = _pollingFlags & ~PollingFlags(PollingForConfiguration);
 
-    _currentPollingType = _previousPollingType;
-    _previousPollingType = NotPolling;
+    // Stop the thread BEFORE updating _pollingFlags. If we cleared the flags first and the
+    // thread was still running, _handleButtons()/_handleAxis() would see PollingNone and
+    // fire a spurious "Internal Error: Joystick not polling!" warning.
+    if (remainingFlags == PollingNone) {
+        _stopPollingThread();
+    }
 
-    if (_currentPollingType == NotPolling) {
-        _exitThread = true;
+    _pollingFlags = remainingFlags;
+    qCDebug(JoystickLog) << "Remaining flags:" << _pollingFlagsToString(_pollingFlags);
+
+    if (remainingFlags.testFlag(PollingForVehicle) && !isRunning()) {
+        qCWarning(JoystickLog) << "Internal Error: Joystick polling not running! Forcing start of polling thread. Continuing polling for vehicle.";
+        _startPollingThread();
     }
 }
 
 void Joystick::_stopAllPollingForVehicle()
 {
+    qCDebug(JoystickLog) << "Stopping all joystick polling for vehicle. Current flags:" << _pollingFlagsToString(_pollingFlags);
+
     if (_pollingVehicle) {
         (void) disconnect(this, nullptr, _pollingVehicle, nullptr);
         (void) disconnect(_pollingVehicle, &Vehicle::flightModesChanged, this, &Joystick::_flightModesChanged);
         if (GimbalController *const gimbal = _pollingVehicle->gimbalController()) {
             (void) disconnect(this, nullptr, gimbal, nullptr);
         }
-        _pollingVehicle = nullptr;
+        if (!isRunning()) {
+            qCWarning(JoystickLog) << "Joystick polling thread not running even though _pollingVehicle was set.";
+        }
     }
 
-    _previousPollingType = NotPolling;
-    if (_currentPollingType == PollingForConfiguration) {
-        qCDebug(JoystickLog) << "Currently PollingForConfiguration. Delayed stop of polling for vehicle until after configuration polling stopped.";
-    } else {
-        qCDebug(JoystickLog) << "Stopped joystick polling for vehicle.";
-        _currentPollingType = NotPolling;
-        if (isRunning()) {
-            _exitThread = true;
-        }
+    const PollingFlags remainingFlags = _pollingFlags & ~PollingFlags(PollingForVehicle);
+
+    // Stop the thread BEFORE updating _pollingFlags. If we cleared the flags first and the
+    // thread was still running, _handleButtons()/_handleAxis() would see PollingNone and
+    // fire a spurious "Internal Error: Joystick not polling!" warning.
+    if (remainingFlags == PollingNone) {
+        _stopPollingThread();
+    }
+
+    // Clear _pollingVehicle AFTER updating _pollingFlags so the polling thread never sees
+    // PollingForVehicle set with a null _pollingVehicle, which would fire spurious
+    // "Internal Error: No vehicle for joystick!" warnings.
+    _pollingVehicle = nullptr;
+    _pollingFlags = remainingFlags;
+    qCDebug(JoystickLog) << "Remaining flags:" << _pollingFlagsToString(_pollingFlags);
+
+    if (remainingFlags.testFlag(PollingForConfiguration) && !isRunning()) {
+        qCWarning(JoystickLog) << "Joystick polling thread not running but configuration polling flag set. Forcing start.";
+        _startPollingThread();
     }
 }
 
-QString Joystick::_pollingTypeToString(PollingType pollingType) const
+void Joystick::_startPollingThread()
 {
-    switch (pollingType) {
-    case NotPolling:
-        return QStringLiteral("NotPolling");
-    case PollingForConfiguration:
-        return QStringLiteral("PollingForConfiguration");
-    case PollingForVehicle:
-        return QStringLiteral("PollingForVehicle");
-    default:
-        break;
+    if (isRunning()) {
+        qCDebug(JoystickLog) << "Polling thread already running. Flags:" << _pollingFlagsToString(_pollingFlags);
+    } else {
+        qCDebug(JoystickLog) << "Starting polling thread. Flags:" << _pollingFlagsToString(_pollingFlags);
+        _exitPollingThread = false;
+        start();
     }
+}
 
-    return QStringLiteral("UnknownPollingType");
+void Joystick::_stopPollingThread()
+{
+    if (isRunning()) {
+        qCDebug(JoystickLog) << "Stopping polling thread. Flags:" << _pollingFlagsToString(_pollingFlags);
+        _exitPollingThread = true;
+        if (QThread::currentThread() == this) {
+            qCWarning(JoystickLog) << "Skipping wait() on joystick thread to avoid deadlock";
+        } else {
+            wait();
+        }
+        // _exitPollingThread is reset to false in _startPollingThread() before the next start()
+    } else {
+        qCDebug(JoystickLog) << "Polling thread already stopped. Flags:" << _pollingFlagsToString(_pollingFlags);
+    }
+}
+
+QString Joystick::_pollingFlagsToString(PollingFlags flags) const
+{
+    if (flags == PollingNone) {
+        return QStringLiteral("None");
+    }
+    QStringList parts;
+    if (flags.testFlag(PollingForVehicle)) {
+        parts << QStringLiteral("PollingForVehicle");
+    }
+    if (flags.testFlag(PollingForConfiguration)) {
+        parts << QStringLiteral("PollingForConfiguration");
+    }
+    return parts.join(QStringLiteral("|"));
 }
 
 void Joystick::setAxisCalibration(int axis, const AxisCalibration_t &calibration)
@@ -1752,7 +1780,7 @@ Joystick::AxisFunction_t Joystick::_getAxisFunctionForJoystickAxis(int joystickA
 
 void Joystick::stop()
 {
-    _exitThread = true;
+    _exitPollingThread = true;
     if (isRunning()) {
         if (QThread::currentThread() == this) {
             qCWarning(JoystickLog) << "Skipping wait() on joystick thread";

--- a/src/Joystick/Joystick.h
+++ b/src/Joystick/Joystick.h
@@ -391,11 +391,12 @@ private slots:
     void _flightModesChanged() { _buildAvailableButtonsActionList(_pollingVehicle); }
 
 private:
-    enum PollingType {
-        NotPolling, ///< Not currrently polling
-        PollingForConfiguration, ///< Polling for configuration/calibration display
-        PollingForVehicle, ///< Normal polling for joystick output to Vehicle
+    enum PollingFlag {
+        PollingNone             = 0x0,
+        PollingForVehicle       = 0x1, ///< Normal polling for joystick output to Vehicle
+        PollingForConfiguration = 0x2, ///< Polling for configuration/calibration display
     };
+    using PollingFlags = QFlags<PollingFlag>;
 
     using AxisFunctionMap_t = QMap<AxisFunction_t, int>;
 
@@ -414,9 +415,10 @@ private:
     void _startPollingForConfiguration();
     void _stopPollingForConfiguration();
     void _stopAllPollingForVehicle();
-    QString _pollingTypeToString(PollingType pollingType) const;
-    PollingType _currentPollingType = NotPolling;
-    PollingType _previousPollingType = NotPolling;
+    void _startPollingThread();
+    void _stopPollingThread();
+    QString _pollingFlagsToString(PollingFlags flags) const;
+    PollingFlags _pollingFlags = PollingNone;
     Vehicle* _pollingVehicle = nullptr;
 
     void _resetFunctionToAxisMap();
@@ -470,7 +472,7 @@ private:
 
     QElapsedTimer _axisElapsedTimer;
     QStringList _availableActionTitles;
-    std::atomic<bool> _exitThread = false;    ///< true: signal thread to exit
+    std::atomic<bool> _exitPollingThread = false;    ///< true: signal thread to exit
 
     // HOTAS/Multi-device linking
     QString _linkedGroupId;


### PR DESCRIPTION
## Summary

Replaces the confusing `_currentPollingType`/`_previousPollingType` save/restore pattern in `Joystick` with a single `PollingFlags` bitmask. This makes it possible for vehicle polling and configuration polling to coexist explicitly, and eliminates the fragile "delayed start" logic where a vehicle poll request had to be deferred if configuration polling was active.

Also fixed a bug related to stopping polling and the starting polling. The second start after stop would fail because of a stale flag.

## Changes

- Add `PollingFlag` enum (`PollingNone=0x0`, `PollingForVehicle=0x1`, `PollingForConfiguration=0x2`) with `using PollingFlags = QFlags<PollingFlag>`
- Remove `_currentPollingType`, `_previousPollingType`, and `_pollingTypeToString()`
- Add `_pollingFlags` bitmask member; all four polling methods updated to use `|=` / `&= ~PollingFlags(...)` / `.testFlag()`
- Extract `_startPollingThread()` / `_stopPollingThread()` private helpers with consistent `qCDebug` logging
- `_startPollingThread()` cancels a pending stop if the thread is still running, fixing a subtle race where a rapid stop+start sequence could leave the thread permanently dead
- Rename `_exitThread` → `_exitPollingThread` for clarity
- Add `_pollingFlagsToString()` that handles all flag combinations including both flags set simultaneously
