### PR TITLE
fix: Request CAMERA_SETTINGS on zoom and focus

### DIFF
--- a/src/Camera/VehicleCameraControl.cc
+++ b/src/Camera/VehicleCameraControl.cc
@@ -173,6 +173,7 @@ VehicleCameraControl::~VehicleCameraControl()
     _streamInfoTimer.stop();
     _streamStatusTimer.stop();
     _cameraSettingsTimer.stop();
+    _cameraSettingsRetryTimer.stop();
     _storageInfoTimer.stop();
 
     delete _netManager;
@@ -191,8 +192,11 @@ void VehicleCameraControl::_initWhenReady()
         _requestAllParameters();
     }
 
+    connect(&_cameraSettingsTimer, &QTimer::timeout, this, &VehicleCameraControl::_requestCameraSettings);
+    _cameraSettingsTimer.setSingleShot(true);
+
     QTimer::singleShot(500, this, &VehicleCameraControl::_requestCameraSettings);
-    connect(&_cameraSettingsTimer, &QTimer::timeout, this, &VehicleCameraControl::_cameraSettingsTimeout);
+    connect(&_cameraSettingsRetryTimer, &QTimer::timeout, this, &VehicleCameraControl::_cameraSettingsTimeout);
 
     QTimer::singleShot(1000, this, &VehicleCameraControl::_checkForVideoStreams);
 
@@ -591,6 +595,7 @@ void VehicleCameraControl::setZoomLevel(qreal level)
                 ZOOM_TYPE_RANGE,                        // Zoom type
                 static_cast<float>(level));             // Level
         }
+        _cameraSettingsTimer.start(1000);
     }
 }
 
@@ -608,6 +613,7 @@ void VehicleCameraControl::setFocusLevel(qreal level)
                 FOCUS_TYPE_RANGE,                       // Focus type
                 static_cast<float>(level));             // Level
         }
+        _cameraSettingsTimer.start(1000);
     }
 }
 
@@ -649,6 +655,8 @@ void VehicleCameraControl::stepZoom(int direction)
             false,                                  // ShowError
             ZOOM_TYPE_STEP,                         // Zoom type
             direction);                             // Direction (-1 wide, 1 tele)
+
+        _cameraSettingsTimer.start(1000);
     }
 }
 
@@ -675,6 +683,8 @@ void VehicleCameraControl::stopZoom()
             false,                                  // ShowError
             ZOOM_TYPE_CONTINUOUS,                   // Zoom type
             0);                                     // Direction (-1 wide, 1 tele)
+
+        _cameraSettingsTimer.start(1000);
     }
 }
 
@@ -688,6 +698,8 @@ void VehicleCameraControl::stepFocus(int direction)
             false,                                  // ShowError
             FOCUS_TYPE_STEP,                        // Focus type
             direction);                             // Direction (-1 in, 1 out)
+
+        _cameraSettingsTimer.start(1000);
     }
 }
 
@@ -714,6 +726,8 @@ void VehicleCameraControl::stopFocus()
             false,                                  // ShowError
             FOCUS_TYPE_CONTINUOUS,                  // Focus type
             0);                                     // Direction (-1 in, 1 out)
+
+        _cameraSettingsTimer.start(1000);
     }
 }
 
@@ -1499,7 +1513,7 @@ void VehicleCameraControl::_requestParamUpdates()
 
 void VehicleCameraControl::_requestCameraSettings()
 {
-    qCDebug(VehicleCameraControlLog) << "_requestCameraSettings() - retries:" << _cameraSettingsRetries << "timer active:" << _cameraSettingsTimer.isActive();
+    qCDebug(VehicleCameraControlLog) << "_requestCameraSettings() - retries:" << _cameraSettingsRetries << "timer active:" << _cameraSettingsRetryTimer.isActive();
     if(_vehicle) {
         // Use REQUEST_MESSAGE instead of deprecated REQUEST_CAMERA_SETTINGS
         // first time and every other time after that.
@@ -1519,12 +1533,12 @@ void VehicleCameraControl::_requestCameraSettings()
                 false,                                  // showError
                 1);                                     // Do Request
         }
