### PR TITLE
fix(mock): spell threshold in MockLink rover yaw param text

### DIFF
--- a/src/Comms/MockLink/MockLink.Parameter.MetaData.json
+++ b/src/Comms/MockLink/MockLink.Parameter.MetaData.json
@@ -57286,7 +57286,7 @@
    "max": 3.14159,
    "min": 0.001,
    "name": "RD_TRANS_DRV_TRN",
-   "shortDesc": "Yaw error threshhold to switch from driving to spot turning",
+   "shortDesc": "Yaw error threshold to switch from driving to spot turning",
    "type": "Float",
    "units": "rad"
   },
@@ -57300,7 +57300,7 @@
    "max": 3.14159,
    "min": 0.001,
    "name": "RD_TRANS_TRN_DRV",
-   "shortDesc": "Yaw error threshhold to switch from spot turning to driving",
+   "shortDesc": "Yaw error threshold to switch from spot turning to driving",
    "type": "Float",
    "units": "rad"
   },


### PR DESCRIPTION
## Summary
MockLink Parameter.MetaData: `threshhold` → `threshold` on two rover yaw-error switch shortDescs. SITL/mock path only.

## Test plan
- [ ] MockLink param browser copy for those two keys
- [x] String-only in mock metadata

AI-assisted; human-reviewed. No vehicle code path.