### PR TITLE
feat(analyze): add PX4 ULog support and refactor log viewer parser architecture

### DIFF
--- a/src/AnalyzeView/LogViewer/APMDataFlash/APMDataFlashLogParser.cc
+++ b/src/AnalyzeView/LogViewer/APMDataFlash/APMDataFlashLogParser.cc
@@ -19,13 +19,13 @@ namespace {
 struct ParseResult {
     bool ok = false;
     QString errorMessage;
-    QStringList availableSignals;
-    QStringList plottableSignals;
+    QStringList availableFields;
+    QStringList plottableFields;
     QVariantList parameters;
     QVariantList events;
     QVariantList messages;
     QVariantList modeSegments;
-    QHash<QString, QVector<QPointF>> signalSamples;
+    QHash<QString, QVector<QPointF>> fieldSamples;
     double minTimestamp = -1.0;
     double maxTimestamp = -1.0;
     int sampleCount = 0;
@@ -528,7 +528,7 @@ ParseResult _parseDataFlashFile(const QString &filePath)
                                  (typeId == QMetaType::LongLong) || (typeId == QMetaType::ULongLong) ||
                                  (typeId == QMetaType::Float) || (typeId == QMetaType::Double);
             if (numeric) {
-                result.signalSamples[signalName].append(QPointF(timestampSecs, it.value().toDouble()));
+                result.fieldSamples[signalName].append(QPointF(timestampSecs, it.value().toDouble()));
                 plottableSet.insert(signalName);
             }
         }
@@ -544,10 +544,10 @@ ParseResult _parseDataFlashFile(const QString &filePath)
         result.modeSegments.append(segment);
     }
 
-    result.availableSignals = signalSet.values();
-    std::sort(result.availableSignals.begin(), result.availableSignals.end());
-    result.plottableSignals = plottableSet.values();
-    std::sort(result.plottableSignals.begin(), result.plottableSignals.end());
+    result.availableFields = signalSet.values();
+    std::sort(result.availableFields.begin(), result.availableFields.end());
+    result.plottableFields = plottableSet.values();
+    std::sort(result.plottableFields.begin(), result.plottableFields.end());
     result.minTimestamp = minTimestampSecs;
     result.maxTimestamp = maxTimestampSecs;
     result.ok = true;
@@ -576,17 +576,17 @@ bool APMDataFlashLogParser::parseFile(const QString &filePath)
         return false;
     }
 
-    _availableSignals = result.availableSignals;
-    _plottableSignals = result.plottableSignals;
+    _availableFields = result.availableFields;
+    _plottableFields = result.plottableFields;
     _parameters = result.parameters;
     _events = result.events;
     _messages = result.messages;
     _modeSegments = result.modeSegments;
-    _signalSamples = result.signalSamples;
+    _fieldSamples = result.fieldSamples;
     _sampleCount = result.sampleCount;
     _detectedVehicleType = result.detectedVehicleType;
-    emit availableSignalsChanged();
-    emit plottableSignalsChanged();
+    emit availableFieldsChanged();
+    emit plottableFieldsChanged();
     emit parametersChanged();
     emit eventsChanged();
     emit messagesChanged();
@@ -601,7 +601,7 @@ bool APMDataFlashLogParser::parseFile(const QString &filePath)
 
     _parsed = true;
     emit parsedChanged();
-    qCDebug(APMDataFlashLogParserLog) << "Parsed signals" << _availableSignals.count() << "parameters" << _parameters.count() << "events" << _events.count();
+    qCDebug(APMDataFlashLogParserLog) << "Parsed fields" << _availableFields.count() << "parameters" << _parameters.count() << "events" << _events.count();
     return true;
 }
 
@@ -626,17 +626,17 @@ void APMDataFlashLogParser::parseFileAsync(const QString &filePath)
             return;
         }
 
-        _availableSignals = result.availableSignals;
-        _plottableSignals = result.plottableSignals;
+        _availableFields = result.availableFields;
+        _plottableFields = result.plottableFields;
         _parameters = result.parameters;
         _events = result.events;
         _messages = result.messages;
         _modeSegments = result.modeSegments;
-        _signalSamples = result.signalSamples;
+        _fieldSamples = result.fieldSamples;
         _sampleCount = result.sampleCount;
         _detectedVehicleType = result.detectedVehicleType;
-        emit availableSignalsChanged();
-        emit plottableSignalsChanged();
+        emit availableFieldsChanged();
+        emit plottableFieldsChanged();
         emit parametersChanged();
         emit eventsChanged();
         emit messagesChanged();
@@ -672,9 +672,9 @@ void APMDataFlashLogParser::clear()
         emit parseErrorChanged();
     }
 