-        if(_cameraSettingsTimer.isActive()) {
+        if(_cameraSettingsRetryTimer.isActive()) {
             qCDebug(VehicleCameraControlLog) << "_requestCameraSettings() - RESTARTING already active timer";
         } else {
             qCDebug(VehicleCameraControlLog) << "_requestCameraSettings() - starting timer";
         }
-        _cameraSettingsTimer.start(1000);               // Wait up to a second for it
+        _cameraSettingsRetryTimer.start(1000);               // Wait up to a second for it
     }
 
 }
@@ -1564,7 +1578,7 @@ void VehicleCameraControl::handleCameraSettings(const mavlink_camera_settings_t&
         << "\n\tZoom level:" << settings.zoomLevel
         << "\n\tFocus level:" << settings.focusLevel;
 
-    _cameraSettingsTimer.stop();
+    _cameraSettingsRetryTimer.stop();
     _cameraSettingsRetries = 0;
 
     _setCameraMode(static_cast<CameraMode>(settings.mode_id));
@@ -2015,7 +2029,7 @@ void VehicleCameraControl::_cameraSettingsTimeout()
     qCDebug(VehicleCameraControlLog) << "_cameraSettingsTimeout() - retries now:" << _cameraSettingsRetries;
     if(_cameraSettingsRetries > 5) {
         qCWarning(VehicleCameraControlLog) << "Giving up requesting camera settings after" << _cameraSettingsRetries << "retries";
-        _cameraSettingsTimer.stop();
+        _cameraSettingsRetryTimer.stop();
         return;
     }
     qCDebug(VehicleCameraControlLog) << "_cameraSettingsTimeout() - calling _requestCameraSettings()";

--- a/src/Camera/VehicleCameraControl.h
+++ b/src/Camera/VehicleCameraControl.h
@@ -298,6 +298,7 @@ protected:
     QTimer                              _streamInfoTimer;
     QTimer                              _streamStatusTimer;
     QTimer                              _cameraSettingsTimer;
+    QTimer                              _cameraSettingsRetryTimer;
     QTimer                              _storageInfoTimer;
     QmlObjectListModel                  _streams;
     QStringList                         _streamLabels;


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail. What problem does this solve? -->
The changes from PR #13612 do not actually end up requesting `CAMERA_SETTINGS`  whenever zoom level or focus changes. Thus, QGC may request `CAMERA_SETTINGS` (and thus CAMERA_FOV_STATUS) once, but it won't necessarily do so after that. This could result in the FOV stored on QGC not actually reflecting the FOV of the camera after zooming.

## Type of Change
<!-- Put an 'x' in the relevant boxes -->
- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] CI/Build changes
- [ ] Other

## Testing
<!-- Describe the tests you ran and how to reproduce them -->
- [x] Tested locally
- [ ] Added/updated unit tests
- [ ] Tested with simulator (SITL)
- [ ] Tested with hardware

### Platforms Tested
<!-- Check all that apply -->
- [x] Linux
- [ ] Windows
- [ ] macOS
- [ ] Android
- [ ] iOS

### Flight Stacks Tested
<!-- If applicable -->
- [ ] PX4
- [ ] ArduPilot

## Screenshots
<!-- If applicable, add screenshots to help explain your changes -->

## Checklist
<!-- Go over all the following points, and put an 'x' in all the boxes that apply -->
- [x] I have read the [Contribution Guidelines](CONTRIBUTING.md)
- [x] I have read the [Code of Conduct](CODE_OF_CONDUCT.md)
- [x] My code follows the project's coding standards
- [ ] I have added tests that prove my fix/feature works
- [ ] New and existing unit tests pass locally

## Related Issues
<!-- Link any related issues using #issue_number -->

---
By submitting this pull request, I confirm that my contribution is made under the terms of the project's dual license (Apache 2.0 and GPL v3).
