### PR TITLE
fix(facts): Hygrometer temperature unit C and clearer ID label

### DIFF
--- a/src/Vehicle/FactGroups/HygrometerFact.json
+++ b/src/Vehicle/FactGroups/HygrometerFact.json
@@ -8,7 +8,7 @@
     "shortDesc": "Temperature",
     "type":             "double",
     "decimalPlaces":    3,
-    "units":            "deg"
+    "units":            "C"
 },
 {
     "name":             "humidity",
@@ -19,7 +19,7 @@
 },
 {
     "name":             "hygrometerid",
-    "shortDesc": "ID",
+    "shortDesc": "Hygrometer ID",
     "type":             "uint16",
     "decimalPlaces":    0
 }


### PR DESCRIPTION
## Summary
Align Hygrometer temperature `units` with other temperature facts (`C`) and expand the ID shortDesc to `Hygrometer ID`.

## Motivation
Consistent SI/operator temperature unit display; less ambiguous telemetry ID label.

## Verification
- Metadata-only HygrometerFact.json.
- Cross-check TemperatureFact uses `C`.

AI-assisted; human-reviewed.