### PR TITLE
feat(MockLink): APM start-with-fresh-params option and fresh-flash setup tests

### DIFF
--- a/src/AppSettings/MockLink.qml
+++ b/src/AppSettings/MockLink.qml
@@ -42,39 +42,57 @@ Rectangle {
                 id:             enableProximity
                 text:           qsTr("Enable proximity sensors")
             }
-            QGCButton {
-                text:               qsTr("PX4 Vehicle")
+            QGCCheckBox {
+                id:             apmStartFreshParams
+                text:           qsTr("Start with fresh firmware parameters (setup required)")
+                visible:        vehicleTypeCombo.apmSelected
+
+                onVisibleChanged: {
+                    if (!visible) {
+                        checked = false
+                    }
+                }
+            }
+            LabelledComboBox {
+                id:                 vehicleTypeCombo
+                label:              qsTr("Vehicle Type")
                 Layout.fillWidth:   true
-                onClicked:          QGroundControl.startPX4MockLink(sendStatusText.checked, enableCamera.checked, enableGimbal.checked, enableProximity.checked)
+                model:              _vehicleNames
+
+                readonly property var _vehicleKeys: QGroundControl.hasAPMSupport ?
+                                                        [ "px4", "apmCopter", "apmPlane", "apmSub", "apmRover", "generic" ] :
+                                                        [ "px4", "generic" ]
+                readonly property var _vehicleNames: QGroundControl.hasAPMSupport ?
+                                                        [ qsTr("PX4 Vehicle"), qsTr("APM ArduCopter Vehicle"), qsTr("APM ArduPlane Vehicle"), qsTr("APM ArduSub Vehicle"), qsTr("APM ArduRover Vehicle"), qsTr("Generic Vehicle") ] :
+                                                        [ qsTr("PX4 Vehicle"), qsTr("Generic Vehicle") ]
+                readonly property string selectedKey: currentIndex >= 0 ? _vehicleKeys[currentIndex] : "px4"
+                readonly property bool apmSelected: selectedKey.startsWith("apm")
             }
             QGCButton {
-                text:               qsTr("APM ArduCopter Vehicle")
-                visible:            QGroundControl.hasAPMSupport
+                text:               qsTr("Start MockLink")
                 Layout.fillWidth:   true
-                onClicked:          QGroundControl.startAPMArduCopterMockLink(sendStatusText.checked, enableCamera.checked, enableGimbal.checked, enableProximity.checked)
-            }
-            QGCButton {
-                text:               qsTr("APM ArduPlane Vehicle")
-                visible:            QGroundControl.hasAPMSupport
-                Layout.fillWidth:   true
-                onClicked:          QGroundControl.startAPMArduPlaneMockLink(sendStatusText.checked, enableCamera.checked, enableGimbal.checked, enableProximity.checked)
-            }
-            QGCButton {
-                text:               qsTr("APM ArduSub Vehicle")
-                visible:            QGroundControl.hasAPMSupport
-                Layout.fillWidth:   true
-                onClicked:          QGroundControl.startAPMArduSubMockLink(sendStatusText.checked, enableCamera.checked, enableGimbal.checked, enableProximity.checked)
-            }
-            QGCButton {
-                text:               qsTr("APM ArduRover Vehicle")
-                visible:            QGroundControl.hasAPMSupport
-                Layout.fillWidth:   true
-                onClicked:          QGroundControl.startAPMArduRoverMockLink(sendStatusText.checked, enableCamera.checked, enableGimbal.checked, enableProximity.checked)
-            }
-            QGCButton {
-                text:               qsTr("Generic Vehicle")
-                Layout.fillWidth:   true
-                onClicked:          QGroundControl.startGenericMockLink(sendStatusText.checked, enableCamera.checked, enableGimbal.checked, enableProximity.checked)
+                onClicked: {
+                    switch (vehicleTypeCombo.selectedKey) {
+                    case "px4":
+                        QGroundControl.startPX4MockLink(sendStatusText.checked, enableCamera.checked, enableGimbal.checked, enableProximity.checked)
+                        break
+                    case "apmCopter":
+                        QGroundControl.startAPMArduCopterMockLink(sendStatusText.checked, enableCamera.checked, enableGimbal.checked, enableProximity.checked, apmStartFreshParams.checked)
+                        break
+                    case "apmPlane":
+                        QGroundControl.startAPMArduPlaneMockLink(sendStatusText.checked, enableCamera.checked, enableGimbal.checked, enableProximity.checked, apmStartFreshParams.checked)
+                        break
+                    case "apmSub":
+                        QGroundControl.startAPMArduSubMockLink(sendStatusText.checked, enableCamera.checked, enableGimbal.checked, enableProximity.checked, apmStartFreshParams.checked)
+                        break
+                    case "apmRover":
+                        QGroundControl.startAPMArduRoverMockLink(sendStatusText.checked, enableCamera.checked, enableGimbal.checked, enableProximity.checked, apmStartFreshParams.checked)
+                        break
+                    default:
+                        QGroundControl.startGenericMockLink(sendStatusText.checked, enableCamera.checked, enableGimbal.checked, enableProximity.checked)
+                        break
+                    }
+                }
             }
             QGCButton {
                 text:               qsTr("Stop One MockLink")

--- a/src/AppSettings/MockLinkSettings.qml
+++ b/src/AppSettings/MockLinkSettings.qml
@@ -32,6 +32,7 @@ ColumnLayout {
             break
         }
         subEditConfig.sendStatus = sendStatus.checked
+        subEditConfig.apmStartFreshParams = apmStartFreshParams.checked
         subEditConfig.enableCamera = enableCamera.checked
         subEditConfig.enableGimbal = enableGimbal.checked
         subEditConfig.enableProximity = enableProximity.checked
@@ -123,6 +124,22 @@ ColumnLayout {
         label:                  qsTr("Vehicle Type")
         model:                  [ qsTr("ArduCopter"), qsTr("ArduPlane") ]
         visible:                firmwareTypeCombo.apmFirmwareSelected
+    }
+
+    QGCCheckBoxSlider {
+        id: apmStartFreshParams
+        Layout.fillWidth: true
+        text: qsTr("Start With Fresh Firmware Parameters (Setup Required)")
+        checked: subEditConfig.apmStartFreshParams
+        visible: firmwareTypeCombo.apmFirmwareSelected
+
+        onVisibleChanged: {
+            if (!visible) {
+                // Reset the model, not the view — an imperative write to checked
+                // would sever its declarative binding
+                subEditConfig.apmStartFreshParams = false
+            }
+        }
     }
 
     SettingsGroupLayout {

--- a/src/AutoPilotPlugins/APM/APMAirframeComponent.qml
+++ b/src/AutoPilotPlugins/APM/APMAirframeComponent.qml
@@ -84,10 +84,11 @@ SetupPage {
 
                     // Outer summary item rectangle
                     Rectangle {
-                        id:     outerRect
-                        width:  _boxWidth
-                        height: ScreenTools.defaultFontPixelHeight * 14
-                        color:  qgcPal.window
+                        id:         outerRect
+                        objectName: "apmAirframeBox_" + object.name
+                        width:      _boxWidth
+                        height:     ScreenTools.defaultFontPixelHeight * 14
+                        color:      qgcPal.window
 
                         readonly property real titleHeight: ScreenTools.defaultFontPixelHeight * 1.75
                         readonly property real innerMargin: ScreenTools.defaultFontPixelWidth

--- a/src/AutoPilotPlugins/APM/APMSensorsComponent.qml
+++ b/src/AutoPilotPlugins/APM/APMSensorsComponent.qml
@@ -158,10 +158,12 @@ SetupPage {
 
                 onCalibrationComplete: (calType) => {
                     switch (calType) {
-                    case MAVLink.CalibrationAccel:
                     case MAVLink.CalibrationMag:
                         _singleCompassSettingsComponentShowPriority = true
                         postOnboardCompassCalibrationFactory.open()
+                        break
+                    case MAVLink.CalibrationAccel:
+                        postCalibrationFactory.open()
                         break
                     }
                 }
@@ -287,6 +289,7 @@ SetupPage {
                     buttons:    Dialog.Ok
 
                     Column {
+                        objectName: "postOnboardCompassCalibrationDialog"
                         width:      40 * ScreenTools.defaultFontPixelWidth
                         spacing:    ScreenTools.defaultFontPixelHeight
 
@@ -317,6 +320,12 @@ SetupPage {
                 }
             }
 
+            QGCPopupDialogFactory {
+                id: postCalibrationFactory
+
+                dialogComponent: postCalibrationComponent
+            }
+
             Component {
                 id: postCalibrationComponent
 
@@ -325,6 +334,7 @@ SetupPage {
                     title:  qsTr("Calibration complete")
 
                     Column {
+                        objectName: "postCalibrationDialog"
                         width:      40 * ScreenTools.defaultFontPixelWidth
                         spacing:    ScreenTools.defaultFontPixelHeight
 

--- a/src/Comms/MockLink/MockConfiguration.cc
+++ b/src/Comms/MockLink/MockConfiguration.cc
@@ -14,6 +14,7 @@ MockConfiguration::MockConfiguration(const MockConfiguration *copy, QObject *par
     , _firmwareType(copy->firmwareType())
     , _vehicleType(copy->vehicleType())
     , _sendStatusText(copy->sendStatusText())
+    , _apmStartFreshParams(copy->apmStartFreshParams())
     , _enableCamera(copy->enableCamera())
     , _enableGimbal(copy->enableGimbal())
     , _enableProximity(copy->enableProximity())
@@ -56,6 +57,7 @@ void MockConfiguration::copyFrom(const LinkConfiguration *source)
     setFirmwareType(mockLinkSource->firmwareType());
     setVehicleType(mockLinkSource->vehicleType());
     setSendStatusText(mockLinkSource->sendStatusText());
+    setApmStartFreshParams(mockLinkSource->apmStartFreshParams());
     setEnableCamera(mockLinkSource->enableCamera());
     setEnableGimbal(mockLinkSource->enableGimbal());
     setEnableProximity(mockLinkSource->enableProximity());
@@ -89,6 +91,7 @@ void MockConfiguration::loadSettings(QSettings &settings, const QString &root)
     setFirmwareType(static_cast<MAV_AUTOPILOT>(settings.value(_firmwareTypeKey, static_cast<int>(MAV_AUTOPILOT_PX4)).toInt()));
     setVehicleType(static_cast<MAV_TYPE>(settings.value(_vehicleTypeKey, static_cast<int>(MAV_TYPE_QUADROTOR)).toInt()));
     setSendStatusText(settings.value(_sendStatusTextKey, false).toBool());
+    setApmStartFreshParams(settings.value(_apmStartFreshParamsKey, false).toBool());
     setEnableCamera(settings.value(_enableCameraKey, false).toBool());
     setEnableGimbal(settings.value(_enableGimbalKey, false).toBool());
     setEnableProximity(settings.value(_enableProximityKey, false).toBool());
@@ -121,6 +124,7 @@ void MockConfiguration::saveSettings(QSettings &settings, const QString &root) c
     settings.setValue(_firmwareTypeKey, firmwareType());
     settings.setValue(_vehicleTypeKey, vehicleType());
     settings.setValue(_sendStatusTextKey, sendStatusText());
+    settings.setValue(_apmStartFreshParamsKey, apmStartFreshParams());
     settings.setValue(_enableCameraKey, enableCamera());
     settings.setValue(_enableGimbalKey, enableGimbal());
     settings.setValue(_enableProximityKey, enableProximity());

--- a/src/Comms/MockLink/MockConfiguration.h
+++ b/src/Comms/MockLink/MockConfiguration.h
@@ -10,6 +10,7 @@ class MockConfiguration : public LinkConfiguration
     Q_PROPERTY(int  firmware                             READ firmware                            WRITE setFirmware                            NOTIFY firmwareChanged)
     Q_PROPERTY(int  vehicle                              READ vehicle                             WRITE setVehicle                             NOTIFY vehicleChanged)
     Q_PROPERTY(bool sendStatus                           READ sendStatusText                      WRITE setSendStatusText                      NOTIFY sendStatusChanged)
+    Q_PROPERTY(bool apmStartFreshParams                  READ apmStartFreshParams                 WRITE setApmStartFreshParams                 NOTIFY apmStartFreshParamsChanged)
     Q_PROPERTY(bool enableCamera                         READ enableCamera                        WRITE setEnableCamera                        NOTIFY enableCameraChanged)
     Q_PROPERTY(bool enableGimbal                        READ enableGimbal                        WRITE setEnableGimbal                        NOTIFY enableGimbalChanged)
     Q_PROPERTY(bool enableProximity                      READ enableProximity                     WRITE setEnableProximity                     NOTIFY enableProximityChanged)
@@ -38,13 +39,14 @@ public:
 
     /// Options for the MockLink::start*MockLink helpers
     enum Option {
-        OptionNone            = 0,
-        OptionSendStatusText  = 1 << 0,
-        OptionEnableCamera    = 1 << 1,
-        OptionEnableGimbal    = 1 << 2,
-        OptionEnableProximity = 1 << 3,
-        OptionPreloadMission  = 1 << 4,
-        OptionStayMavlinkV1   = 1 << 5,
+        OptionNone                = 0,
+        OptionSendStatusText      = 1 << 0,
+        OptionEnableCamera        = 1 << 1,
+        OptionEnableGimbal        = 1 << 2,
+        OptionEnableProximity     = 1 << 3,
+        OptionPreloadMission      = 1 << 4,
+        OptionStayMavlinkV1       = 1 << 5,
+        OptionAPMStartFreshParams = 1 << 6,
     };
     Q_DECLARE_FLAGS(Options, Option)
     Q_FLAG(Options)
@@ -71,6 +73,8 @@ public:
     void setVehicleType(MAV_TYPE vehicleType) { _vehicleType = vehicleType; emit vehicleChanged(); }
     bool sendStatusText() const { return _sendStatusText; }
     void setSendStatusText(bool sendStatusText) { _sendStatusText = sendStatusText; emit sendStatusChanged(); }
+    bool apmStartFreshParams() const { return _apmStartFreshParams; }
+    void setApmStartFreshParams(bool apmStartFreshParams) { _apmStartFreshParams = apmStartFreshParams; emit apmStartFreshParamsChanged(); }
     bool enableCamera() const { return _enableCamera; }
     void setEnableCamera(bool enableCamera) { _enableCamera = enableCamera; emit enableCameraChanged(); }
     bool enableGimbal() const { return _enableGimbal; }
@@ -141,6 +145,7 @@ signals:
     void firmwareChanged();
     void vehicleChanged();
     void sendStatusChanged();
+    void apmStartFreshParamsChanged();
     void enableCameraChanged();
     void enableGimbalChanged();
     void enableProximityChanged();
@@ -166,6 +171,7 @@ private:
     MAV_AUTOPILOT _firmwareType = MAV_AUTOPILOT_PX4;
     MAV_TYPE _vehicleType = MAV_TYPE_QUADROTOR;
     bool _sendStatusText = false;
+    bool _apmStartFreshParams = false;
     bool _enableCamera = false;
     bool _enableGimbal = false;
     bool _enableProximity = false;
@@ -200,6 +206,7 @@ private:
     static constexpr const char *_firmwareTypeKey = "FirmwareType";
     static constexpr const char *_vehicleTypeKey = "VehicleType";
     static constexpr const char *_sendStatusTextKey = "SendStatusText";
+    static constexpr const char *_apmStartFreshParamsKey = "APMStartFreshParams";
     static constexpr const char *_enableCameraKey = "EnableCamera";
     static constexpr const char *_enableGimbalKey = "EnableGimbal";
     static constexpr const char *_enableProximityKey = "EnableProximity";

--- a/src/Comms/MockLink/MockLink.cc
+++ b/src/Comms/MockLink/MockLink.cc
@@ -61,6 +61,7 @@ MockLink::MockLink(SharedLinkConfigurationPtr &config, QObject *parent)
     , _firmwareType(_mockConfig->firmwareType())
     , _vehicleType(_mockConfig->vehicleType())
     , _sendStatusText(_mockConfig->sendStatusText())
+    , _apmStartFreshParams(_mockConfig->apmStartFreshParams())
     , _enableCamera(_mockConfig->enableCamera())
     , _enableGimbal(_mockConfig->enableGimbal())
     , _enableProximity(_mockConfig->enableProximity())
@@ -454,6 +455,10 @@ void MockLink::_loadParams()
         _mapParamName2Value[compId][paramName] = paramValue;
         _mapParamName2MavParamType[compId][paramName] = static_cast<MAV_PARAM_TYPE>(paramType);
     }
+
+    if ((_firmwareType == MAV_AUTOPILOT_ARDUPILOTMEGA) && _apmStartFreshParams) {
+        _applyAPMFreshFlashState();
+    }
 }
 
 /// Unit test support: MAV_CMD_PREFLIGHT_STORAGE with param1=2 (as sent by
@@ -547,6 +552,54 @@ void MockLink::_resetParamsToDefaults()
                 break;
             }
         }
+    }
+}
+
+/// Puts the parameter set into the state of a freshly flashed ArduPilot board: no airframe
+/// selected, compass/accel uncalibrated, radio uncalibrated. QGC's vehicle setup components
+/// then report "Setup required" until the user walks through the normal configuration steps.
+void MockLink::_applyAPMFreshFlashState()
+{
+    // Compass and accel offsets to 0 (uncalibrated)
+    _resetParamsToDefaults();
+
+    auto &paramMap = _mapParamName2Value[MAV_COMP_ID_AUTOPILOT1];
+    const auto &paramTypeMap = _mapParamName2MavParamType[MAV_COMP_ID_AUTOPILOT1];
+
+    // Set an integer param preserving the storage type used by _loadParams()
+    auto setIntParam = [&paramMap, &paramTypeMap](const QString &paramName, int value) {
+        if (!paramMap.contains(paramName)) {
+            return;
+        }
+        switch (paramTypeMap.value(paramName)) {
+        case MAV_PARAM_TYPE_UINT32: paramMap[paramName] = QVariant(static_cast<quint32>(value)); break;
+        case MAV_PARAM_TYPE_INT32:  paramMap[paramName] = QVariant(value); break;
+        case MAV_PARAM_TYPE_UINT16: paramMap[paramName] = QVariant(static_cast<quint16>(value)); break;
+        case MAV_PARAM_TYPE_INT16:  paramMap[paramName] = QVariant(static_cast<qint16>(value)); break;
+        case MAV_PARAM_TYPE_UINT8:  paramMap[paramName] = QVariant(static_cast<quint8>(value)); break;
+        case MAV_PARAM_TYPE_INT8:   paramMap[paramName] = QVariant(static_cast<qint8>(value)); break;
+        default:                    paramMap[paramName] = QVariant(value); break;
+        }
+    };
+
+    // No airframe selected. Not all vehicle types have FRAME_CLASS (Plane/Sub don't).
+    setIntParam(QStringLiteral("FRAME_CLASS"), 0);
+
+    // Radio uncalibrated: RC min/max/trim at firmware defaults for the mapped attitude channels
+    const QStringList rcMapParams = {
+        QStringLiteral("RCMAP_ROLL"),
+        QStringLiteral("RCMAP_PITCH"),
+        QStringLiteral("RCMAP_YAW"),
+        QStringLiteral("RCMAP_THROTTLE"),
+    };
+    for (const QString &mapParam : rcMapParams) {
+        if (!paramMap.contains(mapParam)) {
+            continue;
+        }
+        const int channel = paramMap[mapParam].toInt();
+        setIntParam(QStringLiteral("RC%1_MIN").arg(channel), 1100);
+        setIntParam(QStringLiteral("RC%1_MAX").arg(channel), 1900);
+        setIntParam(QStringLiteral("RC%1_TRIM").arg(channel), 1500);
     }
 }
 
@@ -2331,6 +2384,7 @@ MockLink *MockLink::_startMockLinkWorker(const QString &configName, MAV_AUTOPILO
     mockConfig->setEnableProximity(options.testFlag(MockConfiguration::OptionEnableProximity));
     mockConfig->setPreloadMission(options.testFlag(MockConfiguration::OptionPreloadMission));
     mockConfig->setStayMavlinkV1(options.testFlag(MockConfiguration::OptionStayMavlinkV1));
+    mockConfig->setApmStartFreshParams(options.testFlag(MockConfiguration::OptionAPMStartFreshParams));
     mockConfig->setFailureMode(failureMode);
 
     return _startMockLink(mockConfig);

--- a/src/Comms/MockLink/MockLink.h
+++ b/src/Comms/MockLink/MockLink.h
@@ -242,6 +242,7 @@ private:
 
     void _loadParams();
     void _resetParamsToDefaults();
+    void _applyAPMFreshFlashState();
 
     /// Convert from a parameter variant to the float value from mavlink_param_union_t
     float _floatUnionForParam(int componentId, const QString &paramName);
@@ -329,6 +330,7 @@ private:
     const MAV_AUTOPILOT _firmwareType = MAV_AUTOPILOT_PX4;
     const MAV_TYPE _vehicleType = MAV_TYPE_QUADROTOR;
     const bool _sendStatusText = false;
+    const bool _apmStartFreshParams = false;
     const bool _enableCamera = false;
     const bool _enableGimbal = false;
     const bool _enableProximity = false;

--- a/src/FactSystem/Fact.cc
+++ b/src/FactSystem/Fact.cc
@@ -927,12 +927,12 @@ FactValueSliderListModel *Fact::valueSliderModel()
 void Fact::_checkForRebootMessaging()
 {
     if (qgcApp()) {
-        if (!QGC::runningUnitTests()) {
-            if (vehicleRebootRequired()) {
-                QGC::showRebootAppMessage(tr("Reboot vehicle for changes to take effect."));
-            } else if (qgcRebootRequired()) {
-                QGC::showRebootAppMessage(tr("Restart application for changes to take effect."));
-            }
+        // showAppMessage() logs during unit tests (and additionally shows the real
+        // dialog in UI test mode), so tests assert this messaging via expectAppMessage()
+        if (vehicleRebootRequired()) {
+            QGC::showRebootAppMessage(tr("Reboot vehicle for changes to take effect."));
+        } else if (qgcRebootRequired()) {
+            QGC::showRebootAppMessage(tr("Restart application for changes to take effect."));
         }
     }
 }

--- a/src/QGCApplication.cc
+++ b/src/QGCApplication.cc
@@ -433,11 +433,16 @@ void QGCApplication::showAppMessage(const QString& message, const QString& title
     const QString dialogTitle = title.isEmpty() ? applicationName() : title;
 
     if (runningUnitTests()) {
-        // Never show a blocking dialog during unit tests — it would hang the test runner.
-        // Logged under QGCAppMessageLog so tests can use expectAppMessage() to white-list
-        // expected dialogs without matching against the general QGCApplication category.
+        // Logged under QGCAppMessageLog so tests can assert expected dialogs via
+        // expectAppMessage() without matching against the general QGCApplication category.
         qCDebug(QGCAppMessageLog) << "showAppMessage:" << dialogTitle << "-" << message;
-        return;
+        if (!_uiTestMode) {
+            // Headless test: there is no QML root to host the dialog and the delayed-message
+            // timer would retry forever, so the log is the only record.
+            return;
+        }
+        // UI tests fall through: the message dialog is a non-blocking QML popup, so show it
+        // for real and let the test handle it the same way a user would.
     }
 
     QObject* const rootQmlObject = _rootQmlObject();
@@ -455,11 +460,9 @@ void QGCApplication::showAppMessage(const QString& message, const QString& title
 
 void QGCApplication::showRebootAppMessage(const QString& message, const QString& title)
 {
-    static QTime lastRebootMessage;
-
     const QTime currentTime = QTime::currentTime();
-    const QTime previousTime = lastRebootMessage;
-    lastRebootMessage = currentTime;
+    const QTime previousTime = _lastRebootMessageTime;
+    _lastRebootMessageTime = currentTime;
 
     if (previousTime.isValid() && (previousTime.msecsTo(currentTime) < (60 * 1000 * 2))) {
         // Debounce reboot messages

--- a/src/QGCApplication.h
+++ b/src/QGCApplication.h
@@ -4,6 +4,7 @@
 #include <QtCore/QLoggingCategory>
 #include <QtCore/QMap>
 #include <QtCore/QSet>
+#include <QtCore/QTime>
 #include <QtCore/QTimer>
 #include <QtCore/QTranslator>
 #include <QtGui/QGuiApplication>
@@ -80,6 +81,17 @@ public:
 
     /// Although public, these methods are internal and should only be called by UnitTest code
     QQmlApplicationEngine *qmlAppEngine() const { return _qmlAppEngine; }
+    /// UI test harnesses create their own QML engine; registering it here lets app-level
+    /// messaging (showAppMessage) reach the test's MainWindow. Pass nullptr on teardown.
+    void setQmlAppEngine(QQmlApplicationEngine *engine)
+    {
+        _qmlAppEngine = engine;
+        _mainRootWindow = nullptr;    // cached from the previous engine's root object
+        _uiTestMode = (engine != nullptr);
+    }
+    /// showRebootAppMessage() debounces repeat messages (2 min). Tests reset the
+    /// debounce per-test so each one deterministically sees its own message.
+    void resetRebootMessageDebounce() { _lastRebootMessageTime = QTime(); }
 
 signals:
     void languageChanged(const QLocale &locale);
@@ -124,9 +136,11 @@ private:
 
     bool _runningUnitTests = false;
     bool _simpleBootTest = false;
+    bool _uiTestMode = false;    ///< true: QML UI test harness registered its engine via setQmlAppEngine()
     bool _fakeMobile = false;    ///< true: Fake ui into displaying mobile interface
     bool _logOutput = false;    ///< true: Log Qt debug output to file
     quint8 _systemId = 0; ///< MAVLink system ID, 0 means not set
+    QTime _lastRebootMessageTime;    ///< showRebootAppMessage() debounce state
 
     static constexpr int _missingParamsDelayedDisplayTimerTimeout = 1000;   ///< Timeout to wait for next missing fact to come in before display
     QTimer _missingParamsDelayedDisplayTimer;                               ///< Timer use to delay missing fact display

--- a/src/QmlControls/QGroundControlQmlGlobal.cc
+++ b/src/QmlControls/QGroundControlQmlGlobal.cc
@@ -119,13 +119,14 @@ bool QGroundControlQmlGlobal::loadBoolGlobalSetting (const QString& key, bool de
 }
 
 #ifdef QT_DEBUG
-static MockConfiguration::Options _mockLinkOptions(bool sendStatusText, bool enableCamera, bool enableGimbal, bool enableProximity)
+static MockConfiguration::Options _mockLinkOptions(bool sendStatusText, bool enableCamera, bool enableGimbal, bool enableProximity, bool apmStartFreshParams = false)
 {
     MockConfiguration::Options options = MockConfiguration::OptionNone;
     options.setFlag(MockConfiguration::OptionSendStatusText, sendStatusText);
     options.setFlag(MockConfiguration::OptionEnableCamera, enableCamera);
     options.setFlag(MockConfiguration::OptionEnableGimbal, enableGimbal);
     options.setFlag(MockConfiguration::OptionEnableProximity, enableProximity);
+    options.setFlag(MockConfiguration::OptionAPMStartFreshParams, apmStartFreshParams);
     return options;
 }
 #endif
@@ -154,51 +155,55 @@ void QGroundControlQmlGlobal::startGenericMockLink(bool sendStatusText, bool ena
 #endif
 }
 
-void QGroundControlQmlGlobal::startAPMArduCopterMockLink(bool sendStatusText, bool enableCamera, bool enableGimbal, bool enableProximity)
+void QGroundControlQmlGlobal::startAPMArduCopterMockLink(bool sendStatusText, bool enableCamera, bool enableGimbal, bool enableProximity, bool apmStartFreshParams)
 {
 #ifdef QT_DEBUG
-    MockLink::startAPMArduCopterMockLink(_mockLinkOptions(sendStatusText, enableCamera, enableGimbal, enableProximity));
+    MockLink::startAPMArduCopterMockLink(_mockLinkOptions(sendStatusText, enableCamera, enableGimbal, enableProximity, apmStartFreshParams));
 #else
     Q_UNUSED(sendStatusText);
     Q_UNUSED(enableCamera);
     Q_UNUSED(enableGimbal);
     Q_UNUSED(enableProximity);
+    Q_UNUSED(apmStartFreshParams);
 #endif
 }
 
-void QGroundControlQmlGlobal::startAPMArduPlaneMockLink(bool sendStatusText, bool enableCamera, bool enableGimbal, bool enableProximity)
+void QGroundControlQmlGlobal::startAPMArduPlaneMockLink(bool sendStatusText, bool enableCamera, bool enableGimbal, bool enableProximity, bool apmStartFreshParams)
 {
 #ifdef QT_DEBUG
-    MockLink::startAPMArduPlaneMockLink(_mockLinkOptions(sendStatusText, enableCamera, enableGimbal, enableProximity));
+    MockLink::startAPMArduPlaneMockLink(_mockLinkOptions(sendStatusText, enableCamera, enableGimbal, enableProximity, apmStartFreshParams));
 #else
     Q_UNUSED(sendStatusText);
     Q_UNUSED(enableCamera);
     Q_UNUSED(enableGimbal);
     Q_UNUSED(enableProximity);
+    Q_UNUSED(apmStartFreshParams);
 #endif
 }
 
-void QGroundControlQmlGlobal::startAPMArduSubMockLink(bool sendStatusText, bool enableCamera, bool enableGimbal, bool enableProximity)
+void QGroundControlQmlGlobal::startAPMArduSubMockLink(bool sendStatusText, bool enableCamera, bool enableGimbal, bool enableProximity, bool apmStartFreshParams)
 {
 #ifdef QT_DEBUG
-    MockLink::startAPMArduSubMockLink(_mockLinkOptions(sendStatusText, enableCamera, enableGimbal, enableProximity));
+    MockLink::startAPMArduSubMockLink(_mockLinkOptions(sendStatusText, enableCamera, enableGimbal, enableProximity, apmStartFreshParams));
 #else
     Q_UNUSED(sendStatusText);
     Q_UNUSED(enableCamera);
     Q_UNUSED(enableGimbal);
     Q_UNUSED(enableProximity);
+    Q_UNUSED(apmStartFreshParams);
 #endif
 }
 
-void QGroundControlQmlGlobal::startAPMArduRoverMockLink(bool sendStatusText, bool enableCamera, bool enableGimbal, bool enableProximity)
+void QGroundControlQmlGlobal::startAPMArduRoverMockLink(bool sendStatusText, bool enableCamera, bool enableGimbal, bool enableProximity, bool apmStartFreshParams)
 {
 #ifdef QT_DEBUG
-    MockLink::startAPMArduRoverMockLink(_mockLinkOptions(sendStatusText, enableCamera, enableGimbal, enableProximity));
+    MockLink::startAPMArduRoverMockLink(_mockLinkOptions(sendStatusText, enableCamera, enableGimbal, enableProximity, apmStartFreshParams));
 #else
     Q_UNUSED(sendStatusText);
     Q_UNUSED(enableCamera);
     Q_UNUSED(enableGimbal);
     Q_UNUSED(enableProximity);
+    Q_UNUSED(apmStartFreshParams);
 #endif
 }
 

--- a/src/QmlControls/QGroundControlQmlGlobal.h
+++ b/src/QmlControls/QGroundControlQmlGlobal.h
@@ -116,10 +116,10 @@ public:
 
     Q_INVOKABLE void    startPX4MockLink            (bool sendStatusText, bool enableCamera, bool enableGimbal, bool enableProximity = false);
     Q_INVOKABLE void    startGenericMockLink        (bool sendStatusText, bool enableCamera, bool enableGimbal, bool enableProximity = false);
-    Q_INVOKABLE void    startAPMArduCopterMockLink  (bool sendStatusText, bool enableCamera, bool enableGimbal, bool enableProximity = false);
-    Q_INVOKABLE void    startAPMArduPlaneMockLink   (bool sendStatusText, bool enableCamera, bool enableGimbal, bool enableProximity = false);
-    Q_INVOKABLE void    startAPMArduSubMockLink     (bool sendStatusText, bool enableCamera, bool enableGimbal, bool enableProximity = false);
-    Q_INVOKABLE void    startAPMArduRoverMockLink   (bool sendStatusText, bool enableCamera, bool enableGimbal, bool enableProximity = false);
+    Q_INVOKABLE void    startAPMArduCopterMockLink  (bool sendStatusText, bool enableCamera, bool enableGimbal, bool enableProximity = false, bool apmStartFreshParams = false);
+    Q_INVOKABLE void    startAPMArduPlaneMockLink   (bool sendStatusText, bool enableCamera, bool enableGimbal, bool enableProximity = false, bool apmStartFreshParams = false);
+    Q_INVOKABLE void    startAPMArduSubMockLink     (bool sendStatusText, bool enableCamera, bool enableGimbal, bool enableProximity = false, bool apmStartFreshParams = false);
+    Q_INVOKABLE void    startAPMArduRoverMockLink   (bool sendStatusText, bool enableCamera, bool enableGimbal, bool enableProximity = false, bool apmStartFreshParams = false);
     Q_INVOKABLE void    stopOneMockLink             (void);
 
     Q_INVOKABLE bool linesIntersect(QPointF xLine1, QPointF yLine1, QPointF xLine2, QPointF yLine2);

--- a/test/AutoPilotPlugins/APM/APMFreshFlashParamsTest.cc
+++ b/test/AutoPilotPlugins/APM/APMFreshFlashParamsTest.cc
@@ -1,0 +1,168 @@
+#include "APMFreshFlashParamsTest.h"
+
+#include <QtCore/QRegularExpression>
+#include <QtTest/QSignalSpy>
+#include <QtTest/QTest>
+
+#include "AutoPilotPlugin.h"
+#include "Fact.h"
+#include "MockLink.h"
+#include "MultiVehicleManager.h"
+#include "ParameterManager.h"
+#include "Vehicle.h"
+#include "VehicleComponent.h"
+
+UT_REGISTER_TEST(APMFreshFlashParamsTest, TestLabel::Integration, TestLabel::Vehicle)
+
+void APMFreshFlashParamsTest::_connectAPMMockLink(const QString &vehicleKey, MockConfiguration::Options options)
+{
+    QVERIFY2(!_mockLink, "MockLink already connected");
+
+    QSignalSpy spyVehicle(MultiVehicleManager::instance(), &MultiVehicleManager::activeVehicleChanged);
+    QVERIFY2(spyVehicle.isValid(), "Failed to create spy for activeVehicleChanged");
+
+    if (vehicleKey == QLatin1String("Copter")) {
+        _mockLink = MockLink::startAPMArduCopterMockLink(options);
+    } else if (vehicleKey == QLatin1String("Plane")) {
+        _mockLink = MockLink::startAPMArduPlaneMockLink(options);
+    } else if (vehicleKey == QLatin1String("Rover")) {
+        _mockLink = MockLink::startAPMArduRoverMockLink(options);
+    } else if (vehicleKey == QLatin1String("Sub")) {
+        _mockLink = MockLink::startAPMArduSubMockLink(options);
+    } else {
+        QFAIL(qPrintable(QStringLiteral("Unknown vehicle key: %1").arg(vehicleKey)));
+    }
+    QVERIFY2(_mockLink, "Failed to start MockLink");
+    (void) connect(_mockLink, &QObject::destroyed, this, [this]() { _mockLink = nullptr; });
+
+    QVERIFY2(UnitTest::waitForSignal(spyVehicle, TestTimeout::longMs(), QStringLiteral("activeVehicleChanged")),
+             "Timeout waiting for vehicle connection");
+    _vehicle = MultiVehicleManager::instance()->activeVehicle();
+    QVERIFY2(_vehicle, "Vehicle should not be null after connection");
+
+    QSignalSpy spyConnect(_vehicle, &Vehicle::initialConnectComplete);
+    QVERIFY2(spyConnect.isValid(), "Failed to create spy for initialConnectComplete");
+    QVERIFY2(UnitTest::waitForSignal(spyConnect, TestTimeout::longMs(), QStringLiteral("initialConnectComplete")),
+             "Timeout waiting for initial connect");
+
+    QVERIFY2(waitForParametersReady(), "Timeout waiting for parameters ready");
+}
+
+void APMFreshFlashParamsTest::_testFreshFlashParams_data()
+{
+    QTest::addColumn<QString>("vehicleKey");
+    QTest::addColumn<bool>("hasFrameClass");
+    QTest::addColumn<bool>("hasRadio");
+
+    QTest::newRow("Copter") << QStringLiteral("Copter") << true << true;
+    QTest::newRow("Plane") << QStringLiteral("Plane") << false << true;
+    QTest::newRow("Rover") << QStringLiteral("Rover") << true << true;
+    QTest::newRow("Sub") << QStringLiteral("Sub") << false << false;
+}
+
+void APMFreshFlashParamsTest::_testFreshFlashParams()
+{
+    QFETCH(QString, vehicleKey);
+    QFETCH(bool, hasFrameClass);
+    QFETCH(bool, hasRadio);
+
+    // ArduPilot MockLink does not serve COMP_METADATA_TYPE_GENERAL.
+    ignoreLogMessage(
+        "ComponentInformation.RequestMetaDataTypeStateMachine",
+        QtWarningMsg,
+        QRegularExpression(QStringLiteral("\"COMP_METADATA_TYPE_GENERAL\" : failed to load metadata \\(primary and fallback\\) \"\"")));
+
+    // Fresh-flash vehicles must show the setup-incomplete app message on connect
+    expectAppMessage(QRegularExpression(QStringLiteral("Configuration tasks remain before this vehicle is ready to fly")));
+
+    _connectAPMMockLink(vehicleKey, MockConfiguration::OptionAPMStartFreshParams);
+    if (QTest::currentTestFailed()) return;
+    verifyExpectedLogMessage();
+
+    ParameterManager *mgr = _vehicle->parameterManager();
+
+    // -------------------------------------------------------------------
+    // Sensors uncalibrated: compass and accel offsets zeroed
+    // -------------------------------------------------------------------
+    QVERIFY2(qFuzzyIsNull(mgr->getParameter(ParameterManager::defaultComponentId, QStringLiteral("COMPASS_OFS_X"))->rawValue().toFloat()),
+             "COMPASS_OFS_X not 0 on fresh-flash MockLink");
+    QVERIFY2(qFuzzyIsNull(mgr->getParameter(ParameterManager::defaultComponentId, QStringLiteral("INS_ACCOFFS_X"))->rawValue().toFloat()),
+             "INS_ACCOFFS_X not 0 on fresh-flash MockLink");
+
+    // -------------------------------------------------------------------
+    // No airframe selected — only for vehicle types that have FRAME_CLASS
+    // -------------------------------------------------------------------
+    QCOMPARE(mgr->parameterExists(ParameterManager::defaultComponentId, QStringLiteral("FRAME_CLASS")), hasFrameClass);
+    if (hasFrameClass) {
+        Fact *frameClassFact = mgr->getParameter(ParameterManager::defaultComponentId, QStringLiteral("FRAME_CLASS"));
+        QCOMPARE(frameClassFact->rawValue().toInt(), 0);
+        // FRAME_CLASS is INT8 in the param file: the fresh-flash rewrite must preserve
+        // the wire type through the PARAM_VALUE round-trip (Fact type comes from it)
+        QCOMPARE(frameClassFact->type(), FactMetaData::valueTypeInt8);
+        QCOMPARE(_mockLink->paramValue(MAV_COMP_ID_AUTOPILOT1, QStringLiteral("FRAME_CLASS")).toInt(), 0);
+    }
+
+    // -------------------------------------------------------------------
+    // Radio uncalibrated: RC min/max/trim at firmware defaults for all
+    // RCMAP'd attitude channels
+    // -------------------------------------------------------------------
+    const QStringList rcMapParams = {
+        QStringLiteral("RCMAP_ROLL"),
+        QStringLiteral("RCMAP_PITCH"),
+        QStringLiteral("RCMAP_YAW"),
+        QStringLiteral("RCMAP_THROTTLE"),
+    };
+    for (const QString &mapParam : rcMapParams) {
+        QVERIFY2(mgr->parameterExists(ParameterManager::defaultComponentId, mapParam),
+                 qPrintable(QStringLiteral("%1 missing").arg(mapParam)));
+        const int channel = mgr->getParameter(ParameterManager::defaultComponentId, mapParam)->rawValue().toInt();
+
+        Fact *minFact = mgr->getParameter(ParameterManager::defaultComponentId, QStringLiteral("RC%1_MIN").arg(channel));
+        QCOMPARE(minFact->rawValue().toInt(), 1100);
+        QCOMPARE(mgr->getParameter(ParameterManager::defaultComponentId, QStringLiteral("RC%1_MAX").arg(channel))->rawValue().toInt(), 1900);
+        QCOMPARE(mgr->getParameter(ParameterManager::defaultComponentId, QStringLiteral("RC%1_TRIM").arg(channel))->rawValue().toInt(), 1500);
+
+        // RC params are INT16 in the param file: the wire type must be preserved
+        // through the PARAM_VALUE round-trip (Fact type comes from it)
+        QCOMPARE(minFact->type(), FactMetaData::valueTypeInt16);
+        QCOMPARE(_mockLink->paramValue(MAV_COMP_ID_AUTOPILOT1, QStringLiteral("RC%1_MIN").arg(channel)).toInt(), 1100);
+    }
+
+    // -------------------------------------------------------------------
+    // Vehicle components report setup required
+    // -------------------------------------------------------------------
+    VehicleComponent *sensorsComp = findVehicleComponent(_vehicle, QStringLiteral("Sensors"));
+    QVERIFY2(sensorsComp, "Sensors component not found");
+    QVERIFY2(!sensorsComp->setupComplete(), "Sensors setupComplete despite zero cal offsets");
+
+    VehicleComponent *radioComp = findVehicleComponent(_vehicle, QStringLiteral("Radio"));
+    if (hasRadio) {
+        QVERIFY2(radioComp, "Radio component not found");
+        QVERIFY2(!radioComp->setupComplete(), "Radio setupComplete despite default RC min/max/trim");
+    } else {
+        QVERIFY2(!radioComp, "Radio component unexpectedly present");
+    }
+
+    VehicleComponent *frameComp = findVehicleComponent(_vehicle, QStringLiteral("Frame"));
+    QVERIFY2(frameComp, "Frame component not found");
+    QCOMPARE(frameComp->setupComplete(), !hasFrameClass);
+}
+
+void APMFreshFlashParamsTest::_testNormalConnectNoSetupRequiredMessage()
+{
+    // ArduPilot MockLink does not serve COMP_METADATA_TYPE_GENERAL.
+    ignoreLogMessage(
+        "ComponentInformation.RequestMetaDataTypeStateMachine",
+        QtWarningMsg,
+        QRegularExpression(QStringLiteral("\"COMP_METADATA_TYPE_GENERAL\" : failed to load metadata \\(primary and fallback\\) \"\"")));
+
+    // A normal (calibrated) connect must NOT pop the setup-required app message.
+    // Strict log capture fails this test if any unexpected app message fires.
+    _connectAPMMockLink(QStringLiteral("Copter"), MockConfiguration::OptionNone);
+    if (QTest::currentTestFailed()) return;
+
+    VehicleComponent *sensorsComp = findVehicleComponent(_vehicle, QStringLiteral("Sensors"));
+    QVERIFY2(sensorsComp, "Sensors component not found");
+    QVERIFY2(sensorsComp->setupComplete(), "Sensors setup incomplete on normally provisioned MockLink");
+    QVERIFY2(_vehicle->autopilotPlugin()->setupComplete(), "Vehicle setup incomplete on normally provisioned MockLink");
+}

--- a/test/AutoPilotPlugins/APM/APMFreshFlashParamsTest.h
+++ b/test/AutoPilotPlugins/APM/APMFreshFlashParamsTest.h
@@ -1,0 +1,28 @@
+#pragma once
+
+#include "BaseClasses/VehicleTestManualConnect.h"
+
+/// Non-UI coverage for MockConfiguration::OptionAPMStartFreshParams
+/// (MockLink::_applyAPMFreshFlashState). Verifies for every ArduPilot vehicle
+/// type that a fresh-flash MockLink connects with uncalibrated
+/// sensors/radio, no airframe selected (where FRAME_CLASS exists), correct
+/// parameter storage types, setup-incomplete vehicle components and the
+/// setup-required app message. Also verifies a normal (non-fresh) connect
+/// does NOT show the setup-required message.
+class APMFreshFlashParamsTest : public VehicleTestManualConnect
+{
+    Q_OBJECT
+
+public:
+    APMFreshFlashParamsTest() = default;
+
+private slots:
+    void _testFreshFlashParams_data();
+    void _testFreshFlashParams();
+    void _testNormalConnectNoSetupRequiredMessage();
+
+private:
+    /// Start the APM MockLink for \a vehicleKey (Copter/Plane/Rover/Sub) with
+    /// \a options and wait for connect + parameters ready.
+    void _connectAPMMockLink(const QString &vehicleKey, MockConfiguration::Options options);
+};

--- a/test/AutoPilotPlugins/CMakeLists.txt
+++ b/test/AutoPilotPlugins/CMakeLists.txt
@@ -4,6 +4,8 @@
 
 target_sources(${CMAKE_PROJECT_NAME}
     PRIVATE
+        APM/APMFreshFlashParamsTest.cc
+        APM/APMFreshFlashParamsTest.h
         PX4/AirframeComponentAirframesTest.cc
         PX4/AirframeComponentAirframesTest.h
 )
@@ -11,3 +13,4 @@ target_sources(${CMAKE_PROJECT_NAME}
 target_include_directories(${CMAKE_PROJECT_NAME} PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/PX4)
 
 add_qgc_test(AirframeComponentAirframesTest LABELS Unit)
+add_qgc_test(APMFreshFlashParamsTest LABELS Integration Vehicle TIMEOUT ${QGC_TEST_TIMEOUT_EXTENDED})

--- a/test/FactSystem/FactMetaDataTest.cc
+++ b/test/FactSystem/FactMetaDataTest.cc
@@ -330,6 +330,11 @@ void FactMetaDataTest::_verticalMetersUnitsFeetTranslation_test()
     const auto restoreUnits = qScopeGuard([vertUnitsFact, savedUnits] {
         vertUnitsFact->setRawValue(savedUnits);
     });
+    // Changing units is a qgcRebootRequired setting, so the restart-app message
+    // fires — but only when the locale-dependent default isn't already feet, so
+    // it cannot be asserted deterministically with expectAppMessage()
+    ignoreLogMessage("API.QGCApplication.AppMessage", QtDebugMsg,
+                     QRegularExpression(QStringLiteral("Restart application for changes to take effect")));
     vertUnitsFact->setRawValue(UnitsSettings::VerticalDistanceUnitsFeet);
 
     FactMetaData meta(FactMetaData::valueTypeDouble);

--- a/test/FactSystem/ParameterManagerTest.cc
+++ b/test/FactSystem/ParameterManagerTest.cc
@@ -132,13 +132,21 @@ void ParameterManagerTest::_requestListMissingParamFail()
 
 void ParameterManagerTest::_paramWriteNoAckRetry()
 {
+    // BAT1_V_CHARGED requires a vehicle reboot, so writing it pops the reboot
+    // app message (debounce is reset per-test by the framework)
+    expectAppMessage(QRegularExpression("Reboot vehicle for changes to take effect"));
     _setParamWithFailureMode(MockLink::FailParamSetFirstAttemptNoAck, true /* expectSuccess */);
+    verifyExpectedLogMessage();
 }
 
 void ParameterManagerTest::_paramWriteNoAckPermanent()
 {
+    // Expectations verify in FIFO order: reboot message first (fires at local
+    // setRawValue), then the write-failed message (fires after retries exhaust)
+    expectAppMessage(QRegularExpression("Reboot vehicle for changes to take effect"));
     expectAppMessage(QRegularExpression("Parameter write failed"));
     _setParamWithFailureMode(MockLink::FailParamSetNoAck, false /* expectSuccess */);
+    verifyExpectedLogMessage();
     verifyExpectedLogMessage();
 }
 
@@ -194,8 +202,12 @@ void ParameterManagerTest::_paramReadNoResponse()
 
 void ParameterManagerTest::_paramWriteParamError()
 {
+    // Expectations verify in FIFO order: reboot message first (fires at local
+    // setRawValue), then the write-failed message (fires on the PARAM_ERROR ack)
+    expectAppMessage(QRegularExpression("Reboot vehicle for changes to take effect"));
     expectAppMessage(QRegularExpression("Parameter write failed"));
     _setParamWithFailureMode(MockLink::FailParamSetParamError, false /* expectSuccess */);
+    verifyExpectedLogMessage();
     verifyExpectedLogMessage();
 }
 

--- a/test/QmlUITests/APMFreshFlashUITest.cc
+++ b/test/QmlUITests/APMFreshFlashUITest.cc
@@ -1,0 +1,213 @@
+#include "APMFreshFlashUITest.h"
+
+#include <QtCore/QPointer>
+#include <QtQuick/QQuickItem>
+#include <QtQuick/QQuickWindow>
+#include <QtGui/QColor>
+#include <QtQml/QQmlProperty>
+#include <QtTest/QSignalSpy>
+#include <QtTest/QTest>
+
+#include "AutoPilotPlugin.h"
+#include "Fact.h"
+#include "MockLink.h"
+#include "ParameterManager.h"
+#include "Vehicle.h"
+#include "VehicleComponent.h"
+
+UT_REGISTER_TEST(APMFreshFlashUITest, TestLabel::Integration)
+
+void APMFreshFlashUITest::_verifyFramePrereq(const QString &compObjectName, bool expectPrereqShown)
+{
+    QQuickItem *compBtn = clickSidebarButton(compObjectName);
+    if (QTest::currentTestFailed()) return;
+    QVERIFY2(compBtn, qPrintable(QStringLiteral("Component button not found: %1").arg(compObjectName)));
+
+    QQuickItem *messagePanel = findVisibleItem(_rootItem, QStringLiteral("vehicleConfig_messagePanel"), expectPrereqShown ? 3000 : 0);
+    if (expectPrereqShown) {
+        QVERIFY2(messagePanel,
+                 qPrintable(QStringLiteral("Frame prerequisite message panel not shown for: %1").arg(compObjectName)));
+    } else {
+        QVERIFY2(!messagePanel,
+                 qPrintable(QStringLiteral("Prerequisite message panel unexpectedly shown for: %1").arg(compObjectName)));
+    }
+}
+
+void APMFreshFlashUITest::_verifySetupIndicator(const QString &compObjectName, bool expectSetupComplete)
+{
+    QPointer<QQuickItem> compBtn = findVisibleItem(_rootItem, compObjectName, 3000);
+    QVERIFY2(compBtn, qPrintable(QStringLiteral("Component button not found: %1").arg(compObjectName)));
+
+    // The property drives the visual: wait for it to settle first
+    QVERIFY2(QTest::qWaitFor([&] { return compBtn && (compBtn->property("setupComplete").toBool() == expectSetupComplete); }, 5000),
+             qPrintable(QStringLiteral("%1 setupComplete property never became %2")
+                            .arg(compObjectName).arg(expectSetupComplete ? "true" : "false")));
+
+    // Verify the actual rendered indicator: ConfigButton binds icon.color to
+    // red when setup is incomplete, textColor otherwise
+    const QColor iconColor = QQmlProperty::read(compBtn, QStringLiteral("icon.color")).value<QColor>();
+    QVERIFY2(iconColor.isValid(),
+             qPrintable(QStringLiteral("%1 icon.color could not be read").arg(compObjectName)));
+    if (expectSetupComplete) {
+        QVERIFY2(iconColor != QColor(Qt::red),
+                 qPrintable(QStringLiteral("%1 icon still red although setup is complete").arg(compObjectName)));
+    } else {
+        QCOMPARE(iconColor, QColor(Qt::red));
+    }
+}
+
+void APMFreshFlashUITest::_testFreshFlashSetupState()
+{
+    ignoreAPMMockLinkWarnings();
+    // Fresh-flash vehicles must show the setup-incomplete app message on connect
+    expectAppMessage(QRegularExpression(QStringLiteral("Configuration tasks remain before this vehicle is ready to fly")));
+    runWithMockLink(
+        [] { return MockLink::startAPMArduCopterMockLink(MockConfiguration::OptionAPMStartFreshParams); },
+        [&](QPointer<MockLink> /*mockLink*/, Vehicle *vehicle) {
+
+    // Dismiss the setup-incomplete message dialog before interacting with the UI
+    QVERIFY2(acceptDialog(5000), "Setup-incomplete app message dialog never shown");
+    verifyExpectedLogMessage();
+    if (QTest::currentTestFailed()) return;
+
+    // -------------------------------------------------------------------
+    // Fresh-flash parameter state: no airframe, uncalibrated sensors/radio
+    // -------------------------------------------------------------------
+    ParameterManager *mgr = vehicle->parameterManager();
+    QCOMPARE(mgr->getParameter(ParameterManager::defaultComponentId, QStringLiteral("FRAME_CLASS"))->rawValue().toInt(), 0);
+    QVERIFY2(qFuzzyIsNull(mgr->getParameter(ParameterManager::defaultComponentId, QStringLiteral("COMPASS_OFS_X"))->rawValue().toFloat()),
+             "COMPASS_OFS_X not 0 on fresh-flash MockLink");
+    QVERIFY2(qFuzzyIsNull(mgr->getParameter(ParameterManager::defaultComponentId, QStringLiteral("INS_ACCOFFS_X"))->rawValue().toFloat()),
+             "INS_ACCOFFS_X not 0 on fresh-flash MockLink");
+    QCOMPARE(mgr->getParameter(ParameterManager::defaultComponentId, QStringLiteral("RC1_MIN"))->rawValue().toInt(), 1100);
+    QCOMPARE(mgr->getParameter(ParameterManager::defaultComponentId, QStringLiteral("RC1_MAX"))->rawValue().toInt(), 1900);
+    QCOMPARE(mgr->getParameter(ParameterManager::defaultComponentId, QStringLiteral("RC1_TRIM"))->rawValue().toInt(), 1500);
+
+    // -------------------------------------------------------------------
+    // Frame, Sensors and Radio all report setup required
+    // -------------------------------------------------------------------
+    VehicleComponent *frameComp = findVehicleComponent(vehicle, QStringLiteral("Frame"));
+    VehicleComponent *sensorsComp = findVehicleComponent(vehicle, QStringLiteral("Sensors"));
+    VehicleComponent *radioComp = findVehicleComponent(vehicle, QStringLiteral("Radio"));
+    QVERIFY2(frameComp, "Frame component not found");
+    QVERIFY2(sensorsComp, "Sensors component not found");
+    QVERIFY2(radioComp, "Radio component not found");
+
+    QVERIFY2(!frameComp->setupComplete(), "Frame setupComplete despite FRAME_CLASS == 0");
+    QVERIFY2(!sensorsComp->setupComplete(), "Sensors setupComplete despite zero cal offsets");
+    QVERIFY2(!radioComp->setupComplete(), "Radio setupComplete despite default RC min/max/trim");
+
+    // Frame is the required prerequisite for Sensors and Radio; Frame itself has none
+    AutoPilotPlugin *autopilot = vehicle->autopilotPlugin();
+    QCOMPARE(autopilot->prerequisiteSetup(sensorsComp), frameComp->name());
+    QCOMPARE(autopilot->prerequisiteSetup(radioComp), frameComp->name());
+    QVERIFY2(autopilot->prerequisiteSetup(frameComp).isEmpty(), "Frame unexpectedly has a prerequisite");
+
+    // -------------------------------------------------------------------
+    // UI: Sensors and Radio show the prerequisite message panel, Frame opens
+    // -------------------------------------------------------------------
+    navigateToConfigureView();
+    if (QTest::currentTestFailed()) return;
+
+    // All three sidebar buttons must show the red setup-required icon
+    _verifySetupIndicator(QStringLiteral("vehicleConfig_comp_Frame"), /*expectSetupComplete=*/false);
+    if (QTest::currentTestFailed()) return;
+    _verifySetupIndicator(QStringLiteral("vehicleConfig_comp_Sensors"), /*expectSetupComplete=*/false);
+    if (QTest::currentTestFailed()) return;
+    _verifySetupIndicator(QStringLiteral("vehicleConfig_comp_Radio"), /*expectSetupComplete=*/false);
+    if (QTest::currentTestFailed()) return;
+
+    _verifyFramePrereq(QStringLiteral("vehicleConfig_comp_Frame"), /*expectPrereqShown=*/false);
+    if (QTest::currentTestFailed()) return;
+    _verifyFramePrereq(QStringLiteral("vehicleConfig_comp_Sensors"), /*expectPrereqShown=*/true);
+    if (QTest::currentTestFailed()) return;
+    _verifyFramePrereq(QStringLiteral("vehicleConfig_comp_Radio"), /*expectPrereqShown=*/true);
+    if (QTest::currentTestFailed()) return;
+
+    // -------------------------------------------------------------------
+    // Select the Quad frame class from the Frame page. Clicking the box
+    // writes FRAME_TYPE (default X) then FRAME_CLASS, completing Frame setup.
+    // -------------------------------------------------------------------
+    clickSidebarButton(QStringLiteral("vehicleConfig_comp_Frame"));
+    if (QTest::currentTestFailed()) return;
+
+    QQuickItem *quadBox = findVisibleItem(_rootItem, QStringLiteral("apmAirframeBox_Quad"), 3000);
+    QVERIFY2(quadBox, "Quad airframe box not found on Frame page");
+
+    // FRAME_CLASS/FRAME_TYPE require a vehicle reboot, so selecting a frame
+    // must pop the reboot app message
+    expectAppMessage(QRegularExpression(QStringLiteral("Reboot vehicle for changes to take effect")));
+
+    Fact *frameClassFact = mgr->getParameter(ParameterManager::defaultComponentId, QStringLiteral("FRAME_CLASS"));
+    Fact *frameTypeFact = mgr->getParameter(ParameterManager::defaultComponentId, QStringLiteral("FRAME_TYPE"));
+    QSignalSpy frameClassAckSpy(frameClassFact, &Fact::vehicleUpdated);
+    QVERIFY2(frameClassAckSpy.isValid(), "Failed to create FRAME_CLASS vehicleUpdated spy");
+
+    const QPointF boxCenter = quadBox->mapToScene(QPointF(quadBox->width() / 2, quadBox->height() / 2));
+    QTest::mouseClick(_window, Qt::LeftButton, Qt::NoModifier, boxCenter.toPoint());
+    QTest::qWait(_pageDelay);
+
+    QVERIFY2(QTest::qWaitFor([&] { return frameClassFact->rawValue().toInt() == 1; }, 5000),
+             "FRAME_CLASS never set to Quad after clicking the Quad box");
+    QCOMPARE(frameTypeFact->rawValue().toInt(), 1); // X is the Quad default frame type
+
+    // The reboot message fires when the vehicle acks the param write: dismiss
+    // the resulting dialog before interacting with the UI again
+    QVERIFY2(QTest::qWaitFor([&] { return frameClassAckSpy.count() >= 1; }, 5000),
+             "FRAME_CLASS write never acked by the vehicle");
+    QVERIFY2(acceptDialog(5000), "Reboot app message dialog never shown");
+    verifyExpectedLogMessage();
+    if (QTest::currentTestFailed()) return;
+
+    // The red setup-required indicator on the Frame sidebar button must turn
+    // green (setupComplete) once a frame class is selected
+    QVERIFY2(QTest::qWaitFor([&] { return frameComp->setupComplete(); }, 5000),
+             "Frame setupComplete still false after selecting Quad frame");
+    _verifySetupIndicator(QStringLiteral("vehicleConfig_comp_Frame"), /*expectSetupComplete=*/true);
+    if (QTest::currentTestFailed()) return;
+
+    // Sensors and Radio remain uncalibrated, so their icons must stay red
+    _verifySetupIndicator(QStringLiteral("vehicleConfig_comp_Sensors"), /*expectSetupComplete=*/false);
+    if (QTest::currentTestFailed()) return;
+    _verifySetupIndicator(QStringLiteral("vehicleConfig_comp_Radio"), /*expectSetupComplete=*/false);
+    if (QTest::currentTestFailed()) return;
+
+    // -------------------------------------------------------------------
+    // Frame setup complete: Sensors and Radio prerequisites must clear
+    // -------------------------------------------------------------------
+    QVERIFY2(autopilot->prerequisiteSetup(sensorsComp).isEmpty(), "Sensors still has a prerequisite after frame selection");
+    QVERIFY2(autopilot->prerequisiteSetup(radioComp).isEmpty(), "Radio still has a prerequisite after frame selection");
+
+    _verifyFramePrereq(QStringLiteral("vehicleConfig_comp_Sensors"), /*expectPrereqShown=*/false);
+    if (QTest::currentTestFailed()) return;
+    _verifyFramePrereq(QStringLiteral("vehicleConfig_comp_Radio"), /*expectPrereqShown=*/false);
+    if (QTest::currentTestFailed()) return;
+
+    // -------------------------------------------------------------------
+    // Run accel + compass calibration from the Sensors page: the Sensors
+    // sidebar indicator must turn green while Radio stays red
+    // -------------------------------------------------------------------
+    navigateToAPMSensorsPage();
+    if (QTest::currentTestFailed()) return;
+
+    runAPMFullAccelCal();
+    if (QTest::currentTestFailed()) return;
+    waitForParamRefreshQuiet(vehicle);
+    if (QTest::currentTestFailed()) return;
+
+    runAPMCompassCal();
+    if (QTest::currentTestFailed()) return;
+    waitForParamRefreshQuiet(vehicle);
+    if (QTest::currentTestFailed()) return;
+
+    QVERIFY2(QTest::qWaitFor([&] { return sensorsComp->setupComplete(); }, 5000),
+             "Sensors setupComplete still false after accel + compass calibration");
+    _verifySetupIndicator(QStringLiteral("vehicleConfig_comp_Sensors"), /*expectSetupComplete=*/true);
+    if (QTest::currentTestFailed()) return;
+
+    // Radio is still uncalibrated: its indicator must remain red
+    QVERIFY2(!radioComp->setupComplete(), "Radio setupComplete despite no radio calibration");
+    _verifySetupIndicator(QStringLiteral("vehicleConfig_comp_Radio"), /*expectSetupComplete=*/false);
+
+    });
+}

--- a/test/QmlUITests/APMFreshFlashUITest.h
+++ b/test/QmlUITests/APMFreshFlashUITest.h
@@ -1,0 +1,31 @@
+#pragma once
+
+#include "VehicleConfigUITestBase.h"
+
+/// UI test that connects an ArduPilot MockLink started with the
+/// OptionAPMStartFreshParams option (freshly flashed firmware state: no
+/// airframe selected, compass/accel/radio uncalibrated) and verifies that
+/// Frame, Sensors and Radio all report setup required, that Frame is the
+/// required prerequisite for the Sensors and Radio pages, that selecting
+/// a frame class unblocks them, and that completing accel + compass
+/// calibration turns the Sensors indicator green while Radio stays red.
+class APMFreshFlashUITest : public VehicleConfigUITestBase
+{
+    Q_OBJECT
+
+public:
+    APMFreshFlashUITest() = default;
+
+private slots:
+    void _testFreshFlashSetupState();
+
+private:
+    /// Click the given component button in the config sidebar and verify
+    /// whether the prerequisite-setup message panel is shown.
+    void _verifyFramePrereq(const QString &compObjectName, bool expectPrereqShown);
+
+    /// Verify the sidebar button for the given component shows the red
+    /// setup-required icon (ConfigButton turns icon.color red when
+    /// setupComplete is false).
+    void _verifySetupIndicator(const QString &compObjectName, bool expectSetupComplete);
+};

--- a/test/QmlUITests/APMSensorsCalibrationUITest.cc
+++ b/test/QmlUITests/APMSensorsCalibrationUITest.cc
@@ -1,6 +1,5 @@
 #include "APMSensorsCalibrationUITest.h"
 
-#include <QtCore/QElapsedTimer>
 #include <QtQuick/QQuickItem>
 #include <QtTest/QTest>
 
@@ -9,143 +8,6 @@
 #include "Vehicle.h"
 
 UT_REGISTER_TEST(APMSensorsCalibrationUITest, TestLabel::Integration)
-
-namespace {
-
-/// Wait for _refreshParams() traffic to settle so link teardown doesn't cut off
-/// in-flight PARAM_REQUEST_READs (which can log warnings that fail strict mode).
-void waitForParamRefreshQuiet(Vehicle *vehicle)
-{
-    ParameterManager *mgr = vehicle->parameterManager();
-    QElapsedTimer sinceLastResponse;
-    sinceLastResponse.start();
-
-    QObject context;
-    QObject::connect(mgr, &ParameterManager::_paramRequestReadSuccess, &context,
-                     [&] { sinceLastResponse.restart(); });
-    QObject::connect(mgr, &ParameterManager::_paramRequestReadFailure, &context,
-                     [&] { sinceLastResponse.restart(); });
-
-    (void) QTest::qWaitFor([&] { return sinceLastResponse.elapsed() > 500; }, 10000);
-}
-
-} // namespace
-
-// ---------------------------------------------------------------------------
-
-void APMSensorsCalibrationUITest::_navigateToSensorsPage()
-{
-    navigateToConfigureView();
-    if (QTest::currentTestFailed()) return;
-
-    QQuickItem *sensorsBtn = clickSidebarButton(QStringLiteral("vehicleConfig_comp_Sensors"));
-    if (QTest::currentTestFailed()) return;
-
-    // The Sensors component has no sub-sections on APM; clicking the button opens the page.
-    // The Accelerometer indicator button must appear.
-    QVERIFY2(findVisibleItem(_rootItem, QStringLiteral("sensorsSetup_calibrateAccel"), 5000),
-             "sensorsSetup_calibrateAccel not found after opening Sensors page");
-    QVERIFY2(findVisibleItem(_rootItem, QStringLiteral("sensorsSetup_calibrateCompass"), 3000),
-             "sensorsSetup_calibrateCompass not found after opening Sensors page");
-    Q_UNUSED(sensorsBtn);
-}
-
-void APMSensorsCalibrationUITest::_verifyCalIndicators(bool compassGreen, bool accelGreen, const char *context)
-{
-    struct Check {
-        const char *name;
-        bool expectedGreen;
-    };
-    const Check checks[] = {
-        { "sensorsSetup_calibrateCompass", compassGreen },
-        { "sensorsSetup_calibrateAccel",   accelGreen   },
-    };
-
-    for (const Check &c : checks) {
-        QQuickItem *btn = findVisibleItem(_rootItem, QLatin1String(c.name), 3000);
-        QVERIFY2(btn, qPrintable(QStringLiteral("Button not found (%1): %2")
-                                     .arg(QLatin1String(context), QLatin1String(c.name))));
-        (void) QTest::qWaitFor([&] {
-            return btn->property("indicatorGreen").toBool() == c.expectedGreen;
-        }, 3000);
-        QVERIFY2(btn->property("indicatorGreen").toBool() == c.expectedGreen,
-                 qPrintable(QStringLiteral("indicatorGreen is %1, expected %2 (%3): %4")
-                                .arg(btn->property("indicatorGreen").toBool())
-                                .arg(c.expectedGreen)
-                                .arg(QLatin1String(context), QLatin1String(c.name))));
-    }
-}
-
-void APMSensorsCalibrationUITest::_runFullAccelCal()
-{
-    // APM requires accel cal before compass can be run.
-    // Click Accelerometer button → orientation dialog opens → accept (full cal, not simple).
-    QVERIFY2(clickButton(QStringLiteral("sensorsSetup_calibrateAccel")),
-             "Failed to click Accelerometer button");
-
-    // Accept the orientation/pre-cal dialog (do NOT check the Simple checkbox)
-    QVERIFY2(findVisibleItem(_rootItem, QStringLiteral("popupDialog_acceptButton"), 5000),
-             "Pre-accel-cal dialog accept button not found");
-    QVERIFY2(clickButton(QStringLiteral("popupDialog_acceptButton")),
-             "Failed to accept pre-accel-cal dialog");
-
-    // MockLink will now drive the 6-pose ACCELCAL_VEHICLE_POS handshake.
-    // For each pose the orientation cal area becomes visible with the relevant
-    // side InProgress; the user (test) clicks Next to advance.
-
-    // Poses in the order MockLink sends them:
-    // LEVEL→downSide, LEFT→leftSide, RIGHT→rightSide,
-    // NOSEDOWN→noseDownSide, NOSEUP→tailDownSide, BACK→upsideDownSide
-    struct PoseInfo {
-        const char *sideObjectName;
-    };
-    static constexpr PoseInfo kPoses[] = {
-        { "sensorsCal_downSide"      },
-        { "sensorsCal_leftSide"      },
-        { "sensorsCal_rightSide"     },
-        { "sensorsCal_noseDownSide"  },
-        { "sensorsCal_tailDownSide"  },
-        { "sensorsCal_upsideDownSide" },
-    };
-
-    for (const PoseInfo &pose : kPoses) {
-        // Wait for the orientation cal area to show (controller.showOrientationCalArea = true)
-        // and this side to be InProgress (calState == VehicleRotationCal.CalState.InProgress == 2)
-        QQuickItem *sideItem = findVisibleItem(_rootItem, QLatin1String(pose.sideObjectName), 10000);
-        QVERIFY2(sideItem, qPrintable(QStringLiteral("Side indicator not visible: %1")
-                                          .arg(QLatin1String(pose.sideObjectName))));
-
-        // calState InProgress == 2 (VehicleRotationCal.CalState enum)
-        QVERIFY2(QTest::qWaitFor([&] { return sideItem->property("calState").toInt() == 2; }, 10000),
-                 qPrintable(QStringLiteral("Side never went InProgress: %1")
-                                .arg(QLatin1String(pose.sideObjectName))));
-
-        // Click Next — sends COMMAND_ACK back to MockLink to advance to next pose.
-        // The controller enables the Next button when it receives the ACCELCAL_VEHICLE_POS message,
-        // which happens on the same tick as the side going InProgress, so wait briefly for it.
-        QQuickItem *nextBtn = findVisibleItem(_rootItem, QStringLiteral("sensorsSetup_nextButton"), 3000);
-        QVERIFY2(nextBtn, "Next button not found");
-        QVERIFY2(QTest::qWaitFor([&] { return nextBtn->property("enabled").toBool(); }, 3000),
-                 qPrintable(QStringLiteral("Next button not enabled for side: %1")
-                                .arg(QLatin1String(pose.sideObjectName))));
-        QVERIFY2(clickButton(QStringLiteral("sensorsSetup_nextButton")), "Failed to click Next button");
-    }
-
-    // After the last pose MockLink sends ACCELCAL_VEHICLE_POS_SUCCESS → _stopCalibration(Success)
-    // Progress bar goes to 1.0 and the cal area closes
-    QQuickItem *progressBar = findVisibleItem(_rootItem, QStringLiteral("sensorsSetup_progressBar"), 2000);
-    QVERIFY2(progressBar, "Progress bar not found during accel cal");
-    QVERIFY2(QTest::qWaitFor([&] { return qFuzzyCompare(progressBar->property("value").toDouble(), 1.0); }, 10000),
-             "Progress bar never reached 1.0 after accel cal success");
-
-    // APM's onCalibrationComplete handler opens postOnboardCompassCalibrationFactory for
-    // both CalibrationAccel and CalibrationMag.  Dismiss the dialog so the sensors
-    // page is unblocked before callers proceed.
-    QVERIFY2(findVisibleItem(_rootItem, QStringLiteral("popupDialog_acceptButton"), 5000),
-             "Post-accel-cal dialog not shown");
-    QVERIFY2(clickButton(QStringLiteral("popupDialog_acceptButton")),
-             "Failed to dismiss post-accel-cal dialog");
-}
 
 // ---------------------------------------------------------------------------
 // _testCompassCalibration
@@ -160,57 +22,37 @@ void APMSensorsCalibrationUITest::_testCompassCalibration()
     resetAPMParamsToUncalibrated(vehicle);
     if (QTest::currentTestFailed()) return;
 
-    _navigateToSensorsPage();
+    navigateToAPMSensorsPage();
     if (QTest::currentTestFailed()) return;
 
     // Both indicators must be orange (not calibrated)
-    _verifyCalIndicators(/*compassGreen=*/false, /*accelGreen=*/false, "after param reset");
+    verifyAPMCalIndicators(/*compassGreen=*/false, /*accelGreen=*/false, "after param reset");
     if (QTest::currentTestFailed()) return;
 
     // -------------------------------------------------------------------
     // 1. Accel calibration (required before compass on APM)
     // -------------------------------------------------------------------
-    _runFullAccelCal();
+    runAPMFullAccelCal();
     if (QTest::currentTestFailed()) return;
 
     waitForParamRefreshQuiet(vehicle);
+    if (QTest::currentTestFailed()) return;
 
     // Accel indicator should now be green; compass still orange
-    _verifyCalIndicators(/*compassGreen=*/false, /*accelGreen=*/true, "after accel cal");
+    verifyAPMCalIndicators(/*compassGreen=*/false, /*accelGreen=*/true, "after accel cal");
     if (QTest::currentTestFailed()) return;
 
     // -------------------------------------------------------------------
     // 2. Compass calibration
     // -------------------------------------------------------------------
-    QVERIFY2(clickButton(QStringLiteral("sensorsSetup_calibrateCompass")),
-             "Failed to click Compass button");
-
-    // Orientation dialog opens → accept to start MAV_CMD_DO_START_MAG_CAL
-    QVERIFY2(findVisibleItem(_rootItem, QStringLiteral("popupDialog_acceptButton"), 5000),
-             "Pre-compass-cal dialog accept button not found");
-    QVERIFY2(clickButton(QStringLiteral("popupDialog_acceptButton")),
-             "Failed to accept pre-compass-cal dialog");
-
-    // MockLink sends MAG_CAL_PROGRESS 0→100 at ~10Hz
-    QQuickItem *progressBar = findVisibleItem(_rootItem, QStringLiteral("sensorsSetup_progressBar"), 2000);
-    QVERIFY2(progressBar, "Progress bar not found during compass cal");
-
-    // Wait for progress > 0 (calibration is running)
-    QVERIFY2(QTest::qWaitFor([&] { return progressBar->property("value").toDouble() > 0.0; }, 5000),
-             "Compass cal progress never advanced above 0");
-
-    // Wait for completion: MAG_CAL_REPORT → StopCalibrationSuccessShowLog → dialog opens.
-    // Note: StopCalibrationSuccessShowLog resets progress to 0 (not 1.0), so wait for
-    // the post-cal dialog directly rather than waiting for progress == 1.0.
-    QVERIFY2(findVisibleItem(_rootItem, QStringLiteral("popupDialog_acceptButton"), 25000),
-             "Post-compass-cal dialog not shown");
-    QVERIFY2(clickButton(QStringLiteral("popupDialog_acceptButton")),
-             "Failed to dismiss post-compass-cal dialog");
+    runAPMCompassCal();
+    if (QTest::currentTestFailed()) return;
 
     waitForParamRefreshQuiet(vehicle);
+    if (QTest::currentTestFailed()) return;
 
     // Both indicators must be green
-    _verifyCalIndicators(/*compassGreen=*/true, /*accelGreen=*/true, "after compass cal");
+    verifyAPMCalIndicators(/*compassGreen=*/true, /*accelGreen=*/true, "after compass cal");
 
     });
 }
@@ -228,13 +70,14 @@ void APMSensorsCalibrationUITest::_testCompassCalibrationCancel()
     resetAPMParamsToUncalibrated(vehicle);
     if (QTest::currentTestFailed()) return;
 
-    _navigateToSensorsPage();
+    navigateToAPMSensorsPage();
     if (QTest::currentTestFailed()) return;
 
     // Must do accel first
-    _runFullAccelCal();
+    runAPMFullAccelCal();
     if (QTest::currentTestFailed()) return;
     waitForParamRefreshQuiet(vehicle);
+    if (QTest::currentTestFailed()) return;
 
     // Start compass cal
     QVERIFY2(clickButton(QStringLiteral("sensorsSetup_calibrateCompass")),
@@ -269,7 +112,7 @@ void APMSensorsCalibrationUITest::_testCompassCalibrationCancel()
              "COMPASS_OFS_X is non-zero after compass cal cancel");
 
     // Compass indicator still orange
-    _verifyCalIndicators(/*compassGreen=*/false, /*accelGreen=*/true, "after compass cal cancel");
+    verifyAPMCalIndicators(/*compassGreen=*/false, /*accelGreen=*/true, "after compass cal cancel");
 
     });
 }
@@ -291,13 +134,14 @@ void APMSensorsCalibrationUITest::_testCompassCalibrationIgnoresStaleFailedRepor
     resetAPMParamsToUncalibrated(vehicle);
     if (QTest::currentTestFailed()) return;
 
-    _navigateToSensorsPage();
+    navigateToAPMSensorsPage();
     if (QTest::currentTestFailed()) return;
 
     // Must do accel first
-    _runFullAccelCal();
+    runAPMFullAccelCal();
     if (QTest::currentTestFailed()) return;
     waitForParamRefreshQuiet(vehicle);
+    if (QTest::currentTestFailed()) return;
 
     // Simulate leftover MAG_CAL_REPORT(FAILED) stream from a previously failed cal
     mockLink->startAPMStaleFailedMagCalReportStreaming();
@@ -333,9 +177,10 @@ void APMSensorsCalibrationUITest::_testCompassCalibrationIgnoresStaleFailedRepor
              "Failed to dismiss post-compass-cal dialog");
 
     waitForParamRefreshQuiet(vehicle);
+    if (QTest::currentTestFailed()) return;
 
     // Both indicators must be green - the cal completed successfully
-    _verifyCalIndicators(/*compassGreen=*/true, /*accelGreen=*/true, "after compass cal with stale reports");
+    verifyAPMCalIndicators(/*compassGreen=*/true, /*accelGreen=*/true, "after compass cal with stale reports");
 
     });
 }
@@ -357,13 +202,14 @@ void APMSensorsCalibrationUITest::_testCompassCalibrationStartRejected()
     resetAPMParamsToUncalibrated(vehicle);
     if (QTest::currentTestFailed()) return;
 
-    _navigateToSensorsPage();
+    navigateToAPMSensorsPage();
     if (QTest::currentTestFailed()) return;
 
     // Must do accel first
-    _runFullAccelCal();
+    runAPMFullAccelCal();
     if (QTest::currentTestFailed()) return;
     waitForParamRefreshQuiet(vehicle);
+    if (QTest::currentTestFailed()) return;
 
     // Vehicle rejects MAV_CMD_DO_START_MAG_CAL
     mockLink->setAPMMagCalStartFailureMode(true);
@@ -391,9 +237,10 @@ void APMSensorsCalibrationUITest::_testCompassCalibrationStartRejected()
     verifyExpectedLogMessage();  // Calibration failed
 
     waitForParamRefreshQuiet(vehicle);
+    if (QTest::currentTestFailed()) return;
 
     // Compass indicator still orange, accel green
-    _verifyCalIndicators(/*compassGreen=*/false, /*accelGreen=*/true, "after rejected compass cal start");
+    verifyAPMCalIndicators(/*compassGreen=*/false, /*accelGreen=*/true, "after rejected compass cal start");
 
     });
 }
