### PR TITLE
feat(ParameterEditor): review and selectively send param file diffs

### DIFF
--- a/src/Comms/MockLink/MockLink.cc
+++ b/src/Comms/MockLink/MockLink.cc
@@ -1568,10 +1568,25 @@ void MockLink::_handleParamSet(const mavlink_message_t &msg)
         return;
     }
 
-    Q_ASSERT(_mapParamName2Value.contains(componentId));
-    Q_ASSERT(_mapParamName2MavParamType.contains(componentId));
-    Q_ASSERT(_mapParamName2Value[componentId].contains(paramId));
-    Q_ASSERT(request.param_type == _mapParamName2MavParamType[componentId][paramId]);
+    // Real firmware rejects a PARAM_SET it doesn't recognize rather than crashing.
+    // QGC can legitimately send these: loading a QGC-format param file sends params
+    // not currently known to the vehicle (e.g. params unlocked by another param).
+    if (!_mapParamName2Value.contains(componentId) || !_mapParamName2MavParamType.contains(componentId)) {
+        qCDebug(MockLinkLog) << "_handleParamSet unknown component, rejecting with PARAM_ERROR - componentId:" << componentId << "param:" << paramId;
+        _sendParamError(componentId, paramId, -1, MAV_PARAM_ERROR_COMPONENT_NOT_FOUND);
+        return;
+    }
+    if (!_mapParamName2Value[componentId].contains(paramId)) {
+        qCDebug(MockLinkLog) << "_handleParamSet unknown param, rejecting with PARAM_ERROR - componentId:" << componentId << "param:" << paramId;
+        _sendParamError(componentId, paramId, -1, MAV_PARAM_ERROR_DOES_NOT_EXIST);
+        return;
+    }
+    if (request.param_type != _mapParamName2MavParamType[componentId][paramId]) {
+        qCDebug(MockLinkLog) << "_handleParamSet type mismatch, rejecting with PARAM_ERROR - param:" << paramId
+                             << "requested type:" << request.param_type << "actual type:" << _mapParamName2MavParamType[componentId][paramId];
+        _sendParamError(componentId, paramId, -1, MAV_PARAM_ERROR_TYPE_MISMATCH);
+        return;
+    }
 
     // Apply failure behaviors before committing change.
     if (_paramSetFailureMode == FailParamSetFirstAttemptNoAck && _paramSetFailureFirstAttemptPending) {
@@ -1649,7 +1664,12 @@ void MockLink::_handleParamRequestRead(const mavlink_message_t &msg)
         return;
     }
 
-    Q_ASSERT(_mapParamName2Value.contains(componentId));
+    if (!_mapParamName2Value.contains(componentId)) {
+        qCDebug(MockLinkLog) << "_handleParamRequestRead unknown component, rejecting with PARAM_ERROR - componentId:" << componentId << "param:" << paramName;
+        const QByteArray paramIdBytes = paramName.toLocal8Bit();
+        _sendParamError(componentId, paramIdBytes.constData(), request.param_index, MAV_PARAM_ERROR_COMPONENT_NOT_FOUND);
+        return;
+    }
 
     char paramId[MAVLINK_MSG_PARAM_REQUEST_READ_FIELD_PARAM_ID_LEN + 1]{};
     paramId[0] = 0;
@@ -1668,8 +1688,13 @@ void MockLink::_handleParamRequestRead(const mavlink_message_t &msg)
         strcpy(paramId, key.toLocal8Bit().constData());
     }
 
-    Q_ASSERT(_mapParamName2Value[componentId].contains(paramId));
-    Q_ASSERT(_mapParamName2MavParamType[componentId].contains(paramId));
+    if (!_mapParamName2Value[componentId].contains(paramId) || !_mapParamName2MavParamType[componentId].contains(paramId)) {
+        // Real firmware rejects a read of a parameter it doesn't know about (e.g. QGC
+        // refreshing a param after a failed PARAM_SET for a param not on the vehicle)
+        qCDebug(MockLinkLog) << "_handleParamRequestRead unknown param, rejecting with PARAM_ERROR - componentId:" << componentId << "param:" << paramId;
+        _sendParamError(componentId, paramId, request.param_index, MAV_PARAM_ERROR_DOES_NOT_EXIST);
+        return;
+    }
 
     if ((_failureMode == MockConfiguration::FailMissingParamOnAllRequests) && (strcmp(paramId, _failParam) == 0)) {
         qCDebug(MockLinkLog) << "Ignoring request read for " << _failParam;
@@ -2638,14 +2663,23 @@ void MockLink::_logDownloadWorker()
     QFile file(_logDownloadFilename);
     if (!file.open(QIODevice::ReadOnly)) {
         qCWarning(MockLinkLog) << "_logDownloadWorker open failed" << file.errorString();
+        _logDownloadBytesRemaining = 0; // Abort transfer on I/O failure
         return;
     }
 
     uint8_t buffer[MAVLINK_MSG_LOG_DATA_FIELD_DATA_LEN]{};
 
     const qint64 bytesToRead = qMin(_logDownloadBytesRemaining, (uint32_t)MAVLINK_MSG_LOG_DATA_FIELD_DATA_LEN);
-    Q_ASSERT(file.seek(_logDownloadCurrentOffset));
-    Q_ASSERT(file.read(reinterpret_cast<char*>(buffer), bytesToRead) == bytesToRead);
+    if (!file.seek(_logDownloadCurrentOffset)) {
+        qCWarning(MockLinkLog) << "_logDownloadWorker seek failed - offset:" << _logDownloadCurrentOffset << file.errorString();
+        _logDownloadBytesRemaining = 0; // Abort transfer on I/O failure
+        return;
+    }
+    if (file.read(reinterpret_cast<char*>(buffer), bytesToRead) != bytesToRead) {
+        qCWarning(MockLinkLog) << "_logDownloadWorker read failed - bytesToRead:" << bytesToRead << file.errorString();
+        _logDownloadBytesRemaining = 0; // Abort transfer on I/O failure
+        return;
+    }
 
     qCDebug(MockLinkLog) << "_logDownloadWorker" << _logDownloadCurrentOffset << _logDownloadBytesRemaining;
 

--- a/src/FactSystem/ParameterManager.cc
+++ b/src/FactSystem/ParameterManager.cc
@@ -394,7 +394,13 @@ void ParameterManager::_mavlinkParamSet(int componentId, const QString &paramNam
         _decrementPendingWriteCount();
     });
     auto waitAckState = new WaitForParamResponseState(stateMachine, _waitForParamValueAckMs, checkForCorrectParamValue, checkForParamError);
