### PR TITLE
feat(analyze): add log viewer (.bin/.tlog) and onboard log UX improvements for ardupilot

### DIFF
--- a/docs/en/qgc-user-guide/analyze_view/index.md
+++ b/docs/en/qgc-user-guide/analyze_view/index.md
@@ -6,6 +6,8 @@ The _Analyze View_ is accessed by selecting the _QGroundControl_ application men
 
 The view provides tools to:
 
+- [Log Viewer](../analyze_view/log_viewer.md) — Open and analyze `.bin` DataFlash logs and `.tlog` telemetry logs.
+- [Log Setup](../analyze_view/logging_setup.md) — Configure logging parameters and apply troubleshooting guidance.
 - [Download Logs](../analyze_view/log_download.md) — List, download and clear logs on the vehicle.
 - [GeoTag Images (PX4)](../analyze_view/geotag_images.md) — Geotag survey mission images using the flight log (on a computer).
 - [MAVLink Console (PX4)](../analyze_view/mavlink_console.md) — Access the the nsh shell running on the vehicle.

--- a/docs/en/qgc-user-guide/analyze_view/log_download.md
+++ b/docs/en/qgc-user-guide/analyze_view/log_download.md
@@ -3,4 +3,9 @@
 The _Log Download_ screen (**Analyze > Log Download**) is used to list (_Refresh_),
 _Download_ and _Erase All_ log files from the connected vehicle.
 
+The page also supports:
+
+- Selecting all received logs in one action (_Select All_ / _Deselect All_).
+- Sorting logs by timestamp (_Sort Ascending_ / _Sort Descending_).
+
 ![Analyze View Log Download](../../../assets/analyze/log_download.jpg)

--- a/docs/en/qgc-user-guide/analyze_view/log_viewer.md
+++ b/docs/en/qgc-user-guide/analyze_view/log_viewer.md
@@ -1,0 +1,20 @@
+# Log Viewer (Analyze View)
+
+The _Log Viewer_ screen (**Analyze > Log Viewer**) provides a unified workflow for post-flight analysis:
+
+- Open ArduPilot DataFlash logs (`.bin`/`.log`) for parameter and event inspection.
+- Open telemetry logs (`.tlog`) and replay them with timeline controls.
+- Reuse existing MAVLink inspection and charting tools while replaying telemetry.
+
+## Typical Workflow
+
+1. Download logs from **Analyze > Onboard Logs**.
+1. Open the downloaded `.bin` or `.tlog` file in **Analyze > Log Viewer**.
+1. For `.tlog`, use playback controls (play/pause, speed, seek) to inspect behavior over time.
+1. For `.bin`, review extracted parameters and events, then select signals for plotting.
+
+## Performance Notes
+
+- Very large logs can take noticeable time to parse.
+- Prefer loading logs from local SSD storage for faster indexing.
+- If onboard storage is slow and logs contain gaps, reduce logging rate using related parameters in **Analyze > Log Setup**.

--- a/docs/en/qgc-user-guide/analyze_view/logging_setup.md
+++ b/docs/en/qgc-user-guide/analyze_view/logging_setup.md
@@ -1,0 +1,29 @@
+# Log Setup (Analyze View)
+
+The _Log Setup_ screen (**Analyze > Log Setup**) helps you configure common ArduPilot logging parameters and provides practical troubleshooting guidance.
+
+## Common Parameters
+
+The page exposes key parameters when they are available on the connected vehicle/firmware, including:
+
+- `LOG_BACKEND_TYPE`
+- `LOG_BITMASK`
+- `LOG_DISARMED`
+- `LOG_FILE_DSRMROT`
+- `LOG_FILE_MB_FREE`
+- `LOG_FILE_RATEMAX`
+- `LOG_BLK_RATEMAX`
+- `LOG_MAV_RATEMAX`
+- `LOG_MAX_FILES`
+- `LOG_REPLAY`
+- `EK3_LOG_LEVEL`
+
+All parameter edits are applied through the standard QGroundControl parameter system (Facts).
+
+## Troubleshooting Checklist
+
+- Use a known-good SD card and verify it is writable.
+- Keep enough free space for expected log size.
+- If logs show missing samples, lower block/logging rate limits.
+- Enable disarmed/replay logging only when needed for debugging, because file size increases.
+- Download and clear logs regularly on low-capacity onboard flash.

