### PR TITLE
ci: fix actionlint warning and restore AWS CLI on Linux runners

### DIFF
--- a/.github/actions/free-disk-space/action.yml
+++ b/.github/actions/free-disk-space/action.yml
@@ -20,5 +20,5 @@ runs:
         remove_haskell: true
         remove_packages: azure-cli google-cloud-cli microsoft-edge-stable google-chrome-stable firefox postgresql* temurin-* *llvm* mysql* dotnet-sdk-* julia*
         remove_packages_one_command: true
-        remove_folders: /usr/share/swift /usr/share/miniconda /usr/local/lib/node_modules /usr/local/share/chromium /usr/local/share/powershell /usr/local/julia /usr/local/aws-cli /usr/local/aws-sam-cli
+        remove_folders: /usr/share/swift /usr/share/miniconda /usr/local/lib/node_modules /usr/local/share/chromium /usr/local/share/powershell /usr/local/julia /usr/local/aws-sam-cli
         rm_cmd: rmz

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -92,7 +92,6 @@ jobs:
         with:
           qt-host: ${{ matrix.host }}
           qt-arch: ${{ matrix.arch }}
-          qt-version: ${{ matrix.qt_version || '' }}
           aqt-source: ${{ matrix.aqt_source || '' }}
           build-type: ${{ matrix.build_type }}
 


### PR DESCRIPTION
## Summary

Two CI fixes following the recent master push:

- **`.github/workflows/windows.yml`**: drop `qt-version: ${{ matrix.qt_version || '' }}` from the `build-setup` call. `matrix.qt_version` is never declared in any matrix entry, so actionlint correctly flags `property "qt_version" is not defined`. The `build-setup` action's `qt-version` input already defaults to `""`, so this is a no-op at runtime.
- **`.github/actions/free-disk-space/action.yml`**: stop removing `/usr/local/aws-cli`. `attest-and-upload` invokes `aws s3 cp` on Linux runners (Android, Linux), and removing the CLI caused `FileNotFoundError: [Errno 2] No such file or directory: 'aws'` on the Android (linux) job. `/usr/local/aws-sam-cli` removal is preserved — SAM is unused.

The action only runs on `runner.os == 'Linux'`, so macOS/Windows uploads are unaffected.

## Test plan
- [ ] CI Scripts (Lint Workflows) passes — no actionlint findings on `windows.yml`.
- [ ] Android (linux) Attest and Upload step finds `aws` and completes the S3 upload.
- [ ] Linux job (currently in progress on master) is similarly unblocked once this lands.
- [ ] Windows / macOS / Docker remain green.