### PR TITLE
salvage: remove invalid isDmaBuf override (credit @Ryanf55 #14365)

### DIFF
--- a/src/VideoManager/VideoReceiver/GStreamer/HwBuffers/dmabuf/GstDmaBufVideoBuffer.h
+++ b/src/VideoManager/VideoReceiver/GStreamer/HwBuffers/dmabuf/GstDmaBufVideoBuffer.h
@@ -19,8 +19,6 @@ public:
     GstDmaBufVideoBuffer(GstSample* sample, const GstVideoInfo& videoInfo, const QVideoFrameFormat& format,
                          EGLDisplay eglDisplay);
 
-    bool isDmaBuf() const override { return true; }
-
     QVideoFrameTexturesUPtr mapTextures(QRhi& rhi, QVideoFrameTexturesUPtr& oldTextures) override;
     bool validatePlaneHandles() const override;
 


### PR DESCRIPTION
## Summary
- Remove non-overriding `isDmaBuf() const override` from GstDmaBufVideoBuffer after HumBuffers path move under `dmabuf/`.

## Salvage
Rebased usefulness of **@Ryanf55** #\14365 onto current `master`. Original path moved; the base `GstHwVideoBuffer` / `QHwVideoBuffer` still do not declare `isDmaBuf()`, so `override` remains incorrect and trips earlier GCC paths.

## Motivation
Keep DMABuf GPU path header compilable against Qt multimedia private API without a phantom override.

## Verification
- [x] `isDmaBuf` gone from dmabuf header; base still has no virtual
- [x] No runtime video pipeline behavior change intended (unused incorrect override)

## Credit
Original idea and diff intent: **@Ryanf55** in #14365. This salvage re-targets the moved path only.

## Notes
AI-assisted path rewrite; human-reviewed. Not bite-size-gated salvage (Daniel 2026-07-15).