### PR TITLE
test(format): cover QGCFormat size and number helpers

### DIFF
--- a/test/Utilities/CMakeLists.txt
+++ b/test/Utilities/CMakeLists.txt
@@ -22,6 +22,8 @@ target_sources(${CMAKE_PROJECT_NAME}
         QGCCommandLineParserTest.h
         QGCMathTest.cc
         QGCMathTest.h
+        QGCFormatTest.cc
+        QGCFormatTest.h
         SecureMemoryTest.cc
         SecureMemoryTest.h
 )
@@ -40,4 +42,5 @@ qt_add_resources(${CMAKE_PROJECT_NAME} "UtilitiesTest_res"
 add_qgc_test(DataRateTrackerTest LABELS Unit Utilities)
 add_qgc_test(QGCCommandLineParserTest LABELS Unit Utilities)
 add_qgc_test(QGCMathTest LABELS Unit Utilities)
+add_qgc_test(QGCFormatTest LABELS Unit Utilities)
 add_qgc_test(SecureMemoryTest LABELS Unit Utilities)

--- a/test/Utilities/QGCFormatTest.cc
+++ b/test/Utilities/QGCFormatTest.cc
@@ -1,0 +1,73 @@
+#include "QGCFormatTest.h"
+
+#include <QtCore/QLocale>
+
+#include "QGCFormat.h"
+#include "UnitTest.h"
+
+namespace {
+
+/// Pin formatting against the C locale so unit suffixes stay stable in CI.
+class ScopedCLocale
+{
+public:
+    ScopedCLocale()
+        : _previous(QLocale())
+    {
+        QLocale::setDefault(QLocale::c());
+    }
+
+    ~ScopedCLocale() { QLocale::setDefault(_previous); }
+
+private:
+    QLocale _previous;
+};
+
+} // namespace
+
+void QGCFormatTest::_numberToStringBasic()
+{
+    const ScopedCLocale localeGuard;
+
+    QCOMPARE(QGC::numberToString(0), QStringLiteral("0"));
+    QCOMPARE(QGC::numberToString(42), QStringLiteral("42"));
+    QCOMPARE(QGC::numberToString(1000), QStringLiteral("1000"));
+}
+
+void QGCFormatTest::_bigSizeToStringBoundaries()
+{
+    const ScopedCLocale localeGuard;
+
+    // Bytes (< 1 KiB)
+    QCOMPARE(QGC::bigSizeToString(0), QStringLiteral("0B"));
+    QCOMPARE(QGC::bigSizeToString(512), QStringLiteral("512B"));
+    QCOMPARE(QGC::bigSizeToString(1023), QStringLiteral("1023B"));
+
+    // KiB band
+    QCOMPARE(QGC::bigSizeToString(1024), QStringLiteral("1.0KB"));
+    QCOMPARE(QGC::bigSizeToString(1536), QStringLiteral("1.5KB"));
+
+    // MiB / GiB / TiB lower edges
+    QCOMPARE(QGC::bigSizeToString(1024ULL * 1024ULL), QStringLiteral("1.0MB"));
+    QCOMPARE(QGC::bigSizeToString(1024ULL * 1024ULL * 1024ULL), QStringLiteral("1.0GB"));
+    QCOMPARE(QGC::bigSizeToString(1024ULL * 1024ULL * 1024ULL * 1024ULL), QStringLiteral("1.0TB"));
+}
+
+void QGCFormatTest::_bigSizeMBToStringBoundaries()
+{
+    const ScopedCLocale localeGuard;
+
+    // Input is already in mebibytes. Below 1024 MB → "N MB" (no fractional digit).
+    QCOMPARE(QGC::bigSizeMBToString(0), QStringLiteral("0 MB"));
+    QCOMPARE(QGC::bigSizeMBToString(1), QStringLiteral("1 MB"));
+    QCOMPARE(QGC::bigSizeMBToString(1023), QStringLiteral("1023 MB"));
+
+    // 1024 MB = 1.0 GB
+    QCOMPARE(QGC::bigSizeMBToString(1024), QStringLiteral("1.0 GB"));
+    QCOMPARE(QGC::bigSizeMBToString(1536), QStringLiteral("1.5 GB"));
+
+    // 1024*1024 MB = 1.00 TB
+    QCOMPARE(QGC::bigSizeMBToString(1024ULL * 1024ULL), QStringLiteral("1.00 TB"));
+}
+
+UT_REGISTER_TEST(QGCFormatTest, TestLabel::Unit, TestLabel::Utilities)

--- a/test/Utilities/QGCFormatTest.h
+++ b/test/Utilities/QGCFormatTest.h
@@ -1,0 +1,14 @@
+#pragma once
+
+#include "UnitTest.h"
+
+/// Unit tests for QGCFormat locale-aware number/size helpers.
+class QGCFormatTest : public UnitTest
+{
+    Q_OBJECT
+
+private slots:
+    void _numberToStringBasic();
+    void _bigSizeToStringBoundaries();
+    void _bigSizeMBToStringBoundaries();
+};


### PR DESCRIPTION
## Summary

- New `QGCFormatTest` unit suite covering `numberToString`, `bigSizeToString`, and `bigSizeMBToString` threshold bands under the C locale.

## Motivation

These helpers feed map-tile and onboard-log UI size labels but had no dedicated unit coverage. Boundary pins (B/KB/MB/GB/TB and MB-input scaling) lock the unit cutovers.

## Verification

- CMake registers `QGCFormatTest` under Unit/Utilities labels.
- Assertions use `QLocale::c()` so CI locale does not drift unit strings.
- No product code changes.

---
<!-- fleet-pr-claim: agent_id=sera platform=hermes -->
**Agent-Owner:** `sera` · **Platform:** hermes · **Claim-TTL:** 24h
