### PR TITLE
Remove bug label from issue template in favor of issue type

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,6 +1,5 @@
 name: Bug report
 description: Create a report to help us improve
-labels: ["bug"]
 type: bug
 
 body:


### PR DESCRIPTION
Remove the `labels: ["bug"]` from the bug report issue template since the `type: bug` field provides the same categorization through GitHub's newer issue types system.

This avoids redundant tagging—the issue type alone is sufficient for filtering and organization.
