### PR TITLE
AnalyzeView: Move in-panel page lifecycle out of toolDrawer / fix MAVLink Inspector row spacing

### DIFF
--- a/src/AnalyzeView/AnalyzeView.qml
+++ b/src/AnalyzeView/AnalyzeView.qml
@@ -9,8 +9,6 @@ Rectangle {
     color:  qgcPal.window
     z:      QGroundControl.zOrderTopMost
 
-    signal popout()
-
     readonly property real  _defaultTextHeight:     ScreenTools.defaultFontPixelHeight
     readonly property real  _defaultTextWidth:      ScreenTools.defaultFontPixelWidth
     readonly property real  _horizontalMargin:      _defaultTextWidth / 2
@@ -19,17 +17,23 @@ Rectangle {
     property var  _activeVehicle: QGroundControl.multiVehicleManager.activeVehicle
     property var  _currentPage:   null
     property var  _currentItem:   null
+    // Destroy the in-panel page item while panelContainer is still alive, before the
+    // loader clears the source and tears down this component.
+    Component.onDestruction: mainWindow.destroyInPanelAnalyzePage()
 
     function _loadPage(source) {
-        if (_currentItem) {
-            _currentItem.destroy()
-            _currentItem = null
-        }
+        // Clear reference before calling mainWindow.createAnalyzePage (which destroys the old item).
+        _currentItem = null
         if (source !== "") {
-            var component = Qt.createComponent(source)
-            if (component.status === Component.Ready) {
-                _currentItem = component.createObject(panelContainer)
+            // mainWindow creates and owns the item (QObject parent = mainWindow) so it
+            // survives AnalyzeView being unloaded in the popped-out case.
+            // anchors.fill: parent in AnalyzePage.qml automatically fills panelContainer.
+            _currentItem = mainWindow.createAnalyzePage(source)
+            if (_currentItem) {
+                _currentItem.parent = panelContainer
             }
+        } else {
+            mainWindow.destroyInPanelAnalyzePage()
         }
     }
 
@@ -139,18 +143,22 @@ Rectangle {
         property string title
 
         Connections {
-            target:     _currentItem
+            target: _currentItem
+
             function onPopout() {
                 var existingItem = _currentItem
                 var pageTitle = panelContainer.title
                 var pageSource = _currentPage.url
                 var requiresVehicle = _currentPage ? _currentPage.requiresVehicle : false
-                // Release ownership without destroying
+                // Clear references before handing item to the popup window.
                 _currentItem = null
+                // Tell mainWindow this item has moved to a popup so it is not destroyed
+                // when AnalyzeView is torn down.
+                mainWindow.analyzePageMovedToPopup()
                 existingItem.visible = false
-                // Hand the existing item to the popout window
+                // Hand the existing item to the popout window.
                 mainWindow.createWindowedAnalyzePage(pageTitle, pageSource, requiresVehicle, existingItem)
-                // Create a fresh instance in-place
+                // Create a fresh in-panel instance.
                 _loadPage(pageSource)
             }
         }

--- a/src/AnalyzeView/MAVLinkInspector/MAVLinkInspectorPage.qml
+++ b/src/AnalyzeView/MAVLinkInspector/MAVLinkInspectorPage.qml
@@ -221,7 +221,7 @@ AnalyzePage {
                         id:                 msgInfoGrid
                         columns:            5
                         columnSpacing:      ScreenTools.defaultFontPixelWidth  * 0.25
-                        rowSpacing:         ScreenTools.defaultFontPixelHeight * 0.25
+                        rowSpacing:         0
                         width:              parent.width
                         QGCLabel {
                             text:       qsTr("Name")

--- a/src/MainWindow/MainWindow.qml
+++ b/src/MainWindow/MainWindow.qml
@@ -427,12 +427,6 @@ ApplicationWindow {
             anchors.right:  parent.right
             anchors.top:    toolDrawerToolbar.bottom
             anchors.bottom: parent.bottom
-
-            Connections {
-                target:                 toolDrawerLoader.item
-                ignoreUnknownSignals:   true
-                function onPopout() { toolDrawer.visible = false }
-            }
         }
     }
 
@@ -650,9 +644,45 @@ ApplicationWindow {
         }
     }
 
-    // We have to create the popup windows for the Analyze pages here so that the creation context is rooted
-    // to mainWindow. Otherwise if they are rooted to the AnalyzeView itself they will die when the analyze viewSwitch
-    // closes.
+    // Analyze page items (both in-panel and popped-out windows) are created with mainWindow as their
+    // QObject parent so their lifetime is not tied to AnalyzeView. This lets a popped-out window
+    // survive AnalyzeView being unloaded from the tool drawer.
+
+    // Tracks the analyze page item currently shown inside AnalyzeView's panel (not popped out).
+    // null when no page is loaded or the item has been handed off to a popup window.
+    property var _inPanelAnalyzePage: null
+
+    // Called by AnalyzeView.Component.onDestruction to destroy the in-panel item while
+    // panelContainer is still alive.
+    function destroyInPanelAnalyzePage() {
+        if (_inPanelAnalyzePage) {
+            _inPanelAnalyzePage.destroy()
+            _inPanelAnalyzePage = null
+        }
+    }
+
+    // Called by AnalyzeView to create an analyze page item owned by mainWindow.
+    // The caller sets the visual parent to panelContainer after creation.
+    function createAnalyzePage(source) {
+        if (_inPanelAnalyzePage) {
+            _inPanelAnalyzePage.destroy()
+            _inPanelAnalyzePage = null
+        }
+        var component = Qt.createComponent(source)
+        if (component.status !== Component.Ready) {
+            console.warn("createAnalyzePage failed source:", source, "errorString:", component.errorString())
+            return null
+        }
+        _inPanelAnalyzePage = component.createObject(mainWindow)
+        return _inPanelAnalyzePage
+    }
+
+    // Called by AnalyzeView when the in-panel item is handed off to a popup window.
+    // Clears _inPanelAnalyzePage so destroyInPanelAnalyzePage() does not destroy it
+    // when AnalyzeView is torn down.
+    function analyzePageMovedToPopup() {
+        _inPanelAnalyzePage = null
+    }
 
     function createWindowedAnalyzePage(title, source, requiresVehicle, existingItem) {
         var windowedPage = windowedAnalyzePage.createObject(mainWindow)


### PR DESCRIPTION
Fixes #14373

## Summary

Two independent improvements to the AnalyzeView/MAVLink Inspector area.

### AnalyzeView in-panel page lifecycle cleanup

The `destroyInPanelAnalyzePage()` call was embedded inside `toolDrawer.onVisibleChanged`, which has no logical connection to AnalyzeView. This was a layering violation — the tool drawer had to know about analyze page internals.

**Changes:**
- Move the destroy call to `AnalyzeView.Component.onDestruction`, which fires while `panelContainer` is still alive before the loader tears down the component. This is semantically the correct place: the cleanup is triggered by AnalyzeView going away, not by the drawer hiding.
- `toolDrawer.onVisibleChanged` now only clears the loader source with no analyze-specific knowledge.
- Add `destroyInPanelAnalyzePage()` as an explicit named function in MainWindow near the other analyze page lifecycle functions (`createAnalyzePage`, `analyzePageMovedToPopup`).
- Update all related comments to accurately reflect the current code structure.

### MAVLink Inspector field row spacing

Reduce `rowSpacing` in `msgInfoGrid` from `ScreenTools.defaultFontPixelHeight * 0.25` to `0` to tighten the spacing between message field rows.
