### PR TITLE
AnalyzeView: Preserve page state when popping out to window

### DIFF
--- a/src/AnalyzeView/AnalyzeView.qml
+++ b/src/AnalyzeView/AnalyzeView.qml
@@ -18,20 +18,34 @@ Rectangle {
 
     property var  _activeVehicle: QGroundControl.multiVehicleManager.activeVehicle
     property var  _currentPage:   null
+    property var  _currentItem:   null
+
+    function _loadPage(source) {
+        if (_currentItem) {
+            _currentItem.destroy()
+            _currentItem = null
+        }
+        if (source !== "") {
+            var component = Qt.createComponent(source)
+            if (component.status === Component.Ready) {
+                _currentItem = component.createObject(panelContainer)
+            }
+        }
+    }
 
     function _updatePanelSource() {
         if (_currentPage) {
             if (_currentPage.requiresVehicle && !_activeVehicle) {
-                panelLoader.source = ""
+                _loadPage("")
             } else {
-                panelLoader.source = _currentPage.url
+                _loadPage(_currentPage.url)
             }
         }
     }
 
     on_ActiveVehicleChanged: {
         if (_currentPage && _currentPage.requiresVehicle) {
-            panelLoader.source = ""
+            _loadPage("")
             if (_activeVehicle) {
                 Qt.callLater(_updatePanelSource)
             }
@@ -77,7 +91,7 @@ Rectangle {
                     if (count > 0) {
                         itemAt(0).checked = true
                         _currentPage = QGroundControl.corePlugin.analyzePages[0]
-                        panelLoader.title = _currentPage.title
+                        panelContainer.title = _currentPage.title
                         _updatePanelSource()
                     }
                 }
@@ -90,7 +104,7 @@ Rectangle {
 
                     onClicked: {
                         _currentPage        = modelData
-                        panelLoader.title   = modelData.title
+                        panelContainer.title = modelData.title
                         checked             = true
                         _updatePanelSource()
                     }
@@ -111,8 +125,8 @@ Rectangle {
         color:                  qgcPal.windowShade
     }
 
-    Loader {
-        id:                     panelLoader
+    Item {
+        id:                     panelContainer
         anchors.topMargin:      _verticalMargin
         anchors.bottomMargin:   _verticalMargin
         anchors.leftMargin:     _horizontalMargin
@@ -121,18 +135,29 @@ Rectangle {
         anchors.right:          parent.right
         anchors.top:            parent.top
         anchors.bottom:         parent.bottom
-        source:                 ""
 
         property string title
 
         Connections {
-            target:     panelLoader.item
-            function onPopout() { mainWindow.createWindowedAnalyzePage(panelLoader.title, panelLoader.source, _currentPage ? _currentPage.requiresVehicle : false) }
+            target:     _currentItem
+            function onPopout() {
+                var existingItem = _currentItem
+                var pageTitle = panelContainer.title
+                var pageSource = _currentPage.url
+                var requiresVehicle = _currentPage ? _currentPage.requiresVehicle : false
+                // Release ownership without destroying
+                _currentItem = null
+                existingItem.visible = false
+                // Hand the existing item to the popout window
+                mainWindow.createWindowedAnalyzePage(pageTitle, pageSource, requiresVehicle, existingItem)
+                // Create a fresh instance in-place
+                _loadPage(pageSource)
+            }
         }
     }
 
     QGCLabel {
-        anchors.centerIn:   panelLoader
+        anchors.centerIn:   panelContainer
         text:               qsTr("Requires a connected vehicle")
         visible:            _currentPage && _currentPage.requiresVehicle && !_activeVehicle
     }

--- a/src/UI/MainWindow.qml
+++ b/src/UI/MainWindow.qml
@@ -650,11 +650,16 @@ ApplicationWindow {
     // to mainWindow. Otherwise if they are rooted to the AnalyzeView itself they will die when the analyze viewSwitch
     // closes.
 
-    function createWindowedAnalyzePage(title, source, requiresVehicle) {
+    function createWindowedAnalyzePage(title, source, requiresVehicle, existingItem) {
         var windowedPage = windowedAnalyzePage.createObject(mainWindow)
         windowedPage.title = title
-        windowedPage.source = source
         windowedPage.requiresVehicle = requiresVehicle
+        if (existingItem) {
+            windowedPage.adoptItem(existingItem)
+        } else {
+            windowedPage.source = source
+        }
+        windowedPage.visible = true
     }
 
     Component {
@@ -663,10 +668,19 @@ ApplicationWindow {
         Window {
             width:      ScreenTools.defaultFontPixelWidth  * 100
             height:     ScreenTools.defaultFontPixelHeight * 40
-            visible:    true
+            visible:    false
 
             property alias source: loader.source
             property bool requiresVehicle: false
+
+            function adoptItem(item) {
+                loader.visible = false
+                loader.source = ""
+                item.parent = contentRect
+                item.anchors.fill = contentRect
+                item.popped = true
+                item.visible = true
+            }
 
             Connections {
                 target: QGroundControl.multiVehicleManager
@@ -678,6 +692,7 @@ ApplicationWindow {
             }
 
             Rectangle {
+                id:             contentRect
                 color:          QGroundControl.globalPalette.window
                 anchors.fill:   parent
 
@@ -690,6 +705,13 @@ ApplicationWindow {
 
             onClosing: {
                 visible = false
+                // Destroy any reparented children (not owned by loader)
+                for (var i = contentRect.children.length - 1; i >= 0; i--) {
+                    var child = contentRect.children[i]
+                    if (child !== loader) {
+                        child.destroy()
+                    }
+                }
                 source = ""
                 Qt.callLater(destroy)
             }


### PR DESCRIPTION
Fixes #14373

## Problem
When popping out the MAVLink Inspector (or any Analyze page) to a separate window, all configured chart state (plotted fields, series, scale selections) was lost. The popout created a fresh instance via a Loader, discarding the live QML item.

## Solution
Replace Loader-based page management in AnalyzeView with manual `Qt.createComponent`/`createObject` lifecycle management. When popout is triggered:

1. The existing page item's ownership is released (not destroyed)
2. The live item is reparented directly into the popout Window
3. A fresh instance is created in-place for the main AnalyzeView
4. The popout Window starts hidden until reparenting is complete, avoiding `qt.graphs2d` "window doesn't exist" errors

This preserves all page state (charts, fields, scrollback) in the popout window.
