### PR TITLE
FirmwareUpgrade: add Gear Up AirBrainH743 board

### DIFF
--- a/src/Comms/USBBoardInfo.json
+++ b/src/Comms/USBBoardInfo.json
@@ -57,6 +57,7 @@
         { "vendorID": 9900, "productID": 4131,      "boardClass": "Pixhawk",    "name": "mRo Control Zero H7" },
         { "vendorID": 9900, "productID": 4132,      "boardClass": "Pixhawk",    "name": "mRo Control Zero H7 OEM" },
         { "vendorID": 9900, "productID": 4388,      "boardClass": "Pixhawk",    "name": "3DR Control Zero H7 OEM Rev G" },
+        { "vendorID": 9900, "productID": 80,        "boardClass": "Pixhawk",    "name": "Gear Up AirBrainH743" },
 
         { "vendorID": 2106, "productID": 7120,      "boardClass": "Pixhawk",    "name": "PX4 Accton Godwit GA1" },
 

--- a/src/Vehicle/VehicleSetup/FirmwareUpgradeController.cc
+++ b/src/Vehicle/VehicleSetup/FirmwareUpgradeController.cc
@@ -83,6 +83,7 @@ static QMap<int, QString> px4_board_name_map {
     {1105, "holybro_kakuteh7-wing_default"},
     {1110, "jfb_jfb110_default"},
     {1200, "jfb_jfb200_default"},
+    {1209, "gearup_airbrainh743_default"},
     {1123, "siyi_n7_default"},
     {1124, "3dr_ctrl-zero-h7-oem-revg_default"},
     {5600, "zeroone_x6_default"},


### PR DESCRIPTION
Maps PX4 board id `1209` to the build target `gearup_airbrainh743_default` so QGC's firmware selector offers the hosted PX4 firmware for the Gear Up AirBrainH743.

The board was added to PX4-Autopilot (`boards/gearup/airbrainh743`) and is built/published by PX4 CI automatically. With this entry, the `master` (developer) firmware is reachable from QGC.

Note: tagged releases upload only to versioned S3 directories, which `px4_board_name_map` does not point at, so those builds are not yet reachable via QGC for any board. PX4/PX4-Autopilot#25414 (unified runtime manifest) is the longer-term replacement for this hardcoded map.