### PR TITLE
fix(PX4): add BAT#_CAPACITY to Power Config UI, remove deprecated BAT#_V_LOAD_DROP

### DIFF
--- a/src/AutoPilotPlugins/PX4/BatteryParams.qml
+++ b/src/AutoPilotPlugins/PX4/BatteryParams.qml
@@ -18,14 +18,14 @@ QtObject {
     property Fact battNumCells:                 controller.getParameterFact(-1, "BAT#_N_CELLS".replace      ("#", batteryIndex), false)
     property Fact battHighVolt:                 controller.getParameterFact(-1, "BAT#_V_CHARGED".replace    ("#", batteryIndex), false)
     property Fact battLowVolt:                  controller.getParameterFact(-1, "BAT#_V_EMPTY".replace      ("#", batteryIndex), false)
-    property Fact battVoltLoadDrop:             controller.getParameterFact(-1, "BAT#_V_LOAD_DROP".replace  ("#", batteryIndex), false)
+    property Fact battCapacity:                 controller.getParameterFact(-1, "BAT#_CAPACITY".replace     ("#", batteryIndex), false)
     property Fact battVoltageDivider:           controller.getParameterFact(-1, "BAT#_V_DIV".replace        ("#", batteryIndex), false)
     property Fact battAmpsPerVolt:              controller.getParameterFact(-1, "BAT#_A_PER_V".replace      ("#", batteryIndex), false)
 
     property bool battNumCellsAvailable:        controller.parameterExists(-1, "BAT#_N_CELLS".replace       ("#", batteryIndex))
     property bool battHighVoltAvailable:        controller.parameterExists(-1, "BAT#_V_CHARGED".replace     ("#", batteryIndex))
     property bool battLowVoltAvailable:         controller.parameterExists(-1, "BAT#_V_EMPTY".replace       ("#", batteryIndex))
-    property bool battVoltLoadDropAvailable:    controller.parameterExists(-1, "BAT#_V_LOAD_DROP".replace   ("#", batteryIndex))
+    property bool battCapacityAvailable:        controller.parameterExists(-1, "BAT#_CAPACITY".replace      ("#", batteryIndex))
     property bool battVoltageDividerAvailable:  controller.parameterExists(-1, "BAT#_V_DIV".replace         ("#", batteryIndex))
     property bool battAmpsPerVoltAvailable:     controller.parameterExists(-1, "BAT#_A_PER_V".replace       ("#", batteryIndex))
 }

--- a/src/AutoPilotPlugins/PX4/VehicleConfig/Power.VehicleConfig.json
+++ b/src/AutoPilotPlugins/PX4/VehicleConfig/Power.VehicleConfig.json
@@ -44,6 +44,14 @@
                     "showWhen": "controller.parameterExists(-1, _fullParamName(\"_N_CELLS\"))"
                 },
                 {
+                    "param": "_CAPACITY",
+                    "label": "Battery capacity (mAh)",
+                    "optional": true,
+                    "showWhen": "controller.parameterExists(-1, _fullParamName(\"_CAPACITY\"))",
+                    "description": "Set to -1 to disable. When set to a positive value, enables coulomb counting for more accurate state-of-charge and time-remaining estimates."
+                },
+                {
+
                     "param": "_V_EMPTY",
                     "label": "Empty voltage (per cell)",
                     "optional": true,
@@ -84,12 +92,6 @@
                             "batteryIndex": "_rawIndex"
                         }
                     }
-                },
-                {
-                    "param": "_V_LOAD_DROP",
-                    "label": "Voltage drop on full load (per cell)",
-                    "optional": true,
-                    "showWhen": "controller.parameterExists(-1, _fullParamName(\"_V_LOAD_DROP\"))"
                 }
             ]
         },

--- a/tools/generators/common/controls.py
+++ b/tools/generators/common/controls.py
@@ -256,27 +256,56 @@ def render_textfield(
     label_source: str = "fact.label",
     qml_type: str = "FactTextField",
     extra_lines: list[str] | None = None,
+    description: str = "",
     tr_context: str = "",
 ) -> str:
-    """Render a ``FactTextField`` (or ``LabelledFactTextField``)."""
+    """Render a ``FactTextField`` (or ``LabelledFactTextField``).
+
+    When *description* is set the control is wrapped in a ``ColumnLayout``
+    with a small ``QGCLabel`` below it, matching the app-settings style.
+    """
     if qml_type == "LabelledFactTextField":
         label_line = f'    label: {qml_tr(label, tr_context)}' if label else f"    label: {label_source}"
     else:
         label_line = None
 
-    lines = [f"{indent}{qml_type} {{"]
+    ii = indent + "    " if description else indent
+
+    lines = [f"{ii}{qml_type} {{"]
     if label_line:
-        lines.append(f"{indent}{label_line}")
-    lines.append(f"{indent}    Layout.fillWidth: true")
-    lines.append(f"{indent}    fact: {fact_ref}")
+        lines.append(f"{ii}{label_line}")
+    lines.append(f"{ii}    Layout.fillWidth: true")
+    lines.append(f"{ii}    fact: {fact_ref}")
     if enable_when:
-        lines.append(f"{indent}    enabled: {enable_when}")
+        lines.append(f"{ii}    enabled: {enable_when}")
     if placeholder:
