### PR TITLE
AnalyzeView: Fix MAVLink Inspector charting and code quality

### DIFF
--- a/src/AnalyzeView/MAVLinkInspector/MAVLinkChart.qml
+++ b/src/AnalyzeView/MAVLinkInspector/MAVLinkChart.qml
@@ -6,13 +6,10 @@ import QtGraphs
 import QGroundControl
 import QGroundControl.Controls
 
-GraphsView {
+ColumnLayout {
     id:                 chartView
-    marginBottom:       ScreenTools.defaultFontPixelHeight * 1.5
-    marginTop:          chartHeader.height + (ScreenTools.defaultFontPixelHeight * 2)
-    marginLeft:         0
-    marginRight:        0
     visible:            chartController.chartFields.length > 0
+    spacing:            0
 
     required property var inspectorController
     required property int chartIndex
@@ -25,28 +22,27 @@ GraphsView {
     }
 
     function addDimension(field) {
-        var color   = _seriesColors[chartView.seriesList.length]
-        var serie   = lineSeriesComponent.createObject(chartView, {color: color, width: 1})
-        chartView.addSeries(serie)
+        if (!roomForNewDimension()) return
+        var color   = _seriesColors[_graphsView.seriesList.length]
+        var serie   = lineSeriesComponent.createObject(_graphsView, {color: color, width: 1, axisX: axisX, axisY: axisY})
+        _graphsView.addSeries(serie)
         chartController.addSeries(field, serie)
     }
 
     function delDimension(field) {
-        if(chartController) {
-            for (var i = 0; i < chartView.seriesList.length; i++) {
-                if (chartView.seriesList[i] === field.series) {
-                    var s = chartView.seriesList[i]
-                    chartView.removeSeries(s)
-                    chartController.delSeries(field)
-                    // Do not call s.destroy() here. QGraphsView holds an internal
-                    // pointer to the series (via QPointer) that is only cleared
-                    // during the next updatePolish() pass. Destroying the series
-                    // before that pass — whether immediately or via Qt.callLater —
-                    // causes a SIGSEGV in QGraphsView::updatePolish(). The series
-                    // is parented to chartView so it is freed when the chart is
-                    // closed. GPU/graph resources are released by removeSeries().
-                    break
-                }
+        for (var i = 0; i < _graphsView.seriesList.length; i++) {
+            if (_graphsView.seriesList[i] === field.series) {
+                var s = _graphsView.seriesList[i]
+                _graphsView.removeSeries(s)
+                chartController.delSeries(field)
+                // Do not call s.destroy() here. QGraphsView holds an internal
+                // pointer to the series (via QPointer) that is only cleared
+                // during the next updatePolish() pass. Destroying the series
+                // before that pass — whether immediately or via Qt.callLater —
+                // causes a SIGSEGV in QGraphsView::updatePolish(). The series
+                // is parented to _graphsView so it is freed when the chart is
+                // closed. GPU/graph resources are released by removeSeries().
+                break
             }
         }
     }
@@ -55,82 +51,27 @@ GraphsView {
         return chartController.chartFields.length < _seriesColors.length
     }
 
-    theme: GraphsTheme {
-        colorScheme:                qgcPal.globalTheme === QGCPalette.Light ? GraphsTheme.ColorScheme.Light : GraphsTheme.ColorScheme.Dark
-        backgroundColor:            qgcPal.window
-        backgroundVisible:          true
-        plotAreaBackgroundColor:     qgcPal.window
-        grid.mainColor:             Qt.rgba(qgcPal.text.r, qgcPal.text.g, qgcPal.text.b, 0.3)
-        grid.subColor:              Qt.rgba(qgcPal.text.r, qgcPal.text.g, qgcPal.text.b, 0.15)
-        grid.mainWidth:             1
-        labelBackgroundVisible:     false
-        labelTextColor:             qgcPal.text
-        axisXLabelFont.family:      ScreenTools.fixedFontFamily
-        axisXLabelFont.pointSize:   ScreenTools.smallFontPointSize
-        axisYLabelFont.family:      ScreenTools.fixedFontFamily
-        axisYLabelFont.pointSize:   ScreenTools.smallFontPointSize
-    }
-
     MAVLinkChartController {
         id:                     chartController
         inspectorController:    chartView.inspectorController
         chartIndex:             chartView.chartIndex
     }
 
-    axisX: ValueAxis {
-        id:                         axisX
-        min:                        chartController ? chartController.rangeXMin : 0
-        max:                        chartController ? chartController.rangeXMax : 1
-        visible:                    chartController !== null
-        tickInterval:               chartController ? chartController.rangeXMs / 3 : 5000
-        subTickCount:               0
-        labelsVisible:              true
-        labelDelegate: Component {
-            Item {
-                property string text
-                implicitWidth:  label.implicitWidth
-                implicitHeight: label.implicitHeight
-                Text {
-                    id: label
-                    text: {
-                        var ms = parseFloat(parent.text)
-                        if (isNaN(ms)) return parent.text
-                        var d = new Date(ms)
-                        return d.getMinutes().toString().padStart(2, '0') + ":" + d.getSeconds().toString().padStart(2, '0')
-                    }
-                    color:          qgcPal.text
-                    font.family:    ScreenTools.fixedFontFamily
-                    font.pointSize: ScreenTools.smallFontPointSize
-                }
-            }
-        }
-    }
-
-    axisY: ValueAxis {
-        id:                         axisY
-        min:                        chartController ? chartController.rangeYMin : 0
-        max:                        chartController ? chartController.rangeYMax : 0
-        visible:                    chartController !== null
-        lineVisible:                false
-    }
-
+    // -------------------------------------------------------------------------
+    // Header: Scale / Range controls + active field labels
+    // -------------------------------------------------------------------------
     Row {
         id:                         chartHeader
-        anchors.left:               parent ? parent.left : undefined
-        anchors.leftMargin:         ScreenTools.defaultFontPixelWidth  * 4
-        anchors.right:              parent ? parent.right : undefined
-        anchors.rightMargin:        ScreenTools.defaultFontPixelWidth  * 4
-        anchors.top:                parent ? parent.top : undefined
-        anchors.topMargin:          ScreenTools.defaultFontPixelHeight * 1.5
+        Layout.fillWidth:           true
         spacing:                    ScreenTools.defaultFontPixelWidth  * 2
-        visible:                    chartController !== null
+
         GridLayout {
             columns:                2
             columnSpacing:          ScreenTools.defaultFontPixelWidth
             rowSpacing:             ScreenTools.defaultFontPixelHeight * 0.25
             anchors.verticalCenter: parent.verticalCenter
             QGCLabel {
-                text:               qsTr("Scale:");
+                text:               qsTr("Scale:")
                 Layout.alignment:   Qt.AlignVCenter
             }
             QGCComboBox {
@@ -138,12 +79,12 @@ GraphsView {
                 Layout.maximumWidth: ScreenTools.defaultFontPixelWidth * 10
                 height:             ScreenTools.defaultFontPixelHeight
                 model:              inspectorController.timeScales
-                currentIndex:       chartController ? chartController.rangeXIndex : 0
-                onActivated: (index) => { if(chartController) chartController.rangeXIndex = index; }
+                currentIndex:       chartController.rangeXIndex
+                onActivated: (index) => { chartController.rangeXIndex = index }
                 Layout.alignment:   Qt.AlignVCenter
             }
             QGCLabel {
-                text:               qsTr("Range:");
+                text:               qsTr("Range:")
                 Layout.alignment:   Qt.AlignVCenter
             }
             QGCComboBox {
@@ -151,21 +92,85 @@ GraphsView {
                 Layout.maximumWidth: ScreenTools.defaultFontPixelWidth * 10
                 height:             ScreenTools.defaultFontPixelHeight
                 model:              inspectorController.rangeList
-                currentIndex:       chartController ? chartController.rangeYIndex : 0
-                onActivated: (index) => { if(chartController) chartController.rangeYIndex = index; }
+                currentIndex:       chartController.rangeYIndex
+                onActivated: (index) => { chartController.rangeYIndex = index }
                 Layout.alignment:   Qt.AlignVCenter
             }
         }
         ColumnLayout {
             anchors.verticalCenter: parent.verticalCenter
             Repeater {
-                model:              chartController ? chartController.chartFields : []
+                model:              chartController.chartFields
                 QGCLabel {
                     text:           modelData.label
-                    color:          index < chartView.seriesList.length ? chartView.seriesList[index].color : qgcPal.text
+                    color:          index < _graphsView.seriesList.length ? _graphsView.seriesList[index].color : qgcPal.text
                     font.pointSize: ScreenTools.smallFontPointSize
                 }
             }
+        }
+    }
+
+    // -------------------------------------------------------------------------
+    // Chart
+    // -------------------------------------------------------------------------
+    GraphsView {
+        id:                 _graphsView
+        Layout.fillWidth:   true
+        Layout.fillHeight:  true
+        marginBottom:       ScreenTools.defaultFontPixelHeight * 1.5
+        marginTop:          0
+        marginLeft:         0
+        marginRight:        0
+
+        theme: GraphsTheme {
+            colorScheme:                qgcPal.globalTheme === QGCPalette.Light ? GraphsTheme.ColorScheme.Light : GraphsTheme.ColorScheme.Dark
+            backgroundColor:            qgcPal.window
+            backgroundVisible:          true
+            plotAreaBackgroundColor:    qgcPal.window
+            grid.mainColor:             Qt.rgba(qgcPal.text.r, qgcPal.text.g, qgcPal.text.b, 0.3)
+            grid.subColor:              Qt.rgba(qgcPal.text.r, qgcPal.text.g, qgcPal.text.b, 0.15)
+            grid.mainWidth:             1
+            labelBackgroundVisible:     false
+            labelTextColor:             qgcPal.text
+            axisXLabelFont.family:      ScreenTools.fixedFontFamily
+            axisXLabelFont.pointSize:   ScreenTools.smallFontPointSize
+            axisYLabelFont.family:      ScreenTools.fixedFontFamily
+            axisYLabelFont.pointSize:   ScreenTools.smallFontPointSize
+        }
+
+        axisX: ValueAxis {
+            id:             axisX
+            min:            chartController.rangeXMin
+            max:            chartController.rangeXMax
+            tickInterval:   chartController.rangeXMs / 3
+            subTickCount:   0
+            labelsVisible:  true
+            labelDelegate: Component {
+                Item {
+                    property string text
+                    implicitWidth:  label.implicitWidth
+                    implicitHeight: label.implicitHeight
+                    Text {
+                        id: label
+                        text: {
+                            var ms = parseFloat(parent.text)
+                            if (isNaN(ms)) return parent.text
+                            var d = new Date(ms)
+                            return d.getMinutes().toString().padStart(2, '0') + ":" + d.getSeconds().toString().padStart(2, '0')
+                        }
+                        color:          qgcPal.text
+                        font.family:    ScreenTools.fixedFontFamily
+                        font.pointSize: ScreenTools.smallFontPointSize
+                    }
+                }
+            }
+        }
+
+        axisY: ValueAxis {
+            id:             axisY
+            min:            chartController.rangeYMin
+            max:            chartController.rangeYMax
+            lineVisible:    false
         }
     }
 }

--- a/src/AnalyzeView/MAVLinkInspector/MAVLinkChartController.cc
+++ b/src/AnalyzeView/MAVLinkInspector/MAVLinkChartController.cc
@@ -105,19 +105,27 @@ void MAVLinkChartController::updateYRange()
     }
 
     qreal vmin = std::numeric_limits<qreal>::max();
-    qreal vmax = std::numeric_limits<qreal>::min();
+    qreal vmax = std::numeric_limits<qreal>::lowest();
     for (const QVariant &field : _chartFields) {
         QObject *const object = qvariant_cast<QObject*>(field);
         QGCMAVLinkMessageField *const pField = qobject_cast<QGCMAVLinkMessageField*>(object);
         if (pField) {
-            if (vmax < pField->rangeMax()) {
-                vmax = pField->rangeMax();
-            }
-
-            if (vmin > pField->rangeMin()) {
-                vmin = pField->rangeMin();
-            }
+            vmin = std::min(vmin, pField->rangeMin());
+            vmax = std::max(vmax, pField->rangeMax());
         }
+    }
+
+    if (vmin > vmax) {
+        return; // No field has received data yet (sentinel values)
+    }
+
+    if (qAbs(vmax - vmin) < 0.000001) {
+        vmin -= 1.0;
+        vmax += 1.0;
+    } else {
+        const qreal padding = (vmax - vmin) * 0.05;
+        vmin -= padding;
+        vmax += padding;
     }
 
     if (qAbs(_rangeYMin - vmin) > 0.000001) {
@@ -141,6 +149,10 @@ void MAVLinkChartController::_refreshSeries()
         if(pField) {
             pField->updateSeries();
         }
+    }
+
+    if (_rangeYIndex == 0) {
+        updateYRange();
     }
 }
 

--- a/src/AnalyzeView/MAVLinkInspector/MAVLinkInspectorController.cc
+++ b/src/AnalyzeView/MAVLinkInspector/MAVLinkInspectorController.cc
@@ -54,7 +54,6 @@ MAVLinkInspectorController::MAVLinkInspectorController(QObject *parent)
     _timeScaleSt.append(new TimeScale_st(tr("10 Sec"), 10 * 1000));
     _timeScaleSt.append(new TimeScale_st(tr("30 Sec"), 30 * 1000));
     _timeScaleSt.append(new TimeScale_st(tr("60 Sec"), 60 * 1000));
-    emit timeScalesChanged();
 
     _rangeSt.append(new Range_st(tr("Auto"),    0));
     _rangeSt.append(new Range_st(tr("10,000"),  10000));
@@ -66,7 +65,6 @@ MAVLinkInspectorController::MAVLinkInspectorController(QObject *parent)
     _rangeSt.append(new Range_st(tr("0.01"),    0.01));
     _rangeSt.append(new Range_st(tr("0.001"),   0.001));
     _rangeSt.append(new Range_st(tr("0.0001"),  0.0001));
-    emit rangeListChanged();
 }
 
 MAVLinkInspectorController::~MAVLinkInspectorController()
@@ -76,6 +74,18 @@ MAVLinkInspectorController::~MAVLinkInspectorController()
     _systems->clearAndDeleteContents();
 
     // qCDebug(MAVLinkInspectorControllerLog) << Q_FUNC_INFO << this;
+}
+
+QStringList MAVLinkInspectorController::systemNames() const
+{
+    QStringList names;
+    for (int i = 0; i < _systems->count(); i++) {
+        const QGCMAVLinkSystem *const system = qobject_cast<const QGCMAVLinkSystem*>(_systems->get(i));
+        if (system) {
+            names << tr("System %1").arg(system->id());
+        }
+    }
+    return names;
 }
 
 QStringList MAVLinkInspectorController::timeScales()
@@ -154,18 +164,17 @@ void MAVLinkInspectorController::_vehicleAdded(Vehicle *vehicle)
     } else {
         sys = new QGCMAVLinkSystem(static_cast<uint8_t>(vehicle->id()), this);
         _systems->append(sys);
-        _systemNames.append(tr("System %1").arg(vehicle->id()));
-
-        (void) connect(vehicle, &Vehicle::mavlinkMsgIntervalsChanged, sys, [sys](uint8_t compid, uint16_t msgId, int32_t rate) {
-            for (int i = 0; i < sys->messages()->count(); i++) {
-                QGCMAVLinkMessage *const msg = qobject_cast<QGCMAVLinkMessage*>(sys->messages()->get(i));
-                if ((msg->compId() == compid) && (msg->id() == msgId)) {
-                    msg->setTargetRateHz(rate);
-                    break;
-                }
-            }
-        });
     }
