### PR TITLE
fix(Vehicle): correct successful spelling in mavlinkReceivedCount comment

### DIFF
--- a/src/Vehicle/Vehicle.h
+++ b/src/Vehicle/Vehicle.h
@@ -727,7 +727,7 @@ public:
     void deleteGimbalController();
 
     quint64     mavlinkSentCount        () const{ return _mavlinkSentCount; }        /// Calculated total number of messages sent to us
-    quint64     mavlinkReceivedCount    () const{ return _mavlinkReceivedCount; }    /// Total number of sucessful messages received
+    quint64     mavlinkReceivedCount    () const{ return _mavlinkReceivedCount; }    /// Total number of successful messages received
     quint64     mavlinkLossCount        () const{ return _mavlinkLossCount; }        /// Total number of lost messages
     float       mavlinkLossPercent      () const{ return _mavlinkLossPercent; }      /// Running loss rate
 


### PR DESCRIPTION
## Summary
Fix `sucessful` → `successful` in the `mavlinkReceivedCount` header comment.

## Motivation
Docstring accuracy for maintainers reading Vehicle.h.

## Verification
- Comment-only change.
- No behavioral or API changes.

AI-assisted; human-reviewed.