### PR TITLE
ArduSub: Enable negative thrust and center-zero throttle mode

### DIFF
--- a/src/FirmwarePlugin/APM/ArduSubFirmwarePlugin.h
+++ b/src/FirmwarePlugin/APM/ArduSubFirmwarePlugin.h
@@ -81,7 +81,8 @@ public:
     int defaultJoystickTXMode() const override { return 3; }
     void initializeStreamRates(Vehicle *vehicle) override;
     bool isCapable(const Vehicle *vehicle, FirmwareCapabilities capabilities) const override;
-    bool supportsThrottleModeCenterZero() const override { return false; }
+    bool supportsThrottleModeCenterZero() const override { return true; }
+    bool supportsNegativeThrust(Vehicle *vehicle) const override { Q_UNUSED(vehicle); return true; }
     bool supportsRadio() const override { return false; }
     bool supportsJSButton() const override { return true; }
     bool supportsMotorInterference() const override { return false; }


### PR DESCRIPTION
Related to #10560

Enable negative thrust and center-zero throttle mode for ArduSub.

Previously `supportsThrottleModeCenterZero()` returned `false` and `supportsNegativeThrust()` used the base class default of `false`, which meant joystick throttle was mapped to [0, 1.0] only. This prevented commanding downward thrust for diving.

Now:
- `supportsThrottleModeCenterZero()` returns `true` — joystick center = zero vertical thrust
- `supportsNegativeThrust()` returns `true` — full [-1.0, 1.0] range is sent via MANUAL_CONTROL z-axis
