### PR TITLE
PositionManager/LinkManager: fall back to internal GPS when NMEA disabled

### DIFF
--- a/src/AppSettings/NmeaGpsSettings.qml
+++ b/src/AppSettings/NmeaGpsSettings.qml
@@ -15,29 +15,49 @@ SettingsGroupLayout {
 
         model: ListModel {}
 
+        // Untranslated value stored in the setting for each entry, parallel to the display model.
+        // LinkManager compares these against fixed strings, so they must not be translated.
+        property var _values: []
+
         onActivated: (index) => {
             if (index !== -1) {
-                QGroundControl.settingsManager.autoConnectSettings.autoConnectNmeaPort.value = comboBox.textAt(index);
+                QGroundControl.settingsManager.autoConnectSettings.autoConnectNmeaPort.value = nmeaPortCombo._values[index];
             }
         }
 
         Component.onCompleted: {
             var model = []
+            var values = []
 
             model.push(qsTr("Disabled"))
+            values.push("Disabled")
+
             model.push(qsTr("UDP Port"))
+            values.push("UDP Port")
 
             if (QGroundControl.linkManager.serialPorts.length === 0) {
                 model.push(qsTr("Serial <none available>"))
+                values.push("Serial <none available>")
             } else {
                 for (var i in QGroundControl.linkManager.serialPorts) {
                     model.push(QGroundControl.linkManager.serialPorts[i])
+                    values.push(QGroundControl.linkManager.serialPorts[i])
                 }
             }
+            nmeaPortCombo._values = values
             nmeaPortCombo.model = model
 
-            const index = nmeaPortCombo.comboBox.find(QGroundControl.settingsManager.autoConnectSettings.autoConnectNmeaPort.valueString);
-            nmeaPortCombo.currentIndex = index;
+            const savedValue = QGroundControl.settingsManager.autoConnectSettings.autoConnectNmeaPort.valueString
+            var index = values.indexOf(savedValue)
+            if (index === -1) {
+                // Settings written by an older build stored the translated label. Match the
+                // displayed text instead and rewrite the setting to the untranslated value.
+                index = nmeaPortCombo.comboBox.find(savedValue)
+                if (index !== -1) {
+                    QGroundControl.settingsManager.autoConnectSettings.autoConnectNmeaPort.value = values[index]
+                }
+            }
+            nmeaPortCombo.currentIndex = index
         }
     }
 

--- a/src/Comms/LinkManager.cc
+++ b/src/Comms/LinkManager.cc
@@ -509,7 +509,8 @@ void LinkManager::_updateAutoConnectLinks()
     _reconnectAutoConnectLinks();
 
     // check to see if nmea gps is configured for UDP input, if so, set it up to connect
-    if (_autoConnectSettings->autoConnectNmeaPort()->cookedValueString() == "UDP Port") {
+    const QString nmeaPortValue = _autoConnectSettings->autoConnectNmeaPort()->cookedValueString();
+    if (nmeaPortValue == "UDP Port") {
         if ((_nmeaSocket->localPort() != _autoConnectSettings->nmeaUdpPort()->rawValue().toUInt()) || (_nmeaSocket->state() != UdpIODevice::BoundState)) {
             qCDebug(LinkManagerLog) << "Changing port for UDP NMEA stream";
             _nmeaSocket->close();
@@ -526,6 +527,22 @@ void LinkManager::_updateAutoConnectLinks()
 #endif
     } else {
         _nmeaSocket->close();
+
+        // Only tear things down when NMEA is switched off entirely ("Disabled"). Any other
+        // value is a serial NMEA port, which is set up by _addSerialAutoConnectLink() below;
+        // touching _nmeaPort / the position source here would break it on every tick.
+        if (nmeaPortValue == "Disabled") {
+#ifndef QGC_NO_SERIAL_LINK
+            if (_nmeaPort) {
+                _nmeaPort->close();
+                delete _nmeaPort;
+                _nmeaPort = nullptr;
+                _nmeaDeviceName = "";
+            }
+#endif
+            // Revert QGCPositionManager to the integrated GPS if it was using an NMEA source
+            QGCPositionManager::instance()->resetNmeaSourceDevice();
+        }
     }
 
 #ifndef QGC_NO_SERIAL_LINK

--- a/src/PositionManager/PositionManager.cpp
+++ b/src/PositionManager/PositionManager.cpp
@@ -85,7 +85,7 @@ void QGCPositionManager::setNmeaSourceDevice(QIODevice *device)
 {
     if (_nmeaSource) {
         _nmeaSource->stopUpdates();
-        (void) disconnect(_nmeaSource);
+        (void) _nmeaSource->disconnect(this);
 
         if (_currentSource == _nmeaSource) {
             _currentSource = nullptr;
@@ -99,6 +99,26 @@ void QGCPositionManager::setNmeaSourceDevice(QIODevice *device)
     _nmeaSource->setDevice(device);
     _nmeaSource->setUserEquivalentRangeError(5.1);
     _setPositionSource(QGCPositionManager::NmeaGPS);
+}
+
+void QGCPositionManager::resetNmeaSourceDevice()
+{
+    if (!_nmeaSource) {
+        return;
+    }
+
+    if (_currentSource == _nmeaSource) {
+        // Switch away while the NMEA source is still valid so _setPositionSource() can run its
+        // usual cleanup (stop updates, disconnect, and reset the stale GCS position/accuracy)
+        // before we delete it. Falls back to the platform's default source (e.g. integrated GPS).
+        _setPositionSource(QGCPositionManager::InternalGPS);
+    } else {
+        _nmeaSource->stopUpdates();
+        (void) _nmeaSource->disconnect(this);
+    }
+
+    delete _nmeaSource;
+    _nmeaSource = nullptr;
 }
 
 void QGCPositionManager::_positionUpdated(const QGeoPositionInfo &update)
@@ -168,7 +188,10 @@ void QGCPositionManager::_setPositionSource(QGCPositionSource source)
 {
     if (_currentSource != nullptr) {
         _currentSource->stopUpdates();
-        (void) disconnect(_currentSource);
+        // Note the receiver-side overload: disconnect(_currentSource) would drop our own signals
+        // to the source (of which there are none), leaving source->this connected and duplicating
+        // it every time a source is re-selected.
+        (void) _currentSource->disconnect(this);
 
         _geoPositionInfo = QGeoPositionInfo();
         emit positionInfoUpdated(_geoPositionInfo);

--- a/src/PositionManager/PositionManager.h
+++ b/src/PositionManager/PositionManager.h
@@ -37,6 +37,9 @@ public:
     int updateInterval() const { return _updateInterval; }
 
     void setNmeaSourceDevice(QIODevice *device);
+    /// Tears down any active NMEA source and falls back to the platform's default
+    /// position source (e.g. the integrated Android GPS).
+    void resetNmeaSourceDevice();
 
 signals:
     void gcsPositionChanged(QGeoCoordinate gcsPosition);


### PR DESCRIPTION
Switching NMEA off (e.g. **Disabled** in Comm Links) closed the UDP socket but left `QGCPositionManager` on the dead NMEA source, freezing the GCS position with no way back to the built-in GPS.

Add `QGCPositionManager::resetNmeaSourceDevice()` to tear down the NMEA source and, if active, revert to the platform default (e.g. integrated Android GPS). `LinkManager` calls it when NMEA is no longer configured, and also tears down a lingering serial NMEA port there.
