### PR TITLE
fix(params): improve feedback when loading parameter files

### DIFF
--- a/src/QmlControls/ParameterDiffDialog.qml
+++ b/src/QmlControls/ParameterDiffDialog.qml
@@ -23,9 +23,17 @@ QGCPopupDialog {
         QGCLabel {
             Layout.preferredWidth:  mainGrid.visible ? mainGrid.width : ScreenTools.defaultFontPixelWidth * 40
             wrapMode:               Text.WordWrap
-            text:                   paramController.diffList.count ?
-                                        qsTr("The following parameters from the loaded file differ from what is currently set on the Vehicle. Click 'Ok' to update them on the Vehicle.") :
-                                        qsTr("There are no differences between the file loaded and the current settings on the Vehicle.")
+            text:                   {
+                if (paramController.diffList.count > 0) {
+                    return qsTr("The following parameters from the loaded file differ from what is currently set on the Vehicle. Click 'Ok' to update them on the Vehicle.")
+                } else if (paramController.diffMissingCount > 0) {
+                    return qsTr("No differences found. %1 parameters from the file were not found on the vehicle (see console log for details).").arg(paramController.diffMissingCount)
+                } else if (paramController.diffUnchangedCount > 0) {
+                    return qsTr("All %1 parameters in the file already match the vehicle settings.").arg(paramController.diffUnchangedCount)
+                } else {
+                    return qsTr("There are no differences between the file loaded and the current settings on the Vehicle.")
+                }
+            }
         }
 
         GridLayout {

--- a/src/QmlControls/ParameterEditorController.cc
+++ b/src/QmlControls/ParameterEditorController.cc
@@ -363,10 +363,15 @@ void ParameterEditorController::clearDiff(void)
     _diffList.clearAndDeleteContents();
     _diffOtherVehicle = false;
     _diffMultipleComponents = false;
+    _diffUnchangedCount = 0;
+    _diffParsedCount = 0;
     _diffMissingParams.clear();
 
     emit diffOtherVehicleChanged(_diffOtherVehicle);
     emit diffMultipleComponentsChanged(_diffMultipleComponents);
+    emit diffUnchangedCountChanged(_diffUnchangedCount);
+    emit diffMissingCountChanged(0);
+    emit diffParsedCountChanged(_diffParsedCount);
 }
 
 void ParameterEditorController::sendDiff(void)
@@ -398,8 +403,9 @@ bool ParameterEditorController::buildDiffFromFile(const QString& filename)
 
     QTextStream stream(&file);
 
-    int parsedLineCount = 0;
     int firstComponentId = -1;
+
+    qCDebug(ParameterEditorControllerLog) << "Loading parameter file:" << filename;
     while (!stream.atEnd()) {
         QString line = stream.readLine();
         if (!line.startsWith("#") && !line.trimmed().isEmpty()) {
@@ -437,7 +443,7 @@ bool ParameterEditorController::buildDiffFromFile(const QString& filename)
                 continue;
             }
 
-            parsedLineCount++;
+            _diffParsedCount++;
 
             QString     vehicleValueStr;
             QString     units;
@@ -462,7 +468,14 @@ bool ParameterEditorController::buildDiffFromFile(const QString& filename)
                 vehicleFactMetaData->setVehicleRebootRequired(vehicleRebootRequired);
                 readOnly = vehicleFact->readOnly();
 
+                qCDebug(ParameterEditorControllerLog) << "Comparing param:" << paramName
+                    << "vehicleValue:" << vehicleFact->rawValue()
+                    << "fileValue:" << fileFact->rawValue()
+                    << "fileValueStr:" << fileValueStr;
+
                 if (vehicleFact->rawValue() == fileFact->rawValue()) {
+                    _diffUnchangedCount++;
+                    qCDebug(ParameterEditorControllerLog) << "Param unchanged:" << paramName;
                     continue;
                 }
                 fileValueStr    = fileFact->enumOrValueString();
@@ -471,9 +484,11 @@ bool ParameterEditorController::buildDiffFromFile(const QString& filename)
                 units           = vehicleFact->cookedUnits();
             } else if (isMPFormat) {
                 // MP format: skip params not on vehicle and report them
+                qCDebug(ParameterEditorControllerLog) << "Param not on vehicle (MP format):" << paramName;
                 _diffMissingParams.append(paramName);
                 continue;
             } else {
+                qCDebug(ParameterEditorControllerLog) << "Param not on vehicle (QGC format):" << paramName;
                 noVehicleValue = true;
             }
 
@@ -496,13 +511,22 @@ bool ParameterEditorController::buildDiffFromFile(const QString& filename)
 
     file.close();
 
-    if (parsedLineCount == 0) {
+    if (_diffParsedCount == 0) {
         QGC::showAppMessage(tr("No valid parameters found in file. Check that the file is in QGC or Mission Planner format."));
         return false;
     }
 
+    qCDebug(ParameterEditorControllerLog) << "Parameter file load summary:"
+        << "parsed:" << _diffParsedCount
+        << "different:" << _diffList.count()
+        << "unchanged:" << _diffUnchangedCount
+        << "missing:" << _diffMissingParams.count();
+
     emit diffOtherVehicleChanged(_diffOtherVehicle);
     emit diffMultipleComponentsChanged(_diffMultipleComponents);
+    emit diffUnchangedCountChanged(_diffUnchangedCount);
+    emit diffMissingCountChanged(_diffMissingParams.count());
+    emit diffParsedCountChanged(_diffParsedCount);
     if (!_diffMissingParams.isEmpty()) {
         emit missingParamsFromFile(_diffMissingParams);
     }

--- a/src/QmlControls/ParameterEditorController.h
+++ b/src/QmlControls/ParameterEditorController.h
@@ -139,6 +139,9 @@ class ParameterEditorController : public FactPanelController
     Q_PROPERTY(bool                 diffOtherVehicle        MEMBER _diffOtherVehicle                                    NOTIFY diffOtherVehicleChanged)
     Q_PROPERTY(bool                 diffMultipleComponents  MEMBER _diffMultipleComponents                              NOTIFY diffMultipleComponentsChanged)
     Q_PROPERTY(QmlObjectListModel*  diffList                READ diffList                                               CONSTANT)
+    Q_PROPERTY(int                  diffUnchangedCount      MEMBER _diffUnchangedCount                                  NOTIFY diffUnchangedCountChanged)
+    Q_PROPERTY(int                  diffMissingCount        READ diffMissingCount                                       NOTIFY diffMissingCountChanged)
+    Q_PROPERTY(int                  diffParsedCount         MEMBER _diffParsedCount                                     NOTIFY diffParsedCountChanged)
 
 public:
     explicit ParameterEditorController(QObject *parent = nullptr);
@@ -159,6 +162,7 @@ public:
     QObject*            currentGroup            (void) { return _currentGroup; }
     QmlObjectListModel* categories              (void) { return &_categories; }
     QmlObjectListModel* diffList                (void) { return &_diffList; }
+    int                 diffMissingCount        (void) const { return _diffMissingParams.count(); }
     QStringList         favoriteParameterNames  (void) const;
     void                setCurrentCategory  (QObject* currentCategory);
     void                setCurrentGroup     (QObject* currentGroup);
@@ -173,6 +177,9 @@ signals:
     void favoritesChanged               (void);
     void diffOtherVehicleChanged        (bool diffOtherVehicle);
     void diffMultipleComponentsChanged  (bool diffMultipleComponents);
+    void diffUnchangedCountChanged      (int diffUnchangedCount);
+    void diffMissingCountChanged        (int diffMissingCount);
+    void diffParsedCountChanged         (int diffParsedCount);
     void parametersChanged              (void);
     void missingParamsFromFile          (const QStringList& missingParams);
 
@@ -202,6 +209,8 @@ private:
     bool                        _hideReadOnly           = false;
     bool                        _diffOtherVehicle       = false;
     bool                        _diffMultipleComponents = false;
+    int                         _diffUnchangedCount     = 0;
+    int                         _diffParsedCount        = 0;
     QStringList                 _diffMissingParams;
     QSet<QString>               _favoriteNames;
 


### PR DESCRIPTION
## Summary

- Improve user feedback when loading parameter files to clearly indicate what happened
- Add debug logging for parameter comparison to aid troubleshooting

## Problem

When loading a .params file, QGC reports "no differences" even when:
- Parameters exist in file but not on vehicle
- All parameters already match vehicle settings

This is particularly problematic for ArduPilot helicopters where H_* parameters only exist after setting FRAME_CLASS and rebooting. Users see "no differences" but have no indication of why parameters weren't loaded.

## Solution

- Track count of parsed, changed, unchanged, and missing parameters
- Show specific feedback message based on what happened:
  - "The following parameters differ..." when changes are found
  - "All X parameters already match vehicle settings" when no changes needed
  - "No differences found. X parameters not found on vehicle" when params missing
- Add debug logging showing each parameter comparison for troubleshooting

## Testing

- [x] Tested with ArduPilot helicopter params after FRAME_CLASS change
- [x] Verified feedback messages are accurate
- [x] Build succeeds on macOS

## Related Issues

Fixes #14704