### PR TITLE
fix(ci): replace broken sudo retry and cache apt downloads on Linux

### DIFF
--- a/.github/actions/install-dependencies/action.yml
+++ b/.github/actions/install-dependencies/action.yml
@@ -80,23 +80,42 @@ runs:
       shell: bash
       run: python3 "${GITHUB_WORKSPACE}/.github/scripts/install_dependencies_helper.py" enable-universe
 
+    # Cache downloaded .debs so slow apt mirrors only hurt on a cache miss.
+    # Keyed on the package-list sources plus a year-month stamp: actions/cache
+    # never re-saves on an exact key hit, so without the stamp the cache would
+    # go stale as noble-updates bumps package versions. The cache is saved by
+    # the post step even if the install step fails (see the chown note there).
+    - name: Compute apt cache stamps (Linux)
+      if: runner.os == 'Linux'
+      id: apt-cache-stamp
+      shell: bash
+      # The distro stamp (e.g. ubuntu-24.04) segregates caches per runner image:
+      # this action runs on multiple Ubuntu versions whose .debs don't overlap.
+      run: |
+        echo "month=$(date -u +%Y-%m)" >> "${GITHUB_OUTPUT}"
+        echo "distro=$(. /etc/os-release && echo "${ID}-${VERSION_ID}")" >> "${GITHUB_OUTPUT}"
+
+    - name: Restore apt download cache (Linux)
+      if: runner.os == 'Linux'
+      uses: actions/cache@v5
+      with:
+        path: ~/.cache/qgc-apt-archives
+        key: apt-debs-${{ steps.apt-cache-stamp.outputs.distro }}-${{ runner.arch }}-${{ steps.apt-cache-stamp.outputs.month }}-${{ hashFiles('tools/setup/install_dependencies/_packages.py', 'tools/setup/install_dependencies/_debian.py') }}
+        restore-keys: |
+          apt-debs-${{ steps.apt-cache-stamp.outputs.distro }}-${{ runner.arch }}-${{ steps.apt-cache-stamp.outputs.month }}-
+          apt-debs-${{ steps.apt-cache-stamp.outputs.distro }}-${{ runner.arch }}-
+
     - name: Install apt packages (Linux)
       if: runner.os == 'Linux'
-      # Retry: a slow apt mirror can stall the download past the job timeout; fast-fail and retry.
-      uses: nick-fields/retry@v4
+      shell: bash
       env:
         APT_PACKAGES: ${{ steps.linux-deps.outputs.packages }}
-      with:
-        timeout_minutes: 20
-        max_attempts: 3
-        shell: bash
-        # Acquire::*::Timeout aborts a stalled mirror connection so retries can fire.
-        command: |
-          APT_OPTS="-o Acquire::Retries=3 -o Acquire::http::Timeout=30 -o Acquire::https::Timeout=30"
-          # shellcheck disable=SC2086
-          sudo apt-get $APT_OPTS update -qq
-          # shellcheck disable=SC2086
-          sudo apt-get $APT_OPTS install -y --no-install-recommends $APT_PACKAGES
+      # Retry/cache/timeout rationale lives in .github/scripts/apt_install_retry.sh,
+      # which downloads .debs into the cached directory restored above.
+      run: |
+        read -ra packages <<< "${APT_PACKAGES}"
+        "${GITHUB_WORKSPACE}/.github/scripts/apt_install_retry.sh" \
+          --update --no-install-recommends --autoclean "${packages[@]}"
 
     - name: Fix apt alternatives (Linux)
       if: runner.os == 'Linux'
@@ -115,16 +134,17 @@ runs:
 
     - name: Install extra packages (Linux)
       if: runner.os == 'Linux' && inputs.extra-packages != ''
-      uses: nick-fields/retry@v4
+      shell: bash
       env:
         EXTRA_PACKAGES: ${{ inputs.extra-packages }}
