### PR TITLE
fix(Vehicle): fix log replay crashes from use-after-free and queue re-entrancy

### DIFF
--- a/src/Camera/QGCCameraManager.cc
+++ b/src/Camera/QGCCameraManager.cc
@@ -110,10 +110,22 @@ QGCCameraManager::~QGCCameraManager()
     qDeleteAll(_cameraInfoRequest);
     _cameraInfoRequest.clear();
 
+    qDeleteAll(_cameraInfoContexts);
+    _cameraInfoContexts.clear();
+
     // Stop the main heartbeat timer
     _camerasLostHeartbeatTimer.stop();
 
     qCDebug(CameraManagerLog) << this;
+}
+
+QGCCameraManager::CameraInfoRequestContext* QGCCameraManager::cameraInfoContext(uint8_t compId)
+{
+    CameraInfoRequestContext*& context = _cameraInfoContexts[compId];
+    if (!context) {
+        context = new CameraInfoRequestContext{this, compId};
+    }
+    return context;
 }
 
 void QGCCameraManager::setCurrentCamera(int sel)
@@ -505,9 +517,28 @@ void QGCCameraManager::_handleTrackingImageStatus(const mavlink_message_t &messa
 
 static void _handleCameraInfoRetry(QGCCameraManager::CameraStruct *cameraInfo);
 
+/// Resolves the opaque callback context back to the live CameraStruct. Returns nullptr
+/// if the manager is gone or the camera was removed while the request was in flight.
+static QGCCameraManager::CameraStruct* _cameraStructFromContext(void *resultHandlerData)
+{
+    auto *context = static_cast<QGCCameraManager::CameraInfoRequestContext*>(resultHandlerData);
+    if (!context->manager) {
+        return nullptr;
+    }
+
+    QGCCameraManager::CameraStruct *cameraInfo = context->manager->findCameraStruct(context->compID);
+    if (!cameraInfo) {
+        qCDebug(CameraManagerLog) << "Camera info request callback for removed camera. compId" << QGCMAVLink::compIdToString(context->compID);
+    }
+    return cameraInfo;
+}
+
 static void _requestCameraInfoCommandResultHandler(void *resultHandlerData, int /*compId*/, const mavlink_command_ack_t &ack, Vehicle::MavCmdResultFailureCode_t failureCode)
 {
-    auto *cameraInfo = static_cast<QGCCameraManager::CameraStruct*>(resultHandlerData);
+    QGCCameraManager::CameraStruct *cameraInfo = _cameraStructFromContext(resultHandlerData);
+    if (!cameraInfo) {
+        return;
+    }
 
     if (ack.result != MAV_RESULT_ACCEPTED) {
         qCDebug(CameraManagerLog) << "MAV_CMD_REQUEST_CAMERA_INFORMATION failed. compId" << QGCMAVLink::compIdToString(cameraInfo->compID)
@@ -520,7 +551,10 @@ static void _requestCameraInfoCommandResultHandler(void *resultHandlerData, int 
 
 static void _requestCameraInfoMessageResultHandler(void *resultHandlerData, MAV_RESULT result, Vehicle::RequestMessageResultHandlerFailureCode_t failureCode, [[maybe_unused]] const mavlink_message_t &message)
 {
-    auto *cameraInfo = static_cast<QGCCameraManager::CameraStruct*>(resultHandlerData);
+    QGCCameraManager::CameraStruct *cameraInfo = _cameraStructFromContext(resultHandlerData);
+    if (!cameraInfo) {
+        return;
+    }
 
     if (result != MAV_RESULT_ACCEPTED) {
         qCDebug(CameraManagerLog) << "MAV_CMD_REQUEST_MESSAGE:MAVLINK_MSG_ID_CAMERA_INFORMATION failed. compId" << QGCMAVLink::compIdToString(cameraInfo->compID)
@@ -542,13 +576,13 @@ static void _requestCameraInfoHelper(QGCCameraManager *manager, QGCCameraManager
     // Alternate between REQUEST_MESSAGE and REQUEST_CAMERA_INFORMATION
     if ((pInfo->retryCount % 2) == 0) {
         qCDebug(CameraManagerLog) << "Using MAV_CMD_REQUEST_MESSAGE:CAMERA_INFORMATION for compId" << QGCMAVLink::compIdToString(pInfo->compID);
-        manager->vehicle()->requestMessage(_requestCameraInfoMessageResultHandler, pInfo, pInfo->compID, MAVLINK_MSG_ID_CAMERA_INFORMATION);
+        manager->vehicle()->requestMessage(_requestCameraInfoMessageResultHandler, manager->cameraInfoContext(pInfo->compID), pInfo->compID, MAVLINK_MSG_ID_CAMERA_INFORMATION);
     } else {
         qCDebug(CameraManagerLog) << "Using MAV_CMD_REQUEST_CAMERA_INFORMATION for compId" << QGCMAVLink::compIdToString(pInfo->compID);
 
         Vehicle::MavCmdAckHandlerInfo_t ackHandlerInfo{};
         ackHandlerInfo.resultHandler        = _requestCameraInfoCommandResultHandler;
-        ackHandlerInfo.resultHandlerData    = pInfo;
+        ackHandlerInfo.resultHandlerData    = manager->cameraInfoContext(pInfo->compID);
         ackHandlerInfo.progressHandler      = nullptr;
         ackHandlerInfo.progressHandlerData  = nullptr;
 

--- a/src/Camera/QGCCameraManager.h
+++ b/src/Camera/QGCCameraManager.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <QtCore/QElapsedTimer>
+#include <QtCore/QHash>
 #include <QtCore/QMap>
 #include <QtCore/QObject>
 #include <QtCore/QPointer>
@@ -59,6 +60,18 @@ public:
     private:
         Q_DISABLE_COPY_MOVE(CameraStruct)
     };
+
+    /// Stable context passed as opaque handler data to async camera info request
+    /// callbacks. Owned by the manager and kept alive for its full lifetime so a
+    /// callback firing after the CameraStruct was deleted (lost camera) never
+    /// dereferences freed memory (issue #13251).
+    struct CameraInfoRequestContext {
+        QPointer<QGCCameraManager> manager;
+        uint8_t compID = 0;
+    };
+
+    /// Returns the lazily created, manager-lifetime context for compId.
+    CameraInfoRequestContext* cameraInfoContext(uint8_t compId);
 
     QmlObjectListModel* cameras() { return &_cameras; }
     const QmlObjectListModel* cameras() const { return &_cameras; }
@@ -143,6 +156,7 @@ private:
     QElapsedTimer _lastCameraChange;
     QTimer _camerasLostHeartbeatTimer;
     QMap<QString, CameraStruct*> _cameraInfoRequest;
+    QHash<uint8_t, CameraInfoRequestContext*> _cameraInfoContexts;
     static QVariantList _cameraList;
     bool _initialConnectComplete = false;
 

--- a/src/Comms/LogReplayLinkController.cc
+++ b/src/Comms/LogReplayLinkController.cc
@@ -19,8 +19,8 @@ LogReplayLinkController::~LogReplayLinkController()
 void LogReplayLinkController::setLink(LogReplayLink *link)
 {
     if (_link) {
-        (void) disconnect(_link);
-        (void) disconnect(this, &LogReplayLinkController::playbackSpeedChanged, _link, &LogReplayLink::setPlaybackSpeed);
+        (void) QObject::disconnect(_link, nullptr, this, nullptr);  // link signals -> this
+        (void) QObject::disconnect(this, nullptr, _link, nullptr);  // this signals -> link (playbackSpeedChanged)
 
         _isPlaying = false;
         emit isPlayingChanged(_isPlaying);
@@ -28,6 +28,7 @@ void LogReplayLinkController::setLink(LogReplayLink *link)
         _percentComplete = 0;
         emit percentCompleteChanged(_percentComplete);
 
+        _playheadSecs = kNoPlayhead;
         _playheadTime.clear();
         emit playheadTimeChanged(_playheadTime);
 

--- a/src/Comms/LogReplayLinkController.h
+++ b/src/Comms/LogReplayLinkController.h
@@ -51,9 +51,12 @@ private slots:
 private:
     static QString _secondsToHMS(uint32_t seconds);
 
+    /// Sentinel for _playheadSecs meaning "no playhead yet", so a t=0 update is never deduped
+    static constexpr int64_t kNoPlayhead = -1;
+
     bool _isPlaying = false;
     qreal _percentComplete = 0;
-    uint32_t _playheadSecs = 0;
+    int64_t _playheadSecs = kNoPlayhead;
     qreal _playbackSpeed = 1;
     QString _playheadTime;
     QString _totalTime;

--- a/src/Vehicle/MavCommandQueue.cc
+++ b/src/Vehicle/MavCommandQueue.cc
@@ -438,8 +438,18 @@ void MavCommandQueue::_responseTimeoutCheck()
         return;
     }
 
-    // Walk the list backwards since _sendFromList can remove entries
+    // Walk the list backwards since _sendFromList can remove entries. Give-up result
+    // handlers invoked from _sendFromList can also re-enter the queue and remove or
+    // clear entries (e.g. closing the vehicle from within the callback), so re-validate
+    // the stop flag and index on every iteration.
     for (int i = _list.count() - 1; i >= 0; i--) {
+        if (_stopped) {
+            return;
+        }
+        if (i >= _list.count()) {
+            i = _list.count();  // Handler removed entries below us, clamp (loop decrement follows)
+            continue;
+        }
         MavCommandListEntry_t& commandEntry = _list[i];
         if (commandEntry.elapsedTimer.elapsed() > commandEntry.ackTimeoutMSecs) {
             // Try sending command again

--- a/test/Camera/QGCCameraManagerTest.cc
+++ b/test/Camera/QGCCameraManagerTest.cc
@@ -1,13 +1,87 @@
 #include "QGCCameraManagerTest.h"
 
+#include <QtCore/QLoggingCategory>
+#include <QtCore/QRegularExpression>
+#include <QtCore/QScopeGuard>
+
 #include "CameraMetaData.h"
+#include "MAVLinkLib.h"
 #include "QGCCameraManager.h"
+#include "Vehicle.h"
 
 void QGCCameraManagerTest::_testCameraList()
 {
     const QList<CameraMetaData*> cameraList = CameraMetaData::parseCameraMetaData();
     QVERIFY(!cameraList.isEmpty());
     qDeleteAll(cameraList);
+}
+
+/// Reproduces issue #13251 (crash 1): use-after-free of QGCCameraManager::CameraStruct.
+///
+/// The camera info request commands are queued in the vehicle's MavCommandQueue with
+/// resultHandlerData pointing at the CameraStruct. _checkForLostCameras() deletes the
+/// CameraStruct when the camera goes silent, without cancelling the pending command.
+/// When the command later times out, the failure handler dereferences the freed struct.
+///
+/// In production this is reached when a camera reappears after a silent period (which
+/// re-requests camera info with infoReceived still true) and then goes silent again for
+/// kSilentTimeoutMs while the request is pending. The test shortcuts the two 5 second
+/// silent periods by performing the same cleanup _checkForLostCameras() does (take from
+/// _cameraInfoRequest + delete) while the request is pending.
+///
+/// The use-after-free is only reliably detected when running under AddressSanitizer
+/// (CI ASan job). Without ASan the test exercises the path but may pass silently.
+void QGCCameraManagerTest::_testLostCameraCleanupWithPendingRequest()
+{
+    ignoreLogMessage("Vehicle.MavCommandQueue", QtWarningMsg,
+                     QRegularExpression("Giving up sending command after max retries:"));
+
+    // Enable camera manager debug logging: the failure handlers log CameraStruct
+    // fields, widening the use-after-free reads for ASan to catch. Scoped so the
+    // process-global filter rules are restored even on early test failure.
+    const QByteArray oldLoggingRules = qgetenv("QT_LOGGING_RULES");
+    QLoggingCategory::setFilterRules(QStringLiteral("Camera.QGCCameraManager.debug=true"));
+    const auto restoreLoggingRules = qScopeGuard([oldLoggingRules]() {
+        QLoggingCategory::setFilterRules(QString::fromUtf8(oldLoggingRules));
+    });
+
+    // Ensure MockLink never responds to the camera info request so it stays pending
+    // and eventually times out.
+    mockLink()->setRequestMessageNoResponse(MAVLINK_MSG_ID_CAMERA_INFORMATION);
+
+    // Inject a camera component heartbeat. The camera manager creates a CameraStruct
+    // and immediately requests CAMERA_INFORMATION with the struct as handler data.
+    mavlink_message_t msg{};
+    (void) mavlink_msg_heartbeat_pack_chan(vehicle()->id(),
+                                           MAV_COMP_ID_CAMERA,
+                                           mockLink()->mavlinkChannel(),
+                                           &msg,
+                                           MAV_TYPE_CAMERA,
+                                           MAV_AUTOPILOT_INVALID,
+                                           0,   // base_mode
+                                           0,   // custom_mode
+                                           MAV_STATE_ACTIVE);
+    mockLink()->respondWithMavlinkMessage(msg);
+
+    QGCCameraManager* cameraManager = vehicle()->cameraManager();
+    QVERIFY(cameraManager);
+
+    QTRY_VERIFY_WITH_TIMEOUT(cameraManager->findCameraStruct(MAV_COMP_ID_CAMERA) != nullptr, TestTimeout::longMs());
+    QTRY_VERIFY_WITH_TIMEOUT(vehicle()->isMavCommandPending(MAV_COMP_ID_CAMERA, MAV_CMD_REQUEST_MESSAGE),
+                             TestTimeout::longMs());
+
+    // Mimic the lost-camera cleanup in _checkForLostCameras() while the camera info
+    // request is still pending in the MavCommandQueue.
+    QGCCameraManager::CameraStruct* pInfo = cameraManager->_cameraInfoRequest.take(QString::number(MAV_COMP_ID_CAMERA));
+    QVERIFY(pInfo);
+    delete pInfo;
+
+    // Let the pending request retry and give up. Before the fix the give-up failure
+    // handler dereferenced the freed CameraStruct (issue #13251 crash 1) — detected
+    // by the CI ASan job. With the fix, the handler resolves the compId via the
+    // manager-owned request context, finds the camera gone, and bails out.
+    QTRY_VERIFY_WITH_TIMEOUT(!vehicle()->isMavCommandPending(MAV_COMP_ID_CAMERA, MAV_CMD_REQUEST_MESSAGE),
+                             TestTimeout::longMs());
 }
 
 UT_REGISTER_TEST(QGCCameraManagerTest, TestLabel::Integration, TestLabel::Vehicle)

--- a/test/Camera/QGCCameraManagerTest.h
+++ b/test/Camera/QGCCameraManagerTest.h
@@ -1,11 +1,12 @@
 #pragma once
 
-#include "UnitTest.h"
+#include "BaseClasses/VehicleTest.h"
 
-class QGCCameraManagerTest : public UnitTest
+class QGCCameraManagerTest : public VehicleTest
 {
     Q_OBJECT
 
 private slots:
     void _testCameraList();
+    void _testLostCameraCleanupWithPendingRequest();
 };

--- a/test/Comms/CMakeLists.txt
+++ b/test/Comms/CMakeLists.txt
@@ -9,6 +9,8 @@ target_sources(${CMAKE_PROJECT_NAME}
         LinkConfigurationTest.h
         LinkManagerTest.cc
         LinkManagerTest.h
+        LogReplayLinkControllerTest.cc
+        LogReplayLinkControllerTest.h
         QGCSerialPortInfoTest.cc
         QGCSerialPortInfoTest.h
 )
@@ -19,4 +21,5 @@ add_subdirectory(Bluetooth)
 
 add_qgc_test(LinkConfigurationTest LABELS Unit Comms RESOURCE_LOCK Settings TempFiles)
 add_qgc_test(LinkManagerTest LABELS Integration Comms SERIAL)
+add_qgc_test(LogReplayLinkControllerTest LABELS Unit Comms)
 add_qgc_test(QGCSerialPortInfoTest LABELS Unit Comms)

--- a/test/Comms/LogReplayLinkControllerTest.cc
+++ b/test/Comms/LogReplayLinkControllerTest.cc
@@ -1,0 +1,96 @@
+#include "LogReplayLinkControllerTest.h"
+
+#include "LogReplayLink.h"
+#include "LogReplayLinkController.h"
+
+// Signals are emitted on the links directly rather than playing back a real log file:
+// the controller only reacts to link signals, so this keeps the tests deterministic.
+
+void LogReplayLinkControllerTest::_testStateTracksLinkSignals()
+{
+    SharedLinkConfigurationPtr config = std::make_shared<LogReplayConfiguration>(QStringLiteral("LogReplayLinkControllerTest"));
+    LogReplayLink link(config);
+    LogReplayLinkController controller;
+
+    controller.setLink(&link);
+    QCOMPARE(controller.link(), &link);
+
+    // The very first playhead update at t=0 must not be dropped by the dedup guard
+    // (0 previously doubled as both the initial sentinel and a legitimate time value).
+    emit link.currentLogTimeSecs(0);
+    QCOMPARE(controller.property("playheadTime").toString(), QStringLiteral("00m:00s"));
+
+    emit link.logFileStats(3661);
+    emit link.playbackStarted();
+    emit link.playbackPercentCompleteChanged(0.5);
+    emit link.currentLogTimeSecs(90);
+
+    QCOMPARE(controller.property("totalTime").toString(), QStringLiteral("01h:01m:01s"));
+    QVERIFY(controller.isPlaying());
+    QCOMPARE(controller.percentComplete(), 0.5);
+    QCOMPARE(controller.property("playheadTime").toString(), QStringLiteral("01m:30s"));
+
+    controller.setLink(nullptr);
+}
+
+void LogReplayLinkControllerTest::_testResetWhenLinkDisconnects()
+{
+    SharedLinkConfigurationPtr config = std::make_shared<LogReplayConfiguration>(QStringLiteral("LogReplayLinkControllerTest"));
+    LogReplayLink link(config);
+    LogReplayLinkController controller;
+
+    controller.setLink(&link);
+
+    emit link.logFileStats(3661);
+    emit link.playbackStarted();
+    emit link.playbackPercentCompleteChanged(0.5);
+    emit link.currentLogTimeSecs(90);
+
+    // Link disconnect must reset all controller state (issue #13251 bug 1)
+    emit link.disconnected();
+
+    QCOMPARE(controller.link(), nullptr);
+    QVERIFY(!controller.isPlaying());
+    QCOMPARE(controller.percentComplete(), 0.0);
+    QVERIFY(controller.property("totalTime").toString().isEmpty());
+    QVERIFY(controller.property("playheadTime").toString().isEmpty());
+
+    // Re-attach: a new session starting at t=0 must update the playhead label even
+    // though the detach reset cleared it (0 must not be treated as "no change").
+    controller.setLink(&link);
+    emit link.currentLogTimeSecs(0);
+    QCOMPARE(controller.property("playheadTime").toString(), QStringLiteral("00m:00s"));
+
+    // Replaying the same log time as before the detach must also update the label
+    // (stale _playheadSecs guard).
+    emit link.currentLogTimeSecs(90);
+    QCOMPARE(controller.property("playheadTime").toString(), QStringLiteral("01m:30s"));
+
+    controller.setLink(nullptr);
+}
+
+void LogReplayLinkControllerTest::_testDetachedLinkSignalsIgnored()
+{
+    SharedLinkConfigurationPtr config = std::make_shared<LogReplayConfiguration>(QStringLiteral("LogReplayLinkControllerTest"));
+    LogReplayLink link(config);
+    LogReplayLinkController controller;
+
+    controller.setLink(&link);
+    controller.setLink(nullptr);
+
+    // A detached link's signals must no longer affect the controller (regression:
+    // setLink previously only disconnected controller -> link, leaving the
+    // link -> controller connections live).
+    emit link.logFileStats(3661);
+    emit link.playbackStarted();
+    emit link.playbackPercentCompleteChanged(0.5);
+    emit link.currentLogTimeSecs(90);
+
+    QCOMPARE(controller.link(), nullptr);
+    QVERIFY(!controller.isPlaying());
+    QCOMPARE(controller.percentComplete(), 0.0);
+    QVERIFY(controller.property("totalTime").toString().isEmpty());
+    QVERIFY(controller.property("playheadTime").toString().isEmpty());
+}
+
+UT_REGISTER_TEST(LogReplayLinkControllerTest, TestLabel::Unit, TestLabel::Comms)

--- a/test/Comms/LogReplayLinkControllerTest.h
+++ b/test/Comms/LogReplayLinkControllerTest.h
@@ -1,0 +1,15 @@
+#pragma once
+
+#include "UnitTest.h"
+
+/// Tests for LogReplayLinkController state handling (issue #13251 bug 1: log replay
+/// status bar not resetting when the replay link goes away).
+class LogReplayLinkControllerTest : public UnitTest
+{
+    Q_OBJECT
+
+private slots:
+    void _testStateTracksLinkSignals();
+    void _testResetWhenLinkDisconnects();
+    void _testDetachedLinkSignalsIgnored();
+};

--- a/test/Vehicle/CMakeLists.txt
+++ b/test/Vehicle/CMakeLists.txt
@@ -17,6 +17,10 @@ target_sources(${CMAKE_PROJECT_NAME}
         InitialConnectPeripheralStartupTest.h
         MAVLinkLogManagerTest.cc
         MAVLinkLogManagerTest.h
+        MavCommandQueueReentrancyTest.cc
+        MavCommandQueueReentrancyTest.h
+        MultiVehicleManagerTest.cc
+        MultiVehicleManagerTest.h
         RemoteIDManagerTest.cc
         RemoteIDManagerTest.h
         RequestMessageTest.cc
@@ -53,6 +57,8 @@ add_qgc_test(FirmwareUpgradeControllerTest LABELS Unit Vehicle)
 add_qgc_test(InitialConnectTest LABELS Integration Vehicle)
 add_qgc_test(InitialConnectPeripheralStartupTest LABELS Integration Vehicle)
 add_qgc_test(MAVLinkLogManagerTest LABELS Integration Vehicle)
+add_qgc_test(MavCommandQueueReentrancyTest LABELS Integration Vehicle)
+add_qgc_test(MultiVehicleManagerTest LABELS Integration Vehicle)
 add_qgc_test(RemoteIDManagerTest LABELS Integration Vehicle)
 add_qgc_test(RequestMessageTest LABELS Integration Vehicle TIMEOUT ${QGC_TEST_TIMEOUT_EXTENDED})
 add_qgc_test(SendMavCommandWithHandlerTest LABELS Integration Vehicle)

--- a/test/Vehicle/MavCommandQueueReentrancyTest.cc
+++ b/test/Vehicle/MavCommandQueueReentrancyTest.cc
@@ -1,0 +1,53 @@
+#include "MavCommandQueueReentrancyTest.h"
+
+#include <QtCore/QRegularExpression>
+
+#include "MultiVehicleManager.h"
+
+void MavCommandQueueReentrancyTest::_closeVehicleResultHandler(void* resultHandlerData, int compId,
+                                                               const mavlink_command_ack_t& ack,
+                                                               Vehicle::MavCmdResultFailureCode_t failureCode)
+{
+    auto* self = static_cast<MavCommandQueueReentrancyTest*>(resultHandlerData);
+    self->_resultHandlerCallCount++;
+
+    QCOMPARE(compId, MAV_COMP_ID_AUTOPILOT1);
+    QCOMPARE(ack.result, MAV_RESULT_FAILED);
+    QCOMPARE(failureCode, Vehicle::MavCmdResultFailureNoResponseToCommand);
+
+    // Simulate the user closing log replay / disconnecting the vehicle from within the
+    // give-up callback chain. This synchronously calls Vehicle::_stopCommandProcessing()
+    // which clears the pending command list while _responseTimeoutCheck is iterating it.
+    self->vehicle()->closeVehicle();
+}
+
+void MavCommandQueueReentrancyTest::_testCloseVehicleFromGiveUpHandler()
+{
+    ignoreLogMessage("Vehicle.MavCommandQueue", QtWarningMsg,
+                     QRegularExpression("Giving up sending command after max retries:"));
+
+    _resultHandlerCallCount = 0;
+
+    // First entry (index 0): retried command which stays pending in the list across
+    // multiple timeout checks.
+    vehicle()->sendMavCommand(MAV_COMP_ID_AUTOPILOT1, MockLink::MAV_CMD_MOCKLINK_NO_RESPONSE, false /* showError */);
+
+    // Second entry (index 1): no-retry command which gives up on the first ack timeout.
+    Vehicle::MavCmdAckHandlerInfo_t handlerInfo = {};
+    handlerInfo.resultHandler = _closeVehicleResultHandler;
+    handlerInfo.resultHandlerData = this;
+    vehicle()->sendMavCommandWithHandler(&handlerInfo, MAV_COMP_ID_AUTOPILOT1,
+                                         MockLink::MAV_CMD_MOCKLINK_NO_RESPONSE_NO_RETRY);
+
+    // _responseTimeoutCheck walks the list backwards. The no-retry command (index 1) gives
+    // up first; its result handler closes the vehicle which clears the pending list. The
+    // loop must then not touch index 0 of the now-empty list (issue #13251 crash 3 -
+    // out-of-bounds access in a Debug build aborts here).
+    QTRY_COMPARE_WITH_TIMEOUT(_resultHandlerCallCount, 1, TestTimeout::longMs());
+
+    // closeVehicle() tears the vehicle down asynchronously; wait for it to complete so
+    // any deferred crash in the timeout-check loop has a chance to fire before cleanup.
+    QTRY_VERIFY_WITH_TIMEOUT(MultiVehicleManager::instance()->activeVehicle() == nullptr, TestTimeout::longMs());
+}
+
+UT_REGISTER_TEST(MavCommandQueueReentrancyTest, TestLabel::Integration, TestLabel::Vehicle)

--- a/test/Vehicle/MavCommandQueueReentrancyTest.h
+++ b/test/Vehicle/MavCommandQueueReentrancyTest.h
@@ -1,0 +1,32 @@
+#pragma once
+
+#include "BaseClasses/VehicleTest.h"
+#include "Vehicle.h"
+
+/// Reproduces issue #13251 (crash 3): out-of-bounds list access in
+/// MavCommandQueue::_responseTimeoutCheck. When a command gives up after max retries,
+/// the result handler is invoked from within the timeout-check loop. If that handler
+/// re-enters the queue and clears the pending list (which is exactly what happens when
+/// the user closes log replay or disconnects the vehicle, via
+/// VehicleLinkManager::closeVehicle -> Vehicle::_stopCommandProcessing -> MavCommandQueue::stop),
+/// the loop continues iterating stale indices into the now-empty list.
+class MavCommandQueueReentrancyTest : public VehicleTestNoInitialConnect
+{
+    Q_OBJECT
+
+public:
+    explicit MavCommandQueueReentrancyTest(QObject* parent = nullptr)
+        : VehicleTestNoInitialConnect(parent)
+    {
+        setAutopilotType(MAV_AUTOPILOT_INVALID);
+    }
+
+private slots:
+    void _testCloseVehicleFromGiveUpHandler();
+
+private:
+    static void _closeVehicleResultHandler(void* resultHandlerData, int compId, const mavlink_command_ack_t& ack,
+                                           Vehicle::MavCmdResultFailureCode_t failureCode);
+
+    int _resultHandlerCallCount = 0;
+};

--- a/test/Vehicle/MultiVehicleManagerTest.cc
+++ b/test/Vehicle/MultiVehicleManagerTest.cc
@@ -1,0 +1,56 @@
+#include "MultiVehicleManagerTest.h"
+
+#include <QtCore/QRegularExpression>
+#include <QtTest/QSignalSpy>
+
+#include "MockLink.h"
+#include "MultiVehicleManager.h"
+#include "Vehicle.h"
+#include "VehicleLinkManager.h"
+
+void MultiVehicleManagerTest::_testDuplicateAllLinksRemoved()
+{
+    // The duplicate delivery must hit the not-found guard and warn instead of
+    // double-scheduling vehicle deletion.
+    expectLogMessage("Vehicle.MultiVehicleManager", QtWarningMsg,
+                     QRegularExpression("Vehicle not found in map!"));
+
+    // The forced deletion below bypasses the normal closeVehicle link-release path, so
+    // the MockLink teardown warns about a leftover vehicle reference.
+    ignoreLogMessage("Comms.LinkInterface", QtWarningMsg,
+                     QRegularExpression("still have vehicle references:"));
+
+    Vehicle* vehicle = this->vehicle();
+    QVERIFY(vehicle);
+
+    // Stop heartbeats so a new vehicle isn't created after this one is removed
+    simulateCommLoss(true);
+
+    QSignalSpy destroyedSpy(vehicle, &QObject::destroyed);
+    QVERIFY(destroyedSpy.isValid());
+
+    // Simulate the race from issue #13251 crash 2: allLinksRemoved delivered twice for
+    // the same vehicle.
+    VehicleLinkManager* vehicleLinkManager = vehicle->vehicleLinkManager();
+    QVERIFY(vehicleLinkManager);
+    emit vehicleLinkManager->allLinksRemoved(vehicle);
+    emit vehicleLinkManager->allLinksRemoved(vehicle);
+
+    // The duplicate delivery must have hit the not-found guard
+    verifyExpectedLogMessage();
+
+    QTRY_COMPARE_WITH_TIMEOUT(destroyedSpy.count(), 1, TestTimeout::longMs());
+    QVERIFY(!MultiVehicleManager::instance()->activeVehicle());
+
+    // The vehicle is already gone but the MockLink is still connected. Disconnect it
+    // ourselves so the base class cleanup (which waits for a vehicle removal) doesn't
+    // time out.
+    _vehicle = nullptr;
+    if (_mockLink) {
+        _mockLink->disconnect();
+        _mockLink = nullptr;
+    }
+    settleEventLoopForCleanup();
+}
+
+UT_REGISTER_TEST(MultiVehicleManagerTest, TestLabel::Integration, TestLabel::Vehicle)

--- a/test/Vehicle/MultiVehicleManagerTest.h
+++ b/test/Vehicle/MultiVehicleManagerTest.h
@@ -1,0 +1,16 @@
+#pragma once
+
+#include "BaseClasses/VehicleTest.h"
+
+/// Regression test for issue #13251 (crash 2): double vehicle delete when
+/// VehicleLinkManager::allLinksRemoved is delivered twice for the same vehicle
+/// (e.g. link teardown racing with heartbeat-timeout removal). The second delivery
+/// must hit the not-found guard in MultiVehicleManager::_deleteVehiclePhase1 instead
+/// of double-scheduling _deleteVehiclePhase2 -> double deleteLater -> crash.
+class MultiVehicleManagerTest : public VehicleTest
+{
+    Q_OBJECT
+
+private slots:
+    void _testDuplicateAllLinksRemoved();
+};


### PR DESCRIPTION
Fixes #13251

Fixes the crashes reported in "Daily QGC: Log Replay Status Bar and Telemetry Log Crashes", plus the log replay status bar not updating after reconnect.

### Crash 1 — Camera info request use-after-free
`_checkForLostCameras()` deletes the `CameraStruct` for a silent camera while a `CAMERA_INFORMATION` request queued in `MavCommandQueue` still holds the struct as opaque handler data. When the request later times out, the failure handler dereferenced freed memory.

Fix: callbacks now receive a manager-lifetime `CameraInfoRequestContext` (`QPointer<QGCCameraManager>` + compId) and re-resolve the live `CameraStruct` when they fire, bailing out cleanly if the camera or manager is gone.

### Crash 3 — MavCommandQueue re-entrancy
`_responseTimeoutCheck()` walks the pending command list while `_sendFromList()` give-up result handlers can re-enter the queue and clear the list (e.g. the handler closes the vehicle, as log replay teardown does). The backward walk then indexed past the end of the now-empty list.

Fix: re-validate the stop flag and clamp the index on every loop iteration.

### Crash 2 — duplicate `allLinksRemoved`
Already guarded on master (`Vehicle not found in map!` warning + early return). This PR adds a regression test locking the behavior in.

### Log replay status bar residuals
`LogReplayLinkController::setLink()` only disconnected one signal direction and left `_playheadSecs` stale, so re-attaching a replay link could silently drop playhead updates. Now both directions are disconnected and the cache is reset.

### Tests (all verified failing before the fix where applicable)
- `QGCCameraManagerTest::_testLostCameraCleanupWithPendingRequest` — reproduces the crash 1 UAF (detected by the CI ASan job)
- `MavCommandQueueReentrancyTest` — closes the vehicle from a give-up handler; aborted with out-of-bounds access before the fix
- `MultiVehicleManagerTest` — duplicate `allLinksRemoved` regression test (crash 2)
- `LogReplayLinkControllerTest` — controller state tracking, reset on disconnect, and detached-link signal isolation
