### PR TITLE
PX4FirmwarePlugin: Enable offboard mode for fixed-wings

### DIFF
--- a/src/FirmwarePlugin/PX4/PX4FirmwarePlugin.cc
+++ b/src/FirmwarePlugin/PX4/PX4FirmwarePlugin.cc
@@ -768,13 +768,13 @@ void PX4FirmwarePlugin::updateAvailableFlightModes(FlightModeList &modeList)
 
         // Update Fixed Wing
         switch (cMode){
-        case PX4CustomMode::OFFBOARD          :
         case PX4CustomMode::SIMPLE            :
         case PX4CustomMode::POSCTL_ORBIT      :
         case PX4CustomMode::AUTO_FOLLOW_TARGET:
         case PX4CustomMode::AUTO_PRECLAND     :
             mode.fixedWing = false;
             break;
+        case PX4CustomMode::OFFBOARD          :
         case PX4CustomMode::MANUAL            :
         case PX4CustomMode::STABILIZED        :
         case PX4CustomMode::ACRO              :


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail. What problem does this solve? -->

The offboard mode button is disabled for fixed-wing vehicles when running PX4.

Therefore, the only way to switch to offboard mode on fixed-wing vehicles is to use the mavlink console.

This PR allows fixed-wing vehicles to use offboard mode with PX4

## Type of Change
<!-- Put an 'x' in the relevant boxes -->
- [x] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] CI/Build changes
- [ ] Other

## Testing
<!-- Describe the tests you ran and how to reproduce them -->
- [x] Tested locally
- [ ] Added/updated unit tests
- [ ] Tested with simulator (SITL)
- [ ] Tested with hardware

### Platforms Tested
<!-- Check all that apply -->
- [x] Linux
- [ ] Windows
- [ ] macOS
- [ ] Android
- [ ] iOS

### Flight Stacks Tested
<!-- If applicable -->
- [x] PX4
- [ ] ArduPilot

## Screenshots
<!-- If applicable, add screenshots to help explain your changes -->
Offboard mode is now available for fixed-wing vehicle. Image is shown while running Gz sim.

<img width="1580" height="963" alt="image" src="https://github.com/user-attachments/assets/fa7adcb8-ace3-41df-8d60-7a6ca920e75c" />


## Checklist
<!-- Go over all the following points, and put an 'x' in all the boxes that apply -->
- [x] I have read the [Contribution Guidelines](CONTRIBUTING.md)
- [x] I have read the [Code of Conduct](CODE_OF_CONDUCT.md)
- [x] My code follows the project's coding standards
- [ ] I have added tests that prove my fix/feature works
- [ ] New and existing unit tests pass locally

## Related Issues
<!-- Link any related issues using #issue_number -->

---
By submitting this pull request, I confirm that my contribution is made under the terms of the project's dual license (Apache 2.0 and GPL v3).
