### PR TITLE
VideoManager: Remove unused/incorrect override

### DIFF
--- a/src/VideoManager/VideoReceiver/GStreamer/HwBuffers/dmabuf/GstDmaBufVideoBuffer.h
+++ b/src/VideoManager/VideoReceiver/GStreamer/HwBuffers/dmabuf/GstDmaBufVideoBuffer.h
@@ -19,8 +19,6 @@ public:
     GstDmaBufVideoBuffer(GstSample* sample, const GstVideoInfo& videoInfo, const QVideoFrameFormat& format,
                          EGLDisplay eglDisplay);
 
-    bool isDmaBuf() const override { return true; }
-
     QVideoFrameTexturesUPtr mapTextures(QRhi& rhi, QVideoFrameTexturesUPtr& oldTextures) override;
     bool validatePlaneHandles() const override;
 


### PR DESCRIPTION
Removes the unused/incorrect `isDmaBuf() const override` from `GstDmaBufVideoBuffer`. The method has no callers anywhere in the codebase.

This replaces #14365, which had become unmergeable after the GStreamer backend overhaul (#... "Video: overhaul GStreamer backend and packaging") relocated `GstDmaBufVideoBuffer.h` into the new `HwBuffers/dmabuf/` directory. This branch re-applies the same one-line removal at the file's new location on top of current `master`.

Original author: @Ryanf55
