### PR TITLE
fix(linux): Remove unnecessary system GLib preload from AppRun

### DIFF
--- a/deploy/linux/AppRun
+++ b/deploy/linux/AppRun
@@ -20,8 +20,6 @@ unset GIO_EXTRA_MODULES
 unset GIO_MODULE_DIR
 unset GIO_USE_VFS
 
-# Preload system GLib 2.76+ for TTS compatibility.
-# Set QGC_NO_SYSTEM_GLIB=1 to disable.
 _resolve_system_lib() {
     # Try hardcoded paths first (fast), then ldconfig fallback (NixOS, Guix, etc.)
     local _lib="$1"
@@ -45,39 +43,14 @@ _resolve_system_lib() {
     return 1
 }
 
-if [ -z "$QGC_NO_SYSTEM_GLIB" ]; then
-    SYSTEM_GLIB=""
-    SYSTEM_GIO=""
-    SYSTEM_LIBDIR=""
-    SYSTEM_GLIB=$(_resolve_system_lib "libglib-2.0.so.0") || true
-    if [ -n "$SYSTEM_GLIB" ]; then
-        SYSTEM_LIBDIR="$(dirname "$SYSTEM_GLIB")"
-        SYSTEM_GIO="${SYSTEM_LIBDIR}/libgio-2.0.so.0"
-        if [ ! -f "$SYSTEM_GIO" ]; then
-            SYSTEM_GIO=$(_resolve_system_lib "libgio-2.0.so.0") || true
-        fi
-    fi
-
-    if [ -n "$SYSTEM_GLIB" ]; then
-        if nm -D "$SYSTEM_GLIB" 2>/dev/null | grep -qm1 g_string_free_and_steal; then
-            GLIB_PRELOAD="${SYSTEM_GLIB}"
-            if [ -f "$SYSTEM_GIO" ]; then
-                GLIB_PRELOAD="${GLIB_PRELOAD}:${SYSTEM_GIO}"
-                SYSTEM_LIBMOUNT="${SYSTEM_LIBDIR}/libmount.so.1"
-                if [ -f "$SYSTEM_LIBMOUNT" ]; then
-                    GLIB_PRELOAD="${GLIB_PRELOAD}:${SYSTEM_LIBMOUNT}"
-                fi
-            fi
-            export LD_PRELOAD="${GLIB_PRELOAD}${LD_PRELOAD:+:$LD_PRELOAD}"
-        fi
-    fi
-
-    if [ -n "$SYSTEM_GIO" ] && nm -D "$SYSTEM_GIO" 2>/dev/null | grep -qm1 g_task_set_static_name; then
-        export GIO_MODULE_DIR="${APPDIR}/usr/lib/gio/modules"
-        export GIO_USE_VFS="local"
-    else
-        export GIO_EXTRA_MODULES="${APPDIR}/usr/lib/gio/modules"
-    fi
+# If the system GIO is newer than bundled, use bundled GIO modules.
+# If the system GIO is older than bundled, use both bundled AND system GIO modules.
+# WARNING: Bundled GIO is now 2.80 so this particular symbol checking logic is outdated.
+# Seemingly harmless.
+SYSTEM_GIO=$(_resolve_system_lib "libgio-2.0.so.0") || true
+if [ -n "$SYSTEM_GIO" ] && nm -D "$SYSTEM_GIO" 2>/dev/null | grep -qm1 g_task_set_static_name; then
+    export GIO_MODULE_DIR="${APPDIR}/usr/lib/gio/modules"
+    export GIO_USE_VFS="local"
 else
     export GIO_EXTRA_MODULES="${APPDIR}/usr/lib/gio/modules"
 fi


### PR DESCRIPTION
## Description
Refer to Issue  #14615 for the segfault bug I was experiencing.

The LD_PRELOAD of system libglib-2.0.so.0 was added in #13757 to fix TTS (libspeechd) failing because the bundled GLib lacked the g_string_free_and_steal symbol (added in GLib 2.76).

The CI build environment is now ubuntu-24.04, which ships GLib 2.80. linuxdeploy bundles that GLib into the AppImage, so the TTS issue is no longer applicable.

On systems with a newer system GLib (e.g. Arch Linux), the preload causes a version mismatch between the system GLib and the bundled GObject/GStreamer, resulting in a segfault on pipeline startup.

I also noticed that a similar symbol check exists in AppRun for the GIO module compatibility checking. This is also outdated as it checks against a symbol added in GIO 2.76, meanwhile the Appimage provides GIO 2.80. For now I kept the existing GIO logic to avoid breaking anything else. However I have added a WARNING comment there. 

For now I would suggest merging this change to fix daily build compatibility fast, then coming back and fixing any other stale logic in a separate PR.

## Type of Change
<!-- Put an 'x' in the relevant boxes -->
- [x ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] CI/Build changes
- [ ] Other

## Testing
<!-- Describe the tests you ran and how to reproduce them -->
- [ x] Tested locally
- [ ] Added/updated unit tests
- [ ] Tested with simulator (SITL)
- [ ] Tested with hardware

### Platforms Tested
<!-- Check all that apply -->
- [x ] Linux
- [ ] Windows
- [ ] macOS
- [ ] Android
- [ ] iOS

## Checklist
<!-- Go over all the following points, and put an 'x' in all the boxes that apply -->
- [ x] I have read the [Contribution Guidelines](CONTRIBUTING.md)
- [ x] I have read the [Code of Conduct](CODE_OF_CONDUCT.md)
- [ x] My code follows the project's coding standards
- [ ] I have added tests that prove my fix/feature works
- [ ] New and existing unit tests pass locally

## Related Issues
<!-- Link any related issues using #issue_number -->
 #14615

---
By submitting this pull request, I confirm that my contribution is made under the terms of the project's dual license (Apache 2.0 and GPL v3).
