### PR TITLE
QGCCorePlugin: fix unused parameter warning when video streaming is disabled

### DIFF
--- a/src/API/QGCCorePlugin.cc
+++ b/src/API/QGCCorePlugin.cc
@@ -284,6 +284,7 @@ VideoReceiver *QGCCorePlugin::createVideoReceiver(QObject *parent)
 #elif defined(QGC_QT_STREAMING)
     return QtMultimediaReceiver::createVideoReceiver(parent);
 #else
+    Q_UNUSED(parent);
     return nullptr;
 #endif
 }


### PR DESCRIPTION
## Summary

Fixes a compiler warning (unused parameter `parent`) in `QGCCorePlugin::createVideoReceiver()` when both GStreamer and Qt video streaming backends are disabled.

## Fix

Add `Q_UNUSED(parent)` in the no-streaming fallback `#else` branch.