### PR TITLE
LogViewer: Extract chart into self-contained LogViewerChart component

### DIFF
--- a/src/AnalyzeView/LogViewer/CMakeLists.txt
+++ b/src/AnalyzeView/LogViewer/CMakeLists.txt
@@ -26,3 +26,20 @@ target_include_directories(${CMAKE_PROJECT_NAME}
         ${CMAKE_CURRENT_SOURCE_DIR}/APMDataFlash
         ${CMAKE_CURRENT_SOURCE_DIR}/PX4ULog
 )
+
+# ----------------------------------------------------------------------------
+# QML Module for Log Viewer UI components
+# ----------------------------------------------------------------------------
+qt_add_library(LogViewerModule STATIC)
+
+qt_add_qml_module(LogViewerModule
+    URI QGroundControl.LogViewer
+    VERSION 1.0
+    RESOURCE_PREFIX /qml
+    QML_FILES
+        LogViewerChart.qml
+    NO_PLUGIN
+)
+
+target_link_libraries(LogViewerModule PRIVATE AnalyzeViewModule)
+target_link_libraries(${CMAKE_PROJECT_NAME} PRIVATE LogViewerModule)

--- a/src/AnalyzeView/LogViewer/CMakeLists.txt
+++ b/src/AnalyzeView/LogViewer/CMakeLists.txt
@@ -41,5 +41,4 @@ qt_add_qml_module(LogViewerModule
     NO_PLUGIN
 )
 
-target_link_libraries(LogViewerModule PRIVATE AnalyzeViewModule)
 target_link_libraries(${CMAKE_PROJECT_NAME} PRIVATE LogViewerModule)

