### PR TITLE
fix(QGCFileDialog): avoid macOS native dialog crash on Plan open/save

### DIFF
--- a/src/QmlControls/QGCFileDialog.qml
+++ b/src/QmlControls/QGCFileDialog.qml
@@ -128,6 +128,9 @@ Item {
         nameFilters:    _root.nameFilters ? _root.nameFilters : []
         title:          _root.title
         defaultSuffix:  _root.defaultSuffix
+        // macOS: the native NSOpenPanel crashes inside Apple's ViewBridge/ImageIO when it
+        // snapshots the accessory (name-filter) view over XPC. Use Qt's non-native dialog there.
+        options:        Qt.platform.os === "osx" ? FileDialog.DontUseNativeDialog : 0
 
         onAccepted: {
             var fullPath = QGCFileDialogController.urlToLocalFile(selectedFile)


### PR DESCRIPTION
## Description

Clicking Open/Save in Plan view crashed on macOS 13 with EXC_BAD_ACCESS
<img width="273" height="268" alt="image" src="https://github.com/user-attachments/assets/07c74e11-96cd-4a9a-84da-b752839f0c7a" />

Force Qt's non-native FileDialog on macOS via DontUseNativeDialog so the
buggy NSOpenPanel path is bypassed. Other platforms keep the native
dialog.

## Type of Change
<!-- Put an 'x' in the relevant boxes -->
- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] CI/Build changes
- [ ] Other

## Testing
<!-- Describe the tests you ran and how to reproduce them -->
- [x] Tested locally
- [ ] Added/updated unit tests
- [ ] Tested with simulator (SITL)
- [ ] Tested with hardware

### Platforms Tested
<!-- Check all that apply -->
- [ ] Linux
- [ ] Windows
- [x] macOS
- [ ] Android
- [ ] iOS

### Flight Stacks Tested
<!-- If applicable -->
- [x] PX4
- [ ] ArduPilot

## Screenshots
<!-- If applicable, add screenshots to help explain your changes -->

## Checklist
<!-- Go over all the following points, and put an 'x' in all the boxes that apply -->
- [ ] I have read the [Contribution Guidelines](CONTRIBUTING.md)
- [ ] I have read the [Code of Conduct](CODE_OF_CONDUCT.md)
- [ ] My code follows the project's coding standards
- [ ] I have added tests that prove my fix/feature works
- [ ] New and existing unit tests pass locally

## Related Issues
<!-- Link any related issues using #issue_number -->

---
By submitting this pull request, I confirm that my contribution is made under the terms of the project's dual license (Apache 2.0 and GPL v3).
