### PR TITLE
test(fs): pin QGCFileHelper::joinPath edge cases

### DIFF
--- a/test/Utilities/FileSystem/QGCFileHelperTest.cc
+++ b/test/Utilities/FileSystem/QGCFileHelperTest.cc
@@ -300,6 +300,29 @@ void QGCFileHelperTest::_testHasSufficientDiskSpaceWithMargin()
 // ============================================================================
 // URL/Path utilities tests
 // ============================================================================
+void QGCFileHelperTest::_testJoinPath()
+{
+    // Empty directory keeps the leaf name (including empty).
+    QCOMPARE(QGCFileHelper::joinPath(QString(), QStringLiteral("file.txt")), QStringLiteral("file.txt"));
+    QCOMPARE(QGCFileHelper::joinPath(QString(), QString()), QString());
+
+    // No trailing separator → insert '/'.
+    QCOMPARE(QGCFileHelper::joinPath(QStringLiteral("/tmp"), QStringLiteral("a.txt")),
+             QStringLiteral("/tmp/a.txt"));
+    QCOMPARE(QGCFileHelper::joinPath(QStringLiteral("relative"), QStringLiteral("b")),
+             QStringLiteral("relative/b"));
+
+    // Already ends with '/' → do not double-slash.
+    QCOMPARE(QGCFileHelper::joinPath(QStringLiteral("/tmp/"), QStringLiteral("a.txt")),
+             QStringLiteral("/tmp/a.txt"));
+    QCOMPARE(QGCFileHelper::joinPath(QStringLiteral("/"), QStringLiteral("root.txt")),
+             QStringLiteral("/root.txt"));
+
+    // Empty leaf still produces trailing-slash form of dir join.
+    QCOMPARE(QGCFileHelper::joinPath(QStringLiteral("/tmp"), QString()), QStringLiteral("/tmp/"));
+    QCOMPARE(QGCFileHelper::joinPath(QStringLiteral("/tmp/"), QString()), QStringLiteral("/tmp/"));
+}
+
 void QGCFileHelperTest::_testToLocalPathPlainPaths()
 {
     // Plain paths should pass through unchanged

--- a/test/Utilities/FileSystem/QGCFileHelperTest.h
+++ b/test/Utilities/FileSystem/QGCFileHelperTest.h
@@ -46,6 +46,9 @@ private slots:
     void _testHasSufficientDiskSpaceZeroBytes();
     void _testHasSufficientDiskSpaceWithMargin();
 
+    // Path join helpers
+    void _testJoinPath();
+
     // URL/Path utilities tests
     void _testToLocalPathPlainPaths();
     void _testToLocalPathFileUrls();


### PR DESCRIPTION
## Summary

- Unit coverage for `QGCFileHelper::joinPath` empty-dir, trailing-slash, and empty-leaf edges.

## Motivation

`joinPath` is used by recursive copy/extract paths and previously lacked direct tests. Incorrect double-slashes or empty-dir handling would only show up deeper in filesystem helpers.

## Verification

- Added `_testJoinPath` to existing `QGCFileHelperTest` (Unit/Utilities).
- Tests only; no product code changes.

---
<!-- fleet-pr-claim: agent_id=sera platform=hermes -->
**Agent-Owner:** `sera` · **Platform:** hermes · **Claim-TTL:** 24h
