### PR TITLE
ci(moccache): use run-scoped cache keys so new moc entries persist

### DIFF
--- a/.github/actions/build-setup/action.yml
+++ b/.github/actions/build-setup/action.yml
@@ -34,6 +34,13 @@ inputs:
     description: Optional ccache key discriminator for compile-flag-distinct builds (e.g. coverage|asan).
     required: false
     default: ""
+  cache-key-suffix:
+    description: >-
+      Per-matrix-leg moccache save-key discriminator, forwarded to the cache
+      action. Set when multiple legs share the same host/target/build-type
+      (e.g. android.yml linux vs linux-emulator).
+    required: false
+    default: ""
   cpm-modules:
     description: CPM cache path (mobile modes; desktop derives this internally)
     required: false
@@ -141,6 +148,7 @@ runs:
         target: ${{ inputs.qt-arch }}
         build-type: ${{ inputs.build-type }}
         variant: ${{ inputs.cache-variant }}
+        key-suffix: ${{ inputs.cache-key-suffix }}
         cpm-modules: ${{ runner.temp }}/build/cpm_modules
         save-cache: ${{ inputs.save-cache }}
 
@@ -217,6 +225,7 @@ runs:
         android-cmdline-tools: ${{ steps.prereq.outputs.android_cmdline_tools }}
         android-build-tools: ${{ steps.prereq.outputs.android_build_tools }}
         save-cache: ${{ inputs.save-cache }}
+        cache-key-suffix: ${{ inputs.cache-key-suffix }}
         aqt-source: ${{ inputs.aqt-source }}
 
     - name: Install Qt for iOS

--- a/.github/actions/cache/action.yml
+++ b/.github/actions/cache/action.yml
@@ -14,6 +14,14 @@ inputs:
     description: Optional discriminator (e.g. coverage|asan) — distinct compile flags must not share a ccache key.
     required: false
     default: ''
+  key-suffix:
+    description: >-
+      Optional per-job discriminator appended to the moccache save key. Required
+      when multiple matrix legs share the same host/target/build-type (e.g.
+      android.yml linux vs linux-emulator); without it those legs race to save
+      the same exact key and the loser's new entries are dropped.
+    required: false
+    default: ''
   cpm-modules:
     description: Path to CPM Modules
     required: false
@@ -169,13 +177,22 @@ runs:
     # moccache entries are content-addressed and basedir-normalized, so they
     # are safe to share across build types and branches; keys exist only for
     # scoping and eviction. Windows is skipped (moccache no-ops there).
+    #
+    # The saved key ends in key-suffix + run id + attempt so every saving job
+    # (including matrix legs sharing host/target and re-run attempts) writes a
+    # fresh cache (an exact-key hit would otherwise freeze the cache: new
+    # entries from jobs like linux-emulator or custom builds would never be
+    # saved back). Lookups go through the restore-keys prefixes, and each save
+    # includes the restored entries, so caches converge over successive runs.
+    # MOCCACHE_MAX_SIZE (set by the launcher) bounds growth via LRU trim.
     - name: Cache moc output (moccache, save)
       if: runner.os != 'Windows' && steps.cache-policy.outputs.save == 'true' && inputs.variant != 'coverage'
       uses: actions/cache@v5
       with:
         path: ${{ github.workspace }}/.cache/moccache
-        key: moccache-${{ inputs.host }}-${{ inputs.target }}-${{ inputs.build-type }}-${{ steps.cache-scope.outputs.scope }}-${{ hashFiles('.github/build-config.json') }}
+        key: moccache-${{ inputs.host }}-${{ inputs.target }}-${{ inputs.build-type }}-${{ steps.cache-scope.outputs.scope }}-${{ hashFiles('.github/build-config.json') }}${{ inputs.key-suffix && format('-{0}', inputs.key-suffix) || '' }}-${{ github.run_id }}-${{ github.run_attempt }}
         restore-keys: |
+          moccache-${{ inputs.host }}-${{ inputs.target }}-${{ inputs.build-type }}-${{ steps.cache-scope.outputs.scope }}-${{ hashFiles('.github/build-config.json') }}-
           moccache-${{ inputs.host }}-${{ inputs.target }}-${{ inputs.build-type }}-${{ steps.cache-scope.outputs.scope }}-
           moccache-${{ inputs.host }}-${{ inputs.target }}-${{ inputs.build-type }}-shared-
 
