### PR TITLE
fix(facts): clarify GPS satellite count short description

### DIFF
--- a/src/Vehicle/FactGroups/GPSFact.json
+++ b/src/Vehicle/FactGroups/GPSFact.json
@@ -56,7 +56,7 @@
 },
 {
     "name":             "count",
-    "shortDesc": "Sat Count",
+    "shortDesc": "Satellite Count",
     "type":             "uint32"
 },
 {


### PR DESCRIPTION
## Summary
Expand abbreviated GPS fact shortDesc `Sat Count` → `Satellite Count` for clearer operator UI.

## Test plan
- [ ] GPS fact group satellite count label
- [x] Metadata-only

AI-assisted; human-reviewed.