### PR TITLE
fix(Camera): request CAMERA_SETTINGS after accepted zoom/focus commands

### DIFF
--- a/src/Camera/VehicleCameraControl.cc
+++ b/src/Camera/VehicleCameraControl.cc
@@ -142,6 +142,18 @@ VehicleCameraControl::VehicleCameraControl(const mavlink_camera_information_t *i
     _videoRecordTimeUpdateTimer.setInterval(333);
     connect(&_videoRecordTimeUpdateTimer, &QTimer::timeout, this, &VehicleCameraControl::_recTimerHandler);
 
+    // Cameras are not required to broadcast CAMERA_SETTINGS when zoom/focus changes,
+    // so re-request it after an accepted zoom/focus command to keep zoom level and
+    // FOV current. The delay also coalesces bursts of zoom/focus commands into a
+    // single request.
+    constexpr int kCameraSettingsRefreshDelayMsecs = 1000;
+    _cameraSettingsRefreshTimer.setSingleShot(true);
+    _cameraSettingsRefreshTimer.setInterval(kCameraSettingsRefreshDelayMsecs);
+    connect(&_cameraSettingsRefreshTimer, &QTimer::timeout, this, [this]() {
+        _cameraSettingsRetries = 0; // Start a fresh request/retry cycle
+        _requestCameraSettings();
+    });
+
     //-- Tracking capabilities
     _hasTrackingRectCapability = _mavlinkCameraInfo.flags & CAMERA_CAP_FLAGS_HAS_TRACKING_RECTANGLE;
     _hasTrackingPointCapability = _mavlinkCameraInfo.flags & CAMERA_CAP_FLAGS_HAS_TRACKING_POINT;
@@ -173,6 +185,7 @@ VehicleCameraControl::~VehicleCameraControl()
     _streamInfoTimer.stop();
     _streamStatusTimer.stop();
     _cameraSettingsTimer.stop();
+    _cameraSettingsRefreshTimer.stop();
     _storageInfoTimer.stop();
 
     delete _netManager;
@@ -782,6 +795,10 @@ void VehicleCameraControl::_mavCommandResult(int vehicleId, int component, int c
                 break;
             case MAV_CMD_IMAGE_START_CAPTURE:
                 _captureStatusTimer.start(1000);
+                break;
+            case MAV_CMD_SET_CAMERA_ZOOM:
+            case MAV_CMD_SET_CAMERA_FOCUS:
+                _cameraSettingsRefreshTimer.start();
                 break;
         }
     } else {

--- a/src/Camera/VehicleCameraControl.h
+++ b/src/Camera/VehicleCameraControl.h
@@ -298,6 +298,7 @@ protected:
     QTimer                              _streamInfoTimer;
     QTimer                              _streamStatusTimer;
     QTimer                              _cameraSettingsTimer;
+    QTimer                              _cameraSettingsRefreshTimer;
     QTimer                              _storageInfoTimer;
     QmlObjectListModel                  _streams;
     QStringList                         _streamLabels;

--- a/src/Comms/MockLink/MockLinkCamera.cc
+++ b/src/Comms/MockLink/MockLinkCamera.cc
@@ -350,10 +350,15 @@ bool MockLinkCamera::_handleCameraCommand(const mavlink_command_long_t &request,
 
     case MAV_CMD_SET_CAMERA_ZOOM:
         if (cam->capFlags & CAMERA_CAP_FLAGS_HAS_BASIC_ZOOM) {
-             cam->zoomLevel = request.param2;
-             qCDebug(MockLinkCameraLog) << "Camera" << targetCompId << "zoom set to" << cam->zoomLevel;
+             // param2 is an absolute level only for ZOOM_TYPE_RANGE. For step/continuous
+             // zoom it is a direction, which this simple simulation does not model.
+             if (static_cast<int>(request.param1) == ZOOM_TYPE_RANGE) {
+                 cam->zoomLevel = request.param2;
+                 qCDebug(MockLinkCameraLog) << "Camera" << targetCompId << "zoom set to" << cam->zoomLevel;
+             }
+             // Spec-minimal: CAMERA_SETTINGS is not broadcast after a zoom change.
+             // The GCS must re-request it (MAVLink camera protocol v2).
              _sendCommandAck(targetCompId, request.command, MAV_RESULT_ACCEPTED);
-             _sendCameraSettings(targetCompId);
         } else {
             _sendCommandAck(targetCompId, request.command, MAV_RESULT_DENIED);
         }
@@ -508,10 +513,12 @@ bool MockLinkCamera::_handleRequestMessage(const mavlink_command_long_t &request
     }
 
     default:
-        break;
+        // All commands addressed to a component must be acked, even unsupported ones.
+        // Without this the requester's command queue keeps the request pending, blocking
+        // further REQUEST_MESSAGE commands to this component.
+        _sendCommandAck(targetCompId, MAV_CMD_REQUEST_MESSAGE, MAV_RESULT_DENIED, msgId);
+        return true;
     }
-
-    return false;
 }
 
 void MockLinkCamera::_sendCameraInformation(uint8_t compId)