@@ -411,16 +258,17 @@ void APMSensorsCalibrationUITest::_testAccelCalibration()
     resetAPMParamsToUncalibrated(vehicle);
     if (QTest::currentTestFailed()) return;
 
-    _navigateToSensorsPage();
+    navigateToAPMSensorsPage();
     if (QTest::currentTestFailed()) return;
 
-    _verifyCalIndicators(/*compassGreen=*/false, /*accelGreen=*/false, "after param reset");
+    verifyAPMCalIndicators(/*compassGreen=*/false, /*accelGreen=*/false, "after param reset");
     if (QTest::currentTestFailed()) return;
 
-    _runFullAccelCal();
+    runAPMFullAccelCal();
     if (QTest::currentTestFailed()) return;
 
     waitForParamRefreshQuiet(vehicle);
+    if (QTest::currentTestFailed()) return;
 
     // INS_ACCOFFS_X must be non-zero (MockLink writes 0.1 on SUCCESS)
     ParameterManager *mgr = vehicle->parameterManager();
@@ -431,7 +279,7 @@ void APMSensorsCalibrationUITest::_testAccelCalibration()
              "INS_ACCOFFS_X still 0 after accel cal — param refresh did not bring back non-zero value");
 
     // Accel indicator green, compass still orange
-    _verifyCalIndicators(/*compassGreen=*/false, /*accelGreen=*/true, "after accel cal");
+    verifyAPMCalIndicators(/*compassGreen=*/false, /*accelGreen=*/true, "after accel cal");
 
     });
 }

