### PR TITLE
fix(toolbar): expand dont contraction in BatteryIndicator comment

### DIFF
--- a/src/Toolbar/BatteryIndicator.qml
+++ b/src/Toolbar/BatteryIndicator.qml
@@ -150,7 +150,7 @@ Item {
             // User wants voltage display so use that if available
             _recalcLowestBatteryIdFromVoltage()
         }
-        // If we still dont have a lowest battery id then try charge state
+        // If we still don't have a lowest battery id then try charge state
         if (_lowestBatteryId === -1) {
             _recalcLowestBatteryIdFromChargeState()
         }


### PR DESCRIPTION
## Summary
Expand the `dont` contraction in a BatteryIndicator QML comment for consistency with surrounding grammar.

## Motivation
Comment-only hygiene; no runtime change.

## Verification
- Diff is a single-line comment update.
- No geofence/arm/safety logic touched.

AI-assisted; human-reviewed.