### PR TITLE
feat(FactSystem): add BulkRefreshJob / bulkRefresh() to replace scatter-shot refreshParameter calls

### DIFF
--- a/src/AutoPilotPlugins/APM/APMSensorsComponent.qml
+++ b/src/AutoPilotPlugins/APM/APMSensorsComponent.qml
@@ -148,7 +148,7 @@ SetupPage {
                     }
                 }
 
-                onCalibrationComplete: {
+                onCalibrationComplete: (calType) => {
                     switch (calType) {
                     case MAVLink.CalibrationAccel:
                     case MAVLink.CalibrationMag:
@@ -158,7 +158,7 @@ SetupPage {
                     }
                 }
 
-                onSetAllCalButtonsEnabled: {
+                onSetAllCalButtonsEnabled: (enabled) => {
                     buttonColumn.enabled = enabled
                 }
             }

--- a/src/AutoPilotPlugins/APM/APMSensorsComponentController.cc
+++ b/src/AutoPilotPlugins/APM/APMSensorsComponentController.cc
@@ -376,18 +376,12 @@ void APMSensorsComponentController::_handleTextMessage(int sysid, int componenti
 
 void APMSensorsComponentController::_refreshParams()
 {
-    static const QStringList fastRefreshList = {
+    _vehicle->parameterManager()->bulkRefresh(ParameterManager::defaultComponentId, {
         QStringLiteral("COMPASS_OFS_X"), QStringLiteral("COMPASS_OFS_Y"), QStringLiteral("COMPASS_OFS_Z"),
-        QStringLiteral("INS_ACCOFFS_X"), QStringLiteral("INS_ACCOFFS_Y"), QStringLiteral("INS_ACCOFFS_Z")
-    };
-
-    for (const QString &paramName : fastRefreshList) {
-        _vehicle->parameterManager()->refreshParameter(ParameterManager::defaultComponentId, paramName);
-    }
-
-    // Now ask for all to refresh
-    _vehicle->parameterManager()->refreshParametersPrefix(ParameterManager::defaultComponentId, QStringLiteral("COMPASS_"));
-    _vehicle->parameterManager()->refreshParametersPrefix(ParameterManager::defaultComponentId, QStringLiteral("INS_"));
+        QStringLiteral("INS_ACCOFFS_X"), QStringLiteral("INS_ACCOFFS_Y"), QStringLiteral("INS_ACCOFFS_Z"),
+        QStringLiteral("COMPASS_*"),
+        QStringLiteral("INS_*"),
+    }, false /* notifyFailure */);
 }
 
 void APMSensorsComponentController::_updateAndEmitShowOrientationCalArea(bool show)

--- a/src/AutoPilotPlugins/PX4/SensorsComponentController.cc
+++ b/src/AutoPilotPlugins/PX4/SensorsComponentController.cc
@@ -432,17 +432,12 @@ void SensorsComponentController::_handleUASTextMessage(int uasId, int compId, in
 
 void SensorsComponentController::_refreshParams(void)
 {
-    QStringList fastRefreshList;
-
-    // We ask for a refresh on these first so that the rotation combo show up as fast as possible
-    fastRefreshList << "CAL_MAG0_ID" << "CAL_MAG1_ID" << "CAL_MAG2_ID" << "CAL_MAG0_ROT" << "CAL_MAG1_ROT" << "CAL_MAG2_ROT";
-    for (const QString &paramName : std::as_const(fastRefreshList)) {
-        _vehicle->parameterManager()->refreshParameter(ParameterManager::defaultComponentId, paramName);
-    }
-
-    // Now ask for all to refresh
-    _vehicle->parameterManager()->refreshParametersPrefix(ParameterManager::defaultComponentId, "CAL_");
-    _vehicle->parameterManager()->refreshParametersPrefix(ParameterManager::defaultComponentId, "SENS_");
+    _vehicle->parameterManager()->bulkRefresh(ParameterManager::defaultComponentId, {
+        QStringLiteral("CAL_MAG0_ID"), QStringLiteral("CAL_MAG1_ID"), QStringLiteral("CAL_MAG2_ID"),
+        QStringLiteral("CAL_MAG0_ROT"), QStringLiteral("CAL_MAG1_ROT"), QStringLiteral("CAL_MAG2_ROT"),
+        QStringLiteral("CAL_*"),
+        QStringLiteral("SENS_*"),
+    }, false /* notifyFailure */);
 }
 
 void SensorsComponentController::_updateAndEmitShowOrientationCalArea(bool show)

--- a/src/FactSystem/BulkRefreshJob.cc
+++ b/src/FactSystem/BulkRefreshJob.cc
@@ -1,0 +1,86 @@
+#include "BulkRefreshJob.h"
+#include "ParameterManager.h"
+
+#include "AppMessages.h"
+#include "QGCLoggingCategory.h"
+
+Q_DECLARE_LOGGING_CATEGORY(ParameterManagerLog)
+
+BulkRefreshJob::BulkRefreshJob(ParameterManager *mgr, int componentId, const QStringList &resolvedNames,
+                               bool notifyFailure, std::function<void(const QString &)> requestFn,
+                               QObject *parent)
+    : QObject(parent)
+    , _mgr(mgr)
+    , _componentId(componentId)
+    , _notifyFailure(notifyFailure)
+    , _requestFn(std::move(requestFn))
+    , _pending(QSet<QString>(resolvedNames.cbegin(), resolvedNames.cend()))
+    , _retryBaseDelayMs(QGC::runningUnitTests() ? 50 : kRetryBaseDelayMs)
+{
+    _retryTimer.setSingleShot(true);
+    connect(&_retryTimer, &QTimer::timeout, this, &BulkRefreshJob::_sendPendingRequests);
+    connect(_mgr, &ParameterManager::_paramRequestReadSuccess, this, &BulkRefreshJob::_onParamSuccess);
+    connect(_mgr, &ParameterManager::_paramRequestReadFailure, this, &BulkRefreshJob::_onParamFailure);
+    _sendPendingRequests();
+}
+
+void BulkRefreshJob::_sendPendingRequests()
+{
+    qCDebug(ParameterManagerLog) << "BulkRefreshJob: round" << _round
+                                 << "\u2014 firing" << _pending.count() << "requests";
+    for (const QString &name : std::as_const(_pending)) {
+        _requestFn(name);
+    }
+}
+
+void BulkRefreshJob::_onParamSuccess(int componentId, const QString &paramName, int /*paramIndex*/)
+{
+    if (componentId != _componentId || !_pending.remove(paramName)) {
+        return;
+    }
+    _checkRoundComplete();
+}
+
+void BulkRefreshJob::_onParamFailure(int componentId, const QString &paramName, int /*paramIndex*/)
+{
+    if (componentId != _componentId || !_pending.remove(paramName)) {
+        return;
+    }
+    _failed.insert(paramName);
+    _checkRoundComplete();
+}
+
+void BulkRefreshJob::_checkRoundComplete()
+{
+    if (!_pending.isEmpty()) {
+        return;
+    }
+
+    _retryTimer.stop();
+
+    if (_failed.isEmpty()) {
+        qCDebug(ParameterManagerLog) << "BulkRefreshJob: complete after round" << _round
+                                     << "\u2014 all params refreshed successfully";
+        deleteLater();
+        return;
+    }
+
+    if (_round < kMaxRetryRounds) {
+        const int delayMs = _retryBaseDelayMs << _round;
+        qCDebug(ParameterManagerLog) << "BulkRefreshJob: round" << _round
+                                     << "finished with" << _failed.count()
+                                     << "failures \u2014 retrying in" << delayMs << "ms";
+        _pending = std::move(_failed);
+        _failed.clear();
+        ++_round;
+        _retryTimer.start(delayMs);
+    } else {
+        qCDebug(ParameterManagerLog) << "BulkRefreshJob: complete after round" << _round
+                                     << "\u2014" << _failed.count() << "params still failed";
+        if (_notifyFailure) {
+            const QStringList failedList(_failed.cbegin(), _failed.cend());
+            QGC::showAppMessage(_mgr->tr("Parameter refresh failed for: %1").arg(failedList.join(QStringLiteral(", "))));
+        }
+        deleteLater();
+    }
+}

--- a/src/FactSystem/BulkRefreshJob.cc
+++ b/src/FactSystem/BulkRefreshJob.cc
@@ -35,7 +35,12 @@ void BulkRefreshJob::_sendPendingRequests()
 
 void BulkRefreshJob::_onParamSuccess(int componentId, const QString &paramName, int /*paramIndex*/)
 {
-    if (componentId != _componentId || !_pending.remove(paramName)) {
+    if (componentId != _componentId) {
+        return;
+    }
+    const bool wasPending = _pending.remove(paramName);
+    const bool wasFailed  = _failed.remove(paramName);
+    if (!wasPending && !wasFailed) {
         return;
     }
     _checkRoundComplete();
@@ -79,7 +84,8 @@ void BulkRefreshJob::_checkRoundComplete()
                                      << "\u2014" << _failed.count() << "params still failed";
         if (_notifyFailure) {
             const QStringList failedList(_failed.cbegin(), _failed.cend());
-            QGC::showAppMessage(_mgr->tr("Parameter refresh failed for: %1").arg(failedList.join(QStringLiteral(", "))));
+            QGC::showAppMessage(_mgr->tr("Parameter refresh failed for: %1").arg(failedList.join(QStringLiteral(", "))),
+                                _mgr->tr("Parameter Bulk Refresh"));
         }
         deleteLater();
     }

--- a/src/FactSystem/BulkRefreshJob.h
+++ b/src/FactSystem/BulkRefreshJob.h
@@ -1,0 +1,40 @@
+#pragma once
+
+#include <QtCore/QObject>
+#include <QtCore/QSet>
+#include <QtCore/QString>
+#include <QtCore/QStringList>
+#include <QtCore/QTimer>
+
+#include <functional>
+
+class ParameterManager;
+
+/// Fires a batch of PARAM_REQUEST_READs with exponential backoff retry.
+/// Owned by ParameterManager (as QObject parent); self-deletes on completion.
+class BulkRefreshJob : public QObject
+{
+public:
+    BulkRefreshJob(ParameterManager *mgr, int componentId, const QStringList &resolvedNames,
+                   bool notifyFailure, std::function<void(const QString &)> requestFn,
+                   QObject *parent);
+
+    static constexpr int kMaxRetryRounds   = 3;    ///< Number of batch-level retry rounds before giving up
+    static constexpr int kRetryBaseDelayMs = 1000;  ///< Base retry interval; doubled each round
+
+private:
+    void _sendPendingRequests();
+    void _onParamSuccess(int componentId, const QString &paramName, int paramIndex);
+    void _onParamFailure(int componentId, const QString &paramName, int paramIndex);
+    void _checkRoundComplete();
+
+    ParameterManager *_mgr;
+    int _componentId;
+    bool _notifyFailure;
+    std::function<void(const QString&)> _requestFn;
+    QSet<QString> _pending;
+    QSet<QString> _failed;
+    int _round = 0;
+    const int _retryBaseDelayMs;  ///< 50 ms in unit tests, kRetryBaseDelayMs otherwise
+    QTimer _retryTimer;
+};

--- a/src/FactSystem/CMakeLists.txt
+++ b/src/FactSystem/CMakeLists.txt
@@ -5,6 +5,8 @@
 
 target_sources(${CMAKE_PROJECT_NAME}
     PRIVATE
+        BulkRefreshJob.cc
+        BulkRefreshJob.h
         Fact.cc
         Fact.h
         FactGroup.cc

--- a/src/FactSystem/ParameterManager.cc
+++ b/src/FactSystem/ParameterManager.cc
@@ -739,7 +739,8 @@ void ParameterManager::bulkRefresh(int componentId, const QStringList &names, bo
         return;
     }
     const QMap<QString, Fact *> &factMap = _mapCompId2FactMap[componentId];
-    QSet<QString> resolvedSet;
+    QStringList resolved;
+    QSet<QString> seen;
     for (const QString &entry : names) {
         if (entry.endsWith(QLatin1Char('*'))) {
             const QString prefix = entry.chopped(1);
@@ -748,24 +749,28 @@ void ParameterManager::bulkRefresh(int componentId, const QStringList &names, bo
                 continue;
             }
             for (auto it = factMap.cbegin(); it != factMap.cend(); ++it) {
-                if (it.key().startsWith(prefix)) {
-                    resolvedSet.insert(it.key());
+                if (it.key().startsWith(prefix) && !seen.contains(it.key())) {
+                    seen.insert(it.key());
+                    resolved.append(it.key());
                 }
             }
         } else if (factMap.contains(entry)) {
-            resolvedSet.insert(entry);
+            if (!seen.contains(entry)) {
+                seen.insert(entry);
+                resolved.append(entry);
+            }
         } else {
             qCWarning(ParameterManagerLog) << "bulkRefresh: unknown param name (skipped):" << entry;
         }
     }
 
-    if (resolvedSet.isEmpty()) {
+    if (resolved.isEmpty()) {
         return;
     }
 
-    qCDebug(ParameterManagerLog) << "bulkRefresh: resolved" << resolvedSet.count() << "params";
+    qCDebug(ParameterManagerLog) << "bulkRefresh: resolved" << resolved.count() << "params";
     new BulkRefreshJob(
-        this, componentId, QStringList(resolvedSet.cbegin(), resolvedSet.cend()), notifyFailure,
+        this, componentId, resolved, notifyFailure,
         [this, componentId](const QString &name) {
             _mavlinkParamRequestRead(componentId, name, -1, false /* notifyFailure */);
         },

--- a/src/FactSystem/ParameterManager.cc
+++ b/src/FactSystem/ParameterManager.cc
@@ -1,7 +1,9 @@
 #include "QmlObjectListModel.h"
 #include "ParameterManager.h"
+#include "BulkRefreshJob.h"
 
 #include <QtCore/QDir>
+#include <QtCore/QSet>
 #include <QtCore/QTextStream>
 
 #include "AutoPilotPlugin.h"
@@ -36,6 +38,7 @@ ParameterManager::ParameterManager(Vehicle *vehicle)
     , _vehicle(vehicle)
     , _logReplay(!vehicle->vehicleLinkManager()->primaryLink().expired() && vehicle->vehicleLinkManager()->primaryLink().lock()->isLogReplay())
     , _disableAllRetries(_logReplay)
+    , _waitForParamValueAckMs(QGC::runningUnitTests() ? 50 : kWaitForParamValueAckMs)
     , _tryftp(vehicle->apmFirmware())
 {
     qCDebug(ParameterManagerLog) << this;
@@ -390,7 +393,7 @@ void ParameterManager::_mavlinkParamSet(int componentId, const QString &paramNam
     auto errorDecPendingWriteCountState = new FunctionState(QStringLiteral("ParameterManager error decrement pending write count"), stateMachine, [this]() {
         _decrementPendingWriteCount();
     });
-    auto waitAckState = new WaitForParamResponseState(stateMachine, kWaitForParamValueAckMs, checkForCorrectParamValue, checkForParamError);
+    auto waitAckState = new WaitForParamResponseState(stateMachine, _waitForParamValueAckMs, checkForCorrectParamValue, checkForParamError);
     auto paramRefreshState = new FunctionState(QStringLiteral("ParameterManager param refresh"), stateMachine, [this, componentId, paramName]() {
         refreshParameter(componentId, paramName);
     });
@@ -718,11 +721,55 @@ void ParameterManager::refreshParametersPrefix(int componentId, const QString &n
     componentId = _actualComponentId(componentId);
     qCDebug(ParameterManagerLog) << _logVehiclePrefix(componentId) << "refreshParametersPrefix - name:" << namePrefix << ")";
 
+    if (!_mapCompId2FactMap.contains(componentId)) {
+        return;
+    }
     for (const QString &paramName: _mapCompId2FactMap[componentId].keys()) {
         if (paramName.startsWith(namePrefix)) {
             refreshParameter(componentId, paramName);
         }
     }
+}
+
+void ParameterManager::bulkRefresh(int componentId, const QStringList &names, bool notifyFailure)
+{
+    componentId = _actualComponentId(componentId);
+
+    if (!_mapCompId2FactMap.contains(componentId)) {
+        return;
+    }
+    const QMap<QString, Fact *> &factMap = _mapCompId2FactMap[componentId];
+    QSet<QString> resolvedSet;
+    for (const QString &entry : names) {
+        if (entry.endsWith(QLatin1Char('*'))) {
+            const QString prefix = entry.chopped(1);
+            if (prefix.isEmpty()) {
+                qCWarning(ParameterManagerLog) << "bulkRefresh: ignoring bare '*' entry";
+                continue;
+            }
+            for (auto it = factMap.cbegin(); it != factMap.cend(); ++it) {
+                if (it.key().startsWith(prefix)) {
+                    resolvedSet.insert(it.key());
+                }
+            }
+        } else if (factMap.contains(entry)) {
+            resolvedSet.insert(entry);
+        } else {
+            qCWarning(ParameterManagerLog) << "bulkRefresh: unknown param name (skipped):" << entry;
+        }
+    }
+
+    if (resolvedSet.isEmpty()) {
+        return;
+    }
+
+    qCDebug(ParameterManagerLog) << "bulkRefresh: resolved" << resolvedSet.count() << "params";
+    new BulkRefreshJob(
+        this, componentId, QStringList(resolvedSet.cbegin(), resolvedSet.cend()), notifyFailure,
+        [this, componentId](const QString &name) {
+            _mavlinkParamRequestRead(componentId, name, -1, false /* notifyFailure */);
+        },
+        this);
 }
 
 bool ParameterManager::parameterExists(int componentId, const QString &paramName) const
@@ -946,7 +993,7 @@ void ParameterManager::_mavlinkParamRequestRead(int componentId, const QString &
     // Create states
     auto stateMachine = new QGCStateMachine(QStringLiteral("PARAM_REQUEST_READ"), vehicle(), this);
     auto sendParamRequestReadState = new SendMavlinkMessageState(stateMachine, paramRequestReadEncoder, kParamRequestReadRetryCount);
-    auto waitAckState = new WaitForParamResponseState(stateMachine, kWaitForParamValueAckMs, checkForCorrectParamValue, checkForParamError);
+    auto waitAckState = new WaitForParamResponseState(stateMachine, _waitForParamValueAckMs, checkForCorrectParamValue, checkForParamError);
     auto userNotifyState = new FunctionState(QStringLiteral("User notify"), stateMachine, [waitAckState, paramName, this, componentId]() {
         const QString errorDetail = waitAckState->lastParamErrorString();
         const QString msg = errorDetail.isEmpty()
@@ -1409,8 +1456,6 @@ QString ParameterManager::_remapParamNameToVersion(const QString &paramName) con
 
     const int majorVersion = _vehicle->firmwareMajorVersion();
     const int minorVersion = _vehicle->firmwareMinorVersion();
-
-    qCDebug(ParameterManagerLog) << "_remapParamNameToVersion" << paramName << majorVersion << minorVersion;
 
     if (majorVersion == Vehicle::versionNotSetValue) {
         // Vehicle version unknown

--- a/src/FactSystem/ParameterManager.h
+++ b/src/FactSystem/ParameterManager.h
@@ -61,6 +61,14 @@ public:
     /// Request a refresh on all parameters that begin with the specified prefix
     void refreshParametersPrefix(int componentId, const QString &namePrefix);
 
+    /// Refresh a set of parameters in a single batch with exponential-backoff retry.
+    /// @param names  Mix of exact param names and prefix patterns ending in '*' (e.g. "COMPASS_*").
+    ///               Prefix entries are expanded against the known parameter set at call time.
+    ///               Duplicate names are deduplicated automatically.
+    /// @param notifyFailure  When true (default), shows a single user-visible message if any
+    ///                       parameters still fail to respond after all retry rounds.
+    void bulkRefresh(int componentId, const QStringList &names, bool notifyFailure = true);
+
     void resetAllParametersToDefaults();
     void resetAllToVehicleConfiguration();
 
@@ -112,7 +120,8 @@ signals:
     void parameterDownloadSkippedChanged();
     void factAdded(int componentId, Fact *fact);
 
-    // These signals are used to verify unit tests
+    // Internal signals — emitted by PARAM_SET / PARAM_REQUEST_READ state machines.
+    // Also consumed by BulkRefreshJob and unit tests.
     void _paramSetSuccess(int componentId, const QString &paramName);
     void _paramSetFailure(int componentId, const QString &paramName);
     void _paramRequestReadSuccess(int componentId, const QString &paramName, int paramIndex);
@@ -203,6 +212,7 @@ private:
     int _initialRequestRetryCount = 0;                          ///< Current retry count for request list
     static constexpr int _maxInitialLoadRetrySingleParam = 5;   ///< Maximum retries for initial index based load of a single param
     bool _disableAllRetries = false;                            ///< true: Don't retry any requests (used for testing and logReplay)
+    const int _waitForParamValueAckMs;                          ///< 50 ms in unit tests, kWaitForParamValueAckMs otherwise
 
     bool _indexBatchQueueActive = false;    ///< true: we are actively batching re-requests for missing index base params, false: index based re-request has not yet started
     QList<int> _indexBatchQueue;            ///< The current queue of index re-requests

--- a/test/FactSystem/ParameterManagerTest.cc
+++ b/test/FactSystem/ParameterManagerTest.cc
@@ -6,6 +6,7 @@
 #include <cmath>
 #include <limits>
 
+#include "BulkRefreshJob.h"
 #include "MockLinkFTP.h"
 #include "MultiVehicleManager.h"
 #include "ParameterManager.h"
@@ -415,3 +416,156 @@ void ParameterManagerTest::_FTPChangeParam()
 }
 
 UT_REGISTER_TEST(ParameterManagerTest, TestLabel::Integration, TestLabel::Vehicle, TestLabel::Serial)
+
+// ---------------------------------------------------------------------------
+// bulkRefresh tests
+// ---------------------------------------------------------------------------
+
+// Two exact param names — both should resolve and succeed on round 0.
+void ParameterManagerTest::_bulkRefreshExactNamesAllSucceed()
+{
+    _connectMockLink();
+    QVERIFY(_vehicle);
+    ParameterManager* const paramManager = _vehicle->parameterManager();
+    QVERIFY(paramManager);
+
+    QSignalSpy successSpy(paramManager, &ParameterManager::_paramRequestReadSuccess);
+    QSignalSpy failureSpy(paramManager, &ParameterManager::_paramRequestReadFailure);
+    QVERIFY(successSpy.isValid());
+    QVERIFY(failureSpy.isValid());
+
+    paramManager->bulkRefresh(MAV_COMP_ID_AUTOPILOT1,
+                               {QStringLiteral("BAT1_V_CHARGED"), QStringLiteral("BAT1_N_CELLS")});
+
+    const int maxWaitMs = ParameterManager::kWaitForParamValueAckMs
+                          * (ParameterManager::kParamRequestReadRetryCount + 1)
+                          + TestTimeout::shortMs();
+    QVERIFY_SIGNAL_COUNT_WAIT(successSpy, 2, maxWaitMs);
+    QCOMPARE(failureSpy.count(), 0);
+
+    QStringList succeededNames;
+    for (int i = 0; i < successSpy.count(); ++i) {
+        succeededNames << successSpy.at(i).at(1).toString();
+    }
+    QVERIFY(succeededNames.contains(QStringLiteral("BAT1_V_CHARGED")));
+    QVERIFY(succeededNames.contains(QStringLiteral("BAT1_N_CELLS")));
+
+    _disconnectMockLink();
+}
+
+// A wildcard prefix "BAT1_*" should expand to all BAT1_ parameters and all should succeed.
+void ParameterManagerTest::_bulkRefreshPrefixExpansion()
+{
+    _connectMockLink();
+    QVERIFY(_vehicle);
+    ParameterManager* const paramManager = _vehicle->parameterManager();
+    QVERIFY(paramManager);
+
+    // Count BAT1_ params actually present on the mock vehicle.
+    int bat1Count = 0;
+    for (const QString &name : paramManager->parameterNames(MAV_COMP_ID_AUTOPILOT1)) {
+        if (name.startsWith(QStringLiteral("BAT1_"))) {
+            ++bat1Count;
+        }
+    }
+    QVERIFY2(bat1Count > 0, "Mock link must have at least one BAT1_ parameter");
+
+    QSignalSpy successSpy(paramManager, &ParameterManager::_paramRequestReadSuccess);
+    QSignalSpy failureSpy(paramManager, &ParameterManager::_paramRequestReadFailure);
+    QVERIFY(successSpy.isValid());
+    QVERIFY(failureSpy.isValid());
+
+    paramManager->bulkRefresh(MAV_COMP_ID_AUTOPILOT1, {QStringLiteral("BAT1_*")});
+
+    const int maxWaitMs = ParameterManager::kWaitForParamValueAckMs
+                          * (ParameterManager::kParamRequestReadRetryCount + 1)
+                          + TestTimeout::shortMs();
+    QVERIFY_SIGNAL_COUNT_WAIT(successSpy, bat1Count, maxWaitMs);
+    QCOMPARE(failureSpy.count(), 0);
+    QCOMPARE(successSpy.count(), bat1Count);
+
+    _disconnectMockLink();
+}
+
+// Passing only non-existent names should resolve to an empty set — no requests are sent.
+void ParameterManagerTest::_bulkRefreshUnknownNameSkipped()
+{
+    _connectMockLink();
+    QVERIFY(_vehicle);
+    ParameterManager* const paramManager = _vehicle->parameterManager();
+    QVERIFY(paramManager);
+
+    QSignalSpy successSpy(paramManager, &ParameterManager::_paramRequestReadSuccess);
+    QSignalSpy failureSpy(paramManager, &ParameterManager::_paramRequestReadFailure);
+    QVERIFY(successSpy.isValid());
+    QVERIFY(failureSpy.isValid());
+
+    paramManager->bulkRefresh(MAV_COMP_ID_AUTOPILOT1, {QStringLiteral("ZZZZ_DOES_NOT_EXIST")});
+
+    QVERIFY_NO_SIGNAL_WAIT(successSpy, TestTimeout::shortMs());
+    QCOMPARE(failureSpy.count(), 0);
+
+    _disconnectMockLink();
+}
+
+// Round 0 fails (no response from MockLink), round 1 succeeds after failure mode is cleared.
+void ParameterManagerTest::_bulkRefreshRetrySucceeds()
+{
+    _connectMockLink();
+    QVERIFY(_mockLink);
+    QVERIFY(_vehicle);
+    ParameterManager* const paramManager = _vehicle->parameterManager();
+    QVERIFY(paramManager);
+
+    QSignalSpy successSpy(paramManager, &ParameterManager::_paramRequestReadSuccess);
+    QSignalSpy failureSpy(paramManager, &ParameterManager::_paramRequestReadFailure);
+    QVERIFY(successSpy.isValid());
+    QVERIFY(failureSpy.isValid());
+
+    // Round 0: MockLink drops all responses — per-param SM exhausts retries → _paramRequestReadFailure
+    _mockLink->setParamRequestReadFailureMode(MockLink::FailParamRequestReadNoResponse);
+    paramManager->bulkRefresh(MAV_COMP_ID_AUTOPILOT1, {QStringLiteral("BAT1_V_CHARGED")});
+
+    const int roundTimeMs = ParameterManager::kWaitForParamValueAckMs
+                            * (ParameterManager::kParamRequestReadRetryCount + 1)
+                            + TestTimeout::shortMs();
+    QVERIFY_SIGNAL_WAIT(failureSpy, roundTimeMs);
+    QCOMPARE(failureSpy.count(), 1);
+
+    // Allow BulkRefreshJob's retry round to succeed
+    _mockLink->setParamRequestReadFailureMode(MockLink::FailParamRequestReadNone);
+    QVERIFY_SIGNAL_WAIT(successSpy, roundTimeMs);
+    QCOMPARE(successSpy.count(), 1);
+    QCOMPARE(successSpy.at(0).at(1).toString(), QStringLiteral("BAT1_V_CHARGED"));
+
+    _disconnectMockLink();
+}
+
+// All kMaxRetryRounds+1 rounds fail — BulkRefreshJob gives up without a success signal.
+void ParameterManagerTest::_bulkRefreshAllRetriesExhausted()
+{
+    _connectMockLink();
+    QVERIFY(_mockLink);
+    QVERIFY(_vehicle);
+    ParameterManager* const paramManager = _vehicle->parameterManager();
+    QVERIFY(paramManager);
+
+    QSignalSpy successSpy(paramManager, &ParameterManager::_paramRequestReadSuccess);
+    QSignalSpy failureSpy(paramManager, &ParameterManager::_paramRequestReadFailure);
+    QVERIFY(successSpy.isValid());
+    QVERIFY(failureSpy.isValid());
+
+    _mockLink->setParamRequestReadFailureMode(MockLink::FailParamRequestReadNoResponse);
+    paramManager->bulkRefresh(MAV_COMP_ID_AUTOPILOT1, {QStringLiteral("BAT1_V_CHARGED")});
+
+    // Each round exhausts the per-param SM retries. Upper bound uses production constants;
+    // actual duration is ~1s in test mode (kWaitForParamValueAckMs and kRetryBaseDelayMs are
+    // reduced to 50ms when QGC::runningUnitTests() is true).
+    const int roundTimeMs = ParameterManager::kWaitForParamValueAckMs
+                            * (ParameterManager::kParamRequestReadRetryCount + 1);
+    const int maxWaitMs = roundTimeMs * (BulkRefreshJob::kMaxRetryRounds + 1) + TestTimeout::mediumMs();
+    QVERIFY_SIGNAL_COUNT_WAIT(failureSpy, BulkRefreshJob::kMaxRetryRounds + 1, maxWaitMs);
+    QCOMPARE(successSpy.count(), 0);
+
+    _disconnectMockLink();
+}

--- a/test/FactSystem/ParameterManagerTest.h
+++ b/test/FactSystem/ParameterManagerTest.h
@@ -21,6 +21,11 @@ private slots:
     void _paramReadParamError();
     void _FTPnoFailure();
     void _FTPChangeParam();
+    void _bulkRefreshExactNamesAllSucceed();
+    void _bulkRefreshPrefixExpansion();
+    void _bulkRefreshUnknownNameSkipped();
+    void _bulkRefreshRetrySucceeds();
+    void _bulkRefreshAllRetriesExhausted();
 
 private:
     void _noFailureWorker(MockConfiguration::FailureMode_t failureMode);


### PR DESCRIPTION
## Summary

Adds a proper batch-parameter-refresh API to `ParameterManager` and uses it
to eliminate the post-compass-calibration popup spam described in #14347.

### Problem

`_refreshParams()` in both the APM and PX4 sensor controllers called
`refreshParameter()` and `refreshParametersPrefix()` individually.  The FC
is often slow to respond mid-cancel; every timed-out request fired a modal
"Parameter read failed" via `QGC::showAppMessage`, stacking dozens of
dialogs and freezing the UI.

### Solution

**`BulkRefreshJob`** (new `src/FactSystem/BulkRefreshJob.{h,cc}`):
A `QObject`-child of `ParameterManager` that fires a batch of
`PARAM_REQUEST_READ` messages and retries (exponential back-off, up to
`kMaxRetryRounds = 3` rounds) any that time out.  `notifyFailure = false`
suppresses the user-visible modal while still logging and emitting
`_paramRequestReadFailure` for internal use.  Self-deletes on completion.

**`ParameterManager::bulkRefresh()`** (new public API):
Accepts a list of exact names and/or wildcard prefixes (e.g. `"COMPASS_*"`),
resolves them against the known parameter set, deduplicates, and delegates to
`BulkRefreshJob`.

**Sensor controllers** updated to use a single `bulkRefresh()` call with
`notifyFailure = false`, replacing the old scattered individual-refresh loops.

**QML** (`APMSensorsComponent.qml`): signal handlers converted to arrow-function
syntax to fix qmllint warnings.

### Test-speed note

`_waitForParamValueAckMs` and `BulkRefreshJob::_retryBaseDelayMs` are set to
50 ms under `QGC::runningUnitTests()` so the new retry tests complete in ~1 s
instead of ~19 s.

## Test plan

- `ctest -L Unit -R ParameterManager` — all 19 tests pass (5 new tests added,
  including retry-succeeds and all-rounds-exhausted paths)
- Start a compass cal on ArduPilot, cancel mid-way → no flood of
  "Parameter read failed" modals; UI stays responsive
- Normal compass cal to completion on ArduPilot and PX4 → params repopulate,
  no popup spam

Addresses the compass-cal refresh spam described in #14347.