### PR TITLE
LogViewer: GPS map, Parameters tab, performance, and bug fixes

### DIFF
--- a/docs/en/SUMMARY.md
+++ b/docs/en/SUMMARY.md
@@ -58,6 +58,7 @@
   - [Console Logging](qgc-user-guide/settings_view/console_logging.md)
   - [Virtual Joystick (PX4)](qgc-user-guide/settings_view/virtual_joystick.md)
 - [Analyze](qgc-user-guide/analyze_view/index.md)
+  - [Log Viewer](qgc-user-guide/analyze_view/log_viewer.md)
   - [Log Download](qgc-user-guide/analyze_view/log_download.md)
   - [GeoTag Images (PX4)](qgc-user-guide/analyze_view/geotag_images.md)
   - [MAVLink Console (PX4)](qgc-user-guide/analyze_view/mavlink_console.md)

--- a/docs/en/qgc-user-guide/analyze_view/log_viewer.md
+++ b/docs/en/qgc-user-guide/analyze_view/log_viewer.md
@@ -1,20 +1,79 @@
 # Log Viewer (Analyze View)
 
-The _Log Viewer_ screen (**Analyze > Log Viewer**) provides a unified workflow for post-flight analysis:
+The _Log Viewer_ screen (**Analyze > Log Viewer**) is a unified post-flight analysis tool that supports three log formats:
 
-- Open ArduPilot DataFlash logs (`.bin`/`.log`) for parameter and event inspection.
-- Open telemetry logs (`.tlog`) and replay them with timeline controls.
-- Reuse existing MAVLink inspection and charting tools while replaying telemetry.
+| Format | Extension | Firmware |
+|--------|-----------|----------|
+| ArduPilot DataFlash | `.bin` / `.log` | ArduPilot (ArduCopter, ArduPlane, ArduRover, ArduSub) |
+| PX4 ULog | `.ulg` | PX4 |
+| MAVLink Telemetry | `.tlog` | Any |
+
+## Opening a Log
+
+Use the **Open .bin**, **Open .ulg**, or **Open .tlog** button at the top of the screen to select a log file.
+Click **Clear** to unload the current log.
+
+The filename of the loaded log is shown in the toolbar to the right of the buttons.
+
+## Firmware Log Analysis (.bin / .ulg)
+
+When a DataFlash or ULog file is loaded the screen shows four tabs: **Charting**, **Map**, **Parameters**, and **Messages**.
+
+### Charting Tab
+
+The left panel shows summary information (field count, parameter count, event count, detected vehicle type) and a searchable list of all plottable fields.
+
+- Toggle a field on or off using the slider next to its name.
+- Use the **Search fields** box to filter by name.
+- Click **Clear Selected** to remove all plotted fields at once.
+
+The right panel shows a time-series chart of all selected fields.
+Each field is plotted on its own auto-scaled Y axis.
+Moving the cursor over the chart shows a popup with the current, minimum, and maximum value for each field, as well as the current flight mode.
+Drag horizontally to zoom in; right-click to reset zoom.
+
+### Map Tab
+
+The Map tab displays the GPS flight path overlaid on a map, with the path auto-fitted to the screen on load.
+
+For ArduPilot logs the path is derived from the `GPS` message (requires a valid 3D fix).
+For PX4 ULog the path comes from `vehicle_global_position`.
+
+An altitude mini-chart is shown below the map when GPS altitude data is available.
+Click or drag on the altitude chart to move a position marker (yellow dot) along the flight path on the map.
+Drag horizontally on the altitude chart to zoom in on a time range; right-click to reset.
+The altitude popup shows the current, minimum, and maximum altitude for the full log.
+
+The map cursor is linked to the charting tab: moving the cursor in either the main chart or the altitude chart updates the marker position in both places.
+
+### Parameters Tab
+
+Lists all parameters recorded in the log.
+By default only parameters that differ from their system default are shown; toggle **Changed only** to see all parameters.
+Use the search box to filter by name, value, or description.
+Parameters that differ from their default are shown in bold with an orange indicator dot and the default value alongside.
+
+### Messages Tab
+
+Lists all status messages from the log (ArduPilot `MSG` messages or PX4 equivalent) in chronological order with timestamps.
+
+## Telemetry Log Analysis (.tlog)
+
+When a `.tlog` file is loaded the **Charting** tab shows a playback control bar in the left panel.
+
+| Control | Function |
+|---------|----------|
+| **Play / Pause** | Start or pause log replay |
+| Speed selector | Set replay speed (0.1× – 10×) |
+| Seek slider | Jump to any point in the log |
+| Time display | Shows current and total log duration |
+
+While replaying, all live vehicle data views (HUD, instruments, MAVLink Inspector) update as if the vehicle were connected.
+The right panel of the Charting tab shows a live MAVLink Inspector for the replaying vehicle.
 
 ## Typical Workflow
 
-1. Download logs from **Analyze > Onboard Logs**.
-1. Open the downloaded `.bin` or `.tlog` file in **Analyze > Log Viewer**.
-1. For `.tlog`, use playback controls (play/pause, speed, seek) to inspect behavior over time.
-1. For `.bin`, review extracted parameters and events, then select signals for plotting.
-
-## Performance Notes
-
-- Very large logs can take noticeable time to parse.
-- Prefer loading logs from local SSD storage for faster indexing.
-- If onboard storage is slow and logs contain gaps, reduce logging rate using related parameters in **Analyze > Log Setup**.
+1. Download logs from **Analyze > Log Download**.
+1. Open the downloaded `.bin`, `.ulg`, or `.tlog` in **Analyze > Log Viewer**.
+1. For firmware logs: select fields of interest in the left panel and inspect the chart, map, parameters, and messages.
+1. For telemetry logs: use the playback controls to step through the flight.

--- a/docs/en/qgc-user-guide/index.md
+++ b/docs/en/qgc-user-guide/index.md
@@ -27,3 +27,122 @@ The information provided should be correct, but you may find missing information
 ::: tip
 Information about _QGroundControl_ development, architecture, contributing, and translating can be found in the [Developer Guide](../qgc-dev-guide/index.md) section.
 :::
+
+## What's New Since Stable V5.0
+
+The daily build adds the following features compared to the Stable V5.0 release.
+
+### Log Viewer (Analyze View)
+
+The [Log Viewer](analyze_view/log_viewer.md) (**Analyze > Log Viewer**) is a new unified post-flight analysis tool that supports three log formats:
+
+- **ArduPilot DataFlash** (`.bin` / `.log`) — field charting, GPS flight path map, parameter inspection, and status messages.
+- **PX4 ULog** (`.ulg`) — same capabilities using PX4 log format.
+- **MAVLink Telemetry** (`.tlog`) — playback with speed control, seek slider, and live MAVLink Inspector.
+
+The Charting tab lets you select any logged field for time-series plotting with zoom and a value popup showing current, minimum, and maximum values.
+The Map tab shows the GPS flight path auto-fitted to the screen with an altitude mini-chart below it; clicking or dragging on the altitude chart moves a position marker on the map.
+The Parameters tab lists all recorded parameters with a "changed only" filter.
+
+### Onboard Logs — FTP Download Tab (Analyze View)
+
+A new **Onboard Logs (FTP)** tab in Analyze View downloads logs from the vehicle using the MAVLink FTP protocol.
+This provides a dedicated, explicit FTP path alongside the existing legacy log download method, making it easier to retrieve logs from vehicles that expose them via FTP.
+
+### ArduPilot Logging Configuration (Vehicle Config)
+
+A new **Logging** page in Vehicle Config lets you configure ArduPilot logging parameters directly from QGroundControl, including storage backends (`LOG_BACKEND_TYPE`), data group bitmasks (`LOG_BITMASK`), rate limits, and disarmed logging options.
+This replaces the need to manually edit these parameters in the parameter editor.
+
+### Searchable Settings and Vehicle Config
+
+Both the Application Settings pages and the Vehicle Config sidebar now have a **keyword search** field.
+Typing a word filters the visible sections across all pages, making it much faster to find a specific setting without knowing which page it lives on.
+
+### Settings Pages — JSON-Driven UI
+
+All Application Settings pages are now generated from JSON metadata rather than hand-coded QML.
+Settings are organized into collapsible sections with consistent layout.
+A search bar at the top of each settings page filters visible settings in real time.
+
+### Plan View Toolbar
+
+The Plan View toolbar has been completely reworked:
+
+- Explicit **Open**, **Save**, **Upload**, and **Clear** buttons replace the old File tool button.
+- Vehicle upload and storage status are shown directly in the toolbar.
+- **Save** and **Upload** buttons are highlighted when there are unsaved or un-uploaded changes.
+- A hamburger menu (☰) provides additional options such as Save as KML and Download from vehicle.
+- Plan creation from a template has moved to the right panel and is shown only when the plan is empty.
+
+### Plan View — Mission Status Panel
+
+A new collapsible **Mission Status** panel at the bottom of the Plan View shows terrain profile and mission statistics (distance, time, maximum altitude).
+Switchable sub-panels let you toggle between terrain data and mission stats.
+
+### Plan View — Click-to-Set Home Position
+
+The home position in Plan View is now set by an explicit first click on the map rather than tracking the map center.
+Mission editing tools (Takeoff, Waypoint, Pattern, Land, ROI) are disabled until the home position is placed, preventing accidentally placing items before the reference point is defined.
+
+### Plan View — Plan Templates with Vehicle Class Filtering
+
+The Plan Creator now filters available plan templates by vehicle class (multirotor, fixed wing, VTOL, rover, sub), showing only templates compatible with the connected or configured vehicle.
+
+### ArduPilot — Servo Outputs Page (Vehicle Config)
+
+A new **Servo Outputs** page in Vehicle Config provides real-time visualization and configuration of servo outputs for ArduPilot vehicles:
+
+- Live PWM output bars updated in real time.
+- Per-channel function assignment, direction reversal, and min/max/trim PWM editing.
+
+### ArduPilot — Scripting Component (Vehicle Config)
+
+A new **Scripting** page in Vehicle Config lets you manage Lua scripts on ArduPilot vehicles directly from QGroundControl:
+
+- Browse, upload, and delete scripts stored on the vehicle via MAVLink FTP.
+- No need for a separate file manager or SD card access.
+
+### ArduPilot — Safety Failsafe UI Modernization
+
+The ArduPilot Safety setup page has been modernized with vehicle-specific failsafe sections for Copter, Plane, and Rover.
+Controls use consistent slider and radio-button patterns, and a new `FactBitMaskCheckBoxSlider` control makes bitmask parameters much easier to configure.
+
+### Camera UI Rework
+
+The camera management code and UI have been significantly reworked.
+The camera UI now correctly respects camera capability flags and modes, and behavior is more consistent across different camera types and configurations.
+
+### Joystick — Manual Control Extensions
+
+Full support for MAVLink manual control extensions has been added to the Joystick configuration:
+
+- Improved settings read/write with validation.
+- Improved logging.
+
+Note: joystick settings from earlier versions are not migrated; joysticks will need to be re-calibrated and re-enabled after updating.
+
+### NTRIP RTK Correction Link
+
+QGroundControl now includes a built-in NTRIP client for streaming RTK correction data to the vehicle.
+Configure the NTRIP server, mount point, and credentials in Application Settings; QGroundControl connects and forwards corrections automatically.
+
+### MAVLink 2 Message Signing
+
+The [Telemetry settings](settings_view/telemetry.md) page now includes a **MAVLink 2 Signing** section.
+Signing cryptographically authenticates all messages between QGroundControl and the vehicle, preventing unauthorized command injection.
+Keys are created by entering a friendly name and passphrase; only the SHA-256 hash is stored.
+
+### GPS / RTK GPS Toolbar Indicator Improvements
+
+The GPS/RTK GPS toolbar indicator now shows RTK correction link status even when no vehicle is connected, making it easier to verify RTK base station reception before flight.
+A separate **GPS Resilience** indicator appears when the vehicle reports GPS spoofing or jamming state, with per-GPS details in the dropdown.
+
+### MAVLink v1 Removed
+
+Support for the legacy MAVLink v1 message protocol has been removed.
+QGroundControl now requires MAVLink v2.
+
+### Qt Framework Update
+
+The Qt framework has been updated from 6.8.3 to 6.10.1, and the charting library has been migrated from the deprecated Qt Charts to the new Qt Graphs module.

--- a/src/AnalyzeView/LogViewer/APMDataFlash/LogViewerDataFlashParser.cc
+++ b/src/AnalyzeView/LogViewer/APMDataFlash/LogViewerDataFlashParser.cc
@@ -6,6 +6,7 @@
 #include <QtCore/QCoreApplication>
 #include <QtCore/QFile>
 #include <QtCore/QHash>
+#include <QtCore/QRegularExpression>
 #include <QtCore/QSet>
 #include <QtCore/QVariantMap>
 
@@ -22,6 +23,17 @@ QString _vehicleTypeFromMessageText(const QString &messageText)
     if (text.contains(QStringLiteral("ardurover")))  { return QStringLiteral("ArduRover"); }
     if (text.contains(QStringLiteral("ardusub")))    { return QStringLiteral("ArduSub"); }
     return QString();
+}
+
+// Parse "major.minor" from firmware version strings like "ArduCopter V4.3.1" or "V4.5-stable"
+void _parseFirmwareVersionFromMessageText(const QString &messageText, int &major, int &minor)
+{
+    static const QRegularExpression re(QStringLiteral("V(\\d+)\\.(\\d+)"));
+    const QRegularExpressionMatch m = re.match(messageText);
+    if (m.hasMatch()) {
+        major = m.captured(1).toInt();
+        minor = m.captured(2).toInt();
+    }
 }
 
 QString _ardupilotModeName(const QString &vehicleType, int modeNumber)
