### PR TITLE
test(sql): cover placeholders and user_version helpers

### DIFF
--- a/test/Utilities/Database/QGCSqlHelperTest.cc
+++ b/test/Utilities/Database/QGCSqlHelperTest.cc
@@ -29,6 +29,41 @@ void QGCSqlHelperTest::_escapeLikePattern()
     QCOMPARE(QGCSqlHelper::escapeLikePattern(QString()), QString());
 }
 
+void QGCSqlHelperTest::_placeholders()
+{
+    // Non-positive counts produce an empty fragment (callers gate IN clauses).
+    QCOMPARE(QGCSqlHelper::placeholders(0), QString());
+    QCOMPARE(QGCSqlHelper::placeholders(-3), QString());
+
+    QCOMPARE(QGCSqlHelper::placeholders(1), QStringLiteral("?"));
+    QCOMPARE(QGCSqlHelper::placeholders(3), QStringLiteral("?,?,?"));
+    QCOMPARE(QGCSqlHelper::placeholders(5), QStringLiteral("?,?,?,?,?"));
+}
+
+void QGCSqlHelperTest::_userVersionRoundTrip()
+{
+    QTemporaryDir tempDir;
+    QVERIFY(tempDir.isValid());
+    const QString dbPath = tempDir.filePath(QStringLiteral("userver.db"));
+
+    QGCSqlHelper::ScopedConnection conn(dbPath);
+    QVERIFY(conn.isValid());
+    QSqlDatabase db = conn.database();
+
+    // Fresh SQLite DBs start at user_version 0.
+    const auto initial = QGCSqlHelper::userVersion(db);
+    QVERIFY(initial.has_value());
+    QCOMPARE(*initial, 0);
+
+    QVERIFY(QGCSqlHelper::setUserVersion(db, 7));
+    const auto after = QGCSqlHelper::userVersion(db);
+    QVERIFY(after.has_value());
+    QCOMPARE(*after, 7);
+
+    QVERIFY(QGCSqlHelper::setUserVersion(db, 0));
+    QCOMPARE(*QGCSqlHelper::userVersion(db), 0);
+}
+
 void QGCSqlHelperTest::_scopedConnectionOpen()
 {
     QTemporaryDir tempDir;

--- a/test/Utilities/Database/QGCSqlHelperTest.h
+++ b/test/Utilities/Database/QGCSqlHelperTest.h
@@ -8,6 +8,8 @@ class QGCSqlHelperTest : public UnitTest
 
 private slots:
     void _escapeLikePattern();
+    void _placeholders();
+    void _userVersionRoundTrip();
     void _scopedConnectionOpen();
     void _scopedConnectionReadOnly();
     void _scopedConnectionInvalidPath();


### PR DESCRIPTION
## Summary

- Unit tests for `QGCSqlHelper::placeholders` (n≤0 and multi-`?` shapes) and `userVersion` / `setUserVersion` round-trip on a temp SQLite DB.

## Motivation

IN-clause placeholder generation and schema `user_version` helpers are shared across cache/log DBs but were untested. Wrong `placeholders(0)` / version PRAGMAs are silent until runtime query failures.

## Verification

- Extends `QGCSqlHelperTest` with offline temp DB via existing `ScopedConnection`.
- Tests only; no product code changes.

---
<!-- fleet-pr-claim: agent_id=sera platform=hermes -->
**Agent-Owner:** `sera` · **Platform:** hermes · **Claim-TTL:** 24h
