### PR TITLE
Fix FlightMap scroll wheel zoom to target mouse position

### DIFF
--- a/src/FlightMap/FlightMap.qml
+++ b/src/FlightMap/FlightMap.qml
@@ -141,8 +141,13 @@ Map {
         acceptedDevices:    Qt.platform.pluginName === "cocoa" || Qt.platform.pluginName === "wayland" ?
                                 PointerDevice.Mouse | PointerDevice.TouchPad : PointerDevice.Mouse
         rotationScale:      1 / 120
-        property:           "zoomLevel"
 
+        onWheel: (event) => {
+            const zoomDelta = event.angleDelta.y * rotationScale
+            const mouseGeoPos = _map.toCoordinate(Qt.point(event.x, event.y), false)
+            _map.zoomLevel = Math.max(_map.zoomLevel + zoomDelta, 0)
+            _map.alignCoordinateToPoint(mouseGeoPos, Qt.point(event.x, event.y))
+        }
     }
 
     // We specifically do not use a DragHandler for panning. It just causes too many problems if you overlay anything else like a Flickable above it.


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail. What problem does this solve? -->
There's a regression in FlightMap behavior after the upgrade to Qt6 where zooming no longer zooms at the mouse pointer position. This leads to the user having to often do more panning of the map if they want to zoom in on a point. This change fixes that issue, and zooming will be relative to mouse pointer position again.

## Type of Change
<!-- Put an 'x' in the relevant boxes -->
- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] CI/Build changes
- [ ] Other

## Testing
<!-- Describe the tests you ran and how to reproduce them -->
- [x] Tested locally
- [ ] Added/updated unit tests
- [ ] Tested with simulator (SITL)
- [ ] Tested with hardware

### Platforms Tested
<!-- Check all that apply -->
- [x] Linux
- [ ] Windows
- [ ] macOS
- [ ] Android
- [ ] iOS

### Flight Stacks Tested
<!-- If applicable -->
- [ ] PX4
- [ ] ArduPilot

## Screenshots
<!-- If applicable, add screenshots to help explain your changes -->

## Checklist
<!-- Go over all the following points, and put an 'x' in all the boxes that apply -->
- [x] I have read the [Contribution Guidelines](CONTRIBUTING.md)
- [x] I have read the [Code of Conduct](CODE_OF_CONDUCT.md)
- [x] My code follows the project's coding standards
- [ ] I have added tests that prove my fix/feature works
- [ ] New and existing unit tests pass locally

## Related Issues
<!-- Link any related issues using #issue_number -->

---
By submitting this pull request, I confirm that my contribution is made under the terms of the project's dual license (Apache 2.0 and GPL v3).
