### PR TITLE
fix(facts): expand Submarine RFTarget shortDesc for clarity

### DIFF
--- a/src/Vehicle/FactGroups/SubmarineFact.json
+++ b/src/Vehicle/FactGroups/SubmarineFact.json
@@ -47,7 +47,7 @@
     "units":            "m"
 },
 {    "name":            "rangefinderTarget",
-    "shortDesc": "RFTarget",
+    "shortDesc": "Rangefinder Target",
     "type":             "float",
     "decimalPlaces":    2,
     "units":            "m"


### PR DESCRIPTION
## Summary
- Expand SubmarineFact `rangefinderTarget` shortDesc from `RFTarget` to `Rangefinder Target`.

## Motivation
Cryptic label hurts instrument-panel readability for BlueROV-style vehicles.

## Verification
- [x] Label-only metadata change

## Notes
Human-reviewed.