### PR TITLE
feat(FirmwareUpgrade): improve port selector UX

### DIFF
--- a/src/Vehicle/VehicleSetup/FirmwareUpgrade.qml
+++ b/src/Vehicle/VehicleSetup/FirmwareUpgrade.qml
@@ -59,6 +59,20 @@ SetupPage {
             function setupPageCompleted() {
                 controller.startBoardSearch()
                 _defaultFirmwareIsPX4 = _defaultFirmwareFact.rawValue === _defaultFimwareTypePX4 // we don't want this to be bound and change as radios are selected
+                _lastKnownCount = 0
+            }
+
+            property int _lastKnownCount: 0
+
+            function _recognizedBoardCount() {
+                var ports = controller.availablePorts
+                var count = 0
+                for (var i = 0; i < ports.length; i++) {
+                    if (ports[i].boardType === _boardTypePixhawk || ports[i].boardType === _boardTypeSiKRadio) {
+                        count++
+                    }
+                }
+                return count
             }
 
             function _preselectIndex() {
@@ -66,38 +80,54 @@ SetupPage {
                 if (ports.length === 0) {
                     return -1
                 }
-                // Prefer a recognized Pixhawk
                 for (var i = 0; i < ports.length; i++) {
                     if (ports[i].boardType === _boardTypePixhawk) {
                         return i
                     }
                 }
-                // Else prefer a recognized SiK radio
                 for (var j = 0; j < ports.length; j++) {
                     if (ports[j].boardType === _boardTypeSiKRadio) {
                         return j
                     }
                 }
-                // Else first item
-                return 0
+                // No recognized device found
+                return -1
             }
 
             function _refreshSelection() {
-                if (_flashStarted) {
+                if (_flashStarted || portCombo.popup.visible) {
                     return
                 }
+                var knownCount = _recognizedBoardCount()
+                if (knownCount > 1 && _lastKnownCount <= 1) {
+                    statusTextArea.append(highlightPrefix + qsTr("Multiple devices detected. Make sure to select the correct one from the list.") + highlightSuffix)
+                }
+                _lastKnownCount = knownCount
                 var ports = controller.availablePorts
                 if (ports.length === 0) {
                     portCombo.currentIndex = -1
                     _selectedSystemLocation = ""
                     return
                 }
-                // Try to keep the current selection if its port is still present
                 if (_selectedSystemLocation !== "") {
+                    // Check if the current selection is already a recognized device
+                    var currentIsRecognized = false
                     for (var i = 0; i < ports.length; i++) {
                         if (ports[i].systemLocation === _selectedSystemLocation) {
-                            portCombo.currentIndex = i
-                            return
+                            if (ports[i].boardType === _boardTypePixhawk || ports[i].boardType === _boardTypeSiKRadio) {
+                                currentIsRecognized = true
+                            }
+                            break
+                        }
+                    }
+                    // Only keep the current selection if it is a recognized device;
+                    // otherwise fall through to preselect the first recognized device
+                    if (currentIsRecognized) {
+                        for (var j = 0; j < ports.length; j++) {
+                            if (ports[j].systemLocation === _selectedSystemLocation) {
+                                portCombo.currentIndex = j
+                                return
+                            }
                         }
                     }
                 }
@@ -131,7 +161,7 @@ SetupPage {
 
                 onBoardFound: {
                     if (_flashStarted) {
-                        statusTextArea.append(highlightPrefix + qsTr("Found device") + highlightSuffix + ": " + controller.boardType)
+                        statusTextArea.append(highlightPrefix + qsTr("Found device") + highlightSuffix + ": " + controller.boardType + " (" + controller.boardPort + ")")
                         if (QGroundControl.multiVehicleManager.activeVehicle) {
                             QGroundControl.multiVehicleManager.activeVehicle.vehicleLinkManager.autoDisconnect = true
                         }
@@ -462,17 +492,33 @@ SetupPage {
             } // Component - firmwareSelectDialogComponent
 
             RowLayout {
-                Layout.fillWidth:   true
-                spacing:            ScreenTools.defaultFontPixelWidth
-                visible:            !flashBootloaderButton.visible
+                spacing: ScreenTools.defaultFontPixelWidth
+                visible: !flashBootloaderButton.visible
 
                 QGCComboBox {
                     id:                 portCombo
-                    Layout.fillWidth:   true
+                    sizeToContents:     true
                     visible:            !_flashStarted
                     enabled:            controller.availablePorts.length > 0
                     model:              controller.availablePorts
                     textRole:           "displayName"
+
+                    alternateText: {
+                        if (_lastKnownCount !== 1) {
+                            return ""
+                        }
+                        var idx = portCombo.currentIndex
+                        var ports = controller.availablePorts
+                        if (idx < 0 || idx >= ports.length) {
+                            return ""
+                        }
+                        var p = ports[idx]
+                        if (p.boardName && p.description) {
+                            return p.description + " [" + p.boardName + "]"
+                        }
+                        return p.boardName || p.description || p.displayName
+                    }
+
                     onActivated: (index) => {
                         if (index >= 0 && index < controller.availablePorts.length) {
                             _selectedSystemLocation = controller.availablePorts[index].systemLocation
@@ -481,11 +527,10 @@ SetupPage {
                 }
 
                 QGCLabel {
-                    id:                 portLabel
-                    Layout.fillWidth:   true
-                    visible:            _flashStarted
-                    text:               _selectedDisplayName
-                    elide:              Text.ElideRight
+                    id:         portLabel
+                    visible:    _flashStarted
+                    text:       qsTr("Flashing - %1").arg(_selectedDisplayName)
+                    elide:      Text.ElideRight
                 }
 
                 QGCButton {
@@ -500,7 +545,7 @@ SetupPage {
                         }
                         var entry = ports[portCombo.currentIndex]
                         _selectedSystemLocation = entry.systemLocation
-                        _selectedDisplayName = entry.displayName
+                        _selectedDisplayName = portCombo.alternateText !== "" ? portCombo.alternateText : entry.displayName
                         _flashStarted = true
                         statusTextArea.append(unplugReplugText)
                         if (QGroundControl.multiVehicleManager.activeVehicle) {


### PR DESCRIPTION
## Summary

Improves the port selector UX on the Firmware Upgrade page. The previous UI showed a plain combo box with raw port paths; this change makes the selection smarter and the labels more readable.

The main goal of this PR is to not expose users to port names unless truly needed. For Mac/Windows users who fly a single vehicle on a SiK Radio or WiFi a port name is not something they would normally deal with or ever see.

Related to #14308

## Changes

- **Auto-preselect recognized board** — the first connected Pixhawk or SiK Radio is automatically selected in the combo on page open and whenever the port list changes.
- **Short label in closed combo** — when exactly one recognized device is connected, the combo header shows `Description [BoardName]` (e.g. `Cube Orange [Cube Pilot]`) without the port path. The full `port — description [name]` still appears in the open dropdown list.
- **Multiple devices** — when more than one recognized device is connected the full `displayName` (including port path) is shown so the user can distinguish them. A one-time warning is appended to the status log on the transition from ≤1 to >1 recognized devices.
- **Selection stability** — the current selection is only preserved if it is itself a recognized device. If an unrecognized port is selected and a Pixhawk is plugged in, the combo switches to the Pixhawk automatically.
- **Popup stability** — the port list model is not rebuilt while the combo dropdown is open, preventing it from collapsing mid-browse. A refresh runs when the popup closes.
- **Found device message** includes the port name, e.g. `Found device: Pixhawk 5X (ttyACM0)`.
- **`_lastKnownCount` reset** on `setupPageCompleted()` so the multi-device warning fires correctly on each page visit.
- **`_preselectIndex()` returns `-1`** when no recognized device is present instead of silently selecting the first unrecognized port.
