### PR TITLE
LogViewer: start time, mouse interaction, chart refactoring, crash fix

### DIFF
--- a/src/API/QGCCorePlugin.cc
+++ b/src/API/QGCCorePlugin.cc
@@ -72,11 +72,19 @@ QGCCorePlugin *QGCCorePlugin::instance()
 
 const QVariantList &QGCCorePlugin::analyzePages()
 {
+    // Log Viewer is excluded on mobile (Android/iOS) because parsing large log files
+    // (e.g. 900 MB ULog files with 1000+ fields) exhausts the mobile heap, causing
+    // OOM crashes. Proper mobile support requires time-bucketed downsampling and will
+    // be addressed in a future major release.
+#if defined(Q_OS_ANDROID) || defined(Q_OS_IOS)
+    static const QVariantList analyzeList = {
+#else
     static const QVariantList analyzeList = {
         QVariant::fromValue(new QmlComponentInfo(
             tr("Log Viewer"),
             QUrl::fromUserInput(QStringLiteral("qrc:/qml/QGroundControl/AnalyzeView/LogViewer/LogViewerPage.qml")),
             QUrl::fromUserInput(QStringLiteral("qrc:/qmlimages/MAVLinkInspector.svg")))),
+#endif
         QVariant::fromValue(new QmlComponentInfo(
             tr("Onboard Logs"),
             QUrl::fromUserInput(QStringLiteral("qrc:/qml/QGroundControl/AnalyzeView/OnboardLogs/OnboardLogPage.qml")),

--- a/src/AnalyzeView/LogViewer/APMDataFlash/APMDataFlashLogParser.cc
+++ b/src/AnalyzeView/LogViewer/APMDataFlash/APMDataFlashLogParser.cc
@@ -599,8 +599,8 @@ bool APMDataFlashLogParser::parseFile(const QString &filePath)
     }
     emit sampleCountChanged();
 
-    _parsed = true;
-    emit parsedChanged();
+    _parseComplete = true;
+    emit parseCompleteChanged();
     qCDebug(APMDataFlashLogParserLog) << "Parsed fields" << _availableFields.count() << "parameters" << _parameters.count() << "events" << _events.count();
     return true;
 }
@@ -649,8 +649,8 @@ void APMDataFlashLogParser::parseFileAsync(const QString &filePath)
         }
         emit sampleCountChanged();
 
-        _parsed = true;
-        emit parsedChanged();
+        _parseComplete = true;
+        emit parseCompleteChanged();
         emit parseFileFinished(filePath, true, QString());
     });
 
