### PR TITLE
style(FirmwareUpgrade): clang-format FirmwareImage and FirmwareUpgradeController

### DIFF
--- a/src/Vehicle/VehicleSetup/FirmwareImage.cc
+++ b/src/Vehicle/VehicleSetup/FirmwareImage.cc
@@ -1,12 +1,13 @@
 #include "FirmwareImage.h"
-#include "JsonParsing.h"
-#include "QGCApplication.h"
-#include "FirmwarePlugin.h"
-#include "FirmwarePluginManager.h"
-#include "Bootloader.h"
-#include "QGCLoggingCategory.h"
 
 #include <QtCore/QDir>
+
+#include "Bootloader.h"
+#include "FirmwarePlugin.h"
+#include "FirmwarePluginManager.h"
+#include "JsonParsing.h"
+#include "QGCApplication.h"
+#include "QGCLoggingCategory.h"
 
 QGC_LOGGING_CATEGORY(FirmwareImageLog, "Vehicle.VehicleSetup.FirmwareImage")
 QGC_LOGGING_CATEGORY(FirmwareImageVerboseLog, "Vehicle.VehicleSetup.FirmwareImage.Verbose")
@@ -16,12 +17,7 @@ QGC_LOGGING_CATEGORY(FirmwareImageVerboseLog, "Vehicle.VehicleSetup.FirmwareImag
 #include <QtCore/QJsonObject>
 #include <QtCore/QTextStream>
 
-FirmwareImage::FirmwareImage(QObject* parent) :
-    QObject(parent),
-    _imageSize(0)
-{
-
-}
+FirmwareImage::FirmwareImage(QObject* parent) : QObject(parent), _imageSize(0) {}
 
 bool FirmwareImage::load(const QString& imageFilename, uint32_t boardId)
 {
@@ -55,7 +51,7 @@ bool FirmwareImage::_readByteFromStream(QTextStream& stream, uint8_t& byte)
     }
 
     bool success;
-    byte = (uint8_t)hex.toInt(&success, 16);
+    byte = (uint8_t) hex.toInt(&success, 16);
 
     return success;
 }
@@ -69,7 +65,7 @@ bool FirmwareImage::_readWordFromStream(QTextStream& stream, uint16_t& word)
     }
 
     bool success;
-    word = (uint16_t)hex.toInt(&success, 16);
+    word = (uint16_t) hex.toInt(&success, 16);
 
     return success;
 }
@@ -99,7 +95,8 @@ bool FirmwareImage::_ihxLoad(const QString& ihxFilename)
 
     QFile ihxFile(ihxFilename);
     if (!ihxFile.open(QIODevice::ReadOnly | QIODevice::Text)) {
-        emit statusMessage(QString("Unable to open firmware file %1, error: %2").arg(ihxFilename, ihxFile.errorString()));
+        emit statusMessage(
+            QString("Unable to open firmware file %1, error: %2").arg(ihxFilename, ihxFile.errorString()));
         return false;
     }
 
@@ -111,16 +108,14 @@ bool FirmwareImage::_ihxLoad(const QString& ihxFilename)
             return false;
         }
 
-        uint8_t     blockByteCount;
-        uint16_t    address;
-        uint8_t     recordType;
-        QByteArray  bytes;
-        uint8_t     crc;
+        uint8_t blockByteCount;
+        uint16_t address;
+        uint8_t recordType;
+        QByteArray bytes;
+        uint8_t crc;
 
