### PR TITLE
fix(Comms): replay tlogs with uninterpretable trailing bytes

### DIFF
--- a/src/Comms/LogReplayLink.cc
+++ b/src/Comms/LogReplayLink.cc
@@ -379,8 +379,8 @@ quint64 LogReplayWorker::_findLastTimestamp()
 
     quint64 lastTimestamp = 0;
 
-    while (_logFile.bytesAvailable() > static_cast<qint64>(kTimestamp)) {
-        lastTimestamp = _parseTimestamp(_logFile.read(kTimestamp));
+    while (_logFile.bytesAvailable() >= static_cast<qint64>(kTimestamp)) {
+        const quint64 candidateTimestamp = _parseTimestamp(_logFile.read(kTimestamp));
 
         bool endOfMessage = false;
         char nextByte;
@@ -389,6 +389,21 @@ quint64 LogReplayWorker::_findLastTimestamp()
             mavlink_status_t status{};
             endOfMessage = mavlink_parse_char(_mavlinkChannel, nextByte, &msg, &status);
         }
+
+        if (!endOfMessage) {
+            if (lastTimestamp != 0) {
+                // Trailing bytes which don't form a complete MAVLink message (e.g. the log was not
+                // closed cleanly due to a crash or power loss). Ignore them and keep the timestamp
+                // of the last complete message.
+                qCWarning(LogReplayLinkLog)
+                    << "Ignoring trailing bytes at end of log file which do not form a complete MAVLink message";
+            } else {
+                qCWarning(LogReplayLinkLog) << "No complete MAVLink message found in log file";
+            }
+            break;
+        }
+
+        lastTimestamp = candidateTimestamp;
     }
 
     return lastTimestamp;

