### PR TITLE
fix(facts): correct EFI intake manifold shortDesc spelling

### DIFF
--- a/src/Vehicle/FactGroups/EFIFact.json
+++ b/src/Vehicle/FactGroups/EFIFact.json
@@ -65,14 +65,14 @@
 },
 {
     "name":             "intakePress",
-    "shortDesc":        "Intake mainfold pressure",
+    "shortDesc":        "Intake manifold pressure",
     "type":             "float",
     "decimalPlaces":    1,
     "units":            "kPa"
 },
 {
     "name":             "intakeTemp",
-    "shortDesc":        "Intake mainfold temperature",
+    "shortDesc":        "Intake manifold temperature",
     "type":             "float",
     "decimalPlaces":    1,
     "units":            "°C"


### PR DESCRIPTION
### Summary
Operator-facing EFI fact labels had a long-standing typo: **mainfold** → **manifold** for intake pressure and temperature.

### Why
Makes sensor chips match engine terminology pilot/maintainers already use.

### Test plan
- Inspect `src/Vehicle/FactGroups/EFIFact.json` diff (2 strings)
- No runtime/logic change

AI-assisted; human-reviewed.
