### PR TITLE
fix(rid): Fix Remote ID indicator QML state handling

### DIFF
--- a/src/Toolbar/RemoteIDIndicator.qml
+++ b/src/Toolbar/RemoteIDIndicator.qml
@@ -12,18 +12,19 @@ Item {
     anchors.top:    parent.top
     anchors.bottom: parent.bottom
 
-    property bool   showIndicator:      remoteIDManager.available
+    property bool   showIndicator:      remoteIDManager ? remoteIDManager.available : false
 
     property var    activeVehicle:      QGroundControl.multiVehicleManager.activeVehicle
     property var    remoteIDManager:    activeVehicle ? activeVehicle.remoteIDManager : null
 
-    property bool   gpsFlag:            activeVehicle && remoteIDManager ? remoteIDManager.gcsGPSGood         : false
-    property bool   basicIDFlag:        activeVehicle && remoteIDManager ? remoteIDManager.basicIDGood        : false
-    property bool   armFlag:            activeVehicle && remoteIDManager ? remoteIDManager.armStatusGood      : false
-    property bool   commsFlag:          activeVehicle && remoteIDManager ? remoteIDManager.commsGood          : false
-    property bool   emergencyDeclared:  activeVehicle && remoteIDManager ? remoteIDManager.emergencyDeclared  : false
-    property bool   operatorIDFlag:     activeVehicle && remoteIDManager ? remoteIDManager.operatorIDGood     : false
-    property int    remoteIDState:      getRemoteIDState()
+    property bool   gpsFlag:            remoteIDManager ? remoteIDManager.gcsGPSGood         : false
+    property bool   basicIDFlag:        remoteIDManager ? remoteIDManager.basicIDGood        : false
+    property bool   armFlag:            remoteIDManager ? remoteIDManager.armStatusGood      : false
+    property bool   commsFlag:          remoteIDManager ? remoteIDManager.commsGood          : false
+    property bool   emergencyDeclared:  remoteIDManager ? remoteIDManager.emergencyDeclared  : false
+    property bool   operatorIDFlag:     remoteIDManager ? remoteIDManager.operatorIDGood     : false
+    property bool   sendOperatorID:     QGroundControl.settingsManager.remoteIDSettings.sendOperatorID.value
+    property int    remoteIDState:      getRemoteIDState(activeVehicle, commsFlag, armFlag, emergencyDeclared, gpsFlag, basicIDFlag, regionOperation, sendOperatorID, operatorIDFlag)
 
     property int    regionOperation:    QGroundControl.settingsManager.remoteIDSettings.region.value
 
@@ -34,43 +35,34 @@ Item {
         UNAVAILABLE
     }
 
-    enum RegionOperation {
-        FAA,
-        EU
-    }
-
     function getRidColor() {
         switch (remoteIDState) {
             case RemoteIDIndicator.RIDState.HEALTHY:
                 return qgcPal.colorGreen
-                break
             case RemoteIDIndicator.RIDState.WARNING:
                 return qgcPal.colorYellow
-                break
             case RemoteIDIndicator.RIDState.ERROR:
                 return qgcPal.colorRed
-                break
             case RemoteIDIndicator.RIDState.UNAVAILABLE:
                 return qgcPal.colorGrey
-                break
             default:
                 return qgcPal.colorGrey
         }
     }
 
-    function getRemoteIDState() {
-        if (!activeVehicle) {
+    function getRemoteIDState(vehicle, commsOk, armOk, emergencyActive, gpsOk, basicIDOk, region, sendOperatorIDEnabled, operatorIDOk) {
+        if (!vehicle) {
             return RemoteIDIndicator.RIDState.UNAVAILABLE
         }
         // We need to have comms and arm healthy to even be in any other state other than ERROR
-        if (!commsFlag || !armFlag || emergencyDeclared) {
+        if (!commsOk || !armOk || emergencyActive) {
             return RemoteIDIndicator.RIDState.ERROR
         }
-        if (!gpsFlag || !basicIDFlag) {
+        if (!gpsOk || !basicIDOk) {
             return RemoteIDIndicator.RIDState.WARNING
         }
-        if (regionOperation == RemoteIDIndicator.RegionOperation.EU || QGroundControl.settingsManager.remoteIDSettings.sendOperatorID.value) {
-            if (!operatorIDFlag) {
+        if (region == RemoteIDSettings.RegionOperation.EU || sendOperatorIDEnabled) {
+            if (!operatorIDOk) {
                 return RemoteIDIndicator.RIDState.WARNING
             }
         }

--- a/src/Toolbar/RemoteIDIndicatorPage.qml
+++ b/src/Toolbar/RemoteIDIndicatorPage.qml
@@ -9,13 +9,14 @@ ToolIndicatorPage {
     showExpand: true
 
     property var    _activeVehicle:     QGroundControl.multiVehicleManager.activeVehicle
+    property var    remoteIDManager:    _activeVehicle ? _activeVehicle.remoteIDManager : null
 
-    property bool   gpsFlag:            _activeVehicle && _activeVehicle.remoteIDManager ? _activeVehicle.remoteIDManager.gcsGPSGood         : false
-    property bool   basicIDFlag:        _activeVehicle && _activeVehicle.remoteIDManager ? _activeVehicle.remoteIDManager.basicIDGood        : false
-    property bool   armFlag:            _activeVehicle && _activeVehicle.remoteIDManager ? _activeVehicle.remoteIDManager.armStatusGood      : false
-    property bool   commsFlag:          _activeVehicle && _activeVehicle.remoteIDManager ? _activeVehicle.remoteIDManager.commsGood          : false
-    property bool   emergencyDeclared:  _activeVehicle && _activeVehicle.remoteIDManager ? _activeVehicle.remoteIDManager.emergencyDeclared  : false
-    property bool   operatorIDFlag:     _activeVehicle && _activeVehicle.remoteIDManager ? _activeVehicle.remoteIDManager.operatorIDGood     : false
+    property bool   gpsFlag:            remoteIDManager ? remoteIDManager.gcsGPSGood         : false
+    property bool   basicIDFlag:        remoteIDManager ? remoteIDManager.basicIDGood        : false
+    property bool   armFlag:            remoteIDManager ? remoteIDManager.armStatusGood      : false
+    property bool   commsFlag:          remoteIDManager ? remoteIDManager.commsGood          : false
+    property bool   emergencyDeclared:  remoteIDManager ? remoteIDManager.emergencyDeclared  : false
+    property bool   operatorIDFlag:     remoteIDManager ? remoteIDManager.operatorIDGood     : false
 
     property int    _regionOperation:   QGroundControl.settingsManager.remoteIDSettings.region.value
 
@@ -26,22 +27,6 @@ ToolIndicatorPage {
 
     // Visual properties
     property real   _margins:           ScreenTools.defaultFontPixelWidth
-
-    enum RegionOperation {
-        FAA,
-        EU
-    }
-
-    enum LocationType {
-        TAKEOFF,
-        LIVE,
-        FIXED
-    }
-
-    enum ClassificationType {
-        UNDEFINED,
-        EU
-    }
 
     function goToSettings() {
         if (mainWindow.allowViewSwitch()) {
@@ -156,7 +141,7 @@ ToolIndicatorPage {
                     }
 
                     Image {
-                        id:                 basicIDFlagIge
+                        id:                 basicIDFlagImage
                         width:              flagsWidth
                         height:             flagsHeight
                         source:             basicIDFlag ? "/qmlimages/RidFlagBackgroundGreen.svg" : "/qmlimages/RidFlagBackgroundRed.svg"
@@ -187,7 +172,7 @@ ToolIndicatorPage {
                         source:             operatorIDFlag ? "/qmlimages/RidFlagBackgroundGreen.svg" : "/qmlimages/RidFlagBackgroundRed.svg"
                         fillMode:           Image.PreserveAspectFit
                         sourceSize.height:  height
-                        visible:            commsFlag && _activeVehicle ? (QGroundControl.settingsManager.remoteIDSettings.sendOperatorID.value || _regionOperation == RemoteIDIndicatorPage.EU) : false
+                        visible:            commsFlag ? (QGroundControl.settingsManager.remoteIDSettings.sendOperatorID.value || _regionOperation == RemoteIDSettings.RegionOperation.EU) : false
 
                         QGCLabel {
                             anchors.fill:           parent
@@ -226,19 +211,20 @@ ToolIndicatorPage {
                     anchors.topMargin:      _margins * 3
                     wrapMode:               Text.WordWrap
                     horizontalAlignment:    Text.AlignHCenter
-                    visible:                true
                 }
 
                 Image {
                     id:                         emergencyButton
                     width:                      flagsWidth * 2
                     height:                     flagsHeight * 1.5
-                    source:                     "/qmlimages/RidEmergencyBackground.svg"
+                    source:                     highlighted ? "/qmlimages/RidEmergencyBackgroundHighlight.svg" : "/qmlimages/RidEmergencyBackground.svg"
                     sourceSize.height:          height
                     anchors.horizontalCenter:   parent.horizontalCenter
                     anchors.top:                emergencyDeclareLabel.bottom
                     anchors.margins:            _margins
-                    visible:                    true
+
+                    property bool highlighted: emergencyButtonMouseArea.containsMouse || emergencyButtonMouseArea.pressed || emergencyButtonFlashOn
+                    property bool emergencyButtonFlashOn: false
 
                     QGCLabel {
                         anchors.fill:           parent
@@ -253,30 +239,19 @@ ToolIndicatorPage {
                     Timer {
                         id:             emergencyButtonTimer
                         interval:       350
-                        onTriggered: {
-                            if (emergencyButton.source == "/qmlimages/RidEmergencyBackgroundHighlight.svg" ) {
-                                emergencyButton.source = "/qmlimages/RidEmergencyBackground.svg"
-                            } else {
-                                emergencyButton.source = "/qmlimages/RidEmergencyBackgroundHighlight.svg"
-                            }
-                        }
+                        onTriggered:    emergencyButton.emergencyButtonFlashOn = false
                     }
 
                     MouseArea {
+                        id:                     emergencyButtonMouseArea
                         anchors.fill:           parent
                         hoverEnabled:           true
-                        onEntered:              emergencyButton.source = "/qmlimages/RidEmergencyBackgroundHighlight.svg"
-                        onExited:               emergencyButton.source = "/qmlimages/RidEmergencyBackground.svg"
                         pressAndHoldInterval:   emergencyDeclared ? 3000 : 800
                         onPressAndHold: {
-                            if (emergencyButton.source == "/qmlimages/RidEmergencyBackgroundHighlight.svg" ) {
-                                emergencyButton.source = "/qmlimages/RidEmergencyBackground.svg"
-                            } else {
-                                emergencyButton.source = "/qmlimages/RidEmergencyBackgroundHighlight.svg"
-                            }
+                            emergencyButton.emergencyButtonFlashOn = true
                             emergencyButtonTimer.restart()
-                            if (_activeVehicle) {
-                                _activeVehicle.remoteIDManager.setEmergency(!emergencyDeclared)
+                            if (remoteIDManager) {
+                                remoteIDManager.setEmergency(!emergencyDeclared)
                             }
                         }
                     }
@@ -289,24 +264,24 @@ ToolIndicatorPage {
         RowLayout {
             spacing: ScreenTools.defaultFontPixelWidth
 
-            property var  remoteIDSettings:QGroundControl.settingsManager.remoteIDSettings
+            property var  remoteIDSettings:     QGroundControl.settingsManager.remoteIDSettings
             property Fact regionFact:           remoteIDSettings.region
             property Fact sendOperatorIdFact:   remoteIDSettings.sendOperatorID
             property Fact locationTypeFact:     remoteIDSettings.locationType
             property Fact operatorIDFact:       remoteIDSettings.operatorID
-            property bool isEURegion:           regionFact.rawValue == RemoteIDIndicatorPage.EU
-            property bool isFAARegion:          regionFact.rawValue == RemoteIDIndicatorPage.FAA
+            property bool isEURegion:           regionFact.rawValue == RemoteIDSettings.RegionOperation.EU
+            property bool isFAARegion:          regionFact.rawValue == RemoteIDSettings.RegionOperation.FAA
             property real textFieldWidth:       ScreenTools.defaultFontPixelWidth * 24
             property real textLabelWidth:       ScreenTools.defaultFontPixelWidth * 30
 
             Connections {
                 target: regionFact
-                onRawValueChanged: {
-                    if (regionFact.rawValue === RemoteIDIndicatorPage.EU) {
+                function onRawValueChanged() {
+                    if (regionFact.rawValue === RemoteIDSettings.RegionOperation.EU) {
                         sendOperatorIdFact.rawValue = true
                     }
-                    if (regionFact.rawValue === RemoteIDIndicatorPage.FAA) {
-                        locationTypeFact.value = RemoteIDIndicatorPage.LocationType.LIVE
+                    if (regionFact.rawValue === RemoteIDSettings.RegionOperation.FAA) {
+                        locationTypeFact.value = RemoteIDSettings.LocationType.LIVE
                     }
                 }
             }
@@ -321,7 +296,7 @@ ToolIndicatorPage {
                     LabelledLabel {
                         id :                armStatusLabel
                         label:              qsTr("Arm Status Error")
-                        labelText:          remoteIDManager.armStatusError
+                        labelText:          remoteIDManager ? remoteIDManager.armStatusError : ""
                         Layout.fillWidth:   true
                     }
                 }


### PR DESCRIPTION
## Description

Addresses items 1-13 from #14220 for the Remote ID toolbar indicator and expanded indicator page.

This PR fixes QML runtime issues and cleanup findings, including:
- Guarding `remoteIDManager` access when there is no active vehicle
- Making `remoteIDState` update reactively when Remote ID flags or settings change
- Fixing undefined `remoteIDManager` access in the expanded indicator page
- Using `RemoteIDSettings` enum values instead of duplicated local enums
- Fixing the `basicIDFlagIge` typo
- Removing unreachable `break` statements after `return`
- Replacing emergency button source-string comparisons with boolean highlight state
- Updating the `Connections` handler to Qt6 function syntax

Item 14 from #14220 is intentionally left out because moving region-change side effects from QML into C++ is a broader behavior change and should be handled separately.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [x] Refactoring (no functional changes)
- [ ] CI/Build changes
- [ ] Other

## Testing

- [x] Tested locally
- [ ] Added/updated unit tests
- [ ] Tested with simulator (SITL)
- [ ] Tested with hardware


### Platforms Tested

- [ ] Linux
- [x] Windows
- [ ] macOS
- [ ] Android
- [ ] iOS

### Flight Stacks Tested

- [ ] PX4
- [ ] ArduPilot

## Screenshots

Not applicable.

## Checklist

- [x] I have read the [Contribution Guidelines](CONTRIBUTING.md)
- [x] I have read the [Code of Conduct](CODE_OF_CONDUCT.md)
- [x] My code follows the project's coding standards
- [x] I have added tests that prove my fix/feature works
- [ ] New and existing unit tests pass locally

## Related Issues

Addresses items 1-13 of #14220

---

By submitting this pull request, I confirm that my contribution is made under the terms of the project's dual license (Apache 2.0 and GPL v3).