### PR TITLE
fix(Terrain): back off after failed tile fetches to stop warning spam

### DIFF
--- a/src/Terrain/TerrainTileManager.cc
+++ b/src/Terrain/TerrainTileManager.cc
@@ -10,6 +10,7 @@
 #include "QGCLoggingCategory.h"
 #include "QGCGeo.h"
 
+#include <QtCore/QDateTime>
 #include <QtLocation/private/qgeotilespec_p.h>
 #include <QtNetwork/QNetworkAccessManager>
 #include <QtNetwork/QNetworkRequest>
@@ -72,6 +73,11 @@ bool TerrainTileManager::getAltitudesForCoordinates(const QList<QGeoCoordinate> 
                 qCDebug(TerrainTileManagerLog) << "returning elevation from tile cache" << elevation;
             }
             altitudes.push_back(elevation);
+        } else if (_isFailedTile(tileHash)) {
+            // Tile fetch failed recently; short-circuit to avoid hammering the server with repeated requests
+            // (e.g. uninitialized 0,0 coordinates from MAVLink TERRAIN_REQUEST returning HTTP 500).
+            error = true;
+            altitudes.push_back(qQNaN());
         } else if (_state != TerrainQuery::State::Downloading) {
             QGeoTileSpec spec;
             spec.setX(provider->long2tileX(coordinate.longitude(), 1));
@@ -295,21 +301,36 @@ void TerrainTileManager::_terrainDone()
     const QByteArray responseBytes = reply->mapImageData();
     const QGeoTileSpec spec = reply->tileSpec();
 
+    const QString hash = UrlFactory::getTileHash(UrlFactory::getProviderTypeFromQtMapId(spec.mapId()), spec.x(), spec.y(), spec.zoom());
+
     if (reply->error() != QGeoTiledMapReplyQGC::NoError) {
-        qCWarning(TerrainTileManagerLog) << "Elevation tile fetching returned error:" << reply->errorString();
+        const bool firstFailure = !_failedTiles.contains(hash);
+        _failedTiles.insert(hash, QDateTime::currentMSecsSinceEpoch());
+        if (firstFailure) {
+            qCWarning(TerrainTileManagerLog) << "Elevation tile fetching returned error:" << reply->errorString();
+        } else {
+            qCDebug(TerrainTileManagerLog) << "Elevation tile fetching returned error (suppressed):" << reply->errorString();
+        }
         _tileFailed();
         return;
     }
 
     if (responseBytes.isEmpty()) {
-        qCWarning(TerrainTileManagerLog) << "Error in fetching elevation tile. Empty response.";
+        const bool firstFailure = !_failedTiles.contains(hash);
+        _failedTiles.insert(hash, QDateTime::currentMSecsSinceEpoch());
+        if (firstFailure) {
+            qCWarning(TerrainTileManagerLog) << "Error in fetching elevation tile. Empty response.";
+        } else {
+            qCDebug(TerrainTileManagerLog) << "Error in fetching elevation tile. Empty response (suppressed).";
+        }
         _tileFailed();
         return;
     }
 
+    _failedTiles.remove(hash);
+
     qCDebug(TerrainTileManagerLog) << "Received some bytes of terrain data:" << responseBytes.size();
 
-    const QString hash = UrlFactory::getTileHash(UrlFactory::getProviderTypeFromQtMapId(spec.mapId()), spec.x(), spec.y(), spec.zoom());
     _cacheTile(responseBytes, hash);
 
     for (qsizetype i = _requestQueue.count() - 1; i >= 0; i--) {
@@ -400,6 +421,19 @@ TerrainTile *TerrainTileManager::_getCachedTile(const QString &hash)
     }
 
     return tile;
+}
+
+bool TerrainTileManager::_isFailedTile(const QString &hash)
+{
+    const auto it = _failedTiles.constFind(hash);
+    if (it == _failedTiles.constEnd()) {
+        return false;
+    }
+    if (QDateTime::currentMSecsSinceEpoch() - it.value() < kFailedTileBackoffMs) {
+        return true;
+    }
+    _failedTiles.erase(it);
+    return false;
 }
 
 void TerrainTileManager::_processCarpetResults(const QList<double> &altitudes, int gridSizeLat, int gridSizeLon,

--- a/src/Terrain/TerrainTileManager.h
+++ b/src/Terrain/TerrainTileManager.h
@@ -40,6 +40,7 @@ private:
     void _tileFailed();
     void _cacheTile(const QByteArray &data, const QString &hash);
     TerrainTile *_getCachedTile(const QString &hash);
+    bool _isFailedTile(const QString &hash);
     static void _processCarpetResults(const QList<double> &altitudes, int gridSizeLat, int gridSizeLon,
                                       bool statsOnly, double &minHeight, double &maxHeight, QList<QList<double>> &carpet);
 
@@ -59,6 +60,9 @@ private:
 
     QMutex _tilesMutex;
     QHash<QString, TerrainTile*> _tiles;
+    QHash<QString, qint64> _failedTiles;  ///< Tile hash -> ms since epoch of last failed fetch; suppresses immediate retries
 
     QNetworkAccessManager *_networkManager = nullptr;
+
+    static constexpr qint64 kFailedTileBackoffMs = 5000;
 };

