### PR TITLE
fix: Use vertical distance units consistently for altitude values

### DIFF
--- a/src/AutoPilotPlugins/APM/APMFollowComponent.FactMetaData.json
+++ b/src/AutoPilotPlugins/APM/APMFollowComponent.FactMetaData.json
@@ -28,7 +28,7 @@
     "type": "double",
     "min": 0,
     "decimalPlaces": 1,
-    "units": "m",
+    "units": "vertical m",
     "default": 5
 }
 ]

--- a/src/AutoPilotPlugins/APM/APMFollowComponent.qml
+++ b/src/AutoPilotPlugins/APM/APMFollowComponent.qml
@@ -414,7 +414,7 @@ SetupPage {
                         QGCLabel {
                             id:                 distanceLabel
                             anchors.centerIn:   distanceLine
-                            text:               controller.distance.valueString + " " + QGroundControl.unitsConversion.appSettingsHorizontalDistanceUnitsString
+                            text:               QGroundControl.unitsConversion.metersToAppSettingsHorizontalDistanceUnitsString(controller.distance.rawValue)
 
                             transform: Rotation {
                                 origin.x:       distanceLabel.width  / 2
@@ -492,7 +492,7 @@ SetupPage {
                         QGCLabel {
                             id:                 heightValueLabel
                             anchors.centerIn:   parent
-                            text:               controller.height.valueString + " " + QGroundControl.unitsConversion.appSettingsHorizontalDistanceUnitsString
+                            text:               QGroundControl.unitsConversion.metersToAppSettingsVerticalDistanceUnitsString(controller.height.rawValue)
                         }
                     }
 

--- a/src/FactSystem/Fact.cc
+++ b/src/FactSystem/Fact.cc
@@ -234,6 +234,16 @@ QVariant Fact::cookedValue() const
     return _rawValue;
 }
 
+QVariant Fact::rawToCooked(const QVariant &rawValue) const
+{
+    if (_metaData) {
+        return _metaData->rawTranslator()(rawValue);
+    }
+
+    qCWarning(FactLog) << kMissingMetadata << name();
+    return rawValue;
+}
+
 QString Fact::enumStringValue()
 {
     if (_metaData) {

--- a/src/FactSystem/Fact.h
+++ b/src/FactSystem/Fact.h
@@ -83,6 +83,10 @@ public:
     /// Convert and clamp value
     Q_INVOKABLE QVariant clamp(const QString &cookedValue);
     QVariant cookedValue() const; /// Value after translation
+    /// Converts an arbitrary raw value to the cooked (user units) domain using this fact's own translator.
+    /// Use this instead of the QmlUnitsConversion helpers when mixing constants with Fact values so the
+    /// conversion always follows the fact's metadata.
+    Q_INVOKABLE QVariant rawToCooked(const QVariant &rawValue) const;
     QVariant rawValue() const
     {
         QMutexLocker<QRecursiveMutex> locker(&_rawValueMutex);

--- a/src/FactSystem/FactMetaData.cc
+++ b/src/FactSystem/FactMetaData.cc
@@ -956,6 +956,12 @@ void FactMetaData::_setAppSettingsTranslators()
             }
         }
     }
+
+    // "vertical m" is an artificial lookup unit - never show it to the user. Checking _cookedUnits
+    // rather than _rawUnits ensures a successful translation above is never overwritten.
+    if (_cookedUnits.compare(QStringLiteral("vertical m"), Qt::CaseInsensitive) == 0) {
+        _cookedUnits = QStringLiteral("m");
+    }
 }
 
 const FactMetaData::AppSettingsTranslation_s* FactMetaData::_findAppSettingsUnitsTranslation(const QString &rawUnits, UnitTypes type)

--- a/src/FirmwarePlugin/PX4/PX4FlightModeIndicator.qml
+++ b/src/FirmwarePlugin/PX4/PX4FlightModeIndicator.qml
@@ -30,7 +30,7 @@ ColumnLayout {
             Layout.preferredWidth:  sliderWidth
             label:                  qsTr("RTL Altitude")
             fact:                   controller.getParameterFact(-1, "RTL_RETURN_ALT")
-            to:                     fact.maxIsDefaultForType ? QGroundControl.unitsConversion.metersToAppSettingsVerticalDistanceUnits(121.92) : fact.max
+            to:                     fact.maxIsDefaultForType ? fact.rawToCooked(121.92) : fact.max
             majorTickStepSize:      10
         }
     }
