### PR TITLE
fix(facts): capitalize IMU temperature shortDesc

### DIFF
--- a/src/Vehicle/FactGroups/VehicleFact.json
+++ b/src/Vehicle/FactGroups/VehicleFact.json
@@ -174,7 +174,7 @@
 },
 {
     "name":             "imuTemp",
-    "shortDesc": "Imu temperature",
+    "shortDesc": "IMU temperature",
     "type":             "int16",
     "units":            "°C"
 },


### PR DESCRIPTION
### Change
`VehicleFact.json` imuTemp shortDesc: **Imu temperature** → **IMU temperature**.

### Notes
Cosmetic chip text only. Safe for all vehicle types.

### How checked
Single-string review against upstream master.
