### PR TITLE
fix(camera): treat empty stream resolution as aspect 1.0

### DIFF
--- a/src/Camera/QGCVideoStreamInfo.cc
+++ b/src/Camera/QGCVideoStreamInfo.cc
@@ -19,7 +19,10 @@ QGCVideoStreamInfo::~QGCVideoStreamInfo()
 qreal QGCVideoStreamInfo::aspectRatio() const
 {
     qreal ar = 1.0;
-    if (!resolution().isNull()) {
+    // isNull() is only true when *both* dimensions are 0. A stream that
+    // reports a non-zero width with height 0 (or the reverse) must not
+    // divide and produce Inf/NaN for QML layout.
+    if (!resolution().isEmpty()) {
         ar = static_cast<double>(_streamInfo.resolution_h) / static_cast<double>(_streamInfo.resolution_v);
     }
     return ar;

--- a/test/Camera/QGCVideoStreamInfoTest.cc
+++ b/test/Camera/QGCVideoStreamInfoTest.cc
@@ -58,6 +58,37 @@ void QGCVideoStreamInfoTest::_aspectRatioDefaultsToOneForNullResolution_test()
     QCOMPARE(streamInfo.aspectRatio(), 1.0);
 }
 
+
+void QGCVideoStreamInfoTest::_aspectRatioDefaultsToOneForEmptyResolution_test()
+{
+    // One dimension non-zero → QSize::isNull() is false, but division by zero
+    // would produce Inf without the isEmpty() guard.
+    mavlink_video_stream_information_t info = _makeVideoStreamInfo();
+    info.resolution_h = 1920;
+    info.resolution_v = 0;
+
+    QGCVideoStreamInfo streamInfo(info);
+    QCOMPARE(streamInfo.aspectRatio(), 1.0);
+
+    info.resolution_h = 0;
+    info.resolution_v = 1080;
+    QGCVideoStreamInfo streamInfoV(info);
+    QCOMPARE(streamInfoV.aspectRatio(), 1.0);
+}
+
+void QGCVideoStreamInfoTest::_inactiveThermalFlagsDefault_test()
+{
+    mavlink_video_stream_information_t info = _makeVideoStreamInfo();
+    info.flags = 0;  // not RUNNING, not THERMAL
+
+    QGCVideoStreamInfo streamInfo(info);
+    QVERIFY(!streamInfo.isActive());
+    QVERIFY(!streamInfo.isThermal());
+    QCOMPARE(streamInfo.streamID(), static_cast<quint8>(3));
+    QCOMPARE(streamInfo.uri(), QStringLiteral("rtsp://127.0.0.1/main"));
+    QCOMPARE(streamInfo.name(), QStringLiteral("Main Stream"));
+}
+
 void QGCVideoStreamInfoTest::_updateNoChange_test()
 {
     const mavlink_video_stream_information_t info = _makeVideoStreamInfo();

--- a/test/Camera/QGCVideoStreamInfoTest.h
+++ b/test/Camera/QGCVideoStreamInfoTest.h
@@ -9,6 +9,8 @@ class QGCVideoStreamInfoTest : public UnitTest
 private slots:
     void _aspectRatioFromResolution_test();
     void _aspectRatioDefaultsToOneForNullResolution_test();
+    void _aspectRatioDefaultsToOneForEmptyResolution_test();
+    void _inactiveThermalFlagsDefault_test();
     void _updateNoChange_test();
     void _updateChangedFieldsEmitsSignal_test();
 };


### PR DESCRIPTION
## Summary

- Gate `QGCVideoStreamInfo::aspectRatio()` on `!resolution().isEmpty()` so one-zero dimensions no longer divide-by-zero (Inf) for QML layout.
- Unit tests for partial empty resolution and inactive/thermal flag defaults.

## Motivation

`QSize::isNull()` is only true when **both** width and height are 0. A stream reporting `1920x0` (or `0x1080`) previously computed `h/0` → Inf, which can corrupt aspect-driven UI layout. `isEmpty()` correctly treats any non-positive dimension as empty.

## Verification

- Offline review of `QSize::isNull` vs `isEmpty` contract + new unit slots on `QGCVideoStreamInfoTest`.
- Did not change: stream update merge logic, flag bits, or MAVLink packing.
- No geofence / arm path touches.

## Notes

Specs: `specs/qgroundcontrol/2026-07-22-summary.md` (campaign kit).

---
<!-- fleet-pr-claim: agent_id=sera platform=hermes -->
**Agent-Owner:** `sera` · **Platform:** hermes · **Claim-TTL:** 24h
