### PR TITLE
docs: note JOBS=N override for just build core count

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -59,7 +59,7 @@ The `just` recipes are the canonical workflow — see [tools/README.md](tools/RE
 
 ```bash
 just configure          # CMake configure (pulls submodules first)
-just build              # incremental build; leaves ~half the cores free
+just build              # incremental build; uses all cores (override with JOBS=N)
 just test               # ctest, LABELS="Unit|Integration" EXCLUDE="Flaky|Network"
 just lint               # fast pre-commit gate (clang-format, ruff, qmllint, ...)
 just check              # lint + test (run before declaring done)

--- a/tools/README.md
+++ b/tools/README.md
@@ -102,7 +102,7 @@ with no arguments to print this list from the tool itself.
 | Recipe              | Description                                                                                      |
 | ------------------- | ------------------------------------------------------------------------------------------------ |
 | `just configure`    | Configure CMake build (Debug by default; pulls submodules first)                                 |
-| `just build`        | Build the project (`--parallel` capped at half of `nproc`; override with `JOBS=N`)               |
+| `just build`        | Build the project (uses all cores by default; override with `JOBS=N`)                            |
 | `just release`      | Configure and build in Release mode (testing disabled)                                           |
 | `just clean [ARGS]` | Clean the build directory; forwards `ARGS` to `tools/clean.py` (`--cache`, `--all`, `--dry-run`) |
 | `just rebuild`      | `clean` + `configure` + `build`                                                                  |


### PR DESCRIPTION
Documents in AGENTS.md that `just build` uses all cores by default and the core count can be overridden with `JOBS=N`.