@@ -207,6 +219,7 @@ namespace DataFlashParser {
 LogParseResult parseFile(const QString &filePath)
 {
     LogParseResult result;
+    result.sourceType = LogParseResult::SourceType::APMDataFlash;
 
     QFile file(filePath);
     if (!file.open(QIODevice::ReadOnly)) {
@@ -295,8 +308,14 @@ LogParseResult parseFile(const QString &filePath)
                 : values.value(QStringLiteral("Val"));
             if (!paramName.isEmpty()) {
                 QVariantMap row;
-                row[QStringLiteral("name")] = paramName;
-                row[QStringLiteral("value")] = paramValue;
+                row[QStringLiteral("name")]         = paramName;
+                row[QStringLiteral("value")]        = paramValue;
+                // DataFlash logs don't carry default value metadata
+                row[QStringLiteral("isFloat")]      = paramValue.metaType() == QMetaType::fromType<float>()
+                                                      || paramValue.metaType() == QMetaType::fromType<double>();
+                row[QStringLiteral("hasDefault")]   = false;
+                row[QStringLiteral("defaultValue")] = QVariant();
+                row[QStringLiteral("isDefault")]    = false;
                 result.parameters.append(row);
             }
         } else if (fmt.name == kMSG) {
@@ -304,6 +323,7 @@ LogParseResult parseFile(const QString &filePath)
             const QString detected = _vehicleTypeFromMessageText(text);
             if (result.detectedVehicleType.isEmpty() && !detected.isEmpty()) {
                 result.detectedVehicleType = detected;
+                _parseFirmwareVersionFromMessageText(text, result.firmwareMajorVersion, result.firmwareMinorVersion);
             }
             if (!text.isEmpty()) {
                 QVariantMap row;

--- a/src/AnalyzeView/LogViewer/CMakeLists.txt
+++ b/src/AnalyzeView/LogViewer/CMakeLists.txt
@@ -14,6 +14,8 @@ target_sources(${CMAKE_PROJECT_NAME}
         LogParseResultPrivate.h
         LogViewerController.cc
         LogViewerController.h
+        LogViewerParamMetaData.cc
+        LogViewerParamMetaData.h
         PX4ULog/ULogFullHandler.cc
         PX4ULog/ULogFullHandler.h
         PX4ULog/LogViewerULogParser.cc
@@ -37,6 +39,7 @@ qt_add_qml_module(LogViewerModule
     VERSION 1.0
     RESOURCE_PREFIX /qml
     QML_FILES
+        LogViewerAltChart.qml
         LogViewerChart.qml
     NO_PLUGIN
 )

--- a/src/AnalyzeView/LogViewer/LogFileParser.cc
+++ b/src/AnalyzeView/LogViewer/LogFileParser.cc
@@ -2,6 +2,7 @@
 
 #include "LogViewerDataFlashParser.h"
 #include "LogParseResultPrivate.h"
+#include "LogViewerParamMetaData.h"
 #include "QGCLoggingCategory.h"
 #include "LogViewerULogParser.h"
 
@@ -108,6 +109,20 @@ void LogFileParser::_applyResult(const LogParseResult &result)
     _availableFields = result.availableFields;
     _plottableFields = result.plottableFields;
     _parameters = result.parameters;
+
+    // Enrich parameter rows with FactMetaData (decimal places, units,
+    // short description, enum strings/values) from the bundled metadata JSON.
+    if (!_parameters.isEmpty()) {
+        if (result.sourceType == LogParseResult::SourceType::PX4ULog) {
+            LogViewerParamMetaData::enrichForPX4(_parameters);
+        } else if (result.sourceType == LogParseResult::SourceType::APMDataFlash) {
+            LogViewerParamMetaData::enrichForAPM(
+                _parameters,
+                result.detectedVehicleType,
+                result.firmwareMajorVersion,
+                result.firmwareMinorVersion);
+        }
+    }
     _events = result.events;
     _messages = result.messages;
     _modeSegments = result.modeSegments;
@@ -151,6 +166,9 @@ void LogFileParser::clear()
     if (!_plottableFields.isEmpty()) { _plottableFields.clear(); emit plottableFieldsChanged(); }
 
     _fieldSamples.clear();
+    _gpsLatField.clear();
+    _gpsLonField.clear();
+    _gpsAltField.clear();
     if (_minTimestamp != -1.0 || _maxTimestamp != -1.0) {
         _minTimestamp = -1.0;
         _maxTimestamp = -1.0;
@@ -167,6 +185,94 @@ QVariantList LogFileParser::fieldSamples(const QString &fieldName) const
     const QVector<QPointF> &points = it.value();
     output.reserve(points.size());
     for (const QPointF &p : points) { output.append(p); }
+    return output;
+}
+
+QVariantMap LogFileParser::fieldMinMax(const QString &fieldName) const
+{
+    const auto it = _fieldSamples.constFind(fieldName);
+    if (it == _fieldSamples.cend() || it->isEmpty()) { return {}; }
+    const QVector<QPointF> &points = it.value();
+    double minY = std::numeric_limits<double>::max();
+    double maxY = std::numeric_limits<double>::lowest();
+    for (const QPointF &p : points) {
+        if (p.y() < minY) minY = p.y();
+        if (p.y() > maxY) maxY = p.y();
+    }
+    return QVariantMap{{QStringLiteral("min"), minY}, {QStringLiteral("max"), maxY}};
+}
+
+QVariantList LogFileParser::fieldSamplesFiltered(const QString &fieldName, double minX, double maxX, int pixelWidth) const
+{
+    QVariantList output;
+    const auto it = _fieldSamples.constFind(fieldName);
+    if (it == _fieldSamples.cend() || pixelWidth <= 0 || maxX <= minX) { return output; }
+
+    const QVector<QPointF> &points = it.value();
+
+    // Find the slice within [minX, maxX]
+    const auto sliceBegin = std::lower_bound(points.cbegin(), points.cend(), minX,
+        [](const QPointF &p, double t) { return p.x() < t; });
+    const auto sliceEnd = std::upper_bound(sliceBegin, points.cend(), maxX,
+        [](double t, const QPointF &p) { return t < p.x(); });
+
+    const qsizetype sliceCount = std::distance(sliceBegin, sliceEnd);
+    if (sliceCount == 0) { return output; }
+
+    // If already sparse enough, return slice as-is
+    if (sliceCount <= 4 * pixelWidth) {
+        output.reserve(sliceCount);
+        for (auto jt = sliceBegin; jt != sliceEnd; ++jt) { output.append(*jt); }
+        return output;
+    }
+
+    // Screen-space min/max bucketing: one bucket per pixel column.
+    // For each column track first, min-y, max-y, last indices; flush in time order.
+    output.reserve(4 * pixelWidth);
+    const double range = maxX - minX;
+
+    auto columnOf = [&](double x) -> int {
+        return static_cast<int>((x - minX) / range * pixelWidth);
+    };
+
+    // Per-column state
+    int    curCol   = -1;
+    qsizetype firstIdx = -1;
+    qsizetype minIdx   = -1;
+    qsizetype maxIdx   = -1;
+    qsizetype lastIdx  = -1;
+
+    auto flush = [&]() {
+        if (firstIdx < 0) return;
+        // Collect the up-to-4 representative indices in time order, deduplicated
+        qsizetype indices[4] = { firstIdx, minIdx, maxIdx, lastIdx };
+        std::sort(indices, indices + 4);
+        qsizetype prev = -1;
+        for (qsizetype idx : indices) {
+            if (idx != prev) {
+                output.append(*(sliceBegin + idx));
+                prev = idx;
+            }
+        }
+    };
+
+    for (qsizetype i = 0; i < sliceCount; ++i) {
+        const QPointF &p = *(sliceBegin + i);
+        const int col = std::clamp(columnOf(p.x()), 0, pixelWidth - 1);
+        if (col != curCol) {
+            flush();
+            curCol   = col;
+            firstIdx = i;
+            minIdx   = i;
+            maxIdx   = i;
+        } else {
+            if (p.y() < (sliceBegin + minIdx)->y()) minIdx = i;
+            if (p.y() > (sliceBegin + maxIdx)->y()) maxIdx = i;
+        }
+        lastIdx = i;
+    }
+    flush();
+
     return output;
 }
 
@@ -224,4 +330,161 @@ void LogFileParser::_setParseError(const QString &error)
         _parseError = error;
         emit parseErrorChanged();
     }
+}
+
+QString LogFileParser::gpsAltitudeFieldName() const
+{
+    return _gpsAltField;
+}
+
+QVariantMap LogFileParser::gpsCoordAt(double timestampSeconds) const
+{
+    if (_gpsLatField.isEmpty() || _gpsLonField.isEmpty()) {
+        return {};
+    }
+
+    const auto latIt = _fieldSamples.constFind(_gpsLatField);
+    const auto lonIt = _fieldSamples.constFind(_gpsLonField);
+    if (latIt == _fieldSamples.cend() || lonIt == _fieldSamples.cend()) {
+        return {};
+    }
+
+    const QVector<QPointF> &latPts = latIt.value();
+    const QVector<QPointF> &lonPts = lonIt.value();
+    if (latPts.isEmpty() || lonPts.isEmpty()) {
+        return {};
+    }
+
+    // Binary search for the sample with timestamp closest to timestampSeconds.
+    int lo = 0;
+    int hi = latPts.size() - 1;
+    while (lo < hi) {
+        const int mid = (lo + hi) / 2;
+        if (latPts[mid].x() < timestampSeconds) {
+            lo = mid + 1;
+        } else {
+            hi = mid;
+        }
+    }
+    // lo is the first index >= timestampSeconds; compare with lo-1.
+    if (lo > 0) {
+        const double dPrev = timestampSeconds - latPts[lo - 1].x();
+        const double dCurr = latPts[lo].x() - timestampSeconds;
+        if (dPrev < dCurr) {
+            --lo;
+        }
+    }
+
+    const int lonIdx = std::min(lo, static_cast<int>(lonPts.size()) - 1);
+    QVariantMap coord;
+    coord[QStringLiteral("latitude")]  = latPts[lo].y();
+    coord[QStringLiteral("longitude")] = lonPts[lonIdx].y();
+    return coord;
+}
+
+QVariantList LogFileParser::gpsPath() const
+{
+    // Candidate field-name pairs tried in priority order.
+    // All values are stored in degrees (the parsers handle any raw-unit conversion).
+    // statusField: if non-null, that field's value must be >= statusMinValue to accept the sample.
+    // This is used for APM GPS messages where Status < 3 means no valid 3D fix.
+    struct CandidatePair {
+        const char *latField;
+        const char *lonField;
+        const char *altField;
+        const char *statusField;
+        double      statusMinValue;
+    };
+
+    static const CandidatePair candidates[] = {
+        // PX4 ULog — vehicle_global_position (EKF-fused position, double degrees)
+        { "vehicle_global_position.lat",           "vehicle_global_position.lon",           "vehicle_global_position.alt",            nullptr,       0 },
+        { "vehicle_global_position.latitude_deg",  "vehicle_global_position.longitude_deg", "vehicle_global_position.alt",            nullptr,       0 },
+        // PX4 ULog — vehicle_gps_position / sensor_gps (newer firmware uses latitude_deg)
+        { "vehicle_gps_position.latitude_deg",     "vehicle_gps_position.longitude_deg",    "vehicle_gps_position.altitude_msl_m",    nullptr,       0 },
+        { "vehicle_gps_position[0].latitude_deg",  "vehicle_gps_position[0].longitude_deg", "vehicle_gps_position[0].altitude_msl_m", nullptr,       0 },
+        { "sensor_gps.latitude_deg",               "sensor_gps.longitude_deg",              "sensor_gps.altitude_msl_m",              nullptr,       0 },
+        { "sensor_gps[0].latitude_deg",            "sensor_gps[0].longitude_deg",           "sensor_gps[0].altitude_msl_m",           nullptr,       0 },
+        // APM DataFlash — GPS message (Status >= 3 = 3D fix; 'L' type already divided by 1e7)
+        { "GPS.Lat",                               "GPS.Lng",                               "GPS.Alt",                                "GPS.Status",  3 },
+        { "GPS2.Lat",                              "GPS2.Lng",                              "GPS2.Alt",                               "GPS2.Status", 3 },
+        // APM DataFlash — POS message (EKF-fused; no status field, 'L' type already divided by 1e7)
+        { "POS.Lat",                               "POS.Lng",                               "POS.Alt",                                nullptr,       0 },
+    };
+
+    for (const auto &c : candidates) {
+        const auto latIt = _fieldSamples.constFind(QLatin1String(c.latField));
+        const auto lonIt = _fieldSamples.constFind(QLatin1String(c.lonField));
+        if (latIt == _fieldSamples.cend() || lonIt == _fieldSamples.cend()) {
+            continue;
+        }
+
+        const QVector<QPointF> &latPts = latIt.value();
+        const QVector<QPointF> &lonPts = lonIt.value();
+        if (latPts.isEmpty() || lonPts.isEmpty()) {
+            continue;
+        }
+
+        // Resolve optional status field (same message, same sample count as lat/lon).
+        const QVector<QPointF> *statusPts = nullptr;
+        if (c.statusField) {
+            const auto statusIt = _fieldSamples.constFind(QLatin1String(c.statusField));
+            if (statusIt != _fieldSamples.cend() && !statusIt.value().isEmpty()) {
+                statusPts = &statusIt.value();
+            }
+        }
+
+        qCDebug(LogFileParserLog) << "gpsPath: found candidate" << c.latField
+            << "samples:" << latPts.size()
+            << "first lat:" << latPts.first().y()
+            << "first lon:" << lonPts.first().y();
+
+        QVariantList path;
+        const int n = std::min(latPts.size(), lonPts.size());
+        path.reserve(n);
+
+        for (int i = 0; i < n; i++) {
+            // Skip samples that don't have a valid GPS fix.
+            if (statusPts && i < statusPts->size() && (*statusPts)[i].y() < c.statusMinValue) {
+                continue;
+            }
+
+            const double lat = latPts[i].y();
+            const double lon = lonPts[i].y();
+
+            if (lat < -90.0 || lat > 90.0 || lon < -180.0 || lon > 180.0
+                    || (qFuzzyIsNull(lat) && qFuzzyIsNull(lon))) {
+                continue;
+            }
+            QVariantMap coord;
+            coord[QStringLiteral("latitude")]  = lat;
+            coord[QStringLiteral("longitude")] = lon;
+            path.append(coord);
+        }
+
+        qCDebug(LogFileParserLog) << "gpsPath: valid points after filter:" << path.size();
+
+        if (!path.isEmpty()) {
+            _gpsLatField = QLatin1String(c.latField);
+            _gpsLonField = QLatin1String(c.lonField);
+            // Only cache the alt field if it actually exists and has samples;
+            // otherwise the altitude chart would be shown with no data.
+            const QLatin1String altField(c.altField);
+            const auto altIt = _fieldSamples.constFind(altField);
+            _gpsAltField = (altIt != _fieldSamples.cend() && !altIt.value().isEmpty()) ? altField : QLatin1String{};
+            return path;
+        }
+
+        qCDebug(LogFileParserLog) << "gpsPath: all" << n << "points filtered out for candidate" << c.latField;
+    }
+
+    qCDebug(LogFileParserLog) << "gpsPath: no GPS data found; available fields containing 'lat' or 'lon':";
+    for (auto it = _fieldSamples.cbegin(); it != _fieldSamples.cend(); ++it) {
+        const QString &fn = it.key();
+        if (fn.contains(QLatin1String("lat"), Qt::CaseInsensitive) || fn.contains(QLatin1String("lon"), Qt::CaseInsensitive)) {
+            qCDebug(LogFileParserLog) << " " << fn << "samples:" << it.value().size()
+                << (it.value().isEmpty() ? 0.0 : it.value().first().y());
+        }
+    }
+    return {};
 }

--- a/src/AnalyzeView/LogViewer/LogFileParser.h
+++ b/src/AnalyzeView/LogViewer/LogFileParser.h
@@ -65,9 +65,26 @@ public:
     Q_INVOKABLE void parseFileAsync(const QString &filePath);
     Q_INVOKABLE void clear();
     Q_INVOKABLE QVariantList fieldSamples(const QString &fieldName) const;
+    Q_INVOKABLE QVariantList fieldSamplesFiltered(const QString &fieldName, double minX, double maxX, int pixelWidth) const;
+    Q_INVOKABLE QVariantMap  fieldMinMax(const QString &fieldName) const;
     Q_INVOKABLE double fieldValueAt(const QString &fieldName, double timestampSeconds) const;
     Q_INVOKABLE QString modeAt(double timestampSeconds) const;
     Q_INVOKABLE QVariantList eventsNear(double timestampSeconds, double thresholdSeconds) const;
+
+    /// Returns a list of GPS path points as QVariantMap entries with `latitude` and `longitude` keys
+    /// (compatible with QML MapPolyline.path via implicit coordinate coercion).
+    /// Tries known field name patterns for both PX4 ULog and APM DataFlash.
+    /// Returns an empty list if no GPS data is found.
+    Q_INVOKABLE QVariantList gpsPath() const;
+
+    /// Returns the field name used for altitude data paired with the GPS path source,
+    /// e.g. "vehicle_global_position.alt". Returns empty string if no GPS data was found.
+    /// Must be called after gpsPath() has been evaluated.
+    Q_INVOKABLE QString gpsAltitudeFieldName() const;
+
+    /// Returns {latitude, longitude} for the GPS position nearest to timestampSeconds.
+    /// Returns an empty map if GPS data is not available.
+    Q_INVOKABLE QVariantMap gpsCoordAt(double timestampSeconds) const;
 
 signals:
     void parsedChanged();
@@ -103,4 +120,9 @@ private:
     double _maxTimestamp = -1.0;
     int _sampleCount = 0;
     quint64 _parseRequestId = 0;
+
+    // Cached GPS field names, set by gpsPath() when a valid candidate is found.
+    mutable QString _gpsLatField;
+    mutable QString _gpsLonField;
+    mutable QString _gpsAltField;
 };

--- a/src/AnalyzeView/LogViewer/LogParseResultPrivate.h
+++ b/src/AnalyzeView/LogViewer/LogParseResultPrivate.h
@@ -11,6 +11,8 @@
 #include <QtCore/QVector>
 
 struct LogParseResult {
+    enum class SourceType { Unknown, PX4ULog, APMDataFlash };
+
     bool ok = false;
     QString errorMessage;
     QStringList availableFields;
@@ -25,4 +27,7 @@ struct LogParseResult {
     double maxTimestamp = -1.0;
     int sampleCount = 0;
     QString detectedVehicleType;
+    SourceType sourceType = SourceType::Unknown;
+    int firmwareMajorVersion = -1;
+    int firmwareMinorVersion = -1;
 };

--- a/src/AnalyzeView/LogViewer/LogViewerAltChart.qml
+++ b/src/AnalyzeView/LogViewer/LogViewerAltChart.qml
@@ -1,0 +1,387 @@
+import QtQuick
+import QtQuick.Layouts
+import QtGraphs
+
+import QGroundControl
+import QGroundControl.Controls
+
+/// Altitude mini-chart for the Log Viewer Map tab.
+/// Displays vehicle_global_position.alt (or equivalent) as a line chart
+/// with zoom, position marker, and value popup. The marker timestamp is
+/// exposed via the markerChanged / markerCleared signals so the parent
+/// can place a dot on the map.
+Item {
+    id: root
+
+    required property var    logParser
+    required property string altFieldName   ///< e.g. "vehicle_global_position.alt"
+
+    signal markerChanged(double timestampSeconds)
+    signal markerCleared()
+    signal zoomApplied(real minX, real maxX)
+
+    // -------------------------------------------------------------------------
+    // Internal state
+    // -------------------------------------------------------------------------
+    property real _fullMinX: 0
+    property real _fullMaxX: 1
+    property real _zoomMinX: 0
+    property real _zoomMaxX: 1
+
+    property bool _markerVisible: false
+    property real _markerPixelX: 0
+    property real _markerXValue: 0
+    property real _markerAltValue: 0
+    property real _altMin: 0
+    property real _altMax: 0
+    property bool _hasAltRange: false
+
+    QGCPalette { id: qgcPal }
+
+    // -------------------------------------------------------------------------
+    // Coordinate conversions
+    // -------------------------------------------------------------------------
+    function _pixelToAxisX(pixelX) {
+        const plotX = _altChart.plotArea.x
+        const plotW = _altChart.plotArea.width
+        if (plotW <= 0 || _xAxis.max <= _xAxis.min) return _xAxis.min
+        const ratio = (Math.max(plotX, Math.min(plotX + plotW, pixelX)) - plotX) / plotW
+        return _xAxis.min + ratio * (_xAxis.max - _xAxis.min)
+    }
+
+    function _axisXToPixel(axisX) {
+        const plotX = _altChart.plotArea.x
+        const plotW = _altChart.plotArea.width
+        if (plotW <= 0 || _xAxis.max <= _xAxis.min) return plotX
+        const ratio = (axisX - _xAxis.min) / (_xAxis.max - _xAxis.min)
+        return plotX + Math.max(0, Math.min(plotW, ratio * plotW))
+    }
+
+    // -------------------------------------------------------------------------
+    // Zoom
+    // -------------------------------------------------------------------------
+    function _applyZoomInternal(minX, maxX) {
+        if (maxX <= minX) return
+        _zoomMinX = minX
+        _zoomMaxX = maxX
+        _xAxis.min = minX
+        _xAxis.max = maxX
+        if (_markerVisible && (_markerXValue < minX || _markerXValue > maxX)) {
+            _markerXValue = (minX + maxX) / 2
+        }
+        _markerPixelX = _axisXToPixel(_markerXValue)
+        Qt.callLater(_refreshSeries)
+    }
+
+    // User-driven zoom — emits zoomApplied for cross-chart sync
+    function _applyZoom(minX, maxX) {
+        _applyZoomInternal(minX, maxX)
+        zoomApplied(minX, maxX)
+    }
+
+    // External zoom sync — no re-emit
+    function setSharedZoom(minX, maxX) {
+        _applyZoomInternal(minX, maxX)
+    }
+
+    // External cursor sync — no re-emit
+    function setSharedCursor(t) {
+        _markerVisible = true
+        _markerXValue  = t
+        _markerPixelX  = _axisXToPixel(t)
+        _markerAltValue = logParser.fieldValueAt(root.altFieldName, t)
+    }
+
+    function _resetZoom() {
+        _applyZoom(_fullMinX, _fullMaxX)
+    }
+
+    // -------------------------------------------------------------------------
+    // Series data
+    // -------------------------------------------------------------------------
+    function _refreshSeries() {
+        const fieldName = root.altFieldName
+        if (!logParser.parsed || fieldName.length === 0) {
+            _altSeries.clear()
+            return
+        }
+
+        const pixelWidth = Math.max(1, Math.floor(_altChart.plotArea.width))
+        const points = logParser.fieldSamplesFiltered(fieldName, _zoomMinX, _zoomMaxX, pixelWidth)
+
+        _altSeries.clear()
+        if (!points || points.length === 0) return
+
+        let minY = Number.MAX_VALUE
+        let maxY = -Number.MAX_VALUE
+        for (let i = 0; i < points.length; i++) {
+            _altSeries.append(points[i].x, points[i].y)
+            if (points[i].y < minY) minY = points[i].y
+            if (points[i].y > maxY) maxY = points[i].y
+        }
+
+        // Track full-dataset min/max (not just visible window)
+        const fr = logParser.fieldMinMax(fieldName)
+        if (fr && fr.min !== undefined && fr.min <= fr.max) {
+            _altMin = fr.min
+            _altMax = fr.max
+            _hasAltRange = true
+        } else {
+            _hasAltRange = false
+        }
+
+        const pad = Math.max(1, (maxY - minY) * 0.05)
+        _yAxis.min = minY - pad
+        _yAxis.max = maxY + pad
+
+        if (_markerVisible) {
+            _markerAltValue = logParser.fieldValueAt(root.altFieldName, _markerXValue)
+        }
+    }
+
+    // -------------------------------------------------------------------------
+    // Marker / cursor
+    // -------------------------------------------------------------------------
+    function _updateCursor(pixelX) {
+        if (_xAxis.max <= _xAxis.min) return
+        _markerVisible = true
+        _markerPixelX = Math.max(_altChart.plotArea.x,
+                                 Math.min(_altChart.plotArea.x + _altChart.plotArea.width, pixelX))
+        _markerXValue = _pixelToAxisX(_markerPixelX)
+        _markerAltValue = logParser.fieldValueAt(root.altFieldName, _markerXValue)
+        root.markerChanged(_markerXValue)
+    }
+
+    // -------------------------------------------------------------------------
+    // Connections
+    // -------------------------------------------------------------------------
+    Connections {
+        target: logParser
+
+        function onParsedChanged() {
+            if (!logParser.parsed) {
+                _altSeries.clear()
+                _markerVisible  = false
+                _hasAltRange    = false
+                root.markerCleared()
+                return
+            }
+            if (logParser.minTimestamp >= 0 && logParser.maxTimestamp > logParser.minTimestamp) {
+                root._fullMinX = logParser.minTimestamp
+                root._fullMaxX = logParser.maxTimestamp
+            } else {
+                root._fullMinX = 0
+                root._fullMaxX = 1
+            }
+            root._applyZoom(root._fullMinX, root._fullMaxX)
+            Qt.callLater(root._initCursor)
+        }
+    }
+
+    // Called on first parse and when the component becomes visible after parse
+    function _initCursor() {
+        if (!logParser.parsed || _xAxis.max <= _xAxis.min) return
+        _markerXValue   = (_xAxis.min + _xAxis.max) / 2
+        _markerPixelX   = _axisXToPixel(_markerXValue)
+        _markerAltValue = logParser.fieldValueAt(root.altFieldName, _markerXValue)
+        _markerVisible  = true
+        root.markerChanged(_markerXValue)
+    }
+
+    onVisibleChanged: {
+        if (visible && logParser.parsed && !_markerVisible) {
+            Qt.callLater(_initCursor)
+        }
+    }
+
+    // -------------------------------------------------------------------------
+    // Chart
+    // -------------------------------------------------------------------------
+    Item {
+        id: _chartContainer
+        anchors.fill: parent
+
+        GraphsView {
+            id: _altChart
+            anchors.fill: parent
+            marginTop: 0
+            marginRight: 0
+            marginBottom: 0
+            marginLeft: 0
+
+            theme: GraphsTheme {
+                colorScheme:            qgcPal.globalTheme === QGCPalette.Light ? GraphsTheme.ColorScheme.Light : GraphsTheme.ColorScheme.Dark
+                backgroundColor:        qgcPal.windowShadeDark
+                backgroundVisible:      true
+                plotAreaBackgroundColor: qgcPal.windowShadeDark
+                grid.mainColor:         Qt.rgba(qgcPal.text.r, qgcPal.text.g, qgcPal.text.b, 0.25)
+                grid.subColor:          Qt.rgba(qgcPal.text.r, qgcPal.text.g, qgcPal.text.b, 0.12)
+                grid.mainWidth:         1
+                labelBackgroundVisible: false
+                labelTextColor:         qgcPal.text
+                axisXLabelFont.family:       ScreenTools.fixedFontFamily
+                axisXLabelFont.pointSize:    ScreenTools.smallFontPointSize
+                axisYLabelFont.family:       ScreenTools.fixedFontFamily
+                axisYLabelFont.pointSize:    ScreenTools.smallFontPointSize
+            }
+
+            axisX: ValueAxis {
+                id: _xAxis
+                titleText: qsTr("Time (s)")
+                min: 0
+                max: 1
+            }
+
+            axisY: ValueAxis {
+                id: _yAxis
+                titleText: qsTr("Alt (m)")
+                min: 0
+                max: 1
+            }
+
+            LineSeries {
+                id: _altSeries
+                color: QGroundControl.globalPalette.colorGreen
+                width: 2
+            }
+        }
+
+        // Zoom selection rect
+        Rectangle {
+            id: _zoomRect
+            visible: false
+            color: Qt.rgba(1, 1, 1, 0.2)
+            border.color: qgcPal.buttonHighlight
+            border.width: 1
+            z: 10
+        }
+
+        // Mouse area — drag to zoom, right-click to reset, click/move to set cursor
+        MouseArea {
+            anchors.fill: parent
+            acceptedButtons: Qt.LeftButton | Qt.RightButton
+            z: 11
+
+            property real _dragStartX: 0
+
+            onPressed: (mouse) => {
+                if (mouse.button === Qt.RightButton) {
+                    root._resetZoom()
+                    return
+                }
+                _dragStartX = mouse.x
+                _zoomRect.x = mouse.x
+                _zoomRect.y = _altChart.plotArea.y
+                _zoomRect.width = 0
+                _zoomRect.height = _altChart.plotArea.height
+                _zoomRect.visible = true
+            }
+
+            onPositionChanged: (mouse) => {
+                if (pressed && _zoomRect.visible) {
+                    const left  = Math.min(_dragStartX, mouse.x)
+                    const right = Math.max(_dragStartX, mouse.x)
+                    _zoomRect.x = left
+                    _zoomRect.width = Math.max(0, right - left)
+                }
+            }
+
+            onReleased: (mouse) => {
+                if (!_zoomRect.visible) return
+                const dragW = _zoomRect.width
+                _zoomRect.visible = false
+                if (dragW < ScreenTools.defaultFontPixelWidth * 0.5) {
+                    root._updateCursor(mouse.x)
+                    return
+                }
+                const leftX  = root._pixelToAxisX(_zoomRect.x)
+                const rightX = root._pixelToAxisX(_zoomRect.x + _zoomRect.width)
+                root._applyZoom(Math.min(leftX, rightX), Math.max(leftX, rightX))
+            }
+        }
+
+        // Position marker line
+        Rectangle {
+            visible: _markerVisible
+            x:       _markerPixelX
+            y:       _altChart.plotArea.y
+            width:   1
+            height:  _altChart.plotArea.height
+            color:   qgcPal.text
+            z:       12
+
+            // Recalculate pixel position when the plot area is laid out or resized
+            Connections {
+                target: _altChart
+                function onPlotAreaChanged() {
+                    if (root._markerVisible) {
+                        root._markerPixelX = root._axisXToPixel(root._markerXValue)
+                    }
+                }
+            }
+        }
+
+        // Value popup
+        Rectangle {
+            id: _popup
+            visible:  _markerVisible
+            x:        _popupX()
+            y:        _altChart.plotArea.y + ScreenTools.defaultFontPixelHeight * 0.4
+            implicitWidth:  _popupCol.implicitWidth + (margin * 2)
+            implicitHeight: _popupCol.implicitHeight + (margin * 2)
+            color:    qgcPal.windowShade
+            border.color: qgcPal.windowShadeDark
+            radius:   ScreenTools.defaultFontPixelWidth * 0.3
+            z:        13
+
+            property real margin: ScreenTools.defaultFontPixelWidth / 2
+
+            function _popupX() {
+                const mid = _altChart.plotArea.x + _altChart.plotArea.width / 2
+                if (_markerPixelX < mid) {
+                    return Math.max(0, _altChart.plotArea.x + _altChart.plotArea.width - width)
+                } else {
+                    return Math.max(0, _altChart.plotArea.x)
+                }
+            }
+
+            ColumnLayout {
+                id: _popupCol
+                anchors.fill: parent
+                anchors.margins: _popup.margin
+                spacing: ScreenTools.defaultFontPixelHeight * 0.2
+
+                // Line 1: field name (bold)
+                QGCLabel {
+                    text: altFieldName
+                    font.bold: true
+                    elide: Text.ElideMiddle
+                    width: parent.width
+                }
+
+                // Line 2: time
+                QGCLabel {
+                    text: qsTr("t = %1 s").arg(_markerXValue.toFixed(3))
+                }
+
+                // Line 3: Current / Min / Max
+                RowLayout {
+                    spacing: ScreenTools.defaultFontPixelWidth * 0.3
+
+                    QGCLabel { text: qsTr("Current") }
+                    QGCLabel { text: isNaN(_markerAltValue) ? "\u2014" : _markerAltValue.toFixed(1) + " m"; font.bold: true }
+
+                    Item { visible: _hasAltRange; width: ScreenTools.defaultFontPixelWidth * 0.5 }
+
+                    QGCLabel { visible: _hasAltRange; text: qsTr("Min") }
+                    QGCLabel { visible: _hasAltRange; text: _altMin.toFixed(1) + " m"; font.bold: true }
+
+                    Item { visible: _hasAltRange; width: ScreenTools.defaultFontPixelWidth * 0.5 }
+
+                    QGCLabel { visible: _hasAltRange; text: qsTr("Max") }
+                    QGCLabel { visible: _hasAltRange; text: _altMax.toFixed(1) + " m"; font.bold: true }
+                }
+            }
+        }
+    }
+}

--- a/src/AnalyzeView/LogViewer/LogViewerChart.qml
+++ b/src/AnalyzeView/LogViewer/LogViewerChart.qml
@@ -33,9 +33,13 @@ ColumnLayout {
 
     property var    _seriesByField: ({})
     property var    _fieldYRange: ({})
+    property var    _fieldFullRange: ({})   // full-dataset min/max, set when series is first created
     property var    _eventSeriesByType: ({})
 
-    property int    _maxChartPointsPerField: 6000
+    // Shared position / zoom signals
+    signal cursorMoved(real timestampSeconds)
+    signal zoomApplied(real minX, real maxX)
+
 
     readonly property real _legendRowHeight: ScreenTools.defaultFontPixelHeight * 1.1
     readonly property real _legendColorBlockSize: ScreenTools.defaultFontPixelHeight * 0.8
@@ -105,13 +109,37 @@ ColumnLayout {
     // -------------------------------------------------------------------------
     // Zoom
     // -------------------------------------------------------------------------
-    function applyZoomRange(minX, maxX) {
+    function _applyZoomInternal(minX, maxX) {
         if (maxX <= minX) return
         _zoomMinX = minX
         _zoomMaxX = maxX
         _binXAxis.min = _zoomMinX
         _binXAxis.max = _zoomMaxX
+        if (_positionMarkerVisible && (_markerXValue < _zoomMinX || _markerXValue > _zoomMaxX)) {
+            _markerXValue = (_zoomMinX + _zoomMaxX) / 2
+        }
         _refreshCursorPixelPos()
+        Qt.callLater(_syncSeriesWithSelection)
+    }
+
+    // User-driven zoom — also emits zoomApplied so other charts can sync
+    function applyZoomRange(minX, maxX) {
+        _applyZoomInternal(minX, maxX)
+        zoomApplied(minX, maxX)
+    }
+
+    // External zoom sync — apply without re-emitting
+    function setSharedZoom(minX, maxX) {
+        _applyZoomInternal(minX, maxX)
+    }
+
+    // External cursor sync — apply without re-emitting
+    function setSharedCursor(t) {
+        if (_binXAxis.max <= _binXAxis.min) return
+        _markerXValue = t
+        _markerPixelX = _axisXToPixel(t)
+        _positionMarkerVisible = true
+        _queryCursorValues()
     }
 
     function resetZoom() {
@@ -150,7 +178,14 @@ ColumnLayout {
             const field = selectedFields[i]
             const value = logParser.fieldValueAt(field, _markerXValue)
             if (isNaN(value)) continue
-            rows.push({ name: field, color: fieldColor(field), value: value })
+            const fr = _fieldFullRange[field]
+            rows.push({
+                name:  field,
+                color: fieldColor(field),
+                value: value,
+                min:   fr ? fr.min : NaN,
+                max:   fr ? fr.max : NaN
+            })
         }
         _markerRows = rows
 
@@ -169,6 +204,7 @@ ColumnLayout {
         _markerPixelX = Math.max(_binChart.plotArea.x, Math.min(_binChart.plotArea.x + _binChart.plotArea.width, pixelX))
         _markerXValue = _pixelToAxisX(_markerPixelX)
         _queryCursorValues()
+        cursorMoved(_markerXValue)
     }
 
     function _refreshCursorPixelPos() {
@@ -211,6 +247,7 @@ ColumnLayout {
         }
         _seriesByField = {}
         _fieldYRange = {}
+        _fieldFullRange = {}
         _eventSeriesByType = {}
 
         if (logParser.minTimestamp >= 0.0 && logParser.maxTimestamp > logParser.minTimestamp) {
@@ -231,11 +268,11 @@ ColumnLayout {
     function _syncSeriesWithSelection() {
         const newSelection = logViewerController.selectedFields
 
+        // Remove series no longer in selection
         const desired = {}
         for (let i = 0; i < newSelection.length; i++) {
             desired[String(newSelection[i])] = true
         }
-
         const tracked = Object.keys(_seriesByField)
         for (let i = 0; i < tracked.length; i++) {
             if (!desired[tracked[i]]) {
@@ -245,37 +282,46 @@ ColumnLayout {
             }
         }
 
+        // Rebuild series data for the current zoom window.
+        // Reuse existing series objects (clear + repopulate) to avoid Qt Graphs
+        // lifecycle issues that occur when a series is removed and immediately recreated.
         for (let i = 0; i < newSelection.length; i++) {
             const fieldName = String(newSelection[i])
-            if (_seriesByField[fieldName]) continue
 
-            const points = logParser.fieldSamples(fieldName)
-            if (!points || points.length === 0) continue
+            const pixelWidth = Math.max(1, Math.floor(_binChart.plotArea.width))
+            const points = logParser.fieldSamplesFiltered(fieldName, _zoomMinX, _zoomMaxX, pixelWidth)
 
-            const series = _lineSeriesComponent.createObject(_binChart, {
-                color: fieldColor(fieldName),
-                width: 2,
-                axisX: _binXAxis,
-                axisY: _binYAxis
-            })
-            _binChart.addSeries(series)
+            let series
+            if (_seriesByField[fieldName]) {
+                series = _seriesByField[fieldName]
+                series.clear()
+            } else {
+                series = _lineSeriesComponent.createObject(_binChart, {
+                    color: fieldColor(fieldName),
+                    width: 2,
+                    axisX: _binXAxis,
+                    axisY: _binYAxis
+                })
+                _binChart.addSeries(series)
+                _seriesByField[fieldName] = series
+
+                // Compute full-dataset min/max once when the series is first created
+                const fr = logParser.fieldMinMax(fieldName)
+                _fieldFullRange[fieldName] = (fr && fr.min !== undefined && fr.min <= fr.max) ? { min: fr.min, max: fr.max } : null
+            }
+
+            if (!points || points.length === 0) {
+                _fieldYRange[fieldName] = { min: 0, max: 1 }
+                continue
+            }
 
             let minY = Number.MAX_VALUE
             let maxY = -Number.MAX_VALUE
-            const sampleStep = Math.max(1, Math.ceil(points.length / _maxChartPointsPerField))
-            let appendedLastX = -Number.MAX_VALUE
-            for (let j = 0; j < points.length; j += sampleStep) {
+            for (let j = 0; j < points.length; j++) {
                 series.append(points[j].x, points[j].y)
-                appendedLastX = points[j].x
                 if (points[j].y < minY) minY = points[j].y
                 if (points[j].y > maxY) maxY = points[j].y
             }
-            if (sampleStep > 1) {
-                const last = points[points.length - 1]
-                if (last && last.x !== appendedLastX) series.append(last.x, last.y)
-            }
-
-            _seriesByField[fieldName] = series
             _fieldYRange[fieldName] = { min: minY, max: maxY }
         }
 
@@ -573,28 +619,35 @@ ColumnLayout {
         // Value popup
         Rectangle {
             id: _valuePopup
-            visible: _positionMarkerVisible
             x: _popupX()
             y: _binChart.plotArea.y
-            width: ScreenTools.defaultFontPixelWidth * 30
+            z: 1003
+            implicitWidth: _valueColumnLayout.implicitWidth + (margin * 2)
+            implicitHeight: _valueColumnLayout.implicitHeight + (margin * 2)
             color: qgcPal.windowShade
             border.color: qgcPal.windowShadeDark
             radius: ScreenTools.defaultFontPixelWidth * 0.3
-            z: 1003
-            implicitHeight: _valueColumnLayout.implicitHeight + (ScreenTools.defaultFontPixelHeight * 0.6)
+            visible: _positionMarkerVisible
 
+            property real margin: ScreenTools.defaultFontPixelWidth / 2
             property real colorBlockWidth: ScreenTools.defaultFontPixelHeight * 0.8
 
             function _popupX() {
-                const rightCornerX = _binChart.plotArea.x + _binChart.plotArea.width - width
-                const popupX = (_markerPixelX > rightCornerX) ? _binChart.plotArea.x : rightCornerX
-                return Math.max(0, Math.min(popupX, _chartContainer.width - width))
+                const plotMidX = _binChart.plotArea.x + _binChart.plotArea.width / 2
+                if (_markerPixelX < plotMidX) {
+                    // Cursor in left half — place popup on the right
+                    const rightX = _binChart.plotArea.x + _binChart.plotArea.width - width
+                    return Math.max(0, Math.min(rightX, _chartContainer.width - width))
+                } else {
+                    // Cursor in right half — place popup on the left
+                    return Math.max(0, _binChart.plotArea.x)
+                }
             }
 
             ColumnLayout {
                 id: _valueColumnLayout
                 anchors.fill: parent
-                anchors.margins: ScreenTools.defaultFontPixelHeight * 0.3
+                anchors.margins: _valuePopup.margin
                 spacing: ScreenTools.defaultFontPixelHeight * 0.2
 
                 QGCLabel {
@@ -612,25 +665,51 @@ ColumnLayout {
                         color: modeColor(_markerModeName)
                     }
 
-                    QGCLabel { text: qsTr("Mode: %1").arg(_markerModeName) }
+                    QGCLabel { text: qsTr("Mode:") }
+                    QGCLabel { text: _markerModeName; font.bold: true }
                 }
 
                 Repeater {
                     model: _markerRows
 
-                    RowLayout {
-                        spacing: ScreenTools.defaultFontPixelWidth * 0.2
+                    ColumnLayout {
+                        spacing: ScreenTools.defaultFontPixelHeight * 0.15
 
-                        Rectangle {
-                            Layout.preferredWidth: _valuePopup.colorBlockWidth
-                            Layout.preferredHeight: _valuePopup.colorBlockWidth
-                            color: modelData.color
+                        // Line 1: color block + field name
+                        RowLayout {
+                            spacing: ScreenTools.defaultFontPixelWidth * 0.4
+
+                            Rectangle {
+                                Layout.preferredWidth:  _valuePopup.colorBlockWidth
+                                Layout.preferredHeight: _valuePopup.colorBlockWidth
+                                color: modelData.color
+                            }
+
+                            QGCLabel {
+                                width: _valuePopup.width - (ScreenTools.defaultFontPixelWidth * 4)
+                                elide: Text.ElideMiddle
+                                text:  modelData.name
+                                font.bold: true
+                            }
                         }
 
-                        QGCLabel {
-                            width: _valuePopup.width - (ScreenTools.defaultFontPixelWidth * 4)
-                            elide: Text.ElideMiddle
-                            text: modelData.name + ": " + Number(modelData.value).toFixed(3)
+                        // Line 2: Current / Min / Max
+                        RowLayout {
+                            Layout.leftMargin: _valuePopup.colorBlockWidth + ScreenTools.defaultFontPixelWidth * 0.4
+                            spacing: ScreenTools.defaultFontPixelWidth * 0.3
+
+                            QGCLabel { text: qsTr("Current") }
+                            QGCLabel { text: Number(modelData.value).toFixed(3); font.bold: true }
+
+                            Item { width: ScreenTools.defaultFontPixelWidth * 0.5 }
+
+                            QGCLabel { text: qsTr("Min") }
+                            QGCLabel { text: isNaN(modelData.min) ? "—" : Number(modelData.min).toFixed(3); font.bold: true }
+
+                            Item { width: ScreenTools.defaultFontPixelWidth * 0.5 }
+
+                            QGCLabel { text: qsTr("Max") }
+                            QGCLabel { text: isNaN(modelData.max) ? "—" : Number(modelData.max).toFixed(3); font.bold: true }
                         }
                     }
                 }

--- a/src/AnalyzeView/LogViewer/LogViewerController.cc
+++ b/src/AnalyzeView/LogViewer/LogViewerController.cc
@@ -26,22 +26,22 @@ void LogViewerController::clear()
     _expandedGroups.clear();
     emit fieldRowsChanged();
     emit selectedFieldsChanged();
-    _setLog(SourceType::None, QString(), tr("No log loaded"));
+    _setLog(SourceType::None, QString());
 }
 
 void LogViewerController::openTLog(const QString &path)
 {
-    _setLog(SourceType::TLog, path, tr("Telemetry log loaded"));
+    _setLog(SourceType::TLog, path);
 }
 
 void LogViewerController::openBinLog(const QString &path)
 {
-    _setLog(SourceType::Bin, path, tr("DataFlash log loaded"));
+    _setLog(SourceType::Bin, path);
 }
 
 void LogViewerController::openULogFile(const QString &path)
 {
-    _setLog(SourceType::ULog, path, tr("ULog file loaded"));
+    _setLog(SourceType::ULog, path);
 }
 
 void LogViewerController::setPlottableFields(const QStringList &fieldNames)
@@ -163,7 +163,7 @@ QStringList LogViewerController::modeLegendEntries(const QVariantList &modeSegme
     return modes;
 }
 
-void LogViewerController::_setLog(SourceType sourceType, const QString &path, const QString &statusText)
+void LogViewerController::_setLog(SourceType sourceType, const QString &path)
 {
     if (_sourceType != sourceType) {
         _sourceType = sourceType;
@@ -173,11 +173,6 @@ void LogViewerController::_setLog(SourceType sourceType, const QString &path, co
     if (_currentLogPath != path) {
         _currentLogPath = path;
         emit currentLogPathChanged();
-    }
-
-    if (_statusText != statusText) {
-        _statusText = statusText;
-        emit statusTextChanged();
     }
 
     qCDebug(LogViewerControllerLog) << "sourceType" << static_cast<int>(_sourceType) << "path" << _currentLogPath;

--- a/src/AnalyzeView/LogViewer/LogViewerController.h
+++ b/src/AnalyzeView/LogViewer/LogViewerController.h
@@ -15,7 +15,6 @@ class LogViewerController : public QObject
     Q_PROPERTY(SourceType   sourceType     READ sourceType     NOTIFY sourceTypeChanged)
     Q_PROPERTY(QString      currentLogPath READ currentLogPath NOTIFY currentLogPathChanged)
     Q_PROPERTY(bool         hasLoadedLog   READ hasLoadedLog   NOTIFY currentLogPathChanged)
-    Q_PROPERTY(QString      statusText     READ statusText     NOTIFY statusTextChanged)
     Q_PROPERTY(QVariantList fieldRows      READ fieldRows      NOTIFY fieldRowsChanged)
     Q_PROPERTY(QStringList  selectedFields READ selectedFields NOTIFY selectedFieldsChanged)
 
@@ -34,7 +33,6 @@ public:
     SourceType sourceType() const { return _sourceType; }
     QString currentLogPath() const { return _currentLogPath; }
     bool hasLoadedLog() const { return !_currentLogPath.isEmpty(); }
-    QString statusText() const { return _statusText; }
     QVariantList fieldRows() const { return _fieldRows; }
     QStringList selectedFields() const { return _selectedFields; }
 
@@ -58,18 +56,16 @@ public:
 signals:
     void sourceTypeChanged();
     void currentLogPathChanged();
-    void statusTextChanged();
     void fieldRowsChanged();
     void selectedFieldsChanged();
 
 private:
     void _rebuildFieldRows();
     QString _assignColorForKey(const QString &key) const;
-    void _setLog(SourceType sourceType, const QString &path, const QString &statusText);
+    void _setLog(SourceType sourceType, const QString &path);
 
     SourceType _sourceType = SourceType::None;
     QString _currentLogPath;
-    QString _statusText;
     QStringList _plottableFields;
     QVariantList _fieldRows;
     QStringList _selectedFields;

--- a/src/AnalyzeView/LogViewer/LogViewerPage.qml
+++ b/src/AnalyzeView/LogViewer/LogViewerPage.qml
@@ -1,9 +1,12 @@
 import QtQuick
 import QtQuick.Controls
 import QtQuick.Layouts
+import QtLocation
+import QtPositioning
 
 import QGroundControl
 import QGroundControl.Controls
+import QGroundControl.FlightMap
 import QGroundControl.LogViewer
 
 AnalyzePage {
@@ -23,6 +26,7 @@ AnalyzePage {
             property string pendingBinFile: ""
             property string fieldSearchText: ""
             property string parameterSearchText: ""
+            property bool showOnlyChangedParameters: true
             property var filteredFieldRows: []
             property var filteredParameters: []
 
@@ -79,19 +83,24 @@ AnalyzePage {
 
             function applyParameterFilter() {
                 const query = String(parameterSearchText).trim().toLowerCase()
-                if (query.length === 0) {
-                    filteredParameters = logParser.parameters
-                    return
-                }
+                const onlyChanged = showOnlyChangedParameters
 
                 const output = []
                 for (let i = 0; i < logParser.parameters.length; i++) {
                     const item = logParser.parameters[i]
-                    const name = String(item.name)
-                    const value = String(item.value)
-                    if ((name + " " + value).toLowerCase().indexOf(query) !== -1) {
-                        output.push(item)
+                    // "Show only changed" filter: skip parameters that equal their system default
+                    if (onlyChanged && item.hasDefault && item.isDefault) {
+                        continue
                     }
+                    if (query.length > 0) {
+                        const name = String(item.name)
+                        const desc = item.shortDescription ? String(item.shortDescription) : ""
+                        const value = String(item.value)
+                        if ((name + " " + value + " " + desc).toLowerCase().indexOf(query) === -1) {
+                            continue
+                        }
+                    }
+                    output.push(item)
                 }
                 filteredParameters = output
             }
@@ -158,7 +167,9 @@ AnalyzePage {
             Connections {
                 target: logViewerController
                 function onFieldRowsChanged() {
+                    const savedY = fieldsListView.contentY
                     applyFieldFilter()
+                    Qt.callLater(() => { fieldsListView.contentY = savedY })
                 }
             }
 
@@ -248,253 +259,413 @@ AnalyzePage {
                 }
             }
 
-            RowLayout {
+            QGCTabBar {
+                id: mainTabBar
                 Layout.fillWidth: true
-                visible: logViewerController.sourceType === LogViewerController.TLog && replayController.link
-                spacing: ScreenTools.defaultFontPixelWidth
 
-                QGCButton {
-                    text: replayController.isPlaying ? qsTr("Pause") : qsTr("Play")
-                    onClicked: replayController.isPlaying = !replayController.isPlaying
-                }
-
-                QGCComboBox {
-                    textRole: "text"
-                    currentIndex: 3
-
-                    model: ListModel {
-                        ListElement { text: "0.1x"; value: 0.1 }
-                        ListElement { text: "0.25x"; value: 0.25 }
-                        ListElement { text: "0.5x"; value: 0.5 }
-                        ListElement { text: "1x"; value: 1.0 }
-                        ListElement { text: "2x"; value: 2.0 }
-                        ListElement { text: "5x"; value: 5.0 }
-                        ListElement { text: "10x"; value: 10.0 }
-                    }
-
-                    onActivated: (index) => replayController.playbackSpeed = model.get(index).value
-                }
-
-                QGCLabel { text: replayController.playheadTime }
-
-                Slider {
-                    id: replaySlider
-                    Layout.fillWidth: true
-                    from: 0
-                    to: 100
-
-                    property bool _internalUpdate: false
-
-                    Connections {
-                        target: replayController
-                        function onPercentCompleteChanged(percentComplete) {
-                            replaySlider._internalUpdate = true
-                            replaySlider.value = percentComplete
-                            replaySlider._internalUpdate = false
-                        }
-                    }
-
-                    onValueChanged: {
-                        if (!_internalUpdate) {
-                            replayController.percentComplete = value
-                        }
-                    }
-                }
-
-                QGCLabel { text: replayController.totalTime }
+                QGCTabButton { text: qsTr("Charting") }
+                QGCTabButton { text: qsTr("Map") }
+                QGCTabButton { text: qsTr("Parameters") }
+                QGCTabButton { text: qsTr("Messages") }
             }
 
-            RowLayout {
+            StackLayout {
                 Layout.fillWidth: true
                 Layout.fillHeight: true
-                spacing: ScreenTools.defaultFontPixelWidth
+                currentIndex: mainTabBar.currentIndex
 
-                Rectangle {
-                    Layout.preferredWidth: availableWidth * 0.25
+                // ---- Tab 0: Charting ----
+                RowLayout {
+                    spacing: ScreenTools.defaultFontPixelWidth
+
+                    // Left panel: stats + replay controls + fields list
+                    Rectangle {
+                        Layout.preferredWidth: availableWidth * 0.25
+                        Layout.fillHeight: true
+                        color: qgcPal.windowShade
+                        radius: ScreenTools.defaultFontPixelWidth * 0.5
+
+                        ColumnLayout {
+                            anchors.fill: parent
+                            anchors.margins: ScreenTools.defaultFontPixelWidth
+                            spacing: ScreenTools.defaultFontPixelHeight * 0.5
+
+                            QGCLabel {
+                                visible: isFirmwareLog
+                                text: qsTr("Fields: %1  Parameters: %2  Events: %3")
+                                      .arg(logParser.plottableFields.length)
+                                      .arg(logParser.parameters.length)
+                                      .arg(logParser.events.length)
+                            }
+
+                            QGCLabel {
+                                visible: isFirmwareLog
+                                text: qsTr("Detected vehicle type: %1")
+                                      .arg(logParser.detectedVehicleType.length > 0
+                                           ? logParser.detectedVehicleType
+                                           : qsTr("Unknown"))
+                            }
+
+                            RowLayout {
+                                Layout.fillWidth: true
+                                visible: logViewerController.sourceType === LogViewerController.TLog && replayController.link
+                                spacing: ScreenTools.defaultFontPixelWidth
+
+                                QGCButton {
+                                    text: replayController.isPlaying ? qsTr("Pause") : qsTr("Play")
+                                    onClicked: replayController.isPlaying = !replayController.isPlaying
+                                }
+
+                                QGCComboBox {
+                                    textRole: "text"
+                                    currentIndex: 3
+
+                                    model: ListModel {
+                                        ListElement { text: "0.1x"; value: 0.1 }
+                                        ListElement { text: "0.25x"; value: 0.25 }
+                                        ListElement { text: "0.5x"; value: 0.5 }
+                                        ListElement { text: "1x"; value: 1.0 }
+                                        ListElement { text: "2x"; value: 2.0 }
+                                        ListElement { text: "5x"; value: 5.0 }
+                                        ListElement { text: "10x"; value: 10.0 }
+                                    }
+
+                                    onActivated: (index) => replayController.playbackSpeed = model.get(index).value
+                                }
+
+                                QGCLabel { text: replayController.playheadTime }
+
+                                Slider {
+                                    id: replaySlider
+                                    Layout.fillWidth: true
+                                    from: 0
+                                    to: 100
+
+                                    property bool _internalUpdate: false
+
+                                    Connections {
+                                        target: replayController
+                                        function onPercentCompleteChanged(percentComplete) {
+                                            replaySlider._internalUpdate = true
+                                            replaySlider.value = percentComplete
+                                            replaySlider._internalUpdate = false
+                                        }
+                                    }
+
+                                    onValueChanged: {
+                                        if (!_internalUpdate) {
+                                            replayController.percentComplete = value
+                                        }
+                                    }
+                                }
+
+                                QGCLabel { text: replayController.totalTime }
+                            }
+
+                            RowLayout {
+                                Layout.fillWidth: true
+                                visible: isFirmwareLog
+                                spacing: ScreenTools.defaultFontPixelWidth * 0.5
+
+                                QGCLabel {
+                                    text: qsTr("Fields")
+                                    font.bold: true
+                                }
+
+                                QGCTextField {
+                                    id: fieldSearchField
+                                    Layout.fillWidth: true
+                                    textColor: qgcPal.textFieldText
+                                    placeholderTextColor: Qt.rgba(qgcPal.textFieldText.r, qgcPal.textFieldText.g, qgcPal.textFieldText.b, 0.7)
+                                    placeholderText: qsTr("Search fields")
+                                    onTextChanged: {
+                                        fieldSearchText = text
+                                        if (text.trim().length === 0) {
+                                            fieldSearchTimer.stop()
+                                            applyFieldFilter()
+                                        } else {
+                                            fieldSearchTimer.restart()
+                                        }
+                                    }
+                                    onAccepted: {
+                                        fieldSearchText = text
+                                        fieldSearchTimer.stop()
+                                        applyFieldFilter()
+                                    }
+                                }
+
+                                QGCButton {
+                                    text: qsTr("Clear Selected")
+                                    horizontalAlignment: Text.AlignHCenter
+                                    Layout.preferredHeight: fieldSearchField.implicitHeight
+                                    Layout.minimumHeight: fieldSearchField.implicitHeight
+                                    topPadding: 0
+                                    bottomPadding: 0
+                                    enabled: logViewerController.selectedFields.length > 0
+                                    onClicked: {
+                                        logViewerController.clearSelection()
+                                        applyFieldFilter()
+                                        logViewerChart.refreshBinChart()
+                                    }
+                                }
+                            }
+
+                            ScrollView {
+                                id: fieldsScroll
+                                Layout.fillWidth: true
+                                Layout.fillHeight: true
+                                visible: isFirmwareLog
+                                clip: true
+
+                                ListView {
+                                    id: fieldsListView
+                                    anchors.fill: parent
+                                    model: filteredFieldRows
+                                    spacing: 0
+                                    clip: true
+                                    ScrollBar.vertical: ScrollBar { }
+
+                                    delegate: Item {
+                                        width: fieldsListView.width
+                                        height: (modelData.rowType === "group")
+                                                ? (groupRect.implicitHeight + (ScreenTools.defaultFontPixelHeight * 0.1))
+                                                : (fieldRow.implicitHeight + (ScreenTools.defaultFontPixelHeight * 0.1))
+
+                                        Item {
+                                            id: groupRect
+                                            visible: modelData.rowType === "group"
+                                            width: parent.width
+                                            implicitWidth: groupLayout.implicitWidth
+                                            implicitHeight: groupLayout.implicitHeight
+
+                                            RowLayout {
+                                                id: groupLayout
+                                                spacing: ScreenTools.defaultFontPixelWidth / 2
+
+                                                QGCColoredImage {
+                                                    Layout.preferredWidth: groupLabel.height * 0.5
+                                                    Layout.preferredHeight: groupLabel.height * 0.5
+                                                    source: "/qmlimages/arrow-down.png"
+                                                    color: qgcPal.text
+                                                    fillMode: Image.PreserveAspectFit
+                                                    rotation: (String(fieldSearchText).trim().length > 0 || isGroupExpanded(modelData.group)) ? 0 : -90
+                                                }
+
+                                                QGCLabel {
+                                                    id: groupLabel
+                                                    text: modelData.group;
+                                                    font.bold: true
+                                                }
+                                            }
+
+                                            MouseArea {
+                                                anchors.fill: parent
+                                                onClicked: toggleGroupExpanded(modelData.group)
+                                            }
+                                        }
+
+                                        Item {
+                                            id: fieldRow
+                                            visible: modelData.rowType === "field"
+                                            width: parent.width
+                                            implicitHeight: fieldSlider.implicitHeight
+
+                                            QGCCheckBoxSlider {
+                                                id: fieldSlider
+                                                width: parent.width - ScreenTools.defaultFontPixelWidth * 1.5
+                                                checked: logViewerController.selectedFields.indexOf(modelData.fullName) !== -1
+                                                text: modelData.shortName ? String(modelData.shortName) : ""
+                                                onClicked: logViewerController.setFieldSelected(modelData.fullName, checked)
+                                            }
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    }
+
+                    // Right panel: chart + MAVLink inspector
+                    Rectangle {
+                        Layout.fillWidth: true
+                        Layout.fillHeight: true
+                        color: qgcPal.windowShadeDark
+                        radius: ScreenTools.defaultFontPixelWidth * 0.5
+
+                        ColumnLayout {
+                            anchors.fill: parent
+                            anchors.margins: ScreenTools.defaultFontPixelWidth
+                            spacing: ScreenTools.defaultFontPixelHeight * 0.5
+
+                            LogViewerChart {
+                                id: logViewerChart
+                                Layout.fillWidth: true
+                                Layout.fillHeight: true
+                                visible: isFirmwareLog
+                                logParser: logParser
+                                logViewerController: logViewerController
+
+                                onCursorMoved: (t) => {
+                                    _mapTab._markerVisible = true
+                                    _mapTab._markerCoord   = logParser.gpsCoordAt(t)
+                                    if (_altChart.visible) _altChart.setSharedCursor(t)
+                                }
+                                onZoomApplied: (minX, maxX) => {
+                                    if (_altChart.visible) _altChart.setSharedZoom(minX, maxX)
+                                }
+                            }
+
+                            Loader {
+                                Layout.fillWidth: true
+                                Layout.fillHeight: true
+                                active: logViewerController.sourceType === LogViewerController.TLog
+                                source: "qrc:/qml/QGroundControl/AnalyzeView/MAVLinkInspector/MAVLinkInspectorPage.qml"
+                            }
+                        }
+                    }
+                }
+
+                // ---- Tab 1: Map ----
+                Item {
+                    id: _mapTab
+                    Layout.fillWidth: true
                     Layout.fillHeight: true
-                    color: qgcPal.windowShade
-                    radius: ScreenTools.defaultFontPixelWidth * 0.5
+
+                    // GPS path data
+                    readonly property var    _gpsPath:      logParser.parsed ? logParser.gpsPath() : []
+                    readonly property int    _pathLen:      (_gpsPath && _gpsPath.length) ? _gpsPath.length : 0
+                    readonly property bool   _hasPath:      _pathLen >= 2
+                    readonly property string _altFieldName: _hasPath ? logParser.gpsAltitudeFieldName() : ""
+                    readonly property bool   _hasAltField:  _altFieldName.length > 0
+
+                    // Shared cursor state (driven by altitude chart, displayed on map)
+                    property bool _markerVisible: false
+                    property var  _markerCoord:   ({})
 
                     ColumnLayout {
                         anchors.fill: parent
-                        anchors.margins: ScreenTools.defaultFontPixelWidth
-                        spacing: ScreenTools.defaultFontPixelHeight * 0.5
+                        spacing:      0
 
-                        QGCLabel {
-                            visible: isFirmwareLog
-                            text: qsTr("Fields: %1  Parameters: %2  Events: %3")
-                                  .arg(logParser.plottableFields.length)
-                                  .arg(logParser.parameters.length)
-                                  .arg(logParser.events.length)
-                        }
+                        // ---- Map ----
+                        Item {
+                            Layout.fillWidth:  true
+                            Layout.fillHeight: true
 
-                        QGCLabel {
-                            visible: isFirmwareLog
-                            text: qsTr("Detected vehicle type: %1")
-                                  .arg(logParser.detectedVehicleType.length > 0
-                                       ? logParser.detectedVehicleType
-                                       : qsTr("Unknown"))
-                        }
+                            FlightMap {
+                                id: _flightMap
+                                anchors.fill:          parent
+                                mapName:               "LogViewerMap"
+                                allowGCSLocationCenter: true
 
-                        RowLayout {
-                            Layout.fillWidth: true
-                            visible: isFirmwareLog
-                            spacing: ScreenTools.defaultFontPixelWidth * 0.5
+                                readonly property var _path: _mapTab._gpsPath
+
+                                function _fitPath() {
+                                    const p = _mapTab._gpsPath
+                                    if (!_mapTab._hasPath) return
+                                    var minLat = p[0].latitude, maxLat = minLat
+                                    var minLon = p[0].longitude, maxLon = minLon
+                                    for (var i = 1; i < p.length; i++) {
+                                        var c = p[i]
+                                        if (c.latitude  < minLat) minLat = c.latitude
+                                        if (c.latitude  > maxLat) maxLat = c.latitude
+                                        if (c.longitude < minLon) minLon = c.longitude
+                                        if (c.longitude > maxLon) maxLon = c.longitude
+                                    }
+                                    setVisibleRegion(QtPositioning.rectangle(
+                                        QtPositioning.coordinate(maxLat, minLon),
+                                        QtPositioning.coordinate(minLat, maxLon)))
+                                }
+
+                                Connections {
+                                    target: logParser
+                                    function onParsedChanged() {
+                                        if (logParser.parsed) Qt.callLater(_flightMap._fitPath)
+                                    }
+                                }
+
+                                MapPolyline {
+                                    line.width: 3
+                                    line.color: QGroundControl.globalPalette.colorRed
+                                    path:       _flightMap._path
+                                }
+
+                                // Position dot driven by altitude chart cursor
+                                MapQuickItem {
+                                    readonly property var _coord: _mapTab._markerCoord
+                                    visible:      _mapTab._markerVisible && _mapTab._hasPath
+                                                  && _coord && _coord.latitude !== undefined
+                                    coordinate:   (_coord && _coord.latitude !== undefined)
+                                                  ? QtPositioning.coordinate(_coord.latitude, _coord.longitude)
+                                                  : QtPositioning.coordinate(0, 0)
+                                    anchorPoint:  Qt.point(_posDot.width / 2, _posDot.height / 2)
+                                    sourceItem: Rectangle {
+                                        id:           _posDot
+                                        width:        ScreenTools.defaultFontPixelHeight * 1.2
+                                        height:       width
+                                        radius:       width / 2
+                                        color:        QGroundControl.globalPalette.colorYellow
+                                        border.color: "white"
+                                        border.width: 2
+                                    }
+                                }
+
+                                MapScale {
+                                    anchors.margins: ScreenTools.defaultFontPixelWidth
+                                    anchors.left:    parent.left
+                                    anchors.bottom:  parent.bottom
+                                    mapControl:      _flightMap
+                                }
+                            }
 
                             QGCLabel {
-                                text: qsTr("Fields")
-                                font.bold: true
+                                anchors.centerIn: parent
+                                visible:          logParser.parsed && !_mapTab._hasPath
+                                text:             qsTr("No GPS data found in this log")
+                                font.italic:      true
                             }
 
-                            QGCTextField {
-                                id: fieldSearchField
-                                Layout.fillWidth: true
-                                textColor: qgcPal.textFieldText
-                                placeholderTextColor: Qt.rgba(qgcPal.textFieldText.r, qgcPal.textFieldText.g, qgcPal.textFieldText.b, 0.7)
-                                placeholderText: qsTr("Search fields")
-                                onTextChanged: {
-                                    fieldSearchText = text
-                                    if (text.trim().length === 0) {
-                                        fieldSearchTimer.stop()
-                                        applyFieldFilter()
-                                    } else {
-                                        fieldSearchTimer.restart()
-                                    }
-                                }
-                                onAccepted: {
-                                    fieldSearchText = text
-                                    fieldSearchTimer.stop()
-                                    applyFieldFilter()
-                                }
-                            }
-
-                            QGCButton {
-                                text: qsTr("Clear Selected")
-                                horizontalAlignment: Text.AlignHCenter
-                                Layout.preferredHeight: fieldSearchField.implicitHeight
-                                Layout.minimumHeight: fieldSearchField.implicitHeight
-                                topPadding: 0
-                                bottomPadding: 0
-                                enabled: logViewerController.selectedFields.length > 0
-                                onClicked: {
-                                    logViewerController.clearSelection()
-                                    applyFieldFilter()
-                                    logViewerChart.refreshBinChart()
-                                }
+                            QGCLabel {
+                                anchors.centerIn: parent
+                                visible:          !logParser.parsed
+                                text:             qsTr("Load a log file to view the flight path")
+                                font.italic:      true
                             }
                         }
 
-                        ScrollView {
-                            id: fieldsScroll
-                            Layout.fillWidth: true
-                            Layout.preferredHeight: parent.height * 0.35
-                            visible: isFirmwareLog
-                            clip: true
+                        // ---- Altitude chart ----
+                        LogViewerAltChart {
+                            id:                    _altChart
+                            Layout.fillWidth:      true
+                            Layout.preferredHeight: ScreenTools.defaultFontPixelHeight * 14
+                            visible:               _mapTab._hasAltField && _mapTab._hasPath
+                            logParser:             logParser
+                            altFieldName:          _mapTab._altFieldName
 
-                            ListView {
-                                id: fieldsListView
-                                anchors.fill: parent
-                                model: filteredFieldRows
-                                spacing: 0
-                                clip: true
-                                ScrollBar.vertical: ScrollBar { }
-
-                                delegate: Item {
-                                    width: fieldsListView.width
-                                    height: (modelData.rowType === "group")
-                                            ? (groupRect.implicitHeight + (ScreenTools.defaultFontPixelHeight * 0.1))
-                                            : (fieldRow.implicitHeight + (ScreenTools.defaultFontPixelHeight * 0.1))
-
-                                    Item {
-                                        id: groupRect
-                                        visible: modelData.rowType === "group"
-                                        width: parent.width
-                                        implicitWidth: groupLayout.implicitWidth
-                                        implicitHeight: groupLayout.implicitHeight
-
-                                        RowLayout {
-                                            id: groupLayout
-                                            spacing: ScreenTools.defaultFontPixelWidth / 2
-
-                                            QGCColoredImage {
-                                                Layout.preferredWidth: groupLabel.height * 0.5
-                                                Layout.preferredHeight: groupLabel.height * 0.5
-                                                source: "/qmlimages/arrow-down.png"
-                                                color: qgcPal.text
-                                                fillMode: Image.PreserveAspectFit
-                                                rotation: (String(fieldSearchText).trim().length > 0 || isGroupExpanded(modelData.group)) ? 0 : -90
-                                            }
-
-                                            QGCLabel {
-                                                id: groupLabel
-                                                text: modelData.group;
-                                                font.bold: true
-                                            }
-                                        }
-
-                                        MouseArea {
-                                            anchors.fill: parent
-                                            onClicked: toggleGroupExpanded(modelData.group)
-                                        }
-                                    }
-
-                                    Row {
-                                        id: fieldRow
-                                        visible: modelData.rowType === "field"
-                                        width: parent.width
-                                        height: Math.max(fieldNameLabel.implicitHeight, fieldCheckBox.implicitHeight)
-                                        spacing: ScreenTools.defaultFontPixelWidth * 0.25
-
-                                        QGCCheckBox {
-                                            id: fieldCheckBox
-                                            anchors.verticalCenter: parent.verticalCenter
-                                            onClicked: logViewerController.setFieldSelected(modelData.fullName, checked)
-                                            checked: logViewerController.selectedFields.indexOf(modelData.fullName) !== -1
-                                        }
-
-                                        QGCLabel {
-                                            id: fieldNameLabel
-                                            anchors.verticalCenter: parent.verticalCenter
-                                            width: Math.max(0, parent.width - (ScreenTools.defaultFontPixelWidth * 3))
-                                            height: Math.max(implicitHeight, ScreenTools.defaultFontPixelHeight * 1.2)
-                                            wrapMode: Text.WordWrap
-                                            maximumLineCount: 2
-                                            verticalAlignment: Text.AlignVCenter
-                                            text: modelData.shortName ? String(modelData.shortName) : ""
-                                            color: isFieldSelected(modelData.fullName) ? logViewerChart.fieldColor(modelData.fullName) : qgcPal.text
-                                        }
-                                    }
-                                }
+                            onMarkerChanged: (t) => {
+                                _mapTab._markerVisible = true
+                                _mapTab._markerCoord   = logParser.gpsCoordAt(t)
+                                logViewerChart.setSharedCursor(t)
+                            }
+                            onMarkerCleared: {
+                                _mapTab._markerVisible = false
+                            }
+                            onZoomApplied: (minX, maxX) => {
+                                logViewerChart.setSharedZoom(minX, maxX)
                             }
                         }
+                    }
+                }
 
-                        Rectangle {
-                            Layout.fillWidth: true
-                            Layout.preferredHeight: 1
-                            color: qgcPal.windowShadeDark
-                            visible: isFirmwareLog
-                        }
+                // ---- Tab 2: Parameters ----
+                ColumnLayout {
+                    spacing: ScreenTools.defaultFontPixelHeight * 0.5
 
-                        QGCTabBar {
-                            id: dataTabBar
-                            Layout.fillWidth: true
-                            visible: isFirmwareLog
-
-                            QGCTabButton {
-                                text: qsTr("Parameters")
-                                checked: true
-                            }
-
-                            QGCTabButton {
-                                text: qsTr("Messages")
-                                checked: false
-                            }
-                        }
+                    RowLayout {
+                        Layout.fillWidth: true
+                        spacing: ScreenTools.defaultFontPixelWidth
 
                         QGCTextField {
                             id: parameterSearchField
                             Layout.fillWidth: true
-                            visible: isFirmwareLog && dataTabBar.currentIndex === 0
                             textColor: qgcPal.textFieldText
                             placeholderTextColor: Qt.rgba(qgcPal.textFieldText.r, qgcPal.textFieldText.g, qgcPal.textFieldText.b, 0.7)
                             placeholderText: qsTr("Search parameters")
@@ -516,100 +687,186 @@ AnalyzePage {
                             }
                         }
 
-                        ScrollView {
-                            Layout.fillWidth: true
-                            Layout.fillHeight: true
-                            Layout.minimumHeight: 0
-                            visible: isFirmwareLog && dataTabBar.currentIndex === 0
-                            clip: true
-
-                            ListView {
-                                id: parametersListView
-                                anchors.fill: parent
-                                model: filteredParameters
-                                spacing: ScreenTools.defaultFontPixelHeight * 0.2
-                                clip: true
-                                ScrollBar.vertical: ScrollBar { }
-
-                                delegate: QGCLabel {
-                                    width: ListView.view.width
-                                    wrapMode: Text.WordWrap
-                                    maximumLineCount: 2
-                                    text: modelData.name + " = " + modelData.value
-                                }
+                        QGCCheckBoxSlider {
+                            id: showOnlyChangedCheckBox
+                            text: qsTr("Changed only")
+                            checked: showOnlyChangedParameters
+                            onToggled: {
+                                showOnlyChangedParameters = checked
+                                applyParameterFilter()
                             }
                         }
+                    }
 
-                        ScrollView {
-                            Layout.fillWidth: true
-                            Layout.fillHeight: true
-                            Layout.minimumHeight: 0
-                            visible: isFirmwareLog && dataTabBar.currentIndex === 1
+                    ScrollView {
+                        Layout.fillWidth: true
+                        Layout.fillHeight: true
+                        clip: true
+
+                        ListView {
+                            id: parametersListView
+                            anchors.fill: parent
+                            model: filteredParameters
+                            spacing: ScreenTools.defaultFontPixelHeight * 0.1
                             clip: true
+                            ScrollBar.vertical: ScrollBar { }
 
-                            ListView {
-                                id: messagesListView
-                                anchors.fill: parent
-                                model: logParser.messages
-                                spacing: ScreenTools.defaultFontPixelHeight * 0.2
-                                clip: true
-                                ScrollBar.vertical: ScrollBar { }
+                            delegate: Rectangle {
+                                width: ListView.view.width
+                                height: _paramRow.implicitHeight + ScreenTools.defaultFontPixelHeight * 0.4
+                                color: index % 2 === 0 ? qgcPal.windowShade : qgcPal.windowShadeDark
+                                radius: 2
 
-                                delegate: QGCLabel {
-                                    width: ListView.view.width
-                                    wrapMode: Text.WordWrap
-                                    maximumLineCount: 3
-                                    text: {
-                                        const t = Number(modelData.time)
-                                        const prefix = isNaN(t) || t < 0 ? "" : ("[" + t.toFixed(3) + "s] ")
-                                        return prefix + String(modelData.text)
+                                // Format value: use metadata decimalPlaces when available,
+                                // fall back to isFloat heuristic. Show enum label when applicable.
+                                readonly property string _formattedValue: {
+                                    const v = modelData.value
+                                    if (v === undefined || v === null) return qsTr("N/A")
+                                    const numV = Number(v)
+                                    // Enum: find matching label
+                                    const eStrs = modelData.enumStrings
+                                    const eVals = modelData.enumValues
+                                    if (eStrs && eStrs.length > 0) {
+                                        for (let ei = 0; ei < eVals.length; ei++) {
+                                            if (Number(eVals[ei]) === numV) {
+                                                return eStrs[ei] + " (" + Math.round(numV) + ")"
+                                            }
+                                        }
+                                    }
+                                    // Numeric: metadata decimalPlaces wins
+                                    const dp = (modelData.decimalPlaces !== undefined) ? modelData.decimalPlaces : -1
+                                    let formatted
+                                    if (dp >= 0) {
+                                        formatted = numV.toFixed(dp)
+                                    } else if (modelData.isFloat) {
+                                        formatted = numV.toFixed(6)
+                                    } else {
+                                        formatted = String(Math.round(numV))
+                                    }
+                                    const units = (modelData.units && modelData.units.length > 0) ? (" " + modelData.units) : ""
+                                    return formatted + units
+                                }
+
+                                readonly property string _defaultText: {
+                                    if (!modelData.hasDefault) return ""
+                                    const d = modelData.defaultValue
+                                    if (d === undefined || d === null) return ""
+                                    const numD = Number(d)
+                                    const dp = (modelData.decimalPlaces !== undefined) ? modelData.decimalPlaces : -1
+                                    let formatted
+                                    if (dp >= 0) {
+                                        formatted = numD.toFixed(dp)
+                                    } else if (modelData.isFloat) {
+                                        formatted = numD.toFixed(6)
+                                    } else {
+                                        formatted = String(Math.round(numD))
+                                    }
+                                    return qsTr(" (default: %1)").arg(formatted)
+                                }
+
+                                RowLayout {
+                                    id: _paramRow
+                                    anchors.verticalCenter: parent.verticalCenter
+                                    anchors.left: parent.left
+                                    anchors.right: parent.right
+                                    anchors.margins: ScreenTools.defaultFontPixelWidth * 0.5
+                                    spacing: ScreenTools.defaultFontPixelWidth * 0.5
+
+                                    // Changed-from-default indicator dot
+                                    Rectangle {
+                                        visible: modelData.hasDefault && !modelData.isDefault
+                                        width: ScreenTools.defaultFontPixelHeight * 0.5
+                                        height: width
+                                        radius: width / 2
+                                        color: qgcPal.colorOrange
+                                        Layout.alignment: Qt.AlignVCenter
+                                    }
+
+                                    // Spacer to keep alignment when dot is hidden
+                                    Item {
+                                        visible: !(modelData.hasDefault && !modelData.isDefault)
+                                        width: ScreenTools.defaultFontPixelHeight * 0.5
+                                        height: width
+                                    }
+
+                                    QGCLabel {
+                                        text: modelData.name
+                                        font.bold: modelData.hasDefault && !modelData.isDefault
+                                        Layout.preferredWidth: ScreenTools.defaultFontPixelWidth * 22
+                                        elide: Text.ElideRight
+                                    }
+
+                                    QGCLabel {
+                                        text: _formattedValue
+                                        Layout.preferredWidth: ScreenTools.defaultFontPixelWidth * 14
+                                        horizontalAlignment: Text.AlignRight
+                                    }
+
+                                    QGCLabel {
+                                        text: _defaultText
+                                        color: Qt.rgba(qgcPal.text.r, qgcPal.text.g, qgcPal.text.b, 0.6)
+                                        Layout.preferredWidth: ScreenTools.defaultFontPixelWidth * 16
+                                        elide: Text.ElideRight
+                                    }
+
+                                    QGCLabel {
+                                        text: modelData.shortDescription ? String(modelData.shortDescription) : ""
+                                        color: Qt.rgba(qgcPal.text.r, qgcPal.text.g, qgcPal.text.b, 0.6)
+                                        Layout.fillWidth: true
+                                        elide: Text.ElideRight
                                     }
                                 }
                             }
                         }
-
                     }
                 }
 
-                Rectangle {
+                // ---- Tab 3: Messages ----
+                ScrollView {
                     Layout.fillWidth: true
                     Layout.fillHeight: true
-                    color: qgcPal.windowShadeDark
-                    radius: ScreenTools.defaultFontPixelWidth * 0.5
+                    clip: true
 
-                    ColumnLayout {
+                    ListView {
+                        id: messagesListView
                         anchors.fill: parent
-                        anchors.margins: ScreenTools.defaultFontPixelWidth
-                        spacing: ScreenTools.defaultFontPixelHeight * 0.5
+                        model: logParser.messages
+                        spacing: ScreenTools.defaultFontPixelHeight * 0.2
+                        clip: true
+                        ScrollBar.vertical: ScrollBar { }
 
-                        QGCLabel {
-                            text: qsTr("Charts and Timeline")
-                            font.bold: true
-                        }
+                        delegate: Rectangle {
+                            width: ListView.view.width
+                            height: _msgRow.implicitHeight + ScreenTools.defaultFontPixelHeight * 0.4
+                            color: index % 2 === 0 ? qgcPal.windowShade : qgcPal.windowShadeDark
+                            radius: 2
 
-                        LogViewerChart {
-                            id: logViewerChart
-                            Layout.fillWidth: true
-                            Layout.fillHeight: true
-                            visible: isFirmwareLog
-                            logParser: logParser
-                            logViewerController: logViewerController
-                        }
+                            RowLayout {
+                                id: _msgRow
+                                anchors.verticalCenter: parent.verticalCenter
+                                anchors.left: parent.left
+                                anchors.right: parent.right
+                                anchors.margins: ScreenTools.defaultFontPixelWidth * 0.5
+                                spacing: ScreenTools.defaultFontPixelWidth * 0.5
 
-                        Loader {
-                            Layout.fillWidth: true
-                            Layout.fillHeight: true
-                            active: logViewerController.sourceType === LogViewerController.TLog
-                            source: "qrc:/qml/QGroundControl/AnalyzeView/MAVLinkInspector/MAVLinkInspectorPage.qml"
+                                QGCLabel {
+                                    readonly property double _t: Number(modelData.time)
+                                    text: (isNaN(_t) || _t < 0) ? "" : _t.toFixed(3) + "s"
+                                    color: Qt.rgba(qgcPal.text.r, qgcPal.text.g, qgcPal.text.b, 0.6)
+                                    Layout.preferredWidth: ScreenTools.defaultFontPixelWidth * 10
+                                    horizontalAlignment: Text.AlignRight
+                                }
+
+                                QGCLabel {
+                                    text: String(modelData.text)
+                                    Layout.fillWidth: true
+                                    wrapMode: Text.WordWrap
+                                    maximumLineCount: 3
+                                }
+                            }
                         }
                     }
                 }
-            }
-
-            QGCLabel {
-                Layout.fillWidth: true
-                text: logViewerController.statusText
-                visible: text.length > 0
             }
 
             QGCFileDialog {

--- a/src/AnalyzeView/LogViewer/LogViewerParamMetaData.cc
+++ b/src/AnalyzeView/LogViewer/LogViewerParamMetaData.cc
@@ -1,0 +1,136 @@
+#include "LogViewerParamMetaData.h"
+
+#include "APMParameterMetaData.h"
+#include "FactMetaData.h"
+#include "PX4ParameterMetaData.h"
+#include "QGCLoggingCategory.h"
+
+#include <QtCore/QFileInfo>
+
+QGC_LOGGING_CATEGORY(LogViewerParamMetaDataLog, "AnalyzeView.LogViewerParamMetaData")
+
+namespace {
+
+// Map the APM vehicle name as stored in detectedVehicleType to the file-path
+// component used in :/FirmwarePlugin/APM/APMParameterFactMetaData.{X}.major.minor.json
+QString _apmFileVehicleName(const QString &vehicleType)
+{
+    if (vehicleType == QStringLiteral("ArduCopter")) { return QStringLiteral("Copter"); }
+    if (vehicleType == QStringLiteral("ArduPlane"))  { return QStringLiteral("Plane"); }
+    if (vehicleType == QStringLiteral("ArduRover"))  { return QStringLiteral("Rover"); }
+    if (vehicleType == QStringLiteral("ArduSub"))    { return QStringLiteral("Sub"); }
+    return QString();
+}
+
+// Walk down from (major, minor) to find the best available bundled JSON file,
+// mirroring APMFirmwarePlugin::_internalParameterMetaDataFile logic.
+QString _findAPMMetaDataFile(const QString &fileVehicleName, int major, int minor)
+{
+    int currMajor = major;
+    int currMinor = minor;
+
+    while (currMajor >= 4 && currMinor > 0) {
+        const QString file = QStringLiteral(":/FirmwarePlugin/APM/APMParameterFactMetaData.%1.%2.%3.json")
+            .arg(fileVehicleName).arg(currMajor).arg(currMinor);
+        if (QFileInfo::exists(file)) {
+            return file;
+        }
+        currMinor--;
+        if (currMinor == 0) {
+            currMinor = 10;
+            currMajor--;
+        }
+    }
+
+    // Fallback: oldest available in the 4.x series
+    for (int i = 0; i < 10; i++) {
+        const QString file = QStringLiteral(":/FirmwarePlugin/APM/APMParameterFactMetaData.%1.4.%2.json")
+            .arg(fileVehicleName).arg(i);
+        if (QFileInfo::exists(file)) {
+            return file;
+        }
+    }
+
+    return QString();
+}
+
+void _enrichRows(QVariantList &parameters, ParameterMetaData *metaData)
+{
+    for (int i = 0; i < parameters.size(); i++) {
+        QVariantMap row = parameters[i].toMap();
+
+        const QString name = row.value(QStringLiteral("name")).toString();
+        const bool isFloat = row.value(QStringLiteral("isFloat"), false).toBool();
+        const FactMetaData::ValueType_t type = isFloat
+            ? FactMetaData::valueTypeFloat
+            : FactMetaData::valueTypeInt32;
+
+        FactMetaData *factMeta = metaData->getMetaDataForFact(name, type);
+        if (!factMeta) {
+            parameters[i] = row;
+            continue;
+        }
+
+        row[QStringLiteral("decimalPlaces")]   = factMeta->decimalPlaces();
+        row[QStringLiteral("units")]           = factMeta->rawUnits();
+        row[QStringLiteral("shortDescription")] = factMeta->shortDescription();
+        row[QStringLiteral("enumStrings")]     = QVariant::fromValue(factMeta->enumStrings());
+        row[QStringLiteral("enumValues")]      = QVariant::fromValue(factMeta->enumValues());
+
+        parameters[i] = row;
+    }
+}
+
+} // namespace
+
+void LogViewerParamMetaData::enrichForPX4(QVariantList &parameters)
+{
+    if (parameters.isEmpty()) {
+        return;
+    }
+
+    auto *metaData = new PX4ParameterMetaData(nullptr);
+    metaData->loadParameterFactMetaDataFile(
+        QStringLiteral(":/FirmwarePlugin/PX4/PX4ParameterFactMetaData.json"));
+
+    _enrichRows(parameters, metaData);
+
+    delete metaData;
+}
+
+void LogViewerParamMetaData::enrichForAPM(QVariantList &parameters,
+                                          const QString &vehicleType,
+                                          int major,
+                                          int minor)
+{
+    if (parameters.isEmpty()) {
+        return;
+    }
+
+    const QString fileVehicleName = _apmFileVehicleName(vehicleType);
+    if (fileVehicleName.isEmpty()) {
+        qCDebug(LogViewerParamMetaDataLog) << "Unknown APM vehicle type:" << vehicleType;
+        return;
+    }
+
+    // If no version was detected in the log, start from a high version so the
+    // walk-down finds the newest available file.
+    const int startMajor = (major >= 4) ? major : 9;
+    const int startMinor = (minor >= 0) ? minor : 99;
+
+    const QString metaDataFile = _findAPMMetaDataFile(fileVehicleName, startMajor, startMinor);
+    if (metaDataFile.isEmpty()) {
+        qCDebug(LogViewerParamMetaDataLog) << "No APM metadata file found for" << vehicleType
+                                          << major << "." << minor;
+        return;
+    }
+
+    qCDebug(LogViewerParamMetaDataLog) << "Loading APM metadata:" << metaDataFile;
+
+    auto *metaData = new APMParameterMetaData(nullptr);
+    metaData->loadParameterFactMetaDataFile(metaDataFile);
+
+    _enrichRows(parameters, metaData);
+
+    delete metaData;
+}

--- a/src/AnalyzeView/LogViewer/LogViewerParamMetaData.h
+++ b/src/AnalyzeView/LogViewer/LogViewerParamMetaData.h
@@ -1,0 +1,28 @@
+#pragma once
+
+#include <QtCore/QString>
+#include <QtCore/QVariantList>
+
+/// Helper that enriches parameter rows with metadata from the bundled
+/// PX4 / APM FactMetaData JSON files. Each row in @a parameters is a
+/// QVariantMap; on return the following keys are added (or left absent if
+/// no metadata was found for that parameter):
+///   decimalPlaces  int       — from FactMetaData::decimalPlaces(); -1 = unknown
+///   units          QString   — raw unit string (e.g. "m/s")
+///   shortDescription QString — one-line summary
+///   enumStrings    QStringList — ordered enum labels  (empty if not an enum)
+///   enumValues     QVariantList — corresponding numeric values (parallel array)
+class LogViewerParamMetaData
+{
+public:
+    /// Enrich parameters from a PX4 ULog file.
+    static void enrichForPX4(QVariantList &parameters);
+
+    /// Enrich parameters from an APM DataFlash file.
+    /// @param vehicleType  APM vehicle name: "ArduCopter", "ArduPlane", "ArduRover", "ArduSub"
+    /// @param major / minor  Firmware version numbers parsed from the log (pass -1 if unknown).
+    static void enrichForAPM(QVariantList &parameters,
+                             const QString &vehicleType,
+                             int major,
+                             int minor);
+};

--- a/src/AnalyzeView/LogViewer/PX4ULog/ULogFullHandler.cc
+++ b/src/AnalyzeView/LogViewer/PX4ULog/ULogFullHandler.cc
@@ -216,18 +216,43 @@ void ULogFullHandler::parameter(const ulog_cpp::Parameter &param)
     }
 
     QVariant value;
+    bool isFloat = false;
     try {
         // ULog parameters are restricted to int32_t and float per spec.
         // as<double>() safely static_casts either type.
         value = param.value().as<double>();
+        isFloat = (param.field().type().type == ulog_cpp::Field::BasicType::FLOAT);
     } catch (const std::exception &) {
         value = QVariant();
     }
 
     QVariantMap row;
-    row[QStringLiteral("name")] = name;
-    row[QStringLiteral("value")] = value;
+    row[QStringLiteral("name")]    = name;
+    row[QStringLiteral("value")]   = value;
+    row[QStringLiteral("isFloat")] = isFloat;
+    // hasDefault / defaultValue / isDefault are filled in by finalize() once all
+    // ParameterDefault messages have been collected.
     _result.parameters.append(row);
+}
+
+void ULogFullHandler::parameterDefault(const ulog_cpp::ParameterDefault &param_default)
+{
+    const QString name = QString::fromStdString(param_default.field().name());
+    if (name.isEmpty()) {
+        return;
+    }
+    try {
+        const double defaultVal = param_default.value().as<double>();
+        // Only store system defaults (bit 0 set). Configuration defaults (bit 1) are
+        // user-visible overrides and not what we want to compare against.
+        using DT = ulog_cpp::ulog_parameter_default_type_t;
+        if ((static_cast<uint8_t>(param_default.defaultType()) &
+             static_cast<uint8_t>(DT::system)) != 0) {
+            _paramDefaults[name] = defaultVal;
+        }
+    } catch (const std::exception &) {
+        // Ignore unreadable defaults
+    }
 }
 
 void ULogFullHandler::dropout(const ulog_cpp::Dropout &dropout)
@@ -302,5 +327,37 @@ void ULogFullHandler::finalize()
     _result.plottableFields = _plottableFieldSet.values();
     std::sort(_result.plottableFields.begin(), _result.plottableFields.end());
 
+    // Annotate parameter rows with default value info now that all ParameterDefault
+    // messages have been collected.
+    for (int i = 0; i < _result.parameters.size(); i++) {
+        QVariantMap row = _result.parameters[i].toMap();
+        const QString name = row.value(QStringLiteral("name")).toString();
+        const auto it = _paramDefaults.constFind(name);
+        if (it != _paramDefaults.constEnd()) {
+            const double defaultVal = it.value();
+            const QVariant valueVariant = row.value(QStringLiteral("value"));
+            row[QStringLiteral("hasDefault")]   = true;
+            row[QStringLiteral("defaultValue")] = defaultVal;
+            // Treat parameters whose value couldn't be read (invalid QVariant from
+            // the catch block in parameter()) as non-default so they are never
+            // hidden by the "Changed only" filter.
+            bool isDefault = false;
+            if (valueVariant.isValid() && valueVariant.canConvert<double>()) {
+                const double currentVal = valueVariant.toDouble();
+                // qFuzzyCompare is undefined when either value is 0.0, so use exact
+                // equality for the zero case and relative comparison otherwise.
+                isDefault = (currentVal == defaultVal)
+                    || (!qFuzzyIsNull(defaultVal) && qFuzzyCompare(currentVal, defaultVal));
+            }
+            row[QStringLiteral("isDefault")]    = isDefault;
+        } else {
+            row[QStringLiteral("hasDefault")]   = false;
+            row[QStringLiteral("defaultValue")] = QVariant();
+            row[QStringLiteral("isDefault")]    = false;
+        }
+        _result.parameters[i] = row;
+    }
+
+    _result.sourceType = LogParseResult::SourceType::PX4ULog;
     _result.ok = true;
 }

--- a/src/AnalyzeView/LogViewer/PX4ULog/ULogFullHandler.h
+++ b/src/AnalyzeView/LogViewer/PX4ULog/ULogFullHandler.h
@@ -32,6 +32,7 @@ public:
     void data(const ulog_cpp::Data &data) override;
     void logging(const ulog_cpp::Logging &logging) override;
     void parameter(const ulog_cpp::Parameter &parameter) override;
+    void parameterDefault(const ulog_cpp::ParameterDefault &parameter_default) override;
     void dropout(const ulog_cpp::Dropout &dropout) override;
 
     bool hadFatalError() const { return _hadFatalError; }
@@ -54,6 +55,8 @@ private:
     std::map<uint16_t, SubscriptionInfo> _subscriptions;
     QSet<QString> _fieldSet;
     QSet<QString> _plottableFieldSet;
+    // Map of parameter name -> default value (system default, from ParameterDefault messages)
+    QHash<QString, double> _paramDefaults;
     double _lastTimestampSecs{-1.0};
     bool _hadFatalError{false};
     bool _headerComplete{false};

--- a/test/AnalyzeView/LogFileParserTest.cc
+++ b/test/AnalyzeView/LogFileParserTest.cc
@@ -331,4 +331,349 @@ void LogFileParserTest::_parseUnsupportedExtensionTest()
     QVERIFY(!parser.parseError().isEmpty());
 }
 
+void LogFileParserTest::_fieldSamplesFilteredComprehensiveTest()
+{
+    // -----------------------------------------------------------------------
+    // Dataset: 500 samples, t_i = (i*2000 + 1000) μs  for i = 0..499
+    //          → 0.001 s, 0.003 s, ..., 0.999 s  (step = 0.002 s)
+    //
+    // 10 macro-buckets  b = 0..9, each containing 50 consecutive samples.
+    // Within macro-bucket b  (i = b*50 + offset, offset = 0..49):
+    //   offset  0  → y =  1000.0 + b   unique "first" per bucket
+    //   offset 15  → y = -9999.0       global minimum
+    //   offset 30  → y = +9999.0       global maximum
+    //   offset 49  → y = -(1000.0 + b) unique "last" per bucket
+    //   all other  → y =  0.0
+    //
+    // With filter range [0.0, 1.0] and pixelWidth=10, col = floor(t*10),
+    // so macro-bucket b maps exactly to pixel column b (verified analytically).
+    // 500 > 4×10=40 → filtering applies; expected output = 40 points.
+    // -----------------------------------------------------------------------
+    const QByteArray bytes = buildULog(
+        [](ulog_cpp::Writer &w) {
+            w.messageFormat(ulog_cpp::MessageFormat{
+                "sens",
+                {ulog_cpp::Field{"uint64_t", "timestamp"},
+                 ulog_cpp::Field{"float",    "val"}}
+            });
+        },
+        [](ulog_cpp::Writer &w) {
+            w.addLoggedMessage(ulog_cpp::AddLoggedMessage{0, 1, "sens"});
+            for (int i = 0; i < 500; i++) {
+                const uint64_t ts     = static_cast<uint64_t>(i) * 2000ULL + 1000ULL;
+                const int      b      = i / 50;   // macro-bucket 0..9
+                const int      offset = i % 50;   // position within bucket
+                float y = 0.0f;
+                if      (offset ==  0) y =  1000.0f + static_cast<float>(b);
+                else if (offset == 15) y = -9999.0f;
+                else if (offset == 30) y = +9999.0f;
+                else if (offset == 49) y = -(1000.0f + static_cast<float>(b));
+                w.data(ulog_cpp::Data{1, makePayload64Float(ts, y)});
+            }
+        });
+
+    QTemporaryFile tmp;
+    tmp.setFileTemplate(QDir::tempPath() + QStringLiteral("/logtest_XXXXXX.ulg"));
+    QVERIFY(writeTempFile(tmp, bytes));
+
+    LogFileParser parser;
+    QVERIFY(parser.parseFile(tmp.fileName()));
+    QCOMPARE(parser.fieldSamples(QStringLiteral("sens.val")).size(), 500);
+
+    // -----------------------------------------------------------------------
+    // Full range [0.0, 1.0], pixelWidth=10
+    // 500 > 4×10=40 → filtering; one pixel column per macro-bucket.
+    // Each bucket has 4 distinct landmarks → exactly 40 output points.
+    // -----------------------------------------------------------------------
+    {
+        const QVariantList result = parser.fieldSamplesFiltered(
+            QStringLiteral("sens.val"), 0.0, 1.0, 10);
+
+        QCOMPARE(result.size(), 40);
+
+        int minCount = 0, maxCount = 0, firstCount = 0, lastCount = 0;
+        for (const QVariant &v : result) {
+            const double y = v.toPointF().y();
+            if (qAbs(y - (-9999.0)) < 0.01) ++minCount;
+            if (qAbs(y - (+9999.0)) < 0.01) ++maxCount;
+            if (y >= 1000.0 && y <= 1009.0)   ++firstCount;  // 1000+b, b=0..9
+            if (y <= -1000.0 && y >= -1009.0)  ++lastCount;  // -(1000+b)
+        }
+        QCOMPARE(minCount,   10);  // one per bucket
+        QCOMPARE(maxCount,   10);
+        QCOMPARE(firstCount, 10);
+        QCOMPARE(lastCount,  10);
+
+        for (int i = 1; i < result.size(); i++) {
+            QVERIFY(result[i].toPointF().x() >= result[i - 1].toPointF().x());
+        }
+    }
+
+    // -----------------------------------------------------------------------
+    // Passthrough: pixelWidth=500 → threshold 4×500=2000 ≥ 500 → no filtering
+    // -----------------------------------------------------------------------
+    {
+        const QVariantList result = parser.fieldSamplesFiltered(
+            QStringLiteral("sens.val"), 0.0, 1.0, 500);
+        QCOMPARE(result.size(), 500);
+    }
+
+    // -----------------------------------------------------------------------
+    // Zoom: first half [0.0, 0.5], pixelWidth=10
+    // Slice = 250 samples (i=0..249) > 40 → filtering; 10 sub-buckets of 25.
+    // Sub-buckets 0,2,4,6,8 contain the min; sub-buckets 1,3,5,7,9 the max.
+    // -----------------------------------------------------------------------
+    {
+        const QVariantList result = parser.fieldSamplesFiltered(
+            QStringLiteral("sens.val"), 0.0, 0.5, 10);
+
+        QVERIFY(result.size() > 0);
+        QVERIFY(result.size() <= 40);
+
+        int minCount = 0, maxCount = 0;
+        for (const QVariant &v : result) {
+            const QPointF p = v.toPointF();
+            QVERIFY(p.x() >= 0.0 && p.x() <= 0.5);
+            if (qAbs(p.y() - (-9999.0)) < 0.01) ++minCount;
+            if (qAbs(p.y() - (+9999.0)) < 0.01) ++maxCount;
+        }
+        QCOMPARE(minCount, 5);
+        QCOMPARE(maxCount, 5);
+
+        for (int i = 1; i < result.size(); i++) {
+            QVERIFY(result[i].toPointF().x() >= result[i - 1].toPointF().x());
+        }
+    }
+
+    // -----------------------------------------------------------------------
+    // Zoom: single macro-bucket [0.0, 0.1], pixelWidth=10
+    // Slice = 50 samples > 40 → filtering; 10 sub-buckets of 5 samples each.
+    // Macro-bucket 0 landmarks land in distinct sub-buckets:
+    //   offset  0 → col 0  (y =  1000.0  first of b=0)
+    //   offset 15 → col 3  (y = -9999.0)
+    //   offset 30 → col 6  (y = +9999.0)
+    //   offset 49 → col 9  (y = -1000.0  last of b=0)
+    // -----------------------------------------------------------------------
+    {
+        const QVariantList result = parser.fieldSamplesFiltered(
+            QStringLiteral("sens.val"), 0.0, 0.1, 10);
+
+        QVERIFY(result.size() > 0);
+        QVERIFY(result.size() <= 40);
+
+        bool hasFirst = false, hasMin = false, hasMax = false, hasLast = false;
+        for (const QVariant &v : result) {
+            const QPointF p = v.toPointF();
+            QVERIFY(p.x() >= 0.0 && p.x() <= 0.1);
+            if (qAbs(p.y() -   1000.0) < 0.01) hasFirst = true;
+            if (qAbs(p.y() - (-9999.0)) < 0.01) hasMin   = true;
+            if (qAbs(p.y() -   9999.0) < 0.01) hasMax   = true;
+            if (qAbs(p.y() - (-1000.0)) < 0.01) hasLast  = true;
+        }
+        QVERIFY(hasFirst);
+        QVERIFY(hasMin);
+        QVERIFY(hasMax);
+        QVERIFY(hasLast);
+
+        for (int i = 1; i < result.size(); i++) {
+            QVERIFY(result[i].toPointF().x() >= result[i - 1].toPointF().x());
+        }
+    }
+
+    // -----------------------------------------------------------------------
+    // Out-of-range: no samples in [5.0, 6.0] → empty result
+    // -----------------------------------------------------------------------
+    {
+        const QVariantList result = parser.fieldSamplesFiltered(
+            QStringLiteral("sens.val"), 5.0, 6.0, 100);
+        QCOMPARE(result.size(), 0);
+    }
+}
+
+// ============================================================================
+// gpsPath() tests
+// ============================================================================
+
+namespace {
+
+// Build a ULog payload: uint64_t timestamp + two doubles (lat, lon).
+std::vector<uint8_t> makePayload64DoubleDouble(uint64_t ts, double lat, double lon)
+{
+    std::vector<uint8_t> buf(24);
+    memcpy(buf.data(),      &ts,  8);
+    memcpy(buf.data() +  8, &lat, 8);
+    memcpy(buf.data() + 16, &lon, 8);
+    return buf;
+}
+
+// Build a DataFlash payload for a POS message: Q (uint64) + L (int32) + L (int32).
+// 'L' format = int32 stored as degrees * 1e7.
+QByteArray makePOSPayload(uint64_t timeUs, double latDeg, double lonDeg)
+{
+    QByteArray payload(16, '\0');
+    memcpy(payload.data(), &timeUs, 8);
+    const int32_t latRaw = static_cast<int32_t>(latDeg * 1.0e7);
+    const int32_t lonRaw = static_cast<int32_t>(lonDeg * 1.0e7);
+    memcpy(payload.data() + 8,  &latRaw, 4);
+    memcpy(payload.data() + 12, &lonRaw, 4);
+    return payload;
+}
+
+void appendBinMessage(QByteArray &bytes, uint8_t type, const QByteArray &payload)
+{
+    bytes.append(static_cast<char>(0xA3));
+    bytes.append(static_cast<char>(0x95));
+    bytes.append(static_cast<char>(type));
+    bytes.append(payload);
+}
+
+QByteArray makeFmtPayloadStr(uint8_t type, uint8_t length, const char *name,
+                              const char *format, const char *columns)
+{
+    QByteArray p(86, '\0');
+    p[0] = static_cast<char>(type);
+    p[1] = static_cast<char>(length);
+    memcpy(p.data() + 2,  name,    qMin<int>(4,  static_cast<int>(strlen(name))));
+    memcpy(p.data() + 6,  format,  qMin<int>(16, static_cast<int>(strlen(format))));
+    memcpy(p.data() + 22, columns, qMin<int>(64, static_cast<int>(strlen(columns))));
+    return p;
+}
+
+} // anonymous namespace
+
+void LogFileParserTest::_gpsPathULogVehicleGlobalPositionTest()
+{
+    // Build a ULog with vehicle_global_position containing lat/lon as double (degrees).
+    // Three samples at known coordinates.
+    struct Sample { double lat; double lon; };
+    static const Sample samples[] = {
+        { 47.397742, 8.545594 },
+        { 47.397800, 8.545700 },
+        { 47.397900, 8.545800 },
+    };
+
+    const QByteArray bytes = buildULog(
+        [](ulog_cpp::Writer &w) {
+            w.messageFormat(ulog_cpp::MessageFormat{
+                "vehicle_global_position",
+                {ulog_cpp::Field{"uint64_t", "timestamp"},
+                 ulog_cpp::Field{"double",   "lat"},
+                 ulog_cpp::Field{"double",   "lon"}}
+            });
+        },
+        [](ulog_cpp::Writer &w) {
+            w.addLoggedMessage(ulog_cpp::AddLoggedMessage{0, 1, "vehicle_global_position"});
+            uint64_t ts = 500000ULL;
+            for (const auto &s : samples) {
+                w.data(ulog_cpp::Data{1, makePayload64DoubleDouble(ts, s.lat, s.lon)});
+                ts += 500000ULL;
+            }
+        });
+
+    QTemporaryFile tmp;
+    tmp.setFileTemplate(QDir::tempPath() + QStringLiteral("/logtest_XXXXXX.ulg"));
+    QVERIFY(writeTempFile(tmp, bytes));
+
+    LogFileParser parser;
+    QVERIFY(parser.parseFile(tmp.fileName()));
+    QVERIFY(parser.parsed());
+
+    const QVariantList path = parser.gpsPath();
+    QCOMPARE(path.size(), static_cast<int>(std::size(samples)));
+
+    for (int i = 0; i < path.size(); i++) {
+        const QVariantMap coord = path[i].toMap();
+        QVERIFY(qAbs(coord.value(QStringLiteral("latitude")).toDouble()  - samples[i].lat) < 1e-6);
+        QVERIFY(qAbs(coord.value(QStringLiteral("longitude")).toDouble() - samples[i].lon) < 1e-6);
+    }
+}
+
+void LogFileParserTest::_gpsPathULogVehicleGpsPositionLatDegTest()
+{
+    // Simulates newer PX4 firmware that logs vehicle_gps_position with
+    // latitude_deg/longitude_deg (double, degrees) instead of lat/lon.
+    // vehicle_global_position is intentionally absent to confirm fallback.
+    struct Sample { double lat; double lon; };
+    static const Sample samples[] = {
+        { 47.397742, 8.545594 },
+        { 47.397800, 8.545700 },
+        { 47.397900, 8.545800 },
+    };
+
+    const QByteArray bytes = buildULog(
+        [](ulog_cpp::Writer &w) {
+            w.messageFormat(ulog_cpp::MessageFormat{
+                "vehicle_gps_position",
+                {ulog_cpp::Field{"uint64_t", "timestamp"},
+                 ulog_cpp::Field{"double",   "latitude_deg"},
+                 ulog_cpp::Field{"double",   "longitude_deg"}}
+            });
+        },
+        [](ulog_cpp::Writer &w) {
+            w.addLoggedMessage(ulog_cpp::AddLoggedMessage{0, 1, "vehicle_gps_position"});
+            uint64_t ts = 500000ULL;
+            for (const auto &s : samples) {
+                w.data(ulog_cpp::Data{1, makePayload64DoubleDouble(ts, s.lat, s.lon)});
+                ts += 500000ULL;
+            }
+        });
+
+    QTemporaryFile tmp;
+    tmp.setFileTemplate(QDir::tempPath() + QStringLiteral("/logtest_XXXXXX.ulg"));
+    QVERIFY(writeTempFile(tmp, bytes));
+
+    LogFileParser parser;
+    QVERIFY(parser.parseFile(tmp.fileName()));
+    QVERIFY(parser.parsed());
+
+    const QVariantList path = parser.gpsPath();
+    QCOMPARE(path.size(), static_cast<int>(std::size(samples)));
+
+    for (int i = 0; i < path.size(); i++) {
+        const QVariantMap coord = path[i].toMap();
+        QVERIFY(qAbs(coord.value(QStringLiteral("latitude")).toDouble()  - samples[i].lat) < 1e-6);
+        QVERIFY(qAbs(coord.value(QStringLiteral("longitude")).toDouble() - samples[i].lon) < 1e-6);
+    }
+}
+
+void LogFileParserTest::_gpsPathAPMDataFlashPOSTest()
+{
+    // Build a minimal DataFlash .bin with a POS message (format QLL).
+    // 'L' type: int32 stored, value = raw / 1e7 (degrees).
+    struct Sample { double lat; double lon; };
+    static const Sample samples[] = {
+        { -35.363261, 149.165230 },
+        { -35.363100, 149.165400 },
+        { -35.362900, 149.165600 },
+    };
+
+    QByteArray bytes;
+    // FMT for POS: type=155, length= 3(hdr)+8(Q)+4(L)+4(L)=19, name="POS", format="QLL"
+    appendBinMessage(bytes, 128, makeFmtPayloadStr(155, 19, "POS", "QLL", "TimeUS,Lat,Lng"));
+
+    uint64_t ts = 1000000ULL;
+    for (const auto &s : samples) {
+        appendBinMessage(bytes, 155, makePOSPayload(ts, s.lat, s.lon));
+        ts += 1000000ULL;
+    }
+
+    QTemporaryFile tmp;
+    tmp.setFileTemplate(QDir::tempPath() + QStringLiteral("/logtest_XXXXXX.bin"));
+    QVERIFY(writeTempFile(tmp, bytes));
+
+    LogFileParser parser;
+    QVERIFY(parser.parseFile(tmp.fileName()));
+    QVERIFY(parser.parsed());
+
+    const QVariantList path = parser.gpsPath();
+    QCOMPARE(path.size(), static_cast<int>(std::size(samples)));
+
+    for (int i = 0; i < path.size(); i++) {
+        const QVariantMap coord = path[i].toMap();
+        // 'L' precision is 1e-7 degrees; allow a small rounding tolerance
+        QVERIFY(qAbs(coord.value(QStringLiteral("latitude")).toDouble()  - samples[i].lat) < 1e-6);
+        QVERIFY(qAbs(coord.value(QStringLiteral("longitude")).toDouble() - samples[i].lon) < 1e-6);
+    }
+}
+
 UT_REGISTER_TEST(LogFileParserTest, TestLabel::Unit, TestLabel::AnalyzeView)

--- a/test/AnalyzeView/LogFileParserTest.h
+++ b/test/AnalyzeView/LogFileParserTest.h
@@ -15,4 +15,8 @@ private slots:
     void _parseULogInvalidFileTest();
     void _parseDataFlashRegressionTest();
     void _parseUnsupportedExtensionTest();
+    void _fieldSamplesFilteredComprehensiveTest();
+    void _gpsPathULogVehicleGlobalPositionTest();
+    void _gpsPathULogVehicleGpsPositionLatDegTest();
+    void _gpsPathAPMDataFlashPOSTest();
 };


### PR DESCRIPTION
## Summary

Extends the Log Viewer with a GPS flight path map, a full Parameters tab, performance improvements, and several bug fixes.

## New features

### Map tab
- Displays GPS flight path overlaid on a `FlightMap` for both PX4 ULog and APM DataFlash logs
- APM DataFlash: uses `GPS.Lat`/`GPS.Lng` with `Status >= 3` filter (3D fix required) as primary source; falls back to `POS.Lat`/`POS.Lng` (EKF-fused)
- PX4 ULog: uses `vehicle_global_position.lat`/`lon`, falling back through `vehicle_gps_position` / `sensor_gps` field name variants
- Altitude mini-chart (`LogViewerAltChart`) below the map with zoom and a min/max popup
- Clicking or dragging the altitude chart moves a yellow position dot on the map
- Cursor is linked between the altitude chart and the main Charting tab

### Parameters tab
- "Changed only" toggle (hides parameters matching their system default)
- Search over name, value, and short description
- Per-row: value formatted with units and decimal places from FactMetaData; enum values shown as label + number
- Orange indicator dot for parameters that differ from their system default
- Default value shown alongside for changed parameters

### Messages tab
- Timestamped rows with alternating background

## Performance improvements

- `LogFileParser::fieldSamplesFiltered()`: bucketed min/max downsampling — one pixel column per bucket, up to 4 representative points per bucket (first, min-y, max-y, last), returned in time order
- `LogFileParser::fieldMinMax()`: compute full-dataset min/max in C++ and return a two-value map, eliminating the need to marshal all `QPointF` samples across the C++/QML bridge just to find the range
- `LogViewerChart` and `LogViewerAltChart` both updated to use `fieldMinMax()` and `fieldSamplesFiltered()`

## Bug fixes

- `ULogFullHandler`: `qFuzzyCompare(0.0, 0.0)` returns `false` (Qt documented limitation — relative epsilon is undefined at zero); replaced with exact equality check for the zero case
- `LogViewerPage`: scroll position of the field list is now preserved when a field is toggled on/off
- `LogViewerController`: removed unused `statusText` property

## New files

| File | Purpose |
|------|---------|
| `LogViewerAltChart.qml` | Altitude mini-chart with zoom, cursor, and min/max popup |
| `LogViewerParamMetaData.cc/.h` | Enriches parameter rows from bundled PX4/APM FactMetaData JSON |

## Tests added

- `_fieldSamplesFilteredComprehensiveTest`: 500-sample synthetic dataset; verifies bucketing output count and landmark preservation under full-range, passthrough, zoom, and out-of-range conditions
- `_gpsPathULogVehicleGlobalPositionTest`
- `_gpsPathULogVehicleGpsPositionLatDegTest`
- `_gpsPathAPMDataFlashPOSTest`
