### PR TITLE
fix(APMSensors): ignore stale MAG_CAL_REPORT streams when starting compass cal

### DIFF
--- a/src/AutoPilotPlugins/APM/APMSensorsComponentController.cc
+++ b/src/AutoPilotPlugins/APM/APMSensorsComponentController.cc
@@ -106,6 +106,10 @@ void APMSensorsComponentController::_resetInternalState()
 
 void APMSensorsComponentController::_stopCalibration(APMSensorsComponentController::StopCalibrationCode code)
 {
+    // Clear mag cal sequencing state first so a reentrant CANCEL ack can't trigger a new START
+    _magCalStartAccepted = false;
+    _magCalCancelBeforeStartPending = false;
+
     (void) disconnect(MAVLinkProtocol::instance(), &MAVLinkProtocol::messageReceived, this, &APMSensorsComponentController::_mavlinkMessageReceived);
     _vehicle->vehicleLinkManager()->setCommunicationLostEnabled(true);
 
@@ -117,6 +121,10 @@ void APMSensorsComponentController::_stopCalibration(APMSensorsComponentControll
 
     if (_calTypeInProgress == QGCMAVLink::CalibrationMag) {
         _restorePreviousCompassCalFitness();
+        if (code == StopCalibrationFailed) {
+            // ArduPilot keeps streaming the failed MAG_CAL_REPORT until cancelled
+            _vehicle->sendMavCommand(_vehicle->defaultComponentId(), MAV_CMD_DO_CANCEL_MAG_CAL, false /* showError */);
+        }
     }
 
     if (code == StopCalibrationSuccess) {
@@ -168,8 +176,18 @@ void APMSensorsComponentController::_mavCommandResult(int vehicleId, int compone
     }
 
     switch (command) {
+    case MAV_CMD_DO_CANCEL_MAG_CAL:
+        if (_magCalCancelBeforeStartPending) {
+            // Pre-start flush of stale cal state is complete (result doesn't matter - older
+            // firmwares reject CANCEL when no cal is running). Safe to start the new cal now.
+            _magCalCancelBeforeStartPending = false;
+            _sendStartMagCal();
+        }
+        break;
     case MAV_CMD_DO_START_MAG_CAL:
-        if (result != MAV_RESULT_ACCEPTED) {
+        if (result == MAV_RESULT_ACCEPTED) {
+            _magCalStartAccepted = true;
+        } else {
             _appendStatusLog(tr("Failed to start compass calibration"));
             _stopCalibration(StopCalibrationFailed);
         }
@@ -191,6 +209,7 @@ void APMSensorsComponentController::_mavCommandResult(int vehicleId, int compone
 void APMSensorsComponentController::calibrateCompass()
 {
     _calTypeInProgress = QGCMAVLink::CalibrationMag;
+    _magCalStartAccepted = false;
     _rgCompassCalProgress[0] = 0;
     _rgCompassCalProgress[1] = 0;
     _rgCompassCalProgress[2] = 0;
@@ -236,15 +255,26 @@ void APMSensorsComponentController::calibrateCompass()
 
     _appendStatusLog(tr("Rotate the vehicle randomly around all axes until the progress bar fills all the way to the right."));
     (void) connect(_vehicle, &Vehicle::mavCommandResult, this, &APMSensorsComponentController::_mavCommandResult, Qt::UniqueConnection);
+
+    // A previously failed cal keeps streaming MAG_CAL_REPORT until cancelled. Flush that stale
+    // state before starting so it can't instantly complete the new calibration. START is sent
+    // from the CANCEL ack handler (_mavCommandResult) so the two commands can't race.
+    _magCalCompassBits = compassBits;
+    _magCalCancelBeforeStartPending = true;
+    _vehicle->sendMavCommand(_vehicle->defaultComponentId(), MAV_CMD_DO_CANCEL_MAG_CAL, false /* showError */);
+}
+
+void APMSensorsComponentController::_sendStartMagCal()
+{
     _vehicle->sendMavCommand(
         _vehicle->defaultComponentId(),
         MAV_CMD_DO_START_MAG_CAL,
-        true,          // showError
-        compassBits,   // which compass(es) to calibrate
-        0,             // no retry on failure
-        1,             // save values after complete
-        0,             // no delayed start
-        0              // no auto-reboot
+        true,                // showError
+        _magCalCompassBits,  // which compass(es) to calibrate
+        0,                   // no retry on failure
+        1,                   // save values after complete
+        0,                   // no delayed start
+        0                    // no auto-reboot
     );
 }
 
@@ -394,6 +424,8 @@ void APMSensorsComponentController::cancelCalibration()
     _cancelButton->setEnabled(false);
 
     if (_calTypeInProgress == QGCMAVLink::CalibrationMag) {
+        // Clear pending start first so a reentrant CANCEL ack can't trigger a new START
+        _magCalCancelBeforeStartPending = false;
         _vehicle->sendMavCommand(_vehicle->defaultComponentId(), MAV_CMD_DO_CANCEL_MAG_CAL, true /* showError */);
         _stopCalibration(StopCalibrationCancelled);
     } else {
@@ -478,7 +510,7 @@ void APMSensorsComponentController::_handleCommandAck(const mavlink_message_t &m
 
 void APMSensorsComponentController::_handleMagCalProgress(const mavlink_message_t &message)
 {
-    if (_calTypeInProgress != QGCMAVLink::CalibrationMag) {
+    if ((_calTypeInProgress != QGCMAVLink::CalibrationMag) || !_magCalStartAccepted) {
         return;
     }
 
@@ -510,7 +542,7 @@ void APMSensorsComponentController::_handleMagCalProgress(const mavlink_message_
 
 void APMSensorsComponentController::_handleMagCalReport(const mavlink_message_t &message)
 {
-    if (_calTypeInProgress != QGCMAVLink::CalibrationMag) {
+    if ((_calTypeInProgress != QGCMAVLink::CalibrationMag) || !_magCalStartAccepted) {
         return;
     }
 

--- a/src/AutoPilotPlugins/APM/APMSensorsComponentController.h
+++ b/src/AutoPilotPlugins/APM/APMSensorsComponentController.h
@@ -145,6 +145,10 @@ private:
     };
     void _stopCalibration(StopCalibrationCode code);
 
+    /// Sends MAV_CMD_DO_START_MAG_CAL using _magCalCompassBits. Called from the
+    /// pre-start MAV_CMD_DO_CANCEL_MAG_CAL ack handler.
+    void _sendStartMagCal();
+
     void _updateAndEmitShowOrientationCalArea(bool show);
 
     APMSensorsComponent *_sensorsComponent = nullptr;
@@ -158,6 +162,15 @@ private:
     bool _showOrientationCalArea = false;
 
     QGCMAVLink::CalibrationType _calTypeInProgress = QGCMAVLink::CalibrationNone;
+
+    /// ArduPilot keeps streaming MAG_CAL_PROGRESS/MAG_CAL_REPORT from a previous cal (a failed
+    /// cal streams until cancelled). Ignore those messages until our start command is accepted.
+    bool _magCalStartAccepted = false;
+
+    /// True while waiting for the pre-start MAV_CMD_DO_CANCEL_MAG_CAL ack; START is sent from
+    /// the ack handler so stale messages can't race into the new calibration session.
+    bool _magCalCancelBeforeStartPending = false;
+    uint8_t _magCalCompassBits = 0; ///< Compasses to calibrate, sent with the deferred START
 
     uint8_t _rgCompassCalProgress[3];
     bool _rgCompassCalComplete[3];

--- a/src/Comms/MockLink/MockLink.cc
+++ b/src/Comms/MockLink/MockLink.cc
@@ -1766,18 +1766,25 @@ void MockLink::_handleCommandLong(const mavlink_message_t &msg)
         commandResult = MAV_RESULT_ACCEPTED;
         break;
     case MAV_CMD_DO_START_MAG_CAL:
-        // APM onboard compass calibration: start sending MAG_CAL_PROGRESS then MAG_CAL_REPORT
+        // APM onboard compass calibration: start sending MAG_CAL_PROGRESS then MAG_CAL_REPORT.
+        // Note: does NOT stop stale failed report streaming - like real ArduPilot, only
+        // MAV_CMD_DO_CANCEL_MAG_CAL stops the failed report stream.
         if (_firmwareType == MAV_AUTOPILOT_ARDUPILOTMEGA) {
-            QMutexLocker locker(&_apmCompassCalMutex);
-            _apmCompassCalProgress  = 0;
-            _apmCompassCalTickCount = 0;
-            commandResult = MAV_RESULT_ACCEPTED;
+            if (_apmMagCalStartFailureMode) {
+                commandResult = MAV_RESULT_FAILED;
+            } else {
+                QMutexLocker locker(&_apmCompassCalMutex);
+                _apmCompassCalProgress  = 0;
+                _apmCompassCalTickCount = 0;
+                commandResult = MAV_RESULT_ACCEPTED;
+            }
         }
         break;
     case MAV_CMD_DO_CANCEL_MAG_CAL:
         // Stop APM compass calibration worker
         if (_firmwareType == MAV_AUTOPILOT_ARDUPILOTMEGA) {
             QMutexLocker locker(&_apmCompassCalMutex);
+            _apmStaleFailedMagCalReportStreaming = false;
             _apmCompassCalProgress = -1;
             commandResult = MAV_RESULT_ACCEPTED;
         }
@@ -2952,6 +2959,19 @@ int MockLink::_availableModesCount() const
 // Worker sends MAG_CAL_PROGRESS at ~10Hz (every 50 calls of 500Hz worker),
 // then sends MAG_CAL_REPORT when pct reaches 100.
 // ---------------------------------------------------------------------------
+void MockLink::startAPMStaleFailedMagCalReportStreaming()
+{
+    QMutexLocker locker(&_apmCompassCalMutex);
+    _apmStaleFailedMagCalReportStreaming = true;
+    _apmCompassCalTickCount = 0;
+}
+
+bool MockLink::apmStaleFailedMagCalReportStreamingActive() const
+{
+    QMutexLocker locker(&_apmCompassCalMutex);
+    return _apmStaleFailedMagCalReportStreaming;
+}
+
 void MockLink::_apmCompassCalWorker()
 {
     if (_firmwareType != MAV_AUTOPILOT_ARDUPILOTMEGA) {
@@ -2959,7 +2979,7 @@ void MockLink::_apmCompassCalWorker()
     }
 
     QMutexLocker locker(&_apmCompassCalMutex);
-    if (_apmCompassCalProgress < 0) {
+    if ((_apmCompassCalProgress < 0) && !_apmStaleFailedMagCalReportStreaming) {
         return;
     }
 
@@ -2968,6 +2988,20 @@ void MockLink::_apmCompassCalWorker()
         return;
     }
     _apmCompassCalTickCount = 0;
+
+    if (_apmStaleFailedMagCalReportStreaming) {
+        // Simulate ArduPilot streaming the report from a previously failed cal until cancelled
+        mavlink_message_t msg{};
+        mavlink_mag_cal_report_t report{};
+        report.compass_id  = 0;
+        report.cal_mask    = 0x01;
+        report.cal_status  = MAG_CAL_FAILED;
+        report.fitness     = 999.0f;
+        (void) mavlink_msg_mag_cal_report_encode_chan(
+            _vehicleSystemId, _vehicleComponentId, _outgoingMavlinkChannel, &msg, &report);
+        respondWithMavlinkMessage(msg);
+        return;
+    }
 
     const int pct = _apmCompassCalProgress;
 

--- a/src/Comms/MockLink/MockLink.h
+++ b/src/Comms/MockLink/MockLink.h
@@ -171,6 +171,18 @@ public:
     /// Change a float parameter value directly on MockLink (for testing cache invalidation)
     void setMockParamValue(int componentId, const QString &paramName, float value);
 
+    /// Simulates ArduPilot streaming MAG_CAL_REPORT(MAG_CAL_FAILED) after a failed onboard
+    /// compass cal. Like real ArduPilot, the failed report keeps streaming until
+    /// MAV_CMD_DO_CANCEL_MAG_CAL is received; MAV_CMD_DO_START_MAG_CAL does not stop it.
+    void startAPMStaleFailedMagCalReportStreaming();
+
+    /// Returns true while the stale failed MAG_CAL_REPORT stream is active
+    bool apmStaleFailedMagCalReportStreamingActive() const;
+
+    /// When enabled, MAV_CMD_DO_START_MAG_CAL is rejected with MAV_RESULT_FAILED
+    /// instead of starting the compass cal simulation.
+    void setAPMMagCalStartFailureMode(bool fail) { _apmMagCalStartFailureMode = fail; }
+
     /// Change an int32 parameter value directly on MockLink. Used to simulate the
     /// firmware storing calibration results (e.g. CAL_MAG0_ID).
     void setInt32ParamValue(int componentId, const QString &paramName, int32_t value) { _mapParamName2Value[componentId][paramName] = QVariant::fromValue(value); }
@@ -416,9 +428,11 @@ private:
     // APM compass calibration worker state
     // Protects _apmCompassCalProgress: main thread writes 0 to start/stop,
     // worker thread reads/increments each 100ms tick.
-    QMutex _apmCompassCalMutex;
+    mutable QMutex _apmCompassCalMutex;
     int    _apmCompassCalProgress  = -1; ///< -1 = inactive, 0-100 = progress pct
     int    _apmCompassCalTickCount = 0;  ///< 500 Hz tick counter for ~10 Hz throttle
+    bool   _apmStaleFailedMagCalReportStreaming = false; ///< Streaming MAG_CAL_REPORT(FAILED) from a previous failed cal
+    bool   _apmMagCalStartFailureMode = false; ///< Reject MAV_CMD_DO_START_MAG_CAL with MAV_RESULT_FAILED
 
     // APM accel calibration worker state
     // Protects _apmAccelCalPos: main thread writes the starting pos,

--- a/test/QmlUITests/APMSensorsCalibrationUITest.cc
+++ b/test/QmlUITests/APMSensorsCalibrationUITest.cc
@@ -275,6 +275,130 @@ void APMSensorsCalibrationUITest::_testCompassCalibrationCancel()
 }
 
 // ---------------------------------------------------------------------------
+// _testCompassCalibrationIgnoresStaleFailedReports
+//
+// ArduPilot keeps streaming MAG_CAL_REPORT(MAG_CAL_FAILED) after a failed
+// onboard compass cal until it is cancelled. Starting a new calibration while
+// that stream is active must not instantly complete/fail the new cal.
+// ---------------------------------------------------------------------------
+void APMSensorsCalibrationUITest::_testCompassCalibrationIgnoresStaleFailedReports()
+{
+    ignoreAPMMockLinkWarnings();
+    runWithMockLink(
+        [] { return MockLink::startAPMArduCopterMockLink(); },
+        [&](QPointer<MockLink> mockLink, Vehicle *vehicle) {
+
+    resetAPMParamsToUncalibrated(vehicle);
+    if (QTest::currentTestFailed()) return;
+
+    _navigateToSensorsPage();
+    if (QTest::currentTestFailed()) return;
+
+    // Must do accel first
+    _runFullAccelCal();
+    if (QTest::currentTestFailed()) return;
+    waitForParamRefreshQuiet(vehicle);
+
+    // Simulate leftover MAG_CAL_REPORT(FAILED) stream from a previously failed cal
+    mockLink->startAPMStaleFailedMagCalReportStreaming();
+
+    // Start compass cal while the stale stream is active
+    QVERIFY2(clickButton(QStringLiteral("sensorsSetup_calibrateCompass")),
+             "Failed to click Compass button");
+    QVERIFY2(findVisibleItem(_rootItem, QStringLiteral("popupDialog_acceptButton"), 5000),
+             "Pre-compass-cal dialog not found");
+    QVERIFY2(clickButton(QStringLiteral("popupDialog_acceptButton")),
+             "Failed to accept pre-compass-cal dialog");
+
+    // The stale failed reports must not terminate the new calibration: the cancel
+    // button stays enabled while a compass cal is active, so it must remain enabled.
+    QQuickItem *cancelBtn = findVisibleItem(_rootItem, QStringLiteral("sensorsSetup_cancelButton"), 2000);
+    QVERIFY2(cancelBtn, "Cancel button not found");
+    QVERIFY2(QTest::qWaitFor([&] { return cancelBtn->property("enabled").toBool(); }, 5000),
+             "Compass cal never became active");
+
+    // Starting the new cal must have cancelled the stale stream on the vehicle
+    QVERIFY2(QTest::qWaitFor([&] { return !mockLink->apmStaleFailedMagCalReportStreamingActive(); }, 5000),
+             "Stale failed MAG_CAL_REPORT stream was never cancelled");
+
+    // Calibration must still be running (not instantly completed/failed by a stale report):
+    // give the stale stream time to have been (mis)processed, then check cancel still enabled.
+    QVERIFY2(!QTest::qWaitFor([&] { return !cancelBtn->property("enabled").toBool(); }, 2000),
+             "Compass cal terminated prematurely - stale MAG_CAL_REPORT was processed");
+
+    // Now let the normal MockLink progress simulation complete the calibration
+    QVERIFY2(findVisibleItem(_rootItem, QStringLiteral("popupDialog_acceptButton"), 25000),
+             "Post-compass-cal dialog not shown");
+    QVERIFY2(clickButton(QStringLiteral("popupDialog_acceptButton")),
+             "Failed to dismiss post-compass-cal dialog");
+
+    waitForParamRefreshQuiet(vehicle);
+
+    // Both indicators must be green - the cal completed successfully
+    _verifyCalIndicators(/*compassGreen=*/true, /*accelGreen=*/true, "after compass cal with stale reports");
+
+    });
+}
+
+// ---------------------------------------------------------------------------
+// _testCompassCalibrationStartRejected
+//
+// MAG_CAL_PROGRESS/REPORT are ignored until MAV_CMD_DO_START_MAG_CAL is
+// accepted, so a rejected START is the only exit path for a cal that never
+// starts. Verify the UI exits cleanly instead of staying in a running state.
+// ---------------------------------------------------------------------------
+void APMSensorsCalibrationUITest::_testCompassCalibrationStartRejected()
+{
+    ignoreAPMMockLinkWarnings();
+    runWithMockLink(
+        [] { return MockLink::startAPMArduCopterMockLink(); },
+        [&](QPointer<MockLink> mockLink, Vehicle *vehicle) {
+
+    resetAPMParamsToUncalibrated(vehicle);
+    if (QTest::currentTestFailed()) return;
+
+    _navigateToSensorsPage();
+    if (QTest::currentTestFailed()) return;
+
+    // Must do accel first
+    _runFullAccelCal();
+    if (QTest::currentTestFailed()) return;
+    waitForParamRefreshQuiet(vehicle);
+
+    // Vehicle rejects MAV_CMD_DO_START_MAG_CAL
+    mockLink->setAPMMagCalStartFailureMode(true);
+
+    // START is sent with showError=true so the rejection first shows the command
+    // error, then _stopCalibration(StopCalibrationFailed) shows the cal failed message.
+    expectAppMessage(QRegularExpression(QStringLiteral("command failed")));
+    expectAppMessage(QRegularExpression(QStringLiteral("Calibration failed")));
+
+    QVERIFY2(clickButton(QStringLiteral("sensorsSetup_calibrateCompass")),
+             "Failed to click Compass button");
+    QVERIFY2(findVisibleItem(_rootItem, QStringLiteral("popupDialog_acceptButton"), 5000),
+             "Pre-compass-cal dialog not found");
+    QVERIFY2(clickButton(QStringLiteral("popupDialog_acceptButton")),
+             "Failed to accept pre-compass-cal dialog");
+
+    // The rejected START must cleanly stop the calibration: the cancel button is only
+    // enabled while a cal is active, so it must end up disabled.
+    QQuickItem *cancelBtn = findVisibleItem(_rootItem, QStringLiteral("sensorsSetup_cancelButton"), 2000);
+    QVERIFY2(cancelBtn, "Cancel button not found");
+    QVERIFY2(QTest::qWaitFor([&] { return !cancelBtn->property("enabled").toBool(); }, 10000),
+             "Compass cal still active after START was rejected");
+
+    verifyExpectedLogMessage();  // command failed
+    verifyExpectedLogMessage();  // Calibration failed
+
+    waitForParamRefreshQuiet(vehicle);
+
+    // Compass indicator still orange, accel green
+    _verifyCalIndicators(/*compassGreen=*/false, /*accelGreen=*/true, "after rejected compass cal start");
+
+    });
+}
+
+// ---------------------------------------------------------------------------
 // _testAccelCalibration
 // ---------------------------------------------------------------------------
 void APMSensorsCalibrationUITest::_testAccelCalibration()

--- a/test/QmlUITests/APMSensorsCalibrationUITest.h
+++ b/test/QmlUITests/APMSensorsCalibrationUITest.h
@@ -26,6 +26,8 @@ public:
 private slots:
     void _testCompassCalibration();
     void _testCompassCalibrationCancel();
+    void _testCompassCalibrationIgnoresStaleFailedReports();
+    void _testCompassCalibrationStartRejected();
     void _testAccelCalibration();
 
 private:


### PR DESCRIPTION
## Problem

Starting an onboard compass calibration on ArduPilot could instantly "complete" (or fail) with no user interaction. Root cause: after a failed compass cal, ArduPilot keeps streaming `MAG_CAL_REPORT(MAG_CAL_FAILED)` until it receives `MAV_CMD_DO_CANCEL_MAG_CAL`. If a new calibration was started while that stream was still active, QGC consumed the leftover failed reports as if they belonged to the new calibration.

This regressed in #14491, which removed the `MAV_CMD_DO_CANCEL_MAG_CAL` probe that previously (incidentally) stopped the stale stream.

## Fix

- `calibrateCompass()` now sends `MAV_CMD_DO_CANCEL_MAG_CAL` first and sequences `MAV_CMD_DO_START_MAG_CAL` from the CANCEL command ack, so the two commands cannot race. START is sent regardless of the CANCEL result since older firmwares reject CANCEL when no cal is running.
- `MAG_CAL_PROGRESS` / `MAG_CAL_REPORT` are ignored until the START command is ACCEPTED, so stale reports can never terminate a new calibration.
- A rejected START logs "Failed to start compass calibration" and cleanly stops the calibration UI.
- A failed calibration now sends `MAV_CMD_DO_CANCEL_MAG_CAL` so ArduPilot stops streaming the failed report.

## Testing

- MockLink: simulates the stale failed `MAG_CAL_REPORT` stream (10Hz until cancelled) and a rejected START mode.
- New UI tests in `APMSensorsCalibrationUITest`:
  - `_testCompassCalibrationIgnoresStaleFailedReports` — cal must not terminate prematurely, stale stream is cancelled, cal completes successfully.
  - `_testCompassCalibrationStartRejected` — rejected START shows the failure messages and exits calibration cleanly.
- All 5 `APMSensorsCalibrationUITest` cases pass; full Unit suite passes.
