### PR TITLE
Fix batteryIndex not passed to BatteryParams in calc dialogs

### DIFF
--- a/src/AutoPilotPlugins/APM/APMCalcAmpsPerVoltDialog.qml
+++ b/src/AutoPilotPlugins/APM/APMCalcAmpsPerVoltDialog.qml
@@ -6,6 +6,7 @@ import QGroundControl.FactControls
 import QGroundControl.Controls
 
 QGCPopupDialog {
+    id:         popupDialog
     title:      qsTr("Calculate Amps per Volt")
     buttons:    Dialog.Close
 
@@ -16,7 +17,7 @@ QGCPopupDialog {
     APMBatteryParams {
         id:             batParams
         controller:     _controller
-        batteryIndex:   parent.batteryIndex
+        batteryIndex:   popupDialog.batteryIndex
     }
 
     ColumnLayout {

--- a/src/AutoPilotPlugins/APM/APMCalcVoltageDividerDialog.qml
+++ b/src/AutoPilotPlugins/APM/APMCalcVoltageDividerDialog.qml
@@ -6,6 +6,7 @@ import QGroundControl.FactControls
 import QGroundControl.Controls
 
 QGCPopupDialog {
+    id:         popupDialog
     title:      qsTr("Calculate Voltage Multiplier")
     buttons:    Dialog.Close
 
@@ -16,7 +17,7 @@ QGCPopupDialog {
     APMBatteryParams {
         id:             batParams
         controller:     _controller
-        batteryIndex:   parent.batteryIndex
+        batteryIndex:   popupDialog.batteryIndex
     }
 
     ColumnLayout {

--- a/src/AutoPilotPlugins/PX4/CalcAmpsPerVoltDialog.qml
+++ b/src/AutoPilotPlugins/PX4/CalcAmpsPerVoltDialog.qml
@@ -6,6 +6,7 @@ import QGroundControl.FactControls
 import QGroundControl.Controls
 
 QGCPopupDialog {
+    id:         popupDialog
     title:      qsTr("Calculate Amps per Volt")
     buttons:    Dialog.Close
 
@@ -16,7 +17,7 @@ QGCPopupDialog {
     BatteryParams {
         id:             batParams
         controller:     _controller
-        batteryIndex:   parent.batteryIndex
+        batteryIndex:   popupDialog.batteryIndex
     }
 
     ColumnLayout {

--- a/src/AutoPilotPlugins/PX4/CalcVoltageDividerDialog.qml
+++ b/src/AutoPilotPlugins/PX4/CalcVoltageDividerDialog.qml
@@ -6,6 +6,7 @@ import QGroundControl.FactControls
 import QGroundControl.Controls
 
 QGCPopupDialog {
+    id:         popupDialog
     title:      qsTr("Calculate Voltage Divider")
     buttons:    Dialog.Close
 
@@ -16,7 +17,7 @@ QGCPopupDialog {
     BatteryParams {
         id:             batParams
         controller:     _controller
-        batteryIndex:   parent.batteryIndex
+        batteryIndex:   popupDialog.batteryIndex
     }
 
     ColumnLayout {


### PR DESCRIPTION
## Summary

`BatteryParams` and `APMBatteryParams` are `QtObject` types, which have no visual parent. The previous code used `parent.batteryIndex` inside these objects, which resolves to the C++ `QObject` parent pointer rather than the enclosing dialog component — so `batteryIndex` was always `undefined`.

This caused:
- `Unable to assign [undefined] to int` on dialog open
- `Missing parameter: "BAT0_SOURCE"` (undefined coerced to 0)
- `TypeError: Cannot read property 'valueString' of null` (null fact group)

## Fix

Add `id: popupDialog` to all four affected dialogs and reference `popupDialog.batteryIndex` directly. This ensures the correct battery index is passed regardless of the child's type.

## Files Changed

- `src/AutoPilotPlugins/PX4/CalcVoltageDividerDialog.qml`
- `src/AutoPilotPlugins/PX4/CalcAmpsPerVoltDialog.qml`
- `src/AutoPilotPlugins/APM/APMCalcVoltageDividerDialog.qml`
- `src/AutoPilotPlugins/APM/APMCalcAmpsPerVoltDialog.qml`
