### PR TITLE
USBBoardInfo: add CORVON 743V2 and V5

### DIFF
--- a/src/Comms/USBBoardInfo.json
+++ b/src/Comms/USBBoardInfo.json
@@ -79,7 +79,9 @@
         { "vendorID": 13891, "productID": 5600,     "boardClass": "Pixhawk",    "name": "ZeroOne X6" },
         { "vendorID": 8355, "productID": 16888,     "boardClass": "Pixhawk",    "name": "Svehicle e2" },
         { "vendorID": 16325, "productID": 71,       "boardClass": "Pixhawk",    "name": "VOLOLAND NarinFC-H7" },
-        { "vendorID": 5840,  "productID": 5318,     "boardClass": "Pixhawk",    "name": "CBU H753-SOM" }
+        { "vendorID": 5840,  "productID": 5318,     "boardClass": "Pixhawk",    "name": "CBU H753-SOM" },
+        { "vendorID": 5840,  "productID": 5387,     "boardClass": "Pixhawk",    "name": "CORVON 743V2" },
+        { "vendorID": 5840,  "productID": 5418,     "boardClass": "Pixhawk",    "name": "CORVON V5" }
     ],
 
     "boardDescriptionFallback": [
@@ -139,6 +141,7 @@
     "boardManufacturerFallback": [
         { "regExp": "^ArduPilot$",      "boardClass": "Pixhawk" },
         { "regExp": "^ARK$",            "boardClass": "Pixhawk" },
+        { "regExp": "^CORVON$",         "boardClass": "Pixhawk" },
         { "regExp": "^Hex/ProfiCNC$",   "boardClass": "Pixhawk" },
         { "regExp": "^Holybro$",        "boardClass": "Pixhawk" },
         { "regExp": "^mRo$",            "boardClass": "Pixhawk" },


### PR DESCRIPTION
## Description
Adds USB IDs for the CORVON 743V2 (added to PX4 in PX4/PX4-Autopilot#27569) and CORVON V5 (PX4/PX4-Autopilot#26286) flight controllers:
- 743V2: VID/PID `0x16D0`/`0x150B` (5840/5387)
- V5: VID/PID `0x16D0`/`0x152A` (5840/5418)
- `^CORVON$` manufacturer fallback for other CORVON boards

Each board uses the same VID/PID in the bootloader and the application. Without these entries QGC neither auto-connects to the boards nor detects them for firmware flashing.

## Type of Change
- [x] New feature (non-breaking change that adds functionality)

## Testing
- [x] Tested with hardware

743V2 enumerates as `0x16D0:0x150B` (manufacturer "CORVON") and streams MAVLink on PX4 v1.17.0; the V5 bootloader and app defconfig carry `0x16D0:0x152A`. The PIDs are assigned under the shared MCS Electronics VID.

### Platforms Tested
- [x] macOS

### Flight Stacks Tested
- [x] PX4

## Checklist
- [x] I have read the [Contribution Guidelines](CONTRIBUTING.md)
- [x] I have read the [Code of Conduct](CODE_OF_CONDUCT.md)