--- a/test/QmlUITests/APMSensorsCalibrationUITest.h
+++ b/test/QmlUITests/APMSensorsCalibrationUITest.h
@@ -2,7 +2,6 @@
 
 #include "VehicleConfigUITestBase.h"
 
-class QString;
 class Vehicle;
 
 /// UI test that boots the full QML UI with an ArduCopter MockLink vehicle connected,
@@ -29,15 +28,4 @@ private slots:
     void _testCompassCalibrationIgnoresStaleFailedReports();
     void _testCompassCalibrationStartRejected();
     void _testAccelCalibration();
-
-private:
-    /// Navigate from the Fly view to the APM Sensors page.
-    void _navigateToSensorsPage();
-
-    /// Verify the two calibration indicator buttons reflect the expected green/orange state.
-    void _verifyCalIndicators(bool compassGreen, bool accelGreen, const char *context);
-
-    /// Run a complete full accelerometer calibration by clicking Next for each of the
-    /// six poses as MockLink drives the ACCELCAL_VEHICLE_POS handshake.
-    void _runFullAccelCal();
 };

--- a/test/QmlUITests/CMakeLists.txt
+++ b/test/QmlUITests/CMakeLists.txt
@@ -24,6 +24,8 @@ target_sources(${CMAKE_PROJECT_NAME}
         ${CMAKE_CURRENT_SOURCE_DIR}/PX4SensorsCalibrationUITest.h
         ${CMAKE_CURRENT_SOURCE_DIR}/APMSensorsCalibrationUITest.cc
         ${CMAKE_CURRENT_SOURCE_DIR}/APMSensorsCalibrationUITest.h
+        ${CMAKE_CURRENT_SOURCE_DIR}/APMFreshFlashUITest.cc
+        ${CMAKE_CURRENT_SOURCE_DIR}/APMFreshFlashUITest.h
         ${CMAKE_CURRENT_SOURCE_DIR}/PX4AirframeSetupUITest.cc
         ${CMAKE_CURRENT_SOURCE_DIR}/PX4AirframeSetupUITest.h
         ${CMAKE_CURRENT_SOURCE_DIR}/AppCloseWarningUITest.cc
@@ -46,6 +48,7 @@ add_qgc_test(PlanViewUITest LABELS Integration NoSanitizer TIMEOUT 120)
 add_qgc_test(PlanViewLayerUITest LABELS Integration NoSanitizer TIMEOUT 120)
 add_qgc_test(PX4SensorsCalibrationUITest LABELS Integration NoSanitizer TIMEOUT 180)
 add_qgc_test(APMSensorsCalibrationUITest LABELS Integration NoSanitizer TIMEOUT 240)
+add_qgc_test(APMFreshFlashUITest LABELS Integration NoSanitizer TIMEOUT 180)
 add_qgc_test(PX4AirframeSetupUITest LABELS Integration NoSanitizer TIMEOUT 120)
 add_qgc_test(AppCloseWarningUITest LABELS Integration NoSanitizer TIMEOUT 120)
 add_qgc_test(FlyViewProximityRadarUITest LABELS Integration NoSanitizer TIMEOUT 120)

--- a/test/QmlUITests/PX4AirframeSetupUITest.cc
+++ b/test/QmlUITests/PX4AirframeSetupUITest.cc
@@ -203,6 +203,10 @@ void PX4AirframeSetupUITest::_testApplyAirframe()
     QSignalSpy spyCmdResult(vehicle, &Vehicle::mavCommandResult);
     QVERIFY2(spyCmdResult.isValid(), "Failed to create mavCommandResult spy");
 
+    // SYS_AUTOSTART requires a vehicle reboot, so applying the airframe must
+    // pop the reboot app message
+    expectAppMessage(QRegularExpression(QStringLiteral("Reboot vehicle for changes to take effect")));
+
     QVERIFY2(clickButton(QStringLiteral("airframeSetup_applyButton")), "Failed to click Apply and Restart");
     QVERIFY2(findVisibleItem(_rootItem, QStringLiteral("popupDialog_acceptButton"), 3000),
              "Apply confirmation dialog not shown");
@@ -234,5 +238,10 @@ void PX4AirframeSetupUITest::_testApplyAirframe()
     // The restart flow disconnects the link, dropping the active vehicle
     QVERIFY2(QTest::qWaitFor([&] { return MultiVehicleManager::instance()->activeVehicle() == nullptr; }, 10000),
              "Vehicle never disconnected after Apply and Restart");
+
+    // By now the SYS_AUTOSTART ack has round-tripped, so the reboot app
+    // message dialog must have been shown — dismiss and verify it
+    QVERIFY2(acceptDialog(5000), "Reboot app message dialog never shown");
+    verifyExpectedLogMessage();
     });
 }

