### PR TITLE
fix(facts): use vertical m for vehicle altitude telemetry facts

### DIFF
--- a/.github/build-config.json
+++ b/.github/build-config.json
@@ -73,6 +73,6 @@
         "ios": "d82c51bd81eafa77fd322c39ce7e6d663a5b860359ace6ed98060c87092e4845"
       }
     },
-    "ca_bundle_sha256": "86a1f3366afac7c6f8ae9f3c779ac221129328c43f0ab2b8817eb2f362a5025c"
+    "ca_bundle_sha256": "3ff344e30b9b1ed2971044eabb438a08f2e2245ddb5f8ab1a3ad8b63ab4eaf91"
   }
 }

--- a/.github/build-config.json
+++ b/.github/build-config.json
@@ -73,6 +73,6 @@
         "ios": "d82c51bd81eafa77fd322c39ce7e6d663a5b860359ace6ed98060c87092e4845"
       }
     },
-    "ca_bundle_sha256": "3ff344e30b9b1ed2971044eabb438a08f2e2245ddb5f8ab1a3ad8b63ab4eaf91"
+    "ca_bundle_sha256": "86a1f3366afac7c6f8ae9f3c779ac221129328c43f0ab2b8817eb2f362a5025c"
   }
 }

--- a/src/Vehicle/FactGroups/VehicleFact.json
+++ b/src/Vehicle/FactGroups/VehicleFact.json
@@ -71,21 +71,21 @@
     "shortDesc": "Alt (Rel)",
     "type":             "double",
     "decimalPlaces":    1,
-    "units":            "m"
+    "units":            "vertical m"
 },
 {
     "name":             "altitudeAMSL",
     "shortDesc": "Alt (AMSL)",
     "type":             "double",
     "decimalPlaces":    1,
-    "units":            "m"
+    "units":            "vertical m"
 },
 {
     "name":             "altitudeAboveTerr",
     "shortDesc": "Alt (Above Terrain)",
     "type":             "double",
     "decimalPlaces":    1,
-    "units":            "m"
+    "units":            "vertical m"
 },
 {
     "name":             "flightDistance",


### PR DESCRIPTION
## Summary
- Set units to "vertical m" for Vehicle telemetry facts altitudeRelative, altitudeAMSL, and altitudeAboveTerr.

## Motivation
FactMetaData treats plain "m" as horizontal distance and "vertical m" as the vertical axis. Vehicle altitudes were still tagged "m", so changing Vertical Distance units in Settings did not convert these altitude streams. Metadata-only (no C++/QML arm/geofence changes).

## Verification
- [x] python3 -m json.tool on VehicleFact.json
- [x] Only the three altitude facts changed; horizontal distance facts remain "m"

## Notes
AI-assisted; human-reviewed. Spec path in airborne campaign; Composer Standard posture when Cursor cloud is available.