### PR TITLE
Comms: handle DNS host names for UDP, reconnect auto-connect links

### DIFF
--- a/src/AppSettings/LinkConfigurationManager.qml
+++ b/src/AppSettings/LinkConfigurationManager.qml
@@ -78,7 +78,7 @@ SettingsGroupLayout {
                 text:       object.link ? qsTr("Disconnect") : qsTr("Connect")
                 onClicked: {
                     if (object.link) {
-                        object.link.disconnect()
+                        _linkManager.disconnectLink(object.link)
                     } else {
                         _linkManager.createConnectedLink(object)
                     }

--- a/src/AppSettings/UdpSettings.qml
+++ b/src/AppSettings/UdpSettings.qml
@@ -60,7 +60,7 @@ ColumnLayout {
         QGCTextField {
             id:                     hostField
             Layout.preferredWidth:  _secondColumnWidth
-            placeholderText:        qsTr("Example: 127.0.0.1:14550")
+            placeholderText:        qsTr("IP or hostname, e.g. 127.0.0.1:14550 or my-drone.local:14550")
         }
         QGCButton {
             text:       qsTr("Add Server")

--- a/src/Comms/LinkConfiguration.h
+++ b/src/Comms/LinkConfiguration.h
@@ -54,6 +54,9 @@ public:
     /// Set if this is this an Auto Connect configuration.
     virtual void setAutoConnect(bool autoc = true);
 
+    bool suppressAutoReconnect() const { return _suppressAutoReconnect; }
+    void setSuppressAutoReconnect(bool suppress) { _suppressAutoReconnect = suppress; }
+
     /// Is this a High Latency configuration?
     ///     @return True if this is an High Latency configuration (link with large delays).
     bool isHighLatency() const { return _highLatency; }
@@ -131,6 +134,7 @@ private:
     bool _forwarding = false;  ///< Automatically added Mavlink forwarding connection
     bool _autoConnect = false; ///< This connection is started automatically at boot
     bool _highLatency = false;
+    bool _suppressAutoReconnect = false; ///< User disconnected; skip auto-reconnect until manually reconnected (runtime only)
 };
 
 typedef std::shared_ptr<LinkConfiguration> SharedLinkConfigurationPtr;

--- a/src/Comms/LinkManager.cc
+++ b/src/Comms/LinkManager.cc
@@ -90,8 +90,24 @@ void LinkManager::createConnectedLink(const LinkConfiguration *config)
     }
 }
 
+void LinkManager::disconnectLink(LinkInterface *link)
+{
+    if (!link) {
+        return;
+    }
+
+    const SharedLinkConfigurationPtr config = link->linkConfiguration();
+    if (config) {
+        config->setSuppressAutoReconnect(true);
+    }
+
+    link->disconnect();
+}
+
 bool LinkManager::createConnectedLink(SharedLinkConfigurationPtr &config)
 {
+    config->setSuppressAutoReconnect(false);
+
     SharedLinkInterfacePtr link = nullptr;
 
     switch(config->type()) {
@@ -422,6 +438,22 @@ void LinkManager::_addMAVLinkForwardingLink()
     _createDynamicForwardLink(_mavlinkForwardingLinkName, hostName);
 }
 
+void LinkManager::_reconnectAutoConnectLinks()
+{
+    for (SharedLinkConfigurationPtr &config : _rgLinkConfigs) {
+        if (!config || config->isDynamic() || !config->isAutoConnect()) {
+            continue;
+        }
+
+        if (config->link() || config->suppressAutoReconnect()) {
+            continue;
+        }
+
+        qCDebug(LinkManagerLog) << "Reconnecting auto-connect link" << config->name();
+        createConnectedLink(config);
+    }
+}
+
 void LinkManager::_updateAutoConnectLinks()
 {
     if (_connectionsSuspended) {
@@ -430,6 +462,7 @@ void LinkManager::_updateAutoConnectLinks()
 
     _addUDPAutoConnectLink();
     _addMAVLinkForwardingLink();
+    _reconnectAutoConnectLinks();
 
     // check to see if nmea gps is configured for UDP input, if so, set it up to connect
     if (_autoConnectSettings->autoConnectNmeaPort()->cookedValueString() == "UDP Port") {

--- a/src/Comms/LinkManager.h
+++ b/src/Comms/LinkManager.h
@@ -57,6 +57,7 @@ public:
     Q_INVOKABLE void removeConfiguration(LinkConfiguration *config);
     /// This should only be used by Qml code
     Q_INVOKABLE void createConnectedLink(const LinkConfiguration *config);
+    Q_INVOKABLE void disconnectLink(LinkInterface *link);
     Q_INVOKABLE void createMavlinkForwardingSupportLink();
     /// Called to signal app shutdown. Disconnects all links while turning off auto-connect.
     Q_INVOKABLE void shutdown();
@@ -124,6 +125,7 @@ private:
     void _removeConfiguration(const LinkConfiguration *config);
     void _addUDPAutoConnectLink();
     void _addMAVLinkForwardingLink();
+    void _reconnectAutoConnectLinks();
     void _createDynamicForwardLink(const char *linkName, const QString &hostName);
 
     QTimer *_portListTimer = nullptr;

--- a/src/Comms/UDPLink.cc
+++ b/src/Comms/UDPLink.cc
@@ -28,6 +28,17 @@ namespace {
 
         return false;
     }
+
+    bool containsHost(const QList<std::shared_ptr<UDPClient>> &list, const QString &hostname, quint16 port)
+    {
+        for (const std::shared_ptr<UDPClient> &target : list) {
+            if ((target->hostname == hostname) && (target->port == port)) {
+                return true;
+            }
+        }
+
+        return false;
+    }
 }
 
 /*===========================================================================*/
@@ -83,11 +94,12 @@ void UDPConfiguration::copyFrom(const LinkConfiguration *source)
     _targetHosts.clear();
 
     for (const std::shared_ptr<UDPClient> &target : udpSource->targetHosts()) {
-        if (!containsTarget(_targetHosts, target->address, target->port)) {
+        if (!containsHost(_targetHosts, target->hostname, target->port)) {
             _targetHosts.append(std::make_shared<UDPClient>(target.get()));
-            _updateHostList();
         }
     }
+
+    _updateHostList();
 }
 
 void UDPConfiguration::loadSettings(QSettings &settings, const QString &root)
@@ -121,7 +133,8 @@ void UDPConfiguration::saveSettings(QSettings &settings, const QString &root) co
     for (qsizetype i = 0; i < _targetHosts.size(); i++) {
         const std::shared_ptr<UDPClient> target = _targetHosts.at(i);
         const QString hkey = QStringLiteral("host%1").arg(i);
-        settings.setValue(hkey, target->address.toString());
+        const QString hostValue = target->hostname.isEmpty() ? target->address.toString() : target->hostname;
+        settings.setValue(hkey, hostValue);
         const QString pkey = QStringLiteral("port%1").arg(i);
         settings.setValue(pkey, target->port);
     }
@@ -149,17 +162,22 @@ void UDPConfiguration::addHost(const QString &host)
 
 void UDPConfiguration::addHost(const QString &host, quint16 port)
 {
-    const QString ipAdd = _getIpAddress(host);
-    if (ipAdd.isEmpty()) {
-        qCWarning(UDPLinkLog) << "Could not resolve host:" << host << "port:" << port;
+    const QString cleanHost = host.trimmed();
+    if (cleanHost.isEmpty()) {
         return;
     }
 
-    const QHostAddress address(ipAdd);
-    if (!containsTarget(_targetHosts, address, port)) {
-        _targetHosts.append(std::make_shared<UDPClient>(address, port));
-        _updateHostList();
+    if (containsHost(_targetHosts, cleanHost, port)) {
+        return;
     }
+
+    const QHostAddress address(_getIpAddress(cleanHost));
+    if (address.isNull()) {
+        qCWarning(UDPLinkLog) << "Could not resolve host:" << cleanHost << "port:" << port << "- will retry on connect";
+    }
+
+    _targetHosts.append(std::make_shared<UDPClient>(cleanHost, address, port));
+    _updateHostList();
 }
 
 void UDPConfiguration::removeHost(const QString &host)
@@ -171,22 +189,7 @@ void UDPConfiguration::removeHost(const QString &host)
             return;
         }
 
-        const QHostAddress address = QHostAddress(_getIpAddress(hostInfo.constFirst()));
-        const quint16 port = hostInfo.constLast().toUInt();
-
-        if (!containsTarget(_targetHosts, address, port)) {
-            qCWarning(UDPLinkLog) << "Could not remove unknown host:" << host << "port:" << port;
-            return;
-        }
-
-        for (qsizetype i = 0; i < _targetHosts.size(); ++i) {
-            const std::shared_ptr<UDPClient> &target = _targetHosts[i];
-            if (target->address == address && target->port == port) {
-                _targetHosts.removeAt(i);
-                _updateHostList();
-                return;
-            }
-        }
+        removeHost(hostInfo.constFirst(), hostInfo.constLast().toUInt());
     } else {
         removeHost(host, _localPort);
     }
@@ -194,37 +197,58 @@ void UDPConfiguration::removeHost(const QString &host)
 
 void UDPConfiguration::removeHost(const QString &host, quint16 port)
 {
-    const QString ipAdd = _getIpAddress(host);
-    if (ipAdd.isEmpty()) {
-        qCWarning(UDPLinkLog) << "Could not resolve host:" << host << "port:" << port;
-        return;
-    }
-
-    const QHostAddress address(ipAdd);
-    if (!containsTarget(_targetHosts, address, port)) {
-        qCWarning(UDPLinkLog) << "Could not remove unknown host:" << host << "port:" << port;
-        return;
-    }
+    const QString cleanHost = host.trimmed();
 
     for (qsizetype i = 0; i < _targetHosts.size(); ++i) {
         const std::shared_ptr<UDPClient> &target = _targetHosts[i];
-        if (target->address == address && target->port == port) {
+        if ((target->hostname == cleanHost) && (target->port == port)) {
             _targetHosts.removeAt(i);
             _updateHostList();
             return;
         }
     }
+
+    const QHostAddress resolved(_getIpAddress(cleanHost));
+    if (!resolved.isNull()) {
+        for (qsizetype i = 0; i < _targetHosts.size(); ++i) {
+            const std::shared_ptr<UDPClient> &target = _targetHosts[i];
+            if ((target->address == resolved) && (target->port == port)) {
+                _targetHosts.removeAt(i);
+                _updateHostList();
+                return;
+            }
+        }
+    }
+
+    qCWarning(UDPLinkLog) << "Could not remove unknown host:" << host << "port:" << port;
 }
 
 void UDPConfiguration::_updateHostList()
 {
     _hostList.clear();
     for (const std::shared_ptr<UDPClient> &target : _targetHosts) {
-        const QString host = target->address.toString() + ":" + QString::number(target->port);
+        const QString name = target->hostname.isEmpty() ? target->address.toString() : target->hostname;
+        const QString host = name + ":" + QString::number(target->port);
         _hostList.append(host);
     }
 
     emit hostListChanged();
+}
+
+void UDPConfiguration::resolveHosts() const
+{
+    for (const std::shared_ptr<UDPClient> &target : _targetHosts) {
+        if (target->hostname.isEmpty()) {
+            continue;
+        }
+
+        const QString ipAdd = _getIpAddress(target->hostname);
+        if (!ipAdd.isEmpty()) {
+            target->address = QHostAddress(ipAdd);
+        } else {
+            qCWarning(UDPLinkLog) << "Could not resolve host:" << target->hostname << "port:" << target->port;
+        }
+    }
 }
 
 QString UDPConfiguration::_getIpAddress(const QString &address)
@@ -320,6 +344,8 @@ void UDPWorker::connectLink()
 
     _errorEmitted = false;
 
+    _udpConfig->resolveHosts();
+
     qCDebug(UDPLinkLog) << "Attempting to bind to port:" << _udpConfig->localPort();
     const bool bindSuccess = _socket->bind(QHostAddress::AnyIPv4, _udpConfig->localPort(), QAbstractSocket::ReuseAddressHint | QAbstractSocket::ShareAddress);
     if (!bindSuccess) {
@@ -372,6 +398,9 @@ void UDPWorker::writeData(const QByteArray &data)
 
     // Send to all manually targeted systems
     for (const std::shared_ptr<UDPClient> &target : _udpConfig->targetHosts()) {
+        if (target->address.isNull()) {
+            continue;
+        }
         if (!containsTarget(_sessionTargets, target->address, target->port)) {
             if (_socket->writeDatagram(data, target->address, target->port) < 0) {
                 qCWarning(UDPLinkLog) << "Could Not Send Data - Write Failed!";

--- a/src/Comms/UDPLink.h
+++ b/src/Comms/UDPLink.h
@@ -23,8 +23,15 @@ struct UDPClient
         , port(portNum)
     {}
 
+    UDPClient(const QString &host, const QHostAddress &addr, quint16 portNum)
+        : hostname(host)
+        , address(addr)
+        , port(portNum)
+    {}
+
     explicit UDPClient(const UDPClient *other)
-        : address(other->address)
+        : hostname(other->hostname)
+        , address(other->address)
         , port(other->port)
     {}
 
@@ -35,12 +42,14 @@ struct UDPClient
 
     UDPClient &operator=(const UDPClient &other)
     {
+        hostname = other.hostname;
         address = other.address;
         port = other.port;
 
         return *this;
     }
 
+    QString hostname;
     QHostAddress address;
     quint16 port = 0;
 };
@@ -74,6 +83,7 @@ public:
 
     QStringList hostList() const { return _hostList; }
     QList<std::shared_ptr<UDPClient>> targetHosts() const { return _targetHosts; }
+    void resolveHosts() const;
     quint16 localPort() const { return _localPort; }
     void setLocalPort(quint16 port) { if (port != _localPort) { _localPort = port; emit localPortChanged(); } }
 

--- a/test/Comms/LinkConfigurationTest.cc
+++ b/test/Comms/LinkConfigurationTest.cc
@@ -198,6 +198,51 @@ void LinkConfigurationTest::_testTcpSettingsRoundtrip()
     }
 }
 
+void LinkConfigurationTest::_testTcpHostnameRoundtrip()
+{
+    TestFixtures::TempDirFixture tmpDir;
+    QVERIFY(tmpDir.isValid());
+    const QString iniPath = tmpDir.path() + QStringLiteral("/settings.ini");
+
+    const QString root = QStringLiteral("LinkConfigTest_TCPHost");
+    QSettings settings(iniPath, QSettings::IniFormat);
+
+    {
+        TCPConfiguration config(QStringLiteral("TCPSave"));
+        config.setHost(QStringLiteral("my-drone.local"));
+        config.setPort(5760);
+        config.saveSettings(settings, root);
+    }
+
+    {
+        TCPConfiguration config(QStringLiteral("TCPLoad"));
+        config.loadSettings(settings, root);
+        QCOMPARE(config.host(), QStringLiteral("my-drone.local"));
+        QCOMPARE(config.port(), quint16(5760));
+    }
+}
+
+void LinkConfigurationTest::_testSuppressAutoReconnectNotPersisted()
+{
+    TestFixtures::TempDirFixture tmpDir;
+    QVERIFY(tmpDir.isValid());
+    const QString iniPath = tmpDir.path() + QStringLiteral("/settings.ini");
+
+    const QString root = QStringLiteral("LinkConfigTest_Suppress");
+    QSettings settings(iniPath, QSettings::IniFormat);
+
+    TCPConfiguration config(QStringLiteral("SuppressTest"));
+    QVERIFY(!config.suppressAutoReconnect());
+
+    config.setSuppressAutoReconnect(true);
+    QVERIFY(config.suppressAutoReconnect());
+    config.saveSettings(settings, root);
+
+    TCPConfiguration loaded(QStringLiteral("SuppressLoad"));
+    loaded.loadSettings(settings, root);
+    QVERIFY(!loaded.suppressAutoReconnect());
+}
+
 // ============================================================================
 // UDPConfiguration tests
 // ============================================================================
@@ -327,6 +372,74 @@ void LinkConfigurationTest::_testUdpSettingsRoundtrip()
         QCOMPARE(config.localPort(), quint16(14550));
         QCOMPARE(config.targetHosts().size(), 2);
     }
+}
+
+void LinkConfigurationTest::_testUdpHostnamePreservedWhenUnresolved()
+{
+    ignoreLogMessage("Comms.UDPLink", QtWarningMsg, QRegularExpression("Could not resolve host"));
+    UDPConfiguration config(QStringLiteral("UDPUnresolved"));
+    config.addHost(QStringLiteral("drone.invalid"), 14550);
+
+    const auto targets = config.targetHosts();
+    QCOMPARE(targets.size(), 1);
+    const auto target = targets.constFirst();
+    QCOMPARE(target->hostname, QStringLiteral("drone.invalid"));
+    QVERIFY(target->address.isNull());
+    QCOMPARE(config.hostList().constFirst(), QStringLiteral("drone.invalid:14550"));
+}
+
+void LinkConfigurationTest::_testUdpHostnameRoundtrip()
+{
+    ignoreLogMessage("Comms.UDPLink", QtWarningMsg, QRegularExpression("Could not resolve host"));
+    TestFixtures::TempDirFixture tmpDir;
+    QVERIFY(tmpDir.isValid());
+    const QString iniPath = tmpDir.path() + QStringLiteral("/settings.ini");
+
+    const QString root = QStringLiteral("LinkConfigTest_UDPHost");
+    QSettings settings(iniPath, QSettings::IniFormat);
+
+    {
+        UDPConfiguration config(QStringLiteral("UDPSave"));
+        config.setLocalPort(14550);
+        config.addHost(QStringLiteral("drone.invalid"), 14550);
+        config.saveSettings(settings, root);
+    }
+
+    {
+        UDPConfiguration config(QStringLiteral("UDPLoad"));
+        config.loadSettings(settings, root);
+        QCOMPARE(config.targetHosts().size(), 1);
+        QCOMPARE(config.targetHosts().constFirst()->hostname, QStringLiteral("drone.invalid"));
+    }
+}
+
+void LinkConfigurationTest::_testUdpRemoveByHostname()
+{
+    ignoreLogMessage("Comms.UDPLink", QtWarningMsg, QRegularExpression("Could not resolve host"));
+    UDPConfiguration config(QStringLiteral("UDPRemoveByName"));
+    config.addHost(QStringLiteral("drone.invalid"), 14550);
+    QCOMPARE(config.targetHosts().size(), 1);
+
+    config.removeHost(QStringLiteral("drone.invalid:14550"));
+    QCOMPARE(config.targetHosts().size(), 0);
+    QVERIFY(config.hostList().isEmpty());
+}
+
+void LinkConfigurationTest::_testUdpResolveHostsUpdatesAddress()
+{
+    UDPConfiguration config(QStringLiteral("UDPResolve"));
+    config.addHost(QStringLiteral("localhost"), 14550);
+
+    auto targets = config.targetHosts();
+    QCOMPARE(targets.size(), 1);
+    QCOMPARE(targets.constFirst()->hostname, QStringLiteral("localhost"));
+
+    config.resolveHosts();
+
+    targets = config.targetHosts();
+    const QHostAddress resolved = targets.constFirst()->address;
+    QVERIFY(!resolved.isNull());
+    QVERIFY(resolved.isLoopback());
 }
 
 UT_REGISTER_TEST(LinkConfigurationTest, TestLabel::Unit, TestLabel::Comms)

--- a/test/Comms/LinkConfigurationTest.h
+++ b/test/Comms/LinkConfigurationTest.h
@@ -14,6 +14,7 @@ private slots:
     void _testBaseSetHighLatencyEmitsSignal();
     void _testBaseDefaults();
     void _testBaseSettingsRoot();
+    void _testSuppressAutoReconnectNotPersisted();
 
     // TCPConfiguration
     void _testTcpConstruction();
@@ -22,6 +23,7 @@ private slots:
     void _testTcpCopyConstruction();
     void _testTcpCopyFrom();
     void _testTcpSettingsRoundtrip();
+    void _testTcpHostnameRoundtrip();
 
     // UDPConfiguration
     void _testUdpConstruction();
@@ -30,4 +32,8 @@ private slots:
     void _testUdpCopyConstruction();
     void _testUdpCopyFrom();
     void _testUdpSettingsRoundtrip();
+    void _testUdpHostnamePreservedWhenUnresolved();
+    void _testUdpHostnameRoundtrip();
+    void _testUdpRemoveByHostname();
+    void _testUdpResolveHostsUpdatesAddress();
 };


### PR DESCRIPTION
## Summary

Makes UDP comm links handle DNS host names properly and auto-reconnect user-configured auto-connect links after they drop. TCP DNS persistence was already addressed (commit 73d870778); this adds the equivalent for UDP plus regression coverage.

Resolves #14535 (UDP equivalent — host name now persisted)
Resolves #8421 (auto-connect links reconnect)

### UDP DNS handling
Previously `addHost` resolved DNS names eagerly and stored only the resolved `QHostAddress`, so:
- `saveSettings` persisted the resolved IP and **lost the original host name** (the UDP equivalent of #14535),
- a name that failed to resolve at add time was silently dropped, and
- the address was never re-resolved, so a changed DNS record was never picked up.

Changes:
- `UDPClient` now keeps the original `hostname` alongside the resolved `address`.
- `addHost` preserves the host name, keeps unresolvable entries for later retry, and dedupes by name; `saveSettings`/`hostList` use the name (falling back to the IP).
- New `UDPConfiguration::resolveHosts()` re-resolves all targets; `UDPLink::_connect()` calls it so each (re)connect picks up changed DNS. `writeData` skips still-unresolved targets.

### Auto-connect reconnect (#8421)
User-configured auto-connect links were only started once at boot. `LinkManager::_reconnectAutoConnectLinks()` now re-establishes any dropped non-dynamic auto-connect link on the existing auto-connect timer (e.g. after a vehicle reboot) without manual intervention.

### Tests
`test/Comms/LinkConfigurationTest`: TCP host-name round-trip, UDP host-name preserved when unresolved, UDP host-name round-trip, and UDP remove-by-host-name.

## Test
`QGroundControl --unittest:LinkConfigurationTest` → **24 passed, 0 failed**.
