### PR TITLE
cleanup(facts/docs): consolidate Fact metadata + typo fixes into one PR

### DIFF
--- a/docs/en/qgc-dev-guide/user_interface_design/font_palette.md
+++ b/docs/en/qgc-dev-guide/user_interface_design/font_palette.md
@@ -12,7 +12,7 @@ This item exposes the QGC color palette. There are two variants of this palette:
 
 ## QGCMapPalette
 
-The map palette is used for colors which are used to draw over a map. Due to the the different map styles, specifically satellite and street you need to have different colors to draw over them legibly. Satellite maps needs lighter colors to be seen whereas street maps need darker colors to be seen. The `QGCMapPalette` item provides a set of colors for this as well as the ability to switch between light and dark colors over maps.
+The map palette is used for colors which are used to draw over a map. Due to the different map styles, specifically satellite and street you need to have different colors to draw over them legibly. Satellite maps needs lighter colors to be seen whereas street maps need darker colors to be seen. The `QGCMapPalette` item provides a set of colors for this as well as the ability to switch between light and dark colors over maps.
 
 ## ScreenTools
 

--- a/docs/en/qgc-user-guide/setup_view/tuning_px4.md
+++ b/docs/en/qgc-user-guide/setup_view/tuning_px4.md
@@ -104,7 +104,7 @@ In overview:
      This will guide the plane to fly in circle at constant altitude and speed.
 1. In QGroundControl, open the menu: **Vehicle setup > PID Tuning**
 1. Select the _Rate Controller_ tab.
-   Ensure that the **Autotune enabled** button is is turned off.
+   Ensure that the **Autotune enabled** button is turned off.
 
 
 1. Select the _Tuning axis_ to tune: **Roll**, **Pitch** or **Yaw** (each axis is tuned separately).

--- a/src/MissionManager/CameraCalc.FactMetaData.json
+++ b/src/MissionManager/CameraCalc.FactMetaData.json
@@ -26,7 +26,7 @@
 },
 {
     "name":             "ImageDensity",
-    "shortDesc":        "Image desity at surface.",
+    "shortDesc":        "Image density at surface.",
     "type":             "double",
     "min":              0,
     "units":            "cm/px",

--- a/src/QmlControls/QGCFlickable.qml
+++ b/src/QmlControls/QGCFlickable.qml
@@ -4,7 +4,7 @@ import QtQuick.Controls
 import QGroundControl
 import QGroundControl.Controls
 
-/// QGC version of Flickable control that shows horizontal/vertial scroll indicators
+/// QGC version of Flickable control that shows horizontal/vertical scroll indicators
 Flickable {
     id:                     root
     boundsBehavior:         Flickable.StopAtBounds

--- a/src/QmlControls/QGCListView.qml
+++ b/src/QmlControls/QGCListView.qml
@@ -3,7 +3,7 @@ import QtQuick
 import QGroundControl
 import QGroundControl.Controls
 
-/// QGC version of ListVIew control that shows horizontal/vertial scroll indicators
+/// QGC version of ListView control that shows horizontal/vertical scroll indicators
 ListView {
     id:             root
     boundsBehavior: Flickable.StopAtBounds

--- a/src/Toolbar/BatteryIndicator.qml
+++ b/src/Toolbar/BatteryIndicator.qml
@@ -150,7 +150,7 @@ Item {
             // User wants voltage display so use that if available
             _recalcLowestBatteryIdFromVoltage()
         }
-        // If we still dont have a lowest battery id then try charge state
+        // If we still don't have a lowest battery id then try charge state
         if (_lowestBatteryId === -1) {
             _recalcLowestBatteryIdFromChargeState()
         }

--- a/src/Vehicle/FactGroups/BatteryFact.json
+++ b/src/Vehicle/FactGroups/BatteryFact.json
@@ -29,7 +29,7 @@
     "shortDesc":        "Voltage",
     "type":             "double",
     "decimalPlaces":    2,
-    "units":            "v"
+    "units":            "V"
 },
 {
     "name":             "percentRemaining",

--- a/src/Vehicle/FactGroups/EFIFact.json
+++ b/src/Vehicle/FactGroups/EFIFact.json
@@ -65,14 +65,14 @@
 },
 {
     "name":             "intakePress",
-    "shortDesc":        "Intake mainfold pressure",
+    "shortDesc":        "Intake manifold pressure",
     "type":             "float",
     "decimalPlaces":    1,
     "units":            "kPa"
 },
 {
     "name":             "intakeTemp",
-    "shortDesc":        "Intake mainfold temperature",
+    "shortDesc":        "Intake manifold temperature",
     "type":             "float",
     "decimalPlaces":    1,
     "units":            "°C"

--- a/src/Vehicle/FactGroups/EscStatusFactGroup.json
+++ b/src/Vehicle/FactGroups/EscStatusFactGroup.json
@@ -10,7 +10,7 @@
 },
 {
     "name":             "rpm",
-    "shortDesc":        "Rotation Per Minute",
+    "shortDesc":        "RPM",
     "type":             "float",
     "decimalPlaces":    2,
     "default":          null

--- a/src/Vehicle/FactGroups/GeneratorFact.json
+++ b/src/Vehicle/FactGroups/GeneratorFact.json
@@ -63,7 +63,7 @@
 },
 {
     "name":             "runtime",
-    "shortDesc":        "runtime",
+    "shortDesc":        "Runtime",
     "type":             "uint32",
     "units":            "sec"
 },

--- a/src/Vehicle/FactGroups/HygrometerFact.json
+++ b/src/Vehicle/FactGroups/HygrometerFact.json
@@ -8,7 +8,7 @@
     "shortDesc": "Temperature",
     "type":             "double",
     "decimalPlaces":    3,
-    "units":            "deg"
+    "units":            "C"
 },
 {
     "name":             "humidity",
@@ -19,7 +19,7 @@
 },
 {
     "name":             "hygrometerid",
-    "shortDesc": "ID",
+    "shortDesc": "Hygrometer ID",
     "type":             "uint16",
     "decimalPlaces":    0
 }

--- a/src/Vehicle/FactGroups/LocalPositionFact.json
+++ b/src/Vehicle/FactGroups/LocalPositionFact.json
@@ -26,7 +26,7 @@
 },
 {
     "name":             "vx",
-    "shortDesc": "VX",
+    "shortDesc": "Vx",
     "type":             "double",
     "decimalPlaces":    1,
     "units":            "m/s"

--- a/src/Vehicle/FactGroups/SubmarineFact.json
+++ b/src/Vehicle/FactGroups/SubmarineFact.json
@@ -47,7 +47,7 @@
     "units":            "m"
 },
 {    "name":            "rangefinderTarget",
-    "shortDesc": "RFTarget",
+    "shortDesc": "Rangefinder Target",
     "type":             "float",
     "decimalPlaces":    2,
     "units":            "m"

--- a/src/Vehicle/FactGroups/VehicleFact.json
+++ b/src/Vehicle/FactGroups/VehicleFact.json
@@ -174,7 +174,7 @@
 },
 {
     "name":             "imuTemp",
-    "shortDesc": "Imu temperature",
+    "shortDesc": "IMU temperature",
     "type":             "int16",
     "units":            "°C"
 },

