### PR TITLE
ParameterEditor: fix MP .param import, fix Fact float precision formatting

### DIFF
--- a/src/FactSystem/Fact.cc
+++ b/src/FactSystem/Fact.cc
@@ -1,3 +1,9 @@
+#include <cmath>
+#include <cstdio>
+#include <cstdlib>
+#include <cstring>
+#include <limits>
+
 #include "Fact.h"
 #include "FactValueSliderListModel.h"
 #include "AppMessages.h"
@@ -427,7 +433,40 @@ QString Fact::invalidValueString(int decimalPlaces) const {
 
 QString Fact::rawValueStringFullPrecision() const
 {
-    return _variantToString(rawValue(), 18);
+    if (type() == FactMetaData::valueTypeFloat) {
+        const float fValue = rawValue().toFloat();
+        if (std::isnan(fValue)) {
+            return invalidValueString(0);
+        }
+        // Find the shortest decimal string that round-trips back to the same float bits.
+        // snprintf with "%.*g" formats to p significant digits; strtof checks the round-trip.
+        // TODO: replace with std::to_chars once macOS min target >= 13.3
+        char buf[32];
+        for (int p = 1; p <= std::numeric_limits<float>::max_digits10; ++p) {
+            std::snprintf(buf, sizeof(buf), "%.*g", p, static_cast<double>(fValue));
+            if (std::strtof(buf, nullptr) == fValue) {
+                break;
+            }
+        }
+        if (std::strcmp(buf, "-0") == 0) {
+            buf[0] = '0';
+            buf[1] = '\0';
+        }
+        return QString::fromLatin1(buf);
+    } else if (type() == FactMetaData::valueTypeDouble) {
+        const double dValue = rawValue().toDouble();
+        if (std::isnan(dValue)) {
+            return invalidValueString(0);
+        }
+        // TODO: replace with std::to_chars once macOS min target >= 13.3
+        QString result = QString::number(dValue, 'g', QLocale::FloatingPointShortest);
+        if (result == QStringLiteral("-0")) {
+            result = QStringLiteral("0");
+        }
+        return result;
+    } else {
+        return _variantToString(rawValue(), 0);
+    }
 }
 
 QString Fact::rawValueString() const

--- a/src/QmlControls/ParameterEditor.qml
+++ b/src/QmlControls/ParameterEditor.qml
@@ -26,6 +26,14 @@ Item {
         id: controller
     }
 
+    Connections {
+        target: controller
+        function onMissingParamsFromFile(missingParams) {
+            QGroundControl.showMessageDialog(_root, qsTr("Missing Parameters"),
+                qsTr("The following parameters from the file were not found on the vehicle and were skipped: %1").arg(missingParams.join("\n")))
+        }
+    }
+
     Timer {
         id:         clearTimer
         interval:   100;

--- a/src/QmlControls/ParameterEditorController.cc
+++ b/src/QmlControls/ParameterEditorController.cc
@@ -363,6 +363,7 @@ void ParameterEditorController::clearDiff(void)
     _diffList.clearAndDeleteContents();
     _diffOtherVehicle = false;
     _diffMultipleComponents = false;
+    _diffMissingParams.clear();
 
     emit diffOtherVehicleChanged(_diffOtherVehicle);
     emit diffMultipleComponentsChanged(_diffMultipleComponents);
@@ -402,19 +403,21 @@ bool ParameterEditorController::buildDiffFromFile(const QString& filename)
     while (!stream.atEnd()) {
         QString line = stream.readLine();
         if (!line.startsWith("#") && !line.trimmed().isEmpty()) {
-            QStringList wpParams = line.trimmed().split(QRegularExpression("[\\t ]+"));
+            QStringList wpParams = line.trimmed().split(QRegularExpression("[\\t ,]+"));
+
+            int         componentId     = -1;
+            QString     paramName;
+            QString     fileValueStr;
+            int         mavParamType    = -1;
+            bool        isMPFormat      = false;
+
             if (wpParams.size() == 5) {
-                parsedLineCount++;
-                int         vehicleId       = wpParams.at(0).toInt();
-                int         componentId     = wpParams.at(1).toInt();
-                QString     paramName       = wpParams.at(2);
-                QString     fileValueStr    = wpParams.at(3);
-                int         mavParamType    = wpParams.at(4).toInt();
-                QString     vehicleValueStr;
-                QString     units;
-                QVariant    fileValueVar    = fileValueStr;
-                bool        noVehicleValue   = false;
-                bool        readOnly         = false;
+                // QGC tab-delimited: VehicleId ComponentId Name Value Type
+                int vehicleId   = wpParams.at(0).toInt();
+                componentId     = wpParams.at(1).toInt();
+                paramName       = wpParams.at(2);
+                fileValueStr    = wpParams.at(3);
+                mavParamType    = wpParams.at(4).toInt();
 
                 if (_vehicle->id() != vehicleId) {
                     _diffOtherVehicle = true;
@@ -424,45 +427,69 @@ bool ParameterEditorController::buildDiffFromFile(const QString& filename)
                 } else if (firstComponentId != componentId) {
                     _diffMultipleComponents = true;
                 }
+            } else if (wpParams.size() == 2) {
+                // Mission Planner 2-column: Name Value
+                paramName       = wpParams.at(0);
+                fileValueStr    = wpParams.at(1);
+                componentId     = ParameterManager::defaultComponentId;
+                isMPFormat      = true;
+            } else {
+                continue;
+            }
 
-                if (_parameterMgr->parameterExists(componentId, paramName)) {
-                    Fact*           vehicleFact         = _parameterMgr->getParameter(componentId, paramName);
-                    FactMetaData*   vehicleFactMetaData = vehicleFact->metaData();
-                    Fact*           fileFact            = new Fact(vehicleFact->componentId(), vehicleFact->name(), vehicleFact->type(), this);
+            parsedLineCount++;
 
-                    // Turn off reboot messaging before setting value in fileFact
-                    bool vehicleRebootRequired = vehicleFactMetaData->vehicleRebootRequired();
-                    vehicleFactMetaData->setVehicleRebootRequired(false);
-                    fileFact->setMetaData(vehicleFact->metaData());
-                    fileFact->setRawValue(fileValueStr);
-                    vehicleFactMetaData->setVehicleRebootRequired(vehicleRebootRequired);
-                    readOnly = vehicleFact->readOnly();
+            QString     vehicleValueStr;
+            QString     units;
+            QVariant    fileValueVar    = fileValueStr;
+            bool        noVehicleValue  = false;
+            bool        readOnly        = false;
 
-                    if (vehicleFact->rawValue() == fileFact->rawValue()) {
-                        continue;
-                    }
-                    fileValueStr    = fileFact->enumOrValueString();
-                    fileValueVar    = fileFact->rawValue();
-                    vehicleValueStr = vehicleFact->enumOrValueString();
-                    units           = vehicleFact->cookedUnits();
-                } else {
-                    noVehicleValue = true;
+            if (_parameterMgr->parameterExists(componentId, paramName)) {
+                Fact*           vehicleFact         = _parameterMgr->getParameter(componentId, paramName);
+                FactMetaData*   vehicleFactMetaData = vehicleFact->metaData();
+                Fact*           fileFact            = new Fact(vehicleFact->componentId(), vehicleFact->name(), vehicleFact->type(), this);
+
+                if (mavParamType == -1) {
+                    mavParamType = ParameterManager::factTypeToMavType(vehicleFact->type());
                 }
 
-                if (!readOnly) {
-                    ParameterEditorDiff* paramDiff = new ParameterEditorDiff(this);
+                // Turn off reboot messaging before setting value in fileFact
+                bool vehicleRebootRequired = vehicleFactMetaData->vehicleRebootRequired();
+                vehicleFactMetaData->setVehicleRebootRequired(false);
+                fileFact->setMetaData(vehicleFact->metaData());
+                fileFact->setRawValue(fileValueStr);
+                vehicleFactMetaData->setVehicleRebootRequired(vehicleRebootRequired);
+                readOnly = vehicleFact->readOnly();
 
-                    paramDiff->componentId      = componentId;
-                    paramDiff->name             = paramName;
-                    paramDiff->valueType        = ParameterManager::mavTypeToFactType(static_cast<MAV_PARAM_TYPE>(mavParamType));
-                    paramDiff->fileValue        = fileValueStr;
-                    paramDiff->fileValueVar     = fileValueVar;
-                    paramDiff->vehicleValue     = vehicleValueStr;
-                    paramDiff->noVehicleValue   = noVehicleValue;
-                    paramDiff->units            = units;
-
-                    _diffList.append(paramDiff);
+                if (vehicleFact->rawValue() == fileFact->rawValue()) {
+                    continue;
                 }
+                fileValueStr    = fileFact->enumOrValueString();
+                fileValueVar    = fileFact->rawValue();
+                vehicleValueStr = vehicleFact->enumOrValueString();
+                units           = vehicleFact->cookedUnits();
+            } else if (isMPFormat) {
+                // MP format: skip params not on vehicle and report them
+                _diffMissingParams.append(paramName);
+                continue;
+            } else {
+                noVehicleValue = true;
+            }
+
+            if (!readOnly) {
+                ParameterEditorDiff* paramDiff = new ParameterEditorDiff(this);
+
+                paramDiff->componentId      = componentId;
+                paramDiff->name             = paramName;
+                paramDiff->valueType        = ParameterManager::mavTypeToFactType(static_cast<MAV_PARAM_TYPE>(mavParamType));
+                paramDiff->fileValue        = fileValueStr;
+                paramDiff->fileValueVar     = fileValueVar;
+                paramDiff->vehicleValue     = vehicleValueStr;
+                paramDiff->noVehicleValue   = noVehicleValue;
+                paramDiff->units            = units;
+
+                _diffList.append(paramDiff);
             }
         }
     }
@@ -476,6 +503,9 @@ bool ParameterEditorController::buildDiffFromFile(const QString& filename)
 
     emit diffOtherVehicleChanged(_diffOtherVehicle);
     emit diffMultipleComponentsChanged(_diffMultipleComponents);
+    if (!_diffMissingParams.isEmpty()) {
+        emit missingParamsFromFile(_diffMissingParams);
+    }
 
     return true;
 }

--- a/src/QmlControls/ParameterEditorController.h
+++ b/src/QmlControls/ParameterEditorController.h
@@ -174,6 +174,7 @@ signals:
     void diffOtherVehicleChanged        (bool diffOtherVehicle);
     void diffMultipleComponentsChanged  (bool diffMultipleComponents);
     void parametersChanged              (void);
+    void missingParamsFromFile          (const QStringList& missingParams);
 
 private slots:
     void _currentCategoryChanged(void);
@@ -201,6 +202,7 @@ private:
     bool                        _hideReadOnly           = false;
     bool                        _diffOtherVehicle       = false;
     bool                        _diffMultipleComponents = false;
+    QStringList                 _diffMissingParams;
     QSet<QString>               _favoriteNames;
 
     QmlObjectListModel          _categories;

--- a/test/FactSystem/FactTest.cc
+++ b/test/FactSystem/FactTest.cc
@@ -1,6 +1,7 @@
 #include "FactTest.h"
 #include <QtTest/QSignalSpy>
 
+#include <cstdlib>
 
 #include "Fact.h"
 #include "FactMetaData.h"
@@ -213,6 +214,53 @@ void FactTest::_valueEqualsDefault_test()
 
     fact.setRawValue(QVariant(99));
     QVERIFY(!fact.valueEqualsDefault());
+}
+
+void FactTest::_rawValueStringFullPrecisionFloat_test()
+{
+    Fact fact(0, "FloatParam", FactMetaData::valueTypeFloat);
+
+    // Integer-valued float: no decimal point noise
+    fact.setRawValue(QVariant(1.0f));
+    QCOMPARE(fact.rawValueStringFullPrecision(), QStringLiteral("1"));
+
+    // Simple decimal: only significant digits
+    fact.setRawValue(QVariant(0.912f));
+    const QString s1 = fact.rawValueStringFullPrecision();
+    QVERIFY2(s1.length() <= 8, qPrintable(QStringLiteral("Expected short string, got: ") + s1));
+    QCOMPARE(std::strtof(s1.toLatin1().constData(), nullptr), 0.912f);
+
+    // Round-trip guarantee: parsed value equals original bits
+    fact.setRawValue(QVariant(4.05f));
+    const QString s2 = fact.rawValueStringFullPrecision();
+    QCOMPARE(std::strtof(s2.toLatin1().constData(), nullptr), 4.05f);
+
+    fact.setRawValue(QVariant(-1.5f));
+    QCOMPARE(std::strtof(fact.rawValueStringFullPrecision().toLatin1().constData(), nullptr), -1.5f);
+
+    // Zero
+    fact.setRawValue(QVariant(0.0f));
+    QCOMPARE(fact.rawValueStringFullPrecision(), QStringLiteral("0"));
+}
+
+void FactTest::_rawValueStringFullPrecisionDouble_test()
+{
+    Fact fact(0, "DblParam", FactMetaData::valueTypeDouble);
+
+    fact.setRawValue(QVariant(1.0));
+    QCOMPARE(fact.rawValueStringFullPrecision(), QStringLiteral("1"));
+
+    fact.setRawValue(QVariant(3.14));
+    const QString s1 = fact.rawValueStringFullPrecision();
+    QCOMPARE(std::strtod(s1.toLatin1().constData(), nullptr), 3.14);
+
+    // Round-trip guarantee
+    fact.setRawValue(QVariant(0.0912));
+    const QString s2 = fact.rawValueStringFullPrecision();
+    QCOMPARE(std::strtod(s2.toLatin1().constData(), nullptr), 0.0912);
+
+    fact.setRawValue(QVariant(0.0));
+    QCOMPARE(fact.rawValueStringFullPrecision(), QStringLiteral("0"));
 }
 
 UT_REGISTER_TEST(FactTest, TestLabel::Unit)

--- a/test/FactSystem/FactTest.h
+++ b/test/FactSystem/FactTest.h
@@ -23,4 +23,6 @@ private slots:
     void _typeIsString_test();
     void _typeIsBool_test();
     void _valueEqualsDefault_test();
+    void _rawValueStringFullPrecisionFloat_test();
+    void _rawValueStringFullPrecisionDouble_test();
 };

--- a/test/FactSystem/ParameterEditorControllerTest.cc
+++ b/test/FactSystem/ParameterEditorControllerTest.cc
@@ -3,6 +3,7 @@
 #include <QtCore/QString>
 #include <QtCore/QRegularExpression>
 #include <QtTest/QTest>
+#include <QtTest/QSignalSpy>
 
 #include "ParameterEditorController.h"
 #include "QmlObjectListModel.h"
@@ -25,15 +26,20 @@ static const char* kQGCParamsNoDiff =
     "# Vehicle-Id Component-Id Name Value Type\n"
     "1\t1\tSYS_AUTOSTART\t4001\t6\n";
 
-// Mission Planner space-delimited file with same diff
+// Mission Planner 2-column file with same diff
 static const char* kMPParamsWithDiff =
     "# Mission Planner parameter file\n"
-    "1 1 SYS_AUTOSTART 4002 6\n";
+    "SYS_AUTOSTART,4002\n";
 
-// Mission Planner space-delimited file matching vehicle default
+// Mission Planner 2-column file matching vehicle default
 static const char* kMPParamsNoDiff =
     "# Mission Planner parameter file\n"
-    "1 1 SYS_AUTOSTART 4001 6\n";
+    "SYS_AUTOSTART,4001\n";
+
+// Mission Planner 2-column file with a parameter not on the vehicle
+static const char* kMPParamsMissingParam =
+    "# Mission Planner parameter file\n"
+    "NONEXISTENT_PARAM_XYZ,1\n";
 
 // Garbage — no parseable lines
 static const char* kBadFormatParams =
@@ -143,4 +149,26 @@ void ParameterEditorControllerTest::_buildDiffMissingOnVehicle()
     QVERIFY(diff);
     QVERIFY(diff->noVehicleValue);
     QCOMPARE(diff->name, QStringLiteral("NONEXISTENT_PARAM_XYZ"));
+}
+
+void ParameterEditorControllerTest::_buildDiffMPMissingParam()
+{
+    TestFixtures::TempFileFixture tempFile(QStringLiteral("test_XXXXXX.param"));
+    QVERIFY(tempFile.isValid());
+    QVERIFY(tempFile.write(QByteArray(kMPParamsMissingParam)));
+    QVERIFY(tempFile.file()->flush());
+
+    ParameterEditorController controller;
+    QSignalSpy missingSpy(&controller, &ParameterEditorController::missingParamsFromFile);
+    const bool result = controller.buildDiffFromFile(tempFile.path());
+
+    // File had a parseable line (parsedLineCount > 0) → returns true
+    QVERIFY(result);
+    // Unknown MP param is skipped — diff list stays empty
+    QCOMPARE(controller.diffList()->count(), 0);
+    // Signal emitted once with the missing param name
+    QCOMPARE(missingSpy.count(), 1);
+    const QStringList missingParams = missingSpy.at(0).at(0).toStringList();
+    QCOMPARE(missingParams.count(), 1);
+    QCOMPARE(missingParams.at(0), QStringLiteral("NONEXISTENT_PARAM_XYZ"));
 }

