### PR TITLE
fix(FlightMap): restore mouse wheel zoom on Linux Wayland and xcb/XWayland

### DIFF
--- a/src/FlightMap/FlightMap.qml
+++ b/src/FlightMap/FlightMap.qml
@@ -135,10 +135,18 @@ Map {
     }
 
     WheelHandler {
-        // workaround for QTBUG-87646 / QTBUG-112394 / QTBUG-112432:
-        // Magic Mouse pretends to be a trackpad but doesn't work with PinchHandler
-        // and we don't yet distinguish mice and trackpads on Wayland either
-        acceptedDevices:    Qt.platform.pluginName === "cocoa" || Qt.platform.pluginName === "wayland" ?
+        // Workaround for QTBUG-112394 / QTBUG-112432 (Linux/Wayland, STILL OPEN as of Qt 6.10):
+        // The Wayland protocol (wl_seat) only exposes three capability flags
+        // (POINTER/KEYBOARD/TOUCH) with no way to distinguish a mouse from a trackpad.
+        // Qt's Wayland QPA therefore registers all pointer devices as TouchPad, so
+        // WheelHandler's default acceptedDevices=Mouse silently drops all scroll events.
+        // This cannot be fixed in Qt without a Wayland protocol extension that does not yet exist.
+        //
+        // The same problem affects xcb / XWayland: when QGC runs under XWayland (e.g. an AppImage
+        // forced to QT_QPA_PLATFORM=xcb on a Wayland session), XWayland translates Wayland pointer
+        // events back to X11 and device-type metadata is lost — physical mouse scroll events arrive
+        // at Qt as PointerDevice.TouchPad.
+        acceptedDevices:    Qt.platform.pluginName === "wayland" || Qt.platform.pluginName === "xcb" ?
                                 PointerDevice.Mouse | PointerDevice.TouchPad : PointerDevice.Mouse
         rotationScale:      1 / 120
 


### PR DESCRIPTION
## Summary

Mouse wheel zoom on the flight map is broken on Linux when running under the Wayland platform plugin, and also when running under xcb/XWayland (e.g. from the AppImage).

## Root cause

`WheelHandler` defaults to `acceptedDevices: PointerDevice.Mouse`. Two Qt bugs cause scroll events to arrive classified as `PointerDevice.TouchPad` instead:

- **QTBUG-112432 (Wayland):** The Wayland `wl_seat` protocol only exposes three capability flags (POINTER/KEYBOARD/TOUCH) with no way to distinguish a mouse from a trackpad. Qt's Wayland QPA therefore registers *all* pointer devices as `TouchPad`. This bug is still open as of Qt 6.10 and cannot be fixed without a Wayland protocol extension.

- **xcb / XWayland:** When the AppImage forces `QT_QPA_PLATFORM=xcb` on a Wayland session, XWayland translates Wayland pointer events back to X11 and device-type metadata is lost — physical mouse scroll events arrive at Qt as `PointerDevice.TouchPad`.

## Fix

Accept both `Mouse` and `TouchPad` in `WheelHandler.acceptedDevices` when running under the `wayland` or `xcb` platform plugins.

Also removes the now-obsolete `cocoa` workaround (QTBUG-87646, fixed in Qt 6.2; QGC requires Qt 6.10+).

Fixes #14109