### PR TITLE
Add support for MAV_CMD_DO_SET_GLOBAL_ORIGIN (replaces SET_GPS_GLOBAL…

### DIFF
--- a/src/Comms/MockLink/MockLink.cc
+++ b/src/Comms/MockLink/MockLink.cc
@@ -845,6 +845,12 @@ void MockLink::_updateIncomingMessageCounts(const mavlink_message_t &msg)
             _receivedRequestMessageCountMap[static_cast<uint32_t>(request.param1)]++;
             _receivedRequestMessageByCompAndMsgCountMap[request.target_component][static_cast<int>(request.param1)]++;
         }
+    } else if (msg.msgid == MAVLINK_MSG_ID_COMMAND_INT) {
+        mavlink_command_int_t request{};
+        mavlink_msg_command_int_decode(&msg, &request);
+
+        _receivedMavCommandCountMap[static_cast<MAV_CMD>(request.command)]++;
+        _receivedMavCommandByCompCountMap[static_cast<MAV_CMD>(request.command)][request.target_component]++;
     }
 }
 
@@ -885,6 +891,9 @@ void MockLink::_handleIncomingMavlinkMsg(const mavlink_message_t &msg)
         break;
     case MAVLINK_MSG_ID_COMMAND_LONG:
         _handleCommandLong(msg);
+        break;
+    case MAVLINK_MSG_ID_COMMAND_INT:
+        _handleCommandInt(msg);
         break;
     case MAVLINK_MSG_ID_MANUAL_CONTROL:
         _handleManualControl(msg);
@@ -1781,6 +1790,33 @@ void MockLink::_handleCommandLong(const mavlink_message_t &msg)
         break;
     }
     }
