### PR TITLE
fix(facts): normalize vibration axis shortDesc casing

### DIFF
--- a/src/Vehicle/FactGroups/VibrationFact.json
+++ b/src/Vehicle/FactGroups/VibrationFact.json
@@ -5,19 +5,19 @@
 [
 {
     "name":             "xAxis",
-    "shortDesc": "Vibe xAxis",
+    "shortDesc": "Vibe X",
     "type":             "double",
     "decimalPlaces":    1
 },
 {
     "name":             "yAxis",
-    "shortDesc": "Vibe yAxis",
+    "shortDesc": "Vibe Y",
     "type":             "double",
     "decimalPlaces":    1
 },
 {
     "name":             "zAxis",
-    "shortDesc": "Vibe zAxis",
+    "shortDesc": "Vibe Z",
     "type":             "double",
     "decimalPlaces":    1
 },


### PR DESCRIPTION
## Summary
Normalize vibration fact short descriptions from `Vibe xAxis/yAxis/zAxis` to `Vibe X/Y/Z`.

## Motivation
Cleaner operator-facing labels consistent with other axis facts (VX/VY style caps).

## Verification
- Metadata-only VibrationFact.json.
- Clip count fields unchanged.

AI-assisted; human-reviewed.