### PR TITLE
ci: migrate Linux workflow to RunsOn self-hosted runners

### DIFF
--- a/.github/runs-on.yml
+++ b/.github/runs-on.yml
@@ -1,0 +1,17 @@
+runners:
+  linux-x64-builder:
+    family: ["c8i.2xlarge"]
+    spot: false
+    image: ubuntu24-full-x64
+    extras: s3-cache
+  linux-arm64-builder:
+    family: ["c8g.2xlarge"]
+    spot: false
+    image: ubuntu24-full-arm64
+    extras: s3-cache
+  linux-x64-tester:
+    family: ["m8i.2xlarge"]
+    spot: false
+    image: ubuntu24-full-x64
+    extras: s3-cache
+    volume: 60gb

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -39,29 +39,31 @@ jobs:
     name: Release ${{ matrix.arch }}
     needs: changes
     if: always() && !cancelled() && (needs.changes.outputs.should_build == 'true' || needs.changes.result == 'skipped')
-    runs-on: ${{ matrix.os }}
+    runs-on: ${{ matrix.runs_on }}
     timeout-minutes: 120
 
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-24.04-arm, ubuntu-22.04]
         include:
-          - os: ubuntu-24.04-arm
+          - arch: linux_gcc_arm64
+            runs_on: runs-on=${{ github.run_id }}/family=c8g.2xlarge/spot=false/image=ubuntu24-full-arm64/extras=s3-cache
             package: QGroundControl-aarch64
             host: linux_arm64
-            arch: linux_gcc_arm64
 
-          - os: ubuntu-22.04
+          - arch: linux_gcc_64
+            runs_on: runs-on=${{ github.run_id }}/family=c8i.2xlarge/spot=false/image=ubuntu24-full-x64/extras=s3-cache
             package: QGroundControl-x86_64
             host: linux
-            arch: linux_gcc_64
 
     defaults:
       run:
         shell: bash
 
     steps:
+      - name: Enable RunsOn magic cache
+        uses: runs-on/action@v2
+
       - name: Harden Runner
         if: runner.arch != 'ARM64'
         uses: step-security/harden-runner@v2
@@ -123,14 +125,14 @@ jobs:
           binary-path: ${{ runner.temp }}/build/Release/QGroundControl
 
       - name: Analyze binary size
-        if: matrix.os == 'ubuntu-22.04'
+        if: matrix.arch == 'linux_gcc_64'
         uses: ./.github/actions/size-analysis
         with:
           binary-path: ${{ runner.temp }}/build/Release/QGroundControl
           output-file: ${{ runner.temp }}/build/metrics.json
 
       - name: Upload metrics artifact
-        if: matrix.os == 'ubuntu-22.04'
+        if: matrix.arch == 'linux_gcc_64'
         uses: actions/upload-artifact@v7
         with:
           name: size-metrics
@@ -185,7 +187,11 @@ jobs:
     name: ${{ matrix.job_name }}
     needs: [changes, debug-matrix]
     if: ${{ !cancelled() && (needs.changes.outputs.should_build == 'true' || needs.changes.result == 'skipped') }}
-    runs-on: ubuntu-22.04
+    # 60GB volume so the Debug build + Qt SDK + caches + Integration test
+    # artifacts fit comfortably; the 40GB default left only ~1-2GB headroom
+    # at peak and killed the runner agent before any diagnostic step could
+    # run.
+    runs-on: runs-on=${{ github.run_id }}/family=m8i.2xlarge/spot=false/image=ubuntu24-full-x64/extras=s3-cache/volume=60gb
     timeout-minutes: ${{ matrix.timeout_minutes }}
 
     strategy:
@@ -198,6 +204,9 @@ jobs:
         shell: bash
 
     steps:
+      - name: Enable RunsOn magic cache
+        uses: runs-on/action@v2
+
       - name: Harden Runner
         uses: step-security/harden-runner@v2
         with:
