### PR TITLE
AnalyzeView: fix use-after-free crash when removing MAVLink chart series

### DIFF
--- a/src/AnalyzeView/MAVLinkInspector/MAVLinkChart.qml
+++ b/src/AnalyzeView/MAVLinkInspector/MAVLinkChart.qml
@@ -38,7 +38,13 @@ GraphsView {
                     var s = chartView.seriesList[i]
                     chartView.removeSeries(s)
                     chartController.delSeries(field)
-                    s.destroy()
+                    // Do not call s.destroy() here. QGraphsView holds an internal
+                    // pointer to the series (via QPointer) that is only cleared
+                    // during the next updatePolish() pass. Destroying the series
+                    // before that pass — whether immediately or via Qt.callLater —
+                    // causes a SIGSEGV in QGraphsView::updatePolish(). The series
+                    // is parented to chartView so it is freed when the chart is
+                    // closed. GPU/graph resources are released by removeSeries().
                     break
                 }
             }


### PR DESCRIPTION
## Summary

Fixes a SIGSEGV crash that occurred when removing a series from the MAVLink Inspector chart view.

## Root Cause

`QGraphsView::updatePolish()` holds internal references to series objects after `removeSeries()` returns. The QML `delDimension()` function was calling `s.destroy()` immediately after `removeSeries()`, freeing the `LineSeries` while `QGraphsView` still held a dangling pointer to it. On the next render frame, `updatePolish()` called `QMetaObject::cast()` on the freed object → SIGSEGV.

## Fix

Remove the explicit `s.destroy()` call. The `LineSeries` is created via `createObject(chartView, ...)` so it is parented to the `GraphsView` and will be cleaned up by Qt parent-child ownership when the view is destroyed. Series count is bounded by `_seriesColors.length` (6 max), so there is no practical memory impact.