### PR TITLE
fix(PlanView): reload mission item editors from tree root to avoid stale-delegate loads

### DIFF
--- a/src/PlanView/MissionItemEditor.qml
+++ b/src/PlanView/MissionItemEditor.qml
@@ -43,8 +43,14 @@ Rectangle {
     readonly property real  _trashSize:         commandPicker.height * 0.75
     readonly property bool  _waypointsOnlyMode: QGroundControl.corePlugin.options.missionWaypointsOnly
 
-    // setSource() injects missionItem before internal bindings activate
-    function _loadEditor() {
+    // setSource() injects missionItem before internal bindings activate.
+    // Called on completion and by PlanTreeView when the current item changes.
+    // Intentionally NOT driven by a Connections to missionItem: missionItem
+    // outlives this delegate, and a released-but-not-yet-deleted delegate
+    // receiving isCurrentItemChanged would call setSource() on a Loader whose
+    // QML context is already invalidated ("Cannot create a component in an
+    // invalid context"). PlanTreeView only reaches live delegates.
+    function reloadEditor() {
         if (missionItem.isCurrentItem) {
             editorLoader.setSource(missionItem.editorQml, {
                 missionItem:    _root.missionItem,
@@ -53,11 +59,6 @@ Rectangle {
         } else {
             editorLoader.setSource("")
         }
-    }
-
-    Connections {
-        target: missionItem
-        function onIsCurrentItemChanged() { _root._loadEditor() }
     }
 
     QGCPalette {
@@ -351,7 +352,7 @@ Rectangle {
         anchors.top:        topRowLayout.bottom
         asynchronous:       true
 
-        Component.onCompleted: _root._loadEditor()
+        Component.onCompleted: _root.reloadEditor()
     }
 
     onHeightChanged: {

--- a/src/PlanView/PlanTreeView.qml
+++ b/src/PlanView/PlanTreeView.qml
@@ -52,6 +52,7 @@ TreeView {
     QGCFlickableScrollIndicator { parent: root; orientation: QGCFlickableScrollIndicator.Vertical }
 
     property int _lastMissionItemCount: 0
+    property int _lastPlanViewSeqNum: -1
 
     Connections {
         target: root._missionController.visualItems
@@ -94,7 +95,29 @@ TreeView {
             root.editingLayerChangeRequested(PlanEditLayers.layerMission)
         }
         function onPlanViewStateChanged() {
-            // Current item changed — bring it on-screen if completely off-screen.
+            // planViewStateChanged is also emitted for forced recalcs (home position
+            // set, settings changes) where the current item is unchanged. Skip the
+            // editor reload in that case to avoid tearing down the current editor
+            // (and losing focus/UI state) for no reason.
+            if (_missionController.currentPlanViewSeqNum === root._lastPlanViewSeqNum) {
+                return
+            }
+            root._lastPlanViewSeqNum = _missionController.currentPlanViewSeqNum
+
+            // Current item changed — reload the inline editors of the loaded
+            // mission item delegates. Driven from here rather than from a
+            // Connections inside MissionItemEditor because a released-but-not-
+            // yet-deleted delegate would still receive isCurrentItemChanged and
+            // trigger a Loader load in an invalidated QML context. Iterating
+            // the table only ever reaches live delegates.
+            for (let row = Math.max(root.topRow, 0); row <= root.bottomRow; row++) {
+                let delegateItem = root.itemAtCell(Qt.point(0, row))
+                if (delegateItem && delegateItem.nodeType === "missionItem" && delegateItem.editorItem) {
+                    delegateItem.editorItem.reloadEditor()
+                }
+            }
+
+            // Bring the new current item on-screen if completely off-screen.
             // Fine-tuned scroll happens later via editorExpandedAndLoaded.
             var item = _missionController.currentPlanViewItem
             if (item) {
@@ -217,6 +240,9 @@ TreeView {
         readonly property var nodeObject: model.object
         readonly property string nodeType: model.nodeType
         readonly property bool separator: model.separator ?? false
+
+        // Loaded editor item, reached by PlanTreeView's onPlanViewStateChanged
+        readonly property Item editorItem: loader.item
 
         // In create-new-plan mode, only the Plan Info and Defaults groups and their children are enabled
         readonly property bool _enabledInCreateMode: nodeType === "planFileGroup" || nodeType === "planFileInfo"


### PR DESCRIPTION
## Problem

PlanViewLayerUITest fails intermittently in CI (most recently on #14667) with strict-mode log failures:

```
QQmlContext: Cannot set context object on invalid context.
QQmlComponent: Cannot create a component in an invalid context
```

This is the CI-only "invalid context" flavor noted as unresolved in #14638 ("never reproduced locally in ~340 runs... if it recurs in CI after this change it can be hunted separately"). It recurred.

## Root cause

`MissionItemEditor.qml` used a `Connections { target: missionItem }` to reload its editor `Loader` on `isCurrentItemChanged`. `TreeView` (with `reuseItems: false`) releases delegates by invalidating their QML context immediately while deferring actual destruction via `deleteLater`. In that window the `Connections` to the persistent `MissionItem` C++ object still fires, and `Loader.setSource()` attempts a component load in the invalidated context. `QQuickLoaderPrivate::_q_sourceLoaded()` then does `new QQmlContext(creationContext)` + `setContextObject()` on the dead context — producing exactly the two warnings above.

The race needs delegate teardown (layer switch / group collapse / `forceLayout`) to coincide with a current-item change — e.g. the takeoff-item insertion in test step 2.2 — and is far more likely on slow CI runners, which is why it never reproduced locally.

## Fix

Invert the control:
- Remove the per-delegate `Connections` from `MissionItemEditor.qml`; rename `_loadEditor()` to public `reloadEditor()`.
- `PlanTreeView.qml` (whose root outlives all delegates) reacts to `MissionController::planViewStateChanged` — emitted whenever the current plan-view item changes — and calls `reloadEditor()` only on delegates that are still live, via `itemAtCell()` over the visible rows. Released delegates are unreachable through `itemAtCell`, so no load can ever be triggered in an invalidated context.
- Newly created delegates still load their editor from `Component.onCompleted`.

## Testing

- 100 consecutive local runs of PlanViewLayerUITest with the fix (30 direct binary + 70 via ctest): 0 failures.
- PlanViewUITest and ToolbarIndicatorUITest pass (editor expand/collapse regression check).
- Note: the invalid-context flavor only ever reproduced in CI, so CI is the real verifier here.