### PR TITLE
Test: Add PX4 accelerometer calibration UI tests

### DIFF
--- a/src/AutoPilotPlugins/PX4/SensorsSetup.qml
+++ b/src/AutoPilotPlugins/PX4/SensorsSetup.qml
@@ -395,6 +395,7 @@ Item {
             }
 
             QGCButton {
+                objectName: "sensorsSetup_calibrateAccel"
                 Layout.fillWidth: true
                 text:       qsTr("Calibrate Accelerometer")
                 visible:    sectionNameFilter === "" || sectionNameFilter === qsTr("Accelerometer")

--- a/src/Comms/MockLink/MockLink.cc
+++ b/src/Comms/MockLink/MockLink.cc
@@ -2131,16 +2131,15 @@ void MockLink::_handlePreFlightCalibration(const mavlink_command_long_t& request
         return;
     }
 
-    const char *pCalMessage = nullptr;
     if (request.param1 == 1) {
-        pCalMessage = "[cal] calibration started: 2 gyro";
-    } else if (request.param5 == 1) {
-        pCalMessage = "[cal] calibration started: 2 accel";
-    } else {
+        sendStatusTextMessage(MAV_SEVERITY_INFO, QStringLiteral("[cal] calibration started: 2 gyro"));
         return;
     }
 
-    sendStatusTextMessage(MAV_SEVERITY_INFO, QString::fromLatin1(pCalMessage));
+    if (request.param5 == 1) {
+        // Accelerometer calibration runs the full pose-driven simulation
+        _mockLinkPX4Calibration->startAccelCalibration();
+    }
 }
 
 void MockLink::sendStatusTextMessage(uint8_t severity, const QString &text)

--- a/src/Comms/MockLink/MockLinkPX4Calibration.cc
+++ b/src/Comms/MockLink/MockLinkPX4Calibration.cc
@@ -14,6 +14,16 @@ static constexpr const char *kSideNames[MockLinkPX4Calibration::kSideCount] = {
     "down",     // right side up
 };
 