--- a/test/QmlUITests/PX4SensorsCalibrationUITest.cc
+++ b/test/QmlUITests/PX4SensorsCalibrationUITest.cc
@@ -46,24 +46,6 @@ const char *calStateName(int state)
     return "Unknown";
 }
 
-/// SensorsComponentController refreshes the CAL_*/SENS_* parameters whenever calibration
-/// stops. Wait for that traffic to go quiet so link teardown doesn't cut off in-flight
-/// PARAM_REQUEST_READs (which logs warnings that fail strict mode).
-void waitForParamRefreshQuiet(Vehicle *vehicle)
-{
-    ParameterManager *mgr = vehicle->parameterManager();
-    QElapsedTimer sinceLastResponse;
-    sinceLastResponse.start();
-
-    QObject context;
-    QObject::connect(mgr, &ParameterManager::_paramRequestReadSuccess, &context,
-                     [&] { sinceLastResponse.restart(); });
-    QObject::connect(mgr, &ParameterManager::_paramRequestReadFailure, &context,
-                     [&] { sinceLastResponse.restart(); });
-
-    (void) QTest::qWaitFor([&] { return sinceLastResponse.elapsed() > 500; }, 10000);
-}
-
 } // namespace
 
 void PX4SensorsCalibrationUITest::_navigateToSensorsPanel()
