### PR TITLE
fix(MainWindow): don't warn about unsaved mission after successful upload or save

### DIFF
--- a/src/MainWindow/MainWindow.qml
+++ b/src/MainWindow/MainWindow.qml
@@ -236,7 +236,12 @@ ApplicationWindow {
     }
 
     function checkForUnsavedMission() {
-        if (planView._planMasterController.dirtyForSave || planView._planMasterController.dirtyForUpload) {
+        // Only warn when edits are neither saved to disk nor uploaded to the vehicle.
+        // If either happened the edits are recoverable, so closing loses nothing.
+        // With no active vehicle an upload can't have happened, so treat the plan as
+        // not uploaded regardless of dirtyForUpload.
+        if (planView._planMasterController.dirtyForSave &&
+                (planView._planMasterController.dirtyForUpload || !QGroundControl.multiVehicleManager.activeVehicle)) {
             let accepted = false
             _reentrantCloseGuard = true
             _showMessageDialogWorker(mainWindow, qsTr("Unsaved Mission"),

--- a/test/QmlUITests/AppCloseWarningUITest.cc
+++ b/test/QmlUITests/AppCloseWarningUITest.cc
@@ -3,6 +3,7 @@
 #include <QtCore/QPointer>
 #include <QtCore/QRegularExpression>
 #include <QtCore/QScopeGuard>
+#include <QtCore/QTemporaryDir>
 #include <QtQuick/QQuickItem>
 #include <QtQuick/QQuickWindow>
 #include <QtTest/QTest>
@@ -16,17 +17,27 @@
 
 UT_REGISTER_TEST(AppCloseWarningUITest, TestLabel::Integration, TestLabel::MissionManager)
 
-bool AppCloseWarningUITest::_forcePlanViewMissionDirty()
+PlanMasterController *AppCloseWarningUITest::_planViewMasterController()
 {
     QQuickItem *planView = _window ? _window->findChild<QQuickItem *>(QStringLiteral("mainView_plan")) : nullptr;
     if (!planView) {
         QTest::qFail("Could not find Plan view item (mainView_plan)", __FILE__, __LINE__);
-        return false;
+        return nullptr;
     }
 
     auto *masterController = qvariant_cast<PlanMasterController *>(planView->property("_planMasterController"));
     if (!masterController) {
         QTest::qFail("Plan view _planMasterController property is not a PlanMasterController", __FILE__, __LINE__);
+        return nullptr;
+    }
+
+    return masterController;
+}
+
+bool AppCloseWarningUITest::_forcePlanViewMissionDirty()
+{
+    PlanMasterController *masterController = _planViewMasterController();
+    if (!masterController) {
         return false;
     }
 
@@ -218,5 +229,96 @@ void AppCloseWarningUITest::_testNoUnsavedMissionWarningForDownloadedMission()
             // "mission edit in progress" even though nothing was edited.
             QVERIFY2(!dialogVisible(QStringLiteral("Unsaved Mission")),
                      "Unsaved mission warning shown for a freshly downloaded, unedited plan");
+        });
+}
+
+void AppCloseWarningUITest::_testNoUnsavedMissionWarningAfterSuccessfulUpload()
+{
+    // Incidental one-time startup message when the map cache DB is upgraded.
+    ignoreLogMessage("API.QGCApplication.AppMessage", QtDebugMsg,
+                     QRegularExpression(QStringLiteral("Offline Map Cache database has been upgraded")));
+
+    runWithMockLink(
+        [] { return MockLink::startPX4MockLink(false /* sendStatusText */, false /* enableCamera */, false /* enableGimbal */); },
+        [this](QPointer<MockLink> mockLink, Vehicle *vehicle) {
+            Q_UNUSED(mockLink);
+            Q_UNUSED(vehicle);
+
+            PlanMasterController *masterController = _planViewMasterController();
+            if (!masterController) {
+                return;
+            }
+
+            // Edit the plan, then upload it to the vehicle.
+            masterController->missionController()->setDirty(true);
+            QVERIFY2(masterController->dirtyForSave() && masterController->dirtyForUpload(),
+                     "Dirtying the mission controller did not propagate to the master controller");
+
+            masterController->sendToVehicle();
+            QTRY_VERIFY_WITH_TIMEOUT(!masterController->syncInProgress() && !masterController->dirtyForUpload(), TestTimeout::mediumMs());
+
+            // The plan was never saved to disk, only uploaded.
+            QVERIFY(masterController->dirtyForSave());
+
+            QVERIFY2(clickToolSelectDropdownButton(QStringLiteral("toolbar_viewClose")),
+                     "Failed to click Close button in tool select dropdown");
+
+            // The active-connection check runs only after the unsaved-mission check
+            // passes. Waiting for its dialog to appear proves the mission check did
+            // not block.
+            QVERIFY2(waitForDialog(QStringLiteral("Active Vehicle Connections")),
+                     "Active vehicle connection warning dialog was not shown on close");
+
+            // The edits are safely on the vehicle, so closing loses nothing and the
+            // unsaved-mission warning must NOT appear (issue #14537).
+            QVERIFY2(!dialogVisible(QStringLiteral("Unsaved Mission")),
+                     "Unsaved mission warning shown after a successful mission upload");
+        });
+}
+
+void AppCloseWarningUITest::_testNoUnsavedMissionWarningAfterSaveToFile()
+{
+    // Incidental one-time startup message when the map cache DB is upgraded.
+    ignoreLogMessage("API.QGCApplication.AppMessage", QtDebugMsg,
+                     QRegularExpression(QStringLiteral("Offline Map Cache database has been upgraded")));
+
+    QTemporaryDir tempDir;
+    QVERIFY(tempDir.isValid());
+
+    runWithMockLink(
+        [] { return MockLink::startPX4MockLink(false /* sendStatusText */, false /* enableCamera */, false /* enableGimbal */); },
+        [this, &tempDir](QPointer<MockLink> mockLink, Vehicle *vehicle) {
+            Q_UNUSED(mockLink);
+            Q_UNUSED(vehicle);
+
+            PlanMasterController *masterController = _planViewMasterController();
+            if (!masterController) {
+                return;
+            }
+
+            // Edit the plan, then save it to disk without uploading.
+            masterController->missionController()->setDirty(true);
+            QVERIFY2(masterController->dirtyForSave() && masterController->dirtyForUpload(),
+                     "Dirtying the mission controller did not propagate to the master controller");
+
+            QVERIFY(masterController->saveToFile(tempDir.filePath(QStringLiteral("close-warning-test"))));
+
+            // Saving clears dirty-for-save but the plan was never uploaded.
+            QVERIFY(!masterController->dirtyForSave());
+            QVERIFY(masterController->dirtyForUpload());
+
+            QVERIFY2(clickToolSelectDropdownButton(QStringLiteral("toolbar_viewClose")),
+                     "Failed to click Close button in tool select dropdown");
+
+            // The active-connection check runs only after the unsaved-mission check
+            // passes. Waiting for its dialog to appear proves the mission check did
+            // not block.
+            QVERIFY2(waitForDialog(QStringLiteral("Active Vehicle Connections")),
+                     "Active vehicle connection warning dialog was not shown on close");
+
+            // The edits are safely on disk, so closing loses nothing and the
+            // unsaved-mission warning must NOT appear.
+            QVERIFY2(!dialogVisible(QStringLiteral("Unsaved Mission")),
+                     "Unsaved mission warning shown after saving the plan to disk");
         });
 }

--- a/test/QmlUITests/AppCloseWarningUITest.h
+++ b/test/QmlUITests/AppCloseWarningUITest.h
@@ -2,6 +2,8 @@
 
 #include "QmlUITestBase.h"
 
+class PlanMasterController;
+
 /// UI tests for the application close warning dialogs.
 ///
 /// On close MainWindow runs a sequence of checks (unsaved mission, pending
@@ -14,6 +16,11 @@
 /// A separate test verifies that a freshly downloaded (unedited) mission does
 /// NOT raise the unsaved-mission warning, because a downloaded plan reflects
 /// exactly what is on the vehicle and must not be considered dirty.
+///
+/// Another test verifies that a successfully uploaded mission does NOT raise
+/// the unsaved-mission warning either: the edits are safe on the vehicle, so
+/// nothing is lost by closing (see issue #14537). The same applies to a plan
+/// saved to disk but not uploaded.
 class AppCloseWarningUITest : public QmlUITestBase
 {
     Q_OBJECT
@@ -25,8 +32,14 @@ private slots:
     void _testCloseWarningMatrix_data();
     void _testCloseWarningMatrix();
     void _testNoUnsavedMissionWarningForDownloadedMission();
+    void _testNoUnsavedMissionWarningAfterSuccessfulUpload();
+    void _testNoUnsavedMissionWarningAfterSaveToFile();
 
 private:
+    /// Returns the Plan view's PlanMasterController, or nullptr (after recording
+    /// a test failure) if it cannot be reached.
+    PlanMasterController *_planViewMasterController();
+
     /// Force the Plan view's (offline) mission into a dirty-for-save state so the
     /// unsaved-mission close warning fires, without editing the mission through
     /// the UI. Returns false (after recording a test failure) if the plan


### PR DESCRIPTION
Fixes #14537

## Problem

The close-time "Unsaved Mission" warning fired whenever `dirtyForSave || dirtyForUpload` was set. A successful mission upload only clears `dirtyForUpload`, so the sequence plan → upload → close always warned about an "unsaved mission" even though the edits were safely on the vehicle. The same happened for a plan saved to disk but not uploaded.

## Fix

Only warn when the edits are neither saved to disk nor uploaded to the vehicle — i.e. when closing would actually lose something:

```qml
if (planView._planMasterController.dirtyForSave &&
        (planView._planMasterController.dirtyForUpload || !QGroundControl.multiVehicleManager.activeVehicle)) {
```

The `!activeVehicle` term is a safety net: with no active vehicle an upload can't be counted on, so any save-dirty plan still warns.

## Tests

Two new UI test cases in `AppCloseWarningUITest` (TDD — both fail against the old condition):

- `_testNoUnsavedMissionWarningAfterSuccessfulUpload` — edit, upload to MockLink vehicle, close: no unsaved-mission warning.
- `_testNoUnsavedMissionWarningAfterSaveToFile` — edit, save to disk, close: no unsaved-mission warning.
