### PR TITLE
test(cli): cover logging arg normalize and boot-test mode priority

### DIFF
--- a/test/Utilities/QGCCommandLineParserTest.cc
+++ b/test/Utilities/QGCCommandLineParserTest.cc
@@ -143,4 +143,26 @@ void QGCCommandLineParserTest::_testNormalizeArgs_ColonOptionValuePreserved()
     QCOMPARE(out, QStringList({QStringLiteral("--logging"), QStringLiteral("Vehicle.FTPManager")}));
 }
 
+
+void QGCCommandLineParserTest::_testNormalizeArgs_LoggingSpaceSeparated()
+{
+    const QStringList out = QGCCommandLineParser::normalizeArgs(
+        {QStringLiteral("qgc"), QStringLiteral("--logging"), QStringLiteral("Vehicle.*")});
+    QCOMPARE(out, QStringList({QStringLiteral("qgc"), QStringLiteral("--logging"), QStringLiteral("Vehicle.*")}));
+}
+
+void QGCCommandLineParserTest::_testNormalizeArgs_EmptyList()
+{
+    QCOMPARE(QGCCommandLineParser::normalizeArgs({}), QStringList());
+}
+
+void QGCCommandLineParserTest::_testDetermineAppMode_BootTestWinsOverGuiFlags()
+{
+    CommandLineParseResult result;
+    result.simpleBootTest = true;
+    result.allowMultiple = true;
+    result.fakeMobile = true;
+    QCOMPARE(QGCCommandLineParser::determineAppMode(result), AppMode::BootTest);
+}
+
 UT_REGISTER_TEST(QGCCommandLineParserTest, TestLabel::Unit, TestLabel::Utilities)

--- a/test/Utilities/QGCCommandLineParserTest.h
+++ b/test/Utilities/QGCCommandLineParserTest.h
@@ -32,4 +32,7 @@ private slots:
     void _testNormalizeArgs_UnittestBare();
     void _testNormalizeArgs_UnittestBareFollowedByOption();
     void _testNormalizeArgs_ColonOptionValuePreserved();
+    void _testNormalizeArgs_LoggingSpaceSeparated();
+    void _testNormalizeArgs_EmptyList();
+    void _testDetermineAppMode_BootTestWinsOverGuiFlags();
 };


### PR DESCRIPTION
## Summary
Adds `normalizeArgs` coverage for space-separated `--logging` and empty argv, plus `determineAppMode` BootTest precedence when GUI flags are also set.

AI-assisted; human-reviewed. Tests only.

## Test plan
- [x] QGCCommandLineParserTest only
- [ ] CI
<!-- tol-internal -->
Claim: bartok
Operator: bartok
Campaign: aerial-drone
<!-- /tol-internal -->