### PR TITLE
feat: reboot button in vehicle-reboot-required dialog; Comm Links section reorder

### DIFF
--- a/src/AppSettings/pages/CommLinks.SettingsUI.json
+++ b/src/AppSettings/pages/CommLinks.SettingsUI.json
@@ -3,6 +3,30 @@
     "fileType": "SettingsUI",
     "groups": [
         {
+            "component": "LinkConfigurationManager",
+            "sectionName": "Link Management",
+            "keywords": [
+                "link",
+                "connection",
+                "serial",
+                "tcp",
+                "udp",
+                "bluetooth",
+                "add link"
+            ]
+        },
+        {
+            "component": "NmeaGpsSettings",
+            "sectionName": "NMEA GPS",
+            "keywords": [
+                "nmea",
+                "gps",
+                "serial",
+                "baud rate",
+                "external gps"
+            ]
+        },
+        {
             "heading": "AutoConnect",
             "keywords": ["auto connect", "pixhawk", "sik radio", "librepilot", "udp", "rtk gps", "usb"],
             "showWhen": "QGroundControl.settingsManager.autoConnectSettings.userVisible",
@@ -22,30 +46,6 @@
                 {
                     "setting": "autoConnectSettings.autoConnectRTKGPS"
                 }
-            ]
-        },
-        {
-            "component": "NmeaGpsSettings",
-            "sectionName": "NMEA GPS",
-            "keywords": [
-                "nmea",
-                "gps",
-                "serial",
-                "baud rate",
-                "external gps"
-            ]
-        },
-        {
-            "component": "LinkConfigurationManager",
-            "sectionName": "Link Management",
-            "keywords": [
-                "link",
-                "connection",
-                "serial",
-                "tcp",
-                "udp",
-                "bluetooth",
-                "add link"
             ]
         }
     ]

--- a/src/FactSystem/Fact.cc
+++ b/src/FactSystem/Fact.cc
@@ -930,7 +930,7 @@ void Fact::_checkForRebootMessaging()
         // showAppMessage() logs during unit tests (and additionally shows the real
         // dialog in UI test mode), so tests assert this messaging via expectAppMessage()
         if (vehicleRebootRequired()) {
-            QGC::showRebootAppMessage(tr("Reboot vehicle for changes to take effect."));
+            QGC::showRebootVehicleMessage(tr("Reboot vehicle for changes to take effect."));
         } else if (qgcRebootRequired()) {
             QGC::showRebootAppMessage(tr("Restart application for changes to take effect."));
         }

--- a/src/MainWindow/MainWindow.qml
+++ b/src/MainWindow/MainWindow.qml
@@ -186,6 +186,19 @@ ApplicationWindow {
         _showMessageDialogWorker(mainWindow, dialogTitle, dialogText)
     }
 
+    // This variant is only meant to be called by QGCApplication. Ok reboots the active vehicle.
+    function _showRebootVehicleDialog(dialogTitle, dialogText) {
+        _showMessageDialogWorker(mainWindow, dialogTitle,
+                                 dialogText + " " + qsTr("Click Ok to reboot the vehicle now."),
+                                 Dialog.Ok | Dialog.Cancel,
+                                 function() {
+                                     const activeVehicle = QGroundControl.multiVehicleManager.activeVehicle
+                                     if (activeVehicle) {
+                                         activeVehicle.rebootVehicle()
+                                     }
+                                 })
+    }
+
     Connections {
         target: QGroundControl
 

--- a/src/QGCApplication.cc
+++ b/src/QGCApplication.cc
@@ -458,18 +458,51 @@ void QGCApplication::showAppMessage(const QString& message, const QString& title
     }
 }
 
