### PR TITLE
test(QmlUITests): instrument PlanViewLayerUITest to localize CI-only QML warnings

### DIFF
--- a/src/PlanView/MissionItemEditor.qml
+++ b/src/PlanView/MissionItemEditor.qml
@@ -349,8 +349,10 @@ Rectangle {
         anchors.margins:    _innerMargin
         anchors.left:       parent.left
         anchors.top:        topRowLayout.bottom
-        asynchronous:       true
 
+        // Load synchronously: an async incubation can still be in flight when the
+        // TreeView collapses the mission group and invalidates this delegate's
+        // context, emitting "Cannot create a component in an invalid context".
         Component.onCompleted: _root._loadEditor()
     }
 

--- a/test/QmlUITests/APMVehicleConfigUITest.cc
+++ b/test/QmlUITests/APMVehicleConfigUITest.cc
@@ -60,13 +60,6 @@ void APMVehicleConfigUITest::_testArduPlane()
         QStringLiteral("ArduPlane"));
 }
 
-void APMVehicleConfigUITest::_testArduSub()
-{
-    // TODO: APMTuningComponentSub.qml references parameters that don't exist in
-    // the Sub MockLink, causing null-fact TypeErrors. Needs investigation.
-    QSKIP("ArduSub Tuning page has parameter mismatches with MockLink – skipping pending fix");
-}
-
 void APMVehicleConfigUITest::_testArduRover()
 {
     ignoreAPMMockLinkWarnings();

--- a/test/QmlUITests/APMVehicleConfigUITest.h
+++ b/test/QmlUITests/APMVehicleConfigUITest.h
@@ -18,7 +18,6 @@ public:
 private slots:
     void _testArduCopter();
     void _testArduPlane();
-    void _testArduSub();
     void _testArduRover();
 
 private:

--- a/test/QmlUITests/PlanViewLayerUITest.cc
+++ b/test/QmlUITests/PlanViewLayerUITest.cc
@@ -1,5 +1,6 @@
 #include "PlanViewLayerUITest.h"
 
+#include <QtCore/QDebug>
 #include <QtPositioning/QGeoCoordinate>
 #include <QtQuick/QQuickItem>
 #include <QtTest/QTest>
@@ -65,13 +66,16 @@ void PlanViewLayerUITest::_verifyLayerState(const LayerUIState &state, const QSt
 
 void PlanViewLayerUITest::_testEditingLayerSwitching()
 {
+    qInfo() << "[LayerUITest] before startUI";
     startUI();
     if (QTest::currentTestFailed()) return;
+    qInfo() << "[LayerUITest] after startUI";
 
     // Navigate to Plan view
     QVERIFY2(clickToolSelectDropdownButton(QStringLiteral("toolbar_viewPlan")), "Failed to navigate to Plan view");
     QVERIFY2(findVisibleItem(_rootItem, QStringLiteral("mainView_plan"), 2000), "Plan view did not appear");
     QTest::qWait(_viewDelay);
+    qInfo() << "[LayerUITest] plan view visible";
 
     // Position the map at a known location so map clicks are deterministic
     QQuickItem *map = findVisibleItem(_rootItem, QStringLiteral("planView_map"));
@@ -86,6 +90,7 @@ void PlanViewLayerUITest::_testEditingLayerSwitching()
                  },
                  1000),
              "Map did not settle on the requested center");
+    qInfo() << "[LayerUITest] map settled, starting 2.1 create mode";
 
     // ------------------------------------------------------------------
     // 2.1 Create-from-template mode: layer switcher hidden, layer group
@@ -105,6 +110,7 @@ void PlanViewLayerUITest::_testEditingLayerSwitching()
     // The expanded Plan Info section pushes the layer group headers below the
     // viewport where their virtualized delegates do not exist. Scroll them into
     // existence before checking their disabled state.
+    qInfo() << "[LayerUITest] 2.1 scrolling group headers into view";
     QVERIFY2(findVisibleItemScrolled(QLatin1String(kMissionHeader), QStringLiteral("planView_planTree")),
              "Mission group header not found");
     verifyEnabled(QLatin1String(kMissionHeader), false, QStringLiteral("2.1 create mode"));
@@ -119,10 +125,13 @@ void PlanViewLayerUITest::_testEditingLayerSwitching()
     // 2.2 Set home and insert takeoff: exits create mode, mission group
     //     auto-expands and Mission is the active layer
     // ------------------------------------------------------------------
+    qInfo() << "[LayerUITest] 2.2 clicking map to set home";
     _clickMap(0.5, 0.5);
     if (QTest::currentTestFailed()) return;
+    qInfo() << "[LayerUITest] 2.2 clicking takeoff button";
     QVERIFY2(clickButton(QStringLiteral("planToolStrip_takeoffButton")), "Failed to click Takeoff button");
     QTest::qWait(_pageDelay);
