### PR TITLE
test(network): pin HTTP 2xx/3xx classification edges

### DIFF
--- a/test/Utilities/Network/QGCNetworkHelperTest.cc
+++ b/test/Utilities/Network/QGCNetworkHelperTest.cc
@@ -76,6 +76,21 @@ void QGCNetworkHelperTest::_testIsHttpSuccess()
     QVERIFY(!QGCNetworkHelper::isHttpSuccess(500));
 }
 
+void QGCNetworkHelperTest::_testIsHttpSuccessBoundaries()
+{
+    // Exclusive upper/lower edges near 2xx / 3xx cutovers.
+    QVERIFY(!QGCNetworkHelper::isHttpSuccess(199));
+    QVERIFY(QGCNetworkHelper::isHttpSuccess(200));
+    QVERIFY(QGCNetworkHelper::isHttpSuccess(299));
+    QVERIFY(!QGCNetworkHelper::isHttpSuccess(300));
+    QVERIFY(!QGCNetworkHelper::isHttpSuccess(-1));
+    QVERIFY(!QGCNetworkHelper::isHttpRedirect(299));
+    QVERIFY(QGCNetworkHelper::isHttpRedirect(300));
+    QVERIFY(QGCNetworkHelper::isHttpRedirect(399));
+    QVERIFY(!QGCNetworkHelper::isHttpRedirect(400));
+}
+
+
 void QGCNetworkHelperTest::_testIsHttpRedirect()
 {
     QVERIFY(QGCNetworkHelper::isHttpRedirect(300));

--- a/test/Utilities/Network/QGCNetworkHelperTest.h
+++ b/test/Utilities/Network/QGCNetworkHelperTest.h
@@ -16,6 +16,7 @@ private slots:
     void _testClassifyHttpStatusServerError();
     void _testClassifyHttpStatusUnknown();
     void _testIsHttpSuccess();
+    void _testIsHttpSuccessBoundaries();
     void _testIsHttpRedirect();
     void _testIsHttpClientError();
     void _testIsHttpServerError();


### PR DESCRIPTION
## Summary
Boundary coverage for `isHttpSuccess` / `isHttpRedirect` at 199/200/299/300/399/400 and negative code. Complements existing mid-band checks used by MAVLink HTTP helpers.

AI-assisted; human-reviewed. Tests only.

## Test plan
- [x] QGCNetworkHelperTest only
- [ ] CI