### PR TITLE
fix(Joystick): preserve button assignments for actions not currently available

### DIFF
--- a/src/Joystick/Joystick.cc
+++ b/src/Joystick/Joystick.cc
@@ -242,13 +242,17 @@ void Joystick::_loadButtonSettings()
                 continue;
             }
             if (_findAvailableButtonActionIndex(actionName) == -1) {
-                qCWarning(JoystickLog)
+                // The action may not be available right now but may become available later.
+                // For example flight modes can change dynamically based on the standard modes
+                // protocol and are only known once a vehicle is connected. Keep the assignment
+                // and add it to the available actions list so the UI always shows it;
+                // _executeButtonAction() checks real availability at button press time.
+                qCDebug(JoystickLog)
                     << "    "
                     << "button:" << buttonIndex
-                    << "has unknown action name:" << actionName
-                    << ", clearing action from data";
-                buttonSettings.remove(QString::number(buttonIndex));
-                continue;
+                    << "action name not currently available:" << actionName
+                    << ", keeping assignment";
+                _addAvailableButtonActionIfMissing(actionName);
             }
             if (actionName == _buttonActionNone) {
                 buttonSettings.remove(QString::number(buttonIndex));
@@ -1682,6 +1686,19 @@ int Joystick::_findAvailableButtonActionIndex(const QString &action)
     return -1;
 }
 
