### PR TITLE
test: APM sensors calibration UI tests and MockLink simulation

### DIFF
--- a/src/AutoPilotPlugins/APM/APMSensorsComponent.qml
+++ b/src/AutoPilotPlugins/APM/APMSensorsComponent.qml
@@ -213,8 +213,8 @@ SetupPage {
                 id: singleCompassOnboardResultsComponent
 
                 Column {
-                    anchors.left:   parent.left
-                    anchors.right:  parent.right
+                    anchors.left:   parent ? parent.left : undefined
+                    anchors.right:  parent ? parent.right : undefined
                     spacing:        Math.round(ScreenTools.defaultFontPixelHeight / 2)
                     visible:        sensorParams.rgCompassAvailable[index] && sensorParams.rgCompassUseFact[index].value
 
@@ -688,6 +688,7 @@ SetupPage {
                     Layout.alignment:   Qt.AlignLeft | Qt.AlignTop
 
                     IndicatorButton {
+                        objectName:     "sensorsSetup_calibrateAccel"
                         width:          _buttonWidth
                         text:           qsTr("Accelerometer")
                         indicatorGreen: !accelCalNeeded
@@ -699,6 +700,7 @@ SetupPage {
                     }
 
                     IndicatorButton {
+                        objectName:     "sensorsSetup_calibrateCompass"
                         width:          _buttonWidth
                         text:           qsTr("Compass")
                         indicatorGreen: !compassCalNeeded
@@ -776,6 +778,7 @@ SetupPage {
 
                     QGCButton {
                         id:         nextButton
+                        objectName: "sensorsSetup_nextButton"
                         width:      _buttonWidth
                         text:       qsTr("Next")
                         enabled:    false
@@ -783,11 +786,12 @@ SetupPage {
                     }
 
                     QGCButton {
-                        id:         cancelButton
-                        width:      _buttonWidth
-                        text:       qsTr("Cancel")
-                        enabled:    false
-                        onClicked:  controller.cancelCalibration()
+                        id:             cancelButton
+                        objectName:     "sensorsSetup_cancelButton"
+                        width:          _buttonWidth
+                        text:           qsTr("Cancel")
+                        enabled:        false
+                        onClicked:      controller.cancelCalibration()
                     }
                 }
             } // QGCFlickable - buttons
@@ -802,6 +806,7 @@ SetupPage {
 
                 ProgressBar {
                     id:             progressBar
+                    objectName:     "sensorsSetup_progressBar"
                     anchors.left:   parent.left
                     anchors.right:  parent.right
                 }
@@ -850,6 +855,7 @@ SetupPage {
                             property real indicatorHeight:  (height / 2) - spacing
 
                             VehicleRotationCal {
+                                objectName:         "sensorsCal_downSide"
                                 width:              parent.indicatorWidth
                                 height:             parent.indicatorHeight
                                 visible:            controller.orientationCalDownSideVisible
@@ -858,6 +864,7 @@ SetupPage {
                                 imageSource:        "qrc:///qmlimages/VehicleDown.png"
                             }
                             VehicleRotationCal {
+                                objectName:         "sensorsCal_leftSide"
                                 width:              parent.indicatorWidth
                                 height:             parent.indicatorHeight
                                 visible:            controller.orientationCalLeftSideVisible
@@ -866,6 +873,7 @@ SetupPage {
                                 imageSource:        "qrc:///qmlimages/VehicleLeft.png"
                             }
                             VehicleRotationCal {
+                                objectName:         "sensorsCal_rightSide"
                                 width:              parent.indicatorWidth
                                 height:             parent.indicatorHeight
                                 visible:            controller.orientationCalRightSideVisible
@@ -874,6 +882,7 @@ SetupPage {
                                 imageSource:        "qrc:///qmlimages/VehicleRight.png"
                             }
                             VehicleRotationCal {
+                                objectName:         "sensorsCal_noseDownSide"
                                 width:              parent.indicatorWidth
                                 height:             parent.indicatorHeight
                                 visible:            controller.orientationCalNoseDownSideVisible
@@ -882,6 +891,7 @@ SetupPage {
                                 imageSource:        "qrc:///qmlimages/VehicleNoseDown.png"
                             }
                             VehicleRotationCal {
+                                objectName:         "sensorsCal_tailDownSide"
                                 width:              parent.indicatorWidth
                                 height:             parent.indicatorHeight
                                 visible:            controller.orientationCalTailDownSideVisible
@@ -890,6 +900,7 @@ SetupPage {
                                 imageSource:        "qrc:///qmlimages/VehicleTailDown.png"
                             }
                             VehicleRotationCal {
+                                objectName:         "sensorsCal_upsideDownSide"
                                 width:              parent.indicatorWidth
                                 height:             parent.indicatorHeight
                                 visible:            controller.orientationCalUpsideDownSideVisible

--- a/src/Comms/MockLink/MockLink.cc
+++ b/src/Comms/MockLink/MockLink.cc
@@ -291,6 +291,8 @@ void MockLink::run500HzTasks()
         }
         _logDownloadWorker();
         _availableModesWorker();
+        _apmCompassCalWorker();
+        _apmAccelCalWorker();
     }
 }
 
@@ -435,16 +437,33 @@ void MockLink::_loadParams()
 }
 
 /// Unit test support: MAV_CMD_PREFLIGHT_STORAGE with param1=2 (as sent by
-/// ParameterManager::resetAllParametersToDefaults) resets all parameters to the
-/// firmware default values from the parameter metadata
-/// (MockLink.Parameter.MetaData.json) rather than the initial values from the
-/// .params file. SYS_AUTOSTART is preserved unless setResetSysAutostartOnParamReset
-/// has been called, so the simulated airframe doesn't change by default.
+/// ParameterManager::resetAllParametersToDefaults) resets parameters to firmware defaults.
+///
+/// For PX4: resets all parameters to the values from Parameter.MetaData.json.
+/// SYS_AUTOSTART is preserved unless setResetSysAutostartOnParamReset has been called.
+///
+/// For ArduPilot: resets only the calibration-indicator parameters (compass offsets and
+/// accelerometer offsets) to 0.0, which is the ArduPilot firmware default for an
+/// uncalibrated vehicle. This allows QGC to detect that sensor setup is required after
+/// a reset, matching real ArduPilot behavior.
 void MockLink::_resetParamsToDefaults()
 {
+    if (_firmwareType == MAV_AUTOPILOT_ARDUPILOTMEGA) {
+        // ArduPilot firmware default for calibration-indicator parameters is 0 (uncalibrated).
+        // Resetting these causes QGC's APMSensorsComponent::setupComplete() to return false,
+        // which is the correct post-reset state on a real vehicle.
+        for (auto compIt = _mapParamName2Value.begin(); compIt != _mapParamName2Value.end(); ++compIt) {
+            for (auto paramIt = compIt.value().begin(); paramIt != compIt.value().end(); ++paramIt) {
+                if (kAPMCalOffsetParams.contains(paramIt.key())) {
+                    paramIt.value() = QVariant(0.0f);
+                }
+            }
+        }
+        return;
+    }
+
     if (_firmwareType != MAV_AUTOPILOT_PX4) {
-        // The parameter metadata defaults are PX4-specific
-        qCWarning(MockLinkLog) << "Param reset to defaults only supported for PX4 firmware";
+        qCWarning(MockLinkLog) << "Param reset to defaults not supported for firmware type" << _firmwareType;
         return;
     }
 
@@ -880,6 +899,20 @@ void MockLink::_handleIncomingMavlinkMsg(const mavlink_message_t &msg)
         break;
     case MAVLINK_MSG_ID_SETUP_SIGNING:
         _handleSetupSigning(msg);
+        break;
+    case MAVLINK_MSG_ID_COMMAND_ACK:
+        // GCS sends COMMAND_ACK(command=0) via nextClicked() to acknowledge each pose
+        // during APM full accel calibration (the "Next" button press).
+        if (_firmwareType == MAV_AUTOPILOT_ARDUPILOTMEGA) {
+            mavlink_command_ack_t ack{};
+            mavlink_msg_command_ack_decode(&msg, &ack);
+            if (ack.command == 0) {
+                QMutexLocker locker(&_apmAccelCalMutex);
+                if (_apmAccelCalPosIndex >= 0 && _apmAccelCalPosIndex < 6) {
+                    _apmAccelCalGotAck = true;
+                }
+            }
+        }
         break;
     default:
         break;
@@ -1635,6 +1668,23 @@ void MockLink::_handleCommandLong(const mavlink_message_t &msg)
     case MAV_CMD_DO_MOTOR_TEST:
         commandResult = MAV_RESULT_ACCEPTED;
         break;
+    case MAV_CMD_DO_START_MAG_CAL:
+        // APM onboard compass calibration: start sending MAG_CAL_PROGRESS then MAG_CAL_REPORT
+        if (_firmwareType == MAV_AUTOPILOT_ARDUPILOTMEGA) {
+            QMutexLocker locker(&_apmCompassCalMutex);
+            _apmCompassCalProgress  = 0;
+            _apmCompassCalTickCount = 0;
+            commandResult = MAV_RESULT_ACCEPTED;
+        }
+        break;
+    case MAV_CMD_DO_CANCEL_MAG_CAL:
+        // Stop APM compass calibration worker
+        if (_firmwareType == MAV_AUTOPILOT_ARDUPILOTMEGA) {
+            QMutexLocker locker(&_apmCompassCalMutex);
+            _apmCompassCalProgress = -1;
+            commandResult = MAV_RESULT_ACCEPTED;
+        }
+        break;
     case MAV_CMD_CONTROL_HIGH_LATENCY:
         if (linkConfiguration()->isHighLatency()) {
             _highLatencyTransmissionEnabled = static_cast<int>(request.param1) != 0;
@@ -2210,8 +2260,26 @@ void MockLink::_handlePreFlightCalibration(const mavlink_command_long_t& request
     if ((request.param1 == 0) && (request.param2 == 0) && (request.param3 == 0) &&
         (request.param4 == 0) && (request.param5 == 0) && (request.param6 == 0) &&
         (request.param7 == 0)) {
-        // All zeros is a calibration cancel request. See PX4 calibrate_cancel_check().
-        (void) _mockLinkPX4Calibration->cancel();
+        // All zeros is a calibration cancel request.
+        if (_firmwareType == MAV_AUTOPILOT_ARDUPILOTMEGA) {
+            // Send ACCELCAL_VEHICLE_POS_FAILED so controller calls _stopCalibration(Failed)
+            QMutexLocker locker(&_apmAccelCalMutex);
+            if (_apmAccelCalPosIndex >= 0) {
+                mavlink_message_t msg{};
+                mavlink_command_long_t cmd{};
+                cmd.target_system    = 255;
+                cmd.target_component = MAV_COMP_ID_MISSIONPLANNER;
+                cmd.command          = MAV_CMD_ACCELCAL_VEHICLE_POS;
+                cmd.param1           = static_cast<float>(ACCELCAL_VEHICLE_POS_FAILED);
+                (void) mavlink_msg_command_long_encode_chan(
+                    _vehicleSystemId, _vehicleComponentId, _outgoingMavlinkChannel, &msg, &cmd);
+                respondWithMavlinkMessage(msg);
+                _apmAccelCalPosIndex = -1;
+            }
+        } else {
+            // PX4: See PX4 calibrate_cancel_check().
+            (void) _mockLinkPX4Calibration->cancel();
+        }
         return;
     }
 
@@ -2227,8 +2295,16 @@ void MockLink::_handlePreFlightCalibration(const mavlink_command_long_t& request
     }
 
     if (request.param5 == 1) {
-        // Accelerometer calibration runs the full pose-driven simulation
-        _mockLinkPX4Calibration->startAccelCalibration();
+        if (_firmwareType == MAV_AUTOPILOT_ARDUPILOTMEGA) {
+            // APM full accelerometer calibration: drive the ACCELCAL_VEHICLE_POS handshake
+            QMutexLocker locker(&_apmAccelCalMutex);
+            _apmAccelCalPosIndex  = 0;
+            _apmAccelCalGotAck    = false;
+            _apmAccelCalTickCount = 0;
+        } else {
+            // Accelerometer calibration runs the full pose-driven simulation
+            _mockLinkPX4Calibration->startAccelCalibration();
+        }
     }
 }
 
@@ -2718,4 +2794,147 @@ void MockLink::_sendAvailableModesMonitor()
 int MockLink::_availableModesCount() const
 {
     return _availableFlightModes.count() - (_availableModesMonitorSeqNumber == 0 ? 1 : 0); // Exclude the delayed mode
+}
+
+// ---------------------------------------------------------------------------
+// ArduPilot compass calibration simulation
+//
+// Driven by _apmCompassCalProgress: -1 = inactive, 0..100 = current pct.
+// Main thread sets it to 0 to start and -1 to stop.
+// Worker sends MAG_CAL_PROGRESS at ~10Hz (every 50 calls of 500Hz worker),
+// then sends MAG_CAL_REPORT when pct reaches 100.
+// ---------------------------------------------------------------------------
+void MockLink::_apmCompassCalWorker()
+{
+    if (_firmwareType != MAV_AUTOPILOT_ARDUPILOTMEGA) {
+        return;
+    }
+
+    QMutexLocker locker(&_apmCompassCalMutex);
+    if (_apmCompassCalProgress < 0) {
+        return;
+    }
+
+    // Tick ~10 Hz: advance every 50 calls of the 500 Hz worker
+    if (++_apmCompassCalTickCount < 50) {
+        return;
+    }
+    _apmCompassCalTickCount = 0;
+
+    const int pct = _apmCompassCalProgress;
+
+    // Send MAG_CAL_PROGRESS for all 3 active compasses
+    mavlink_message_t msg{};
+    for (uint8_t id = 0; id < 3; ++id) {
+        mavlink_mag_cal_progress_t progress{};
+        progress.compass_id      = id;
+        progress.cal_mask        = 0x07; // all 3 compasses
+        progress.cal_status      = MAG_CAL_RUNNING_STEP_ONE;
+        progress.completion_pct  = static_cast<uint8_t>(qMin(pct, 100));
+        (void) mavlink_msg_mag_cal_progress_encode_chan(
+            _vehicleSystemId, _vehicleComponentId, _outgoingMavlinkChannel, &msg, &progress);
+        respondWithMavlinkMessage(msg);
+    }
+
+    if (pct >= 100) {
+        // Send MAG_CAL_REPORT for all 3 compasses
+        for (uint8_t id = 0; id < 3; ++id) {
+            mavlink_mag_cal_report_t report{};
+            report.compass_id  = id;
+            report.cal_mask    = 0x07;
+            report.cal_status  = MAG_CAL_SUCCESS;
+            report.fitness     = 0.5f;
+            (void) mavlink_msg_mag_cal_report_encode_chan(
+                _vehicleSystemId, _vehicleComponentId, _outgoingMavlinkChannel, &msg, &report);
+            respondWithMavlinkMessage(msg);
+        }
+
+        // Write non-zero offsets so QGC sees all compasses as calibrated after refresh.
+        // _mapParamName2Value is owned by MockLink's main thread; dispatch the write there
+        // to avoid a data race with concurrent param reads on the main thread.
+        (void) QMetaObject::invokeMethod(this, [this] {
+            constexpr int compId = MAV_COMP_ID_AUTOPILOT1;
+            _mapParamName2Value[compId][QStringLiteral("COMPASS_OFS_X")]   = QVariant(10.0f);
+            _mapParamName2Value[compId][QStringLiteral("COMPASS_OFS_Y")]   = QVariant(10.0f);
+            _mapParamName2Value[compId][QStringLiteral("COMPASS_OFS_Z")]   = QVariant(10.0f);
+            _mapParamName2Value[compId][QStringLiteral("COMPASS_OFS2_X")]  = QVariant(10.0f);
+            _mapParamName2Value[compId][QStringLiteral("COMPASS_OFS2_Y")]  = QVariant(10.0f);
+            _mapParamName2Value[compId][QStringLiteral("COMPASS_OFS2_Z")]  = QVariant(10.0f);
+            _mapParamName2Value[compId][QStringLiteral("COMPASS_OFS3_X")]  = QVariant(10.0f);
+            _mapParamName2Value[compId][QStringLiteral("COMPASS_OFS3_Y")]  = QVariant(10.0f);
+            _mapParamName2Value[compId][QStringLiteral("COMPASS_OFS3_Z")]  = QVariant(10.0f);
+        }, Qt::QueuedConnection);
+
+        _apmCompassCalProgress = -1; // deactivate
+    } else {
+        _apmCompassCalProgress = qMin(pct + 5, 100);
+    }
+}
+
+// ---------------------------------------------------------------------------
+// ArduPilot full accelerometer calibration simulation
+//
+// The firmware sends COMMAND_LONG(MAV_CMD_ACCELCAL_VEHICLE_POS, pos) to QGC
+// and waits for a COMMAND_ACK (the "Next" button press) before advancing.
+// State: _apmAccelCalPosIndex -1=inactive, 0..5=current pose, 6=done.
+// ---------------------------------------------------------------------------
+void MockLink::_apmAccelCalWorker()
+{
+    if (_firmwareType != MAV_AUTOPILOT_ARDUPILOTMEGA) {
+        return;
+    }
+
+    QMutexLocker locker(&_apmAccelCalMutex);
+    if (_apmAccelCalPosIndex < 0) {
+        return;
+    }
+
+    if (_apmAccelCalPosIndex == 6) {
+        // All poses done: send SUCCESS
+        mavlink_message_t msg{};
+        mavlink_command_long_t cmd{};
+        cmd.target_system    = 255; // GCS
+        cmd.target_component = MAV_COMP_ID_MISSIONPLANNER;
+        cmd.command          = MAV_CMD_ACCELCAL_VEHICLE_POS;
+        cmd.param1           = static_cast<float>(ACCELCAL_VEHICLE_POS_SUCCESS);
+        (void) mavlink_msg_command_long_encode_chan(
+            _vehicleSystemId, _vehicleComponentId, _outgoingMavlinkChannel, &msg, &cmd);
+        respondWithMavlinkMessage(msg);
+
+        // Write non-zero accel offsets.
+        // _mapParamName2Value is owned by MockLink's main thread; dispatch the write there
+        // to avoid a data race with concurrent param reads on the main thread.
+        (void) QMetaObject::invokeMethod(this, [this] {
+            constexpr int compId = MAV_COMP_ID_AUTOPILOT1;
+            _mapParamName2Value[compId][QStringLiteral("INS_ACCOFFS_X")] = QVariant(0.1f);
+            _mapParamName2Value[compId][QStringLiteral("INS_ACCOFFS_Y")] = QVariant(0.1f);
+            _mapParamName2Value[compId][QStringLiteral("INS_ACCOFFS_Z")] = QVariant(0.1f);
+        }, Qt::QueuedConnection);
+
+        _apmAccelCalPosIndex = -1;
+        return;
+    }
+
+    // Send the current position request once; wait for Next ack before advancing
+    if (!_apmAccelCalGotAck) {
+        // Throttle re-sends to ~10 Hz
+        if (++_apmAccelCalTickCount < 50) {
+            return;
+        }
+        _apmAccelCalTickCount = 0;
+
+        mavlink_message_t msg{};
+        mavlink_command_long_t cmd{};
+        cmd.target_system    = 255;
+        cmd.target_component = MAV_COMP_ID_MISSIONPLANNER;
+        cmd.command          = MAV_CMD_ACCELCAL_VEHICLE_POS;
+        cmd.param1           = static_cast<float>(kAPMAccelCalPosSequence[_apmAccelCalPosIndex]);
+        (void) mavlink_msg_command_long_encode_chan(
+            _vehicleSystemId, _vehicleComponentId, _outgoingMavlinkChannel, &msg, &cmd);
+        respondWithMavlinkMessage(msg);
+    } else {
+        // Ack received — advance to next pose
+        _apmAccelCalGotAck  = false;
+        _apmAccelCalPosIndex++;
+    }
 }

--- a/src/Comms/MockLink/MockLink.h
+++ b/src/Comms/MockLink/MockLink.h
@@ -2,6 +2,7 @@
 
 #include "PX4/px4_custom_mode.h"
 #include "LinkInterface.h"
+#include "MAVLinkEnums.h"
 #include "MAVLinkMessageType.h"
 #include "QGCMAVLinkTypes.h"
 #include "MockConfiguration.h"
@@ -275,6 +276,8 @@ private:
     void _paramRequestListWorker();
     void _logDownloadWorker();
     void _availableModesWorker();
+    void _apmCompassCalWorker();
+    void _apmAccelCalWorker();
     void _sendAvailableMode(uint8_t modeIndexOneBased);
     int  _availableModesCount() const;
     void _moveADSBVehicle(int vehicleIndex);
@@ -380,6 +383,30 @@ private:
     bool _paramRequestListHashCheckSent = false;
     bool _resetSysAutostartOnParamReset = false;
 
+    // APM compass calibration worker state
+    // Protects _apmCompassCalProgress: main thread writes 0 to start/stop,
+    // worker thread reads/increments each 100ms tick.
+    QMutex _apmCompassCalMutex;
+    int    _apmCompassCalProgress  = -1; ///< -1 = inactive, 0-100 = progress pct
+    int    _apmCompassCalTickCount = 0;  ///< 500 Hz tick counter for ~10 Hz throttle
+
+    // APM accel calibration worker state
+    // Protects _apmAccelCalPos: main thread writes the starting pos,
+    // worker thread reads and advances through the sequence.
+    QMutex _apmAccelCalMutex;
+    /// Each position the firmware sends to QGC in sequence
+    static constexpr ACCELCAL_VEHICLE_POS kAPMAccelCalPosSequence[] = {
+        ACCELCAL_VEHICLE_POS_LEVEL,
+        ACCELCAL_VEHICLE_POS_LEFT,
+        ACCELCAL_VEHICLE_POS_RIGHT,
+        ACCELCAL_VEHICLE_POS_NOSEDOWN,
+        ACCELCAL_VEHICLE_POS_NOSEUP,
+        ACCELCAL_VEHICLE_POS_BACK,
+    };
+    int  _apmAccelCalPosIndex   = -1;   ///< -1 = inactive, 0..5 = current pos, 6 = done
+    bool _apmAccelCalGotAck     = false; ///< GCS clicked Next
+    int  _apmAccelCalTickCount  = 0;    ///< 500 Hz tick counter for ~10 Hz throttle
+
     struct RCChannelOverride {
         enum class State { Ignore, Overridden, Released } state = State::Ignore;
         uint16_t value = 0;
@@ -421,6 +448,16 @@ private:
     static constexpr uint32_t _logDownloadFileSize = 1000;  ///< Size of simulated log file
 
     static constexpr bool _mavlinkStarted = true;
+
+    /// ArduPilot calibration-indicator parameters whose firmware default is 0 (uncalibrated).
+    /// Used by _resetParamsToDefaults() and MockLinkFTP::_generateParamPck() to keep both
+    /// sites in sync.
+    inline static const QSet<QString> kAPMCalOffsetParams = {
+        QStringLiteral("COMPASS_OFS_X"),  QStringLiteral("COMPASS_OFS_Y"),  QStringLiteral("COMPASS_OFS_Z"),
+        QStringLiteral("COMPASS_OFS2_X"), QStringLiteral("COMPASS_OFS2_Y"), QStringLiteral("COMPASS_OFS2_Z"),
+        QStringLiteral("COMPASS_OFS3_X"), QStringLiteral("COMPASS_OFS3_Y"), QStringLiteral("COMPASS_OFS3_Z"),
+        QStringLiteral("INS_ACCOFFS_X"),  QStringLiteral("INS_ACCOFFS_Y"),  QStringLiteral("INS_ACCOFFS_Z"),
+    };
 
     static QList<FlightMode_t> _availableFlightModes;
 

--- a/src/Comms/MockLink/MockLinkFTP.cc
+++ b/src/Comms/MockLink/MockLinkFTP.cc
@@ -683,10 +683,13 @@ QString MockLinkFTP::_generateParamPck(bool withDefaults)
             commonLen = 0;
         }
 
-        // For MockLink all params are at defaults, so when withDefaults is requested
-        // we still include the default value for every param (matching real ArduPilot
-        // behavior where value == default means no default flag, but we include them
-        // so QGC can show default values in the UI)
+        // For ArduPilot, calibration-indicator parameters have a firmware default of 0
+        // (uncalibrated). All other parameters use their current value as the default,
+        // since MockLink params are loaded from a snapshot and we have no separate
+        // defaults file.
+        const bool useZeroDefault = withDefaults
+            && (_mockLink->getFirmwareType() == MAV_AUTOPILOT_ARDUPILOTMEGA)
+            && MockLink::kAPMCalOffsetParams.contains(name);
         const bool addDefault = withDefaults;
         const quint8 flags = addDefault ? 0x01 : 0x00;
         const int packedLen = 2 + nameLen + valueSize + (addDefault ? valueSize : 0);
@@ -721,19 +724,19 @@ QString MockLinkFTP::_generateParamPck(bool withDefaults)
         case AP_PARAM_INT8: {
             const qint8 v = static_cast<qint8>(value.toInt());
             stream << v;
-            if (addDefault) stream << v;
+            if (addDefault) stream << (useZeroDefault ? qint8(0) : v);
             break;
         }
         case AP_PARAM_INT16: {
             const qint16 v = static_cast<qint16>(value.toInt());
             stream << v;
-            if (addDefault) stream << v;
+            if (addDefault) stream << (useZeroDefault ? qint16(0) : v);
             break;
         }
         case AP_PARAM_INT32: {
             const qint32 v = value.toInt();
             stream << v;
-            if (addDefault) stream << v;
+            if (addDefault) stream << (useZeroDefault ? qint32(0) : v);
             break;
         }
         case AP_PARAM_FLOAT: {
@@ -741,7 +744,13 @@ QString MockLinkFTP::_generateParamPck(bool withDefaults)
             qint32 raw;
             memcpy(&raw, &f, sizeof(raw));
             stream << raw;
-            if (addDefault) stream << raw;
+            if (addDefault) {
+                if (useZeroDefault) {
+                    stream << qint32(0);
+                } else {
+                    stream << raw;
+                }
+            }
             break;
         }
         }

--- a/test/QmlUITests/APMSensorsCalibrationUITest.cc
+++ b/test/QmlUITests/APMSensorsCalibrationUITest.cc
@@ -1,0 +1,313 @@
+#include "APMSensorsCalibrationUITest.h"
+
+#include <QtCore/QElapsedTimer>
+#include <QtQuick/QQuickItem>
+#include <QtTest/QTest>
+
+#include "MockLink.h"
+#include "ParameterManager.h"
+#include "Vehicle.h"
+
+UT_REGISTER_TEST(APMSensorsCalibrationUITest, TestLabel::Integration)
+
+namespace {
+
+/// Wait for _refreshParams() traffic to settle so link teardown doesn't cut off
+/// in-flight PARAM_REQUEST_READs (which can log warnings that fail strict mode).
+void waitForParamRefreshQuiet(Vehicle *vehicle)
+{
+    ParameterManager *mgr = vehicle->parameterManager();
+    QElapsedTimer sinceLastResponse;
+    sinceLastResponse.start();
+
+    QObject context;
+    QObject::connect(mgr, &ParameterManager::_paramRequestReadSuccess, &context,
+                     [&] { sinceLastResponse.restart(); });
+    QObject::connect(mgr, &ParameterManager::_paramRequestReadFailure, &context,
+                     [&] { sinceLastResponse.restart(); });
+
+    (void) QTest::qWaitFor([&] { return sinceLastResponse.elapsed() > 500; }, 10000);
+}
+
+} // namespace
+
+// ---------------------------------------------------------------------------
+
+void APMSensorsCalibrationUITest::_navigateToSensorsPage()
+{
+    navigateToConfigureView();
+    if (QTest::currentTestFailed()) return;
+
+    QQuickItem *sensorsBtn = clickSidebarButton(QStringLiteral("vehicleConfig_comp_Sensors"));
+    if (QTest::currentTestFailed()) return;
+
+    // The Sensors component has no sub-sections on APM; clicking the button opens the page.
+    // The Accelerometer indicator button must appear.
+    QVERIFY2(findVisibleItem(_rootItem, QStringLiteral("sensorsSetup_calibrateAccel"), 5000),
+             "sensorsSetup_calibrateAccel not found after opening Sensors page");
+    QVERIFY2(findVisibleItem(_rootItem, QStringLiteral("sensorsSetup_calibrateCompass"), 3000),
+             "sensorsSetup_calibrateCompass not found after opening Sensors page");
+    Q_UNUSED(sensorsBtn);
+}
+
+void APMSensorsCalibrationUITest::_verifyCalIndicators(bool compassGreen, bool accelGreen, const char *context)
+{
+    struct Check {
+        const char *name;
+        bool expectedGreen;
+    };
+    const Check checks[] = {
+        { "sensorsSetup_calibrateCompass", compassGreen },
+        { "sensorsSetup_calibrateAccel",   accelGreen   },
+    };
+
+    for (const Check &c : checks) {
+        QQuickItem *btn = findVisibleItem(_rootItem, QLatin1String(c.name), 3000);
+        QVERIFY2(btn, qPrintable(QStringLiteral("Button not found (%1): %2")
+                                     .arg(QLatin1String(context), QLatin1String(c.name))));
+        (void) QTest::qWaitFor([&] {
+            return btn->property("indicatorGreen").toBool() == c.expectedGreen;
+        }, 3000);
+        QVERIFY2(btn->property("indicatorGreen").toBool() == c.expectedGreen,
+                 qPrintable(QStringLiteral("indicatorGreen is %1, expected %2 (%3): %4")
+                                .arg(btn->property("indicatorGreen").toBool())
+                                .arg(c.expectedGreen)
+                                .arg(QLatin1String(context), QLatin1String(c.name))));
+    }
+}
+
+void APMSensorsCalibrationUITest::_runFullAccelCal()
+{
+    // APM requires accel cal before compass can be run.
+    // Click Accelerometer button → orientation dialog opens → accept (full cal, not simple).
+    QVERIFY2(clickButton(QStringLiteral("sensorsSetup_calibrateAccel")),
+             "Failed to click Accelerometer button");
+
+    // Accept the orientation/pre-cal dialog (do NOT check the Simple checkbox)
+    QVERIFY2(findVisibleItem(_rootItem, QStringLiteral("popupDialog_acceptButton"), 5000),
+             "Pre-accel-cal dialog accept button not found");
+    QVERIFY2(clickButton(QStringLiteral("popupDialog_acceptButton")),
+             "Failed to accept pre-accel-cal dialog");
+
+    // MockLink will now drive the 6-pose ACCELCAL_VEHICLE_POS handshake.
+    // For each pose the orientation cal area becomes visible with the relevant
+    // side InProgress; the user (test) clicks Next to advance.
+
+    // Poses in the order MockLink sends them:
+    // LEVEL→downSide, LEFT→leftSide, RIGHT→rightSide,
+    // NOSEDOWN→noseDownSide, NOSEUP→tailDownSide, BACK→upsideDownSide
+    struct PoseInfo {
+        const char *sideObjectName;
+    };
+    static constexpr PoseInfo kPoses[] = {
+        { "sensorsCal_downSide"      },
+        { "sensorsCal_leftSide"      },
+        { "sensorsCal_rightSide"     },
+        { "sensorsCal_noseDownSide"  },
+        { "sensorsCal_tailDownSide"  },
+        { "sensorsCal_upsideDownSide" },
+    };
+
+    for (const PoseInfo &pose : kPoses) {
+        // Wait for the orientation cal area to show (controller.showOrientationCalArea = true)
+        // and this side to be InProgress (calState == VehicleRotationCal.CalState.InProgress == 2)
+        QQuickItem *sideItem = findVisibleItem(_rootItem, QLatin1String(pose.sideObjectName), 10000);
+        QVERIFY2(sideItem, qPrintable(QStringLiteral("Side indicator not visible: %1")
+                                          .arg(QLatin1String(pose.sideObjectName))));
+
+        // calState InProgress == 2 (VehicleRotationCal.CalState enum)
+        QVERIFY2(QTest::qWaitFor([&] { return sideItem->property("calState").toInt() == 2; }, 10000),
+                 qPrintable(QStringLiteral("Side never went InProgress: %1")
+                                .arg(QLatin1String(pose.sideObjectName))));
+
+        // Click Next — sends COMMAND_ACK back to MockLink to advance to next pose.
+        // The controller enables the Next button when it receives the ACCELCAL_VEHICLE_POS message,
+        // which happens on the same tick as the side going InProgress, so wait briefly for it.
+        QQuickItem *nextBtn = findVisibleItem(_rootItem, QStringLiteral("sensorsSetup_nextButton"), 3000);
+        QVERIFY2(nextBtn, "Next button not found");
+        QVERIFY2(QTest::qWaitFor([&] { return nextBtn->property("enabled").toBool(); }, 3000),
+                 qPrintable(QStringLiteral("Next button not enabled for side: %1")
+                                .arg(QLatin1String(pose.sideObjectName))));
+        QVERIFY2(clickButton(QStringLiteral("sensorsSetup_nextButton")), "Failed to click Next button");
+    }
+
+    // After the last pose MockLink sends ACCELCAL_VEHICLE_POS_SUCCESS → _stopCalibration(Success)
+    // Progress bar goes to 1.0 and the cal area closes
+    QQuickItem *progressBar = findVisibleItem(_rootItem, QStringLiteral("sensorsSetup_progressBar"), 2000);
+    QVERIFY2(progressBar, "Progress bar not found during accel cal");
+    QVERIFY2(QTest::qWaitFor([&] { return qFuzzyCompare(progressBar->property("value").toDouble(), 1.0); }, 10000),
+             "Progress bar never reached 1.0 after accel cal success");
+
+    // APM's onCalibrationComplete handler opens postOnboardCompassCalibrationFactory for
+    // both CalibrationAccel and CalibrationMag.  Dismiss the dialog so the sensors
+    // page is unblocked before callers proceed.
+    QVERIFY2(findVisibleItem(_rootItem, QStringLiteral("popupDialog_acceptButton"), 5000),
+             "Post-accel-cal dialog not shown");
+    QVERIFY2(clickButton(QStringLiteral("popupDialog_acceptButton")),
+             "Failed to dismiss post-accel-cal dialog");
+}
+
+// ---------------------------------------------------------------------------
+// _testCompassCalibration
+// ---------------------------------------------------------------------------
+void APMSensorsCalibrationUITest::_testCompassCalibration()
+{
+    ignoreAPMMockLinkWarnings();
+    runWithMockLink(
+        [] { return MockLink::startAPMArduCopterMockLink(false, false, false); },
+        [&](QPointer<MockLink> /*mockLink*/, Vehicle *vehicle) {
+
+    resetAPMParamsToUncalibrated(vehicle);
+    if (QTest::currentTestFailed()) return;
+
+    _navigateToSensorsPage();
+    if (QTest::currentTestFailed()) return;
+
+    // Both indicators must be orange (not calibrated)
+    _verifyCalIndicators(/*compassGreen=*/false, /*accelGreen=*/false, "after param reset");
+    if (QTest::currentTestFailed()) return;
+
+    // -------------------------------------------------------------------
+    // 1. Accel calibration (required before compass on APM)
+    // -------------------------------------------------------------------
+    _runFullAccelCal();
+    if (QTest::currentTestFailed()) return;
+
+    waitForParamRefreshQuiet(vehicle);
+
+    // Accel indicator should now be green; compass still orange
+    _verifyCalIndicators(/*compassGreen=*/false, /*accelGreen=*/true, "after accel cal");
+    if (QTest::currentTestFailed()) return;
+
+    // -------------------------------------------------------------------
+    // 2. Compass calibration
+    // -------------------------------------------------------------------
+    QVERIFY2(clickButton(QStringLiteral("sensorsSetup_calibrateCompass")),
+             "Failed to click Compass button");
+
+    // Orientation dialog opens → accept to start MAV_CMD_DO_START_MAG_CAL
+    QVERIFY2(findVisibleItem(_rootItem, QStringLiteral("popupDialog_acceptButton"), 5000),
+             "Pre-compass-cal dialog accept button not found");
+    QVERIFY2(clickButton(QStringLiteral("popupDialog_acceptButton")),
+             "Failed to accept pre-compass-cal dialog");
+
+    // MockLink sends MAG_CAL_PROGRESS 0→100 at ~10Hz
+    QQuickItem *progressBar = findVisibleItem(_rootItem, QStringLiteral("sensorsSetup_progressBar"), 2000);
+    QVERIFY2(progressBar, "Progress bar not found during compass cal");
+
+    // Wait for progress > 0 (calibration is running)
+    QVERIFY2(QTest::qWaitFor([&] { return progressBar->property("value").toDouble() > 0.0; }, 5000),
+             "Compass cal progress never advanced above 0");
+
+    // Wait for completion: MAG_CAL_REPORT → StopCalibrationSuccessShowLog → dialog opens.
+    // Note: StopCalibrationSuccessShowLog resets progress to 0 (not 1.0), so wait for
+    // the post-cal dialog directly rather than waiting for progress == 1.0.
+    QVERIFY2(findVisibleItem(_rootItem, QStringLiteral("popupDialog_acceptButton"), 25000),
+             "Post-compass-cal dialog not shown");
+    QVERIFY2(clickButton(QStringLiteral("popupDialog_acceptButton")),
+             "Failed to dismiss post-compass-cal dialog");
+
+    waitForParamRefreshQuiet(vehicle);
+
+    // Both indicators must be green
+    _verifyCalIndicators(/*compassGreen=*/true, /*accelGreen=*/true, "after compass cal");
+
+    });
+}
+
+// ---------------------------------------------------------------------------
+// _testCompassCalibrationCancel
+// ---------------------------------------------------------------------------
+void APMSensorsCalibrationUITest::_testCompassCalibrationCancel()
+{
+    ignoreAPMMockLinkWarnings();
+    runWithMockLink(
+        [] { return MockLink::startAPMArduCopterMockLink(false, false, false); },
+        [&](QPointer<MockLink> /*mockLink*/, Vehicle *vehicle) {
+
+    resetAPMParamsToUncalibrated(vehicle);
+    if (QTest::currentTestFailed()) return;
+
+    _navigateToSensorsPage();
+    if (QTest::currentTestFailed()) return;
+
+    // Must do accel first
+    _runFullAccelCal();
+    if (QTest::currentTestFailed()) return;
+    waitForParamRefreshQuiet(vehicle);
+
+    // Start compass cal
+    QVERIFY2(clickButton(QStringLiteral("sensorsSetup_calibrateCompass")),
+             "Failed to click Compass button");
+    QVERIFY2(findVisibleItem(_rootItem, QStringLiteral("popupDialog_acceptButton"), 5000),
+             "Pre-compass-cal dialog not found");
+    QVERIFY2(clickButton(QStringLiteral("popupDialog_acceptButton")),
+             "Failed to accept pre-compass-cal dialog");
+
+    // Wait for some progress
+    QQuickItem *progressBar = findVisibleItem(_rootItem, QStringLiteral("sensorsSetup_progressBar"), 2000);
+    QVERIFY2(progressBar, "Progress bar not found");
+    QVERIFY2(QTest::qWaitFor([&] { return progressBar->property("value").toDouble() > 0.0; }, 5000),
+             "Compass cal progress never started");
+
+    // Cancel
+    QVERIFY2(clickButton(QStringLiteral("sensorsSetup_cancelButton")),
+             "Failed to click Cancel button");
+
+    // After cancel the cancel button should become disabled (cal no longer active)
+    QQuickItem *cancelBtn = findVisibleItem(_rootItem, QStringLiteral("sensorsSetup_cancelButton"), 2000);
+    QVERIFY2(cancelBtn, "Cancel button not found after cancel");
+    QVERIFY2(QTest::qWaitFor([&] { return !cancelBtn->property("enabled").toBool(); }, 5000),
+             "Cancel button still enabled after cancellation");
+
+    // COMPASS_OFS_X must still be 0 (compass not calibrated)
+    ParameterManager *mgr = vehicle->parameterManager();
+    QVERIFY2(mgr->parameterExists(ParameterManager::defaultComponentId, QStringLiteral("COMPASS_OFS_X")),
+             "COMPASS_OFS_X parameter not found");
+    Fact *compassOfs = mgr->getParameter(ParameterManager::defaultComponentId, QStringLiteral("COMPASS_OFS_X"));
+    QVERIFY2(qFuzzyIsNull(compassOfs->rawValue().toFloat()),
+             "COMPASS_OFS_X is non-zero after compass cal cancel");
+
+    // Compass indicator still orange
+    _verifyCalIndicators(/*compassGreen=*/false, /*accelGreen=*/true, "after compass cal cancel");
+
+    });
+}
+
+// ---------------------------------------------------------------------------
+// _testAccelCalibration
+// ---------------------------------------------------------------------------
+void APMSensorsCalibrationUITest::_testAccelCalibration()
+{
+    ignoreAPMMockLinkWarnings();
+    runWithMockLink(
+        [] { return MockLink::startAPMArduCopterMockLink(false, false, false); },
+        [&](QPointer<MockLink> /*mockLink*/, Vehicle *vehicle) {
+
+    resetAPMParamsToUncalibrated(vehicle);
+    if (QTest::currentTestFailed()) return;
+
+    _navigateToSensorsPage();
+    if (QTest::currentTestFailed()) return;
+
+    _verifyCalIndicators(/*compassGreen=*/false, /*accelGreen=*/false, "after param reset");
+    if (QTest::currentTestFailed()) return;
+
+    _runFullAccelCal();
+    if (QTest::currentTestFailed()) return;
+
+    waitForParamRefreshQuiet(vehicle);
+
+    // INS_ACCOFFS_X must be non-zero (MockLink writes 0.1 on SUCCESS)
+    ParameterManager *mgr = vehicle->parameterManager();
+    QVERIFY2(mgr->parameterExists(ParameterManager::defaultComponentId, QStringLiteral("INS_ACCOFFS_X")),
+             "INS_ACCOFFS_X parameter not found");
+    Fact *accelOfs = mgr->getParameter(ParameterManager::defaultComponentId, QStringLiteral("INS_ACCOFFS_X"));
+    QVERIFY2(QTest::qWaitFor([&] { return !qFuzzyIsNull(accelOfs->rawValue().toFloat()); }, 10000),
+             "INS_ACCOFFS_X still 0 after accel cal — param refresh did not bring back non-zero value");
+
+    // Accel indicator green, compass still orange
+    _verifyCalIndicators(/*compassGreen=*/false, /*accelGreen=*/true, "after accel cal");
+
+    });
+}

--- a/test/QmlUITests/APMSensorsCalibrationUITest.h
+++ b/test/QmlUITests/APMSensorsCalibrationUITest.h
@@ -1,0 +1,41 @@
+#pragma once
+
+#include "VehicleConfigUITestBase.h"
+
+class QString;
+class Vehicle;
+
+/// UI test that boots the full QML UI with an ArduCopter MockLink vehicle connected,
+/// navigates to the Sensors setup page and runs magnetometer and accelerometer
+/// calibrations by clicking the real UI buttons.
+///
+/// MockLink simulates the ArduPilot MAV_CMD_DO_START_MAG_CAL / MAG_CAL_PROGRESS /
+/// MAG_CAL_REPORT protocol for compass and the ACCELCAL_VEHICLE_POS COMMAND_LONG
+/// handshake for full accelerometer calibration.
+///
+/// Tests start from an uncalibrated state produced by resetAPMParamsToUncalibrated(),
+/// which zeroes the compass and accel offset parameters via MockLink's APM
+/// MAV_CMD_PREFLIGHT_STORAGE param1=2 handler.
+class APMSensorsCalibrationUITest : public VehicleConfigUITestBase
+{
+    Q_OBJECT
+
+public:
+    APMSensorsCalibrationUITest() = default;
+
+private slots:
+    void _testCompassCalibration();
+    void _testCompassCalibrationCancel();
+    void _testAccelCalibration();
+
+private:
+    /// Navigate from the Fly view to the APM Sensors page.
+    void _navigateToSensorsPage();
+
+    /// Verify the two calibration indicator buttons reflect the expected green/orange state.
+    void _verifyCalIndicators(bool compassGreen, bool accelGreen, const char *context);
+
+    /// Run a complete full accelerometer calibration by clicking Next for each of the
+    /// six poses as MockLink drives the ACCELCAL_VEHICLE_POS handshake.
+    void _runFullAccelCal();
+};

--- a/test/QmlUITests/CMakeLists.txt
+++ b/test/QmlUITests/CMakeLists.txt
@@ -20,6 +20,8 @@ target_sources(${CMAKE_PROJECT_NAME}
         ${CMAKE_CURRENT_SOURCE_DIR}/PlanViewUITest.h
         ${CMAKE_CURRENT_SOURCE_DIR}/PX4SensorsCalibrationUITest.cc
         ${CMAKE_CURRENT_SOURCE_DIR}/PX4SensorsCalibrationUITest.h
+        ${CMAKE_CURRENT_SOURCE_DIR}/APMSensorsCalibrationUITest.cc
+        ${CMAKE_CURRENT_SOURCE_DIR}/APMSensorsCalibrationUITest.h
         ${CMAKE_CURRENT_SOURCE_DIR}/PX4AirframeSetupUITest.cc
         ${CMAKE_CURRENT_SOURCE_DIR}/PX4AirframeSetupUITest.h
 )
@@ -35,4 +37,5 @@ add_qgc_test(APMVehicleConfigUITest LABELS Integration NoSanitizer TIMEOUT 360)
 add_qgc_test(ToolbarIndicatorUITest LABELS Integration NoSanitizer TIMEOUT 180)
 add_qgc_test(PlanViewUITest LABELS Integration NoSanitizer TIMEOUT 120)
 add_qgc_test(PX4SensorsCalibrationUITest LABELS Integration NoSanitizer TIMEOUT 180)
+add_qgc_test(APMSensorsCalibrationUITest LABELS Integration NoSanitizer TIMEOUT 240)
 add_qgc_test(PX4AirframeSetupUITest LABELS Integration NoSanitizer TIMEOUT 120)

--- a/test/QmlUITests/QmlUITestBase.cc
+++ b/test/QmlUITests/QmlUITestBase.cc
@@ -94,13 +94,25 @@ void QmlUITestBase::closeUIWindow()
 {
     if (_window) {
         _window->close();
-        QTest::qWait(100);
+        (void) QTest::qWaitFor([this] { return !_window->isVisible(); }, 1000);
+        for (int i = 0; i < 5; ++i) {
+            QCoreApplication::processEvents();
+            QTest::qWait(20);
+        }
     }
 }
 
 void QmlUITestBase::destroyUIEngine()
 {
     if (_engine) {
+        // Give asynchronous QML item creation/destruction a brief drain window
+        // before engine teardown to avoid strict-mode warnings at shutdown.
+        for (int i = 0; i < 10; ++i) {
+            _engine->collectGarbage();
+            QCoreApplication::processEvents();
+            QTest::qWait(10);
+        }
+
         // Force GC and event processing so QML releases references to C++ singletons
         // (e.g. SettingsFacts) before the engine is destroyed.  Without this,
         // QQmlData attached to those objects fires stale binding updates during

--- a/test/QmlUITests/VehicleConfigUITestBase.cc
+++ b/test/QmlUITests/VehicleConfigUITestBase.cc
@@ -58,6 +58,24 @@ void VehicleConfigUITestBase::resetParamsToFirmwareDefaults(Vehicle *vehicle, co
              "Parameters never refreshed to firmware defaults");
 }
 
+void VehicleConfigUITestBase::resetAPMParamsToUncalibrated(Vehicle *vehicle)
+{
+    ParameterManager *mgr = vehicle->parameterManager();
+
+    QVERIFY2(mgr->parameterExists(ParameterManager::defaultComponentId, QStringLiteral("COMPASS_OFS_X")),
+             "COMPASS_OFS_X parameter not found");
+    Fact *compassOfs = mgr->getParameter(ParameterManager::defaultComponentId, QStringLiteral("COMPASS_OFS_X"));
+    QVERIFY2(compassOfs, "COMPASS_OFS_X fact not found");
+
+    // Sends MAV_CMD_PREFLIGHT_STORAGE param1=2 which MockLink's APM branch zeroes
+    // the compass and accel offset parameters.
+    mgr->resetAllParametersToDefaults();
+    mgr->refreshAllParameters();
+
+    QVERIFY2(QTest::qWaitFor([&] { return qFuzzyIsNull(compassOfs->rawValue().toFloat()); }, 30000),
+             "COMPASS_OFS_X never refreshed to 0 after APM param reset");
+}
+
 void VehicleConfigUITestBase::clickThroughAllComponents(Vehicle *vehicle, const QString &vehicleName)
 {
     const QString prefix = vehicleName.isEmpty() ? QString() : (vehicleName + QStringLiteral(": "));

--- a/test/QmlUITests/VehicleConfigUITestBase.h
+++ b/test/QmlUITests/VehicleConfigUITestBase.h
@@ -33,6 +33,12 @@ protected:
     /// sentinel for the refresh completing.
     void resetParamsToFirmwareDefaults(Vehicle *vehicle, const QString &sentinelParamName);
 
+    /// Reset an APM MockLink to an uncalibrated state by sending
+    /// MAV_CMD_PREFLIGHT_STORAGE param1=2 (which MockLink now zeros the
+    /// calibration-indicator params for ArduPilot) and waiting for
+    /// COMPASS_OFS_X to read back as 0 from the vehicle.
+    void resetAPMParamsToUncalibrated(Vehicle *vehicle);
+
     /// Click through every vehicle component in the config sidebar and verify
     /// each one loads a panel. Hidden components (e.g. optional peripherals not
     /// present) are skipped silently. When non-empty, \a vehicleName is


### PR DESCRIPTION
## Summary

Adds full UI-level integration tests for APM compass and accelerometer calibration, backed by a new MockLink simulation of the ArduPilot calibration protocols.

## MockLink changes

- **Compass cal** (`_apmCompassCalWorker`): simulate `MAG_CAL_PROGRESS` (0→100 at ~10 Hz) and `MAG_CAL_REPORT` for all 3 active compasses (`cal_mask=0x07`); write `COMPASS_OFS*` on completion dispatched via `Qt::QueuedConnection` to avoid a data race with concurrent param reads on the main thread.
- **Accel cal** (`_apmAccelCalWorker`): drive the `ACCELCAL_VEHICLE_POS` handshake for all 6 poses (LEVEL/LEFT/RIGHT/NOSEDOWN/NOSEUP/BACK) at ~10 Hz, waiting for a `COMMAND_ACK` between each pose, then sending `ACCELCAL_VEHICLE_POS_SUCCESS` and writing `INS_ACCOFFS*` via `Qt::QueuedConnection`.
- Promote local-static tick counters to instance members (`_apmCompassCalTickCount`, `_apmAccelCalTickCount`), reset on cal start — eliminates a data race and doubled tick rate when two MockLink instances run concurrently.
- **MockLinkFTP**: write firmware default 0 for the 12 calibration offset params in `withDefaults=1` param packs so `MAV_CMD_PREFLIGHT_STORAGE(param1=2)` correctly resets them to uncalibrated state.

## QML changes (APMSensorsComponent.qml)

- Add `objectName` on the Accel/Compass buttons, Next/Cancel buttons, progress bar, and all six `VehicleRotationCal` side indicators.
- Fix null-parent anchor binding in `singleCompassOnboardResultsComponent` Column delegate.

## Test infrastructure

- `VehicleConfigUITestBase::resetAPMParamsToUncalibrated()`: resets params to firmware defaults and waits for `COMPASS_OFS_X == 0` as sentinel.

## New tests (APMSensorsCalibrationUITest)

| Test | What it verifies |
|------|-----------------|
| `_testCompassCalibration` | Full accel cal → compass cal → both indicators green |
| `_testCompassCalibrationCancel` | Start compass cal, cancel → `COMPASS_OFS_X` stays 0, indicator stays orange |
| `_testAccelCalibration` | Full accel cal → `INS_ACCOFFS_X` non-zero, indicator green |