--- a/src/Vehicle/FactGroups/VibrationFact.json
+++ b/src/Vehicle/FactGroups/VibrationFact.json
@@ -5,19 +5,19 @@
 [
 {
     "name":             "xAxis",
-    "shortDesc": "Vibe xAxis",
+    "shortDesc": "Vibe X",
     "type":             "double",
     "decimalPlaces":    1
 },
 {
     "name":             "yAxis",
-    "shortDesc": "Vibe yAxis",
+    "shortDesc": "Vibe Y",
     "type":             "double",
     "decimalPlaces":    1
 },
 {
     "name":             "zAxis",
-    "shortDesc": "Vibe zAxis",
+    "shortDesc": "Vibe Z",
     "type":             "double",
     "decimalPlaces":    1
 },

--- a/src/Vehicle/FactGroups/WindFact.json
+++ b/src/Vehicle/FactGroups/WindFact.json
@@ -12,14 +12,14 @@
 },
 {
     "name":             "speed",
-    "shortDesc": "Wind Spd",
+    "shortDesc": "Wind Speed",
     "type":             "double",
     "decimalPlaces":    1,
     "units":            "m/s"
 },
 {
     "name":             "verticalSpeed",
-    "shortDesc": "Wind Spd (vert)",
+    "shortDesc": "Wind Speed (vert)",
     "type":             "double",
     "decimalPlaces":    1,
     "units":            "m/s"

--- a/src/Vehicle/Vehicle.h
+++ b/src/Vehicle/Vehicle.h
@@ -727,7 +727,7 @@ public:
     void deleteGimbalController();
 
     quint64     mavlinkSentCount        () const{ return _mavlinkSentCount; }        /// Calculated total number of messages sent to us
-    quint64     mavlinkReceivedCount    () const{ return _mavlinkReceivedCount; }    /// Total number of sucessful messages received
+    quint64     mavlinkReceivedCount    () const{ return _mavlinkReceivedCount; }    /// Total number of successful messages received
     quint64     mavlinkLossCount        () const{ return _mavlinkLossCount; }        /// Total number of lost messages
     float       mavlinkLossPercent      () const{ return _mavlinkLossPercent; }      /// Running loss rate
 


### PR DESCRIPTION
## Summary
@DonLakeFlyer — per your request on #14649, this consolidates my pile of tiny one-line changes into a **single** cosmetic-only PR so you don't have to manage them individually during stable lockdown.

All purely display-string / comment / doc fixes, **no functional or behavioral changes**:

**Fact metadata (shortDesc / units normalization)**
- Hygrometer: temp units `deg`→`C`, ID label → `Hygrometer ID`
- Vibration: `Vibe xAxis/yAxis/zAxis` → `Vibe X/Y/Z`
- Wind: `Wind Spd` → `Wind Speed`
- Battery: voltage units `v`→`V` (SI)
- Vehicle: `Imu temperature` → `IMU temperature`
- Generator: `runtime` → `Runtime`
- ESC: `Rotation Per Minute` → `RPM`
- EFI: `mainfold` → `manifold` (x2)
- Submarine: `RFTarget` → `Rangefinder Target`
- LocalPosition: `VX` → `Vx`
- CameraCalc: `Image desity` → `Image density`

**Comment / doc typos**
- Vehicle.h `sucessful`→`successful`
- BatteryIndicator.qml `dont`→`don't`
- font_palette.md `the the`, tuning_px4.md `is is`
- QGCFlickable.qml / QGCListView.qml `vertial`→`vertical`, `ListVIew`→`ListView`

## Supersedes
Closing in favor of this single PR: #14649 #14650 #14648 #14647 #14646 #14637 #14636 #14635 #14634 #14633 #14621 #14619 #14618 #14636 #14611

I intentionally **dropped** the `vertical m` unit-type changes (#14617/#14620) and the units-doc rewrite (#14599) since those are behavioral and not appropriate during stable lockdown — happy to revisit after the release.

AI-assisted; human-reviewed. Thanks for the patience!