### PR TITLE
docs(facts): fix ImageDensity shortDesc spelling (desity → density)

### DIFF
--- a/src/MissionManager/CameraCalc.FactMetaData.json
+++ b/src/MissionManager/CameraCalc.FactMetaData.json
@@ -26,7 +26,7 @@
 },
 {
     "name":             "ImageDensity",
-    "shortDesc":        "Image desity at surface.",
+    "shortDesc":        "Image density at surface.",
     "type":             "double",
     "min":              0,
     "units":            "cm/px",


### PR DESCRIPTION
## Summary
- Correct CameraCalc `ImageDensity` shortDesc typo: "desity" → "density".

## Motivation
User-visible survey/camera metadata string.

## Verification
- [x] Single-line string change in CameraCalc.FactMetaData.json

## Notes
Human-reviewed micro-docs fix.