### PR TITLE
fix(FlyView): fix guided action cancel/supersede semantics

### DIFF
--- a/src/FlyView/GuidedActionConfirm.qml
+++ b/src/FlyView/GuidedActionConfirm.qml
@@ -43,18 +43,28 @@ Item {
         }
     }
 
-    function confirmCancelled() {
-        guidedValueSlider.visible = false
+    function reset() {
         visible = false
+        guidedValueSlider.visible = false
         hideTrigger = false
         visibleTimer.stop()
         messageDisplay.opacity = 1.0
         messageFadeTimer.stop()
         messageOpacityAnimation.stop()
-        if (mapIndicator) {
+    }
+
+    // Cancel the current pending action and notify its map indicator.
+    // Pass incomingIndicator when superseding one action with another (e.g. from confirmAction):
+    // if the old and new indicator are the same object, actionCancelled() is intentionally skipped
+    // so that a show() call made before confirmAction() is not undone (e.g. goto -> goto).
+    // Omit incomingIndicator (or pass undefined) for explicit user cancellation via the X button
+    // or auto-hide trigger, where the indicator must always be notified.
+    function confirmCancelled(incomingIndicator) {
+        reset()
+        if (mapIndicator && mapIndicator !== incomingIndicator) {
             mapIndicator.actionCancelled()
-            mapIndicator = undefined
         }
+        mapIndicator = undefined
     }
 
     function _reallyShow() {

--- a/src/FlyView/GuidedActionsController.qml
+++ b/src/FlyView/GuidedActionsController.qml
@@ -376,10 +376,12 @@ Item {
     // Called when an action is about to be executed in order to confirm
     function confirmAction(actionCode, actionData, mapIndicator) {
         var showImmediate = true
-        closeAll()
+
+        // Cancel any previously pending action, notifying its map indicator if it differs from the incoming one
+        confirmDialog.confirmCancelled(mapIndicator)
+
         confirmDialog.action = actionCode
         confirmDialog.actionData = actionData
-        confirmDialog.hideTrigger = true
         confirmDialog.mapIndicator = mapIndicator
         confirmDialog.optionText = ""
         _actionData = actionData
@@ -398,7 +400,6 @@ Item {
         case actionMVArm:
             confirmDialog.title = mvArmTitle
             confirmDialog.message = mvArmMessage
-            confirmDialog.hideTrigger = true
             break;
         case actionForceArm:
             confirmDialog.title = forceArmTitle
@@ -416,7 +417,6 @@ Item {
         case actionMVDisarm:
             confirmDialog.title = mvDisarmTitle
             confirmDialog.message = mvDisarmMessage
-            confirmDialog.hideTrigger = true
             break;
         case actionEmergencyStop:
             confirmDialog.title = emergencyStopTitle
@@ -438,7 +438,6 @@ Item {
         case actionMVStartMission:
             confirmDialog.title = mvStartMissionTitle
             confirmDialog.message = mvStartMissionMessage
-            confirmDialog.hideTrigger = true
             break;
         case actionContinueMission:
             showImmediate = false
@@ -510,7 +509,6 @@ Item {
         case actionMVPause:
             confirmDialog.title = mvPauseTitle
             confirmDialog.message = mvPauseMessage
-            confirmDialog.hideTrigger = true
             break;
         case actionROI:
             confirmDialog.title = roiTitle
@@ -518,7 +516,6 @@ Item {
             confirmDialog.hideTrigger = Qt.binding(function() { return !showROI })
             break;
         case actionChangeSpeed:
-            confirmDialog.hideTrigger = true
             confirmDialog.title = changeSpeedTitle
             confirmDialog.message = changeSpeedMessage
             guidedValueSlider.visible = true


### PR DESCRIPTION
Fixes #13711

## Problem

`confirmAction()` conflated two distinct operations:
- **State reset** (clearing dialog visibility, timers, slider)
- **Cancellation** (notifying the map indicator that the action was rejected)

`hideTrigger = true` was being set at the start of `confirmAction()` and in several switch cases (MVArm, MVDisarm, MVStartMission, MVPause, ChangeSpeed). Because `onHideTriggerChanged` fires `confirmCancelled()` whenever `hideTrigger` becomes `true`, this incorrectly called `actionCancelled()` on map indicators (e.g. `orbitMapCircle`) during action *setup*, not during actual user cancellation.

Additionally, when one action superseded another (e.g. Orbit → Arm), the old map indicator's `actionCancelled()` was never called, leaving the orbit circle visible with no cleanup.

## Fix

- Extract `reset()` from `confirmCancelled()` for pure state cleanup with no cancel notification
- Add `incomingIndicator` parameter to `confirmCancelled()`: skips `actionCancelled()` if the old and new indicator are the same object, preserving `show()` calls made before `confirmAction()` (e.g. goto→goto where `gotoLocationItem.show()` is called before `confirmAction()`)
- Replace the ad-hoc guard block in `confirmAction()` with a single `confirmCancelled(mapIndicator)` call, correctly notifying the previous indicator when an action is superseded
- Remove redundant `hideTrigger = true` assignments from switch cases that had no auto-hide condition
- Remove redundant `closeAll()` call from inside `confirmAction()`