### PR TITLE
test: ToolbarIndicatorUITest — FlyView toolbar indicator smoke test

### DIFF
--- a/src/Comms/MockLink/MockLink.cc
+++ b/src/Comms/MockLink/MockLink.cc
@@ -213,6 +213,10 @@ void MockLink::run1HzTasks()
         _mockLinkGimbal->run1HzTasks();
     }
 
+    _sendEscInfo();
+    _sendEscStatus();
+    _sendRadioStatus();
+
     if (_enableCamera) {
         _mockLinkCamera->sendCameraHeartbeats();
     }
@@ -246,7 +250,8 @@ void MockLink::run10HzTasks()
         if (_sendGPSPositionDelayCount > 0) {
             // We delay gps position for better testing
             _sendGPSPositionDelayCount--;
-        } else {
+        }
+        if (_sendGPSPositionDelayCount == 0 || QGC::runningUnitTests()) {
             if (_vehicleType != MAV_TYPE_SUBMARINE) {
                 _sendGpsRawInt();
                 _sendGlobalPositionInt();
@@ -2455,6 +2460,75 @@ void MockLink::_sendRemoteIDArmStatus()
         &msg,
         MAV_ODID_ARM_STATUS_GOOD_TO_ARM,
         armStatusError
+    );
+    respondWithMavlinkMessage(msg);
+}
+
+void MockLink::_sendEscInfo()
+{
+    // Send ESC_INFO for 4 motors starting at index 0.
+    // count=4 and info bitmask=0x0F (all 4 online) makes the ESC indicator visible.
+    static const uint16_t failureFlags[4] = {0, 0, 0, 0};
+    static const uint32_t errorCount[4]   = {0, 0, 0, 0};
+    static const int16_t  temperature[4]  = {3000, 3000, 3000, 3000}; // centidegrees
+
+    mavlink_message_t msg{};
+    (void) mavlink_msg_esc_info_pack_chan(
+        _vehicleSystemId,
+        _vehicleComponentId,
+        _outgoingMavlinkChannel,
+        &msg,
+        0,                              // index: first group starts at 0
+        static_cast<uint64_t>(_runningTime.elapsed()) * 1000, // time_usec
+        0,                              // counter
+        4,                              // count: 4 motors
+        ESC_CONNECTION_TYPE_DSHOT,      // connection_type
+        0x0F,                           // info: bitmask — motors 0-3 online
+        failureFlags,
+        errorCount,
+        temperature
+    );
+    respondWithMavlinkMessage(msg);
+}
+
+void MockLink::_sendEscStatus()
+{
+    static const int32_t rpm[4]     = {5000, 5000, 5000, 5000};
+    static const float   voltage[4] = {16.0f, 16.0f, 16.0f, 16.0f};
+    static const float   current[4] = {5.0f, 5.0f, 5.0f, 5.0f};
+
+    mavlink_message_t msg{};
+    (void) mavlink_msg_esc_status_pack_chan(
+        _vehicleSystemId,
+        _vehicleComponentId,
+        _outgoingMavlinkChannel,
+        &msg,
+        0,                              // index: first group
+        static_cast<uint64_t>(_runningTime.elapsed()) * 1000, // time_usec
+        rpm,
+        voltage,
+        current
+    );
+    respondWithMavlinkMessage(msg);
+}
+
+void MockLink::_sendRadioStatus()
+{
+    // Send a RADIO_STATUS message to make the TelemetryRSSI indicator visible.
+    // rssi=100 → int8_t(100) = 100 dBm (non-zero), which sets lrssi and triggers showIndicator.
+    mavlink_message_t msg{};
+    (void) mavlink_msg_radio_status_pack_chan(
+        _vehicleSystemId,
+        _vehicleComponentId,
+        _outgoingMavlinkChannel,
+        &msg,
+        100,    // rssi: local signal strength
+        100,    // remrssi: remote signal strength
+        50,     // txbuf: transmit buffer fill (%)
+        10,     // noise: local background noise
+        10,     // remnoise: remote background noise
+        0,      // rxerrors
+        0       // fixed
     );
     respondWithMavlinkMessage(msg);
 }

