### PR TITLE
feat(ParameterEditor): allow Advanced UI override of read-only params

### DIFF
--- a/src/QmlControls/ParameterEditorDialog.qml
+++ b/src/QmlControls/ParameterEditorDialog.qml
@@ -11,12 +11,10 @@ QGCPopupDialog {
     id:         root
     title:      fact.componentId > 0 ? fact.name : qsTr("Value Editor")
 
-    buttons:    fact.readOnly ? Dialog.Close : (Dialog.Save | (validate ? 0 : Dialog.Cancel))
+    buttons:    _readOnlyDisplay ? Dialog.Close : (Dialog.Save | Dialog.Cancel)
 
     property Fact   fact
     property bool   showRCToParam:  false
-    property bool   validate:       false
-    property string validateValue
     property bool   setFocus:       true    ///< true: focus is set to text field on display, false: focus not set (works around strange virtual keyboard bug with FactValueSlider
 
     property real   _editFieldWidth:            ScreenTools.defaultFontPixelWidth * 20
@@ -24,14 +22,18 @@ QGCPopupDialog {
     property bool   _editingParameter:          fact.componentId != 0
     property bool   _allowForceSave:            QGroundControl.corePlugin.showAdvancedUI && _editingParameter
     property bool   _allowDefaultReset:         fact.defaultValueAvailable
-    property bool   _showCombo:                 fact.enumStrings.length !== 0 && fact.bitmaskStrings.length === 0 && !validate
+    property bool   _showCombo:                 fact.enumStrings.length !== 0 && fact.bitmaskStrings.length === 0
+    property bool   _readOnlyDisplay:           fact.readOnly && !forceEdit.checked
+    property bool   _allowForceEdit:            fact.readOnly && _allowForceSave
+    property real   _rowSpacing:                ScreenTools.defaultFontPixelHeight / 2
+    property real   _columnSpacing:             ScreenTools.defaultFontPixelWidth
 
     ParameterEditorController { id: controller; }
 
     QGCPalette { id: qgcPal; colorGroupEnabled: true }
 
     onAccepted: {
-        if (fact.readOnly) return
+        if (_readOnlyDisplay) return
         if (bitmaskColumn.visible && !manualEntry.checked) {
             fact.value = bitmaskValue();
             fact.valueChanged(fact.value)
@@ -64,25 +66,20 @@ QGCPopupDialog {
     }
 
     Component.onCompleted: {
-        if (validate) {
-            valueField.text = validateValue
-            validationError.text = fact.validate(validateValue, false /* convertOnly */)
-            if (_allowForceSave) {
-                forceSave.visible = true
-            }
-        } else {
-            valueField.text = fact.valueString
-        }
+        valueField.text = fact.valueString
     }
 
     ColumnLayout {
         width:      Math.min(mainWindow.width * .75, Math.max(ScreenTools.defaultFontPixelWidth * 60, editRow.width))
-        spacing:    globals.defaultTextHeight
+        spacing:    _rowSpacing
 
         QGCLabel {
             Layout.fillWidth:   true
             wrapMode:           Text.WordWrap
-            text:               qsTr("This parameter is read-only and cannot be modified.")
+            text:               forceEdit.checked
+                                    ? qsTr("Warning: This parameter is read-only. Force edit is enabled.")
+                                    : qsTr("This parameter is read-only and cannot be modified.")
+            color:              forceEdit.checked ? qgcPal.warningText : qgcPal.text
             visible:            fact.readOnly
         }
 
@@ -96,8 +93,8 @@ QGCPopupDialog {
 
         RowLayout {
             id:         editRow
-            spacing:    ScreenTools.defaultFontPixelWidth
-            visible:    !fact.readOnly
+            spacing:    _columnSpacing
+            visible:    !_readOnlyDisplay
 
             QGCTextField {
                 id:                 valueField
@@ -108,7 +105,7 @@ QGCPopupDialog {
                 inputMethodHints:   (fact.typeIsString || ScreenTools.isiOS) ? // iOS numeric keyboard has no done button, we can't use it
                                         Qt.ImhNone :
                                         Qt.ImhFormattedNumbersOnly  // Forces use of virtual numeric keyboard
-                visible:            !_showCombo || validate || manualEntry.checked
+                visible:            !_showCombo || manualEntry.checked
             }
 
             QGCComboBox {
@@ -147,14 +144,14 @@ QGCPopupDialog {
         }
 
         QGCLabel {
-            visible:            fact.readOnly
-            text:               qsTr("Value: ") + fact.valueString + (fact.units != "" ? (" " + fact.units) : "")
+            visible:    _readOnlyDisplay
+            text:       qsTr("Value: ") + fact.valueString + (fact.units != "" ? (" " + fact.units) : "")
         }
 
         Column {
             id:         bitmaskColumn
-            spacing:    ScreenTools.defaultFontPixelHeight / 2
-            visible:    fact.bitmaskStrings.length > 0 && !fact.readOnly
+            spacing:    _rowSpacing
+            visible:    fact.bitmaskStrings.length > 0 && !_readOnlyDisplay
 
             Repeater {
                 id:     bitmaskRepeater
@@ -186,8 +183,8 @@ QGCPopupDialog {
             text:               fact.longDescription
         }
 
-        Row {
-            spacing: ScreenTools.defaultFontPixelWidth
+        RowLayout {
+            spacing: _columnSpacing
 
             QGCLabel {
                 id:         minValueDisplay
@@ -221,7 +218,7 @@ QGCPopupDialog {
             wrapMode:   Text.WordWrap
             text:       qsTr("Warning: Modifying values while vehicle is in flight can lead to vehicle instability and possible vehicle loss. ") +
                         qsTr("Make sure you know what you are doing and double-check your values before Save!")
-            visible:    fact.componentId != -1 && !fact.readOnly
+            visible:    fact.componentId != -1 && !_readOnlyDisplay
         }
 
         QGCCheckBox {
@@ -231,15 +228,39 @@ QGCPopupDialog {
         }
 
         QGCCheckBox {
-            id:         _advanced
+            id:         advancedCheckbox
             text:       qsTr("Advanced settings")
-            visible:    !fact.readOnly && (showRCToParam || factCombo.visible || bitmaskColumn.visible)
+            visible:    _allowForceEdit || (!_readOnlyDisplay && (showRCToParam || factCombo.visible || bitmaskColumn.visible))
+        }
+
+        // Force-edit escape hatch for read-only params. Nested under the
+        // Advanced settings checkbox so it is never shown without opt-in.
+        QGCCheckBox {
+            id:         forceEdit
+            visible:    _allowForceEdit && advancedCheckbox.checked
+            text:       qsTr("Force edit read-only param")
+
+            // Re-lock the param if Advanced settings is unchecked, so edit
+            // mode can never persist without the Advanced checkbox checked.
+            onVisibleChanged: {
+                if (!visible) {
+                    checked = false
+                }
+            }
+
+            // Clear any stale validation/force-save state when the param is re-locked.
+            onCheckedChanged: {
+                if (!checked) {
+                    validationError.text = ""
+                    forceSave.visible = false
+                }
+            }
         }
 
         // Checkbox to allow manual entry of enumerated or bitmask parameters
         QGCCheckBox {
             id:         manualEntry
-            visible:    _advanced.checked && (factCombo.visible || bitmaskColumn.visible)
+            visible:    advancedCheckbox.checked && !_readOnlyDisplay && (factCombo.visible || bitmaskColumn.visible)
             text:       qsTr("Manual Entry")
 
             onClicked: {
@@ -249,7 +270,7 @@ QGCPopupDialog {
 
         QGCButton {
             text:       qsTr("Set RC to Param")
-            visible:    _advanced.checked && !validate && showRCToParam
+            visible:    advancedCheckbox.checked && !_readOnlyDisplay && showRCToParam
             onClicked:  rcToParamDialogFactory.open()
         }
     } // Column

--- a/src/QmlControls/QGCPopupDialog.qml
+++ b/src/QmlControls/QGCPopupDialog.qml
@@ -104,6 +104,8 @@ Popup {
         }
     }
 
+    onButtonsChanged: setupDialogButtons(buttons)
+
     function _accept() {
         if (_acceptAllowed && (bypassNavigationCheck || mainWindow.allowViewSwitch(_previousValidationErrorCount))) {
             accepted()
@@ -144,9 +146,6 @@ Popup {
             acceptButton.visible = true
         } else if (buttons & Dialog.Apply) {
             acceptButton.text = qsTr("Apply")
-            acceptButton.visible = true
-        } else if (buttons & Dialog.Open) {
-            acceptButton.text = qsTr("Open")
             acceptButton.visible = true
         } else if (buttons & Dialog.SaveAll) {
             acceptButton.text = qsTr("Save All")


### PR DESCRIPTION
Replacement for #14415.

## Summary

Lets Advanced-UI users override the read-only lock on a parameter, mirroring the existing "Force save" escape hatch for min/max bounds.

## Problem

QGC respects the `readOnly` metadata flag (#14007) by hiding the input field entirely, with no way to override it — even for diagnostic or recovery cases where the lock is too strict, such as unjamming ArduPilot (ArduPilot/ardupilot#33136).

## Solution

In `ParameterEditorDialog`, read-only params get a "Force edit read-only param" checkbox nested under the existing "Advanced settings" checkbox — hidden by default, requiring a deliberate opt-in. Ticking it switches to the normal edit view (input + Save); unticking "Advanced settings" re-locks the param. UI-only change, no firmware/C++ gating.

`QGCPopupDialog` now reconfigures its buttons whenever `buttons` changes, so the dialog's Save/Cancel vs Close state tracks the force-edit toggle. Also removes the unused `validate`/`validateValue` code path from `ParameterEditorDialog`.
