### PR TITLE
Fix in-source build configure failure (compile_commands.json symlink)

### DIFF
--- a/cmake/Toolchain.cmake
+++ b/cmake/Toolchain.cmake
@@ -42,7 +42,8 @@ include(CompilerWarnings)
 
 # set(CMAKE_EXPORT_BUILD_DATABASE ON)
 
-if(CMAKE_EXPORT_COMPILE_COMMANDS AND NOT WIN32)
+# In-source builds make link and target the same path, which CREATE_LINK rejects.
+if(CMAKE_EXPORT_COMPILE_COMMANDS AND NOT WIN32 AND NOT "${CMAKE_BINARY_DIR}" STREQUAL "${CMAKE_SOURCE_DIR}")
     file(CREATE_LINK
         "${CMAKE_BINARY_DIR}/compile_commands.json"
         "${CMAKE_SOURCE_DIR}/compile_commands.json"


### PR DESCRIPTION
## Summary

Fixes #14525.

In-source builds (cloning into a directory and configuring in place, so `CMAKE_BINARY_DIR == CMAKE_SOURCE_DIR`) abort during configure with:

```
CMake Error at cmake/Toolchain.cmake:46 (file):
  file CREATE_LINK cannot use same file and newfile
Call Stack (most recent call first):
  CMakeLists.txt:130 (include)
```

`file(CREATE_LINK ... SYMBOLIC)` is asked to link `${CMAKE_BINARY_DIR}/compile_commands.json` to `${CMAKE_SOURCE_DIR}/compile_commands.json`. For an in-source build those resolve to the same path, which CMake rejects, and the failure cascades into the downstream `Cannot open input file ... .qml` errors reported in the issue.

## Fix

Only create the convenience symlink when the binary and source directories differ. In an in-source build `compile_commands.json` is already written at the source root, so no link is needed.

## Test

- Out-of-source build: unchanged behavior, symlink still created.
- In-source build (`cmake -S . -B .`): configure no longer fails at `Toolchain.cmake`.