### PR TITLE
fix(Vehicle): suppress expected APM metadata warning; fix GStreamerTest on macOS

### DIFF
--- a/src/Vehicle/ComponentInformation/RequestMetaDataTypeStateMachine.cc
+++ b/src/Vehicle/ComponentInformation/RequestMetaDataTypeStateMachine.cc
@@ -436,8 +436,14 @@ void RequestMetaDataTypeStateMachine::_completeRequest()
                                                     << sourceLabel << _metadataUri;
         }
     } else {
-        qCWarning(RequestMetaDataTypeStateMachineLog) << typeToString() << ": failed to load metadata (primary and fallback)"
-                                                  << (_metadataUri.isEmpty() ? _compInfo->uriMetaData() : _metadataUri);
+        const QString failureMsg = QStringLiteral("%1 : failed to load metadata (primary and fallback) %2")
+                .arg(typeToString(), _metadataUri.isEmpty() ? _compInfo->uriMetaData() : _metadataUri);
+        if (_compInfo->vehicle->apmFirmware()) {
+            // ArduPilot doesn't support the component metadata protocol, so failure is expected
+            qCDebug(RequestMetaDataTypeStateMachineLog).noquote() << failureMsg;
+        } else {
+            qCWarning(RequestMetaDataTypeStateMachineLog).noquote() << failureMsg;
+        }
     }
 }
 

--- a/src/VideoManager/VideoReceiver/GStreamer/HwBuffers/common/GstContextBridgeRegistry.cc
+++ b/src/VideoManager/VideoReceiver/GStreamer/HwBuffers/common/GstContextBridgeRegistry.cc
@@ -161,6 +161,11 @@ void resetAllCaches()
 }
 
 #ifdef QGC_GST_BUILD_TESTING
+int bridgeCapacityForTest()
+{
+    return kMaxBridges;
+}
+
 void clearForTest()
 {
     resetAllBridges();

--- a/src/VideoManager/VideoReceiver/GStreamer/HwBuffers/common/GstContextBridgeRegistry.h
+++ b/src/VideoManager/VideoReceiver/GStreamer/HwBuffers/common/GstContextBridgeRegistry.h
@@ -43,6 +43,9 @@ void resetAllCaches();
 #ifdef QGC_GST_BUILD_TESTING
 /// Reset all registrations and call resetAllBridges() so tests start from a clean state.
 void clearForTest();
+
+/// Number of bridge slots compiled into this build (one per GPU bridge path).
+int bridgeCapacityForTest();
 #endif
 
 }  // namespace GstContextBridgeRegistry

--- a/test/AutoPilotPlugins/APM/APMFreshFlashParamsTest.cc
+++ b/test/AutoPilotPlugins/APM/APMFreshFlashParamsTest.cc
@@ -66,12 +66,6 @@ void APMFreshFlashParamsTest::_testFreshFlashParams()
     QFETCH(bool, hasFrameClass);
     QFETCH(bool, hasRadio);
 
-    // ArduPilot MockLink does not serve COMP_METADATA_TYPE_GENERAL.
-    ignoreLogMessage(
-        "ComponentInformation.RequestMetaDataTypeStateMachine",
-        QtWarningMsg,
-        QRegularExpression(QStringLiteral("\"COMP_METADATA_TYPE_GENERAL\" : failed to load metadata \\(primary and fallback\\) \"\"")));
-
     // Fresh-flash vehicles must show the setup-incomplete app message on connect
     expectAppMessage(QRegularExpression(QStringLiteral("Configuration tasks remain before this vehicle is ready to fly")));
 

