### PR TITLE
feat(LogViewer): dual hover+fixed cursor, extract Parameters/Messages tabs, fix console.log

### DIFF
--- a/src/AnalyzeView/LogViewer/CMakeLists.txt
+++ b/src/AnalyzeView/LogViewer/CMakeLists.txt
@@ -41,6 +41,9 @@ qt_add_qml_module(LogViewerModule
     QML_FILES
         LogViewerAltChart.qml
         LogViewerChart.qml
+        LogViewerFieldsPanel.qml
+        LogViewerMessagesTab.qml
+        LogViewerParametersTab.qml
     NO_PLUGIN
 )
 

--- a/src/AnalyzeView/LogViewer/LogViewerChart.qml
+++ b/src/AnalyzeView/LogViewer/LogViewerChart.qml
@@ -19,12 +19,21 @@ ColumnLayout {
     // -------------------------------------------------------------------------
     // Internal state
     // -------------------------------------------------------------------------
+    // Fixed cursor — set by clicking on the chart
     property bool   _positionMarkerVisible: false
     property real   _markerPixelX: 0
     property real   _markerXValue: 0
     property var    _markerRows: []
     property var    _markerEventRows: []
     property string _markerModeName: ""
+
+    // Hover cursor — follows mouse, disappears when mouse leaves chart
+    property bool   _hoverVisible: false
+    property real   _hoverPixelX: 0
+    property real   _hoverXValue: 0
+    property var    _hoverRows: []
+    property var    _hoverEventRows: []
+    property string _hoverModeName: ""
 
     property real   _fullMinX: 0
     property real   _fullMaxX: 1
@@ -169,14 +178,13 @@ ColumnLayout {
     // -------------------------------------------------------------------------
     // Marker / cursor
     // -------------------------------------------------------------------------
-    function _queryCursorValues() {
-        _markerModeName = logParser.modeAt(_markerXValue)
-
+    function _queryValuesAtTime(xValue) {
+        const modeName = logParser.modeAt(xValue)
         const selectedFields = logViewerController.selectedFields
         const rows = []
         for (let i = 0; i < selectedFields.length; i++) {
             const field = selectedFields[i]
-            const value = logParser.fieldValueAt(field, _markerXValue)
+            const value = logParser.fieldValueAt(field, xValue)
             if (isNaN(value)) continue
             const fr = _fieldFullRange[field]
             rows.push({
@@ -187,24 +195,43 @@ ColumnLayout {
                 max:   fr ? fr.max : NaN
             })
         }
-        _markerRows = rows
-
         const threshold = Math.max(0.05, (_binXAxis.max - _binXAxis.min) / 200.0)
-        const nearbyEvents = logParser.eventsNear(_markerXValue, threshold)
+        const nearbyEvents = logParser.eventsNear(xValue, threshold)
         const events = []
         for (let i = 0; i < nearbyEvents.length; i++) {
             events.push({ color: eventColor(nearbyEvents[i].type), text: nearbyEvents[i].description })
         }
-        _markerEventRows = events
+        return { modeName: modeName, rows: rows, events: events }
     }
 
-    function _updateCursorInfo(pixelX, pixelY, w, h) {
-        if (w <= 0 || h <= 0 || _binXAxis.max <= _binXAxis.min) return
+    function _queryCursorValues() {
+        const result = _queryValuesAtTime(_markerXValue)
+        _markerModeName = result.modeName
+        _markerRows = result.rows
+        _markerEventRows = result.events
+    }
+
+    function _queryHoverValues() {
+        const result = _queryValuesAtTime(_hoverXValue)
+        _hoverModeName = result.modeName
+        _hoverRows = result.rows
+        _hoverEventRows = result.events
+    }
+
+    function _updateCursorInfo(pixelX) {
+        if (_binXAxis.max <= _binXAxis.min) return
         _positionMarkerVisible = true
         _markerPixelX = Math.max(_binChart.plotArea.x, Math.min(_binChart.plotArea.x + _binChart.plotArea.width, pixelX))
         _markerXValue = _pixelToAxisX(_markerPixelX)
         _queryCursorValues()
         cursorMoved(_markerXValue)
+    }
+
+    function _updateHoverInfo(pixelX) {
+        if (_binXAxis.max <= _binXAxis.min) return
+        _hoverPixelX = Math.max(_binChart.plotArea.x, Math.min(_binChart.plotArea.x + _binChart.plotArea.width, pixelX))
+        _hoverXValue = _pixelToAxisX(_hoverPixelX)
+        _queryHoverValues()
     }
 
     function _refreshCursorPixelPos() {
@@ -227,6 +254,10 @@ ColumnLayout {
         _positionMarkerVisible = true
         _markerPixelX = _axisXToPixel(_markerXValue)
         _queryCursorValues()
+        if (_hoverVisible) {
+            _hoverPixelX = _axisXToPixel(_hoverXValue)
+            _queryHoverValues()
+        }
     }
 
     // Public: called by parent on log clear
@@ -234,6 +265,9 @@ ColumnLayout {
         _positionMarkerVisible = false
         _markerRows = []
         _markerEventRows = []
+        _hoverVisible = false
+        _hoverRows = []
+        _hoverEventRows = []
     }
 
     // -------------------------------------------------------------------------
@@ -564,6 +598,7 @@ ColumnLayout {
             id: _chartZoomArea
             anchors.fill: parent
             enabled: _binXAxis.max > _binXAxis.min
+            hoverEnabled: !ScreenTools.isMobile
             acceptedButtons: Qt.LeftButton | Qt.RightButton
             z: 1001
 
@@ -574,6 +609,7 @@ ColumnLayout {
                     resetZoom()
                     return
                 }
+                _hoverVisible = false
                 _dragStartX = mouse.x
                 _zoomSelectionRect.x = mouse.x
                 _zoomSelectionRect.y = _binChart.plotArea.y
@@ -582,12 +618,25 @@ ColumnLayout {
                 _zoomSelectionRect.visible = true
             }
 
+            onEntered: (mouse) => {
+                _hoverVisible = hoverEnabled && (_binXAxis.max > _binXAxis.min)
+                if (_hoverVisible) {
+                    _updateHoverInfo(mouse.x)
+                }
+            }
+
+            onExited: {
+                _hoverVisible = false
+            }
+
             onPositionChanged: (mouse) => {
                 if (pressed && _zoomSelectionRect.visible) {
                     const left  = Math.min(_dragStartX, mouse.x)
                     const right = Math.max(_dragStartX, mouse.x)
                     _zoomSelectionRect.x = left
                     _zoomSelectionRect.width = Math.max(0, right - left)
+                } else if (!pressed && hoverEnabled) {
+                    _updateHoverInfo(mouse.x)
                 }
             }
 
@@ -595,8 +644,12 @@ ColumnLayout {
                 if (!_zoomSelectionRect.visible) return
                 const dragWidth = _zoomSelectionRect.width
                 _zoomSelectionRect.visible = false
+                _hoverVisible = hoverEnabled && (_binXAxis.max > _binXAxis.min)
+                if (hoverEnabled) {
+                    _updateHoverInfo(mouse.x)
+                }
                 if (dragWidth < ScreenTools.defaultFontPixelWidth * 0.5) {
-                    _updateCursorInfo(mouse.x, mouse.y, width, height)
+                    _updateCursorInfo(mouse.x)
                     return
                 }
                 const leftX  = _pixelToAxisX(_zoomSelectionRect.x)
@@ -605,7 +658,7 @@ ColumnLayout {
             }
         }
 
-        // Position marker line
+        // Fixed cursor marker line (set by click)
         Rectangle {
             visible: _positionMarkerVisible
             x: _markerPixelX
@@ -616,10 +669,21 @@ ColumnLayout {
             z: 1002
         }
 
-        // Value popup
+        // Hover cursor marker line (follows mouse)
+        Rectangle {
+            visible: _hoverVisible
+            x: _hoverPixelX
+            y: _binChart.plotArea.y
+            width: 1
+            height: _binChart.plotArea.height
+            color: Qt.rgba(qgcPal.text.r, qgcPal.text.g, qgcPal.text.b, 0.45)
+            z: 1002
+        }
+
+        // Fixed cursor popup (click)
         Rectangle {
             id: _valuePopup
-            x: _popupX()
+            x: _popupX(_markerPixelX)
             y: _binChart.plotArea.y
             z: 1003
             implicitWidth: _valueColumnLayout.implicitWidth + (margin * 2)
@@ -632,14 +696,12 @@ ColumnLayout {
             property real margin: ScreenTools.defaultFontPixelWidth / 2
             property real colorBlockWidth: ScreenTools.defaultFontPixelHeight * 0.8
 
-            function _popupX() {
+            function _popupX(cursorPx) {
                 const plotMidX = _binChart.plotArea.x + _binChart.plotArea.width / 2
-                if (_markerPixelX < plotMidX) {
-                    // Cursor in left half — place popup on the right
+                if (cursorPx < plotMidX) {
                     const rightX = _binChart.plotArea.x + _binChart.plotArea.width - width
                     return Math.max(0, Math.min(rightX, _chartContainer.width - width))
                 } else {
-                    // Cursor in right half — place popup on the left
                     return Math.max(0, _binChart.plotArea.x)
                 }
             }
@@ -675,7 +737,6 @@ ColumnLayout {
                     ColumnLayout {
                         spacing: ScreenTools.defaultFontPixelHeight * 0.15
 
-                        // Line 1: color block + field name
                         RowLayout {
                             spacing: ScreenTools.defaultFontPixelWidth * 0.4
 
@@ -693,7 +754,6 @@ ColumnLayout {
                             }
                         }
 
-                        // Line 2: Current / Min / Max
                         RowLayout {
                             Layout.leftMargin: _valuePopup.colorBlockWidth + ScreenTools.defaultFontPixelWidth * 0.4
                             spacing: ScreenTools.defaultFontPixelWidth * 0.3
@@ -723,6 +783,113 @@ ColumnLayout {
                         Rectangle {
                             Layout.preferredWidth: _valuePopup.colorBlockWidth
                             Layout.preferredHeight: _valuePopup.colorBlockWidth
+                            color: modelData.color
+                        }
+
+                        QGCLabel {
+                            Layout.maximumWidth: ScreenTools.defaultFontPixelWidth * 20
+                            wrapMode: Text.WordWrap
+                            maximumLineCount: 2
+                            text: modelData.text
+                        }
+                    }
+                }
+            }
+        }
+
+        // Hover cursor popup (mouse position)
+        Rectangle {
+            id: _hoverPopup
+            x: _hoverPopupX(_hoverPixelX)
+            y: _binChart.plotArea.y + _binChart.plotArea.height - height
+            z: 1004
+            implicitWidth: _hoverColumnLayout.implicitWidth + (margin * 2)
+            implicitHeight: _hoverColumnLayout.implicitHeight + (margin * 2)
+            color: Qt.rgba(qgcPal.windowShade.r, qgcPal.windowShade.g, qgcPal.windowShade.b, 0.85)
+            border.color: qgcPal.windowShadeDark
+            radius: ScreenTools.defaultFontPixelWidth * 0.3
+            visible: _hoverVisible
+
+            property real margin: ScreenTools.defaultFontPixelWidth / 2
+            property real colorBlockWidth: ScreenTools.defaultFontPixelHeight * 0.8
+
+            function _hoverPopupX(cursorPx) {
+                const plotMidX = _binChart.plotArea.x + _binChart.plotArea.width / 2
+                if (cursorPx < plotMidX) {
+                    const rightX = _binChart.plotArea.x + _binChart.plotArea.width - width
+                    return Math.max(0, Math.min(rightX, _chartContainer.width - width))
+                } else {
+                    return Math.max(0, _binChart.plotArea.x)
+                }
+            }
+
+            ColumnLayout {
+                id: _hoverColumnLayout
+                anchors.fill: parent
+                anchors.margins: _hoverPopup.margin
+                spacing: ScreenTools.defaultFontPixelHeight * 0.2
+
+                QGCLabel {
+                    text: qsTr("t=%1 s").arg(_hoverXValue.toFixed(3))
+                    font.bold: true
+                }
+
+                RowLayout {
+                    visible: _hoverModeName.length > 0
+                    spacing: ScreenTools.defaultFontPixelWidth * 0.2
+
+                    Rectangle {
+                        Layout.preferredWidth: _hoverPopup.colorBlockWidth
+                        Layout.preferredHeight: _hoverPopup.colorBlockWidth
+                        color: modeColor(_hoverModeName)
+                    }
+
+                    QGCLabel { text: qsTr("Mode:") }
+                    QGCLabel { text: _hoverModeName; font.bold: true }
+                }
+
+                Repeater {
+                    model: _hoverRows
+
+                    ColumnLayout {
+                        spacing: ScreenTools.defaultFontPixelHeight * 0.15
+
+                        RowLayout {
+                            spacing: ScreenTools.defaultFontPixelWidth * 0.4
+
+                            Rectangle {
+                                Layout.preferredWidth:  _hoverPopup.colorBlockWidth
+                                Layout.preferredHeight: _hoverPopup.colorBlockWidth
+                                color: modelData.color
+                            }
+
+                            QGCLabel {
+                                width: _hoverPopup.width - (ScreenTools.defaultFontPixelWidth * 4)
+                                elide: Text.ElideMiddle
+                                text:  modelData.name
+                                font.bold: true
+                            }
+                        }
+
+                        RowLayout {
+                            Layout.leftMargin: _hoverPopup.colorBlockWidth + ScreenTools.defaultFontPixelWidth * 0.4
+                            spacing: ScreenTools.defaultFontPixelWidth * 0.3
+
+                            QGCLabel { text: qsTr("Current") }
+                            QGCLabel { text: Number(modelData.value).toFixed(3); font.bold: true }
+                        }
+                    }
+                }
+
+                Repeater {
+                    model: _hoverEventRows
+
+                    RowLayout {
+                        spacing: ScreenTools.defaultFontPixelWidth * 0.2
+
+                        Rectangle {
+                            Layout.preferredWidth: _hoverPopup.colorBlockWidth
+                            Layout.preferredHeight: _hoverPopup.colorBlockWidth
                             color: modelData.color
                         }
 

--- a/src/AnalyzeView/LogViewer/LogViewerFieldsPanel.qml
+++ b/src/AnalyzeView/LogViewer/LogViewerFieldsPanel.qml
@@ -1,0 +1,262 @@
+import QtQuick
+import QtQuick.Controls
+import QtQuick.Layouts
+
+import QGroundControl
+import QGroundControl.Controls
+
+/// Left panel for the Log Viewer charting tab.
+/// Shows log stats and the grouped fields list.
+Rectangle {
+    id: control
+
+    required property var logParser
+    required property var logViewerController
+
+    signal clearSelectedRequested
+
+    color: qgcPal.windowShade
+    radius: ScreenTools.defaultFontPixelWidth * 0.5
+    Layout.preferredWidth: mainLayout.implicitWidth + (mainLayout.anchors.margins * 2)
+
+    // -------------------------------------------------------------------------
+    // Internal state
+    // -------------------------------------------------------------------------
+    property string _fieldSearchText: ""
+    property var _filteredFieldRows: []
+    property real _maxFieldRowWidth: _minFieldRowWidth
+
+    readonly property real _minFieldRowWidth: ScreenTools.defaultFontPixelWidth
+    readonly property bool _isFirmwareLog: logViewerController.sourceType === LogViewerController.Bin
+                                        || logViewerController.sourceType === LogViewerController.ULog
+
+    QGCPalette { id: qgcPal }
+
+    // -------------------------------------------------------------------------
+    // Public API
+    // -------------------------------------------------------------------------
+
+    /// Called by the parent after a log finishes loading.
+    function rebuildGroupedFields() {
+        _maxFieldRowWidth = _minFieldRowWidth
+        logViewerController.setPlottableFields(logParser.plottableFields)
+        _applyFieldFilter()
+    }
+
+    // -------------------------------------------------------------------------
+    // Internal helpers
+    // -------------------------------------------------------------------------
+
+    function _applyFieldFilter() {
+        const query = String(_fieldSearchText).trim().toLowerCase()
+        if (query.length === 0) {
+            _filteredFieldRows = logViewerController.fieldRows
+            return
+        }
+
+        const groupedMap = {}
+        const fields = logParser.plottableFields
+        for (let i = 0; i < fields.length; i++) {
+            const fullName = String(fields[i])
+            const splitIndex = fullName.indexOf(".")
+            const groupName = splitIndex > 0 ? fullName.substring(0, splitIndex) : qsTr("Other")
+            const shortName = splitIndex > 0 ? fullName.substring(splitIndex + 1) : fullName
+            const haystack = (fullName + " " + groupName + " " + shortName).toLowerCase()
+            if (haystack.indexOf(query) === -1) {
+                continue
+            }
+            if (!groupedMap[groupName]) {
+                groupedMap[groupName] = []
+            }
+            groupedMap[groupName].push({ fullName: fullName, shortName: shortName })
+        }
+
+        const groups = Object.keys(groupedMap).sort()
+        const rows = []
+        for (let g = 0; g < groups.length; g++) {
+            const groupName = groups[g]
+            rows.push({ rowType: "group", group: groupName })
+            groupedMap[groupName].sort((a, b) => String(a.shortName).localeCompare(String(b.shortName)))
+            for (let s = 0; s < groupedMap[groupName].length; s++) {
+                rows.push({
+                    rowType:   "field",
+                    group:     groupName,
+                    fullName:  groupedMap[groupName][s].fullName,
+                    shortName: groupedMap[groupName][s].shortName
+                })
+            }
+        }
+        _filteredFieldRows = rows
+    }
+
+    function _isGroupExpanded(groupName) {
+        return logViewerController.isGroupExpanded(groupName)
+    }
+
+    function _toggleGroupExpanded(groupName) {
+        if (String(_fieldSearchText).trim().length > 0) {
+            return
+        }
+        logViewerController.toggleGroupExpanded(groupName)
+        _applyFieldFilter()
+    }
+
+    // -------------------------------------------------------------------------
+    // Connections
+    // -------------------------------------------------------------------------
+
+    Connections {
+        target: logViewerController
+        function onFieldRowsChanged() {
+            const savedY = _fieldsListView.contentY
+            _applyFieldFilter()
+            Qt.callLater(() => { _fieldsListView.contentY = savedY })
+        }
+    }
+
+    // -------------------------------------------------------------------------
+    // UI
+    // -------------------------------------------------------------------------
+
+    Component {
+        id: _groupRowComponent
+
+        Item {
+            width: _maxFieldRowWidth
+            implicitWidth: _groupLayout.implicitWidth
+            implicitHeight: _groupLayout.implicitHeight
+
+            Component.onCompleted: _maxFieldRowWidth = Math.max(_maxFieldRowWidth, implicitWidth)
+
+            RowLayout {
+                id: _groupLayout
+                spacing: ScreenTools.defaultFontPixelWidth / 2
+
+                QGCColoredImage {
+                    Layout.preferredWidth: _groupLabel.height * 0.5
+                    Layout.preferredHeight: _groupLabel.height * 0.5
+                    source: "/qmlimages/arrow-down.png"
+                    color: qgcPal.text
+                    fillMode: Image.PreserveAspectFit
+                    rotation: (String(control._fieldSearchText).trim().length > 0 || control._isGroupExpanded(rowData.group)) ? 0 : -90
+                }
+
+                QGCLabel {
+                    id: _groupLabel
+                    text: rowData.group
+                    font.bold: true
+                }
+            }
+
+            MouseArea {
+                anchors.fill: parent
+                onClicked: control._toggleGroupExpanded(rowData.group)
+            }
+        }
+    }
+
+    Component {
+        id: _fieldRowComponent
+
+        QGCCheckBoxSlider {
+            id: _fieldSlider
+            width: _maxFieldRowWidth
+            checked: logViewerController.selectedFields.indexOf(rowData.fullName) !== -1
+            text: rowData.shortName ? " " + String(rowData.shortName) : ""
+            onClicked: logViewerController.setFieldSelected(rowData.fullName, checked)
+
+            Component.onCompleted: _maxFieldRowWidth = Math.max(_maxFieldRowWidth, implicitWidth)
+        }
+    }
+
+    ColumnLayout {
+        id: mainLayout
+        anchors.top: parent.top
+        anchors.bottom: parent.bottom
+        anchors.left: parent.left
+        anchors.margins: ScreenTools.defaultFontPixelWidth / 2
+        spacing: ScreenTools.defaultFontPixelHeight * 0.5
+
+        QGCLabel {
+            visible: _isFirmwareLog
+            text: qsTr("Fields: %1  Parameters: %2  Events: %3")
+                  .arg(logParser.plottableFields.length)
+                  .arg(logParser.parameters.length)
+                  .arg(logParser.events.length)
+        }
+
+        QGCLabel {
+            visible: _isFirmwareLog
+            text: qsTr("Detected vehicle type: %1")
+                  .arg(logParser.detectedVehicleType.length > 0
+                       ? logParser.detectedVehicleType
+                       : qsTr("Unknown"))
+        }
+
+        RowLayout {
+            visible: _isFirmwareLog
+            spacing: ScreenTools.defaultFontPixelWidth * 0.5
+
+            QGCLabel {
+                text: qsTr("Fields")
+                font.bold: true
+            }
+
+            QGCTextField {
+                id: _fieldSearchField
+                Layout.fillWidth: true
+                textColor: qgcPal.textFieldText
+                placeholderTextColor: Qt.rgba(qgcPal.textFieldText.r, qgcPal.textFieldText.g, qgcPal.textFieldText.b, 0.7)
+                placeholderText: qsTr("Search fields")
+
+                onTextChanged: {
+                    control._fieldSearchText = text
+                    if (text.trim().length === 0) {
+                        _fieldSearchTimer.stop()
+                        control._applyFieldFilter()
+                    } else {
+                        _fieldSearchTimer.restart()
+                    }
+                }
+
+                onAccepted: {
+                    control._fieldSearchText = text
+                    _fieldSearchTimer.stop()
+                    control._applyFieldFilter()
+                }
+            }
+
+            QGCButton {
+                text: qsTr("Clear Selected")
+                enabled: logViewerController.selectedFields.length > 0
+
+                onClicked: {
+                    logViewerController.clearSelection()
+                    control._applyFieldFilter()
+                    control.clearSelectedRequested()
+                }
+            }
+        }
+
+        QGCListView {
+            id: _fieldsListView
+            Layout.fillHeight: true
+            Layout.preferredWidth: _maxFieldRowWidth + ScreenTools.defaultFontPixelWidth
+            visible: _isFirmwareLog
+            model: _filteredFieldRows
+            spacing: ScreenTools.defaultFontPixelHeight * 0.25
+
+            delegate: Loader {
+                sourceComponent: modelData.rowType === "group" ? _groupRowComponent : _fieldRowComponent
+                property var rowData: modelData
+            }
+        }
+    }
+
+    Timer {
+        id: _fieldSearchTimer
+        interval: 250
+        repeat: false
+        onTriggered: control._applyFieldFilter()
+    }
+}

--- a/src/AnalyzeView/LogViewer/LogViewerMessagesTab.qml
+++ b/src/AnalyzeView/LogViewer/LogViewerMessagesTab.qml
@@ -1,0 +1,56 @@
+import QtQuick
+import QtQuick.Controls
+import QtQuick.Layouts
+
+import QGroundControl
+import QGroundControl.Controls
+
+/// Messages tab for the Log Viewer.
+ScrollView {
+    id: control
+
+    required property var logParser
+
+    clip: true
+
+    QGCPalette { id: qgcPal }
+
+    ListView {
+        anchors.fill: parent
+        model: logParser.messages
+        spacing: ScreenTools.defaultFontPixelHeight * 0.2
+        clip: true
+        ScrollBar.vertical: ScrollBar { }
+
+        delegate: Rectangle {
+            width: ListView.view.width
+            height: _msgRow.implicitHeight + ScreenTools.defaultFontPixelHeight * 0.4
+            color: index % 2 === 0 ? qgcPal.windowShade : qgcPal.windowShadeDark
+            radius: 2
+
+            RowLayout {
+                id: _msgRow
+                anchors.verticalCenter: parent.verticalCenter
+                anchors.left: parent.left
+                anchors.right: parent.right
+                anchors.margins: ScreenTools.defaultFontPixelWidth * 0.5
+                spacing: ScreenTools.defaultFontPixelWidth * 0.5
+
+                QGCLabel {
+                    readonly property double _t: Number(modelData.time)
+                    text: (isNaN(_t) || _t < 0) ? "" : _t.toFixed(3) + "s"
+                    color: Qt.rgba(qgcPal.text.r, qgcPal.text.g, qgcPal.text.b, 0.6)
+                    Layout.preferredWidth: ScreenTools.defaultFontPixelWidth * 10
+                    horizontalAlignment: Text.AlignRight
+                }
+
+                QGCLabel {
+                    text: String(modelData.text)
+                    Layout.fillWidth: true
+                    wrapMode: Text.WordWrap
+                    maximumLineCount: 3
+                }
+            }
+        }
+    }
+}

--- a/src/AnalyzeView/LogViewer/LogViewerPage.qml
+++ b/src/AnalyzeView/LogViewer/LogViewerPage.qml
@@ -24,102 +24,9 @@ AnalyzePage {
 
             property bool binLoading: false
             property string pendingBinFile: ""
-            property string fieldSearchText: ""
-            property string parameterSearchText: ""
-            property bool showOnlyChangedParameters: true
-            property var filteredFieldRows: []
-            property var filteredParameters: []
 
             readonly property bool isFirmwareLog: logViewerController.sourceType === LogViewerController.Bin
                                              || logViewerController.sourceType === LogViewerController.ULog
-
-            function rebuildGroupedFields() {
-                logViewerController.setPlottableFields(logParser.plottableFields)
-                applyFieldFilter()
-            }
-
-            function applyFieldFilter() {
-                const query = String(fieldSearchText).trim().toLowerCase()
-                if (query.length === 0) {
-                    filteredFieldRows = logViewerController.fieldRows
-                    return
-                }
-
-                const groupedMap = {}
-                const fields = logParser.plottableFields
-                for (let i = 0; i < fields.length; i++) {
-                    const fullName = String(fields[i])
-                    const splitIndex = fullName.indexOf(".")
-                    const groupName = splitIndex > 0 ? fullName.substring(0, splitIndex) : qsTr("Other")
-                    const shortName = splitIndex > 0 ? fullName.substring(splitIndex + 1) : fullName
-                    const haystack = (fullName + " " + groupName + " " + shortName).toLowerCase()
-                    if (haystack.indexOf(query) === -1) {
-                        continue
-                    }
-
-                    if (!groupedMap[groupName]) {
-                        groupedMap[groupName] = []
-                    }
-                    groupedMap[groupName].push({ fullName: fullName, shortName: shortName })
-                }
-
-                const groups = Object.keys(groupedMap).sort()
-                const rows = []
-                for (let g = 0; g < groups.length; g++) {
-                    const groupName = groups[g]
-                    rows.push({ rowType: "group", group: groupName })
-                    groupedMap[groupName].sort((a, b) => String(a.shortName).localeCompare(String(b.shortName)))
-                    for (let s = 0; s < groupedMap[groupName].length; s++) {
-                        rows.push({
-                            rowType: "field",
-                            group: groupName,
-                            fullName: groupedMap[groupName][s].fullName,
-                            shortName: groupedMap[groupName][s].shortName
-                        })
-                    }
-                }
-                filteredFieldRows = rows
-            }
-
-            function applyParameterFilter() {
-                const query = String(parameterSearchText).trim().toLowerCase()
-                const onlyChanged = showOnlyChangedParameters
-
-                const output = []
-                for (let i = 0; i < logParser.parameters.length; i++) {
-                    const item = logParser.parameters[i]
-                    // "Show only changed" filter: skip parameters that equal their system default
-                    if (onlyChanged && item.hasDefault && item.isDefault) {
-                        continue
-                    }
-                    if (query.length > 0) {
-                        const name = String(item.name)
-                        const desc = item.shortDescription ? String(item.shortDescription) : ""
-                        const value = String(item.value)
-                        if ((name + " " + value + " " + desc).toLowerCase().indexOf(query) === -1) {
-                            continue
-                        }
-                    }
-                    output.push(item)
-                }
-                filteredParameters = output
-            }
-
-            function isGroupExpanded(groupName) {
-                return logViewerController.isGroupExpanded(groupName)
-            }
-
-            function toggleGroupExpanded(groupName) {
-                if (String(fieldSearchText).trim().length > 0) {
-                    return
-                }
-                logViewerController.toggleGroupExpanded(groupName)
-                applyFieldFilter()
-            }
-
-            function isFieldSelected(fieldName) {
-                return logViewerController.isFieldSelected(fieldName)
-            }
 
             function clearLoadedLogState(clearControllerState) {
                 replayController.isPlaying = false
@@ -127,8 +34,7 @@ AnalyzePage {
                 logParser.clear()
                 logViewerController.setPlottableFields([])
                 logViewerController.clearSelection()
-                filteredFieldRows = []
-                filteredParameters = []
+                _parametersTab.applyFilter()
                 logViewerChart.clearMarker()
                 logViewerChart.refreshBinChart()
                 if (clearControllerState) {
@@ -165,15 +71,6 @@ AnalyzePage {
             }
 
             Connections {
-                target: logViewerController
-                function onFieldRowsChanged() {
-                    const savedY = fieldsListView.contentY
-                    applyFieldFilter()
-                    Qt.callLater(() => { fieldsListView.contentY = savedY })
-                }
-            }
-
-            Connections {
                 target: logParser
                 ignoreUnknownSignals: true
 
@@ -189,8 +86,8 @@ AnalyzePage {
                         return
                     }
 
-                    rebuildGroupedFields()
-                    applyParameterFilter()
+                    fieldsPanel.rebuildGroupedFields()
+                    _parametersTab.applyFilter()
                     logViewerController.clearSelection()
                     logViewerChart.clearMarker()
                     logViewerChart.refreshBinChart()
@@ -260,6 +157,62 @@ AnalyzePage {
                 }
             }
 
+            RowLayout {
+                Layout.fillWidth: true
+                visible: logViewerController.sourceType === LogViewerController.TLog && replayController.link
+                spacing: ScreenTools.defaultFontPixelWidth
+
+                QGCButton {
+                    text: replayController.isPlaying ? qsTr("Pause") : qsTr("Play")
+                    onClicked: replayController.isPlaying = !replayController.isPlaying
+                }
+
+                QGCComboBox {
+                    textRole: "text"
+                    currentIndex: 3
+
+                    model: ListModel {
+                        ListElement { text: "0.1x";  value: 0.1  }
+                        ListElement { text: "0.25x"; value: 0.25 }
+                        ListElement { text: "0.5x";  value: 0.5  }
+                        ListElement { text: "1x";    value: 1.0  }
+                        ListElement { text: "2x";    value: 2.0  }
+                        ListElement { text: "5x";    value: 5.0  }
+                        ListElement { text: "10x";   value: 10.0 }
+                    }
+
+                    onActivated: (index) => replayController.playbackSpeed = model.get(index).value
+                }
+
+                QGCLabel { text: replayController.playheadTime }
+
+                Slider {
+                    id: _replaySlider
+                    Layout.fillWidth: true
+                    from: 0
+                    to: 100
+
+                    property bool _internalUpdate: false
+
+                    Connections {
+                        target: replayController
+                        function onPercentCompleteChanged(percentComplete) {
+                            _replaySlider._internalUpdate = true
+                            _replaySlider.value = percentComplete
+                            _replaySlider._internalUpdate = false
+                        }
+                    }
+
+                    onValueChanged: {
+                        if (!_internalUpdate) {
+                            replayController.percentComplete = value
+                        }
+                    }
+                }
+
+                QGCLabel { text: replayController.totalTime }
+            }
+
             QGCTabBar {
                 id: mainTabBar
                 Layout.fillWidth: true
@@ -279,210 +232,13 @@ AnalyzePage {
                 RowLayout {
                     spacing: ScreenTools.defaultFontPixelWidth
 
-                    // Left panel: stats + replay controls + fields list
-                    Rectangle {
-                        Layout.preferredWidth: availableWidth * 0.25
+                    // Left panel: stats + fields list
+                    LogViewerFieldsPanel {
+                        id: fieldsPanel
                         Layout.fillHeight: true
-                        color: qgcPal.windowShade
-                        radius: ScreenTools.defaultFontPixelWidth * 0.5
-
-                        ColumnLayout {
-                            anchors.fill: parent
-                            anchors.margins: ScreenTools.defaultFontPixelWidth
-                            spacing: ScreenTools.defaultFontPixelHeight * 0.5
-
-                            QGCLabel {
-                                visible: isFirmwareLog
-                                text: qsTr("Fields: %1  Parameters: %2  Events: %3")
-                                      .arg(logParser.plottableFields.length)
-                                      .arg(logParser.parameters.length)
-                                      .arg(logParser.events.length)
-                            }
-
-                            QGCLabel {
-                                visible: isFirmwareLog
-                                text: qsTr("Detected vehicle type: %1")
-                                      .arg(logParser.detectedVehicleType.length > 0
-                                           ? logParser.detectedVehicleType
-                                           : qsTr("Unknown"))
-                            }
-
-                            RowLayout {
-                                Layout.fillWidth: true
-                                visible: logViewerController.sourceType === LogViewerController.TLog && replayController.link
-                                spacing: ScreenTools.defaultFontPixelWidth
-
-                                QGCButton {
-                                    text: replayController.isPlaying ? qsTr("Pause") : qsTr("Play")
-                                    onClicked: replayController.isPlaying = !replayController.isPlaying
-                                }
-
-                                QGCComboBox {
-                                    textRole: "text"
-                                    currentIndex: 3
-
-                                    model: ListModel {
-                                        ListElement { text: "0.1x"; value: 0.1 }
-                                        ListElement { text: "0.25x"; value: 0.25 }
-                                        ListElement { text: "0.5x"; value: 0.5 }
-                                        ListElement { text: "1x"; value: 1.0 }
-                                        ListElement { text: "2x"; value: 2.0 }
-                                        ListElement { text: "5x"; value: 5.0 }
-                                        ListElement { text: "10x"; value: 10.0 }
-                                    }
-
-                                    onActivated: (index) => replayController.playbackSpeed = model.get(index).value
-                                }
-
-                                QGCLabel { text: replayController.playheadTime }
-
-                                Slider {
-                                    id: replaySlider
-                                    Layout.fillWidth: true
-                                    from: 0
-                                    to: 100
-
-                                    property bool _internalUpdate: false
-
-                                    Connections {
-                                        target: replayController
-                                        function onPercentCompleteChanged(percentComplete) {
-                                            replaySlider._internalUpdate = true
-                                            replaySlider.value = percentComplete
-                                            replaySlider._internalUpdate = false
-                                        }
-                                    }
-
-                                    onValueChanged: {
-                                        if (!_internalUpdate) {
-                                            replayController.percentComplete = value
-                                        }
-                                    }
-                                }
-
-                                QGCLabel { text: replayController.totalTime }
-                            }
-
-                            RowLayout {
-                                Layout.fillWidth: true
-                                visible: isFirmwareLog
-                                spacing: ScreenTools.defaultFontPixelWidth * 0.5
-
-                                QGCLabel {
-                                    text: qsTr("Fields")
-                                    font.bold: true
-                                }
-
-                                QGCTextField {
-                                    id: fieldSearchField
-                                    Layout.fillWidth: true
-                                    textColor: qgcPal.textFieldText
-                                    placeholderTextColor: Qt.rgba(qgcPal.textFieldText.r, qgcPal.textFieldText.g, qgcPal.textFieldText.b, 0.7)
-                                    placeholderText: qsTr("Search fields")
-                                    onTextChanged: {
-                                        fieldSearchText = text
-                                        if (text.trim().length === 0) {
-                                            fieldSearchTimer.stop()
-                                            applyFieldFilter()
-                                        } else {
-                                            fieldSearchTimer.restart()
-                                        }
-                                    }
-                                    onAccepted: {
-                                        fieldSearchText = text
-                                        fieldSearchTimer.stop()
-                                        applyFieldFilter()
-                                    }
-                                }
-
-                                QGCButton {
-                                    text: qsTr("Clear Selected")
-                                    horizontalAlignment: Text.AlignHCenter
-                                    Layout.preferredHeight: fieldSearchField.implicitHeight
-                                    Layout.minimumHeight: fieldSearchField.implicitHeight
-                                    topPadding: 0
-                                    bottomPadding: 0
-                                    enabled: logViewerController.selectedFields.length > 0
-                                    onClicked: {
-                                        logViewerController.clearSelection()
-                                        applyFieldFilter()
-                                        logViewerChart.refreshBinChart()
-                                    }
-                                }
-                            }
-
-                            ScrollView {
-                                id: fieldsScroll
-                                Layout.fillWidth: true
-                                Layout.fillHeight: true
-                                visible: isFirmwareLog
-                                clip: true
-
-                                ListView {
-                                    id: fieldsListView
-                                    anchors.fill: parent
-                                    model: filteredFieldRows
-                                    spacing: 0
-                                    clip: true
-                                    ScrollBar.vertical: ScrollBar { }
-
-                                    delegate: Item {
-                                        width: fieldsListView.width
-                                        height: (modelData.rowType === "group")
-                                                ? (groupRect.implicitHeight + (ScreenTools.defaultFontPixelHeight * 0.1))
-                                                : (fieldRow.implicitHeight + (ScreenTools.defaultFontPixelHeight * 0.1))
-
-                                        Item {
-                                            id: groupRect
-                                            visible: modelData.rowType === "group"
-                                            width: parent.width
-                                            implicitWidth: groupLayout.implicitWidth
-                                            implicitHeight: groupLayout.implicitHeight
-
-                                            RowLayout {
-                                                id: groupLayout
-                                                spacing: ScreenTools.defaultFontPixelWidth / 2
-
-                                                QGCColoredImage {
-                                                    Layout.preferredWidth: groupLabel.height * 0.5
-                                                    Layout.preferredHeight: groupLabel.height * 0.5
-                                                    source: "/qmlimages/arrow-down.png"
-                                                    color: qgcPal.text
-                                                    fillMode: Image.PreserveAspectFit
-                                                    rotation: (String(fieldSearchText).trim().length > 0 || isGroupExpanded(modelData.group)) ? 0 : -90
-                                                }
-
-                                                QGCLabel {
-                                                    id: groupLabel
-                                                    text: modelData.group;
-                                                    font.bold: true
-                                                }
-                                            }
-
-                                            MouseArea {
-                                                anchors.fill: parent
-                                                onClicked: toggleGroupExpanded(modelData.group)
-                                            }
-                                        }
-
-                                        Item {
-                                            id: fieldRow
-                                            visible: modelData.rowType === "field"
-                                            width: parent.width
-                                            implicitHeight: fieldSlider.implicitHeight
-
-                                            QGCCheckBoxSlider {
-                                                id: fieldSlider
-                                                width: parent.width - ScreenTools.defaultFontPixelWidth * 1.5
-                                                checked: logViewerController.selectedFields.indexOf(modelData.fullName) !== -1
-                                                text: modelData.shortName ? String(modelData.shortName) : ""
-                                                onClicked: logViewerController.setFieldSelected(modelData.fullName, checked)
-                                            }
-                                        }
-                                    }
-                                }
-                            }
-                        }
+                        logParser: logParser
+                        logViewerController: logViewerController
+                        onClearSelectedRequested: logViewerChart.refreshBinChart()
                     }
 
                     // Right panel: chart + MAVLink inspector
@@ -657,216 +413,19 @@ AnalyzePage {
                 }
 
                 // ---- Tab 2: Parameters ----
-                ColumnLayout {
-                    spacing: ScreenTools.defaultFontPixelHeight * 0.5
-
-                    RowLayout {
-                        Layout.fillWidth: true
-                        spacing: ScreenTools.defaultFontPixelWidth
-
-                        QGCTextField {
-                            id: parameterSearchField
-                            Layout.fillWidth: true
-                            textColor: qgcPal.textFieldText
-                            placeholderTextColor: Qt.rgba(qgcPal.textFieldText.r, qgcPal.textFieldText.g, qgcPal.textFieldText.b, 0.7)
-                            placeholderText: qsTr("Search parameters")
-
-                            onTextChanged: {
-                                parameterSearchText = text
-                                if (text.trim().length === 0) {
-                                    parameterSearchTimer.stop()
-                                    applyParameterFilter()
-                                } else {
-                                    parameterSearchTimer.restart()
-                                }
-                            }
-
-                            onAccepted: {
-                                parameterSearchText = text
-                                parameterSearchTimer.stop()
-                                applyParameterFilter()
-                            }
-                        }
-
-                        QGCCheckBoxSlider {
-                            id: showOnlyChangedCheckBox
-                            text: qsTr("Changed only")
-                            checked: showOnlyChangedParameters
-                            onToggled: {
-                                showOnlyChangedParameters = checked
-                                applyParameterFilter()
-                            }
-                        }
-                    }
-
-                    ScrollView {
-                        Layout.fillWidth: true
-                        Layout.fillHeight: true
-                        clip: true
-
-                        ListView {
-                            id: parametersListView
-                            anchors.fill: parent
-                            model: filteredParameters
-                            spacing: ScreenTools.defaultFontPixelHeight * 0.1
-                            clip: true
-                            ScrollBar.vertical: ScrollBar { }
-
-                            delegate: Rectangle {
-                                width: ListView.view.width
-                                height: _paramRow.implicitHeight + ScreenTools.defaultFontPixelHeight * 0.4
-                                color: index % 2 === 0 ? qgcPal.windowShade : qgcPal.windowShadeDark
-                                radius: 2
-
-                                // Format value: use metadata decimalPlaces when available,
-                                // fall back to isFloat heuristic. Show enum label when applicable.
-                                readonly property string _formattedValue: {
-                                    const v = modelData.value
-                                    if (v === undefined || v === null) return qsTr("N/A")
-                                    const numV = Number(v)
-                                    // Enum: find matching label
-                                    const eStrs = modelData.enumStrings
-                                    const eVals = modelData.enumValues
-                                    if (eStrs && eStrs.length > 0) {
-                                        for (let ei = 0; ei < eVals.length; ei++) {
-                                            if (Number(eVals[ei]) === numV) {
-                                                return eStrs[ei] + " (" + Math.round(numV) + ")"
-                                            }
-                                        }
-                                    }
-                                    // Numeric: metadata decimalPlaces wins
-                                    const dp = (modelData.decimalPlaces !== undefined) ? modelData.decimalPlaces : -1
-                                    let formatted
-                                    if (dp >= 0) {
-                                        formatted = numV.toFixed(dp)
-                                    } else if (modelData.isFloat) {
-                                        formatted = numV.toFixed(6)
-                                    } else {
-                                        formatted = String(Math.round(numV))
-                                    }
-                                    const units = (modelData.units && modelData.units.length > 0) ? (" " + modelData.units) : ""
-                                    return formatted + units
-                                }
-
-                                readonly property string _defaultText: {
-                                    if (!modelData.hasDefault) return ""
-                                    const d = modelData.defaultValue
-                                    if (d === undefined || d === null) return ""
-                                    const numD = Number(d)
-                                    const dp = (modelData.decimalPlaces !== undefined) ? modelData.decimalPlaces : -1
-                                    let formatted
-                                    if (dp >= 0) {
-                                        formatted = numD.toFixed(dp)
-                                    } else if (modelData.isFloat) {
-                                        formatted = numD.toFixed(6)
-                                    } else {
-                                        formatted = String(Math.round(numD))
-                                    }
-                                    return qsTr(" (default: %1)").arg(formatted)
-                                }
-
-                                RowLayout {
-                                    id: _paramRow
-                                    anchors.verticalCenter: parent.verticalCenter
-                                    anchors.left: parent.left
-                                    anchors.right: parent.right
-                                    anchors.margins: ScreenTools.defaultFontPixelWidth * 0.5
-                                    spacing: ScreenTools.defaultFontPixelWidth * 0.5
-
-                                    // Changed-from-default indicator dot
-                                    Rectangle {
-                                        visible: modelData.hasDefault && !modelData.isDefault
-                                        width: ScreenTools.defaultFontPixelHeight * 0.5
-                                        height: width
-                                        radius: width / 2
-                                        color: qgcPal.colorOrange
-                                        Layout.alignment: Qt.AlignVCenter
-                                    }
-
-                                    // Spacer to keep alignment when dot is hidden
-                                    Item {
-                                        visible: !(modelData.hasDefault && !modelData.isDefault)
-                                        width: ScreenTools.defaultFontPixelHeight * 0.5
-                                        height: width
-                                    }
-
-                                    QGCLabel {
-                                        text: modelData.name
-                                        font.bold: modelData.hasDefault && !modelData.isDefault
-                                        Layout.preferredWidth: ScreenTools.defaultFontPixelWidth * 22
-                                        elide: Text.ElideRight
-                                    }
-
-                                    QGCLabel {
-                                        text: _formattedValue
-                                        Layout.preferredWidth: ScreenTools.defaultFontPixelWidth * 14
-                                        horizontalAlignment: Text.AlignRight
-                                    }
-
-                                    QGCLabel {
-                                        text: _defaultText
-                                        color: Qt.rgba(qgcPal.text.r, qgcPal.text.g, qgcPal.text.b, 0.6)
-                                        Layout.preferredWidth: ScreenTools.defaultFontPixelWidth * 16
-                                        elide: Text.ElideRight
-                                    }
-
-                                    QGCLabel {
-                                        text: modelData.shortDescription ? String(modelData.shortDescription) : ""
-                                        color: Qt.rgba(qgcPal.text.r, qgcPal.text.g, qgcPal.text.b, 0.6)
-                                        Layout.fillWidth: true
-                                        elide: Text.ElideRight
-                                    }
-                                }
-                            }
-                        }
-                    }
+                LogViewerParametersTab {
+                    id: _parametersTab
+                    Layout.fillWidth: true
+                    Layout.fillHeight: true
+                    logParser: logParser
                 }
 
                 // ---- Tab 3: Messages ----
-                ScrollView {
+                LogViewerMessagesTab {
+                    id: _messagesTab
                     Layout.fillWidth: true
                     Layout.fillHeight: true
-                    clip: true
-
-                    ListView {
-                        id: messagesListView
-                        anchors.fill: parent
-                        model: logParser.messages
-                        spacing: ScreenTools.defaultFontPixelHeight * 0.2
-                        clip: true
-                        ScrollBar.vertical: ScrollBar { }
-
-                        delegate: Rectangle {
-                            width: ListView.view.width
-                            height: _msgRow.implicitHeight + ScreenTools.defaultFontPixelHeight * 0.4
-                            color: index % 2 === 0 ? qgcPal.windowShade : qgcPal.windowShadeDark
-                            radius: 2
-
-                            RowLayout {
-                                id: _msgRow
-                                anchors.verticalCenter: parent.verticalCenter
-                                anchors.left: parent.left
-                                anchors.right: parent.right
-                                anchors.margins: ScreenTools.defaultFontPixelWidth * 0.5
-                                spacing: ScreenTools.defaultFontPixelWidth * 0.5
-
-                                QGCLabel {
-                                    readonly property double _t: Number(modelData.time)
-                                    text: (isNaN(_t) || _t < 0) ? "" : _t.toFixed(3) + "s"
-                                    color: Qt.rgba(qgcPal.text.r, qgcPal.text.g, qgcPal.text.b, 0.6)
-                                    Layout.preferredWidth: ScreenTools.defaultFontPixelWidth * 10
-                                    horizontalAlignment: Text.AlignRight
-                                }
-
-                                QGCLabel {
-                                    text: String(modelData.text)
-                                    Layout.fillWidth: true
-                                    wrapMode: Text.WordWrap
-                                    maximumLineCount: 3
-                                }
-                            }
-                        }
-                    }
+                    logParser: logParser
                 }
             }
 
@@ -928,20 +487,6 @@ AnalyzePage {
                 interval: 50
                 repeat: false
                 onTriggered: _executePendingBinParse()
-            }
-
-            Timer {
-                id: fieldSearchTimer
-                interval: 250
-                repeat: false
-                onTriggered: applyFieldFilter()
-            }
-
-            Timer {
-                id: parameterSearchTimer
-                interval: 250
-                repeat: false
-                onTriggered: applyParameterFilter()
             }
         }
     }

--- a/src/AnalyzeView/LogViewer/LogViewerParametersTab.qml
+++ b/src/AnalyzeView/LogViewer/LogViewerParametersTab.qml
@@ -1,0 +1,224 @@
+import QtQuick
+import QtQuick.Controls
+import QtQuick.Layouts
+
+import QGroundControl
+import QGroundControl.Controls
+
+/// Parameters tab for the Log Viewer.
+/// Owns all filter state; call applyFilter() after a log loads or clears.
+ColumnLayout {
+    id: control
+
+    required property var logParser
+
+    spacing: ScreenTools.defaultFontPixelHeight * 0.5
+
+    // -------------------------------------------------------------------------
+    // Internal state
+    // -------------------------------------------------------------------------
+    property string _parameterSearchText:       ""
+    property bool   _showOnlyChangedParameters: true
+    property var    _filteredParameters:        []
+
+    QGCPalette { id: qgcPal }
+
+    // -------------------------------------------------------------------------
+    // Public API
+    // -------------------------------------------------------------------------
+
+    /// Recompute the filtered parameter list. Call after log load or clear.
+    function applyFilter() {
+        const query = String(_parameterSearchText).trim().toLowerCase()
+        const onlyChanged = _showOnlyChangedParameters
+
+        const output = []
+        for (let i = 0; i < logParser.parameters.length; i++) {
+            const item = logParser.parameters[i]
+            // "Show only changed" filter: skip parameters that equal their system default
+            if (onlyChanged && item.hasDefault && item.isDefault) {
+                continue
+            }
+            if (query.length > 0) {
+                const name = String(item.name)
+                const desc = item.shortDescription ? String(item.shortDescription) : ""
+                const value = String(item.value)
+                if ((name + " " + value + " " + desc).toLowerCase().indexOf(query) === -1) {
+                    continue
+                }
+            }
+            output.push(item)
+        }
+        _filteredParameters = output
+    }
+
+    // -------------------------------------------------------------------------
+    // UI
+    // -------------------------------------------------------------------------
+
+    RowLayout {
+        Layout.fillWidth: true
+        spacing: ScreenTools.defaultFontPixelWidth
+
+        QGCTextField {
+            id: _parameterSearchField
+            Layout.fillWidth: true
+            textColor: qgcPal.textFieldText
+            placeholderTextColor: Qt.rgba(qgcPal.textFieldText.r, qgcPal.textFieldText.g, qgcPal.textFieldText.b, 0.7)
+            placeholderText: qsTr("Search parameters")
+
+            onTextChanged: {
+                control._parameterSearchText = text
+                if (text.trim().length === 0) {
+                    _parameterSearchTimer.stop()
+                    control.applyFilter()
+                } else {
+                    _parameterSearchTimer.restart()
+                }
+            }
+
+            onAccepted: {
+                control._parameterSearchText = text
+                _parameterSearchTimer.stop()
+                control.applyFilter()
+            }
+        }
+
+        QGCCheckBoxSlider {
+            text: qsTr("Changed only")
+            checked: _showOnlyChangedParameters
+            onToggled: {
+                control._showOnlyChangedParameters = checked
+                control.applyFilter()
+            }
+        }
+    }
+
+    ScrollView {
+        Layout.fillWidth: true
+        Layout.fillHeight: true
+        clip: true
+
+        ListView {
+            anchors.fill: parent
+            model: _filteredParameters
+            spacing: ScreenTools.defaultFontPixelHeight * 0.1
+            clip: true
+            ScrollBar.vertical: ScrollBar { }
+
+            delegate: Rectangle {
+                width: ListView.view.width
+                height: _paramRow.implicitHeight + ScreenTools.defaultFontPixelHeight * 0.4
+                color: index % 2 === 0 ? qgcPal.windowShade : qgcPal.windowShadeDark
+                radius: 2
+
+                // Format value: use metadata decimalPlaces when available,
+                // fall back to isFloat heuristic. Show enum label when applicable.
+                readonly property string _formattedValue: {
+                    const v = modelData.value
+                    if (v === undefined || v === null) return qsTr("N/A")
+                    const numV = Number(v)
+                    // Enum: find matching label
+                    const eStrs = modelData.enumStrings
+                    const eVals = modelData.enumValues
+                    if (eStrs && eVals && eStrs.length > 0 && eVals.length === eStrs.length) {
+                        for (let ei = 0; ei < eVals.length; ei++) {
+                            if (Number(eVals[ei]) === numV) {
+                                return eStrs[ei] + " (" + Math.round(numV) + ")"
+                            }
+                        }
+                    }
+                    // Numeric: metadata decimalPlaces wins
+                    const dp = (modelData.decimalPlaces !== undefined) ? modelData.decimalPlaces : -1
+                    let formatted
+                    if (dp >= 0) {
+                        formatted = numV.toFixed(dp)
+                    } else if (modelData.isFloat) {
+                        formatted = numV.toFixed(6)
+                    } else {
+                        formatted = String(Math.round(numV))
+                    }
+                    const units = (modelData.units && modelData.units.length > 0) ? (" " + modelData.units) : ""
+                    return formatted + units
+                }
+
+                readonly property string _defaultText: {
+                    if (!modelData.hasDefault) return ""
+                    const d = modelData.defaultValue
+                    if (d === undefined || d === null) return ""
+                    const numD = Number(d)
+                    const dp = (modelData.decimalPlaces !== undefined) ? modelData.decimalPlaces : -1
+                    let formatted
+                    if (dp >= 0) {
+                        formatted = numD.toFixed(dp)
+                    } else if (modelData.isFloat) {
+                        formatted = numD.toFixed(6)
+                    } else {
+                        formatted = String(Math.round(numD))
+                    }
+                    return qsTr(" (default: %1)").arg(formatted)
+                }
+
+                RowLayout {
+                    id: _paramRow
+                    anchors.verticalCenter: parent.verticalCenter
+                    anchors.left: parent.left
+                    anchors.right: parent.right
+                    anchors.margins: ScreenTools.defaultFontPixelWidth * 0.5
+                    spacing: ScreenTools.defaultFontPixelWidth * 0.5
+
+                    // Changed-from-default indicator dot
+                    Rectangle {
+                        visible: modelData.hasDefault && !modelData.isDefault
+                        width: ScreenTools.defaultFontPixelHeight * 0.5
+                        height: width
+                        radius: width / 2
+                        color: qgcPal.colorOrange
+                        Layout.alignment: Qt.AlignVCenter
+                    }
+
+                    // Spacer to keep alignment when dot is hidden
+                    Item {
+                        visible: !(modelData.hasDefault && !modelData.isDefault)
+                        width: ScreenTools.defaultFontPixelHeight * 0.5
+                        height: width
+                    }
+
+                    QGCLabel {
+                        text: modelData.name
+                        font.bold: modelData.hasDefault && !modelData.isDefault
+                        Layout.preferredWidth: ScreenTools.defaultFontPixelWidth * 22
+                        elide: Text.ElideRight
+                    }
+
+                    QGCLabel {
+                        text: _formattedValue
+                        Layout.preferredWidth: ScreenTools.defaultFontPixelWidth * 14
+                        horizontalAlignment: Text.AlignRight
+                    }
+
+                    QGCLabel {
+                        text: _defaultText
+                        color: Qt.rgba(qgcPal.text.r, qgcPal.text.g, qgcPal.text.b, 0.6)
+                        Layout.preferredWidth: ScreenTools.defaultFontPixelWidth * 16
+                        elide: Text.ElideRight
+                    }
+
+                    QGCLabel {
+                        text: modelData.shortDescription ? String(modelData.shortDescription) : ""
+                        color: Qt.rgba(qgcPal.text.r, qgcPal.text.g, qgcPal.text.b, 0.6)
+                        Layout.fillWidth: true
+                        elide: Text.ElideRight
+                    }
+                }
+            }
+        }
+    }
+
+    Timer {
+        id: _parameterSearchTimer
+        interval: 250
+        repeat: false
+        onTriggered: control.applyFilter()
+    }
+}

--- a/src/Utilities/Logging/QGCLoggingCategoryManager.cc
+++ b/src/Utilities/Logging/QGCLoggingCategoryManager.cc
@@ -239,7 +239,10 @@ void QGCLoggingCategoryManager::_categoryFilter(QLoggingCategory* category)
         return;
     }
 
-    if (categoryName == QLatin1String("default")) {
+    // Leave "default" (uncategorized qDebug()) and "qml" (QML console.log/warn/error)
+    // to Qt's built-in filter, which enables debug messages in Debug builds by default.
+    // Without this, the QGC filter would suppress them at kDefaultLevel (Warning).
+    if (categoryName == QLatin1String("default") || categoryName == QLatin1String("qml")) {
         return;
     }
 


### PR DESCRIPTION
## Description

Related to #14407.

This PR takes a different approach to the hover-vs-fixed-cursor problem: both cursors coexist simultaneously.

- **Fixed cursor** (solid line + full popup with Current/Min/Max): set by clicking anywhere on the chart, stays locked in place when you move the mouse away so you can add/remove fields and still see values at the point of interest.
- **Hover cursor** (semi-transparent line + compact popup with Current only): follows the mouse, disappears when the pointer leaves the chart. Gives a lightweight scan-as-you-move experience without disturbing the locked position.

### Additional changes

**LogViewerPage — tab extraction**
- `LogViewerParametersTab.qml`: new standalone component owning all parameter filter state (search text, timer, `_filteredParameters`). Exposes `applyFilter()` for parent lifecycle hooks.
- `LogViewerMessagesTab.qml`: new standalone component for the messages list.
- Both are `required property var logParser`-driven with zero cross-tab coupling.

**QGCLoggingCategoryManager**
- The `"qml"` logging category now passes through to Qt's built-in filter so `console.log` / `console.warn` / `console.error` are visible in Debug builds. Previously the QGC filter was silencing them at `kDefaultLevel` (Warning).

## Type of Change

- [x] New feature (non-breaking change that adds functionality)
- [x] Refactoring (no functional changes)

## Testing

Manual verification:

1. Open Analyze → Log Viewer and load a `.bin` or `.ulg` log.
2. On the Charting tab, select one or more fields.
3. **Click** anywhere on the chart — a solid vertical line and full popup (time, mode, field Current/Min/Max) appears and stays locked.
4. **Hover** over the chart — a semi-transparent line and compact popup follow the mouse. The locked cursor is unaffected.
5. Move the mouse off the chart — hover cursor disappears; locked cursor remains.
6. **Drag** to zoom — hover cursor is hidden for the duration of the drag and reappears at the release position.
7. Switch to the Parameters and Messages tabs — they work as before.
8. In a Debug build, verify `console.log("test")` from QML appears in the output.

### Platforms Tested

- [x] macOS

### Flight Stacks Tested

- [x] PX4
- [x] ArduPilot

## Checklist

- [x] I have read the [Contribution Guidelines](https://github.com/mavlink/qgroundcontrol/blob/master/.github/CONTRIBUTING.md)
- [x] My code follows the project's coding standards
- [x] New and existing unit tests pass locally

By submitting this pull request, I confirm that my contribution is made under the terms of the project's dual license (Apache 2.0 and GPL v3).
