### PR TITLE
FirmwareUpgrade: emit correct signal for PX4 beta version

### DIFF
--- a/src/Vehicle/VehicleSetup/FirmwareUpgradeController.cc
+++ b/src/Vehicle/VehicleSetup/FirmwareUpgradeController.cc
@@ -674,7 +674,7 @@ void FirmwareUpgradeController::_px4ReleasesGithubDownloadComplete(bool success,
                 foundStable = true;
             } else if (!foundBeta && release["prerelease"].toBool()) {
                 _px4BetaVersion = release["name"].toString();
-                emit px4StableVersionChanged(_px4BetaVersion);
+                emit px4BetaVersionChanged(_px4BetaVersion);
                 qCDebug(FirmwareUpgradeControllerLog()) << "Found px4 beta version" << _px4BetaVersion;
                 foundBeta = true;
             }


### PR DESCRIPTION
When parsing the PX4 GitHub releases list, the beta-version branch set `_px4BetaVersion` but then emitted `px4StableVersionChanged` instead of `px4BetaVersionChanged`. As a result the QML-bound `px4BetaVersion` property does not get a change notification, so the "Beta Testing" radio label can fail to update to the detected beta version.

One-line fix: emit `px4BetaVersionChanged`.

Note: this is the notification-signal bug only. There is a separate, larger issue that the displayed PX4 version (from the GitHub releases API) and the actually-downloaded firmware (from the hardcoded `Firmware/{stable,beta,master}/` S3 paths) have no shared source of truth, so the label can advertise a version different from what is fetched. That is better addressed alongside a manifest-based firmware lookup and is left out of scope here.