### PR TITLE
fix(Terrain): back off after failed tile fetches to stop warning spam

### DIFF
--- a/src/Terrain/TerrainTileManager.cc
+++ b/src/Terrain/TerrainTileManager.cc
@@ -10,6 +10,7 @@
 #include "QGCLoggingCategory.h"
 #include "QGCGeo.h"
 
+#include <QtCore/QDateTime>
 #include <QtLocation/private/qgeotilespec_p.h>
 #include <QtNetwork/QNetworkAccessManager>
 #include <QtNetwork/QNetworkRequest>
@@ -72,6 +73,11 @@ bool TerrainTileManager::getAltitudesForCoordinates(const QList<QGeoCoordinate> 
                 qCDebug(TerrainTileManagerLog) << "returning elevation from tile cache" << elevation;
             }
             altitudes.push_back(elevation);
+        } else if (_isFailedTile(tileHash)) {
+            // Tile fetch failed recently; short-circuit to avoid hammering the server with repeated requests
+            // (e.g. uninitialized 0,0 coordinates from MAVLink TERRAIN_REQUEST returning HTTP 500).
+            error = true;
+            altitudes.push_back(qQNaN());
         } else if (_state != TerrainQuery::State::Downloading) {
             QGeoTileSpec spec;
             spec.setX(provider->long2tileX(coordinate.longitude(), 1));
@@ -295,21 +301,34 @@ void TerrainTileManager::_terrainDone()
     const QByteArray responseBytes = reply->mapImageData();
     const QGeoTileSpec spec = reply->tileSpec();
 
+    const QString hash = UrlFactory::getTileHash(UrlFactory::getProviderTypeFromQtMapId(spec.mapId()), spec.x(), spec.y(), spec.zoom());
+
     if (reply->error() != QGeoTiledMapReplyQGC::NoError) {
-        qCWarning(TerrainTileManagerLog) << "Elevation tile fetching returned error:" << reply->errorString();
+        const bool firstFailure = _recordFailedTile(hash);
+        if (firstFailure) {
+            qCWarning(TerrainTileManagerLog) << "Elevation tile fetching returned error:" << reply->errorString();
+        } else {
+            qCDebug(TerrainTileManagerLog) << "Elevation tile fetching returned error (suppressed):" << reply->errorString();
+        }
         _tileFailed();
         return;
     }
 
     if (responseBytes.isEmpty()) {
-        qCWarning(TerrainTileManagerLog) << "Error in fetching elevation tile. Empty response.";
+        const bool firstFailure = _recordFailedTile(hash);
+        if (firstFailure) {
+            qCWarning(TerrainTileManagerLog) << "Error in fetching elevation tile. Empty response.";
+        } else {
+            qCDebug(TerrainTileManagerLog) << "Error in fetching elevation tile. Empty response (suppressed).";
+        }
         _tileFailed();
         return;
     }
 
+    _clearFailedTile(hash);
+
     qCDebug(TerrainTileManagerLog) << "Received some bytes of terrain data:" << responseBytes.size();
 
-    const QString hash = UrlFactory::getTileHash(UrlFactory::getProviderTypeFromQtMapId(spec.mapId()), spec.x(), spec.y(), spec.zoom());
     _cacheTile(responseBytes, hash);
 
     for (qsizetype i = _requestQueue.count() - 1; i >= 0; i--) {
@@ -400,6 +419,54 @@ TerrainTile *TerrainTileManager::_getCachedTile(const QString &hash)
     }
 
     return tile;
+}
+
+bool TerrainTileManager::_isFailedTile(const QString &hash)
+{
+    QMutexLocker locker(&_tilesMutex);
+
+    const auto it = _failedTiles.constFind(hash);
+    if (it == _failedTiles.constEnd()) {
+        return false;
+    }
+    if (QDateTime::currentMSecsSinceEpoch() - it.value() < kFailedTileBackoffMs) {
+        return true;
+    }
+    _failedTiles.erase(it);
+    return false;
+}
+
+bool TerrainTileManager::_recordFailedTile(const QString &hash)
+{
+    QMutexLocker locker(&_tilesMutex);
+
+    const qint64 now = QDateTime::currentMSecsSinceEpoch();
+
+    // Opportunistic, throttled sweep: failed-tile entries are useless once their backoff
+    // window expires, so prune stale ones while we already hold the lock. Throttling to at
+    // most once per backoff window keeps this O(n) sweep from running on every failure during
+    // a burst of distinct failures.
+    if (now - _lastFailedTileSweepMs >= kFailedTileBackoffMs) {
+        _lastFailedTileSweepMs = now;
+        for (auto it = _failedTiles.begin(); it != _failedTiles.end();) {
+            if (now - it.value() >= kFailedTileBackoffMs) {
+                it = _failedTiles.erase(it);
+            } else {
+                ++it;
+            }
+        }
+    }
+
+    const bool firstFailure = !_failedTiles.contains(hash);
+    _failedTiles.insert(hash, now);
+    return firstFailure;
+}
+
+void TerrainTileManager::_clearFailedTile(const QString &hash)
+{
+    QMutexLocker locker(&_tilesMutex);
+
+    _failedTiles.remove(hash);
 }
 
 void TerrainTileManager::_processCarpetResults(const QList<double> &altitudes, int gridSizeLat, int gridSizeLon,

--- a/src/Terrain/TerrainTileManager.h
+++ b/src/Terrain/TerrainTileManager.h
@@ -40,6 +40,9 @@ private:
     void _tileFailed();
     void _cacheTile(const QByteArray &data, const QString &hash);
     TerrainTile *_getCachedTile(const QString &hash);
+    bool _isFailedTile(const QString &hash);
+    bool _recordFailedTile(const QString &hash);    ///< Records a failed fetch; returns true if this is the first failure for the tile
+    void _clearFailedTile(const QString &hash);
     static void _processCarpetResults(const QList<double> &altitudes, int gridSizeLat, int gridSizeLon,
                                       bool statsOnly, double &minHeight, double &maxHeight, QList<QList<double>> &carpet);
 
@@ -57,8 +60,12 @@ private:
     QQueue<QueuedRequestInfo_t> _requestQueue;
     TerrainQuery::State _state = TerrainQuery::State::Idle;
 
-    QMutex _tilesMutex;
+    QMutex _tilesMutex;                     ///< Guards both _tiles and _failedTiles
     QHash<QString, TerrainTile*> _tiles;
+    QHash<QString, qint64> _failedTiles;  ///< Tile hash -> ms since epoch of last failed fetch; suppresses immediate retries
+    qint64 _lastFailedTileSweepMs = 0;      ///< ms since epoch of last expired-entry sweep of _failedTiles
 
     QNetworkAccessManager *_networkManager = nullptr;
+
+    static constexpr qint64 kFailedTileBackoffMs = 5000;
 };

