### PR TITLE
feat(MockLink): serve synthetic video stream for manual video testing

### DIFF
--- a/cmake/GStreamer/Components.cmake
+++ b/cmake/GStreamer/Components.cmake
@@ -65,6 +65,7 @@ set(GSTREAMER_COMPONENT_REGISTRY
     "Rtsp:api_rtsp:gstreamer-rtsp-1.0:1"
     "Video:api_video:gstreamer-video-1.0:1"
     "App:api_app:gstreamer-app-1.0:0"
+    "RtspServer:api_rtsp_server:gstreamer-rtsp-server-1.0:0"
     "Allocators:api_allocators:gstreamer-allocators-1.0:0"
     "Pbutils:api_pbutils:gstreamer-pbutils-1.0:0"
     "Tag:api_tag:gstreamer-tag-1.0:0"

--- a/src/AppSettings/MockLink.qml
+++ b/src/AppSettings/MockLink.qml
@@ -68,28 +68,42 @@ Rectangle {
                 readonly property string selectedKey: currentIndex >= 0 ? _vehicleKeys[currentIndex] : "px4"
                 readonly property bool apmSelected: selectedKey.startsWith("apm")
             }
+            LabelledComboBox {
+                id:                 videoStreamTypeCombo
+                label:              qsTr("Served Video Stream")
+                Layout.fillWidth:   true
+                visible:            enableCamera.checked
+                model: [
+                    qsTr("Disabled"),
+                    qsTr("RTP/UDP H.264"),
+                    qsTr("RTP/UDP H.265"),
+                    qsTr("RTSP (H.264)"),
+                    qsTr("MPEG-TS (UDP)"),
+                    qsTr("MPEG-TS (TCP)")
+                ]
+            }
             QGCButton {
                 text:               qsTr("Start MockLink")
                 Layout.fillWidth:   true
                 onClicked: {
                     switch (vehicleTypeCombo.selectedKey) {
                     case "px4":
-                        QGroundControl.startPX4MockLink(sendStatusText.checked, enableCamera.checked, enableGimbal.checked, enableProximity.checked)
+                        QGroundControl.startPX4MockLink(sendStatusText.checked, enableCamera.checked, enableGimbal.checked, enableProximity.checked, videoStreamTypeCombo.currentIndex)
                         break
                     case "apmCopter":
-                        QGroundControl.startAPMArduCopterMockLink(sendStatusText.checked, enableCamera.checked, enableGimbal.checked, enableProximity.checked, apmStartFreshParams.checked)
+                        QGroundControl.startAPMArduCopterMockLink(sendStatusText.checked, enableCamera.checked, enableGimbal.checked, enableProximity.checked, apmStartFreshParams.checked, videoStreamTypeCombo.currentIndex)
                         break
                     case "apmPlane":
-                        QGroundControl.startAPMArduPlaneMockLink(sendStatusText.checked, enableCamera.checked, enableGimbal.checked, enableProximity.checked, apmStartFreshParams.checked)
+                        QGroundControl.startAPMArduPlaneMockLink(sendStatusText.checked, enableCamera.checked, enableGimbal.checked, enableProximity.checked, apmStartFreshParams.checked, videoStreamTypeCombo.currentIndex)
                         break
                     case "apmSub":
-                        QGroundControl.startAPMArduSubMockLink(sendStatusText.checked, enableCamera.checked, enableGimbal.checked, enableProximity.checked, apmStartFreshParams.checked)
+                        QGroundControl.startAPMArduSubMockLink(sendStatusText.checked, enableCamera.checked, enableGimbal.checked, enableProximity.checked, apmStartFreshParams.checked, videoStreamTypeCombo.currentIndex)
                         break
                     case "apmRover":
-                        QGroundControl.startAPMArduRoverMockLink(sendStatusText.checked, enableCamera.checked, enableGimbal.checked, enableProximity.checked, apmStartFreshParams.checked)
+                        QGroundControl.startAPMArduRoverMockLink(sendStatusText.checked, enableCamera.checked, enableGimbal.checked, enableProximity.checked, apmStartFreshParams.checked, videoStreamTypeCombo.currentIndex)
                         break
                     default:
-                        QGroundControl.startGenericMockLink(sendStatusText.checked, enableCamera.checked, enableGimbal.checked, enableProximity.checked)
+                        QGroundControl.startGenericMockLink(sendStatusText.checked, enableCamera.checked, enableGimbal.checked, enableProximity.checked, videoStreamTypeCombo.currentIndex)
                         break
                     }
                 }

--- a/src/AppSettings/MockLinkSettings.qml
+++ b/src/AppSettings/MockLinkSettings.qml
@@ -41,6 +41,9 @@ ColumnLayout {
         subEditConfig.cameraCaptureImage = cameraCaptureImage.checked
         subEditConfig.cameraHasModes = cameraHasModes.checked
         subEditConfig.cameraHasVideoStream = cameraHasVideoStream.checked
+        // The stream type combo only applies when the camera advertises a video stream;
+        // persist Disabled otherwise so a stale selection can't linger in settings.
+        subEditConfig.videoStreamType = cameraHasVideoStream.checked ? videoStreamTypeCombo.currentIndex : 0
         subEditConfig.cameraCanCaptureImageInVideoMode = cameraCanCaptureImageInVideoMode.checked
         subEditConfig.cameraCanCaptureVideoInImageMode = cameraCanCaptureVideoInImageMode.checked
         subEditConfig.cameraHasBasicZoom = cameraHasBasicZoom.checked
@@ -72,6 +75,7 @@ ColumnLayout {
         } else {
             vehicleTypeCombo.currentIndex = 0
         }
+        videoStreamTypeCombo.currentIndex = subEditConfig.videoStreamType
     }
 
     QGCCheckBoxSlider {
@@ -153,6 +157,21 @@ ColumnLayout {
             text: "CAMERA_CAP_FLAGS_HAS_VIDEO_STREAM"
             checked: subEditConfig.cameraHasVideoStream
             visible: enableCamera.checked
+        }
+
+        LabelledComboBox {
+            id: videoStreamTypeCombo
+            Layout.fillWidth: true
+            label: qsTr("Served Video Stream")
+            visible: enableCamera.checked && cameraHasVideoStream.checked
+            model: [
+                qsTr("Disabled"),
+                qsTr("RTP/UDP H.264"),
+                qsTr("RTP/UDP H.265"),
+                qsTr("RTSP (H.264)"),
+                qsTr("MPEG-TS (UDP)"),
+                qsTr("MPEG-TS (TCP)")
+            ]
         }
 
         QGCCheckBoxSlider {

--- a/src/Comms/MockLink/MockConfiguration.cc
+++ b/src/Comms/MockLink/MockConfiguration.cc
@@ -32,6 +32,7 @@ MockConfiguration::MockConfiguration(const MockConfiguration *copy, QObject *par
     , _cameraHasBasicZoom(copy->cameraHasBasicZoom())
     , _cameraHasTrackingPoint(copy->cameraHasTrackingPoint())
     , _cameraHasTrackingRectangle(copy->cameraHasTrackingRectangle())
+    , _videoStreamType(copy->videoStreamTypeEnum())
     , _gimbalHasRollAxis(copy->gimbalHasRollAxis())
     , _gimbalHasPitchAxis(copy->gimbalHasPitchAxis())
     , _gimbalHasYawAxis(copy->gimbalHasYawAxis())
@@ -72,6 +73,7 @@ void MockConfiguration::copyFrom(const LinkConfiguration *source)
     setCameraHasBasicZoom(mockLinkSource->cameraHasBasicZoom());
     setCameraHasTrackingPoint(mockLinkSource->cameraHasTrackingPoint());
     setCameraHasTrackingRectangle(mockLinkSource->cameraHasTrackingRectangle());
+    setVideoStreamType(mockLinkSource->videoStreamType());
     setGimbalHasRollAxis(mockLinkSource->gimbalHasRollAxis());
     setGimbalHasPitchAxis(mockLinkSource->gimbalHasPitchAxis());
     setGimbalHasYawAxis(mockLinkSource->gimbalHasYawAxis());
@@ -106,6 +108,7 @@ void MockConfiguration::loadSettings(QSettings &settings, const QString &root)
     setCameraHasBasicZoom(settings.value(_cameraHasBasicZoomKey, true).toBool());
     setCameraHasTrackingPoint(settings.value(_cameraHasTrackingPointKey, true).toBool());
     setCameraHasTrackingRectangle(settings.value(_cameraHasTrackingRectangleKey, true).toBool());
+    setVideoStreamType(settings.value(_videoStreamTypeKey, static_cast<int>(VideoStreamNone)).toInt());
     setGimbalHasRollAxis(settings.value(_gimbalHasRollAxisKey, true).toBool());
     setGimbalHasPitchAxis(settings.value(_gimbalHasPitchAxisKey, true).toBool());
     setGimbalHasYawAxis(settings.value(_gimbalHasYawAxisKey, true).toBool());
@@ -139,6 +142,7 @@ void MockConfiguration::saveSettings(QSettings &settings, const QString &root) c
     settings.setValue(_cameraHasBasicZoomKey, cameraHasBasicZoom());
     settings.setValue(_cameraHasTrackingPointKey, cameraHasTrackingPoint());
     settings.setValue(_cameraHasTrackingRectangleKey, cameraHasTrackingRectangle());
+    settings.setValue(_videoStreamTypeKey, videoStreamType());
     settings.setValue(_gimbalHasRollAxisKey, gimbalHasRollAxis());
     settings.setValue(_gimbalHasPitchAxisKey, gimbalHasPitchAxis());
     settings.setValue(_gimbalHasYawAxisKey, gimbalHasYawAxis());

--- a/src/Comms/MockLink/MockConfiguration.h
+++ b/src/Comms/MockLink/MockConfiguration.h
@@ -31,6 +31,7 @@ class MockConfiguration : public LinkConfiguration
     Q_PROPERTY(bool cameraHasBasicZoom                   READ cameraHasBasicZoom                  WRITE setCameraHasBasicZoom                  NOTIFY cameraHasBasicZoomChanged)
     Q_PROPERTY(bool cameraHasTrackingPoint               READ cameraHasTrackingPoint              WRITE setCameraHasTrackingPoint              NOTIFY cameraHasTrackingPointChanged)
     Q_PROPERTY(bool cameraHasTrackingRectangle           READ cameraHasTrackingRectangle          WRITE setCameraHasTrackingRectangle          NOTIFY cameraHasTrackingRectangleChanged)
+    Q_PROPERTY(int  videoStreamType                      READ videoStreamType                     WRITE setVideoStreamType                     NOTIFY videoStreamTypeChanged)
 
 public:
     explicit MockConfiguration(const QString &name, QObject *parent = nullptr);
@@ -51,6 +52,18 @@ public:
     };
     Q_DECLARE_FLAGS(Options, Option)
     Q_FLAG(Options)
+
+    /// Kind of live video stream MockLink serves (and advertises via VIDEO_STREAM_INFORMATION).
+    /// Order must match the combo box model in MockLinkSettings.qml / MockLink.qml.
+    enum VideoStreamType {
+        VideoStreamNone = 0,    ///< No stream served
+        VideoStreamRtpUdpH264,  ///< RTP/UDP H.264    -> udp://
+        VideoStreamRtpUdpH265,  ///< RTP/UDP H.265    -> udp265://
+        VideoStreamRtspH264,    ///< RTSP H.264       -> rtsp://
+        VideoStreamMpegTsUdp,   ///< MPEG-TS over UDP -> mpegts://
+        VideoStreamMpegTsTcp,   ///< MPEG-TS over TCP -> tcp://
+    };
+    Q_ENUM(VideoStreamType)
 
     LinkType type() const final { return LinkConfiguration::TypeMock; }
     void copyFrom(const LinkConfiguration *source) final;
@@ -117,6 +130,17 @@ public:
     bool cameraHasTrackingRectangle() const { return _cameraHasTrackingRectangle; }
     void setCameraHasTrackingRectangle(bool value) { _cameraHasTrackingRectangle = value; emit cameraHasTrackingRectangleChanged(); }
 
+    int videoStreamType() const { return static_cast<int>(_videoStreamType); }
+    void setVideoStreamType(int value) { _videoStreamType = videoStreamTypeFromInt(value); emit videoStreamTypeChanged(); }
+    VideoStreamType videoStreamTypeEnum() const { return _videoStreamType; }
+
+    /// Maps an int (QML combo index / persisted setting) to a valid VideoStreamType.
+    /// Out-of-range values (e.g. corrupted settings) map to VideoStreamNone.
+    static VideoStreamType videoStreamTypeFromInt(int value)
+    {
+        return ((value >= VideoStreamNone) && (value <= VideoStreamMpegTsTcp)) ? static_cast<VideoStreamType>(value) : VideoStreamNone;
+    }
+
     enum FailureMode_t {
         FailNone,                                                   ///< No failures
         FailParamNoResponseToRequestList,                           ///< Do not respond to PARAM_REQUEST_LIST
@@ -172,6 +196,7 @@ signals:
     void cameraHasBasicZoomChanged();
     void cameraHasTrackingPointChanged();
     void cameraHasTrackingRectangleChanged();
+    void videoStreamTypeChanged();
 
 private:
     MAV_AUTOPILOT _firmwareType = MAV_AUTOPILOT_PX4;
@@ -200,6 +225,7 @@ private:
     bool _cameraHasBasicZoom = true;
     bool _cameraHasTrackingPoint = true;
     bool _cameraHasTrackingRectangle = true;
+    VideoStreamType _videoStreamType = VideoStreamNone;
 
     // Gimbal capability flags (defaults - all enabled)
     bool _gimbalHasRollAxis = true;
@@ -235,6 +261,7 @@ private:
     static constexpr const char *_cameraHasBasicZoomKey = "CameraHasBasicZoom";
     static constexpr const char *_cameraHasTrackingPointKey = "CameraHasTrackingPoint";
     static constexpr const char *_cameraHasTrackingRectangleKey = "CameraHasTrackingRectangle";
+    static constexpr const char *_videoStreamTypeKey = "VideoStreamType";
 };
 
 Q_DECLARE_OPERATORS_FOR_FLAGS(MockConfiguration::Options)

--- a/src/Comms/MockLink/MockLink.cc
+++ b/src/Comms/MockLink/MockLink.cc
@@ -15,6 +15,10 @@
 #include "AppMessages.h"
 #include "QGCMath.h"
 
+#ifdef QGC_GST_STREAMING
+#include "MockVideoStreamServer.h"
+#endif
+
 #include <QtCore/QFile>
 #include <QtCore/QJsonArray>
 #include <QtCore/QJsonDocument>
@@ -96,6 +100,7 @@ MockLink::MockLink(SharedLinkConfigurationPtr &config, QObject *parent)
                                     : nullptr)
     , _mockLinkPX4Calibration(new MockLinkPX4Calibration(this))
     , _mockLinkFTP(new MockLinkFTP(_vehicleSystemId, _vehicleComponentId, this))
+    , _requestedVideoStreamType(_mockConfig->videoStreamTypeEnum())
 {
     qCDebug(MockLinkLog) << this;
 
@@ -176,6 +181,9 @@ bool MockLink::_connect()
         }
         mavlink_status_t *const incomingStatus = mavlink_get_channel_status(_incomingMavlinkChannel);
         incomingStatus->flags &= ~MAVLINK_STATUS_FLAG_OUT_MAVLINK1;
+
+        _startVideoStreamServer();
+
         emit connected();
     }
 
@@ -203,12 +211,93 @@ void MockLink::disconnect()
         mavlink_reset_channel_status(_outgoingMavlinkChannel);
     }
 
+    // Must run before the disconnected emit below: that signal can release the last
+    // shared_ptr to this MockLink, so touching members afterwards is use-after-free.
+    _stopVideoStreamServer();
+
     if (_connected) {
         _connected = false;
         if (!_disconnectedEmitted.exchange(true)) {
             emit disconnected();
         }
     }
+}
+
+void MockLink::_startVideoStreamServer()
+{
+#ifdef QGC_GST_STREAMING
+    // Only serve a stream when a camera advertising a video stream is present and a type was requested.
+    if (_videoStreamServer || !_mockLinkCamera || !_mockConfig->cameraHasVideoStream()
+            || _requestedVideoStreamType == MockConfiguration::VideoStreamNone) {
+        return;
+    }
+
+    MockVideoStreamServer::StreamType serverType = MockVideoStreamServer::StreamType::RtpUdpH264;
+    quint16 port = 5600;
+    switch (_requestedVideoStreamType) {
+    case MockConfiguration::VideoStreamRtpUdpH264:
+        serverType = MockVideoStreamServer::StreamType::RtpUdpH264;
+        port = 5600;
+        break;
+    case MockConfiguration::VideoStreamRtpUdpH265:
+        serverType = MockVideoStreamServer::StreamType::RtpUdpH265;
+        port = 5601;
+        break;
+    case MockConfiguration::VideoStreamRtspH264:
+        serverType = MockVideoStreamServer::StreamType::RtspH264;
+        port = 8554;
+        break;
+    case MockConfiguration::VideoStreamMpegTsUdp:
+        serverType = MockVideoStreamServer::StreamType::MpegTsUdp;
+        port = 5600;
+        break;
+    case MockConfiguration::VideoStreamMpegTsTcp:
+        serverType = MockVideoStreamServer::StreamType::MpegTsTcp;
+        port = 5600;
+        break;
+    case MockConfiguration::VideoStreamNone:
+        return;
+    }
+
+    auto *server = new MockVideoStreamServer();
+    if (!server->start(serverType, QStringLiteral("127.0.0.1"), port)) {
+        qCWarning(MockLinkLog) << "Failed to start mock video stream server for type" << _requestedVideoStreamType;
+        delete server;
+        return;
+    }
+
+    _videoStreamServer = server;
+    {
+        QMutexLocker locker(&_videoStreamMutex);
+        _servedVideoStreamType = _requestedVideoStreamType;
+        _videoStreamUri = server->servedUri();
+    }
+    qCDebug(MockLinkLog) << "Mock video stream server serving" << server->servedUri();
+#endif
+}
+
+void MockLink::_stopVideoStreamServer()
+{
+#ifdef QGC_GST_STREAMING
+    // Clear the served-stream snapshot first so observers (servedVideoStream) stop
+    // advertising the URI before the server actually goes away.
+    {
+        QMutexLocker locker(&_videoStreamMutex);
+        _servedVideoStreamType = MockConfiguration::VideoStreamNone;
+        _videoStreamUri.clear();
+    }
+    if (_videoStreamServer) {
+        delete _videoStreamServer;
+        _videoStreamServer = nullptr;
+    }
+#endif
+}
+
+void MockLink::servedVideoStream(MockConfiguration::VideoStreamType &type, QString &uri) const
+{
+    QMutexLocker locker(&_videoStreamMutex);
+    type = _servedVideoStreamType;
+    uri = _videoStreamUri;
 }
 
 void MockLink::run1HzTasks()
