### PR TITLE
docs: fix Guided Maximum Altitude copy and spelling in comments

### DIFF
--- a/docs/en/qgc-user-guide/settings_view/general.md
+++ b/docs/en/qgc-user-guide/settings_view/general.md
@@ -86,7 +86,7 @@ The settings are:
 
 - **Lock Compass Nose-Up**: Check to rotate the compass rose (default is to rotate the vehicle inside the compass indicateor).
 - **Guided Minimum Altitude**: Minimum value for guided actions altitude slider.
-- **Guided Maximum Altitude**: Minimum value for guided actions altitude slider.
+- **Guided Maximum Altitude**: Maximum value for guided actions altitude slider.
 - **Go To Location Max Distance**: The maximum distance that a Go To location can be set from the current vehicle location (in guided mode).
 
 ## Plan View {#plan_view}

--- a/src/FirmwarePlugin/FirmwarePlugin.h
+++ b/src/FirmwarePlugin/FirmwarePlugin.h
@@ -386,7 +386,7 @@ public:
     /// Creates Autotune object.
     virtual Autotune *createAutotune(Vehicle *vehicle) const;
 
-    /// Update Available flight modes recieved from vehicle
+    /// Update Available flight modes received from vehicle
     virtual void updateAvailableFlightModes(FlightModeList &flightModeList) { _updateFlightModeList(flightModeList); }
 
     ParameterMetaData *loadParameterMetaData(const Vehicle *vehicle);

--- a/src/MissionManager/StructureScanComplexItem.h
+++ b/src/MissionManager/StructureScanComplexItem.h
@@ -149,7 +149,7 @@ private:
 
     static constexpr const char* _jsonCameraCalcKey =          "CameraCalc";
 
-    static constexpr const char* _entranceAltName = "EntranceAltitude"; // This value cannot be overriden
+    static constexpr const char* _entranceAltName = "EntranceAltitude"; // This value cannot be overridden
 
 #ifdef QGC_UNITTEST_BUILD
     friend class StructureScanComplexItemTest;


### PR DESCRIPTION
## Summary
- User guide: Guided Maximum Altitude wrongly said Minimum value — set to Maximum.
- Comment typos: recieved → received (FirmwarePlugin.h); overriden → overridden (StructureScanComplexItem.h).

## Testing
- Docs/comment-only; no runtime change.
