### PR TITLE
fix: Mission edit in progress warning always occurs whenever vehicle has mission

### DIFF
--- a/src/MissionManager/PlanMasterController.cc
+++ b/src/MissionManager/PlanMasterController.cc
@@ -260,7 +260,7 @@ void PlanMasterController::_loadGeoFenceComplete(void)
 void PlanMasterController::_loadRallyPointsComplete(void)
 {
     qCDebug(PlanMasterControllerLog) << "PlanMasterController::_loadRallyPointsComplete";
-    _setDirtyStates(containsItems() /* dirtyForSave */, false /* dirtyForUpload */);
+    _setDirtyStates(false /* dirtyForSave */, false /* dirtyForUpload */);
 }
 
 void PlanMasterController::_sendMissionComplete(void)


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail. What problem does this solve? -->

Commit [8e12b37](https://github.com/mavlink/qgroundcontrol/commit/8e12b37c9dcdca71572b72574558a0e2c4b846f7) added a change to fix  `_loadRallyPointsComplete` setting `dirtyforSave` to true whenever rally point loading completed. However, the change in this commit introduced a bug where `_loadRallyPointComplete` now automatically sets missions to dirty whenever the mission isn't empty.

Made `_loadRallyPointsComplete` unconditionally set dirty to false for both save and upload to solve this problem.

## Type of Change
<!-- Put an 'x' in the relevant boxes -->
- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] CI/Build changes
- [ ] Other

## Testing
<!-- Describe the tests you ran and how to reproduce them -->
- [ ] Tested locally
- [ ] Added/updated unit tests
- [x] Tested with simulator (SITL)
- [ ] Tested with hardware

### Platforms Tested
<!-- Check all that apply -->
- [x] Linux
- [ ] Windows
- [ ] macOS
- [ ] Android
- [ ] iOS

### Flight Stacks Tested
<!-- If applicable -->
- [ ] PX4
- [x] ArduPilot

## Screenshots
<!-- If applicable, add screenshots to help explain your changes -->
Before this change, this popup would show up whenever vehicle was connected with a mission loaded.
<img width="712" height="137" alt="image" src="https://github.com/user-attachments/assets/182fa4f5-70f5-4507-bc31-1ea810bfe5cc" />


## Checklist
<!-- Go over all the following points, and put an 'x' in all the boxes that apply -->
- [x] I have read the [Contribution Guidelines](CONTRIBUTING.md)
- [x] I have read the [Code of Conduct](CODE_OF_CONDUCT.md)
- [x] My code follows the project's coding standards
- [ ] I have added tests that prove my fix/feature works
- [ ] New and existing unit tests pass locally

## Related Issues
<!-- Link any related issues using #issue_number -->

---
By submitting this pull request, I confirm that my contribution is made under the terms of the project's dual license (Apache 2.0 and GPL v3).