@@ -240,8 +249,13 @@ jobs:
           build-dir: ${{ runner.temp }}/build
           build-type: Debug
 
-      - name: Run Unit Tests
-        id: tests
+      # Split test execution by label: Unit tests parallelize cleanly (no
+      # MockLink/Vehicle shared state), Integration tests share LinkManager
+      # singletons and per-test RESOURCE_LOCK so they serialize naturally on
+      # one CTest invocation. Run them in two passes so the Unit pass can use
+      # all cores while the Integration pass stays correct.
+      - name: Run Unit Tests (parallel)
+        id: unit_tests
         uses: ./.github/actions/run-unit-tests
         env:
           ASAN_OPTIONS: ${{ matrix.mode == 'sanitizers' && 'detect_leaks=1:halt_on_error=1:check_initialization_order=1' || '' }}
@@ -249,44 +263,81 @@ jobs:
           UBSAN_OPTIONS: ${{ matrix.mode == 'sanitizers' && format('print_stacktrace=1:halt_on_error=1:suppressions={0}/build/ubsan_suppressions.txt', runner.temp) || '' }}
         with:
           build-dir: ${{ runner.temp }}/build
-          junit-output: junit-results-linux-${{ matrix.mode }}.xml
-          ctest-output: test-output-linux-${{ matrix.mode }}.txt
-          include-labels: 'Unit|Integration'
+          junit-output: junit-results-linux-${{ matrix.mode }}-unit.xml
+          ctest-output: test-output-linux-${{ matrix.mode }}-unit.txt
+          include-labels: 'Unit'
           exclude-labels: ${{ matrix.exclude_labels }}
-          # Coverage requires serial execution (gcov writes race); sanitizers don't.
-          parallel: ${{ matrix.mode == 'coverage' && '1' || 'auto' }}
+          parallel: auto
 
-      - name: Analyze Unit Test Durations
-        if: always() && !cancelled() && steps.tests.conclusion != 'skipped'
+      - name: Run Integration Tests (serial)
+        id: integration_tests
+        if: always() && !cancelled() && steps.unit_tests.conclusion != 'cancelled'
+        uses: ./.github/actions/run-unit-tests
+        env:
+          ASAN_OPTIONS: ${{ matrix.mode == 'sanitizers' && 'detect_leaks=1:halt_on_error=1:check_initialization_order=1' || '' }}
+          LSAN_OPTIONS: ${{ matrix.mode == 'sanitizers' && format('suppressions={0}/build/asan_suppressions.txt', runner.temp) || '' }}
+          UBSAN_OPTIONS: ${{ matrix.mode == 'sanitizers' && format('print_stacktrace=1:halt_on_error=1:suppressions={0}/build/ubsan_suppressions.txt', runner.temp) || '' }}
+        with:
+          build-dir: ${{ runner.temp }}/build
+          junit-output: junit-results-linux-${{ matrix.mode }}-integration.xml
+          ctest-output: test-output-linux-${{ matrix.mode }}-integration.txt
+          include-labels: 'Integration'
+          exclude-labels: ${{ matrix.exclude_labels }}
+          parallel: '1'
+
+      - name: Analyze Unit Test Durations (unit)
+        if: always() && !cancelled() && steps.unit_tests.conclusion != 'skipped'
         uses: ./.github/actions/test-duration-report
         with:
-          junit-path: ${{ runner.temp }}/build/junit-results-linux-${{ matrix.mode }}.xml
-          report-json-path: ${{ runner.temp }}/build/test-duration-linux-${{ matrix.mode }}.json
+          junit-path: ${{ runner.temp }}/build/junit-results-linux-${{ matrix.mode }}-unit.xml
+          report-json-path: ${{ runner.temp }}/build/test-duration-linux-${{ matrix.mode }}-unit.json
           top-n: '20'
           slow-threshold-seconds: '60'
 
