### PR TITLE
test(Terrain): serve synthetic tiles at the cache layer to fix flaky unit tests

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -338,6 +338,15 @@ qt_add_qml_module(${CMAKE_PROJECT_NAME}
 # ----------------------------------------------------------------------------
 # Source & Test Subdirectories
 # ----------------------------------------------------------------------------
+if(QGC_BUILD_TESTING)
+    # Marks test-capable builds at the preprocessor level so production code can
+    # compile out unit-test-only hooks (e.g. QGCCacheWorker::setUnitTestTileGenerator).
+    # Directory scope is intentional: the hooks live in sources compiled into several
+    # targets (${CMAKE_PROJECT_NAME}, QGroundControlModule, QGCLocation), so a single
+    # target-scoped definition would not cover them all.
+    add_compile_definitions(QGC_UNITTEST_BUILD)
+endif()
+
 add_subdirectory(src)
 
 if(QGC_BUILD_TESTING)

--- a/src/QtLocationPlugin/QGCMapEngine.cpp
+++ b/src/QtLocationPlugin/QGCMapEngine.cpp
@@ -37,13 +37,23 @@ QGCMapEngine::QGCMapEngine(QObject *parent)
 
 QGCMapEngine::~QGCMapEngine()
 {
-    if (m_initialized && m_worker) {
+    shutdown();
+
+    qCDebug(QGCMapEngineLog) << this;
+}
+
+void QGCMapEngine::shutdown()
+{
+    // Tear down whenever a worker exists, even if init() failed partway and
+    // cleared m_initialized - otherwise the worker thread would leak.
+    if (m_worker) {
         (void) disconnect(m_worker);
         m_worker->stop();
         (void) m_worker->wait();
+        delete m_worker;
+        m_worker = nullptr;
     }
-
-    qCDebug(QGCMapEngineLog) << this;
+    m_initialized = false;
 }
 
 QGCMapEngine *QGCMapEngine::instance()
@@ -72,6 +82,10 @@ void QGCMapEngine::init(const QString &databasePath)
 
 bool QGCMapEngine::addTask(QGCMapTask *task)
 {
+    if (!m_worker) {
+        return false;
+    }
+
     // DirectConnection is intentional: the worker thread uses a custom loop (not
     // an event loop), so queued connections would never be delivered. The queue
     // is mutex-protected in enqueueTask, so calling from the main thread is safe.

--- a/src/QtLocationPlugin/QGCMapEngine.h
+++ b/src/QtLocationPlugin/QGCMapEngine.h
@@ -17,6 +17,11 @@ public:
     void init(const QString &databasePath);
     bool addTask(QGCMapTask *task);
 
+    /// Stops the cache worker thread and closes the database. Call before
+    /// QCoreApplication teardown when the engine was initialized outside the
+    /// normal QML map lifecycle (e.g. unit test runs).
+    void shutdown();
+
     static QGCMapEngine *instance();
 
 signals:

--- a/src/QtLocationPlugin/QGCTileCacheWorker.cpp
+++ b/src/QtLocationPlugin/QGCTileCacheWorker.cpp
@@ -10,7 +10,20 @@
 #include "QGCMapTasks.h"
 #include "QGCMapUrlEngine.h"
 
+#ifdef QGC_UNITTEST_BUILD
+#include "AppMessages.h"
+#endif
+
 QGC_LOGGING_CATEGORY(QGCTileCacheWorkerLog, "QtLocationPlugin.QGCTileCacheWorker")
+
+#ifdef QGC_UNITTEST_BUILD
+std::function<QGCCacheTile*(const QString&)> QGCCacheWorker::_unitTestTileGenerator;
+
+void QGCCacheWorker::setUnitTestTileGenerator(std::function<QGCCacheTile*(const QString &hash)> generator)
+{
+    _unitTestTileGenerator = std::move(generator);
+}
+#endif
 
 QGCCacheWorker::QGCCacheWorker(QObject *parent)
     : QThread(parent)
@@ -216,9 +229,23 @@ void QGCCacheWorker::_getTile(QGCMapTask *mtask)
     auto tile = _database->getTile(task->hash());
     if (tile) {
         task->setTileFetched(tile.release());
-    } else {
-        task->setError("Tile not in cache database");
+        return;
     }
+
+    // Under unit tests a cache miss consults the synthetic tile generator instead of
+    // erroring, so tile consumers never fall back to real network fetches (late
+    // replies race UI teardown and crash). See UnitTestTileGenerator.
+#ifdef QGC_UNITTEST_BUILD
+    if (QGC::runningUnitTests() && _unitTestTileGenerator) {
+        QGCCacheTile* const generated = _unitTestTileGenerator(task->hash());
+        if (generated) {
+            task->setTileFetched(generated);
+            return;
+        }
+    }
+#endif
+
+    task->setError("Tile not in cache database");
 }
 
 void QGCCacheWorker::_getTileSets(QGCMapTask *mtask)

--- a/src/QtLocationPlugin/QGCTileCacheWorker.h
+++ b/src/QtLocationPlugin/QGCTileCacheWorker.h
@@ -9,8 +9,16 @@
 
 #include <memory>
 
+#ifdef QGC_UNITTEST_BUILD
+#include <functional>
+#endif
+
 class QGCMapTask;
 class QGCTileCacheDatabase;
+
+#ifdef QGC_UNITTEST_BUILD
+struct QGCCacheTile;
+#endif
 
 class QGCCacheWorker : public QThread
 {
@@ -21,6 +29,18 @@ public:
     ~QGCCacheWorker();
 
     void setDatabaseFile(const QString &path) { if (isRunning()) { return; } _databasePath = path; }
+
+#ifdef QGC_UNITTEST_BUILD
+    /// Unit-test hook: consulted on tile cache miss to synthesize a tile instead of
+    /// erroring, so tests never fall back to real network fetches. Only active while
+    /// running unit tests. A nullptr result falls through to the normal miss error.
+    ///
+    /// Threading contract: the generator is read from worker threads without
+    /// synchronization. It must be installed once, before any QGCCacheWorker thread
+    /// has started, and never changed afterward (see UnitTestTileGenerator::install,
+    /// called at test-run startup). The generator itself must be thread-safe.
+    static void setUnitTestTileGenerator(std::function<QGCCacheTile*(const QString &hash)> generator);
+#endif
 
 public slots:
     bool enqueueTask(QGCMapTask *task);
@@ -62,4 +82,8 @@ private:
 
     static constexpr int kShortTimeoutMs = 2000;
     static constexpr int kLongTimeoutMs = 5000;
+
+#ifdef QGC_UNITTEST_BUILD
+    static std::function<QGCCacheTile*(const QString&)> _unitTestTileGenerator;
+#endif
 };

--- a/src/Terrain/TerrainQuery.cc
+++ b/src/Terrain/TerrainQuery.cc
@@ -51,19 +51,6 @@ void TerrainAtCoordinateBatchManager::addQuery(TerrainAtCoordinateQuery *terrain
     }
 }
 
-void TerrainAtCoordinateBatchManager::setTerrainQueryInterface(TerrainQueryInterface *terrainQuery)
-{
-    if (_terrainQuery) {
-        disconnect(_terrainQuery, &TerrainQueryInterface::coordinateHeightsReceived, this, &TerrainAtCoordinateBatchManager::_coordinateHeights);
-        delete _terrainQuery;
-    }
-    _terrainQuery = terrainQuery;
-    if (_terrainQuery) {
-        _terrainQuery->setParent(this);
-        (void) connect(_terrainQuery, &TerrainQueryInterface::coordinateHeightsReceived, this, &TerrainAtCoordinateBatchManager::_coordinateHeights);
-    }
-}
-
 void TerrainAtCoordinateBatchManager::_sendNextBatch()
 {
     qCDebug(TerrainQueryLog) << Q_FUNC_INFO << "_state:_requestQueue.count:_sentRequests.count" << _stateToString(_state) << _requestQueue.count() << _sentRequests.count();

--- a/src/Terrain/TerrainQuery.h
+++ b/src/Terrain/TerrainQuery.h
@@ -36,9 +36,6 @@ public:
 
     void addQuery(TerrainAtCoordinateQuery *terrainAtCoordinateQuery, const QList<QGeoCoordinate> &coordinates);
 
-    /// Set custom terrain query interface (for testing). Takes ownership.
-    void setTerrainQueryInterface(TerrainQueryInterface *terrainQuery);
-
 private slots:
     void _sendNextBatch();
     void _coordinateHeights(bool success, const QList<double> &heights);

--- a/src/Terrain/TerrainTileManager.h
+++ b/src/Terrain/TerrainTileManager.h
@@ -9,13 +9,10 @@
 
 class TerrainTile;
 class QNetworkAccessManager;
-class UnitTestTerrainQuery;
 
 class TerrainTileManager : public QObject
 {
     Q_OBJECT
-
-    friend class UnitTestTerrainQuery;
 public:
     explicit TerrainTileManager(QObject *parent = nullptr);
     ~TerrainTileManager();

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -23,7 +23,8 @@ target_link_libraries(${CMAKE_PROJECT_NAME} PRIVATE Qt6::Test)
 
 target_include_directories(${CMAKE_PROJECT_NAME} PRIVATE ${CMAKE_CURRENT_SOURCE_DIR})
 
-target_compile_definitions(${CMAKE_PROJECT_NAME} PRIVATE QGC_UNITTEST_BUILD)
+# QGC_UNITTEST_BUILD is defined directory-wide from the root CMakeLists.txt when
+# QGC_BUILD_TESTING is enabled, covering this target and all src/ targets.
 
 target_precompile_headers(${CMAKE_PROJECT_NAME} PRIVATE
     <QtTest/QTest>
@@ -60,8 +61,8 @@ include(Sanitizers)
 #   3. C++ ENTRY POINT (not owned here): qgc_tests needs a main() that parses
 #      `--unittest:<name>` and runs the UnitTestList dispatch, mirroring the app's
 #      existing --unittest handling. Without this the binary cannot run tests.
-#   4. Mirror QGC_UNITTEST_BUILD compile definition, include dirs, and PCH onto
-#      qgc_tests.
+#   4. Mirror include dirs and PCH onto qgc_tests (QGC_UNITTEST_BUILD is already
+#      inherited from the root directory-scope definition).
 # Until items 1-4 land, configuring with -DQGC_BUILD_TEST_BINARY=ON builds no
 # qgc_tests target, so add_qgc_test() falls back to the app binary (no breakage).
 if(QGC_BUILD_TEST_BINARY)

--- a/test/MissionManager/TransectStyleComplexItemTest.cc
+++ b/test/MissionManager/TransectStyleComplexItemTest.cc
@@ -166,7 +166,7 @@ TestTransectStyleItem::TestTransectStyleItem(PlanMasterController* masterControl
 {
     // We use a 100m by 100m square test polygon
     const double edgeDistance = 100;
-    surveyAreaPolygon()->appendVertex(UnitTestTerrainQuery::linearSlopeRegion.center());
+    surveyAreaPolygon()->appendVertex(UnitTestTerrainData::linearSlopeRegion.center());
     surveyAreaPolygon()->appendVertex(surveyAreaPolygon()->vertexCoordinate(0).atDistanceAndAzimuth(edgeDistance, 90));
     surveyAreaPolygon()->appendVertex(surveyAreaPolygon()->vertexCoordinate(1).atDistanceAndAzimuth(edgeDistance, 180));
     surveyAreaPolygon()->appendVertex(

--- a/test/QmlUITests/QmlUITestBase.cc
+++ b/test/QmlUITests/QmlUITestBase.cc
@@ -24,8 +24,6 @@
 #include "QGCFileDialogController.h"
 #include "QGCImageProvider.h"
 #include "SettingsManager.h"
-#include "TerrainQuery.h"
-#include "TerrainTest.h"
 #include "Vehicle.h"
 
 // Bounded real-time window for render/GC/deferred-delete settle drains during UI teardown.
@@ -82,12 +80,6 @@ void QmlUITestBase::startUI()
     MAVLinkProtocol::instance()->init();
     MultiVehicleManager::instance()->init();
 
-    // Replace the live terrain backend with the synthetic unit-test provider so
-    // mission editing in the UI never makes real HTTP terrain requests. Live
-    // fetches can return HTTP 500, emitting warning logs that trip the
-    // strict-mode log check. Restored to the default backend in stopUI().
-    TerrainAtCoordinateBatchManager::instance()->setTerrainQueryInterface(new UnitTestTerrainQuery());
-
     // Suppress first-run prompts so they don't block the UI
     AppSettings *appSettings = SettingsManager::instance()->appSettings();
     const QList<int> promptIds = QGCCorePlugin::instance()->firstRunPromptStdIds();
@@ -111,17 +103,6 @@ void QmlUITestBase::startUI()
     // Offscreen incubation can leave an item incubating at teardown; the drain is best-effort.
     ignoreLogMessage("default", QtWarningMsg,
                      QRegularExpression(QStringLiteral("in the process of being created at engine destruction")));
-
-    // The synthetic terrain provider installed above only covers coordinate
-    // queries routed through TerrainAtCoordinateBatchManager. Path/carpet queries
-    // (TerrainPathQuery, TerrainAreaQuery) hardcode their own online backend and
-    // hit the live terrain server, which intermittently returns HTTP errors. Those
-    // are external-server reachability warnings, never something a UI smoke test
-    // should assert on, so ignore them to keep the full run deterministic.
-    ignoreLogMessage("QtLocationPlugin.QGeoTiledMapReplyQGC", QtWarningMsg,
-                     QRegularExpression(QStringLiteral("Error transferring|Operation timed out")));
-    ignoreLogMessage("Terrain.TerrainTileManager", QtWarningMsg,
-                     QRegularExpression(QStringLiteral("Elevation tile fetching returned error")));
 
     // Slow headless/software-GL runners can leave async-incubated QML items still
     // creating when the engine is torn down (destroyUIEngine drains best-effort but
@@ -235,11 +216,6 @@ void QmlUITestBase::stopUI()
 {
     closeUIWindow();
     destroyUIEngine();
-
-    // Restore the default terrain backend. The batch manager is a process-global
-    // singleton shared across all tests in a single-process --unittest run, so the
-    // mock must not leak into later tests.
-    TerrainAtCoordinateBatchManager::instance()->setTerrainQueryInterface(new TerrainOfflineQuery());
 }
 
 void QmlUITestBase::_verifyFileDialogTestHookConsumed()

--- a/test/QtLocationPlugin/QGCCacheWorkerTest.cc
+++ b/test/QtLocationPlugin/QGCCacheWorkerTest.cc
@@ -1,13 +1,19 @@
 #include "QGCCacheWorkerTest.h"
 
+#include <QtCore/QTemporaryDir>
+#include <QtPositioning/QGeoCoordinate>
 #include <QtTest/QTest>
+#include <cmath>
 
+#include "BaseClasses/TerrainTest.h"
+#include "ElevationMapProvider.h"
 #include "QGCCacheTile.h"
 #include "QGCCachedTileSet.h"
 #include "QGCMapTasks.h"
 #include "QGCMapUrlEngine.h"
 #include "QGCTileCacheWorker.h"
-#include <QtCore/QTemporaryDir>
+#include "TerrainTile.h"
+#include "TerrainTileCopernicus.h"
 
 static const QString kTestProviderType = QStringLiteral("Bing Road");
 
@@ -147,6 +153,109 @@ void QGCCacheWorkerTest::_testFetchTileNotFound()
 
     QVERIFY(fetched == nullptr);
     QVERIFY(fetchError);
+
+    worker.stop();
+    worker.wait(TestTimeout::mediumMs());
+}
+
+void QGCCacheWorkerTest::_testFetchMapTileMissServesFakeTile()
+{
+    QTemporaryDir tempDir;
+    QGCCacheWorker worker;
+    worker.setDatabaseFile(tempDir.filePath("map_miss_fake.db"));
+    QVERIFY(_startWorker(worker));
+
+    // Cache miss on a valid map provider hash: under unit tests the worker must
+    // serve a fake tile instead of erroring, so the map UI never falls back to
+    // real network fetches.
+    const QString hash = UrlFactory::getTileHash(kTestProviderType, 1, 2, 3);
+    auto* fetchTask = new QGCFetchTileTask(hash);
+    QGCCacheTile* fetched = nullptr;
+    bool fetchError = false;
+    connect(
+        fetchTask, &QGCFetchTileTask::tileFetched, this, [&](QGCCacheTile* t) { fetched = t; }, Qt::QueuedConnection);
+    connect(
+        fetchTask, &QGCMapTask::error, this, [&](QGCMapTask::TaskType, const QString&) { fetchError = true; },
+        Qt::QueuedConnection);
+
+    QVERIFY(worker.enqueueTask(fetchTask));
+    QTRY_VERIFY_WITH_TIMEOUT(fetched || fetchError, TestTimeout::mediumMs());
+
+    QVERIFY2(fetched != nullptr, "Expected fake tile on map tile cache miss under unit tests");
+    QVERIFY(!fetchError);
+    QCOMPARE(fetched->hash, hash);
+    QCOMPARE(fetched->type, kTestProviderType);
+    QVERIFY(!fetched->img.isEmpty());
+    QCOMPARE(fetched->format, QStringLiteral("png"));
+    delete fetched;
+
+    worker.stop();
+    worker.wait(TestTimeout::mediumMs());
+}
+
+void QGCCacheWorkerTest::_testFetchElevationTileMissServesSyntheticTerrain()
+{
+    QTemporaryDir tempDir;
+    QGCCacheWorker worker;
+    worker.setDatabaseFile(tempDir.filePath("elev_miss.db"));
+    QVERIFY(_startWorker(worker));
+
+    // An elevation tile cache miss serves a synthetic terrain tile built from the
+    // unit test terrain regions, with 0 height everywhere else.
+    const QString elevationType = QString::fromLatin1(CopernicusElevationProvider::kProviderKey);
+    const QGeoCoordinate flatCenter = UnitTestTerrainData::flat10Region.center();
+    const int x =
+        static_cast<int>(std::floor((flatCenter.longitude() + 180.0) / TerrainTileCopernicus::kTileSizeDegrees));
+    const int y =
+        static_cast<int>(std::floor((flatCenter.latitude() + 90.0) / TerrainTileCopernicus::kTileSizeDegrees));
+    const QString hash = UrlFactory::getTileHash(elevationType, x, y, 1);
+
+    auto* fetchTask = new QGCFetchTileTask(hash);
+    QGCCacheTile* fetched = nullptr;
+    bool fetchError = false;
+    connect(
+        fetchTask, &QGCFetchTileTask::tileFetched, this, [&](QGCCacheTile* t) { fetched = t; }, Qt::QueuedConnection);
+    connect(
+        fetchTask, &QGCMapTask::error, this, [&](QGCMapTask::TaskType, const QString&) { fetchError = true; },
+        Qt::QueuedConnection);
+
+    QVERIFY(worker.enqueueTask(fetchTask));
+    QTRY_VERIFY_WITH_TIMEOUT(fetched || fetchError, TestTimeout::mediumMs());
+
+    QVERIFY2(fetched != nullptr, "Expected synthetic terrain tile on elevation cache miss under unit tests");
+    QVERIFY(!fetchError);
+    QCOMPARE(fetched->hash, hash);
+    QCOMPARE(fetched->type, elevationType);
+    QCOMPARE(fetched->format, QStringLiteral("bin"));
+
+    const TerrainTile tile(fetched->img);
+    QVERIFY(tile.isValid());
+    QCOMPARE(tile.elevation(flatCenter), UnitTestTerrainData::Flat10Region::amslElevation);
+    delete fetched;
+
+    // A tile far away from the test regions serves 0 heights
+    const QGeoCoordinate elsewhere(0.005, 0.005);
+    const int farX =
+        static_cast<int>(std::floor((elsewhere.longitude() + 180.0) / TerrainTileCopernicus::kTileSizeDegrees));
+    const int farY =
+        static_cast<int>(std::floor((elsewhere.latitude() + 90.0) / TerrainTileCopernicus::kTileSizeDegrees));
+    auto* farTask = new QGCFetchTileTask(UrlFactory::getTileHash(elevationType, farX, farY, 1));
+    QGCCacheTile* farFetched = nullptr;
+    bool farError = false;
+    connect(
+        farTask, &QGCFetchTileTask::tileFetched, this, [&](QGCCacheTile* t) { farFetched = t; }, Qt::QueuedConnection);
+    connect(
+        farTask, &QGCMapTask::error, this, [&](QGCMapTask::TaskType, const QString&) { farError = true; },
+        Qt::QueuedConnection);
+    QVERIFY(worker.enqueueTask(farTask));
+    QTRY_VERIFY_WITH_TIMEOUT(farFetched || farError, TestTimeout::mediumMs());
+    QVERIFY2(farFetched != nullptr, "Expected synthetic terrain tile for coordinate outside test regions");
+    QVERIFY(!farError);
+
+    const TerrainTile farTile(farFetched->img);
+    QVERIFY(farTile.isValid());
+    QCOMPARE(farTile.elevation(elsewhere), 0.0);
+    delete farFetched;
 
     worker.stop();
     worker.wait(TestTimeout::mediumMs());

--- a/test/QtLocationPlugin/QGCCacheWorkerTest.h
+++ b/test/QtLocationPlugin/QGCCacheWorkerTest.h
@@ -15,6 +15,8 @@ private slots:
     void _testUpdateTotalsOnInit();
     void _testSaveAndFetchTile();
     void _testFetchTileNotFound();
+    void _testFetchMapTileMissServesFakeTile();
+    void _testFetchElevationTileMissServesSyntheticTerrain();
     void _testFetchTileSets();
     void _testCreateAndDeleteTileSet();
     void _testPruneCache();

--- a/test/Terrain/CMakeLists.txt
+++ b/test/Terrain/CMakeLists.txt
@@ -13,5 +13,5 @@ target_sources(${CMAKE_PROJECT_NAME}
 
 target_include_directories(${CMAKE_PROJECT_NAME} PRIVATE ${CMAKE_CURRENT_SOURCE_DIR})
 
-add_qgc_test(TerrainQueryTest LABELS Integration Terrain Network)
+add_qgc_test(TerrainQueryTest LABELS Integration Terrain)
 add_qgc_test(TerrainTileTest LABELS Unit Terrain)

--- a/test/Terrain/TerrainQueryTest.cc
+++ b/test/Terrain/TerrainQueryTest.cc
@@ -8,103 +8,180 @@
 #include "TerrainQueryInterface.h"
 #include "TerrainTileCopernicus.h"
 
+// These tests run the full production terrain pipeline: query classes route through
+// TerrainTileManager, whose elevation tile cache misses are served synthetic tiles
+// built from the UnitTestTerrainData regions (see UnitTestTileGenerator). No network
+// access ever occurs.
+
 void TerrainQueryTest::_testRequestCoordinateHeights()
 {
-    QSignalSpy spy(terrainQuery(), &UnitTestTerrainQuery::coordinateHeightsReceived);
+    TerrainAtCoordinateQuery* const query = new TerrainAtCoordinateQuery(true, this);
+    QSignalSpy spy(query, &TerrainAtCoordinateQuery::terrainDataReceived);
     QVERIFY(spy.isValid());
-    const QList<QGeoCoordinate> coords = {pointNemo()};
-    terrainQuery()->requestCoordinateHeights(coords);
+
+    // Half an arc-second inside the flat region's north-west corner (pointNemo).
+    // Exact edge coordinates are ambiguous with grid cell floor-indexing.
+    const QGeoCoordinate nearNwCorner(pointNemo().latitude() - (UnitTestTerrainData::oneSecondDeg / 2.0),
+                                      pointNemo().longitude() + (UnitTestTerrainData::oneSecondDeg / 2.0));
+    const QList<QGeoCoordinate> coords = {nearNwCorner, flat10Region().center()};
+    query->requestData(coords);
+
+    QTRY_VERIFY_WITH_TIMEOUT(spy.count() > 0, TestTimeout::mediumMs());
     const QVariantList arguments = spy.takeFirst();
-    QVERIFY(arguments.at(0).toBool() == true);
-    QCOMPARE(arguments.at(1).toList().size(), coords.size());
-    QVERIFY(arguments.at(1).toList().at(0).toDouble() == UnitTestTerrainQuery::Flat10Region::amslElevation);
+    QVERIFY(arguments.at(0).toBool());
+
+    const QList<double> heights = qvariant_cast<QList<double>>(arguments.at(1));
+    QCOMPARE(heights.size(), coords.size());
+    QCOMPARE(heights.at(0), UnitTestTerrainData::Flat10Region::amslElevation);
+    QCOMPARE(heights.at(1), UnitTestTerrainData::Flat10Region::amslElevation);
+}
+
+void TerrainQueryTest::_testRequestCoordinateHeightsSlope()
+{
+    TerrainAtCoordinateQuery* const query = new TerrainAtCoordinateQuery(true, this);
+    QSignalSpy spy(query, &TerrainAtCoordinateQuery::terrainDataReceived);
+    QVERIFY(spy.isValid());
+
+    // Center of the linear slope region: halfway between -100m and 1000m. The tile
+    // grid samples on 1 arc-second cells, so allow one cell (~3m of slope) of error.
+    query->requestData({linearSlopeRegion().center()});
+
+    QTRY_VERIFY_WITH_TIMEOUT(spy.count() > 0, TestTimeout::mediumMs());
+    const QVariantList arguments = spy.takeFirst();
+    QVERIFY(arguments.at(0).toBool());
+
+    const QList<double> heights = qvariant_cast<QList<double>>(arguments.at(1));
+    QCOMPARE(heights.size(), 1);
+    QVERIFY(qAbs(heights.at(0) - 450.0) <= 5.0);
+}
+
+void TerrainQueryTest::_testRequestCoordinateHeightsOutsideRegions()
+{
+    TerrainAtCoordinateQuery* const query = new TerrainAtCoordinateQuery(true, this);
+    QSignalSpy spy(query, &TerrainAtCoordinateQuery::terrainDataReceived);
+    QVERIFY(spy.isValid());
+
+    // Coordinates outside the test regions succeed with 0 height
+    query->requestData({QGeoCoordinate(0.005, 0.005)});
+
+    QTRY_VERIFY_WITH_TIMEOUT(spy.count() > 0, TestTimeout::mediumMs());
+    const QVariantList arguments = spy.takeFirst();
+    QVERIFY(arguments.at(0).toBool());
+
+    const QList<double> heights = qvariant_cast<QList<double>>(arguments.at(1));
+    QCOMPARE(heights.size(), 1);
+    QCOMPARE(heights.at(0), 0.0);
 }
 
 void TerrainQueryTest::_testRequestPathHeights()
 {
-    QSignalSpy spy(terrainQuery(), &UnitTestTerrainQuery::pathHeightsReceived);
+    TerrainPathQuery* const query = new TerrainPathQuery(true, this);
+    QSignalSpy spy(query, &TerrainPathQuery::terrainDataReceived);
     QVERIFY(spy.isValid());
-    const QGeoCoordinate from = pointNemo();
-    const QGeoCoordinate to =
-        QGeoCoordinate(pointNemo().latitude(), pointNemo().longitude() + UnitTestTerrainQuery::regionSizeDeg);
-    terrainQuery()->requestPathHeights(from, to);
+
+    const double centerLat = flat10Region().center().latitude();
+    const QGeoCoordinate from(centerLat, flat10Region().topLeft().longitude() + 0.02);
+    const QGeoCoordinate to(centerLat, flat10Region().topRight().longitude() - 0.02);
+    query->requestData(from, to);
+
+    // The signal is synchronous when all tiles are already cached, async otherwise
+    QTRY_VERIFY_WITH_TIMEOUT(spy.count() > 0, TestTimeout::mediumMs());
     const QVariantList arguments = spy.takeFirst();
-    QVERIFY(arguments.at(0).toBool() == true);
-    QVERIFY(arguments.at(1).toDouble() > 0.);
-    QVERIFY(arguments.at(2).toDouble() > 0.);
-    QVERIFY(arguments.at(3).toList().size() > 2);
-    QVERIFY(arguments.at(3).toList().constFirst().toDouble() == UnitTestTerrainQuery::Flat10Region::amslElevation);
-    QVERIFY(arguments.at(3).toList().constLast().toDouble() == UnitTestTerrainQuery::Flat10Region::amslElevation);
+    QVERIFY(arguments.at(0).toBool());
+
+    const auto pathHeightInfo = qvariant_cast<TerrainPathQuery::PathHeightInfo_t>(arguments.at(1));
+    QVERIFY(pathHeightInfo.heights.size() > 2);
+    QCOMPARE(pathHeightInfo.heights.constFirst(), UnitTestTerrainData::Flat10Region::amslElevation);
+    QCOMPARE(pathHeightInfo.heights.constLast(), UnitTestTerrainData::Flat10Region::amslElevation);
 }
 
 void TerrainQueryTest::_testRequestPathHeightsSpacing()
 {
-    QSignalSpy spy(terrainQuery(), &UnitTestTerrainQuery::pathHeightsReceived);
+    TerrainPathQuery* const query = new TerrainPathQuery(true, this);
+    QSignalSpy spy(query, &TerrainPathQuery::terrainDataReceived);
     QVERIFY(spy.isValid());
 
-    const QGeoCoordinate from = pointNemo();
-    const QGeoCoordinate to = QGeoCoordinate(pointNemo().latitude(), pointNemo().longitude() + UnitTestTerrainQuery::regionSizeDeg);
-    terrainQuery()->requestPathHeights(from, to);
+    const double centerLat = flat10Region().center().latitude();
+    const QGeoCoordinate from(centerLat, flat10Region().topLeft().longitude() + 0.02);
+    const QGeoCoordinate to(centerLat, flat10Region().topRight().longitude() - 0.02);
+    query->requestData(from, to);
 
+    // The signal is synchronous when all tiles are already cached, async otherwise
+    QTRY_VERIFY_WITH_TIMEOUT(spy.count() > 0, TestTimeout::mediumMs());
     const QVariantList arguments = spy.takeFirst();
-    QVERIFY(arguments.at(0).toBool() == true);
-
-    const double distanceBetween = arguments.at(1).toDouble();
-    const double finalDistanceBetween = arguments.at(2).toDouble();
-    QVERIFY(distanceBetween > 0.0);
-    QVERIFY(finalDistanceBetween > 0.0);
+    QVERIFY(arguments.at(0).toBool());
 
     // Spacing should track the terrain tile sample spacing with a small tolerance.
-    QVERIFY(qAbs(distanceBetween - TerrainTileCopernicus::kTileValueSpacingMeters) < 2.0);
-    QVERIFY(qAbs(finalDistanceBetween - TerrainTileCopernicus::kTileValueSpacingMeters) < 2.0);
+    const auto pathHeightInfo = qvariant_cast<TerrainPathQuery::PathHeightInfo_t>(arguments.at(1));
+    QVERIFY(pathHeightInfo.distanceBetween > 0.0);
+    QVERIFY(pathHeightInfo.finalDistanceBetween > 0.0);
+    QVERIFY(qAbs(pathHeightInfo.distanceBetween - TerrainTileCopernicus::kTileValueSpacingMeters) < 2.0);
+    QVERIFY(qAbs(pathHeightInfo.finalDistanceBetween - TerrainTileCopernicus::kTileValueSpacingMeters) < 2.0);
 }
 
 void TerrainQueryTest::_testRequestCarpetHeights()
 {
-    QSignalSpy spy(terrainQuery(), &UnitTestTerrainQuery::carpetHeightsReceived);
+    TerrainAreaQuery* const query = new TerrainAreaQuery(true, this);
+    QSignalSpy spy(query, &TerrainAreaQuery::terrainDataReceived);
     QVERIFY(spy.isValid());
-    const QGeoCoordinate sw = pointNemo();
-    const QGeoCoordinate ne = QGeoCoordinate(pointNemo().latitude() + UnitTestTerrainQuery::regionSizeDeg,
-                                             pointNemo().longitude() + UnitTestTerrainQuery::regionSizeDeg);
-    terrainQuery()->requestCarpetHeights(sw, ne, false);
+
+    // Rectangle fully inside the flat region
+    const QGeoCoordinate regionCenter = flat10Region().center();
+    const QGeoCoordinate sw(regionCenter.latitude() - 0.01, regionCenter.longitude() - 0.01);
+    const QGeoCoordinate ne(regionCenter.latitude() + 0.01, regionCenter.longitude() + 0.01);
+    query->requestData(sw, ne);
+
+    // The signal is synchronous when all tiles are already cached, async otherwise
+    QTRY_VERIFY_WITH_TIMEOUT(spy.count() > 0, TestTimeout::mediumMs());
     const QVariantList arguments = spy.takeFirst();
-    QVERIFY(arguments.at(0).toBool() == true);
-    QVERIFY(arguments.at(1).toDouble() == UnitTestTerrainQuery::Flat10Region::amslElevation);
-    QVERIFY(arguments.at(2).toDouble() == UnitTestTerrainQuery::Flat10Region::amslElevation);
-    QVERIFY(!arguments.at(3).toList().isEmpty());
-    QVERIFY(!arguments.at(3).toList().constFirst().toList().isEmpty());
-    QVERIFY(arguments.at(3).toList().constFirst().toList().constFirst().toDouble() ==
-            UnitTestTerrainQuery::Flat10Region::amslElevation);
+    QVERIFY(arguments.at(0).toBool());
+
+    const auto carpetHeightInfo = qvariant_cast<TerrainAreaQuery::CarpetHeightInfo_t>(arguments.at(1));
+    QCOMPARE(carpetHeightInfo.minHeight, UnitTestTerrainData::Flat10Region::amslElevation);
+    QCOMPARE(carpetHeightInfo.maxHeight, UnitTestTerrainData::Flat10Region::amslElevation);
+    QVERIFY(!carpetHeightInfo.carpet.isEmpty());
+    QVERIFY(!carpetHeightInfo.carpet.constFirst().isEmpty());
+    QCOMPARE(carpetHeightInfo.carpet.constFirst().constFirst(), UnitTestTerrainData::Flat10Region::amslElevation);
 }
 
 void TerrainQueryTest::_testRequestCarpetHeightsStatsOnly()
 {
-    QSignalSpy spy(terrainQuery(), &UnitTestTerrainQuery::carpetHeightsReceived);
+    TerrainOfflineQuery* const query = new TerrainOfflineQuery(this);
+    QSignalSpy spy(query, &TerrainQueryInterface::carpetHeightsReceived);
     QVERIFY(spy.isValid());
 
-    const QGeoCoordinate sw = pointNemo();
-    const QGeoCoordinate ne = QGeoCoordinate(pointNemo().latitude() + UnitTestTerrainQuery::regionSizeDeg,
-                                             pointNemo().longitude() + UnitTestTerrainQuery::regionSizeDeg);
-    terrainQuery()->requestCarpetHeights(sw, ne, true);
+    const QGeoCoordinate regionCenter = flat10Region().center();
+    const QGeoCoordinate sw(regionCenter.latitude() - 0.01, regionCenter.longitude() - 0.01);
+    const QGeoCoordinate ne(regionCenter.latitude() + 0.01, regionCenter.longitude() + 0.01);
+    query->requestCarpetHeights(sw, ne, true /* statsOnly */);
 
+    // The signal is synchronous when all tiles are already cached, async otherwise
+    QTRY_VERIFY_WITH_TIMEOUT(spy.count() > 0, TestTimeout::mediumMs());
     const QVariantList arguments = spy.takeFirst();
-    QVERIFY(arguments.at(0).toBool() == true);
-    QCOMPARE(arguments.at(1).toDouble(), UnitTestTerrainQuery::Flat10Region::amslElevation);
-    QCOMPARE(arguments.at(2).toDouble(), UnitTestTerrainQuery::Flat10Region::amslElevation);
-    QVERIFY(arguments.at(3).toList().isEmpty());
+    QVERIFY(arguments.at(0).toBool());
+    QCOMPARE(arguments.at(1).toDouble(), UnitTestTerrainData::Flat10Region::amslElevation);
+    QCOMPARE(arguments.at(2).toDouble(), UnitTestTerrainData::Flat10Region::amslElevation);
+    QVERIFY(qvariant_cast<QList<QList<double>>>(arguments.at(3)).isEmpty());
 }
 
 void TerrainQueryTest::_testRequestCarpetHeightsInvalidBounds()
 {
-    QSignalSpy spy(terrainQuery(), &UnitTestTerrainQuery::carpetHeightsReceived);
+    TerrainOfflineQuery* const query = new TerrainOfflineQuery(this);
+    QSignalSpy spy(query, &TerrainQueryInterface::carpetHeightsReceived);
     QVERIFY(spy.isValid());
+
     // SW and NE are reversed (NE is actually SW)
-    const QGeoCoordinate sw = QGeoCoordinate(pointNemo().latitude() + UnitTestTerrainQuery::regionSizeDeg,
-                                             pointNemo().longitude() + UnitTestTerrainQuery::regionSizeDeg);
+    const QGeoCoordinate sw = QGeoCoordinate(pointNemo().latitude() + UnitTestTerrainData::regionSizeDeg,
+                                             pointNemo().longitude() + UnitTestTerrainData::regionSizeDeg);
     const QGeoCoordinate ne = pointNemo();
-    terrainQuery()->requestCarpetHeights(sw, ne, false);
+    expectLogMessage("Terrain.TerrainTileManager", QtWarningMsg, QRegularExpression("Invalid carpet bounds"));
+    query->requestCarpetHeights(sw, ne, false /* statsOnly */);
+    verifyExpectedLogMessage();
+
+    // Signal is emitted synchronously for invalid bounds
+    QCOMPARE(spy.count(), 1);
     const QVariantList arguments = spy.takeFirst();
-    QVERIFY(arguments.at(0).toBool() == false);
+    QVERIFY(!arguments.at(0).toBool());
     QVERIFY(qIsNaN(arguments.at(1).toDouble()));
     QVERIFY(qIsNaN(arguments.at(2).toDouble()));
 }
@@ -115,7 +192,8 @@ void TerrainQueryTest::_testPolyPathQueryEmptyPath()
     QSignalSpy spy(query, &TerrainPolyPathQuery::terrainDataReceived);
     QVERIFY(spy.isValid());
     const QList<QGeoCoordinate> emptyPath;
-    expectLogMessage("Terrain.TerrainQuery", QtWarningMsg, QRegularExpression("polyPath requires at least 2 coordinates"));
+    expectLogMessage("Terrain.TerrainQuery", QtWarningMsg,
+                     QRegularExpression("polyPath requires at least 2 coordinates"));
     query->requestData(emptyPath);
     verifyExpectedLogMessage();
     // Signal is emitted synchronously for invalid path
@@ -130,8 +208,9 @@ void TerrainQueryTest::_testPolyPathQuerySingleCoord()
     QSignalSpy spy(query, &TerrainPolyPathQuery::terrainDataReceived);
     QVERIFY(spy.isValid());
     QList<QGeoCoordinate> singleCoordPath;
-    (void)singleCoordPath.append(pointNemo());
-    expectLogMessage("Terrain.TerrainQuery", QtWarningMsg, QRegularExpression("polyPath requires at least 2 coordinates"));
+    (void) singleCoordPath.append(pointNemo());
+    expectLogMessage("Terrain.TerrainQuery", QtWarningMsg,
+                     QRegularExpression("polyPath requires at least 2 coordinates"));
     query->requestData(singleCoordPath);
     verifyExpectedLogMessage();
     // Signal is emitted synchronously for invalid path
@@ -142,18 +221,17 @@ void TerrainQueryTest::_testPolyPathQuerySingleCoord()
 
 void TerrainQueryTest::_testPolyPathQueryFailureClearsAccumulatedSegments()
 {
-    TerrainPolyPathQuery *const query = new TerrainPolyPathQuery(false, this);
+    TerrainPolyPathQuery* const query = new TerrainPolyPathQuery(false, this);
     QSignalSpy spy(query, &TerrainPolyPathQuery::terrainDataReceived);
     QVERIFY(spy.isValid());
 
     TerrainPathQuery::PathHeightInfo_t segment;
     segment.distanceBetween = 10.0;
     segment.finalDistanceBetween = 10.0;
-    (void) segment.heights.append(UnitTestTerrainQuery::Flat10Region::amslElevation);
-    (void) segment.heights.append(UnitTestTerrainQuery::Flat10Region::amslElevation);
+    (void) segment.heights.append(UnitTestTerrainData::Flat10Region::amslElevation);
+    (void) segment.heights.append(UnitTestTerrainData::Flat10Region::amslElevation);
 
-    bool invoked = QMetaObject::invokeMethod(query, "_terrainDataReceived", Qt::DirectConnection,
-                                             Q_ARG(bool, true),
+    bool invoked = QMetaObject::invokeMethod(query, "_terrainDataReceived", Qt::DirectConnection, Q_ARG(bool, true),
                                              Q_ARG(TerrainPathQuery::PathHeightInfo_t, segment));
     QVERIFY(invoked);
     QCOMPARE(spy.count(), 1);
@@ -165,8 +243,7 @@ void TerrainQueryTest::_testPolyPathQueryFailureClearsAccumulatedSegments()
     QVERIFY(!initialSegments.isEmpty());
 
     const TerrainPathQuery::PathHeightInfo_t emptySegment{};
-    invoked = QMetaObject::invokeMethod(query, "_terrainDataReceived", Qt::DirectConnection,
-                                        Q_ARG(bool, false),
+    invoked = QMetaObject::invokeMethod(query, "_terrainDataReceived", Qt::DirectConnection, Q_ARG(bool, false),
                                         Q_ARG(TerrainPathQuery::PathHeightInfo_t, emptySegment));
     QVERIFY(invoked);
 
@@ -178,34 +255,4 @@ void TerrainQueryTest::_testPolyPathQueryFailureClearsAccumulatedSegments()
     QVERIFY(clearedSegments.isEmpty());
 }
 
-void TerrainQueryTest::_testTerrainAtCoordinateQuery()
-{
-    // Inject our test terrain query into the batch manager
-    TerrainAtCoordinateBatchManager::instance()->setTerrainQueryInterface(new UnitTestTerrainQuery());
-
-    QList<QGeoCoordinate> coordinates;
-    (void)coordinates.append(pointNemo());
-    (void)coordinates.append(QGeoCoordinate(pointNemo().latitude() - 0.01, pointNemo().longitude() + 0.01));
-
-    TerrainAtCoordinateQuery* const query = new TerrainAtCoordinateQuery(true, this);
-    QSignalSpy spy(query, &TerrainAtCoordinateQuery::terrainDataReceived);
-    QVERIFY(spy.isValid());
-
-    query->requestData(coordinates);
-
-    QVERIFY_SIGNAL_WAIT(spy, TestTimeout::mediumMs());
-    QCOMPARE(spy.count(), 1);
-
-    const QVariantList arguments = spy.takeFirst();
-    QVERIFY(arguments.at(0).toBool() == true);
-
-    const QList<QVariant> heights = arguments.at(1).toList();
-    QCOMPARE(heights.size(), coordinates.size());
-    QCOMPARE(heights.at(0).toDouble(), UnitTestTerrainQuery::Flat10Region::amslElevation);
-    QCOMPARE(heights.at(1).toDouble(), UnitTestTerrainQuery::Flat10Region::amslElevation);
-
-    // Restore default terrain query for other tests
-    TerrainAtCoordinateBatchManager::instance()->setTerrainQueryInterface(new TerrainOfflineQuery());
-}
-
-UT_REGISTER_TEST(TerrainQueryTest, TestLabel::Integration, TestLabel::Terrain, TestLabel::Network)
+UT_REGISTER_TEST(TerrainQueryTest, TestLabel::Integration, TestLabel::Terrain)

--- a/test/Terrain/TerrainQueryTest.h
+++ b/test/Terrain/TerrainQueryTest.h
@@ -8,6 +8,8 @@ class TerrainQueryTest : public TerrainTest
 
 private slots:
     void _testRequestCoordinateHeights();
+    void _testRequestCoordinateHeightsSlope();
+    void _testRequestCoordinateHeightsOutsideRegions();
     void _testRequestPathHeights();
     void _testRequestPathHeightsSpacing();
     void _testRequestCarpetHeights();
@@ -16,5 +18,4 @@ private slots:
     void _testPolyPathQueryEmptyPath();
     void _testPolyPathQuerySingleCoord();
     void _testPolyPathQueryFailureClearsAccumulatedSegments();
-    void _testTerrainAtCoordinateQuery();
 };

--- a/test/UnitTestFramework/BaseClasses/TerrainTest.cc
+++ b/test/UnitTestFramework/BaseClasses/TerrainTest.cc
@@ -1,129 +1,53 @@
 #include "TerrainTest.h"
 
-#include "TerrainTileManager.h"
+#include <cmath>
 
 // Use the canonical definition from TerrainTest::pointNemo()
 static const QGeoCoordinate pointNemo = TerrainTest::pointNemo();
 
-const UnitTestTerrainQuery::Flat10Region UnitTestTerrainQuery::flat10Region{
-    {pointNemo, QGeoCoordinate{pointNemo.latitude() - UnitTestTerrainQuery::regionSizeDeg,
-                               pointNemo.longitude() + UnitTestTerrainQuery::regionSizeDeg}}};
+const UnitTestTerrainData::Flat10Region UnitTestTerrainData::flat10Region{
+    {pointNemo, QGeoCoordinate{pointNemo.latitude() - UnitTestTerrainData::regionSizeDeg,
+                               pointNemo.longitude() + UnitTestTerrainData::regionSizeDeg}}};
 
-const UnitTestTerrainQuery::LinearSlopeRegion UnitTestTerrainQuery::linearSlopeRegion{
+const UnitTestTerrainData::LinearSlopeRegion UnitTestTerrainData::linearSlopeRegion{
     {flat10Region.topRight(),
-     QGeoCoordinate{flat10Region.topRight().latitude() - UnitTestTerrainQuery::regionSizeDeg,
-                    flat10Region.topRight().longitude() + UnitTestTerrainQuery::regionSizeDeg}}};
+     QGeoCoordinate{flat10Region.topRight().latitude() - UnitTestTerrainData::regionSizeDeg,
+                    flat10Region.topRight().longitude() + UnitTestTerrainData::regionSizeDeg}}};
 
-const UnitTestTerrainQuery::HillRegion UnitTestTerrainQuery::hillRegion{
+const UnitTestTerrainData::HillRegion UnitTestTerrainData::hillRegion{
     {linearSlopeRegion.topRight(),
-     QGeoCoordinate{linearSlopeRegion.topRight().latitude() - UnitTestTerrainQuery::regionSizeDeg,
-                    linearSlopeRegion.topRight().longitude() + UnitTestTerrainQuery::regionSizeDeg}}};
+     QGeoCoordinate{linearSlopeRegion.topRight().latitude() - UnitTestTerrainData::regionSizeDeg,
+                    linearSlopeRegion.topRight().longitude() + UnitTestTerrainData::regionSizeDeg}}};
 
-UnitTestTerrainQuery::UnitTestTerrainQuery(QObject* parent) : TerrainQueryInterface(parent)
+double UnitTestTerrainData::heightAt(const QGeoCoordinate& coordinate)
 {
-}
-
-UnitTestTerrainQuery::~UnitTestTerrainQuery()
-{
-}
-
-void UnitTestTerrainQuery::requestCoordinateHeights(const QList<QGeoCoordinate>& coordinates)
-{
-    const QList<double> result = _requestCoordinateHeights(coordinates);
-    emit coordinateHeightsReceived(result.size() == coordinates.size(), result);
-}
-
-void UnitTestTerrainQuery::requestPathHeights(const QGeoCoordinate& fromCoord, const QGeoCoordinate& toCoord)
-{
-    const PathHeightInfo_t pathHeightInfo = _requestPathHeights(fromCoord, toCoord);
-    emit pathHeightsReceived(!pathHeightInfo.rgHeights.isEmpty(), pathHeightInfo.distanceBetween,
-                             pathHeightInfo.finalDistanceBetween, pathHeightInfo.rgHeights);
-}
-
-void UnitTestTerrainQuery::requestCarpetHeights(const QGeoCoordinate& swCoord, const QGeoCoordinate& neCoord,
-                                                bool statsOnly)
-{
-    QList<QList<double>> carpet;
-    if ((swCoord.longitude() > neCoord.longitude()) || (swCoord.latitude() > neCoord.latitude())) {
-        emit carpetHeightsReceived(false, qQNaN(), qQNaN(), carpet);
-        return;
+    if (flat10Region.contains(coordinate)) {
+        return Flat10Region::amslElevation;
     }
-    double min = std::numeric_limits<double>::max();
-    double max = std::numeric_limits<double>::min();
-    for (double lat = swCoord.latitude(); lat < neCoord.latitude(); lat++) {
-        const QGeoCoordinate fromCoord(lat, swCoord.longitude());
-        const QGeoCoordinate toCoord(lat, neCoord.longitude());
-        const QList<double> row = _requestPathHeights(fromCoord, toCoord).rgHeights;
-        if (row.isEmpty()) {
-            emit carpetHeightsReceived(false, qQNaN(), qQNaN(), QList<QList<double>>());
-            return;
-        }
-        for (const double val : row) {
-            min = qMin(val, min);
-            max = qMax(val, max);
-        }
-        if (!statsOnly) {
-            (void)carpet.append(row);
-        }
-    }
-    emit carpetHeightsReceived(true, min, max, carpet);
-}
 
-UnitTestTerrainQuery::PathHeightInfo_t UnitTestTerrainQuery::_requestPathHeights(const QGeoCoordinate& fromCoord,
-                                                                                 const QGeoCoordinate& toCoord)
-{
-    PathHeightInfo_t pathHeights;
-    pathHeights.rgCoords = TerrainTileManager::_pathQueryToCoords(fromCoord, toCoord, pathHeights.distanceBetween,
-                                                                  pathHeights.finalDistanceBetween);
-    pathHeights.rgHeights = _requestCoordinateHeights(pathHeights.rgCoords);
-    return pathHeights;
-}
-
-QList<double> UnitTestTerrainQuery::_requestCoordinateHeights(const QList<QGeoCoordinate>& coordinates)
-{
-    QList<double> result;
-    for (const auto& coordinate : coordinates) {
-        if (flat10Region.contains(coordinate)) {
-            (void)result.append(UnitTestTerrainQuery::Flat10Region::amslElevation);
-        } else if (linearSlopeRegion.contains(coordinate)) {
-            // cast to oneSecondDeg grid and round to int to emulate SRTM1 even better
-            const double x = (coordinate.longitude() - linearSlopeRegion.topLeft().longitude()) / oneSecondDeg;
-            const double dx = regionSizeDeg / oneSecondDeg;
-            const double fraction = x / dx;
-            (void)result.append(std::round(UnitTestTerrainQuery::LinearSlopeRegion::minAMSLElevation +
-                                           (fraction * UnitTestTerrainQuery::LinearSlopeRegion::totalElevationChange)));
-        } else if (hillRegion.contains(coordinate)) {
-            const double arcSecondMeters = (earthsRadiusMts * oneSecondDeg) * (M_PI / 180.);
-            const double x = (coordinate.latitude() - hillRegion.center().latitude()) * arcSecondMeters / oneSecondDeg;
-            const double y =
-                (coordinate.longitude() - hillRegion.center().longitude()) * arcSecondMeters / oneSecondDeg;
-            const double x2y2 = pow(x, 2) + pow(y, 2);
-            const double r2 = pow(UnitTestTerrainQuery::HillRegion::radius, 2);
-            const double z = (x2y2 <= r2) ? sqrt(r2 - x2y2) : UnitTestTerrainQuery::Flat10Region::amslElevation;
-            (void)result.append(z);
-        } else {
-            result.clear();
-            break;
-        }
+    if (linearSlopeRegion.contains(coordinate)) {
+        // cast to oneSecondDeg grid and round to int to emulate SRTM1 even better
+        const double x = (coordinate.longitude() - linearSlopeRegion.topLeft().longitude()) / oneSecondDeg;
+        const double dx = regionSizeDeg / oneSecondDeg;
+        const double fraction = x / dx;
+        return std::round(LinearSlopeRegion::minAMSLElevation + (fraction * LinearSlopeRegion::totalElevationChange));
     }
-    return result;
+
+    if (hillRegion.contains(coordinate)) {
+        // Distance from the hill center in meters, compared against the sphere radius in meters.
+        // Longitude degrees are scaled by cos(latitude) so the hill is truly spherical.
+        const double metersPerDeg = earthsRadiusMts * (M_PI / 180.);
+        const double x = (coordinate.latitude() - hillRegion.center().latitude()) * metersPerDeg;
+        const double y = (coordinate.longitude() - hillRegion.center().longitude()) * metersPerDeg *
+                         cos(hillRegion.center().latitude() * (M_PI / 180.));
+        const double x2y2 = (x * x) + (y * y);
+        const double r2 = HillRegion::radiusMts * HillRegion::radiusMts;
+        return (x2y2 <= r2) ? sqrt(r2 - x2y2) : Flat10Region::amslElevation;
+    }
+
+    return 0.;
 }
 
 /*===========================================================================*/
 
-TerrainTest::TerrainTest(QObject* parent) : UnitTest(parent)
-{
-}
-
-void TerrainTest::init()
-{
-    UnitTest::init();
-    _terrainQuery = new UnitTestTerrainQuery(this);
-}
-
-void TerrainTest::cleanup()
-{
-    delete _terrainQuery;
-    _terrainQuery = nullptr;
-    UnitTest::cleanup();
-}
+TerrainTest::TerrainTest(QObject* parent) : UnitTest(parent) {}

--- a/test/UnitTestFramework/BaseClasses/TerrainTest.h
+++ b/test/UnitTestFramework/BaseClasses/TerrainTest.h
@@ -3,26 +3,19 @@
 #include <QtPositioning/QGeoCoordinate>
 #include <QtPositioning/QGeoRectangle>
 
-#include "TerrainQueryInterface.h"
 #include "UnitTest.h"
 
 /// @file
-/// @brief Base class for terrain-related tests
+/// @brief Base class and synthetic terrain data for terrain-related tests
 
-/// Provides unit test terrain query responses.
-/// It provides preset, emulated, 1 arc-second (SRTM1) resolution regions that are either
-/// flat or sloped in a fashion that aids testing terrain-sensitive functionality. All emulated
-/// regions are positioned around Point Nemo - should real terrain become useful and checked in one day.
-class UnitTestTerrainQuery : public TerrainQueryInterface
+/// Synthetic terrain regions used to generate deterministic elevation data for unit tests.
+/// Preset, emulated, 1 arc-second (SRTM1) resolution regions that are either flat or sloped
+/// in a fashion that aids testing terrain-sensitive functionality. All emulated regions are
+/// positioned around Point Nemo - should real terrain become useful and checked in one day.
+/// Any coordinate outside the regions has 0 height.
+class UnitTestTerrainData
 {
 public:
-    explicit UnitTestTerrainQuery(QObject* parent = nullptr);
-    ~UnitTestTerrainQuery() override;
-
-    void requestCoordinateHeights(const QList<QGeoCoordinate>& coordinates) final;
-    void requestPathHeights(const QGeoCoordinate& fromCoord, const QGeoCoordinate& toCoord) final;
-    void requestCarpetHeights(const QGeoCoordinate& swCoord, const QGeoCoordinate& neCoord, bool statsOnly) final;
-
     static constexpr double regionSizeDeg = 0.1;  ///< all regions are 0.1deg (~11km) square
     static constexpr double oneSecondDeg = 1.0 / 3600.;
     static constexpr double earthsRadiusMts = 6371000.;
@@ -30,9 +23,7 @@ public:
     /// Region with constant 10m terrain elevation
     struct Flat10Region : public QGeoRectangle
     {
-        explicit Flat10Region(const QGeoRectangle& region) : QGeoRectangle(region)
-        {
-        }
+        explicit Flat10Region(const QGeoRectangle& region) : QGeoRectangle(region) {}
 
         static constexpr double amslElevation = 10.;
     };
@@ -42,9 +33,7 @@ public:
     /// Region with a linear west to east slope raising at a rate of 100 meters per kilometer (-100m to 1000m)
     struct LinearSlopeRegion : public QGeoRectangle
     {
-        explicit LinearSlopeRegion(const QGeoRectangle& region) : QGeoRectangle(region)
-        {
-        }
+        explicit LinearSlopeRegion(const QGeoRectangle& region) : QGeoRectangle(region) {}
 
         static constexpr double minAMSLElevation = -100.;
         static constexpr double maxAMSLElevation = 1000.;
@@ -56,47 +45,25 @@ public:
     /// Region with a hill (top half of a sphere) in the center.
     struct HillRegion : public QGeoRectangle
     {
-        explicit HillRegion(const QGeoRectangle& region) : QGeoRectangle(region)
-        {
-        }
+        explicit HillRegion(const QGeoRectangle& region) : QGeoRectangle(region) {}
 
-        static constexpr double radius = UnitTestTerrainQuery::regionSizeDeg / UnitTestTerrainQuery::oneSecondDeg;
+        /// Sphere radius in meters (also the hill's peak height)
+        static constexpr double radiusMts = 360.;
     };
 
     static const HillRegion hillRegion;
 
-    /// Path height info returned by terrain queries
-    struct PathHeightInfo_t
-    {
-        QList<QGeoCoordinate> rgCoords;
-        QList<double> rgHeights;
-        double distanceBetween;
-        double finalDistanceBetween;
-    };
-
-private:
-    QList<double> _requestCoordinateHeights(const QList<QGeoCoordinate>& coordinates);
-    PathHeightInfo_t _requestPathHeights(const QGeoCoordinate& fromCoord, const QGeoCoordinate& toCoord);
+    /// Returns the synthetic terrain height for the coordinate. Coordinates outside
+    /// the test regions return 0.
+    static double heightAt(const QGeoCoordinate& coordinate);
 };
 
 /*===========================================================================*/
 
 /// Base class for terrain-related tests.
-/// Provides access to UnitTestTerrainQuery for mock terrain data.
-///
-/// Example usage:
-/// @code
-/// class MyTerrainTest : public TerrainTest
-/// {
-///     Q_OBJECT
-/// private slots:
-///     void _testTerrainQuery() {
-///         QList<QGeoCoordinate> coords;
-///         coords << pointNemo();
-///         terrainQuery()->requestCoordinateHeights(coords);
-///     }
-/// };
-/// @endcode
+/// Synthetic elevation data for the UnitTestTerrainData regions is served to all unit
+/// tests at the tile cache layer (see UnitTestTileGenerator), so production terrain
+/// queries resolve against it without any network access.
 class TerrainTest : public UnitTest
 {
     Q_OBJECT
@@ -107,39 +74,17 @@ public:
     ~TerrainTest() override = default;
 
     /// Point Nemo - furthest point from land, used as terrain test origin
-    static QGeoCoordinate pointNemo()
-    {
-        return QGeoCoordinate(-48.875556, -123.392500);
-    }
-
-    /// Returns the test terrain query interface
-    UnitTestTerrainQuery* terrainQuery() const
-    {
-        return _terrainQuery;
-    }
+    static QGeoCoordinate pointNemo() { return QGeoCoordinate(-48.875556, -123.392500); }
 
     /// Access to flat 10m region
-    static const UnitTestTerrainQuery::Flat10Region& flat10Region()
-    {
-        return UnitTestTerrainQuery::flat10Region;
-    }
+    static const UnitTestTerrainData::Flat10Region& flat10Region() { return UnitTestTerrainData::flat10Region; }
 
     /// Access to linear slope region
-    static const UnitTestTerrainQuery::LinearSlopeRegion& linearSlopeRegion()
+    static const UnitTestTerrainData::LinearSlopeRegion& linearSlopeRegion()
     {
-        return UnitTestTerrainQuery::linearSlopeRegion;
+        return UnitTestTerrainData::linearSlopeRegion;
     }
 
     /// Access to hill region
-    static const UnitTestTerrainQuery::HillRegion& hillRegion()
-    {
-        return UnitTestTerrainQuery::hillRegion;
-    }
-
-protected slots:
-    void init() override;
-    void cleanup() override;
-
-private:
-    UnitTestTerrainQuery* _terrainQuery = nullptr;
+    static const UnitTestTerrainData::HillRegion& hillRegion() { return UnitTestTerrainData::hillRegion; }
 };

--- a/test/UnitTestFramework/CMakeLists.txt
+++ b/test/UnitTestFramework/CMakeLists.txt
@@ -5,6 +5,8 @@ target_sources(${CMAKE_PROJECT_NAME}
         ${CMAKE_CURRENT_SOURCE_DIR}/PropertyTestHelper.h
         ${CMAKE_CURRENT_SOURCE_DIR}/UnitTest.cc
         ${CMAKE_CURRENT_SOURCE_DIR}/UnitTest.h
+        ${CMAKE_CURRENT_SOURCE_DIR}/UnitTestTileGenerator.cc
+        ${CMAKE_CURRENT_SOURCE_DIR}/UnitTestTileGenerator.h
 )
 
 target_include_directories(${CMAKE_PROJECT_NAME} PRIVATE ${CMAKE_CURRENT_SOURCE_DIR})

--- a/test/UnitTestFramework/UnitTestTileGenerator.cc
+++ b/test/UnitTestFramework/UnitTestTileGenerator.cc
@@ -1,0 +1,162 @@
+#include "UnitTestTileGenerator.h"
+
+#include <QtCore/QFile>
+#include <QtCore/QJsonArray>
+#include <QtCore/QJsonDocument>
+#include <QtCore/QJsonObject>
+#include <QtCore/QString>
+#include <QtCore/QTemporaryDir>
+#include <QtPositioning/QGeoCoordinate>
+#include <limits>
+
+#include "BaseClasses/TerrainTest.h"
+#include "QGCCacheTile.h"
+#include "QGCLoggingCategory.h"
+#include "QGCMapEngine.h"
+#include "QGCMapUrlEngine.h"
+#include "QGCTileCacheWorker.h"
+#include "TerrainTileCopernicus.h"
+
+QGC_LOGGING_CATEGORY(UnitTestTileGeneratorLog, "Test.UnitTestTileGenerator")
+
+namespace {
+
+/// Resolves the provider type from a tile hash without tripping UrlFactory's
+/// "not found" warnings on garbage hashes.
+QString _providerTypeFromHash(const QString& hash)
+{
+    // Hash format: "%010d%08d%08d%03d" (provider map id, x, y, zoom)
+    if (hash.size() != 29) {
+        return QString();
+    }
+
+    bool ok = false;
+    const int providerId = hash.left(10).toInt(&ok);
+    if (!ok) {
+        return QString();
+    }
+
+    for (const QString& type : UrlFactory::getProviderTypes()) {
+        if (UrlFactory::getQtMapIdFromProviderType(type) == providerId) {
+            return type;
+        }
+    }
+
+    return QString();
+}
+
+/// Builds a serialized terrain tile for the given Copernicus tile x/y using the
+/// production serializer, sampling UnitTestTerrainData heights on the SRTM1 grid.
+QByteArray _syntheticTerrainTileData(int x, int y)
+{
+    constexpr double tileSizeDeg = TerrainTileCopernicus::kTileSizeDegrees;
+    constexpr double spacingDeg = TerrainTileCopernicus::kTileValueSpacingDegrees;
+
+    // Declared bounds are padded by one arc-second on every side. Coordinate-to-tile
+    // hashing (floor) and TerrainTile's cell indexing round independently, so an exact
+    // tile-edge coordinate can otherwise index one cell outside the grid (seen with
+    // (0,0) queries). With the padding, cell size stays exactly one arc-second:
+    // (tileSize + 2*spacing) / gridSize == spacing.
+    const int gridSize = qRound(tileSizeDeg / spacingDeg) + 2;  // 36 + 2 padding cells
+    const double swLat = (y * tileSizeDeg) - 90.0 - spacingDeg;
+    const double swLon = (x * tileSizeDeg) - 180.0 - spacingDeg;
+
+    double minHeight = std::numeric_limits<double>::max();
+    double maxHeight = std::numeric_limits<double>::lowest();
+    double sumHeights = 0.;
+
+    QJsonArray carpet;
+    for (int latIdx = 0; latIdx < gridSize; latIdx++) {
+        QJsonArray row;
+        // Sample at cell centers: cell values are representative of the cell and
+        // never land knife-edge on region boundaries (which lie on whole arc-seconds).
+        const double lat = swLat + ((latIdx + 0.5) * spacingDeg);
+        for (int lonIdx = 0; lonIdx < gridSize; lonIdx++) {
+            const double lon = swLon + ((lonIdx + 0.5) * spacingDeg);
+            const double height = UnitTestTerrainData::heightAt(QGeoCoordinate(lat, lon));
+            minHeight = qMin(minHeight, height);
+            maxHeight = qMax(maxHeight, height);
+            sumHeights += height;
+            (void) row.append(height);
+        }
+        (void) carpet.append(row);
+    }
+
+    const QJsonObject root{
+        {"status", "success"},
+        {"data",
+         QJsonObject{
+             {"bounds",
+              QJsonObject{{"sw", QJsonArray{swLat, swLon}},
+                          {"ne", QJsonArray{swLat + (gridSize * spacingDeg), swLon + (gridSize * spacingDeg)}}}},
+             {"stats",
+              QJsonObject{{"min", minHeight}, {"max", maxHeight}, {"avg", sumHeights / (gridSize * gridSize)}}},
+             {"carpet", carpet},
+         }},
+    };
+
+    return TerrainTileCopernicus::serializeFromData(QJsonDocument(root).toJson(QJsonDocument::Compact));
+}
+
+}  // namespace
+
+namespace UnitTestTileGenerator {
+
+QGCCacheTile* generateTile(const QString& hash)
+{
+    const QString type = _providerTypeFromHash(hash);
+    if (type.isEmpty()) {
+        return nullptr;
+    }
+
+    if (UrlFactory::getElevationProviderTypes().contains(type)) {
+        // The provider prefix already validated as numeric, so unparsable x/y can only
+        // mean corrupt hash construction upstream — warn so strict-mode tests fail.
+        bool okX = false;
+        bool okY = false;
+        const int x = hash.mid(10, 8).toInt(&okX);
+        const int y = hash.mid(18, 8).toInt(&okY);
+        if (!okX || !okY) {
+            qCWarning(UnitTestTileGeneratorLog) << "Internal error: unparsable x/y in tile hash" << hash;
+            return nullptr;
+        }
+        return new QGCCacheTile(hash, _syntheticTerrainTileData(x, y), QStringLiteral("bin"), type);
+    }
+
+    static const QByteArray placeholderImage = []() {
+        QFile file(QStringLiteral(":/res/notile.png"));
+        if (!file.open(QFile::ReadOnly)) {
+            qFatal("UnitTestTileGenerator: failed to open placeholder tile %s: %s",
+                   qPrintable(file.fileName()), qPrintable(file.errorString()));
+        }
+        return file.readAll();
+    }();
+    return new QGCCacheTile(hash, placeholderImage, QStringLiteral("png"), type);
+}
+
+void install()
+{
+    QGCCacheWorker::setUnitTestTileGenerator(&generateTile);
+}
+
+void initMapEngine()
+{
+    // The map engine (tile cache worker) is normally initialized when the first QML
+    // map is created. Tests query terrain without a map, so initialize it here with
+    // a fresh, per-process temp database: every fetch misses and is served by the
+    // generator. QTemporaryDir gives each parallel ctest process its own database
+    // and cleans up at exit.
+    static QTemporaryDir tempDir;
+    if (!tempDir.isValid()) {
+        qFatal("UnitTestTileGenerator: failed to create temp dir for tile cache db: %s",
+               qPrintable(tempDir.errorString()));
+    }
+    getQGCMapEngine()->init(tempDir.filePath(QStringLiteral("qgc_unit_test_tile_cache.db")));
+}
+
+void shutdownMapEngine()
+{
+    getQGCMapEngine()->shutdown();
+}
+
+}  // namespace UnitTestTileGenerator

--- a/test/UnitTestFramework/UnitTestTileGenerator.h
+++ b/test/UnitTestFramework/UnitTestTileGenerator.h
@@ -1,0 +1,30 @@
+#pragma once
+
+class QString;
+struct QGCCacheTile;
+
+/// Serves synthetic tiles to the tile cache layer while running unit tests.
+///
+/// Installed on QGCCacheWorker at test-run startup, the generator is consulted on
+/// every tile cache miss so production code never falls back to real network fetches:
+///   - Map providers get a placeholder image tile.
+///   - Elevation providers get a terrain tile synthesized from the UnitTestTerrainData
+///     regions (0 height outside them), built with the production Copernicus serializer.
+///   - Hashes that resolve to no provider return nullptr, preserving the miss-error path.
+namespace UnitTestTileGenerator {
+/// Installs the generator hook on QGCCacheWorker.
+void install();
+
+/// Initializes the global map engine (tile cache worker) with a fresh temp database
+/// so terrain queries work without a QML map ever being created. Full-app test runs
+/// only: the worker thread requires orderly QApplication teardown.
+void initMapEngine();
+
+/// Stops the map engine worker thread. Must be called before QApplication teardown:
+/// the worker's database teardown cannot run after the app is gone.
+void shutdownMapEngine();
+
+/// Generates a synthetic tile for the given tile hash. Returns nullptr if the hash
+/// does not resolve to a known provider. Caller takes ownership.
+QGCCacheTile* generateTile(const QString& hash);
+}  // namespace UnitTestTileGenerator

--- a/test/UnitTestList.cc
+++ b/test/UnitTestList.cc
@@ -5,6 +5,7 @@
 #include <QtCore/QSet>
 
 #include "QGCLoggingCategory.h"
+#include "UnitTestTileGenerator.h"
 
 QGC_LOGGING_CATEGORY(UnitTestListLog, "Test.UnitTestList")
 
@@ -16,6 +17,9 @@ namespace QGCUnitTest {
 
 int runTests(const QStringList& unitTests, int iterations, const QString& outputFile, TestLabels labelFilter)
 {
+    // Serve synthetic tiles on tile cache misses so no test ever hits the network
+    UnitTestTileGenerator::install();
+
     // Determine which tests to run
     QStringList testsToRun;
     if (unitTests.isEmpty()) {
@@ -36,6 +40,11 @@ int runTests(const QStringList& unitTests, int iterations, const QString& output
         qCWarning(UnitTestListLog) << "No tests to run";
         return 0;
     }
+
+    // Started only after the early returns above: the worker thread must be shut down
+    // before returning (see shutdownMapEngine below), so don't start it until the run
+    // is definitely happening.
+    UnitTestTileGenerator::initMapEngine();
 
     iterations = qMax(1, iterations);
     int result = 0;
@@ -61,6 +70,10 @@ int runTests(const QStringList& unitTests, int iterations, const QString& output
         }
     }
 
+    // Stop the tile cache worker while the app still exists: its database teardown
+    // cannot run after QApplication destruction.
+    UnitTestTileGenerator::shutdownMapEngine();
+
     return result;
 }
 
@@ -71,6 +84,9 @@ int runLightweightTests(const QStringList& unitTests, int iterations, const QStr
         qCWarning(UnitTestListLog) << "runLightweightTests called with no QCoreApplication instance";
         return -1;
     }
+
+    // Serve synthetic tiles on tile cache misses so no test ever hits the network
+    UnitTestTileGenerator::install();
 
     QStringList testsToRun;
     if (unitTests.isEmpty()) {


### PR DESCRIPTION
## Problem

Unit tests were flaky due to real network access in the tile fetch path:

- A tile cache miss falls back to a real HTTP fetch. UI tests reached the live terrain server through path/carpet terrain queries (`TerrainPathQuery`/`TerrainAreaQuery`), which hardcode their own backend and bypassed the injected `UnitTestTerrainQuery`. Intermittent HTTP errors from the live server tripped the strict-mode log check.
- Late/timed-out network replies delivered during UI teardown raced destroyed receivers and crashed (SIGSEGV seen in CI in `AppCloseWarningUITest`).
- Test behavior also varied with the contents of the developer's local tile cache database.

## Solution

Serve synthetic tiles at the tile cache layer for all unit test runs, so the network fallback is never reached:

- `QGCCacheWorker` gains a unit-test-only generator hook consulted on tile cache miss. It is compiled only in test-capable builds via a new `QGC_UNITTEST_BUILD` compile definition (driven by `QGC_BUILD_TESTING`), and additionally gated on `runningUnitTests()` at runtime.
- New `UnitTestTileGenerator` (test framework) serves:
  - placeholder images for map providers
  - valid Copernicus-format terrain tiles synthesized from the `UnitTestTerrainData` regions around Point Nemo (flat 10m / linear slope / hill), 0 height everywhere else — built with the production serializer
  - `nullptr` for unresolvable hashes, preserving the normal miss/error path
- The map engine is initialized per test process with an isolated `QTemporaryDir` database (parallel-ctest safe, hermetic) and explicitly shut down before `QApplication` teardown via new `QGCMapEngine::shutdown()` — the worker's SQL teardown after app destruction previously segfaulted.

## Consequences

- `UnitTestTerrainQuery` and the `TerrainAtCoordinateBatchManager::setTerrainQueryInterface()` injection API are removed. All terrain query paths (coordinate, path, carpet) now exercise the real `TerrainTileManager` pipeline instead of a bypass fake.
- `TerrainQueryTest` is rewritten against the production pipeline and no longer needs the `Network` label — it now runs in CI.
- The tile-fetch log ignores in `QmlUITestBase` are removed.
- New tests: cache-miss fake serving for map and elevation tiles (`QGCCacheWorkerTest`), plus slope/outside-region coordinate query coverage (`TerrainQueryTest`).

## Testing

- Full `Unit|Integration` sweep passes locally (182+ tests), including previously teardown-crashing tests.
- `--unittest:BogusTestName` early-return path verified to exit cleanly.
- Release-configuration compile (without `QGC_UNITTEST_BUILD`) verified for the touched production files.
