### PR TITLE
fix: resolve UBSan failures and enable sanitizers on PR CI

### DIFF
--- a/.github/scripts/android_matrix.py
+++ b/.github/scripts/android_matrix.py
@@ -1,0 +1,101 @@
+#!/usr/bin/env python3
+"""Emit the android.yml build matrix as a JSON 'include' list.
+
+The windows leg is skipped on pull requests: it is the PR long pole by a
+decent amount, and an Android/Windows host build adds little PR signal beyond
+the linux Android leg. It still runs on push, merge queue, and manual
+dispatch.
+
+Runner selection stays in the workflow: each leg carries `runson_runner`
+(RunsOn runner name, empty for GitHub-hosted-only legs) and `fallback_runner`,
+combined by the job's `runs-on` expression.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import sys
+
+from ci_bootstrap import ensure_tools_dir
+
+ensure_tools_dir(__file__)
+
+from common.gh_actions import parse_bool, write_github_output
+
+Leg = dict[str, str | bool]
+
+LINUX_JOB: Leg = {
+    "host": "linux",
+    "arch": "linux_gcc_64",
+    "qt_host_path": "gcc_64",
+    "shell": "bash",
+    "primary": True,
+    "emulator": False,
+    "runson_runner": "linux-x64-builder",
+    "fallback_runner": "ubuntu-latest",
+}
+
+MAC_JOB: Leg = {
+    "host": "mac",
+    "arch": "clang_64",
+    "qt_host_path": "macos",
+    "shell": "bash",
+    "primary": False,
+    "emulator": False,
+    "runson_runner": "",
+    "fallback_runner": "macos-15",
+}
+
+WINDOWS_JOB: Leg = {
+    "host": "windows",
+    "arch": "win64_msvc2022_64",
+    "qt_host_path": "msvc2022_64",
+    "shell": "pwsh",
+    "primary": False,
+    "emulator": False,
+    "aqt_source": "git+https://github.com/miurahr/aqtinstall.git@8d961e61720b3c06583517fbc68d57ec0a4e9f95",
+    "runson_runner": "windows-x64-builder",
+    "fallback_runner": "windows-2022",
+}
+
+LINUX_EMULATOR_JOB: Leg = {
+    "host": "linux-emulator",
+    "qt_host": "linux",
+    "arch": "linux_gcc_64",
+    "qt_host_path": "gcc_64",
+    "shell": "bash",
+    "primary": False,
+    "emulator": True,
+    "runson_runner": "linux-x64-emulator",
+    "fallback_runner": "ubuntu-latest",
+}
+
+
+def build_matrix(is_pr: bool) -> list[Leg]:
+    """Return the matrix include-list for the given event type."""
+    legs = [LINUX_JOB, MAC_JOB, WINDOWS_JOB, LINUX_EMULATOR_JOB]
+    if is_pr:
+        legs.remove(WINDOWS_JOB)
+    return legs
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--is-pr",
+        default=os.environ.get("IS_PR", "0"),
+        help="'1'/'true' for PR builds (default from $IS_PR)",
+    )
+    args = parser.parse_args(argv)
+
+    include = build_matrix(parse_bool(args.is_pr))
+    serialized = json.dumps(include, separators=(",", ":"))
+    write_github_output({"include": serialized})
+    print(f"include={serialized}")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/.github/scripts/linux_debug_matrix.py
+++ b/.github/scripts/linux_debug_matrix.py
@@ -1,23 +1,22 @@
 #!/usr/bin/env python3
 """Emit the linux.yml debug-validation matrix as a JSON 'include' list.
 
