### PR TITLE
support for Ubuntu 26.04+

### DIFF
--- a/tools/setup/install_dependencies.py
+++ b/tools/setup/install_dependencies.py
@@ -178,6 +178,12 @@ JUST_TARGETS: dict[str, str] = {
     "aarch64": "aarch64-unknown-linux-musl",
 }
 
+# Fallback alternatives tried (in order) when a primary package is unavailable.
+# Ubuntu 26.04+ renamed libgstreamer-plugins-good1.0-dev → libgstreamer-plugins-extra1.0-dev.
+DEBIAN_PACKAGE_ALTERNATIVES: dict[str, list[str]] = {
+    "libgstreamer-plugins-good1.0-dev": ["libgstreamer-plugins-extra1.0-dev"],
+}
+
 APT_BASE_OPTIONS: list[str] = [
     "-o",
     "DPkg::Lock::Timeout=300",
@@ -285,12 +291,18 @@ def get_brew_install_command(packages: list[str]) -> list[str]:
 
 
 def check_apt_package_available(package: str) -> bool:
-    """Check if an apt package is available."""
+    """Check if an apt package has an installation candidate (not merely referenced)."""
     result = subprocess.run(
-        ["apt-cache", "show", package],
+        ["apt-cache", "policy", package],
         capture_output=True,
+        text=True,
     )
-    return result.returncode == 0
+    if result.returncode != 0:
+        return False
+    for line in result.stdout.splitlines():
+        if "Candidate:" in line:
+            return "(none)" not in line
+    return False
 
 
 def get_available_debian_packages(category: str) -> list[str]:
@@ -301,6 +313,32 @@ def get_available_debian_packages(category: str) -> list[str]:
     with ThreadPoolExecutor() as pool:
         available = list(pool.map(check_apt_package_available, packages))
     return [pkg for pkg, ok in zip(packages, available, strict=False) if ok]
+
+
+def resolve_package_alternatives(packages: list[str]) -> list[str]:
+    """Replace packages with their first available alternative when the primary is missing."""
+    needs_check = {pkg for pkg in packages if pkg in DEBIAN_PACKAGE_ALTERNATIVES}
+    if not needs_check:
+        return packages
+
+    all_candidates = {name for pkg in needs_check for name in [pkg, *DEBIAN_PACKAGE_ALTERNATIVES[pkg]]}
+    with ThreadPoolExecutor() as pool:
+        availability = dict(zip(all_candidates, pool.map(check_apt_package_available, all_candidates), strict=False))
+
+    resolved = []
+    for pkg in packages:
+        if pkg not in needs_check:
+            resolved.append(pkg)
+            continue
+        chosen = pkg
+        if not availability.get(pkg):
+            for alt in DEBIAN_PACKAGE_ALTERNATIVES[pkg]:
+                if availability.get(alt):
+                    print(f"  Package {pkg} not available; using {alt}")
+                    chosen = alt
+                    break
+        resolved.append(chosen)
+    return resolved
 
 
 def validate_extra_packages(packages: list[str]) -> list[str]:
@@ -514,6 +552,9 @@ def install_debian(
         else:
             packages = get_debian_packages()
             packages = [pkg for pkg in packages if pkg not in bootstrap_packages]
+
+        # Resolve alternatives for packages renamed/replaced in newer distro releases
+        packages = resolve_package_alternatives(packages)
 
         # Install main packages
         print(f"\nInstalling {len(packages)} packages...")

--- a/tools/setup/install_dependencies.py
+++ b/tools/setup/install_dependencies.py
@@ -321,9 +321,17 @@ def resolve_package_alternatives(packages: list[str]) -> list[str]:
     if not needs_check:
         return packages
 
-    all_candidates = {name for pkg in needs_check for name in [pkg, *DEBIAN_PACKAGE_ALTERNATIVES[pkg]]}
+    all_candidates = sorted(
+        {name for pkg in needs_check for name in [pkg, *DEBIAN_PACKAGE_ALTERNATIVES[pkg]]}
+    )
     with ThreadPoolExecutor() as pool:
-        availability = dict(zip(all_candidates, pool.map(check_apt_package_available, all_candidates), strict=False))
+        availability = dict(
+            zip(
+                all_candidates,
+                pool.map(check_apt_package_available, all_candidates),
+                strict=False,
+            )
+        )
 
     resolved = []
     for pkg in packages:


### PR DESCRIPTION
## Description
The llibgstreamer package changed name.
This is how an attempt to install libgstreamer-plugins-good1.0-dev on newer Ubuntu went:
```sudo apt install libgstreamer-plugins-good1.0-dev
Package libgstreamer-plugins-good1.0-dev is not available, but is referred to by another package.
This may mean that the package is missing, has been obsoleted, or
is only available from another source
However the following packages replace it:
  libgstreamer-plugins-extra1.0-dev
```
## Type of Change
<!-- Put an 'x' in the relevant boxes -->
- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] CI/Build changes
- [x] Other

## Testing
<!-- Describe the tests you ran and how to reproduce them -->
- [x] Tested locally
- [ ] Added/updated unit tests
- [ ] Tested with simulator (SITL)
- [ ] Tested with hardware

### Platforms Tested
<!-- Check all that apply -->
- [x] Linux
- [ ] Windows
- [ ] macOS
- [ ] Android
- [ ] iOS

### Flight Stacks Tested
<!-- If applicable -->
- [ ] PX4
- [ ] ArduPilot

## Screenshots
<!-- If applicable, add screenshots to help explain your changes -->

## Checklist
<!-- Go over all the following points, and put an 'x' in all the boxes that apply -->
- [x] I have read the [Contribution Guidelines](CONTRIBUTING.md)
- [x] I have read the [Code of Conduct](CODE_OF_CONDUCT.md)
- [x] My code follows the project's coding standards
- [ ] I have added tests that prove my fix/feature works
- [ ] New and existing unit tests pass locally

## Related Issues
<!-- Link any related issues using #issue_number -->

---
By submitting this pull request, I confirm that my contribution is made under the terms of the project's dual license (Apache 2.0 and GPL v3).
