### PR TITLE
VideoManager: Remove unused/incorrect override

### DIFF
--- a/src/VideoManager/VideoReceiver/GStreamer/HwBuffers/GstDmaBufVideoBuffer.h
+++ b/src/VideoManager/VideoReceiver/GStreamer/HwBuffers/GstDmaBufVideoBuffer.h
@@ -24,7 +24,6 @@ public:
                          EGLDisplay eglDisplay);
 
     MapData map(QVideoFrame::MapMode mode) override;
-    bool isDmaBuf() const override { return true; }
 
     ~GstDmaBufVideoBuffer() override;
 


### PR DESCRIPTION
## Description
Fixes a compilation error on Ubuntu 22 introduced by https://github.com/mavlink/qgroundcontrol/pull/14332.
This function is not used in the codebase, so it can just be removed.

```
/home/ryan/Dev/qgroundcontrol/src/VideoManager/VideoReceiver/GStreamer/HwBuffers/GstDmaBufVideoBuffer.h:27:10: error: ‘bool GstDmaBufVideoBuffer::isDmaBuf() const’ marked ‘override’, but does not override
   27 |     bool isDmaBuf() const override { return true; }
```
   
   


## Type of Change
<!-- Put an 'x' in the relevant boxes -->
- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] CI/Build changes
- [ ] Other

## Testing
<!-- Describe the tests you ran and how to reproduce them -->
- [x] Tested locally
- [ ] Added/updated unit tests
- [ ] Tested with simulator (SITL)
- [ ] Tested with hardware

### Platforms Tested
<!-- Check all that apply -->
- [x] Linux
- [ ] Windows
- [ ] macOS
- [ ] Android
- [ ] iOS

### Flight Stacks Tested
<!-- If applicable -->
- [ ] PX4
- [ ] ArduPilot

## Screenshots
<!-- If applicable, add screenshots to help explain your changes -->

## Checklist
<!-- Go over all the following points, and put an 'x' in all the boxes that apply -->
- [x] I have read the [Contribution Guidelines](CONTRIBUTING.md)
- [x] I have read the [Code of Conduct](CODE_OF_CONDUCT.md)
- [x] My code follows the project's coding standards
- [ ] I have added tests that prove my fix/feature works
- [x] New and existing unit tests pass locally

## Related Issues
<!-- Link any related issues using #issue_number -->

---
By submitting this pull request, I confirm that my contribution is made under the terms of the project's dual license (Apache 2.0 and GPL v3).