+void Joystick::_addAvailableButtonActionIfMissing(const QString &action)
+{
+    if (_findAvailableButtonActionIndex(action) != -1) {
+        return;
+    }
+
+    // No onDown handler: _executeButtonAction() falls through to flight mode / MAVLink
+    // dispatch at button press time.
+    _availableButtonActions->append(new AvailableButtonAction(action, nullptr));
+    _availableActionTitles << action;
+    emit assignableActionsChanged();
+}
+
 void Joystick::_buildAvailableButtonsActionList(Vehicle *vehicle)
 {
     if (_availableButtonActions->count()) {
@@ -1800,6 +1817,17 @@ void Joystick::_buildAvailableButtonsActionList(Vehicle *vehicle)
     for (int i = 0; i < _mavlinkActionManager->actions()->count(); i++) {
         const MavlinkAction *const mavlinkAction = _mavlinkActionManager->actions()->value<const MavlinkAction*>(i);
         _availableButtonActions->append(new AvailableButtonAction(mavlinkAction->label(), nullptr));
+    }
+
+    // Always include actions currently assigned to buttons even if they are not otherwise
+    // available right now. Flight modes can change dynamically (standard modes protocol),
+    // so an assignment stored in settings may reference a mode which only shows up later.
+    // Keeping them in the list means the UI combo always displays the real assignment.
+    for (int buttonIndex = 0; buttonIndex < _assignedButtonActions.count(); buttonIndex++) {
+        const AssignedButtonAction *const assigned = _assignedButtonActions[buttonIndex];
+        if (assigned && (_findAvailableButtonActionIndex(assigned->actionName) == -1)) {
+            _availableButtonActions->append(new AvailableButtonAction(assigned->actionName, nullptr));
+        }
     }
 
     for (int i = 0; i < _availableButtonActions->count(); i++) {

--- a/src/Joystick/Joystick.h
+++ b/src/Joystick/Joystick.h
@@ -445,6 +445,7 @@ private:
 
     void _executeButtonAction(const QString &action, const ButtonEvent_t buttonEvent);
     int  _findAvailableButtonActionIndex(const QString &action);
+    void _addAvailableButtonActionIfMissing(const QString &action);
     bool _validAxis(int axis) const;
     bool _validButton(int button) const;
     void _handleAxis();

--- a/test/Joystick/JoystickTest.cc
+++ b/test/Joystick/JoystickTest.cc
@@ -7,6 +7,7 @@
 
 #include <QtCore/QPointer>
 #include <QtCore/QRegularExpression>
+#include <QtCore/QSettings>
 
 void JoystickTest::initTestCase()
 {
@@ -43,6 +44,17 @@ JoystickSDL* JoystickTest::_findJoystickByInstanceId(int instanceId)
 void JoystickTest::_pumpEvents()
 {
     SDLJoystick::pumpEvents();
+}
+
+// Seeds a stored button action assignment as if it was saved by a previous session
+void JoystickTest::_seedButtonActionSetting(const QString &joystickName, int buttonIndex, const QString &actionName)
+{
+    QSettings settings;
+    settings.beginGroup(QStringLiteral("JoystickSettingsV2/%1").arg(joystickName));
+    settings.beginGroup(QStringLiteral("JoystickButtonActionSettingsArray"));
+    settings.beginGroup(QString::number(buttonIndex));
+    settings.setValue(QStringLiteral("actionName"), actionName);
+    settings.setValue(QStringLiteral("repeat"), false);
 }
 
 //-----------------------------------------------------------------------------
@@ -819,6 +831,117 @@ void JoystickTest::_adjustRangeToRcOverridePwmTest()
     QCOMPARE(js->_adjustRangeToRcOverridePwm(Joystick::AxisMin,  cal, true),  static_cast<uint16_t>(1000));  // full negative
 
     js->_close();
+}
+
+// Regression test for #13918: stored button assignments whose action is not in the
+// currently-available actions list (e.g. flight-mode actions saved while a vehicle was
+// connected) must NOT be scrubbed when the joystick is created without a vehicle. The
+// available flight modes can change dynamically (standard modes protocol), so the
+// assignment is kept and availability is checked at button press time.
+void JoystickTest::_buttonActionUnknownActionPreservedTest()
+{
+    const QString joystickName = QStringLiteral("Unknown Action Test");
+    const QString settingsGroup = QStringLiteral("JoystickSettingsV2/%1").arg(joystickName);
+    const QString buttonArrayGroup = QStringLiteral("JoystickButtonActionSettingsArray");
+    const QString actionNameKey = QStringLiteral("actionName");
+
+    // "Position" is a vehicle flight-mode action: only available when a vehicle is active.
+    const QString knownAction1 = QStringLiteral("Arm");
+    const QString vehicleOnlyAction = QStringLiteral("Position");
+    const QString knownAction2 = QStringLiteral("Disarm");
+
+    // Seed settings as if a previous session assigned three buttons while a vehicle was connected
+    _seedButtonActionSetting(joystickName, 0, knownAction1);
+    _seedButtonActionSetting(joystickName, 1, vehicleOnlyAction);
+    _seedButtonActionSetting(joystickName, 2, knownAction2);
+
+    // Create the joystick with no active vehicle: flight-mode actions are not in the available list
+    _mockJoystick = std::unique_ptr<MockJoystick>(MockJoystick::create(joystickName, 4, 16, 1));
+    QVERIFY(_mockJoystick->isValid());
+    _pumpEvents();
+    _discoveredJoysticks = JoystickSDL::discover();
+    JoystickSDL* js = _findJoystickByInstanceId(_mockJoystick->instanceId());
+    QVERIFY(js != nullptr);
+
+    // Known actions must be assigned in memory
+    QCOMPARE(js->getButtonAction(0), knownAction1);
+    QCOMPARE(js->getButtonAction(2), knownAction2);
+
+    // The vehicle-only action assignment must be kept even though the action is not
+    // currently available. It becomes usable once a vehicle provides that flight mode.
+    QCOMPARE(js->getButtonAction(1), vehicleOnlyAction);
+
+    // The assigned action must also be added to the available actions list so the button
+    // assignment combo in the UI always shows the real assignment.
+    QVERIFY(js->assignableActionTitles().contains(vehicleOnlyAction));
+
+    // THE BUG (#13918): loading must not permanently delete the stored assignment for the
+    // vehicle-only action. It must still be present in settings so it comes back when a
+    // vehicle next provides that flight mode.
+    {
+        QSettings settings;
+        settings.beginGroup(settingsGroup);
+        settings.beginGroup(buttonArrayGroup);
+        settings.beginGroup(QStringLiteral("1"));
+        QCOMPARE(settings.value(actionNameKey).toString(), vehicleOnlyAction);
+    }
+}
+
+// Companion to _buttonActionUnknownActionPreservedTest: a full save cycle
+// (_saveFromCalibrationDataIntoSettings does _clearButtonSettings + _saveButtonSettings)
+// must not lose an assignment whose action is not currently available.
+void JoystickTest::_buttonActionUnknownActionSaveRoundTripTest()
+{
+    const QString joystickName = QStringLiteral("Save Round Trip Test");
+    const QString settingsGroup = QStringLiteral("JoystickSettingsV2/%1").arg(joystickName);
+    const QString buttonArrayGroup = QStringLiteral("JoystickButtonActionSettingsArray");
+    const QString actionNameKey = QStringLiteral("actionName");
+    const QString vehicleOnlyAction = QStringLiteral("Position");
+
+    _seedButtonActionSetting(joystickName, 1, vehicleOnlyAction);
+
+    _mockJoystick = std::unique_ptr<MockJoystick>(MockJoystick::create(joystickName, 4, 16, 1));
+    QVERIFY(_mockJoystick->isValid());
+    _pumpEvents();
+    _discoveredJoysticks = JoystickSDL::discover();
+    JoystickSDL* js = _findJoystickByInstanceId(_mockJoystick->instanceId());
+    QVERIFY(js != nullptr);
+    QCOMPARE(js->getButtonAction(1), vehicleOnlyAction);
+
+    // Full save cycle: clears the settings group and rewrites it from in-memory data
+    js->_saveFromCalibrationDataIntoSettings();
+
+    QSettings settings;
+    settings.beginGroup(settingsGroup);
+    settings.beginGroup(buttonArrayGroup);
+    settings.beginGroup(QStringLiteral("1"));
+    QCOMPARE(settings.value(actionNameKey).toString(), vehicleOnlyAction);
+}
+
+// The available actions list is rebuilt whenever the vehicle changes or the vehicle's
+// flight modes change (standard modes protocol). Assigned actions must survive the
+// rebuild so the UI combo always contains them.
+void JoystickTest::_buttonActionAvailableListRebuildTest()
+{
+    const QString joystickName = QStringLiteral("List Rebuild Test");
+    const QString vehicleOnlyAction = QStringLiteral("Position");
+
+    _seedButtonActionSetting(joystickName, 1, vehicleOnlyAction);
+
+    _mockJoystick = std::unique_ptr<MockJoystick>(MockJoystick::create(joystickName, 4, 16, 1));
+    QVERIFY(_mockJoystick->isValid());
+    _pumpEvents();
+    _discoveredJoysticks = JoystickSDL::discover();
+    JoystickSDL* js = _findJoystickByInstanceId(_mockJoystick->instanceId());
+    QVERIFY(js != nullptr);
+    QVERIFY(js->assignableActionTitles().contains(vehicleOnlyAction));
+
+    // Simulate the rebuild that happens on vehicle change / flightModesChanged
+    js->_buildAvailableButtonsActionList(nullptr);
+
+    // Assignment and its presence in the available list must both survive
+    QCOMPARE(js->getButtonAction(1), vehicleOnlyAction);
+    QVERIFY(js->assignableActionTitles().contains(vehicleOnlyAction));
 }
 
 UT_REGISTER_TEST(JoystickTest, TestLabel::Unit, TestLabel::Joystick)

--- a/test/Joystick/JoystickTest.h
+++ b/test/Joystick/JoystickTest.h
@@ -66,6 +66,9 @@ private slots:
 
     // Button action tests
     void _buttonActionAssignmentTest();
+    void _buttonActionUnknownActionPreservedTest();
+    void _buttonActionUnknownActionSaveRoundTripTest();
+    void _buttonActionAvailableListRebuildTest();
 
     // Connection state tests
     void _connectionStateTest();
@@ -79,6 +82,7 @@ private slots:
 private:
     JoystickSDL* _findJoystickByInstanceId(int instanceId);
     void _pumpEvents();
+    static void _seedButtonActionSetting(const QString &joystickName, int buttonIndex, const QString &actionName);
 
     std::unique_ptr<MockJoystick> _mockJoystick;
     QMap<QString, Joystick*> _discoveredJoysticks;


### PR DESCRIPTION
## Problem

Related to #13918

Stored joystick button action assignments which reference actions not currently available were being permanently scrubbed from settings at joystick construction. Joysticks are created at app startup — before any vehicle connects — so assignments to vehicle flight modes (which can change dynamically via the standard modes protocol and are only known once a vehicle connects) were deleted every session.

## Fix

- `_loadButtonSettings()`: an assignment whose action is not currently available is kept (in memory and in settings) instead of being removed. Availability is still enforced at button press time in `_executeButtonAction()`.
- The assigned action is injected into the available actions list (`_addAvailableButtonActionIfMissing()`) so the UI combo always displays the real assignment instead of falling back to "No Action".
- `_buildAvailableButtonsActionList()`: assigned actions survive the list rebuild that happens on vehicle change / `flightModesChanged`.

Legitimate scrubbing (empty action name, "No Action") is preserved.

## Tests

Three new regression tests in `JoystickTest`:
- `_buttonActionUnknownActionPreservedTest` — load with no vehicle keeps the assignment in memory, in the combo model, and in settings
- `_buttonActionUnknownActionSaveRoundTripTest` — full save cycle (`_clearButtonSettings` + `_saveButtonSettings`) does not lose the assignment
- `_buttonActionAvailableListRebuildTest` — assignment survives `_buildAvailableButtonsActionList()` rebuild