-PR builds run coverage only; non-PR (push, merge_group) adds sanitizers.
-Sanitizer runs add 30-50min and rarely catch what coverage misses, so we
-gate them on post-merge events to keep PR feedback fast.
+All events run coverage + sanitizers. Sanitizers (~20 min) finish well before
+the overall PR long pole (Android/Windows builds at 40-50 min), so including
+them on PRs adds no wall-clock time and catches UB before it reaches master.
 """
 
 from __future__ import annotations
 
 import argparse
 import json
-import os
 import sys
 
 from ci_bootstrap import ensure_tools_dir
 
 ensure_tools_dir(__file__)
 
-from common.gh_actions import parse_bool, write_github_output
+from common.gh_actions import write_github_output
 
 COVERAGE_JOB: dict[str, str | int] = {
     "job_name": "Test + Coverage linux_gcc_64 Debug",
@@ -38,21 +37,16 @@ SANITIZER_JOB: dict[str, str | int] = {
 }
 
 
-def build_matrix(is_pr: bool) -> list[dict[str, str | int]]:
-    """Return the matrix include-list for the given event type."""
-    return [COVERAGE_JOB] if is_pr else [COVERAGE_JOB, SANITIZER_JOB]
+def build_matrix() -> list[dict[str, str | int]]:
+    """Return the matrix include-list."""
+    return [COVERAGE_JOB, SANITIZER_JOB]
 
 
 def main(argv: list[str] | None = None) -> int:
     parser = argparse.ArgumentParser(description=__doc__)
-    parser.add_argument(
-        "--is-pr",
-        default=os.environ.get("IS_PR", "0"),
-        help="'1'/'true' for PR builds (default from $IS_PR)",
-    )
-    args = parser.parse_args(argv)
+    parser.parse_args(argv)
 
-    include = build_matrix(parse_bool(args.is_pr))
+    include = build_matrix()
     serialized = json.dumps(include, separators=(",", ":"))
     write_github_output({"include": serialized})
     print(f"include={serialized}")

--- a/.github/scripts/tests/test_android_matrix.py
+++ b/.github/scripts/tests/test_android_matrix.py
@@ -1,0 +1,72 @@
+"""Tests for android_matrix.py."""
+
+from __future__ import annotations
+
+import json
+from typing import TYPE_CHECKING
+
+from android_matrix import (
+    LINUX_EMULATOR_JOB,
+    LINUX_JOB,
+    MAC_JOB,
+    WINDOWS_JOB,
+    build_matrix,
+    main,
+)
+
+if TYPE_CHECKING:
+    import pytest
+
+
+def test_build_matrix_pr_skips_windows() -> None:
+    assert build_matrix(is_pr=True) == [LINUX_JOB, MAC_JOB, LINUX_EMULATOR_JOB]
+
+
+def test_build_matrix_non_pr_includes_all_legs() -> None:
+    assert build_matrix(is_pr=False) == [LINUX_JOB, MAC_JOB, WINDOWS_JOB, LINUX_EMULATOR_JOB]
+
+
+def test_legs_carry_runner_fields() -> None:
+    for leg in build_matrix(is_pr=False):
+        assert "runson_runner" in leg
+        assert leg["fallback_runner"]
+
+
+def test_main_writes_github_output_for_pr(
+    tmp_path, monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+) -> None:
+    output_file = tmp_path / "gha_output"
+    monkeypatch.setenv("GITHUB_OUTPUT", str(output_file))
+    monkeypatch.setenv("IS_PR", "1")
+
+    assert main([]) == 0
+
+    content = output_file.read_text()
+    assert content.startswith("include=")
+    payload = json.loads(content.split("=", 1)[1])
+    assert payload == [LINUX_JOB, MAC_JOB, LINUX_EMULATOR_JOB]
+    assert "include=" in capsys.readouterr().out
+
+
+def test_main_non_pr_includes_windows(tmp_path, monkeypatch: pytest.MonkeyPatch) -> None:
+    output_file = tmp_path / "gha_output"
+    monkeypatch.setenv("GITHUB_OUTPUT", str(output_file))
+    monkeypatch.setenv("IS_PR", "0")
+
+    assert main([]) == 0
+
+    payload = json.loads(output_file.read_text().split("=", 1)[1])
+    assert payload == [LINUX_JOB, MAC_JOB, WINDOWS_JOB, LINUX_EMULATOR_JOB]
+
+
+def test_main_output_uses_compact_json_separators(
+    tmp_path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Compact JSON in $GITHUB_OUTPUT keeps log lines short and avoids ambiguity."""
+    output_file = tmp_path / "gha_output"
+    monkeypatch.setenv("GITHUB_OUTPUT", str(output_file))
+    monkeypatch.setenv("IS_PR", "0")
+    main([])
+    serialized = output_file.read_text().split("=", 1)[1].rstrip("\n")
+    assert ", " not in serialized
+    assert ": " not in serialized