--- a/src/AnalyzeView/LogViewer/LogViewerChart.qml
+++ b/src/AnalyzeView/LogViewer/LogViewerChart.qml
@@ -22,7 +22,6 @@ ColumnLayout {
     property bool   _positionMarkerVisible: false
     property real   _markerPixelX: 0
     property real   _markerXValue: 0
-    property real   _markerPopupY: 0
     property var    _markerRows: []
     property var    _markerEventRows: []
     property string _markerModeName: ""
@@ -169,7 +168,6 @@ ColumnLayout {
         _positionMarkerVisible = true
         _markerPixelX = Math.max(_binChart.plotArea.x, Math.min(_binChart.plotArea.x + _binChart.plotArea.width, pixelX))
         _markerXValue = _pixelToAxisX(_markerPixelX)
-        _markerPopupY = Math.max(0, Math.min(h - (ScreenTools.defaultFontPixelHeight * 4), pixelY))
         _queryCursorValues()
     }
 
@@ -184,7 +182,6 @@ ColumnLayout {
         if (_binXAxis.max <= _binXAxis.min) return
         _markerXValue = (_binXAxis.min + _binXAxis.max) / 2
         _markerPixelX = _axisXToPixel(_markerXValue)
-        _markerPopupY = _binChart.plotArea.y
         _positionMarkerVisible = true
         _queryCursorValues()
     }
@@ -345,24 +342,27 @@ ColumnLayout {
     // -------------------------------------------------------------------------
     ColumnLayout {
         id: _timelineContainer
-        Layout.preferredWidth: _binChart.plotArea.width
+        Layout.preferredWidth: _binChart.plotArea.x + _binChart.plotArea.width
         spacing: ScreenTools.defaultFontPixelHeight * 0.1
 
         property real _barHeight: ScreenTools.defaultFontPixelHeight * 0.6
 
         function _segmentX(start) {
+            const w = _binChart.plotArea.width
             if (_binXAxis.max <= _binXAxis.min) return 0
-            return Math.max(0, Math.min(width, ((Math.max(start, _binXAxis.min) - _binXAxis.min) / (_binXAxis.max - _binXAxis.min)) * width))
+            return Math.max(0, Math.min(w, ((Math.max(start, _binXAxis.min) - _binXAxis.min) / (_binXAxis.max - _binXAxis.min)) * w))
         }
 
         function _segmentWidth(start, end) {
+            const w = _binChart.plotArea.width
             if (_binXAxis.max <= _binXAxis.min) return 0
-            return ((Math.min(end, _binXAxis.max) - Math.max(start, _binXAxis.min)) / (_binXAxis.max - _binXAxis.min)) * width
+            return ((Math.min(end, _binXAxis.max) - Math.max(start, _binXAxis.min)) / (_binXAxis.max - _binXAxis.min)) * w
         }
 
         function _eventX(time, itemWidth) {
+            const w = _binChart.plotArea.width
             if (_binXAxis.max <= _binXAxis.min) return 0
-            return Math.max(0, Math.min(width - itemWidth, ((time - _binXAxis.min) / (_binXAxis.max - _binXAxis.min)) * width))
+            return Math.max(0, Math.min(w - itemWidth, ((time - _binXAxis.min) / (_binXAxis.max - _binXAxis.min)) * w))
         }
 
         // Bar 1: Flight modes
@@ -571,7 +571,7 @@ ColumnLayout {
         // Value popup
         Rectangle {
             id: _valuePopup
-            visible: _positionMarkerVisible && _markerRows.length > 0
+            visible: _positionMarkerVisible
             x: _popupX()
             y: _binChart.plotArea.y
             width: ScreenTools.defaultFontPixelWidth * 30

--- a/src/AnalyzeView/LogViewer/LogViewerChart.qml
+++ b/src/AnalyzeView/LogViewer/LogViewerChart.qml
@@ -324,7 +324,9 @@ ColumnLayout {
             _eventSeriesByType[ev.type].append(ev.time, _binYAxis.max)
         }
 
-        Qt.callLater(_refreshCursorAtCurrentPosition)
+        if (_positionMarkerVisible) {
+            Qt.callLater(_refreshCursorAtCurrentPosition)
+        }
     }
 
     // -------------------------------------------------------------------------
@@ -585,7 +587,8 @@ ColumnLayout {
 
             function _popupX() {
                 const rightCornerX = _binChart.plotArea.x + _binChart.plotArea.width - width
-                return (_markerPixelX > rightCornerX) ? _binChart.plotArea.x : rightCornerX
+                const popupX = (_markerPixelX > rightCornerX) ? _binChart.plotArea.x : rightCornerX
+                return Math.max(0, Math.min(popupX, _chartContainer.width - width))
             }
 
             ColumnLayout {

--- a/src/AnalyzeView/LogViewer/LogViewerChart.qml
+++ b/src/AnalyzeView/LogViewer/LogViewerChart.qml
@@ -1,0 +1,761 @@
+import QtQuick
+import QtQuick.Controls
+import QtQuick.Layouts
+import QtGraphs
+
+import QGroundControl
+import QGroundControl.Controls
+
+/// Self-contained chart view for the Log Viewer.
+/// Sizing and visibility are controlled entirely by the parent.
+/// The parent calls refreshBinChart(), centerCursor(), and clearMarker() at
+/// appropriate lifecycle points (log load, log clear, field-clear).
+ColumnLayout {
+    required property var logParser
+    required property var logViewerController
+
+    spacing: ScreenTools.defaultFontPixelHeight * 0.5
+
+    // -------------------------------------------------------------------------
+    // Internal state
+    // -------------------------------------------------------------------------
+    property bool   _positionMarkerVisible: false
+    property real   _markerPixelX: 0
+    property real   _markerXValue: 0
+    property real   _markerPopupY: 0
+    property var    _markerRows: []
+    property var    _markerEventRows: []
+    property string _markerModeName: ""
+
+    property real   _fullMinX: 0
+    property real   _fullMaxX: 1
+    property real   _zoomMinX: 0
+    property real   _zoomMaxX: 1
+
+    property var    _seriesByField: ({})
+    property var    _fieldYRange: ({})
+    property var    _eventSeriesByType: ({})
+
+    property int    _maxChartPointsPerField: 6000
+
+    readonly property real _legendRowHeight: ScreenTools.defaultFontPixelHeight * 1.1
+    readonly property real _legendColorBlockSize: ScreenTools.defaultFontPixelHeight * 0.8
+    readonly property real _legendItemSpacing: ScreenTools.defaultFontPixelWidth * 0.2
+
+    QGCPalette { id: qgcPal }
+
+    readonly property var _fieldChartColors: [
+        "#1E88E5", // blue
+        "#E53935", // red
+        "#43A047", // green
+        "#FB8C00", // orange
+        "#8E24AA", // purple
+        "#00ACC1", // cyan
+        "#FDD835", // yellow
+        "#D81B60", // pink
+        "#6D4C41", // brown
+        "#546E7A", // blue grey
+        "#3949AB", // indigo
+        "#00897B", // teal
+    ]
+
+    // -------------------------------------------------------------------------
+    // Helper components
+    // -------------------------------------------------------------------------
+    Component {
+        id: _lineSeriesComponent
+        LineSeries { }
+    }
+
+    Component {
+        id: _scatterSeriesComponent
+        ScatterSeries { }
+    }
+
+    // -------------------------------------------------------------------------
+    // Color helpers (public — parent may call fieldColor() for the field list)
+    // -------------------------------------------------------------------------
+    function eventColor(eventType) {
+        return logViewerController.eventColor(eventType)
+    }
+
+    function modeColor(modeName) {
+        return logViewerController.modeColor(String(modeName))
+    }
+
+    function modeLegendEntries() {
+        return logViewerController.modeLegendEntries(logParser.modeSegments)
+    }
+
+    function fieldColor(fieldName) {
+        const idx = logViewerController.selectedFields.indexOf(fieldName)
+        if (idx >= 0) {
+            return _fieldChartColors[idx % _fieldChartColors.length]
+        }
+        return logViewerController.fieldColor(fieldName)
+    }
+
+    function eventTypeLabel(eventType) {
+        if (eventType === "mode")    return qsTr("Mode")
+        if (eventType === "event")   return qsTr("Event")
+        if (eventType === "error")   return qsTr("Error")
+        if (eventType === "warning") return qsTr("Warning")
+        return eventType
+    }
+
+    // -------------------------------------------------------------------------
+    // Zoom
+    // -------------------------------------------------------------------------
+    function applyZoomRange(minX, maxX) {
+        if (maxX <= minX) return
+        _zoomMinX = minX
+        _zoomMaxX = maxX
+        _binXAxis.min = _zoomMinX
+        _binXAxis.max = _zoomMaxX
+        _refreshCursorPixelPos()
+    }
+
+    function resetZoom() {
+        applyZoomRange(_fullMinX, _fullMaxX)
+    }
+
+    // -------------------------------------------------------------------------
+    // Coordinate conversions
+    // -------------------------------------------------------------------------
+    function _pixelToAxisX(pixelX) {
+        const plotX = _binChart.plotArea.x
+        const plotW = _binChart.plotArea.width
+        if (plotW <= 0 || _binXAxis.max <= _binXAxis.min) return _binXAxis.min
+        const clampedPixel = Math.max(plotX, Math.min(plotX + plotW, pixelX))
+        const ratio = (clampedPixel - plotX) / plotW
+        return _binXAxis.min + (ratio * (_binXAxis.max - _binXAxis.min))
+    }
+
+    function _axisXToPixel(axisX) {
+        const plotX = _binChart.plotArea.x
+        const plotW = _binChart.plotArea.width
+        if (plotW <= 0 || _binXAxis.max <= _binXAxis.min) return plotX
+        const ratio = (axisX - _binXAxis.min) / (_binXAxis.max - _binXAxis.min)
+        return plotX + Math.max(0, Math.min(plotW, ratio * plotW))
+    }
+
+    // -------------------------------------------------------------------------
+    // Marker / cursor
+    // -------------------------------------------------------------------------
+    function _queryCursorValues() {
+        _markerModeName = logParser.modeAt(_markerXValue)
+
+        const selectedFields = logViewerController.selectedFields
+        const rows = []
+        for (let i = 0; i < selectedFields.length; i++) {
+            const field = selectedFields[i]
+            const value = logParser.fieldValueAt(field, _markerXValue)
+            if (isNaN(value)) continue
+            rows.push({ name: field, color: fieldColor(field), value: value })
+        }
+        _markerRows = rows
+
+        const threshold = Math.max(0.05, (_binXAxis.max - _binXAxis.min) / 200.0)
+        const nearbyEvents = logParser.eventsNear(_markerXValue, threshold)
+        const events = []
+        for (let i = 0; i < nearbyEvents.length; i++) {
+            events.push({ color: eventColor(nearbyEvents[i].type), text: nearbyEvents[i].description })
+        }
+        _markerEventRows = events
+    }
+
+    function _updateCursorInfo(pixelX, pixelY, w, h) {
+        if (w <= 0 || h <= 0 || _binXAxis.max <= _binXAxis.min) return
+        _positionMarkerVisible = true
+        _markerPixelX = Math.max(_binChart.plotArea.x, Math.min(_binChart.plotArea.x + _binChart.plotArea.width, pixelX))
+        _markerXValue = _pixelToAxisX(_markerPixelX)
+        _markerPopupY = Math.max(0, Math.min(h - (ScreenTools.defaultFontPixelHeight * 4), pixelY))
+        _queryCursorValues()
+    }
+
+    function _refreshCursorPixelPos() {
+        if (_positionMarkerVisible) {
+            _markerPixelX = _axisXToPixel(_markerXValue)
+        }
+    }
+
+    // Public: called by parent after log load
+    function centerCursor() {
+        if (_binXAxis.max <= _binXAxis.min) return
+        _markerXValue = (_binXAxis.min + _binXAxis.max) / 2
+        _markerPixelX = _axisXToPixel(_markerXValue)
+        _markerPopupY = _binChart.plotArea.y
+        _positionMarkerVisible = true
+        _queryCursorValues()
+    }
+
+    function _refreshCursorAtCurrentPosition() {
+        if (_binXAxis.max <= _binXAxis.min) return
+        _positionMarkerVisible = true
+        _markerPixelX = _axisXToPixel(_markerXValue)
+        _queryCursorValues()
+    }
+
+    // Public: called by parent on log clear
+    function clearMarker() {
+        _positionMarkerVisible = false
+        _markerRows = []
+        _markerEventRows = []
+    }
+
+    // -------------------------------------------------------------------------
+    // Chart / series management
+    // -------------------------------------------------------------------------
+
+    // Public: full reset — called by parent on log load or clear
+    function refreshBinChart() {
+        while (_binChart.seriesList.length > 0) {
+            _binChart.removeSeries(_binChart.seriesList[0])
+        }
+        _seriesByField = {}
+        _fieldYRange = {}
+        _eventSeriesByType = {}
+
+        if (logParser.minTimestamp >= 0.0 && logParser.maxTimestamp > logParser.minTimestamp) {
+            _fullMinX = logParser.minTimestamp
+            _fullMaxX = logParser.maxTimestamp
+        } else {
+            _fullMinX = 0
+            _fullMaxX = 1
+        }
+        _zoomMinX = _fullMinX
+        _zoomMaxX = _fullMaxX
+        _binXAxis.min = _zoomMinX
+        _binXAxis.max = _zoomMaxX
+        _binYAxis.min = 0
+        _binYAxis.max = 1
+    }
+
+    function _syncSeriesWithSelection() {
+        const newSelection = logViewerController.selectedFields
+
+        const desired = {}
+        for (let i = 0; i < newSelection.length; i++) {
+            desired[String(newSelection[i])] = true
+        }
+
+        const tracked = Object.keys(_seriesByField)
+        for (let i = 0; i < tracked.length; i++) {
+            if (!desired[tracked[i]]) {
+                _binChart.removeSeries(_seriesByField[tracked[i]])
+                delete _seriesByField[tracked[i]]
+                delete _fieldYRange[tracked[i]]
+            }
+        }
+
+        for (let i = 0; i < newSelection.length; i++) {
+            const fieldName = String(newSelection[i])
+            if (_seriesByField[fieldName]) continue
+
+            const points = logParser.fieldSamples(fieldName)
+            if (!points || points.length === 0) continue
+
+            const series = _lineSeriesComponent.createObject(_binChart, {
+                color: fieldColor(fieldName),
+                width: 2,
+                axisX: _binXAxis,
+                axisY: _binYAxis
+            })
+            _binChart.addSeries(series)
+
+            let minY = Number.MAX_VALUE
+            let maxY = -Number.MAX_VALUE
+            const sampleStep = Math.max(1, Math.ceil(points.length / _maxChartPointsPerField))
+            let appendedLastX = -Number.MAX_VALUE
+            for (let j = 0; j < points.length; j += sampleStep) {
+                series.append(points[j].x, points[j].y)
+                appendedLastX = points[j].x
+                if (points[j].y < minY) minY = points[j].y
+                if (points[j].y > maxY) maxY = points[j].y
+            }
+            if (sampleStep > 1) {
+                const last = points[points.length - 1]
+                if (last && last.x !== appendedLastX) series.append(last.x, last.y)
+            }
+
+            _seriesByField[fieldName] = series
+            _fieldYRange[fieldName] = { min: minY, max: maxY }
+        }
+
+        for (let i = 0; i < newSelection.length; i++) {
+            const fn = String(newSelection[i])
+            const s = _seriesByField[fn]
+            if (s) s.color = fieldColor(fn)
+        }
+
+        const allTracked = Object.keys(_seriesByField)
+        let globalMinY = 0
+        let globalMaxY = 1
+        if (allTracked.length > 0) {
+            globalMinY = Number.MAX_VALUE
+            globalMaxY = -Number.MAX_VALUE
+            for (let i = 0; i < allTracked.length; i++) {
+                const r = _fieldYRange[allTracked[i]]
+                if (r) {
+                    if (r.min < globalMinY) globalMinY = r.min
+                    if (r.max > globalMaxY) globalMaxY = r.max
+                }
+            }
+            if (globalMinY === globalMaxY) globalMaxY = globalMinY + 1
+        }
+        _binYAxis.min = globalMinY
+        _binYAxis.max = globalMaxY
+
+        const existingTypes = Object.keys(_eventSeriesByType)
+        for (let i = 0; i < existingTypes.length; i++) {
+            _binChart.removeSeries(_eventSeriesByType[existingTypes[i]])
+        }
+        _eventSeriesByType = {}
+        const eventList = logParser.events
+        for (let e = 0; e < eventList.length; e++) {
+            const ev = eventList[e]
+            if (ev.time < _binXAxis.min || ev.time > _binXAxis.max) continue
+            if (!_eventSeriesByType[ev.type]) {
+                const eventSeries = _scatterSeriesComponent.createObject(_binChart, {
+                    color: eventColor(ev.type),
+                    axisX: _binXAxis,
+                    axisY: _binYAxis
+                })
+                _binChart.addSeries(eventSeries)
+                _eventSeriesByType[ev.type] = eventSeries
+            }
+            _eventSeriesByType[ev.type].append(ev.time, _binYAxis.max)
+        }
+
+        Qt.callLater(_refreshCursorAtCurrentPosition)
+    }
+
+    // -------------------------------------------------------------------------
+    // Internal connections
+    // -------------------------------------------------------------------------
+    Connections {
+        target: logViewerController
+        function onSelectedFieldsChanged() {
+            Qt.callLater(_syncSeriesWithSelection)
+        }
+    }
+
+    // -------------------------------------------------------------------------
+    // Timeline bars (offset to align with chart plot area)
+    // -------------------------------------------------------------------------
+    ColumnLayout {
+        id: _timelineContainer
+        Layout.preferredWidth: _binChart.plotArea.width
+        spacing: ScreenTools.defaultFontPixelHeight * 0.1
+
+        property real _barHeight: ScreenTools.defaultFontPixelHeight * 0.6
+
+        function _segmentX(start) {
+            if (_binXAxis.max <= _binXAxis.min) return 0
+            return Math.max(0, Math.min(width, ((Math.max(start, _binXAxis.min) - _binXAxis.min) / (_binXAxis.max - _binXAxis.min)) * width))
+        }
+
+        function _segmentWidth(start, end) {
+            if (_binXAxis.max <= _binXAxis.min) return 0
+            return ((Math.min(end, _binXAxis.max) - Math.max(start, _binXAxis.min)) / (_binXAxis.max - _binXAxis.min)) * width
+        }
+
+        function _eventX(time, itemWidth) {
+            if (_binXAxis.max <= _binXAxis.min) return 0
+            return Math.max(0, Math.min(width - itemWidth, ((time - _binXAxis.min) / (_binXAxis.max - _binXAxis.min)) * width))
+        }
+
+        // Bar 1: Flight modes
+        RowLayout {
+            Layout.fillWidth: true
+            visible: logParser.modeSegments.length > 0
+
+            QGCLabel {
+                text: qsTr("Modes")
+                font.bold: true
+                Layout.preferredWidth: _binChart.plotArea.x  // Align with chart plot area
+                Layout.maximumWidth: Layout.preferredWidth
+            }
+
+            Item {
+                Layout.fillWidth: true
+                Layout.preferredHeight: _timelineContainer._barHeight
+
+                Repeater {
+                    model: logParser.modeSegments
+
+                    Rectangle {
+                        visible: _binXAxis.max > _binXAxis.min && modelData.end >= _binXAxis.min && modelData.start <= _binXAxis.max
+                        height: parent.height
+                        color: modeColor(modelData.mode)
+                        x: _timelineContainer._segmentX(modelData.start)
+                        width: Math.max(1, _timelineContainer._segmentWidth(modelData.start, modelData.end))
+                    }
+                }
+            }
+        }
+
+        // Bar 2: Dropouts
+        RowLayout {
+            Layout.fillWidth: true
+            visible: logParser.dropouts.length > 0
+
+            QGCLabel {
+                text: qsTr("Dropouts")
+                font.bold: true
+                Layout.preferredWidth: _binChart.plotArea.x  // Align with chart plot area
+                Layout.maximumWidth: Layout.preferredWidth
+            }
+
+            Item {
+                Layout.fillWidth: true
+                Layout.preferredHeight: _timelineContainer._barHeight
+
+                Repeater {
+                    model: logParser.dropouts
+
+                    Rectangle {
+                        visible: _binXAxis.max > _binXAxis.min && modelData.end >= _binXAxis.min && modelData.start <= _binXAxis.max
+                        height: parent.height
+                        color: Qt.alpha(eventColor("error"), 0.533)
+                        x: _timelineContainer._segmentX(modelData.start)
+                        width: Math.max(2, _timelineContainer._segmentWidth(modelData.start, modelData.end))
+                    }
+                }
+            }
+        }
+
+        // Bar 3: Events
+        RowLayout {
+            Layout.fillWidth: true
+            visible: logParser.events.length > 0
+
+            QGCLabel {
+                text: qsTr("Events")
+                font.bold: true
+                Layout.preferredWidth: _binChart.plotArea.x  // Align with chart plot area
+                Layout.maximumWidth: Layout.preferredWidth
+            }
+
+            Item {
+                Layout.fillWidth: true
+                Layout.preferredHeight: _timelineContainer._barHeight
+
+                Repeater {
+                    model: logParser.events
+
+                    Rectangle {
+                        width: 2
+                        height: parent.height
+                        visible: _binXAxis.max > _binXAxis.min
+                        color: eventColor(modelData.type)
+                        x: _timelineContainer._eventX(modelData.time, width)
+                    }
+                }
+            }
+        }
+    }
+
+    // -------------------------------------------------------------------------
+    // Chart area
+    // -------------------------------------------------------------------------
+    Item {
+        id: _chartContainer
+        Layout.fillWidth: true
+        Layout.fillHeight: true
+
+        GraphsView {
+            id: _binChart
+            anchors.fill: parent
+            marginTop: 0
+            marginRight: 0
+            marginBottom: 0
+            marginLeft: 0
+
+            theme: GraphsTheme {
+                colorScheme: qgcPal.globalTheme === QGCPalette.Light ? GraphsTheme.ColorScheme.Light : GraphsTheme.ColorScheme.Dark
+                backgroundColor: qgcPal.windowShadeDark
+                backgroundVisible: true
+                plotAreaBackgroundColor: qgcPal.windowShadeDark
+                grid.mainColor: Qt.rgba(qgcPal.text.r, qgcPal.text.g, qgcPal.text.b, 0.25)
+                grid.subColor: Qt.rgba(qgcPal.text.r, qgcPal.text.g, qgcPal.text.b, 0.12)
+                grid.mainWidth: 1
+                labelBackgroundVisible: false
+                labelTextColor: qgcPal.text
+                axisXLabelFont.family: ScreenTools.fixedFontFamily
+                axisXLabelFont.pointSize: ScreenTools.smallFontPointSize
+                axisYLabelFont.family: ScreenTools.fixedFontFamily
+                axisYLabelFont.pointSize: ScreenTools.smallFontPointSize
+            }
+
+            axisX: ValueAxis {
+                id: _binXAxis
+                titleText: qsTr("Time (s)")
+                min: 0
+                max: 1
+            }
+
+            axisY: ValueAxis {
+                id: _binYAxis
+                titleText: qsTr("Value")
+                min: 0
+                max: 1
+            }
+        }
+
+        Rectangle {
+            id: _zoomSelectionRect
+            visible: false
+            color: Qt.rgba(1, 1, 1, 0.2)
+            border.color: qgcPal.buttonHighlight
+            border.width: 1
+            z: 1000
+        }
+
+        MouseArea {
+            id: _chartZoomArea
+            anchors.fill: parent
+            enabled: _binXAxis.max > _binXAxis.min
+            acceptedButtons: Qt.LeftButton | Qt.RightButton
+            z: 1001
+
+            property real _dragStartX: 0
+
+            onPressed: (mouse) => {
+                if (mouse.button === Qt.RightButton) {
+                    resetZoom()
+                    return
+                }
+                _dragStartX = mouse.x
+                _zoomSelectionRect.x = mouse.x
+                _zoomSelectionRect.y = _binChart.plotArea.y
+                _zoomSelectionRect.width = 0
+                _zoomSelectionRect.height = _binChart.plotArea.height
+                _zoomSelectionRect.visible = true
+            }
+
+            onPositionChanged: (mouse) => {
+                if (pressed && _zoomSelectionRect.visible) {
+                    const left  = Math.min(_dragStartX, mouse.x)
+                    const right = Math.max(_dragStartX, mouse.x)
+                    _zoomSelectionRect.x = left
+                    _zoomSelectionRect.width = Math.max(0, right - left)
+                }
+            }
+
+            onReleased: (mouse) => {
+                if (!_zoomSelectionRect.visible) return
+                const dragWidth = _zoomSelectionRect.width
+                _zoomSelectionRect.visible = false
+                if (dragWidth < ScreenTools.defaultFontPixelWidth * 0.5) {
+                    _updateCursorInfo(mouse.x, mouse.y, width, height)
+                    return
+                }
+                const leftX  = _pixelToAxisX(_zoomSelectionRect.x)
+                const rightX = _pixelToAxisX(_zoomSelectionRect.x + _zoomSelectionRect.width)
+                applyZoomRange(Math.min(leftX, rightX), Math.max(leftX, rightX))
+            }
+        }
+
+        // Position marker line
+        Rectangle {
+            visible: _positionMarkerVisible
+            x: _markerPixelX
+            y: _binChart.plotArea.y
+            width: 1
+            height: _binChart.plotArea.height
+            color: qgcPal.text
+            z: 1002
+        }
+
+        // Value popup
+        Rectangle {
+            id: _valuePopup
+            visible: _positionMarkerVisible && _markerRows.length > 0
+            x: _popupX()
+            y: _binChart.plotArea.y
+            width: ScreenTools.defaultFontPixelWidth * 30
+            color: qgcPal.windowShade
+            border.color: qgcPal.windowShadeDark
+            radius: ScreenTools.defaultFontPixelWidth * 0.3
+            z: 1003
+            implicitHeight: _valueColumnLayout.implicitHeight + (ScreenTools.defaultFontPixelHeight * 0.6)
+
+            property real colorBlockWidth: ScreenTools.defaultFontPixelHeight * 0.8
+
+            function _popupX() {
+                const rightCornerX = _binChart.plotArea.x + _binChart.plotArea.width - width
+                return (_markerPixelX > rightCornerX) ? _binChart.plotArea.x : rightCornerX
+            }
+
+            ColumnLayout {
+                id: _valueColumnLayout
+                anchors.fill: parent
+                anchors.margins: ScreenTools.defaultFontPixelHeight * 0.3
+                spacing: ScreenTools.defaultFontPixelHeight * 0.2
+
+                QGCLabel {
+                    text: qsTr("t=%1 s").arg(_markerXValue.toFixed(3))
+                    font.bold: true
+                }
+
+                RowLayout {
+                    visible: _markerModeName.length > 0
+                    spacing: ScreenTools.defaultFontPixelWidth * 0.2
+
+                    Rectangle {
+                        Layout.preferredWidth: _valuePopup.colorBlockWidth
+                        Layout.preferredHeight: _valuePopup.colorBlockWidth
+                        color: modeColor(_markerModeName)
+                    }
+
+                    QGCLabel { text: qsTr("Mode: %1").arg(_markerModeName) }
+                }
+
+                Repeater {
+                    model: _markerRows
+
+                    RowLayout {
+                        spacing: ScreenTools.defaultFontPixelWidth * 0.2
+
+                        Rectangle {
+                            Layout.preferredWidth: _valuePopup.colorBlockWidth
+                            Layout.preferredHeight: _valuePopup.colorBlockWidth
+                            color: modelData.color
+                        }
+
+                        QGCLabel {
+                            width: _valuePopup.width - (ScreenTools.defaultFontPixelWidth * 4)
+                            elide: Text.ElideMiddle
+                            text: modelData.name + ": " + Number(modelData.value).toFixed(3)
+                        }
+                    }
+                }
+
+                Repeater {
+                    model: _markerEventRows
+
+                    RowLayout {
+                        spacing: ScreenTools.defaultFontPixelWidth * 0.2
+
+                        Rectangle {
+                            Layout.preferredWidth: _valuePopup.colorBlockWidth
+                            Layout.preferredHeight: _valuePopup.colorBlockWidth
+                            color: modelData.color
+                        }
+
+                        QGCLabel {
+                            Layout.maximumWidth: ScreenTools.defaultFontPixelWidth * 20
+                            wrapMode: Text.WordWrap
+                            maximumLineCount: 2
+                            text: modelData.text
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    // -------------------------------------------------------------------------
+    // Legends
+    // -------------------------------------------------------------------------
+    Row {
+        Layout.fillWidth: true
+        Layout.preferredHeight: _legendRowHeight
+        visible: modeLegendEntries().length > 0
+        spacing: ScreenTools.defaultFontPixelWidth
+
+        QGCLabel { text: qsTr("Modes:"); font.bold: true }
+
+        Repeater {
+            model: modeLegendEntries()
+
+            RowLayout {
+                spacing: _legendItemSpacing
+
+                Rectangle {
+                    Layout.preferredWidth: _legendColorBlockSize
+                    Layout.preferredHeight: _legendColorBlockSize
+                    color: modeColor(modelData)
+                }
+
+                QGCLabel { text: modelData }
+            }
+        }
+    }
+
+    Row {
+        Layout.fillWidth: true
+        Layout.preferredHeight: _legendRowHeight
+        visible: logViewerController.selectedFields.length > 0
+        spacing: ScreenTools.defaultFontPixelWidth
+
+        QGCLabel { text: qsTr("Fields:"); font.bold: true }
+
+        Repeater {
+            model: logViewerController.selectedFields
+
+            RowLayout {
+                spacing: _legendItemSpacing
+
+                Rectangle {
+                    Layout.preferredWidth: _legendColorBlockSize
+                    Layout.preferredHeight: _legendColorBlockSize
+                    color: fieldColor(modelData)
+                }
+
+                QGCLabel { text: modelData }
+            }
+        }
+    }
+
+    Row {
+        Layout.fillWidth: true
+        Layout.preferredHeight: _legendRowHeight
+        visible: logParser.events.length > 0
+        spacing: ScreenTools.defaultFontPixelWidth
+
+        QGCLabel { text: qsTr("Events:"); font.bold: true }
+
+        Repeater {
+            model: ["mode", "event", "error", "warning"]
+
+            RowLayout {
+                spacing: _legendItemSpacing
+                visible: {
+                    for (let i = 0; i < logParser.events.length; i++) {
+                        if (logParser.events[i].type === modelData) return true
+                    }
+                    return false
+                }
+
+                Rectangle {
+                    Layout.preferredWidth: _legendColorBlockSize
+                    Layout.preferredHeight: _legendColorBlockSize
+                    color: eventColor(modelData)
+                }
+
+                QGCLabel { text: eventTypeLabel(modelData) }
+            }
+        }
+    }
+
+    // -------------------------------------------------------------------------
+    // Zoom controls
+    // -------------------------------------------------------------------------
+    RowLayout {
+        Layout.fillWidth: true
+        spacing: ScreenTools.defaultFontPixelWidth
+
+        QGCLabel {
+            Layout.fillWidth: true
+            text: qsTr("Drag on chart to zoom X-axis. Right click chart to reset zoom.")
+        }
+
+        QGCButton {
+            text: qsTr("Reset Zoom")
+            enabled: _zoomMinX !== _fullMinX || _zoomMaxX !== _fullMaxX
+            onClicked: resetZoom()
+        }
+    }
+}

--- a/src/AnalyzeView/LogViewer/LogViewerPage.qml
+++ b/src/AnalyzeView/LogViewer/LogViewerPage.qml
@@ -408,6 +408,7 @@ AnalyzePage {
                                     Item {
                                         id: groupRect
                                         visible: modelData.rowType === "group"
+                                        width: parent.width
                                         implicitWidth: groupLayout.implicitWidth
                                         implicitHeight: groupLayout.implicitHeight
 

--- a/src/AnalyzeView/LogViewer/LogViewerPage.qml
+++ b/src/AnalyzeView/LogViewer/LogViewerPage.qml
@@ -1,10 +1,10 @@
 import QtQuick
 import QtQuick.Controls
 import QtQuick.Layouts
-import QtGraphs
 
 import QGroundControl
 import QGroundControl.Controls
+import QGroundControl.LogViewer
 
 AnalyzePage {
     id: logViewerPage
@@ -21,92 +21,13 @@ AnalyzePage {
 
             property bool binLoading: false
             property string pendingBinFile: ""
-            property bool cursorVisible: false
-            property real cursorPixelX: 0
-            property real cursorXValue: 0
-            property real cursorPopupY: 0
-            property var cursorRows: []
-            property var cursorEventRows: []
-            property string cursorModeName: ""
             property string fieldSearchText: ""
             property string parameterSearchText: ""
             property var filteredFieldRows: []
             property var filteredParameters: []
-            property real fullMinX: 0
-            property real fullMaxX: 1
-            property real zoomMinX: 0
-            property real zoomMaxX: 1
-
-            // Maps fieldName → LineSeries and fieldName → {min, max} for incremental add/remove.
-            property var _seriesByField: ({})
-            property var _fieldYRange: ({})
-            // Maps eventType → ScatterSeries; rebuilt whenever field selection changes,
-            // because Y pin position depends on binYAxis.max which is recomputed at that time.
-            property var _eventSeriesByType: ({})
-
-            // Cap decimation to keep QtGraphs rendering below ~16ms per frame.
-            // Empirically, >~6000 points per series causes visible frame drops on mid-range hardware.
-            property int maxChartPointsPerField: 6000
 
             readonly property bool isFirmwareLog: logViewerController.sourceType === LogViewerController.Bin
                                              || logViewerController.sourceType === LogViewerController.ULog
-
-            // Visually distinct categorical palette for selected-field series.
-            // Position-based picks avoid hash collisions producing similar colors.
-            readonly property var _fieldChartColors: [
-                "#1E88E5", // blue
-                "#E53935", // red
-                "#43A047", // green
-                "#FB8C00", // orange
-                "#8E24AA", // purple
-                "#00ACC1", // cyan
-                "#FDD835", // yellow
-                "#D81B60", // pink
-                "#6D4C41", // brown
-                "#546E7A", // blue grey
-                "#3949AB", // indigo
-                "#00897B", // teal
-            ]
-
-            Component {
-                id: lineSeriesComponent
-
-                LineSeries { }
-            }
-
-            Component {
-                id: scatterSeriesComponent
-
-                ScatterSeries { }
-            }
-
-            function eventColor(eventType) {
-                return logViewerController.eventColor(eventType)
-            }
-
-            function eventTypeLabel(eventType) {
-                if (eventType === "mode") {
-                    return qsTr("Mode")
-                }
-                if (eventType === "event") {
-                    return qsTr("Event")
-                }
-                if (eventType === "error") {
-                    return qsTr("Error")
-                }
-                if (eventType === "warning") {
-                    return qsTr("Warning")
-                }
-                return eventType
-            }
-
-            function modeColor(modeName) {
-                return logViewerController.modeColor(String(modeName))
-            }
-
-            function modeLegendEntries() {
-                return logViewerController.modeLegendEntries(logParser.modeSegments)
-            }
 
             function rebuildGroupedFields() {
                 logViewerController.setPlottableFields(logParser.plottableFields)
@@ -191,90 +112,16 @@ AnalyzePage {
                 return logViewerController.isFieldSelected(fieldName)
             }
 
-            function fieldColor(fieldName) {
-                const idx = logViewerController.selectedFields.indexOf(fieldName)
-                if (idx >= 0) {
-                    return _fieldChartColors[idx % _fieldChartColors.length]
-                }
-                return logViewerController.fieldColor(fieldName)
-            }
-
-            function applyZoomRange(minX, maxX) {
-                if (maxX <= minX) {
-                    return
-                }
-                zoomMinX = minX
-                zoomMaxX = maxX
-                binXAxis.min = zoomMinX
-                binXAxis.max = zoomMaxX
-            }
-
-            function resetZoom() {
-                applyZoomRange(fullMinX, fullMaxX)
-            }
-
-            function _pixelToAxisX(pixelX) {
-                const plotX = binChart.plotArea.x
-                const plotW = binChart.plotArea.width
-                if (plotW <= 0 || binXAxis.max <= binXAxis.min) {
-                    return binXAxis.min
-                }
-
-                const clampedPixel = Math.max(plotX, Math.min(plotX + plotW, pixelX))
-                const ratio = (clampedPixel - plotX) / plotW
-                return binXAxis.min + (ratio * (binXAxis.max - binXAxis.min))
-            }
-
-            function updateCursorInfo(pixelX, pixelY, width, height) {
-                const selectedFields = logViewerController.selectedFields
-                if (selectedFields.length === 0 || width <= 0 || height <= 0) {
-                    cursorVisible = false
-                    return
-                }
-
-                cursorVisible = true
-                cursorPixelX = Math.max(binChart.plotArea.x, Math.min(binChart.plotArea.x + binChart.plotArea.width, pixelX))
-                cursorXValue = _pixelToAxisX(cursorPixelX)
-                cursorPopupY = Math.max(0, Math.min(height - (ScreenTools.defaultFontPixelHeight * 4), pixelY))
-                cursorModeName = logParser.modeAt(cursorXValue)
-
-                const rows = []
-                for (let i = 0; i < selectedFields.length; i++) {
-                    const field = selectedFields[i]
-                    const value = logParser.fieldValueAt(field, cursorXValue)
-                    if (isNaN(value)) {
-                        continue
-                    }
-                    rows.push({
-                        name: field,
-                        color: fieldColor(field),
-                        value: value
-                    })
-                }
-                cursorRows = rows
-
-                const threshold = Math.max(0.05, (binXAxis.max - binXAxis.min) / 200.0)
-                const nearbyEvents = logParser.eventsNear(cursorXValue, threshold)
-                const events = []
-                for (let i = 0; i < nearbyEvents.length; i++) {
-                    events.push({
-                        color: eventColor(nearbyEvents[i].type),
-                        text: nearbyEvents[i].description
-                    })
-                }
-                cursorEventRows = events
-            }
-
             function clearLoadedLogState(clearControllerState) {
                 replayController.isPlaying = false
                 replayController.link = null
                 logParser.clear()
                 logViewerController.setPlottableFields([])
                 logViewerController.clearSelection()
-                cursorEventRows = []
                 filteredFieldRows = []
                 filteredParameters = []
-                refreshBinChart()
+                logViewerChart.clearMarker()
+                logViewerChart.refreshBinChart()
                 if (clearControllerState) {
                     logViewerController.clear()
                 }
@@ -300,147 +147,6 @@ AnalyzePage {
                 logParser.parseFileAsync(file)
             }
 
-            // Full reset: remove all series and reinitialise axes from the log time range.
-            // Called on log load, on full clear (clearLoadedLogState), and when all selected fields
-            // are cleared via the "Clear Selected" button. For incremental selection changes use
-            // _syncSeriesWithSelection instead.
-            function refreshBinChart() {
-                while (binChart.seriesList.length > 0) {
-                    binChart.removeSeries(binChart.seriesList[0])
-                }
-                _seriesByField = {}
-                _fieldYRange = {}
-                _eventSeriesByType = {}
-
-                if (logParser.minTimestamp >= 0.0 && logParser.maxTimestamp > logParser.minTimestamp) {
-                    fullMinX = logParser.minTimestamp
-                    fullMaxX = logParser.maxTimestamp
-                } else {
-                    fullMinX = 0
-                    fullMaxX = 1
-                }
-                zoomMinX = fullMinX
-                zoomMaxX = fullMaxX
-                binXAxis.min = zoomMinX
-                binXAxis.max = zoomMaxX
-                binYAxis.min = 0
-                binYAxis.max = 1
-            }
-
-            // Incremental update: diff the current series map against the new selection,
-            // remove series for deselected fields, add series for newly selected fields,
-            // then recompute the Y axis and rebuild the event scatter series.
-            function _syncSeriesWithSelection() {
-                const newSelection = logViewerController.selectedFields
-
-                // Build lookup of desired fields
-                const desired = {}
-                for (let i = 0; i < newSelection.length; i++) {
-                    desired[String(newSelection[i])] = true
-                }
-
-                // Remove series for fields that are no longer selected
-                const tracked = Object.keys(_seriesByField)
-                for (let i = 0; i < tracked.length; i++) {
-                    if (!desired[tracked[i]]) {
-                        binChart.removeSeries(_seriesByField[tracked[i]])
-                        delete _seriesByField[tracked[i]]
-                        delete _fieldYRange[tracked[i]]
-                    }
-                }
-
-                // Add a series for each newly selected field
-                for (let i = 0; i < newSelection.length; i++) {
-                    const fieldName = String(newSelection[i])
-                    if (_seriesByField[fieldName]) {
-                        continue
-                    }
-
-                    const points = logParser.fieldSamples(fieldName)
-                    if (!points || points.length === 0) {
-                        continue
-                    }
-
-                    const series = lineSeriesComponent.createObject(binChart, {
-                        color: fieldColor(fieldName),
-                        width: 2,
-                        axisX: binXAxis,
-                        axisY: binYAxis
-                    })
-                    binChart.addSeries(series)
-
-                    let minY = Number.MAX_VALUE
-                    let maxY = -Number.MAX_VALUE
-                    const sampleStep = Math.max(1, Math.ceil(points.length / maxChartPointsPerField))
-                    let appendedLastX = -Number.MAX_VALUE
-                    for (let j = 0; j < points.length; j += sampleStep) {
-                        series.append(points[j].x, points[j].y)
-                        appendedLastX = points[j].x
-                        if (points[j].y < minY) minY = points[j].y
-                        if (points[j].y > maxY) maxY = points[j].y
-                    }
-                    if (sampleStep > 1) {
-                        const last = points[points.length - 1]
-                        if (last && last.x !== appendedLastX) {
-                            series.append(last.x, last.y)
-                        }
-                    }
-
-                    _seriesByField[fieldName] = series
-                    _fieldYRange[fieldName] = { min: minY, max: maxY }
-                }
-
-                // Update colors for all tracked series (selection indices may have shifted)
-                for (let i = 0; i < newSelection.length; i++) {
-                    const fn = String(newSelection[i])
-                    const s = _seriesByField[fn]
-                    if (s) s.color = fieldColor(fn)
-                }
-
-                // Recompute Y axis from cached per-field ranges
-                const allTracked = Object.keys(_seriesByField)
-                let globalMinY = 0
-                let globalMaxY = 1
-                if (allTracked.length > 0) {
-                    globalMinY = Number.MAX_VALUE
-                    globalMaxY = -Number.MAX_VALUE
-                    for (let i = 0; i < allTracked.length; i++) {
-                        const r = _fieldYRange[allTracked[i]]
-                        if (r) {
-                            if (r.min < globalMinY) globalMinY = r.min
-                            if (r.max > globalMaxY) globalMaxY = r.max
-                        }
-                    }
-                    if (globalMinY === globalMaxY) globalMaxY = globalMinY + 1
-                }
-                binYAxis.min = globalMinY
-                binYAxis.max = globalMaxY
-
-                // Rebuild event scatter series (Y position is pinned to current binYAxis.max)
-                const existingTypes = Object.keys(_eventSeriesByType)
-                for (let i = 0; i < existingTypes.length; i++) {
-                    binChart.removeSeries(_eventSeriesByType[existingTypes[i]])
-                }
-                _eventSeriesByType = {}
-                const eventList = logParser.events
-                for (let e = 0; e < eventList.length; e++) {
-                    const ev = eventList[e]
-                    if (ev.time < binXAxis.min || ev.time > binXAxis.max) {
-                        continue
-                    }
-                    if (!_eventSeriesByType[ev.type]) {
-                        const eventSeries = scatterSeriesComponent.createObject(binChart, {
-                            color: eventColor(ev.type),
-                            axisX: binXAxis,
-                            axisY: binYAxis
-                        })
-                        binChart.addSeries(eventSeries)
-                        _eventSeriesByType[ev.type] = eventSeries
-                    }
-                    _eventSeriesByType[ev.type].append(ev.time, binYAxis.max)
-                }
-            }
-
             LogViewerController {
                 id: logViewerController
             }
@@ -453,9 +159,6 @@ AnalyzePage {
                 target: logViewerController
                 function onFieldRowsChanged() {
                     applyFieldFilter()
-                }
-                function onSelectedFieldsChanged() {
-                    Qt.callLater(_syncSeriesWithSelection)
                 }
             }
 
@@ -478,11 +181,9 @@ AnalyzePage {
                     rebuildGroupedFields()
                     applyParameterFilter()
                     logViewerController.clearSelection()
-                    fullMinX = 0
-                    fullMaxX = 1
-                    zoomMinX = 0
-                    zoomMaxX = 1
-                    refreshBinChart()
+                    logViewerChart.clearMarker()
+                    logViewerChart.refreshBinChart()
+                    Qt.callLater(logViewerChart.centerCursor)
 
                     const lowerPath = filePath.toLowerCase()
                     if (lowerPath.endsWith(".ulg")) {
@@ -620,20 +321,6 @@ AnalyzePage {
                         spacing: ScreenTools.defaultFontPixelHeight * 0.5
 
                         QGCLabel {
-                            text: qsTr("Messages / Parameters")
-                            font.bold: true
-                        }
-
-                        QGCLabel {
-                            Layout.fillWidth: true
-                            wrapMode: Text.WordWrap
-                            maximumLineCount: 3
-                            text: (isFirmwareLog)
-                                  ? qsTr("DataFlash message and parameter browser will appear here.")
-                                  : qsTr("For telemetry replay, MAVLink message and field selection is available through the Inspector integration.")
-                        }
-
-                        QGCLabel {
                             visible: isFirmwareLog
                             text: qsTr("Fields: %1  Parameters: %2  Events: %3")
                                   .arg(logParser.plottableFields.length)
@@ -655,7 +342,7 @@ AnalyzePage {
                             spacing: ScreenTools.defaultFontPixelWidth * 0.5
 
                             QGCLabel {
-                                text: qsTr("Fields (click to plot)")
+                                text: qsTr("Fields")
                                 font.bold: true
                             }
 
@@ -692,7 +379,7 @@ AnalyzePage {
                                 onClicked: {
                                     logViewerController.clearSelection()
                                     applyFieldFilter()
-                                    refreshBinChart()
+                                    logViewerChart.refreshBinChart()
                                 }
                             }
                         }
@@ -708,7 +395,7 @@ AnalyzePage {
                                 id: fieldsListView
                                 anchors.fill: parent
                                 model: filteredFieldRows
-                                spacing: ScreenTools.defaultFontPixelHeight * 0.15
+                                spacing: 0
                                 clip: true
                                 ScrollBar.vertical: ScrollBar { }
 
@@ -718,22 +405,30 @@ AnalyzePage {
                                             ? (groupRect.implicitHeight + (ScreenTools.defaultFontPixelHeight * 0.1))
                                             : (fieldRow.implicitHeight + (ScreenTools.defaultFontPixelHeight * 0.1))
 
-                                    Rectangle {
+                                    Item {
                                         id: groupRect
                                         visible: modelData.rowType === "group"
-                                        width: parent.width
-                                        implicitHeight: groupLabel.implicitHeight + (ScreenTools.defaultFontPixelHeight * 0.35)
-                                        color: qgcPal.windowShadeDark
-                                        radius: ScreenTools.defaultFontPixelWidth * 0.25
+                                        implicitWidth: groupLayout.implicitWidth
+                                        implicitHeight: groupLayout.implicitHeight
 
-                                        Row {
-                                            anchors.fill: parent
-                                            anchors.leftMargin: ScreenTools.defaultFontPixelWidth * 0.2
-                                            anchors.verticalCenter: parent.verticalCenter
-                                            spacing: ScreenTools.defaultFontPixelWidth * 0.3
+                                        RowLayout {
+                                            id: groupLayout
+                                            spacing: ScreenTools.defaultFontPixelWidth / 2
 
-                                            QGCLabel { text: (String(fieldSearchText).trim().length > 0) ? "▼" : (isGroupExpanded(modelData.group) ? "▼" : "▶") }
-                                            QGCLabel { id: groupLabel; text: modelData.group; font.bold: true }
+                                            QGCColoredImage {
+                                                Layout.preferredWidth: groupLabel.height * 0.5
+                                                Layout.preferredHeight: groupLabel.height * 0.5
+                                                source: "/qmlimages/arrow-down.png"
+                                                color: qgcPal.text
+                                                fillMode: Image.PreserveAspectFit
+                                                rotation: (String(fieldSearchText).trim().length > 0 || isGroupExpanded(modelData.group)) ? 0 : -90
+                                            }
+
+                                            QGCLabel {
+                                                id: groupLabel
+                                                text: modelData.group;
+                                                font.bold: true
+                                            }
                                         }
 
                                         MouseArea {
@@ -765,7 +460,7 @@ AnalyzePage {
                                             maximumLineCount: 2
                                             verticalAlignment: Text.AlignVCenter
                                             text: modelData.shortName ? String(modelData.shortName) : ""
-                                            color: isFieldSelected(modelData.fullName) ? fieldColor(modelData.fullName) : qgcPal.text
+                                            color: isFieldSelected(modelData.fullName) ? logViewerChart.fieldColor(modelData.fullName) : qgcPal.text
                                         }
                                     }
                                 }
@@ -802,6 +497,7 @@ AnalyzePage {
                             textColor: qgcPal.textFieldText
                             placeholderTextColor: Qt.rgba(qgcPal.textFieldText.r, qgcPal.textFieldText.g, qgcPal.textFieldText.b, 0.7)
                             placeholderText: qsTr("Search parameters")
+
                             onTextChanged: {
                                 parameterSearchText = text
                                 if (text.trim().length === 0) {
@@ -811,6 +507,7 @@ AnalyzePage {
                                     parameterSearchTimer.restart()
                                 }
                             }
+
                             onAccepted: {
                                 parameterSearchText = text
                                 parameterSearchTimer.stop()
@@ -889,380 +586,13 @@ AnalyzePage {
                             font.bold: true
                         }
 
-                        QGCLabel {
-                            Layout.fillWidth: true
-                            wrapMode: Text.WordWrap
-                            maximumLineCount: 2
-                            text: qsTr("Multi-series charts, event markers, and timeline controls are shown here.")
-                            visible: logViewerController.sourceType !== LogViewerController.TLog
-                        }
-
-                        Item {
-                            id: chartContainer
+                        LogViewerChart {
+                            id: logViewerChart
                             Layout.fillWidth: true
                             Layout.fillHeight: true
-                            Layout.preferredHeight: parent.height * 0.72
                             visible: isFirmwareLog
-
-                            GraphsView {
-                                id: binChart
-                                anchors.fill: parent
-                                marginTop: 0
-                                marginRight: 0
-                                marginBottom: 0
-                                marginLeft: 0
-
-                                theme: GraphsTheme {
-                                    colorScheme: qgcPal.globalTheme === QGCPalette.Light ? GraphsTheme.ColorScheme.Light : GraphsTheme.ColorScheme.Dark
-                                    backgroundColor: qgcPal.windowShadeDark
-                                    backgroundVisible: true
-                                    plotAreaBackgroundColor: qgcPal.windowShadeDark
-                                    grid.mainColor: Qt.rgba(qgcPal.text.r, qgcPal.text.g, qgcPal.text.b, 0.25)
-                                    grid.subColor: Qt.rgba(qgcPal.text.r, qgcPal.text.g, qgcPal.text.b, 0.12)
-                                    grid.mainWidth: 1
-                                    labelBackgroundVisible: false
-                                    labelTextColor: qgcPal.text
-                                    axisXLabelFont.family: ScreenTools.fixedFontFamily
-                                    axisXLabelFont.pointSize: ScreenTools.smallFontPointSize
-                                    axisYLabelFont.family: ScreenTools.fixedFontFamily
-                                    axisYLabelFont.pointSize: ScreenTools.smallFontPointSize
-                                }
-
-                                axisX: ValueAxis {
-                                    id: binXAxis
-                                    titleText: qsTr("Time (s)")
-                                    min: 0
-                                    max: 1
-                                }
-
-                                axisY: ValueAxis {
-                                    id: binYAxis
-                                    titleText: qsTr("Value")
-                                    min: 0
-                                    max: 1
-                                }
-                            }
-
-                            Rectangle {
-                                id: zoomSelectionRect
-                                visible: false
-                                color: Qt.rgba(1, 1, 1, 0.2)
-                                border.color: qgcPal.buttonHighlight
-                                border.width: 1
-                                z: 1000
-                            }
-
-                            MouseArea {
-                                id: chartZoomArea
-                                anchors.fill: parent
-                                enabled: isFirmwareLog && (binXAxis.max > binXAxis.min)
-                                hoverEnabled: true
-                                acceptedButtons: Qt.LeftButton | Qt.RightButton
-                                z: 1001
-
-                                property real _dragStartX: 0
-
-                                onPressed: (mouse) => {
-                                    if (mouse.button === Qt.RightButton) {
-                                        resetZoom()
-                                        return
-                                    }
-                                    _dragStartX = mouse.x
-                                    zoomSelectionRect.x = mouse.x
-                                    zoomSelectionRect.y = 0
-                                    zoomSelectionRect.width = 0
-                                    zoomSelectionRect.height = height
-                                    zoomSelectionRect.visible = true
-                                    updateCursorInfo(mouse.x, mouse.y, width, height)
-                                }
-
-                                onPositionChanged: (mouse) => {
-                                    if (pressed && zoomSelectionRect.visible) {
-                                        const left = Math.min(_dragStartX, mouse.x)
-                                        const right = Math.max(_dragStartX, mouse.x)
-                                        zoomSelectionRect.x = left
-                                        zoomSelectionRect.width = Math.max(0, right - left)
-                                        return
-                                    }
-
-                                    if (!pressed) {
-                                        updateCursorInfo(mouse.x, mouse.y, width, height)
-                                        return
-                                    }
-                                }
-
-                                onReleased: (mouse) => {
-                                    if (!zoomSelectionRect.visible) {
-                                        return
-                                    }
-
-                                    const dragWidth = zoomSelectionRect.width
-                                    zoomSelectionRect.visible = false
-                                    // Treat drags narrower than half a character width as accidental clicks, not zoom gestures.
-                                    if (dragWidth < ScreenTools.defaultFontPixelWidth * 0.5) {
-                                        return
-                                    }
-
-                                    const leftX = _pixelToAxisX(zoomSelectionRect.x)
-                                    const rightX = _pixelToAxisX(zoomSelectionRect.x + zoomSelectionRect.width)
-                                    applyZoomRange(Math.min(leftX, rightX), Math.max(leftX, rightX))
-                                    updateCursorInfo(mouse.x, mouse.y, width, height)
-                                }
-
-                                onExited: {
-                                    cursorVisible = false
-                                }
-                            }
-
-                            Rectangle {
-                                visible: cursorVisible && (isFirmwareLog)
-                                x: cursorPixelX
-                                y: binChart.plotArea.y
-                                width: 1
-                                height: binChart.plotArea.height
-                                color: qgcPal.buttonHighlight
-                                z: 1002
-                            }
-
-                            Rectangle {
-                                id: cursorPopup
-                                visible: cursorVisible && cursorRows.length > 0 && (isFirmwareLog)
-                                x: Math.max(0, Math.min(chartContainer.width - width, cursorPixelX + ScreenTools.defaultFontPixelWidth))
-                                y: cursorPopupY
-                                width: ScreenTools.defaultFontPixelWidth * 30
-                                color: qgcPal.windowShade
-                                border.color: qgcPal.windowShadeDark
-                                radius: ScreenTools.defaultFontPixelWidth * 0.3
-                                z: 1003
-                                implicitHeight: cursorColumn.implicitHeight + (ScreenTools.defaultFontPixelHeight * 0.6)
-
-                                Column {
-                                    id: cursorColumn
-                                    anchors.fill: parent
-                                    anchors.margins: ScreenTools.defaultFontPixelHeight * 0.3
-                                    spacing: ScreenTools.defaultFontPixelHeight * 0.2
-
-                                    QGCLabel {
-                                        text: qsTr("t=%1 s").arg(cursorXValue.toFixed(3))
-                                        font.bold: true
-                                    }
-
-                                    QGCLabel {
-                                        visible: cursorModeName.length > 0
-                                        text: qsTr("Mode: %1").arg(cursorModeName)
-                                        font.bold: true
-                                        color: cursorModeName.length > 0 ? modeColor(cursorModeName) : qgcPal.text
-                                    }
-
-                                    Repeater {
-                                        model: cursorRows
-
-                                        Row {
-                                            spacing: ScreenTools.defaultFontPixelWidth * 0.2
-
-                                            Rectangle {
-                                                width: ScreenTools.defaultFontPixelWidth * 0.8
-                                                height: ScreenTools.defaultFontPixelHeight * 0.6
-                                                color: modelData.color
-                                            }
-
-                                            QGCLabel {
-                                                width: cursorPopup.width - (ScreenTools.defaultFontPixelWidth * 4)
-                                                elide: Text.ElideMiddle
-                                                text: modelData.name + ": " + Number(modelData.value).toFixed(3)
-                                            }
-                                        }
-                                    }
-
-                                    Repeater {
-                                        model: cursorEventRows
-
-                                        Row {
-                                            spacing: ScreenTools.defaultFontPixelWidth * 0.2
-
-                                            Rectangle {
-                                                width: ScreenTools.defaultFontPixelWidth * 0.8
-                                                height: ScreenTools.defaultFontPixelHeight * 0.6
-                                                color: modelData.color
-                                            }
-
-                                            QGCLabel {
-                                                width: cursorPopup.width - (ScreenTools.defaultFontPixelWidth * 4)
-                                                wrapMode: Text.WordWrap
-                                                maximumLineCount: 2
-                                                text: modelData.text
-                                            }
-                                        }
-                                    }
-                                }
-                            }
-                        }
-
-                        Rectangle {
-                            Layout.fillWidth: true
-                            Layout.preferredHeight: ScreenTools.defaultFontPixelHeight * 0.6
-                            visible: isFirmwareLog
-                            color: qgcPal.windowShade
-
-                            Repeater {
-                                model: logParser.modeSegments
-
-                                Rectangle {
-                                    visible: binXAxis.max > binXAxis.min && modelData.end >= binXAxis.min && modelData.start <= binXAxis.max
-                                    y: 0
-                                    height: parent.height
-                                    color: modeColor(modelData.mode)
-                                    opacity: 1.0
-                                    x: Math.max(binChart.plotArea.x,
-                                                Math.min(binChart.plotArea.x + binChart.plotArea.width,
-                                                         binChart.plotArea.x + ((Math.max(modelData.start, binXAxis.min) - binXAxis.min) / (binXAxis.max - binXAxis.min)) * binChart.plotArea.width))
-                                    width: Math.max(1, ((Math.min(modelData.end, binXAxis.max) - Math.max(modelData.start, binXAxis.min)) / (binXAxis.max - binXAxis.min)) * binChart.plotArea.width)
-                                }
-                            }
-
-                            Repeater {
-                                model: logParser.dropouts
-
-                                Rectangle {
-                                    visible: binXAxis.max > binXAxis.min && modelData.end >= binXAxis.min && modelData.start <= binXAxis.max
-                                    y: 0
-                                    height: parent.height
-                                    color: Qt.alpha(eventColor("error"), 0.533)
-                                    x: Math.max(binChart.plotArea.x,
-                                                Math.min(binChart.plotArea.x + binChart.plotArea.width,
-                                                         binChart.plotArea.x + ((Math.max(modelData.start, binXAxis.min) - binXAxis.min) / (binXAxis.max - binXAxis.min)) * binChart.plotArea.width))
-                                    width: Math.max(2, ((Math.min(modelData.end, binXAxis.max) - Math.max(modelData.start, binXAxis.min)) / (binXAxis.max - binXAxis.min)) * binChart.plotArea.width)
-                                }
-                            }
-
-                            Repeater {
-                                model: logParser.events
-
-                                Rectangle {
-                                    width: 2
-                                    height: parent.height
-                                    visible: binXAxis.max > binXAxis.min
-                                    color: eventColor(modelData.type)
-                                    x: Math.max(binChart.plotArea.x,
-                                                Math.min((binChart.plotArea.x + binChart.plotArea.width) - width,
-                                                         binChart.plotArea.x + ((modelData.time - binXAxis.min) / (binXAxis.max - binXAxis.min)) * binChart.plotArea.width))
-                                }
-                            }
-                        }
-
-                        Row {
-                            Layout.fillWidth: true
-                            visible: isFirmwareLog && modeLegendEntries().length > 0
-                            Layout.preferredHeight: ScreenTools.defaultFontPixelHeight * 1.1
-                            spacing: ScreenTools.defaultFontPixelWidth
-
-                            QGCLabel {
-                                text: qsTr("Modes:")
-                                font.bold: true
-                            }
-
-                            Repeater {
-                                model: modeLegendEntries()
-
-                                Row {
-                                    spacing: ScreenTools.defaultFontPixelWidth * 0.2
-
-                                    Rectangle {
-                                        width: ScreenTools.defaultFontPixelWidth
-                                        height: ScreenTools.defaultFontPixelHeight * 0.6
-                                        color: modeColor(modelData)
-                                    }
-
-                                    QGCLabel {
-                                        text: modelData
-                                    }
-                                }
-                            }
-                        }
-
-                        Row {
-                            Layout.fillWidth: true
-                            visible: isFirmwareLog && logViewerController.selectedFields.length > 0
-                            Layout.preferredHeight: ScreenTools.defaultFontPixelHeight * 1.1
-                            spacing: ScreenTools.defaultFontPixelWidth
-
-                            QGCLabel {
-                                text: qsTr("Fields:")
-                                font.bold: true
-                            }
-
-                            Repeater {
-                                model: logViewerController.selectedFields
-
-                                Row {
-                                    spacing: ScreenTools.defaultFontPixelWidth * 0.2
-
-                                    Rectangle {
-                                        width: ScreenTools.defaultFontPixelWidth
-                                        height: ScreenTools.defaultFontPixelHeight * 0.6
-                                        color: fieldColor(modelData)
-                                    }
-
-                                    QGCLabel {
-                                        text: modelData
-                                    }
-                                }
-                            }
-                        }
-
-                        Row {
-                            Layout.fillWidth: true
-                            visible: isFirmwareLog && logParser.events.length > 0
-                            Layout.preferredHeight: ScreenTools.defaultFontPixelHeight * 1.1
-                            spacing: ScreenTools.defaultFontPixelWidth
-
-                            QGCLabel {
-                                text: qsTr("Events:")
-                                font.bold: true
-                            }
-
-                            Repeater {
-                                model: ["mode", "event", "error", "warning"]
-
-                                Row {
-                                    spacing: ScreenTools.defaultFontPixelWidth * 0.2
-                                    visible: {
-                                        for (let i = 0; i < logParser.events.length; i++) {
-                                            if (logParser.events[i].type === modelData) {
-                                                return true
-                                            }
-                                        }
-                                        return false
-                                    }
-
-                                    Rectangle {
-                                        width: ScreenTools.defaultFontPixelWidth
-                                        height: ScreenTools.defaultFontPixelHeight * 0.6
-                                        color: eventColor(modelData)
-                                    }
-
-                                    QGCLabel {
-                                        text: eventTypeLabel(modelData)
-                                    }
-                                }
-                            }
-                        }
-
-                        RowLayout {
-                            Layout.fillWidth: true
-                            visible: isFirmwareLog
-                            spacing: ScreenTools.defaultFontPixelWidth
-
-                            QGCLabel {
-                                Layout.fillWidth: true
-                                text: qsTr("Drag on chart to zoom X-axis. Right click chart to reset zoom.")
-                            }
-
-                            QGCButton {
-                                text: qsTr("Reset Zoom")
-                                enabled: zoomMinX !== fullMinX || zoomMaxX !== fullMaxX
-                                onClicked: resetZoom()
-                            }
+                            logParser: logParser
+                            logViewerController: logViewerController
                         }
 
                         Loader {


### PR DESCRIPTION
## Summary

Extracts all chart logic from `LogViewerPage.qml` into a new self-contained `LogViewerChart` component, and wires it up via a new `QGroundControl.LogViewer` QML module.

## Changes

### `LogViewerChart.qml` (new)
Self-contained chart component. The parent controls sizing/visibility and calls three public functions at lifecycle points:
- `refreshBinChart()` — on log load or clear
- `centerCursor()` — after log load
- `clearMarker()` — on log clear

Features:
- **X-axis zoom**: click-drag to zoom, right-click to reset
- **Cursor/marker**: click to place; value popup shows field values, current flight mode, and nearby events
- **Timeline bars**: flight modes, dropouts, and events aligned to the chart plot area
- **Legends**: color swatches for modes, fields, and event types
- **Decimation**: uniform stride capped at 6000 points per field (LTTB replacement tracked in #14353)

### `LogViewerPage.qml` (modified)
Delegates all chart rendering to `LogViewerChart`. The field list and section headers remain in the page.

### `CMakeLists.txt` (modified)
Adds a `qt_add_qml_module` target (`QGroundControl.LogViewer`) to register `LogViewerChart.qml`.
