### PR TITLE
test(json): external header wrong type and version range

### DIFF
--- a/test/Utilities/Parsing/Json/JsonHelperTest.cc
+++ b/test/Utilities/Parsing/Json/JsonHelperTest.cc
@@ -83,6 +83,28 @@ void JsonHelperTest::_validateInternalMissingKeys_test()
     QVERIFY(!errorString.isEmpty());
 }
 
+void JsonHelperTest::_validateExternalWrongFileType_test()
+{
+    QJsonObject obj;
+    JsonParsing::saveQGCJsonFileHeader(obj, "OtherType", 2);
+
+    int version = 0;
+    QString errorString;
+    QVERIFY(!JsonParsing::validateExternalQGCJsonFile(obj, "TestFile", 1, 3, version, errorString));
+    QVERIFY(!errorString.isEmpty());
+}
+
+void JsonHelperTest::_validateExternalVersionTooNew_test()
+{
+    QJsonObject obj;
+    JsonParsing::saveQGCJsonFileHeader(obj, "TestFile", 9);
+
+    int version = 0;
+    QString errorString;
+    QVERIFY(!JsonParsing::validateExternalQGCJsonFile(obj, "TestFile", 1, 3, version, errorString));
+    QVERIFY(!errorString.isEmpty());
+}
+
 void JsonHelperTest::_validateKeysRequired_test()
 {
     const QJsonObject obj = {

--- a/test/Utilities/Parsing/Json/JsonHelperTest.h
+++ b/test/Utilities/Parsing/Json/JsonHelperTest.h
@@ -13,6 +13,8 @@ private slots:
     void _validateInternalVersionTooNew_test();
     void _validateInternalWrongFileType_test();
     void _validateInternalMissingKeys_test();
+    void _validateExternalWrongFileType_test();
+    void _validateExternalVersionTooNew_test();
     void _validateKeysRequired_test();
     void _validateKeysOptional_test();
     void _validateKeysWrongType_test();


### PR DESCRIPTION
## Summary
External QGC JSON header validation now has reject tests parallel to the internal-file suite:
- wrong `fileType`
- version above allowed max

Guards plan/mission-style loaders. AI-assisted; human-reviewed.

## Test plan
- [x] JsonHelperTest only
- [ ] CI