### PR TITLE
fix(facts): normalize local-position velocity shortDescs to Vx/Vy/Vz

### DIFF
--- a/src/Vehicle/FactGroups/LocalPositionFact.json
+++ b/src/Vehicle/FactGroups/LocalPositionFact.json
@@ -26,7 +26,7 @@
 },
 {
     "name":             "vx",
-    "shortDesc": "VX",
+    "shortDesc": "Vx",
     "type":             "double",
     "decimalPlaces":    1,
     "units":            "m/s"


### PR DESCRIPTION
## Summary
- Align LocalPositionFact velocity labels to `Vx` / `Vy` / `Vz` (was mixed `VX` / `Vy` / `Vz`).

## Motivation
Inconsistent casing surfaces directly in fact short descriptions and any UI that binds them.

## Verification
- [x] Only shortDesc strings for vx/vy adjusted; units unchanged

## Notes
AI-assisted; human-reviewed.