### PR TITLE
test(memory): cover secureZero one-byte wipe and cleared size

### DIFF
--- a/test/Utilities/SecureMemoryTest.cc
+++ b/test/Utilities/SecureMemoryTest.cc
@@ -54,4 +54,22 @@ void SecureMemoryTest::_testSecureZeroStdArray()
     }
 }
 
+
+void SecureMemoryTest::_testSecureZeroOneByte()
+{
+    unsigned char b = 0x5A;
+    QGC::secureZero(&b, 1);
+    QCOMPARE(b, static_cast<unsigned char>(0));
+}
+
+void SecureMemoryTest::_testSecureZeroByteArrayDetachSize()
+{
+    QByteArray data(4, '\x11');
+    const qsizetype before = data.size();
+    QCOMPARE(before, 4);
+    QGC::secureZero(data);
+    QVERIFY(data.isEmpty());
+    QCOMPARE(data.size(), 0);
+}
+
 UT_REGISTER_TEST(SecureMemoryTest, TestLabel::Unit, TestLabel::Utilities)

--- a/test/Utilities/SecureMemoryTest.h
+++ b/test/Utilities/SecureMemoryTest.h
@@ -12,4 +12,6 @@ private slots:
     void _testSecureZeroEmptyByteArray();
     void _testSecureZeroZeroSize();
     void _testSecureZeroStdArray();
+    void _testSecureZeroOneByte();
+    void _testSecureZeroByteArrayDetachSize();
 };


### PR DESCRIPTION
## Summary
Pins one-byte `secureZero` and confirms `QByteArray` wipe ends at `size() == 0` so callers cannot reuse a cleared buffer as still sized.

AI-assisted; human-reviewed. Tests only.

## Test plan
- [x] SecureMemoryTest only
- [ ] CI
<!-- tol-internal -->
Claim: bartok
Operator: bartok
Campaign: aerial-drone
<!-- /tol-internal -->