### PR TITLE
LogViewer: guard APM dialect code and broaden custom-build CI trigger

### DIFF
--- a/.github/workflows/custom-build.yml
+++ b/.github/workflows/custom-build.yml
@@ -1,16 +1,17 @@
 name: Custom Build
 
 on:
+  # Intentionally mirrors the paths-ignore filter used by the standard platform
+  # CI workflows (linux.yml, macos.yml, windows.yml). Mainline QGC source
+  # changes can break the custom build, so this workflow must run whenever
+  # those workflows run.
   push:
     branches: [master]
-    paths:
-      - 'custom-example/**'
-      - '.github/workflows/custom-build.yml'
+    paths-ignore:
+      - 'docs/**'
   pull_request:
-    branches: [master]
-    paths:
-      - 'custom-example/**'
-      - '.github/workflows/custom-build.yml'
+    paths-ignore:
+      - 'docs/**'
   workflow_dispatch:
 
 concurrency:

--- a/src/AnalyzeView/LogViewer/LogFileParser.cc
+++ b/src/AnalyzeView/LogViewer/LogFileParser.cc
@@ -115,12 +115,14 @@ void LogFileParser::_applyResult(const LogParseResult &result)
     if (!_parameters.isEmpty()) {
         if (result.sourceType == LogParseResult::SourceType::PX4ULog) {
             LogViewerParamMetaData::enrichForPX4(_parameters);
+#ifndef QGC_NO_ARDUPILOT_DIALECT
         } else if (result.sourceType == LogParseResult::SourceType::APMDataFlash) {
             LogViewerParamMetaData::enrichForAPM(
                 _parameters,
                 result.detectedVehicleType,
                 result.firmwareMajorVersion,
                 result.firmwareMinorVersion);
+#endif
         }
     }
     _events = result.events;

--- a/src/AnalyzeView/LogViewer/LogViewerPage.qml
+++ b/src/AnalyzeView/LogViewer/LogViewerPage.qml
@@ -216,7 +216,8 @@ AnalyzePage {
                 spacing: ScreenTools.defaultFontPixelWidth
 
                 QGCButton {
-                    text: qsTr("Open .bin")
+                    text:    qsTr("Open .bin")
+                    visible: QGroundControl.hasAPMSupport
                     onClicked: {
                         openDialog.nameFilters = ["DataFlash Logs (*.bin *.BIN *.log *.LOG)"]
                         openDialog.openForLoad()

--- a/src/AnalyzeView/LogViewer/LogViewerParamMetaData.cc
+++ b/src/AnalyzeView/LogViewer/LogViewerParamMetaData.cc
@@ -1,6 +1,8 @@
 #include "LogViewerParamMetaData.h"
 
+#ifndef QGC_NO_ARDUPILOT_DIALECT
 #include "APMParameterMetaData.h"
+#endif
 #include "FactMetaData.h"
 #include "PX4ParameterMetaData.h"
 #include "QGCLoggingCategory.h"
@@ -10,6 +12,8 @@
 QGC_LOGGING_CATEGORY(LogViewerParamMetaDataLog, "AnalyzeView.LogViewerParamMetaData")
 
 namespace {
+
+#ifndef QGC_NO_ARDUPILOT_DIALECT
 
 // Map the APM vehicle name as stored in detectedVehicleType to the file-path
 // component used in :/FirmwarePlugin/APM/APMParameterFactMetaData.{X}.major.minor.json
@@ -53,6 +57,8 @@ QString _findAPMMetaDataFile(const QString &fileVehicleName, int major, int mino
 
     return QString();
 }
+
+#endif // QGC_NO_ARDUPILOT_DIALECT
 
 void _enrichRows(QVariantList &parameters, ParameterMetaData *metaData)
 {
@@ -98,6 +104,7 @@ void LogViewerParamMetaData::enrichForPX4(QVariantList &parameters)
     delete metaData;
 }
 
+#ifndef QGC_NO_ARDUPILOT_DIALECT
 void LogViewerParamMetaData::enrichForAPM(QVariantList &parameters,
                                           const QString &vehicleType,
                                           int major,
@@ -134,3 +141,5 @@ void LogViewerParamMetaData::enrichForAPM(QVariantList &parameters,
 
     delete metaData;
 }
+
+#endif // QGC_NO_ARDUPILOT_DIALECT

--- a/src/AnalyzeView/LogViewer/LogViewerParamMetaData.h
+++ b/src/AnalyzeView/LogViewer/LogViewerParamMetaData.h
@@ -20,6 +20,7 @@ public:
     /// Enrich parameters from a PX4 ULog file.
     static void enrichForPX4(QVariantList &parameters);
 
+#ifndef QGC_NO_ARDUPILOT_DIALECT
     /// Enrich parameters from an APM DataFlash file.
     /// @param vehicleType  APM vehicle name: "ArduCopter", "ArduPlane", "ArduRover", "ArduSub"
     /// @param major / minor  Firmware version numbers parsed from the log (pass -1 if unknown).
@@ -27,4 +28,5 @@ public:
                              const QString &vehicleType,
                              int major,
                              int minor);
+#endif
 };


### PR DESCRIPTION
## Summary

Guard all APM-dialect-specific code in the Log Viewer behind `QGC_NO_ARDUPILOT_DIALECT` so that custom builds compiled without APM support build and link cleanly. Also broaden the custom-build CI trigger so that mainline `src/` changes that break the custom build are caught automatically.

## Changes

### `src/AnalyzeView/LogViewer/LogViewerParamMetaData.h`
- Wrap `enrichForAPM()` declaration in `#ifndef QGC_NO_ARDUPILOT_DIALECT`.

### `src/AnalyzeView/LogViewer/LogViewerParamMetaData.cc`
- Wrap `#include "APMParameterMetaData.h"` and the two APM helper functions in `#ifndef QGC_NO_ARDUPILOT_DIALECT`.
- Wrap the `enrichForAPM()` definition in `#ifndef QGC_NO_ARDUPILOT_DIALECT`.

### `src/AnalyzeView/LogViewer/LogFileParser.cc`
- Wrap the `enrichForAPM()` call site in `#ifndef QGC_NO_ARDUPILOT_DIALECT`.

### `src/AnalyzeView/LogViewer/LogViewerPage.qml`
- Add `visible: QGroundControl.hasAPMSupport` to the "Open .bin" button so it is hidden in non-APM builds.

### `.github/workflows/custom-build.yml`
- Change trigger from `paths: [custom-example/**, …]` to `paths-ignore: [docs/**]`, matching the pattern used by `linux.yml`, `macos.yml`, and `windows.yml`. Mainline `src/` changes can break the custom build; this ensures the workflow runs whenever the platform CI workflows run.
