### PR TITLE
MainWindow: Fix repeated Cmd+Q stacking close confirmation dialogs

### DIFF
--- a/src/MainWindow/MainWindow.qml
+++ b/src/MainWindow/MainWindow.qml
@@ -220,6 +220,7 @@ ApplicationWindow {
     readonly property int _skipPendingParameterWritesCheckMask: 0x02
     readonly property int _skipActiveConnectionsCheckMask: 0x04
     property int _closeChecksToSkip: 0
+    property bool _reentrantCloseGuard: false
     function performCloseChecks() {
         if (!(_closeChecksToSkip & _skipUnsavedMissionCheckMask) && !checkForUnsavedMission()) {
             return false
@@ -238,11 +239,13 @@ ApplicationWindow {
 
     function checkForUnsavedMission() {
         if (planView._planMasterController.dirtyForSave || planView._planMasterController.dirtyForUpload) {
+            let accepted = false
+            _reentrantCloseGuard = true
             _showMessageDialogWorker(mainWindow, closeDialogTitle,
                               qsTr("You have a mission edit in progress which has not been saved/uploaded. If you close you will lose changes. Are you sure you want to close?"),
                               Dialog.Yes | Dialog.No,
-                              function() { _closeChecksToSkip |= _skipUnsavedMissionCheckMask; performCloseChecks() },
-                              null,
+                              function() { accepted = true; _closeChecksToSkip |= _skipUnsavedMissionCheckMask; performCloseChecks() },
+                              function() { if (!accepted) _reentrantCloseGuard = false },
                               true /* bypassNavigationCheck */)
             return false
         } else {
@@ -253,11 +256,13 @@ ApplicationWindow {
     function checkForPendingParameterWrites() {
         for (var index=0; index<QGroundControl.multiVehicleManager.vehicles.count; index++) {
             if (QGroundControl.multiVehicleManager.vehicles.get(index).parameterManager.pendingWrites) {
+                let accepted = false
+                _reentrantCloseGuard = true
                 _showMessageDialogWorker(mainWindow, closeDialogTitle,
                     qsTr("You have pending parameter updates to a vehicle. If you close you will lose changes. Are you sure you want to close?"),
                     Dialog.Yes | Dialog.No,
-                    function() { _closeChecksToSkip |= _skipPendingParameterWritesCheckMask; performCloseChecks() },
-                    null,
+                    function() { accepted = true; _closeChecksToSkip |= _skipPendingParameterWritesCheckMask; performCloseChecks() },
+                    function() { if (!accepted) _reentrantCloseGuard = false },
                     true /* bypassNavigationCheck */)
                 return false
             }
@@ -267,11 +272,13 @@ ApplicationWindow {
 
     function checkForActiveConnections() {
         if (QGroundControl.multiVehicleManager.activeVehicle) {
+            let accepted = false
+            _reentrantCloseGuard = true
             _showMessageDialogWorker(mainWindow, closeDialogTitle,
                 qsTr("There are still active connections to vehicles. Are you sure you want to exit?"),
                 Dialog.Yes | Dialog.No,
-                function() { _closeChecksToSkip |= _skipActiveConnectionsCheckMask; performCloseChecks() },
-                null,
+                function() { accepted = true; _closeChecksToSkip |= _skipActiveConnectionsCheckMask; performCloseChecks() },
+                function() { if (!accepted) _reentrantCloseGuard = false },
                 true /* bypassNavigationCheck */)
             return false
         } else {
@@ -281,6 +288,10 @@ ApplicationWindow {
 
     onClosing: (close) => {
         if (!_forceClose) {
+            if (_reentrantCloseGuard) {
+                close.accepted = false
+                return
+            }
             _closeChecksToSkip = 0
             close.accepted = performCloseChecks()
         }

--- a/test/Vehicle/VehicleLinkManagerTest.cc
+++ b/test/Vehicle/VehicleLinkManagerTest.cc
@@ -17,33 +17,42 @@ void VehicleLinkManagerTest::_simpleLinkTest()
     _startMockLink(1, false /*highLatency*/, true /*incrementVehicleId*/, mockConfig, mockLink);
     QVERIFY(mockConfig);
     QVERIFY(mockLink);
+
     const QSignalSpy spyConfigDelete(mockConfig.get(), &QObject::destroyed);
     const QSignalSpy spyLinkDelete(mockLink.get(), &QObject::destroyed);
     QVERIFY(spyConfigDelete.isValid());
     QVERIFY(spyLinkDelete.isValid());
+
     Vehicle* const vehicle = waitForVehicleConnect(TestTimeout::shortMs());
     QVERIFY(vehicle);
     QVERIFY_TRUE_WAIT(MultiVehicleManager::instance()->vehicles()->count() == 1, TestTimeout::shortMs());
+
     QSignalSpy spyVehicleDelete(vehicle, &QObject::destroyed);
     QSignalSpy spyVehicleInitialConnectComplete(vehicle, &Vehicle::initialConnectComplete);
     QCOMPARE(mockConfig.use_count(), 2);  // Refs: This method, MockLink
     QCOMPARE(mockLink.use_count(), 3);    // Refs: This method, LinkManager, Vehicle
+
     // We wait for the full initial connect sequence to complete to catch anby ComponentInformationManager bugs
     QVERIFY_TRUE_WAIT(spyVehicleInitialConnectComplete.count() > 0 || vehicle->isInitialConnectComplete(),
                       TestTimeout::mediumMs());
+
     // Drain queued command traffic before disconnect to avoid racing pending writes with link teardown.
     UnitTest::settleEventLoopForCleanup(2, 10);
     mockLink->disconnect();
+
     // Vehicle should go away due to disconnect
     QVERIFY_SIGNAL_WAIT(spyVehicleDelete, TestTimeout::shortMs());
+
     // Config/Link should still be alive due to the last refs being held by this method
     QCOMPARE(spyConfigDelete.count(), 0);
     QCOMPARE(spyLinkDelete.count(), 0);
     QCOMPARE(mockConfig.use_count(), 2);  // Refs: This method, MockLink
     QCOMPARE(mockLink.use_count(), 1);    // Refs: This method
+
     // Let go of our refs from this method and config and link should go away
     mockConfig.reset();
     mockLink.reset();
+
     QCOMPARE(mockConfig.use_count(), 0);
     QCOMPARE(mockLink.use_count(), 0);
     QCOMPARE(spyLinkDelete.count(), 1);
@@ -56,27 +65,34 @@ void VehicleLinkManagerTest::_simpleCommLossTest()
     SharedLinkInterfacePtr mockLink;
     _startMockLink(1, false /*highLatency*/, true /*incrementVehicleId*/, mockConfig, mockLink);
     MockLink* const pMockLink = qobject_cast<MockLink*>(mockLink.get());
+
     Vehicle* const vehicle = waitForVehicleConnect(TestTimeout::shortMs());
     QVERIFY(vehicle);
     QVERIFY_TRUE_WAIT(MultiVehicleManager::instance()->vehicles()->count() == 1, TestTimeout::mediumMs());
+
     QSignalSpy spyVehicleInitialConnectComplete(vehicle, &Vehicle::initialConnectComplete);
     QVERIFY_TRUE_WAIT(spyVehicleInitialConnectComplete.count() > 0 || vehicle->isInitialConnectComplete(),
                       TestTimeout::mediumMs());
+
     QSignalSpy spyCommLostChanged(vehicle->vehicleLinkManager(), &VehicleLinkManager::communicationLostChanged);
+
     pMockLink->setCommLost(true);
     QVERIFY_SIGNAL_WAIT(spyCommLostChanged, VehicleLinkManager::kTestCommLostDetectionTimeoutMs);
     QCOMPARE(spyCommLostChanged.count(), 1);
     QCOMPARE(spyCommLostChanged[0][0].toBool(), true);
     spyCommLostChanged.clear();
+
     pMockLink->setCommLost(false);
     QVERIFY_SIGNAL_WAIT(spyCommLostChanged, VehicleLinkManager::kTestCommLostDetectionTimeoutMs);
     QCOMPARE(spyCommLostChanged.count(), 1);
     QCOMPARE(spyCommLostChanged[0][0].toBool(), false);
     spyCommLostChanged.clear();
+
     vehicle->vehicleLinkManager()->setCommunicationLostEnabled(false);
     pMockLink->setCommLost(true);
     QVERIFY_NO_SIGNAL_WAIT(spyCommLostChanged, VehicleLinkManager::kTestCommLostDetectionTimeoutMs);
     spyCommLostChanged.clear();
+
     vehicle->vehicleLinkManager()->setCommunicationLostEnabled(true);
     QVERIFY_SIGNAL_WAIT(spyCommLostChanged, VehicleLinkManager::kTestCommLostDetectionTimeoutMs);
     QCOMPARE(spyCommLostChanged.count(), 1);
@@ -90,23 +106,29 @@ void VehicleLinkManagerTest::_multiLinkSingleVehicleTest()
     SharedLinkInterfacePtr mockLink2;
     _startMockLink(1, false /*highLatency*/, false /*incrementVehicleId*/, mockConfig1, mockLink1);
     _startMockLink(2, false /*highLatency*/, false /*incrementVehicleId*/, mockConfig2, mockLink2);
+
     Vehicle* const vehicle = waitForVehicleConnect(TestTimeout::shortMs());
     QVERIFY(vehicle);
     QVERIFY_TRUE_WAIT(MultiVehicleManager::instance()->vehicles()->count() == 1, TestTimeout::mediumMs());
+
     VehicleLinkManager* const vehicleLinkManager = vehicle->vehicleLinkManager();
     QVERIFY(vehicleLinkManager);
+
     QSignalSpy spyVehicleInitialConnectComplete(vehicle, &Vehicle::initialConnectComplete);
     QVERIFY_TRUE_WAIT(spyVehicleInitialConnectComplete.count() > 0 || vehicle->isInitialConnectComplete(),
                       TestTimeout::mediumMs());
+
     // The first link to start sending a heartbeat will be the primary link.
     // Depending on how the thread scheduling works, that could be the mockLink2.
     const SharedLinkInterfacePtr primaryLink = vehicleLinkManager->primaryLink().lock();
     QVERIFY(primaryLink == mockLink1 || primaryLink == mockLink2);
+
     MockLink* pMockLink1 = qobject_cast<MockLink*>(mockLink1.get());
     MockLink* pMockLink2 = qobject_cast<MockLink*>(mockLink2.get());
     if (primaryLink == mockLink2) {
         std::swap(pMockLink1, pMockLink2);
     }
+
     const QStringList rgNames = vehicleLinkManager->linkNames();
     QStringList rgStatus = vehicleLinkManager->linkStatuses();
     QCOMPARE(rgNames.count(), 2);
@@ -115,49 +137,62 @@ void VehicleLinkManagerTest::_multiLinkSingleVehicleTest()
     QCOMPARE(rgStatus.count(), 2);
     QVERIFY(rgStatus[0].isEmpty());
     QVERIFY(rgStatus[1].isEmpty());
+
     MultiSignalSpy multiSpy;
     QVERIFY(multiSpy.init(vehicleLinkManager));
+
     // Comm lost on 2: 1 is primary, 2 is secondary so comm loss/regain on 2 should only update status text
     pMockLink2->setCommLost(true);
     QCOMPARE(multiSpy.waitForSignal(_linkStatusesChangedSignalName, VehicleLinkManager::kTestCommLostDetectionTimeoutMs),
              true);
-    QVERIFY(multiSpy.onlyEmittedOnce(_linkStatusesChangedSignalName));
+    QVERIFY(multiSpy.onlyEmitted(_linkStatusesChangedSignalName));
+
     rgStatus = vehicleLinkManager->linkStatuses();
     QCOMPARE(rgStatus.count(), 2);
     QVERIFY(rgStatus[0].isEmpty());
     QVERIFY(!rgStatus[1].isEmpty());
+
     multiSpy.clearAllSignals();
+
     pMockLink2->setCommLost(false);
     QCOMPARE(multiSpy.waitForSignal(_linkStatusesChangedSignalName, VehicleLinkManager::kTestCommLostDetectionTimeoutMs),
              true);
-    QVERIFY(multiSpy.onlyEmittedOnce(_linkStatusesChangedSignalName));
+    QVERIFY(multiSpy.onlyEmitted(_linkStatusesChangedSignalName));
+
     rgStatus = vehicleLinkManager->linkStatuses();
     QCOMPARE(rgStatus.count(), 2);
     QVERIFY(rgStatus[0].isEmpty());
     QVERIFY(rgStatus[1].isEmpty());
+
     multiSpy.clearAllSignals();
+
     // Comm loss on 1: 1 is primary so should trigger switch of primary to 2
     pMockLink1->setCommLost(true);
     QCOMPARE(multiSpy.waitForSignal(_primaryLinkChangedSignalName, VehicleLinkManager::kTestCommLostDetectionTimeoutMs),
              true);
     QVERIFY(
         multiSpy.onlyEmittedOnceByMask(multiSpy.mask(_primaryLinkChangedSignalName, _linkStatusesChangedSignalName)));
+
     QCOMPARE(pMockLink2, vehicleLinkManager->primaryLink().lock().get());
     rgStatus = vehicleLinkManager->linkStatuses();
     QCOMPARE(rgStatus.count(), 2);
     QVERIFY(!rgStatus[0].isEmpty());
     QVERIFY(rgStatus[1].isEmpty());
+
     multiSpy.clearAllSignals();
+
     // Comm regained on 1 should leave 2 as primary and only update status
     pMockLink1->setCommLost(false);
     QCOMPARE(multiSpy.waitForSignal(_linkStatusesChangedSignalName, VehicleLinkManager::kTestCommLostDetectionTimeoutMs),
              true);
-    QVERIFY(multiSpy.onlyEmittedOnce(_linkStatusesChangedSignalName));
+    QVERIFY(multiSpy.onlyEmitted(_linkStatusesChangedSignalName));
+
     QCOMPARE(pMockLink2, vehicleLinkManager->primaryLink().lock().get());
     rgStatus = vehicleLinkManager->linkStatuses();
     QCOMPARE(rgStatus.count(), 2);
     QVERIFY(rgStatus[0].isEmpty());
     QVERIFY(rgStatus[1].isEmpty());
+
     multiSpy.clearAllSignals();
 }
 
@@ -167,13 +202,17 @@ void VehicleLinkManagerTest::_connectionRemovedTest()
     SharedLinkInterfacePtr mockLink;
     _startMockLink(1, false /*highLatency*/, true /*incrementVehicleId*/, mockConfig, mockLink);
     MockLink* const pMockLink = qobject_cast<MockLink*>(mockLink.get());
+
     Vehicle* const vehicle = waitForVehicleConnect(TestTimeout::mediumMs());
     QVERIFY(vehicle);
     QVERIFY_TRUE_WAIT(MultiVehicleManager::instance()->vehicles()->count() == 1, TestTimeout::mediumMs());
+
     QSignalSpy spyVehicleInitialConnectComplete(vehicle, &Vehicle::initialConnectComplete);
     QVERIFY_TRUE_WAIT(spyVehicleInitialConnectComplete.count() > 0 || vehicle->isInitialConnectComplete(),
                       TestTimeout::mediumMs());
+
     QSignalSpy spyCommLostChanged(vehicle->vehicleLinkManager(), &VehicleLinkManager::communicationLostChanged);
+
     // Connection removed should just signal communication lost
     pMockLink->simulateConnectionRemoved();
     QVERIFY_SIGNAL_WAIT(spyCommLostChanged, VehicleLinkManager::kTestCommLostDetectionTimeoutMs);
@@ -189,30 +228,38 @@ void VehicleLinkManagerTest::_highLatencyLinkTest()
     SharedLinkInterfacePtr mockLink2;
     _startMockLink(1, true /*highLatency*/, false /*incrementVehicleId*/, mockConfig1, mockLink1);
     MockLink* const pMockLink1 = qobject_cast<MockLink*>(mockLink1.get());
+
     Vehicle* const vehicle = waitForVehicleConnect(TestTimeout::mediumMs());
     QVERIFY(vehicle);
     QVERIFY_TRUE_WAIT(MultiVehicleManager::instance()->vehicles()->count() == 1, TestTimeout::mediumMs());
+
     VehicleLinkManager* const vehicleLinkManager = vehicle->vehicleLinkManager();
     QVERIFY(vehicleLinkManager);
+
     MultiSignalSpy multiSpyVLM;
     QVERIFY(multiSpyVLM.init(vehicleLinkManager));
+
     // Addition of second non high latency link should:
     //  Change primary link from 1 to 2
     //  Stop high latency transmission on 1
     QSignalSpy spyTransmissionEnabledChanged(pMockLink1, &MockLink::highLatencyTransmissionEnabledChanged);
     QVERIFY(spyTransmissionEnabledChanged.isValid());
+
     _startMockLink(2, false /*highLatency*/, false /*incrementVehicleId*/, mockConfig2, mockLink2);
     MockLink* pMockLink2 = qobject_cast<MockLink*>(mockLink2.get());
     QCOMPARE(multiSpyVLM.waitForSignal(_primaryLinkChangedSignalName, TestTimeout::shortMs()), true);
     QCOMPARE(pMockLink2, vehicleLinkManager->primaryLink().lock().get());
+
     // Wait for the MAV_CMD_CONTROL_HIGH_LATENCY command to be processed
     if (spyTransmissionEnabledChanged.count() == 0) {
         QVERIFY_SIGNAL_WAIT(spyTransmissionEnabledChanged, TestTimeout::shortMs());
     }
     QCOMPARE(spyTransmissionEnabledChanged.count(), 1);
     QCOMPARE(spyTransmissionEnabledChanged.takeFirst()[0].toBool(), false);
+
     multiSpyVLM.clearAllSignals();
     spyTransmissionEnabledChanged.clear();
+
     // Comm lost on primary:2 should:
     //  Switch primary to 1
     //  Re-enable high latency transmission on 1
@@ -221,12 +268,14 @@ void VehicleLinkManagerTest::_highLatencyLinkTest()
         multiSpyVLM.waitForSignal(_primaryLinkChangedSignalName, VehicleLinkManager::kTestCommLostDetectionTimeoutMs),
         true);
     QCOMPARE(pMockLink1, vehicleLinkManager->primaryLink().lock().get());
+
     // Wait for the MAV_CMD_CONTROL_HIGH_LATENCY command to be processed
     if (spyTransmissionEnabledChanged.count() == 0) {
         QVERIFY_SIGNAL_WAIT(spyTransmissionEnabledChanged, TestTimeout::shortMs());
     }
     QCOMPARE(spyTransmissionEnabledChanged.count(), 1);
     QCOMPARE(spyTransmissionEnabledChanged.takeFirst()[0].toBool(), true);
+
     spyTransmissionEnabledChanged.clear();
 }
 


### PR DESCRIPTION
## Problem

Pressing Cmd+Q while a close-confirmation dialog (e.g. "There are still active connections") is already visible causes `onClosing` to fire again. Each press resets `_closeChecksToSkip` and opens another dialog on top of the existing one, making the window progressively dimmer.

## Fix

Add a `_reentrantCloseGuard` boolean property. When any close-check function opens a confirmation dialog it sets the guard to `true`. `onClosing` now bails out immediately with `close.accepted = false` when the guard is set, preventing any further dialogs from being stacked.

The guard is cleared in the dialog's `closeFunction` (fired on dismiss/No) only when the user has not already clicked Yes (tracked via a `let accepted` closure per dialog), ensuring the guard stays set when the Yes path hands off to the next check in the chain.