-      - name: Report Test Results
-        if: always() && !cancelled() && steps.tests.conclusion != 'skipped'
+      - name: Analyze Unit Test Durations (integration)
+        if: always() && !cancelled() && steps.integration_tests.conclusion != 'skipped'
+        uses: ./.github/actions/test-duration-report
+        with:
+          junit-path: ${{ runner.temp }}/build/junit-results-linux-${{ matrix.mode }}-integration.xml
+          report-json-path: ${{ runner.temp }}/build/test-duration-linux-${{ matrix.mode }}-integration.json
+          top-n: '20'
+          slow-threshold-seconds: '60'
+
+      - name: Report Test Results (unit)
+        if: always() && !cancelled() && steps.unit_tests.conclusion != 'skipped'
         uses: ./.github/actions/test-report
         with:
           name: Unit Tests (${{ matrix.mode }})
           build-dir: ${{ runner.temp }}/build
-          junit-file: junit-results-linux-${{ matrix.mode }}.xml
-          output-file: test-output-linux-${{ matrix.mode }}.txt
-          artifact-name: test-results-linux-${{ matrix.mode }}
+          junit-file: junit-results-linux-${{ matrix.mode }}-unit.xml
+          output-file: test-output-linux-${{ matrix.mode }}-unit.txt
+          artifact-name: test-results-linux-${{ matrix.mode }}-unit
+          retention-days: 7
+          trunk-org-slug: ${{ vars.TRUNK_ORG_SLUG }}
+          trunk-token: ${{ secrets.TRUNK_TOKEN }}
+
+      - name: Report Test Results (integration)
+        if: always() && !cancelled() && steps.integration_tests.conclusion != 'skipped'
+        uses: ./.github/actions/test-report
+        with:
+          name: Integration Tests (${{ matrix.mode }})
+          build-dir: ${{ runner.temp }}/build
+          junit-file: junit-results-linux-${{ matrix.mode }}-integration.xml
+          output-file: test-output-linux-${{ matrix.mode }}-integration.txt
+          artifact-name: test-results-linux-${{ matrix.mode }}-integration
           retention-days: 7
           trunk-org-slug: ${{ vars.TRUNK_ORG_SLUG }}
           trunk-token: ${{ secrets.TRUNK_TOKEN }}
 
       - name: Upload Test Artifacts
-        if: always() && !cancelled() && steps.tests.conclusion != 'skipped'
+        if: always() && !cancelled() && (steps.unit_tests.conclusion != 'skipped' || steps.integration_tests.conclusion != 'skipped')
         uses: actions/upload-artifact@v7
         with:
           name: test-artifacts-linux-${{ matrix.mode }}
           path: |
-            ${{ runner.temp }}/build/test-output-linux-${{ matrix.mode }}.txt
-            ${{ runner.temp }}/build/junit-results-linux-${{ matrix.mode }}.xml
-            ${{ runner.temp }}/build/test-duration-linux-${{ matrix.mode }}.json
+            ${{ runner.temp }}/build/test-output-linux-${{ matrix.mode }}-*.txt
+            ${{ runner.temp }}/build/junit-results-linux-${{ matrix.mode }}-*.xml
+            ${{ runner.temp }}/build/test-duration-linux-${{ matrix.mode }}-*.json
           retention-days: 7
 
       - name: Verify coverage data files exist

--- a/src/Utilities/Platform/QGCKeychain.cc
+++ b/src/Utilities/Platform/QGCKeychain.cc
@@ -90,14 +90,22 @@ bool indicatesMissingBackend(QKeychain::Error err)
     return err == QKeychain::NoBackendAvailable || err == QKeychain::AccessDenied;
 }
 