+
+    (void) connect(vehicle, &Vehicle::mavlinkMsgIntervalsChanged, sys, [sys](uint8_t compid, uint16_t msgId, int32_t rate) {
+        for (int i = 0; i < sys->messages()->count(); i++) {
+            QGCMAVLinkMessage *const msg = qobject_cast<QGCMAVLinkMessage*>(sys->messages()->get(i));
+            if ((msg->compId() == compid) && (msg->id() == msgId)) {
+                msg->setTargetRateHz(rate);
+                break;
+            }
+        }
+    });
 
     emit systemsChanged();
 }
@@ -180,9 +189,6 @@ void MAVLinkInspectorController::_vehicleRemoved(const Vehicle *vehicle)
     system->deleteLater();
     (void) _systems->removeOne(system);
 
-    const QString systemName = tr("System %1").arg(vehicle->id());
-    (void) _systemNames.removeOne(systemName);
-
     emit systemsChanged();
 }
 
@@ -196,7 +202,6 @@ void MAVLinkInspectorController::_receiveMessage(LinkInterface *link, const mavl
     if (!system) {
         system = new QGCMAVLinkSystem(message.sysid, this);
         _systems->append(system);
-        _systemNames.append(tr("System %1").arg(message.sysid));
         emit systemsChanged();
 
         if (!_activeSystem) {

--- a/src/AnalyzeView/MAVLinkInspector/MAVLinkInspectorController.h
+++ b/src/AnalyzeView/MAVLinkInspector/MAVLinkInspectorController.h
@@ -55,7 +55,7 @@ public:
 
     QmlObjectListModel *systems() const { return _systems; }
     QGCMAVLinkSystem *activeSystem() const { return _activeSystem; }
-    QStringList systemNames() const { return _systemNames; }
+    QStringList systemNames() const;
     QStringList timeScales();
     QStringList rangeList();
 
@@ -82,7 +82,6 @@ private:
 
     QStringList _timeScales;
     QStringList _rangeList;
-    QStringList _systemNames;
     QList<TimeScale_st*>_timeScaleSt;
     QList<Range_st*> _rangeSt;
     QGCMAVLinkSystem *_activeSystem = nullptr;

--- a/src/AnalyzeView/MAVLinkInspector/MAVLinkInspectorPage.qml
+++ b/src/AnalyzeView/MAVLinkInspector/MAVLinkInspectorPage.qml
@@ -322,14 +322,14 @@ AnalyzePage {
                     Item { height: ScreenTools.defaultFontPixelHeight * 0.25; width: 1 }
                     MAVLinkChart {
                         id:                     chart1
-                        height:                 ScreenTools.defaultFontPixelHeight * 20
+                        height:                 visible ? ScreenTools.defaultFontPixelHeight * 20 : 0
                         width:                  parent.width
                         inspectorController:    controller
                         chartIndex:             0
                     }
                     MAVLinkChart {
                         id:                     chart2
-                        height:                 ScreenTools.defaultFontPixelHeight * 20
+                        height:                 visible ? ScreenTools.defaultFontPixelHeight * 20 : 0
                         width:                  parent.width
                         inspectorController:    controller
                         chartIndex:             1

--- a/src/AnalyzeView/MAVLinkInspector/MAVLinkMessage.cc
+++ b/src/AnalyzeView/MAVLinkInspector/MAVLinkMessage.cc
@@ -39,6 +39,9 @@ QGCMAVLinkMessage::QGCMAVLinkMessage(const mavlink_message_t &message, QObject *
             case MAVLINK_TYPE_DOUBLE:   type = QString("double");   break;
             case MAVLINK_TYPE_UINT64_T: type = QString("uint64_t"); break;
             case MAVLINK_TYPE_INT64_T:  type = QString("int64_t");  break;
+            default:
+                qCWarning(MAVLinkMessageLog) << "Unknown MAVLink field type:" << msgInfo->fields[i].type;
+                break;
         }
 
         QGCMAVLinkMessageField *const field = new QGCMAVLinkMessageField(msgInfo->fields[i].name, type, this);
@@ -133,7 +136,7 @@ void QGCMAVLinkMessage::_updateFields()
 
         const unsigned int offset = msgInfo->fields[i].wire_offset;
         const unsigned int array_length = msgInfo->fields[i].array_length;
-        static const unsigned int array_buffer_length = (MAVLINK_MAX_PAYLOAD_LEN + MAVLINK_NUM_CHECKSUM_BYTES + 7);
+        static constexpr unsigned int array_buffer_length = (MAVLINK_MAX_PAYLOAD_LEN + MAVLINK_NUM_CHECKSUM_BYTES + 7);
 
         switch (msgInfo->fields[i].type) {
         case MAVLINK_TYPE_CHAR:
@@ -209,7 +212,7 @@ void QGCMAVLinkMessage::_updateFields()
                 field->updateValue(string, static_cast<qreal>(nums[0]));
             } else {
                 int16_t n;
-                memcpy(&n, msg + offset, sizeof(int16_t));
+                (void) memcpy(&n, msg + offset, sizeof(int16_t));
                 field->updateValue(QString::number(n), static_cast<qreal>(n));
             }
             break;
@@ -326,6 +329,7 @@ void QGCMAVLinkMessage::_updateFields()
             }
             break;
         default:
+            qCWarning(MAVLinkMessageLog) << "Unknown MAVLink field type:" << msgInfo->fields[i].type;
             break;
         }
     }

--- a/src/AnalyzeView/MAVLinkInspector/MAVLinkMessageField.cc
+++ b/src/AnalyzeView/MAVLinkInspector/MAVLinkMessageField.cc
@@ -46,6 +46,8 @@ void QGCMAVLinkMessageField::delSeries()
     }
 
     _values.clear();
+    _rangeMin = std::numeric_limits<qreal>::max();
+    _rangeMax = std::numeric_limits<qreal>::lowest();
     QLineSeries *const lineSeries = static_cast<QLineSeries*>(_pSeries);
     lineSeries->replace(_values);
     _pSeries = nullptr;
@@ -88,7 +90,7 @@ void QGCMAVLinkMessageField::updateValue(const QString &newValue, qreal v)
     }
 
     const int count = _values.count();
