### PR TITLE
Fly View: add altitude support for Click to ROI

### DIFF
--- a/src/FlyView/FlyViewMap.qml
+++ b/src/FlyView/FlyViewMap.qml
@@ -709,7 +709,7 @@ FlightMap {
                         visible:            globals.guidedControllerFlyView.showROI
                         onClicked: {
                             mapClickDropPanel.close()
-                            globals.guidedControllerFlyView.executeAction(globals.guidedControllerFlyView.actionROI, mapClickCoord, 0, false)
+                            globals.guidedControllerFlyView.confirmAction(globals.guidedControllerFlyView.actionROI, mapClickCoord)
                         }
                     }
 

--- a/src/FlyView/GuidedActionsController.qml
+++ b/src/FlyView/GuidedActionsController.qml
@@ -225,7 +225,7 @@ Item {
             } else {
                 console.error("setupSlider called for inapproproate change speed action", _vehicleInFwdFlight, _activeVehicle.haveMRSpeedLimits)
             }
-        } else if (actionCode === actionChangeAlt || actionCode === actionOrbit || actionCode === actionGoto || actionCode === actionPause) {
+        } else if (actionCode === actionChangeAlt || actionCode === actionOrbit || actionCode === actionROI || actionCode === actionGoto || actionCode === actionPause) {
             guidedValueSlider.setupSlider(
                 GuidedValueSlider.SliderType.Altitude,
                 _flyViewSettings.guidedMinimumAltitude.value,
@@ -656,7 +656,12 @@ Item {
             }
             break
         case actionROI:
-            _activeVehicle.guidedModeROI(actionData)
+            var roiCoordinate = actionData
+            var valueInMeters = _unitsConversion.appSettingsVerticalDistanceUnitsToMeters(sliderOutputValue)
+            if (!isNaN(valueInMeters)) {
+                roiCoordinate = QtPositioning.coordinate(actionData.latitude, actionData.longitude, valueInMeters)
+            }
+            _activeVehicle.guidedModeROI(roiCoordinate)
             break
         case actionChangeSpeed:
             if (_activeVehicle) {

--- a/src/Vehicle/TerrainQueryCoordinator.cc
+++ b/src/Vehicle/TerrainQueryCoordinator.cc
@@ -84,7 +84,7 @@ void TerrainQueryCoordinator::_doSetHomeTerrainReceived(bool success, QList<doub
     _doSetHomeCoordinate = QGeoCoordinate(); // Invalidate for extra safety
 }
 
-void TerrainQueryCoordinator::roiWithTerrain(const QGeoCoordinate& coord)
+void TerrainQueryCoordinator::roiWithTerrain(const QGeoCoordinate& coord, double relativeAltitude)
 {
     if (!coord.isValid()) {
         return;
@@ -97,6 +97,7 @@ void TerrainQueryCoordinator::roiWithTerrain(const QGeoCoordinate& coord)
     }
 
     _roiCoordinate = coord;
+    _roiRelativeAltitude = relativeAltitude;
 
     _roiQuery = new TerrainAtCoordinateQuery(true /* autoDelete */);
     connect(_roiQuery, &TerrainAtCoordinateQuery::terrainDataReceived,
@@ -112,6 +113,7 @@ void TerrainQueryCoordinator::_roiTerrainReceived(bool success, QList<double> he
     _roiQuery = nullptr;
 
     if (!_roiCoordinate.isValid()) {
+        _roiRelativeAltitude = qQNaN();
         return;
     }
 
@@ -123,13 +125,19 @@ void TerrainQueryCoordinator::_roiTerrainReceived(bool success, QList<double> he
         roiAltitude = static_cast<float>(_vehicle->homePosition().altitude());
     }
 
+    if (!qIsNaN(_roiRelativeAltitude)) {
+        roiAltitude += static_cast<float>(_roiRelativeAltitude);
+    }
+
     qCDebug(TerrainQueryCoordinatorLog) << "roiWithTerrain: lat" << _roiCoordinate.latitude()
                                         << "lon" << _roiCoordinate.longitude()
-                                        << "terrainAltAMSL" << roiAltitude << "success" << success;
+                                        << "altAMSL" << roiAltitude << "success" << success
+                                        << "relativeAlt" << _roiRelativeAltitude;
 
     sendROICommand(_roiCoordinate, MAV_FRAME_GLOBAL, roiAltitude);
 
     _roiCoordinate = QGeoCoordinate();
+    _roiRelativeAltitude = qQNaN();
 }
 
 void TerrainQueryCoordinator::sendROICommand(const QGeoCoordinate& coord, MAV_FRAME frame, float altitude)

--- a/src/Vehicle/TerrainQueryCoordinator.h
+++ b/src/Vehicle/TerrainQueryCoordinator.h
@@ -37,8 +37,8 @@ public:
 
     /// PX4 ROI flow. Starts a terrain query; when it resolves, sends
     /// MAV_CMD_DO_SET_ROI_LOCATION in MAV_FRAME_GLOBAL at the resolved altitude
-    /// (falling back to home altitude on query failure).
-    void roiWithTerrain(const QGeoCoordinate& coord);
+    /// or at resolved altitude plus requested relative altitude.
+    void roiWithTerrain(const QGeoCoordinate& coord, double relativeAltitude = qQNaN());
 
     /// Build + send MAV_CMD_DO_SET_ROI_LOCATION directly (no terrain query).
     /// Used by the ArduPilot MAV_FRAME_GLOBAL_RELATIVE_ALT direct path.
@@ -62,6 +62,7 @@ private:
 
     QPointer<TerrainAtCoordinateQuery> _roiQuery;
     QGeoCoordinate                     _roiCoordinate;
+    double                              _roiRelativeAltitude = qQNaN();
 
     QElapsedTimer                      _altQueryTimer;
     QPointer<TerrainAtCoordinateQuery> _altQuery;

--- a/src/Vehicle/Vehicle.cc
+++ b/src/Vehicle/Vehicle.cc
@@ -1985,7 +1985,7 @@ void Vehicle::guidedModeROI(const QGeoCoordinate& centerCoord)
     if (px4Firmware()) {
         // PX4 ignores the coordinate frame in COMMAND_INT and treats the altitude as AMSL,
         // so a terrain query is required before we can send the ROI command.
-        _terrainQueryCoordinator->roiWithTerrain(centerCoord);
+        _terrainQueryCoordinator->roiWithTerrain(centerCoord, centerCoord.altitude());
     } else {
         // ArduPilot handles MAV_FRAME_GLOBAL_RELATIVE_ALT correctly, so altitude 0 relative to
         // home is a reasonable default for a map click with no altitude info.


### PR DESCRIPTION
## Description
Adds altitude support for Fly View "Click to ROI".

Previously, ROI commands only sent latitude and longitude coordinates,
causing the altitude field to remain unset/zero. This update includes
altitude in the ROI coordinate sent through MAVLink.

This improves camera/gimbal targeting accuracy when using Click to ROI.

Fixes #14394.

## Type of Change
- [x] New feature (non-breaking change that adds functionality)

## Testing
- [x] Tested locally
- [x] Tested with simulator (SITL)

### Platforms Tested
- [x] Windows

### Flight Stacks Tested
- [x] ArduPilot

## Screenshots
N/A

## Checklist
- [x] I have read the Contribution Guidelines
- [x] I have read the Code of Conduct
- [x] My code follows the project's coding standards

## Related Issues
#14394