### PR TITLE
fix(facts): capitalize Generator runtime shortDesc

### DIFF
--- a/src/Vehicle/FactGroups/GeneratorFact.json
+++ b/src/Vehicle/FactGroups/GeneratorFact.json
@@ -63,7 +63,7 @@
 },
 {
     "name":             "runtime",
-    "shortDesc":        "runtime",
+    "shortDesc":        "Runtime",
     "type":             "uint32",
     "units":            "sec"
 },


### PR DESCRIPTION
Capitalizes the Generator fact `runtime` shortDesc (`runtime` → `Runtime`) so it matches nearby labels like "Time until Maintenance".

Tiny UI consistency fix. No behavior change.

AI-assisted; human-reviewed.
