### PR TITLE
fix: building on Windows with Clang

### DIFF
--- a/cmake/platform/Windows.cmake
+++ b/cmake/platform/Windows.cmake
@@ -11,9 +11,10 @@ endif()
 # ----------------------------------------------------------------------------
 target_compile_definitions(${CMAKE_PROJECT_NAME}
     PRIVATE
-        _USE_MATH_DEFINES    # Enable M_PI and other math constants
-        NOMINMAX             # Prevent min/max macro conflicts
-        WIN32_LEAN_AND_MEAN  # Reduce Windows.h bloat
+        _USE_MATH_DEFINES       # Enable M_PI and other math constants
+        NOMINMAX                # Prevent min/max macro conflicts
+        WIN32_LEAN_AND_MEAN     # Reduce Windows.h bloat
+        _CRT_SECURE_NO_WARNINGS # Disable warnings for unsafe C functions
 )
 
 # ----------------------------------------------------------------------------

--- a/src/MAVLink/QGCMAVLink.cc
+++ b/src/MAVLink/QGCMAVLink.cc
@@ -328,8 +328,8 @@ QString QGCMAVLink::mavResultToString(uint8_t result)
 QString QGCMAVLink::mavSysStatusSensorToString(MAV_SYS_STATUS_SENSOR sysStatusSensor)
 {
     struct sensorInfo_s {
-        uint32_t    bit;
-        const char* sensorName;
+        MAV_SYS_STATUS_SENSOR bit;
+        const char*           sensorName;
     };
 
     static const sensorInfo_s rgSensorInfo[] = {

--- a/src/Utilities/Platform/Platform.cc
+++ b/src/Utilities/Platform/Platform.cc
@@ -76,6 +76,8 @@ void disableAppNapViaInfoDict()
 #if defined(Q_OS_WIN)
 
 #if defined(_MSC_VER)
+
+#if defined(_DEBUG)
 int __cdecl WindowsCrtReportHook(int reportType, char* message, int* returnValue)
 {
     if (message) {
@@ -89,6 +91,7 @@ int __cdecl WindowsCrtReportHook(int reportType, char* message, int* returnValue
     }
     return 0; // let CRT continue
 }
+#endif // _DEBUG
 
 void __cdecl WindowsPurecallHandler()
 {


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail. What problem does this solve? -->
Before building with Clang on Windows will fail due to various warnings and the projects use of `-Werror`.

QGC uses various "unsafe" C function which cause an deprecation warning when compiling unless you specific the `_CRT_SECURE_NO_WARNINGS` macro. [Documentation](https://learn.microsoft.com/en-us/cpp/c-runtime-library/security-features-in-the-crt?view=msvc-170)

In `QGCMAVLink::mavSysStatusSensorToString` we build a table mapping a `MAV_SYS_STATUS_SENSOR` value to the sensors name. However the used `sensorInfo_s` struct defines `bit` as `uint32` while `MAV_SYS_STATUS_SENSOR` is actually an `int32`. This causes a conversion warning [here](https://github.com/mavlink/qgroundcontrol/blob/9b731444278e1739f72c1db4b69877d755b73801/src/MAVLink/QGCMAVLink.cc#L371).

The `WindowsCrtReportHook` function is only used [here](https://github.com/mavlink/qgroundcontrol/blob/9b731444278e1739f72c1db4b69877d755b73801/src/Utilities/Platform/Platform.cc#L144). But if the `_DEBUG` macro is not defined `_CrtSetReportHook2` expands to just `(void)0` which leaves the function unused and causes a unused function compiler warning. So to fix that I've replicated the condition to only define `WindowsCrtReportHook` if the `_DEBUG` macro is set.

## Type of Change
<!-- Put an 'x' in the relevant boxes -->
- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [x] Refactoring (no functional changes)
- [ ] CI/Build changes
- [ ] Other

## Testing
<!-- Describe the tests you ran and how to reproduce them -->
- [x] Tested locally
- [ ] Added/updated unit tests
- [ ] Tested with simulator (SITL)
- [ ] Tested with hardware

### Platforms Tested
<!-- Check all that apply -->
- [ ] Linux
- [x] Windows
- [ ] macOS
- [ ] Android
- [ ] iOS

### Flight Stacks Tested
<!-- If applicable -->
- [ ] PX4
- [ ] ArduPilot

## Screenshots
<!-- If applicable, add screenshots to help explain your changes -->

## Checklist
<!-- Go over all the following points, and put an 'x' in all the boxes that apply -->
- [x] I have read the [Contribution Guidelines](CONTRIBUTING.md)
- [x] I have read the [Code of Conduct](CODE_OF_CONDUCT.md)
- [x] My code follows the project's coding standards
- [ ] I have added tests that prove my fix/feature works
- [ ] New and existing unit tests pass locally

## Related Issues
<!-- Link any related issues using #issue_number -->

---
By submitting this pull request, I confirm that my contribution is made under the terms of the project's dual license (Apache 2.0 and GPL v3).
