### PR TITLE
docs: fix broken links, update confirmation UI, add UI overview

### DIFF
--- a/.github/workflows/check-links.yml
+++ b/.github/workflows/check-links.yml
@@ -63,7 +63,7 @@ jobs:
           args: '--config .lychee.toml --cache --max-cache-age 3d --no-progress **/*.md docs/en/**'
           lycheeVersion: v0.22.0
           failIfEmpty: false
-          fail: ${{ github.event_name == 'push' && github.ref == 'refs/heads/master' }}
+          fail: ${{ github.event_name == 'pull_request' }}
 
       - name: Upload report
         uses: actions/upload-artifact@v7

--- a/docs/en/qgc-dev-guide/custom_build/first_run_prompts.md
+++ b/docs/en/qgc-dev-guide/custom_build/first_run_prompts.md
@@ -11,8 +11,8 @@ The custom build architecure includes mechanisms for a custom build to both over
 
 Each first run prompt is a simple dialog which can display ui to the user. Whether the specific dialog has already been show to the user or not is stored in a setting. Here is the code for the upstream first run prompt dialogs:
 
-- [FirstRunPrompt](https://github.com/mavlink/qgroundcontrol/blob/master/src/UI/FirstRunPromptDialogs/FirstRunPrompt.qml) - base class
-- [InitialSetupPrompt](https://github.com/mavlink/qgroundcontrol/blob/master/src/UI/FirstRunPromptDialogs/InitialSetupPrompt.qml) - units & offline vehicle settings
+- [FirstRunPrompt](https://github.com/mavlink/qgroundcontrol/blob/master/src/FirstRunPromptDialogs/FirstRunPrompt.qml) - base class
+- [InitialSetupPrompt](https://github.com/mavlink/qgroundcontrol/blob/master/src/FirstRunPromptDialogs/InitialSetupPrompt.qml) - units & offline vehicle settings
 
 ## Standard First Run Prompt Dialogs
 

--- a/docs/en/qgc-dev-guide/views/settings.md
+++ b/docs/en/qgc-dev-guide/views/settings.md
@@ -3,7 +3,7 @@
 The QGC Application Settings UI is built from a mix of generated and hand-written QML.
 
 - The settings container/sidebar is implemented in [src/QmlControls/AppSettings.qml](../../../../src/QmlControls/AppSettings.qml).
-- Most settings content pages are generated from JSON definitions in [src/UI/AppSettings/pages](../../../../src/UI/AppSettings/pages).
+- Most settings content pages are generated from JSON definitions in [src/AppSettings/pages](../../../../src/AppSettings/pages).
 - Some pages are still hand-written and referenced directly (for example Help/Logging/debug pages).
 
 ## How It Is Generated

--- a/docs/en/qgc-dev-guide/views/settings_generation.md
+++ b/docs/en/qgc-dev-guide/views/settings_generation.md
@@ -10,8 +10,8 @@ The runtime stack is:
 
 1. Fact metadata in `src/Settings/*.SettingsGroup.json`
 2. Settings Fact accessors in `src/Settings/*Settings.h/.cc`
-3. Settings UI page definitions in `src/UI/AppSettings/pages/*.SettingsUI.json`
-4. Page list in `src/UI/AppSettings/pages/SettingsPages.json`
+3. Settings UI page definitions in `src/AppSettings/pages/*.SettingsUI.json`
+4. Page list in `src/AppSettings/pages/SettingsPages.json`
 5. Python generator in `tools/generators/settings_qml`
 6. Generated QML loaded by `src/QmlControls/AppSettings.qml`
 
@@ -19,12 +19,12 @@ At build time, CMake runs the generator and places generated QML in the build tr
 
 ## Where Generation Is Wired
 
-Generation is configured in [src/UI/AppSettings/CMakeLists.txt](../../../../src/UI/AppSettings/CMakeLists.txt):
+Generation is configured in [src/AppSettings/CMakeLists.txt](../../../../src/AppSettings/CMakeLists.txt):
 
 - Custom command runs:
   - `python -m tools.generators.settings_qml.generate_pages --output-dir <build>/generated`
 - Inputs:
-  - `src/UI/AppSettings/pages/*.json`
+  - `src/AppSettings/pages/*.json`
   - `src/Settings/*.SettingsGroup.json`
 - Outputs:
   - Generated page QML files (e.g. `GeneralSettings.qml`, `FlyViewSettings.qml`)
@@ -65,7 +65,7 @@ Search terms are derived from:
    - Add `DEFINE_SETTINGFACT(<factName>)` in the matching `*Settings.h`.
    - Ensure `DECLARE_SETTINGSFACT` exists in `*Settings.cc` if required by that file pattern.
 3. Add a control entry in the page JSON:
-   - File: `src/UI/AppSettings/pages/<Page>.SettingsUI.json`
+   - File: `src/AppSettings/pages/<Page>.SettingsUI.json`
    - Add: `{ "setting": "<accessor>.<factName>" }`
 
    See [tools/generators/settings_qml/README.md](../../../../tools/generators/settings_qml/README.md) for the full JSON schema.
@@ -73,11 +73,11 @@ Search terms are derived from:
 
 ## Add a New Generated Settings Page
 
-1. Create a new page definition JSON in `src/UI/AppSettings/pages`, e.g. `MyFeature.SettingsUI.json`.
-2. Add a new entry to `src/UI/AppSettings/pages/SettingsPages.json`:
+1. Create a new page definition JSON in `src/AppSettings/pages`, e.g. `MyFeature.SettingsUI.json`.
+2. Add a new entry to `src/AppSettings/pages/SettingsPages.json`:
    - `name`, `icon`, `qml` (output filename), `pageDefinition` (your new JSON file)
    - Optional `visible` expression
-3. Update the generated outputs list in [src/UI/AppSettings/CMakeLists.txt](../../../../src/UI/AppSettings/CMakeLists.txt):
+3. Update the generated outputs list in [src/AppSettings/CMakeLists.txt](../../../../src/AppSettings/CMakeLists.txt):
    - Add your new QML filename to `_generated_qml_names`.
 4. Build QGC to generate and include the new page.
 

--- a/docs/en/qgc-user-guide/fly_view/fly_tools.md
+++ b/docs/en/qgc-user-guide/fly_view/fly_tools.md
@@ -1,5 +1,9 @@
 # Fly Tools
 
+## Action Confirmation {#confirmation}
+
+Safety-critical actions (takeoff, land, RTL, etc.) require confirmation before they are executed. When you trigger one of these actions, a confirmation button appears with chevrons on its left side. To confirm, click and hold the button until the action is accepted. This prevents accidental activation of critical commands.
+
 ## Pre Flight Checklist {#preflight_checklist}
 
 An automated preflight checklist can be used to run through standard checks that the vehicle is configured correctly and it is safe to fly.
@@ -23,7 +27,7 @@ To takeoff (when landed):
 1. Optionally set the takeoff altitude in the right-side vertical slider.
   - You can slide up/down to change the altitude
   - You can also click on the specified altitude (10 ft in example) and then type in a specific altitude.
-1. Confirm takeoff using the slider.
+1. [Confirm](#confirmation) the action.
 
 
 ## Land {#land}
@@ -31,14 +35,14 @@ To takeoff (when landed):
 You can land at the current position at any time while flying:
 
 1. Press the **Land** button in the _Fly Tools_ (this will toggle to a **Takeoff** button when landed).
-1. Confirm landing using the slider.
+1. [Confirm](#confirmation) the action.
 
 ## RTL/Return
 
 Return to a "safe point" at any time while flying:
 
 1. Press the **RTL** button in the _Fly Tools_.
-1. Confirm RTL using the slider.
+1. [Confirm](#confirmation) the action.
 
 ::: info
 Vehicles commonly return to the "home" (takeoff) location and land.

--- a/docs/en/qgc-user-guide/fly_view/fly_view.md
+++ b/docs/en/qgc-user-guide/fly_view/fly_view.md
@@ -53,13 +53,13 @@ To pause:
 
 1. Press the **Pause** button in the _Fly Tools_.
 1. Optionally set a new altitude using the right-side vertical slider.
-1. Confirm the pause using the slider.
+1. [Confirm](fly_tools.md#confirmation) the action.
 
 ### Missions
 
 #### Start Mission {#start_mission}
 
-You can start a mission when the vehicle is landed (the start mission confirmation slider is often displayed by default).
+You can start a mission when the vehicle is landed (the start mission confirmation button is often displayed by default).
 
 To start a mission from landed:
 
@@ -67,14 +67,12 @@ To start a mission from landed:
 1. Select the _Start Mission_ action from the dialog.
 
 
-   (to display the confirmation slider)
-
-1. When the confirmation slider appears, drag it to start the mission.
+1. [Confirm](fly_tools.md#confirmation) the action to start the mission.
 
 
 #### Continue Mission {#continue_mission}
 
-You can _continue_ mission from the _next_ waypoint when you're flying (the _Continue Mission_ confirmation slider is often displayed by default after you takeoff).
+You can _continue_ mission from the _next_ waypoint when you're flying (the _Continue Mission_ confirmation button is often displayed by default after you takeoff).
 
 ::: info
 Continue and [Resume mission](#resume_mission) are different!
@@ -88,7 +86,7 @@ You can continue the current mission while (unless already in a mission!):
 1. Select the _Continue Mission_ action from the dialog.
 
 
-1. Drag the confirmation slider to continue the mission.
+1. [Confirm](fly_tools.md#confirmation) the action to continue the mission.
 
 
 #### Resume Mission {#resume_mission}
@@ -104,7 +102,7 @@ After landing you will be prompted with a _Flight Plan complete_ dialog, which g
 
 
 If you select to resume the mission, then _QGroundControl_ will rebuild the mission and upload it to the vehicle.
-Then use the _Start Mission_ slider to continue the mission.
+Then [confirm](fly_tools.md#confirmation) the action to continue the mission.
 
 
 ::: info

--- a/docs/en/qgc-user-guide/getting_started/ui_overview.md
+++ b/docs/en/qgc-user-guide/getting_started/ui_overview.md
@@ -1,0 +1,45 @@
+# UI Overview
+
+QGroundControl is organized into a small number of top-level views, each accessed from the toolbar on the left side of the screen.
+
+## Toolbar
+
+The toolbar is always visible and provides:
+
+- **View switching** — click the **Q** icon in the toolbar to open the view selector, then choose Fly, Plan, or any other view.
+- **View-specific content** — the rest of the toolbar changes based on the current view, showing relevant status and controls for that view.
+
+## Main Views
+
+### Fly View
+
+The primary view while your vehicle is in the air. It shows a live map with the vehicle position, a heads-up display (HUD) with attitude and speed, and an instrument panel with telemetry values. Action buttons let you arm, take off, land, return to launch, and more.
+
+See: [Fly View](../fly_view/fly_view.md)
+
+### Plan View
+
+Used before flight to create and upload autonomous missions. You can place waypoints on the map, configure survey patterns, set geofence boundaries, and define rally points. Missions are uploaded to the vehicle over the active link.
+
+See: [Plan View](../plan_view/plan_view.md)
+
+### Vehicle Configuration
+
+Configure your vehicle's firmware, airframe, sensors, flight modes, and safety settings. This view walks you through each setup step with a sidebar checklist. Available options vary depending on the connected firmware (PX4 or ArduPilot).
+
+See: [Vehicle Setup](../setup_view/firmware.md)
+
+### Analyze View
+
+Tools for post-flight analysis and debugging:
+
+- **Log Download** — retrieve onboard flight logs.
+- **GeoTag Images** — stamp survey photos with GPS coordinates.
+- **MAVLink Console** — send commands directly to the autopilot.
+- **MAVLink Inspector** — view raw MAVLink messages in real time.
+
+See: [Analyze](../analyze_view/index.md)
+
+### Application Settings
+
+Persistent application preferences organized by category — general behavior, fly view layout, map providers, video streaming, RTK/NTRIP, telemetry logging, and more.

--- a/docs/en/qgc-user-guide/index.md
+++ b/docs/en/qgc-user-guide/index.md
@@ -19,7 +19,7 @@ It provides easy and straightforward usage for beginners, while still delivering
 
 ::: info
 These docs cover the **daily build** (master branch).
-If you are using the stable release, see the [Stable V5.0 docs](https://docs.qgroundcontrol.com/v5.0/en/qgc-user-guide/).
+If you are using the stable release, see the [Stable V5.0 docs](https://docs.qgroundcontrol.com/Stable_V5.0/en/qgc-user-guide/).
 :::
 
 ## Getting Started

--- a/docs/en/qgc-user-guide/settings_view/fly_view.md
+++ b/docs/en/qgc-user-guide/settings_view/fly_view.md
@@ -19,7 +19,7 @@ Settings that control the behavior and appearance of the [Fly View](../fly_view/
 - **Maximum Altitude** — highest altitude allowed for guided mode commands (default: 121.92 m / 400 ft)
 - **Go To Location Max Distance** — maximum distance for Go To commands (default: 1000 m)
 - **Loiter Radius in Forward Flight Guided Mode** — loiter radius for fixed-wing guided mode (default: 80 m)
-- **Require Confirmation for Go To Location in Guided Mode** — require slider confirmation before executing Go To
+- **Require Confirmation for Go To Location in Guided Mode** — require confirmation before executing Go To
 
 ## MAVLink Actions
 


### PR DESCRIPTION
Fixes broken links found by the check-links CI workflow and updates outdated UI references.

## Changes

**CI workflow fix:**
- Flip `check-links.yml` fail condition: now fails on PRs (where authors can fix issues) instead of on master pushes (where it's too late to gate)

**Broken link fixes:**
- Fix settings dev-guide docs referencing old `src/UI/AppSettings/` path → `src/AppSettings/`
- Create `ui_overview.md` page that was referenced from SUMMARY.md and index.md but never existed

**Confirmation UI update:**
- Replace all "confirm using the slider" references with the current click-and-hold confirmation button
- Add new "Action Confirmation" section to Fly Tools explaining how the chevron button works
