### PR TITLE
Plan View: Make "Waypoint" and "ROI" options disabled if need to set takeoff point

### DIFF
--- a/src/PlanView/PlanView.qml
+++ b/src/PlanView/PlanView.qml
@@ -460,7 +460,7 @@ Item {
                         id: waypointButton
                         text: qsTr("Waypoint")
                         iconSource: "/res/waypoint.svg"
-                        enabled: _homePositionSet
+                        enabled: _homePositionSet && !_planMasterController.showCreateFromTemplate
                         visible: toolStrip._isMissionLayer
                         checkable: true
                         onTriggered: { _addWaypointOnClick = !_addWaypointOnClick; if (_addWaypointOnClick) _addROIOnClick = false }
@@ -469,7 +469,7 @@ Item {
                         id: roiButton
                         text: qsTr("ROI")
                         iconSource: "/qmlimages/roi.svg"
-                        enabled: _homePositionSet
+                        enabled: _homePositionSet && !_planMasterController.showCreateFromTemplate
                         visible: toolStrip._isMissionLayer && _planMasterController.controllerVehicle.supports.roiMode
                         checkable: true
                         onTriggered: { _addROIOnClick = !_addROIOnClick; if (_addROIOnClick) _addWaypointOnClick = false }


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail. What problem does this solve? -->
When you are in plan view with a blank mission, and you set your home position, three options in the left become enabled. "Takeoff", "Waypoint" and "ROI". However, without a takeoff point, having "Waypoint" or "ROI" selected does not affect anything and clicking on the map simply moves the home point. 

This change makes it so that the user interface reflects that "Waypoint" and "ROI" would do nothing without a takeoff point by making them disabled in that situation.

## Type of Change
<!-- Put an 'x' in the relevant boxes -->
- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] CI/Build changes
- [ ] Other

## Testing
<!-- Describe the tests you ran and how to reproduce them -->
- [x] Tested locally
- [ ] Added/updated unit tests
- [ ] Tested with simulator (SITL)
- [ ] Tested with hardware

### Platforms Tested
<!-- Check all that apply -->
- [x] Linux
- [ ] Windows
- [ ] macOS
- [ ] Android
- [ ] iOS

### Flight Stacks Tested
<!-- If applicable -->
- [ ] PX4
- [ ] ArduPilot

## Screenshots
<!-- If applicable, add screenshots to help explain your changes -->

Before:
<img width="1746" height="955" alt="image" src="https://github.com/user-attachments/assets/0905f562-93f0-4b4c-a76f-03adc98236f3" />

After:
<img width="1757" height="948" alt="image" src="https://github.com/user-attachments/assets/eaec441d-392b-4545-9de6-e2b8260c7897" />


## Checklist
<!-- Go over all the following points, and put an 'x' in all the boxes that apply -->
- [x] I have read the [Contribution Guidelines](CONTRIBUTING.md)
- [x] I have read the [Code of Conduct](CODE_OF_CONDUCT.md)
- [x] My code follows the project's coding standards
- [ ] I have added tests that prove my fix/feature works
- [ ] New and existing unit tests pass locally

## Related Issues
<!-- Link any related issues using #issue_number -->

---
By submitting this pull request, I confirm that my contribution is made under the terms of the project's dual license (Apache 2.0 and GPL v3).
