### PR TITLE
fix(facts): use RPM shortDesc for ESC rotation rate

### DIFF
--- a/src/Vehicle/FactGroups/EscStatusFactGroup.json
+++ b/src/Vehicle/FactGroups/EscStatusFactGroup.json
@@ -10,7 +10,7 @@
 },
 {
     "name":             "rpm",
-    "shortDesc":        "Rotation Per Minute",
+    "shortDesc":        "RPM",
     "type":             "float",
     "decimalPlaces":    2,
     "default":          null


### PR DESCRIPTION
## What
Replace EscStatus `rpm` shortDesc "Rotation Per Minute" with the standard abbreviation **RPM**.

## Motivation
Telemetry panels are dense; RPM is universal and matches generator fact style (`units: rpm`).

## Verification
JSON-only metadata; no unit conversion change.

Reviewed by hand on master tip.