+// Ideal accel readings per side, same order as kSideNames (see PX4 accel_calibration_worker())
+static constexpr const char *kSideAccelResults[MockLinkPX4Calibration::kSideCount] = {
+    "[9.810 0.000 0.000]",
+    "[-9.810 0.000 0.000]",
+    "[0.000 9.810 0.000]",
+    "[0.000 -9.810 0.000]",
+    "[0.000 0.000 9.810]",
+    "[0.000 0.000 -9.810]",
+};
+
 MockLinkPX4Calibration::MockLinkPX4Calibration(MockLink *mockLink)
     : _mockLink(mockLink)
 {
@@ -21,27 +31,38 @@ MockLinkPX4Calibration::MockLinkPX4Calibration(MockLink *mockLink)
 
 void MockLinkPX4Calibration::startMagCalibration()
 {
+    _startCalibration(CalType::Mag);
+}
+
+void MockLinkPX4Calibration::startAccelCalibration()
+{
+    _startCalibration(CalType::Accel);
+}
+
+void MockLinkPX4Calibration::_startCalibration(CalType calType)
+{
     QMutexLocker locker(&_mutex);
 
-    _magCalActive = true;
+    _calType = calType;
     _requestedPose = -1;
     _activeSide = -1;
     _sideTickCount = 0;
     _finishTickCount = -1;
     std::fill(std::begin(_sideDone), std::end(_sideDone), false);
 
-    _mockLink->sendStatusTextMessage(MAV_SEVERITY_INFO, QStringLiteral("[cal] calibration started: 2 mag"));
+    _mockLink->sendStatusTextMessage(MAV_SEVERITY_INFO, QStringLiteral("[cal] calibration started: 2 %1")
+        .arg(QLatin1String((calType == CalType::Mag) ? "mag" : "accel")));
 }
 
 bool MockLinkPX4Calibration::cancel()
 {
     QMutexLocker locker(&_mutex);
 
-    if (!_magCalActive) {
+    if (_calType == CalType::None) {
         return false;
     }
 
-    _magCalActive = false;
+    _calType = CalType::None;
     _requestedPose = -1;
     _activeSide = -1;
     _finishTickCount = -1;
@@ -50,10 +71,10 @@ bool MockLinkPX4Calibration::cancel()
     return true;
 }
 
-bool MockLinkPX4Calibration::magCalActive() const
+bool MockLinkPX4Calibration::calibrationActive() const
 {
     QMutexLocker locker(&_mutex);
-    return _magCalActive;
+    return _calType != CalType::None;
 }
 
 void MockLinkPX4Calibration::setPose(Pose pose)
@@ -66,20 +87,25 @@ void MockLinkPX4Calibration::run10HzTasks()
 {
     QMutexLocker locker(&_mutex);
 
-    if (!_magCalActive) {
+    if (_calType == CalType::None) {
         return;
     }
 
     if (_finishTickCount >= 0) {
-        // Finishing phase: simulates the firmware calculating the final mag fit
-        // before reporting completion. Gives the UI time to display the last
+        // Finishing phase: simulates the firmware calculating the final calibration
+        // values before reporting completion. Gives the UI time to display the last
         // side as completed while the calibration is still active.
         _finishTickCount++;
         if (_finishTickCount >= kTicksToFinish) {
-            _magCalActive = false;
+            const CalType calType = _calType;
+            _calType = CalType::None;
             _finishTickCount = -1;
-            _mockLink->sendStatusTextMessage(MAV_SEVERITY_INFO, QStringLiteral("[cal] progress <100>"));
-            _mockLink->sendStatusTextMessage(MAV_SEVERITY_INFO, QStringLiteral("[cal] calibration done: mag"));
+            if (calType == CalType::Mag) {
+                // The mag fit calculation reports its own final progress
+                _mockLink->sendStatusTextMessage(MAV_SEVERITY_INFO, QStringLiteral("[cal] progress <100>"));
+            }
+            _mockLink->sendStatusTextMessage(MAV_SEVERITY_INFO, QStringLiteral("[cal] calibration done: %1")
+                .arg(QLatin1String((calType == CalType::Mag) ? "mag" : "accel")));
         }
         return;
     }
@@ -117,16 +143,40 @@ void MockLinkPX4Calibration::_detectPose()
     }
 
     _mockLink->sendStatusTextMessage(MAV_SEVERITY_INFO, QStringLiteral("[cal] %1 orientation detected").arg(QLatin1String(kSideNames[pose])));
+    if (_calType == CalType::Accel) {
+        // The accel worker starts sampling immediately (see PX4 accel_calibration_worker())
+        _mockLink->sendStatusTextMessage(MAV_SEVERITY_INFO, QStringLiteral("[cal] Hold still, measuring %1 side").arg(QLatin1String(kSideNames[pose])));
+    }
     _activeSide = pose;
     _sideTickCount = 0;
 }
 
-/// Side in progress: simulate the rotation/sampling phase with progress messages,
-/// then complete the side. Completing the last side finishes the calibration.
+/// Side in progress: simulate the sampling phase, then complete the side.
+/// Completing the last side enters the finishing phase.
 void MockLinkPX4Calibration::_sideTick()
 {
     _sideTickCount++;
 
+    switch (_calType) {
+    case CalType::Mag:
+        _magSideTick();
+        break;
+    case CalType::Accel:
+        _accelSideTick();
+        break;
+    case CalType::None:
+        return;
+    }
+
+    if (_doneCount() == kSideCount) {
+        // All sides collected: enter the finishing phase
+        _finishTickCount = 0;
+    }
+}
+
+/// Mag side: rotation phase with per-tick progress messages.
+void MockLinkPX4Calibration::_magSideTick()
+{
     if (_sideTickCount < kTicksPerSide) {
         // Same progress calculation as PX4 mag_calibration_worker()
         const unsigned progress = (_doneCount() * 100 / kSideCount) + ((100 / kSideCount) * _sideTickCount / kTicksPerSide);
@@ -137,9 +187,22 @@ void MockLinkPX4Calibration::_sideTick()
     _sideDone[_activeSide] = true;
     _mockLink->sendStatusTextMessage(MAV_SEVERITY_INFO, QStringLiteral("[cal] %1 side done, rotate to a different side").arg(QLatin1String(kSideNames[_activeSide])));
     _activeSide = -1;
+}
 
-    if (_doneCount() == kSideCount) {
-        // All sides collected: enter the finishing phase
-        _finishTickCount = 0;
+/// Accel side: hold-still sampling phase with no progress messages, then the
+/// side result and a single progress jump (see PX4 accel_calibration_worker()).
+void MockLinkPX4Calibration::_accelSideTick()
+{
+    if (_sideTickCount < kTicksPerSide) {
+        return;
     }
+
+    _sideDone[_activeSide] = true;
+    _mockLink->sendStatusTextMessage(MAV_SEVERITY_INFO, QStringLiteral("[cal] %1 side result: %2").arg(QLatin1String(kSideNames[_activeSide]), QLatin1String(kSideAccelResults[_activeSide])));
+    // Same progress calculation as PX4 accel_calibration_worker(): 17 * doneCount.
+    // Intentionally reaches 102 after the final side, matching firmware; the UI
+    // progress bar clamps it to 100%.
+    _mockLink->sendStatusTextMessage(MAV_SEVERITY_INFO, QStringLiteral("[cal] progress <%1>").arg(17 * _doneCount()));
+    _mockLink->sendStatusTextMessage(MAV_SEVERITY_INFO, QStringLiteral("[cal] %1 side done, rotate to a different side").arg(QLatin1String(kSideNames[_activeSide])));
+    _activeSide = -1;
 }

--- a/src/Comms/MockLink/MockLinkPX4Calibration.h
+++ b/src/Comms/MockLink/MockLinkPX4Calibration.h
@@ -4,10 +4,11 @@
 
 class MockLink;
 
-/// \brief Simulates the PX4 commander magnetometer calibration protocol for MockLink.
+/// \brief Simulates the PX4 commander magnetometer and accelerometer calibration protocols for MockLink.
 ///
 /// Replays the [cal] STATUSTEXT protocol emitted by the PX4 firmware
-/// (src/modules/commander/mag_calibration.cpp and calibration_routines.cpp):
+/// (src/modules/commander/mag_calibration.cpp, accelerometer_calibration.cpp and
+/// calibration_routines.cpp). Magnetometer:
 ///
 ///     [cal] calibration started: 2 mag
 ///     [cal] <side> orientation detected
@@ -16,10 +17,20 @@ class MockLink;
 ///     [cal] progress <100>
 ///     [cal] calibration done: mag
 ///
+/// Accelerometer:
+///
+///     [cal] calibration started: 2 accel
+///     [cal] <side> orientation detected
+///     [cal] Hold still, measuring <side> side
+///     [cal] <side> side result: [x y z]
+///     [cal] progress <17*doneCount>
+///     [cal] <side> side done, rotate to a different side
+///     [cal] calibration done: accel
+///
 /// The simulation is pose-driven: a unit test places the simulated vehicle into a
 /// pose with setPose(). On subsequent 10Hz ticks the state machine detects the
-/// orientation, simulates the rotation/sampling phase with progress messages and
-/// completes the side. Setting a pose for an already completed side emits
+/// orientation, simulates the rotation/sampling phase and completes the side.
+/// Setting a pose for an already completed side emits
 /// "[cal] <side> side already completed", matching firmware behavior.
 ///
 /// All six sides are required, matching CAL_MAG_SIDES=63 in PX4MockLink.params.
@@ -47,11 +58,15 @@ public:
     /// and resets the side state machine.
     void startMagCalibration();
 
+    /// Starts simulated accel calibration: sends "[cal] calibration started: 2 accel"
+    /// and resets the side state machine.
+    void startAccelCalibration();
+
     /// Handles an all-zero MAV_CMD_PREFLIGHT_CALIBRATION (cancel request).
     ///     @return true if a calibration was active and has been cancelled
     bool cancel();
 
-    bool magCalActive() const;
+    bool calibrationActive() const;
 
     /// Test API: places the simulated vehicle into the given pose. The state
     /// machine advances on subsequent 10Hz ticks. Thread-safe.
@@ -61,14 +76,23 @@ public:
     void run10HzTasks();
 
 private:
+    enum class CalType {
+        None,
+        Mag,
+        Accel,
+    };
+
+    void _startCalibration(CalType calType);
     void _sideTick();
+    void _magSideTick();
+    void _accelSideTick();
     void _detectPose();
     int _doneCount() const;
 
     MockLink *_mockLink = nullptr;
 
     mutable QMutex _mutex;
-    bool _magCalActive = false;
+    CalType _calType = CalType::None;
     int _requestedPose = -1;            ///< Pose set by test, -1 when consumed/none
     int _activeSide = -1;               ///< Side currently calibrating, -1 when waiting for pose
     int _sideTickCount = 0;             ///< Ticks elapsed in the active side
@@ -76,5 +100,5 @@ private:
     bool _sideDone[kSideCount] = {};
 
     static constexpr int kTicksPerSide = 5;     ///< 10Hz ticks to complete one side
-    static constexpr int kTicksToFinish = 10;   ///< 10Hz ticks simulating the final mag fit calculation
+    static constexpr int kTicksToFinish = 10;   ///< 10Hz ticks simulating the final calibration calculation
 };

--- a/test/QmlUITests/PX4SensorsCalibrationUITest.cc
+++ b/test/QmlUITests/PX4SensorsCalibrationUITest.cc
@@ -17,16 +17,17 @@ namespace {
 struct PoseInfo {
     MockLinkPX4Calibration::Pose pose;
     const char *objectName;     ///< VehicleRotationCal objectName in SensorsSetup.qml
-    const char *rotateImage;    ///< Image shown while rotating on this side
+    const char *rotateImage;    ///< Image shown while rotating on this side (mag cal)
+    const char *stillImage;     ///< Image shown while holding still on this side (accel cal)
 };
 
 constexpr PoseInfo kPoses[MockLinkPX4Calibration::kSideCount] = {
-    { MockLinkPX4Calibration::Pose::RightSideUp, "sensorsCal_downSide",       "VehicleDownRotate.png" },
-    { MockLinkPX4Calibration::Pose::UpsideDown,  "sensorsCal_upsideDownSide", "VehicleUpsideDownRotate.png" },
-    { MockLinkPX4Calibration::Pose::NoseDown,    "sensorsCal_noseDownSide",   "VehicleNoseDownRotate.png" },
-    { MockLinkPX4Calibration::Pose::TailDown,    "sensorsCal_tailDownSide",   "VehicleTailDownRotate.png" },
-    { MockLinkPX4Calibration::Pose::Left,        "sensorsCal_leftSide",       "VehicleLeftRotate.png" },
-    { MockLinkPX4Calibration::Pose::Right,       "sensorsCal_rightSide",      "VehicleRightRotate.png" },
+    { MockLinkPX4Calibration::Pose::RightSideUp, "sensorsCal_downSide",       "VehicleDownRotate.png",       "VehicleDown.png" },
+    { MockLinkPX4Calibration::Pose::UpsideDown,  "sensorsCal_upsideDownSide", "VehicleUpsideDownRotate.png", "VehicleUpsideDown.png" },
+    { MockLinkPX4Calibration::Pose::NoseDown,    "sensorsCal_noseDownSide",   "VehicleNoseDownRotate.png",   "VehicleNoseDown.png" },
+    { MockLinkPX4Calibration::Pose::TailDown,    "sensorsCal_tailDownSide",   "VehicleTailDownRotate.png",   "VehicleTailDown.png" },
+    { MockLinkPX4Calibration::Pose::Left,        "sensorsCal_leftSide",       "VehicleLeftRotate.png",       "VehicleLeft.png" },
+    { MockLinkPX4Calibration::Pose::Right,       "sensorsCal_rightSide",      "VehicleRightRotate.png",      "VehicleRight.png" },
 };
 
 bool waitForCalState(QQuickItem *item, SensorsComponentController::SideCalState expected, int timeoutMs)
@@ -113,9 +114,10 @@ void PX4SensorsCalibrationUITest::_verifyAllPosesState(int expectedState, const 
     }
 }
 
-void PX4SensorsCalibrationUITest::_startCompassCalibration()
+void PX4SensorsCalibrationUITest::_startCalibration(const QString &calibrateButtonObjectName)
 {
-    QVERIFY2(clickButton(QStringLiteral("sensorsSetup_calibrateCompass")), "Failed to click Calibrate Compass");
+    QVERIFY2(clickButton(calibrateButtonObjectName),
+             qPrintable(QStringLiteral("Failed to click calibrate button: %1").arg(calibrateButtonObjectName)));
 
     // Accept the pre-calibration dialog which sends MAV_CMD_PREFLIGHT_CALIBRATION
     QVERIFY2(findVisibleItem(_rootItem, QStringLiteral("popupDialog_acceptButton"), 3000),
@@ -139,7 +141,7 @@ void PX4SensorsCalibrationUITest::_testMagCalibration()
     _verifyAllPosesState(SensorsComponentController::SideCalStateIdle, "idle preview");
     if (QTest::currentTestFailed()) return;
 
-    _startCompassCalibration();
+    _startCalibration(QStringLiteral("sensorsSetup_calibrateCompass"));
     if (QTest::currentTestFailed()) return;
 
     // MockLink responds with "[cal] calibration started: 2 mag" which makes all
@@ -243,7 +245,7 @@ void PX4SensorsCalibrationUITest::_testMagCalibration()
     });
 }
 
-void PX4SensorsCalibrationUITest::_testMagCalibrationCancel()
+void PX4SensorsCalibrationUITest::_runCalibrationCancelTest(const QString &sectionObjectName, const QString &calibrateButtonObjectName)
 {
     runWithMockLink(
         [] { return MockLink::startPX4MockLink(false, false, false); },
@@ -251,7 +253,11 @@ void PX4SensorsCalibrationUITest::_testMagCalibrationCancel()
     _navigateToSensorsPanel();
     if (QTest::currentTestFailed()) return;
 
-    _startCompassCalibration();
+    // Select the sensor section so its calibrate button is at the top of the page
+    _clickSidebarSection(sectionObjectName);
+    if (QTest::currentTestFailed()) return;
+
+    _startCalibration(calibrateButtonObjectName);
     if (QTest::currentTestFailed()) return;
 
     // Start calibrating one side
@@ -279,11 +285,137 @@ void PX4SensorsCalibrationUITest::_testMagCalibrationCancel()
              qPrintable(QStringLiteral("Side not Idle after cancel (state %1)")
                             .arg(QLatin1String(calStateName(side->property("calState").toInt())))));
 
-    // Calibrate Compass button is clickable again
-    QVERIFY2(findVisibleItem(_rootItem, QStringLiteral("sensorsSetup_calibrateCompass"), 3000),
-             "Calibrate Compass button not available after cancel");
+    // The calibrate button is clickable again
+    QVERIFY2(findVisibleItem(_rootItem, calibrateButtonObjectName, 3000),
+             qPrintable(QStringLiteral("Calibrate button not available after cancel: %1")
+                            .arg(calibrateButtonObjectName)));
 
     waitForParamRefreshQuiet(vehicle);
 
     });
+}
+
+void PX4SensorsCalibrationUITest::_testMagCalibrationCancel()
+{
+    _runCalibrationCancelTest(QStringLiteral("vehicleConfig_section_Compass"),
+                              QStringLiteral("sensorsSetup_calibrateCompass"));
+}
+
+void PX4SensorsCalibrationUITest::_testAccelCalibration()
+{
+    runWithMockLink(
+        [] { return MockLink::startPX4MockLink(false, false, false); },
+        [&](QPointer<MockLink> mockLink, Vehicle *vehicle) {
+    _navigateToSensorsPanel();
+    if (QTest::currentTestFailed()) return;
+
+    // Select the Accelerometer section: the idle orientation preview appears with
+    // all six poses in the neutral Idle state
+    _clickSidebarSection(QStringLiteral("vehicleConfig_section_Accelerometer"));
+    if (QTest::currentTestFailed()) return;
+
+    _verifyAllPosesState(SensorsComponentController::SideCalStateIdle, "idle preview");
+    if (QTest::currentTestFailed()) return;
+
+    _startCalibration(QStringLiteral("sensorsSetup_calibrateAccel"));
+    if (QTest::currentTestFailed()) return;
+
+    // MockLink responds with "[cal] calibration started: 2 accel" which makes all
+    // six pose indicators visible and Incomplete (red, not yet visited)
+    for (const PoseInfo &info : kPoses) {
+        QQuickItem *side = findVisibleItem(_rootItem, QLatin1String(info.objectName), 5000);
+        QVERIFY2(side, qPrintable(QStringLiteral("Pose indicator not visible: %1").arg(QLatin1String(info.objectName))));
+        QVERIFY2(waitForCalState(side, SensorsComponentController::SideCalStateIncomplete, 5000),
+                 qPrintable(QStringLiteral("Pose not Incomplete at start (state %1): %2")
+                                .arg(QLatin1String(calStateName(side->property("calState").toInt())),
+                                     QLatin1String(info.objectName))));
+    }
+
+    QQuickItem *progressBar = findVisibleItem(_rootItem, QStringLiteral("sensorsSetup_progressBar"), 2000);
+    QVERIFY2(progressBar, "Progress bar not visible during calibration");
+    QVERIFY2(qFuzzyIsNull(progressBar->property("value").toDouble()), "Progress bar not at 0 at calibration start");
+
+    QQuickItem *cancelButton = findVisibleItem(_rootItem, QStringLiteral("sensorsSetup_cancelCalibration"), 2000);
+    QVERIFY2(cancelButton, "Cancel button not visible during calibration");
+
+    // ---------------------------------------------------------------------
+    // Place the vehicle into each pose and watch the UI track the side
+    // ---------------------------------------------------------------------
+    int sidesDone = 0;
+
+    for (const PoseInfo &info : kPoses) {
+        const QString sideName = QLatin1String(info.objectName);
+        QQuickItem *side = findVisibleItem(_rootItem, sideName);
+        QVERIFY2(side, qPrintable(QStringLiteral("Pose indicator disappeared: %1").arg(sideName)));
+
+        mockLink->setCalibrationPose(info.pose);
+
+        // Orientation detected: the side goes InProgress. Unlike mag cal the
+        // vehicle must be held still, so the static (non-rotating) image stays up
+        QVERIFY2(waitForCalState(side, SensorsComponentController::SideCalStateInProgress, 5000),
+                 qPrintable(QStringLiteral("Side never went in-progress: %1").arg(sideName)));
+        QCOMPARE(side->property("calInProgressText").toString(), QStringLiteral("Hold Still"));
+        QVERIFY2(side->property("imageSource").toString().endsWith(QLatin1String(info.stillImage)),
+                 qPrintable(QStringLiteral("Wrong hold-still image for %1: %2")
+                                .arg(sideName, side->property("imageSource").toString())));
+
+        // Side completes and marks itself done (green/Completed)
+        QVERIFY2(waitForCalState(side, SensorsComponentController::SideCalStateCompleted, 5000),
+                 qPrintable(QStringLiteral("Side never completed: %1").arg(sideName)));
+
+        sidesDone++;
+
+        // The firmware reports progress in 17% jumps after each side (see PX4
+        // accel_calibration_worker())
+        if (sidesDone < MockLinkPX4Calibration::kSideCount) {
+            const double progress = progressBar->property("value").toDouble();
+            const double expected = (17.0 * sidesDone) / 100.0;
+            QVERIFY2(qAbs(progress - expected) < 0.005,
+                     qPrintable(QStringLiteral("Unexpected progress after %1 sides: %2, expected %3")
+                                    .arg(sidesDone).arg(progress).arg(expected)));
+        }
+
+        // Previously completed sides must remain marked complete
+        for (const PoseInfo &doneInfo : kPoses) {
+            if (&doneInfo == &info) break;
+            QQuickItem *doneSide = findVisibleItem(_rootItem, QLatin1String(doneInfo.objectName));
+            QVERIFY2(doneSide && (doneSide->property("calState").toInt() == SensorsComponentController::SideCalStateCompleted),
+                     qPrintable(QStringLiteral("Previously completed side no longer marked complete: %1")
+                                    .arg(QLatin1String(doneInfo.objectName))));
+        }
+    }
+
+    // ---------------------------------------------------------------------
+    // Calibration complete: progress hits 100% and the calibration-active UI
+    // (progress bar + cancel button row) hides. Unlike mag cal there is no
+    // completion dialog.
+    // ---------------------------------------------------------------------
+    QVERIFY2(QTest::qWaitFor([&] { return qFuzzyCompare(progressBar->property("value").toDouble(), 1.0); }, 5000),
+             qPrintable(QStringLiteral("Progress bar never reached 1.0: %1")
+                            .arg(progressBar->property("value").toDouble())));
+
+    QVERIFY2(QTest::qWaitFor([&] { return !cancelButton->isVisible(); }, 5000),
+             "Cancel button still visible after calibration completed");
+
+    waitForParamRefreshQuiet(vehicle);
+
+    // All sides must remain marked complete (green) after calibration ends and
+    // the post-calibration parameter refresh settles
+    _verifyAllPosesState(SensorsComponentController::SideCalStateCompleted, "after calibration finished");
+    if (QTest::currentTestFailed()) return;
+
+    // Switching the preview to a different sensor resets the completed sides:
+    // the Compass preview must show all poses in the neutral Idle state
+    _clickSidebarSection(QStringLiteral("vehicleConfig_section_Compass"));
+    if (QTest::currentTestFailed()) return;
+
+    _verifyAllPosesState(SensorsComponentController::SideCalStateIdle, "after section switch");
+
+    });
+}
+
+void PX4SensorsCalibrationUITest::_testAccelCalibrationCancel()
+{
+    _runCalibrationCancelTest(QStringLiteral("vehicleConfig_section_Accelerometer"),
+                              QStringLiteral("sensorsSetup_calibrateAccel"));
 }

