### PR TITLE
feat(Viewer3D): add file browse button for OSM file selection

### DIFF
--- a/src/AppSettings/pages/Viewer3D.SettingsUI.json
+++ b/src/AppSettings/pages/Viewer3D.SettingsUI.json
@@ -23,7 +23,18 @@
             "enableWhen": "QGroundControl.settingsManager.viewer3DSettings.enabled.rawValue",
             "controls": [
                 {
-                    "setting": "viewer3DSettings.osmFilePath"
+                    "setting": "viewer3DSettings.osmFilePath",
+                    "control": "browse",
+                    "showWhen": "!ScreenTools.isMobile",
+                    "properties": {
+                        "selectFolder": false,
+                        "nameFilters": "[ qsTr(\"OpenStreetMap files (*.osm)\"), qsTr(\"All Files (*)\") ]"
+                    }
+                },
+                {
+                    "setting": "viewer3DSettings.osmFilePath",
+                    "control": "textfield",
+                    "showWhen": "ScreenTools.isMobile"
                 },
                 {
                     "setting": "viewer3DSettings.buildingLevelHeight"

--- a/src/FactSystem/FactControls/LabelledFactBrowse.qml
+++ b/src/FactSystem/FactControls/LabelledFactBrowse.qml
@@ -14,6 +14,7 @@ import QGroundControl.FactControls
 ///   label        - Display label (defaults to fact.shortDescription).
 ///   dialogTitle  - Title for the file dialog (defaults to label).
 ///   selectFolder - true to browse folders, false for files (default true).
+///   nameFilters  - Name filters for file browsing (simple wildcards only).
 ///   defaultText  - Placeholder shown when the Fact value is empty.
 RowLayout {
     id:      root
@@ -22,6 +23,7 @@ RowLayout {
     property Fact   fact
     property string dialogTitle:    label
     property bool   selectFolder:   true
+    property var    nameFilters:    []
     property string defaultText:    qsTr("<not set>")
 
     spacing: ScreenTools.defaultFontPixelWidth * 2
@@ -53,6 +55,7 @@ RowLayout {
             title:              root.dialogTitle
             folder:             root.fact.rawValue
             selectFolder:       root.selectFolder
+            nameFilters:        root.nameFilters
             onAcceptedForLoad:  (file) => root.fact.rawValue = file
         }
     }

--- a/tools/generators/settings_qml/README.md
+++ b/tools/generators/settings_qml/README.md
@@ -118,6 +118,7 @@ A collapsible group with an optional heading.
 | `showWhen` | string | no | Extra QML visibility expression (combined with `fact.userVisible` via logical AND) |
 | `enableWhen` | string | no | QML expression bound to `enabled` |
 | `placeholder` | string | no | Placeholder text for text fields |
+| `properties` | object | no | Extra QML property bindings for `browse`/`scaler` controls (see below) |
 | `enableCheckbox` | object | no | Enable-checkbox for sliders (see below) |
 | `button` | object | no | Adjacent button (see below) |
 
@@ -155,6 +156,25 @@ Explicit `control` values:
 | --- | --- | --- |
 | `enableCheckbox` | object | `{ "checked": "expr", "onClicked": "body" }` |
 | `button` | object | `{ "text": "label", "onClicked": "body", "enabled": "expr" }` |
+
+#### `browse` / `scaler` extra keys
+
+`properties` maps QML property names to values emitted into the control.
+Booleans and numbers map to their QML literals; strings are emitted verbatim
+as QML expressions. For example, to make a `browse` control pick a file
+instead of a folder:
+
+```json
+{
+    "setting": "viewer3DSettings.osmFilePath",
+    "control": "browse",
+    "showWhen": "!ScreenTools.isMobile",
+    "properties": {
+        "selectFolder": false,
+        "nameFilters": "[ qsTr(\"OpenStreetMap files (*.osm)\") ]"
+    }
+}
+```
 
 ---
 

--- a/tools/generators/settings_qml/emit.py
+++ b/tools/generators/settings_qml/emit.py
@@ -100,6 +100,7 @@ def _qml_control(ctrl: ControlDef, settings_dir: Path, json_context: str = "") -
             label_expr=label_expr,
             fact_ref=fact_ref,
             enable_when=ctrl.enableWhen,
+            properties=ctrl.properties,
         )
         return _wrap_with_description(control_qml, fact_ref, _vis_expr(), indent)
     elif ctrl.control == "checkbox":

--- a/tools/generators/settings_qml/model.py
+++ b/tools/generators/settings_qml/model.py
@@ -21,12 +21,40 @@ _TRANSLATED_LIST_RE = re.compile("[,，、]")
 # ASCII-only, non-empty segments: fact_name feeds objectNames, which must stay grep-able.
 _SETTING_RE = re.compile(r"[A-Za-z0-9_]+(\.[A-Za-z0-9_]+)+")
 
+# QML property names emitted verbatim into generated QML; a bad name must fail here
+# with context, not as a qmllint/build error pointing at generated code.
+_QML_PROPERTY_NAME_RE = re.compile(r"[a-z_][A-Za-z0-9_]*")
+
+# Names the control template already emits (or that QML treats specially); a JSON
+# 'properties' entry using one would generate a duplicate binding.
+_RESERVED_PROPERTY_NAMES = frozenset({"id", "objectName", "label", "fact", "enabled"})
+
+
+def _coerce_property_value(value: object) -> str:
+    """Convert a JSON property value to a QML expression string.
+
+    JSON booleans and numbers map to their QML literals so authors can write
+    the natural spelling (e.g. ``"selectFolder": false``); strings pass
+    through verbatim as QML expressions. Anything else is a schema error.
+    """
+    if isinstance(value, bool):
+        return "true" if value else "false"
+    if isinstance(value, (int, float)):
+        return repr(value)
+    if isinstance(value, str):
+        return value
+    raise ValueError(
+        f"'properties' value must be a string, boolean, or number, "
+        f"got {type(value).__name__}: {clamped_repr(value)}"
+    )
+
 
 @dataclass
 class ControlDef(BaseControlDef):
     """A single control referencing a setting."""
     placeholder: str = ""
     value: str = ""
+    properties: dict[str, str] = field(default_factory=dict)
 
     @property
     def settings_group(self) -> str:
@@ -86,7 +114,7 @@ _ALLOWED_GROUP_KEYS = frozenset({
 })
 _ALLOWED_CONTROL_KEYS = frozenset({
     "comment", "setting", "label", "control", "showWhen", "enableWhen",
-    "placeholder", "value", "component",
+    "placeholder", "value", "component", "properties",
     "enableCheckbox", "button",
 })
 
@@ -125,9 +153,30 @@ def load_page_def(json_path: Path) -> PageDef:
                 placeholder=ctrl_data.get("placeholder", ""),
                 value=ctrl_data.get("value", ""),
                 component=ctrl_data.get("component", ""),
+                properties=require_dict(ctrl_data.get("properties", {}), "control 'properties'", json_path),
                 enableCheckbox=parse_enable_checkbox(ctrl_data.get("enableCheckbox")),
                 button=parse_button(ctrl_data.get("button")),
             )
+            if ctrl.properties and ctrl.control not in ("browse", "scaler"):
+                raise ValueError(
+                    f"{json_path}: 'properties' is only supported on 'browse'/'scaler' controls, "
+                    f"got control {ctrl.control!r} (control: {clamped_repr(ctrl_data)})"
+                )
+            for prop_name, prop_value in ctrl.properties.items():
+                if not _QML_PROPERTY_NAME_RE.fullmatch(prop_name):
+                    raise ValueError(
+                        f"{json_path}: 'properties' key must be a valid QML property name, "
+                        f"got: {prop_name!r} (control: {clamped_repr(ctrl_data)})"
+                    )
+                if prop_name in _RESERVED_PROPERTY_NAMES:
+                    raise ValueError(
+                        f"{json_path}: 'properties' key {prop_name!r} is reserved (already emitted "
+                        f"by the generator) (control: {clamped_repr(ctrl_data)})"
+                    )
+                try:
+                    ctrl.properties[prop_name] = _coerce_property_value(prop_value)
+                except ValueError as exc:
+                    raise ValueError(f"{json_path}: {exc} (control: {clamped_repr(ctrl_data)})") from None
             # component/info controls have no fact; every other kind derives its fact
             # reference and objectName from setting, so a bad one must fail here with
             # context, not deep inside the emitter with an IndexError

--- a/tools/generators/settings_qml/templates/control_labelled_fact.qml.j2
+++ b/tools/generators/settings_qml/templates/control_labelled_fact.qml.j2
@@ -2,6 +2,9 @@
 {{ indent }}    Layout.fillWidth: true
 {{ indent }}    label: {{ label_expr }}
 {{ indent }}    fact: {{ fact_ref }}
+{% for name, expr in (properties | default({})).items() %}
+{{ indent }}    {{ name }}: {{ expr }}
+{% endfor %}
 {% if enable_when %}
 {{ indent }}    enabled: {{ enable_when }}
 {% endif %}

--- a/tools/tests/test_settings_qml_generator.py
+++ b/tools/tests/test_settings_qml_generator.py
@@ -662,6 +662,149 @@ class TestGeneratePageQml:
         qml = generate_page_qml(page, settings_dir)
         assert "LabelledFactBrowse {" in qml
 
+    def test_browse_control_properties(self, settings_dir: Path):
+        page = PageDef(
+            groups=[
+                GroupDef(
+                    controls=[
+                        ControlDef(
+                            setting="appSettings.savePath",
+                            control="browse",
+                            properties={"selectFolder": "false", "nameFilters": '[ qsTr("OSM (*.osm)") ]'},
+                        )
+                    ]
+                ),
+            ]
+        )
+        qml = generate_page_qml(page, settings_dir)
+        assert "selectFolder: false" in qml
+        assert 'nameFilters: [ qsTr("OSM (*.osm)") ]' in qml
+
+    def test_properties_rejected_on_non_browse_control(self, tmp_path: Path):
+        data = {
+            "version": 1,
+            "groups": [
+                {
+                    "heading": "G",
+                    "controls": [
+                        {"setting": "appSettings.x", "control": "textfield", "properties": {"a": "b"}}
+                    ],
+                }
+            ],
+        }
+        with pytest.raises(ValueError, match="properties"):
+            load_page_def(_make_page_json(tmp_path, data))
+
+    def test_properties_bad_name_rejected(self, tmp_path: Path):
+        # Property names are emitted verbatim into QML; invalid ones must fail at load time
+        data = {
+            "version": 1,
+            "groups": [
+                {
+                    "heading": "G",
+                    "controls": [
+                        {
+                            "setting": "appSettings.x",
+                            "control": "browse",
+                            "properties": {"name filters": "[]"},
+                        }
+                    ],
+                }
+            ],
+        }
+        with pytest.raises(ValueError, match="valid QML property name"):
+            load_page_def(_make_page_json(tmp_path, data))
+
+    @pytest.mark.parametrize("reserved", ["id", "objectName", "label", "fact", "enabled"])
+    def test_properties_reserved_name_rejected(self, tmp_path: Path, reserved: str):
+        # These are already emitted by the control template; a JSON override would
+        # generate a duplicate binding that only fails later at qmllint/build time
+        data = {
+            "version": 1,
+            "groups": [
+                {
+                    "heading": "G",
+                    "controls": [
+                        {
+                            "setting": "appSettings.x",
+                            "control": "browse",
+                            "properties": {reserved: "oops"},
+                        }
+                    ],
+                }
+            ],
+        }
+        with pytest.raises(ValueError, match="reserved"):
+            load_page_def(_make_page_json(tmp_path, data))
+
+    def test_properties_primitive_values_coerced(self, tmp_path: Path):
+        # JSON booleans/numbers must become QML literals, not Python reprs (True/False)
+        data = {
+            "version": 1,
+            "groups": [
+                {
+                    "heading": "G",
+                    "controls": [
+                        {
+                            "setting": "appSettings.x",
+                            "control": "browse",
+                            "properties": {"selectFolder": False, "maxCount": 42},
+                        }
+                    ],
+                }
+            ],
+        }
+        page = load_page_def(_make_page_json(tmp_path, data))
+        props = page.groups[0].controls[0].properties
+        assert props["selectFolder"] == "false"
+        assert props["maxCount"] == "42"
+
+    def test_properties_non_primitive_value_rejected(self, tmp_path: Path):
+        data = {
+            "version": 1,
+            "groups": [
+                {
+                    "heading": "G",
+                    "controls": [
+                        {
+                            "setting": "appSettings.x",
+                            "control": "browse",
+                            "properties": {"nameFilters": ["*.osm"]},
+                        }
+                    ],
+                }
+            ],
+        }
+        with pytest.raises(ValueError, match="string, boolean, or number"):
+            load_page_def(_make_page_json(tmp_path, data))
+
+    def test_properties_end_to_end_json_to_qml(self, tmp_path: Path, settings_dir: Path):
+        # Full pipeline: JSON schema -> load_page_def (coercion) -> generate_page_qml.
+        # Guards the seam between loader and emitter that the unit tests above bypass.
+        data = {
+            "version": 1,
+            "groups": [
+                {
+                    "heading": "G",
+                    "controls": [
+                        {
+                            "setting": "appSettings.savePath",
+                            "control": "browse",
+                            "properties": {
+                                "selectFolder": False,
+                                "nameFilters": '[ qsTr("OSM (*.osm)") ]',
+                            },
+                        }
+                    ],
+                }
+            ],
+        }
+        page = load_page_def(_make_page_json(tmp_path, data))
+        qml = generate_page_qml(page, settings_dir)
+        assert "LabelledFactBrowse {" in qml
+        assert "selectFolder: false" in qml
+        assert 'nameFilters: [ qsTr("OSM (*.osm)") ]' in qml
+
     def test_slider_control(self, settings_dir: Path):
         page = PageDef(
             groups=[
@@ -981,6 +1124,10 @@ class TestRealPageDefinitions:
         assert 'heading: qsTr("General")' in qml
         assert 'heading: qsTr("Data")' in qml
         assert "viewer3DSettings.enabled" in qml
+        # osmFilePath browse control: properties from the JSON must survive to QML
+        assert "LabelledFactBrowse {" in qml
+        assert "selectFolder: false" in qml
+        assert "nameFilters:" in qml
 
     def test_pages_model_generates(self, repo_root: Path):
         pages_path = repo_root / "src" / "AppSettings" / "pages" / "SettingsPages.json"


### PR DESCRIPTION
## Summary

Adds a browse button to the 3D View settings page so the OpenStreetMap file can be picked with a file dialog instead of typing the path (desktop only; mobile keeps the plain text field).

## Changes

- **Viewer3D settings page**: `osmFilePath` now uses a `browse` control on desktop (`.osm` name filter, file selection) with a `textfield` fallback on mobile.
- **Settings QML generator**: new optional `properties` key on `browse`/`scaler` controls that emits extra QML property bindings. Validated at load time: QML property name syntax, reserved-name denylist (`id`, `objectName`, `label`, `fact`, `enabled`), and JSON boolean/number coercion to QML literals.
- **LabelledFactBrowse.qml**: new `nameFilters` property forwarded to `QGCFileDialog`.
- **Docs**: generator README updated with the `properties` key and an example.

## Testing

- Generator test suite: 99 passed, including new tests for property emission, validation errors, value coercion, end-to-end JSON→QML, and the real Viewer3D page.
- Full build passes; verified the browse dialog in the running app with a MockLink vehicle and a test `.osm` file.