### PR TITLE
fix(facts): expand Wind Spd shortDesc to Wind Speed

### DIFF
--- a/src/Vehicle/FactGroups/WindFact.json
+++ b/src/Vehicle/FactGroups/WindFact.json
@@ -12,14 +12,14 @@
 },
 {
     "name":             "speed",
-    "shortDesc": "Wind Spd",
+    "shortDesc": "Wind Speed",
     "type":             "double",
     "decimalPlaces":    1,
     "units":            "m/s"
 },
 {
     "name":             "verticalSpeed",
-    "shortDesc": "Wind Spd (vert)",
+    "shortDesc": "Wind Speed (vert)",
     "type":             "double",
     "decimalPlaces":    1,
     "units":            "m/s"


### PR DESCRIPTION
## Summary
Expand abbreviated wind fact short descriptions (`Wind Spd` / `Wind Spd (vert)`) to full `Wind Speed` labels for operator readability.

## Motivation
UI fact labels should match common GCS wording without cryptic abbreviation.

## Verification
- Metadata-only (WindFact.json shortDesc).
- Units and types unchanged.

AI-assisted; human-reviewed.