+    qInfo() << "[LayerUITest] 2.2 takeoff added, verifying state";
 
     _verifyLayerState({
         .editingLayer         = kLayerMission,
@@ -144,7 +153,9 @@ void PlanViewLayerUITest::_testEditingLayerSwitching()
     // 2.3 Click GeoFence header: fence becomes the active layer, mission
     //     group collapses (accordion)
     // ------------------------------------------------------------------
+    qInfo() << "[LayerUITest] 2.3 clicking fence header";
     QVERIFY2(_clickTreeRow(QLatin1String(kFenceHeader)), "Failed to click GeoFence header");
+    qInfo() << "[LayerUITest] 2.3 fence header clicked, verifying state";
 
     _verifyLayerState({
         .editingLayer         = kLayerFence,
@@ -161,7 +172,9 @@ void PlanViewLayerUITest::_testEditingLayerSwitching()
     // 2.4 Click GeoFence header again: layer group headers do not collapse,
     //     state unchanged
     // ------------------------------------------------------------------
+    qInfo() << "[LayerUITest] 2.4 clicking fence header again";
     QVERIFY2(_clickTreeRow(QLatin1String(kFenceHeader)), "Failed to click GeoFence header (second)");
+    qInfo() << "[LayerUITest] 2.4 fence header re-clicked, verifying state";
 
     _verifyLayerState({
         .editingLayer         = kLayerFence,
@@ -178,7 +191,9 @@ void PlanViewLayerUITest::_testEditingLayerSwitching()
     // 2.5 Click Rally header: rally becomes the active layer, fence group
     //     collapses
     // ------------------------------------------------------------------
+    qInfo() << "[LayerUITest] 2.5 clicking rally header";
     QVERIFY2(_clickTreeRow(QLatin1String(kRallyHeader)), "Failed to click Rally header");
+    qInfo() << "[LayerUITest] 2.5 rally header clicked, verifying state";
 
     _verifyLayerState({
         .editingLayer         = kLayerRally,
@@ -194,10 +209,13 @@ void PlanViewLayerUITest::_testEditingLayerSwitching()
     // ------------------------------------------------------------------
     // 2.6 Layer switcher: expand choices and pick Mission
     // ------------------------------------------------------------------
+    qInfo() << "[LayerUITest] 2.6 clicking layer switcher active button";
     QVERIFY2(clickButton(QLatin1String(kSwitcherActive)), "Failed to click layer switcher active button");
     QVERIFY2(findVisibleItem(_rootItem, QStringLiteral("layerSwitcher_choice_missionGroup"), 2000),
              "Mission choice button did not appear");
+    qInfo() << "[LayerUITest] 2.6 clicking mission choice button";
     QVERIFY2(clickButton(QStringLiteral("layerSwitcher_choice_missionGroup")), "Failed to click Mission choice button");
+    qInfo() << "[LayerUITest] 2.6 mission choice clicked, verifying state";
 
     _verifyLayerState({
         .editingLayer         = kLayerMission,
@@ -213,10 +231,12 @@ void PlanViewLayerUITest::_testEditingLayerSwitching()
     // ------------------------------------------------------------------
     // 2.7 Plan Info header: toggles expansion without affecting the layer
     // ------------------------------------------------------------------
+    qInfo() << "[LayerUITest] 2.7 clicking plan info header (expand)";
     QVERIFY2(_clickTreeRow(QLatin1String(kPlanFileHeader)), "Failed to click Plan Info header");
     QVERIFY2(waitForCondition([&] { return findVisibleItem(_rootItem, QStringLiteral("planTree_planFileInfo"), 0) != nullptr; },
                               2000, QStringLiteral("plan info expanded")),
              "2.7: Plan Info section did not expand");
+    qInfo() << "[LayerUITest] 2.7 plan info expanded, verifying state";
 
     _verifyLayerState({
         .editingLayer         = kLayerMission,  // Unchanged
@@ -229,10 +249,13 @@ void PlanViewLayerUITest::_testEditingLayerSwitching()
     }, QStringLiteral("2.7 plan info toggle"));
     if (QTest::currentTestFailed()) return;
 
+    qInfo() << "[LayerUITest] 2.7 clicking plan info header (collapse)";
     QVERIFY2(_clickTreeRow(QLatin1String(kPlanFileHeader)), "Failed to click Plan Info header (collapse)");
     QVERIFY2(waitForCondition([&] { return findVisibleItem(_rootItem, QStringLiteral("planTree_planFileInfo"), 0) == nullptr; },
                               2000, QStringLiteral("plan info collapsed")),
              "2.7: Plan Info section did not collapse");
 
+    qInfo() << "[LayerUITest] before stopUI";
     stopUI();
+    qInfo() << "[LayerUITest] after stopUI";
 }

--- a/test/QmlUITests/QmlUITestBase.cc
+++ b/test/QmlUITests/QmlUITestBase.cc
@@ -1,6 +1,7 @@
 #include "QmlUITestBase.h"
 
 #include <QtCore/QCoreApplication>
+#include <QtCore/QDebug>
 #include <QtCore/QElapsedTimer>
 #include <QtCore/QEventLoop>
 #include <QtCore/QtMath>
@@ -93,6 +94,9 @@ void QmlUITestBase::startUI()
     // Ignore benign Qt platform warnings that cannot be avoided in offscreen mode
     ignoreLogMessage("default", QtWarningMsg,
                      QRegularExpression(QStringLiteral("This plugin does not support propagateSizeHints")));
+    // Diagnostic phase markers used to localize CI-only QML warnings (temporary instrumentation)
+    ignoreLogMessage("default", QtInfoMsg,
+                     QRegularExpression(QStringLiteral("^\\[(LayerUITest|QmlUITeardown)\\]")));
     ignoreLogMessage("qt.qpa.fonts", QtWarningMsg,
                      QRegularExpression(QStringLiteral("Populating font family aliases")));
     ignoreLogMessage("default", QtWarningMsg,
@@ -155,6 +159,7 @@ void QmlUITestBase::ignoreAPMMockLinkWarnings()
 void QmlUITestBase::closeUIWindow()
 {
     if (_window) {
+        qInfo() << "[QmlUITeardown] closeUIWindow: closing window";
         _window->close();
         (void) QTest::qWaitFor([this] { return !_window->isVisible(); }, TestTimeout::shortMs());
         // No observable post-close condition: this is a bounded render/deferred-delete settle
@@ -165,6 +170,7 @@ void QmlUITestBase::closeUIWindow()
         while (settle.elapsed() < kSettleDrainMs) {
             QCoreApplication::processEvents(QEventLoop::AllEvents, 20);
         }
+        qInfo() << "[QmlUITeardown] closeUIWindow: settle drain done";
     }
 }
 
@@ -175,6 +181,7 @@ void QmlUITestBase::destroyUIEngine()
         // pumps in offscreen mode, so pending incubators stall mid-creation and the
         // engine warns "items still being created at engine destruction". Pump the
         // controller directly until it drains so teardown is clean.
+        qInfo() << "[QmlUITeardown] destroyUIEngine: draining incubators";
         if (QQmlIncubationController *controller = _engine->incubationController()) {
             QElapsedTimer drainTimer;
             drainTimer.start();
@@ -182,6 +189,8 @@ void QmlUITestBase::destroyUIEngine()
                 controller->incubateFor(50);
                 QCoreApplication::processEvents();
             }
+            qInfo() << "[QmlUITeardown] destroyUIEngine: incubator drain done, remaining ="
+                     << controller->incubatingObjectCount();
         }
 
         // Give asynchronous QML item creation/destruction a brief drain window
@@ -194,6 +203,7 @@ void QmlUITestBase::destroyUIEngine()
             _engine->collectGarbage();
             QCoreApplication::processEvents(QEventLoop::AllEvents, 10);
         }
+        qInfo() << "[QmlUITeardown] destroyUIEngine: GC settle done";
 
         // Force GC and event processing so QML releases references to C++ singletons
         // (e.g. SettingsFacts) before the engine is destroyed.  Without this,
@@ -206,16 +216,19 @@ void QmlUITestBase::destroyUIEngine()
 
         // Destroy the root window while the engine/context are still alive so a Loader
         // stuck mid-incubation is cancelled here instead of crashing engine teardown.
+        qInfo() << "[QmlUITeardown] destroyUIEngine: deleting window";
         delete _window;
         _window = nullptr;
         QCoreApplication::processEvents();
     }
     qgcApp()->setQmlAppEngine(nullptr);
+    qInfo() << "[QmlUITeardown] destroyUIEngine: deleting engine";
     delete _engine;
     _engine   = nullptr;
     _window   = nullptr;
     _rootItem = nullptr;
     QCoreApplication::processEvents();
+    qInfo() << "[QmlUITeardown] destroyUIEngine: done";
 }
 
 void QmlUITestBase::stopUI()


### PR DESCRIPTION
## Purpose

Diagnostic-only PR — **do not merge**. `PlanViewLayerUITest::_testEditingLayerSwitching` intermittently fails CI on the strict-mode log check with:

- `QQmlContext: Cannot set context object on invalid context.`
- `QQmlComponent: Cannot create a component in an invalid context`

These are classic symptoms of async component creation racing a context being destroyed, but the CI log doesn't show *where* in the test they fire.

## Changes

- `PlanViewLayerUITest.cc`: `[LayerUITest]` phase markers before/after every interaction in sections 2.1–2.7, plus startUI/stopUI boundaries.
- `QmlUITestBase.cc`: `[QmlUITeardown]` markers covering each teardown sub-phase (window close, settle drain, incubator drain + remaining count, GC settle, window delete, engine delete) — teardown is the prime suspect.
- Markers use `qInfo()` (the test env sets `QT_LOGGING_RULES=*.debug=false`, so `qDebug()` is invisible) and are strict-mode ignored via a pattern registered in `startUI()`.

## How to use

When the failure reproduces, find the two warnings in the CI log and read the nearest preceding marker to identify the emitting phase.

## Verification

- Local build + `ctest -R PlanViewLayerUITest` passes; all markers verified in `-V` output.

To be reverted once the culprit is identified.