### PR TITLE
test(comms): DataRateTracker zero-byte records stay idle

### DIFF
--- a/test/Utilities/DataRateTrackerTest.cc
+++ b/test/Utilities/DataRateTrackerTest.cc
@@ -72,4 +72,14 @@ void DataRateTrackerTest::testKBpsConversion()
     QCOMPARE(tracker.kBps(), tracker.bytesPerSec() / 1024.0);
 }
 
+void DataRateTrackerTest::testRecordBytesZeroKeepsRateClear()
+{
+    DataRateTracker tracker;
+    tracker.recordBytes(0);
+    QCOMPARE(tracker.totalBytes(), static_cast<quint64>(0));
+    QCOMPARE(tracker.bytesPerSec(), 0.0);
+    // Window not elapsed → rate must not be marked updated.
+    QVERIFY(!tracker.rateUpdated());
+}
+
 UT_REGISTER_TEST(DataRateTrackerTest, TestLabel::Unit)

--- a/test/Utilities/DataRateTrackerTest.h
+++ b/test/Utilities/DataRateTrackerTest.h
@@ -9,4 +9,5 @@ private slots:
     void testRecordBytesAccumulates();
     void testReset();
     void testKBpsConversion();
+    void testRecordBytesZeroKeepsRateClear();
 };


### PR DESCRIPTION
## Summary
`recordBytes(0)` must keep `totalBytes` at 0, `bytesPerSec` at 0, and leave `rateUpdated` false inside a fresh window so telemetry plugins cannot invent a spike from empty ticks.

AI-assisted; human-reviewed. Tests only.

## Test plan
- [x] DataRateTrackerTest only
- [ ] CI