--- a/test/QmlUITests/PX4SensorsCalibrationUITest.h
+++ b/test/QmlUITests/PX4SensorsCalibrationUITest.h
@@ -2,12 +2,14 @@
 
 #include "QmlUITestBase.h"
 
+class QString;
+
 /// UI test that boots the full QML UI with a PX4 MockLink vehicle connected,
-/// navigates to the Sensors setup page and runs a complete magnetometer
-/// calibration by clicking the real UI buttons. MockLinkPX4Calibration simulates
-/// the PX4 firmware [cal] protocol; the test drives it by placing the
-/// simulated vehicle into each pose and verifies that the pose indicator
-/// images and the progress bar update correctly.
+/// navigates to the Sensors setup page and runs complete magnetometer and
+/// accelerometer calibrations by clicking the real UI buttons.
+/// MockLinkPX4Calibration simulates the PX4 firmware [cal] protocol; the test
+/// drives it by placing the simulated vehicle into each pose and verifies that
+/// the pose indicator images and the progress bar update correctly.
 class PX4SensorsCalibrationUITest : public QmlUITestBase
 {
     Q_OBJECT
@@ -18,6 +20,8 @@ public:
 private slots:
     void _testMagCalibration();
     void _testMagCalibrationCancel();
+    void _testAccelCalibration();
+    void _testAccelCalibrationCancel();
 
 private:
     /// Navigate from the Fly view to the Sensors page of the Configure view.
@@ -29,6 +33,11 @@ private:
     /// Verify all six pose indicators are visible and in the given SideCalState.
     void _verifyAllPosesState(int expectedState, const char *context);
 
-    /// Click "Calibrate Compass" and accept the pre-calibration dialog.
-    void _startCompassCalibration();
+    /// Click the given calibrate button and accept the pre-calibration dialog.
+    void _startCalibration(const QString &calibrateButtonObjectName);
+
+    /// Shared cancel-mid-calibration flow: select the sensor section, start the
+    /// given calibration, put one side in progress, cancel and verify the UI
+    /// returns to the idle state.
+    void _runCalibrationCancelTest(const QString &sectionObjectName, const QString &calibrateButtonObjectName);
 };


