### PR TITLE
LogViewer APM dialect guards, CI hardening, and PerimeterScan custom complex item

### DIFF
--- a/.github/workflows/custom-build.yml
+++ b/.github/workflows/custom-build.yml
@@ -1,16 +1,17 @@
 name: Custom Build
 
 on:
+  # Intentionally mirrors the paths-ignore filter used by the standard platform
+  # CI workflows (linux.yml, macos.yml, windows.yml). Mainline QGC source
+  # changes can break the custom build, so this workflow must run whenever
+  # those workflows run.
   push:
     branches: [master]
-    paths:
-      - 'custom-example/**'
-      - '.github/workflows/custom-build.yml'
+    paths-ignore:
+      - 'docs/**'
   pull_request:
-    branches: [master]
-    paths:
-      - 'custom-example/**'
-      - '.github/workflows/custom-build.yml'
+    paths-ignore:
+      - 'docs/**'
   workflow_dispatch:
 
 concurrency:

--- a/custom-example/CMakeLists.txt
+++ b/custom-example/CMakeLists.txt
@@ -88,6 +88,27 @@ qt_add_qml_module(CustomModule
 )
 
 # ============================================================================
+# Custom Plan Module (PerimeterScan map visual + editor)
+# ============================================================================
+
+qt_add_library(CustomPlanModule STATIC)
+
+qgc_set_qt_resource_alias(
+    ${CMAKE_CURRENT_SOURCE_DIR}/src/PlanView/PerimeterScanMapVisual.qml
+    ${CMAKE_CURRENT_SOURCE_DIR}/src/PlanView/PerimeterScanEditor.qml
+)
+
+qt_add_qml_module(CustomPlanModule
+    URI Custom.Plan
+    VERSION 1.0
+    RESOURCE_PREFIX /qml
+    QML_FILES
+        ${CMAKE_CURRENT_SOURCE_DIR}/src/PlanView/PerimeterScanMapVisual.qml
+        ${CMAKE_CURRENT_SOURCE_DIR}/src/PlanView/PerimeterScanEditor.qml
+    NO_PLUGIN
+)
+
+# ============================================================================
 # Custom Plugin Sources
 # ============================================================================
 
@@ -100,6 +121,10 @@ set(CUSTOM_SOURCES
     ${CMAKE_CURRENT_SOURCE_DIR}/src/FirmwarePlugin/CustomFirmwarePlugin.h
     ${CMAKE_CURRENT_SOURCE_DIR}/src/FirmwarePlugin/CustomFirmwarePluginFactory.cc
     ${CMAKE_CURRENT_SOURCE_DIR}/src/FirmwarePlugin/CustomFirmwarePluginFactory.h
+    ${CMAKE_CURRENT_SOURCE_DIR}/src/MissionManager/PerimeterScanComplexItem.cc
+    ${CMAKE_CURRENT_SOURCE_DIR}/src/MissionManager/PerimeterScanComplexItem.h
+    ${CMAKE_CURRENT_SOURCE_DIR}/src/MissionManager/PerimeterScanPlanCreator.cc
+    ${CMAKE_CURRENT_SOURCE_DIR}/src/MissionManager/PerimeterScanPlanCreator.h
     CACHE INTERNAL "" FORCE
 )
 
