### PR TITLE
test(cli): pin normalizeArgs empty-colon and mixed options

### DIFF
--- a/test/Utilities/QGCCommandLineParserTest.cc
+++ b/test/Utilities/QGCCommandLineParserTest.cc
@@ -143,4 +143,26 @@ void QGCCommandLineParserTest::_testNormalizeArgs_ColonOptionValuePreserved()
     QCOMPARE(out, QStringList({QStringLiteral("--logging"), QStringLiteral("Vehicle.FTPManager")}));
 }
 
+void QGCCommandLineParserTest::_testNormalizeArgs_EmptyColonValueDropped()
+{
+    // Non-unittest options with an empty --opt: value drop the empty token
+    // (unlike bare --unittest which deliberately injects an empty arg).
+    const QStringList out = QGCCommandLineParser::normalizeArgs(
+        {QStringLiteral("qgc"), QStringLiteral("--logging:")});
+    QCOMPARE(out, QStringList({QStringLiteral("qgc"), QStringLiteral("--logging")}));
+}
+
+void QGCCommandLineParserTest::_testNormalizeArgs_MixedColonAndPlain()
+{
+    const QStringList out = QGCCommandLineParser::normalizeArgs(
+        {QStringLiteral("qgc"),
+         QStringLiteral("--logging:Vehicle.FTPManager"),
+         QStringLiteral("--allow-multiple"),
+         QStringLiteral("--clear-settings")});
+    QCOMPARE(out,
+             QStringList({QStringLiteral("qgc"), QStringLiteral("--logging"),
+                          QStringLiteral("Vehicle.FTPManager"), QStringLiteral("--allow-multiple"),
+                          QStringLiteral("--clear-settings")}));
+}
+
 UT_REGISTER_TEST(QGCCommandLineParserTest, TestLabel::Unit, TestLabel::Utilities)

--- a/test/Utilities/QGCCommandLineParserTest.h
+++ b/test/Utilities/QGCCommandLineParserTest.h
@@ -32,4 +32,6 @@ private slots:
     void _testNormalizeArgs_UnittestBare();
     void _testNormalizeArgs_UnittestBareFollowedByOption();
     void _testNormalizeArgs_ColonOptionValuePreserved();
+    void _testNormalizeArgs_EmptyColonValueDropped();
+    void _testNormalizeArgs_MixedColonAndPlain();
 };


### PR DESCRIPTION
## Summary

- Pin `normalizeArgs` behavior for empty `--option:` values (drop blank token) and mixed colon + plain flags.

## Motivation

The unittest-build normalizer intentionally injects an empty arg for bare `--unittest`, but general `--logging:` style empty values must **not** inject a blank token. Locking both alone and in a mixedargv keeps boot option parsing stable.

## Verification

- Extends `QGCCommandLineParserTest` pure-function layer (no process exit paths).
- Tests only; no product code changes.

---
<!-- fleet-pr-claim: agent_id=sera platform=hermes -->
**Agent-Owner:** `sera` · **Platform:** hermes · **Claim-TTL:** 24h