@@ -95,7 +95,8 @@ ColumnLayout {
                 id:                 maxAltitudeSlider
                 Layout.fillWidth:   true
                 fact:               controller.getParameterFact(-1, "GF_MAX_VER_DIST")
-                to:                 flyViewSettings.guidedMaximumAltitude.value
+                // Setting is "vertical m" family, slider fact may cook differently - convert through the fact's own translator
+                to:                 fact.rawToCooked(flyViewSettings.guidedMaximumAltitude.rawValue)
                 majorTickStepSize:  10
                 enabled:            fact.value > 0
             }

--- a/src/FlightMap/MapItems/VehicleMapItem.qml
+++ b/src/FlightMap/MapItems/VehicleMapItem.qml
@@ -132,7 +132,7 @@ MapQuickItem {
             visible:                    _adsbVehicle ? !isNaN(altitude) : _multiVehicle
             property string vehicleLabelText: visible ?
                                                   (_adsbVehicle ?
-                                                       QGroundControl.unitsConversion.metersToAppSettingsVerticalDistanceUnits(altitude).toFixed(0) + " " + QGroundControl.unitsConversion.appSettingsHorizontalDistanceUnitsString + "\n" + callsign :
+                                                       QGroundControl.unitsConversion.metersToAppSettingsVerticalDistanceUnitsString(altitude, 0) + "\n" + callsign :
                                                        (_multiVehicle ? qsTr("Vehicle %1").arg(vehicle.id) : "")) :
                                                   ""
 

--- a/src/MissionManager/BreachReturn.FactMetaData.json
+++ b/src/MissionManager/BreachReturn.FactMetaData.json
@@ -20,7 +20,7 @@
     "shortDesc": "Altitude of breach return point position (Rel)",
     "type":             "double",
     "decimalPlaces":    2,
-    "units":            "m"
+    "units":            "vertical m"
 }
 ]
 }

--- a/src/MissionManager/CorridorScan.SettingsGroup.json
+++ b/src/MissionManager/CorridorScan.SettingsGroup.json
@@ -7,7 +7,7 @@
     "name":             "Altitude",
     "shortDesc": "Altitude for the bottom layer of the structure scan.",
     "type":             "double",
-    "units":            "m",
+    "units":            "vertical m",
     "decimalPlaces":    1,
     "default":     50
 },

--- a/src/MissionManager/FWLandingPattern.FactMetaData.json
+++ b/src/MissionManager/FWLandingPattern.FactMetaData.json
@@ -26,7 +26,7 @@
     "name":             "FinalApproachAltitude",
     "shortDesc":        "Altitude to begin landing approach from.",
     "type":             "double",
-    "units":            "m",
+    "units":            "vertical m",
     "decimalPlaces":    1,
     "default":          40.0
 },
@@ -64,7 +64,7 @@
     "name":             "LandingAltitude",
     "shortDesc":        "Altitude for landing point.",
     "type":             "double",
-    "units":            "m",
+    "units":            "vertical m",
     "decimalPlaces":    1,
     "default":          0.0
 },

