### PR TITLE
fix(CorridorScanComplexItem): Fix the signal emission logic for

### DIFF
--- a/src/MissionManager/CorridorScanComplexItem.cc
+++ b/src/MissionManager/CorridorScanComplexItem.cc
@@ -19,6 +19,10 @@ CorridorScanComplexItem::CorridorScanComplexItem(PlanMasterController* masterCon
 {
     _editorQml = "qrc:/qml/QGroundControl/PlanView/CorridorScanEditor.qml";
 
+    // specifiesCoordinate() depends on _corridorPolyline.count(), so cache the
+    // initial value before any signal connections fire to keep the cache in sync.
+    _specifiesCoordinate = specifiesCoordinate();
+
     // We override the altitude to the mission default
     if (_cameraCalc.isManualCamera() || !_cameraCalc.valueSetIsDistance()->rawValue().toBool()) {
         _cameraCalc.distanceToSurface()->setRawValue(SettingsManager::instance()->appSettings()->defaultMissionItemAltitude()->rawValue());
@@ -211,6 +215,16 @@ void CorridorScanComplexItem::rotateEntryPoint(void)
 
 void CorridorScanComplexItem::_rebuildCorridorPolygon(void)
 {
+    // specifiesCoordinate() flips when the polyline crosses the 2-vertex threshold.
+    // MissionController only re-evaluates waypoint connector lines on this signal,
+    // so emit it here to link the corridor entry to the previous waypoint once the
+    // corridor polyline becomes valid.
+    const bool specifiesCoord = specifiesCoordinate();
+    if (specifiesCoord != _specifiesCoordinate) {
+        _specifiesCoordinate = specifiesCoord;
+        emit specifiesCoordinateChanged();
+    }
+
     if (_corridorPolyline.count() < 2) {
         _surveyAreaPolygon.clear();
         return;

--- a/src/MissionManager/CorridorScanComplexItem.h
+++ b/src/MissionManager/CorridorScanComplexItem.h
@@ -82,5 +82,9 @@ private:
     QMap<QString, FactMetaData*>    _metaDataMap;
     SettingsFact                    _corridorWidthFact;
 
+    // Cache of the last specifiesCoordinate() value so we can emit
+    // specifiesCoordinateChanged when the polyline crosses the 2-vertex threshold.
+    bool                            _specifiesCoordinate =   false;
+
     static constexpr const char* _jsonEntryPointKey =       "EntryPoint";
 };


### PR DESCRIPTION
coordinate specification state changes

Add a cache variable to record the previous coordinate specification status, detect status changes during corridor polygon reconstruction, and emit corresponding signals to ensure the task controller correctly updates the waypoint connection lines.

## Description
<!-- Describe your changes in detail. What problem does this solve? -->

## Type of Change
<!-- Put an 'x' in the relevant boxes -->
- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] CI/Build changes
- [ ] Other

## Testing
<!-- Describe the tests you ran and how to reproduce them -->
- [x] Tested locally
- [ ] Added/updated unit tests
- [ ] Tested with simulator (SITL)
- [ ] Tested with hardware

### Platforms Tested
<!-- Check all that apply -->
- [ ] Linux
- [x] Windows
- [ ] macOS
- [ ] Android
- [ ] iOS

### Flight Stacks Tested
<!-- If applicable -->
- [ ] PX4
- [x] ArduPilot

## Screenshots
<!-- If applicable, add screenshots to help explain your changes -->
<img width="530" height="475" alt="test1" src="https://github.com/user-attachments/assets/a45744ee-9e03-40b0-a746-04cde49428b5" />
<img width="720" height="556" alt="test2" src="https://github.com/user-attachments/assets/257f9e84-789d-4e45-b386-d34b96b4d877" />

## Checklist
<!-- Go over all the following points, and put an 'x' in all the boxes that apply -->
- [x] I have read the [Contribution Guidelines](CONTRIBUTING.md)
- [x] I have read the [Code of Conduct](CODE_OF_CONDUCT.md)
- [x] My code follows the project's coding standards
- [ ] I have added tests that prove my fix/feature works
- [ ] New and existing unit tests pass locally

## Related Issues
<!-- Link any related issues using #issue_number -->

---
By submitting this pull request, I confirm that my contribution is made under the terms of the project's dual license (Apache 2.0 and GPL v3).