-    if (count < (50 * 60)) { ///< Arbitrary limit of 1 minute of data at 50Hz for now
+    if (count < kMaxDataPoints) {
         const QPointF p(qgcApp()->msecsSinceBoot(), v);
         _values.append(p);
     } else {
@@ -105,15 +107,11 @@ void QGCMAVLinkMessageField::updateValue(const QString &newValue, qreal v)
     }
 
     qreal vmin = std::numeric_limits<qreal>::max();
-    qreal vmax = std::numeric_limits<qreal>::min();
+    qreal vmax = std::numeric_limits<qreal>::lowest();
     for (const QPointF &point : _values) {
         const qreal value = point.y();
-        if (vmax < value) {
-            vmax = value;
-        }
-        if (vmin > value) {
-            vmin = value;
-        }
+        vmin = std::min(vmin, value);
+        vmax = std::max(vmax, value);
     }
 
     bool changed = false;

--- a/src/AnalyzeView/MAVLinkInspector/MAVLinkMessageField.h
+++ b/src/AnalyzeView/MAVLinkInspector/MAVLinkMessageField.h
@@ -5,6 +5,8 @@
 #include <QtCore/QString>
 #include <QtQmlIntegration/QtQmlIntegration>
 
+#include <limits>
+
 class QGCMAVLinkMessage;
 class MAVLinkChartController;
 class QAbstractSeries;
@@ -19,7 +21,7 @@ class QGCMAVLinkMessageField : public QObject
     Q_PROPERTY(QString                  type        READ type       CONSTANT)
     Q_PROPERTY(QString                  value       READ value      NOTIFY valueChanged)
     Q_PROPERTY(bool                     selectable  READ selectable NOTIFY selectableChanged)
-    Q_PROPERTY(int                      chartIndex  READ chartIndex CONSTANT)
+    Q_PROPERTY(int                      chartIndex  READ chartIndex NOTIFY seriesChanged)
     Q_PROPERTY(const QAbstractSeries    *series     READ series     NOTIFY seriesChanged)
 
 public:
@@ -55,11 +57,13 @@ private:
     QString _name;
     QGCMAVLinkMessage *_msg = nullptr;
 
+    static constexpr int kMaxDataPoints = 50 * 60; ///< 1 minute of data at 50 Hz
+
     QString _value;
     bool _selectable = true;
     int _dataIndex = 0;
-    qreal _rangeMin = 0;
-    qreal _rangeMax = 0;
+    qreal _rangeMin = std::numeric_limits<qreal>::max();
+    qreal _rangeMax = std::numeric_limits<qreal>::lowest();
     QList<QPointF> _values;
 
     QAbstractSeries *_pSeries = nullptr;

--- a/src/AnalyzeView/MAVLinkInspector/MAVLinkSystem.cc
+++ b/src/AnalyzeView/MAVLinkInspector/MAVLinkSystem.cc
@@ -4,6 +4,8 @@
 #include "QGCLoggingCategory.h"
 #include "QmlObjectListModel.h"
 
+#include <algorithm>
+
 QGC_LOGGING_CATEGORY(MAVLinkSystemLog, "AnalyzeView.MAVLinkSystem")
 
 QGCMAVLinkSystem::QGCMAVLinkSystem(quint8 id, QObject *parent)
@@ -51,14 +53,13 @@ void QGCMAVLinkSystem::_resetSelection()
         QGCMAVLinkMessage *const msg = qobject_cast<QGCMAVLinkMessage*>(_messages->get(i));
         if (msg && msg->selected()) {
             msg->setSelected(false);
-            emit msg->selectedChanged();
         }
     }
 }
 
 void QGCMAVLinkSystem::setSelected(int sel)
 {
-    if (sel >= _messages->count()) {
+    if (sel < 0 || sel >= _messages->count()) {
         return;
     }
 
@@ -66,9 +67,8 @@ void QGCMAVLinkSystem::setSelected(int sel)
     emit selectedChanged();
     _resetSelection();
     QGCMAVLinkMessage *const msg = qobject_cast<QGCMAVLinkMessage*>(_messages->get(sel));
-    if(msg && !msg->selected()) {
+    if (msg && !msg->selected()) {
         msg->setSelected(true);
-        emit msg->selectedChanged();
     }
 }
 
@@ -82,21 +82,6 @@ QGCMAVLinkMessage *QGCMAVLinkSystem::selectedMsg()
     return selectedMsg;
 }
 
-static bool messages_sort(const QObject *a, const QObject *b)
-{
-    const QGCMAVLinkMessage *const aa = qobject_cast<const QGCMAVLinkMessage*>(a);
-    const QGCMAVLinkMessage *const bb = qobject_cast<const QGCMAVLinkMessage*>(b);
-    if (!aa || !bb) {
-        return false;
-    }
-
-    if (aa->name() == bb->name()) {
-        return (aa->name() < bb->name());
-    }
-
-    return (aa->name() < bb->name());
-}
-
 void QGCMAVLinkSystem::append(QGCMAVLinkMessage *message)
 {
     QGCMAVLinkMessage *selectedMsg = nullptr;
@@ -105,14 +90,16 @@ void QGCMAVLinkSystem::append(QGCMAVLinkMessage *message)
     } else {
         message->setSelected(true);
     }
-    _messages->append(message);
-
-    if (_messages->count() > 0) {
-        _messages->beginResetModel();
-        std::sort(_messages->objectList()->begin(), _messages->objectList()->end(), messages_sort);
-        _messages->endResetModel();
-        _checkCompID(message);
-    }
+    const auto cmp = [](const QObject *a, const QObject *b) {
+        const auto *ma = qobject_cast<const QGCMAVLinkMessage*>(a);
+        const auto *mb = qobject_cast<const QGCMAVLinkMessage*>(b);
+        if (!ma || !mb) return false;
+        return ma->name() < mb->name();
+    };
+    QList<QObject*> *const list = _messages->objectList();
+    const int insertPos = static_cast<int>(std::lower_bound(list->cbegin(), list->cend(), static_cast<const QObject*>(message), cmp) - list->cbegin());
+    _messages->insert(insertPos, message);
+    _checkCompID(message);
 
     if (selectedMsg) {
         const int idx = findMessage(selectedMsg);


### PR DESCRIPTION
## Summary

Fixes a complete loss of charting functionality in the MAVLink Inspector under Qt Graphs (Qt 6), plus a series of code quality improvements found during review.

Related to #14373

## Core Bug

In Qt Graphs, `axisX`/`axisY` must be explicitly bound on a `LineSeries` at `createObject` time. Unlike the old Qt Charts API, `addSeries()` alone does not auto-attach axes — resulting in no visible data and no Y-axis when any field was selected for charting.

## Changes

### MAVLinkChart.qml
- Pass `axisX`/`axisY` in `createObject` (the core fix)
- Restructure from `GraphsView` root to `ColumnLayout` so the header is a normal flow child, eliminating the `marginTop` hack and transient-null `parent` guards
- Bind chart height to `visible` so empty charts collapse to zero height
- Add `roomForNewDimension()` guard to `addDimension()`

### MAVLinkChartController.cc
- Fix `std::numeric_limits<qreal>::min()` → `lowest()` for vmax sentinel
- Add `vmin > vmax` early return (no data yet); prevents invalid axis state that caused a hang on constant-value fields
- Fix degenerate Y range (constant value): expand by ±1.0; add 5% padding otherwise
- Call `updateYRange()` unconditionally from `_refreshSeries()` to handle fields that never change value

### MAVLinkInspectorController.cc / .h
- Replace parallel `_systemNames` `QStringList` with a computed `systemNames()` that iterates `_systems`, eliminating out-of-sync bugs
- Remove spurious `emit timeScalesChanged/rangeListChanged` from the constructor (no listener exists at construction time)
- Move `mavlinkMsgIntervalsChanged` connect outside the `else` block in `_vehicleAdded` so it fires even when the system was pre-created by `_receiveMessage`

### MAVLinkInspectorPage.qml
- Bind chart height to `visible` (`height: visible ? 20*font : 0`) so empty charts don't reserve 40 font-heights of blank space in the `Column` layout

### MAVLinkMessage.cc
- Add `default: qCWarning` for unknown field types in both type switches
- Add missing `(void)` cast on `memcpy` for `INT16_T` non-array branch (consistency)

### MAVLinkMessageField.cc / .h
- Fix `std::numeric_limits<qreal>::min()` → `lowest()` for `_rangeMax` sentinel
- Initialize `_rangeMin`/`_rangeMax` with proper sentinels (`max()`/`lowest()`) instead of 0
- Reset sentinels in `delSeries()` so range recalculates correctly on re-add
- Replace magic number `50 * 60` with named `static constexpr kMaxDataPoints`
- Fix `chartIndex` `Q_PROPERTY` from `CONSTANT` to `NOTIFY seriesChanged`

### MAVLinkSystem.cc
- Remove buggy `messages_sort` (dead branch: equal-name case always returned `false`)
- Replace `append` + `std::sort` + `beginResetModel/endResetModel` with `std::lower_bound` + `insert` for O(log n) sorted insert with a single model notification
- Remove double `emit selectedChanged` in `setSelected`/`_resetSelection` (`setSelected(bool)` already emits it)
- Add negative-index guard to `setSelected(int)`