### PR TITLE
Joystick: per-device Auto/Force Joystick/Force Gamepad type override

### DIFF
--- a/src/Joystick/JoystickManager.cc
+++ b/src/Joystick/JoystickManager.cc
@@ -15,6 +15,8 @@
 using JoystickBackend = JoystickSDL;
 
 #include <QtCore/QApplicationStatic>
+#include <QtCore/QJsonDocument>
+#include <QtCore/QJsonObject>
 #include <QtCore/QSettings>
 #include <QtGui/QVector3D>
 
@@ -364,6 +366,64 @@ QStringList JoystickManager::linkedGroupMembers(const QString &groupId) const
 Joystick *JoystickManager::joystickByName(const QString &name) const
 {
     return _name2JoystickMap.value(name, nullptr);
+}
+
+QString JoystickManager::joystickTypeOverride(const QString &name) const
+{
+    if (name.isEmpty()) {
+        return QStringLiteral("auto");
+    }
+    const QString raw = _joystickManagerSettings->joystickTypeOverrides()->rawValue().toString();
+    const QJsonDocument doc = QJsonDocument::fromJson(raw.toUtf8());
+    if (!doc.isObject()) {
+        return QStringLiteral("auto");
+    }
+    const QString mode = doc.object().value(name).toString();
+    if (mode == QLatin1String("joystick") || mode == QLatin1String("gamepad")) {
+        return mode;
+    }
+    return QStringLiteral("auto");
+}
+
+void JoystickManager::setJoystickTypeOverride(const QString &name, const QString &mode)
+{
+    if (name.isEmpty()) {
+        return;
+    }
+
+    QString normalized = mode;
+    if (normalized != QLatin1String("joystick") && normalized != QLatin1String("gamepad")) {
+        normalized = QStringLiteral("auto");
+    }
+    if (joystickTypeOverride(name) == normalized) {
+        return;
+    }
+
+    const QString raw = _joystickManagerSettings->joystickTypeOverrides()->rawValue().toString();
+    QJsonObject obj = QJsonDocument::fromJson(raw.toUtf8()).object();
+    if (normalized == QLatin1String("auto")) {
+        obj.remove(name);
+    } else {
+        obj.insert(name, normalized);
+    }
+    _joystickManagerSettings->joystickTypeOverrides()->setRawValue(QString::fromUtf8(QJsonDocument(obj).toJson(QJsonDocument::Compact)));
+
+    // Drop the cached + active instance so discovery rebuilds it on the requested branch.
+    if (_activeJoystick && _activeJoystick->name() == name) {
+        _setActiveJoystick(nullptr);
+    }
+    if (Joystick *existing = _name2JoystickMap.take(name)) {
+        existing->_stopAllPollingForVehicle();
+        existing->stop();
+        existing->deleteLater();
+    }
+    JoystickBackend::forgetCachedJoystick(name);
+
+    qCInfo(JoystickManagerLog) << "Joystick type override set" << name << "->" << normalized;
+
+    emit joystickTypeOverrideChanged(name);
+
+    _checkForAddedOrRemovedJoysticks();
 }
 
 void JoystickManager::_updatePollingTimer()

--- a/src/Joystick/JoystickManager.h
+++ b/src/Joystick/JoystickManager.h
@@ -50,10 +50,18 @@ public:
     /// Get joystick by name (returns nullptr if not found)
     Q_INVOKABLE Joystick *joystickByName(const QString &name) const;
 
+    /// Returns "auto", "joystick", or "gamepad" for the named device.
+    Q_INVOKABLE QString joystickTypeOverride(const QString &name) const;
+
+    /// Set per-device override; "auto" clears it. Triggers re-discovery so the
+    /// device is recreated with the new branch (gamepad vs raw joystick).
+    Q_INVOKABLE void setJoystickTypeOverride(const QString &name, const QString &mode);
+
 signals:
     void activeJoystickChanged(Joystick *joystick);
     void activeJoystickEnabledForActiveVehicleChanged();
     void availableJoystickNamesChanged();
