### PR TITLE
ci(moccache): report moc cache stats at the end of CI builds

### DIFF
--- a/.github/actions/cache/action.yml
+++ b/.github/actions/cache/action.yml
@@ -189,6 +189,17 @@ runs:
           moccache-${{ inputs.host }}-${{ inputs.target }}-${{ inputs.build-type }}-${{ steps.cache-scope.outputs.scope }}-
           moccache-${{ inputs.host }}-${{ inputs.target }}-${{ inputs.build-type }}-shared-
 
+    # Record per-run moc hit/miss stats; a restored cache may carry the
+    # previous run's stats.log, so reset it for accurate numbers.
+    - name: Enable moccache stats
+      if: runner.os != 'Windows'
+      shell: bash
+      env:
+        MOCCACHE_DIR: ${{ github.workspace }}/.cache/moccache
+      run: |
+        echo "MOCCACHE_STATS=1" >> "$GITHUB_ENV"
+        python3 "${GITHUB_WORKSPACE}/tools/moccache.py" --zero-stats
+
     # CPM is content-identical across build types; only Release writes the
     # cache. Debug + sanitizer + coverage jobs are read-only to avoid parallel
     # save races on the same key (last-writer-wins waste).

--- a/.github/actions/cmake-build/action.yml
+++ b/.github/actions/cmake-build/action.yml
@@ -89,3 +89,10 @@ runs:
         if command -v ccache >/dev/null 2>&1; then
           python3 "${GITHUB_WORKSPACE}/.github/scripts/ccache_helper.py" summary
         fi
+
+    - name: Moc Cache Stats
+      if: always() && runner.os != 'Windows'
+      shell: bash
+      env:
+        MOCCACHE_DIR: ${{ github.workspace }}/.cache/moccache
+      run: python3 "${GITHUB_WORKSPACE}/tools/moccache.py" --show-stats

--- a/tools/moccache.py
+++ b/tools/moccache.py
@@ -11,10 +11,14 @@ or set MOCCACHE_MOC=/path/to/moc and invoke:
     moccache.py [moc args...]
 or trim the cache to a size limit (LRU eviction):
     moccache.py --trim [--max-size 256M]
+or report / reset recorded stats (requires MOCCACHE_STATS during the build):
+    moccache.py --show-stats
+    moccache.py --zero-stats
 
 Environment:
     MOCCACHE_MOC      Path to the real moc (if --real-moc not given).