-void QGCApplication::showRebootAppMessage(const QString& message, const QString& title)
+bool QGCApplication::_rebootMessageDebounced()
 {
     const QTime currentTime = QTime::currentTime();
     const QTime previousTime = _lastRebootMessageTime;
     _lastRebootMessageTime = currentTime;
 
-    if (previousTime.isValid() && (previousTime.msecsTo(currentTime) < (60 * 1000 * 2))) {
-        // Debounce reboot messages
+    return previousTime.isValid() && (previousTime.msecsTo(currentTime) < (60 * 1000 * 2));
+}
+
+void QGCApplication::showRebootAppMessage(const QString& message, const QString& title)
+{
+    if (_rebootMessageDebounced()) {
         return;
     }
 
     showAppMessage(message, title);
+}
+
+void QGCApplication::showRebootVehicleMessage(const QString& message, const QString& title)
+{
+    if (_rebootMessageDebounced()) {
+        return;
+    }
+
+    const QString dialogTitle = title.isEmpty() ? applicationName() : title;
+
+    if (runningUnitTests()) {
+        // Same log format as showAppMessage() so tests assert this via expectAppMessage()
+        qCDebug(QGCAppMessageLog) << "showAppMessage:" << dialogTitle << "-" << message;
+        if (!_uiTestMode) {
+            return;
+        }
+    }
+
+    QObject* const rootQmlObject = _rootQmlObject();
+    if (rootQmlObject) {
+        QVariant varReturn;
+        QVariant varMessage = QVariant::fromValue(message);
+        QMetaObject::invokeMethod(rootQmlObject, "_showRebootVehicleDialog", Q_RETURN_ARG(QVariant, varReturn),
+                                  Q_ARG(QVariant, dialogTitle), Q_ARG(QVariant, varMessage));
+    } else {
+        // UI isn't ready yet: fall back to the plain app message queue
+        _delayedAppMessages.append(QPair<QString, QString>(dialogTitle, message));
+        QTimer::singleShot(200, this, &QGCApplication::_showDelayedAppMessages);
+    }
 }
 
 void QGCApplication::_showDelayedAppMessages()

--- a/src/QGCApplication.h
+++ b/src/QGCApplication.h
@@ -112,6 +112,9 @@ public slots:
     /// one after the other.
     void showRebootAppMessage(const QString &message, const QString &title = QString());
 
+    /// Same as showRebootAppMessage() but the dialog also includes a button which reboots the active vehicle.
+    void showRebootVehicleMessage(const QString &message, const QString &title = QString());
+
     QGCImageProvider *qgcImageProvider();
 
 private slots:
@@ -133,6 +136,7 @@ private:
 
     QObject *_rootQmlObject();
     void _checkForNewVersion();
+    bool _rebootMessageDebounced();
 
     bool _runningUnitTests = false;
     bool _simpleBootTest = false;

--- a/src/Utilities/AppMessages.cc
+++ b/src/Utilities/AppMessages.cc
@@ -27,6 +27,13 @@ void showRebootAppMessage(const QString &message, const QString &title)
     }
 }
 
+void showRebootVehicleMessage(const QString &message, const QString &title)
+{
+    if (auto *const app = qgcApp()) {
+        app->showRebootVehicleMessage(message, title);
+    }
+}
+
 bool runningUnitTests()
 {
     auto *const app = qgcApp();

--- a/src/Utilities/AppMessages.h
+++ b/src/Utilities/AppMessages.h
@@ -15,5 +15,8 @@ namespace QGC
     /// Modal reboot-required message. Debounced within 2 minutes.
     void showRebootAppMessage(const QString &message, const QString &title = QString());
 
+    /// Modal vehicle-reboot-required message with a reboot button. Debounced within 2 minutes.
+    void showRebootVehicleMessage(const QString &message, const QString &title = QString());
+
     bool runningUnitTests();
 }

--- a/test/QmlUITests/APMFreshFlashUITest.cc
+++ b/test/QmlUITests/APMFreshFlashUITest.cc
@@ -151,10 +151,11 @@ void APMFreshFlashUITest::_testFreshFlashSetupState()
     QCOMPARE(frameTypeFact->rawValue().toInt(), 1); // X is the Quad default frame type
 
     // The reboot message fires when the vehicle acks the param write: dismiss
