### PR TITLE
fix(PlanView): arming Waypoint/ROI tool exits template mode so map clicks insert items instead of moving home

### DIFF
--- a/src/PlanView/PlanView.qml
+++ b/src/PlanView/PlanView.qml
@@ -468,7 +468,15 @@ Item {
                         enabled: _missionController.flyThroughCommandsAllowed
                         visible: toolStrip._isMissionLayer
                         checkable: true
-                        onTriggered: { _addWaypointOnClick = !_addWaypointOnClick; if (_addWaypointOnClick) _addROIOnClick = false }
+                        onTriggered: {
+                            _addWaypointOnClick = !_addWaypointOnClick
+                            if (_addWaypointOnClick) {
+                                _addROIOnClick = false
+                                // Arming an insert tool leaves template-creation mode, otherwise
+                                // map clicks keep moving the home position instead of inserting
+                                _planMasterController.userSelectedManualCreation = true
+                            }
+                        }
                     },
                     ToolStripAction {
                         id: roiButton
@@ -478,7 +486,13 @@ Item {
                         enabled: _missionController.isInsertROIValid
                         visible: toolStrip._isMissionLayer && _planMasterController.controllerVehicle.supports.roiMode
                         checkable: true
-                        onTriggered: { _addROIOnClick = !_addROIOnClick; if (_addROIOnClick) _addWaypointOnClick = false }
+                        onTriggered: {
+                            _addROIOnClick = !_addROIOnClick
+                            if (_addROIOnClick) {
+                                _addWaypointOnClick = false
+                                _planMasterController.userSelectedManualCreation = true
+                            }
+                        }
                     },
                     ToolStripAction {
                         objectName: "planToolStrip_landButton"

--- a/test/QmlUITests/PlanViewUITest.cc
+++ b/test/QmlUITests/PlanViewUITest.cc
@@ -1,13 +1,19 @@
 #include "PlanViewUITest.h"
 
 #include <QtCore/QFile>
+#include <QtCore/QScopeGuard>
 #include <QtCore/QTemporaryDir>
 #include <QtPositioning/QGeoCoordinate>
 #include <QtQuick/QQuickItem>
 #include <QtQuick/QQuickWindow>
 #include <QtTest/QTest>
 
+#include "AppSettings.h"
+#include "Fact.h"
+#include "PlanViewSettings.h"
 #include "QGCFileDialogController.h"
+#include "QGCMAVLink.h"
+#include "SettingsManager.h"
 
 UT_REGISTER_TEST(PlanViewUITest, TestLabel::Integration, TestLabel::MissionManager)
 
@@ -30,6 +36,114 @@ int PlanViewUITest::_missionItemCount()
         return -1;
     }
     return visualItems->property("count").toInt();
+}
+
+QGeoCoordinate PlanViewUITest::_plannedHomePosition()
+{
+    QQuickItem *planView = findVisibleItem(_rootItem, QStringLiteral("mainView_plan"));
+    if (!planView) {
+        return QGeoCoordinate();
+    }
+    QObject *missionController = planView->property("_missionController").value<QObject*>();
+    if (!missionController) {
+        return QGeoCoordinate();
+    }
+    return missionController->property("plannedHomePosition").value<QGeoCoordinate>();
+}
+
+void PlanViewUITest::_navigateToPlanAndCenterMap()
+{
+    QVERIFY2(clickToolSelectDropdownButton(QStringLiteral("toolbar_viewPlan")), "Failed to navigate to Plan view");
+    QVERIFY2(findVisibleItem(_rootItem, QStringLiteral("mainView_plan"), 2000), "Plan view did not appear");
+    QTest::qWait(_viewDelay);
+
+    // Position the map at a known location and reasonable zoom so map clicks
+    // are deterministic and offset clicks produce nearby waypoints.
+    QQuickItem *map = findVisibleItem(_rootItem, QStringLiteral("planView_map"));
+    QVERIFY2(map, "planView_map not found");
+    const QGeoCoordinate mapCenter(47.397742, 8.545594); // Zurich
+    map->setProperty("center", QVariant::fromValue(mapCenter));
+    map->setProperty("zoomLevel", 15.0);
+    QVERIFY2(waitForCondition(
+                 [&] {
+                     const QGeoCoordinate c = map->property("center").value<QGeoCoordinate>();
+                     return c.isValid() && (c.distanceTo(mapCenter) < 1.0)
+                         && qFuzzyCompare(map->property("zoomLevel").toReal(), 15.0);
+                 },
+                 1000),
+             "Map did not settle on the requested center/zoom");
+}
+
+void PlanViewUITest::_verifyWaypointToolAddsWaypointOnEmptyPlan(bool expectTakeoffButtonVisible)
+{
+    startUI();
+    if (QTest::currentTestFailed()) return;
+
+    _navigateToPlanAndCenterMap();
+    if (QTest::currentTestFailed()) return;
+
+    const QString takeoffBtn  = QStringLiteral("planToolStrip_takeoffButton");
+    const QString waypointBtn = QStringLiteral("planToolStrip_waypointButton");
+    const QString context     = QStringLiteral("waypoint on empty plan");
+
+    verifyVisibility(takeoffBtn, expectTakeoffButtonVisible, context);
+    if (QTest::currentTestFailed()) return;
+
+    // Home-position gate: Waypoint tool must be disabled until home is set
+    verifyEnabled(waypointBtn, false, context);
+    if (QTest::currentTestFailed()) return;
+
+    // Click map to set home position: plan stays empty
+    _clickMap(0.5, 0.5);
+    if (QTest::currentTestFailed()) return;
+
+    QVERIFY2(waitForCondition([&] { return _plannedHomePosition().isValid(); }, 2000,
+                              QStringLiteral("home position set")),
+             "Map click did not set home position");
+    QCOMPARE(_missionItemCount(), 1);
+
+    // Precondition that distinguishes this path from the takeoff-first flow:
+    // the Waypoint tool is enabled while the plan is still empty.
+    verifyEnabled(waypointBtn, true, context);
+    if (QTest::currentTestFailed()) return;
+
+    const QGeoCoordinate homePosition = _plannedHomePosition();
+
+    // Arm the Waypoint tool and click the map: must insert a waypoint, not move home
+    QVERIFY2(clickButton(waypointBtn), "Failed to click Waypoint button");
+    verifyChecked(waypointBtn, true, context);
+    if (QTest::currentTestFailed()) return;
+
+    _clickMap(0.35, 0.4);
+    if (QTest::currentTestFailed()) return;
+
+    QVERIFY2(waitForCondition([&] { return _missionItemCount() == 2; }, 2000,
+                              QStringLiteral("waypoint inserted")),
+             qPrintable(QStringLiteral("Map click with Waypoint tool armed did not insert a waypoint (item count %1)")
+                            .arg(_missionItemCount())));
+    QVERIFY2(_plannedHomePosition().distanceTo(homePosition) < 1.0,
+             "Map click with Waypoint tool armed moved the home position");
+}
+
+void PlanViewUITest::_testRoverWaypointOnEmptyPlan()
+{
+    // Rover has no takeoff item, so the Waypoint tool is the first insert tool
+    // available on an empty plan.
+    SettingsManager::instance()->appSettings()->offlineEditingVehicleClass()->setRawValue(QGCMAVLink::VehicleClassRoverBoat);
+
+    _verifyWaypointToolAddsWaypointOnEmptyPlan(false /* expectTakeoffButtonVisible */);
+}
+
+void PlanViewUITest::_testTakeoffNotRequiredWaypointOnEmptyPlan()
+{
+    // Multi-rotor with "takeoff item not required": the Waypoint tool is
+    // enabled on an empty plan just like the rover case.
+    Fact* const takeoffItemNotRequired = SettingsManager::instance()->planViewSettings()->takeoffItemNotRequired();
+    const QVariant savedValue = takeoffItemNotRequired->rawValue();
+    const auto restoreGuard = qScopeGuard([takeoffItemNotRequired, savedValue] { takeoffItemNotRequired->setRawValue(savedValue); });
+    takeoffItemNotRequired->setRawValue(true);
+
+    _verifyWaypointToolAddsWaypointOnEmptyPlan(true /* expectTakeoffButtonVisible */);
 }
 
 void PlanViewUITest::_verifyFullState(const PlanUIState &state, const QString &context)