@@ -269,6 +251,7 @@ void PX4SensorsCalibrationUITest::_testMagCalibration()
              "Cancel button still visible after calibration completed");
 
     waitForParamRefreshQuiet(vehicle);
+    if (QTest::currentTestFailed()) return;
 
     // All sides must remain marked complete (green) after calibration ends and
     // the post-calibration parameter refresh settles
@@ -356,6 +339,7 @@ void PX4SensorsCalibrationUITest::_runCalibrationCancelTest(const QString &secti
                             .arg(calibrateButtonObjectName)));
 
     waitForParamRefreshQuiet(vehicle);
+    if (QTest::currentTestFailed()) return;
 
     // The cancelled calibration discarded its results: every sensor still
     // requires config
@@ -487,6 +471,7 @@ void PX4SensorsCalibrationUITest::_testAccelCalibration()
              "Cancel button still visible after calibration completed");
 
     waitForParamRefreshQuiet(vehicle);
+    if (QTest::currentTestFailed()) return;
 
     // All sides must remain marked complete (green) after calibration ends and
     // the post-calibration parameter refresh settles

--- a/test/QmlUITests/QmlUITestBase.cc
+++ b/test/QmlUITests/QmlUITestBase.cc
@@ -128,6 +128,10 @@ void QmlUITestBase::startUI()
     _engine->load(QUrl(QStringLiteral("qrc:/qml/QGroundControl/MainWindow.qml")));
     QVERIFY(!_engine->rootObjects().isEmpty());
 
