### PR TITLE
fix(facts): use SI capital V for battery voltage units

### DIFF
--- a/src/Vehicle/FactGroups/BatteryFact.json
+++ b/src/Vehicle/FactGroups/BatteryFact.json
@@ -29,7 +29,7 @@
     "shortDesc":        "Voltage",
     "type":             "double",
     "decimalPlaces":    2,
-    "units":            "v"
+    "units":            "V"
 },
 {
     "name":             "percentRemaining",


### PR DESCRIPTION
Battery voltage fact used units `"v"` while Esc/Generator voltage facts use `"V"`. Align battery metadata unit casing to SI capital V.

No conversion table change expected; Fact units string only.

AI-assisted; human-reviewed. Path-orthogonal to other fact PRs tonight.
