### PR TITLE
PX4 Sensors: Track orientation calibration state with explicit enum

### DIFF
--- a/src/AutoPilotPlugins/APM/APMSensorsComponent.qml
+++ b/src/AutoPilotPlugins/APM/APMSensorsComponent.qml
@@ -103,6 +103,14 @@ SetupPage {
                 _showSimpleAccelCalOption = true
             }
 
+            // Maps the APM controller per-side done/inProgress bools to a VehicleRotationCal.CalState
+            function sideCalState(done, inProgress) {
+                if (inProgress) {
+                    return VehicleRotationCal.CalState.InProgress
+                }
+                return done ? VehicleRotationCal.CalState.Completed : VehicleRotationCal.CalState.Incomplete
+            }
+
             function compassLabel(index) {
                 let label = qsTr("Compass %1 ").arg(index+1)
                 let addOpenParan = true
@@ -845,8 +853,7 @@ SetupPage {
                                 width:              parent.indicatorWidth
                                 height:             parent.indicatorHeight
                                 visible:            controller.orientationCalDownSideVisible
-                                calValid:           controller.orientationCalDownSideDone
-                                calInProgress:      controller.orientationCalDownSideInProgress
+                                calState:           sideCalState(controller.orientationCalDownSideDone, controller.orientationCalDownSideInProgress)
                                 calInProgressText:  controller.orientationCalDownSideRotate ? qsTr("Rotate") : qsTr("Hold Still")
                                 imageSource:        "qrc:///qmlimages/VehicleDown.png"
                             }
@@ -854,8 +861,7 @@ SetupPage {
                                 width:              parent.indicatorWidth
                                 height:             parent.indicatorHeight
                                 visible:            controller.orientationCalLeftSideVisible
-                                calValid:           controller.orientationCalLeftSideDone
-                                calInProgress:      controller.orientationCalLeftSideInProgress
+                                calState:           sideCalState(controller.orientationCalLeftSideDone, controller.orientationCalLeftSideInProgress)
                                 calInProgressText:  controller.orientationCalLeftSideRotate ? qsTr("Rotate") : qsTr("Hold Still")
                                 imageSource:        "qrc:///qmlimages/VehicleLeft.png"
                             }
@@ -863,8 +869,7 @@ SetupPage {
                                 width:              parent.indicatorWidth
                                 height:             parent.indicatorHeight
                                 visible:            controller.orientationCalRightSideVisible
-                                calValid:           controller.orientationCalRightSideDone
-                                calInProgress:      controller.orientationCalRightSideInProgress
+                                calState:           sideCalState(controller.orientationCalRightSideDone, controller.orientationCalRightSideInProgress)
                                 calInProgressText:  controller.orientationCalRightSideRotate ? qsTr("Rotate") : qsTr("Hold Still")
                                 imageSource:        "qrc:///qmlimages/VehicleRight.png"
                             }
@@ -872,8 +877,7 @@ SetupPage {
                                 width:              parent.indicatorWidth
                                 height:             parent.indicatorHeight
                                 visible:            controller.orientationCalNoseDownSideVisible
-                                calValid:           controller.orientationCalNoseDownSideDone
-                                calInProgress:      controller.orientationCalNoseDownSideInProgress
+                                calState:           sideCalState(controller.orientationCalNoseDownSideDone, controller.orientationCalNoseDownSideInProgress)
                                 calInProgressText:  controller.orientationCalNoseDownSideRotate ? qsTr("Rotate") : qsTr("Hold Still")
                                 imageSource:        "qrc:///qmlimages/VehicleNoseDown.png"
                             }
@@ -881,8 +885,7 @@ SetupPage {
                                 width:              parent.indicatorWidth
                                 height:             parent.indicatorHeight
                                 visible:            controller.orientationCalTailDownSideVisible
-                                calValid:           controller.orientationCalTailDownSideDone
-                                calInProgress:      controller.orientationCalTailDownSideInProgress
+                                calState:           sideCalState(controller.orientationCalTailDownSideDone, controller.orientationCalTailDownSideInProgress)
                                 calInProgressText:  controller.orientationCalTailDownSideRotate ? qsTr("Rotate") : qsTr("Hold Still")
                                 imageSource:        "qrc:///qmlimages/VehicleTailDown.png"
                             }
@@ -890,8 +893,7 @@ SetupPage {
                                 width:              parent.indicatorWidth
                                 height:             parent.indicatorHeight
                                 visible:            controller.orientationCalUpsideDownSideVisible
-                                calValid:           controller.orientationCalUpsideDownSideDone
-                                calInProgress:      controller.orientationCalUpsideDownSideInProgress
+                                calState:           sideCalState(controller.orientationCalUpsideDownSideDone, controller.orientationCalUpsideDownSideInProgress)
                                 calInProgressText:  controller.orientationCalUpsideDownSideRotate ? qsTr("Rotate") : qsTr("Hold Still")
                                 imageSource:        "qrc:///qmlimages/VehicleUpsideDown.png"
                             }

--- a/src/AutoPilotPlugins/PX4/SensorsComponentController.cc
+++ b/src/AutoPilotPlugins/PX4/SensorsComponentController.cc
@@ -16,30 +16,18 @@ SensorsComponentController::SensorsComponentController(void)
     , _accelCalInProgress                       (false)
     , _airspeedCalInProgress                    (false)
     , _levelCalInProgress                       (false)
-    , _orientationCalDownSideDone               (false)
-    , _orientationCalUpsideDownSideDone         (false)
-    , _orientationCalLeftSideDone               (false)
-    , _orientationCalRightSideDone              (false)
-    , _orientationCalNoseDownSideDone           (false)
-    , _orientationCalTailDownSideDone           (false)
     , _orientationCalDownSideVisible            (false)
     , _orientationCalUpsideDownSideVisible      (false)
     , _orientationCalLeftSideVisible            (false)
     , _orientationCalRightSideVisible           (false)
     , _orientationCalNoseDownSideVisible        (false)
     , _orientationCalTailDownSideVisible        (false)
-    , _orientationCalDownSideInProgress         (false)
-    , _orientationCalUpsideDownSideInProgress   (false)
-    , _orientationCalLeftSideInProgress         (false)
-    , _orientationCalRightSideInProgress        (false)
-    , _orientationCalNoseDownSideInProgress     (false)
-    , _orientationCalTailDownSideInProgress     (false)
-    , _orientationCalDownSideRotate             (false)
-    , _orientationCalUpsideDownSideRotate       (false)
-    , _orientationCalLeftSideRotate             (false)
-    , _orientationCalRightSideRotate            (false)
-    , _orientationCalNoseDownSideRotate         (false)
-    , _orientationCalTailDownSideRotate         (false)
+    , _orientationCalDownSideState              (SideCalStateIdle)
+    , _orientationCalUpsideDownSideState        (SideCalStateIdle)
+    , _orientationCalLeftSideState              (SideCalStateIdle)
+    , _orientationCalRightSideState             (SideCalStateIdle)
+    , _orientationCalNoseDownSideState          (SideCalStateIdle)
+    , _orientationCalTailDownSideState          (SideCalStateIdle)
     , _unknownFirmwareVersion                   (false)
     , _waitingForCancel                         (false)
 {
@@ -81,35 +69,32 @@ void SensorsComponentController::_startLogCalibration(void)
 
 void SensorsComponentController::_startVisualCalibration(void)
 {
-    _resetInternalState();
+    _setAllSidesState(SideCalStateIncomplete);
 
     _progressBar->setProperty("value", 0);
 }
 
-void SensorsComponentController::_resetInternalState(void)
+/// Returns the orientation preview side indicators to the neutral Idle state.
+/// Called when the preview switches to a different sensor so completion state from
+/// a previous calibration doesn't carry over.
+void SensorsComponentController::resetSidesToIdle(void)
 {
-    _orientationCalDownSideDone = true;
-    _orientationCalUpsideDownSideDone = true;
-    _orientationCalLeftSideDone = true;
-    _orientationCalRightSideDone = true;
-    _orientationCalTailDownSideDone = true;
-    _orientationCalNoseDownSideDone = true;
-    _orientationCalDownSideInProgress = false;
-    _orientationCalUpsideDownSideInProgress = false;
-    _orientationCalLeftSideInProgress = false;
-    _orientationCalRightSideInProgress = false;
-    _orientationCalNoseDownSideInProgress = false;
-    _orientationCalTailDownSideInProgress = false;
-    _orientationCalDownSideRotate = false;
-    _orientationCalUpsideDownSideRotate = false;
-    _orientationCalLeftSideRotate = false;
-    _orientationCalRightSideRotate = false;
-    _orientationCalNoseDownSideRotate = false;
-    _orientationCalTailDownSideRotate = false;
+    if (calibrationActive()) {
+        return;
+    }
+    _setAllSidesState(SideCalStateIdle);
+}
 
-    emit orientationCalSidesRotateChanged();
-    emit orientationCalSidesDoneChanged();
-    emit orientationCalSidesInProgressChanged();
+void SensorsComponentController::_setAllSidesState(SideCalState state)
+{
+    _orientationCalDownSideState = state;
+    _orientationCalUpsideDownSideState = state;
+    _orientationCalLeftSideState = state;
+    _orientationCalRightSideState = state;
+    _orientationCalTailDownSideState = state;
+    _orientationCalNoseDownSideState = state;
+
+    emit orientationCalSidesStateChanged();
 }
 
 void SensorsComponentController::_stopCalibration(SensorsComponentController::StopCalibrationCode code)
@@ -117,10 +102,14 @@ void SensorsComponentController::_stopCalibration(SensorsComponentController::St
     disconnect(_vehicle, &Vehicle::textMessageReceived, this, &SensorsComponentController::_handleUASTextMessage);
 
     if (code == StopCalibrationSuccess) {
-        _resetInternalState();
+        _setAllSidesState(SideCalStateCompleted);
 
         _progressBar->setProperty("value", 1);
     } else {
+        // Calibration results are discarded: return any partially completed sides
+        // to the neutral idle preview state
+        _setAllSidesState(SideCalStateIdle);
+
         _progressBar->setProperty("value", 0);
     }
 
@@ -252,19 +241,7 @@ void SensorsComponentController::_handleUASTextMessage(int uasId, int compId, in
 
         text = parts[1];
         if (text == "accel" || text == "mag" || text == "gyro") {
-            // Reset all progress indication
-            _orientationCalDownSideDone = false;
-            _orientationCalUpsideDownSideDone = false;
-            _orientationCalLeftSideDone = false;
-            _orientationCalRightSideDone = false;
-            _orientationCalTailDownSideDone = false;
-            _orientationCalNoseDownSideDone = false;
-            _orientationCalDownSideInProgress = false;
-            _orientationCalUpsideDownSideInProgress = false;
-            _orientationCalLeftSideInProgress = false;
-            _orientationCalRightSideInProgress = false;
-            _orientationCalNoseDownSideInProgress = false;
-            _orientationCalTailDownSideInProgress = false;
+            // _startVisualCalibration() above reset all side indicators to Incomplete
 
             // Reset all visibility
             _orientationCalDownSideVisible = false;
@@ -310,9 +287,7 @@ void SensorsComponentController::_handleUASTextMessage(int uasId, int compId, in
             } else {
                 qWarning() << "Unknown calibration message type" << text;
             }
-            emit orientationCalSidesDoneChanged();
             emit orientationCalSidesVisibleChanged();
-            emit orientationCalSidesInProgressChanged();
             _updateAndEmitShowOrientationCalArea(true);
         } else if (text == "airspeed") {
             _airspeedCalInProgress = true;
@@ -328,35 +303,17 @@ void SensorsComponentController::_handleUASTextMessage(int uasId, int compId, in
         qCDebug(SensorsComponentControllerLog) << "Side started" << side;
 
         if (side == "down") {
-            _orientationCalDownSideInProgress = true;
-            if (_magCalInProgress) {
-                _orientationCalDownSideRotate = true;
-            }
+            _orientationCalDownSideState = SideCalStateInProgress;
         } else if (side == "up") {
-            _orientationCalUpsideDownSideInProgress = true;
-            if (_magCalInProgress) {
-                _orientationCalUpsideDownSideRotate = true;
-            }
+            _orientationCalUpsideDownSideState = SideCalStateInProgress;
         } else if (side == "left") {
-            _orientationCalLeftSideInProgress = true;
-            if (_magCalInProgress) {
-                _orientationCalLeftSideRotate = true;
-            }
+            _orientationCalLeftSideState = SideCalStateInProgress;
         } else if (side == "right") {
-            _orientationCalRightSideInProgress = true;
-            if (_magCalInProgress) {
-                _orientationCalRightSideRotate = true;
-            }
+            _orientationCalRightSideState = SideCalStateInProgress;
         } else if (side == "front") {
-            _orientationCalNoseDownSideInProgress = true;
-            if (_magCalInProgress) {
-                _orientationCalNoseDownSideRotate = true;
-            }
+            _orientationCalNoseDownSideState = SideCalStateInProgress;
         } else if (side == "back") {
-            _orientationCalTailDownSideInProgress = true;
-            if (_magCalInProgress) {
-                _orientationCalTailDownSideRotate = true;
-            }
+            _orientationCalTailDownSideState = SideCalStateInProgress;
         }
 
         if (_magCalInProgress) {
@@ -365,8 +322,7 @@ void SensorsComponentController::_handleUASTextMessage(int uasId, int compId, in
             _orientationCalAreaHelpText->setProperty("text", tr("Hold still in the current orientation"));
         }
 
-        emit orientationCalSidesInProgressChanged();
-        emit orientationCalSidesRotateChanged();
+        emit orientationCalSidesStateChanged();
         return;
     }
 
@@ -375,36 +331,22 @@ void SensorsComponentController::_handleUASTextMessage(int uasId, int compId, in
         qCDebug(SensorsComponentControllerLog) << "Side finished" << side;
 
         if (side == "down") {
-            _orientationCalDownSideInProgress = false;
-            _orientationCalDownSideDone = true;
-            _orientationCalDownSideRotate = false;
+            _orientationCalDownSideState = SideCalStateCompleted;
         } else if (side == "up") {
-            _orientationCalUpsideDownSideInProgress = false;
-            _orientationCalUpsideDownSideDone = true;
-            _orientationCalUpsideDownSideRotate = false;
+            _orientationCalUpsideDownSideState = SideCalStateCompleted;
         } else if (side == "left") {
-            _orientationCalLeftSideInProgress = false;
-            _orientationCalLeftSideDone = true;
-            _orientationCalLeftSideRotate = false;
+            _orientationCalLeftSideState = SideCalStateCompleted;
         } else if (side == "right") {
-            _orientationCalRightSideInProgress = false;
-            _orientationCalRightSideDone = true;
-            _orientationCalRightSideRotate = false;
+            _orientationCalRightSideState = SideCalStateCompleted;
         } else if (side == "front") {
-            _orientationCalNoseDownSideInProgress = false;
-            _orientationCalNoseDownSideDone = true;
-            _orientationCalNoseDownSideRotate = false;
+            _orientationCalNoseDownSideState = SideCalStateCompleted;
         } else if (side == "back") {
-            _orientationCalTailDownSideInProgress = false;
-            _orientationCalTailDownSideDone = true;
-            _orientationCalTailDownSideRotate = false;
+            _orientationCalTailDownSideState = SideCalStateCompleted;
         }
 
         _orientationCalAreaHelpText->setProperty("text", tr("Place you vehicle into one of the orientations shown below and hold it still"));
 
-        emit orientationCalSidesInProgressChanged();
-        emit orientationCalSidesDoneChanged();
-        emit orientationCalSidesRotateChanged();
+        emit orientationCalSidesStateChanged();
         return;
     }
 

--- a/src/AutoPilotPlugins/PX4/SensorsComponentController.h
+++ b/src/AutoPilotPlugins/PX4/SensorsComponentController.h
@@ -14,21 +14,32 @@ class SensorsComponentController : public FactPanelController
 public:
     SensorsComponentController(void);
 
+    /// Calibration state of a single orientation side shown in the preview.
+    /// Values must stay in sync with the VehicleRotationCal.CalState QML enum.
+    enum SideCalState {
+        SideCalStateIdle,       ///< No calibration data to show (neutral preview)
+        SideCalStateIncomplete, ///< Calibration running, side not yet calibrated
+        SideCalStateInProgress, ///< Side actively being calibrated
+        SideCalStateCompleted   ///< Side calibration complete
+    };
+    Q_ENUM(SideCalState)
+
     Q_PROPERTY(QQuickItem* statusLog MEMBER _statusLog)
     Q_PROPERTY(QQuickItem* progressBar MEMBER _progressBar)
 
     Q_PROPERTY(QQuickItem* orientationCalAreaHelpText MEMBER _orientationCalAreaHelpText)
 
     Q_PROPERTY(bool calibrationActive READ calibrationActive NOTIFY calibrationActiveChanged)
+    Q_PROPERTY(bool magCalInProgress MEMBER _magCalInProgress NOTIFY calibrationActiveChanged)
 
     Q_PROPERTY(bool showOrientationCalArea MEMBER _showOrientationCalArea NOTIFY showOrientationCalAreaChanged)
 
-    Q_PROPERTY(bool orientationCalDownSideDone MEMBER _orientationCalDownSideDone NOTIFY orientationCalSidesDoneChanged)
-    Q_PROPERTY(bool orientationCalUpsideDownSideDone MEMBER _orientationCalUpsideDownSideDone NOTIFY orientationCalSidesDoneChanged)
-    Q_PROPERTY(bool orientationCalLeftSideDone MEMBER _orientationCalLeftSideDone NOTIFY orientationCalSidesDoneChanged)
-    Q_PROPERTY(bool orientationCalRightSideDone MEMBER _orientationCalRightSideDone NOTIFY orientationCalSidesDoneChanged)
-    Q_PROPERTY(bool orientationCalNoseDownSideDone MEMBER _orientationCalNoseDownSideDone NOTIFY orientationCalSidesDoneChanged)
-    Q_PROPERTY(bool orientationCalTailDownSideDone MEMBER _orientationCalTailDownSideDone NOTIFY orientationCalSidesDoneChanged)
+    Q_PROPERTY(SideCalState orientationCalDownSideState MEMBER _orientationCalDownSideState NOTIFY orientationCalSidesStateChanged)
+    Q_PROPERTY(SideCalState orientationCalUpsideDownSideState MEMBER _orientationCalUpsideDownSideState NOTIFY orientationCalSidesStateChanged)
+    Q_PROPERTY(SideCalState orientationCalLeftSideState MEMBER _orientationCalLeftSideState NOTIFY orientationCalSidesStateChanged)
+    Q_PROPERTY(SideCalState orientationCalRightSideState MEMBER _orientationCalRightSideState NOTIFY orientationCalSidesStateChanged)
+    Q_PROPERTY(SideCalState orientationCalNoseDownSideState MEMBER _orientationCalNoseDownSideState NOTIFY orientationCalSidesStateChanged)
+    Q_PROPERTY(SideCalState orientationCalTailDownSideState MEMBER _orientationCalTailDownSideState NOTIFY orientationCalSidesStateChanged)
 
     Q_PROPERTY(bool orientationCalDownSideVisible MEMBER _orientationCalDownSideVisible NOTIFY orientationCalSidesVisibleChanged)
     Q_PROPERTY(bool orientationCalUpsideDownSideVisible MEMBER _orientationCalUpsideDownSideVisible NOTIFY orientationCalSidesVisibleChanged)
@@ -36,20 +47,6 @@ public:
     Q_PROPERTY(bool orientationCalRightSideVisible MEMBER _orientationCalRightSideVisible NOTIFY orientationCalSidesVisibleChanged)
     Q_PROPERTY(bool orientationCalNoseDownSideVisible MEMBER _orientationCalNoseDownSideVisible NOTIFY orientationCalSidesVisibleChanged)
     Q_PROPERTY(bool orientationCalTailDownSideVisible MEMBER _orientationCalTailDownSideVisible NOTIFY orientationCalSidesVisibleChanged)
-
-    Q_PROPERTY(bool orientationCalDownSideInProgress MEMBER _orientationCalDownSideInProgress NOTIFY orientationCalSidesInProgressChanged)
-    Q_PROPERTY(bool orientationCalUpsideDownSideInProgress MEMBER _orientationCalUpsideDownSideInProgress NOTIFY orientationCalSidesInProgressChanged)
-    Q_PROPERTY(bool orientationCalLeftSideInProgress MEMBER _orientationCalLeftSideInProgress NOTIFY orientationCalSidesInProgressChanged)
-    Q_PROPERTY(bool orientationCalRightSideInProgress MEMBER _orientationCalRightSideInProgress NOTIFY orientationCalSidesInProgressChanged)
-    Q_PROPERTY(bool orientationCalNoseDownSideInProgress MEMBER _orientationCalNoseDownSideInProgress NOTIFY orientationCalSidesInProgressChanged)
-    Q_PROPERTY(bool orientationCalTailDownSideInProgress MEMBER _orientationCalTailDownSideInProgress NOTIFY orientationCalSidesInProgressChanged)
-
-    Q_PROPERTY(bool orientationCalDownSideRotate MEMBER _orientationCalDownSideRotate NOTIFY orientationCalSidesRotateChanged)
-    Q_PROPERTY(bool orientationCalUpsideDownSideRotate MEMBER _orientationCalUpsideDownSideRotate NOTIFY orientationCalSidesRotateChanged)
-    Q_PROPERTY(bool orientationCalLeftSideRotate MEMBER _orientationCalLeftSideRotate NOTIFY orientationCalSidesRotateChanged)
-    Q_PROPERTY(bool orientationCalRightSideRotate MEMBER _orientationCalRightSideRotate NOTIFY orientationCalSidesRotateChanged)
-    Q_PROPERTY(bool orientationCalNoseDownSideRotate MEMBER _orientationCalNoseDownSideRotate NOTIFY orientationCalSidesRotateChanged)
-    Q_PROPERTY(bool orientationCalTailDownSideRotate MEMBER _orientationCalTailDownSideRotate NOTIFY orientationCalSidesRotateChanged)
 
     Q_PROPERTY(bool waitingForCancel MEMBER _waitingForCancel NOTIFY waitingForCancelChanged)
 
@@ -61,16 +58,15 @@ public:
     Q_INVOKABLE void cancelCalibration(void);
     Q_INVOKABLE bool usingUDPLink(void);
     Q_INVOKABLE void resetFactoryParameters();
+    Q_INVOKABLE void resetSidesToIdle(void);
 
     bool calibrationActive() const { return _magCalInProgress || _gyroCalInProgress || _accelCalInProgress || _airspeedCalInProgress || _levelCalInProgress; }
 
 signals:
     void showGyroCalAreaChanged(void);
     void showOrientationCalAreaChanged(void);
-    void orientationCalSidesDoneChanged(void);
+    void orientationCalSidesStateChanged(void);
     void orientationCalSidesVisibleChanged(void);
-    void orientationCalSidesInProgressChanged(void);
-    void orientationCalSidesRotateChanged(void);
     void resetStatusTextArea(void);
     void waitingForCancelChanged(void);
     void magCalComplete(void);
@@ -86,7 +82,7 @@ private:
     void _appendStatusLog(const QString& text);
     void _refreshParams(void);
     void _hideAllCalAreas(void);
-    void _resetInternalState(void);
+    void _setAllSidesState(SideCalState state);
 
     enum StopCalibrationCode {
         StopCalibrationSuccess,
@@ -110,13 +106,6 @@ private:
     bool _airspeedCalInProgress;
     bool _levelCalInProgress;
 
-    bool _orientationCalDownSideDone;
-    bool _orientationCalUpsideDownSideDone;
-    bool _orientationCalLeftSideDone;
-    bool _orientationCalRightSideDone;
-    bool _orientationCalNoseDownSideDone;
-    bool _orientationCalTailDownSideDone;
-
     bool _orientationCalDownSideVisible;
     bool _orientationCalUpsideDownSideVisible;
     bool _orientationCalLeftSideVisible;
@@ -124,19 +113,12 @@ private:
     bool _orientationCalNoseDownSideVisible;
     bool _orientationCalTailDownSideVisible;
 
-    bool _orientationCalDownSideInProgress;
-    bool _orientationCalUpsideDownSideInProgress;
-    bool _orientationCalLeftSideInProgress;
-    bool _orientationCalRightSideInProgress;
-    bool _orientationCalNoseDownSideInProgress;
-    bool _orientationCalTailDownSideInProgress;
-
-    bool _orientationCalDownSideRotate;
-    bool _orientationCalUpsideDownSideRotate;
-    bool _orientationCalLeftSideRotate;
-    bool _orientationCalRightSideRotate;
-    bool _orientationCalNoseDownSideRotate;
-    bool _orientationCalTailDownSideRotate;
+    SideCalState _orientationCalDownSideState;
+    SideCalState _orientationCalUpsideDownSideState;
+    SideCalState _orientationCalLeftSideState;
+    SideCalState _orientationCalRightSideState;
+    SideCalState _orientationCalNoseDownSideState;
+    SideCalState _orientationCalTailDownSideState;
 
     bool _unknownFirmwareVersion;
     bool _waitingForCancel;

--- a/src/AutoPilotPlugins/PX4/SensorsSetup.qml
+++ b/src/AutoPilotPlugins/PX4/SensorsSetup.qml
@@ -331,6 +331,11 @@ Item {
 
     property string sectionNameFilter: ""
 
+    // Completed (green) side indicators are only meaningful for the sensor that was
+    // just calibrated. Return them to the neutral idle state when the preview switches
+    // to a different sensor.
+    onSectionNameFilterChanged: controller.resetSidesToIdle()
+
     function sectionVisible(name) {
         if (name === qsTr("Compass")) return !_allMagsDisabled && QGroundControl.corePlugin.options.showSensorCalibrationCompass && showSensorCalibrationCompass
         if (name === qsTr("Gyroscope")) return QGroundControl.corePlugin.options.showSensorCalibrationGyro && showSensorCalibrationGyro
@@ -345,6 +350,11 @@ Item {
         preCalibrationDialogType = type
         preCalibrationDialogHelp = help
         preCalibrationDialogFactory.open({ title: title })
+    }
+
+    // Mag calibration requires the vehicle to be rotated while a side is calibrating
+    function _sideRotating(calState) {
+        return (calState === VehicleRotationCal.CalState.InProgress) && controller.magCalInProgress
     }
 
     property bool _showOrientationPreview: !controller.calibrationActive &&
@@ -370,6 +380,7 @@ Item {
             visible: !controller.calibrationActive
 
             QGCButton {
+                objectName: "sensorsSetup_calibrateCompass"
                 Layout.fillWidth: true
                 text:       qsTr("Calibrate Compass")
                 visible:    sectionNameFilter === "" || sectionNameFilter === qsTr("Compass")
@@ -438,10 +449,12 @@ Item {
 
             ProgressBar {
                 id:                 progressBar
+                objectName:         "sensorsSetup_progressBar"
                 Layout.fillWidth:   true
             }
 
             QGCButton {
+                objectName: "sensorsSetup_cancelCalibration"
                 text:       qsTr("Cancel")
                 onClicked:  controller.cancelCalibration()
             }
@@ -491,58 +504,58 @@ Item {
                     property real indicatorHeight:  (height / 2) - spacing
 
                     VehicleRotationCal {
+                        objectName:         "sensorsCal_downSide"
                         width:              parent.indicatorWidth
                         height:             parent.indicatorHeight
                         visible:            controller.orientationCalDownSideVisible || _showAllSidesPreview || _showDownOnlyPreview
-                        calValid:           controller.orientationCalDownSideDone && !_showOrientationPreview
-                        calInProgress:      controller.orientationCalDownSideInProgress
-                        calInProgressText:  controller.orientationCalDownSideRotate ? qsTr("Rotate") : qsTr("Hold Still")
-                        imageSource:        controller.orientationCalDownSideRotate ? "qrc:///qmlimages/VehicleDownRotate.png" : "qrc:///qmlimages/VehicleDown.png"
+                        calState:           controller.orientationCalDownSideState
+                        calInProgressText:  controller.magCalInProgress ? qsTr("Rotate") : qsTr("Hold Still")
+                        imageSource:        _sideRotating(calState) ? "qrc:///qmlimages/VehicleDownRotate.png" : "qrc:///qmlimages/VehicleDown.png"
                     }
                     VehicleRotationCal {
+                        objectName:         "sensorsCal_upsideDownSide"
                         width:              parent.indicatorWidth
                         height:             parent.indicatorHeight
                         visible:            controller.orientationCalUpsideDownSideVisible || _showAllSidesPreview
-                        calValid:           controller.orientationCalUpsideDownSideDone && !_showOrientationPreview
-                        calInProgress:      controller.orientationCalUpsideDownSideInProgress
-                        calInProgressText:  controller.orientationCalUpsideDownSideRotate ? qsTr("Rotate") : qsTr("Hold Still")
-                        imageSource:        controller.orientationCalUpsideDownSideRotate ? "qrc:///qmlimages/VehicleUpsideDownRotate.png" : "qrc:///qmlimages/VehicleUpsideDown.png"
+                        calState:           controller.orientationCalUpsideDownSideState
+                        calInProgressText:  controller.magCalInProgress ? qsTr("Rotate") : qsTr("Hold Still")
+                        imageSource:        _sideRotating(calState) ? "qrc:///qmlimages/VehicleUpsideDownRotate.png" : "qrc:///qmlimages/VehicleUpsideDown.png"
                     }
                     VehicleRotationCal {
+                        objectName:         "sensorsCal_noseDownSide"
                         width:              parent.indicatorWidth
                         height:             parent.indicatorHeight
                         visible:            controller.orientationCalNoseDownSideVisible || _showAllSidesPreview
-                        calValid:           controller.orientationCalNoseDownSideDone && !_showOrientationPreview
-                        calInProgress:      controller.orientationCalNoseDownSideInProgress
-                        calInProgressText:  controller.orientationCalNoseDownSideRotate ? qsTr("Rotate") : qsTr("Hold Still")
-                        imageSource:        controller.orientationCalNoseDownSideRotate ? "qrc:///qmlimages/VehicleNoseDownRotate.png" : "qrc:///qmlimages/VehicleNoseDown.png"
+                        calState:           controller.orientationCalNoseDownSideState
+                        calInProgressText:  controller.magCalInProgress ? qsTr("Rotate") : qsTr("Hold Still")
+                        imageSource:        _sideRotating(calState) ? "qrc:///qmlimages/VehicleNoseDownRotate.png" : "qrc:///qmlimages/VehicleNoseDown.png"
                     }
                     VehicleRotationCal {
+                        objectName:         "sensorsCal_tailDownSide"
                         width:              parent.indicatorWidth
                         height:             parent.indicatorHeight
                         visible:            controller.orientationCalTailDownSideVisible || _showAllSidesPreview
-                        calValid:           controller.orientationCalTailDownSideDone && !_showOrientationPreview
-                        calInProgress:      controller.orientationCalTailDownSideInProgress
-                        calInProgressText:  controller.orientationCalTailDownSideRotate ? qsTr("Rotate") : qsTr("Hold Still")
-                        imageSource:        controller.orientationCalTailDownSideRotate ? "qrc:///qmlimages/VehicleTailDownRotate.png" : "qrc:///qmlimages/VehicleTailDown.png"
+                        calState:           controller.orientationCalTailDownSideState
+                        calInProgressText:  controller.magCalInProgress ? qsTr("Rotate") : qsTr("Hold Still")
+                        imageSource:        _sideRotating(calState) ? "qrc:///qmlimages/VehicleTailDownRotate.png" : "qrc:///qmlimages/VehicleTailDown.png"
                     }
                     VehicleRotationCal {
+                        objectName:         "sensorsCal_leftSide"
                         width:              parent.indicatorWidth
                         height:             parent.indicatorHeight
                         visible:            controller.orientationCalLeftSideVisible || _showAllSidesPreview
-                        calValid:           controller.orientationCalLeftSideDone && !_showOrientationPreview
-                        calInProgress:      controller.orientationCalLeftSideInProgress
-                        calInProgressText:  controller.orientationCalLeftSideRotate ? qsTr("Rotate") : qsTr("Hold Still")
-                        imageSource:        controller.orientationCalLeftSideRotate ? "qrc:///qmlimages/VehicleLeftRotate.png" : "qrc:///qmlimages/VehicleLeft.png"
+                        calState:           controller.orientationCalLeftSideState
+                        calInProgressText:  controller.magCalInProgress ? qsTr("Rotate") : qsTr("Hold Still")
+                        imageSource:        _sideRotating(calState) ? "qrc:///qmlimages/VehicleLeftRotate.png" : "qrc:///qmlimages/VehicleLeft.png"
                     }
                     VehicleRotationCal {
+                        objectName:         "sensorsCal_rightSide"
                         width:              parent.indicatorWidth
                         height:             parent.indicatorHeight
                         visible:            controller.orientationCalRightSideVisible || _showAllSidesPreview
-                        calValid:           controller.orientationCalRightSideDone && !_showOrientationPreview
-                        calInProgress:      controller.orientationCalRightSideInProgress
-                        calInProgressText:  controller.orientationCalRightSideRotate ? qsTr("Rotate") : qsTr("Hold Still")
-                        imageSource:        controller.orientationCalRightSideRotate ? "qrc:///qmlimages/VehicleRightRotate.png" : "qrc:///qmlimages/VehicleRight.png"
+                        calState:           controller.orientationCalRightSideState
+                        calInProgressText:  controller.magCalInProgress ? qsTr("Rotate") : qsTr("Hold Still")
+                        imageSource:        _sideRotating(calState) ? "qrc:///qmlimages/VehicleRightRotate.png" : "qrc:///qmlimages/VehicleRight.png"
                     }
                 }
             }

--- a/src/Comms/MockLink/CMakeLists.txt
+++ b/src/Comms/MockLink/CMakeLists.txt
@@ -18,6 +18,8 @@ target_sources(${CMAKE_PROJECT_NAME}
         MockLinkWorker.h
         MockLinkMissionItemHandler.cc
         MockLinkMissionItemHandler.h
+        MockLinkPX4Calibration.cc
+        MockLinkPX4Calibration.h
 )
 
 # Add resource files

--- a/src/Comms/MockLink/MockLink.cc
+++ b/src/Comms/MockLink/MockLink.cc
@@ -86,6 +86,7 @@ MockLink::MockLink(SharedLinkConfigurationPtr &config, QObject *parent)
                                                         _mockConfig->gimbalHasRetract(),
                                                         _mockConfig->gimbalHasNeutral())
                                     : nullptr)
+    , _mockLinkPX4Calibration(new MockLinkPX4Calibration(this))
     , _mockLinkFTP(new MockLinkFTP(_vehicleSystemId, _vehicleComponentId, this))
 {
     qCDebug(MockLinkLog) << this;
@@ -131,6 +132,7 @@ MockLink::~MockLink()
 
     delete _mockLinkCamera;
     delete _mockLinkGimbal;
+    delete _mockLinkPX4Calibration;
 
     if (!_logDownloadFilename.isEmpty()) {
         QFile::remove(_logDownloadFilename);
@@ -264,6 +266,8 @@ void MockLink::run10HzTasks()
         _sendAttitudeTarget();
         _sendLocalPositionNed();
         _sendPositionTargetLocalNed();
+
+        _mockLinkPX4Calibration->run10HzTasks();
 
         if (_enableCamera) {
             _mockLinkCamera->run10HzTasks();
@@ -2113,23 +2117,36 @@ void MockLink::_sendRCChannels()
 
 void MockLink::_handlePreFlightCalibration(const mavlink_command_long_t& request)
 {
-    static constexpr const char *gyroCalResponse = "[cal] calibration started: 2 gyro";
-    static constexpr const char *magCalResponse = "[cal] calibration started: 2 mag";
-    static constexpr const char *accelCalResponse = "[cal] calibration started: 2 accel";
-    const char *pCalMessage;
+    if ((request.param1 == 0) && (request.param2 == 0) && (request.param3 == 0) &&
+        (request.param4 == 0) && (request.param5 == 0) && (request.param6 == 0) &&
+        (request.param7 == 0)) {
+        // All zeros is a calibration cancel request. See PX4 calibrate_cancel_check().
+        (void) _mockLinkPX4Calibration->cancel();
+        return;
+    }
 
+    if (request.param2 == 1) {
+        // Magnetometer calibration runs the full pose-driven simulation
+        _mockLinkPX4Calibration->startMagCalibration();
+        return;
+    }
+
+    const char *pCalMessage = nullptr;
     if (request.param1 == 1) {
-        pCalMessage = gyroCalResponse;
-    } else if (request.param2 == 1) {
-        pCalMessage = magCalResponse;
+        pCalMessage = "[cal] calibration started: 2 gyro";
     } else if (request.param5 == 1) {
-        pCalMessage = accelCalResponse;
+        pCalMessage = "[cal] calibration started: 2 accel";
     } else {
         return;
     }
 
+    sendStatusTextMessage(MAV_SEVERITY_INFO, QString::fromLatin1(pCalMessage));
+}
+
+void MockLink::sendStatusTextMessage(uint8_t severity, const QString &text)
+{
     char statusText[MAVLINK_MSG_STATUSTEXT_FIELD_TEXT_LEN] = {};
-    (void) std::strncpy(statusText, pCalMessage, sizeof(statusText) - 1);
+    (void) std::strncpy(statusText, text.toUtf8().constData(), sizeof(statusText) - 1);
 
     mavlink_message_t msg{};
     (void) mavlink_msg_statustext_pack_chan(
@@ -2137,7 +2154,7 @@ void MockLink::_handlePreFlightCalibration(const mavlink_command_long_t& request
         _vehicleComponentId,
         _outgoingMavlinkChannel,
         &msg,
-        MAV_SEVERITY_INFO,
+        severity,
         statusText,
         0,
         0 // Not chunked

--- a/src/Comms/MockLink/MockLink.h
+++ b/src/Comms/MockLink/MockLink.h
@@ -5,6 +5,7 @@
 #include "MAVLinkMessageType.h"
 #include "QGCMAVLinkTypes.h"
 #include "MockConfiguration.h"
+#include "MockLinkPX4Calibration.h"
 #include "MockLinkMissionItemHandler.h"
 
 #include <QtCore/QElapsedTimer>
@@ -55,6 +56,13 @@ public:
 
     /// Sends the specified mavlink message to QGC
     void respondWithMavlinkMessage(const mavlink_message_t &msg);
+
+    /// Sends a STATUSTEXT message to QGC
+    ///     @param severity MAV_SEVERITY value
+    void sendStatusTextMessage(uint8_t severity, const QString &text);
+
+    /// Test API: places the simulated vehicle into the given pose during calibration
+    void setCalibrationPose(MockLinkPX4Calibration::Pose pose) const { _mockLinkPX4Calibration->setPose(pose); }
 
     MockLinkFTP *mockLinkFTP() const;
 
@@ -285,6 +293,7 @@ private:
     MockLinkMissionItemHandler *const _missionItemHandler = nullptr;
     MockLinkCamera *const _mockLinkCamera = nullptr;
     MockLinkGimbal *const _mockLinkGimbal = nullptr;
+    MockLinkPX4Calibration *const _mockLinkPX4Calibration = nullptr;
     MockLinkFTP *const _mockLinkFTP = nullptr;
 
     uint8_t _incomingMavlinkChannel = std::numeric_limits<uint8_t>::max();

--- a/src/Comms/MockLink/MockLinkPX4Calibration.cc
+++ b/src/Comms/MockLink/MockLinkPX4Calibration.cc
@@ -1,0 +1,145 @@
+#include "MockLinkPX4Calibration.h"
+#include "MAVLinkLib.h"
+#include "MockLink.h"
+
+#include <algorithm>
+
+// Side names in PX4 detect_orientation_return order (see PX4 detect_orientation_str())
+static constexpr const char *kSideNames[MockLinkPX4Calibration::kSideCount] = {
+    "back",     // tail down
+    "front",    // nose down
+    "left",
+    "right",
+    "up",       // upside down
+    "down",     // right side up
+};
+
+MockLinkPX4Calibration::MockLinkPX4Calibration(MockLink *mockLink)
+    : _mockLink(mockLink)
+{
+}
+
+void MockLinkPX4Calibration::startMagCalibration()
+{
+    QMutexLocker locker(&_mutex);
+
+    _magCalActive = true;
+    _requestedPose = -1;
+    _activeSide = -1;
+    _sideTickCount = 0;
+    _finishTickCount = -1;
+    std::fill(std::begin(_sideDone), std::end(_sideDone), false);
+
+    _mockLink->sendStatusTextMessage(MAV_SEVERITY_INFO, QStringLiteral("[cal] calibration started: 2 mag"));
+}
+
+bool MockLinkPX4Calibration::cancel()
+{
+    QMutexLocker locker(&_mutex);
+
+    if (!_magCalActive) {
+        return false;
+    }
+
+    _magCalActive = false;
+    _requestedPose = -1;
+    _activeSide = -1;
+    _finishTickCount = -1;
+
+    _mockLink->sendStatusTextMessage(MAV_SEVERITY_CRITICAL, QStringLiteral("[cal] calibration cancelled"));
+    return true;
+}
+
+bool MockLinkPX4Calibration::magCalActive() const
+{
+    QMutexLocker locker(&_mutex);
+    return _magCalActive;
+}
+
+void MockLinkPX4Calibration::setPose(Pose pose)
+{
+    QMutexLocker locker(&_mutex);
+    _requestedPose = static_cast<int>(pose);
+}
+
+void MockLinkPX4Calibration::run10HzTasks()
+{
+    QMutexLocker locker(&_mutex);
+
+    if (!_magCalActive) {
+        return;
+    }
+
+    if (_finishTickCount >= 0) {
+        // Finishing phase: simulates the firmware calculating the final mag fit
+        // before reporting completion. Gives the UI time to display the last
+        // side as completed while the calibration is still active.
+        _finishTickCount++;
+        if (_finishTickCount >= kTicksToFinish) {
+            _magCalActive = false;
+            _finishTickCount = -1;
+            _mockLink->sendStatusTextMessage(MAV_SEVERITY_INFO, QStringLiteral("[cal] progress <100>"));
+            _mockLink->sendStatusTextMessage(MAV_SEVERITY_INFO, QStringLiteral("[cal] calibration done: mag"));
+        }
+        return;
+    }
+
+    if (_activeSide >= 0) {
+        _sideTick();
+    } else {
+        _detectPose();
+    }
+}
+
+int MockLinkPX4Calibration::_doneCount() const
+{
+    int count = 0;
+    for (bool done : _sideDone) {
+        if (done) {
+            count++;
+        }
+    }
+    return count;
+}
+
+/// Waiting for a pose: detect the requested orientation as the firmware would.
+void MockLinkPX4Calibration::_detectPose()
+{
+    const int pose = _requestedPose;
+    if ((pose < 0) || (pose >= kSideCount)) {
+        return;
+    }
+    _requestedPose = -1; // consume
+
+    if (_sideDone[pose]) {
+        _mockLink->sendStatusTextMessage(MAV_SEVERITY_INFO, QStringLiteral("[cal] %1 side already completed").arg(QLatin1String(kSideNames[pose])));
+        return;
+    }
+
+    _mockLink->sendStatusTextMessage(MAV_SEVERITY_INFO, QStringLiteral("[cal] %1 orientation detected").arg(QLatin1String(kSideNames[pose])));
+    _activeSide = pose;
+    _sideTickCount = 0;
+}
+
+/// Side in progress: simulate the rotation/sampling phase with progress messages,
+/// then complete the side. Completing the last side finishes the calibration.
+void MockLinkPX4Calibration::_sideTick()
+{
+    _sideTickCount++;
+
+    if (_sideTickCount < kTicksPerSide) {
+        // Same progress calculation as PX4 mag_calibration_worker()
+        const unsigned progress = (_doneCount() * 100 / kSideCount) + ((100 / kSideCount) * _sideTickCount / kTicksPerSide);
+        _mockLink->sendStatusTextMessage(MAV_SEVERITY_INFO, QStringLiteral("[cal] %1 side calibration: progress <%2>").arg(QLatin1String(kSideNames[_activeSide])).arg(progress));
+        return;
+    }
+
+    _sideDone[_activeSide] = true;
+    _mockLink->sendStatusTextMessage(MAV_SEVERITY_INFO, QStringLiteral("[cal] %1 side done, rotate to a different side").arg(QLatin1String(kSideNames[_activeSide])));
+    _activeSide = -1;
+
+    if (_doneCount() == kSideCount) {
+        // All sides collected: enter the finishing phase
+        _finishTickCount = 0;
+    }
+}

--- a/src/Comms/MockLink/MockLinkPX4Calibration.h
+++ b/src/Comms/MockLink/MockLinkPX4Calibration.h
@@ -1,0 +1,80 @@
+#pragma once
+
+#include <QtCore/QMutex>
+
+class MockLink;
+
+/// \brief Simulates the PX4 commander magnetometer calibration protocol for MockLink.
+///
+/// Replays the [cal] STATUSTEXT protocol emitted by the PX4 firmware
+/// (src/modules/commander/mag_calibration.cpp and calibration_routines.cpp):
+///
+///     [cal] calibration started: 2 mag
+///     [cal] <side> orientation detected
+///     [cal] <side> side calibration: progress <N>
+///     [cal] <side> side done, rotate to a different side
+///     [cal] progress <100>
+///     [cal] calibration done: mag
+///
+/// The simulation is pose-driven: a unit test places the simulated vehicle into a
+/// pose with setPose(). On subsequent 10Hz ticks the state machine detects the
+/// orientation, simulates the rotation/sampling phase with progress messages and
+/// completes the side. Setting a pose for an already completed side emits
+/// "[cal] <side> side already completed", matching firmware behavior.
+///
+/// All six sides are required, matching CAL_MAG_SIDES=63 in PX4MockLink.params.
+///
+/// An all-zero MAV_CMD_PREFLIGHT_CALIBRATION while a calibration is active cancels
+/// it with "[cal] calibration cancelled" (see PX4 calibrate_cancel_check()).
+class MockLinkPX4Calibration
+{
+public:
+    /// Vehicle poses. Order matches the PX4 detect_orientation_return enum.
+    enum class Pose {
+        None = -1,
+        TailDown = 0,   ///< "back"  accel [  g,  0,  0 ]
+        NoseDown,       ///< "front" accel [ -g,  0,  0 ]
+        Left,           ///< "left"  accel [  0,  g,  0 ]
+        Right,          ///< "right" accel [  0, -g,  0 ]
+        UpsideDown,     ///< "up"    accel [  0,  0,  g ]
+        RightSideUp,    ///< "down"  accel [  0,  0, -g ]
+    };
+    static constexpr int kSideCount = 6;
+
+    explicit MockLinkPX4Calibration(MockLink *mockLink);
+
+    /// Starts simulated mag calibration: sends "[cal] calibration started: 2 mag"
+    /// and resets the side state machine.
+    void startMagCalibration();
+
+    /// Handles an all-zero MAV_CMD_PREFLIGHT_CALIBRATION (cancel request).
+    ///     @return true if a calibration was active and has been cancelled
+    bool cancel();
+
+    bool magCalActive() const;
+
+    /// Test API: places the simulated vehicle into the given pose. The state
+    /// machine advances on subsequent 10Hz ticks. Thread-safe.
+    void setPose(Pose pose);
+
+    /// Called by MockLink::run10HzTasks on the worker thread.
+    void run10HzTasks();
+
+private:
+    void _sideTick();
+    void _detectPose();
+    int _doneCount() const;
+
+    MockLink *_mockLink = nullptr;
+
+    mutable QMutex _mutex;
+    bool _magCalActive = false;
+    int _requestedPose = -1;            ///< Pose set by test, -1 when consumed/none
+    int _activeSide = -1;               ///< Side currently calibrating, -1 when waiting for pose
+    int _sideTickCount = 0;             ///< Ticks elapsed in the active side
+    int _finishTickCount = -1;          ///< Ticks elapsed in the finishing phase, -1 when not finishing
+    bool _sideDone[kSideCount] = {};
+
+    static constexpr int kTicksPerSide = 5;     ///< 10Hz ticks to complete one side
+    static constexpr int kTicksToFinish = 10;   ///< 10Hz ticks simulating the final mag fit calculation
+};

--- a/src/QmlControls/VehicleRotationCal.qml
+++ b/src/QmlControls/VehicleRotationCal.qml
@@ -5,11 +5,18 @@ import QGroundControl
 import QGroundControl.Controls
 
 Rectangle {
-    // Indicates whether calibration is valid for this control
-    property bool calValid: false
+    id: root
 
-    // Indicates whether the control is currently being calibrated
-    property bool calInProgress: false
+    // Calibration state of the orientation shown by this control.
+    // Values must stay in sync with SensorsComponentController::SideCalState.
+    enum CalState {
+        Idle,       ///< No calibration data to show (neutral preview)
+        Incomplete, ///< Calibration running, this orientation not yet calibrated
+        InProgress, ///< This orientation actively being calibrated
+        Completed   ///< This orientation calibration complete
+    }
+
+    property int calState: VehicleRotationCal.CalState.Idle
 
     // Text to show while calibration is in progress
     property string calInProgressText: qsTr("Hold Still")
@@ -17,9 +24,44 @@ Rectangle {
     // Image source
     property var imageSource: ""
 
-    property var __qgcPal: QGCPalette { colorGroupEnabled: enabled }
+    color: qgcPal.text
 
-    color:  calInProgress ? "yellow" : (calValid ? "green" : "red")
+    states: [
+        State {
+            name: "idle"
+            when: root.calState === VehicleRotationCal.CalState.Idle
+            PropertyChanges {
+                root.color: qgcPal.text
+                statusLabel.text: ""
+            }
+        },
+        State {
+            name: "incomplete"
+            when: root.calState === VehicleRotationCal.CalState.Incomplete
+            PropertyChanges {
+                root.color: "red"
+                statusLabel.text: qsTr("Incomplete")
+            }
+        },
+        State {
+            name: "inProgress"
+            when: root.calState === VehicleRotationCal.CalState.InProgress
+            PropertyChanges {
+                root.color: "yellow"
+                statusLabel.text: root.calInProgressText
+            }
+        },
+        State {
+            name: "completed"
+            when: root.calState === VehicleRotationCal.CalState.Completed
+            PropertyChanges {
+                root.color: "green"
+                statusLabel.text: qsTr("Completed")
+            }
+        }
+    ]
+
+    QGCPalette { id: qgcPal; colorGroupEnabled: root.enabled }
 
     Rectangle {
         readonly property int inset: 5
@@ -33,18 +75,18 @@ Rectangle {
         Image {
             width:      parent.width
             height:     parent.height
-            source:     imageSource
+            source:     root.imageSource
             fillMode:   Image.PreserveAspectFit
             smooth: true
         }
 
         QGCLabel {
+            id:                     statusLabel
             width:                  parent.width
             height:                 parent.height
             horizontalAlignment:    Text.AlignHCenter
             verticalAlignment:      Text.AlignBottom
             font.pointSize:         ScreenTools.mediumFontPointSize
-            text:                   calInProgress ? calInProgressText : (calValid ? qsTr("Completed") : qsTr("Incomplete"))
         }
     }
 }

--- a/src/Vehicle/VehicleSetup/VehicleConfigView.qml
+++ b/src/Vehicle/VehicleSetup/VehicleConfigView.qml
@@ -432,6 +432,7 @@ Rectangle {
 
                             Button {
                                 id:             sectionBtn
+                                objectName:     "vehicleConfig_section_" + modelData.replace(/ /g, "")
                                 Layout.fillWidth: true
                                 padding:        ScreenTools.defaultFontPixelWidth * 0.75
                                 leftPadding:    ScreenTools.defaultFontPixelWidth * 3

--- a/test/QmlUITests/CMakeLists.txt
+++ b/test/QmlUITests/CMakeLists.txt
@@ -16,6 +16,8 @@ target_sources(${CMAKE_PROJECT_NAME}
         ${CMAKE_CURRENT_SOURCE_DIR}/ToolbarIndicatorUITest.h
         ${CMAKE_CURRENT_SOURCE_DIR}/PlanViewUITest.cc
         ${CMAKE_CURRENT_SOURCE_DIR}/PlanViewUITest.h
+        ${CMAKE_CURRENT_SOURCE_DIR}/PX4SensorsCalibrationUITest.cc
+        ${CMAKE_CURRENT_SOURCE_DIR}/PX4SensorsCalibrationUITest.h
 )
 
 target_include_directories(${CMAKE_PROJECT_NAME}
@@ -28,3 +30,4 @@ add_qgc_test(PX4VehicleConfigUITest LABELS Integration NoSanitizer TIMEOUT 180)
 add_qgc_test(APMVehicleConfigUITest LABELS Integration NoSanitizer TIMEOUT 360)
 add_qgc_test(ToolbarIndicatorUITest LABELS Integration NoSanitizer TIMEOUT 180)
 add_qgc_test(PlanViewUITest LABELS Integration NoSanitizer TIMEOUT 120)
+add_qgc_test(PX4SensorsCalibrationUITest LABELS Integration NoSanitizer TIMEOUT 180)

--- a/test/QmlUITests/PX4SensorsCalibrationUITest.cc
+++ b/test/QmlUITests/PX4SensorsCalibrationUITest.cc
@@ -1,0 +1,289 @@
+#include "PX4SensorsCalibrationUITest.h"
+
+#include <QtCore/QElapsedTimer>
+#include <QtQuick/QQuickItem>
+#include <QtQuick/QQuickWindow>
+#include <QtTest/QTest>
+
+#include "MockLink.h"
+#include "ParameterManager.h"
+#include "SensorsComponentController.h"
+#include "Vehicle.h"
+
+UT_REGISTER_TEST(PX4SensorsCalibrationUITest, TestLabel::Integration)
+
+namespace {
+
+struct PoseInfo {
+    MockLinkPX4Calibration::Pose pose;
+    const char *objectName;     ///< VehicleRotationCal objectName in SensorsSetup.qml
+    const char *rotateImage;    ///< Image shown while rotating on this side
+};
+
+constexpr PoseInfo kPoses[MockLinkPX4Calibration::kSideCount] = {
+    { MockLinkPX4Calibration::Pose::RightSideUp, "sensorsCal_downSide",       "VehicleDownRotate.png" },
+    { MockLinkPX4Calibration::Pose::UpsideDown,  "sensorsCal_upsideDownSide", "VehicleUpsideDownRotate.png" },
+    { MockLinkPX4Calibration::Pose::NoseDown,    "sensorsCal_noseDownSide",   "VehicleNoseDownRotate.png" },
+    { MockLinkPX4Calibration::Pose::TailDown,    "sensorsCal_tailDownSide",   "VehicleTailDownRotate.png" },
+    { MockLinkPX4Calibration::Pose::Left,        "sensorsCal_leftSide",       "VehicleLeftRotate.png" },
+    { MockLinkPX4Calibration::Pose::Right,       "sensorsCal_rightSide",      "VehicleRightRotate.png" },
+};
+
+bool waitForCalState(QQuickItem *item, SensorsComponentController::SideCalState expected, int timeoutMs)
+{
+    return QTest::qWaitFor([&] { return item->property("calState").toInt() == static_cast<int>(expected); }, timeoutMs);
+}
+
+const char *calStateName(int state)
+{
+    switch (static_cast<SensorsComponentController::SideCalState>(state)) {
+    case SensorsComponentController::SideCalStateIdle:       return "Idle";
+    case SensorsComponentController::SideCalStateIncomplete: return "Incomplete";
+    case SensorsComponentController::SideCalStateInProgress: return "InProgress";
+    case SensorsComponentController::SideCalStateCompleted:  return "Completed";
+    }
+    return "Unknown";
+}
+
+/// SensorsComponentController refreshes the CAL_*/SENS_* parameters whenever calibration
+/// stops. Wait for that traffic to go quiet so link teardown doesn't cut off in-flight
+/// PARAM_REQUEST_READs (which logs warnings that fail strict mode).
+void waitForParamRefreshQuiet(Vehicle *vehicle)
+{
+    ParameterManager *mgr = vehicle->parameterManager();
+    QElapsedTimer sinceLastResponse;
+    sinceLastResponse.start();
+
+    QObject context;
+    QObject::connect(mgr, &ParameterManager::_paramRequestReadSuccess, &context,
+                     [&] { sinceLastResponse.restart(); });
+    QObject::connect(mgr, &ParameterManager::_paramRequestReadFailure, &context,
+                     [&] { sinceLastResponse.restart(); });
+
+    (void) QTest::qWaitFor([&] { return sinceLastResponse.elapsed() > 500; }, 10000);
+}
+
+} // namespace
+
+void PX4SensorsCalibrationUITest::_navigateToSensorsPanel()
+{
+    QVERIFY2(clickButton(QStringLiteral("toolbar_qgcLogo")), "Failed to click Q logo button");
+    QVERIFY2(findVisibleItem(_rootItem, QStringLiteral("toolbar_viewConfigure"), 2000),
+             "toolbar_viewConfigure button not found");
+    QVERIFY2(clickButton(QStringLiteral("toolbar_viewConfigure")), "Failed to click Configure button");
+    QTest::qWait(_viewDelay);
+
+    QVERIFY2(findVisibleItem(_rootItem, QStringLiteral("vehicleConfig_root"), 3000),
+             "vehicleConfig_root not found after navigating to Configure");
+
+    QQuickItem *sensorsBtn = findVisibleItem(_rootItem, QStringLiteral("vehicleConfig_comp_Sensors"), 2000);
+    QVERIFY2(sensorsBtn, "vehicleConfig_comp_Sensors button not found");
+
+    scrollIntoView(sensorsBtn, QStringLiteral("vehicleConfig_sidebarFlickable"));
+    const QPointF center = sensorsBtn->mapToScene(QPointF(sensorsBtn->width() / 2, sensorsBtn->height() / 2));
+    QTest::mouseClick(_window, Qt::LeftButton, Qt::NoModifier, center.toPoint());
+    QTest::qWait(_pageDelay);
+
+    QVERIFY2(findVisibleItem(_rootItem, QStringLiteral("sensorsSetup_calibrateCompass"), 3000),
+             "Calibrate Compass button not found after opening Sensors page");
+}
+
+void PX4SensorsCalibrationUITest::_clickSidebarSection(const QString &objectName)
+{
+    QQuickItem *sectionBtn = findVisibleItem(_rootItem, objectName, 3000);
+    QVERIFY2(sectionBtn, qPrintable(QStringLiteral("Section button not found: %1").arg(objectName)));
+
+    scrollIntoView(sectionBtn, QStringLiteral("vehicleConfig_sidebarFlickable"));
+    const QPointF center = sectionBtn->mapToScene(QPointF(sectionBtn->width() / 2, sectionBtn->height() / 2));
+    QTest::mouseClick(_window, Qt::LeftButton, Qt::NoModifier, center.toPoint());
+    QTest::qWait(_pageDelay);
+}
+
+void PX4SensorsCalibrationUITest::_verifyAllPosesState(int expectedState, const char *context)
+{
+    for (const PoseInfo &info : kPoses) {
+        QQuickItem *side = findVisibleItem(_rootItem, QLatin1String(info.objectName), 5000);
+        QVERIFY2(side, qPrintable(QStringLiteral("Pose indicator not visible (%1): %2")
+                                      .arg(QLatin1String(context), QLatin1String(info.objectName))));
+        const int state = side->property("calState").toInt();
+        QVERIFY2(state == expectedState,
+                 qPrintable(QStringLiteral("Pose in state %1, expected %2 (%3): %4")
+                                .arg(QLatin1String(calStateName(state)), QLatin1String(calStateName(expectedState)),
+                                     QLatin1String(context), QLatin1String(info.objectName))));
+    }
+}
+
+void PX4SensorsCalibrationUITest::_startCompassCalibration()
+{
+    QVERIFY2(clickButton(QStringLiteral("sensorsSetup_calibrateCompass")), "Failed to click Calibrate Compass");
+
+    // Accept the pre-calibration dialog which sends MAV_CMD_PREFLIGHT_CALIBRATION
+    QVERIFY2(findVisibleItem(_rootItem, QStringLiteral("popupDialog_acceptButton"), 3000),
+             "Pre-calibration dialog Ok button not found");
+    QVERIFY2(clickButton(QStringLiteral("popupDialog_acceptButton")), "Failed to accept pre-calibration dialog");
+}
+
+void PX4SensorsCalibrationUITest::_testMagCalibration()
+{
+    runWithMockLink(
+        [] { return MockLink::startPX4MockLink(false, false, false); },
+        [&](QPointer<MockLink> mockLink, Vehicle *vehicle) {
+    _navigateToSensorsPanel();
+    if (QTest::currentTestFailed()) return;
+
+    // Select the Compass section: the idle orientation preview appears with all
+    // six poses in the neutral Idle state
+    _clickSidebarSection(QStringLiteral("vehicleConfig_section_Compass"));
+    if (QTest::currentTestFailed()) return;
+
+    _verifyAllPosesState(SensorsComponentController::SideCalStateIdle, "idle preview");
+    if (QTest::currentTestFailed()) return;
+
+    _startCompassCalibration();
+    if (QTest::currentTestFailed()) return;
+
+    // MockLink responds with "[cal] calibration started: 2 mag" which makes all
+    // six pose indicators visible and Incomplete (red, not yet visited)
+    for (const PoseInfo &info : kPoses) {
+        QQuickItem *side = findVisibleItem(_rootItem, QLatin1String(info.objectName), 5000);
+        QVERIFY2(side, qPrintable(QStringLiteral("Pose indicator not visible: %1").arg(QLatin1String(info.objectName))));
+        QVERIFY2(waitForCalState(side, SensorsComponentController::SideCalStateIncomplete, 5000),
+                 qPrintable(QStringLiteral("Pose not Incomplete at start (state %1): %2")
+                                .arg(QLatin1String(calStateName(side->property("calState").toInt())),
+                                     QLatin1String(info.objectName))));
+    }
+
+    QQuickItem *progressBar = findVisibleItem(_rootItem, QStringLiteral("sensorsSetup_progressBar"), 2000);
+    QVERIFY2(progressBar, "Progress bar not visible during calibration");
+    QVERIFY2(qFuzzyIsNull(progressBar->property("value").toDouble()), "Progress bar not at 0 at calibration start");
+
+    QQuickItem *cancelButton = findVisibleItem(_rootItem, QStringLiteral("sensorsSetup_cancelCalibration"), 2000);
+    QVERIFY2(cancelButton, "Cancel button not visible during calibration");
+
+    // ---------------------------------------------------------------------
+    // Place the vehicle into each pose and watch the UI track the side
+    // ---------------------------------------------------------------------
+    double lastProgress = 0.0;
+    int sidesDone = 0;
+
+    for (const PoseInfo &info : kPoses) {
+        const QString sideName = QLatin1String(info.objectName);
+        QQuickItem *side = findVisibleItem(_rootItem, sideName);
+        QVERIFY2(side, qPrintable(QStringLiteral("Pose indicator disappeared: %1").arg(sideName)));
+
+        mockLink->setCalibrationPose(info.pose);
+
+        // Orientation detected: the side goes InProgress with the rotate animation
+        QVERIFY2(waitForCalState(side, SensorsComponentController::SideCalStateInProgress, 5000),
+                 qPrintable(QStringLiteral("Side never went in-progress: %1").arg(sideName)));
+        QCOMPARE(side->property("calInProgressText").toString(), QStringLiteral("Rotate"));
+        QVERIFY2(side->property("imageSource").toString().endsWith(QLatin1String(info.rotateImage)),
+                 qPrintable(QStringLiteral("Wrong rotate image for %1: %2")
+                                .arg(sideName, side->property("imageSource").toString())));
+
+        // Side completes and marks itself done (green/Completed)
+        QVERIFY2(waitForCalState(side, SensorsComponentController::SideCalStateCompleted, 5000),
+                 qPrintable(QStringLiteral("Side never completed: %1").arg(sideName)));
+
+        sidesDone++;
+
+        // Progress bar must move forward with each side and stay within the
+        // band expected for the number of completed sides
+        const double progress = progressBar->property("value").toDouble();
+        QVERIFY2(progress > lastProgress,
+                 qPrintable(QStringLiteral("Progress did not advance after %1: %2 -> %3")
+                                .arg(sideName).arg(lastProgress).arg(progress)));
+        if (sidesDone < MockLinkPX4Calibration::kSideCount) {
+            constexpr double sideCount = MockLinkPX4Calibration::kSideCount;
+            QVERIFY2((progress >= ((sidesDone - 1) / sideCount)) && (progress <= ((sidesDone / sideCount) + 0.01)),
+                     qPrintable(QStringLiteral("Progress out of expected band after %1 sides: %2")
+                                    .arg(sidesDone).arg(progress)));
+        }
+        lastProgress = progress;
+
+        // Previously completed sides must remain marked complete
+        for (const PoseInfo &doneInfo : kPoses) {
+            if (&doneInfo == &info) break;
+            QQuickItem *doneSide = findVisibleItem(_rootItem, QLatin1String(doneInfo.objectName));
+            QVERIFY2(doneSide && (doneSide->property("calState").toInt() == SensorsComponentController::SideCalStateCompleted),
+                     qPrintable(QStringLiteral("Previously completed side no longer marked complete: %1")
+                                    .arg(QLatin1String(doneInfo.objectName))));
+        }
+    }
+
+    // ---------------------------------------------------------------------
+    // Calibration complete: progress hits 100% and the completion dialog opens
+    // ---------------------------------------------------------------------
+    QVERIFY2(QTest::qWaitFor([&] { return qFuzzyCompare(progressBar->property("value").toDouble(), 1.0); }, 5000),
+             qPrintable(QStringLiteral("Progress bar never reached 1.0: %1")
+                            .arg(progressBar->property("value").toDouble())));
+
+    QVERIFY2(findVisibleItem(_rootItem, QStringLiteral("popupDialog_acceptButton"), 5000),
+             "Compass Calibration Complete dialog not shown");
+    QVERIFY2(clickButton(QStringLiteral("popupDialog_acceptButton")), "Failed to dismiss completion dialog");
+
+    // Calibration no longer active: the cancel button row hides
+    QVERIFY2(QTest::qWaitFor([&] { return !cancelButton->isVisible(); }, 5000),
+             "Cancel button still visible after calibration completed");
+
+    waitForParamRefreshQuiet(vehicle);
+
+    // All sides must remain marked complete (green) after calibration ends and
+    // the post-calibration parameter refresh settles
+    _verifyAllPosesState(SensorsComponentController::SideCalStateCompleted, "after calibration finished");
+    if (QTest::currentTestFailed()) return;
+
+    // Switching the preview to a different sensor resets the completed sides:
+    // the Accelerometer preview must show all poses in the neutral Idle state
+    _clickSidebarSection(QStringLiteral("vehicleConfig_section_Accelerometer"));
+    if (QTest::currentTestFailed()) return;
+
+    _verifyAllPosesState(SensorsComponentController::SideCalStateIdle, "after section switch");
+
+    });
+}
+
+void PX4SensorsCalibrationUITest::_testMagCalibrationCancel()
+{
+    runWithMockLink(
+        [] { return MockLink::startPX4MockLink(false, false, false); },
+        [&](QPointer<MockLink> mockLink, Vehicle *vehicle) {
+    _navigateToSensorsPanel();
+    if (QTest::currentTestFailed()) return;
+
+    _startCompassCalibration();
+    if (QTest::currentTestFailed()) return;
+
+    // Start calibrating one side
+    const PoseInfo &info = kPoses[0];
+    QQuickItem *side = findVisibleItem(_rootItem, QLatin1String(info.objectName), 5000);
+    QVERIFY2(side, "Pose indicator not visible after calibration start");
+
+    mockLink->setCalibrationPose(info.pose);
+    QVERIFY2(waitForCalState(side, SensorsComponentController::SideCalStateInProgress, 5000),
+             "Side never went in-progress");
+
+    // Cancel mid-calibration: MockLink responds with "[cal] calibration cancelled"
+    QQuickItem *cancelButton = findVisibleItem(_rootItem, QStringLiteral("sensorsSetup_cancelCalibration"));
+    QVERIFY2(cancelButton, "Cancel button not visible during calibration");
+    QVERIFY2(clickButton(QStringLiteral("sensorsSetup_cancelCalibration")), "Failed to click Cancel");
+
+    // The calibration-active UI (progress bar + cancel button row) hides once
+    // the controller processes the cancel response
+    QVERIFY2(QTest::qWaitFor([&] { return !cancelButton->isVisible(); }, 5000),
+             "Cancel button still visible after cancel");
+
+    // Cancelled calibration discards results: the partially calibrated side
+    // returns to the neutral Idle state, not red and not green
+    QVERIFY2(waitForCalState(side, SensorsComponentController::SideCalStateIdle, 5000),
+             qPrintable(QStringLiteral("Side not Idle after cancel (state %1)")
+                            .arg(QLatin1String(calStateName(side->property("calState").toInt())))));
+
+    // Calibrate Compass button is clickable again
+    QVERIFY2(findVisibleItem(_rootItem, QStringLiteral("sensorsSetup_calibrateCompass"), 3000),
+             "Calibrate Compass button not available after cancel");
+
+    waitForParamRefreshQuiet(vehicle);
+
+    });
+}

--- a/test/QmlUITests/PX4SensorsCalibrationUITest.h
+++ b/test/QmlUITests/PX4SensorsCalibrationUITest.h
@@ -1,0 +1,34 @@
+#pragma once
+
+#include "QmlUITestBase.h"
+
+/// UI test that boots the full QML UI with a PX4 MockLink vehicle connected,
+/// navigates to the Sensors setup page and runs a complete magnetometer
+/// calibration by clicking the real UI buttons. MockLinkPX4Calibration simulates
+/// the PX4 firmware [cal] protocol; the test drives it by placing the
+/// simulated vehicle into each pose and verifies that the pose indicator
+/// images and the progress bar update correctly.
+class PX4SensorsCalibrationUITest : public QmlUITestBase
+{
+    Q_OBJECT
+
+public:
+    PX4SensorsCalibrationUITest() = default;
+
+private slots:
+    void _testMagCalibration();
+    void _testMagCalibrationCancel();
+
+private:
+    /// Navigate from the Fly view to the Sensors page of the Configure view.
+    void _navigateToSensorsPanel();
+
+    /// Click a section sub-item in the vehicle config sidebar.
+    void _clickSidebarSection(const QString &objectName);
+
+    /// Verify all six pose indicators are visible and in the given SideCalState.
+    void _verifyAllPosesState(int expectedState, const char *context);
+
+    /// Click "Calibrate Compass" and accept the pre-calibration dialog.
+    void _startCompassCalibration();
+};


### PR DESCRIPTION
Fixes #14516

Replaces the per-side `Done`/`InProgress`/`Rotate` bool trio in `SensorsComponentController` with a single `SideCalState` enum (`Idle`/`Incomplete`/`InProgress`/`Completed`), exposed as one state property per orientation. `VehicleRotationCal` now takes a single `calState` property and renders its border color and status text via QML `states`, including a new neutral **Idle** state (palette text color) shown before any calibration has run.

### Behavior changes
- Side indicators start in a neutral Idle state instead of red
- Completed (green) indicators no longer carry over when the sensor setup preview switches to a different sensor section
- Calibration failure or cancel resets indicators to Idle instead of leaving them red

### Implementation
- `SensorsComponentController`: new `SideCalState` `Q_ENUM`; 18 bool properties collapsed to 6 state properties plus a `magCalInProgress` property; `clearSidesDone()` renamed to `resetSidesToIdle()`
- `VehicleRotationCal.qml`: mirrored `CalState` QML enum, state-driven rendering, self-contained `QGCPalette`
- `SensorsSetup.qml`: binds `calState` directly from the controller; per-side rotate derived as `InProgress && magCalInProgress`
- `APMSensorsComponent.qml`: maps its existing controller bools onto the new `VehicleRotationCal` `calState` API (APM controller unchanged)

### Testing
Adds an end-to-end UI test (`PX4SensorsCalibrationUITest`) for PX4 compass calibration backed by a new `MockLinkPX4Calibration` which replays the PX4 commander `[cal]` STATUSTEXT protocol with a pose-driven state machine. The test asserts each side's state transitions (Idle → Incomplete → InProgress → Completed) and reset behavior on cancel and section change. `PX4VehicleConfigUITest` and `APMVehicleConfigUITest` also pass.
