### PR TITLE
fix(FactSystem): fall back to shortDescription/name when Fact label is empty

### DIFF
--- a/src/FactSystem/Fact.cc
+++ b/src/FactSystem/Fact.cc
@@ -534,7 +534,14 @@ QString Fact::shortDescription() const
 QString Fact::label() const
 {
     if (_metaData) {
-        return _metaData->label();
+        // Fall back for older metadata which is missing a label
+        if (!_metaData->label().isEmpty()) {
+            return _metaData->label();
+        }
+        if (!_metaData->shortDescription().isEmpty()) {
+            return _metaData->shortDescription();
+        }
+        return name();
     } else {
         qCWarning(FactLog) << kMissingMetadata << name();
         return QString();

--- a/test/FactSystem/FactTest.cc
+++ b/test/FactSystem/FactTest.cc
@@ -15,6 +15,25 @@ void FactTest::_constructWithTypeAndName_test()
     QCOMPARE(fact.type(), FactMetaData::valueTypeInt32);
 }
 
+void FactTest::_labelFallback_test()
+{
+    Fact fact(0, "FallbackParam", FactMetaData::valueTypeInt32);
+
+    auto *meta = fact.metaData();
+    QVERIFY(meta);
+
+    // No label, no short description -> falls back to name
+    QCOMPARE(fact.label(), QStringLiteral("FallbackParam"));
+
+    // No label, short description set -> falls back to short description
+    meta->setShortDescription("Short desc");
+    QCOMPARE(fact.label(), QStringLiteral("Short desc"));
+
+    // Label set -> returned as-is
+    meta->setLabel("The Label");
+    QCOMPARE(fact.label(), QStringLiteral("The Label"));
+}
+
 void FactTest::_setRawValueInt_test()
 {
     Fact fact(0, "IntParam", FactMetaData::valueTypeInt32);

--- a/test/FactSystem/FactTest.h
+++ b/test/FactSystem/FactTest.h
@@ -27,4 +27,5 @@ private slots:
     void _valueEqualsDefault_test();
     void _rawValueStringFullPrecisionFloat_test();
     void _rawValueStringFullPrecisionDouble_test();
+    void _labelFallback_test();
 };


### PR DESCRIPTION
Fixes item 5 of #14218

`Fact::label()` returned the raw metadata label, which can be empty for older JSON/C++ metadata that has not been updated with a `label` field, leaving blank labels in the UI.

Now falls back to `shortDescription()`, then `name()`, when the label is empty.

Includes a unit test (`FactTest::_labelFallback_test`) covering all three cases (test was written first and verified to fail before the fix).
