### PR TITLE
Extended camera settings readonly show in UI

### DIFF
--- a/src/FlightMap/Widgets/PhotoVideoControl.qml
+++ b/src/FlightMap/Widgets/PhotoVideoControl.qml
@@ -523,6 +523,7 @@ Rectangle {
                                 property bool _isCombo: !_isBool && _fact.enumStrings.length > 0
                                 property bool _isSlider: _fact && !isNaN(_fact.increment)
                                 property bool _isEdit: !_isBool && !_isSlider && _fact.enumStrings.length < 1
+                                property bool _isReadOnly: _fact && _fact.readOnly
 
                                 FactComboBox {
                                     Layout.fillWidth: true
@@ -530,11 +531,13 @@ Rectangle {
                                     fact: parent._fact
                                     indexModel: false
                                     visible: parent._isCombo
+                                    enabled: !parent._isReadOnly
                                 }
                                 FactTextField {
                                     Layout.fillWidth: true
                                     fact: parent._fact
                                     visible: parent._isEdit
+                                    enabled: !parent._isReadOnly
                                 }
                                 QGCSlider {
                                     Layout.fillWidth: true
@@ -542,6 +545,7 @@ Rectangle {
                                     from: parent._fact.min
                                     stepSize: parent._fact.increment
                                     visible: parent._isSlider
+                                    enabled: !parent._isReadOnly
                                     live: false
                                     property bool initialized: false
 
@@ -560,6 +564,7 @@ Rectangle {
                                 QGCCheckBoxSlider {
                                     checked: parent._fact ? parent._fact.value : false
                                     visible: parent._isBool
+                                    enabled: !parent._isReadOnly
                                     onClicked: parent._fact.value = checked ? 1 : 0
                                 }
                             }


### PR DESCRIPTION
## Description
The wiring already exists in VehicleCameraControl to process an extended camera setting being readOnly, but the UI doesn't reflect that. This change makes it so that in QML,  "enabled" is false for settings which are readonly.

Note that I don't think readonly is officially supported in camera definition files. At least, it isn't documented by MAVLink: https://mavlink.io/en/services/camera_def.html. However, I personally have run into situations where making an extended camera param readonly would be useful, and the implementation already exists on the C++ side.

## Type of Change
<!-- Put an 'x' in the relevant boxes -->
- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] CI/Build changes
- [ ] Other

## Testing
<!-- Describe the tests you ran and how to reproduce them -->
- [x] Tested locally
- [ ] Added/updated unit tests
- [ ] Tested with simulator (SITL)
- [ ] Tested with hardware

### Platforms Tested
<!-- Check all that apply -->
- [x] Linux
- [ ] Windows
- [ ] macOS
- [ ] Android
- [ ] iOS

### Flight Stacks Tested
<!-- If applicable -->
- [ ] PX4
- [ ] ArduPilot

## Screenshots
<!-- If applicable, add screenshots to help explain your changes -->

## Checklist
<!-- Go over all the following points, and put an 'x' in all the boxes that apply -->
- [x] I have read the [Contribution Guidelines](CONTRIBUTING.md)
- [x] I have read the [Code of Conduct](CODE_OF_CONDUCT.md)
- [x] My code follows the project's coding standards
- [ ] I have added tests that prove my fix/feature works
- [ ] New and existing unit tests pass locally

## Related Issues
<!-- Link any related issues using #issue_number -->

---
By submitting this pull request, I confirm that my contribution is made under the terms of the project's dual license (Apache 2.0 and GPL v3).