-    auto paramRefreshState = new FunctionState(QStringLiteral("ParameterManager param refresh"), stateMachine, [this, componentId, paramName]() {
+    auto paramRefreshState = new FunctionState(QStringLiteral("ParameterManager param refresh"), stateMachine, [this, waitAckState, componentId, paramName]() {
+        // A definitive "does not exist" rejection means there is nothing on the vehicle
+        // to refresh - stop here rather than generating a redundant read failure.
+        if (waitAckState->lastParamError() == MAV_PARAM_ERROR_DOES_NOT_EXIST) {
+            qCDebug(ParameterManagerLog) << "Skipping post-write-failure refresh, param does not exist on vehicle:" << paramName << _vehicleAndComponentString(componentId);
+            return;
+        }
         refreshParameter(componentId, paramName);
     });
     auto userNotifyState = new FunctionState(QStringLiteral("ParameterManager user notify"), stateMachine, [waitAckState, paramName, this, componentId]() {

--- a/src/QmlControls/ParameterDiffDialog.qml
+++ b/src/QmlControls/ParameterDiffDialog.qml
@@ -8,10 +8,13 @@ import QGroundControl.Controls
 import QGroundControl.FactControls
 
 QGCPopupDialog {
-    title:      qsTr("Load Parameters")
-    buttons:    Dialog.Cancel | (paramController.diffList.count ? Dialog.Ok : 0)
+    title:                  qsTr("Load Parameters")
+    buttons:                Dialog.Cancel | (_sendableCount > 0 ? Dialog.Ok : 0)
+    acceptButtonEnabled:    paramController.diffSelectedCount > 0
 
-    property var paramController
+    required property var paramController
+
+    property int _sendableCount: paramController.diffSendableCount
 
     onAccepted: paramController.sendDiff()
 
@@ -21,31 +24,76 @@ QGCPopupDialog {
         spacing: ScreenTools.defaultDialogControlSpacing
 
         QGCLabel {
+            id:                     summaryLabel
+            objectName:             "diffSummaryLabel"
             Layout.preferredWidth:  mainGrid.visible ? mainGrid.width : ScreenTools.defaultFontPixelWidth * 40
             wrapMode:               Text.WordWrap
-            text:                   paramController.diffList.count ?
-                                        qsTr("The following parameters from the loaded file differ from what is currently set on the Vehicle. Click 'Ok' to update them on the Vehicle.") :
-                                        qsTr("There are no differences between the file loaded and the current settings on the Vehicle.")
+            text: {
+                var clauses = []
+                if (_sendableCount > 0) {
+                    if (paramController.diffNoVehicleCount > 0) {
+                        clauses.push(qsTr("%1 will be changed (including %2 not currently on the Vehicle)").arg(_sendableCount).arg(paramController.diffNoVehicleCount))
+                    } else {
+                        clauses.push(qsTr("%1 will be changed").arg(_sendableCount))
+                    }
+                }
+                if (paramController.diffUnchangedCount === 1) {
+                    clauses.push(qsTr("1 already matches the Vehicle"))
+                } else if (paramController.diffUnchangedCount > 1) {
+                    clauses.push(qsTr("%1 already match the Vehicle").arg(paramController.diffUnchangedCount))
+                }
+                if (paramController.diffReadOnlyCount === 1) {
+                    clauses.push(qsTr("1 read-only parameter will not be sent"))
+                } else if (paramController.diffReadOnlyCount > 1) {
+                    clauses.push(qsTr("%1 read-only parameters will not be sent").arg(paramController.diffReadOnlyCount))
+                }
+                if (paramController.diffMissingParams.length > 0) {
+                    clauses.push(qsTr("%1 not found on the Vehicle and cannot be sent").arg(paramController.diffMissingParams.length))
+                }
+                if (paramController.diffParsedCount === 1) {
+                    return clauses.length === 0 ? qsTr("Loaded 1 parameter from file.")
+                                                : qsTr("Loaded 1 parameter from file: %1.").arg(clauses.join(", "))
+                }
+                return clauses.length === 0 ? qsTr("Loaded %1 parameters from file.").arg(paramController.diffParsedCount)
+                                            : qsTr("Loaded %1 parameters from file: %2.").arg(paramController.diffParsedCount).arg(clauses.join(", "))
+            }
+        }
+
+        QGCLabel {
+            objectName:             "diffOkHintLabel"
+            Layout.preferredWidth:  summaryLabel.Layout.preferredWidth
+            wrapMode:               Text.WordWrap
+            visible:                _sendableCount > 0
+            text:                   qsTr("Click 'Ok' to update the parameters below on the Vehicle.")
         }
 
         GridLayout {
-            id:         mainGrid
-            rows:       paramController.diffList.count + 1
-            columns:    paramController.diffMultipleComponents ? 5 : 4
-            flow:       GridLayout.TopToBottom
-            visible:    paramController.diffList.count
+            id:             mainGrid
+            objectName:     "diffGrid"
+            rows:           paramController.diffList.count + 1
+            columns:        paramController.diffMultipleComponents ? 5 : 4
+            flow:           GridLayout.TopToBottom
+            rowSpacing:     0
+            columnSpacing:  ScreenTools.defaultFontPixelWidth
+            visible:        paramController.diffList.count
 
             QGCCheckBox {
+                objectName: "diffCheckAllCheckbox"
                 checked: true
                 onClicked: {
                     for (var i=0; i<paramController.diffList.count; i++) {
-                        paramController.diffList.get(i).load = checked
+                        var paramDiff = paramController.diffList.get(i)
+                        if (!paramDiff.cannotSend) {
+                            paramDiff.load = checked
+                        }
                     }
                 }
             }
             Repeater {
                 model: paramController.diffList
                 QGCCheckBox {
+                    objectName: "diffRowCheckbox_" + (paramController.diffMultipleComponents ? object.componentId + "_" : "") + object.name
+                    enabled:    !object.cannotSend
                     checked:    object.load
                     onClicked:  object.load = checked
                 }
@@ -75,8 +123,28 @@ QGCPopupDialog {
             QGCLabel { text: qsTr("Vehicle") }
             Repeater {
                 model: paramController.diffList
-                QGCLabel { text: object.noVehicleValue ? qsTr("N/A") : object.vehicleValue + " " + object.units }
+                QGCLabel {
+                    text: object.cannotSend ? qsTr("N/A — not on Vehicle") :
+                          object.noVehicleValue ? qsTr("N/A — new to Vehicle") :
+                          object.vehicleValue + " " + object.units
+                }
             }
+        }
+
+        QGCLabel {
+            objectName:             "diffNoVehicleHintLabel"
+            Layout.preferredWidth:  summaryLabel.Layout.preferredWidth
+            wrapMode:               Text.WordWrap
+            visible:                paramController.diffNoVehicleCount > 0
+            text:                   qsTr("Parameters marked 'new to Vehicle' have not been reported by the Vehicle. They may only become visible after they are sent and the Vehicle is rebooted.")
+        }
+
+        QGCLabel {
+            objectName:             "diffCannotSendHintLabel"
+            Layout.preferredWidth:  summaryLabel.Layout.preferredWidth
+            wrapMode:               Text.WordWrap
+            visible:                paramController.diffMissingParams.length > 0
+            text:                   qsTr("Parameters marked 'not on Vehicle' cannot be sent since the file does not include type information. They may only exist after another parameter is changed and the Vehicle is rebooted, after which you can load this file again.")
         }
     }
 }

--- a/src/QmlControls/ParameterEditor.qml
+++ b/src/QmlControls/ParameterEditor.qml
@@ -26,14 +26,6 @@ Item {
         id: controller
     }
 
-    Connections {
-        target: controller
-        function onMissingParamsFromFile(missingParams) {
-            QGroundControl.showMessageDialog(_root, qsTr("Missing Parameters"),
-                qsTr("The following parameters from the file were not found on the vehicle and were skipped: %1").arg(missingParams.join("\n")))
-        }
-    }
-
     Timer {
         id:         clearTimer
         interval:   100;
@@ -68,6 +60,7 @@ Item {
         }
         QGCMenuSeparator { }
         QGCMenuItem {
+            objectName:     "parameterEditor_toolLoadFromFile"
             text:           qsTr("Load from file for review...")
             onTriggered: {
                 fileDialog.title =          qsTr("Load Parameters")
@@ -184,6 +177,7 @@ Item {
 
         QGCButton {
             Layout.alignment:   Qt.AlignRight
+            objectName:         "parameterEditor_toolsButton"
             text:               qsTr("Tools")
             onClicked:          toolsMenu.popup()
         }

--- a/src/QmlControls/ParameterEditorController.cc
+++ b/src/QmlControls/ParameterEditorController.cc
@@ -348,41 +348,87 @@ void ParameterEditorController::saveToFile(const QString& filename)
         QFile file(parameterFilename);
 
         if (!file.open(QIODevice::WriteOnly | QIODevice::Text)) {
+            qCWarning(ParameterEditorControllerLog) << "saveToFile: unable to create file" << parameterFilename;
             QGC::showAppMessage(tr("Unable to create file: %1").arg(parameterFilename));
             return;
         }
 
+        qCDebug(ParameterEditorControllerLog) << "saveToFile:" << parameterFilename;
         QTextStream stream(&file);
         _parameterMgr->writeParametersToStream(stream);
         file.close();
     }
 }
 
+template <typename T, typename SignalFn>
+void ParameterEditorController::_setDiffProperty(T& member, const T& value, SignalFn changedSignal)
+{
+    if (member == value) {
+        return;
+    }
+    member = value;
+    emit (this->*changedSignal)(member);
+}
+
 void ParameterEditorController::clearDiff(void)
 {
     _diffList.clearAndDeleteContents();
-    _diffOtherVehicle = false;
-    _diffMultipleComponents = false;
-    _diffMissingParams.clear();
+    _setDiffProperty(_diffOtherVehicle,         false,          &ParameterEditorController::diffOtherVehicleChanged);
+    _setDiffProperty(_diffMultipleComponents,   false,          &ParameterEditorController::diffMultipleComponentsChanged);
+    _setDiffProperty(_diffParsedCount,          0,              &ParameterEditorController::diffParsedCountChanged);
+    _setDiffProperty(_diffUnchangedCount,       0,              &ParameterEditorController::diffUnchangedCountChanged);
+    _setDiffProperty(_diffReadOnlyCount,        0,              &ParameterEditorController::diffReadOnlyCountChanged);
+    _setDiffProperty(_diffNoVehicleCount,       0,              &ParameterEditorController::diffNoVehicleCountChanged);
+    _setDiffProperty(_diffSendableCount,        0,              &ParameterEditorController::diffSendableCountChanged);
+    _setDiffProperty(_diffSelectedCount,        0,              &ParameterEditorController::diffSelectedCountChanged);
+    _setDiffProperty(_diffMissingParams,        QStringList(),  &ParameterEditorController::diffMissingParamsChanged);
+}
 
-    emit diffOtherVehicleChanged(_diffOtherVehicle);
-    emit diffMultipleComponentsChanged(_diffMultipleComponents);
+// Recomputed whenever a diff row's load checkbox changes. Drives the dialog's Ok button enabled state.
+void ParameterEditorController::_updateDiffSelectedCount()
+{
+    int selectedCount = 0;
+    for (int i=0; i<_diffList.count(); i++) {
+        const ParameterEditorDiff* paramDiff = _diffList.value<ParameterEditorDiff*>(i);
+        if (paramDiff->load && !paramDiff->cannotSend) {
+            selectedCount++;
+        }
+    }
+    _setDiffProperty(_diffSelectedCount, selectedCount, &ParameterEditorController::diffSelectedCountChanged);
 }
 
 void ParameterEditorController::sendDiff(void)
 {
+    int sentCount = 0;
+    int uncheckedCount = 0;
+
     for (int i=0; i<_diffList.count(); i++) {
         ParameterEditorDiff* paramDiff = _diffList.value<ParameterEditorDiff*>(i);
 
+        if (paramDiff->cannotSend) {
+            qCDebug(ParameterEditorControllerLog) << "sendDiff: skipped (cannot send, not on vehicle) -" << paramDiff->name;
+            continue;
+        }
+
         if (paramDiff->load) {
+            sentCount++;
             if (paramDiff->noVehicleValue) {
+                qCDebug(ParameterEditorControllerLog) << "sendDiff: PARAM_SET new param -" << paramDiff->name
+                    << "componentId:" << paramDiff->componentId << "value:" << paramDiff->fileValueVar;
                 _parameterMgr->_mavlinkParamSet(paramDiff->componentId, paramDiff->name, paramDiff->valueType, paramDiff->fileValueVar);
             } else {
+                qCDebug(ParameterEditorControllerLog) << "sendDiff: fact write -" << paramDiff->name
+                    << "componentId:" << paramDiff->componentId << "value:" << paramDiff->fileValueVar;
                 Fact* fact = _parameterMgr->getParameter(paramDiff->componentId, paramDiff->name);
                 fact->setRawValue(paramDiff->fileValueVar);
             }
+        } else {
+            uncheckedCount++;
+            qCDebug(ParameterEditorControllerLog) << "sendDiff: skipped (unchecked) -" << paramDiff->name;
         }
     }
+
+    qCDebug(ParameterEditorControllerLog) << "sendDiff summary - sent:" << sentCount << "unchecked:" << uncheckedCount;
 }
 
 bool ParameterEditorController::buildDiffFromFile(const QString& filename)
@@ -390,15 +436,27 @@ bool ParameterEditorController::buildDiffFromFile(const QString& filename)
     QFile file(filename);
 
     if (!file.open(QIODevice::ReadOnly | QIODevice::Text)) {
+        qCWarning(ParameterEditorControllerLog) << "buildDiffFromFile: unable to open file" << filename;
         QGC::showAppMessage(tr("Unable to open file: %1").arg(filename));
         return false;
     }
 
     clearDiff();
 
+    qCDebug(ParameterEditorControllerLog) << "buildDiffFromFile:" << filename;
+
     QTextStream stream(&file);
 
-    int parsedLineCount = 0;
+    // Accumulate in locals; property setters at the end emit only for values that changed.
+    bool        diffOtherVehicle        = false;
+    bool        diffMultipleComponents  = false;
+    int         diffParsedCount         = 0;
+    int         diffUnchangedCount      = 0;
+    int         diffReadOnlyCount       = 0;
+    int         diffNoVehicleCount      = 0;
+    int         diffSendableCount       = 0;
+    QStringList diffMissingParams;
+
     int firstComponentId = -1;
     while (!stream.atEnd()) {
         QString line = stream.readLine();
@@ -420,12 +478,18 @@ bool ParameterEditorController::buildDiffFromFile(const QString& filename)
                 mavParamType    = wpParams.at(4).toInt();
 
                 if (_vehicle->id() != vehicleId) {
-                    _diffOtherVehicle = true;
+                    if (!diffOtherVehicle) {
+                        qCDebug(ParameterEditorControllerLog) << "buildDiffFromFile: file is from other vehicle - file vehicleId:" << vehicleId << "connected vehicleId:" << _vehicle->id();
+                    }
+                    diffOtherVehicle = true;
                 }
                 if (firstComponentId == -1) {
                     firstComponentId = componentId;
                 } else if (firstComponentId != componentId) {
-                    _diffMultipleComponents = true;
+                    if (!diffMultipleComponents) {
+                        qCDebug(ParameterEditorControllerLog) << "buildDiffFromFile: file contains multiple componentIds:" << firstComponentId << componentId;
+                    }
+                    diffMultipleComponents = true;
                 }
             } else if (wpParams.size() == 2) {
                 // Mission Planner 2-column: Name Value
@@ -434,10 +498,11 @@ bool ParameterEditorController::buildDiffFromFile(const QString& filename)
                 componentId     = ParameterManager::defaultComponentId;
                 isMPFormat      = true;
             } else {
+                qCDebug(ParameterEditorControllerLog) << "buildDiffFromFile: skipping unparseable line:" << line.trimmed().left(80);
                 continue;
             }
 
-            parsedLineCount++;
+            diffParsedCount++;
 
             QString     vehicleValueStr;
             QString     units;
@@ -448,7 +513,7 @@ bool ParameterEditorController::buildDiffFromFile(const QString& filename)
             if (_parameterMgr->parameterExists(componentId, paramName)) {
                 Fact*           vehicleFact         = _parameterMgr->getParameter(componentId, paramName);
                 FactMetaData*   vehicleFactMetaData = vehicleFact->metaData();
-                Fact*           fileFact            = new Fact(vehicleFact->componentId(), vehicleFact->name(), vehicleFact->type(), this);
+                Fact            fileFact(vehicleFact->componentId(), vehicleFact->name(), vehicleFact->type());
 
                 if (mavParamType == -1) {
                     mavParamType = ParameterManager::factTypeToMavType(vehicleFact->type());
@@ -457,24 +522,57 @@ bool ParameterEditorController::buildDiffFromFile(const QString& filename)
                 // Turn off reboot messaging before setting value in fileFact
                 bool vehicleRebootRequired = vehicleFactMetaData->vehicleRebootRequired();
                 vehicleFactMetaData->setVehicleRebootRequired(false);
-                fileFact->setMetaData(vehicleFact->metaData());
-                fileFact->setRawValue(fileValueStr);
+                fileFact.setMetaData(vehicleFact->metaData());
+                fileFact.setRawValue(fileValueStr);
                 vehicleFactMetaData->setVehicleRebootRequired(vehicleRebootRequired);
                 readOnly = vehicleFact->readOnly();
 
-                if (vehicleFact->rawValue() == fileFact->rawValue()) {
+                if (vehicleFact->rawValue() == fileFact.rawValue()) {
+                    diffUnchangedCount++;
                     continue;
                 }
-                fileValueStr    = fileFact->enumOrValueString();
-                fileValueVar    = fileFact->rawValue();
+                qCDebug(ParameterEditorControllerLog) << "buildDiffFromFile: changed -" << paramName
+                    << "vehicle:" << vehicleFact->rawValue() << "file:" << fileFact.rawValue();
+                fileValueStr    = fileFact.enumOrValueString();
+                fileValueVar    = fileFact.rawValue();
                 vehicleValueStr = vehicleFact->enumOrValueString();
                 units           = vehicleFact->cookedUnits();
             } else if (isMPFormat) {
-                // MP format: skip params not on vehicle and report them
-                _diffMissingParams.append(paramName);
+                // MP format: param not on vehicle and file carries no type info, so it can never
+                // be sent. Show it in the diff list as a disabled (cannot-send) row.
+                qCDebug(ParameterEditorControllerLog) << "buildDiffFromFile: not on vehicle, cannot send (MP format) -" << paramName;
+                diffMissingParams.append(paramName);
+
+                ParameterEditorDiff* paramDiff = new ParameterEditorDiff(this);
+
+                paramDiff->componentId  = componentId;
+                paramDiff->name         = paramName;
+                paramDiff->valueType    = FactMetaData::valueTypeFloat;    // Unknown - never sent
+                paramDiff->fileValue    = fileValueStr;
+                paramDiff->fileValueVar = fileValueVar;
+                paramDiff->cannotSend   = true;
+                paramDiff->load         = false;
+
+                _diffList.append(paramDiff);
                 continue;
             } else {
+                qCDebug(ParameterEditorControllerLog) << "buildDiffFromFile: not on vehicle, will send as new (QGC format) -" << paramName << "value:" << fileValueStr;
                 noVehicleValue = true;
+
+                // fileValueVar is still a QString variant. Convert it to the typed variant matching the
+                // file's param type, otherwise the PARAM_VALUE ack type check in _mavlinkParamSet fails
+                // and the send would retry/time out.
+                const FactMetaData metaData(ParameterManager::mavTypeToFactType(static_cast<MAV_PARAM_TYPE>(mavParamType)));
+                QVariant    typedValue;
+                QString     errorString;
+                if (metaData.convertAndValidateRaw(fileValueVar, true /* convertOnly */, typedValue, errorString)) {
+                    fileValueVar = typedValue;
+                } else {
+                    qCWarning(ParameterEditorControllerLog) << "buildDiffFromFile: value conversion failed, skipping -" << paramName
+                        << "value:" << fileValueStr << "error:" << errorString;
+                    diffParsedCount--;
+                    continue;
+                }
             }
 
             if (!readOnly) {
@@ -489,23 +587,46 @@ bool ParameterEditorController::buildDiffFromFile(const QString& filename)
                 paramDiff->noVehicleValue   = noVehicleValue;
                 paramDiff->units            = units;
 
+                (void) connect(paramDiff, &ParameterEditorDiff::loadChanged, this, &ParameterEditorController::_updateDiffSelectedCount);
+
                 _diffList.append(paramDiff);
+                diffSendableCount++;
+
+                if (noVehicleValue) {
+                    diffNoVehicleCount++;
+                }
+            } else {
+                qCDebug(ParameterEditorControllerLog) << "buildDiffFromFile: skipping read-only param -" << paramName;
+                diffReadOnlyCount++;
             }
         }
     }
 
     file.close();
 
-    if (parsedLineCount == 0) {
+    if (diffParsedCount == 0) {
         QGC::showAppMessage(tr("No valid parameters found in file. Check that the file is in QGC or Mission Planner format."));
         return false;
     }
 
-    emit diffOtherVehicleChanged(_diffOtherVehicle);
-    emit diffMultipleComponentsChanged(_diffMultipleComponents);
-    if (!_diffMissingParams.isEmpty()) {
-        emit missingParamsFromFile(_diffMissingParams);
-    }
+    qCDebug(ParameterEditorControllerLog) << "buildDiffFromFile summary -"
+        << "parsed:" << diffParsedCount
+        << "changed:" << diffSendableCount
+        << "unchanged:" << diffUnchangedCount
+        << "readOnly:" << diffReadOnlyCount
+        << "noVehicleValue:" << diffNoVehicleCount
+        << "missing:" << diffMissingParams.count()
+        << (diffMissingParams.isEmpty() ? QString() : diffMissingParams.join(QStringLiteral(", ")));
+
+    _setDiffProperty(_diffOtherVehicle,         diffOtherVehicle,       &ParameterEditorController::diffOtherVehicleChanged);
+    _setDiffProperty(_diffMultipleComponents,   diffMultipleComponents, &ParameterEditorController::diffMultipleComponentsChanged);
+    _setDiffProperty(_diffParsedCount,          diffParsedCount,        &ParameterEditorController::diffParsedCountChanged);
+    _setDiffProperty(_diffUnchangedCount,       diffUnchangedCount,     &ParameterEditorController::diffUnchangedCountChanged);
+    _setDiffProperty(_diffReadOnlyCount,        diffReadOnlyCount,      &ParameterEditorController::diffReadOnlyCountChanged);
+    _setDiffProperty(_diffNoVehicleCount,       diffNoVehicleCount,     &ParameterEditorController::diffNoVehicleCountChanged);
+    _setDiffProperty(_diffSendableCount,        diffSendableCount,      &ParameterEditorController::diffSendableCountChanged);
+    _setDiffProperty(_diffSelectedCount,        diffSendableCount,      &ParameterEditorController::diffSelectedCountChanged); // All sendable rows start checked
+    _setDiffProperty(_diffMissingParams,        diffMissingParams,      &ParameterEditorController::diffMissingParamsChanged);
 
     return true;
 }

--- a/src/QmlControls/ParameterEditorController.h
+++ b/src/QmlControls/ParameterEditorController.h
@@ -104,6 +104,7 @@ public:
     Q_PROPERTY(QString  fileValue           MEMBER fileValue        CONSTANT)
     Q_PROPERTY(QString  vehicleValue        MEMBER vehicleValue     CONSTANT)
     Q_PROPERTY(bool     noVehicleValue      MEMBER noVehicleValue   CONSTANT)
+    Q_PROPERTY(bool     cannotSend          MEMBER cannotSend       CONSTANT)
     Q_PROPERTY(QString  units               MEMBER units            CONSTANT)
     Q_PROPERTY(bool     load                MEMBER load             NOTIFY loadChanged)
 
@@ -114,6 +115,7 @@ public:
     QVariant                    fileValueVar;
     QString                     vehicleValue;
     bool                        noVehicleValue  = false;
+    bool                        cannotSend      = false;    ///< Param not on vehicle and file has no type info (MP format) - shown but never sent
     QString                     units;
     bool                        load            = true;
 
@@ -136,9 +138,16 @@ class ParameterEditorController : public FactPanelController
     Q_PROPERTY(QStringList          favoriteParameterNames  READ favoriteParameterNames                                 NOTIFY favoritesChanged)
 
     // These property are related to the diff associated with a load from file
-    Q_PROPERTY(bool                 diffOtherVehicle        MEMBER _diffOtherVehicle                                    NOTIFY diffOtherVehicleChanged)
-    Q_PROPERTY(bool                 diffMultipleComponents  MEMBER _diffMultipleComponents                              NOTIFY diffMultipleComponentsChanged)
+    Q_PROPERTY(bool                 diffOtherVehicle        READ diffOtherVehicle                                       NOTIFY diffOtherVehicleChanged)
+    Q_PROPERTY(bool                 diffMultipleComponents  READ diffMultipleComponents                                 NOTIFY diffMultipleComponentsChanged)
     Q_PROPERTY(QmlObjectListModel*  diffList                READ diffList                                               CONSTANT)
+    Q_PROPERTY(int                  diffParsedCount         READ diffParsedCount                                        NOTIFY diffParsedCountChanged)
+    Q_PROPERTY(int                  diffUnchangedCount      READ diffUnchangedCount                                     NOTIFY diffUnchangedCountChanged)
+    Q_PROPERTY(int                  diffReadOnlyCount       READ diffReadOnlyCount                                      NOTIFY diffReadOnlyCountChanged)
+    Q_PROPERTY(int                  diffNoVehicleCount      READ diffNoVehicleCount                                     NOTIFY diffNoVehicleCountChanged)
+    Q_PROPERTY(int                  diffSendableCount       READ diffSendableCount                                      NOTIFY diffSendableCountChanged)
+    Q_PROPERTY(int                  diffSelectedCount       READ diffSelectedCount                                      NOTIFY diffSelectedCountChanged)
+    Q_PROPERTY(QStringList          diffMissingParams       READ diffMissingParams                                      NOTIFY diffMissingParamsChanged)
 
 public:
     explicit ParameterEditorController(QObject *parent = nullptr);
@@ -159,6 +168,15 @@ public:
     QObject*            currentGroup            (void) { return _currentGroup; }
     QmlObjectListModel* categories              (void) { return &_categories; }
     QmlObjectListModel* diffList                (void) { return &_diffList; }
+    bool                diffOtherVehicle        (void) const { return _diffOtherVehicle; }
+    bool                diffMultipleComponents  (void) const { return _diffMultipleComponents; }
+    int                 diffParsedCount         (void) const { return _diffParsedCount; }
+    int                 diffUnchangedCount      (void) const { return _diffUnchangedCount; }
+    int                 diffReadOnlyCount       (void) const { return _diffReadOnlyCount; }
+    int                 diffNoVehicleCount      (void) const { return _diffNoVehicleCount; }
+    int                 diffSendableCount       (void) const { return _diffSendableCount; }
+    int                 diffSelectedCount       (void) const { return _diffSelectedCount; }
+    QStringList         diffMissingParams       (void) const { return _diffMissingParams; }
     QStringList         favoriteParameterNames  (void) const;
     void                setCurrentCategory  (QObject* currentCategory);
     void                setCurrentGroup     (QObject* currentGroup);
@@ -173,8 +191,14 @@ signals:
     void favoritesChanged               (void);
     void diffOtherVehicleChanged        (bool diffOtherVehicle);
     void diffMultipleComponentsChanged  (bool diffMultipleComponents);
+    void diffParsedCountChanged         (int diffParsedCount);
+    void diffUnchangedCountChanged      (int diffUnchangedCount);
+    void diffReadOnlyCountChanged       (int diffReadOnlyCount);
+    void diffNoVehicleCountChanged      (int diffNoVehicleCount);
+    void diffSendableCountChanged       (int diffSendableCount);
+    void diffSelectedCountChanged       (int diffSelectedCount);
+    void diffMissingParamsChanged       (const QStringList& diffMissingParams);
     void parametersChanged              (void);
-    void missingParamsFromFile          (const QStringList& missingParams);
 
 private slots:
     void _currentCategoryChanged(void);
@@ -190,8 +214,12 @@ private:
     void _performSearch();
     void _loadFavorites();
     void _saveFavorites();
+    void _updateDiffSelectedCount();
 
-private:
+    /// Assigns value to member and emits changedSignal only if the value actually changed.
+    template <typename T, typename SignalFn>
+    void _setDiffProperty(T& member, const T& value, SignalFn changedSignal);
+
     ParameterManager*           _parameterMgr           = nullptr;
     QString                     _searchText;
     QTimer                      _searchTimer;
@@ -202,6 +230,12 @@ private:
     bool                        _hideReadOnly           = false;
     bool                        _diffOtherVehicle       = false;
     bool                        _diffMultipleComponents = false;
+    int                         _diffParsedCount        = 0;
+    int                         _diffUnchangedCount     = 0;
+    int                         _diffReadOnlyCount      = 0;
+    int                         _diffNoVehicleCount     = 0;
+    int                         _diffSendableCount      = 0;
+    int                         _diffSelectedCount      = 0;
     QStringList                 _diffMissingParams;
     QSet<QString>               _favoriteNames;
 

--- a/src/Vehicle/VehicleSetup/VehicleConfigView.qml
+++ b/src/Vehicle/VehicleSetup/VehicleConfigView.qml
@@ -524,6 +524,7 @@ Rectangle {
 
                 ConfigButton {
                     id:                 parametersButton
+                    objectName:         "vehicleConfig_parametersButton"
                     visible:            QGroundControl.multiVehicleManager.parameterReadyVehicleAvailable &&
                                         !_activeVehicle.usingHighLatencyLink &&
                                         _corePlugin.showAdvancedUI &&

--- a/test/FactSystem/ParameterEditorControllerTest.cc
+++ b/test/FactSystem/ParameterEditorControllerTest.cc
@@ -6,6 +6,7 @@
 #include <QtTest/QSignalSpy>
 
 #include "ParameterEditorController.h"
+#include "ParameterManager.h"
 #include "QmlObjectListModel.h"
 #include "Fixtures/RAIIFixtures.h"
 #include "UnitTest.h"
@@ -39,7 +40,7 @@ static const char* kMPParamsNoDiff =
 // Mission Planner 2-column file with a parameter not on the vehicle
 static const char* kMPParamsMissingParam =
     "# Mission Planner parameter file\n"
-    "NONEXISTENT_PARAM_XYZ,1\n";
+    "NO_SUCH_PARAM,1\n";
 
 // Garbage — no parseable lines
 static const char* kBadFormatParams =
@@ -51,7 +52,24 @@ static const char* kQGCParamsUnknownParam =
     "# Onboard parameters for Vehicle 1\n"
     "#\n"
     "# Vehicle-Id Component-Id Name Value Type\n"
-    "1\t1\tNONEXISTENT_PARAM_XYZ\t1\t6\n";
+    "1\t1\tNO_SUCH_PARAM\t1\t6\n";
+
+// Mission Planner file mixing a changed, an unchanged and a missing parameter
+static const char* kMPParamsMixed =
+    "# Mission Planner parameter file\n"
+    "SYS_AUTOSTART,4002\n"
+    "COM_DL_LOSS_T,10\n"
+    "NO_SUCH_PARAM,1\n";
+
+// Verify the diff summary counter invariant: parsed == diffList (sendable + cannot-send) + unchanged + readOnly.
+// MP-format missing params are included in diffList as cannot-send rows.
+static void verifyDiffInvariant(ParameterEditorController& controller)
+{
+    QCOMPARE(controller.property("diffParsedCount").toInt(),
+             controller.diffList()->count()
+                 + controller.property("diffUnchangedCount").toInt()
+                 + controller.property("diffReadOnlyCount").toInt());
+}
 
 void ParameterEditorControllerTest::_buildDiffQGCFormat()
 {
@@ -68,6 +86,19 @@ void ParameterEditorControllerTest::_buildDiffQGCFormat()
     const auto* diff = controller.diffList()->value<ParameterEditorDiff*>(0);
     QVERIFY(diff);
     QCOMPARE(diff->name, QStringLiteral("SYS_AUTOSTART"));
+    QCOMPARE(controller.property("diffParsedCount").toInt(), 1);
+    QCOMPARE(controller.property("diffUnchangedCount").toInt(), 0);
+    QCOMPARE(controller.property("diffNoVehicleCount").toInt(), 0);
+    QVERIFY(controller.property("diffMissingParams").toStringList().isEmpty());
+    verifyDiffInvariant(controller);
+
+    // Selected count starts at the sendable count and tracks load checkbox changes
+    QCOMPARE(controller.property("diffSelectedCount").toInt(), 1);
+    auto* mutableDiff = controller.diffList()->value<ParameterEditorDiff*>(0);
+    mutableDiff->setProperty("load", false);
+    QCOMPARE(controller.property("diffSelectedCount").toInt(), 0);
+    mutableDiff->setProperty("load", true);
+    QCOMPARE(controller.property("diffSelectedCount").toInt(), 1);
 }
 
 void ParameterEditorControllerTest::_buildDiffMPFormat()
@@ -85,6 +116,8 @@ void ParameterEditorControllerTest::_buildDiffMPFormat()
     const auto* diff = controller.diffList()->value<ParameterEditorDiff*>(0);
     QVERIFY(diff);
     QCOMPARE(diff->name, QStringLiteral("SYS_AUTOSTART"));
+    QCOMPARE(controller.property("diffParsedCount").toInt(), 1);
+    verifyDiffInvariant(controller);
 }
 
 void ParameterEditorControllerTest::_buildDiffNoDifferencesQGC()
@@ -99,6 +132,9 @@ void ParameterEditorControllerTest::_buildDiffNoDifferencesQGC()
 
     QVERIFY(result);
     QCOMPARE(controller.diffList()->count(), 0);
+    QCOMPARE(controller.property("diffParsedCount").toInt(), 1);
+    QCOMPARE(controller.property("diffUnchangedCount").toInt(), 1);
+    verifyDiffInvariant(controller);
 }
 
 void ParameterEditorControllerTest::_buildDiffNoDifferencesMP()
@@ -113,6 +149,9 @@ void ParameterEditorControllerTest::_buildDiffNoDifferencesMP()
 
     QVERIFY(result);
     QCOMPARE(controller.diffList()->count(), 0);
+    QCOMPARE(controller.property("diffParsedCount").toInt(), 1);
+    QCOMPARE(controller.property("diffUnchangedCount").toInt(), 1);
+    verifyDiffInvariant(controller);
 }
 
 void ParameterEditorControllerTest::_buildDiffBadFormat()
@@ -129,6 +168,7 @@ void ParameterEditorControllerTest::_buildDiffBadFormat()
 
     QVERIFY(!result);
     QCOMPARE(controller.diffList()->count(), 0);
+    QCOMPARE(controller.property("diffParsedCount").toInt(), 0);
 }
 
 void ParameterEditorControllerTest::_buildDiffMissingOnVehicle()
@@ -146,7 +186,15 @@ void ParameterEditorControllerTest::_buildDiffMissingOnVehicle()
     const auto* diff = controller.diffList()->value<ParameterEditorDiff*>(0);
     QVERIFY(diff);
     QVERIFY(diff->noVehicleValue);
-    QCOMPARE(diff->name, QStringLiteral("NONEXISTENT_PARAM_XYZ"));
+    QCOMPARE(diff->name, QStringLiteral("NO_SUCH_PARAM"));
+    // File value must be converted from string to the typed variant (file type 6 = INT32),
+    // otherwise the PARAM_VALUE ack type check in _mavlinkParamSet never matches.
+    QCOMPARE(diff->fileValueVar.typeId(), QMetaType::Int);
+    QCOMPARE(diff->fileValueVar.toInt(), 1);
+    QCOMPARE(controller.property("diffParsedCount").toInt(), 1);
+    QCOMPARE(controller.property("diffNoVehicleCount").toInt(), 1);
+    QVERIFY(controller.property("diffMissingParams").toStringList().isEmpty());
+    verifyDiffInvariant(controller);
 }
 
 void ParameterEditorControllerTest::_buildDiffMPMissingParam()
@@ -157,15 +205,163 @@ void ParameterEditorControllerTest::_buildDiffMPMissingParam()
     QVERIFY(tempFile.file()->flush());
 
     ParameterEditorController controller;
-    QSignalSpy missingSpy(&controller, &ParameterEditorController::missingParamsFromFile);
     const bool result = controller.buildDiffFromFile(tempFile.path());
 
     QVERIFY(result);
-    // Unknown MP param is skipped — diff list stays empty
-    QCOMPARE(controller.diffList()->count(), 0);
-    // Signal emitted once with the missing param name
-    QCOMPARE(missingSpy.count(), 1);
-    const QStringList missingParams = missingSpy.at(0).at(0).toStringList();
+    // Unknown MP param becomes a disabled cannot-send row in the diff list
+    QCOMPARE(controller.diffList()->count(), 1);
+    const auto* diff = controller.diffList()->value<ParameterEditorDiff*>(0);
+    QVERIFY(diff);
+    QCOMPARE(diff->name, QStringLiteral("NO_SUCH_PARAM"));
+    QVERIFY(diff->cannotSend);
+    QVERIFY(!diff->load);
+    const QStringList missingParams = controller.property("diffMissingParams").toStringList();
     QCOMPARE(missingParams.count(), 1);
-    QCOMPARE(missingParams.at(0), QStringLiteral("NONEXISTENT_PARAM_XYZ"));
+    QCOMPARE(missingParams.at(0), QStringLiteral("NO_SUCH_PARAM"));
+    QCOMPARE(controller.property("diffParsedCount").toInt(), 1);
+    verifyDiffInvariant(controller);
+}
+
+void ParameterEditorControllerTest::_buildDiffMixedMP()
+{
+    TestFixtures::TempFileFixture tempFile(QStringLiteral("test_XXXXXX.param"));
+    QVERIFY(tempFile.isValid());
+    QVERIFY(tempFile.write(QByteArray(kMPParamsMixed)));
+    QVERIFY(tempFile.file()->flush());
+
+    ParameterEditorController controller;
+    const bool result = controller.buildDiffFromFile(tempFile.path());
+
+    QVERIFY(result);
+    QCOMPARE(controller.property("diffParsedCount").toInt(), 3);
+    // Diff list holds the changed row plus the cannot-send row
+    QCOMPARE(controller.diffList()->count(), 2);
+    const auto* changedDiff = controller.diffList()->value<ParameterEditorDiff*>(0);
+    QVERIFY(changedDiff);
+    QCOMPARE(changedDiff->name, QStringLiteral("SYS_AUTOSTART"));
+    QVERIFY(!changedDiff->cannotSend);
+    const auto* missingDiff = controller.diffList()->value<ParameterEditorDiff*>(1);
+    QVERIFY(missingDiff);
+    QCOMPARE(missingDiff->name, QStringLiteral("NO_SUCH_PARAM"));
+    QVERIFY(missingDiff->cannotSend);
+    QVERIFY(!missingDiff->load);
+    QCOMPARE(controller.property("diffUnchangedCount").toInt(), 1);
+    const QStringList missingParams = controller.property("diffMissingParams").toStringList();
+    QCOMPARE(missingParams, QStringList{QStringLiteral("NO_SUCH_PARAM")});
+    verifyDiffInvariant(controller);
+}
+
+void ParameterEditorControllerTest::_clearDiffResetsState()
+{
+    TestFixtures::TempFileFixture tempFile(QStringLiteral("test_XXXXXX.param"));
+    QVERIFY(tempFile.isValid());
+    QVERIFY(tempFile.write(QByteArray(kMPParamsMixed)));
+    QVERIFY(tempFile.file()->flush());
+
+    ParameterEditorController controller;
+    QVERIFY(controller.buildDiffFromFile(tempFile.path()));
+    QCOMPARE(controller.property("diffParsedCount").toInt(), 3);
+
+    QSignalSpy parsedSpy(&controller, &ParameterEditorController::diffParsedCountChanged);
+    QSignalSpy unchangedSpy(&controller, &ParameterEditorController::diffUnchangedCountChanged);
+    QSignalSpy missingSpy(&controller, &ParameterEditorController::diffMissingParamsChanged);
+    QSignalSpy noVehicleSpy(&controller, &ParameterEditorController::diffNoVehicleCountChanged);
+
+    controller.clearDiff();
+
+    QCOMPARE(controller.diffList()->count(), 0);
+    QCOMPARE(controller.property("diffParsedCount").toInt(), 0);
+    QCOMPARE(controller.property("diffUnchangedCount").toInt(), 0);
+    QCOMPARE(controller.property("diffReadOnlyCount").toInt(), 0);
+    QCOMPARE(controller.property("diffNoVehicleCount").toInt(), 0);
+    QVERIFY(controller.property("diffMissingParams").toStringList().isEmpty());
+
+    // Signals emit exactly once for properties that changed, never for ones that didn't
+    QCOMPARE(parsedSpy.count(), 1);
+    QCOMPARE(unchangedSpy.count(), 1);
+    QCOMPARE(missingSpy.count(), 1);
+    QCOMPARE(noVehicleSpy.count(), 0);  // was already 0
+
+    // Clearing an already-clear diff must not emit anything
+    controller.clearDiff();
+    QCOMPARE(parsedSpy.count(), 1);
+    QCOMPARE(unchangedSpy.count(), 1);
+    QCOMPARE(missingSpy.count(), 1);
+    QCOMPARE(noVehicleSpy.count(), 0);
+}
+
+void ParameterEditorControllerTest::_diffSignalsEmitOnlyOnChange()
+{
+    TestFixtures::TempFileFixture tempFile(QStringLiteral("test_XXXXXX.param"));
+    QVERIFY(tempFile.isValid());
+    QVERIFY(tempFile.write(QByteArray(kMPParamsMixed)));
+    QVERIFY(tempFile.file()->flush());
+
+    ParameterEditorController controller;
+
+    QSignalSpy parsedSpy(&controller, &ParameterEditorController::diffParsedCountChanged);
+    QSignalSpy unchangedSpy(&controller, &ParameterEditorController::diffUnchangedCountChanged);
+    QSignalSpy readOnlySpy(&controller, &ParameterEditorController::diffReadOnlyCountChanged);
+    QSignalSpy noVehicleSpy(&controller, &ParameterEditorController::diffNoVehicleCountChanged);
+    QSignalSpy sendableSpy(&controller, &ParameterEditorController::diffSendableCountChanged);
+    QSignalSpy missingSpy(&controller, &ParameterEditorController::diffMissingParamsChanged);
+    QSignalSpy otherVehicleSpy(&controller, &ParameterEditorController::diffOtherVehicleChanged);
+    QSignalSpy multipleComponentsSpy(&controller, &ParameterEditorController::diffMultipleComponentsChanged);
+
+    QVERIFY(controller.buildDiffFromFile(tempFile.path()));
+
+    // Mixed MP file: parsed 0→3, unchanged 0→1, sendable 0→1, missing []→[NO_SUCH_PARAM].
+    // Each changed property emits exactly once with the final value.
+    QCOMPARE(parsedSpy.count(), 1);
+    QCOMPARE(parsedSpy.takeFirst().at(0).toInt(), 3);
+    QCOMPARE(unchangedSpy.count(), 1);
+    QCOMPARE(unchangedSpy.takeFirst().at(0).toInt(), 1);
+    QCOMPARE(sendableSpy.count(), 1);
+    QCOMPARE(sendableSpy.takeFirst().at(0).toInt(), 1);
+    QCOMPARE(missingSpy.count(), 1);
+    QCOMPARE(missingSpy.takeFirst().at(0).toStringList(), QStringList{QStringLiteral("NO_SUCH_PARAM")});
+
+    // Properties whose values did not change must not emit at all
+    QCOMPARE(readOnlySpy.count(), 0);
+    QCOMPARE(noVehicleSpy.count(), 0);
+    QCOMPARE(otherVehicleSpy.count(), 0);
+    QCOMPARE(multipleComponentsSpy.count(), 0);
+}
+
+void ParameterEditorControllerTest::_sendDiffUnknownParamStopsAfterWriteFailure()
+{
+    TestFixtures::TempFileFixture tempFile(QStringLiteral("test_XXXXXX.params"));
+    QVERIFY(tempFile.isValid());
+    QVERIFY(tempFile.write(QByteArray(kQGCParamsUnknownParam)));
+    QVERIFY(tempFile.file()->flush());
+
+    ParameterEditorController controller;
+    QVERIFY(controller.buildDiffFromFile(tempFile.path()));
+    QCOMPARE(controller.diffList()->count(), 1);
+
+    ParameterManager* const paramMgr = parameterManager();
+    QVERIFY(paramMgr);
+    QSignalSpy writeFailureSpy(paramMgr, &ParameterManager::_paramSetFailure);
+    QSignalSpy readSuccessSpy(paramMgr, &ParameterManager::_paramRequestReadSuccess);
+    QSignalSpy readFailureSpy(paramMgr, &ParameterManager::_paramRequestReadFailure);
+    QVERIFY(writeFailureSpy.isValid());
+    QVERIFY(readSuccessSpy.isValid());
+    QVERIFY(readFailureSpy.isValid());
+
+    // MockLink rejects the PARAM_SET with PARAM_ERROR DOES_NOT_EXIST: exactly one
+    // write-failed notification, and NO follow-up refresh read of the unknown param
+    expectAppMessage(QRegularExpression(QStringLiteral("Parameter write failed: param: NO_SUCH_PARAM")));
+    controller.sendDiff();
+
+    // PARAM_ERROR is a definitive rejection - no retries, one ack interval suffices
+    const int maxWaitTimeMs = ParameterManager::kWaitForParamValueAckMs + TestTimeout::shortMs();
+    QVERIFY_SIGNAL_WAIT(writeFailureSpy, maxWaitTimeMs);
+    QCOMPARE(writeFailureSpy.count(), 1);
+    verifyExpectedLogMessage();
+
+    // Wait long enough that a (buggy) post-failure refresh would have completed,
+    // then verify no PARAM_REQUEST_READ was ever issued for the unknown param
+    QVERIFY_NO_SIGNAL_WAIT(readFailureSpy, maxWaitTimeMs);
+    QCOMPARE(readFailureSpy.count(), 0);
+    QCOMPARE(readSuccessSpy.count(), 0);
 }

--- a/test/FactSystem/ParameterEditorControllerTest.h
+++ b/test/FactSystem/ParameterEditorControllerTest.h
@@ -14,4 +14,8 @@ private slots:
     void _buildDiffBadFormat();
     void _buildDiffMissingOnVehicle();
     void _buildDiffMPMissingParam();
+    void _buildDiffMixedMP();
+    void _clearDiffResetsState();
+    void _diffSignalsEmitOnlyOnChange();
+    void _sendDiffUnknownParamStopsAfterWriteFailure();
 };

--- a/test/QmlUITests/CMakeLists.txt
+++ b/test/QmlUITests/CMakeLists.txt
@@ -36,6 +36,8 @@ target_sources(${CMAKE_PROJECT_NAME}
         ${CMAKE_CURRENT_SOURCE_DIR}/NTRIPSettingsUITest.h
         ${CMAKE_CURRENT_SOURCE_DIR}/OnboardLogUITest.cc
         ${CMAKE_CURRENT_SOURCE_DIR}/OnboardLogUITest.h
+        ${CMAKE_CURRENT_SOURCE_DIR}/ParameterDiffDialogUITest.cc
+        ${CMAKE_CURRENT_SOURCE_DIR}/ParameterDiffDialogUITest.h
         ${CMAKE_CURRENT_SOURCE_DIR}/RemoteIDSettingsUITest.cc
         ${CMAKE_CURRENT_SOURCE_DIR}/RemoteIDSettingsUITest.h
         ${CMAKE_CURRENT_SOURCE_DIR}/Viewer3DUITest.cc
@@ -58,6 +60,7 @@ add_qgc_test(AppCloseWarningUITest LABELS Integration NoSanitizer TIMEOUT 120)
 add_qgc_test(FlyViewProximityRadarUITest LABELS Integration NoSanitizer TIMEOUT 120)
 add_qgc_test(NTRIPSettingsUITest LABELS Integration NoSanitizer TIMEOUT 120)
 add_qgc_test(OnboardLogUITest LABELS Integration NoSanitizer TIMEOUT 180)
+add_qgc_test(ParameterDiffDialogUITest LABELS Integration NoSanitizer TIMEOUT 180)
 add_qgc_test(RemoteIDSettingsUITest LABELS Integration NoSanitizer TIMEOUT 120)
 
 # Qt Quick 3D requires an RHI backend, which the default software Quick backend

--- a/test/QmlUITests/ParameterDiffDialogUITest.cc
+++ b/test/QmlUITests/ParameterDiffDialogUITest.cc
@@ -1,0 +1,314 @@
+#include "ParameterDiffDialogUITest.h"
+
+#include <QtCore/QPointer>
+#include <QtCore/QRegularExpression>
+#include <QtQuick/QQuickItem>
+#include <QtTest/QTest>
+#include <algorithm>
+
+#include "Fact.h"
+#include "Fixtures/RAIIFixtures.h"
+#include "LogManager.h"
+#include "MockLink.h"
+#include "ParameterManager.h"
+#include "QGCFileDialogController.h"
+#include "Vehicle.h"
+
+UT_REGISTER_TEST(ParameterDiffDialogUITest, TestLabel::Integration)
+
+// QGC tab-delimited file with SYS_AUTOSTART changed from 4001 → 4002
+static const char* kQGCParamsWithDiff =
+    "# Onboard parameters for Vehicle 1\n"
+    "#\n"
+    "# Vehicle-Id Component-Id Name Value Type\n"
+    "1\t1\tSYS_AUTOSTART\t4002\t6\n";
+
+// Mission Planner file where the parameter already matches the vehicle default
+static const char* kMPParamsNoDiff =
+    "# Mission Planner parameter file\n"
+    "SYS_AUTOSTART,4001\n";
+
+// Mission Planner file with a parameter not on the vehicle (cannot be sent)
+static const char* kMPParamsMissingParam =
+    "# Mission Planner parameter file\n"
+    "NO_SUCH_PARAM,1\n";
+
+// QGC file with a parameter not on the vehicle (will be sent as new)
+static const char* kQGCParamsUnknownParam =
+    "# Onboard parameters for Vehicle 1\n"
+    "#\n"
+    "# Vehicle-Id Component-Id Name Value Type\n"
+    "1\t1\tNO_SUCH_PARAM\t1\t6\n";
+
+// QGC file with two changed parameters, for checkbox select/deselect coverage
+static const char* kQGCParamsTwoDiffs =
+    "# Onboard parameters for Vehicle 1\n"
+    "#\n"
+    "# Vehicle-Id Component-Id Name Value Type\n"
+    "1\t1\tSYS_AUTOSTART\t4002\t6\n"
+    "1\t1\tCOM_DL_LOSS_T\t20\t6\n";
+
+// Arm the file dialog test hook with filePath and drive Tools → "Load from
+// file for review..." so ParameterEditor builds the diff and opens the dialog.
+void ParameterDiffDialogUITest::_openDiffDialogForFile(const QString& filePath)
+{
+    QGCFileDialogController::setTestNextFileForAccept(filePath);
+
+    QVERIFY2(clickButton(QStringLiteral("parameterEditor_toolsButton")), "Failed to click Tools button");
+    QVERIFY2(clickButton(QStringLiteral("parameterEditor_toolLoadFromFile")),
+             "Failed to click Load from file menu item");
+    QVERIFY2(waitForDialog(QStringLiteral("Load Parameters")), "Load Parameters dialog never appeared");
+}
+
+bool ParameterDiffDialogUITest::_labelTextContains(const QString& objectName, const QString& substring)
+{
+    QQuickItem* label = findVisibleItem(_rootItem, objectName, 2000);
+    if (!label) {
+        QTest::qFail(qPrintable(QStringLiteral("Label not found: %1").arg(objectName)), __FILE__, __LINE__);
+        return false;
+    }
+    const QString text = label->property("text").toString();
+    if (!text.contains(substring)) {
+        QTest::qFail(
+            qPrintable(QStringLiteral("Label %1 text '%2' does not contain '%3'").arg(objectName, text, substring)),
+            __FILE__, __LINE__);
+        return false;
+    }
+    return true;
+}
+
+void ParameterDiffDialogUITest::_testDiffDialogCases()
+{
+    runWithMockLink(
+        [] { return MockLink::startPX4MockLink(); },
+        [&](QPointer<MockLink> mockLink, Vehicle* vehicle) {
+            navigateToConfigureView();
+            if (QTest::currentTestFailed())
+                return;
+
+            clickSidebarButton(QStringLiteral("vehicleConfig_parametersButton"));
+            if (QTest::currentTestFailed())
+                return;
+
+            QVERIFY2(findVisibleItem(_rootItem, QStringLiteral("parameterEditor_toolsButton"), 3000),
+                     "Parameter editor Tools button never appeared");
+
+            // -------------------------------------------------------------------------
+            // Case: all parameters already match the vehicle (MP format)
+            // -------------------------------------------------------------------------
+            {
+                TestFixtures::TempFileFixture tempFile(QStringLiteral("test_XXXXXX.param"));
+                QVERIFY(tempFile.isValid());
+                QVERIFY(tempFile.write(QByteArray(kMPParamsNoDiff)));
+                QVERIFY(tempFile.file()->flush());
+
+                _openDiffDialogForFile(tempFile.path());
+                if (QTest::currentTestFailed())
+                    return;
+
+                if (!_labelTextContains(QStringLiteral("diffSummaryLabel"),
+                                        QStringLiteral("1 already matches the Vehicle")))
+                    return;
+                verifyVisibility(QStringLiteral("diffGrid"), false, QStringLiteral("all-match case"));
+                verifyVisibility(QStringLiteral("diffCannotSendHintLabel"), false, QStringLiteral("all-match case"));
+                if (QTest::currentTestFailed())
+                    return;
+
+                QVERIFY2(rejectDialog(), "Failed to close all-match dialog");
+            }
+
+            // -------------------------------------------------------------------------
+            // Case: parameter not on vehicle, MP format — cannot be sent
+            // -------------------------------------------------------------------------
+            {
+                TestFixtures::TempFileFixture tempFile(QStringLiteral("test_XXXXXX.param"));
+                QVERIFY(tempFile.isValid());
+                QVERIFY(tempFile.write(QByteArray(kMPParamsMissingParam)));
+                QVERIFY(tempFile.file()->flush());
+
+                _openDiffDialogForFile(tempFile.path());
+                if (QTest::currentTestFailed())
+                    return;
+
+                if (!_labelTextContains(QStringLiteral("diffSummaryLabel"),
+                                        QStringLiteral("1 not found on the Vehicle and cannot be sent")))
+                    return;
+                // Cannot-send param is shown in the grid as a disabled row
+                verifyVisibility(QStringLiteral("diffGrid"), true, QStringLiteral("missing-param case"));
+                verifyVisibility(QStringLiteral("diffCannotSendHintLabel"), true, QStringLiteral("missing-param case"));
+                verifyEnabled(QStringLiteral("diffRowCheckbox_NO_SUCH_PARAM"), false,
+                              QStringLiteral("missing-param case"));
+                // No sendable rows means no Ok button
+                verifyVisibility(QStringLiteral("diffOkHintLabel"), false, QStringLiteral("missing-param case"));
+                if (QTest::currentTestFailed())
+                    return;
+
+                QVERIFY2(rejectDialog(), "Failed to close missing-param dialog");
+            }
+
+            // -------------------------------------------------------------------------
+            // Case: parameter not on vehicle, QGC format — sent as new to vehicle
+            // -------------------------------------------------------------------------
+            {
+                TestFixtures::TempFileFixture tempFile(QStringLiteral("test_XXXXXX.params"));
+                QVERIFY(tempFile.isValid());
+                QVERIFY(tempFile.write(QByteArray(kQGCParamsUnknownParam)));
+                QVERIFY(tempFile.file()->flush());
+
+                _openDiffDialogForFile(tempFile.path());
+                if (QTest::currentTestFailed())
+                    return;
+
+                if (!_labelTextContains(QStringLiteral("diffSummaryLabel"),
+                                        QStringLiteral("1 will be changed (including 1 not currently on the Vehicle)")))
+                    return;
+                verifyVisibility(QStringLiteral("diffGrid"), true, QStringLiteral("new-to-vehicle case"));
+                verifyVisibility(QStringLiteral("diffNoVehicleHintLabel"), true, QStringLiteral("new-to-vehicle case"));
+                if (QTest::currentTestFailed())
+                    return;
+
+                // Accepting sends a PARAM_SET for the unknown param. MockLink (like real
+                // firmware) rejects it with PARAM_ERROR DOES_NOT_EXIST. QGC must report
+                // exactly one write failure and stop - no crash, and no redundant
+                // follow-up "Parameter read failed" popup (any extra app message would
+                // fail this test's strict log checking).
+                expectAppMessage(QRegularExpression(QStringLiteral("Parameter write failed: param: NO_SUCH_PARAM")));
+                QVERIFY2(acceptDialog(), "Failed to accept new-to-vehicle dialog");
+
+                // The write-failed message is the last step of the async failure flow
+                auto writeFailedCaptured = []() {
+                    const auto msgs = LogManager::capturedMessages();
+                    return std::any_of(msgs.cbegin(), msgs.cend(), [](const LogEntry& entry) {
+                        return entry.message.contains(QStringLiteral("Parameter write failed: param: NO_SUCH_PARAM"));
+                    });
+                };
+                QTRY_VERIFY_WITH_TIMEOUT(writeFailedCaptured(), 10000);
+                verifyExpectedLogMessage();
+                if (QTest::currentTestFailed())
+                    return;
+
+                // Dismiss the app message dialog(s) so the next case can use the menus.
+                // Bounded so a runaway popup loop fails loudly instead of hitting the ctest timeout.
+                int dismissAttempts = 0;
+                while (findVisibleItem(_rootItem, QStringLiteral("popupDialog_acceptButton"), 1000)) {
+                    QVERIFY2(++dismissAttempts <= 5, "App message dialogs keep re-appearing - runaway popup loop");
+                    QVERIFY2(clickButton(QStringLiteral("popupDialog_acceptButton")),
+                             "Failed to dismiss app message dialog");
+                }
+
+                // The dismiss loop above idled for at least a second after the last
+                // dialog - long enough for a (buggy) post-failure refresh to have
+                // produced its "Parameter read failed" popup. Verify it never appeared.
+                const auto msgs = LogManager::capturedMessages();
+                const bool readFailed = std::any_of(msgs.cbegin(), msgs.cend(), [](const LogEntry& entry) {
+                    return entry.message.contains(QStringLiteral("Parameter read failed: param: NO_SUCH_PARAM"));
+                });
+                QVERIFY2(!readFailed,
+                         "Unexpected redundant 'Parameter read failed' after DOES_NOT_EXIST write rejection");
+            }
+
+            // -------------------------------------------------------------------------
+            // Case: checkbox behavior — select all / deselect all, and only the
+            // checked subset of params is sent
+            // -------------------------------------------------------------------------
+            {
+                TestFixtures::TempFileFixture tempFile(QStringLiteral("test_XXXXXX.params"));
+                QVERIFY(tempFile.isValid());
+                QVERIFY(tempFile.write(QByteArray(kQGCParamsTwoDiffs)));
+                QVERIFY(tempFile.file()->flush());
+
+                _openDiffDialogForFile(tempFile.path());
+                if (QTest::currentTestFailed())
+                    return;
+
+                // Both rows start checked
+                verifyChecked(QStringLiteral("diffRowCheckbox_SYS_AUTOSTART"), true,
+                              QStringLiteral("checkbox case: initial"));
+                verifyChecked(QStringLiteral("diffRowCheckbox_COM_DL_LOSS_T"), true,
+                              QStringLiteral("checkbox case: initial"));
+                if (QTest::currentTestFailed())
+                    return;
+
+                // Header checkbox deselects all rows...
+                QVERIFY2(clickButton(QStringLiteral("diffCheckAllCheckbox")), "Failed to click check-all checkbox");
+                verifyChecked(QStringLiteral("diffRowCheckbox_SYS_AUTOSTART"), false,
+                              QStringLiteral("checkbox case: deselect all"));
+                verifyChecked(QStringLiteral("diffRowCheckbox_COM_DL_LOSS_T"), false,
+                              QStringLiteral("checkbox case: deselect all"));
+                // ...which disables Ok since there is nothing to send
+                verifyEnabled(QStringLiteral("popupDialog_acceptButton"), false,
+                              QStringLiteral("checkbox case: deselect all"));
+                if (QTest::currentTestFailed())
+                    return;
+
+                // ...and selects them all again
+                QVERIFY2(clickButton(QStringLiteral("diffCheckAllCheckbox")), "Failed to click check-all checkbox");
+                verifyChecked(QStringLiteral("diffRowCheckbox_SYS_AUTOSTART"), true,
+                              QStringLiteral("checkbox case: reselect all"));
+                verifyChecked(QStringLiteral("diffRowCheckbox_COM_DL_LOSS_T"), true,
+                              QStringLiteral("checkbox case: reselect all"));
+                verifyEnabled(QStringLiteral("popupDialog_acceptButton"), true,
+                              QStringLiteral("checkbox case: reselect all"));
+                if (QTest::currentTestFailed())
+                    return;
+
+                // Uncheck just SYS_AUTOSTART, then accept: only COM_DL_LOSS_T may be sent
+                QVERIFY2(clickButton(QStringLiteral("diffRowCheckbox_SYS_AUTOSTART")),
+                         "Failed to uncheck SYS_AUTOSTART row");
+                verifyChecked(QStringLiteral("diffRowCheckbox_SYS_AUTOSTART"), false,
+                              QStringLiteral("checkbox case: single deselect"));
+                verifyChecked(QStringLiteral("diffRowCheckbox_COM_DL_LOSS_T"), true,
+                              QStringLiteral("checkbox case: single deselect"));
+                if (QTest::currentTestFailed())
+                    return;
+
+                QVERIFY2(acceptDialog(), "Failed to accept checkbox-case dialog");
+
+                // COM_DL_LOSS_T (checked) reaches the vehicle...
+                QTRY_COMPARE_WITH_TIMEOUT(mockLink->paramValue(1, QStringLiteral("COM_DL_LOSS_T")).toInt(), 20, 5000);
+                // ...while SYS_AUTOSTART (unchecked) must remain at the vehicle default
+                QCOMPARE(mockLink->paramValue(1, QStringLiteral("SYS_AUTOSTART")).toInt(), 4001);
+
+                // Let in-flight param traffic settle before the next case
+                waitForParamRefreshQuiet(vehicle);
+                if (QTest::currentTestFailed())
+                    return;
+            }
+
+            // -------------------------------------------------------------------------
+            // Case: real difference (QGC format) — accept sends the change to the vehicle
+            // -------------------------------------------------------------------------
+            {
+                TestFixtures::TempFileFixture tempFile(QStringLiteral("test_XXXXXX.params"));
+                QVERIFY(tempFile.isValid());
+                QVERIFY(tempFile.write(QByteArray(kQGCParamsWithDiff)));
+                QVERIFY(tempFile.file()->flush());
+
+                _openDiffDialogForFile(tempFile.path());
+                if (QTest::currentTestFailed())
+                    return;
+
+                if (!_labelTextContains(QStringLiteral("diffSummaryLabel"), QStringLiteral("1 will be changed")))
+                    return;
+                verifyVisibility(QStringLiteral("diffGrid"), true, QStringLiteral("changed case"));
+                verifyVisibility(QStringLiteral("diffCannotSendHintLabel"), false, QStringLiteral("changed case"));
+                if (QTest::currentTestFailed())
+                    return;
+
+                // SYS_AUTOSTART is reboot-required, so accepting pops the reboot advisory
+                expectAppMessage(QRegularExpression(QStringLiteral("Reboot vehicle for changes to take effect")));
+                QVERIFY2(acceptDialog(), "Failed to accept diff dialog");
+
+                // Verify the new value actually reached the (mock) vehicle
+                QTRY_COMPARE_WITH_TIMEOUT(mockLink->paramValue(1, QStringLiteral("SYS_AUTOSTART")).toInt(), 4002, 5000);
+                verifyExpectedLogMessage();
+
+                Fact* fact = vehicle->parameterManager()->getParameter(1, QStringLiteral("SYS_AUTOSTART"));
+                QVERIFY2(fact, "SYS_AUTOSTART fact not found");
+                QTRY_COMPARE_WITH_TIMEOUT(fact->rawValue().toInt(), 4002, 5000);
+
+                // Let in-flight PARAM_SET/PARAM_REQUEST_READ traffic settle before link teardown
+                waitForParamRefreshQuiet(vehicle);
+            }
+        });
+}

--- a/test/QmlUITests/ParameterDiffDialogUITest.h
+++ b/test/QmlUITests/ParameterDiffDialogUITest.h
@@ -1,0 +1,20 @@
+#pragma once
+
+#include "VehicleConfigUITestBase.h"
+
+class QQuickItem;
+
+/// UI test for ParameterDiffDialog: verifies the load-from-file summary and
+/// sections for each diff outcome (changes, all-match, missing-on-vehicle,
+/// new-to-vehicle) and that accepting the dialog sends the diff.
+class ParameterDiffDialogUITest : public VehicleConfigUITestBase
+{
+    Q_OBJECT
+
+private slots:
+    void _testDiffDialogCases();
+
+private:
+    void _openDiffDialogForFile(const QString& filePath);
+    bool _labelTextContains(const QString& objectName, const QString& substring);
+};


### PR DESCRIPTION
## Overview

Replaces #14705.

Loading a parameter file no longer blind-writes every value to the vehicle. It now builds a
diff against the current vehicle state and shows a review dialog where the user can inspect
and selectively send only the parameters that actually differ.

## UI

- New `ParameterDiffDialog` shown after choosing a file in the Parameters tool:
  - Summary line (parsed / changed / unchanged / read-only / not-on-vehicle counts).
  - Grid of changed params with file value, vehicle value, and units, each with a
    per-row checkbox to include/exclude it from the send.
  - Params not on the vehicle from a QGC-format file are sent as new (PARAM_SET);
    params not on the vehicle from a Mission Planner file (no type info) are shown as
    disabled cannot-send rows.
  - OK button is only offered when there is at least one sendable parameter.
  - Warnings when the file came from a different vehicle or contains multiple components.

## Controller (`ParameterEditorController`)

- New invokables: `buildDiffFromFile()`, `sendDiff()`, `clearDiff()`.
- New diff properties (`diffParsedCount`, `diffUnchangedCount`, `diffReadOnlyCount`,
  `diffNoVehicleCount`, `diffSendableCount`, `diffMissingParams`, `diffOtherVehicle`,
  `diffMultipleComponents`, `diffList`).
- Property change signals emit only when the value actually changes (guarded
  `_setDiffProperty` helper) instead of an unconditional bulk emit.
- Supports both QGC 5-column and Mission Planner 2-column file formats.
- New `QMLControls.ParameterEditorController` logging category: per-parameter decision
  logging (changed / unchanged / read-only / not-on-vehicle / unparseable) and
  build/send summaries for diagnosing param-file load issues from user logs.

## Supporting changes

- `MockLink`: `_handleParamSet` / `_handleParamRequestRead` now reject unknown
  component/param/type with `PARAM_ERROR` (matching real firmware) instead of
  `Q_ASSERT`-crashing, enabling the new-param send path to be tested.
- `ParameterManager`: skip the post-set param refresh when the set failed with
  `MAV_PARAM_ERROR_DOES_NOT_EXIST`, avoiding a redundant read-failure popup.

## Tests

- `ParameterEditorControllerTest`: diff building for QGC/MP/mixed files, unchanged/read-only
  skipping, missing-param handling, signal emit-only-on-change verification, clearDiff reset,
  send failure handling.
- New `ParameterDiffDialogUITest` (QML UI test): drives the full load-from-file flow through
  the dialog and verifies row checkboxes, disabled cannot-send rows, and button states.