--- a/test/Comms/MAVLinkV1TrafficTest.cc
+++ b/test/Comms/MAVLinkV1TrafficTest.cc
@@ -49,10 +49,6 @@ void MAVLinkV1TrafficTest::cleanup()
 
 void MAVLinkV1TrafficTest::_testV1UpgradeToV2NoWarning()
 {
-    // Expected warning on any full APM MockLink connect (no metadata json available).
-    ignoreLogMessage("ComponentInformation.RequestMetaDataTypeStateMachine", QtWarningMsg,
-                     QRegularExpression(QStringLiteral("failed to load metadata")));
-
     // MockLink starts out sending MAVLink v1 just like a real ArduPilot. The initial connect
     // sequence can only complete if the v1 -> v2 upgrade handshake works.
     _connectMockLink(MAV_AUTOPILOT_ARDUPILOTMEGA);

--- a/test/FactSystem/ParameterManagerTest.cc
+++ b/test/FactSystem/ParameterManagerTest.cc
@@ -364,9 +364,6 @@ void ParameterManagerTest::_setParamWithFailureMode(MockLink::ParamSetFailureMod
 
 void ParameterManagerTest::_FTPnoFailure()
 {
-    // ArduPilot mock link has no metadata source; this warning is expected for the APM FTP path.
-    ignoreLogMessage("ComponentInformation.RequestMetaDataTypeStateMachine", QtWarningMsg,
-                     QRegularExpression("failed to load metadata"));
     // Test APM FTP-based parameter download (param.pck).
     // FailParamNoResponseToRequestList forces the FTP path by blocking PARAM_REQUEST_LIST.
     QVERIFY2(!_mockLink, "MockLink already connected");
@@ -410,9 +407,6 @@ void ParameterManagerTest::_FTPnoFailure()
 
 void ParameterManagerTest::_FTPChangeParam()
 {
-    // ArduPilot mock link has no metadata source; this warning is expected for the APM FTP path.
-    ignoreLogMessage("ComponentInformation.RequestMetaDataTypeStateMachine", QtWarningMsg,
-                     QRegularExpression("failed to load metadata"));
     // Test that parameter set works after APM FTP param download
     QVERIFY2(!_mockLink, "MockLink already connected");
     _mockLink = MockLink::startAPMArduPlaneMockLink(MockConfiguration::OptionNone, MockConfiguration::FailParamNoResponseToRequestList);

--- a/test/MissionManager/MissionControllerTest.cc
+++ b/test/MissionManager/MissionControllerTest.cc
@@ -76,9 +76,7 @@ void MissionControllerTest::_testEmptyVehicle()
 {
     UT_FETCH_AUTOPILOT();
     Q_UNUSED(autopilotName);
-    // ArduPilot mock link has no metadata source; these warnings are expected for that autopilot.
-    ignoreLogMessage("ComponentInformation.RequestMetaDataTypeStateMachine", QtWarningMsg,
-                     QRegularExpression("failed to load metadata"));
+    // ArduPilot metadata includes an invalid enum value; skip warning is expected for that autopilot.
     ignoreLogMessage("FirmwarePlugin.ParameterMetaData", QtWarningMsg,
                      QRegularExpression("Skipping invalid enum value"));
     _initForFirmwareType(autopilot);

--- a/test/MissionManager/MissionManagerTest.cc
+++ b/test/MissionManager/MissionManagerTest.cc
@@ -36,9 +36,6 @@ void MissionManagerTest::init()
     // cause showAppMessage() debug logs. Ignore them for the whole fixture.
     ignoreLogMessage("API.QGCApplication.AppMessage", QtDebugMsg,
                      QRegularExpression("Mission transfer failed"));
-    // ArduPilot mock link has no metadata source; this warning is expected for APM variants.
-    ignoreLogMessage("ComponentInformation.RequestMetaDataTypeStateMachine", QtWarningMsg,
-                     QRegularExpression("failed to load metadata"));
     // ArduPilot metadata includes an invalid enum value for RTL_CONE_SLOPE; skip warning is expected.
     ignoreLogMessage("FirmwarePlugin.ParameterMetaData", QtWarningMsg,
                      QRegularExpression("Skipping invalid enum value"));

--- a/test/QmlUITests/APMFreshFlashUITest.cc
+++ b/test/QmlUITests/APMFreshFlashUITest.cc
@@ -58,7 +58,6 @@ void APMFreshFlashUITest::_verifySetupIndicator(const QString &compObjectName, b
 
 void APMFreshFlashUITest::_testFreshFlashSetupState()
 {
-    ignoreAPMMockLinkWarnings();
     // Fresh-flash vehicles must show the setup-incomplete app message on connect
     expectAppMessage(QRegularExpression(QStringLiteral("Configuration tasks remain before this vehicle is ready to fly")));
     runWithMockLink(

--- a/test/QmlUITests/APMSensorsCalibrationUITest.cc
+++ b/test/QmlUITests/APMSensorsCalibrationUITest.cc
@@ -14,7 +14,6 @@ UT_REGISTER_TEST(APMSensorsCalibrationUITest, TestLabel::Integration)
 // ---------------------------------------------------------------------------
 void APMSensorsCalibrationUITest::_testCompassCalibration()
 {
-    ignoreAPMMockLinkWarnings();
     runWithMockLink(
         [] { return MockLink::startAPMArduCopterMockLink(); },
         [&](QPointer<MockLink> /*mockLink*/, Vehicle *vehicle) {
@@ -62,7 +61,6 @@ void APMSensorsCalibrationUITest::_testCompassCalibration()
 // ---------------------------------------------------------------------------
 void APMSensorsCalibrationUITest::_testCompassCalibrationCancel()
 {
-    ignoreAPMMockLinkWarnings();
     runWithMockLink(
         [] { return MockLink::startAPMArduCopterMockLink(); },
         [&](QPointer<MockLink> /*mockLink*/, Vehicle *vehicle) {
@@ -126,7 +124,6 @@ void APMSensorsCalibrationUITest::_testCompassCalibrationCancel()
 // ---------------------------------------------------------------------------
 void APMSensorsCalibrationUITest::_testCompassCalibrationIgnoresStaleFailedReports()
 {
-    ignoreAPMMockLinkWarnings();
     runWithMockLink(
         [] { return MockLink::startAPMArduCopterMockLink(); },
         [&](QPointer<MockLink> mockLink, Vehicle *vehicle) {
@@ -194,7 +191,6 @@ void APMSensorsCalibrationUITest::_testCompassCalibrationIgnoresStaleFailedRepor
 // ---------------------------------------------------------------------------
 void APMSensorsCalibrationUITest::_testCompassCalibrationStartRejected()
 {
-    ignoreAPMMockLinkWarnings();
     runWithMockLink(
         [] { return MockLink::startAPMArduCopterMockLink(); },
         [&](QPointer<MockLink> mockLink, Vehicle *vehicle) {
@@ -250,7 +246,6 @@ void APMSensorsCalibrationUITest::_testCompassCalibrationStartRejected()
 // ---------------------------------------------------------------------------
 void APMSensorsCalibrationUITest::_testAccelCalibration()
 {
-    ignoreAPMMockLinkWarnings();
     runWithMockLink(
         [] { return MockLink::startAPMArduCopterMockLink(); },
         [&](QPointer<MockLink> /*mockLink*/, Vehicle *vehicle) {

--- a/test/QmlUITests/APMVehicleConfigUITest.cc
+++ b/test/QmlUITests/APMVehicleConfigUITest.cc
@@ -46,7 +46,6 @@ void APMVehicleConfigUITest::_runNavigateVehicleConfig(
 
 void APMVehicleConfigUITest::_testArduCopter()
 {
-    ignoreAPMMockLinkWarnings();
     _runNavigateVehicleConfig(
         [] { return MockLink::startAPMArduCopterMockLink(); },
         QStringLiteral("ArduCopter"));
@@ -54,7 +53,6 @@ void APMVehicleConfigUITest::_testArduCopter()
 
 void APMVehicleConfigUITest::_testArduPlane()
 {
-    ignoreAPMMockLinkWarnings();
     _runNavigateVehicleConfig(
         [] { return MockLink::startAPMArduPlaneMockLink(); },
         QStringLiteral("ArduPlane"));
@@ -69,7 +67,6 @@ void APMVehicleConfigUITest::_testArduSub()
 
 void APMVehicleConfigUITest::_testArduRover()
 {
-    ignoreAPMMockLinkWarnings();
     _runNavigateVehicleConfig(
         [] { return MockLink::startAPMArduRoverMockLink(); },
         QStringLiteral("ArduRover"));

--- a/test/QmlUITests/QmlUITestBase.cc
+++ b/test/QmlUITests/QmlUITestBase.cc
@@ -143,15 +143,6 @@ void QmlUITestBase::startUI()
     _rootItem = _window->contentItem();
 }
 
-void QmlUITestBase::ignoreAPMMockLinkWarnings()
-{
-    // ArduPilot MockLink does not serve COMP_METADATA_TYPE_GENERAL.
-    ignoreLogMessage(
-        "ComponentInformation.RequestMetaDataTypeStateMachine",
-        QtWarningMsg,
-        QRegularExpression(QStringLiteral("\"COMP_METADATA_TYPE_GENERAL\" : failed to load metadata \\(primary and fallback\\) \"\"")));
-}
-
 void QmlUITestBase::closeUIWindow()
 {
     if (_window) {

--- a/test/QmlUITests/QmlUITestBase.h
+++ b/test/QmlUITests/QmlUITestBase.h
@@ -175,10 +175,6 @@ protected:
     /// binding bugs.
     void disconnectMockLink(QPointer<MockLink> mockLink);
 
-    /// Register ignores for known warnings produced by any ArduPilot MockLink
-    /// connection. Call once before connectMockLinkAndWaitReady().
-    void ignoreAPMMockLinkWarnings();
-
     /// Start a MockLink using \a factory, wait for the vehicle to connect and
     /// parameters to be fully loaded, then return the MockLink pointer and set
     /// \a vehicleOut to the active Vehicle.

--- a/test/QmlUITests/ToolbarIndicatorUITest.cc
+++ b/test/QmlUITests/ToolbarIndicatorUITest.cc
@@ -126,7 +126,6 @@ void ToolbarIndicatorUITest::_testPX4Indicators()
 
 void ToolbarIndicatorUITest::_testAPMCopterIndicators()
 {
-    ignoreAPMMockLinkWarnings();
     _runIndicatorTest(
         [] { return MockLink::startAPMArduCopterMockLink(MockConfiguration::OptionEnableGimbal); },
         QStringLiteral("APMCopter"));

--- a/test/Vehicle/APMAirframeComponentControllerTest.cc
+++ b/test/Vehicle/APMAirframeComponentControllerTest.cc
@@ -14,9 +14,6 @@ APMAirframeComponentControllerTest::APMAirframeComponentControllerTest()
 
 void APMAirframeComponentControllerTest::_downloadCompleteSlotsRestoreCursor()
 {
-    // ArduPilot mock link has no metadata source; failure to load metadata is expected.
-    ignoreLogMessage("ComponentInformation.RequestMetaDataTypeStateMachine", QtWarningMsg,
-                     QRegularExpression("failed to load metadata"));
     // The test explicitly injects download and parse errors; all resulting showAppMessage logs are expected.
     ignoreLogMessage("API.QGCApplication.AppMessage", QtDebugMsg,
                      QRegularExpression("Param file.*failed"));

--- a/test/Vehicle/ComponentInformation/ComponentInformationManagerTest.cc
+++ b/test/Vehicle/ComponentInformation/ComponentInformationManagerTest.cc
@@ -137,9 +137,6 @@ void ComponentInformationManagerTest::_compInfoAccessorsReturnValidObjects()
 
 void ComponentInformationManagerTest::_requestCompletesForArduPilot()
 {
-    // ArduPilot mock link has no metadata source; this warning is expected.
-    ignoreLogMessage("ComponentInformation.RequestMetaDataTypeStateMachine", QtWarningMsg,
-                     QRegularExpression("failed to load metadata"));
     _disconnectMockLink();
     _connectMockLink(MAV_AUTOPILOT_ARDUPILOTMEGA);
 

--- a/test/Vehicle/ComponentInformation/RequestMetaDataTypeStateMachineTest.cc
+++ b/test/Vehicle/ComponentInformation/RequestMetaDataTypeStateMachineTest.cc
@@ -111,9 +111,6 @@ void RequestMetaDataTypeStateMachineTest::_sequentialRequestsReuseMachine()
 
 void RequestMetaDataTypeStateMachineTest::_requestCompletesForArduPilot()
 {
-    // ArduPilot mock link has no metadata source; this warning is expected.
-    ignoreLogMessage("ComponentInformation.RequestMetaDataTypeStateMachine", QtWarningMsg,
-                     QRegularExpression("failed to load metadata"));
     _disconnectMockLink();
     _connectMockLink(MAV_AUTOPILOT_ARDUPILOTMEGA);
 

--- a/test/VideoManager/GStreamer/HwBuffers/common/GStreamerHwBuffersCommonTest.cc
+++ b/test/VideoManager/GStreamer/HwBuffers/common/GStreamerHwBuffersCommonTest.cc
@@ -147,13 +147,18 @@ void GStreamerTest::_testContextBridgeRegistry()
     gst_message_unref(miss);
 
     // Reset-callback round-trip: registerResetCallback + resetAllBridges must invoke every cb.
+    // Registry capacity is one slot per compiled bridge, so single-bridge builds (e.g. macOS
+    // GLMemory-only) can only exercise a single registration.
+    const bool multiSlot = GstContextBridgeRegistry::bridgeCapacityForTest() >= 2;
     GstContextBridgeRegistry::clearForTest();
     static int s_resetCount = 0;
     s_resetCount = 0;
     GstContextBridgeRegistry::registerResetCallback([]() { ++s_resetCount; });
-    GstContextBridgeRegistry::registerResetCallback([]() { s_resetCount += 10; });
+    if (multiSlot) {
+        GstContextBridgeRegistry::registerResetCallback([]() { s_resetCount += 10; });
+    }
     GstContextBridgeRegistry::resetAllBridges();
-    QCOMPARE(s_resetCount, 11);
+    QCOMPARE(s_resetCount, multiSlot ? 11 : 1);
     // clearForTest must invoke pending reset callbacks before zeroing the slots so cached
     // bridge state can't leak across test cases. Drop the prior round's callbacks first so we
     // measure exactly the new callback's invocation count, not 1+10+1=12 from leftovers.
@@ -166,37 +171,40 @@ void GStreamerTest::_testContextBridgeRegistry()
     QCOMPARE(s_resetCount, 1);
 
     // Coexistence: two bridges with different context types must not consume each other's messages.
-    GstContextBridgeRegistry::clearForTest();
-    static bool s_aHit = false;
-    static bool s_bHit = false;
-    s_aHit = s_bHit = false;
-    GstContextBridgeRegistry::registerBridgeHandler([](GstMessage* m) -> GstBusSyncReply {
-        const gchar* t = nullptr;
-        gst_message_parse_context_type(m, &t);
-        if (t && std::string_view(t) == "type-A") {
-            s_aHit = true;
-            return GST_BUS_DROP;
-        }
-        return GST_BUS_PASS;
-    });
-    GstContextBridgeRegistry::registerBridgeHandler([](GstMessage* m) -> GstBusSyncReply {
-        const gchar* t = nullptr;
-        gst_message_parse_context_type(m, &t);
-        if (t && std::string_view(t) == "type-B") {
-            s_bHit = true;
-            return GST_BUS_DROP;
-        }
-        return GST_BUS_PASS;
-    });
-    GstMessage* msgA = gst_message_new_need_context(GST_OBJECT(dummy), "type-A");
-    QCOMPARE(GstContextBridgeRegistry::dispatchBridges(msgA), GST_BUS_DROP);
-    QVERIFY(s_aHit);
-    QVERIFY(!s_bHit);
-    gst_message_unref(msgA);
-    GstMessage* msgB = gst_message_new_need_context(GST_OBJECT(dummy), "type-B");
-    QCOMPARE(GstContextBridgeRegistry::dispatchBridges(msgB), GST_BUS_DROP);
-    QVERIFY(s_bHit);
-    gst_message_unref(msgB);
+    // Needs two handler slots, so only meaningful on multi-bridge builds.
+    if (multiSlot) {
+        GstContextBridgeRegistry::clearForTest();
+        static bool s_aHit = false;
+        static bool s_bHit = false;
+        s_aHit = s_bHit = false;
+        GstContextBridgeRegistry::registerBridgeHandler([](GstMessage* m) -> GstBusSyncReply {
+            const gchar* t = nullptr;
+            gst_message_parse_context_type(m, &t);
+            if (t && std::string_view(t) == "type-A") {
+                s_aHit = true;
+                return GST_BUS_DROP;
+            }
+            return GST_BUS_PASS;
+        });
+        GstContextBridgeRegistry::registerBridgeHandler([](GstMessage* m) -> GstBusSyncReply {
+            const gchar* t = nullptr;
+            gst_message_parse_context_type(m, &t);
+            if (t && std::string_view(t) == "type-B") {
+                s_bHit = true;
+                return GST_BUS_DROP;
+            }
+            return GST_BUS_PASS;
+        });
+        GstMessage* msgA = gst_message_new_need_context(GST_OBJECT(dummy), "type-A");
+        QCOMPARE(GstContextBridgeRegistry::dispatchBridges(msgA), GST_BUS_DROP);
+        QVERIFY(s_aHit);
+        QVERIFY(!s_bHit);
+        gst_message_unref(msgA);
+        GstMessage* msgB = gst_message_new_need_context(GST_OBJECT(dummy), "type-B");
+        QCOMPARE(GstContextBridgeRegistry::dispatchBridges(msgB), GST_BUS_DROP);
+        QVERIFY(s_bHit);
+        gst_message_unref(msgB);
+    }
 
     gst_object_unref(dummy);
 #endif

--- a/test/VideoManager/GStreamer/gstqgc/GStreamerGstQgcTest.cc
+++ b/test/VideoManager/GStreamer/gstqgc/GStreamerGstQgcTest.cc
@@ -499,10 +499,17 @@ void GStreamerTest::_testQgcVideoSinkBinGpuZeroCopyProperty()
         }
 #endif
 #else
-        // Direct DMABuf: format_capsfilter → qgcqvideosink (2 children).
+        // Native memory passthrough: format_capsfilter → qgcqvideosink (2 children). Caps advertise
+        // whichever GPU memory types are compiled in (e.g. GLMemory on macOS/iOS).
         QCOMPARE(elementCount, 2);
+#if defined(QGC_HAS_GST_DMABUF_GPU_PATH)
         QVERIFY2(s.contains(QStringLiteral("memory:DMABuf")),
                  qUtf8Printable(QStringLiteral("GPU bin caps missing memory:DMABuf: ") + s));
+#endif
+#if defined(QGC_HAS_GST_GLMEMORY_GPU_PATH)
+        QVERIFY2(s.contains(QStringLiteral("memory:GLMemory")),
+                 qUtf8Printable(QStringLiteral("GPU bin caps missing memory:GLMemory: ") + s));
+#endif
 #endif
 
         gst_object_unref(qvideosink);


### PR DESCRIPTION
## Overview

Two related cleanups around test/log noise:

### 1. Suppress expected component metadata warning on ArduPilot

ArduPilot doesn't support the component metadata protocol, so every ArduPilot connect logged:

```
COMP_METADATA_TYPE_GENERAL : failed to load metadata (primary and fallback)
```

as a warning. This is expected behavior, so it is now logged at debug level for APM firmware. Other firmwares still warn, since a metadata load failure there is a real anomaly.

This also removes the now-redundant `ignoreLogMessage` suppressions for this warning across the APM tests (including the `QmlUITestBase::ignoreAPMMockLinkWarnings` helper, whose only purpose was this message). Since the unit test framework fails on unexpected warnings, those tests now implicitly verify that APM connects stay warning-free.

### 2. Fix GStreamerTest failures on single-bridge macOS builds

CI only runs unit tests on Linux, so two GStreamerTest cases had latent macOS macro-arm bugs that made them always fail on a local macOS build:

- `_testQgcVideoSinkBinGpuZeroCopyProperty`: the fallback assertion arm assumed a direct-DMABuf GPU bin and required `memory:DMABuf` caps. macOS uses the GLMemory native-passthrough bin. The arm now asserts caps per compiled GPU path (`memory:GLMemory` on macOS/iOS, `memory:DMABuf` only when that path is compiled).
- `_testContextBridgeRegistry`: registered two reset callbacks and two bridge handlers, but registry capacity is one slot per compiled bridge and macOS compiles only one (GLMemory). The test now queries the compiled capacity via a new `GstContextBridgeRegistry::bridgeCapacityForTest()` accessor (under `QGC_GST_BUILD_TESTING`) and runs the multi-slot assertions only when two or more slots exist — Linux CI coverage is unchanged.

## Testing

- `GStreamerTest`: 74 passed, 0 failed, 19 skipped locally on macOS (previously 72/2)
- All tests that previously carried the APM metadata warning suppressions re-run and pass: RequestMetaDataTypeStateMachineTest, ComponentInformationManagerTest, MAVLinkV1TrafficTest, APMFreshFlashParamsTest, APMAirframeComponentControllerTest, ParameterManagerTest, MissionManagerTest, MissionControllerTest, APMSensorsCalibrationUITest, APMVehicleConfigUITest, ToolbarIndicatorUITest, APMFreshFlashUITest
