### PR TITLE
Plan View: Disable insert buttons until home position and takeoff are set

### DIFF
--- a/src/FlightMap/MapItems/MissionLineView.qml
+++ b/src/FlightMap/MapItems/MissionLineView.qml
@@ -17,7 +17,7 @@ MapItemView {
         path:       _calcMissionLinePath()
 
         property bool _terrainCollision:    object && object.terrainCollision
-        property bool _showSpecialVisual:   object && showSpecialVisual && object.specialVisual
+        property bool _showSpecialVisual:   Boolean(object && showSpecialVisual && object.specialVisual)
 
         readonly property real _maxSegmentLengthM: 50000 // 50 km
 

--- a/src/MissionManager/MissionController.cc
+++ b/src/MissionManager/MissionController.cc
@@ -49,10 +49,11 @@ MissionController::MissionController(PlanMasterController* masterController, QOb
     _updateTimer.setSingleShot(true);
 
     connect(&_updateTimer,                                      &QTimer::timeout,                                       this, &MissionController::_updateTimeout);
-    connect(_planViewSettings->takeoffItemNotRequired(),        &Fact::rawValueChanged,                                 this, &MissionController::_forceRecalcOfAllowedBits);
+    connect(_planViewSettings->takeoffItemNotRequired(),        &Fact::rawValueChanged,                                 this, &MissionController::_recalcPlanViewState);
     connect(_planViewSettings->allowMultipleLandingPatterns(),  &Fact::rawValueChanged,                                 this, &MissionController::multipleLandPatternsAllowedChanged);
     connect(_masterController,                                  &PlanMasterController::managerVehicleChanged,           this, &MissionController::multipleLandPatternsAllowedChanged);
-    connect(this,                                               &MissionController::multipleLandPatternsAllowedChanged, this, &MissionController::_forceRecalcOfAllowedBits);
+    connect(this,                                               &MissionController::multipleLandPatternsAllowedChanged, this, &MissionController::_recalcPlanViewState);
+    connect(this,                                               &MissionController::homePositionSetChanged,             this, &MissionController::_recalcPlanViewState);
     connect(this,                                               &MissionController::missionPlannedDistanceChanged,      this, &MissionController::recalcTerrainProfile);
 
     // The follow is used to compress multiple recalc calls in a row to into a single call.
@@ -1929,6 +1930,7 @@ void MissionController::setCurrentPlanViewSeqNum(int sequenceNumber, bool force)
     if (_visualItems && (force || sequenceNumber != _currentPlanViewSeqNum)) {
         qCDebug(MissionControllerLog) << "setCurrentPlanViewSeqNum";
         bool    foundLand =             false;
+        bool    onlyInsertTakeoffValid = false;
         int     takeoffSeqNum =         -1;
         int     landSeqNum =            -1;
         int     lastFlyThroughSeqNum =  -1;
@@ -1937,9 +1939,9 @@ void MissionController::setCurrentPlanViewSeqNum(int sequenceNumber, bool force)
         _currentPlanViewItem  =         nullptr;
         _currentPlanViewSeqNum =        -1;
         _currentPlanViewVIIndex =       -1;
-        _onlyInsertTakeoffValid =       false;
         _isInsertTakeoffValid =         true;
         _isInsertLandValid =            true;
+        _isInsertROIValid =             false;
         _isROIActive =                  false;
         _isROIBeginCurrentItem =        false;
         _flyThroughCommandsAllowed =    true;
@@ -1947,7 +1949,7 @@ void MissionController::setCurrentPlanViewSeqNum(int sequenceNumber, bool force)
 
         bool noItemsAddedYet = _visualItems->count() == 1;
         if (_masterController->controllerVehicle()->supports()->takeoffMissionCommand() && !_planViewSettings->takeoffItemNotRequired()->rawValue().toBool() && noItemsAddedYet) {
-            _onlyInsertTakeoffValid = true;
+            onlyInsertTakeoffValid = true;
         }
 
         for (int viIndex=0; viIndex<_visualItems->count(); viIndex++) {
@@ -2087,12 +2089,19 @@ void MissionController::setCurrentPlanViewSeqNum(int sequenceNumber, bool force)
         }
 
         // These are not valid when only takeoff is allowed
-        _isInsertLandValid =            _isInsertLandValid && !_onlyInsertTakeoffValid;
-        _flyThroughCommandsAllowed =    _flyThroughCommandsAllowed && !_onlyInsertTakeoffValid;
+        _isInsertLandValid =            _isInsertLandValid && !onlyInsertTakeoffValid;
+        _flyThroughCommandsAllowed =    _flyThroughCommandsAllowed && !onlyInsertTakeoffValid;
 
-        // These 10 properties are all recomputed together above, so a single signal is sufficient.
+        // Nothing can be inserted until the home position has been set
+        const bool homePosSet = homePositionSet();
+        _isInsertTakeoffValid =         _isInsertTakeoffValid && homePosSet;
+        _isInsertLandValid =            _isInsertLandValid && homePosSet;
+        _flyThroughCommandsAllowed =    _flyThroughCommandsAllowed && homePosSet;
+        _isInsertROIValid =             homePosSet && !onlyInsertTakeoffValid;
+
+        // These properties are all recomputed together above, so a single signal is sufficient.
         // QML property bindings list planViewStateChanged as their NOTIFY signal which means
-        // one emit re-evaluates all dependent bindings in one pass instead of 10 separate updates.
+        // one emit re-evaluates all dependent bindings in one pass instead of many separate updates.
         // splitSegmentChanged is kept separate because PlanView.qml has an explicit onSplitSegmentChanged handler.
         emit planViewStateChanged();
         emit splitSegmentChanged();
@@ -2355,9 +2364,8 @@ bool MissionController::isEmpty(void) const
     return _visualItems->count() <= 1;
 }
 
-void MissionController::_forceRecalcOfAllowedBits(void)
+void MissionController::_recalcPlanViewState(void)
 {
-    // Force a recalc of allowed bits
     setCurrentPlanViewSeqNum(_currentPlanViewSeqNum, true /* force */);
 }
 

--- a/src/MissionManager/MissionController.h
+++ b/src/MissionManager/MissionController.h
@@ -82,9 +82,9 @@ public:
     Q_PROPERTY(int                  batteryChangePoint              READ batteryChangePoint             NOTIFY batteryChangePointChanged)
     Q_PROPERTY(int                  batteriesRequired               READ batteriesRequired              NOTIFY batteriesRequiredChanged)
     Q_PROPERTY(QGCGeoBoundingCube*  travelBoundingCube              READ travelBoundingCube             NOTIFY missionBoundingCubeChanged)
-    Q_PROPERTY(bool                 onlyInsertTakeoffValid          MEMBER _onlyInsertTakeoffValid      NOTIFY planViewStateChanged)
     Q_PROPERTY(bool                 isInsertTakeoffValid            MEMBER _isInsertTakeoffValid        NOTIFY planViewStateChanged)
     Q_PROPERTY(bool                 isInsertLandValid               MEMBER _isInsertLandValid           NOTIFY planViewStateChanged)
+    Q_PROPERTY(bool                 isInsertROIValid                MEMBER _isInsertROIValid            NOTIFY planViewStateChanged)
     Q_PROPERTY(bool                 hasLandItem                     MEMBER _hasLandItem                 NOTIFY hasLandItemChanged)
     Q_PROPERTY(bool                 multipleLandPatternsAllowed     READ multipleLandPatternsAllowed    NOTIFY multipleLandPatternsAllowedChanged)
     Q_PROPERTY(bool                 isROIActive                     MEMBER _isROIActive                 NOTIFY planViewStateChanged)
@@ -352,7 +352,7 @@ private slots:
     void _complexBoundingBoxChanged             (void);
     void _recalcAll                             (void);
     void _managerVehicleChanged                 (Vehicle* managerVehicle);
-    void _forceRecalcOfAllowedBits              (void);
+    void _recalcPlanViewState                   (void);
     // Incremental tree model sync slots
     void _syncTreeMissionItemsInserted                (const QModelIndex& parent, int first, int last);
     void _syncTreeMissionItemsAboutToBeRemoved         (const QModelIndex& parent, int first, int last);
@@ -441,9 +441,9 @@ private:
     QGeoCoordinate              _previousCoordinate;
     FlightPathSegment*          _splitSegment =                 nullptr;
     bool                        _delayedSplitSegmentUpdate =    false;
-    bool                        _onlyInsertTakeoffValid =       true;
     bool                        _isInsertTakeoffValid =         true;
     bool                        _isInsertLandValid =            false;
+    bool                        _isInsertROIValid =             false;
     bool                        _hasLandItem =                  false;
     bool                        _isROIActive =                  false;
     bool                        _flyThroughCommandsAllowed =    false;

--- a/src/PlanView/PlanInfoEditor.qml
+++ b/src/PlanView/PlanInfoEditor.qml
@@ -79,24 +79,28 @@ Rectangle {
             visible: vehicleInfoSectionHeader.visible && vehicleInfoSectionHeader.checked
 
             FactComboBox {
+                objectName: "planInfo_firmwareCombo"
                 fact: QGroundControl.settingsManager.appSettings.offlineEditingFirmwareClass
                 indexModel: false
                 Layout.fillWidth: true
                 visible: _root._multipleFirmware && _root._allowFWVehicleTypeSelection
             }
             QGCLabel {
+                objectName: "planInfo_firmwareLabel"
                 text: _root._controllerVehicle ? _root._controllerVehicle.firmwareTypeString : ""
                 Layout.fillWidth: true
                 visible: _root._multipleFirmware && !_root._allowFWVehicleTypeSelection
             }
 
             FactComboBox {
+                objectName: "planInfo_vehicleTypeCombo"
                 fact: QGroundControl.settingsManager.appSettings.offlineEditingVehicleClass
                 indexModel: false
                 Layout.fillWidth: true
                 visible: _root._multipleVehicleTypes && _root._allowFWVehicleTypeSelection
             }
             QGCLabel {
+                objectName: "planInfo_vehicleTypeLabel"
                 text: _root._controllerVehicle ? _root._controllerVehicle.vehicleTypeString : ""
                 Layout.fillWidth: true
                 visible: _root._multipleVehicleTypes && !_root._allowFWVehicleTypeSelection
@@ -179,12 +183,14 @@ Rectangle {
         // ── Plan Templates ──
         SectionHeader {
             id: planTemplateSectionHeader
+            objectName: "planInfo_templatesSection"
             Layout.fillWidth: true
             text: qsTr("Plan Templates")
             visible: _root.planMasterController.showCreateFromTemplate
         }
 
         ColumnLayout {
+            objectName: "planInfo_templatesColumn"
             Layout.fillWidth: true
             spacing: ScreenTools.defaultFontPixelHeight / 2
             visible: planTemplateSectionHeader.visible && planTemplateSectionHeader.checked
@@ -195,6 +201,7 @@ Rectangle {
                 model: _root.planMasterController.planCreators
 
                 QGCButton {
+                    objectName: "planCreator_" + object.name
                     Layout.fillWidth: true
                     text: object.name
                     onClicked: {

--- a/src/PlanView/PlanToolBarIndicators.qml
+++ b/src/PlanView/PlanToolBarIndicators.qml
@@ -116,6 +116,7 @@ RowLayout {
     QGCPalette { id: qgcPal }
 
     QGCButton {
+        objectName: "planToolbar_openButton"
         text: qsTr("Open")
         iconSource: "/qmlimages/Plan.svg"
         enabled: !_planMasterController.syncInProgress
@@ -123,6 +124,7 @@ RowLayout {
     }
 
     QGCButton {
+        objectName: "planToolbar_saveButton"
         text: qsTr("Save")
         iconSource: "/res/SaveToDisk.svg"
         enabled: !_syncInProgress && _hasPlanItems
@@ -132,15 +134,17 @@ RowLayout {
 
     QGCButton {
         id: uploadButton
+        objectName: "planToolbar_uploadButton"
         text: qsTr("Upload")
         iconSource: "/res/UploadToVehicle.svg"
-        enabled: !_syncInProgress && _hasPlanItems
+        enabled: !_syncInProgress && _hasPlanItems && !_controllerOffline
         visible: !_syncInProgress
-        primary: _uploadDirty
+        primary: _uploadDirty && !_controllerOffline
         onClicked: { toolbarButtonClicked(); _uploadClicked() }
     }
 
     QGCButton {
+        objectName: "planToolbar_clearButton"
         text: qsTr("Clear")
         iconSource: "/res/TrashCan.svg"
         enabled: !_syncInProgress

--- a/src/PlanView/PlanTreeView.qml
+++ b/src/PlanView/PlanTreeView.qml
@@ -328,6 +328,7 @@ TreeView {
             id: groupHeaderComponent
 
             Rectangle {
+                objectName: "planTree_" + delegateRoot.nodeType + "Header"
                 width:  delegateRoot.width
                 height: ScreenTools.implicitComboBoxHeight + ScreenTools.defaultFontPixelWidth
                 color:  qgcPal.windowShade

--- a/src/PlanView/PlanView.qml
+++ b/src/PlanView/PlanView.qml
@@ -34,7 +34,6 @@ Item {
     property bool   _promptForPlanUsageShowing: false
     property bool   _addROIOnClick: false
     property bool   _addWaypointOnClick: false
-    property bool   _homePositionSet: _missionController.homePositionSet
 
     readonly property int _layerMission: 1
     readonly property int _layerFence: 2
@@ -240,6 +239,7 @@ Item {
 
         FlightMap {
             id: editorMap
+            objectName: "planView_map"
             anchors.fill: parent
             mapName: "MissionEditor"
             allowGCSLocationCenter: true
@@ -436,18 +436,20 @@ Item {
                 id: toolStripActionList
                 model: [
                     ToolStripAction {
+                        objectName: "planToolStrip_takeoffButton"
                         text: qsTr("Takeoff")
                         iconSource: "/res/takeoff.svg"
-                        enabled: _homePositionSet && _missionController.isInsertTakeoffValid
+                        enabled: _missionController.isInsertTakeoffValid
                         visible: toolStrip._isMissionLayer && !_planMasterController.controllerVehicle.rover
                         onTriggered: {
                             insertTakeoffItemAfterCurrent()
                         }
                     },
                     ToolStripAction {
+                        objectName: "planToolStrip_patternButton"
                         text: _singleComplexItem ? _missionController.complexMissionItems[0].translatedName : qsTr("Pattern")
                         iconSource: "/qmlimages/MapDrawShape.svg"
-                        enabled: _homePositionSet && _missionController.flyThroughCommandsAllowed
+                        enabled: _missionController.flyThroughCommandsAllowed
                         visible: toolStrip._isMissionLayer
                         dropPanelComponent: _singleComplexItem ? undefined : patternDropPanel
                         onTriggered: {
@@ -458,30 +460,33 @@ Item {
                     },
                     ToolStripAction {
                         id: waypointButton
+                        objectName: "planToolStrip_waypointButton"
                         text: qsTr("Waypoint")
                         iconSource: "/res/waypoint.svg"
-                        enabled: _homePositionSet
+                        enabled: _missionController.flyThroughCommandsAllowed
                         visible: toolStrip._isMissionLayer
                         checkable: true
                         onTriggered: { _addWaypointOnClick = !_addWaypointOnClick; if (_addWaypointOnClick) _addROIOnClick = false }
                     },
                     ToolStripAction {
                         id: roiButton
-                        text: qsTr("ROI")
+                        objectName: "planToolStrip_roiButton"
+                        text: _missionController.isROIActive ? qsTr("Cancel ROI") : qsTr("ROI")
                         iconSource: "/qmlimages/roi.svg"
-                        enabled: _homePositionSet
+                        enabled: _missionController.isInsertROIValid
                         visible: toolStrip._isMissionLayer && _planMasterController.controllerVehicle.supports.roiMode
                         checkable: true
                         onTriggered: { _addROIOnClick = !_addROIOnClick; if (_addROIOnClick) _addWaypointOnClick = false }
                     },
                     ToolStripAction {
+                        objectName: "planToolStrip_landButton"
                         text: _planMasterController.controllerVehicle.multiRotor
                                     ? qsTr("Return")
                                     : _missionController.isInsertLandValid && _missionController.hasLandItem
                                       ? qsTr("Alt Land")
                                       : qsTr("Land")
                         iconSource: "/res/rtl.svg"
-                        enabled: _homePositionSet && _missionController.isInsertLandValid
+                        enabled: _missionController.isInsertLandValid
                         visible: toolStrip._isMissionLayer
                         onTriggered: {
                             insertLandItemAfterCurrent()

--- a/src/QmlControls/QGCFileDialog.qml
+++ b/src/QmlControls/QGCFileDialog.qml
@@ -26,7 +26,15 @@ Item {
 
     function openForLoad() {
         _openForLoad = true
-        if (_mobileDlg && folder.length !== 0) {
+        if (QGCFileDialogController.testHookArmed()) {
+            // Unit test shim: bypass the native dialog and produce the armed result
+            var testFile = QGCFileDialogController.takeTestNextFile()
+            if (testFile.length === 0) {
+                _root.rejected()
+            } else {
+                _root.acceptedForLoad(testFile)
+            }
+        } else if (_mobileDlg && folder.length !== 0) {
             mobileFileOpenDialogFactory.open()
         } else if (selectFolder) {
             fullFolderDialog.open()
@@ -38,7 +46,15 @@ Item {
 
     function openForSave() {
         _openForLoad = false
-        if (_mobileDlg && folder.length !== 0) {
+        if (QGCFileDialogController.testHookArmed()) {
+            // Unit test shim: bypass the native dialog and produce the armed result
+            var testFile = QGCFileDialogController.takeTestNextFile()
+            if (testFile.length === 0) {
+                _root.rejected()
+            } else {
+                _root.acceptedForSave(testFile)
+            }
+        } else if (_mobileDlg && folder.length !== 0) {
             mobileFileSaveDialogFactory.open()
         } else {
             fullFileDialog.fileMode = FileDialog.SaveFile

--- a/src/QmlControls/QGCFileDialogController.cc
+++ b/src/QmlControls/QGCFileDialogController.cc
@@ -12,6 +12,46 @@
 
 QGC_LOGGING_CATEGORY(QGCFileDialogControllerLog, "QMLControls.QGCFileDialogController")
 
+#ifdef QGC_UNITTEST_BUILD
+static bool s_testHookArmed = false;
+static QString s_testNextFile;
+
+bool QGCFileDialogController::testHookArmed()
+{
+    return s_testHookArmed;
+}
+
+QString QGCFileDialogController::takeTestNextFile()
+{
+    s_testHookArmed = false;
+    const QString file = s_testNextFile;
+    s_testNextFile.clear();
+    return file;
+}
+
+void QGCFileDialogController::setTestNextFileForAccept(const QString &file)
+{
+    s_testHookArmed = true;
+    s_testNextFile = file;
+}
+
+void QGCFileDialogController::setTestRejectNext()
+{
+    s_testHookArmed = true;
+    s_testNextFile.clear();
+}
+#else
+bool QGCFileDialogController::testHookArmed()
+{
+    return false;
+}
+
+QString QGCFileDialogController::takeTestNextFile()
+{
+    return QString();
+}
+#endif
+
 QGCFileDialogController::QGCFileDialogController(QObject *parent)
     : QObject(parent)
 {

--- a/src/QmlControls/QGCFileDialogController.h
+++ b/src/QmlControls/QGCFileDialogController.h
@@ -38,6 +38,30 @@ public:
     /// On non-Android platforms this is a no-op.
     Q_INVOKABLE void importFromNativePicker();
 
+    /// @name Unit test file dialog shim
+    /// Native file dialogs cannot be driven from automated tests. Tests arm the
+    /// shim with the result the next dialog should produce; QGCFileDialog.qml
+    /// checks testHookArmed() in openForLoad()/openForSave() and, when armed,
+    /// emits acceptedForLoad/acceptedForSave (or rejected) directly instead of
+    /// opening the native dialog. Outside of unit test builds the hook is never
+    /// armed and the QML check is a no-op.
+    ///@{
+
+    /// Returns true if a test result has been armed for the next dialog open.
+    Q_INVOKABLE static bool testHookArmed();
+
+    /// Returns the armed file path (empty for reject) and disarms the hook.
+    Q_INVOKABLE static QString takeTestNextFile();
+
+#ifdef QGC_UNITTEST_BUILD
+    /// Arms the next dialog open to be accepted with the specified file.
+    static void setTestNextFileForAccept(const QString &file);
+
+    /// Arms the next dialog open to be rejected.
+    static void setTestRejectNext();
+#endif
+    ///@}
+
 signals:
     /// Emitted when the selected file has been successfully imported to the Missions directory.
     /// @param filePath Fully-qualified path of the imported file in the Missions directory.

--- a/src/QmlControls/QGCPopupDialog.qml
+++ b/src/QmlControls/QGCPopupDialog.qml
@@ -232,12 +232,14 @@ Popup {
 
             QGCButton {
                 id:                     rejectButton
+                objectName:             "popupDialog_rejectButton"
                 onClicked:              _reject()
                 Layout.minimumWidth:    height * 1.5
             }
 
             QGCButton {
                 id:                     acceptButton
+                objectName:             "popupDialog_acceptButton"
                 primary:                true
                 onClicked:              _accept()
                 Layout.minimumWidth:    height * 1.5

--- a/src/QmlControls/ToolStripHoverButton.qml
+++ b/src/QmlControls/ToolStripHoverButton.qml
@@ -6,6 +6,7 @@ import QGroundControl.Controls
 
 Button {
     id:             control
+    objectName:     toolStripAction ? toolStripAction.objectName : ""
     width:          contentLayoutItem.contentWidth + (contentMargins * 2)
     height:         width
     hoverEnabled:   !ScreenTools.isMobile

--- a/test/MissionManager/MissionControllerTest.cc
+++ b/test/MissionManager/MissionControllerTest.cc
@@ -97,6 +97,44 @@ void MissionControllerTest::_setupVisualItemSignals(VisualMissionItem* visualIte
     QVERIFY(visualItemSpy.init(visualItem));
 }
 
+void MissionControllerTest::_testInsertValidityHomePositionGating()
+{
+    _initForFirmwareType(MAV_AUTOPILOT_PX4);
+
+    auto boolProperty = [this](const char* name) {
+        const QVariant value = _missionController->property(name);
+        return value.isValid() && value.toBool();
+    };
+
+    // All insert validity properties must exist
+    QVERIFY(_missionController->property("isInsertTakeoffValid").isValid());
+    QVERIFY(_missionController->property("isInsertLandValid").isValid());
+    QVERIFY(_missionController->property("isInsertROIValid").isValid());
+    QVERIFY(_missionController->property("flyThroughCommandsAllowed").isValid());
+
+    // No home position set: no inserts are valid
+    QCOMPARE(_missionController->homePositionSet(), false);
+    QCOMPARE(boolProperty("isInsertTakeoffValid"), false);
+    QCOMPARE(boolProperty("isInsertLandValid"), false);
+    QCOMPARE(boolProperty("isInsertROIValid"), false);
+    QCOMPARE(boolProperty("flyThroughCommandsAllowed"), false);
+
+    // Home position set, empty plan: only takeoff insert is valid
+    _missionController->setHomePosition(Coord::zurich());
+    QCOMPARE(_missionController->homePositionSet(), true);
+    QCOMPARE(boolProperty("isInsertTakeoffValid"), true);
+    QCOMPARE(boolProperty("isInsertLandValid"), false);
+    QCOMPARE(boolProperty("isInsertROIValid"), false);
+    QCOMPARE(boolProperty("flyThroughCommandsAllowed"), false);
+
+    // Takeoff added: takeoff no longer valid, everything else is
+    QVERIFY(_missionController->insertTakeoffItem(Coord::zurich(), 1, true /* makeCurrentItem */));
+    QCOMPARE(boolProperty("isInsertTakeoffValid"), false);
+    QCOMPARE(boolProperty("isInsertLandValid"), true);
+    QCOMPARE(boolProperty("isInsertROIValid"), true);
+    QCOMPARE(boolProperty("flyThroughCommandsAllowed"), true);
+}
+
 void MissionControllerTest::_testGimbalRecalc()
 {
     _initForFirmwareType(MAV_AUTOPILOT_PX4);

--- a/test/MissionManager/MissionControllerTest.h
+++ b/test/MissionManager/MissionControllerTest.h
@@ -31,6 +31,7 @@ private slots:
     void _testInsertSurveyAppliesAltFrameInMixedMode();
     void _testInsertNonSurveyComplexItemMixedModeNoCrash();
     void _testInsertComplexItemFromKML();
+    void _testInsertValidityHomePositionGating();
 
     // Parameterized tests - runs once per autopilot type
     UT_PARAMETERIZED_TEST(_testEmptyVehicle);

--- a/test/QmlUITests/CMakeLists.txt
+++ b/test/QmlUITests/CMakeLists.txt
@@ -14,6 +14,8 @@ target_sources(${CMAKE_PROJECT_NAME}
         ${CMAKE_CURRENT_SOURCE_DIR}/APMVehicleConfigUITest.h
         ${CMAKE_CURRENT_SOURCE_DIR}/ToolbarIndicatorUITest.cc
         ${CMAKE_CURRENT_SOURCE_DIR}/ToolbarIndicatorUITest.h
+        ${CMAKE_CURRENT_SOURCE_DIR}/PlanViewUITest.cc
+        ${CMAKE_CURRENT_SOURCE_DIR}/PlanViewUITest.h
 )
 
 target_include_directories(${CMAKE_PROJECT_NAME}
@@ -25,3 +27,4 @@ add_qgc_test(TopLevelViewsTest LABELS Integration NoSanitizer TIMEOUT 120)
 add_qgc_test(PX4VehicleConfigUITest LABELS Integration NoSanitizer TIMEOUT 180)
 add_qgc_test(APMVehicleConfigUITest LABELS Integration NoSanitizer TIMEOUT 360)
 add_qgc_test(ToolbarIndicatorUITest LABELS Integration NoSanitizer TIMEOUT 180)
+add_qgc_test(PlanViewUITest LABELS Integration NoSanitizer TIMEOUT 120)

--- a/test/QmlUITests/PlanViewUITest.cc
+++ b/test/QmlUITests/PlanViewUITest.cc
@@ -1,0 +1,468 @@
+#include "PlanViewUITest.h"
+
+#include <QtCore/QFile>
+#include <QtCore/QTemporaryDir>
+#include <QtPositioning/QGeoCoordinate>
+#include <QtQuick/QQuickItem>
+#include <QtQuick/QQuickWindow>
+#include <QtTest/QTest>
+
+#include "QGCFileDialogController.h"
+
+UT_REGISTER_TEST(PlanViewUITest, TestLabel::Integration, TestLabel::MissionManager)
+
+// Offline Plan view lifecycle test. No vehicle is connected for the entire
+// test, so Upload must remain disabled and un-highlighted throughout.
+
+void PlanViewUITest::_clickMap(qreal fractionX, qreal fractionY)
+{
+    QQuickItem *map = findVisibleItem(_rootItem, QStringLiteral("planView_map"));
+    QVERIFY2(map, "planView_map not found");
+
+    const QPointF scenePos = map->mapToScene(QPointF(map->width() * fractionX, map->height() * fractionY));
+    QTest::mouseClick(_window, Qt::LeftButton, Qt::NoModifier, scenePos.toPoint());
+}
+
+int PlanViewUITest::_missionItemCount()
+{
+    QQuickItem *planView = findVisibleItem(_rootItem, QStringLiteral("mainView_plan"));
+    if (!planView) {
+        return -1;
+    }
+    QObject *visualItems = planView->property("_visualItems").value<QObject*>();
+    if (!visualItems) {
+        return -1;
+    }
+    return visualItems->property("count").toInt();
+}
+
+void PlanViewUITest::_verifyFullState(const PlanUIState &state, const QString &context)
+{
+    const QString takeoffBtn   = QStringLiteral("planToolStrip_takeoffButton");
+    const QString waypointBtn  = QStringLiteral("planToolStrip_waypointButton");
+    const QString roiBtn       = QStringLiteral("planToolStrip_roiButton");
+    const QString patternBtn   = QStringLiteral("planToolStrip_patternButton");
+    const QString landBtn      = QStringLiteral("planToolStrip_landButton");
+    const QString saveBtn      = QStringLiteral("planToolbar_saveButton");
+    const QString uploadBtn    = QStringLiteral("planToolbar_uploadButton");
+    const QString openBtn      = QStringLiteral("planToolbar_openButton");
+    const QString clearBtn     = QStringLiteral("planToolbar_clearButton");
+    const QString templatesCol = QStringLiteral("planInfo_templatesColumn");
+
+    // Templates section
+    if (state.templatesVisible) {
+        QVERIFY2(findVisibleItem(_rootItem, templatesCol, 2000),
+                 qPrintable(context + ": templates section not visible"));
+        verifyEnabled(templatesCol, state.templatesEnabled, context);
+    } else {
+        QVERIFY2(waitForCondition(
+                     [&] { return findVisibleItem(_rootItem, templatesCol, 0) == nullptr; },
+                     2000, QStringLiteral("templates section hidden")),
+                 qPrintable(context + ": templates section unexpectedly visible"));
+    }
+
+    // Toolstrip
+    verifyEnabled(takeoffBtn,  state.takeoffEnabled,  context);
+    verifyEnabled(waypointBtn, state.waypointEnabled, context);
+    verifyChecked(waypointBtn, state.waypointChecked, context);
+    verifyEnabled(patternBtn,  state.patternEnabled,  context);
+    verifyEnabled(landBtn,     state.landEnabled,     context);
+    verifyText(landBtn,        state.landText,        context);
+    if (findVisibleItem(_rootItem, roiBtn, 0)) {
+        verifyEnabled(roiBtn, state.roiEnabled, context);
+        verifyChecked(roiBtn, state.roiChecked, context);
+        verifyText(roiBtn, state.roiCancelText ? QStringLiteral("Cancel ROI") : QStringLiteral("ROI"), context);
+    }
+
+    // Toolbar
+    verifyEnabled(saveBtn, state.saveEnabled, context);
+    verifyPrimary(saveBtn, state.savePrimary, context);
+    verifyEnabled(openBtn,  true, context);
+    verifyEnabled(clearBtn, true, context);
+
+    // Offline invariant: Upload must never be enabled or highlighted
+    verifyEnabled(uploadBtn, false, context);
+    verifyPrimary(uploadBtn, false, context);
+
+    // Visual item count
+    QVERIFY2(waitForCondition([&] { return _missionItemCount() == state.itemCount; }, 2000,
+                              QStringLiteral("visual item count")),
+             qPrintable(QStringLiteral("%1: expected %2 visual items but found %3")
+                            .arg(context).arg(state.itemCount).arg(_missionItemCount())));
+}
+
+void PlanViewUITest::_testPlanViewStates()
+{
+    startUI();
+    if (QTest::currentTestFailed()) return;
+
+    // Navigate to Plan view
+    QVERIFY2(clickButton(QStringLiteral("toolbar_qgcLogo")), "Failed to click Q logo button");
+    QVERIFY2(findVisibleItem(_rootItem, QStringLiteral("toolbar_viewPlan"), 2000), "Plan view button not found");
+    QVERIFY2(clickButton(QStringLiteral("toolbar_viewPlan")), "Failed to click Plan view button");
+    QVERIFY2(findVisibleItem(_rootItem, QStringLiteral("mainView_plan"), 2000), "Plan view did not appear");
+    QTest::qWait(_viewDelay);
+
+    // Position the map at a known location and reasonable zoom so map clicks
+    // are deterministic and offset clicks produce nearby waypoints.
+    QQuickItem *map = findVisibleItem(_rootItem, QStringLiteral("planView_map"));
+    QVERIFY2(map, "planView_map not found");
+    map->setProperty("center", QVariant::fromValue(QGeoCoordinate(47.397742, 8.545594))); // Zurich
+    map->setProperty("zoomLevel", 15.0);
+    QTest::qWait(100); // Let the map settle
+
+    const QString takeoffBtn  = QStringLiteral("planToolStrip_takeoffButton");
+    const QString waypointBtn = QStringLiteral("planToolStrip_waypointButton");
+    const QString saveBtn     = QStringLiteral("planToolbar_saveButton");
+    const QString clearBtn    = QStringLiteral("planToolbar_clearButton");
+
+    // ------------------------------------------------------------------
+    // 1.1 Initial state: no home position, empty plan
+    // ------------------------------------------------------------------
+    _verifyFullState({
+        .templatesVisible = true,
+        .templatesEnabled = false,  // No home position
+        .takeoffEnabled   = false,
+        .waypointEnabled  = false,
+        .waypointChecked  = false,
+        .patternEnabled   = false,
+        .roiEnabled       = false,
+        .roiChecked       = false,
+        .roiCancelText    = false,
+        .landEnabled      = false,
+        .landText         = QStringLiteral("Return"),
+        .saveEnabled      = false,
+        .savePrimary      = false,
+        .itemCount        = 1,      // Mission settings item only
+    }, QStringLiteral("1.1 initial"));
+    if (QTest::currentTestFailed()) return;
+
+    // ------------------------------------------------------------------
+    // 1.2 Click map center to set home position
+    // ------------------------------------------------------------------
+    _clickMap(0.5, 0.5);
+    if (QTest::currentTestFailed()) return;
+
+    _verifyFullState({
+        .templatesVisible = true,
+        .templatesEnabled = true,   // Home position now set
+        .takeoffEnabled   = true,   // Plan empty: takeoff insertable
+        .waypointEnabled  = false,  // Takeoff required first
+        .waypointChecked  = false,
+        .patternEnabled   = false,
+        .roiEnabled       = false,
+        .roiChecked       = false,
+        .roiCancelText    = false,
+        .landEnabled      = false,
+        .landText         = QStringLiteral("Return"),
+        .saveEnabled      = false,  // Still no items
+        .savePrimary      = false,
+        .itemCount        = 1,      // Setting home adds no item
+    }, QStringLiteral("1.2 home set"));
+    if (QTest::currentTestFailed()) return;
+
+    // ------------------------------------------------------------------
+    // 1.3 Insert takeoff item
+    // ------------------------------------------------------------------
+    QVERIFY2(clickButton(takeoffBtn), "Failed to click Takeoff button");
+    QTest::qWait(_pageDelay);
+
+    _verifyFullState({
+        .templatesVisible = false,
+        .templatesEnabled = false,
+        .takeoffEnabled   = false,  // Plan no longer empty
+        .waypointEnabled  = true,
+        .waypointChecked  = false,
+        .patternEnabled   = true,
+        .roiEnabled       = true,
+        .roiChecked       = false,
+        .roiCancelText    = false,
+        .landEnabled      = true,
+        .landText         = QStringLiteral("Return"),
+        .saveEnabled      = true,
+        .savePrimary      = true,   // Unsaved changes
+        .itemCount        = 2,      // Settings + takeoff
+    }, QStringLiteral("1.3 takeoff"));
+    if (QTest::currentTestFailed()) return;
+
+    // ------------------------------------------------------------------
+    // 1.4 Insert waypoint at an offset from center
+    // ------------------------------------------------------------------
+    QVERIFY2(clickButton(waypointBtn), "Failed to click Waypoint button");
+    _clickMap(0.35, 0.4);
+    if (QTest::currentTestFailed()) return;
+    QTest::qWait(_pageDelay);
+
+    _verifyFullState({
+        .templatesVisible = false,
+        .templatesEnabled = false,
+        .takeoffEnabled   = false,
+        .waypointEnabled  = true,
+        .waypointChecked  = true,   // Add-waypoint mode stays active after insert
+        .patternEnabled   = true,
+        .roiEnabled       = true,
+        .roiChecked       = false,
+        .roiCancelText    = false,
+        .landEnabled      = true,
+        .landText         = QStringLiteral("Return"),
+        .saveEnabled      = true,
+        .savePrimary      = true,
+        .itemCount        = 3,      // + waypoint
+    }, QStringLiteral("1.4 waypoint"));
+    if (QTest::currentTestFailed()) return;
+
+    // ------------------------------------------------------------------
+    // 1.5 Save to disk via file dialog shim. First arm a rejection (user
+    //     cancels the dialog): nothing is written, plan stays dirty.
+    // ------------------------------------------------------------------
+    QTemporaryDir tempDir;
+    QVERIFY(tempDir.isValid());
+    const QString planFile = tempDir.filePath(QStringLiteral("PlanViewUITest.plan"));
+
+    QGCFileDialogController::setTestRejectNext();
+    QVERIFY2(clickButton(saveBtn), "Failed to click Save button (cancelled save)");
+
+    QVERIFY2(waitForCondition([] { return !QGCFileDialogController::testHookArmed(); }, 5000,
+                              QStringLiteral("file dialog shim consumed")),
+             "1.5 cancelled save: file dialog shim was not consumed");
+
+    _verifyFullState({
+        .templatesVisible = false,
+        .templatesEnabled = false,
+        .takeoffEnabled   = false,
+        .waypointEnabled  = true,
+        .waypointChecked  = false,  // Toolbar click cancels add-waypoint mode
+        .patternEnabled   = true,
+        .roiEnabled       = true,
+        .roiChecked       = false,
+        .roiCancelText    = false,
+        .landEnabled      = true,
+        .landText         = QStringLiteral("Return"),
+        .saveEnabled      = true,
+        .savePrimary      = true,   // Cancelled save: still dirty
+        .itemCount        = 3,      // Cancelled save changes nothing
+    }, QStringLiteral("1.5 cancelled save"));
+    if (QTest::currentTestFailed()) return;
+    QVERIFY2(!QFile::exists(planFile), "1.5 cancelled save: plan file was unexpectedly written");
+
+    // Now the accepted save
+    QGCFileDialogController::setTestNextFileForAccept(planFile);
+    QVERIFY2(clickButton(saveBtn), "Failed to click Save button");
+
+    QVERIFY2(waitForCondition([&] { return QFile::exists(planFile); }, 5000,
+                              QStringLiteral("plan file written")),
+             "1.5 save: plan file was not written");
+    QVERIFY2(!QGCFileDialogController::testHookArmed(), "1.5 save: file dialog shim was not consumed");
+
+    _verifyFullState({
+        .templatesVisible = false,
+        .templatesEnabled = false,
+        .takeoffEnabled   = false,
+        .waypointEnabled  = true,
+        .waypointChecked  = false,  // Toolbar click cancels add-waypoint mode
+        .patternEnabled   = true,
+        .roiEnabled       = true,
+        .roiChecked       = false,
+        .roiCancelText    = false,
+        .landEnabled      = true,
+        .landText         = QStringLiteral("Return"),
+        .saveEnabled      = true,
+        .savePrimary      = false,  // dirtyForSave cleared
+        .itemCount        = 3,      // Save changes nothing
+    }, QStringLiteral("1.5 save"));
+    if (QTest::currentTestFailed()) return;
+
+    // ------------------------------------------------------------------
+    // 1.6 Modify plan again: Save highlight returns
+    // ------------------------------------------------------------------
+    QVERIFY2(clickButton(waypointBtn), "Failed to click Waypoint button (second)");
+    _clickMap(0.65, 0.6);
+    if (QTest::currentTestFailed()) return;
+    QTest::qWait(_pageDelay);
+
+    _verifyFullState({
+        .templatesVisible = false,
+        .templatesEnabled = false,
+        .takeoffEnabled   = false,
+        .waypointEnabled  = true,
+        .waypointChecked  = true,   // Add-waypoint mode active again
+        .patternEnabled   = true,
+        .roiEnabled       = true,
+        .roiChecked       = false,
+        .roiCancelText    = false,
+        .landEnabled      = true,
+        .landText         = QStringLiteral("Return"),
+        .saveEnabled      = true,
+        .savePrimary      = true,   // Save highlight returns
+        .itemCount        = 4,      // + second waypoint
+    }, QStringLiteral("1.6 modify"));
+    if (QTest::currentTestFailed()) return;
+
+    // ------------------------------------------------------------------
+    // 1.7 Toolstrip checked state is mutually exclusive: clicking ROI
+    //     while in add-waypoint mode moves the checkmark to ROI
+    // ------------------------------------------------------------------
+    const QString roiBtn = QStringLiteral("planToolStrip_roiButton");
+    const bool roiSupported = findVisibleItem(_rootItem, roiBtn, 0) != nullptr;
+    if (roiSupported) {
+        QVERIFY2(clickButton(roiBtn), "Failed to click ROI button");
+
+        _verifyFullState({
+            .templatesVisible = false,
+            .templatesEnabled = false,
+            .takeoffEnabled   = false,
+            .waypointEnabled  = true,
+            .waypointChecked  = false,  // Checkmark moved from waypoint to ROI
+            .patternEnabled   = true,
+            .roiEnabled       = true,
+            .roiChecked       = true,
+            .roiCancelText    = false,
+            .landEnabled      = true,
+            .landText         = QStringLiteral("Return"),
+            .saveEnabled      = true,
+            .savePrimary      = true,
+            .itemCount        = 4,      // Entering ROI mode adds no item
+        }, QStringLiteral("1.7 roi mode"));
+        if (QTest::currentTestFailed()) return;
+
+        // ROI is one-shot: adding the ROI clears the mode (unchecked) and
+        // the button relabels to "Cancel ROI" while an ROI is active.
+        _clickMap(0.6, 0.35);
+        if (QTest::currentTestFailed()) return;
+        QTest::qWait(_pageDelay);
+
+        _verifyFullState({
+            .templatesVisible = false,
+            .templatesEnabled = false,
+            .takeoffEnabled   = false,
+            .waypointEnabled  = true,
+            .waypointChecked  = false,
+            .patternEnabled   = true,
+            .roiEnabled       = true,
+            .roiChecked       = false,  // One-shot mode cleared
+            .roiCancelText    = true,   // ROI active in plan
+            .landEnabled      = true,
+            .landText         = QStringLiteral("Return"),
+            .saveEnabled      = true,
+            .savePrimary      = true,
+            .itemCount        = 5,      // + ROI
+        }, QStringLiteral("1.7 roi added"));
+        if (QTest::currentTestFailed()) return;
+    }
+
+    // ------------------------------------------------------------------
+    // 1.8 Insert land/return item: land no longer insertable and no fly
+    //     through commands are allowed after it
+    // ------------------------------------------------------------------
+    const QString landBtn = QStringLiteral("planToolStrip_landButton");
+    QVERIFY2(clickButton(landBtn), "Failed to click Land button");
+    QTest::qWait(_pageDelay);
+
+    _verifyFullState({
+        .templatesVisible = false,
+        .templatesEnabled = false,
+        .takeoffEnabled   = false,
+        .waypointEnabled  = false,  // No fly through commands after land item
+        .waypointChecked  = false,
+        .patternEnabled   = false,  // No fly through commands after land item
+        .roiEnabled       = true,
+        .roiChecked       = false,
+        .roiCancelText    = true,   // ROI from 1.7 still active
+        .landEnabled      = false,  // Only one land item allowed
+        .landText         = QStringLiteral("Return"),
+        .saveEnabled      = true,
+        .savePrimary      = true,
+        .itemCount        = roiSupported ? 6 : 5,   // + land/return item
+    }, QStringLiteral("1.8 land added"));
+    if (QTest::currentTestFailed()) return;
+
+    // ------------------------------------------------------------------
+    // 1.9 Clear plan: full round trip back to initial state
+    // ------------------------------------------------------------------
+    QVERIFY2(clickButton(clearBtn), "Failed to click Clear button");
+    QVERIFY2(findVisibleItem(_rootItem, QStringLiteral("popupDialog_acceptButton"), 2000),
+             "1.9 clear: confirmation dialog did not appear");
+    QVERIFY2(clickButton(QStringLiteral("popupDialog_acceptButton")), "Failed to confirm Clear");
+    QTest::qWait(_pageDelay);
+
+    // Clear removes the plan items and the home position: back to initial state
+    _verifyFullState({
+        .templatesVisible = true,
+        .templatesEnabled = false,  // Home position cleared
+        .takeoffEnabled   = false,
+        .waypointEnabled  = false,
+        .waypointChecked  = false,
+        .patternEnabled   = false,
+        .roiEnabled       = false,
+        .roiChecked       = false,
+        .roiCancelText    = false,
+        .landEnabled      = false,
+        .landText         = QStringLiteral("Return"),
+        .saveEnabled      = false,
+        .savePrimary      = false,
+        .itemCount        = 1,      // Back to settings item only
+    }, QStringLiteral("1.9 after clear"));
+    if (QTest::currentTestFailed()) return;
+
+    // ------------------------------------------------------------------
+    // 1.10 Open the plan saved in 1.5: save -> clear -> open round trip.
+    //      First arm a rejection (user cancels the dialog): nothing loads.
+    // ------------------------------------------------------------------
+    QGCFileDialogController::setTestRejectNext();
+    QVERIFY2(clickButton(QStringLiteral("planToolbar_openButton")), "Failed to click Open button (cancelled open)");
+
+    QVERIFY2(waitForCondition([] { return !QGCFileDialogController::testHookArmed(); }, 5000,
+                              QStringLiteral("file dialog shim consumed")),
+             "1.10 cancelled open: file dialog shim was not consumed");
+
+    // Cancelled open: still in the post-clear initial state
+    _verifyFullState({
+        .templatesVisible = true,
+        .templatesEnabled = false,
+        .takeoffEnabled   = false,
+        .waypointEnabled  = false,
+        .waypointChecked  = false,
+        .patternEnabled   = false,
+        .roiEnabled       = false,
+        .roiChecked       = false,
+        .roiCancelText    = false,
+        .landEnabled      = false,
+        .landText         = QStringLiteral("Return"),
+        .saveEnabled      = false,
+        .savePrimary      = false,
+        .itemCount        = 1,      // Cancelled open loads nothing
+    }, QStringLiteral("1.10 cancelled open"));
+    if (QTest::currentTestFailed()) return;
+
+    // Now the accepted open
+    QGCFileDialogController::setTestNextFileForAccept(planFile);
+    QVERIFY2(clickButton(QStringLiteral("planToolbar_openButton")), "Failed to click Open button");
+
+    QVERIFY2(waitForCondition([] { return !QGCFileDialogController::testHookArmed(); }, 5000,
+                              QStringLiteral("file dialog shim consumed")),
+             "1.10 open: file dialog shim was not consumed");
+    QTest::qWait(_pageDelay);
+
+    // Loaded plan is the 1.5 snapshot: takeoff + one waypoint, home position
+    // restored from the file, not dirty for save. After load the current item
+    // is mission settings (seq 0), so fly-through/land inserts are disabled
+    // because they would be placed before the takeoff item.
+    _verifyFullState({
+        .templatesVisible = false,
+        .templatesEnabled = false,
+        .takeoffEnabled   = false,  // Takeoff already in plan
+        .waypointEnabled  = false,  // Insert would precede takeoff
+        .waypointChecked  = false,
+        .patternEnabled   = false,  // Insert would precede takeoff
+        .roiEnabled       = true,
+        .roiChecked       = false,
+        .roiCancelText    = false,  // Saved plan predates the ROI
+        .landEnabled      = false,  // Insert would precede takeoff
+        .landText         = QStringLiteral("Return"),
+        .saveEnabled      = true,
+        .savePrimary      = false,  // Freshly loaded plan is not dirty
+        .itemCount        = 3,      // Settings + takeoff + waypoint
+    }, QStringLiteral("1.10 open round trip"));
+
+    stopUI();
+}

--- a/test/QmlUITests/PlanViewUITest.h
+++ b/test/QmlUITests/PlanViewUITest.h
@@ -1,0 +1,52 @@
+#pragma once
+
+#include "QmlUITestBase.h"
+
+class QQuickItem;
+
+/// UI test for Plan view state transitions (offline, no vehicle).
+///
+/// Walks the Plan view through its full editing lifecycle verifying at each
+/// step: template-creation availability, toolstrip button enablement, and
+/// Save/Upload button enabled/highlight state.
+class PlanViewUITest : public QmlUITestBase
+{
+    Q_OBJECT
+
+public:
+    PlanViewUITest() = default;
+
+private slots:
+    void _testPlanViewStates();
+
+private:
+    /// Complete expected state of all Plan view UI under test
+    struct PlanUIState {
+        bool templatesVisible;
+        bool templatesEnabled;  ///< only checked when templatesVisible
+        bool takeoffEnabled;
+        bool waypointEnabled;
+        bool waypointChecked;   ///< add-waypoint-on-click mode active
+        bool patternEnabled;
+        bool roiEnabled;        ///< only checked if ROI button is visible (vehicle support)
+        bool roiChecked;        ///< add-ROI-on-click mode active
+        bool roiCancelText;     ///< ROI button reads "Cancel ROI" (an ROI is active in the plan)
+        bool landEnabled;
+        QString landText;       ///< expected Land button label ("Return" for multirotor)
+        bool saveEnabled;
+        bool savePrimary;
+        int itemCount;          ///< expected visualItems.count (mission settings item counts as 1)
+    };
+
+    /// Verify every Plan view UI element against the full expected state.
+    /// Also checks the invariants that hold while offline: Upload disabled
+    /// and not highlighted, Open/Clear always enabled.
+    void _verifyFullState(const PlanUIState &state, const QString &context);
+
+    /// Click the Plan view map at a fractional position within its viewport.
+    /// (0.5, 0.5) is the map center.
+    void _clickMap(qreal fractionX, qreal fractionY);
+
+    /// Current MissionController visualItems count, or -1 if unavailable.
+    int _missionItemCount();
+};

--- a/test/QmlUITests/QmlUITestBase.cc
+++ b/test/QmlUITests/QmlUITestBase.cc
@@ -3,6 +3,7 @@
 #include <QtCore/QCoreApplication>
 #include <QtCore/QRegularExpression>
 #include <QtCore/QScopeGuard>
+#include <QtCore/QVariant>
 #include <QtQml/QQmlApplicationEngine>
 #include <QtQuick/QQuickItem>
 #include <QtQuick/QQuickWindow>
@@ -17,6 +18,7 @@
 #include "MultiVehicleManager.h"
 #include "QGCApplication.h"
 #include "QGCCorePlugin.h"
+#include "QGCFileDialogController.h"
 #include "QGCImageProvider.h"
 #include "SettingsManager.h"
 #include "Vehicle.h"
@@ -121,6 +123,14 @@ void QmlUITestBase::stopUI()
     destroyUIEngine();
 }
 
+void QmlUITestBase::_verifyFileDialogTestHookConsumed()
+{
+    if (QGCFileDialogController::testHookArmed()) {
+        QGCFileDialogController::takeTestNextFile();  // clear so later tests aren't contaminated
+        QTest::qFail("file dialog test hook was armed but never consumed by a dialog", __FILE__, __LINE__);
+    }
+}
+
 bool QmlUITestBase::clickButton(const QString &objectName)
 {
     QQuickItem *btn = findVisibleItem(_rootItem, objectName);
@@ -130,6 +140,74 @@ bool QmlUITestBase::clickButton(const QString &objectName)
     const QPointF center = btn->mapToScene(QPointF(btn->width() / 2, btn->height() / 2));
     QTest::mouseClick(_window, Qt::LeftButton, Qt::NoModifier, center.toPoint());
     return true;
+}
+
+// Format a property value for failure messages: quote strings, otherwise use
+// QVariant's string form ("true"/"false" for bools).
+static QString _displayValue(const QVariant &value)
+{
+    if (value.typeId() == QMetaType::QString) {
+        return QStringLiteral("'%1'").arg(value.toString());
+    }
+    return value.toString();
+}
+
+bool QmlUITestBase::_verifyItemProperty(const QString &objectName, const char *propertyName,
+                                        const QVariant &expectedValue, const QString &context)
+{
+    // Item discovery is as asynchronous as state propagation (view transitions,
+    // Loaders); poll for the item with the same ceiling as the state check.
+    // findVisibleItem returns immediately once the item exists.
+    QQuickItem *item = findVisibleItem(_rootItem, objectName, 2000);
+    if (!item) {
+        QTest::qFail(qPrintable(QStringLiteral("%1: item not found: %2").arg(context, objectName)),
+                     __FILE__, __LINE__);
+        return false;
+    }
+
+    // An invalid QVariant silently converts to false/"", which would make a
+    // false/empty expected value pass vacuously on an item without the property.
+    if (!item->property(propertyName).isValid()) {
+        QTest::qFail(qPrintable(QStringLiteral("%1: %2 has no '%3' property")
+                                    .arg(context, objectName, QLatin1String(propertyName))),
+                     __FILE__, __LINE__);
+        return false;
+    }
+
+    // State changes propagate through bindings; allow them to settle
+    const bool matched = waitForCondition(
+        [item, propertyName, expectedValue] { return item->property(propertyName) == expectedValue; },
+        2000,
+        QStringLiteral("%1 %2 == %3").arg(objectName, QLatin1String(propertyName), _displayValue(expectedValue)));
+    if (!matched) {
+        QTest::qFail(qPrintable(QStringLiteral("%1: %2 expected %3=%4 but was %5")
+                                    .arg(context, objectName, QLatin1String(propertyName),
+                                         _displayValue(expectedValue),
+                                         _displayValue(item->property(propertyName)))),
+                     __FILE__, __LINE__);
+        return false;
+    }
+    return true;
+}
+
+bool QmlUITestBase::verifyEnabled(const QString &objectName, bool expectedEnabled, const QString &context)
+{
+    return _verifyItemProperty(objectName, "enabled", expectedEnabled, context);
+}
+
+bool QmlUITestBase::verifyPrimary(const QString &objectName, bool expectedPrimary, const QString &context)
+{
+    return _verifyItemProperty(objectName, "primary", expectedPrimary, context);
+}
+
+bool QmlUITestBase::verifyChecked(const QString &objectName, bool expectedChecked, const QString &context)
+{
+    return _verifyItemProperty(objectName, "checked", expectedChecked, context);
+}
+
+bool QmlUITestBase::verifyText(const QString &objectName, const QString &expectedText, const QString &context)
+{
+    return _verifyItemProperty(objectName, "text", expectedText, context);
 }
 
 void QmlUITestBase::scrollIntoView(QQuickItem *item, const QString &flickableObjectName)

--- a/test/QmlUITests/QmlUITestBase.h
+++ b/test/QmlUITests/QmlUITestBase.h
@@ -10,6 +10,7 @@ class MockLink;
 class QQmlApplicationEngine;
 class QQuickItem;
 class QQuickWindow;
+class QVariant;
 class Vehicle;
 
 /// Base class for QML UI smoke tests.
@@ -37,6 +38,7 @@ class QmlUITestBase : public UnitTest
 protected slots:
     void cleanup() override
     {
+        _verifyFileDialogTestHookConsumed();
         stopUI();
         UnitTest::cleanup();
     }
@@ -61,9 +63,33 @@ protected:
     /// null-reference bugs in QML bindings.
     void stopUI();
 
+    /// Fail the current test if the QGCFileDialogController test hook is still
+    /// armed at teardown. A hook armed but never consumed means the expected
+    /// dialog never opened; left armed it would be silently consumed by the
+    /// next dialog anywhere — possibly in a later test. Clears the hook so the
+    /// failure stays in the offending test.
+    void _verifyFileDialogTestHookConsumed();
+
     /// Click the visible QQuickItem with \a objectName in the current window.
     /// Returns false if the item cannot be found.
     bool clickButton(const QString &objectName);
+
+    /// Verify the enabled state of a visible item found by \a objectName,
+    /// waiting up to 2 seconds for bindings to settle. Returns false (after
+    /// recording a test failure) if the item is missing or the enabled state
+    /// does not match. \a context is prepended to failure messages.
+    bool verifyEnabled(const QString &objectName, bool expectedEnabled, const QString &context);
+
+    /// Verify the primary (highlight) state of a button found by \a objectName.
+    /// Same semantics as verifyEnabled().
+    bool verifyPrimary(const QString &objectName, bool expectedPrimary, const QString &context);
+
+    /// Verify the checked state of a checkable button found by \a objectName.
+    /// Same semantics as verifyEnabled().
+    bool verifyChecked(const QString &objectName, bool expectedChecked, const QString &context);
+
+    /// Same semantics as verifyEnabled().
+    bool verifyText(const QString &objectName, const QString &expectedText, const QString &context);
 
     /// Scroll the QQuickFlickable identified by \a flickableObjectName so that
     /// \a item's centre is fully visible inside the flickable. Does nothing if
@@ -108,4 +134,12 @@ protected:
     QQuickItem            *_rootItem = nullptr;
     int _viewDelay = 0;  ///< ms to pause between view switches when onscreen
     int _pageDelay = 0;  ///< ms to pause between page switches when onscreen
+
+private:
+    /// Shared implementation for the verify* helpers: find the visible item,
+    /// guard against the property not existing (an invalid QVariant silently
+    /// converts to false/"" which would make false/empty expectations pass
+    /// vacuously), then wait up to 2 seconds for the property to match.
+    bool _verifyItemProperty(const QString &objectName, const char *propertyName,
+                             const QVariant &expectedValue, const QString &context);
 };


### PR DESCRIPTION
Supersedes #14494

## Description

When the Plan view has a blank mission and no home position, the Waypoint and ROI toolstrip buttons were enabled even though selecting them did nothing — clicking the map just moves the home point (see #14494). This PR fixes that and goes further by moving the insert-button enablement logic out of QML and into `MissionController` where the actual insert validity is computed:

- All insert buttons (Takeoff, Waypoint, Pattern, ROI, Land) are disabled until the home position is set
- Waypoint, Pattern, ROI and Land are additionally disabled until a takeoff item exists, for vehicles that require takeoff first
- New `isInsertROIValid` property; the QML-only `onlyInsertTakeoffValid` property is removed (folded into the C++ recalculation)
- Upload is disabled and un-highlighted while the controller is offline

Because the gating now lives in the controller, the QML bindings reduce to single property references and the behavior is unit-testable.

## Type of Change
- [x] Bug fix (non-breaking change that fixes an issue)

## Testing
- [x] Tested locally
- [x] Added/updated unit tests

Test coverage added:
- `MissionControllerTest`: gating matrix for the insert validity properties (no home → home set → takeoff inserted)
- New `PlanViewUITest`: walks the offline Plan view through its full editing lifecycle verifying template availability, toolstrip enable/check states, Save/Upload enable/highlight, and visual item counts — including save/open file dialog accept *and* reject paths via a new `QGCFileDialogController` unit-test hook (compiled out of release builds)
- `QmlUITestBase`: shared property-verify helpers and automatic detection of leaked file-dialog test hooks in `cleanup()`

### Platforms Tested
- [x] macOS