-        lines.append(f'{indent}    textField.placeholderText: {qml_tr(placeholder, tr_context)}')
+        lines.append(f'{ii}    textField.placeholderText: {qml_tr(placeholder, tr_context)}')
     if extra_lines:
         for el in extra_lines:
-            lines.append(f"{indent}    {el}")
-    lines.append(f"{indent}}}")
+            lines.append(f"{ii}    {el}")
+    lines.append(f"{ii}}}")
+
+    if description:
+        desc_lines = [
+            f"{ii}QGCLabel {{",
+            f"{ii}    Layout.fillWidth: true",
+            f"{ii}    Layout.preferredWidth: 0",
+            f"{ii}    text: {qml_tr(description, tr_context)}",
+            f"{ii}    font.pointSize: ScreenTools.smallFontPointSize",
+            f"{ii}    wrapMode: Text.WordWrap",
+            f"{ii}}}",
+        ]
+        wrapped = [
+            f"{indent}ColumnLayout {{",
+            f"{indent}    Layout.fillWidth: true",
+            f"{indent}    Layout.preferredWidth: 0",
+            f"{indent}    spacing: ScreenTools.defaultFontPixelHeight / 4",
+            "\n".join(lines),
+            "\n".join(desc_lines),
+            f"{indent}}}",
+        ]
+        return "\n".join(wrapped)
+
     return "\n".join(lines)
 
 

--- a/tools/generators/config_qml/README.md
+++ b/tools/generators/config_qml/README.md
@@ -99,7 +99,7 @@ auto-detects based on fact metadata (bool → checkbox, enum → combobox, etc.)
 |-----------------|--------|------------|
 | *(omitted)* | Auto-detected | — |
 | `combobox` | `LabelledFactComboBox` | `enumValues` for manual value/label list |
-| `textfield` | `LabelledFactTextField` | — |
+| `textfield` | `LabelledFactTextField` | `description` for optional help text below the field |
 | `checkbox` | `FactCheckBoxSlider` | — |
 | `toggleCheckbox` | `QGCCheckBoxSlider` with custom logic | `toggleCheckbox` |
 | `slider` | Slider with optional enable-checkbox and adjacent button | `sliderMin`, `sliderMax`, `enableCheckbox`, `button` |
@@ -131,6 +131,12 @@ supply a manual value/label list:
 ```
 
 `value` must be a number or string. `label` must be a string.
+
+#### `textfield` keys
+
+| Key | Type | Description |
+|-----|------|-------------|
+| `description` | string | Help text rendered below the field in small font. Wraps the control in a `ColumnLayout`. |
 
 #### `factslider` keys
 

--- a/tools/generators/config_qml/emit.py
+++ b/tools/generators/config_qml/emit.py
@@ -317,9 +317,13 @@ def _qml_control(ctrl: ControlDef, indent: str, *, indexed: bool = False, dialog
         enable_when=ctrl.enableWhen,
         label_source=f"{fact_ref}.shortDescription",
         qml_type="LabelledFactTextField",
+        description=ctrl.description,
         tr_context=tr_context,
     )
-    _v = _vis_expr(ctrl.showWhen, ctrl.optional, ctrl.param, "fact")
+    # When description is set, render_textfield wraps in a ColumnLayout which
+    # has no `fact` property, so we must use the full fact_ref expression.
+    _fact_for_vis = fact_ref if ctrl.description else "fact"
+    _v = _vis_expr(ctrl.showWhen, ctrl.optional, ctrl.param, _fact_for_vis)
     if _v:
         qml = _inject_prop(qml, f"{indent}    visible: {_v}")
     return _apply_indent(qml)


### PR DESCRIPTION
Fixes #14035

## Summary

### Problem
The PX4 Power Config page did not expose `BAT#_CAPACITY` (battery capacity in mAh), and still showed `BAT#_V_LOAD_DROP` which has been removed from PX4.

### Changes

**`BatteryParams.qml`**
- Add `battCapacity` / `battCapacityAvailable` for `BAT#_CAPACITY`
- Remove `battVoltLoadDrop` / `battVoltLoadDropAvailable` for `BAT#_V_LOAD_DROP`

**`Power.VehicleConfig.json`**
- Add `_CAPACITY` control after `_N_CELLS`, with a help-text description explaining the -1 sentinel and coulomb-counting behaviour
- Remove `_V_LOAD_DROP` control

**`tools/generators/common/controls.py`**
- `render_textfield()` gains an optional `description` parameter; when set, the `LabelledFactTextField` is wrapped in a `ColumnLayout` with a small `QGCLabel` below it (`Layout.preferredWidth: 0` prevents the text from expanding the column width)

**`tools/generators/config_qml/emit.py`**
- Pass `ctrl.description` through to `render_textfield()` in the textfield fallthrough path

**`tools/generators/config_qml/README.md`**
- Document the new `description` key for `textfield` controls

## Background
`BAT#_CAPACITY` is defined in PX4's `lib/battery/module.yaml`. When set to a positive value, `battery.cpp` enables coulomb counting and time-remaining estimation (both gated on `capacity_mah > 0`). Setting it to -1 disables the feature. `BAT#_V_LOAD_DROP` is no longer present in any PX4 parameter YAML files.