### PR TITLE
fix(FlyView): prevent map pinch-zoom from stealing virtual joystick touches

### DIFF
--- a/android/res/drawable/ic_launcher_foreground.xml
+++ b/android/res/drawable/ic_launcher_foreground.xml
@@ -1,0 +1,28 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- Adaptive icon foreground: QGC logo only (no background plate), scaled to fit
+     within the 66/108dp safe zone so launcher masks (circle/squircle/rounded
+     square) never clip the artwork. Derived from resources/QGCLogoFull.svg. -->
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="108dp"
+    android:height="108dp"
+    android:viewportWidth="72"
+    android:viewportHeight="72">
+    <group
+        android:scaleX="0.8"
+        android:scaleY="0.8"
+        android:translateX="6.57"
+        android:translateY="7.01">
+        <path
+            android:fillColor="#5ECBF1"
+            android:pathData="M34.7 12.607h-.137c-11.423.992-20.52 10.123-21.546 21.546v.24c0 .752.616 1.334 1.334 1.334s1.3-.581 1.334-1.265c.855-10.157 8.96-18.263 19.084-19.152a1.333 1.333 0 0 0 1.265-1.265v-.068c.034-.788-.581-1.37-1.334-1.37"/>
+        <path
+            android:fillColor="#5ECBF1"
+            android:pathData="M34.7 17.908h-.171c-8.584.992-15.39 7.969-16.211 16.279v.171c0 .752.616 1.334 1.334 1.334s1.3-.581 1.334-1.265v-.034c.855-7.25 6.566-12.996 13.783-13.851a1.333 1.333 0 0 0 1.265-1.265v-.068c.034-.719-.581-1.301-1.334-1.301"/>
+        <path
+            android:fillColor="#5ECBF1"
+            android:pathData="M34.7 23.243c-.068 0-.171 0-.239.034-5.506.923-9.85 5.301-10.773 10.807v.034c0 .068-.034.205-.034.239 0 .752.581 1.334 1.334 1.334h.171c.616-.068 1.129-.581 1.163-1.197v-.137c.787-4.275 4.172-7.661 8.482-8.447h.068c.65-.068 1.163-.616 1.163-1.265v-.068c.033-.718-.582-1.334-1.335-1.334"/>
+        <path
+            android:fillColor="#FFFFFF"
+            android:pathData="m49.748 55.802-3.659-3.659c-2.736 1.642-5.951 2.565-9.371 2.565-9.508 0-17.374-7.216-18.331-16.484h7.969a10.52 10.52 0 0 0 11.423 8.55 9.4 9.4 0 0 0 2.394-.547l-3.728-3.728 5.609-5.609 4.07 4.036c.547-1.129.923-2.36 1.06-3.659.547-5.643-3.352-10.465-8.584-11.389v-7.969c9.268.958 16.519 8.789 16.519 18.331 0 3.865-1.197 7.49-3.249 10.431l3.488 3.488z"/>
+    </group>
+</vector>

--- a/android/res/mipmap-anydpi-v26/ic_launcher.xml
+++ b/android/res/mipmap-anydpi-v26/ic_launcher.xml
@@ -1,5 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <adaptive-icon xmlns:android="http://schemas.android.com/apk/res/android">
     <background android:drawable="@color/ic_launcher_background"/>
-    <foreground android:drawable="@drawable/icon"/>
+    <foreground android:drawable="@drawable/ic_launcher_foreground"/>
+    <monochrome android:drawable="@drawable/ic_launcher_foreground"/>
 </adaptive-icon>

--- a/android/res/values/ic_launcher_colors.xml
+++ b/android/res/values/ic_launcher_colors.xml
@@ -1,4 +1,4 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
-    <color name="ic_launcher_background">#FFFFFF</color>
+    <color name="ic_launcher_background">#4B2C6D</color>
 </resources>

