### PR TITLE
fix(FactSystem): defer enumsChanged emission to avoid QML binding loops

### DIFF
--- a/src/FactSystem/Fact.cc
+++ b/src/FactSystem/Fact.cc
@@ -278,9 +278,10 @@ int Fact::enumIndex()
                 }
                 index++;
             }
-            // Current value is not in list, add it manually
+            // Current value is not in list, add it manually. Defer the signal since this can
+            // be called from within a QML binding read and a synchronous emit causes binding loops.
             _metaData->addEnumInfo(tr("Unknown: %1").arg(rawValue().toString()), rawValue());
-            emit enumsChanged();
+            QMetaObject::invokeMethod(this, &Fact::enumsChanged, Qt::QueuedConnection);
             return index;
         }
     } else {

--- a/test/FactSystem/FactTest.cc
+++ b/test/FactSystem/FactTest.cc
@@ -157,6 +157,31 @@ void FactTest::_enumOperations_test()
     QCOMPARE(fact.enumIndex(), 3);
 }
 
+void FactTest::_enumIndexUnknownValueNoSyncSignal_test()
+{
+    Fact fact(0, "EnumParam", FactMetaData::valueTypeInt32);
+
+    const QStringList strings = {"Off", "Low", "Medium", "High"};
+    const QVariantList values = {QVariant(0), QVariant(1), QVariant(2), QVariant(3)};
+    fact.setEnumInfo(strings, values);
+
+    fact.setRawValue(QVariant(42)); // Not in enum list
+
+    QSignalSpy spy(&fact, &Fact::enumsChanged);
+    QVERIFY(spy.isValid());
+
+    // Reading enumIndex for an unknown value adds an "Unknown" entry to the enum list.
+    // The enumsChanged signal must NOT be emitted synchronously during the read, since
+    // that causes QML binding loops for bindings which read both enumStrings and enumStringValue.
+    const int index = fact.enumIndex();
+    QCOMPARE(index, 4);
+    QCOMPARE(fact.enumStrings().count(), 5);
+    QCOMPARE(spy.count(), 0);
+
+    // Signal must still arrive once the event loop runs
+    QTRY_COMPARE_WITH_TIMEOUT(spy.count(), 1, 1000);
+}
+
 void FactTest::_valueChangedSignal_test()
 {
     Fact fact(0, "SigParam", FactMetaData::valueTypeInt32);

--- a/test/FactSystem/FactTest.h
+++ b/test/FactSystem/FactTest.h
@@ -18,6 +18,7 @@ private slots:
     void _validateConvertOnly_test();
     void _clampOutOfRange_test();
     void _enumOperations_test();
+    void _enumIndexUnknownValueNoSyncSignal_test();
     void _valueChangedSignal_test();
     void _rawValueChangedSignal_test();
     void _noSignalOnSameValue_test();


### PR DESCRIPTION
## Problem

`Fact::enumIndex()` emits `enumsChanged` synchronously when it appends an "Unknown: value" entry for a raw value not present in the enum list. Since `enumIndex()` is typically called while QML is evaluating a binding that also depends on `enumsChanged` (e.g. `ParameterEditor.qml`), the synchronous emission re-triggers the binding mid-evaluation and QML reports a binding loop.

## Fix

Defer the `enumsChanged` emission with a queued `QMetaObject::invokeMethod` so it fires after the current binding evaluation completes. The "Unknown" entry itself is still added synchronously, so the returned index is valid immediately.

## Testing

New unit test `FactTest::_enumIndexUnknownValueNoSyncSignal_test`:
- sets a raw value not in the enum list
- verifies `enumIndex()` returns the appended "Unknown" entry with no synchronous `enumsChanged` emission
- verifies the deferred signal still arrives via the event loop

Test was verified to fail against the previous synchronous emission behavior. Full FactTest suite passes.