--- a/src/Vehicle/TerrainProtocolHandler.cc
+++ b/src/Vehicle/TerrainProtocolHandler.cc
@@ -137,14 +137,17 @@ void TerrainProtocolHandler::_sendTerrainData(const QGeoCoordinate &swCorner, ui
         return;
     }
 
-    if (error) {
-        qCWarning(TerrainProtocolHandlerLog) << Q_FUNC_INFO << "TerrainAtCoordinateQuery::getAltitudesForCoordinates failed";
-        return;
-    }
-
-    // Only clear the bit if the query succeeds. Otherwise just let it try again on the next timer tick
+    // Clear the bit on error or success. On error (e.g. tile fetch failed at the server),
+    // looping on the bit would just hammer the same failed tile every timer tick. The vehicle
+    // will re-issue TERRAIN_REQUEST if it still needs the data, allowing a fresh attempt after
+    // TerrainTileManager's failed-tile backoff expires.
     const uint64_t removeBit = ~(1ull << gridBit);
     _currentTerrainRequest.mask &= removeBit;
+
+    if (error) {
+        qCDebug(TerrainProtocolHandlerLog) << Q_FUNC_INFO << "terrain data unavailable for gridBit" << gridBit;
+        return;
+    }
     int altIndex = 0;
     int16_t terrainData[16];
     for (const double& altitude : altitudes) {

--- a/src/Vehicle/TerrainProtocolHandler.cc
+++ b/src/Vehicle/TerrainProtocolHandler.cc
@@ -44,8 +44,18 @@ bool TerrainProtocolHandler::mavlinkMessageReceived(const mavlink_message_t &mes
 
 void TerrainProtocolHandler::_handleTerrainRequest(const mavlink_message_t &message)
 {
+    mavlink_terrain_request_t terrainRequest;
+    mavlink_msg_terrain_request_decode(&message, &terrainRequest);
+
+    // Defensive drop: autopilots can emit TERRAIN_REQUEST with uninitialized (0, 0)
+    // before GPS lock; honoring it just spams the elevation server with tile-(0,0) fetches.
+    if (terrainRequest.lat == 0 && terrainRequest.lon == 0) {
+        qCDebug(TerrainProtocolHandlerLog) << "Ignoring TERRAIN_REQUEST with lat=0, lon=0";
+        return;
+    }
+
+    _currentTerrainRequest = terrainRequest;
     _terrainRequestActive = true;
-    mavlink_msg_terrain_request_decode(&message, &_currentTerrainRequest);
     _sendNextTerrainData();
 }
 


### PR DESCRIPTION
## Summary

Eliminate the warning spam (and unnecessary network traffic) when the elevation server cannot return data for a tile, by caching recent failures in `TerrainTileManager` and not looping on a known-failed tile in `TerrainProtocolHandler`.

## Problem

When a vehicle sends `TERRAIN_REQUEST` with uninitialized lat=0/lon=0, the request maps to elevation tile (0, 0) — "Null Island". The Auterion terrain server returns HTTP 500 for that tile, but `TerrainTileManager` had no memory of recent failures, so every `TerrainProtocolHandler` timer tick (~12 Hz) dispatched a fresh HTTP request. Observed log shows continuous warnings from both `QtLocationPlugin.QGeoTiledMapReplyQGC` and `Terrain.TerrainTileManager::_terrainDone` at ~80–150 ms intervals:

```
Warning: 1 "Error transferring https://terrain-ce.suite.auterion.com/api/v1/carpet?points=0,0,0.01,0.01 - server replied with status code 500"
Warning: Elevation tile fetching returned error: "Error transferring https://terrain-ce.suite.auterion.com/api/v1/carpet?points=0,0,0.01,0.01 - server replied with status code 500"
```

The handler also intentionally never cleared the mask bit on a non-success result, so even with backoff added, it would just transfer the spam to its own log line.

## Solution

`src/Terrain/TerrainTileManager.{h,cc}`

- Add `_failedTiles` (tile hash → ms timestamp) with a 5 s backoff.
- While a tile is in the failed set, `getAltitudesForCoordinates` returns NaN + `error=true` without dispatching a network request.
- `_terrainDone` records the hash on failure, removes it on success, and rate-limits the warning (first failure at warning level; repeats inside the window at debug level).

`src/Vehicle/TerrainProtocolHandler.cc`

- `_sendTerrainData` now clears the mask bit on `error` as well as on success, so the handler stops looping on a known-failed tile. The vehicle re-issues `TERRAIN_REQUEST` if it still needs the data, which then gets a fresh fetch once the backoff window expires.
- Demote the per-call warning to debug since the underlying cause is already logged by `TerrainTileManager`.