+    // Register the engine with the app so showAppMessage() reaches this MainWindow
+    // and app message dialogs are shown for real during UI tests.
+    qgcApp()->setQmlAppEngine(_engine);
+
     _window = qobject_cast<QQuickWindow *>(_engine->rootObjects().first());
     QVERIFY(_window);
 
@@ -206,6 +210,7 @@ void QmlUITestBase::destroyUIEngine()
         _window = nullptr;
         QCoreApplication::processEvents();
     }
+    qgcApp()->setQmlAppEngine(nullptr);
     delete _engine;
     _engine   = nullptr;
     _window   = nullptr;

--- a/test/QmlUITests/VehicleConfigUITestBase.cc
+++ b/test/QmlUITests/VehicleConfigUITestBase.cc
@@ -1,5 +1,7 @@
 #include "VehicleConfigUITestBase.h"
 
+#include <QtCore/QElapsedTimer>
+#include <QtCore/QPointer>
 #include <QtQuick/QQuickItem>
 #include <QtQuick/QQuickWindow>
 #include <QtTest/QTest>
@@ -110,4 +112,167 @@ void VehicleConfigUITestBase::clickThroughAllComponents(Vehicle *vehicle, const 
                  qPrintable(QStringLiteral("%1Panel loader has no item after clicking %2")
                                 .arg(prefix, comp->name())));
     }
