### PR TITLE
test(format): cover QGC number and byte-size string helpers

### DIFF
--- a/test/Utilities/CMakeLists.txt
+++ b/test/Utilities/CMakeLists.txt
@@ -24,6 +24,8 @@ target_sources(${CMAKE_PROJECT_NAME}
         QGCMathTest.h
         SecureMemoryTest.cc
         SecureMemoryTest.h
+        QGCFormatTest.cc
+        QGCFormatTest.h
 )
 
 target_include_directories(${CMAKE_PROJECT_NAME} PRIVATE ${CMAKE_CURRENT_SOURCE_DIR})
@@ -41,3 +43,4 @@ add_qgc_test(DataRateTrackerTest LABELS Unit Utilities)
 add_qgc_test(QGCCommandLineParserTest LABELS Unit Utilities)
 add_qgc_test(QGCMathTest LABELS Unit Utilities)
 add_qgc_test(SecureMemoryTest LABELS Unit Utilities)
+add_qgc_test(QGCFormatTest LABELS Unit Utilities)

--- a/test/Utilities/QGCFormatTest.cc
+++ b/test/Utilities/QGCFormatTest.cc
@@ -1,0 +1,58 @@
+#include "QGCFormatTest.h"
+
+#include <QtCore/QLocale>
+
+#include "QGCFormat.h"
+#include "UnitTest.h"
+
+void QGCFormatTest::_numberToStringZero_test()
+{
+    const QLocale locale;
+    QCOMPARE(QGC::numberToString(0), locale.toString(static_cast<quint64>(0)));
+}
+
+void QGCFormatTest::_numberToStringLarge_test()
+{
+    const QLocale locale;
+    const quint64 value = 1234567ULL;
+    QCOMPARE(QGC::numberToString(value), locale.toString(value));
+}
+
+void QGCFormatTest::_bigSizeToStringBytes_test()
+{
+    const QLocale locale;
+    QCOMPARE(QGC::bigSizeToString(0), locale.toString(static_cast<quint64>(0)) + QStringLiteral("B"));
+    QCOMPARE(QGC::bigSizeToString(512), locale.toString(static_cast<quint64>(512)) + QStringLiteral("B"));
+    QCOMPARE(QGC::bigSizeToString(1023), locale.toString(static_cast<quint64>(1023)) + QStringLiteral("B"));
+}
+
+void QGCFormatTest::_bigSizeToStringKB_test()
+{
+    const QLocale locale;
+    QCOMPARE(QGC::bigSizeToString(1024), locale.toString(1.0, 'f', 1) + QStringLiteral("KB"));
+    QCOMPARE(QGC::bigSizeToString(1536), locale.toString(1.5, 'f', 1) + QStringLiteral("KB"));
+}
+
+void QGCFormatTest::_bigSizeToStringMB_test()
+{
+    const QLocale locale;
+    const quint64 oneMB = 1024ULL * 1024ULL;
+    QCOMPARE(QGC::bigSizeToString(oneMB), locale.toString(1.0, 'f', 1) + QStringLiteral("MB"));
+}
+
+void QGCFormatTest::_bigSizeMBToStringMB_test()
+{
+    const QLocale locale;
+    QCOMPARE(QGC::bigSizeMBToString(0), locale.toString(0.0, 'f', 0) + QStringLiteral(" MB"));
+    QCOMPARE(QGC::bigSizeMBToString(512), locale.toString(512.0, 'f', 0) + QStringLiteral(" MB"));
+    QCOMPARE(QGC::bigSizeMBToString(1023), locale.toString(1023.0, 'f', 0) + QStringLiteral(" MB"));
+}
+
+void QGCFormatTest::_bigSizeMBToStringGB_test()
+{
+    const QLocale locale;
+    QCOMPARE(QGC::bigSizeMBToString(1024), locale.toString(1.0, 'f', 1) + QStringLiteral(" GB"));
+    QCOMPARE(QGC::bigSizeMBToString(1536), locale.toString(1.5, 'f', 1) + QStringLiteral(" GB"));
+}
+
+UT_REGISTER_TEST(QGCFormatTest, TestLabel::Unit, TestLabel::Utilities)

--- a/test/Utilities/QGCFormatTest.h
+++ b/test/Utilities/QGCFormatTest.h
@@ -1,0 +1,17 @@
+#pragma once
+
+#include "UnitTest.h"
+
+class QGCFormatTest : public UnitTest
+{
+    Q_OBJECT
+
+private slots:
+    void _numberToStringZero_test();
+    void _numberToStringLarge_test();
+    void _bigSizeToStringBytes_test();
+    void _bigSizeToStringKB_test();
+    void _bigSizeToStringMB_test();
+    void _bigSizeMBToStringMB_test();
+    void _bigSizeMBToStringGB_test();
+};


### PR DESCRIPTION
## Summary
Adds a small unit suite for `QGC::numberToString`, `bigSizeToString`, and `bigSizeMBToString` so locale-aware thresholds at byte/KB/MB and MB/GB boundaries stay pinned.

AI-assisted; human-reviewed. Tests only. No geofence/arm changes.

## Test plan
- [x] New `QGCFormatTest` registered under Utilities
- [ ] CI unit suite
<!-- tol-internal -->
Claim: bartok
Operator: bartok
Campaign: aerial-drone
<!-- /tol-internal -->