### PR TITLE
fix(ci): update pinned iOS CA bundle SHA256 to current curl.se cacert.pem

### DIFF
--- a/.github/build-config.json
+++ b/.github/build-config.json
@@ -73,6 +73,6 @@
         "ios": "d82c51bd81eafa77fd322c39ce7e6d663a5b860359ace6ed98060c87092e4845"
       }
     },
-    "ca_bundle_sha256": "86a1f3366afac7c6f8ae9f3c779ac221129328c43f0ab2b8817eb2f362a5025c"
+    "ca_bundle_sha256": "3ff344e30b9b1ed2971044eabb438a08f2e2245ddb5f8ab1a3ad8b63ab4eaf91"
   }
 }


### PR DESCRIPTION
## Problem

Every `Configure` step (build (Release), Docker Linux-aarch64, Release linux_gcc_arm64, iOS, etc.) is currently failing on **master** and all PRs:

```
CMake Error at cmake/modules/Download.cmake:123 (message):
  iOS CA bundle: SHA256 mismatch for ca-certificates.crt from
  https://curl.se/ca/cacert.pem (expected
  86a1f3366afac7c6f8ae9f3c779ac221129328c43f0ab2b8817eb2f362a5025c, got
  3ff344e30b9b1ed2971044eabb438a08f2e2245ddb5f8ab1a3ad8b63ab4eaf91).
  Refusing to fall back to other mirrors with a pinned checksum.
```

## Root cause

Mozilla/curl rotated `cacert.pem` (the live bundle header now reads *Certificate data from Mozilla as of: Thu Jul 16 03:12:01 2026 GMT*), so the `ca_bundle_sha256` pinned in `.github/build-config.json` is stale. The pinned-checksum guard in `Download.cmake` correctly refuses to proceed, which is why this breaks configure across the board rather than silently pulling a different file.

## Fix

Update `ca_bundle_sha256` to the current published bundle checksum:

- old: `86a1f3366afac7c6f8ae9f3c779ac221129328c43f0ab2b8817eb2f362a5025c`
- new: `3ff344e30b9b1ed2971044eabb438a08f2e2245ddb5f8ab1a3ad8b63ab4eaf91`

Verified locally:

```
$ curl -sL https://curl.se/ca/cacert.pem | shasum -a 256
3ff344e30b9b1ed2971044eabb438a08f2e2245ddb5f8ab1a3ad8b63ab4eaf91
```

The bundle is the official Mozilla extract from https://curl.se/docs/caextract.html. One-line data change; no code changes.