### PR TITLE
ci: disable non-critical caches to protect ccache from LRU eviction

### DIFF
--- a/.github/actions/android-emulator-test/action.yml
+++ b/.github/actions/android-emulator-test/action.yml
@@ -39,58 +39,6 @@ runs:
         sudo udevadm control --reload-rules
         sudo udevadm trigger --name-match=kvm
 
-    - name: Restore AVD cache
-      id: avd-cache
-      uses: actions/cache/restore@v5
-      with:
-        path: |
-          ~/.android/avd/*
-          ~/.android/adb*
-        key: >-
-          avd-${{ runner.os }}-${{ runner.arch }}-api${{ inputs.android-platform }}
-          -x86_64-google_apis-pixel_6-qt${{ inputs.qt-version }}
-          -ndk${{ inputs.ndk-version }}-v2
-
-    - name: Create AVD Snapshot
-      id: avd-snapshot
-      if: steps.avd-cache.outputs.cache-hit != 'true'
-      continue-on-error: true
-      uses: reactivecircus/android-emulator-runner@v2
-      with:
-        api-level: ${{ inputs.android-platform }}
-        system-image-api-level: ${{ inputs.android-platform }}
-        arch: x86_64
-        target: google_apis
-        profile: pixel_6
-        cores: 4
-        ram-size: 4096M
-        heap-size: 1024M
-        avd-name: qgc-ci
-        force-avd-creation: false
-        emulator-boot-timeout: 420
-        disable-animations: true
-        disable-spellchecker: true
-        emulator-options: -no-window -gpu swiftshader_indirect -noaudio -no-boot-anim
-        script: echo "Generated AVD snapshot for cache."
-
-    # PRs are read-only on the shared cache (fork PRs can't poison it, same-repo PRs don't churn).
-    - name: Save AVD cache
-      if: github.event_name != 'pull_request' && steps.avd-cache.outputs.cache-hit != 'true' && steps.avd-snapshot.outcome == 'success'
-      uses: actions/cache/save@v5
-      with:
-        path: |
-          ~/.android/avd/*
-          ~/.android/adb*
-        key: ${{ steps.avd-cache.outputs.cache-primary-key }}
-
-    - name: Kill Stale Emulator
-      if: steps.avd-snapshot.outcome == 'failure'
-      shell: bash
-      run: |
-        pkill -9 -f qemu-system || true
-        adb kill-server 2>/dev/null || true
-        sleep 5
-
     - name: Emulator Boot Test
       uses: reactivecircus/android-emulator-runner@v2
       with:

--- a/.github/actions/build-action/action.yml
+++ b/.github/actions/build-action/action.yml
@@ -20,8 +20,6 @@ runs:
     - uses: actions/setup-node@v6
       with:
         node-version: 22
-        cache: npm
-        cache-dependency-path: build-action/package-lock.json
 
     - name: Build ${{ inputs.repo }}
       run: |

--- a/.github/actions/build-setup/action.yml
+++ b/.github/actions/build-setup/action.yml
@@ -193,12 +193,11 @@ runs:
           echo "Renamed Git link.exe to prevent Rust linker conflict"
         fi
 
-    # Gradle daemon + dependency cache for Android cross-compile. Read-only on PRs so fork PRs can't poison the shared cache and same-repo PRs don't churn it.
     - name: Setup Gradle (Android)
       if: inputs.mode == 'android'
       uses: gradle/actions/setup-gradle@v6
       with:
-        cache-read-only: ${{ github.event_name == 'pull_request' }}
+        cache-disabled: true
 
     - name: Install Qt for Android
       if: inputs.mode == 'android'

--- a/.github/actions/cache/action.yml
+++ b/.github/actions/cache/action.yml
@@ -179,7 +179,7 @@ runs:
         restore-keys: |
           ccache-${{ inputs.host }}-${{ inputs.target }}-${{ inputs.build-type }}${{ inputs.variant && format('-{0}', inputs.variant) }}-${{ steps.cache-scope.outputs.scope }}-
           ccache-${{ inputs.host }}-${{ inputs.target }}-${{ inputs.build-type }}${{ inputs.variant && format('-{0}', inputs.variant) }}-shared-
-          ccache-${{ inputs.host }}-${{ inputs.target }}-${{ inputs.build-type }}-shared-
+          ${{ inputs.variant && format('ccache-{0}-{1}-{2}-shared-', inputs.host, inputs.target, inputs.build-type) || '' }}
 
     - name: Restore Build Cache (ccache, read-only)
       if: steps.cache-policy.outputs.save != 'true'
@@ -190,7 +190,7 @@ runs:
         restore-keys: |
           ccache-${{ inputs.host }}-${{ inputs.target }}-${{ inputs.build-type }}${{ inputs.variant && format('-{0}', inputs.variant) }}-${{ steps.cache-scope.outputs.scope }}-
           ccache-${{ inputs.host }}-${{ inputs.target }}-${{ inputs.build-type }}${{ inputs.variant && format('-{0}', inputs.variant) }}-shared-
-          ccache-${{ inputs.host }}-${{ inputs.target }}-${{ inputs.build-type }}-shared-
+          ${{ inputs.variant && format('ccache-{0}-{1}-{2}-shared-', inputs.host, inputs.target, inputs.build-type) || '' }}
 
     - name: Initialize ccache stats
       shell: bash

--- a/.github/actions/docker/action.yml
+++ b/.github/actions/docker/action.yml
@@ -33,7 +33,7 @@ runs:
     - name: Set up setup-qemu-action
       uses: docker/setup-qemu-action@v4
       with:
-        cache-image: ${{ github.event_name != 'pull_request' }}
+        cache-image: false
 
     - name: Set up Docker Buildx
       uses: docker/setup-buildx-action@v4

--- a/.github/actions/docker/action.yml
+++ b/.github/actions/docker/action.yml
@@ -30,7 +30,7 @@ inputs:
 runs:
   using: composite
   steps:
-    - name: Set up setup-qemu-action
+    - name: Set up QEMU
       uses: docker/setup-qemu-action@v4
       with:
         cache-image: false

--- a/.github/actions/install-dependencies/action.yml
+++ b/.github/actions/install-dependencies/action.yml
@@ -65,7 +65,7 @@ runs:
         # shellcheck disable=SC2086
         sudo apt-get -o Acquire::Retries=3 install -y --no-install-recommends $APT_PACKAGES
 
-    - name: Fix apt alternatives after cache restore (Linux)
+    - name: Fix apt alternatives (Linux)
       if: runner.os == 'Linux'
       shell: bash
       run: python3 "${GITHUB_WORKSPACE}/.github/scripts/install_dependencies_helper.py" fix-apt-alternatives

--- a/.github/actions/install-dependencies/action.yml
+++ b/.github/actions/install-dependencies/action.yml
@@ -22,14 +22,6 @@ inputs:
 runs:
   using: composite
   steps:
-    - name: Restore GStreamer cache (Windows)
-      if: runner.os == 'Windows' && inputs.gstreamer == 'true'
-      id: gst-win-cache
-      uses: actions/cache/restore@v5
-      with:
-        path: C:\gstreamer
-        key: gstreamer-windows-${{ inputs.gstreamer-version || hashFiles('.github/build-config.json') }}
-
     - name: Install dependencies (Windows)
       if: runner.os == 'Windows'
       uses: nick-fields/retry@v4
@@ -52,13 +44,6 @@ runs:
               args.append('--vulkan')
           sys.exit(subprocess.run(args).returncode)
 
-    - name: Save GStreamer cache (Windows)
-      if: runner.os == 'Windows' && inputs.gstreamer == 'true' && github.event_name != 'pull_request' && steps.gst-win-cache.outputs.cache-hit != 'true'
-      uses: actions/cache/save@v5
-      with:
-        path: C:\gstreamer
-        key: ${{ steps.gst-win-cache.outputs.cache-primary-key }}
-
     - name: Get system package list (Linux)
       if: runner.os == 'Linux'
       id: linux-deps
@@ -70,17 +55,8 @@ runs:
       shell: bash
       run: python3 "${GITHUB_WORKSPACE}/.github/scripts/install_dependencies_helper.py" enable-universe
 
-    # cache-apt-pkgs-action has no save toggle; skip it on PRs to avoid cache churn.
-    - name: Cache and install apt packages (Linux, non-PR)
-      if: runner.os == 'Linux' && github.event_name != 'pull_request' && github.event_name != 'pull_request_target'
-      uses: awalsh128/cache-apt-pkgs-action@v1.6.0
-      with:
-        packages: ${{ steps.linux-deps.outputs.packages }}
-        # Only this file defines the apt list; broader hashes churned the cache on unrelated edits.
-        version: linux-deps-v2-${{ hashFiles('tools/setup/install_dependencies/**') }}
-
-    - name: Install apt packages (Linux, PR)
-      if: runner.os == 'Linux' && (github.event_name == 'pull_request' || github.event_name == 'pull_request_target')
+    - name: Install apt packages (Linux)
+      if: runner.os == 'Linux'
       shell: bash
       env:
         APT_PACKAGES: ${{ steps.linux-deps.outputs.packages }}
@@ -99,38 +75,10 @@ runs:
       shell: bash
       run: python3 "${GITHUB_WORKSPACE}/.github/scripts/install_dependencies_helper.py" install-optional
 
-    - name: Detect Python version for pipx cache (Linux)
-      if: runner.os == 'Linux'
-      id: python-version
-      shell: bash
-      run: python3 "${GITHUB_WORKSPACE}/.github/scripts/install_dependencies_helper.py" detect-python-version
-
-    - name: Restore pipx/pip cache (Linux)
-      if: runner.os == 'Linux'
-      id: pipx-cache
-      uses: actions/cache/restore@v5
-      with:
-        path: |
-          ~/.cache/pip
-          ~/.local/pipx
-        key: pipx-linux-v2-py${{ steps.python-version.outputs.minor }}-${{ hashFiles('tools/setup/install_dependencies/**', '.github/actions/install-dependencies/action.yml') }}
-        restore-keys: |
-          pipx-linux-v2-py${{ steps.python-version.outputs.minor }}-
-          pipx-linux-v2-
-
     - name: Install pipx packages (Linux)
       if: runner.os == 'Linux'
       shell: bash
       run: python3 tools/setup/install_dependencies --platform debian --skip-system-packages
-
-    - name: Save pipx/pip cache (Linux)
-      if: runner.os == 'Linux' && github.event_name != 'pull_request' && steps.pipx-cache.outputs.cache-hit != 'true'
-      uses: actions/cache/save@v5
-      with:
-        path: |
-          ~/.cache/pip
-          ~/.local/pipx
-        key: ${{ steps.pipx-cache.outputs.cache-primary-key }}
 
     - name: Install extra packages (Linux)
       if: runner.os == 'Linux' && inputs.extra-packages != ''
@@ -145,14 +93,6 @@ runs:
           # shellcheck disable=SC2086
           sudo apt-get install -y $validated
 
-    - name: Restore GStreamer cache (macOS)
-      if: runner.os == 'macOS'
-      id: gst-mac-cache
-      uses: actions/cache/restore@v5
-      with:
-        path: /Library/Frameworks/GStreamer.framework
-        key: gstreamer-macos-${{ inputs.gstreamer-version || hashFiles('.github/build-config.json') }}
-
     - name: Install dependencies (macOS)
       if: runner.os == 'macOS'
       uses: nick-fields/retry@v4
@@ -162,9 +102,3 @@ runs:
         command: |
           python3 tools/setup/install_dependencies --platform macos
 
-    - name: Save GStreamer cache (macOS)
-      if: runner.os == 'macOS' && github.event_name != 'pull_request' && steps.gst-mac-cache.outputs.cache-hit != 'true'
-      uses: actions/cache/save@v5
-      with:
-        path: /Library/Frameworks/GStreamer.framework
-        key: ${{ steps.gst-mac-cache.outputs.cache-primary-key }}

--- a/.github/actions/qt-android/action.yml
+++ b/.github/actions/qt-android/action.yml
@@ -60,28 +60,12 @@ runs:
         distribution: temurin
         java-version: ${{ inputs.java-version }}
 
-    # Restore before setup-android so sdkmanager skips the ~1.5GB download.
-    - name: Restore Android NDK cache
-      id: ndk-cache
-      uses: actions/cache/restore@v5
-      with:
-        path: ${{ env.ANDROID_HOME }}/ndk/${{ inputs.ndk-full-version }}
-        key: android-ndk-${{ runner.os }}-${{ runner.arch }}-${{ inputs.ndk-full-version }}
-
     - name: Setup Android Environment
       uses: android-actions/setup-android@v4
       with:
         cmdline-tools-version: ${{ inputs.android-cmdline-tools }}
         packages: 'platform-tools platforms;android-${{ inputs.android-platform }} build-tools;${{ inputs.android-build-tools }} ndk;${{ inputs.ndk-full-version }}'
         log-accepted-android-sdk-licenses: false
-
-    # PRs are read-only; only push/release builds populate the shared cache.
-    - name: Save Android NDK cache
-      if: steps.ndk-cache.outputs.cache-hit != 'true' && github.event_name != 'pull_request' && github.event_name != 'pull_request_target'
-      uses: actions/cache/save@v5
-      with:
-        path: ${{ env.ANDROID_HOME }}/ndk/${{ inputs.ndk-full-version }}
-        key: android-ndk-${{ runner.os }}-${{ runner.arch }}-${{ inputs.ndk-full-version }}
 
     - name: Update Android SDK / NDK / Tools
       shell: bash

--- a/.github/actions/qt-install/action.yml
+++ b/.github/actions/qt-install/action.yml
@@ -95,7 +95,7 @@ runs:
 
     # Forks can't write to the parent repo's cache (token is read-only), so skip the save attempt there to avoid noisy warnings. Same-repo PRs save normally.
     - name: Save Qt cache
-      if: steps.qt-cache.outputs.cache-hit != 'true' && (github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository)
+      if: steps.qt-cache.outputs.cache-hit != 'true' && inputs.target != 'ios' && (github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository)
       uses: actions/cache/save@v5
       with:
         path: ${{ inputs.dir }}/Qt/${{ inputs.version }}

--- a/.github/actions/setup-python/action.yml
+++ b/.github/actions/setup-python/action.yml
@@ -22,13 +22,7 @@ runs:
     - name: Setup uv
       uses: astral-sh/setup-uv@v8.1.0
       with:
-        enable-cache: true
-        save-cache: ${{ github.event_name != 'pull_request' && github.event_name != 'pull_request_target' }}
-        cache-dependency-glob: |
-          tools/pyproject.toml
-          tools/uv.lock
-          tools/setup/install_python.py
-          .pre-commit-config.yaml
+        enable-cache: false
 
     - name: Install dependencies
       shell: bash

--- a/.github/scripts/ccache_helper.py
+++ b/.github/scripts/ccache_helper.py
@@ -27,8 +27,12 @@ import tarfile
 import tempfile
 import time
 import zipfile
+from dataclasses import dataclass
 from pathlib import Path
-from typing import NamedTuple
+from typing import TYPE_CHECKING, NamedTuple
+
+if TYPE_CHECKING:
+    from collections.abc import Callable
 
 from ci_bootstrap import ensure_tools_dir
 
@@ -58,16 +62,65 @@ def _download_file(url: str, dest: Path, *, timeout: int = 120) -> None:
                 break
             f.write(chunk)
 
-# SHA256s below are bound to this version; test_ccache_version_drift.py enforces sync with build-config.json.
-PINNED_BINARY_VERSION = "4.13.6"
 
-WINDOWS_BINARY_SHA256 = {
-    "x86_64": "3d7cebb05850ad704e197b3f1d3f0f924ab6c9fdfc561578e146184fe9d89380",
-    "aarch64": "bec01846b06d6d87bf35eda50544d7c8bf9b9a4859f218417a7081aa45d7fd47",
-}
+_CCACHE_RELEASE_URL = "https://github.com/ccache/ccache/releases/download"
 
-# macOS release is a universal (x86_64 + arm64) tarball, no arch suffix.
-MACOS_BINARY_SHA256 = "0274210ec9c9936ed5711d59b0de3167a51216a588ddde35f6bc828f366fe6d9"
+
+def _extract_zip(archive: Path, dest: Path) -> None:
+    with zipfile.ZipFile(archive) as zf:
+        zf.extractall(dest)
+
+
+def _extract_tar_gz(archive: Path, dest: Path) -> None:
+    with tarfile.open(archive, "r:gz") as tar:
+        tar.extractall(dest, filter="data")
+
+
+def _install_release_binary(
+    url: str,
+    sha256: str,
+    archive_name: str,
+    extract: Callable[[Path, Path], None],
+    locate_source: Callable[[Path], Path],
+    dest: Path,
+) -> Path:
+    """Download a SHA256-verified release archive, extract it, and copy the binary to ``dest``."""
+    with tempfile.TemporaryDirectory() as temp_dir:
+        temp_path = Path(temp_dir)
+        archive_path = temp_path / archive_name
+        _download_file(url, archive_path)
+        actual = hashlib.sha256(archive_path.read_bytes()).hexdigest()
+        if actual != sha256:
+            raise RuntimeError(f"SHA256 mismatch: {actual} != {sha256}")
+        extract(archive_path, temp_path)
+        source = locate_source(temp_path)
+        if not source.exists():
+            raise FileNotFoundError(f"ccache binary not found in archive: {source}")
+        shutil.copy2(source, dest)
+    return dest
+
+@dataclass(frozen=True)
+class CcacheRelease:
+    """A pinned ccache release: version coupled to its per-platform digests."""
+
+    version: str
+    windows_sha256: dict[str, str]  # keyed by arch (x86_64, aarch64)
+    macos_sha256: str  # universal (x86_64 + arm64) tarball, no arch suffix
+
+
+# Digests are bound to .version; test_ccache_version_drift.py enforces sync with build-config.json.
+PINNED_RELEASE = CcacheRelease(
+    version="4.13.6",
+    windows_sha256={
+        "x86_64": "3d7cebb05850ad704e197b3f1d3f0f924ab6c9fdfc561578e146184fe9d89380",
+        "aarch64": "bec01846b06d6d87bf35eda50544d7c8bf9b9a4859f218417a7081aa45d7fd47",
+    },
+    macos_sha256="0274210ec9c9936ed5711d59b0de3167a51216a588ddde35f6bc828f366fe6d9",
+)
+
+PINNED_BINARY_VERSION = PINNED_RELEASE.version
+WINDOWS_BINARY_SHA256 = PINNED_RELEASE.windows_sha256
+MACOS_BINARY_SHA256 = PINNED_RELEASE.macos_sha256
 
 # ---------------------------------------------------------------------------
 # Data classes
@@ -92,7 +145,7 @@ class CcacheInstaller:
     MINISIGN_VERSION = "0.11"
     MINISIGN_KEY = "RWQX7yXbBedVfI4PNx6FLdFXu9GHUFsr28s4BVGxm4BeybtnX3P06saF"
 
-    CCACHE_RELEASE_URL = "https://github.com/ccache/ccache/releases/download"
+    CCACHE_RELEASE_URL = _CCACHE_RELEASE_URL
     MINISIGN_RELEASE_URL = "https://github.com/jedisct1/minisign/releases/download"
     MINISIGN_ARCHIVE_SHA256 = "f0a0954413df8531befed169e447a66da6868d79052ed7e892e50a4291af7ae0"
 
@@ -471,64 +524,37 @@ def _assert_pinned_version(version: str, platform_label: str) -> None:
 def install_windows_binary(version: str, arch: str, sha256: str, runner_temp: Path) -> Path:
     """Download and install the ccache Windows binary under ``runner_temp``."""
     _assert_pinned_version(version, "Windows")
-    ccache_url = (
-        f"https://github.com/ccache/ccache/releases/download/v{version}/"
-        f"ccache-{version}-windows-{arch}.zip"
-    )
     install_dir = runner_temp / f"ccache-{version}-windows-{arch}"
     install_dir.mkdir(parents=True, exist_ok=True)
-
-    with tempfile.TemporaryDirectory() as temp_dir:
-        temp_path = Path(temp_dir)
-        archive_path = temp_path / "ccache.zip"
-        _download_file(ccache_url, archive_path)
-        actual = hashlib.sha256(archive_path.read_bytes()).hexdigest()
-        if actual != sha256:
-            raise RuntimeError(f"SHA256 mismatch: {actual} != {sha256}")
-
-        with zipfile.ZipFile(archive_path) as archive:
-            archive.extractall(temp_path)
-
-        source = temp_path / f"ccache-{version}-windows-{arch}" / "ccache.exe"
-        if not source.exists():
-            raise FileNotFoundError(f"ccache.exe not found in downloaded archive for {arch}")
-        shutil.copy2(source, install_dir / "ccache.exe")
+    _install_release_binary(
+        f"{_CCACHE_RELEASE_URL}/v{version}/ccache-{version}-windows-{arch}.zip",
+        sha256,
+        "ccache.zip",
+        _extract_zip,
+        lambda root: root / f"ccache-{version}-windows-{arch}" / "ccache.exe",
+        install_dir / "ccache.exe",
+    )
     return install_dir
 
 def install_macos_binary(version: str, sha256: str, prefix: Path) -> Path:
     """Download and install the ccache macOS universal binary under ``prefix``/bin.
 
-    Matches the Windows install shape (SHA256-verified GitHub release tarball)
-    rather than the Linux path's minisign verification, so the macOS runner
-    doesn't need a minisign binary. Replaces the previous unpinned
-    ``brew install ccache`` step so all three platforms install the version
-    declared in ``.github/build-config.json``.
+    SHA256-verified GitHub release tarball (not the Linux minisign path), so the
+    macOS runner needs no minisign binary, and all three platforms install the
+    version declared in ``.github/build-config.json`` (vs unpinned brew).
     """
     _assert_pinned_version(version, "macOS")
-    ccache_url = (
-        f"https://github.com/ccache/ccache/releases/download/v{version}/"
-        f"ccache-{version}-darwin.tar.gz"
-    )
     bin_dir = prefix / "bin"
     bin_dir.mkdir(parents=True, exist_ok=True)
-    dest = bin_dir / "ccache"
-
-    with tempfile.TemporaryDirectory() as temp_dir:
-        temp_path = Path(temp_dir)
-        archive_path = temp_path / "ccache.tar.gz"
-        _download_file(ccache_url, archive_path)
-        actual = hashlib.sha256(archive_path.read_bytes()).hexdigest()
-        if actual != sha256:
-            raise RuntimeError(f"SHA256 mismatch: {actual} != {sha256}")
-
-        with tarfile.open(archive_path, "r:gz") as tar:
-            tar.extractall(temp_path, filter="data")
-
-        source = temp_path / f"ccache-{version}-darwin" / "ccache"
-        if not source.exists():
-            raise FileNotFoundError("ccache binary not found in macOS archive")
-        shutil.copy2(source, dest)
-        dest.chmod(0o755)
+    dest = _install_release_binary(
+        f"{_CCACHE_RELEASE_URL}/v{version}/ccache-{version}-darwin.tar.gz",
+        sha256,
+        "ccache.tar.gz",
+        _extract_tar_gz,
+        lambda root: root / f"ccache-{version}-darwin" / "ccache",
+        bin_dir / "ccache",
+    )
+    dest.chmod(0o755)
     return dest
 
 def add_windows_binary_to_path(version: str, arch: str, runner_temp: Path) -> Path:

--- a/.github/scripts/check_baseline_ready.py
+++ b/.github/scripts/check_baseline_ready.py
@@ -12,6 +12,7 @@ from ci_bootstrap import ensure_tools_dir
 ensure_tools_dir(__file__)
 
 from common.gh_actions import list_workflow_runs_for_sha, parse_csv_list, write_github_output
+from common.github_runs import select_latest_runs_by_name
 
 
 def evaluate_readiness(
@@ -20,18 +21,7 @@ def evaluate_readiness(
     event: str = "push",
 ) -> tuple[bool, list[str], list[str], list[str]]:
     """Return readiness and missing/incomplete/failed platform workflow lists."""
-    latest_by_name: dict[str, dict[str, Any]] = {}
-    target = set(platforms)
-
-    for run in runs:
-        name = str(run.get("name", ""))
-        if name not in target:
-            continue
-        if str(run.get("event", "")) != event:
-            continue
-        existing = latest_by_name.get(name)
-        if existing is None or str(run.get("created_at", "")) > str(existing.get("created_at", "")):
-            latest_by_name[name] = run
+    latest_by_name = select_latest_runs_by_name(runs, set(platforms), event=event)
 
     missing = [name for name in platforms if name not in latest_by_name]
     incomplete = [

--- a/.github/scripts/size_analysis.py
+++ b/.github/scripts/size_analysis.py
@@ -25,8 +25,70 @@ from ci_bootstrap import ensure_tools_dir
 
 ensure_tools_dir(__file__)
 
-from common.gh_actions import write_github_output, write_step_summary  # noqa: E402
-from common.proc import run_captured  # noqa: E402
+from common.gh_actions import write_github_output, write_step_summary
+from common.proc import run_captured
+
+
+def install_bloaty(timeout: int = 120) -> bool:
+    """Ensure bloaty is on PATH, preferring the apt package over a source build."""
+    if shutil.which("bloaty"):
+        return True
+
+    print("Installing bloaty (apt)...")
+    try:
+        run_captured(["sudo", "apt-get", "update"], timeout=30, check=True)
+        run_captured(["sudo", "apt-get", "install", "-y", "bloaty"], timeout=120, check=True)
+        if shutil.which("bloaty"):
+            print("bloaty installed from apt")
+            return True
+    except (subprocess.TimeoutExpired, subprocess.CalledProcessError):
+        pass  # not packaged on this image — fall back to the source build
+
+    return _install_bloaty_from_source(timeout)
+
+
+def _install_bloaty_from_source(timeout: int) -> bool:
+    """Build bloaty from a pinned commit when no prebuilt package is available."""
+    print(f"Building bloaty from source (timeout: {timeout}s)...")
+    try:
+        run_captured(
+            ["sudo", "apt-get", "install", "-y",
+             "libprotobuf-dev", "protobuf-compiler", "libre2-dev", "libcapstone-dev"],
+            timeout=60, check=True,
+        )
+        bloaty_dir = tempfile.mkdtemp(prefix="bloaty-")
+        run_captured(["git", "init", bloaty_dir], timeout=10, check=True)
+        run_captured(
+            ["git", "-C", bloaty_dir, "fetch", "--depth", "1",
+             "https://github.com/google/bloaty.git",
+             "87082741b1cc0a97cd84bd17cd4ee41d70a42fc6"],
+            timeout=30, check=True,
+        )
+        run_captured(["git", "-C", bloaty_dir, "checkout", "FETCH_HEAD"], timeout=10, check=True)
+        run_captured(
+            ["cmake", "-B", f"{bloaty_dir}/build", "-S", bloaty_dir,
+             "-DCMAKE_BUILD_TYPE=Release", "-DBLOATY_ENABLE_RE2=ON"],
+            timeout=60, check=True,
+        )
+        run_captured(
+            ["cmake", "--build", f"{bloaty_dir}/build", "--parallel"],
+            timeout=timeout, check=True,
+        )
+        run_captured(
+            ["sudo", "cmake", "--install", f"{bloaty_dir}/build"],
+            timeout=30, check=True,
+        )
+        print("bloaty installed from source")
+        return True
+    except subprocess.TimeoutExpired:
+        print(
+            "::warning::bloaty installation timed out, size analysis will be limited",
+            file=sys.stderr,
+        )
+        return False
+    except subprocess.CalledProcessError as e:
+        print(f"::warning::bloaty installation failed: {e}", file=sys.stderr)
+        return False
 
 
 class BinaryAnalyzer:
@@ -69,59 +131,6 @@ class BinaryAnalyzer:
             return result.stdout
         except (subprocess.SubprocessError, FileNotFoundError):
             return "Section sizes unavailable"
-
-    @staticmethod
-    def install_bloaty(timeout: int = 120) -> bool:
-        """
-        Install bloaty from source with timeout.
-
-        Returns True if bloaty is available after installation attempt.
-        """
-        if shutil.which("bloaty"):
-            return True
-
-        print(f"Installing bloaty (timeout: {timeout}s)...")
-
-        try:
-            run_captured(["sudo", "apt-get", "update"], timeout=30, check=True)
-            run_captured(
-                ["sudo", "apt-get", "install", "-y",
-                 "libprotobuf-dev", "protobuf-compiler", "libre2-dev", "libcapstone-dev"],
-                timeout=60, check=True,
-            )
-            bloaty_dir = tempfile.mkdtemp(prefix="bloaty-")
-            run_captured(["git", "init", bloaty_dir], timeout=10, check=True)
-            run_captured(
-                ["git", "-C", bloaty_dir, "fetch", "--depth", "1",
-                 "https://github.com/google/bloaty.git",
-                 "87082741b1cc0a97cd84bd17cd4ee41d70a42fc6"],
-                timeout=30, check=True,
-            )
-            run_captured(["git", "-C", bloaty_dir, "checkout", "FETCH_HEAD"], timeout=10, check=True)
-            run_captured(
-                ["cmake", "-B", f"{bloaty_dir}/build", "-S", bloaty_dir,
-                 "-DCMAKE_BUILD_TYPE=Release", "-DBLOATY_ENABLE_RE2=ON"],
-                timeout=60, check=True,
-            )
-            run_captured(
-                ["cmake", "--build", f"{bloaty_dir}/build", "--parallel"],
-                timeout=timeout, check=True,
-            )
-            run_captured(
-                ["sudo", "cmake", "--install", f"{bloaty_dir}/build"],
-                timeout=30, check=True,
-            )
-            print("bloaty installed successfully")
-            return True
-        except subprocess.TimeoutExpired:
-            print(
-                "::warning::bloaty installation timed out, size analysis will be limited",
-                file=sys.stderr,
-            )
-            return False
-        except subprocess.CalledProcessError as e:
-            print(f"::warning::bloaty installation failed: {e}", file=sys.stderr)
-            return False
 
     def run_bloaty(self, analysis_type: str, top_n: int = 20) -> str:
         """
@@ -239,7 +248,7 @@ def main() -> int:
     args = parse_args()
 
     if args.install_bloaty:
-        BinaryAnalyzer.install_bloaty(args.bloaty_timeout)
+        install_bloaty(args.bloaty_timeout)
 
     try:
         analyzer = BinaryAnalyzer(args.binary)

--- a/.github/scripts/tests/test_bootstrap_sparse_checkout.py
+++ b/.github/scripts/tests/test_bootstrap_sparse_checkout.py
@@ -44,14 +44,32 @@ def _common_module_to_path(module: str) -> str | None:
     return rel if (REPO_ROOT / rel).is_file() else None
 
 
+def _type_checking_body_nodes(tree: ast.AST) -> set[ast.AST]:
+    """Nodes inside `if TYPE_CHECKING:` blocks — those imports never run at runtime."""
+    skip: set[ast.AST] = set()
+    for node in ast.walk(tree):
+        if isinstance(node, ast.If):
+            test = node.test
+            is_tc = (isinstance(test, ast.Name) and test.id == "TYPE_CHECKING") or (
+                isinstance(test, ast.Attribute) and test.attr == "TYPE_CHECKING"
+            )
+            if is_tc:
+                for stmt in node.body:
+                    skip.update(ast.walk(stmt))
+    return skip
+
+
 def _iter_common_imports(source: Path) -> Iterator[str]:
-    """Yield `common.<dotted>` module names imported (directly or relatively) by `source`."""
+    """Yield `common.<dotted>` module names imported at runtime (directly or relatively) by `source`."""
     try:
         tree = ast.parse(source.read_text(encoding="utf-8"))
     except (OSError, SyntaxError):
         return
     inside_common = TOOLS_DIR / "common" in source.parents
+    skip = _type_checking_body_nodes(tree)
     for node in ast.walk(tree):
+        if node in skip:
+            continue
         if isinstance(node, ast.ImportFrom):
             if node.module is None:
                 continue
@@ -121,6 +139,9 @@ def test_bootstrap_sparse_checkout_matches_canonical() -> None:
             if BOOTSTRAP_TRIPWIRE not in entries:
                 continue
             required: set[str] = set(BASE_BOOTSTRAP_PATHS)
+            # `import common` runs __init__ at runtime; an eager facade that pulls
+            # every submodule would need them all present even under a thin sparse set.
+            required |= _required_common_paths(TOOLS_DIR / "common" / "__init__.py")
             for script in _scripts_in_block(entries):
                 required |= _required_common_paths(script)
             missing = sorted(required - entries)

--- a/.github/workflows/analysis.yml
+++ b/.github/workflows/analysis.yml
@@ -56,6 +56,7 @@ jobs:
           qt-host: linux
           qt-arch: linux_gcc_64
           build-type: Debug
+          cache-variant: ${{ inputs.tool }}
           save-cache: true
 
       - name: Prepare apt repositories (clazy)
@@ -74,7 +75,6 @@ jobs:
       - name: Install clazy packages
         if: inputs.tool == 'clazy'
         run: |
-          sudo apt-get -o Acquire::Retries=3 update -qq
           sudo apt-get -o Acquire::Retries=3 install -y --no-install-recommends clazy ninja-build
 
       - name: Install Dependencies (iwyu)
@@ -90,6 +90,7 @@ jobs:
           qt-host: linux
           qt-arch: linux_gcc_64
           build-type: Debug
+          cache-variant: ${{ inputs.tool }}
           save-cache: true
 
       - name: Install Dependencies (sanitizers)

--- a/.github/workflows/analysis.yml
+++ b/.github/workflows/analysis.yml
@@ -71,12 +71,11 @@ jobs:
             fi
             sudo apt-get -o DPkg::Lock::Timeout=300 -o Acquire::Retries=3 update -y -qq
 
-      - name: Cache and install clazy packages
+      - name: Install clazy packages
         if: inputs.tool == 'clazy'
-        uses: awalsh128/cache-apt-pkgs-action@v1.6.0
-        with:
-          packages: clazy ninja-build
-          version: clazy-linux-v1
+        run: |
+          sudo apt-get -o Acquire::Retries=3 update -qq
+          sudo apt-get -o Acquire::Retries=3 install -y --no-install-recommends clazy ninja-build
 
       - name: Install Dependencies (iwyu)
         if: inputs.tool == 'iwyu'

--- a/.github/workflows/android.yml
+++ b/.github/workflows/android.yml
@@ -31,7 +31,6 @@ permissions:
   id-token: write
   attestations: write
   actions: read
-  security-events: write
 
 jobs:
   changes:

--- a/.github/workflows/build-gstreamer.yml
+++ b/.github/workflows/build-gstreamer.yml
@@ -115,17 +115,16 @@ jobs:
 
       - name: Install dependencies (Linux)
         if: inputs.platform == 'linux'
-        uses: awalsh128/cache-apt-pkgs-action@v1.6.0
-        with:
-          packages: >-
-            build-essential pkg-config git
-            libx11-dev libxext-dev libxv-dev
-            libwayland-dev wayland-protocols
-            libegl1-mesa-dev libgles2-mesa-dev libgl1-mesa-dev
-            libdrm-dev libgbm-dev
-            libasound2-dev libpulse-dev
+        run: |
+          sudo apt-get -o Acquire::Retries=3 update -qq
+          sudo apt-get -o Acquire::Retries=3 install -y --no-install-recommends \
+            build-essential pkg-config git \
+            libx11-dev libxext-dev libxv-dev \
+            libwayland-dev wayland-protocols \
+            libegl1-mesa-dev libgles2-mesa-dev libgl1-mesa-dev \
+            libdrm-dev libgbm-dev \
+            libasound2-dev libpulse-dev \
             libva-dev nasm yasm
-          version: gstreamer-linux-deps-v1
 
       - name: Install dependencies (macOS)
         if: inputs.platform == 'macos' || inputs.platform == 'ios'
@@ -137,12 +136,11 @@ jobs:
 
       - name: Install dependencies (Android)
         if: inputs.platform == 'android'
-        uses: awalsh128/cache-apt-pkgs-action@v1.6.0
-        with:
-          packages: >-
-            python3-pip git autoconf automake libtool
+        run: |
+          sudo apt-get -o Acquire::Retries=3 update -qq
+          sudo apt-get -o Acquire::Retries=3 install -y --no-install-recommends \
+            python3-pip git autoconf automake libtool \
             pkg-config gettext bison flex cmake ninja-build
-          version: gstreamer-android-deps-v1
 
       # Android/iOS GStreamer builds don't link against host Qt — skip build-setup there. The desktop platforms run through build-setup so we get qt-install + setup-python + platform compiler toolchain in one shot.
       - name: Build Setup

--- a/.github/workflows/check-links.yml
+++ b/.github/workflows/check-links.yml
@@ -41,22 +41,6 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v6
 
-      - name: Restore lychee cache (PR)
-        if: github.event_name == 'pull_request'
-        uses: actions/cache/restore@v5
-        with:
-          path: .lycheecache
-          key: cache-lychee-${{ hashFiles('.lychee.toml') }}
-          restore-keys: cache-lychee-
-
-      - name: Cache lychee (push)
-        if: github.event_name != 'pull_request'
-        uses: actions/cache@v5
-        with:
-          path: .lycheecache
-          key: cache-lychee-${{ hashFiles('.lychee.toml') }}
-          restore-keys: cache-lychee-
-
       - name: Check links
         uses: lycheeverse/lychee-action@v2
         with:

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -42,24 +42,8 @@ jobs:
         with:
           node-version: 'lts/*'
 
-      - name: Restore npm cache
-        id: npm-cache
-        uses: actions/cache/restore@v5
-        with:
-          path: ~/.npm
-          key: node-cache-${{ runner.os }}-${{ runner.arch }}-npm-${{ hashFiles('package-lock.json') }}
-          restore-keys: |
-            node-cache-${{ runner.os }}-${{ runner.arch }}-npm-
-
       - name: Install dependencies
         run: npm ci
-
-      - name: Save npm cache
-        if: github.event_name != 'pull_request' && steps.npm-cache.outputs.cache-hit != 'true'
-        uses: actions/cache/save@v5
-        with:
-          path: ~/.npm
-          key: ${{ steps.npm-cache.outputs.cache-primary-key }}
 
       - name: Build with VitePress
         run: |

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -75,6 +75,7 @@ jobs:
           sparse-checkout: |
             .github/actions
             .github/scripts
+            tools/common
 
       - name: Deploy docs
         uses: ./.github/actions/deploy-docs

--- a/.github/workflows/doxygen.yml
+++ b/.github/workflows/doxygen.yml
@@ -33,10 +33,9 @@ jobs:
         uses: actions/checkout@v6
 
       - name: Install Doxygen and Graphviz
-        uses: awalsh128/cache-apt-pkgs-action@v1.6.0
-        with:
-          packages: doxygen graphviz
-          version: doxygen-deps-v1
+        run: |
+          sudo apt-get -o Acquire::Retries=3 update -qq
+          sudo apt-get -o Acquire::Retries=3 install -y --no-install-recommends doxygen graphviz
 
       - name: Build Doxygen docs
         run: doxygen Doxyfile

--- a/.github/workflows/ios.yml
+++ b/.github/workflows/ios.yml
@@ -22,7 +22,6 @@ permissions:
   id-token: write
   attestations: write
   actions: read
-  security-events: write
 
 jobs:
   changes:

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -21,7 +21,6 @@ permissions:
   contents: read
   id-token: write
   attestations: write
-  security-events: write
   actions: read
   checks: write
 
@@ -37,6 +36,16 @@ jobs:
     if: needs.changes.outputs.should_build == 'true'
     runs-on: ${{ matrix.os }}
     timeout-minutes: 120
+
+    # security-events: write is scoped here (CodeQL runs only in this job),
+    # not at workflow level — the debug/changes jobs cannot upload SARIF.
+    permissions:
+      contents: read
+      id-token: write
+      attestations: write
+      security-events: write
+      actions: read
+      checks: write
 
     strategy:
       fail-fast: false

--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -31,7 +31,6 @@ permissions:
   id-token: write
   attestations: write
   actions: read
-  security-events: write
 
 jobs:
   changes:

--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -45,20 +45,6 @@ jobs:
           groups: precommit
           python-version: '3.12'
 
-      - name: Restore pre-commit cache (PR)
-        if: github.event_name == 'pull_request'
-        uses: actions/cache/restore@v5
-        with:
-          path: ~/.cache/pre-commit
-          key: pre-commit|${{ env.pythonLocation }}|${{ hashFiles('.pre-commit-config.yaml') }}
-
-      - name: Cache pre-commit hooks (push)
-        if: github.event_name != 'pull_request'
-        uses: actions/cache@v5
-        with:
-          path: ~/.cache/pre-commit
-          key: pre-commit|${{ env.pythonLocation }}|${{ hashFiles('.pre-commit-config.yaml') }}
-
       - name: Install Qt (for qmllint)
         uses: ./.github/actions/qt-install
         with:

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -31,7 +31,6 @@ permissions:
   id-token: write
   attestations: write
   actions: read
-  security-events: write
 
 jobs:
   changes:

--- a/tools/analyzers/clang_format.py
+++ b/tools/analyzers/clang_format.py
@@ -7,6 +7,7 @@ from typing import TYPE_CHECKING, ClassVar
 from common.analyzer import AnalysisResult, AnalyzerBase
 from common.logging import log_error, log_info, log_ok
 from common.proc import run_captured
+from common.tool_version import probe_version
 
 if TYPE_CHECKING:
     from pathlib import Path
@@ -22,10 +23,9 @@ class ClangFormatAnalyzer(AnalyzerBase):
         if not self.require_tool("clang-format"):
             return AnalysisResult(tool=self.name, passed=False, output="Tool not found")
 
-        version_result = run_captured(["clang-format", "--version"])
-        parts = version_result.stdout.split() if version_result.stdout else []
-        version_match = parts[2] if len(parts) > 2 else "unknown"
-        log_info(f"Using clang-format version {version_match}")
+        version = probe_version("clang-format")
+        version_str = ".".join(map(str, version)) if version else "unknown"
+        log_info(f"Using clang-format version {version_str}")
 
         if not files:
             log_info("No files to check")

--- a/tools/analyzers/qt_translate_noop_check.py
+++ b/tools/analyzers/qt_translate_noop_check.py
@@ -33,8 +33,10 @@ from dataclasses import dataclass
 from pathlib import Path
 from typing import ClassVar
 
-# Add tools to path for imports
-sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+from _bootstrap import ensure_tools_dir
+
+ensure_tools_dir(__file__)
 
 from common.analyzer import AnalysisResult, AnalyzerBase
 from common.file_traversal import find_cpp_files

--- a/tools/analyzers/vehicle_null_check.py
+++ b/tools/analyzers/vehicle_null_check.py
@@ -25,8 +25,10 @@ from dataclasses import asdict, dataclass
 from pathlib import Path
 from typing import ClassVar
 
-# Add tools to path for imports
-sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+from _bootstrap import ensure_tools_dir
+
+ensure_tools_dir(__file__)
 
 from common.analyzer import AnalysisResult, AnalyzerBase
 from common.file_traversal import find_cpp_files

--- a/tools/common/README.md
+++ b/tools/common/README.md
@@ -45,7 +45,6 @@ Shared GitHub Actions API helpers (via `gh`) used by CI scripts.
 ```python
 from tools.common.gh_actions import (
     gh,                        # Run gh command and capture output
-    parse_json_documents,      # Parse concatenated paginated JSON
     list_workflow_runs_for_sha,# List workflow runs for commit SHA
     list_run_artifacts,        # List artifacts for a workflow run
 )

--- a/tools/common/__init__.py
+++ b/tools/common/__init__.py
@@ -86,9 +86,6 @@ if TYPE_CHECKING:
         list_workflow_runs_for_sha as list_workflow_runs_for_sha,
     )
     from .gh_actions import (
-        parse_json_documents as parse_json_documents,
-    )
-    from .gh_actions import (
         write_github_output as write_github_output,
     )
     from .gh_actions import (
@@ -187,7 +184,6 @@ _LAZY_SYMBOLS: dict[str, str] = {
     "find_json_files": "file_traversal",
     "DEFAULT_SKIP_DIRS": "file_traversal",
     "gh": "gh_actions",
-    "parse_json_documents": "gh_actions",
     "list_workflow_runs_for_sha": "gh_actions",
     "list_run_artifacts": "gh_actions",
     "write_github_output": "gh_actions",

--- a/tools/common/gh_actions.py
+++ b/tools/common/gh_actions.py
@@ -6,7 +6,6 @@ from __future__ import annotations
 import json
 import os
 import subprocess
-import time
 from typing import Any
 
 
@@ -20,131 +19,27 @@ def gh(*args: str, check: bool = True) -> subprocess.CompletedProcess:
     )
 
 
-def _github_token() -> str:
-    return os.environ.get("GH_TOKEN") or os.environ.get("GITHUB_TOKEN") or ""
+def _paginate_items(path: str, item_key: str, params: dict[str, str]) -> list[dict[str, Any]]:
+    """Fetch all pages of a GitHub list endpoint and return the unpacked items.
 
-
-def _should_use_http_api() -> bool:
-    mode = os.environ.get("QGC_GH_API_MODE", "").strip().lower()
-    return mode == "http" and bool(_github_token())
-
-
-def _build_http_client():
-    import httpx
-    transport = httpx.HTTPTransport(retries=3)
-    base_url = os.environ.get("GITHUB_API_URL", "https://api.github.com").rstrip("/")
-    return httpx.Client(
-        base_url=base_url,
-        transport=transport,
-        timeout=30.0,
-        headers={
-            "Accept": "application/vnd.github+json",
-            "User-Agent": "qgc-ci-gh-actions/1.0",
-            "X-GitHub-Api-Version": "2022-11-28",
-            "Authorization": f"Bearer {_github_token()}",
-        },
-    )
-
-
-def _retry_after_seconds(value: str, fallback: float) -> float:
-    """Parse a Retry-After header value, falling back to a simple backoff."""
-    try:
-        retry_after = float(value)
-    except (TypeError, ValueError):
-        return fallback
-    return retry_after if retry_after > 0 else fallback
-
-
-def _http_get_with_retries(client, url: str, **kwargs) -> Any:
-    """GET a GitHub API endpoint with retries for transient status failures."""
-    import httpx
-
-    retryable_statuses = {429, 500, 502, 503, 504}
-
-    for attempt in range(1, 4):
-        try:
-            resp = client.get(url, **kwargs)
-            resp.raise_for_status()
-            return resp
-        except httpx.HTTPStatusError as exc:
-            status_code = exc.response.status_code
-            if attempt >= 3 or status_code not in retryable_statuses:
-                raise
-            delay = _retry_after_seconds(exc.response.headers.get("Retry-After", ""), float(attempt))
-        except httpx.RequestError:
-            if attempt >= 3:
-                raise
-            delay = float(attempt)
-
-        time.sleep(delay)
-
-
-def _http_paginated_docs(path: str, params: dict[str, str]) -> list[dict[str, Any]]:
-    docs: list[dict[str, Any]] = []
-    with _build_http_client() as client:
-        resp = _http_get_with_retries(client, f"/{path.lstrip('/')}", params=params)
-        docs.append(resp.json())
-
-        while "next" in resp.links:
-            resp = _http_get_with_retries(client, resp.links["next"]["url"])
-            docs.append(resp.json())
-    return docs
-
-
-def parse_json_documents(stdout: str) -> list[dict[str, Any]]:
-    """Parse one or more concatenated JSON documents."""
-    docs: list[dict[str, Any]] = []
-    decoder = json.JSONDecoder()
-    index = 0
-    length = len(stdout)
-
-    while index < length:
-        while index < length and stdout[index].isspace():
-            index += 1
-        if index >= length:
-            break
-        try:
-            value, next_index = decoder.raw_decode(stdout, index)
-        except json.JSONDecodeError as exc:
-            snippet = stdout[index:index + 120].replace("\n", "\\n")
-            raise ValueError(f"Failed to parse GitHub API JSON output near: {snippet}") from exc
-        if isinstance(value, dict):
-            docs.append(value)
-        index = next_index
-
-    return docs
+    ``gh --paginate --jq`` applies the filter per page and streams one JSON
+    value per line (NDJSON), so the list is unpacked server-side; ``[]?``
+    tolerates pages where the key is absent.
+    """
+    cmd = ["api", "--method", "GET", "--paginate", "--jq", f".{item_key}[]?", path]
+    for key, value in params.items():
+        cmd += ["-F", f"{key}={value}"]
+    result = gh(*cmd)
+    return [json.loads(line) for line in result.stdout.splitlines() if line.strip()]
 
 
 def list_workflow_runs_for_sha(repo: str, head_sha: str) -> list[dict[str, Any]]:
     """List workflow runs for a commit SHA across all paginated API results."""
-    if _should_use_http_api():
-        docs = _http_paginated_docs(
-            f"repos/{repo}/actions/runs",
-            {
-                "head_sha": head_sha,
-                "per_page": "100",
-            },
-        )
-    else:
-        result = gh(
-            "api",
-            "--method",
-            "GET",
-            "--paginate",
-            f"repos/{repo}/actions/runs",
-            "-F",
-            f"head_sha={head_sha}",
-            "-F",
-            "per_page=100",
-        )
-        docs = parse_json_documents(result.stdout)
-
-    runs: list[dict[str, Any]] = []
-    for doc in docs:
-        items = doc.get("workflow_runs", [])
-        if isinstance(items, list):
-            runs.extend(item for item in items if isinstance(item, dict))
-    return runs
+    return _paginate_items(
+        f"repos/{repo}/actions/runs",
+        "workflow_runs",
+        {"head_sha": head_sha, "per_page": "100"},
+    )
 
 
 def list_run_artifacts(repo: str, run_id: int | str) -> list[dict[str, Any]]:
@@ -156,31 +51,11 @@ def list_run_artifacts(repo: str, run_id: int | str) -> list[dict[str, Any]]:
     if run_id_int <= 0:
         raise ValueError(f"run_id must be positive, got {run_id_int}")
 
-    if _should_use_http_api():
-        docs = _http_paginated_docs(
-            f"repos/{repo}/actions/runs/{run_id_int}/artifacts",
-            {
-                "per_page": "100",
-            },
-        )
-    else:
-        result = gh(
-            "api",
-            "--method",
-            "GET",
-            "--paginate",
-            f"repos/{repo}/actions/runs/{run_id_int}/artifacts",
-            "-F",
-            "per_page=100",
-        )
-        docs = parse_json_documents(result.stdout)
-
-    artifacts: list[dict[str, Any]] = []
-    for doc in docs:
-        items = doc.get("artifacts", [])
-        if isinstance(items, list):
-            artifacts.extend(item for item in items if isinstance(item, dict))
-    return artifacts
+    return _paginate_items(
+        f"repos/{repo}/actions/runs/{run_id_int}/artifacts",
+        "artifacts",
+        {"per_page": "100"},
+    )
 
 
 def parse_csv_list(value: str) -> list[str]:

--- a/tools/common/github_runs.py
+++ b/tools/common/github_runs.py
@@ -11,10 +11,8 @@ def parse_created_at(created_at: Any) -> datetime | None:
     value = str(created_at).strip()
     if not value:
         return None
-    if value.endswith("Z"):
-        value = f"{value[:-1]}+00:00"
     try:
-        return datetime.fromisoformat(value)
+        return datetime.fromisoformat(value)  # 3.11+ accepts the trailing 'Z'
     except ValueError:
         return None
 

--- a/tools/configs/ccache.conf
+++ b/tools/configs/ccache.conf
@@ -15,9 +15,12 @@
 # Base directory - set by CMake via CCACHE_BASEDIR environment variable
 # base_dir = .
 
-# Ceiling, not target — Qt6 + QGC has ~1000+ TUs so 2G triggered mid-build LRU
-# eviction. 5G fits comfortably under GHA's 10 GiB/repo quota even with multiple
-# variant/scope keys (each key is its own actions/cache entry, not a shared pool).
+# Local .ccache ceiling during a build, not the saved-entry size — Qt6 + QGC has
+# ~1000+ TUs so 2G triggered mid-build LRU eviction. The entry uploaded to GHA is
+# the compressed dir (smaller). GHA's 10 GiB/repo quota is a single shared pool
+# across ALL cache entries, so total footprint = sum of every ccache key (one per
+# host/target/build-type/variant on the shared scope, since PRs are read-only)
+# plus qt/cpm entries — keep that sum under 10 GiB.
 max_size = 5G
 
 # Compression level (1-19, higher = smaller but slower)

--- a/tools/generators/common/controls.py
+++ b/tools/generators/common/controls.py
@@ -74,6 +74,19 @@ class ToggleCheckboxDef:
     onUnchecked: str = ""    # QML statement when unchecked
 
 
+@dataclass
+class BaseControlDef:
+    """Fields common to the config and settings control definitions."""
+    setting: str = ""          # settings path, e.g. "flyViewSettings.showObstacleDistanceOverlay"
+    label: str = ""
+    control: str = ""          # combobox | textfield | checkbox | slider | ... (auto-detected if empty)
+    showWhen: str = ""
+    enableWhen: str = ""
+    component: str = ""        # escape hatch: inline hand-written QML component
+    enableCheckbox: EnableCheckboxDef | None = None
+    button: ButtonDef | None = None
+
+
 # --------------------------------------------------------------------------- #
 # Rendering helpers
 # --------------------------------------------------------------------------- #

--- a/tools/generators/config_qml/emit.py
+++ b/tools/generators/config_qml/emit.py
@@ -330,16 +330,6 @@ def _inject_prop(qml: str, prop_line: str) -> str:
     qml_lines.insert(1, prop_line)
     return "\n".join(qml_lines)
 
-def _wrap_visible(qml: str, expr: str, indent: str) -> str:
-    """Wrap a QML block in an Item with a visible binding."""
-    lines = [f"{indent}Item {{"]
-    lines.append(f"{indent}    visible: {expr}")
-    lines.append(f"{indent}    Layout.fillWidth: true")
-    for line in qml.splitlines():
-        lines.append(f"    {line}" if line.strip() else line)
-    lines.append(f"{indent}}}")
-    return "\n".join(lines)
-
 def _section_visible(sec: SectionDef) -> str:
     name_vis = f'sectionMatchesFilter("{sec.title}")'
     return f"{name_vis} && {sec.showWhen}" if sec.showWhen else name_vis

--- a/tools/generators/config_qml/generate_pages.py
+++ b/tools/generators/config_qml/generate_pages.py
@@ -15,9 +15,10 @@ import argparse
 import sys
 from pathlib import Path
 
-# Allow running as a module (-m) from the repo root
-_SCRIPT_DIR = Path(__file__).resolve().parent
-sys.path.insert(0, str(_SCRIPT_DIR.parent.parent))
+sys.path.insert(0, str(Path(__file__).resolve().parents[2]))
+from _bootstrap import ensure_tools_dir
+
+ensure_tools_dir(__file__)
 
 from generators.config_qml.page_generator import generate_config_page_qml, load_page_def
 

--- a/tools/generators/config_qml/model.py
+++ b/tools/generators/config_qml/model.py
@@ -8,9 +8,8 @@ from pathlib import Path  # noqa: TC003
 
 from ..common.controls import (
     ActionButtonDef,
-    ButtonDef,
+    BaseControlDef,
     DialogButtonDef,
-    EnableCheckboxDef,
     LinkedParamDef,
     RadioOptionDef,
     ToggleCheckboxDef,
@@ -25,19 +24,16 @@ from ..common.controls import (
 
 
 @dataclass
-class ControlDef:
-    """A single control inside a config section."""
+class ControlDef(BaseControlDef):
+    """A single control inside a config section.
+
+    Inherits setting/label/control/showWhen/enableWhen/component/enableCheckbox/
+    button from BaseControlDef; the fields below are config-specific.
+    """
     param: str = ""            # vehicle parameter name via FactPanelController
-    setting: str = ""          # settings path, e.g. "flyViewSettings.showObstacleDistanceOverlay"
-    label: str = ""
-    control: str = ""          # combobox | textfield | checkbox | slider | dialogButton (auto-detected if empty)
-    showWhen: str = ""
-    enableWhen: str = ""
     optional: bool = False     # true: param may not exist, pass false to getParameterFact
     sliderMin: str = ""        # explicit slider min override
     sliderMax: str = ""        # explicit slider max override
-    enableCheckbox: EnableCheckboxDef | None = None  # slider: checked/onClicked
-    button: ButtonDef | None = None                  # adjacent button
     options: list[RadioOptionDef] = field(default_factory=list)  # radiogroup options
     enumValues: list[tuple[int | float | str, str]] = field(default_factory=list)  # combobox: manual [(value, label), ...]
     dialogButton: DialogButtonDef | None = None      # button that opens a popup dialog
@@ -55,7 +51,6 @@ class ControlDef:
     majorTickStepSize: str = ""                       # factslider: tick interval
     decimalPlaces: str = ""                           # factslider: decimal places
     linkedParams: list[LinkedParamDef] = field(default_factory=list)  # factslider: coupled params
-    component: str = ""                               # component: inline hand-written QML component
 
 @dataclass
 class DisabledSectionDef:

--- a/tools/generators/config_qml/page_generator.py
+++ b/tools/generators/config_qml/page_generator.py
@@ -10,22 +10,7 @@ This module is a re-export facade.  Implementation lives in:
   - ``.emit``   — QML rendering
 """
 
-from .emit import (
-    _HEADER,
-    _detect_control_type,
-    _fact_ref,
-    _inject_prop,
-    _qml_component_section,
-    _qml_control,
-    _qml_disabled_companion_section,
-    _qml_generated_section,
-    _qml_repeat_count_property,
-    _qml_repeat_section,
-    _safe_id,
-    _wrap_visible,
-    generate_config_page_qml,
-    get_section_names,
-)
+from .emit import generate_config_page_qml, get_section_names
 from .model import (
     ControlDef,
     DisabledSectionDef,
@@ -33,36 +18,16 @@ from .model import (
     ParamDef,
     RepeatDef,
     SectionDef,
-    _build_search_terms,
-    _build_translatable_terms,
-    _propagate_optional,
-    _vis_expr,
     load_page_def,
 )
 
 __all__ = [
-    "_HEADER",
     "ControlDef",
     "DisabledSectionDef",
     "PageDef",
     "ParamDef",
     "RepeatDef",
     "SectionDef",
-    "_build_search_terms",
-    "_build_translatable_terms",
-    "_detect_control_type",
-    "_fact_ref",
-    "_inject_prop",
-    "_propagate_optional",
-    "_qml_component_section",
-    "_qml_control",
-    "_qml_disabled_companion_section",
-    "_qml_generated_section",
-    "_qml_repeat_count_property",
-    "_qml_repeat_section",
-    "_safe_id",
-    "_vis_expr",
-    "_wrap_visible",
     "generate_config_page_qml",
     "get_section_names",
     "load_page_def",

--- a/tools/generators/settings_qml/emit.py
+++ b/tools/generators/settings_qml/emit.py
@@ -239,16 +239,6 @@ def generate_page_qml(
     ) + "\n"
 
 
-def _dedup(items: list[str]) -> list[str]:
-    seen: set[str] = set()
-    out: list[str] = []
-    for item in items:
-        if item not in seen:
-            seen.add(item)
-            out.append(item)
-    return out
-
-
 def generate_pages_model_qml(pages_json_path: Path) -> str:
     """Generate SettingsPagesModel.qml from SettingsPages.json."""
     with open(pages_json_path, encoding="utf-8") as f:
@@ -282,7 +272,7 @@ def generate_pages_model_qml(pages_json_path: Path) -> str:
                     terms_parts.extend(c.label.lower() for c in grp.controls if c.label)
                     search_terms.append({
                         "section": grp_idx,
-                        "terms": " ".join(_dedup(terms_parts)),
+                        "terms": " ".join(dict.fromkeys(terms_parts)),
                     })
 
                     tr_parts: list[str] = [section_name, *grp.keywords]
@@ -290,7 +280,7 @@ def generate_pages_model_qml(pages_json_path: Path) -> str:
                     translatable_terms.append({
                         "section": grp_idx,
                         "context": page_def_name,
-                        "terms": _dedup(tr_parts),
+                        "terms": list(dict.fromkeys(tr_parts)),
                     })
 
         entries.append({

--- a/tools/generators/settings_qml/model.py
+++ b/tools/generators/settings_qml/model.py
@@ -8,8 +8,7 @@ from dataclasses import dataclass, field
 from pathlib import Path  # noqa: TC003
 
 from ..common.controls import (
-    ButtonDef,
-    EnableCheckboxDef,
+    BaseControlDef,
     parse_button,
     parse_enable_checkbox,
 )
@@ -19,18 +18,10 @@ _TRANSLATED_LIST_RE = re.compile("[,，、]")
 
 
 @dataclass
-class ControlDef:
+class ControlDef(BaseControlDef):
     """A single control referencing a setting."""
-    setting: str
-    label: str = ""
-    control: str = ""
-    showWhen: str = ""
-    enableWhen: str = ""
     placeholder: str = ""
     value: str = ""
-    component: str = ""
-    enableCheckbox: EnableCheckboxDef | None = None
-    button: ButtonDef | None = None
 
     @property
     def settings_group(self) -> str:

--- a/tools/tests/test_common_import_isolation.py
+++ b/tools/tests/test_common_import_isolation.py
@@ -1,0 +1,54 @@
+"""Regression guard: the `common` facade must not eagerly import submodules.
+
+CI setup scripts run on system Python (pre-venv, possibly 3.10) and under
+sparse checkouts that contain only a subset of `tools/common/*.py`. Importing
+one submodule must therefore NOT drag in siblings — otherwise a missing file
+(ModuleNotFoundError) or a newer-Python-only feature in an unrelated submodule
+(e.g. `enum.StrEnum` in common.logging) breaks scripts that never used it.
+"""
+
+from __future__ import annotations
+
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+TOOLS_DIR = Path(__file__).resolve().parents[1]
+
+CI_CRITICAL_SUBMODULES = [
+    "gh_actions",
+    "build_config",
+    "git",
+    "proc",
+    "github_runs",
+    "env",
+    "format",
+    "io",
+    "tool_version",
+]
+
+
+def _loaded_common_submodules(import_stmt: str) -> set[str]:
+    code = (
+        "import sys\n"
+        f"sys.path.insert(0, {str(TOOLS_DIR)!r})\n"
+        f"{import_stmt}\n"
+        "print(chr(10).join(m for m in sys.modules if m.startswith('common.')))\n"
+    )
+    out = subprocess.run([sys.executable, "-c", code], capture_output=True, text=True, check=True)
+    return {line.strip() for line in out.stdout.splitlines() if line.strip()}
+
+
+def test_importing_package_loads_no_submodules():
+    assert _loaded_common_submodules("import common") == set()
+
+
+@pytest.mark.parametrize("sub", CI_CRITICAL_SUBMODULES)
+def test_submodule_import_does_not_pull_logging(sub):
+    loaded = _loaded_common_submodules(f"import common.{sub}")
+    assert "common.logging" not in loaded, (
+        f"importing common.{sub} transitively loaded common.logging "
+        f"(StrEnum/3.11+); setup scripts on system Python would break"
+    )

--- a/tools/tests/test_gh_actions.py
+++ b/tools/tests/test_gh_actions.py
@@ -8,7 +8,6 @@ import os
 import subprocess
 from unittest.mock import patch
 
-import httpx
 from common import gh_actions as mod
 
 
@@ -16,102 +15,43 @@ def _cp(stdout: str = "", stderr: str = "", returncode: int = 0) -> subprocess.C
     return subprocess.CompletedProcess(args=["gh"], returncode=returncode, stdout=stdout, stderr=stderr)
 
 
-def _mock_response(
-    data: dict,
-    next_url: str = "",
-    status_code: int = 200,
-    extra_headers: dict[str, str] | None = None,
-) -> httpx.Response:
-    headers = {}
-    if next_url:
-        headers["link"] = f'<{next_url}>; rel="next"'
-    if extra_headers:
-        headers.update(extra_headers)
-    request = httpx.Request("GET", "https://api.github.com/test")
-    resp = httpx.Response(status_code, json=data, headers=headers, request=request)
-    return resp
-
-
-def test_parse_json_documents_handles_paginated_stream() -> None:
-    payload = (
-        json.dumps({"workflow_runs": [{"id": 1}]})
-        + "\n"
-        + json.dumps({"workflow_runs": [{"id": 2}]})
-    )
-    docs = mod.parse_json_documents(payload)
-    assert [doc["workflow_runs"][0]["id"] for doc in docs] == [1, 2]
-
-
-def test_parse_json_documents_raises_on_invalid_json() -> None:
-    payload = '{"workflow_runs":[{"id":1}]}\nnot-json'
-    try:
-        mod.parse_json_documents(payload)
-    except ValueError as exc:
-        assert "Failed to parse GitHub API JSON output near:" in str(exc)
-    else:
-        raise AssertionError("Expected ValueError for invalid JSON stream")
-
-
-def test_list_workflow_runs_for_sha_uses_get_method() -> None:
-    payload = json.dumps({"workflow_runs": [{"id": 1, "name": "Linux"}]})
-    with patch.dict(os.environ, {"QGC_GH_API_MODE": "gh"}, clear=False), \
-         patch.object(mod, "gh", return_value=_cp(stdout=payload)) as gh_mock:
+def test_list_workflow_runs_for_sha_uses_jq_get_method() -> None:
+    payload = json.dumps({"id": 1, "name": "Linux"})
+    with patch.object(mod, "gh", return_value=_cp(stdout=payload)) as gh_mock:
         runs = mod.list_workflow_runs_for_sha("owner/repo", "abc123")
 
     assert runs == [{"id": 1, "name": "Linux"}]
     called_args = gh_mock.call_args[0]
     assert "--method" in called_args
     assert "GET" in called_args
+    assert ".workflow_runs[]?" in called_args
 
 
-def test_list_workflow_runs_for_sha_http_mode() -> None:
-    first = _mock_response(
-        {"workflow_runs": [{"id": 1, "name": "Linux"}]},
-        next_url="https://api.github.com/next",
+def test_list_workflow_runs_for_sha_unpacks_ndjson_stream() -> None:
+    payload = (
+        json.dumps({"id": 1, "name": "Linux"})
+        + "\n"
+        + json.dumps({"id": 2, "name": "Windows"})
     )
-    second = _mock_response({"workflow_runs": [{"id": 2, "name": "Windows"}]})
-
-    with patch.dict(os.environ, {"QGC_GH_API_MODE": "http", "GH_TOKEN": "token"}, clear=False), \
-         patch.object(mod, "_build_http_client") as mock_client:
-        client = mock_client.return_value.__enter__.return_value
-        client.get.side_effect = [first, second]
-        with patch.object(mod, "gh") as gh_mock:
-            runs = mod.list_workflow_runs_for_sha("owner/repo", "abc123")
+    with patch.object(mod, "gh", return_value=_cp(stdout=payload)) as gh_mock:
+        runs = mod.list_workflow_runs_for_sha("owner/repo", "abc123")
 
     assert [run["id"] for run in runs] == [1, 2]
-    gh_mock.assert_not_called()
+    gh_mock.assert_called_once()
 
 
-def test_list_workflow_runs_for_sha_http_mode_retries_retryable_status() -> None:
-    first = _mock_response(
-        {"message": "try again"},
-        status_code=503,
-        extra_headers={"Retry-After": "0"},
-    )
-    second = _mock_response({"workflow_runs": [{"id": 7, "name": "Linux"}]})
-
-    with patch.dict(os.environ, {"QGC_GH_API_MODE": "http", "GH_TOKEN": "token"}, clear=False), \
-         patch.object(mod, "_build_http_client") as mock_client:
-        client = mock_client.return_value.__enter__.return_value
-        client.get.side_effect = [first, second]
-        with patch.object(mod.time, "sleep") as sleep_mock:
-            runs = mod.list_workflow_runs_for_sha("owner/repo", "abc123")
-
-    assert runs == [{"id": 7, "name": "Linux"}]
-    assert client.get.call_count == 2
-    sleep_mock.assert_called_once_with(1.0)
-
-
-def test_list_run_artifacts_parses_paginated_stream() -> None:
+def test_list_run_artifacts_parses_ndjson_stream() -> None:
     payload = (
-        json.dumps({"artifacts": [{"name": "QGroundControl", "size_in_bytes": 1}]})
+        json.dumps({"name": "QGroundControl", "size_in_bytes": 1})
         + "\n"
-        + json.dumps({"artifacts": [{"name": "QGroundControl2", "size_in_bytes": 2}]})
+        + json.dumps({"name": "QGroundControl2", "size_in_bytes": 2})
     )
     with patch.object(mod, "gh", return_value=_cp(stdout=payload)) as gh_mock:
         artifacts = mod.list_run_artifacts("owner/repo", 77)
 
     assert [a["name"] for a in artifacts] == ["QGroundControl", "QGroundControl2"]
+    called_args = gh_mock.call_args[0]
+    assert ".artifacts[]?" in called_args
     gh_mock.assert_called_once()
 
 


### PR DESCRIPTION
## Problem

The repo's 10 GB GitHub Actions cache quota was fully consumed by auxiliary caches (qt-install ~6.2 GB, android-avd ~1.76 GB, apt ~1.65 GB, gradle ~1 GB, …), so **ccache and cpm-modules — the actual build caches — were being LRU-evicted on every overflow** and never survived between runs.

## Change

Disable the non-critical caches so the build caches survive:

| Cache | Mechanism |
|-------|-----------|
| gradle | `setup-gradle` → `cache-disabled: true` |
| apt packages | drop `cache-apt-pkgs-action`, plain `apt-get install` (install-dependencies, build-gstreamer, analysis, doxygen) |
| setup-uv | `enable-cache: false` |
| iOS Qt install (~4 GB) | skip save for `ios` target (biggest single object, least-frequent build) |
| binfmt/qemu image | `cache-image: false` |
| pip/pipx, npm | remove cache steps (setup-node + docs `~/.npm`) |
| pre-commit hooks, lychee | remove restore/save steps |
| Android NDK, GStreamer (Win+macOS) | remove restore/save steps |

## Kept

- **ccache / cpm-modules** — the build caches we're protecting
- **qt-install** desktop/android (~2.2 GB) and **android-avd** (~1.76 GB) — high re-download/boot cost
- KB-scale size/coverage baselines (CI state, self-overwriting)

Frees ~6.7 GB of the 10 GB cap. Auxiliary jobs now reinstall from network instead of cache; build jobs keep their ccache.