### PR TITLE
ci: drop invalid trap-caching key from CodeQL config

### DIFF
--- a/.github/codeql/codeql-config.yml
+++ b/.github/codeql/codeql-config.yml
@@ -26,5 +26,3 @@ query-filters:
       # Excluded due to frequent false positives with Qt/moc-heavy call patterns.
       # Re-evaluate before enabling if CodeQL signal quality improves.
       id: cpp/mistyped-function-arguments
-
-trap-caching: false


### PR DESCRIPTION
`trap-caching` is a `codeql-action/init` workflow input, not a `codeql-config.yml` property. CodeQL rejected it on every run:

```
Invalid property specified in the configuration file. Ignoring it and proceeding.
```

Trap caching is already disabled by the `trap-caching: false` inputs in both `codeql.yml` and `linux.yml` (the latter since 7cfc0f66), so this line had zero effect. Removing it deletes dead, misleading config and silences the per-run warning. No behavior change.