### PR TITLE
mission planning editing views toggle for geofense, mission items

### DIFF
--- a/src/PlanView/GeoFenceEditor.qml
+++ b/src/PlanView/GeoFenceEditor.qml
@@ -16,6 +16,10 @@ Rectangle {
     property var    myGeoFenceController
     property var    flightMap
 
+    /// Emitted when the user interacts with the editor, so the plan view can make
+    /// GeoFence the active editing layer (required for the map visuals to be interactive).
+    signal requestEditingLayer()
+
     readonly property real  _editFieldWidth:    Math.min(width - _margin * 2, ScreenTools.defaultFontPixelWidth * 15)
     readonly property real  _margin:            ScreenTools.defaultFontPixelWidth / 2
     readonly property real  _radius:            ScreenTools.defaultFontPixelWidth / 2
@@ -112,6 +116,7 @@ Rectangle {
                     text:               qsTr("Polygon Fence")
 
                     onClicked: {
+                        geoFenceEditorRect.requestEditingLayer()
                         var rect = Qt.rect(flightMap.centerViewport.x, flightMap.centerViewport.y, flightMap.centerViewport.width, flightMap.centerViewport.height)
                         var topLeftCoord = flightMap.toCoordinate(Qt.point(rect.x, rect.y), false /* clipToViewPort */)
                         var bottomRightCoord = flightMap.toCoordinate(Qt.point(rect.x + rect.width, rect.y + rect.height), false /* clipToViewPort */)
@@ -124,6 +129,7 @@ Rectangle {
                     text:               qsTr("Circular Fence")
 
                     onClicked: {
+                        geoFenceEditorRect.requestEditingLayer()
                         var rect = Qt.rect(flightMap.centerViewport.x, flightMap.centerViewport.y, flightMap.centerViewport.width, flightMap.centerViewport.height)
                         var topLeftCoord = flightMap.toCoordinate(Qt.point(rect.x, rect.y), false /* clipToViewPort */)
                         var bottomRightCoord = flightMap.toCoordinate(Qt.point(rect.x + rect.width, rect.y + rect.height), false /* clipToViewPort */)
@@ -183,6 +189,7 @@ Rectangle {
                             on_InteractiveChanged: checked = _interactive
 
                             onClicked: {
+                                geoFenceEditorRect.requestEditingLayer()
                                 myGeoFenceController.clearAllInteractive()
                                 object.interactive = checked
                             }
@@ -223,7 +230,7 @@ Rectangle {
                     anchors.right:      parent.right
                     columns:            4
                     flow:               GridLayout.TopToBottom
-                    visible:            polygonSection.checked && myGeoFenceController.circles.count > 0
+                    visible:            circleSection.checked && myGeoFenceController.circles.count > 0
 
                     QGCLabel {
                         text:               qsTr("Inclusion")
@@ -259,6 +266,7 @@ Rectangle {
                             on_InteractiveChanged: checked = _interactive
 
                             onClicked: {
+                                geoFenceEditorRect.requestEditingLayer()
                                 myGeoFenceController.clearAllInteractive()
                                 object.interactive = checked
                             }

--- a/src/PlanView/PlanTreeView.qml
+++ b/src/PlanView/PlanTreeView.qml
@@ -285,8 +285,25 @@ TreeView {
             }
 
             onLoaded: {
+                if (delegateRoot.nodeType === "fenceEditor" && item) {
+                    // Interacting with the GeoFence editor makes the fence the active
+                    // editing layer so its map visuals become interactive.
+                    item.requestEditingLayer.connect(function() {
+                        root.editingLayerChangeRequested(root._layerFence)
+                    })
+                }
+                if (delegateRoot.nodeType === "rallyItem" && item) {
+                    // Selecting a rally point makes Rally the active editing layer so its
+                    // map visuals become interactive.
+                    item.requestEditingLayer.connect(function() {
+                        root.editingLayerChangeRequested(root._layerRally)
+                    })
+                }
                 if (delegateRoot.nodeType === "missionItem" && item) {
                     item.clicked.connect(function() {
+                        // Selecting a mission item makes Mission the active editing layer so its
+                        // map visuals (e.g. survey polygon tools) become interactive.
+                        root.editingLayerChangeRequested(root._layerMission)
                         root._missionController.setCurrentPlanViewSeqNum(delegateRoot.nodeObject.sequenceNumber, false)
                     })
                     item.remove.connect(function() {

--- a/src/PlanView/RallyPointItemEditor.qml
+++ b/src/PlanView/RallyPointItemEditor.qml
@@ -15,6 +15,10 @@ Rectangle {
     property var rallyPoint ///< RallyPoint object associated with editor
     property var controller ///< RallyPointController
 
+    /// Emitted when the user interacts with the editor, so the plan view can make
+    /// Rally the active editing layer (required for the map visuals to be interactive).
+    signal requestEditingLayer()
+
     property bool _currentItem: rallyPoint ? rallyPoint === controller.currentRallyPoint : false
     property color _outerTextColor: qgcPal.text
 
@@ -58,6 +62,7 @@ Rectangle {
         anchors.right: titleLayout.right
         onClicked: {
             if (mainWindow.allowViewSwitch()) {
+                root.requestEditingLayer()
                 controller.currentRallyPoint = rallyPoint
             }
         }


### PR DESCRIPTION
## Description
bug: Geofence only editable when you don't expand mission items first, this fix allows toggling edit layers of mission items, geofences and rallypoints. 

## Type of Change
<!-- Put an 'x' in the relevant boxes -->
- [ x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] CI/Build changes
- [ ] Other

## Testing
<!-- Describe the tests you ran and how to reproduce them -->
- [x ] Tested locally
- [ ] Added/updated unit tests
- [ ] Tested with simulator (SITL)
- [ ] Tested with hardware

### Platforms Tested
<!-- Check all that apply -->
- [ x] Linux
- [ ] Windows
- [ ] macOS
- [ ] Android
- [ ] iOS

### Flight Stacks Tested
<!-- If applicable -->
- [x ] PX4
- [ ] ArduPilot

## Screenshots
<!-- If applicable, add screenshots to help explain your changes -->

## Checklist
<!-- Go over all the following points, and put an 'x' in all the boxes that apply -->
- [ x] I have read the [Contribution Guidelines](CONTRIBUTING.md)
- [ x] I have read the [Code of Conduct](CODE_OF_CONDUCT.md)
- [x ] My code follows the project's coding standards
- [ ] I have added tests that prove my fix/feature works
- [ ] New and existing unit tests pass locally

## Related Issues
<!-- Link any related issues using #issue_number -->

---
By submitting this pull request, I confirm that my contribution is made under the terms of the project's dual license (Apache 2.0 and GPL v3).
