### PR TITLE
fix(facts): use vertical m for mission altitude fact units

### DIFF
--- a/src/MissionManager/BreachReturn.FactMetaData.json
+++ b/src/MissionManager/BreachReturn.FactMetaData.json
@@ -20,7 +20,7 @@
     "shortDesc": "Altitude of breach return point position (Rel)",
     "type":             "double",
     "decimalPlaces":    2,
-    "units":            "m"
+    "units":            "vertical m"
 }
 ]
 }

--- a/src/MissionManager/CorridorScan.SettingsGroup.json
+++ b/src/MissionManager/CorridorScan.SettingsGroup.json
@@ -7,7 +7,7 @@
     "name":             "Altitude",
     "shortDesc": "Altitude for the bottom layer of the structure scan.",
     "type":             "double",
-    "units":            "m",
+    "units":            "vertical m",
     "decimalPlaces":    1,
     "default":     50
 },

--- a/src/MissionManager/FWLandingPattern.FactMetaData.json
+++ b/src/MissionManager/FWLandingPattern.FactMetaData.json
@@ -26,7 +26,7 @@
     "name":             "FinalApproachAltitude",
     "shortDesc":        "Altitude to begin landing approach from.",
     "type":             "double",
-    "units":            "m",
+    "units":            "vertical m",
     "decimalPlaces":    1,
     "default":          40.0
 },
@@ -64,7 +64,7 @@
     "name":             "LandingAltitude",
     "shortDesc":        "Altitude for landing point.",
     "type":             "double",
-    "units":            "m",
+    "units":            "vertical m",
     "decimalPlaces":    1,
     "default":          0.0
 },

--- a/src/MissionManager/MissionSettings.FactMetaData.json
+++ b/src/MissionManager/MissionSettings.FactMetaData.json
@@ -7,7 +7,7 @@
     "name":             "PlannedHomePositionAltitude",
     "shortDesc": "Launch position altitude",
     "type":             "double",
-    "units":            "m",
+    "units":            "vertical m",
     "decimalPlaces":    1,
     "default":     0
 }

--- a/src/MissionManager/RallyPoint.FactMetaData.json
+++ b/src/MissionManager/RallyPoint.FactMetaData.json
@@ -20,7 +20,7 @@
     "shortDesc":        "Altitude (rel)",
     "type":             "double",
     "decimalPlaces":    2,
-    "units":            "m",
+    "units":            "vertical m",
     "default":          0.0
 }
 ]

--- a/src/MissionManager/StructureScan.SettingsGroup.json
+++ b/src/MissionManager/StructureScan.SettingsGroup.json
@@ -17,7 +17,7 @@
     "name":             "EntranceAltitude",
     "shortDesc": "Vehicle will fly to/from the structure at this altitude.",
     "type":             "double",
-    "units":            "m",
+    "units":            "vertical m",
     "decimalPlaces":    1,
     "default":     50
 },
@@ -25,7 +25,7 @@
     "name":             "ScanBottomAlt",
     "shortDesc": "Altitude for the bottomost covered area of the scan. You can adjust this value such that the Bottom Layer Alt will fly above obstacles on the ground.",
     "type":             "double",
-    "units":            "m",
+    "units":            "vertical m",
     "decimalPlaces":    1,
     "default":     50
 },
@@ -41,7 +41,7 @@
     "shortDesc": "Height of structure being scanned.",
     "type":             "double",
     "decimalPlaces":    2,
-    "units":            "m",
+    "units":            "vertical m",
     "min":              1,
     "default":     100
 },

--- a/src/MissionManager/VTOLLandingPattern.FactMetaData.json
+++ b/src/MissionManager/VTOLLandingPattern.FactMetaData.json
@@ -26,7 +26,7 @@
     "name":             "FinalApproachAltitude",
     "shortDesc":        "Altitude to begin landing approach from.",
     "type":             "double",
-    "units":            "m",
+    "units":            "vertical m",
     "decimalPlaces":    1,
     "default":          30.0
 },
@@ -64,7 +64,7 @@
     "name":             "LandingAltitude",
     "shortDesc":        "Altitude for landing point on ground.",
     "type":             "double",
-    "units":            "m",
+    "units":            "vertical m",
     "decimalPlaces":    1,
     "default":          0.0
 },

--- a/src/Settings/Viewer3D.SettingsGroup.json
+++ b/src/Settings/Viewer3D.SettingsGroup.json
@@ -32,7 +32,7 @@
             "name": "buildingLevelHeight",
             "shortDesc": "Average floor-to-floor height in meters used for 3D building visualization.",
             "type": "double",
-            "units": "m",
+            "units": "vertical m",
             "min": 0.5,
             "max": 20,
             "default": 3,


### PR DESCRIPTION
## Summary
- Switch mission/plan altitude/height Fact JSON from unit type `m` (horizontal) to `vertical m`.
- Landing patterns (FW/VTOL), structure/corridor scans, planned home altitude, rally relative altitude, breach-return altitude, Viewer3D buildingLevelHeight.
- Complements open #14539 and #14598 without duplicating those lines.

## Testing
- [x] python3 -m json.tool on each modified JSON
- [ ] Manual UI with independent vertical units

## Related
- #14539
- #14598