### PR DESCRIPTION
Adds UI test coverage for PX4 accelerometer calibration, building on the existing magnetometer calibration UI test infrastructure.

## Changes

- **MockLinkPX4Calibration**: Generalized from mag-only to simulate both the mag and accel PX4 commander `[cal]` STATUSTEXT protocols. The accel simulation follows `accelerometer_calibration.cpp`: "Hold still, measuring \<side\> side", per-side `[x y z]` result messages, and the firmware's single 17% progress jump per side (intentionally reaching 102 after the final side, which the UI clamps).
- **MockLink**: `MAV_CMD_PREFLIGHT_CALIBRATION` with `param5 == 1` now starts the full pose-driven accel simulation.
- **SensorsSetup.qml**: Added `objectName` to the Calibrate Accelerometer button for test access.
- **PX4SensorsCalibrationUITest**: Two new tests:
  - `_testAccelCalibration` — full six-side accel calibration via real UI clicks, verifying "Hold Still" text, static (non-rotating) pose images, exact 17% progress increments, completion behavior (no dialog, unlike mag) and section-switch state reset.
  - `_testAccelCalibrationCancel` — cancel mid-calibration, verifying the UI returns to idle. The mag/accel cancel flows now share a common `_runCalibrationCancelTest` helper.

## Testing

All 6 tests pass offscreen and onscreen:

```
PASS   : PX4SensorsCalibrationUITest::initTestCase()
PASS   : PX4SensorsCalibrationUITest::_testMagCalibration()
PASS   : PX4SensorsCalibrationUITest::_testMagCalibrationCancel()
PASS   : PX4SensorsCalibrationUITest::_testAccelCalibration()
PASS   : PX4SensorsCalibrationUITest::_testAccelCalibrationCancel()
PASS   : PX4SensorsCalibrationUITest::cleanupTestCase()
Totals: 6 passed, 0 failed, 0 skipped, 0 blacklisted
```