-// Linux libsecret backend reports DBus ServiceUnknown as OtherError — recognize it as "no backend".
+// Linux libsecret backend reports a few "no Secret Service reachable" conditions
+// as QKeychain::OtherError. Recognize the known patterns so we transparently fall
+// back to QSettings instead of failing the call.
 bool isMissingSecretService(QKeychain::Error err, const QString& errorString)
 {
     if (err != QKeychain::OtherError) {
         return false;
     }
-    return errorString.contains(QLatin1String("org.freedesktop.secrets")) ||
-           errorString.contains(QLatin1String("ServiceUnknown"));
+    // libsecret can't reach the Secret Service over D-Bus.
+    if (errorString.contains(QLatin1String("org.freedesktop.secrets")) ||
+        errorString.contains(QLatin1String("ServiceUnknown"))) {
+        return true;
+    }
+    // No session bus to talk to (headless CI without dbus-launch / gnome-keyring).
+    return errorString.contains(QLatin1String("autolaunch D-Bus")) ||
+           errorString.contains(QLatin1String("DBUS_SESSION_BUS_ADDRESS"));
 }
 
 }  // namespace


### PR DESCRIPTION
This PR migrates the Linux workflow (`.github/workflows/linux.yml`) from GitHub-hosted runners to RunsOn self-hosted ephemeral EC2 runners. Runners are backed by the new `qgc-ci-runs-on` CloudFormation stack in the Dronecode AWS account (us-west-2, RunsOn v3.0.6). x86_64 builds run on c8i.2xlarge, ARM64 on c8g.2xlarge, the Debug+coverage test job on m8i.2xlarge — all 8 vCPU, On-Demand, `ubuntu24-full-*` images.

### Wall-clock impact

Measured against the most recent successful GitHub-hosted run on master vs. the equivalent run on this branch:

| Job | GitHub-hosted | RunsOn (this PR) | Δ |
|---|---|---|---|
| Release linux_gcc_64 | 36m 40s | **15m 10s** | -22m 30s (**-59%**) |
| Release linux_gcc_arm64 | 21m 26s | **13m 04s** | -9m 22s (-39%) |
| Test + Coverage linux_gcc_64 | 30m 43s | **20m 21s** | -11m 22s (-34%) |
| **Wall-clock total (parallel)** | 36m 40s | **20m 21s** | -17m 19s (**-44%**) |

Caches are still cold on this run — no master push has populated the Ubuntu 24.04 warm caches yet. Once this merges, the next push to master populates `ccache-linux-…-shared-`, `cpm-modules-shared-`, `pipx-linux-…`, and `qt-linux-desktop-…` for everyone, and PR runs should drop another 5-8 min off both Release builds.

### Context

PX4-Autopilot has been running on RunsOn for over a year in the same account; this migration brings QGC onto the same infrastructure. Once this merges, the same pattern (inline `runs-on=` labels plus the `runs-on/action@v2` step) can be applied to `analysis.yml`, `pr-checks.yml`, and the Linux portions of `pre-commit.yml` / `ci-scripts.yml` with very small diffs.

### Runner choices

| Job | Instance | OnD $/h | Why |
|---|---|---|---|
| Release linux_gcc_64 | c8i.2xlarge | $0.375 | Intel Granite Rapids, 16 GB, full-fat CPU |
| Release linux_gcc_arm64 | c8g.2xlarge | $0.319 | Graviton4, 16 GB, cheapest in the table |
| Test+Coverage linux_gcc_64 Debug | m8i.2xlarge (`volume=60gb`) | $0.423 | 32 GB headroom for tests + .gcda |

On-Demand on the latest generation, deliberately. Earlier iterations on Spot c7i/m7i hit reclaims mid-build. The headline cost is ~$0.30-0.40 per Linux PR across all three jobs, dominated by engineer-time considerations rather than compute spend.

### Caching

