### PR TITLE
test(geo): pin zero-distance destination and self geodesic length

### DIFF
--- a/test/Utilities/Geo/GeoTest.cc
+++ b/test/Utilities/Geo/GeoTest.cc
@@ -243,6 +243,21 @@ void GeoTest::_geodesicRoundTrip_test()
     QVERIFY(compareDoubles(calculatedAzimuth, originalAzimuth, 0.0001));
 }
 
+
+void GeoTest::_geodesicDestinationZeroDistance_test()
+{
+    const QGeoCoordinate dest = QGCGeo::geodesicDestination(m_origin, 45.0, 0.0);
+    QCOMPARE_FUZZY(dest.latitude(), m_origin.latitude(), 1e-9);
+    QCOMPARE_FUZZY(dest.longitude(), m_origin.longitude(), 1e-9);
+}
+
+void GeoTest::_geodesicDistanceSelfExact_test()
+{
+    QCOMPARE_FUZZY(QGCGeo::geodesicDistance(m_origin, m_origin), 0.0, 1e-9);
+    const QGeoCoordinate elevated(m_origin.latitude(), m_origin.longitude(), 120.0);
+    QCOMPARE_FUZZY(QGCGeo::geodesicDistance(elevated, elevated), 0.0, 1e-9);
+}
+
 void GeoTest::_pathLength_test()
 {
     // Empty and single-point paths

--- a/test/Utilities/Geo/GeoTest.h
+++ b/test/Utilities/Geo/GeoTest.h
@@ -30,6 +30,8 @@ private slots:
     void _geodesicAzimuth_test();
     void _geodesicDestination_test();
     void _geodesicRoundTrip_test();
+    void _geodesicDestinationZeroDistance_test();
+    void _geodesicDistanceSelfExact_test();
 
     void _pathLength_test();
     void _polygonArea_test();


### PR DESCRIPTION
## Summary
Asserts `geodesicDestination(..., 0)` returns the start point and `geodesicDistance` to self is zero (including elevated alt that must not affect horizontal geodesics).

AI-assisted; human-reviewed. Tests only. No flight safety path edits.

## Test plan
- [x] GeoTest slots only
- [ ] CI
<!-- tol-internal -->
Claim: bartok
Operator: bartok
Campaign: aerial-drone
<!-- /tol-internal -->