### PR TITLE
ci: fix Windows NSIS download and Multipass snapd install

### DIFF
--- a/.github/workflows/vm-builds.yml
+++ b/.github/workflows/vm-builds.yml
@@ -70,7 +70,7 @@ jobs:
           # seed it first. No-op on the ubuntu-latest fork fallback (snapd already present).
           if ! command -v snap >/dev/null 2>&1; then
             sudo apt-get update
-            sudo apt-get install -y snapd
+            sudo apt-get install -y --allow-change-held-packages snapd
             sudo systemctl enable --now snapd.socket
           fi
           sudo snap wait system seed.loaded

--- a/tools/setup/install_dependencies/_windows.py
+++ b/tools/setup/install_dependencies/_windows.py
@@ -19,9 +19,11 @@ WINDOWS_GSTREAMER_PREFIX = "C:\\gstreamer\\1.0\\msvc_x86_64"
 WINDOWS_VULKAN_INSTALL_DIR = "C:\\VulkanSDK\\latest"
 WINDOWS_VULKAN_URL = "https://sdk.lunarg.com/sdk/download/latest/windows/vulkan-sdk.exe"
 WINDOWS_VS_BUILDTOOLS_URL = "https://aka.ms/vs/17/release/vs_BuildTools.exe"
-# SourceForge redirects this to the newest NSIS Windows setup.exe (its default
-# download); NSIS ships no lockfile pin, so track latest like Vulkan/VS above.
-WINDOWS_NSIS_URL = "https://sourceforge.net/projects/nsis/files/latest/download"
+WINDOWS_NSIS_VERSION = "3.11"
+WINDOWS_NSIS_URL = (
+    f"https://downloads.sourceforge.net/project/nsis/NSIS%203/{WINDOWS_NSIS_VERSION}/"
+    f"nsis-{WINDOWS_NSIS_VERSION}-setup.exe"
+)
 
 
 def install_windows_nsis(dry_run: bool = False) -> bool:
@@ -32,7 +34,7 @@ def install_windows_nsis(dry_run: bool = False) -> bool:
         print(f"NSIS already installed at {makensis}; skipping")
         return True
 
-    print("\nInstalling latest NSIS...")
+    print(f"\nInstalling NSIS {WINDOWS_NSIS_VERSION}...")
     with tempfile.TemporaryDirectory() as tmpdir:
         installer = Path(tmpdir) / "nsis-setup.exe"
         if not _c.download_file(WINDOWS_NSIS_URL, installer, dry_run):


### PR DESCRIPTION
## Summary

Two regressions from `a3f587072` broke master CI. Fixes both.

### Windows build — `Install Visual Studio Build Tools` (WinError 216)
`install_dependencies/_windows.py` switched the NSIS URL to SourceForge's `/files/latest/download`, which returns an HTML interstitial rather than the setup binary. The saved `nsis-setup.exe` was not a valid PE and failed to execute with `OSError: [WinError 216]`, failing the amd64 and arm64-cross Windows jobs. Restored the pinned direct `nsis-3.11-setup.exe` download.

### VM Builds — `Install Multipass` (exit 100)
`vm-builds.yml`'s new snapd bootstrap ran `apt-get install -y snapd`, but `snapd` is a held package on the RunsOn emulator AMI, so apt aborted:

```
E: Held packages were changed and -y was used without --allow-change-held-packages.
```

Added `--allow-change-held-packages` so the install proceeds.

## Test plan
- `ruff check` clean on the touched Python file
- `actionlint` clean on `vm-builds.yml`
- CI on this branch exercises both the Windows and VM Builds workflows