### PR TITLE
MAVLink Inspector: instance awareness, array expansion, debug separation, chart improvements

### DIFF
--- a/src/AnalyzeView/MAVLinkInspector/MAVLinkChart.qml
+++ b/src/AnalyzeView/MAVLinkInspector/MAVLinkChart.qml
@@ -55,6 +55,7 @@ ColumnLayout {
         id:                     chartController
         inspectorController:    chartView.inspectorController
         chartIndex:             chartView.chartIndex
+        plotPixelWidth:         Math.max(1, Math.floor(_graphsView.plotArea.width))
     }
 
     // -------------------------------------------------------------------------

--- a/src/AnalyzeView/MAVLinkInspector/MAVLinkChartController.cc
+++ b/src/AnalyzeView/MAVLinkInspector/MAVLinkChartController.cc
@@ -7,6 +7,8 @@
 #include <QtGraphs/QAbstractSeries>
 #include <QtCore/QTimer>
 
+static constexpr qreal kMinDelta = 1e-6;
+
 QGC_LOGGING_CATEGORY(MAVLinkChartControllerLog, "AnalyzeView.MAVLinkChartController")
 
 MAVLinkChartController::MAVLinkChartController(QObject *parent)
@@ -78,6 +80,7 @@ void MAVLinkChartController::setRangeXIndex(quint32 index)
     emit rangeXIndexChanged();
 
     updateXRange();
+    _resetFieldBucketing();
 }
 
 void MAVLinkChartController::updateXRange()
@@ -119,7 +122,7 @@ void MAVLinkChartController::updateYRange()
         return; // No field has received data yet (sentinel values)
     }
 