--- a/src/Vehicle/TerrainProtocolHandler.cc
+++ b/src/Vehicle/TerrainProtocolHandler.cc
@@ -44,8 +44,18 @@ bool TerrainProtocolHandler::mavlinkMessageReceived(const mavlink_message_t &mes
 
 void TerrainProtocolHandler::_handleTerrainRequest(const mavlink_message_t &message)
 {
+    mavlink_terrain_request_t terrainRequest;
+    mavlink_msg_terrain_request_decode(&message, &terrainRequest);
+
+    // Defensive drop: autopilots can emit TERRAIN_REQUEST with uninitialized (0, 0)
+    // before GPS lock; honoring it just spams the elevation server with tile-(0,0) fetches.
+    if (terrainRequest.lat == 0 && terrainRequest.lon == 0) {
+        qCDebug(TerrainProtocolHandlerLog) << "Ignoring TERRAIN_REQUEST with lat=0, lon=0";
+        return;
+    }
+
+    _currentTerrainRequest = terrainRequest;
     _terrainRequestActive = true;
-    mavlink_msg_terrain_request_decode(&message, &_currentTerrainRequest);
     _sendNextTerrainData();
 }
 
@@ -137,14 +147,17 @@ void TerrainProtocolHandler::_sendTerrainData(const QGeoCoordinate &swCorner, ui
         return;
     }
 
-    if (error) {
-        qCWarning(TerrainProtocolHandlerLog) << Q_FUNC_INFO << "TerrainAtCoordinateQuery::getAltitudesForCoordinates failed";
-        return;
-    }
-
-    // Only clear the bit if the query succeeds. Otherwise just let it try again on the next timer tick
+    // Clear the bit on error or success. On error (e.g. tile fetch failed at the server),
+    // looping on the bit would just hammer the same failed tile every timer tick. The vehicle
+    // will re-issue TERRAIN_REQUEST if it still needs the data, allowing a fresh attempt after
+    // TerrainTileManager's failed-tile backoff expires.
     const uint64_t removeBit = ~(1ull << gridBit);
     _currentTerrainRequest.mask &= removeBit;
+
+    if (error) {
+        qCDebug(TerrainProtocolHandlerLog) << Q_FUNC_INFO << "terrain data unavailable for gridBit" << gridBit;
+        return;
+    }
     int altIndex = 0;
     int16_t terrainData[16];
     for (const double& altitude : altitudes) {


### PR DESCRIPTION
## Summary

Eliminate the warning spam (and unnecessary network traffic) when the elevation server cannot return data for a tile, by caching recent failures in `TerrainTileManager` and not looping on a known-failed tile in `TerrainProtocolHandler`.

## Problem

When a vehicle sends `TERRAIN_REQUEST` with uninitialized lat=0/lon=0, the request maps to elevation tile (0, 0) — "Null Island". The Auterion terrain server returns HTTP 500 for that tile, but `TerrainTileManager` had no memory of recent failures, so every `TerrainProtocolHandler` timer tick (~12 Hz) dispatched a fresh HTTP request, producing continuous warnings at ~80–150 ms intervals. The handler also never cleared the mask bit on a non-success result, so it kept looping on the same failed tile.

## Solution

**`src/Terrain/TerrainTileManager.{h,cc}`**
- Add `_failedTiles` (tile hash → ms timestamp) with a 5 s backoff. While a tile is in the failed set, `getAltitudesForCoordinates` returns NaN + `error=true` without dispatching a network request.
- `_terrainDone` records the hash on failure, removes it on success, and rate-limits the warning (first failure at warning level; repeats inside the window at debug level).
- All `_failedTiles` access is serialized under the existing `_tilesMutex` (which already guards `_tiles`) via `_isFailedTile` / `_recordFailedTile` / `_clearFailedTile` helpers.
- `_recordFailedTile` performs a throttled opportunistic sweep of expired entries (at most once per backoff window) to bound memory growth.

**`src/Vehicle/TerrainProtocolHandler.cc`**
- `_sendTerrainData` now clears the mask bit on `error` as well as on success, so the handler stops looping on a known-failed tile. The vehicle re-issues `TERRAIN_REQUEST` if it still needs the data, which gets a fresh fetch once the backoff window expires.
- Demote the per-call warning to debug since the underlying cause is already logged by `TerrainTileManager`.
- Defensive drop of `TERRAIN_REQUEST` with lat=0/lon=0.

The corresponding ArduPilot PR fixes the root cause: ArduPilot/ardupilot#33135.

## How this differs from #14414

This PR is a replacement for #14414 and carries the same core approach, plus the following improvements that address review feedback on that PR:

1. **Thread-safe failed-tile cache.** #14414 read and wrote `_failedTiles` directly from `_terrainDone` and `getAltitudesForCoordinates` with **no locking**, even though the sibling `_tiles` cache is guarded by `_tilesMutex` and the public query entry points have no documented thread restriction. Here, all `_failedTiles` access goes through `_isFailedTile` / `_recordFailedTile` / `_clearFailedTile`, each taking `_tilesMutex`, consistent with `_getCachedTile` / `_cacheTile`. The lock is never held across `_tileFailed()`, `_cacheTile()`, or the queue-drain re-entry, so there is no recursive-lock risk.

2. **Bounded memory growth.** In #14414, `_failedTiles` entries were only removed on success or lazily when the same tile was re-queried after expiry, so a tile that failed once and was never revisited leaked for the process lifetime. This PR adds a throttled opportunistic sweep in `_recordFailedTile` that prunes expired entries (at most once per backoff window), keeping the set bounded by the *active* failure rate rather than lifetime-cumulative failures.

3. **Cleaner first-vs-repeat logging.** The "first failure" determination is encapsulated in `_recordFailedTile` (returns whether this was the first failure) rather than open-coded `contains`/`insert` at each call site, keeping `_terrainDone` readable and the locking correct.

Behavioral intent (5 s backoff, vehicle-driven retry, lat=0/lon=0 drop) is unchanged from #14414.