+}
+
+void VehicleConfigUITestBase::waitForParamRefreshQuiet(Vehicle *vehicle)
+{
+    ParameterManager *mgr = vehicle->parameterManager();
+    QElapsedTimer sinceLastResponse;
+    sinceLastResponse.start();
+
+    QObject context;
+    QObject::connect(mgr, &ParameterManager::_paramRequestReadSuccess, &context,
+                     [&] { sinceLastResponse.restart(); });
+    QObject::connect(mgr, &ParameterManager::_paramRequestReadFailure, &context,
+                     [&] { sinceLastResponse.restart(); });
+
+    QVERIFY2(QTest::qWaitFor([&] { return sinceLastResponse.elapsed() > 500; }, 10000),
+             "waitForParamRefreshQuiet: parameter refresh traffic still active after 10s");
+}
+
+void VehicleConfigUITestBase::navigateToAPMSensorsPage()
+{
+    navigateToConfigureView();
+    if (QTest::currentTestFailed()) return;
+
+    QQuickItem *sensorsBtn = clickSidebarButton(QStringLiteral("vehicleConfig_comp_Sensors"));
+    if (QTest::currentTestFailed()) return;
+
+    // The Sensors component has no sub-sections on APM; clicking the button opens the page.
+    // The Accelerometer indicator button must appear.
+    QVERIFY2(findVisibleItem(_rootItem, QStringLiteral("sensorsSetup_calibrateAccel"), 5000),
+             "sensorsSetup_calibrateAccel not found after opening Sensors page");
+    QVERIFY2(findVisibleItem(_rootItem, QStringLiteral("sensorsSetup_calibrateCompass"), 3000),
+             "sensorsSetup_calibrateCompass not found after opening Sensors page");
+    Q_UNUSED(sensorsBtn);
+}
+
+void VehicleConfigUITestBase::verifyAPMCalIndicators(bool compassGreen, bool accelGreen, const char *context)
+{
+    struct Check {
+        const char *name;
+        bool expectedGreen;
+    };
+    const Check checks[] = {
+        { "sensorsSetup_calibrateCompass", compassGreen },
+        { "sensorsSetup_calibrateAccel",   accelGreen   },
+    };
+
+    for (const Check &c : checks) {
+        QPointer<QQuickItem> btn = findVisibleItem(_rootItem, QLatin1String(c.name), 3000);
+        QVERIFY2(btn, qPrintable(QStringLiteral("Button not found (%1): %2")
+                                     .arg(QLatin1String(context), QLatin1String(c.name))));
+        (void) QTest::qWaitFor([&] {
+            return btn && (btn->property("indicatorGreen").toBool() == c.expectedGreen);
+        }, 3000);
+        QVERIFY2(btn, qPrintable(QStringLiteral("Button destroyed while waiting (%1): %2")
+                                     .arg(QLatin1String(context), QLatin1String(c.name))));
+        QVERIFY2(btn->property("indicatorGreen").toBool() == c.expectedGreen,
+                 qPrintable(QStringLiteral("indicatorGreen is %1, expected %2 (%3): %4")
+                                .arg(btn->property("indicatorGreen").toBool())
+                                .arg(c.expectedGreen)
+                                .arg(QLatin1String(context), QLatin1String(c.name))));
+    }
+}
+
+void VehicleConfigUITestBase::runAPMFullAccelCal()
+{
+    // APM requires accel cal before compass can be run.
+    // Click Accelerometer button → orientation dialog opens → accept (full cal, not simple).
+    QVERIFY2(clickButton(QStringLiteral("sensorsSetup_calibrateAccel")),
+             "Failed to click Accelerometer button");
+
+    // Accept the orientation/pre-cal dialog (do NOT check the Simple checkbox)
+    QVERIFY2(findVisibleItem(_rootItem, QStringLiteral("popupDialog_acceptButton"), 5000),
+             "Pre-accel-cal dialog accept button not found");
+    QVERIFY2(clickButton(QStringLiteral("popupDialog_acceptButton")),
+             "Failed to accept pre-accel-cal dialog");
+
+    // MockLink will now drive the 6-pose ACCELCAL_VEHICLE_POS handshake.
+    // For each pose the orientation cal area becomes visible with the relevant
+    // side InProgress; the user (test) clicks Next to advance.
+
+    // Poses in the order MockLink sends them:
+    // LEVEL→downSide, LEFT→leftSide, RIGHT→rightSide,
+    // NOSEDOWN→noseDownSide, NOSEUP→tailDownSide, BACK→upsideDownSide
+    struct PoseInfo {
+        const char *sideObjectName;
+    };
+    static constexpr PoseInfo kPoses[] = {
+        { "sensorsCal_downSide"      },
+        { "sensorsCal_leftSide"      },
+        { "sensorsCal_rightSide"     },
+        { "sensorsCal_noseDownSide"  },
+        { "sensorsCal_tailDownSide"  },
+        { "sensorsCal_upsideDownSide" },
+    };
+
+    for (const PoseInfo &pose : kPoses) {
+        // Wait for the orientation cal area to show (controller.showOrientationCalArea = true)
+        // and this side to be InProgress (calState == VehicleRotationCal.CalState.InProgress == 2)
+        QPointer<QQuickItem> sideItem = findVisibleItem(_rootItem, QLatin1String(pose.sideObjectName), 10000);
+        QVERIFY2(sideItem, qPrintable(QStringLiteral("Side indicator not visible: %1")
+                                          .arg(QLatin1String(pose.sideObjectName))));
+
+        // calState InProgress == 2 (VehicleRotationCal.CalState enum)
+        QVERIFY2(QTest::qWaitFor([&] { return sideItem && (sideItem->property("calState").toInt() == 2); }, 10000),
+                 qPrintable(QStringLiteral("Side never went InProgress: %1")
+                                .arg(QLatin1String(pose.sideObjectName))));
+
+        // Click Next — sends COMMAND_ACK back to MockLink to advance to next pose.
+        // The controller enables the Next button when it receives the ACCELCAL_VEHICLE_POS message,
+        // which happens on the same tick as the side going InProgress, so wait briefly for it.
+        QPointer<QQuickItem> nextBtn = findVisibleItem(_rootItem, QStringLiteral("sensorsSetup_nextButton"), 3000);
+        QVERIFY2(nextBtn, "Next button not found");
+        QVERIFY2(QTest::qWaitFor([&] { return nextBtn && nextBtn->property("enabled").toBool(); }, 3000),
+                 qPrintable(QStringLiteral("Next button not enabled for side: %1")
+                                .arg(QLatin1String(pose.sideObjectName))));
+        QVERIFY2(clickButton(QStringLiteral("sensorsSetup_nextButton")), "Failed to click Next button");
+    }
+
+    // After the last pose MockLink sends ACCELCAL_VEHICLE_POS_SUCCESS → _stopCalibration(Success)
+    // Progress bar goes to 1.0 and the cal area closes
+    QPointer<QQuickItem> progressBar = findVisibleItem(_rootItem, QStringLiteral("sensorsSetup_progressBar"), 2000);
+    QVERIFY2(progressBar, "Progress bar not found during accel cal");
+    QVERIFY2(QTest::qWaitFor([&] { return progressBar && qFuzzyCompare(progressBar->property("value").toDouble(), 1.0); }, 10000),
+             "Progress bar never reached 1.0 after accel cal success");
+
+    // Accel cal completion must show the generic post-calibration dialog
+    // (postCalibrationDialog), NOT the compass results dialog with fitness bars
+    // (postOnboardCompassCalibrationDialog).  Dismiss it so the sensors page is
+    // unblocked before callers proceed.
+    QVERIFY2(findVisibleItem(_rootItem, QStringLiteral("postCalibrationDialog"), 5000),
+             "Post-accel-cal dialog not shown");
+    QVERIFY2(!_rootItem->findChild<QQuickItem*>(QStringLiteral("postOnboardCompassCalibrationDialog")),
+             "Compass results dialog incorrectly shown after accel cal");
+    QVERIFY2(clickButton(QStringLiteral("popupDialog_acceptButton")),
+             "Failed to dismiss post-accel-cal dialog");
+}
+
+void VehicleConfigUITestBase::runAPMCompassCal()
+{
+    QVERIFY2(clickButton(QStringLiteral("sensorsSetup_calibrateCompass")),
+             "Failed to click Compass button");
+
+    // Orientation dialog opens → accept to start MAV_CMD_DO_START_MAG_CAL
+    QVERIFY2(findVisibleItem(_rootItem, QStringLiteral("popupDialog_acceptButton"), 5000),
+             "Pre-compass-cal dialog accept button not found");
+    QVERIFY2(clickButton(QStringLiteral("popupDialog_acceptButton")),
+             "Failed to accept pre-compass-cal dialog");
+
+    // MockLink sends MAG_CAL_PROGRESS 0→100 at ~10Hz
+    QPointer<QQuickItem> progressBar = findVisibleItem(_rootItem, QStringLiteral("sensorsSetup_progressBar"), 2000);
+    QVERIFY2(progressBar, "Progress bar not found during compass cal");
+
+    // Wait for progress > 0 (calibration is running)
+    QVERIFY2(QTest::qWaitFor([&] { return progressBar && (progressBar->property("value").toDouble() > 0.0); }, 5000),
+             "Compass cal progress never advanced above 0");
+
+    // Wait for completion: MAG_CAL_REPORT → StopCalibrationSuccessShowLog → dialog opens.
+    // Note: StopCalibrationSuccessShowLog resets progress to 0 (not 1.0), so wait for
+    // the post-cal dialog directly rather than waiting for progress == 1.0.
+    QVERIFY2(findVisibleItem(_rootItem, QStringLiteral("postOnboardCompassCalibrationDialog"), 25000),
+             "Post-compass-cal dialog not shown");
+    QVERIFY2(clickButton(QStringLiteral("popupDialog_acceptButton")),
+             "Failed to dismiss post-compass-cal dialog");
 }

