### PR TITLE
fix: suppress critical vehicle message popup when vehicle messages panel is open

### DIFF
--- a/src/MainWindow/MainWindow.qml
+++ b/src/MainWindow/MainWindow.qml
@@ -202,6 +202,7 @@ ApplicationWindow {
     }
 
     property bool _forceClose: false
+    property bool suppressCriticalVehicleMessages: false
 
     function finishCloseProcess() {
         _forceClose = true
@@ -434,7 +435,9 @@ ApplicationWindow {
     //-- Critical Vehicle Message Popup
 
     function showCriticalVehicleMessage(message) {
-        closeIndicatorDrawer()
+        if (suppressCriticalVehicleMessages) {
+            return
+        }
         if (criticalVehicleMessagePopup.visible || QGroundControl.videoManager.fullScreen) {
             // We received additional warning message while an older warning message was still displayed.
             // When the user close the older one drop the message indicator tool so they can see the rest of them.

--- a/src/Toolbar/MainStatusIndicator.qml
+++ b/src/Toolbar/MainStatusIndicator.qml
@@ -160,7 +160,10 @@ RowLayout {
     Component {
         id: overallStatusOfflineIndicatorPage
 
-        MainStatusIndicatorOfflinePage { }
+        MainStatusIndicatorOfflinePage {
+            Component.onCompleted:   mainWindow.suppressCriticalVehicleMessages = true
+            Component.onDestruction: mainWindow.suppressCriticalVehicleMessages = false
+        }
     }
 
     Component {
@@ -172,6 +175,9 @@ RowLayout {
             expandedComponentWaitForParameters: true
             contentComponent:                   mainStatusContentComponent
             expandedComponent:                  mainStatusExpandedComponent
+
+            Component.onCompleted:   mainWindow.suppressCriticalVehicleMessages = true
+            Component.onDestruction: mainWindow.suppressCriticalVehicleMessages = false
         }
     }
 


### PR DESCRIPTION
## Summary

When the user opens the main status indicator panel (which displays all vehicle messages) to review errors during flight, incoming critical message popups would close the panel — making it impossible to read the list.

## Changes

- Added `suppressCriticalVehicleMessages` bool property to `MainWindow`
- `showCriticalVehicleMessage()` returns early when suppression is active
- Both indicator pages in `MainStatusIndicator.qml` set the flag on `Component.onCompleted` and clear it on `Component.onDestruction`, scoping suppression exactly to the panel lifetime
- The toolbar icon still changes color (orange/red) to signal new messages while the panel is open

Fixes #14464