### PR TITLE
fix(PlanView): load mission item editors synchronously to avoid invalid-context race

### DIFF
--- a/src/PlanView/MissionItemEditor.qml
+++ b/src/PlanView/MissionItemEditor.qml
@@ -349,8 +349,13 @@ Rectangle {
         anchors.margins:    _innerMargin
         anchors.left:       parent.left
         anchors.top:        topRowLayout.bottom
-        asynchronous:       true
 
+        // Deliberately not asynchronous. With asynchronous: true the editor is built
+        // incrementally over later event-loop ticks. If the user switches layers before
+        // that finishes, the TreeView collapses the mission group and destroys this
+        // delegate, and the still-running load then warns "Cannot create a component in
+        // an invalid context". Synchronous loading closes that window: the editor is
+        // fully built before control returns to the event loop.
         Component.onCompleted: _root._loadEditor()
     }
 


### PR DESCRIPTION
## Problem

`PlanViewLayerUITest::_testEditingLayerSwitching` failed intermittently on slow CI runners with:

```
QQmlContext: Cannot set context object on invalid context.
QQmlComponent: Cannot create a component in an invalid context
```

## Root Cause

The mission item editor `Loader` used `asynchronous: true`, so the editor was built incrementally over later event-loop ticks. Switching layers (e.g. clicking the GeoFence header) collapses the mission group in the plan TreeView, destroying the delegate while the incubation was still in flight. The orphaned load then ran against an invalidated context, emitting the warnings above — which failed the UI test's strict-mode log checking. The race is timing-dependent, so it only reproduced on loaded CI runners.

This is not just a test artifact: a real user switching layers quickly enough would hit the same race in production.

## Fix

Load the editor synchronously. The editor is fully built before control returns to the event loop, so there is no in-flight incubation window for the TreeView collapse to invalidate. Only the single current item's editor loads at a time (on explicit user click), so the synchronous cost is negligible.

Debugging was done in draft PR #14678, which this replaces.