--- a/test/QmlUITests/VehicleConfigUITestBase.h
+++ b/test/QmlUITests/VehicleConfigUITestBase.h
@@ -44,4 +44,28 @@ protected:
     /// present) are skipped silently. When non-empty, \a vehicleName is
     /// prepended to failure messages.
     void clickThroughAllComponents(Vehicle *vehicle, const QString &vehicleName = QString());
+
+    /// Wait for _refreshParams() traffic to settle so link teardown doesn't cut
+    /// off in-flight PARAM_REQUEST_READs (which can log warnings that fail
+    /// strict mode). Fails the test if traffic is still active after 10s;
+    /// callers must check QTest::currentTestFailed() after calling.
+    void waitForParamRefreshQuiet(Vehicle *vehicle);
+
+    /// Navigate from the Fly view to the APM Sensors page and wait for the
+    /// calibration indicator buttons to appear.
+    void navigateToAPMSensorsPage();
+
+    /// Verify the two APM Sensors calibration indicator buttons reflect the
+    /// expected green/orange state.
+    void verifyAPMCalIndicators(bool compassGreen, bool accelGreen, const char *context);
+
+    /// Run a complete full accelerometer calibration from the APM Sensors page
+    /// by clicking Next for each of the six poses as MockLink drives the
+    /// ACCELCAL_VEHICLE_POS handshake, then dismiss the post-cal dialog.
+    void runAPMFullAccelCal();
+
+    /// Run a complete onboard compass calibration from the APM Sensors page as
+    /// MockLink drives the MAG_CAL_PROGRESS/MAG_CAL_REPORT protocol, then
+    /// dismiss the compass results dialog. Accel cal must already be complete.
+    void runAPMCompassCal();
 };

--- a/test/UnitTestFramework/UnitTest.cc
+++ b/test/UnitTestFramework/UnitTest.cc
@@ -19,6 +19,7 @@
 #include <iterator>
 
 #include "AppSettings.h"
+#include "AutoPilotPlugin.h"
 #include "LinkManager.h"
 #include "LogEntry.h"
 #include "MultiVehicleManager.h"
@@ -28,6 +29,7 @@
 #include "QmlObjectListModel.h"
 #include "SettingsManager.h"
 #include "Vehicle.h"
+#include "VehicleComponent.h"
 
 struct UnitTest::ExpectedLogMessages
 {
@@ -537,6 +539,22 @@ void UnitTest::settleEventLoopForCleanup(int iterations, int waitMs)
     }
 }
 
+VehicleComponent *UnitTest::findVehicleComponent(Vehicle *vehicle, const QString &name)
+{
+    if (!vehicle || !vehicle->autopilotPlugin()) {
+        return nullptr;
+    }
+
+    const QVariantList components = vehicle->autopilotPlugin()->vehicleComponents();
+    for (const QVariant &compVariant : components) {
+        auto *comp = compVariant.value<VehicleComponent *>();
+        if (comp && (comp->name() == name)) {
+            return comp;
+        }
+    }
+    return nullptr;
+}
+
 int UnitTest::run(QStringView singleTest, const QString& outputFile, TestLabels labelFilter)
 {
     int ret = 0;
@@ -789,6 +807,13 @@ void UnitTest::init()
     _expectedLogMessages->ignored.clear();
     _expectedLogMessages->pending.clear();
     _expectedLogMessages->consumedMessageIndices.clear();
+
+    // showRebootAppMessage() debounces repeats (2 min) across tests — reset so each
+    // test deterministically sees its own reboot message. Lightweight harness runs a
+    // bare QCoreApplication, hence the cast check.
+    if (auto *app = qobject_cast<QGCApplication *>(QCoreApplication::instance())) {
+        app->resetRebootMessageDebounce();
+    }
 
     // MockLink emulates an Open Drone ID device (sends OPEN_DRONE_ID_ARM_STATUS at
     // 1Hz), which makes RemoteIDManager start its periodic send timer. That timer

--- a/test/UnitTestFramework/UnitTest.h
+++ b/test/UnitTestFramework/UnitTest.h
@@ -208,6 +208,8 @@ Q_DECLARE_LOGGING_CATEGORY(UnitTestLog)
 class Fact;
 class MissionItem;
 class QSignalSpy;
+class Vehicle;
+class VehicleComponent;
 
 // ============================================================================
 // Test Context - Improved failure diagnostics
@@ -363,6 +365,10 @@ public:
     /// If iterations <= 0, CI-aware defaults are used.
     /// If waitMs < 0, CI-aware defaults are used. If waitMs == 0, no sleep between iterations.
     static void settleEventLoopForCleanup(int iterations = 0, int waitMs = 0);
+
+    /// Find a vehicle setup component (e.g. "Frame", "Sensors", "Radio") by display name.
+    /// Returns nullptr if not found.
+    static VehicleComponent *findVehicleComponent(Vehicle *vehicle, const QString &name);
 
     // ========================================================================
     // Test Properties


### PR DESCRIPTION
## Description

Adds a MockLink option to start an APM vehicle in a "fresh flash" state — the parameter state a user sees after flashing firmware for the first time — so the initial vehicle setup experience can be exercised manually and by automated tests.

### MockLink / UI

- `MockConfiguration.apmStartFreshParams` property with settings persistence
- When enabled, MockLink connects with calibration offsets zeroed, `FRAME_CLASS = 0`, and `RC*_MIN/MAX/TRIM` at board defaults (MAVLink param storage types preserved)
- Comm link settings and the dev-tools MockLink page get a vehicle type combo plus a fresh-params checkbox (APM only)

### Production fix

- APM accel calibration completion was incorrectly opening the compass results dialog (fitness bars); it now shows a generic calibration-complete dialog (separate commit)

### Test infrastructure

- Reboot-required app messages now flow through `showAppMessage()` during unit tests and are asserted via `expectAppMessage()`; debounce is reset per-test
- UI tests register the QML engine with the app so app message dialogs are shown for real
- New `APMFreshFlashParamsTest` (headless, data-driven Copter/Plane/Rover/Sub) verifying fresh param state, component `setupComplete` flags, and the setup-required message
- New `APMFreshFlashUITest` driving the full setup flow through the real UI: frame selection, accel cal (6-pose), compass cal, and setup indicator states
- APM sensor-cal UI helpers consolidated into `VehicleConfigUITestBase` with `QPointer` hardening in event-pumping waits

## Test Steps

- `ctest -R "ParameterManagerTest|APMFreshFlashParamsTest|APMFreshFlashUITest|APMSensorsCalibrationUITest|PX4SensorsCalibrationUITest|PX4AirframeSetupUITest"` — all pass locally (macOS, Qt 6.11.1)