@@ -110,6 +135,7 @@ set(CUSTOM_SOURCES
 # Custom libraries to link
 set(CUSTOM_LIBRARIES
     CustomModule
+    CustomPlanModule
     CACHE INTERNAL "" FORCE
 )
 
@@ -118,6 +144,7 @@ set(CUSTOM_INCLUDE_DIRECTORIES
     ${CMAKE_CURRENT_SOURCE_DIR}/src
     ${CMAKE_CURRENT_SOURCE_DIR}/src/AutoPilotPlugin
     ${CMAKE_CURRENT_SOURCE_DIR}/src/FirmwarePlugin
+    ${CMAKE_CURRENT_SOURCE_DIR}/src/MissionManager
     CACHE INTERNAL "" FORCE
 )
 

--- a/custom-example/custom.qrc
+++ b/custom-example/custom.qrc
@@ -27,4 +27,10 @@
         <file alias="QGCLogoFull.svg">res/Images/QGCLogoFull.svg</file>
         <file alias="qgroundcontrol.ico">res/icons/custom_qgroundcontrol.ico</file>
     </qresource>
+    <qresource prefix="/res">
+        <file alias="gear-white.svg">../resources/gear-white.svg</file>
+    </qresource>
+    <qresource prefix="/json">
+        <file alias="PerimeterScan.SettingsGroup.json">res/json/PerimeterScan.SettingsGroup.json</file>
+    </qresource>
 </RCC>

--- a/custom-example/res/json/PerimeterScan.SettingsGroup.json
+++ b/custom-example/res/json/PerimeterScan.SettingsGroup.json
@@ -1,0 +1,13 @@
+{
+    "version":      1,
+    "fileType":  "FactMetaData",
+    "QGC.MetaData.Facts":
+[{
+    "name":             "Altitude",
+    "shortDesc": "Altitude to fly the perimeter scan.",
+    "type":             "double",
+    "units":            "m",
+    "decimalPlaces":    1,
+    "default":     50
+}]
+}

--- a/custom-example/src/CustomPlugin.cc
+++ b/custom-example/src/CustomPlugin.cc
@@ -1,4 +1,6 @@
 #include "CustomPlugin.h"
+#include "PerimeterScanComplexItem.h"
+#include "PerimeterScanPlanCreator.h"
 #include "QmlComponentInfo.h"
 #include "QGCLoggingCategory.h"
 #include "QGCPalette.h"
@@ -256,6 +258,7 @@ QQmlApplicationEngine* CustomPlugin::createQmlApplicationEngine(QObject* parent)
 {
     _qmlEngine = QGCCorePlugin::createQmlApplicationEngine(parent);
     _qmlEngine->addImportPath("qrc:/qml/Custom/Widgets");
+    _qmlEngine->addImportPath("qrc:/qml/Custom/Plan");
     // TODO: Investigate _qmlEngine->setExtraSelectors({"custom"})
 
     _selector = new CustomOverrideInterceptor();
@@ -294,4 +297,40 @@ QUrl CustomOverrideInterceptor::intercept(const QUrl &url, QQmlAbstractUrlInterc
     }
 
     return url;
+}
+
+/*===========================================================================*/
+
+QVariantList CustomPlugin::complexMissionItemNames(Vehicle *vehicle)
+{
+    // Start with the standard set, then append our custom item.
+    QVariantList items = QGCCorePlugin::complexMissionItemNames(vehicle);
+
+    QVariantMap entry;
+    entry[QStringLiteral("canonicalName")]  = QString(PerimeterScanComplexItem::canonicalName);
+    entry[QStringLiteral("translatedName")] = PerimeterScanComplexItem::tr(PerimeterScanComplexItem::canonicalName);
+    items.append(entry);
+
+    return items;
+}
+
+ComplexMissionItem *CustomPlugin::createComplexMissionItem(const QString &complexItemType,
+                                                            PlanMasterController *masterController,
+                                                            bool flyView,
+                                                            const QString &kmlOrShpFile)
+{
+    if (complexItemType == PerimeterScanComplexItem::canonicalName
+            || complexItemType == PerimeterScanComplexItem::jsonComplexItemTypeValue) {
+        return new PerimeterScanComplexItem(masterController, flyView, kmlOrShpFile);
+    }
+    // Fall back to the built-in factory for all standard item types.
+    return QGCCorePlugin::createComplexMissionItem(complexItemType, masterController, flyView, kmlOrShpFile);
+}
+
+QList<PlanCreator *> CustomPlugin::planCreators(PlanMasterController *planMasterController)
+{
+    // Start with the standard creators, then add ours.
+    QList<PlanCreator *> creators = QGCCorePlugin::planCreators(planMasterController);
+    creators.append(new PerimeterScanPlanCreator(planMasterController));
+    return creators;
 }

--- a/custom-example/src/CustomPlugin.h
+++ b/custom-example/src/CustomPlugin.h
@@ -6,6 +6,9 @@
 #include "QGCCorePlugin.h"
 #include "QGCOptions.h"
 
+class ComplexMissionItem;
+class PlanCreator;
+
 class CustomOptions;
 class CustomPlugin;
 class CustomSettings;
@@ -70,6 +73,16 @@ public:
     void paletteOverride(const QString &colorName, QGCPalette::PaletteColorInfo_t &colorInfo) final;
     /// We override this so we can get access to QQmlApplicationEngine and use it to register our qml module
     QQmlApplicationEngine *createQmlApplicationEngine(QObject *parent) final;
+
+    /// Adds the Perimeter Scan item to the complex-item menu.
+    QVariantList complexMissionItemNames(Vehicle *vehicle) final;
+    /// Factory: creates PerimeterScanComplexItem for our custom type, falls back to base for built-ins.
+    ComplexMissionItem *createComplexMissionItem(const QString &complexItemType,
+                                                 PlanMasterController *masterController,
+                                                 bool flyView,
+                                                 const QString &kmlOrShpFile = QString()) final;
+    /// Adds the Perimeter Scan plan creator to the New Plan dialog.
+    QList<PlanCreator *> planCreators(PlanMasterController *planMasterController) final;
 
 private slots:
     void _advancedChanged(bool advanced);

--- a/custom-example/src/MissionManager/PerimeterScanComplexItem.cc
+++ b/custom-example/src/MissionManager/PerimeterScanComplexItem.cc
@@ -1,0 +1,257 @@
+#include "PerimeterScanComplexItem.h"
+
+#include "AppSettings.h"
+#include "JsonParsing.h"
+#include "MissionFlightStatus.h"
+#include "PlanMasterController.h"
+#include "QGCApplication.h"
+#include "QGCLoggingCategory.h"
+#include "SettingsManager.h"
+
+#include <QtCore/QJsonArray>
+
+QGC_LOGGING_CATEGORY(PerimeterScanLog, "Custom.PerimeterScan")
+
+PerimeterScanComplexItem::PerimeterScanComplexItem(PlanMasterController *masterController,
+                                                   bool flyView,
+                                                   const QString &kmlOrShpFile)
+    : ComplexMissionItem(masterController, flyView)
+    , _metaDataMap(FactMetaData::createMapFromJsonFile(
+          QStringLiteral(":/json/PerimeterScan.SettingsGroup.json"), this))
+    , _altitudeFact(settingsGroup, _metaDataMap[QStringLiteral("Altitude")])
+{
+    _editorQml = QStringLiteral("qrc:/qml/Custom/Plan/PerimeterScanEditor.qml");
+
+    // Initialise altitude from the application default.
+    _altitudeFact.setRawValue(
+        SettingsManager::instance()->appSettings()->defaultMissionItemAltitude()->rawValue());
+
+    connect(&_altitudeFact, &Fact::valueChanged, this, [this]() {
+        _setDirty();
+        emit amslEntryAltChanged(amslEntryAlt());
+        emit amslExitAltChanged(amslExitAlt());
+        emit minAMSLAltitudeChanged();
+        emit maxAMSLAltitudeChanged();
+    });
+    connect(&_perimeterPolygon, &QGCMapPolygon::pathChanged, this, &PerimeterScanComplexItem::_setDirty);
+    connect(&_perimeterPolygon, &QGCMapPolygon::pathChanged, this, &PerimeterScanComplexItem::_polygonChanged);
+
+    if (!kmlOrShpFile.isEmpty()) {
+        _perimeterPolygon.loadKMLOrSHPFile(kmlOrShpFile);
+        _perimeterPolygon.setDirty(false);
+    }
+
+    setDirty(false);
+}
+
+/*---------------------------------------------------------------------------*/
+
+void PerimeterScanComplexItem::setDirty(bool dirty)
+{
+    if (_dirty != dirty) {
+        _dirty = dirty;
+        emit dirtyChanged(_dirty);
+    }
+}
+
+void PerimeterScanComplexItem::_setDirty()
+{
+    setDirty(true);
+}
+
+void PerimeterScanComplexItem::_polygonChanged()
+{
+    _recalcScanDistance();
+    emit coordinateChanged(coordinate());
+    emit exitCoordinateChanged(exitCoordinate());
+    emit specifiesCoordinateChanged();
+    emit lastSequenceNumberChanged(lastSequenceNumber());
+    emit readyForSaveStateChanged();
+}
+
+void PerimeterScanComplexItem::_recalcScanDistance()
+{
+    _scanDistance = 0.0;
+    const int count = _perimeterPolygon.count();
+    for (int i = 0; i < count; ++i) {
+        _scanDistance += _perimeterPolygon.vertexCoordinate(i)
+                             .distanceTo(_perimeterPolygon.vertexCoordinate((i + 1) % count));
+    }
+    emit complexDistanceChanged();
+}
+
+/*---------------------------------------------------------------------------*/
+
+QGeoCoordinate PerimeterScanComplexItem::coordinate() const
+{
+    if (_perimeterPolygon.count() > 0) {
+        return _perimeterPolygon.vertexCoordinate(0);
+    }
+    return {};
+}
+
+QGeoCoordinate PerimeterScanComplexItem::exitCoordinate() const
+{
+    const int count = _perimeterPolygon.count();
+    if (count > 0) {
+        return _perimeterPolygon.vertexCoordinate(count - 1);
+    }
+    return {};
+}
+
+double PerimeterScanComplexItem::amslEntryAlt() const
+{
+    return _altitudeFact.rawValue().toDouble()
+           + _missionController->plannedHomePosition().altitude();
+}
+
+int PerimeterScanComplexItem::lastSequenceNumber() const
+{
+    const int n = _perimeterPolygon.count();
+    if (n < 3) {
+        return _sequenceNumber;
+    }
+    // N vertices + 1 closing waypoint back to first vertex
+    return _sequenceNumber + n;
+}
+
+VisualMissionItem::ReadyForSaveState PerimeterScanComplexItem::readyForSaveState() const
+{
+    return _perimeterPolygon.isValid() ? ReadyForSave : NotReadyForSaveData;
+}
+
+double PerimeterScanComplexItem::greatestDistanceTo(const QGeoCoordinate &other) const
+{
+    double maxDist = 0;
+    for (int i = 0; i < _perimeterPolygon.count(); ++i) {
+        maxDist = qMax(maxDist, _perimeterPolygon.vertexCoordinate(i).distanceTo(other));
+    }
+    return maxDist;
+}
+
+/*---------------------------------------------------------------------------*/
+
+void PerimeterScanComplexItem::setSequenceNumber(int sequenceNumber)
+{
+    if (_sequenceNumber != sequenceNumber) {
+        _sequenceNumber = sequenceNumber;
+        emit sequenceNumberChanged(sequenceNumber);
+        emit lastSequenceNumberChanged(lastSequenceNumber());
+    }
+}
+
+void PerimeterScanComplexItem::setCoordinate(const QGeoCoordinate & /* coord */)
+{
+    // Complex items do not support repositioning via a single coordinate.
+}
+
+void PerimeterScanComplexItem::applyNewAltitude(double newAltitude)
+{
+    _altitudeFact.setRawValue(newAltitude);
+}
+
+void PerimeterScanComplexItem::setMissionFlightStatus(MissionFlightStatus_t &missionFlightStatus)
+{
+    ComplexMissionItem::setMissionFlightStatus(missionFlightStatus);
+}
+
+/*---------------------------------------------------------------------------*/
+
+void PerimeterScanComplexItem::appendMissionItems(QList<MissionItem *> &items,
+                                                  QObject *missionItemParent)
+{
+    int    seqNum   = _sequenceNumber;
+    double altitude = _altitudeFact.rawValue().toDouble();
+    const int count = _perimeterPolygon.count();
+
+    // One waypoint per polygon vertex.
+    for (int i = 0; i < count; ++i) {
+        const QGeoCoordinate coord = _perimeterPolygon.vertexCoordinate(i);
+        items.append(new MissionItem(
+            seqNum++,
+            MAV_CMD_NAV_WAYPOINT,
+            MAV_FRAME_GLOBAL_RELATIVE_ALT,
+            0,                                            // hold time
+            0.0,                                          // acceptance radius
+            0.0,                                          // pass-through
+            std::numeric_limits<double>::quiet_NaN(),     // yaw – unchanged
+            coord.latitude(),
+            coord.longitude(),
+            altitude,
+            true,   // autoContinue
+            false,  // isCurrentItem
+            missionItemParent));
+    }
+
+    // Closing waypoint – return to first vertex to complete the loop.
+    if (count >= 3) {
+        const QGeoCoordinate first = _perimeterPolygon.vertexCoordinate(0);
+        items.append(new MissionItem(
+            seqNum++,
+            MAV_CMD_NAV_WAYPOINT,
+            MAV_FRAME_GLOBAL_RELATIVE_ALT,
+            0, 0.0, 0.0,
+            std::numeric_limits<double>::quiet_NaN(),
+            first.latitude(),
+            first.longitude(),
+            altitude,
+            true, false,
+            missionItemParent));
+    }
+}
+
+/*---------------------------------------------------------------------------*/
+
+void PerimeterScanComplexItem::save(QJsonArray &missionItems)
+{
+    QJsonObject saveObject;
+    saveObject[JsonParsing::jsonVersionKey]                 = 1;
+    saveObject[VisualMissionItem::jsonTypeKey]              = VisualMissionItem::jsonTypeComplexItemValue;
+    saveObject[ComplexMissionItem::jsonComplexItemTypeKey]  = jsonComplexItemTypeValue;
+    saveObject[_jsonAltitudeKey]                           = _altitudeFact.rawValue().toDouble();
+    _perimeterPolygon.saveToJson(saveObject);
+    missionItems.append(saveObject);
+}
+
+bool PerimeterScanComplexItem::load(const QJsonObject &complexObject,
+                                    int sequenceNumber,
+                                    QString &errorString)
+{
+    const QList<JsonParsing::KeyValidateInfo> keyInfoList = {
+        { JsonParsing::jsonVersionKey,                  QJsonValue::Double, true },
+        { VisualMissionItem::jsonTypeKey,               QJsonValue::String, true },
+        { ComplexMissionItem::jsonComplexItemTypeKey,   QJsonValue::String, true },
+        { _jsonAltitudeKey,                             QJsonValue::Double, true },
+        { QGCMapPolygon::jsonPolygonKey,                QJsonValue::Array,  true },
+    };
+
+    if (!JsonParsing::validateKeys(complexObject, keyInfoList, errorString)) {
+        return false;
+    }
+
+    const QString itemType    = complexObject[VisualMissionItem::jsonTypeKey].toString();
+    const QString complexType = complexObject[ComplexMissionItem::jsonComplexItemTypeKey].toString();
+    if (itemType != VisualMissionItem::jsonTypeComplexItemValue
+            || complexType != jsonComplexItemTypeValue) {
+        errorString = tr("%1 does not support loading this complex mission item type: %2:%3")
+                          .arg(qgcApp()->applicationName(), itemType, complexType);
+        return false;
+    }
+
+    const int version = complexObject[JsonParsing::jsonVersionKey].toInt();
+    if (version != 1) {
+        errorString = tr("%1 version %2 not supported").arg(jsonComplexItemTypeValue).arg(version);
+        return false;
+    }
+
+    setSequenceNumber(sequenceNumber);
+    _perimeterPolygon.clear();
+    _altitudeFact.setRawValue(complexObject[_jsonAltitudeKey].toDouble());
+
+    if (!_perimeterPolygon.loadFromJson(complexObject, true /* required */, errorString)) {
+        return false;
+    }
+
+    setDirty(false);
+    return true;
+}

--- a/custom-example/src/MissionManager/PerimeterScanComplexItem.h
+++ b/custom-example/src/MissionManager/PerimeterScanComplexItem.h
@@ -1,0 +1,99 @@
+#pragma once
+
+#include <limits>
+
+#include "ComplexMissionItem.h"
+#include "FactMetaData.h"
+#include "MissionItem.h"
+#include "QGCMapPolygon.h"
+#include "SettingsFact.h"
+
+class PlanMasterController;
+
+/// \brief A custom complex mission item that generates waypoints following the perimeter of a user-defined polygon.
+///
+/// A custom complex mission item that generates waypoints following the
+/// perimeter of a user-defined polygon. Shows full polygon-editing tools
+/// on the map (same toolbar as Survey/StructureScan).
+
+class PerimeterScanComplexItem : public ComplexMissionItem
+{
+    Q_OBJECT
+
+public:
+    /// @param kmlOrShpFile  Optional KML/SHP file to seed the polygon from; empty for blank.
+    explicit PerimeterScanComplexItem(PlanMasterController *masterController,
+                                      bool flyView,
+                                      const QString &kmlOrShpFile = QString());
+
+    Q_PROPERTY(QGCMapPolygon *perimeterPolygon READ perimeterPolygon CONSTANT)
+    Q_PROPERTY(Fact          *altitude         READ altitude         CONSTANT)
+
+    QGCMapPolygon *perimeterPolygon() { return &_perimeterPolygon; }
+    Fact          *altitude()         { return &_altitudeFact; }
+
+    // These are called by the editor QML's polygon-capture callbacks.
+    Q_INVOKABLE void clearPolygon()                                              { _perimeterPolygon.clear(); }
+    Q_INVOKABLE void addPolygonCoordinate(const QGeoCoordinate &coordinate)     { _perimeterPolygon.appendVertex(coordinate); }
+    Q_INVOKABLE void adjustPolygonCoordinate(int vertexIndex,
+                                             const QGeoCoordinate &coordinate)  { _perimeterPolygon.adjustVertex(vertexIndex, coordinate); }
+
+    static constexpr const char *canonicalName           = "Perimeter Scan";
+    static constexpr const char *jsonComplexItemTypeValue = "perimeterScan";
+    static constexpr const char *settingsGroup            = "PerimeterScan";
+
+    // ComplexMissionItem overrides
+    QString             patternName         () const final { return tr(canonicalName); }
+    double              complexDistance     () const final { return _scanDistance; }
+    double              minAMSLAltitude     () const final { return amslEntryAlt(); }
+    double              maxAMSLAltitude     () const final { return amslExitAlt(); }
+    int                 lastSequenceNumber  () const final;
+    bool                load                (const QJsonObject &complexObject, int sequenceNumber, QString &errorString) final;
+    double              greatestDistanceTo  (const QGeoCoordinate &other) const final;
+    QString             mapVisualQML        () const final { return QStringLiteral("qrc:/qml/Custom/Plan/PerimeterScanMapVisual.qml"); }
+
+    // VisualMissionItem overrides
+    bool                dirty                     () const final { return _dirty; }
+    bool                isSimpleItem              () const final { return false; }
+    bool                isStandaloneCoordinate    () const final { return false; }
+    bool                specifiesCoordinate       () const final { return _perimeterPolygon.isValid(); }
+    bool                specifiesAltitudeOnly     () const final { return false; }
+    QString             commandDescription        () const final { return tr("Perimeter Scan"); }
+    QString             commandName               () const final { return tr("Perimeter Scan"); }
+    QString             abbreviation              () const final { return "P"; }
+    QGeoCoordinate      coordinate                () const final;
+    QGeoCoordinate      entryCoordinate           () const final { return coordinate(); }
+    QGeoCoordinate      exitCoordinate            () const final;
+    bool                exitCoordinateSameAsEntry () const final { return false; }
+    double              editableAlt               () const final { return _altitudeFact.rawValue().toDouble(); }
+    double              amslEntryAlt              () const final;
+    double              amslExitAlt               () const final { return amslEntryAlt(); }
+    int                 sequenceNumber            () const final { return _sequenceNumber; }
+    double              specifiedFlightSpeed      () final { return std::numeric_limits<double>::quiet_NaN(); }
+    double              specifiedGimbalYaw        () final { return std::numeric_limits<double>::quiet_NaN(); }
+    double              specifiedGimbalPitch      () final { return std::numeric_limits<double>::quiet_NaN(); }
+    void                appendMissionItems        (QList<MissionItem *> &items, QObject *missionItemParent) final;
+    void                setMissionFlightStatus    (MissionFlightStatus_t &missionFlightStatus) final;
+    void                applyNewAltitude          (double newAltitude) final;
+    double              additionalTimeDelay       () const final { return 0; }
+    ReadyForSaveState   readyForSaveState         () const final;
+    void                setDirty                  (bool dirty) final;
+    void                setCoordinate             (const QGeoCoordinate &coord) final;
+    void                setSequenceNumber         (int sequenceNumber) final;
+    void                save                      (QJsonArray &missionItems) final;
+
+private slots:
+    void _setDirty();
+    void _polygonChanged();
+
+private:
+    void _recalcScanDistance();
+
+    int                          _sequenceNumber = 0;
+    double                       _scanDistance   = 0.0;
+    QGCMapPolygon                _perimeterPolygon;
+    QMap<QString, FactMetaData *> _metaDataMap;
+    SettingsFact                 _altitudeFact;
+
+    static constexpr const char *_jsonAltitudeKey = "altitude";
+};

--- a/custom-example/src/MissionManager/PerimeterScanPlanCreator.cc
+++ b/custom-example/src/MissionManager/PerimeterScanPlanCreator.cc
@@ -1,0 +1,24 @@
+#include "PerimeterScanPlanCreator.h"
+
+#include "MissionController.h"
+#include "PerimeterScanComplexItem.h"
+#include "PlanMasterController.h"
+#include "QGCMAVLink.h"
+
+PerimeterScanPlanCreator::PerimeterScanPlanCreator(PlanMasterController *planMasterController)
+    : PlanCreator(planMasterController,
+                  PerimeterScanComplexItem::tr(PerimeterScanComplexItem::canonicalName),
+                  QStringLiteral("/qmlimages/PlanCreator/SurveyPlanCreator.png"),
+                  QGCMAVLink::allVehicleClasses())
+{
+}
+
+void PerimeterScanPlanCreator::createPlan(const QGeoCoordinate &mapCenterCoord)
+{
+    _planMasterController->removeAll();
+    VisualMissionItem *takeoffItem = _missionController->insertTakeoffItem(mapCenterCoord, -1);
+    _missionController->insertComplexMissionItem(
+        PerimeterScanComplexItem::canonicalName, mapCenterCoord, -1);
+    _missionController->insertLandItem(mapCenterCoord, -1);
+    _missionController->setCurrentPlanViewSeqNum(takeoffItem->sequenceNumber(), true);
+}

--- a/custom-example/src/MissionManager/PerimeterScanPlanCreator.h
+++ b/custom-example/src/MissionManager/PerimeterScanPlanCreator.h
@@ -1,0 +1,13 @@
+#pragma once
+
+#include "PlanCreator.h"
+
+class PerimeterScanPlanCreator : public PlanCreator
+{
+    Q_OBJECT
+
+public:
+    explicit PerimeterScanPlanCreator(PlanMasterController *planMasterController);
+
+    Q_INVOKABLE void createPlan(const QGeoCoordinate &mapCenterCoord) final;
+};

--- a/custom-example/src/PlanView/PerimeterScanEditor.qml
+++ b/custom-example/src/PlanView/PerimeterScanEditor.qml
@@ -1,0 +1,87 @@
+import QtQuick
+import QtQuick.Controls
+import QtQuick.Layouts
+
+import QGroundControl
+import QGroundControl.Controls
+import QGroundControl.FactControls
+import QGroundControl.FlightMap
+
+/// \brief Editor panel for PerimeterScanComplexItem.
+///
+/// Appears in the right-hand mission item list when the item is selected.
+/// The polygon tools toolbar on the map is provided automatically by
+/// QGCMapPolygonVisuals — no extra wiring is needed here.
+
+Rectangle {
+    id:     _root
+    height: visible ? (editorColumn.height + (_margin * 2)) : 0
+    width:  availableWidth
+    color:  qgcPal.windowShadeDark
+    radius: _radius
+
+    required property var  missionItem
+    required property real availableWidth
+
+    property real _margin:     ScreenTools.defaultFontPixelWidth / 2
+    property real _fieldWidth: ScreenTools.defaultFontPixelWidth * 10.5
+    property real _radius:     ScreenTools.defaultFontPixelWidth / 2
+
+    // These callbacks are invoked by QGCMapPolygonVisuals when it is used
+    // in a "capture" mode (legacy path — kept for API completeness).
+    function polygonCaptureStarted()                              { missionItem.clearPolygon() }
+    function polygonCaptureFinished(coordinates) {
+        for (var i = 0; i < coordinates.length; i++) {
+            missionItem.addPolygonCoordinate(coordinates[i])
+        }
+    }
+    function polygonAdjustVertex(vertexIndex, vertexCoordinate)   { missionItem.adjustPolygonCoordinate(vertexIndex, vertexCoordinate) }
+    function polygonAdjustStarted()  {}
+    function polygonAdjustFinished() {}
+
+    QGCPalette { id: qgcPal; colorGroupEnabled: true }
+
+    ColumnLayout {
+        id:             editorColumn
+        anchors {
+            top:    parent.top
+            left:   parent.left
+            right:  parent.right
+            margins: _margin
+        }
+        spacing: _margin
+
+        // Wizard hint – shown until the polygon is valid.
+        QGCLabel {
+            Layout.fillWidth:    true
+            wrapMode:            Text.WordWrap
+            horizontalAlignment: Text.AlignHCenter
+            text:                qsTr("Use the Polygon Tools to draw the perimeter to scan.")
+            visible:             !missionItem.perimeterPolygon.isValid
+        }
+
+        // Settings – shown once the polygon has been defined.
+        GridLayout {
+            Layout.fillWidth: true
+            columnSpacing:    _margin
+            rowSpacing:       _margin
+            columns:          2
+            visible:          missionItem.perimeterPolygon.isValid
+
+            QGCLabel { text: qsTr("Altitude") }
+            FactTextField {
+                fact:               missionItem.altitude
+                Layout.preferredWidth: _fieldWidth
+                showUnits:          true
+            }
+
+            QGCLabel { text: qsTr("Perimeter") }
+            QGCLabel {
+                text: QGroundControl.unitsConversion.metersToAppSettingsHorizontalDistanceUnits(
+                          missionItem.complexDistance).toFixed(0)
+                      + " "
+                      + QGroundControl.unitsConversion.appSettingsHorizontalDistanceUnitsString
+            }
+        }
+    }
+}

--- a/custom-example/src/PlanView/PerimeterScanMapVisual.qml
+++ b/custom-example/src/PlanView/PerimeterScanMapVisual.qml
@@ -1,0 +1,99 @@
+import QtQuick
+import QtQuick.Controls
+import QtLocation
+import QtPositioning
+
+import QGroundControl
+import QGroundControl.Controls
+import QGroundControl.FlightMap
+import QGroundControl.PlanView
+
+/// \brief Map visuals for PerimeterScanComplexItem.
+///
+/// Shows an interactive, editable polygon using the standard QGCMapPolygonVisuals
+/// component, which automatically provides the full Polygon Tools toolbar
+/// (Basic, Circular, Trace, Load KML, …) when the item is selected.
+///
+/// A flight-path polyline traces the perimeter in waypoint order so the user
+/// can see the direction of travel.
+
+Item {
+    id: _root
+
+    property var  map
+    property var  vehicle
+    property bool interactive: true
+
+    signal clicked(int sequenceNumber)
+
+    property var  _missionItem:  object
+    property var  _polygon:      object.perimeterPolygon
+    property bool _currentItem:  object.isCurrentItem
+
+    // ----- polygon editing visuals (provides the Polygon Tools toolbar) -----
+    QGCMapPolygonVisuals {
+        id:               polygonVisuals
+        mapControl:       map
+        mapPolygon:       _polygon
+        interactive:      _currentItem && _root.interactive
+        borderWidth:      2
+        borderColor:      "#00cc44"
+        interiorColor:    "#00cc44"
+        interiorOpacity:  0.08 * _root.opacity
+    }
+
+    // ----- flight-path polyline (perimeter traversal order) ----------------
+    // Shown only when the item is selected so the map stays uncluttered.
+    Component {
+        id: flightPathComponent
+
+        MapPolyline {
+            line.color: "#00cc44"
+            line.width: 2
+            visible:    _currentItem
+            opacity:    _root.opacity
+
+            // Build the closed path from the polygon vertices.
+            path: {
+                const pts = _polygon.path
+                if (pts.length < 2) return []
+                // Append first vertex at the end to close the loop visually.
+                return pts.concat([pts[0]])
+            }
+        }
+    }
+
+    // ----- entry-point marker ----------------------------------------------
+    Component {
+        id: entryPointComponent
+
+        MapQuickItem {
+            anchorPoint.x: sourceItem.width  / 2
+            anchorPoint.y: sourceItem.height / 2
+            coordinate:    _missionItem.coordinate
+            visible:       _currentItem && _polygon.isValid
+            opacity:       _root.opacity
+            z:             QGroundControl.zOrderMapItems + 1
+
+            sourceItem: MissionItemIndexLabel {
+                checked:     true
+                index:       _missionItem.sequenceNumber
+                label:       ""
+                onClicked:   _root.clicked(_missionItem.sequenceNumber)
+            }
+        }
+    }
+
+    QGCDynamicObjectManager { id: objMgr }
+
+    Component.onCompleted: {
+        objMgr.createObjects(
+            [flightPathComponent, entryPointComponent],
+            map,
+            true /* parentObjectIsMap */)
+    }
+
+    Component.onDestruction: {
+        objMgr.destroyObjects()
+    }
+}

--- a/src/API/QGCCorePlugin.cc
+++ b/src/API/QGCCorePlugin.cc
@@ -25,8 +25,11 @@
 #include "SurveyComplexItem.h"
 #include "CorridorScanComplexItem.h"
 #include "StructureScanComplexItem.h"
+#include "FixedWingLandingComplexItem.h"
+#include "VTOLLandingComplexItem.h"
 #include "Vehicle.h"
 #include "BlankPlanCreator.h"
+#include "ComplexMissionItem.h"
 #include "PlanMasterController.h"
 
 #ifdef QGC_CUSTOM_BUILD
@@ -403,4 +406,26 @@ QList<PlanCreator*> QGCCorePlugin::planCreators(PlanMasterController *planMaster
         new StructureScanPlanCreator(planMasterController),
         new BlankPlanCreator(planMasterController),
     };
+}
+
+ComplexMissionItem *QGCCorePlugin::createComplexMissionItem(
+    const QString &complexItemType,
+    PlanMasterController *masterController,
+    bool flyView,
+    const QString &kmlOrShpFile)
+{
+    if (complexItemType == SurveyComplexItem::canonicalName || complexItemType == SurveyComplexItem::jsonComplexItemTypeValue) {
+        return new SurveyComplexItem(masterController, flyView, kmlOrShpFile);
+    } else if (complexItemType == CorridorScanComplexItem::canonicalName || complexItemType == CorridorScanComplexItem::jsonComplexItemTypeValue) {
+        return new CorridorScanComplexItem(masterController, flyView, kmlOrShpFile);
+    } else if (complexItemType == StructureScanComplexItem::canonicalName || complexItemType == StructureScanComplexItem::jsonComplexItemTypeValue) {
+        return new StructureScanComplexItem(masterController, flyView, kmlOrShpFile);
+    } else if (complexItemType == FixedWingLandingComplexItem::canonicalName || complexItemType == FixedWingLandingComplexItem::jsonComplexItemTypeValue) {
+        return new FixedWingLandingComplexItem(masterController, flyView);
+    } else if (complexItemType == VTOLLandingComplexItem::canonicalName || complexItemType == VTOLLandingComplexItem::jsonComplexItemTypeValue) {
+        return new VTOLLandingComplexItem(masterController, flyView);
+    }
+
+    qCWarning(QGCCorePluginLog) << "QGCCorePlugin::createComplexMissionItem - Unknown complex item type:" << complexItemType;
+    return nullptr;
 }

