### PR TITLE
docs: add redirect for removed daily_builds page

### DIFF
--- a/docs/en/qgc-user-guide/releases/daily_builds.md
+++ b/docs/en/qgc-user-guide/releases/daily_builds.md
@@ -1,0 +1,9 @@
+---
+title: Daily Builds
+head:
+  - - meta
+    - http-equiv: refresh
+      content: 0; url=../getting_started/download_and_install.html
+---
+
+This page has moved to [Download and Install](../getting_started/download_and_install.md).


### PR DESCRIPTION
The recent docs restructure (34224e4) removed `releases/daily_builds.md` which broke the external URL:
https://docs.qgroundcontrol.com/master/en/qgc-user-guide/releases/daily_builds.html

This adds a meta-refresh redirect at the old path that sends visitors to the new download page at `getting_started/download_and_install.html`.
