### PR TITLE
FTP: support ListDirectoryWithTime, use mtime for log dates

### DIFF
--- a/src/AnalyzeView/OnboardLogsFtp/OnboardLogFtpController.cc
+++ b/src/AnalyzeView/OnboardLogsFtp/OnboardLogFtpController.cc
@@ -178,6 +178,8 @@ uint OnboardLogFtpController::_processFileEntries(const QStringList &dirList, co
             continue;
         }
 
+        // Entry format is "F<name>\t<size>" and, when the server supports kCmdListDirectoryWithTime,
+        // "F<name>\t<size>\t<modification time in seconds since UNIX epoch UTC>".
         const QString fileInfo = entry.mid(1);
         const int tabIdx = fileInfo.indexOf(QLatin1Char('\t'));
         if (tabIdx < 0) {
@@ -185,7 +187,8 @@ uint OnboardLogFtpController::_processFileEntries(const QStringList &dirList, co
         }
 
         const QString fileName = fileInfo.left(tabIdx);
-        const QString sizeStr = fileInfo.mid(tabIdx + 1);
+        const QString sizeStr = fileInfo.section(QLatin1Char('\t'), 1, 1);
+        const QString mtimeStr = fileInfo.section(QLatin1Char('\t'), 2, 2);
 
         if (!fileName.endsWith(QStringLiteral(".ulg"), Qt::CaseInsensitive) &&
             !fileName.endsWith(QStringLiteral(".bin"), Qt::CaseInsensitive)) {
@@ -199,7 +202,16 @@ uint OnboardLogFtpController::_processFileEntries(const QStringList &dirList, co
         }
 
         QDateTime dateTime;
-        if (dirDate.isValid()) {
+
+        // Prefer the modification time reported by the vehicle when available (0 means unknown).
+        bool mtimeOk = false;
+        const qint64 mtimeSecs = mtimeStr.toLongLong(&mtimeOk);
+        if (mtimeOk && mtimeSecs > 0) {
+            dateTime = QDateTime::fromSecsSinceEpoch(mtimeSecs, QTimeZone::UTC);
+        }
+
+        // Otherwise reconstruct the date from the date sub-directory name and the filename time.
+        if (!dateTime.isValid() && dirDate.isValid()) {
             const QString baseName = fileName.left(fileName.lastIndexOf(QLatin1Char('.')));
             const QTime fileTime = QTime::fromString(baseName, QStringLiteral("HH_mm_ss"));
             if (fileTime.isValid()) {

--- a/src/Comms/MockLink/MockLinkFTP.cc
+++ b/src/Comms/MockLink/MockLinkFTP.cc
@@ -33,24 +33,31 @@ void MockLinkFTP::ensureNullTemination(MavlinkFTP::Request *request)
     }
 }
 
-void MockLinkFTP::_listCommand(uint8_t senderSystemId, uint8_t senderComponentId, MavlinkFTP::Request *request, uint16_t seqNumber)
+void MockLinkFTP::_listCommand(uint8_t senderSystemId, uint8_t senderComponentId, MavlinkFTP::Request *request, uint16_t seqNumber, bool withTime)
 {
     MavlinkFTP::Request ackResponse{};
     ensureNullTemination(request);
 
     const uint16_t outgoingSeqNumber = _nextSeqNumber(seqNumber);
+    const MavlinkFTP::OpCode_t listOpCode = withTime ? MavlinkFTP::kCmdListDirectoryWithTime : MavlinkFTP::kCmdListDirectory;
+
+    if (withTime && !_listDirectoryWithTimeSupported) {
+        // Simulate a server which doesn't implement the command. The client should fall back to kCmdListDirectory.
+        _sendNak(senderSystemId, senderComponentId, MavlinkFTP::kErrUnknownCommand, outgoingSeqNumber, listOpCode);
+        return;
+    }
 
     // We only support root path
     const QString path = reinterpret_cast<char*>(&request->data[0]);
     if (!path.isEmpty() && path != "/") {
-        _sendNak(senderSystemId, senderComponentId, MavlinkFTP::kErrFail, outgoingSeqNumber, MavlinkFTP::kCmdListDirectory);
+        _sendNak(senderSystemId, senderComponentId, MavlinkFTP::kErrFail, outgoingSeqNumber, listOpCode);
         return;
     }
 
     if (request->hdr.offset > 0) {
         if (_errMode == errModeNakSecondResponse) {
             // Nak error all subsequent requests
-            _sendNak(senderSystemId, senderComponentId, MavlinkFTP::kErrFail, outgoingSeqNumber, MavlinkFTP::kCmdListDirectory);
+            _sendNak(senderSystemId, senderComponentId, MavlinkFTP::kErrFail, outgoingSeqNumber, listOpCode);
             return;
         }
 
@@ -67,20 +74,29 @@ void MockLinkFTP::_listCommand(uint8_t senderSystemId, uint8_t senderComponentId
     }
 
     ackResponse.hdr.opcode = MavlinkFTP::kRspAck;
-    ackResponse.hdr.req_opcode = MavlinkFTP::kCmdListDirectory;
+    ackResponse.hdr.req_opcode = listOpCode;
     ackResponse.hdr.session = 0;
     ackResponse.hdr.offset = request->hdr.offset;
     ackResponse.hdr.size = 0;
 
+    // Entry format is "F<name>\t<size>", plus a trailing "\t<modification time>" for kCmdListDirectoryWithTime.
+    const auto makeEntry = [withTime](uint32_t index) {
+        QString entry = QStringLiteral("Ffile%1.txt\t%2").arg(index).arg(1024 + index);
+        if (withTime) {
+            entry += QStringLiteral("\t%1").arg(kMockModificationTime + index);
+        }
+        return entry;
+    };
+
     // MockLink sends two directory entries per packet for a maximum of 3 packets, 6 total entries
     if (request->hdr.offset <= 5) {
         char *bufPtr = reinterpret_cast<char*>(&ackResponse.data[0]);
-        QString dirEntry = QStringLiteral("Ffile%1.txt").arg(request->hdr.offset);
+        QString dirEntry = makeEntry(request->hdr.offset);
         auto cchDirEntry = dirEntry.length();
         (void) strncpy(bufPtr, dirEntry.toStdString().c_str(), cchDirEntry);
         ackResponse.hdr.size += dirEntry.length() + 1;
         bufPtr += cchDirEntry + 1;
-        dirEntry = QStringLiteral("Ffile%1.txt").arg(request->hdr.offset + 1);
+        dirEntry = makeEntry(request->hdr.offset + 1);
         cchDirEntry = dirEntry.length();
         (void) strncpy(bufPtr, dirEntry.toStdString().c_str(), cchDirEntry);
         ackResponse.hdr.size += dirEntry.length() + 1;
@@ -444,7 +460,10 @@ void MockLinkFTP::mavlinkMessageReceived(const mavlink_message_t &message)
         _sendResponse(message.sysid, message.compid, &ackResponse, outgoingSeqNumber);
         break;
     case MavlinkFTP::kCmdListDirectory:
-        _listCommand(message.sysid, message.compid, request, incomingSeqNumber);
+        _listCommand(message.sysid, message.compid, request, incomingSeqNumber, false /* withTime */);
+        break;
+    case MavlinkFTP::kCmdListDirectoryWithTime:
+        _listCommand(message.sysid, message.compid, request, incomingSeqNumber, true /* withTime */);
         break;
     case MavlinkFTP::kCmdOpenFileRO:
         _openCommand(message.sysid, message.compid, request, incomingSeqNumber);

--- a/src/Comms/MockLink/MockLinkFTP.h
+++ b/src/Comms/MockLink/MockLinkFTP.h
@@ -52,6 +52,10 @@ public:
     /// Sets the error mode for command responses. This allows you to simulate various server errors.
     void setErrorMode(ErrorMode_t errMode) { _errMode = errMode; };
 
+    /// Controls whether the server implements the kCmdListDirectoryWithTime command. When false the
+    /// server Naks it with kErrUnknownCommand so the client fallback to kCmdListDirectory can be tested.
+    void setListDirectoryWithTimeSupported(bool supported) { _listDirectoryWithTimeSupported = supported; }
+
     /// Array of failure modes you can cycle through for testing. By looping through this array you can avoid
     /// hardcoding the specific error modes in your unit test. This way when new error modes are added your unit test
     /// code may not need to be modified.
@@ -67,6 +71,10 @@ public:
     static constexpr const size_t cFailureModes = std::size(MockLinkFTP::rgFailureModes);
 
     static constexpr const char *sizeFilenamePrefix = "mocklink-size-";
+
+    /// Base modification time (seconds since UNIX epoch UTC) reported by the kCmdListDirectoryWithTime
+    /// mock listing. Entry N reports kMockModificationTime + N.
+    static constexpr uint32_t kMockModificationTime = 1700000000;
 
 signals:
     /// You can connect to this signal to be notified when the server receives a Terminate command.
@@ -84,7 +92,7 @@ private:
     void _sendResponse(uint8_t targetSystemId, uint8_t targetComponentId, MavlinkFTP::Request *request, uint16_t seqNumber);
     /// Handles List command requests. Only supports root folder paths.
     /// File list returned is set using the setFileList method.
-    void _listCommand(uint8_t senderSystemId, uint8_t senderComponentId, MavlinkFTP::Request *request, uint16_t seqNumber);
+    void _listCommand(uint8_t senderSystemId, uint8_t senderComponentId, MavlinkFTP::Request *request, uint16_t seqNumber, bool withTime);
     void _openCommand(uint8_t senderSystemId, uint8_t senderComponentId, MavlinkFTP::Request *request, uint16_t seqNumber);
     void _createFileCommand(uint8_t senderSystemId, uint8_t senderComponentId, MavlinkFTP::Request *request, uint16_t seqNumber);
     void _openFileWOCommand(uint8_t senderSystemId, uint8_t senderComponentId, MavlinkFTP::Request *request, uint16_t seqNumber);
@@ -110,6 +118,7 @@ private:
     bool _lastReplyValid = false;
     bool _randomDropsEnabled = false;
     ErrorMode_t _errMode = errModeNone;         ///< Currently set error mode, as specified by setErrorMode
+    bool _listDirectoryWithTimeSupported = true; ///< Whether the server implements kCmdListDirectoryWithTime
     mavlink_message_t _lastReply{};
     QFile _currentFile;
     QString _paramPckTempFile;

--- a/src/MAVLink/MAVLinkFTP.cc
+++ b/src/MAVLink/MAVLinkFTP.cc
@@ -35,6 +35,8 @@ QString MavlinkFTP::opCodeToString(OpCode_t opCode)
         return "Calc File CRC32";
     case kCmdBurstReadFile:
         return "Burst Read File";
+    case kCmdListDirectoryWithTime:
+        return "List Directory With Time";
     case kRspAck:
         return "Ack";
     case kRspNak:

--- a/src/MAVLink/MAVLinkFTP.h
+++ b/src/MAVLink/MAVLinkFTP.h
@@ -52,6 +52,7 @@ public:
         kCmdRename,				///< Rename <path1> to <path2>
         kCmdCalcFileCRC32,		///< Calculate CRC32 for file at <path>
         kCmdBurstReadFile,      ///< Burst download session file
+        kCmdListDirectoryWithTime,  ///< List directory as kCmdListDirectory, each entry additionally carrying trailing \t<modification time>
 
         kRspAck = 128,          ///< Ack response
         kRspNak,                ///< Nak response

--- a/src/Vehicle/FTPManager.cc
+++ b/src/Vehicle/FTPManager.cc
@@ -158,6 +158,11 @@ bool FTPManager::listDirectory(uint8_t fromCompId, const QString& fromURI)
 
     _listDirectoryState.reset();
 
+    // Prefer the timestamped listing unless we already learned this vehicle doesn't support it.
+    _listDirectoryState.opCode = (_listDirWithTimeSupport == WithTimeSupport_t::Unsupported)
+            ? MavlinkFTP::kCmdListDirectory
+            : MavlinkFTP::kCmdListDirectoryWithTime;
+
     if (!_parseURI(fromCompId, fromURI, _listDirectoryState.fullPathOnVehicle, _ftpCompId)) {
         qCWarning(FTPManagerLog) << "_parseURI failed";
         return false;
@@ -911,7 +916,7 @@ void FTPManager::_listDirectoryWorker(bool firstRequest)
 
     MavlinkFTP::Request request{};
     request.hdr.session = _downloadState.sessionId;
-    request.hdr.opcode  = MavlinkFTP::kCmdListDirectory;
+    request.hdr.opcode  = _listDirectoryState.opCode;
     request.hdr.offset  = _listDirectoryState.expectedOffset;
     request.hdr.size    = sizeof(request.data);
     _fillRequestDataWithString(&request, _listDirectoryState.fullPathOnVehicle);
@@ -935,7 +940,7 @@ void FTPManager::_listDirectoryAckOrNak(const MavlinkFTP::Request* ackOrNak)
 {
     MavlinkFTP::OpCode_t requestOpCode = static_cast<MavlinkFTP::OpCode_t>(ackOrNak->hdr.req_opcode);
 
-    if (requestOpCode != MavlinkFTP::kCmdListDirectory) {
+    if (requestOpCode != _listDirectoryState.opCode) {
         qCDebug(FTPManagerLog) << "_listDirectoryAckOrNak: Disregarding due to incorrect requestOpCode" << MavlinkFTP::opCodeToString(requestOpCode);
         return;
     }
@@ -946,6 +951,10 @@ void FTPManager::_listDirectoryAckOrNak(const MavlinkFTP::Request* ackOrNak)
         if (ackOrNak->hdr.seqNumber < _expectedIncomingSeqNumber) {
             qCDebug(FTPManagerLog) << "_listDirectoryAckOrNak: Disregarding Ack due to incorrect sequence actual:expected" << ackOrNak->hdr.seqNumber << _expectedIncomingSeqNumber;
             return;
+        }
+
+        if (_listDirectoryState.opCode == MavlinkFTP::kCmdListDirectoryWithTime) {
+            _listDirWithTimeSupport = WithTimeSupport_t::Supported;
         }
 
         qCDebug(FTPManagerLog) << QString("_listDirectoryAckOrNak: Ack size(%1)").arg(ackOrNak->hdr.size);
@@ -973,8 +982,23 @@ void FTPManager::_listDirectoryAckOrNak(const MavlinkFTP::Request* ackOrNak)
                 return;
             } else {
                 qCDebug(FTPManagerLog) << "_listDirectoryAckOrNak EOF";
+                if (_listDirectoryState.opCode == MavlinkFTP::kCmdListDirectoryWithTime) {
+                    _listDirWithTimeSupport = WithTimeSupport_t::Supported;
+                }
                 _advanceStateMachine();
             }
+        } else if (errorCode == MavlinkFTP::kErrUnknownCommand && _listDirectoryState.opCode == MavlinkFTP::kCmdListDirectoryWithTime) {
+            // Server doesn't implement kCmdListDirectoryWithTime. Remember that, fall back to the
+            // plain listing and restart from the beginning. The UnknownCommand Nak is a definitive
+            // capability statement so we act on it without a strict sequence check; the restart is
+            // idempotent (offset and accumulated entries are reset).
+            qCDebug(FTPManagerLog) << "_listDirectoryAckOrNak: kCmdListDirectoryWithTime unsupported, falling back to kCmdListDirectory";
+            _listDirWithTimeSupport             = WithTimeSupport_t::Unsupported;
+            _listDirectoryState.opCode          = MavlinkFTP::kCmdListDirectory;
+            _listDirectoryState.expectedOffset  = 0;
+            _listDirectoryState.rgDirectoryList.clear();
+            _expectedIncomingSeqNumber          = ackOrNak->hdr.seqNumber;
+            _listDirectoryWorker(true /* firstRequest */);
         } else { /* Don't care is this is out of sequence */
             qCDebug(FTPManagerLog) << "_listDirectoryAckOrNak: Nak -" << _errorMsgFromNak(ackOrNak);
             _listDirectoryComplete(tr("List directory failed"));

--- a/src/Vehicle/FTPManager.h
+++ b/src/Vehicle/FTPManager.h
@@ -131,11 +131,12 @@ private:
     };
 
     struct ListDirectoryState_t {
-        uint8_t     sessionId;
-        uint32_t    expectedOffset;         ///< offset which should be coming next
-        QString     fullPathOnVehicle;      ///< Fully qualified path to file on vehicle
-        QStringList rgDirectoryList;
-        int         retryCount;
+        uint8_t                 sessionId;
+        uint32_t                expectedOffset;         ///< offset which should be coming next
+        QString                 fullPathOnVehicle;      ///< Fully qualified path to file on vehicle
+        QStringList             rgDirectoryList;
+        int                     retryCount;
+        MavlinkFTP::OpCode_t    opCode;                 ///< List opcode currently in use (kCmdListDirectoryWithTime or kCmdListDirectory)
 
         bool inProgress() const { return !fullPathOnVehicle.isEmpty(); }
 
@@ -145,8 +146,13 @@ private:
             fullPathOnVehicle.clear();
             rgDirectoryList.clear();
             retryCount      = 0;
+            opCode          = MavlinkFTP::kCmdListDirectory;
         }
     };
+
+    /// Whether the vehicle supports the kCmdListDirectoryWithTime command. Cached per FTPManager
+    /// instance (i.e. per vehicle) so repeated listings don't keep probing an unsupporting server.
+    enum class WithTimeSupport_t { Unknown, Supported, Unsupported };
 
     struct DeleteFileState_t {
         QString fullPathOnVehicle;      ///< Fully qualified path to file on vehicle
@@ -249,6 +255,7 @@ private:
     QTimer                  _ackOrNakTimeoutTimer;
     int                     _currentStateMachineIndex   = -1;
     uint16_t                _expectedIncomingSeqNumber  = 0;
+    WithTimeSupport_t       _listDirWithTimeSupport     = WithTimeSupport_t::Unknown;
 
     static const int _ackOrNakTimeoutMsecs  = 1000;
     static const int _maxRetry              = 3;

--- a/test/Vehicle/FTPManagerTest.cc
+++ b/test/Vehicle/FTPManagerTest.cc
@@ -139,6 +139,52 @@ void FTPManagerTest::_testListDirectory()
     _disconnectMockLink();
 }
 
+void FTPManagerTest::_testListDirectoryWithTime()
+{
+    _connectMockLinkNoInitialConnectSequence();
+    FTPManager* ftpManager = _vehicle->ftpManager();
+    QSignalSpy spyListDirectoryComplete(ftpManager, &FTPManager::listDirectoryComplete);
+    ftpManager->listDirectory(MAV_COMP_ID_AUTOPILOT1, "/");
+    QVERIFY_SIGNAL_WAIT(spyListDirectoryComplete, TestTimeout::longMs());
+    QCOMPARE(spyListDirectoryComplete.count(), 1);
+    QList<QVariant> arguments = spyListDirectoryComplete.takeFirst();
+    const QStringList entries = arguments[0].toStringList();
+    QCOMPARE(entries.count(), 6);
+    QVERIFY(arguments[1].toString().isEmpty());
+
+    // Each entry should carry "F<name>\t<size>\t<modification time>"
+    for (int i = 0; i < entries.count(); i++) {
+        const QStringList fields = entries.at(i).mid(1).split(QLatin1Char('\t'));
+        QCOMPARE(fields.count(), 3);
+        bool ok = false;
+        const qint64 mtime = fields.at(2).toLongLong(&ok);
+        QVERIFY(ok);
+        QCOMPARE(mtime, static_cast<qint64>(MockLinkFTP::kMockModificationTime) + i);
+    }
+    _disconnectMockLink();
+}
+
+void FTPManagerTest::_testListDirectoryWithTimeFallback()
+{
+    _connectMockLinkNoInitialConnectSequence();
+    FTPManager* ftpManager = _vehicle->ftpManager();
+    _mockLink->mockLinkFTP()->setListDirectoryWithTimeSupported(false);
+    QSignalSpy spyListDirectoryComplete(ftpManager, &FTPManager::listDirectoryComplete);
+    ftpManager->listDirectory(MAV_COMP_ID_AUTOPILOT1, "/");
+    QVERIFY_SIGNAL_WAIT(spyListDirectoryComplete, TestTimeout::longMs());
+    QCOMPARE(spyListDirectoryComplete.count(), 1);
+    QList<QVariant> arguments = spyListDirectoryComplete.takeFirst();
+    const QStringList entries = arguments[0].toStringList();
+    QCOMPARE(entries.count(), 6);
+    QVERIFY(arguments[1].toString().isEmpty());
+
+    // After falling back to kCmdListDirectory the entries carry no modification-time field.
+    for (const QString &entry : entries) {
+        QCOMPARE(entry.mid(1).count(QLatin1Char('\t')), 1);
+    }
+    _disconnectMockLink();
+}
+
 void FTPManagerTest::_testListDirectoryNoResponse()
 {
     _connectMockLinkNoInitialConnectSequence();

--- a/test/Vehicle/FTPManagerTest.h
+++ b/test/Vehicle/FTPManagerTest.h
@@ -13,6 +13,8 @@ private slots:
     void _performSizeBasedTestCases();
     void _testLostPackets();
     void _testListDirectory();
+    void _testListDirectoryWithTime();
+    void _testListDirectoryWithTimeFallback();
     void _testListDirectoryNoResponse();
     void _testListDirectoryNakResponse();
     void _testListDirectoryNoSecondResponse();


### PR DESCRIPTION
## Description

Try the new kCmdListDirectoryWithTime (opcode 16) listing and fall back to ListDirectory on UnknownCommand, caching support per vehicle.

Onboard log download now prefers the vehicle-reported modification time.

## Type of Change
<!-- Put an 'x' in the relevant boxes -->
- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] CI/Build changes
- [ ] Other

## Testing
<!-- Describe the tests you ran and how to reproduce them -->
- [x] Tested locally
- [ ] Added/updated unit tests
- [ ] Tested with simulator (SITL)
- [ ] Tested with hardware

### Platforms Tested
<!-- Check all that apply -->
- [x] Linux
- [ ] Windows
- [ ] macOS
- [ ] Android
- [ ] iOS

### Flight Stacks Tested
<!-- If applicable -->
- [x] PX4
- [x] ArduPilot

## Screenshots
<!-- If applicable, add screenshots to help explain your changes -->

## Checklist
<!-- Go over all the following points, and put an 'x' in all the boxes that apply -->
- [x] I have read the [Contribution Guidelines](CONTRIBUTING.md)
- [x] I have read the [Code of Conduct](CODE_OF_CONDUCT.md)
- [x] My code follows the project's coding standards
- [x] I have added tests that prove my fix/feature works
- [ ] New and existing unit tests pass locally

## Related Issues
<!-- Link any related issues using #issue_number -->

Follow up to https://github.com/mavlink/qgroundcontrol/pull/14290.
Implementing https://github.com/mavlink/mavlink-devguide/pull/701.

Tested against:
https://github.com/ArduPilot/ardupilot/pull/33290
And:
https://github.com/PX4/PX4-Autopilot/pull/27542

---
By submitting this pull request, I confirm that my contribution is made under the terms of the project's dual license (Apache 2.0 and GPL v3).
