### PR TITLE
fix(ADSB): eliminate UI freezes and memory growth with high traffic volumes

### DIFF
--- a/src/ADSB/ADSBTCPLink.cc
+++ b/src/ADSB/ADSBTCPLink.cc
@@ -2,17 +2,15 @@
 // #include "QGCSensors.h"
 #include "QGCLoggingCategory.h"
 
-#include <QtCore/QTimer>
 #include <QtNetwork/QTcpSocket>
 
 QGC_LOGGING_CATEGORY(ADSBTCPLinkLog, "ADSB.ADSBTCPLink")
 
-ADSBTCPLink::ADSBTCPLink(const QHostAddress &hostAddress, quint16 port, QObject *parent)
+ADSBTCPLink::ADSBTCPLink(const QString &hostAddress, quint16 port, QObject *parent)
     : QObject(parent)
     , _hostAddress(hostAddress)
     , _port(port)
     , _socket(new QTcpSocket(this))
-    , _processTimer(new QTimer(this))
 {
     if (ADSBTCPLinkLog().isDebugEnabled()) {
         (void) connect(_socket, &QTcpSocket::stateChanged, this, [](QTcpSocket::SocketState state) {
@@ -43,9 +41,6 @@ ADSBTCPLink::ADSBTCPLink(const QHostAddress &hostAddress, quint16 port, QObject 
 
     (void) connect(_socket, &QTcpSocket::readyRead, this, &ADSBTCPLink::_readBytes);
 
-    _processTimer->setInterval(_processInterval); // Set an interval for processing lines
-    (void) connect(_processTimer, &QTimer::timeout, this, &ADSBTCPLink::_processLines);
-
     // qCDebug(ADSBTCPLinkLog) << Q_FUNC_INFO << this;
 }
 
@@ -60,10 +55,11 @@ bool ADSBTCPLink::init()
         return false;
     } */
 
-    if (_hostAddress.isNull()) {
+    if (_hostAddress.isEmpty()) {
         return false;
     }
 
+    // connectToHost with a hostname resolves DNS asynchronously
     _socket->connectToHost(_hostAddress, _port);
 
     return true;
@@ -73,27 +69,7 @@ void ADSBTCPLink::_readBytes()
 {
     while (_socket && _socket->canReadLine()) {
         const QByteArray bytes = _socket->readLine();
-        (void) _lineBuffer.append(QString::fromLocal8Bit(bytes));
-    }
-
-    // Start or restart the timer to process lines
-    if (!_processTimer->isActive()) {
-        _processTimer->start();
-    }
-}
-
-void ADSBTCPLink::_processLines()
-{
-    int linesProcessed = 0;
-    while (!_lineBuffer.isEmpty() && (linesProcessed < _maxLinesToProcess)) {
-        const QString line = _lineBuffer.takeFirst();
-        _parseLine(line);
-        ++linesProcessed;
-    }
-
-    // Stop the timer if there are no more lines to process
-    if (_lineBuffer.isEmpty()) {
-        _processTimer->stop();
+        _parseLine(QString::fromLocal8Bit(bytes));
     }
 }
 

--- a/src/ADSB/ADSBTCPLink.h
+++ b/src/ADSB/ADSBTCPLink.h
@@ -1,15 +1,19 @@
 #pragma once
 
 #include <QtCore/QObject>
-#include <QtNetwork/QHostAddress>
+#include <QtCore/QString>
+#include <QtCore/QStringList>
 
 #include "ADSB.h"
 
 class QTcpSocket;
-class QTimer;
 
 /// \brief The ADSBTCPLink class handles the TCP connection to an ADS-B server
 /// and processes incoming ADS-B data.
+///
+/// The link is designed to be moved to a worker thread so that socket reads and
+/// SBS-1 parsing stay off the ui thread. init() must be invoked on the link's
+/// thread (e.g. via QThread::started).
 
 class ADSBTCPLink : public QObject
 {
@@ -17,10 +21,10 @@ class ADSBTCPLink : public QObject
 
 public:
     /// Constructs an ADSBTCPLink object.
-    ///     @param hostAddress The address of the host to connect to.
+    ///     @param hostAddress The IP address or hostname of the host to connect to.
     ///     @param port The port to connect to on the host.
     ///     @param parent The parent object.
-    explicit ADSBTCPLink(const QHostAddress &hostAddress, quint16 port = 30003, QObject *parent = nullptr);
+    explicit ADSBTCPLink(const QString &hostAddress, quint16 port = 30003, QObject *parent = nullptr);
 
     /// Destroys the ADSBTCPLink object.
     ~ADSBTCPLink();
@@ -38,11 +42,8 @@ signals:
     void errorOccurred(const QString &errorMsg, bool stopped = false);
 
 private slots:
-    /// Reads bytes from the TCP socket.
+    /// Reads and parses lines from the TCP socket.
     void _readBytes();
-
-    /// Processes buffered lines of ADS-B data.
-    void _processLines();
 
 private:
     /// Parses a line of ADS-B data.
@@ -64,13 +65,8 @@ private:
     ///     @param values The values parsed from the line.
     void _parseAndEmitHeading(ADSB::VehicleInfo_t &adsbInfo, const QStringList &values);
 
-    QHostAddress _hostAddress;
+    QString _hostAddress;
     quint16 _port = 30003;
 
     QTcpSocket *_socket = nullptr;     ///< Pointer to the TCP socket used for connection
-    QTimer *_processTimer = nullptr;   ///< Timer for periodic processing of ADS-B data
-    QStringList _lineBuffer;           ///< Buffer for storing incoming lines of ADS-B data
-
-    static constexpr int _processInterval = 50;     ///< Interval for processing lines
-    static constexpr int _maxLinesToProcess = 100;  ///< Maximum number of lines to process per timer timeout
 };

--- a/src/ADSB/ADSBVehicle.cc
+++ b/src/ADSB/ADSBVehicle.cc
@@ -29,6 +29,18 @@ void ADSBVehicle::update(const ADSB::VehicleInfo_t &vehicleInfo)
 
     qCDebug(ADSBVehicleLog) << "Updating" << QStringLiteral("%1 Flags: %2").arg(vehicleInfo.icaoAddress, 0, 16).arg(vehicleInfo.availableFlags.toInt(), 0, 2);
 
+    // Keep-alive for expiration tracking. This must be updated even for throttled updates.
+    _lastUpdateTimer.start();
+
+    // Throttle the property update rate to prevent overloading the ui with map item updates. Skipped info will be
+    // picked up by a later update since ADS-B data is continuously re-transmitted. Alert transitions bypass the
+    // throttle since the collision warning must not be delayed.
+    const bool alertChange = (vehicleInfo.availableFlags & ADSB::AlertAvailable) && (vehicleInfo.alert != alert());
+    if (!alertChange && _lastPropertyUpdateTimer.isValid() && !_lastPropertyUpdateTimer.hasExpired(_propertyUpdateMinIntervalMs)) {
+        return;
+    }
+    _lastPropertyUpdateTimer.start();
+
     if (vehicleInfo.availableFlags & ADSB::LocationAvailable) {
         if (!QGC::fuzzyCompare(vehicleInfo.location.latitude(), coordinate().latitude()) || !QGC::fuzzyCompare(vehicleInfo.location.longitude(), coordinate().longitude())) {
             _info.location.setLatitude(vehicleInfo.location.latitude());
@@ -85,6 +97,4 @@ void ADSBVehicle::update(const ADSB::VehicleInfo_t &vehicleInfo)
             emit alertChanged();
         }
     }
-
-    _lastUpdateTimer.start();
 }

--- a/src/ADSB/ADSBVehicle.h
+++ b/src/ADSB/ADSBVehicle.h
@@ -13,6 +13,8 @@ class ADSBVehicle : public QObject
     Q_OBJECT
     // QML_ELEMENT
 
+    friend class ADSBTest;
+
     Q_PROPERTY(uint             icaoAddress READ    icaoAddress CONSTANT)
     Q_PROPERTY(QString          callsign    READ    callsign    NOTIFY callsignChanged)
     Q_PROPERTY(QGeoCoordinate   coordinate  READ    coordinate  NOTIFY coordinateChanged)
@@ -36,7 +38,7 @@ public:
     double verticalVel() const { return _info.verticalVel; }
     uint16_t squawk() const { return _info.squawk; }
     bool alert() const { return _info.alert; }
-    bool expired() const { return _lastUpdateTimer.hasExpired(_expirationTimeoutMs); }
+    bool expired() const { return !_lastUpdateTimer.isValid() || _lastUpdateTimer.hasExpired(_expirationTimeoutMs); }
     void update(const ADSB::VehicleInfo_t &vehicleInfo);
 
 signals:
@@ -52,6 +54,8 @@ signals:
 private:
     ADSB::VehicleInfo_t _info{};
     QElapsedTimer _lastUpdateTimer;
+    QElapsedTimer _lastPropertyUpdateTimer;
 
     static constexpr qint64 _expirationTimeoutMs = 120000; ///< timeout with no update in ms after which the vehicle is removed.
+    static constexpr qint64 _propertyUpdateMinIntervalMs = 1000; ///< min interval in ms between property updates
 };

--- a/src/ADSB/ADSBVehicleManager.cc
+++ b/src/ADSB/ADSBVehicleManager.cc
@@ -9,8 +9,8 @@
 #include "QGCLoggingCategory.h"
 
 #include <QtCore/QApplicationStatic>
+#include <QtCore/QThread>
 #include <QtCore/QTimer>
-#include <qassert.h>
 
 QGC_LOGGING_CATEGORY(ADSBVehicleManagerLog, "ADSB.ADSBVehicleManager")
 
@@ -29,6 +29,8 @@ ADSBVehicleManager::ADSBVehicleManager(ADSBVehicleManagerSettings *settings, QOb
     _adsbVehicleCleanupTimer->setSingleShot(false);
     _adsbVehicleCleanupTimer->setInterval(1000);
     (void) connect(_adsbVehicleCleanupTimer, &QTimer::timeout, this, &ADSBVehicleManager::_cleanupStaleVehicles);
+    // Always run: vehicles can also arrive via mavlink messages, not just the tcp link
+    _adsbVehicleCleanupTimer->start();
 
     Fact* const adsbEnabled = _adsbSettings->adsbServerConnectEnabled();
     Fact* const hostAddress = _adsbSettings->adsbServerHostAddress();
@@ -49,6 +51,8 @@ ADSBVehicleManager::ADSBVehicleManager(ADSBVehicleManagerSettings *settings, QOb
 
 ADSBVehicleManager::~ADSBVehicleManager()
 {
+    _stop();
+
     // qCDebug(ADSBVehicleManagerLog) << Q_FUNC_INFO << this;
 }
 
@@ -154,30 +158,51 @@ void ADSBVehicleManager::adsbVehicleUpdate(const ADSB::VehicleInfo_t &vehicleInf
 
 void ADSBVehicleManager::_start(const QString &hostAddress, quint16 port)
 {
-    Q_ASSERT(!_adsbTcpLink);
-
-    ADSBTCPLink *adsbTcpLink = new ADSBTCPLink(QHostAddress(hostAddress), port, this);
-    if (!adsbTcpLink->init()) {
-        delete adsbTcpLink;
-        adsbTcpLink = nullptr;
-        qCWarning(ADSBVehicleManagerLog) << "Failed to Initialize TCP Link at:" << hostAddress << port;
+    if (_adsbTcpLink) {
+        qCWarning(ADSBVehicleManagerLog) << "TCP Link already started";
         return;
     }
 
-    _adsbTcpLink = adsbTcpLink;
-    (void) connect(_adsbTcpLink, &ADSBTCPLink::adsbVehicleUpdate, this, &ADSBVehicleManager::adsbVehicleUpdate, Qt::AutoConnection);
-    (void) connect(_adsbTcpLink, &ADSBTCPLink::errorOccurred, this, &ADSBVehicleManager::_linkError, Qt::AutoConnection);
+    if (hostAddress.isEmpty()) {
+        qCWarning(ADSBVehicleManagerLog) << "No ADSB server host address set";
+        return;
+    }
 
-    _adsbVehicleCleanupTimer->start();
+    // Run the link on a worker thread so socket reads and SBS-1 parsing stay off the ui thread.
+    // The thread is unparented so QObject parent-child destruction can never delete it while it
+    // is still running (which is fatal); _stop() manages its lifetime explicitly.
+    _adsbTcpLinkThread = new QThread();
+    _adsbTcpLinkThread->setObjectName(QStringLiteral("ADSBTCPLink"));
+
+    _adsbTcpLink = new ADSBTCPLink(hostAddress, port); // unparented, deleted when the thread finishes
+    _adsbTcpLink->moveToThread(_adsbTcpLinkThread);
+
+    (void) connect(_adsbTcpLinkThread, &QThread::started, _adsbTcpLink, &ADSBTCPLink::init);
+    (void) connect(_adsbTcpLinkThread, &QThread::finished, _adsbTcpLink, &QObject::deleteLater);
+    (void) connect(_adsbTcpLink, &ADSBTCPLink::adsbVehicleUpdate, this, &ADSBVehicleManager::adsbVehicleUpdate, Qt::QueuedConnection);
+    (void) connect(_adsbTcpLink, &ADSBTCPLink::errorOccurred, this, &ADSBVehicleManager::_linkError, Qt::QueuedConnection);
+
+    _adsbTcpLinkThread->start();
 }
 
 void ADSBVehicleManager::_stop()
 {
-    Q_CHECK_PTR(_adsbTcpLink);
-    _adsbTcpLink->deleteLater();
-    _adsbTcpLink = nullptr;
+    if (!_adsbTcpLinkThread) {
+        return;
+    }
 
-    _adsbVehicleCleanupTimer->stop();
+    _adsbTcpLinkThread->quit();
+    if (!_adsbTcpLinkThread->wait(kThreadStopTimeoutMs)) {
+        // Bail out without deleting or resetting state: destroying a still-running QThread is
+        // fatal, and clearing the pointers would allow a second link to be started alongside it.
+        qCWarning(ADSBVehicleManagerLog) << "ADSBTCPLink thread failed to stop";
+        return;
+    }
+    // wait() succeeded so the thread has finished: delete it directly rather than with
+    // deleteLater(), which would leak during shutdown once the event loop stops running.
+    delete _adsbTcpLinkThread;
+    _adsbTcpLinkThread = nullptr;
+    _adsbTcpLink = nullptr; // deleted via the thread finished connection
 
     _adsbVehicles->clearAndDeleteContents();
     _adsbICAOMap.clear();

--- a/src/ADSB/ADSBVehicleManager.h
+++ b/src/ADSB/ADSBVehicleManager.h
@@ -8,6 +8,7 @@
 class ADSBTCPLink;
 class ADSBVehicle;
 class QmlObjectListModel;
+class QThread;
 class QTimer;
 class ADSBVehicleManagerSettings;
 
@@ -46,6 +47,8 @@ private:
 
     QMap<uint32_t, ADSBVehicle*> _adsbICAOMap;
     ADSBTCPLink *_adsbTcpLink = nullptr;
+    QThread *_adsbTcpLinkThread = nullptr;
 
     static constexpr uint8_t kMaxTimeSinceLastSeen = 15;
+    static constexpr unsigned long kThreadStopTimeoutMs = 5000; ///< max time in ms to wait for the tcp link thread to stop
 };

--- a/src/FlightMap/CMakeLists.txt
+++ b/src/FlightMap/CMakeLists.txt
@@ -10,6 +10,7 @@ qt_add_qml_module(FlightMapModule
     VERSION 1.0
     RESOURCE_PREFIX /qml
     QML_FILES
+        MapItems/ADSBVehicleMapItem.qml
         MapItems/CameraTriggerIndicator.qml
         MapItems/CustomMapItems.qml
         MapItems/MapLineArrow.qml

--- a/src/FlightMap/MapItems/ADSBVehicleMapItem.qml
+++ b/src/FlightMap/MapItems/ADSBVehicleMapItem.qml
@@ -1,0 +1,51 @@
+import QtQuick
+import QtLocation
+import QtPositioning
+
+import QGroundControl
+import QGroundControl.Controls
+
+/// Marker for displaying an ADS-B vehicle location on the map
+MapQuickItem {
+    id: _root
+
+    property var    map
+    property double altitude:   Number.NaN  ///< NAN to not show
+    property string callsign:   ""          ///< Vehicle callsign
+    property double heading:    Number.NaN  ///< Vehicle heading, NAN for none
+    property real   size:       ScreenTools.defaultFontPixelHeight * 3
+    property bool   alert:      false       ///< Collision alert
+
+    anchorPoint.x:  vehicleItem.width  / 2
+    anchorPoint.y:  vehicleItem.height / 2
+    visible:        coordinate.isValid
+
+    sourceItem: Item {
+        id:     vehicleItem
+        width:  vehicleIcon.width
+        height: vehicleIcon.height
+
+        Image {
+            id:                 vehicleIcon
+            source:             alert ? "/qmlimages/AlertAircraft.svg" : "/qmlimages/AwarenessAircraft.svg"
+            mipmap:             true
+            width:              _root.size
+            sourceSize.width:   _root.size
+            fillMode:           Image.PreserveAspectFit
+            transform: Rotation {
+                origin.x:   vehicleIcon.width  / 2
+                origin.y:   vehicleIcon.height / 2
+                angle:      isNaN(heading) ? 0 : heading
+            }
+        }
+
+        QGCMapLabel {
+            anchors.top:                parent.bottom
+            anchors.horizontalCenter:   parent.horizontalCenter
+            map:                        _root.map
+            font.pointSize:             ScreenTools.defaultFontPointSize
+            visible:                    !isNaN(altitude)
+            text:                       visible ? QGroundControl.unitsConversion.metersToAppSettingsVerticalDistanceUnitsString(altitude, 0) + "\n" + callsign : ""
+        }
+    }
+}

--- a/src/FlightMap/MapItems/VehicleMapItem.qml
+++ b/src/FlightMap/MapItems/VehicleMapItem.qml
@@ -1,5 +1,4 @@
 import QtQuick
-import QtQuick.Effects
 import QtLocation
 import QtPositioning
 
@@ -10,20 +9,16 @@ import QGroundControl.Controls
 MapQuickItem {
     id: _root
 
-    property var    vehicle                                                         /// Vehicle object, undefined for ADSB vehicle
+    property var    vehicle                                                         /// Vehicle object
     property var    map
-    property double altitude:       Number.NaN                                      ///< NAN to not show
-    property string callsign:       ""                                              ///< Vehicle callsign
     property double heading:        vehicle ? vehicle.heading.value : Number.NaN    ///< Vehicle heading, NAN for none
     property real   size:           ScreenTools.defaultFontPixelHeight * 3          /// Default size for icon, most usage overrides this
-    property bool   alert:          false                                           /// Collision alert
 
     anchorPoint.x:  vehicleItem.width  / 2
     anchorPoint.y:  vehicleItem.height / 2
     visible:        coordinate.isValid
 
     property var    _activeVehicle: QGroundControl.multiVehicleManager.activeVehicle
-    property bool   _adsbVehicle:   vehicle ? false : true
     property var    _map:           map
     property bool   _multiVehicle:  QGroundControl.multiVehicleManager.vehicles.count > 1
 
@@ -31,20 +26,7 @@ MapQuickItem {
         id:         vehicleItem
         width:      vehicleIcon.width
         height:     vehicleIcon.height
-        opacity:    _adsbVehicle || vehicle === _activeVehicle ? 1.0 : 0.5
-
-        MultiEffect {
-            source: vehicleIcon
-            shadowEnabled: vehicleIcon.visible && _adsbVehicle
-            shadowColor: Qt.rgba(0.94,0.91,0,1.0)
-            shadowVerticalOffset: 4
-            shadowHorizontalOffset: 4
-            shadowBlur: 1.0
-            shadowOpacity: 0.5
-            shadowScale: 1.3
-            blurMax: 32
-            blurMultiplier: .1
-        }
+        opacity:    vehicle === _activeVehicle ? 1.0 : 0.5
 
         Repeater {
             model: vehicle ? vehicle.gimbalController.gimbals : []
@@ -110,7 +92,7 @@ MapQuickItem {
 
         Image {
             id:                 vehicleIcon
-            source:             _adsbVehicle ? (alert ? "/qmlimages/AlertAircraft.svg" : "/qmlimages/AwarenessAircraft.svg") : vehicle.vehicleImageOpaque
+            source:             vehicle ? vehicle.vehicleImageOpaque : ""
             mipmap:             true
             width:              _root.size
             sourceSize.width:   _root.size
@@ -127,15 +109,9 @@ MapQuickItem {
             anchors.top:                parent.bottom
             anchors.horizontalCenter:   parent.horizontalCenter
             map:                        _map
-            text:                       vehicleLabelText
-            font.pointSize:             _adsbVehicle ? ScreenTools.defaultFontPointSize : ScreenTools.smallFontPointSize
-            visible:                    _adsbVehicle ? !isNaN(altitude) : _multiVehicle
-            property string vehicleLabelText: visible ?
-                                                  (_adsbVehicle ?
-                                                       QGroundControl.unitsConversion.metersToAppSettingsVerticalDistanceUnitsString(altitude, 0) + "\n" + callsign :
-                                                       (_multiVehicle ? qsTr("Vehicle %1").arg(vehicle.id) : "")) :
-                                                  ""
-
+            text:                       visible && vehicle ? qsTr("Vehicle %1").arg(vehicle.id) : ""
+            font.pointSize:             ScreenTools.smallFontPointSize
+            visible:                    _multiVehicle
         }
     }
 }

--- a/src/FlyView/FlyViewMap.qml
+++ b/src/FlyView/FlyViewMap.qml
@@ -283,7 +283,7 @@ FlightMap {
     // Add ADSB vehicles to the map
     MapItemView {
         model: QGroundControl.adsbVehicleManager.adsbVehicles
-        delegate: VehicleMapItem {
+        delegate: ADSBVehicleMapItem {
             coordinate:     object.coordinate
             altitude:       object.altitude
             callsign:       object.callsign

--- a/test/ADSB/ADSBTest.cc
+++ b/test/ADSB/ADSBTest.cc
@@ -1,13 +1,16 @@
 #include "ADSBTest.h"
 
 #include <QtCore/QRegularExpression>
+#include <QtCore/QScopeGuard>
 #include <QtNetwork/QTcpServer>
 #include <QtTest/QSignalSpy>
 
 #include "ADSBTCPLink.h"
 #include "ADSBVehicle.h"
 #include "ADSBVehicleManager.h"
+#include "ADSBVehicleManagerSettings.h"
 #include "QmlObjectListModel.h"
+#include "SettingsManager.h"
 
 void ADSBTest::_adsbVehicleTest()
 {
@@ -35,6 +38,13 @@ void ADSBTest::_adsbVehicleTest()
     QCOMPARE_NE(adsbVehicle->callsign(), vehicleInfo2.callsign);
     QCOMPARE_NE(adsbVehicle->coordinate(), vehicleInfo2.location);
     vehicleInfo2.icaoAddress = 1;
+    // Rapid updates are throttled and dropped
+    adsbVehicle->update(vehicleInfo2);
+    QCOMPARE_NE(adsbVehicle->callsign(), vehicleInfo2.callsign);
+    QCOMPARE_NE(adsbVehicle->coordinate(), vehicleInfo2.location);
+    QVERIFY(!adsbVehicle->expired());
+    // Bypass the update throttle
+    adsbVehicle->_lastPropertyUpdateTimer.invalidate();
     adsbVehicle->update(vehicleInfo2);
     QCOMPARE(adsbVehicle->callsign(), vehicleInfo2.callsign);
     QCOMPARE(adsbVehicle->coordinate(), vehicleInfo2.location);
@@ -47,7 +57,7 @@ void ADSBTest::_adsbTcpLinkTest()
     QVERIFY(server->listen(QHostAddress::LocalHost, 0));
     const quint16 serverPort = server->serverPort();
     QVERIFY(serverPort > 0);
-    ADSBTCPLink* const adsbLink = new ADSBTCPLink(QHostAddress::LocalHost, serverPort, this);
+    ADSBTCPLink* const adsbLink = new ADSBTCPLink(QStringLiteral("127.0.0.1"), serverPort, this);
     QVERIFY(adsbLink);
     QVERIFY(adsbLink->init());
     QSignalSpy spy(adsbLink, &ADSBTCPLink::adsbVehicleUpdate);
@@ -72,7 +82,7 @@ void ADSBTest::_adsbTcpLinkTest()
 
 void ADSBTest::_adsbTcpLinkRejectsNullHostTest()
 {
-    ADSBTCPLink* const adsbLink = new ADSBTCPLink(QHostAddress(), 30003, this);
+    ADSBTCPLink* const adsbLink = new ADSBTCPLink(QString(), 30003, this);
     QVERIFY(adsbLink);
     QVERIFY(!adsbLink->init());
 }
@@ -85,7 +95,7 @@ void ADSBTest::_adsbTcpLinkIgnoresInvalidMessagesTest()
     const quint16 serverPort = server->serverPort();
     QVERIFY(serverPort > 0);
 
-    ADSBTCPLink* const adsbLink = new ADSBTCPLink(QHostAddress::LocalHost, serverPort, this);
+    ADSBTCPLink* const adsbLink = new ADSBTCPLink(QStringLiteral("127.0.0.1"), serverPort, this);
     QVERIFY(adsbLink);
     QVERIFY(adsbLink->init());
 
@@ -123,7 +133,7 @@ void ADSBTest::_adsbTcpLinkCallsignMessageTest()
     const quint16 serverPort = server->serverPort();
     QVERIFY(serverPort > 0);
 
-    ADSBTCPLink* const adsbLink = new ADSBTCPLink(QHostAddress::LocalHost, serverPort, this);
+    ADSBTCPLink* const adsbLink = new ADSBTCPLink(QStringLiteral("127.0.0.1"), serverPort, this);
     QVERIFY(adsbLink);
     QVERIFY(adsbLink->init());
 
@@ -169,6 +179,100 @@ void ADSBTest::_adsbVehicleManagerTest()
     vehicleInfo.availableFlags = ADSB::LocationAvailable;
     manager->adsbVehicleUpdate(vehicleInfo);
     QCOMPARE(manager->adsbVehicles()->count(), initialCount + 1);
+}
+
+void ADSBTest::_adsbVehicleManagerExpirationTest()
+{
+    ADSBVehicleManager* const manager = ADSBVehicleManager::instance();
+    QVERIFY(manager);
+
+    const int initialCount = manager->adsbVehicles()->count();
+
+    ADSB::VehicleInfo_t vehicleInfo;
+    vehicleInfo.icaoAddress = 0xFEEDFACE;
+    vehicleInfo.location = QGeoCoordinate(1., 1., 1.);
+    vehicleInfo.availableFlags = ADSB::LocationAvailable;
+    manager->adsbVehicleUpdate(vehicleInfo);
+    QCOMPARE(manager->adsbVehicles()->count(), initialCount + 1);
+
+    ADSBVehicle* adsbVehicle = nullptr;
+    for (int i = 0; i < manager->adsbVehicles()->count(); i++) {
+        ADSBVehicle* const candidate = manager->adsbVehicles()->value<ADSBVehicle*>(i);
+        if (candidate->icaoAddress() == vehicleInfo.icaoAddress) {
+            adsbVehicle = candidate;
+            break;
+        }
+    }
+    QVERIFY(adsbVehicle);
+    QVERIFY(!adsbVehicle->expired());
+
+    // Force expiration. The always-running cleanup timer must remove the vehicle even though
+    // no tcp link is active (regression test: mavlink-sourced vehicles previously never expired).
+    adsbVehicle->_lastUpdateTimer.invalidate();
+    QVERIFY(adsbVehicle->expired());
+    QTRY_COMPARE_WITH_TIMEOUT(manager->adsbVehicles()->count(), initialCount, TestTimeout::mediumMs());
+
+    // The vehicle must also be gone from the icao map: re-adding it must create a new entry
+    manager->adsbVehicleUpdate(vehicleInfo);
+    QCOMPARE(manager->adsbVehicles()->count(), initialCount + 1);
+}
+
+void ADSBTest::_adsbVehicleManagerStartStopTest()
+{
+    QTcpServer* const server = new QTcpServer(this);
+    QVERIFY(server);
+    QVERIFY(server->listen(QHostAddress::LocalHost, 0));
+    const quint16 serverPort = server->serverPort();
+    QVERIFY(serverPort > 0);
+
+    ADSBVehicleManager* const manager = ADSBVehicleManager::instance();
+    QVERIFY(manager);
+
+    // Settings facts are not reset between test functions, so restore whatever we mutate
+    ADSBVehicleManagerSettings* const settings = SettingsManager::instance()->adsbVehicleManagerSettings();
+    const QVariant originalHostAddress = settings->adsbServerHostAddress()->rawValue();
+    const QVariant originalPort = settings->adsbServerPort()->rawValue();
+    const QVariant originalEnabled = settings->adsbServerConnectEnabled()->rawValue();
+    const auto restoreSettings = qScopeGuard([settings, originalHostAddress, originalPort, originalEnabled]() {
+        // Restore host/port before enabled so a restart (if originalEnabled is true) uses the
+        // restored values rather than the test's ephemeral server
+        settings->adsbServerHostAddress()->setRawValue(originalHostAddress);
+        settings->adsbServerPort()->setRawValue(originalPort);
+        settings->adsbServerConnectEnabled()->setRawValue(originalEnabled);
+    });
+
+    // Force a disable->enable transition so the start is deterministic even if a prior test
+    // left the connection enabled
+    settings->adsbServerConnectEnabled()->setRawValue(false);
+    settings->adsbServerHostAddress()->setRawValue(QStringLiteral("127.0.0.1"));
+    settings->adsbServerPort()->setRawValue(serverPort);
+    settings->adsbServerConnectEnabled()->setRawValue(true);
+
+    bool timeout = false;
+    QVERIFY(server->waitForNewConnection(TestTimeout::mediumMs(), &timeout));
+    QVERIFY(!timeout);
+    QTcpSocket* const clientSocket = server->nextPendingConnection();
+    QVERIFY(clientSocket != nullptr);
+
+    const int initialCount = manager->adsbVehicles()->count();
+    const QByteArray message(
+        "MSG,3,1,1,4840D7,1,2024/01/01,12:00:00.000,2024/01/01,12:00:00.000,,35000,,,47.0,-122.0,,,,0,,0\n");
+    clientSocket->write(message);
+    clientSocket->flush();
+    (void) clientSocket->waitForBytesWritten(TestTimeout::shortMs());
+    QTRY_COMPARE_WITH_TIMEOUT(manager->adsbVehicles()->count(), initialCount + 1, TestTimeout::mediumMs());
+
+    // Disabling stops the worker thread and clears all vehicles
+    settings->adsbServerConnectEnabled()->setRawValue(false);
+    QCOMPARE(manager->adsbVehicles()->count(), 0);
+
+    // The link must be restartable after a stop
+    settings->adsbServerConnectEnabled()->setRawValue(true);
+    QVERIFY(server->waitForNewConnection(TestTimeout::mediumMs(), &timeout));
+    QVERIFY(!timeout);
+
+    settings->adsbServerConnectEnabled()->setRawValue(false);
+    server->close();
 }
 
 UT_REGISTER_TEST(ADSBTest, TestLabel::Unit)

--- a/test/ADSB/ADSBTest.h
+++ b/test/ADSB/ADSBTest.h
@@ -13,4 +13,6 @@ private slots:
     void _adsbTcpLinkIgnoresInvalidMessagesTest();
     void _adsbTcpLinkCallsignMessageTest();
     void _adsbVehicleManagerTest();
+    void _adsbVehicleManagerExpirationTest();
+    void _adsbVehicleManagerStartStopTest();
 };


### PR DESCRIPTION
## Summary

Fixes the ADS-B portion of #14470. With ~3000 targets streaming from an SBS-1 server, the UI thread saturated (map froze) and memory grew without bound — a regression relative to Qt5 builds.

## Root causes and fixes

- **Main-thread parsing with a throughput cap**: `ADSBTCPLink` parsed SBS-1 lines on the UI thread, capped at 2000 lines/sec (50 ms timer × 100 lines). A 3000 msg/sec feed outran the cap, so the line buffer grew forever while the UI churned. The link now runs on a worker thread (canonical QThread worker pattern); lines are parsed inline as they arrive and the cap/buffer are gone.
- **Per-message property updates**: every message triggered property signals → `MapQuickItem` re-projections across thousands of map items. `ADSBVehicle` now throttles property updates to 1 Hz. Alert transitions bypass the throttle; the expiration keep-alive still updates on every message.
- **Unbounded vehicle accumulation**: the stale-vehicle cleanup timer only ran while a TCP link was active, so MAVLink-sourced ADS-B vehicles never expired. The timer now always runs.
- **Heavy map delegate**: ADS-B targets shared `VehicleMapItem`, instantiating a `MultiEffect` shader (which was 0×0 and never rendered) plus vehicle-only bindings per target. New lightweight `ADSBVehicleMapItem` delegate; `VehicleMapItem` is now vehicle-only.

Also restores hostname support for the ADS-B server address (Qt5 behavior lost in the Qt6 port) by deferring resolution to `QTcpSocket::connectToHost`, and bounds the worker-thread shutdown wait with a warning.

## Testing

- New unit tests: vehicle expiration/cleanup via the manager (regression test for the MAVLink-source leak), TCP link start/stop/restart lifecycle through the settings facts, and property update throttling.
- `ADSBTest` 8/8 passing; `ToolbarIndicatorUITest` passing; qmllint/clang hooks clean.
- Manually verified with a 3000-target SBS-1 generator feeding localhost: map stays responsive, memory stable, targets expire correctly.