@@ -184,8 +201,9 @@ runs:
       uses: actions/cache/restore@v5
       with:
         path: ${{ github.workspace }}/.cache/moccache
-        key: moccache-${{ inputs.host }}-${{ inputs.target }}-${{ inputs.build-type }}-${{ steps.cache-scope.outputs.scope }}-${{ hashFiles('.github/build-config.json') }}
+        key: moccache-${{ inputs.host }}-${{ inputs.target }}-${{ inputs.build-type }}-${{ steps.cache-scope.outputs.scope }}-${{ hashFiles('.github/build-config.json') }}${{ inputs.key-suffix && format('-{0}', inputs.key-suffix) || '' }}-${{ github.run_id }}-${{ github.run_attempt }}
         restore-keys: |
+          moccache-${{ inputs.host }}-${{ inputs.target }}-${{ inputs.build-type }}-${{ steps.cache-scope.outputs.scope }}-${{ hashFiles('.github/build-config.json') }}-
           moccache-${{ inputs.host }}-${{ inputs.target }}-${{ inputs.build-type }}-${{ steps.cache-scope.outputs.scope }}-
           moccache-${{ inputs.host }}-${{ inputs.target }}-${{ inputs.build-type }}-shared-
 

--- a/.github/actions/qt-android/action.yml
+++ b/.github/actions/qt-android/action.yml
@@ -50,6 +50,10 @@ inputs:
     description: "Whether to save cache (auto = save for pushes and same-repo PRs, skip for fork PRs)"
     required: false
     default: 'auto'
+  cache-key-suffix:
+    description: Forwarded to the cache action's key-suffix (per-matrix-leg moccache save-key discriminator).
+    required: false
+    default: ''
   aqt-source:
     description: Optional pip spec used to install aqtinstall (e.g. git+https://github.com/miurahr/aqtinstall.git@<sha>)
     required: false
@@ -86,6 +90,7 @@ runs:
         host: ${{ inputs.host }}
         target: android
         build-type: ${{ inputs.build-type }}
+        key-suffix: ${{ inputs.cache-key-suffix }}
         cpm-modules: ${{ inputs.cpm-modules }}
         save-cache: ${{ inputs.save-cache }}
 

--- a/.github/workflows/android.yml
+++ b/.github/workflows/android.yml
@@ -141,6 +141,10 @@ jobs:
           aqt-source: ${{ matrix.aqt_source || '' }}
           abis: ${{ env.QT_ANDROID_ABIS }}
           build-type: ${{ env.BUILD_TYPE }}
+          # matrix.host is unique per leg; linux and linux-emulator otherwise
+          # resolve to identical cache inputs and would race on the moccache
+          # save key.
+          cache-key-suffix: ${{ matrix.host }}
           cpm-modules: ${{ runner.temp }}/build/cpm_modules
 
       - name: Install host build dependencies


### PR DESCRIPTION
Follow-up to #14709. The post-merge stats runs showed ~95% moc cache hit rates on macOS/iOS/Android/Linux Release, but three structural 0%/low cases:

- **Android linux-emulator: 0%** — restored the shared `moccache-linux-android-Release` cache, but its x86_64 moc entries aren't in it
- **Custom Plugin Build: 10.6%** — same, custom-plugin moc outputs missing from the standard linux cache
- **Debug jobs: 0%** — `moccache-...-Debug-...` cache never seeded

Root cause: with `actions/cache`, an exact-key hit skips saving ("Cache hit occurred on the primary key, not saving cache"), so once seeded a cache is frozen until `build-config.json` changes — new entries from these jobs are never persisted, and even the Release jobs' residual misses are never absorbed.

Fix: append `github.run_id` to the save key (append-style cache pattern) and resolve lookups via `restore-keys` prefixes. Each saving run restores the newest cache, adds its entries, and saves the union, so caches converge over successive runs. Growth stays bounded by moccache's built-in `MOCCACHE_MAX_SIZE` LRU trim (256M default from the launcher).