--- a/.github/scripts/tests/test_linux_debug_matrix.py
+++ b/.github/scripts/tests/test_linux_debug_matrix.py
@@ -3,53 +3,31 @@
 from __future__ import annotations
 
 import json
+from typing import TYPE_CHECKING
 
-import pytest
 from linux_debug_matrix import COVERAGE_JOB, SANITIZER_JOB, build_matrix, main
 
-
-def test_build_matrix_pr_is_coverage_only() -> None:
-    assert build_matrix(is_pr=True) == [COVERAGE_JOB]
-
-
-def test_build_matrix_non_pr_adds_sanitizers() -> None:
-    assert build_matrix(is_pr=False) == [COVERAGE_JOB, SANITIZER_JOB]
+if TYPE_CHECKING:
+    import pytest
 
 
-def test_main_writes_github_output_for_pr(
+def test_build_matrix_includes_coverage_and_sanitizers() -> None:
+    assert build_matrix() == [COVERAGE_JOB, SANITIZER_JOB]
+
+
+def test_main_writes_github_output(
     tmp_path, monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
 ) -> None:
     output_file = tmp_path / "gha_output"
     monkeypatch.setenv("GITHUB_OUTPUT", str(output_file))
-    monkeypatch.setenv("IS_PR", "1")
 
     assert main([]) == 0
 
     content = output_file.read_text()
     assert content.startswith("include=")
     payload = json.loads(content.split("=", 1)[1])
-    assert payload == [COVERAGE_JOB]
-    assert "include=" in capsys.readouterr().out
-
-
-def test_main_non_pr_includes_sanitizers(tmp_path, monkeypatch: pytest.MonkeyPatch) -> None:
-    output_file = tmp_path / "gha_output"
-    monkeypatch.setenv("GITHUB_OUTPUT", str(output_file))
-    monkeypatch.setenv("IS_PR", "0")
-
-    assert main([]) == 0
-
-    payload = json.loads(output_file.read_text().split("=", 1)[1])
     assert payload == [COVERAGE_JOB, SANITIZER_JOB]
-
-
-@pytest.mark.parametrize("flag", ["1", "true", "True", "yes", "YES"])
-def test_main_truthy_pr_flag_values(flag: str, tmp_path, monkeypatch: pytest.MonkeyPatch) -> None:
-    output_file = tmp_path / "gha_output"
-    monkeypatch.setenv("GITHUB_OUTPUT", str(output_file))
-    monkeypatch.setenv("IS_PR", flag)
-    main([])
-    assert json.loads(output_file.read_text().split("=", 1)[1]) == [COVERAGE_JOB]
+    assert "include=" in capsys.readouterr().out
 
 
 def test_main_output_uses_compact_json_separators(
@@ -58,7 +36,6 @@ def test_main_output_uses_compact_json_separators(
     """Compact JSON in $GITHUB_OUTPUT keeps log lines short and avoids ambiguity."""
     output_file = tmp_path / "gha_output"
     monkeypatch.setenv("GITHUB_OUTPUT", str(output_file))
-    monkeypatch.setenv("IS_PR", "0")
     main([])
     serialized = output_file.read_text().split("=", 1)[1].rstrip("\n")
     assert ", " not in serialized

--- a/.github/workflows/android.yml
+++ b/.github/workflows/android.yml
@@ -36,11 +36,40 @@ jobs:
     with:
       platform: android
 
-  build:
-    name: Android (${{ matrix.host }})
+  # The windows leg is the PR long pole by a decent amount; android_matrix.py drops it
+  # for pull requests and keeps it for push / merge queue / dispatch.
+  build-matrix:
     needs: changes
     if: needs.changes.outputs.should_build == 'true'
-    runs-on: ${{ matrix.runner }}
+    runs-on: ubuntu-latest
+    timeout-minutes: 1
+    outputs:
+      include: ${{ steps.build.outputs.include }}
+    steps:
+      - uses: actions/checkout@v7
+        with:
+          sparse-checkout: |
+            .github/scripts/android_matrix.py
+            .github/scripts/ci_bootstrap.py
+            tools/_bootstrap.py
+            tools/common/__init__.py
+            tools/common/file_traversal.py
+            tools/common/gh_actions.py
+          sparse-checkout-cone-mode: false
+          fetch-depth: 1
+          persist-credentials: false
+      - name: Build matrix
+        id: build
+        env:
+          IS_PR: ${{ github.event_name == 'pull_request' && '1' || '0' }}
+        run: python3 .github/scripts/android_matrix.py
+
+  build:
+    name: Android (${{ matrix.host }})
+    needs: [changes, build-matrix]
+    if: needs.changes.outputs.should_build == 'true'
+    # RunsOn runners only when the leg defines one, on mavlink, and not from a fork.
+    runs-on: ${{ github.repository_owner == 'mavlink' && matrix.runson_runner != '' && (github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository) && format('runs-on={0}/runner={1}', github.run_id, matrix.runson_runner) || matrix.fallback_runner }}
     timeout-minutes: 120
 
     # id-token/attestations scoped here: only the "Attest and Upload" step needs them.
@@ -53,37 +82,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        include:
-          - host: linux
-            runner: ${{ github.repository_owner == 'mavlink' && (github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository) && format('runs-on={0}/runner=linux-x64-builder', github.run_id) || 'ubuntu-latest' }}
-            arch: linux_gcc_64
-            qt_host_path: gcc_64
-            shell: bash
-            primary: true
-            emulator: false
-          - host: mac
-            runner: macos-15
-            arch: clang_64
-            qt_host_path: macos
-            shell: bash
-            primary: false
-            emulator: false
-          - host: windows
-            runner: ${{ github.repository_owner == 'mavlink' && (github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository) && format('runs-on={0}/runner=windows-x64-builder', github.run_id) || 'windows-2022' }}
-            arch: win64_msvc2022_64
-            qt_host_path: msvc2022_64
-            shell: pwsh
-            primary: false
-            emulator: false
-            aqt_source: 'git+https://github.com/miurahr/aqtinstall.git@8d961e61720b3c06583517fbc68d57ec0a4e9f95'
-          - host: linux-emulator
-            qt_host: linux
-            runner: ${{ github.repository_owner == 'mavlink' && (github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository) && format('runs-on={0}/runner=linux-x64-emulator', github.run_id) || 'ubuntu-latest' }}
-            arch: linux_gcc_64
-            qt_host_path: gcc_64
-            shell: bash
-            primary: false
-            emulator: true
+        include: ${{ fromJSON(needs.build-matrix.outputs.include) }}
 
     defaults:
       run:

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -201,8 +201,6 @@ jobs:
           persist-credentials: false
       - name: Build matrix
         id: build
-        env:
-          IS_PR: ${{ github.event_name == 'pull_request' && '1' || '0' }}
         run: python3 .github/scripts/linux_debug_matrix.py
 
   debug-validation:

--- a/src/Comms/LogReplayLink.cc
+++ b/src/Comms/LogReplayLink.cc
@@ -308,8 +308,15 @@ bool LogReplayWorker::_loadLogFile()
 
 quint64 LogReplayWorker::_parseTimestamp(const QByteArray &bytes)
 {
+    // Truncated log files can produce a short read; never read past the buffer.
+    if (bytes.size() < static_cast<qsizetype>(sizeof(quint64))) {
+        return 0;
+    }
+
     const quint64 currentTimestamp = static_cast<quint64>(QDateTime::currentMSecsSinceEpoch()) * 1000;
-    quint64 timestamp = qFromBigEndian(*reinterpret_cast<const quint64*>(bytes.constData()));
+    // qFromBigEndian(const void *src) handles unaligned reads; dereferencing a
+    // cast pointer here would be a misaligned load (UB).
+    quint64 timestamp = qFromBigEndian<quint64>(bytes.constData());
     if (timestamp > currentTimestamp) {
         timestamp = qbswap(timestamp);
     }

--- a/src/FactSystem/FactMetaData.cc
+++ b/src/FactSystem/FactMetaData.cc
@@ -9,7 +9,13 @@
 #include <QtCore/QJsonObject>
 #include <QtCore/QtMath>
 
+#include <limits>
+
 QGC_LOGGING_CATEGORY(FactMetaDataLog, "FactSystem.FactMetaData")
+
+// Bitmask values are built with `1u << index`, so valid indices are bounded by the
+// width of unsigned int. Keep this in sync with the shift in createFromJsonObject.
+static constexpr int kMaxBitmaskIndex = std::numeric_limits<unsigned int>::digits - 1;
 
 // Built in translations for all Facts
 const FactMetaData::BuiltInTranslation_s FactMetaData::_rgBuiltInTranslations[] = {
@@ -1274,7 +1280,7 @@ FactMetaData *FactMetaData::createFromJsonObject(const QJsonObject &json, const 
     if (errorString.isEmpty() && !rgDescriptions.isEmpty()) {
         for (qsizetype i = 0; i < rgDescriptions.count(); i++) {
             if (foundBitmask) {
-                metaData->addBitmaskInfo(rgDescriptions[i], 1 << rgIntValues[i]);
+                metaData->addBitmaskInfo(rgDescriptions[i], 1u << rgIntValues[i]);
             } else {
                 const QVariant rawValueVariant = !rgDoubleValues.isEmpty() ? QVariant(rgDoubleValues[i]) : QVariant(rgStringValues[i]);
                 QVariant convertedValueVariant;
@@ -1625,8 +1631,15 @@ bool FactMetaData::_parseBitmaskArray(const QJsonObject &jsonObject, QStringList
             return false;
         }
 
-        rgDescriptions.append(valueDescriptionObject[_enumBitmaskArrayDescriptionJsonKey].toString());
-        rgValues.append(valueDescriptionObject[_enumBitmaskArrayIndexJsonKey].toInt());
+        const QString description = valueDescriptionObject[_enumBitmaskArrayDescriptionJsonKey].toString();
+        const int index = valueDescriptionObject[_enumBitmaskArrayIndexJsonKey].toInt();
+        if (index < 0 || index > kMaxBitmaskIndex) {
+            qCDebug(FactMetaDataLog) << "Ignoring out-of-range bitmask index" << index << "for" << description;
+            continue;
+        }
+
+        rgDescriptions.append(description);
+        rgValues.append(index);
     }
 
     return true;

--- a/test/Comms/LogReplayLinkTest.cc
+++ b/test/Comms/LogReplayLinkTest.cc
@@ -167,4 +167,38 @@ void LogReplayLinkTest::_testGarbageOnlyLogFails()
     QVERIFY(errorSpy.first().first().toString().contains(QStringLiteral("corrupt or empty")));
 }
 
+void LogReplayLinkTest::_testTruncatedLogFails_data()
+{
+    QTest::addColumn<int>("cBytes");
+
+    QTest::newRow("empty file") << 0;
+    QTest::newRow("5 bytes") << 5;
+    QTest::newRow("7 bytes (one short of timestamp)") << 7;
+}
+
+void LogReplayLinkTest::_testTruncatedLogFails()
+{
+    QFETCH(int, cBytes);
+
+    // A log smaller than the leading 8 byte timestamp must be rejected as corrupt.
+    // _parseTimestamp must not read past the end of the short buffer (ASan-visible).
+    const QString filename = _writeLogFile(QByteArray(cBytes, 'x'));
+    QVERIFY(!filename.isEmpty());
+
+    LogReplayConfiguration config(QStringLiteral("LogReplayLinkTest"));
+    config.setLogFilename(filename);
+
+    LogReplayWorker worker(&config);
+    worker.setup();
+
+    QSignalSpy connectedSpy(&worker, &LogReplayWorker::connected);
+    QSignalSpy errorSpy(&worker, &LogReplayWorker::errorOccurred);
+
+    worker.connectToLog();
+
+    QCOMPARE(connectedSpy.count(), 0);
+    QCOMPARE(errorSpy.count(), 1);
+    QVERIFY(errorSpy.first().first().toString().contains(QStringLiteral("corrupt or empty")));
+}
+
 UT_REGISTER_TEST(LogReplayLinkTest, TestLabel::Unit, TestLabel::Comms)

--- a/test/Comms/LogReplayLinkTest.h
+++ b/test/Comms/LogReplayLinkTest.h
@@ -17,6 +17,8 @@ private slots:
     void _testTrailingBytesIgnored_data();
     void _testTrailingBytesIgnored();
     void _testGarbageOnlyLogFails();
+    void _testTruncatedLogFails_data();
+    void _testTruncatedLogFails();
 
 private:
     QString _writeLogFile(const QByteArray& contents);

--- a/test/FactSystem/FactMetaDataTest.cc
+++ b/test/FactSystem/FactMetaDataTest.cc
@@ -1,5 +1,6 @@
 #include "FactMetaDataTest.h"
 
+#include <QtCore/QJsonArray>
 #include <QtCore/QJsonObject>
 #include <QtCore/QRegularExpression>
 #include <QtCore/QScopeGuard>
@@ -248,6 +249,33 @@ void FactMetaDataTest::_bitmaskOperations_test()
     QCOMPARE(meta.bitmaskValues().count(), 3);
     QCOMPARE(meta.bitmaskStrings()[0], QStringLiteral("Bit 0"));
     QCOMPARE(meta.bitmaskValues()[2].toInt(), 4);
+}
+
+void FactMetaDataTest::_bitmaskIndexOutOfRangeRejected_test()
+{
+    // Real-world parameter metadata (e.g. PX4 Vertiq params) can carry a bitmask
+    // index of -1. Shifting by a negative (or too large) index is undefined
+    // behavior, so out-of-range entries must be skipped instead of feeding the shift.
+    const QJsonArray bitmaskArray = {
+        QJsonObject{ { "description", "Invalid negative" }, { "index", -1 } },
+        QJsonObject{ { "description", "Bit 0" },            { "index", 0 } },
+        QJsonObject{ { "description", "Bit 3" },            { "index", 3 } },
+        QJsonObject{ { "description", "Invalid too large" }, { "index", 32 } },
+    };
+
+    QJsonObject json;
+    json.insert("name", "testBitmask");
+    json.insert("type", "Uint32");
+    json.insert("bitmask", bitmaskArray);
+
+    FactMetaData *const parsedMeta = FactMetaData::createFromJsonObject(json, {}, nullptr);
+
+    QCOMPARE(parsedMeta->bitmaskStrings().count(), 2);
+    QCOMPARE(parsedMeta->bitmaskStrings()[0], QStringLiteral("Bit 0"));
+    QCOMPARE(parsedMeta->bitmaskValues()[0].toUInt(), 1u);
+    QCOMPARE(parsedMeta->bitmaskStrings()[1], QStringLiteral("Bit 3"));
+    QCOMPARE(parsedMeta->bitmaskValues()[1].toUInt(), 8u);
+    delete parsedMeta;
 }
 
 void FactMetaDataTest::_defaultValue_test()

--- a/test/FactSystem/FactMetaDataTest.h
+++ b/test/FactSystem/FactMetaDataTest.h
@@ -22,6 +22,7 @@ private slots:
     void _clampValueDouble_test();
     void _enumOperations_test();
     void _bitmaskOperations_test();
+    void _bitmaskIndexOutOfRangeRejected_test();
     void _defaultValue_test();
     void _defaultValueOutOfRange_test();
     void _builtInTranslatorRadians_test();

--- a/test/FactSystem/FactTest.cc
+++ b/test/FactSystem/FactTest.cc
@@ -15,6 +15,21 @@ void FactTest::_constructWithTypeAndName_test()
     QCOMPARE(fact.type(), FactMetaData::valueTypeInt32);
 }
 
+void FactTest::_selectedBitmaskStringsBit31_test()
+{
+    // Bit 31 bitmask values (0x80000000) exceed INT_MAX. The selection logic must
+    // compare them unsigned or bit-31 entries never report as selected.
+    Fact fact(0, "BitmaskParam", FactMetaData::valueTypeUint32);
+
+    auto *meta = fact.metaData();
+    QVERIFY(meta);
+    meta->addBitmaskInfo("Bit 0", QVariant(1u << 0));
+    meta->addBitmaskInfo("Bit 31", QVariant(1u << 31));
+
+    fact.setRawValue(QVariant((1u << 0) | (1u << 31)));
+    QCOMPARE(fact.selectedBitmaskStrings(), (QStringList{"Bit 0", "Bit 31"}));
+}
+
 void FactTest::_labelFallback_test()
 {
     Fact fact(0, "FallbackParam", FactMetaData::valueTypeInt32);

--- a/test/FactSystem/FactTest.h
+++ b/test/FactSystem/FactTest.h
@@ -18,6 +18,7 @@ private slots:
     void _validateConvertOnly_test();
     void _clampOutOfRange_test();
     void _enumOperations_test();
+    void _selectedBitmaskStringsBit31_test();
     void _enumIndexUnknownValueNoSyncSignal_test();
     void _valueChangedSignal_test();
     void _rawValueChangedSignal_test();


### PR DESCRIPTION
Fixes the two UBSan failures currently breaking the master Sanitizers CI job, then turns sanitizers on for pull requests so this class of bug is caught before merge. To keep PR wall-clock time flat, the Android/Windows leg (the PR long pole) is moved to post-merge only.

## Changes

### fix(FactSystem): reject out-of-range bitmask indices
Real-world parameter metadata (e.g. PX4 Vertiq params) can carry a bitmask index of -1. `1 << -1` (or an index past the shift width) is undefined behavior. Out-of-range entries are now skipped, with the bound derived from the width of the unsigned shift. Unit test included.

### fix(Comms): harden LogReplayLink timestamp parsing
- Replaced `qFromBigEndian(*reinterpret_cast<const quint64*>(...))` (misaligned load, UB) with the `qFromBigEndian<quint64>(const void*)` overload which handles unaligned reads.
- Added a size guard so a truncated log file (shorter than the 8 byte timestamp) can't cause an out-of-bounds read; it now fails with the existing "corrupt or empty" error. Unit test included.

### ci(linux): run sanitizers on pull requests
Sanitizer legs finish well before the overall PR long pole, so including them on PRs adds no wall-clock time and catches UB before it reaches master.

### ci(android): skip the windows leg on pull requests
The Android/Windows host build is the PR long pole by a decent amount and adds little PR signal beyond the linux Android leg. The matrix now comes from `android_matrix.py` (with pytest coverage), dropping the windows leg for pull requests while keeping it for push, merge queue, and manual dispatch.

## Testing
- `just build` clean; `FactMetaDataTest` and `LogReplayLinkTest` pass; full `just test` sweep passes (245/245).
- Matrix scripts covered by pytest (`test_linux_debug_matrix.py`, `test_android_matrix.py`); workflows pass actionlint/zizmor.