--- a/src/MissionManager/MavCmdInfoCommon.json
+++ b/src/MissionManager/MavCmdInfoCommon.json
@@ -196,13 +196,12 @@
             "category":             "Basic",
             "param1": {
                 "label":            "Abort Alt",
-                "units":            "m",
+                "units":            "vertical m",
                 "default":          0,
                 "decimalPlaces":    2
             },
             "param2": {
                 "label":            "Precision Land",
-                "units":            "m",
                 "enumStrings":      "Disabled,Opportunistic,Required",
                 "enumValues":       "0,1,2",
                 "default":          0,
@@ -345,7 +344,6 @@
             "category":             "Basic",
             "param2": {
                 "label":            "Transition Heading",
-                "units":            "m",
                 "enumStrings":      "Default,Next waypoint,Takeoff,Specified,Any",
                 "enumValues":       "0,1,2,3,4",
                 "default":          0,
@@ -373,7 +371,7 @@
             "category":             "Basic",
             "param3": {
                 "label":            "Approach Alt",
-                "units":            "m",
+                "units":            "vertical m",
                 "nanUnchanged":     true,
                 "default":          null,
                 "decimalPlaces":    2,
@@ -477,7 +475,7 @@
             },
             "param7": {
                 "label":            "Target",
-                "units":            "m",
+                "units":            "vertical m",
                 "default":          100,
                 "decimalPlaces":    2,
                 "userMin":          0,
@@ -1179,12 +1177,12 @@
             "param2": {
                 "label":            "Min Alt",
                 "default":          25,
-                "units":            "m",
+                "units":            "vertical m",
                 "decimalPlaces":    2
             },
             "param3": {
                 "label":            "Max Alt",
-                "units":            "m",
+                "units":            "vertical m",
                 "default":          100,
                 "decimalPlaces":    2
             },

--- a/src/MissionManager/MissionSettings.FactMetaData.json
+++ b/src/MissionManager/MissionSettings.FactMetaData.json
@@ -7,7 +7,7 @@
     "name":             "PlannedHomePositionAltitude",
     "shortDesc": "Launch position altitude",
     "type":             "double",
-    "units":            "m",
+    "units":            "vertical m",
     "decimalPlaces":    1,
     "default":     0
 }

--- a/src/MissionManager/RallyPoint.FactMetaData.json
+++ b/src/MissionManager/RallyPoint.FactMetaData.json
@@ -20,7 +20,7 @@
     "shortDesc":        "Altitude (rel)",
     "type":             "double",
     "decimalPlaces":    2,
-    "units":            "m",
+    "units":            "vertical m",
     "default":          0.0
 }
 ]

--- a/src/MissionManager/StructureScan.SettingsGroup.json
+++ b/src/MissionManager/StructureScan.SettingsGroup.json
@@ -17,7 +17,7 @@
     "name":             "EntranceAltitude",
     "shortDesc": "Vehicle will fly to/from the structure at this altitude.",
     "type":             "double",
-    "units":            "m",
+    "units":            "vertical m",
     "decimalPlaces":    1,
     "default":     50
 },
@@ -25,7 +25,7 @@
     "name":             "ScanBottomAlt",
     "shortDesc": "Altitude for the bottomost covered area of the scan. You can adjust this value such that the Bottom Layer Alt will fly above obstacles on the ground.",
     "type":             "double",
-    "units":            "m",
+    "units":            "vertical m",
     "decimalPlaces":    1,
     "default":     50
 },
@@ -41,7 +41,7 @@
     "shortDesc": "Height of structure being scanned.",
     "type":             "double",
     "decimalPlaces":    2,
-    "units":            "m",
+    "units":            "vertical m",
     "min":              1,
     "default":     100
 },

--- a/src/MissionManager/TransectStyle.SettingsGroup.json
+++ b/src/MissionManager/TransectStyle.SettingsGroup.json
@@ -45,7 +45,7 @@
     "type":             "double",
     "decimalPlaces":    2,
     "min":              0,
-    "units":            "m",
+    "units":            "vertical m",
     "default":     10
 },
 {

--- a/src/MissionManager/VTOLLandingPattern.FactMetaData.json
+++ b/src/MissionManager/VTOLLandingPattern.FactMetaData.json
@@ -26,7 +26,7 @@
     "name":             "FinalApproachAltitude",
     "shortDesc":        "Altitude to begin landing approach from.",
     "type":             "double",
-    "units":            "m",
+    "units":            "vertical m",
     "decimalPlaces":    1,
     "default":          30.0
 },
@@ -64,7 +64,7 @@
     "name":             "LandingAltitude",
     "shortDesc":        "Altitude for landing point on ground.",
     "type":             "double",
-    "units":            "m",
+    "units":            "vertical m",
     "decimalPlaces":    1,
     "default":          0.0
 },