@@ -92,26 +206,8 @@ void PlanViewUITest::_testPlanViewStates()
     startUI();
     if (QTest::currentTestFailed()) return;
 
-    // Navigate to Plan view
-    QVERIFY2(clickToolSelectDropdownButton(QStringLiteral("toolbar_viewPlan")), "Failed to navigate to Plan view");
-    QVERIFY2(findVisibleItem(_rootItem, QStringLiteral("mainView_plan"), 2000), "Plan view did not appear");
-    QTest::qWait(_viewDelay);
-
-    // Position the map at a known location and reasonable zoom so map clicks
-    // are deterministic and offset clicks produce nearby waypoints.
-    QQuickItem *map = findVisibleItem(_rootItem, QStringLiteral("planView_map"));
-    QVERIFY2(map, "planView_map not found");
-    const QGeoCoordinate mapCenter(47.397742, 8.545594); // Zurich
-    map->setProperty("center", QVariant::fromValue(mapCenter));
-    map->setProperty("zoomLevel", 15.0);
-    QVERIFY2(waitForCondition(
-                 [&] {
-                     const QGeoCoordinate c = map->property("center").value<QGeoCoordinate>();
-                     return c.isValid() && (c.distanceTo(mapCenter) < 1.0)
-                         && qFuzzyCompare(map->property("zoomLevel").toReal(), 15.0);
-                 },
-                 1000),
-             "Map did not settle on the requested center/zoom");
+    _navigateToPlanAndCenterMap();
+    if (QTest::currentTestFailed()) return;
 
     const QString takeoffBtn  = QStringLiteral("planToolStrip_takeoffButton");
     const QString waypointBtn = QStringLiteral("planToolStrip_waypointButton");

