### PR TITLE
Add TopLevelViewsTest: UI smoke test for views and settings pages

### DIFF
--- a/cmake/QGCTest.cmake
+++ b/cmake/QGCTest.cmake
@@ -26,6 +26,8 @@ set(QGC_TEST_TIMEOUT_INTEGRATION 120 CACHE STRING "Timeout for integration tests
 set(QGC_TEST_TIMEOUT_SLOW 180 CACHE STRING "Timeout for slow tests (seconds)")
 set(QGC_TEST_TIMEOUT_DEFAULT 90 CACHE STRING "Default test timeout (seconds)")
 
+option(QGC_TEST_ONSCREEN "Run tests with native display instead of offscreen" OFF)
+
 # ----------------------------------------------------------------------------
 # Convenience Targets
 # ----------------------------------------------------------------------------
@@ -114,9 +116,14 @@ endforeach()
 function(add_qgc_test test_name)
     cmake_parse_arguments(ARG "SERIAL" "TIMEOUT" "LABELS;RESOURCE_LOCK" ${ARGN})
 
+    set(_test_command $<TARGET_FILE:${CMAKE_PROJECT_NAME}> --unittest:${test_name} --allow-multiple)
+    if(QGC_TEST_ONSCREEN)
+        list(APPEND _test_command --onscreen)
+    endif()
+
     add_test(
         NAME ${test_name}
-        COMMAND $<TARGET_FILE:${CMAKE_PROJECT_NAME}> --unittest:${test_name} --allow-multiple
+        COMMAND ${_test_command}
         WORKING_DIRECTORY ${CMAKE_BINARY_DIR}
     )
 
@@ -133,7 +140,10 @@ function(add_qgc_test test_name)
         set(_timeout ${QGC_TEST_TIMEOUT_DEFAULT})
     endif()
 
-    set(_test_env "QT_QPA_PLATFORM=offscreen" "QT_LOGGING_RULES=*.debug=false")
+    set(_test_env "QT_LOGGING_RULES=*.debug=false")
+    if(NOT QGC_TEST_ONSCREEN)
+        list(PREPEND _test_env "QT_QPA_PLATFORM=offscreen")
+    endif()
 
     # LSan's tracer process needs ptrace, which Yama (ptrace_scope>=1) blocks on
     # most dev/CI hosts — disable leak detection under ASan to avoid spurious

--- a/src/AppSettings/AppLogging.qml
+++ b/src/AppSettings/AppLogging.qml
@@ -6,6 +6,7 @@ import QtQuick.Layouts
 
 Item {
     id: root
+    objectName: "settingsPage_LogViewer"
 
     readonly property real _indicatorWidth: ScreenTools.defaultFontPixelWidth * 0.4
     readonly property real _margin: ScreenTools.defaultFontPixelWidth

--- a/src/AppSettings/HelpSettings.qml
+++ b/src/AppSettings/HelpSettings.qml
@@ -5,6 +5,7 @@ import QGroundControl
 import QGroundControl.Controls
 
 Rectangle {
+    objectName: "settingsPage_Help"
     color:          qgcPal.window
     anchors.fill:   parent
 

--- a/src/MainWindow/MainWindow.qml
+++ b/src/MainWindow/MainWindow.qml
@@ -286,11 +286,13 @@ ApplicationWindow {
 
     FlyView {
         id:                     flyView
+        objectName:             "mainView_fly"
         anchors.fill:           parent
     }
 
     PlanView {
         id:             planView
+        objectName:     "mainView_plan"
         anchors.fill:   parent
         visible:        false
     }
@@ -365,6 +367,7 @@ ApplicationWindow {
 
     Rectangle {
         id:             toolDrawer
+        objectName:     "mainView_toolDrawer"
         anchors.fill:   parent
         visible:        false
         color:          qgcPal.window
@@ -403,6 +406,7 @@ ApplicationWindow {
 
                 QGCToolBarButton {
                     id: qgcButton
+                    objectName: "toolbar_qgcLogo"
                     height: parent.height
                     icon.source: "/res/QGCLogoFull.svg"
                     logo: true

--- a/src/QmlControls/AppSettings.qml
+++ b/src/QmlControls/AppSettings.qml
@@ -171,6 +171,7 @@ Rectangle {
 
         QGCFlickable {
             id:                 buttonList
+            objectName:         "settings_buttonList"
             Layout.fillWidth:   true
             Layout.fillHeight:  true
             contentHeight:      buttonColumn.height + _verticalMargin
@@ -237,6 +238,7 @@ Rectangle {
                     // Page button
                     SettingsButton {
                         Layout.fillWidth: true
+                        objectName:    "settingsButton_" + (model.nameKey ?? pageName)
                         text:          pageName
                         icon.source:   pageIconUrl
                         expandable:    hasMultipleSections
@@ -338,6 +340,7 @@ Rectangle {
     //-- Panel Contents
     Loader {
         id:                     rightPanel
+        objectName:             "settings_rightPanel"
         anchors.leftMargin:     _horizontalMargin
         anchors.rightMargin:    _horizontalMargin
         anchors.topMargin:      _verticalMargin

--- a/src/Toolbar/FlyViewToolBar.qml
+++ b/src/Toolbar/FlyViewToolBar.qml
@@ -76,6 +76,7 @@ Item {
 
                         QGCToolBarButton {
                             id:                 qgcButton
+                            objectName:         "toolbar_qgcLogo"
                             Layout.fillHeight:  true
                             icon.source:        "/res/QGCLogoFull.svg"
                             logo:               true

--- a/src/Toolbar/PlanViewToolBar.qml
+++ b/src/Toolbar/PlanViewToolBar.qml
@@ -35,6 +35,7 @@ Rectangle {
 
     QGCToolBarButton {
         id: qgcButton
+        objectName: "toolbar_qgcLogo"
         height: parent.height
         icon.source: "/res/QGCLogoFull.svg"
         logo: true

--- a/src/Toolbar/SelectViewDropdown.qml
+++ b/src/Toolbar/SelectViewDropdown.qml
@@ -17,6 +17,7 @@ ToolIndicatorPage {
             rowSpacing: columnSpacing
 
             SubMenuButton {
+                objectName: "toolbar_viewFly"
                 implicitHeight: root._toolButtonHeight
                 Layout.fillWidth: true
                 text: qsTr("Fly")
@@ -30,6 +31,7 @@ ToolIndicatorPage {
             }
 
             SubMenuButton {
+                objectName: "toolbar_viewPlan"
                 implicitHeight: root._toolButtonHeight
                 Layout.fillWidth: true
                 text: qsTr("Plan")
@@ -43,6 +45,7 @@ ToolIndicatorPage {
             }
 
             SubMenuButton {
+                objectName: "toolbar_viewAnalyze"
                 implicitHeight: root._toolButtonHeight
                 Layout.fillWidth: true
                 text: qsTr("Analyze")
@@ -58,6 +61,7 @@ ToolIndicatorPage {
 
             SubMenuButton {
                 id: setupButton
+                objectName: "toolbar_viewConfigure"
                 implicitHeight: root._toolButtonHeight
                 Layout.fillWidth: true
                 text: qsTr("Configure")
@@ -72,6 +76,7 @@ ToolIndicatorPage {
 
             SubMenuButton {
                 id: settingsButton
+                objectName: "toolbar_viewSettings"
                 implicitHeight: root._toolButtonHeight
                 Layout.fillWidth: true
                 text: qsTr("Settings")
@@ -87,6 +92,7 @@ ToolIndicatorPage {
 
             SubMenuButton {
                 id: closeButton
+                objectName: "toolbar_viewClose"
                 implicitHeight: root._toolButtonHeight
                 Layout.fillWidth: true
                 text: qsTr("Close")

--- a/src/Utilities/Platform/Platform.cc
+++ b/src/Utilities/Platform/Platform.cc
@@ -210,7 +210,7 @@ std::optional<int> Platform::initialize(int argc, char* argv[],
 #endif
 
 #ifdef QGC_UNITTEST_BUILD
-    if (args.runningUnitTests || args.listTests) {
+    if ((args.runningUnitTests || args.listTests) && !args.onscreen) {
         if (!qEnvironmentVariableIsSet("QT_QPA_PLATFORM")) {
             (void) qputenv("QT_QPA_PLATFORM", "offscreen");
         }

--- a/src/Utilities/QGCCommandLineParser.cc
+++ b/src/Utilities/QGCCommandLineParser.cc
@@ -37,6 +37,7 @@ constexpr QLatin1StringView kOptUnittestStress = QLatin1StringView("unittest-str
 constexpr QLatin1StringView kOptUnittestOutput = QLatin1StringView("unittest-output");
 constexpr QLatin1StringView kOptUnittestLabel  = QLatin1StringView("label");
 constexpr QLatin1StringView kOptListTests      = QLatin1StringView("list-tests");
+constexpr QLatin1StringView kOptOnscreen       = QLatin1StringView("onscreen");
 #endif
 
 #ifdef Q_OS_WIN
@@ -181,6 +182,11 @@ CommandLineParseResult parseCommandLine()
         QString(kOptListTests),
         QCoreApplication::translate("main", "List available unit tests and exit."));
     (void) parser.addOption(listTestsOpt);
+
+    const QCommandLineOption onscreenOpt(
+        QString(kOptOnscreen),
+        QCoreApplication::translate("main", "Show test windows on screen instead of running offscreen."));
+    (void) parser.addOption(onscreenOpt);
 #endif
 
 #if !defined(Q_OS_ANDROID) && !defined(Q_OS_IOS)
@@ -380,6 +386,8 @@ CommandLineParseResult parseCommandLine()
     if (out.listTests) {
         qCDebug(QGCCommandLineParserLog) << "List tests requested";
     }
+
+    out.onscreen = parser.isSet(onscreenOpt);
 #endif
 
     // --- Parse desktop options ---

--- a/src/Utilities/QGCCommandLineParser.h
+++ b/src/Utilities/QGCCommandLineParser.h
@@ -46,6 +46,7 @@ struct CommandLineParseResult
     std::optional<QString> unitTestOutput;  ///< Output file for test results (JUnit XML)
     std::optional<QString> labelFilter;     ///< Filter tests by label (comma-separated)
     bool listTests = false;                 ///< List available tests and exit
+    bool onscreen = false;                  ///< Show test windows on screen (skip offscreen override)
 
     // --- Desktop options (not on Android/iOS) ---
     bool fakeMobile = false;

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -352,3 +352,9 @@ add_qgc_test(RequestMetaDataTypeStateMachineTest LABELS Integration Vehicle RESO
 add_qgc_test(SendMavCommandWithHandlerTest LABELS Integration Vehicle RESOURCE_LOCK MockLink)
 add_qgc_test(SendMavCommandWithSignallingTest LABELS Integration Vehicle RESOURCE_LOCK MockLink)
 add_qgc_test(VehicleLinkManagerTest LABELS Integration Vehicle RESOURCE_LOCK MockLink)
+
+# ----------------------------------------------------------------------------
+# QML UI Smoke Tests
+# ----------------------------------------------------------------------------
+add_subdirectory(QmlUITests)
+add_qgc_test(TopLevelViewsTest LABELS Integration TIMEOUT 120)

--- a/test/QmlUITests/CMakeLists.txt
+++ b/test/QmlUITests/CMakeLists.txt
@@ -1,0 +1,14 @@
+# ============================================================================
+# QML UI Smoke Tests
+# ============================================================================
+
+target_sources(${CMAKE_PROJECT_NAME}
+    PRIVATE
+        ${CMAKE_CURRENT_SOURCE_DIR}/TopLevelViewsTest.cc
+        ${CMAKE_CURRENT_SOURCE_DIR}/TopLevelViewsTest.h
+)
+
+target_include_directories(${CMAKE_PROJECT_NAME}
+    PRIVATE
+        ${CMAKE_CURRENT_SOURCE_DIR}
+)

--- a/test/QmlUITests/TopLevelViewsTest.cc
+++ b/test/QmlUITests/TopLevelViewsTest.cc
@@ -1,0 +1,174 @@
+#include "TopLevelViewsTest.h"
+
+#include <QtCore/QRegularExpression>
+#include <QtQml/QQmlApplicationEngine>
+#include <QtQml/QQmlContext>
+#include <QtQuick/QQuickItem>
+#include <QtQuick/QQuickWindow>
+#include <QtQuickControls2/QQuickStyle>
+#include <QtTest/QTest>
+
+#include "ColoredSvgImageProvider.h"
+#include "LinkManager.h"
+#include "MAVLinkProtocol.h"
+#include "MultiVehicleManager.h"
+#include "QGCApplication.h"
+#include "QGCCorePlugin.h"
+#include "QGCImageProvider.h"
+#include "JoystickManager.h"
+#include "SettingsManager.h"
+#include "AppSettings.h"
+
+UT_REGISTER_TEST(TopLevelViewsTest, TestLabel::Integration)
+
+// This test assumes Advanced UI mode is enabled (the default). All views including
+// Analyze are expected to be visible.
+
+void TopLevelViewsTest::_testNavigateViews()
+{
+    setStrictLogCheck(true);
+
+    // Initialize subsystems needed for full QML UI
+    QQuickStyle::setStyle("Basic");
+    QGCCorePlugin::instance()->init();
+    MAVLinkProtocol::instance()->init();
+    MultiVehicleManager::instance()->init();
+
+    // Suppress first-run prompts so they don't block the UI
+    AppSettings *appSettings = SettingsManager::instance()->appSettings();
+    const QList<int> promptIds = QGCCorePlugin::instance()->firstRunPromptStdIds();
+    for (int id : promptIds) {
+        appSettings->firstRunPromptIdsMarkIdAsShown(id);
+    }
+
+    // Verify we are in Advanced UI mode as this test requires it
+    QVERIFY2(QGCCorePlugin::instance()->showAdvancedUI(), "Test requires Advanced UI mode");
+
+    // Ignore benign Qt platform warnings that can't be avoided in offscreen mode
+    ignoreLogMessage(QRegularExpression(QStringLiteral("^default$")), QtWarningMsg, QRegularExpression(QStringLiteral("This plugin does not support propagateSizeHints")));
+    ignoreLogMessage(QRegularExpression(QStringLiteral("^qt\\.qpa\\.fonts$")), QtWarningMsg, QRegularExpression(QStringLiteral("Populating font family aliases")));
+    ignoreLogMessage(QRegularExpression(QStringLiteral("^default$")), QtWarningMsg, QRegularExpression(QStringLiteral("QRhiGles2")));
+
+    // Create QML engine (mirrors _initForNormalAppBoot)
+    QQmlApplicationEngine *engine = QGCCorePlugin::instance()->createQmlApplicationEngine(this);
+    QVERIFY(engine);
+
+    engine->addImageProvider(QStringLiteral("QGCImages"), new QGCImageProvider());
+    engine->addImageProvider(QLatin1String(ColoredSvgImageProvider::ProviderId), new ColoredSvgImageProvider());
+
+    // Load MainWindow
+    engine->load(QUrl(QStringLiteral("qrc:/qml/QGroundControl/MainWindow.qml")));
+    QVERIFY(!engine->rootObjects().isEmpty());
+
+    QQuickWindow *window = qobject_cast<QQuickWindow *>(engine->rootObjects().first());
+    QVERIFY(window);
+
+    // Wait for window to be fully rendered
+    QVERIFY(QTest::qWaitForWindowExposed(window));
+
+    QQuickItem *rootItem = window->contentItem();
+
+    // Verify the Q logo button exists
+    QQuickItem *qgcButton = findVisibleItem(rootItem, QStringLiteral("toolbar_qgcLogo"));
+    QVERIFY2(qgcButton, "Q logo button not found");
+
+    // Helper to click a button and wait
+    auto clickButton = [&](const QString &objectName) -> bool {
+        QQuickItem *btn = findVisibleItem(rootItem, objectName);
+        if (!btn) {
+            return false;
+        }
+        const QPointF center = btn->mapToScene(QPointF(btn->width() / 2, btn->height() / 2));
+        QTest::mouseClick(window, Qt::LeftButton, Qt::NoModifier, center.toPoint());
+        return true;
+    };
+
+    // Helper to navigate to a view and verify the switch
+    auto navigateAndVerify = [&](const QString &view, bool expectFlyView, bool expectPlanView, bool expectToolDrawer) {
+        QVERIFY2(clickButton(QStringLiteral("toolbar_qgcLogo")),
+                 qPrintable(QStringLiteral("Failed to click Q logo button before %1").arg(view)));
+
+        const QString buttonName = QStringLiteral("toolbar_view") + view;
+        QVERIFY2(findVisibleItem(rootItem, buttonName, 2000),
+                 qPrintable(QStringLiteral("View button not found: %1").arg(buttonName)));
+        QVERIFY2(clickButton(buttonName),
+                 qPrintable(QStringLiteral("Failed to click %1").arg(buttonName)));
+
+        const int flyTimeout = expectFlyView ? 1000 : 0;
+        const int planTimeout = expectPlanView ? 1000 : 0;
+        const int drawerTimeout = expectToolDrawer ? 1000 : 0;
+        QVERIFY2((findVisibleItem(rootItem, QStringLiteral("mainView_fly"), flyTimeout) != nullptr) == expectFlyView,
+                 qPrintable(QStringLiteral("mainView_fly visibility wrong after switching to %1").arg(view)));
+        QVERIFY2((findVisibleItem(rootItem, QStringLiteral("mainView_plan"), planTimeout) != nullptr) == expectPlanView,
+                 qPrintable(QStringLiteral("mainView_plan visibility wrong after switching to %1").arg(view)));
+        QVERIFY2((findVisibleItem(rootItem, QStringLiteral("mainView_toolDrawer"), drawerTimeout) != nullptr) == expectToolDrawer,
+                 qPrintable(QStringLiteral("mainView_toolDrawer visibility wrong after switching to %1").arg(view)));
+    };
+
+    //                   view name      flyView  planView  toolDrawer
+    navigateAndVerify(QStringLiteral("Fly"),       true,    false,    false);
+    navigateAndVerify(QStringLiteral("Plan"),      false,   true,     false);
+    navigateAndVerify(QStringLiteral("Configure"), false,   true,     true);
+    navigateAndVerify(QStringLiteral("Analyze"),   false,   true,     true);
+    navigateAndVerify(QStringLiteral("Settings"),  false,   true,     true);
+
+    // Navigate through settings pages that are unconditionally visible
+    {
+        navigateAndVerify(QStringLiteral("Settings"), false, true, true);
+
+        const QStringList settingsPages = {
+            QStringLiteral("General"),
+            QStringLiteral("Fly View"),
+            QStringLiteral("Plan View"),
+            QStringLiteral("ADSB Server"),
+            QStringLiteral("Comm Links"),
+            QStringLiteral("Logging"),
+            QStringLiteral("Log Viewer"),
+            QStringLiteral("Maps"),
+            QStringLiteral("Remote ID"),
+            QStringLiteral("Telemetry"),
+            QStringLiteral("Video"),
+            QStringLiteral("Help"),
+        };
+
+        for (const QString &page : settingsPages) {
+            const QString buttonName = QStringLiteral("settingsButton_") + page;
+
+            QQuickItem *btn = findVisibleItem(rootItem, buttonName);
+            QVERIFY2(btn, qPrintable(QStringLiteral("Settings page button not found: %1").arg(buttonName)));
+
+            // Scroll the flickable if the button is out of view
+            QQuickItem *flickable = findVisibleItem(rootItem, QStringLiteral("settings_buttonList"));
+            if (flickable) {
+                // Map button position to flickable coordinates and scroll to it
+                const QPointF btnPos = btn->mapToItem(flickable, QPointF(0, 0));
+                const qreal contentY = flickable->property("contentY").toReal();
+                const qreal flickHeight = flickable->height();
+                if (btnPos.y() < 0 || btnPos.y() + btn->height() > flickHeight) {
+                    flickable->setProperty("contentY", contentY + btnPos.y() - flickHeight / 4);
+                }
+            }
+
+            const QPointF center = btn->mapToScene(QPointF(btn->width() / 2, btn->height() / 2));
+            QTest::mouseClick(window, Qt::LeftButton, Qt::NoModifier, center.toPoint());
+
+            // Verify the correct page is showing by checking its objectName
+            const QString expectedObjectName = QStringLiteral("settingsPage_") + QString(page).remove(' ');
+            QVERIFY2(findVisibleItem(rootItem, expectedObjectName),
+                     qPrintable(QStringLiteral("Settings page objectName not found: %1").arg(expectedObjectName)));
+        }
+    }
+
+    // Close the window before destroying the engine to avoid QML teardown issues
+    window->close();
+    QTest::qWait(100);
+
+    // Clean up the engine before the test ends
+    delete engine;
+    QTest::qWait(100);
+}
+
+QQmlApplicationEngine *TopLevelViewsTest::_createTestEngine()
+{
+    return nullptr; // unused, kept for future expansion
+}

--- a/test/QmlUITests/TopLevelViewsTest.h
+++ b/test/QmlUITests/TopLevelViewsTest.h
@@ -1,0 +1,24 @@
+#pragma once
+
+#include "UnitTest.h"
+
+class QQmlApplicationEngine;
+
+/// @brief UI smoke test that loads MainWindow and navigates through all top-level views.
+///
+/// This test boots the full QML UI (MainWindow) and clicks through each view
+/// accessible from the Q icon menu: Fly, Plan, Analyze, Configure, Settings.
+/// It verifies no QML errors/warnings occur during navigation.
+class TopLevelViewsTest : public UnitTest
+{
+    Q_OBJECT
+
+public:
+    TopLevelViewsTest() = default;
+
+private slots:
+    void _testNavigateViews();
+
+private:
+    QQmlApplicationEngine *_createTestEngine();
+};

--- a/test/UnitTestFramework/UnitTest.cc
+++ b/test/UnitTestFramework/UnitTest.cc
@@ -11,6 +11,7 @@
 #include <QtCore/QTemporaryDir>
 #include <QtCore/QTemporaryFile>
 #include <QtPositioning/QGeoCoordinate>
+#include <QtQuick/QQuickItem>
 #include <QtTest/QSignalSpy>
 #include <QtTest/QTest>
 
@@ -38,6 +39,7 @@ struct UnitTest::ExpectedLogMessages
     {
         LogEntry::Level level;
         QRegularExpression pattern;
+        QRegularExpression categoryPattern; // empty = match any category
     };
     QList<Entry> list;
 };
@@ -488,6 +490,40 @@ bool UnitTest::waitForDeleted(const QPointer<QObject>& objectPtr, int timeoutMs,
     return false;
 }
 
+static QQuickItem* findVisibleItemImmediate(QQuickItem* root, const QString& objectName)
+{
+    if (!root || !root->isVisible()) {
+        return nullptr;
+    }
+    if (root->objectName() == objectName) {
+        return root;
+    }
+    const auto children = root->childItems();
+    for (auto* child : children) {
+        if (auto* found = findVisibleItemImmediate(child, objectName)) {
+            return found;
+        }
+    }
+    return nullptr;
+}
+
+QQuickItem* UnitTest::findVisibleItem(QQuickItem* root, const QString& objectName, int timeoutMs)
+{
+    constexpr int pollIntervalMs = 50;
+    int elapsed = 0;
+    while (elapsed <= timeoutMs) {
+        if (auto* item = findVisibleItemImmediate(root, objectName)) {
+            return item;
+        }
+        if (elapsed >= timeoutMs) {
+            break;
+        }
+        QTest::qWait(pollIntervalMs);
+        elapsed += pollIntervalMs;
+    }
+    return nullptr;
+}
+
 void UnitTest::settleEventLoopForCleanup(int iterations, int waitMs)
 {
     if (iterations <= 0) {
@@ -691,13 +727,29 @@ void UnitTest::cleanupTestCase()
 
 void UnitTest::expectLogMessage(QtMsgType type, const QRegularExpression &pattern)
 {
-    _expectedLogMessages->list.append({LogEntry::fromQtMsgType(type), pattern});
+    _expectedLogMessages->list.append({LogEntry::fromQtMsgType(type), pattern, {}});
+}
+
+void UnitTest::expectLogMessage(const QRegularExpression &categoryPattern, QtMsgType type, const QRegularExpression &messagePattern)
+{
+    _expectedLogMessages->list.append({LogEntry::fromQtMsgType(type), messagePattern, categoryPattern});
+}
+
+void UnitTest::ignoreLogMessage(QtMsgType type, const QRegularExpression &pattern)
+{
+    _expectedLogMessages->list.append({LogEntry::fromQtMsgType(type), pattern, {}});
+}
+
+void UnitTest::ignoreLogMessage(const QRegularExpression &categoryPattern, QtMsgType type, const QRegularExpression &messagePattern)
+{
+    _expectedLogMessages->list.append({LogEntry::fromQtMsgType(type), messagePattern, categoryPattern});
 }
 
 void UnitTest::init()
 {
     _initCalled = true;
     _failureContextDumped = false;
+    _strictLogCheck = false;
     _expectedLogMessages->list.clear();
 
     // Start capturing log messages for this test (cleared from previous test)
@@ -733,30 +785,46 @@ void UnitTest::cleanup()
 
         auto isExpected = [this](const LogEntry &m) {
             for (const auto &e : _expectedLogMessages->list) {
-                if (e.level == m.level && e.pattern.match(m.message).hasMatch()) {
-                    return true;
-                }
+                if (e.level != m.level) continue;
+                if (!e.pattern.match(m.message).hasMatch()) continue;
+                if (!e.categoryPattern.pattern().isEmpty() &&
+                    !e.categoryPattern.match(m.category).hasMatch()) continue;
+                return true;
             }
             return false;
         };
 
         const auto allMsgs = LogManager::capturedMessages();
+        QString strictDetails;
         for (const auto &m : allMsgs) {
             if (isExpected(m)) {
                 continue;
             }
-            if (m.category.isEmpty() || m.category == QStringLiteral("default")) {
+            if (_strictLogCheck) {
                 const char *lvl = (m.level == LogEntry::Debug)   ? "debug"
                                 : (m.level == LogEntry::Warning) ? "warning"
                                 : (m.level == LogEntry::Info)    ? "info"
+                                : (m.level == LogEntry::Critical) ? "critical"
                                                                  : "other";
-                uncategorizedDetails += QStringLiteral("  [%1] %2\n").arg(QLatin1String(lvl), m.message);
-            }
-            if (m.level == LogEntry::Critical) {
-                criticalDetails += QStringLiteral("  [%1] %2\n").arg(m.category, m.message);
+                strictDetails += QStringLiteral("  [%1][%2] %3\n")
+                                     .arg(QLatin1String(lvl), m.category, m.message);
+            } else {
+                if (m.category.isEmpty() || m.category == QStringLiteral("default")) {
+                    const char *lvl = (m.level == LogEntry::Debug)   ? "debug"
+                                    : (m.level == LogEntry::Warning) ? "warning"
+                                    : (m.level == LogEntry::Info)    ? "info"
+                                                                     : "other";
+                    uncategorizedDetails += QStringLiteral("  [%1] %2\n").arg(QLatin1String(lvl), m.message);
+                }
+                if (m.level == LogEntry::Critical) {
+                    criticalDetails += QStringLiteral("  [%1] %2\n").arg(m.category, m.message);
+                }
             }
         }
 
+        if (!strictDetails.isEmpty()) {
+            QFAIL(qPrintable(QStringLiteral("Unexpected log messages (strict mode):\n%1").arg(strictDetails)));
+        }
         if (!uncategorizedDetails.isEmpty() || !criticalDetails.isEmpty()) {
             QString msg;
             if (!uncategorizedDetails.isEmpty()) {

--- a/test/UnitTestFramework/UnitTest.h
+++ b/test/UnitTestFramework/UnitTest.h
@@ -8,6 +8,7 @@
 #include <QtTest/QTest>
 
 class QGeoCoordinate;
+class QQuickItem;
 class QRegularExpression;
 class QTemporaryDir;
 class QTemporaryFile;
@@ -314,6 +315,10 @@ public:
     static bool waitForDeleted(const QPointer<QObject>& objectPtr, int timeoutMs,
                                QStringView objectName = {});
 
+    /// Finds a visible QQuickItem by objectName in the visual tree, polling with
+    /// 50ms intervals up to timeoutMs. Returns nullptr if not found within the timeout.
+    static QQuickItem* findVisibleItem(QQuickItem* root, const QString& objectName, int timeoutMs = 1000);
+
     /// @name std::chrono overloads — prefer these in new code
     /// @{
     static bool waitForSignal(QSignalSpy& spy, std::chrono::milliseconds timeout, QStringView signalName = {})
@@ -460,6 +465,21 @@ protected:
     /// Call this before the code that emits the message.
     void expectLogMessage(QtMsgType type, const QRegularExpression &pattern);
 
+    /// Overload that also matches on category (useful for whitelisting Qt internal categories).
+    void expectLogMessage(const QRegularExpression &categoryPattern, QtMsgType type, const QRegularExpression &messagePattern);
+
+    /// Permanently suppress all log messages matching @a pattern at level @a type
+    /// for the duration of the test. Semantically signals that the message may
+    /// fire any number of times (vs expectLogMessage for known single occurrences).
+    void ignoreLogMessage(QtMsgType type, const QRegularExpression &pattern);
+
+    /// Overload that also matches on category.
+    void ignoreLogMessage(const QRegularExpression &categoryPattern, QtMsgType type, const QRegularExpression &messagePattern);
+
+    /// Enable strict log checking: ANY unexpected log message (regardless of
+    /// category or level) will fail the test in cleanup().
+    void setStrictLogCheck(bool strict) { _strictLogCheck = strict; }
+
 private:
     void _cleanupTempFiles();
     void _resetTestState();
@@ -480,6 +500,7 @@ private:
     bool _cleanupCalled = false;
     bool _failureContextDumped = false;
     bool _standalone = false;
+    bool _strictLogCheck = false;
 };
 
 // ============================================================================

--- a/tools/generators/settings_qml/generate_pages.py
+++ b/tools/generators/settings_qml/generate_pages.py
@@ -70,7 +70,7 @@ def main() -> int:
             continue
 
         page = load_page_def(page_def_path)
-        qml = generate_page_qml(page, SETTINGS_DIR, json_context=page_def_name)
+        qml = generate_page_qml(page, SETTINGS_DIR, json_context=page_def_name, page_name=entry.get("name", ""))
 
         if args.dry_run:
             print(f"=== {qml_name} ===")

--- a/tools/generators/settings_qml/page_generator.py
+++ b/tools/generators/settings_qml/page_generator.py
@@ -429,7 +429,7 @@ def _needs_string_field_width(page: PageDef, settings_dir: Path) -> bool:
     return False
 
 
-def generate_page_qml(page: PageDef, settings_dir: Path, json_context: str = "") -> str:
+def generate_page_qml(page: PageDef, settings_dir: Path, json_context: str = "", page_name: str = "") -> str:
     """Generate a complete QML settings page from a page definition."""
     _tr = (lambda s: f'qsTranslate("{json_context}", "{s}")') if json_context else (lambda s: f'qsTr("{s}")')
     has_string_fields = _needs_string_field_width(page, settings_dir)
@@ -450,6 +450,9 @@ def generate_page_qml(page: PageDef, settings_dir: Path, json_context: str = "")
 
     # Root element
     lines.append("SettingsPage {")
+    if page_name:
+        object_name = page_name.replace(" ", "")
+        lines.append(f'    objectName: "settingsPage_{object_name}"')
     if has_string_fields:
         lines.append("    property real _stringFieldWidth: ScreenTools.defaultFontPixelWidth * 30")
 
@@ -659,6 +662,7 @@ def generate_pages_model_qml(pages_json_path: Path) -> str:
         lines.append("")
         lines.append("    ListElement {")
         lines.append(f'        name: qsTranslate("SettingsPages.json", "{name}")')
+        lines.append(f'        nameKey: "{name}"')
         lines.append(f'        url: "{url}"')
         lines.append(f'        iconUrl: "{icon}"')
         lines.append(f"        sections: '{sections_json}'")

--- a/tools/tests/test_settings_qml_generator.py
+++ b/tools/tests/test_settings_qml_generator.py
@@ -196,6 +196,20 @@ class TestGeneratePageQml:
         assert "SettingsPage {" in qml
         assert qml.rstrip().endswith("}")
 
+    def test_page_name_emits_object_name(self, settings_dir: Path):
+        page = PageDef(groups=[
+            GroupDef(heading="G", controls=[ControlDef(setting="appSettings.enableFeature")]),
+        ])
+        qml = generate_page_qml(page, settings_dir, page_name="Fly View")
+        assert 'objectName: "settingsPage_FlyView"' in qml
+
+    def test_page_name_empty_no_object_name(self, settings_dir: Path):
+        page = PageDef(groups=[
+            GroupDef(heading="G", controls=[ControlDef(setting="appSettings.enableFeature")]),
+        ])
+        qml = generate_page_qml(page, settings_dir, page_name="")
+        assert "objectName:" not in qml
+
     def test_bool_generates_checkbox(self, settings_dir: Path):
         page = PageDef(groups=[
             GroupDef(controls=[ControlDef(setting="appSettings.enableFeature")]),
@@ -515,6 +529,7 @@ class TestGeneratePagesModelQml:
     def test_page_entry(self, pages_setup: Path):
         qml = generate_pages_model_qml(pages_setup)
         assert 'name: qsTranslate("SettingsPages.json", "Test Page")' in qml
+        assert 'nameKey: "Test Page"' in qml
         assert "qrc:/qml/QGroundControl/AppSettings/TestPage.qml" in qml
         assert "qrc:/test.svg" in qml
 


### PR DESCRIPTION
## Summary

Adds `TopLevelViewsTest` — a UI smoke test that exercises navigating all top-level views (Fly, Plan, Configure, Analyze, Settings) and iterates through every settings page verifying each loads correctly.

## Changes

### Test (`test/QmlUITests/TopLevelViewsTest.cc`)
- Navigates all views via the toolbar dropdown and verifies correct view visibility
- Iterates all settings pages, scrolling the button list as needed, and verifies each page loads with the expected `objectName`
- Uses 50ms polling instead of fixed waits for ~2x faster execution (~10s vs ~22s)

### Consistent objectName convention (QML files)
- `toolbar_` — toolbar buttons (logo, view selectors)
- `mainView_` — top-level views (fly, plan, toolDrawer)
- `settings_` — settings chrome (buttonList, rightPanel)
- `settingsButton_` — settings navigation buttons
- `settingsPage_` — settings page content areas

### UnitTest base class (`test/UnitTestFramework/UnitTest.h/.cc`)
- `findVisibleItem()` — static utility that polls the QML visual tree for a visible item by objectName with configurable timeout

### `--onscreen` option (`cmake/QGCTest.cmake`, `QGCCommandLineParser`, `Platform.cc`)
- `QGC_TEST_ONSCREEN` CMake option skips `QT_QPA_PLATFORM=offscreen` and passes `--onscreen` to the test executable
- Useful for visually observing UI tests during development

### Settings generator (`tools/generators/settings_qml/`)
- `generate_page_qml()` emits `objectName: "settingsPage_<Name>"` when `page_name` is provided