--- a/src/FlightMap/FlightMap.qml
+++ b/src/FlightMap/FlightMap.qml
@@ -24,6 +24,7 @@ Map {
     property bool   firstGCSPositionReceived:       false   ///< true: first gcs position update was responded to
     property bool   firstVehiclePositionReceived:   false   ///< true: first vehicle position update was responded to
     property bool   planView:                       false   ///< true: map being using for Plan view, items should be draggable
+    property bool   pinchZoomDisabledByVirtualJoysticks: false ///< true: disable pinch-to-zoom while virtual joystick thumbs are down
 
     property var    _activeVehicle:             QGroundControl.multiVehicleManager.activeVehicle
     property var    _activeVehicleCoordinate:   _activeVehicle ? _activeVehicle.coordinate : QtPositioning.coordinate()
@@ -116,8 +117,14 @@ Map {
     signal mapPressAndHold(var position)
 
     PinchHandler {
-        id:     pinchHandler
-        target: null
+        id:      pinchHandler
+        target:  null
+        // Disabled while virtual joystick thumbs are down. The default grabPermissions include
+        // CanTakeOverFromItems, which lets this handler steal touch grabs from the joystick pads'
+        // MultiPointTouchAreas and zoom the map instead. The permission can't be removed since
+        // pinch on the map itself must take over from the panning MultiPointTouchArea below.
+        // See GitHub issue #13450.
+        enabled: !_map.pinchZoomDisabledByVirtualJoysticks
 
         property var pinchStartGeoCoord     // geo coordinate under centroid at pinch start
         property var pinchStartScreenPoint  // screen point of centroid at pinch start

--- a/src/FlyView/FlyViewWidgetLayer.qml
+++ b/src/FlyView/FlyViewWidgetLayer.qml
@@ -92,6 +92,13 @@ Item {
         rallyPointController:   _rallyPointController
     }
 
+    // Prevent the map's PinchHandler from stealing touch grabs from the joystick pads (issue #13450)
+    Binding {
+        target:   mapControl
+        property: "pinchZoomDisabledByVirtualJoysticks"
+        value:    virtualJoystickMultiTouch.visible && virtualJoystickMultiTouch.item && virtualJoystickMultiTouch.item.stickActive
+    }
+
     //-- Virtual Joystick
     Loader {
         id:                         virtualJoystickMultiTouch

--- a/src/FlyView/VirtualJoystick.qml
+++ b/src/FlyView/VirtualJoystick.qml
@@ -10,6 +10,8 @@ Item {
 
     id: virtualJoysticks
 
+    readonly property bool stickActive:       leftStick.touchActive || rightStick.touchActive
+
     property var   _activeVehicle:            QGroundControl.multiVehicleManager.activeVehicle
     property bool  _initialConnectComplete:   _activeVehicle ? _activeVehicle.initialConnectComplete : false
     property real  leftYAxisValue:            autoCenterThrottle ? height / 2 : height

--- a/src/QmlControls/JoystickThumbPad.qml
+++ b/src/QmlControls/JoystickThumbPad.qml
@@ -14,6 +14,7 @@ Item {
     property bool   yAxisReCenter:          false               ///< true: snaps back to center on release, false: stays at current position on release
     property real   xPositionDelta:         0                   ///< Amount to move the control on x axis
     property real   yPositionDelta:         0                   ///< Amount to move the control on y axis
+    property bool   touchActive:            false               ///< true: thumb is currently down on the pad
 
     property real   _centerXY:              width / 2
     property bool   _processTouchPoints:    false
@@ -256,7 +257,17 @@ Item {
         minimumTouchPoints:     1
         maximumTouchPoints:     1
         touchPoints:            [ TouchPoint { id: touchPoint } ]
-        onPressed:              touchPoints => _joyRoot.thumbDown(touchPoints)
-        onReleased:             _joyRoot.reCenter()
+        onPressed: touchPoints => {
+            _joyRoot.touchActive = true
+            _joyRoot.thumbDown(touchPoints)
+        }
+        onReleased: {
+            _joyRoot.touchActive = false
+            _joyRoot.reCenter()
+        }
+        onCanceled: {
+            _joyRoot.touchActive = false
+            _joyRoot.reCenter()
+        }
     }
 }


### PR DESCRIPTION
Fixes #13450
Fixes #13882

## Problem

With virtual joysticks enabled, resting both thumbs on the joystick pads caused the map to pinch-zoom instead of moving the sticks independently.

## Root Cause

The map's `PinchHandler` uses the default `grabPermissions`, which include `CanTakeOverFromItems`. This allows it to steal the exclusive touch grabs already held by the joystick pads' `MultiPointTouchArea`s and interpret the two touch points as a pinch gesture.

The permission can't simply be removed (the approach tried in #14396): pinch-to-zoom on the map itself requires taking over the first touch point from the map's own panning `MultiPointTouchArea`, which is also an Item.

## Fix

Disable the map's `PinchHandler` while any virtual joystick thumb is down:

- `JoystickThumbPad` exposes `touchActive` (set on press, cleared on release **and cancel** so a stolen/canceled touch can't leave pinch disabled)
- `VirtualJoystick` exposes `stickActive` (either stick touched)
- `FlyViewWidgetLayer` binds `mapControl.pinchZoomDisabledByVirtualJoysticks` to that state
- `FlightMap`'s `PinchHandler` is `enabled` only while the flag is clear

Pinch on the open map area, wheel zoom, and desktop trackpad behavior are unchanged. No `grabPermissions` were modified, avoiding the desktop regressions that blocked #14396.

## Second commit: Android adaptive icon fix

The launcher icon looked clipped/strange on modern Android launchers. The adaptive icon foreground was the full-bleed icon PNG (baked-in rounded-square background); launcher masks only guarantee the center 66/108dp safe zone, so the artwork was cropped.

- New vector-drawable foreground with just the QGC logo, centered on the Q ring and scaled to fit the safe zone
- Background layer changed from white to QGC purple (white Q stays visible, edges blend under any mask shape)
- Added `monochrome` layer for Android 13+ themed icons

## Testing

- qmllint passes on all touched QML
- Icon geometry verified numerically (max radial extent 19.1 units vs 22-unit safe radius) and via rendered mask previews
- Needs on-device verification: two thumbs on sticks move independently; pinch on open map still zooms