--- a/test/QmlUITests/PlanViewUITest.h
+++ b/test/QmlUITests/PlanViewUITest.h
@@ -2,6 +2,8 @@
 
 #include "QmlUITestBase.h"
 
+#include <QtPositioning/QGeoCoordinate>
+
 class QQuickItem;
 
 /// UI test for Plan view state transitions (offline, no vehicle).
@@ -18,6 +20,8 @@ public:
 
 private slots:
     void _testPlanViewStates();
+    void _testRoverWaypointOnEmptyPlan();
+    void _testTakeoffNotRequiredWaypointOnEmptyPlan();
 
 private:
     /// Complete expected state of all Plan view UI under test
@@ -43,10 +47,22 @@ private:
     /// and not highlighted, Open/Clear always enabled.
     void _verifyFullState(const PlanUIState &state, const QString &context);
 
+    /// Navigate to the Plan view and position the map at a known center/zoom
+    /// so map clicks are deterministic.
+    void _navigateToPlanAndCenterMap();
+
+    /// Shared worker for the empty-plan Waypoint tool regression: set home by
+    /// map click, arm the Waypoint tool while the plan is still empty, click
+    /// the map, and verify a waypoint is inserted and home does not move.
+    void _verifyWaypointToolAddsWaypointOnEmptyPlan(bool expectTakeoffButtonVisible);
+
     /// Click the Plan view map at a fractional position within its viewport.
     /// (0.5, 0.5) is the map center.
     void _clickMap(qreal fractionX, qreal fractionY);
 
     /// Current MissionController visualItems count, or -1 if unavailable.
     int _missionItemCount();
+
+    /// Current MissionController plannedHomePosition, or invalid if unavailable.
+    QGeoCoordinate _plannedHomePosition();
 };


### PR DESCRIPTION
Fixes #14625

## Problem

Start a plan with no vehicle connected, set vehicle to Rover (or enable the "Takeoff item not required" setting on a multi-rotor), click the map to set home, then arm the Waypoint tool and click the map: the click moves the home position instead of inserting a waypoint.

## Root cause

In `PlanView.qml` `onMapClicked`, the `showCreateFromTemplate` branch takes precedence over the armed Waypoint/ROI tool. Arming a tool never set `userSelectedManualCreation`, and setting home doesn't add plan items, so template-creation mode stayed active and every map click kept re-setting home. The default multi-rotor flow masked this because the Waypoint tool is disabled until a Takeoff item exists (which exits template mode first).

## Fix

Arming the Waypoint or ROI click-to-insert tool now sets `userSelectedManualCreation = true`, exiting template-creation mode so map clicks fall through to item insertion. Clearing the plan still returns to template mode via the existing `_updateShowCreateFromTemplate()` reset.

## Tests

Added two `PlanViewUITest` cases (written first, verified failing on the bug before the fix):
- `_testRoverWaypointOnEmptyPlan` — Rover: no Takeoff button, Waypoint armed on an empty plan inserts a waypoint and home does not move.
- `_testTakeoffNotRequiredWaypointOnEmptyPlan` — Multi-rotor with `takeoffItemNotRequired`: same flow with the Takeoff button visible.

Both also verify the home-position gate (Waypoint disabled before home is set). Existing `_testPlanViewStates` (including the Clear -> template-mode round trip) and `PlanViewLayerUITest` still pass.
