### PR TITLE
fix(facts): use vertical m for distance-sensor up/down ranges

### DIFF
--- a/src/Vehicle/FactGroups/DistanceSensorFact.json
+++ b/src/Vehicle/FactGroups/DistanceSensorFact.json
@@ -73,7 +73,7 @@
     "type":             "double",
     "default":          null,
     "decimalPlaces":    2,
-    "units":            "m"
+    "units":            "vertical m"
 },
 {
     "name":             "rotationPitch270",
@@ -81,7 +81,7 @@
     "type":             "double",
     "default":          null,
     "decimalPlaces":    2,
-    "units":            "m"
+    "units":            "vertical m"
 },
 {
     "name":             "minDistance",


### PR DESCRIPTION
## Summary
- Tag DistanceSensorFact `rotationPitch90` (Up) and `rotationPitch270` (Down) units as `vertical m`.

## Motivation
Plain `m` is treated as horizontal distance by FactMetaData. Up/down rangefinder ranges are vertical lengths; they should honor the Vertical Distance units setting. Lateral yaw ranges and min/max stay `m`.

## Verification
- [x] JSON parses
- [x] Only pitch-up/down unit fields changed
- [x] No flight/arm/geofence code paths touched

## Notes
AI-assisted; human-reviewed. Spec: `specs/qgroundcontrol/2026-07-17-1.md` (Composer 2.5 Standard intent).