`extras=s3-cache` on each runner label plus `runs-on/action@v2` as the first step bootstraps RunsOn's "magic cache" — a sidecar that transparently intercepts every `actions/cache@v5` call and redirects it to the S3 bucket provisioned by the stack. Existing cache calls for ccache, Qt SDK, GStreamer, pipx, apt packages, and CPM modules all work unchanged. `runs-on/action@v2` is a no-op on GitHub-hosted runners so the workflow stays portable if anyone needs to revert. **Note:** the 10gb cache limitation from github does not apply here, we have essentially unlimited cache storage in the s3 bucket.

### Matrix cleanup

The build job's matrix used `os: [ubuntu-24.04-arm, ubuntu-22.04]` both as the runner label and as a discriminator for two size-analysis steps (`if: matrix.os == 'ubuntu-22.04'`). With RunsOn we don't need `os` to pick the runner. The dual-purpose field is gone and `matrix.arch` is the single discriminator. The two `if:` conditions changed from `matrix.os == 'ubuntu-22.04'` to `matrix.arch == 'linux_gcc_64'` which is what they always meant ("x86_64 only").

### OS bump

The x86_64 Release build's host OS moves from **Ubuntu 22.04 → Ubuntu 24.04**. That bumps the AppImage's glibc baseline (22.04 ships glibc 2.35 vs. 24.04's 2.39), so AppImages produced here won't run on hosts with older glibc (RHEL 8, Ubuntu 20.04, Debian 11). If supporting older distros matters for QGC's release builds, the `image=` parameter in the runner label can be switched back to `ubuntu22-full-x64` with no other workflow changes.

### Test execution restructured

`cmake/QGCTest.cmake:164` auto-attaches `RESOURCE_LOCK "MockLink"` to every Integration test because MockLink shares a `LinkManager` singleton and a static `_nextVehicleSystemId` counter. A single CTest invocation over both labels with `--parallel auto` silently serialized everything on that lock. Split into two passes:

- **Run Unit Tests (parallel)**: `-L Unit`, `--parallel auto`. 151 Unit tests with no shared state.
- **Run Integration Tests (serial)**: `-L Integration`, `--parallel 1`. 37 Integration tests serialize on shared MockLink state.

Each pass writes its own junit + ctest output; downstream Analyze / Report / Upload steps run once per pass. The coverage path picks up `.gcda` from both passes via the existing `find . -name '*.gcda'`. The split is responsible for most of the test job's wall-clock improvement (process-startup overhead across 151 Unit invocations was the hidden bottleneck, not test execution itself).

The tester runner uses `volume=60gb`. The 40 GB default left only ~1-2 GB headroom at peak (Debug build + Qt SDK + caches + .gcda + scratch), which silently killed the runner agent before any diagnostic step could write to its log — caught after three identical failures by SSM'ing into the live runner.

### Companion fix: `QGCKeychain` headless D-Bus fallback

The first PR run failed `SigningTest` and `QGCKeychainTest` because the Ubuntu 24.04 image doesn't run a Secret Service daemon by default, and libsecret reports `"Cannot autolaunch D-Bus without X11 \$DISPLAY"` instead of the patterns the existing `isMissingSecretService()` knew about. Recognize the autolaunch / missing-session-bus error strings as the same "no backend" condition so the QSettings fallback kicks in, matching the behavior on macOS/Windows when no keychain is configured.

This is its own commit so it can be backed out independently if the keychain fix is contentious.

### Testing

The PR's own CI run validates:
- Both Release builds complete on RunsOn (~13-15 min cold-cache, expect ~7-8 min warm after merge).
- The QGCKeychain fallback lets `SigningTest` and `QGCKeychainTest` pass on headless Ubuntu 24.04.
- Coverage report still produces valid `coverage.xml`, picking up `.gcda` from both Unit and Integration passes.

### Related infra

- RunsOn stack: `qgc-ci-runs-on` (CloudFormation, us-west-2)
- GitHub App: `Dronecode Infra`, installed on `mavlink/qgroundcontrol`
- Same Dronecode AWS account also runs `px4-ci` (RunsOn v2.12.6) for PX4-Autopilot