### PR TITLE
APM sensors: block navigation during calibration, fix compass cal probe

### DIFF
--- a/src/AutoPilotPlugins/APM/APMSensorsComponent.qml
+++ b/src/AutoPilotPlugins/APM/APMSensorsComponent.qml
@@ -161,7 +161,17 @@ SetupPage {
                 onSetAllCalButtonsEnabled: (enabled) => {
                     buttonColumn.enabled = enabled
                 }
+
+                onCalibrationActiveChanged: {
+                    if (controller.calibrationActive) {
+                        globals.navigationBlockedReason = qsTr("Complete or cancel the current calibration first")
+                    } else {
+                        globals.navigationBlockedReason = ""
+                    }
+                }
             }
+
+            Component.onDestruction: globals.navigationBlockedReason = ""
 
             QGCPalette { id: qgcPal; colorGroupEnabled: true }
 

--- a/src/AutoPilotPlugins/APM/APMSensorsComponentController.cc
+++ b/src/AutoPilotPlugins/APM/APMSensorsComponentController.cc
@@ -61,6 +61,7 @@ void APMSensorsComponentController::_startLogCalibration()
     _cancelButton->setEnabled(_calTypeInProgress == QGCMAVLink::CalibrationMag);
 
     (void) connect(MAVLinkProtocol::instance(), &MAVLinkProtocol::messageReceived, this, &APMSensorsComponentController::_mavlinkMessageReceived);
+    emit calibrationActiveChanged();
 }
 
 void APMSensorsComponentController::_startVisualCalibration()
@@ -74,6 +75,7 @@ void APMSensorsComponentController::_startVisualCalibration()
     (void) _progressBar->setProperty("value", 0);
 
     (void) connect(MAVLinkProtocol::instance(), &MAVLinkProtocol::messageReceived, this, &APMSensorsComponentController::_mavlinkMessageReceived);
+    emit calibrationActiveChanged();
 }
 
 void APMSensorsComponentController::_resetInternalState()
@@ -152,7 +154,9 @@ void APMSensorsComponentController::_stopCalibration(APMSensorsComponentControll
         break;
     }
 
+    (void) disconnect(_vehicle, &Vehicle::mavCommandResult, this, &APMSensorsComponentController::_mavCommandResult);
     _calTypeInProgress = QGCMAVLink::CalibrationNone;
+    emit calibrationActiveChanged();
 }
 
 void APMSensorsComponentController::_mavCommandResult(int vehicleId, int component, int command, int result, int failureCode)
