### PR TITLE
FirmwareUpgrade: add Gear Up AirBrainH743 board

### DIFF
--- a/src/Comms/USBBoardInfo.json
+++ b/src/Comms/USBBoardInfo.json
@@ -57,6 +57,7 @@
         { "vendorID": 9900, "productID": 4131,      "boardClass": "Pixhawk",    "name": "mRo Control Zero H7" },
         { "vendorID": 9900, "productID": 4132,      "boardClass": "Pixhawk",    "name": "mRo Control Zero H7 OEM" },
         { "vendorID": 9900, "productID": 4388,      "boardClass": "Pixhawk",    "name": "3DR Control Zero H7 OEM Rev G" },
+        { "vendorID": 9900, "productID": 80,        "boardClass": "Pixhawk",    "name": "Gear Up AirBrainH743" },
 
         { "vendorID": 2106, "productID": 7120,      "boardClass": "Pixhawk",    "name": "PX4 Accton Godwit GA1" },
 

--- a/src/Vehicle/VehicleSetup/FirmwareUpgradeController.cc
+++ b/src/Vehicle/VehicleSetup/FirmwareUpgradeController.cc
@@ -83,6 +83,7 @@ static QMap<int, QString> px4_board_name_map {
     {1105, "holybro_kakuteh7-wing_default"},
     {1110, "jfb_jfb110_default"},
     {1200, "jfb_jfb200_default"},
+    {1209, "gearup_airbrainh743_default"},
     {1123, "siyi_n7_default"},
     {1124, "3dr_ctrl-zero-h7-oem-revg_default"},
     {5600, "zeroone_x6_default"},


### PR DESCRIPTION
## Description

Maps board id 1209 to gearup_airbrainh743_default so QGC offers the hosted PX4 firmware for the Gear Up AirBrainH743.

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] CI/Build changes
- [ ] Other

## Testing

- [x] Tested locally
- [ ] Added/updated unit tests
- [ ] Tested with simulator (SITL)
- [ ] Tested with hardware

### Platforms Tested

- [x] Linux
- [ ] Windows
- [ ] macOS
- [ ] Android
- [ ] iOS

### Flight Stacks Tested

- [x] PX4
- [ ] ArduPilot

## Screenshots


## Checklist

- [ ] I have read the [Contribution Guidelines](CONTRIBUTING.md)
- [ ] I have read the [Code of Conduct](CODE_OF_CONDUCT.md)
- [ ] My code follows the project's coding standards
- [ ] I have added tests that prove my fix/feature works
- [ ] New and existing unit tests pass locally

## Related Issues

Following https://github.com/PX4/PX4-Autopilot/pull/26239.

---
By submitting this pull request, I confirm that my contribution is made under the terms of the project's dual license (Apache 2.0 and GPL v3).