--- a/src/PlanView/FWLandingPatternMapVisual.qml
+++ b/src/PlanView/FWLandingPatternMapVisual.qml
@@ -476,7 +476,7 @@ Item {
 
             sourceItem: HeightIndicator {
                 map:        _root.map
-                heightText: Math.floor(QGroundControl.unitsConversion.metersToAppSettingsVerticalDistanceUnits(_transitionAltitudeMeters)) +
+                heightText: Math.floor(QGroundControl.unitsConversion.metersToAppSettingsVerticalDistanceUnits(_transitionAltitudeMeters)) + " " +
                             QGroundControl.unitsConversion.appSettingsVerticalDistanceUnitsString + "<sup>*</sup>"
             }
 
@@ -508,7 +508,7 @@ Item {
 
             sourceItem: HeightIndicator {
                 map:        _root.map
-                heightText: Math.floor(QGroundControl.unitsConversion.metersToAppSettingsVerticalDistanceUnits(_midSlopeAltitudeMeters)) +
+                heightText: Math.floor(QGroundControl.unitsConversion.metersToAppSettingsVerticalDistanceUnits(_midSlopeAltitudeMeters)) + " " +
                             QGroundControl.unitsConversion.appSettingsVerticalDistanceUnitsString + "<sup>*</sup>"
             }
 
@@ -548,7 +548,7 @@ Item {
 
             sourceItem: HeightIndicator {
                 map:        _root.map
-                heightText: _missionItem.finalApproachAltitude.value.toFixed(1) + QGroundControl.unitsConversion.appSettingsHorizontalDistanceUnitsString
+                heightText: _missionItem.finalApproachAltitude.value.toFixed(1) + " " + _missionItem.finalApproachAltitude.units
             }
         }
     }

--- a/src/PlanView/MissionStats.qml
+++ b/src/PlanView/MissionStats.qml
@@ -50,8 +50,8 @@ Rectangle {
                                                          0 : (Math.atan(_currentMissionItem.altDifference / _currentMissionItem.distance) * (180.0/Math.PI)))
                                                   : NaN
 
-    property string _distanceText: isNaN(_distance) ? "-.-" : QGroundControl.unitsConversion.metersToAppSettingsHorizontalDistanceUnits(_distance).toFixed(1) + " " + QGroundControl.unitsConversion.appSettingsHorizontalDistanceUnitsString
-    property string _altDifferenceText: isNaN(_altDifference) ? "-.-" : QGroundControl.unitsConversion.metersToAppSettingsVerticalDistanceUnits(_altDifference).toFixed(1) + " " + QGroundControl.unitsConversion.appSettingsVerticalDistanceUnitsString
+    property string _distanceText: isNaN(_distance) ? "-.-" : QGroundControl.unitsConversion.metersToAppSettingsHorizontalDistanceUnitsString(_distance)
+    property string _altDifferenceText: isNaN(_altDifference) ? "-.-" : QGroundControl.unitsConversion.metersToAppSettingsVerticalDistanceUnitsString(_altDifference)
     property string _gradientText: isNaN(_gradient) ? "-.-" : _gradient.toFixed(0) + qsTr(" deg")
     property string _azimuthText: isNaN(_azimuth) ? "-.-" : Math.round(_azimuth) % 360
     property string _headingText: isNaN(_azimuth) ? "-.-" : Math.round(_heading) % 360

--- a/src/PlanView/StructureScanEditor.qml
+++ b/src/PlanView/StructureScanEditor.qml
@@ -190,10 +190,10 @@ Rectangle {
                     QGCLabel { text: missionItem.cameraCalc.adjustedFootprintFrontal.valueString + " " + QGroundControl.unitsConversion.appSettingsHorizontalDistanceUnitsString }
 
                     QGCLabel { text: qsTr("Top Layer Alt") }
-                    QGCLabel { text: QGroundControl.unitsConversion.metersToAppSettingsVerticalDistanceUnits(missionItem.topFlightAlt).toFixed(1) + " " + QGroundControl.unitsConversion.appSettingsHorizontalDistanceUnitsString }
+                    QGCLabel { text: QGroundControl.unitsConversion.metersToAppSettingsVerticalDistanceUnitsString(missionItem.topFlightAlt) }
 
                     QGCLabel { text: qsTr("Bottom Layer Alt") }
-                    QGCLabel { text: QGroundControl.unitsConversion.metersToAppSettingsVerticalDistanceUnits(missionItem.bottomFlightAlt).toFixed(1) + " " + QGroundControl.unitsConversion.appSettingsHorizontalDistanceUnitsString }
+                    QGCLabel { text: QGroundControl.unitsConversion.metersToAppSettingsVerticalDistanceUnitsString(missionItem.bottomFlightAlt) }
 
                     QGCLabel { text: qsTr("Photo Count") }
                     QGCLabel { text: missionItem.cameraShots }

--- a/src/QmlControls/QmlUnitsConversion.h
+++ b/src/QmlControls/QmlUnitsConversion.h
@@ -25,6 +25,13 @@ public:
 
     QString appSettingsHorizontalDistanceUnitsString(void) const { return FactMetaData::appSettingsHorizontalDistanceUnitsString(); }
 
+    /// Converts from meters to the user specified horizontal distance unit with units appended, e.g. "16.4 ft".
+    /// Keeps the converted value and units label paired so they can never disagree.
+    Q_INVOKABLE QString metersToAppSettingsHorizontalDistanceUnitsString(const QVariant& meters, int decimalPlaces = 1) const
+    {
+        return QStringLiteral("%1 %2").arg(FactMetaData::metersToAppSettingsHorizontalDistanceUnits(meters).toDouble(), 0, 'f', decimalPlaces).arg(FactMetaData::appSettingsHorizontalDistanceUnitsString());
+    }
+
     /// Converts from meters to the user specified distance unit
     Q_INVOKABLE QVariant metersToAppSettingsVerticalDistanceUnits(const QVariant& meters) const { return FactMetaData::metersToAppSettingsVerticalDistanceUnits(meters); }
 
@@ -32,6 +39,13 @@ public:
     Q_INVOKABLE QVariant appSettingsVerticalDistanceUnitsToMeters(const QVariant& distance) const { return FactMetaData::appSettingsVerticalDistanceUnitsToMeters(distance); }
 
     QString appSettingsVerticalDistanceUnitsString(void) const { return FactMetaData::appSettingsVerticalDistanceUnitsString(); }
+
+    /// Converts from meters to the user specified vertical distance unit with units appended, e.g. "16.4 ft".
+    /// Keeps the converted value and units label paired so they can never disagree.
+    Q_INVOKABLE QString metersToAppSettingsVerticalDistanceUnitsString(const QVariant& meters, int decimalPlaces = 1) const
+    {
+        return QStringLiteral("%1 %2").arg(FactMetaData::metersToAppSettingsVerticalDistanceUnits(meters).toDouble(), 0, 'f', decimalPlaces).arg(FactMetaData::appSettingsVerticalDistanceUnitsString());
+    }
 
     /// Converts from grams to the user specified weight unit
     Q_INVOKABLE QVariant gramsToAppSettingsWeightUnits(const QVariant& meters) const { return FactMetaData::gramsToAppSettingsWeightUnits(meters); }

--- a/src/QmlControls/TransformPositionController.FactMetaData.json
+++ b/src/QmlControls/TransformPositionController.FactMetaData.json
@@ -72,7 +72,7 @@
     "name":             "OffsetUp",
     "shortDesc":        "Up offset",
     "type":             "double",
-    "units":            "m",
+    "units":            "vertical m",
     "default":          0,
     "decimalPlaces":    2
 },

--- a/src/Settings/App.SettingsGroup.json
+++ b/src/Settings/App.SettingsGroup.json
@@ -112,7 +112,7 @@
             "type": "double",
             "default": 50.0,
             "min": 0.0,
-            "units": "m",
+            "units": "vertical m",
             "decimalPlaces": 1,
             "userMin": 0.0,
             "userMax": 121.92,

--- a/src/Settings/FlyView.SettingsGroup.json
+++ b/src/Settings/FlyView.SettingsGroup.json
@@ -6,7 +6,7 @@
             "name": "guidedMinimumAltitude",
             "shortDesc": "Minimum altitude allowed for guided mode actions like takeoff and altitude changes.",
             "type": "double",
-            "units": "m",
+            "units": "vertical m",
             "default": 2,
             "label": "Minimum Altitude",
             "keywords": "altitude,guided,minimum"
@@ -15,7 +15,7 @@
             "name": "guidedMaximumAltitude",
             "shortDesc": "Maximum altitude allowed for guided mode actions like takeoff and altitude changes.",
             "type": "double",
-            "units": "m",
+            "units": "vertical m",
             "default": 121.92,
             "label": "Maximum Altitude",
             "keywords": "altitude,guided,maximum"

--- a/src/Settings/RTK.SettingsGroup.json
+++ b/src/Settings/RTK.SettingsGroup.json
@@ -80,7 +80,7 @@
             "longDesc": "Defines the altitude of the fixed RTK base position.",
             "type": "float",
             "default": 0,
-            "units": "m",
+            "units": "vertical m",
             "decimalPlaces": 2,
             "qgcRebootRequired": true,
             "label": "Base Position Alt (WGS84)"

--- a/src/Settings/RemoteID.SettingsGroup.json
+++ b/src/Settings/RemoteID.SettingsGroup.json
@@ -183,7 +183,8 @@
             "shortDesc": "Fixed altitude for operator location when not using live GNSS.",
             "longDesc": "Fixed Altitude to send on SYSTEM message",
             "type": "double",
-            "decimalPlaces": 7,
+            "units": "vertical m",
+            "decimalPlaces": 1,
             "default": 0,
             "label": "Altitude Fixed",
             "keywords": "altitude,fixed position"

--- a/src/Settings/Viewer3D.SettingsGroup.json
+++ b/src/Settings/Viewer3D.SettingsGroup.json
@@ -30,9 +30,9 @@
         },
         {
             "name": "buildingLevelHeight",
-            "shortDesc": "Average floor-to-floor height in meters used for 3D building visualization.",
+            "shortDesc": "Average floor-to-floor height used for 3D building visualization.",
             "type": "double",
-            "units": "m",
+            "units": "vertical m",
             "min": 0.5,
             "max": 20,
             "default": 3,
@@ -41,9 +41,9 @@
         },
         {
             "name": "altitudeBias",
-            "shortDesc": "Vertical offset in meters for vehicle rendering in the 3D viewer.",
+            "shortDesc": "Vertical offset for vehicle rendering in the 3D viewer.",
             "type": "double",
-            "units": "m",
+            "units": "vertical m",
             "min": -1000,
             "max": 1000,
             "default": 0,

--- a/src/Vehicle/FactGroups/LocalPositionFact.json
+++ b/src/Vehicle/FactGroups/LocalPositionFact.json
@@ -22,7 +22,7 @@
     "shortDesc": "Z",
     "type":             "double",
     "decimalPlaces":    1,
-    "units":            "m"
+    "units":            "vertical m"
 },
 {
     "name":             "vx",

--- a/src/Vehicle/FactGroups/VehicleFact.json
+++ b/src/Vehicle/FactGroups/VehicleFact.json
@@ -71,21 +71,21 @@
     "shortDesc": "Alt (Rel)",
     "type":             "double",
     "decimalPlaces":    1,
-    "units":            "m"
+    "units":            "vertical m"
 },
 {
     "name":             "altitudeAMSL",
     "shortDesc": "Alt (AMSL)",
     "type":             "double",
     "decimalPlaces":    1,
-    "units":            "m"
+    "units":            "vertical m"
 },
 {
     "name":             "altitudeAboveTerr",
     "shortDesc": "Alt (Above Terrain)",
     "type":             "double",
     "decimalPlaces":    1,
-    "units":            "m"
+    "units":            "vertical m"
 },
 {
     "name":             "flightDistance",

--- a/src/Viewer3D/Viewer3DQml/Drones/DroneModelDjiF450.qml
+++ b/src/Viewer3D/Viewer3DQml/Drones/DroneModelDjiF450.qml
@@ -21,7 +21,8 @@ Node {
     property double pitch: vehicle ? finiteOr(vehicle.pitch.value, 0) : 0
     property double pose_x: finiteOr(geo2Enu.localCoordinate.x, 0) * 10
     property double pose_y: finiteOr(geo2Enu.localCoordinate.y, 0) * 10
-    property double pose_z: (finiteOr((vehicle ? vehicle.altitudeRelative.value : 0), 0) + altitudeBias) * 10
+    // Scene coordinates are meters - use rawValue since cooked value follows the user's units setting
+    property double pose_z: (finiteOr((vehicle ? vehicle.altitudeRelative.rawValue : 0), 0) + altitudeBias) * 10
     property double roll: vehicle ? finiteOr(vehicle.roll.value, 0) : 0
     property var vehicle
 

--- a/test/FactSystem/FactMetaDataTest.cc
+++ b/test/FactSystem/FactMetaDataTest.cc
@@ -2,12 +2,15 @@
 
 #include <QtCore/QJsonObject>
 #include <QtCore/QRegularExpression>
+#include <QtCore/QScopeGuard>
 #include <QtCore/QtNumeric>
 
 #include <cmath>
 #include <limits>
 
 #include "FactMetaData.h"
+#include "SettingsManager.h"
+#include "UnitsSettings.h"
 
 void FactMetaDataTest::_stringToTypeRoundTrip_test()
 {
@@ -306,6 +309,35 @@ void FactMetaDataTest::_builtInTranslatorNorm_test()
 
     const QVariant cooked = meta.rawTranslator()(QVariant(0.5));
     QCOMPARE_FUZZY(cooked.toDouble(), 50.0, 1e-5);
+}
+
+void FactMetaDataTest::_verticalMetersUnitsIntType_test()
+{
+    // "vertical m" is an artificial lookup unit. Int types don't get app settings
+    // translators, but the artificial unit string must never be shown to the user.
+    FactMetaData meta(FactMetaData::valueTypeInt32);
+    meta.setRawUnits("vertical m");
+
+    QCOMPARE(meta.cookedUnits(), QStringLiteral("m"));
+}
+
+void FactMetaDataTest::_verticalMetersUnitsFeetTranslation_test()
+{
+    // With vertical distance units set to feet, a double fact must translate to "ft"
+    // and the artificial-unit fallback must not clobber the translated units
+    Fact *const vertUnitsFact = SettingsManager::instance()->unitsSettings()->verticalDistanceUnits();
+    const QVariant savedUnits = vertUnitsFact->rawValue();
+    const auto restoreUnits = qScopeGuard([vertUnitsFact, savedUnits] {
+        vertUnitsFact->setRawValue(savedUnits);
+    });
+    vertUnitsFact->setRawValue(UnitsSettings::VerticalDistanceUnitsFeet);
+
+    FactMetaData meta(FactMetaData::valueTypeDouble);
+    meta.setRawUnits("vertical m");
+
+    QCOMPARE(meta.cookedUnits(), QStringLiteral("ft"));
+    QCOMPARE_FUZZY(meta.rawTranslator()(QVariant(1.0)).toDouble(), 3.28084, 1e-4);
+    QCOMPARE_FUZZY(meta.cookedTranslator()(QVariant(3.28084)).toDouble(), 1.0, 1e-4);
 }
 
 void FactMetaDataTest::_setMinMax_test()

--- a/test/FactSystem/FactMetaDataTest.h
+++ b/test/FactSystem/FactMetaDataTest.h
@@ -27,6 +27,8 @@ private slots:
     void _builtInTranslatorRadians_test();
     void _builtInTranslatorCentiDegrees_test();
     void _builtInTranslatorNorm_test();
+    void _verticalMetersUnitsIntType_test();
+    void _verticalMetersUnitsFeetTranslation_test();
     void _setMinMax_test();
     void _maxStringLength_test();
     void _maxStringLengthNegativeRejected_test();

--- a/test/FactSystem/FactTest.cc
+++ b/test/FactSystem/FactTest.cc
@@ -59,6 +59,22 @@ void FactTest::_setCookedValueWithTranslator_test()
     QCOMPARE_FUZZY(fact.cookedValue().toDouble(), 180.0, 1e-5);
 }
 
+void FactTest::_rawToCooked_test()
+{
+    // Converts an arbitrary raw value through the fact's own translator
+    Fact fact(0, "RadParam", FactMetaData::valueTypeDouble);
+
+    auto *meta = fact.metaData();
+    QVERIFY(meta);
+    meta->setRawUnits("radians");
+
+    QCOMPARE_FUZZY(fact.rawToCooked(QVariant(M_PI)).toDouble(), 180.0, 1e-5);
+
+    // Default identity translator - value passes through unchanged
+    Fact plainFact(0, "PlainParam", FactMetaData::valueTypeDouble);
+    QCOMPARE(plainFact.rawToCooked(QVariant(42.0)).toDouble(), 42.0);
+}
+
 void FactTest::_validateValid_test()
 {
     Fact fact(0, "IntParam", FactMetaData::valueTypeInt32);

--- a/test/FactSystem/FactTest.h
+++ b/test/FactSystem/FactTest.h
@@ -12,6 +12,7 @@ private slots:
     void _setRawValueDouble_test();
     void _setRawValueString_test();
     void _setCookedValueWithTranslator_test();
+    void _rawToCooked_test();
     void _validateValid_test();
     void _validateInvalid_test();
     void _validateConvertOnly_test();


### PR DESCRIPTION
## Summary

Based on contributions from @Bartok9 (#14598, #14601, #14606, #14607) and @n-sleeman (#14539) — credited as co-authors on the commit.

This PR coalesces the following open PRs into a single change and replaces them:

- Replaces #14607
- Replaces #14606
- Replaces #14601
- Replaces #14598
- Replaces #14539

All of those PRs switch altitude-related fact metadata units from `"m"` to `"vertical m"` so the values honor the **vertical** distance units app setting instead of the horizontal one. This PR combines them and extends the work with additional `"vertical m"` usage, bug fixes, and better unit testing.

## Additional "vertical m" usage beyond the coalesced PRs

- Mission command params in `MavCmdInfoCommon.json` (NAV_LAND Abort Alt, NAV_VTOL_LAND Approach Alt, CONDITION_CHANGE_ALT Target, DO_GUIDED_LIMITS Min/Max Alt)
- `TransectStyle.SettingsGroup.json` TerrainAdjustTolerance
- Vehicle fact groups: `VehicleFact.json` (altitudeRelative/AMSL/AboveTerr), `LocalPositionFact.json` (z)
- `RemoteID.SettingsGroup.json` altitudeFixed (also fixed decimalPlaces 7 → 1)

## Bug fixes

- `FactMetaData`: the artificial `"vertical m"` lookup unit could leak into the UI for int-type facts (app-settings translation only applies to double/float). Added a fallback so it always displays as `"m"`.
- `PX4FlightModeIndicator.qml`: both altitude sliders mixed raw and cooked value domains (RTL_RETURN_ALT max, GF_MAX_VER_DIST-based max).
- `FWLandingPatternMapVisual.qml`: final approach altitude label used the horizontal distance units string.
- `DroneModelDjiF450.qml`: 3D scene mixed cooked `altitudeRelative.value` with raw altitude bias; now uses `rawValue`.
- Removed bogus units from enum params ("Precision Land", "Transition Heading") in `MavCmdInfoCommon.json`.

## API additions

- `Fact::rawToCooked()` (Q_INVOKABLE) — convert a raw value through the fact's own translator from QML, avoiding hand-rolled conversions.
- `QmlUnitsConversion::metersToAppSettingsVerticalDistanceUnitsString()` / `...HorizontalDistanceUnitsString()` — paired value+units display strings (e.g. "16.4 ft").

## Testing

- New unit tests: int-type `"vertical m"` fallback, feet translation (with settings restore via `qScopeGuard`), `Fact::rawToCooked()` (builtin + identity translators).
- `FactMetaDataTest`, `FactTest`, `MissionCommandTreeTest`, `SurveyComplexItemTest` all pass; qmllint clean on all touched QML; all JSON validated.

