### PR TITLE
fix(Comms): defer MAVLink v1 warning to tolerate ArduPilot v1 to v2 upgrade

### DIFF
--- a/src/Comms/LinkInterface.cc
+++ b/src/Comms/LinkInterface.cc
@@ -132,16 +132,27 @@ void LinkInterface::_connectionRemoved()
 
 void LinkInterface::reportMavlinkV1Traffic()
 {
-    if (!_mavlinkV1TrafficReported) {
-        _mavlinkV1TrafficReported = true;
-
-        const SharedLinkConfigurationPtr linkConfig = linkConfiguration();
-        const QString linkName = linkConfig ? linkConfig->name() : QStringLiteral("unknown");
-        qCWarning(LinkInterfaceLog) << "MAVLink v1 traffic detected on link" << linkName;
-        const QString message = tr("MAVLink v1 traffic detected on link '%1'. "
-                                   "%2 only supports MAVLink v2. "
-                                   "Please ensure your vehicle is configured to use MAVLink v2.")
-                                    .arg(linkName).arg(qgcApp()->applicationName());
-        QGC::showAppMessage(message);
+    if (_mavlinkV1TrafficReported || _mavlinkV2TrafficSeen) {
+        return;
     }
+
+    // Defer the warning: ArduPilot starts out sending v1 and upgrades to v2 once it sees v2
+    // traffic from QGC. Only warn if the link never produces v2 within the grace period.
+    if (!_mavlinkV1FirstSeenTimer.isValid()) {
+        _mavlinkV1FirstSeenTimer.start();
+    }
+    if (_mavlinkV1FirstSeenTimer.elapsed() < _mavlinkV1TrafficGraceMsecs) {
+        return;
+    }
+
+    _mavlinkV1TrafficReported = true;
+
+    const SharedLinkConfigurationPtr linkConfig = linkConfiguration();
+    const QString linkName = linkConfig ? linkConfig->name() : QStringLiteral("unknown");
+    qCWarning(LinkInterfaceLog) << "MAVLink v1 traffic detected on link" << linkName;
+    const QString message = tr("MAVLink v1 traffic detected on link '%1'. "
+                               "%2 only supports MAVLink v2. "
+                               "Please ensure your vehicle is configured to use MAVLink v2.")
+                                .arg(linkName).arg(qgcApp()->applicationName());
+    QGC::showAppMessage(message);
 }

--- a/src/Comms/LinkInterface.h
+++ b/src/Comms/LinkInterface.h
@@ -1,5 +1,6 @@
 #pragma once
 
+#include <QtCore/QElapsedTimer>
 #include <QtQmlIntegration/QtQmlIntegration>
 
 #include <memory>
@@ -40,7 +41,17 @@ public:
     void sendMessageThreadSafe(mavlink_message_t &message);
     void addVehicleReference() { ++_vehicleReferenceCount; }
     void removeVehicleReference();
+    /// Called for each received v1 message which QGC drops. The warning is deferred by a grace
+    /// period since ArduPilot starts links in v1 and upgrades to v2 on first v2 message from QGC.
     void reportMavlinkV1Traffic();
+    /// Called when a v2 message is received: permanently suppresses the v1-only warning for this link.
+    void reportMavlinkV2Traffic() { _mavlinkV2TrafficSeen = true; }
+    bool mavlinkV1TrafficReported() const { return _mavlinkV1TrafficReported; }
+
+    /// Grace period a link is given to upgrade from MAVLink v1 to v2 (ArduPilot starts out in v1)
+    /// before the v1-only warning is reported. Settable for tests.
+    static constexpr int kMavlinkV1TrafficGraceMsecsDefault = 10000;
+    static void setMavlinkV1TrafficGraceMsecs(int msecs) { _mavlinkV1TrafficGraceMsecs = msecs; }
 
     /// Per-link signing state and confirmation state machine. Non-null after channel allocation.
     SigningController* signing() { return _signingController.get(); }
@@ -79,6 +90,9 @@ private:
     bool _decodedFirstMavlinkPacket = false;
     int _vehicleReferenceCount = 0;
     bool _mavlinkV1TrafficReported = false;
+    bool _mavlinkV2TrafficSeen = false;
+    QElapsedTimer _mavlinkV1FirstSeenTimer;
+    static inline int _mavlinkV1TrafficGraceMsecs = kMavlinkV1TrafficGraceMsecsDefault;
     /// Must `reset()` in `_freeMavlinkChannel` before LinkManager frees the channel so the
     /// controller can flush the final timestamp.
     std::unique_ptr<SigningController> _signingController;

--- a/src/Comms/MAVLinkProtocol.cc
+++ b/src/Comms/MAVLinkProtocol.cc
@@ -126,13 +126,15 @@ void MAVLinkProtocol::receiveBytes(LinkInterface* link, const QByteArray& data)
         }
 
         // v1/v2 share per-(sysid,compid) sequence counters; counting v1 makes every v2 appear lost. Skip v1 non-heartbeats.