+
+    mavlink_message_t commandAck{};
+    (void) mavlink_msg_command_ack_pack_chan(
+        _vehicleSystemId,
+        _vehicleComponentId,
+        _outgoingMavlinkChannel,
+        &commandAck,
+        request.command,
+        commandResult,
+        0,    // progress
+        0,    // result_param2
+        0,    // target_system
+        0     // target_component
+    );
+    respondWithMavlinkMessage(commandAck);
+}
+
+void MockLink::_handleCommandInt(const mavlink_message_t &msg)
+{
+    mavlink_command_int_t request{};
+    mavlink_msg_command_int_decode(&msg, &request);
+
+    // MockLink does not implement any COMMAND_INT commands yet, so it reports them as
+    // unsupported (mirroring the COMMAND_LONG default for unrecognized commands). This
+    // lets unit tests exercise "try command, fall back to legacy message" code paths
+    // such as Vehicle::setEstimatorOrigin.
+    const uint8_t commandResult = MAV_RESULT_UNSUPPORTED;
 
     mavlink_message_t commandAck{};
     (void) mavlink_msg_command_ack_pack_chan(

--- a/src/Comms/MockLink/MockLink.h
+++ b/src/Comms/MockLink/MockLink.h
@@ -235,6 +235,7 @@ private:
     void _handleParamRequestRead(const mavlink_message_t &msg);
     void _handleFTP(const mavlink_message_t &msg);
     void _handleCommandLong(const mavlink_message_t &msg);
+    void _handleCommandInt(const mavlink_message_t &msg);
     void _handleInProgressCommandLong(const mavlink_command_long_t &request);
     void _handleCommandLongSetMessageInterval(const mavlink_command_long_t &request, bool &acccepted);
     void _handleManualControl(const mavlink_message_t &msg);

--- a/src/Vehicle/MavCommandQueue.cc
+++ b/src/Vehicle/MavCommandQueue.cc
@@ -126,7 +126,7 @@ void lambdaFallbackResultHandler(void* resultHandlerData, int /*compId*/, const 
 
 } // namespace
 
-void MavCommandQueue::sendCommandWithLambdaFallback(std::function<void()> lambda, int compId, MAV_CMD command, bool showError, float param1, float param2, float param3, float param4, float param5, float param6, float param7)
+void MavCommandQueue::sendCommandWithLambdaFallbackWorker(std::function<void()> lambda, bool commandInt, int compId, MAV_CMD command, MAV_FRAME frame, bool showError, float param1, float param2, float param3, float param4, double param5, double param6, float param7)
 {
     auto* instanceData = _vehicle->firmwarePluginInstanceData();
 
@@ -135,7 +135,11 @@ void MavCommandQueue::sendCommandWithLambdaFallback(std::function<void()> lambda
         lambda();
         break;
     case FirmwarePluginInstanceData::CommandSupportedResult::SUPPORTED:
-        sendCommand(compId, command, showError, param1, param2, param3, param4, param5, param6, param7);
+        if (commandInt) {
+            sendCommandInt(compId, command, frame, showError, param1, param2, param3, param4, param5, param6, param7);
+        } else {
+            sendCommand(compId, command, showError, param1, param2, param3, param4, param5, param6, param7);
+        }
         break;
     case FirmwarePluginInstanceData::CommandSupportedResult::UNKNOWN: {
         auto* data = new LambdaFallbackHandlerData { _vehicle, showError, std::move(lambda) };
@@ -145,10 +149,24 @@ void MavCommandQueue::sendCommandWithLambdaFallback(std::function<void()> lambda
             /* .progressHandler       = */ nullptr,
             /* .progressHandlerData   = */ nullptr,
         };
-        sendCommandWithHandler(&handlerInfo, compId, command, param1, param2, param3, param4, param5, param6, param7);
+        if (commandInt) {
+            sendCommandIntWithHandler(&handlerInfo, compId, command, frame, param1, param2, param3, param4, param5, param6, param7);
+        } else {
+            sendCommandWithHandler(&handlerInfo, compId, command, param1, param2, param3, param4, param5, param6, param7);
+        }
         break;
     }
     }
+}
+
+void MavCommandQueue::sendCommandWithLambdaFallback(std::function<void()> lambda, int compId, MAV_CMD command, bool showError, float param1, float param2, float param3, float param4, float param5, float param6, float param7)
+{
+    sendCommandWithLambdaFallbackWorker(std::move(lambda), false /* commandInt */, compId, command, MAV_FRAME_GLOBAL, showError, param1, param2, param3, param4, param5, param6, param7);
+}
+
+void MavCommandQueue::sendCommandIntWithLambdaFallback(std::function<void()> lambda, int compId, MAV_CMD command, MAV_FRAME frame, bool showError, float param1, float param2, float param3, float param4, double param5, double param6, float param7)
+{
+    sendCommandWithLambdaFallbackWorker(std::move(lambda), true /* commandInt */, compId, command, frame, showError, param1, param2, param3, param4, param5, param6, param7);
 }
 
 bool MavCommandQueue::isPending(int targetCompId, MAV_CMD command) const

--- a/src/Vehicle/MavCommandQueue.h
+++ b/src/Vehicle/MavCommandQueue.h
@@ -35,6 +35,7 @@ public:
     void sendCommandIntWithHandler (const MavCmdAckHandlerInfo_t* ackHandlerInfo, int compId, MAV_CMD command, MAV_FRAME frame, float param1 = 0.0f, float param2 = 0.0f, float param3 = 0.0f, float param4 = 0.0f, double param5 = 0.0, double param6 = 0.0, float param7 = 0.0f);
 
     void sendCommandWithLambdaFallback(std::function<void()> lambda, int compId, MAV_CMD command, bool showError, float param1 = 0.0f, float param2 = 0.0f, float param3 = 0.0f, float param4 = 0.0f, float param5 = 0.0f, float param6 = 0.0f, float param7 = 0.0f);
+    void sendCommandIntWithLambdaFallback(std::function<void()> lambda, int compId, MAV_CMD command, MAV_FRAME frame, bool showError, float param1 = 0.0f, float param2 = 0.0f, float param3 = 0.0f, float param4 = 0.0f, double param5 = 0.0, double param6 = 0.0, float param7 = 0.0f);
 
     /// Full-control entry point used by higher-level coordinators (e.g. RequestMessageCoordinator)
     /// that need to set commandInt/frame/handlers explicitly. Consumers should prefer the
@@ -91,6 +92,8 @@ private:
         QElapsedTimer           elapsedTimer;
         int                     ackTimeoutMSecs     = 0;
     } MavCommandListEntry_t;
+
+    void sendCommandWithLambdaFallbackWorker(std::function<void()> lambda, bool commandInt, int compId, MAV_CMD command, MAV_FRAME frame, bool showError, float param1, float param2, float param3, float param4, double param5, double param6, float param7);
 
     void _sendFromList(int index);
     static bool _shouldRetry(MAV_CMD command);

--- a/src/Vehicle/Vehicle.cc
+++ b/src/Vehicle/Vehicle.cc
@@ -2184,6 +2184,11 @@ void Vehicle::sendMavCommandWithLambdaFallback(std::function<void()> lambda, int
     _mavCmdQueue->sendCommandWithLambdaFallback(std::move(lambda), compId, command, showError, param1, param2, param3, param4, param5, param6, param7);
 }
 
+void Vehicle::sendMavCommandIntWithLambdaFallback(std::function<void()> lambda, int compId, MAV_CMD command, MAV_FRAME frame, bool showError, float param1, float param2, float param3, float param4, double param5, double param6, float param7)
+{
+    _mavCmdQueue->sendCommandIntWithLambdaFallback(std::move(lambda), compId, command, frame, showError, param1, param2, param3, param4, param5, param6, param7);
+}
+
 bool Vehicle::isMavCommandPending(int targetCompId, MAV_CMD command)
 {
     return _mavCmdQueue->isPending(targetCompId, command);
@@ -3142,6 +3147,24 @@ void Vehicle::sendGripperAction(GRIPPER_ACTIONS gripperAction)
 }
 
 void Vehicle::setEstimatorOrigin(const QGeoCoordinate& centerCoord)
+{
+    // Prefer MAV_CMD_DO_SET_GLOBAL_ORIGIN (sent as COMMAND_INT, supersedes SET_GPS_GLOBAL_ORIGIN).
+    sendMavCommandIntWithLambdaFallback(
+        [this, centerCoord]() {  // fallback: deprecated SET_GPS_GLOBAL_ORIGIN message
+            setEstimatorOrigin_SET_GPS_GLOBAL_ORIGIN(centerCoord);
+        },
+        defaultComponentId(),
+        MAV_CMD_DO_SET_GLOBAL_ORIGIN,
+        MAV_FRAME_GLOBAL,
+        false,                                          // showError
+        0.0f, 0.0f, 0.0f, 0.0f,                         // param 1-4 empty
+        centerCoord.latitude(),                         // param5: latitude (deg) -> degE7
+        centerCoord.longitude(),                        // param6: longitude (deg) -> degE7
+        static_cast<float>(centerCoord.altitude())      // param7: altitude (m)
+    );
+}
+
+void Vehicle::setEstimatorOrigin_SET_GPS_GLOBAL_ORIGIN(const QGeoCoordinate& centerCoord)
 {
     SharedLinkInterfacePtr sharedLink = vehicleLinkManager()->primaryLink().lock();
     if (!sharedLink) {

--- a/src/Vehicle/Vehicle.h
+++ b/src/Vehicle/Vehicle.h
@@ -356,6 +356,9 @@ public:
     Q_INVOKABLE void sendPlan(QString planFile);
     Q_INVOKABLE void setEstimatorOrigin(const QGeoCoordinate& centerCoord);
 
+    /// Fallback for setEstimatorOrigin which sends the deprecated SET_GPS_GLOBAL_ORIGIN message.
+    void setEstimatorOrigin_SET_GPS_GLOBAL_ORIGIN(const QGeoCoordinate& centerCoord);
+
     /// Used to check if running current version is equal or higher than the one being compared.
     //  returns 1 if current > compare, 0 if current == compare, -1 if current < compare
     Q_INVOKABLE int versionCompare(const QString& compare) const;
@@ -635,6 +638,14 @@ public:
         int compId, MAV_CMD command,
         bool showError,
         float param1 = 0.0f, float param2 = 0.0f, float param3 = 0.0f, float param4 = 0.0f, float param5 = 0.0f, float param6 = 0.0f, float param7 = 0.0f);
+
+    /// Sends the command as a COMMAND_INT and calls the fallback lambda function in
+    /// case the command is MAV_RESULT_UNSUPPORTED
+    void sendMavCommandIntWithLambdaFallback(
+        std::function<void()> lambda,
+        int compId, MAV_CMD command, MAV_FRAME frame,
+        bool showError,
+        float param1 = 0.0f, float param2 = 0.0f, float param3 = 0.0f, float param4 = 0.0f, double param5 = 0.0, double param6 = 0.0, float param7 = 0.0f);
 
 
     static QString requestMessageResultHandlerFailureCodeToString(RequestMessageResultHandlerFailureCode_t failureCode);

--- a/test/Vehicle/CMakeLists.txt
+++ b/test/Vehicle/CMakeLists.txt
@@ -23,6 +23,8 @@ target_sources(${CMAKE_PROJECT_NAME}
         SendMavCommandWithHandlerTest.h
         SendMavCommandWithSignallingTest.cc
         SendMavCommandWithSignallingTest.h
+        SetEstimatorOriginTest.cc
+        SetEstimatorOriginTest.h
         VehicleLinkManagerTest.cc
         VehicleLinkManagerTest.h
 )
@@ -52,4 +54,5 @@ add_qgc_test(MAVLinkLogManagerTest LABELS Integration Vehicle)
 add_qgc_test(RequestMessageTest LABELS Integration Vehicle TIMEOUT ${QGC_TEST_TIMEOUT_EXTENDED})
 add_qgc_test(SendMavCommandWithHandlerTest LABELS Integration Vehicle)
 add_qgc_test(SendMavCommandWithSignallingTest LABELS Integration Vehicle)
+add_qgc_test(SetEstimatorOriginTest LABELS Integration Vehicle)
 add_qgc_test(VehicleLinkManagerTest LABELS Integration Vehicle SERIAL)

--- a/test/Vehicle/SetEstimatorOriginTest.cc
+++ b/test/Vehicle/SetEstimatorOriginTest.cc
@@ -1,0 +1,88 @@
+#include "SetEstimatorOriginTest.h"
+
+#include <QtPositioning/QGeoCoordinate>
+
+#include "FirmwarePlugin.h"
+#include "MockLink.h"
+#include "Vehicle.h"
+
+namespace {
+using CommandSupportedResult = FirmwarePluginInstanceData::CommandSupportedResult;
+
+// Arbitrary valid origin (Zurich) used for all cases.
+const QGeoCoordinate kOrigin(47.3977419, 8.5455938, 488.0);
+}
+
+/// When the command is already known to be unsupported, setEstimatorOrigin must skip the
+/// command entirely and send the deprecated SET_GPS_GLOBAL_ORIGIN message directly.
+void SetEstimatorOriginTest::_cachedUnsupported_sendsLegacyMessageOnly()
+{
+    QVERIFY(_vehicle);
+    FirmwarePluginInstanceData* instanceData = _vehicle->firmwarePluginInstanceData();
+    QVERIFY(instanceData);
+
+    instanceData->setCommandSupported(MAV_CMD_DO_SET_GLOBAL_ORIGIN, CommandSupportedResult::UNSUPPORTED);
+
+    _mockLink->clearReceivedMavCommandCounts();
+    _mockLink->clearReceivedMavlinkMessageCounts();
+    _vehicle->setEstimatorOrigin(kOrigin);
+
+    QVERIFY_TRUE_WAIT(_mockLink->receivedMavlinkMessageCount(MAVLINK_MSG_ID_SET_GPS_GLOBAL_ORIGIN) == 1,
+                      TestTimeout::longMs());
+    QCOMPARE(_mockLink->receivedMavCommandCount(MAV_CMD_DO_SET_GLOBAL_ORIGIN), 0);
+}
+
+/// When the command is already known to be supported, setEstimatorOrigin must send it as a
+/// COMMAND_INT and must never fall back to the deprecated message (even if the vehicle NAKs).
+void SetEstimatorOriginTest::_cachedSupported_sendsCommandIntOnly()
+{
+    QVERIFY(_vehicle);
+    FirmwarePluginInstanceData* instanceData = _vehicle->firmwarePluginInstanceData();
+    QVERIFY(instanceData);
+
+    instanceData->setCommandSupported(MAV_CMD_DO_SET_GLOBAL_ORIGIN, CommandSupportedResult::SUPPORTED);
+
+    _mockLink->clearReceivedMavCommandCounts();
+    _mockLink->clearReceivedMavlinkMessageCounts();
+    _vehicle->setEstimatorOrigin(kOrigin);
+
+    QVERIFY_TRUE_WAIT(_mockLink->receivedMavCommandCount(MAV_CMD_DO_SET_GLOBAL_ORIGIN) == 1,
+                      TestTimeout::longMs());
+    QCOMPARE(_mockLink->receivedMavlinkMessageCount(MAVLINK_MSG_ID_SET_GPS_GLOBAL_ORIGIN), 0);
+    // The cached-supported path installs no fallback handler, so the vehicle's UNSUPPORTED ack
+    // must not re-cache the command or trigger the legacy message.
+    QVERIFY(instanceData->getCommandSupported(MAV_CMD_DO_SET_GLOBAL_ORIGIN) == CommandSupportedResult::SUPPORTED);
+}
+
+/// With support unknown, setEstimatorOrigin probes with a COMMAND_INT. MockLink NAKs it with
+/// MAV_RESULT_UNSUPPORTED, which must trigger the SET_GPS_GLOBAL_ORIGIN fallback and cache the
+/// command as unsupported so subsequent calls skip the probe.
+void SetEstimatorOriginTest::_probeUnsupported_fallsBackAndCachesUnsupported()
+{
+    QVERIFY(_vehicle);
+    FirmwarePluginInstanceData* instanceData = _vehicle->firmwarePluginInstanceData();
+    QVERIFY(instanceData);
+    QVERIFY(instanceData->getCommandSupported(MAV_CMD_DO_SET_GLOBAL_ORIGIN) == CommandSupportedResult::UNKNOWN);
+
+    _mockLink->clearReceivedMavCommandCounts();
+    _mockLink->clearReceivedMavlinkMessageCounts();
+    _vehicle->setEstimatorOrigin(kOrigin);
+
+    // Probe goes out as a COMMAND_INT, then the legacy message is sent once the NAK arrives.
+    QVERIFY_TRUE_WAIT(_mockLink->receivedMavlinkMessageCount(MAVLINK_MSG_ID_SET_GPS_GLOBAL_ORIGIN) == 1,
+                      TestTimeout::longMs());
+    QCOMPARE(_mockLink->receivedMavCommandCount(MAV_CMD_DO_SET_GLOBAL_ORIGIN), 1);
+    QVERIFY(instanceData->getCommandSupported(MAV_CMD_DO_SET_GLOBAL_ORIGIN) == CommandSupportedResult::UNSUPPORTED);
+
+    // Now that it is cached unsupported, a second call must skip the command and go straight to
+    // the legacy message.
+    _mockLink->clearReceivedMavCommandCounts();
+    _mockLink->clearReceivedMavlinkMessageCounts();
+    _vehicle->setEstimatorOrigin(kOrigin);
+
+    QVERIFY_TRUE_WAIT(_mockLink->receivedMavlinkMessageCount(MAVLINK_MSG_ID_SET_GPS_GLOBAL_ORIGIN) == 1,
+                      TestTimeout::longMs());
+    QCOMPARE(_mockLink->receivedMavCommandCount(MAV_CMD_DO_SET_GLOBAL_ORIGIN), 0);
+}
+
+UT_REGISTER_TEST(SetEstimatorOriginTest, TestLabel::Integration, TestLabel::Vehicle)

--- a/test/Vehicle/SetEstimatorOriginTest.h
+++ b/test/Vehicle/SetEstimatorOriginTest.h
@@ -1,0 +1,23 @@
+#pragma once
+
+#include "BaseClasses/VehicleTest.h"
+
+/// Regression tests for Vehicle::setEstimatorOrigin.
+///
+/// setEstimatorOrigin prefers MAV_CMD_DO_SET_GLOBAL_ORIGIN (sent as a COMMAND_INT)
+/// and falls back to the deprecated SET_GPS_GLOBAL_ORIGIN message when the command
+/// is reported unsupported by the vehicle. These tests exercise all three branches
+/// of the command-support cache: cached-unsupported, cached-supported, and the
+/// unknown -> probe -> unsupported-ack -> fallback path.
+class SetEstimatorOriginTest : public VehicleTest
+{
+    Q_OBJECT
+
+public:
+    explicit SetEstimatorOriginTest(QObject* parent = nullptr) : VehicleTest(parent) {}
+
+private slots:
+    void _cachedUnsupported_sendsLegacyMessageOnly();
+    void _cachedSupported_sendsCommandIntOnly();
+    void _probeUnsupported_fallsBackAndCachesUnsupported();
+};


### PR DESCRIPTION
…_ORIGIN msg)

tries the command and falls back to the message using the existing methods for this sort of thing

## Description
QGC only supports the deprecated message equivalent of this command

## Type of Change
- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] CI/Build changes
- [ ] Other

## Testing
- [x] Tested locally
- [ ] Added/updated unit tests
- [ ] Tested with simulator (SITL)
- [x] Tested with hardware

I used ArduPilot on a CUAVv5 .  With modern ArduPilot the command succeeds.  With modern ArduPiulot with MAV_CMD_DO_SET_GLOBAL_ORIGIN hacked out it correctly falls back to using the message.

### Platforms Tested
- [x] Linux
- [ ] Windows
- [ ] macOS
- [ ] Android
- [ ] iOS

### Flight Stacks Tested
- [ ] PX4
- [x] ArduPilot

## Screenshots
<img width="1759" height="848" alt="image" src="https://github.com/user-attachments/assets/d5c1ec69-d83f-48d1-a273-4048590bab91" />


## Checklist
- [x] I have read the [Contribution Guidelines](CONTRIBUTING.md)
- [x] I have read the [Code of Conduct](CODE_OF_CONDUCT.md)
- [x] My code follows the project's coding standards
- [ ] I have added tests that prove my fix/feature works
- [ ] New and existing unit tests pass locally

## Related Issues
n/a

---
By submitting this pull request, I confirm that my contribution is made under the terms of the project's dual license (Apache 2.0 and GPL v3).
