### PR TITLE
test: add APMVehicleConfigUITest for ArduCopter/Plane/Rover MockLinks

### DIFF
--- a/src/FactSystem/FactMetaData.cc
+++ b/src/FactSystem/FactMetaData.cc
@@ -144,6 +144,12 @@ void FactMetaData::setRawDefaultValue(const QVariant &rawDefaultValue)
     }
 }
 
+void FactMetaData::setRawDefaultValueFirmwareForce(const QVariant &rawDefaultValue)
+{
+    _rawDefaultValue = rawDefaultValue;
+    _defaultValueAvailable = true;
+}
+
 void FactMetaData::setRawMin(const QVariant &rawMin)
 {
     if (isInRawMinLimit(rawMin)) {

--- a/src/FactSystem/FactMetaData.h
+++ b/src/FactSystem/FactMetaData.h
@@ -167,6 +167,14 @@ public:
 
     void setDecimalPlaces(int decimalPlaces) { _decimalPlaces = decimalPlaces; }
     void setRawDefaultValue(const QVariant &rawDefaultValue);
+
+    /// Use when the default value comes from authoritative firmware data
+    /// (e.g. ArduPilot FTP parameter file). Sets the default unconditionally
+    /// without range validation — firmware may legitimately use values outside
+    /// the metadata operating range (e.g. 0 as a "disabled" sentinel).
+    /// Do NOT use for user-supplied or QGC-settings defaults.
+    void setRawDefaultValueFirmwareForce(const QVariant &rawDefaultValue);
+
     void setBitmaskInfo(const QStringList &strings, const QVariantList &values);
     void setEnumInfo(const QStringList &strings, const QVariantList &values);
     void setCategory(const QString &category) { _category = category; }

--- a/src/FactSystem/ParameterManager.cc
+++ b/src/FactSystem/ParameterManager.cc
@@ -1736,7 +1736,10 @@ bool ParameterManager::_parseParamFile(const QString& filename)
         if (_mapCompId2FactMap.contains(componentId) && _mapCompId2FactMap[componentId].contains(parameterName)) {
             fact = _mapCompId2FactMap[componentId][parameterName];
             if (withdefault && defaultValue.isValid()) {
-                fact->metaData()->setRawDefaultValue(defaultValue);
+                // Firmware-provided defaults are authoritative: use the unchecked
+                // setter so parameters that legitimately default to 0 ("disabled")
+                // but have a metadata min > 0 don't produce false warnings.
+                fact->metaData()->setRawDefaultValueFirmwareForce(defaultValue);
             }
         } else {
             qCDebug(ParameterManagerVerbose1Log) << _logVehiclePrefix(componentId) << "Adding new fact" << parameterName;
@@ -1752,7 +1755,7 @@ bool ParameterManager::_parseParamFile(const QString& filename)
 
             // Set default before emitting factAdded so QML sees defaultValueAvailable from the start
             if (withdefault && defaultValue.isValid()) {
-                fact->metaData()->setRawDefaultValue(defaultValue);
+                fact->metaData()->setRawDefaultValueFirmwareForce(defaultValue);
             }
 
             emit factAdded(componentId, fact);

--- a/src/FirmwarePlugin/APM/APMParameterMetaData.cc
+++ b/src/FirmwarePlugin/APM/APMParameterMetaData.cc
@@ -177,7 +177,23 @@ QList<ParameterMetaData::ValueDescPair> APMParameterMetaData::_sortedNumericPair
 
 void APMParameterMetaData::_applyEnumValues(FactMetaData *metaData, const QJsonObject &valuesObj)
 {
-    setEnumFromPairs(metaData, _sortedNumericPairs(valuesObj, metaData->name()));
+    QList<ValueDescPair> pairs = _sortedNumericPairs(valuesObj, metaData->name());
+
+    // ArduPilot JSON stores some int8 enum codes as unsigned values (e.g. 200 for
+    // BTN#_FUNCTION actuator functions added in Sub-4.5+). Reinterpret codes in
+    // [128..255] as their signed equivalent so convertAndValidateRaw passes and
+    // the correct bit pattern is sent back over MAVLink as INT8.
+    if (metaData->type() == FactMetaData::valueTypeInt8) {
+        for (auto &pair : pairs) {
+            bool ok = false;
+            const int code = pair.value.toInt(&ok);
+            if (ok && code >= 128 && code <= 255) {
+                pair.value = QString::number(code - 256);
+            }
+        }
+    }
+
+    setEnumFromPairs(metaData, pairs);
 }
 
 void APMParameterMetaData::_applyBitmask(FactMetaData *metaData, const QJsonObject &bitmaskObj)

--- a/src/FirmwarePlugin/ParameterMetaData.cc
+++ b/src/FirmwarePlugin/ParameterMetaData.cc
@@ -200,15 +200,49 @@ void ParameterMetaData::setBitmaskFromPairs(FactMetaData *metaData, const QList<
             continue;
         }
 
-        const QVariant rawValue = QVariant::fromValue(static_cast<quint64>(1ull << bitIndex));
+        const quint64 bits = 1ull << bitIndex;
+        const QVariant rawValue = QVariant::fromValue(bits);
         QVariant bitmaskValue;
         QString errorString;
-        if (metaData->convertAndValidateRaw(rawValue, false, bitmaskValue, errorString)) {
-            bitmaskValues << bitmaskValue;
-            bitmaskStrings << description;
-        } else {
-            qCWarning(ParameterMetaDataLog) << "Skipping invalid bitmask value for" << metaData->name() << "bit:" << bitIndex << "error:" << errorString;
+        if (!metaData->convertAndValidateRaw(rawValue, false, bitmaskValue, errorString)) {
+            // Firmware may declare a bitmask parameter as a signed integer type
+            // (e.g. int8) while still using the sign bit (bit 7 = 0x80).  The
+            // unsigned value 128 overflows int8, but the two's-complement signed
+            // representation -128 is valid and carries the same bit pattern.
+            // Only attempt reinterpretation for exactly the sign bit of the type;
+            // wider bit indices would truncate to 0 and silently produce a bogus entry.
+            QVariant signedRaw;
+            switch (metaData->type()) {
+            case FactMetaData::valueTypeInt8:
+                if (bitIndex == 7) {
+                    signedRaw = QVariant::fromValue(static_cast<qint8>(static_cast<quint8>(bits)));
+                }
+                break;
+            case FactMetaData::valueTypeInt16:
+                if (bitIndex == 15) {
+                    signedRaw = QVariant::fromValue(static_cast<qint16>(static_cast<quint16>(bits)));
+                }
+                break;
+            case FactMetaData::valueTypeInt32:
+                if (bitIndex == 31) {
+                    signedRaw = QVariant::fromValue(static_cast<qint32>(static_cast<quint32>(bits)));
+                }
+                break;
+            case FactMetaData::valueTypeInt64:
+                if (bitIndex == 63) {
+                    signedRaw = QVariant::fromValue(static_cast<qint64>(bits));
+                }
+                break;
+            default:
+                break;
+            }
+            if (!signedRaw.isValid() || !metaData->convertAndValidateRaw(signedRaw, false, bitmaskValue, errorString)) {
+                qCWarning(ParameterMetaDataLog) << "Skipping invalid bitmask value for" << metaData->name() << "bit:" << bitIndex << "error:" << errorString;
+                continue;
+            }
         }
+        bitmaskValues << bitmaskValue;
+        bitmaskStrings << description;
     }
 
     if (!bitmaskStrings.isEmpty()) {

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -359,3 +359,4 @@ add_qgc_test(VehicleLinkManagerTest LABELS Integration Vehicle RESOURCE_LOCK Moc
 add_subdirectory(QmlUITests)
 add_qgc_test(TopLevelViewsTest LABELS Integration TIMEOUT 120)
 add_qgc_test(PX4VehicleConfigUITest LABELS Integration TIMEOUT 180)
+add_qgc_test(APMVehicleConfigUITest LABELS Integration TIMEOUT 360)

--- a/test/QmlUITests/APMVehicleConfigUITest.cc
+++ b/test/QmlUITests/APMVehicleConfigUITest.cc
@@ -1,0 +1,141 @@
+#include "APMVehicleConfigUITest.h"
+
+#include <QtQuick/QQuickItem>
+#include <QtQuick/QQuickWindow>
+#include <QtTest/QSignalSpy>
+#include <QtTest/QTest>
+
+#include "MockLink.h"
+#include "MultiVehicleManager.h"
+#include "Vehicle.h"
+#include "VehicleComponent.h"
+
+#include <QtCore/QPointer>
+#include <QtCore/QScopeGuard>
+
+UT_REGISTER_TEST(APMVehicleConfigUITest, TestLabel::Integration)
+
+// ---------------------------------------------------------------------------
+// Shared implementation
+// ---------------------------------------------------------------------------
+
+void APMVehicleConfigUITest::_runNavigateVehicleConfig(
+    const std::function<MockLink *()> &factory, const QString &vehicleName)
+{
+    startUI();
+    if (QTest::currentTestFailed()) return;
+
+    ignoreAPMMockLinkWarnings();
+
+    // -------------------------------------------------------------------------
+    // Connect MockLink and wait for parameters to be ready
+    // -------------------------------------------------------------------------
+    Vehicle *vehicle = nullptr;
+    QPointer<MockLink> mockLink = connectMockLinkAndWaitReady(factory, vehicle);
+    if (!mockLink) return;
+
+    const auto cleanup = qScopeGuard([&] {
+        closeUIWindow();
+        if (mockLink) {
+            QSignalSpy spyDisconnect(MultiVehicleManager::instance(), &MultiVehicleManager::activeVehicleChanged);
+            mockLink->disconnect();
+            if (spyDisconnect.isValid()) {
+                (void)waitForSignal(spyDisconnect, 5000, QStringLiteral("activeVehicleChanged"));
+            }
+        }
+        destroyUIEngine();
+    });
+
+    // -------------------------------------------------------------------------
+    // Navigate to the Configure view
+    // -------------------------------------------------------------------------
+    QVERIFY2(clickButton(QStringLiteral("toolbar_qgcLogo")),
+             qPrintable(QStringLiteral("%1: Failed to click Q logo button").arg(vehicleName)));
+    QVERIFY2(findVisibleItem(_rootItem, QStringLiteral("toolbar_viewConfigure"), 2000),
+             qPrintable(QStringLiteral("%1: toolbar_viewConfigure button not found").arg(vehicleName)));
+    QVERIFY2(clickButton(QStringLiteral("toolbar_viewConfigure")),
+             qPrintable(QStringLiteral("%1: Failed to click Configure button").arg(vehicleName)));
+    QTest::qWait(_viewDelay);
+
+    QVERIFY2(findVisibleItem(_rootItem, QStringLiteral("vehicleConfig_root"), 3000),
+             qPrintable(QStringLiteral("%1: vehicleConfig_root not found after navigating to Configure").arg(vehicleName)));
+
+    // -------------------------------------------------------------------------
+    // Click Summary
+    // -------------------------------------------------------------------------
+    QVERIFY2(clickButton(QStringLiteral("vehicleConfig_summary")),
+             qPrintable(QStringLiteral("%1: Failed to click Summary button").arg(vehicleName)));
+    QTest::qWait(_viewDelay);
+
+    // -------------------------------------------------------------------------
+    // Click through each vehicle component
+    // -------------------------------------------------------------------------
+    const QVariantList components = vehicle->autopilotPlugin()->vehicleComponents();
+    QVERIFY2(!components.isEmpty(),
+             qPrintable(QStringLiteral("%1: No vehicle components found").arg(vehicleName)));
+
+    for (const QVariant &compVariant : components) {
+        auto *comp = compVariant.value<VehicleComponent *>();
+        if (!comp) {
+            continue;
+        }
+
+        // Match the objectName set in VehicleConfigView.qml:
+        // "vehicleConfig_comp_" + compName.replace(/ /g, "")
+        const QString cleanName  = QString(comp->name()).remove(QLatin1Char(' '));
+        const QString buttonName = QStringLiteral("vehicleConfig_comp_") + cleanName;
+
+        QQuickItem *btn = findVisibleItem(_rootItem, buttonName, 2000);
+        if (!btn) {
+            // Component may be hidden (e.g. optional peripheral not present) – skip silently
+            continue;
+        }
+
+        scrollIntoView(btn, QStringLiteral("vehicleConfig_sidebarFlickable"));
+
+        const QPointF center = btn->mapToScene(QPointF(btn->width() / 2, btn->height() / 2));
+        QTest::mouseClick(_window, Qt::LeftButton, Qt::NoModifier, center.toPoint());
+        QTest::qWait(_pageDelay);
+
+        QQuickItem *loader = findVisibleItem(_rootItem, QStringLiteral("vehicleConfig_panelLoader"), 2000);
+        QVERIFY2(loader,
+                 qPrintable(QStringLiteral("%1: vehicleConfig_panelLoader not found after clicking %2")
+                            .arg(vehicleName, comp->name())));
+        QVERIFY2(loader->property("item").value<QQuickItem *>() != nullptr,
+                 qPrintable(QStringLiteral("%1: Panel loader has no item after clicking %2")
+                            .arg(vehicleName, comp->name())));
+    }
+
+}
+
+// ---------------------------------------------------------------------------
+// Per-vehicle-type test slots
+// ---------------------------------------------------------------------------
+
+void APMVehicleConfigUITest::_testArduCopter()
+{
+    _runNavigateVehicleConfig(
+        [] { return MockLink::startAPMArduCopterMockLink(false, false, false); },
+        QStringLiteral("ArduCopter"));
+}
+
+void APMVehicleConfigUITest::_testArduPlane()
+{
+    _runNavigateVehicleConfig(
+        [] { return MockLink::startAPMArduPlaneMockLink(false, false, false); },
+        QStringLiteral("ArduPlane"));
+}
+
+void APMVehicleConfigUITest::_testArduSub()
+{
+    // TODO: APMTuningComponentSub.qml references parameters that don't exist in
+    // the Sub MockLink, causing null-fact TypeErrors. Needs investigation.
+    QSKIP("ArduSub Tuning page has parameter mismatches with MockLink – skipping pending fix");
+}
+
+void APMVehicleConfigUITest::_testArduRover()
+{
+    _runNavigateVehicleConfig(
+        [] { return MockLink::startAPMArduRoverMockLink(false, false, false); },
+        QStringLiteral("ArduRover"));
+}

--- a/test/QmlUITests/APMVehicleConfigUITest.h
+++ b/test/QmlUITests/APMVehicleConfigUITest.h
@@ -1,0 +1,30 @@
+#pragma once
+
+#include "QmlUITestBase.h"
+
+#include <functional>
+
+class MockLink;
+
+/// UI smoke test that boots the full QML UI with each ArduPilot MockLink
+/// vehicle type connected and navigates through all vehicle configuration pages.
+class APMVehicleConfigUITest : public QmlUITestBase
+{
+    Q_OBJECT
+
+public:
+    APMVehicleConfigUITest() = default;
+
+private slots:
+    void _testArduCopter();
+    void _testArduPlane();
+    void _testArduSub();
+    void _testArduRover();
+
+private:
+    /// Shared implementation: connect a MockLink via \a factory, navigate to
+    /// the Configure view, and click through every vehicle component.
+    /// \a vehicleName is used only in QVERIFY2 failure messages.
+    void _runNavigateVehicleConfig(const std::function<MockLink *()> &factory,
+                                   const QString &vehicleName);
+};

--- a/test/QmlUITests/CMakeLists.txt
+++ b/test/QmlUITests/CMakeLists.txt
@@ -10,6 +10,8 @@ target_sources(${CMAKE_PROJECT_NAME}
         ${CMAKE_CURRENT_SOURCE_DIR}/TopLevelViewsTest.h
         ${CMAKE_CURRENT_SOURCE_DIR}/PX4VehicleConfigUITest.cc
         ${CMAKE_CURRENT_SOURCE_DIR}/PX4VehicleConfigUITest.h
+        ${CMAKE_CURRENT_SOURCE_DIR}/APMVehicleConfigUITest.cc
+        ${CMAKE_CURRENT_SOURCE_DIR}/APMVehicleConfigUITest.h
 )
 
 target_include_directories(${CMAKE_PROJECT_NAME}

--- a/test/QmlUITests/PX4VehicleConfigUITest.cc
+++ b/test/QmlUITests/PX4VehicleConfigUITest.cc
@@ -9,6 +9,7 @@
 #include "MultiVehicleManager.h"
 
 #include <QtCore/QPointer>
+#include <QtCore/QScopeGuard>
 #include "Vehicle.h"
 #include "VehicleComponent.h"
 
@@ -26,6 +27,18 @@ void PX4VehicleConfigUITest::_testNavigateVehicleConfig()
     QPointer<MockLink> mockLink = connectMockLinkAndWaitReady(
         [] { return MockLink::startPX4MockLink(false, false, false); }, vehicle);
     if (!mockLink) return;
+
+    const auto cleanup = qScopeGuard([&] {
+        closeUIWindow();
+        if (mockLink) {
+            QSignalSpy spyDisconnect(MultiVehicleManager::instance(), &MultiVehicleManager::activeVehicleChanged);
+            mockLink->disconnect();
+            if (spyDisconnect.isValid()) {
+                (void)waitForSignal(spyDisconnect, 5000, QStringLiteral("activeVehicleChanged"));
+            }
+        }
+        destroyUIEngine();
+    });
 
     // -------------------------------------------------------------------------
     // Navigate to the Configure view
@@ -80,20 +93,6 @@ void PX4VehicleConfigUITest::_testNavigateVehicleConfig()
                  qPrintable(QStringLiteral("Panel loader has no item after clicking %1").arg(comp->name())));
     }
 
-    // -------------------------------------------------------------------------
-    // Clean up: close the window before disconnecting the MockLink so that QML
-    // bindings are torn down before the vehicle object is destroyed.
-    // -------------------------------------------------------------------------
-    closeUIWindow();
-
-    if (mockLink) {
-        QSignalSpy spyDisconnect(MultiVehicleManager::instance(), &MultiVehicleManager::activeVehicleChanged);
-        QVERIFY2(spyDisconnect.isValid(), "Failed to create spy for disconnect");
-        mockLink->disconnect();
-        (void)waitForSignal(spyDisconnect, 5000, QStringLiteral("activeVehicleChanged"));
-    }
-
-    destroyUIEngine();
 }
 
 // Cycle through the axis buttons on a PID tuning tab. Each click exercises

--- a/test/QmlUITests/QmlUITestBase.cc
+++ b/test/QmlUITests/QmlUITestBase.cc
@@ -80,6 +80,15 @@ void QmlUITestBase::startUI()
     _rootItem = _window->contentItem();
 }
 
+void QmlUITestBase::ignoreAPMMockLinkWarnings()
+{
+    // ArduPilot MockLink does not serve COMP_METADATA_TYPE_GENERAL.
+    ignoreLogMessage(
+        QRegularExpression(QStringLiteral("^ComponentInformation\\.RequestMetaDataTypeStateMachine$")),
+        QtWarningMsg,
+        QRegularExpression(QStringLiteral("\"COMP_METADATA_TYPE_GENERAL\" : failed to load metadata \\(primary and fallback\\) \"\"")));
+}
+
 void QmlUITestBase::closeUIWindow()
 {
     if (_window) {

--- a/test/QmlUITests/QmlUITestBase.h
+++ b/test/QmlUITests/QmlUITestBase.h
@@ -70,6 +70,10 @@ protected:
     /// \a item is already visible or if the flickable cannot be found.
     void scrollIntoView(QQuickItem *item, const QString &flickableObjectName);
 
+    /// Register ignores for known warnings produced by any ArduPilot MockLink
+    /// connection. Call once before connectMockLinkAndWaitReady().
+    void ignoreAPMMockLinkWarnings();
+
     /// Start a MockLink using \a factory, wait for the vehicle to connect and
     /// parameters to be fully loaded, then return the MockLink pointer and set
     /// \a vehicleOut to the active Vehicle.


### PR DESCRIPTION
Add integration tests that navigate the Vehicle Config UI for each ArduPilot vehicle type (Copter, Plane, Rover). ArduSub is skipped pending investigation of parameter mismatches on its Tuning page.

Fix APM metadata parsing bugs uncovered by strict log checking:

**`ParameterMetaData::setBitmaskFromPairs`**: when a bitmask parameter is declared with a signed integer type (e.g. int8), the unsigned bit value `1<<7 = 128` overflows. Fall back to a two's-complement signed reinterpretation so `EK2/EK3_GPS_CHECK` bit 7 is accepted without warnings.

**`APMParameterMetaData::_applyEnumValues`**: ArduPilot JSON stores some int8 enum codes in the unsigned range [128..255] (e.g. `BTN#_FUNCTION` Sub-4.5+ actuator functions). Reinterpret those codes as signed int8 so `convertAndValidateRaw` passes and `PARAM_SET` sends the correct `INT8` wire type.

**`FactMetaData::setRawDefaultValueFirmwareForce`**: new unchecked setter used by `ParameterManager` when applying firmware FTP defaults. Avoids false 'default outside range' warnings for parameters that use 0 as a 'disabled' sentinel but have a metadata `min > 0`.

**`QmlUITestBase::ignoreAPMMockLinkWarnings`**: suppress the expected `COMP_METADATA_TYPE_GENERAL` warning produced by all APM MockLinks (APM does not serve component metadata).

Tests verified passing: `_testArduCopter`, `_testArduPlane`, `_testArduRover`