### PR TITLE
MAVLinkChart: fix Y axis tick labels being clipped

### DIFF
--- a/src/AnalyzeView/MAVLinkInspector/MAVLinkChart.qml
+++ b/src/AnalyzeView/MAVLinkInspector/MAVLinkChart.qml
@@ -104,7 +104,7 @@ ColumnLayout {
         Layout.fillHeight: true
         marginBottom: ScreenTools.defaultFontPixelHeight * 1.5
         marginTop: 0
-        marginLeft: 0
+        marginLeft: ScreenTools.defaultFontPixelWidth // Without this the Y axis tick labels are cut off
         marginRight: 0
 
         theme: GraphsTheme {


### PR DESCRIPTION
Fixes #14373

Add left margin to the MAVLink Inspector graph view so that Y axis tick mark labels are not cut off at the edge of the chart area.
