### PR TITLE
docs: align Windows build instructions with CI

### DIFF
--- a/docs/en/qgc-dev-guide/getting_started/index.md
+++ b/docs/en/qgc-dev-guide/getting_started/index.md
@@ -1,5 +1,5 @@
 ---
-qt_version: 6.10.1
+qt_version: 6.11.1
 ---
 
 # Getting Started with Source and Builds
@@ -72,28 +72,35 @@ To install Qt:
 
 1. Install Additional Packages (Platform Specific)
 
-   - **Ubuntu:** `python3 ./qgroundcontrol/tools/setup/install_dependencies --platform debian`
+   Run these from the root of the cloned repository (`cd qgroundcontrol`):
+
+   - **Ubuntu:** `python3 tools/setup/install_dependencies --platform debian`
    - **Fedora:** `sudo dnf install speech-dispatcher SDL2-devel SDL2 systemd-devel patchelf`
    - **Arch Linux:** `pacman -Sy speech-dispatcher patchelf`
-   - **Mac:** `python3 ./qgroundcontrol/tools/setup/install_dependencies --platform macos`
-   - **Windows:** `python3 ./qgroundcontrol/tools/setup/install_dependencies --platform windows`
-   - **Android:** Installing dependencies for android is quite involved. You are better off using Qt documentation for android setup instructions. Read [Qt 6 for Android](https://doc.qt.io/qt-6/android.html) carefully to the extend. Continue with [Gettting Started with Qt 6 for Android](https://doc.qt.io/qt-6/android-getting-started.html).
+   - **Mac:** `python3 tools/setup/install_dependencies --platform macos`
+   - **Windows:** `python tools/setup/install_dependencies --platform windows`
+
+     This is the same script used by CI. By default it installs only GStreamer (x64 only, from the QGC dependency mirror). Optional flags: `--nsis` installs NSIS (needed to build the installer), `--msvc` installs the Visual Studio 2022 Build Tools C++ workload, and `--vulkan` installs the Vulkan SDK.
+
+   - **Android:** Installing dependencies for Android is quite involved. You are better off using Qt documentation for Android setup instructions. Read [Qt 6 for Android](https://doc.qt.io/qt-6/android.html) carefully. Continue with [Getting Started with Qt 6 for Android](https://doc.qt.io/qt-6/android-getting-started.html).
 
 1. Install OS-Specific Functionalities
 
    ::: info
+   QGC is built exclusively with CMake; qmake builds are no longer supported.
    Optional features that are dependent on the operating system and user-installed libraries are linked/described below.
-   These features can be forcibly enabled/disabled by specifying additional values to qmake.
+   These features can be forcibly enabled/disabled by passing additional `-D` options to CMake (e.g. `-DQGC_ENABLE_GST_VIDEOSTREAMING=OFF`).
    :::
 
-   - **Video Streaming/Gstreamer:** - see [Video Streaming](https://github.com/mavlink/qgroundcontrol/blob/master/src/VideoManager/VideoReceiver/GStreamer/README.md)
-   - **Scripting Install:** - to build the installation file at Windows, install [NSIS](https://nsis.sourceforge.io/Download).
+   - **Video Streaming/GStreamer:** - installed by the dependency script above, or downloaded automatically at CMake configure time on Windows/macOS if not already present. See [Video Streaming](https://github.com/mavlink/qgroundcontrol/blob/master/src/VideoManager/VideoReceiver/GStreamer/README.md) for details. Note: when cross-compiling for Windows ARM64 from an x64 host, disable video streaming with `-DQGC_ENABLE_GST_VIDEOSTREAMING=OFF` (this is what CI does) — the ARM64 GStreamer SDK installer cannot run on an x64 host, so the automatic download will fail.
+   - **Windows Installer:** - building the Windows installer requires [NSIS](https://nsis.sourceforge.io/Download), which the dependency script above installs when run with `--nsis`.
 
-#### Install Visual Studio (Windows Only) {#vs}
+#### Install Visual Studio Compiler (Windows Only) {#vs}
 
-Install [Visual Studio 2022 Community Edition](https://visualstudio.microsoft.com/downloads/).
+An MSVC 2022 C++ toolchain is required. Either of the following works:
 
-When installing, select _Desktop development with C++_.
+- The [Visual Studio 2022 Build Tools](https://visualstudio.microsoft.com/downloads/) with the _C++ build tools_ workload (this is what CI uses, and what the dependency script above installs when run with `--msvc`), or
+- [Visual Studio 2022 Community Edition](https://visualstudio.microsoft.com/downloads/) with the _Desktop development with C++_ workload, if you also want the IDE.
 
    ::: info
    Visual Studio is ONLY used to get the compiler. Building _QGroundControl_ is done using [Qt Creator](#qt-creator) or [cmake](#cmake) directly as outlined below.
@@ -123,10 +130,12 @@ Example commands to build a default QGC and run it afterwards:
 1. Configure:
 
    ```sh
-   ~/Qt/{{ qt_version }}/gcc_64/bin/qt-cmake -B build -G Ninja -DCMAKE_BUILD_TYPE=Debug
+   ~/Qt/{{ $frontmatter.qt_version }}/gcc_64/bin/qt-cmake -B build -G Ninja -DCMAKE_BUILD_TYPE=Debug
    ```
 
    Change the directory for `qt-cmake` to match your install location for Qt and the kit you want to use.
+
+   **Windows**: use the corresponding kit path, e.g. `C:\Qt\{{ $frontmatter.qt_version }}\msvc2022_64\bin\qt-cmake.bat`, from a _x64 Native Tools Command Prompt for VS 2022_.
 
    **Mac**: To Sign/Notarize/Staple the QGC app bundle, add `-DQGC_MACOS_SIGN_WITH_IDENTITY=ON` to the configure command line. During the `install` phase the following environment variables will need to be available:
 
@@ -147,6 +156,8 @@ Example commands to build a default QGC and run it afterwards:
    ./build/Debug/QGroundControl
    ```
 
+   On Windows: `build\Debug\QGroundControl.exe`
+
 ### Vagrant
 
 [Vagrant](https://www.vagrantup.com/) can be used to build and run _QGroundControl_ within a Linux virtual machine (the build can also be run on the host machine if it is compatible).
@@ -157,7 +168,7 @@ Example commands to build a default QGC and run it afterwards:
 
 ### Additional Build Notes for all Supported OS
 
-- **Parallel builds:** For non Windows builds, you can use the `-j#` option to run parellel builds.
+- **Parallel builds:** You can use the `-j#` option with `cmake --build` to control the number of parallel build jobs.
 - **If you get this error when running _QGroundControl_**: `/usr/lib/x86_64-linux-gnu/libstdc++.so.6: version 'GLIBCXX_3.4.20' not found.`, you need to either update to the latest _gcc_, or install the latest _libstdc++.6_ using: `sudo apt-get install libstdc++6`.
 - **Unit tests:** To run the [unit tests](../contribute/unit_tests.md), build in `debug` mode with `QGC_UNITTEST_BUILD` definition, and then copy `deploy/qgroundcontrol-start.sh` script into the `debug` directory before running the tests.
 
@@ -166,5 +177,9 @@ Example commands to build a default QGC and run it afterwards:
 You can additionally create installation file(s) for _QGroundControl_ as part of the normal build process.
 
 ```sh
-cmake --install . --config Release
+cmake --install build --config Release
 ```
+
+Use the same build directory you passed to `-B` when configuring, and a configuration (`Release`/`Debug`) that you actually built.
+
+On Windows this creates the NSIS installer (requires NSIS, installed by the dependency script when run with `--nsis`).


### PR DESCRIPTION
## Summary

Updates the Windows portions of the getting-started build docs to match what CI actually does.

### Fixes
- **Qt version**: frontmatter said 6.10.1; CI/build-config.json pin 6.11.1
- **Dependency script**: documents that `tools/setup/install_dependencies --platform windows` is the same script CI uses, installs GStreamer by default (x64 only, QGC mirror), and supports `--nsis`, `--msvc`, `--vulkan` flags
- **Compiler**: recommends VS 2022 Build Tools (what CI uses) with Community Edition as the IDE alternative
- **qmake**: replaced stale qmake reference with CMake `-D` options and an explicit CMake-only note
- **GStreamer on Windows ARM64**: documents that native ARM64 auto-downloads the SDK at configure time, while x64→ARM64 cross-compile disables video streaming (the ARM64 SDK installer cannot run on an x64 host)
- **CLI build**: adds Windows `qt-cmake.bat` kit path and run path examples; fixes broken `{{ qt_version }}` template variable
- **Install**: `cmake --install .` → `cmake --install build` with clarifying note; notes NSIS installer output on Windows
- Typos: Android capitalization, "Gettting", "parellel", "to the extend", "Gstreamer" → "GStreamer"

Translated copies (ko/tr/zh) are left to sync via Crowdin.