### PR TITLE
fix(FlightMap): fix trackpad scroll and pinch zoom on all platforms

### DIFF
--- a/src/FlightMap/FlightMap.qml
+++ b/src/FlightMap/FlightMap.qml
@@ -29,7 +29,6 @@ Map {
     property var    _activeVehicleCoordinate:   _activeVehicle ? _activeVehicle.coordinate : QtPositioning.coordinate()
 
     function setVisibleRegion(region) {
-        // TODO: Is this still necessary with Qt 5.11?
         // This works around a bug on Qt where if you set a visibleRegion and then the user moves or zooms the map
         // and then you set the same visibleRegion the map will not move/scale appropriately since it thinks there
         // is nothing to do.
@@ -120,34 +119,36 @@ Map {
         id:     pinchHandler
         target: null
 
-        property var pinchStartCentroid
+        property var pinchStartGeoCoord     // geo coordinate under centroid at pinch start
+        property var pinchStartScreenPoint  // screen point of centroid at pinch start
 
         onActiveChanged: {
             if (active) {
-                pinchStartCentroid = _map.toCoordinate(pinchHandler.centroid.position, false)
+                // Capture both the screen point and its geo coordinate once at pinch start.
+                // alignCoordinateToPoint requires a fixed screen anchor; using the live
+                // centroid.position causes the map to pan as fingers drift.
+                pinchStartScreenPoint = pinchHandler.centroid.position
+                pinchStartGeoCoord    = _map.toCoordinate(pinchStartScreenPoint, false)
             }
         }
         onScaleChanged: (delta) => {
-            let newZoomLevel = Math.max(_map.zoomLevel + Math.log2(delta), 0)
-            _map.zoomLevel = newZoomLevel
-            _map.alignCoordinateToPoint(pinchStartCentroid, pinchHandler.centroid.position)
+            _map.zoomLevel = Math.max(_map.zoomLevel + Math.log2(delta), 0)
+            _map.alignCoordinateToPoint(pinchStartGeoCoord, pinchStartScreenPoint)
         }
     }
 
     WheelHandler {
-        // Workaround for QTBUG-112394 / QTBUG-112432 (Linux/Wayland, STILL OPEN as of Qt 6.10):
-        // The Wayland protocol (wl_seat) only exposes three capability flags
-        // (POINTER/KEYBOARD/TOUCH) with no way to distinguish a mouse from a trackpad.
-        // Qt's Wayland QPA therefore registers all pointer devices as TouchPad, so
-        // WheelHandler's default acceptedDevices=Mouse silently drops all scroll events.
-        // This cannot be fixed in Qt without a Wayland protocol extension that does not yet exist.
-        //
-        // The same problem affects xcb / XWayland: when QGC runs under XWayland (e.g. an AppImage
-        // forced to QT_QPA_PLATFORM=xcb on a Wayland session), XWayland translates Wayland pointer
-        // events back to X11 and device-type metadata is lost — physical mouse scroll events arrive
-        // at Qt as PointerDevice.TouchPad.
-        acceptedDevices:    Qt.platform.pluginName === "wayland" || Qt.platform.pluginName === "xcb" ?
-                                PointerDevice.Mouse | PointerDevice.TouchPad : PointerDevice.Mouse
+        // WheelHandler's default acceptedDevices=Mouse silently drops trackpad scroll events on
+        // multiple platforms:
+        //   - Linux/Wayland (QTBUG-112394 / QTBUG-112432): the Wayland
+        //     protocol exposes no way to distinguish a mouse from a trackpad, so Qt registers all
+        //     pointer devices as TouchPad.
+        //   - xcb / XWayland: Wayland pointer events are translated back to X11 and device-type
+        //     metadata is lost — physical mouse scroll events arrive as PointerDevice.TouchPad.
+        //   - macOS (cocoa): trackpad scroll events are correctly reported as PointerDevice.TouchPad
+        //     but are excluded by the Mouse-only default.
+        // Accepting both Mouse and TouchPad on all platforms is harmless and covers every case.
+        acceptedDevices:    PointerDevice.Mouse | PointerDevice.TouchPad
         rotationScale:      1 / 120
 
         onWheel: (event) => {


### PR DESCRIPTION
Fixes #14473

## Changes

- **Trackpad scroll zoom**: Changed `WheelHandler.acceptedDevices` from `PointerDevice.Mouse` to `PointerDevice.Mouse | PointerDevice.TouchPad` on all platforms. On macOS (cocoa), trackpad scroll events are correctly typed as `TouchPad` by Qt but were silently dropped by the Mouse-only default. The same issue affects Linux/Wayland (QTBUG-112394/QTBUG-112432) and xcb/XWayland where all pointer devices appear as `TouchPad`.

- **Pinch zoom panning**: Fixed `PinchHandler` incorrectly panning the map during a pinch gesture. The old code passed the live `centroid.position` as the screen anchor to `alignCoordinateToPoint`, so as fingers drifted the anchor moved and the map panned. Now both the screen point and its geo coordinate are captured once at pinch start and held fixed for the entire gesture.