--- a/test/Camera/VehicleCameraControlTest.cc
+++ b/test/Camera/VehicleCameraControlTest.cc
@@ -181,4 +181,84 @@ void VehicleCameraControlTest::_testCameraCapFlags()
     QCOMPARE(camera->hasFocus(), false);
 }
 
+void VehicleCameraControlTest::_testZoomTriggersCameraSettingsRequest()
+{
+    // A spec-minimal camera does not broadcast CAMERA_SETTINGS after a zoom change,
+    // so QGC must re-request it itself once a zoom command is accepted. Otherwise
+    // the zoom level (and FOV) shown by QGC goes stale after the first zoom.
+
+    auto* mockConfig = new MockConfiguration(QStringLiteral("CameraZoomSettingsTest"));
+    mockConfig->setFirmwareType(MAV_AUTOPILOT_PX4);
+    mockConfig->setVehicleType(MAV_TYPE_QUADROTOR);
+    mockConfig->setDynamic(true);
+    mockConfig->setEnableCamera(true);
+    mockConfig->setCameraCaptureImage(true);
+    mockConfig->setCameraHasBasicZoom(true);
+
+    QSignalSpy spyVehicle(MultiVehicleManager::instance(), &MultiVehicleManager::activeVehicleChanged);
+    QVERIFY(spyVehicle.isValid());
+
+    SharedLinkConfigurationPtr linkConfig = LinkManager::instance()->addConfiguration(mockConfig);
+    QVERIFY(LinkManager::instance()->createConnectedLink(linkConfig));
+
+    QVERIFY2(UnitTest::waitForSignal(spyVehicle, TestTimeout::longMs(), QStringLiteral("activeVehicleChanged")),
+             "Timeout waiting for vehicle connection");
+
+    _vehicle = MultiVehicleManager::instance()->activeVehicle();
+    QVERIFY(_vehicle);
+
+    _mockLink = qobject_cast<MockLink*>(linkConfig->link());
+    QVERIFY(_mockLink);
+
+    if (!_vehicle->isInitialConnectComplete()) {
+        QSignalSpy spyConnect(_vehicle, &Vehicle::initialConnectComplete);
+        QVERIFY(spyConnect.isValid());
+        QVERIFY2(UnitTest::waitForSignal(spyConnect, TestTimeout::longMs(), QStringLiteral("initialConnectComplete")),
+                 "Timeout waiting for initial connect");
+    }
+
+    QGCCameraManager* cameraManager = _vehicle->cameraManager();
+    QVERIFY(cameraManager);
+    QVERIFY_TRUE_WAIT(cameraManager->cameras()->count() >= 2, TestTimeout::longMs());
+
+    MavlinkCameraControlInterface* camera = nullptr;
+    for (int i = 0; i < cameraManager->cameras()->count(); i++) {
+        auto* cam = qobject_cast<MavlinkCameraControlInterface*>(cameraManager->cameras()->get(i));
+        if (cam && cam->compID() == MAV_COMP_ID_CAMERA) {
+            camera = cam;
+            break;
+        }
+    }
+    QVERIFY2(camera, "Camera 1 (MAV_COMP_ID_CAMERA) not found in camera list");
+    QVERIFY(camera->hasZoom());
+
+    // Wait for the initial CAMERA_SETTINGS exchange to settle: the mock reports zoom
+    // level 1.0, so once QGC shows it the initial request/retry cycle is complete.
+    QVERIFY_TRUE_WAIT(qFuzzyCompare(camera->zoomLevel(), 1.0), TestTimeout::longMs());
+
+    // QGC alternates between REQUEST_MESSAGE and the deprecated REQUEST_CAMERA_SETTINGS
+    // on retries (dual-transport migration), so accept either as a settings request.
+    auto settingsRequestCount = [this]() {
+        return _mockLink->receivedRequestMessageCount(MAV_COMP_ID_CAMERA, MAVLINK_MSG_ID_CAMERA_SETTINGS)
+             + _mockLink->receivedMavCommandCount(MAV_CMD_REQUEST_CAMERA_SETTINGS, MAV_COMP_ID_CAMERA);
+    };
+
+    // An accepted zoom command must cause QGC to re-request CAMERA_SETTINGS on its own
+    const int baselineAfterConnect = settingsRequestCount();
+    camera->setZoomLevel(50.0);
+    QTRY_VERIFY2_WITH_TIMEOUT(settingsRequestCount() > baselineAfterConnect,
+                              "QGC did not re-request CAMERA_SETTINGS after setZoomLevel was accepted",
+                              TestTimeout::longMs());
+    // And the fresh settings update QGC's stale zoom level
+    QVERIFY_TRUE_WAIT(qFuzzyCompare(camera->zoomLevel(), 50.0), TestTimeout::longMs());
+
+    // Continuous zoom (start/stop) must trigger a refresh as well
+    const int baselineAfterSetZoom = settingsRequestCount();
+    camera->startZoom(1);
+    camera->stopZoom();
+    QTRY_VERIFY2_WITH_TIMEOUT(settingsRequestCount() > baselineAfterSetZoom,
+                              "QGC did not re-request CAMERA_SETTINGS after startZoom/stopZoom were accepted",
+                              TestTimeout::longMs());
+}
+
 UT_REGISTER_TEST(VehicleCameraControlTest, TestLabel::Integration, TestLabel::Vehicle)

