### PR TITLE
fix(facts): bind goodAttitudeEstimate fact name to metadata

### DIFF
--- a/src/Vehicle/FactGroups/EstimatorStatusFactGroup.json
+++ b/src/Vehicle/FactGroups/EstimatorStatusFactGroup.json
@@ -4,8 +4,8 @@
     "QGC.MetaData.Facts":
 [
 {
-    "name":         "goodAttitudeEsimate",
-    "shortDesc":    "Good Attitude Esimate",
+    "name":         "goodAttitudeEstimate",
+    "shortDesc":    "Good Attitude Estimate",
     "type":         "bool",
     "default":      false
 },

--- a/src/Vehicle/FactGroups/VehicleEstimatorStatusFactGroup.h
+++ b/src/Vehicle/FactGroups/VehicleEstimatorStatusFactGroup.h
@@ -54,7 +54,7 @@ public:
     void handleMessage(Vehicle *vehicle, const mavlink_message_t &message) final;
 
 private:
-    Fact _goodAttitudeEstimateFact = Fact(0, QStringLiteral("goodAttitudeEsimate"), FactMetaData::valueTypeBool);
+    Fact _goodAttitudeEstimateFact = Fact(0, QStringLiteral("goodAttitudeEstimate"), FactMetaData::valueTypeBool);
     Fact _goodHorizVelEstimateFact = Fact(0, QStringLiteral("goodHorizVelEstimate"), FactMetaData::valueTypeBool);
     Fact _goodVertVelEstimateFact = Fact(0, QStringLiteral("goodVertVelEstimate"), FactMetaData::valueTypeBool);
     Fact _goodHorizPosRelEstimateFact = Fact(0, QStringLiteral("goodHorizPosRelEstimate"), FactMetaData::valueTypeBool);


### PR DESCRIPTION
## Summary
Fact id typo (`goodAttitudeEsimate`) broke metadata binding for `VehicleEstimatorStatusFactGroup::goodAttitudeEstimate`. Align JSON `name`/`shortDesc` and Fact ctor string to `goodAttitudeEstimate`.

## Test plan
- [ ] Confirm Estimator status fact group still loads; attitude estimate flag present in vehicle inspect UI
- [x] Diff-only review of Fact name wiring

AI-assisted; human-reviewed. No geofence/arm changes.