### PR TITLE
fix(MissionManager): cap transect count at 1000; fix degenerate polygon crash

### DIFF
--- a/src/Comms/MockLink/MockLink.h
+++ b/src/Comms/MockLink/MockLink.h
@@ -309,7 +309,7 @@ private:
     MAV_BATTERY_CHARGE_STATE _battery2ChargeState = MAV_BATTERY_CHARGE_STATE_OK;
 
     double _vehicleAltitudeAMSL = _defaultVehicleHomeAltitude;
-    bool _commLost = false;
+    std::atomic<bool> _commLost = false;
     bool _signingEnabled = false;
     bool _highLatencyTransmissionEnabled = true;
 

--- a/src/MissionManager/CorridorScanComplexItem.cc
+++ b/src/MissionManager/CorridorScanComplexItem.cc
@@ -175,7 +175,11 @@ void CorridorScanComplexItem::setCoordinate(const QGeoCoordinate& coordinate)
 int CorridorScanComplexItem::_calcTransectCount(void) const
 {
     double fullWidth = _corridorWidthFact.rawValue().toDouble();
-    return fullWidth > 0.0 ? qCeil(fullWidth / _calcTransectSpacing()) : 1;
+    if (fullWidth <= 0.0) {
+        return 1;
+    }
+    const double spacing = _calcTransectSpacing();
+    return spacing > 0.0 ? qMin(qCeil(fullWidth / spacing), maxTransectCount) : 1;
 }
 
 void CorridorScanComplexItem::_polylineDirtyChanged(bool dirty)
