### PR TITLE
fix(PlanView): make tree layer groups exclusive and drive editing layer from panel interactions

### DIFF
--- a/src/PlanView/CMakeLists.txt
+++ b/src/PlanView/CMakeLists.txt
@@ -5,6 +5,10 @@
 
 qt_add_library(PlanViewModule STATIC)
 
+set_source_files_properties(PlanEditLayers.qml PROPERTIES
+    QT_QML_SINGLETON_TYPE TRUE
+)
+
 qt_add_qml_module(PlanViewModule
     URI QGroundControl.PlanView
     VERSION 1.0
@@ -28,6 +32,7 @@ qt_add_qml_module(PlanViewModule
         MissionItemStatus.qml
         MissionSettingsEditor.qml
         MissionStats.qml
+        PlanEditLayers.qml
         PlanEditToolbar.qml
         PlanInfoEditor.qml
         PlanToolBarIndicators.qml

--- a/src/PlanView/PlanEditLayers.qml
+++ b/src/PlanView/PlanEditLayers.qml
@@ -1,0 +1,22 @@
+pragma Singleton
+
+import QtQuick
+
+/// Single source of truth for the Plan View map editing layers. Used by the
+/// layer switcher (PlanView), the plan tree view group headers, and the map
+/// visual bindings.
+QtObject {
+    readonly property int layerMission: 1
+    readonly property int layerFence:   2
+    readonly property int layerRally:   3
+
+    readonly property var layerInfos: [
+        { layer: layerMission, nodeType: "missionGroup", icon: "/res/waypoint.svg",   name: qsTr("Mission") },
+        { layer: layerFence,   nodeType: "fenceGroup",   icon: "/res/GeoFence.svg",   name: qsTr("GeoFence") },
+        { layer: layerRally,   nodeType: "rallyGroup",   icon: "/res/RallyPoint.svg", name: qsTr("Rally Points") }
+    ]
+
+    function infoForNodeType(nodeType) {
+        return layerInfos.find(l => l.nodeType === nodeType) ?? null
+    }
+}

--- a/src/PlanView/PlanTreeView.qml
+++ b/src/PlanView/PlanTreeView.qml
@@ -24,9 +24,6 @@ TreeView {
 
     signal editingLayerChangeRequested(int layer)
 
-    readonly property int _layerMission: 1
-    readonly property int _layerFence:   2
-    readonly property int _layerRally:   3
     readonly property bool _createNewPlanMode: planMasterController.showCreateFromTemplate
 
     on_CreateNewPlanModeChanged: {
@@ -72,11 +69,8 @@ TreeView {
                         root.collapse(defaultsRow)
                     }
                 }
-                // Expand mission group and scroll to the new item
-                var missionRow = _rowFor(_missionController.missionGroupIndex)
-                if (!root.isExpanded(missionRow)) {
-                    root.expand(missionRow)
-                }
+                // Expand mission group (making Mission the active layer) and scroll to the new item
+                root.selectLayer("missionGroup")
                 // Scroll happens when the editor signals editorExpandedAndLoaded
             }
             root._lastMissionItemCount = newCount
@@ -97,7 +91,7 @@ TreeView {
                 root.contentY = 0
             }
             root._lastMissionItemCount = _missionController.visualItems ? _missionController.visualItems.count : 0
-            root.editingLayerChangeRequested(root._layerMission)
+            root.editingLayerChangeRequested(PlanEditLayers.layerMission)
         }
         function onPlanViewStateChanged() {
             // Current item changed — bring it on-screen if completely off-screen.
@@ -114,33 +108,52 @@ TreeView {
         }
     }
 
-    // Public API: select a layer and expand its group. Called by the layer tool buttons.
-    function selectLayer(nodeType) {
-        let targetRow = -1
-        switch (nodeType) {
-        case "missionGroup":
-            targetRow = _rowFor(_missionController.missionGroupIndex)
-            editingLayerChangeRequested(_layerMission)
-            break
-        case "fenceGroup":
-            targetRow = _rowFor(_missionController.fenceGroupIndex)
-            editingLayerChangeRequested(_layerFence)
-            break
-        case "rallyGroup":
-            targetRow = _rowFor(_missionController.rallyGroupIndex)
-            editingLayerChangeRequested(_layerRally)
-            break
-        }
+    // The three groups which correspond to map editing layers. These are exclusive:
+    // expanding one collapses the others and makes it the active editing layer.
 
+    function _layerGroupRow(nodeType) {
+        switch (nodeType) {
+        case "missionGroup":    return _rowFor(_missionController.missionGroupIndex)
+        case "fenceGroup":      return _rowFor(_missionController.fenceGroupIndex)
+        case "rallyGroup":      return _rowFor(_missionController.rallyGroupIndex)
+        }
+        return -1
+    }
+
+    function _collapseOtherLayerGroups(nodeType) {
+        for (var layerInfo of PlanEditLayers.layerInfos) {
+            if (layerInfo.nodeType !== nodeType) {
+                var row = _layerGroupRow(layerInfo.nodeType)
+                if (row >= 0 && root.isExpanded(row)) {
+                    root.collapse(row)
+                }
+            }
+        }
+    }
+
+    // Public API: make a layer group the active editing layer and expand it,
+    // collapsing the other layer groups. Called by the layer tool buttons and group headers.
+    function selectLayer(nodeType) {
+        var layerInfo = PlanEditLayers.infoForNodeType(nodeType)
+        if (!layerInfo) {
+            return
+        }
+        if (!mainWindow.allowViewSwitch()) {
+            return
+        }
+        editingLayerChangeRequested(layerInfo.layer)
+        _collapseOtherLayerGroups(nodeType)
+        var targetRow = _layerGroupRow(nodeType)
         if (targetRow >= 0) {
-            if (!root.isExpanded(targetRow))
+            if (!root.isExpanded(targetRow)) {
                 root.expand(targetRow)
+            }
             root.forceLayout()
             root.positionViewAtRow(targetRow, TableView.AlignTop)
         }
     }
 
-    // Toggle expand/collapse for a group header. Does not affect the editing layer.
+    // Toggle expand/collapse for a non-layer group header (Plan Info, Defaults, Transform).
     // Caller is responsible for calling allowViewSwitch() before invoking this.
     function _toggleGroup(row) {
         if (root.isExpanded(row)) {
@@ -155,10 +168,15 @@ TreeView {
     function _groupSubtitle(nodeType) {
         switch (nodeType) {
         case "planFileGroup":   return planMasterController.currentPlanFileName === "" ? qsTr("<Untitled>") : planMasterController.currentPlanFileName
-        case "missionGroup":    return _missionController.visualItems ? (_missionController.visualItems.count - 1) + qsTr(" items") : ""
-        case "rallyGroup":      return _rallyPointController.points ? _rallyPointController.points.count + qsTr(" points") : ""
+        case "missionGroup":    return _missionController.visualItems ? qsTr("%1 items").arg(_missionController.visualItems.count - 1) : ""
+        case "rallyGroup":      return _rallyPointController.points ? qsTr("%1 points").arg(_rallyPointController.points.count) : ""
         default:                return ""
         }
+    }
+
+    // Icon shown on group headers, matches the layer switcher icons
+    function _groupIcon(nodeType) {
+        return PlanEditLayers.infoForNodeType(nodeType)?.icon ?? ""
     }
 
     // Coalesces multiple delegate height changes into a single forceLayout() call
@@ -184,8 +202,8 @@ TreeView {
         id: delegateRoot
         implicitWidth: root.width
         implicitHeight: (loader.item ? loader.item.height : 1) + (separatorLine.visible ? separatorLine.height + root.rowSpacing : 0)
-        visible: !root._createNewPlanMode || _visibleInCreateMode
-        height: visible ? implicitHeight : 0
+        enabled: !root._createNewPlanMode || _enabledInCreateMode
+        opacity: enabled ? 1 : root.editorMap._nonInteractiveOpacity
         width: root.width
 
         required property TreeView treeView
@@ -200,8 +218,8 @@ TreeView {
         readonly property string nodeType: model.nodeType
         readonly property bool separator: model.separator ?? false
 
-        // In create-new-plan mode, only show Plan Info and Defaults groups and their children
-        readonly property bool _visibleInCreateMode: nodeType === "planFileGroup" || nodeType === "planFileInfo"
+        // In create-new-plan mode, only the Plan Info and Defaults groups and their children are enabled
+        readonly property bool _enabledInCreateMode: nodeType === "planFileGroup" || nodeType === "planFileInfo"
                                                      || nodeType === "defaultsGroup" || nodeType === "defaultsInfo"
 
         onImplicitHeightChanged: layoutTimer.restart()
@@ -227,6 +245,7 @@ TreeView {
                     break
                 case "planFileInfo":
                     setSource(delegateRoot._qrcBase + "PlanInfoEditor.qml", {
+                        objectName:             "planTree_planFileInfo",
                         width:                  Qt.binding(() => delegateRoot.width),
                         planMasterController:   root.planMasterController,
                         missionController:      root._missionController,
@@ -243,6 +262,7 @@ TreeView {
                 case "missionItem":
                     if (delegateRoot.nodeObject) {
                         setSource(delegateRoot._qrcBase + "MissionItemEditor.qml", {
+                            objectName:     "planTree_missionItemEditor",
                             width:          Qt.binding(() => delegateRoot.width),
                             map:            root.editorMap,
                             missionItem:    delegateRoot.nodeObject
@@ -252,6 +272,7 @@ TreeView {
                 case "fenceEditor":
                     if (delegateRoot.nodeObject) {
                         setSource(delegateRoot._qrcBase + "GeoFenceEditor.qml", {
+                            objectName:             "planTree_fenceEditor",
                             width:                  Qt.binding(() => delegateRoot.width),
                             myGeoFenceController:   root._geoFenceController,
                             flightMap:              root.editorMap
@@ -261,6 +282,7 @@ TreeView {
                 case "rallyHeader":
                     if (delegateRoot.nodeObject) {
                         setSource(delegateRoot._qrcBase + "RallyPointEditorHeader.qml", {
+                            objectName: "planTree_rallyHeader",
                             width:      Qt.binding(() => delegateRoot.width),
                             controller: root._rallyPointController
                         })
@@ -356,6 +378,15 @@ TreeView {
                         font.bold: true
                     }
 
+                    QGCColoredImage {
+                        Layout.alignment: Qt.AlignVCenter
+                        Layout.preferredWidth: ScreenTools.defaultFontPixelHeight * 0.75
+                        Layout.preferredHeight: Layout.preferredWidth
+                        source: root._groupIcon(delegateRoot.nodeType)
+                        color: qgcPal.text
+                        visible: source.toString() !== ""
+                    }
+
                     QGCLabel {
                         Layout.alignment: Qt.AlignBaseline
                         Layout.fillWidth: true
@@ -369,10 +400,17 @@ TreeView {
                 MouseArea {
                     anchors.fill: parent
                     onClicked: {
-                        if (!mainWindow.allowViewSwitch()) {
-                            return
+                        if (PlanEditLayers.infoForNodeType(delegateRoot.nodeType)) {
+                            // Layer groups cannot be collapsed by clicking their header. The active
+                            // editing layer always has its group expanded. selectLayer() handles
+                            // the allowViewSwitch() guard.
+                            root.selectLayer(delegateRoot.nodeType)
+                        } else {
+                            if (!mainWindow.allowViewSwitch()) {
+                                return
+                            }
+                            root._toggleGroup(delegateRoot.row)
                         }
-                        root._toggleGroup(delegateRoot.row)
                     }
                 }
             }

--- a/src/PlanView/PlanView.qml
+++ b/src/PlanView/PlanView.qml
@@ -35,9 +35,9 @@ Item {
     property bool   _addROIOnClick: false
     property bool   _addWaypointOnClick: false
 
-    readonly property int _layerMission: 1
-    readonly property int _layerFence: 2
-    readonly property int _layerRally: 3
+    readonly property int _layerMission: PlanEditLayers.layerMission
+    readonly property int _layerFence: PlanEditLayers.layerFence
+    readonly property int _layerRally: PlanEditLayers.layerRally
 
     onVisibleChanged: {
         if(visible) {
@@ -389,6 +389,7 @@ Item {
             }
 
             GeoFenceMapVisuals {
+                objectName: "planView_geoFenceMapVisuals"
                 map: editorMap
                 myGeoFenceController: _geoFenceController
                 interactive: _editingLayer == _layerFence
@@ -398,6 +399,7 @@ Item {
             }
 
             RallyPointMapVisuals {
+                objectName: "planView_rallyPointMapVisuals"
                 map: editorMap
                 myRallyPointController: _rallyPointController
                 interactive: _editingLayer == _layerRally
@@ -526,6 +528,7 @@ Item {
         // Layer switching icons — only active icon visible; click to expand choices leftward
         Item {
             id:                     layerSwitcher
+            objectName:             "planView_layerSwitcher"
             anchors.right:          rightPanel.left
             anchors.rightMargin:    _toolsMargin
             anchors.top:            parent.top
@@ -533,16 +536,11 @@ Item {
             width:                  layerRow.width
             height:                 _layerButtonSize
             z:                      QGroundControl.zOrderWidgets
+            visible:                !_planMasterController.showCreateFromTemplate
 
             property bool   expanded: false
             property real   _layerButtonSize: ScreenTools.defaultFontPixelHeight * 2.0
             property real   _spacing: ScreenTools.defaultFontPixelHeight * 0.25
-
-            readonly property var _layers: [
-                { layer: _layerMission, icon: "/res/waypoint.svg",      nodeType: "missionGroup" },
-                { layer: _layerFence,   icon: "/res/GeoFence.svg",      nodeType: "fenceGroup" },
-                { layer: _layerRally,   icon: "/res/RallyPoint.svg",    nodeType: "rallyGroup" }
-            ]
 
             Timer {
                 id: collapseTimer
@@ -574,6 +572,7 @@ Item {
 
                 // Active layer button (always visible)
                 Rectangle {
+                    objectName: "layerSwitcher_activeButton"
                     width:  layerSwitcher._layerButtonSize
                     height: width
                     radius: ScreenTools.defaultBorderRadius
@@ -583,7 +582,7 @@ Item {
                         anchors.centerIn:   parent
                         width:              parent.width * 0.6
                         height:             width
-                        source:             layerSwitcher._layers.find(l => l.layer === _editingLayer)?.icon ?? "/res/waypoint.svg"
+                        source:             PlanEditLayers.layerInfos.find(l => l.layer === _editingLayer)?.icon ?? "/res/waypoint.svg"
                         color:              QGroundControl.globalPalette.buttonHighlightText
                     }
 
@@ -595,12 +594,13 @@ Item {
 
                 // Choice buttons (only layers that are NOT the current one)
                 Repeater {
-                    model: layerSwitcher._layers.filter(l => l.layer !== _editingLayer)
+                    model: PlanEditLayers.layerInfos.filter(l => l.layer !== _editingLayer)
 
                     Rectangle {
                         required property var modelData
-                        width:   layerSwitcher._layerButtonSize
-                        height:  width
+                        objectName: "layerSwitcher_choice_" + modelData.nodeType
+                        width:   choiceRow.implicitWidth + layerSwitcher._spacing * 2
+                        height:  layerSwitcher._layerButtonSize
                         radius:  ScreenTools.defaultBorderRadius
                         color:   QGroundControl.globalPalette.button
                         visible: opacity > 0
@@ -608,12 +608,24 @@ Item {
 
                         Behavior on opacity { NumberAnimation { duration: 150 } }
 
-                        QGCColoredImage {
-                            anchors.centerIn:   parent
-                            width:              parent.width * 0.6
-                            height:             width
-                            source:             modelData.icon
-                            color:              QGroundControl.globalPalette.buttonText
+                        Row {
+                            id:                     choiceRow
+                            anchors.centerIn:       parent
+                            spacing:                layerSwitcher._spacing
+
+                            QGCColoredImage {
+                                anchors.verticalCenter: parent.verticalCenter
+                                width:                  layerSwitcher._layerButtonSize * 0.6
+                                height:                 width
+                                source:                 modelData.icon
+                                color:                  QGroundControl.globalPalette.buttonText
+                            }
+
+                            QGCLabel {
+                                anchors.verticalCenter: parent.verticalCenter
+                                text:                   modelData.name
+                                color:                  QGroundControl.globalPalette.buttonText
+                            }
                         }
 
                         QGCMouseArea {

--- a/src/PlanView/PlanViewRightPanel.qml
+++ b/src/PlanView/PlanViewRightPanel.qml
@@ -92,6 +92,7 @@ Item {
 
         PlanTreeView {
             id:                     planTreeView
+            objectName:             "planView_planTree"
             anchors.fill:           parent
             editorMap:              root.editorMap
             planMasterController:   root.planMasterController

--- a/test/QmlUITests/CMakeLists.txt
+++ b/test/QmlUITests/CMakeLists.txt
@@ -18,6 +18,8 @@ target_sources(${CMAKE_PROJECT_NAME}
         ${CMAKE_CURRENT_SOURCE_DIR}/ToolbarIndicatorUITest.h
         ${CMAKE_CURRENT_SOURCE_DIR}/PlanViewUITest.cc
         ${CMAKE_CURRENT_SOURCE_DIR}/PlanViewUITest.h
+        ${CMAKE_CURRENT_SOURCE_DIR}/PlanViewLayerUITest.cc
+        ${CMAKE_CURRENT_SOURCE_DIR}/PlanViewLayerUITest.h
         ${CMAKE_CURRENT_SOURCE_DIR}/PX4SensorsCalibrationUITest.cc
         ${CMAKE_CURRENT_SOURCE_DIR}/PX4SensorsCalibrationUITest.h
         ${CMAKE_CURRENT_SOURCE_DIR}/APMSensorsCalibrationUITest.cc
@@ -39,6 +41,7 @@ add_qgc_test(PX4VehicleConfigUITest LABELS Integration NoSanitizer TIMEOUT 180)
 add_qgc_test(APMVehicleConfigUITest LABELS Integration NoSanitizer TIMEOUT 360)
 add_qgc_test(ToolbarIndicatorUITest LABELS Integration NoSanitizer TIMEOUT 180)
 add_qgc_test(PlanViewUITest LABELS Integration NoSanitizer TIMEOUT 120)
+add_qgc_test(PlanViewLayerUITest LABELS Integration NoSanitizer TIMEOUT 120)
 add_qgc_test(PX4SensorsCalibrationUITest LABELS Integration NoSanitizer TIMEOUT 180)
 add_qgc_test(APMSensorsCalibrationUITest LABELS Integration NoSanitizer TIMEOUT 240)
 add_qgc_test(PX4AirframeSetupUITest LABELS Integration NoSanitizer TIMEOUT 120)

--- a/test/QmlUITests/PlanViewLayerUITest.cc
+++ b/test/QmlUITests/PlanViewLayerUITest.cc
@@ -1,0 +1,238 @@
+#include "PlanViewLayerUITest.h"
+
+#include <QtPositioning/QGeoCoordinate>
+#include <QtQuick/QQuickItem>
+#include <QtTest/QTest>
+
+UT_REGISTER_TEST(PlanViewLayerUITest, TestLabel::Integration, TestLabel::MissionManager)
+
+// Editing layer switching test. Offline for the entire test — layer state is
+// purely a UI concern so no vehicle is needed.
+
+namespace {
+constexpr int kLayerMission = 1;
+constexpr int kLayerFence   = 2;
+constexpr int kLayerRally   = 3;
+
+const char *kLayerSwitcher      = "planView_layerSwitcher";
+const char *kSwitcherActive     = "layerSwitcher_activeButton";
+const char *kMissionHeader      = "planTree_missionGroupHeader";
+const char *kFenceHeader        = "planTree_fenceGroupHeader";
+const char *kRallyHeader        = "planTree_rallyGroupHeader";
+const char *kPlanFileHeader     = "planTree_planFileGroupHeader";
+const char *kMissionItemEditor  = "planTree_missionItemEditor";
+const char *kFenceEditor        = "planTree_fenceEditor";
+const char *kRallyEditorHeader  = "planTree_rallyHeader";
+const char *kFenceMapVisuals    = "planView_geoFenceMapVisuals";
+const char *kRallyMapVisuals    = "planView_rallyPointMapVisuals";
+} // namespace
+
+void PlanViewLayerUITest::_clickMap(qreal fractionX, qreal fractionY)
+{
+    QVERIFY2(clickItemFraction(QStringLiteral("planView_map"), fractionX, fractionY), "Failed to click planView_map");
+}
+
+int PlanViewLayerUITest::_editingLayer()
+{
+    QQuickItem *planView = findVisibleItem(_rootItem, QStringLiteral("mainView_plan"));
+    if (!planView) {
+        return -1;
+    }
+    return planView->property("_editingLayer").toInt();
+}
+
+bool PlanViewLayerUITest::_clickTreeRow(const QString &objectName)
+{
+    return clickButtonScrolled(objectName, QStringLiteral("planView_planTree"));
+}
+
+void PlanViewLayerUITest::_verifyLayerState(const LayerUIState &state, const QString &context)
+{
+    QVERIFY2(waitForCondition([&] { return _editingLayer() == state.editingLayer; }, 2000,
+                              QStringLiteral("editing layer")),
+             qPrintable(QStringLiteral("%1: expected editing layer %2 but found %3")
+                            .arg(context).arg(state.editingLayer).arg(_editingLayer())));
+
+    if (!verifyVisibility(QLatin1String(kLayerSwitcher), state.switcherVisible, context)) return;
+    if (!verifyVisibility(QLatin1String(kMissionItemEditor), state.missionEditorVisible, context)) return;
+    if (!verifyVisibility(QLatin1String(kFenceEditor), state.fenceEditorVisible, context)) return;
+    if (!verifyVisibility(QLatin1String(kRallyEditorHeader), state.rallyHeaderVisible, context)) return;
+
+    // Map visuals interactive state follows the active layer
+    if (!verifyProperty(QLatin1String(kFenceMapVisuals), "interactive", state.fenceInteractive, context)) return;
+    if (!verifyProperty(QLatin1String(kRallyMapVisuals), "interactive", state.rallyInteractive, context)) return;
+}
+
+void PlanViewLayerUITest::_testEditingLayerSwitching()
+{
+    startUI();
+    if (QTest::currentTestFailed()) return;
+
+    // Navigate to Plan view
+    QVERIFY2(clickToolSelectDropdownButton(QStringLiteral("toolbar_viewPlan")), "Failed to navigate to Plan view");
+    QVERIFY2(findVisibleItem(_rootItem, QStringLiteral("mainView_plan"), 2000), "Plan view did not appear");
+    QTest::qWait(_viewDelay);
+
+    // Position the map at a known location so map clicks are deterministic
+    QQuickItem *map = findVisibleItem(_rootItem, QStringLiteral("planView_map"));
+    QVERIFY2(map, "planView_map not found");
+    const QGeoCoordinate mapCenter(47.397742, 8.545594); // Zurich
+    map->setProperty("center", QVariant::fromValue(mapCenter));
+    map->setProperty("zoomLevel", 15.0);
+    QVERIFY2(waitForCondition(
+                 [&] {
+                     const QGeoCoordinate c = map->property("center").value<QGeoCoordinate>();
+                     return c.isValid() && (c.distanceTo(mapCenter) < 1.0);
+                 },
+                 1000),
+             "Map did not settle on the requested center");
+
+    // ------------------------------------------------------------------
+    // 2.1 Create-from-template mode: layer switcher hidden, layer group
+    //     headers disabled, Plan Info header enabled
+    // ------------------------------------------------------------------
+    _verifyLayerState({
+        .editingLayer         = kLayerMission,
+        .switcherVisible      = false,
+        .missionEditorVisible = false,  // Empty plan
+        .fenceEditorVisible   = false,
+        .rallyHeaderVisible   = false,
+        .fenceInteractive     = false,
+        .rallyInteractive     = false,
+    }, QStringLiteral("2.1 create mode"));
+    if (QTest::currentTestFailed()) return;
+
+    // The expanded Plan Info section pushes the layer group headers below the
+    // viewport where their virtualized delegates do not exist. Scroll them into
+    // existence before checking their disabled state.
+    QVERIFY2(findVisibleItemScrolled(QLatin1String(kMissionHeader), QStringLiteral("planView_planTree")),
+             "Mission group header not found");
+    verifyEnabled(QLatin1String(kMissionHeader), false, QStringLiteral("2.1 create mode"));
+    verifyEnabled(QLatin1String(kFenceHeader),   false, QStringLiteral("2.1 create mode"));
+    verifyEnabled(QLatin1String(kRallyHeader),   false, QStringLiteral("2.1 create mode"));
+    QVERIFY2(findVisibleItemScrolled(QLatin1String(kPlanFileHeader), QStringLiteral("planView_planTree")),
+             "Plan Info header not found");
+    verifyEnabled(QLatin1String(kPlanFileHeader), true, QStringLiteral("2.1 create mode"));
+    if (QTest::currentTestFailed()) return;
+
+    // ------------------------------------------------------------------
+    // 2.2 Set home and insert takeoff: exits create mode, mission group
+    //     auto-expands and Mission is the active layer
+    // ------------------------------------------------------------------
+    _clickMap(0.5, 0.5);
+    if (QTest::currentTestFailed()) return;
+    QVERIFY2(clickButton(QStringLiteral("planToolStrip_takeoffButton")), "Failed to click Takeoff button");
+    QTest::qWait(_pageDelay);
+
+    _verifyLayerState({
+        .editingLayer         = kLayerMission,
+        .switcherVisible      = true,
+        .missionEditorVisible = true,   // Takeoff item editor, mission group auto-expanded
+        .fenceEditorVisible   = false,
+        .rallyHeaderVisible   = false,
+        .fenceInteractive     = false,
+        .rallyInteractive     = false,
+    }, QStringLiteral("2.2 takeoff added"));
+    if (QTest::currentTestFailed()) return;
+
+    verifyEnabled(QLatin1String(kMissionHeader), true, QStringLiteral("2.2 takeoff added"));
+    verifyEnabled(QLatin1String(kFenceHeader),   true, QStringLiteral("2.2 takeoff added"));
+    verifyEnabled(QLatin1String(kRallyHeader),   true, QStringLiteral("2.2 takeoff added"));
+    if (QTest::currentTestFailed()) return;
+
+    // ------------------------------------------------------------------
+    // 2.3 Click GeoFence header: fence becomes the active layer, mission
+    //     group collapses (accordion)
+    // ------------------------------------------------------------------
+    QVERIFY2(_clickTreeRow(QLatin1String(kFenceHeader)), "Failed to click GeoFence header");
+
+    _verifyLayerState({
+        .editingLayer         = kLayerFence,
+        .switcherVisible      = true,
+        .missionEditorVisible = false,  // Accordion collapsed mission group
+        .fenceEditorVisible   = true,
+        .rallyHeaderVisible   = false,
+        .fenceInteractive     = true,
+        .rallyInteractive     = false,
+    }, QStringLiteral("2.3 fence layer"));
+    if (QTest::currentTestFailed()) return;
+
+    // ------------------------------------------------------------------
+    // 2.4 Click GeoFence header again: layer group headers do not collapse,
+    //     state unchanged
+    // ------------------------------------------------------------------
+    QVERIFY2(_clickTreeRow(QLatin1String(kFenceHeader)), "Failed to click GeoFence header (second)");
+
+    _verifyLayerState({
+        .editingLayer         = kLayerFence,
+        .switcherVisible      = true,
+        .missionEditorVisible = false,
+        .fenceEditorVisible   = true,   // Still expanded
+        .rallyHeaderVisible   = false,
+        .fenceInteractive     = true,
+        .rallyInteractive     = false,
+    }, QStringLiteral("2.4 fence header re-click"));
+    if (QTest::currentTestFailed()) return;
+
+    // ------------------------------------------------------------------
+    // 2.5 Click Rally header: rally becomes the active layer, fence group
+    //     collapses
+    // ------------------------------------------------------------------
+    QVERIFY2(_clickTreeRow(QLatin1String(kRallyHeader)), "Failed to click Rally header");
+
+    _verifyLayerState({
+        .editingLayer         = kLayerRally,
+        .switcherVisible      = true,
+        .missionEditorVisible = false,
+        .fenceEditorVisible   = false,  // Accordion collapsed fence group
+        .rallyHeaderVisible   = true,
+        .fenceInteractive     = false,
+        .rallyInteractive     = true,
+    }, QStringLiteral("2.5 rally layer"));
+    if (QTest::currentTestFailed()) return;
+
+    // ------------------------------------------------------------------
+    // 2.6 Layer switcher: expand choices and pick Mission
+    // ------------------------------------------------------------------
+    QVERIFY2(clickButton(QLatin1String(kSwitcherActive)), "Failed to click layer switcher active button");
+    QVERIFY2(findVisibleItem(_rootItem, QStringLiteral("layerSwitcher_choice_missionGroup"), 2000),
+             "Mission choice button did not appear");
+    QVERIFY2(clickButton(QStringLiteral("layerSwitcher_choice_missionGroup")), "Failed to click Mission choice button");
+
+    _verifyLayerState({
+        .editingLayer         = kLayerMission,
+        .switcherVisible      = true,
+        .missionEditorVisible = true,   // selectLayer expanded mission group
+        .fenceEditorVisible   = false,
+        .rallyHeaderVisible   = false,  // Accordion collapsed rally group
+        .fenceInteractive     = false,
+        .rallyInteractive     = false,
+    }, QStringLiteral("2.6 switcher to mission"));
+    if (QTest::currentTestFailed()) return;
+
+    // ------------------------------------------------------------------
+    // 2.7 Plan Info header: toggles expansion without affecting the layer
+    // ------------------------------------------------------------------
+    QVERIFY2(_clickTreeRow(QLatin1String(kPlanFileHeader)), "Failed to click Plan Info header");
+    QVERIFY2(waitForCondition([&] { return findVisibleItem(_rootItem, QStringLiteral("planTree_planFileInfo"), 0) != nullptr; },
+                              2000, QStringLiteral("plan info expanded")),
+             "2.7: Plan Info section did not expand");
+
+    _verifyLayerState({
+        .editingLayer         = kLayerMission,  // Unchanged
+        .switcherVisible      = true,
+        .missionEditorVisible = true,           // Unchanged: Plan Info is not a layer group
+        .fenceEditorVisible   = false,
+        .rallyHeaderVisible   = false,
+        .fenceInteractive     = false,
+        .rallyInteractive     = false,
+    }, QStringLiteral("2.7 plan info toggle"));
+    if (QTest::currentTestFailed()) return;
+
+    QVERIFY2(_clickTreeRow(QLatin1String(kPlanFileHeader)), "Failed to click Plan Info header (collapse)");
+    QVERIFY2(waitForCondition([&] { return findVisibleItem(_rootItem, QStringLiteral("planTree_planFileInfo"), 0) == nullptr; },
+                              2000, QStringLiteral("plan info collapsed")),
+             "2.7: Plan Info section did not collapse");
+
+    stopUI();
+}

--- a/test/QmlUITests/PlanViewLayerUITest.h
+++ b/test/QmlUITests/PlanViewLayerUITest.h
@@ -1,0 +1,43 @@
+#pragma once
+
+#include "QmlUITestBase.h"
+
+/// UI test for Plan view editing layer switching (offline, no vehicle).
+///
+/// Verifies the accordion behavior of the Mission/GeoFence/Rally tree groups,
+/// the layer switcher tool, create-from-template gating, and that the map
+/// visuals' interactive state follows the active editing layer.
+class PlanViewLayerUITest : public QmlUITestBase
+{
+    Q_OBJECT
+
+public:
+    PlanViewLayerUITest() = default;
+
+private slots:
+    void _testEditingLayerSwitching();
+
+private:
+    /// Complete expected state of the layer-related UI
+    struct LayerUIState {
+        int  editingLayer;          ///< expected PlanView._editingLayer (1=Mission 2=Fence 3=Rally)
+        bool switcherVisible;       ///< layer switcher tool visible (hidden in create-from-template mode)
+        bool missionEditorVisible;  ///< a mission item editor is visible (mission group expanded, plan non-empty)
+        bool fenceEditorVisible;    ///< the fence editor is visible (fence group expanded)
+        bool rallyHeaderVisible;    ///< the rally editor header is visible (rally group expanded)
+        bool fenceInteractive;      ///< GeoFenceMapVisuals.interactive
+        bool rallyInteractive;      ///< RallyPointMapVisuals.interactive
+    };
+
+    /// Verify the full layer UI state against expectations
+    void _verifyLayerState(const LayerUIState &state, const QString &context);
+
+    /// Current PlanView._editingLayer value, or -1 if unavailable
+    int _editingLayer();
+
+    /// Click the Plan view map at a fractional position within its viewport
+    void _clickMap(qreal fractionX, qreal fractionY);
+
+    /// Scroll a tree row into view and click it
+    bool _clickTreeRow(const QString &objectName);
+};

--- a/test/QmlUITests/PlanViewUITest.cc
+++ b/test/QmlUITests/PlanViewUITest.cc
@@ -16,11 +16,7 @@ UT_REGISTER_TEST(PlanViewUITest, TestLabel::Integration, TestLabel::MissionManag
 
 void PlanViewUITest::_clickMap(qreal fractionX, qreal fractionY)
 {
-    QQuickItem *map = findVisibleItem(_rootItem, QStringLiteral("planView_map"));
-    QVERIFY2(map, "planView_map not found");
-
-    const QPointF scenePos = map->mapToScene(QPointF(map->width() * fractionX, map->height() * fractionY));
-    QTest::mouseClick(_window, Qt::LeftButton, Qt::NoModifier, scenePos.toPoint());
+    QVERIFY2(clickItemFraction(QStringLiteral("planView_map"), fractionX, fractionY), "Failed to click planView_map");
 }
 
 int PlanViewUITest::_missionItemCount()

--- a/test/QmlUITests/QmlUITestBase.cc
+++ b/test/QmlUITests/QmlUITestBase.cc
@@ -237,6 +237,74 @@ bool QmlUITestBase::clickButton(const QString &objectName)
     return true;
 }
 
+bool QmlUITestBase::clickItemFraction(const QString &objectName, qreal fractionX, qreal fractionY)
+{
+    // Fail loudly on nonsense fractions rather than silently clicking outside
+    // the item (which would surface as an unrelated failure later in the test)
+    if (!qIsFinite(fractionX) || !qIsFinite(fractionY)
+        || (fractionX < 0) || (fractionX > 1) || (fractionY < 0) || (fractionY > 1)) {
+        QTest::qFail(qPrintable(QStringLiteral("clickItemFraction: fractions out of [0,1]: (%1, %2)")
+                                    .arg(fractionX).arg(fractionY)),
+                     __FILE__, __LINE__);
+        return false;
+    }
+    QQuickItem *item = findVisibleItem(_rootItem, objectName);
+    if (!item) {
+        return false;
+    }
+    const QPointF scenePos = item->mapToScene(QPointF(item->width() * fractionX, item->height() * fractionY));
+    QTest::mouseClick(_window, Qt::LeftButton, Qt::NoModifier, scenePos.toPoint());
+    return true;
+}
+
+QQuickItem *QmlUITestBase::findVisibleItemScrolled(const QString &objectName, const QString &flickableObjectName)
+{
+    // Fast path: delegate already instantiated somewhere in the visual tree
+    QQuickItem *item = findVisibleItem(_rootItem, objectName, 500);
+    if (item) {
+        scrollIntoView(item, flickableObjectName);
+        return item;
+    }
+
+    QQuickItem *flickable = findVisibleItem(_rootItem, flickableObjectName);
+    if (!flickable) {
+        return nullptr;
+    }
+
+    // Virtualized delegates only exist for rows near the viewport. Step the
+    // flickable through its content range to force the target row to instantiate.
+    const double viewportHeight = flickable->height();
+    if (viewportHeight <= 0) {
+        return nullptr; // not laid out yet: stepping cannot advance
+    }
+    // Iteration cap guards against content that grows as delegates instantiate
+    constexpr int kMaxScrollSteps = 100;
+    double y = 0;
+    for (int step = 0; step < kMaxScrollSteps; step++, y += viewportHeight) {
+        const double maxContentY =
+            qMax(0.0, flickable->property("contentHeight").toDouble() - viewportHeight);
+        const double clampedY = qMin(y, maxContentY);
+        flickable->setProperty("contentY", clampedY);
+        item = findVisibleItem(_rootItem, objectName, 100);
+        if (item) {
+            scrollIntoView(item, flickableObjectName);
+            return item;
+        }
+        if (clampedY >= maxContentY) {
+            break;
+        }
+    }
+    return nullptr;
+}
+
+bool QmlUITestBase::clickButtonScrolled(const QString &objectName, const QString &flickableObjectName)
+{
+    if (!findVisibleItemScrolled(objectName, flickableObjectName)) {
+        return false;
+    }
+    return clickButton(objectName);
+}
+
 bool QmlUITestBase::clickToolSelectDropdownButton(const QString &viewObjectName, int timeoutMs)
 {
     if (!clickButton(QStringLiteral("toolbar_qgcLogo"))) {
@@ -338,16 +406,22 @@ bool QmlUITestBase::_verifyItemProperty(const QString &objectName, const char *p
         return false;
     }
 
+    // Guard against the item being destroyed while waiting (e.g. view rebuilds)
+    const QPointer<QQuickItem> guardedItem(item);
+
     // State changes propagate through bindings; allow them to settle
     const bool matched = waitForCondition(
-        [item, propertyName, expectedValue] { return item->property(propertyName) == expectedValue; },
+        [guardedItem, propertyName, expectedValue] {
+            return guardedItem && (guardedItem->property(propertyName) == expectedValue);
+        },
         2000,
         QStringLiteral("%1 %2 == %3").arg(objectName, QLatin1String(propertyName), _displayValue(expectedValue)));
     if (!matched) {
         QTest::qFail(qPrintable(QStringLiteral("%1: %2 expected %3=%4 but was %5")
                                     .arg(context, objectName, QLatin1String(propertyName),
                                          _displayValue(expectedValue),
-                                         _displayValue(item->property(propertyName)))),
+                                         guardedItem ? _displayValue(guardedItem->property(propertyName))
+                                                     : QStringLiteral("<item destroyed>"))),
                      __FILE__, __LINE__);
         return false;
     }
@@ -357,6 +431,29 @@ bool QmlUITestBase::_verifyItemProperty(const QString &objectName, const char *p
 bool QmlUITestBase::verifyEnabled(const QString &objectName, bool expectedEnabled, const QString &context)
 {
     return _verifyItemProperty(objectName, "enabled", expectedEnabled, context);
+}
+
+bool QmlUITestBase::verifyProperty(const QString &objectName, const char *propertyName,
+                                   const QVariant &expectedValue, const QString &context)
+{
+    return _verifyItemProperty(objectName, propertyName, expectedValue, context);
+}
+
+bool QmlUITestBase::verifyVisibility(const QString &objectName, bool expectedVisible, const QString &context)
+{
+    const bool result = waitForCondition(
+        [this, objectName, expectedVisible] {
+            return (findVisibleItem(_rootItem, objectName, 0) != nullptr) == expectedVisible;
+        },
+        2000,
+        QStringLiteral("%1 %2").arg(objectName, expectedVisible ? QStringLiteral("visible") : QStringLiteral("absent")));
+    if (!result) {
+        QTest::qFail(qPrintable(QStringLiteral("%1: %2 expected %3")
+                                    .arg(context, objectName,
+                                         expectedVisible ? QStringLiteral("visible") : QStringLiteral("absent"))),
+                     __FILE__, __LINE__);
+    }
+    return result;
 }
 
 bool QmlUITestBase::verifyPrimary(const QString &objectName, bool expectedPrimary, const QString &context)

--- a/test/QmlUITests/QmlUITestBase.h
+++ b/test/QmlUITests/QmlUITestBase.h
@@ -78,6 +78,21 @@ protected:
     /// Returns false if the item cannot be found.
     bool clickButton(const QString &objectName);
 
+    /// Click the visible QQuickItem with \a objectName at a fractional position
+    /// within the item ((0.5, 0.5) is the center). Returns false if the item
+    /// cannot be found.
+    bool clickItemFraction(const QString &objectName, qreal fractionX, qreal fractionY);
+
+    /// Find an item that may live in a virtualized view (ListView/TableView/
+    /// TreeView) inside the flickable with \a flickableObjectName. Virtualized
+    /// delegates only exist near the viewport, so this steps the flickable
+    /// through its content range until the item instantiates, then scrolls it
+    /// into view. Returns nullptr if the item never appears.
+    QQuickItem *findVisibleItemScrolled(const QString &objectName, const QString &flickableObjectName);
+
+    /// Convenience: findVisibleItemScrolled() followed by clickButton().
+    bool clickButtonScrolled(const QString &objectName, const QString &flickableObjectName);
+
     /// Open the toolbar Q-logo tool-select dropdown and click the entry with
     /// objectName \a viewObjectName (e.g. "toolbar_viewPlan", "toolbar_viewClose").
     /// Clicks the Q logo, waits up to \a timeoutMs for the entry to appear, then
@@ -117,6 +132,17 @@ protected:
 
     /// Same semantics as verifyEnabled().
     bool verifyText(const QString &objectName, const QString &expectedText, const QString &context);
+
+    /// Verify an arbitrary property of a visible item found by \a objectName,
+    /// waiting up to 2 seconds for bindings to settle. Fails the test if the
+    /// item is missing, the property does not exist, or the value never matches.
+    bool verifyProperty(const QString &objectName, const char *propertyName,
+                        const QVariant &expectedValue, const QString &context);
+
+    /// Verify that an item found by \a objectName is present-and-visible
+    /// (\a expectedVisible true) or absent/hidden (false), waiting up to
+    /// 2 seconds. Fails the test on mismatch.
+    bool verifyVisibility(const QString &objectName, bool expectedVisible, const QString &context);
 
     /// Scroll the QQuickFlickable identified by \a flickableObjectName so that
     /// \a item's centre is fully visible inside the flickable. Does nothing if
@@ -167,6 +193,7 @@ private:
     /// guard against the property not existing (an invalid QVariant silently
     /// converts to false/"" which would make false/empty expectations pass
     /// vacuously), then wait up to 2 seconds for the property to match.
+    /// Exposed publicly as verifyProperty().
     bool _verifyItemProperty(const QString &objectName, const char *propertyName,
                              const QVariant &expectedValue, const QString &context);
 };


### PR DESCRIPTION
Replaces #14544.

## Description

#14544 correctly identified a real bug: GeoFence (and Rally Point) map visuals only become editable when their editing layer is active, but interacting with the fence/rally editors in the plan panel never activated that layer. You could add a polygon fence from the panel and be unable to edit it on the map.

This PR fixes the same underlying bug with a simpler, less error-prone approach than #14544, and goes further:

### Why replace #14544

#14544 fixed the problem by adding `requestEditingLayer` signals to individual editors and wiring them through the TreeView delegate `onLoaded` with dynamic `.connect()` calls. That approach:

- Requires an emit at every user interaction point inside every editor (add buttons, edit radios, delete buttons, ...) — easy to miss one now, easier to miss one in future editors
- Risks duplicate signal connections when delegates reload (flagged by review on that PR)

### What this PR does instead

**Accordion layer groups.** The Mission Items / GeoFence / Rally Points tree groups are now exclusive: expanding one collapses the others and makes it the active editing layer. The mental model is simply "the section you have open is the layer you're editing" — the panel and the map can no longer disagree, which eliminates the bug class rather than patching individual instances of it. Layer group headers cannot be collapsed by clicking; the active layer always has its group expanded.

### Beyond the #14544 fix

- **Single source of truth for layer definitions.** New `PlanEditLayers` QML singleton holds the layer IDs, nodeTypes, icons, and display names that were previously duplicated across `PlanView.qml` and `PlanTreeView.qml`
- **Layer switcher improvements.** Expanded choice buttons now show a text label next to the icon (icons alone were unclear); the switcher is hidden during create-from-template mode
- **Tree header icons.** Mission/GeoFence/Rally group headers show the same icons as the layer switcher
- **Create-from-template mode.** Non-applicable tree groups are now shown disabled/dimmed instead of hidden, so sections no longer pop into existence when the first item is added
- **Centralized `allowViewSwitch()` gating.** Layer switching via the tool buttons previously bypassed the validation/navigation-block guard that header clicks enforced; both paths now go through one guarded `selectLayer()`
- **i18n fix.** Group header subtitles use `qsTr("%1 items").arg(n)` instead of string concatenation
- **Waypoint auto-expand honors the accordion.** Adding a waypoint routes through `selectLayer()` so the invariant holds

### Test coverage

New `PlanViewLayerUITest` (offline, full-UI) covers: create-mode gating (switcher hidden, layer groups disabled), accordion switching via headers and via the layer switcher, no-collapse-on-header-reclick, map visual `interactive` state following the layer, and Plan Info toggling independently. Regression validity verified by reverting the accordion collapse and confirming the test fails.

Also adds reusable helpers to `QmlUITestBase`: `verifyProperty`, `verifyVisibility`, `clickItemFraction` (with input validation), and `findVisibleItemScrolled`/`clickButtonScrolled` for items in virtualized views (bounded stepping with zero-height and iteration guards).

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [x] Refactoring (no functional changes) — layer descriptor consolidation

## Testing

- [x] Tested locally
- [x] Added/updated unit tests

### Platforms Tested

- [x] macOS

By submitting this pull request, I confirm that my contribution is made under the terms of the project's dual license (Apache 2.0 and GPL v3).