+        // RADIO_STATUS is exempt: SiK radios always frame it as v1, so it is processed and never triggers the v1 warning.
         const bool isV1 = (status.flags & MAVLINK_STATUS_FLAG_IN_MAVLINK1);
-        if (isV1 && message.msgid != MAVLINK_MSG_ID_HEARTBEAT) {
+        if (isV1 && (message.msgid != MAVLINK_MSG_ID_HEARTBEAT) && (message.msgid != MAVLINK_MSG_ID_RADIO_STATUS)) {
             link->reportMavlinkV1Traffic();
             continue;
         }
 
         if (!isV1) {
+            link->reportMavlinkV2Traffic();
             _updateCounters(mavlinkChannel, message);
         }
         if (!linkPtr->linkConfiguration()->isForwarding()) {

--- a/src/Comms/MockLink/MockConfiguration.cc
+++ b/src/Comms/MockLink/MockConfiguration.cc
@@ -21,6 +21,7 @@ MockConfiguration::MockConfiguration(const MockConfiguration *copy, QObject *par
     , _incrementVehicleId(copy->incrementVehicleId())
     , _startArmed(copy->startArmed())
     , _preloadMission(copy->preloadMission())
+    , _stayMavlinkV1(copy->stayMavlinkV1())
     , _cameraCaptureVideo(copy->cameraCaptureVideo())
     , _cameraCaptureImage(copy->cameraCaptureImage())
     , _cameraHasModes(copy->cameraHasModes())
@@ -78,6 +79,7 @@ void MockConfiguration::copyFrom(const LinkConfiguration *source)
     setGimbalHasNeutral(mockLinkSource->gimbalHasNeutral());
     setStartArmed(mockLinkSource->startArmed());
     setPreloadMission(mockLinkSource->preloadMission());
+    setStayMavlinkV1(mockLinkSource->stayMavlinkV1());
 }
 
 void MockConfiguration::loadSettings(QSettings &settings, const QString &root)

--- a/src/Comms/MockLink/MockConfiguration.h
+++ b/src/Comms/MockLink/MockConfiguration.h
@@ -44,6 +44,7 @@ public:
         OptionEnableGimbal    = 1 << 2,
         OptionEnableProximity = 1 << 3,
         OptionPreloadMission  = 1 << 4,
+        OptionStayMavlinkV1   = 1 << 5,
     };
     Q_DECLARE_FLAGS(Options, Option)
     Q_FLAG(Options)
@@ -131,6 +132,11 @@ public:
     bool preloadMission() const { return _preloadMission; }
     void setPreloadMission(bool preloadMission) { _preloadMission = preloadMission; }
 
+    // Test-only: when true, outgoing traffic never upgrades from MAVLink v1 to v2,
+    // simulating a vehicle which only supports MAVLink v1. Not persisted.
+    bool stayMavlinkV1() const { return _stayMavlinkV1; }
+    void setStayMavlinkV1(bool stayV1) { _stayMavlinkV1 = stayV1; }
+
 signals:
     void firmwareChanged();
     void vehicleChanged();
@@ -169,6 +175,7 @@ private:
     uint16_t _boardProductId = 0;
     bool _startArmed = false;
     bool _preloadMission = false;
+    bool _stayMavlinkV1 = false;
 
     // Camera capability flags (defaults match current Camera 1 configuration)
     bool _cameraCaptureVideo = true;

--- a/src/Comms/MockLink/MockLink.cc
+++ b/src/Comms/MockLink/MockLink.cc
@@ -65,6 +65,7 @@ MockLink::MockLink(SharedLinkConfigurationPtr &config, QObject *parent)
     , _enableGimbal(_mockConfig->enableGimbal())
     , _enableProximity(_mockConfig->enableProximity())
     , _failureMode(_mockConfig->failureMode())
+    , _stayMavlinkV1(_mockConfig->stayMavlinkV1())
     , _vehicleSystemId(_mockConfig->incrementVehicleId() ? _nextVehicleSystemId++ : static_cast<int>(_nextVehicleSystemId))
     , _vehicleLatitude(_defaultVehicleLatitude + ((_vehicleSystemId - 128) * 0.0001))
     , _vehicleLongitude(_defaultVehicleLongitude + ((_vehicleSystemId - 128) * 0.0001))
@@ -160,8 +161,17 @@ bool MockLink::_connect()
     if (!_connected) {
         _connected = true;
         _disconnectedEmitted = false;
+        // ArduPilot starts out sending MAVLink v1 and only switches to v2 once it sees a v2
+        // message from the GCS. Emulate that: outgoing traffic starts as v1.
+        // High latency links are exempt: QGC doesn't transmit on them, so the upgrade could never happen.
+        // Note: high latency takes precedence over OptionStayMavlinkV1 (the two are not meant to be combined).
+        _mavlinkV2Upgraded = linkConfiguration()->isHighLatency();
         mavlink_status_t *const outgoingStatus = mavlink_get_channel_status(_outgoingMavlinkChannel);
-        outgoingStatus->flags &= ~MAVLINK_STATUS_FLAG_OUT_MAVLINK1;
+        if (_mavlinkV2Upgraded) {
+            outgoingStatus->flags &= ~MAVLINK_STATUS_FLAG_OUT_MAVLINK1;
+        } else {
+            outgoingStatus->flags |= MAVLINK_STATUS_FLAG_OUT_MAVLINK1;
+        }
         mavlink_status_t *const incomingStatus = mavlink_get_channel_status(_incomingMavlinkChannel);
         incomingStatus->flags &= ~MAVLINK_STATUS_FLAG_OUT_MAVLINK1;
         emit connected();
@@ -875,6 +885,13 @@ void MockLink::_handleIncomingMavlinkBytes(const uint8_t *bytes, int cBytes)
         const int parsed = mavlink_parse_char(_incomingMavlinkChannel, bytes[i], &msg, &comm);
         if (!parsed) {
             continue;
+        }
+        if (!_mavlinkV2Upgraded && !_stayMavlinkV1 && (msg.magic == MAVLINK_STX)) {
+            // First v2 message from GCS: switch outgoing traffic to v2, same as ArduPilot does.
+            _mavlinkV2Upgraded = true;
+            mavlink_status_t *const outgoingStatus = mavlink_get_channel_status(_outgoingMavlinkChannel);
+            outgoingStatus->flags &= ~MAVLINK_STATUS_FLAG_OUT_MAVLINK1;
+            qCDebug(MockLinkLog) << "Received MAVLink v2 message from GCS, upgrading outgoing traffic to v2";
         }
         lock.unlock();
         _handleIncomingMavlinkMsg(msg);
@@ -2306,6 +2323,7 @@ MockLink *MockLink::_startMockLinkWorker(const QString &configName, MAV_AUTOPILO
     mockConfig->setEnableGimbal(options.testFlag(MockConfiguration::OptionEnableGimbal));
     mockConfig->setEnableProximity(options.testFlag(MockConfiguration::OptionEnableProximity));
     mockConfig->setPreloadMission(options.testFlag(MockConfiguration::OptionPreloadMission));
+    mockConfig->setStayMavlinkV1(options.testFlag(MockConfiguration::OptionStayMavlinkV1));
     mockConfig->setFailureMode(failureMode);
 
     return _startMockLink(mockConfig);
@@ -2766,9 +2784,10 @@ void MockLink::_sendRemoteIDArmStatus()
     std::strncpy(armStatusError, errorUtf8.constData(), sizeof(armStatusError) - 1);
 
     mavlink_message_t msg{};
-    (void) mavlink_msg_open_drone_id_arm_status_pack(
+    (void) mavlink_msg_open_drone_id_arm_status_pack_chan(
         _vehicleSystemId,
         MAV_COMP_ID_ODID_TXRX_1,
+        static_cast<uint8_t>(_outgoingMavlinkChannel),
         &msg,
         armStatus,
         armStatusError

--- a/src/Comms/MockLink/MockLink.h
+++ b/src/Comms/MockLink/MockLink.h
@@ -321,6 +321,7 @@ private:
     const bool _enableGimbal = false;
     const bool _enableProximity = false;
     const MockConfiguration::FailureMode_t _failureMode = MockConfiguration::FailNone;
+    const bool _stayMavlinkV1 = false;  ///< Test-only: never upgrade outgoing traffic to MAVLink v2
     const uint8_t _vehicleSystemId = 0;
     const double _vehicleLatitude = 0.0;
     const double _vehicleLongitude = 0.0;
@@ -362,6 +363,7 @@ private:
 
     double _vehicleAltitudeAMSL = _defaultVehicleHomeAltitude;
     std::atomic<bool> _commLost = false;
+    bool _mavlinkV2Upgraded = false;    ///< True once outgoing traffic has switched from v1 to v2
     bool _signingEnabled = false;
     bool _highLatencyTransmissionEnabled = true;
 

--- a/test/Comms/CMakeLists.txt
+++ b/test/Comms/CMakeLists.txt
@@ -11,6 +11,8 @@ target_sources(${CMAKE_PROJECT_NAME}
         LinkManagerTest.h
         LogReplayLinkControllerTest.cc
         LogReplayLinkControllerTest.h
+        MAVLinkV1TrafficTest.cc
+        MAVLinkV1TrafficTest.h
         QGCSerialPortInfoTest.cc
         QGCSerialPortInfoTest.h
 )
@@ -22,4 +24,5 @@ add_subdirectory(Bluetooth)
 add_qgc_test(LinkConfigurationTest LABELS Unit Comms RESOURCE_LOCK Settings TempFiles)
 add_qgc_test(LinkManagerTest LABELS Integration Comms SERIAL)
 add_qgc_test(LogReplayLinkControllerTest LABELS Unit Comms)
+add_qgc_test(MAVLinkV1TrafficTest LABELS Integration Comms)
 add_qgc_test(QGCSerialPortInfoTest LABELS Unit Comms)

--- a/test/Comms/MAVLinkV1TrafficTest.cc
+++ b/test/Comms/MAVLinkV1TrafficTest.cc
@@ -1,0 +1,113 @@
+#include "MAVLinkV1TrafficTest.h"
+
+#include <QtTest/QSignalSpy>
+#include <QtTest/QTest>
+
+#include "LinkInterface.h"
+#include "MAVLinkLib.h"
+#include "MAVLinkProtocol.h"
+#include "MockLink.h"
+
+namespace {
+
+/// Packs a MAVLink v1 framed message and returns the wire bytes.
+template <typename PackFunc>
+QByteArray packV1Message(int systemId, PackFunc packFunc)
+{
+    mavlink_status_t packStatus{};
+    packStatus.flags |= MAVLINK_STATUS_FLAG_OUT_MAVLINK1;
+
+    mavlink_message_t msg{};
+    packFunc(static_cast<uint8_t>(systemId), MAV_COMP_ID_AUTOPILOT1, &packStatus, &msg);
+
+    uint8_t buffer[MAVLINK_MAX_PACKET_LEN]{};
+    const int cBuffer = mavlink_msg_to_send_buffer(buffer, &msg);
+    return QByteArray(reinterpret_cast<char*>(buffer), cBuffer);
+}
+
+QByteArray v1RadioStatusBytes(int systemId)
+{
+    return packV1Message(systemId, [](uint8_t sysId, uint8_t compId, mavlink_status_t* status, mavlink_message_t* msg) {
+        (void) mavlink_msg_radio_status_pack_status(sysId, compId, status, msg, 100, 100, 50, 10, 10, 0, 0);
+    });
+}
+
+QByteArray v1VibrationBytes(int systemId)
+{
+    return packV1Message(systemId, [](uint8_t sysId, uint8_t compId, mavlink_status_t* status, mavlink_message_t* msg) {
+        (void) mavlink_msg_vibration_pack_status(sysId, compId, status, msg, 0, 0.1f, 0.1f, 0.1f, 0, 0, 0);
+    });
+}
+
+} // namespace
+
+void MAVLinkV1TrafficTest::cleanup()
+{
+    LinkInterface::setMavlinkV1TrafficGraceMsecs(LinkInterface::kMavlinkV1TrafficGraceMsecsDefault);
+    VehicleTestManualConnect::cleanup();
+}
+
+void MAVLinkV1TrafficTest::_testV1UpgradeToV2NoWarning()
+{
+    // Expected warning on any full APM MockLink connect (no metadata json available).
+    ignoreLogMessage("ComponentInformation.RequestMetaDataTypeStateMachine", QtWarningMsg,
+                     QRegularExpression(QStringLiteral("failed to load metadata")));
+
+    // MockLink starts out sending MAVLink v1 just like a real ArduPilot. The initial connect
+    // sequence can only complete if the v1 -> v2 upgrade handshake works.
+    _connectMockLink(MAV_AUTOPILOT_ARDUPILOTMEGA);
+
+    const mavlink_status_t* const outgoingStatus = mavlink_get_channel_status(_mockLink->outgoingMavlinkChannel());
+    QVERIFY2(!(outgoingStatus->flags & MAVLINK_STATUS_FLAG_OUT_MAVLINK1), "MockLink should have upgraded outgoing traffic to MAVLink v2");
+
+    // The early v1 traffic must not have triggered the v1-only warning.
+    // Strict log capture additionally fails this test if the warning/dialog fired.
+    QVERIFY(!_mockLink->mavlinkV1TrafficReported());
+}
+
+void MAVLinkV1TrafficTest::_testV1OnlyVehicleWarns()
+{
+    LinkInterface::setMavlinkV1TrafficGraceMsecs(250);
+
+    expectLogMessage("Comms.LinkInterface", QtWarningMsg, QRegularExpression(QStringLiteral("MAVLink v1 traffic detected")));
+    expectAppMessage(QRegularExpression(QStringLiteral("only supports MAVLink v2")));
+
+    // Vehicle which never upgrades to v2: MockLink streams telemetry at 1Hz, so once the grace
+    // period expires the next v1 message must trigger the warning.
+    _connectMockLinkNoInitialConnectSequence(MockConfiguration::OptionStayMavlinkV1);
+
+    QTRY_VERIFY_WITH_TIMEOUT(_mockLink->mavlinkV1TrafficReported(), TestTimeout::longMs());
+    verifyExpectedLogMessage();
+    verifyExpectedLogMessage();
+}
+
+void MAVLinkV1TrafficTest::_testV1RadioStatusDoesNotWarn()
+{
+    _connectMockLinkNoInitialConnectSequence(MockConfiguration::OptionStayMavlinkV1);
+
+    // Silence MockLink's own streams so the injected messages are the only v1 traffic.
+    _mockLink->setCommLost(true);
+
+    // Grace period must only be zeroed after the connect above: while connecting, MockLink's own
+    // v1 streams are still running and must not trigger the warning (default grace covers them).
+    LinkInterface::setMavlinkV1TrafficGraceMsecs(0);
+
+    // SiK radios frame RADIO_STATUS as v1 forever — it must never trigger the warning.
+    MAVLinkProtocol* const protocol = MAVLinkProtocol::instance();
+    for (int i = 0; i < 2; i++) {
+        protocol->receiveBytes(_mockLink, v1RadioStatusBytes(_mockLink->vehicleId()));
+    }
+    QVERIFY2(!_mockLink->mavlinkV1TrafficReported(), "v1 RADIO_STATUS must not trigger the v1-only warning");
+
+    // Positive control: a non-exempt v1 message does trigger the warning once the grace period (0) expired.
+    expectLogMessage("Comms.LinkInterface", QtWarningMsg, QRegularExpression(QStringLiteral("MAVLink v1 traffic detected")));
+    expectAppMessage(QRegularExpression(QStringLiteral("only supports MAVLink v2")));
+    for (int i = 0; i < 2; i++) {
+        protocol->receiveBytes(_mockLink, v1VibrationBytes(_mockLink->vehicleId()));
+    }
+    QVERIFY(_mockLink->mavlinkV1TrafficReported());
+    verifyExpectedLogMessage();
+    verifyExpectedLogMessage();
+}
+
+UT_REGISTER_TEST(MAVLinkV1TrafficTest, TestLabel::Integration, TestLabel::Comms)

--- a/test/Comms/MAVLinkV1TrafficTest.h
+++ b/test/Comms/MAVLinkV1TrafficTest.h
@@ -1,0 +1,22 @@
+#pragma once
+
+#include "BaseClasses/VehicleTestManualConnect.h"
+
+/// Tests handling of MAVLink v1 traffic.
+///
+/// ArduPilot starts each link in MAVLink v1 and only upgrades to v2 once it receives a v2
+/// message from the GCS. QGC must tolerate that handshake without reporting the
+/// "only supports MAVLink v2" warning, while still reporting vehicles which never upgrade.
+/// RADIO_STATUS is exempt since SiK radios always frame it as v1.
+class MAVLinkV1TrafficTest : public VehicleTestManualConnect
+{
+    Q_OBJECT
+
+protected slots:
+    void cleanup() override;
+
+private slots:
+    void _testV1UpgradeToV2NoWarning();
+    void _testV1OnlyVehicleWarns();
+    void _testV1RadioStatusDoesNotWarn();
+};

--- a/test/UnitTestFramework/BaseClasses/VehicleTest.cc
+++ b/test/UnitTestFramework/BaseClasses/VehicleTest.cc
@@ -125,7 +125,7 @@ void VehicleTest::simulateConnectionRemoved()
     }
 }
 
-void VehicleTest::_connectMockLink(MAV_AUTOPILOT autopilot, MockConfiguration::FailureMode_t failureMode)
+void VehicleTest::_connectMockLink(MAV_AUTOPILOT autopilot, MockConfiguration::FailureMode_t failureMode, MockConfiguration::Options options)
 {
     QVERIFY2(!_mockLink, "MockLink already connected");
 
@@ -134,16 +134,16 @@ void VehicleTest::_connectMockLink(MAV_AUTOPILOT autopilot, MockConfiguration::F
 
     switch (autopilot) {
         case MAV_AUTOPILOT_PX4:
-            _mockLink = MockLink::startPX4MockLink(MockConfiguration::OptionNone, failureMode);
+            _mockLink = MockLink::startPX4MockLink(options, failureMode);
             break;
         case MAV_AUTOPILOT_ARDUPILOTMEGA:
-            _mockLink = MockLink::startAPMArduCopterMockLink(MockConfiguration::OptionNone, failureMode);
+            _mockLink = MockLink::startAPMArduCopterMockLink(options, failureMode);
             break;
         case MAV_AUTOPILOT_GENERIC:
-            _mockLink = MockLink::startGenericMockLink(MockConfiguration::OptionNone, failureMode);
+            _mockLink = MockLink::startGenericMockLink(options, failureMode);
             break;
         case MAV_AUTOPILOT_INVALID:
-            _mockLink = MockLink::startNoInitialConnectMockLink();
+            _mockLink = MockLink::startNoInitialConnectMockLink(options);
             break;
         default:
             QFAIL(qPrintable(QStringLiteral("Unsupported autopilot type: %1").arg(autopilot)));

--- a/test/UnitTestFramework/BaseClasses/VehicleTest.h
+++ b/test/UnitTestFramework/BaseClasses/VehicleTest.h
@@ -132,13 +132,15 @@ protected:
     /// Connects a MockLink vehicle and waits for initial connect sequence
     /// @param autopilot Autopilot type (PX4, ArduPilot, Generic)
     /// @param failureMode Optional failure mode for testing error handling
+    /// @param options Optional MockConfiguration options
     void _connectMockLink(MAV_AUTOPILOT autopilot = MAV_AUTOPILOT_PX4,
-                          MockConfiguration::FailureMode_t failureMode = MockConfiguration::FailNone);
+                          MockConfiguration::FailureMode_t failureMode = MockConfiguration::FailNone,
+                          MockConfiguration::Options options = MockConfiguration::OptionNone);
 
     /// Connects MockLink without waiting for initial connect sequence
-    void _connectMockLinkNoInitialConnectSequence()
+    void _connectMockLinkNoInitialConnectSequence(MockConfiguration::Options options = MockConfiguration::OptionNone)
     {
-        _connectMockLink(MAV_AUTOPILOT_INVALID);
+        _connectMockLink(MAV_AUTOPILOT_INVALID, MockConfiguration::FailNone, options);
     }
 
     /// Disconnects the current MockLink and waits for vehicle to be removed


### PR DESCRIPTION
## Problem

Connecting a stable ArduPilot vehicle pops a false "MAVLink v1 traffic detected" dialog. ArduPilot starts links in MAVLink v1 and only upgrades to v2 after it sees v2 traffic from the GCS, so the early v1 messages during connect are expected and harmless — but QGC warned on the first v1 non-heartbeat message.

## Fix

- **LinkInterface**: the v1-only warning is now deferred by a 10s grace period, and permanently suppressed once any v2 message is seen on the link. A v1-only vehicle still gets the warning after the grace period expires.
- **MAVLinkProtocol**: `RADIO_STATUS` is exempt from the v1 warning and is now allowed through to processing — SiK radios always frame it as v1.
- **MockLink**: now emulates ArduPilot's real behavior — outgoing traffic starts as v1 and upgrades to v2 on the first v2 message from the GCS. High latency links start directly in v2 since QGC never transmits on them. Also fixes `OPEN_DRONE_ID_ARM_STATUS` being packed on the wrong (QGC-side) channel.
- **Tests**: new `MAVLinkV1TrafficTest` covers the v1→v2 upgrade (no warning), a v1-only vehicle (warning fires after grace), and the `RADIO_STATUS` exemption. Test-only `OptionStayMavlinkV1` MockLink option simulates a v1-only vehicle.

## Testing

- New `MAVLinkV1TrafficTest` written first and verified failing before the fix (TDD)
- Full `InitialConnectTest` + `MAVLinkV1TrafficTest` pass; full Unit/Integration regression run locally