@@ -661,10 +661,10 @@ void APMDataFlashLogParser::parseFileAsync(const QString &filePath)
 
 void APMDataFlashLogParser::clear()
 {
-    const bool oldParsed = _parsed;
-    _parsed = false;
-    if (oldParsed) {
-        emit parsedChanged();
+    const bool oldParseComplete = _parseComplete;
+    _parseComplete = false;
+    if (oldParseComplete) {
+        emit parseCompleteChanged();
     }
 
     if (!_parseError.isEmpty()) {

--- a/src/AnalyzeView/LogViewer/APMDataFlash/APMDataFlashLogParser.h
+++ b/src/AnalyzeView/LogViewer/APMDataFlash/APMDataFlashLogParser.h
@@ -16,7 +16,7 @@ class APMDataFlashLogParser : public QObject
     Q_OBJECT
     QML_ELEMENT
 
-    Q_PROPERTY(bool        parsed              READ parsed              NOTIFY parsedChanged)
+    Q_PROPERTY(bool        parseComplete              READ parseComplete              NOTIFY parseCompleteChanged)
     Q_PROPERTY(QString      parseError          READ parseError          NOTIFY parseErrorChanged)
     Q_PROPERTY(QStringList  availableFields     READ availableFields     NOTIFY availableFieldsChanged)
     Q_PROPERTY(QVariantList parameters          READ parameters          NOTIFY parametersChanged)
@@ -33,7 +33,7 @@ public:
     explicit APMDataFlashLogParser(QObject *parent = nullptr);
     ~APMDataFlashLogParser();
 
-    bool parsed() const { return _parsed; }
+    bool parseComplete() const { return _parseComplete; }
     QString parseError() const { return _parseError; }
     QStringList availableFields() const { return _availableFields; }
     QVariantList parameters() const { return _parameters; }
@@ -55,7 +55,7 @@ public:
     Q_INVOKABLE QVariantList eventsNear(double timestampSeconds, double thresholdSeconds) const;
 
 signals:
-    void parsedChanged();
+    void parseCompleteChanged();
     void parseErrorChanged();
     void availableFieldsChanged();
     void parametersChanged();
@@ -71,7 +71,7 @@ signals:
 private:
     void _setParseError(const QString &error);
 
-    bool _parsed = false;
+    bool _parseComplete = false;
     QString _parseError;
     QStringList _availableFields;
     QStringList _plottableFields;

--- a/src/AnalyzeView/LogViewer/APMDataFlash/LogViewerDataFlashParser.cc
+++ b/src/AnalyzeView/LogViewer/APMDataFlash/LogViewerDataFlashParser.cc
@@ -4,16 +4,37 @@
 
 #include <QtCore/QByteArray>
 #include <QtCore/QCoreApplication>
+#include <QtCore/QDateTime>
 #include <QtCore/QFile>
 #include <QtCore/QHash>
 #include <QtCore/QRegularExpression>
 #include <QtCore/QSet>
+#include <QtCore/QTimeZone>
 #include <QtCore/QVariantMap>
 
 #include <algorithm>
 #include <limits>
 
 namespace {
+
+int _leapSecondsTAI(int year, int month)
+{
+    const int yyyymm = year * 100 + month;
+    if (yyyymm >= 201701) return 37;
+    if (yyyymm >= 201507) return 36;
+    if (yyyymm >= 201207) return 35;
+    if (yyyymm >= 200901) return 34;
+    if (yyyymm >= 200601) return 33;
+    if (yyyymm >= 199901) return 32;
+    if (yyyymm >= 199707) return 31;
+    if (yyyymm >= 199601) return 30;
+    return 0;
+}
+
+int _leapSecondsGPS(int year, int month)
+{
+    return _leapSecondsTAI(year, month) - 19;
+}
 
 QString _vehicleTypeFromMessageText(const QString &messageText)
 {
@@ -216,7 +237,7 @@ void _appendEvent(QVariantList &events, double timestampSecs, const QString &typ
 
 namespace DataFlashParser {
 
-LogParseResult parseFile(const QString &filePath)
+LogParseResult parseFile(const QString &filePath, const ProgressCallback &progressCallback, const CancelToken &cancelToken)
 {
     LogParseResult result;
     result.sourceType = LogParseResult::SourceType::APMDataFlash;
@@ -291,6 +312,8 @@ LogParseResult parseFile(const QString &filePath)
     static const QString kMODE = QStringLiteral("MODE");
     static const QString kERR  = QStringLiteral("ERR");
     static const QString kEV   = QStringLiteral("EV");
+    static const QString kGPS  = QStringLiteral("GPS");
+    static const QString kGPS2 = QStringLiteral("GPS2");
 
     APMDataFlashUtility::iterateMessages(bytes.constData(), bytes.size(), formats,
         [&](uint8_t msgType, const char *payload, int, const APMDataFlashUtility::MessageFormat &fmt) {
@@ -299,6 +322,22 @@ LogParseResult parseFile(const QString &filePath)
         if (timestampSecs >= 0.0) {
             if (minTimestampSecs < 0.0 || timestampSecs < minTimestampSecs) { minTimestampSecs = timestampSecs; }
             maxTimestampSecs = std::max(maxTimestampSecs, timestampSecs);
+        }
+
+        if ((fmt.name == kGPS || fmt.name == kGPS2) && result.startTime.isNull()
+                && values.contains(QStringLiteral("GWk")) && values.contains(QStringLiteral("GMS"))
+                && timestampSecs >= 0.0) {
+            const int gwk = values.value(QStringLiteral("GWk")).toInt();
+            const int gms = values.value(QStringLiteral("GMS")).toInt();
+            if (gwk > 2000) {
+                const double gpsSecs = 315964800.0 + (7.0 * 24 * 60 * 60) * gwk + (gms / 1000.0);
+                const QDateTime gpsDateTime = QDateTime::fromMSecsSinceEpoch(
+                    static_cast<qint64>(gpsSecs * 1000.0), QTimeZone::utc());
+                const int leapSecs = _leapSecondsGPS(gpsDateTime.date().year(), gpsDateTime.date().month());
+                const double utcSecs = gpsSecs - leapSecs;
+                result.startTime = QDateTime::fromMSecsSinceEpoch(
+                    static_cast<qint64>((utcSecs - timestampSecs) * 1000.0), QTimeZone::utc());
+            }
         }
 
         if (fmt.name == kPARM) {
@@ -385,8 +424,12 @@ LogParseResult parseFile(const QString &filePath)
                 plottableFieldSet.insert(fieldName);
             }
         }
-        return true;
-    });
+        return !cancelToken || !cancelToken->load(std::memory_order_relaxed);
+    }, progressCallback);
+
+    if (cancelToken && cancelToken->load(std::memory_order_relaxed)) {
+        return result; // cancelled; ok remains false
+    }
 
     if (hasOpenModeSegment && (maxTimestampSecs >= modeSegmentStartSecs)) {
         QVariantMap segment;

--- a/src/AnalyzeView/LogViewer/APMDataFlash/LogViewerDataFlashParser.h
+++ b/src/AnalyzeView/LogViewer/APMDataFlash/LogViewerDataFlashParser.h
@@ -9,5 +9,5 @@
 // Returns a filled LogParseResult on success (result.ok == true) or an error
 // message in result.errorMessage on failure.
 namespace DataFlashParser {
-    LogParseResult parseFile(const QString &filePath);
+    LogParseResult parseFile(const QString &filePath, const ProgressCallback &progressCallback = nullptr, const CancelToken &cancelToken = nullptr);
 }

--- a/src/AnalyzeView/LogViewer/CMakeLists.txt
+++ b/src/AnalyzeView/LogViewer/CMakeLists.txt
@@ -40,7 +40,9 @@ qt_add_qml_module(LogViewerModule
     RESOURCE_PREFIX /qml
     QML_FILES
         LogViewerAltChart.qml
+        LogViewerBaseChart.qml
         LogViewerChart.qml
+        LogViewerCursorPopup.qml
         LogViewerFieldsPanel.qml
         LogViewerMessagesTab.qml
         LogViewerParametersTab.qml

--- a/src/AnalyzeView/LogViewer/LogFileParser.cc
+++ b/src/AnalyzeView/LogViewer/LogFileParser.cc
@@ -9,6 +9,7 @@
 #include <QtConcurrent/QtConcurrent>
 #include <QtCore/QFileInfo>
 #include <QtCore/QFutureWatcher>
+#include <QtCore/QPointer>
 
 #include <algorithm>
 #include <cmath>
@@ -18,16 +19,16 @@ QGC_LOGGING_CATEGORY(LogFileParserLog, "AnalyzeView.LogFileParser")
 
 namespace {
 
-LogParseResult _parseFile(const QString &filePath)
+LogParseResult _parseFile(const QString &filePath, const ProgressCallback &progressCallback = nullptr, const CancelToken &cancelToken = nullptr)
 {
     const QString suffix = QFileInfo(filePath).suffix().toLower();
 
     if (suffix == QStringLiteral("bin") || suffix == QStringLiteral("log")) {
-        return DataFlashParser::parseFile(filePath);
+        return DataFlashParser::parseFile(filePath, progressCallback, cancelToken);
     }
 
     if (suffix == QStringLiteral("ulg")) {
-        return ULogParser::parseFile(filePath);
+        return ULogParser::parseFile(filePath, progressCallback, cancelToken);
     }
 
     const QString fileTypeDescription = suffix.isEmpty()
@@ -74,10 +75,26 @@ bool LogFileParser::parseFile(const QString &filePath)
     return true;
 }
 
-void LogFileParser::parseFileAsync(const QString &filePath)
+void LogFileParser::startParsingAsync(const QString &filePath)
 {
+    clear();  // cancels any in-flight parse, resets data
+
+    _cancelToken = std::make_shared<std::atomic<bool>>(false);
     const quint64 requestId = ++_parseRequestId;
-    clear();
+    _parsing = true;
+    emit parsingChanged();
+
+    // Use QPointer so the background thread's invokeMethod posts are safe even if
+    // this object is destroyed before all pending events are drained from the queue.
+    QPointer<LogFileParser> self(this);
+    auto progressCallback = [self, requestId](float v) {
+        if (!self) return;
+        QMetaObject::invokeMethod(self.data(), [self, requestId, v]() {
+            if (!self || requestId != self->_parseRequestId) return;
+            self->_parseProgress = v;
+            emit self->parseProgressChanged();
+        }, Qt::QueuedConnection);
+    };
 
     auto *watcher = new QFutureWatcher<LogParseResult>(this);
     (void) connect(watcher, &QFutureWatcher<LogParseResult>::finished, this,
@@ -89,6 +106,11 @@ void LogFileParser::parseFileAsync(const QString &filePath)
                 return;
             }
 
+            _parseProgress = 1.f;
+            emit parseProgressChanged();
+            _parsing = false;
+            emit parsingChanged();
+
             if (!result.ok) {
                 _setParseError(result.errorMessage);
                 emit parseFileFinished(filePath, false, result.errorMessage);
@@ -99,8 +121,8 @@ void LogFileParser::parseFileAsync(const QString &filePath)
             emit parseFileFinished(filePath, true, QString());
         });
 
-    watcher->setFuture(QtConcurrent::run([filePath]() {
-        return _parseFile(filePath);
+    watcher->setFuture(QtConcurrent::run([filePath, progressCallback, cancelToken = _cancelToken]() {
+        return _parseFile(filePath, progressCallback, cancelToken);
     }));
 }
 
@@ -129,6 +151,17 @@ void LogFileParser::_applyResult(const LogParseResult &result)
     _messages = result.messages;
     _modeSegments = result.modeSegments;
     _dropouts = result.dropouts;
+
+    // Build mode color cache in first-appearance (chronological) order.
+    _modeColorCache.clear();
+    _modeNames.clear();
+    for (const QVariant &v : _modeSegments) {
+        const QString mode = v.toMap().value(QStringLiteral("mode")).toString();
+        if (!mode.isEmpty() && !_modeNames.contains(mode)) {
+            _modeColorCache.insert(mode, _modeColorCache.size());
+            _modeNames.append(mode);
+        }
+    }
     _fieldSamples = result.fieldSamples;
     _sampleCount = result.sampleCount;
     _detectedVehicleType = result.detectedVehicleType;
@@ -138,6 +171,7 @@ void LogFileParser::_applyResult(const LogParseResult &result)
     emit eventsChanged();
     emit messagesChanged();
     emit modeSegmentsChanged();
+    emit modeNamesChanged();
     emit dropoutsChanged();
     emit detectedVehicleTypeChanged();
     if (_minTimestamp != result.minTimestamp || _maxTimestamp != result.maxTimestamp) {
@@ -146,16 +180,29 @@ void LogFileParser::_applyResult(const LogParseResult &result)
         emit timeRangeChanged();
     }
     emit sampleCountChanged();
+    if (_startTime != result.startTime) {
+        _startTime = result.startTime;
+        emit startTimeChanged();
+    }
 
-    _parsed = true;
-    emit parsedChanged();
+    _parseComplete = true;
+    emit parseCompleteChanged();
 }
 
 void LogFileParser::clear()
 {
-    const bool oldParsed = _parsed;
-    _parsed = false;
-    if (oldParsed) { emit parsedChanged(); }
+    if (_parsing) {
+        ++_parseRequestId;
+        if (_cancelToken) {
+            _cancelToken->store(true, std::memory_order_relaxed);
+        }
+        _parsing = false;
+        emit parsingChanged();
+    }
+
+    const bool oldParseComplete = _parseComplete;
+    _parseComplete = false;
+    if (oldParseComplete) { emit parseCompleteChanged(); }
 
     if (!_parseError.isEmpty()) { _parseError.clear(); emit parseErrorChanged(); }
     if (!_availableFields.isEmpty()) { _availableFields.clear(); emit availableFieldsChanged(); }
@@ -163,6 +210,7 @@ void LogFileParser::clear()
     if (!_events.isEmpty()) { _events.clear(); emit eventsChanged(); }
     if (!_messages.isEmpty()) { _messages.clear(); emit messagesChanged(); }
     if (!_modeSegments.isEmpty()) { _modeSegments.clear(); emit modeSegmentsChanged(); }
+    if (!_modeNames.isEmpty()) { _modeNames.clear(); _modeColorCache.clear(); emit modeNamesChanged(); }
     if (!_dropouts.isEmpty()) { _dropouts.clear(); emit dropoutsChanged(); }
     if (!_detectedVehicleType.isEmpty()) { _detectedVehicleType.clear(); emit detectedVehicleTypeChanged(); }
     if (!_plottableFields.isEmpty()) { _plottableFields.clear(); emit plottableFieldsChanged(); }
@@ -177,6 +225,8 @@ void LogFileParser::clear()
         emit timeRangeChanged();
     }
     if (_sampleCount != 0) { _sampleCount = 0; emit sampleCountChanged(); }
+    if (!_startTime.isNull()) { _startTime = QDateTime(); emit startTimeChanged(); }
+    if (_parseProgress != 0.f) { _parseProgress = 0.f; emit parseProgressChanged(); }
 }
 
 QVariantList LogFileParser::fieldSamples(const QString &fieldName) const
@@ -294,6 +344,30 @@ double LogFileParser::fieldValueAt(const QString &fieldName, double timestampSec
     const auto prev = std::prev(lower);
     return (std::fabs(prev->x() - timestampSeconds) <= std::fabs(lower->x() - timestampSeconds))
         ? prev->y() : lower->y();
+}
+
+QString LogFileParser::modeColor(const QString &modeName) const
+{
+    static const QStringList modePalette = {
+        QStringLiteral("#E53935"), // red
+        QStringLiteral("#FB8C00"), // orange
+        QStringLiteral("#FDD835"), // yellow
+        QStringLiteral("#43A047"), // green
+        QStringLiteral("#00897B"), // teal
+        QStringLiteral("#00ACC1"), // cyan
+        QStringLiteral("#1E88E5"), // blue
+        QStringLiteral("#5E35B1"), // indigo
+        QStringLiteral("#8E24AA"), // purple
+        QStringLiteral("#D81B60"), // pink
+        QStringLiteral("#6D4C41"), // brown
+        QStringLiteral("#546E7A"), // blue grey
+    };
+
+    const auto it = _modeColorCache.constFind(modeName);
+    if (it == _modeColorCache.constEnd()) {
+        return modePalette[0]; // unknown mode; cache was not seeded yet
+    }
+    return modePalette[it.value() % modePalette.size()];
 }
 
 QString LogFileParser::modeAt(double timestampSeconds) const

--- a/src/AnalyzeView/LogViewer/LogFileParser.h
+++ b/src/AnalyzeView/LogViewer/LogFileParser.h
@@ -7,9 +7,13 @@
 #include <QtCore/QStringList>
 #include <QtCore/QVariant>
 #include <QtCore/QVariantList>
+#include <QtCore/QDateTime>
 #include <QtCore/QVector>
 #include <QtCore/QtGlobal>
 #include <QtQmlIntegration/QtQmlIntegration>
+
+#include <atomic>
+#include <memory>
 
 /// \brief Unified log file parser for both DataFlash (.bin/.log) and PX4 ULog (.ulg) files.
 ///
@@ -30,7 +34,9 @@ class LogFileParser : public QObject
     Q_OBJECT
     QML_ELEMENT
 
-    Q_PROPERTY(bool         parsed              READ parsed              NOTIFY parsedChanged)
+    Q_PROPERTY(bool         parsing             READ parsing             NOTIFY parsingChanged)
+    Q_PROPERTY(float        parseProgress       READ parseProgress       NOTIFY parseProgressChanged)
+    Q_PROPERTY(bool         parseComplete       READ parseComplete       NOTIFY parseCompleteChanged)
     Q_PROPERTY(QString      parseError          READ parseError          NOTIFY parseErrorChanged)
     Q_PROPERTY(QStringList  availableFields     READ availableFields     NOTIFY availableFieldsChanged)
     Q_PROPERTY(QVariantList parameters          READ parameters          NOTIFY parametersChanged)
@@ -38,17 +44,19 @@ class LogFileParser : public QObject
     Q_PROPERTY(QVariantList messages            READ messages            NOTIFY messagesChanged)
     Q_PROPERTY(QStringList  plottableFields     READ plottableFields     NOTIFY plottableFieldsChanged)
     Q_PROPERTY(QVariantList modeSegments        READ modeSegments        NOTIFY modeSegmentsChanged)
+    Q_PROPERTY(QStringList  modeNames           READ modeNames           NOTIFY modeNamesChanged)
     Q_PROPERTY(QVariantList dropouts            READ dropouts            NOTIFY dropoutsChanged)
     Q_PROPERTY(QString      detectedVehicleType READ detectedVehicleType NOTIFY detectedVehicleTypeChanged)
     Q_PROPERTY(double       minTimestamp        READ minTimestamp        NOTIFY timeRangeChanged)
     Q_PROPERTY(double       maxTimestamp        READ maxTimestamp        NOTIFY timeRangeChanged)
     Q_PROPERTY(int          sampleCount         READ sampleCount         NOTIFY sampleCountChanged)
+    Q_PROPERTY(QDateTime    startTime           READ startTime           NOTIFY startTimeChanged)
 
 public:
     explicit LogFileParser(QObject *parent = nullptr);
     ~LogFileParser();
 
-    bool parsed() const { return _parsed; }
+    bool parseComplete() const { return _parseComplete; }
     QString parseError() const { return _parseError; }
     QStringList availableFields() const { return _availableFields; }
     QVariantList parameters() const { return _parameters; }
@@ -56,20 +64,25 @@ public:
     QVariantList messages() const { return _messages; }
     QStringList plottableFields() const { return _plottableFields; }
     QVariantList modeSegments() const { return _modeSegments; }
+    QStringList modeNames() const { return _modeNames; }
     QVariantList dropouts() const { return _dropouts; }
     QString detectedVehicleType() const { return _detectedVehicleType; }
     double minTimestamp() const { return _minTimestamp; }
     double maxTimestamp() const { return _maxTimestamp; }
     int sampleCount() const { return _sampleCount; }
+    QDateTime startTime() const { return _startTime; }
+    bool parsing() const { return _parsing; }
+    float parseProgress() const { return _parseProgress; }
 
     Q_INVOKABLE bool parseFile(const QString &filePath);
-    Q_INVOKABLE void parseFileAsync(const QString &filePath);
+    Q_INVOKABLE void startParsingAsync(const QString &filePath);
     Q_INVOKABLE void clear();
     Q_INVOKABLE QVariantList fieldSamples(const QString &fieldName) const;
     Q_INVOKABLE QVariantList fieldSamplesFiltered(const QString &fieldName, double minX, double maxX, int pixelWidth) const;
     Q_INVOKABLE QVariantMap  fieldMinMax(const QString &fieldName) const;
     Q_INVOKABLE double fieldValueAt(const QString &fieldName, double timestampSeconds) const;
     Q_INVOKABLE QString modeAt(double timestampSeconds) const;
+    Q_INVOKABLE QString modeColor(const QString &modeName) const;
     Q_INVOKABLE QVariantList eventsNear(double timestampSeconds, double thresholdSeconds) const;
 
     /// Returns a list of GPS path points as QVariantMap entries with `latitude` and `longitude` keys
@@ -88,7 +101,7 @@ public:
     Q_INVOKABLE QVariantMap gpsCoordAt(double timestampSeconds) const;
 
 signals:
-    void parsedChanged();
+    void parseCompleteChanged();
     void parseErrorChanged();
     void availableFieldsChanged();
     void parametersChanged();
@@ -96,17 +109,21 @@ signals:
     void messagesChanged();
     void plottableFieldsChanged();
     void modeSegmentsChanged();
+    void modeNamesChanged();
     void dropoutsChanged();
     void detectedVehicleTypeChanged();
     void timeRangeChanged();
     void sampleCountChanged();
+    void startTimeChanged();
+    void parsingChanged();
+    void parseProgressChanged();
     void parseFileFinished(const QString &filePath, bool ok, const QString &errorMessage);
 
 private:
     void _setParseError(const QString &error);
     void _applyResult(const struct LogParseResult &result);
 
-    bool _parsed = false;
+    bool _parseComplete = false;
     QString _parseError;
     QStringList _availableFields;
     QStringList _plottableFields;
@@ -121,6 +138,13 @@ private:
     double _maxTimestamp = -1.0;
     int _sampleCount = 0;
     quint64 _parseRequestId = 0;
+    QDateTime _startTime;
+    bool _parsing = false;
+    float _parseProgress = 0.f;
+    std::shared_ptr<std::atomic<bool>> _cancelToken;
+
+    QStringList _modeNames;
+    QHash<QString, int> _modeColorCache;
 
     // Cached GPS field names, set by gpsPath() when a valid candidate is found.
     mutable QString _gpsLatField;

--- a/src/AnalyzeView/LogViewer/LogParseResultPrivate.h
+++ b/src/AnalyzeView/LogViewer/LogParseResultPrivate.h
@@ -3,12 +3,25 @@
 // Private implementation detail shared between LogFileParser.cc and ULogFullHandler.cc.
 // Do NOT include this header from any public-facing header.
 
+#include <QtCore/QDateTime>
 #include <QtCore/QHash>
 #include <QtCore/QPointF>
 #include <QtCore/QString>
 #include <QtCore/QStringList>
 #include <QtCore/QVariantList>
 #include <QtCore/QVector>
+
+#include <atomic>
+#include <functional>
+#include <memory>
+
+/// Callback invoked periodically during async parsing to report byte-position progress.
+/// @param progress 0.0–1.0 fraction of the file consumed so far.
+using ProgressCallback = std::function<void(float)>;
+
+/// Shared cancellation token. The background parse thread checks this via
+/// load(std::memory_order_relaxed) and exits early when it is set to true.
+using CancelToken = std::shared_ptr<std::atomic<bool>>;
 
 struct LogParseResult {
     enum class SourceType { Unknown, PX4ULog, APMDataFlash };
@@ -30,4 +43,5 @@ struct LogParseResult {
     SourceType sourceType = SourceType::Unknown;
     int firmwareMajorVersion = -1;
     int firmwareMinorVersion = -1;
+    QDateTime startTime;
 };

--- a/src/AnalyzeView/LogViewer/LogViewerAltChart.qml
+++ b/src/AnalyzeView/LogViewer/LogViewerAltChart.qml
@@ -11,10 +11,12 @@ import QGroundControl.Controls
 /// exposed via the markerChanged / markerCleared signals so the parent
 /// can place a dot on the map.
 Item {
-    id: root
+    id: control
 
-    required property var    logParser
+    required property var logParser
     required property string altFieldName   ///< e.g. "vehicle_global_position.alt"
+
+    property bool xAxisShowLocalTime: false
 
     signal markerChanged(double timestampSeconds)
     signal markerCleared()
@@ -23,91 +25,46 @@ Item {
     // -------------------------------------------------------------------------
     // Internal state
     // -------------------------------------------------------------------------
-    property real _fullMinX: 0
-    property real _fullMaxX: 1
-    property real _zoomMinX: 0
-    property real _zoomMaxX: 1
-
-    property bool _markerVisible: false
-    property real _markerPixelX: 0
-    property real _markerXValue: 0
     property real _markerAltValue: 0
     property real _altMin: 0
     property real _altMax: 0
     property bool _hasAltRange: false
-
-    QGCPalette { id: qgcPal }
-
-    // -------------------------------------------------------------------------
-    // Coordinate conversions
-    // -------------------------------------------------------------------------
-    function _pixelToAxisX(pixelX) {
-        const plotX = _altChart.plotArea.x
-        const plotW = _altChart.plotArea.width
-        if (plotW <= 0 || _xAxis.max <= _xAxis.min) return _xAxis.min
-        const ratio = (Math.max(plotX, Math.min(plotX + plotW, pixelX)) - plotX) / plotW
-        return _xAxis.min + ratio * (_xAxis.max - _xAxis.min)
-    }
-
-    function _axisXToPixel(axisX) {
-        const plotX = _altChart.plotArea.x
-        const plotW = _altChart.plotArea.width
-        if (plotW <= 0 || _xAxis.max <= _xAxis.min) return plotX
-        const ratio = (axisX - _xAxis.min) / (_xAxis.max - _xAxis.min)
-        return plotX + Math.max(0, Math.min(plotW, ratio * plotW))
-    }
+    property var _altSeries: null
 
     // -------------------------------------------------------------------------
-    // Zoom
+    // Public API (delegated to _base)
     // -------------------------------------------------------------------------
-    function _applyZoomInternal(minX, maxX) {
-        if (maxX <= minX) return
-        _zoomMinX = minX
-        _zoomMaxX = maxX
-        _xAxis.min = minX
-        _xAxis.max = maxX
-        if (_markerVisible && (_markerXValue < minX || _markerXValue > maxX)) {
-            _markerXValue = (minX + maxX) / 2
+    function setSharedZoom(minX, maxX) { _base.setSharedZoom(minX, maxX) }
+    function setSharedCursor(t)        { _base.setSharedCursor(t) }
+
+    // -------------------------------------------------------------------------
+    // Series management
+    // -------------------------------------------------------------------------
+    Component {
+        id: _altSeriesComp
+        LineSeries {
+            color: QGroundControl.globalPalette.colorGreen
+            width: 2
         }
-        _markerPixelX = _axisXToPixel(_markerXValue)
-        Qt.callLater(_refreshSeries)
     }
 
-    // User-driven zoom — emits zoomApplied for cross-chart sync
-    function _applyZoom(minX, maxX) {
-        _applyZoomInternal(minX, maxX)
-        zoomApplied(minX, maxX)
+    Component.onCompleted: {
+        _altSeries = _altSeriesComp.createObject(_base.graphsView, {
+            axisX: _base.xAxis,
+            axisY: _base.yAxis
+        })
+        _base.graphsView.addSeries(_altSeries)
     }
 
-    // External zoom sync — no re-emit
-    function setSharedZoom(minX, maxX) {
-        _applyZoomInternal(minX, maxX)
-    }
-
-    // External cursor sync — no re-emit
-    function setSharedCursor(t) {
-        _markerVisible = true
-        _markerXValue  = t
-        _markerPixelX  = _axisXToPixel(t)
-        _markerAltValue = logParser.fieldValueAt(root.altFieldName, t)
-    }
-
-    function _resetZoom() {
-        _applyZoom(_fullMinX, _fullMaxX)
-    }
-
-    // -------------------------------------------------------------------------
-    // Series data
-    // -------------------------------------------------------------------------
     function _refreshSeries() {
-        const fieldName = root.altFieldName
-        if (!logParser.parsed || fieldName.length === 0) {
-            _altSeries.clear()
+        const fieldName = control.altFieldName
+        if (!logParser.parseComplete || fieldName.length === 0 || !_altSeries) {
+            if (_altSeries) _altSeries.clear()
             return
         }
 
-        const pixelWidth = Math.max(1, Math.floor(_altChart.plotArea.width))
-        const points = logParser.fieldSamplesFiltered(fieldName, _zoomMinX, _zoomMaxX, pixelWidth)
+        const pixelWidth = Math.max(1, Math.floor(_base.graphsView.plotArea.width))
+        const points = logParser.fieldSamplesFiltered(fieldName, _base.zoomMinX, _base.zoomMaxX, pixelWidth)
 
         _altSeries.clear()
         if (!points || points.length === 0) return
@@ -131,25 +88,22 @@ Item {
         }
 
         const pad = Math.max(1, (maxY - minY) * 0.05)
-        _yAxis.min = minY - pad
-        _yAxis.max = maxY + pad
+        _base.yAxis.min = minY - pad
+        _base.yAxis.max = maxY + pad
 
-        if (_markerVisible) {
-            _markerAltValue = logParser.fieldValueAt(root.altFieldName, _markerXValue)
+        if (_base.markerVisible) {
+            _markerAltValue = logParser.fieldValueAt(control.altFieldName, _base.markerXValue)
         }
     }
 
     // -------------------------------------------------------------------------
-    // Marker / cursor
+    // Cursor helpers
     // -------------------------------------------------------------------------
-    function _updateCursor(pixelX) {
-        if (_xAxis.max <= _xAxis.min) return
-        _markerVisible = true
-        _markerPixelX = Math.max(_altChart.plotArea.x,
-                                 Math.min(_altChart.plotArea.x + _altChart.plotArea.width, pixelX))
-        _markerXValue = _pixelToAxisX(_markerPixelX)
-        _markerAltValue = logParser.fieldValueAt(root.altFieldName, _markerXValue)
-        root.markerChanged(_markerXValue)
+    function _initCursor() {
+        if (!logParser.parseComplete || _base.xAxis.max <= _base.xAxis.min) return
+        const mid = (_base.xAxis.min + _base.xAxis.max) / 2
+        _base.setCursor(mid)
+        control.markerChanged(mid)
     }
 
     // -------------------------------------------------------------------------
@@ -158,230 +112,69 @@ Item {
     Connections {
         target: logParser
 
-        function onParsedChanged() {
-            if (!logParser.parsed) {
-                _altSeries.clear()
-                _markerVisible  = false
-                _hasAltRange    = false
-                root.markerCleared()
+        function onParseCompleteChanged() {
+            if (!logParser.parseComplete) {
+                if (_altSeries) _altSeries.clear()
+                _hasAltRange = false
+                control.markerCleared()
                 return
             }
-            if (logParser.minTimestamp >= 0 && logParser.maxTimestamp > logParser.minTimestamp) {
-                root._fullMinX = logParser.minTimestamp
-                root._fullMaxX = logParser.maxTimestamp
-            } else {
-                root._fullMinX = 0
-                root._fullMaxX = 1
-            }
-            root._applyZoom(root._fullMinX, root._fullMaxX)
-            Qt.callLater(root._initCursor)
+            const hasRange = logParser.minTimestamp >= 0 && logParser.maxTimestamp > logParser.minTimestamp
+            _base.initRange(hasRange ? logParser.minTimestamp : 0,
+                            hasRange ? logParser.maxTimestamp : 1)
+            Qt.callLater(control._initCursor)
         }
     }
 
-    // Called on first parse and when the component becomes visible after parse
-    function _initCursor() {
-        if (!logParser.parsed || _xAxis.max <= _xAxis.min) return
-        _markerXValue   = (_xAxis.min + _xAxis.max) / 2
-        _markerPixelX   = _axisXToPixel(_markerXValue)
-        _markerAltValue = logParser.fieldValueAt(root.altFieldName, _markerXValue)
-        _markerVisible  = true
-        root.markerChanged(_markerXValue)
+    Connections {
+        target: _base
+        function onZoomRangeSet(minX, maxX) { Qt.callLater(_refreshSeries) }
+        function onCursorPositionSet(t)     { _markerAltValue = logParser.fieldValueAt(altFieldName, t) }
+        function onCursorMoved(t)           { control.markerChanged(t) }
+        function onZoomApplied(minX, maxX)  { control.zoomApplied(minX, maxX) }
     }
 
     onVisibleChanged: {
-        if (visible && logParser.parsed && !_markerVisible) {
+        if (visible && logParser.parseComplete && !_base.markerVisible) {
             Qt.callLater(_initCursor)
         }
     }
 
     // -------------------------------------------------------------------------
-    // Chart
+    // Base chart
     // -------------------------------------------------------------------------
-    Item {
-        id: _chartContainer
+    LogViewerBaseChart {
+        id: _base
         anchors.fill: parent
+        logParser: control.logParser
+        xAxisShowLocalTime: control.xAxisShowLocalTime
+        yAxisTitle: qsTr("Alt (m)")
+        popupYOffset: ScreenTools.defaultFontPixelHeight * 0.4
 
-        GraphsView {
-            id: _altChart
-            anchors.fill: parent
-            marginTop: 0
-            marginRight: 0
-            marginBottom: 0
-            marginLeft: 0
-
-            theme: GraphsTheme {
-                colorScheme:            qgcPal.globalTheme === QGCPalette.Light ? GraphsTheme.ColorScheme.Light : GraphsTheme.ColorScheme.Dark
-                backgroundColor:        qgcPal.windowShadeDark
-                backgroundVisible:      true
-                plotAreaBackgroundColor: qgcPal.windowShadeDark
-                grid.mainColor:         Qt.rgba(qgcPal.text.r, qgcPal.text.g, qgcPal.text.b, 0.25)
-                grid.subColor:          Qt.rgba(qgcPal.text.r, qgcPal.text.g, qgcPal.text.b, 0.12)
-                grid.mainWidth:         1
-                labelBackgroundVisible: false
-                labelTextColor:         qgcPal.text
-                axisXLabelFont.family:       ScreenTools.fixedFontFamily
-                axisXLabelFont.pointSize:    ScreenTools.smallFontPointSize
-                axisYLabelFont.family:       ScreenTools.fixedFontFamily
-                axisYLabelFont.pointSize:    ScreenTools.smallFontPointSize
-            }
-
-            axisX: ValueAxis {
-                id: _xAxis
-                titleText: qsTr("Time (s)")
-                min: 0
-                max: 1
-            }
-
-            axisY: ValueAxis {
-                id: _yAxis
-                titleText: qsTr("Alt (m)")
-                min: 0
-                max: 1
-            }
-
-            LineSeries {
-                id: _altSeries
-                color: QGroundControl.globalPalette.colorGreen
-                width: 2
-            }
+        // ---- Chart-specific popup rows ----
+        QGCLabel {
+            text: altFieldName
+            font.bold: true
+            elide: Text.ElideMiddle
+            width: _base.popupWidth - (ScreenTools.defaultFontPixelWidth * 2)
         }
 
-        // Zoom selection rect
-        Rectangle {
-            id: _zoomRect
-            visible: false
-            color: Qt.rgba(1, 1, 1, 0.2)
-            border.color: qgcPal.buttonHighlight
-            border.width: 1
-            z: 10
-        }
+        RowLayout {
+            spacing: ScreenTools.defaultFontPixelWidth * 0.3
 
-        // Mouse area — drag to zoom, right-click to reset, click/move to set cursor
-        MouseArea {
-            anchors.fill: parent
-            acceptedButtons: Qt.LeftButton | Qt.RightButton
-            z: 11
+            QGCLabel { text: qsTr("Current") }
+            QGCLabel { text: isNaN(_markerAltValue) ? "—" : _markerAltValue.toFixed(1) + " m"; font.bold: true }
 
-            property real _dragStartX: 0
+            Item { visible: _hasAltRange; width: ScreenTools.defaultFontPixelWidth * 0.5 }
 
-            onPressed: (mouse) => {
-                if (mouse.button === Qt.RightButton) {
-                    root._resetZoom()
-                    return
-                }
-                _dragStartX = mouse.x
-                _zoomRect.x = mouse.x
-                _zoomRect.y = _altChart.plotArea.y
-                _zoomRect.width = 0
-                _zoomRect.height = _altChart.plotArea.height
-                _zoomRect.visible = true
-            }
+            QGCLabel { visible: _hasAltRange; text: qsTr("Min") }
+            QGCLabel { visible: _hasAltRange; text: _altMin.toFixed(1) + " m"; font.bold: true }
 
-            onPositionChanged: (mouse) => {
-                if (pressed && _zoomRect.visible) {
-                    const left  = Math.min(_dragStartX, mouse.x)
-                    const right = Math.max(_dragStartX, mouse.x)
-                    _zoomRect.x = left
-                    _zoomRect.width = Math.max(0, right - left)
-                }
-            }
+            Item { visible: _hasAltRange; width: ScreenTools.defaultFontPixelWidth * 0.5 }
 
-            onReleased: (mouse) => {
-                if (!_zoomRect.visible) return
-                const dragW = _zoomRect.width
-                _zoomRect.visible = false
-                if (dragW < ScreenTools.defaultFontPixelWidth * 0.5) {
-                    root._updateCursor(mouse.x)
-                    return
-                }
-                const leftX  = root._pixelToAxisX(_zoomRect.x)
-                const rightX = root._pixelToAxisX(_zoomRect.x + _zoomRect.width)
-                root._applyZoom(Math.min(leftX, rightX), Math.max(leftX, rightX))
-            }
-        }
-
-        // Position marker line
-        Rectangle {
-            visible: _markerVisible
-            x:       _markerPixelX
-            y:       _altChart.plotArea.y
-            width:   1
-            height:  _altChart.plotArea.height
-            color:   qgcPal.text
-            z:       12
-
-            // Recalculate pixel position when the plot area is laid out or resized
-            Connections {
-                target: _altChart
-                function onPlotAreaChanged() {
-                    if (root._markerVisible) {
-                        root._markerPixelX = root._axisXToPixel(root._markerXValue)
-                    }
-                }
-            }
-        }
-
-        // Value popup
-        Rectangle {
-            id: _popup
-            visible:  _markerVisible
-            x:        _popupX()
-            y:        _altChart.plotArea.y + ScreenTools.defaultFontPixelHeight * 0.4
-            implicitWidth:  _popupCol.implicitWidth + (margin * 2)
-            implicitHeight: _popupCol.implicitHeight + (margin * 2)
-            color:    qgcPal.windowShade
-            border.color: qgcPal.windowShadeDark
-            radius:   ScreenTools.defaultFontPixelWidth * 0.3
-            z:        13
-
-            property real margin: ScreenTools.defaultFontPixelWidth / 2
-
-            function _popupX() {
-                const mid = _altChart.plotArea.x + _altChart.plotArea.width / 2
-                if (_markerPixelX < mid) {
-                    return Math.max(0, _altChart.plotArea.x + _altChart.plotArea.width - width)
-                } else {
-                    return Math.max(0, _altChart.plotArea.x)
-                }
-            }
-
-            ColumnLayout {
-                id: _popupCol
-                anchors.fill: parent
-                anchors.margins: _popup.margin
-                spacing: ScreenTools.defaultFontPixelHeight * 0.2
-
-                // Line 1: field name (bold)
-                QGCLabel {
-                    text: altFieldName
-                    font.bold: true
-                    elide: Text.ElideMiddle
-                    width: parent.width
-                }
-
-                // Line 2: time
-                QGCLabel {
-                    text: qsTr("t = %1 s").arg(_markerXValue.toFixed(3))
-                }
-
-                // Line 3: Current / Min / Max
-                RowLayout {
-                    spacing: ScreenTools.defaultFontPixelWidth * 0.3
-
-                    QGCLabel { text: qsTr("Current") }
-                    QGCLabel { text: isNaN(_markerAltValue) ? "\u2014" : _markerAltValue.toFixed(1) + " m"; font.bold: true }
-
-                    Item { visible: _hasAltRange; width: ScreenTools.defaultFontPixelWidth * 0.5 }
-
-                    QGCLabel { visible: _hasAltRange; text: qsTr("Min") }
-                    QGCLabel { visible: _hasAltRange; text: _altMin.toFixed(1) + " m"; font.bold: true }
-
-                    Item { visible: _hasAltRange; width: ScreenTools.defaultFontPixelWidth * 0.5 }
-
-                    QGCLabel { visible: _hasAltRange; text: qsTr("Max") }
-                    QGCLabel { visible: _hasAltRange; text: _altMax.toFixed(1) + " m"; font.bold: true }
-                }
-            }
+            QGCLabel { visible: _hasAltRange; text: qsTr("Max") }
+            QGCLabel { visible: _hasAltRange; text: _altMax.toFixed(1) + " m"; font.bold: true }
         }
     }
 }
+

--- a/src/AnalyzeView/LogViewer/LogViewerBaseChart.qml
+++ b/src/AnalyzeView/LogViewer/LogViewerBaseChart.qml
@@ -1,0 +1,383 @@
+import QtQuick
+import QtQuick.Layouts
+import QtGraphs
+
+import QGroundControl
+import QGroundControl.Controls
+
+/// Shared chart base for the Log Viewer.
+///
+/// Provides: GraphsView with QGC-themed GraphsTheme, a HH:MM:SS x-axis
+/// labelDelegate, zoom/cursor interaction, position marker line, and
+/// LogViewerCursorPopup.
+///
+/// Derived charts (LogViewerChart, LogViewerAltChart) embed this as an Item,
+/// connect to zoomRangeSet / cursorPositionSet to refresh their series data,
+/// and supply popup extra rows as declarative children (forwarded via the
+/// default property alias to the popup's extraContent).
+Item {
+    id: control
+
+    // -------------------------------------------------------------------------
+    // Required
+    // -------------------------------------------------------------------------
+    required property var logParser
+
+    // -------------------------------------------------------------------------
+    // Optional
+    // -------------------------------------------------------------------------
+    property bool xAxisShowLocalTime: false
+    property string yAxisTitle: ""
+    property real popupYOffset: 0   ///< added to popup y (alt chart offsets slightly)
+
+    // -------------------------------------------------------------------------
+    // Read-only aliases to child items — derived charts access these
+    // -------------------------------------------------------------------------
+    readonly property alias graphsView: _chart
+    readonly property alias xAxis: _xAxis
+    readonly property alias yAxis: _yAxis
+    readonly property alias colorBlockWidth: _popup.colorBlockWidth
+    readonly property real popupWidth: _popup.implicitWidth
+
+    // -------------------------------------------------------------------------
+    // Default property — children declared inside LogViewerBaseChart { } go
+    // into the popup's extraContent column (chart-specific popup rows).
+    // -------------------------------------------------------------------------
+    default property alias content: _popup.extraContent
+
+    // -------------------------------------------------------------------------
+    // Signals
+    // -------------------------------------------------------------------------
+
+    /// Emitted only on user-driven cursor interaction.
+    /// Do NOT re-emit this when handling an external sync (setSharedCursor).
+    signal cursorMoved(real t)
+
+    /// Emitted only on user-driven zoom.
+    /// Do NOT re-emit this when handling an external sync (setSharedZoom).
+    signal zoomApplied(real minX, real maxX)
+
+    /// Emitted whenever the zoom range changes (user-driven or external sync).
+    /// Derived charts connect here to refresh their series data.
+    signal zoomRangeSet(real minX, real maxX)
+
+    /// Emitted whenever the cursor position changes (user-driven or external sync).
+    /// Derived charts connect here to update popup values (e.g. _markerAltValue).
+    signal cursorPositionSet(real t)
+
+    // -------------------------------------------------------------------------
+    // State — writable by base, readable by derived charts
+    // -------------------------------------------------------------------------
+    property bool markerVisible: false
+    property real markerPixelX: 0
+    property real markerXValue: 0
+    property real fullMinX: 0
+    property real fullMaxX: 1
+    property real zoomMinX: 0
+    property real zoomMaxX: 1
+
+    // -------------------------------------------------------------------------
+    // Public API
+    // -------------------------------------------------------------------------
+
+    /// Set the full and zoom range (called on log load).
+    /// Emits zoomRangeSet so derived charts can refresh their series.
+    function initRange(minX, maxX) {
+        fullMinX   = minX
+        fullMaxX   = maxX
+        zoomMinX   = minX
+        zoomMaxX   = maxX
+        _xAxis.min = minX
+        _xAxis.max = maxX
+        zoomRangeSet(minX, maxX)
+    }
+
+    /// User-driven zoom — also emits zoomApplied for cross-chart sync.
+    function applyZoomRange(minX, maxX) {
+        _applyZoomInternal(minX, maxX)
+        zoomApplied(minX, maxX)
+    }
+
+    /// External zoom sync — does not re-emit zoomApplied.
+    function setSharedZoom(minX, maxX) {
+        _applyZoomInternal(minX, maxX)
+    }
+
+    /// Place the cursor at axis value t and emit cursorPositionSet.
+    /// Does NOT emit cursorMoved — use for both external sync and initial placement.
+    function setCursor(t) {
+        if (_xAxis.max <= _xAxis.min) return
+        markerXValue  = t
+        markerPixelX  = _axisXToPixel(t)
+        markerVisible = true
+        cursorPositionSet(t)
+    }
+
+    /// External cursor sync — delegates to setCursor (no cursorMoved emitted).
+    function setSharedCursor(t) {
+        setCursor(t)
+    }
+
+    function resetZoom() {
+        applyZoomRange(fullMinX, fullMaxX)
+    }
+
+    function clearCursor() {
+        markerVisible = false
+    }
+
+    // -------------------------------------------------------------------------
+    // Internal helpers
+    // -------------------------------------------------------------------------
+    function _pixelToAxisX(pixelX) {
+        const plotX = _chart.plotArea.x
+        const plotW = _chart.plotArea.width
+        if (plotW <= 0 || _xAxis.max <= _xAxis.min) return _xAxis.min
+        const ratio = (Math.max(plotX, Math.min(plotX + plotW, pixelX)) - plotX) / plotW
+        return _xAxis.min + ratio * (_xAxis.max - _xAxis.min)
+    }
+
+    function _axisXToPixel(axisX) {
+        const plotX = _chart.plotArea.x
+        const plotW = _chart.plotArea.width
+        if (plotW <= 0 || _xAxis.max <= _xAxis.min) return plotX
+        const ratio = (axisX - _xAxis.min) / (_xAxis.max - _xAxis.min)
+        return plotX + Math.max(0, Math.min(plotW, ratio * plotW))
+    }
+
+    function _applyZoomInternal(minX, maxX) {
+        if (maxX <= minX) return
+        zoomMinX   = minX
+        zoomMaxX   = maxX
+        _xAxis.min = minX
+        _xAxis.max = maxX
+        if (markerVisible && (markerXValue < minX || markerXValue > maxX)) {
+            markerXValue = (minX + maxX) / 2
+        }
+        markerPixelX = _axisXToPixel(markerXValue)
+        zoomRangeSet(minX, maxX)
+    }
+
+    function _updateCursorFromInteraction(pixelX) {
+        if (_xAxis.max <= _xAxis.min) return
+        const plotX   = _chart.plotArea.x
+        const plotW   = _chart.plotArea.width
+        markerVisible = true
+        markerPixelX  = Math.max(plotX, Math.min(plotX + plotW, pixelX))
+        markerXValue  = _pixelToAxisX(markerPixelX)
+        cursorPositionSet(markerXValue)
+        cursorMoved(markerXValue)
+    }
+
+    function _popupX() {
+        const plotMidX = _chart.plotArea.x + _chart.plotArea.width / 2
+        if (markerPixelX < plotMidX) {
+            const rightX = _chart.plotArea.x + _chart.plotArea.width - _popup.width
+            return Math.max(0, Math.min(rightX, control.width - _popup.width))
+        } else {
+            return _chart.plotArea.x + _popup._margin
+        }
+    }
+
+    // -------------------------------------------------------------------------
+    // Visual tree
+    // -------------------------------------------------------------------------
+    QGCPalette { id: qgcPal }
+
+    GraphsView {
+        id: _chart
+        anchors.fill: parent
+        marginTop: 0
+        marginRight: 0
+        marginBottom: 0
+        marginLeft: 0
+
+        theme: GraphsTheme {
+            colorScheme: qgcPal.globalTheme === QGCPalette.Light ? GraphsTheme.ColorScheme.Light : GraphsTheme.ColorScheme.Dark
+            backgroundColor: qgcPal.windowShadeDark
+            backgroundVisible: true
+            plotAreaBackgroundColor: qgcPal.windowShadeDark
+            grid.mainColor: Qt.rgba(qgcPal.text.r, qgcPal.text.g, qgcPal.text.b, 0.25)
+            grid.subColor: Qt.rgba(qgcPal.text.r, qgcPal.text.g, qgcPal.text.b, 0.12)
+            grid.mainWidth: 1
+            labelBackgroundVisible: false
+            labelTextColor: qgcPal.text
+            axisXLabelFont.family: ScreenTools.fixedFontFamily
+            axisXLabelFont.pointSize: ScreenTools.smallFontPointSize
+            axisYLabelFont.family: ScreenTools.fixedFontFamily
+            axisYLabelFont.pointSize: ScreenTools.smallFontPointSize
+        }
+
+        axisX: ValueAxis {
+            id: _xAxis
+            titleText: xAxisShowLocalTime ? qsTr("Time (local)") : qsTr("Elapsed")
+            labelFormat: "%.3f"
+            min: 0
+            max: 1
+
+            labelDelegate: Component {
+                Item {
+                    property string text: ""  // raw seconds value, assigned by axis
+
+                    Text {
+                        anchors.centerIn: parent
+                        color: _chart.theme.labelTextColor
+                        font: _chart.theme.axisXLabelFont
+                        horizontalAlignment: Text.AlignHCenter
+                        text: {
+                            const secs = parseFloat(parent.text)
+                            if (isNaN(secs)) { return parent.text }
+                            if (xAxisShowLocalTime) {
+                                const st = logParser.startTime
+                                if (st && !isNaN(st.getTime()) && st.getTime() > 0) {
+                                    const use12h = Qt.locale().timeFormat(Locale.ShortFormat).indexOf("a") >= 0
+                                                || Qt.locale().timeFormat(Locale.ShortFormat).indexOf("A") >= 0
+                                    return Qt.formatTime(new Date(st.getTime() + secs * 1000),
+                                                         use12h ? "h:mm:ss AP" : "HH:mm:ss")
+                                }
+                            }
+                            const wholeSecs = Math.floor(secs)
+                            const hh = Math.floor(wholeSecs / 3600)
+                            const mm = Math.floor((wholeSecs % 3600) / 60)
+                            const ss = wholeSecs % 60
+                            if (hh > 0) {
+                                return hh + ":" + String(mm).padStart(2, "0") + ":" + String(ss).padStart(2, "0")
+                            } else if (mm > 0) {
+                                return mm + ":" + String(ss).padStart(2, "0")
+                            }
+                            return ss + "s"
+                        }
+                    }
+                }
+            }
+        }
+
+        axisY: ValueAxis {
+            id: _yAxis
+            titleText: yAxisTitle
+            min: 0
+            max: 1
+        }
+    }
+
+    // Recalculate marker pixel position when the chart is resized or laid out.
+    Connections {
+        target: _chart
+        function onPlotAreaChanged() {
+            if (control.markerVisible) {
+                control.markerPixelX = control._axisXToPixel(control.markerXValue)
+            }
+        }
+    }
+
+    // Zoom selection rectangle
+    Rectangle {
+        id: _zoomRect
+        visible: false
+        color: Qt.rgba(1, 1, 1, 0.2)
+        border.color: qgcPal.buttonHighlight
+        border.width: 1
+        z: 10
+    }
+
+    MouseArea {
+        anchors.fill: parent
+        acceptedButtons: Qt.LeftButton
+        enabled: _xAxis.max > _xAxis.min
+        z: 11
+
+        property real _dragStartX: 0
+        property bool _isDraggingCursor: false
+        property bool _isDraggingZoom: false
+        property bool _wasDoubleClick: false
+
+        onPressed: (mouse) => {
+            _isDraggingCursor = false
+            _isDraggingZoom   = false
+            _wasDoubleClick   = false
+            if (mouse.modifiers & Qt.ShiftModifier) {
+                // Shift pressed — start cursor drag
+                _isDraggingCursor = true
+                control._updateCursorFromInteraction(mouse.x)
+            } else {
+                // Plain press — start zoom selection
+                _dragStartX       = mouse.x
+                _zoomRect.x       = mouse.x
+                _zoomRect.y       = _chart.plotArea.y
+                _zoomRect.width   = 0
+                _zoomRect.height  = _chart.plotArea.height
+                _zoomRect.visible = false   // only show once drag is meaningful
+            }
+        }
+
+        onPositionChanged: (mouse) => {
+            if (!pressed) return
+            if (_isDraggingCursor) {
+                control._updateCursorFromInteraction(mouse.x)
+            } else {
+                // Plain drag — update zoom selection rect
+                const left  = Math.min(_dragStartX, mouse.x)
+                const right = Math.max(_dragStartX, mouse.x)
+                _zoomRect.x     = left
+                _zoomRect.width = Math.max(0, right - left)
+                if (_zoomRect.width >= ScreenTools.defaultFontPixelWidth * 0.5) {
+                    _isDraggingZoom   = true
+                    _zoomRect.visible = true
+                }
+            }
+        }
+
+        onReleased: (mouse) => {
+            if (_isDraggingCursor) {
+                _isDraggingCursor = false
+                return
+            }
+            _zoomRect.visible = false
+            if (_isDraggingZoom) {
+                _isDraggingZoom = false
+                const leftX  = control._pixelToAxisX(_zoomRect.x)
+                const rightX = control._pixelToAxisX(_zoomRect.x + _zoomRect.width)
+                control.applyZoomRange(Math.min(leftX, rightX), Math.max(leftX, rightX))
+            } else if (!_wasDoubleClick) {
+                // Tap — place cursor (suppressed on the second click of a double-click)
+                control._updateCursorFromInteraction(mouse.x)
+            }
+        }
+
+        onDoubleClicked: (mouse) => {
+            // onDoubleClicked fires before onReleased for the second click,
+            // so this flag prevents onReleased from repositioning the cursor.
+            _wasDoubleClick = true
+            control.resetZoom()
+            const centerT = (control.fullMinX + control.fullMaxX) / 2
+            control.setCursor(centerT)
+            control.cursorMoved(centerT)
+        }
+    }
+
+    // Position marker line
+    Rectangle {
+        visible: markerVisible
+        x: markerPixelX
+        y: _chart.plotArea.y
+        width: 1
+        height: _chart.plotArea.height
+        color: qgcPal.text
+        z: 12
+    }
+
+    // Cursor popup — chart-specific rows are injected via default property alias
+    LogViewerCursorPopup {
+        id: _popup
+        visible: markerVisible
+        x: _popupX()
+        y: _chart.plotArea.y + popupYOffset
+        z: 13
+        cursorXValue: markerXValue
+        logParser: control.logParser
+        xAxisShowLocalTime: control.xAxisShowLocalTime
+        zoomMinX: control.zoomMinX
+        zoomMaxX: control.zoomMaxX
+        plotAreaWidth: _chart.plotArea.width
+    }
+}

--- a/src/AnalyzeView/LogViewer/LogViewerChart.qml
+++ b/src/AnalyzeView/LogViewer/LogViewerChart.qml
@@ -11,39 +11,26 @@ import QGroundControl.Controls
 /// The parent calls refreshBinChart(), centerCursor(), and clearMarker() at
 /// appropriate lifecycle points (log load, log clear, field-clear).
 ColumnLayout {
+    id: control
+
     required property var logParser
     required property var logViewerController
+
+    property bool xAxisShowLocalTime: false
 
     spacing: ScreenTools.defaultFontPixelHeight * 0.5
 
     // -------------------------------------------------------------------------
     // Internal state
     // -------------------------------------------------------------------------
-    // Fixed cursor — set by clicking on the chart
-    property bool   _positionMarkerVisible: false
-    property real   _markerPixelX: 0
-    property real   _markerXValue: 0
-    property var    _markerRows: []
-    property var    _markerEventRows: []
+    property var _markerRows: []
+    property var _markerEventRows: []
     property string _markerModeName: ""
 
-    // Hover cursor — follows mouse, disappears when mouse leaves chart
-    property bool   _hoverVisible: false
-    property real   _hoverPixelX: 0
-    property real   _hoverXValue: 0
-    property var    _hoverRows: []
-    property var    _hoverEventRows: []
-    property string _hoverModeName: ""
-
-    property real   _fullMinX: 0
-    property real   _fullMaxX: 1
-    property real   _zoomMinX: 0
-    property real   _zoomMaxX: 1
-
-    property var    _seriesByField: ({})
-    property var    _fieldYRange: ({})
-    property var    _fieldFullRange: ({})   // full-dataset min/max, set when series is first created
-    property var    _eventSeriesByType: ({})
+    property var _seriesByField: ({})
+    property var _fieldYRange: ({})
+    property var _fieldFullRange: ({})   // full-dataset min/max, set when series is first created
+    property var _eventSeriesByType: ({})
 
     // Shared position / zoom signals
     signal cursorMoved(real timestampSeconds)
@@ -53,8 +40,6 @@ ColumnLayout {
     readonly property real _legendRowHeight: ScreenTools.defaultFontPixelHeight * 1.1
     readonly property real _legendColorBlockSize: ScreenTools.defaultFontPixelHeight * 0.8
     readonly property real _legendItemSpacing: ScreenTools.defaultFontPixelWidth * 0.2
-
-    QGCPalette { id: qgcPal }
 
     readonly property var _fieldChartColors: [
         "#1E88E5", // blue
@@ -92,11 +77,11 @@ ColumnLayout {
     }
 
     function modeColor(modeName) {
-        return logViewerController.modeColor(String(modeName))
+        return logParser.modeColor(String(modeName))
     }
 
     function modeLegendEntries() {
-        return logViewerController.modeLegendEntries(logParser.modeSegments)
+        return logParser.modeNames
     }
 
     function fieldColor(fieldName) {
@@ -116,64 +101,12 @@ ColumnLayout {
     }
 
     // -------------------------------------------------------------------------
-    // Zoom
+    // Zoom / cursor (delegated to _base)
     // -------------------------------------------------------------------------
-    function _applyZoomInternal(minX, maxX) {
-        if (maxX <= minX) return
-        _zoomMinX = minX
-        _zoomMaxX = maxX
-        _binXAxis.min = _zoomMinX
-        _binXAxis.max = _zoomMaxX
-        if (_positionMarkerVisible && (_markerXValue < _zoomMinX || _markerXValue > _zoomMaxX)) {
-            _markerXValue = (_zoomMinX + _zoomMaxX) / 2
-        }
-        _refreshCursorPixelPos()
-        Qt.callLater(_syncSeriesWithSelection)
-    }
-
-    // User-driven zoom — also emits zoomApplied so other charts can sync
-    function applyZoomRange(minX, maxX) {
-        _applyZoomInternal(minX, maxX)
-        zoomApplied(minX, maxX)
-    }
-
-    // External zoom sync — apply without re-emitting
-    function setSharedZoom(minX, maxX) {
-        _applyZoomInternal(minX, maxX)
-    }
-
-    // External cursor sync — apply without re-emitting
-    function setSharedCursor(t) {
-        if (_binXAxis.max <= _binXAxis.min) return
-        _markerXValue = t
-        _markerPixelX = _axisXToPixel(t)
-        _positionMarkerVisible = true
-        _queryCursorValues()
-    }
-
-    function resetZoom() {
-        applyZoomRange(_fullMinX, _fullMaxX)
-    }
-
-    // -------------------------------------------------------------------------
-    // Coordinate conversions
-    // -------------------------------------------------------------------------
-    function _pixelToAxisX(pixelX) {
-        const plotX = _binChart.plotArea.x
-        const plotW = _binChart.plotArea.width
-        if (plotW <= 0 || _binXAxis.max <= _binXAxis.min) return _binXAxis.min
-        const clampedPixel = Math.max(plotX, Math.min(plotX + plotW, pixelX))
-        const ratio = (clampedPixel - plotX) / plotW
-        return _binXAxis.min + (ratio * (_binXAxis.max - _binXAxis.min))
-    }
-
-    function _axisXToPixel(axisX) {
-        const plotX = _binChart.plotArea.x
-        const plotW = _binChart.plotArea.width
-        if (plotW <= 0 || _binXAxis.max <= _binXAxis.min) return plotX
-        const ratio = (axisX - _binXAxis.min) / (_binXAxis.max - _binXAxis.min)
-        return plotX + Math.max(0, Math.min(plotW, ratio * plotW))
-    }
+    function applyZoomRange(minX, maxX) { _base.applyZoomRange(minX, maxX) }
+    function setSharedZoom(minX, maxX)  { _base.setSharedZoom(minX, maxX) }
+    function setSharedCursor(t)         { _base.setSharedCursor(t) }
+    function resetZoom()                { _base.resetZoom() }
 
     // -------------------------------------------------------------------------
     // Marker / cursor
@@ -188,14 +121,14 @@ ColumnLayout {
             if (isNaN(value)) continue
             const fr = _fieldFullRange[field]
             rows.push({
-                name:  field,
+                name: field,
                 color: fieldColor(field),
                 value: value,
-                min:   fr ? fr.min : NaN,
-                max:   fr ? fr.max : NaN
+                min: fr ? fr.min : NaN,
+                max: fr ? fr.max : NaN
             })
         }
-        const threshold = Math.max(0.05, (_binXAxis.max - _binXAxis.min) / 200.0)
+        const threshold = Math.max(0.05, (_base.xAxis.max - _base.xAxis.min) / 200.0)
         const nearbyEvents = logParser.eventsNear(xValue, threshold)
         const events = []
         for (let i = 0; i < nearbyEvents.length; i++) {
@@ -205,69 +138,24 @@ ColumnLayout {
     }
 
     function _queryCursorValues() {
-        const result = _queryValuesAtTime(_markerXValue)
+        const result = _queryValuesAtTime(_base.markerXValue)
         _markerModeName = result.modeName
         _markerRows = result.rows
         _markerEventRows = result.events
     }
 
-    function _queryHoverValues() {
-        const result = _queryValuesAtTime(_hoverXValue)
-        _hoverModeName = result.modeName
-        _hoverRows = result.rows
-        _hoverEventRows = result.events
-    }
-
-    function _updateCursorInfo(pixelX) {
-        if (_binXAxis.max <= _binXAxis.min) return
-        _positionMarkerVisible = true
-        _markerPixelX = Math.max(_binChart.plotArea.x, Math.min(_binChart.plotArea.x + _binChart.plotArea.width, pixelX))
-        _markerXValue = _pixelToAxisX(_markerPixelX)
-        _queryCursorValues()
-        cursorMoved(_markerXValue)
-    }
-
-    function _updateHoverInfo(pixelX) {
-        if (_binXAxis.max <= _binXAxis.min) return
-        _hoverPixelX = Math.max(_binChart.plotArea.x, Math.min(_binChart.plotArea.x + _binChart.plotArea.width, pixelX))
-        _hoverXValue = _pixelToAxisX(_hoverPixelX)
-        _queryHoverValues()
-    }
-
-    function _refreshCursorPixelPos() {
-        if (_positionMarkerVisible) {
-            _markerPixelX = _axisXToPixel(_markerXValue)
-        }
-    }
-
     // Public: called by parent after log load
     function centerCursor() {
-        if (_binXAxis.max <= _binXAxis.min) return
-        _markerXValue = (_binXAxis.min + _binXAxis.max) / 2
-        _markerPixelX = _axisXToPixel(_markerXValue)
-        _positionMarkerVisible = true
-        _queryCursorValues()
-    }
-
-    function _refreshCursorAtCurrentPosition() {
-        if (_binXAxis.max <= _binXAxis.min) return
-        _positionMarkerVisible = true
-        _markerPixelX = _axisXToPixel(_markerXValue)
-        _queryCursorValues()
-        if (_hoverVisible) {
-            _hoverPixelX = _axisXToPixel(_hoverXValue)
-            _queryHoverValues()
-        }
+        if (_base.xAxis.max <= _base.xAxis.min) return
+        _base.setCursor((_base.xAxis.min + _base.xAxis.max) / 2)
     }
 
     // Public: called by parent on log clear
     function clearMarker() {
-        _positionMarkerVisible = false
+        _base.clearCursor()
+        _markerModeName = ""
         _markerRows = []
         _markerEventRows = []
-        _hoverVisible = false
-        _hoverRows = []
-        _hoverEventRows = []
     }
 
     // -------------------------------------------------------------------------
@@ -276,27 +164,19 @@ ColumnLayout {
 
     // Public: full reset — called by parent on log load or clear
     function refreshBinChart() {
-        while (_binChart.seriesList.length > 0) {
-            _binChart.removeSeries(_binChart.seriesList[0])
+        while (_base.graphsView.seriesList.length > 0) {
+            _base.graphsView.removeSeries(_base.graphsView.seriesList[0])
         }
         _seriesByField = {}
         _fieldYRange = {}
         _fieldFullRange = {}
         _eventSeriesByType = {}
 
-        if (logParser.minTimestamp >= 0.0 && logParser.maxTimestamp > logParser.minTimestamp) {
-            _fullMinX = logParser.minTimestamp
-            _fullMaxX = logParser.maxTimestamp
-        } else {
-            _fullMinX = 0
-            _fullMaxX = 1
-        }
-        _zoomMinX = _fullMinX
-        _zoomMaxX = _fullMaxX
-        _binXAxis.min = _zoomMinX
-        _binXAxis.max = _zoomMaxX
-        _binYAxis.min = 0
-        _binYAxis.max = 1
+        const hasRange = logParser.minTimestamp >= 0.0 && logParser.maxTimestamp > logParser.minTimestamp
+        _base.initRange(hasRange ? logParser.minTimestamp : 0,
+                        hasRange ? logParser.maxTimestamp : 1)
+        _base.yAxis.min = 0
+        _base.yAxis.max = 1
     }
 
     function _syncSeriesWithSelection() {
@@ -310,7 +190,7 @@ ColumnLayout {
         const tracked = Object.keys(_seriesByField)
         for (let i = 0; i < tracked.length; i++) {
             if (!desired[tracked[i]]) {
-                _binChart.removeSeries(_seriesByField[tracked[i]])
+                _base.graphsView.removeSeries(_seriesByField[tracked[i]])
                 delete _seriesByField[tracked[i]]
                 delete _fieldYRange[tracked[i]]
             }
@@ -322,21 +202,21 @@ ColumnLayout {
         for (let i = 0; i < newSelection.length; i++) {
             const fieldName = String(newSelection[i])
 
-            const pixelWidth = Math.max(1, Math.floor(_binChart.plotArea.width))
-            const points = logParser.fieldSamplesFiltered(fieldName, _zoomMinX, _zoomMaxX, pixelWidth)
+            const pixelWidth = Math.max(1, Math.floor(_base.graphsView.plotArea.width))
+            const points = logParser.fieldSamplesFiltered(fieldName, _base.zoomMinX, _base.zoomMaxX, pixelWidth)
 
             let series
             if (_seriesByField[fieldName]) {
                 series = _seriesByField[fieldName]
                 series.clear()
             } else {
-                series = _lineSeriesComponent.createObject(_binChart, {
+                series = _lineSeriesComponent.createObject(_base.graphsView, {
                     color: fieldColor(fieldName),
                     width: 2,
-                    axisX: _binXAxis,
-                    axisY: _binYAxis
+                    axisX: _base.xAxis,
+                    axisY: _base.yAxis
                 })
-                _binChart.addSeries(series)
+                _base.graphsView.addSeries(series)
                 _seriesByField[fieldName] = series
 
                 // Compute full-dataset min/max once when the series is first created
@@ -380,32 +260,32 @@ ColumnLayout {
             }
             if (globalMinY === globalMaxY) globalMaxY = globalMinY + 1
         }
-        _binYAxis.min = globalMinY
-        _binYAxis.max = globalMaxY
+        _base.yAxis.min = globalMinY
+        _base.yAxis.max = globalMaxY
 
         const existingTypes = Object.keys(_eventSeriesByType)
         for (let i = 0; i < existingTypes.length; i++) {
-            _binChart.removeSeries(_eventSeriesByType[existingTypes[i]])
+            _base.graphsView.removeSeries(_eventSeriesByType[existingTypes[i]])
         }
         _eventSeriesByType = {}
         const eventList = logParser.events
         for (let e = 0; e < eventList.length; e++) {
             const ev = eventList[e]
-            if (ev.time < _binXAxis.min || ev.time > _binXAxis.max) continue
+            if (ev.time < _base.xAxis.min || ev.time > _base.xAxis.max) continue
             if (!_eventSeriesByType[ev.type]) {
-                const eventSeries = _scatterSeriesComponent.createObject(_binChart, {
+                const eventSeries = _scatterSeriesComponent.createObject(_base.graphsView, {
                     color: eventColor(ev.type),
-                    axisX: _binXAxis,
-                    axisY: _binYAxis
+                    axisX: _base.xAxis,
+                    axisY: _base.yAxis
                 })
-                _binChart.addSeries(eventSeries)
+                _base.graphsView.addSeries(eventSeries)
                 _eventSeriesByType[ev.type] = eventSeries
             }
-            _eventSeriesByType[ev.type].append(ev.time, _binYAxis.max)
+            _eventSeriesByType[ev.type].append(ev.time, _base.yAxis.max)
         }
 
-        if (_positionMarkerVisible) {
-            Qt.callLater(_refreshCursorAtCurrentPosition)
+        if (_base.markerVisible) {
+            Qt.callLater(_queryCursorValues)
         }
     }
 
@@ -419,32 +299,40 @@ ColumnLayout {
         }
     }
 
+    Connections {
+        target: _base
+        function onZoomRangeSet(minX, maxX) { Qt.callLater(_syncSeriesWithSelection) }
+        function onCursorPositionSet(t)     { _queryCursorValues() }
+        function onCursorMoved(t)           { cursorMoved(t) }
+        function onZoomApplied(minX, maxX)  { zoomApplied(minX, maxX) }
+    }
+
     // -------------------------------------------------------------------------
     // Timeline bars (offset to align with chart plot area)
     // -------------------------------------------------------------------------
     ColumnLayout {
         id: _timelineContainer
-        Layout.preferredWidth: _binChart.plotArea.x + _binChart.plotArea.width
+        Layout.preferredWidth: _base.graphsView.plotArea.x + _base.graphsView.plotArea.width
         spacing: ScreenTools.defaultFontPixelHeight * 0.1
 
         property real _barHeight: ScreenTools.defaultFontPixelHeight * 0.6
 
         function _segmentX(start) {
-            const w = _binChart.plotArea.width
-            if (_binXAxis.max <= _binXAxis.min) return 0
-            return Math.max(0, Math.min(w, ((Math.max(start, _binXAxis.min) - _binXAxis.min) / (_binXAxis.max - _binXAxis.min)) * w))
+            const w = _base.graphsView.plotArea.width
+            if (_base.xAxis.max <= _base.xAxis.min) return 0
+            return Math.max(0, Math.min(w, ((Math.max(start, _base.xAxis.min) - _base.xAxis.min) / (_base.xAxis.max - _base.xAxis.min)) * w))
         }
 
         function _segmentWidth(start, end) {
-            const w = _binChart.plotArea.width
-            if (_binXAxis.max <= _binXAxis.min) return 0
-            return ((Math.min(end, _binXAxis.max) - Math.max(start, _binXAxis.min)) / (_binXAxis.max - _binXAxis.min)) * w
+            const w = _base.graphsView.plotArea.width
+            if (_base.xAxis.max <= _base.xAxis.min) return 0
+            return ((Math.min(end, _base.xAxis.max) - Math.max(start, _base.xAxis.min)) / (_base.xAxis.max - _base.xAxis.min)) * w
         }
 
         function _eventX(time, itemWidth) {
-            const w = _binChart.plotArea.width
-            if (_binXAxis.max <= _binXAxis.min) return 0
-            return Math.max(0, Math.min(w - itemWidth, ((time - _binXAxis.min) / (_binXAxis.max - _binXAxis.min)) * w))
+            const w = _base.graphsView.plotArea.width
+            if (_base.xAxis.max <= _base.xAxis.min) return 0
+            return Math.max(0, Math.min(w - itemWidth, ((time - _base.xAxis.min) / (_base.xAxis.max - _base.xAxis.min)) * w))
         }
 
         // Bar 1: Flight modes
@@ -455,7 +343,7 @@ ColumnLayout {
             QGCLabel {
                 text: qsTr("Modes")
                 font.bold: true
-                Layout.preferredWidth: _binChart.plotArea.x  // Align with chart plot area
+                Layout.preferredWidth: _base.graphsView.plotArea.x  // Align with chart plot area
                 Layout.maximumWidth: Layout.preferredWidth
             }
 
@@ -467,7 +355,7 @@ ColumnLayout {
                     model: logParser.modeSegments
 
                     Rectangle {
-                        visible: _binXAxis.max > _binXAxis.min && modelData.end >= _binXAxis.min && modelData.start <= _binXAxis.max
+                        visible: _base.xAxis.max > _base.xAxis.min && modelData.end >= _base.xAxis.min && modelData.start <= _base.xAxis.max
                         height: parent.height
                         color: modeColor(modelData.mode)
                         x: _timelineContainer._segmentX(modelData.start)
@@ -485,7 +373,7 @@ ColumnLayout {
             QGCLabel {
                 text: qsTr("Dropouts")
                 font.bold: true
-                Layout.preferredWidth: _binChart.plotArea.x  // Align with chart plot area
+                Layout.preferredWidth: _base.graphsView.plotArea.x  // Align with chart plot area
                 Layout.maximumWidth: Layout.preferredWidth
             }
 
@@ -497,7 +385,7 @@ ColumnLayout {
                     model: logParser.dropouts
 
                     Rectangle {
-                        visible: _binXAxis.max > _binXAxis.min && modelData.end >= _binXAxis.min && modelData.start <= _binXAxis.max
+                        visible: _base.xAxis.max > _base.xAxis.min && modelData.end >= _base.xAxis.min && modelData.start <= _base.xAxis.max
                         height: parent.height
                         color: Qt.alpha(eventColor("error"), 0.533)
                         x: _timelineContainer._segmentX(modelData.start)
@@ -515,7 +403,7 @@ ColumnLayout {
             QGCLabel {
                 text: qsTr("Events")
                 font.bold: true
-                Layout.preferredWidth: _binChart.plotArea.x  // Align with chart plot area
+                Layout.preferredWidth: _base.graphsView.plotArea.x  // Align with chart plot area
                 Layout.maximumWidth: Layout.preferredWidth
             }
 
@@ -529,7 +417,7 @@ ColumnLayout {
                     Rectangle {
                         width: 2
                         height: parent.height
-                        visible: _binXAxis.max > _binXAxis.min
+                        visible: _base.xAxis.max > _base.xAxis.min
                         color: eventColor(modelData.type)
                         x: _timelineContainer._eventX(modelData.time, width)
                     }
@@ -541,365 +429,89 @@ ColumnLayout {
     // -------------------------------------------------------------------------
     // Chart area
     // -------------------------------------------------------------------------
-    Item {
-        id: _chartContainer
+    LogViewerBaseChart {
+        id: _base
         Layout.fillWidth: true
         Layout.fillHeight: true
+        logParser: control.logParser
+        xAxisShowLocalTime: control.xAxisShowLocalTime
+        yAxisTitle: qsTr("Value")
 
-        GraphsView {
-            id: _binChart
-            anchors.fill: parent
-            marginTop: 0
-            marginRight: 0
-            marginBottom: 0
-            marginLeft: 0
+        // ---- Chart-specific popup rows ----
+        RowLayout {
+            visible: _markerModeName.length > 0
+            spacing: ScreenTools.defaultFontPixelWidth * 0.2
 
-            theme: GraphsTheme {
-                colorScheme: qgcPal.globalTheme === QGCPalette.Light ? GraphsTheme.ColorScheme.Light : GraphsTheme.ColorScheme.Dark
-                backgroundColor: qgcPal.windowShadeDark
-                backgroundVisible: true
-                plotAreaBackgroundColor: qgcPal.windowShadeDark
-                grid.mainColor: Qt.rgba(qgcPal.text.r, qgcPal.text.g, qgcPal.text.b, 0.25)
-                grid.subColor: Qt.rgba(qgcPal.text.r, qgcPal.text.g, qgcPal.text.b, 0.12)
-                grid.mainWidth: 1
-                labelBackgroundVisible: false
-                labelTextColor: qgcPal.text
-                axisXLabelFont.family: ScreenTools.fixedFontFamily
-                axisXLabelFont.pointSize: ScreenTools.smallFontPointSize
-                axisYLabelFont.family: ScreenTools.fixedFontFamily
-                axisYLabelFont.pointSize: ScreenTools.smallFontPointSize
+            Rectangle {
+                Layout.preferredWidth: _base.colorBlockWidth
+                Layout.preferredHeight: _base.colorBlockWidth
+                color: modeColor(_markerModeName)
             }
 
-            axisX: ValueAxis {
-                id: _binXAxis
-                titleText: qsTr("Time (s)")
-                min: 0
-                max: 1
-            }
-
-            axisY: ValueAxis {
-                id: _binYAxis
-                titleText: qsTr("Value")
-                min: 0
-                max: 1
-            }
+            QGCLabel { text: qsTr("Mode:") }
+            QGCLabel { text: _markerModeName; font.bold: true }
         }
 
-        Rectangle {
-            id: _zoomSelectionRect
-            visible: false
-            color: Qt.rgba(1, 1, 1, 0.2)
-            border.color: qgcPal.buttonHighlight
-            border.width: 1
-            z: 1000
-        }
-
-        MouseArea {
-            id: _chartZoomArea
-            anchors.fill: parent
-            enabled: _binXAxis.max > _binXAxis.min
-            hoverEnabled: !ScreenTools.isMobile
-            acceptedButtons: Qt.LeftButton | Qt.RightButton
-            z: 1001
-
-            property real _dragStartX: 0
-
-            onPressed: (mouse) => {
-                if (mouse.button === Qt.RightButton) {
-                    resetZoom()
-                    return
-                }
-                _hoverVisible = false
-                _dragStartX = mouse.x
-                _zoomSelectionRect.x = mouse.x
-                _zoomSelectionRect.y = _binChart.plotArea.y
-                _zoomSelectionRect.width = 0
-                _zoomSelectionRect.height = _binChart.plotArea.height
-                _zoomSelectionRect.visible = true
-            }
-
-            onEntered: (mouse) => {
-                _hoverVisible = hoverEnabled && (_binXAxis.max > _binXAxis.min)
-                if (_hoverVisible) {
-                    _updateHoverInfo(mouse.x)
-                }
-            }
-
-            onExited: {
-                _hoverVisible = false
-            }
-
-            onPositionChanged: (mouse) => {
-                if (pressed && _zoomSelectionRect.visible) {
-                    const left  = Math.min(_dragStartX, mouse.x)
-                    const right = Math.max(_dragStartX, mouse.x)
-                    _zoomSelectionRect.x = left
-                    _zoomSelectionRect.width = Math.max(0, right - left)
-                } else if (!pressed && hoverEnabled) {
-                    _updateHoverInfo(mouse.x)
-                }
-            }
-
-            onReleased: (mouse) => {
-                if (!_zoomSelectionRect.visible) return
-                const dragWidth = _zoomSelectionRect.width
-                _zoomSelectionRect.visible = false
-                _hoverVisible = hoverEnabled && (_binXAxis.max > _binXAxis.min)
-                if (hoverEnabled) {
-                    _updateHoverInfo(mouse.x)
-                }
-                if (dragWidth < ScreenTools.defaultFontPixelWidth * 0.5) {
-                    _updateCursorInfo(mouse.x)
-                    return
-                }
-                const leftX  = _pixelToAxisX(_zoomSelectionRect.x)
-                const rightX = _pixelToAxisX(_zoomSelectionRect.x + _zoomSelectionRect.width)
-                applyZoomRange(Math.min(leftX, rightX), Math.max(leftX, rightX))
-            }
-        }
-
-        // Fixed cursor marker line (set by click)
-        Rectangle {
-            visible: _positionMarkerVisible
-            x: _markerPixelX
-            y: _binChart.plotArea.y
-            width: 1
-            height: _binChart.plotArea.height
-            color: qgcPal.text
-            z: 1002
-        }
-
-        // Hover cursor marker line (follows mouse)
-        Rectangle {
-            visible: _hoverVisible
-            x: _hoverPixelX
-            y: _binChart.plotArea.y
-            width: 1
-            height: _binChart.plotArea.height
-            color: Qt.rgba(qgcPal.text.r, qgcPal.text.g, qgcPal.text.b, 0.45)
-            z: 1002
-        }
-
-        // Fixed cursor popup (click)
-        Rectangle {
-            id: _valuePopup
-            x: _popupX(_markerPixelX)
-            y: _binChart.plotArea.y
-            z: 1003
-            implicitWidth: _valueColumnLayout.implicitWidth + (margin * 2)
-            implicitHeight: _valueColumnLayout.implicitHeight + (margin * 2)
-            color: qgcPal.windowShade
-            border.color: qgcPal.windowShadeDark
-            radius: ScreenTools.defaultFontPixelWidth * 0.3
-            visible: _positionMarkerVisible
-
-            property real margin: ScreenTools.defaultFontPixelWidth / 2
-            property real colorBlockWidth: ScreenTools.defaultFontPixelHeight * 0.8
-
-            function _popupX(cursorPx) {
-                const plotMidX = _binChart.plotArea.x + _binChart.plotArea.width / 2
-                if (cursorPx < plotMidX) {
-                    const rightX = _binChart.plotArea.x + _binChart.plotArea.width - width
-                    return Math.max(0, Math.min(rightX, _chartContainer.width - width))
-                } else {
-                    return Math.max(0, _binChart.plotArea.x)
-                }
-            }
+        Repeater {
+            model: _markerRows
 
             ColumnLayout {
-                id: _valueColumnLayout
-                anchors.fill: parent
-                anchors.margins: _valuePopup.margin
-                spacing: ScreenTools.defaultFontPixelHeight * 0.2
+                spacing: ScreenTools.defaultFontPixelHeight * 0.15
 
-                QGCLabel {
-                    text: qsTr("t=%1 s").arg(_markerXValue.toFixed(3))
-                    font.bold: true
+                RowLayout {
+                    spacing: ScreenTools.defaultFontPixelWidth * 0.4
+
+                    Rectangle {
+                        Layout.preferredWidth: _base.colorBlockWidth
+                        Layout.preferredHeight: _base.colorBlockWidth
+                        color: modelData.color
+                    }
+
+                    QGCLabel {
+                        width: _base.popupWidth - (ScreenTools.defaultFontPixelWidth * 4)
+                        elide: Text.ElideMiddle
+                        text: modelData.name
+                        font.bold: true
+                    }
                 }
 
                 RowLayout {
-                    visible: _markerModeName.length > 0
-                    spacing: ScreenTools.defaultFontPixelWidth * 0.2
+                    Layout.leftMargin: _base.colorBlockWidth + ScreenTools.defaultFontPixelWidth * 0.4
+                    spacing: ScreenTools.defaultFontPixelWidth * 0.3
 
-                    Rectangle {
-                        Layout.preferredWidth: _valuePopup.colorBlockWidth
-                        Layout.preferredHeight: _valuePopup.colorBlockWidth
-                        color: modeColor(_markerModeName)
-                    }
+                    QGCLabel { text: qsTr("Current") }
+                    QGCLabel { text: Number(modelData.value).toFixed(3); font.bold: true }
 
-                    QGCLabel { text: qsTr("Mode:") }
-                    QGCLabel { text: _markerModeName; font.bold: true }
-                }
+                    Item { width: ScreenTools.defaultFontPixelWidth * 0.5 }
 
-                Repeater {
-                    model: _markerRows
+                    QGCLabel { text: qsTr("Min") }
+                    QGCLabel { text: isNaN(modelData.min) ? "—" : Number(modelData.min).toFixed(3); font.bold: true }
 
-                    ColumnLayout {
-                        spacing: ScreenTools.defaultFontPixelHeight * 0.15
+                    Item { width: ScreenTools.defaultFontPixelWidth * 0.5 }
 
-                        RowLayout {
-                            spacing: ScreenTools.defaultFontPixelWidth * 0.4
-
-                            Rectangle {
-                                Layout.preferredWidth:  _valuePopup.colorBlockWidth
-                                Layout.preferredHeight: _valuePopup.colorBlockWidth
-                                color: modelData.color
-                            }
-
-                            QGCLabel {
-                                width: _valuePopup.width - (ScreenTools.defaultFontPixelWidth * 4)
-                                elide: Text.ElideMiddle
-                                text:  modelData.name
-                                font.bold: true
-                            }
-                        }
-
-                        RowLayout {
-                            Layout.leftMargin: _valuePopup.colorBlockWidth + ScreenTools.defaultFontPixelWidth * 0.4
-                            spacing: ScreenTools.defaultFontPixelWidth * 0.3
-
-                            QGCLabel { text: qsTr("Current") }
-                            QGCLabel { text: Number(modelData.value).toFixed(3); font.bold: true }
-
-                            Item { width: ScreenTools.defaultFontPixelWidth * 0.5 }
-
-                            QGCLabel { text: qsTr("Min") }
-                            QGCLabel { text: isNaN(modelData.min) ? "—" : Number(modelData.min).toFixed(3); font.bold: true }
-
-                            Item { width: ScreenTools.defaultFontPixelWidth * 0.5 }
-
-                            QGCLabel { text: qsTr("Max") }
-                            QGCLabel { text: isNaN(modelData.max) ? "—" : Number(modelData.max).toFixed(3); font.bold: true }
-                        }
-                    }
-                }
-
-                Repeater {
-                    model: _markerEventRows
-
-                    RowLayout {
-                        spacing: ScreenTools.defaultFontPixelWidth * 0.2
-
-                        Rectangle {
-                            Layout.preferredWidth: _valuePopup.colorBlockWidth
-                            Layout.preferredHeight: _valuePopup.colorBlockWidth
-                            color: modelData.color
-                        }
-
-                        QGCLabel {
-                            Layout.maximumWidth: ScreenTools.defaultFontPixelWidth * 20
-                            wrapMode: Text.WordWrap
-                            maximumLineCount: 2
-                            text: modelData.text
-                        }
-                    }
+                    QGCLabel { text: qsTr("Max") }
+                    QGCLabel { text: isNaN(modelData.max) ? "—" : Number(modelData.max).toFixed(3); font.bold: true }
                 }
             }
         }
 
-        // Hover cursor popup (mouse position)
-        Rectangle {
-            id: _hoverPopup
-            x: _hoverPopupX(_hoverPixelX)
-            y: _binChart.plotArea.y + _binChart.plotArea.height - height
-            z: 1004
-            implicitWidth: _hoverColumnLayout.implicitWidth + (margin * 2)
-            implicitHeight: _hoverColumnLayout.implicitHeight + (margin * 2)
-            color: Qt.rgba(qgcPal.windowShade.r, qgcPal.windowShade.g, qgcPal.windowShade.b, 0.85)
-            border.color: qgcPal.windowShadeDark
-            radius: ScreenTools.defaultFontPixelWidth * 0.3
-            visible: _hoverVisible
+        Repeater {
+            model: _markerEventRows
 
-            property real margin: ScreenTools.defaultFontPixelWidth / 2
-            property real colorBlockWidth: ScreenTools.defaultFontPixelHeight * 0.8
+            RowLayout {
+                spacing: ScreenTools.defaultFontPixelWidth * 0.2
 
-            function _hoverPopupX(cursorPx) {
-                const plotMidX = _binChart.plotArea.x + _binChart.plotArea.width / 2
-                if (cursorPx < plotMidX) {
-                    const rightX = _binChart.plotArea.x + _binChart.plotArea.width - width
-                    return Math.max(0, Math.min(rightX, _chartContainer.width - width))
-                } else {
-                    return Math.max(0, _binChart.plotArea.x)
+                Rectangle {
+                    Layout.preferredWidth: _base.colorBlockWidth
+                    Layout.preferredHeight: _base.colorBlockWidth
+                    color: modelData.color
                 }
-            }
-
-            ColumnLayout {
-                id: _hoverColumnLayout
-                anchors.fill: parent
-                anchors.margins: _hoverPopup.margin
-                spacing: ScreenTools.defaultFontPixelHeight * 0.2
 
                 QGCLabel {
-                    text: qsTr("t=%1 s").arg(_hoverXValue.toFixed(3))
-                    font.bold: true
-                }
-
-                RowLayout {
-                    visible: _hoverModeName.length > 0
-                    spacing: ScreenTools.defaultFontPixelWidth * 0.2
-
-                    Rectangle {
-                        Layout.preferredWidth: _hoverPopup.colorBlockWidth
-                        Layout.preferredHeight: _hoverPopup.colorBlockWidth
-                        color: modeColor(_hoverModeName)
-                    }
-
-                    QGCLabel { text: qsTr("Mode:") }
-                    QGCLabel { text: _hoverModeName; font.bold: true }
-                }
-
-                Repeater {
-                    model: _hoverRows
-
-                    ColumnLayout {
-                        spacing: ScreenTools.defaultFontPixelHeight * 0.15
-
-                        RowLayout {
-                            spacing: ScreenTools.defaultFontPixelWidth * 0.4
-
-                            Rectangle {
-                                Layout.preferredWidth:  _hoverPopup.colorBlockWidth
-                                Layout.preferredHeight: _hoverPopup.colorBlockWidth
-                                color: modelData.color
-                            }
-
-                            QGCLabel {
-                                width: _hoverPopup.width - (ScreenTools.defaultFontPixelWidth * 4)
-                                elide: Text.ElideMiddle
-                                text:  modelData.name
-                                font.bold: true
-                            }
-                        }
-
-                        RowLayout {
-                            Layout.leftMargin: _hoverPopup.colorBlockWidth + ScreenTools.defaultFontPixelWidth * 0.4
-                            spacing: ScreenTools.defaultFontPixelWidth * 0.3
-
-                            QGCLabel { text: qsTr("Current") }
-                            QGCLabel { text: Number(modelData.value).toFixed(3); font.bold: true }
-                        }
-                    }
-                }
-
-                Repeater {
-                    model: _hoverEventRows
-
-                    RowLayout {
-                        spacing: ScreenTools.defaultFontPixelWidth * 0.2
-
-                        Rectangle {
-                            Layout.preferredWidth: _hoverPopup.colorBlockWidth
-                            Layout.preferredHeight: _hoverPopup.colorBlockWidth
-                            color: modelData.color
-                        }
-
-                        QGCLabel {
-                            Layout.maximumWidth: ScreenTools.defaultFontPixelWidth * 20
-                            wrapMode: Text.WordWrap
-                            maximumLineCount: 2
-                            text: modelData.text
-                        }
-                    }
+                    Layout.maximumWidth: ScreenTools.defaultFontPixelWidth * 20
+                    wrapMode: Text.WordWrap
+                    maximumLineCount: 2
+                    text: modelData.text
                 }
             }
         }
@@ -926,31 +538,6 @@ ColumnLayout {
                     Layout.preferredWidth: _legendColorBlockSize
                     Layout.preferredHeight: _legendColorBlockSize
                     color: modeColor(modelData)
-                }
-
-                QGCLabel { text: modelData }
-            }
-        }
-    }
-
-    Row {
-        Layout.fillWidth: true
-        Layout.preferredHeight: _legendRowHeight
-        visible: logViewerController.selectedFields.length > 0
-        spacing: ScreenTools.defaultFontPixelWidth
-
-        QGCLabel { text: qsTr("Fields:"); font.bold: true }
-
-        Repeater {
-            model: logViewerController.selectedFields
-
-            RowLayout {
-                spacing: _legendItemSpacing
-
-                Rectangle {
-                    Layout.preferredWidth: _legendColorBlockSize
-                    Layout.preferredHeight: _legendColorBlockSize
-                    color: fieldColor(modelData)
                 }
 
                 QGCLabel { text: modelData }
@@ -998,13 +585,13 @@ ColumnLayout {
 
         QGCLabel {
             Layout.fillWidth: true
-            text: qsTr("Drag on chart to zoom X-axis. Right click chart to reset zoom.")
+            text: qsTr("Click to place cursor. Shift+drag to move cursor. Drag to zoom X-axis. Double-click to reset zoom.")
         }
 
         QGCButton {
             text: qsTr("Reset Zoom")
-            enabled: _zoomMinX !== _fullMinX || _zoomMaxX !== _fullMaxX
-            onClicked: resetZoom()
+            enabled: _base.zoomMinX !== _base.fullMinX || _base.zoomMaxX !== _base.fullMaxX
+            onClicked: _base.resetZoom()
         }
     }
 }

--- a/src/AnalyzeView/LogViewer/LogViewerController.cc
+++ b/src/AnalyzeView/LogViewer/LogViewerController.cc
@@ -123,46 +123,6 @@ QString LogViewerController::eventColor(const QString &eventType) const
     return _assignColorForKey(QStringLiteral("event-other"));
 }
 
-QString LogViewerController::modeColor(const QString &modeName) const
-{
-    static const QStringList modePalette = {
-        QStringLiteral("#E53935"), // red
-        QStringLiteral("#FB8C00"), // orange
-        QStringLiteral("#FDD835"), // yellow
-        QStringLiteral("#43A047"), // green
-        QStringLiteral("#00897B"), // teal
-        QStringLiteral("#00ACC1"), // cyan
-        QStringLiteral("#1E88E5"), // blue
-        QStringLiteral("#5E35B1"), // indigo
-        QStringLiteral("#8E24AA"), // purple
-        QStringLiteral("#D81B60"), // pink
-        QStringLiteral("#6D4C41"), // brown
-        QStringLiteral("#546E7A"), // blue grey
-    };
-
-    quint32 hash = 0;
-    for (const QChar ch : modeName) {
-        hash = (hash * 31U) + ch.unicode();
-    }
-
-    const qsizetype idx = static_cast<qsizetype>(hash % static_cast<quint32>(modePalette.count()));
-    return modePalette[idx];
-}
-
-QStringList LogViewerController::modeLegendEntries(const QVariantList &modeSegments) const
-{
-    QStringList modes;
-    for (const QVariant &variant : modeSegments) {
-        const QVariantMap segment = variant.toMap();
-        const QString mode = segment.value(QStringLiteral("mode")).toString();
-        if (!mode.isEmpty() && !modes.contains(mode)) {
-            modes.append(mode);
-        }
-    }
-
-    return modes;
-}
-
 void LogViewerController::_setLog(SourceType sourceType, const QString &path)
 {
     if (_sourceType != sourceType) {

--- a/src/AnalyzeView/LogViewer/LogViewerController.h
+++ b/src/AnalyzeView/LogViewer/LogViewerController.h
@@ -1,5 +1,6 @@
 #pragma once
 
+#include <QtCore/QHash>
 #include <QtCore/QObject>
 #include <QtCore/QSet>
 #include <QtCore/QString>
@@ -50,8 +51,6 @@ public:
     /// For selected fields, QML assigns index-based colors from its own palette.
     Q_INVOKABLE QString fieldColor(const QString &fieldName) const;
     Q_INVOKABLE QString eventColor(const QString &eventType) const;
-    Q_INVOKABLE QString modeColor(const QString &modeName) const;
-    Q_INVOKABLE QStringList modeLegendEntries(const QVariantList &modeSegments) const;
 
 signals:
     void sourceTypeChanged();

--- a/src/AnalyzeView/LogViewer/LogViewerCursorPopup.qml
+++ b/src/AnalyzeView/LogViewer/LogViewerCursorPopup.qml
@@ -1,0 +1,100 @@
+import QtQuick
+import QtQuick.Layouts
+
+import QGroundControl
+import QGroundControl.Controls
+
+/// Shared cursor-position info popup used by LogViewerChart and LogViewerAltChart.
+///
+/// Set required properties and place chart-specific rows as children — they
+/// appear below the shared time label via the default property alias.
+///
+/// Caller is responsible for setting x/y and visible.
+Rectangle {
+    id: control
+
+    // -------------------------------------------------------------------------
+    // Required properties
+    // -------------------------------------------------------------------------
+    required property real cursorXValue        ///< seconds from log start
+    required property var logParser           ///< for logParser.startTime
+    required property bool xAxisShowLocalTime  ///< elapsed vs. local clock
+    required property real zoomMinX
+    required property real zoomMaxX
+    required property real plotAreaWidth       ///< drives sub-second decimal count
+
+    // -------------------------------------------------------------------------
+    // Chart-specific content — injected as children of this item
+    // -------------------------------------------------------------------------
+    default property alias extraContent: _extraColumn.data
+
+    // Exposed so callers can align indented rows to the color block
+    readonly property real colorBlockWidth: ScreenTools.defaultFontPixelHeight * 0.8
+
+    // -------------------------------------------------------------------------
+    // Styling
+    // -------------------------------------------------------------------------
+    readonly property real _margin: ScreenTools.defaultFontPixelWidth / 2
+
+    color: qgcPal.windowShade
+    border.color: qgcPal.windowShadeDark
+    radius: ScreenTools.defaultFontPixelWidth * 0.3
+    implicitWidth: _mainColumn.implicitWidth  + _margin * 2
+    implicitHeight: _mainColumn.implicitHeight + _margin * 2
+
+    QGCPalette { id: qgcPal }
+
+    // -------------------------------------------------------------------------
+    // Content
+    // -------------------------------------------------------------------------
+    ColumnLayout {
+        id: _mainColumn
+        anchors.fill: parent
+        anchors.margins: control._margin
+        spacing: ScreenTools.defaultFontPixelHeight * 0.2
+
+        // ---- Shared time label ----
+        QGCLabel {
+            font.bold: true
+            text: {
+                const secsPerPixel = control.plotAreaWidth > 0
+                        ? (control.zoomMaxX - control.zoomMinX) / control.plotAreaWidth : 1.0
+                const decimals = secsPerPixel < 0.1 ? 2 : secsPerPixel < 1.0 ? 1 : 0
+
+                const wholeSecs = Math.floor(control.cursorXValue)
+                const frac      = control.cursorXValue - wholeSecs
+                const hh = Math.floor(wholeSecs / 3600)
+                const mm = Math.floor((wholeSecs % 3600) / 60)
+                const ss = wholeSecs % 60
+                const fracStr = decimals > 0 ? frac.toFixed(decimals).slice(1) : ""
+
+                let elapsed = ""
+                if (hh > 0) {
+                    elapsed = hh + ":" + String(mm).padStart(2, "0") + ":" + String(ss).padStart(2, "0") + fracStr
+                } else if (mm > 0) {
+                    elapsed = mm + ":" + String(ss).padStart(2, "0") + fracStr
+                } else {
+                    elapsed = decimals > 0 ? (ss + frac).toFixed(decimals) + "s" : ss + "s"
+                }
+
+                if (control.xAxisShowLocalTime) {
+                    const st = control.logParser.startTime
+                    if (st && !isNaN(st.getTime()) && st.getTime() > 0) {
+                        const use12h = Qt.locale().timeFormat(Locale.ShortFormat).indexOf("a") >= 0
+                                    || Qt.locale().timeFormat(Locale.ShortFormat).indexOf("A") >= 0
+                        const local = Qt.formatTime(new Date(st.getTime() + control.cursorXValue * 1000),
+                                                     use12h ? "h:mm:ss AP" : "HH:mm:ss")
+                        return local + qsTr(" (local)  /  ") + elapsed + qsTr(" (elapsed)")
+                    }
+                }
+                return elapsed + qsTr(" (elapsed)")
+            }
+        }
+
+        // ---- Chart-specific rows (provided by each chart as children) ----
+        ColumnLayout {
+            id: _extraColumn
+            spacing: ScreenTools.defaultFontPixelHeight * 0.2
+        }
+    }
+}

--- a/src/AnalyzeView/LogViewer/LogViewerFieldsPanel.qml
+++ b/src/AnalyzeView/LogViewer/LogViewerFieldsPanel.qml
@@ -15,6 +15,8 @@ Rectangle {
 
     signal clearSelectedRequested
 
+    property bool xAxisShowLocalTime: QGroundControl.settingsManager.logViewerSettings.xAxisShowLocalTime.rawValue
+
     color: qgcPal.windowShade
     radius: ScreenTools.defaultFontPixelWidth * 0.5
     Layout.preferredWidth: mainLayout.implicitWidth + (mainLayout.anchors.margins * 2)
@@ -79,9 +81,9 @@ Rectangle {
             groupedMap[groupName].sort((a, b) => String(a.shortName).localeCompare(String(b.shortName)))
             for (let s = 0; s < groupedMap[groupName].length; s++) {
                 rows.push({
-                    rowType:   "field",
-                    group:     groupName,
-                    fullName:  groupedMap[groupName][s].fullName,
+                    rowType: "field",
+                    group: groupName,
+                    fullName: groupedMap[groupName][s].fullName,
                     shortName: groupedMap[groupName][s].shortName
                 })
             }
@@ -185,12 +187,30 @@ Rectangle {
                   .arg(logParser.events.length)
         }
 
-        QGCLabel {
+        RowLayout {
             visible: _isFirmwareLog
-            text: qsTr("Detected vehicle type: %1")
-                  .arg(logParser.detectedVehicleType.length > 0
-                       ? logParser.detectedVehicleType
-                       : qsTr("Unknown"))
+                     && logParser.startTime
+                     && !isNaN(logParser.startTime.getTime())
+                     && logParser.startTime.getTime() > 0
+            spacing: ScreenTools.defaultFontPixelWidth
+
+            QGCLabel { text: qsTr("X axis:") }
+
+            ButtonGroup { id: _xAxisButtonGroup }
+
+            QGCRadioButton {
+                text: qsTr("Elapsed")
+                checked: !control.xAxisShowLocalTime
+                ButtonGroup.group: _xAxisButtonGroup
+                onClicked: QGroundControl.settingsManager.logViewerSettings.xAxisShowLocalTime.rawValue = false
+            }
+
+            QGCRadioButton {
+                text: qsTr("Local time")
+                checked: control.xAxisShowLocalTime
+                ButtonGroup.group: _xAxisButtonGroup
+                onClicked: QGroundControl.settingsManager.logViewerSettings.xAxisShowLocalTime.rawValue = true
+            }
         }
 
         RowLayout {

--- a/src/AnalyzeView/LogViewer/LogViewerMessagesTab.qml
+++ b/src/AnalyzeView/LogViewer/LogViewerMessagesTab.qml
@@ -38,9 +38,17 @@ ScrollView {
 
                 QGCLabel {
                     readonly property double _t: Number(modelData.time)
-                    text: (isNaN(_t) || _t < 0) ? "" : _t.toFixed(3) + "s"
+                    text: {
+                        if (isNaN(_t) || _t < 0) return ""
+                        const st = logParser.startTime
+                        if (st && !isNaN(st.getTime()) && st.getTime() > 0)
+                            return Qt.formatDateTime(new Date(st.getTime() + _t * 1000), "yyyy-MM-dd HH:mm:ss.zzz")
+                        return _t.toFixed(3) + "s"
+                    }
                     color: Qt.rgba(qgcPal.text.r, qgcPal.text.g, qgcPal.text.b, 0.6)
-                    Layout.preferredWidth: ScreenTools.defaultFontPixelWidth * 10
+                    Layout.preferredWidth: (logParser.startTime && !isNaN(logParser.startTime.getTime()) && logParser.startTime.getTime() > 0)
+                        ? ScreenTools.defaultFontPixelWidth * 20
+                        : ScreenTools.defaultFontPixelWidth * 10
                     horizontalAlignment: Text.AlignRight
                 }
 

--- a/src/AnalyzeView/LogViewer/LogViewerPage.qml
+++ b/src/AnalyzeView/LogViewer/LogViewerPage.qml
@@ -13,6 +13,7 @@ AnalyzePage {
     id: logViewerPage
     pageComponent: pageComponent
     pageDescription: qsTr("Open and inspect DataFlash (.bin), PX4 ULog (.ulg), and telemetry (.tlog) logs in a unified workflow.")
+    allowPopout: true
 
     Component {
         id: pageComponent
@@ -22,11 +23,18 @@ AnalyzePage {
             height: availableHeight
             spacing: ScreenTools.defaultFontPixelHeight
 
-            property bool binLoading: false
             property string pendingBinFile: ""
+
+            readonly property bool _xAxisShowLocalTime: QGroundControl.settingsManager.logViewerSettings.xAxisShowLocalTime.rawValue
 
             readonly property bool isFirmwareLog: logViewerController.sourceType === LogViewerController.Bin
                                              || logViewerController.sourceType === LogViewerController.ULog
+
+            // Cancel any in-flight async parse before QML starts tearing down the tree.
+            // Without this, the background thread can emit signals (parseProgressChanged,
+            // parseFileFinished) into partially-destroyed QML objects, causing a
+            // QQmlData::disconnectNotifiers crash.
+            Component.onDestruction: logParser.clear()
 
             function clearLoadedLogState(clearControllerState) {
                 replayController.isPlaying = false
@@ -48,18 +56,7 @@ AnalyzePage {
                     clearLoadedLogState(true)
                 }
                 pendingBinFile = file
-                binLoading = true
-                parseStartTimer.start()
-            }
-
-            function _executePendingBinParse() {
-                if (!pendingBinFile || pendingBinFile.length === 0) {
-                    binLoading = false
-                    return
-                }
-
-                const file = pendingBinFile
-                logParser.parseFileAsync(file)
+                logParser.startParsingAsync(file)
             }
 
             LogViewerController {
@@ -81,7 +78,6 @@ AnalyzePage {
 
                     if (!ok) {
                         QGroundControl.showMessageDialog(logViewerPage, qsTr("Log Viewer"), errorMessage)
-                        binLoading = false
                         pendingBinFile = ""
                         return
                     }
@@ -99,7 +95,6 @@ AnalyzePage {
                     } else {
                         logViewerController.openBinLog(filePath)
                     }
-                    binLoading = false
                     pendingBinFile = ""
                 }
             }
@@ -113,7 +108,7 @@ AnalyzePage {
                 spacing: ScreenTools.defaultFontPixelWidth
 
                 QGCButton {
-                    text:    qsTr("Open .bin")
+                    text: qsTr("Open .bin")
                     visible: QGroundControl.hasAPMSupport
                     onClicked: {
                         openDialog.nameFilters = ["DataFlash Logs (*.bin *.BIN *.log *.LOG)"]
@@ -153,7 +148,50 @@ AnalyzePage {
                 QGCLabel {
                     Layout.fillWidth: true
                     elide: Text.ElideMiddle
-                    text: logViewerController.hasLoadedLog ? logViewerController.currentLogPath : qsTr("No log selected")
+                    text: logViewerController.hasLoadedLog ? logViewerController.currentLogPath.replace(/.*[/\\]/, "") : qsTr("No log selected")
+                }
+
+                QGCLabel {
+                    visible: logViewerController.hasLoadedLog
+                    text: qsTr("Start time:")
+                }
+
+                QGCLabel {
+                    readonly property bool _hasStartTime: logParser.startTime
+                                                          && !isNaN(logParser.startTime.getTime())
+                                                          && logParser.startTime.getTime() > 0
+                    visible: logViewerController.hasLoadedLog
+                    text: _hasStartTime
+                             ? Qt.formatDateTime(logParser.startTime, Qt.locale().dateTimeFormat(Locale.ShortFormat))
+                             : qsTr("N/A")
+                }
+
+                QGCLabel {
+                    visible: logViewerController.hasLoadedLog && logParser.detectedVehicleType.length > 0
+                    text: qsTr("Vehicle:")
+                }
+
+                QGCLabel {
+                    visible: logViewerController.hasLoadedLog && logParser.detectedVehicleType.length > 0
+                    text: logParser.detectedVehicleType
+                }
+            }
+
+            RowLayout {
+                Layout.fillWidth: true
+                visible: logParser.parsing
+                spacing: ScreenTools.defaultFontPixelWidth
+
+                QGCLabel {
+                    text: qsTr("Loading...")
+                }
+
+                QGCSlider {
+                    Layout.fillWidth: true
+                    from: 0
+                    to: 1
+                    value: logParser.parseProgress
+                    enabled: false
                 }
             }
 
@@ -260,6 +298,7 @@ AnalyzePage {
                                 visible: isFirmwareLog
                                 logParser: logParser
                                 logViewerController: logViewerController
+                                xAxisShowLocalTime: _xAxisShowLocalTime
 
                                 onCursorMoved: (t) => {
                                     _mapTab._markerVisible = true
@@ -288,29 +327,29 @@ AnalyzePage {
                     Layout.fillHeight: true
 
                     // GPS path data
-                    readonly property var    _gpsPath:      logParser.parsed ? logParser.gpsPath() : []
-                    readonly property int    _pathLen:      (_gpsPath && _gpsPath.length) ? _gpsPath.length : 0
-                    readonly property bool   _hasPath:      _pathLen >= 2
+                    readonly property var _gpsPath: logParser.parseComplete ? logParser.gpsPath() : []
+                    readonly property int _pathLen: (_gpsPath && _gpsPath.length) ? _gpsPath.length : 0
+                    readonly property bool _hasPath: _pathLen >= 2
                     readonly property string _altFieldName: _hasPath ? logParser.gpsAltitudeFieldName() : ""
-                    readonly property bool   _hasAltField:  _altFieldName.length > 0
+                    readonly property bool _hasAltField: _altFieldName.length > 0
 
                     // Shared cursor state (driven by altitude chart, displayed on map)
                     property bool _markerVisible: false
-                    property var  _markerCoord:   ({})
+                    property var _markerCoord: ({})
 
                     ColumnLayout {
                         anchors.fill: parent
-                        spacing:      0
+                        spacing: 0
 
                         // ---- Map ----
                         Item {
-                            Layout.fillWidth:  true
+                            Layout.fillWidth: true
                             Layout.fillHeight: true
 
                             FlightMap {
                                 id: _flightMap
-                                anchors.fill:          parent
-                                mapName:               "LogViewerMap"
+                                anchors.fill: parent
+                                mapName: "LogViewerMap"
                                 allowGCSLocationCenter: true
 
                                 readonly property var _path: _mapTab._gpsPath
@@ -334,32 +373,32 @@ AnalyzePage {
 
                                 Connections {
                                     target: logParser
-                                    function onParsedChanged() {
-                                        if (logParser.parsed) Qt.callLater(_flightMap._fitPath)
+                                    function onParseCompleteChanged() {
+                                        if (logParser.parseComplete) Qt.callLater(_flightMap._fitPath)
                                     }
                                 }
 
                                 MapPolyline {
                                     line.width: 3
                                     line.color: QGroundControl.globalPalette.colorRed
-                                    path:       _flightMap._path
+                                    path: _flightMap._path
                                 }
 
                                 // Position dot driven by altitude chart cursor
                                 MapQuickItem {
                                     readonly property var _coord: _mapTab._markerCoord
-                                    visible:      _mapTab._markerVisible && _mapTab._hasPath
+                                    visible: _mapTab._markerVisible && _mapTab._hasPath
                                                   && _coord && _coord.latitude !== undefined
-                                    coordinate:   (_coord && _coord.latitude !== undefined)
+                                    coordinate: (_coord && _coord.latitude !== undefined)
                                                   ? QtPositioning.coordinate(_coord.latitude, _coord.longitude)
                                                   : QtPositioning.coordinate(0, 0)
-                                    anchorPoint:  Qt.point(_posDot.width / 2, _posDot.height / 2)
+                                    anchorPoint: Qt.point(_posDot.width / 2, _posDot.height / 2)
                                     sourceItem: Rectangle {
-                                        id:           _posDot
-                                        width:        ScreenTools.defaultFontPixelHeight * 1.2
-                                        height:       width
-                                        radius:       width / 2
-                                        color:        QGroundControl.globalPalette.colorYellow
+                                        id: _posDot
+                                        width: ScreenTools.defaultFontPixelHeight * 1.2
+                                        height: width
+                                        radius: width / 2
+                                        color: QGroundControl.globalPalette.colorYellow
                                         border.color: "white"
                                         border.width: 2
                                     }
@@ -367,35 +406,36 @@ AnalyzePage {
 
                                 MapScale {
                                     anchors.margins: ScreenTools.defaultFontPixelWidth
-                                    anchors.left:    parent.left
-                                    anchors.bottom:  parent.bottom
-                                    mapControl:      _flightMap
+                                    anchors.left: parent.left
+                                    anchors.bottom: parent.bottom
+                                    mapControl: _flightMap
                                 }
                             }
 
                             QGCLabel {
                                 anchors.centerIn: parent
-                                visible:          logParser.parsed && !_mapTab._hasPath
-                                text:             qsTr("No GPS data found in this log")
-                                font.italic:      true
+                                visible: logParser.parseComplete && !_mapTab._hasPath
+                                text: qsTr("No GPS data found in this log")
+                                font.italic: true
                             }
 
                             QGCLabel {
                                 anchors.centerIn: parent
-                                visible:          !logParser.parsed
-                                text:             qsTr("Load a log file to view the flight path")
-                                font.italic:      true
+                                visible: !logParser.parseComplete
+                                text: qsTr("Load a log file to view the flight path")
+                                font.italic: true
                             }
                         }
 
                         // ---- Altitude chart ----
                         LogViewerAltChart {
-                            id:                    _altChart
-                            Layout.fillWidth:      true
+                            id: _altChart
+                            Layout.fillWidth: true
                             Layout.preferredHeight: ScreenTools.defaultFontPixelHeight * 14
-                            visible:               _mapTab._hasAltField && _mapTab._hasPath
-                            logParser:             logParser
-                            altFieldName:          _mapTab._altFieldName
+                            visible: _mapTab._hasAltField && _mapTab._hasPath
+                            logParser: logParser
+                            altFieldName: _mapTab._altFieldName
+                            xAxisShowLocalTime: _xAxisShowLocalTime
 
                             onMarkerChanged: (t) => {
                                 _mapTab._markerVisible = true
@@ -458,35 +498,6 @@ AnalyzePage {
                     }
                     close()
                 }
-            }
-
-            Rectangle {
-                Layout.fillWidth: true
-                Layout.fillHeight: true
-                visible: binLoading
-                color: Qt.rgba(0, 0, 0, 0.4)
-                z: 5000
-
-                Column {
-                    anchors.centerIn: parent
-                    spacing: ScreenTools.defaultFontPixelHeight * 0.5
-
-                    BusyIndicator {
-                        anchors.horizontalCenter: parent.horizontalCenter
-                        running: binLoading
-                    }
-
-                    QGCLabel {
-                        text: qsTr("Parsing log file...")
-                    }
-                }
-            }
-
-            Timer {
-                id: parseStartTimer
-                interval: 50
-                repeat: false
-                onTriggered: _executePendingBinParse()
             }
         }
     }

--- a/src/AnalyzeView/LogViewer/LogViewerParametersTab.qml
+++ b/src/AnalyzeView/LogViewer/LogViewerParametersTab.qml
@@ -17,9 +17,9 @@ ColumnLayout {
     // -------------------------------------------------------------------------
     // Internal state
     // -------------------------------------------------------------------------
-    property string _parameterSearchText:       ""
-    property bool   _showOnlyChangedParameters: true
-    property var    _filteredParameters:        []
+    property string _parameterSearchText: ""
+    property bool _showOnlyChangedParameters: true
+    property var _filteredParameters: []
 
     QGCPalette { id: qgcPal }
 

--- a/src/AnalyzeView/LogViewer/PX4ULog/LogViewerULogParser.cc
+++ b/src/AnalyzeView/LogViewer/PX4ULog/LogViewerULogParser.cc
@@ -13,7 +13,7 @@
 
 namespace ULogParser {
 
-LogParseResult parseFile(const QString &filePath)
+LogParseResult parseFile(const QString &filePath, const ProgressCallback &progressCallback, const CancelToken &cancelToken)
 {
     LogParseResult result;
 
@@ -53,9 +53,23 @@ LogParseResult parseFile(const QString &filePath)
         return result;
     }
 
-    auto handler = std::make_shared<ULogFullHandler>(result);
+    auto handler = std::make_shared<ULogFullHandler>(result, progressCallback);
     ulog_cpp::Reader reader(handler);
-    reader.readChunk(reinterpret_cast<const uint8_t *>(raw), static_cast<size_t>(fileSize));
+
+    static constexpr qint64 kChunkSize = 64 * 1024;
+    qint64 offset = 0;
+    while (offset < fileSize) {
+        const qint64 remaining = fileSize - offset;
+        const qint64 chunk = (remaining < kChunkSize) ? remaining : kChunkSize;
+        reader.readChunk(reinterpret_cast<const uint8_t *>(raw) + offset, static_cast<size_t>(chunk));
+        offset += chunk;
+        if (cancelToken && cancelToken->load(std::memory_order_relaxed)) {
+            return result;  // cancelled; result.ok is false, discarded by requestId guard
+        }
+        if (progressCallback) {
+            progressCallback(static_cast<float>(offset) / static_cast<float>(fileSize));
+        }
+    }
 
     if (handler->hadFatalError()) {
         if (result.errorMessage.isEmpty()) {

--- a/src/AnalyzeView/LogViewer/PX4ULog/LogViewerULogParser.h
+++ b/src/AnalyzeView/LogViewer/PX4ULog/LogViewerULogParser.h
@@ -8,5 +8,5 @@
 // Returns a filled LogParseResult on success (result.ok == true) or an error
 // message in result.errorMessage on failure.
 namespace ULogParser {
-    LogParseResult parseFile(const QString &filePath);
+    LogParseResult parseFile(const QString &filePath, const ProgressCallback &progressCallback = nullptr, const CancelToken &cancelToken = nullptr);
 }

--- a/src/AnalyzeView/LogViewer/PX4ULog/ULogFullHandler.cc
+++ b/src/AnalyzeView/LogViewer/PX4ULog/ULogFullHandler.cc
@@ -4,6 +4,7 @@
 #include "QGCLoggingCategory.h"
 
 #include <QtCore/QStringList>
+#include <QtCore/QTimeZone>
 
 #include <algorithm>
 #include <stdexcept>
@@ -11,6 +12,9 @@
 #include <ulog_cpp/subscription.hpp>
 
 QGC_LOGGING_CATEGORY(ULogFullHandlerLog, "AnalyzeView.ULogFullHandler")
+
+// Used for testing
+//#define QGC_NO_LOG_START_TIME
 
 namespace {
 
@@ -67,7 +71,7 @@ bool _isNumericScalarField(const ulog_cpp::Field &field)
 
 } // namespace
 
-ULogFullHandler::ULogFullHandler(LogParseResult &result)
+ULogFullHandler::ULogFullHandler(LogParseResult &result, const ProgressCallback &/*progressCallback*/)
     : _result(result)
 {
 }
@@ -135,6 +139,22 @@ void ULogFullHandler::data(const ulog_cpp::Data &data)
             timestampSecs = static_cast<double>(tsUs) / 1e6;
             _lastTimestampSecs = timestampSecs;
         }
+
+        // Extract GPS UTC start time from first valid sensor_gps/vehicle_gps_position sample.
+        // Define QGC_NO_LOG_START_TIME at build time to suppress this for UI testing.
+#ifndef QGC_NO_LOG_START_TIME
+        if (_result.startTime.isNull() && timestampSecs >= 0.0) {
+            if ((sub.topicName == "sensor_gps" || sub.topicName == "vehicle_gps_position")
+                    && sub.format->fieldMap().count("time_utc_usec") > 0) {
+                const uint64_t utcUsec = view.at("time_utc_usec").as<uint64_t>();
+                const uint64_t tsUs   = view.at("timestamp").as<uint64_t>();
+                if (utcUsec > 0 && utcUsec >= tsUs) {
+                    const qint64 startMs = static_cast<qint64>((utcUsec - tsUs) / 1000);
+                    _result.startTime = QDateTime::fromMSecsSinceEpoch(startMs, QTimeZone::utc());
+                }
+            }
+        }
+#endif // QGC_NO_LOG_START_TIME
 
         // Field name: "topic_name.field" or "topic_name[N].field" for multi-instance
         const QString prefix = (sub.multiId > 0)

--- a/src/AnalyzeView/LogViewer/PX4ULog/ULogFullHandler.h
+++ b/src/AnalyzeView/LogViewer/PX4ULog/ULogFullHandler.h
@@ -1,5 +1,7 @@
 #pragma once
 
+#include "LogParseResultPrivate.h"
+
 #include <QtCore/QHash>
 #include <QtCore/QPointF>
 #include <QtCore/QSet>
@@ -24,7 +26,7 @@ struct LogParseResult;
 class ULogFullHandler final : public ulog_cpp::DataHandlerInterface
 {
 public:
-    explicit ULogFullHandler(LogParseResult &result);
+    explicit ULogFullHandler(LogParseResult &result, const ProgressCallback &progressCallback = nullptr); // progressCallback unused; progress is reported by the caller's chunk loop
     ~ULogFullHandler() = default;
 
     void error(const std::string &msg, bool is_recoverable) override;

--- a/src/AppSettings/pages/General.SettingsUI.json
+++ b/src/AppSettings/pages/General.SettingsUI.json
@@ -33,7 +33,8 @@
                     }
                 },
                 {
-                    "setting": "appSettings.gstDebugLevel"
+                    "setting": "appSettings.androidDontSaveToSDCard",
+                    "showWhen": "ScreenTools.isMobile"
                 },
                 {
                     "setting": "appSettings.uiScalePercent",

--- a/src/Settings/App.SettingsGroup.json
+++ b/src/Settings/App.SettingsGroup.json
@@ -246,7 +246,8 @@
             "type": "bool",
             "default": false,
             "qgcRebootRequired": true,
-            "label": "Don't save to SD card, even if available"
+            "label": "Don't save to SD card, even if available",
+            "keywords": "sd card,storage,android,save path"
         },
         {
             "name": "tiandituToken",

--- a/src/Settings/CMakeLists.txt
+++ b/src/Settings/CMakeLists.txt
@@ -31,6 +31,8 @@ target_sources(${CMAKE_PROJECT_NAME}
         JoystickSettings.h
         LogManagerSettings.cc
         LogManagerSettings.h
+        LogViewerSettings.cc
+        LogViewerSettings.h
         MavlinkSettings.cc
         MavlinkSettings.h
         OfflineMapsSettings.cc

--- a/src/Settings/LogViewer.SettingsGroup.json
+++ b/src/Settings/LogViewer.SettingsGroup.json
@@ -1,0 +1,13 @@
+{
+    "version": 1,
+    "fileType": "FactMetaData",
+    "QGC.MetaData.Facts": [
+        {
+            "name": "xAxisShowLocalTime",
+            "shortDesc": "Show local time on the x-axis instead of elapsed time",
+            "type": "bool",
+            "default": false,
+            "label": "Show local time on x-axis"
+        }
+    ]
+}

--- a/src/Settings/LogViewerSettings.cc
+++ b/src/Settings/LogViewerSettings.cc
@@ -1,0 +1,7 @@
+#include "LogViewerSettings.h"
+
+DECLARE_SETTINGGROUP(LogViewer, "LogViewer")
+{
+}
+
+DECLARE_SETTINGSFACT(LogViewerSettings, xAxisShowLocalTime)

--- a/src/Settings/LogViewerSettings.h
+++ b/src/Settings/LogViewerSettings.h
@@ -1,0 +1,17 @@
+#pragma once
+
+#include <QtQmlIntegration/QtQmlIntegration>
+
+#include "SettingsGroup.h"
+
+class LogViewerSettings : public SettingsGroup
+{
+    Q_OBJECT
+    QML_ELEMENT
+    QML_UNCREATABLE("")
+public:
+    LogViewerSettings(QObject* parent = nullptr);
+    DEFINE_SETTING_NAME_GROUP()
+
+    DEFINE_SETTINGFACT(xAxisShowLocalTime)
+};

--- a/src/Settings/SettingsManager.cc
+++ b/src/Settings/SettingsManager.cc
@@ -25,6 +25,7 @@
 #include "MavlinkSettings.h"
 #include "JoystickManagerSettings.h"
 #include "LogManagerSettings.h"
+#include "LogViewerSettings.h"
 #include "Viewer3DSettings.h"
 #include "JsonParsing.h"
 #include "QGCCorePlugin.h"
@@ -76,6 +77,7 @@ void SettingsManager::init()
     _mavlinkSettings = new MavlinkSettings(this);
     _joystickManagerSettings = new JoystickManagerSettings(this);
     _logManagerSettings = new LogManagerSettings(this);
+    _logViewerSettings = new LogViewerSettings(this);
     _viewer3DSettings = new Viewer3DSettings(this);
     _adsbVehicleManagerSettings = new ADSBVehicleManagerSettings(this);
 #ifndef QGC_NO_ARDUPILOT_DIALECT
@@ -107,6 +109,7 @@ VideoSettings *SettingsManager::videoSettings() const { return _videoSettings; }
 MavlinkSettings *SettingsManager::mavlinkSettings() const { return _mavlinkSettings; }
 JoystickManagerSettings *SettingsManager::joystickManagerSettings() const { return _joystickManagerSettings; }
 LogManagerSettings *SettingsManager::logManagerSettings() const { return _logManagerSettings; }
+LogViewerSettings *SettingsManager::logViewerSettings() const { return _logViewerSettings; }
 Viewer3DSettings *SettingsManager::viewer3DSettings() const { return _viewer3DSettings; }
 
 void SettingsManager::_loadSettingsFiles()

--- a/src/Settings/SettingsManager.h
+++ b/src/Settings/SettingsManager.h
@@ -29,6 +29,7 @@ class MavlinkSettings;
 class FactMetaData;
 class JoystickManagerSettings;
 class LogManagerSettings;
+class LogViewerSettings;
 
 /// \brief Provides access to all app settings
 ///
@@ -61,6 +62,7 @@ class SettingsManager : public QObject
     Q_MOC_INCLUDE("MavlinkSettings.h")
     Q_MOC_INCLUDE("JoystickManagerSettings.h")
     Q_MOC_INCLUDE("LogManagerSettings.h")
+    Q_MOC_INCLUDE("LogViewerSettings.h")
     Q_MOC_INCLUDE("Viewer3DSettings.h")
     Q_PROPERTY(QObject *adsbVehicleManagerSettings      READ adsbVehicleManagerSettings     CONSTANT)
 #ifndef QGC_NO_ARDUPILOT_DIALECT
@@ -86,6 +88,7 @@ class SettingsManager : public QObject
     Q_PROPERTY(QObject *mavlinkSettings                 READ mavlinkSettings                CONSTANT)
     Q_PROPERTY(QObject *joystickManagerSettings         READ joystickManagerSettings        CONSTANT)
     Q_PROPERTY(QObject *logManagerSettings              READ logManagerSettings              CONSTANT)
+    Q_PROPERTY(QObject *logViewerSettings               READ logViewerSettings               CONSTANT)
     Q_PROPERTY(QObject *viewer3DSettings                READ viewer3DSettings               CONSTANT)
 public:
     SettingsManager(QObject *parent = nullptr);
@@ -125,6 +128,7 @@ public:
     MavlinkSettings *mavlinkSettings() const;
     JoystickManagerSettings *joystickManagerSettings() const;
     LogManagerSettings *logManagerSettings() const;
+    LogViewerSettings *logViewerSettings() const;
     Viewer3DSettings *viewer3DSettings() const;
 
 private:
@@ -154,6 +158,7 @@ private:
     MavlinkSettings *_mavlinkSettings = nullptr;
     JoystickManagerSettings *_joystickManagerSettings = nullptr;
     LogManagerSettings *_logManagerSettings = nullptr;
+    LogViewerSettings *_logViewerSettings = nullptr;
     Viewer3DSettings *_viewer3DSettings = nullptr;
 
     QMap<QString, QMap<QString, QJsonObject>> _settingsFileOverrides;   // groupName:settingName:metaDataObject

--- a/src/Utilities/Parsing/APMDataFlash/APMDataFlashUtility.cc
+++ b/src/Utilities/Parsing/APMDataFlash/APMDataFlashUtility.cc
@@ -274,7 +274,8 @@ bool parseFmtMessages(const char *data, qint64 size, QMap<uint8_t, MessageFormat
 
 int iterateMessages(const char *data, qint64 size,
                     const QMap<uint8_t, MessageFormat> &formats,
-                    const MessageCallback &callback)
+                    const MessageCallback &callback,
+                    const std::function<void(float)> &progressCallback)
 {
     int count = 0;
     qint64 pos = 0;
@@ -307,6 +308,10 @@ int iterateMessages(const char *data, qint64 size,
         }
 
         pos += payloadSize;
+
+        if (progressCallback && (count % 1000 == 0)) {
+            progressCallback(static_cast<float>(pos) / static_cast<float>(size));
+        }
     }
 
     return count;

--- a/src/Utilities/Parsing/APMDataFlash/APMDataFlashUtility.h
+++ b/src/Utilities/Parsing/APMDataFlash/APMDataFlashUtility.h
@@ -119,10 +119,12 @@ using MessageCallback = std::function<bool(uint8_t msgType, const char *payload,
 /// @param size Size of log data
 /// @param formats Message formats from parseFmtMessages()
 /// @param callback Function called for each message
+/// @param progressCallback Optional callback invoked every ~1000 messages with byte-position progress (0.0–1.0)
 /// @return Number of messages processed
 int iterateMessages(const char *data, qint64 size,
                     const QMap<uint8_t, MessageFormat> &formats,
-                    const MessageCallback &callback);
+                    const MessageCallback &callback,
+                    const std::function<void(float)> &progressCallback = nullptr);
 
 // ============================================================================
 // Half-Precision Float Conversion

--- a/test/AnalyzeView/APMDataFlashLogParserTest.cc
+++ b/test/AnalyzeView/APMDataFlashLogParserTest.cc
@@ -71,7 +71,7 @@ void APMDataFlashLogParserTest::_parseMinimalLogTest()
 
     APMDataFlashLogParser parser;
     QVERIFY(parser.parseFile(tempFile.fileName()));
-    QVERIFY(parser.parsed());
+    QVERIFY(parser.parseComplete());
     QCOMPARE(parser.parseError(), QString());
     QVERIFY(parser.availableFields().contains(QStringLiteral("PARM.Name")));
     QVERIFY(parser.availableFields().contains(QStringLiteral("PARM.Value")));
@@ -89,7 +89,7 @@ void APMDataFlashLogParserTest::_parseInvalidLogTest()
 
     APMDataFlashLogParser parser;
     QVERIFY(!parser.parseFile(tempFile.fileName()));
-    QVERIFY(!parser.parsed());
+    QVERIFY(!parser.parseComplete());
     QVERIFY(!parser.parseError().isEmpty());
 }
 

--- a/test/AnalyzeView/LogFileParserTest.cc
+++ b/test/AnalyzeView/LogFileParserTest.cc
@@ -1,6 +1,8 @@
 #include "LogFileParserTest.h"
 
 #include "LogFileParser.h"
+#include "LogViewerDataFlashParser.h"
+#include "LogViewerULogParser.h"
 
 #include <cstring>
 #include <functional>
@@ -8,9 +10,12 @@
 
 #include <QtCore/QByteArray>
 #include <QtCore/QDir>
+#include <QtCore/QDateTime>
 #include <QtCore/QPointF>
 #include <QtCore/QTemporaryFile>
+#include <QtCore/QTimeZone>
 #include <QtCore/QVariantList>
+#include <QtTest/QSignalSpy>
 
 #include <ulog_cpp/messages.hpp>
 #include <ulog_cpp/writer.hpp>
@@ -101,7 +106,7 @@ void LogFileParserTest::_parseULogNumericTopicTest()
 
     LogFileParser parser;
     QVERIFY(parser.parseFile(tmp.fileName()));
-    QVERIFY(parser.parsed());
+    QVERIFY(parser.parseComplete());
     QCOMPARE(parser.parseError(), QString());
 
     // Field should appear in both available and plottable lists
@@ -144,7 +149,7 @@ void LogFileParserTest::_parseULogParameterTest()
 
     LogFileParser parser;
     QVERIFY(parser.parseFile(tmp.fileName()));
-    QVERIFY(parser.parsed());
+    QVERIFY(parser.parseComplete());
 
     QCOMPARE(parser.parameters().count(), 1);
     const QVariantMap param = parser.parameters().first().toMap();
@@ -272,7 +277,7 @@ void LogFileParserTest::_parseULogInvalidFileTest()
 
     LogFileParser parser;
     QVERIFY(!parser.parseFile(tmp.fileName()));
-    QVERIFY(!parser.parsed());
+    QVERIFY(!parser.parseComplete());
     QVERIFY(!parser.parseError().isEmpty());
 }
 
@@ -313,7 +318,7 @@ void LogFileParserTest::_parseDataFlashRegressionTest()
 
     LogFileParser parser;
     QVERIFY(parser.parseFile(tmp.fileName()));
-    QVERIFY(parser.parsed());
+    QVERIFY(parser.parseComplete());
     QCOMPARE(parser.parameters().count(), 1);
 }
 
@@ -327,7 +332,7 @@ void LogFileParserTest::_parseUnsupportedExtensionTest()
 
     LogFileParser parser;
     QVERIFY(!parser.parseFile(tmp.fileName()));
-    QVERIFY(!parser.parsed());
+    QVERIFY(!parser.parseComplete());
     QVERIFY(!parser.parseError().isEmpty());
 }
 
@@ -539,6 +544,25 @@ QByteArray makeFmtPayloadStr(uint8_t type, uint8_t length, const char *name,
     return p;
 }
 
+// DataFlash GPS message payload: Q(TimeUS) + H(GWk) + I(GMS) = 14 bytes
+QByteArray makeGPSBinPayload(uint64_t timeUs, uint16_t gwk, uint32_t gms)
+{
+    QByteArray payload(14, '\0');
+    memcpy(payload.data(),      &timeUs, 8);
+    memcpy(payload.data() + 8,  &gwk,   2);
+    memcpy(payload.data() + 10, &gms,   4);
+    return payload;
+}
+
+// ULog payload: two consecutive uint64_t fields (e.g. timestamp + time_utc_usec)
+std::vector<uint8_t> makePayloadUint64Uint64(uint64_t a, uint64_t b)
+{
+    std::vector<uint8_t> buf(16);
+    memcpy(buf.data(),     &a, 8);
+    memcpy(buf.data() + 8, &b, 8);
+    return buf;
+}
+
 } // anonymous namespace
 
 void LogFileParserTest::_gpsPathULogVehicleGlobalPositionTest()
@@ -576,7 +600,7 @@ void LogFileParserTest::_gpsPathULogVehicleGlobalPositionTest()
 
     LogFileParser parser;
     QVERIFY(parser.parseFile(tmp.fileName()));
-    QVERIFY(parser.parsed());
+    QVERIFY(parser.parseComplete());
 
     const QVariantList path = parser.gpsPath();
     QCOMPARE(path.size(), static_cast<int>(std::size(samples)));
@@ -624,7 +648,7 @@ void LogFileParserTest::_gpsPathULogVehicleGpsPositionLatDegTest()
 
     LogFileParser parser;
     QVERIFY(parser.parseFile(tmp.fileName()));
-    QVERIFY(parser.parsed());
+    QVERIFY(parser.parseComplete());
 
     const QVariantList path = parser.gpsPath();
     QCOMPARE(path.size(), static_cast<int>(std::size(samples)));
@@ -663,7 +687,7 @@ void LogFileParserTest::_gpsPathAPMDataFlashPOSTest()
 
     LogFileParser parser;
     QVERIFY(parser.parseFile(tmp.fileName()));
-    QVERIFY(parser.parsed());
+    QVERIFY(parser.parseComplete());
 
     const QVariantList path = parser.gpsPath();
     QCOMPARE(path.size(), static_cast<int>(std::size(samples)));
@@ -674,6 +698,330 @@ void LogFileParserTest::_gpsPathAPMDataFlashPOSTest()
         QVERIFY(qAbs(coord.value(QStringLiteral("latitude")).toDouble()  - samples[i].lat) < 1e-6);
         QVERIFY(qAbs(coord.value(QStringLiteral("longitude")).toDouble() - samples[i].lon) < 1e-6);
     }
+}
+
+void LogFileParserTest::_startTimeAPMFromGwkGmsTest()
+{
+    // GPS week 2243, GMS=18000 ms (18 s), boot at TimeUS=0.
+    // gpsSecs = 315964800 + 2243*604800 + 18 = 1,672,531,218
+    // leapSecondsGPS(2023, 1) = 37-19 = 18  →  utcSecs = 1,672,531,200
+    // startMs = (1,672,531,200 - 0) * 1000  →  2023-01-01 00:00:00 UTC
+    QByteArray bytes;
+    appendBinMessage(bytes, 128, makeFmtPayloadStr(153, 17, "GPS", "QHI", "TimeUS,GWk,GMS"));
+    appendBinMessage(bytes, 153, makeGPSBinPayload(0ULL, uint16_t(2243), uint32_t(18000)));
+
+    QTemporaryFile tmp;
+    tmp.setFileTemplate(QDir::tempPath() + QStringLiteral("/logtest_XXXXXX.bin"));
+    QVERIFY(writeTempFile(tmp, bytes));
+
+    LogFileParser parser;
+    QVERIFY(parser.parseFile(tmp.fileName()));
+
+    const QDateTime startTime = parser.startTime();
+    QVERIFY(!startTime.isNull());
+    const QDateTime expected = QDateTime(QDate(2023, 1, 1), QTime(0, 0, 0), QTimeZone::utc());
+    QCOMPARE(startTime.toMSecsSinceEpoch(), expected.toMSecsSinceEpoch());
+}
+
+void LogFileParserTest::_startTimeAPMInvalidGwkTest()
+{
+    // GWk=500 is below the > 2000 guard; startTime must remain null.
+    QByteArray bytes;
+    appendBinMessage(bytes, 128, makeFmtPayloadStr(153, 17, "GPS", "QHI", "TimeUS,GWk,GMS"));
+    appendBinMessage(bytes, 153, makeGPSBinPayload(0ULL, uint16_t(500), uint32_t(18000)));
+
+    QTemporaryFile tmp;
+    tmp.setFileTemplate(QDir::tempPath() + QStringLiteral("/logtest_XXXXXX.bin"));
+    QVERIFY(writeTempFile(tmp, bytes));
+
+    LogFileParser parser;
+    QVERIFY(parser.parseFile(tmp.fileName()));
+    QVERIFY(parser.startTime().isNull());
+}
+
+void LogFileParserTest::_startTimePX4FromSensorGpsTest()
+{
+    // sensor_gps: timestamp=2,000,000 µs, time_utc_usec=1,672,531,202,000,000 µs.
+    // startMs = (1,672,531,202,000,000 - 2,000,000) / 1000 = 1,672,531,200,000
+    // Expected startTime: 2023-01-01 00:00:00 UTC.
+    const QByteArray bytes = buildULog(
+        [](ulog_cpp::Writer &w) {
+            w.messageFormat(ulog_cpp::MessageFormat{
+                "sensor_gps",
+                {ulog_cpp::Field{"uint64_t", "timestamp"},
+                 ulog_cpp::Field{"uint64_t", "time_utc_usec"}}
+            });
+        },
+        [](ulog_cpp::Writer &w) {
+            w.addLoggedMessage(ulog_cpp::AddLoggedMessage{0, 1, "sensor_gps"});
+            w.data(ulog_cpp::Data{1, makePayloadUint64Uint64(2000000ULL, 1672531202000000ULL)});
+        });
+
+    QTemporaryFile tmp;
+    tmp.setFileTemplate(QDir::tempPath() + QStringLiteral("/logtest_XXXXXX.ulg"));
+    QVERIFY(writeTempFile(tmp, bytes));
+
+    LogFileParser parser;
+    QVERIFY(parser.parseFile(tmp.fileName()));
+
+    const QDateTime startTime = parser.startTime();
+    QVERIFY(!startTime.isNull());
+    const QDateTime expected = QDateTime(QDate(2023, 1, 1), QTime(0, 0, 0), QTimeZone::utc());
+    QCOMPARE(startTime.toMSecsSinceEpoch(), expected.toMSecsSinceEpoch());
+}
+
+void LogFileParserTest::_startTimePX4ZeroUtcTest()
+{
+    // time_utc_usec=0 means no GPS fix; startTime must remain null.
+    const QByteArray bytes = buildULog(
+        [](ulog_cpp::Writer &w) {
+            w.messageFormat(ulog_cpp::MessageFormat{
+                "sensor_gps",
+                {ulog_cpp::Field{"uint64_t", "timestamp"},
+                 ulog_cpp::Field{"uint64_t", "time_utc_usec"}}
+            });
+        },
+        [](ulog_cpp::Writer &w) {
+            w.addLoggedMessage(ulog_cpp::AddLoggedMessage{0, 1, "sensor_gps"});
+            w.data(ulog_cpp::Data{1, makePayloadUint64Uint64(1000000ULL, 0ULL)});
+        });
+
+    QTemporaryFile tmp;
+    tmp.setFileTemplate(QDir::tempPath() + QStringLiteral("/logtest_XXXXXX.ulg"));
+    QVERIFY(writeTempFile(tmp, bytes));
+
+    LogFileParser parser;
+    QVERIFY(parser.parseFile(tmp.fileName()));
+    QVERIFY(parser.startTime().isNull());
+}
+
+void LogFileParserTest::_startTimeClearedOnResetTest()
+{
+    // Parse a ULog with a valid GPS fix, then verify clear() resets startTime.
+    const QByteArray bytes = buildULog(
+        [](ulog_cpp::Writer &w) {
+            w.messageFormat(ulog_cpp::MessageFormat{
+                "sensor_gps",
+                {ulog_cpp::Field{"uint64_t", "timestamp"},
+                 ulog_cpp::Field{"uint64_t", "time_utc_usec"}}
+            });
+        },
+        [](ulog_cpp::Writer &w) {
+            w.addLoggedMessage(ulog_cpp::AddLoggedMessage{0, 1, "sensor_gps"});
+            w.data(ulog_cpp::Data{1, makePayloadUint64Uint64(2000000ULL, 1672531202000000ULL)});
+        });
+
+    QTemporaryFile tmp;
+    tmp.setFileTemplate(QDir::tempPath() + QStringLiteral("/logtest_XXXXXX.ulg"));
+    QVERIFY(writeTempFile(tmp, bytes));
+
+    LogFileParser parser;
+    QVERIFY(parser.parseFile(tmp.fileName()));
+    QVERIFY(!parser.startTime().isNull());
+
+    parser.clear();
+    QVERIFY(parser.startTime().isNull());
+}
+
+// ============================================================================
+// Progress reporting tests
+// ============================================================================
+
+void LogFileParserTest::_parseProgressULogTest()
+{
+    // Build a ULog with enough data so the 64 KB chunk loop fires at least once.
+    // ~100 KB of float samples: 8000 messages × 12 bytes each ≈ 96 KB.
+    const QByteArray bytes = buildULog(
+        [](ulog_cpp::Writer &w) {
+            w.messageFormat(ulog_cpp::MessageFormat{
+                "sens",
+                {ulog_cpp::Field{"uint64_t", "timestamp"},
+                 ulog_cpp::Field{"float", "val"}}
+            });
+        },
+        [](ulog_cpp::Writer &w) {
+            w.addLoggedMessage(ulog_cpp::AddLoggedMessage{0, 1, "sens"});
+            for (int i = 0; i < 8000; ++i) {
+                w.data(ulog_cpp::Data{1, makePayload64Float(static_cast<uint64_t>(i) * 1000ULL, static_cast<float>(i))});
+            }
+        });
+
+    QTemporaryFile tmp;
+    tmp.setFileTemplate(QDir::tempPath() + QStringLiteral("/logtest_XXXXXX.ulg"));
+    QVERIFY(writeTempFile(tmp, bytes));
+
+    QList<float> progressValues;
+    QVERIFY(ULogParser::parseFile(tmp.fileName(), [&](float v) {
+        progressValues.append(v);
+    }).ok);
+
+    // Must have fired at least once (file > 64 KB)
+    QVERIFY(!progressValues.isEmpty());
+
+    // All values in (0, 1]
+    for (float v : progressValues) {
+        QVERIFY(v > 0.f);
+        QVERIFY(v <= 1.f);
+    }
+
+    // Monotonically non-decreasing
+    for (int i = 1; i < progressValues.size(); ++i) {
+        QVERIFY(progressValues[i] >= progressValues[i - 1]);
+    }
+
+    // Final value must be exactly 1.0 (chunk loop always reaches fileSize)
+    QCOMPARE(progressValues.last(), 1.f);
+}
+
+void LogFileParserTest::_parseProgressDataFlashTest()
+{
+    // Build a DataFlash log with >1000 messages to trigger the progress callback.
+    auto makeFmt = [](uint8_t type, uint8_t len, const char *name,
+                      const char *fmt, const char *cols) -> QByteArray {
+        QByteArray p(86, '\0');
+        p[0] = static_cast<char>(type);
+        p[1] = static_cast<char>(len);
+        memcpy(p.data() + 2,  name, qMin<int>(4,  static_cast<int>(strlen(name))));
+        memcpy(p.data() + 6,  fmt,  qMin<int>(16, static_cast<int>(strlen(fmt))));
+        memcpy(p.data() + 22, cols, qMin<int>(64, static_cast<int>(strlen(cols))));
+        return p;
+    };
+    auto appendMsg = [](QByteArray &b, uint8_t type, const QByteArray &payload) {
+        b.append(static_cast<char>(0xA3));
+        b.append(static_cast<char>(0x95));
+        b.append(static_cast<char>(type));
+        b.append(payload);
+    };
+
+    QByteArray bytes;
+    // FMT: type 150, total length 12 = 3-byte header + 9-byte payload (QB)
+    appendMsg(bytes, 128, makeFmt(150, 12, "SMPL", "Qb", "TimeUS,V"));
+
+    // Append 2000 SMPL messages (crosses the 1000-message threshold twice)
+    for (int i = 0; i < 2000; ++i) {
+        QByteArray payload(9, '\0');
+        uint64_t ts = static_cast<uint64_t>(i) * 1000ULL;
+        memcpy(payload.data(), &ts, 8);
+        payload[8] = static_cast<char>(i & 0xFF);
+        appendMsg(bytes, 150, payload);
+    }
+
+    QTemporaryFile tmp;
+    tmp.setFileTemplate(QDir::tempPath() + QStringLiteral("/logtest_XXXXXX.bin"));
+    QVERIFY(writeTempFile(tmp, bytes));
+
+    QList<float> progressValues;
+    QVERIFY(DataFlashParser::parseFile(tmp.fileName(), [&](float v) {
+        progressValues.append(v);
+    }).ok);
+
+    // Must have fired at least twice (2000 messages / 1000 per callback = 2)
+    QVERIFY(progressValues.size() >= 2);
+
+    // All values in (0, 1]
+    for (float v : progressValues) {
+        QVERIFY(v > 0.f);
+        QVERIFY(v <= 1.f);
+    }
+
+    // Monotonically non-decreasing
+    for (int i = 1; i < progressValues.size(); ++i) {
+        QVERIFY(progressValues[i] >= progressValues[i - 1]);
+    }
+}
+
+void LogFileParserTest::_startParsingAsyncProgressTest()
+{
+    // Build a ULog file — same dataset as _parseProgressULogTest
+    const QByteArray bytes = buildULog(
+        [](ulog_cpp::Writer &w) {
+            w.messageFormat(ulog_cpp::MessageFormat{
+                "sens",
+                {ulog_cpp::Field{"uint64_t", "timestamp"},
+                 ulog_cpp::Field{"float", "val"}}
+            });
+        },
+        [](ulog_cpp::Writer &w) {
+            w.addLoggedMessage(ulog_cpp::AddLoggedMessage{0, 1, "sens"});
+            for (int i = 0; i < 8000; ++i) {
+                w.data(ulog_cpp::Data{1, makePayload64Float(static_cast<uint64_t>(i) * 1000ULL, static_cast<float>(i))});
+            }
+        });
+
+    QTemporaryFile tmp;
+    tmp.setFileTemplate(QDir::tempPath() + QStringLiteral("/logtest_XXXXXX.ulg"));
+    QVERIFY(writeTempFile(tmp, bytes));
+
+    LogFileParser parser;
+    QSignalSpy progressSpy(&parser, &LogFileParser::parseProgressChanged);
+    QSignalSpy parsingSpy (&parser, &LogFileParser::parsingChanged);
+    QSignalSpy doneSpy    (&parser, &LogFileParser::parseFileFinished);
+
+    // parsing must be true immediately after startParsingAsync returns
+    parser.startParsingAsync(tmp.fileName());
+    QCOMPARE(parser.parsing(), true);
+    QCOMPARE(parser.parseProgress(), 0.f);
+
+    // Wait for the async parse to complete (up to 10 seconds)
+    QTRY_COMPARE_WITH_TIMEOUT(doneSpy.count(), 1, 10000);
+
+    // parsing must be false after completion
+    QCOMPARE(parser.parsing(), false);
+
+    // parsed must be true
+    QVERIFY(parser.parseComplete());
+
+    // parseProgress signals must have fired and final value is 1.0
+    QVERIFY(progressSpy.count() > 0);
+    QCOMPARE(parser.parseProgress(), 1.f);
+
+    // parsingChanged fired: true (on start) then false (on finish)
+    QVERIFY(parsingSpy.count() >= 2);
+}
+
+void LogFileParserTest::_clearDuringAsyncParseTest()
+{
+    // Build a large ULog file so the background parse is still running when we call clear().
+    const QByteArray bytes = buildULog(
+        [](ulog_cpp::Writer &w) {
+            w.messageFormat(ulog_cpp::MessageFormat{
+                "sens",
+                {ulog_cpp::Field{"uint64_t", "timestamp"},
+                 ulog_cpp::Field{"float", "val"}}
+            });
+        },
+        [](ulog_cpp::Writer &w) {
+            w.addLoggedMessage(ulog_cpp::AddLoggedMessage{0, 1, "sens"});
+            for (int i = 0; i < 50000; ++i) {
+                w.data(ulog_cpp::Data{1, makePayload64Float(static_cast<uint64_t>(i) * 1000ULL, static_cast<float>(i))});
+            }
+        });
+
+    QTemporaryFile tmp;
+    tmp.setFileTemplate(QDir::tempPath() + QStringLiteral("/logtest_XXXXXX.ulg"));
+    QVERIFY(writeTempFile(tmp, bytes));
+
+    LogFileParser parser;
+    QSignalSpy parsingSpy(&parser, &LogFileParser::parsingChanged);
+
+    parser.startParsingAsync(tmp.fileName());
+    QCOMPARE(parser.parsing(), true);
+
+    // Cancel immediately — parsing() must go false synchronously.
+    parser.clear();
+    QCOMPARE(parser.parsing(), false);
+
+    // parsingChanged must have fired at least once for the false transition.
+    QVERIFY(parsingSpy.count() >= 1);
+
+    // Drain the event loop long enough for the background thread to finish
+    // and any queued signals to be dispatched.
+    QTest::qWait(3000);
+
+    // The cancelled result must NOT have been applied.
+    QCOMPARE(parser.parsing(), false);
+    QCOMPARE(parser.parseComplete(), false);
+    QVERIFY(parser.availableFields().isEmpty());
 }
 
 UT_REGISTER_TEST(LogFileParserTest, TestLabel::Unit, TestLabel::AnalyzeView)

--- a/test/AnalyzeView/LogFileParserTest.h
+++ b/test/AnalyzeView/LogFileParserTest.h
@@ -19,4 +19,13 @@ private slots:
     void _gpsPathULogVehicleGlobalPositionTest();
     void _gpsPathULogVehicleGpsPositionLatDegTest();
     void _gpsPathAPMDataFlashPOSTest();
+    void _startTimeAPMFromGwkGmsTest();
+    void _startTimeAPMInvalidGwkTest();
+    void _startTimePX4FromSensorGpsTest();
+    void _startTimePX4ZeroUtcTest();
+    void _startTimeClearedOnResetTest();
+    void _parseProgressULogTest();
+    void _parseProgressDataFlashTest();
+    void _startParsingAsyncProgressTest();
+    void _clearDuringAsyncParseTest();
 };

--- a/test/Utilities/Parsing/APMDataFlash/APMDataFlashUtilityTest.cc
+++ b/test/Utilities/Parsing/APMDataFlash/APMDataFlashUtilityTest.cc
@@ -403,4 +403,70 @@ void APMDataFlashUtilityTest::_testIterateMessages()
     QCOMPARE(msgTypes[1], static_cast<uint8_t>(200));  // TEST
 }
 
+void APMDataFlashUtilityTest::_testIterateMessagesProgress()
+{
+    // Build a buffer with enough messages to cross the 1000-message threshold at least once.
+    QByteArray data;
+
+    // FMT message for a small record type (type 200, 12 bytes total = 9 byte payload)
+    data.append(static_cast<char>(0xA3));
+    data.append(static_cast<char>(0x95));
+    data.append(static_cast<char>(128));
+    char fmtPayload[86];
+    memset(fmtPayload, 0, sizeof(fmtPayload));
+    fmtPayload[0] = static_cast<char>(200);
+    fmtPayload[1] = 12;
+    memcpy(fmtPayload + 2, "TEST", 4);
+    memcpy(fmtPayload + 6, "Qb", 2);
+    memcpy(fmtPayload + 22, "TimeUS,Val", 10);
+    data.append(fmtPayload, sizeof(fmtPayload));
+
+    QMap<uint8_t, APMDataFlashUtility::MessageFormat> formats;
+    QVERIFY(APMDataFlashUtility::parseFmtMessages(data.constData(), data.size(), formats));
+
+    // Append 2000 TEST messages so the progress callback fires at least once (every 1000 messages)
+    for (int i = 0; i < 2000; ++i) {
+        data.append(static_cast<char>(0xA3));
+        data.append(static_cast<char>(0x95));
+        data.append(static_cast<char>(200));
+        char msg[9];
+        uint64_t ts = static_cast<uint64_t>(i) * 1000;
+        memcpy(msg, &ts, 8);
+        msg[8] = static_cast<char>(i & 0xFF);
+        data.append(msg, 9);
+    }
+
+    formats.clear();
+    QVERIFY(APMDataFlashUtility::parseFmtMessages(data.constData(), data.size(), formats));
+
+    QList<float> progressValues;
+    int messageCount = 0;
+
+    APMDataFlashUtility::iterateMessages(
+        data.constData(), data.size(), formats,
+        [&](uint8_t, const char *, int, const APMDataFlashUtility::MessageFormat &) {
+            ++messageCount;
+            return true;
+        },
+        [&](float v) {
+            progressValues.append(v);
+        });
+
+    QCOMPARE(messageCount, 2000);
+
+    // Progress callback must have fired at least once (at 1000-message mark)
+    QVERIFY(!progressValues.isEmpty());
+
+    // All values must be in (0, 1]
+    for (float v : progressValues) {
+        QVERIFY(v > 0.f);
+        QVERIFY(v <= 1.f);
+    }
+
+    // Values must be monotonically non-decreasing
+    for (int i = 1; i < progressValues.size(); ++i) {
+        QVERIFY(progressValues[i] >= progressValues[i - 1]);
+    }
+}
+
 UT_REGISTER_TEST(APMDataFlashUtilityTest, TestLabel::Unit, TestLabel::Utilities)

--- a/test/Utilities/Parsing/APMDataFlash/APMDataFlashUtilityTest.h
+++ b/test/Utilities/Parsing/APMDataFlash/APMDataFlashUtilityTest.h
@@ -39,4 +39,5 @@ private slots:
 
     // Message iteration tests
     void _testIterateMessages();
+    void _testIterateMessagesProgress();
 };


### PR DESCRIPTION
## Summary

Several related improvements to the Log Viewer: start time extraction and
display, chart mouse interaction improvements, async parse refactoring, and a
navigation crash fix.

### Start time

Extracts the log start wall-clock time from GPS data embedded in the log:
APM DataFlash uses GPS week + GMS; PX4 ULog uses `sensor_gps.time_utc_usec`.
The result is shown in the toolbar row next to the log filename when a log
is loaded. Includes GPS-to-UTC leap-second conversion for APM logs.

### Mouse handling in charts

| Gesture | Action |
|---|---|
| Click | Place cursor at that x position |
| Shift+drag | Scrub cursor continuously |
| Drag | Zooms the x-axis to the dragged area |
| Double-click | Reset zoom to full range and center cursor; syncs alt chart cursor |

### X-axis time mode

A toggle below the chart switches between elapsed and local time display.
The setting is persisted across sessions via `LogViewerSettings`.

- **Elapsed mode** (default): x-axis tick labels show `H:MM:SS` (or `MM:SS` /
  `Xs` for short logs). The cursor info block shows elapsed time only.
- **Local time mode**: when a GPS fix was found in the log, tick labels show
  wall-clock time in `HH:mm:ss` format (12-hour or 24-hour, following the
  system locale). The cursor info block shows both:
  `HH:mm:ss (local)  /  elapsed (elapsed)`. If no GPS fix was found, the
  axis and cursor fall back to elapsed display.

### Control refactoring

- Replace the opaque overlay + 50 ms timer with a progress bar driven directly
  by `LogFileParser.parsing` / `parseProgress`. Progress is reported by a
  `ProgressCallback` threaded through both the DataFlash and ULog parsers.
- Extract shared chart logic into two new QML components:
  - `LogViewerBaseChart` — common base used by both `LogViewerChart` and
    `LogViewerAltChart`. Owns the `GraphsView`, QGC-themed `GraphsTheme`, the
    HH:MM:SS / local-time x-axis label delegate, all zoom and cursor state, and
    mouse interaction (click to place cursor, shift+drag to scrub, drag to zoom,
    double-click to reset). Derived charts embed this and connect to its
    `zoomRangeSet` / `cursorPositionSet` signals to refresh their series data.
  - `LogViewerCursorPopup` — shared cursor value popup injected with
    chart-specific rows via a default property alias, used by both charts.

### Other changes

- Fix crash when navigating away from the Log Viewer during an active parse
  (`Component.onDestruction: logParser.clear()` + `QPointer` in the progress
  callback).
- Log Viewer can now be popped out into a separate window.
- Toolbar shows only the filename (not the full path).

### Testing

Unit tests added covering GPS path extraction (ULog `vehicle_global_position`,
`vehicle_gps_position` fallback, APM DataFlash `POS`), start-time computation
(APM and PX4, invalid inputs, `clear()` reset), and async progress reporting
for both parsers.