@@ -403,11 +407,20 @@ double CorridorScanComplexItem::timeBetweenShots(void)
 double CorridorScanComplexItem::_calcTransectSpacing(void) const
 {
     double transectSpacing = _cameraCalc.adjustedFootprintSide()->rawValue().toDouble();
-    if (transectSpacing < _minimumTransectSpacingMeters) {
-        // We can't let spacing get too small otherwise we will end up with too many transects.
-        // So we limit the spacing to be above a small increment and below that value we set to huge spacing
-        // which will cause a single transect to be added instead of having things blow up.
-        transectSpacing = _forceLargeTransectSpacingMeters;
+    if (transectSpacing <= 0) {
+        return 0;
+    }
+
+    // Cap spacing so the corridor never generates more than maxTransectCount transects.
+    // The relevant extent is the corridor width (transects run perpendicular to the path).
+    const double corridorWidth = _corridorWidthFact.rawValue().toDouble();
+    if (corridorWidth <= 0.0) {
+        qCWarning(CorridorScanComplexItemLog) << "Corridor width" << corridorWidth << "is invalid, skipping transect count cap";
+        return transectSpacing;
+    }
+    if (transectSpacing < corridorWidth / maxTransectCount) {
+        qCWarning(CorridorScanComplexItemLog) << "Transect spacing" << transectSpacing << "raised to" << corridorWidth / maxTransectCount << "to limit transect count to" << maxTransectCount;
+        transectSpacing = corridorWidth / maxTransectCount;
     }
 
     return transectSpacing;

--- a/src/MissionManager/SurveyComplexItem.cc
+++ b/src/MissionManager/SurveyComplexItem.cc
@@ -552,7 +552,6 @@ void SurveyComplexItem::_intersectLinesWithPolygon(const QList<QLineF>& lineList
             for (int intersectionIndex=0; intersectionIndex<intersections.count(); intersectionIndex++) {
                 for (int compareIndex=0; compareIndex<intersections.count(); compareIndex++) {
                     QLineF lineTest(intersections[intersectionIndex], intersections[compareIndex]);
-                    \
                     double newMaxDistance = lineTest.length();
                     if (newMaxDistance > currentMaxDistance) {
                         firstPoint = intersections[intersectionIndex];
@@ -669,12 +668,6 @@ void SurveyComplexItem::_rebuildTransectsPhase1WorkerSinglePolygon(bool refly)
 
     double gridAngle = _gridAngleFact.rawValue().toDouble();
     double gridSpacing = _cameraCalc.adjustedFootprintSide()->rawValue().toDouble();
-    if (gridSpacing < _minimumTransectSpacingMeters) {
-        // We can't let spacing get too small otherwise we will end up with too many transects.
-        // So we limit the spacing to be above a small increment and below that value we set to huge spacing
-        // which will cause a single transect to be added instead of having things blow up.
-        gridSpacing = _forceLargeTransectSpacingMeters;
-    }
 
     gridAngle = _clampGridAngle90(gridAngle);
     gridAngle += refly ? 90 : 0;
@@ -700,19 +693,43 @@ void SurveyComplexItem::_rebuildTransectsPhase1WorkerSinglePolygon(bool refly)
 
     QList<QLineF> lineList;
 
-    // Transects are generated to be as long as the largest width/height of the bounding rect plus some fudge factor.
-    // This way they will always be guaranteed to intersect with a polygon edge no matter what angle they are rotated to.
-    // They are initially generated with the transects flowing from west to east and then points within the transect north to south.
-    double maxWidth = qMax(boundingRect.width(), boundingRect.height()) + 2000.0;
-    double halfWidth = maxWidth / 2.0;
-    double transectX = boundingCenter.x() - halfWidth;
-    double transectXMax = transectX + maxWidth;
-    while (transectX < transectXMax) {
-        double transectYTop = boundingCenter.y() - halfWidth;
-        double transectYBottom = boundingCenter.y() + halfWidth;
+    // Sweep lines must extend beyond the polygon boundary regardless of grid angle.
+    // The worst case is when the polygon is rotated 45° relative to the sweep direction,
+    // where the required reach equals half the diagonal of the bounding rect.
+    // We use diagonal * 1.5 to provide a 50% safety margin beyond that worst case.
+    // Note: the old fixed +2000m was insufficient for polygons larger than ~10km.
+    const double diagonal = qSqrt(boundingRect.width() * boundingRect.width() + boundingRect.height() * boundingRect.height());
+    double maxWidth = diagonal * 1.5;
+    if (maxWidth <= 0.0) {
+        qCWarning(SurveyComplexItemLog) << "Degenerate polygon bounding rect (all vertices coincident or collinear), aborting transect rebuild";
+        return;
+    }
 
-        lineList += QLineF(_rotatePoint(QPointF(transectX, transectYTop), boundingCenter, gridAngle), _rotatePoint(QPointF(transectX, transectYBottom), boundingCenter, gridAngle));
-        transectX += gridSpacing;
+    if (gridSpacing <= 0) {
+        // Invalid spacing: seed one center line so the < 2 fallback produces a single center transect.
+        qCWarning(SurveyComplexItemLog) << "Grid spacing" << gridSpacing << "is invalid, falling back to single center transect";
+        const double halfW = maxWidth / 2.0;
+        lineList += QLineF(
+            _rotatePoint(QPointF(boundingCenter.x(), boundingCenter.y() - halfW), boundingCenter, gridAngle),
+            _rotatePoint(QPointF(boundingCenter.x(), boundingCenter.y() + halfW), boundingCenter, gridAngle));
+    } else {
+        // Cap spacing so the sweep never generates more than maxTransectCount transects.
+        // Uses diagonal (not maxWidth) so the count reflects actual polygon-crossing transects.
+        if (gridSpacing < diagonal / maxTransectCount) {
+            qCWarning(SurveyComplexItemLog) << "Transect spacing" << gridSpacing << "raised to" << diagonal / maxTransectCount << "to limit transect count to" << maxTransectCount;
+            gridSpacing = diagonal / maxTransectCount;
+        }
+
+        double halfWidth = maxWidth / 2.0;
+        double transectX = boundingCenter.x() - halfWidth;
+        double transectXMax = transectX + maxWidth;
+        while (transectX < transectXMax) {
+            double transectYTop = boundingCenter.y() - halfWidth;
+            double transectYBottom = boundingCenter.y() + halfWidth;
+
+            lineList += QLineF(_rotatePoint(QPointF(transectX, transectYTop), boundingCenter, gridAngle), _rotatePoint(QPointF(transectX, transectYBottom), boundingCenter, gridAngle));
+            transectX += gridSpacing;
+        }
     }
 
     // Now intersect the lines with the polygon
@@ -845,413 +862,6 @@ void SurveyComplexItem::_rebuildTransectsPhase1WorkerSinglePolygon(bool refly)
     }
 }
 
-#if 0
-    // Splitting polygons is not supported since this code would get stuck in a infinite loop
-    // Code is left here in case someone wants to try to resurrect it
-
-void SurveyComplexItem::_rebuildTransectsPhase1WorkerSplitPolygons(bool refly)
-{
-    if (_ignoreRecalc) {
-        return;
-    }
-
-    // If the transects are getting rebuilt then any previously loaded mission items are now invalid
-    if (_loadedMissionItemsParent) {
-        _loadedMissionItems.clear();
-        _loadedMissionItemsParent->deleteLater();
-        _loadedMissionItemsParent = nullptr;
-    }
-
-    if (_surveyAreaPolygon.count() < 3) {
-        return;
-    }
-
-    // Convert polygon to NED
-
-    QList<QPointF> polygonPoints;
-    QGeoCoordinate tangentOrigin = _surveyAreaPolygon.pathModel().value<QGCQGeoCoordinate*>(0)->coordinate();
-    qCDebug(SurveyComplexItemLog) << "_rebuildTransectsPhase1 Convert polygon to NED - _surveyAreaPolygon.count():tangentOrigin" << _surveyAreaPolygon.count() << tangentOrigin;
-    for (int i=0; i<_surveyAreaPolygon.count(); i++) {
-        double y, x, down;
-        QGeoCoordinate vertex = _surveyAreaPolygon.pathModel().value<QGCQGeoCoordinate*>(i)->coordinate();
-        if (i == 0) {
-            // This avoids a nan calculation that comes out of convertGeoToNed
-            x = y = 0;
-        } else {
-            convertGeoToNed(vertex, tangentOrigin, y, x, down);
-        }
-        polygonPoints += QPointF(x, y);
-        qCDebug(SurveyComplexItemLog) << "_rebuildTransectsPhase1 vertex:x:y" << vertex << polygonPoints.last().x() << polygonPoints.last().y();
-    }
-
-    // convert into QPolygonF
-    QPolygonF polygon;
-    for (int i=0; i<polygonPoints.count(); i++) {
-        qCDebug(SurveyComplexItemLog) << "Vertex" << polygonPoints[i];
-        polygon << polygonPoints[i];
-    }
-
-    // Create list of separate polygons
-    QList<QPolygonF> polygons{};
-    _PolygonDecomposeConvex(polygon, polygons);
-
-    // iterate over polygons
-    for (auto p = polygons.begin(); p != polygons.end(); ++p) {
-        QPointF* vMatch = nullptr;
-        // find matching vertex in previous polygon
-        if (p != polygons.begin()) {
-            auto pLast = p - 1;
-            for (auto& i : *p) {
-                for (auto& j : *pLast) {
-                   if (i == j) {
-                       vMatch = &i;
-                       break;
-                   }
-                   if (vMatch) break;
-                }
-            }
-
-        }
-
-
-        // close polygon
-        *p << p->front();
-        // build transects for this polygon
-        // TODO figure out tangent origin
-        // TODO improve selection of entry points
-//        qCDebug(SurveyComplexItemLog) << "Transects from polynom p " << p;
-        _rebuildTransectsFromPolygon(refly, *p, tangentOrigin, vMatch);
-    }
-}
-
-void SurveyComplexItem::_PolygonDecomposeConvex(const QPolygonF& polygon, QList<QPolygonF>& decomposedPolygons)
-{
-	// this follows "Mark Keil's Algorithm" https://mpen.ca/406/keil
-    int decompSize = std::numeric_limits<int>::max();
-    if (polygon.size() < 3) return;
-    if (polygon.size() == 3) {
-        decomposedPolygons << polygon;
-        return;
-    }
-
-    QList<QPolygonF> decomposedPolygonsMin{};
-
-    for (auto vertex = polygon.begin(); vertex != polygon.end(); ++vertex)
-    {
-        // is vertex reflex?
-        bool vertexIsReflex = _VertexIsReflex(polygon, vertex);
-
-        if (!vertexIsReflex) continue;
-
-        for (auto vertexOther = polygon.begin(); vertexOther != polygon.end(); ++vertexOther)
-        {
-            auto vertexBefore = vertex == polygon.begin() ? polygon.end() - 1 : vertex - 1;
-            auto vertexAfter = vertex == polygon.end() - 1 ? polygon.begin() : vertex + 1;
-            if (vertexOther == vertex) continue;
-            if (vertexAfter == vertexOther) continue;
-            if (vertexBefore == vertexOther) continue;
-            bool canSee = _VertexCanSeeOther(polygon, vertex, vertexOther);
-            if (!canSee) continue;
-
-            QPolygonF polyLeft;
-            auto v = vertex;
-            auto polyLeftContainsReflex = false;
-            while ( v != vertexOther) {
-                if (v != vertex && _VertexIsReflex(polygon, v)) {
-                    polyLeftContainsReflex = true;
-                }
-                polyLeft << *v;
-                ++v;
-                if (v == polygon.end()) v = polygon.begin();
-            }
-            polyLeft << *vertexOther;
-            auto polyLeftValid = !(polyLeftContainsReflex && polyLeft.size() == 3);
-
-            QPolygonF polyRight;
-            v = vertexOther;
-            auto polyRightContainsReflex = false;
-            while ( v != vertex) {
-                if (v != vertex && _VertexIsReflex(polygon, v)) {
-                    polyRightContainsReflex = true;
-                }
-                polyRight << *v;
-                ++v;
-                if (v == polygon.end()) v = polygon.begin();
-            }
-            polyRight << *vertex;
-            auto polyRightValid = !(polyRightContainsReflex && polyRight.size() == 3);
-
-            if (!polyLeftValid || ! polyRightValid) {
-//                decompSize = std::numeric_limits<int>::max();
-                continue;
-            }
-
-            // recursion
-            QList<QPolygonF> polyLeftDecomposed{};
-            _PolygonDecomposeConvex(polyLeft, polyLeftDecomposed);
-
-            QList<QPolygonF> polyRightDecomposed{};
-            _PolygonDecomposeConvex(polyRight, polyRightDecomposed);
-
-            // compositon
-            auto subSize = polyLeftDecomposed.size() + polyRightDecomposed.size();
-            if ((polyLeftContainsReflex && polyLeftDecomposed.size() == 1)
-                    || (polyRightContainsReflex && polyRightDecomposed.size() == 1))
-            {
-                // don't accept polygons that contian reflex vertices and were not split
-                subSize = std::numeric_limits<int>::max();
-            }
-            if (subSize < decompSize) {
-                decompSize = subSize;
-                decomposedPolygonsMin = polyLeftDecomposed + polyRightDecomposed;
-            }
-        }
-
-    }
-
-    // assemble output
-    if (decomposedPolygonsMin.size() > 0) {
-        decomposedPolygons << decomposedPolygonsMin;
-    } else {
-        decomposedPolygons << polygon;
-    }
-
-    return;
-}
-
-bool SurveyComplexItem::_VertexCanSeeOther(const QPolygonF& polygon, const QPointF* vertexA, const QPointF* vertexB) {
-    if (vertexA == vertexB) return false;
-    auto vertexAAfter = vertexA + 1 == polygon.end() ? polygon.begin() : vertexA + 1;
-    auto vertexABefore = vertexA == polygon.begin() ? polygon.end() - 1 : vertexA - 1;
-    if (vertexAAfter == vertexB) return false;
-    if (vertexABefore == vertexB) return false;
-//    qCDebug(SurveyComplexItemLog) << "_VertexCanSeeOther false after first checks ";
-
-    bool visible = true;
-//    auto diff = *vertexA - *vertexB;
-    QLineF lineAB{*vertexA, *vertexB};
-    auto distanceAB = lineAB.length();//sqrtf(diff.x() * diff.x() + diff.y()*diff.y());
-
-//    qCDebug(SurveyComplexItemLog) << "_VertexCanSeeOther distanceAB " << distanceAB;
-    for (auto vertexC = polygon.begin(); vertexC != polygon.end(); ++vertexC)
-    {
-        if (vertexC == vertexA) continue;
-        if (vertexC == vertexB) continue;
-        auto vertexD = vertexC + 1 == polygon.end() ? polygon.begin() : vertexC + 1;
-        if (vertexD == vertexA) continue;
-        if (vertexD == vertexB) continue;
-        QLineF lineCD(*vertexC, *vertexD);
-        QPointF intersection{};
-
-        auto intersects = lineAB.intersects(lineCD, &intersection);
-        if (intersects == QLineF::IntersectType::BoundedIntersection) {
-//            auto diffIntersection = *vertexA - intersection;
-//            auto distanceIntersection = sqrtf(diffIntersection.x() * diffIntersection.x() + diffIntersection.y()*diffIntersection.y());
-//            qCDebug(SurveyComplexItemLog) << "*vertexA " << *vertexA << "*vertexB " << *vertexB  << " intersection " << intersection;
-
-            QLineF lineIntersection{*vertexA, intersection};
-            auto distanceIntersection = lineIntersection.length();//sqrtf(diff.x() * diff.x() + diff.y()*diff.y());
-            qCDebug(SurveyComplexItemLog) << "_VertexCanSeeOther distanceIntersection " << distanceIntersection;
-            if (distanceIntersection < distanceAB) {
-                visible = false;
-                break;
-            }
-        }
-
-    }
-
-    return visible;
-}
-
-bool SurveyComplexItem::_VertexIsReflex(const QPolygonF& polygon, QList<QPointF>::const_iterator& vertexIter) {
-    auto vertexBefore = vertex == polygon.begin() ? polygon.end() - 1 : vertex - 1;
-    auto vertexAfter = vertex == polygon.end() - 1 ? polygon.begin() : vertex + 1;
-    auto area = (((vertex->x() - vertexBefore->x())*(vertexAfter->y() - vertexBefore->y()))-((vertexAfter->x() - vertexBefore->x())*(vertex->y() - vertexBefore->y())));
-    return area > 0;
-
-}
-#endif
-
-void SurveyComplexItem::_rebuildTransectsFromPolygon(bool refly, const QPolygonF& polygon, const QGeoCoordinate& tangentOrigin, const QPointF* const transitionPoint)
-{
-    // Generate transects
-
-    double gridAngle = _gridAngleFact.rawValue().toDouble();
-    double gridSpacing = _cameraCalc.adjustedFootprintSide()->rawValue().toDouble();
-
-    gridAngle = _clampGridAngle90(gridAngle);
-    gridAngle += refly ? 90 : 0;
-    qCDebug(SurveyComplexItemLog) << "_rebuildTransectsPhase1 Clamped grid angle" << gridAngle;
-
-    qCDebug(SurveyComplexItemLog) << "_rebuildTransectsPhase1 gridSpacing:gridAngle:refly" << gridSpacing << gridAngle << refly;
-
-    // Convert polygon to bounding rect
-
-    qCDebug(SurveyComplexItemLog) << "_rebuildTransectsPhase1 Polygon";
-    QRectF boundingRect = polygon.boundingRect();
-    QPointF boundingCenter = boundingRect.center();
-    qCDebug(SurveyComplexItemLog) << "Bounding rect" << boundingRect.topLeft().x() << boundingRect.topLeft().y() << boundingRect.bottomRight().x() << boundingRect.bottomRight().y();
-
-    // Create set of rotated parallel lines within the expanded bounding rect. Make the lines larger than the
-    // bounding box to guarantee intersection.
-
-    QList<QLineF> lineList;
-
-    // Transects are generated to be as long as the largest width/height of the bounding rect plus some fudge factor.
-    // This way they will always be guaranteed to intersect with a polygon edge no matter what angle they are rotated to.
-    // They are initially generated with the transects flowing from west to east and then points within the transect north to south.
-    double maxWidth = qMax(boundingRect.width(), boundingRect.height()) + 2000.0;
-    double halfWidth = maxWidth / 2.0;
-    double transectX = boundingCenter.x() - halfWidth;
-    double transectXMax = transectX + maxWidth;
-    while (transectX < transectXMax) {
-        double transectYTop = boundingCenter.y() - halfWidth;
-        double transectYBottom = boundingCenter.y() + halfWidth;
-
-        lineList += QLineF(_rotatePoint(QPointF(transectX, transectYTop), boundingCenter, gridAngle), _rotatePoint(QPointF(transectX, transectYBottom), boundingCenter, gridAngle));
-        transectX += gridSpacing;
-    }
-
-    // Now intersect the lines with the polygon
-    QList<QLineF> intersectLines;
-#if 1
-    _intersectLinesWithPolygon(lineList, polygon, intersectLines);
-#else
-    // This is handy for debugging grid problems, not for release
-    intersectLines = lineList;
-#endif
-
-    // Less than two transects intersected with the polygon:
-    //      Create a single transect which goes through the center of the polygon
-    //      Intersect it with the polygon
-    if (intersectLines.count() < 2) {
-        _surveyAreaPolygon.center();
-        QLineF firstLine = lineList.first();
-        QPointF lineCenter = firstLine.pointAt(0.5);
-        QPointF centerOffset = boundingCenter - lineCenter;
-        firstLine.translate(centerOffset);
-        lineList.clear();
-        lineList.append(firstLine);
-        intersectLines = lineList;
-        _intersectLinesWithPolygon(lineList, polygon, intersectLines);
-    }
-
-    // Make sure all lines are going the same direction. Polygon intersection leads to lines which
-    // can be in varied directions depending on the order of the intesecting sides.
-    QList<QLineF> resultLines;
-    _adjustLineDirection(intersectLines, resultLines);
-
-    // Convert from NED to Geo
-    QList<QList<QGeoCoordinate>> transects;
-
-    if (transitionPoint != nullptr) {
-        QList<QGeoCoordinate>   transect;
-        QGeoCoordinate          coord;
-        QGCGeo::convertNedToGeo(transitionPoint->y(), transitionPoint->x(), 0, tangentOrigin, coord);
-        transect.append(coord);
-        transect.append(coord); //TODO
-        transects.append(transect);
-    }
-
-    for (const QLineF& line: resultLines) {
-        QList<QGeoCoordinate>   transect;
-        QGeoCoordinate          coord;
-
-        QGCGeo::convertNedToGeo(line.p1().y(), line.p1().x(), 0, tangentOrigin, coord);
-        transect.append(coord);
-        QGCGeo::convertNedToGeo(line.p2().y(), line.p2().x(), 0, tangentOrigin, coord);
-        transect.append(coord);
-
-        transects.append(transect);
-    }
-
-    _adjustTransectsToEntryPointLocation(transects);
-
-    if (refly) {
-        _optimizeTransectsForShortestDistance(_transects.last().last().coord, transects);
-    }
-
-    if (_flyAlternateTransectsFact.rawValue().toBool()) {
-        QList<QList<QGeoCoordinate>> alternatingTransects;
-        for (int i=0; i<transects.count(); i++) {
-            if (!(i & 1)) {
-                alternatingTransects.append(transects[i]);
-            }
-        }
-        for (int i=transects.count()-1; i>0; i--) {
-            if (i & 1) {
-                alternatingTransects.append(transects[i]);
-            }
-        }
-        transects = alternatingTransects;
-    }
-
-    // Adjust to lawnmower pattern
-    bool reverseVertices = false;
-    for (int i=0; i<transects.count(); i++) {
-        // We must reverse the vertices for every other transect in order to make a lawnmower pattern
-        QList<QGeoCoordinate> transectVertices = transects[i];
-        if (reverseVertices) {
-            reverseVertices = false;
-            QList<QGeoCoordinate> reversedVertices;
-            for (int j=transectVertices.count()-1; j>=0; j--) {
-                reversedVertices.append(transectVertices[j]);
-            }
-            transectVertices = reversedVertices;
-        } else {
-            reverseVertices = true;
-        }
-        transects[i] = transectVertices;
-    }
-
-    // Convert to CoordInfo transects and append to _transects
-    for (const QList<QGeoCoordinate>& transect: transects) {
-        QGeoCoordinate                                  coord;
-        QList<TransectStyleComplexItem::CoordInfo_t>    coordInfoTransect;
-        TransectStyleComplexItem::CoordInfo_t           coordInfo;
-
-        coordInfo = { transect[0], CoordTypeSurveyEntry };
-        coordInfoTransect.append(coordInfo);
-        coordInfo = { transect[1], CoordTypeSurveyExit };
-        coordInfoTransect.append(coordInfo);
-
-        // For hover and capture we need points for each camera location within the transect
-        if (triggerCamera() && hoverAndCaptureEnabled()) {
-            double transectLength = transect[0].distanceTo(transect[1]);
-            double transectAzimuth = transect[0].azimuthTo(transect[1]);
-            if (triggerDistance() < transectLength) {
-                int cInnerHoverPoints = static_cast<int>(floor(transectLength / triggerDistance()));
-                qCDebug(SurveyComplexItemLog) << "cInnerHoverPoints" << cInnerHoverPoints;
-                for (int i=0; i<cInnerHoverPoints; i++) {
-                    QGeoCoordinate hoverCoord = transect[0].atDistanceAndAzimuth(triggerDistance() * (i + 1), transectAzimuth);
-                    TransectStyleComplexItem::CoordInfo_t hoverCoordInfo = { hoverCoord, CoordTypeInteriorHoverTrigger };
-                    coordInfoTransect.insert(1 + i, hoverCoordInfo);
-                }
-            }
-        }
-
-        // Extend the transect ends for turnaround
-        if (_hasTurnaround()) {
-            QGeoCoordinate turnaroundCoord;
-            double turnAroundDistance = _turnAroundDistanceFact.rawValue().toDouble();
-
-            double azimuth = transect[0].azimuthTo(transect[1]);
-            turnaroundCoord = transect[0].atDistanceAndAzimuth(-turnAroundDistance, azimuth);
-            turnaroundCoord.setAltitude(qQNaN());
-            TransectStyleComplexItem::CoordInfo_t turnaroundCoordInfo = { turnaroundCoord, CoordTypeTurnaround };
-            coordInfoTransect.prepend(turnaroundCoordInfo);
-
-            azimuth = transect.last().azimuthTo(transect[transect.count() - 2]);
-            turnaroundCoord = transect.last().atDistanceAndAzimuth(-turnAroundDistance, azimuth);
-            turnaroundCoord.setAltitude(qQNaN());
-            coordInfo = { turnaroundCoord, CoordTypeTurnaround };
-            coordInfoTransect.append(coordInfo);
-        }
-
-        _transects.append(coordInfoTransect);
-    }
-    qCDebug(SurveyComplexItemLog) << "_transects.size() " << _transects.size();
-}
 
 void SurveyComplexItem::_recalcCameraShots(void)
 {

--- a/src/MissionManager/SurveyComplexItem.h
+++ b/src/MissionManager/SurveyComplexItem.h
@@ -112,23 +112,7 @@ private:
     bool _loadV3(const QJsonObject& complexObject, int sequenceNumber, QString& errorString);
     bool _loadV4V5(const QJsonObject& complexObject, int sequenceNumber, QString& errorString, int version, bool forPresets);
     void _saveCommon(QJsonObject& complexObject);
-    void _rebuildTransectsPhase1Worker(bool refly);
     void _rebuildTransectsPhase1WorkerSinglePolygon(bool refly);
-    /// Adds to the _transects array from one polygon
-    void _rebuildTransectsFromPolygon(bool refly, const QPolygonF& polygon, const QGeoCoordinate& tangentOrigin, const QPointF* const transitionPoint);
-
-#if 0
-    // Splitting polygons is not supported since this code would get stuck in a infinite loop
-    // Code is left here in case someone wants to try to resurrect it
-
-    void _rebuildTransectsPhase1WorkerSplitPolygons(bool refly);
-
-    // Decompose polygon into list of convex sub polygons
-    void _PolygonDecomposeConvex(const QPolygonF& polygon, QList<QPolygonF>& decomposedPolygons);
-    // return true if vertex a can see vertex b
-    bool _VertexCanSeeOther(const QPolygonF& polygon, const QPointF* vertexA, const QPointF* vertexB);
-    bool _VertexIsReflex(const QPolygonF& polygon, QList<QPointF>::const_iterator& vertexIter);
-#endif
 
     QMap<QString, FactMetaData*> _metaDataMap;
 

--- a/src/MissionManager/TransectStyleComplexItem.h
+++ b/src/MissionManager/TransectStyleComplexItem.h
@@ -108,6 +108,8 @@ public:
     static constexpr const char* terrainAdjustMaxClimbRateName         = "TerrainAdjustMaxClimbRate";
     static constexpr const char* terrainAdjustMaxDescentRateName       = "TerrainAdjustMaxDescentRate";
 
+    static constexpr int maxTransectCount = 1000; ///< Maximum number of transects allowed; spacing is raised to enforce this limit
+
 signals:
     void cameraShotsChanged             (void);
     void timeBetweenShotsChanged        (void);
@@ -200,8 +202,6 @@ protected:
 
     static constexpr int _terrainQueryTimeoutMsecs=     1000;
     static constexpr int _hoverAndCaptureDelaySeconds = 4;
-    static constexpr double _minimumTransectSpacingMeters = 0.3;
-    static constexpr double _forceLargeTransectSpacingMeters = 100000;
 
 private slots:
     void _reallyQueryTransectsPathHeightInfo        (void);

--- a/test/MissionManager/CameraCalcTest.cc
+++ b/test/MissionManager/CameraCalcTest.cc
@@ -42,7 +42,7 @@ void CameraCalcTest::_testDirty()
             << _cameraCalc->frontalOverlap() << _cameraCalc->sideOverlap() << _cameraCalc->adjustedFootprintSide()
             << _cameraCalc->adjustedFootprintFrontal();
     for (Fact* fact : rgFacts) {
-        qDebug() << fact->name();
+        qCDebug(UnitTestLog) << fact->name();
         QVERIFY(!_cameraCalc->dirty());
         if (fact->typeIsBool()) {
             fact->setRawValue(!fact->rawValue().toBool());

--- a/test/MissionManager/CameraSectionTest.cc
+++ b/test/MissionManager/CameraSectionTest.cc
@@ -918,7 +918,7 @@ void CameraSectionTest::_testScanForMultipleItems()
             item2->missionItem() = cameraItem->missionItem();
             visualItems.append(item1);
             visualItems.append(item2);
-            // qDebug() << MissionCommandTree::instance()->getUIInfo(_controllerVehicle,
+            // qCDebug(UnitTestLog) << MissionCommandTree::instance()->getUIInfo(_controllerVehicle,
             // QGCMAVLink::VehicleClassGeneric, (MAV_CMD)item1->command())->rawName() <<
             // MissionCommandTree::instance()->getUIInfo(_controllerVehicle, QGCMAVLink::VehicleClassGeneric,
             // (MAV_CMD)item2->command())->rawName();

--- a/test/MissionManager/CorridorScanComplexItemTest.cc
+++ b/test/MissionManager/CorridorScanComplexItemTest.cc
@@ -4,6 +4,9 @@
 #include "CorridorScanComplexItem.h"
 #include "MultiSignalSpy.h"
 #include "PlanViewSettings.h"
+#include "TransectStyleComplexItem.h"
+
+#include <QtTest/QSignalSpy>
 
 CorridorScanComplexItemTest::CorridorScanComplexItemTest()
 {
@@ -74,7 +77,7 @@ void CorridorScanComplexItemTest::_testItemCount()
     };
     QList<MissionItem*> items;
     for (const TestCase_t& testCase : rgTestCases) {
-        qDebug() << "triggerInTurnAround:hasTurnaround" << testCase.triggerInTurnAround << testCase.hasTurnaround;
+        qCDebug(UnitTestLog) << "triggerInTurnAround:hasTurnaround" << testCase.triggerInTurnAround << testCase.hasTurnaround;
         _corridorItem->cameraTriggerInTurnAround()->setRawValue(testCase.triggerInTurnAround);
         _corridorItem->turnAroundDistance()->setRawValue(testCase.hasTurnaround ? 50 : 0);
         _corridorItem->appendMissionItems(items, this);
@@ -123,7 +126,7 @@ void CorridorScanComplexItemTest::_testItemGenerationWorker(bool imagesInTurnaro
                                                             bool useConditionGate,
                                                             const QList<MAV_CMD>& expectedCommands)
 {
-    qDebug() << QStringLiteral("_testItemGenerationWorker imagesInTuraround:%1 turnaround:%2 gate:%3")
+    qCDebug(UnitTestLog) << QStringLiteral("_testItemGenerationWorker imagesInTurnaround:%1 turnaround:%2 gate:%3")
                     .arg(imagesInTurnaround)
                     .arg(hasTurnaround)
                     .arg(useConditionGate);
@@ -137,7 +140,7 @@ void CorridorScanComplexItemTest::_testItemGenerationWorker(bool imagesInTurnaro
     for (int i = 0; i < expectedCommands.count(); i++) {
         int actualCommand = items[i]->command();
         int expectedCommand = expectedCommands[i];
-        // qDebug() << "Index" << i;
+        // qCDebug(UnitTestLog) << "Index" << i;
         QCOMPARE(actualCommand, expectedCommand);
     }
 }
@@ -159,6 +162,28 @@ void CorridorScanComplexItemTest::_testItemGeneration()
     for (const TestCase_t& testCase : rgTestCases) {
         _testItemGenerationWorker(false /* imagesInTurnaround */, testCase.hasTurnaround, testCase.useConditionGate,
                                   _createExpectedCommands(testCase.hasTurnaround, testCase.useConditionGate));
+    }
+}
+
+void CorridorScanComplexItemTest::_testMaxTransectCount()
+{
+    // Tiny spacing triggers the cap: transect count must not exceed maxTransectCount.
+    // cameraShotsChanged is emitted at the end of every _rebuildTransects(); the rebuild
+    // fires synchronously (direct connection) so the spy count is already 1 on return.
+    {
+        QSignalSpy rebuildSpy(_corridorItem, &TransectStyleComplexItem::cameraShotsChanged);
+        _corridorItem->cameraCalc()->adjustedFootprintSide()->setRawValue(0.001);
+        QCOMPARE(rebuildSpy.count(), 1);
+        QVERIFY(_corridorItem->_transectCount() <= TransectStyleComplexItem::maxTransectCount);
+        QVERIFY(_corridorItem->_transectCount() > 0);
+    }
+
+    // Zero spacing must not crash and must fall back to a single center transect.
+    {
+        QSignalSpy rebuildSpy(_corridorItem, &TransectStyleComplexItem::cameraShotsChanged);
+        _corridorItem->cameraCalc()->adjustedFootprintSide()->setRawValue(0);
+        QCOMPARE(rebuildSpy.count(), 1);
+        QCOMPARE(_corridorItem->_transectCount(), 1);
     }
 }
 

--- a/test/MissionManager/CorridorScanComplexItemTest.h
+++ b/test/MissionManager/CorridorScanComplexItemTest.h
@@ -25,6 +25,7 @@ private slots:
     void _testPathChanges();
     void _testItemGeneration();
     void _testItemCount();
+    void _testMaxTransectCount();
 
 private:
     void _waitForReadyForSave();

--- a/test/MissionManager/FWLandingPatternTest.cc
+++ b/test/MissionManager/FWLandingPatternTest.cc
@@ -56,7 +56,7 @@ void FWLandingPatternTest::_testDirty()
     QList<Fact*> rgFacts;
     rgFacts << _fwItem->glideSlope() << _fwItem->valueSetIsDistance();
     for (Fact* fact : rgFacts) {
-        qDebug() << fact->name();
+        qCDebug(UnitTestLog) << fact->name();
         QVERIFY(!_fwItem->dirty());
         changeFactValue(fact);
         QVERIFY(_viSpy->emittedOnce("dirtyChanged"));
@@ -75,7 +75,7 @@ void FWLandingPatternTest::_testSaveLoad()
     FixedWingLandingComplexItem* newItem = new FixedWingLandingComplexItem(planController(), false /* flyView */);
     bool success = newItem->load(items[0].toObject(), 10, errorString);
     if (!success) {
-        qDebug() << errorString;
+        qCDebug(UnitTestLog) << errorString;
     }
     QVERIFY(success);
     QVERIFY(errorString.isEmpty());

--- a/test/MissionManager/LandingComplexItemTest.cc
+++ b/test/MissionManager/LandingComplexItemTest.cc
@@ -71,7 +71,7 @@ void LandingComplexItemTest::_testDirty()
             << _item->landingDistance() << _item->useLoiterToAlt() << _item->stopTakingPhotos()
             << _item->stopTakingVideo();
     for (Fact* fact : rgFacts) {
-        qDebug() << fact->name();
+        qCDebug(UnitTestLog) << fact->name();
         QVERIFY(!_item->dirty());
         changeFactValue(fact);
         QVERIFY(_viMultiSpy->emittedOnce("dirtyChanged"));
@@ -84,7 +84,7 @@ void LandingComplexItemTest::_testDirty()
     rgBoolNames << "altitudesAreRelative";
     const QMetaObject* metaObject = _item->metaObject();
     for (const char* boolName : rgBoolNames) {
-        qDebug() << boolName;
+        qCDebug(UnitTestLog) << boolName;
         QVERIFY(!_item->dirty());
         QMetaProperty boolProp = metaObject->property(metaObject->indexOfProperty(boolName));
         QVERIFY(boolProp.write(_item, !boolProp.read(_item).toBool()));
@@ -151,7 +151,7 @@ void LandingComplexItemTest::_testAppendSectionItems()
 
     for (size_t i = 0; i < std::size(rgTestCases); i++) {
         TestCase_s& testCase = rgTestCases[i];
-        qDebug() << "stopTakingPhotos" << testCase.stopTakingPhotos << "stopTakingVideo" << testCase.stopTakingVideo
+        qCDebug(UnitTestLog) << "stopTakingPhotos" << testCase.stopTakingPhotos << "stopTakingVideo" << testCase.stopTakingVideo
                  << "useLoiterToAlt" << testCase.useLoiterToAlt;
         _item->stopTakingPhotos()->setRawValue(testCase.stopTakingPhotos);
         _item->stopTakingVideo()->setRawValue(testCase.stopTakingVideo);
@@ -180,7 +180,7 @@ void LandingComplexItemTest::_testAppendSectionItems()
                                  (testCase.stopTakingVideo ? CameraSection::stopTakingVideoCommandCount() : 0);
         QCOMPARE(rgMissionItems[finalApproachIndex]->command(),
                  testCase.useLoiterToAlt ? MAV_CMD_NAV_LOITER_TO_ALT : MAV_CMD_NAV_WAYPOINT);
-        qDebug() << rgMissionItems[finalApproachIndex + 1]->command();
+        qCDebug(UnitTestLog) << rgMissionItems[finalApproachIndex + 1]->command();
         QCOMPARE(rgMissionItems[finalApproachIndex + 1]->command(), MAV_CMD_NAV_LAND);
         simpleItems->deleteLater();
         rgMissionItems.clear();
@@ -203,7 +203,7 @@ void LandingComplexItemTest::_testScanForItems()
 
     for (size_t i = 0; i < std::size(rgTestCases); i++) {
         TestCase_s& testCase = rgTestCases[i];
-        qDebug() << "stopTakingPhotos" << testCase.stopTakingPhotos << "stopTakingVideo" << testCase.stopTakingVideo
+        qCDebug(UnitTestLog) << "stopTakingPhotos" << testCase.stopTakingPhotos << "stopTakingVideo" << testCase.stopTakingVideo
                  << "useLoiterToAlt" << testCase.useLoiterToAlt;
         _item->stopTakingPhotos()->setRawValue(testCase.stopTakingPhotos);
         _item->stopTakingVideo()->setRawValue(testCase.stopTakingVideo);
@@ -242,7 +242,7 @@ void LandingComplexItemTest::_testSaveLoad()
         newItem->_load(saveObject, 0 /* sequenceNumber */, SimpleLandingComplexItem::jsonComplexItemTypeValue,
                        false /* useDeprecatedRelAltKeys */, errorString);
     if (!loadSuccess) {
-        qDebug() << "_load failed" << errorString;
+        qCDebug(UnitTestLog) << "_load failed" << errorString;
     }
     QVERIFY(loadSuccess);
     QVERIFY(errorString.isEmpty());
@@ -257,7 +257,7 @@ void LandingComplexItemTest::_testSaveLoad()
     loadSuccess = newItem->_load(saveObject, 0 /* sequenceNumber */, SimpleLandingComplexItem::jsonComplexItemTypeValue,
                                  true /* useDeprecatedRelAltKeys */, errorString);
     if (!loadSuccess) {
-        qDebug() << "_load failed" << errorString;
+        qCDebug(UnitTestLog) << "_load failed" << errorString;
     }
     QVERIFY(loadSuccess);
     QVERIFY(errorString.isEmpty());
@@ -275,7 +275,7 @@ void LandingComplexItemTest::_testSaveLoad()
     loadSuccess = newItem->_load(saveObject, 0 /* sequenceNumber */, SimpleLandingComplexItem::jsonComplexItemTypeValue,
                                  false /* useDeprecatedRelAltKeys */, errorString);
     if (!loadSuccess) {
-        qDebug() << "_load failed" << errorString;
+        qCDebug(UnitTestLog) << "_load failed" << errorString;
     }
     QVERIFY(loadSuccess);
     QVERIFY(errorString.isEmpty());

--- a/test/MissionManager/MissionCommandTreeTest.cc
+++ b/test/MissionManager/MissionCommandTreeTest.cc
@@ -188,7 +188,7 @@ void MissionCommandTreeTest::testAllTrees()
                 // VTOL in ArduPilot shows up as plane so we can test this pair
                 continue;
             }
-            qDebug() << firmwareType << vehicleType;
+            qCDebug(UnitTestLog) << firmwareType << vehicleType;
             Vehicle* const vehicle = new Vehicle(firmwareType, vehicleType, this);
             QVERIFY(MissionCommandTree::instance()->getUIInfo(vehicle, QGCMAVLink::VehicleClassMultiRotor,
                                                               MAV_CMD_NAV_WAYPOINT) != nullptr);

--- a/test/MissionManager/StructureScanComplexItemTest.cc
+++ b/test/MissionManager/StructureScanComplexItemTest.cc
@@ -51,7 +51,7 @@ void StructureScanComplexItemTest::_testDirty()
     QList<Fact*> rgFacts;
     rgFacts << _structureScanItem->entranceAlt() << _structureScanItem->layers();
     for (Fact* fact : rgFacts) {
-        qDebug() << fact->name();
+        qCDebug(UnitTestLog) << fact->name();
         QVERIFY(!_structureScanItem->dirty());
         if (fact->typeIsBool()) {
             fact->setRawValue(!fact->rawValue().toBool());

--- a/test/MissionManager/SurveyComplexItemTest.cc
+++ b/test/MissionManager/SurveyComplexItemTest.cc
@@ -4,6 +4,9 @@
 #include "MultiSignalSpy.h"
 #include "PlanViewSettings.h"
 #include "SurveyComplexItem.h"
+#include "TransectStyleComplexItem.h"
+
+#include <QtTest/QSignalSpy>
 
 SurveyComplexItemTest::SurveyComplexItemTest()
 {
@@ -66,7 +69,7 @@ void SurveyComplexItemTest::_testDirty()
     QList<Fact*> rgFacts;
     rgFacts << _surveyItem->gridAngle() << _surveyItem->flyAlternateTransects();
     for (Fact* fact : rgFacts) {
-        qDebug() << fact->name();
+        qCDebug(UnitTestLog) << fact->name();
         QVERIFY(!_surveyItem->dirty());
         if (fact->typeIsBool()) {
             fact->setRawValue(!fact->rawValue().toBool());
@@ -108,7 +111,7 @@ void SurveyComplexItemTest::_testGridAngle()
         QGeoCoordinate firstTransectEntry = gridPoints[0].value<QGeoCoordinate>();
         QGeoCoordinate firstTransectExit = gridPoints[1].value<QGeoCoordinate>();
         double azimuth = firstTransectEntry.azimuthTo(firstTransectExit);
-        // qDebug() << gridAngle << azimuth << _clampGridAngle180(gridAngle) << _clampGridAngle180(azimuth);
+        // qCDebug(UnitTestLog) << gridAngle << azimuth << _clampGridAngle180(gridAngle) << _clampGridAngle180(azimuth);
         int clampGridAngle = qRound(_clampGridAngle180(gridAngle));
         int clampAzimuth = qRound(_clampGridAngle180(azimuth));
         QCOMPARE(clampGridAngle, clampAzimuth);
@@ -157,7 +160,7 @@ void SurveyComplexItemTest::_testItemCount()
     }
     QList<MissionItem*> items;
     for (const TestCase_t& testCase : rgTestCases) {
-        qDebug() << "hoverAndCapture:triggerInTurnAround:refly90:hasTuraround" << testCase.hoverAndCapture
+        qCDebug(UnitTestLog) << "hoverAndCapture:triggerInTurnAround:refly90:hasTurnaround" << testCase.hoverAndCapture
                  << testCase.triggerInTurnAround << testCase.refly90 << testCase.hasTurnaround;
         _surveyItem->hoverAndCapture()->setRawValue(testCase.hoverAndCapture);
         _surveyItem->cameraTriggerInTurnAround()->setRawValue(testCase.triggerInTurnAround);
@@ -198,7 +201,7 @@ QList<MAV_CMD> SurveyComplexItemTest::_createExpectedCommands(bool hasTurnaround
 void SurveyComplexItemTest::_testItemGenerationWorker(bool imagesInTurnaround, bool hasTurnaround,
                                                       bool useConditionGate, const QList<MAV_CMD>& expectedCommands)
 {
-    qDebug() << QStringLiteral("_testItemGenerationWorker imagesInTuraround:%1 turnaround:%2 gate:%3")
+    qCDebug(UnitTestLog) << QStringLiteral("_testItemGenerationWorker imagesInTurnaround:%1 turnaround:%2 gate:%3")
                     .arg(imagesInTurnaround)
                     .arg(hasTurnaround)
                     .arg(useConditionGate);
@@ -236,7 +239,7 @@ void SurveyComplexItemTest::_testItemGeneration()
     // Test cameraTriggerInTurnAround = true cases
     QList<MAV_CMD> imagesInTurnaroundWithTurnaroundDistanceCommands = {
         // Transect 1
-        MAV_CMD_CONDITION_GATE,         // First turaround
+        MAV_CMD_CONDITION_GATE,         // First turnaround
         MAV_CMD_DO_SET_CAM_TRIGG_DIST,
         MAV_CMD_CONDITION_GATE,         // Survey entry
         MAV_CMD_DO_SET_CAM_TRIGG_DIST,  // Survey entry also has trigger start
@@ -306,6 +309,28 @@ void SurveyComplexItemTest::_testHoverCaptureItemGeneration()
                               expectedCommands);
     _testItemGenerationWorker(false /* imagesInTurnaround */, true /* hasTurnaround */, false /* useConditionGate */,
                               expectedCommands);
+}
+
+void SurveyComplexItemTest::_testMaxTransectCount()
+{
+    // Tiny spacing triggers the cap: transect count must not exceed maxTransectCount.
+    // cameraShotsChanged is emitted at the end of every _rebuildTransects(); the rebuild
+    // fires synchronously (direct connection) so the spy count is already 1 on return.
+    {
+        QSignalSpy rebuildSpy(_surveyItem, &TransectStyleComplexItem::cameraShotsChanged);
+        _surveyItem->cameraCalc()->adjustedFootprintSide()->setRawValue(0.001);
+        QCOMPARE(rebuildSpy.count(), 1);
+        QVERIFY(_surveyItem->_transectCount() <= TransectStyleComplexItem::maxTransectCount);
+        QVERIFY(_surveyItem->_transectCount() > 0);
+    }
+
+    // Zero spacing must not crash and must fall back to a single center transect.
+    {
+        QSignalSpy rebuildSpy(_surveyItem, &TransectStyleComplexItem::cameraShotsChanged);
+        _surveyItem->cameraCalc()->adjustedFootprintSide()->setRawValue(0);
+        QCOMPARE(rebuildSpy.count(), 1);
+        QCOMPARE(_surveyItem->_transectCount(), 1);
+    }
 }
 
 UT_REGISTER_TEST(SurveyComplexItemTest, TestLabel::Unit, TestLabel::MissionManager)

--- a/test/MissionManager/SurveyComplexItemTest.h
+++ b/test/MissionManager/SurveyComplexItemTest.h
@@ -29,6 +29,7 @@ private slots:
     void _testItemGeneration();
     void _testItemCount();
     void _testHoverCaptureItemGeneration();
+    void _testMaxTransectCount();
 
 private:
     double _clampGridAngle180(double gridAngle);

--- a/test/MissionManager/TransectStyleComplexItemTest.cc
+++ b/test/MissionManager/TransectStyleComplexItemTest.cc
@@ -46,7 +46,7 @@ void TransectStyleComplexItemTest::_testDirty()
     rgFacts << _transectStyleItem->turnAroundDistance() << _transectStyleItem->cameraTriggerInTurnAround()
             << _transectStyleItem->hoverAndCapture() << _transectStyleItem->refly90Degrees();
     for (Fact* fact : rgFacts) {
-        qDebug() << fact->name();
+        qCDebug(UnitTestLog) << fact->name();
         QVERIFY(!_transectStyleItem->dirty());
         changeFactValue(fact);
         QVERIFY(_multiSpy->emittedOnce("dirtyChanged"));
@@ -91,7 +91,7 @@ void TransectStyleComplexItemTest::_testRebuildTransects()
             << _transectStyleItem->hoverAndCapture() << _transectStyleItem->refly90Degrees()
             << _transectStyleItem->cameraCalc()->frontalOverlap() << _transectStyleItem->cameraCalc()->sideOverlap();
     for (Fact* fact : rgFacts) {
-        qDebug() << fact->name();
+        qCDebug(UnitTestLog) << fact->name();
         changeFactValue(fact);
         QVERIFY(_transectStyleItem->rebuildTransectsPhase1Called);
         QVERIFY(_transectStyleItem->recalcCameraShotsCalled);
@@ -134,7 +134,7 @@ void TransectStyleComplexItemTest::_testDistanceSignalling()
     rgFacts << _transectStyleItem->turnAroundDistance() << _transectStyleItem->hoverAndCapture()
             << _transectStyleItem->refly90Degrees();
     for (Fact* fact : rgFacts) {
-        qDebug() << fact->name();
+        qCDebug(UnitTestLog) << fact->name();
         changeFactValue(fact);
         QVERIFY(_multiSpy->emittedByMask(_multiSpy->mask("complexDistanceChanged", "greatestDistanceToChanged")));
         _transectStyleItem->setDirty(false);
@@ -148,12 +148,12 @@ void TransectStyleComplexItemTest::_testAltitudes()
     _transectStyleItem->cameraCalc()->distanceToSurface()->setRawValue(50);
     _transectStyleItem->cameraCalc()->adjustedFootprintFrontal()->setRawValue(10);
     _transectStyleItem->cameraCalc()->adjustedFootprintSide()->setRawValue(10);
-    qDebug() << _transectStyleItem->_transectCount();
+    qCDebug(UnitTestLog) << _transectStyleItem->_transectCount();
     QList<MissionItem*> rgItems;
     _transectStyleItem->appendMissionItems(rgItems, this);
     for (const MissionItem* missionItem : rgItems) {
         if (missionItem->command() == MAV_CMD_NAV_WAYPOINT) {
-            qDebug() << missionItem->param7();
+            qCDebug(UnitTestLog) << missionItem->param7();
         }
     }
 }

--- a/test/Utilities/StateMachine/transitions/SignalDataTransitionTest.cc
+++ b/test/Utilities/StateMachine/transitions/SignalDataTransitionTest.cc
@@ -51,7 +51,7 @@ void SignalDataTransitionTest::_testSignalDataTransition()
 
     // Give time for event processing
     if (!finishedSpy.wait(TestTimeout::shortMs())) {
-        qDebug() << "finishedSpy wait failed. guardCalled:" << guardCalled << "actionCalled:" << actionCalled;
+        qCDebug(UnitTestLog) << "finishedSpy wait failed. guardCalled:" << guardCalled << "actionCalled:" << actionCalled;
     }
     QVERIFY(guardCalled);
     QVERIFY(actionCalled);

--- a/test/Vehicle/RequestMessageTest.cc
+++ b/test/Vehicle/RequestMessageTest.cc
@@ -58,7 +58,7 @@ void RequestMessageTest::_performTestCases()
 {
     int index = 0;
     for (TestCase_t& testCase : _rgTestCases) {
-        qDebug() << "Testing case" << index++;
+        qCDebug(UnitTestLog) << "Testing case" << index++;
         _testCaseWorker(testCase);
     }
 }

--- a/test/Vehicle/SendMavCommandWithHandlerTest.cc
+++ b/test/Vehicle/SendMavCommandWithHandlerTest.cc
@@ -75,7 +75,7 @@ void SendMavCommandWithHandlerTest::_performTestCases()
 {
     int index = 0;
     for (TestCase_t& testCase : _rgTestCases) {
-        qDebug() << "Testing case" << index++;
+        qCDebug(UnitTestLog) << "Testing case" << index++;
         _testCaseWorker(testCase);
     }
 }

--- a/test/Vehicle/SendMavCommandWithSignallingTest.cc
+++ b/test/Vehicle/SendMavCommandWithSignallingTest.cc
@@ -28,7 +28,7 @@ bool _waitForExpectedCommandResult(QSignalSpy& spyResult, MAV_CMD expectedComman
             return true;
         }
 
-        qDebug() << "Received response to command" << arguments.at(2).toInt() << ", ignoring, waiting for:" << expectedCommand;
+        qCDebug(UnitTestLog) << "Received response to command" << arguments.at(2).toInt() << ", ignoring, waiting for:" << expectedCommand;
     }
 }
 }
@@ -77,7 +77,7 @@ void SendMavCommandWithSignallingTest::_performTestCases()
 {
     int index = 0;
     for (TestCase_t& testCase : _rgTestCases) {
-        qDebug() << "Testing case" << index++;
+        qCDebug(UnitTestLog) << "Testing case" << index++;
         _testCaseWorker(testCase);
     }
 }


### PR DESCRIPTION
Fixes #14467

## Problem

`SurveyComplexItem` and `CorridorScanComplexItem` could generate thousands of transects when a very small footprint spacing was configured, freezing or crashing QGC. The underlying cause was that both items used a hack (`_forceLargeTransectSpacingMeters = 100000`) to produce a single transect for near-zero spacing rather than properly capping the count. Additionally, the fixed `+2000 m` sweep-line extent in `SurveyComplexItem` was insufficient for polygons larger than ~10 km, causing transects to miss polygon edges.

## Changes

### Production

**`TransectStyleComplexItem.h`**
- Add `public static constexpr int maxTransectCount = 1000`
- Remove obsolete `_minimumTransectSpacingMeters` and `_forceLargeTransectSpacingMeters`

**`SurveyComplexItem`**
- Replace the fixed `+2000 m` sweep extent with `diagonal * 1.5` (scales with polygon size; provides a 50% safety margin beyond the worst-case 45° rotation reach)
- Add `maxWidth <= 0` guard to handle degenerate polygons (all vertices coincident/collinear) — the old fixed offset was immune to this; the new formula introduced a crash at `lineList.first()` on an empty list
- Add `gridSpacing <= 0` guard: seed a single center transect and warn instead of using the force-large-spacing hack
- Cap `gridSpacing` at `diagonal / maxTransectCount` with `qCWarning` when too small
- Remove dead code: `_rebuildTransectsPhase1Worker`, `_rebuildTransectsFromPolygon`, and the `#if 0`-guarded polygon-splitting functions (`_rebuildTransectsPhase1WorkerSplitPolygons`, `_PolygonDecomposeConvex`, `_VertexCanSeeOther`, `_VertexIsReflex`)

**`CorridorScanComplexItem`**
- `_calcTransectCount`: guard `fullWidth <= 0` → 1; guard `spacing == 0` → 1; clamp with `qMin(..., maxTransectCount)`
- `_calcTransectSpacing`: replace force-large-spacing hack with a proper cap at `corridorWidth / maxTransectCount`; add `qCWarning` for invalid `corridorWidth <= 0`

### Tests

- Add `_testMaxTransectCount` to `SurveyComplexItemTest` and `CorridorScanComplexItemTest`: verifies tiny spacing is capped at `<= maxTransectCount` and zero spacing falls back to a single transect; uses `QSignalSpy` on `cameraShotsChanged` to confirm the rebuild ran
- Replace all bare `qDebug()` with `qCDebug(UnitTestLog)` across 11 test files
- Fix typos: `hasTuraround` → `hasTurnaround`, `imagesInTuraround` → `imagesInTurnaround`