--- a/src/API/QGCCorePlugin.h
+++ b/src/API/QGCCorePlugin.h
@@ -6,6 +6,7 @@
 
 #include "QGCPalette.h"
 
+class ComplexMissionItem;
 class FactMetaData;
 class LinkInterface;
 class PlanCreator;
@@ -151,10 +152,25 @@ public:
     /// The base class builds and returns the default set. Custom builds should
     /// override this method, call the base class to get the defaults, modify as
     /// needed, and return the result. When adding a new entry, set both keys and
-    /// override insertComplexMissionItem() to handle the new canonicalName.
+    /// override createComplexMissionItem() to handle the new canonicalName.
     /// @param vehicle Vehicle for which the list is being built
     /// @return Complex items to be made available to user
     virtual QVariantList complexMissionItemNames(Vehicle *vehicle);
+
+    /// Factory for creating custom complex mission items.
+    /// Called by MissionController when the canonicalName/complexItemType is not one of the
+    /// built-in types (Survey, CorridorScan, StructureScan, FixedWingLanding, VTOLLanding).
+    /// For JSON load, the returned item has load() called on it immediately afterward.
+    ///     @param complexItemType  The canonicalName / jsonComplexItemTypeValue identifying the item
+    ///     @param masterController PlanMasterController for the item
+    ///     @param flyView          true if creating for fly view (read-only)
+    ///     @param kmlOrShpFile     Optional KML/SHP file to initialize from; QString() if none
+    /// @return New item (caller takes ownership), or nullptr if the type is not handled
+    virtual ComplexMissionItem *createComplexMissionItem(
+        const QString &complexItemType,
+        PlanMasterController *masterController,
+        bool flyView,
+        const QString &kmlOrShpFile = QString());
 
     /// Returns the list of plan creators to show when creating a new plan.
     /// Custom builds can override to provide their own set of plan creators.