-    MOCCACHE_DIR      Cache directory (default ~/.cache/moccache).
+    MOCCACHE_DIR      Cache directory (default <source tree>/.cache/moccache,
+                      matching the CMake-generated launcher).
     MOCCACHE_BASEDIR  Build dir root; rewritten to a token in cache keys and
                       manifests so different build trees share cache entries
                       (same idea as ccache's base_dir).
@@ -264,7 +268,7 @@ def _log_stat(cache_dir: Path, what: str, input_file: str) -> None:
     if not os.environ.get("MOCCACHE_STATS"):
         return
     try:
-        with (cache_dir / "stats.log").open("a") as f:
+        with (cache_dir / "stats.log").open("a", encoding="utf-8") as f:
             f.write(f"{what}\t{input_file}\n")
     except OSError:
         pass
@@ -383,9 +387,53 @@ def _trim_main(argv: list[str]) -> int:
     except ValueError as e:
         print(f"moccache: {e}", file=sys.stderr)
         return 2
-    cache_dir = Path(os.environ.get("MOCCACHE_DIR", str(Path.home() / ".cache" / "moccache")))
+    cache_dir = _cache_dir()
     removed = _trim(cache_dir, max_bytes)
     print(f"moccache: trimmed {removed} entries from {cache_dir}")
+    return 0
+
+
+def _cache_dir() -> Path:
+    """Cache directory: $MOCCACHE_DIR, else <source tree>/.cache/moccache.
+
+    The source-tree default matches the CMake-generated launcher so the
+    --show-stats/--trim CLI works out-of-the-box after a normal build.
+    """
+    env = os.environ.get("MOCCACHE_DIR")
+    if env:
+        return Path(env)
+    return Path(__file__).resolve().parent.parent / ".cache" / "moccache"
+
+
+def _show_stats_main() -> int:
+    cache_dir = _cache_dir()
+    log = cache_dir / "stats.log"
+    counts: dict[str, int] = {}
+    try:
+        for line in log.read_text(encoding="utf-8", errors="replace").splitlines():
+            what = line.split("\t", 1)[0]
+            counts[what] = counts.get(what, 0) + 1
+    except OSError:
+        pass
+    hits = counts.pop("hit", 0)
+    misses = counts.pop("miss", 0)
+    total = hits + misses
+    print(f"moccache stats ({cache_dir}):")
+    if total == 0 and not counts:
+        print("  no stats recorded")
+        return 0
+    print(f"  hits     {hits}")
+    print(f"  misses   {misses}")
+    if total:
+        print(f"  hit rate {100.0 * hits / total:.1f}%")
+    for what in sorted(counts):
+        print(f"  {what}  {counts[what]}")
+    return 0
+
+
+def _zero_stats_main() -> int:
+    with contextlib.suppress(OSError):
+        (_cache_dir() / "stats.log").unlink()
     return 0
 
 
@@ -393,6 +441,11 @@ def main() -> int:
     argv = sys.argv[1:]
     if argv and argv[0] == "--trim":
         return _trim_main(argv[1:])
+    if argv and argv[0] in ("--show-stats", "--zero-stats"):
+        if len(argv) > 1:
+            print(f"moccache: {argv[0]} takes no arguments: {argv[1]}", file=sys.stderr)
+            return 2
+        return _show_stats_main() if argv[0] == "--show-stats" else _zero_stats_main()
     real_moc = None
     if argv and argv[0] == "--real-moc":
         if len(argv) < 2:
@@ -418,7 +471,7 @@ def main() -> int:
     if not output or not input_file or not Path(input_file).is_file():
         return passthrough()
 
-    cache_dir = Path(os.environ.get("MOCCACHE_DIR", str(Path.home() / ".cache" / "moccache")))
+    cache_dir = _cache_dir()
     basedir_prefixes = _basedir_prefixes()
 
     # Manifest key: moc identity + args (minus output/dep paths) + input content

--- a/tools/tests/test_moccache.py
+++ b/tools/tests/test_moccache.py
@@ -710,6 +710,82 @@ class TestTrim:
         assert moccache.main() == 2
         assert "requires --max-size or MOCCACHE_MAX_SIZE" in capsys.readouterr().err
 
+
+# ---------------------------------------------------------------------------
+# Stats CLI (--show-stats / --zero-stats)
+# ---------------------------------------------------------------------------
+
+
+class TestStatsCli:
+    def _show(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setattr(sys, "argv", ["moccache.py", "--show-stats"])
+        assert moccache.main() == 0
+
+    def test_show_stats_counts_hits_and_misses(
+        self, harness: Harness, capsys: pytest.CaptureFixture[str]
+    ) -> None:
+        tree = harness.make_tree("build")
+        harness.run(tree, out=tree.out_path("a.cpp"))
+        harness.run(tree, out=tree.out_path("b.cpp"))
+        harness.run(tree, out=tree.out_path("c.cpp"))
+        self._show(harness.monkeypatch)
+        out = capsys.readouterr().out
+        assert "hits     2" in out
+        assert "misses   1" in out
+        assert "hit rate 66.7%" in out
+
+    def test_show_stats_without_log_reports_zero(
+        self, harness: Harness, capsys: pytest.CaptureFixture[str]
+    ) -> None:
+        self._show(harness.monkeypatch)
+        out = capsys.readouterr().out
+        assert "no stats recorded" in out
+
+    def test_zero_stats_removes_log(self, harness: Harness) -> None:
+        tree = harness.make_tree("build")
+        harness.run(tree)
+        assert (harness.cache / "stats.log").is_file()
+        harness.monkeypatch.setattr(sys, "argv", ["moccache.py", "--zero-stats"])
+        assert moccache.main() == 0
+        assert not (harness.cache / "stats.log").exists()
+
+    def test_zero_stats_without_log_succeeds(
+        self, harness: Harness, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.setattr(sys, "argv", ["moccache.py", "--zero-stats"])
+        assert moccache.main() == 0
+
+    @pytest.mark.parametrize("flag", ["--show-stats", "--zero-stats"])
+    def test_stats_flags_reject_extra_arguments(
+        self, monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str], flag: str
+    ) -> None:
+        monkeypatch.setattr(sys, "argv", ["moccache.py", flag, "--frobnicate"])
+        assert moccache.main() == 2
+        assert f"{flag} takes no arguments: --frobnicate" in capsys.readouterr().err
+
+    def test_show_stats_with_only_other_events_still_prints_counts(
+        self, harness: Harness, capsys: pytest.CaptureFixture[str]
+    ) -> None:
+        harness.cache.mkdir(parents=True, exist_ok=True)
+        (harness.cache / "stats.log").write_text("bad-max-size\tx\n")
+        self._show(harness.monkeypatch)
+        out = capsys.readouterr().out
+        assert "no stats recorded" not in out
+        assert "hits     0" in out
+        assert "misses   0" in out
+        assert "hit rate" not in out
+        assert "bad-max-size  1" in out
+
+    def test_zero_then_show_reports_zero(
+        self, harness: Harness, capsys: pytest.CaptureFixture[str]
+    ) -> None:
+        tree = harness.make_tree("build")
+        harness.run(tree)
+        harness.monkeypatch.setattr(sys, "argv", ["moccache.py", "--zero-stats"])
+        assert moccache.main() == 0
+        self._show(harness.monkeypatch)
+        assert "no stats recorded" in capsys.readouterr().out
+
     def test_auto_trim_on_miss_when_max_size_set(
         self, harness: Harness, monkeypatch: pytest.MonkeyPatch
     ) -> None:


### PR DESCRIPTION
Follow-up to #14702.

CI now records and reports moc cache effectiveness at the end of every build, next to the existing ccache stats:

- `tools/moccache.py` gains `--show-stats` (prints hits / misses / hit rate from `stats.log`) and `--zero-stats` (removes it).
- The cache action sets `MOCCACHE_STATS=1` for the job and zeroes any `stats.log` restored from a previous run's cache, so the reported numbers are per-run.
- `cmake-build` prints the summary in a new "Moc Cache Stats" step (skipped on Windows, where moccache is not used).

Covered by new unit tests in `tools/tests/test_moccache.py` (written first, verified failing).