-    // the resulting dialog before interacting with the UI again
+    // the resulting dialog before interacting with the UI again. Cancel rather
+    // than Ok — Ok would reboot the vehicle.
     QVERIFY2(QTest::qWaitFor([&] { return frameClassAckSpy.count() >= 1; }, 5000),
              "FRAME_CLASS write never acked by the vehicle");
-    QVERIFY2(acceptDialog(5000), "Reboot app message dialog never shown");
+    QVERIFY2(rejectDialog(5000), "Reboot app message dialog never shown");
     verifyExpectedLogMessage();
     if (QTest::currentTestFailed()) return;
 

--- a/test/QmlUITests/PX4AirframeSetupUITest.cc
+++ b/test/QmlUITests/PX4AirframeSetupUITest.cc
@@ -240,8 +240,9 @@ void PX4AirframeSetupUITest::_testApplyAirframe()
              "Vehicle never disconnected after Apply and Restart");
 
     // By now the SYS_AUTOSTART ack has round-tripped, so the reboot app
-    // message dialog must have been shown — dismiss and verify it
-    QVERIFY2(acceptDialog(5000), "Reboot app message dialog never shown");
+    // message dialog must have been shown — dismiss and verify it. Cancel
+    // rather than Ok — Ok would reboot the (already disconnected) vehicle.
+    QVERIFY2(rejectDialog(5000), "Reboot app message dialog never shown");
     verifyExpectedLogMessage();
     });
 }

--- a/test/QmlUITests/PX4AirframeSetupUITest.cc
+++ b/test/QmlUITests/PX4AirframeSetupUITest.cc
@@ -239,10 +239,10 @@ void PX4AirframeSetupUITest::_testApplyAirframe()
     QVERIFY2(QTest::qWaitFor([&] { return MultiVehicleManager::instance()->activeVehicle() == nullptr; }, 10000),
              "Vehicle never disconnected after Apply and Restart");
 
-    // By now the SYS_AUTOSTART ack has round-tripped, so the reboot app
-    // message dialog must have been shown — dismiss and verify it. Cancel
-    // rather than Ok — Ok would reboot the (already disconnected) vehicle.
-    QVERIFY2(rejectDialog(5000), "Reboot app message dialog never shown");
+    // By now the SYS_AUTOSTART ack has round-tripped, so the vehicle
+    // reboot-required dialog must have been shown — dismiss and verify it.
+    // Cancel rather than Ok — Ok would reboot the (already disconnected) vehicle.
+    QVERIFY2(rejectDialog(5000), "Vehicle reboot-required dialog never shown");
     verifyExpectedLogMessage();
     });
 }


### PR DESCRIPTION
Two related UX improvements, in separate commits:

## 1. Reboot button in vehicle-reboot-required dialog

When changing a parameter that requires a vehicle reboot (e.g. selecting frame type on ArduPilot), the app previously showed a plain message telling the user to reboot. It now shows a dialog with an Ok/Cancel choice where Ok reboots the active vehicle directly.

- New `QGCApplication::showRebootVehicleMessage()` / `QGC::showRebootVehicleMessage()` alongside the existing `showRebootAppMessage()`, sharing the same 2-minute debounce.
- `Fact::_checkForRebootMessaging()` uses the new dialog for `vehicleRebootRequired` metadata.
- New `_showRebootVehicleDialog()` in MainWindow.qml with an accept handler that null-checks `activeVehicle` and calls `rebootVehicle()`.
- Existing UI tests updated to Cancel the dialog instead of Ok (Ok would now reboot the vehicle).

## 2. Comm Links settings page section order

The section for adding new links was at the bottom of the page. Reordered to: Link Management, NMEA GPS, AutoConnect.

## Testing

- `just build` passes
- `ctest -R "APMFreshFlashUITest|PX4AirframeSetupUITest"` — 2/2 pass