--- a/src/API/QGCCorePlugin.cc
+++ b/src/API/QGCCorePlugin.cc
@@ -71,6 +71,15 @@ const QVariantList &QGCCorePlugin::analyzePages()
 {
     static const QVariantList analyzeList = {
         QVariant::fromValue(new QmlComponentInfo(
+            tr("Log Viewer"),
+            QUrl::fromUserInput(QStringLiteral("qrc:/qml/QGroundControl/AnalyzeView/LogViewer/LogViewerPage.qml")),
+            QUrl::fromUserInput(QStringLiteral("qrc:/qmlimages/MAVLinkInspector.svg")))),
+        QVariant::fromValue(new QmlComponentInfo(
+            tr("Log Setup"),
+            QUrl::fromUserInput(QStringLiteral("qrc:/qml/QGroundControl/AnalyzeView/LogViewer/LoggingSetupPage.qml")),
+            QUrl::fromUserInput(QStringLiteral("qrc:/qmlimages/OnboardLogIcon.svg")),
+            nullptr, true /* requiresVehicle */)),
+        QVariant::fromValue(new QmlComponentInfo(
             tr("Onboard Logs"),
             QUrl::fromUserInput(QStringLiteral("qrc:/qml/QGroundControl/AnalyzeView/OnboardLogs/OnboardLogPage.qml")),
             QUrl::fromUserInput(QStringLiteral("qrc:/qmlimages/OnboardLogIcon.svg")),

--- a/src/AnalyzeView/CMakeLists.txt
+++ b/src/AnalyzeView/CMakeLists.txt
@@ -4,6 +4,7 @@
 # ============================================================================
 
 add_subdirectory(GeoTag)
+add_subdirectory(LogViewer)
 add_subdirectory(MAVLinkConsole)
 add_subdirectory(MAVLinkInspector)
 add_subdirectory(OnboardLogs)
@@ -31,6 +32,8 @@ qt_add_qml_module(AnalyzeViewModule
         MAVLinkInspector/MAVLinkChart.qml
         MAVLinkInspector/MAVLinkMessageButton.qml
         MAVLinkInspector/MAVLinkInspectorPage.qml
+        LogViewer/LogViewerPage.qml
+        LogViewer/LoggingSetupPage.qml
         OnboardLogs/OnboardLogPage.qml
         OnboardLogsFtp/OnboardLogFtpPage.qml
         Vibration/VibrationPage.qml

--- a/src/AnalyzeView/GeoTag/DataFlashParser.cc
+++ b/src/AnalyzeView/GeoTag/DataFlashParser.cc
@@ -1,5 +1,5 @@
 #include "DataFlashParser.h"
-#include "DataFlashUtility.h"
+#include "APMDataFlashUtility.h"
 #include "GeoTagData.h"
 #include "QGCLoggingCategory.h"
 
@@ -81,14 +81,14 @@ bool getTagsFromLog(const char *data, qint64 size, QList<GeoTagData> &cameraFeed
 {
     cameraFeedback.clear();
 
-    if (!DataFlashUtility::isValidHeader(data, size)) {
+    if (!APMDataFlashUtility::isValidHeader(data, size)) {
         errorMessage = QStringLiteral("Invalid DataFlash log format");
         return false;
     }
 
     // First pass: Parse FMT messages to learn message formats
-    QMap<uint8_t, DataFlashUtility::MessageFormat> formats;
-    if (!DataFlashUtility::parseFmtMessages(data, size, formats)) {
+    QMap<uint8_t, APMDataFlashUtility::MessageFormat> formats;
+    if (!APMDataFlashUtility::parseFmtMessages(data, size, formats)) {
         errorMessage = QStringLiteral("No message formats found in log");
         return false;
     }
@@ -110,10 +110,10 @@ bool getTagsFromLog(const char *data, qint64 size, QList<GeoTagData> &cameraFeed
     }
 
     // Second pass: Extract CAM messages using iterator
-    DataFlashUtility::iterateMessages(data, size, formats,
-        [&](uint8_t msgType, const char *payload, int, const DataFlashUtility::MessageFormat &fmt) {
+    APMDataFlashUtility::iterateMessages(data, size, formats,
+        [&](uint8_t msgType, const char *payload, int, const APMDataFlashUtility::MessageFormat &fmt) {
             if (msgType == camMessageType) {
-                const QMap<QString, QVariant> fields = DataFlashUtility::parseMessage(payload, fmt);
+                const QMap<QString, QVariant> fields = APMDataFlashUtility::parseMessage(payload, fmt);
                 GeoTagData feedback = extractGeoTagData(fields);
 
                 if (feedback.coordinate.isValid()) {

--- a/src/AnalyzeView/GeoTag/ULogParser.cc
+++ b/src/AnalyzeView/GeoTag/ULogParser.cc
@@ -1,5 +1,5 @@
 #include "ULogParser.h"
-#include "ULogUtility.h"
+#include "PX4ULogUtility.h"
 #include "QGCLoggingCategory.h"
 
 #include <cmath>
@@ -58,7 +58,7 @@ bool getTagsFromLog(const char *data, qint64 size, QList<GeoTagData> &cameraFeed
 {
     cameraFeedback.clear();
 
-    const bool success = ULogUtility::iterateMessages(data, size, "camera_capture",
+    const bool success = PX4ULogUtility::iterateMessages(data, size, "camera_capture",
         [&](const ulog_cpp::TypedDataView &sample) {
             cameraFeedback.append(parseGeoTagData(sample));
             return true;

--- a/src/AnalyzeView/LogViewer/APMDataFlash/APMDataFlashLogParser.cc
+++ b/src/AnalyzeView/LogViewer/APMDataFlash/APMDataFlashLogParser.cc
@@ -1,0 +1,812 @@
+#include "APMDataFlashLogParser.h"
+
+#include "APMDataFlashUtility.h"
+#include "QGCLoggingCategory.h"
+
+#include <QtConcurrent/QtConcurrent>
+#include <QtCore/QFile>
+#include <QtCore/QFutureWatcher>
+#include <QtCore/QHash>
+#include <QtCore/QSet>
+
+#include <algorithm>
+#include <cmath>
+#include <limits>
+
+QGC_LOGGING_CATEGORY(APMDataFlashLogParserLog, "AnalyzeView.APMDataFlashLogParser")
+
+namespace {
+struct ParseResult {
+    bool ok = false;
+    QString errorMessage;
+    QStringList availableSignals;
+    QStringList plottableSignals;
+    QVariantList parameters;
+    QVariantList events;
+    QVariantList messages;
+    QVariantList modeSegments;
+    QHash<QString, QVector<QPointF>> signalSamples;
+    double minTimestamp = -1.0;
+    double maxTimestamp = -1.0;
+    int sampleCount = 0;
+    QString detectedVehicleType;
+};
+
+QString _vehicleTypeFromMessageText(const QString &messageText)
+{
+    const QString text = messageText.toLower();
+    if (text.contains(QStringLiteral("arducopter"))) {
+        return QStringLiteral("ArduCopter");
+    }
+    if (text.contains(QStringLiteral("arduplane"))) {
+        return QStringLiteral("ArduPlane");
+    }
+    if (text.contains(QStringLiteral("ardurover"))) {
+        return QStringLiteral("ArduRover");
+    }
+    if (text.contains(QStringLiteral("ardusub"))) {
+        return QStringLiteral("ArduSub");
+    }
+
+    return QString();
+}
+
+QString _ardupilotModeName(const QString &vehicleType, int modeNumber)
+{
+    static const QHash<int, QString> planeModes = {
+        {0, QStringLiteral("Manual")},
+        {1, QStringLiteral("CIRCLE")},
+        {2, QStringLiteral("STABILIZE")},
+        {3, QStringLiteral("TRAINING")},
+        {4, QStringLiteral("ACRO")},
+        {5, QStringLiteral("FBWA")},
+        {6, QStringLiteral("FBWB")},
+        {7, QStringLiteral("CRUISE")},
+        {8, QStringLiteral("AUTOTUNE")},
+        {10, QStringLiteral("Auto")},
+        {11, QStringLiteral("RTL")},
+        {12, QStringLiteral("Loiter")},
+        {13, QStringLiteral("TAKEOFF")},
+        {14, QStringLiteral("AVOID_ADSB")},
+        {15, QStringLiteral("Guided")},
+        {17, QStringLiteral("QSTABILIZE")},
+        {18, QStringLiteral("QHOVER")},
+        {19, QStringLiteral("QLOITER")},
+        {20, QStringLiteral("QLAND")},
+        {21, QStringLiteral("QRTL")},
+        {22, QStringLiteral("QAUTOTUNE")},
+        {23, QStringLiteral("QACRO")},
+        {24, QStringLiteral("THERMAL")},
+        {25, QStringLiteral("Loiter to QLand")},
+        {26, QStringLiteral("AUTOLAND")},
+    };
+    static const QHash<int, QString> copterModes = {
+        {0, QStringLiteral("Stabilize")},
+        {1, QStringLiteral("Acro")},
+        {2, QStringLiteral("AltHold")},
+        {3, QStringLiteral("Auto")},
+        {4, QStringLiteral("Guided")},
+        {5, QStringLiteral("Loiter")},
+        {6, QStringLiteral("RTL")},
+        {7, QStringLiteral("Circle")},
+        {9, QStringLiteral("Land")},
+        {11, QStringLiteral("Drift")},
+        {13, QStringLiteral("Sport")},
+        {14, QStringLiteral("Flip")},
+        {15, QStringLiteral("AutoTune")},
+        {16, QStringLiteral("PosHold")},
+        {17, QStringLiteral("Brake")},
+        {18, QStringLiteral("Throw")},
+        {19, QStringLiteral("Avoid_ADSB")},
+        {20, QStringLiteral("Guided_NoGPS")},
+        {21, QStringLiteral("Smart_RTL")},
+        {22, QStringLiteral("FlowHold")},
+        {23, QStringLiteral("Follow")},
+        {24, QStringLiteral("ZigZag")},
+        {25, QStringLiteral("SystemID")},
+        {26, QStringLiteral("Heli_Autorotate")},
+        {27, QStringLiteral("Auto RTL")},
+        {28, QStringLiteral("Turtle")},
+    };
+
+    if (vehicleType == QStringLiteral("ArduPlane")) {
+        return planeModes.value(modeNumber, QStringLiteral("Mode %1").arg(modeNumber));
+    }
+    if (vehicleType == QStringLiteral("ArduCopter")) {
+        return copterModes.value(modeNumber, QStringLiteral("Mode %1").arg(modeNumber));
+    }
+
+    // Numeric ArduPilot mode values are vehicle-specific. Without reliable
+    // vehicle-type detection, preserve numeric representation.
+    return QStringLiteral("Mode %1").arg(modeNumber);
+}
+
+QString _ardupilotErrDescription(int subsystem, int ecode)
+{
+    QString subsystemName;
+    switch (subsystem) {
+    case 1:  subsystemName = APMDataFlashLogParser::tr("Main"); break;
+    case 2:  subsystemName = APMDataFlashLogParser::tr("Radio"); break;
+    case 3:  subsystemName = APMDataFlashLogParser::tr("Compass"); break;
+    case 4:  subsystemName = APMDataFlashLogParser::tr("Optflow"); break;
+    case 5:  subsystemName = APMDataFlashLogParser::tr("Radio Failsafe"); break;
+    case 6:  subsystemName = APMDataFlashLogParser::tr("Battery Failsafe"); break;
+    case 7:  subsystemName = APMDataFlashLogParser::tr("GPS Failsafe"); break;
+    case 8:  subsystemName = APMDataFlashLogParser::tr("GCS Failsafe"); break;
+    case 9:  subsystemName = APMDataFlashLogParser::tr("Fence Failsafe"); break;
+    case 10: subsystemName = APMDataFlashLogParser::tr("Flight mode"); break;
+    case 11: subsystemName = APMDataFlashLogParser::tr("GPS"); break;
+    case 12: subsystemName = APMDataFlashLogParser::tr("Crash Check"); break;
+    case 13: subsystemName = APMDataFlashLogParser::tr("Flip"); break;
+    case 14: subsystemName = APMDataFlashLogParser::tr("Autotune"); break;
+    case 15: subsystemName = APMDataFlashLogParser::tr("Parachute"); break;
+    case 16: subsystemName = APMDataFlashLogParser::tr("EKF Check"); break;
+    case 17: subsystemName = APMDataFlashLogParser::tr("EKF Failsafe"); break;
+    case 18: subsystemName = APMDataFlashLogParser::tr("Barometer"); break;
+    case 19: subsystemName = APMDataFlashLogParser::tr("CPU Load Watchdog"); break;
+    case 20: subsystemName = APMDataFlashLogParser::tr("ADSB Failsafe"); break;
+    case 21: subsystemName = APMDataFlashLogParser::tr("Terrain Data"); break;
+    case 22: subsystemName = APMDataFlashLogParser::tr("Navigation"); break;
+    case 23: subsystemName = APMDataFlashLogParser::tr("Terrain Failsafe"); break;
+    case 24: subsystemName = APMDataFlashLogParser::tr("EKF Primary"); break;
+    case 25: subsystemName = APMDataFlashLogParser::tr("Thrust Loss Check"); break;
+    case 26: subsystemName = APMDataFlashLogParser::tr("Sensor Failsafe"); break;
+    case 27: subsystemName = APMDataFlashLogParser::tr("Leak Failsafe"); break;
+    case 28: subsystemName = APMDataFlashLogParser::tr("Pilot Input"); break;
+    case 29: subsystemName = APMDataFlashLogParser::tr("Vibration Failsafe"); break;
+    case 30: subsystemName = APMDataFlashLogParser::tr("Internal Error"); break;
+    case 31: subsystemName = APMDataFlashLogParser::tr("Deadreckon Failsafe"); break;
+    default: subsystemName = APMDataFlashLogParser::tr("Subsystem %1").arg(subsystem); break;
+    }
+
+    QString ecodeText;
+    switch (subsystem) {
+    case 1: // MAIN
+        if (ecode == 1) { ecodeText = APMDataFlashLogParser::tr("INS delay"); }
+        break;
+    case 2: // RADIO
+        if (ecode == 0) { ecodeText = APMDataFlashLogParser::tr("Errors Resolved"); }
+        else if (ecode == 2) { ecodeText = APMDataFlashLogParser::tr("Late Frame"); }
+        break;
+    case 3: // COMPASS
+        if (ecode == 0) { ecodeText = APMDataFlashLogParser::tr("Errors Resolved"); }
+        else if (ecode == 1) { ecodeText = APMDataFlashLogParser::tr("Failed to initialise"); }
+        else if (ecode == 4) { ecodeText = APMDataFlashLogParser::tr("Unhealthy"); }
+        break;
+    case 5: // FAILSAFE_RADIO
+    case 6: // FAILSAFE_BATT
+    case 7: // FAILSAFE_GPS
+    case 8: // FAILSAFE_GCS
+    case 17: // FAILSAFE_EKFINAV
+    case 19: // CPU
+    case 23: // FAILSAFE_TERRAIN
+    case 26: // FAILSAFE_SENSORS
+    case 27: // FAILSAFE_LEAK
+    case 28: // PILOT_INPUT
+    case 31: // FAILSAFE_DEADRECKON
+        if (ecode == 0) { ecodeText = APMDataFlashLogParser::tr("Failsafe Resolved"); }
+        else if (ecode == 1) { ecodeText = APMDataFlashLogParser::tr("Failsafe Triggered"); }
+        break;
+    case 9: // FAILSAFE_FENCE
+        if (ecode == 0) { ecodeText = APMDataFlashLogParser::tr("Failsafe Resolved"); }
+        else if (ecode == 1) { ecodeText = APMDataFlashLogParser::tr("Altitude fence breach"); }
+        else if (ecode == 2) { ecodeText = APMDataFlashLogParser::tr("Circular fence breach"); }
+        else if (ecode == 3) { ecodeText = APMDataFlashLogParser::tr("Altitude and circular fence breach"); }
+        else if (ecode == 4) { ecodeText = APMDataFlashLogParser::tr("Polygon fence breach"); }
+        break;
+    case 10: // FLIGHT_MODE
+        if (ecode == 0) { ecodeText = APMDataFlashLogParser::tr("Flight mode change failure"); }
+        break;
+    case 11: // GPS
+        if (ecode == 0) { ecodeText = APMDataFlashLogParser::tr("Glitch cleared"); }
+        else if (ecode == 2) { ecodeText = APMDataFlashLogParser::tr("GPS glitch occurred"); }
+        break;
+    case 12: // CRASH_CHECK
+        if (ecode == 1) { ecodeText = APMDataFlashLogParser::tr("Crash into ground detected"); }
+        else if (ecode == 2) { ecodeText = APMDataFlashLogParser::tr("Loss of control detected"); }
+        break;
+    case 13: // FLIP
+        if (ecode == 2) { ecodeText = APMDataFlashLogParser::tr("Flip abandoned"); }
+        break;
+    case 15: // PARACHUTES
+        if (ecode == 2) { ecodeText = APMDataFlashLogParser::tr("Parachute not deployed (too low)"); }
+        else if (ecode == 3) { ecodeText = APMDataFlashLogParser::tr("Parachute not deployed (landed)"); }
+        break;
+    case 16: // EKFCHECK
+        if (ecode == 0) { ecodeText = APMDataFlashLogParser::tr("Variance cleared"); }
+        else if (ecode == 2) { ecodeText = APMDataFlashLogParser::tr("Bad variance"); }
+        break;
+    case 18: // BARO
+        if (ecode == 0) { ecodeText = APMDataFlashLogParser::tr("Errors Resolved"); }
+        else if (ecode == 2) { ecodeText = APMDataFlashLogParser::tr("Baro glitch"); }
+        else if (ecode == 3) { ecodeText = APMDataFlashLogParser::tr("Bad depth"); }
+        else if (ecode == 4) { ecodeText = APMDataFlashLogParser::tr("Unhealthy"); }
+        break;
+    case 20: // FAILSAFE_ADSB
+        if (ecode == 0) { ecodeText = APMDataFlashLogParser::tr("Failsafe Resolved"); }
+        else if (ecode == 1) { ecodeText = APMDataFlashLogParser::tr("No action report only"); }
+        else if (ecode == 2) { ecodeText = APMDataFlashLogParser::tr("Avoid by climb/descend"); }
+        else if (ecode == 3) { ecodeText = APMDataFlashLogParser::tr("Avoid by horizontal move"); }
+        else if (ecode == 4) { ecodeText = APMDataFlashLogParser::tr("Avoid perpendicular move"); }
+        else if (ecode == 5) { ecodeText = APMDataFlashLogParser::tr("RTL invoked"); }
+        break;
+    case 21: // TERRAIN
+        if (ecode == 2) { ecodeText = APMDataFlashLogParser::tr("Missing terrain data"); }
+        break;
+    case 22: // NAVIGATION
+        if (ecode == 2) { ecodeText = APMDataFlashLogParser::tr("Failed to set destination"); }
+        else if (ecode == 3) { ecodeText = APMDataFlashLogParser::tr("RTL restarted"); }
+        else if (ecode == 4) { ecodeText = APMDataFlashLogParser::tr("Circle initialisation failed"); }
+        else if (ecode == 5) { ecodeText = APMDataFlashLogParser::tr("Destination outside fence"); }
+        else if (ecode == 6) { ecodeText = APMDataFlashLogParser::tr("RTL missing rangefinder"); }
+        break;
+    case 24: // EKF_PRIMARY
+        if (ecode == 0) { ecodeText = APMDataFlashLogParser::tr("1st EKF became primary"); }
+        else if (ecode == 1) { ecodeText = APMDataFlashLogParser::tr("2nd EKF became primary"); }
+        break;
+    case 25: // THRUST_LOSS_CHECK
+        if (ecode == 0) { ecodeText = APMDataFlashLogParser::tr("Thrust restored"); }
+        else if (ecode == 1) { ecodeText = APMDataFlashLogParser::tr("Thrust loss detected"); }
+        break;
+    case 29: // FAILSAFE_VIBE
+        if (ecode == 0) { ecodeText = APMDataFlashLogParser::tr("Excessive vibration compensation de-activated"); }
+        else if (ecode == 1) { ecodeText = APMDataFlashLogParser::tr("Excessive vibration compensation activated"); }
+        break;
+    case 30: // INTERNAL_ERROR
+        if (ecode == 1) { ecodeText = APMDataFlashLogParser::tr("Internal errors detected"); }
+        break;
+    default:
+        break;
+    }
+
+    if (ecodeText.isEmpty()) {
+        ecodeText = APMDataFlashLogParser::tr("Code %1").arg(ecode);
+    }
+
+    return QStringLiteral("%1 (%2): %3 (%4)").arg(subsystemName).arg(subsystem).arg(ecodeText).arg(ecode);
+}
+
+QString _ardupilotEventDescription(int eventId)
+{
+    switch (eventId) {
+    case 10: return APMDataFlashLogParser::tr("Armed");
+    case 11: return APMDataFlashLogParser::tr("Disarmed");
+    case 15: return APMDataFlashLogParser::tr("Auto Armed");
+    case 17: return APMDataFlashLogParser::tr("Land Complete Maybe");
+    case 18: return APMDataFlashLogParser::tr("Land Complete");
+    case 19: return APMDataFlashLogParser::tr("Lost GPS");
+    case 21: return APMDataFlashLogParser::tr("Flip Start");
+    case 22: return APMDataFlashLogParser::tr("Flip End");
+    case 25: return APMDataFlashLogParser::tr("Set Home");
+    case 26: return APMDataFlashLogParser::tr("Simple Mode Enabled");
+    case 27: return APMDataFlashLogParser::tr("Simple Mode Disabled");
+    case 28: return APMDataFlashLogParser::tr("Not Landed");
+    case 29: return APMDataFlashLogParser::tr("Super Simple Mode Enabled");
+    case 30: return APMDataFlashLogParser::tr("AutoTune Initialised");
+    case 31: return APMDataFlashLogParser::tr("AutoTune Off");
+    case 32: return APMDataFlashLogParser::tr("AutoTune Restart");
+    case 33: return APMDataFlashLogParser::tr("AutoTune Success");
+    case 34: return APMDataFlashLogParser::tr("AutoTune Failed");
+    case 35: return APMDataFlashLogParser::tr("AutoTune Reached Limit");
+    case 36: return APMDataFlashLogParser::tr("AutoTune Pilot Testing");
+    case 37: return APMDataFlashLogParser::tr("AutoTune Saved Gains");
+    case 38: return APMDataFlashLogParser::tr("Save Trim");
+    case 39: return APMDataFlashLogParser::tr("Save Waypoint Add");
+    case 41: return APMDataFlashLogParser::tr("Fence Enabled");
+    case 42: return APMDataFlashLogParser::tr("Fence Disabled");
+    case 43: return APMDataFlashLogParser::tr("Acro Trainer Off");
+    case 44: return APMDataFlashLogParser::tr("Acro Trainer Leveling");
+    case 45: return APMDataFlashLogParser::tr("Acro Trainer Limited");
+    case 46: return APMDataFlashLogParser::tr("Gripper Grab");
+    case 47: return APMDataFlashLogParser::tr("Gripper Release");
+    case 49: return APMDataFlashLogParser::tr("Parachute Disabled");
+    case 50: return APMDataFlashLogParser::tr("Parachute Enabled");
+    case 51: return APMDataFlashLogParser::tr("Parachute Released");
+    case 52: return APMDataFlashLogParser::tr("Landing Gear Deployed");
+    case 53: return APMDataFlashLogParser::tr("Landing Gear Retracted");
+    case 54: return APMDataFlashLogParser::tr("Motors Emergency Stopped");
+    case 55: return APMDataFlashLogParser::tr("Motors Emergency Stop Cleared");
+    case 56: return APMDataFlashLogParser::tr("Motors Interlock Disabled");
+    case 57: return APMDataFlashLogParser::tr("Motors Interlock Enabled");
+    case 58: return APMDataFlashLogParser::tr("Rotor Runup Complete");
+    case 59: return APMDataFlashLogParser::tr("Rotor Speed Below Critical");
+    case 60: return APMDataFlashLogParser::tr("EKF Altitude Reset");
+    case 61: return APMDataFlashLogParser::tr("Land Cancelled By Pilot");
+    case 62: return APMDataFlashLogParser::tr("EKF Yaw Reset");
+    case 63: return APMDataFlashLogParser::tr("ADSB Avoidance Enabled");
+    case 64: return APMDataFlashLogParser::tr("ADSB Avoidance Disabled");
+    case 65: return APMDataFlashLogParser::tr("Proximity Avoidance Enabled");
+    case 66: return APMDataFlashLogParser::tr("Proximity Avoidance Disabled");
+    case 67: return APMDataFlashLogParser::tr("GPS Primary Changed");
+    case 71: return APMDataFlashLogParser::tr("ZigZag Store A");
+    case 72: return APMDataFlashLogParser::tr("ZigZag Store B");
+    case 73: return APMDataFlashLogParser::tr("Land Repo Active");
+    case 74: return APMDataFlashLogParser::tr("Standby Enabled");
+    case 75: return APMDataFlashLogParser::tr("Standby Disabled");
+    case 76: return APMDataFlashLogParser::tr("Fence Alt Max Enabled");
+    case 77: return APMDataFlashLogParser::tr("Fence Alt Max Disabled");
+    case 78: return APMDataFlashLogParser::tr("Fence Circle Enabled");
+    case 79: return APMDataFlashLogParser::tr("Fence Circle Disabled");
+    case 80: return APMDataFlashLogParser::tr("Fence Alt Min Enabled");
+    case 81: return APMDataFlashLogParser::tr("Fence Alt Min Disabled");
+    case 82: return APMDataFlashLogParser::tr("Fence Polygon Enabled");
+    case 83: return APMDataFlashLogParser::tr("Fence Polygon Disabled");
+    case 85: return APMDataFlashLogParser::tr("EK3 Source Set: Primary");
+    case 86: return APMDataFlashLogParser::tr("EK3 Source Set: Secondary");
+    case 87: return APMDataFlashLogParser::tr("EK3 Source Set: Tertiary");
+    case 90: return APMDataFlashLogParser::tr("Airspeed Primary Changed");
+    case 163: return APMDataFlashLogParser::tr("Surfaced");
+    case 164: return APMDataFlashLogParser::tr("Not Surfaced");
+    case 165: return APMDataFlashLogParser::tr("Bottomed");
+    case 166: return APMDataFlashLogParser::tr("Not Bottomed");
+    default: return APMDataFlashLogParser::tr("Event %1").arg(eventId);
+    }
+}
+
+double _extractTimestampSeconds(const QMap<QString, QVariant> &values)
+{
+    if (values.contains(QStringLiteral("TimeUS"))) {
+        return values.value(QStringLiteral("TimeUS")).toDouble() / 1000000.0;
+    }
+    if (values.contains(QStringLiteral("TimeMS"))) {
+        return values.value(QStringLiteral("TimeMS")).toDouble() / 1000.0;
+    }
+    if (values.contains(QStringLiteral("Time"))) {
+        return values.value(QStringLiteral("Time")).toDouble() / 1000.0;
+    }
+
+    return -1.0;
+}
+
+void _appendEvent(QVariantList &events, double timestampSecs, const QString &type, const QString &description)
+{
+    if ((timestampSecs < 0.0) || description.isEmpty()) {
+        return;
+    }
+
+    QVariantMap eventRow;
+    eventRow[QStringLiteral("time")] = timestampSecs;
+    eventRow[QStringLiteral("type")] = type;
+    eventRow[QStringLiteral("description")] = description;
+    events.append(eventRow);
+}
+
+ParseResult _parseDataFlashFile(const QString &filePath)
+{
+    ParseResult result;
+
+    QFile file(filePath);
+    if (!file.open(QIODevice::ReadOnly)) {
+        result.errorMessage = APMDataFlashLogParser::tr("Failed to open DataFlash file");
+        return result;
+    }
+
+    const qint64 fileSize = file.size();
+    if (fileSize <= 0) {
+        result.errorMessage = APMDataFlashLogParser::tr("DataFlash file is empty");
+        return result;
+    }
+    if (fileSize > std::numeric_limits<qsizetype>::max()) {
+        result.errorMessage = APMDataFlashLogParser::tr("DataFlash file is too large to parse");
+        return result;
+    }
+
+    uchar *const mappedData = file.map(0, fileSize);
+    if (mappedData == nullptr) {
+        result.errorMessage = APMDataFlashLogParser::tr("Failed to memory-map DataFlash file");
+        return result;
+    }
+
+    struct ScopedFileUnmap {
+        QFile &file;
+        uchar *data = nullptr;
+        ~ScopedFileUnmap()
+        {
+            if (data != nullptr) {
+                file.unmap(data);
+            }
+        }
+    } scopedFileUnmap{file, mappedData};
+
+    const QByteArray bytes = QByteArray::fromRawData(reinterpret_cast<const char *>(mappedData), static_cast<qsizetype>(fileSize));
+
+    QMap<uint8_t, APMDataFlashUtility::MessageFormat> formats;
+    if (!APMDataFlashUtility::parseFmtMessages(bytes.constData(), bytes.size(), formats)) {
+        result.errorMessage = APMDataFlashLogParser::tr("No valid FMT messages were found");
+        return result;
+    }
+
+    QSet<QString> signalSet;
+    QSet<QString> plottableSet;
+    double minTimestampSecs = -1.0;
+    double maxTimestampSecs = -1.0;
+    bool hasOpenModeSegment = false;
+    double modeSegmentStartSecs = -1.0;
+    QString currentModeName;
+
+    // Precompute, once per format, the fully-qualified signal names ("<msg>.<col>")
+    // and a lookup map from column name to that pre-formatted signal name. Building
+    // these names per-message via QString::arg() previously dominated parse cost.
+    QHash<uint8_t, QHash<QString, QString>> signalNameByCol;
+    signalNameByCol.reserve(formats.size());
+    for (auto fmtIt = formats.cbegin(); fmtIt != formats.cend(); ++fmtIt) {
+        const APMDataFlashUtility::MessageFormat &fmt = fmtIt.value();
+        QHash<QString, QString> &perCol = signalNameByCol[fmtIt.key()];
+        perCol.reserve(fmt.columns.size());
+        for (const QString &col : fmt.columns) {
+            perCol.insert(col, fmt.name + QLatin1Char('.') + col);
+        }
+    }
+
+    static const QString kPARM = QStringLiteral("PARM");
+    static const QString kMSG  = QStringLiteral("MSG");
+    static const QString kMODE = QStringLiteral("MODE");
+    static const QString kERR  = QStringLiteral("ERR");
+    static const QString kEV   = QStringLiteral("EV");
+
+    APMDataFlashUtility::iterateMessages(bytes.constData(), bytes.size(), formats, [&result, &signalSet, &plottableSet, &minTimestampSecs, &maxTimestampSecs, &hasOpenModeSegment, &modeSegmentStartSecs, &currentModeName, &signalNameByCol](uint8_t msgType, const char *payload, int, const APMDataFlashUtility::MessageFormat &fmt) {
+        const QMap<QString, QVariant> values = APMDataFlashUtility::parseMessage(payload, fmt);
+        const double timestampSecs = _extractTimestampSeconds(values);
+        if (timestampSecs >= 0.0) {
+            if (minTimestampSecs < 0.0 || timestampSecs < minTimestampSecs) {
+                minTimestampSecs = timestampSecs;
+            }
+            maxTimestampSecs = std::max(maxTimestampSecs, timestampSecs);
+        }
+
+        if (fmt.name == kPARM) {
+            const QString paramName = values.value(QStringLiteral("Name")).toString();
+            const QVariant paramValue = values.contains(QStringLiteral("Value")) ? values.value(QStringLiteral("Value")) : values.value(QStringLiteral("Val"));
+            if (!paramName.isEmpty()) {
+                QVariantMap row;
+                row[QStringLiteral("name")] = paramName;
+                row[QStringLiteral("value")] = paramValue;
+                result.parameters.append(row);
+            }
+        } else if (fmt.name == kMSG) {
+            const QString text = values.value(QStringLiteral("Message")).toString();
+            const QString detected = _vehicleTypeFromMessageText(text);
+            if (result.detectedVehicleType.isEmpty() && !detected.isEmpty()) {
+                result.detectedVehicleType = detected;
+            }
+            if (!text.isEmpty()) {
+                QVariantMap row;
+                row[QStringLiteral("time")] = timestampSecs;
+                row[QStringLiteral("text")] = text;
+                result.messages.append(row);
+            }
+        } else if (fmt.name == kMODE) {
+            QString modeName = values.value(QStringLiteral("Mode")).toString();
+            bool isNumericMode = false;
+            const int modeNumber = modeName.toInt(&isNumericMode);
+            if (isNumericMode) {
+                modeName = _ardupilotModeName(result.detectedVehicleType, modeNumber);
+            } else if (modeName.isEmpty()) {
+                modeName = APMDataFlashLogParser::tr("Unknown");
+            }
+            _appendEvent(result.events, timestampSecs, QStringLiteral("mode"), APMDataFlashLogParser::tr("Mode: %1").arg(modeName));
+            if (timestampSecs >= 0.0) {
+                if (hasOpenModeSegment && (timestampSecs > modeSegmentStartSecs)) {
+                    QVariantMap segment;
+                    segment[QStringLiteral("mode")] = currentModeName;
+                    segment[QStringLiteral("start")] = modeSegmentStartSecs;
+                    segment[QStringLiteral("end")] = timestampSecs;
+                    result.modeSegments.append(segment);
+                }
+                hasOpenModeSegment = true;
+                modeSegmentStartSecs = timestampSecs;
+                currentModeName = modeName;
+            }
+        } else if (fmt.name == kERR) {
+            const int subsystem = values.value(QStringLiteral("Subsys")).toInt();
+            const int ecode = values.value(QStringLiteral("ECode")).toInt();
+            _appendEvent(result.events, timestampSecs, QStringLiteral("error"), _ardupilotErrDescription(subsystem, ecode));
+        } else if (fmt.name == kEV) {
+            const int eventId = values.value(QStringLiteral("Id"), values.value(QStringLiteral("Event"))).toInt();
+            _appendEvent(result.events, timestampSecs, QStringLiteral("event"), _ardupilotEventDescription(eventId));
+        }
+
+        result.sampleCount++;
+
+        // Single pass: lookup precomputed signal names, populate signal/plottable
+        // sets, and append numeric samples in one walk over the values map.
+        const QHash<QString, QString> &perCol = signalNameByCol[msgType];
+        const bool haveTimestamp = (timestampSecs >= 0.0);
+        for (auto it = values.cbegin(); it != values.cend(); ++it) {
+            const auto nameIt = perCol.constFind(it.key());
+            if (nameIt == perCol.constEnd()) {
+                continue;
+            }
+            const QString &signalName = nameIt.value();
+            signalSet.insert(signalName);
+
+            if (!haveTimestamp) {
+                continue;
+            }
+            const int typeId = it.value().metaType().id();
+            const bool numeric = (typeId == QMetaType::Int) || (typeId == QMetaType::UInt) ||
+                                 (typeId == QMetaType::LongLong) || (typeId == QMetaType::ULongLong) ||
+                                 (typeId == QMetaType::Float) || (typeId == QMetaType::Double);
+            if (numeric) {
+                result.signalSamples[signalName].append(QPointF(timestampSecs, it.value().toDouble()));
+                plottableSet.insert(signalName);
+            }
+        }
+
+        return true;
+    });
+
+    if (hasOpenModeSegment && (maxTimestampSecs >= modeSegmentStartSecs)) {
+        QVariantMap segment;
+        segment[QStringLiteral("mode")] = currentModeName;
+        segment[QStringLiteral("start")] = modeSegmentStartSecs;
+        segment[QStringLiteral("end")] = maxTimestampSecs;
+        result.modeSegments.append(segment);
+    }
+
+    result.availableSignals = signalSet.values();
+    std::sort(result.availableSignals.begin(), result.availableSignals.end());
+    result.plottableSignals = plottableSet.values();
+    std::sort(result.plottableSignals.begin(), result.plottableSignals.end());
+    result.minTimestamp = minTimestampSecs;
+    result.maxTimestamp = maxTimestampSecs;
+    result.ok = true;
+    return result;
+}
+} // namespace
+
+APMDataFlashLogParser::APMDataFlashLogParser(QObject *parent)
+    : QObject(parent)
+{
+    qCDebug(APMDataFlashLogParserLog) << this;
+}
+
+APMDataFlashLogParser::~APMDataFlashLogParser()
+{
+    qCDebug(APMDataFlashLogParserLog) << this;
+}
+
+bool APMDataFlashLogParser::parseFile(const QString &filePath)
+{
+    ++_parseRequestId; // Invalidate any in-flight async parse results.
+    clear();
+    const ParseResult result = _parseDataFlashFile(filePath);
+    if (!result.ok) {
+        _setParseError(result.errorMessage);
+        return false;
+    }
+
+    _availableSignals = result.availableSignals;
+    _plottableSignals = result.plottableSignals;
+    _parameters = result.parameters;
+    _events = result.events;
+    _messages = result.messages;
+    _modeSegments = result.modeSegments;
+    _signalSamples = result.signalSamples;
+    _sampleCount = result.sampleCount;
+    _detectedVehicleType = result.detectedVehicleType;
+    emit availableSignalsChanged();
+    emit plottableSignalsChanged();
+    emit parametersChanged();
+    emit eventsChanged();
+    emit messagesChanged();
+    emit modeSegmentsChanged();
+    emit detectedVehicleTypeChanged();
+    if (_minTimestamp != result.minTimestamp || _maxTimestamp != result.maxTimestamp) {
+        _minTimestamp = result.minTimestamp;
+        _maxTimestamp = result.maxTimestamp;
+        emit timeRangeChanged();
+    }
+    emit sampleCountChanged();
+
+    _parsed = true;
+    emit parsedChanged();
+    qCDebug(APMDataFlashLogParserLog) << "Parsed signals" << _availableSignals.count() << "parameters" << _parameters.count() << "events" << _events.count();
+    return true;
+}
+
+void APMDataFlashLogParser::parseFileAsync(const QString &filePath)
+{
+    const quint64 requestId = ++_parseRequestId;
+    clear();
+
+    auto *watcher = new QFutureWatcher<ParseResult>(this);
+    (void) connect(watcher, &QFutureWatcher<ParseResult>::finished, this, [this, watcher, filePath, requestId]() {
+        const ParseResult result = watcher->result();
+        watcher->deleteLater();
+
+        if (requestId != _parseRequestId) {
+            // A newer parse request has superseded this result.
+            return;
+        }
+
+        if (!result.ok) {
+            _setParseError(result.errorMessage);
+            emit parseFileFinished(filePath, false, result.errorMessage);
+            return;
+        }
+
+        _availableSignals = result.availableSignals;
+        _plottableSignals = result.plottableSignals;
+        _parameters = result.parameters;
+        _events = result.events;
+        _messages = result.messages;
+        _modeSegments = result.modeSegments;
+        _signalSamples = result.signalSamples;
+        _sampleCount = result.sampleCount;
+        _detectedVehicleType = result.detectedVehicleType;
+        emit availableSignalsChanged();
+        emit plottableSignalsChanged();
+        emit parametersChanged();
+        emit eventsChanged();
+        emit messagesChanged();
+        emit modeSegmentsChanged();
+        emit detectedVehicleTypeChanged();
+        if (_minTimestamp != result.minTimestamp || _maxTimestamp != result.maxTimestamp) {
+            _minTimestamp = result.minTimestamp;
+            _maxTimestamp = result.maxTimestamp;
+            emit timeRangeChanged();
+        }
+        emit sampleCountChanged();
+
+        _parsed = true;
+        emit parsedChanged();
+        emit parseFileFinished(filePath, true, QString());
+    });
+
+    watcher->setFuture(QtConcurrent::run([filePath]() {
+        return _parseDataFlashFile(filePath);
+    }));
+}
+
+void APMDataFlashLogParser::clear()
+{
+    const bool oldParsed = _parsed;
+    _parsed = false;
+    if (oldParsed) {
+        emit parsedChanged();
+    }
+
+    if (!_parseError.isEmpty()) {
+        _parseError.clear();
+        emit parseErrorChanged();
+    }
+
+    if (!_availableSignals.isEmpty()) {
+        _availableSignals.clear();
+        emit availableSignalsChanged();
+    }
+
+    if (!_parameters.isEmpty()) {
+        _parameters.clear();
+        emit parametersChanged();
+    }
+
+    if (!_events.isEmpty()) {
+        _events.clear();
+        emit eventsChanged();
+    }
+
+    if (!_messages.isEmpty()) {
+        _messages.clear();
+        emit messagesChanged();
+    }
+
+    if (!_modeSegments.isEmpty()) {
+        _modeSegments.clear();
+        emit modeSegmentsChanged();
+    }
+
+    if (!_detectedVehicleType.isEmpty()) {
+        _detectedVehicleType.clear();
+        emit detectedVehicleTypeChanged();
+    }
+
+    if (!_plottableSignals.isEmpty()) {
+        _plottableSignals.clear();
+        emit plottableSignalsChanged();
+    }
+
+    _signalSamples.clear();
+    if (_minTimestamp != -1.0 || _maxTimestamp != -1.0) {
+        _minTimestamp = -1.0;
+        _maxTimestamp = -1.0;
+        emit timeRangeChanged();
+    }
+
+    if (_sampleCount != 0) {
+        _sampleCount = 0;
+        emit sampleCountChanged();
+    }
+}
+
+QVariantList APMDataFlashLogParser::signalSamples(const QString &signalName) const
+{
+    QVariantList output;
+    const auto signalIt = _signalSamples.constFind(signalName);
+    if (signalIt == _signalSamples.cend()) {
+        return output;
+    }
+
+    const QVector<QPointF> &points = signalIt.value();
+    output.reserve(points.size());
+    for (const QPointF &point : points) {
+        output.append(point);
+    }
+
+    return output;
+}
+
+double APMDataFlashLogParser::signalValueAt(const QString &signalName, double timestampSeconds) const
+{
+    const auto signalIt = _signalSamples.constFind(signalName);
+    if ((signalIt == _signalSamples.cend()) || signalIt->isEmpty()) {
+        return std::numeric_limits<double>::quiet_NaN();
+    }
+
+    const QVector<QPointF> &points = signalIt.value();
+    const auto lower = std::lower_bound(points.cbegin(), points.cend(), timestampSeconds,
+        [](const QPointF &point, double timestamp) {
+            return point.x() < timestamp;
+        });
+
+    if (lower == points.cbegin()) {
+        return lower->y();
+    }
+
+    if (lower == points.cend()) {
+        return points.constLast().y();
+    }
+
+    const auto previous = std::prev(lower);
+    const double lowerDistance = std::fabs(lower->x() - timestampSeconds);
+    const double previousDistance = std::fabs(previous->x() - timestampSeconds);
+
+    return (previousDistance <= lowerDistance)
+        ? previous->y()
+        : lower->y();
+}
+
+QString APMDataFlashLogParser::modeAt(double timestampSeconds) const
+{
+    for (const QVariant &variant : _modeSegments) {
+        const QVariantMap segment = variant.toMap();
+        const double start = segment.value(QStringLiteral("start")).toDouble();
+        const double end = segment.value(QStringLiteral("end")).toDouble();
+        if (timestampSeconds >= start && timestampSeconds <= end) {
+            return segment.value(QStringLiteral("mode")).toString();
+        }
+    }
+
+    return QString();
+}
+
+QVariantList APMDataFlashLogParser::eventsNear(double timestampSeconds, double thresholdSeconds) const
+{
+    QVariantList matches;
+    const double threshold = std::max(0.0, thresholdSeconds);
+
+    const auto lower = std::lower_bound(_events.cbegin(), _events.cend(), timestampSeconds - threshold,
+        [](const QVariant &v, double t) {
+            return v.toMap().value(QStringLiteral("time")).toDouble() < t;
+        });
+    for (auto it = lower; it != _events.cend(); ++it) {
+        const QVariantMap eventItem = it->toMap();
+        const double eventTime = eventItem.value(QStringLiteral("time")).toDouble();
+        if (eventTime > timestampSeconds + threshold) {
+            break;
+        }
+        matches.append(eventItem);
+    }
+
+    return matches;
+}
+
+void APMDataFlashLogParser::_setParseError(const QString &error)
+{
+    if (_parseError != error) {
+        _parseError = error;
+        emit parseErrorChanged();
+    }
+    qCWarning(APMDataFlashLogParserLog) << error;
+}

--- a/src/AnalyzeView/LogViewer/APMDataFlash/APMDataFlashLogParser.h
+++ b/src/AnalyzeView/LogViewer/APMDataFlash/APMDataFlashLogParser.h
@@ -1,0 +1,88 @@
+#pragma once
+
+#include <QtCore/QObject>
+#include <QtCore/QHash>
+#include <QtCore/QPointF>
+#include <QtCore/QString>
+#include <QtCore/QStringList>
+#include <QtCore/QVariant>
+#include <QtCore/QVariantList>
+#include <QtCore/QVector>
+#include <QtCore/QtGlobal>
+#include <QtQmlIntegration/QtQmlIntegration>
+
+class APMDataFlashLogParser : public QObject
+{
+    Q_OBJECT
+    QML_ELEMENT
+
+    Q_PROPERTY(bool parsed READ parsed NOTIFY parsedChanged)
+    Q_PROPERTY(QString parseError READ parseError NOTIFY parseErrorChanged)
+    Q_PROPERTY(QStringList availableSignals READ availableSignals NOTIFY availableSignalsChanged)
+    Q_PROPERTY(QVariantList parameters READ parameters NOTIFY parametersChanged)
+    Q_PROPERTY(QVariantList events READ events NOTIFY eventsChanged)
+    Q_PROPERTY(QVariantList messages READ messages NOTIFY messagesChanged)
+    Q_PROPERTY(QStringList plottableSignals READ plottableSignals NOTIFY plottableSignalsChanged)
+    Q_PROPERTY(QVariantList modeSegments READ modeSegments NOTIFY modeSegmentsChanged)
+    Q_PROPERTY(QString detectedVehicleType READ detectedVehicleType NOTIFY detectedVehicleTypeChanged)
+    Q_PROPERTY(double minTimestamp READ minTimestamp NOTIFY timeRangeChanged)
+    Q_PROPERTY(double maxTimestamp READ maxTimestamp NOTIFY timeRangeChanged)
+    Q_PROPERTY(int sampleCount READ sampleCount NOTIFY sampleCountChanged)
+
+public:
+    explicit APMDataFlashLogParser(QObject *parent = nullptr);
+    ~APMDataFlashLogParser();
+
+    bool parsed() const { return _parsed; }
+    QString parseError() const { return _parseError; }
+    QStringList availableSignals() const { return _availableSignals; }
+    QVariantList parameters() const { return _parameters; }
+    QVariantList events() const { return _events; }
+    QVariantList messages() const { return _messages; }
+    QStringList plottableSignals() const { return _plottableSignals; }
+    QVariantList modeSegments() const { return _modeSegments; }
+    QString detectedVehicleType() const { return _detectedVehicleType; }
+    double minTimestamp() const { return _minTimestamp; }
+    double maxTimestamp() const { return _maxTimestamp; }
+    int sampleCount() const { return _sampleCount; }
+
+    Q_INVOKABLE bool parseFile(const QString &filePath);
+    Q_INVOKABLE void parseFileAsync(const QString &filePath);
+    Q_INVOKABLE void clear();
+    Q_INVOKABLE QVariantList signalSamples(const QString &signalName) const;
+    Q_INVOKABLE double signalValueAt(const QString &signalName, double timestampSeconds) const;
+    Q_INVOKABLE QString modeAt(double timestampSeconds) const;
+    Q_INVOKABLE QVariantList eventsNear(double timestampSeconds, double thresholdSeconds) const;
+
+signals:
+    void parsedChanged();
+    void parseErrorChanged();
+    void availableSignalsChanged();
+    void parametersChanged();
+    void eventsChanged();
+    void messagesChanged();
+    void plottableSignalsChanged();
+    void modeSegmentsChanged();
+    void detectedVehicleTypeChanged();
+    void timeRangeChanged();
+    void sampleCountChanged();
+    void parseFileFinished(const QString &filePath, bool ok, const QString &errorMessage);
+
+private:
+    void _setParseError(const QString &error);
+
+    bool _parsed = false;
+    QString _parseError;
+    QStringList _availableSignals;
+    QStringList _plottableSignals;
+    QVariantList _parameters;
+    QVariantList _events;
+    QVariantList _messages;
+    QVariantList _modeSegments;
+    QString _detectedVehicleType;
+    QHash<QString, QVector<QPointF>> _signalSamples;
+    double _minTimestamp = -1.0;
+    double _maxTimestamp = -1.0;
+    int _sampleCount = 0;
+    quint64 _parseRequestId = 0;
+};

--- a/src/AnalyzeView/LogViewer/CMakeLists.txt
+++ b/src/AnalyzeView/LogViewer/CMakeLists.txt
@@ -1,0 +1,18 @@
+# ============================================================================
+# Unified Log Viewer Module
+# Shared shell for .tlog and .bin log workflows
+# ============================================================================
+
+target_sources(${CMAKE_PROJECT_NAME}
+    PRIVATE
+        APMDataFlash/APMDataFlashLogParser.cc
+        APMDataFlash/APMDataFlashLogParser.h
+        LogViewerController.cc
+        LogViewerController.h
+)
+
+target_include_directories(${CMAKE_PROJECT_NAME}
+    PRIVATE
+        ${CMAKE_CURRENT_SOURCE_DIR}
+        ${CMAKE_CURRENT_SOURCE_DIR}/APMDataFlash
+)

--- a/src/AnalyzeView/LogViewer/LogViewerController.cc
+++ b/src/AnalyzeView/LogViewer/LogViewerController.cc
@@ -1,0 +1,244 @@
+#include "LogViewerController.h"
+
+#include "QGCLoggingCategory.h"
+
+#include <algorithm>
+#include <cmath>
+
+QGC_LOGGING_CATEGORY(LogViewerControllerLog, "AnalyzeView.LogViewerController")
+
+LogViewerController::LogViewerController(QObject *parent)
+    : QObject(parent)
+{
+    qCDebug(LogViewerControllerLog) << this;
+}
+
+LogViewerController::~LogViewerController()
+{
+    qCDebug(LogViewerControllerLog) << this;
+}
+
+void LogViewerController::clear()
+{
+    _plottableSignals.clear();
+    _signalRows.clear();
+    _selectedSignals.clear();
+    _expandedGroups.clear();
+    emit signalRowsChanged();
+    emit selectedSignalsChanged();
+    _setLog(SourceType::None, QString(), tr("No log loaded"));
+}
+
+void LogViewerController::openTLog(const QString &path)
+{
+    _setLog(SourceType::TLog, path, tr("Telemetry log loaded"));
+}
+
+void LogViewerController::openBinLog(const QString &path)
+{
+    _setLog(SourceType::Bin, path, tr("DataFlash log loaded"));
+}
+
+void LogViewerController::setPlottableSignals(const QStringList &signalNames)
+{
+    _plottableSignals = signalNames;
+    std::sort(_plottableSignals.begin(), _plottableSignals.end());
+    _selectedSignals.clear();
+    emit selectedSignalsChanged();
+    _rebuildSignalRows();
+}
+
+void LogViewerController::clearSelection()
+{
+    if (_selectedSignals.isEmpty()) {
+        return;
+    }
+
+    _selectedSignals.clear();
+    emit selectedSignalsChanged();
+}
+
+void LogViewerController::toggleGroupExpanded(const QString &groupName)
+{
+    if (_expandedGroups.contains(groupName)) {
+        _expandedGroups.remove(groupName);
+    } else {
+        _expandedGroups.insert(groupName);
+    }
+
+    _rebuildSignalRows();
+}
+
+bool LogViewerController::isGroupExpanded(const QString &groupName) const
+{
+    return _expandedGroups.contains(groupName);
+}
+
+void LogViewerController::setSignalSelected(const QString &signalName, bool selected)
+{
+    const bool currentlySelected = _selectedSignals.contains(signalName);
+    if (currentlySelected == selected) {
+        return;
+    }
+
+    if (selected) {
+        _selectedSignals.append(signalName);
+    } else {
+        _selectedSignals.removeAll(signalName);
+    }
+
+    emit selectedSignalsChanged();
+}
+
+bool LogViewerController::isSignalSelected(const QString &signalName) const
+{
+    return _selectedSignals.contains(signalName);
+}
+
+QString LogViewerController::signalColor(const QString &signalName) const
+{
+    return _assignColorForKey(signalName);
+}
+
+QString LogViewerController::eventColor(const QString &eventType) const
+{
+    if (eventType == QStringLiteral("mode")) {
+        return _assignColorForKey(QStringLiteral("event-mode"));
+    }
+    if (eventType == QStringLiteral("error")) {
+        return _assignColorForKey(QStringLiteral("event-error"));
+    }
+    if (eventType == QStringLiteral("event")) {
+        return _assignColorForKey(QStringLiteral("event-generic"));
+    }
+
+    return _assignColorForKey(QStringLiteral("event-other"));
+}
+
+QString LogViewerController::modeColor(const QString &modeName) const
+{
+    static const QStringList modePalette = {
+        QStringLiteral("#E53935"), // red
+        QStringLiteral("#FB8C00"), // orange
+        QStringLiteral("#FDD835"), // yellow
+        QStringLiteral("#43A047"), // green
+        QStringLiteral("#00897B"), // teal
+        QStringLiteral("#00ACC1"), // cyan
+        QStringLiteral("#1E88E5"), // blue
+        QStringLiteral("#5E35B1"), // indigo
+        QStringLiteral("#8E24AA"), // purple
+        QStringLiteral("#D81B60"), // pink
+        QStringLiteral("#6D4C41"), // brown
+        QStringLiteral("#546E7A"), // blue grey
+    };
+
+    quint32 hash = 0;
+    for (const QChar ch : modeName) {
+        hash = (hash * 31U) + ch.unicode();
+    }
+
+    const qsizetype idx = static_cast<qsizetype>(hash % static_cast<quint32>(modePalette.count()));
+    return modePalette[idx];
+}
+
+QStringList LogViewerController::modeLegendEntries(const QVariantList &modeSegments) const
+{
+    QStringList modes;
+    for (const QVariant &variant : modeSegments) {
+        const QVariantMap segment = variant.toMap();
+        const QString mode = segment.value(QStringLiteral("mode")).toString();
+        if (!mode.isEmpty() && !modes.contains(mode)) {
+            modes.append(mode);
+        }
+    }
+
+    return modes;
+}
+
+void LogViewerController::_setLog(SourceType sourceType, const QString &path, const QString &statusText)
+{
+    if (_sourceType != sourceType) {
+        _sourceType = sourceType;
+        emit sourceTypeChanged();
+    }
+
+    if (_currentLogPath != path) {
+        _currentLogPath = path;
+        emit currentLogPathChanged();
+    }
+
+    if (_statusText != statusText) {
+        _statusText = statusText;
+        emit statusTextChanged();
+    }
+
+    qCDebug(LogViewerControllerLog) << "sourceType" << static_cast<int>(_sourceType) << "path" << _currentLogPath;
+}
+
+void LogViewerController::_rebuildSignalRows()
+{
+    QHash<QString, QStringList> groupedMap;
+    QStringList groups;
+
+    for (const QString &signal : _plottableSignals) {
+        const int splitIndex = signal.indexOf('.');
+        const QString groupName = (splitIndex > 0) ? signal.left(splitIndex) : tr("Other");
+        const QString shortName = (splitIndex > 0) ? signal.mid(splitIndex + 1) : signal;
+        if (!groupedMap.contains(groupName)) {
+            groups.append(groupName);
+        }
+        groupedMap[groupName].append(shortName);
+    }
+
+    std::sort(groups.begin(), groups.end());
+
+    QVariantList rows;
+    for (const QString &groupName : groups) {
+        QVariantMap groupRow;
+        groupRow[QStringLiteral("rowType")] = QStringLiteral("group");
+        groupRow[QStringLiteral("group")] = groupName;
+        rows.append(groupRow);
+
+        if (!_expandedGroups.contains(groupName)) {
+            continue;
+        }
+
+        QStringList signalNames = groupedMap.value(groupName);
+        std::sort(signalNames.begin(), signalNames.end());
+        for (const QString &shortName : signalNames) {
+            QVariantMap signalRow;
+            signalRow[QStringLiteral("rowType")] = QStringLiteral("signal");
+            signalRow[QStringLiteral("group")] = groupName;
+            signalRow[QStringLiteral("shortName")] = shortName;
+            signalRow[QStringLiteral("fullName")] = QStringLiteral("%1.%2").arg(groupName, shortName);
+            rows.append(signalRow);
+        }
+    }
+
+    _signalRows = rows;
+    emit signalRowsChanged();
+}
+
+QString LogViewerController::_assignColorForKey(const QString &key) const
+{
+    static const QStringList palette = {
+        QStringLiteral("#3776D6"),
+        QStringLiteral("#D9534F"),
+        QStringLiteral("#3FA96B"),
+        QStringLiteral("#D98E04"),
+        QStringLiteral("#7B5CC9"),
+        QStringLiteral("#D64E8B"),
+        QStringLiteral("#2FA9A2"),
+        QStringLiteral("#D96A2D"),
+        QStringLiteral("#4A6CD4"),
+        QStringLiteral("#6EA827"),
+    };
+
+    quint32 hash = 0;
+    for (const QChar ch : key) {
+        hash = (hash * 31U) + ch.unicode();
+    }
+
+    const qsizetype idx = static_cast<qsizetype>(hash % static_cast<quint32>(palette.count()));
+    return palette[idx];
+}

--- a/src/AnalyzeView/LogViewer/LogViewerController.h
+++ b/src/AnalyzeView/LogViewer/LogViewerController.h
@@ -1,0 +1,75 @@
+#pragma once
+
+#include <QtCore/QObject>
+#include <QtCore/QSet>
+#include <QtCore/QString>
+#include <QtCore/QStringList>
+#include <QtCore/QVariantList>
+#include <QtQmlIntegration/QtQmlIntegration>
+
+class LogViewerController : public QObject
+{
+    Q_OBJECT
+    QML_ELEMENT
+
+    Q_PROPERTY(SourceType sourceType READ sourceType NOTIFY sourceTypeChanged)
+    Q_PROPERTY(QString currentLogPath READ currentLogPath NOTIFY currentLogPathChanged)
+    Q_PROPERTY(bool hasLoadedLog READ hasLoadedLog NOTIFY currentLogPathChanged)
+    Q_PROPERTY(QString statusText READ statusText NOTIFY statusTextChanged)
+    Q_PROPERTY(QVariantList signalRows READ signalRows NOTIFY signalRowsChanged)
+    Q_PROPERTY(QStringList selectedSignals READ selectedSignals NOTIFY selectedSignalsChanged)
+
+public:
+    enum class SourceType {
+        None,
+        TLog,
+        Bin,
+    };
+    Q_ENUM(SourceType)
+
+    explicit LogViewerController(QObject *parent = nullptr);
+    ~LogViewerController();
+
+    SourceType sourceType() const { return _sourceType; }
+    QString currentLogPath() const { return _currentLogPath; }
+    bool hasLoadedLog() const { return !_currentLogPath.isEmpty(); }
+    QString statusText() const { return _statusText; }
+    QVariantList signalRows() const { return _signalRows; }
+    QStringList selectedSignals() const { return _selectedSignals; }
+
+    Q_INVOKABLE void clear();
+    Q_INVOKABLE void openTLog(const QString &path);
+    Q_INVOKABLE void openBinLog(const QString &path);
+    Q_INVOKABLE void setPlottableSignals(const QStringList &signalNames);
+    Q_INVOKABLE void clearSelection();
+    Q_INVOKABLE void toggleGroupExpanded(const QString &groupName);
+    Q_INVOKABLE bool isGroupExpanded(const QString &groupName) const;
+    Q_INVOKABLE void setSignalSelected(const QString &signalName, bool selected);
+    Q_INVOKABLE bool isSignalSelected(const QString &signalName) const;
+    /// Returns a deterministic hash-based color for unselected signals.
+    /// For selected signals, QML assigns index-based colors from its own palette.
+    Q_INVOKABLE QString signalColor(const QString &signalName) const;
+    Q_INVOKABLE QString eventColor(const QString &eventType) const;
+    Q_INVOKABLE QString modeColor(const QString &modeName) const;
+    Q_INVOKABLE QStringList modeLegendEntries(const QVariantList &modeSegments) const;
+
+signals:
+    void sourceTypeChanged();
+    void currentLogPathChanged();
+    void statusTextChanged();
+    void signalRowsChanged();
+    void selectedSignalsChanged();
+
+private:
+    void _rebuildSignalRows();
+    QString _assignColorForKey(const QString &key) const;
+    void _setLog(SourceType sourceType, const QString &path, const QString &statusText);
+
+    SourceType _sourceType = SourceType::None;
+    QString _currentLogPath;
+    QString _statusText;
+    QStringList _plottableSignals;
+    QVariantList _signalRows;
+    QStringList _selectedSignals;
+    QSet<QString> _expandedGroups;
+};

--- a/src/AnalyzeView/LogViewer/LogViewerPage.qml
+++ b/src/AnalyzeView/LogViewer/LogViewerPage.qml
@@ -1,0 +1,1404 @@
+import QtQuick
+import QtQuick.Controls
+import QtQuick.Layouts
+import QtGraphs
+
+import QGroundControl
+import QGroundControl.Controls
+
+AnalyzePage {
+    id: logViewerPage
+    pageComponent: pageComponent
+    pageDescription: qsTr("Open and inspect DataFlash (.bin) and telemetry (.tlog) logs in a unified workflow.")
+
+    Component {
+        id: pageComponent
+
+        ColumnLayout {
+            width: availableWidth
+            height: availableHeight
+            spacing: ScreenTools.defaultFontPixelHeight
+
+            property bool binLoading: false
+            property string pendingBinFile: ""
+            property bool cursorVisible: false
+            property real cursorPixelX: 0
+            property real cursorXValue: 0
+            property real cursorPopupY: 0
+            property var cursorRows: []
+            property var cursorEventRows: []
+            property string cursorModeName: ""
+            property string signalSearchText: ""
+            property string parameterSearchText: ""
+            property var filteredSignalRows: []
+            property var filteredParameters: []
+            property real fullMinX: 0
+            property real fullMaxX: 1
+            property real zoomMinX: 0
+            property real zoomMaxX: 1
+
+            // Cap decimation to keep QtGraphs rendering below ~16ms per frame.
+            // Empirically, >~6000 points per series causes visible frame drops on mid-range hardware.
+            property int maxChartPointsPerSignal: 6000
+
+            // Visually distinct categorical palette for selected-signal series.
+            // Position-based picks avoid hash collisions producing similar colors.
+            readonly property var _signalChartColors: [
+                "#1E88E5", // blue
+                "#E53935", // red
+                "#43A047", // green
+                "#FB8C00", // orange
+                "#8E24AA", // purple
+                "#00ACC1", // cyan
+                "#FDD835", // yellow
+                "#D81B60", // pink
+                "#6D4C41", // brown
+                "#546E7A", // blue grey
+                "#3949AB", // indigo
+                "#00897B", // teal
+            ]
+
+            Component {
+                id: lineSeriesComponent
+
+                LineSeries { }
+            }
+
+            Component {
+                id: scatterSeriesComponent
+
+                ScatterSeries { }
+            }
+
+            function eventColor(eventType) {
+                return logViewerController.eventColor(eventType)
+            }
+
+            function eventTypeLabel(eventType) {
+                if (eventType === "mode") {
+                    return qsTr("Mode")
+                }
+                if (eventType === "event") {
+                    return qsTr("Event")
+                }
+                if (eventType === "error") {
+                    return qsTr("Error")
+                }
+                return eventType
+            }
+
+            function modeColor(modeName) {
+                return logViewerController.modeColor(String(modeName))
+            }
+
+            function modeLegendEntries() {
+                return logViewerController.modeLegendEntries(dataFlashParser.modeSegments)
+            }
+
+            function rebuildGroupedSignals() {
+                logViewerController.setPlottableSignals(dataFlashParser.plottableSignals)
+                applySignalFilter()
+            }
+
+            function applySignalFilter() {
+                const query = String(signalSearchText).trim().toLowerCase()
+                if (query.length === 0) {
+                    filteredSignalRows = logViewerController.signalRows
+                    return
+                }
+
+                const groupedMap = {}
+                const signals = dataFlashParser.plottableSignals
+                for (let i = 0; i < signals.length; i++) {
+                    const fullName = String(signals[i])
+                    const splitIndex = fullName.indexOf(".")
+                    const groupName = splitIndex > 0 ? fullName.substring(0, splitIndex) : qsTr("Other")
+                    const shortName = splitIndex > 0 ? fullName.substring(splitIndex + 1) : fullName
+                    const haystack = (fullName + " " + groupName + " " + shortName).toLowerCase()
+                    if (haystack.indexOf(query) === -1) {
+                        continue
+                    }
+
+                    if (!groupedMap[groupName]) {
+                        groupedMap[groupName] = []
+                    }
+                    groupedMap[groupName].push({ fullName: fullName, shortName: shortName })
+                }
+
+                const groups = Object.keys(groupedMap).sort()
+                const rows = []
+                for (let g = 0; g < groups.length; g++) {
+                    const groupName = groups[g]
+                    rows.push({ rowType: "group", group: groupName })
+                    groupedMap[groupName].sort((a, b) => String(a.shortName).localeCompare(String(b.shortName)))
+                    for (let s = 0; s < groupedMap[groupName].length; s++) {
+                        rows.push({
+                            rowType: "signal",
+                            group: groupName,
+                            fullName: groupedMap[groupName][s].fullName,
+                            shortName: groupedMap[groupName][s].shortName
+                        })
+                    }
+                }
+                filteredSignalRows = rows
+            }
+
+            function applyParameterFilter() {
+                const query = String(parameterSearchText).trim().toLowerCase()
+                if (query.length === 0) {
+                    filteredParameters = dataFlashParser.parameters
+                    return
+                }
+
+                const output = []
+                for (let i = 0; i < dataFlashParser.parameters.length; i++) {
+                    const item = dataFlashParser.parameters[i]
+                    const name = String(item.name)
+                    const value = String(item.value)
+                    if ((name + " " + value).toLowerCase().indexOf(query) !== -1) {
+                        output.push(item)
+                    }
+                }
+                filteredParameters = output
+            }
+
+            function isGroupExpanded(groupName) {
+                return logViewerController.isGroupExpanded(groupName)
+            }
+
+            function toggleGroupExpanded(groupName) {
+                if (String(signalSearchText).trim().length > 0) {
+                    return
+                }
+                logViewerController.toggleGroupExpanded(groupName)
+                applySignalFilter()
+            }
+
+            function isSignalSelected(signalName) {
+                return logViewerController.isSignalSelected(signalName)
+            }
+
+            function signalColor(signalName) {
+                const idx = logViewerController.selectedSignals.indexOf(signalName)
+                if (idx >= 0) {
+                    return _signalChartColors[idx % _signalChartColors.length]
+                }
+                return logViewerController.signalColor(signalName)
+            }
+
+            function applyZoomRange(minX, maxX) {
+                if (maxX <= minX) {
+                    return
+                }
+                zoomMinX = minX
+                zoomMaxX = maxX
+                binXAxis.min = zoomMinX
+                binXAxis.max = zoomMaxX
+            }
+
+            function resetZoom() {
+                applyZoomRange(fullMinX, fullMaxX)
+            }
+
+            function _pixelToAxisX(pixelX) {
+                const plotX = binChart.plotArea.x
+                const plotW = binChart.plotArea.width
+                if (plotW <= 0 || binXAxis.max <= binXAxis.min) {
+                    return binXAxis.min
+                }
+
+                const clampedPixel = Math.max(plotX, Math.min(plotX + plotW, pixelX))
+                const ratio = (clampedPixel - plotX) / plotW
+                return binXAxis.min + (ratio * (binXAxis.max - binXAxis.min))
+            }
+
+            function _axisXToPixel(xValue) {
+                const plotX = binChart.plotArea.x
+                const plotW = binChart.plotArea.width
+                if (plotW <= 0 || binXAxis.max <= binXAxis.min) {
+                    return plotX
+                }
+
+                const ratio = (xValue - binXAxis.min) / (binXAxis.max - binXAxis.min)
+                return plotX + (Math.max(0, Math.min(1, ratio)) * plotW)
+            }
+
+            function updateCursorInfo(pixelX, pixelY, width, height) {
+                const selectedSignals = logViewerController.selectedSignals
+                if (selectedSignals.length === 0 || width <= 0 || height <= 0) {
+                    cursorVisible = false
+                    return
+                }
+
+                cursorVisible = true
+                cursorPixelX = Math.max(binChart.plotArea.x, Math.min(binChart.plotArea.x + binChart.plotArea.width, pixelX))
+                cursorXValue = _pixelToAxisX(cursorPixelX)
+                cursorPopupY = Math.max(0, Math.min(height - (ScreenTools.defaultFontPixelHeight * 4), pixelY))
+                cursorModeName = dataFlashParser.modeAt(cursorXValue)
+
+                const rows = []
+                for (let i = 0; i < selectedSignals.length; i++) {
+                    const signal = selectedSignals[i]
+                    const value = dataFlashParser.signalValueAt(signal, cursorXValue)
+                    if (isNaN(value)) {
+                        continue
+                    }
+                    rows.push({
+                        name: signal,
+                        color: signalColor(signal),
+                        value: value
+                    })
+                }
+                cursorRows = rows
+
+                const threshold = Math.max(0.05, (binXAxis.max - binXAxis.min) / 200.0)
+                const nearbyEvents = dataFlashParser.eventsNear(cursorXValue, threshold)
+                const events = []
+                for (let i = 0; i < nearbyEvents.length; i++) {
+                    events.push({
+                        color: eventColor(nearbyEvents[i].type),
+                        text: nearbyEvents[i].description
+                    })
+                }
+                cursorEventRows = events
+            }
+
+            function clearLoadedLogState(clearControllerState) {
+                replayController.isPlaying = false
+                replayController.link = null
+                dataFlashParser.clear()
+                logViewerController.setPlottableSignals([])
+                logViewerController.clearSelection()
+                cursorEventRows = []
+                filteredSignalRows = []
+                filteredParameters = []
+                refreshBinChart()
+                if (clearControllerState) {
+                    logViewerController.clear()
+                }
+            }
+
+            function loadBinFile(file) {
+                if (logViewerController.hasLoadedLog) {
+                    // Match explicit "Clear" behavior before loading replacement .bin file.
+                    clearLoadedLogState(true)
+                }
+                pendingBinFile = file
+                binLoading = true
+                parseStartTimer.start()
+            }
+
+            function _executePendingBinParse() {
+                if (!pendingBinFile || pendingBinFile.length === 0) {
+                    binLoading = false
+                    return
+                }
+
+                const file = pendingBinFile
+                if (typeof dataFlashParser.parseFileAsync === "function") {
+                    dataFlashParser.parseFileAsync(file)
+                    return
+                }
+
+                // Compatibility fallback if async parser API is unavailable.
+                const ok = dataFlashParser.parseFile(file)
+                if (!ok) {
+                    QGroundControl.showMessageDialog(logViewerPage, qsTr("Log Viewer"), dataFlashParser.parseError)
+                    binLoading = false
+                    pendingBinFile = ""
+                    return
+                }
+
+                rebuildGroupedSignals()
+                applyParameterFilter()
+                logViewerController.clearSelection()
+                fullMinX = 0
+                fullMaxX = 1
+                zoomMinX = 0
+                zoomMaxX = 1
+                refreshBinChart()
+                logViewerController.openBinLog(file)
+                binLoading = false
+                pendingBinFile = ""
+            }
+
+            function refreshBinChart() {
+                while (binChart.seriesList.length > 0) {
+                    binChart.removeSeries(binChart.seriesList[0])
+                }
+
+                const selectedSignals = logViewerController.selectedSignals
+
+                // Empty selection: keep axes initialized and only show event markers.
+                if (selectedSignals.length === 0) {
+                    if (dataFlashParser.minTimestamp >= 0.0 && dataFlashParser.maxTimestamp > dataFlashParser.minTimestamp) {
+                        fullMinX = dataFlashParser.minTimestamp
+                        fullMaxX = dataFlashParser.maxTimestamp
+                    } else {
+                        fullMinX = 0
+                        fullMaxX = 1
+                    }
+                    zoomMinX = fullMinX
+                    zoomMaxX = fullMaxX
+                    binXAxis.min = zoomMinX
+                    binXAxis.max = zoomMaxX
+                    binYAxis.min = 0
+                    binYAxis.max = 1
+
+                    const emptySeries = lineSeriesComponent.createObject(binChart, {
+                        color: "transparent",
+                        width: 1,
+                        axisX: binXAxis,
+                        axisY: binYAxis
+                    })
+                    binChart.addSeries(emptySeries)
+                    emptySeries.visible = false
+
+                    const eventListNoSignals = dataFlashParser.events
+                    const eventSeriesByType = ({})
+                    for (let e = 0; e < eventListNoSignals.length; e++) {
+                        const event = eventListNoSignals[e]
+                        if (event.time < binXAxis.min || event.time > binXAxis.max) {
+                            continue
+                        }
+                        if (!eventSeriesByType[event.type]) {
+                            const eventSeries = scatterSeriesComponent.createObject(binChart, {
+                                color: eventColor(event.type),
+                                axisX: binXAxis,
+                                axisY: binYAxis
+                            })
+                            binChart.addSeries(eventSeries)
+                            eventSeriesByType[event.type] = eventSeries
+                        }
+                        eventSeriesByType[event.type].append(event.time, binYAxis.max)
+                    }
+                    binChart.update()
+                    Qt.callLater(_nudgeChartLayout)
+                    return
+                }
+
+                // First pass: collect decimated points per signal and compute axis ranges
+                // BEFORE creating series, so axes are stable when series are populated.
+                let minX = Number.MAX_VALUE
+                let maxX = -Number.MAX_VALUE
+                let minY = Number.MAX_VALUE
+                let maxY = -Number.MAX_VALUE
+                const decimatedPerSignal = []
+                for (let s = 0; s < selectedSignals.length; s++) {
+                    const signalName = selectedSignals[s]
+                    const points = dataFlashParser.signalSamples(signalName)
+                    if (!points || points.length === 0) {
+                        decimatedPerSignal.push(null)
+                        continue
+                    }
+
+                    const sampleStep = Math.max(1, Math.ceil(points.length / Math.max(1, maxChartPointsPerSignal)))
+                    const decimated = []
+                    let appendedLastX = -Number.MAX_VALUE
+                    for (let i = 0; i < points.length; i += sampleStep) {
+                        const p = points[i]
+                        decimated.push({ x: p.x, y: p.y })
+                        appendedLastX = p.x
+                        if (p.x < minX) { minX = p.x }
+                        if (p.x > maxX) { maxX = p.x }
+                        if (p.y < minY) { minY = p.y }
+                        if (p.y > maxY) { maxY = p.y }
+                    }
+                    if (sampleStep > 1) {
+                        const lastPoint = points[points.length - 1]
+                        if (lastPoint && lastPoint.x !== appendedLastX) {
+                            decimated.push({ x: lastPoint.x, y: lastPoint.y })
+                            if (lastPoint.x < minX) { minX = lastPoint.x }
+                            if (lastPoint.x > maxX) { maxX = lastPoint.x }
+                            if (lastPoint.y < minY) { minY = lastPoint.y }
+                            if (lastPoint.y > maxY) { maxY = lastPoint.y }
+                        }
+                    }
+                    decimatedPerSignal.push(decimated)
+                }
+
+                if (minX === Number.MAX_VALUE) {
+                    minX = 0
+                    maxX = 1
+                    minY = 0
+                    maxY = 1
+                } else if (minX === maxX) {
+                    maxX = minX + 1
+                }
+                if (minY === maxY) {
+                    maxY = minY + 1
+                }
+
+                // Set axes BEFORE creating/populating series so QtGraphs lays out
+                // the plot area correctly the first time and renders all series.
+                fullMinX = minX
+                fullMaxX = maxX
+                if (zoomMaxX <= zoomMinX || zoomMinX < fullMinX || zoomMaxX > fullMaxX) {
+                    zoomMinX = fullMinX
+                    zoomMaxX = fullMaxX
+                }
+                binXAxis.min = zoomMinX
+                binXAxis.max = zoomMaxX
+                binYAxis.min = minY
+                binYAxis.max = maxY
+
+                // Second pass: create one series per selected signal and feed points.
+                // Explicit axisX/axisY bind is required for QtGraphs LineSeries created
+                // dynamically; without it only the last-added series renders until the
+                // axes are mutated (e.g. by zooming).
+                for (let s = 0; s < selectedSignals.length; s++) {
+                    const decimated = decimatedPerSignal[s]
+                    if (!decimated || decimated.length === 0) {
+                        continue
+                    }
+
+                    const signalName = selectedSignals[s]
+                    const series = lineSeriesComponent.createObject(binChart, {
+                        color: signalColor(signalName),
+                        width: 2,
+                        axisX: binXAxis,
+                        axisY: binYAxis
+                    })
+                    binChart.addSeries(series)
+                    for (let i = 0; i < decimated.length; i++) {
+                        series.append(decimated[i].x, decimated[i].y)
+                    }
+                }
+
+                const eventList = dataFlashParser.events
+                const eventTypeSeries = ({})
+                for (let e = 0; e < eventList.length; e++) {
+                    const event = eventList[e]
+                    if (event.time < binXAxis.min || event.time > binXAxis.max) {
+                        continue
+                    }
+                    if (!eventTypeSeries[event.type]) {
+                        const eventSeries = scatterSeriesComponent.createObject(binChart, {
+                            color: eventColor(event.type),
+                            axisX: binXAxis,
+                            axisY: binYAxis
+                        })
+                        binChart.addSeries(eventSeries)
+                        eventTypeSeries[event.type] = eventSeries
+                    }
+                    eventTypeSeries[event.type].append(event.time, maxY)
+                }
+                binChart.update()
+
+                // QtGraphs sometimes only renders the most recently added series until
+                // the axis range changes. Re-applying the same range on the next event
+                // loop turn forces a re-layout for every series at once.
+                Qt.callLater(_nudgeChartLayout)
+            }
+
+            // Workaround for a QtGraphs bug: after dynamically adding multiple series,
+            // only the most recently added series renders until the axis range changes.
+            // Writing axis.max to (value + epsilon) then back to value on the next event-loop
+            // turn triggers the property-change notification twice, forcing a full re-layout.
+            // The factor 1e-9 is intentional: small enough to be imperceptible on any realistic
+            // axis range (up to ~10^9 s), yet large enough to produce a distinct double value
+            // that passes Qt's property-change equality check.
+            function _nudgeChartLayout() {
+                const xMax = binXAxis.max
+                const xMin = binXAxis.min
+                const yMax = binYAxis.max
+                const yMin = binYAxis.min
+                if (xMax <= xMin || yMax <= yMin) {
+                    return
+                }
+                const xEpsilon = (xMax - xMin) * 1e-9
+                const yEpsilon = (yMax - yMin) * 1e-9
+                binXAxis.max = xMax + xEpsilon
+                binXAxis.max = xMax
+                binYAxis.max = yMax + yEpsilon
+                binYAxis.max = yMax
+                binChart.update()
+            }
+
+            LogViewerController {
+                id: logViewerController
+            }
+
+            APMDataFlashLogParser {
+                id: dataFlashParser
+            }
+
+            Connections {
+                target: logViewerController
+                function onSignalRowsChanged() {
+                    applySignalFilter()
+                }
+                function onSelectedSignalsChanged() {
+                    Qt.callLater(refreshBinChart)
+                }
+            }
+
+            Connections {
+                target: dataFlashParser
+                ignoreUnknownSignals: true
+
+                function onParseFileFinished(filePath, ok, errorMessage) {
+                    if (filePath !== pendingBinFile) {
+                        return
+                    }
+
+                    if (!ok) {
+                        QGroundControl.showMessageDialog(logViewerPage, qsTr("Log Viewer"), errorMessage)
+                        binLoading = false
+                        pendingBinFile = ""
+                        return
+                    }
+
+                    rebuildGroupedSignals()
+                    applyParameterFilter()
+                    logViewerController.clearSelection()
+                    fullMinX = 0
+                    fullMaxX = 1
+                    zoomMinX = 0
+                    zoomMaxX = 1
+                    refreshBinChart()
+                    logViewerController.openBinLog(filePath)
+                    binLoading = false
+                    pendingBinFile = ""
+                }
+            }
+
+            LogReplayLinkController {
+                id: replayController
+            }
+
+            RowLayout {
+                Layout.fillWidth: true
+                spacing: ScreenTools.defaultFontPixelWidth
+
+                QGCButton {
+                    text: qsTr("Open .bin")
+                    onClicked: {
+                        openDialog.nameFilters = ["DataFlash Logs (*.bin *.BIN *.log *.LOG)"]
+                        openDialog.openForLoad()
+                    }
+                }
+
+                QGCButton {
+                    text: qsTr("Open .tlog")
+                    onClicked: {
+                        const activeVehicle = QGroundControl.multiVehicleManager.activeVehicle
+                        if (activeVehicle && !activeVehicle.isOfflineEditingVehicle) {
+                            QGroundControl.showMessageDialog(logViewerPage, qsTr("Log Viewer"), qsTr("Close active vehicle connections before starting telemetry replay."))
+                            return
+                        }
+                        openDialog.nameFilters = ["Telemetry Logs (*.tlog *.TLOG)"]
+                        openDialog.openForLoad()
+                    }
+                }
+
+                QGCButton {
+                    text: qsTr("Clear")
+                    enabled: logViewerController.hasLoadedLog
+                    onClicked: {
+                        clearLoadedLogState(true)
+                    }
+                }
+
+                QGCLabel {
+                    Layout.fillWidth: true
+                    elide: Text.ElideMiddle
+                    text: logViewerController.hasLoadedLog ? logViewerController.currentLogPath : qsTr("No log selected")
+                }
+            }
+
+            RowLayout {
+                Layout.fillWidth: true
+                visible: logViewerController.sourceType === LogViewerController.TLog && replayController.link
+                spacing: ScreenTools.defaultFontPixelWidth
+
+                QGCButton {
+                    text: replayController.isPlaying ? qsTr("Pause") : qsTr("Play")
+                    onClicked: replayController.isPlaying = !replayController.isPlaying
+                }
+
+                QGCComboBox {
+                    textRole: "text"
+                    currentIndex: 3
+
+                    model: ListModel {
+                        ListElement { text: "0.1x"; value: 0.1 }
+                        ListElement { text: "0.25x"; value: 0.25 }
+                        ListElement { text: "0.5x"; value: 0.5 }
+                        ListElement { text: "1x"; value: 1.0 }
+                        ListElement { text: "2x"; value: 2.0 }
+                        ListElement { text: "5x"; value: 5.0 }
+                        ListElement { text: "10x"; value: 10.0 }
+                    }
+
+                    onActivated: (index) => replayController.playbackSpeed = model.get(index).value
+                }
+
+                QGCLabel { text: replayController.playheadTime }
+
+                Slider {
+                    id: replaySlider
+                    Layout.fillWidth: true
+                    from: 0
+                    to: 100
+
+                    property bool _internalUpdate: false
+
+                    Connections {
+                        target: replayController
+                        function onPercentCompleteChanged(percentComplete) {
+                            replaySlider._internalUpdate = true
+                            replaySlider.value = percentComplete
+                            replaySlider._internalUpdate = false
+                        }
+                    }
+
+                    onValueChanged: {
+                        if (!_internalUpdate) {
+                            replayController.percentComplete = value
+                        }
+                    }
+                }
+
+                QGCLabel { text: replayController.totalTime }
+            }
+
+            RowLayout {
+                Layout.fillWidth: true
+                Layout.fillHeight: true
+                spacing: ScreenTools.defaultFontPixelWidth
+
+                Rectangle {
+                    Layout.preferredWidth: availableWidth * 0.25
+                    Layout.fillHeight: true
+                    color: qgcPal.windowShade
+                    radius: ScreenTools.defaultFontPixelWidth * 0.5
+
+                    ColumnLayout {
+                        anchors.fill: parent
+                        anchors.margins: ScreenTools.defaultFontPixelWidth
+                        spacing: ScreenTools.defaultFontPixelHeight * 0.5
+
+                        QGCLabel {
+                            text: qsTr("Messages / Parameters")
+                            font.bold: true
+                        }
+
+                        QGCLabel {
+                            Layout.fillWidth: true
+                            wrapMode: Text.WordWrap
+                            maximumLineCount: 3
+                            text: logViewerController.sourceType === LogViewerController.Bin
+                                  ? qsTr("DataFlash message and parameter browser will appear here.")
+                                  : qsTr("For telemetry replay, MAVLink message and field selection is available through the Inspector integration.")
+                        }
+
+                        QGCLabel {
+                            visible: logViewerController.sourceType === LogViewerController.Bin
+                            text: qsTr("Signals: %1  Parameters: %2  Events: %3")
+                                  .arg(dataFlashParser.plottableSignals.length)
+                                  .arg(dataFlashParser.parameters.length)
+                                  .arg(dataFlashParser.events.length)
+                        }
+
+                        QGCLabel {
+                            visible: logViewerController.sourceType === LogViewerController.Bin
+                            text: qsTr("Detected vehicle type: %1")
+                                  .arg(dataFlashParser.detectedVehicleType.length > 0
+                                       ? dataFlashParser.detectedVehicleType
+                                       : qsTr("Unknown"))
+                        }
+
+                        RowLayout {
+                            Layout.fillWidth: true
+                            visible: logViewerController.sourceType === LogViewerController.Bin
+                            spacing: ScreenTools.defaultFontPixelWidth * 0.5
+
+                            QGCLabel {
+                                text: qsTr("Signals (click to plot)")
+                                font.bold: true
+                            }
+
+                            QGCTextField {
+                                id: signalSearchField
+                                Layout.fillWidth: true
+                                textColor: qgcPal.textFieldText
+                                placeholderTextColor: Qt.rgba(qgcPal.textFieldText.r, qgcPal.textFieldText.g, qgcPal.textFieldText.b, 0.7)
+                                placeholderText: qsTr("Search signals")
+                                onTextChanged: {
+                                    signalSearchText = text
+                                    if (text.trim().length === 0) {
+                                        signalSearchTimer.stop()
+                                        applySignalFilter()
+                                    } else {
+                                        signalSearchTimer.restart()
+                                    }
+                                }
+                                onAccepted: {
+                                    signalSearchText = text
+                                    signalSearchTimer.stop()
+                                    applySignalFilter()
+                                }
+                            }
+
+                            QGCButton {
+                                text: qsTr("Clear Selected")
+                                horizontalAlignment: Text.AlignHCenter
+                                Layout.preferredHeight: signalSearchField.implicitHeight
+                                Layout.minimumHeight: signalSearchField.implicitHeight
+                                topPadding: 0
+                                bottomPadding: 0
+                                enabled: logViewerController.selectedSignals.length > 0
+                                onClicked: {
+                                    logViewerController.clearSelection()
+                                    applySignalFilter()
+                                    refreshBinChart()
+                                }
+                            }
+                        }
+
+                        ScrollView {
+                            id: signalsScroll
+                            Layout.fillWidth: true
+                            Layout.preferredHeight: parent.height * 0.35
+                            visible: logViewerController.sourceType === LogViewerController.Bin
+                            clip: true
+
+                            ListView {
+                                id: signalsListView
+                                anchors.fill: parent
+                                model: filteredSignalRows
+                                spacing: ScreenTools.defaultFontPixelHeight * 0.15
+                                clip: true
+                                ScrollBar.vertical: ScrollBar { }
+
+                                delegate: Item {
+                                    width: signalsListView.width
+                                    height: (modelData.rowType === "group")
+                                            ? (groupRect.implicitHeight + (ScreenTools.defaultFontPixelHeight * 0.1))
+                                            : (signalRow.implicitHeight + (ScreenTools.defaultFontPixelHeight * 0.1))
+
+                                    Rectangle {
+                                        id: groupRect
+                                        visible: modelData.rowType === "group"
+                                        width: parent.width
+                                        implicitHeight: groupLabel.implicitHeight + (ScreenTools.defaultFontPixelHeight * 0.35)
+                                        color: qgcPal.windowShadeDark
+                                        radius: ScreenTools.defaultFontPixelWidth * 0.25
+
+                                        Row {
+                                            anchors.fill: parent
+                                            anchors.leftMargin: ScreenTools.defaultFontPixelWidth * 0.2
+                                            anchors.verticalCenter: parent.verticalCenter
+                                            spacing: ScreenTools.defaultFontPixelWidth * 0.3
+
+                                            QGCLabel { text: (String(signalSearchText).trim().length > 0) ? "▼" : (isGroupExpanded(modelData.group) ? "▼" : "▶") }
+                                            QGCLabel { id: groupLabel; text: modelData.group; font.bold: true }
+                                        }
+
+                                        MouseArea {
+                                            anchors.fill: parent
+                                            onClicked: toggleGroupExpanded(modelData.group)
+                                        }
+                                    }
+
+                                    Row {
+                                        id: signalRow
+                                        visible: modelData.rowType === "signal"
+                                        width: parent.width
+                                        height: Math.max(signalNameLabel.implicitHeight, signalCheckBox.implicitHeight)
+                                        spacing: ScreenTools.defaultFontPixelWidth * 0.25
+
+                                        QGCCheckBox {
+                                            id: signalCheckBox
+                                            anchors.verticalCenter: parent.verticalCenter
+                                            onClicked: logViewerController.setSignalSelected(modelData.fullName, checked)
+                                            checked: logViewerController.selectedSignals.indexOf(modelData.fullName) !== -1
+                                        }
+
+                                        QGCLabel {
+                                            id: signalNameLabel
+                                            anchors.verticalCenter: parent.verticalCenter
+                                            width: Math.max(0, parent.width - (ScreenTools.defaultFontPixelWidth * 3))
+                                            height: Math.max(implicitHeight, ScreenTools.defaultFontPixelHeight * 1.2)
+                                            wrapMode: Text.WordWrap
+                                            maximumLineCount: 2
+                                            verticalAlignment: Text.AlignVCenter
+                                            text: modelData.shortName ? String(modelData.shortName) : ""
+                                            color: isSignalSelected(modelData.fullName) ? signalColor(modelData.fullName) : qgcPal.text
+                                        }
+                                    }
+                                }
+                            }
+                        }
+
+                        Rectangle {
+                            Layout.fillWidth: true
+                            Layout.preferredHeight: 1
+                            color: qgcPal.windowShadeDark
+                            visible: logViewerController.sourceType === LogViewerController.Bin
+                        }
+
+                        QGCTabBar {
+                            id: dataTabBar
+                            Layout.fillWidth: true
+                            visible: logViewerController.sourceType === LogViewerController.Bin
+
+                            QGCTabButton {
+                                text: qsTr("Parameters")
+                                checked: true
+                            }
+
+                            QGCTabButton {
+                                text: qsTr("Messages")
+                                checked: false
+                            }
+                        }
+
+                        QGCTextField {
+                            id: parameterSearchField
+                            Layout.fillWidth: true
+                            visible: logViewerController.sourceType === LogViewerController.Bin && dataTabBar.currentIndex === 0
+                            textColor: qgcPal.textFieldText
+                            placeholderTextColor: Qt.rgba(qgcPal.textFieldText.r, qgcPal.textFieldText.g, qgcPal.textFieldText.b, 0.7)
+                            placeholderText: qsTr("Search parameters")
+                            onTextChanged: {
+                                parameterSearchText = text
+                                if (text.trim().length === 0) {
+                                    parameterSearchTimer.stop()
+                                    applyParameterFilter()
+                                } else {
+                                    parameterSearchTimer.restart()
+                                }
+                            }
+                            onAccepted: {
+                                parameterSearchText = text
+                                parameterSearchTimer.stop()
+                                applyParameterFilter()
+                            }
+                        }
+
+                        ScrollView {
+                            Layout.fillWidth: true
+                            Layout.fillHeight: true
+                            Layout.minimumHeight: 0
+                            visible: logViewerController.sourceType === LogViewerController.Bin && dataTabBar.currentIndex === 0
+                            clip: true
+
+                            ListView {
+                                id: parametersListView
+                                anchors.fill: parent
+                                model: filteredParameters
+                                spacing: ScreenTools.defaultFontPixelHeight * 0.2
+                                clip: true
+                                ScrollBar.vertical: ScrollBar { }
+
+                                delegate: QGCLabel {
+                                    width: ListView.view.width
+                                    wrapMode: Text.WordWrap
+                                    maximumLineCount: 2
+                                    text: modelData.name + " = " + modelData.value
+                                }
+                            }
+                        }
+
+                        ScrollView {
+                            Layout.fillWidth: true
+                            Layout.fillHeight: true
+                            Layout.minimumHeight: 0
+                            visible: logViewerController.sourceType === LogViewerController.Bin && dataTabBar.currentIndex === 1
+                            clip: true
+
+                            ListView {
+                                id: messagesListView
+                                anchors.fill: parent
+                                model: dataFlashParser.messages
+                                spacing: ScreenTools.defaultFontPixelHeight * 0.2
+                                clip: true
+                                ScrollBar.vertical: ScrollBar { }
+
+                                delegate: QGCLabel {
+                                    width: ListView.view.width
+                                    wrapMode: Text.WordWrap
+                                    maximumLineCount: 3
+                                    text: {
+                                        const t = Number(modelData.time)
+                                        const prefix = isNaN(t) || t < 0 ? "" : ("[" + t.toFixed(3) + "s] ")
+                                        return prefix + String(modelData.text)
+                                    }
+                                }
+                            }
+                        }
+
+                    }
+                }
+
+                Rectangle {
+                    Layout.fillWidth: true
+                    Layout.fillHeight: true
+                    color: qgcPal.windowShadeDark
+                    radius: ScreenTools.defaultFontPixelWidth * 0.5
+
+                    ColumnLayout {
+                        anchors.fill: parent
+                        anchors.margins: ScreenTools.defaultFontPixelWidth
+                        spacing: ScreenTools.defaultFontPixelHeight * 0.5
+
+                        QGCLabel {
+                            text: qsTr("Charts and Timeline")
+                            font.bold: true
+                        }
+
+                        QGCLabel {
+                            Layout.fillWidth: true
+                            wrapMode: Text.WordWrap
+                            maximumLineCount: 2
+                            text: qsTr("Multi-series charts, event markers, and timeline controls are shown here.")
+                            visible: logViewerController.sourceType !== LogViewerController.TLog
+                        }
+
+                        Item {
+                            id: chartContainer
+                            Layout.fillWidth: true
+                            Layout.fillHeight: true
+                            Layout.preferredHeight: parent.height * 0.72
+                            visible: logViewerController.sourceType === LogViewerController.Bin
+
+                            GraphsView {
+                                id: binChart
+                                anchors.fill: parent
+                                marginTop: 0
+                                marginRight: 0
+                                marginBottom: 0
+                                marginLeft: 0
+
+                                theme: GraphsTheme {
+                                    colorScheme: qgcPal.globalTheme === QGCPalette.Light ? GraphsTheme.ColorScheme.Light : GraphsTheme.ColorScheme.Dark
+                                    backgroundColor: qgcPal.windowShadeDark
+                                    backgroundVisible: true
+                                    plotAreaBackgroundColor: qgcPal.windowShadeDark
+                                    grid.mainColor: Qt.rgba(qgcPal.text.r, qgcPal.text.g, qgcPal.text.b, 0.25)
+                                    grid.subColor: Qt.rgba(qgcPal.text.r, qgcPal.text.g, qgcPal.text.b, 0.12)
+                                    grid.mainWidth: 1
+                                    labelBackgroundVisible: false
+                                    labelTextColor: qgcPal.text
+                                    axisXLabelFont.family: ScreenTools.fixedFontFamily
+                                    axisXLabelFont.pointSize: ScreenTools.smallFontPointSize
+                                    axisYLabelFont.family: ScreenTools.fixedFontFamily
+                                    axisYLabelFont.pointSize: ScreenTools.smallFontPointSize
+                                }
+
+                                axisX: ValueAxis {
+                                    id: binXAxis
+                                    titleText: qsTr("Time (s)")
+                                    min: 0
+                                    max: 1
+                                }
+
+                                axisY: ValueAxis {
+                                    id: binYAxis
+                                    titleText: qsTr("Value")
+                                    min: 0
+                                    max: 1
+                                }
+                            }
+
+                            Rectangle {
+                                id: zoomSelectionRect
+                                visible: false
+                                color: Qt.rgba(1, 1, 1, 0.2)
+                                border.color: qgcPal.buttonHighlight
+                                border.width: 1
+                                z: 1000
+                            }
+
+                            MouseArea {
+                                id: chartZoomArea
+                                anchors.fill: parent
+                                enabled: logViewerController.sourceType === LogViewerController.Bin && (binXAxis.max > binXAxis.min)
+                                hoverEnabled: true
+                                acceptedButtons: Qt.LeftButton | Qt.RightButton
+                                z: 1001
+
+                                property real _dragStartX: 0
+
+                                onPressed: (mouse) => {
+                                    if (mouse.button === Qt.RightButton) {
+                                        resetZoom()
+                                        return
+                                    }
+                                    _dragStartX = mouse.x
+                                    zoomSelectionRect.x = mouse.x
+                                    zoomSelectionRect.y = 0
+                                    zoomSelectionRect.width = 0
+                                    zoomSelectionRect.height = height
+                                    zoomSelectionRect.visible = true
+                                    updateCursorInfo(mouse.x, mouse.y, width, height)
+                                }
+
+                                onPositionChanged: (mouse) => {
+                                    if (pressed && zoomSelectionRect.visible) {
+                                        const left = Math.min(_dragStartX, mouse.x)
+                                        const right = Math.max(_dragStartX, mouse.x)
+                                        zoomSelectionRect.x = left
+                                        zoomSelectionRect.width = Math.max(0, right - left)
+                                        return
+                                    }
+
+                                    if (!pressed) {
+                                        updateCursorInfo(mouse.x, mouse.y, width, height)
+                                        return
+                                    }
+                                }
+
+                                onReleased: (mouse) => {
+                                    if (!zoomSelectionRect.visible) {
+                                        return
+                                    }
+
+                                    const dragWidth = zoomSelectionRect.width
+                                    zoomSelectionRect.visible = false
+                                    // Treat drags narrower than half a character width as accidental clicks, not zoom gestures.
+                                    if (dragWidth < ScreenTools.defaultFontPixelWidth * 0.5) {
+                                        return
+                                    }
+
+                                    const leftX = _pixelToAxisX(zoomSelectionRect.x)
+                                    const rightX = _pixelToAxisX(zoomSelectionRect.x + zoomSelectionRect.width)
+                                    applyZoomRange(Math.min(leftX, rightX), Math.max(leftX, rightX))
+                                    updateCursorInfo(mouse.x, mouse.y, width, height)
+                                }
+
+                                onExited: {
+                                    cursorVisible = false
+                                }
+                            }
+
+                            Rectangle {
+                                visible: cursorVisible && logViewerController.sourceType === LogViewerController.Bin
+                                x: cursorPixelX
+                                y: binChart.plotArea.y
+                                width: 1
+                                height: binChart.plotArea.height
+                                color: qgcPal.buttonHighlight
+                                z: 1002
+                            }
+
+                            Rectangle {
+                                id: cursorPopup
+                                visible: cursorVisible && cursorRows.length > 0 && logViewerController.sourceType === LogViewerController.Bin
+                                x: Math.max(0, Math.min(chartContainer.width - width, cursorPixelX + ScreenTools.defaultFontPixelWidth))
+                                y: cursorPopupY
+                                width: ScreenTools.defaultFontPixelWidth * 30
+                                color: qgcPal.windowShade
+                                border.color: qgcPal.windowShadeDark
+                                radius: ScreenTools.defaultFontPixelWidth * 0.3
+                                z: 1003
+                                implicitHeight: cursorColumn.implicitHeight + (ScreenTools.defaultFontPixelHeight * 0.6)
+
+                                Column {
+                                    id: cursorColumn
+                                    anchors.fill: parent
+                                    anchors.margins: ScreenTools.defaultFontPixelHeight * 0.3
+                                    spacing: ScreenTools.defaultFontPixelHeight * 0.2
+
+                                    QGCLabel {
+                                        text: qsTr("t=%1 s").arg(cursorXValue.toFixed(3))
+                                        font.bold: true
+                                    }
+
+                                    QGCLabel {
+                                        visible: cursorModeName.length > 0
+                                        text: qsTr("Mode: %1").arg(cursorModeName)
+                                        font.bold: true
+                                        color: cursorModeName.length > 0 ? modeColor(cursorModeName) : qgcPal.text
+                                    }
+
+                                    Repeater {
+                                        model: cursorRows
+
+                                        Row {
+                                            spacing: ScreenTools.defaultFontPixelWidth * 0.2
+
+                                            Rectangle {
+                                                width: ScreenTools.defaultFontPixelWidth * 0.8
+                                                height: ScreenTools.defaultFontPixelHeight * 0.6
+                                                color: modelData.color
+                                            }
+
+                                            QGCLabel {
+                                                width: cursorPopup.width - (ScreenTools.defaultFontPixelWidth * 4)
+                                                elide: Text.ElideMiddle
+                                                text: modelData.name + ": " + Number(modelData.value).toFixed(3)
+                                            }
+                                        }
+                                    }
+
+                                    Repeater {
+                                        model: cursorEventRows
+
+                                        Row {
+                                            spacing: ScreenTools.defaultFontPixelWidth * 0.2
+
+                                            Rectangle {
+                                                width: ScreenTools.defaultFontPixelWidth * 0.8
+                                                height: ScreenTools.defaultFontPixelHeight * 0.6
+                                                color: modelData.color
+                                            }
+
+                                            QGCLabel {
+                                                width: cursorPopup.width - (ScreenTools.defaultFontPixelWidth * 4)
+                                                wrapMode: Text.WordWrap
+                                                maximumLineCount: 2
+                                                text: modelData.text
+                                            }
+                                        }
+                                    }
+                                }
+                            }
+                        }
+
+                        Rectangle {
+                            Layout.fillWidth: true
+                            Layout.preferredHeight: ScreenTools.defaultFontPixelHeight * 0.6
+                            visible: logViewerController.sourceType === LogViewerController.Bin
+                            color: qgcPal.windowShade
+
+                            Repeater {
+                                model: dataFlashParser.modeSegments
+
+                                Rectangle {
+                                    visible: binXAxis.max > binXAxis.min && modelData.end >= binXAxis.min && modelData.start <= binXAxis.max
+                                    y: 0
+                                    height: parent.height
+                                    color: modeColor(modelData.mode)
+                                    opacity: 1.0
+                                    x: Math.max(binChart.plotArea.x,
+                                                Math.min(binChart.plotArea.x + binChart.plotArea.width,
+                                                         binChart.plotArea.x + ((Math.max(modelData.start, binXAxis.min) - binXAxis.min) / (binXAxis.max - binXAxis.min)) * binChart.plotArea.width))
+                                    width: Math.max(1, ((Math.min(modelData.end, binXAxis.max) - Math.max(modelData.start, binXAxis.min)) / (binXAxis.max - binXAxis.min)) * binChart.plotArea.width)
+                                }
+                            }
+
+                            Repeater {
+                                model: dataFlashParser.events
+
+                                Rectangle {
+                                    width: 2
+                                    height: parent.height
+                                    visible: binXAxis.max > binXAxis.min
+                                    color: eventColor(modelData.type)
+                                    x: Math.max(binChart.plotArea.x,
+                                                Math.min((binChart.plotArea.x + binChart.plotArea.width) - width,
+                                                         binChart.plotArea.x + ((modelData.time - binXAxis.min) / (binXAxis.max - binXAxis.min)) * binChart.plotArea.width))
+                                }
+                            }
+                        }
+
+                        Row {
+                            Layout.fillWidth: true
+                            visible: logViewerController.sourceType === LogViewerController.Bin && modeLegendEntries().length > 0
+                            Layout.preferredHeight: ScreenTools.defaultFontPixelHeight * 1.1
+                            spacing: ScreenTools.defaultFontPixelWidth
+
+                            QGCLabel {
+                                text: qsTr("Modes:")
+                                font.bold: true
+                            }
+
+                            Repeater {
+                                model: modeLegendEntries()
+
+                                Row {
+                                    spacing: ScreenTools.defaultFontPixelWidth * 0.2
+
+                                    Rectangle {
+                                        width: ScreenTools.defaultFontPixelWidth
+                                        height: ScreenTools.defaultFontPixelHeight * 0.6
+                                        color: modeColor(modelData)
+                                    }
+
+                                    QGCLabel {
+                                        text: eventTypeLabel(modelData)
+                                    }
+                                }
+                            }
+                        }
+
+                        Row {
+                            Layout.fillWidth: true
+                            visible: logViewerController.sourceType === LogViewerController.Bin && logViewerController.selectedSignals.length > 0
+                            Layout.preferredHeight: ScreenTools.defaultFontPixelHeight * 1.1
+                            spacing: ScreenTools.defaultFontPixelWidth
+
+                            QGCLabel {
+                                text: qsTr("Signals:")
+                                font.bold: true
+                            }
+
+                            Repeater {
+                                model: logViewerController.selectedSignals
+
+                                Row {
+                                    spacing: ScreenTools.defaultFontPixelWidth * 0.2
+
+                                    Rectangle {
+                                        width: ScreenTools.defaultFontPixelWidth
+                                        height: ScreenTools.defaultFontPixelHeight * 0.6
+                                        color: signalColor(modelData)
+                                    }
+
+                                    QGCLabel {
+                                        text: modelData
+                                    }
+                                }
+                            }
+                        }
+
+                        Row {
+                            Layout.fillWidth: true
+                            visible: logViewerController.sourceType === LogViewerController.Bin && dataFlashParser.events.length > 0
+                            Layout.preferredHeight: ScreenTools.defaultFontPixelHeight * 1.1
+                            spacing: ScreenTools.defaultFontPixelWidth
+
+                            QGCLabel {
+                                text: qsTr("Events:")
+                                font.bold: true
+                            }
+
+                            Repeater {
+                                model: ["mode", "event", "error"]
+
+                                Row {
+                                    spacing: ScreenTools.defaultFontPixelWidth * 0.2
+                                    visible: {
+                                        for (let i = 0; i < dataFlashParser.events.length; i++) {
+                                            if (dataFlashParser.events[i].type === modelData) {
+                                                return true
+                                            }
+                                        }
+                                        return false
+                                    }
+
+                                    Rectangle {
+                                        width: ScreenTools.defaultFontPixelWidth
+                                        height: ScreenTools.defaultFontPixelHeight * 0.6
+                                        color: eventColor(modelData)
+                                    }
+
+                                    QGCLabel {
+                                        text: modelData
+                                    }
+                                }
+                            }
+                        }
+
+                        RowLayout {
+                            Layout.fillWidth: true
+                            visible: logViewerController.sourceType === LogViewerController.Bin
+                            spacing: ScreenTools.defaultFontPixelWidth
+
+                            QGCLabel {
+                                Layout.fillWidth: true
+                                text: qsTr("Drag on chart to zoom X-axis. Right click chart to reset zoom.")
+                            }
+
+                            QGCButton {
+                                text: qsTr("Reset Zoom")
+                                enabled: zoomMinX !== fullMinX || zoomMaxX !== fullMaxX
+                                onClicked: resetZoom()
+                            }
+                        }
+
+                        Loader {
+                            Layout.fillWidth: true
+                            Layout.fillHeight: true
+                            active: logViewerController.sourceType === LogViewerController.TLog
+                            source: "qrc:/qml/QGroundControl/AnalyzeView/MAVLinkInspector/MAVLinkInspectorPage.qml"
+                        }
+                    }
+                }
+            }
+
+            QGCLabel {
+                Layout.fillWidth: true
+                text: logViewerController.statusText
+                visible: text.length > 0
+            }
+
+            QGCFileDialog {
+                id: openDialog
+                title: qsTr("Select log file")
+                folder: QGroundControl.settingsManager.appSettings.logSavePath
+                selectFolder: false
+
+                onAcceptedForLoad: (file) => {
+                    const fileLower = file.toLowerCase()
+                    if (fileLower.endsWith(".tlog")) {
+                        if (logViewerController.hasLoadedLog) {
+                            clearLoadedLogState(true)
+                        }
+                        const replayLink = QGroundControl.linkManager.startLogReplay(file)
+                        if (!replayLink) {
+                            QGroundControl.showMessageDialog(
+                                logViewerPage,
+                                qsTr("Log Viewer"),
+                                qsTr("Failed to start telemetry replay for the selected .tlog file.")
+                            )
+                            close()
+                            return
+                        }
+                        replayController.link = replayLink
+                        logViewerController.openTLog(file)
+                    } else {
+                        loadBinFile(file)
+                    }
+                    close()
+                }
+            }
+
+            Rectangle {
+                Layout.fillWidth: true
+                Layout.fillHeight: true
+                visible: binLoading
+                color: Qt.rgba(0, 0, 0, 0.4)
+                z: 5000
+
+                Column {
+                    anchors.centerIn: parent
+                    spacing: ScreenTools.defaultFontPixelHeight * 0.5
+
+                    BusyIndicator {
+                        anchors.horizontalCenter: parent.horizontalCenter
+                        running: binLoading
+                    }
+
+                    QGCLabel {
+                        text: qsTr("Parsing log file...")
+                    }
+                }
+            }
+
+            Timer {
+                id: parseStartTimer
+                interval: 50
+                repeat: false
+                onTriggered: _executePendingBinParse()
+            }
+
+            Timer {
+                id: signalSearchTimer
+                interval: 250
+                repeat: false
+                onTriggered: applySignalFilter()
+            }
+
+            Timer {
+                id: parameterSearchTimer
+                interval: 250
+                repeat: false
+                onTriggered: applyParameterFilter()
+            }
+        }
+    }
+}

--- a/src/AnalyzeView/LogViewer/LoggingSetupPage.qml
+++ b/src/AnalyzeView/LogViewer/LoggingSetupPage.qml
@@ -1,0 +1,135 @@
+import QtQuick
+import QtQuick.Controls
+import QtQuick.Layouts
+
+import QGroundControl
+import QGroundControl.Controls
+import QGroundControl.FactControls
+
+AnalyzePage {
+    id: loggingSetupPage
+    pageComponent: pageComponent
+    pageDescription: qsTr("Configure ArduPilot logging parameters, then follow download and troubleshooting guidance.")
+
+    FactPanelController {
+        id: controller
+    }
+
+    Component {
+        id: pageComponent
+
+        QGCFlickable {
+            width: availableWidth
+            height: availableHeight
+            contentHeight: contentColumn.height
+            contentWidth: contentColumn.width
+
+            ColumnLayout {
+                id: contentColumn
+                width: availableWidth
+                spacing: ScreenTools.defaultFontPixelHeight
+
+                Repeater {
+                    model: [
+                        { param: "LOG_BACKEND_TYPE", desc: qsTr("Where logs are stored (SD, MAVLink stream, onboard flash).") },
+                        { param: "LOG_BITMASK", desc: qsTr("What data groups are included in the log.") },
+                        { param: "LOG_DISARMED", desc: qsTr("Enable disarmed logging for pre-arm and replay diagnostics.") },
+                        { param: "LOG_FILE_DSRMROT", desc: qsTr("Rotate log file after disarm/rearm sequence.") },
+                        { param: "LOG_FILE_MB_FREE", desc: qsTr("Minimum free space to keep available before logging.") },
+                        { param: "LOG_FILE_RATEMAX", desc: qsTr("Limit file logging rate to control size.") },
+                        { param: "LOG_BLK_RATEMAX", desc: qsTr("Limit block logging rate for constrained flash media.") },
+                        { param: "LOG_MAV_RATEMAX", desc: qsTr("Limit MAVLink log stream rate.") },
+                        { param: "LOG_MAX_FILES", desc: qsTr("Maximum retained log files before rotation.") },
+                        { param: "LOG_REPLAY", desc: qsTr("Capture extra data needed for EKF replay analysis.") },
+                        { param: "EK3_LOG_LEVEL", desc: qsTr("Controls EKF3 logging verbosity and log size.") }
+                    ]
+
+                    delegate: Rectangle {
+                        id: paramCard
+                        Layout.fillWidth: true
+                        color: qgcPal.windowShade
+                        radius: ScreenTools.defaultFontPixelWidth * 0.5
+                        implicitHeight: paramColumn.implicitHeight + (ScreenTools.defaultFontPixelHeight * 0.8)
+
+                        property string _paramName: modelData.param
+                        property bool _available: controller.parameterExists(-1, _paramName)
+                        property var _fact: _available ? controller.getParameterFact(-1, _paramName, false) : null
+
+                        ColumnLayout {
+                            id: paramColumn
+                            anchors.fill: parent
+                            anchors.margins: ScreenTools.defaultFontPixelHeight * 0.4
+                            spacing: ScreenTools.defaultFontPixelHeight * 0.3
+
+                            QGCLabel {
+                                text: modelData.param
+                                font.bold: true
+                            }
+
+                            QGCLabel {
+                                wrapMode: Text.WordWrap
+                                text: modelData.desc
+                            }
+
+                            RowLayout {
+                                Layout.fillWidth: true
+
+                                FactComboBox {
+                                    Layout.preferredWidth: ScreenTools.defaultFontPixelWidth * 38
+                                    Layout.maximumWidth: ScreenTools.defaultFontPixelWidth * 48
+                                    // Prefer bitmask over enum if both are non-empty to avoid showing both controls simultaneously.
+                                    visible: paramCard._available && paramCard._fact && (paramCard._fact.enumStrings.length > 0) && (paramCard._fact.bitmaskStrings.length === 0)
+                                    fact: paramCard._fact
+                                }
+
+                                ColumnLayout {
+                                    visible: paramCard._available && paramCard._fact && (paramCard._fact.bitmaskStrings.length > 0)
+                                    spacing: ScreenTools.defaultFontPixelHeight * 0.2
+
+                                    FactBitmask {
+                                        Layout.fillWidth: true
+                                        fact: paramCard._fact
+                                    }
+
+                                    QGCLabel {
+                                        text: qsTr("Combined value: %1").arg(paramCard._fact ? paramCard._fact.rawValue : 0)
+                                        color: qgcPal.text
+                                    }
+                                }
+
+                                FactTextField {
+                                    Layout.preferredWidth: ScreenTools.defaultFontPixelWidth * 18
+                                    visible: paramCard._available
+                                             && paramCard._fact
+                                             && (paramCard._fact.enumStrings.length === 0)
+                                             && (paramCard._fact.bitmaskStrings.length === 0)
+                                    fact: paramCard._fact
+                                }
+
+                                QGCLabel {
+                                    visible: !paramCard._available
+                                    text: qsTr("Parameter not available on this firmware/vehicle")
+                                }
+                            }
+                        }
+                    }
+                }
+
+                Rectangle {
+                    Layout.fillWidth: true
+                    color: qgcPal.windowShade
+                    radius: ScreenTools.defaultFontPixelWidth * 0.5
+                    implicitHeight: guidanceText.implicitHeight + (ScreenTools.defaultFontPixelHeight * 1.2)
+
+                    QGCLabel {
+                        id: guidanceText
+                        anchors.fill: parent
+                        anchors.margins: ScreenTools.defaultFontPixelHeight * 0.6
+                        wrapMode: Text.WordWrap
+                        text: qsTr("Workflow: connect vehicle, review logging parameters, download logs from Onboard Logs page, open .bin/.tlog in Log Viewer, and use lower rate limits if SD/dataflash cannot keep up.")
+                    }
+                }
+            }
+        }
+    }
+}

--- a/src/AnalyzeView/OnboardLogs/OnboardLogController.cc
+++ b/src/AnalyzeView/OnboardLogs/OnboardLogController.cc
@@ -12,6 +12,8 @@
 #include "Vehicle.h"
 #include "VehicleLinkManager.h"
 
+#include <algorithm>
+
 #include <QtCore/QApplicationStatic>
 #include <QtCore/QTimer>
 
@@ -162,6 +164,7 @@ void OnboardLogController::_logEntry(uint32_t time_utc, uint32_t size, uint16_t 
 
         for (int i = 0; i < num_logs; i++) {
             QGCOnboardLogEntry *const entry = new QGCOnboardLogEntry(i);
+            (void) connect(entry, &QGCOnboardLogEntry::selectedChanged, this, &OnboardLogController::selectionChanged);
             _logEntriesModel->append(entry);
         }
     }
@@ -442,6 +445,7 @@ bool OnboardLogController::_prepareLogDownload()
 void OnboardLogController::refresh()
 {
     _logEntriesModel->clearAndDeleteContents();
+    emit selectionChanged();
     _requestLogList(0, 0xffff);
 }
 
@@ -480,6 +484,73 @@ void OnboardLogController::cancel()
     _setDownloading(false);
 }
 
+void OnboardLogController::selectAll(bool select)
+{
+    const int count = _logEntriesModel->count();
+    for (int i = 0; i < count; i++) {
+        QGCOnboardLogEntry *const entry = _logEntriesModel->value<QGCOnboardLogEntry*>(i);
+        if (!entry || !entry->received()) {
+            continue;
+        }
+
+        if (entry->selected() != select) {
+            // Block per-entry signals to avoid O(n²) allLogsSelected() re-evaluations.
+            // A single selectionChanged() is emitted after the loop.
+            QSignalBlocker blocker(entry);
+            entry->setSelected(select);
+        }
+    }
+    emit selectionChanged();
+}
+
+int OnboardLogController::selectedCount() const
+{
+    int selected = 0;
+    const int count = _logEntriesModel->count();
+    for (int i = 0; i < count; i++) {
+        const QGCOnboardLogEntry *const entry = _logEntriesModel->value<const QGCOnboardLogEntry*>(i);
+        if (entry && entry->received() && entry->selected()) {
+            selected++;
+        }
+    }
+
+    return selected;
+}
+
+bool OnboardLogController::allLogsSelected() const
+{
+    int selectable = 0;
+    int selected = 0;
+    const int count = _logEntriesModel->count();
+    for (int i = 0; i < count; i++) {
+        const QGCOnboardLogEntry *const entry = _logEntriesModel->value<const QGCOnboardLogEntry*>(i);
+        if (entry && entry->received()) {
+            selectable++;
+            if (entry->selected()) {
+                selected++;
+            }
+        }
+    }
+
+    return (selectable > 0) && (selected == selectable);
+}
+
+void OnboardLogController::toggleSortByDate()
+{
+    setSortAscending(!_sortAscending);
+}
+
+void OnboardLogController::setSortAscending(bool ascending)
+{
+    if (_sortAscending == ascending) {
+        return;
+    }
+
+    _sortAscending = ascending;
+    _sortEntriesByTimestamp();
+    emit sortAscendingChanged();
+}
+
 void OnboardLogController::_resetSelection(bool canceled)
 {
     const int num_logs = _logEntriesModel->count();
@@ -498,6 +569,44 @@ void OnboardLogController::_resetSelection(bool canceled)
     }
 
     emit selectionChanged();
+}
+
+void OnboardLogController::_sortEntriesByTimestamp()
+{
+    QObjectList sortedEntries = *_logEntriesModel->objectList();
+    std::stable_sort(sortedEntries.begin(), sortedEntries.end(), [this](const QObject *lhsObj, const QObject *rhsObj) {
+        const QGCOnboardLogEntry *const lhs = qobject_cast<const QGCOnboardLogEntry*>(lhsObj);
+        const QGCOnboardLogEntry *const rhs = qobject_cast<const QGCOnboardLogEntry*>(rhsObj);
+        if (lhs == rhs) {
+            return false;
+        }
+        if (!lhs) {
+            return false;
+        }
+        if (!rhs) {
+            return true;
+        }
+
+        const bool lhsHasTime = lhs->received() && (lhs->time().toSecsSinceEpoch() > 0);
+        const bool rhsHasTime = rhs->received() && (rhs->time().toSecsSinceEpoch() > 0);
+        if (lhsHasTime != rhsHasTime) {
+            // Keep entries with valid timestamps grouped first.
+            return lhsHasTime;
+        }
+
+        if (lhsHasTime && rhsHasTime) {
+            if (lhs->time() == rhs->time()) {
+                return _sortAscending ? (lhs->id() < rhs->id()) : (lhs->id() > rhs->id());
+            }
+
+            return _sortAscending ? (lhs->time() < rhs->time()) : (lhs->time() > rhs->time());
+        }
+
+        // Fallback for entries with missing/invalid time.
+        return _sortAscending ? (lhs->id() < rhs->id()) : (lhs->id() > rhs->id());
+    });
+
+    (void) _logEntriesModel->swapObjectList(sortedEntries);
 }
 
 void OnboardLogController::eraseAll()
@@ -642,6 +751,9 @@ void OnboardLogController::_setListing(bool active)
     if (_requestingLogEntries != active) {
         _requestingLogEntries = active;
         _vehicle->vehicleLinkManager()->setCommunicationLostEnabled(!active);
+        if (!active) {
+            _sortEntriesByTimestamp();
+        }
         emit requestingListChanged();
     }
 }

--- a/src/AnalyzeView/OnboardLogs/OnboardLogController.h
+++ b/src/AnalyzeView/OnboardLogs/OnboardLogController.h
@@ -16,14 +16,18 @@ class OnboardLogController : public QObject
     Q_OBJECT
     QML_ELEMENT
     QML_SINGLETON
+
     Q_MOC_INCLUDE("Vehicle.h")
     Q_MOC_INCLUDE("QmlObjectListModel.h")
-    Q_PROPERTY(QmlObjectListModel *model          READ _getModel            CONSTANT)
-    Q_PROPERTY(bool               requestingList  READ _getRequestingList   NOTIFY requestingListChanged)
-    Q_PROPERTY(bool               downloadingLogs READ _getDownloadingLogs  NOTIFY downloadingLogsChanged)
-    Q_PROPERTY(bool               compressLogs    READ compressLogs         WRITE setCompressLogs NOTIFY compressLogsChanged)
-    Q_PROPERTY(bool               compressing     READ compressing          NOTIFY compressingChanged)
-    Q_PROPERTY(float              compressionProgress READ compressionProgress NOTIFY compressionProgressChanged)
+
+    Q_PROPERTY(QmlObjectListModel *model               READ _getModel                                           CONSTANT)
+    Q_PROPERTY(bool               requestingList       READ _getRequestingList                                  NOTIFY requestingListChanged)
+    Q_PROPERTY(bool               downloadingLogs      READ _getDownloadingLogs                                 NOTIFY downloadingLogsChanged)
+    Q_PROPERTY(bool               allLogsSelected      READ allLogsSelected                                     NOTIFY selectionChanged)
+    Q_PROPERTY(bool               sortAscending        READ sortAscending          WRITE setSortAscending       NOTIFY sortAscendingChanged)
+    Q_PROPERTY(bool               compressLogs         READ compressLogs           WRITE setCompressLogs        NOTIFY compressLogsChanged)
+    Q_PROPERTY(bool               compressing          READ compressing                                         NOTIFY compressingChanged)
+    Q_PROPERTY(float              compressionProgress  READ compressionProgress                                 NOTIFY compressionProgressChanged)
 
     friend class OnboardLogDownloadTest;
 
@@ -35,11 +39,17 @@ public:
     Q_INVOKABLE void download(const QString &path = QString());
     Q_INVOKABLE void eraseAll();
     Q_INVOKABLE void cancel();
+    Q_INVOKABLE void selectAll(bool select);
+    Q_INVOKABLE int selectedCount() const;
+    Q_INVOKABLE void toggleSortByDate();
 
     bool compressLogs() const { return _compressLogs; }
     void setCompressLogs(bool compress);
     bool compressing() const { return _compressing; }
     float compressionProgress() const { return _compressionProgress; }
+    bool allLogsSelected() const;
+    bool sortAscending() const { return _sortAscending; }
+    void setSortAscending(bool ascending);
 
     /// Compress a single log file
     Q_INVOKABLE bool compressLogFile(const QString &logPath);
@@ -52,12 +62,14 @@ signals:
     void downloadingLogsChanged();
     void selectionChanged();
     void compressLogsChanged();
+    void sortAscendingChanged();
     void compressingChanged();
     void compressionProgressChanged();
     void compressionComplete(const QString &outputPath, const QString &error);
 
 private slots:
     void _setActiveVehicle(Vehicle *vehicle);
+
     void _logEntry(uint32_t time_utc, uint32_t size, uint16_t id, uint16_t num_logs, uint16_t last_log_num);
     void _logData(uint32_t ofs, uint16_t id, uint8_t count, const uint8_t *data);
     void _processDownload();
@@ -86,6 +98,8 @@ private:
     void _setListing(bool active);
     void _updateDataRate();
 
+    void _sortEntriesByTimestamp();
+
     QGCOnboardLogEntry *_getNextSelected() const;
 
     QTimer *_timer = nullptr;
@@ -101,6 +115,7 @@ private:
     bool _compressLogs = false;
     bool _compressing = false;
     float _compressionProgress = 0.0F;
+    bool _sortAscending = false;
 
     static constexpr uint32_t kTimeOutMs = 500;
     static constexpr uint32_t kGUIRateMs = 500; ///< Update download rate twice per second

--- a/src/AnalyzeView/OnboardLogs/OnboardLogPage.qml
+++ b/src/AnalyzeView/OnboardLogs/OnboardLogPage.qml
@@ -34,10 +34,7 @@ AnalyzePage {
                     columnSpacing: ScreenTools.defaultFontPixelWidth
                     rowSpacing: 0
 
-                    QGCCheckBox {
-                        id: headerCheckBox
-                        enabled: false
-                    }
+                    Item { } // First column is for checkboxes, so add empty item to align headers with log entries
 
                     Repeater {
                         model: OnboardLogController.model
@@ -119,6 +116,13 @@ AnalyzePage {
 
                 QGCButton {
                     Layout.fillWidth: true
+                    enabled: !OnboardLogController.requestingList && !OnboardLogController.downloadingLogs && (OnboardLogController.model.count > 0)
+                    text: OnboardLogController.allLogsSelected ? qsTr("Deselect All") : qsTr("Select All")
+                    onClicked: OnboardLogController.selectAll(!OnboardLogController.allLogsSelected)
+                }
+
+                QGCButton {
+                    Layout.fillWidth: true
                     enabled: !OnboardLogController.requestingList && !OnboardLogController.downloadingLogs
                     text: qsTr("Download")
 
@@ -154,6 +158,13 @@ AnalyzePage {
                             close()
                         }
                     }
+                }
+
+                QGCButton {
+                    Layout.fillWidth: true
+                    enabled: !OnboardLogController.requestingList && !OnboardLogController.downloadingLogs && (OnboardLogController.model.count > 1)
+                    text: OnboardLogController.sortAscending ? qsTr("Sort Descending") : qsTr("Sort Ascending")
+                    onClicked: OnboardLogController.toggleSortByDate()
                 }
 
                 QGCButton {

--- a/src/Utilities/Parsing/APMDataFlash/APMDataFlashUtility.cc
+++ b/src/Utilities/Parsing/APMDataFlash/APMDataFlashUtility.cc
@@ -1,11 +1,11 @@
-#include "DataFlashUtility.h"
+#include "APMDataFlashUtility.h"
 #include "QGCLoggingCategory.h"
 
 #include <cstring>
 
-QGC_LOGGING_CATEGORY(DataFlashUtilityLog, "Utilities.DataFlashUtility")
+QGC_LOGGING_CATEGORY(APMDataFlashUtilityLog, "Utilities.APMDataFlashUtility")
 
-namespace DataFlashUtility
+namespace APMDataFlashUtility
 {
 
 // ============================================================================
@@ -312,4 +312,4 @@ int iterateMessages(const char *data, qint64 size,
     return count;
 }
 
-} // namespace DataFlashUtility
+} // namespace APMDataFlashUtility

--- a/src/Utilities/Parsing/APMDataFlash/APMDataFlashUtility.h
+++ b/src/Utilities/Parsing/APMDataFlash/APMDataFlashUtility.h
@@ -9,7 +9,7 @@
 #include <cstdint>
 #include <functional>
 
-namespace DataFlashUtility
+namespace APMDataFlashUtility
 {
 
 // ============================================================================
@@ -133,4 +133,4 @@ int iterateMessages(const char *data, qint64 size,
 /// @return Converted float value
 float halfToFloat(uint16_t bits);
 
-} // namespace DataFlashUtility
+} // namespace APMDataFlashUtility

--- a/src/Utilities/Parsing/CMakeLists.txt
+++ b/src/Utilities/Parsing/CMakeLists.txt
@@ -1,17 +1,17 @@
 # ============================================================================
 # Parsing Utilities
-# EXIF, DataFlash, ULog, JSON
+# EXIF, APMDataFlash (ArduPilot DataFlash binary log), PX4ULog (PX4 ULog), JSON
 # ============================================================================
 
 qt_add_library(QGCParsing STATIC
-    DataFlash/DataFlashUtility.cc
-    DataFlash/DataFlashUtility.h
+    APMDataFlash/APMDataFlashUtility.cc
+    APMDataFlash/APMDataFlashUtility.h
     Exif/ExifUtility.cc
     Exif/ExifUtility.h
     Json/JsonParsing.cc
     Json/JsonParsing.h
-    ULog/ULogUtility.cc
-    ULog/ULogUtility.h
+    PX4ULog/PX4ULogUtility.cc
+    PX4ULog/PX4ULogUtility.h
 )
 
 # ============================================================================
@@ -129,10 +129,10 @@ target_include_directories(QGCParsing SYSTEM PUBLIC ${ulog_cpp_SOURCE_DIR})
 target_include_directories(QGCParsing
     PUBLIC
         ${CMAKE_CURRENT_SOURCE_DIR}
-        ${CMAKE_CURRENT_SOURCE_DIR}/DataFlash
+        ${CMAKE_CURRENT_SOURCE_DIR}/APMDataFlash
         ${CMAKE_CURRENT_SOURCE_DIR}/Exif
         ${CMAKE_CURRENT_SOURCE_DIR}/Json
-        ${CMAKE_CURRENT_SOURCE_DIR}/ULog
+        ${CMAKE_CURRENT_SOURCE_DIR}/PX4ULog
 )
 
 target_precompile_headers(QGCParsing PRIVATE

--- a/src/Utilities/Parsing/PX4ULog/PX4ULogUtility.cc
+++ b/src/Utilities/Parsing/PX4ULog/PX4ULogUtility.cc
@@ -1,13 +1,13 @@
-#include "ULogUtility.h"
+#include "PX4ULogUtility.h"
 #include "QGCLoggingCategory.h"
 
 #include <cstring>
 
 #include <ulog_cpp/reader.hpp>
 
-QGC_LOGGING_CATEGORY(ULogUtilityLog, "Utilities.ULogUtility")
+QGC_LOGGING_CATEGORY(PX4ULogUtilityLog, "Utilities.PX4ULogUtility")
 
-namespace ULogUtility
+namespace PX4ULogUtility
 {
 
 // ============================================================================
@@ -112,13 +112,13 @@ void MessageHandler::data(const ulog_cpp::Data &data)
             // Note: ulog_cpp doesn't support early termination, so we just skip remaining
         }
     } catch (const ulog_cpp::AccessException &exception) {
-        qCWarning(ULogUtilityLog) << "Failed to parse" << QString::fromStdString(_targetMessageName)
+        qCWarning(PX4ULogUtilityLog) << "Failed to parse" << QString::fromStdString(_targetMessageName)
                                   << ":" << exception.what();
         QStringList fields;
         for (const std::string &name : _messageFormat->fieldNames()) {
             fields.append(QString::fromStdString(name));
         }
-        qCDebug(ULogUtilityLog) << "Available fields:" << fields;
+        qCDebug(PX4ULogUtilityLog) << "Available fields:" << fields;
     }
 }
 
@@ -150,4 +150,4 @@ bool iterateMessages(const char *data, qint64 size,
     return true;
 }
 
-} // namespace ULogUtility
+} // namespace PX4ULogUtility

--- a/src/Utilities/Parsing/PX4ULog/PX4ULogUtility.h
+++ b/src/Utilities/Parsing/PX4ULog/PX4ULogUtility.h
@@ -12,7 +12,7 @@
 #include <ulog_cpp/messages.hpp>
 #include <ulog_cpp/subscription.hpp>
 
-namespace ULogUtility
+namespace PX4ULogUtility
 {
 
 // ============================================================================
@@ -110,4 +110,4 @@ bool iterateMessages(const char *data, qint64 size,
                      const MessageCallback &callback,
                      QString &errorMessage);
 
-} // namespace ULogUtility
+} // namespace PX4ULogUtility

--- a/test/AnalyzeView/APMDataFlashLogParserTest.cc
+++ b/test/AnalyzeView/APMDataFlashLogParserTest.cc
@@ -1,0 +1,96 @@
+#include "APMDataFlashLogParserTest.h"
+
+#include "APMDataFlashLogParser.h"
+
+#include <QtCore/QFile>
+#include <QtCore/QTemporaryFile>
+
+#include <cstring>
+
+namespace {
+
+QByteArray makeFmtPayload(uint8_t type, uint8_t length, const char *name, const char *format, const char *columns)
+{
+    QByteArray payload(86, '\0');
+    payload[0] = static_cast<char>(type);
+    payload[1] = static_cast<char>(length);
+    memcpy(payload.data() + 2, name, qMin<int>(4, static_cast<int>(strlen(name))));
+    memcpy(payload.data() + 6, format, qMin<int>(16, static_cast<int>(strlen(format))));
+    memcpy(payload.data() + 22, columns, qMin<int>(64, static_cast<int>(strlen(columns))));
+    return payload;
+}
+
+void appendMessage(QByteArray &bytes, uint8_t type, const QByteArray &payload)
+{
+    bytes.append(static_cast<char>(0xA3));
+    bytes.append(static_cast<char>(0x95));
+    bytes.append(static_cast<char>(type));
+    bytes.append(payload);
+}
+
+QByteArray makeParamPayload(const char *name, float value)
+{
+    QByteArray payload(20, '\0'); // Nf = 16 bytes + 4 bytes
+    memcpy(payload.data(), name, qMin<int>(16, static_cast<int>(strlen(name))));
+    memcpy(payload.data() + 16, &value, sizeof(value));
+    return payload;
+}
+
+QByteArray makeModePayload(uint64_t timeUs, uint8_t mode)
+{
+    QByteArray payload(9, '\0'); // QB = 8 + 1
+    memcpy(payload.data(), &timeUs, sizeof(timeUs));
+    payload[8] = static_cast<char>(mode);
+    return payload;
+}
+
+QByteArray makeEventPayload(uint64_t timeUs, uint16_t eventId)
+{
+    QByteArray payload(10, '\0'); // QH = 8 + 2
+    memcpy(payload.data(), &timeUs, sizeof(timeUs));
+    memcpy(payload.data() + 8, &eventId, sizeof(eventId));
+    return payload;
+}
+
+} // namespace
+
+void APMDataFlashLogParserTest::_parseMinimalLogTest()
+{
+    QByteArray bytes;
+    appendMessage(bytes, 128, makeFmtPayload(150, 23, "PARM", "Nf", "Name,Value"));
+    appendMessage(bytes, 128, makeFmtPayload(151, 12, "MODE", "QB", "TimeUS,Mode"));
+    appendMessage(bytes, 128, makeFmtPayload(152, 13, "EV", "QH", "TimeUS,Id"));
+    appendMessage(bytes, 150, makeParamPayload("LOG_BITMASK", 65535.0f));
+    appendMessage(bytes, 151, makeModePayload(5000000ULL, 4));
+    appendMessage(bytes, 152, makeEventPayload(6000000ULL, 10));
+
+    QTemporaryFile tempFile;
+    QVERIFY(tempFile.open());
+    QVERIFY(tempFile.write(bytes) == bytes.size());
+    tempFile.close();
+
+    APMDataFlashLogParser parser;
+    QVERIFY(parser.parseFile(tempFile.fileName()));
+    QVERIFY(parser.parsed());
+    QCOMPARE(parser.parseError(), QString());
+    QVERIFY(parser.availableSignals().contains(QStringLiteral("PARM.Name")));
+    QVERIFY(parser.availableSignals().contains(QStringLiteral("PARM.Value")));
+    QCOMPARE(parser.parameters().count(), 1);
+    // One MODE message produces a "mode" event; one EV message produces an "event" event.
+    QCOMPARE(parser.events().count(), 2);
+}
+
+void APMDataFlashLogParserTest::_parseInvalidLogTest()
+{
+    QTemporaryFile tempFile;
+    QVERIFY(tempFile.open());
+    QVERIFY(tempFile.write("invalid", 7) == 7);
+    tempFile.close();
+
+    APMDataFlashLogParser parser;
+    QVERIFY(!parser.parseFile(tempFile.fileName()));
+    QVERIFY(!parser.parsed());
+    QVERIFY(!parser.parseError().isEmpty());
+}
+
+UT_REGISTER_TEST(APMDataFlashLogParserTest, TestLabel::Unit, TestLabel::AnalyzeView)

--- a/test/AnalyzeView/APMDataFlashLogParserTest.h
+++ b/test/AnalyzeView/APMDataFlashLogParserTest.h
@@ -1,0 +1,12 @@
+#pragma once
+
+#include "UnitTest.h"
+
+class APMDataFlashLogParserTest : public UnitTest
+{
+    Q_OBJECT
+
+private slots:
+    void _parseMinimalLogTest();
+    void _parseInvalidLogTest();
+};

--- a/test/AnalyzeView/CMakeLists.txt
+++ b/test/AnalyzeView/CMakeLists.txt
@@ -23,6 +23,8 @@ target_sources(${CMAKE_PROJECT_NAME}
         MAVLinkSystemTest.h
         MavlinkLogTest.cc
         MavlinkLogTest.h
+        APMDataFlashLogParserTest.cc
+        APMDataFlashLogParserTest.h
 )
 
 target_include_directories(${CMAKE_PROJECT_NAME} PRIVATE ${CMAKE_CURRENT_SOURCE_DIR})

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -86,6 +86,7 @@ add_qgc_test(MAVLinkMessageFieldTest LABELS Unit AnalyzeView)
 add_qgc_test(MAVLinkMessageTest LABELS Unit AnalyzeView)
 add_qgc_test(MAVLinkSystemTest LABELS Unit AnalyzeView)
 add_qgc_test(MavlinkLogTest LABELS Integration AnalyzeView Vehicle RESOURCE_LOCK MockLink)
+add_qgc_test(APMDataFlashLogParserTest LABELS Unit AnalyzeView)
 
 # ----------------------------------------------------------------------------
 # Camera
@@ -244,11 +245,11 @@ add_qgc_test(QGCStreamingDecompressionTest LABELS Unit Utilities)
 # Network
 add_qgc_test(QGCNetworkHelperTest LABELS Unit Utilities Network)
 # Parsing
-add_qgc_test(DataFlashUtilityTest LABELS Unit Utilities)
+add_qgc_test(APMDataFlashUtilityTest LABELS Unit Utilities)
 add_qgc_test(ExifUtilityTest LABELS Unit Utilities)
 add_qgc_test(JsonHelperTest LABELS Unit Utilities)
 add_qgc_test(JsonParsingTest LABELS Unit Utilities)
-add_qgc_test(ULogUtilityTest LABELS Unit Utilities)
+add_qgc_test(PX4ULogUtilityTest LABELS Unit Utilities)
 # FileSystem
 add_qgc_test(QGCArchiveWatcherTest LABELS Unit Utilities RESOURCE_LOCK TempFiles)
 add_qgc_test(QGCCachedFileDownloadTest LABELS Integration Network Utilities)

--- a/test/UnitTestFramework/UnitTestCoords.h
+++ b/test/UnitTestFramework/UnitTestCoords.h
@@ -2,32 +2,20 @@
 
 // Split from UnitTest.h so QtPositioning isn't pulled into every test TU.
 
+#include <QtCore/QDebug>
 #include <QtCore/QString>
 #include <QtPositioning/QGeoCoordinate>
 #include <QtTest/QTest>
 
 /// Compare two QGeoCoordinates with meter tolerance (default 1.0m)
-#define QCOMPARE_COORDS(actual, expected, ...)                                                                 \
-    do {                                                                                                       \
-        const QGeoCoordinate _actual = (actual);                                                               \
-        const QGeoCoordinate _expected = (expected);                                                           \
-        const double _tolerance = (0.0 __VA_OPT__(+) __VA_ARGS__) > 0 ? (0.0 __VA_OPT__(+) __VA_ARGS__) : 1.0; \
-        const double _distance = _actual.distanceTo(_expected);                                                \
-        if (_distance > _tolerance) {                                                                          \
-            const QString _msg = QString(                                                                      \
-                                     "Coordinates differ by %1m (tolerance: %2m)\n"                            \
-                                     "  Actual:   (%3, %4, %5)\n"                                              \
-                                     "  Expected: (%6, %7, %8)")                                               \
-                                     .arg(_distance, 0, 'f', 3)                                                \
-                                     .arg(_tolerance, 0, 'f', 3)                                               \
-                                     .arg(_actual.latitude(), 0, 'f', 7)                                       \
-                                     .arg(_actual.longitude(), 0, 'f', 7)                                      \
-                                     .arg(_actual.altitude(), 0, 'f', 2)                                       \
-                                     .arg(_expected.latitude(), 0, 'f', 7)                                     \
-                                     .arg(_expected.longitude(), 0, 'f', 7)                                    \
-                                     .arg(_expected.altitude(), 0, 'f', 2);                                    \
-            QFAIL(qPrintable(_msg));                                                                           \
-        }                                                                                                      \
+#define QCOMPARE_COORDS(actual, expected, ...) \
+    do { \
+        const double _qcc_tol = [] { \
+            const double _v = (0.0 __VA_OPT__(+) __VA_ARGS__); \
+            return _v > 0.0 ? _v : 1.0; \
+        }(); \
+        QString _qcc_msg; \
+        QVERIFY2(QTest::compareCoords((actual), (expected), _qcc_tol, _qcc_msg), qPrintable(_qcc_msg)); \
     } while (false)
 
 /// Verify coordinates are equal within tolerance (less verbose than QCOMPARE_COORDS)
@@ -36,6 +24,39 @@
              qPrintable(QString("Coordinates differ by %1m").arg((actual).distanceTo(expected))))
 
 namespace QTest {
+
+inline bool compareCoords(const QGeoCoordinate &actual, const QGeoCoordinate &expected, double toleranceMeters, QString &outMessage)
+{
+    const double tolerance = (toleranceMeters > 0.0) ? toleranceMeters : 1.0;
+    const double distance = actual.distanceTo(expected);
+    if (distance > tolerance) {
+        outMessage = QStringLiteral(
+                         "Coordinates differ by %1m (tolerance: %2m)\n"
+                         "  Actual:   (%3, %4, %5)\n"
+                         "  Expected: (%6, %7, %8)")
+                         .arg(distance, 0, 'f', 3)
+                         .arg(tolerance, 0, 'f', 3)
+                         .arg(actual.latitude(), 0, 'f', 7)
+                         .arg(actual.longitude(), 0, 'f', 7)
+                         .arg(actual.altitude(), 0, 'f', 2)
+                         .arg(expected.latitude(), 0, 'f', 7)
+                         .arg(expected.longitude(), 0, 'f', 7)
+                         .arg(expected.altitude(), 0, 'f', 2);
+        return false;
+    }
+    return true;
+}
+
+inline bool compareCoords(const QGeoCoordinate &actual, const QGeoCoordinate &expected, double toleranceMeters = 1.0)
+{
+    QString message;
+    const bool ok = compareCoords(actual, expected, toleranceMeters, message);
+    if (!ok) {
+        qDebug("%s", qPrintable(message));
+    }
+    return ok;
+}
+
 // Readable QCOMPARE diagnostics for QGeoCoordinate.
 template <>
 inline char* toString(const QGeoCoordinate& c)
@@ -45,4 +66,5 @@ inline char* toString(const QGeoCoordinate& c)
                                   .arg(c.longitude(), 0, 'f', 7)
                                   .arg(c.altitude(), 0, 'f', 2)));
 }
+
 }  // namespace QTest

--- a/test/Utilities/Parsing/APMDataFlash/APMDataFlashUtilityTest.cc
+++ b/test/Utilities/Parsing/APMDataFlash/APMDataFlashUtilityTest.cc
@@ -1,212 +1,212 @@
-#include "DataFlashUtilityTest.h"
+#include "APMDataFlashUtilityTest.h"
 
 
 #include <cmath>
 #include <cstring>
 
-#include "DataFlashUtility.h"
+#include "APMDataFlashUtility.h"
 
 // ============================================================================
 // Format Character Size Tests
 // ============================================================================
 
-void DataFlashUtilityTest::_testFormatCharSize()
+void APMDataFlashUtilityTest::_testFormatCharSize()
 {
     // 1-byte types
-    QCOMPARE(DataFlashUtility::formatCharSize('b'), 1);
-    QCOMPARE(DataFlashUtility::formatCharSize('B'), 1);
-    QCOMPARE(DataFlashUtility::formatCharSize('M'), 1);
+    QCOMPARE(APMDataFlashUtility::formatCharSize('b'), 1);
+    QCOMPARE(APMDataFlashUtility::formatCharSize('B'), 1);
+    QCOMPARE(APMDataFlashUtility::formatCharSize('M'), 1);
 
     // 2-byte types
-    QCOMPARE(DataFlashUtility::formatCharSize('h'), 2);
-    QCOMPARE(DataFlashUtility::formatCharSize('H'), 2);
-    QCOMPARE(DataFlashUtility::formatCharSize('c'), 2);
-    QCOMPARE(DataFlashUtility::formatCharSize('C'), 2);
-    QCOMPARE(DataFlashUtility::formatCharSize('g'), 2);  // half-precision float
+    QCOMPARE(APMDataFlashUtility::formatCharSize('h'), 2);
+    QCOMPARE(APMDataFlashUtility::formatCharSize('H'), 2);
+    QCOMPARE(APMDataFlashUtility::formatCharSize('c'), 2);
+    QCOMPARE(APMDataFlashUtility::formatCharSize('C'), 2);
+    QCOMPARE(APMDataFlashUtility::formatCharSize('g'), 2);  // half-precision float
 
     // 4-byte types
-    QCOMPARE(DataFlashUtility::formatCharSize('i'), 4);
-    QCOMPARE(DataFlashUtility::formatCharSize('I'), 4);
-    QCOMPARE(DataFlashUtility::formatCharSize('e'), 4);
-    QCOMPARE(DataFlashUtility::formatCharSize('E'), 4);
-    QCOMPARE(DataFlashUtility::formatCharSize('L'), 4);
-    QCOMPARE(DataFlashUtility::formatCharSize('f'), 4);
-    QCOMPARE(DataFlashUtility::formatCharSize('n'), 4);
+    QCOMPARE(APMDataFlashUtility::formatCharSize('i'), 4);
+    QCOMPARE(APMDataFlashUtility::formatCharSize('I'), 4);
+    QCOMPARE(APMDataFlashUtility::formatCharSize('e'), 4);
+    QCOMPARE(APMDataFlashUtility::formatCharSize('E'), 4);
+    QCOMPARE(APMDataFlashUtility::formatCharSize('L'), 4);
+    QCOMPARE(APMDataFlashUtility::formatCharSize('f'), 4);
+    QCOMPARE(APMDataFlashUtility::formatCharSize('n'), 4);
 
     // 8-byte types
-    QCOMPARE(DataFlashUtility::formatCharSize('d'), 8);
-    QCOMPARE(DataFlashUtility::formatCharSize('q'), 8);
-    QCOMPARE(DataFlashUtility::formatCharSize('Q'), 8);
+    QCOMPARE(APMDataFlashUtility::formatCharSize('d'), 8);
+    QCOMPARE(APMDataFlashUtility::formatCharSize('q'), 8);
+    QCOMPARE(APMDataFlashUtility::formatCharSize('Q'), 8);
 
     // 16-byte types
-    QCOMPARE(DataFlashUtility::formatCharSize('N'), 16);
+    QCOMPARE(APMDataFlashUtility::formatCharSize('N'), 16);
 
     // 64-byte types
-    QCOMPARE(DataFlashUtility::formatCharSize('Z'), 64);
-    QCOMPARE(DataFlashUtility::formatCharSize('a'), 64);
+    QCOMPARE(APMDataFlashUtility::formatCharSize('Z'), 64);
+    QCOMPARE(APMDataFlashUtility::formatCharSize('a'), 64);
 }
 
-void DataFlashUtilityTest::_testFormatCharSizeUnknown()
+void APMDataFlashUtilityTest::_testFormatCharSizeUnknown()
 {
-    QCOMPARE(DataFlashUtility::formatCharSize('x'), 0);
-    QCOMPARE(DataFlashUtility::formatCharSize('?'), 0);
-    QCOMPARE(DataFlashUtility::formatCharSize('\0'), 0);
+    QCOMPARE(APMDataFlashUtility::formatCharSize('x'), 0);
+    QCOMPARE(APMDataFlashUtility::formatCharSize('?'), 0);
+    QCOMPARE(APMDataFlashUtility::formatCharSize('\0'), 0);
 }
 
-void DataFlashUtilityTest::_testCalculatePayloadSize()
+void APMDataFlashUtilityTest::_testCalculatePayloadSize()
 {
     // Empty format
-    QCOMPARE(DataFlashUtility::calculatePayloadSize(QString()), 0);
+    QCOMPARE(APMDataFlashUtility::calculatePayloadSize(QString()), 0);
 
     // Single type
-    QCOMPARE(DataFlashUtility::calculatePayloadSize(QStringLiteral("B")), 1);
-    QCOMPARE(DataFlashUtility::calculatePayloadSize(QStringLiteral("Q")), 8);
+    QCOMPARE(APMDataFlashUtility::calculatePayloadSize(QStringLiteral("B")), 1);
+    QCOMPARE(APMDataFlashUtility::calculatePayloadSize(QStringLiteral("Q")), 8);
 
     // Mixed format (typical CAM message: QBILLefffff)
     // Q(8) + B(1) + I(4) + L(4) + L(4) + e(4) + f(4) + f(4) + f(4) + f(4) + f(4) = 45
-    QCOMPARE(DataFlashUtility::calculatePayloadSize(QStringLiteral("QBILLefffff")), 45);
+    QCOMPARE(APMDataFlashUtility::calculatePayloadSize(QStringLiteral("QBILLefffff")), 45);
 }
 
 // ============================================================================
 // Value Parsing Tests
 // ============================================================================
 
-void DataFlashUtilityTest::_testParseValueIntegers()
+void APMDataFlashUtilityTest::_testParseValueIntegers()
 {
     // int8
     char i8 = -42;
-    QCOMPARE(DataFlashUtility::parseValue(&i8, 'b').toInt(), -42);
+    QCOMPARE(APMDataFlashUtility::parseValue(&i8, 'b').toInt(), -42);
 
     // uint8
     unsigned char u8 = 200;
-    QCOMPARE(DataFlashUtility::parseValue(reinterpret_cast<char*>(&u8), 'B').toUInt(), 200u);
+    QCOMPARE(APMDataFlashUtility::parseValue(reinterpret_cast<char*>(&u8), 'B').toUInt(), 200u);
 
     // int16
     int16_t i16 = -1234;
-    QCOMPARE(DataFlashUtility::parseValue(reinterpret_cast<char*>(&i16), 'h').toInt(), -1234);
+    QCOMPARE(APMDataFlashUtility::parseValue(reinterpret_cast<char*>(&i16), 'h').toInt(), -1234);
 
     // uint16
     uint16_t u16 = 50000;
-    QCOMPARE(DataFlashUtility::parseValue(reinterpret_cast<char*>(&u16), 'H').toUInt(), 50000u);
+    QCOMPARE(APMDataFlashUtility::parseValue(reinterpret_cast<char*>(&u16), 'H').toUInt(), 50000u);
 
     // int32
     int32_t i32 = -123456;
-    QCOMPARE(DataFlashUtility::parseValue(reinterpret_cast<char*>(&i32), 'i').toInt(), -123456);
+    QCOMPARE(APMDataFlashUtility::parseValue(reinterpret_cast<char*>(&i32), 'i').toInt(), -123456);
 
     // uint32
     uint32_t u32 = 4000000000u;
-    QCOMPARE(DataFlashUtility::parseValue(reinterpret_cast<char*>(&u32), 'I').toUInt(), 4000000000u);
+    QCOMPARE(APMDataFlashUtility::parseValue(reinterpret_cast<char*>(&u32), 'I').toUInt(), 4000000000u);
 
     // int64
     int64_t i64 = -1234567890123LL;
-    QCOMPARE(DataFlashUtility::parseValue(reinterpret_cast<char*>(&i64), 'q').toLongLong(), -1234567890123LL);
+    QCOMPARE(APMDataFlashUtility::parseValue(reinterpret_cast<char*>(&i64), 'q').toLongLong(), -1234567890123LL);
 
     // uint64
     uint64_t u64 = 12345678901234ULL;
-    QCOMPARE(DataFlashUtility::parseValue(reinterpret_cast<char*>(&u64), 'Q').toULongLong(), 12345678901234ULL);
+    QCOMPARE(APMDataFlashUtility::parseValue(reinterpret_cast<char*>(&u64), 'Q').toULongLong(), 12345678901234ULL);
 }
 
-void DataFlashUtilityTest::_testParseValueScaled()
+void APMDataFlashUtilityTest::_testParseValueScaled()
 {
     // Centi-degrees (c) - signed, divide by 100
     int16_t cdeg = 4500;  // 45.00 degrees
-    QVERIFY(qAbs(DataFlashUtility::parseValue(reinterpret_cast<char*>(&cdeg), 'c').toDouble() - 45.0) < 0.001);
+    QVERIFY(qAbs(APMDataFlashUtility::parseValue(reinterpret_cast<char*>(&cdeg), 'c').toDouble() - 45.0) < 0.001);
 
     // Centi-units (C) - unsigned, divide by 100
     uint16_t cunit = 1234;  // 12.34
-    QVERIFY(qAbs(DataFlashUtility::parseValue(reinterpret_cast<char*>(&cunit), 'C').toDouble() - 12.34) < 0.001);
+    QVERIFY(qAbs(APMDataFlashUtility::parseValue(reinterpret_cast<char*>(&cunit), 'C').toDouble() - 12.34) < 0.001);
 
     // Centi-units (e) - signed int32, divide by 100
     int32_t e32 = 123456;  // 1234.56
-    QVERIFY(qAbs(DataFlashUtility::parseValue(reinterpret_cast<char*>(&e32), 'e').toDouble() - 1234.56) < 0.001);
+    QVERIFY(qAbs(APMDataFlashUtility::parseValue(reinterpret_cast<char*>(&e32), 'e').toDouble() - 1234.56) < 0.001);
 
     // Centi-units (E) - unsigned int32, divide by 100
     uint32_t E32 = 98765432;  // 987654.32
-    QVERIFY(qAbs(DataFlashUtility::parseValue(reinterpret_cast<char*>(&E32), 'E').toDouble() - 987654.32) < 0.01);
+    QVERIFY(qAbs(APMDataFlashUtility::parseValue(reinterpret_cast<char*>(&E32), 'E').toDouble() - 987654.32) < 0.01);
 
     // Latitude/Longitude (L) - divide by 1e7
     int32_t latlon = 377490000;  // 37.749 degrees
-    QVERIFY(qAbs(DataFlashUtility::parseValue(reinterpret_cast<char*>(&latlon), 'L').toDouble() - 37.749) < 0.0001);
+    QVERIFY(qAbs(APMDataFlashUtility::parseValue(reinterpret_cast<char*>(&latlon), 'L').toDouble() - 37.749) < 0.0001);
 }
 
-void DataFlashUtilityTest::_testParseValueFloats()
+void APMDataFlashUtilityTest::_testParseValueFloats()
 {
     // Single-precision float
     float f32 = 3.14159f;
-    double result = DataFlashUtility::parseValue(reinterpret_cast<char*>(&f32), 'f').toDouble();
+    double result = APMDataFlashUtility::parseValue(reinterpret_cast<char*>(&f32), 'f').toDouble();
     QVERIFY2(qAbs(result - 3.14159) < 0.0001, qPrintable(QString("Expected ~3.14159, got %1").arg(result)));
 
     // Double-precision float
     double f64 = 2.718281828459045;
-    result = DataFlashUtility::parseValue(reinterpret_cast<char*>(&f64), 'd').toDouble();
+    result = APMDataFlashUtility::parseValue(reinterpret_cast<char*>(&f64), 'd').toDouble();
     QVERIFY2(qAbs(result - 2.718281828459045) < 0.0000001,
              qPrintable(QString("Expected ~2.718281828459045, got %1").arg(result)));
 }
 
-void DataFlashUtilityTest::_testParseValueStrings()
+void APMDataFlashUtilityTest::_testParseValueStrings()
 {
     // 4-char string (n)
     char n4[4] = {'T', 'E', 'S', 'T'};
-    QCOMPARE(DataFlashUtility::parseValue(n4, 'n').toString(), QStringLiteral("TEST"));
+    QCOMPARE(APMDataFlashUtility::parseValue(n4, 'n').toString(), QStringLiteral("TEST"));
 
     // 4-char string with null terminator
     char n4null[4] = {'A', 'B', '\0', 'D'};
-    QCOMPARE(DataFlashUtility::parseValue(n4null, 'n').toString(), QStringLiteral("AB"));
+    QCOMPARE(APMDataFlashUtility::parseValue(n4null, 'n').toString(), QStringLiteral("AB"));
 
     // 16-char string (N)
     char n16[16] = "HelloWorld123";
-    QCOMPARE(DataFlashUtility::parseValue(n16, 'N').toString(), QStringLiteral("HelloWorld123"));
+    QCOMPARE(APMDataFlashUtility::parseValue(n16, 'N').toString(), QStringLiteral("HelloWorld123"));
 
     // 64-char string (Z)
     char z64[64] = {};
     memset(z64, 0, sizeof(z64));
     strcpy(z64, "This is a longer test string");
-    QCOMPARE(DataFlashUtility::parseValue(z64, 'Z').toString(), QStringLiteral("This is a longer test string"));
+    QCOMPARE(APMDataFlashUtility::parseValue(z64, 'Z').toString(), QStringLiteral("This is a longer test string"));
 }
 
 // ============================================================================
 // Half-Precision Float Tests
 // ============================================================================
 
-void DataFlashUtilityTest::_testHalfToFloat()
+void APMDataFlashUtilityTest::_testHalfToFloat()
 {
     // Test common values
     // 1.0 in half-precision: sign=0, exp=15 (biased), mantissa=0 -> 0x3C00
-    QVERIFY(qAbs(DataFlashUtility::halfToFloat(0x3C00) - 1.0f) < 0.001f);
+    QVERIFY(qAbs(APMDataFlashUtility::halfToFloat(0x3C00) - 1.0f) < 0.001f);
 
     // 2.0 in half-precision: 0x4000
-    QVERIFY(qAbs(DataFlashUtility::halfToFloat(0x4000) - 2.0f) < 0.001f);
+    QVERIFY(qAbs(APMDataFlashUtility::halfToFloat(0x4000) - 2.0f) < 0.001f);
 
     // -1.0 in half-precision: 0xBC00
-    QVERIFY(qAbs(DataFlashUtility::halfToFloat(0xBC00) - (-1.0f)) < 0.001f);
+    QVERIFY(qAbs(APMDataFlashUtility::halfToFloat(0xBC00) - (-1.0f)) < 0.001f);
 
     // 0.5 in half-precision: 0x3800
-    QVERIFY(qAbs(DataFlashUtility::halfToFloat(0x3800) - 0.5f) < 0.001f);
+    QVERIFY(qAbs(APMDataFlashUtility::halfToFloat(0x3800) - 0.5f) < 0.001f);
 
     // Test via parseValue
     uint16_t half = 0x3C00;  // 1.0
-    double result = DataFlashUtility::parseValue(reinterpret_cast<char*>(&half), 'g').toDouble();
+    double result = APMDataFlashUtility::parseValue(reinterpret_cast<char*>(&half), 'g').toDouble();
     QVERIFY2(qAbs(result - 1.0) < 0.001, qPrintable(QString("Expected 1.0, got %1").arg(result)));
 }
 
-void DataFlashUtilityTest::_testHalfToFloatSpecial()
+void APMDataFlashUtilityTest::_testHalfToFloatSpecial()
 {
     // Zero
-    QCOMPARE(DataFlashUtility::halfToFloat(0x0000), 0.0f);
+    QCOMPARE(APMDataFlashUtility::halfToFloat(0x0000), 0.0f);
 
     // Negative zero
-    QCOMPARE(DataFlashUtility::halfToFloat(0x8000), -0.0f);
+    QCOMPARE(APMDataFlashUtility::halfToFloat(0x8000), -0.0f);
 
     // Infinity (exponent=31, mantissa=0)
-    float inf = DataFlashUtility::halfToFloat(0x7C00);
+    float inf = APMDataFlashUtility::halfToFloat(0x7C00);
     QVERIFY(std::isinf(inf) && inf > 0);
 
     // Negative infinity
-    float ninf = DataFlashUtility::halfToFloat(0xFC00);
+    float ninf = APMDataFlashUtility::halfToFloat(0xFC00);
     QVERIFY(std::isinf(ninf) && ninf < 0);
 
     // NaN (exponent=31, mantissa!=0)
-    float nan = DataFlashUtility::halfToFloat(0x7C01);
+    float nan = APMDataFlashUtility::halfToFloat(0x7C01);
     QVERIFY(std::isnan(nan));
 }
 
@@ -214,28 +214,28 @@ void DataFlashUtilityTest::_testHalfToFloatSpecial()
 // Header Validation Tests
 // ============================================================================
 
-void DataFlashUtilityTest::_testIsValidHeader()
+void APMDataFlashUtilityTest::_testIsValidHeader()
 {
     // Valid DataFlash header
     char valid[] = {static_cast<char>(0xA3), static_cast<char>(0x95), static_cast<char>(128)};
-    QVERIFY(DataFlashUtility::isValidHeader(valid, sizeof(valid)));
+    QVERIFY(APMDataFlashUtility::isValidHeader(valid, sizeof(valid)));
 }
 
-void DataFlashUtilityTest::_testIsValidHeaderInvalid()
+void APMDataFlashUtilityTest::_testIsValidHeaderInvalid()
 {
     // Wrong magic bytes
     char invalid1[] = {static_cast<char>(0xA3), static_cast<char>(0x96), static_cast<char>(128)};
-    QVERIFY(!DataFlashUtility::isValidHeader(invalid1, sizeof(invalid1)));
+    QVERIFY(!APMDataFlashUtility::isValidHeader(invalid1, sizeof(invalid1)));
 
     // Too small
     char small[] = {static_cast<char>(0xA3), static_cast<char>(0x95)};
-    QVERIFY(!DataFlashUtility::isValidHeader(small, 2));
+    QVERIFY(!APMDataFlashUtility::isValidHeader(small, 2));
 
     // Empty
-    QVERIFY(!DataFlashUtility::isValidHeader(nullptr, 0));
+    QVERIFY(!APMDataFlashUtility::isValidHeader(nullptr, 0));
 }
 
-void DataFlashUtilityTest::_testFindNextHeader()
+void APMDataFlashUtilityTest::_testFindNextHeader()
 {
     // Create test data with embedded headers
     char data[20];
@@ -249,16 +249,16 @@ void DataFlashUtilityTest::_testFindNextHeader()
     data[11] = static_cast<char>(0x95);
     data[12] = 2;  // message type
 
-    QCOMPARE(DataFlashUtility::findNextHeader(data, sizeof(data), 0), 0LL);
-    QCOMPARE(DataFlashUtility::findNextHeader(data, sizeof(data), 1), 10LL);
-    QCOMPARE(DataFlashUtility::findNextHeader(data, sizeof(data), 11), -1LL);
+    QCOMPARE(APMDataFlashUtility::findNextHeader(data, sizeof(data), 0), 0LL);
+    QCOMPARE(APMDataFlashUtility::findNextHeader(data, sizeof(data), 1), 10LL);
+    QCOMPARE(APMDataFlashUtility::findNextHeader(data, sizeof(data), 11), -1LL);
 }
 
 // ============================================================================
 // FMT Message Parsing Tests
 // ============================================================================
 
-void DataFlashUtilityTest::_testParseFmtPayload()
+void APMDataFlashUtilityTest::_testParseFmtPayload()
 {
     // Create a minimal FMT payload (86 bytes)
     // Type(1) + Length(1) + Name(4) + Format(16) + Columns(64)
@@ -271,7 +271,7 @@ void DataFlashUtilityTest::_testParseFmtPayload()
     memcpy(payload + 6, "QBILLff\0\0\0\0\0\0\0\0\0", 16);    // format
     memcpy(payload + 22, "TimeUS,Img,Lat,Lng,Alt,R,P", 27);  // columns (including null)
 
-    const DataFlashUtility::MessageFormat fmt = DataFlashUtility::parseFmtPayload(payload);
+    const APMDataFlashUtility::MessageFormat fmt = APMDataFlashUtility::parseFmtPayload(payload);
 
     QCOMPARE(fmt.type, static_cast<uint8_t>(100));
     QCOMPARE(fmt.length, static_cast<uint8_t>(25));
@@ -283,7 +283,7 @@ void DataFlashUtilityTest::_testParseFmtPayload()
     QCOMPARE(fmt.columns[2], QStringLiteral("Lat"));
 }
 
-void DataFlashUtilityTest::_testParseFmtMessages()
+void APMDataFlashUtilityTest::_testParseFmtMessages()
 {
     // This requires a real DataFlash log buffer with FMT messages
     // We'll use a minimal synthetic test
@@ -304,8 +304,8 @@ void DataFlashUtilityTest::_testParseFmtMessages()
     memcpy(fmtPayload + 22, "Type,Length,Name,Format,Columns", 32);
     data.append(fmtPayload, sizeof(fmtPayload));
 
-    QMap<uint8_t, DataFlashUtility::MessageFormat> formats;
-    QVERIFY(DataFlashUtility::parseFmtMessages(data.constData(), data.size(), formats));
+    QMap<uint8_t, APMDataFlashUtility::MessageFormat> formats;
+    QVERIFY(APMDataFlashUtility::parseFmtMessages(data.constData(), data.size(), formats));
     QVERIFY(formats.contains(128));
     QCOMPARE(formats[128].name, QStringLiteral("FMT"));
 }
@@ -314,10 +314,10 @@ void DataFlashUtilityTest::_testParseFmtMessages()
 // Message Parsing Tests
 // ============================================================================
 
-void DataFlashUtilityTest::_testParseMessage()
+void APMDataFlashUtilityTest::_testParseMessage()
 {
     // Create a simple message format
-    DataFlashUtility::MessageFormat fmt;
+    APMDataFlashUtility::MessageFormat fmt;
     fmt.type = 100;
     fmt.length = 13;  // 3 header + 10 payload (8+1+1)
     fmt.name = QStringLiteral("TEST");
@@ -331,7 +331,7 @@ void DataFlashUtilityTest::_testParseMessage()
     payload[8] = static_cast<char>(42);   // uint8
     payload[9] = static_cast<char>(-10);  // int8
 
-    const QMap<QString, QVariant> fields = DataFlashUtility::parseMessage(payload, fmt);
+    const QMap<QString, QVariant> fields = APMDataFlashUtility::parseMessage(payload, fmt);
 
     QCOMPARE(fields.size(), 3);
     QCOMPARE(fields[QStringLiteral("TimeUS")].toULongLong(), 1234567890ULL);
@@ -343,7 +343,7 @@ void DataFlashUtilityTest::_testParseMessage()
 // Message Iteration Tests
 // ============================================================================
 
-void DataFlashUtilityTest::_testIterateMessages()
+void APMDataFlashUtilityTest::_testIterateMessages()
 {
     // Create a minimal DataFlash buffer with:
     // 1. FMT message defining TEST (type 200)
@@ -366,8 +366,8 @@ void DataFlashUtilityTest::_testIterateMessages()
     data.append(fmtPayload, sizeof(fmtPayload));
 
     // Parse formats first
-    QMap<uint8_t, DataFlashUtility::MessageFormat> formats;
-    QVERIFY(DataFlashUtility::parseFmtMessages(data.constData(), data.size(), formats));
+    QMap<uint8_t, APMDataFlashUtility::MessageFormat> formats;
+    QVERIFY(APMDataFlashUtility::parseFmtMessages(data.constData(), data.size(), formats));
 
     // Add two TEST messages
     for (int i = 0; i < 2; ++i) {
@@ -384,14 +384,14 @@ void DataFlashUtilityTest::_testIterateMessages()
 
     // Re-parse formats to include the TEST format
     formats.clear();
-    QVERIFY(DataFlashUtility::parseFmtMessages(data.constData(), data.size(), formats));
+    QVERIFY(APMDataFlashUtility::parseFmtMessages(data.constData(), data.size(), formats));
 
     // Iterate messages
     int messageCount = 0;
     QList<uint8_t> msgTypes;
 
-    DataFlashUtility::iterateMessages(data.constData(), data.size(), formats,
-                                      [&](uint8_t msgType, const char*, int, const DataFlashUtility::MessageFormat&) {
+    APMDataFlashUtility::iterateMessages(data.constData(), data.size(), formats,
+                                      [&](uint8_t msgType, const char*, int, const APMDataFlashUtility::MessageFormat&) {
                                           ++messageCount;
                                           msgTypes.append(msgType);
                                           return true;
@@ -403,4 +403,4 @@ void DataFlashUtilityTest::_testIterateMessages()
     QCOMPARE(msgTypes[1], static_cast<uint8_t>(200));  // TEST
 }
 
-UT_REGISTER_TEST(DataFlashUtilityTest, TestLabel::Unit, TestLabel::Utilities)
+UT_REGISTER_TEST(APMDataFlashUtilityTest, TestLabel::Unit, TestLabel::Utilities)

--- a/test/Utilities/Parsing/APMDataFlash/APMDataFlashUtilityTest.h
+++ b/test/Utilities/Parsing/APMDataFlash/APMDataFlashUtilityTest.h
@@ -2,12 +2,12 @@
 
 #include "UnitTest.h"
 
-class DataFlashUtilityTest : public UnitTest
+class APMDataFlashUtilityTest : public UnitTest
 {
     Q_OBJECT
 
 public:
-    DataFlashUtilityTest() = default;
+    APMDataFlashUtilityTest() = default;
 
 private slots:
     // Format character size tests

--- a/test/Utilities/Parsing/APMDataFlash/CMakeLists.txt
+++ b/test/Utilities/Parsing/APMDataFlash/CMakeLists.txt
@@ -1,12 +1,12 @@
 # ============================================================================
-# ULog Utility Unit Tests
-# Tests for ULogUtility (general-purpose ULog parsing)
+# DataFlash Utility Unit Tests
+# Tests for DataFlashUtility (general-purpose DataFlash parsing)
 # ============================================================================
 
 target_sources(${CMAKE_PROJECT_NAME}
     PRIVATE
-        ULogUtilityTest.cc
-        ULogUtilityTest.h
+        APMDataFlashUtilityTest.cc
+        APMDataFlashUtilityTest.h
 )
 
 target_include_directories(${CMAKE_PROJECT_NAME} PRIVATE ${CMAKE_CURRENT_SOURCE_DIR})

--- a/test/Utilities/Parsing/CMakeLists.txt
+++ b/test/Utilities/Parsing/CMakeLists.txt
@@ -1,9 +1,9 @@
 # ============================================================================
 # Parsing Utility Tests
-# Tests for EXIF, DataFlash, and ULog parsing modules
+# Tests for EXIF, APMDataFlash (ArduPilot), and PX4ULog (PX4) parsing modules
 # ============================================================================
 
-add_subdirectory(DataFlash)
+add_subdirectory(APMDataFlash)
 add_subdirectory(Exif)
 add_subdirectory(Json)
-add_subdirectory(ULog)
+add_subdirectory(PX4ULog)

--- a/test/Utilities/Parsing/PX4ULog/CMakeLists.txt
+++ b/test/Utilities/Parsing/PX4ULog/CMakeLists.txt
@@ -1,12 +1,12 @@
 # ============================================================================
-# DataFlash Utility Unit Tests
-# Tests for DataFlashUtility (general-purpose DataFlash parsing)
+# PX4ULog Utility Unit Tests
+# Tests for PX4ULogUtility (PX4 ULog parsing)
 # ============================================================================
 
 target_sources(${CMAKE_PROJECT_NAME}
     PRIVATE
-        DataFlashUtilityTest.cc
-        DataFlashUtilityTest.h
+        PX4ULogUtilityTest.cc
+        PX4ULogUtilityTest.h
 )
 
 target_include_directories(${CMAKE_PROJECT_NAME} PRIVATE ${CMAKE_CURRENT_SOURCE_DIR})

--- a/test/Utilities/Parsing/PX4ULog/PX4ULogUtilityTest.cc
+++ b/test/Utilities/Parsing/PX4ULog/PX4ULogUtilityTest.cc
@@ -1,93 +1,93 @@
-#include "ULogUtilityTest.h"
+#include "PX4ULogUtilityTest.h"
 
 
 #include <cstring>
 
-#include "ULogUtility.h"
+#include "PX4ULogUtility.h"
 
 // ============================================================================
 // Header Validation Tests
 // ============================================================================
 
-void ULogUtilityTest::_testIsValidHeader()
+void PX4ULogUtilityTest::_testIsValidHeader()
 {
     // Valid ULog header: "ULog" magic bytes
     char valid[16] = {'U', 'L', 'o', 'g', 0x01, 0x12, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00};
 
-    QVERIFY(ULogUtility::isValidHeader(valid, sizeof(valid)));
+    QVERIFY(PX4ULogUtility::isValidHeader(valid, sizeof(valid)));
 }
 
-void ULogUtilityTest::_testIsValidHeaderInvalid()
+void PX4ULogUtilityTest::_testIsValidHeaderInvalid()
 {
     // Wrong magic bytes
     char invalid1[8] = {'u', 'l', 'o', 'g', 0x01, 0x12, 0x00, 0x00};
-    QVERIFY(!ULogUtility::isValidHeader(invalid1, sizeof(invalid1)));
+    QVERIFY(!PX4ULogUtility::isValidHeader(invalid1, sizeof(invalid1)));
 
     // Completely wrong data
     char invalid2[8] = {0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00};
-    QVERIFY(!ULogUtility::isValidHeader(invalid2, sizeof(invalid2)));
+    QVERIFY(!PX4ULogUtility::isValidHeader(invalid2, sizeof(invalid2)));
 
     // DataFlash header (not ULog)
     char dataflash[3] = {static_cast<char>(0xA3), static_cast<char>(0x95), static_cast<char>(0x80)};
-    QVERIFY(!ULogUtility::isValidHeader(dataflash, sizeof(dataflash)));
+    QVERIFY(!PX4ULogUtility::isValidHeader(dataflash, sizeof(dataflash)));
 
     // Too small
     char small[3] = {'U', 'L', 'o'};
-    QVERIFY(!ULogUtility::isValidHeader(small, sizeof(small)));
+    QVERIFY(!PX4ULogUtility::isValidHeader(small, sizeof(small)));
 
     // Empty
-    QVERIFY(!ULogUtility::isValidHeader(nullptr, 0));
+    QVERIFY(!PX4ULogUtility::isValidHeader(nullptr, 0));
 }
 
-void ULogUtilityTest::_testIsValidHeaderQByteArray()
+void PX4ULogUtilityTest::_testIsValidHeaderQByteArray()
 {
     // Test QByteArray data with pointer/size API
     QByteArray valid("ULog", 4);
     valid.append('\x01');      // version
     valid.append(11, '\x00');  // rest of header
-    QVERIFY(ULogUtility::isValidHeader(valid.constData(), valid.size()));
+    QVERIFY(PX4ULogUtility::isValidHeader(valid.constData(), valid.size()));
 
     QByteArray invalid("NotULog", 7);
-    QVERIFY(!ULogUtility::isValidHeader(invalid.constData(), invalid.size()));
+    QVERIFY(!PX4ULogUtility::isValidHeader(invalid.constData(), invalid.size()));
 
     QByteArray empty;
-    QVERIFY(!ULogUtility::isValidHeader(empty.constData(), empty.size()));
+    QVERIFY(!PX4ULogUtility::isValidHeader(empty.constData(), empty.size()));
 }
 
 // ============================================================================
 // Version Detection Tests
 // ============================================================================
 
-void ULogUtilityTest::_testGetVersion()
+void PX4ULogUtilityTest::_testGetVersion()
 {
     // Version 1 ULog
     char v1[8] = {'U', 'L', 'o', 'g', 0x01, 0x12, 0x00, 0x00};
-    QCOMPARE(ULogUtility::getVersion(v1, sizeof(v1)), 1);
+    QCOMPARE(PX4ULogUtility::getVersion(v1, sizeof(v1)), 1);
 
     // Hypothetical version 2
     char v2[8] = {'U', 'L', 'o', 'g', 0x02, 0x12, 0x00, 0x00};
-    QCOMPARE(ULogUtility::getVersion(v2, sizeof(v2)), 2);
+    QCOMPARE(PX4ULogUtility::getVersion(v2, sizeof(v2)), 2);
 }
 
-void ULogUtilityTest::_testGetVersionInvalid()
+void PX4ULogUtilityTest::_testGetVersionInvalid()
 {
     // Invalid magic
     char invalid[8] = {'n', 'o', 't', ' ', 'u', 'l', 'o', 'g'};
-    QCOMPARE(ULogUtility::getVersion(invalid, sizeof(invalid)), -1);
+    QCOMPARE(PX4ULogUtility::getVersion(invalid, sizeof(invalid)), -1);
 
     // Too short to contain version
     char short_data[4] = {'U', 'L', 'o', 'g'};
-    QCOMPARE(ULogUtility::getVersion(short_data, sizeof(short_data)), -1);
+    QCOMPARE(PX4ULogUtility::getVersion(short_data, sizeof(short_data)), -1);
 
     // Empty
-    QCOMPARE(ULogUtility::getVersion(nullptr, 0), -1);
+    QCOMPARE(PX4ULogUtility::getVersion(nullptr, 0), -1);
 }
 
 // ============================================================================
 // Timestamp Tests
 // ============================================================================
 
-void ULogUtilityTest::_testGetHeaderTimestamp()
+void PX4ULogUtilityTest::_testGetHeaderTimestamp()
 {
     // Create a valid ULog header with timestamp
     char header[16];
@@ -109,14 +109,14 @@ void ULogUtilityTest::_testGetHeaderTimestamp()
     uint64_t timestamp = 1234567890123456ULL;
     memcpy(header + 8, &timestamp, sizeof(timestamp));
 
-    QCOMPARE(ULogUtility::getHeaderTimestamp(header, sizeof(header)), timestamp);
+    QCOMPARE(PX4ULogUtility::getHeaderTimestamp(header, sizeof(header)), timestamp);
 
     // Invalid header should return 0
     char invalid[16] = {0};
-    QCOMPARE(ULogUtility::getHeaderTimestamp(invalid, sizeof(invalid)), 0ULL);
+    QCOMPARE(PX4ULogUtility::getHeaderTimestamp(invalid, sizeof(invalid)), 0ULL);
 
     // Too small
-    QCOMPARE(ULogUtility::getHeaderTimestamp(header, 8), 0ULL);
+    QCOMPARE(PX4ULogUtility::getHeaderTimestamp(header, 8), 0ULL);
 }
 
-UT_REGISTER_TEST(ULogUtilityTest, TestLabel::Unit, TestLabel::Utilities)
+UT_REGISTER_TEST(PX4ULogUtilityTest, TestLabel::Unit, TestLabel::Utilities)

--- a/test/Utilities/Parsing/PX4ULog/PX4ULogUtilityTest.h
+++ b/test/Utilities/Parsing/PX4ULog/PX4ULogUtilityTest.h
@@ -2,12 +2,12 @@
 
 #include "UnitTest.h"
 
-class ULogUtilityTest : public UnitTest
+class PX4ULogUtilityTest : public UnitTest
 {
     Q_OBJECT
 
 public:
-    ULogUtilityTest() = default;
+    PX4ULogUtilityTest() = default;
 
 private slots:
     // Header validation tests


### PR DESCRIPTION
## Description
This PR adds a new **Analyze View Log Viewer** workflow for ArduPilot logs and improves onboard log management UX.

Replaces #14301.

### What this solves
QGroundControl previously lacked an integrated DataFlash (`.bin`) log viewer and had limited telemetry replay analysis, forcing users into external tools for post-flight debugging/tuning. Onboard log list management was also limited.

### What's included
- New **Log Viewer** page in Analyze View for:
  - Opening and parsing **DataFlash** logs (`.bin`, `.log`)
  - Opening **telemetry logs** (`.tlog`) through replay flow
- New **APMDataFlashLogParser** pipeline:
  - FMT-driven decode
  - parameter extraction
  - plottable signal extraction
  - event extraction (EV, ERR, MODE messages)
  - mode segment extraction with vehicle-type-aware mode name resolution
- DataFlash UI capabilities:
  - multi-signal plotting with color coding
  - grouped signal browser (expand/collapse by message type prefix)
  - parameter list and message log
  - timeline event markers + mode bands + legends
  - chart cursor popup with synchronized signal values/mode/events
  - drag-to-zoom + reset zoom
- New **Log Setup** page with common ArduPilot logging parameter guidance and troubleshooting content
- Onboard logs UX improvements:
  - Select All / Deselect All action
  - Timestamp sort toggle (Sort Ascending / Sort Descending)
  - Sorting logic prioritizes date/time with ID fallback for missing timestamps
- **Renamed** firmware-specific parsing utilities with vendor prefix:
  - `DataFlash/` → `APMDataFlash/` (ArduPilot-specific)
  - `ULog/` → `PX4ULog/` (PX4-specific)
- Documentation updates for Analyze View index, log download, log viewer, and logging setup pages
- Parser unit tests: minimal valid DataFlash log + invalid log rejection

### Bug fixes included
- `LoggingSetupPage`: `FactComboBox` and `FactBitmask` were both visible when a parameter had both `enumStrings` and `bitmaskStrings` non-empty; fixed by prioritising bitmask
- `OnboardLogController::selectAll()`: fixed O(n²) signal storm — now uses `QSignalBlocker` per entry and emits `selectionChanged()` once
- `UnitTestCoords::QCOMPARE_COORDS`: `compareCoords` now returns `bool`; macro wraps with `QVERIFY` so test failures abort the calling test at the correct call site
- `_sortEntriesByTimestamp` moved from `private slots:` to `private:` (never connected to a signal)

## Type of Change
- [x] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Documentation update
- [x] Refactoring (no functional changes)
- [ ] CI/Build changes
- [ ] Other

## Testing
- [x] Tested locally
- [x] Added/updated unit tests
- [x] Tested with simulator (SITL)
- [ ] Tested with hardware

### Platforms Tested
- [ ] Linux
- [x] Windows
- [ ] macOS
- [ ] Android
- [ ] iOS

### Flight Stacks Tested
- [ ] PX4
- [x] ArduPilot

## Screenshots
- Log Viewer main page (`.bin` loaded): signal list + chart + timeline markers + cursor popup showing synchronized values/mode/events
<img width="1600" height="898" alt="image" src="https://github.com/user-attachments/assets/4ba63b31-e4b7-46a7-816c-5655d99bfa12" />

- Log Setup page with logging parameter guidance
<img width="1919" height="1079" alt="image" src="https://github.com/user-attachments/assets/def00d1e-091c-45e3-b769-442d32b1353e" />

- Onboard Logs page with updated sort/select behavior
<img width="1919" height="1079" alt="image" src="https://github.com/user-attachments/assets/ecac5c6a-bd4f-4744-a694-8d789a683146" />

## Checklist
- [x] I have read the [Contribution Guidelines](CONTRIBUTING.md)
- [x] I have read the [Code of Conduct](CODE_OF_CONDUCT.md)
- [x] My code follows the project's coding standards
- [x] I have added tests that prove my fix/feature works
- [x] New and existing unit tests pass locally

## Related Issues
- #14267
- #13583
- #11932
- #13226

---
By submitting this pull request, I confirm that my contribution is made under the terms of the project's dual license (Apache 2.0 and GPL v3).