--- a/src/AnalyzeView/LogViewer/LogFileParser.cc
+++ b/src/AnalyzeView/LogViewer/LogFileParser.cc
@@ -115,12 +115,14 @@ void LogFileParser::_applyResult(const LogParseResult &result)
     if (!_parameters.isEmpty()) {
         if (result.sourceType == LogParseResult::SourceType::PX4ULog) {
             LogViewerParamMetaData::enrichForPX4(_parameters);
+#ifndef QGC_NO_ARDUPILOT_DIALECT
         } else if (result.sourceType == LogParseResult::SourceType::APMDataFlash) {
             LogViewerParamMetaData::enrichForAPM(
                 _parameters,
                 result.detectedVehicleType,
                 result.firmwareMajorVersion,
                 result.firmwareMinorVersion);
+#endif
         }
     }
     _events = result.events;

--- a/src/AnalyzeView/LogViewer/LogViewerPage.qml
+++ b/src/AnalyzeView/LogViewer/LogViewerPage.qml
@@ -216,7 +216,8 @@ AnalyzePage {
                 spacing: ScreenTools.defaultFontPixelWidth
 
                 QGCButton {
-                    text: qsTr("Open .bin")
+                    text:    qsTr("Open .bin")
+                    visible: QGroundControl.hasAPMSupport
                     onClicked: {
                         openDialog.nameFilters = ["DataFlash Logs (*.bin *.BIN *.log *.LOG)"]
                         openDialog.openForLoad()

--- a/src/AnalyzeView/LogViewer/LogViewerParamMetaData.cc
+++ b/src/AnalyzeView/LogViewer/LogViewerParamMetaData.cc
@@ -1,6 +1,8 @@
 #include "LogViewerParamMetaData.h"
 
+#ifndef QGC_NO_ARDUPILOT_DIALECT
 #include "APMParameterMetaData.h"
+#endif
 #include "FactMetaData.h"
 #include "PX4ParameterMetaData.h"
 #include "QGCLoggingCategory.h"
@@ -10,6 +12,8 @@
 QGC_LOGGING_CATEGORY(LogViewerParamMetaDataLog, "AnalyzeView.LogViewerParamMetaData")
 
 namespace {
+
+#ifndef QGC_NO_ARDUPILOT_DIALECT
 
 // Map the APM vehicle name as stored in detectedVehicleType to the file-path
 // component used in :/FirmwarePlugin/APM/APMParameterFactMetaData.{X}.major.minor.json
@@ -53,6 +57,8 @@ QString _findAPMMetaDataFile(const QString &fileVehicleName, int major, int mino
 
     return QString();
 }
+
+#endif // QGC_NO_ARDUPILOT_DIALECT
 
 void _enrichRows(QVariantList &parameters, ParameterMetaData *metaData)
 {
@@ -98,6 +104,7 @@ void LogViewerParamMetaData::enrichForPX4(QVariantList &parameters)
     delete metaData;
 }
 
+#ifndef QGC_NO_ARDUPILOT_DIALECT
 void LogViewerParamMetaData::enrichForAPM(QVariantList &parameters,
                                           const QString &vehicleType,
                                           int major,
@@ -134,3 +141,5 @@ void LogViewerParamMetaData::enrichForAPM(QVariantList &parameters,
 
     delete metaData;
 }
+
+#endif // QGC_NO_ARDUPILOT_DIALECT

--- a/src/AnalyzeView/LogViewer/LogViewerParamMetaData.h
+++ b/src/AnalyzeView/LogViewer/LogViewerParamMetaData.h
@@ -19,6 +19,7 @@ public:
     ///   enumValues       QVariantList — corresponding numeric values (parallel array)
     static void enrichForPX4(QVariantList &parameters);
 
+#ifndef QGC_NO_ARDUPILOT_DIALECT
     /// Enrich parameters from an APM DataFlash file. Adds the same keys as enrichForPX4().
     /// @param vehicleType  APM vehicle name: "ArduCopter", "ArduPlane", "ArduRover", "ArduSub"
     /// @param major / minor  Firmware version numbers parsed from the log (pass -1 if unknown).
@@ -26,4 +27,5 @@ public:
                              const QString &vehicleType,
                              int major,
                              int minor);
+#endif
 };

--- a/src/MissionManager/ComplexMissionItem.h
+++ b/src/MissionManager/ComplexMissionItem.h
@@ -2,6 +2,7 @@
 
 #include <QtCore/QMap>
 
+#include "QGroundControlQmlGlobal.h"
 #include "VisualMissionItem.h"
 #include "QmlObjectListModel.h"
 #include "FlightPathSegment.h"
@@ -84,6 +85,14 @@ public:
     virtual QString presetsSettingsGroup(void) { return QString(); }
 
     virtual void addKMLVisuals(KMLPlanDomDocument& domDocument);
+
+    /// Called by MissionController after inserting a new item when a previous altitude is available and the
+    /// global altitude frame is AltitudeFrameMixed. Override to apply altitude frame context to the item.
+    /// The default implementation is a no-op.
+    ///     @param prevAltFrame     Altitude frame of the previous mission item
+    ///     @param prevAltitude     Altitude of the previous mission item
+    virtual void applyPreviousAltitudeFrame(QGroundControlQmlGlobal::AltitudeFrame prevAltFrame, double prevAltitude)
+        { Q_UNUSED(prevAltFrame); Q_UNUSED(prevAltitude); }
 
     bool presetsSupported   (void) { return !presetsSettingsGroup().isEmpty(); }
     bool isIncomplete       (void) const { return _isIncomplete; }

--- a/src/MissionManager/MissionController.cc
+++ b/src/MissionManager/MissionController.cc
@@ -389,31 +389,18 @@ VisualMissionItem* MissionController::insertCancelROIMissionItem(int visualItemI
 
 VisualMissionItem* MissionController::insertComplexMissionItem(QString itemName, QGeoCoordinate mapCenterCoordinate, int visualItemIndex, bool makeCurrentItem)
 {
-    ComplexMissionItem* newItem = nullptr;
-
-    if (itemName == SurveyComplexItem::canonicalName) {
-        newItem = new SurveyComplexItem(_masterController, _flyView, QString() /* kmlOrShpFile */);
-        newItem->setCoordinate(mapCenterCoordinate);
-
-        double                              prevAltitude;
-        QGroundControlQmlGlobal::AltitudeFrame    prevAltFrame;
-        if (globalAltitudeFrame() == QGroundControlQmlGlobal::AltitudeFrameMixed) {
-            // We are in mixed altitude frames, so copy from previous. Otherwise alt mode will be set from global setting in constructor.
-            if (_findPreviousAltitude(visualItemIndex, &prevAltitude, &prevAltFrame)) {
-                qobject_cast<SurveyComplexItem*>(newItem)->cameraCalc()->setDistanceMode(prevAltFrame);
-            }
-        }
-    } else if (itemName == FixedWingLandingComplexItem::canonicalName) {
-        newItem = new FixedWingLandingComplexItem(_masterController, _flyView);
-    } else if (itemName == VTOLLandingComplexItem::canonicalName) {
-        newItem = new VTOLLandingComplexItem(_masterController, _flyView);
-    } else if (itemName == StructureScanComplexItem::canonicalName) {
-        newItem = new StructureScanComplexItem(_masterController, _flyView, QString() /* kmlOrShpFile */);
-    } else if (itemName == CorridorScanComplexItem::canonicalName) {
-        newItem = new CorridorScanComplexItem(_masterController, _flyView, QString() /* kmlOrShpFile */);
-    } else {
-        qWarning() << "Internal error: Unknown complex item:" << itemName;
+    ComplexMissionItem* newItem = QGCCorePlugin::instance()->createComplexMissionItem(itemName, _masterController, _flyView);
+    if (!newItem) {
         return nullptr;
+    }
+    newItem->setCoordinate(mapCenterCoordinate);
+
+    if (globalAltitudeFrame() == QGroundControlQmlGlobal::AltitudeFrameMixed) {
+        double prevAltitude;
+        QGroundControlQmlGlobal::AltitudeFrame prevAltFrame;
+        if (_findPreviousAltitude(visualItemIndex, &prevAltitude, &prevAltFrame)) {
+            newItem->applyPreviousAltitudeFrame(prevAltFrame, prevAltitude);
+        }
     }
 
     _insertComplexMissionItemWorker(mapCenterCoordinate, newItem, visualItemIndex, makeCurrentItem);
@@ -423,16 +410,8 @@ VisualMissionItem* MissionController::insertComplexMissionItem(QString itemName,
 
 VisualMissionItem* MissionController::insertComplexMissionItemFromKMLOrSHP(QString itemName, QString file, int visualItemIndex, bool makeCurrentItem)
 {
-    ComplexMissionItem* newItem = nullptr;
-
-    if (itemName == SurveyComplexItem::canonicalName) {
-        newItem = new SurveyComplexItem(_masterController, _flyView, file);
-    } else if (itemName == StructureScanComplexItem::canonicalName) {
-        newItem = new StructureScanComplexItem(_masterController, _flyView, file);
-    } else if (itemName == CorridorScanComplexItem::canonicalName) {
-        newItem = new CorridorScanComplexItem(_masterController, _flyView, file);
-    } else {
-        qWarning() << "Internal error: Unknown complex item:" << itemName;
+    ComplexMissionItem* newItem = QGCCorePlugin::instance()->createComplexMissionItem(itemName, _masterController, _flyView, file);
+    if (!newItem) {
         return nullptr;
     }
 
@@ -714,54 +693,19 @@ bool MissionController::_loadJsonMissionFileV2(const QJsonObject& json, QmlObjec
             }
             QString complexItemType = itemObject[ComplexMissionItem::jsonComplexItemTypeKey].toString();
 
-            if (complexItemType == SurveyComplexItem::jsonComplexItemTypeValue) {
-                qCDebug(MissionControllerLog) << "Loading Survey: nextSequenceNumber" << nextSequenceNumber;
-                SurveyComplexItem* surveyItem = new SurveyComplexItem(_masterController, _flyView, QString() /* kmlOrShpFile */);
-                if (!surveyItem->load(itemObject, nextSequenceNumber++, errorString)) {
-                    return false;
-                }
-                nextSequenceNumber = surveyItem->lastSequenceNumber() + 1;
-                qCDebug(MissionControllerLog) << "Survey load complete: nextSequenceNumber" << nextSequenceNumber;
-                visualItems->append(surveyItem);
-            } else if (complexItemType == FixedWingLandingComplexItem::jsonComplexItemTypeValue) {
-                qCDebug(MissionControllerLog) << "Loading Fixed Wing Landing Pattern: nextSequenceNumber" << nextSequenceNumber;
-                FixedWingLandingComplexItem* landingItem = new FixedWingLandingComplexItem(_masterController, _flyView);
-                if (!landingItem->load(itemObject, nextSequenceNumber++, errorString)) {
-                    return false;
-                }
-                nextSequenceNumber = landingItem->lastSequenceNumber() + 1;
-                qCDebug(MissionControllerLog) << "FW Landing Pattern load complete: nextSequenceNumber" << nextSequenceNumber;
-                visualItems->append(landingItem);
-            } else if (complexItemType == VTOLLandingComplexItem::jsonComplexItemTypeValue) {
-                qCDebug(MissionControllerLog) << "Loading VTOL Landing Pattern: nextSequenceNumber" << nextSequenceNumber;
-                VTOLLandingComplexItem* landingItem = new VTOLLandingComplexItem(_masterController, _flyView);
-                if (!landingItem->load(itemObject, nextSequenceNumber++, errorString)) {
-                    return false;
-                }
-                nextSequenceNumber = landingItem->lastSequenceNumber() + 1;
-                qCDebug(MissionControllerLog) << "VTOL Landing Pattern load complete: nextSequenceNumber" << nextSequenceNumber;
-                visualItems->append(landingItem);
-            } else if (complexItemType == StructureScanComplexItem::jsonComplexItemTypeValue) {
-                qCDebug(MissionControllerLog) << "Loading Structure Scan: nextSequenceNumber" << nextSequenceNumber;
-                StructureScanComplexItem* structureItem = new StructureScanComplexItem(_masterController, _flyView, QString() /* kmlOrShpFile */);
-                if (!structureItem->load(itemObject, nextSequenceNumber++, errorString)) {
-                    return false;
-                }
-                nextSequenceNumber = structureItem->lastSequenceNumber() + 1;
-                qCDebug(MissionControllerLog) << "Structure Scan load complete: nextSequenceNumber" << nextSequenceNumber;
-                visualItems->append(structureItem);
-            } else if (complexItemType == CorridorScanComplexItem::jsonComplexItemTypeValue) {
-                qCDebug(MissionControllerLog) << "Loading Corridor Scan: nextSequenceNumber" << nextSequenceNumber;
-                CorridorScanComplexItem* corridorItem = new CorridorScanComplexItem(_masterController, _flyView, QString() /* kmlOrShpFile */);
-                if (!corridorItem->load(itemObject, nextSequenceNumber++, errorString)) {
-                    return false;
-                }
-                nextSequenceNumber = corridorItem->lastSequenceNumber() + 1;
-                qCDebug(MissionControllerLog) << "Corridor Scan load complete: nextSequenceNumber" << nextSequenceNumber;
-                visualItems->append(corridorItem);
-            } else {
+            qCDebug(MissionControllerLog) << "Loading complex item type:" << complexItemType << "nextSequenceNumber:" << nextSequenceNumber;
+            ComplexMissionItem* complexItem = QGCCorePlugin::instance()->createComplexMissionItem(complexItemType, _masterController, _flyView);
+            if (!complexItem) {
                 errorString = tr("Unsupported complex item type: %1").arg(complexItemType);
+                return false;
             }
+            if (!complexItem->load(itemObject, nextSequenceNumber++, errorString)) {
+                delete complexItem;
+                return false;
+            }
+            nextSequenceNumber = complexItem->lastSequenceNumber() + 1;
+            qCDebug(MissionControllerLog) << "Complex item load complete nextSequenceNumber:" << nextSequenceNumber;
+            visualItems->append(complexItem);
         } else {
             errorString = tr("Unknown item type: %1").arg(itemType);
             return false;

--- a/src/MissionManager/SurveyComplexItem.cc
+++ b/src/MissionManager/SurveyComplexItem.cc
@@ -100,6 +100,12 @@ void SurveyComplexItem::loadPreset(const QString& presetName)
     _rebuildTransects();
 }
 
+void SurveyComplexItem::applyPreviousAltitudeFrame(QGroundControlQmlGlobal::AltitudeFrame prevAltFrame, double prevAltitude)
+{
+    Q_UNUSED(prevAltitude);
+    _cameraCalc.setDistanceMode(prevAltFrame);
+}
+
 bool SurveyComplexItem::load(const QJsonObject& complexObject, int sequenceNumber, QString& errorString)
 {
     // We need to pull version first to determine what validation/conversion needs to be performed

--- a/src/MissionManager/SurveyComplexItem.h
+++ b/src/MissionManager/SurveyComplexItem.h
@@ -28,6 +28,7 @@ public:
 
     // Overrides from ComplexMissionItem
     QString         patternName         (void) const final { return tr(canonicalName); }
+    void            applyPreviousAltitudeFrame(QGroundControlQmlGlobal::AltitudeFrame prevAltFrame, double prevAltitude) final;
     bool            load                (const QJsonObject& complexObject, int sequenceNumber, QString& errorString) final;
     QString         mapVisualQML        (void) const final { return QStringLiteral("SurveyMapVisual.qml"); }
     QString         presetsSettingsGroup(void) { return settingsGroup; }

--- a/test/MissionManager/MissionControllerTest.cc
+++ b/test/MissionManager/MissionControllerTest.cc
@@ -2,6 +2,10 @@
 #include "MissionControllerTest.h"
 
 #include "AppSettings.h"
+#include "CameraCalc.h"
+#include "CorridorScanComplexItem.h"
+#include "StructureScanComplexItem.h"
+#include "SurveyComplexItem.h"
 #include "UnitTestCoords.h"
 #include "MissionController.h"
 #include "MissionSettingsItem.h"
@@ -10,6 +14,8 @@
 #include "SettingsManager.h"
 #include "SimpleMissionItem.h"
 #include "TestFixtures.h"
+
+#include <QtCore/QTemporaryDir>
 using namespace TestFixtures;
 
 MissionControllerTest::~MissionControllerTest() = default;
@@ -406,6 +412,131 @@ void MissionControllerTest::_testGlobalAltFrame()
             QCOMPARE(siLoop->missionItem().frame(), testCase.expectedMavFrame);
         }
     }
+}
+
+void MissionControllerTest::_testInsertComplexItemFromKML()
+{
+    _initForFirmwareType(MAV_AUTOPILOT_PX4);
+
+    // PolygonAreaTest.kml contains a 4-vertex polygon (5th coordinate is ring closure).
+    // polyline.kml contains a LineString; CorridorScan expects a polyline, not a polygon.
+    constexpr int kExpectedPolygonVertexCount = 4;
+    const QString polygonKml = QStringLiteral(":/unittest/PolygonAreaTest.kml");
+    const QString polylineKml = QStringLiteral(":/unittest/polyline.kml");
+
+    // Survey — polygon KML defines the survey area
+    VisualMissionItem* surveyVisual = _missionController->insertComplexMissionItemFromKMLOrSHP(
+        SurveyComplexItem::canonicalName, polygonKml, 1, false);
+    QVERIFY(surveyVisual);
+    SurveyComplexItem* surveyItem = qobject_cast<SurveyComplexItem*>(surveyVisual);
+    QVERIFY(surveyItem);
+    QCOMPARE(surveyItem->surveyAreaPolygon()->count(), kExpectedPolygonVertexCount);
+
+    // CorridorScan — polyline KML defines the corridor path; corridor polygon is computed from it
+    VisualMissionItem* corridorVisual = _missionController->insertComplexMissionItemFromKMLOrSHP(
+        CorridorScanComplexItem::canonicalName, polylineKml, 2, false);
+    QVERIFY(corridorVisual);
+    CorridorScanComplexItem* corridorItem = qobject_cast<CorridorScanComplexItem*>(corridorVisual);
+    QVERIFY(corridorItem);
+    QVERIFY(corridorItem->surveyAreaPolygon()->count() > 0);
+
+    // StructureScan — polygon KML defines the structure perimeter
+    VisualMissionItem* structureVisual = _missionController->insertComplexMissionItemFromKMLOrSHP(
+        StructureScanComplexItem::canonicalName, polygonKml, 3, false);
+    QVERIFY(structureVisual);
+    StructureScanComplexItem* structureItem = qobject_cast<StructureScanComplexItem*>(structureVisual);
+    QVERIFY(structureItem);
+    QCOMPARE(structureItem->structurePolygon()->count(), kExpectedPolygonVertexCount);
+
+    // home + Survey + CorridorScan + StructureScan
+    QCOMPARE(_missionController->visualItems()->count(), 4);
+}
+
+void MissionControllerTest::_testLoadPlanRoundTripComplexItems()
+{
+    _initForFirmwareType(MAV_AUTOPILOT_PX4);
+
+    const QGeoCoordinate center = Coord::zurich();
+
+    // Insert a Survey and a CorridorScan
+    VisualMissionItem* surveyVisual = _missionController->insertComplexMissionItem(
+        SurveyComplexItem::canonicalName, center, 1, false);
+    QVERIFY(surveyVisual);
+    QVERIFY(qobject_cast<SurveyComplexItem*>(surveyVisual));
+
+    VisualMissionItem* corridorVisual = _missionController->insertComplexMissionItem(
+        CorridorScanComplexItem::canonicalName, center, 2, false);
+    QVERIFY(corridorVisual);
+    QVERIFY(qobject_cast<CorridorScanComplexItem*>(corridorVisual));
+
+    // home + Survey + CorridorScan
+    QCOMPARE(_missionController->visualItems()->count(), 3);
+
+    // Save to a temporary file, reload, and verify the types survive the round-trip
+    QTemporaryDir tmpDir;
+    QVERIFY(tmpDir.isValid());
+    const QString planPath = QStringLiteral("%1/test.%2").arg(tmpDir.path(), _masterController->fileExtension());
+    QVERIFY(_masterController->saveToFile(planPath));
+
+    _missionController->removeAll();
+    QCOMPARE(_missionController->visualItems()->count(), 1); // home only
+
+    _masterController->loadFromFile(planPath);
+    QCOMPARE(_missionController->visualItems()->count(), 3);
+
+    QVERIFY(qobject_cast<SurveyComplexItem*>(_missionController->visualItems()->value<VisualMissionItem*>(1)));
+    QVERIFY(qobject_cast<CorridorScanComplexItem*>(_missionController->visualItems()->value<VisualMissionItem*>(2)));
+}
+
+void MissionControllerTest::_testInsertSurveyAppliesAltFrameInMixedMode()
+{
+    _initForFirmwareType(MAV_AUTOPILOT_PX4);
+    _missionController->setGlobalAltitudeFrame(QGroundControlQmlGlobal::AltitudeFrameMixed);
+
+    const QGeoCoordinate coord = Coord::zurich();
+
+    // Insert a simple waypoint and force its altitude frame to Absolute
+    VisualMissionItem* simpleVisual = _missionController->insertSimpleMissionItem(coord, 1, false);
+    QVERIFY(simpleVisual);
+    SimpleMissionItem* simpleItem = qobject_cast<SimpleMissionItem*>(simpleVisual);
+    QVERIFY(simpleItem);
+    simpleItem->setAltitudeFrame(QGroundControlQmlGlobal::AltitudeFrameAbsolute);
+    simpleItem->altitude()->setRawValue(150.0);
+
+    // Survey default distanceMode is Relative; inserting after an Absolute item should change it
+    QCOMPARE(_missionController->visualItems()->count(), 2); // home + simple
+    VisualMissionItem* surveyVisual = _missionController->insertComplexMissionItem(
+        SurveyComplexItem::canonicalName, coord, 2, false);
+    QVERIFY(surveyVisual);
+    SurveyComplexItem* surveyItem = qobject_cast<SurveyComplexItem*>(surveyVisual);
+    QVERIFY(surveyItem);
+
+    QCOMPARE(surveyItem->cameraCalc()->distanceMode(), QGroundControlQmlGlobal::AltitudeFrameAbsolute);
+}
+
+void MissionControllerTest::_testInsertNonSurveyComplexItemMixedModeNoCrash()
+{
+    _initForFirmwareType(MAV_AUTOPILOT_PX4);
+    _missionController->setGlobalAltitudeFrame(QGroundControlQmlGlobal::AltitudeFrameMixed);
+
+    const QGeoCoordinate coord = Coord::zurich();
+
+    // Insert a simple waypoint with Absolute frame to provide altitude context
+    VisualMissionItem* simpleVisual = _missionController->insertSimpleMissionItem(coord, 1, false);
+    QVERIFY(simpleVisual);
+    SimpleMissionItem* simpleItem = qobject_cast<SimpleMissionItem*>(simpleVisual);
+    QVERIFY(simpleItem);
+    simpleItem->setAltitudeFrame(QGroundControlQmlGlobal::AltitudeFrameAbsolute);
+
+    // CorridorScan inherits the base-class no-op — distanceMode stays at its default (Relative)
+    VisualMissionItem* corridorVisual = _missionController->insertComplexMissionItem(
+        CorridorScanComplexItem::canonicalName, coord, 2, false);
+    QVERIFY(corridorVisual);
+    CorridorScanComplexItem* corridorItem = qobject_cast<CorridorScanComplexItem*>(corridorVisual);
+    QVERIFY(corridorItem);
+
+    QCOMPARE(corridorItem->cameraCalc()->distanceMode(), QGroundControlQmlGlobal::AltitudeFrameRelative);
+    QCOMPARE(_missionController->visualItems()->count(), 3);
 }
 
 #include "UnitTest.h"

--- a/test/MissionManager/MissionControllerTest.h
+++ b/test/MissionManager/MissionControllerTest.h
@@ -27,6 +27,10 @@ private slots:
     void _testMissionOffset();
     void _testMissionRotate();
     void _testMissionTransformsInvalidHome();
+    void _testLoadPlanRoundTripComplexItems();
+    void _testInsertSurveyAppliesAltFrameInMixedMode();
+    void _testInsertNonSurveyComplexItemMixedModeNoCrash();
+    void _testInsertComplexItemFromKML();
 
     // Parameterized tests - runs once per autopilot type
     UT_PARAMETERIZED_TEST(_testEmptyVehicle);


### PR DESCRIPTION
## Summary

Three focused commits that fix a custom-build linker failure in the Log Viewer, harden CI, and add a complete `PerimeterScan` custom complex mission item to `custom-example`.

---

## Commit 1 — LogViewer: guard APM dialect code behind `QGC_NO_ARDUPILOT_DIALECT`

Custom builds compiled without APM support (`QGC_DISABLE_APM_MAVLINK=ON`) failed to link because `LogViewerParamMetaData.cc` unconditionally included `APMParameterMetaData.h` and defined `enrichForAPM()`.

- Wrap `#include "APMParameterMetaData.h"` and both APM helper functions in `#ifndef QGC_NO_ARDUPILOT_DIALECT`
- Wrap the `enrichForAPM()` definition and its declaration in the same guard
- Wrap the `enrichForAPM()` call site in `LogFileParser.cc`
- Hide the "Open .bin" button in `LogViewerPage.qml` when `QGroundControl.hasAPMSupport` is false

## Commit 2 — CI: broaden custom-build workflow trigger to match platform CIs

The `custom-build.yml` workflow previously only triggered on `custom-example/**` changes, so mainline `src/` changes that break the custom build went undetected (as demonstrated by the above linker error).

Change the trigger to `paths-ignore: docs/**`, matching the pattern used by `linux.yml`, `macos.yml`, and `windows.yml`.

## Commit 3 — custom-example: add PerimeterScan complex mission item

Adds a complete working example of a custom `ComplexMissionItem` to `custom-example`:

- **`PerimeterScanComplexItem`** — generates waypoints around the perimeter of a user-defined polygon; stores altitude as a `SettingsFact`
- **`PerimeterScanPlanCreator`** — surfaces the item in the Plan view "Add Pattern" toolbar
- **`PerimeterScanEditor.qml`** — sidebar editor (altitude + polygon tools)
- **`PerimeterScanMapVisual.qml`** — interactive polygon + flight-path polyline on the map
- **`PerimeterScan.SettingsGroup.json`** — `FactMetaData` for the altitude fact

Infrastructure changes to support custom complex items:

- `QGCCorePlugin` gains `createComplexMissionItem()` — a virtual factory called by `MissionController` when it encounters an unknown complex item type
- `ComplexMissionItem` gains `applyPreviousAltitudeFrame()` — a virtual hook used when inserting items into a mixed-altitude plan
- `MissionController` and `SurveyComplexItem` updated to use the new factory API
- `MissionControllerTest` extended with a PerimeterScan save/load round-trip test
