### PR TITLE
docs(settings): clarify horizontal vs vertical distance units

### DIFF
--- a/docs/en/qgc-user-guide/settings_view/general.md
+++ b/docs/en/qgc-user-guide/settings_view/general.md
@@ -12,10 +12,14 @@ Values are settable even if no vehicle is connected. Settings that require a veh
 
 This section defines the display units used in the application.
 
+QGroundControl tracks **horizontal** and **vertical** distance preferences separately in the Fact system.
+Facts tagged with unit type `m` follow the horizontal distance setting, while altitude and height facts use the `vertical m` unit type so they can show feet independently of map/distance units.
+When altitudes look wrong after you change Display Units, verify both distance axes (and area/speed/temperature) rather than only the generic distance control.
 
 The settings are:
 
-- **Distance**: Meters | Feet
+- **Distance** (horizontal): Meters | Feet
+- **Vertical Distance** (altitude/height): Meters | Feet
 - **Area**: SquareMetres | SquareFeet | SquareKilometers | Hectares | Acres | SquareMiles
 - **Speed**: Metres/second | Feet/second | Miles/hour | Kilometres/hour | Knots
 - **Temperature**: Celsius | Fahrenheit


### PR DESCRIPTION
## Summary
- Document that QGC tracks **horizontal** vs **vertical** distance display units separately.
- Clarify that altitude/height facts use the vertical distance axis (`vertical m` in FactMetaData).
- Align the Units list in Settings → General with Distance + Vertical Distance.

## Motivation
Operators troubleshooting wrong altitude displays after changing units currently only see a single “Distance” bullet. This notes the dual-axis model and lists Vertical Distance explicitly.

## Testing
- [x] Docs-only review of `docs/en/qgc-user-guide/settings_view/general.md`

## Related
- Vertical units fact work and open #14539