-    if (!_availableSignals.isEmpty()) {
-        _availableSignals.clear();
-        emit availableSignalsChanged();
+    if (!_availableFields.isEmpty()) {
+        _availableFields.clear();
+        emit availableFieldsChanged();
     }
 
     if (!_parameters.isEmpty()) {
@@ -702,12 +702,12 @@ void APMDataFlashLogParser::clear()
         emit detectedVehicleTypeChanged();
     }
 
-    if (!_plottableSignals.isEmpty()) {
-        _plottableSignals.clear();
-        emit plottableSignalsChanged();
+    if (!_plottableFields.isEmpty()) {
+        _plottableFields.clear();
+        emit plottableFieldsChanged();
     }
 
-    _signalSamples.clear();
+    _fieldSamples.clear();
     if (_minTimestamp != -1.0 || _maxTimestamp != -1.0) {
         _minTimestamp = -1.0;
         _maxTimestamp = -1.0;
@@ -720,15 +720,15 @@ void APMDataFlashLogParser::clear()
     }
 }
 
-QVariantList APMDataFlashLogParser::signalSamples(const QString &signalName) const
+QVariantList APMDataFlashLogParser::fieldSamples(const QString &fieldName) const
 {
     QVariantList output;
-    const auto signalIt = _signalSamples.constFind(signalName);
-    if (signalIt == _signalSamples.cend()) {
+    const auto fieldIt = _fieldSamples.constFind(fieldName);
+    if (fieldIt == _fieldSamples.cend()) {
         return output;
     }
 
-    const QVector<QPointF> &points = signalIt.value();
+    const QVector<QPointF> &points = fieldIt.value();
     output.reserve(points.size());
     for (const QPointF &point : points) {
         output.append(point);
@@ -737,14 +737,14 @@ QVariantList APMDataFlashLogParser::signalSamples(const QString &signalName) con
     return output;
 }
 
-double APMDataFlashLogParser::signalValueAt(const QString &signalName, double timestampSeconds) const
+double APMDataFlashLogParser::fieldValueAt(const QString &fieldName, double timestampSeconds) const
 {
-    const auto signalIt = _signalSamples.constFind(signalName);
-    if ((signalIt == _signalSamples.cend()) || signalIt->isEmpty()) {
+    const auto fieldIt = _fieldSamples.constFind(fieldName);
+    if ((fieldIt == _fieldSamples.cend()) || fieldIt->isEmpty()) {
         return std::numeric_limits<double>::quiet_NaN();
     }
 
-    const QVector<QPointF> &points = signalIt.value();
+    const QVector<QPointF> &points = fieldIt.value();
     const auto lower = std::lower_bound(points.cbegin(), points.cend(), timestampSeconds,
         [](const QPointF &point, double timestamp) {
             return point.x() < timestamp;

--- a/src/AnalyzeView/LogViewer/APMDataFlash/LogViewerDataFlashParser.cc
+++ b/src/AnalyzeView/LogViewer/APMDataFlash/LogViewerDataFlashParser.cc
@@ -1,0 +1,389 @@
+#include "LogViewerDataFlashParser.h"
+
+#include "APMDataFlashUtility.h"
+
+#include <QtCore/QByteArray>
+#include <QtCore/QCoreApplication>
+#include <QtCore/QFile>
+#include <QtCore/QHash>
+#include <QtCore/QSet>
+#include <QtCore/QVariantMap>
+
+#include <algorithm>
+#include <limits>
+
+namespace {
+
+QString _vehicleTypeFromMessageText(const QString &messageText)
+{
+    const QString text = messageText.toLower();
+    if (text.contains(QStringLiteral("arducopter"))) { return QStringLiteral("ArduCopter"); }
+    if (text.contains(QStringLiteral("arduplane")))  { return QStringLiteral("ArduPlane"); }
+    if (text.contains(QStringLiteral("ardurover")))  { return QStringLiteral("ArduRover"); }
+    if (text.contains(QStringLiteral("ardusub")))    { return QStringLiteral("ArduSub"); }
+    return QString();
+}
+
+QString _ardupilotModeName(const QString &vehicleType, int modeNumber)
+{
+    static const QHash<int, QString> planeModes = {
+        {0,QStringLiteral("Manual")},{1,QStringLiteral("CIRCLE")},{2,QStringLiteral("STABILIZE")},
+        {3,QStringLiteral("TRAINING")},{4,QStringLiteral("ACRO")},{5,QStringLiteral("FBWA")},
+        {6,QStringLiteral("FBWB")},{7,QStringLiteral("CRUISE")},{8,QStringLiteral("AUTOTUNE")},
+        {10,QStringLiteral("Auto")},{11,QStringLiteral("RTL")},{12,QStringLiteral("Loiter")},
+        {13,QStringLiteral("TAKEOFF")},{14,QStringLiteral("AVOID_ADSB")},{15,QStringLiteral("Guided")},
+        {17,QStringLiteral("QSTABILIZE")},{18,QStringLiteral("QHOVER")},{19,QStringLiteral("QLOITER")},
+        {20,QStringLiteral("QLAND")},{21,QStringLiteral("QRTL")},{22,QStringLiteral("QAUTOTUNE")},
+        {23,QStringLiteral("QACRO")},{24,QStringLiteral("THERMAL")},{25,QStringLiteral("Loiter to QLand")},
+        {26,QStringLiteral("AUTOLAND")},
+    };
+    static const QHash<int, QString> copterModes = {
+        {0,QStringLiteral("Stabilize")},{1,QStringLiteral("Acro")},{2,QStringLiteral("AltHold")},
+        {3,QStringLiteral("Auto")},{4,QStringLiteral("Guided")},{5,QStringLiteral("Loiter")},
+        {6,QStringLiteral("RTL")},{7,QStringLiteral("Circle")},{9,QStringLiteral("Land")},
+        {11,QStringLiteral("Drift")},{13,QStringLiteral("Sport")},{14,QStringLiteral("Flip")},
+        {15,QStringLiteral("AutoTune")},{16,QStringLiteral("PosHold")},{17,QStringLiteral("Brake")},
+        {18,QStringLiteral("Throw")},{19,QStringLiteral("Avoid_ADSB")},{20,QStringLiteral("Guided_NoGPS")},
+        {21,QStringLiteral("Smart_RTL")},{22,QStringLiteral("FlowHold")},{23,QStringLiteral("Follow")},
+        {24,QStringLiteral("ZigZag")},{25,QStringLiteral("SystemID")},{26,QStringLiteral("Heli_Autorotate")},
+        {27,QStringLiteral("Auto RTL")},{28,QStringLiteral("Turtle")},
+    };
+    if (vehicleType == QStringLiteral("ArduPlane")) {
+        return planeModes.value(modeNumber, QStringLiteral("Mode %1").arg(modeNumber));
+    }
+    if (vehicleType == QStringLiteral("ArduCopter")) {
+        return copterModes.value(modeNumber, QStringLiteral("Mode %1").arg(modeNumber));
+    }
+    return QStringLiteral("Mode %1").arg(modeNumber);
+}
+
+QString _ardupilotErrDescription(int subsystem, int ecode)
+{
+    QString sub;
+    switch (subsystem) {
+    case 1:  sub = QCoreApplication::translate("LogFileParser", "Main"); break;
+    case 2:  sub = QCoreApplication::translate("LogFileParser", "Radio"); break;
+    case 3:  sub = QCoreApplication::translate("LogFileParser", "Compass"); break;
+    case 4:  sub = QCoreApplication::translate("LogFileParser", "Optflow"); break;
+    case 5:  sub = QCoreApplication::translate("LogFileParser", "Radio Failsafe"); break;
+    case 6:  sub = QCoreApplication::translate("LogFileParser", "Battery Failsafe"); break;
+    case 7:  sub = QCoreApplication::translate("LogFileParser", "GPS Failsafe"); break;
+    case 8:  sub = QCoreApplication::translate("LogFileParser", "GCS Failsafe"); break;
+    case 9:  sub = QCoreApplication::translate("LogFileParser", "Fence Failsafe"); break;
+    case 10: sub = QCoreApplication::translate("LogFileParser", "Flight mode"); break;
+    case 11: sub = QCoreApplication::translate("LogFileParser", "GPS"); break;
+    case 12: sub = QCoreApplication::translate("LogFileParser", "Crash Check"); break;
+    case 13: sub = QCoreApplication::translate("LogFileParser", "Flip"); break;
+    case 14: sub = QCoreApplication::translate("LogFileParser", "Autotune"); break;
+    case 15: sub = QCoreApplication::translate("LogFileParser", "Parachute"); break;
+    case 16: sub = QCoreApplication::translate("LogFileParser", "EKF Check"); break;
+    case 17: sub = QCoreApplication::translate("LogFileParser", "EKF Failsafe"); break;
+    case 18: sub = QCoreApplication::translate("LogFileParser", "Barometer"); break;
+    case 19: sub = QCoreApplication::translate("LogFileParser", "CPU Load Watchdog"); break;
+    case 20: sub = QCoreApplication::translate("LogFileParser", "ADSB Failsafe"); break;
+    case 21: sub = QCoreApplication::translate("LogFileParser", "Terrain Data"); break;
+    case 22: sub = QCoreApplication::translate("LogFileParser", "Navigation"); break;
+    case 23: sub = QCoreApplication::translate("LogFileParser", "Terrain Failsafe"); break;
+    case 24: sub = QCoreApplication::translate("LogFileParser", "EKF Primary"); break;
+    case 25: sub = QCoreApplication::translate("LogFileParser", "Thrust Loss Check"); break;
+    case 26: sub = QCoreApplication::translate("LogFileParser", "Sensor Failsafe"); break;
+    case 27: sub = QCoreApplication::translate("LogFileParser", "Leak Failsafe"); break;
+    case 28: sub = QCoreApplication::translate("LogFileParser", "Pilot Input"); break;
+    case 29: sub = QCoreApplication::translate("LogFileParser", "Vibration Failsafe"); break;
+    case 30: sub = QCoreApplication::translate("LogFileParser", "Internal Error"); break;
+    case 31: sub = QCoreApplication::translate("LogFileParser", "Deadreckon Failsafe"); break;
+    default: sub = QCoreApplication::translate("LogFileParser", "Subsystem %1").arg(subsystem); break;
+    }
+    return QStringLiteral("%1 (%2): Code %3").arg(sub).arg(subsystem).arg(ecode);
+}
+
+QString _ardupilotEventDescription(int eventId)
+{
+    switch (eventId) {
+    case 10: return QCoreApplication::translate("LogFileParser", "Armed");
+    case 11: return QCoreApplication::translate("LogFileParser", "Disarmed");
+    case 15: return QCoreApplication::translate("LogFileParser", "Auto Armed");
+    case 17: return QCoreApplication::translate("LogFileParser", "Land Complete Maybe");
+    case 18: return QCoreApplication::translate("LogFileParser", "Land Complete");
+    case 19: return QCoreApplication::translate("LogFileParser", "Lost GPS");
+    case 21: return QCoreApplication::translate("LogFileParser", "Flip Start");
+    case 22: return QCoreApplication::translate("LogFileParser", "Flip End");
+    case 25: return QCoreApplication::translate("LogFileParser", "Set Home");
+    case 26: return QCoreApplication::translate("LogFileParser", "Simple Mode Enabled");
+    case 27: return QCoreApplication::translate("LogFileParser", "Simple Mode Disabled");
+    case 28: return QCoreApplication::translate("LogFileParser", "Not Landed");
+    case 29: return QCoreApplication::translate("LogFileParser", "Super Simple Mode Enabled");
+    case 30: return QCoreApplication::translate("LogFileParser", "AutoTune Initialised");
+    case 31: return QCoreApplication::translate("LogFileParser", "AutoTune Off");
+    case 32: return QCoreApplication::translate("LogFileParser", "AutoTune Restart");
+    case 33: return QCoreApplication::translate("LogFileParser", "AutoTune Success");
+    case 34: return QCoreApplication::translate("LogFileParser", "AutoTune Failed");
+    case 35: return QCoreApplication::translate("LogFileParser", "AutoTune Reached Limit");
+    case 36: return QCoreApplication::translate("LogFileParser", "AutoTune Pilot Testing");
+    case 37: return QCoreApplication::translate("LogFileParser", "AutoTune Saved Gains");
+    case 38: return QCoreApplication::translate("LogFileParser", "Save Trim");
+    case 39: return QCoreApplication::translate("LogFileParser", "Save Waypoint Add");
+    case 41: return QCoreApplication::translate("LogFileParser", "Fence Enabled");
+    case 42: return QCoreApplication::translate("LogFileParser", "Fence Disabled");
+    case 43: return QCoreApplication::translate("LogFileParser", "Acro Trainer Off");
+    case 44: return QCoreApplication::translate("LogFileParser", "Acro Trainer Leveling");
+    case 45: return QCoreApplication::translate("LogFileParser", "Acro Trainer Limited");
+    case 46: return QCoreApplication::translate("LogFileParser", "Gripper Grab");
+    case 47: return QCoreApplication::translate("LogFileParser", "Gripper Release");
+    case 49: return QCoreApplication::translate("LogFileParser", "Parachute Disabled");
+    case 50: return QCoreApplication::translate("LogFileParser", "Parachute Enabled");
+    case 51: return QCoreApplication::translate("LogFileParser", "Parachute Released");
+    case 52: return QCoreApplication::translate("LogFileParser", "Landing Gear Deployed");
+    case 53: return QCoreApplication::translate("LogFileParser", "Landing Gear Retracted");
+    case 54: return QCoreApplication::translate("LogFileParser", "Motors Emergency Stopped");
+    case 55: return QCoreApplication::translate("LogFileParser", "Motors Emergency Stop Cleared");
+    case 56: return QCoreApplication::translate("LogFileParser", "Motors Interlock Disabled");
+    case 57: return QCoreApplication::translate("LogFileParser", "Motors Interlock Enabled");
+    case 58: return QCoreApplication::translate("LogFileParser", "Rotor Runup Complete");
+    case 59: return QCoreApplication::translate("LogFileParser", "Rotor Speed Below Critical");
+    case 60: return QCoreApplication::translate("LogFileParser", "EKF Altitude Reset");
+    case 61: return QCoreApplication::translate("LogFileParser", "Land Cancelled By Pilot");
+    case 62: return QCoreApplication::translate("LogFileParser", "EKF Yaw Reset");
+    case 63: return QCoreApplication::translate("LogFileParser", "ADSB Avoidance Enabled");
+    case 64: return QCoreApplication::translate("LogFileParser", "ADSB Avoidance Disabled");
+    case 65: return QCoreApplication::translate("LogFileParser", "Proximity Avoidance Enabled");
+    case 66: return QCoreApplication::translate("LogFileParser", "Proximity Avoidance Disabled");
+    case 67: return QCoreApplication::translate("LogFileParser", "GPS Primary Changed");
+    case 71: return QCoreApplication::translate("LogFileParser", "ZigZag Store A");
+    case 72: return QCoreApplication::translate("LogFileParser", "ZigZag Store B");
+    case 73: return QCoreApplication::translate("LogFileParser", "Land Repo Active");
+    case 74: return QCoreApplication::translate("LogFileParser", "Standby Enabled");
+    case 75: return QCoreApplication::translate("LogFileParser", "Standby Disabled");
+    case 76: return QCoreApplication::translate("LogFileParser", "Fence Alt Max Enabled");
+    case 77: return QCoreApplication::translate("LogFileParser", "Fence Alt Max Disabled");
+    case 78: return QCoreApplication::translate("LogFileParser", "Fence Circle Enabled");
+    case 79: return QCoreApplication::translate("LogFileParser", "Fence Circle Disabled");
+    case 80: return QCoreApplication::translate("LogFileParser", "Fence Alt Min Enabled");
+    case 81: return QCoreApplication::translate("LogFileParser", "Fence Alt Min Disabled");
+    case 82: return QCoreApplication::translate("LogFileParser", "Fence Polygon Enabled");
+    case 83: return QCoreApplication::translate("LogFileParser", "Fence Polygon Disabled");
+    case 85: return QCoreApplication::translate("LogFileParser", "EK3 Source Set: Primary");
+    case 86: return QCoreApplication::translate("LogFileParser", "EK3 Source Set: Secondary");
+    case 87: return QCoreApplication::translate("LogFileParser", "EK3 Source Set: Tertiary");
+    case 90: return QCoreApplication::translate("LogFileParser", "Airspeed Primary Changed");
+    case 163: return QCoreApplication::translate("LogFileParser", "Surfaced");
+    case 164: return QCoreApplication::translate("LogFileParser", "Not Surfaced");
+    case 165: return QCoreApplication::translate("LogFileParser", "Bottomed");
+    case 166: return QCoreApplication::translate("LogFileParser", "Not Bottomed");
+    default: return QCoreApplication::translate("LogFileParser", "Event %1").arg(eventId);
+    }
+}
+
+double _extractTimestampSeconds(const QMap<QString, QVariant> &values)
+{
+    if (values.contains(QStringLiteral("TimeUS"))) {
+        return values.value(QStringLiteral("TimeUS")).toDouble() / 1000000.0;
+    }
+    if (values.contains(QStringLiteral("TimeMS"))) {
+        return values.value(QStringLiteral("TimeMS")).toDouble() / 1000.0;
+    }
+    if (values.contains(QStringLiteral("Time"))) {
+        return values.value(QStringLiteral("Time")).toDouble() / 1000.0;
+    }
+    return -1.0;
+}
+
+void _appendEvent(QVariantList &events, double timestampSecs, const QString &type, const QString &description)
+{
+    if ((timestampSecs < 0.0) || description.isEmpty()) {
+        return;
+    }
+    QVariantMap eventRow;
+    eventRow[QStringLiteral("time")] = timestampSecs;
+    eventRow[QStringLiteral("type")] = type;
+    eventRow[QStringLiteral("description")] = description;
+    events.append(eventRow);
+}
+
+} // namespace
+
+namespace DataFlashParser {
+
+LogParseResult parseFile(const QString &filePath)
+{
+    LogParseResult result;
+
+    QFile file(filePath);
+    if (!file.open(QIODevice::ReadOnly)) {
+        result.errorMessage = QCoreApplication::translate("LogFileParser", "Failed to open file");
+        return result;
+    }
+
+    const qint64 fileSize = file.size();
+    if (fileSize <= 0) {
+        result.errorMessage = QCoreApplication::translate("LogFileParser", "File is empty");
+        return result;
+    }
+    if (fileSize > std::numeric_limits<qsizetype>::max()) {
+        result.errorMessage = QCoreApplication::translate("LogFileParser", "File is too large to parse");
+        return result;
+    }
+
+    uchar *const mappedData = file.map(0, fileSize);
+    if (mappedData == nullptr) {
+        result.errorMessage = QCoreApplication::translate("LogFileParser", "Failed to memory-map file");
+        return result;
+    }
+
+    struct ScopedUnmap {
+        QFile &file;
+        uchar *data = nullptr;
+        ~ScopedUnmap() { if (data) { file.unmap(data); } }
+    } scopedUnmap{file, mappedData};
+
+    const char *const raw = reinterpret_cast<const char *>(mappedData);
+
+    // Verify DataFlash magic
+    if (fileSize < 3 ||
+        static_cast<uint8_t>(raw[0]) != 0xA3 ||
+        static_cast<uint8_t>(raw[1]) != 0x95) {
+        result.errorMessage = QCoreApplication::translate("LogFileParser", "File does not appear to be a DataFlash log (invalid header)");
+        return result;
+    }
+
+    const QByteArray bytes = QByteArray::fromRawData(raw, static_cast<qsizetype>(fileSize));
+
+    QMap<uint8_t, APMDataFlashUtility::MessageFormat> formats;
+    if (!APMDataFlashUtility::parseFmtMessages(bytes.constData(), bytes.size(), formats)) {
+        result.errorMessage = QCoreApplication::translate("LogFileParser", "No valid FMT messages were found");
+        return result;
+    }
+
+    QSet<QString> fieldSet;
+    QSet<QString> plottableFieldSet;
+    double minTimestampSecs = -1.0;
+    double maxTimestampSecs = -1.0;
+    bool hasOpenModeSegment = false;
+    double modeSegmentStartSecs = -1.0;
+    QString currentModeName;
+
+    QHash<uint8_t, QHash<QString, QString>> fieldNameByCol;
+    fieldNameByCol.reserve(formats.size());
+    for (auto fmtIt = formats.cbegin(); fmtIt != formats.cend(); ++fmtIt) {
+        const APMDataFlashUtility::MessageFormat &fmt = fmtIt.value();
+        QHash<QString, QString> &perCol = fieldNameByCol[fmtIt.key()];
+        perCol.reserve(fmt.columns.size());
+        for (const QString &col : fmt.columns) {
+            perCol.insert(col, fmt.name + QLatin1Char('.') + col);
+        }
+    }
+
+    static const QString kPARM = QStringLiteral("PARM");
+    static const QString kMSG  = QStringLiteral("MSG");
+    static const QString kMODE = QStringLiteral("MODE");
+    static const QString kERR  = QStringLiteral("ERR");
+    static const QString kEV   = QStringLiteral("EV");
+
+    APMDataFlashUtility::iterateMessages(bytes.constData(), bytes.size(), formats,
+        [&](uint8_t msgType, const char *payload, int, const APMDataFlashUtility::MessageFormat &fmt) {
+        const QMap<QString, QVariant> values = APMDataFlashUtility::parseMessage(payload, fmt);
+        const double timestampSecs = _extractTimestampSeconds(values);
+        if (timestampSecs >= 0.0) {
+            if (minTimestampSecs < 0.0 || timestampSecs < minTimestampSecs) { minTimestampSecs = timestampSecs; }
+            maxTimestampSecs = std::max(maxTimestampSecs, timestampSecs);
+        }
+
+        if (fmt.name == kPARM) {
+            const QString paramName = values.value(QStringLiteral("Name")).toString();
+            const QVariant paramValue = values.contains(QStringLiteral("Value"))
+                ? values.value(QStringLiteral("Value"))
+                : values.value(QStringLiteral("Val"));
+            if (!paramName.isEmpty()) {
+                QVariantMap row;
+                row[QStringLiteral("name")] = paramName;
+                row[QStringLiteral("value")] = paramValue;
+                result.parameters.append(row);
+            }
+        } else if (fmt.name == kMSG) {
+            const QString text = values.value(QStringLiteral("Message")).toString();
+            const QString detected = _vehicleTypeFromMessageText(text);
+            if (result.detectedVehicleType.isEmpty() && !detected.isEmpty()) {
+                result.detectedVehicleType = detected;
+            }
+            if (!text.isEmpty()) {
+                QVariantMap row;
+                row[QStringLiteral("time")] = timestampSecs;
+                row[QStringLiteral("text")] = text;
+                result.messages.append(row);
+            }
+        } else if (fmt.name == kMODE) {
+            QString modeName = values.value(QStringLiteral("Mode")).toString();
+            bool isNumeric = false;
+            const int modeNumber = modeName.toInt(&isNumeric);
+            if (isNumeric) {
+                modeName = _ardupilotModeName(result.detectedVehicleType, modeNumber);
+            } else if (modeName.isEmpty()) {
+                modeName = QCoreApplication::translate("LogFileParser", "Unknown");
+            }
+            _appendEvent(result.events, timestampSecs, QStringLiteral("mode"),
+                         QCoreApplication::translate("LogFileParser", "Mode: %1").arg(modeName));
+            if (timestampSecs >= 0.0) {
+                if (hasOpenModeSegment && (timestampSecs > modeSegmentStartSecs)) {
+                    QVariantMap segment;
+                    segment[QStringLiteral("mode")] = currentModeName;
+                    segment[QStringLiteral("start")] = modeSegmentStartSecs;
+                    segment[QStringLiteral("end")] = timestampSecs;
+                    result.modeSegments.append(segment);
+                }
+                hasOpenModeSegment = true;
+                modeSegmentStartSecs = timestampSecs;
+                currentModeName = modeName;
+            }
+        } else if (fmt.name == kERR) {
+            const int subsystem = values.value(QStringLiteral("Subsys")).toInt();
+            const int ecode = values.value(QStringLiteral("ECode")).toInt();
+            _appendEvent(result.events, timestampSecs, QStringLiteral("error"),
+                         _ardupilotErrDescription(subsystem, ecode));
+        } else if (fmt.name == kEV) {
+            const int eventId = values.value(QStringLiteral("Id"), values.value(QStringLiteral("Event"))).toInt();
+            _appendEvent(result.events, timestampSecs, QStringLiteral("event"),
+                         _ardupilotEventDescription(eventId));
+        }
+
+        result.sampleCount++;
+
+        const QHash<QString, QString> &perCol = fieldNameByCol[msgType];
+        const bool haveTimestamp = (timestampSecs >= 0.0);
+        for (auto it = values.cbegin(); it != values.cend(); ++it) {
+            const auto nameIt = perCol.constFind(it.key());
+            if (nameIt == perCol.constEnd()) { continue; }
+            const QString &fieldName = nameIt.value();
+            fieldSet.insert(fieldName);
+            if (!haveTimestamp) { continue; }
+            const int typeId = it.value().metaType().id();
+            const bool numeric =
+                (typeId == QMetaType::Int) || (typeId == QMetaType::UInt) ||
+                (typeId == QMetaType::LongLong) || (typeId == QMetaType::ULongLong) ||
+                (typeId == QMetaType::Float) || (typeId == QMetaType::Double);
+            if (numeric) {
+                result.fieldSamples[fieldName].append(QPointF(timestampSecs, it.value().toDouble()));
+                plottableFieldSet.insert(fieldName);
+            }
+        }
+        return true;
+    });
+
+    if (hasOpenModeSegment && (maxTimestampSecs >= modeSegmentStartSecs)) {
+        QVariantMap segment;
+        segment[QStringLiteral("mode")] = currentModeName;
+        segment[QStringLiteral("start")] = modeSegmentStartSecs;
+        segment[QStringLiteral("end")] = maxTimestampSecs;
+        result.modeSegments.append(segment);
+    }
+
+    result.availableFields = fieldSet.values();
+    std::sort(result.availableFields.begin(), result.availableFields.end());
+    result.plottableFields = plottableFieldSet.values();
+    std::sort(result.plottableFields.begin(), result.plottableFields.end());
+    result.minTimestamp = minTimestampSecs;
+    result.maxTimestamp = maxTimestampSecs;
+    result.ok = true;
+    return result;
+}
+
+} // namespace DataFlashParser

--- a/src/AnalyzeView/LogViewer/APMDataFlash/LogViewerDataFlashParser.h
+++ b/src/AnalyzeView/LogViewer/APMDataFlash/LogViewerDataFlashParser.h
@@ -1,0 +1,13 @@
+#pragma once
+
+#include "LogParseResultPrivate.h"
+// Note: named LogViewerDataFlashParser to avoid collision with GeoTag/DataFlashParser.h
+
+#include <QtCore/QString>
+
+// Free-function parser for ArduPilot DataFlash (.bin / .log) files.
+// Returns a filled LogParseResult on success (result.ok == true) or an error
+// message in result.errorMessage on failure.
+namespace DataFlashParser {
+    LogParseResult parseFile(const QString &filePath);
+}

--- a/src/AnalyzeView/LogViewer/CMakeLists.txt
+++ b/src/AnalyzeView/LogViewer/CMakeLists.txt
@@ -1,18 +1,28 @@
 # ============================================================================
 # Unified Log Viewer Module
-# Shared shell for .tlog and .bin log workflows
+# Shared shell for .tlog, .bin (DataFlash), and .ulg (PX4 ULog) log workflows
 # ============================================================================
 
 target_sources(${CMAKE_PROJECT_NAME}
     PRIVATE
         APMDataFlash/APMDataFlashLogParser.cc
         APMDataFlash/APMDataFlashLogParser.h
+        APMDataFlash/LogViewerDataFlashParser.cc
+        APMDataFlash/LogViewerDataFlashParser.h
+        LogFileParser.cc
+        LogFileParser.h
+        LogParseResultPrivate.h
         LogViewerController.cc
         LogViewerController.h
+        PX4ULog/ULogFullHandler.cc
+        PX4ULog/ULogFullHandler.h
+        PX4ULog/LogViewerULogParser.cc
+        PX4ULog/LogViewerULogParser.h
 )
 
 target_include_directories(${CMAKE_PROJECT_NAME}
     PRIVATE
         ${CMAKE_CURRENT_SOURCE_DIR}
         ${CMAKE_CURRENT_SOURCE_DIR}/APMDataFlash
+        ${CMAKE_CURRENT_SOURCE_DIR}/PX4ULog
 )

--- a/src/AnalyzeView/LogViewer/LogFileParser.cc
+++ b/src/AnalyzeView/LogViewer/LogFileParser.cc
@@ -1,0 +1,227 @@
+#include "LogFileParser.h"
+
+#include "LogViewerDataFlashParser.h"
+#include "LogParseResultPrivate.h"
+#include "QGCLoggingCategory.h"
+#include "LogViewerULogParser.h"
+
+#include <QtConcurrent/QtConcurrent>
+#include <QtCore/QFileInfo>
+#include <QtCore/QFutureWatcher>
+
+#include <algorithm>
+#include <cmath>
+#include <limits>
+
+QGC_LOGGING_CATEGORY(LogFileParserLog, "AnalyzeView.LogFileParser")
+
+namespace {
+
+LogParseResult _parseFile(const QString &filePath)
+{
+    const QString suffix = QFileInfo(filePath).suffix().toLower();
+
+    if (suffix == QStringLiteral("bin") || suffix == QStringLiteral("log")) {
+        return DataFlashParser::parseFile(filePath);
+    }
+
+    if (suffix == QStringLiteral("ulg")) {
+        return ULogParser::parseFile(filePath);
+    }
+
+    const QString fileTypeDescription = suffix.isEmpty()
+        ? LogFileParser::tr("no extension")
+        : QStringLiteral(".%1").arg(suffix);
+
+    LogParseResult result;
+    result.errorMessage = LogFileParser::tr(
+        "Unsupported file type (%1) for file '%2'. Expected .bin, .log, or .ulg.")
+        .arg(fileTypeDescription, filePath);
+    return result;
+}
+
+} // namespace
+
+// ============================================================================
+// LogFileParser
+// ============================================================================
+
+LogFileParser::LogFileParser(QObject *parent)
+    : QObject(parent)
+{
+    qCDebug(LogFileParserLog) << this;
+}
+
+LogFileParser::~LogFileParser()
+{
+    qCDebug(LogFileParserLog) << this;
+}
+
+bool LogFileParser::parseFile(const QString &filePath)
+{
+    ++_parseRequestId;
+    clear();
+    const LogParseResult result = _parseFile(filePath);
+    if (!result.ok) {
+        _setParseError(result.errorMessage);
+        return false;
+    }
+    _applyResult(result);
+    qCDebug(LogFileParserLog) << "Parsed fields" << _availableFields.count()
+                              << "parameters" << _parameters.count()
+                              << "events" << _events.count();
+    return true;
+}
+
+void LogFileParser::parseFileAsync(const QString &filePath)
+{
+    const quint64 requestId = ++_parseRequestId;
+    clear();
+
+    auto *watcher = new QFutureWatcher<LogParseResult>(this);
+    (void) connect(watcher, &QFutureWatcher<LogParseResult>::finished, this,
+        [this, watcher, filePath, requestId]() {
+            const LogParseResult result = watcher->result();
+            watcher->deleteLater();
+
+            if (requestId != _parseRequestId) {
+                return;
+            }
+
+            if (!result.ok) {
+                _setParseError(result.errorMessage);
+                emit parseFileFinished(filePath, false, result.errorMessage);
+                return;
+            }
+
+            _applyResult(result);
+            emit parseFileFinished(filePath, true, QString());
+        });
+
+    watcher->setFuture(QtConcurrent::run([filePath]() {
+        return _parseFile(filePath);
+    }));
+}
+
+void LogFileParser::_applyResult(const LogParseResult &result)
+{
+    _availableFields = result.availableFields;
+    _plottableFields = result.plottableFields;
+    _parameters = result.parameters;
+    _events = result.events;
+    _messages = result.messages;
+    _modeSegments = result.modeSegments;
+    _dropouts = result.dropouts;
+    _fieldSamples = result.fieldSamples;
+    _sampleCount = result.sampleCount;
+    _detectedVehicleType = result.detectedVehicleType;
+    emit availableFieldsChanged();
+    emit plottableFieldsChanged();
+    emit parametersChanged();
+    emit eventsChanged();
+    emit messagesChanged();
+    emit modeSegmentsChanged();
+    emit dropoutsChanged();
+    emit detectedVehicleTypeChanged();
+    if (_minTimestamp != result.minTimestamp || _maxTimestamp != result.maxTimestamp) {
+        _minTimestamp = result.minTimestamp;
+        _maxTimestamp = result.maxTimestamp;
+        emit timeRangeChanged();
+    }
+    emit sampleCountChanged();
+
+    _parsed = true;
+    emit parsedChanged();
+}
+
+void LogFileParser::clear()
+{
+    const bool oldParsed = _parsed;
+    _parsed = false;
+    if (oldParsed) { emit parsedChanged(); }
+
+    if (!_parseError.isEmpty()) { _parseError.clear(); emit parseErrorChanged(); }
+    if (!_availableFields.isEmpty()) { _availableFields.clear(); emit availableFieldsChanged(); }
+    if (!_parameters.isEmpty()) { _parameters.clear(); emit parametersChanged(); }
+    if (!_events.isEmpty()) { _events.clear(); emit eventsChanged(); }
+    if (!_messages.isEmpty()) { _messages.clear(); emit messagesChanged(); }
+    if (!_modeSegments.isEmpty()) { _modeSegments.clear(); emit modeSegmentsChanged(); }
+    if (!_dropouts.isEmpty()) { _dropouts.clear(); emit dropoutsChanged(); }
+    if (!_detectedVehicleType.isEmpty()) { _detectedVehicleType.clear(); emit detectedVehicleTypeChanged(); }
+    if (!_plottableFields.isEmpty()) { _plottableFields.clear(); emit plottableFieldsChanged(); }
+
+    _fieldSamples.clear();
+    if (_minTimestamp != -1.0 || _maxTimestamp != -1.0) {
+        _minTimestamp = -1.0;
+        _maxTimestamp = -1.0;
+        emit timeRangeChanged();
+    }
+    if (_sampleCount != 0) { _sampleCount = 0; emit sampleCountChanged(); }
+}
+
+QVariantList LogFileParser::fieldSamples(const QString &fieldName) const
+{
+    QVariantList output;
+    const auto it = _fieldSamples.constFind(fieldName);
+    if (it == _fieldSamples.cend()) { return output; }
+    const QVector<QPointF> &points = it.value();
+    output.reserve(points.size());
+    for (const QPointF &p : points) { output.append(p); }
+    return output;
+}
+
+double LogFileParser::fieldValueAt(const QString &fieldName, double timestampSeconds) const
+{
+    const auto it = _fieldSamples.constFind(fieldName);
+    if (it == _fieldSamples.cend() || it->isEmpty()) {
+        return std::numeric_limits<double>::quiet_NaN();
+    }
+    const QVector<QPointF> &points = it.value();
+    const auto lower = std::lower_bound(points.cbegin(), points.cend(), timestampSeconds,
+        [](const QPointF &p, double t) { return p.x() < t; });
+
+    if (lower == points.cbegin()) { return lower->y(); }
+    if (lower == points.cend()) { return points.constLast().y(); }
+
+    const auto prev = std::prev(lower);
+    return (std::fabs(prev->x() - timestampSeconds) <= std::fabs(lower->x() - timestampSeconds))
+        ? prev->y() : lower->y();
+}
+
+QString LogFileParser::modeAt(double timestampSeconds) const
+{
+    for (const QVariant &v : _modeSegments) {
+        const QVariantMap seg = v.toMap();
+        const double start = seg.value(QStringLiteral("start")).toDouble();
+        const double end   = seg.value(QStringLiteral("end")).toDouble();
+        if (timestampSeconds >= start && timestampSeconds <= end) {
+            return seg.value(QStringLiteral("mode")).toString();
+        }
+    }
+    return QString();
+}
+
+QVariantList LogFileParser::eventsNear(double timestampSeconds, double thresholdSeconds) const
+{
+    QVariantList matches;
+    const double threshold = std::max(0.0, thresholdSeconds);
+    const auto lower = std::lower_bound(_events.cbegin(), _events.cend(),
+        timestampSeconds - threshold,
+        [](const QVariant &v, double t) {
+            return v.toMap().value(QStringLiteral("time")).toDouble() < t;
+        });
+    for (auto it = lower; it != _events.cend(); ++it) {
+        const QVariantMap ev = it->toMap();
+        if (ev.value(QStringLiteral("time")).toDouble() > timestampSeconds + threshold) { break; }
+        matches.append(ev);
+    }
+    return matches;
+}
+
+void LogFileParser::_setParseError(const QString &error)
+{
+    if (_parseError != error) {
+        _parseError = error;
+        emit parseErrorChanged();
+    }
+}

--- a/src/AnalyzeView/LogViewer/LogFileParser.h
+++ b/src/AnalyzeView/LogViewer/LogFileParser.h
@@ -1,7 +1,7 @@
 #pragma once
 
-#include <QtCore/QObject>
 #include <QtCore/QHash>
+#include <QtCore/QObject>
 #include <QtCore/QPointF>
 #include <QtCore/QString>
 #include <QtCore/QStringList>
@@ -11,12 +11,25 @@
 #include <QtCore/QtGlobal>
 #include <QtQmlIntegration/QtQmlIntegration>
 
-class APMDataFlashLogParser : public QObject
+/// Unified log file parser for both DataFlash (.bin/.log) and PX4 ULog (.ulg) files.
+///
+/// Dispatches by file extension, verifies the header magic bytes match the expected
+/// format, then parses the file into a canonical set of properties that the log
+/// viewer UI consumes identically for both formats:
+///
+///  - availableFields / plottableFields — two-level "Type.Field" hierarchy
+///  - fieldSamples(name) — time-series (QPointF) for charting
+///  - modeSegments — flight-mode bands for the chart timeline
+///  - events — timestamped events / errors / warnings
+///  - parameters — parameter name/value pairs from the log
+///  - messages — free-text log messages
+///  - dropouts — (ULog only) data-dropout intervals rendered as chart overlays
+class LogFileParser : public QObject
 {
     Q_OBJECT
     QML_ELEMENT
 
-    Q_PROPERTY(bool        parsed              READ parsed              NOTIFY parsedChanged)
+    Q_PROPERTY(bool         parsed              READ parsed              NOTIFY parsedChanged)
     Q_PROPERTY(QString      parseError          READ parseError          NOTIFY parseErrorChanged)
     Q_PROPERTY(QStringList  availableFields     READ availableFields     NOTIFY availableFieldsChanged)
     Q_PROPERTY(QVariantList parameters          READ parameters          NOTIFY parametersChanged)
@@ -24,14 +37,15 @@ class APMDataFlashLogParser : public QObject
     Q_PROPERTY(QVariantList messages            READ messages            NOTIFY messagesChanged)
     Q_PROPERTY(QStringList  plottableFields     READ plottableFields     NOTIFY plottableFieldsChanged)
     Q_PROPERTY(QVariantList modeSegments        READ modeSegments        NOTIFY modeSegmentsChanged)
+    Q_PROPERTY(QVariantList dropouts            READ dropouts            NOTIFY dropoutsChanged)
     Q_PROPERTY(QString      detectedVehicleType READ detectedVehicleType NOTIFY detectedVehicleTypeChanged)
     Q_PROPERTY(double       minTimestamp        READ minTimestamp        NOTIFY timeRangeChanged)
     Q_PROPERTY(double       maxTimestamp        READ maxTimestamp        NOTIFY timeRangeChanged)
     Q_PROPERTY(int          sampleCount         READ sampleCount         NOTIFY sampleCountChanged)
 
 public:
-    explicit APMDataFlashLogParser(QObject *parent = nullptr);
-    ~APMDataFlashLogParser();
+    explicit LogFileParser(QObject *parent = nullptr);
+    ~LogFileParser();
 
     bool parsed() const { return _parsed; }
     QString parseError() const { return _parseError; }
@@ -41,6 +55,7 @@ public:
     QVariantList messages() const { return _messages; }
     QStringList plottableFields() const { return _plottableFields; }
     QVariantList modeSegments() const { return _modeSegments; }
+    QVariantList dropouts() const { return _dropouts; }
     QString detectedVehicleType() const { return _detectedVehicleType; }
     double minTimestamp() const { return _minTimestamp; }
     double maxTimestamp() const { return _maxTimestamp; }
@@ -63,6 +78,7 @@ signals:
     void messagesChanged();
     void plottableFieldsChanged();
     void modeSegmentsChanged();
+    void dropoutsChanged();
     void detectedVehicleTypeChanged();
     void timeRangeChanged();
     void sampleCountChanged();
@@ -70,6 +86,7 @@ signals:
 
 private:
     void _setParseError(const QString &error);
+    void _applyResult(const struct LogParseResult &result);
 
     bool _parsed = false;
     QString _parseError;
@@ -79,6 +96,7 @@ private:
     QVariantList _events;
     QVariantList _messages;
     QVariantList _modeSegments;
+    QVariantList _dropouts;
     QString _detectedVehicleType;
     QHash<QString, QVector<QPointF>> _fieldSamples;
     double _minTimestamp = -1.0;

--- a/src/AnalyzeView/LogViewer/LogParseResultPrivate.h
+++ b/src/AnalyzeView/LogViewer/LogParseResultPrivate.h
@@ -1,0 +1,28 @@
+#pragma once
+
+// Private implementation detail shared between LogFileParser.cc and ULogFullHandler.cc.
+// Do NOT include this header from any public-facing header.
+
+#include <QtCore/QHash>
+#include <QtCore/QPointF>
+#include <QtCore/QString>
+#include <QtCore/QStringList>
+#include <QtCore/QVariantList>
+#include <QtCore/QVector>
+
+struct LogParseResult {
+    bool ok = false;
+    QString errorMessage;
+    QStringList availableFields;
+    QStringList plottableFields;
+    QVariantList parameters;
+    QVariantList events;
+    QVariantList messages;
+    QVariantList modeSegments;
+    QVariantList dropouts;
+    QHash<QString, QVector<QPointF>> fieldSamples;
+    double minTimestamp = -1.0;
+    double maxTimestamp = -1.0;
+    int sampleCount = 0;
+    QString detectedVehicleType;
+};

--- a/src/AnalyzeView/LogViewer/LogViewerController.cc
+++ b/src/AnalyzeView/LogViewer/LogViewerController.cc
@@ -20,12 +20,12 @@ LogViewerController::~LogViewerController()
 
 void LogViewerController::clear()
 {
-    _plottableSignals.clear();
-    _signalRows.clear();
-    _selectedSignals.clear();
+    _plottableFields.clear();
+    _fieldRows.clear();
+    _selectedFields.clear();
     _expandedGroups.clear();
-    emit signalRowsChanged();
-    emit selectedSignalsChanged();
+    emit fieldRowsChanged();
+    emit selectedFieldsChanged();
     _setLog(SourceType::None, QString(), tr("No log loaded"));
 }
 
@@ -39,23 +39,28 @@ void LogViewerController::openBinLog(const QString &path)
     _setLog(SourceType::Bin, path, tr("DataFlash log loaded"));
 }
 
-void LogViewerController::setPlottableSignals(const QStringList &signalNames)
+void LogViewerController::openULogFile(const QString &path)
 {
-    _plottableSignals = signalNames;
-    std::sort(_plottableSignals.begin(), _plottableSignals.end());
-    _selectedSignals.clear();
-    emit selectedSignalsChanged();
-    _rebuildSignalRows();
+    _setLog(SourceType::ULog, path, tr("ULog file loaded"));
+}
+
+void LogViewerController::setPlottableFields(const QStringList &fieldNames)
+{
+    _plottableFields = fieldNames;
+    std::sort(_plottableFields.begin(), _plottableFields.end());
+    _selectedFields.clear();
+    emit selectedFieldsChanged();
+    _rebuildFieldRows();
 }
 
 void LogViewerController::clearSelection()
 {
-    if (_selectedSignals.isEmpty()) {
+    if (_selectedFields.isEmpty()) {
         return;
     }
 
-    _selectedSignals.clear();
-    emit selectedSignalsChanged();
+    _selectedFields.clear();
+    emit selectedFieldsChanged();
 }
 
 void LogViewerController::toggleGroupExpanded(const QString &groupName)
@@ -66,7 +71,7 @@ void LogViewerController::toggleGroupExpanded(const QString &groupName)
         _expandedGroups.insert(groupName);
     }
 
-    _rebuildSignalRows();
+    _rebuildFieldRows();
 }
 
 bool LogViewerController::isGroupExpanded(const QString &groupName) const
@@ -74,30 +79,30 @@ bool LogViewerController::isGroupExpanded(const QString &groupName) const
     return _expandedGroups.contains(groupName);
 }
 
-void LogViewerController::setSignalSelected(const QString &signalName, bool selected)
+void LogViewerController::setFieldSelected(const QString &fieldName, bool selected)
 {
-    const bool currentlySelected = _selectedSignals.contains(signalName);
+    const bool currentlySelected = _selectedFields.contains(fieldName);
     if (currentlySelected == selected) {
         return;
     }
 
     if (selected) {
-        _selectedSignals.append(signalName);
+        _selectedFields.append(fieldName);
     } else {
-        _selectedSignals.removeAll(signalName);
+        _selectedFields.removeAll(fieldName);
     }
 
-    emit selectedSignalsChanged();
+    emit selectedFieldsChanged();
 }
 
-bool LogViewerController::isSignalSelected(const QString &signalName) const
+bool LogViewerController::isFieldSelected(const QString &fieldName) const
 {
-    return _selectedSignals.contains(signalName);
+    return _selectedFields.contains(fieldName);
 }
 
-QString LogViewerController::signalColor(const QString &signalName) const
+QString LogViewerController::fieldColor(const QString &fieldName) const
 {
-    return _assignColorForKey(signalName);
+    return _assignColorForKey(fieldName);
 }
 
 QString LogViewerController::eventColor(const QString &eventType) const
@@ -110,6 +115,9 @@ QString LogViewerController::eventColor(const QString &eventType) const
     }
     if (eventType == QStringLiteral("event")) {
         return _assignColorForKey(QStringLiteral("event-generic"));
+    }
+    if (eventType == QStringLiteral("warning")) {
+        return _assignColorForKey(QStringLiteral("event-warning"));
     }
 
     return _assignColorForKey(QStringLiteral("event-other"));
@@ -175,15 +183,15 @@ void LogViewerController::_setLog(SourceType sourceType, const QString &path, co
     qCDebug(LogViewerControllerLog) << "sourceType" << static_cast<int>(_sourceType) << "path" << _currentLogPath;
 }
 
-void LogViewerController::_rebuildSignalRows()
+void LogViewerController::_rebuildFieldRows()
 {
     QHash<QString, QStringList> groupedMap;
     QStringList groups;
 
-    for (const QString &signal : _plottableSignals) {
-        const int splitIndex = signal.indexOf('.');
-        const QString groupName = (splitIndex > 0) ? signal.left(splitIndex) : tr("Other");
-        const QString shortName = (splitIndex > 0) ? signal.mid(splitIndex + 1) : signal;
+    for (const QString &field : _plottableFields) {
+        const int splitIndex = field.indexOf('.');
+        const QString groupName = (splitIndex > 0) ? field.left(splitIndex) : tr("Other");
+        const QString shortName = (splitIndex > 0) ? field.mid(splitIndex + 1) : field;
         if (!groupedMap.contains(groupName)) {
             groups.append(groupName);
         }
@@ -203,20 +211,20 @@ void LogViewerController::_rebuildSignalRows()
             continue;
         }
 
-        QStringList signalNames = groupedMap.value(groupName);
-        std::sort(signalNames.begin(), signalNames.end());
-        for (const QString &shortName : signalNames) {
-            QVariantMap signalRow;
-            signalRow[QStringLiteral("rowType")] = QStringLiteral("signal");
-            signalRow[QStringLiteral("group")] = groupName;
-            signalRow[QStringLiteral("shortName")] = shortName;
-            signalRow[QStringLiteral("fullName")] = QStringLiteral("%1.%2").arg(groupName, shortName);
-            rows.append(signalRow);
+        QStringList fieldNames = groupedMap.value(groupName);
+        std::sort(fieldNames.begin(), fieldNames.end());
+        for (const QString &shortName : fieldNames) {
+            QVariantMap fieldRow;
+            fieldRow[QStringLiteral("rowType")] = QStringLiteral("field");
+            fieldRow[QStringLiteral("group")] = groupName;
+            fieldRow[QStringLiteral("shortName")] = shortName;
+            fieldRow[QStringLiteral("fullName")] = QStringLiteral("%1.%2").arg(groupName, shortName);
+            rows.append(fieldRow);
         }
     }
 
-    _signalRows = rows;
-    emit signalRowsChanged();
+    _fieldRows = rows;
+    emit fieldRowsChanged();
 }
 
 QString LogViewerController::_assignColorForKey(const QString &key) const

--- a/src/AnalyzeView/LogViewer/LogViewerController.h
+++ b/src/AnalyzeView/LogViewer/LogViewerController.h
@@ -12,18 +12,19 @@ class LogViewerController : public QObject
     Q_OBJECT
     QML_ELEMENT
 
-    Q_PROPERTY(SourceType sourceType READ sourceType NOTIFY sourceTypeChanged)
-    Q_PROPERTY(QString currentLogPath READ currentLogPath NOTIFY currentLogPathChanged)
-    Q_PROPERTY(bool hasLoadedLog READ hasLoadedLog NOTIFY currentLogPathChanged)
-    Q_PROPERTY(QString statusText READ statusText NOTIFY statusTextChanged)
-    Q_PROPERTY(QVariantList signalRows READ signalRows NOTIFY signalRowsChanged)
-    Q_PROPERTY(QStringList selectedSignals READ selectedSignals NOTIFY selectedSignalsChanged)
+    Q_PROPERTY(SourceType   sourceType     READ sourceType     NOTIFY sourceTypeChanged)
+    Q_PROPERTY(QString      currentLogPath READ currentLogPath NOTIFY currentLogPathChanged)
+    Q_PROPERTY(bool         hasLoadedLog   READ hasLoadedLog   NOTIFY currentLogPathChanged)
+    Q_PROPERTY(QString      statusText     READ statusText     NOTIFY statusTextChanged)
+    Q_PROPERTY(QVariantList fieldRows      READ fieldRows      NOTIFY fieldRowsChanged)
+    Q_PROPERTY(QStringList  selectedFields READ selectedFields NOTIFY selectedFieldsChanged)
 
 public:
     enum class SourceType {
         None,
         TLog,
         Bin,
+        ULog,
     };
     Q_ENUM(SourceType)
 
@@ -34,21 +35,22 @@ public:
     QString currentLogPath() const { return _currentLogPath; }
     bool hasLoadedLog() const { return !_currentLogPath.isEmpty(); }
     QString statusText() const { return _statusText; }
-    QVariantList signalRows() const { return _signalRows; }
-    QStringList selectedSignals() const { return _selectedSignals; }
+    QVariantList fieldRows() const { return _fieldRows; }
+    QStringList selectedFields() const { return _selectedFields; }
 
     Q_INVOKABLE void clear();
     Q_INVOKABLE void openTLog(const QString &path);
     Q_INVOKABLE void openBinLog(const QString &path);
-    Q_INVOKABLE void setPlottableSignals(const QStringList &signalNames);
+    Q_INVOKABLE void openULogFile(const QString &path);
+    Q_INVOKABLE void setPlottableFields(const QStringList &fieldNames);
     Q_INVOKABLE void clearSelection();
     Q_INVOKABLE void toggleGroupExpanded(const QString &groupName);
     Q_INVOKABLE bool isGroupExpanded(const QString &groupName) const;
-    Q_INVOKABLE void setSignalSelected(const QString &signalName, bool selected);
-    Q_INVOKABLE bool isSignalSelected(const QString &signalName) const;
-    /// Returns a deterministic hash-based color for unselected signals.
-    /// For selected signals, QML assigns index-based colors from its own palette.
-    Q_INVOKABLE QString signalColor(const QString &signalName) const;
+    Q_INVOKABLE void setFieldSelected(const QString &fieldName, bool selected);
+    Q_INVOKABLE bool isFieldSelected(const QString &fieldName) const;
+    /// Returns a deterministic hash-based color for unselected fields.
+    /// For selected fields, QML assigns index-based colors from its own palette.
+    Q_INVOKABLE QString fieldColor(const QString &fieldName) const;
     Q_INVOKABLE QString eventColor(const QString &eventType) const;
     Q_INVOKABLE QString modeColor(const QString &modeName) const;
     Q_INVOKABLE QStringList modeLegendEntries(const QVariantList &modeSegments) const;
@@ -57,19 +59,19 @@ signals:
     void sourceTypeChanged();
     void currentLogPathChanged();
     void statusTextChanged();
-    void signalRowsChanged();
-    void selectedSignalsChanged();
+    void fieldRowsChanged();
+    void selectedFieldsChanged();
 
 private:
-    void _rebuildSignalRows();
+    void _rebuildFieldRows();
     QString _assignColorForKey(const QString &key) const;
     void _setLog(SourceType sourceType, const QString &path, const QString &statusText);
 
     SourceType _sourceType = SourceType::None;
     QString _currentLogPath;
     QString _statusText;
-    QStringList _plottableSignals;
-    QVariantList _signalRows;
-    QStringList _selectedSignals;
+    QStringList _plottableFields;
+    QVariantList _fieldRows;
+    QStringList _selectedFields;
     QSet<QString> _expandedGroups;
 };

--- a/src/AnalyzeView/LogViewer/LogViewerPage.qml
+++ b/src/AnalyzeView/LogViewer/LogViewerPage.qml
@@ -9,7 +9,7 @@ import QGroundControl.Controls
 AnalyzePage {
     id: logViewerPage
     pageComponent: pageComponent
-    pageDescription: qsTr("Open and inspect DataFlash (.bin) and telemetry (.tlog) logs in a unified workflow.")
+    pageDescription: qsTr("Open and inspect DataFlash (.bin), PX4 ULog (.ulg), and telemetry (.tlog) logs in a unified workflow.")
 
     Component {
         id: pageComponent
@@ -28,22 +28,32 @@ AnalyzePage {
             property var cursorRows: []
             property var cursorEventRows: []
             property string cursorModeName: ""
-            property string signalSearchText: ""
+            property string fieldSearchText: ""
             property string parameterSearchText: ""
-            property var filteredSignalRows: []
+            property var filteredFieldRows: []
             property var filteredParameters: []
             property real fullMinX: 0
             property real fullMaxX: 1
             property real zoomMinX: 0
             property real zoomMaxX: 1
 
+            // Maps fieldName → LineSeries and fieldName → {min, max} for incremental add/remove.
+            property var _seriesByField: ({})
+            property var _fieldYRange: ({})
+            // Maps eventType → ScatterSeries; rebuilt whenever field selection changes,
+            // because Y pin position depends on binYAxis.max which is recomputed at that time.
+            property var _eventSeriesByType: ({})
+
             // Cap decimation to keep QtGraphs rendering below ~16ms per frame.
             // Empirically, >~6000 points per series causes visible frame drops on mid-range hardware.
-            property int maxChartPointsPerSignal: 6000
+            property int maxChartPointsPerField: 6000
 
-            // Visually distinct categorical palette for selected-signal series.
+            readonly property bool isFirmwareLog: logViewerController.sourceType === LogViewerController.Bin
+                                             || logViewerController.sourceType === LogViewerController.ULog
+
+            // Visually distinct categorical palette for selected-field series.
             // Position-based picks avoid hash collisions producing similar colors.
-            readonly property var _signalChartColors: [
+            readonly property var _fieldChartColors: [
                 "#1E88E5", // blue
                 "#E53935", // red
                 "#43A047", // green
@@ -84,6 +94,9 @@ AnalyzePage {
                 if (eventType === "error") {
                     return qsTr("Error")
                 }
+                if (eventType === "warning") {
+                    return qsTr("Warning")
+                }
                 return eventType
             }
 
@@ -92,25 +105,25 @@ AnalyzePage {
             }
 
             function modeLegendEntries() {
-                return logViewerController.modeLegendEntries(dataFlashParser.modeSegments)
+                return logViewerController.modeLegendEntries(logParser.modeSegments)
             }
 
-            function rebuildGroupedSignals() {
-                logViewerController.setPlottableSignals(dataFlashParser.plottableSignals)
-                applySignalFilter()
+            function rebuildGroupedFields() {
+                logViewerController.setPlottableFields(logParser.plottableFields)
+                applyFieldFilter()
             }
 
-            function applySignalFilter() {
-                const query = String(signalSearchText).trim().toLowerCase()
+            function applyFieldFilter() {
+                const query = String(fieldSearchText).trim().toLowerCase()
                 if (query.length === 0) {
-                    filteredSignalRows = logViewerController.signalRows
+                    filteredFieldRows = logViewerController.fieldRows
                     return
                 }
 
                 const groupedMap = {}
-                const signals = dataFlashParser.plottableSignals
-                for (let i = 0; i < signals.length; i++) {
-                    const fullName = String(signals[i])
+                const fields = logParser.plottableFields
+                for (let i = 0; i < fields.length; i++) {
+                    const fullName = String(fields[i])
                     const splitIndex = fullName.indexOf(".")
                     const groupName = splitIndex > 0 ? fullName.substring(0, splitIndex) : qsTr("Other")
                     const shortName = splitIndex > 0 ? fullName.substring(splitIndex + 1) : fullName
@@ -133,26 +146,26 @@ AnalyzePage {
                     groupedMap[groupName].sort((a, b) => String(a.shortName).localeCompare(String(b.shortName)))
                     for (let s = 0; s < groupedMap[groupName].length; s++) {
                         rows.push({
-                            rowType: "signal",
+                            rowType: "field",
                             group: groupName,
                             fullName: groupedMap[groupName][s].fullName,
                             shortName: groupedMap[groupName][s].shortName
                         })
                     }
                 }
-                filteredSignalRows = rows
+                filteredFieldRows = rows
             }
 
             function applyParameterFilter() {
                 const query = String(parameterSearchText).trim().toLowerCase()
                 if (query.length === 0) {
-                    filteredParameters = dataFlashParser.parameters
+                    filteredParameters = logParser.parameters
                     return
                 }
 
                 const output = []
-                for (let i = 0; i < dataFlashParser.parameters.length; i++) {
-                    const item = dataFlashParser.parameters[i]
+                for (let i = 0; i < logParser.parameters.length; i++) {
+                    const item = logParser.parameters[i]
                     const name = String(item.name)
                     const value = String(item.value)
                     if ((name + " " + value).toLowerCase().indexOf(query) !== -1) {
@@ -167,23 +180,23 @@ AnalyzePage {
             }
 
             function toggleGroupExpanded(groupName) {
-                if (String(signalSearchText).trim().length > 0) {
+                if (String(fieldSearchText).trim().length > 0) {
                     return
                 }
                 logViewerController.toggleGroupExpanded(groupName)
-                applySignalFilter()
+                applyFieldFilter()
             }
 
-            function isSignalSelected(signalName) {
-                return logViewerController.isSignalSelected(signalName)
+            function isFieldSelected(fieldName) {
+                return logViewerController.isFieldSelected(fieldName)
             }
 
-            function signalColor(signalName) {
-                const idx = logViewerController.selectedSignals.indexOf(signalName)
+            function fieldColor(fieldName) {
+                const idx = logViewerController.selectedFields.indexOf(fieldName)
                 if (idx >= 0) {
-                    return _signalChartColors[idx % _signalChartColors.length]
+                    return _fieldChartColors[idx % _fieldChartColors.length]
                 }
-                return logViewerController.signalColor(signalName)
+                return logViewerController.fieldColor(fieldName)
             }
 
             function applyZoomRange(minX, maxX) {
@@ -212,20 +225,9 @@ AnalyzePage {
                 return binXAxis.min + (ratio * (binXAxis.max - binXAxis.min))
             }
 
-            function _axisXToPixel(xValue) {
-                const plotX = binChart.plotArea.x
-                const plotW = binChart.plotArea.width
-                if (plotW <= 0 || binXAxis.max <= binXAxis.min) {
-                    return plotX
-                }
-
-                const ratio = (xValue - binXAxis.min) / (binXAxis.max - binXAxis.min)
-                return plotX + (Math.max(0, Math.min(1, ratio)) * plotW)
-            }
-
             function updateCursorInfo(pixelX, pixelY, width, height) {
-                const selectedSignals = logViewerController.selectedSignals
-                if (selectedSignals.length === 0 || width <= 0 || height <= 0) {
+                const selectedFields = logViewerController.selectedFields
+                if (selectedFields.length === 0 || width <= 0 || height <= 0) {
                     cursorVisible = false
                     return
                 }
@@ -234,25 +236,25 @@ AnalyzePage {
                 cursorPixelX = Math.max(binChart.plotArea.x, Math.min(binChart.plotArea.x + binChart.plotArea.width, pixelX))
                 cursorXValue = _pixelToAxisX(cursorPixelX)
                 cursorPopupY = Math.max(0, Math.min(height - (ScreenTools.defaultFontPixelHeight * 4), pixelY))
-                cursorModeName = dataFlashParser.modeAt(cursorXValue)
+                cursorModeName = logParser.modeAt(cursorXValue)
 
                 const rows = []
-                for (let i = 0; i < selectedSignals.length; i++) {
-                    const signal = selectedSignals[i]
-                    const value = dataFlashParser.signalValueAt(signal, cursorXValue)
+                for (let i = 0; i < selectedFields.length; i++) {
+                    const field = selectedFields[i]
+                    const value = logParser.fieldValueAt(field, cursorXValue)
                     if (isNaN(value)) {
                         continue
                     }
                     rows.push({
-                        name: signal,
-                        color: signalColor(signal),
+                        name: field,
+                        color: fieldColor(field),
                         value: value
                     })
                 }
                 cursorRows = rows
 
                 const threshold = Math.max(0.05, (binXAxis.max - binXAxis.min) / 200.0)
-                const nearbyEvents = dataFlashParser.eventsNear(cursorXValue, threshold)
+                const nearbyEvents = logParser.eventsNear(cursorXValue, threshold)
                 const events = []
                 for (let i = 0; i < nearbyEvents.length; i++) {
                     events.push({
@@ -266,11 +268,11 @@ AnalyzePage {
             function clearLoadedLogState(clearControllerState) {
                 replayController.isPlaying = false
                 replayController.link = null
-                dataFlashParser.clear()
-                logViewerController.setPlottableSignals([])
+                logParser.clear()
+                logViewerController.setPlottableFields([])
                 logViewerController.clearSelection()
                 cursorEventRows = []
-                filteredSignalRows = []
+                filteredFieldRows = []
                 filteredParameters = []
                 refreshBinChart()
                 if (clearControllerState) {
@@ -295,246 +297,170 @@ AnalyzePage {
                 }
 
                 const file = pendingBinFile
-                if (typeof dataFlashParser.parseFileAsync === "function") {
-                    dataFlashParser.parseFileAsync(file)
-                    return
-                }
-
-                // Compatibility fallback if async parser API is unavailable.
-                const ok = dataFlashParser.parseFile(file)
-                if (!ok) {
-                    QGroundControl.showMessageDialog(logViewerPage, qsTr("Log Viewer"), dataFlashParser.parseError)
-                    binLoading = false
-                    pendingBinFile = ""
-                    return
-                }
-
-                rebuildGroupedSignals()
-                applyParameterFilter()
-                logViewerController.clearSelection()
-                fullMinX = 0
-                fullMaxX = 1
-                zoomMinX = 0
-                zoomMaxX = 1
-                refreshBinChart()
-                logViewerController.openBinLog(file)
-                binLoading = false
-                pendingBinFile = ""
+                logParser.parseFileAsync(file)
             }
 
+            // Full reset: remove all series and reinitialise axes from the log time range.
+            // Called on log load, on full clear (clearLoadedLogState), and when all selected fields
+            // are cleared via the "Clear Selected" button. For incremental selection changes use
+            // _syncSeriesWithSelection instead.
             function refreshBinChart() {
                 while (binChart.seriesList.length > 0) {
                     binChart.removeSeries(binChart.seriesList[0])
                 }
+                _seriesByField = {}
+                _fieldYRange = {}
+                _eventSeriesByType = {}
 
-                const selectedSignals = logViewerController.selectedSignals
-
-                // Empty selection: keep axes initialized and only show event markers.
-                if (selectedSignals.length === 0) {
-                    if (dataFlashParser.minTimestamp >= 0.0 && dataFlashParser.maxTimestamp > dataFlashParser.minTimestamp) {
-                        fullMinX = dataFlashParser.minTimestamp
-                        fullMaxX = dataFlashParser.maxTimestamp
-                    } else {
-                        fullMinX = 0
-                        fullMaxX = 1
-                    }
-                    zoomMinX = fullMinX
-                    zoomMaxX = fullMaxX
-                    binXAxis.min = zoomMinX
-                    binXAxis.max = zoomMaxX
-                    binYAxis.min = 0
-                    binYAxis.max = 1
-
-                    const emptySeries = lineSeriesComponent.createObject(binChart, {
-                        color: "transparent",
-                        width: 1,
-                        axisX: binXAxis,
-                        axisY: binYAxis
-                    })
-                    binChart.addSeries(emptySeries)
-                    emptySeries.visible = false
-
-                    const eventListNoSignals = dataFlashParser.events
-                    const eventSeriesByType = ({})
-                    for (let e = 0; e < eventListNoSignals.length; e++) {
-                        const event = eventListNoSignals[e]
-                        if (event.time < binXAxis.min || event.time > binXAxis.max) {
-                            continue
-                        }
-                        if (!eventSeriesByType[event.type]) {
-                            const eventSeries = scatterSeriesComponent.createObject(binChart, {
-                                color: eventColor(event.type),
-                                axisX: binXAxis,
-                                axisY: binYAxis
-                            })
-                            binChart.addSeries(eventSeries)
-                            eventSeriesByType[event.type] = eventSeries
-                        }
-                        eventSeriesByType[event.type].append(event.time, binYAxis.max)
-                    }
-                    binChart.update()
-                    Qt.callLater(_nudgeChartLayout)
-                    return
+                if (logParser.minTimestamp >= 0.0 && logParser.maxTimestamp > logParser.minTimestamp) {
+                    fullMinX = logParser.minTimestamp
+                    fullMaxX = logParser.maxTimestamp
+                } else {
+                    fullMinX = 0
+                    fullMaxX = 1
                 }
-
-                // First pass: collect decimated points per signal and compute axis ranges
-                // BEFORE creating series, so axes are stable when series are populated.
-                let minX = Number.MAX_VALUE
-                let maxX = -Number.MAX_VALUE
-                let minY = Number.MAX_VALUE
-                let maxY = -Number.MAX_VALUE
-                const decimatedPerSignal = []
-                for (let s = 0; s < selectedSignals.length; s++) {
-                    const signalName = selectedSignals[s]
-                    const points = dataFlashParser.signalSamples(signalName)
-                    if (!points || points.length === 0) {
-                        decimatedPerSignal.push(null)
-                        continue
-                    }
-
-                    const sampleStep = Math.max(1, Math.ceil(points.length / Math.max(1, maxChartPointsPerSignal)))
-                    const decimated = []
-                    let appendedLastX = -Number.MAX_VALUE
-                    for (let i = 0; i < points.length; i += sampleStep) {
-                        const p = points[i]
-                        decimated.push({ x: p.x, y: p.y })
-                        appendedLastX = p.x
-                        if (p.x < minX) { minX = p.x }
-                        if (p.x > maxX) { maxX = p.x }
-                        if (p.y < minY) { minY = p.y }
-                        if (p.y > maxY) { maxY = p.y }
-                    }
-                    if (sampleStep > 1) {
-                        const lastPoint = points[points.length - 1]
-                        if (lastPoint && lastPoint.x !== appendedLastX) {
-                            decimated.push({ x: lastPoint.x, y: lastPoint.y })
-                            if (lastPoint.x < minX) { minX = lastPoint.x }
-                            if (lastPoint.x > maxX) { maxX = lastPoint.x }
-                            if (lastPoint.y < minY) { minY = lastPoint.y }
-                            if (lastPoint.y > maxY) { maxY = lastPoint.y }
-                        }
-                    }
-                    decimatedPerSignal.push(decimated)
-                }
-
-                if (minX === Number.MAX_VALUE) {
-                    minX = 0
-                    maxX = 1
-                    minY = 0
-                    maxY = 1
-                } else if (minX === maxX) {
-                    maxX = minX + 1
-                }
-                if (minY === maxY) {
-                    maxY = minY + 1
-                }
-
-                // Set axes BEFORE creating/populating series so QtGraphs lays out
-                // the plot area correctly the first time and renders all series.
-                fullMinX = minX
-                fullMaxX = maxX
-                if (zoomMaxX <= zoomMinX || zoomMinX < fullMinX || zoomMaxX > fullMaxX) {
-                    zoomMinX = fullMinX
-                    zoomMaxX = fullMaxX
-                }
+                zoomMinX = fullMinX
+                zoomMaxX = fullMaxX
                 binXAxis.min = zoomMinX
                 binXAxis.max = zoomMaxX
-                binYAxis.min = minY
-                binYAxis.max = maxY
+                binYAxis.min = 0
+                binYAxis.max = 1
+            }
 
-                // Second pass: create one series per selected signal and feed points.
-                // Explicit axisX/axisY bind is required for QtGraphs LineSeries created
-                // dynamically; without it only the last-added series renders until the
-                // axes are mutated (e.g. by zooming).
-                for (let s = 0; s < selectedSignals.length; s++) {
-                    const decimated = decimatedPerSignal[s]
-                    if (!decimated || decimated.length === 0) {
+            // Incremental update: diff the current series map against the new selection,
+            // remove series for deselected fields, add series for newly selected fields,
+            // then recompute the Y axis and rebuild the event scatter series.
+            function _syncSeriesWithSelection() {
+                const newSelection = logViewerController.selectedFields
+
+                // Build lookup of desired fields
+                const desired = {}
+                for (let i = 0; i < newSelection.length; i++) {
+                    desired[String(newSelection[i])] = true
+                }
+
+                // Remove series for fields that are no longer selected
+                const tracked = Object.keys(_seriesByField)
+                for (let i = 0; i < tracked.length; i++) {
+                    if (!desired[tracked[i]]) {
+                        binChart.removeSeries(_seriesByField[tracked[i]])
+                        delete _seriesByField[tracked[i]]
+                        delete _fieldYRange[tracked[i]]
+                    }
+                }
+
+                // Add a series for each newly selected field
+                for (let i = 0; i < newSelection.length; i++) {
+                    const fieldName = String(newSelection[i])
+                    if (_seriesByField[fieldName]) {
                         continue
                     }
 
-                    const signalName = selectedSignals[s]
+                    const points = logParser.fieldSamples(fieldName)
+                    if (!points || points.length === 0) {
+                        continue
+                    }
+
                     const series = lineSeriesComponent.createObject(binChart, {
-                        color: signalColor(signalName),
+                        color: fieldColor(fieldName),
                         width: 2,
                         axisX: binXAxis,
                         axisY: binYAxis
                     })
                     binChart.addSeries(series)
-                    for (let i = 0; i < decimated.length; i++) {
-                        series.append(decimated[i].x, decimated[i].y)
+
+                    let minY = Number.MAX_VALUE
+                    let maxY = -Number.MAX_VALUE
+                    const sampleStep = Math.max(1, Math.ceil(points.length / maxChartPointsPerField))
+                    let appendedLastX = -Number.MAX_VALUE
+                    for (let j = 0; j < points.length; j += sampleStep) {
+                        series.append(points[j].x, points[j].y)
+                        appendedLastX = points[j].x
+                        if (points[j].y < minY) minY = points[j].y
+                        if (points[j].y > maxY) maxY = points[j].y
                     }
+                    if (sampleStep > 1) {
+                        const last = points[points.length - 1]
+                        if (last && last.x !== appendedLastX) {
+                            series.append(last.x, last.y)
+                        }
+                    }
+
+                    _seriesByField[fieldName] = series
+                    _fieldYRange[fieldName] = { min: minY, max: maxY }
                 }
 
-                const eventList = dataFlashParser.events
-                const eventTypeSeries = ({})
+                // Update colors for all tracked series (selection indices may have shifted)
+                for (let i = 0; i < newSelection.length; i++) {
+                    const fn = String(newSelection[i])
+                    const s = _seriesByField[fn]
+                    if (s) s.color = fieldColor(fn)
+                }
+
+                // Recompute Y axis from cached per-field ranges
+                const allTracked = Object.keys(_seriesByField)
+                let globalMinY = 0
+                let globalMaxY = 1
+                if (allTracked.length > 0) {
+                    globalMinY = Number.MAX_VALUE
+                    globalMaxY = -Number.MAX_VALUE
+                    for (let i = 0; i < allTracked.length; i++) {
+                        const r = _fieldYRange[allTracked[i]]
+                        if (r) {
+                            if (r.min < globalMinY) globalMinY = r.min
+                            if (r.max > globalMaxY) globalMaxY = r.max
+                        }
+                    }
+                    if (globalMinY === globalMaxY) globalMaxY = globalMinY + 1
+                }
+                binYAxis.min = globalMinY
+                binYAxis.max = globalMaxY
+
+                // Rebuild event scatter series (Y position is pinned to current binYAxis.max)
+                const existingTypes = Object.keys(_eventSeriesByType)
+                for (let i = 0; i < existingTypes.length; i++) {
+                    binChart.removeSeries(_eventSeriesByType[existingTypes[i]])
+                }
+                _eventSeriesByType = {}
+                const eventList = logParser.events
                 for (let e = 0; e < eventList.length; e++) {
-                    const event = eventList[e]
-                    if (event.time < binXAxis.min || event.time > binXAxis.max) {
+                    const ev = eventList[e]
+                    if (ev.time < binXAxis.min || ev.time > binXAxis.max) {
                         continue
                     }
-                    if (!eventTypeSeries[event.type]) {
+                    if (!_eventSeriesByType[ev.type]) {
                         const eventSeries = scatterSeriesComponent.createObject(binChart, {
-                            color: eventColor(event.type),
+                            color: eventColor(ev.type),
                             axisX: binXAxis,
                             axisY: binYAxis
                         })
                         binChart.addSeries(eventSeries)
-                        eventTypeSeries[event.type] = eventSeries
+                        _eventSeriesByType[ev.type] = eventSeries
                     }
-                    eventTypeSeries[event.type].append(event.time, maxY)
+                    _eventSeriesByType[ev.type].append(ev.time, binYAxis.max)
                 }
-                binChart.update()
-
-                // QtGraphs sometimes only renders the most recently added series until
-                // the axis range changes. Re-applying the same range on the next event
-                // loop turn forces a re-layout for every series at once.
-                Qt.callLater(_nudgeChartLayout)
-            }
-
-            // Workaround for a QtGraphs bug: after dynamically adding multiple series,
-            // only the most recently added series renders until the axis range changes.
-            // Writing axis.max to (value + epsilon) then back to value on the next event-loop
-            // turn triggers the property-change notification twice, forcing a full re-layout.
-            // The factor 1e-9 is intentional: small enough to be imperceptible on any realistic
-            // axis range (up to ~10^9 s), yet large enough to produce a distinct double value
-            // that passes Qt's property-change equality check.
-            function _nudgeChartLayout() {
-                const xMax = binXAxis.max
-                const xMin = binXAxis.min
-                const yMax = binYAxis.max
-                const yMin = binYAxis.min
-                if (xMax <= xMin || yMax <= yMin) {
-                    return
-                }
-                const xEpsilon = (xMax - xMin) * 1e-9
-                const yEpsilon = (yMax - yMin) * 1e-9
-                binXAxis.max = xMax + xEpsilon
-                binXAxis.max = xMax
-                binYAxis.max = yMax + yEpsilon
-                binYAxis.max = yMax
-                binChart.update()
             }
 
             LogViewerController {
                 id: logViewerController
             }
 
-            APMDataFlashLogParser {
-                id: dataFlashParser
+            LogFileParser {
+                id: logParser
             }
 
             Connections {
                 target: logViewerController
-                function onSignalRowsChanged() {
-                    applySignalFilter()
+                function onFieldRowsChanged() {
+                    applyFieldFilter()
                 }
-                function onSelectedSignalsChanged() {
-                    Qt.callLater(refreshBinChart)
+                function onSelectedFieldsChanged() {
+                    Qt.callLater(_syncSeriesWithSelection)
                 }
             }
 
             Connections {
-                target: dataFlashParser
+                target: logParser
                 ignoreUnknownSignals: true
 
                 function onParseFileFinished(filePath, ok, errorMessage) {
@@ -549,7 +475,7 @@ AnalyzePage {
                         return
                     }
 
-                    rebuildGroupedSignals()
+                    rebuildGroupedFields()
                     applyParameterFilter()
                     logViewerController.clearSelection()
                     fullMinX = 0
@@ -557,7 +483,13 @@ AnalyzePage {
                     zoomMinX = 0
                     zoomMaxX = 1
                     refreshBinChart()
-                    logViewerController.openBinLog(filePath)
+
+                    const lowerPath = filePath.toLowerCase()
+                    if (lowerPath.endsWith(".ulg")) {
+                        logViewerController.openULogFile(filePath)
+                    } else {
+                        logViewerController.openBinLog(filePath)
+                    }
                     binLoading = false
                     pendingBinFile = ""
                 }
@@ -575,6 +507,14 @@ AnalyzePage {
                     text: qsTr("Open .bin")
                     onClicked: {
                         openDialog.nameFilters = ["DataFlash Logs (*.bin *.BIN *.log *.LOG)"]
+                        openDialog.openForLoad()
+                    }
+                }
+
+                QGCButton {
+                    text: qsTr("Open .ulg")
+                    onClicked: {
+                        openDialog.nameFilters = ["PX4 ULog Files (*.ulg *.ULG)"]
                         openDialog.openForLoad()
                     }
                 }
@@ -688,95 +628,95 @@ AnalyzePage {
                             Layout.fillWidth: true
                             wrapMode: Text.WordWrap
                             maximumLineCount: 3
-                            text: logViewerController.sourceType === LogViewerController.Bin
+                            text: (isFirmwareLog)
                                   ? qsTr("DataFlash message and parameter browser will appear here.")
                                   : qsTr("For telemetry replay, MAVLink message and field selection is available through the Inspector integration.")
                         }
 
                         QGCLabel {
-                            visible: logViewerController.sourceType === LogViewerController.Bin
-                            text: qsTr("Signals: %1  Parameters: %2  Events: %3")
-                                  .arg(dataFlashParser.plottableSignals.length)
-                                  .arg(dataFlashParser.parameters.length)
-                                  .arg(dataFlashParser.events.length)
+                            visible: isFirmwareLog
+                            text: qsTr("Fields: %1  Parameters: %2  Events: %3")
+                                  .arg(logParser.plottableFields.length)
+                                  .arg(logParser.parameters.length)
+                                  .arg(logParser.events.length)
                         }
 
                         QGCLabel {
-                            visible: logViewerController.sourceType === LogViewerController.Bin
+                            visible: isFirmwareLog
                             text: qsTr("Detected vehicle type: %1")
-                                  .arg(dataFlashParser.detectedVehicleType.length > 0
-                                       ? dataFlashParser.detectedVehicleType
+                                  .arg(logParser.detectedVehicleType.length > 0
+                                       ? logParser.detectedVehicleType
                                        : qsTr("Unknown"))
                         }
 
                         RowLayout {
                             Layout.fillWidth: true
-                            visible: logViewerController.sourceType === LogViewerController.Bin
+                            visible: isFirmwareLog
                             spacing: ScreenTools.defaultFontPixelWidth * 0.5
 
                             QGCLabel {
-                                text: qsTr("Signals (click to plot)")
+                                text: qsTr("Fields (click to plot)")
                                 font.bold: true
                             }
 
                             QGCTextField {
-                                id: signalSearchField
+                                id: fieldSearchField
                                 Layout.fillWidth: true
                                 textColor: qgcPal.textFieldText
                                 placeholderTextColor: Qt.rgba(qgcPal.textFieldText.r, qgcPal.textFieldText.g, qgcPal.textFieldText.b, 0.7)
-                                placeholderText: qsTr("Search signals")
+                                placeholderText: qsTr("Search fields")
                                 onTextChanged: {
-                                    signalSearchText = text
+                                    fieldSearchText = text
                                     if (text.trim().length === 0) {
-                                        signalSearchTimer.stop()
-                                        applySignalFilter()
+                                        fieldSearchTimer.stop()
+                                        applyFieldFilter()
                                     } else {
-                                        signalSearchTimer.restart()
+                                        fieldSearchTimer.restart()
                                     }
                                 }
                                 onAccepted: {
-                                    signalSearchText = text
-                                    signalSearchTimer.stop()
-                                    applySignalFilter()
+                                    fieldSearchText = text
+                                    fieldSearchTimer.stop()
+                                    applyFieldFilter()
                                 }
                             }
 
                             QGCButton {
                                 text: qsTr("Clear Selected")
                                 horizontalAlignment: Text.AlignHCenter
-                                Layout.preferredHeight: signalSearchField.implicitHeight
-                                Layout.minimumHeight: signalSearchField.implicitHeight
+                                Layout.preferredHeight: fieldSearchField.implicitHeight
+                                Layout.minimumHeight: fieldSearchField.implicitHeight
                                 topPadding: 0
                                 bottomPadding: 0
-                                enabled: logViewerController.selectedSignals.length > 0
+                                enabled: logViewerController.selectedFields.length > 0
                                 onClicked: {
                                     logViewerController.clearSelection()
-                                    applySignalFilter()
+                                    applyFieldFilter()
                                     refreshBinChart()
                                 }
                             }
                         }
 
                         ScrollView {
-                            id: signalsScroll
+                            id: fieldsScroll
                             Layout.fillWidth: true
                             Layout.preferredHeight: parent.height * 0.35
-                            visible: logViewerController.sourceType === LogViewerController.Bin
+                            visible: isFirmwareLog
                             clip: true
 
                             ListView {
-                                id: signalsListView
+                                id: fieldsListView
                                 anchors.fill: parent
-                                model: filteredSignalRows
+                                model: filteredFieldRows
                                 spacing: ScreenTools.defaultFontPixelHeight * 0.15
                                 clip: true
                                 ScrollBar.vertical: ScrollBar { }
 
                                 delegate: Item {
-                                    width: signalsListView.width
+                                    width: fieldsListView.width
                                     height: (modelData.rowType === "group")
                                             ? (groupRect.implicitHeight + (ScreenTools.defaultFontPixelHeight * 0.1))
-                                            : (signalRow.implicitHeight + (ScreenTools.defaultFontPixelHeight * 0.1))
+                                            : (fieldRow.implicitHeight + (ScreenTools.defaultFontPixelHeight * 0.1))
 
                                     Rectangle {
                                         id: groupRect
@@ -792,7 +732,7 @@ AnalyzePage {
                                             anchors.verticalCenter: parent.verticalCenter
                                             spacing: ScreenTools.defaultFontPixelWidth * 0.3
 
-                                            QGCLabel { text: (String(signalSearchText).trim().length > 0) ? "▼" : (isGroupExpanded(modelData.group) ? "▼" : "▶") }
+                                            QGCLabel { text: (String(fieldSearchText).trim().length > 0) ? "▼" : (isGroupExpanded(modelData.group) ? "▼" : "▶") }
                                             QGCLabel { id: groupLabel; text: modelData.group; font.bold: true }
                                         }
 
@@ -803,21 +743,21 @@ AnalyzePage {
                                     }
 
                                     Row {
-                                        id: signalRow
-                                        visible: modelData.rowType === "signal"
+                                        id: fieldRow
+                                        visible: modelData.rowType === "field"
                                         width: parent.width
-                                        height: Math.max(signalNameLabel.implicitHeight, signalCheckBox.implicitHeight)
+                                        height: Math.max(fieldNameLabel.implicitHeight, fieldCheckBox.implicitHeight)
                                         spacing: ScreenTools.defaultFontPixelWidth * 0.25
 
                                         QGCCheckBox {
-                                            id: signalCheckBox
+                                            id: fieldCheckBox
                                             anchors.verticalCenter: parent.verticalCenter
-                                            onClicked: logViewerController.setSignalSelected(modelData.fullName, checked)
-                                            checked: logViewerController.selectedSignals.indexOf(modelData.fullName) !== -1
+                                            onClicked: logViewerController.setFieldSelected(modelData.fullName, checked)
+                                            checked: logViewerController.selectedFields.indexOf(modelData.fullName) !== -1
                                         }
 
                                         QGCLabel {
-                                            id: signalNameLabel
+                                            id: fieldNameLabel
                                             anchors.verticalCenter: parent.verticalCenter
                                             width: Math.max(0, parent.width - (ScreenTools.defaultFontPixelWidth * 3))
                                             height: Math.max(implicitHeight, ScreenTools.defaultFontPixelHeight * 1.2)
@@ -825,7 +765,7 @@ AnalyzePage {
                                             maximumLineCount: 2
                                             verticalAlignment: Text.AlignVCenter
                                             text: modelData.shortName ? String(modelData.shortName) : ""
-                                            color: isSignalSelected(modelData.fullName) ? signalColor(modelData.fullName) : qgcPal.text
+                                            color: isFieldSelected(modelData.fullName) ? fieldColor(modelData.fullName) : qgcPal.text
                                         }
                                     }
                                 }
@@ -836,13 +776,13 @@ AnalyzePage {
                             Layout.fillWidth: true
                             Layout.preferredHeight: 1
                             color: qgcPal.windowShadeDark
-                            visible: logViewerController.sourceType === LogViewerController.Bin
+                            visible: isFirmwareLog
                         }
 
                         QGCTabBar {
                             id: dataTabBar
                             Layout.fillWidth: true
-                            visible: logViewerController.sourceType === LogViewerController.Bin
+                            visible: isFirmwareLog
 
                             QGCTabButton {
                                 text: qsTr("Parameters")
@@ -858,7 +798,7 @@ AnalyzePage {
                         QGCTextField {
                             id: parameterSearchField
                             Layout.fillWidth: true
-                            visible: logViewerController.sourceType === LogViewerController.Bin && dataTabBar.currentIndex === 0
+                            visible: isFirmwareLog && dataTabBar.currentIndex === 0
                             textColor: qgcPal.textFieldText
                             placeholderTextColor: Qt.rgba(qgcPal.textFieldText.r, qgcPal.textFieldText.g, qgcPal.textFieldText.b, 0.7)
                             placeholderText: qsTr("Search parameters")
@@ -882,7 +822,7 @@ AnalyzePage {
                             Layout.fillWidth: true
                             Layout.fillHeight: true
                             Layout.minimumHeight: 0
-                            visible: logViewerController.sourceType === LogViewerController.Bin && dataTabBar.currentIndex === 0
+                            visible: isFirmwareLog && dataTabBar.currentIndex === 0
                             clip: true
 
                             ListView {
@@ -906,13 +846,13 @@ AnalyzePage {
                             Layout.fillWidth: true
                             Layout.fillHeight: true
                             Layout.minimumHeight: 0
-                            visible: logViewerController.sourceType === LogViewerController.Bin && dataTabBar.currentIndex === 1
+                            visible: isFirmwareLog && dataTabBar.currentIndex === 1
                             clip: true
 
                             ListView {
                                 id: messagesListView
                                 anchors.fill: parent
-                                model: dataFlashParser.messages
+                                model: logParser.messages
                                 spacing: ScreenTools.defaultFontPixelHeight * 0.2
                                 clip: true
                                 ScrollBar.vertical: ScrollBar { }
@@ -962,7 +902,7 @@ AnalyzePage {
                             Layout.fillWidth: true
                             Layout.fillHeight: true
                             Layout.preferredHeight: parent.height * 0.72
-                            visible: logViewerController.sourceType === LogViewerController.Bin
+                            visible: isFirmwareLog
 
                             GraphsView {
                                 id: binChart
@@ -1015,7 +955,7 @@ AnalyzePage {
                             MouseArea {
                                 id: chartZoomArea
                                 anchors.fill: parent
-                                enabled: logViewerController.sourceType === LogViewerController.Bin && (binXAxis.max > binXAxis.min)
+                                enabled: isFirmwareLog && (binXAxis.max > binXAxis.min)
                                 hoverEnabled: true
                                 acceptedButtons: Qt.LeftButton | Qt.RightButton
                                 z: 1001
@@ -1075,7 +1015,7 @@ AnalyzePage {
                             }
 
                             Rectangle {
-                                visible: cursorVisible && logViewerController.sourceType === LogViewerController.Bin
+                                visible: cursorVisible && (isFirmwareLog)
                                 x: cursorPixelX
                                 y: binChart.plotArea.y
                                 width: 1
@@ -1086,7 +1026,7 @@ AnalyzePage {
 
                             Rectangle {
                                 id: cursorPopup
-                                visible: cursorVisible && cursorRows.length > 0 && logViewerController.sourceType === LogViewerController.Bin
+                                visible: cursorVisible && cursorRows.length > 0 && (isFirmwareLog)
                                 x: Math.max(0, Math.min(chartContainer.width - width, cursorPixelX + ScreenTools.defaultFontPixelWidth))
                                 y: cursorPopupY
                                 width: ScreenTools.defaultFontPixelWidth * 30
@@ -1161,11 +1101,11 @@ AnalyzePage {
                         Rectangle {
                             Layout.fillWidth: true
                             Layout.preferredHeight: ScreenTools.defaultFontPixelHeight * 0.6
-                            visible: logViewerController.sourceType === LogViewerController.Bin
+                            visible: isFirmwareLog
                             color: qgcPal.windowShade
 
                             Repeater {
-                                model: dataFlashParser.modeSegments
+                                model: logParser.modeSegments
 
                                 Rectangle {
                                     visible: binXAxis.max > binXAxis.min && modelData.end >= binXAxis.min && modelData.start <= binXAxis.max
@@ -1181,7 +1121,22 @@ AnalyzePage {
                             }
 
                             Repeater {
-                                model: dataFlashParser.events
+                                model: logParser.dropouts
+
+                                Rectangle {
+                                    visible: binXAxis.max > binXAxis.min && modelData.end >= binXAxis.min && modelData.start <= binXAxis.max
+                                    y: 0
+                                    height: parent.height
+                                    color: Qt.alpha(eventColor("error"), 0.533)
+                                    x: Math.max(binChart.plotArea.x,
+                                                Math.min(binChart.plotArea.x + binChart.plotArea.width,
+                                                         binChart.plotArea.x + ((Math.max(modelData.start, binXAxis.min) - binXAxis.min) / (binXAxis.max - binXAxis.min)) * binChart.plotArea.width))
+                                    width: Math.max(2, ((Math.min(modelData.end, binXAxis.max) - Math.max(modelData.start, binXAxis.min)) / (binXAxis.max - binXAxis.min)) * binChart.plotArea.width)
+                                }
+                            }
+
+                            Repeater {
+                                model: logParser.events
 
                                 Rectangle {
                                     width: 2
@@ -1197,7 +1152,7 @@ AnalyzePage {
 
                         Row {
                             Layout.fillWidth: true
-                            visible: logViewerController.sourceType === LogViewerController.Bin && modeLegendEntries().length > 0
+                            visible: isFirmwareLog && modeLegendEntries().length > 0
                             Layout.preferredHeight: ScreenTools.defaultFontPixelHeight * 1.1
                             spacing: ScreenTools.defaultFontPixelWidth
 
@@ -1219,7 +1174,7 @@ AnalyzePage {
                                     }
 
                                     QGCLabel {
-                                        text: eventTypeLabel(modelData)
+                                        text: modelData
                                     }
                                 }
                             }
@@ -1227,17 +1182,17 @@ AnalyzePage {
 
                         Row {
                             Layout.fillWidth: true
-                            visible: logViewerController.sourceType === LogViewerController.Bin && logViewerController.selectedSignals.length > 0
+                            visible: isFirmwareLog && logViewerController.selectedFields.length > 0
                             Layout.preferredHeight: ScreenTools.defaultFontPixelHeight * 1.1
                             spacing: ScreenTools.defaultFontPixelWidth
 
                             QGCLabel {
-                                text: qsTr("Signals:")
+                                text: qsTr("Fields:")
                                 font.bold: true
                             }
 
                             Repeater {
-                                model: logViewerController.selectedSignals
+                                model: logViewerController.selectedFields
 
                                 Row {
                                     spacing: ScreenTools.defaultFontPixelWidth * 0.2
@@ -1245,7 +1200,7 @@ AnalyzePage {
                                     Rectangle {
                                         width: ScreenTools.defaultFontPixelWidth
                                         height: ScreenTools.defaultFontPixelHeight * 0.6
-                                        color: signalColor(modelData)
+                                        color: fieldColor(modelData)
                                     }
 
                                     QGCLabel {
@@ -1257,7 +1212,7 @@ AnalyzePage {
 
                         Row {
                             Layout.fillWidth: true
-                            visible: logViewerController.sourceType === LogViewerController.Bin && dataFlashParser.events.length > 0
+                            visible: isFirmwareLog && logParser.events.length > 0
                             Layout.preferredHeight: ScreenTools.defaultFontPixelHeight * 1.1
                             spacing: ScreenTools.defaultFontPixelWidth
 
@@ -1267,13 +1222,13 @@ AnalyzePage {
                             }
 
                             Repeater {
-                                model: ["mode", "event", "error"]
+                                model: ["mode", "event", "error", "warning"]
 
                                 Row {
                                     spacing: ScreenTools.defaultFontPixelWidth * 0.2
                                     visible: {
-                                        for (let i = 0; i < dataFlashParser.events.length; i++) {
-                                            if (dataFlashParser.events[i].type === modelData) {
+                                        for (let i = 0; i < logParser.events.length; i++) {
+                                            if (logParser.events[i].type === modelData) {
                                                 return true
                                             }
                                         }
@@ -1287,7 +1242,7 @@ AnalyzePage {
                                     }
 
                                     QGCLabel {
-                                        text: modelData
+                                        text: eventTypeLabel(modelData)
                                     }
                                 }
                             }
@@ -1295,7 +1250,7 @@ AnalyzePage {
 
                         RowLayout {
                             Layout.fillWidth: true
-                            visible: logViewerController.sourceType === LogViewerController.Bin
+                            visible: isFirmwareLog
                             spacing: ScreenTools.defaultFontPixelWidth
 
                             QGCLabel {
@@ -1387,10 +1342,10 @@ AnalyzePage {
             }
 
             Timer {
-                id: signalSearchTimer
+                id: fieldSearchTimer
                 interval: 250
                 repeat: false
-                onTriggered: applySignalFilter()
+                onTriggered: applyFieldFilter()
             }
 
             Timer {

--- a/src/AnalyzeView/LogViewer/PX4ULog/LogViewerULogParser.cc
+++ b/src/AnalyzeView/LogViewer/PX4ULog/LogViewerULogParser.cc
@@ -1,0 +1,76 @@
+#include "LogViewerULogParser.h"
+
+#include "PX4ULogUtility.h"
+
+#include <QtCore/QCoreApplication>
+#include "ULogFullHandler.h"
+
+#include <QtCore/QFile>
+
+#include <ulog_cpp/reader.hpp>
+
+#include <limits>
+
+namespace ULogParser {
+
+LogParseResult parseFile(const QString &filePath)
+{
+    LogParseResult result;
+
+    QFile file(filePath);
+    if (!file.open(QIODevice::ReadOnly)) {
+        result.errorMessage = QCoreApplication::translate("LogFileParser", "Failed to open file");
+        return result;
+    }
+
+    const qint64 fileSize = file.size();
+    if (fileSize <= 0) {
+        result.errorMessage = QCoreApplication::translate("LogFileParser", "File is empty");
+        return result;
+    }
+    if (fileSize > std::numeric_limits<qsizetype>::max()) {
+        result.errorMessage = QCoreApplication::translate("LogFileParser", "File is too large to parse");
+        return result;
+    }
+
+    uchar *const mappedData = file.map(0, fileSize);
+    if (mappedData == nullptr) {
+        result.errorMessage = QCoreApplication::translate("LogFileParser", "Failed to memory-map file");
+        return result;
+    }
+
+    struct ScopedUnmap {
+        QFile &file;
+        uchar *data = nullptr;
+        ~ScopedUnmap() { if (data) { file.unmap(data); } }
+    } scopedUnmap{file, mappedData};
+
+    const char *const raw = reinterpret_cast<const char *>(mappedData);
+
+    // Verify ULog magic
+    if (!PX4ULogUtility::isValidHeader(raw, fileSize)) {
+        result.errorMessage = QCoreApplication::translate("LogFileParser", "File does not appear to be a ULog file (invalid header)");
+        return result;
+    }
+
+    auto handler = std::make_shared<ULogFullHandler>(result);
+    ulog_cpp::Reader reader(handler);
+    reader.readChunk(reinterpret_cast<const uint8_t *>(raw), static_cast<size_t>(fileSize));
+
+    if (handler->hadFatalError()) {
+        if (result.errorMessage.isEmpty()) {
+            result.errorMessage = QCoreApplication::translate("LogFileParser", "Fatal error while parsing ULog file");
+        }
+        return result;
+    }
+
+    if (!handler->isHeaderComplete()) {
+        result.errorMessage = QCoreApplication::translate("LogFileParser", "ULog file header is incomplete or corrupt");
+        return result;
+    }
+
+    handler->finalize();
+    return result;
+}
+
+} // namespace ULogParser

--- a/src/AnalyzeView/LogViewer/PX4ULog/LogViewerULogParser.h
+++ b/src/AnalyzeView/LogViewer/PX4ULog/LogViewerULogParser.h
@@ -1,0 +1,12 @@
+#pragma once
+
+#include "LogParseResultPrivate.h"
+
+#include <QtCore/QString>
+
+// Free-function parser for PX4 ULog (.ulg) files.
+// Returns a filled LogParseResult on success (result.ok == true) or an error
+// message in result.errorMessage on failure.
+namespace ULogParser {
+    LogParseResult parseFile(const QString &filePath);
+}

--- a/src/AnalyzeView/LogViewer/PX4ULog/ULogFullHandler.cc
+++ b/src/AnalyzeView/LogViewer/PX4ULog/ULogFullHandler.cc
@@ -1,0 +1,306 @@
+#include "ULogFullHandler.h"
+
+#include "LogParseResultPrivate.h"
+#include "QGCLoggingCategory.h"
+
+#include <QtCore/QStringList>
+
+#include <algorithm>
+#include <stdexcept>
+
+#include <ulog_cpp/subscription.hpp>
+
+QGC_LOGGING_CATEGORY(ULogFullHandlerLog, "AnalyzeView.ULogFullHandler")
+
+namespace {
+
+QString _px4NavStateName(int state)
+{
+    switch (state) {
+    // Values from PX4 VehicleStatus.msg NAVIGATION_STATE_* constants
+    case 0:  return QStringLiteral("Manual");
+    case 1:  return QStringLiteral("Altitude");
+    case 2:  return QStringLiteral("Position");
+    case 3:  return QStringLiteral("Mission");
+    case 4:  return QStringLiteral("Hold");
+    case 5:  return QStringLiteral("Return");
+    case 6:  return QStringLiteral("Position Slow");
+    case 8:  return QStringLiteral("Altitude Cruise");
+    case 10: return QStringLiteral("Acro");
+    case 12: return QStringLiteral("Descend");
+    case 13: return QStringLiteral("Termination");
+    case 14: return QStringLiteral("Offboard");
+    case 15: return QStringLiteral("Stabilized");
+    case 17: return QStringLiteral("Takeoff");
+    case 18: return QStringLiteral("Land");
+    case 19: return QStringLiteral("Follow Target");
+    case 20: return QStringLiteral("Precision Land");
+    case 21: return QStringLiteral("Orbit");
+    case 22: return QStringLiteral("VTOL Takeoff");
+    default: return QStringLiteral("Mode %1").arg(state);
+    }
+}
+
+bool _isNumericScalarField(const ulog_cpp::Field &field)
+{
+    if (field.arrayLength() >= 0) {
+        return false; // arrays excluded from plottable fields
+    }
+    using BT = ulog_cpp::Field::BasicType;
+    switch (field.type().type) {
+    case BT::INT8:
+    case BT::UINT8:
+    case BT::INT16:
+    case BT::UINT16:
+    case BT::INT32:
+    case BT::UINT32:
+    case BT::INT64:
+    case BT::UINT64:
+    case BT::FLOAT:
+    case BT::DOUBLE:
+    case BT::BOOL:
+        return true;
+    default:
+        return false;
+    }
+}
+
+} // namespace
+
+ULogFullHandler::ULogFullHandler(LogParseResult &result)
+    : _result(result)
+{
+}
+
+void ULogFullHandler::error(const std::string &msg, bool is_recoverable)
+{
+    const QString errorMessage = QString::fromStdString(msg);
+    if (!is_recoverable) {
+        _hadFatalError = true;
+        if (_result.errorMessage.isEmpty()) {
+            _result.errorMessage = errorMessage;
+        }
+    }
+    qCWarning(ULogFullHandlerLog) << "ULog parse error:" << errorMessage;
+}
+
+void ULogFullHandler::messageFormat(const ulog_cpp::MessageFormat &message_format)
+{
+    _formats[message_format.name()] = std::make_shared<ulog_cpp::MessageFormat>(message_format);
+}
+
+void ULogFullHandler::addLoggedMessage(const ulog_cpp::AddLoggedMessage &add_logged_message)
+{
+    const auto it = _formats.find(add_logged_message.messageName());
+    if (it != _formats.cend()) {
+        _subscriptions[add_logged_message.msgId()] = {
+            it->second,
+            add_logged_message.multiId(),
+            add_logged_message.messageName()
+        };
+    }
+}
+
+void ULogFullHandler::headerComplete()
+{
+    _headerComplete = true;
+    for (auto &[name, fmt] : _formats) {
+        fmt->resolveDefinition(_formats);
+    }
+}
+
+void ULogFullHandler::data(const ulog_cpp::Data &data)
+{
+    if (!_headerComplete) {
+        return;
+    }
+
+    const auto it = _subscriptions.find(data.msgId());
+    if (it == _subscriptions.cend()) {
+        return;
+    }
+
+    const SubscriptionInfo &sub = it->second;
+    if (!sub.format) {
+        return;
+    }
+
+    try {
+        const ulog_cpp::TypedDataView view(data, *sub.format);
+
+        // Extract timestamp (ULog convention: field named "timestamp", unit µs)
+        double timestampSecs = -1.0;
+        if (sub.format->fieldMap().count("timestamp") > 0) {
+            const uint64_t tsUs = view.at("timestamp").as<uint64_t>();
+            timestampSecs = static_cast<double>(tsUs) / 1e6;
+            _lastTimestampSecs = timestampSecs;
+        }
+
+        // Field name: "topic_name.field" or "topic_name[N].field" for multi-instance
+        const QString prefix = (sub.multiId > 0)
+            ? QStringLiteral("%1[%2].").arg(QString::fromStdString(sub.topicName)).arg(sub.multiId)
+            : QString::fromStdString(sub.topicName) + QLatin1Char('.');
+
+        for (const auto &field : sub.format->fields()) {
+            // Skip padding fields and the timestamp itself
+            if (field->name().rfind("_padding", 0) == 0) {
+                continue;
+            }
+            if (field->name() == "timestamp") {
+                continue;
+            }
+            if (!field->definitionResolved()) {
+                continue;
+            }
+
+            const QString fieldName = prefix + QString::fromStdString(field->name());
+            _fieldSet.insert(fieldName);
+
+            if (!_isNumericScalarField(*field) || timestampSecs < 0.0) {
+                continue;
+            }
+
+            const double value = view.at(field).as<double>();
+            _result.fieldSamples[fieldName].append(QPointF(timestampSecs, value));
+            _plottableFieldSet.insert(fieldName);
+        }
+
+        _result.sampleCount++;
+
+        if (timestampSecs >= 0.0) {
+            if (_result.minTimestamp < 0.0 || timestampSecs < _result.minTimestamp) {
+                _result.minTimestamp = timestampSecs;
+            }
+            _result.maxTimestamp = std::max(_result.maxTimestamp, timestampSecs);
+        }
+    } catch (const std::exception &e) {
+        qCWarning(ULogFullHandlerLog) << "Failed to decode data message:" << e.what();
+    }
+}
+
+void ULogFullHandler::logging(const ulog_cpp::Logging &logging)
+{
+    const double timestampSecs = static_cast<double>(logging.timestamp()) / 1e6;
+    const QString text = QString::fromStdString(logging.message());
+
+    if (text.isEmpty()) {
+        return;
+    }
+
+    QVariantMap msgRow;
+    msgRow[QStringLiteral("time")] = timestampSecs;
+    msgRow[QStringLiteral("text")] = text;
+    _result.messages.append(msgRow);
+
+    using Level = ulog_cpp::Logging::Level;
+    if (logging.logLevel() <= Level::Warning) {
+        const QString eventType = (logging.logLevel() <= Level::Error)
+            ? QStringLiteral("error")
+            : QStringLiteral("warning");
+
+        if (timestampSecs >= 0.0) {
+            QVariantMap eventRow;
+            eventRow[QStringLiteral("time")] = timestampSecs;
+            eventRow[QStringLiteral("type")] = eventType;
+            eventRow[QStringLiteral("description")] = text;
+            _result.events.append(eventRow);
+        }
+    }
+}
+
+void ULogFullHandler::parameter(const ulog_cpp::Parameter &param)
+{
+    const QString name = QString::fromStdString(param.field().name());
+    if (name.isEmpty()) {
+        return;
+    }
+
+    QVariant value;
+    try {
+        // ULog parameters are restricted to int32_t and float per spec.
+        // as<double>() safely static_casts either type.
+        value = param.value().as<double>();
+    } catch (const std::exception &) {
+        value = QVariant();
+    }
+
+    QVariantMap row;
+    row[QStringLiteral("name")] = name;
+    row[QStringLiteral("value")] = value;
+    _result.parameters.append(row);
+}
+
+void ULogFullHandler::dropout(const ulog_cpp::Dropout &dropout)
+{
+    if (_lastTimestampSecs < 0.0) {
+        return;
+    }
+
+    const double start = _lastTimestampSecs;
+    const double end = start + static_cast<double>(dropout.durationMs()) / 1000.0;
+    QVariantMap row;
+    row[QStringLiteral("start")] = start;
+    row[QStringLiteral("end")] = end;
+    _result.dropouts.append(row);
+}
+
+void ULogFullHandler::finalize()
+{
+    // Detect vehicle type from vehicle_status.vehicle_type
+    // PX4 vehicle_type enum: 0=Unknown, 1=Rotary Wing, 2=Fixed Wing, 3=Rover, 4=Airship
+    const auto vehicleTypeIt = _result.fieldSamples.constFind(QStringLiteral("vehicle_status.vehicle_type"));
+    if (vehicleTypeIt != _result.fieldSamples.cend() && !vehicleTypeIt->isEmpty()) {
+        const int vtype = static_cast<int>(vehicleTypeIt->first().y());
+        switch (vtype) {
+        case 1: _result.detectedVehicleType = QStringLiteral("Multirotor/Helicopter"); break;
+        case 2: _result.detectedVehicleType = QStringLiteral("Fixed Wing");            break;
+        case 3: _result.detectedVehicleType = QStringLiteral("Rover");                 break;
+        case 4: _result.detectedVehicleType = QStringLiteral("Airship");               break;
+        default: break; // 0 = Unknown, leave empty so UI shows "Unknown"
+        }
+    }
+
+    // Derive mode segments from vehicle_status.nav_state samples.
+    // nav_state is a uint8_t mapped to the PX4 navigation_state enum.
+    const auto navStateIt = _result.fieldSamples.constFind(QStringLiteral("vehicle_status.nav_state"));
+    if (navStateIt != _result.fieldSamples.cend()) {
+        const QVector<QPointF> &samples = navStateIt.value();
+        int lastNavState = -1;
+        double segmentStart = -1.0;
+        QString segmentMode;
+
+        for (const QPointF &pt : samples) {
+            const int navState = static_cast<int>(pt.y());
+            if (navState != lastNavState) {
+                // Close the previous segment
+                if (lastNavState >= 0 && segmentStart >= 0.0) {
+                    QVariantMap seg;
+                    seg[QStringLiteral("mode")] = segmentMode;
+                    seg[QStringLiteral("start")] = segmentStart;
+                    seg[QStringLiteral("end")] = pt.x();
+                    _result.modeSegments.append(seg);
+                }
+                lastNavState = navState;
+                segmentStart = pt.x();
+                segmentMode = _px4NavStateName(navState);
+            }
+        }
+
+        // Close the final open segment
+        if (lastNavState >= 0 && segmentStart >= 0.0 && _result.maxTimestamp >= segmentStart) {
+            QVariantMap seg;
+            seg[QStringLiteral("mode")] = segmentMode;
+            seg[QStringLiteral("start")] = segmentStart;
+            seg[QStringLiteral("end")] = _result.maxTimestamp;
+            _result.modeSegments.append(seg);
+        }
+    }
+
+    // Sort field lists for consistent display
+    _result.availableFields = _fieldSet.values();
+    std::sort(_result.availableFields.begin(), _result.availableFields.end());
+    _result.plottableFields = _plottableFieldSet.values();
+    std::sort(_result.plottableFields.begin(), _result.plottableFields.end());
+
+    _result.ok = true;
+}

--- a/src/AnalyzeView/LogViewer/PX4ULog/ULogFullHandler.h
+++ b/src/AnalyzeView/LogViewer/PX4ULog/ULogFullHandler.h
@@ -1,0 +1,60 @@
+#pragma once
+
+#include <QtCore/QHash>
+#include <QtCore/QPointF>
+#include <QtCore/QSet>
+#include <QtCore/QString>
+#include <QtCore/QVector>
+
+#include <map>
+#include <memory>
+#include <string>
+
+#include <ulog_cpp/data_handler_interface.hpp>
+#include <ulog_cpp/messages.hpp>
+
+struct LogParseResult;
+
+/// Full-scan ULog DataHandlerInterface implementation.
+/// Streams through a ULog file in a single pass, collecting signal samples,
+/// parameters, log messages, events, and dropouts into a LogParseResult.
+/// Call finalize() after parsing to build mode segments and sort signal lists.
+class ULogFullHandler final : public ulog_cpp::DataHandlerInterface
+{
+public:
+    explicit ULogFullHandler(LogParseResult &result);
+    ~ULogFullHandler() = default;
+
+    void error(const std::string &msg, bool is_recoverable) override;
+    void messageFormat(const ulog_cpp::MessageFormat &message_format) override;
+    void addLoggedMessage(const ulog_cpp::AddLoggedMessage &add_logged_message) override;
+    void headerComplete() override;
+    void data(const ulog_cpp::Data &data) override;
+    void logging(const ulog_cpp::Logging &logging) override;
+    void parameter(const ulog_cpp::Parameter &parameter) override;
+    void dropout(const ulog_cpp::Dropout &dropout) override;
+
+    bool hadFatalError() const { return _hadFatalError; }
+    bool isHeaderComplete() const { return _headerComplete; }
+
+    /// Post-parse: derive mode segments from vehicle_status.nav_state samples
+    /// and sort availableFields / plottableFields lists.
+    void finalize();
+
+private:
+    LogParseResult &_result;
+
+    struct SubscriptionInfo {
+        std::shared_ptr<ulog_cpp::MessageFormat> format;
+        uint8_t multiId{0};
+        std::string topicName;
+    };
+
+    std::map<std::string, std::shared_ptr<ulog_cpp::MessageFormat>> _formats;
+    std::map<uint16_t, SubscriptionInfo> _subscriptions;
+    QSet<QString> _fieldSet;
+    QSet<QString> _plottableFieldSet;
+    double _lastTimestampSecs{-1.0};
+    bool _hadFatalError{false};
+    bool _headerComplete{false};
+};

--- a/test/AnalyzeView/APMDataFlashLogParserTest.cc
+++ b/test/AnalyzeView/APMDataFlashLogParserTest.cc
@@ -73,8 +73,8 @@ void APMDataFlashLogParserTest::_parseMinimalLogTest()
     QVERIFY(parser.parseFile(tempFile.fileName()));
     QVERIFY(parser.parsed());
     QCOMPARE(parser.parseError(), QString());
-    QVERIFY(parser.availableSignals().contains(QStringLiteral("PARM.Name")));
-    QVERIFY(parser.availableSignals().contains(QStringLiteral("PARM.Value")));
+    QVERIFY(parser.availableFields().contains(QStringLiteral("PARM.Name")));
+    QVERIFY(parser.availableFields().contains(QStringLiteral("PARM.Value")));
     QCOMPARE(parser.parameters().count(), 1);
     // One MODE message produces a "mode" event; one EV message produces an "event" event.
     QCOMPARE(parser.events().count(), 2);

--- a/test/AnalyzeView/CMakeLists.txt
+++ b/test/AnalyzeView/CMakeLists.txt
@@ -25,6 +25,8 @@ target_sources(${CMAKE_PROJECT_NAME}
         MavlinkLogTest.h
         APMDataFlashLogParserTest.cc
         APMDataFlashLogParserTest.h
+        LogFileParserTest.cc
+        LogFileParserTest.h
 )
 
 target_include_directories(${CMAKE_PROJECT_NAME} PRIVATE ${CMAKE_CURRENT_SOURCE_DIR})

--- a/test/AnalyzeView/LogFileParserTest.cc
+++ b/test/AnalyzeView/LogFileParserTest.cc
@@ -1,0 +1,334 @@
+#include "LogFileParserTest.h"
+
+#include "LogFileParser.h"
+
+#include <cstring>
+#include <functional>
+#include <vector>
+
+#include <QtCore/QByteArray>
+#include <QtCore/QDir>
+#include <QtCore/QPointF>
+#include <QtCore/QTemporaryFile>
+#include <QtCore/QVariantList>
+
+#include <ulog_cpp/messages.hpp>
+#include <ulog_cpp/writer.hpp>
+
+// ============================================================================
+// In-memory ULog builder helpers
+// ============================================================================
+
+namespace {
+
+// Build a minimal but complete ULog byte stream via ulog_cpp::Writer.
+// Callers add formats, subscriptions, and data messages via the callbacks.
+using WriterFn = std::function<void(ulog_cpp::Writer &)>;
+
+QByteArray buildULog(WriterFn headerFn, WriterFn dataFn)
+{
+    std::vector<uint8_t> buffer;
+    ulog_cpp::Writer writer([&](const uint8_t *data, int length) {
+        buffer.insert(buffer.end(), data, data + length);
+    });
+
+    writer.fileHeader(ulog_cpp::FileHeader{});
+    if (headerFn) {
+        headerFn(writer);
+    }
+    writer.headerComplete();
+    if (dataFn) {
+        dataFn(writer);
+    }
+
+    return QByteArray(reinterpret_cast<const char *>(buffer.data()), static_cast<int>(buffer.size()));
+}
+
+// Write bytes to a QTemporaryFile with a given suffix and leave it closed.
+// Returns false if writing failed.
+bool writeTempFile(QTemporaryFile &tmp, const QByteArray &bytes)
+{
+    if (!tmp.open()) {
+        return false;
+    }
+    const bool ok = (tmp.write(bytes) == bytes.size());
+    tmp.close();
+    return ok;
+}
+
+std::vector<uint8_t> makePayload64Float(uint64_t ts, float value)
+{
+    std::vector<uint8_t> buf(12);
+    memcpy(buf.data(),     &ts,    8);
+    memcpy(buf.data() + 8, &value, 4);
+    return buf;
+}
+
+std::vector<uint8_t> makePayload64Int32(uint64_t ts, int32_t value)
+{
+    std::vector<uint8_t> buf(12);
+    memcpy(buf.data(),     &ts,    8);
+    memcpy(buf.data() + 8, &value, 4);
+    return buf;
+}
+
+} // anonymous namespace
+
+// ============================================================================
+// Tests
+// ============================================================================
+
+void LogFileParserTest::_parseULogNumericTopicTest()
+{
+    const QByteArray bytes = buildULog(
+        [](ulog_cpp::Writer &w) {
+            w.messageFormat(ulog_cpp::MessageFormat{
+                "sensor_combined",
+                {ulog_cpp::Field{"uint64_t", "timestamp"},
+                 ulog_cpp::Field{"float", "gyro_rad_x"}}
+            });
+        },
+        [](ulog_cpp::Writer &w) {
+            w.addLoggedMessage(ulog_cpp::AddLoggedMessage{0, 1, "sensor_combined"});
+            // Two samples
+            w.data(ulog_cpp::Data{1, makePayload64Float(500000ULL, 0.1f)});
+            w.data(ulog_cpp::Data{1, makePayload64Float(1000000ULL, 0.2f)});
+        });
+
+    QTemporaryFile tmp;
+    tmp.setFileTemplate(QDir::tempPath() + QStringLiteral("/logtest_XXXXXX.ulg"));
+    QVERIFY(writeTempFile(tmp, bytes));
+
+    LogFileParser parser;
+    QVERIFY(parser.parseFile(tmp.fileName()));
+    QVERIFY(parser.parsed());
+    QCOMPARE(parser.parseError(), QString());
+
+    // Field should appear in both available and plottable lists
+    QVERIFY(parser.availableFields().contains(QStringLiteral("sensor_combined.gyro_rad_x")));
+    QVERIFY(parser.plottableFields().contains(QStringLiteral("sensor_combined.gyro_rad_x")));
+
+    // timestamp pseudo-field must NOT be plottable
+    QVERIFY(!parser.plottableFields().contains(QStringLiteral("sensor_combined.timestamp")));
+
+    // fieldSamples returns two points
+    const QVariantList samples = parser.fieldSamples(QStringLiteral("sensor_combined.gyro_rad_x"));
+    QCOMPARE(samples.size(), 2);
+    QVERIFY(qAbs(samples[0].toPointF().x() - 0.5) < 1e-5);
+    QVERIFY(qAbs(samples[0].toPointF().y() - 0.1) < 1e-5);
+    QVERIFY(qAbs(samples[1].toPointF().x() - 1.0) < 1e-5);
+    QVERIFY(qAbs(samples[1].toPointF().y() - 0.2) < 1e-5);
+}
+
+void LogFileParserTest::_parseULogParameterTest()
+{
+    const QByteArray bytes = buildULog(
+        [](ulog_cpp::Writer &w) {
+            // Include a format so the file is fully valid
+            w.messageFormat(ulog_cpp::MessageFormat{
+                "sensor_combined",
+                {ulog_cpp::Field{"uint64_t", "timestamp"},
+                 ulog_cpp::Field{"float", "gyro_rad_x"}}
+            });
+            // Parameter in header section — name only, type inferred from value type
+            w.parameter(ulog_cpp::Parameter{"MY_PARAM", 42.0f});
+        },
+        [](ulog_cpp::Writer &w) {
+            w.addLoggedMessage(ulog_cpp::AddLoggedMessage{0, 1, "sensor_combined"});
+            w.data(ulog_cpp::Data{1, makePayload64Float(500000ULL, 0.0f)});
+        });
+
+    QTemporaryFile tmp;
+    tmp.setFileTemplate(QDir::tempPath() + QStringLiteral("/logtest_XXXXXX.ulg"));
+    QVERIFY(writeTempFile(tmp, bytes));
+
+    LogFileParser parser;
+    QVERIFY(parser.parseFile(tmp.fileName()));
+    QVERIFY(parser.parsed());
+
+    QCOMPARE(parser.parameters().count(), 1);
+    const QVariantMap param = parser.parameters().first().toMap();
+    QCOMPARE(param.value(QStringLiteral("name")).toString(), QStringLiteral("MY_PARAM"));
+    QVERIFY(qAbs(param.value(QStringLiteral("value")).toDouble() - 42.0) < 1e-5);
+}
+
+void LogFileParserTest::_parseULogWarningEventTest()
+{
+    const QByteArray bytes = buildULog(
+        [](ulog_cpp::Writer &) {},
+        [](ulog_cpp::Writer &w) {
+            // Warning-level message → should appear in both messages AND events
+            w.logging(ulog_cpp::Logging{
+                ulog_cpp::Logging::Level::Warning,
+                "Low battery warning",
+                500000ULL
+            });
+            // Debug-level message → messages only, NOT events
+            w.logging(ulog_cpp::Logging{
+                ulog_cpp::Logging::Level::Debug,
+                "Debug info",
+                1000000ULL
+            });
+        });
+
+    QTemporaryFile tmp;
+    tmp.setFileTemplate(QDir::tempPath() + QStringLiteral("/logtest_XXXXXX.ulg"));
+    QVERIFY(writeTempFile(tmp, bytes));
+
+    LogFileParser parser;
+    QVERIFY(parser.parseFile(tmp.fileName()));
+
+    QCOMPARE(parser.messages().count(), 2);
+    QCOMPARE(parser.events().count(), 1);
+
+    const QVariantMap ev = parser.events().first().toMap();
+    QCOMPARE(ev.value(QStringLiteral("type")).toString(), QStringLiteral("warning"));
+    QVERIFY(ev.value(QStringLiteral("description")).toString().contains(QStringLiteral("Low battery")));
+}
+
+void LogFileParserTest::_parseULogModeSegmentsTest()
+{
+    // Two nav_state changes: Manual(0) at t=0.5s, then Mission(3) at t=1.0s
+    const QByteArray bytes = buildULog(
+        [](ulog_cpp::Writer &w) {
+            w.messageFormat(ulog_cpp::MessageFormat{
+                "vehicle_status",
+                {ulog_cpp::Field{"uint64_t", "timestamp"},
+                 ulog_cpp::Field{"int32_t", "nav_state"}}
+            });
+        },
+        [](ulog_cpp::Writer &w) {
+            w.addLoggedMessage(ulog_cpp::AddLoggedMessage{0, 2, "vehicle_status"});
+            w.data(ulog_cpp::Data{2, makePayload64Int32(500000ULL,  0)});  // Manual
+            w.data(ulog_cpp::Data{2, makePayload64Int32(1000000ULL, 3)});  // Mission
+            w.data(ulog_cpp::Data{2, makePayload64Int32(2000000ULL, 3)});  // Mission (continues)
+        });
+
+    QTemporaryFile tmp;
+    tmp.setFileTemplate(QDir::tempPath() + QStringLiteral("/logtest_XXXXXX.ulg"));
+    QVERIFY(writeTempFile(tmp, bytes));
+
+    LogFileParser parser;
+    QVERIFY(parser.parseFile(tmp.fileName()));
+
+    // Should have two mode segments: Manual and Mission
+    QVERIFY(parser.modeSegments().count() >= 2);
+
+    const QStringList modes = [&]() {
+        QStringList list;
+        for (const QVariant &seg : parser.modeSegments()) {
+            list << seg.toMap().value(QStringLiteral("mode")).toString();
+        }
+        return list;
+    }();
+
+    QVERIFY(modes.contains(QStringLiteral("Manual")));
+    QVERIFY(modes.contains(QStringLiteral("Mission")));
+}
+
+void LogFileParserTest::_parseULogDropoutTest()
+{
+    const QByteArray bytes = buildULog(
+        [](ulog_cpp::Writer &w) {
+            w.messageFormat(ulog_cpp::MessageFormat{
+                "sensor_combined",
+                {ulog_cpp::Field{"uint64_t", "timestamp"},
+                 ulog_cpp::Field{"float", "gyro_rad_x"}}
+            });
+        },
+        [](ulog_cpp::Writer &w) {
+            w.addLoggedMessage(ulog_cpp::AddLoggedMessage{0, 1, "sensor_combined"});
+            w.data(ulog_cpp::Data{1, makePayload64Float(500000ULL, 1.0f)});
+            // 100 ms dropout after the data message
+            w.dropout(ulog_cpp::Dropout{100});
+        });
+
+    QTemporaryFile tmp;
+    tmp.setFileTemplate(QDir::tempPath() + QStringLiteral("/logtest_XXXXXX.ulg"));
+    QVERIFY(writeTempFile(tmp, bytes));
+
+    LogFileParser parser;
+    QVERIFY(parser.parseFile(tmp.fileName()));
+
+    QCOMPARE(parser.dropouts().count(), 1);
+
+    const QVariantMap dropout = parser.dropouts().first().toMap();
+    // start should be around 0.5 s (the timestamp of the preceding data message)
+    const double start = dropout.value(QStringLiteral("start")).toDouble();
+    const double end   = dropout.value(QStringLiteral("end")).toDouble();
+    QVERIFY(start >= 0.0);
+    QVERIFY(end > start);
+    // Duration should be approximately 0.1 s
+    QVERIFY(qAbs((end - start) - 0.1) < 0.01);
+}
+
+void LogFileParserTest::_parseULogInvalidFileTest()
+{
+    QTemporaryFile tmp;
+    tmp.setFileTemplate(QDir::tempPath() + QStringLiteral("/logtest_XXXXXX.ulg"));
+    QVERIFY(tmp.open());
+    tmp.write("this is not a valid ulg file", 28);
+    tmp.close();
+
+    LogFileParser parser;
+    QVERIFY(!parser.parseFile(tmp.fileName()));
+    QVERIFY(!parser.parsed());
+    QVERIFY(!parser.parseError().isEmpty());
+}
+
+void LogFileParserTest::_parseDataFlashRegressionTest()
+{
+    // Build a minimal DataFlash binary log to verify the .bin parse path
+    // still works via LogFileParser (regression guard for APMDataFlashLogParser).
+    auto makeFmt = [](uint8_t type, uint8_t len, const char *name,
+                      const char *fmt, const char *cols) -> QByteArray {
+        QByteArray p(86, '\0');
+        p[0] = static_cast<char>(type);
+        p[1] = static_cast<char>(len);
+        memcpy(p.data() + 2,  name, qMin<int>(4,  static_cast<int>(strlen(name))));
+        memcpy(p.data() + 6,  fmt,  qMin<int>(16, static_cast<int>(strlen(fmt))));
+        memcpy(p.data() + 22, cols, qMin<int>(64, static_cast<int>(strlen(cols))));
+        return p;
+    };
+    auto appendMsg = [](QByteArray &b, uint8_t type, const QByteArray &payload) {
+        b.append(static_cast<char>(0xA3));
+        b.append(static_cast<char>(0x95));
+        b.append(static_cast<char>(type));
+        b.append(payload);
+    };
+    auto makeParam = [](const char *name, float value) -> QByteArray {
+        QByteArray p(20, '\0');
+        memcpy(p.data(), name, qMin<int>(16, static_cast<int>(strlen(name))));
+        memcpy(p.data() + 16, &value, sizeof(value));
+        return p;
+    };
+
+    QByteArray bytes;
+    appendMsg(bytes, 128, makeFmt(150, 23, "PARM", "Nf", "Name,Value"));
+    appendMsg(bytes, 150, makeParam("ARMING_CHECK", 1.0f));
+
+    QTemporaryFile tmp;
+    tmp.setFileTemplate(QDir::tempPath() + QStringLiteral("/logtest_XXXXXX.bin"));
+    QVERIFY(writeTempFile(tmp, bytes));
+
+    LogFileParser parser;
+    QVERIFY(parser.parseFile(tmp.fileName()));
+    QVERIFY(parser.parsed());
+    QCOMPARE(parser.parameters().count(), 1);
+}
+
+void LogFileParserTest::_parseUnsupportedExtensionTest()
+{
+    QTemporaryFile tmp;
+    tmp.setFileTemplate(QDir::tempPath() + QStringLiteral("/logtest_XXXXXX.txt"));
+    QVERIFY(tmp.open());
+    tmp.write("dummy", 5);
+    tmp.close();
+
+    LogFileParser parser;
+    QVERIFY(!parser.parseFile(tmp.fileName()));
+    QVERIFY(!parser.parsed());
+    QVERIFY(!parser.parseError().isEmpty());
+}
+
+UT_REGISTER_TEST(LogFileParserTest, TestLabel::Unit, TestLabel::AnalyzeView)

--- a/test/AnalyzeView/LogFileParserTest.h
+++ b/test/AnalyzeView/LogFileParserTest.h
@@ -1,0 +1,18 @@
+#pragma once
+
+#include "UnitTest.h"
+
+class LogFileParserTest : public UnitTest
+{
+    Q_OBJECT
+
+private slots:
+    void _parseULogNumericTopicTest();
+    void _parseULogParameterTest();
+    void _parseULogWarningEventTest();
+    void _parseULogModeSegmentsTest();
+    void _parseULogDropoutTest();
+    void _parseULogInvalidFileTest();
+    void _parseDataFlashRegressionTest();
+    void _parseUnsupportedExtensionTest();
+};

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -87,6 +87,7 @@ add_qgc_test(MAVLinkMessageTest LABELS Unit AnalyzeView)
 add_qgc_test(MAVLinkSystemTest LABELS Unit AnalyzeView)
 add_qgc_test(MavlinkLogTest LABELS Integration AnalyzeView Vehicle RESOURCE_LOCK MockLink)
 add_qgc_test(APMDataFlashLogParserTest LABELS Unit AnalyzeView)
+add_qgc_test(LogFileParserTest LABELS Unit AnalyzeView)
 
 # ----------------------------------------------------------------------------
 # Camera


### PR DESCRIPTION
## Summary

Adds PX4 ULog (**.ulg**) file support to the Log Viewer and refactors the DataFlash parser out of the monolithic `LogFileParser.cc` into separate, independently testable sub-parsers.

## Changes

### Architecture
- **`LogFileParser`** (QML_ELEMENT) is now a thin dispatcher: reads the file extension and delegates to `DataFlashParser::parseFile()` or `ULogParser::parseFile()`
- **`LogParseResultPrivate.h`** defines the shared `LogParseResult` struct used by all sub-parsers
- **`LogViewerDataFlashParser`** — renamed from the old inline code to avoid an include-path collision with `GeoTag/DataFlashParser.h`
- **`LogViewerULogParser`** — new parser using `ulog_cpp::Reader` + `ULogFullHandler` to extract plottable fields, parameters, events (warning/error/info), mode segments, dropouts, and messages from ULog files
- Sub-parsers no longer include `LogFileParser.h`; use `QCoreApplication::translate()` instead

### QML
- `LogViewerPage.qml`: removed dead `_axisXToPixel` function; series creation uses explicit `axisX`/`axisY` bindings required by Qt Graphs 2D; incremental add/remove pattern for field series

### Tests
- `LogFileParserTest`: 8 unit tests covering ULog numeric fields, parameters, warning events, mode segments, dropouts, invalid files, and unsupported extensions; DataFlash regression guard
- `APMDataFlashLogParserTest`: fixed temp file paths to use `QDir::tempPath()` instead of hardcoded `/tmp`

## Test Plan
```
cd build && ctest --output-on-failure -L Unit -R LogFileParser
```