### PR TITLE
Bump to 6.10.1 minimum

### DIFF
--- a/.github/build-config.json
+++ b/.github/build-config.json
@@ -18,7 +18,7 @@
   "ndk_full_version": "27.2.12479018",
   "platform_workflows": "Linux,Windows,MacOS,Android",
   "ndk_version": "r27c",
-  "qt_minimum_version": "6.10.0",
+  "qt_minimum_version": "6.10.1",
   "qt_modules": "qtgraphs qtlocation qtpositioning qtspeech qtmultimedia qtserialport qtimageformats qtshadertools qtconnectivity qtquick3d qtsensors qtscxml qtwebsockets qthttpserver",
   "qt_version": "6.10.3",
   "vulkan_sdk_version": "1.4.304.1",

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -68,15 +68,12 @@ jobs:
             arch: win64_msvc2022_arm64
             package: QGroundControl-installer-ARM64
 
-          # TODO: Remove qt_version override once aqtinstall supports Qt 6.10.1+ for cross-compiled ARM64
-          # Workaround: Pin to Qt 6.10.0 until aqtinstall fix is released
-          # Tracking: https://github.com/miurahr/aqtinstall/pull/952
           - variant: arm64-cross
             os: windows-2022
             host: windows
             arch: win64_msvc2022_arm64_cross_compiled
             package: QGroundControl-installer-AMD64-ARM64
-            qt_version: '6.10.0'
+            qt_version: '6.10.1'
 
     defaults:
       run:


### PR DESCRIPTION
## Description

* 6.10.0 does not compile anymore due to ABI breaks  in QVideoTextureHelper (private header).
* QGC documentations says only to use 6.10.1, so let's fail at configure time if you have 6.10.0, which used to be recommended.

## Type of Change
<!-- Put an 'x' in the relevant boxes -->
- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)
- [x] CI/Build changes
- [ ] Other

## Testing
<!-- Describe the tests you ran and how to reproduce them -->
- [x] Tested locally
- [ ] Added/updated unit tests
- [ ] Tested with simulator (SITL)
- [ ] Tested with hardware

### Platforms Tested
<!-- Check all that apply -->
- [x] Linux
- [ ] Windows
- [ ] macOS
- [ ] Android
- [ ] iOS

### Flight Stacks Tested
<!-- If applicable -->
- [ ] PX4
- [ ] ArduPilot

## Screenshots
<!-- If applicable, add screenshots to help explain your changes -->

## Checklist
<!-- Go over all the following points, and put an 'x' in all the boxes that apply -->
- [ ] I have read the [Contribution Guidelines](CONTRIBUTING.md)
- [ ] I have read the [Code of Conduct](CODE_OF_CONDUCT.md)
- [ ] My code follows the project's coding standards
- [ ] I have added tests that prove my fix/feature works
- [ ] New and existing unit tests pass locally

## Related Issues
<!-- Link any related issues using #issue_number -->

---
By submitting this pull request, I confirm that my contribution is made under the terms of the project's dual license (Apache 2.0 and GPL v3).
