### PR TITLE
fix(MainWindow): zero ApplicationWindow safe-area padding on Android

### DIFF
--- a/src/MainWindow/MainWindow.qml
+++ b/src/MainWindow/MainWindow.qml
@@ -20,6 +20,14 @@ ApplicationWindow {
     // The special casing for android prevents white bars from showing up on the edges of the screen with newer android versions
     flags:      Qt.Window | (ScreenTools.isAndroid ? Qt.ExpandedClientAreaHint | Qt.NoTitleBarBackgroundHint : 0)
 
+    // Qt 6.9+ auto-sets ApplicationWindow padding to the display safe-area insets on mobile,
+    // which insets our full-bleed content and leaves a blank strip along the screen edge.
+    // QGC draws edge-to-edge and manages its own insets, so zero the padding.
+    topPadding:    0
+    bottomPadding: 0
+    leftPadding:   0
+    rightPadding:  0
+
     Component.onCompleted: {
         // Start the sequence of first run prompt(s)
         firstRunPromptManager.nextPrompt()


### PR DESCRIPTION
Fixes #14695

## Problem

On Android the QGC window did not extend to the top and right edges of the screen — it left blank strips where the system status/navigation bars would sit. Reproducible on the RadioMaster AX12.

## Root cause

Qt 6.9+ automatically sets `ApplicationWindow`'s `padding` (`topPadding`/`bottomPadding`/`leftPadding`/`rightPadding`) to the display safe-area insets on mobile. This insets the window `contentItem`, so QGC's full-bleed content is pushed inward and the window `background` shows through as a strip along the edge.

## Fix

QGC draws edge-to-edge and manages its own insets, so zero the four padding properties on the main `ApplicationWindow`. Content then fills the entire display. Verified on the RadioMaster AX12.