--- a/test/FactSystem/ParameterEditorControllerTest.h
+++ b/test/FactSystem/ParameterEditorControllerTest.h
@@ -13,4 +13,5 @@ private slots:
     void _buildDiffNoDifferencesMP();
     void _buildDiffBadFormat();
     void _buildDiffMissingOnVehicle();
+    void _buildDiffMPMissingParam();
 };


### PR DESCRIPTION
Fixes #14451, related to #12881

## ParameterEditorController

- Support Mission Planner 2-column `.param` file format (`Name Value`) in `buildDiffFromFile` in addition to the existing QGC 5-column format
- Fix delimiter splitting to handle tab, space, and comma separators so MP files parse correctly
- Track parameters from MP files that are not present on the vehicle and emit `missingParamsFromFile` signal so the UI can inform the user
- Clear `_diffMissingParams` in `clearDiff()`

## ParameterEditor.qml

- Fix `onMissingParamsFromFile` handler: replace invalid QML syntax `QGC::showAppMessage(...)` with `QGroundControl.showMessageDialog(...)`
- Display each missing parameter name on its own line instead of a single comma-separated line that does not wrap

## Fact.cc

- Replace Qt float formatting loop (`QString::number` / `.toFloat()`) with std equivalents: `snprintf` / `strtof` / `strcmp`
- Normalise `-0` output via `strcmp` instead of `QString` comparison
- Increase `snprintf` buffer from 16 to 32 bytes (defensive against 3-digit exponent renderers on older MSVC runtimes)
- Move std system headers before project headers per convention

## Tests

- Add unit tests for `rawValueStringFullPrecision()` (float and double) using `strtof`/`strtod` round-trip assertions
- Add unit tests for `ParameterEditorController` MP format parsing and `missingParamsFromFile` signal
