### PR TITLE
Comms: non-modal error for auto-reconnecting links

### DIFF
--- a/src/AppSettings/LinkConfigurationManager.qml
+++ b/src/AppSettings/LinkConfigurationManager.qml
@@ -75,10 +75,10 @@ SettingsGroupLayout {
                 }
             }
             QGCButton {
-                text:       object.link ? qsTr("Disconnect") : qsTr("Connect")
+                text:       object.linkActive ? qsTr("Disconnect") : qsTr("Connect")
                 onClicked: {
-                    if (object.link) {
-                        _linkManager.disconnectLink(object.link)
+                    if (object.linkActive) {
+                        _linkManager.disconnectLinkConfiguration(object)
                     } else {
                         _linkManager.createConnectedLink(object)
                     }

--- a/src/AppSettings/TcpSettings.qml
+++ b/src/AppSettings/TcpSettings.qml
@@ -19,7 +19,7 @@ GridLayout {
     QGCTextField {
         id:                     hostField
         Layout.preferredWidth:  _secondColumnWidth
-        text:                   subEditConfig.host
+        text:                   subEditConfig ? subEditConfig.host : ""
         placeholderText:        qsTr("localhost or 192.168.1.1")
 
         // Allow IPv4, IPv6, hostnames, and domain names
@@ -34,7 +34,7 @@ GridLayout {
     QGCTextField {
         id:                     portField
         Layout.preferredWidth:  _secondColumnWidth
-        text:                   subEditConfig.port.toString()
+        text:                   subEditConfig ? subEditConfig.port.toString() : ""
         inputMethodHints:       Qt.ImhFormattedNumbersOnly
         placeholderText:        qsTr("5760")
 

--- a/src/AppSettings/UdpSettings.qml
+++ b/src/AppSettings/UdpSettings.qml
@@ -26,18 +26,18 @@ ColumnLayout {
         QGCLabel { text: qsTr("Port") }
         QGCTextField {
             id:                     portField
-            text:                   subEditConfig.localPort.toString()
+            text:                   subEditConfig ? subEditConfig.localPort.toString() : ""
             focus:                  true
             Layout.preferredWidth:  _secondColumnWidth
             inputMethodHints:       Qt.ImhFormattedNumbersOnly
-            onTextChanged:          subEditConfig.localPort = parseInt(portField.text)
+            onTextChanged:          { if (subEditConfig) subEditConfig.localPort = parseInt(portField.text) }
         }
     }
 
     QGCLabel { text: qsTr("Server Addresses (optional)") }
 
     Repeater {
-        model: subEditConfig.hostList
+        model: subEditConfig ? subEditConfig.hostList : []
 
         delegate: RowLayout {
             spacing: _colSpacing

--- a/src/Comms/LinkConfiguration.cc
+++ b/src/Comms/LinkConfiguration.cc
@@ -132,6 +132,7 @@ void LinkConfiguration::setLink(const SharedLinkInterfacePtr link)
     if (link.get() != this->link()) {
         _link = link;
         emit linkChanged();
+        emit linkActiveChanged();
 
         if (link.get()) {
             (void) connect(link.get(), &LinkInterface::disconnected, this, &LinkConfiguration::linkChanged, Qt::QueuedConnection);
@@ -152,6 +153,7 @@ void LinkConfiguration::setAutoConnect(bool autoc)
     if (autoc != _autoConnect) {
         _autoConnect = autoc;
         emit autoConnectChanged();
+        emit linkActiveChanged();
     }
 }
 

--- a/src/Comms/LinkConfiguration.h
+++ b/src/Comms/LinkConfiguration.h
@@ -1,5 +1,7 @@
 #pragma once
 
+#include <QtCore/QDeadlineTimer>
+#include <QtCore/QElapsedTimer>
 #include <QtCore/QSettings>
 #include <QtCore/QString>
 #include <QtQmlIntegration/QtQmlIntegration>
@@ -17,6 +19,7 @@ class LinkConfiguration : public QObject
 
     Q_PROPERTY(QString          name            READ name           WRITE setName           NOTIFY nameChanged)
     Q_PROPERTY(LinkInterface    *link           READ link                                   NOTIFY linkChanged)
+    Q_PROPERTY(bool             linkActive      READ linkActive                             NOTIFY linkActiveChanged)
     Q_PROPERTY(LinkType         linkType        READ type                                   CONSTANT)
     Q_PROPERTY(bool             dynamic         READ isDynamic      WRITE setDynamic        NOTIFY dynamicChanged)
     Q_PROPERTY(bool             autoConnect     READ isAutoConnect  WRITE setAutoConnect    NOTIFY autoConnectChanged)
@@ -34,6 +37,10 @@ public:
 
     LinkInterface *link() const { return _link.lock().get(); }
     void setLink(const std::shared_ptr<LinkInterface> link);
+
+    /// True while the link is connected or being kept connected by auto-reconnect.
+    /// Stays true across reconnect attempts so UI doesn't flicker between retries.
+    bool linkActive() const { return (link() != nullptr) || (_autoConnect && _autoConnectStarted && !_suppressAutoReconnect); }
 
     /// Is this a dynamic configuration?
     ///     @return True if not persisted
@@ -55,7 +62,30 @@ public:
     virtual void setAutoConnect(bool autoc = true);
 
     bool suppressAutoReconnect() const { return _suppressAutoReconnect; }
-    void setSuppressAutoReconnect(bool suppress) { _suppressAutoReconnect = suppress; }
+    void setSuppressAutoReconnect(bool suppress) {
+        if (_suppressAutoReconnect != suppress) { _suppressAutoReconnect = suppress; emit linkActiveChanged(); }
+    }
+
+    bool autoConnectStarted() const { return _autoConnectStarted; }
+    void setAutoConnectStarted(bool started) {
+        if (_autoConnectStarted != started) { _autoConnectStarted = started; emit linkActiveChanged(); }
+    }
+
+    bool reconnectReady() const { return _nextReconnect.hasExpired(); }
+    void noteReconnectAttempt() {
+        const int exp = qMin(_reconnectAttempts, 16);
+        _reconnectAttempts = qMin(_reconnectAttempts + 1, 17);
+        _nextReconnect = QDeadlineTimer(qMin(_reconnectBaseMs << exp, _reconnectMaxMs));
+    }
+    void resetReconnectBackoff() { _reconnectAttempts = 0; _nextReconnect = QDeadlineTimer(); }
+    void noteConnected() { _connectedTimer.start(); }
+    /// Reset backoff only if the link stayed up long enough to count as working.
+    void noteDisconnected() {
+        if (_connectedTimer.isValid() && (_connectedTimer.elapsed() >= _reconnectStableMs)) {
+            resetReconnectBackoff();
+        }
+        _connectedTimer.invalidate();
+    }
 
     /// Is this a High Latency configuration?
     ///     @return True if this is an High Latency configuration (link with large delays).
@@ -121,6 +151,7 @@ public:
 signals:
     void nameChanged(const QString &name);
     void linkChanged();
+    void linkActiveChanged();
     void dynamicChanged();
     void autoConnectChanged();
     void highLatencyChanged();
@@ -135,6 +166,14 @@ private:
     bool _autoConnect = false; ///< This connection is started automatically at boot
     bool _highLatency = false;
     bool _suppressAutoReconnect = false; ///< User disconnected; skip auto-reconnect until manually reconnected (runtime only)
+    bool _autoConnectStarted = false;    ///< Link was started at boot or manually connected; gates timer reconnect (runtime only)
+    int _reconnectAttempts = 0;          ///< Consecutive failed auto-reconnect attempts (runtime only)
+    QDeadlineTimer _nextReconnect;       ///< Earliest time the next auto-reconnect may run; default-expired = ready now
+    QElapsedTimer _connectedTimer;       ///< Measures how long the current link has stayed connected (runtime only)
+
+    static constexpr int _reconnectBaseMs = 1000;
+    static constexpr int _reconnectMaxMs = 5000;
+    static constexpr int _reconnectStableMs = 2000; ///< Min connected duration to count as a working link
 };
 
 typedef std::shared_ptr<LinkConfiguration> SharedLinkConfigurationPtr;

--- a/src/Comms/LinkManager.cc
+++ b/src/Comms/LinkManager.cc
@@ -85,6 +85,8 @@ void LinkManager::createConnectedLink(const LinkConfiguration *config)
 {
     for (SharedLinkConfigurationPtr &sharedConfig : _rgLinkConfigs) {
         if (sharedConfig.get() == config) {
+            sharedConfig->setAutoConnectStarted(true);
+            sharedConfig->resetReconnectBackoff();
             createConnectedLink(sharedConfig);
         }
     }
@@ -102,6 +104,19 @@ void LinkManager::disconnectLink(LinkInterface *link)
     }
 
     link->disconnect();
+}
+
+void LinkManager::disconnectLinkConfiguration(LinkConfiguration *config)
+{
+    if (!config) {
+        return;
+    }
+
+    config->setSuppressAutoReconnect(true);
+
+    if (LinkInterface *const link = config->link()) {
+        link->disconnect();
+    }
 }
 
 bool LinkManager::createConnectedLink(SharedLinkConfigurationPtr &config)
@@ -151,6 +166,7 @@ bool LinkManager::createConnectedLink(SharedLinkConfigurationPtr &config)
     (void) connect(link.get(), &LinkInterface::communicationError, this, &LinkManager::_communicationError);
     (void) connect(link.get(), &LinkInterface::bytesReceived, MAVLinkProtocol::instance(), &MAVLinkProtocol::receiveBytes);
     (void) connect(link.get(), &LinkInterface::bytesSent, MAVLinkProtocol::instance(), &MAVLinkProtocol::logSentBytes);
+    (void) connect(link.get(), &LinkInterface::connected, this, &LinkManager::_linkConnected);
     (void) connect(link.get(), &LinkInterface::disconnected, this, &LinkManager::_linkDisconnected);
 
     MAVLinkProtocol::instance()->resetMetadataForLink(link.get());
@@ -175,8 +191,26 @@ bool LinkManager::createConnectedLink(SharedLinkConfigurationPtr &config)
     return true;
 }
 
+void LinkManager::_linkConnected()
+{
+    const LinkInterface *const link = qobject_cast<LinkInterface*>(sender());
+    const SharedLinkConfigurationPtr config = link ? link->linkConfiguration() : nullptr;
+    if (config) {
+        config->noteConnected();
+    }
+}
+
 void LinkManager::_communicationError(const QString &title, const QString &error)
 {
+    const LinkInterface *const link = qobject_cast<LinkInterface*>(sender());
+    const SharedLinkConfigurationPtr config = link ? link->linkConfiguration() : nullptr;
+
+    // Auto-connect links retry on a timer; a popup per failed attempt is just noise. Log only.
+    if (config && config->isAutoConnect() && !config->suppressAutoReconnect()) {
+        qCDebug(LinkManagerLog) << "Auto-connect link error (will retry):" << title << error;
+        return;
+    }
+
     QGC::showAppMessage(error, title);
 }
 
@@ -252,12 +286,14 @@ void LinkManager::_linkDisconnected()
     }
 
     if (config) {
+        config->noteDisconnected();
         config->setLink(nullptr);
     }
 
     (void) disconnect(link, &LinkInterface::communicationError, this, &LinkManager::_communicationError);
     (void) disconnect(link, &LinkInterface::bytesReceived, MAVLinkProtocol::instance(), &MAVLinkProtocol::receiveBytes);
     (void) disconnect(link, &LinkInterface::bytesSent, MAVLinkProtocol::instance(), &MAVLinkProtocol::logSentBytes);
+    (void) disconnect(link, &LinkInterface::connected, this, &LinkManager::_linkConnected);
     (void) disconnect(link, &LinkInterface::disconnected, this, &LinkManager::_linkDisconnected);
 
     link->_freeMavlinkChannel();
@@ -445,11 +481,19 @@ void LinkManager::_reconnectAutoConnectLinks()
             continue;
         }
 
-        if (config->link() || config->suppressAutoReconnect()) {
+        // Only re-establish links started this session (boot or manual connect); a freshly
+        // added auto-connect config waits for next app start rather than connecting now.
+        if (config->link() || config->suppressAutoReconnect() || !config->autoConnectStarted()) {
+            continue;
+        }
+
+        // Exponential backoff between attempts so a dead host isn't hammered every tick.
+        if (!config->reconnectReady()) {
             continue;
         }
 
         qCDebug(LinkManagerLog) << "Reconnecting auto-connect link" << config->name();
+        config->noteReconnectAttempt();
         createConnectedLink(config);
     }
 }
@@ -646,6 +690,7 @@ void LinkManager::startAutoConnectedLinks()
 {
     for (SharedLinkConfigurationPtr &sharedConfig : _rgLinkConfigs) {
         if (sharedConfig->isAutoConnect()) {
+            sharedConfig->setAutoConnectStarted(true);
             createConnectedLink(sharedConfig);
         }
     }

--- a/src/Comms/LinkManager.h
+++ b/src/Comms/LinkManager.h
@@ -40,6 +40,8 @@ class LinkManager : public QObject
     Q_PROPERTY(QStringList linkTypeStrings READ linkTypeStrings CONSTANT)
     Q_PROPERTY(bool mavlinkSupportForwardingEnabled READ mavlinkSupportForwardingEnabled NOTIFY mavlinkSupportForwardingEnabledChanged)
 
+    friend class LinkManagerTest;
+
 public:
     explicit LinkManager(QObject *parent = nullptr);
     ~LinkManager();
@@ -58,6 +60,8 @@ public:
     /// This should only be used by Qml code
     Q_INVOKABLE void createConnectedLink(const LinkConfiguration *config);
     Q_INVOKABLE void disconnectLink(LinkInterface *link);
+    /// Stop a link and suppress auto-reconnect, working whether or not a live link currently exists.
+    Q_INVOKABLE void disconnectLinkConfiguration(LinkConfiguration *config);
     Q_INVOKABLE void createMavlinkForwardingSupportLink();
     /// Called to signal app shutdown. Disconnects all links while turning off auto-connect.
     Q_INVOKABLE void shutdown();
@@ -114,6 +118,7 @@ signals:
     void isBluetoothAvailableChanged();
 
 private slots:
+    void _linkConnected();
     void _linkDisconnected();
     void _communicationError(const QString &title, const QString &error);
 

--- a/src/MainWindow/MainWindow.qml
+++ b/src/MainWindow/MainWindow.qml
@@ -546,7 +546,7 @@ ApplicationWindow {
                 if (criticalVehicleMessagePopup.additionalCriticalMessagesReceived) {
                     criticalVehicleMessagePopup.additionalCriticalMessagesReceived = false;
                     flyView.dropMainStatusIndicatorTool();
-                } else {
+                } else if (QGroundControl.multiVehicleManager.activeVehicle) {
                     QGroundControl.multiVehicleManager.activeVehicle.resetErrorLevelMessages();
                 }
             }

--- a/test/Comms/CMakeLists.txt
+++ b/test/Comms/CMakeLists.txt
@@ -7,6 +7,8 @@ target_sources(${CMAKE_PROJECT_NAME}
     PRIVATE
         LinkConfigurationTest.cc
         LinkConfigurationTest.h
+        LinkManagerTest.cc
+        LinkManagerTest.h
         QGCSerialPortInfoTest.cc
         QGCSerialPortInfoTest.h
 )
@@ -16,4 +18,5 @@ target_include_directories(${CMAKE_PROJECT_NAME} PRIVATE ${CMAKE_CURRENT_SOURCE_
 add_subdirectory(Bluetooth)
 
 add_qgc_test(LinkConfigurationTest LABELS Unit Comms RESOURCE_LOCK Settings TempFiles)
+add_qgc_test(LinkManagerTest LABELS Integration Comms SERIAL)
 add_qgc_test(QGCSerialPortInfoTest LABELS Unit Comms)

--- a/test/Comms/LinkConfigurationTest.cc
+++ b/test/Comms/LinkConfigurationTest.cc
@@ -243,6 +243,18 @@ void LinkConfigurationTest::_testSuppressAutoReconnectNotPersisted()
     QVERIFY(!loaded.suppressAutoReconnect());
 }
 
+void LinkConfigurationTest::_testReconnectBackoff()
+{
+    TCPConfiguration config(QStringLiteral("BackoffTest"));
+    QVERIFY(config.reconnectReady());
+
+    config.noteReconnectAttempt();
+    QVERIFY(!config.reconnectReady());
+
+    config.resetReconnectBackoff();
+    QVERIFY(config.reconnectReady());
+}
+
 // ============================================================================
 // UDPConfiguration tests
 // ============================================================================

--- a/test/Comms/LinkConfigurationTest.h
+++ b/test/Comms/LinkConfigurationTest.h
@@ -15,6 +15,7 @@ private slots:
     void _testBaseDefaults();
     void _testBaseSettingsRoot();
     void _testSuppressAutoReconnectNotPersisted();
+    void _testReconnectBackoff();
 
     // TCPConfiguration
     void _testTcpConstruction();

--- a/test/Comms/LinkManagerTest.cc
+++ b/test/Comms/LinkManagerTest.cc
@@ -1,0 +1,123 @@
+#include "LinkManagerTest.h"
+
+#include "LinkManager.h"
+#include "MockLink.h"
+
+#include <QtTest/QTest>
+
+SharedLinkConfigurationPtr LinkManagerTest::_addMockConfig(const QString &name, bool dynamic, bool autoConnect)
+{
+    MockConfiguration *const mockConfig = new MockConfiguration(name);
+    mockConfig->setDynamic(dynamic);
+    mockConfig->setAutoConnect(autoConnect);
+
+    SharedLinkConfigurationPtr config = linkManager()->addConfiguration(mockConfig);
+    config->setAutoConnectStarted(true);
+    if (!linkManager()->createConnectedLink(config)) {
+        linkManager()->removeConfiguration(config.get());
+        return nullptr;
+    }
+    return config;
+}
+
+void LinkManagerTest::_reconnect()
+{
+    linkManager()->_reconnectAutoConnectLinks();
+}
+
+void LinkManagerTest::_testReconnectsDroppedAutoConnectLink()
+{
+    SharedLinkConfigurationPtr config = _addMockConfig(QStringLiteral("ReconnectMock"), false /*dynamic*/, true /*autoConnect*/);
+    QVERIFY(config);
+    QVERIFY(config->link());
+
+    config->link()->disconnect();
+    QTRY_VERIFY_WITH_TIMEOUT(config->link() == nullptr, TestTimeout::mediumMs());
+
+    _reconnect();
+    QVERIFY(config->link());
+
+    linkManager()->removeConfiguration(config.get());
+}
+
+void LinkManagerTest::_testSuppressedLinkNotReconnected()
+{
+    SharedLinkConfigurationPtr config = _addMockConfig(QStringLiteral("SuppressMock"), false /*dynamic*/, true /*autoConnect*/);
+    QVERIFY(config);
+    QVERIFY(config->link());
+
+    // Manual disconnect sets suppressAutoReconnect so the timer leaves it alone.
+    linkManager()->disconnectLink(config->link());
+    QTRY_VERIFY_WITH_TIMEOUT(config->link() == nullptr, TestTimeout::mediumMs());
+    QVERIFY(config->suppressAutoReconnect());
+
+    _reconnect();
+    QVERIFY(config->link() == nullptr);
+
+    linkManager()->removeConfiguration(config.get());
+}
+
+void LinkManagerTest::_testDynamicLinkNotReconnected()
+{
+    SharedLinkConfigurationPtr config = _addMockConfig(QStringLiteral("DynamicMock"), true /*dynamic*/, true /*autoConnect*/);
+    QVERIFY(config);
+    QVERIFY(config->link());
+
+    config->link()->disconnect();
+    QTRY_VERIFY_WITH_TIMEOUT(config->link() == nullptr, TestTimeout::mediumMs());
+
+    _reconnect();
+    QVERIFY(config->link() == nullptr);
+
+    linkManager()->removeConfiguration(config.get());
+}
+
+void LinkManagerTest::_testNonAutoConnectLinkNotReconnected()
+{
+    SharedLinkConfigurationPtr config = _addMockConfig(QStringLiteral("ManualMock"), false /*dynamic*/, false /*autoConnect*/);
+    QVERIFY(config);
+    QVERIFY(config->link());
+
+    config->link()->disconnect();
+    QTRY_VERIFY_WITH_TIMEOUT(config->link() == nullptr, TestTimeout::mediumMs());
+
+    _reconnect();
+    QVERIFY(config->link() == nullptr);
+
+    linkManager()->removeConfiguration(config.get());
+}
+
+void LinkManagerTest::_testNeverStartedLinkNotConnected()
+{
+    MockConfiguration *const mockConfig = new MockConfiguration(QStringLiteral("NeverStartedMock"));
+    mockConfig->setDynamic(false);
+    mockConfig->setAutoConnect(true);
+    SharedLinkConfigurationPtr config = linkManager()->addConfiguration(mockConfig);
+    QVERIFY(!config->autoConnectStarted());
+    QVERIFY(config->link() == nullptr);
+
+    _reconnect();
+    QVERIFY(config->link() == nullptr);
+
+    linkManager()->removeConfiguration(config.get());
+}
+
+void LinkManagerTest::_testLinkActiveStableAcrossReconnect()
+{
+    SharedLinkConfigurationPtr config = _addMockConfig(QStringLiteral("ActiveMock"), false /*dynamic*/, true /*autoConnect*/);
+    QVERIFY(config);
+    QVERIFY(config->linkActive());
+
+    config->link()->disconnect();
+    QTRY_VERIFY_WITH_TIMEOUT(config->link() == nullptr, TestTimeout::mediumMs());
+    QVERIFY(config->linkActive());
+
+    linkManager()->disconnectLinkConfiguration(config.get());
+    QVERIFY(!config->linkActive());
+    _reconnect();
+    QVERIFY(config->link() == nullptr);
+
+    linkManager()->removeConfiguration(config.get());
+}
+
+UT_REGISTER_TEST(LinkManagerTest, TestLabel::Integration, TestLabel::Comms)

--- a/test/Comms/LinkManagerTest.h
+++ b/test/Comms/LinkManagerTest.h
@@ -1,0 +1,23 @@
+#pragma once
+
+#include "CommsTest.h"
+#include "LinkConfiguration.h"
+
+/// Tests for LinkManager::_reconnectAutoConnectLinks() — the auto-connect link
+/// re-establishment driven off the auto-connect timer (PR #14547).
+class LinkManagerTest : public CommsTest
+{
+    Q_OBJECT
+
+private slots:
+    void _testReconnectsDroppedAutoConnectLink();
+    void _testSuppressedLinkNotReconnected();
+    void _testDynamicLinkNotReconnected();
+    void _testNonAutoConnectLinkNotReconnected();
+    void _testNeverStartedLinkNotConnected();
+    void _testLinkActiveStableAcrossReconnect();
+
+private:
+    SharedLinkConfigurationPtr _addMockConfig(const QString &name, bool dynamic, bool autoConnect);
+    void _reconnect();
+};


### PR DESCRIPTION
## Summary

Follow-up to #14547. As reported in https://github.com/mavlink/qgroundcontrol/pull/14547#issuecomment-4738512694, auto-connect links that fail to (re)connect spammed blocking modal dialogs. While fixing that, a few related rough edges in the auto-reconnect path are addressed.

Auto-connect links are re-established by `LinkManager::_reconnectAutoConnectLinks()` on the auto-connect timer (#8421). This PR makes that quiet and well-behaved:

- **No popup spam** — errors from auto-connect links are logged only (no dialog); manual connections still get the modal `showAppMessage`.
- **Boot-only autostart** — reconnect is gated on a runtime `autoConnectStarted` flag (set at boot in `startAutoConnectedLinks()` and on explicit user Connect), so a freshly *added* auto-connect config waits for the next app start instead of being connected immediately by the timer.
- **Stable Comm Links button** — new `LinkConfiguration::linkActive` (connected **or** armed auto-reconnect) keeps the Connect/Disconnect button from flickering between retries; `disconnectLinkConfiguration()` cancels a link that has no live instance (the retry gap).
- **Exponential backoff** — per-config reconnect backoff (1 s → 5 s cap), reset only after a link stays up long enough to count as working (so an accept-then-close host keeps backing off instead of being hammered every tick).
- **Pre-existing fix** — guards the null-`subEditConfig` `TypeError` in `TcpSettings.qml`/`UdpSettings.qml` thrown when the edit dialog's config is torn down on close.

## Tests

`LinkManagerTest` (Integration/Comms) and `LinkConfigurationTest` (Unit/Comms) cover: reconnect of a dropped auto-connect link; skip of suppressed / dynamic / non-auto-connect / never-started configs; `linkActive` stability across a reconnect; and the backoff state machine.

```
$ build/Debug/QGroundControl --unittest:LinkManagerTest        # 8 passed
$ build/Debug/QGroundControl --unittest:LinkConfigurationTest  # 27 passed
```