@@ -2405,7 +2494,7 @@ MockLink *MockLink::_startMockLink(MockConfiguration *mockConfig)
     return nullptr;
 }
 
-MockLink *MockLink::_startMockLinkWorker(const QString &configName, MAV_AUTOPILOT firmwareType, MAV_TYPE vehicleType, MockConfiguration::Options options, MockConfiguration::FailureMode_t failureMode)
+MockLink *MockLink::_startMockLinkWorker(const QString &configName, MAV_AUTOPILOT firmwareType, MAV_TYPE vehicleType, MockConfiguration::Options options, MockConfiguration::FailureMode_t failureMode, MockConfiguration::VideoStreamType videoStreamType)
 {
     MockConfiguration *const mockConfig = new MockConfiguration(configName);
 
@@ -2419,14 +2508,15 @@ MockLink *MockLink::_startMockLinkWorker(const QString &configName, MAV_AUTOPILO
     mockConfig->setStayMavlinkV1(options.testFlag(MockConfiguration::OptionStayMavlinkV1));
     mockConfig->setApmStartFreshParams(options.testFlag(MockConfiguration::OptionAPMStartFreshParams));
     mockConfig->setFtpCapability(options.testFlag(MockConfiguration::OptionFtpCapability));
+    mockConfig->setVideoStreamType(videoStreamType);
     mockConfig->setFailureMode(failureMode);
 
     return _startMockLink(mockConfig);
 }
 
-MockLink *MockLink::startPX4MockLink(MockConfiguration::Options options, MockConfiguration::FailureMode_t failureMode)
+MockLink *MockLink::startPX4MockLink(MockConfiguration::Options options, MockConfiguration::FailureMode_t failureMode, MockConfiguration::VideoStreamType videoStreamType)
 {
-    return _startMockLinkWorker(QStringLiteral("PX4 MultiRotor MockLink"), MAV_AUTOPILOT_PX4, MAV_TYPE_QUADROTOR, options, failureMode);
+    return _startMockLinkWorker(QStringLiteral("PX4 MultiRotor MockLink"), MAV_AUTOPILOT_PX4, MAV_TYPE_QUADROTOR, options, failureMode, videoStreamType);
 }
 
 MockLink *MockLink::startPX4MockLinkWithMission(MockConfiguration::Options options, MockConfiguration::FailureMode_t failureMode)
@@ -2434,9 +2524,9 @@ MockLink *MockLink::startPX4MockLinkWithMission(MockConfiguration::Options optio
     return _startMockLinkWorker(QStringLiteral("PX4 MultiRotor MockLink"), MAV_AUTOPILOT_PX4, MAV_TYPE_QUADROTOR, options | MockConfiguration::OptionPreloadMission, failureMode);
 }
 
-MockLink *MockLink::startGenericMockLink(MockConfiguration::Options options, MockConfiguration::FailureMode_t failureMode)
+MockLink *MockLink::startGenericMockLink(MockConfiguration::Options options, MockConfiguration::FailureMode_t failureMode, MockConfiguration::VideoStreamType videoStreamType)
 {
-    return _startMockLinkWorker(QStringLiteral("Generic MockLink"), MAV_AUTOPILOT_GENERIC, MAV_TYPE_QUADROTOR, options, failureMode);
+    return _startMockLinkWorker(QStringLiteral("Generic MockLink"), MAV_AUTOPILOT_GENERIC, MAV_TYPE_QUADROTOR, options, failureMode, videoStreamType);
 }
 
 MockLink *MockLink::startNoInitialConnectMockLink(MockConfiguration::Options options, MockConfiguration::FailureMode_t failureMode)
@@ -2444,24 +2534,24 @@ MockLink *MockLink::startNoInitialConnectMockLink(MockConfiguration::Options opt
     return _startMockLinkWorker(QStringLiteral("No Initial Connect MockLink"), MAV_AUTOPILOT_PX4, MAV_TYPE_GENERIC, options, failureMode);
 }
 
-MockLink *MockLink::startAPMArduCopterMockLink(MockConfiguration::Options options, MockConfiguration::FailureMode_t failureMode)
+MockLink *MockLink::startAPMArduCopterMockLink(MockConfiguration::Options options, MockConfiguration::FailureMode_t failureMode, MockConfiguration::VideoStreamType videoStreamType)
 {
-    return _startMockLinkWorker(QStringLiteral("ArduCopter MockLink"),MAV_AUTOPILOT_ARDUPILOTMEGA, MAV_TYPE_QUADROTOR, options, failureMode);
+    return _startMockLinkWorker(QStringLiteral("ArduCopter MockLink"),MAV_AUTOPILOT_ARDUPILOTMEGA, MAV_TYPE_QUADROTOR, options, failureMode, videoStreamType);
 }
 
-MockLink *MockLink::startAPMArduPlaneMockLink(MockConfiguration::Options options, MockConfiguration::FailureMode_t failureMode)
+MockLink *MockLink::startAPMArduPlaneMockLink(MockConfiguration::Options options, MockConfiguration::FailureMode_t failureMode, MockConfiguration::VideoStreamType videoStreamType)
 {
-    return _startMockLinkWorker(QStringLiteral("ArduPlane MockLink"), MAV_AUTOPILOT_ARDUPILOTMEGA, MAV_TYPE_FIXED_WING, options, failureMode);
+    return _startMockLinkWorker(QStringLiteral("ArduPlane MockLink"), MAV_AUTOPILOT_ARDUPILOTMEGA, MAV_TYPE_FIXED_WING, options, failureMode, videoStreamType);
 }
 
-MockLink *MockLink::startAPMArduSubMockLink(MockConfiguration::Options options, MockConfiguration::FailureMode_t failureMode)
+MockLink *MockLink::startAPMArduSubMockLink(MockConfiguration::Options options, MockConfiguration::FailureMode_t failureMode, MockConfiguration::VideoStreamType videoStreamType)
 {
-    return _startMockLinkWorker(QStringLiteral("ArduSub MockLink"), MAV_AUTOPILOT_ARDUPILOTMEGA, MAV_TYPE_SUBMARINE, options, failureMode);
+    return _startMockLinkWorker(QStringLiteral("ArduSub MockLink"), MAV_AUTOPILOT_ARDUPILOTMEGA, MAV_TYPE_SUBMARINE, options, failureMode, videoStreamType);
 }
 
-MockLink *MockLink::startAPMArduRoverMockLink(MockConfiguration::Options options, MockConfiguration::FailureMode_t failureMode)
+MockLink *MockLink::startAPMArduRoverMockLink(MockConfiguration::Options options, MockConfiguration::FailureMode_t failureMode, MockConfiguration::VideoStreamType videoStreamType)
 {
-    return _startMockLinkWorker(QStringLiteral("ArduRover MockLink"), MAV_AUTOPILOT_ARDUPILOTMEGA, MAV_TYPE_GROUND_ROVER, options, failureMode);
+    return _startMockLinkWorker(QStringLiteral("ArduRover MockLink"), MAV_AUTOPILOT_ARDUPILOTMEGA, MAV_TYPE_GROUND_ROVER, options, failureMode, videoStreamType);
 }
 
 void MockLink::_sendRCChannels()

--- a/src/Comms/MockLink/MockLink.h
+++ b/src/Comms/MockLink/MockLink.h
@@ -22,6 +22,7 @@ class MockLinkCamera;
 class MockLinkFTP;
 class MockLinkGimbal;
 class MockLinkWorker;
+class MockVideoStreamServer;
 class QThread;
 
 class MockLink : public LinkInterface
@@ -195,14 +196,23 @@ public:
     /// status is a MAV_ODID_ARM_STATUS value.
     void setRemoteIDArmStatus(uint8_t status, const QString& error);
 
-    static MockLink *startPX4MockLink(MockConfiguration::Options options = MockConfiguration::OptionNone, MockConfiguration::FailureMode_t failureMode = MockConfiguration::FailNone);
+    static MockLink *startPX4MockLink(MockConfiguration::Options options = MockConfiguration::OptionNone, MockConfiguration::FailureMode_t failureMode = MockConfiguration::FailNone, MockConfiguration::VideoStreamType videoStreamType = MockConfiguration::VideoStreamNone);
     static MockLink *startPX4MockLinkWithMission(MockConfiguration::Options options = MockConfiguration::OptionNone, MockConfiguration::FailureMode_t failureMode = MockConfiguration::FailNone);
-    static MockLink *startGenericMockLink(MockConfiguration::Options options = MockConfiguration::OptionNone, MockConfiguration::FailureMode_t failureMode = MockConfiguration::FailNone);
+    static MockLink *startGenericMockLink(MockConfiguration::Options options = MockConfiguration::OptionNone, MockConfiguration::FailureMode_t failureMode = MockConfiguration::FailNone, MockConfiguration::VideoStreamType videoStreamType = MockConfiguration::VideoStreamNone);
     static MockLink *startNoInitialConnectMockLink(MockConfiguration::Options options = MockConfiguration::OptionNone, MockConfiguration::FailureMode_t failureMode = MockConfiguration::FailNone);
-    static MockLink *startAPMArduCopterMockLink(MockConfiguration::Options options = MockConfiguration::OptionNone, MockConfiguration::FailureMode_t failureMode = MockConfiguration::FailNone);
-    static MockLink *startAPMArduPlaneMockLink(MockConfiguration::Options options = MockConfiguration::OptionNone, MockConfiguration::FailureMode_t failureMode = MockConfiguration::FailNone);
-    static MockLink *startAPMArduSubMockLink(MockConfiguration::Options options = MockConfiguration::OptionNone, MockConfiguration::FailureMode_t failureMode = MockConfiguration::FailNone);
-    static MockLink *startAPMArduRoverMockLink(MockConfiguration::Options options = MockConfiguration::OptionNone, MockConfiguration::FailureMode_t failureMode = MockConfiguration::FailNone);
+    static MockLink *startAPMArduCopterMockLink(MockConfiguration::Options options = MockConfiguration::OptionNone, MockConfiguration::FailureMode_t failureMode = MockConfiguration::FailNone, MockConfiguration::VideoStreamType videoStreamType = MockConfiguration::VideoStreamNone);
+    static MockLink *startAPMArduPlaneMockLink(MockConfiguration::Options options = MockConfiguration::OptionNone, MockConfiguration::FailureMode_t failureMode = MockConfiguration::FailNone, MockConfiguration::VideoStreamType videoStreamType = MockConfiguration::VideoStreamNone);
+    static MockLink *startAPMArduSubMockLink(MockConfiguration::Options options = MockConfiguration::OptionNone, MockConfiguration::FailureMode_t failureMode = MockConfiguration::FailNone, MockConfiguration::VideoStreamType videoStreamType = MockConfiguration::VideoStreamNone);
+    static MockLink *startAPMArduRoverMockLink(MockConfiguration::Options options = MockConfiguration::OptionNone, MockConfiguration::FailureMode_t failureMode = MockConfiguration::FailNone, MockConfiguration::VideoStreamType videoStreamType = MockConfiguration::VideoStreamNone);
+
+    /// Thread-safe snapshot of the video stream actually being served (VideoStreamNone/empty
+    /// when none is served). Safe to call from the worker thread while _connect()/disconnect()
+    /// mutate the served state on the main thread. MockLinkCamera advertises
+    /// VIDEO_STREAM_INFORMATION consistent with this snapshot.
+    void servedVideoStream(MockConfiguration::VideoStreamType &type, QString &uri) const;
+
+    /// Video stream type the configuration requested (immutable after construction).
+    MockConfiguration::VideoStreamType requestedVideoStreamType() const { return _requestedVideoStreamType; }
 
     // Special commands for testing Vehicle::sendMavCommandWithHandler
     static constexpr MAV_CMD MAV_CMD_MOCKLINK_ALWAYS_RESULT_ACCEPTED = MAV_CMD_USER_1;
@@ -317,8 +327,11 @@ private:
     int  _availableModesCount() const;
     void _moveADSBVehicle(int vehicleIndex);
 
-    static MockLink *_startMockLinkWorker(const QString &configName, MAV_AUTOPILOT firmwareType, MAV_TYPE vehicleType, MockConfiguration::Options options, MockConfiguration::FailureMode_t failureMode);
+    static MockLink *_startMockLinkWorker(const QString &configName, MAV_AUTOPILOT firmwareType, MAV_TYPE vehicleType, MockConfiguration::Options options, MockConfiguration::FailureMode_t failureMode, MockConfiguration::VideoStreamType videoStreamType = MockConfiguration::VideoStreamNone);
     static MockLink *_startMockLink(MockConfiguration *mockConfig);
+
+    void _startVideoStreamServer();
+    void _stopVideoStreamServer();
 
     /// Creates a file with random contents of the specified size.
     /// @return Fully qualified path to created file
@@ -351,6 +364,14 @@ private:
     MockLinkGimbal *const _mockLinkGimbal = nullptr;
     MockLinkPX4Calibration *const _mockLinkPX4Calibration = nullptr;
     MockLinkFTP *const _mockLinkFTP = nullptr;
+
+    const MockConfiguration::VideoStreamType _requestedVideoStreamType = MockConfiguration::VideoStreamNone;
+    MockVideoStreamServer *_videoStreamServer = nullptr;
+    // Served state is written on the connect/disconnect thread and read from the worker
+    // thread (MockLinkCamera), so it is guarded by _videoStreamMutex.
+    mutable QMutex _videoStreamMutex;
+    MockConfiguration::VideoStreamType _servedVideoStreamType = MockConfiguration::VideoStreamNone;
+    QString _videoStreamUri;
 
     uint8_t _incomingMavlinkChannel = std::numeric_limits<uint8_t>::max();
     QMutex _incomingMavlinkMutex;

--- a/src/Comms/MockLink/MockLinkCamera.cc
+++ b/src/Comms/MockLink/MockLinkCamera.cc
@@ -690,7 +690,57 @@ void MockLinkCamera::_sendVideoStreamInformation(uint8_t compId, uint8_t streamI
     QByteArray nameBA = name.toLocal8Bit();
     nameBA.resize(MAVLINK_MSG_VIDEO_STREAM_INFORMATION_FIELD_NAME_LEN);
 
-    const QString uri = QStringLiteral("udp://127.0.0.1:5600");
+    // Match the transport/codec/URI to whatever MockLink is actually serving so QGC's
+    // receiver auto-configures correctly. Falls back to a static UDP H.264 advertisement
+    // when no live stream is being served (e.g. GStreamer streaming disabled at build).
+    uint8_t streamType = VIDEO_STREAM_TYPE_RTPUDP;
+    uint8_t encoding = VIDEO_STREAM_ENCODING_H264;
+    QString uri = QStringLiteral("udp://127.0.0.1:5600");
+    uint16_t flags = VIDEO_STREAM_STATUS_FLAGS_RUNNING;
+
+    MockConfiguration::VideoStreamType servedType = MockConfiguration::VideoStreamNone;
+    QString servedUri;
+    _mockLink->servedVideoStream(servedType, servedUri);
+    switch (servedType) {
+    case MockConfiguration::VideoStreamRtpUdpH264:
+        streamType = VIDEO_STREAM_TYPE_RTPUDP;
+        encoding = VIDEO_STREAM_ENCODING_H264;
+        uri = servedUri;
+        break;
+    case MockConfiguration::VideoStreamRtpUdpH265:
+        streamType = VIDEO_STREAM_TYPE_RTPUDP;
+        encoding = VIDEO_STREAM_ENCODING_H265;
+        uri = servedUri;
+        break;
+    case MockConfiguration::VideoStreamRtspH264:
+        streamType = VIDEO_STREAM_TYPE_RTSP;
+        encoding = VIDEO_STREAM_ENCODING_H264;
+        uri = servedUri;
+        break;
+    case MockConfiguration::VideoStreamMpegTsUdp:
+        streamType = VIDEO_STREAM_TYPE_MPEG_TS;
+        encoding = VIDEO_STREAM_ENCODING_H264;
+        uri = servedUri;
+        break;
+    case MockConfiguration::VideoStreamMpegTsTcp:
+        streamType = VIDEO_STREAM_TYPE_TCP_MPEG;
+        encoding = VIDEO_STREAM_ENCODING_H264;
+        uri = servedUri;
+        break;
+    case MockConfiguration::VideoStreamNone:
+#ifdef QGC_GST_STREAMING
+        // A specific stream type was requested but no live server is running (start failed).
+        // Advertise it as not-running with an empty URI so QGC doesn't try to open a receiver
+        // on a dead stream (video auto-configuration keys off the URI, not the RUNNING flag).
+        // When nothing was requested (the default), keep the historical static UDP advertisement.
+        if (_mockLink->requestedVideoStreamType() != MockConfiguration::VideoStreamNone) {
+            flags = 0;
+            uri.clear();
+        }
+#endif
+        break;
+    }
+
     QByteArray uriBA = uri.toLocal8Bit();
     uriBA.resize(MAVLINK_MSG_VIDEO_STREAM_INFORMATION_FIELD_URI_LEN);
 
@@ -702,25 +752,40 @@ void MockLinkCamera::_sendVideoStreamInformation(uint8_t compId, uint8_t streamI
         &msg,
         streamId,                               // stream_id
         kNumStreams,                            // count
-        VIDEO_STREAM_TYPE_RTPUDP,               // type
-        VIDEO_STREAM_STATUS_FLAGS_RUNNING,      // flags
+        streamType,                             // type
+        flags,                                  // flags
         30,                                     // framerate
-        1920,                                   // resolution_h
-        1080,                                   // resolution_v
-        4000,                                   // bitrate (kbit/s)
+        1280,                                   // resolution_h (matches MockVideoStreamServer test source)
+        720,                                    // resolution_v
+        2000,                                   // bitrate (kbit/s, matches encoder settings)
         0,                                      // rotation
         70,                                     // hfov
         nameBA.constData(),
         uriBA.constData(),
-        VIDEO_STREAM_ENCODING_H264,
+        encoding,
         0);                                     // encoding_sub
     _mockLink->respondWithMavlinkMessage(msg);
 
-    qCDebug(MockLinkCameraLog) << "Sent VIDEO_STREAM_INFORMATION for compId:" << compId << "stream:" << streamId;
+    qCDebug(MockLinkCameraLog) << "Sent VIDEO_STREAM_INFORMATION for compId:" << compId << "stream:" << streamId
+                               << "type:" << streamType << "uri:" << uri;
 }
 
 void MockLinkCamera::_sendVideoStreamStatus(uint8_t compId, uint8_t streamId)
 {
+    // Mirror the served/requested logic in _sendVideoStreamInformation: when a specific
+    // stream type was requested but no live server is running, report not-running so
+    // STATUS doesn't overwrite the non-running state advertised in INFORMATION.
+    uint16_t flags = VIDEO_STREAM_STATUS_FLAGS_RUNNING;
+#ifdef QGC_GST_STREAMING
+    MockConfiguration::VideoStreamType servedType = MockConfiguration::VideoStreamNone;
+    QString servedUri;
+    _mockLink->servedVideoStream(servedType, servedUri);
+    if (servedType == MockConfiguration::VideoStreamNone
+            && _mockLink->requestedVideoStreamType() != MockConfiguration::VideoStreamNone) {
+        flags = 0;
+    }
+#endif
+
     mavlink_message_t msg{};
     (void) mavlink_msg_video_stream_status_pack_chan(
         _mockLink->vehicleId(),
@@ -728,11 +793,11 @@ void MockLinkCamera::_sendVideoStreamStatus(uint8_t compId, uint8_t streamId)
         _mockLink->outgoingMavlinkChannel(),
         &msg,
         streamId,                               // stream_id
-        VIDEO_STREAM_STATUS_FLAGS_RUNNING,      // flags
+        flags,                                  // flags
         30,                                     // framerate
-        1920,                                   // resolution_h
-        1080,                                   // resolution_v
-        4000,                                   // bitrate (kbit/s)
+        1280,                                   // resolution_h (matches MockVideoStreamServer test source)
+        720,                                    // resolution_v
+        2000,                                   // bitrate (kbit/s, matches encoder settings)
         0,                                      // rotation
         70,                                     // hfov
         0);                                     // encoding (reserved in status)

--- a/src/QmlControls/QGroundControlQmlGlobal.cc
+++ b/src/QmlControls/QGroundControlQmlGlobal.cc
@@ -131,79 +131,85 @@ static MockConfiguration::Options _mockLinkOptions(bool sendStatusText, bool ena
 }
 #endif
 
-void QGroundControlQmlGlobal::startPX4MockLink(bool sendStatusText, bool enableCamera, bool enableGimbal, bool enableProximity)
+void QGroundControlQmlGlobal::startPX4MockLink(bool sendStatusText, bool enableCamera, bool enableGimbal, bool enableProximity, int videoStreamType)
 {
 #ifdef QT_DEBUG
-    MockLink::startPX4MockLink(_mockLinkOptions(sendStatusText, enableCamera, enableGimbal, enableProximity));
+    MockLink::startPX4MockLink(_mockLinkOptions(sendStatusText, enableCamera, enableGimbal, enableProximity), MockConfiguration::FailNone, MockConfiguration::videoStreamTypeFromInt(videoStreamType));
 #else
     Q_UNUSED(sendStatusText);
     Q_UNUSED(enableCamera);
     Q_UNUSED(enableGimbal);
     Q_UNUSED(enableProximity);
+    Q_UNUSED(videoStreamType);
 #endif
 }
 
-void QGroundControlQmlGlobal::startGenericMockLink(bool sendStatusText, bool enableCamera, bool enableGimbal, bool enableProximity)
+void QGroundControlQmlGlobal::startGenericMockLink(bool sendStatusText, bool enableCamera, bool enableGimbal, bool enableProximity, int videoStreamType)
 {
 #ifdef QT_DEBUG
-    MockLink::startGenericMockLink(_mockLinkOptions(sendStatusText, enableCamera, enableGimbal, enableProximity));
+    MockLink::startGenericMockLink(_mockLinkOptions(sendStatusText, enableCamera, enableGimbal, enableProximity), MockConfiguration::FailNone, MockConfiguration::videoStreamTypeFromInt(videoStreamType));
 #else
     Q_UNUSED(sendStatusText);
     Q_UNUSED(enableCamera);
     Q_UNUSED(enableGimbal);
     Q_UNUSED(enableProximity);
+    Q_UNUSED(videoStreamType);
 #endif
 }
 
-void QGroundControlQmlGlobal::startAPMArduCopterMockLink(bool sendStatusText, bool enableCamera, bool enableGimbal, bool enableProximity, bool apmStartFreshParams)
+void QGroundControlQmlGlobal::startAPMArduCopterMockLink(bool sendStatusText, bool enableCamera, bool enableGimbal, bool enableProximity, bool apmStartFreshParams, int videoStreamType)
 {
 #ifdef QT_DEBUG
-    MockLink::startAPMArduCopterMockLink(_mockLinkOptions(sendStatusText, enableCamera, enableGimbal, enableProximity, apmStartFreshParams));
+    MockLink::startAPMArduCopterMockLink(_mockLinkOptions(sendStatusText, enableCamera, enableGimbal, enableProximity, apmStartFreshParams), MockConfiguration::FailNone, MockConfiguration::videoStreamTypeFromInt(videoStreamType));
 #else
     Q_UNUSED(sendStatusText);
     Q_UNUSED(enableCamera);
     Q_UNUSED(enableGimbal);
     Q_UNUSED(enableProximity);
     Q_UNUSED(apmStartFreshParams);
+    Q_UNUSED(videoStreamType);
 #endif
 }
 
-void QGroundControlQmlGlobal::startAPMArduPlaneMockLink(bool sendStatusText, bool enableCamera, bool enableGimbal, bool enableProximity, bool apmStartFreshParams)
+void QGroundControlQmlGlobal::startAPMArduPlaneMockLink(bool sendStatusText, bool enableCamera, bool enableGimbal, bool enableProximity, bool apmStartFreshParams, int videoStreamType)
 {
 #ifdef QT_DEBUG
-    MockLink::startAPMArduPlaneMockLink(_mockLinkOptions(sendStatusText, enableCamera, enableGimbal, enableProximity, apmStartFreshParams));
+    MockLink::startAPMArduPlaneMockLink(_mockLinkOptions(sendStatusText, enableCamera, enableGimbal, enableProximity, apmStartFreshParams), MockConfiguration::FailNone, MockConfiguration::videoStreamTypeFromInt(videoStreamType));
 #else
     Q_UNUSED(sendStatusText);
     Q_UNUSED(enableCamera);
     Q_UNUSED(enableGimbal);
     Q_UNUSED(enableProximity);
     Q_UNUSED(apmStartFreshParams);
+    Q_UNUSED(videoStreamType);
 #endif
 }
 
-void QGroundControlQmlGlobal::startAPMArduSubMockLink(bool sendStatusText, bool enableCamera, bool enableGimbal, bool enableProximity, bool apmStartFreshParams)
+void QGroundControlQmlGlobal::startAPMArduSubMockLink(bool sendStatusText, bool enableCamera, bool enableGimbal, bool enableProximity, bool apmStartFreshParams, int videoStreamType)
 {
 #ifdef QT_DEBUG
-    MockLink::startAPMArduSubMockLink(_mockLinkOptions(sendStatusText, enableCamera, enableGimbal, enableProximity, apmStartFreshParams));
+    MockLink::startAPMArduSubMockLink(_mockLinkOptions(sendStatusText, enableCamera, enableGimbal, enableProximity, apmStartFreshParams), MockConfiguration::FailNone, MockConfiguration::videoStreamTypeFromInt(videoStreamType));
 #else
     Q_UNUSED(sendStatusText);
     Q_UNUSED(enableCamera);
     Q_UNUSED(enableGimbal);
     Q_UNUSED(enableProximity);
     Q_UNUSED(apmStartFreshParams);
+    Q_UNUSED(videoStreamType);
 #endif
 }
 
-void QGroundControlQmlGlobal::startAPMArduRoverMockLink(bool sendStatusText, bool enableCamera, bool enableGimbal, bool enableProximity, bool apmStartFreshParams)
+void QGroundControlQmlGlobal::startAPMArduRoverMockLink(bool sendStatusText, bool enableCamera, bool enableGimbal, bool enableProximity, bool apmStartFreshParams, int videoStreamType)
 {
 #ifdef QT_DEBUG
-    MockLink::startAPMArduRoverMockLink(_mockLinkOptions(sendStatusText, enableCamera, enableGimbal, enableProximity, apmStartFreshParams));
+    MockLink::startAPMArduRoverMockLink(_mockLinkOptions(sendStatusText, enableCamera, enableGimbal, enableProximity, apmStartFreshParams), MockConfiguration::FailNone, MockConfiguration::videoStreamTypeFromInt(videoStreamType));
 #else
     Q_UNUSED(sendStatusText);
     Q_UNUSED(enableCamera);
     Q_UNUSED(enableGimbal);
     Q_UNUSED(enableProximity);
     Q_UNUSED(apmStartFreshParams);
+    Q_UNUSED(videoStreamType);
 #endif
 }
 

--- a/src/QmlControls/QGroundControlQmlGlobal.h
+++ b/src/QmlControls/QGroundControlQmlGlobal.h
@@ -114,12 +114,12 @@ public:
 
 
 
-    Q_INVOKABLE void    startPX4MockLink            (bool sendStatusText, bool enableCamera, bool enableGimbal, bool enableProximity = false);
-    Q_INVOKABLE void    startGenericMockLink        (bool sendStatusText, bool enableCamera, bool enableGimbal, bool enableProximity = false);
-    Q_INVOKABLE void    startAPMArduCopterMockLink  (bool sendStatusText, bool enableCamera, bool enableGimbal, bool enableProximity = false, bool apmStartFreshParams = false);
-    Q_INVOKABLE void    startAPMArduPlaneMockLink   (bool sendStatusText, bool enableCamera, bool enableGimbal, bool enableProximity = false, bool apmStartFreshParams = false);
-    Q_INVOKABLE void    startAPMArduSubMockLink     (bool sendStatusText, bool enableCamera, bool enableGimbal, bool enableProximity = false, bool apmStartFreshParams = false);
-    Q_INVOKABLE void    startAPMArduRoverMockLink   (bool sendStatusText, bool enableCamera, bool enableGimbal, bool enableProximity = false, bool apmStartFreshParams = false);
+    Q_INVOKABLE void    startPX4MockLink            (bool sendStatusText, bool enableCamera, bool enableGimbal, bool enableProximity = false, int videoStreamType = 0);
+    Q_INVOKABLE void    startGenericMockLink        (bool sendStatusText, bool enableCamera, bool enableGimbal, bool enableProximity = false, int videoStreamType = 0);
+    Q_INVOKABLE void    startAPMArduCopterMockLink  (bool sendStatusText, bool enableCamera, bool enableGimbal, bool enableProximity = false, bool apmStartFreshParams = false, int videoStreamType = 0);
+    Q_INVOKABLE void    startAPMArduPlaneMockLink   (bool sendStatusText, bool enableCamera, bool enableGimbal, bool enableProximity = false, bool apmStartFreshParams = false, int videoStreamType = 0);
+    Q_INVOKABLE void    startAPMArduSubMockLink     (bool sendStatusText, bool enableCamera, bool enableGimbal, bool enableProximity = false, bool apmStartFreshParams = false, int videoStreamType = 0);
+    Q_INVOKABLE void    startAPMArduRoverMockLink   (bool sendStatusText, bool enableCamera, bool enableGimbal, bool enableProximity = false, bool apmStartFreshParams = false, int videoStreamType = 0);
     Q_INVOKABLE void    stopOneMockLink             (void);
 
     Q_INVOKABLE bool linesIntersect(QPointF xLine1, QPointF yLine1, QPointF xLine2, QPointF yLine2);

--- a/src/VideoManager/VideoReceiver/GStreamer/CMakeLists.txt
+++ b/src/VideoManager/VideoReceiver/GStreamer/CMakeLists.txt
@@ -3,7 +3,14 @@ if(NOT QGC_ENABLE_GST_VIDEOSTREAMING)
 endif()
 
 # Linux adds Allocators (gstreamer-allocators-1.0) for the DMABuf header probe in Orchestrator.cmake.
+# RtspServer (gstreamer-rtsp-server-1.0) drives the MockLink test video stream server, which is
+# Debug-only (see Comms/MockLink/CMakeLists.txt) — so only request it in Debug to keep the
+# rtsp-server lib out of release builds. It is also optional: a define is emitted below only
+# when the SDK actually ships it.
 set(_qgc_gst_components Core Base Video App Rtsp)
+if(CMAKE_BUILD_TYPE STREQUAL "Debug")
+    list(APPEND _qgc_gst_components RtspServer)
+endif()
 if(LINUX)
     list(APPEND _qgc_gst_components Allocators)
 endif()
@@ -24,8 +31,25 @@ target_link_libraries(QGCGStreamer
 
 target_compile_definitions(QGCGStreamer PUBLIC QGC_GST_STREAMING)
 
+# gstreamer-rtsp-server-1.0 is only requested in Debug (MockLink test server) and may be absent
+# on minimal installs. Its api_rtsp_server target is already aggregated into GStreamer::GStreamer
+# when found; just flag availability for MockVideoStreamServer.
+if(CMAKE_BUILD_TYPE STREQUAL "Debug" AND GStreamer_RtspServer_FOUND)
+    target_compile_definitions(QGCGStreamer PUBLIC QGC_GST_RTSP_SERVER)
+endif()
+
 if(LINUX AND GStreamer_VERSION VERSION_LESS "1.28.0")
     target_compile_definitions(QGCGStreamer PUBLIC QGC_GST_ENABLE_LEGACY_PARSEBIN_CAPS_FILTER=1)
+endif()
+
+# MockVideoStreamServer feeds MockLink's synthetic video stream; MockLink is Debug-only
+# (see Comms/MockLink/CMakeLists.txt), so only compile it in Debug to keep it out of release.
+if(CMAKE_BUILD_TYPE STREQUAL "Debug")
+    target_sources(QGCGStreamer
+        PRIVATE
+            MockVideoStreamServer.cc
+            MockVideoStreamServer.h
+    )
 endif()
 
 # The *ForTest() helpers (singleFdImportEnabledForTest, clearForTest) compile only under this flag.

--- a/src/VideoManager/VideoReceiver/GStreamer/MockVideoStreamServer.cc
+++ b/src/VideoManager/VideoReceiver/GStreamer/MockVideoStreamServer.cc
@@ -1,0 +1,248 @@
+// GStreamer/GLib headers must precede any Qt header: Qt's `signals` keyword macro
+// clashes with a struct member named `signals` in glib's gdbusintrospection.h
+// (pulled in transitively by rtsp-server.h).
+#include <gst/gst.h>
+
+#ifdef QGC_GST_RTSP_SERVER
+#include <glib.h>
+#include <gst/rtsp-server/rtsp-server.h>
+#endif
+
+#include "MockVideoStreamServer.h"
+
+#include "QGCLoggingCategory.h"
+
+QGC_LOGGING_CATEGORY(MockVideoStreamServerLog, "VideoManager.MockVideoStreamServer")
+
+namespace {
+
+// Shared test pattern source. videotestsrc's "ball" pattern makes motion obvious so a
+// stalled pipeline is easy to spot by eye.
+constexpr const char *kTestSource =
+    "videotestsrc is-live=true pattern=ball ! "
+    "video/x-raw,width=1280,height=720,framerate=30/1 ! "
+    "videoconvert";
+
+constexpr const char *kH264Encoder = "x264enc tune=zerolatency bitrate=2000 key-int-max=30";
+constexpr const char *kH265Encoder = "x265enc tune=zerolatency bitrate=2000";
+
+bool factoryExists(const char *name)
+{
+    GstElementFactory *factory = gst_element_factory_find(name);
+    if (factory) {
+        gst_object_unref(factory);
+        return true;
+    }
+    return false;
+}
+
+// GStreamer init is owned by QGC's central VideoBackend/GStreamer::initialize() path
+// (environment prep, static plugin registration, logging). Never call gst_init() here —
+// running it first would bypass that setup and turn the central init into a no-op.
+bool gstInitialized()
+{
+    if (!gst_is_initialized()) {
+        qCWarning(MockVideoStreamServerLog) << "GStreamer not initialized; QGC's central GStreamer init must run before serving a mock stream";
+        return false;
+    }
+    return true;
+}
+
+} // namespace
+
+MockVideoStreamServer::~MockVideoStreamServer()
+{
+    stop();
+}
+
+bool MockVideoStreamServer::isStreamTypeAvailable(StreamType type)
+{
+    if (!gstInitialized()) {
+        return false;
+    }
+
+    switch (type) {
+    case StreamType::RtpUdpH264:
+        return factoryExists("x264enc") && factoryExists("videotestsrc");
+    case StreamType::MpegTsUdp:
+    case StreamType::MpegTsTcp:
+        // mpegtsmux ships in gst-plugins-bad and can be absent even when the encoder is present.
+        return factoryExists("x264enc") && factoryExists("videotestsrc") && factoryExists("mpegtsmux");
+    case StreamType::RtpUdpH265:
+        return factoryExists("x265enc") && factoryExists("videotestsrc");
+    case StreamType::RtspH264:
+#ifdef QGC_GST_RTSP_SERVER
+        return factoryExists("x264enc") && factoryExists("videotestsrc");
+#else
+        return false;
+#endif
+    }
+
+    return false;
+}
+
+bool MockVideoStreamServer::start(StreamType type, const QString &host, quint16 port)
+{
+    if (_running) {
+        stop();
+    }
+
+    if (!isStreamTypeAvailable(type)) {
+        qCWarning(MockVideoStreamServerLog) << "Requested stream type is not available in this GStreamer install";
+        return false;
+    }
+
+    if (type == StreamType::RtspH264) {
+#ifdef QGC_GST_RTSP_SERVER
+        if (!_startRtsp(host, port)) {
+            return false;
+        }
+        _servedUri = QStringLiteral("rtsp://%1:%2/test").arg(host, QString::number(port));
+        _running = true;
+        qCDebug(MockVideoStreamServerLog) << "Serving" << _servedUri;
+        return true;
+#else
+        qCWarning(MockVideoStreamServerLog) << "RTSP requested but gst-rtsp-server is not available";
+        return false;
+#endif
+    }
+
+    QString launch;
+    QString uri;
+    const QString portString = QString::number(port);
+    switch (type) {
+    case StreamType::RtpUdpH264:
+        launch = QStringLiteral("%1 ! %2 ! rtph264pay config-interval=1 pt=96 ! udpsink host=%3 port=%4")
+                     .arg(kTestSource, kH264Encoder, host, portString);
+        uri = QStringLiteral("udp://%1:%2").arg(host, portString);
+        break;
+    case StreamType::RtpUdpH265:
+        launch = QStringLiteral("%1 ! %2 ! rtph265pay config-interval=1 pt=96 ! udpsink host=%3 port=%4")
+                     .arg(kTestSource, kH265Encoder, host, portString);
+        uri = QStringLiteral("udp265://%1:%2").arg(host, portString);
+        break;
+    case StreamType::MpegTsUdp:
+        launch = QStringLiteral("%1 ! %2 ! mpegtsmux ! udpsink host=%3 port=%4")
+                     .arg(kTestSource, kH264Encoder, host, portString);
+        uri = QStringLiteral("mpegts://%1:%2").arg(host, portString);
+        break;
+    case StreamType::MpegTsTcp:
+        launch = QStringLiteral("%1 ! %2 ! mpegtsmux ! tcpserversink host=%3 port=%4")
+                     .arg(kTestSource, kH264Encoder, host, portString);
+        uri = QStringLiteral("tcp://%1:%2").arg(host, portString);
+        break;
+    case StreamType::RtspH264:
+        return false; // handled above
+    }
+
+    if (!_startPipeline(launch)) {
+        return false;
+    }
+
+    _servedUri = uri;
+    _running = true;
+    qCDebug(MockVideoStreamServerLog) << "Serving" << _servedUri << "via" << launch;
+    return true;
+}
+
+bool MockVideoStreamServer::_startPipeline(const QString &launch)
+{
+    GError *error = nullptr;
+    GstElement *pipeline = gst_parse_launch(launch.toUtf8().constData(), &error);
+    if (error) {
+        qCWarning(MockVideoStreamServerLog) << "Failed to build pipeline:" << error->message;
+        g_error_free(error);
+        if (pipeline) {
+            gst_object_unref(pipeline);
+        }
+        return false;
+    }
+
+    if (gst_element_set_state(pipeline, GST_STATE_PLAYING) == GST_STATE_CHANGE_FAILURE) {
+        qCWarning(MockVideoStreamServerLog) << "Failed to set pipeline to PLAYING";
+        gst_object_unref(pipeline);
+        return false;
+    }
+
+    _pipeline = pipeline;
+    return true;
+}
+
+void MockVideoStreamServer::stop()
+{
+    if (_pipeline) {
+        gst_element_set_state(_pipeline, GST_STATE_NULL);
+        gst_object_unref(_pipeline);
+        _pipeline = nullptr;
+    }
+
+#ifdef QGC_GST_RTSP_SERVER
+    _stopRtsp();
+#endif
+
+    _running = false;
+    _servedUri.clear();
+}
+
+#ifdef QGC_GST_RTSP_SERVER
+bool MockVideoStreamServer::_startRtsp(const QString &host, quint16 port)
+{
+    Q_UNUSED(host); // RTSP server binds all interfaces; client connects via the advertised host.
+
+    _rtspContext = g_main_context_new();
+
+    GstRTSPServer *server = gst_rtsp_server_new();
+    const QByteArray service = QByteArray::number(port);
+    gst_rtsp_server_set_service(server, service.constData());
+
+    GstRTSPMountPoints *mounts = gst_rtsp_server_get_mount_points(server);
+    GstRTSPMediaFactory *factory = gst_rtsp_media_factory_new();
+    const QString launch = QStringLiteral("( %1 ! %2 ! rtph264pay name=pay0 pt=96 )")
+                               .arg(kTestSource, kH264Encoder);
+    gst_rtsp_media_factory_set_launch(factory, launch.toUtf8().constData());
+    gst_rtsp_media_factory_set_shared(factory, TRUE);
+    gst_rtsp_mount_points_add_factory(mounts, "/test", factory);
+    g_object_unref(mounts);
+
+    if (gst_rtsp_server_attach(server, _rtspContext) == 0) {
+        qCWarning(MockVideoStreamServerLog) << "Failed to attach RTSP server on port" << port;
+        gst_object_unref(server);
+        g_main_context_unref(_rtspContext);
+        _rtspContext = nullptr;
+        return false;
+    }
+
+    _rtspServer = server;
+    _rtspLoop = g_main_loop_new(_rtspContext, FALSE);
+
+    _rtspThread = std::thread([this]() {
+        g_main_context_push_thread_default(_rtspContext);
+        g_main_loop_run(_rtspLoop);
+        g_main_context_pop_thread_default(_rtspContext);
+    });
+
+    return true;
+}
+
+void MockVideoStreamServer::_stopRtsp()
+{
+    if (_rtspLoop) {
+        g_main_loop_quit(_rtspLoop);
+    }
+    if (_rtspThread.joinable()) {
+        _rtspThread.join();
+    }
+    if (_rtspLoop) {
+        g_main_loop_unref(_rtspLoop);
+        _rtspLoop = nullptr;
+    }
+    if (_rtspServer) {
+        gst_object_unref(_rtspServer);
+        _rtspServer = nullptr;
+    }
+    if (_rtspContext) {
+        g_main_context_unref(_rtspContext);
+        _rtspContext = nullptr;
+    }
+}
+#endif // QGC_GST_RTSP_SERVER

--- a/src/VideoManager/VideoReceiver/GStreamer/MockVideoStreamServer.h
+++ b/src/VideoManager/VideoReceiver/GStreamer/MockVideoStreamServer.h
@@ -1,0 +1,73 @@
+#pragma once
+
+#include <QtCore/QLoggingCategory>
+#include <QtCore/QString>
+#include <QtCore/QtGlobal>
+
+typedef struct _GstElement GstElement;
+
+#ifdef QGC_GST_RTSP_SERVER
+#include <thread>
+typedef struct _GstRTSPServer GstRTSPServer;
+typedef struct _GMainLoop GMainLoop;
+typedef struct _GMainContext GMainContext;
+#endif
+
+Q_DECLARE_LOGGING_CATEGORY(MockVideoStreamServerLog)
+
+/// \brief Serves a synthetic (videotestsrc) live video stream for MockLink so the
+/// GStreamer receive pipeline can be exercised end-to-end without real hardware.
+///
+/// One instance serves exactly one stream. The served URI (available via servedUri()
+/// after a successful start()) is what MockLink advertises via VIDEO_STREAM_INFORMATION,
+/// so QGC auto-configures its receiver to the matching transport/codec.
+class MockVideoStreamServer
+{
+public:
+    /// Transport + codec of the served stream. Kept independent of MockConfiguration
+    /// so the GStreamer layer carries no dependency on the Comms/MockLink module.
+    enum class StreamType {
+        RtpUdpH264, ///< RTP/H.264 over UDP   -> udp://
+        RtpUdpH265, ///< RTP/H.265 over UDP   -> udp265://
+        RtspH264,   ///< RTSP (H.264)         -> rtsp://
+        MpegTsUdp,  ///< MPEG-TS over UDP     -> mpegts://
+        MpegTsTcp,  ///< MPEG-TS over TCP     -> tcp://
+    };
+
+    MockVideoStreamServer() = default;
+    ~MockVideoStreamServer();
+
+    MockVideoStreamServer(const MockVideoStreamServer &) = delete;
+    MockVideoStreamServer &operator=(const MockVideoStreamServer &) = delete;
+
+    /// Start serving a test pattern of the given type on host:port.
+    /// @return true on success; on success servedUri() holds the URI QGC should connect to.
+    bool start(StreamType type, const QString &host, quint16 port);
+
+    /// Stop the stream and release all resources. Safe to call when not running.
+    void stop();
+
+    bool isRunning() const { return _running; }
+    QString servedUri() const { return _servedUri; }
+
+    /// True when the encoder/muxer elements required for @p type are present in the
+    /// local GStreamer install (e.g. false for RtpUdpH265 when x265enc is missing,
+    /// or RtspH264 when gst-rtsp-server was not built in).
+    static bool isStreamTypeAvailable(StreamType type);
+
+private:
+    bool _startPipeline(const QString &launch);
+#ifdef QGC_GST_RTSP_SERVER
+    bool _startRtsp(const QString &host, quint16 port);
+    void _stopRtsp();
+
+    GstRTSPServer *_rtspServer = nullptr;
+    GMainLoop *_rtspLoop = nullptr;
+    GMainContext *_rtspContext = nullptr;
+    std::thread _rtspThread;
+#endif
+
+    GstElement *_pipeline = nullptr;
+    bool _running = false;
+    QString _servedUri;
+};


### PR DESCRIPTION
## Summary

Adds a synthetic video stream server to MockLink so video playback and the FlyView video pipeline can be exercised end-to-end without real hardware or an external RTSP/RTP source. When a MockLink camera is configured with a video stream type, MockLink spins up a local GStreamer test source and advertises it over MAVLink.

## What's included

- New `MockVideoStreamServer` (`src/VideoManager/VideoReceiver/GStreamer/MockVideoStreamServer.{h,cc}`) that serves a synthetic stream. Supported types:
  - RTP/UDP H.264 (port 5600)
  - RTP/UDP H.265 (port 5601)
  - RTSP H.264 (port 8554, gated on `QGC_GST_RTSP_SERVER`)
  - MPEG-TS over UDP (port 5600)
  - MPEG-TS over TCP (port 5600)
- MockLink starts/stops the server on connect/disconnect and exposes the served type/URI (`servedVideoStream()`), guarded by a mutex for thread-safe snapshots.
- `MockConfiguration` gains a `VideoStreamType` enum plus JSON/settings plumbing so the stream type is selectable.
- MockLink settings UI (`MockLink.qml` / `MockLinkSettings.qml`) exposes the video stream type selection.
- All GStreamer usage is gated behind `QGC_GST_STREAMING` (and RTSP behind `QGC_GST_RTSP_SERVER`); builds without streaming are unaffected.

## Notes

- `MockVideoStreamServer.h` uses forward declarations for the GStreamer/glib types to keep the header lightweight (no `<gst/gst.h>` in the header).
- The `.cc` includes `<gst/gst.h>` before any Qt header to avoid the Qt `signals` macro clashing with the glib struct member.

## Testing

- Built locally with GStreamer streaming enabled.
- Manually verified MockLink serves each stream type and the FlyView video pipeline connects.
