### PR TITLE
PlanView: improve Expected Vehicle Speeds section in Defaults

### DIFF
--- a/src/PlanView/MissionDefaultsEditor.qml
+++ b/src/PlanView/MissionDefaultsEditor.qml
@@ -17,9 +17,11 @@ Rectangle {
     property var _visualItems: missionController.visualItems
     property bool _noMissionItemsAdded: _visualItems ? _visualItems.count <= 1 : true
     property var _settingsItem: _visualItems && _visualItems.count > 0 ? _visualItems.get(0) : null
+    property bool _flightSpeedSpecified: _settingsItem ? _settingsItem.speedSection.specifyFlightSpeed : false
     property bool _showCruiseSpeed: _controllerVehicle ? !_controllerVehicle.multiRotor : false
     property bool _showHoverSpeed: _controllerVehicle ? (_controllerVehicle.multiRotor || _controllerVehicle.vtol) : false
-    property real _fieldWidth: ScreenTools.defaultFontPixelWidth * 16
+    property bool _showAscentDescentSpeed: _controllerVehicle ? (_controllerVehicle.multiRotor || _controllerVehicle.vtol) : false
+    property bool _isVtol: _controllerVehicle ? _controllerVehicle.vtol : false
 
     width:  parent ? parent.width : 0
     height: mainColumn.height + ScreenTools.defaultFontPixelHeight
@@ -106,47 +108,50 @@ Rectangle {
         SectionHeader {
             id: vehicleSpeedsSectionHeader
             Layout.fillWidth: true
-            text: qsTr("Vehicle Speeds")
-            visible: _root._showCruiseSpeed || _root._showHoverSpeed
-            checked: false
+            text: qsTr("Expected Vehicle Speeds")
+            visible: _root._showCruiseSpeed || _root._showHoverSpeed || _root._showAscentDescentSpeed
         }
 
-        GridLayout {
+        ColumnLayout {
             Layout.fillWidth: true
-            columnSpacing: ScreenTools.defaultFontPixelWidth
-            rowSpacing: columnSpacing
-            columns: 2
+            spacing: ScreenTools.defaultFontPixelHeight * 0.5
             visible: vehicleSpeedsSectionHeader.visible && vehicleSpeedsSectionHeader.checked
 
             QGCLabel {
-                Layout.columnSpan: 2
-                Layout.alignment: Qt.AlignHCenter
                 Layout.fillWidth: true
                 wrapMode: Text.WordWrap
                 font.pointSize: ScreenTools.smallFontPointSize
                 text: qsTr("The following speed values are used to calculate total mission time. They do not affect the flight speed for the mission.")
             }
 
-            QGCLabel {
-                text: qsTr("Cruise speed")
-                visible: _root._showCruiseSpeed
+            FactTextFieldSlider {
                 Layout.fillWidth: true
-            }
-            FactTextField {
+                label: _root._isVtol ? qsTr("FW - Flight speed") : qsTr("Flight speed")
                 fact: QGroundControl.settingsManager.appSettings.offlineEditingCruiseSpeed
                 visible: _root._showCruiseSpeed
-                Layout.preferredWidth: _root._fieldWidth
+                enabled: !_root._flightSpeedSpecified
             }
 
-            QGCLabel {
-                text: qsTr("Hover speed")
-                visible: _root._showHoverSpeed
+            FactTextFieldSlider {
                 Layout.fillWidth: true
-            }
-            FactTextField {
+                label: _root._isVtol ? qsTr("MR - Flight speed") : qsTr("Flight speed")
                 fact: QGroundControl.settingsManager.appSettings.offlineEditingHoverSpeed
                 visible: _root._showHoverSpeed
-                Layout.preferredWidth: _root._fieldWidth
+                enabled: !_root._flightSpeedSpecified
+            }
+
+            FactTextFieldSlider {
+                Layout.fillWidth: true
+                label: _root._isVtol ? qsTr("MR - Ascent speed") : qsTr("Ascent speed")
+                fact: QGroundControl.settingsManager.appSettings.offlineEditingAscentSpeed
+                visible: _root._showAscentDescentSpeed
+            }
+
+            FactTextFieldSlider {
+                Layout.fillWidth: true
+                label: _root._isVtol ? qsTr("MR - Descent speed") : qsTr("Descent speed")
+                fact: QGroundControl.settingsManager.appSettings.offlineEditingDescentSpeed
+                visible: _root._showAscentDescentSpeed
             }
         }
     }

--- a/src/Settings/App.SettingsGroup.json
+++ b/src/Settings/App.SettingsGroup.json
@@ -50,7 +50,9 @@
             "default": 15.0,
             "min": 1.0,
             "units": "m/s",
-            "decimalPlaces": 2,
+            "decimalPlaces": 1,
+            "userMin": 1.0,
+            "userMax": 30,
             "label": "Offline editing cruise speed"
         },
         {
@@ -61,7 +63,9 @@
             "default": 5.0,
             "min": 1.0,
             "units": "m/s",
-            "decimalPlaces": 2,
+            "decimalPlaces": 1,
+            "userMin": 1.0,
+            "userMax": 30,
             "label": "Offline editing hover speed"
         },
         {
@@ -72,7 +76,9 @@
             "default": 3.0,
             "min": 0.1,
             "units": "m/s",
-            "decimalPlaces": 2,
+            "decimalPlaces": 1,
+            "userMin": 0.1,
+            "userMax": 30,
             "label": "Offline editing ascent speed"
         },
         {
@@ -83,7 +89,9 @@
             "default": 1.0,
             "min": 0.1,
             "units": "m/s",
-            "decimalPlaces": 2,
+            "decimalPlaces": 1,
+            "userMin": 0.1,
+            "userMax": 30,
             "label": "Offline editing descent speed"
         },
         {


### PR DESCRIPTION
## Summary

Improves the **Expected Vehicle Speeds** section in the Plan view Defaults panel.

### Changes

**`MissionDefaultsEditor.qml`**
- Added ascent and descent speed fields (previously hidden — only cruise/hover were shown)
- Disable cruise/hover speed fields when the **Flight Speed** checkbox is enabled, since the override takes precedence for mission time calculation
- Replaced `GridLayout` + `FactTextField` rows with `ColumnLayout` + `FactTextFieldSlider` for a consistent slider UX matching the rest of the Defaults panel
- Added VTOL-aware labels (`FW -` / `MR -` prefixes) for cruise and hover speeds
- Renamed section header from "Vehicle Speeds" → "Expected Vehicle Speeds"
- Renamed "Cruise speed" / "Hover speed" labels to "Flight speed" (with wing-type prefixes for VTOL)

**`App.SettingsGroup.json`**
- Changed all four offline editing speed facts from `decimalPlaces: 2` to `decimalPlaces: 1`, matching `SpeedSection.FlightSpeed`
- Added `userMin` / `userMax` (matching each fact's `min` and 30 m/s) so `FactTextFieldSlider` has a valid slider range