### PR TITLE
ci: stop non-ccache/non-qt caches from polluting the repo cache pool

### DIFF
--- a/.github/actions/build-prerequisites/action.yml
+++ b/.github/actions/build-prerequisites/action.yml
@@ -81,8 +81,8 @@ runs:
 
     - uses: lukka/get-cmake@v4.3.2
       with:
-        useCloudCache: ${{ github.event_name != 'pull_request' && github.event_name != 'pull_request_target' }}
-        useLocalCache: ${{ github.event_name == 'pull_request' || github.event_name == 'pull_request_target' }}
+        useCloudCache: false
+        useLocalCache: true
 
     - uses: ./.github/actions/setup-python
       with:

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -103,6 +103,8 @@ jobs:
           # c-cpp can't use overlay DBs (those require build-mode: none, interpreted-only); declare manual to match the cmake-build step below and silence the "undefined build-mode" fallback warning.
           build-mode: manual
           config-file: ./.github/codeql/codeql-config.yml
+          trap-caching: false
+          dependency-caching: false
 
       - name: Configure
         uses: ./.github/actions/cmake-configure


### PR DESCRIPTION
## Summary

Continuation of #14474 — two more cache sources still wrote into the 10 GiB/repo pool, competing with (and risking LRU eviction of) the expensive `ccache-*` and `qt-*` caches.

### 1. CodeQL trap cache (`linux.yml`)
The c-cpp CodeQL init wrote `codeql-trap-*-cpp` caches, unlike `codeql.yml` which already disables both (#14475). Added `trap-caching: false` + `dependency-caching: false`.

### 2. get-cmake tool cache (`build-prerequisites`)
`lukka/get-cmake` hashes the CMake/Ninja download URLs into an integer key (`1631280068`, `-1467762025`, …) and, with `useCloudCache: true` on push/merge_group, uploaded the binaries (~128 MB) to the cloud pool. Switched to the runner-local tool cache (`useCloudCache: false`, `useLocalCache: true`).

## After this change
Caches written to the pool from master are limited to the intended ones:
- `ccache-*` (kept)
- `qt-*` downloads (kept)
- `cpm-modules` (build cache, GC-protected)
- `coverage-baseline-latest` / `artifact-sizes-baseline-latest` (tiny functional regression baselines)

All other cache saves (gradle, codeql.yml, python pip/uv, build-profile, flatpak) were already disabled in #14474/#14475.