### PR TITLE
fix(MockLink): encode sub-handler messages on dedicated outgoing channel

### DIFF
--- a/src/Comms/MockLink/MockLink.h
+++ b/src/Comms/MockLink/MockLink.h
@@ -96,6 +96,9 @@ public:
     /// Returns the filename for the simulated log file. Only available after a download is requested.
     QString logDownloadFile() const { return _logDownloadFilename; }
 
+    /// Vehicle-side channel used to encode outgoing (mock vehicle -> QGC) messages. Signing state lives here.
+    uint8_t outgoingMavlinkChannel() const { return _outgoingMavlinkChannel; }
+
     void clearReceivedMavCommandCounts() { _receivedMavCommandCountMap.clear(); _receivedMavCommandByCompCountMap.clear(); _receivedRequestMessageByCompAndMsgCountMap.clear(); }
     int receivedMavCommandCount(MAV_CMD command) const { return _receivedMavCommandCountMap.value(command, 0); }
     int receivedMavCommandCount(MAV_CMD command, int compId) const { return _receivedMavCommandByCompCountMap.value(command).value(compId, 0); }

--- a/src/Comms/MockLink/MockLinkCamera.cc
+++ b/src/Comms/MockLink/MockLinkCamera.cc
@@ -78,7 +78,7 @@ void MockLinkCamera::sendCameraHeartbeats()
         (void) mavlink_msg_heartbeat_pack_chan(
             _mockLink->vehicleId(),
             _cameras[i].compId,
-            _mockLink->mavlinkChannel(),
+            _mockLink->outgoingMavlinkChannel(),
             &msg,
             MAV_TYPE_CAMERA,
             MAV_AUTOPILOT_INVALID,
@@ -540,7 +540,7 @@ void MockLinkCamera::_sendCameraInformation(uint8_t compId)
     (void) mavlink_msg_camera_information_pack_chan(
         _mockLink->vehicleId(),
         compId,
-        _mockLink->mavlinkChannel(),
+        _mockLink->outgoingMavlinkChannel(),
         &msg,
         0,                                              // time_boot_ms
         vendorName,
@@ -573,7 +573,7 @@ void MockLinkCamera::_sendCameraSettings(uint8_t compId)
     (void) mavlink_msg_camera_settings_pack_chan(
         _mockLink->vehicleId(),
         compId,
-        _mockLink->mavlinkChannel(),
+        _mockLink->outgoingMavlinkChannel(),
         &msg,
         0,                  // time_boot_ms
         cam->cameraMode,    // mode_id
@@ -596,7 +596,7 @@ void MockLinkCamera::_sendStorageInformation(uint8_t compId)
     (void) mavlink_msg_storage_information_pack_chan(
         _mockLink->vehicleId(),
         compId,
-        _mockLink->mavlinkChannel(),
+        _mockLink->outgoingMavlinkChannel(),
         &msg,
         0,                                      // time_boot_ms
         1,                                      // storage_id
@@ -626,7 +626,7 @@ void MockLinkCamera::_sendCameraCaptureStatus(uint8_t compId)
     (void) mavlink_msg_camera_capture_status_pack_chan(
         _mockLink->vehicleId(),
         compId,
-        _mockLink->mavlinkChannel(),
+        _mockLink->outgoingMavlinkChannel(),
         &msg,
         0,                                              // time_boot_ms
         cam->image_status,                              // image_status (ImageCaptureStatus enum)
@@ -664,7 +664,7 @@ void MockLinkCamera::_sendCameraImageCaptured(uint8_t compId)
     (void) mavlink_msg_camera_image_captured_pack_chan(
         _mockLink->vehicleId(),
         compId,
-        _mockLink->mavlinkChannel(),
+        _mockLink->outgoingMavlinkChannel(),
         &msg,
         0,                                              // time_boot_ms
         0,                                              // time_utc
@@ -698,7 +698,7 @@ void MockLinkCamera::_sendVideoStreamInformation(uint8_t compId, uint8_t streamI
     (void) mavlink_msg_video_stream_information_pack_chan(
         _mockLink->vehicleId(),
         compId,
-        _mockLink->mavlinkChannel(),
+        _mockLink->outgoingMavlinkChannel(),
         &msg,
         streamId,                               // stream_id
         kNumStreams,                            // count
@@ -725,7 +725,7 @@ void MockLinkCamera::_sendVideoStreamStatus(uint8_t compId, uint8_t streamId)
     (void) mavlink_msg_video_stream_status_pack_chan(
         _mockLink->vehicleId(),
         compId,
-        _mockLink->mavlinkChannel(),
+        _mockLink->outgoingMavlinkChannel(),
         &msg,
         streamId,                               // stream_id
         VIDEO_STREAM_STATUS_FLAGS_RUNNING,      // flags
@@ -752,7 +752,7 @@ void MockLinkCamera::_sendCameraTrackingImageStatus(uint8_t compId)
     (void) mavlink_msg_camera_tracking_image_status_pack_chan(
         _mockLink->vehicleId(),
         compId,
-        _mockLink->mavlinkChannel(),
+        _mockLink->outgoingMavlinkChannel(),
         &msg,
         CAMERA_TRACKING_STATUS_FLAGS_ACTIVE,    // tracking_status
         cam->trackingMode,                      // tracking_mode
@@ -774,7 +774,7 @@ void MockLinkCamera::_sendCommandAck(uint8_t compId, uint16_t command, uint8_t r
     (void) mavlink_msg_command_ack_pack_chan(
         _mockLink->vehicleId(),
         compId,
-        _mockLink->mavlinkChannel(),
+        _mockLink->outgoingMavlinkChannel(),
         &msg,
         command,
         result,

--- a/src/Comms/MockLink/MockLinkFTP.cc
+++ b/src/Comms/MockLink/MockLinkFTP.cc
@@ -545,7 +545,7 @@ void MockLinkFTP::_sendResponse(uint8_t targetSystemId, uint8_t targetComponentI
     (void) mavlink_msg_file_transfer_protocol_pack_chan(
         _systemIdServer,                    // System ID
         _componentIdServer,                 // Component ID
-        _mockLink->mavlinkChannel(),
+        _mockLink->outgoingMavlinkChannel(),
         &_lastReply,                        // Mavlink Message to pack into
         0,                                  // Target network
         targetSystemId,

--- a/src/Comms/MockLink/MockLinkGimbal.cc
+++ b/src/Comms/MockLink/MockLinkGimbal.cc
@@ -120,7 +120,7 @@ void MockLinkGimbal::_sendCommandAck(uint16_t command, uint8_t result, uint8_t s
     (void) mavlink_msg_command_ack_pack_chan(
         _mockLink->vehicleId(),
         sourceCompId,
-        _mockLink->mavlinkChannel(),
+        _mockLink->outgoingMavlinkChannel(),
         &msg,
         command,
         result,
@@ -274,7 +274,7 @@ void MockLinkGimbal::_sendGimbalManagerStatus()
     (void) mavlink_msg_gimbal_manager_status_pack_chan(
         _mockLink->vehicleId(),
         MAV_COMP_ID_AUTOPILOT1,
-        _mockLink->mavlinkChannel(),
+        _mockLink->outgoingMavlinkChannel(),
         &msg,
         0, // time_boot_ms
         0, // flags
@@ -312,7 +312,7 @@ void MockLinkGimbal::_sendGimbalDeviceAttitudeStatus()
     (void) mavlink_msg_gimbal_device_attitude_status_pack_chan(
         _mockLink->vehicleId(),
         kGimbalCompId,
-        _mockLink->mavlinkChannel(),
+        _mockLink->outgoingMavlinkChannel(),
         &msg,
         0, 0,   // target system, component
         0,      // time_boot_ms
@@ -343,7 +343,7 @@ void MockLinkGimbal::_sendGimbalManagerInformation()
     (void) mavlink_msg_gimbal_manager_information_pack_chan(
         _mockLink->vehicleId(),
         MAV_COMP_ID_AUTOPILOT1,
-        _mockLink->mavlinkChannel(),
+        _mockLink->outgoingMavlinkChannel(),
         &msg,
         0, // time_boot_ms
         capFlags,

--- a/src/Comms/MockLink/MockLinkMissionItemHandler.cc
+++ b/src/Comms/MockLink/MockLinkMissionItemHandler.cc
@@ -171,7 +171,7 @@ void MockLinkMissionItemHandler::_handleMissionRequestList(const mavlink_message
     (void) mavlink_msg_mission_count_pack_chan(
         _mockLink->vehicleId(),
         MAV_COMP_ID_AUTOPILOT1,
-        _mockLink->mavlinkChannel(),
+        _mockLink->outgoingMavlinkChannel(),
         &responseMsg,               // Outgoing message
         msg.sysid,                  // Target is original sender
         msg.compid,                 // Target is original sender
@@ -250,7 +250,7 @@ void MockLinkMissionItemHandler::_handleMissionRequest(const mavlink_message_t &
     (void) mavlink_msg_mission_item_int_pack_chan(
         _mockLink->vehicleId(),
         MAV_COMP_ID_AUTOPILOT1,
-        _mockLink->mavlinkChannel(),
+        _mockLink->outgoingMavlinkChannel(),
         &responseMsg,                // Outgoing message
         msg.sysid,                   // Target is original sender
         msg.compid,                  // Target is original sender
@@ -342,7 +342,7 @@ void MockLinkMissionItemHandler::_requestNextMissionItem(int sequenceNumber)
     (void) mavlink_msg_mission_request_int_pack_chan(
         _mockLink->vehicleId(),
         MAV_COMP_ID_AUTOPILOT1,
-        _mockLink->mavlinkChannel(),
+        _mockLink->outgoingMavlinkChannel(),
         &message,
         MAVLinkProtocol::instance()->getSystemId(),
         MAVLinkProtocol::getComponentId(),
@@ -363,7 +363,7 @@ void MockLinkMissionItemHandler::_sendAck(MAV_MISSION_RESULT ackType) const
     (void) mavlink_msg_mission_ack_pack_chan(
         _mockLink->vehicleId(),
         MAV_COMP_ID_AUTOPILOT1,
-        _mockLink->mavlinkChannel(),
+        _mockLink->outgoingMavlinkChannel(),
         &message,
         MAVLinkProtocol::instance()->getSystemId(),
         MAVLinkProtocol::getComponentId(),

--- a/test/MAVLink/Signing/MockLinkSigningTest.cc
+++ b/test/MAVLink/Signing/MockLinkSigningTest.cc
@@ -7,6 +7,8 @@
 
 #include "MAVLinkSigning.h"
 #include "MAVLinkSigningKeys.h"
+#include "MissionItem.h"
+#include "MissionManager.h"
 #include "QmlObjectListModel.h"
 #include "SigningController.h"
 #include "Vehicle.h"
@@ -41,7 +43,7 @@ void MockLinkSigningTest::_testSendSetupSigning()
     QVERIFY(mockLink());
 
     auto* signingKeys = MAVLinkSigningKeys::instance();
-    signingKeys->addKey("TestKey", "TestPassphrase");
+    QVERIFY(signingKeys->addKey("TestKey", "TestPassphrase"));
     QVERIFY(signingKeys->keyAt(0));
     QCOMPARE(static_cast<int>(signingKeys->keyAt(0)->keyBytes().size()), 32);
 
@@ -64,7 +66,7 @@ void MockLinkSigningTest::_testSendDisableSigning()
     QVERIFY(mockLink());
 
     auto* signingKeys = MAVLinkSigningKeys::instance();
-    signingKeys->addKey("TestKey2", "TestPassphrase2");
+    QVERIFY(signingKeys->addKey("TestKey2", "TestPassphrase2"));
 
     vehicle()->signingController()->enable(QStringLiteral("TestKey2"));
     QVERIFY_TRUE_WAIT(mockLink()->signingEnabled(), TestTimeout::mediumMs());
@@ -95,7 +97,7 @@ void MockLinkSigningTest::_testSigningEnableTimeout()
     expectAppMessage(QRegularExpression("Signing setup not confirmed by vehicle"));
 
     auto* signingKeys = MAVLinkSigningKeys::instance();
-    signingKeys->addKey("BadKey", "BadPassphrase");
+    QVERIFY(signingKeys->addKey("BadKey", "BadPassphrase"));
 
     // Comm is lost, so only the FSM timeout resolves this — shorten it to avoid the production 5s wait.
     SigningController::setTimeoutForTesting(std::chrono::milliseconds(500));
@@ -121,14 +123,14 @@ void MockLinkSigningTest::_testSigningKeysAddRemove()
     QCOMPARE(signingKeys->keys()->count(), 0);
 
     QSignalSpy spy(signingKeys, &MAVLinkSigningKeys::keysChanged);
-    signingKeys->addKey("Key1", "pass1pass");
+    QVERIFY(signingKeys->addKey("Key1", "pass1pass"));
     QCOMPARE(signingKeys->keys()->count(), 1);
     QCOMPARE(signingKeys->keyAt(0)->name(), "Key1");
     QCOMPARE(static_cast<int>(signingKeys->keyAt(0)->keyBytes().size()), 32);
     QVERIFY(spy.count() > 0);
 
     spy.clear();
-    signingKeys->addKey("Key2", "pass2pass");
+    QVERIFY(signingKeys->addKey("Key2", "pass2pass"));
     QCOMPARE(signingKeys->keys()->count(), 2);
     QCOMPARE(signingKeys->keyAt(1)->name(), "Key2");
     QVERIFY(spy.count() > 0);
@@ -147,7 +149,7 @@ void MockLinkSigningTest::_testSigningPendingState()
     QVERIFY(mockLink());
 
     auto* signingKeys = MAVLinkSigningKeys::instance();
-    signingKeys->addKey("PendingKey", "PendingPass");
+    QVERIFY(signingKeys->addKey("PendingKey", "PendingPass"));
 
     QVERIFY(!vehicle()->signingController()->signingStatus().pending());
 
@@ -183,7 +185,7 @@ void MockLinkSigningTest::_testSigningStatusChangedSignalFiresOnEnable()
     QVERIFY(mockLink());
 
     auto* signingKeys = MAVLinkSigningKeys::instance();
-    signingKeys->addKey("SignalKey", "SignalPass");
+    QVERIFY(signingKeys->addKey("SignalKey", "SignalPass"));
 
     QSignalSpy spy(vehicle()->signingController(), &VehicleSigningController::signingStatusChanged);
     vehicle()->signingController()->enable(QStringLiteral("SignalKey"));
@@ -201,8 +203,8 @@ void MockLinkSigningTest::_testEnableDisableReEnableCycle()
     QVERIFY(mockLink());
 
     auto* signingKeys = MAVLinkSigningKeys::instance();
-    signingKeys->addKey("CycleA", "CyclePassphraseA");
-    signingKeys->addKey("CycleB", "CyclePassphraseB");
+    QVERIFY(signingKeys->addKey("CycleA", "CyclePassphraseA"));
+    QVERIFY(signingKeys->addKey("CycleB", "CyclePassphraseB"));
 
     auto* const sc = vehicle()->signingController();
     QSignalSpy failedSpy(sc, &VehicleSigningController::signingFailed);
@@ -222,6 +224,63 @@ void MockLinkSigningTest::_testEnableDisableReEnableCycle()
     QVERIFY(mockLink()->signingEnabled());
 
     QCOMPARE(failedSpy.count(), 0);
+}
+
+// Regression: MockLink sub-handlers (MockLinkMissionItemHandler et al) encode replies on MockLink's dedicated
+// outgoing channel, whose signing state is independent of QGC's channel. If those replies fell off the signed
+// stream while signing is active, QGC would silently drop them and mission transfer would time out. Verify a
+// full mission write/read cycle completes with signing enabled.
+void MockLinkSigningTest::_testMissionTransferWithSigningEnabled()
+{
+    QVERIFY(vehicle());
+    QVERIFY(mockLink());
+
+    auto* signingKeys = MAVLinkSigningKeys::instance();
+    QVERIFY(signingKeys->addKey("MissionKey", "MissionPassphrase"));
+
+    vehicle()->signingController()->enable(QStringLiteral("MissionKey"));
+    QVERIFY_TRUE_WAIT(mockLink()->signingEnabled(), TestTimeout::mediumMs());
+    QVERIFY_TRUE_WAIT(vehicle()->signingController()->signingStatus().enabled, TestTimeout::mediumMs());
+
+    MissionManager* const missionManager = vehicle()->missionManager();
+    QVERIFY(missionManager);
+
+    const auto makeItem = [this](int seq, double lat, double lon, double alt) {
+        MissionItem* const item = new MissionItem(this);
+        item->setCommand(MAV_CMD_NAV_WAYPOINT);
+        item->setFrame(MAV_FRAME_GLOBAL_RELATIVE_ALT);
+        item->setParam5(lat);
+        item->setParam6(lon);
+        item->setParam7(alt);
+        item->setSequenceNumber(seq);
+        return item;
+    };
+
+    // Write: home item at seq 0 plus two waypoints (1-based sequence numbers)
+    QList<MissionItem*> missionItems;
+    missionItems.append(makeItem(0, 47.3769, 8.549444, 0.0));
+    missionItems.append(makeItem(1, 47.3770, 8.5500, 50.0));
+    missionItems.append(makeItem(2, 47.3780, 8.5510, 50.0));
+
+    QSignalSpy sendCompleteSpy(missionManager, &MissionManager::sendComplete);
+    missionManager->writeMissionItems(missionItems);
+    QVERIFY(missionManager->inProgress());
+    QTRY_COMPARE_WITH_TIMEOUT(sendCompleteSpy.count(), 1, TestTimeout::mediumMs());
+    QCOMPARE(sendCompleteSpy.takeFirst().at(0).toBool(), false); // error == false
+
+    // Read back: replies (MISSION_COUNT/MISSION_ITEM_INT/MISSION_ACK) are encoded on the outgoing channel
+    QSignalSpy newItemsSpy(missionManager, &MissionManager::newMissionItemsAvailable);
+    missionManager->loadFromVehicle();
+    QTRY_COMPARE_WITH_TIMEOUT(newItemsSpy.count(), 1, TestTimeout::mediumMs());
+    QVERIFY(!missionManager->inProgress());
+
+    int expectedCount = 2; // home item is stripped on read for PX4
+    if (mockLink()->getFirmwareType() == MAV_AUTOPILOT_ARDUPILOTMEGA) {
+        expectedCount++; // Home position at index 0 comes from vehicle
+    }
+    QCOMPARE(missionManager->missionItems().count(), expectedCount);
+
+    QVERIFY(mockLink()->signingEnabled());
 }
 
 UT_REGISTER_TEST(MockLinkSigningTest, TestLabel::Integration, TestLabel::Vehicle)

--- a/test/MAVLink/Signing/MockLinkSigningTest.h
+++ b/test/MAVLink/Signing/MockLinkSigningTest.h
@@ -20,4 +20,5 @@ private slots:
     void _testSigningPendingState();
     void _testSigningStatusChangedSignalFiresOnEnable();
     void _testEnableDisableReEnableCycle();
+    void _testMissionTransferWithSigningEnabled();
 };


### PR DESCRIPTION
## Summary

MockLink sub-handlers (`MockLinkCamera`, `MockLinkGimbal`, `MockLinkMissionItemHandler`, `MockLinkFTP`) were still encoding outgoing messages on QGC's shared `LinkInterface::mavlinkChannel()`, piggy-backing on QGC's signing context. This completes the channel separation started earlier by switching all 19 remaining `mavlink_msg_*_pack_chan` call sites to MockLink's dedicated outgoing channel via a new `outgoingMavlinkChannel()` accessor.

This means the simulated vehicle now:
- Maintains its own independent signing state (own key, own `link_id`, own timestamps)
- Emits all vehicle-side traffic with a single unified sequence counter (previously split across two channels, which QGC's seq-loss accounting could misread as packet drops)
- More accurately simulates a real vehicle with fully independent MAVLink channels

## Test coverage

Adds `MockLinkSigningTest::_testMissionTransferWithSigningEnabled`: enables signing with a real key, then runs a full mission write/read cycle. Every reply in that exchange (MISSION_COUNT, MISSION_REQUEST_INT, MISSION_ITEM_INT, MISSION_ACK) is encoded by the sub-handler on the outgoing channel, so any regression where sub-handler traffic falls off the signed stream fails the test with a transfer timeout.

## Verification

- `MockLinkSigningTest` passes (8 tests including the new one)
- All affected suites green: MissionManagerTest, MissionControllerTest, FTPManagerTest, FTPControllerTest, QGCCameraManagerTest, VehicleCameraControlTest, SigningTest, SigningStatusTest, SigningControllerTest

Fixes #14166