+    void joystickTypeOverrideChanged(const QString &name);
 
 public slots:
     void init();

--- a/src/Joystick/JoystickSDL.cc
+++ b/src/Joystick/JoystickSDL.cc
@@ -175,6 +175,16 @@ void JoystickSDL::shutdown(bool deleteDiscoveryCache)
     s_discoveryCache.clear();
 }
 
+void JoystickSDL::forgetCachedJoystick(const QString &name)
+{
+    auto it = s_discoveryCache.find(name);
+    if (it == s_discoveryCache.end()) {
+        return;
+    }
+    // Caller already deleteLater()'d the live instance; the cache holds the same pointer.
+    s_discoveryCache.erase(it);
+}
+
 QMap<QString, Joystick*> JoystickSDL::discover()
 {
     Q_ASSERT(QThread::isMainThread());
@@ -252,38 +262,55 @@ QMap<QString, Joystick*> JoystickSDL::discover()
         QList<int> gamepadAxes;
         QSet<int> joyAxesMappedToGamepad;
 
-        if (SDL_IsGamepad(jid)) {
+        const QString typeOverride = JoystickManager::instance()->joystickTypeOverride(name);
+        bool tryAsGamepad;
+        if (typeOverride == QLatin1String("joystick")) {
+            tryAsGamepad = false;
+        } else if (typeOverride == QLatin1String("gamepad")) {
+            // SDL_OpenGamepad will fail if no mapping is registered for this GUID — we
+            // fall through to the joystick path below in that case.
+            tryAsGamepad = true;
+        } else {
+            tryAsGamepad = SDL_IsGamepad(jid);
+        }
+
+        if (tryAsGamepad) {
             auto tmpGamepad = SDL_OpenGamepad(jid);
             if (!tmpGamepad) {
-                qCWarning(JoystickSDLLog) << "Failed to open gamepad" << jid << SDL_GetError();
-                continue;
-            }
-
-            // Determine if this gamepad axis is one we should show to the user
-            for (int i = 0; i < SDL_GAMEPAD_AXIS_COUNT; i++) {
-                if (SDL_GamepadHasAxis(tmpGamepad, static_cast<SDL_GamepadAxis>(i))) {
-                    gamepadAxes.append(i);
+                if (typeOverride == QLatin1String("gamepad")) {
+                    qCWarning(JoystickSDLLog) << "Forced-gamepad open failed for" << name
+                                              << "- no SDL mapping; falling back to joystick:" << SDL_GetError();
+                } else {
+                    qCWarning(JoystickSDLLog) << "Failed to open gamepad" << jid << SDL_GetError();
+                    continue;
                 }
-            }
-
-            // If a sdlJoystick axis is mapped to a sdlGamepad axis, then the axis is represented
-            // by both the sdlJoystick interface and the sdlGamepad interface. If this is the case,
-            // We'll only show the sdlGamepad interface version of the axis to the user.
-            int bindingCount = 0;
-            SDL_GamepadBinding **bindings = SDL_GetGamepadBindings(tmpGamepad, &bindingCount);
-            if (bindings) {
-                for (int i = 0; i < bindingCount; ++i) {
-                    SDL_GamepadBinding *binding = bindings[i];
-                    if (binding && binding->input_type == SDL_GAMEPAD_BINDTYPE_AXIS && binding->output_type == SDL_GAMEPAD_BINDTYPE_AXIS) {
-                        joyAxesMappedToGamepad.insert(binding->input.axis.axis);
+            } else {
+                // Determine if this gamepad axis is one we should show to the user
+                for (int i = 0; i < SDL_GAMEPAD_AXIS_COUNT; i++) {
+                    if (SDL_GamepadHasAxis(tmpGamepad, static_cast<SDL_GamepadAxis>(i))) {
+                        gamepadAxes.append(i);
                     }
                 }
-                SDL_free(bindings);
-            } else {
-                qCWarning(JoystickSDLLog) << "Failed to get bindings for" << name << "error:" << SDL_GetError();
-            }
 
-            SDL_CloseGamepad(tmpGamepad);
+                // If a sdlJoystick axis is mapped to a sdlGamepad axis, then the axis is represented
+                // by both the sdlJoystick interface and the sdlGamepad interface. If this is the case,
+                // We'll only show the sdlGamepad interface version of the axis to the user.
+                int bindingCount = 0;
+                SDL_GamepadBinding **bindings = SDL_GetGamepadBindings(tmpGamepad, &bindingCount);
+                if (bindings) {
+                    for (int i = 0; i < bindingCount; ++i) {
+                        SDL_GamepadBinding *binding = bindings[i];
+                        if (binding && binding->input_type == SDL_GAMEPAD_BINDTYPE_AXIS && binding->output_type == SDL_GAMEPAD_BINDTYPE_AXIS) {
+                            joyAxesMappedToGamepad.insert(binding->input.axis.axis);
+                        }
+                    }
+                    SDL_free(bindings);
+                } else {
+                    qCWarning(JoystickSDLLog) << "Failed to get bindings for" << name << "error:" << SDL_GetError();
+                }
+
+                SDL_CloseGamepad(tmpGamepad);
+            }
         }
 
         SDL_Joystick *tmpJoy = SDL_OpenJoystick(jid);
@@ -739,7 +766,9 @@ QString JoystickSDL::powerState() const
 
 bool JoystickSDL::isGamepad() const
 {
-    return SDL_IsGamepad(_instanceId);
+    // Tracks the discovery-time decision (which honors the user override). Querying
+    // SDL here would ignore "force joystick" / "force gamepad" overrides.
+    return !_gamepadAxes.isEmpty();
 }
 
 QString JoystickSDL::gamepadType() const

--- a/src/Joystick/JoystickSDL.h
+++ b/src/Joystick/JoystickSDL.h
@@ -140,6 +140,9 @@ public:
     [[nodiscard]] static bool init();
     static void shutdown(bool deleteDiscoveryCache = true);
     static QMap<QString, Joystick*> discover();
+    /// Drop a single name from the discovery cache (caller must have already
+    /// stopped/deleted the live instance in `_name2JoystickMap`).
+    static void forgetCachedJoystick(const QString &name);
 
 private:
     [[nodiscard]] bool _open() final;

--- a/src/Settings/JoystickManager.SettingsGroup.json
+++ b/src/Settings/JoystickManager.SettingsGroup.json
@@ -15,6 +15,13 @@
             "type": "string",
             "default": "",
             "label": "Comma separated list of vehicle IDs with joystick enabled"
+        },
+        {
+            "name": "joystickTypeOverrides",
+            "shortDesc": "JSON map of joystick name to type override (\"joystick\" or \"gamepad\")",
+            "type": "string",
+            "default": "{}",
+            "label": "Per-device joystick type overrides"
         }
     ]
 }

--- a/src/Settings/JoystickManagerSettings.cc
+++ b/src/Settings/JoystickManagerSettings.cc
@@ -15,3 +15,4 @@ DECLARE_SETTINGGROUP(JoystickManager, "JoystickManager")
 
 DECLARE_SETTINGSFACT(JoystickManagerSettings, activeJoystickName)
 DECLARE_SETTINGSFACT(JoystickManagerSettings, joystickEnabledVehiclesIds)
+DECLARE_SETTINGSFACT(JoystickManagerSettings, joystickTypeOverrides)

--- a/src/Settings/JoystickManagerSettings.h
+++ b/src/Settings/JoystickManagerSettings.h
@@ -25,4 +25,5 @@ public:
 
     DEFINE_SETTINGFACT(activeJoystickName)
     DEFINE_SETTINGFACT(joystickEnabledVehiclesIds)
+    DEFINE_SETTINGFACT(joystickTypeOverrides)
 };