--- a/src/Comms/MockLink/MockLink.cc
+++ b/src/Comms/MockLink/MockLink.cc
@@ -247,11 +247,12 @@ void MockLink::run10HzTasks()
 
     if (_mavlinkStarted && _connected && mavlinkChannelIsSet()) {
         _sendHeartBeat();
+        const bool gpsDelayExpired = (_sendGPSPositionDelayCount == 0);
         if (_sendGPSPositionDelayCount > 0) {
             // We delay gps position for better testing
             _sendGPSPositionDelayCount--;
         }
-        if (_sendGPSPositionDelayCount == 0 || QGC::runningUnitTests()) {
+        if (gpsDelayExpired || QGC::runningUnitTests()) {
             if (_vehicleType != MAV_TYPE_SUBMARINE) {
                 _sendGpsRawInt();
                 _sendGlobalPositionInt();
@@ -2515,7 +2516,7 @@ void MockLink::_sendEscStatus()
 void MockLink::_sendRadioStatus()
 {
     // Send a RADIO_STATUS message to make the TelemetryRSSI indicator visible.
-    // rssi=100 → int8_t(100) = 100 dBm (non-zero), which sets lrssi and triggers showIndicator.
+    // Any non-zero rssi value triggers showIndicator (TelemetryRSSIIndicator checks lrssi.rawValue != 0).
     mavlink_message_t msg{};
     (void) mavlink_msg_radio_status_pack_chan(
         _vehicleSystemId,

--- a/src/Comms/MockLink/MockLink.h
+++ b/src/Comms/MockLink/MockLink.h
@@ -241,6 +241,9 @@ private:
     void _sendADSBVehicles();
     void _sendGeneralMetaData();
     void _sendRemoteIDArmStatus();
+    void _sendEscInfo();
+    void _sendEscStatus();
+    void _sendRadioStatus();
     void _sendAvailableModesMonitor();
     void _sendAttitudeQuaternion();
     void _sendAttitudeTarget();

--- a/src/Comms/MockLink/MockLinkGimbal.cc
+++ b/src/Comms/MockLink/MockLinkGimbal.cc
@@ -78,32 +78,32 @@ bool MockLinkGimbal::handleMavlinkMessage(const mavlink_message_t &msg)
     switch (request.command) {
     case MAV_CMD_SET_MESSAGE_INTERVAL:
         if (_handleSetMessageInterval(request)) {
-            _sendCommandAck(request.command, MAV_RESULT_ACCEPTED);
+            _sendCommandAck(request.command, MAV_RESULT_ACCEPTED, request.target_component);
             return true;
         }
         return false;
 
     case MAV_CMD_REQUEST_MESSAGE:
         if (_handleRequestMessage(request)) {
-            _sendCommandAck(request.command, MAV_RESULT_ACCEPTED);
+            _sendCommandAck(request.command, MAV_RESULT_ACCEPTED, request.target_component);
             return true;
         }
         return false;
 
     case MAV_CMD_DO_GIMBAL_MANAGER_PITCHYAW:
         if (_handleGimbalManagerPitchYaw(request)) {
-            _sendCommandAck(request.command, MAV_RESULT_ACCEPTED);
+            _sendCommandAck(request.command, MAV_RESULT_ACCEPTED, request.target_component);
             return true;
         }
-        _sendCommandAck(request.command, MAV_RESULT_DENIED);
+        _sendCommandAck(request.command, MAV_RESULT_DENIED, request.target_component);
         return true;
 
     case MAV_CMD_DO_GIMBAL_MANAGER_CONFIGURE:
         if (_handleGimbalManagerConfigure(request)) {
-            _sendCommandAck(request.command, MAV_RESULT_ACCEPTED);
+            _sendCommandAck(request.command, MAV_RESULT_ACCEPTED, request.target_component);
             return true;
         }
-        _sendCommandAck(request.command, MAV_RESULT_DENIED);
+        _sendCommandAck(request.command, MAV_RESULT_DENIED, request.target_component);
         return true;
 
     default:
@@ -111,7 +111,7 @@ bool MockLinkGimbal::handleMavlinkMessage(const mavlink_message_t &msg)
     }
 }
 
-void MockLinkGimbal::_sendCommandAck(uint16_t command, uint8_t result)
+void MockLinkGimbal::_sendCommandAck(uint16_t command, uint8_t result, uint8_t sourceCompId)
 {
     QString commandName = MissionCommandTree::instance()->rawName(static_cast<MAV_CMD>(command));
     qCDebug(MockLinkGimbalLog) << "Sending command ACK -" << QString("%1(%2)").arg(commandName).arg(command) << "result:" << (result == MAV_RESULT_ACCEPTED ? "ACCEPTED" : result == MAV_RESULT_DENIED ? "DENIED" : QString::number(result));
@@ -119,7 +119,7 @@ void MockLinkGimbal::_sendCommandAck(uint16_t command, uint8_t result)
     mavlink_message_t msg{};
     (void) mavlink_msg_command_ack_pack_chan(
         _mockLink->vehicleId(),
-        MAV_COMP_ID_AUTOPILOT1,
+        sourceCompId,
         _mockLink->mavlinkChannel(),
         &msg,
         command,

--- a/src/Comms/MockLink/MockLinkGimbal.h
+++ b/src/Comms/MockLink/MockLinkGimbal.h
@@ -61,7 +61,7 @@ private:
     void _sendGimbalManagerStatus();
     void _sendGimbalDeviceAttitudeStatus();
     void _sendGimbalManagerInformation();
-    void _sendCommandAck(uint16_t command, uint8_t result);
+    void _sendCommandAck(uint16_t command, uint8_t result, uint8_t sourceCompId);
 
     static constexpr uint8_t kGimbalCompId = MAV_COMP_ID_GIMBAL;
     static constexpr int kDefaultIntervalUs = 1000000; // 1 Hz default

--- a/src/MainWindow/MainWindow.qml
+++ b/src/MainWindow/MainWindow.qml
@@ -600,6 +600,7 @@ ApplicationWindow {
             }
 
             Rectangle {
+                objectName:                 "indicatorDrawerExpandButton"
                 anchors.horizontalCenter:   backgroundRect.right
                 anchors.verticalCenter:     backgroundRect.top
                 width:                      ScreenTools.largeFontPixelHeight
@@ -630,7 +631,8 @@ ApplicationWindow {
             contentHeight:  indicatorDrawerLoader.height
 
             Loader {
-                id: indicatorDrawerLoader
+                id:         indicatorDrawerLoader
+                objectName: "indicatorDrawerLoader"
 
                 Binding {
                     target:     indicatorDrawerLoader.item

--- a/src/QmlControls/ToolIndicatorPage.qml
+++ b/src/QmlControls/ToolIndicatorPage.qml
@@ -59,6 +59,7 @@ RowLayout {
 
     Loader {
         id:                     expandedItemLoader
+        objectName:             "indicatorExpandedLoader"
         Layout.alignment:       Qt.AlignTop
         Layout.preferredWidth:  visible ? -1 : 0
         visible:                expanded && _expandedParametersReady

--- a/src/Toolbar/BatteryIndicator.qml
+++ b/src/Toolbar/BatteryIndicator.qml
@@ -9,6 +9,7 @@ import QGroundControl.FactControls
 //-- Battery Indicator
 Item {
     id:             control
+    objectName:     "toolbar_batteryIndicator"
     anchors.top:    parent.top
     anchors.bottom: parent.bottom
     width:          batteryIndicatorRow.width

--- a/src/Toolbar/EscIndicator.qml
+++ b/src/Toolbar/EscIndicator.qml
@@ -6,6 +6,7 @@ import QGroundControl.Controls
 
 Item {
     id:             control
+    objectName:     "toolbar_escIndicator"
     anchors.top:    parent.top
     anchors.bottom: parent.bottom
     width:          escIndicatorRow.width

--- a/src/Toolbar/FlyViewToolBar.qml
+++ b/src/Toolbar/FlyViewToolBar.qml
@@ -85,6 +85,7 @@ Item {
 
                         MainStatusIndicator {
                             id:                 mainStatusIndicator
+                            objectName:         "toolbar_mainStatusIndicator"
                             Layout.fillHeight:  true
                         }
                     }
@@ -97,6 +98,7 @@ Item {
                     }
 
                     FlightModeIndicator {
+                        objectName:         "toolbar_flightModeIndicator"
                         Layout.fillHeight:  true
                         visible:            _activeVehicle
                     }

--- a/src/Toolbar/FlyViewToolBarIndicators.qml
+++ b/src/Toolbar/FlyViewToolBarIndicators.qml
@@ -5,6 +5,7 @@ import QGroundControl.Controls
 import QGroundControl.Toolbar
 
 Item {
+    objectName:    "flyViewToolBarIndicators"
     implicitWidth: mainLayout.width + _widthMargin
 
     property var  _activeVehicle:           QGroundControl.multiVehicleManager.activeVehicle

--- a/src/Toolbar/GimbalIndicator.qml
+++ b/src/Toolbar/GimbalIndicator.qml
@@ -8,6 +8,7 @@ import QGroundControl.FactControls
 
 Item {
     id:             control
+    objectName:     "toolbar_gimbalIndicator"
     anchors.top:    parent.top
     anchors.bottom: parent.bottom
     width:          gimbalIndicatorRow.width

--- a/src/Toolbar/RemoteIDIndicator.qml
+++ b/src/Toolbar/RemoteIDIndicator.qml
@@ -8,6 +8,7 @@ import QGroundControl.Controls
 //-- Remote ID Indicator
 Item {
     id:             control
+    objectName:     "toolbar_remoteIDIndicator"
     width:          remoteIDIcon.width * 1.1
     anchors.top:    parent.top
     anchors.bottom: parent.bottom

--- a/src/Toolbar/TelemetryRSSIIndicator.qml
+++ b/src/Toolbar/TelemetryRSSIIndicator.qml
@@ -8,6 +8,7 @@ import QGroundControl.Controls
 //-- Telemetry RSSI
 Item {
     id:             control
+    objectName:     "toolbar_telemetryRSSIIndicator"
     anchors.top:    parent.top
     anchors.bottom: parent.bottom
     width:          telemIcon.width * 1.1

--- a/src/Toolbar/VehicleGPSIndicator.qml
+++ b/src/Toolbar/VehicleGPSIndicator.qml
@@ -5,6 +5,7 @@ import QGroundControl
 import QGroundControl.Controls
 
 GPSIndicator {
+    objectName:     "toolbar_gpsIndicator"
     property bool showIndicator: _activeVehicle.gps.telemetryAvailable
 
     property var _activeVehicle: QGroundControl.multiVehicleManager.activeVehicle

--- a/test/QmlUITests/APMVehicleConfigUITest.cc
+++ b/test/QmlUITests/APMVehicleConfigUITest.cc
@@ -2,16 +2,13 @@
 
 #include <QtQuick/QQuickItem>
 #include <QtQuick/QQuickWindow>
-#include <QtTest/QSignalSpy>
 #include <QtTest/QTest>
 
 #include "MockLink.h"
-#include "MultiVehicleManager.h"
 #include "Vehicle.h"
 #include "VehicleComponent.h"
 
 #include <QtCore/QPointer>
-#include <QtCore/QScopeGuard>
 
 UT_REGISTER_TEST(APMVehicleConfigUITest, TestLabel::Integration)
 
@@ -22,30 +19,7 @@ UT_REGISTER_TEST(APMVehicleConfigUITest, TestLabel::Integration)
 void APMVehicleConfigUITest::_runNavigateVehicleConfig(
     const std::function<MockLink *()> &factory, const QString &vehicleName)
 {
-    startUI();
-    if (QTest::currentTestFailed()) return;
-
-    ignoreAPMMockLinkWarnings();
-
-    // -------------------------------------------------------------------------
-    // Connect MockLink and wait for parameters to be ready
-    // -------------------------------------------------------------------------
-    Vehicle *vehicle = nullptr;
-    QPointer<MockLink> mockLink = connectMockLinkAndWaitReady(factory, vehicle);
-    if (!mockLink) return;
-
-    const auto cleanup = qScopeGuard([&] {
-        closeUIWindow();
-        if (mockLink) {
-            QSignalSpy spyDisconnect(MultiVehicleManager::instance(), &MultiVehicleManager::activeVehicleChanged);
-            mockLink->disconnect();
-            if (spyDisconnect.isValid()) {
-                (void)waitForSignal(spyDisconnect, 5000, QStringLiteral("activeVehicleChanged"));
-            }
-        }
-        destroyUIEngine();
-    });
-
+    runWithMockLink(factory, [&](QPointer<MockLink> /*mockLink*/, Vehicle *vehicle) {
     // -------------------------------------------------------------------------
     // Navigate to the Configure view
     // -------------------------------------------------------------------------
@@ -106,6 +80,7 @@ void APMVehicleConfigUITest::_runNavigateVehicleConfig(
                             .arg(vehicleName, comp->name())));
     }
 
+    });
 }
 
 // ---------------------------------------------------------------------------
@@ -114,6 +89,7 @@ void APMVehicleConfigUITest::_runNavigateVehicleConfig(
 
 void APMVehicleConfigUITest::_testArduCopter()
 {
+    ignoreAPMMockLinkWarnings();
     _runNavigateVehicleConfig(
         [] { return MockLink::startAPMArduCopterMockLink(false, false, false); },
         QStringLiteral("ArduCopter"));
@@ -121,6 +97,7 @@ void APMVehicleConfigUITest::_testArduCopter()
 
 void APMVehicleConfigUITest::_testArduPlane()
 {
+    ignoreAPMMockLinkWarnings();
     _runNavigateVehicleConfig(
         [] { return MockLink::startAPMArduPlaneMockLink(false, false, false); },
         QStringLiteral("ArduPlane"));
@@ -135,6 +112,7 @@ void APMVehicleConfigUITest::_testArduSub()
 
 void APMVehicleConfigUITest::_testArduRover()
 {
+    ignoreAPMMockLinkWarnings();
     _runNavigateVehicleConfig(
         [] { return MockLink::startAPMArduRoverMockLink(false, false, false); },
         QStringLiteral("ArduRover"));

--- a/test/QmlUITests/CMakeLists.txt
+++ b/test/QmlUITests/CMakeLists.txt
@@ -12,6 +12,8 @@ target_sources(${CMAKE_PROJECT_NAME}
         ${CMAKE_CURRENT_SOURCE_DIR}/PX4VehicleConfigUITest.h
         ${CMAKE_CURRENT_SOURCE_DIR}/APMVehicleConfigUITest.cc
         ${CMAKE_CURRENT_SOURCE_DIR}/APMVehicleConfigUITest.h
+        ${CMAKE_CURRENT_SOURCE_DIR}/ToolbarIndicatorUITest.cc
+        ${CMAKE_CURRENT_SOURCE_DIR}/ToolbarIndicatorUITest.h
 )
 
 target_include_directories(${CMAKE_PROJECT_NAME}
@@ -22,3 +24,4 @@ target_include_directories(${CMAKE_PROJECT_NAME}
 add_qgc_test(TopLevelViewsTest LABELS Integration NoSanitizer TIMEOUT 120)
 add_qgc_test(PX4VehicleConfigUITest LABELS Integration NoSanitizer TIMEOUT 180)
 add_qgc_test(APMVehicleConfigUITest LABELS Integration NoSanitizer TIMEOUT 360)
+add_qgc_test(ToolbarIndicatorUITest LABELS Integration NoSanitizer TIMEOUT 180)

--- a/test/QmlUITests/PX4VehicleConfigUITest.cc
+++ b/test/QmlUITests/PX4VehicleConfigUITest.cc
@@ -2,14 +2,11 @@
 
 #include <QtQuick/QQuickItem>
 #include <QtQuick/QQuickWindow>
-#include <QtTest/QSignalSpy>
 #include <QtTest/QTest>
 
 #include "MockLink.h"
-#include "MultiVehicleManager.h"
 
 #include <QtCore/QPointer>
-#include <QtCore/QScopeGuard>
 #include "Vehicle.h"
 #include "VehicleComponent.h"
 
@@ -17,29 +14,9 @@ UT_REGISTER_TEST(PX4VehicleConfigUITest, TestLabel::Integration)
 
 void PX4VehicleConfigUITest::_testNavigateVehicleConfig()
 {
-    startUI();
-    if (QTest::currentTestFailed()) return;
-
-    // -------------------------------------------------------------------------
-    // Connect PX4 MockLink and wait for parameters to be ready
-    // -------------------------------------------------------------------------
-    Vehicle *vehicle = nullptr;
-    QPointer<MockLink> mockLink = connectMockLinkAndWaitReady(
-        [] { return MockLink::startPX4MockLink(false, false, false); }, vehicle);
-    if (!mockLink) return;
-
-    const auto cleanup = qScopeGuard([&] {
-        closeUIWindow();
-        if (mockLink) {
-            QSignalSpy spyDisconnect(MultiVehicleManager::instance(), &MultiVehicleManager::activeVehicleChanged);
-            mockLink->disconnect();
-            if (spyDisconnect.isValid()) {
-                (void)waitForSignal(spyDisconnect, 5000, QStringLiteral("activeVehicleChanged"));
-            }
-        }
-        destroyUIEngine();
-    });
-
+    runWithMockLink(
+        [] { return MockLink::startPX4MockLink(false, false, false); },
+        [&](QPointer<MockLink> /*mockLink*/, Vehicle *vehicle) {
     // -------------------------------------------------------------------------
     // Navigate to the Configure view
     // -------------------------------------------------------------------------
@@ -93,6 +70,7 @@ void PX4VehicleConfigUITest::_testNavigateVehicleConfig()
                  qPrintable(QStringLiteral("Panel loader has no item after clicking %1").arg(comp->name())));
     }
 
+    });
 }
 
 // Cycle through the axis buttons on a PID tuning tab. Each click exercises
@@ -111,17 +89,9 @@ void PX4VehicleConfigUITest::_cycleAxisButtons(const QStringList &axisNames)
 
 void PX4VehicleConfigUITest::_testDisconnectWithPIDTuningOpen()
 {
-    startUI();
-    if (QTest::currentTestFailed()) return;
-
-    // -------------------------------------------------------------------------
-    // Connect PX4 MockLink and wait for parameters to be ready
-    // -------------------------------------------------------------------------
-    Vehicle *vehicle = nullptr;
-    QPointer<MockLink> mockLink = connectMockLinkAndWaitReady(
-        [] { return MockLink::startPX4MockLink(false, false, false); }, vehicle);
-    if (!mockLink) return;
-
+    runWithMockLink(
+        [] { return MockLink::startPX4MockLink(false, false, false); },
+        [&](QPointer<MockLink> /*mockLink*/, Vehicle * /*vehicle*/) {
     // -------------------------------------------------------------------------
     // Navigate to Configure view and open the PID Tuning sidebar page
     // -------------------------------------------------------------------------
@@ -186,14 +156,5 @@ void PX4VehicleConfigUITest::_testDisconnectWithPIDTuningOpen()
     _cycleAxisButtons({QStringLiteral("Horizontal"), QStringLiteral("Vertical"), QStringLiteral("Horizontal")});
     if (QTest::currentTestFailed()) return;
 
-    closeUIWindow();
-
-    if (mockLink) {
-        QSignalSpy spyDisconnect(MultiVehicleManager::instance(), &MultiVehicleManager::activeVehicleChanged);
-        QVERIFY2(spyDisconnect.isValid(), "Failed to create spy for disconnect");
-        mockLink->disconnect();
-        (void)waitForSignal(spyDisconnect, 5000, QStringLiteral("activeVehicleChanged"));
-    }
-
-    destroyUIEngine();
+    });
 }

--- a/test/QmlUITests/QmlUITestBase.cc
+++ b/test/QmlUITests/QmlUITestBase.cc
@@ -2,6 +2,7 @@
 
 #include <QtCore/QCoreApplication>
 #include <QtCore/QRegularExpression>
+#include <QtCore/QScopeGuard>
 #include <QtQml/QQmlApplicationEngine>
 #include <QtQuick/QQuickItem>
 #include <QtQuick/QQuickWindow>
@@ -164,6 +165,38 @@ void QmlUITestBase::scrollIntoView(QQuickItem *item, const QString &flickableObj
     QTest::qWait(50);
 }
 
+void QmlUITestBase::runWithMockLink(
+    const std::function<MockLink *()> &factory,
+    const std::function<void(QPointer<MockLink>, Vehicle *)> &body)
+{
+    startUI();
+    if (QTest::currentTestFailed()) return;
+
+    Vehicle *vehicle = nullptr;
+    QPointer<MockLink> mockLink = connectMockLinkAndWaitReady(factory, vehicle);
+    if (!mockLink) return;
+
+    const auto cleanup = qScopeGuard([&] {
+        disconnectMockLink(mockLink);
+        closeUIWindow();
+        destroyUIEngine();
+    });
+
+    body(mockLink, vehicle);
+}
+
+void QmlUITestBase::disconnectMockLink(QPointer<MockLink> mockLink)
+{
+    if (!mockLink) return;
+
+    QSignalSpy spyDisconnect(MultiVehicleManager::instance(),
+                             &MultiVehicleManager::activeVehicleChanged);
+    mockLink->disconnect();
+    if (spyDisconnect.isValid()) {
+        (void)waitForSignal(spyDisconnect, 5000, QStringLiteral("activeVehicleChanged"));
+    }
+}
+
 QPointer<MockLink> QmlUITestBase::connectMockLinkAndWaitReady(
     const std::function<MockLink *()> &factory,
     Vehicle *&vehicleOut)
@@ -182,45 +215,46 @@ QPointer<MockLink> QmlUITestBase::connectMockLinkAndWaitReady(
         return {};
     }
 
-    if (!waitForSignal(spyVehicle, 10000, QStringLiteral("activeVehicleChanged"))) {
-        QTest::qFail("Timeout waiting for vehicle connection", __FILE__, __LINE__);
+    // Helper: disconnect the MockLink and return {} so callers never receive a
+    // live link they cannot clean up (the caller's qScopeGuard is not yet active).
+    const auto failAndDisconnect = [&](const char *msg) -> QPointer<MockLink> {
+        QTest::qFail(msg, __FILE__, __LINE__);
+        mockLink->disconnect();
         return {};
+    };
+
+    if (!waitForSignal(spyVehicle, 10000, QStringLiteral("activeVehicleChanged"))) {
+        return failAndDisconnect("Timeout waiting for vehicle connection");
     }
 
     Vehicle *vehicle = MultiVehicleManager::instance()->activeVehicle();
     if (!vehicle) {
-        QTest::qFail("No active vehicle after MockLink connection", __FILE__, __LINE__);
-        return {};
+        return failAndDisconnect("No active vehicle after MockLink connection");
     }
 
     QSignalSpy spyConnect(vehicle, &Vehicle::initialConnectComplete);
     if (!spyConnect.isValid()) {
-        QTest::qFail("Failed to create spy for initialConnectComplete", __FILE__, __LINE__);
-        return {};
+        return failAndDisconnect("Failed to create spy for initialConnectComplete");
     }
     if (!vehicle->isInitialConnectComplete()) {
         if (!waitForSignal(spyConnect, 10000, QStringLiteral("initialConnectComplete"))) {
-            QTest::qFail("Timeout waiting for initial connect", __FILE__, __LINE__);
-            return {};
+            return failAndDisconnect("Timeout waiting for initial connect");
         }
     }
 
     QSignalSpy spyParamsReady(MultiVehicleManager::instance(),
                               &MultiVehicleManager::parameterReadyVehicleAvailableChanged);
     if (!spyParamsReady.isValid()) {
-        QTest::qFail("Failed to create spy for parameterReadyVehicleAvailableChanged", __FILE__, __LINE__);
-        return {};
+        return failAndDisconnect("Failed to create spy for parameterReadyVehicleAvailableChanged");
     }
     if (!MultiVehicleManager::instance()->parameterReadyVehicleAvailable()) {
         if (!waitForSignal(spyParamsReady, 15000,
                            QStringLiteral("parameterReadyVehicleAvailableChanged"))) {
-            QTest::qFail("Timeout waiting for parameters to be ready", __FILE__, __LINE__);
-            return {};
+            return failAndDisconnect("Timeout waiting for parameters to be ready");
         }
     }
     if (!MultiVehicleManager::instance()->parameterReadyVehicleAvailable()) {
-        QTest::qFail("Parameters should be ready after signal", __FILE__, __LINE__);
-        return {};
+        return failAndDisconnect("Parameters should be ready after signal");
     }
 
     vehicleOut = vehicle;

--- a/test/QmlUITests/QmlUITestBase.h
+++ b/test/QmlUITests/QmlUITestBase.h
@@ -49,7 +49,6 @@ protected:
     void startUI();
 
     /// Close the QML window and wait for it to settle.
-    /// Call this before any MockLink disconnect to avoid QML teardown null-dereferences.
     void closeUIWindow();
 
     /// Delete the QML engine and reset all pointers.
@@ -57,8 +56,9 @@ protected:
     void destroyUIEngine();
 
     /// Convenience: closeUIWindow() followed by destroyUIEngine().
-    /// Use closeUIWindow() + destroyUIEngine() separately when MockLink
-    /// teardown needs to happen between them.
+    /// When a MockLink is active, call mockLink->disconnect() first so the
+    /// window tears down with a null vehicle — this intentionally exposes
+    /// null-reference bugs in QML bindings.
     void stopUI();
 
     /// Click the visible QQuickItem with \a objectName in the current window.
@@ -70,6 +70,22 @@ protected:
     /// \a item is already visible or if the flickable cannot be found.
     void scrollIntoView(QQuickItem *item, const QString &flickableObjectName);
 
+    /// Convenience wrapper: boots the UI, connects a MockLink, runs \a body
+    /// with the active MockLink and Vehicle, then tears down in the correct
+    /// order (disconnect → closeUIWindow → destroyUIEngine).
+    ///
+    /// \a body may use QVERIFY2/QFAIL; on failure the lambda returns early and
+    /// teardown still runs via the scope guard.
+    void runWithMockLink(
+        const std::function<MockLink *()> &factory,
+        const std::function<void(QPointer<MockLink>, Vehicle *)> &body);
+
+    /// Disconnect a MockLink and wait for the active vehicle to clear.
+    /// Safe to call with a null pointer. Always call before closeUIWindow() so
+    /// QML handles a null vehicle while the window is still open, exposing
+    /// binding bugs.
+    void disconnectMockLink(QPointer<MockLink> mockLink);
+
     /// Register ignores for known warnings produced by any ArduPilot MockLink
     /// connection. Call once before connectMockLinkAndWaitReady().
     void ignoreAPMMockLinkWarnings();
@@ -79,8 +95,10 @@ protected:
     /// \a vehicleOut to the active Vehicle.
     ///
     /// Returns null and marks the test failed on any error — check the return
-    /// value before proceeding. The caller owns teardown: call closeUIWindow(),
-    /// mockLink->disconnect(), and destroyUIEngine() in that order.
+    /// value before proceeding. The caller owns teardown: call
+    /// mockLink->disconnect(), closeUIWindow(), and destroyUIEngine() in that
+    /// order — disconnecting first forces QML to handle a null vehicle while
+    /// the window is still open, exposing binding bugs.
     QPointer<MockLink> connectMockLinkAndWaitReady(
         const std::function<MockLink *()> &factory,
         Vehicle *&vehicleOut);

--- a/test/QmlUITests/ToolbarIndicatorUITest.cc
+++ b/test/QmlUITests/ToolbarIndicatorUITest.cc
@@ -1,0 +1,133 @@
+#include "ToolbarIndicatorUITest.h"
+
+#include <QtQuick/QQuickItem>
+#include <QtQuick/QQuickWindow>
+#include <QtTest/QTest>
+
+#include "MockLink.h"
+
+#include <QtCore/QPointer>
+
+UT_REGISTER_TEST(ToolbarIndicatorUITest, TestLabel::Integration)
+
+// ---------------------------------------------------------------------------
+// _exerciseIndicator
+// ---------------------------------------------------------------------------
+
+bool ToolbarIndicatorUITest::_exerciseIndicator(QQuickItem *indicatorItem, const QString &indicatorName, bool expectExpand)
+{
+    if (!indicatorItem || !_window) {
+        return false;
+    }
+
+    // 1. Click the indicator — verify the drawer opens
+    const QPointF indicatorCenter = indicatorItem->mapToScene(
+        QPointF(indicatorItem->width() / 2.0, indicatorItem->height() / 2.0));
+    QTest::mouseClick(_window, Qt::LeftButton, Qt::NoModifier, indicatorCenter.toPoint());
+
+    if (!findVisibleItem(_rootItem, QStringLiteral("indicatorDrawerLoader"), 2000)) {
+        qWarning() << indicatorName << ": drawer did not open after clicking indicator";
+        return false;
+    }
+
+    QTest::qWait(_pageDelay);
+
+    // 2. Expand — verify the expand button is present when expected, and that
+    //    expanded content appears after clicking it
+    if (expectExpand) {
+        QQuickItem *expandBtn = findVisibleItem(_rootItem, QStringLiteral("indicatorDrawerExpandButton"), 500);
+        if (!expandBtn) {
+            qWarning() << indicatorName << ": expand button not found but was expected";
+            return false;
+        }
+        const QPointF expandCenter = expandBtn->mapToScene(
+            QPointF(expandBtn->width() / 2.0, expandBtn->height() / 2.0));
+        QTest::mouseClick(_window, Qt::LeftButton, Qt::NoModifier, expandCenter.toPoint());
+        QTest::qWait(_pageDelay);
+
+        if (!findVisibleItem(_rootItem, QStringLiteral("indicatorExpandedLoader"), 2000)) {
+            qWarning() << indicatorName << ": expanded content did not appear after clicking expand button";
+            return false;
+        }
+    }
+
+    // 3. Close the drawer with Escape — verify it closes
+    QTest::keyClick(_window, Qt::Key_Escape);
+
+    const bool drawerClosed = waitForCondition(
+        [&] { return findVisibleItem(_rootItem, QStringLiteral("indicatorDrawerLoader"), 0) == nullptr; },
+        2000,
+        QStringLiteral("indicatorDrawerLoader hidden"));
+    if (!drawerClosed) {
+        qWarning() << indicatorName << ": drawer did not close after pressing Escape";
+        return false;
+    }
+
+    return true;
+}
+
+// ---------------------------------------------------------------------------
+// _runIndicatorTest
+// ---------------------------------------------------------------------------
+
+void ToolbarIndicatorUITest::_runIndicatorTest(
+    const std::function<MockLink *()> &factory,
+    const QString &vehicleName)
+{
+    runWithMockLink(factory, [&](QPointer<MockLink> /*mockLink*/, Vehicle * /*vehicle*/) {
+    // -------------------------------------------------------------------------
+    // Ensure we are on the Fly view (default after vehicle connects)
+    // -------------------------------------------------------------------------
+    QVERIFY2(findVisibleItem(_rootItem, QStringLiteral("mainView_fly"), 3000),
+             qPrintable(QStringLiteral("%1: Fly view not visible").arg(vehicleName)));
+
+    // -------------------------------------------------------------------------
+    // Table of indicators to exercise: { objectName, displayName, expectExpand }
+    // -------------------------------------------------------------------------
+    struct IndicatorSpec {
+        const char *objectName;
+        const char *displayName;
+        bool        expectExpand;
+    };
+    static const IndicatorSpec kIndicators[] = {
+        { "toolbar_mainStatusIndicator",    "MainStatus",   true  },
+        { "toolbar_flightModeIndicator",    "FlightMode",   true  },
+        { "toolbar_gpsIndicator",           "GPS",          true  },
+        { "toolbar_batteryIndicator",       "Battery",      true  },
+        { "toolbar_remoteIDIndicator",      "RemoteID",     true  },
+        { "toolbar_gimbalIndicator",        "Gimbal",       true  },
+        { "toolbar_escIndicator",           "ESC",          false },
+        { "toolbar_telemetryRSSIIndicator", "TelemetryRSSI",false },
+    };
+
+    for (const IndicatorSpec &spec : kIndicators) {
+        const QString objName     = QString::fromLatin1(spec.objectName);
+        const QString displayName = vehicleName + QLatin1Char('/') + QLatin1String(spec.displayName);
+
+        QQuickItem *item = findVisibleItem(_rootItem, objName, 2000);
+        QVERIFY2(item,
+                 qPrintable(QStringLiteral("%1: %2 not found in toolbar").arg(vehicleName, objName)));
+        QVERIFY2(_exerciseIndicator(item, displayName, spec.expectExpand),
+                 qPrintable(QStringLiteral("%1: exercise failed").arg(displayName)));
+    }
+    });
+}
+
+// ---------------------------------------------------------------------------
+// Per-vehicle-type test slots
+// ---------------------------------------------------------------------------
+
+void ToolbarIndicatorUITest::_testPX4Indicators()
+{
+    _runIndicatorTest(
+        [] { return MockLink::startPX4MockLink(false, false, true); },
+        QStringLiteral("PX4"));
+}
+
+void ToolbarIndicatorUITest::_testAPMCopterIndicators()
+{
+    ignoreAPMMockLinkWarnings();
+    _runIndicatorTest(
+        [] { return MockLink::startAPMArduCopterMockLink(false, false, true); },
+        QStringLiteral("APMCopter"));
+}

--- a/test/QmlUITests/ToolbarIndicatorUITest.h
+++ b/test/QmlUITests/ToolbarIndicatorUITest.h
@@ -1,0 +1,38 @@
+#pragma once
+
+#include "QmlUITestBase.h"
+
+#include <functional>
+
+class MockLink;
+
+/// UI smoke test that boots the full QML UI, connects each MockLink vehicle
+/// type, and exercises every toolbar indicator: opens the drop-down drawer,
+/// expands it when supported, then closes it by pressing Escape.
+///
+/// Covered vehicles:
+///   - PX4 generic (PX4MockLink)
+///   - ArduCopter (APM MockLink)
+class ToolbarIndicatorUITest : public QmlUITestBase
+{
+    Q_OBJECT
+
+public:
+    ToolbarIndicatorUITest() = default;
+
+private slots:
+    void _testPX4Indicators();
+    void _testAPMCopterIndicators();
+
+private:
+    /// Shared implementation: connect a MockLink via \a factory and cycle
+    /// through every visible toolbar indicator.
+    /// \a vehicleName is used only in QVERIFY2 failure messages.
+    void _runIndicatorTest(const std::function<MockLink *()> &factory,
+                           const QString &vehicleName);
+
+    /// Open the drawer for \a indicatorItem, verify it opens, expand it when
+    /// \a expectExpand is true (failing if the button is absent), then close
+    /// it with Escape.  Returns true on success.
+    bool _exerciseIndicator(QQuickItem *indicatorItem, const QString &indicatorName, bool expectExpand);
+};


### PR DESCRIPTION
## Summary

Adds `ToolbarIndicatorUITest`, a QML UI integration test that boots the full QML UI, connects each MockLink vehicle type, and exercises every visible FlyView toolbar indicator.

### What the test does

For each vehicle (PX4, APM Copter):
1. Connects a MockLink and waits for parameters to be ready
2. Verifies the Fly view is displayed
3. For each indicator: clicks it to open the drawer, expands it if the indicator supports expansion, then presses Escape to close

### Indicators covered

| Indicator | Expand | Notes |
|---|---|---|
| MainStatus | ✓ | |
| FlightMode | ✓ | |
| GPS | ✓ | Requires GPS delay bypass for unit tests |
| Battery | ✓ | |
| RemoteID | ✓ | |
| Gimbal | ✓ | Requires MockLink gimbal enabled |
| ESC | — | Added `_sendEscInfo`/`_sendEscStatus` to MockLink |
| TelemetryRSSI | — | Added `_sendRadioStatus` to MockLink |

### Production code changes

- Added `objectName` to each toolbar indicator root item and to the drawer/expand/expanded-content QML nodes
- Fixed `MockLinkGimbal::_sendCommandAck` to echo `request.target_component` as the ACK source compid instead of hardcoding `MAV_COMP_ID_AUTOPILOT1` — previously `MavCommandQueue` never matched the ACK and retried until timeout, producing strict-log failures
- GPS delay bypassed immediately when running unit tests via `QGC::runningUnitTests()`

### Test infrastructure changes

- Fixed `QmlUITestBase::connectMockLinkAndWaitReady()` to disconnect the MockLink on every post-factory failure path (previously a timeout left the link running in `LinkManager`)
- Added `ToolbarIndicatorUITest` to CTest with `LABELS Integration TIMEOUT 180`