### PR TITLE
docs: add Settings Override Files documentation + fix override key validation

### DIFF
--- a/docs/en/SUMMARY.md
+++ b/docs/en/SUMMARY.md
@@ -115,6 +115,7 @@
     - [Parameters](qgc-dev-guide/file_formats/parameters.md)
     - [Plan](qgc-dev-guide/file_formats/plan.md)
     - [MAVLink Logs](qgc-dev-guide/file_formats/mavlink.md)
+    - [Settings Override Files](qgc-dev-guide/file_formats/settings_override.md)
   - [Developer Tools](qgc-dev-guide/tools/index.md)
     - [Mock Link](qgc-dev-guide/tools/mock_link.md)
   - [Command Line Options](qgc-dev-guide/command_line_options.md)

--- a/docs/en/qgc-dev-guide/file_formats/settings_override.md
+++ b/docs/en/qgc-dev-guide/file_formats/settings_override.md
@@ -1,0 +1,121 @@
+# Settings Override Files
+
+Settings override files let you change the metadata and values of _QGroundControl_ application settings without creating a custom build. You can use them to:
+
+- Change the default value for a setting
+- Force a setting to a specific value and hide it from the user
+- Hide individual settings from the Settings UI
+- Adjust setting metadata such as min/max ranges, decimal places, descriptions, and enum/bitmask choices
+
+Override files are loaded once at application startup.
+
+## File Location
+
+_QGroundControl_ scans the `Settings` subdirectory of the [Application Load/Save Path](../../qgc-user-guide/settings_view/general.md) (for example `~/Documents/QGroundControl/Settings`) for files with a `.settings` extension. Every matching file is loaded in case-insensitive alphabetical order by filename. If multiple files override the same setting, the last one loaded (alphabetically latest) wins.
+
+## File Format
+
+A settings override file is a JSON file with the following structure:
+
+```json
+{
+    "version": 1,
+    "fileType": "Settings",
+    "groups": {
+        "groupName": {
+            "settingName": {
+                "overrideKey": "overrideValue"
+            }
+        }
+    }
+}
+```
+
+- `version` — Must be `1`.
+- `fileType` — Must be `"Settings"`.
+- `groups` — An object keyed by settings group name. Each group contains one object per setting to override, keyed by setting name.
+
+### Group and Setting Names
+
+The group name is the `settingsGroup` value used by the corresponding `SettingsGroup` subclass in the source code (the group used for `QSettings` storage). Examples: `FlyView`, `PlanView`, `Video`, `AutoConnect`, `RTK`, `Units`. Note that top-level application settings (`AppSettings`) and MAVLink settings (`MavlinkSettings`) use an empty group name: `""`.
+
+Setting names are the fact names defined in the `*.SettingsGroup.json` metadata files found in [src/Settings](https://github.com/mavlink/qgroundcontrol/tree/master/src/Settings). For example `FlyView.SettingsGroup.json` contains the setting names available in the `FlyView` group.
+
+### Supported Override Keys
+
+| Key | Description |
+| --- | ----------- |
+| `forceRawValue` | Forces the setting to the specified value and hides it from the Settings UI. May not be combined with `visible`. |
+| `visible` | Set to `false` to hide the setting from the Settings UI. May not be combined with `forceRawValue`. |
+| `default` | Changes the default value for the setting. Unlike `forceRawValue` the user can still change the value. |
+| `min` | Changes the minimum allowed value. |
+| `max` | Changes the maximum allowed value. |
+| `decimalPlaces` | Changes the number of decimal places shown. |
+| `shortDesc` | Changes the short description (label). |
+| `longDesc` | Changes the long description (tooltip). |
+| `enumValues` / `enumStrings` | Replaces the enum choices for the setting. |
+| `bitmask` | Replaces the bitmask choices for the setting. |
+
+These are the same key names used by the Fact metadata JSON format ([src/Settings/*.SettingsGroup.json](https://github.com/mavlink/qgroundcontrol/tree/master/src/Settings)). Keys other than those listed above are not supported — specifying an unknown key causes the entire override for that setting to be ignored, with a warning in the console log. The same applies to combining `forceRawValue` and `visible` in the same override. The `name` and `type` keys must not be specified — they are taken from the existing setting.
+
+Override values are converted to the setting's underlying Fact type as declared in its `*.SettingsGroup.json` metadata (for example a number for `uint32`/`double` settings, `true`/`false` for `bool` settings). For enum settings, `forceRawValue` and `default` take the raw enum value — an entry from the setting's `enumValues` list — not the index or display string.
+
+### Enum and Bitmask Overrides
+
+Enum and bitmask overrides replace the full choice list — partial overrides (for example renaming a single entry) are not supported. The formats are the same as the Fact metadata JSON:
+
+- `enumStrings` / `enumValues` — A pair of comma-separated strings which must be specified together and contain the same number of entries. `enumStrings` holds the display labels, `enumValues` the corresponding raw values:
+
+  ```json
+  "someEnumSetting": {
+      "enumStrings": "Low,Medium,High",
+      "enumValues": "0,1,2"
+  }
+  ```
+
+- `bitmask` — An array of objects, each with a `description` (display label) and an `index` (bit index, not the mask value — bit index `n` corresponds to raw value `1 << n`):
+
+  ```json
+  "someBitmaskSetting": {
+      "bitmask": [
+          { "description": "Option A", "index": 0 },
+          { "description": "Option B", "index": 1 }
+      ]
+  }
+  ```
+
+## Example
+
+The following file forces the video decoder setting to a specific value and hides it, hides the virtual joystick setting (which lives in the top-level application group `""`), and changes the default guided minimum altitude:
+
+```json
+{
+    "version": 1,
+    "fileType": "Settings",
+    "groups": {
+        "Video": {
+            "forceVideoDecoder": {
+                "forceRawValue": 0
+            }
+        },
+        "": {
+            "virtualJoystick": {
+                "visible": false
+            }
+        },
+        "FlyView": {
+            "guidedMinimumAltitude": {
+                "default": 5
+            }
+        }
+    }
+}
+```
+
+## Debugging
+
+Enable the `SettingsManagerLog` logging category ([Console Logging](../../qgc-user-guide/settings_view/console_logging.md)) to see which override files are loaded and which overrides are applied at startup.
+
+## Related Mechanisms
+
+Custom builds can achieve the same result in code by overriding `QGCCorePlugin::adjustSettingMetaData` — see [Custom Build Plugins](../custom_build/plugins.md). Settings file overrides are applied first, then the core plugin gets a chance to adjust the metadata.

--- a/docs/en/qgc-user-guide/getting_started/whats_new.md
+++ b/docs/en/qgc-user-guide/getting_started/whats_new.md
@@ -114,6 +114,11 @@ Settings are organized into collapsible sections with consistent layout.
 
 New and updated MAVLink Actions support in Fly View settings.
 
+### Settings Override Files
+
+Application settings can now be overridden using [Settings Override Files](../../qgc-dev-guide/file_formats/settings_override.md) placed in the `Settings` subdirectory of the [Application Load/Save Path](../settings_view/general.md#load_save_path).
+These JSON files can change setting defaults, force settings to fixed values, hide settings from the UI, and adjust metadata such as min/max ranges — without requiring a custom build.
+
 ### Virtual Joystick
 
 Virtual Joystick now supports left-handed mode.

--- a/src/Settings/SettingsManager.cc
+++ b/src/Settings/SettingsManager.cc
@@ -225,41 +225,60 @@ void SettingsManager::adjustSettingMetaData(const QString &settingsGroup, FactMe
 
             qCDebug(SettingsManagerLog) << "Applying settings file override for" << settingsGroup << metaData.name();
 
-            QScopedPointer<FactMetaData> overrideMetaData(FactMetaData::createFromJsonObject(settingOverrideJsonObject, {}, nullptr));
+            // Strip SettingsManager-level keys which are not valid Fact metadata keys. Otherwise strict key
+            // validation in createFromJsonObject fails and returns default metadata, corrupting the overrides below.
+            QJsonObject factMetaDataJsonObject = settingOverrideJsonObject;
+            factMetaDataJsonObject.remove(kJsonVisibleKey);
+            factMetaDataJsonObject.remove(kJsonForceRawValueKey);
 
-            // Apply overrides
-            for (const QString &metaDataName : settingOverrideJsonObject.keys()) {
-                if (metaDataName == kJsonVisibleKey) {
-                    qCDebug(SettingsManagerLog) << "  Setting visibility to" << settingOverrideJsonObject[kJsonVisibleKey].toBool();
-                    userVisible = settingOverrideJsonObject[kJsonVisibleKey].toBool();
-                } else if (metaDataName == kJsonForceRawValueKey) {
+            QScopedPointer<FactMetaData> overrideMetaData(FactMetaData::createFromJsonObject(factMetaDataJsonObject, {}, nullptr));
+
+            if (settingOverrideJsonObject.contains(kJsonForceRawValueKey) && settingOverrideJsonObject.contains(kJsonVisibleKey)) {
+                // A visible setting reads its value from QSettings which defeats forceRawValue
+                qCWarning(SettingsManagerLog) << "Ignoring settings file override which combines 'forceRawValue' and 'visible' keys:" << settingsGroup << metaData.name();
+            } else if (overrideMetaData->name() != metaData.name()) {
+                // createFromJsonObject failed validation (it already logged why) and returned default metadata.
+                // Don't apply any part of a bad override.
+                qCWarning(SettingsManagerLog) << "Ignoring settings file override which failed validation:" << settingsGroup << metaData.name();
+            } else {
+                // Apply Fact metadata overrides
+                for (const QString &metaDataName : factMetaDataJsonObject.keys()) {
+                    if (metaDataName == FactMetaData::_defaultValueJsonKey) {
+                        qCDebug(SettingsManagerLog) << "  Setting default to" << overrideMetaData->rawDefaultValue();
+                        metaData.setRawDefaultValue(overrideMetaData->rawDefaultValue());
+                    } else if (metaDataName == FactMetaData::_minJsonKey) {
+                        qCDebug(SettingsManagerLog) << "  Setting min to" << overrideMetaData->rawMin();
+                        metaData.setRawMin(overrideMetaData->rawMin());
+                    } else if (metaDataName == FactMetaData::_maxJsonKey) {
+                        qCDebug(SettingsManagerLog) << "  Setting max to" << overrideMetaData->rawMax();
+                        metaData.setRawMax(overrideMetaData->rawMax());
+                    } else if (metaDataName == FactMetaData::_decimalPlacesJsonKey) {
+                        qCDebug(SettingsManagerLog) << "  Setting decimalPlaces to" << overrideMetaData->decimalPlaces();
+                        metaData.setDecimalPlaces(overrideMetaData->decimalPlaces());
+                    } else if (metaDataName == FactMetaData::_enumValuesJsonKey) {
+                        qCDebug(SettingsManagerLog) << "  Setting enumInfo to" << overrideMetaData->enumValues() << overrideMetaData->enumStrings();
+                        metaData.setEnumInfo(overrideMetaData->enumStrings(), overrideMetaData->enumValues());
+                    } else if (metaDataName == FactMetaData::_enumBitmaskArrayJsonKey) {
+                        qCDebug(SettingsManagerLog) << "  Setting bitmaskInfo to" << overrideMetaData->bitmaskValues() << overrideMetaData->bitmaskStrings();
+                        metaData.setBitmaskInfo(overrideMetaData->bitmaskStrings(), overrideMetaData->bitmaskValues());
+                    } else if (metaDataName == FactMetaData::_longDescriptionJsonKey) {
+                        qCDebug(SettingsManagerLog) << "  Setting longDesc to" << overrideMetaData->longDescription();
+                        metaData.setLongDescription(overrideMetaData->longDescription());
+                    } else if (metaDataName == FactMetaData::_shortDescriptionJsonKey) {
+                        qCDebug(SettingsManagerLog) << "  Setting shortDesc to" << overrideMetaData->shortDescription();
+                        metaData.setShortDescription(overrideMetaData->shortDescription());
+                    }
+                }
+
+                // Apply SettingsManager-level overrides last so forceRawValue wins over a default override
+                if (settingOverrideJsonObject.contains(kJsonForceRawValueKey)) {
                     qCDebug(SettingsManagerLog) << "  Setting forceRawValue to" << settingOverrideJsonObject[kJsonForceRawValueKey];
                     metaData.setRawDefaultValue(settingOverrideJsonObject[kJsonForceRawValueKey].toVariant());
                     userVisible = false;
-                } else if (metaDataName == FactMetaData::_defaultValueJsonKey) {
-                    qCDebug(SettingsManagerLog) << "  Setting default to" << overrideMetaData->rawDefaultValue();
-                    metaData.setRawDefaultValue(overrideMetaData->rawDefaultValue());
-                } else if (metaDataName == FactMetaData::_minJsonKey) {
-                    qCDebug(SettingsManagerLog) << "  Setting min to" << overrideMetaData->rawMin();
-                    metaData.setRawMin(overrideMetaData->rawMin());
-                } else if (metaDataName == FactMetaData::_maxJsonKey) {
-                    qCDebug(SettingsManagerLog) << "  Setting max to" << overrideMetaData->rawMax();
-                    metaData.setRawMax(overrideMetaData->rawMax());
-                } else if (metaDataName == FactMetaData::_decimalPlacesJsonKey) {
-                    qCDebug(SettingsManagerLog) << "  Setting decimalPlaces to" << overrideMetaData->decimalPlaces();
-                    metaData.setDecimalPlaces(overrideMetaData->decimalPlaces());
-                } else if (metaDataName == FactMetaData::_enumValuesJsonKey) {
-                    qCDebug(SettingsManagerLog) << "  Setting enumInfo to" << overrideMetaData->enumValues() << overrideMetaData->enumStrings();
-                    metaData.setEnumInfo(overrideMetaData->enumStrings(), overrideMetaData->enumValues());
-                } else if (metaDataName == FactMetaData::_enumBitmaskArrayJsonKey) {
-                    qCDebug(SettingsManagerLog) << "  Setting bitmaskInfo to" << overrideMetaData->bitmaskValues() << overrideMetaData->bitmaskStrings();
-                    metaData.setBitmaskInfo(overrideMetaData->bitmaskStrings(), overrideMetaData->bitmaskValues());
-                } else if (metaDataName == FactMetaData::_longDescriptionJsonKey) {
-                    qCDebug(SettingsManagerLog) << "  Setting longDesc to" << overrideMetaData->longDescription();
-                    metaData.setLongDescription(overrideMetaData->longDescription());
-                } else if (metaDataName == FactMetaData::_shortDescriptionJsonKey) {
-                    qCDebug(SettingsManagerLog) << "  Setting shortDesc to" << overrideMetaData->shortDescription();
-                    metaData.setShortDescription(overrideMetaData->shortDescription());
+                }
+                if (settingOverrideJsonObject.contains(kJsonVisibleKey)) {
+                    qCDebug(SettingsManagerLog) << "  Setting visibility to" << settingOverrideJsonObject[kJsonVisibleKey].toBool();
+                    userVisible = settingOverrideJsonObject[kJsonVisibleKey].toBool();
                 }
             }
         }


### PR DESCRIPTION
Fixes #13555

## Summary

- Adds a new dev-guide page documenting the Settings Override Files format: file location and load order, JSON structure, group/setting naming, supported override keys, value typing, and enum/bitmask override formats with examples.
- Adds the page to the docs sidebar (SUMMARY.md).
- Adds a What's New entry linking to the new page and the Application Load/Save Path setting.
- Fixes a bug found while verifying the documented behavior: `visible`/`forceRawValue` are SettingsManager-level keys, not Fact metadata keys, so passing them to `FactMetaData::createFromJsonObject` failed strict key validation. This returned default metadata and silently corrupted any `default`/`min`/`max`/enum/description overrides combined with those keys in the same setting override. They are now stripped before metadata parsing and applied explicitly after the metadata overrides, preserving the original precedence (`forceRawValue` wins over `default`, `visible` applied last).

Documented behavior was verified against `SettingsManager.cc` and `FactMetaData.cc` (alphabetical load order, raw enum value semantics, bitmask bit-index encoding).