--- a/test/Camera/VehicleCameraControlTest.h
+++ b/test/Camera/VehicleCameraControlTest.h
@@ -15,6 +15,7 @@ private slots:
     void cleanup() override;
 
     UT_PARAMETERIZED_TEST(_testCameraCapFlags);
+    void _testZoomTriggersCameraSettingsRequest();
 
 private:
     MockLink* _mockLink = nullptr;


### PR DESCRIPTION
## Description

Superset/replacement for #14519 (with @jnomikos's agreement — thanks for the original fix and diagnosis!). Addresses all items from the review discussion on that PR.

The changes from #13612 never actually re-request `CAMERA_SETTINGS` after zoom/focus changes. The MAVLink camera protocol v2 does not require cameras to broadcast `CAMERA_SETTINGS` on change (it is a request/response message), so with a camera that doesn't volunteer it, QGC's zoom level and FOV go stale after the first zoom.

### What this does differently from #14519

Instead of six scattered debounce-timer starts in each zoom/focus method, the refresh is driven from a single point: `_mavCommandResult()` on `MAV_RESULT_ACCEPTED` for `MAV_CMD_SET_CAMERA_ZOOM` / `MAV_CMD_SET_CAMERA_FOCUS` starts a single-shot debounce timer which resets the retry counter and starts a fresh `CAMERA_SETTINGS` request cycle. This resolves the review items structurally:

- **Timer naming** — the existing `_cameraSettingsTimer` keeps its retry meaning; the new debounce timer gets the new name (`_cameraSettingsRefreshTimer`)
- **Retry counter reset** — a fresh cycle resets `_cameraSettingsRetries`, so an exhausted connect-time cycle can't starve zoom-triggered refreshes, and the fresh request leads with `REQUEST_MESSAGE` rather than the deprecated legacy command
- **`startZoom()`/`startFocus()` coverage** — ack-driven, so every zoom/focus entry point (current and future) is covered automatically
- **No refresh on NAK** — settings are only re-requested when the camera actually accepted the command
- **Timer configured single-shot in the constructor** — no ordering hazard with `_initWhenReady()`
- **No repeated magic numbers** — one delay constant at the single use site

### MockLink changes (why the bug never failed unit tests)

`MockLinkCamera` modeled a "friendlier than spec" camera that proactively broadcast `CAMERA_SETTINGS` after a zoom command, masking this class of bug. It is now spec-minimal for zoom (ack only). It also now acks unsupported `REQUEST_MESSAGE` commands with `MAV_RESULT_DENIED` as the spec requires — without that, GimbalController's `REQUEST_MESSAGE(GIMBAL_MANAGER_INFORMATION)` probe to the camera component goes unacked and the pending entry in `MavCommandQueue` blocks all further `REQUEST_MESSAGE` commands to that component (duplicate detection is param-blind).

### Test

New `VehicleCameraControlTest::_testZoomTriggersCameraSettingsRequest` asserts (baseline-delta on MockLink's received-request counters, accepting either `REQUEST_MESSAGE` or the legacy fallback transport):

1. An accepted `setZoomLevel()` causes QGC to re-request `CAMERA_SETTINGS` on its own
2. The fresh settings update QGC's stale zoom level end-to-end
3. `startZoom()`/`stopZoom()` trigger a refresh as well

Test was written first and verified to fail without the production fix (TDD).

## Type of Change
- [x] Bug fix (non-breaking change that fixes an issue)

## Testing
- [x] Tested locally
- [x] Added/updated unit tests
- [x] New and existing unit tests pass locally (full Unit+Integration suite)

### Platforms Tested
- [x] macOS

## Checklist
- [x] I have read the [Contribution Guidelines](CONTRIBUTING.md)
- [x] I have read the [Code of Conduct](CODE_OF_CONDUCT.md)
- [x] My code follows the project's coding standards
- [x] I have added tests that prove my fix/feature works
- [x] New and existing unit tests pass locally

## Related Issues
Replaces #14519

---
By submitting this pull request, I confirm that my contribution is made under the terms of the project's dual license (Apache 2.0 and GPL v3).
