### PR TITLE
fix(facts): capitalize GPS/GNSS in operator fact labels

### DIFF
--- a/src/Vehicle/FactGroups/EstimatorStatusFactGroup.json
+++ b/src/Vehicle/FactGroups/EstimatorStatusFactGroup.json
@@ -65,7 +65,7 @@
 },
 {
     "name":         "gpsGlitch",
-    "shortDesc":    "Gps Glitch",
+    "shortDesc":    "GPS Glitch",
     "type":         "bool",
     "default":      false
 },

--- a/src/Vehicle/FactGroups/GPSFact.json
+++ b/src/Vehicle/FactGroups/GPSFact.json
@@ -100,7 +100,7 @@
 },
 {
     "name":             "gnssSignalQuality",
-    "shortDesc": "Gnss Signal Quality",
+    "shortDesc": "GNSS Signal Quality",
     "type":             "uint8"
 },
 {


### PR DESCRIPTION
## Summary
Display-only shortDesc casing: `Gps Glitch` → `GPS Glitch`, `Gnss Signal Quality` → `GNSS Signal Quality`. Fact names unchanged.

## Test plan
- [ ] Vehicle inspect estimator GPS glitch + GPS quality labels
- [x] Metadata-only

AI-assisted; human-reviewed. Orthogonal to #14651 cosmetic consolidations.