### PR TITLE
Doxygen: fix QML macro preprocessing and standardize class doc comments

### DIFF
--- a/Doxyfile
+++ b/Doxyfile
@@ -59,7 +59,17 @@ INTERACTIVE_SVG        = YES
 ENABLE_PREPROCESSING   = YES
 MACRO_EXPANSION        = YES
 EXPAND_ONLY_PREDEF     = NO
-PREDEFINED             = Q_OBJECT Q_PROPERTY Q_INVOKABLE Q_SIGNAL Q_SLOT
+PREDEFINED             = Q_OBJECT Q_PROPERTY Q_INVOKABLE Q_SIGNAL Q_SLOT \
+                         QML_ELEMENT \
+                         QML_ANONYMOUS \
+                         QML_INTERFACE \
+                         QML_SINGLETON \
+                         "QML_UNCREATABLE(x)=" \
+                         "QML_NAMED_ELEMENT(x)=" \
+                         "QML_EXTENDED(x)=" \
+                         "QML_ATTACHED(x)=" \
+                         "QML_ADDED_IN_VERSION(x,y)=" \
+                         "Q_MOC_INCLUDE(x)="
 
 # Warnings
 QUIET                  = NO

--- a/src/ADSB/ADSBTCPLink.h
+++ b/src/ADSB/ADSBTCPLink.h
@@ -8,8 +8,10 @@
 class QTcpSocket;
 class QTimer;
 
-/// The ADSBTCPLink class handles the TCP connection to an ADS-B server
+/// \brief The ADSBTCPLink class handles the TCP connection to an ADS-B server
+///
 /// and processes incoming ADS-B data.
