### PR TITLE
test(geo): pin geodesicDistance for identical endpoints

### DIFF
--- a/test/Utilities/Geo/GeoTest.cc
+++ b/test/Utilities/Geo/GeoTest.cc
@@ -194,6 +194,14 @@ void GeoTest::_geodesicDistance_test()
     QVERIFY(qAbs(distance - qtDistance) < 2000.0);  // Within 2km for this distance
 }
 
+void GeoTest::_geodesicDistanceSelf_test()
+{
+    // Identical coordinates must report zero length on the ellipsoid model.
+    QCOMPARE_FUZZY(QGCGeo::geodesicDistance(m_origin, m_origin), 0.0, 1e-9);
+    const QGeoCoordinate elevated(m_origin.latitude(), m_origin.longitude(), 250.0);
+    QCOMPARE_FUZZY(QGCGeo::geodesicDistance(elevated, elevated), 0.0, 1e-9);
+}
+
 void GeoTest::_geodesicAzimuth_test()
 {
     // Test azimuth from ETH Zurich heading northwest to Paris

--- a/test/Utilities/Geo/GeoTest.h
+++ b/test/Utilities/Geo/GeoTest.h
@@ -27,6 +27,7 @@ private slots:
     void _convertEnuToEcef_test();
 
     void _geodesicDistance_test();
+    void _geodesicDistanceSelf_test();
     void _geodesicAzimuth_test();
     void _geodesicDestination_test();
     void _geodesicRoundTrip_test();


### PR DESCRIPTION
## Summary
Pins ellipsoid `geodesicDistance(p, p) == 0` for the unit origin and an elevated clone. Protects the zero-length path used by mission/path tooling.

No production-code change. AI-assisted; human-reviewed.

## Test plan
- [x] Diff limited to Geo unit tests
- [ ] CI