### PR TITLE
fix(math): reject opposite-signed infinities in fuzzyCompare

### DIFF
--- a/src/Utilities/Math/QGCMath.cc
+++ b/src/Utilities/Math/QGCMath.cc
@@ -112,6 +112,9 @@ bool fuzzyCompare(double value1, double value2)
         return true;
     } else if (qIsNaN(value1) || qIsNaN(value2)) {
         return false;
+    } else if (qIsInf(value1) || qIsInf(value2)) {
+        // qFuzzyCompare(+inf, -inf) is true on Qt — reject opposite-signed infinities.
+        return value1 == value2;
     } else if (value1 == value2) {
         return true;
     } else {
@@ -136,6 +139,8 @@ bool fuzzyCompare(float value1, float value2)
         return true;
     } else if (qIsNaN(value1) || qIsNaN(value2)) {
         return false;
+    } else if (qIsInf(value1) || qIsInf(value2)) {
+        return value1 == value2;
     } else if (value1 == value2) {
         return true;
     } else {

--- a/test/Utilities/QGCMathTest.cc
+++ b/test/Utilities/QGCMathTest.cc
@@ -160,4 +160,23 @@ void QGCMathTest::_crc32Incremental_test()
     QCOMPARE(crc, 0xCBF43926u);
 }
 
+void QGCMathTest::_fuzzyCompareDoubleInfMismatch_test()
+{
+    const double inf = std::numeric_limits<double>::infinity();
+    const double nan = std::numeric_limits<double>::quiet_NaN();
+    QVERIFY(!QGC::fuzzyCompare(inf, -inf));
+    QVERIFY(!QGC::fuzzyCompare(-inf, inf));
+    QVERIFY(!QGC::fuzzyCompare(inf, nan));
+    QVERIFY(!QGC::fuzzyCompare(nan, inf));
+}
+
+void QGCMathTest::_limitAngleToPMPIdThreePi_test()
+{
+    // 3π should wrap into (-π, π] / [-π, π] family — expect ±π
+    const double r = QGC::limitAngleToPMPId(3.0 * M_PI);
+    QVERIFY(r >= -M_PI - 1e-10);
+    QVERIFY(r <= M_PI + 1e-10);
+    QCOMPARE_FUZZY(std::abs(r), M_PI, 1e-9);
+}
+
 UT_REGISTER_TEST(QGCMathTest, TestLabel::Unit, TestLabel::Utilities)

--- a/test/Utilities/QGCMathTest.cc
+++ b/test/Utilities/QGCMathTest.cc
@@ -164,10 +164,18 @@ void QGCMathTest::_fuzzyCompareDoubleInfMismatch_test()
 {
     const double inf = std::numeric_limits<double>::infinity();
     const double nan = std::numeric_limits<double>::quiet_NaN();
+    QVERIFY(QGC::fuzzyCompare(inf, inf));
+    QVERIFY(QGC::fuzzyCompare(-inf, -inf));
     QVERIFY(!QGC::fuzzyCompare(inf, -inf));
     QVERIFY(!QGC::fuzzyCompare(-inf, inf));
     QVERIFY(!QGC::fuzzyCompare(inf, nan));
     QVERIFY(!QGC::fuzzyCompare(nan, inf));
+
+    const float finf = std::numeric_limits<float>::infinity();
+    const float fnan = std::numeric_limits<float>::quiet_NaN();
+    QVERIFY(QGC::fuzzyCompare(finf, finf));
+    QVERIFY(!QGC::fuzzyCompare(finf, -finf));
+    QVERIFY(!QGC::fuzzyCompare(finf, fnan));
 }
 
 void QGCMathTest::_limitAngleToPMPIdThreePi_test()

--- a/test/Utilities/QGCMathTest.h
+++ b/test/Utilities/QGCMathTest.h
@@ -25,4 +25,6 @@ private slots:
     void _crc32Empty_test();
     void _crc32KnownVector_test();
     void _crc32Incremental_test();
+    void _fuzzyCompareDoubleInfMismatch_test();
+    void _limitAngleToPMPIdThreePi_test();
 };


### PR DESCRIPTION
## Summary
- `QGC::fuzzyCompare` (double + float defaults) now treats infinity via `qIsInf` + `==`, so `+inf` vs `-inf` is **not** equal. Qt’s `qFuzzyCompare(+inf, -inf)` returning true is a known pitfall.
- Unit coverage: same/opposite signed inf, inf/NaN (double + float), plus existing `limitAngleToPMPId(3π)` wrap check.

## Test plan
- [x] Diff on `src/Utilities/Math/QGCMath.cc` + `test/Utilities/QGCMathTest.*`
- [ ] CI Linux unit matrix green