### PR TITLE
gstreamer: add jpeg plugins

### DIFF
--- a/.github/build-config.json
+++ b/.github/build-config.json
@@ -38,6 +38,8 @@
         "app",
         "coreelements",
         "isomp4",
+        "jpeg",
+        "jpegformat",
         "libav",
         "matroska",
         "mpegtsdemux",


### PR DESCRIPTION
## Description

Add `jpeg` and `jpegformat` to the GStreamer common plugins list. MJPEG support in GStreamer is not limited to just these two plugins, but these are the native GStreamer plugins that provide the core JPEG parsing and codec support we were missing in bundled builds.

Many IP cameras support MJPEG in addition to H264/H265, so it makes sense to support it out of the box.

Stable_V5.0 bundled the whole GStreamer plugin directory, but master ships only allowlisted plugins since 5066dc09ad75.

## Type of Change
<!-- Put an 'x' in the relevant boxes -->
- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] CI/Build changes
- [x] Other

## Testing
<!-- Describe the tests you ran and how to reproduce them -->
- [x] Tested locally
- [ ] Added/updated unit tests
- [ ] Tested with simulator (SITL)
- [ ] Tested with hardware

### Platforms Tested
<!-- Check all that apply -->
- [x] Linux
- [x] Windows
- [ ] macOS
- [x] Android
- [ ] iOS

### Flight Stacks Tested
<!-- If applicable -->
- [ ] PX4
- [ ] ArduPilot

## Screenshots
<!-- If applicable, add screenshots to help explain your changes -->

## Checklist
<!-- Go over all the following points, and put an 'x' in all the boxes that apply -->
- [x] I have read the [Contribution Guidelines](CONTRIBUTING.md)
- [x] I have read the [Code of Conduct](CODE_OF_CONDUCT.md)
- [x] My code follows the project's coding standards
- [ ] I have added tests that prove my fix/feature works
- [ ] New and existing unit tests pass locally

## Related Issues
<!-- Link any related issues using #issue_number -->

---
By submitting this pull request, I confirm that my contribution is made under the terms of the project's dual license (Apache 2.0 and GPL v3).
