### PR TITLE
Fix logging categories search results clipping

### DIFF
--- a/src/LogManager/LoggingCategoriesDialog.qml
+++ b/src/LogManager/LoggingCategoriesDialog.qml
@@ -39,10 +39,7 @@ QGCPopupDialog {
                         id: _searchDebounce
                         interval: 200
                         repeat: false
-                        onTriggered: {
-                            searchResultsView._maxRowWidth = ScreenTools.defaultFontPixelWidth
-                            QGCLoggingCategoryManager.setFilterText(searchText.text)
-                        }
+                        onTriggered: QGCLoggingCategoryManager.setFilterText(searchText.text)
                     }
                 }
 


### PR DESCRIPTION
## Fixes #14509

### Problem
In the App Log Viewer → Categories dialog, searching (e.g. typing "PlanManager" quickly) intermittently clips the search-result rows: the category text and/or the enable switch get cut off.

### Root cause
The search-results `QGCListView` tracks the widest row in `_maxRowWidth`, and the debounce timer reset it back to a single character width on every query:

```qml
searchResultsView._maxRowWidth = ScreenTools.defaultFontPixelWidth
```

But `setFilterText()` updates the underlying `QSortFilterProxyModel` **incrementally** (granular row insert/remove signals, not a `modelReset`). Delegates for rows that survive the filter change are neither recreated (`Component.onCompleted`) nor recycled (`ListView.onReused`), so they never re-run their width callback. The reset discarded their measured width and was never restored, leaving `_maxRowWidth` too small — so rows rendered narrower than their content and got clipped.

### Fix
Remove the reset so `_maxRowWidth` only ever grows. Surviving rows keep their correct measured width, and newly inserted rows still expand it as needed.

### Test
- App Log Viewer → Categories → type "PlanManager" fast; rows and switches stay fully visible.