--- a/test/Comms/CMakeLists.txt
+++ b/test/Comms/CMakeLists.txt
@@ -11,6 +11,8 @@ target_sources(${CMAKE_PROJECT_NAME}
         LinkManagerTest.h
         LogReplayLinkControllerTest.cc
         LogReplayLinkControllerTest.h
+        LogReplayLinkTest.cc
+        LogReplayLinkTest.h
         MAVLinkV1TrafficTest.cc
         MAVLinkV1TrafficTest.h
         QGCSerialPortInfoTest.cc
@@ -24,5 +26,6 @@ add_subdirectory(Bluetooth)
 add_qgc_test(LinkConfigurationTest LABELS Unit Comms RESOURCE_LOCK Settings TempFiles)
 add_qgc_test(LinkManagerTest LABELS Integration Comms SERIAL)
 add_qgc_test(LogReplayLinkControllerTest LABELS Unit Comms)
+add_qgc_test(LogReplayLinkTest LABELS Unit Comms)
 add_qgc_test(MAVLinkV1TrafficTest LABELS Integration Comms)
 add_qgc_test(QGCSerialPortInfoTest LABELS Unit Comms)

--- a/test/Comms/LogReplayLinkTest.cc
+++ b/test/Comms/LogReplayLinkTest.cc
@@ -1,0 +1,170 @@
+#include "LogReplayLinkTest.h"
+
+#include <QtCore/QFile>
+#include <QtCore/QRegularExpression>
+#include <QtCore/QtEndian>
+#include <QtTest/QSignalSpy>
+#include <QtTest/QTest>
+
+#include "LogReplayLink.h"
+#include "MAVLinkLib.h"
+
+namespace {
+
+/// Returns a valid tlog stream: cMessages HEARTBEATs, each preceded by a big-endian
+/// microsecond timestamp, spaced one second apart starting at baseTimeUSecs.
+QByteArray buildTlogBytes(int cMessages, quint64 baseTimeUSecs)
+{
+    QByteArray tlog;
+
+    for (int i = 0; i < cMessages; i++) {
+        const quint64 timestampUSecs = qToBigEndian<quint64>(baseTimeUSecs + (i * 1000000ULL));
+        (void) tlog.append(reinterpret_cast<const char*>(&timestampUSecs), sizeof(timestampUSecs));
+
+        mavlink_message_t msg{};
+        (void) mavlink_msg_heartbeat_pack(1, MAV_COMP_ID_AUTOPILOT1, &msg, MAV_TYPE_QUADROTOR, MAV_AUTOPILOT_PX4, 0, 0,
+                                          MAV_STATE_ACTIVE);
+
+        uint8_t buffer[MAVLINK_MAX_PACKET_LEN]{};
+        const int cBuffer = mavlink_msg_to_send_buffer(buffer, &msg);
+        (void) tlog.append(reinterpret_cast<const char*>(buffer), cBuffer);
+    }
+
+    return tlog;
+}
+
+}  // namespace
+
+QString LogReplayLinkTest::_writeLogFile(const QByteArray& contents)
+{
+    if (!_tempDir.isValid()) {
+        qCritical() << "Temp dir invalid:" << _tempDir.errorString();
+        return QString();
+    }
+
+    const QString filename = _tempDir.filePath(QStringLiteral("%1.tlog").arg(QTest::currentTestFunction()));
+
+    QFile file(filename);
+    if (!file.open(QFile::WriteOnly)) {
+        qCritical() << "Failed to open" << filename << ":" << file.errorString();
+        return QString();
+    }
+    if (file.write(contents) != contents.size()) {
+        qCritical() << "Short write to" << filename << ":" << file.errorString();
+        return QString();
+    }
+
+    return filename;
+}
+
+void LogReplayLinkTest::_testCleanLogLoads()
+{
+    const quint64 baseTimeUSecs = 1700000000000000ULL;
+    const QString filename = _writeLogFile(buildTlogBytes(3, baseTimeUSecs));
+    QVERIFY(!filename.isEmpty());
+
+    LogReplayConfiguration config(QStringLiteral("LogReplayLinkTest"));
+    config.setLogFilename(filename);
+
+    LogReplayWorker worker(&config);
+    worker.setup();
+
+    QSignalSpy connectedSpy(&worker, &LogReplayWorker::connected);
+    QSignalSpy errorSpy(&worker, &LogReplayWorker::errorOccurred);
+    QSignalSpy statsSpy(&worker, &LogReplayWorker::logFileStats);
+
+    worker.connectToLog();
+
+    QCOMPARE(errorSpy.count(), 0);
+    QCOMPARE(connectedSpy.count(), 1);
+    QCOMPARE(statsSpy.count(), 1);
+    QCOMPARE(statsSpy.first().first().toUInt(), 2u);  // 3 messages, 1 second apart
+
+    worker.pause();
+    worker.disconnectFromLog();
+}
+
+void LogReplayLinkTest::_testTrailingBytesIgnored_data()
+{
+    QTest::addColumn<int>("cTrailingBytes");
+    QTest::addColumn<bool>("expectWarning");
+
+    // Trailing junk smaller than the 8 byte timestamp is never read (loop condition), so no warning.
+    // Anything at least timestamp-sized is read as a candidate timestamp, detected as incomplete
+    // and warned about.
+    QTest::newRow("1 byte") << 1 << false;
+    QTest::newRow("7 bytes") << 7 << false;
+    QTest::newRow("8 bytes (timestamp size)") << 8 << true;
+    QTest::newRow("9 bytes") << 9 << true;
+    QTest::newRow("100 bytes") << 100 << true;
+}
+
+void LogReplayLinkTest::_testTrailingBytesIgnored()
+{
+    QFETCH(int, cTrailingBytes);
+    QFETCH(bool, expectWarning);
+
+    // Issue #14210: a log which was not closed cleanly (crash/power loss) can end with
+    // trailing bytes which are not part of any MAVLink message. Those bytes must be
+    // ignored rather than failing the load with a corrupt file error.
+    const quint64 baseTimeUSecs = 1700000000000000ULL;
+    QByteArray tlog = buildTlogBytes(3, baseTimeUSecs);
+    (void) tlog.append(QByteArray(cTrailingBytes, '\0'));
+
+    const QString filename = _writeLogFile(tlog);
+    QVERIFY(!filename.isEmpty());
+
+    LogReplayConfiguration config(QStringLiteral("LogReplayLinkTest"));
+    config.setLogFilename(filename);
+
+    LogReplayWorker worker(&config);
+    worker.setup();
+
+    QSignalSpy connectedSpy(&worker, &LogReplayWorker::connected);
+    QSignalSpy errorSpy(&worker, &LogReplayWorker::errorOccurred);
+    QSignalSpy statsSpy(&worker, &LogReplayWorker::logFileStats);
+
+    if (expectWarning) {
+        expectLogMessage("Comms.LogReplayLink", QtWarningMsg,
+                         QRegularExpression(QStringLiteral("Ignoring trailing bytes")));
+    }
+    worker.connectToLog();
+    if (expectWarning) {
+        verifyExpectedLogMessage();
+    }
+
+    QCOMPARE(errorSpy.count(), 0);
+    QCOMPARE(connectedSpy.count(), 1);
+    QCOMPARE(statsSpy.count(), 1);
+    QCOMPARE(statsSpy.first().first().toUInt(), 2u);  // trailing bytes must not affect duration
+
+    worker.pause();
+    worker.disconnectFromLog();
+}
+
+void LogReplayLinkTest::_testGarbageOnlyLogFails()
+{
+    // A log without any complete MAVLink message must still be rejected as corrupt.
+    const QString filename = _writeLogFile(QByteArray(100, '\0'));
+    QVERIFY(!filename.isEmpty());
+
+    LogReplayConfiguration config(QStringLiteral("LogReplayLinkTest"));
+    config.setLogFilename(filename);
+
+    LogReplayWorker worker(&config);
+    worker.setup();
+
+    QSignalSpy connectedSpy(&worker, &LogReplayWorker::connected);
+    QSignalSpy errorSpy(&worker, &LogReplayWorker::errorOccurred);
+
+    expectLogMessage("Comms.LogReplayLink", QtWarningMsg,
+                     QRegularExpression(QStringLiteral("No complete MAVLink message found")));
+    worker.connectToLog();
+    verifyExpectedLogMessage();
+
+    QCOMPARE(connectedSpy.count(), 0);
+    QCOMPARE(errorSpy.count(), 1);
+    QVERIFY(errorSpy.first().first().toString().contains(QStringLiteral("corrupt or empty")));
+}
+
+UT_REGISTER_TEST(LogReplayLinkTest, TestLabel::Unit, TestLabel::Comms)

--- a/test/Comms/LogReplayLinkTest.h
+++ b/test/Comms/LogReplayLinkTest.h
@@ -1,0 +1,25 @@
+#pragma once
+
+#include <QtCore/QByteArray>
+#include <QtCore/QString>
+#include <QtCore/QTemporaryDir>
+
+#include "UnitTest.h"
+
+/// Tests for LogReplayWorker tlog file loading. Logs with uninterpretable trailing
+/// bytes (e.g. not closed cleanly due to crash/power loss) must still replay (issue #14210).
+class LogReplayLinkTest : public UnitTest
+{
+    Q_OBJECT
+
+private slots:
+    void _testCleanLogLoads();
+    void _testTrailingBytesIgnored_data();
+    void _testTrailingBytesIgnored();
+    void _testGarbageOnlyLogFails();
+
+private:
+    QString _writeLogFile(const QByteArray& contents);
+
+    QTemporaryDir _tempDir;
+};


### PR DESCRIPTION
## Summary

A tlog which was not closed cleanly (e.g. crash or power loss on the logging device) can end with trailing bytes which are not part of any MAVLink message. `LogReplayWorker::_findLastTimestamp()` unconditionally consumed the next 8 bytes as a timestamp, so more than 8 bytes of trailing junk (e.g. zeros) overwrote the last valid timestamp with 0 and the load failed with **'The log file is corrupt or empty'**.

## Fix

Only commit a candidate timestamp once a complete MAVLink message has been parsed after it. Trailing bytes which don't form a complete message are ignored with a warning, and replay proceeds normally. Logs containing no complete MAVLink message at all are still rejected as corrupt (with a more accurate log message).

## Tests

New `LogReplayLinkTest` unit test exercising `LogReplayWorker` with generated heartbeat tlogs:
- clean log loads with correct duration
- data-driven trailing-junk rows (1, 7, 8, 9, 100 bytes) covering both sides of the 8-byte timestamp loop boundary — duration unaffected, warning only for >8 bytes (fails without the fix)
- all-garbage log still rejected as corrupt

Fixes #14210