### PR TITLE
fix: "Move to vehicle position" shouldn't be available when vehicle has no valid position

### DIFF
--- a/src/PlanView/MissionItemEditor.qml
+++ b/src/PlanView/MissionItemEditor.qml
@@ -225,7 +225,7 @@ Rectangle {
                     QGCButton {
                         Layout.fillWidth:   true
                         text:               qsTr("Move to vehicle position")
-                        enabled:            _activeVehicle && missionItem.specifiesCoordinate
+                        enabled:            _activeVehicle && missionItem.specifiesCoordinate && _activeVehicle.coordinate.isValid
 
                         onClicked: {
                             missionItem.coordinate = _activeVehicle.coordinate


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail. What problem does this solve? -->
"Move to vehicle position" option is allowed even when vehicle has an invalid position (e.g no GPS). So, you can technically move waypoints to vehicle's invalid position causing the waypoints to disappear from the map but still exist.

## Type of Change
<!-- Put an 'x' in the relevant boxes -->
- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] CI/Build changes
- [ ] Other

## Testing
<!-- Describe the tests you ran and how to reproduce them -->
- [x] Tested locally
- [ ] Added/updated unit tests
- [ ] Tested with simulator (SITL)
- [ ] Tested with hardware

### Platforms Tested
<!-- Check all that apply -->
- [x] Linux
- [ ] Windows
- [ ] macOS
- [ ] Android
- [ ] iOS

### Flight Stacks Tested
<!-- If applicable -->
- [ ] PX4
- [ ] ArduPilot

## Screenshots
<!-- If applicable, add screenshots to help explain your changes -->
<img width="308" height="293" alt="image" src="https://github.com/user-attachments/assets/2f8e22c6-7fee-410f-a366-87eb6bbb0fc9" />


## Checklist
<!-- Go over all the following points, and put an 'x' in all the boxes that apply -->
- [x] I have read the [Contribution Guidelines](CONTRIBUTING.md)
- [x] I have read the [Code of Conduct](CODE_OF_CONDUCT.md)
- [x] My code follows the project's coding standards
- [ ] I have added tests that prove my fix/feature works
- [ ] New and existing unit tests pass locally

## Related Issues
<!-- Link any related issues using #issue_number -->

---
By submitting this pull request, I confirm that my contribution is made under the terms of the project's dual license (Apache 2.0 and GPL v3).
