### PR TITLE
fix(GraphicsSetup): don't set RHI pipeline cache load file when missing

### DIFF
--- a/src/Utilities/Platform/GraphicsSetup.cc
+++ b/src/Utilities/Platform/GraphicsSetup.cc
@@ -1,6 +1,7 @@
 #include "GraphicsSetup.h"
 
 #include <QtCore/QDir>
+#include <QtCore/QFileInfo>
 #include <QtCore/QRunnable>
 #include <QtCore/QStandardPaths>
 #include <QtCore/QString>
@@ -53,7 +54,12 @@ void configurePipelineCache(QQuickGraphicsConfiguration& config)
     }
 
     const QString cacheFile = cacheDir + QStringLiteral("/qgc_rhi_pipeline.cache");
-    config.setPipelineCacheLoadFile(cacheFile);
+    // Only load when the cache already exists: Qt 6.11 warns if the load file
+    // can't be opened, which is expected on first run. Always set the save file
+    // so the cache is written at shutdown and picked up on the next launch.
+    if (QFileInfo::exists(cacheFile)) {
+        config.setPipelineCacheLoadFile(cacheFile);
+    }
     config.setPipelineCacheSaveFile(cacheFile);
     qCDebug(GraphicsSetupLog) << "RHI pipeline cache:" << cacheFile;
 }


### PR DESCRIPTION
Qt 6.11 warns `Could not open pipeline cache source file` when the RHI pipeline cache load file doesn't exist yet, which is expected on first run (or a fresh cache dir for a new build flavor).

Only set the load file when the cache already exists. The save file is still always set, so the cache is written at shutdown and picked up on the next launch.

Fixes #14707