### PR TITLE
PX4FirmwarePlugin: use correct unset param1

### DIFF
--- a/src/FirmwarePlugin/PX4/PX4FirmwarePlugin.cc
+++ b/src/FirmwarePlugin/PX4/PX4FirmwarePlugin.cc
@@ -330,8 +330,9 @@ void PX4FirmwarePlugin::guidedModeTakeoff(Vehicle* vehicle, double takeoffAltRel
         vehicle->defaultComponentId(),
         MAV_CMD_NAV_TAKEOFF,
         true,                                   // show error is fails
-        -1,                                     // No pitch requested
-        0, 0,                                   // param 2-4 unused
+        NAN,                                    // No pitch requested
+        NAN,                                    // param 2 unused
+        0,                                      // param 3 takeoff flags
         NAN, NAN, NAN,                          // No yaw, lat, lon
         static_cast<float>(takeoffAltAMSL));    // AMSL altitude
 }


### PR DESCRIPTION
## Description

NAV_TAKEOFF param1 allows to set the minimum pitch. Generally, when not setting a param it should be set to NAN or 0. The sentinel value -1 is not in the spec.

Note that this value is not used in PX4 anyway.

Also, unused param2 can be NAN instead of 0 which is generally preferred.

## Type of Change
<!-- Put an 'x' in the relevant boxes -->
- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] CI/Build changes
- [ ] Other

## Testing
<!-- Describe the tests you ran and how to reproduce them -->
- [ ] Tested locally
- [ ] Added/updated unit tests
- [x] Tested with simulator (SITL)
- [ ] Tested with hardware

### Platforms Tested
<!-- Check all that apply -->
- [x] Linux
- [ ] Windows
- [ ] macOS
- [ ] Android
- [ ] iOS

### Flight Stacks Tested
<!-- If applicable -->
- [x] PX4
- [ ] ArduPilot

## Screenshots
<!-- If applicable, add screenshots to help explain your changes -->

## Checklist
<!-- Go over all the following points, and put an 'x' in all the boxes that apply -->
- [ ] I have read the [Contribution Guidelines](CONTRIBUTING.md)
- [ ] I have read the [Code of Conduct](CODE_OF_CONDUCT.md)
- [ ] My code follows the project's coding standards
- [ ] I have added tests that prove my fix/feature works
- [ ] New and existing unit tests pass locally

## Related Issues
<!-- Link any related issues using #issue_number -->
https://github.com/PX4/PX4-Autopilot/pull/27899

---
By submitting this pull request, I confirm that my contribution is made under the terms of the project's dual license (Apache 2.0 and GPL v3).
