### PR TITLE
ci: remove qttools from lupdate modules (now a base archive in Qt 6.10.3)

### DIFF
--- a/.github/workflows/lupdate.yml
+++ b/.github/workflows/lupdate.yml
@@ -37,7 +37,6 @@ jobs:
           version: ${{ steps.config.outputs.qt_version }}
           host: linux
           arch: linux_gcc_64
-          modules: qttools
 
       - name: Update translation files
         run: python3 tools/translations/qgc_lupdate.py


### PR DESCRIPTION
## Summary

`qttools` is no longer installable via `--modules` in Qt 6.10.3 — it now ships as a base archive included in the default installation. Passing it via `--modules` causes aqtinstall to fail:

```
ERROR: The packages ['qttools'] were not found while parsing XML of package information!
```

This prevents Qt from installing at all, so `lupdate` never runs.

## Fix

Remove `modules: qttools` from the lupdate workflow. The `qttools` package (including `lupdate`) is already present in the base Qt 6.10.3 installation.

Verified via:
```
aqt list-qt linux desktop --archives 6.10.3 linux_gcc_64 | grep qttools  # present
aqt list-qt linux desktop --modules 6.10.3 linux_gcc_64 | grep qttools   # absent
```

Refs #14405