### PR TITLE
Add app-close warning UI test and route in-app Close through close checks

### DIFF
--- a/src/AutoPilotPlugins/APM/APMSensorsComponent.qml
+++ b/src/AutoPilotPlugins/APM/APMSensorsComponent.qml
@@ -386,7 +386,6 @@ SetupPage {
                                     currentIndex = 3
                                     let compassId = sensorParams.rgCompassId[_compassIndex].rawValue
                                     for (let prioIndex=0; prioIndex<3; prioIndex++) {
-                                        console.log(`comparing ${compassId} with ${sensorParams.rgCompassPrio[prioIndex].rawValue} (index ${prioIndex})`)
                                         if (compassId == sensorParams.rgCompassPrio[prioIndex].rawValue) {
                                             currentIndex = prioIndex
                                             break

--- a/src/AutoPilotPlugins/PX4/AirframeComponent.qml
+++ b/src/AutoPilotPlugins/PX4/AirframeComponent.qml
@@ -190,7 +190,6 @@ SetupPage {
 
                                 onCheckedChanged: {
                                     if (checked && combo.currentIndex !== -1) {
-                                        console.log("check box change", combo.currentIndex)
                                         controller.autostartId = modelData.airframes[combo.currentIndex].autostartId
                                     }
                                 }

--- a/src/Comms/MockLink/MockConfiguration.cc
+++ b/src/Comms/MockLink/MockConfiguration.cc
@@ -19,6 +19,7 @@ MockConfiguration::MockConfiguration(const MockConfiguration *copy, QObject *par
     , _failureMode(copy->failureMode())
     , _incrementVehicleId(copy->incrementVehicleId())
     , _startArmed(copy->startArmed())
+    , _preloadMission(copy->preloadMission())
     , _cameraCaptureVideo(copy->cameraCaptureVideo())
     , _cameraCaptureImage(copy->cameraCaptureImage())
     , _cameraHasModes(copy->cameraHasModes())
@@ -74,6 +75,7 @@ void MockConfiguration::copyFrom(const LinkConfiguration *source)
     setGimbalHasRetract(mockLinkSource->gimbalHasRetract());
     setGimbalHasNeutral(mockLinkSource->gimbalHasNeutral());
     setStartArmed(mockLinkSource->startArmed());
+    setPreloadMission(mockLinkSource->preloadMission());
 }
 
 void MockConfiguration::loadSettings(QSettings &settings, const QString &root)

--- a/src/Comms/MockLink/MockConfiguration.h
+++ b/src/Comms/MockLink/MockConfiguration.h
@@ -111,6 +111,11 @@ public:
     bool startArmed() const { return _startArmed; }
     void setStartArmed(bool armed) { _startArmed = armed; }
 
+    // Test-only: when true, the simulated vehicle starts with a simple
+    // multirotor mission (takeoff, waypoint, RTL) already loaded. Not persisted.
+    bool preloadMission() const { return _preloadMission; }
+    void setPreloadMission(bool preloadMission) { _preloadMission = preloadMission; }
+
 signals:
     void firmwareChanged();
     void vehicleChanged();
@@ -146,6 +151,7 @@ private:
     uint16_t _boardVendorId = 0;
     uint16_t _boardProductId = 0;
     bool _startArmed = false;
+    bool _preloadMission = false;
 
     // Camera capability flags (defaults match current Camera 1 configuration)
     bool _cameraCaptureVideo = true;

--- a/src/Comms/MockLink/MockLink.cc
+++ b/src/Comms/MockLink/MockLink.cc
@@ -98,6 +98,10 @@ MockLink::MockLink(SharedLinkConfigurationPtr &config, QObject *parent)
         setArmed(true);
     }
 
+    if (_mockConfig->preloadMission()) {
+        _missionItemHandler->loadSimpleMultirotorMission();
+    }
+
     // Initialize ADS-B vehicles with different starting conditions
     _adsbVehicles.reserve(_numberOfVehicles);
     for (int i = 0; i < _numberOfVehicles; ++i) {
@@ -2188,7 +2192,7 @@ MockLink *MockLink::_startMockLink(MockConfiguration *mockConfig)
     return nullptr;
 }
 
-MockLink *MockLink::_startMockLinkWorker(const QString &configName, MAV_AUTOPILOT firmwareType, MAV_TYPE vehicleType, bool sendStatusText, bool enableCamera, bool enableGimbal, MockConfiguration::FailureMode_t failureMode)
+MockLink *MockLink::_startMockLinkWorker(const QString &configName, MAV_AUTOPILOT firmwareType, MAV_TYPE vehicleType, bool sendStatusText, bool enableCamera, bool enableGimbal, MockConfiguration::FailureMode_t failureMode, bool preloadMission)
 {
     MockConfiguration *const mockConfig = new MockConfiguration(configName);
 
@@ -2198,6 +2202,7 @@ MockLink *MockLink::_startMockLinkWorker(const QString &configName, MAV_AUTOPILO
     mockConfig->setEnableCamera(enableCamera);
     mockConfig->setEnableGimbal(enableGimbal);
     mockConfig->setFailureMode(failureMode);
+    mockConfig->setPreloadMission(preloadMission);
 
     return _startMockLink(mockConfig);
 }
@@ -2205,6 +2210,11 @@ MockLink *MockLink::_startMockLinkWorker(const QString &configName, MAV_AUTOPILO
 MockLink *MockLink::startPX4MockLink(bool sendStatusText, bool enableCamera, bool enableGimbal, MockConfiguration::FailureMode_t failureMode)
 {
     return _startMockLinkWorker(QStringLiteral("PX4 MultiRotor MockLink"), MAV_AUTOPILOT_PX4, MAV_TYPE_QUADROTOR, sendStatusText, enableCamera, enableGimbal, failureMode);
+}
+
+MockLink *MockLink::startPX4MockLinkWithMission(bool sendStatusText, bool enableCamera, bool enableGimbal, MockConfiguration::FailureMode_t failureMode)
+{
+    return _startMockLinkWorker(QStringLiteral("PX4 MultiRotor MockLink"), MAV_AUTOPILOT_PX4, MAV_TYPE_QUADROTOR, sendStatusText, enableCamera, enableGimbal, failureMode, true /* preloadMission */);
 }
 
 MockLink *MockLink::startGenericMockLink(bool sendStatusText, bool enableCamera, bool enableGimbal, MockConfiguration::FailureMode_t failureMode)

--- a/src/Comms/MockLink/MockLink.h
+++ b/src/Comms/MockLink/MockLink.h
@@ -90,6 +90,9 @@ public:
     /// Reset the state of the MissionItemHandler to no items, no transactions in progress.
     void resetMissionItemHandler() const { _missionItemHandler->reset(); }
 
+    /// Test-only: seeds a simple multirotor mission (takeoff, waypoint, RTL) onto the simulated vehicle.
+    void loadSimpleMultirotorMission() const { _missionItemHandler->loadSimpleMultirotorMission(); }
+
     /// Returns the filename for the simulated log file. Only available after a download is requested.
     QString logDownloadFile() const { return _logDownloadFilename; }
 
@@ -166,6 +169,7 @@ public:
     QVariant paramValue(int componentId, const QString &paramName) const { return _mapParamName2Value.value(componentId).value(paramName); }
 
     static MockLink *startPX4MockLink(bool sendStatusText, bool enableCamera, bool enableGimbal, MockConfiguration::FailureMode_t failureMode = MockConfiguration::FailNone);
+    static MockLink *startPX4MockLinkWithMission(bool sendStatusText, bool enableCamera, bool enableGimbal, MockConfiguration::FailureMode_t failureMode = MockConfiguration::FailNone);
     static MockLink *startGenericMockLink(bool sendStatusText, bool enableCamera, bool enableGimbal, MockConfiguration::FailureMode_t failureMode = MockConfiguration::FailNone);
     static MockLink *startNoInitialConnectMockLink(bool sendStatusText, bool enableCamera, bool enableGimbal, MockConfiguration::FailureMode_t failureMode = MockConfiguration::FailNone);
     static MockLink *startAPMArduCopterMockLink(bool sendStatusText, bool enableCamera, bool enableGimbal, MockConfiguration::FailureMode_t failureMode = MockConfiguration::FailNone);
@@ -282,7 +286,7 @@ private:
     int  _availableModesCount() const;
     void _moveADSBVehicle(int vehicleIndex);
 
-    static MockLink *_startMockLinkWorker(const QString &configName, MAV_AUTOPILOT firmwareType, MAV_TYPE vehicleType, bool sendStatusText, bool enableCamera, bool enableGimbal, MockConfiguration::FailureMode_t failureMode);
+    static MockLink *_startMockLinkWorker(const QString &configName, MAV_AUTOPILOT firmwareType, MAV_TYPE vehicleType, bool sendStatusText, bool enableCamera, bool enableGimbal, MockConfiguration::FailureMode_t failureMode, bool preloadMission = false);
     static MockLink *_startMockLink(MockConfiguration *mockConfig);
 
     /// Creates a file with random contents of the specified size.

--- a/src/Comms/MockLink/MockLinkMissionItemHandler.cc
+++ b/src/Comms/MockLink/MockLinkMissionItemHandler.cc
@@ -27,6 +27,38 @@ void MockLinkMissionItemHandler::_startMissionItemResponseTimer()
     _missionItemResponseTimer.start(500);
 }
 
+void MockLinkMissionItemHandler::loadSimpleMultirotorMission()
+{
+    _missionItems.clear();
+
+    constexpr double homeLatitude = 47.397;
+    constexpr double homeLongitude = 8.5455;
+    constexpr float relativeAltitude = 50.0f;
+
+    const auto makeItem = [](uint16_t seq, uint16_t command, bool current, double latitude, double longitude, float altitude) {
+        mavlink_mission_item_int_t item{};
+        item.seq = seq;
+        item.frame = MAV_FRAME_GLOBAL_RELATIVE_ALT;
+        item.command = command;
+        item.current = current ? 1 : 0;
+        item.autocontinue = 1;
+        item.x = static_cast<int32_t>(latitude * 1e7);
+        item.y = static_cast<int32_t>(longitude * 1e7);
+        item.z = altitude;
+        item.mission_type = MAV_MISSION_TYPE_MISSION;
+        return item;
+    };
+
+    // Seq 0: Takeoff
+    _missionItems[0] = makeItem(0, MAV_CMD_NAV_TAKEOFF, true, homeLatitude, homeLongitude, relativeAltitude);
+    // Seq 1: Waypoint
+    _missionItems[1] = makeItem(1, MAV_CMD_NAV_WAYPOINT, false, homeLatitude + 0.001, homeLongitude + 0.001, relativeAltitude);
+    // Seq 2: Return to launch
+    _missionItems[2] = makeItem(2, MAV_CMD_NAV_RETURN_TO_LAUNCH, false, 0.0, 0.0, 0.0);
+
+    qCDebug(MockLinkMissionItemHandlerLog) << "loadSimpleMultirotorMission seeded" << _missionItems.count() << "items";
+}
+
 bool MockLinkMissionItemHandler::handleMavlinkMessage(const mavlink_message_t &msg)
 {
     switch (msg.msgid) {

--- a/src/Comms/MockLink/MockLinkMissionItemHandler.h
+++ b/src/Comms/MockLink/MockLinkMissionItemHandler.h
@@ -64,6 +64,10 @@ public:
     /// Reset the state of the MissionItemHandler to no items, no transactions in progress.
     void reset() { _missionItems.clear(); _requestListCounts.clear(); }
 
+    /// Test-only: seeds a simple multirotor mission (takeoff, waypoint, RTL) so that a
+    /// connecting GCS will download a non-empty mission.
+    void loadSimpleMultirotorMission();
+
     void setSendHomePositionOnEmptyList(bool sendHomePositionOnEmptyList) { _sendHomePositionOnEmptyList = sendHomePositionOnEmptyList; }
 
     int requestListCount(MAV_MISSION_TYPE type) const { return _requestListCounts.value(type, 0); }

--- a/src/FactSystem/ParameterManager.cc
+++ b/src/FactSystem/ParameterManager.cc
@@ -1557,6 +1557,17 @@ bool ParameterManager::pendingWrites() const
     return _pendingWritesCount > 0;
 }
 
+#ifdef QGC_UNITTEST_BUILD
+void ParameterManager::setPendingWritesForTest(bool pending)
+{
+    const bool wasPending = (_pendingWritesCount > 0);
+    _pendingWritesCount = pending ? 1 : 0;
+    if (wasPending != pending) {
+        emit pendingWritesChanged(pending);
+    }
+}
+#endif
+
 Vehicle *ParameterManager::vehicle()
 {
     return _vehicle;

--- a/src/FactSystem/ParameterManager.h
+++ b/src/FactSystem/ParameterManager.h
@@ -90,6 +90,14 @@ public:
 
     bool pendingWrites() const;
 
+#ifdef QGC_UNITTEST_BUILD
+    /// Test-only: deterministically force the pendingWrites state on or off,
+    /// emitting pendingWritesChanged when the state actually changes. Used by
+    /// UI tests to exercise the app-close "pending parameter updates" warning
+    /// without driving the racy real PARAM_SET state machine.
+    void setPendingWritesForTest(bool pending);
+#endif
+
     Vehicle *vehicle();
 
     static MAV_PARAM_TYPE factTypeToMavType(FactMetaData::ValueType_t factType);

--- a/src/MainWindow/MainWindow.qml
+++ b/src/MainWindow/MainWindow.qml
@@ -235,13 +235,11 @@ ApplicationWindow {
         return true
     }
 
-    property string closeDialogTitle: qsTr("Close %1").arg(QGroundControl.appName)
-
     function checkForUnsavedMission() {
         if (planView._planMasterController.dirtyForSave || planView._planMasterController.dirtyForUpload) {
             let accepted = false
             _reentrantCloseGuard = true
-            _showMessageDialogWorker(mainWindow, closeDialogTitle,
+            _showMessageDialogWorker(mainWindow, qsTr("Unsaved Mission"),
                               qsTr("You have a mission edit in progress which has not been saved/uploaded. If you close you will lose changes. Are you sure you want to close?"),
                               Dialog.Yes | Dialog.No,
                               function() { accepted = true; _closeChecksToSkip |= _skipUnsavedMissionCheckMask; performCloseChecks() },
@@ -258,7 +256,7 @@ ApplicationWindow {
             if (QGroundControl.multiVehicleManager.vehicles.get(index).parameterManager.pendingWrites) {
                 let accepted = false
                 _reentrantCloseGuard = true
-                _showMessageDialogWorker(mainWindow, closeDialogTitle,
+                _showMessageDialogWorker(mainWindow, qsTr("Pending Parameter Updates"),
                     qsTr("You have pending parameter updates to a vehicle. If you close you will lose changes. Are you sure you want to close?"),
                     Dialog.Yes | Dialog.No,
                     function() { accepted = true; _closeChecksToSkip |= _skipPendingParameterWritesCheckMask; performCloseChecks() },
@@ -274,7 +272,7 @@ ApplicationWindow {
         if (QGroundControl.multiVehicleManager.activeVehicle) {
             let accepted = false
             _reentrantCloseGuard = true
-            _showMessageDialogWorker(mainWindow, closeDialogTitle,
+            _showMessageDialogWorker(mainWindow, qsTr("Active Vehicle Connections"),
                 qsTr("There are still active connections to vehicles. Are you sure you want to exit?"),
                 Dialog.Yes | Dialog.No,
                 function() { accepted = true; _closeChecksToSkip |= _skipActiveConnectionsCheckMask; performCloseChecks() },

--- a/src/MissionManager/PlanMasterController.cc
+++ b/src/MissionManager/PlanMasterController.cc
@@ -260,7 +260,9 @@ void PlanMasterController::_loadGeoFenceComplete(void)
 void PlanMasterController::_loadRallyPointsComplete(void)
 {
     qCDebug(PlanMasterControllerLog) << "PlanMasterController::_loadRallyPointsComplete";
-    _setDirtyStates(containsItems() /* dirtyForSave */, false /* dirtyForUpload */);
+    // A plan just downloaded from the vehicle reflects exactly what is on the vehicle.
+    // The user has made no edits, so it must not be dirty for save or upload.
+    _setDirtyStates(false /* dirtyForSave */, false /* dirtyForUpload */);
 }
 
 void PlanMasterController::_sendMissionComplete(void)

--- a/src/QmlControls/QGCPopupDialog.qml
+++ b/src/QmlControls/QGCPopupDialog.qml
@@ -224,6 +224,7 @@ Popup {
 
             QGCLabel {
                 id:                 titleLabel
+                objectName:         "popupDialog_title"
                 Layout.fillWidth:   true
                 text:               root.title
                 font.pointSize:     ScreenTools.mediumFontPointSize

--- a/src/Toolbar/SelectViewDropdown.qml
+++ b/src/Toolbar/SelectViewDropdown.qml
@@ -99,7 +99,11 @@ ToolIndicatorPage {
                 imageResource: "/res/OpenDoor.svg"
                 onClicked: {
                     if (mainWindow.allowViewSwitch()) {
-                        mainWindow.finishCloseProcess()
+                        mainWindow.closeIndicatorDrawer()
+                        // Route through the window close handler so the unsaved
+                        // mission / pending parameter / active connection checks
+                        // run, matching the desktop window-close behavior.
+                        mainWindow.close()
                     }
                 }
             }

--- a/test/MissionManager/PlanMasterControllerTest.cc
+++ b/test/MissionManager/PlanMasterControllerTest.cc
@@ -78,7 +78,7 @@ void PlanMasterControllerTest::_testDirtyFlagsMatrix_data()
     //
     // | State \ Action | Upload OK | Clear | SaveDirty=true | Load plan | Save file OK | Clear save-dirty | Download w/ items | Download empty |
     // |----------------|-----------|-------|----------------|-----------|--------------|------------------|-------------------|----------------|
-    // | dirtyForSave   | unchanged | false | true           | false     | false        | false            | true              | false          |
+    // | dirtyForSave   | unchanged | false | true           | false     | false        | false            | false             | false          |
     // | dirtyForUpload | false     | false | true           | true      | unchanged    | unchanged        | false             | false          |
 
     // Data columns:
@@ -112,7 +112,7 @@ void PlanMasterControllerTest::_testDirtyFlagsMatrix_data()
         { SaveFalseOnSuccessfulLoad,          "save false on successful load",       DirtyStateFalse,     DirtyStateTrue },
         { ClearSaveDirtyPreservesUploadTrue,  "clear save dirty keeps upload true",  DirtyStateFalse,     DirtyStateUnchanged },
         { ClearSaveDirtyPreservesUploadFalse, "clear save dirty keeps upload false", DirtyStateFalse,     DirtyStateUnchanged },
-        { DownloadWithItemsDirtyForSave,      "download with items marks save dirty",DirtyStateTrue,      DirtyStateFalse },
+        { DownloadWithItemsNotDirtyForSave,   "download with items stays clean",     DirtyStateFalse,     DirtyStateFalse },
         { DownloadEmptyNotDirtyForSave,       "download empty keeps save clean",     DirtyStateFalse,     DirtyStateFalse },
     };
 
@@ -160,7 +160,7 @@ void PlanMasterControllerTest::_testDirtyFlagsMatrix()
     QVERIFY(initialDirtyForUpload != DirtyStateUnchanged);
 
     // Pre-load items for scenarios that need containsItems() == true
-    if (scenario == DownloadWithItemsDirtyForSave) {
+    if (scenario == DownloadWithItemsNotDirtyForSave) {
         _masterController->loadFromFile(":/unittest/MissionPlanner.waypoints");
     }
 
@@ -226,7 +226,7 @@ void PlanMasterControllerTest::_testDirtyFlagsMatrix()
     case ClearSaveDirtyPreservesUploadFalse:
         _masterController->_setDirtyForSave(false);
         break;
-    case DownloadWithItemsDirtyForSave: {
+    case DownloadWithItemsNotDirtyForSave: {
         QVERIFY(_masterController->containsItems());
         const bool invoked = QMetaObject::invokeMethod(_masterController, "_loadRallyPointsComplete", Qt::DirectConnection);
         QVERIFY(invoked);

--- a/test/MissionManager/PlanMasterControllerTest.h
+++ b/test/MissionManager/PlanMasterControllerTest.h
@@ -53,7 +53,7 @@ private:
         SaveFalseOnSuccessfulLoad,
         ClearSaveDirtyPreservesUploadTrue,
         ClearSaveDirtyPreservesUploadFalse,
-        DownloadWithItemsDirtyForSave,
+        DownloadWithItemsNotDirtyForSave,
         DownloadEmptyNotDirtyForSave,
     };
 

--- a/test/QmlUITests/AppCloseWarningUITest.cc
+++ b/test/QmlUITests/AppCloseWarningUITest.cc
@@ -1,0 +1,222 @@
+#include "AppCloseWarningUITest.h"
+
+#include <QtCore/QPointer>
+#include <QtCore/QRegularExpression>
+#include <QtCore/QScopeGuard>
+#include <QtQuick/QQuickItem>
+#include <QtQuick/QQuickWindow>
+#include <QtTest/QTest>
+
+#include "MissionController.h"
+#include "MockLink.h"
+#include "MultiVehicleManager.h"
+#include "ParameterManager.h"
+#include "PlanMasterController.h"
+#include "Vehicle.h"
+
+UT_REGISTER_TEST(AppCloseWarningUITest, TestLabel::Integration, TestLabel::MissionManager)
+
+bool AppCloseWarningUITest::_forcePlanViewMissionDirty()
+{
+    QQuickItem *planView = _window ? _window->findChild<QQuickItem *>(QStringLiteral("mainView_plan")) : nullptr;
+    if (!planView) {
+        QTest::qFail("Could not find Plan view item (mainView_plan)", __FILE__, __LINE__);
+        return false;
+    }
+
+    auto *masterController = qvariant_cast<PlanMasterController *>(planView->property("_planMasterController"));
+    if (!masterController) {
+        QTest::qFail("Plan view _planMasterController property is not a PlanMasterController", __FILE__, __LINE__);
+        return false;
+    }
+
+    // Marking the mission controller dirty propagates to the master controller's
+    // dirtyForSave/dirtyForUpload, which is exactly what the unsaved-mission close
+    // check reads. The plan need not contain real items for the check to fire.
+    masterController->missionController()->setDirty(true);
+    return true;
+}
+
+void AppCloseWarningUITest::_testCloseWarningMatrix_data()
+{
+    // Each row sets up some combination of the three close-warning conditions and
+    // chooses where to reject. The three dialogs always appear in the fixed order
+    // Unsaved Mission -> Pending Parameter Updates -> Active Vehicle Connections.
+    //
+    //   mission       (M): force the Plan view mission dirty-for-save.
+    //   pendingWrites (P): force a vehicle parameter pending-write (requires a
+    //                      connection, since pending writes belong to a vehicle).
+    //   connection    (C): keep a MockLink connected.
+    //   rejectAtStep     : 1-based index into the *shown* dialog list at which to
+    //                      press No (cancel close). 0 means accept every dialog,
+    //                      which must close the app.
+    //
+    // Rows with P set but C clear are impossible (pending writes cannot outlive
+    // their vehicle) and are therefore omitted.
+    QTest::addColumn<bool>("mission");
+    QTest::addColumn<bool>("pendingWrites");
+    QTest::addColumn<bool>("connection");
+    QTest::addColumn<int>("rejectAtStep");
+
+    // No conditions: closing must proceed immediately with no warning dialog.
+    QTest::newRow("none-acceptAll")            << false << false << false << 0;
+
+    // Connection only.
+    QTest::newRow("C-acceptAll")               << false << false << true  << 0;
+    QTest::newRow("C-rejectConnection")        << false << false << true  << 1;
+
+    // Pending writes + connection.
+    QTest::newRow("PC-acceptAll")              << false << true  << true  << 0;
+    QTest::newRow("PC-rejectPending")          << false << true  << true  << 1;
+    QTest::newRow("PC-rejectConnection")       << false << true  << true  << 2;
+
+    // Mission only (offline, no connection).
+    QTest::newRow("M-acceptAll")               << true  << false << false << 0;
+    QTest::newRow("M-rejectMission")           << true  << false << false << 1;
+
+    // Mission + connection.
+    QTest::newRow("MC-acceptAll")              << true  << false << true  << 0;
+    QTest::newRow("MC-rejectMission")          << true  << false << true  << 1;
+    QTest::newRow("MC-rejectConnection")       << true  << false << true  << 2;
+
+    // Mission + pending writes + connection (all three dialogs).
+    QTest::newRow("MPC-acceptAll")             << true  << true  << true  << 0;
+    QTest::newRow("MPC-rejectMission")         << true  << true  << true  << 1;
+    QTest::newRow("MPC-rejectPending")         << true  << true  << true  << 2;
+    QTest::newRow("MPC-rejectConnection")      << true  << true  << true  << 3;
+}
+
+void AppCloseWarningUITest::_testCloseWarningMatrix()
+{
+    QFETCH(bool, mission);
+    QFETCH(bool, pendingWrites);
+    QFETCH(bool, connection);
+    QFETCH(int, rejectAtStep);
+
+    // Pending writes belong to a vehicle, so they can only exist alongside a
+    // connection. The data set never produces this combination.
+    QVERIFY2(!pendingWrites || connection, "Invalid matrix row: pending writes without a connection");
+
+    // Incidental one-time startup message when the map cache DB is upgraded.
+    ignoreLogMessage("API.QGCApplication.AppMessage", QtDebugMsg,
+                     QRegularExpression(QStringLiteral("Offline Map Cache database has been upgraded")));
+
+    startUI();
+    if (QTest::currentTestFailed()) {
+        return;
+    }
+
+    QPointer<MockLink> mockLink;
+    Vehicle *vehicle = nullptr;
+    bool appClosed = false;
+
+    // Teardown: on reject paths the window is still open and any MockLink is still
+    // connected, so disconnect before tearing down (matching runWithMockLink). On
+    // accept-all paths finishCloseProcess() has already shut the links down and
+    // closed the window, so only the engine needs destroying.
+    const auto guard = qScopeGuard([&] {
+        if (!appClosed) {
+            disconnectMockLink(mockLink);
+        }
+        closeUIWindow();
+        destroyUIEngine();
+    });
+
+    if (connection) {
+        mockLink = connectMockLinkAndWaitReady(
+            [] { return MockLink::startPX4MockLink(false /* sendStatusText */, false /* enableCamera */, false /* enableGimbal */); },
+            vehicle);
+        if (!mockLink) {
+            return;
+        }
+    }
+
+    if (mission) {
+        if (!_forcePlanViewMissionDirty()) {
+            return;
+        }
+    }
+
+    if (pendingWrites) {
+        QVERIFY2(vehicle, "Pending writes requested but no vehicle is connected");
+        vehicle->parameterManager()->setPendingWritesForTest(true);
+    }
+
+    QVERIFY2(clickToolSelectDropdownButton(QStringLiteral("toolbar_viewClose")),
+             "Failed to click Close button in tool select dropdown");
+
+    // The dialogs that should appear, in their fixed presentation order.
+    QStringList expectedDialogs;
+    if (mission)       expectedDialogs << QStringLiteral("Unsaved Mission");
+    if (pendingWrites) expectedDialogs << QStringLiteral("Pending Parameter Updates");
+    if (connection)    expectedDialogs << QStringLiteral("Active Vehicle Connections");
+
+    for (int step = 0; step < expectedDialogs.size(); ++step) {
+        const QString &title = expectedDialogs.at(step);
+        QVERIFY2(waitForDialog(title),
+                 qPrintable(QStringLiteral("Expected close-warning dialog not shown: %1").arg(title)));
+
+        const bool rejectHere = (rejectAtStep != 0) && (step == rejectAtStep - 1);
+        if (rejectHere) {
+            QVERIFY2(rejectDialog(),
+                     qPrintable(QStringLiteral("Failed to reject dialog: %1").arg(title)));
+
+            // Rejecting cancels the close: the window must stay open and no later
+            // dialog in the sequence may appear.
+            QVERIFY2(_window && _window->isVisible(),
+                     qPrintable(QStringLiteral("Window closed after rejecting dialog: %1").arg(title)));
+            if (step + 1 < expectedDialogs.size()) {
+                QVERIFY2(!dialogVisible(expectedDialogs.at(step + 1)),
+                         qPrintable(QStringLiteral("Later dialog shown after a reject: %1").arg(expectedDialogs.at(step + 1))));
+            }
+            return;
+        }
+
+        QVERIFY2(acceptDialog(),
+                 qPrintable(QStringLiteral("Failed to accept dialog: %1").arg(title)));
+    }
+
+    // Every shown dialog (if any) was accepted, so the app must finish closing.
+    QVERIFY2(QTest::qWaitFor([this] { return _window && !_window->isVisible(); }, 3000),
+             "App did not close after accepting all close-warning dialogs");
+    appClosed = true;
+}
+
+void AppCloseWarningUITest::_testNoUnsavedMissionWarningForDownloadedMission()
+{
+    // Incidental one-time startup message when the map cache DB is upgraded.
+    ignoreLogMessage("API.QGCApplication.AppMessage", QtDebugMsg,
+                     QRegularExpression(QStringLiteral("Offline Map Cache database has been upgraded")));
+
+    // connectMockLinkAndWaitReady (used by runWithMockLink) waits for the
+    // vehicle's initialConnectComplete signal. The InitialConnectStateMachine
+    // requests the mission as one of its states, so by the time the body runs
+    // the mission has been downloaded from the vehicle and the Plan view's
+    // PlanMasterController has loaded it.
+    runWithMockLink(
+        [] { return MockLink::startPX4MockLinkWithMission(false /* sendStatusText */, false /* enableCamera */, false /* enableGimbal */); },
+        [this](QPointer<MockLink> mockLink, Vehicle *vehicle) {
+            Q_UNUSED(mockLink);
+            Q_UNUSED(vehicle);
+
+            // runWithMockLink waits for initialConnectComplete. The
+            // InitialConnectStateMachine blocks on completion of the mission,
+            // geofence, and rally point loads before that signal fires, so the
+            // plan is fully downloaded by the time this body runs.
+            QVERIFY2(clickToolSelectDropdownButton(QStringLiteral("toolbar_viewClose")),
+                     "Failed to click Close button in tool select dropdown");
+
+            // The active-connection check runs only after the unsaved-mission check
+            // passes. Waiting for its dialog to appear proves the mission check did
+            // not block — i.e. the downloaded plan was not treated as dirty.
+            QVERIFY2(waitForDialog(QStringLiteral("Active Vehicle Connections")),
+                     "Active vehicle connection warning dialog was not shown on close");
+
+            // A plan that was just downloaded from the vehicle reflects exactly what is
+            // on the vehicle. The user has made no edits, so the unsaved-mission warning
+            // must NOT appear. Otherwise closing the app would wrongly warn about a
+            // "mission edit in progress" even though nothing was edited.
+            QVERIFY2(!dialogVisible(QStringLiteral("Unsaved Mission")),
+                     "Unsaved mission warning shown for a freshly downloaded, unedited plan");
+        });
+}

--- a/test/QmlUITests/AppCloseWarningUITest.h
+++ b/test/QmlUITests/AppCloseWarningUITest.h
@@ -1,0 +1,35 @@
+#pragma once
+
+#include "QmlUITestBase.h"
+
+/// UI tests for the application close warning dialogs.
+///
+/// On close MainWindow runs a sequence of checks (unsaved mission, pending
+/// parameter writes, active vehicle connections), each of which raises its own
+/// warning dialog in that fixed order. Accepting a warning advances to the next
+/// check; rejecting one cancels the close. The matrix test drives every
+/// reachable permutation of the three conditions and every accept/reject
+/// decision through the real toolbar Q-logo dropdown Close button.
+///
+/// A separate test verifies that a freshly downloaded (unedited) mission does
+/// NOT raise the unsaved-mission warning, because a downloaded plan reflects
+/// exactly what is on the vehicle and must not be considered dirty.
+class AppCloseWarningUITest : public QmlUITestBase
+{
+    Q_OBJECT
+
+public:
+    AppCloseWarningUITest() = default;
+
+private slots:
+    void _testCloseWarningMatrix_data();
+    void _testCloseWarningMatrix();
+    void _testNoUnsavedMissionWarningForDownloadedMission();
+
+private:
+    /// Force the Plan view's (offline) mission into a dirty-for-save state so the
+    /// unsaved-mission close warning fires, without editing the mission through
+    /// the UI. Returns false (after recording a test failure) if the plan
+    /// controller cannot be reached.
+    bool _forcePlanViewMissionDirty();
+};

--- a/test/QmlUITests/CMakeLists.txt
+++ b/test/QmlUITests/CMakeLists.txt
@@ -24,6 +24,8 @@ target_sources(${CMAKE_PROJECT_NAME}
         ${CMAKE_CURRENT_SOURCE_DIR}/APMSensorsCalibrationUITest.h
         ${CMAKE_CURRENT_SOURCE_DIR}/PX4AirframeSetupUITest.cc
         ${CMAKE_CURRENT_SOURCE_DIR}/PX4AirframeSetupUITest.h
+        ${CMAKE_CURRENT_SOURCE_DIR}/AppCloseWarningUITest.cc
+        ${CMAKE_CURRENT_SOURCE_DIR}/AppCloseWarningUITest.h
 )
 
 target_include_directories(${CMAKE_PROJECT_NAME}
@@ -39,3 +41,4 @@ add_qgc_test(PlanViewUITest LABELS Integration NoSanitizer TIMEOUT 120)
 add_qgc_test(PX4SensorsCalibrationUITest LABELS Integration NoSanitizer TIMEOUT 180)
 add_qgc_test(APMSensorsCalibrationUITest LABELS Integration NoSanitizer TIMEOUT 240)
 add_qgc_test(PX4AirframeSetupUITest LABELS Integration NoSanitizer TIMEOUT 120)
+add_qgc_test(AppCloseWarningUITest LABELS Integration NoSanitizer TIMEOUT 120)

--- a/test/QmlUITests/PlanViewUITest.cc
+++ b/test/QmlUITests/PlanViewUITest.cc
@@ -97,9 +97,7 @@ void PlanViewUITest::_testPlanViewStates()
     if (QTest::currentTestFailed()) return;
 
     // Navigate to Plan view
-    QVERIFY2(clickButton(QStringLiteral("toolbar_qgcLogo")), "Failed to click Q logo button");
-    QVERIFY2(findVisibleItem(_rootItem, QStringLiteral("toolbar_viewPlan"), 2000), "Plan view button not found");
-    QVERIFY2(clickButton(QStringLiteral("toolbar_viewPlan")), "Failed to click Plan view button");
+    QVERIFY2(clickToolSelectDropdownButton(QStringLiteral("toolbar_viewPlan")), "Failed to navigate to Plan view");
     QVERIFY2(findVisibleItem(_rootItem, QStringLiteral("mainView_plan"), 2000), "Plan view did not appear");
     QTest::qWait(_viewDelay);
 

--- a/test/QmlUITests/QmlUITestBase.cc
+++ b/test/QmlUITests/QmlUITestBase.cc
@@ -21,6 +21,8 @@
 #include "QGCFileDialogController.h"
 #include "QGCImageProvider.h"
 #include "SettingsManager.h"
+#include "TerrainQuery.h"
+#include "TerrainTest.h"
 #include "Vehicle.h"
 
 void QmlUITestBase::startUI()
@@ -38,6 +40,12 @@ void QmlUITestBase::startUI()
     MAVLinkProtocol::instance()->init();
     MultiVehicleManager::instance()->init();
 
+    // Replace the live terrain backend with the synthetic unit-test provider so
+    // mission editing in the UI never makes real HTTP terrain requests. Live
+    // fetches can return HTTP 500, emitting warning logs that trip the
+    // strict-mode log check. Restored to the default backend in stopUI().
+    TerrainAtCoordinateBatchManager::instance()->setTerrainQueryInterface(new UnitTestTerrainQuery());
+
     // Suppress first-run prompts so they don't block the UI
     AppSettings *appSettings = SettingsManager::instance()->appSettings();
     const QList<int> promptIds = QGCCorePlugin::instance()->firstRunPromptStdIds();
@@ -54,6 +62,17 @@ void QmlUITestBase::startUI()
                      QRegularExpression(QStringLiteral("Populating font family aliases")));
     ignoreLogMessage("default", QtWarningMsg,
                      QRegularExpression(QStringLiteral("QRhiGles2")));
+
+    // The synthetic terrain provider installed above only covers coordinate
+    // queries routed through TerrainAtCoordinateBatchManager. Path/carpet queries
+    // (TerrainPathQuery, TerrainAreaQuery) hardcode their own online backend and
+    // hit the live terrain server, which intermittently returns HTTP errors. Those
+    // are external-server reachability warnings, never something a UI smoke test
+    // should assert on, so ignore them to keep the full run deterministic.
+    ignoreLogMessage("QtLocationPlugin.QGeoTiledMapReplyQGC", QtWarningMsg,
+                     QRegularExpression(QStringLiteral("Error transferring")));
+    ignoreLogMessage("Terrain.TerrainTileManager", QtWarningMsg,
+                     QRegularExpression(QStringLiteral("Elevation tile fetching returned error")));
 #ifdef QT_DEBUG
     // Debug builds on macOS are ad-hoc signed with an unbound Info.plist, so
     // macOS never shows the camera permission dialog and silently denies access.
@@ -133,6 +152,11 @@ void QmlUITestBase::stopUI()
 {
     closeUIWindow();
     destroyUIEngine();
+
+    // Restore the default terrain backend. The batch manager is a process-global
+    // singleton shared across all tests in a single-process --unittest run, so the
+    // mock must not leak into later tests.
+    TerrainAtCoordinateBatchManager::instance()->setTerrainQueryInterface(new TerrainOfflineQuery());
 }
 
 void QmlUITestBase::_verifyFileDialogTestHookConsumed()
@@ -152,6 +176,75 @@ bool QmlUITestBase::clickButton(const QString &objectName)
     const QPointF center = btn->mapToScene(QPointF(btn->width() / 2, btn->height() / 2));
     QTest::mouseClick(_window, Qt::LeftButton, Qt::NoModifier, center.toPoint());
     return true;
+}
+
+bool QmlUITestBase::clickToolSelectDropdownButton(const QString &viewObjectName, int timeoutMs)
+{
+    if (!clickButton(QStringLiteral("toolbar_qgcLogo"))) {
+        QTest::qFail("Failed to click Q logo button", __FILE__, __LINE__);
+        return false;
+    }
+    if (!findVisibleItem(_rootItem, viewObjectName, timeoutMs)) {
+        QTest::qFail(qPrintable(QStringLiteral("Tool select dropdown button not found: %1").arg(viewObjectName)),
+                     __FILE__, __LINE__);
+        return false;
+    }
+    if (!clickButton(viewObjectName)) {
+        QTest::qFail(qPrintable(QStringLiteral("Failed to click tool select dropdown button: %1").arg(viewObjectName)),
+                     __FILE__, __LINE__);
+        return false;
+    }
+    return true;
+}
+
+// Recursively search the visible item tree for an item with the given
+// objectName whose "text" property contains the given substring. Used to
+// locate a specific dialog by its title label.
+static QQuickItem *_findVisibleItemWithText(QQuickItem *root, const QString &objectName, const QString &textSubstring)
+{
+    if (!root || !root->isVisible()) {
+        return nullptr;
+    }
+    if (root->objectName() == objectName) {
+        const QVariant textProp = root->property("text");
+        if (textProp.isValid() && textProp.toString().contains(textSubstring)) {
+            return root;
+        }
+    }
+    const auto children = root->childItems();
+    for (auto *child : children) {
+        if (auto *found = _findVisibleItemWithText(child, objectName, textSubstring)) {
+            return found;
+        }
+    }
+    return nullptr;
+}
+
+bool QmlUITestBase::dialogVisible(const QString &titleSubstring)
+{
+    return _findVisibleItemWithText(_rootItem, QStringLiteral("popupDialog_title"), titleSubstring) != nullptr;
+}
+
+bool QmlUITestBase::waitForDialog(const QString &titleSubstring, int timeoutMs)
+{
+    return waitForCondition([this, &titleSubstring] { return dialogVisible(titleSubstring); },
+                            timeoutMs, QStringLiteral("dialog '%1'").arg(titleSubstring));
+}
+
+bool QmlUITestBase::acceptDialog(int timeoutMs)
+{
+    if (!findVisibleItem(_rootItem, QStringLiteral("popupDialog_acceptButton"), timeoutMs)) {
+        return false;
+    }
+    return clickButton(QStringLiteral("popupDialog_acceptButton"));
+}
+
+bool QmlUITestBase::rejectDialog(int timeoutMs)
+{
+    if (!findVisibleItem(_rootItem, QStringLiteral("popupDialog_rejectButton"), timeoutMs)) {
+        return false;
+    }
+    return clickButton(QStringLiteral("popupDialog_rejectButton"));
 }
 
 // Format a property value for failure messages: quote strings, otherwise use

--- a/test/QmlUITests/QmlUITestBase.h
+++ b/test/QmlUITests/QmlUITestBase.h
@@ -74,6 +74,29 @@ protected:
     /// Returns false if the item cannot be found.
     bool clickButton(const QString &objectName);
 
+    /// Open the toolbar Q-logo tool-select dropdown and click the entry with
+    /// objectName \a viewObjectName (e.g. "toolbar_viewPlan", "toolbar_viewClose").
+    /// Clicks the Q logo, waits up to \a timeoutMs for the entry to appear, then
+    /// clicks it. Returns false (after recording a test failure) if any step fails.
+    bool clickToolSelectDropdownButton(const QString &viewObjectName, int timeoutMs = 2000);
+
+    /// Wait up to \a timeoutMs for a QGCPopupDialog whose title contains
+    /// \a titleSubstring to become visible. Matches against the dialog title
+    /// label (objectName "popupDialog_title"). Returns true once found.
+    bool waitForDialog(const QString &titleSubstring, int timeoutMs = 3000);
+
+    /// Returns true if a QGCPopupDialog whose title contains \a titleSubstring
+    /// is currently visible. Does not wait — use to assert a dialog is absent.
+    bool dialogVisible(const QString &titleSubstring);
+
+    /// Wait up to \a timeoutMs for the popup dialog accept button to become
+    /// visible, then click it. Returns false if the button never appears.
+    bool acceptDialog(int timeoutMs = 3000);
+
+    /// Wait up to \a timeoutMs for the popup dialog reject button to become
+    /// visible, then click it. Returns false if the button never appears.
+    bool rejectDialog(int timeoutMs = 3000);
+
     /// Verify the enabled state of a visible item found by \a objectName,
     /// waiting up to 2 seconds for bindings to settle. Returns false (after
     /// recording a test failure) if the item is missing or the enabled state

--- a/test/QmlUITests/TopLevelViewsTest.cc
+++ b/test/QmlUITests/TopLevelViewsTest.cc
@@ -18,14 +18,9 @@ void TopLevelViewsTest::_testNavigateViews()
 
     // Navigate to a view and verify which main panels become visible
     auto navigateAndVerify = [this](const QString &view, bool expectFlyView, bool expectPlanView, bool expectToolDrawer) {
-        QVERIFY2(clickButton(QStringLiteral("toolbar_qgcLogo")),
-                 qPrintable(QStringLiteral("Failed to click Q logo button before %1").arg(view)));
-
         const QString buttonName = QStringLiteral("toolbar_view") + view;
-        QVERIFY2(findVisibleItem(_rootItem, buttonName, 2000),
-                 qPrintable(QStringLiteral("View button not found: %1").arg(buttonName)));
-        QVERIFY2(clickButton(buttonName),
-                 qPrintable(QStringLiteral("Failed to click %1").arg(buttonName)));
+        QVERIFY2(clickToolSelectDropdownButton(buttonName),
+                 qPrintable(QStringLiteral("Failed to navigate to %1").arg(view)));
 
         const int flyTimeout    = expectFlyView    ? 1000 : 0;
         const int planTimeout   = expectPlanView   ? 1000 : 0;

--- a/test/QmlUITests/VehicleConfigUITestBase.cc
+++ b/test/QmlUITests/VehicleConfigUITestBase.cc
@@ -12,10 +12,8 @@
 
 void VehicleConfigUITestBase::navigateToConfigureView()
 {
-    QVERIFY2(clickButton(QStringLiteral("toolbar_qgcLogo")), "Failed to click Q logo button");
-    QVERIFY2(findVisibleItem(_rootItem, QStringLiteral("toolbar_viewConfigure"), 2000),
-             "toolbar_viewConfigure button not found");
-    QVERIFY2(clickButton(QStringLiteral("toolbar_viewConfigure")), "Failed to click Configure button");
+    QVERIFY2(clickToolSelectDropdownButton(QStringLiteral("toolbar_viewConfigure")),
+             "Failed to navigate to Configure view");
     QTest::qWait(_viewDelay);
 
     QVERIFY2(findVisibleItem(_rootItem, QStringLiteral("vehicleConfig_root"), 3000),

--- a/test/UnitTestFramework/UnitTest.cc
+++ b/test/UnitTestFramework/UnitTest.cc
@@ -806,6 +806,16 @@ void UnitTest::init()
     _expectedLogMessages->pending.clear();
     _expectedLogMessages->consumedMessageIndices.clear();
 
+    // MockLink emulates an Open Drone ID device (sends OPEN_DRONE_ID_ARM_STATUS at
+    // 1Hz), which makes RemoteIDManager start its periodic send timer. That timer
+    // warns about the missing GCS GPS fix — but headless unit tests never have a
+    // GCS GPS source, so this is expected noise. Whether the timer ticks inside a
+    // given test's strict-mode capture window is timing-dependent, so without this
+    // ignore the warning lands in a random test each full run, causing flaky
+    // failures across many vehicle/UI tests. Ignore it globally.
+    ignoreLogMessage("Vehicle.RemoteIDManager", QtWarningMsg,
+                     QRegularExpression(QStringLiteral("^GCS GPS error:")));
+
     // Start capturing log messages for this test (cleared from previous test)
     LogManager::clearCapturedMessages();
     LogManager::setCaptureEnabled(true);


### PR DESCRIPTION
## Description

Adds `AppCloseWarningUITest`, a data-driven UI test that exercises every reachable permutation of the three app-close warning dialogs — **Unsaved Mission**, **Pending Parameter Updates**, and **Active Vehicle Connections** — driven through the real toolbar Close button. While building it, this surfaced and fixes a real bug where the in-app Close button bypassed the close checks entirely.

Related to #14510 (the `_loadRallyPointsComplete` mission-dirty fix this test verifies).

### Production fixes
- **In-app Close now runs the close checks.** `SelectViewDropdown`'s Close button routed through `finishCloseProcess()`, which closed immediately and skipped the unsaved-mission / pending-writes / active-connection prompts. It now calls `mainWindow.close()` so `onClosing → performCloseChecks()` runs.
- `MainWindow.qml` gives each of the three close-check dialogs a distinct title.
- `PlanMasterController::_loadRallyPointsComplete` unconditionally clears `dirtyForSave` (carries the #14510 fix), so a freshly downloaded mission isn't flagged dirty.

### Test infrastructure
- `ParameterManager::setPendingWritesForTest()` test-only hook (guarded by `QGC_UNITTEST_BUILD`) for deterministic pending-writes state.
- `MockLink` mission-handler support for deterministic mission download in tests.
- `QmlUITestBase` helpers for dialog handling and tool-select dropdown navigation.

### Full-run flakiness fixes
These eliminate the dominant intermittent failures seen when running the whole suite in a single process (24 → 9 failures locally):
- Install the synthetic `UnitTestTerrainQuery` in `QmlUITestBase` so UI tests don't hit the live terrain server, and ignore terrain network-error warnings for the path/carpet queries that hardcode the online backend.
- Globally ignore the benign `RemoteIDManager` "GCS GPS error" warning — emitted at random by the MockLink Open Drone ID 1 Hz timer in headless tests that have no GCS GPS source.
- Remove stray `console.log()` calls in `APMSensorsComponent.qml` and `AirframeComponent.qml` that tripped strict-mode log checking.

## Type of Change
- [x] Bug fix (non-breaking change that fixes an issue)
- [x] Added/updated unit tests

## Testing
- [x] Tested locally (macOS)
- `AppCloseWarningUITest` passes (18 cases). Sensor/airframe/plan UI tests and `TerrainQueryTest` pass in single-process full runs without the previously flaky strict-mode failures.

## Related Issues
Related to #14510