-    if (qAbs(vmax - vmin) < 0.000001) {
+    if (qAbs(vmax - vmin) < kMinDelta) {
         vmin -= 1.0;
         vmax += 1.0;
     } else {
@@ -128,12 +131,12 @@ void MAVLinkChartController::updateYRange()
         vmax += padding;
     }
 
-    if (qAbs(_rangeYMin - vmin) > 0.000001) {
+    if (qAbs(_rangeYMin - vmin) > kMinDelta) {
         _rangeYMin = vmin;
         emit rangeYMinChanged();
     }
 
-    if (qAbs(_rangeYMax - vmax) > 0.000001) {
+    if (qAbs(_rangeYMax - vmax) > kMinDelta) {
         _rangeYMax = vmax;
         emit rangeYMaxChanged();
     }
@@ -193,6 +196,33 @@ void MAVLinkChartController::delSeries(QGCMAVLinkMessageField *field)
         if (_chartFields.isEmpty()) {
             updateXRange();
             _updateSeriesTimer->stop();
+        }
+    }
+}
+
+void MAVLinkChartController::setPlotPixelWidth(int width)
+{
+    if (width == _plotPixelWidth) {
+        return;
+    }
+
+    _plotPixelWidth = width;
+    emit plotPixelWidthChanged();
+    _resetFieldBucketing();
+}
+
+void MAVLinkChartController::_resetFieldBucketing()
+{
+    if (_plotPixelWidth <= 0) {
+        return;
+    }
+
+    const qreal bucketWidthMs = rangeXMs() / _plotPixelWidth;
+    for (const QVariant &field : _chartFields) {
+        QObject *const object = qvariant_cast<QObject*>(field);
+        QGCMAVLinkMessageField *const pField = qobject_cast<QGCMAVLinkMessageField*>(object);
+        if (pField) {
+            pField->resetBucketing(_plotPixelWidth, bucketWidthMs);
         }
     }
 }

--- a/src/AnalyzeView/MAVLinkInspector/MAVLinkChartController.h
+++ b/src/AnalyzeView/MAVLinkInspector/MAVLinkChartController.h
@@ -27,6 +27,7 @@ class MAVLinkChartController : public QObject
     Q_PROPERTY(quint32      rangeYIndex READ rangeYIndex    WRITE setRangeYIndex    NOTIFY rangeYIndexChanged)
     Q_PROPERTY(quint32      rangeXIndex READ rangeXIndex    WRITE setRangeXIndex    NOTIFY rangeXIndexChanged)
     Q_PROPERTY(qreal        rangeXMs    READ rangeXMs                               NOTIFY rangeXIndexChanged)
+    Q_PROPERTY(int          plotPixelWidth READ plotPixelWidth WRITE setPlotPixelWidth NOTIFY plotPixelWidthChanged)
 
 public:
     explicit MAVLinkChartController(QObject *parent = nullptr);
@@ -46,9 +47,11 @@ public:
     qreal rangeXMs() const;
     quint32 rangeYIndex() const { return _rangeYIndex; }
     int chartIndex() const { return _chartIndex; }
+    int plotPixelWidth() const { return _plotPixelWidth; }
 
     void setRangeXIndex(quint32 index);
     void setRangeYIndex(quint32 index);
+    void setPlotPixelWidth(int width);
     void updateXRange();
     void updateYRange();
 
@@ -60,11 +63,13 @@ signals:
     void rangeYMaxChanged();
     void rangeYIndexChanged();
     void rangeXIndexChanged();
+    void plotPixelWidthChanged();
 
 private slots:
     void _refreshSeries();
 
 private:
+    void _resetFieldBucketing();
     int _chartIndex = 0;
     MAVLinkInspectorController *_inspectorController = nullptr;
     QTimer *_updateSeriesTimer = nullptr;
@@ -75,6 +80,7 @@ private:
     qreal _rangeYMax = 1;
     quint32 _rangeXIndex = 0;   ///< 5 Seconds
     quint32 _rangeYIndex = 0;   ///< Auto Range
+    int _plotPixelWidth = 0;
     QVariantList _chartFields;
 
     static constexpr int kUpdateFrequency = 1000 / 15;  ///< 15Hz

--- a/src/AnalyzeView/MAVLinkInspector/MAVLinkInspectorController.cc
+++ b/src/AnalyzeView/MAVLinkInspector/MAVLinkInspectorController.cc
@@ -50,10 +50,12 @@ MAVLinkInspectorController::MAVLinkInspectorController(QObject *parent)
     _updateFrequencyTimer->setSingleShot(false);
     _updateFrequencyTimer->start();
 
-    _timeScaleSt.append(new TimeScale_st(tr("5 Sec"),   5 * 1000));
-    _timeScaleSt.append(new TimeScale_st(tr("10 Sec"), 10 * 1000));
-    _timeScaleSt.append(new TimeScale_st(tr("30 Sec"), 30 * 1000));
-    _timeScaleSt.append(new TimeScale_st(tr("60 Sec"), 60 * 1000));
+    _timeScaleSt.append(new TimeScale_st(tr("5 Sec"),    5 * 1000));
+    _timeScaleSt.append(new TimeScale_st(tr("10 Sec"),  10 * 1000));
+    _timeScaleSt.append(new TimeScale_st(tr("30 Sec"),  30 * 1000));
+    _timeScaleSt.append(new TimeScale_st(tr("60 Sec"),  60 * 1000));
+    _timeScaleSt.append(new TimeScale_st(tr("2 Min"),  120 * 1000));
+    _timeScaleSt.append(new TimeScale_st(tr("5 Min"),  300 * 1000));
 
     _rangeSt.append(new Range_st(tr("Auto"),    0));
     _rangeSt.append(new Range_st(tr("10,000"),  10000));
@@ -198,6 +200,7 @@ void MAVLinkInspectorController::_receiveMessage(LinkInterface *link, const mavl
 
     QGCMAVLinkMessage *msg = nullptr;
     QGCMAVLinkSystem *system = _findVehicle(message.sysid);
+    const QString instanceValue = QGCMAVLinkMessage::extractInstanceValue(message);
 
     if (!system) {
         system = new QGCMAVLinkSystem(message.sysid, this);
@@ -209,11 +212,11 @@ void MAVLinkInspectorController::_receiveMessage(LinkInterface *link, const mavl
             emit activeSystemChanged();
         }
     } else {
-        msg = system->findMessage(message.msgid, message.compid);
+        msg = system->findMessage(message.msgid, message.compid, instanceValue);
     }
 
     if (!msg) {
-        msg = new QGCMAVLinkMessage(message, this);
+        msg = new QGCMAVLinkMessage(message, instanceValue, this);
         system->append(msg);
     } else {
         msg->update(message);

--- a/src/AnalyzeView/MAVLinkInspector/MAVLinkMessage.cc
+++ b/src/AnalyzeView/MAVLinkInspector/MAVLinkMessage.cc
@@ -1,4 +1,5 @@
 #include "MAVLinkMessage.h"
+#include "MAVLinkInstanceFields.h"
 #include "MAVLinkLib.h"
 #include "MAVLinkMessageField.h"
 #include "QGCLoggingCategory.h"
@@ -8,11 +9,11 @@
 
 QGC_LOGGING_CATEGORY(MAVLinkMessageLog, "AnalyzeView.MAVLinkMessage")
 
-QGCMAVLinkMessage::QGCMAVLinkMessage(const mavlink_message_t &message, QObject *parent)
+QGCMAVLinkMessage::QGCMAVLinkMessage(const mavlink_message_t &message, const QString &instanceValue, QObject *parent)
     : QObject(parent)
     , _message(message)
     , _fields(new QmlObjectListModel(this))
-
+    , _instanceValue(instanceValue)
 {
     qCDebug(MAVLinkMessageLog) << this;
 
@@ -23,6 +24,9 @@ QGCMAVLinkMessage::QGCMAVLinkMessage(const mavlink_message_t &message, QObject *
     }
 
     _name = QString(msgInfo->name);
+    if (!_instanceValue.isEmpty()) {
+        _name += QStringLiteral(" [%1]").arg(_instanceValue);
+    }
     qCDebug(MAVLinkMessageLog) << "New Message:" << _name;
 
     for (unsigned int i = 0; i < msgInfo->num_fields; ++i) {
@@ -44,8 +48,22 @@ QGCMAVLinkMessage::QGCMAVLinkMessage(const mavlink_message_t &message, QObject *
                 break;
         }
 
-        QGCMAVLinkMessageField *const field = new QGCMAVLinkMessageField(msgInfo->fields[i].name, type, this);
-        _fields->append(field);
+        const unsigned int array_length = msgInfo->fields[i].array_length;
+        const QString fieldName = QString(msgInfo->fields[i].name);
+
+        if (array_length > 0 && msgInfo->fields[i].type != MAVLINK_TYPE_CHAR) {
+            // Expand numeric arrays into individual element fields
+            for (unsigned int j = 0; j < array_length; ++j) {
+                const QString elementName = QStringLiteral("%1[%2]").arg(fieldName).arg(j);
+                QGCMAVLinkMessageField *const field = new QGCMAVLinkMessageField(elementName, type, this);
+                _fields->append(field);
+                _fieldMappings.append({i, static_cast<int>(j)});
+            }
+        } else {
+            QGCMAVLinkMessageField *const field = new QGCMAVLinkMessageField(fieldName, type, this);
+            _fields->append(field);
+            _fieldMappings.append({i, -1});
+        }
     }
 }
 
@@ -54,6 +72,110 @@ QGCMAVLinkMessage::~QGCMAVLinkMessage()
     _fields->clearAndDeleteContents();
 
     qCDebug(MAVLinkMessageLog) << this;
+}
+
+QString QGCMAVLinkMessage::extractInstanceValue(const mavlink_message_t &message)
+{
+    const QString instanceFieldName = mavlinkInstanceFields().value(message.msgid);
+    if (instanceFieldName.isEmpty()) {
+        // Special-case debug messages that use name/ind as implicit instance discriminator
+        return _extractDebugInstanceValue(message);
+    }
+
+    const mavlink_message_info_t *const msgInfo = mavlink_get_message_info(&message);
+    if (!msgInfo) {
+        return QString();
+    }
+
+    const uint8_t *const payload = reinterpret_cast<const uint8_t*>(&message.payload64[0]);
+
+    for (unsigned int i = 0; i < msgInfo->num_fields; ++i) {
+        if (instanceFieldName != QLatin1String(msgInfo->fields[i].name)) {
+            continue;
+        }
+
+        const unsigned int offset = msgInfo->fields[i].wire_offset;
+        const unsigned int array_length = msgInfo->fields[i].array_length;
+
+        switch (msgInfo->fields[i].type) {
+        case MAVLINK_TYPE_CHAR:
+            if (array_length > 0) {
+                char buf[MAVLINK_MAX_PAYLOAD_LEN + 1]{};
+                memcpy(buf, payload + offset, array_length);
+                buf[array_length] = '\0';
+                return QString::fromLatin1(buf).trimmed();
+            } else {
+                return QString(QChar::fromLatin1(static_cast<char>(*(payload + offset))));
+            }
+        case MAVLINK_TYPE_UINT8_T:
+            return QString::number(*(payload + offset));
+        case MAVLINK_TYPE_INT8_T:
+            return QString::number(*reinterpret_cast<const int8_t*>(payload + offset));
+        case MAVLINK_TYPE_UINT16_T: {
+            uint16_t val = 0;
+            memcpy(&val, payload + offset, sizeof(val));
+            return QString::number(val);
+        }
+        case MAVLINK_TYPE_INT16_T: {
+            int16_t val = 0;
+            memcpy(&val, payload + offset, sizeof(val));
+            return QString::number(val);
+        }
+        case MAVLINK_TYPE_UINT32_T: {
+            uint32_t val = 0;
+            memcpy(&val, payload + offset, sizeof(val));
+            return QString::number(val);
+        }
+        case MAVLINK_TYPE_INT32_T: {
+            int32_t val = 0;
+            memcpy(&val, payload + offset, sizeof(val));
+            return QString::number(val);
+        }
+        case MAVLINK_TYPE_UINT64_T: {
+            uint64_t val = 0;
+            memcpy(&val, payload + offset, sizeof(val));
+            return QString::number(val);
+        }
+        case MAVLINK_TYPE_INT64_T: {
+            int64_t val = 0;
+            memcpy(&val, payload + offset, sizeof(val));
+            return QString::number(val);
+        }
+        default:
+            return QString();
+        }
+    }
+
+    return QString();
+}
+
+QString QGCMAVLinkMessage::_extractDebugInstanceValue(const mavlink_message_t &message)
+{
+    switch (message.msgid) {
+    case MAVLINK_MSG_ID_NAMED_VALUE_FLOAT: {
+        char name[MAVLINK_MSG_NAMED_VALUE_FLOAT_FIELD_NAME_LEN + 1]{};
+        mavlink_msg_named_value_float_get_name(&message, name);
+        name[MAVLINK_MSG_NAMED_VALUE_FLOAT_FIELD_NAME_LEN] = '\0';
+        return QString::fromLatin1(name).trimmed();
+    }
+    case MAVLINK_MSG_ID_NAMED_VALUE_INT: {
+        char name[MAVLINK_MSG_NAMED_VALUE_INT_FIELD_NAME_LEN + 1]{};
+        mavlink_msg_named_value_int_get_name(&message, name);
+        name[MAVLINK_MSG_NAMED_VALUE_INT_FIELD_NAME_LEN] = '\0';
+        return QString::fromLatin1(name).trimmed();
+    }
+    case MAVLINK_MSG_ID_DEBUG_VECT: {
+        char name[MAVLINK_MSG_DEBUG_VECT_FIELD_NAME_LEN + 1]{};
+        mavlink_msg_debug_vect_get_name(&message, name);
+        name[MAVLINK_MSG_DEBUG_VECT_FIELD_NAME_LEN] = '\0';
+        return QString::fromLatin1(name).trimmed();
+    }
+    case MAVLINK_MSG_ID_DEBUG: {
+        return QString::number(mavlink_msg_debug_get_ind(&message));
+    }
+    default:
+        return QString();
+    }
 }
 
 void QGCMAVLinkMessage::updateFieldSelection()
@@ -122,28 +244,30 @@ void QGCMAVLinkMessage::_updateFields()
         return;
     }
 
-    if (_fields->count() != static_cast<int>(msgInfo->num_fields)) {
-        qCWarning(MAVLinkMessageLog) << "QGCMAVLinkMessage::update msgInfo field count mismatch msgid" << _message.msgid;
+    if (_fields->count() != _fieldMappings.count()) {
+        qCWarning(MAVLinkMessageLog) << "QGCMAVLinkMessage::update field mapping count mismatch msgid" << _message.msgid;
         return;
     }
 
     uint8_t *const msg = reinterpret_cast<uint8_t*>(&_message.payload64[0]);
-    for (unsigned int i = 0; i < msgInfo->num_fields; ++i) {
-        QGCMAVLinkMessageField *const field = qobject_cast<QGCMAVLinkMessageField*>(_fields->get(static_cast<int>(i)));
+
+    for (int idx = 0; idx < _fieldMappings.count(); ++idx) {
+        QGCMAVLinkMessageField *const field = qobject_cast<QGCMAVLinkMessageField*>(_fields->get(idx));
         if (!field) {
             continue;
         }
 
+        const FieldMapping &mapping = _fieldMappings.at(idx);
+        const unsigned int i = mapping.fieldIndex;
+        const int element = mapping.arrayElement;
         const unsigned int offset = msgInfo->fields[i].wire_offset;
-        const unsigned int array_length = msgInfo->fields[i].array_length;
-        static constexpr unsigned int array_buffer_length = (MAVLINK_MAX_PAYLOAD_LEN + MAVLINK_NUM_CHECKSUM_BYTES + 7);
 
         switch (msgInfo->fields[i].type) {
         case MAVLINK_TYPE_CHAR:
             field->setSelectable(false);
-            if (array_length > 0) {
+            if (msgInfo->fields[i].array_length > 0) {
                 char *const str = reinterpret_cast<char*>(msg + offset);
-                str[array_length - 1] = '\0';
+                str[msgInfo->fields[i].array_length - 1] = '\0';
                 const QString v(str);
                 field->updateValue(v, 0);
             } else {
@@ -153,181 +277,121 @@ void QGCMAVLinkMessage::_updateFields()
             }
             break;
         case MAVLINK_TYPE_UINT8_T:
-            if (array_length > 0) {
-                const uint8_t *const nums = msg + offset;
-                const QString tmp("%1, ");
-                QString string;
-                for (unsigned int j = 0; j < array_length - 1; ++j) {
-                    string += tmp.arg(nums[j]);
-                }
-                string += QString::number(nums[array_length - 1]);
-                field->updateValue(string, static_cast<qreal>(nums[0]));
+            if (element >= 0) {
+                const uint8_t u = *(msg + offset + element);
+                field->updateValue(QString::number(u), static_cast<qreal>(u));
             } else {
                 const uint8_t u = *(msg + offset);
                 field->updateValue(QString::number(u), static_cast<qreal>(u));
             }
             break;
         case MAVLINK_TYPE_INT8_T:
-            if (array_length > 0) {
-                const int8_t *const nums = reinterpret_cast<int8_t*>(msg + offset);
-                const QString tmp("%1, ");
-                QString string;
-                for (unsigned int j = 0; j < array_length - 1; ++j) {
-                    string += tmp.arg(nums[j]);
-                }
-                string += QString::number(nums[array_length - 1]);
-                field->updateValue(string, static_cast<qreal>(nums[0]));
+            if (element >= 0) {
+                const int8_t n = *(reinterpret_cast<int8_t*>(msg + offset) + element);
+                field->updateValue(QString::number(n), static_cast<qreal>(n));
             } else {
                 const int8_t n = *(reinterpret_cast<int8_t*>(msg + offset));
                 field->updateValue(QString::number(n), static_cast<qreal>(n));
             }
             break;
-        case MAVLINK_TYPE_UINT16_T:
-            if (array_length > 0) {
-                uint16_t nums[array_buffer_length / sizeof(uint16_t)]{};
-                (void) memcpy(nums, msg + offset,  sizeof(uint16_t) * array_length);
-                const QString tmp("%1, ");
-                QString string;
-                for (unsigned int j = 0; j < array_length - 1; ++j) {
-                    string += tmp.arg(nums[j]);
-                }
-                string += QString::number(nums[array_length - 1]);
-                field->updateValue(string, static_cast<qreal>(nums[0]));
+        case MAVLINK_TYPE_UINT16_T: {
+            uint16_t n = 0;
+            if (element >= 0) {
+                (void) memcpy(&n, msg + offset + element * static_cast<int>(sizeof(uint16_t)),
+                              sizeof(uint16_t));
             } else {
-                uint16_t n = 0;
                 (void) memcpy(&n, msg + offset, sizeof(uint16_t));
-                field->updateValue(QString::number(n), static_cast<qreal>(n));
             }
+            field->updateValue(QString::number(n), static_cast<qreal>(n));
             break;
-        case MAVLINK_TYPE_INT16_T:
-            if (array_length > 0) {
-                int16_t nums[array_buffer_length / sizeof(int16_t)]{};
-                (void) memcpy(nums, msg + offset, sizeof(int16_t) * array_length);
-                const QString tmp("%1, ");
-                QString string;
-                for (unsigned int j = 0; j < array_length - 1; ++j) {
-                    string += tmp.arg(nums[j]);
-                }
-                string += QString::number(nums[array_length - 1]);
-                field->updateValue(string, static_cast<qreal>(nums[0]));
+        }
+        case MAVLINK_TYPE_INT16_T: {
+            int16_t n = 0;
+            if (element >= 0) {
+                (void) memcpy(&n, msg + offset + element * static_cast<int>(sizeof(int16_t)),
+                              sizeof(int16_t));
             } else {
-                int16_t n;
                 (void) memcpy(&n, msg + offset, sizeof(int16_t));
-                field->updateValue(QString::number(n), static_cast<qreal>(n));
             }
+            field->updateValue(QString::number(n), static_cast<qreal>(n));
             break;
-        case MAVLINK_TYPE_UINT32_T:
-            if (array_length > 0) {
-                uint32_t nums[array_buffer_length / sizeof(uint32_t)]{};
-                (void) memcpy(nums, msg + offset, sizeof(uint32_t) * array_length);
-                const QString tmp("%1, ");
-                QString string;
-                for (unsigned int j = 0; j < array_length - 1; ++j) {
-                    string += tmp.arg(nums[j]);
-                }
-                string += QString::number(nums[array_length - 1]);
-                field->updateValue(string, static_cast<qreal>(nums[0]));
+        }
+        case MAVLINK_TYPE_UINT32_T: {
+            uint32_t n = 0;
+            if (element >= 0) {
+                (void) memcpy(&n, msg + offset + element * static_cast<int>(sizeof(uint32_t)),
+                              sizeof(uint32_t));
             } else {
-                uint32_t n;
                 (void) memcpy(&n, msg + offset, sizeof(uint32_t));
-                if (_message.msgid == MAVLINK_MSG_ID_SYSTEM_TIME) {
-                    const QDateTime d = QDateTime::fromMSecsSinceEpoch(static_cast<qint64>(n), QTimeZone::utc());
-                    field->updateValue(d.toString("HH:mm:ss"), static_cast<qreal>(n));
-                } else {
-                    field->updateValue(QString::number(n), static_cast<qreal>(n));
-                }
+            }
+            if (_message.msgid == MAVLINK_MSG_ID_SYSTEM_TIME && element < 0) {
+                const QDateTime d = QDateTime::fromMSecsSinceEpoch(static_cast<qint64>(n), QTimeZone::utc());
+                field->updateValue(d.toString("HH:mm:ss"), static_cast<qreal>(n));
+            } else {
+                field->updateValue(QString::number(n), static_cast<qreal>(n));
             }
             break;
-        case MAVLINK_TYPE_INT32_T:
-            if (array_length > 0) {
-                int32_t nums[array_buffer_length / sizeof(int32_t)]{};
-                (void) memcpy(nums, msg + offset,  sizeof(int32_t) * array_length);
-                const QString tmp("%1, ");
-                QString string;
-                for (unsigned int j = 0; j < array_length - 1; ++j) {
-                    string += tmp.arg(nums[j]);
-                }
-                string += QString::number(nums[array_length - 1]);
-                field->updateValue(string, static_cast<qreal>(nums[0]));
+        }
+        case MAVLINK_TYPE_INT32_T: {
+            int32_t n = 0;
+            if (element >= 0) {
+                (void) memcpy(&n, msg + offset + element * static_cast<int>(sizeof(int32_t)),
+                              sizeof(int32_t));
             } else {
-                int32_t n;
                 (void) memcpy(&n, msg + offset, sizeof(int32_t));
-                field->updateValue(QString::number(n), static_cast<qreal>(n));
             }
+            field->updateValue(QString::number(n), static_cast<qreal>(n));
             break;
-        case MAVLINK_TYPE_FLOAT:
-            if (array_length > 0) {
-                float nums[array_buffer_length / sizeof(float)]{};
-                (void) memcpy(nums, msg + offset,  sizeof(float) * array_length);
-                const QString tmp("%1, ");
-                QString string;
-                for (unsigned int j = 0; j < array_length - 1; ++j) {
-                   string += tmp.arg(static_cast<double>(nums[j]));
-                }
-                string += QString::number(static_cast<double>(nums[array_length - 1]));
-                field->updateValue(string, static_cast<qreal>(nums[0]));
+        }
+        case MAVLINK_TYPE_FLOAT: {
+            float fv = 0;
+            if (element >= 0) {
+                (void) memcpy(&fv, msg + offset + element * static_cast<int>(sizeof(float)),
+                              sizeof(float));
             } else {
-                float fv;
                 (void) memcpy(&fv, msg + offset, sizeof(float));
-                field->updateValue(QString::number(static_cast<double>(fv)), static_cast<qreal>(fv));
             }
+            field->updateValue(QString::number(static_cast<double>(fv), 'g', 10), static_cast<qreal>(fv));
             break;
-        case MAVLINK_TYPE_DOUBLE:
-            if (array_length > 0) {
-                double nums[array_buffer_length / sizeof(double)]{};
-                (void) memcpy(nums, msg + offset, sizeof(double) * array_length);
-                const QString tmp("%1, ");
-                QString string;
-                for (unsigned int j = 0; j < array_length - 1; ++j) {
-                    string += tmp.arg(nums[j]);
-                }
-                string += QString::number(static_cast<double>(nums[array_length - 1]));
-                field->updateValue(string, static_cast<qreal>(nums[0]));
+        }
+        case MAVLINK_TYPE_DOUBLE: {
+            double d = 0;
+            if (element >= 0) {
+                (void) memcpy(&d, msg + offset + element * static_cast<int>(sizeof(double)),
+                              sizeof(double));
             } else {
-                double d;
                 (void) memcpy(&d, msg + offset, sizeof(double));
-                field->updateValue(QString::number(d), static_cast<qreal>(d));
             }
+            field->updateValue(QString::number(d, 'g', 15), static_cast<qreal>(d));
             break;
-        case MAVLINK_TYPE_UINT64_T:
-            if (array_length > 0) {
-                uint64_t nums[array_buffer_length / sizeof(uint64_t)]{};
-                (void) memcpy(nums, msg + offset, sizeof(uint64_t) * array_length);
-                const QString tmp("%1, ");
-                QString string;
-                for (unsigned int j = 0; j < array_length - 1; ++j) {
-                    string += tmp.arg(nums[j]);
-                }
-                string += QString::number(nums[array_length - 1]);
-                field->updateValue(string, static_cast<qreal>(nums[0]));
+        }
+        case MAVLINK_TYPE_UINT64_T: {
+            uint64_t n = 0;
+            if (element >= 0) {
+                (void) memcpy(&n, msg + offset + element * static_cast<int>(sizeof(uint64_t)),
+                              sizeof(uint64_t));
             } else {
-                uint64_t n;
                 (void) memcpy(&n, msg + offset, sizeof(uint64_t));
-                if(_message.msgid == MAVLINK_MSG_ID_SYSTEM_TIME) {
-                    const QDateTime d = QDateTime::fromMSecsSinceEpoch(n / 1000, QTimeZone::utc());
-                    field->updateValue(d.toString("yyyy MM dd HH:mm:ss"), static_cast<qreal>(n));
-                } else {
-                    field->updateValue(QString::number(n), static_cast<qreal>(n));
-                }
             }
-            break;
-        case MAVLINK_TYPE_INT64_T:
-            if (array_length > 0) {
-                int64_t nums[array_buffer_length / sizeof(int64_t)]{};
-                (void) memcpy(nums, msg + offset,  sizeof(int64_t) * array_length);
-                const QString tmp("%1, ");
-                QString string;
-                for (unsigned int j = 0; j < array_length - 1; ++j) {
-                    string += tmp.arg(nums[j]);
-                }
-                string += QString::number(nums[array_length - 1]);
-                field->updateValue(string, static_cast<qreal>(nums[0]));
+            if (_message.msgid == MAVLINK_MSG_ID_SYSTEM_TIME && element < 0) {
+                const QDateTime d = QDateTime::fromMSecsSinceEpoch(n / 1000, QTimeZone::utc());
+                field->updateValue(d.toString("yyyy MM dd HH:mm:ss"), static_cast<qreal>(n));
             } else {
-                int64_t n;
-                (void) memcpy(&n, msg + offset, sizeof(int64_t));
                 field->updateValue(QString::number(n), static_cast<qreal>(n));
             }
             break;
+        }
+        case MAVLINK_TYPE_INT64_T: {
+            int64_t n = 0;
+            if (element >= 0) {
+                (void) memcpy(&n, msg + offset + element * static_cast<int>(sizeof(int64_t)),
+                              sizeof(int64_t));
+            } else {
+                (void) memcpy(&n, msg + offset, sizeof(int64_t));
+            }
+            field->updateValue(QString::number(n), static_cast<qreal>(n));
+            break;
+        }
         default:
             qCWarning(MAVLinkMessageLog) << "Unknown MAVLink field type:" << msgInfo->fields[i].type;
             break;

--- a/src/AnalyzeView/MAVLinkInspector/MAVLinkMessage.h
+++ b/src/AnalyzeView/MAVLinkInspector/MAVLinkMessage.h
@@ -2,6 +2,7 @@
 
 #include <QtCore/QObject>
 #include <QtCore/QString>
+#include <QtCore/QList>
 #include <QtQmlIntegration/QtQmlIntegration>
 
 #include "MAVLinkMessageType.h"
@@ -17,6 +18,7 @@ class QGCMAVLinkMessage : public QObject
     Q_PROPERTY(quint32              sysId           READ sysId          CONSTANT)
     Q_PROPERTY(quint32              compId          READ compId         CONSTANT)
     Q_PROPERTY(QString              name            READ name           CONSTANT)
+    Q_PROPERTY(QString              instanceValue   READ instanceValue  CONSTANT)
     Q_PROPERTY(qreal                actualRateHz    READ actualRateHz   NOTIFY actualRateHzChanged)
     Q_PROPERTY(int32_t              targetRateHz    READ targetRateHz   NOTIFY targetRateHzChanged)
     Q_PROPERTY(quint64              count           READ count          NOTIFY countChanged)
@@ -25,13 +27,17 @@ class QGCMAVLinkMessage : public QObject
     Q_PROPERTY(bool                 selected        READ selected       NOTIFY selectedChanged)
 
 public:
-    explicit QGCMAVLinkMessage(const mavlink_message_t &message, QObject *parent = nullptr);
+    explicit QGCMAVLinkMessage(const mavlink_message_t &message, const QString &instanceValue = QString(), QObject *parent = nullptr);
     ~QGCMAVLinkMessage();
+
+    /// Extract the instance field value from a raw mavlink message, or empty string if none.
+    static QString extractInstanceValue(const mavlink_message_t &message);
 
     quint32 id() const { return _message.msgid;  }
     quint8 sysId() const { return _message.sysid; }
     quint8 compId() const { return _message.compid; }
     QString name() const { return _name;  }
+    QString instanceValue() const { return _instanceValue; }
     qreal actualRateHz() const { return _actualRateHz; }
     int32_t targetRateHz() const { return _targetRateHz; }
     quint64 count() const { return _count; }
@@ -55,10 +61,19 @@ signals:
 
 private:
     void _updateFields();
+    static QString _extractDebugInstanceValue(const mavlink_message_t &message);
+
+    /// Maps each entry in _fields back to its msgInfo field index and array element.
+    struct FieldMapping {
+        unsigned int fieldIndex = 0;    ///< Index into mavlink_message_info_t::fields[]
+        int arrayElement = -1;          ///< -1 for scalar, 0..N-1 for array element
+    };
 
     mavlink_message_t _message{};
     QmlObjectListModel *_fields = nullptr;
+    QList<FieldMapping> _fieldMappings;
     QString _name;
+    QString _instanceValue;
     qreal _actualRateHz = 0.0;
     int32_t _targetRateHz = 0;
     uint64_t _count = 1;

--- a/src/AnalyzeView/MAVLinkInspector/MAVLinkMessageField.cc
+++ b/src/AnalyzeView/MAVLinkInspector/MAVLinkMessageField.cc
@@ -7,6 +7,11 @@
 #include <QtGraphs/QLineSeries>
 #include <QtGraphs/QAbstractSeries>
 
+#include <algorithm>
+#include <cmath>
+
+static constexpr qreal kMinDelta = 1e-6;
+
 QGC_LOGGING_CATEGORY(MAVLinkMessageFieldLog, "AnalyzeView.MAVLinkMessageField")
 
 QGCMAVLinkMessageField::QGCMAVLinkMessageField(const QString &name, const QString &type, QGCMAVLinkMessage *parent)
@@ -36,6 +41,9 @@ void QGCMAVLinkMessageField::addSeries(MAVLinkChartController *chartController, 
     emit seriesChanged();
 
     _dataIndex = 0;
+    _bucketCount = std::max(1, chartController->plotPixelWidth());
+    _bucketWidthMs = chartController->rangeXMs() / _bucketCount;
+    _currentBucketStart = -1;
     _msg->updateFieldSelection();
 }
 
@@ -52,8 +60,25 @@ void QGCMAVLinkMessageField::delSeries()
     lineSeries->replace(_values);
     _pSeries = nullptr;
     _chartController = nullptr;
+    _bucketCount = 0;
+    _bucketWidthMs = 0;
+    _currentBucketStart = -1;
+    _dataIndex = 0;
     emit seriesChanged();
     _msg->updateFieldSelection();
+}
+
+void QGCMAVLinkMessageField::resetBucketing(int bucketCount, qreal bucketWidthMs)
+{
+    _bucketCount = std::max(1, bucketCount);
+    _bucketWidthMs = bucketWidthMs;
+    _currentBucketStart = -1;
+    _currentBucketMin = 0;
+    _currentBucketMax = 0;
+    _dataIndex = 0;
+    _values.clear();
+    _rangeMin = std::numeric_limits<qreal>::max();
+    _rangeMax = std::numeric_limits<qreal>::lowest();
 }
 
 QString QGCMAVLinkMessageField::label() const
@@ -85,42 +110,82 @@ void QGCMAVLinkMessageField::updateValue(const QString &newValue, qreal v)
         emit valueChanged();
     }
 
-    if (!_pSeries || !_chartController) {
+    if (!_pSeries || !_chartController || _bucketCount <= 0) {
         return;
     }
 
-    const int count = _values.count();
-    if (count < kMaxDataPoints) {
-        const QPointF p(qgcApp()->msecsSinceBoot(), v);
-        _values.append(p);
-    } else {
-        if (_dataIndex >= count) {
-            _dataIndex = 0;
+    const qreal now = qgcApp()->msecsSinceBoot();
+
+    if (_currentBucketStart < 0) {
+        // First sample — start first bucket
+        _currentBucketStart = now;
+        _currentBucketMin = v;
+        _currentBucketMax = v;
+        if (_chartController->rangeYIndex() == 0) {
+            bool changed = false;
+            if (std::abs(_rangeMin - v) > kMinDelta) {
+                _rangeMin = v;
+                changed = true;
+            }
+            if (std::abs(_rangeMax - v) > kMinDelta) {
+                _rangeMax = v;
+                changed = true;
+            }
+            if (changed) {
+                _chartController->updateYRange();
+            }
         }
-        _values[_dataIndex].setX(qgcApp()->msecsSinceBoot());
-        _values[_dataIndex].setY(v);
-        _dataIndex++;
+        return;
     }
 
+    if (now < _currentBucketStart + _bucketWidthMs) {
+        // Still in current bucket — update min/max
+        _currentBucketMin = std::min(_currentBucketMin, v);
+        _currentBucketMax = std::max(_currentBucketMax, v);
+        if (_chartController->rangeYIndex() == 0) {
+            bool changed = false;
+            if (v < _rangeMin - kMinDelta) {
+                _rangeMin = v;
+                changed = true;
+            }
+            if (v > _rangeMax + kMinDelta) {
+                _rangeMax = v;
+                changed = true;
+            }
+            if (changed) {
+                _chartController->updateYRange();
+            }
+        }
+        return;
+    }
+
+    // Crossed into next bucket — commit current bucket
+    _commitBucket();
+
+    // Start new bucket with this sample
+    _currentBucketStart = now;
+    _currentBucketMin = v;
+    _currentBucketMax = v;
+
+    // Update Y auto-range from committed data and current bucket
     if (_chartController->rangeYIndex() != 0) {
         return;
     }
 
-    qreal vmin = std::numeric_limits<qreal>::max();
-    qreal vmax = std::numeric_limits<qreal>::lowest();
+    qreal vmin = _currentBucketMin;
+    qreal vmax = _currentBucketMax;
     for (const QPointF &point : _values) {
-        const qreal value = point.y();
-        vmin = std::min(vmin, value);
-        vmax = std::max(vmax, value);
+        vmin = std::min(vmin, point.y());
+        vmax = std::max(vmax, point.y());
     }
 
     bool changed = false;
-    if (std::abs(_rangeMin - vmin) > 0.000001) {
+    if (std::abs(_rangeMin - vmin) > kMinDelta) {
         _rangeMin = vmin;
         changed = true;
     }
 
-    if (std::abs(_rangeMax - vmax) > 0.000001) {
+    if (std::abs(_rangeMax - vmax) > kMinDelta) {
         _rangeMax = vmax;
         changed = true;
     }
@@ -130,15 +195,37 @@ void QGCMAVLinkMessageField::updateValue(const QString &newValue, qreal v)
     }
 }
 
+void QGCMAVLinkMessageField::_commitBucket()
+{
+    const qreal bucketMidTime = _currentBucketStart + _bucketWidthMs * 0.5;
+    const int maxPoints = _bucketCount * 2;
+
+    // Append min and max points for this bucket (always two points to keep capacity predictable)
+    const int count = _values.count();
+    if (count < maxPoints) {
+        _values.append(QPointF(bucketMidTime, _currentBucketMin));
+        _values.append(QPointF(bucketMidTime, _currentBucketMax));
+    } else {
+        // Ring buffer wrap
+        if (_dataIndex >= maxPoints) {
+            _dataIndex = 0;
+        }
+        _values[_dataIndex] = QPointF(bucketMidTime, _currentBucketMin);
+        _dataIndex++;
+        if (_dataIndex >= maxPoints) {
+            _dataIndex = 0;
+        }
+        _values[_dataIndex] = QPointF(bucketMidTime, _currentBucketMax);
+        _dataIndex++;
+    }
+}
+
 void QGCMAVLinkMessageField::updateSeries()
 {
     const int count = _values.count();
-    if (count <= 1) {
-        return;
-    }
 
     QList<QPointF> s;
-    s.reserve(count);
+    s.reserve(count + 2);
     int idx = _dataIndex;
     for (int i = 0; i < count; i++, idx++) {
         if (idx >= count) {
@@ -149,6 +236,20 @@ void QGCMAVLinkMessageField::updateSeries()
         s.append(p);
     }
 
+    // Append the in-progress bucket so the chart always shows the latest data
+    if (_currentBucketStart >= 0) {
+        const qreal now = qgcApp()->msecsSinceBoot();
+        s.append(QPointF(now, _currentBucketMin));
+        if (std::abs(_currentBucketMax - _currentBucketMin) > kMinDelta) {
+            s.append(QPointF(now, _currentBucketMax));
+        }
+    }
+
     QLineSeries *const lineSeries = static_cast<QLineSeries*>(_pSeries);
+    if (s.isEmpty()) {
+        lineSeries->clear();
+        return;
+    }
+
     lineSeries->replace(s);
 }

--- a/src/AnalyzeView/MAVLinkInspector/MAVLinkMessageField.h
+++ b/src/AnalyzeView/MAVLinkInspector/MAVLinkMessageField.h
@@ -42,6 +42,7 @@ public:
 
     void setSelectable(bool sel);
     void updateValue(const QString &newValue, qreal v);
+    void resetBucketing(int bucketCount, qreal bucketWidthMs);
 
     void addSeries(MAVLinkChartController *chartController, QAbstractSeries *series);
     void delSeries();
@@ -53,15 +54,20 @@ signals:
     void valueChanged();
 
 private:
+    void _commitBucket();
+
     QString _type;
     QString _name;
     QGCMAVLinkMessage *_msg = nullptr;
 
-    static constexpr int kMaxDataPoints = 50 * 60; ///< 1 minute of data at 50 Hz
-
     QString _value;
     bool _selectable = true;
     int _dataIndex = 0;
+    int _bucketCount = 0;
+    qreal _bucketWidthMs = 0;
+    qreal _currentBucketStart = -1;
+    qreal _currentBucketMin = 0;
+    qreal _currentBucketMax = 0;
     qreal _rangeMin = std::numeric_limits<qreal>::max();
     qreal _rangeMax = std::numeric_limits<qreal>::lowest();
     QList<QPointF> _values;

--- a/src/AnalyzeView/MAVLinkInspector/MAVLinkSystem.cc
+++ b/src/AnalyzeView/MAVLinkInspector/MAVLinkSystem.cc
@@ -21,12 +21,12 @@ QGCMAVLinkSystem::~QGCMAVLinkSystem()
     _messages->clearAndDeleteContents();
 }
 
-QGCMAVLinkMessage *QGCMAVLinkSystem::findMessage(uint32_t id, uint8_t compId)
+QGCMAVLinkMessage *QGCMAVLinkSystem::findMessage(uint32_t id, uint8_t compId, const QString &instanceValue)
 {
     for (int i = 0; i < _messages->count(); i++) {
         QGCMAVLinkMessage *const msg = qobject_cast<QGCMAVLinkMessage*>(_messages->get(i));
         if(msg) {
-            if((msg->id() == id) && (msg->compId() == compId)) {
+            if((msg->id() == id) && (msg->compId() == compId) && (msg->instanceValue() == instanceValue)) {
                 return msg;
             }
         }

--- a/src/AnalyzeView/MAVLinkInspector/MAVLinkSystem.h
+++ b/src/AnalyzeView/MAVLinkInspector/MAVLinkSystem.h
@@ -28,7 +28,7 @@ public:
     int selected() const { return _selected; }
 
     void setSelected(int sel);
-    QGCMAVLinkMessage *findMessage(uint32_t id, uint8_t compId);
+    QGCMAVLinkMessage *findMessage(uint32_t id, uint8_t compId, const QString &instanceValue = QString());
     int findMessage(const QGCMAVLinkMessage *message);
     void append(QGCMAVLinkMessage *message);
     QGCMAVLinkMessage *selectedMsg();

--- a/src/Comms/MockLink/MockLink.cc
+++ b/src/Comms/MockLink/MockLink.cc
@@ -22,6 +22,7 @@
 #include <QtCore/QThread>
 #include <QtCore/QTimer>
 
+#include <cmath>
 #include <cstring>
 
 QGC_LOGGING_CATEGORY(MockLinkLog, "Comms.MockLink.MockLink")
@@ -199,6 +200,7 @@ void MockLink::run1HzTasks()
 
     _sendVibration();
     _sendBatteryStatus();
+    _sendNamedValueFloats();
     _sendSysStatus();
     _sendADSBVehicles();
     if (_vehicleType != MAV_TYPE_SUBMARINE) {
@@ -571,6 +573,38 @@ void MockLink::_sendBatteryStatus()
         rgVoltagesExtNone,
         0, // MAV_BATTERY_MODE
         0  // MAV_BATTERY_FAULT
+    );
+    respondWithMavlinkMessage(msg);
+}
+
+void MockLink::_sendNamedValueFloats()
+{
+    const uint32_t timeBootMs = static_cast<uint32_t>(_runningTime.elapsed());
+
+    // Send two named float values with varying data to exercise Inspector instance separation
+    const float sinVal = static_cast<float>(std::sin(static_cast<double>(timeBootMs) / 1000.0));
+    const float cosVal = static_cast<float>(std::cos(static_cast<double>(timeBootMs) / 1000.0));
+
+    mavlink_message_t msg{};
+    (void) mavlink_msg_named_value_float_pack_chan(
+        _vehicleSystemId,
+        _vehicleComponentId,
+        _getMavlinkVehicleChannel(),
+        &msg,
+        timeBootMs,
+        "sin_wave",
+        sinVal
+    );
+    respondWithMavlinkMessage(msg);
+
+    (void) mavlink_msg_named_value_float_pack_chan(
+        _vehicleSystemId,
+        _vehicleComponentId,
+        _getMavlinkVehicleChannel(),
+        &msg,
+        timeBootMs,
+        "cos_wave",
+        cosVal
     );
     respondWithMavlinkMessage(msg);
 }

--- a/src/Comms/MockLink/MockLink.h
+++ b/src/Comms/MockLink/MockLink.h
@@ -235,6 +235,7 @@ private:
     void _sendVibration();
     void _sendSysStatus();
     void _sendBatteryStatus();
+    void _sendNamedValueFloats();
     void _sendChunkedStatusText(uint16_t chunkId, bool missingChunks);
     void _sendStatusTextMessages();
     void _respondWithAutopilotVersion();

--- a/src/MAVLink/CMakeLists.txt
+++ b/src/MAVLink/CMakeLists.txt
@@ -72,6 +72,21 @@ if(mavlink_ADDED)
     # Register the QML anchor files so AUTOMOC picks up Q_NAMESPACE + Q_ENUM_NS
     set_source_files_properties("${MAVLINK_ENUMS_QML_H}" "${MAVLINK_ENUMS_QML_CC}" PROPERTIES GENERATED TRUE)
     target_sources(${CMAKE_PROJECT_NAME} PRIVATE "${MAVLINK_ENUMS_QML_H}" "${MAVLINK_ENUMS_QML_CC}")
+
+    # Generate MAVLinkInstanceFields.h (message ID → instance field name mapping)
+    set(MAVLINK_INSTANCE_FIELDS_H "${CMAKE_BINARY_DIR}/MAVLinkInstanceFields.h")
+    set(MAVLINK_INSTANCE_FIELDS_GENERATOR "${CMAKE_SOURCE_DIR}/tools/generators/mavlink_instance_fields.py")
+    set(MAVLINK_XML_DIR "${mavlink_SOURCE_DIR}/message_definitions/v1.0")
+    add_custom_command(
+        OUTPUT "${MAVLINK_INSTANCE_FIELDS_H}"
+        COMMAND ${Python3_EXECUTABLE} "${MAVLINK_INSTANCE_FIELDS_GENERATOR}"
+                "${MAVLINK_XML_DIR}" "${QGC_MAVLINK_DIALECT}" "${MAVLINK_INSTANCE_FIELDS_H}"
+        DEPENDS mavlink "${MAVLINK_INSTANCE_FIELDS_GENERATOR}"
+        COMMENT "Generating MAVLinkInstanceFields.h"
+        VERBATIM
+    )
+    add_custom_target(mavlink_instance_fields DEPENDS "${MAVLINK_INSTANCE_FIELDS_H}")
+    add_dependencies(${CMAKE_PROJECT_NAME} mavlink_instance_fields)
 endif()
 
 # ----------------------------------------------------------------------------

--- a/test/AnalyzeView/MAVLinkInspectorControllerTest.cc
+++ b/test/AnalyzeView/MAVLinkInspectorControllerTest.cc
@@ -44,9 +44,9 @@ void MAVLinkInspectorControllerTest::_timeScalesCountTest()
 {
     MAVLinkInspectorController controller;
 
-    // 4 time scales: 5s, 10s, 30s, 60s
-    QCOMPARE(controller.timeScales().count(), 4);
-    QCOMPARE(controller.timeScaleSt().count(), 4);
+    // 6 time scales: 5s, 10s, 30s, 60s, 2min, 5min
+    QCOMPARE(controller.timeScales().count(), 6);
+    QCOMPARE(controller.timeScaleSt().count(), 6);
 }
 
 void MAVLinkInspectorControllerTest::_rangeListCountTest()

--- a/test/AnalyzeView/MAVLinkTestHelpers.h
+++ b/test/AnalyzeView/MAVLinkTestHelpers.h
@@ -20,7 +20,7 @@ inline mavlink_message_t makeHeartbeat(uint8_t sysId = 1, uint8_t compId = 1)
 inline QGCMAVLinkMessage* makeHeartbeatMsg(uint8_t sysId, uint8_t compId, QObject* parent = nullptr)
 {
     mavlink_message_t msg = makeHeartbeat(sysId, compId);
-    return new QGCMAVLinkMessage(msg, parent);
+    return new QGCMAVLinkMessage(msg, QString(), parent);
 }
 
 inline QGCMAVLinkMessage* makeHeartbeatMsg(QObject* parent = nullptr)

--- a/tools/generators/mavlink_instance_fields.py
+++ b/tools/generators/mavlink_instance_fields.py
@@ -1,0 +1,121 @@
+#!/usr/bin/env python3
+"""Parse MAVLink XML definitions and emit a C++ header mapping message IDs to instance field names.
+
+Usage: mavlink_instance_fields.py <xml_dir> <dialect> <output_header>
+
+The script resolves the dialect's <include> chain, finds all <field instance="true">
+elements, and generates a QMap<uint32_t, QString> lookup table.
+"""
+
+import sys
+import xml.etree.ElementTree as ET
+from pathlib import Path
+
+
+def resolve_includes(xml_dir: Path, dialect: str, visited: set | None = None) -> list[Path]:
+    """Recursively resolve the include chain for a dialect, returning XML paths in dependency order."""
+    if visited is None:
+        visited = set()
+    xml_path = xml_dir / f"{dialect}.xml"
+    if dialect in visited or not xml_path.exists():
+        return []
+    visited.add(dialect)
+
+    result = []
+    tree = ET.parse(xml_path)
+    root = tree.getroot()
+    for include_elem in root.findall("include"):
+        included_dialect = include_elem.text.replace(".xml", "")
+        result.extend(resolve_includes(xml_dir, included_dialect, visited))
+    result.append(xml_path)
+    return result
+
+
+def extract_instance_fields(xml_paths: list[Path]) -> dict[int, tuple[str, str]]:
+    """Extract instance fields from XML files.
+
+    Returns a dict of msg_id -> (msg_name, field_name), deduplicated by msg_id.
+    """
+    instance_fields: dict[int, tuple[str, str]] = {}
+    for xml_path in xml_paths:
+        tree = ET.parse(xml_path)
+        root = tree.getroot()
+        for message in root.iter("message"):
+            msg_id = int(message.get("id"))
+            msg_name = message.get("name")
+            for field in message.findall("field"):
+                if field.get("instance") == "true":
+                    field_name = field.get("name")
+                    if msg_id not in instance_fields:
+                        instance_fields[msg_id] = (msg_name, field_name)
+                    break  # Only one instance field per message
+    return instance_fields
+
+
+def generate_header(instance_fields: dict[int, tuple[str, str]]) -> str:
+    """Generate the C++ header content."""
+    lines = [
+        "#pragma once",
+        "",
+        "/// @file MAVLinkInstanceFields.h",
+        "/// @brief Maps MAVLink message IDs to their instance field names.",
+        "///",
+        "/// AUTO-GENERATED from MAVLink XML definitions during the build.",
+        "/// Do not edit manually. Regenerate via tools/generators/mavlink_instance_fields.py.",
+        "",
+        "#include <QtCore/QMap>",
+        "#include <QtCore/QString>",
+        "",
+        "/// Returns the instance field name for a given message ID, or empty QString if none.",
+        "inline const QMap<quint32, QString> &mavlinkInstanceFields()",
+        "{",
+        "    static const QMap<quint32, QString> fields = {",
+    ]
+
+    for msg_id in sorted(instance_fields.keys()):
+        msg_name, field_name = instance_fields[msg_id]
+        lines.append(f'        {{{msg_id}, QStringLiteral("{field_name}")}},  // {msg_name}')
+
+    lines.extend([
+        "    };",
+        "    return fields;",
+        "}",
+        "",
+    ])
+    return "\n".join(lines)
+
+
+def write_if_changed(path: Path, content: str) -> bool:
+    """Write file only if content changed. Returns True if written."""
+    if path.exists() and path.read_text() == content:
+        return False
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(content)
+    return True
+
+
+def main():
+    if len(sys.argv) != 4:
+        print(f"Usage: {sys.argv[0]} <xml_dir> <dialect> <output_header>", file=sys.stderr)
+        sys.exit(1)
+
+    xml_dir = Path(sys.argv[1])
+    dialect = sys.argv[2]
+    output_path = Path(sys.argv[3])
+
+    xml_paths = resolve_includes(xml_dir, dialect)
+    if not xml_paths:
+        print(f"Error: Could not find {dialect}.xml in {xml_dir}", file=sys.stderr)
+        sys.exit(1)
+
+    instance_fields = extract_instance_fields(xml_paths)
+    header_content = generate_header(instance_fields)
+
+    if write_if_changed(output_path, header_content):
+        print(f"Generated {output_path} ({len(instance_fields)} instance fields)")
+    else:
+        print(f"Unchanged: {output_path}")
+
+
+if __name__ == "__main__":
+    main()

--- a/tools/tests/test_mavlink_instance_fields.py
+++ b/tools/tests/test_mavlink_instance_fields.py
@@ -1,0 +1,172 @@
+#!/usr/bin/env python3
+"""Tests for mavlink_instance_fields generator."""
+
+import textwrap
+
+import pytest
+
+from generators.mavlink_instance_fields import (
+    extract_instance_fields,
+    generate_header,
+    resolve_includes,
+)
+
+
+@pytest.fixture
+def xml_dir(tmp_path):
+    """Create a minimal MAVLink XML structure for testing."""
+    # minimal.xml - no instance fields
+    (tmp_path / "minimal.xml").write_text(textwrap.dedent("""\
+        <?xml version="1.0"?>
+        <mavlink>
+          <messages>
+            <message id="0" name="HEARTBEAT">
+              <field type="uint8_t" name="type">Type</field>
+            </message>
+          </messages>
+        </mavlink>
+    """))
+
+    # common.xml - includes minimal, has instance fields
+    (tmp_path / "common.xml").write_text(textwrap.dedent("""\
+        <?xml version="1.0"?>
+        <mavlink>
+          <include>minimal.xml</include>
+          <messages>
+            <message id="147" name="BATTERY_STATUS">
+              <field type="uint8_t" name="id" instance="true">Battery ID</field>
+              <field type="uint8_t" name="battery_function">Function</field>
+            </message>
+            <message id="132" name="DISTANCE_SENSOR">
+              <field type="uint8_t" name="sensor_id" instance="true">Sensor ID</field>
+              <field type="uint8_t" name="type">Type</field>
+            </message>
+            <message id="251" name="NAMED_VALUE_FLOAT">
+              <field type="char[10]" name="name" instance="true">Name</field>
+              <field type="float" name="value">Value</field>
+            </message>
+            <message id="100" name="NO_INSTANCE">
+              <field type="uint8_t" name="id">Regular field</field>
+            </message>
+          </messages>
+        </mavlink>
+    """))
+
+    # all.xml - includes common
+    (tmp_path / "all.xml").write_text(textwrap.dedent("""\
+        <?xml version="1.0"?>
+        <mavlink>
+          <include>common.xml</include>
+        </mavlink>
+    """))
+
+    return tmp_path
+
+
+class TestResolveIncludes:
+    """Test XML include resolution."""
+
+    def test_single_file(self, xml_dir):
+        paths = resolve_includes(xml_dir, "minimal")
+        assert len(paths) == 1
+        assert paths[0].name == "minimal.xml"
+
+    def test_include_chain(self, xml_dir):
+        paths = resolve_includes(xml_dir, "common")
+        assert len(paths) == 2
+        assert paths[0].name == "minimal.xml"
+        assert paths[1].name == "common.xml"
+
+    def test_full_chain(self, xml_dir):
+        paths = resolve_includes(xml_dir, "all")
+        assert len(paths) == 3
+        assert paths[0].name == "minimal.xml"
+        assert paths[1].name == "common.xml"
+        assert paths[2].name == "all.xml"
+
+    def test_missing_dialect(self, xml_dir):
+        paths = resolve_includes(xml_dir, "nonexistent")
+        assert paths == []
+
+    def test_no_circular(self, xml_dir):
+        """Circular includes don't infinite loop."""
+        (xml_dir / "a.xml").write_text(textwrap.dedent("""\
+            <?xml version="1.0"?>
+            <mavlink><include>b.xml</include></mavlink>
+        """))
+        (xml_dir / "b.xml").write_text(textwrap.dedent("""\
+            <?xml version="1.0"?>
+            <mavlink><include>a.xml</include></mavlink>
+        """))
+        paths = resolve_includes(xml_dir, "a")
+        assert len(paths) == 2
+
+
+class TestExtractInstanceFields:
+    """Test instance field extraction."""
+
+    def test_finds_instance_fields(self, xml_dir):
+        paths = resolve_includes(xml_dir, "common")
+        fields = extract_instance_fields(paths)
+        assert 147 in fields
+        assert fields[147] == ("BATTERY_STATUS", "id")
+        assert 132 in fields
+        assert fields[132] == ("DISTANCE_SENSOR", "sensor_id")
+
+    def test_string_instance_field(self, xml_dir):
+        paths = resolve_includes(xml_dir, "common")
+        fields = extract_instance_fields(paths)
+        assert 251 in fields
+        assert fields[251] == ("NAMED_VALUE_FLOAT", "name")
+
+    def test_skips_non_instance(self, xml_dir):
+        paths = resolve_includes(xml_dir, "common")
+        fields = extract_instance_fields(paths)
+        assert 100 not in fields
+        assert 0 not in fields
+
+    def test_deduplicates_by_msg_id(self, xml_dir):
+        """If same message appears in multiple XMLs, keep first occurrence."""
+        (xml_dir / "extra.xml").write_text(textwrap.dedent("""\
+            <?xml version="1.0"?>
+            <mavlink>
+              <include>common.xml</include>
+              <messages>
+                <message id="147" name="BATTERY_STATUS">
+                  <field type="uint8_t" name="other_id" instance="true">Other</field>
+                </message>
+              </messages>
+            </mavlink>
+        """))
+        paths = resolve_includes(xml_dir, "extra")
+        fields = extract_instance_fields(paths)
+        # First occurrence wins (from common.xml)
+        assert fields[147] == ("BATTERY_STATUS", "id")
+
+
+class TestGenerateHeader:
+    """Test header generation."""
+
+    def test_generates_valid_header(self, xml_dir):
+        paths = resolve_includes(xml_dir, "common")
+        fields = extract_instance_fields(paths)
+        header = generate_header(fields)
+        assert "#pragma once" in header
+        assert "QMap<quint32, QString>" in header
+        assert '{147, QStringLiteral("id")}' in header
+        assert '{132, QStringLiteral("sensor_id")}' in header
+        assert "BATTERY_STATUS" in header
+
+    def test_sorted_by_msg_id(self, xml_dir):
+        paths = resolve_includes(xml_dir, "common")
+        fields = extract_instance_fields(paths)
+        header = generate_header(fields)
+        # 132 should appear before 147
+        pos_132 = header.find("132")
+        pos_147 = header.find("147")
+        assert pos_132 < pos_147
+
+    def test_empty_fields(self):
+        header = generate_header({})
+        assert "#pragma once" in header
+        assert "QMap<quint32, QString>" in header


### PR DESCRIPTION
## Summary

Enhance the MAVLink Inspector with instance-aware message separation, array field expansion, debug message handling, and efficient chart data management.

## Changes

- **Instance awareness**: Separate messages by instance field (e.g. `sensor_id`, `target_system`) using a build-time generated lookup table from MAVLink XML (`instance="true"` attribute)
- **Array field expansion**: Numeric array fields are expanded into individual elements (e.g. `covariance[0]`, `covariance[1]`, ...) that can be individually charted
- **Debug message separation**: `NAMED_VALUE_FLOAT`, `NAMED_VALUE_INT`, `DEBUG_VECT`, and `DEBUG` messages are separated by their name/ind field as implicit instance discriminators
- **Longer time scales**: Added "2 Min" and "5 Min" options
- **Bucketed ring buffer**: Replaced unbounded data storage with a pixel-width-proportional ring buffer using min/max bucketing (2 points per pixel column, ~64KB per plotted field)
- **Chart lag fix**: In-progress bucket is rendered at current time so the series line always extends to the chart's right edge
- **Scientific notation fix**: Float/double values now use higher precision formatting to avoid scientific notation for large integer-like values (bitfields)
- **MockLink test output**: Added sin/cos wave `NAMED_VALUE_FLOAT` messages for manual testing

## Testing

- All existing unit tests pass (updated `_timeScalesCountTest` for new count)
- New `test_mavlink_instance_fields.py` (12 tests) validates the generator
- Manual testing with MockLink confirms instance separation and charting

Fixes #12234
Fixes #8454
Fixes #9578
Fixes #9581
Fixes #7313