+///
 class ADSBTCPLink : public QObject
 {
     Q_OBJECT

--- a/src/API/QGCCorePlugin.h
+++ b/src/API/QGCCorePlugin.h
@@ -22,6 +22,16 @@ class VideoSink;
 class FactValueGrid;
 typedef struct __mavlink_message mavlink_message_t;
 
+/// \brief Extension mechanism for generic, non-firmware-specific customization of QGC.
+///
+/// QGCCorePlugin is the extension point for custom builds that need to modify QGC
+/// as a whole, rather than for behavior that varies by firmware type (which belongs
+/// in FirmwarePlugin). Override its virtual methods to add or replace UI pages,
+/// Flight Map items, toolbar indicators, video pipeline components, plan file
+/// hooks, and other application-level behavior. The base class provides the
+/// standard QGC implementation; custom builds subclass it and register the
+/// subclass before \c QGCApplication starts up.
+///
 class QGCCorePlugin : public QObject
 {
     Q_OBJECT

--- a/src/API/QmlComponentInfo.h
+++ b/src/API/QmlComponentInfo.h
@@ -3,7 +3,8 @@
 #include <QtCore/QObject>
 #include <QtCore/QUrl>
 
-/// Represents a Qml component which can be loaded from a resource.
+/// \brief Represents a Qml component which can be loaded from a resource.
+///
 class QmlComponentInfo : public QObject
 {
     Q_OBJECT

--- a/src/AnalyzeView/GeoTag/GeoTagController.h
+++ b/src/AnalyzeView/GeoTag/GeoTagController.h
@@ -41,8 +41,10 @@ CalibrationResult calibrate(const QList<qint64> &imageTimestamps,
 
 } // namespace GeoTagCalibrator
 
-/// Controller for GeoTagPage.qml. Supports geotagging images based on logfile camera tags.
+/// \brief Controller for GeoTagPage.qml. Supports geotagging images based on logfile camera tags.
+///
 /// Uses async signal-based processing with QFutureWatcher for non-blocking operation.
+///
 class GeoTagController : public QObject
 {
     Q_OBJECT

--- a/src/AnalyzeView/GeoTag/GeoTagImageModel.h
+++ b/src/AnalyzeView/GeoTag/GeoTagImageModel.h
@@ -4,7 +4,8 @@
 #include <QtPositioning/QGeoCoordinate>
 #include <QtQmlIntegration/QtQmlIntegration>
 
-/// Model for displaying geotagging image status in QML
+/// \brief Model for displaying geotagging image status in QML
+///
 class GeoTagImageModel : public QAbstractListModel
 {
     Q_OBJECT

--- a/src/AnalyzeView/LogViewer/LogFileParser.h
+++ b/src/AnalyzeView/LogViewer/LogFileParser.h
@@ -11,7 +11,7 @@
 #include <QtCore/QtGlobal>
 #include <QtQmlIntegration/QtQmlIntegration>
 
-/// Unified log file parser for both DataFlash (.bin/.log) and PX4 ULog (.ulg) files.
+/// \brief Unified log file parser for both DataFlash (.bin/.log) and PX4 ULog (.ulg) files.
 ///
 /// Dispatches by file extension, verifies the header magic bytes match the expected
 /// format, then parses the file into a canonical set of properties that the log
@@ -24,6 +24,7 @@
 ///  - parameters — parameter name/value pairs from the log
 ///  - messages — free-text log messages
 ///  - dropouts — (ULog only) data-dropout intervals rendered as chart overlays
+///
 class LogFileParser : public QObject
 {
     Q_OBJECT

--- a/src/AnalyzeView/LogViewer/LogViewerParamMetaData.h
+++ b/src/AnalyzeView/LogViewer/LogViewerParamMetaData.h
@@ -3,7 +3,8 @@
 #include <QtCore/QString>
 #include <QtCore/QVariantList>
 
-/// Helper that enriches parameter rows with metadata from the bundled
+/// \brief Helper that enriches parameter rows with metadata from the bundled
+///
 /// PX4 / APM FactMetaData JSON files. Each row in @a parameters is a
 /// QVariantMap; on return the following keys are added (or left absent if
 /// no metadata was found for that parameter):
@@ -12,6 +13,7 @@
 ///   shortDescription QString — one-line summary
 ///   enumStrings    QStringList — ordered enum labels  (empty if not an enum)
 ///   enumValues     QVariantList — corresponding numeric values (parallel array)
+///
 class LogViewerParamMetaData
 {
 public:

--- a/src/AnalyzeView/LogViewer/PX4ULog/ULogFullHandler.h
+++ b/src/AnalyzeView/LogViewer/PX4ULog/ULogFullHandler.h
@@ -15,10 +15,12 @@
 
 struct LogParseResult;
 
-/// Full-scan ULog DataHandlerInterface implementation.
+/// \brief Full-scan ULog DataHandlerInterface implementation.
+///
 /// Streams through a ULog file in a single pass, collecting signal samples,
 /// parameters, log messages, events, and dropouts into a LogParseResult.
 /// Call finalize() after parsing to build mode segments and sort signal lists.
+///
 class ULogFullHandler final : public ulog_cpp::DataHandlerInterface
 {
 public:

--- a/src/AnalyzeView/MAVLinkInspector/MAVLinkInspectorController.h
+++ b/src/AnalyzeView/MAVLinkInspector/MAVLinkInspectorController.h
@@ -13,7 +13,8 @@ class QmlObjectListModel;
 class QTimer;
 class Vehicle;
 
-/// MAVLink message inspector controller (provides the logic for UI display)
+/// \brief MAVLink message inspector controller (provides the logic for UI display)
+///
 class MAVLinkInspectorController : public QObject
 {
     Q_OBJECT

--- a/src/AutoPilotPlugins/APM/APMAirframeComponentController.h
+++ b/src/AutoPilotPlugins/APM/APMAirframeComponentController.h
@@ -10,7 +10,8 @@ class APMAirframeModel;
 class APMAirframeType;
 class QmlObjectListModel;
 
-/// MVC Controller for APMAirframeComponent.qml.
+/// \brief MVC Controller for APMAirframeComponent.qml.
+///
 class APMAirframeComponentController : public FactPanelController
 {
     Q_OBJECT

--- a/src/AutoPilotPlugins/APM/APMAutoPilotPlugin.h
+++ b/src/AutoPilotPlugins/APM/APMAutoPilotPlugin.h
@@ -27,7 +27,8 @@ class JoystickComponent;
 class ScriptingComponent;
 class Vehicle;
 
-/// This is the AutoPilotPlugin implementation for the MAV_AUTOPILOT_ARDUPILOT type.
+/// \brief This is the AutoPilotPlugin implementation for the MAV_AUTOPILOT_ARDUPILOT type.
+///
 class APMAutoPilotPlugin : public AutoPilotPlugin
 {
     Q_OBJECT

--- a/src/AutoPilotPlugins/APM/APMFlightModesComponentController.h
+++ b/src/AutoPilotPlugins/APM/APMFlightModesComponentController.h
@@ -7,7 +7,8 @@
 #include "FactPanelController.h"
 #include "QGCMAVLinkTypes.h"
 
-/// MVC Controller for FlightModesComponent.qml.
+/// \brief MVC Controller for FlightModesComponent.qml.
+///
 class APMFlightModesComponentController : public FactPanelController
 {
     Q_OBJECT

--- a/src/AutoPilotPlugins/APM/APMSensorsComponentController.h
+++ b/src/AutoPilotPlugins/APM/APMSensorsComponentController.h
@@ -11,7 +11,8 @@
 class APMSensorsComponent;
 class LinkInterface;
 
-/// Sensors Component MVC Controller for SensorsComponent.qml.
+/// \brief Sensors Component MVC Controller for SensorsComponent.qml.
+///
 class APMSensorsComponentController : public FactPanelController
 {
     Q_OBJECT

--- a/src/AutoPilotPlugins/APM/APMSubMotorComponentController.h
+++ b/src/AutoPilotPlugins/APM/APMSubMotorComponentController.h
@@ -4,7 +4,8 @@
 
 #include "FactPanelController.h"
 
-/// MVC Controller for APMSubMotorComponent.qml.
+/// \brief MVC Controller for APMSubMotorComponent.qml.
+///
 class APMSubMotorComponentController : public FactPanelController
 {
     Q_OBJECT

--- a/src/AutoPilotPlugins/AutoPilotPlugin.h
+++ b/src/AutoPilotPlugins/AutoPilotPlugin.h
@@ -9,10 +9,12 @@ class FirmwarePlugin;
 class Vehicle;
 class VehicleComponent;
 
-/// The AutoPilotPlugin class is an abstract base class which represent the methods and objects
+/// \brief The AutoPilotPlugin class is an abstract base class which represent the methods and objects
+///
 /// which are specific to a certain AutoPilot. This is the only place where AutoPilot specific
 /// code should reside in QGroundControl. The remainder of the QGroundControl source is
 /// generic to a common mavlink implementation.
+///
 class AutoPilotPlugin : public QObject
 {
     Q_OBJECT

--- a/src/AutoPilotPlugins/Common/RadioComponentController.h
+++ b/src/AutoPilotPlugins/Common/RadioComponentController.h
@@ -2,7 +2,8 @@
 
 #include "RemoteControlCalibrationController.h"
 
-/// Controller class for RC Transmitter calibration
+/// \brief Controller class for RC Transmitter calibration
+///
 class RadioComponentController : public RemoteControlCalibrationController
 {
     Q_OBJECT

--- a/src/AutoPilotPlugins/Generic/GenericAutoPilotPlugin.h
+++ b/src/AutoPilotPlugins/Generic/GenericAutoPilotPlugin.h
@@ -4,8 +4,10 @@
 
 class JoystickComponent;
 
-/// This is the generic implementation of the AutoPilotPlugin class for mavs
+/// \brief This is the generic implementation of the AutoPilotPlugin class for mavs
+///
 /// we do not have a specific AutoPilotPlugin implementation.
+///
 class GenericAutoPilotPlugin : public AutoPilotPlugin
 {
     Q_OBJECT

--- a/src/AutoPilotPlugins/PX4/AirframeComponentAirframes.h
+++ b/src/AutoPilotPlugins/PX4/AirframeComponentAirframes.h
@@ -3,7 +3,8 @@
 #include <QtCore/QList>
 #include <QtCore/QMap>
 
-/// MVC Controller for AirframeComponent.qml.
+/// \brief MVC Controller for AirframeComponent.qml.
+///
 class AirframeComponentAirframes
 {
 public:

--- a/src/AutoPilotPlugins/PX4/AirframeComponentController.h
+++ b/src/AutoPilotPlugins/PX4/AirframeComponentController.h
@@ -7,7 +7,8 @@
 #include "QmlObjectListModel.h"
 #include "FactPanelController.h"
 
-/// MVC Controller for AirframeComponent.qml.
+/// \brief MVC Controller for AirframeComponent.qml.
+///
 class AirframeComponentController : public FactPanelController
 {
     Q_OBJECT

--- a/src/AutoPilotPlugins/PX4/PX4AirframeLoader.h
+++ b/src/AutoPilotPlugins/PX4/PX4AirframeLoader.h
@@ -6,7 +6,7 @@ class AutoPilotPlugin;
 
 class FactMetaData;
 
-/// Collection of Parameter Facts for PX4 AutoPilot
+/// \brief Collection of Parameter Facts for PX4 AutoPilot
 
 class PX4AirframeLoader : QObject
 {

--- a/src/AutoPilotPlugins/PX4/PX4SimpleFlightModesController.h
+++ b/src/AutoPilotPlugins/PX4/PX4SimpleFlightModesController.h
@@ -5,7 +5,8 @@
 
 #include "FactPanelController.h"
 
-/// MVC Controller for PX4SimpleFlightModes.qml
+/// \brief MVC Controller for PX4SimpleFlightModes.qml
+///
 class PX4SimpleFlightModesController : public FactPanelController
 {
     Q_OBJECT

--- a/src/AutoPilotPlugins/PX4/PowerComponentController.h
+++ b/src/AutoPilotPlugins/PX4/PowerComponentController.h
@@ -4,7 +4,8 @@
 
 #include "FactPanelController.h"
 
-/// Power Component MVC Controller for PowerComponent.qml.
+/// \brief Power Component MVC Controller for PowerComponent.qml.
+///
 class PowerComponentController : public FactPanelController
 {
     Q_OBJECT

--- a/src/AutoPilotPlugins/PX4/SensorsComponentController.h
+++ b/src/AutoPilotPlugins/PX4/SensorsComponentController.h
@@ -5,7 +5,8 @@
 
 #include "FactPanelController.h"
 
-/// Sensors Component MVC Controller for SensorsComponent.qml.
+/// \brief Sensors Component MVC Controller for SensorsComponent.qml.
+///
 class SensorsComponentController : public FactPanelController
 {
     Q_OBJECT

--- a/src/AutoPilotPlugins/VehicleComponent.h
+++ b/src/AutoPilotPlugins/VehicleComponent.h
@@ -12,8 +12,10 @@ class Vehicle;
 class QQuickItem;
 class QQmlContext;
 
-/// A vehicle component is an object which abstracts the physical portion of a vehicle into a set of
+/// \brief A vehicle component is an object which abstracts the physical portion of a vehicle into a set of
+///
 /// configurable values and user interface.
+///
 class VehicleComponent : public QObject
 {
     Q_OBJECT

--- a/src/Camera/CameraMetaData.h
+++ b/src/Camera/CameraMetaData.h
@@ -2,7 +2,8 @@
 
 #include <QtQmlIntegration/QtQmlIntegration>
 
-/// Set of meta data which describes a camera available on the vehicle
+/// \brief Set of meta data which describes a camera available on the vehicle
+///
 class CameraMetaData
 {
     Q_GADGET

--- a/src/Camera/MavlinkCameraControlInterface.h
+++ b/src/Camera/MavlinkCameraControlInterface.h
@@ -14,7 +14,8 @@ class QGCVideoStreamInfo;
 class QmlObjectListModel;
 class Vehicle;
 
-/// Abstract base class for all camera controls: real and simulated
+/// \brief Abstract base class for all camera controls: real and simulated
+///
 class MavlinkCameraControlInterface : public FactGroup
 {
     Q_OBJECT

--- a/src/Camera/QGCCameraIO.h
+++ b/src/Camera/QGCCameraIO.h
@@ -8,7 +8,8 @@ class MavlinkCameraControlInterface;
 class Fact;
 class Vehicle;
 
-/// Camera parameter handler.
+/// \brief Camera parameter handler.
+///
 class QGCCameraParamIO : public QObject
 {
 public:

--- a/src/Camera/QGCCameraManager.h
+++ b/src/Camera/QGCCameraManager.h
@@ -20,7 +20,8 @@ class QGCCameraManagerTest;
 class QGCVideoStreamInfo;
 class SimulatedCameraControl;
 
-/// Camera Manager
+/// \brief Camera Manager
+///
 class QGCCameraManager : public QObject
 {
     Q_OBJECT

--- a/src/Camera/QGCVideoStreamInfo.h
+++ b/src/Camera/QGCVideoStreamInfo.h
@@ -6,7 +6,8 @@
 
 #include "MAVLinkLib.h"
 
-/// Encapsulates the contents of a [VIDEO_STREAM_INFORMATION](https://mavlink.io/en/messages/common.html#VIDEO_STREAM_INFORMATION) message
+/// \brief Encapsulates the contents of a [VIDEO_STREAM_INFORMATION](https://mavlink.io/en/messages/common.html#VIDEO_STREAM_INFORMATION) message
+///
 class QGCVideoStreamInfo : public QObject
 {
     Q_OBJECT

--- a/src/Camera/SimulatedCameraControl.h
+++ b/src/Camera/SimulatedCameraControl.h
@@ -8,10 +8,12 @@
 class QGCVideoStreamInfo;
 class Vehicle;
 
-/// Creates a simulated Camera Control which supports:
+/// \brief Creates a simulated Camera Control which supports:
+///
 ///     Video record if a manual stream is available
 ///     Photo capture using DO_DIGICAM_CONTROL if the setting is enabled
 ///     It does not support time lapse capture
+///
 class SimulatedCameraControl : public MavlinkCameraControlInterface
 {
     Q_OBJECT

--- a/src/Camera/VehicleCameraControl.h
+++ b/src/Camera/VehicleCameraControl.h
@@ -9,7 +9,8 @@ class QDomNode;
 class QDomNodeList;
 
 //-----------------------------------------------------------------------------
-/// Camera option exclusions
+/// \brief Camera option exclusions
+///
 class QGCCameraOptionExclusion : public QObject
 {
 public:
@@ -20,7 +21,8 @@ public:
 };
 
 //-----------------------------------------------------------------------------
-/// Camera option ranges
+/// \brief Camera option ranges
+///
 class QGCCameraOptionRange : public QObject
 {
 public:
@@ -34,7 +36,8 @@ public:
     QVariantList optVariants;
 };
 
-/// MAVLink Camera API controller - connected to a real mavlink v2 camera
+/// \brief MAVLink Camera API controller - connected to a real mavlink v2 camera
+///
 class VehicleCameraControl : public MavlinkCameraControlInterface
 {
     Q_OBJECT

--- a/src/Comms/LinkConfiguration.h
+++ b/src/Comms/LinkConfiguration.h
@@ -6,7 +6,8 @@
 
 class LinkInterface;
 
-/// Interface holding link specific settings.
+/// \brief Interface holding link specific settings.
+///
 class LinkConfiguration : public QObject
 {
     Q_OBJECT

--- a/src/Comms/LinkInterface.h
+++ b/src/Comms/LinkInterface.h
@@ -9,7 +9,8 @@
 class LinkManager;
 class SigningController;
 
-/// The link interface defines the interface for all links used to communicate with the ground station application.
+/// \brief The link interface defines the interface for all links used to communicate with the ground station application.
+///
 class LinkInterface : public QObject
 {
     Q_OBJECT

--- a/src/Comms/LinkManager.h
+++ b/src/Comms/LinkManager.h
@@ -27,6 +27,7 @@ class UdpIODevice;
 ///        The Link Manager organizes the physical Links. It can manage arbitrary
 ///        links and takes care of connecting them as well assigning the correct
 ///        protocol instance to transport the link data into the application.
+///
 class LinkManager : public QObject
 {
     Q_OBJECT

--- a/src/Comms/MAVLinkProtocol.h
+++ b/src/Comms/MAVLinkProtocol.h
@@ -12,7 +12,8 @@
 
 class QFile;
 
-/// MAVLink micro air vehicle protocol reference implementation.
+/// \brief MAVLink micro air vehicle protocol reference implementation.
+///
 class MAVLinkProtocol : public QObject
 {
     Q_OBJECT

--- a/src/Comms/MockLink/MockLinkCamera.h
+++ b/src/Comms/MockLink/MockLinkCamera.h
@@ -6,7 +6,7 @@
 
 class MockLink;
 
-/// Simulates MAVLink Camera Protocol v2 components for MockLink.
+/// \brief Simulates MAVLink Camera Protocol v2 components for MockLink.
 ///
 /// Two cameras are provided:
 ///   Camera 1 (MAV_COMP_ID_CAMERA)  – full-featured: video capture, photo capture,
@@ -31,6 +31,7 @@ class MockLink;
 ///   MAV_CMD_CAMERA_TRACK_POINT / TRACK_RECTANGLE / STOP_TRACKING
 ///
 /// Simulated storage: 16 GiB total, 8 GiB free, SD card.
+///
 class MockLinkCamera
 {
 public:

--- a/src/Comms/MockLink/MockLinkFTP.h
+++ b/src/Comms/MockLink/MockLinkFTP.h
@@ -10,7 +10,8 @@
 
 class MockLink;
 
-/// Mock implementation of Mavlink FTP server.
+/// \brief Mock implementation of Mavlink FTP server.
+///
 class MockLinkFTP : public QObject
 {
     Q_OBJECT

--- a/src/Comms/MockLink/MockLinkGimbal.h
+++ b/src/Comms/MockLink/MockLinkGimbal.h
@@ -6,7 +6,7 @@
 
 class MockLink;
 
-/// Simulates MAVLink Gimbal Manager Protocol for MockLink.
+/// \brief Simulates MAVLink Gimbal Manager Protocol for MockLink.
 ///
 /// Supports a Gimbal Manager on MAV_COMPID_AUTOPILOT1 with a single gimbal device with the id MAV_COMP_ID_GIMBAL.
 /// Gimbal attitude is simulated with a slow oscillation when not under manual control.
@@ -19,6 +19,7 @@ class MockLink;
 ///   MAV_CMD_DO_GIMBAL_MANAGER_PITCHYAW
 ///   MAV_CMD_DO_GIMBAL_MANAGER_CONFIGURE
 ///   Periodic sending of GIMBAL_MANAGER_STATUS and GIMBAL_DEVICE_ATTITUDE_STATUS
+///
 class MockLinkGimbal
 {
 public:

--- a/src/Comms/MockLink/MockLinkWorker.h
+++ b/src/Comms/MockLink/MockLinkWorker.h
@@ -5,8 +5,10 @@
 class MockLink;
 class QTimer;
 
-/// Worker class that runs periodic tasks for MockLink simulation.
+/// \brief Worker class that runs periodic tasks for MockLink simulation.
+///
 /// Operates on a separate thread to avoid blocking the main thread.
+///
 class MockLinkWorker : public QObject
 {
     Q_OBJECT

--- a/src/Comms/QGCSerialPortInfo.h
+++ b/src/Comms/QGCSerialPortInfo.h
@@ -10,8 +10,10 @@
 
 class QGCSerialPortInfoTest;
 
-/// QGC's version of Qt QSerialPortInfo. It provides additional information about board types
+/// \brief QGC's version of Qt QSerialPortInfo. It provides additional information about board types
+///
 /// that QGC cares about.
+///
 class QGCSerialPortInfo : public QSerialPortInfo
 {
     friend class QGCSerialPortInfoTest;

--- a/src/Comms/UdpIODevice.h
+++ b/src/Comms/UdpIODevice.h
@@ -3,8 +3,10 @@
 #include <QtCore/QByteArray>
 #include <QtNetwork/QUdpSocket>
 
-/// UdpIODevice provides a QIODevice interface over a QUdpSocket in server mode.
+/// \brief UdpIODevice provides a QIODevice interface over a QUdpSocket in server mode.
+///
 /// It allows line-based reading using canReadLine() and readLineData() even when the socket is in bound mode.
+///
 class UdpIODevice: public QUdpSocket
 {
     Q_OBJECT

--- a/src/FactSystem/Fact.h
+++ b/src/FactSystem/Fact.h
@@ -11,7 +11,8 @@
 
 class FactValueSliderListModel;
 
-/// A Fact is used to hold a single value within the system.
+/// \brief A Fact is used to hold a single value within the system.
+///
 class Fact : public QObject
 {
     Q_OBJECT

--- a/src/FactSystem/FactControls/FactPanelController.h
+++ b/src/FactSystem/FactControls/FactPanelController.h
@@ -8,7 +8,8 @@
 class Vehicle;
 class Fact;
 
-/// Used for handling missing Facts from C++ code.
+/// \brief Used for handling missing Facts from C++ code.
+///
 class FactPanelController : public QObject
 {
     Q_OBJECT

--- a/src/FactSystem/FactGroup.h
+++ b/src/FactSystem/FactGroup.h
@@ -10,7 +10,8 @@
 
 class Vehicle;
 
-/// Used to group Facts together into an object hierarachy.
+/// \brief Used to group Facts together into an object hierarachy.
+///
 class FactGroup : public QObject
 {
     Q_OBJECT

--- a/src/FactSystem/FactGroupListModel.h
+++ b/src/FactSystem/FactGroupListModel.h
@@ -6,7 +6,8 @@
 
 #include <QList>
 
-/// Dynamically manages FactGroupWithIds based on incoming messages.
+/// \brief Dynamically manages FactGroupWithIds based on incoming messages.
+///
 class FactGroupListModel : public QmlObjectListModel
 {
     Q_OBJECT

--- a/src/FactSystem/FactGroupWithId.h
+++ b/src/FactSystem/FactGroupWithId.h
@@ -2,7 +2,8 @@
 
 #include "FactGroup.h"
 
-/// FactGroupWithId is a FactGroup which has an id Fact which can be used to identify the group.
+/// \brief FactGroupWithId is a FactGroup which has an id Fact which can be used to identify the group.
+///
 /// It is mainly used in combination with FactGroupListModel to manage dynamic FactGroups.
 
 class FactGroupWithId : public FactGroup

--- a/src/FactSystem/FactMetaData.h
+++ b/src/FactSystem/FactMetaData.h
@@ -8,9 +8,11 @@
 
 class SettingsManager;
 
-/// Holds the meta data associated with a Fact. This is kept in a separate object from the Fact itself
+/// \brief Holds the meta data associated with a Fact. This is kept in a separate object from the Fact itself
+///
 /// since you may have multiple instances of the same Fact. But there is only ever one FactMetaData
 /// instance or each Fact.
+///
 class FactMetaData : public QObject
 {
     Q_OBJECT

--- a/src/FactSystem/FactValueSliderListModel.h
+++ b/src/FactSystem/FactValueSliderListModel.h
@@ -8,7 +8,8 @@
 
 class Fact;
 
-/// Provides a list model of values for incrementing/decrementing the value of a Fact
+/// \brief Provides a list model of values for incrementing/decrementing the value of a Fact
+///
 class FactValueSliderListModel : public QAbstractListModel
 {
     Q_OBJECT

--- a/src/FactSystem/SettingsFact.h
+++ b/src/FactSystem/SettingsFact.h
@@ -5,7 +5,8 @@
 
 #include "Fact.h"
 
-/// A SettingsFact is Fact which holds a QSettings value.
+/// \brief A SettingsFact is Fact which holds a QSettings value.
+///
 class SettingsFact : public Fact
 {
     Q_OBJECT

--- a/src/FirmwarePlugin/APM/APMFirmwarePlugin.h
+++ b/src/FirmwarePlugin/APM/APMFirmwarePlugin.h
@@ -17,7 +17,8 @@ struct APMCustomMode
     };
 };
 
-/// This is the base class for all stack specific APM firmware plugins
+/// \brief This is the base class for all stack specific APM firmware plugins
+///
 class APMFirmwarePlugin : public FirmwarePlugin
 {
     Q_OBJECT

--- a/src/FirmwarePlugin/FirmwarePlugin.h
+++ b/src/FirmwarePlugin/FirmwarePlugin.h
@@ -63,10 +63,12 @@ struct FirmwareFlightMode
 typedef QList<FirmwareFlightMode> FlightModeList;
 typedef QMap<uint32_t,QString> FlightModeCustomModeMap;
 
-/// The FirmwarePlugin class represents the methods and objects which are specific to a certain Firmware flight stack.
+/// \brief The FirmwarePlugin class represents the methods and objects which are specific to a certain Firmware flight stack.
+///
 /// This is the only place where flight stack specific code should reside in QGroundControl. The remainder of the
 /// QGroundControl source is generic to a common mavlink implementation. The implementation in the base class supports
 /// mavlink generic firmware. Override the base clase virtuals to create your own firmware specific plugin.
+///
 class FirmwarePlugin : public QObject
 {
     Q_OBJECT

--- a/src/FirmwarePlugin/FirmwarePluginManager.h
+++ b/src/FirmwarePlugin/FirmwarePluginManager.h
@@ -7,7 +7,8 @@
 class FirmwarePlugin;
 class FirmwarePluginFactory;
 
-/// FirmwarePluginManager is a singleton which is used to return the correct FirmwarePlugin for a MAV_AUTOPILOT type.
+/// \brief FirmwarePluginManager is a singleton which is used to return the correct FirmwarePlugin for a MAV_AUTOPILOT type.
+///
 class FirmwarePluginManager : public QObject
 {
     Q_OBJECT

--- a/src/LogManager/LogEntryTableModel.h
+++ b/src/LogManager/LogEntryTableModel.h
@@ -5,9 +5,11 @@
 
 #include "LogEntry.h"
 
-/// Base class for table models that display LogEntry data.
+/// \brief Base class for table models that display LogEntry data.
+///
 /// Provides shared data(), headerData(), roleNames(), and columnCount()
 /// implementations. Subclasses supply entries via entryAt().
+///
 class LogEntryTableModel : public QAbstractTableModel
 {
     Q_OBJECT

--- a/src/MAVLink/ImageProtocolManager.h
+++ b/src/MAVLink/ImageProtocolManager.h
@@ -6,8 +6,10 @@
 #include <QtCore/QObject>
 #include <QtGui/QImage>
 
-/// Supports the Mavlink image transmission protocol (https://mavlink.io/en/services/image_transmission.html).
+/// \brief Supports the Mavlink image transmission protocol (https://mavlink.io/en/services/image_transmission.html).
+///
 /// Mainly used by optical flow cameras.
+///
 class ImageProtocolManager : public QObject
 {
     Q_OBJECT

--- a/src/MAVLink/LibEvents/EventHandler.h
+++ b/src/MAVLink/LibEvents/EventHandler.h
@@ -16,7 +16,8 @@ class ParsedEvent;
 } // namespace parser
 } // namespace events
 
-/// Drives the MAVLink events protocol for a single component.
+/// \brief Drives the MAVLink events protocol for a single component.
+///
 class EventHandler : public QObject
 {
     Q_OBJECT

--- a/src/MAVLink/LibEvents/MAVLinkEventManager.h
+++ b/src/MAVLink/LibEvents/MAVLinkEventManager.h
@@ -18,8 +18,10 @@ namespace events::parser {
 class ParsedEvent;
 }
 
-/// Owns per-component EventHandler instances and drives the Health & Arming
+/// \brief Owns per-component EventHandler instances and drives the Health & Arming
+///
 /// Check report.
+///
 class MAVLinkEventManager : public QObject
 {
     Q_OBJECT

--- a/src/MAVLink/MAVLinkStreamConfig.h
+++ b/src/MAVLink/MAVLinkStreamConfig.h
@@ -1,9 +1,11 @@
 #pragma once
 
 #include <QtCore/QList>
-/// Allows to configure a set of mavlink streams to a specific rate,
+/// \brief Allows to configure a set of mavlink streams to a specific rate,
+///
 /// and restore back to default.
 /// Note that only one set is active at a time.
+///
 class MAVLinkStreamConfig
 {
 public:

--- a/src/MAVLink/Signing/MAVLinkSigningKeys.h
+++ b/src/MAVLink/Signing/MAVLinkSigningKeys.h
@@ -15,7 +15,8 @@ class QmlObjectListModel;
 class SigningController;
 class Vehicle;
 
-/// A single named signing key entry.
+/// \brief A single named signing key entry.
+///
 class MAVLinkSigningKey : public QObject
 {
     Q_OBJECT
@@ -43,7 +44,8 @@ private:
     uint64_t _lastTimestamp = 0;
 };
 
-/// Bag of named MAVLink signing keys; correct key per vehicle is auto-detected from incoming signed packets.
+/// \brief Bag of named MAVLink signing keys; correct key per vehicle is auto-detected from incoming signed packets.
+///
 class MAVLinkSigningKeys : public QObject
 {
     Q_OBJECT

--- a/src/MAVLink/Signing/SigningChannel.h
+++ b/src/MAVLink/Signing/SigningChannel.h
@@ -13,7 +13,8 @@
 
 class SigningController;
 
-/// Owns MAVLink signing state for one channel: signing/streams structs, key hint, and RW lock.
+/// \brief Owns MAVLink signing state for one channel: signing/streams structs, key hint, and RW lock.
+///
 class SigningChannel
 {
 public:

--- a/src/MAVLink/Signing/SigningController.h
+++ b/src/MAVLink/Signing/SigningController.h
@@ -14,7 +14,8 @@
 #include "SigningFailure.h"
 #include "SigningStatus.h"
 
-/// Owns MAVLink signing state and the deferred-confirmation state machine for one LinkInterface.
+/// \brief Owns MAVLink signing state and the deferred-confirmation state machine for one LinkInterface.
+///
 class SigningController : public QObject
 {
     Q_OBJECT

--- a/src/MAVLink/Signing/SigningFailure.h
+++ b/src/MAVLink/Signing/SigningFailure.h
@@ -6,7 +6,8 @@
 
 #include <cstdint>
 
-/// Reason a signing operation failed. Used by SigningController error path and Vehicle::signingFailed.
+/// \brief Reason a signing operation failed. Used by SigningController error path and Vehicle::signingFailed.
+///
 class SigningFailure
 {
     Q_GADGET

--- a/src/MAVLink/SysStatusSensorInfo.h
+++ b/src/MAVLink/SysStatusSensorInfo.h
@@ -5,7 +5,8 @@
 
 #include "MAVLinkLib.h"
 
-/// Class which represents sensor info from the SYS_STATUS mavlink message
+/// \brief Class which represents sensor info from the SYS_STATUS mavlink message
+///
 class SysStatusSensorInfo : public QObject
 {
     Q_OBJECT

--- a/src/MissionManager/GeoFenceManager.h
+++ b/src/MissionManager/GeoFenceManager.h
@@ -9,8 +9,10 @@
 class Vehicle;
 class QmlObjectListModel;
 
-/// This is the base class for firmware specific geofence managers. A geofence manager is responsible
+/// \brief This is the base class for firmware specific geofence managers. A geofence manager is responsible
+///
 /// for communicating with the vehicle to set/get geofence settings.
+///
 class GeoFenceManager : public PlanManager
 {
     Q_OBJECT

--- a/src/MissionManager/KMLPlanDomDocument.h
+++ b/src/MissionManager/KMLPlanDomDocument.h
@@ -6,7 +6,8 @@ class MissionItem;
 class Vehicle;
 class QmlObjectListModel;
 
-/// Used to convert a Plan to a KML document
+/// \brief Used to convert a Plan to a KML document
+///
 class KMLPlanDomDocument : public KMLDomDocument
 {
 

--- a/src/MissionManager/MissionCommandList.h
+++ b/src/MissionManager/MissionCommandList.h
@@ -8,7 +8,8 @@
 
 class MissionCommandUIInfo;
 
-/// Maintains a list of MissionCommandUIInfo objects loaded from a json file.
+/// \brief Maintains a list of MissionCommandUIInfo objects loaded from a json file.
+///
 class MissionCommandList : public QObject
 {
     Q_OBJECT

--- a/src/MissionManager/MissionCommandTree.h
+++ b/src/MissionManager/MissionCommandTree.h
@@ -12,7 +12,7 @@ class MissionCommandTreeTest;
 class MissionCommandUIInfo;
 class Vehicle;
 
-/// Manages a hierarchy of MissionCommandUIInfo.
+/// \brief Manages a hierarchy of MissionCommandUIInfo.
 ///
 /// The static hierarchy allows for overriding mission command ui info based on firmware and vehicle class. The hierarchy of the tree is:
 ///     FirmwareClassGeneric - VehicleClassGeneric - Base set of all command definitions for any firmware, any vehicle, ui defined by mavlink spec

--- a/src/MissionManager/MissionCommandUIInfo.h
+++ b/src/MissionManager/MissionCommandUIInfo.h
@@ -11,7 +11,7 @@ class MissionCommandUIInfo;
 class MissionCommandTreeTest;
 #endif
 
-/// UI Information associated with a mission command (MAV_CMD) parameter
+/// \brief UI Information associated with a mission command (MAV_CMD) parameter
 ///
 /// MissionCommandParamInfo is used to automatically generate editing ui for a parameter associated with a MAV_CMD.
 ///
@@ -92,7 +92,7 @@ private:
     friend class MissionCommandUIInfo;
 };
 
-/// UI Information associated with a mission command (MAV_CMD)
+/// \brief UI Information associated with a mission command (MAV_CMD)
 ///
 /// MissionCommandUIInfo is used to automatically generate editing ui for a MAV_CMD. This object also supports the concept of only having a set of partial
 /// information for the command. This is used to create overrides of the base command information. For on override just specify the keys you want to modify

--- a/src/MissionManager/MissionFlightStatusCalculator.h
+++ b/src/MissionManager/MissionFlightStatusCalculator.h
@@ -11,9 +11,11 @@ class SimpleMissionItem;
 class Vehicle;
 class VisualMissionItem;
 
-/// Computes mission flight status (distances, times, battery, altitude range)
+/// \brief Computes mission flight status (distances, times, battery, altitude range)
+///
 /// from a list of visual mission items and vehicle properties.
 /// Extracted from MissionController to reduce its complexity.
+///
 class MissionFlightStatusCalculator
 {
 public:

--- a/src/MissionManager/PlanCreator.h
+++ b/src/MissionManager/PlanCreator.h
@@ -10,7 +10,8 @@
 class PlanMasterController;
 class MissionController;
 
-/// Base class for PlanCreator objects which are used to create a full plan in a single step.
+/// \brief Base class for PlanCreator objects which are used to create a full plan in a single step.
+///
 class PlanCreator : public QObject
 {
     Q_OBJECT

--- a/src/MissionManager/PlanElementController.h
+++ b/src/MissionManager/PlanElementController.h
@@ -5,8 +5,10 @@
 class PlanMasterController;
 
 
-/// This is the abstract base clas for Plan Element controllers.
+/// \brief This is the abstract base clas for Plan Element controllers.
+///
 /// Examples of plan elements are: missions (MissionController), geofence (GeoFenceController)
+///
 class PlanElementController : public QObject
 {
     Q_OBJECT

--- a/src/MissionManager/PlanManager.h
+++ b/src/MissionManager/PlanManager.h
@@ -7,8 +7,10 @@
 
 class Vehicle;
 
-/// The PlanManager class is the base class for the Mission, GeoFence and Rally Point managers. All of which use the
+/// \brief The PlanManager class is the base class for the Mission, GeoFence and Rally Point managers. All of which use the
+///
 /// new mavlink v2 mission protocol.
+///
 class PlanManager : public QObject
 {
     Q_OBJECT

--- a/src/MissionManager/PlanMasterController.h
+++ b/src/MissionManager/PlanMasterController.h
@@ -16,7 +16,8 @@ class Vehicle;
 class PlanMasterControllerTest;
 #endif
 
-/// Master controller for mission, fence, rally
+/// \brief Master controller for mission, fence, rally
+///
 class PlanMasterController : public QObject
 {
     Q_OBJECT

--- a/src/MissionManager/RallyPoint.h
+++ b/src/MissionManager/RallyPoint.h
@@ -5,8 +5,10 @@
 
 #include "Fact.h"
 
-/// This class is used to encapsulate the QGeoCoordinate associated with a Rally Point into a QObject such
+/// \brief This class is used to encapsulate the QGeoCoordinate associated with a Rally Point into a QObject such
+///
 /// that it can be used in a QmlObjectListMode for Qml.
+///
 class RallyPoint : public QObject
 {
     Q_OBJECT

--- a/src/MissionManager/RallyPointManager.h
+++ b/src/MissionManager/RallyPointManager.h
@@ -6,8 +6,10 @@
 
 class Vehicle;
 
-/// This is the base class for firmware specific rally point managers. A rally point manager is responsible
+/// \brief This is the base class for firmware specific rally point managers. A rally point manager is responsible
+///
 /// for communicating with the vehicle to set/get rally points.
+///
 class RallyPointManager : public PlanManager
 {
     Q_OBJECT

--- a/src/MissionManager/SimpleMissionItem.h
+++ b/src/MissionManager/SimpleMissionItem.h
@@ -7,7 +7,8 @@
 class SpeedSection;
 class CameraSection;
 
-/// A SimpleMissionItem is used to represent a single MissionItem to the ui.
+/// \brief A SimpleMissionItem is used to represent a single MissionItem to the ui.
+///
 class SimpleMissionItem : public VisualMissionItem
 {
     Q_OBJECT

--- a/src/MissionManager/TakeoffMissionItem.h
+++ b/src/MissionManager/TakeoffMissionItem.h
@@ -5,8 +5,10 @@
 class PlanMasterController;
 class MissionSettingsItem;
 
-/// Takeoff mission item is a special case of a SimpleMissionItem which supports Launch Location display/editing
+/// \brief Takeoff mission item is a special case of a SimpleMissionItem which supports Launch Location display/editing
+///
 /// which is tied to home position.
+///
 class TakeoffMissionItem : public SimpleMissionItem
 {
     Q_OBJECT

--- a/src/QGCApplication.h
+++ b/src/QGCApplication.h
@@ -32,7 +32,8 @@ struct QMetaObject;
 
 #define qgcApp() qApp
 
-/// The main application and management class.
+/// \brief The main application and management class.
+///
 class QGCApplication : public QGuiApplication
 {
     Q_OBJECT

--- a/src/QmlControls/ColoredSvgImageProvider.h
+++ b/src/QmlControls/ColoredSvgImageProvider.h
@@ -2,11 +2,13 @@
 
 #include <QtQuick/QQuickImageProvider>
 
-/// Image provider that rasterizes an SVG (or any QImage-loadable Qt resource)
+/// \brief Image provider that rasterizes an SVG (or any QImage-loadable Qt resource)
+///
 /// and recolors its alpha mask with a caller-supplied tint, avoiding the need
 /// for a runtime ColorOverlay shader.
 ///
 /// URL format: image://coloredsvg/<resource-path>?color=<RRGGBB|AARRGGBB>
+///
 class ColoredSvgImageProvider : public QQuickImageProvider
 {
 public:

--- a/src/QmlControls/MavlinkActionManager.h
+++ b/src/QmlControls/MavlinkActionManager.h
@@ -6,9 +6,11 @@
 class Fact;
 class QmlObjectListModel;
 
-/// Loads the specified action file and provides access to the actions it contains.
+/// \brief Loads the specified action file and provides access to the actions it contains.
+///
 /// Action files are loaded from the default MavlinkActions directory.
 /// The actions file name is filename only, no path.
+///
 class MavlinkActionManager : public QObject
 {
     Q_OBJECT

--- a/src/QmlControls/ObjectItemModelBase.h
+++ b/src/QmlControls/ObjectItemModelBase.h
@@ -12,8 +12,10 @@
 #include <QtCore/QAbstractItemModel>
 #include <QtQmlIntegration/QtQmlIntegration>
 
-/// Common base for QObject*-based item models (flat lists and trees).
+/// \brief Common base for QObject*-based item models (flat lists and trees).
+///
 /// Provides: dirty tracking, depth-counted begin/endResetModel, shared role constants, roleNames.
+///
 class ObjectItemModelBase : public QAbstractItemModel
 {
     Q_OBJECT

--- a/src/QmlControls/ObjectListModelBase.h
+++ b/src/QmlControls/ObjectListModelBase.h
@@ -11,8 +11,10 @@
 
 #include "ObjectItemModelBase.h"
 
-/// Base class for flat QObject* list models. Inherits common dirty/reset/role
+/// \brief Base class for flat QObject* list models. Inherits common dirty/reset/role
+///
 /// handling from ObjectItemModelBase and adds flat-list index()/parent() overrides.
+///
 class ObjectListModelBase : public ObjectItemModelBase
 {
     Q_OBJECT

--- a/src/QmlControls/QGCFenceCircle.h
+++ b/src/QmlControls/QGCFenceCircle.h
@@ -2,7 +2,8 @@
 
 #include "QGCMapCircle.h"
 
-/// The QGCFenceCircle class provides a cicle used by GeoFence support.
+/// \brief The QGCFenceCircle class provides a cicle used by GeoFence support.
+///
 class QGCFenceCircle : public QGCMapCircle
 {
     Q_OBJECT

--- a/src/QmlControls/QGCFencePolygon.h
+++ b/src/QmlControls/QGCFencePolygon.h
@@ -2,7 +2,8 @@
 
 #include "QGCMapPolygon.h"
 
-/// The QGCFencePolygon class provides a polygon used by GeoFence support.
+/// \brief The QGCFencePolygon class provides a polygon used by GeoFence support.
+///
 class QGCFencePolygon : public QGCMapPolygon
 {
     Q_OBJECT

--- a/src/QmlControls/QGCImageProvider.h
+++ b/src/QmlControls/QGCImageProvider.h
@@ -4,7 +4,8 @@
 #include <QtGui/QImage>
 #include <QtQuick/QQuickImageProvider>
 
-/// This is used to expose images from ImageProtocolHandler
+/// \brief This is used to expose images from ImageProtocolHandler
+///
 class QGCImageProvider : public QQuickImageProvider
 {
 public:

--- a/src/QmlControls/QGCMapCircle.h
+++ b/src/QmlControls/QGCMapCircle.h
@@ -6,7 +6,8 @@
 
 #include "Fact.h"
 
-/// The QGCMapCircle represents a circular area which can be displayed on a Map control.
+/// \brief The QGCMapCircle represents a circular area which can be displayed on a Map control.
+///
 class QGCMapCircle : public QObject
 {
     Q_OBJECT

--- a/src/QmlControls/QGCMapPolygon.h
+++ b/src/QmlControls/QGCMapPolygon.h
@@ -10,8 +10,10 @@
 
 class KMLDomDocument;
 
-/// The QGCMapPolygon class provides a polygon which can be displayed on a map using a map visuals control.
+/// \brief The QGCMapPolygon class provides a polygon which can be displayed on a map using a map visuals control.
+///
 /// It maintains a representation of the polygon on QVariantList and QmlObjectListModel format.
+///
 class QGCMapPolygon : public QObject
 {
     Q_OBJECT

--- a/src/QmlControls/QGCQGeoCoordinate.h
+++ b/src/QmlControls/QGCQGeoCoordinate.h
@@ -3,7 +3,8 @@
 #include <QtCore/QObject>
 #include <QtPositioning/QGeoCoordinate>
 
-/// This is a QGeoCoordinate within a QObject such that it can be used on a QmlObjectListModel
+/// \brief This is a QGeoCoordinate within a QObject such that it can be used on a QmlObjectListModel
+///
 class QGCQGeoCoordinate : public QObject
 {
     Q_OBJECT

--- a/src/QmlControls/QmlObjectTreeModel.h
+++ b/src/QmlControls/QmlObjectTreeModel.h
@@ -13,12 +13,14 @@
 
 #include <QtQmlIntegration/QtQmlIntegration>
 
-/// A tree model for QObject* items, usable from both C++ and QML.
+/// \brief A tree model for QObject* items, usable from both C++ and QML.
+///
 /// Works like QmlObjectListModel but supports hierarchical parent/child relationships.
 /// Compatible with Qt 6 TreeView.
 ///
 /// Top-level items are children of an invisible root node. The root is represented
 /// by an invalid QModelIndex (the default).
+///
 class QmlObjectTreeModel : public ObjectItemModelBase
 {
     Q_OBJECT

--- a/src/QmlControls/ScreenToolsController.h
+++ b/src/QmlControls/ScreenToolsController.h
@@ -3,7 +3,8 @@
 #include <QtCore/QObject>
 #include <QtQmlIntegration/QtQmlIntegration>
 
-/// This Qml control is used to return screen parameters
+/// \brief This Qml control is used to return screen parameters
+///
 class ScreenToolsController : public QObject
 {
     Q_OBJECT

--- a/src/QtLocationPlugin/Providers/ElevationMapProvider.h
+++ b/src/QtLocationPlugin/Providers/ElevationMapProvider.h
@@ -19,7 +19,8 @@ public:
     virtual QByteArray serialize(const QByteArray &image) const = 0;
 };
 
-/// https://spacedata.copernicus.eu/collections/copernicus-digital-elevation-model
+/// \brief https://spacedata.copernicus.eu/collections/copernicus-digital-elevation-model
+///
 class CopernicusElevationProvider : public ElevationProvider
 {
 public:

--- a/src/Settings/AppSettings.h
+++ b/src/Settings/AppSettings.h
@@ -4,7 +4,8 @@
 
 #include "SettingsGroup.h"
 
-/// Application Settings
+/// \brief Application Settings
+///
 class AppSettings : public SettingsGroup
 {
     Q_OBJECT

--- a/src/Settings/AutoConnectSettings.h
+++ b/src/Settings/AutoConnectSettings.h
@@ -4,8 +4,10 @@
 
 #include "SettingsGroup.h"
 
-/// Auto connect settings
+/// \brief Auto connect settings
+///
 /// Defines which links should be automatically created and started at runtime
+///
 class AutoConnectSettings : public SettingsGroup
 {
     Q_OBJECT

--- a/src/Settings/MavlinkSettings.h
+++ b/src/Settings/MavlinkSettings.h
@@ -4,7 +4,8 @@
 
 #include "SettingsGroup.h"
 
-/// Application Settings
+/// \brief Application Settings
+///
 class MavlinkSettings : public SettingsGroup
 {
     Q_OBJECT

--- a/src/Settings/SettingsGroup.h
+++ b/src/Settings/SettingsGroup.h
@@ -36,9 +36,11 @@
         Fact* NAME(); \
         static const char* NAME ## Name;
 
-/// Provides access to group of settings. The group is named and has a userVisible
+/// \brief Provides access to group of settings. The group is named and has a userVisible
+///
 /// property that controls whether the entire group is shown in the UI.
 /// Custom builds can hide groups via QGCCorePlugin::overrideSettingsGroupVisibility.
+///
 class SettingsGroup : public QObject
 {
     Q_OBJECT

--- a/src/Settings/SettingsManager.h
+++ b/src/Settings/SettingsManager.h
@@ -29,7 +29,8 @@ class MavlinkSettings;
 class FactMetaData;
 class JoystickManagerSettings;
 
-/// Provides access to all app settings
+/// \brief Provides access to all app settings
+///
 class SettingsManager : public QObject
 {
     Q_OBJECT

--- a/src/Terrain/Providers/TerrainTileCopernicus.h
+++ b/src/Terrain/Providers/TerrainTileCopernicus.h
@@ -3,7 +3,8 @@
 #include <QtCore/QList>
 #include "TerrainTile.h"
 
-/// Implements an interface for https://terrain-ce.suite.auterion.com/api/v1/
+/// \brief Implements an interface for https://terrain-ce.suite.auterion.com/api/v1/
+///
 class TerrainTileCopernicus : public TerrainTile
 {
     friend class TerrainTileTest;

--- a/src/Terrain/TerrainQuery.h
+++ b/src/Terrain/TerrainQuery.h
@@ -67,7 +67,8 @@ private:
 
 /*===========================================================================*/
 
-/// NOTE: TerrainAtCoordinateQuery is not thread safe. All instances/calls to ElevationProvider must be on main thread.
+/// \brief NOTE: TerrainAtCoordinateQuery is not thread safe. All instances/calls to ElevationProvider must be on main thread.
+///
 class TerrainAtCoordinateQuery : public QObject
 {
     Q_OBJECT

--- a/src/Terrain/TerrainQueryInterface.h
+++ b/src/Terrain/TerrainQueryInterface.h
@@ -22,7 +22,8 @@ namespace TerrainQuery
     };
 }
 
-/// Base class for offline/online terrain queries
+/// \brief Base class for offline/online terrain queries
+///
 class TerrainQueryInterface : public QObject
 {
     Q_OBJECT

--- a/src/Utilities/Audio/AudioOutput.h
+++ b/src/Utilities/Audio/AudioOutput.h
@@ -6,7 +6,8 @@ class QTextToSpeech;
 class Fact;
 class AudioOutputTest;
 
-/// The AudioOutput class provides functionality for audio output using text-to-speech.
+/// \brief The AudioOutput class provides functionality for audio output using text-to-speech.
+///
 class AudioOutput : public QObject
 {
     Q_OBJECT

--- a/src/Utilities/Compression/QGCArchiveDeviceBase.h
+++ b/src/Utilities/Compression/QGCArchiveDeviceBase.h
@@ -11,9 +11,11 @@
 
 struct archive;
 
-/// Base class for QIODevice wrappers that use libarchive for decompression
+/// \brief Base class for QIODevice wrappers that use libarchive for decompression
+///
 /// Provides common source management, buffer handling, and archive lifecycle
 /// Read-only, sequential access only
+///
 class QGCArchiveDeviceBase : public QIODevice
 {
     Q_OBJECT

--- a/src/Utilities/Compression/QGCArchiveFile.h
+++ b/src/Utilities/Compression/QGCArchiveFile.h
@@ -6,7 +6,8 @@
 #include "QGCArchiveDeviceBase.h"
 
 #include <QtCore/QDateTime>
-/// QIODevice for reading a single entry from an archive without full extraction
+/// \brief QIODevice for reading a single entry from an archive without full extraction
+///
 /// Supports ZIP, TAR, 7z, and other libarchive-supported formats
 /// Read-only, sequential access only
 ///
@@ -16,6 +17,7 @@
 /// file.open(QIODevice::ReadOnly);
 /// QJsonDocument doc = QJsonDocument::fromJson(file.readAll());
 /// @endcode
+///
 class QGCArchiveFile : public QGCArchiveDeviceBase
 {
     Q_OBJECT

--- a/src/Utilities/Compression/QGCArchiveModel.h
+++ b/src/Utilities/Compression/QGCArchiveModel.h
@@ -7,7 +7,8 @@
 #include <QtCore/QUrl>
 #include <QtQmlIntegration/QtQmlIntegration>
 
-/// List model for archive contents, suitable for QML ListView binding.
+/// \brief List model for archive contents, suitable for QML ListView binding.
+///
 /// Provides natural sorting, filtering by type, and lazy loading support.
 ///
 /// Usage in QML:
@@ -24,6 +25,7 @@
 ///     }
 /// }
 /// @endcode
+///
 class QGCArchiveModel : public QAbstractListModel
 {
     Q_OBJECT

--- a/src/Utilities/Compression/QGCArchiveWatcher.h
+++ b/src/Utilities/Compression/QGCArchiveWatcher.h
@@ -12,7 +12,7 @@
 
 class QGCCompressionJob;
 
-/// Watches directories for new archive files and optionally auto-decompresses them
+/// \brief Watches directories for new archive files and optionally auto-decompresses them
 ///
 /// Example usage:
 /// @code
@@ -30,6 +30,7 @@ class QGCCompressionJob;
 /// });
 /// watcher.watchDirectory("/downloads");
 /// @endcode
+///
 class QGCArchiveWatcher : public QObject
 {
     Q_OBJECT

--- a/src/Utilities/Compression/QGCCompressionJob.h
+++ b/src/Utilities/Compression/QGCCompressionJob.h
@@ -11,7 +11,8 @@
 #include <QtCore/QFutureWatcher>
 #include <QtCore/QObject>
 
-/// QObject wrapper for compression operations with progress signals
+/// \brief QObject wrapper for compression operations with progress signals
+///
 /// Uses QtConcurrent and QPromise for modern async operations
 /// Can be used from C++ or QML
 ///
@@ -54,6 +55,7 @@
 /// });
 /// watcher->setFuture(future);
 /// @endcode
+///
 class QGCCompressionJob : public QObject
 {
     Q_OBJECT

--- a/src/Utilities/Compression/QGCDecompressDevice.h
+++ b/src/Utilities/Compression/QGCDecompressDevice.h
@@ -5,7 +5,8 @@
 
 #include "QGCArchiveDeviceBase.h"
 
-/// QIODevice wrapper for streaming decompression of single-file formats
+/// \brief QIODevice wrapper for streaming decompression of single-file formats
+///
 /// Supports .gz, .xz, .zst, .bz2, .lz4 compressed data
 /// Read-only, sequential access only
 ///
@@ -16,6 +17,7 @@
 /// QTextStream stream(&device);
 /// QString content = stream.readAll();
 /// @endcode
+///
 class QGCDecompressDevice : public QGCArchiveDeviceBase
 {
     Q_OBJECT

--- a/src/Utilities/Compression/QGClibarchive.h
+++ b/src/Utilities/Compression/QGClibarchive.h
@@ -41,7 +41,8 @@ enum class ReaderMode {
 // RAII Archive Reader
 // ============================================================================
 
-/// RAII wrapper for libarchive reader with automatic cleanup
+/// \brief RAII wrapper for libarchive reader with automatic cleanup
+///
 class ArchiveReader {
 public:
     ArchiveReader() = default;

--- a/src/Utilities/Concurrency/AutoSuspendGuard.h
+++ b/src/Utilities/Concurrency/AutoSuspendGuard.h
@@ -4,8 +4,10 @@
 
 namespace QGC {
 
-/// RAII guard for an atomic suspend flag: sets on construction, clears on destruction.
+/// \brief RAII guard for an atomic suspend flag: sets on construction, clears on destruction.
+///
 /// Movable so it can live in moved-from owner objects (e.g. PendingOp variants).
+///
 class AutoSuspendGuard
 {
 public:

--- a/src/Utilities/Database/QGCSqlHelper.h
+++ b/src/Utilities/Database/QGCSqlHelper.h
@@ -31,10 +31,12 @@ void applySqlitePragmas(QSqlDatabase& db);
 [[nodiscard]] bool setUserVersion(QSqlDatabase& db, int v);
 
 // ── Scoped connection RAII ─────────────────────────────────────────────
-/// RAII wrapper around QSqlDatabase::addDatabase / removeDatabase.
+/// \brief RAII wrapper around QSqlDatabase::addDatabase / removeDatabase.
+///
 /// Creates a uniquely-named connection on construction, removes it on
 /// destruction. Avoids the common pitfall of reusing connection names
 /// or forgetting to call removeDatabase.
+///
 class ScopedConnection
 {
 public:
@@ -62,10 +64,12 @@ private:
 };
 
 // ── Transaction RAII ───────────────────────────────────────────────────
-/// RAII wrapper around QSqlDatabase::transaction()/commit()/rollback().
+/// \brief RAII wrapper around QSqlDatabase::transaction()/commit()/rollback().
+///
 /// Begins a transaction on construction; rolls back in destructor unless
 /// commit() was called. Check ok() before issuing queries — begin can fail
 /// (e.g. driver doesn't support transactions, or one is already open).
+///
 class Transaction
 {
 public:

--- a/src/Utilities/FileSystem/QGCFileWatcher.h
+++ b/src/Utilities/FileSystem/QGCFileWatcher.h
@@ -11,7 +11,8 @@
 
 #include <functional>
 
-/// Callback-based file/directory watcher with debouncing support
+/// \brief Callback-based file/directory watcher with debouncing support
+///
 /// Provides a simpler API than QFileSystemWatcher for common use cases
 ///
 /// Example usage:
@@ -21,6 +22,7 @@
 ///     qDebug() << "Config changed:" << path;
 /// });
 /// @endcode
+///
 class QGCFileWatcher : public QObject
 {
     Q_OBJECT

--- a/src/Utilities/Geo/Formats/KMLDomDocument.h
+++ b/src/Utilities/Geo/Formats/KMLDomDocument.h
@@ -7,7 +7,8 @@
 class QColor;
 class QGeoCoordinate;
 
-/// Used to convert a Plan to a KML document
+/// \brief Used to convert a Plan to a KML document
+///
 class KMLDomDocument : public QDomDocument
 {
 public:

--- a/src/Utilities/Geo/Formats/KMLSchemaValidator.h
+++ b/src/Utilities/Geo/Formats/KMLSchemaValidator.h
@@ -7,8 +7,10 @@
 class QDomDocument;
 class QDomElement;
 
-/// Validates KML documents against rules extracted from the OGC KML 2.2 XSD schema.
+/// \brief Validates KML documents against rules extracted from the OGC KML 2.2 XSD schema.
+///
 /// This provides schema-driven validation without requiring a full XML Schema processor.
+///
 class KMLSchemaValidator
 {
 public:

--- a/src/Utilities/Geo/Formats/ShapeFileHelper.h
+++ b/src/Utilities/Geo/Formats/ShapeFileHelper.h
@@ -5,7 +5,8 @@
 #include <QtPositioning/QGeoCoordinate>
 #include <QtQmlIntegration/QtQmlIntegration>
 
-/// Routines for loading polygons or polylines from KML or SHP files.
+/// \brief Routines for loading polygons or polylines from KML or SHP files.
+///
 class ShapeFileHelper : public QObject
 {
     Q_OBJECT

--- a/src/Utilities/Logging/QGCLoggingCategory.h
+++ b/src/Utilities/Logging/QGCLoggingCategory.h
@@ -12,8 +12,10 @@ class QString;
     static QGCLoggingCategory qgcCategory##name(categoryStr); \
     Q_LOGGING_CATEGORY(name, categoryStr, QtInfoMsg)
 
-/// Helper that defers category registration until the QGCLoggingCategoryManager
+/// \brief Helper that defers category registration until the QGCLoggingCategoryManager
+///
 /// singleton exists. Pre-manager registrations are buffered and replayed on init().
+///
 class QGCLoggingCategory
 {
 public:

--- a/src/Utilities/Network/QGCCachedFileDownload.h
+++ b/src/Utilities/Network/QGCCachedFileDownload.h
@@ -11,7 +11,7 @@
 class QGCFileDownload;
 class QNetworkDiskCache;
 
-/// Cached file download with time-based expiration
+/// \brief Cached file download with time-based expiration
 ///
 /// Features:
 /// - Downloads files with Qt's network disk cache
@@ -49,6 +49,7 @@ class QNetworkDiskCache;
 ///     onClicked: cachedDownloader.download(urlField.text, 3600)
 /// }
 /// @endcode
+///
 class QGCCachedFileDownload : public QObject
 {
     Q_OBJECT

--- a/src/Utilities/Network/QGCFileDownload.h
+++ b/src/Utilities/Network/QGCFileDownload.h
@@ -15,7 +15,7 @@ class QAbstractNetworkCache;
 class QGCCompressionJob;
 class QFile;
 
-/// File download with progress, decompression, and hash verification
+/// \brief File download with progress, decompression, and hash verification
 ///
 /// Features:
 /// - HTTP/HTTPS and local file:// downloads
@@ -56,6 +56,7 @@ class QFile;
 ///                                   : downloader.start(urlField.text)
 /// }
 /// @endcode
+///
 class QGCFileDownload : public QObject
 {
     Q_OBJECT

--- a/src/Utilities/Network/TransportStrategy.h
+++ b/src/Utilities/Network/TransportStrategy.h
@@ -8,8 +8,10 @@
 class TcpTransport;
 class UdpTransport;
 
-/// Encapsulates UDP/TCP/AutoFallback protocol selection, lazy transport
+/// \brief Encapsulates UDP/TCP/AutoFallback protocol selection, lazy transport
+///
 /// creation, TLS configuration, and TCP reconnection with exponential backoff.
+///
 class TransportStrategy : public QObject
 {
     Q_OBJECT

--- a/src/Utilities/Parsing/PX4ULog/PX4ULogUtility.h
+++ b/src/Utilities/Parsing/PX4ULog/PX4ULogUtility.h
@@ -55,8 +55,10 @@ uint64_t getHeaderTimestamp(const char *data, qint64 size);
 /// @return true to continue processing, false to stop
 using MessageCallback = std::function<bool(const ulog_cpp::TypedDataView &sample)>;
 
-/// Generic streaming handler for ULog messages by name
+/// \brief Generic streaming handler for ULog messages by name
+///
 /// Filters messages by name and calls a callback for each matching message
+///
 class MessageHandler : public ulog_cpp::DataHandlerInterface {
 public:
     /// Create a handler that filters for a specific message type

--- a/src/Utilities/SDL/SDLJoystick.h
+++ b/src/Utilities/SDL/SDLJoystick.h
@@ -56,7 +56,8 @@ void updateGamepads();
 void lockJoysticks();
 void unlockJoysticks();
 
-/// RAII lock guard for joysticks
+/// \brief RAII lock guard for joysticks
+///
 class JoystickLock {
 public:
     JoystickLock() { lockJoysticks(); }

--- a/src/Utilities/StateMachine/Helpers/ErrorRecoveryBuilder.h
+++ b/src/Utilities/StateMachine/Helpers/ErrorRecoveryBuilder.h
@@ -8,7 +8,7 @@
 
 class QGCStateMachine;
 
-/// Fluent builder for creating error recovery states.
+/// \brief Fluent builder for creating error recovery states.
 ///
 /// Combines multiple error recovery patterns into a single state
 /// using a declarative fluent API.
@@ -23,6 +23,7 @@ class QGCStateMachine;
 ///     .onExhausted(ErrorRecoveryBuilder::LogAndError)
 ///     .build();
 /// @endcode
+///
 class ErrorRecoveryBuilder
 {
 public:
@@ -74,7 +75,8 @@ private:
     ExhaustedBehavior _exhaustedBehavior = EmitError;
 };
 
-/// The state created by ErrorRecoveryBuilder
+/// \brief The state created by ErrorRecoveryBuilder
+///
 class ErrorRecoveryState : public QGCState
 {
     Q_OBJECT

--- a/src/Utilities/StateMachine/Helpers/StateContext.h
+++ b/src/Utilities/StateMachine/Helpers/StateContext.h
@@ -8,7 +8,7 @@
 #include <optional>
 #include <typeinfo>
 
-/// Type-safe context for passing data between states in a state machine.
+/// \brief Type-safe context for passing data between states in a state machine.
 ///
 /// StateContext provides a way for states to share data without tight coupling.
 /// Data is stored by key and can be retrieved with type checking.
@@ -27,6 +27,7 @@
 /// @endcode
 ///
 /// The context can also be accessed via QGCStateMachine::context().
+///
 class StateContext
 {
 public:

--- a/src/Utilities/StateMachine/Helpers/StateHistoryRecorder.h
+++ b/src/Utilities/StateMachine/Helpers/StateHistoryRecorder.h
@@ -10,7 +10,7 @@
 class QAbstractState;
 class QGCStateMachine;
 
-/// Records state machine transitions for debugging and analysis.
+/// \brief Records state machine transitions for debugging and analysis.
 ///
 /// Maintains a circular buffer of state transitions with timestamps,
 /// transition reasons, and optional metadata.
@@ -25,6 +25,7 @@ class QGCStateMachine;
 ///
 /// qDebug() << recorder.dumpHistory();
 /// @endcode
+///
 class StateHistoryRecorder : public QObject
 {
     Q_OBJECT

--- a/src/Utilities/StateMachine/Helpers/StateMachineLogger.h
+++ b/src/Utilities/StateMachine/Helpers/StateMachineLogger.h
@@ -17,7 +17,7 @@ class QAbstractState;
 class QAbstractTransition;
 class QGCStateMachine;
 
-/// Extended logging for state machines.
+/// \brief Extended logging for state machines.
 ///
 /// Provides configurable, structured logging with multiple output options.
 ///
@@ -34,6 +34,7 @@ class QGCStateMachine;
 /// // Or log to file
 /// logger.setLogFile("/tmp/machine.log");
 /// @endcode
+///
 class StateMachineLogger : public QObject
 {
     Q_OBJECT

--- a/src/Utilities/StateMachine/Helpers/StateMachineProfiler.h
+++ b/src/Utilities/StateMachine/Helpers/StateMachineProfiler.h
@@ -9,7 +9,7 @@
 class QAbstractState;
 class QGCStateMachine;
 
-/// Performance profiler for state machines.
+/// \brief Performance profiler for state machines.
 ///
 /// Tracks time spent in each state and provides profiling data.
 ///
@@ -24,6 +24,7 @@ class QGCStateMachine;
 /// qDebug() << profiler.summary();
 /// qDebug() << profiler.toJson();
 /// @endcode
+///
 class StateMachineProfiler : public QObject
 {
     Q_OBJECT

--- a/src/Utilities/StateMachine/QGCStateMachine.h
+++ b/src/Utilities/StateMachine/QGCStateMachine.h
@@ -57,7 +57,8 @@ class StateMachineLogger;
 class StateMachineProfiler;
 class StateHistoryRecorder;
 
-/// QGroundControl specific state machine with enhanced error handling
+/// \brief QGroundControl specific state machine with enhanced error handling
+///
 class QGCStateMachine : public QStateMachine
 {
     Q_OBJECT

--- a/src/Utilities/StateMachine/QGCStateMachineEvent.h
+++ b/src/Utilities/StateMachine/QGCStateMachineEvent.h
@@ -4,7 +4,8 @@
 #include <QtCore/QString>
 #include <QtCore/QVariant>
 
-/// Custom event for QGCStateMachine delayed/scheduled events
+/// \brief Custom event for QGCStateMachine delayed/scheduled events
+///
 class QGCStateMachineEvent : public QEvent
 {
 public:

--- a/src/Utilities/StateMachine/States/AsyncFunctionState.h
+++ b/src/Utilities/StateMachine/States/AsyncFunctionState.h
@@ -4,13 +4,15 @@
 
 #include <functional>
 
-/// Calls a function when entered and waits for an external trigger to advance
+/// \brief Calls a function when entered and waits for an external trigger to advance
+///
 /// Unlike FunctionState (which advances immediately), this state waits for:
 /// - A signal from an external object, OR
 /// - A call to complete() from within the function's callbacks
 ///
 /// Useful for async operations like loading from vehicle where you call a function
 /// and wait for a completion signal.
+///
 class AsyncFunctionState : public WaitStateBase
 {
     Q_OBJECT

--- a/src/Utilities/StateMachine/States/CircuitBreakerState.h
+++ b/src/Utilities/StateMachine/States/CircuitBreakerState.h
@@ -6,7 +6,7 @@
 
 #include <functional>
 
-/// A state that implements the circuit breaker pattern.
+/// \brief A state that implements the circuit breaker pattern.
 ///
 /// After a threshold of failures, the circuit "trips" and immediately
 /// fails without attempting the action for a reset timeout period.
@@ -28,6 +28,7 @@
 /// state->addTransition(state, &CircuitBreakerState::advance, successState);
 /// state->addTransition(state, &CircuitBreakerState::error, errorState);
 /// @endcode
+///
 class CircuitBreakerState : public QGCState
 {
     Q_OBJECT

--- a/src/Utilities/StateMachine/States/ConditionalState.h
+++ b/src/Utilities/StateMachine/States/ConditionalState.h
@@ -4,8 +4,10 @@
 
 #include <functional>
 
-/// A state that evaluates a predicate on entry and either executes or skips
+/// \brief A state that evaluates a predicate on entry and either executes or skips
+///
 /// Useful for conditional logic like "skip if high latency link"
+///
 class ConditionalState : public QGCState
 {
     Q_OBJECT

--- a/src/Utilities/StateMachine/States/DelayState.h
+++ b/src/Utilities/StateMachine/States/DelayState.h
@@ -4,7 +4,8 @@
 
 #include <QtCore/QTimer>
 
-/// Delays that state machine for the specified time in milliseconds
+/// \brief Delays that state machine for the specified time in milliseconds
+///
 class DelayState : public QGCState
 {
     Q_OBJECT

--- a/src/Utilities/StateMachine/States/EventQueuedState.h
+++ b/src/Utilities/StateMachine/States/EventQueuedState.h
@@ -5,7 +5,7 @@
 #include <QtCore/QSet>
 #include <QtCore/QString>
 
-/// A state that waits for one or more named events before advancing.
+/// \brief A state that waits for one or more named events before advancing.
 ///
 /// This state integrates with QGCStateMachine's postEvent() and postDelayedEvent()
 /// methods to provide event-based state coordination.
@@ -26,6 +26,7 @@
 /// Multiple events can be configured using addExpectedEvent().
 /// The state advances when ANY of the expected events is received (OR logic).
 /// For AND logic (wait for all events), chain multiple EventQueuedState instances.
+///
 class EventQueuedState : public WaitStateBase
 {
     Q_OBJECT

--- a/src/Utilities/StateMachine/States/FallbackChainState.h
+++ b/src/Utilities/StateMachine/States/FallbackChainState.h
@@ -4,7 +4,7 @@
 
 #include <functional>
 
-/// A state that tries multiple strategies in order until one succeeds.
+/// \brief A state that tries multiple strategies in order until one succeeds.
 ///
 /// Strategies are executed in the order they were added. If a strategy
 /// succeeds, the state emits advance(). If all strategies fail, error() is emitted.
@@ -19,6 +19,7 @@
 /// state->addTransition(state, &FallbackChainState::advance, connectedState);
 /// state->addTransition(state, &FallbackChainState::error, failedState);
 /// @endcode
+///
 class FallbackChainState : public QGCState
 {
     Q_OBJECT

--- a/src/Utilities/StateMachine/States/ParallelState.h
+++ b/src/Utilities/StateMachine/States/ParallelState.h
@@ -2,9 +2,11 @@
 
 #include "QGCState.h"
 
-/// State that executes all child states in parallel
+/// \brief State that executes all child states in parallel
+///
 /// When entered, all child states are activated simultaneously.
 /// The state completes when all child states have finished.
+///
 class ParallelState : public QGCState
 {
     Q_OBJECT

--- a/src/Utilities/StateMachine/States/ProgressState.h
+++ b/src/Utilities/StateMachine/States/ProgressState.h
@@ -4,7 +4,8 @@
 
 #include <functional>
 
-/// State that reports progress on entry.
+/// \brief State that reports progress on entry.
+///
 /// Useful for state machines that need to track progress through a sequence of states.
 ///
 /// Progress can be reported as:
@@ -22,6 +23,7 @@
 ///     return calculateProgress();
 /// });
 /// @endcode
+///
 class ProgressState : public QGCState
 {
     Q_OBJECT

--- a/src/Utilities/StateMachine/States/QGCAbstractState.h
+++ b/src/Utilities/StateMachine/States/QGCAbstractState.h
@@ -8,7 +8,7 @@
 class QGCStateMachine;
 class Vehicle;
 
-/// Lightweight base class for simple states.
+/// \brief Lightweight base class for simple states.
 ///
 /// ## When to use QGCAbstractState vs QGCState
 ///
@@ -24,6 +24,7 @@ class Vehicle;
 ///
 /// ## Notes
 /// - Local error-state helpers are not provided; use registerState() for global error handling.
+///
 class QGCAbstractState : public QState
 {
     Q_OBJECT

--- a/src/Utilities/StateMachine/States/QGCFinalState.h
+++ b/src/Utilities/StateMachine/States/QGCFinalState.h
@@ -6,7 +6,8 @@
 class QGCStateMachine;
 class Vehicle;
 
-/// Final state for a QGCStateMachine with logging support
+/// \brief Final state for a QGCStateMachine with logging support
+///
 class QGCFinalState : public QFinalState
 {
     Q_OBJECT

--- a/src/Utilities/StateMachine/States/QGCHistoryState.h
+++ b/src/Utilities/StateMachine/States/QGCHistoryState.h
@@ -8,8 +8,10 @@ Q_DECLARE_LOGGING_CATEGORY(QGCStateMachineLog)
 class QGCStateMachine;
 class Vehicle;
 
-/// QGroundControl wrapper around QHistoryState for consistency with other QGC state classes
+/// \brief QGroundControl wrapper around QHistoryState for consistency with other QGC state classes
+///
 /// History states remember which child state was active and return to it
+///
 class QGCHistoryState : public QHistoryState
 {
     Q_OBJECT

--- a/src/Utilities/StateMachine/States/QGCState.h
+++ b/src/Utilities/StateMachine/States/QGCState.h
@@ -9,7 +9,7 @@ Q_DECLARE_LOGGING_CATEGORY(QGCStateMachineLog)
 class QGCStateMachine;
 class Vehicle;
 
-/// Full-featured base class for QGroundControl state machine states.
+/// \brief Full-featured base class for QGroundControl state machine states.
 ///
 /// Extends QGCAbstractState with:
 /// - Local per-state error handling (setLocalErrorState)
@@ -18,6 +18,7 @@ class Vehicle;
 ///
 /// Use QGCAbstractState when you only need callback-driven entry/exit.
 /// Use QGCState when you need the extra features listed above.
+///
 class QGCState : public QGCAbstractState
 {
     Q_OBJECT

--- a/src/Utilities/StateMachine/States/RequestMessageState.h
+++ b/src/Utilities/StateMachine/States/RequestMessageState.h
@@ -10,12 +10,14 @@ class Vehicle;
 #include <cstdint>
 #include <functional>
 
-/// Requests a MAVLink message from the vehicle using MAV_CMD_REQUEST_MESSAGE.
+/// \brief Requests a MAVLink message from the vehicle using MAV_CMD_REQUEST_MESSAGE.
+///
 /// Emits messageReceived() with the decoded message on success.
 /// Emits completed()/advance() on success, timeout()/timedOut() on timeout, error() on failure.
 ///
 /// Note: Vehicle::requestMessage() has its own internal timeout, but this state
 /// adds an additional safety timeout at the state machine level.
+///
 class RequestMessageState : public WaitStateBase
 {
     Q_OBJECT

--- a/src/Utilities/StateMachine/States/RetryState.h
+++ b/src/Utilities/StateMachine/States/RetryState.h
@@ -6,10 +6,11 @@
 
 #include <functional>
 
-/// A state that retries an action and chooses behavior when retries are exhausted.
+/// \brief A state that retries an action and chooses behavior when retries are exhausted.
 ///
 /// The action is executed on entry. If it fails, the state retries after a delay.
 /// Once retries are exhausted, behavior is controlled by ExhaustedBehavior.
+///
 class RetryState : public QGCState
 {
     Q_OBJECT

--- a/src/Utilities/StateMachine/States/RetryableRequestMessageState.h
+++ b/src/Utilities/StateMachine/States/RetryableRequestMessageState.h
@@ -9,7 +9,8 @@ class Vehicle;
 
 #include <functional>
 
-/// Requests a MAVLink message with built-in retry logic.
+/// \brief Requests a MAVLink message with built-in retry logic.
+///
 /// On failure, retries up to maxRetries times before giving up.
 ///
 /// Emits advance() on success or after all retries exhausted.
@@ -26,6 +27,7 @@ class Vehicle;
 ///     2  // max retries
 /// );
 /// @endcode
+///
 class RetryableRequestMessageState : public WaitStateBase
 {
     Q_OBJECT

--- a/src/Utilities/StateMachine/States/RollbackState.h
+++ b/src/Utilities/StateMachine/States/RollbackState.h
@@ -4,7 +4,7 @@
 
 #include <functional>
 
-/// A state that executes an action with automatic rollback on failure.
+/// \brief A state that executes an action with automatic rollback on failure.
 ///
 /// If the forward action fails, the rollback action is executed before
 /// emitting the error() signal. This provides transaction-like semantics.
@@ -19,6 +19,7 @@
 /// state->addTransition(state, &RollbackState::advance, successState);
 /// state->addTransition(state, &RollbackState::error, errorState);
 /// @endcode
+///
 class RollbackState : public QGCState
 {
     Q_OBJECT

--- a/src/Utilities/StateMachine/States/SendMavlinkCommandState.h
+++ b/src/Utilities/StateMachine/States/SendMavlinkCommandState.h
@@ -5,7 +5,8 @@
 
 class Vehicle;
 
-/// Sends the specified MAVLink command to the vehicle and waits for the result
+/// \brief Sends the specified MAVLink command to the vehicle and waits for the result
+///
 class SendMavlinkCommandState : public WaitStateBase
 {
     Q_OBJECT

--- a/src/Utilities/StateMachine/States/SendMavlinkMessageState.h
+++ b/src/Utilities/StateMachine/States/SendMavlinkMessageState.h
@@ -8,7 +8,8 @@
 
 class Vehicle;
 
-/// Sends the specified MAVLink message to the vehicle
+/// \brief Sends the specified MAVLink message to the vehicle
+///
 class SendMavlinkMessageState : public QGCState
 {
     Q_OBJECT

--- a/src/Utilities/StateMachine/States/SequenceState.h
+++ b/src/Utilities/StateMachine/States/SequenceState.h
@@ -4,7 +4,7 @@
 
 #include <functional>
 
-/// A composite state that executes a sequence of actions in order.
+/// \brief A composite state that executes a sequence of actions in order.
 ///
 /// Each action is executed in turn. If any action fails (returns false),
 /// the sequence stops and error() is emitted. When all actions complete
@@ -29,6 +29,7 @@
 /// seqState->addTransition(seqState, &SequenceState::advance, successState);
 /// seqState->addTransition(seqState, &SequenceState::error, errorState);
 /// @endcode
+///
 class SequenceState : public QGCState
 {
     Q_OBJECT

--- a/src/Utilities/StateMachine/States/ShowAppMessageState.h
+++ b/src/Utilities/StateMachine/States/ShowAppMessageState.h
@@ -4,7 +4,7 @@
 
 #include <QtCore/QString>
 
-/// Display an application message to the user
+/// \brief Display an application message to the user
 
 class ShowAppMessageState : public QGCState
 {

--- a/src/Utilities/StateMachine/States/SkippableAsyncState.h
+++ b/src/Utilities/StateMachine/States/SkippableAsyncState.h
@@ -4,7 +4,8 @@
 
 #include <functional>
 
-/// Combines skip condition checking with async operation setup in a single state.
+/// \brief Combines skip condition checking with async operation setup in a single state.
+///
 /// Common pattern in initialization workflows where operations should be skipped under certain conditions.
 ///
 /// On entry:
@@ -29,6 +30,7 @@
 /// missionState->addTransition(missionState, &QGCState::advance, nextState);
 /// missionState->addTransition(missionState, &SkippableAsyncState::skipped, nextState);
 /// @endcode
+///
 class SkippableAsyncState : public WaitStateBase
 {
     Q_OBJECT

--- a/src/Utilities/StateMachine/States/SubMachineState.h
+++ b/src/Utilities/StateMachine/States/SubMachineState.h
@@ -6,9 +6,11 @@
 
 class QGCStateMachine;
 
-/// State that invokes a child state machine
+/// \brief State that invokes a child state machine
+///
 /// When entered, creates and starts a child state machine.
 /// When the child machine finishes, emits advance() or error().
+///
 class SubMachineState : public QGCState
 {
     Q_OBJECT

--- a/src/Utilities/StateMachine/States/WaitForMavlinkMessageState.h
+++ b/src/Utilities/StateMachine/States/WaitForMavlinkMessageState.h
@@ -8,8 +8,10 @@
 
 class Vehicle;
 
-/// Waits for the specified MAVLink message from the vehicle
+/// \brief Waits for the specified MAVLink message from the vehicle
+///
 /// Filters by message ID and optional predicate before advancing
+///
 class WaitForMavlinkMessageState : public WaitStateBase
 {
     Q_OBJECT

--- a/src/Utilities/StateMachine/States/WaitForParamResponseState.h
+++ b/src/Utilities/StateMachine/States/WaitForParamResponseState.h
@@ -8,10 +8,12 @@
 
 class Vehicle;
 
-/// Waits for either PARAM_VALUE (success) or PARAM_ERROR (rejection) from the vehicle.
+/// \brief Waits for either PARAM_VALUE (success) or PARAM_ERROR (rejection) from the vehicle.
+///
 /// On PARAM_VALUE matching predicate: calls waitComplete() (emits advance())
 /// On PARAM_ERROR matching predicate: stores error info, calls waitFailed() (emits error())
 /// On timeout: existing timeout() signal fires (for retry path)
+///
 class WaitForParamResponseState : public WaitStateBase
 {
     Q_OBJECT

--- a/src/Utilities/StateMachine/States/WaitForSignalState.h
+++ b/src/Utilities/StateMachine/States/WaitForSignalState.h
@@ -6,8 +6,10 @@
 
 #include <functional>
 
-/// Waits for a signal from a QObject before advancing
+/// \brief Waits for a signal from a QObject before advancing
+///
 /// Can optionally timeout if the signal is not received within a specified time
+///
 class WaitForSignalState : public WaitStateBase
 {
     Q_OBJECT

--- a/src/Utilities/StateMachine/States/WaitStateBase.h
+++ b/src/Utilities/StateMachine/States/WaitStateBase.h
@@ -4,8 +4,10 @@
 
 #include <QtCore/QTimer>
 
-/// Base class for states that wait for something with optional timeout
+/// \brief Base class for states that wait for something with optional timeout
+///
 /// Provides common timeout handling infrastructure
+///
 class WaitStateBase : public QGCState
 {
     Q_OBJECT

--- a/src/Utilities/StateMachine/Transitions/GuardedTransition.h
+++ b/src/Utilities/StateMachine/Transitions/GuardedTransition.h
@@ -4,8 +4,10 @@
 
 #include <functional>
 
-/// A transition that only fires if a guard predicate returns true
+/// \brief A transition that only fires if a guard predicate returns true
+///
 /// Useful for conditional transitions based on runtime state
+///
 class GuardedTransition : public QGCSignalTransition
 {
     Q_OBJECT

--- a/src/Utilities/StateMachine/Transitions/InternalTransition.h
+++ b/src/Utilities/StateMachine/Transitions/InternalTransition.h
@@ -4,9 +4,11 @@
 
 #include <functional>
 
-/// Transition that fires without exiting/re-entering the current state
+/// \brief Transition that fires without exiting/re-entering the current state
+///
 /// Useful for handling repeated signals (like heartbeats) without state churn.
 /// The action is executed but no state exit/entry occurs.
+///
 class InternalTransition : public QGCSignalTransition
 {
     Q_OBJECT

--- a/src/Utilities/StateMachine/Transitions/MachineEventTransition.h
+++ b/src/Utilities/StateMachine/Transitions/MachineEventTransition.h
@@ -6,9 +6,11 @@
 #include <QtCore/QString>
 #include <functional>
 
-/// Transition that fires when a named event is posted to the state machine
+/// \brief Transition that fires when a named event is posted to the state machine
+///
 /// Use this for events posted via QGCStateMachine::postEvent/postDelayedEvent.
 /// For events on watched objects, use NamedEventTransition instead.
+///
 class MachineEventTransition : public QGCAbstractTransition
 {
     Q_OBJECT

--- a/src/Utilities/StateMachine/Transitions/NamedEventTransition.h
+++ b/src/Utilities/StateMachine/Transitions/NamedEventTransition.h
@@ -6,9 +6,11 @@
 #include <QtCore/QString>
 #include <functional>
 
-/// Transition that fires when a named QGCStateMachineEvent is posted to the state machine
+/// \brief Transition that fires when a named QGCStateMachineEvent is posted to the state machine
+///
 /// Uses QAbstractTransition (via QGCAbstractTransition) to intercept events posted via
 /// QStateMachine::postEvent() / QGCStateMachine::postEvent().
+///
 class NamedEventTransition : public QGCAbstractTransition
 {
     Q_OBJECT

--- a/src/Utilities/StateMachine/Transitions/QGCAbstractTransition.h
+++ b/src/Utilities/StateMachine/Transitions/QGCAbstractTransition.h
@@ -6,7 +6,8 @@
 class QGCStateMachine;
 class Vehicle;
 
-/// Base class for custom transitions that need access to QGCStateMachine and Vehicle
+/// \brief Base class for custom transitions that need access to QGCStateMachine and Vehicle
+///
 class QGCAbstractTransition : public QAbstractTransition
 {
     Q_OBJECT

--- a/src/Utilities/StateMachine/Transitions/QGCEventTransition.h
+++ b/src/Utilities/StateMachine/Transitions/QGCEventTransition.h
@@ -3,8 +3,10 @@
 #include <QtStateMachine/QEventTransition>
 #include <functional>
 
-/// Transition that fires when a specific QEvent is received by a watched object
+/// \brief Transition that fires when a specific QEvent is received by a watched object
+///
 /// Useful for reacting to timer events, mouse events, focus changes, etc.
+///
 class QGCEventTransition : public QEventTransition
 {
     Q_OBJECT

--- a/src/Utilities/StateMachine/Transitions/QGCSignalTransition.h
+++ b/src/Utilities/StateMachine/Transitions/QGCSignalTransition.h
@@ -6,7 +6,8 @@
 class QGCStateMachine;
 class Vehicle;
 
-/// Base class for signal-based transitions that need access to QGCStateMachine and Vehicle
+/// \brief Base class for signal-based transitions that need access to QGCStateMachine and Vehicle
+///
 class QGCSignalTransition : public QSignalTransition
 {
     Q_OBJECT

--- a/src/Utilities/StateMachine/Transitions/RetryTransition.h
+++ b/src/Utilities/StateMachine/Transitions/RetryTransition.h
@@ -4,7 +4,8 @@
 
 #include <functional>
 
-/// Transition that retries an action N times before advancing to target state.
+/// \brief Transition that retries an action N times before advancing to target state.
+///
 /// Useful for timeout handling where you want to retry before giving up.
 ///
 /// On each trigger (e.g., timeout signal):
@@ -21,6 +22,7 @@
 /// );
 /// state->addTransition(retry);
 /// @endcode
+///
 class RetryTransition : public QGCSignalTransition
 {
     Q_OBJECT

--- a/src/Utilities/StateMachine/Transitions/TimeoutTransition.h
+++ b/src/Utilities/StateMachine/Transitions/TimeoutTransition.h
@@ -4,7 +4,8 @@
 
 #include <QtCore/QTimer>
 
-/// Transition that fires automatically after a specified delay.
+/// \brief Transition that fires automatically after a specified delay.
+///
 /// Useful for adding timeout behavior to any state without requiring WaitStateBase.
 ///
 /// The timer starts when the source state is entered and stops when exited.
@@ -15,6 +16,7 @@
 /// auto* timeoutTransition = new TimeoutTransition(5000, errorState);
 /// normalState->addTransition(timeoutTransition);
 /// @endcode
+///
 class TimeoutTransition : public QGCSignalTransition
 {
     Q_OBJECT

--- a/src/Vehicle/ComponentInformation/CompInfo.h
+++ b/src/Vehicle/ComponentInformation/CompInfo.h
@@ -9,7 +9,8 @@ class Vehicle;
 class FirmwarePlugin;
 class CompInfoGeneral;
 
-/// Base class for all CompInfo types
+/// \brief Base class for all CompInfo types
+///
 class CompInfo : public QObject
 {
     Q_OBJECT

--- a/src/Vehicle/FTPController.h
+++ b/src/Vehicle/FTPController.h
@@ -14,7 +14,8 @@ class FTPManager;
 class Vehicle;
 class QGCCompressionJob;
 
-/// QML-facing controller for MAVLink FTP operations.
+/// \brief QML-facing controller for MAVLink FTP operations.
+///
 class FTPController : public QObject
 {
     Q_OBJECT

--- a/src/Vehicle/FactGroups/RadioStatusFactGroup.h
+++ b/src/Vehicle/FactGroups/RadioStatusFactGroup.h
@@ -2,13 +2,14 @@
 
 #include "FactGroup.h"
 
-/// Radio link telemetry decoded from MAVLINK_MSG_ID_RADIO_STATUS.
+/// \brief Radio link telemetry decoded from MAVLINK_MSG_ID_RADIO_STATUS.
 ///
 /// Consolidates the seven scalars that the 3DR-style telemetry radios publish:
 /// local/remote RSSI (dBm), local/remote noise floor (dBm), RX error counters,
 /// errors fixed, and the TX buffer fill percentage. The 3DR Si1k raw-to-dBm
 /// conversion from the datasheet is applied here (detected via the '3'/'D'
 /// sysid/compid marker).
+///
 class RadioStatusFactGroup : public FactGroup
 {
     Q_OBJECT

--- a/src/Vehicle/InitialConnectStateMachine.h
+++ b/src/Vehicle/InitialConnectStateMachine.h
@@ -9,13 +9,15 @@ class AsyncFunctionState;
 class RetryableRequestMessageState;
 class RetryState;
 
-/// State machine for initial vehicle connection sequence.
+/// \brief State machine for initial vehicle connection sequence.
+///
 /// Handles requesting autopilot version, standard modes, component info,
 /// parameters, missions, geofence, and rally points in sequence.
 ///
 /// Uses QGCStateMachine's built-in weighted progress tracking where different
 /// states contribute different amounts to the overall progress (e.g., parameter
 /// loading takes longer than version request).
+///
 class InitialConnectStateMachine : public QGCStateMachine
 {
     Q_OBJECT

--- a/src/Vehicle/MavCommandQueue.h
+++ b/src/Vehicle/MavCommandQueue.h
@@ -11,12 +11,13 @@
 
 class Vehicle;
 
-/// Owns the COMMAND_LONG / COMMAND_INT send/retry/ack pipeline for a single Vehicle.
+/// \brief Owns the COMMAND_LONG / COMMAND_INT send/retry/ack pipeline for a single Vehicle.
 ///
 /// Each outbound command is appended to a per-vehicle queue with its retry policy
 /// and ack timeout. A periodic timer resends entries whose ack window has expired;
 /// incoming COMMAND_ACK messages are matched by (compId, command) and either complete
 /// the entry or refresh its timer on MAV_RESULT_IN_PROGRESS.
+///
 class MavCommandQueue : public QObject, public VehicleTypes
 {
     Q_OBJECT

--- a/src/Vehicle/MessageIntervalManager.h
+++ b/src/Vehicle/MessageIntervalManager.h
@@ -12,11 +12,13 @@ class MavCommandQueue;
 class RequestMessageCoordinator;
 class Vehicle;
 
-/// Tracks per-component MAVLink message intervals and mediates SET_MESSAGE_INTERVAL
+/// \brief Tracks per-component MAVLink message intervals and mediates SET_MESSAGE_INTERVAL
+///
 /// commands plus MESSAGE_INTERVAL request/response flows.
 ///
 /// Layers on top of MavCommandQueue (for SET_MESSAGE_INTERVAL) and
 /// RequestMessageCoordinator (for MESSAGE_INTERVAL queries).
+///
 class MessageIntervalManager : public QObject, public VehicleTypes
 {
     Q_OBJECT

--- a/src/Vehicle/RequestMessageCoordinator.h
+++ b/src/Vehicle/RequestMessageCoordinator.h
@@ -11,10 +11,12 @@
 class MavCommandQueue;
 class Vehicle;
 
-/// Coordinates MAV_CMD_REQUEST_MESSAGE workflows: per-component queueing, ack/message
+/// \brief Coordinates MAV_CMD_REQUEST_MESSAGE workflows: per-component queueing, ack/message
+///
 /// correlation, duplicate suppression, and timeout handling for the requested message.
 ///
 /// Layers on top of MavCommandQueue for the actual command send + ack callback.
+///
 class RequestMessageCoordinator : public QObject, public VehicleTypes
 {
     Q_OBJECT

--- a/src/Vehicle/TerrainQueryCoordinator.h
+++ b/src/Vehicle/TerrainQueryCoordinator.h
@@ -11,7 +11,8 @@
 class TerrainAtCoordinateQuery;
 class Vehicle;
 
-/// Coordinates the three terrain-query workflows attached to a Vehicle:
+/// \brief Coordinates the three terrain-query workflows attached to a Vehicle:
+///
 ///   1. DO_SET_HOME: query terrain altitude for the target coord, then send
 ///      MAV_CMD_DO_SET_HOME with a sanity-checked AMSL altitude.
 ///   2. ROI (PX4 only): query terrain altitude for the target coord, then send
@@ -22,6 +23,7 @@ class Vehicle;
 /// Each workflow owns a single outstanding TerrainAtCoordinateQuery; starting a new
 /// request while one is in-flight disconnects the previous one (auto-deleted by
 /// TerrainQuery). Callbacks access the Vehicle to send commands or write facts.
+///
 class TerrainQueryCoordinator : public QObject
 {
     Q_OBJECT

--- a/src/Vehicle/VehicleSetup/Bootloader.h
+++ b/src/Vehicle/VehicleSetup/Bootloader.h
@@ -10,7 +10,8 @@
 
 class FirmwareImage;
 
-/// Bootloader Utility routines. Works with PX4 and 3DR Radio bootloaders.
+/// \brief Bootloader Utility routines. Works with PX4 and 3DR Radio bootloaders.
+///
 class Bootloader : public QObject
 {
     Q_OBJECT

--- a/src/Vehicle/VehicleSetup/FirmwareImage.h
+++ b/src/Vehicle/VehicleSetup/FirmwareImage.h
@@ -6,7 +6,8 @@
 #include <QtCore/QList>
 #include <QtCore/QTextStream>
 
-/// Support for Intel Hex firmware file
+/// \brief Support for Intel Hex firmware file
+///
 class FirmwareImage : public QObject
 {
     Q_OBJECT

--- a/src/Vehicle/VehicleSetup/PX4FirmwareUpgradeThread.h
+++ b/src/Vehicle/VehicleSetup/PX4FirmwareUpgradeThread.h
@@ -17,6 +17,7 @@ class QTimer;
 /// @brief Used to run bootloader commands on a separate thread. These routines are mainly meant to to be called
 ///         internally by the PX4FirmwareUpgradeThreadController. Clients should call the various public methods
 ///         exposed by PX4FirmwareUpgradeThreadController.
+///
 class PX4FirmwareUpgradeThreadWorker : public QObject
 {
     Q_OBJECT
@@ -69,6 +70,7 @@ private:
 
 /// @brief Provides methods to interact with the bootloader. The commands themselves are signalled
 ///         across to PX4FirmwareUpgradeThreadWorker so that they run on the separate thread.
+///
 class PX4FirmwareUpgradeThreadController : public QObject
 {
     Q_OBJECT

--- a/src/Vehicle/VehicleSetup/RemoteControlCalibrationController.h
+++ b/src/Vehicle/VehicleSetup/RemoteControlCalibrationController.h
@@ -7,7 +7,8 @@
 #include "FactPanelController.h"
 #include "QGCMAVLink.h"
 
-/// Abstract base class for calibrating RC and Joystick controller.
+/// \brief Abstract base class for calibrating RC and Joystick controller.
+///
 class RemoteControlCalibrationController : public FactPanelController
 {
     Q_OBJECT

--- a/src/Vehicle/VehicleSigningController.h
+++ b/src/Vehicle/VehicleSigningController.h
@@ -17,8 +17,10 @@
 class SigningController;
 class Vehicle;
 
-/// Per-vehicle signing facade. Owns the wiring between Vehicle and the active SigningController
+/// \brief Per-vehicle signing facade. Owns the wiring between Vehicle and the active SigningController
+///
 /// (which lives on the vehicle's primary LinkInterface). Re-binds when the primary link changes.
+///
 class VehicleSigningController : public QObject
 {
     Q_OBJECT

--- a/src/VideoManager/VideoReceiver/GStreamer/GstAppSinkAdapter.h
+++ b/src/VideoManager/VideoReceiver/GStreamer/GstAppSinkAdapter.h
@@ -34,11 +34,12 @@ QVideoFrameFormat                applyCropMeta    (QVideoFrameFormat format, Gst
 #include <gst/video/video.h>
 void                             applyOrientationToFrame(QVideoFrame &frame, GstVideoOrientationMethod method);
 
-/// Bridges a GStreamer appsink to a Qt QVideoSink.
+/// \brief Bridges a GStreamer appsink to a Qt QVideoSink.
 ///
 /// Each decoded frame arriving at the appsink is copied into a QVideoFrame
 /// and pushed to the QVideoSink, which renders through Qt's native RHI
 /// backend (Metal on macOS, Vulkan/D3D elsewhere).
+///
 class GstAppSinkAdapter : public QObject
 {
     Q_OBJECT

--- a/src/VideoManager/VideoReceiver/GStreamer/HwBuffers/GstAHardwareBufferVideoBuffer.h
+++ b/src/VideoManager/VideoReceiver/GStreamer/HwBuffers/GstAHardwareBufferVideoBuffer.h
@@ -10,10 +10,11 @@
 
 class QRhi;
 
-/// Zero-copy QVideoFrame backing for GStreamer AHardwareBuffer samples (Android).
+/// \brief Zero-copy QVideoFrame backing for GStreamer AHardwareBuffer samples (Android).
 ///
 /// Imports via eglGetNativeClientBufferANDROID + eglCreateImageKHR into GL textures.
 /// Requires EGL_ANDROID_image_native_buffer.
+///
 class GstAHardwareBufferVideoBuffer final : public GstHwVideoBuffer
 {
 public:

--- a/src/VideoManager/VideoReceiver/GStreamer/HwBuffers/GstD3D11VideoBuffer.h
+++ b/src/VideoManager/VideoReceiver/GStreamer/HwBuffers/GstD3D11VideoBuffer.h
@@ -8,7 +8,8 @@
 
 class QRhi;
 
-/// Wraps a D3D11Memory-backed GstSample as a QHwVideoBuffer; samples natively on QRhi::D3D11.
+/// \brief Wraps a D3D11Memory-backed GstSample as a QHwVideoBuffer; samples natively on QRhi::D3D11.
+///
 class GstD3D11VideoBuffer final : public GstHwVideoBuffer
 {
 public:

--- a/src/VideoManager/VideoReceiver/GStreamer/HwBuffers/GstD3D12VideoBuffer.h
+++ b/src/VideoManager/VideoReceiver/GStreamer/HwBuffers/GstD3D12VideoBuffer.h
@@ -8,7 +8,8 @@
 
 class QRhi;
 
-/// Wraps a D3D12Memory-backed GstSample as a QHwVideoBuffer; samples natively on QRhi::D3D12.
+/// \brief Wraps a D3D12Memory-backed GstSample as a QHwVideoBuffer; samples natively on QRhi::D3D12.
+///
 class GstD3D12VideoBuffer final : public GstHwVideoBuffer
 {
 public:

--- a/src/VideoManager/VideoReceiver/GStreamer/HwBuffers/GstDmaBufVideoBuffer.h
+++ b/src/VideoManager/VideoReceiver/GStreamer/HwBuffers/GstDmaBufVideoBuffer.h
@@ -11,10 +11,11 @@
 
 class QRhi;
 
-/// Zero-copy QVideoFrame backing for GStreamer DMABuf samples.
+/// \brief Zero-copy QVideoFrame backing for GStreamer DMABuf samples.
 ///
 /// Imports per-plane DMABuf fds into EGLImages on demand in mapTextures(),
 /// which Qt invokes on the render thread with a current GL context.
+///
 class GstDmaBufVideoBuffer final : public GstHwVideoBuffer
 {
 public:

--- a/src/VideoManager/VideoReceiver/GStreamer/HwBuffers/GstGlVideoBuffer.h
+++ b/src/VideoManager/VideoReceiver/GStreamer/HwBuffers/GstGlVideoBuffer.h
@@ -8,10 +8,11 @@
 
 class QRhi;
 
-/// Zero-copy QVideoFrame backing for GStreamer GLMemory samples.
+/// \brief Zero-copy QVideoFrame backing for GStreamer GLMemory samples.
 ///
 /// Wraps GstGLMemory texture ids in QRhiTextures. Requires the QRhi GL context
 /// to share with the GstGLContext — see GstGlContextBridge for the wiring.
+///
 class GstGlVideoBuffer final : public GstHwVideoBuffer
 {
 public:

--- a/src/VideoManager/VideoReceiver/GStreamer/HwBuffers/GstHwVideoBuffer.h
+++ b/src/VideoManager/VideoReceiver/GStreamer/HwBuffers/GstHwVideoBuffer.h
@@ -8,10 +8,11 @@
 #include <gst/gst.h>
 #include <gst/video/video-info.h>
 
-/// Common base for GStreamer-backed QHwVideoBuffer subclasses.
+/// \brief Common base for GStreamer-backed QHwVideoBuffer subclasses.
 ///
 /// Owns a ref on GstSample for its lifetime; holds a GstVideoInfo and
 /// QVideoFrameFormat so subclasses don't duplicate those three members.
+///
 class GstHwVideoBuffer : public QHwVideoBuffer
 {
 public:

--- a/src/VideoManager/VideoReceiver/GStreamer/HwBuffers/GstIOSurfaceVideoBuffer.h
+++ b/src/VideoManager/VideoReceiver/GStreamer/HwBuffers/GstIOSurfaceVideoBuffer.h
@@ -8,7 +8,8 @@
 
 class QRhi;
 
-/// Wraps a GstAppleCoreVideoMemory/IOSurface-backed sample as a QHwVideoBuffer; samples natively on QRhi::Metal.
+/// \brief Wraps a GstAppleCoreVideoMemory/IOSurface-backed sample as a QHwVideoBuffer; samples natively on QRhi::Metal.
+///
 class GstIOSurfaceVideoBuffer final : public GstHwVideoBuffer
 {
 public:

--- a/tools/coding-style/CodingStyle.h
+++ b/tools/coding-style/CodingStyle.h
@@ -29,13 +29,22 @@ class Vehicle;
 // with a suffix of Log.
 Q_DECLARE_LOGGING_CATEGORY(CodingStyleLog)
 
-/// Here is the class documentation. Class names are PascalCase. If you override any of the Qt base classes to provide
-/// generic base implementations for widespread use prefix the class name with QGC. For example:
-/// For normal single use classes do not prefix the name with QGC.
+/// \brief One-line summary of the class (the Doxygen "brief" description).
+///
+/// The first line must begin with \brief followed by a blank /// line.
+/// It becomes the brief description shown in the
+/// annotated class list and at the top of the class page in the generated docs.
+///
+/// Everything after the blank /// line is the detailed description. Explain the purpose,
+/// ownership model, thread safety, and any important usage notes here.
+///
+/// Class names are PascalCase. If you override any Qt base class to provide a generic
+/// base implementation for widespread use, prefix the name with QGC (e.g. QGCMapPolygon).
+/// For normal single-use classes do not prefix the name with QGC.
 ///
 /// Qt6 QML Integration: Use QML_ELEMENT for QML-creatable types, QML_SINGLETON for singletons,
 /// and QML_UNCREATABLE("reason") for C++-only instantiation.
-
+///
 class CodingStyle : public QObject
 {
     Q_OBJECT


### PR DESCRIPTION
## Problem

Several issues caused QGC classes to be poorly documented in the Doxygen output at https://api.qgroundcontrol.com/master/:

1. **Missing QML macros in `PREDEFINED`** — `QML_UNCREATABLE`, `QML_ELEMENT`, `Q_MOC_INCLUDE`, and related macros were not defined for Doxygen's preprocessor. When Doxygen encountered these in a class body, it misparsed the surrounding code, causing public member functions to be absent from the search index.

2. **No `\brief` on class doc comments** — Class doc blocks used plain `///` comments with no `\brief` tag. Without `QT_AUTOBRIEF` enabled, Doxygen produces no brief description, so classes appear with blank entries in the annotated class list.

3. **No visual separation in class doc blocks** — Class doc blocks had no blank `///` line after `\brief` or before the `class` keyword, making them harder to read.

## Fix

- Add `QML_UNCREATABLE(x)=`, `QML_ELEMENT`, `QML_SINGLETON`, `QML_ANONYMOUS`, `QML_NAMED_ELEMENT(x)=`, `QML_EXTENDED(x)=`, `QML_ATTACHED(x)=`, `QML_ADDED_IN_VERSION(x,y)=`, and `Q_MOC_INCLUDE(x)=` to `PREDEFINED` in the Doxyfile.
- Standardize class-level Doxygen doc comments across all `src/` headers (184 class blocks, 178 files):
  - Add `\brief` to the first line of every class doc block
  - Add a blank `///` line after `\brief` when followed by a detailed description
  - Add a trailing blank `///` line between the doc block and the `class` declaration
- Update `tools/coding-style/CodingStyle.h` to document the class doc comment conventions.