### PR TITLE
fix(facts): use vertical m for vehicle altitude telemetry facts

### DIFF
--- a/src/Vehicle/FactGroups/VehicleFact.json
+++ b/src/Vehicle/FactGroups/VehicleFact.json
@@ -71,21 +71,21 @@
     "shortDesc": "Alt (Rel)",
     "type":             "double",
     "decimalPlaces":    1,
-    "units":            "m"
+    "units":            "vertical m"
 },
 {
     "name":             "altitudeAMSL",
     "shortDesc": "Alt (AMSL)",
     "type":             "double",
     "decimalPlaces":    1,
-    "units":            "m"
+    "units":            "vertical m"
 },
 {
     "name":             "altitudeAboveTerr",
     "shortDesc": "Alt (Above Terrain)",
     "type":             "double",
     "decimalPlaces":    1,
-    "units":            "m"
+    "units":            "vertical m"
 },
 {
     "name":             "flightDistance",


### PR DESCRIPTION
## Summary
- Mark altitudeRelative, altitudeAMSL, and altitudeAboveTerr in VehicleFact.json with units vertical m so they follow the vertical distance unit preference.
- Leave horizontal flight distances (flightDistance, distanceToHome, distanceToGCS, distanceToNextWP) as plain m.

## Motivation
FactMetaData treats plain m as horizontal distance and vertical m as vertical. Telemetry altitudes were still horizontal-tagged. Complements #14539 / #14598 / #14601 without path overlap.

## Verification
- python3 -m json.tool on VehicleFact.json
- Diff is three unit strings only; no C++/QML, no geofence/arm changes.