--- a/src/Vehicle/VehicleSetup/JoystickComponent.qml
+++ b/src/Vehicle/VehicleSetup/JoystickComponent.qml
@@ -72,6 +72,36 @@ SetupPage {
                     onClicked: joystickManager.activeJoystickEnabledForActiveVehicle = checked
                 }
 
+                QGCLabel { text: qsTr("Type:") }
+
+                QGCComboBox {
+                    id: typeOverrideCombo
+                    sizeToContents: true
+                    visible: activeJoystickName !== ""
+                    // Display labels (translated) backed by stable mode keys.
+                    readonly property var modeKeys: ["auto", "joystick", "gamepad"]
+                    model: [qsTr("Auto"), qsTr("Force Joystick"), qsTr("Force Gamepad")]
+
+                    function _sync() {
+                        const mode = joystickManager.joystickTypeOverride(activeJoystickName)
+                        const idx = modeKeys.indexOf(mode)
+                        currentIndex = idx >= 0 ? idx : 0
+                    }
+
+                    onActivated: (index) => {
+                        joystickManager.setJoystickTypeOverride(activeJoystickName, modeKeys[index])
+                    }
+
+                    Component.onCompleted: _sync()
+                    Connections { target: root; function onActiveJoystickNameChanged() { typeOverrideCombo._sync() } }
+                    Connections {
+                        target: joystickManager
+                        function onJoystickTypeOverrideChanged(name) {
+                            if (name === root.activeJoystickName) typeOverrideCombo._sync()
+                        }
+                    }
+                }
+
                 QGCLabel {
                     font.pointSize: ScreenTools.smallFontPointSize
                     text: qsTr("Not currently available")


### PR DESCRIPTION
## Summary

Adds a per-device joystick type override (Auto / Force Joystick / Force Gamepad) for cases where SDL's gamepad auto-detection misclassifies a device or applies a wrong mapping.

- New `joystickTypeOverrides` setting on `JoystickManager` (JSON map of device name → `joystick`/`gamepad`).
- `JoystickManager::{joystickTypeOverride,setJoystickTypeOverride}` Q_INVOKABLE pair + `joystickTypeOverrideChanged` signal. Setter evicts the live instance and the discovery cache so the device is recreated on the chosen branch.
- `JoystickSDL::discover()` consults the override before `SDL_IsGamepad(jid)`. "Force Gamepad" on a device with no SDL mapping logs a warning and falls back to joystick instead of skipping the device.
- `JoystickSDL::isGamepad()` now returns `!_gamepadAxes.isEmpty()` so `_open()` honors the discovery-time decision instead of re-querying SDL (which would clobber the override).
- New "Type" combo on `JoystickComponent.qml` next to the existing Enable checkbox; auto-syncs via `joystickTypeOverrideChanged`.

## Why

SDL's `SDL_IsGamepad` plus the gamepad-mapping database covers most controllers, but real-world cases still slip through:
- Generic HID adapters that the database doesn't recognize, where the user wants raw joystick axes.
- Devices that *are* in the database but whose mapping is wrong on a given platform (axis swapped, trigger reported as full-range, etc.) — the user wants to bypass the mapping and use raw axes.
- Devices that should be gamepads but aren't auto-detected; with a user-installed mapping (`addMapping()` already supported) Force Gamepad re-runs the gamepad code path.

## Caveats

- "Force Gamepad" only succeeds if SDL has a mapping for the device GUID (registered or via `SDL_HINT_GAMECONTROLLERCONFIG`). If `SDL_OpenGamepad` returns null, it falls back to raw joystick and logs a warning — the existing `addMapping()` path is the way to install one.
- The override is keyed by joystick **name**. Multiple identical devices get the `#2`/`#3` suffixes that `discover()` already assigns, and each suffix is overridden independently.

## Test plan

- [ ] Verify default behavior (Auto) is unchanged for a known gamepad (Xbox/PS controller).
- [ ] Verify "Force Joystick" on a known gamepad exposes raw axes/buttons and skips gamepad mapping translation.
- [ ] Verify "Force Gamepad" on a non-gamepad joystick logs the fallback warning and reverts to joystick mode.
- [ ] Verify the override survives a disconnect/reconnect of the same device (cache eviction + persistence).
- [ ] Verify multiple devices with identical names (`Foo`, `Foo #2`) can be overridden independently.
- [ ] Run existing joystick unit tests (`ctest -L Unit -R Joystick`).