### PR TITLE
fix(GimbalIndicator): prevent angle text jittering in toolbar

### DIFF
--- a/src/Toolbar/GimbalIndicator.qml
+++ b/src/Toolbar/GimbalIndicator.qml
@@ -75,6 +75,30 @@ Item {
             rowSpacing:     0
             columnSpacing:  margins / 2
 
+            // Round to whole degrees and normalize -0 to 0 to prevent the text from
+            // jittering around as the gimbal telemetry noise changes the value slightly.
+            function formatAngle(fact) {
+                var angle = Math.round(fact.rawValue)
+                return isNaN(angle) ? "--" : (angle + 0).toString()
+            }
+
+            // The labels are fixed to the width of the widest possible value so the
+            // toolbar doesn't shift as the digit count changes. "-188" is used since
+            // 8 is the widest digit.
+            TextMetrics {
+                id:             pitchTextMetrics
+                font.family:    pitchLabel.font.family
+                font.pointSize: ScreenTools.smallFontPointSize
+                text:           qsTr("P: ") + "-188"
+            }
+
+            TextMetrics {
+                id:             panTextMetrics
+                font.family:    panLabel.font.family
+                font.pointSize: ScreenTools.smallFontPointSize
+                text:           (showAzimuth ? qsTr("Az: ") : qsTr("Y: ")) + "-188"
+            }
+
             QGCLabel {
                 id:                     statusLabel
                 font.pointSize:         ScreenTools.smallFontPointSize
@@ -86,20 +110,22 @@ Item {
                 Layout.alignment:       Qt.AlignHCenter
             }
             QGCLabel {
-                id:             pitchLabel
-                font.pointSize: ScreenTools.smallFontPointSize
-                text:           activeGimbal ? qsTr("P: ") + activeGimbal.absolutePitch.valueString : ""
-                color:          qgcPal.text
+                id:                     pitchLabel
+                font.pointSize:         ScreenTools.smallFontPointSize
+                text:                   activeGimbal ? qsTr("P: ") + parent.formatAngle(activeGimbal.absolutePitch) : ""
+                color:                  qgcPal.text
+                Layout.preferredWidth:  pitchTextMetrics.width
             }
             QGCLabel {
-                id:             panLabel
-                font.pointSize: ScreenTools.smallFontPointSize
-                text:           activeGimbal ?
-                                    (showAzimuth ?
-                                        (qsTr("Az: ") + activeGimbal.absoluteYaw.valueString) :
-                                        (qsTr("Y: ") + activeGimbal.bodyYaw.valueString)) :
-                                    ""
-                color:          qgcPal.text
+                id:                     panLabel
+                font.pointSize:         ScreenTools.smallFontPointSize
+                text:                   activeGimbal ?
+                                            (showAzimuth ?
+                                                (qsTr("Az: ") + parent.formatAngle(activeGimbal.absoluteYaw)) :
+                                                (qsTr("Y: ") + parent.formatAngle(activeGimbal.bodyYaw))) :
+                                            ""
+                color:                  qgcPal.text
+                Layout.preferredWidth:  panTextMetrics.width
             }
         }
     }


### PR DESCRIPTION
## Description

Fixes the gimbal toolbar indicator angle text jittering around as telemetry noise changes the values.

- Round displayed pitch/yaw/azimuth to whole degrees (raw fact values are untouched, so map arrow etc. stay smooth)
- Normalize `-0` to `0` so the sign doesn't flicker around zero
- Show `--` instead of `NaN` when no valid angle has been received
- Give each angle label a fixed width (via `TextMetrics` on the widest possible value) so the toolbar no longer shifts when the digit count changes (e.g. 9 ↔ 10, sign appearing)

Follows the approach discussed in #13204.

Fixes #13427

## Testing

- `qmllint` pre-commit hook passes
- Incremental build succeeds
- `ctest -R ToolbarIndicatorUITest` passes (strict QML warning checking)