### PR TITLE
fix(facts): use vertical m for submarine rangefinder distance facts

### DIFF
--- a/src/Vehicle/FactGroups/SubmarineFact.json
+++ b/src/Vehicle/FactGroups/SubmarineFact.json
@@ -44,13 +44,13 @@
     "shortDesc": "Rangefinder",
     "type":             "float",
     "decimalPlaces":    2,
-    "units":            "m"
+    "units":            "vertical m"
 },
 {    "name":            "rangefinderTarget",
     "shortDesc": "RFTarget",
     "type":             "float",
     "decimalPlaces":    2,
-    "units":            "m"
+    "units":            "vertical m"
 },
 {   "name":             "rollPitchToggle",
     "shortDesc": "Roll/Pitch Toggle",


### PR DESCRIPTION
## Summary
- Set SubmarineFact `rangefinderDistance` and `rangefinderTarget` units to `vertical m`.

## Motivation
ROV rangefinder range/target are vertical-axis lengths. Plain `m` skips Vertical Distance unit conversion.

## Verification
- [x] JSON OK; two unit fields only
- [x] No vehicle control changes

## Notes
AI-assisted; human-reviewed. Complements prior vertical-m fact work (DonLakeFlyer coalesce credited earlier merges).