-      with:
-        timeout_minutes: 5
-        max_attempts: 3
-        command: |
-          validated="$(python3 tools/setup/install_dependencies --validate-extra-packages $EXTRA_PACKAGES)"
-          # shellcheck disable=SC2086
-          sudo apt-get install -y $validated
+      # Same retry/cache helper as "Install apt packages" above; shorter install
+      # timeout since this only ever installs a handful of small packages.
+      run: |
+        read -ra extra <<< "${EXTRA_PACKAGES}"
+        validated="$(python3 tools/setup/install_dependencies --validate-extra-packages "${extra[@]}")"
+        read -ra packages <<< "${validated}"
+        "${GITHUB_WORKSPACE}/.github/scripts/apt_install_retry.sh" \
+          --install-timeout 300 --label "extra apt packages" "${packages[@]}"
 
     - name: Install dependencies (macOS)
       if: runner.os == 'macOS'

--- a/.github/scripts/apt_install_retry.sh
+++ b/.github/scripts/apt_install_retry.sh
@@ -1,0 +1,95 @@
+#!/usr/bin/env bash
+#
+# Retry-wrapped apt-get install that downloads .debs into the cached archive
+# directory (~/.cache/qgc-apt-archives, saved/restored by actions/cache in
+# .github/actions/install-dependencies/action.yml).
+#
+# Slow apt mirrors can stall downloads past any reasonable budget. A
+# shell-level retry loop with `timeout` is used instead of nick-fields/retry:
+# that action cannot kill a root-owned (sudo) process on timeout
+# ("Error: kill EPERM"), which turns a stalled attempt into a hard step
+# failure with no retry. Acquire::*::Timeout aborts stalled mirror
+# connections; `timeout` under sudo runs as root and can reliably kill apt.
+#
+# Usage: apt_install_retry.sh [options] PACKAGE...
+#   --update                  run apt-get update before each install attempt
+#   --no-install-recommends   pass --no-install-recommends to apt-get install
+#   --autoclean               prune superseded .debs from the cache dir afterwards
+#   --install-timeout SECS    per-attempt install timeout (default: 1200)
+#   --label NAME              label used in warning/error annotations
+set -euo pipefail
+
+MAX_ATTEMPTS=3
+UPDATE_TIMEOUT=300   # seconds per apt-get update attempt
+INSTALL_TIMEOUT=1200 # seconds per apt-get install attempt (~80 min worst case over 3 attempts incl. update timeouts, kill grace, and backoff)
+KILL_GRACE=30        # SIGKILL grace period after SIGTERM
+
+run_update=false
+autoclean=false
+label="apt packages"
+install_args=()
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --update) run_update=true; shift ;;
+    --no-install-recommends) install_args+=(--no-install-recommends); shift ;;
+    --autoclean) autoclean=true; shift ;;
+    --install-timeout) INSTALL_TIMEOUT="$2"; shift 2 ;;
+    --label) label="$2"; shift 2 ;;
+    --) shift; break ;;
+    -*) echo "::error::unknown option: $1" >&2; exit 2 ;;
+    *) break ;;
+  esac
+done
+packages=("$@")
+if [[ ${#packages[@]} -eq 0 ]]; then
+  echo "::error::no packages given to $(basename "$0")" >&2
+  exit 2
+fi
+
+APT_CACHE_DIR="${HOME}/.cache/qgc-apt-archives"
+mkdir -p "${APT_CACHE_DIR}"
+sudo mkdir -p "${APT_CACHE_DIR}/partial"
+# Match the stock /var/cache/apt/archives layout (partial/ is _apt:root 0700):
+# APT downloads via the _apt sandbox user, and a root-owned 0755 partial/ would
+# force noisy "unsandboxed as root" fallback downloads.
+if id _apt &> /dev/null; then
+  sudo chown _apt:root "${APT_CACHE_DIR}/partial"
+fi
+sudo chmod 700 "${APT_CACHE_DIR}/partial"
+APT_OPTS=(
+  -o Acquire::Retries=3
+  -o Acquire::http::Timeout=30
+  -o Acquire::https::Timeout=30
+  -o DPkg::Lock::Timeout=300
+  -o "Dir::Cache::Archives=${APT_CACHE_DIR}"
+  -o APT::Keep-Downloaded-Packages=true
+)
+
+ok=false
+for attempt in $(seq 1 "${MAX_ATTEMPTS}"); do
+  if { [[ "${run_update}" != "true" ]] ||
+       sudo timeout -k "${KILL_GRACE}" "${UPDATE_TIMEOUT}" apt-get "${APT_OPTS[@]}" update -qq; } &&
+     sudo timeout -k "${KILL_GRACE}" "${INSTALL_TIMEOUT}" apt-get "${APT_OPTS[@]}" install -y "${install_args[@]}" "${packages[@]}"; then
+    ok=true
+    break
+  fi
+  echo "::warning::${label} install attempt ${attempt} failed (stall/timeout or error); retrying"
+  sleep $((attempt * 15))
+done
+
+if [[ "${autoclean}" == "true" ]]; then
+  # Prune superseded .deb versions so the cached directory doesn't grow unboundedly.
+  sudo apt-get "${APT_OPTS[@]}" autoclean -qq || true
+fi
+
+# Drop root-owned bits so actions/cache (runner user) can save the directory.
+# Keep this BEFORE the failure check: the cache post step saves even when the
+# calling step fails, letting a retried job reuse already-downloaded .debs.
+sudo rm -rf "${APT_CACHE_DIR}/partial"
+sudo chown -R "$(id -u):$(id -g)" "${APT_CACHE_DIR}"
+
+if [[ "${ok}" != "true" ]]; then
+  echo "::error::${label} installation failed after ${MAX_ATTEMPTS} attempts"
+  exit 1
+fi


### PR DESCRIPTION
## Problem

The Linux `Install Dependencies` step has been failing intermittently across PRs and master pushes, most often on the `Release linux_gcc_arm64` job (e.g. run 29971380517).

Root cause, confirmed from the failed-step logs:

1. apt needs ~428 packages / 236 MB. During slow-mirror periods on `ports.ubuntu.com` the download exceeds the 20-minute per-attempt timeout of `nick-fields/retry`.
2. On timeout, `nick-fields/retry` crashes with `Error: kill EPERM` — it cannot kill the root-owned (`sudo`) apt process — so the configured 3-attempt retry never fires and the step hard-fails on the first stall.

## Fix

- **Working retries**: replace `nick-fields/retry` with a retry loop in a shared helper script (`.github/scripts/apt_install_retry.sh`) using `sudo timeout -k`, which runs as root and can reliably kill a stalled apt. 3 attempts with backoff; named timeout constants (`UPDATE_TIMEOUT=300`, `INSTALL_TIMEOUT=1200`, `KILL_GRACE=30`) keep worst case ~80 min under the 120-min job budget.
- **apt download cache**: `actions/cache` on `~/.cache/qgc-apt-archives` (apt pointed there via `Dir::Cache::Archives` + `Keep-Downloaded-Packages=true`), keyed on the distro (`/etc/os-release` ID + VERSION_ID), arch, package-list sources, and a year-month stamp (actions/cache never re-saves on an exact key hit, so the stamp prevents staleness as noble-updates churns versions). `apt-get autoclean` prunes superseded .debs before save. Cleanup/chown runs before the failure check so a failed run's downloads are still saved for the retried job.
- Same helper used by the `extra-packages` step (same sudo/EPERM issue), so its downloads land in the cache too. `partial/` is set up as `_apt:root` 0700 to keep APT's download sandbox working, and `DPkg::Lock::Timeout=300` tolerates transient dpkg locks. Windows/macOS steps are untouched (no sudo, bug does not apply).

## Testing

- `check-yaml` and `zizmor` pre-commit hooks pass; all embedded scripts pass `bash -n`.
- Watch the Linux workflow on this PR: first run populates the cache; subsequent runs should show Install Dependencies at ~1–2 min on cache hit.