@@ -164,71 +168,10 @@ void APMSensorsComponentController::_mavCommandResult(int vehicleId, int compone
     }
 
     switch (command) {
-    case MAV_CMD_DO_CANCEL_MAG_CAL:
-        (void) disconnect(_vehicle, &Vehicle::mavCommandResult, this, &APMSensorsComponentController::_mavCommandResult);
-        if (result == MAV_RESULT_ACCEPTED) {
-            // Onboard mag cal is supported
-            _calTypeInProgress = QGCMAVLink::CalibrationMag;
-            _rgCompassCalProgress[0] = 0;
-            _rgCompassCalProgress[1] = 0;
-            _rgCompassCalProgress[2] = 0;
-            _rgCompassCalComplete[0] = false;
-            _rgCompassCalComplete[1] = false;
-            _rgCompassCalComplete[2] = false;
-
-            _startLogCalibration();
-            uint8_t compassBits = 0;
-            if ((getParameterFact(ParameterManager::defaultComponentId, QStringLiteral("COMPASS_DEV_ID"))->rawValue().toInt() > 0) &&
-                    getParameterFact(ParameterManager::defaultComponentId, QStringLiteral("COMPASS_USE"))->rawValue().toBool()) {
-                compassBits |= 1 << 0;
-                qCDebug(APMSensorsComponentControllerLog) << "Performing onboard compass cal for compass 1";
-            } else {
-                _rgCompassCalComplete[0] = true;
-                _rgCompassCalSucceeded[0] = true;
-                _rgCompassCalFitness[0] = 0;
-            }
-            if ((getParameterFact(ParameterManager::defaultComponentId, QStringLiteral("COMPASS_DEV_ID2"))->rawValue().toInt() > 0) &&
-                    getParameterFact(ParameterManager::defaultComponentId, QStringLiteral("COMPASS_USE2"))->rawValue().toBool()) {
-                compassBits |= 1 << 1;
-                qCDebug(APMSensorsComponentControllerLog) << "Performing onboard compass cal for compass 2";
-            } else {
-                _rgCompassCalComplete[1] = true;
-                _rgCompassCalSucceeded[1] = true;
-                _rgCompassCalFitness[1] = 0;
-            }
-            if ((getParameterFact(ParameterManager::defaultComponentId, QStringLiteral("COMPASS_DEV_ID3"))->rawValue().toInt() > 0) &&
-                    getParameterFact(ParameterManager::defaultComponentId, QStringLiteral("COMPASS_USE3"))->rawValue().toBool()) {
-                compassBits |= 1 << 2;
-                qCDebug(APMSensorsComponentControllerLog) << "Performing onboard compass cal for compass 3";
-            } else {
-                _rgCompassCalComplete[2] = true;
-                _rgCompassCalSucceeded[2] = true;
-                _rgCompassCalFitness[2] = 0;
-            }
-
-            // We bump up the fitness value so calibration will always succeed
-            const Fact *const compassCalFitness = getParameterFact(ParameterManager::defaultComponentId, _compassCalFitnessParam);
-            _restoreCompassCalFitness = true;
-            _previousCompassCalFitness = compassCalFitness->rawValue().toFloat();
-            getParameterFact(ParameterManager::defaultComponentId, _compassCalFitnessParam)->setRawValue(100.0);
-
-            _appendStatusLog(tr("Rotate the vehicle randomly around all axes until the progress bar fills all the way to the right ."));
-            _vehicle->sendMavCommand(
-                _vehicle->defaultComponentId(),
-                MAV_CMD_DO_START_MAG_CAL,
-                true,          // showError
-                compassBits,   // which compass(es) to calibrate
-                0,             // no retry on failure
-                1,             // save values after complete
-                0,             // no delayed start
-                0              // no auto-reboot
-            );
-
-        }
-        break;
     case MAV_CMD_DO_START_MAG_CAL:
         if (result != MAV_RESULT_ACCEPTED) {
-            _restorePreviousCompassCalFitness();
+            _appendStatusLog(tr("Failed to start compass calibration"));
+            _stopCalibration(StopCalibrationFailed);
         }
         break;
     case MAV_CMD_FIXED_MAG_CAL_YAW:
@@ -247,18 +190,69 @@ void APMSensorsComponentController::_mavCommandResult(int vehicleId, int compone
 
 void APMSensorsComponentController::calibrateCompass()
 {
-    // First we need to determine if the vehicle support onboard compass cal. There isn't an easy way to
-    // do this. A hack is to send the mag cancel command and see if it is accepted.
-    (void) connect(_vehicle, &Vehicle::mavCommandResult, this, &APMSensorsComponentController::_mavCommandResult);
-    _vehicle->sendMavCommand(_vehicle->defaultComponentId(), MAV_CMD_DO_CANCEL_MAG_CAL, false /* showError */);
+    _calTypeInProgress = QGCMAVLink::CalibrationMag;
+    _rgCompassCalProgress[0] = 0;
+    _rgCompassCalProgress[1] = 0;
+    _rgCompassCalProgress[2] = 0;
+    _rgCompassCalComplete[0] = false;
+    _rgCompassCalComplete[1] = false;
+    _rgCompassCalComplete[2] = false;
 
-    // Now we wait for the result to come back
+    _startLogCalibration();
+    uint8_t compassBits = 0;
+    if ((getParameterFact(ParameterManager::defaultComponentId, QStringLiteral("COMPASS_DEV_ID"))->rawValue().toInt() > 0) &&
+            getParameterFact(ParameterManager::defaultComponentId, QStringLiteral("COMPASS_USE"))->rawValue().toBool()) {
+        compassBits |= 1 << 0;
+        qCDebug(APMSensorsComponentControllerLog) << "Performing onboard compass cal for compass 1";
+    } else {
+        _rgCompassCalComplete[0] = true;
+        _rgCompassCalSucceeded[0] = true;
+        _rgCompassCalFitness[0] = 0;
+    }
+    if ((getParameterFact(ParameterManager::defaultComponentId, QStringLiteral("COMPASS_DEV_ID2"))->rawValue().toInt() > 0) &&
+            getParameterFact(ParameterManager::defaultComponentId, QStringLiteral("COMPASS_USE2"))->rawValue().toBool()) {
+        compassBits |= 1 << 1;
+        qCDebug(APMSensorsComponentControllerLog) << "Performing onboard compass cal for compass 2";
+    } else {
+        _rgCompassCalComplete[1] = true;
+        _rgCompassCalSucceeded[1] = true;
+        _rgCompassCalFitness[1] = 0;
+    }
+    if ((getParameterFact(ParameterManager::defaultComponentId, QStringLiteral("COMPASS_DEV_ID3"))->rawValue().toInt() > 0) &&
+            getParameterFact(ParameterManager::defaultComponentId, QStringLiteral("COMPASS_USE3"))->rawValue().toBool()) {
+        compassBits |= 1 << 2;
+        qCDebug(APMSensorsComponentControllerLog) << "Performing onboard compass cal for compass 3";
+    } else {
+        _rgCompassCalComplete[2] = true;
+        _rgCompassCalSucceeded[2] = true;
+        _rgCompassCalFitness[2] = 0;
+    }
+
+    // We bump up the fitness value so calibration will always succeed
+    const Fact *const compassCalFitness = getParameterFact(ParameterManager::defaultComponentId, _compassCalFitnessParam);
+    _restoreCompassCalFitness = true;
+    _previousCompassCalFitness = compassCalFitness->rawValue().toFloat();
+    getParameterFact(ParameterManager::defaultComponentId, _compassCalFitnessParam)->setRawValue(100.0);
+
+    _appendStatusLog(tr("Rotate the vehicle randomly around all axes until the progress bar fills all the way to the right."));
+    (void) connect(_vehicle, &Vehicle::mavCommandResult, this, &APMSensorsComponentController::_mavCommandResult, Qt::UniqueConnection);
+    _vehicle->sendMavCommand(
+        _vehicle->defaultComponentId(),
+        MAV_CMD_DO_START_MAG_CAL,
+        true,          // showError
+        compassBits,   // which compass(es) to calibrate
+        0,             // no retry on failure
+        1,             // save values after complete
+        0,             // no delayed start
+        0              // no auto-reboot
+    );
 }
 
 void APMSensorsComponentController::calibrateCompassNorth(float lat, float lon, int mask)
 {
+    _calTypeInProgress = QGCMAVLink::CalibrationMag;
     _startLogCalibration();
-    (void) connect(_vehicle, &Vehicle::mavCommandResult, this, &APMSensorsComponentController::_mavCommandResult);
+    (void) connect(_vehicle, &Vehicle::mavCommandResult, this, &APMSensorsComponentController::_mavCommandResult, Qt::UniqueConnection);
     _vehicle->sendMavCommand(_vehicle->defaultComponentId(), MAV_CMD_FIXED_MAG_CAL_YAW, true /* showError */, 0 /* north*/, mask, lat, lon);
 }
 

--- a/src/AutoPilotPlugins/APM/APMSensorsComponentController.h
+++ b/src/AutoPilotPlugins/APM/APMSensorsComponentController.h
@@ -59,6 +59,8 @@ class APMSensorsComponentController : public FactPanelController
 
     Q_PROPERTY(bool waitingForCancel                        MEMBER _waitingForCancel                        NOTIFY waitingForCancelChanged)
 
+    Q_PROPERTY(bool calibrationActive                       READ calibrationActive                          NOTIFY calibrationActiveChanged)
+
     Q_PROPERTY(bool compass1CalSucceeded                    READ compass1CalSucceeded                       NOTIFY compass1CalSucceededChanged)
     Q_PROPERTY(bool compass2CalSucceeded                    READ compass2CalSucceeded                       NOTIFY compass2CalSucceededChanged)
     Q_PROPERTY(bool compass3CalSucceeded                    READ compass3CalSucceeded                       NOTIFY compass3CalSucceededChanged)
@@ -89,6 +91,8 @@ public:
     bool compass2CalSucceeded() const { return _rgCompassCalSucceeded[1]; }
     bool compass3CalSucceeded() const { return _rgCompassCalSucceeded[2]; }
 
+    bool calibrationActive() const { return _calTypeInProgress != QGCMAVLink::CalibrationNone; }
+
     double compass1CalFitness() const { return _rgCompassCalFitness[0]; }
     double compass2CalFitness() const { return _rgCompassCalFitness[1]; }
     double compass3CalFitness() const { return _rgCompassCalFitness[2]; }
@@ -102,6 +106,7 @@ signals:
     void orientationCalSidesRotateChanged();
     void resetStatusTextArea();
     void waitingForCancelChanged();
+    void calibrationActiveChanged();
     void setupNeededChanged();
     void calibrationComplete(QGCMAVLink::CalibrationType calType);
     void compass1CalSucceededChanged(bool compass1CalSucceeded);

--- a/src/MainWindow/MainWindow.qml
+++ b/src/MainWindow/MainWindow.qml
@@ -176,8 +176,8 @@ ApplicationWindow {
     //-------------------------------------------------------------------------
     //-- Global simple message dialog
 
-    function _showMessageDialogWorker(owner, dialogTitle, dialogText, buttons = Dialog.Ok, acceptFunction = null, closeFunction = null) {
-        let dialog = simpleMessageDialogComponent.createObject(owner, { title: dialogTitle, text: dialogText, buttons: buttons, acceptFunction: acceptFunction, closeFunction: closeFunction })
+    function _showMessageDialogWorker(owner, dialogTitle, dialogText, buttons = Dialog.Ok, acceptFunction = null, closeFunction = null, bypassNavigationCheck = false) {
+        let dialog = simpleMessageDialogComponent.createObject(owner, { title: dialogTitle, text: dialogText, buttons: buttons, acceptFunction: acceptFunction, closeFunction: closeFunction, bypassNavigationCheck: bypassNavigationCheck })
         dialog.open()
     }
 
@@ -238,10 +238,12 @@ ApplicationWindow {
 
     function checkForUnsavedMission() {
         if (planView._planMasterController.dirtyForSave || planView._planMasterController.dirtyForUpload) {
-            QGroundControl.showMessageDialog(mainWindow, closeDialogTitle,
+            _showMessageDialogWorker(mainWindow, closeDialogTitle,
                               qsTr("You have a mission edit in progress which has not been saved/uploaded. If you close you will lose changes. Are you sure you want to close?"),
                               Dialog.Yes | Dialog.No,
-                              function() { _closeChecksToSkip |= _skipUnsavedMissionCheckMask; performCloseChecks() })
+                              function() { _closeChecksToSkip |= _skipUnsavedMissionCheckMask; performCloseChecks() },
+                              null,
+                              true /* bypassNavigationCheck */)
             return false
         } else {
             return true
@@ -251,10 +253,12 @@ ApplicationWindow {
     function checkForPendingParameterWrites() {
         for (var index=0; index<QGroundControl.multiVehicleManager.vehicles.count; index++) {
             if (QGroundControl.multiVehicleManager.vehicles.get(index).parameterManager.pendingWrites) {
-                QGroundControl.showMessageDialog(mainWindow, closeDialogTitle,
+                _showMessageDialogWorker(mainWindow, closeDialogTitle,
                     qsTr("You have pending parameter updates to a vehicle. If you close you will lose changes. Are you sure you want to close?"),
                     Dialog.Yes | Dialog.No,
-                    function() { _closeChecksToSkip |= _skipPendingParameterWritesCheckMask; performCloseChecks() })
+                    function() { _closeChecksToSkip |= _skipPendingParameterWritesCheckMask; performCloseChecks() },
+                    null,
+                    true /* bypassNavigationCheck */)
                 return false
             }
         }
@@ -263,10 +267,12 @@ ApplicationWindow {
 
     function checkForActiveConnections() {
         if (QGroundControl.multiVehicleManager.activeVehicle) {
-            QGroundControl.showMessageDialog(mainWindow, closeDialogTitle,
+            _showMessageDialogWorker(mainWindow, closeDialogTitle,
                 qsTr("There are still active connections to vehicles. Are you sure you want to exit?"),
                 Dialog.Yes | Dialog.No,
-                function() { _closeChecksToSkip |= _skipActiveConnectionsCheckMask; performCloseChecks() })
+                function() { _closeChecksToSkip |= _skipActiveConnectionsCheckMask; performCloseChecks() },
+                null,
+                true /* bypassNavigationCheck */)
             return false
         } else {
             return true

--- a/src/QmlControls/QGCPopupDialog.qml
+++ b/src/QmlControls/QGCPopupDialog.qml
@@ -50,6 +50,7 @@ Popup {
     property var    dialogProperties
     property bool   destroyOnClose:         true
     property bool   preventClose:           false
+    property bool   bypassNavigationCheck:  false
 
     property real maxContentAvailableWidth:    mainWindow.width - _contentMargin * 6
     property real maxContentAvailableHeight:   mainWindow.height - titleRowLayout.height - _contentMargin * 7
@@ -104,7 +105,7 @@ Popup {
     }
 
     function _accept() {
-        if (_acceptAllowed && mainWindow.allowViewSwitch(_previousValidationErrorCount)) {
+        if (_acceptAllowed && (bypassNavigationCheck || mainWindow.allowViewSwitch(_previousValidationErrorCount))) {
             accepted()
             if (preventClose) {
                 preventClose = false
@@ -116,7 +117,7 @@ Popup {
 
     function _reject() {
         // Dialogs with cancel button are allowed to close with validation errors
-        if (_rejectAllowed && ((buttons & Dialog.Cancel) || mainWindow.allowViewSwitch(_previousValidationErrorCount))) {
+        if (_rejectAllowed && ((buttons & Dialog.Cancel) || bypassNavigationCheck || mainWindow.allowViewSwitch(_previousValidationErrorCount))) {
             rejected()
             if (preventClose) {
                 preventClose = false


### PR DESCRIPTION
Fixes #13951

## Problem

The ArduPilot sensors page had no navigation blocking during active calibration, unlike the PX4 sensors page. This allowed the user to navigate away mid-calibration, return to the sensors page, and restart calibration — leaving the page in a broken state with the Next button permanently disabled (the firmware was still mid-calibration but QGC had lost all state).

## Changes

### Core fix (issue #13951)
- Add `calibrationActive` Q_PROPERTY to `APMSensorsComponentController`, emitting `calibrationActiveChanged()` at calibration start and stop
- Block navigation in `APMSensorsComponent.qml` via `globals.navigationBlockedReason` while any calibration is active, mirroring the existing `PX4/SensorsSetup.qml` pattern

### Bug fixes found during review
- Fix `calibrateCompassNorth()` which was calling `_startLogCalibration()` without first setting `_calTypeInProgress`, so `calibrationActive` would return `false` during a north/fixed-yaw calibration
- Remove the `MAV_CMD_DO_CANCEL_MAG_CAL` probe from `calibrateCompass()`. The probe was a hack to detect onboard compass cal support but had no fallback path when it failed. The feature has been in ArduPilot since 2015 (ArduPilot 3.3). Compass cal now starts directly with `MAV_CMD_DO_START_MAG_CAL`, eliminating a round-trip delay before calibration begins.

### App-close fix
- Add `bypassNavigationCheck` property to `QGCPopupDialog` so app-close confirmation dialogs (unsaved mission, pending parameter writes, active connections) can proceed even when navigation is blocked by an active calibration. Previously clicking "Yes" on the close dialog would show the calibration toast and refuse to close.