### PR TITLE
fix(facts): use vertical m units for altitude settings facts

### DIFF
--- a/src/Settings/App.SettingsGroup.json
+++ b/src/Settings/App.SettingsGroup.json
@@ -112,7 +112,7 @@
             "type": "double",
             "default": 50.0,
             "min": 0.0,
-            "units": "m",
+            "units": "vertical m",
             "decimalPlaces": 1,
             "userMin": 0.0,
             "userMax": 121.92,

--- a/src/Settings/RTK.SettingsGroup.json
+++ b/src/Settings/RTK.SettingsGroup.json
@@ -80,7 +80,7 @@
             "longDesc": "Defines the altitude of the fixed RTK base position.",
             "type": "float",
             "default": 0,
-            "units": "m",
+            "units": "vertical m",
             "decimalPlaces": 2,
             "qgcRebootRequired": true,
             "label": "Base Position Alt (WGS84)"

--- a/src/Settings/RemoteID.SettingsGroup.json
+++ b/src/Settings/RemoteID.SettingsGroup.json
@@ -183,6 +183,7 @@
             "shortDesc": "Fixed altitude for operator location when not using live GNSS.",
             "longDesc": "Fixed Altitude to send on SYSTEM message",
             "type": "double",
+            "units": "vertical m",
             "decimalPlaces": 7,
             "default": 0,
             "label": "Altitude Fixed",

--- a/src/Settings/Viewer3D.SettingsGroup.json
+++ b/src/Settings/Viewer3D.SettingsGroup.json
@@ -43,7 +43,7 @@
             "name": "altitudeBias",
             "shortDesc": "Vertical offset in meters for vehicle rendering in the 3D viewer.",
             "type": "double",
-            "units": "m",
+            "units": "vertical m",
             "min": -1000,
             "max": 1000,
             "default": 0,


### PR DESCRIPTION
## Summary
- Switch selected **altitude/height** settings facts from unit type `m` (horizontal distance) to `vertical m` so display conversion respects **vertical** distance units in `FactMetaData`.
- Touched facts: `defaultMissionItemAltitude`, `fixedBasePositionAltitude`, `altitudeBias`, `altitudeFixed` (units added).
- Complements open #14539 (vehicle + guided fly altitude facts) without duplicating those lines.

## Motivation
`FactMetaData.cc` maps plain `"m"` → horizontal distance and `"vertical m"` → vertical distance. Settings that describe altitude/height were still `"m"`, so splitting horizontal vs vertical preferences in the UI did not affect them.

## Testing
- [x] `python3 -m json.tool` on each modified JSON
- [ ] Manual UI (Settings): switch vertical units, confirm labels for default mission alt / RTK base alt convert

### Platforms
- JSON metadata only (no C++/QML runtime change)

## Related
- #14539
