### PR TITLE
Add "Restart Mission" checkbox to "Set Current Waypoint" action

### DIFF
--- a/src/FlyView/GuidedActionsController.qml
+++ b/src/FlyView/GuidedActionsController.qml
@@ -488,6 +488,10 @@ Item {
         case actionSetWaypoint:
             confirmDialog.title = setWaypointTitle
             confirmDialog.message = setWaypointMessage
+            if (_activeVehicle.supports.restartMission) {
+                confirmDialog.optionText = qsTr("Restart Mission")
+                confirmDialog.optionChecked = false
+            }
             break;
         case actionOrbit:
             confirmDialog.title = orbitTitle
@@ -632,7 +636,7 @@ Item {
             }
             break
         case actionSetWaypoint:
-            _activeVehicle.setCurrentMissionSequence(actionData)
+            _activeVehicle.setCurrentMissionSequence(actionData, optionChecked /* restartMission */)
             break
         case actionOrbit:
             var valueInMeters = _unitsConversion.appSettingsVerticalDistanceUnitsToMeters(sliderOutputValue)

--- a/src/Vehicle/Vehicle.cc
+++ b/src/Vehicle/Vehicle.cc
@@ -2106,7 +2106,7 @@ void Vehicle::landingGearRetract()
                 1.0f);      // up
 }
 
-void Vehicle::setCurrentMissionSequence(int seq)
+void Vehicle::setCurrentMissionSequence(int seq, bool restartMission)
 {
     if (!_firmwarePlugin->sendHomePositionToVehicle()) {
         seq--;
@@ -2137,7 +2137,8 @@ void Vehicle::setCurrentMissionSequence(int seq)
         static_cast<uint8_t>(defaultComponentId()),
         MAV_CMD_DO_SET_MISSION_CURRENT,
         true, // showError
-        static_cast<uint16_t>(seq)
+        static_cast<uint16_t>(seq),
+        restartMission ? 1.0f : 0.0f
     );
 }
 

--- a/src/Vehicle/Vehicle.h
+++ b/src/Vehicle/Vehicle.h
@@ -338,18 +338,22 @@ public:
     /// Command vehicle to abort landing
     Q_INVOKABLE void abortLanding(double climbOutAltitude);
 
-    /// Command vichecle to deploy landing gear
+    /// Command vehicle to deploy landing gear
     Q_INVOKABLE void landingGearDeploy();
 
-    /// Command vichecle to retract landing gear
+    /// Command vehicle to retract landing gear
     Q_INVOKABLE void landingGearRetract();
 
     Q_INVOKABLE void startTakeoff();
 
     Q_INVOKABLE void startMission();
 
-    /// Alter the current mission item on the vehicle
-    Q_INVOKABLE void setCurrentMissionSequence(int seq);
+    /// Set the current mission item on the vehicle.
+    ///     @param seq Mission sequence number to make current.
+    ///     @param restartMission Passed as param2 of MAV_CMD_DO_SET_MISSION_CURRENT when the
+    ///            firmware supports that command (e.g. ArduPilot). Has no effect on firmware
+    ///            that falls back to the deprecated MISSION_SET_CURRENT message (e.g. PX4).
+    Q_INVOKABLE void setCurrentMissionSequence(int seq, bool restartMission = false);
 
     /// Reboot vehicle
     Q_INVOKABLE void rebootVehicle();

--- a/src/Vehicle/VehicleSupports.cc
+++ b/src/Vehicle/VehicleSupports.cc
@@ -86,3 +86,11 @@ bool VehicleSupports::changeHeading() const
 {
     return _vehicle->firmwarePlugin()->isCapable(_vehicle, FirmwarePlugin::ChangeHeadingCapability);
 }
+
+bool VehicleSupports::restartMission() const
+{
+    auto* instanceData = _vehicle->firmwarePluginInstanceData();
+    if (!instanceData) return false;
+    return instanceData->anyVersionSupportsCommand(MAV_CMD_DO_SET_MISSION_CURRENT)
+        == FirmwarePluginInstanceData::CommandSupportedResult::SUPPORTED;
+}

--- a/src/Vehicle/VehicleSupports.h
+++ b/src/Vehicle/VehicleSupports.h
@@ -30,6 +30,7 @@ public:
     Q_PROPERTY(bool guidedTakeoffWithAltitude       READ guidedTakeoffWithAltitude      CONSTANT)
     Q_PROPERTY(bool guidedTakeoffWithoutAltitude    READ guidedTakeoffWithoutAltitude   CONSTANT)
     Q_PROPERTY(bool changeHeading                   READ changeHeading                  CONSTANT)
+    Q_PROPERTY(bool restartMission                  READ restartMission                 CONSTANT)
 
     bool throttleModeCenterZero() const;
     bool negativeThrust() const;
@@ -46,6 +47,7 @@ public:
     bool guidedTakeoffWithAltitude() const;
     bool guidedTakeoffWithoutAltitude() const;
     bool changeHeading() const;
+    bool restartMission() const;
 
 signals:
     void terrainFrameChanged();


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail. What problem does this solve? -->
On firmware which supports `MAV_CMD_DO_SET_MISSION_CURRENT` (ArduPilot), "Set Current Waypoint" command now has a checkbox to optionally "Restart Mission".

To summarize, when "Restart Mission" is checked, `MAV_CMD_DO_SET_MISSION_CURRENT` will be sent with the restart param set to true which will restart the mission and any jump counters. This is useful for two cases:

1. User flew a mission to the end which does not contain a RTL and wants to restart their mission from a previous waypoint.

2. User has a mission with jump counters and wishes to go to a previous waypoint and reset those counters too.

This solves the issue listed here: #13927 and was discussed in this closed PR here: #13934


## Type of Change
<!-- Put an 'x' in the relevant boxes -->
- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] CI/Build changes
- [ ] Other

## Testing
<!-- Describe the tests you ran and how to reproduce them -->
- [x] Tested locally
- [ ] Added/updated unit tests
- [x] Tested with simulator (SITL)
- [ ] Tested with hardware

### Platforms Tested
<!-- Check all that apply -->
- [x] Linux
- [ ] Windows
- [ ] macOS
- [ ] Android
- [ ] iOS

### Flight Stacks Tested
<!-- If applicable -->
- [ ] PX4
- [x] ArduPilot

## Screenshots

https://github.com/user-attachments/assets/33a60d41-4693-4248-9a49-0d15e6ea7c21


<img width="298" height="105" alt="image" src="https://github.com/user-attachments/assets/2d882684-94a3-49ab-9a06-b56a9677d4ed" />

https://github.com/user-attachments/assets/7bc56a63-fc61-453c-ae68-1fd43ccc0580


## Checklist
<!-- Go over all the following points, and put an 'x' in all the boxes that apply -->
- [x] I have read the [Contribution Guidelines](CONTRIBUTING.md)
- [x] I have read the [Code of Conduct](CODE_OF_CONDUCT.md)
- [x] My code follows the project's coding standards
- [ ] I have added tests that prove my fix/feature works
- [ ] New and existing unit tests pass locally

## Related Issues
#13927

---
By submitting this pull request, I confirm that my contribution is made under the terms of the project's dual license (Apache 2.0 and GPL v3).
