### PR TITLE
feat(AutoPilotPlugin): don't auto-switch to Vehicle Configuration on incomplete setup

### DIFF
--- a/src/AutoPilotPlugins/AutoPilotPlugin.cc
+++ b/src/AutoPilotPlugins/AutoPilotPlugin.cc
@@ -1,12 +1,9 @@
 #include "AutoPilotPlugin.h"
 #include "FirmwarePlugin.h"
 #include "AppMessages.h"
-#include "QGCApplication.h"
 #include "QGCLoggingCategory.h"
 #include "Vehicle.h"
 #include "VehicleComponent.h"
-
-#include <QtCore/QCoreApplication>
 
 QGC_LOGGING_CATEGORY(AutoPilotPluginLog, "AutoPilotPlugins.AutoPilotPlugin");
 
@@ -60,10 +57,7 @@ void AutoPilotPlugin::parametersReadyPreChecks()
     }
 
     if (!_setupComplete) {
-        // Take the user to Vehicle Config Summary
-        qgcApp()->showVehicleConfig();
-        QCoreApplication::processEvents(QEventLoop::ExcludeUserInputEvents);
-        QGC::showAppMessage(tr("One or more vehicle components require setup prior to flight."));
+        QGC::showAppMessage(tr("Configuration tasks remain before this vehicle is ready to fly. See Vehicle Configuration for details."));
     }
 }
 

--- a/src/QGCApplication.cc
+++ b/src/QGCApplication.cc
@@ -490,13 +490,6 @@ QQuickWindow* QGCApplication::mainRootWindow()
     return _mainRootWindow;
 }
 
-void QGCApplication::showVehicleConfig()
-{
-    if (_rootQmlObject()) {
-        QMetaObject::invokeMethod(_rootQmlObject(), "showVehicleConfig");
-    }
-}
-
 void QGCApplication::qmlAttemptWindowClose()
 {
     if (_rootQmlObject()) {

--- a/src/QGCApplication.h
+++ b/src/QGCApplication.h
@@ -85,8 +85,6 @@ signals:
     void languageChanged(const QLocale &locale);
 
 public slots:
-    void showVehicleConfig();
-
     void qmlAttemptWindowClose();
 
     /// Get current language


### PR DESCRIPTION
## Description

When a vehicle connects with incomplete component setup, QGC currently forces the UI to the Vehicle Configuration view. This removes that automatic view switch while keeping the notification to the user.

## Changes
- `AutoPilotPlugin::parametersReadyPreChecks()` no longer calls `showVehicleConfig()`; it only shows the app message.
- Updated the message wording to match current UI terminology: *"Configuration tasks remain before this vehicle is ready to fly. See Vehicle Configuration for details."*
- Removed the now-dead `QGCApplication::showVehicleConfig()` C++ method (the QML `mainWindow.showVehicleConfig()` used by toolbar indicators is unchanged).