-        if (!_readByteFromStream(stream, blockByteCount) ||
-            !_readWordFromStream(stream, address) ||
-            !_readByteFromStream(stream, recordType) ||
-            !_readBytesFromStream(stream, blockByteCount, bytes) ||
+        if (!_readByteFromStream(stream, blockByteCount) || !_readWordFromStream(stream, address) ||
+            !_readByteFromStream(stream, recordType) || !_readBytesFromStream(stream, blockByteCount, bytes) ||
             !_readByteFromStream(stream, crc)) {
             emit statusMessage(tr("Incorrectly formatted line in .ihx file, line too short"));
             return false;
@@ -147,7 +142,8 @@ bool FirmwareImage::_ihxLoad(const QString& ihxFilename)
             if (appendToLastBlock) {
                 _ihxBlocks[_ihxBlocks.length() - 1].bytes += bytes;
                 // Too noisy even for verbose
-                //qCDebug(FirmwareImageVerboseLog) << QString("_ihxLoad - append - address:%1 size:%2 block:%3").arg(address).arg(blockByteCount).arg(ihxBlockCount());
+                // qCDebug(FirmwareImageVerboseLog) << QString("_ihxLoad - append - address:%1 size:%2
+                // block:%3").arg(address).arg(blockByteCount).arg(ihxBlockCount());
             } else {
                 IntelHexBlock_t block;
 
@@ -155,7 +151,10 @@ bool FirmwareImage::_ihxLoad(const QString& ihxFilename)
                 block.bytes = bytes;
 
                 _ihxBlocks += block;
-                qCDebug(FirmwareImageVerboseLog) << QString("_ihxLoad - new block - address:%1 size:%2 block:%3").arg(address).arg(blockByteCount).arg(ihxBlockCount());
+                qCDebug(FirmwareImageVerboseLog) << QString("_ihxLoad - new block - address:%1 size:%2 block:%3")
+                                                        .arg(address)
+                                                        .arg(blockByteCount)
+                                                        .arg(ihxBlockCount());
             }
 
             _imageSize += blockByteCount;
@@ -174,17 +173,19 @@ bool FirmwareImage::_ihxLoad(const QString& ihxFilename)
     return true;
 }
 
-bool FirmwareImage::isCompatible(uint32_t boardId, uint32_t firmwareId) {
+bool FirmwareImage::isCompatible(uint32_t boardId, uint32_t firmwareId)
+{
     bool result = false;
-    if (boardId == firmwareId ) {
+    if (boardId == firmwareId) {
         result = true;
     }
-    switch(boardId) {
-    case Bootloader::boardIDPX4FMUV3:
-        if (firmwareId == 9) result = true;
-        break;
-    default:
-        break;
+    switch (boardId) {
+        case Bootloader::boardIDPX4FMUV3:
+            if (firmwareId == 9)
+                result = true;
+            break;
+        default:
+            break;
     }
     return result;
 }
@@ -224,21 +225,25 @@ bool FirmwareImage::_px4Load(const QString& imageFilename)
     // Make sure the keys are the correct type
     QStringList keys;
     QList<QJsonValue::Type> types;
-    keys << _jsonBoardIdKey << _jsonParamXmlSizeKey << _jsonParamXmlKey << _jsonAirframeXmlSizeKey << _jsonAirframeXmlKey << _jsonImageSizeKey << _jsonImageKey << _jsonMavAutopilotKey;
-    types << QJsonValue::Double << QJsonValue::Double << QJsonValue::String << QJsonValue::Double << QJsonValue::String << QJsonValue::Double << QJsonValue::String << QJsonValue::Double;
+    keys << _jsonBoardIdKey << _jsonParamXmlSizeKey << _jsonParamXmlKey << _jsonAirframeXmlSizeKey
+         << _jsonAirframeXmlKey << _jsonImageSizeKey << _jsonImageKey << _jsonMavAutopilotKey;
+    types << QJsonValue::Double << QJsonValue::Double << QJsonValue::String << QJsonValue::Double << QJsonValue::String
+          << QJsonValue::Double << QJsonValue::String << QJsonValue::Double;
     if (!JsonParsing::validateKeyTypes(px4Json, keys, types, errorString)) {
         emit statusMessage(tr("Firmware file has invalid key: %1").arg(errorString));
         return false;
     }
 
-    uint32_t firmwareBoardId = (uint32_t)px4Json.value(_jsonBoardIdKey).toInt();
+    uint32_t firmwareBoardId = (uint32_t) px4Json.value(_jsonBoardIdKey).toInt();
     if (!isCompatible(_boardId, firmwareBoardId)) {
-        emit statusMessage(tr("Downloaded firmware board id does not match hardware board id: %1 != %2").arg(firmwareBoardId).arg(_boardId));
+        emit statusMessage(tr("Downloaded firmware board id does not match hardware board id: %1 != %2")
+                               .arg(firmwareBoardId)
+                               .arg(_boardId));
         return false;
     }
 
     // What firmware type is this?
-    MAV_AUTOPILOT firmwareType = (MAV_AUTOPILOT)px4Json[_jsonMavAutopilotKey].toInt(MAV_AUTOPILOT_PX4);
+    MAV_AUTOPILOT firmwareType = (MAV_AUTOPILOT) px4Json[_jsonMavAutopilotKey].toInt(MAV_AUTOPILOT_PX4);
 
     // NOTE: PX4 firmware currently embeds parameter metadata as XML
     // ("parameter_xml" key), but the metadata system now expects JSON.
@@ -260,55 +265,60 @@ bool FirmwareImage::_px4Load(const QString& imageFilename)
         if (parameterFile.open(QIODevice::WriteOnly | QIODevice::Truncate)) {
             qint64 bytesWritten = parameterFile.write(decompressedBytes);
             if (bytesWritten != decompressedBytes.length()) {
-                emit statusMessage(tr("Write failed for parameter meta data file, error: %1").arg(parameterFile.errorString()));
+                emit statusMessage(
+                    tr("Write failed for parameter meta data file, error: %1").arg(parameterFile.errorString()));
                 parameterFile.close();
                 QFile::remove(parameterFilename);
             } else {
                 parameterFile.close();
             }
         } else {
-            emit statusMessage(tr("Unable to open parameter meta data file %1 for writing, error: %2").arg(parameterFilename, parameterFile.errorString()));
+            emit statusMessage(tr("Unable to open parameter meta data file %1 for writing, error: %2")
+                                   .arg(parameterFilename, parameterFile.errorString()));
         }
 
-        FirmwarePlugin *fwPlugin = FirmwarePluginManager::instance()->firmwarePluginForAutopilot(firmwareType, MAV_TYPE_GENERIC);
+        FirmwarePlugin* fwPlugin =
+            FirmwarePluginManager::instance()->firmwarePluginForAutopilot(firmwareType, MAV_TYPE_GENERIC);
         if (fwPlugin) {
             fwPlugin->cacheParameterMetaDataFile(parameterFilename);
         }
     }
 
     // Decompress the airframe xml and save to file
-    success = _decompressJsonValue(px4Json,                         // JSON object
-                                        bytes,                      // Raw bytes of JSON document
-                                        _jsonAirframeXmlSizeKey,    // key which holds byte size
-                                        _jsonAirframeXmlKey,        // key which holds compressed bytes
-                                        decompressedBytes);         // Returned decompressed bytes
+    success = _decompressJsonValue(px4Json,                  // JSON object
+                                   bytes,                    // Raw bytes of JSON document
+                                   _jsonAirframeXmlSizeKey,  // key which holds byte size
+                                   _jsonAirframeXmlKey,      // key which holds compressed bytes
+                                   decompressedBytes);       // Returned decompressed bytes
     if (success) {
         QString airframeFilename = QGCApplication::cachedAirframeMetaDataFile();
-        //qDebug() << airframeFilename;
+        // qDebug() << airframeFilename;
         QFile airframeFile(QGCApplication::cachedAirframeMetaDataFile());
 
         if (airframeFile.open(QIODevice::WriteOnly | QIODevice::Truncate)) {
             qint64 bytesWritten = airframeFile.write(decompressedBytes);
             if (bytesWritten != decompressedBytes.length()) {
                 // FIXME: What about these warnings?
-                emit statusMessage(tr("Write failed for airframe meta data file, error: %1").arg(airframeFile.errorString()));
+                emit statusMessage(
+                    tr("Write failed for airframe meta data file, error: %1").arg(airframeFile.errorString()));
                 airframeFile.close();
                 QFile::remove(airframeFilename);
             } else {
                 airframeFile.close();
             }
         } else {
-            emit statusMessage(tr("Unable to open airframe meta data file %1 for writing, error: %2").arg(airframeFilename, airframeFile.errorString()));
+            emit statusMessage(tr("Unable to open airframe meta data file %1 for writing, error: %2")
+                                   .arg(airframeFilename, airframeFile.errorString()));
         }
     }
 
     // Decompress the image and save to file
     _imageSize = px4Json.value(QString("image_size")).toInt();
-    success = _decompressJsonValue(px4Json,               // JSON object
-                                   bytes,                 // Raw bytes of JSON document
-                                   _jsonImageSizeKey,     // key which holds byte size
-                                   _jsonImageKey,         // key which holds compressed bytes
-                                   decompressedBytes);    // Returned decompressed bytes
+    success = _decompressJsonValue(px4Json,             // JSON object
+                                   bytes,               // Raw bytes of JSON document
+                                   _jsonImageSizeKey,   // key which holds byte size
+                                   _jsonImageKey,       // key which holds compressed bytes
+                                   decompressedBytes);  // Returned decompressed bytes
     if (!success) {
         return false;
     }
@@ -324,7 +334,8 @@ bool FirmwareImage::_px4Load(const QString& imageFilename)
 
     QFile decompressFile(decompressFilename);
     if (!decompressFile.open(QIODevice::WriteOnly | QIODevice::Truncate)) {
-        emit statusMessage(tr("Unable to open decompressed file %1 for writing, error: %2").arg(decompressFilename, decompressFile.errorString()));
+        emit statusMessage(tr("Unable to open decompressed file %1 for writing, error: %2")
+                               .arg(decompressFilename, decompressFile.errorString()));
         return false;
     }
 
@@ -341,11 +352,11 @@ bool FirmwareImage::_px4Load(const QString& imageFilename)
 }
 
 /// Decompress a set of bytes stored in a Json document.
-bool FirmwareImage::_decompressJsonValue(const QJsonObject&	jsonObject,			///< JSON object
-                                         const QByteArray&	jsonDocBytes,		///< Raw bytes of JSON document
-                                         const QString&		sizeKey,			///< key which holds byte size
-                                         const QString&		bytesKey,			///< key which holds compress bytes
-                                         QByteArray&		decompressedBytes)	///< Returned decompressed bytes
+bool FirmwareImage::_decompressJsonValue(const QJsonObject& jsonObject,   ///< JSON object
+                                         const QByteArray& jsonDocBytes,  ///< Raw bytes of JSON document
+                                         const QString& sizeKey,          ///< key which holds byte size
+                                         const QString& bytesKey,         ///< key which holds compress bytes
+                                         QByteArray& decompressedBytes)   ///< Returned decompressed bytes
 {
     // Validate decompressed size key
     if (!jsonObject.contains(sizeKey)) {
@@ -377,10 +388,10 @@ bool FirmwareImage::_decompressJsonValue(const QJsonObject&	jsonObject,			///< J
 
     // Store decompressed size as first four bytes. This is required by qUncompress routine.
     QByteArray raw;
-    raw.append((unsigned char)((decompressedSize >> 24) & 0xFF));
-    raw.append((unsigned char)((decompressedSize >> 16) & 0xFF));
-    raw.append((unsigned char)((decompressedSize >> 8) & 0xFF));
-    raw.append((unsigned char)((decompressedSize >> 0) & 0xFF));
+    raw.append((unsigned char) ((decompressedSize >> 24) & 0xFF));
+    raw.append((unsigned char) ((decompressedSize >> 16) & 0xFF));
+    raw.append((unsigned char) ((decompressedSize >> 8) & 0xFF));
+    raw.append((unsigned char) ((decompressedSize >> 0) & 0xFF));
 
     QByteArray raw64 = parts.first().toUtf8();
     raw.append(QByteArray::fromBase64(raw64));
@@ -391,7 +402,9 @@ bool FirmwareImage::_decompressJsonValue(const QJsonObject&	jsonObject,			///< J
         return false;
     }
     if (decompressedBytes.length() != decompressedSize) {
-        emit statusMessage(tr("Size for decompressed %1 does not match stored size: Expected(%1) Actual(%2)").arg(decompressedSize).arg(decompressedBytes.length()));
+        emit statusMessage(tr("Size for decompressed %1 does not match stored size: Expected(%1) Actual(%2)")
+                               .arg(decompressedSize)
+                               .arg(decompressedBytes.length()));
         return false;
     }
 
@@ -425,7 +438,7 @@ bool FirmwareImage::_binLoad(const QString& imageFilename)
         return false;
     }
 
-    _imageSize = (uint32_t)binFile.size();
+    _imageSize = (uint32_t) binFile.size();
 
     binFile.close();
 

--- a/src/Vehicle/VehicleSetup/FirmwareImage.h
+++ b/src/Vehicle/VehicleSetup/FirmwareImage.h
@@ -1,9 +1,9 @@
 #pragma once
 
-#include <QtCore/QObject>
-#include <QtCore/QString>
 #include <QtCore/QByteArray>
 #include <QtCore/QList>
+#include <QtCore/QObject>
+#include <QtCore/QString>
 #include <QtCore/QTextStream>
 
 /// \brief Support for Intel Hex firmware file
@@ -13,7 +13,7 @@ class FirmwareImage : public QObject
     Q_OBJECT
 
 public:
-    FirmwareImage(QObject *parent = 0);
+    FirmwareImage(QObject* parent = 0);
 
     /// Loads the specified image file. Supported formats: .px4, .bin, .ihx.
     /// Emits errorMesssage and statusMessage signals while loading.
@@ -57,29 +57,27 @@ private:
     bool _readWordFromStream(QTextStream& stream, uint16_t& word);
     bool _readBytesFromStream(QTextStream& stream, uint8_t byteCount, QByteArray& bytes);
 
-    bool _decompressJsonValue(const QJsonObject&	jsonObject,
-                              const QByteArray&     jsonDocBytes,
-                              const QString&		sizeKey,
-                              const QString&		bytesKey,
-                              QByteArray&			decompressedBytes);
+    bool _decompressJsonValue(const QJsonObject& jsonObject, const QByteArray& jsonDocBytes, const QString& sizeKey,
+                              const QString& bytesKey, QByteArray& decompressedBytes);
 
-    typedef struct {
-        uint16_t    address;
-        QByteArray  bytes;
+    typedef struct
+    {
+        uint16_t address;
+        QByteArray bytes;
     } IntelHexBlock_t;
 
-    bool                    _binFormat;
-    uint32_t                _boardId;
-    QString                 _binFilename;
-    QList<IntelHexBlock_t>  _ihxBlocks;
-    uint32_t                _imageSize;
+    bool _binFormat;
+    uint32_t _boardId;
+    QString _binFilename;
+    QList<IntelHexBlock_t> _ihxBlocks;
+    uint32_t _imageSize;
 
-    static constexpr const char* _jsonBoardIdKey =            "board_id";
-    static constexpr const char* _jsonParamXmlSizeKey =       "parameter_xml_size";
-    static constexpr const char* _jsonParamXmlKey =           "parameter_xml";
-    static constexpr const char* _jsonAirframeXmlSizeKey =    "airframe_xml_size";
-    static constexpr const char* _jsonAirframeXmlKey =        "airframe_xml";
-    static constexpr const char* _jsonImageSizeKey =          "image_size";
-    static constexpr const char* _jsonImageKey =              "image";
-    static constexpr const char* _jsonMavAutopilotKey =       "mav_autopilot";
+    static constexpr const char* _jsonBoardIdKey = "board_id";
+    static constexpr const char* _jsonParamXmlSizeKey = "parameter_xml_size";
+    static constexpr const char* _jsonParamXmlKey = "parameter_xml";
+    static constexpr const char* _jsonAirframeXmlSizeKey = "airframe_xml_size";
+    static constexpr const char* _jsonAirframeXmlKey = "airframe_xml";
+    static constexpr const char* _jsonImageSizeKey = "image_size";
+    static constexpr const char* _jsonImageKey = "image";
+    static constexpr const char* _jsonMavAutopilotKey = "mav_autopilot";
 };

--- a/src/Vehicle/VehicleSetup/FirmwareUpgradeController.cc
+++ b/src/Vehicle/VehicleSetup/FirmwareUpgradeController.cc
@@ -1,37 +1,39 @@
 ﻿#include "FirmwareUpgradeController.h"
-#include "PX4FirmwareUpgradeThread.h"
-#include "Bootloader.h"
-#include "QGCFileDownload.h"
-#include "QGCOptions.h"
-#include "QGCCorePlugin.h"
-#include "FirmwareUpgradeSettings.h"
-#include "SettingsManager.h"
-#include "JsonParsing.h"
-#include "LinkManager.h"
-#include "MultiVehicleManager.h"
-#include "FirmwareImage.h"
-#include "Fact.h"
-#include "QGCLoggingCategory.h"
 
 #include <QtCore/QDir>
 
+#include "Bootloader.h"
+#include "Fact.h"
+#include "FirmwareImage.h"
+#include "FirmwareUpgradeSettings.h"
+#include "JsonParsing.h"
+#include "LinkManager.h"
+#include "MultiVehicleManager.h"
+#include "PX4FirmwareUpgradeThread.h"
+#include "QGCCorePlugin.h"
+#include "QGCFileDownload.h"
+#include "QGCLoggingCategory.h"
+#include "QGCOptions.h"
+#include "SettingsManager.h"
+
 QGC_LOGGING_CATEGORY(FirmwareUpgradeControllerLog, "Vehicle.VehicleSetup.FirmwareUpgradeController")
-#include <QtCore/QStandardPaths>
+#include <QtCore/QJsonArray>
 #include <QtCore/QJsonDocument>
 #include <QtCore/QJsonObject>
-#include <QtCore/QJsonArray>
+#include <QtCore/QStandardPaths>
 
-struct FirmwareToUrlElement_t {
-    FirmwareUpgradeController::AutoPilotStackType_t     stackType;
-    FirmwareUpgradeController::FirmwareBuildType_t      firmwareType;
-    FirmwareUpgradeController::FirmwareVehicleType_t    vehicleType;
-    QString                                             url;
+struct FirmwareToUrlElement_t
+{
+    FirmwareUpgradeController::AutoPilotStackType_t stackType;
+    FirmwareUpgradeController::FirmwareBuildType_t firmwareType;
+    FirmwareUpgradeController::FirmwareVehicleType_t vehicleType;
+    QString url;
 };
 
 // See PX4 Bootloader board_types.txt - https://raw.githubusercontent.com/PX4/PX4-Bootloader/master/board_types.txt
-static QMap<int, QString> px4_board_name_map {
+static QMap<int, QString> px4_board_name_map{
     {9, "px4_fmu-v2_default"},
-    {255, "px4_fmu-v3_default"}, // Simulated board id for V3 which is a V2 board which supports larger flash space
+    {255, "px4_fmu-v3_default"},  // Simulated board id for V3 which is a V2 board which supports larger flash space
     {11, "px4_fmu-v4_default"},
     {13, "px4_fmu-v4pro_default"},
     {20, "uvify_core_default"},
@@ -93,58 +95,67 @@ static QMap<int, QString> px4_board_name_map {
     {7001, "cuav_fmu-v6x_default"},
     {7002, "cuav_x25-evo_default"},
     {7003, "cuav_x25-super_default"},
-    {7004, "cuav_x25-mega_default"}
-};
+    {7004, "cuav_x25-mega_default"}};
 
 uint qHash(const FirmwareUpgradeController::FirmwareIdentifier& firmwareId)
 {
-    return static_cast<uint>(( firmwareId.autopilotStackType |
-                               (firmwareId.firmwareType << 8) |
-                               (firmwareId.firmwareVehicleType << 16) ));
+    return static_cast<uint>(
+        (firmwareId.autopilotStackType | (firmwareId.firmwareType << 8) | (firmwareId.firmwareVehicleType << 16)));
 }
 
-/// @Brief Constructs a new FirmwareUpgradeController Widget. This widget is used within the PX4VehicleConfig set of screens.
+/// @Brief Constructs a new FirmwareUpgradeController Widget. This widget is used within the PX4VehicleConfig set of
+/// screens.
 FirmwareUpgradeController::FirmwareUpgradeController(void)
-    : _singleFirmwareURL                (QGCCorePlugin::instance()->options()->firmwareUpgradeSingleURL())
-    , _singleFirmwareMode               (!_singleFirmwareURL.isEmpty())
-    , _downloadingFirmwareList          (false)
-    , _statusLog                        (nullptr)
-    , _selectedFirmwareBuildType        (StableFirmware)
-    , _image                            (nullptr)
-    , _apmBoardDescriptionReplaceText   ("<APMBoardDescription>")
-    , _apmChibiOSSetting                (SettingsManager::instance()->firmwareUpgradeSettings()->apmChibiOS())
-    , _apmVehicleTypeSetting            (SettingsManager::instance()->firmwareUpgradeSettings()->apmVehicleType())
+    : _singleFirmwareURL(QGCCorePlugin::instance()->options()->firmwareUpgradeSingleURL()),
+      _singleFirmwareMode(!_singleFirmwareURL.isEmpty()),
+      _downloadingFirmwareList(false),
+      _statusLog(nullptr),
+      _selectedFirmwareBuildType(StableFirmware),
+      _image(nullptr),
+      _apmBoardDescriptionReplaceText("<APMBoardDescription>"),
+      _apmChibiOSSetting(SettingsManager::instance()->firmwareUpgradeSettings()->apmChibiOS()),
+      _apmVehicleTypeSetting(SettingsManager::instance()->firmwareUpgradeSettings()->apmVehicleType())
 {
-    _manifestMavFirmwareVersionTypeToFirmwareBuildTypeMap["OFFICIAL"] =  StableFirmware;
-    _manifestMavFirmwareVersionTypeToFirmwareBuildTypeMap["BETA"] =      BetaFirmware;
-    _manifestMavFirmwareVersionTypeToFirmwareBuildTypeMap["DEV"] =       DeveloperFirmware;
+    _manifestMavFirmwareVersionTypeToFirmwareBuildTypeMap["OFFICIAL"] = StableFirmware;
+    _manifestMavFirmwareVersionTypeToFirmwareBuildTypeMap["BETA"] = BetaFirmware;
+    _manifestMavFirmwareVersionTypeToFirmwareBuildTypeMap["DEV"] = DeveloperFirmware;
 
-    _manifestMavTypeToFirmwareVehicleTypeMap["Copter"] =        CopterFirmware;
-    _manifestMavTypeToFirmwareVehicleTypeMap["HELICOPTER"] =    HeliFirmware;
-    _manifestMavTypeToFirmwareVehicleTypeMap["FIXED_WING"] =    PlaneFirmware;
-    _manifestMavTypeToFirmwareVehicleTypeMap["GROUND_ROVER"] =  RoverFirmware;
-    _manifestMavTypeToFirmwareVehicleTypeMap["SUBMARINE"] =     SubFirmware;
+    _manifestMavTypeToFirmwareVehicleTypeMap["Copter"] = CopterFirmware;
+    _manifestMavTypeToFirmwareVehicleTypeMap["HELICOPTER"] = HeliFirmware;
+    _manifestMavTypeToFirmwareVehicleTypeMap["FIXED_WING"] = PlaneFirmware;
+    _manifestMavTypeToFirmwareVehicleTypeMap["GROUND_ROVER"] = RoverFirmware;
+    _manifestMavTypeToFirmwareVehicleTypeMap["SUBMARINE"] = SubFirmware;
 
     _threadController = new PX4FirmwareUpgradeThreadController(this);
     Q_CHECK_PTR(_threadController);
 
-    connect(_threadController, &PX4FirmwareUpgradeThreadController::foundBoard,             this, &FirmwareUpgradeController::_foundBoard);
-    connect(_threadController, &PX4FirmwareUpgradeThreadController::noBoardFound,           this, &FirmwareUpgradeController::_noBoardFound);
-    connect(_threadController, &PX4FirmwareUpgradeThreadController::boardGone,              this, &FirmwareUpgradeController::_boardGone);
-    connect(_threadController, &PX4FirmwareUpgradeThreadController::foundBoardInfo,         this, &FirmwareUpgradeController::_foundBoardInfo);
-    connect(_threadController, &PX4FirmwareUpgradeThreadController::error,                  this, &FirmwareUpgradeController::_error);
-    connect(_threadController, &PX4FirmwareUpgradeThreadController::updateProgress,         this, &FirmwareUpgradeController::_updateProgress);
-    connect(_threadController, &PX4FirmwareUpgradeThreadController::status,                 this, &FirmwareUpgradeController::_status);
-    connect(_threadController, &PX4FirmwareUpgradeThreadController::eraseStarted,           this, &FirmwareUpgradeController::_eraseStarted);
-    connect(_threadController, &PX4FirmwareUpgradeThreadController::eraseComplete,          this, &FirmwareUpgradeController::_eraseComplete);
-    connect(_threadController, &PX4FirmwareUpgradeThreadController::flashComplete,          this, &FirmwareUpgradeController::_flashComplete);
-    connect(_threadController, &PX4FirmwareUpgradeThreadController::updateProgress,         this, &FirmwareUpgradeController::_updateProgress);
-    connect(_threadController, &PX4FirmwareUpgradeThreadController::portsAvailable,         this, &FirmwareUpgradeController::_portsAvailable);
+    connect(_threadController, &PX4FirmwareUpgradeThreadController::foundBoard, this,
+            &FirmwareUpgradeController::_foundBoard);
+    connect(_threadController, &PX4FirmwareUpgradeThreadController::noBoardFound, this,
+            &FirmwareUpgradeController::_noBoardFound);
+    connect(_threadController, &PX4FirmwareUpgradeThreadController::boardGone, this,
+            &FirmwareUpgradeController::_boardGone);
+    connect(_threadController, &PX4FirmwareUpgradeThreadController::foundBoardInfo, this,
+            &FirmwareUpgradeController::_foundBoardInfo);
+    connect(_threadController, &PX4FirmwareUpgradeThreadController::error, this, &FirmwareUpgradeController::_error);
+    connect(_threadController, &PX4FirmwareUpgradeThreadController::updateProgress, this,
+            &FirmwareUpgradeController::_updateProgress);
+    connect(_threadController, &PX4FirmwareUpgradeThreadController::status, this, &FirmwareUpgradeController::_status);
+    connect(_threadController, &PX4FirmwareUpgradeThreadController::eraseStarted, this,
+            &FirmwareUpgradeController::_eraseStarted);
+    connect(_threadController, &PX4FirmwareUpgradeThreadController::eraseComplete, this,
+            &FirmwareUpgradeController::_eraseComplete);
+    connect(_threadController, &PX4FirmwareUpgradeThreadController::flashComplete, this,
+            &FirmwareUpgradeController::_flashComplete);
+    connect(_threadController, &PX4FirmwareUpgradeThreadController::updateProgress, this,
+            &FirmwareUpgradeController::_updateProgress);
+    connect(_threadController, &PX4FirmwareUpgradeThreadController::portsAvailable, this,
+            &FirmwareUpgradeController::_portsAvailable);
 
     connect(&_eraseTimer, &QTimer::timeout, this, &FirmwareUpgradeController::_eraseProgressTick);
 
 #if !defined(QGC_NO_ARDUPILOT_DIALECT)
-    connect(_apmChibiOSSetting,     &Fact::rawValueChanged, this, &FirmwareUpgradeController::_buildAPMFirmwareNames);
+    connect(_apmChibiOSSetting, &Fact::rawValueChanged, this, &FirmwareUpgradeController::_buildAPMFirmwareNames);
     connect(_apmVehicleTypeSetting, &Fact::rawValueChanged, this, &FirmwareUpgradeController::_buildAPMFirmwareNames);
 #endif
 
@@ -175,11 +186,11 @@ void FirmwareUpgradeController::startBoardSearch(void)
     _threadController->startFindBoardLoop();
 }
 
-void FirmwareUpgradeController::flash(AutoPilotStackType_t stackType,
-                                      FirmwareBuildType_t firmwareType,
+void FirmwareUpgradeController::flash(AutoPilotStackType_t stackType, FirmwareBuildType_t firmwareType,
                                       FirmwareVehicleType_t vehicleType)
 {
-    qCDebug(FirmwareUpgradeControllerLog) << "FirmwareUpgradeController::flash stackType:firmwareType:vehicleType" << stackType << firmwareType << vehicleType;
+    qCDebug(FirmwareUpgradeControllerLog) << "FirmwareUpgradeController::flash stackType:firmwareType:vehicleType"
+                                          << stackType << firmwareType << vehicleType;
     FirmwareIdentifier firmwareId = FirmwareIdentifier(stackType, firmwareType, vehicleType);
     if (_bootloaderFound) {
         _getFirmwareFile(firmwareId);
@@ -244,7 +255,7 @@ QStringList FirmwareUpgradeController::availableBoardsName(void)
 
     auto ports = QGCSerialPortInfo::availablePorts();
     for (const auto& info : ports) {
-        if(info.canFlash()) {
+        if (info.canFlash()) {
             info.getBoardInfo(boardType, boardName);
             names.append(boardName);
         }
@@ -253,10 +264,11 @@ QStringList FirmwareUpgradeController::availableBoardsName(void)
     return names;
 }
 
-void FirmwareUpgradeController::_foundBoard(bool firstAttempt, const QSerialPortInfo& info, int boardType, QString boardName)
+void FirmwareUpgradeController::_foundBoard(bool firstAttempt, const QSerialPortInfo& info, int boardType,
+                                            QString boardName)
 {
-    _boardInfo      = info;
-    _boardType      = static_cast<QGCSerialPortInfo::BoardType_t>(boardType);
+    _boardInfo = info;
+    _boardType = static_cast<QGCSerialPortInfo::BoardType_t>(boardType);
     if (!boardName.isEmpty()) {
         _boardTypeName = boardName;
     } else if (!info.description().isEmpty()) {
@@ -274,16 +286,14 @@ void FirmwareUpgradeController::_foundBoard(bool firstAttempt, const QSerialPort
             // Radio always flashes latest firmware, so we can start right away without
             // any further user input.
             _startFlashWhenBootloaderFound = true;
-            _startFlashWhenBootloaderFoundFirmwareIdentity = FirmwareIdentifier(SiKRadio,
-                                                                                StableFirmware,
-                                                                                DefaultVehicleFirmware);
+            _startFlashWhenBootloaderFoundFirmwareIdentity =
+                FirmwareIdentifier(SiKRadio, StableFirmware, DefaultVehicleFirmware);
         }
     }
 
     qCDebug(FirmwareUpgradeControllerLog) << _boardType << _boardTypeName;
     emit boardFound();
 }
-
 
 void FirmwareUpgradeController::_noBoardFound(void)
 {
@@ -299,10 +309,10 @@ void FirmwareUpgradeController::_boardGone(void)
 ///         to the next step.
 void FirmwareUpgradeController::_foundBoardInfo(int bootloaderVersion, int boardID, int flashSize)
 {
-    _bootloaderFound            = true;
-    _bootloaderVersion          = static_cast<uint32_t>(bootloaderVersion);
-    _bootloaderBoardID          = static_cast<uint32_t>(boardID);
-    _bootloaderBoardFlashSize   = static_cast<uint32_t>(flashSize);
+    _bootloaderFound = true;
+    _bootloaderVersion = static_cast<uint32_t>(bootloaderVersion);
+    _bootloaderBoardID = static_cast<uint32_t>(boardID);
+    _bootloaderBoardFlashSize = static_cast<uint32_t>(flashSize);
 
     _appendStatusLog(tr("Connected to bootloader:"));
     _appendStatusLog(tr("  Version: %1").arg(_bootloaderVersion));
@@ -326,32 +336,37 @@ void FirmwareUpgradeController::_bootloaderSyncFailed(void)
     _errorCancel("Unable to sync with bootloader.");
 }
 
-QHash<FirmwareUpgradeController::FirmwareIdentifier, QString>* FirmwareUpgradeController::_firmwareHashForBoardId(int boardId)
+QHash<FirmwareUpgradeController::FirmwareIdentifier, QString>* FirmwareUpgradeController::_firmwareHashForBoardId(
+    int boardId)
 {
     _rgFirmwareDynamic.clear();
 
     switch (boardId) {
-    case Bootloader::boardIDSiKRadio1000:
-    {
-        FirmwareToUrlElement_t element = { SiKRadio, StableFirmware, DefaultVehicleFirmware, "http://px4-travis.s3.amazonaws.com/SiK/stable/radio~hm_trp.ihx" };
-        _rgFirmwareDynamic.insert(FirmwareIdentifier(element.stackType, element.firmwareType, element.vehicleType), element.url);
-    }
-        break;
-    case Bootloader::boardIDSiKRadio1060:
-    {
-        FirmwareToUrlElement_t element = { SiKRadio, StableFirmware, DefaultVehicleFirmware, "https://px4-travis.s3.amazonaws.com/SiK/stable/radio~hb1060.ihx" };
-        _rgFirmwareDynamic.insert(FirmwareIdentifier(element.stackType, element.firmwareType, element.vehicleType), element.url);
-    }
-        break;
-    default:
-        if (px4_board_name_map.contains(boardId)) {
-            const QString px4Url{"http://px4-travis.s3.amazonaws.com/Firmware/%1/%2.px4"};
+        case Bootloader::boardIDSiKRadio1000: {
+            FirmwareToUrlElement_t element = {SiKRadio, StableFirmware, DefaultVehicleFirmware,
+                                              "http://px4-travis.s3.amazonaws.com/SiK/stable/radio~hm_trp.ihx"};
+            _rgFirmwareDynamic.insert(FirmwareIdentifier(element.stackType, element.firmwareType, element.vehicleType),
+                                      element.url);
+        } break;
+        case Bootloader::boardIDSiKRadio1060: {
+            FirmwareToUrlElement_t element = {SiKRadio, StableFirmware, DefaultVehicleFirmware,
+                                              "https://px4-travis.s3.amazonaws.com/SiK/stable/radio~hb1060.ihx"};
+            _rgFirmwareDynamic.insert(FirmwareIdentifier(element.stackType, element.firmwareType, element.vehicleType),
+                                      element.url);
+        } break;
+        default:
+            if (px4_board_name_map.contains(boardId)) {
+                const QString px4Url{"http://px4-travis.s3.amazonaws.com/Firmware/%1/%2.px4"};
 
-            _rgFirmwareDynamic.insert(FirmwareIdentifier(AutoPilotStackPX4, StableFirmware,    DefaultVehicleFirmware), px4Url.arg("stable").arg(px4_board_name_map.value(boardId)));
-            _rgFirmwareDynamic.insert(FirmwareIdentifier(AutoPilotStackPX4, BetaFirmware,      DefaultVehicleFirmware), px4Url.arg("beta").arg(px4_board_name_map.value(boardId)));
-            _rgFirmwareDynamic.insert(FirmwareIdentifier(AutoPilotStackPX4, DeveloperFirmware, DefaultVehicleFirmware), px4Url.arg("master").arg(px4_board_name_map.value(boardId)));
-        }
-        break;
+                _rgFirmwareDynamic.insert(FirmwareIdentifier(AutoPilotStackPX4, StableFirmware, DefaultVehicleFirmware),
+                                          px4Url.arg("stable").arg(px4_board_name_map.value(boardId)));
+                _rgFirmwareDynamic.insert(FirmwareIdentifier(AutoPilotStackPX4, BetaFirmware, DefaultVehicleFirmware),
+                                          px4Url.arg("beta").arg(px4_board_name_map.value(boardId)));
+                _rgFirmwareDynamic.insert(
+                    FirmwareIdentifier(AutoPilotStackPX4, DeveloperFirmware, DefaultVehicleFirmware),
+                    px4Url.arg("master").arg(px4_board_name_map.value(boardId)));
+            }
+            break;
     }
 
     return &_rgFirmwareDynamic;
@@ -397,7 +412,8 @@ void FirmwareUpgradeController::_downloadFirmware(void)
     _activeDownloader = downloader;
     connect(downloader, &QGCFileDownload::finished, downloader, &QObject::deleteLater);
     connect(downloader, &QGCFileDownload::finished, this, &FirmwareUpgradeController::_firmwareDownloadComplete);
-    connect(downloader, &QGCFileDownload::downloadProgress, this, &FirmwareUpgradeController::_firmwareDownloadProgress);
+    connect(downloader, &QGCFileDownload::downloadProgress, this,
+            &FirmwareUpgradeController::_firmwareDownloadProgress);
     if (!downloader->start(_firmwareFilename)) {
         downloader->deleteLater();
         _activeDownloader = nullptr;
@@ -416,7 +432,8 @@ void FirmwareUpgradeController::_firmwareDownloadProgress(qint64 curr, qint64 to
 }
 
 /// @brief Called when the firmware download completes.
-void FirmwareUpgradeController::_firmwareDownloadComplete(bool success, const QString &localFile, const QString &errorMsg)
+void FirmwareUpgradeController::_firmwareDownloadComplete(bool success, const QString& localFile,
+                                                          const QString& errorMsg)
 {
     _activeDownloader = nullptr;
 
@@ -448,7 +465,9 @@ void FirmwareUpgradeController::_firmwareDownloadComplete(bool success, const QS
         }
 
         if (_bootloaderBoardFlashSize != 0 && image->imageSize() > _bootloaderBoardFlashSize) {
-            _errorCancel(tr("Image size of %1 is too large for board flash size %2").arg(image->imageSize()).arg(_bootloaderBoardFlashSize));
+            _errorCancel(tr("Image size of %1 is too large for board flash size %2")
+                             .arg(image->imageSize())
+                             .arg(_bootloaderBoardFlashSize));
             return;
         }
 
@@ -462,14 +481,14 @@ void FirmwareUpgradeController::_firmwareDownloadComplete(bool success, const QS
 QString FirmwareUpgradeController::firmwareTypeAsString(FirmwareBuildType_t type) const
 {
     switch (type) {
-    case StableFirmware:
-        return "stable";
-    case DeveloperFirmware:
-        return "developer";
-    case BetaFirmware:
-        return "beta";
-    default:
-        return "custom";
+        case StableFirmware:
+            return "stable";
+        case DeveloperFirmware:
+            return "developer";
+        case BetaFirmware:
+            return "beta";
+        default:
+            return "custom";
     }
 }
 
@@ -511,7 +530,8 @@ void FirmwareUpgradeController::_updateProgress(int curr, int total)
 void FirmwareUpgradeController::_eraseProgressTick(void)
 {
     _eraseTickCount++;
-    _progressBar->setProperty("value", static_cast<float>(_eraseTickCount*_eraseTickMsec) / static_cast<float>(_eraseTotalMsec));
+    _progressBar->setProperty(
+        "value", static_cast<float>(_eraseTickCount * _eraseTickMsec) / static_cast<float>(_eraseTotalMsec));
 }
 
 /// Appends the specified text to the status log area in the ui
@@ -527,9 +547,7 @@ void FirmwareUpgradeController::_appendStatusLog(const QString& text, bool criti
         varText = text;
     }
 
-    QMetaObject::invokeMethod(_statusLog,
-                              "append",
-                              Q_ARG(QString, varText));
+    QMetaObject::invokeMethod(_statusLog, "append", Q_ARG(QString, varText));
 }
 
 void FirmwareUpgradeController::_errorCancel(const QString& msg)
@@ -564,14 +582,21 @@ void FirmwareUpgradeController::setSelectedFirmwareBuildType(FirmwareBuildType_t
 void FirmwareUpgradeController::_buildAPMFirmwareNames(void)
 {
 #if !defined(QGC_NO_ARDUPILOT_DIALECT)
-    bool                    chibios =           _apmChibiOSSetting->rawValue().toInt() == 0;
-    FirmwareVehicleType_t   vehicleType =       static_cast<FirmwareVehicleType_t>(_apmVehicleTypeSetting->rawValue().toInt());
-    QString                 boardDescription =  _boardInfo.description();
-    quint16                 boardVID =          _boardInfo.vendorIdentifier();
-    quint16                 boardPID =          _boardInfo.productIdentifier();
-    uint32_t                rawBoardId =        _bootloaderBoardID == Bootloader::boardIDPX4FMUV3 ? Bootloader::boardIDPX4FMUV2 : _bootloaderBoardID;
+    bool chibios = _apmChibiOSSetting->rawValue().toInt() == 0;
+    FirmwareVehicleType_t vehicleType = static_cast<FirmwareVehicleType_t>(_apmVehicleTypeSetting->rawValue().toInt());
+    QString boardDescription = _boardInfo.description();
+    quint16 boardVID = _boardInfo.vendorIdentifier();
+    quint16 boardPID = _boardInfo.productIdentifier();
+    uint32_t rawBoardId =
+        _bootloaderBoardID == Bootloader::boardIDPX4FMUV3 ? Bootloader::boardIDPX4FMUV2 : _bootloaderBoardID;
 
-    qCDebug(FirmwareUpgradeControllerLog) << QStringLiteral("_buildAPMFirmwareNames description(%1) vid(%2/0x%3) pid(%4/0x%5)").arg(boardDescription).arg(boardVID).arg(boardVID, 1, 16).arg(boardPID).arg(boardPID, 1, 16);
+    qCDebug(FirmwareUpgradeControllerLog)
+        << QStringLiteral("_buildAPMFirmwareNames description(%1) vid(%2/0x%3) pid(%4/0x%5)")
+               .arg(boardDescription)
+               .arg(boardVID)
+               .arg(boardVID, 1, 16)
+               .arg(boardPID)
+               .arg(boardPID, 1, 16);
 
     _apmFirmwareNames.clear();
     _apmFirmwareNamesBestIndex = -1;
@@ -579,20 +604,28 @@ void FirmwareUpgradeController::_buildAPMFirmwareNames(void)
 
     QString apmDescriptionSuffix("-BL");
     QString boardDescriptionPrefix;
-    bool    bootloaderMatch = boardDescription.endsWith(apmDescriptionSuffix);
+    bool bootloaderMatch = boardDescription.endsWith(apmDescriptionSuffix);
 
     int currentIndex = 0;
-    for (const ManifestFirmwareInfo_t& firmwareInfo: _rgManifestFirmwareInfo) {
+    for (const ManifestFirmwareInfo_t& firmwareInfo : _rgManifestFirmwareInfo) {
         bool match = false;
-        if (firmwareInfo.firmwareBuildType == _selectedFirmwareBuildType && firmwareInfo.chibios == chibios && firmwareInfo.vehicleType == vehicleType && firmwareInfo.boardId == rawBoardId) {
+        if (firmwareInfo.firmwareBuildType == _selectedFirmwareBuildType && firmwareInfo.chibios == chibios &&
+            firmwareInfo.vehicleType == vehicleType && firmwareInfo.boardId == rawBoardId) {
             if (firmwareInfo.fmuv2 && _bootloaderBoardID == Bootloader::boardIDPX4FMUV3) {
-                qCDebug(FirmwareUpgradeControllerLog) << "Skipping fmuv2 manifest entry for fmuv3 board:" << firmwareInfo.friendlyName << boardDescription << firmwareInfo.rgBootloaderPortString << firmwareInfo.url << firmwareInfo.vehicleType;
+                qCDebug(FirmwareUpgradeControllerLog)
+                    << "Skipping fmuv2 manifest entry for fmuv3 board:" << firmwareInfo.friendlyName << boardDescription
+                    << firmwareInfo.rgBootloaderPortString << firmwareInfo.url << firmwareInfo.vehicleType;
             } else {
-                qCDebug(FirmwareUpgradeControllerLog) << "Board id match:" << firmwareInfo.friendlyName << boardDescription << firmwareInfo.rgBootloaderPortString << firmwareInfo.url << firmwareInfo.vehicleType;
+                qCDebug(FirmwareUpgradeControllerLog)
+                    << "Board id match:" << firmwareInfo.friendlyName << boardDescription
+                    << firmwareInfo.rgBootloaderPortString << firmwareInfo.url << firmwareInfo.vehicleType;
                 match = true;
-                if (bootloaderMatch && _apmFirmwareNamesBestIndex == -1 && firmwareInfo.rgBootloaderPortString.contains(boardDescription)) {
+                if (bootloaderMatch && _apmFirmwareNamesBestIndex == -1 &&
+                    firmwareInfo.rgBootloaderPortString.contains(boardDescription)) {
                     _apmFirmwareNamesBestIndex = currentIndex;
-                    qCDebug(FirmwareUpgradeControllerLog) << "Bootloader best match:" << firmwareInfo.friendlyName << boardDescription << firmwareInfo.rgBootloaderPortString << firmwareInfo.url << firmwareInfo.vehicleType;
+                    qCDebug(FirmwareUpgradeControllerLog)
+                        << "Bootloader best match:" << firmwareInfo.friendlyName << boardDescription
+                        << firmwareInfo.rgBootloaderPortString << firmwareInfo.url << firmwareInfo.vehicleType;
                 }
             }
         }
@@ -616,7 +649,8 @@ void FirmwareUpgradeController::_buildAPMFirmwareNames(void)
 #endif
 }
 
-FirmwareUpgradeController::FirmwareVehicleType_t FirmwareUpgradeController::vehicleTypeFromFirmwareSelectionIndex(int index)
+FirmwareUpgradeController::FirmwareVehicleType_t FirmwareUpgradeController::vehicleTypeFromFirmwareSelectionIndex(
+    int index)
 {
     if (index < 0 || index >= _apmVehicleTypeFromCurrentVersionList.length()) {
         qWarning() << "Invalid index, index:count" << index << _apmVehicleTypeFromCurrentVersionList.length();
@@ -630,20 +664,24 @@ void FirmwareUpgradeController::_determinePX4StableVersion(void)
 {
     QGCFileDownload* downloader = new QGCFileDownload(this);
     connect(downloader, &QGCFileDownload::finished, downloader, &QObject::deleteLater);
-    connect(downloader, &QGCFileDownload::finished, this, &FirmwareUpgradeController::_px4ReleasesGithubDownloadComplete);
+    connect(downloader, &QGCFileDownload::finished, this,
+            &FirmwareUpgradeController::_px4ReleasesGithubDownloadComplete);
     if (!downloader->start(QStringLiteral("https://api.github.com/repos/PX4/Firmware/releases"))) {
-        qCWarning(FirmwareUpgradeControllerLog) << "PX4 releases github download did not start:" << downloader->errorString();
+        qCWarning(FirmwareUpgradeControllerLog)
+            << "PX4 releases github download did not start:" << downloader->errorString();
         downloader->deleteLater();
         return;
     }
 }
 
-void FirmwareUpgradeController::_px4ReleasesGithubDownloadComplete(bool success, const QString &localFile, const QString &errorMsg)
+void FirmwareUpgradeController::_px4ReleasesGithubDownloadComplete(bool success, const QString& localFile,
+                                                                   const QString& errorMsg)
 {
     if (success) {
         QFile jsonFile(localFile);
         if (!jsonFile.open(QIODevice::ReadOnly | QIODevice::Text)) {
-            qCWarning(FirmwareUpgradeControllerLog) << "Unable to open github px4 releases json file" << localFile << jsonFile.errorString();
+            qCWarning(FirmwareUpgradeControllerLog)
+                << "Unable to open github px4 releases json file" << localFile << jsonFile.errorString();
             return;
         }
         QByteArray bytes = jsonFile.readAll();
@@ -652,13 +690,14 @@ void FirmwareUpgradeController::_px4ReleasesGithubDownloadComplete(bool success,
         QJsonParseError jsonParseError;
         QJsonDocument doc = QJsonDocument::fromJson(bytes, &jsonParseError);
         if (jsonParseError.error != QJsonParseError::NoError) {
-            qCWarning(FirmwareUpgradeControllerLog) <<  "Unable to open px4 releases json document" << localFile << jsonParseError.errorString();
+            qCWarning(FirmwareUpgradeControllerLog)
+                << "Unable to open px4 releases json document" << localFile << jsonParseError.errorString();
             return;
         }
 
         // Json should be an array of release objects
         if (!doc.isArray()) {
-            qCWarning(FirmwareUpgradeControllerLog) <<  "px4 releases json document is not an array" << localFile;
+            qCWarning(FirmwareUpgradeControllerLog) << "px4 releases json document is not an array" << localFile;
             return;
         }
         QJsonArray releases = doc.array();
@@ -667,7 +706,7 @@ void FirmwareUpgradeController::_px4ReleasesGithubDownloadComplete(bool success,
         // The first release marked prerelease=true is beta
         bool foundStable = false;
         bool foundBeta = false;
-        for (int i=0; i<releases.count() && (!foundStable || !foundBeta); i++) {
+        for (int i = 0; i < releases.count() && (!foundStable || !foundBeta); i++) {
             QJsonObject release = releases[i].toObject();
             if (!foundStable && !release["prerelease"].toBool()) {
                 _px4StableVersion = release["name"].toString();
@@ -700,18 +739,21 @@ void FirmwareUpgradeController::_downloadArduPilotManifest(void)
 
     QGCFileDownload* downloader = new QGCFileDownload(this);
     connect(downloader, &QGCFileDownload::finished, downloader, &QObject::deleteLater);
-    connect(downloader, &QGCFileDownload::finished, this, &FirmwareUpgradeController::_ardupilotManifestDownloadComplete);
+    connect(downloader, &QGCFileDownload::finished, this,
+            &FirmwareUpgradeController::_ardupilotManifestDownloadComplete);
     // Use autoDecompress to stream-decompress directly during download
     downloader->setAutoDecompress(true);
     if (!downloader->start(QStringLiteral("https://firmware.ardupilot.org/manifest.json.gz"))) {
-        qCWarning(FirmwareUpgradeControllerLog) << "ArduPilot Manifest download did not start:" << downloader->errorString();
+        qCWarning(FirmwareUpgradeControllerLog)
+            << "ArduPilot Manifest download did not start:" << downloader->errorString();
         downloader->deleteLater();
         _downloadingFirmwareList = false;
         emit downloadingFirmwareListChanged(false);
     }
 }
 
-void FirmwareUpgradeController::_ardupilotManifestDownloadComplete(bool success, const QString &localFile, const QString &errorMsg)
+void FirmwareUpgradeController::_ardupilotManifestDownloadComplete(bool success, const QString& localFile,
+                                                                   const QString& errorMsg)
 {
     const auto clearDownloadState = [this]() {
         if (_downloadingFirmwareList) {
@@ -724,26 +766,29 @@ void FirmwareUpgradeController::_ardupilotManifestDownloadComplete(bool success,
         qCDebug(FirmwareUpgradeControllerLog) << "_ardupilotManifestDownloadFinished" << localFile;
 
         // localFile is already decompressed (autoDecompress=true streams directly to .json)
-        QString         errorString;
-        QJsonDocument   doc;
+        QString errorString;
+        QJsonDocument doc;
         if (!JsonParsing::isJsonFile(localFile, doc, errorString)) {
             qCWarning(FirmwareUpgradeControllerLog) << "Json file read failed" << errorString;
             clearDownloadState();
             return;
         }
 
-        QJsonObject json =          doc.object();
-        QJsonArray  rgFirmware =    json[_manifestFirmwareJsonKey].toArray();
+        QJsonObject json = doc.object();
+        QJsonArray rgFirmware = json[_manifestFirmwareJsonKey].toArray();
 
-        for (int i=0; i<rgFirmware.count(); i++) {
+        for (int i = 0; i < rgFirmware.count(); i++) {
             const QJsonObject& firmwareJson = rgFirmware[i].toObject();
 
-            FirmwareVehicleType_t   firmwareVehicleType =   _manifestMavTypeToFirmwareVehicleType(firmwareJson[_manifestMavTypeJsonKey].toString());
-            FirmwareBuildType_t     firmwareBuildType =     _manifestMavFirmwareVersionTypeToFirmwareBuildType(firmwareJson[_manifestMavFirmwareVersionTypeJsonKey].toString());
-            QString                 format =                firmwareJson[_manifestFormatJsonKey].toString();
-            QString                 platform =              firmwareJson[_manifestPlatformKey].toString();
+            FirmwareVehicleType_t firmwareVehicleType =
+                _manifestMavTypeToFirmwareVehicleType(firmwareJson[_manifestMavTypeJsonKey].toString());
+            FirmwareBuildType_t firmwareBuildType = _manifestMavFirmwareVersionTypeToFirmwareBuildType(
+                firmwareJson[_manifestMavFirmwareVersionTypeJsonKey].toString());
+            QString format = firmwareJson[_manifestFormatJsonKey].toString();
+            QString platform = firmwareJson[_manifestPlatformKey].toString();
 
-            if (firmwareVehicleType != DefaultVehicleFirmware && firmwareBuildType != CustomFirmware && (format == QStringLiteral("apj") || format == QStringLiteral("px4"))) {
+            if (firmwareVehicleType != DefaultVehicleFirmware && firmwareBuildType != CustomFirmware &&
+                (format == QStringLiteral("apj") || format == QStringLiteral("px4"))) {
                 if (platform.contains("-heli") && firmwareVehicleType != HeliFirmware) {
                     continue;
                 }
@@ -751,20 +796,21 @@ void FirmwareUpgradeController::_ardupilotManifestDownloadComplete(bool success,
                 _rgManifestFirmwareInfo.append(ManifestFirmwareInfo_t());
                 ManifestFirmwareInfo_t& firmwareInfo = _rgManifestFirmwareInfo.last();
 
-                firmwareInfo.boardId =              static_cast<uint32_t>(firmwareJson[_manifestBoardIdJsonKey].toInt());
-                firmwareInfo.firmwareBuildType =    firmwareBuildType;
-                firmwareInfo.vehicleType =          firmwareVehicleType;
-                firmwareInfo.url =                  firmwareJson[_manifestUrlJsonKey].toString();
-                firmwareInfo.version =              firmwareJson[_manifestMavFirmwareVersionJsonKey].toString();
-                firmwareInfo.chibios =              format == QStringLiteral("apj");                firmwareInfo.fmuv2 =                platform.contains(QStringLiteral("fmuv2"));
+                firmwareInfo.boardId = static_cast<uint32_t>(firmwareJson[_manifestBoardIdJsonKey].toInt());
+                firmwareInfo.firmwareBuildType = firmwareBuildType;
+                firmwareInfo.vehicleType = firmwareVehicleType;
+                firmwareInfo.url = firmwareJson[_manifestUrlJsonKey].toString();
+                firmwareInfo.version = firmwareJson[_manifestMavFirmwareVersionJsonKey].toString();
+                firmwareInfo.chibios = format == QStringLiteral("apj");
+                firmwareInfo.fmuv2 = platform.contains(QStringLiteral("fmuv2"));
 
                 QJsonArray bootloaderArray = firmwareJson[_manifestBootloaderStrJsonKey].toArray();
-                for (int j=0; j<bootloaderArray.count(); j++) {
+                for (int j = 0; j < bootloaderArray.count(); j++) {
                     firmwareInfo.rgBootloaderPortString.append(bootloaderArray[j].toString());
                 }
 
                 QJsonArray usbidArray = firmwareJson[_manifestUSBIDJsonKey].toArray();
-                for (int j=0; j<usbidArray.count(); j++) {
+                for (int j = 0; j < usbidArray.count(); j++) {
                     QStringList vidpid = usbidArray[j].toString().split('/');
                     QString vid = vidpid[0];
                     QString pid = vidpid[1];
@@ -775,7 +821,8 @@ void FirmwareUpgradeController::_ardupilotManifestDownloadComplete(bool success,
                 }
 
                 QString brandName = firmwareJson[_manifestBrandNameKey].toString();
-                firmwareInfo.friendlyName = QStringLiteral("%1 - %2").arg(brandName.isEmpty() ? platform : brandName).arg(firmwareInfo.version);
+                firmwareInfo.friendlyName =
+                    QStringLiteral("%1 - %2").arg(brandName.isEmpty() ? platform : brandName).arg(firmwareInfo.version);
             }
         }
 
@@ -790,7 +837,9 @@ void FirmwareUpgradeController::_ardupilotManifestDownloadComplete(bool success,
     }
 }
 
-FirmwareUpgradeController::FirmwareBuildType_t FirmwareUpgradeController::_manifestMavFirmwareVersionTypeToFirmwareBuildType(const QString& manifestMavFirmwareVersionType)
+FirmwareUpgradeController::FirmwareBuildType_t
+FirmwareUpgradeController::_manifestMavFirmwareVersionTypeToFirmwareBuildType(
+    const QString& manifestMavFirmwareVersionType)
 {
     if (_manifestMavFirmwareVersionTypeToFirmwareBuildTypeMap.contains(manifestMavFirmwareVersionType)) {
         return _manifestMavFirmwareVersionTypeToFirmwareBuildTypeMap[manifestMavFirmwareVersionType];
@@ -799,7 +848,8 @@ FirmwareUpgradeController::FirmwareBuildType_t FirmwareUpgradeController::_manif
     }
 }
 
-FirmwareUpgradeController::FirmwareVehicleType_t FirmwareUpgradeController::_manifestMavTypeToFirmwareVehicleType(const QString& manifestMavType)
+FirmwareUpgradeController::FirmwareVehicleType_t FirmwareUpgradeController::_manifestMavTypeToFirmwareVehicleType(
+    const QString& manifestMavType)
 {
     if (_manifestMavTypeToFirmwareVehicleTypeMap.contains(manifestMavType)) {
         return _manifestMavTypeToFirmwareVehicleTypeMap[manifestMavType];

--- a/src/Vehicle/VehicleSetup/FirmwareUpgradeController.h
+++ b/src/Vehicle/VehicleSetup/FirmwareUpgradeController.h
@@ -24,35 +24,38 @@ class FirmwareUpgradeController : public QObject
     Q_OBJECT
     QML_ELEMENT
 #ifdef QGC_UNITTEST_BUILD
-    friend class FirmwareUpgradeControllerTest; // Unit test
+    friend class FirmwareUpgradeControllerTest;  // Unit test
 #endif
 public:
-        typedef enum {
-            AutoPilotStackPX4 = 0,
-            AutoPilotStackAPM,
-            SiKRadio,
-            SingleFirmwareMode
-        } AutoPilotStackType_t;
+    typedef enum
+    {
+        AutoPilotStackPX4 = 0,
+        AutoPilotStackAPM,
+        SiKRadio,
+        SingleFirmwareMode
+    } AutoPilotStackType_t;
 
-        typedef enum {
-            StableFirmware = 0,
-            BetaFirmware,
-            DeveloperFirmware,
-            CustomFirmware
-        } FirmwareBuildType_t;
+    typedef enum
+    {
+        StableFirmware = 0,
+        BetaFirmware,
+        DeveloperFirmware,
+        CustomFirmware
+    } FirmwareBuildType_t;
 
-        typedef enum {
-            CopterFirmware = 0,
-            HeliFirmware,
-            PlaneFirmware,
-            RoverFirmware,
-            SubFirmware,
-            DefaultVehicleFirmware
-        } FirmwareVehicleType_t;
+    typedef enum
+    {
+        CopterFirmware = 0,
+        HeliFirmware,
+        PlaneFirmware,
+        RoverFirmware,
+        SubFirmware,
+        DefaultVehicleFirmware
+    } FirmwareVehicleType_t;
 
-        Q_ENUM(AutoPilotStackType_t)
-        Q_ENUM(FirmwareBuildType_t)
-        Q_ENUM(FirmwareVehicleType_t)
+    Q_ENUM(AutoPilotStackType_t)
+    Q_ENUM(FirmwareBuildType_t)
+    Q_ENUM(FirmwareVehicleType_t)
 
     class FirmwareIdentifier
     {
@@ -60,36 +63,37 @@ public:
         FirmwareIdentifier(AutoPilotStackType_t stack = AutoPilotStackPX4,
                            FirmwareBuildType_t firmware = StableFirmware,
                            FirmwareVehicleType_t vehicle = DefaultVehicleFirmware)
-            : autopilotStackType(stack), firmwareType(firmware), firmwareVehicleType(vehicle) {}
+            : autopilotStackType(stack), firmwareType(firmware), firmwareVehicleType(vehicle)
+        {}
 
         bool operator==(const FirmwareIdentifier& firmwareId) const
         {
-            return (firmwareId.autopilotStackType == autopilotStackType &&
-                    firmwareId.firmwareType == firmwareType &&
+            return (firmwareId.autopilotStackType == autopilotStackType && firmwareId.firmwareType == firmwareType &&
                     firmwareId.firmwareVehicleType == firmwareVehicleType);
         }
 
         // members
-        AutoPilotStackType_t    autopilotStackType;
-        FirmwareBuildType_t     firmwareType;
-        FirmwareVehicleType_t   firmwareVehicleType;
+        AutoPilotStackType_t autopilotStackType;
+        FirmwareBuildType_t firmwareType;
+        FirmwareVehicleType_t firmwareVehicleType;
     };
 
     FirmwareUpgradeController(void);
     ~FirmwareUpgradeController();
 
-    Q_PROPERTY(bool                 downloadingFirmwareList     MEMBER _downloadingFirmwareList                                     NOTIFY downloadingFirmwareListChanged)
-    Q_PROPERTY(QString              boardPort                   READ boardPort                                                      NOTIFY boardFound)
-    Q_PROPERTY(QString              boardDescription            READ boardDescription                                               NOTIFY boardFound)
-    Q_PROPERTY(QString              boardType                   MEMBER _boardTypeName                                               NOTIFY boardFound)
-    Q_PROPERTY(bool                 pixhawkBoard                READ pixhawkBoard                                                   NOTIFY boardFound)
-    Q_PROPERTY(FirmwareBuildType_t  selectedFirmwareBuildType   READ selectedFirmwareBuildType  WRITE setSelectedFirmwareBuildType  NOTIFY selectedFirmwareBuildTypeChanged)
-    Q_PROPERTY(QStringList          apmFirmwareNames            MEMBER _apmFirmwareNames                                            NOTIFY apmFirmwareNamesChanged)
-    Q_PROPERTY(int                  apmFirmwareNamesBestIndex   MEMBER _apmFirmwareNamesBestIndex                                   NOTIFY apmFirmwareNamesChanged)
-    Q_PROPERTY(QStringList          apmFirmwareUrls             MEMBER _apmFirmwareUrls                                             NOTIFY apmFirmwareNamesChanged)
-    Q_PROPERTY(QString              px4StableVersion            READ px4StableVersion                                               NOTIFY px4StableVersionChanged)
-    Q_PROPERTY(QString              px4BetaVersion              READ px4BetaVersion                                                 NOTIFY px4BetaVersionChanged)
-    Q_PROPERTY(QVariantList         availablePorts              MEMBER _availablePorts                                              NOTIFY availablePortsChanged)
+    Q_PROPERTY(bool downloadingFirmwareList MEMBER _downloadingFirmwareList NOTIFY downloadingFirmwareListChanged)
+    Q_PROPERTY(QString boardPort READ boardPort NOTIFY boardFound)
+    Q_PROPERTY(QString boardDescription READ boardDescription NOTIFY boardFound)
+    Q_PROPERTY(QString boardType MEMBER _boardTypeName NOTIFY boardFound)
+    Q_PROPERTY(bool pixhawkBoard READ pixhawkBoard NOTIFY boardFound)
+    Q_PROPERTY(FirmwareBuildType_t selectedFirmwareBuildType READ selectedFirmwareBuildType WRITE
+                   setSelectedFirmwareBuildType NOTIFY selectedFirmwareBuildTypeChanged)
+    Q_PROPERTY(QStringList apmFirmwareNames MEMBER _apmFirmwareNames NOTIFY apmFirmwareNamesChanged)
+    Q_PROPERTY(int apmFirmwareNamesBestIndex MEMBER _apmFirmwareNamesBestIndex NOTIFY apmFirmwareNamesChanged)
+    Q_PROPERTY(QStringList apmFirmwareUrls MEMBER _apmFirmwareUrls NOTIFY apmFirmwareNamesChanged)
+    Q_PROPERTY(QString px4StableVersion READ px4StableVersion NOTIFY px4StableVersionChanged)
+    Q_PROPERTY(QString px4BetaVersion READ px4BetaVersion NOTIFY px4BetaVersionChanged)
+    Q_PROPERTY(QVariantList availablePorts MEMBER _availablePorts NOTIFY availablePortsChanged)
 
     /// TextArea for log output
     Q_PROPERTY(QQuickItem* statusLog READ statusLog WRITE setStatusLog)
@@ -100,16 +104,16 @@ public:
     /// Starts searching for boards on the background thread
     Q_INVOKABLE void startBoardSearch(void);
 
-    /// Selects which serial port to flash. The worker will wait for this port to be in bootloader mode and then handshake.
+    /// Selects which serial port to flash. The worker will wait for this port to be in bootloader mode and then
+    /// handshake.
     Q_INVOKABLE void flashPort(const QString& systemLocation);
 
     /// Cancels whatever state the upgrade worker thread is in
     Q_INVOKABLE void cancel(void);
 
     /// Called when the firmware type has been selected by the user to continue the flash process.
-    Q_INVOKABLE void flash(AutoPilotStackType_t stackType,
-                           FirmwareBuildType_t firmwareType = StableFirmware,
-                           FirmwareVehicleType_t vehicleType = DefaultVehicleFirmware );
+    Q_INVOKABLE void flash(AutoPilotStackType_t stackType, FirmwareBuildType_t firmwareType = StableFirmware,
+                           FirmwareVehicleType_t vehicleType = DefaultVehicleFirmware);
 
     Q_INVOKABLE void flashFirmwareUrl(QString firmwareUrl);
 
@@ -124,20 +128,25 @@ public:
     // Property accessors
 
     QQuickItem* progressBar(void) { return _progressBar; }
+
     void setProgressBar(QQuickItem* progressBar) { _progressBar = progressBar; }
 
     QQuickItem* statusLog(void) { return _statusLog; }
+
     void setStatusLog(QQuickItem* statusLog) { _statusLog = statusLog; }
 
     QString boardPort(void) { return _boardInfo.portName(); }
+
     QString boardDescription(void) { return _boardInfo.description(); }
 
     FirmwareBuildType_t selectedFirmwareBuildType(void) { return _selectedFirmwareBuildType; }
+
     void setSelectedFirmwareBuildType(FirmwareBuildType_t firmwareType);
     QString firmwareTypeAsString(FirmwareBuildType_t type) const;
 
-    QString     px4StableVersion    (void) { return _px4StableVersion; }
-    QString     px4BetaVersion  (void) { return _px4BetaVersion; }
+    QString px4StableVersion(void) { return _px4StableVersion; }
+
+    QString px4BetaVersion(void) { return _px4BetaVersion; }
 
     bool pixhawkBoard(void) const { return _boardType == QGCSerialPortInfo::BoardTypePixhawk; }
 
@@ -149,53 +158,53 @@ public:
     Q_INVOKABLE QStringList availableBoardsName(void);
 
 signals:
-    void boardFound                     (void);
-    void showFirmwareSelectDlg          (void);
-    void noBoardFound                   (void);
-    void boardGone                      (void);
-    void flashComplete                  (void);
-    void flashCancelled                 (void);
-    void error                          (void);
-    void eraseStarted                   (void);
+    void boardFound(void);
+    void showFirmwareSelectDlg(void);
+    void noBoardFound(void);
+    void boardGone(void);
+    void flashComplete(void);
+    void flashCancelled(void);
+    void error(void);
+    void eraseStarted(void);
     void selectedFirmwareBuildTypeChanged(FirmwareBuildType_t firmwareType);
-    void apmFirmwareNamesChanged        (void);
-    void px4StableVersionChanged        (const QString& px4StableVersion);
-    void px4BetaVersionChanged          (const QString& px4BetaVersion);
-    void downloadingFirmwareListChanged (bool downloadingFirmwareList);
-    void availablePortsChanged          (void);
+    void apmFirmwareNamesChanged(void);
+    void px4StableVersionChanged(const QString& px4StableVersion);
+    void px4BetaVersionChanged(const QString& px4BetaVersion);
+    void downloadingFirmwareListChanged(bool downloadingFirmwareList);
+    void availablePortsChanged(void);
 
 private slots:
-    void _firmwareDownloadProgress          (qint64 curr, qint64 total);
-    void _firmwareDownloadComplete          (bool success, const QString &localFile, const QString &errorMsg);
-    void _foundBoard                        (bool firstAttempt, const QSerialPortInfo& portInfo, int boardType, QString boardName);
-    void _noBoardFound                      (void);
-    void _boardGone                         (void);
-    void _foundBoardInfo                    (int bootloaderVersion, int boardID, int flashSize);
-    void _error                             (const QString& errorString);
-    void _status                            (const QString& statusString);
-    void _bootloaderSyncFailed              (void);
-    void _flashComplete                     (void);
-    void _updateProgress                    (int curr, int total);
-    void _eraseStarted                      (void);
-    void _eraseComplete                     (void);
-    void _eraseProgressTick                 (void);
-    void _px4ReleasesGithubDownloadComplete (bool success, const QString &localFile, const QString &errorMsg);
-    void _ardupilotManifestDownloadComplete (bool success, const QString &localFile, const QString &errorMsg);
-    void _buildAPMFirmwareNames             (void);
-    void _portsAvailable                    (const QVariantList& ports);
+    void _firmwareDownloadProgress(qint64 curr, qint64 total);
+    void _firmwareDownloadComplete(bool success, const QString& localFile, const QString& errorMsg);
+    void _foundBoard(bool firstAttempt, const QSerialPortInfo& portInfo, int boardType, QString boardName);
+    void _noBoardFound(void);
+    void _boardGone(void);
+    void _foundBoardInfo(int bootloaderVersion, int boardID, int flashSize);
+    void _error(const QString& errorString);
+    void _status(const QString& statusString);
+    void _bootloaderSyncFailed(void);
+    void _flashComplete(void);
+    void _updateProgress(int curr, int total);
+    void _eraseStarted(void);
+    void _eraseComplete(void);
+    void _eraseProgressTick(void);
+    void _px4ReleasesGithubDownloadComplete(bool success, const QString& localFile, const QString& errorMsg);
+    void _ardupilotManifestDownloadComplete(bool success, const QString& localFile, const QString& errorMsg);
+    void _buildAPMFirmwareNames(void);
+    void _portsAvailable(const QVariantList& ports);
 
 private:
     QHash<FirmwareIdentifier, QString>* _firmwareHashForBoardId(int boardId);
-    void _getFirmwareFile           (FirmwareIdentifier firmwareId);
-    void _downloadFirmware          (void);
-    void _appendStatusLog           (const QString& text, bool critical = false);
-    void _errorCancel               (const QString& msg);
-    void _determinePX4StableVersion (void);
-    void _downloadArduPilotManifest (void);
+    void _getFirmwareFile(FirmwareIdentifier firmwareId);
+    void _downloadFirmware(void);
+    void _appendStatusLog(const QString& text, bool critical = false);
+    void _errorCancel(const QString& msg);
+    void _determinePX4StableVersion(void);
+    void _downloadArduPilotManifest(void);
 
     QString _singleFirmwareURL;
-    bool    _singleFirmwareMode;
-    bool    _downloadingFirmwareList;
+    bool _singleFirmwareMode;
+    bool _downloadingFirmwareList;
     QString _portName;
     QString _portDescription;
 
@@ -206,93 +215,94 @@ private:
     QHash<FirmwareIdentifier, QString> _rgAPMChibiosReplaceNamedBoardFirmware;
     QHash<FirmwareIdentifier, QString> _rgFirmwareDynamic;
 
-    QMap<FirmwareBuildType_t, QMap<FirmwareVehicleType_t, QString> > _apmVersionMap;
-    QList<FirmwareVehicleType_t>                                _apmVehicleTypeFromCurrentVersionList;
+    QMap<FirmwareBuildType_t, QMap<FirmwareVehicleType_t, QString>> _apmVersionMap;
+    QList<FirmwareVehicleType_t> _apmVehicleTypeFromCurrentVersionList;
 
     /// Information which comes back from the bootloader
-    bool        _bootloaderFound;           ///< true: we have received the foundBootloader signals
-    uint32_t    _bootloaderVersion;         ///< Bootloader version
-    uint32_t    _bootloaderBoardID;         ///< Board ID
-    uint32_t    _bootloaderBoardFlashSize;  ///< Flash size in bytes of board
+    bool _bootloaderFound;               ///< true: we have received the foundBootloader signals
+    uint32_t _bootloaderVersion;         ///< Bootloader version
+    uint32_t _bootloaderBoardID;         ///< Board ID
+    uint32_t _bootloaderBoardFlashSize;  ///< Flash size in bytes of board
 
-    bool                 _startFlashWhenBootloaderFound;
-    FirmwareIdentifier   _startFlashWhenBootloaderFoundFirmwareIdentity;
+    bool _startFlashWhenBootloaderFound;
+    FirmwareIdentifier _startFlashWhenBootloaderFoundFirmwareIdentity;
 
-    QPixmap _boardIcon;             ///< Icon used to display image of board
+    QPixmap _boardIcon;         ///< Icon used to display image of board
 
-    QString _firmwareFilename;      ///< Image which we are going to flash to the board
+    QString _firmwareFilename;  ///< Image which we are going to flash to the board
 
     /// @brief Thread controller which is used to run bootloader commands on separate thread
     PX4FirmwareUpgradeThreadController* _threadController;
 
-    static const int    _eraseTickMsec = 500;       ///< Progress bar update tick time for erase
-    static const int    _eraseTotalMsec = 15000;    ///< Estimated amount of time erase takes
-    int                 _eraseTickCount;            ///< Number of ticks for erase progress update
-    QTimer              _eraseTimer;                ///< Timer used to update progress bar for erase
+    static const int _eraseTickMsec = 500;               ///< Progress bar update tick time for erase
+    static const int _eraseTotalMsec = 15000;            ///< Estimated amount of time erase takes
+    int _eraseTickCount;                                 ///< Number of ticks for erase progress update
+    QTimer _eraseTimer;                                  ///< Timer used to update progress bar for erase
 
-    static const int    _findBoardTimeoutMsec = 30000;      ///< Amount of time for user to plug in USB
-    static const int    _findBootloaderTimeoutMsec = 5000;  ///< Amount time to look for bootloader
+    static const int _findBoardTimeoutMsec = 30000;      ///< Amount of time for user to plug in USB
+    static const int _findBootloaderTimeoutMsec = 5000;  ///< Amount time to look for bootloader
 
-    QQuickItem*     _statusLog;         ///< Status log TextArea Qml control
-    QQuickItem*     _progressBar;
+    QQuickItem* _statusLog;                              ///< Status log TextArea Qml control
+    QQuickItem* _progressBar;
 
-    bool _searchingForBoard;    ///< true: searching for board, false: search for bootloader
+    bool _searchingForBoard;  ///< true: searching for board, false: search for bootloader
 
-    QSerialPortInfo                 _boardInfo;
-    QGCSerialPortInfo::BoardType_t  _boardType;
-    QString                         _boardTypeName;
+    QSerialPortInfo _boardInfo;
+    QGCSerialPortInfo::BoardType_t _boardType;
+    QString _boardTypeName;
 
-    FirmwareBuildType_t             _selectedFirmwareBuildType;
+    FirmwareBuildType_t _selectedFirmwareBuildType;
 
-    FirmwareImage*                  _image;
+    FirmwareImage* _image;
 
     QString _px4StableVersion;  // Version strange for latest PX4 stable
     QString _px4BetaVersion;    // Version strange for latest PX4 beta
 
     const QString _apmBoardDescriptionReplaceText;
 
-    static constexpr const char* _manifestFirmwareJsonKey =               "firmware";
-    static constexpr const char* _manifestBoardIdJsonKey =                "board_id";
-    static constexpr const char* _manifestMavTypeJsonKey =                "mav-type";
-    static constexpr const char* _manifestFormatJsonKey =                 "format";
-    static constexpr const char* _manifestUrlJsonKey =                    "url";
+    static constexpr const char* _manifestFirmwareJsonKey = "firmware";
+    static constexpr const char* _manifestBoardIdJsonKey = "board_id";
+    static constexpr const char* _manifestMavTypeJsonKey = "mav-type";
+    static constexpr const char* _manifestFormatJsonKey = "format";
+    static constexpr const char* _manifestUrlJsonKey = "url";
     static constexpr const char* _manifestMavFirmwareVersionTypeJsonKey = "mav-firmware-version-type";
-    static constexpr const char* _manifestUSBIDJsonKey =                  "USBID";
-    static constexpr const char* _manifestMavFirmwareVersionJsonKey =     "mav-firmware-version";
-    static constexpr const char* _manifestBootloaderStrJsonKey =          "bootloader_str";
-    static constexpr const char* _manifestLatestKey =                     "latest";
-    static constexpr const char* _manifestPlatformKey =                   "platform";
-    static constexpr const char* _manifestBrandNameKey =                  "brand_name";
+    static constexpr const char* _manifestUSBIDJsonKey = "USBID";
+    static constexpr const char* _manifestMavFirmwareVersionJsonKey = "mav-firmware-version";
+    static constexpr const char* _manifestBootloaderStrJsonKey = "bootloader_str";
+    static constexpr const char* _manifestLatestKey = "latest";
+    static constexpr const char* _manifestPlatformKey = "platform";
+    static constexpr const char* _manifestBrandNameKey = "brand_name";
 
-    typedef struct {
-        uint32_t                boardId;
-        FirmwareBuildType_t     firmwareBuildType;
-        FirmwareVehicleType_t   vehicleType;
-        QString                 url;
-        QString                 version;
-        QStringList             rgBootloaderPortString;
-        QList<int>              rgVID;
-        QList<int>              rgPID;
-        QString                 friendlyName;
-        bool                    chibios;
-        bool                    fmuv2;
+    typedef struct
+    {
+        uint32_t boardId;
+        FirmwareBuildType_t firmwareBuildType;
+        FirmwareVehicleType_t vehicleType;
+        QString url;
+        QString version;
+        QStringList rgBootloaderPortString;
+        QList<int> rgVID;
+        QList<int> rgPID;
+        QString friendlyName;
+        bool chibios;
+        bool fmuv2;
     } ManifestFirmwareInfo_t;
 
+    QList<ManifestFirmwareInfo_t> _rgManifestFirmwareInfo;
+    QMap<QString, FirmwareBuildType_t> _manifestMavFirmwareVersionTypeToFirmwareBuildTypeMap;
+    QMap<QString, FirmwareVehicleType_t> _manifestMavTypeToFirmwareVehicleTypeMap;
+    QStringList _apmFirmwareNames;
+    int _apmFirmwareNamesBestIndex = 0;
+    QStringList _apmFirmwareUrls;
+    Fact* _apmChibiOSSetting;
+    Fact* _apmVehicleTypeSetting;
+    QVariantList _availablePorts;
+    QPointer<QGCFileDownload> _activeDownloader;  ///< in-flight firmware download, aborted on cancel
+    bool _flashCancelled = false;                 ///< cancel was issued; ignore late download completions
 
-    QList<ManifestFirmwareInfo_t>           _rgManifestFirmwareInfo;
-    QMap<QString, FirmwareBuildType_t>      _manifestMavFirmwareVersionTypeToFirmwareBuildTypeMap;
-    QMap<QString, FirmwareVehicleType_t>    _manifestMavTypeToFirmwareVehicleTypeMap;
-    QStringList                             _apmFirmwareNames;
-    int                                     _apmFirmwareNamesBestIndex = 0;
-    QStringList                             _apmFirmwareUrls;
-    Fact*                                   _apmChibiOSSetting;
-    Fact*                                   _apmVehicleTypeSetting;
-    QVariantList                            _availablePorts;
-    QPointer<QGCFileDownload>               _activeDownloader;          ///< in-flight firmware download, aborted on cancel
-    bool                                    _flashCancelled = false;    ///< cancel was issued; ignore late download completions
-
-    FirmwareBuildType_t     _manifestMavFirmwareVersionTypeToFirmwareBuildType  (const QString& manifestMavFirmwareVersionType);
-    FirmwareVehicleType_t   _manifestMavTypeToFirmwareVehicleType               (const QString& manifestMavType);
+    FirmwareBuildType_t _manifestMavFirmwareVersionTypeToFirmwareBuildType(
+        const QString& manifestMavFirmwareVersionType);
+    FirmwareVehicleType_t _manifestMavTypeToFirmwareVehicleType(const QString& manifestMavType);
 };
 
 // global hashing function


### PR DESCRIPTION
## Summary
Apply clang-format (the repo's pinned 21.1.7 config) to FirmwareImage and FirmwareUpgradeController with no functional changes.

## Problem
These files predate clang-format enforcement and are not `.clang-format`-compliant. Since the pre-commit/CI check formats whole files, any PR that touches them is forced to reformat the entire file, burying the real change under hundreds of lines of pointer-alignment, include-sorting, brace-style and comment-reflow churn. #14530 is the immediate case.

## Solution
Reformat the files in isolation so the churn lands as a standalone, trivially-verifiable commit. The diff is pure formatting — identical include set, and code token-identical to master ignoring whitespace — and #14530 rebases on top to show a clean, formatting-free diff.
