### PR TITLE
test(UnitTest): handle early local HTTP requests

### DIFF
--- a/test/UnitTestFramework/Fixtures/LocalHttpTestServer.cc
+++ b/test/UnitTestFramework/Fixtures/LocalHttpTestServer.cc
@@ -45,24 +45,33 @@ namespace {
 QByteArray httpReasonPhrase(int statusCode)
 {
     switch (statusCode) {
-    case 200: return QByteArrayLiteral("OK");
-    case 204: return QByteArrayLiteral("No Content");
-    case 206: return QByteArrayLiteral("Partial Content");
-    case 304: return QByteArrayLiteral("Not Modified");
-    case 400: return QByteArrayLiteral("Bad Request");
-    case 404: return QByteArrayLiteral("Not Found");
-    case 500: return QByteArrayLiteral("Internal Server Error");
-    default: return QByteArrayLiteral("Status");
+        case 200:
+            return QByteArrayLiteral("OK");
+        case 204:
+            return QByteArrayLiteral("No Content");
+        case 206:
+            return QByteArrayLiteral("Partial Content");
+        case 304:
+            return QByteArrayLiteral("Not Modified");
+        case 400:
+            return QByteArrayLiteral("Bad Request");
+        case 404:
+            return QByteArrayLiteral("Not Found");
+        case 500:
+            return QByteArrayLiteral("Internal Server Error");
+        default:
+            return QByteArrayLiteral("Status");
     }
 }
-} // namespace
+}  // namespace
 
 void LocalHttpTestServer::installHttpResponder(const QByteArray& body, int statusCode, const QByteArray& contentType,
                                                int cacheMaxAge)
 {
-    QByteArray header = QStringLiteral("HTTP/1.1 %1 %2\r\n"
-                                       "Content-Type: %3\r\n"
-                                       "Connection: close\r\n")
+    QByteArray header = QStringLiteral(
+                            "HTTP/1.1 %1 %2\r\n"
+                            "Content-Type: %3\r\n"
+                            "Connection: close\r\n")
                             .arg(statusCode)
                             .arg(QString::fromLatin1(httpReasonPhrase(statusCode)))
                             .arg(QString::fromLatin1(contentType))
@@ -80,16 +89,20 @@ void LocalHttpTestServer::installRawResponder(const QByteArray& rawResponse)
     (void) QObject::connect(&_server, &QTcpServer::newConnection, &_server, [this, rawResponse]() {
         while (_server.hasPendingConnections()) {
             QTcpSocket* const socket = _server.nextPendingConnection();
-            (void) QObject::connect(
-                socket, &QTcpSocket::readyRead, socket,
-                [socket, rawResponse]() {
-                    socket->readAll();
-                    socket->write(rawResponse);
-                    socket->flush();
-                    socket->disconnectFromHost();
-                },
-                Qt::SingleShotConnection);
             (void) QObject::connect(socket, &QTcpSocket::disconnected, socket, &QObject::deleteLater);
+
+            const auto sendResponse = [socket, rawResponse]() {
+                socket->readAll();
+                socket->write(rawResponse);
+                socket->flush();
+                socket->disconnectFromHost();
+            };
+
+            if (socket->bytesAvailable() > 0) {
+                sendResponse();
+            } else {
+                (void) QObject::connect(socket, &QTcpSocket::readyRead, socket, sendResponse, Qt::SingleShotConnection);
+            }
         }
     });
 }

--- a/test/UnitTestFramework/Fixtures/LocalHttpTestServer.cc
+++ b/test/UnitTestFramework/Fixtures/LocalHttpTestServer.cc
@@ -17,7 +17,21 @@ struct RawResponderState
     QByteArray request;
     bool responseSent = false;
 };
-}  // namespace
+
+QByteArray httpReasonPhrase(int statusCode)
+{
+    switch (statusCode) {
+    case 200: return QByteArrayLiteral("OK");
+    case 204: return QByteArrayLiteral("No Content");
+    case 206: return QByteArrayLiteral("Partial Content");
+    case 304: return QByteArrayLiteral("Not Modified");
+    case 400: return QByteArrayLiteral("Bad Request");
+    case 404: return QByteArrayLiteral("Not Found");
+    case 500: return QByteArrayLiteral("Internal Server Error");
+    default: return QByteArrayLiteral("Status");
+    }
+}
+} // namespace
 
 LocalHttpTestServer::~LocalHttpTestServer()
 {
@@ -52,37 +66,12 @@ QString LocalHttpTestServer::url(const QString& path) const
     return QStringLiteral("http://%1:%2%3").arg(host).arg(port()).arg(path);
 }
 
-namespace {
-QByteArray httpReasonPhrase(int statusCode)
-{
-    switch (statusCode) {
-        case 200:
-            return QByteArrayLiteral("OK");
-        case 204:
-            return QByteArrayLiteral("No Content");
-        case 206:
-            return QByteArrayLiteral("Partial Content");
-        case 304:
-            return QByteArrayLiteral("Not Modified");
-        case 400:
-            return QByteArrayLiteral("Bad Request");
-        case 404:
-            return QByteArrayLiteral("Not Found");
-        case 500:
-            return QByteArrayLiteral("Internal Server Error");
-        default:
-            return QByteArrayLiteral("Status");
-    }
-}
-}  // namespace
-
 void LocalHttpTestServer::installHttpResponder(const QByteArray& body, int statusCode, const QByteArray& contentType,
                                                int cacheMaxAge)
 {
-    QByteArray header = QStringLiteral(
-                            "HTTP/1.1 %1 %2\r\n"
-                            "Content-Type: %3\r\n"
-                            "Connection: close\r\n")
+    QByteArray header = QStringLiteral("HTTP/1.1 %1 %2\r\n"
+                                       "Content-Type: %3\r\n"
+                                       "Connection: close\r\n")
                             .arg(statusCode)
                             .arg(QString::fromLatin1(httpReasonPhrase(statusCode)))
                             .arg(QString::fromLatin1(contentType))
@@ -111,6 +100,7 @@ void LocalHttpTestServer::installRawResponder(const QByteArray& rawResponse)
                 state->request.append(socket->readAll());
                 if (!state->request.contains(QByteArrayLiteral("\r\n\r\n"))) {
                     if (state->request.size() > MAX_REQUEST_HEADER_SIZE) {
+                        state->responseSent = true;
                         socket->disconnectFromHost();
                     }
                     return;

--- a/test/UnitTestFramework/Fixtures/LocalHttpTestServer.cc
+++ b/test/UnitTestFramework/Fixtures/LocalHttpTestServer.cc
@@ -1,12 +1,37 @@
 #include "LocalHttpTestServer.h"
 
 #include <QtCore/QLoggingCategory>
+#include <QtCore/QSharedPointer>
 #include <QtNetwork/QAbstractSocket>
 #include <QtNetwork/QHostAddress>
 
 #include "UnitTest.h"
 
 namespace TestFixtures {
+
+namespace {
+constexpr qsizetype MAX_REQUEST_HEADER_SIZE = 64 * 1024;
+
+struct RawResponderState
+{
+    QByteArray request;
+    bool responseSent = false;
+};
+
+QByteArray httpReasonPhrase(int statusCode)
+{
+    switch (statusCode) {
+    case 200: return QByteArrayLiteral("OK");
+    case 204: return QByteArrayLiteral("No Content");
+    case 206: return QByteArrayLiteral("Partial Content");
+    case 304: return QByteArrayLiteral("Not Modified");
+    case 400: return QByteArrayLiteral("Bad Request");
+    case 404: return QByteArrayLiteral("Not Found");
+    case 500: return QByteArrayLiteral("Internal Server Error");
+    default: return QByteArrayLiteral("Status");
+    }
+}
+} // namespace
 
 LocalHttpTestServer::~LocalHttpTestServer()
 {
@@ -41,22 +66,6 @@ QString LocalHttpTestServer::url(const QString& path) const
     return QStringLiteral("http://%1:%2%3").arg(host).arg(port()).arg(path);
 }
 
-namespace {
-QByteArray httpReasonPhrase(int statusCode)
-{
-    switch (statusCode) {
-    case 200: return QByteArrayLiteral("OK");
-    case 204: return QByteArrayLiteral("No Content");
-    case 206: return QByteArrayLiteral("Partial Content");
-    case 304: return QByteArrayLiteral("Not Modified");
-    case 400: return QByteArrayLiteral("Bad Request");
-    case 404: return QByteArrayLiteral("Not Found");
-    case 500: return QByteArrayLiteral("Internal Server Error");
-    default: return QByteArrayLiteral("Status");
-    }
-}
-} // namespace
-
 void LocalHttpTestServer::installHttpResponder(const QByteArray& body, int statusCode, const QByteArray& contentType,
                                                int cacheMaxAge)
 {
@@ -80,16 +89,31 @@ void LocalHttpTestServer::installRawResponder(const QByteArray& rawResponse)
     (void) QObject::connect(&_server, &QTcpServer::newConnection, &_server, [this, rawResponse]() {
         while (_server.hasPendingConnections()) {
             QTcpSocket* const socket = _server.nextPendingConnection();
-            (void) QObject::connect(
-                socket, &QTcpSocket::readyRead, socket,
-                [socket, rawResponse]() {
-                    socket->readAll();
-                    socket->write(rawResponse);
-                    socket->flush();
-                    socket->disconnectFromHost();
-                },
-                Qt::SingleShotConnection);
             (void) QObject::connect(socket, &QTcpSocket::disconnected, socket, &QObject::deleteLater);
+
+            const auto state = QSharedPointer<RawResponderState>::create();
+            const auto sendResponseWhenRequestComplete = [socket, rawResponse, state]() {
+                if (state->responseSent) {
+                    return;
+                }
+
+                state->request.append(socket->readAll());
+                if (!state->request.contains(QByteArrayLiteral("\r\n\r\n"))) {
+                    if (state->request.size() > MAX_REQUEST_HEADER_SIZE) {
+                        state->responseSent = true;
+                        socket->disconnectFromHost();
+                    }
+                    return;
+                }
+
+                state->responseSent = true;
+                socket->write(rawResponse);
+                socket->flush();
+                socket->disconnectFromHost();
+            };
+
+            (void) QObject::connect(socket, &QTcpSocket::readyRead, socket, sendResponseWhenRequestComplete);
+            sendResponseWhenRequestComplete();
         }
     });
 }

--- a/test/UnitTestFramework/Fixtures/LocalHttpTestServer.cc
+++ b/test/UnitTestFramework/Fixtures/LocalHttpTestServer.cc
@@ -1,12 +1,23 @@
 #include "LocalHttpTestServer.h"
 
 #include <QtCore/QLoggingCategory>
+#include <QtCore/QSharedPointer>
 #include <QtNetwork/QAbstractSocket>
 #include <QtNetwork/QHostAddress>
 
 #include "UnitTest.h"
 
 namespace TestFixtures {
+
+namespace {
+constexpr qsizetype MAX_REQUEST_HEADER_SIZE = 64 * 1024;
+
+struct RawResponderState
+{
+    QByteArray request;
+    bool responseSent = false;
+};
+}  // namespace
 
 LocalHttpTestServer::~LocalHttpTestServer()
 {
@@ -91,18 +102,28 @@ void LocalHttpTestServer::installRawResponder(const QByteArray& rawResponse)
             QTcpSocket* const socket = _server.nextPendingConnection();
             (void) QObject::connect(socket, &QTcpSocket::disconnected, socket, &QObject::deleteLater);
 
-            const auto sendResponse = [socket, rawResponse]() {
-                socket->readAll();
+            const auto state = QSharedPointer<RawResponderState>::create();
+            const auto sendResponseWhenRequestComplete = [socket, rawResponse, state]() {
+                if (state->responseSent) {
+                    return;
+                }
+
+                state->request.append(socket->readAll());
+                if (!state->request.contains(QByteArrayLiteral("\r\n\r\n"))) {
+                    if (state->request.size() > MAX_REQUEST_HEADER_SIZE) {
+                        socket->disconnectFromHost();
+                    }
+                    return;
+                }
+
+                state->responseSent = true;
                 socket->write(rawResponse);
                 socket->flush();
                 socket->disconnectFromHost();
             };
 
-            if (socket->bytesAvailable() > 0) {
-                sendResponse();
-            } else {
-                (void) QObject::connect(socket, &QTcpSocket::readyRead, socket, sendResponse, Qt::SingleShotConnection);
-            }
+            (void) QObject::connect(socket, &QTcpSocket::readyRead, socket, sendResponseWhenRequestComplete);
+            sendResponseWhenRequestComplete();
         }
     });
 }

--- a/test/UnitTestFramework/Tests/CMakeLists.txt
+++ b/test/UnitTestFramework/Tests/CMakeLists.txt
@@ -2,6 +2,8 @@ target_sources(${CMAKE_PROJECT_NAME}
     PRIVATE
         ${CMAKE_CURRENT_SOURCE_DIR}/MultiSignalSpyTest.cc
         ${CMAKE_CURRENT_SOURCE_DIR}/MultiSignalSpyTest.h
+        ${CMAKE_CURRENT_SOURCE_DIR}/LocalHttpTestServerTest.cc
+        ${CMAKE_CURRENT_SOURCE_DIR}/LocalHttpTestServerTest.h
         ${CMAKE_CURRENT_SOURCE_DIR}/SignalEmitter.h
         ${CMAKE_CURRENT_SOURCE_DIR}/TestBaseClassesTest.cc
         ${CMAKE_CURRENT_SOURCE_DIR}/TestBaseClassesTest.h
@@ -16,6 +18,7 @@ target_sources(${CMAKE_PROJECT_NAME}
 target_include_directories(${CMAKE_PROJECT_NAME} PRIVATE ${CMAKE_CURRENT_SOURCE_DIR})
 
 add_qgc_test(MultiSignalSpyTest LABELS Unit)
+add_qgc_test(LocalHttpTestServerTest LABELS Unit)
 add_qgc_test(TestBaseClassesTest LABELS Unit)
 add_qgc_test(TestFixturesTest LABELS Unit)
 add_qgc_test(UnitTestAsyncHelpersTest LABELS Unit Utilities)

--- a/test/UnitTestFramework/Tests/CMakeLists.txt
+++ b/test/UnitTestFramework/Tests/CMakeLists.txt
@@ -1,9 +1,9 @@
 target_sources(${CMAKE_PROJECT_NAME}
     PRIVATE
-        ${CMAKE_CURRENT_SOURCE_DIR}/MultiSignalSpyTest.cc
-        ${CMAKE_CURRENT_SOURCE_DIR}/MultiSignalSpyTest.h
         ${CMAKE_CURRENT_SOURCE_DIR}/LocalHttpTestServerTest.cc
         ${CMAKE_CURRENT_SOURCE_DIR}/LocalHttpTestServerTest.h
+        ${CMAKE_CURRENT_SOURCE_DIR}/MultiSignalSpyTest.cc
+        ${CMAKE_CURRENT_SOURCE_DIR}/MultiSignalSpyTest.h
         ${CMAKE_CURRENT_SOURCE_DIR}/SignalEmitter.h
         ${CMAKE_CURRENT_SOURCE_DIR}/TestBaseClassesTest.cc
         ${CMAKE_CURRENT_SOURCE_DIR}/TestBaseClassesTest.h
@@ -17,8 +17,8 @@ target_sources(${CMAKE_PROJECT_NAME}
 
 target_include_directories(${CMAKE_PROJECT_NAME} PRIVATE ${CMAKE_CURRENT_SOURCE_DIR})
 
-add_qgc_test(MultiSignalSpyTest LABELS Unit)
 add_qgc_test(LocalHttpTestServerTest LABELS Unit)
+add_qgc_test(MultiSignalSpyTest LABELS Unit)
 add_qgc_test(TestBaseClassesTest LABELS Unit)
 add_qgc_test(TestFixturesTest LABELS Unit)
 add_qgc_test(UnitTestAsyncHelpersTest LABELS Unit Utilities)

--- a/test/UnitTestFramework/Tests/CMakeLists.txt
+++ b/test/UnitTestFramework/Tests/CMakeLists.txt
@@ -1,5 +1,7 @@
 target_sources(${CMAKE_PROJECT_NAME}
     PRIVATE
+        ${CMAKE_CURRENT_SOURCE_DIR}/LocalHttpTestServerTest.cc
+        ${CMAKE_CURRENT_SOURCE_DIR}/LocalHttpTestServerTest.h
         ${CMAKE_CURRENT_SOURCE_DIR}/MultiSignalSpyTest.cc
         ${CMAKE_CURRENT_SOURCE_DIR}/MultiSignalSpyTest.h
         ${CMAKE_CURRENT_SOURCE_DIR}/SignalEmitter.h
@@ -15,6 +17,7 @@ target_sources(${CMAKE_PROJECT_NAME}
 
 target_include_directories(${CMAKE_PROJECT_NAME} PRIVATE ${CMAKE_CURRENT_SOURCE_DIR})
 
+add_qgc_test(LocalHttpTestServerTest LABELS Unit)
 add_qgc_test(MultiSignalSpyTest LABELS Unit)
 add_qgc_test(TestBaseClassesTest LABELS Unit)
 add_qgc_test(TestFixturesTest LABELS Unit)

--- a/test/UnitTestFramework/Tests/LocalHttpTestServerTest.cc
+++ b/test/UnitTestFramework/Tests/LocalHttpTestServerTest.cc
@@ -1,0 +1,40 @@
+#include "LocalHttpTestServerTest.h"
+
+#include "Fixtures/LocalHttpTestServer.h"
+
+#include <QtCore/QUrl>
+#include <QtNetwork/QTcpSocket>
+#include <QtTest/QSignalSpy>
+
+void LocalHttpTestServerTest::_testFragmentedRequestHeader()
+{
+    TestFixtures::LocalHttpTestServer server;
+    QVERIFY(server.listen());
+    server.installHttpResponder(QByteArrayLiteral("ready"));
+
+    const QUrl serverUrl(server.url());
+    QVERIFY(serverUrl.isValid());
+
+    QTcpSocket client;
+    client.connectToHost(serverUrl.host(), static_cast<quint16>(serverUrl.port()));
+    QVERIFY(client.waitForConnected(TestTimeout::mediumMs()));
+
+    QSignalSpy readyReadSpy(&client, &QTcpSocket::readyRead);
+    const QByteArray firstRequestFragment =
+        QByteArrayLiteral("GET / HTTP/1.1\r\nHost: localhost\r\nConnection: close\r\n");
+    QCOMPARE(client.write(firstRequestFragment), firstRequestFragment.size());
+    QVERIFY(client.waitForBytesWritten(TestTimeout::mediumMs()));
+    QVERIFY(!readyReadSpy.wait(TestTimeout::shortMs()));
+    QCOMPARE(client.state(), QAbstractSocket::ConnectedState);
+
+    const QByteArray finalRequestFragment = QByteArrayLiteral("\r\n");
+    QCOMPARE(client.write(finalRequestFragment), finalRequestFragment.size());
+    QVERIFY(client.waitForBytesWritten(TestTimeout::mediumMs()));
+
+    QTRY_COMPARE_WITH_TIMEOUT(client.state(), QAbstractSocket::UnconnectedState, TestTimeout::mediumMs());
+    const QByteArray response = client.readAll();
+    QVERIFY(response.startsWith(QByteArrayLiteral("HTTP/1.1 200 OK\r\n")));
+    QVERIFY(response.endsWith(QByteArrayLiteral("\r\n\r\nready")));
+}
+
+UT_REGISTER_TEST(LocalHttpTestServerTest, TestLabel::Unit)

--- a/test/UnitTestFramework/Tests/LocalHttpTestServerTest.cc
+++ b/test/UnitTestFramework/Tests/LocalHttpTestServerTest.cc
@@ -1,0 +1,28 @@
+#include "LocalHttpTestServerTest.h"
+
+#include <QtNetwork/QHostAddress>
+#include <QtNetwork/QTcpSocket>
+
+#include "Fixtures/LocalHttpTestServer.h"
+
+void LocalHttpTestServerTest::_testEarlyRequest()
+{
+    TestFixtures::LocalHttpTestServer server;
+    QVERIFY(server.listen());
+    server.installHttpResponder(QByteArrayLiteral("ready"));
+
+    QTcpSocket client;
+    client.connectToHost(QHostAddress::LocalHost, server.port());
+    QVERIFY(client.waitForConnected(TestTimeout::mediumMs()));
+
+    const QByteArray request = QByteArrayLiteral("GET / HTTP/1.1\r\nHost: localhost\r\nConnection: close\r\n\r\n");
+    QCOMPARE(client.write(request), request.size());
+    QVERIFY(client.waitForBytesWritten(TestTimeout::mediumMs()));
+
+    QTRY_COMPARE_WITH_TIMEOUT(client.state(), QAbstractSocket::UnconnectedState, TestTimeout::mediumMs());
+    const QByteArray response = client.readAll();
+    QVERIFY(response.startsWith(QByteArrayLiteral("HTTP/1.1 200 OK\r\n")));
+    QVERIFY(response.endsWith(QByteArrayLiteral("\r\n\r\nready")));
+}
+
+UT_REGISTER_TEST(LocalHttpTestServerTest, TestLabel::Unit)

--- a/test/UnitTestFramework/Tests/LocalHttpTestServerTest.cc
+++ b/test/UnitTestFramework/Tests/LocalHttpTestServerTest.cc
@@ -2,6 +2,7 @@
 
 #include <QtNetwork/QHostAddress>
 #include <QtNetwork/QTcpSocket>
+#include <QtTest/QSignalSpy>
 
 #include "Fixtures/LocalHttpTestServer.h"
 
@@ -15,8 +16,16 @@ void LocalHttpTestServerTest::_testEarlyRequest()
     client.connectToHost(QHostAddress::LocalHost, server.port());
     QVERIFY(client.waitForConnected(TestTimeout::mediumMs()));
 
-    const QByteArray request = QByteArrayLiteral("GET / HTTP/1.1\r\nHost: localhost\r\nConnection: close\r\n\r\n");
-    QCOMPARE(client.write(request), request.size());
+    QSignalSpy readyReadSpy(&client, &QTcpSocket::readyRead);
+    const QByteArray firstRequestFragment =
+        QByteArrayLiteral("GET / HTTP/1.1\r\nHost: localhost\r\nConnection: close\r\n");
+    QCOMPARE(client.write(firstRequestFragment), firstRequestFragment.size());
+    QVERIFY(client.waitForBytesWritten(TestTimeout::mediumMs()));
+    QVERIFY(!readyReadSpy.wait(TestTimeout::shortMs()));
+    QCOMPARE(client.state(), QAbstractSocket::ConnectedState);
+
+    const QByteArray finalRequestFragment = QByteArrayLiteral("\r\n");
+    QCOMPARE(client.write(finalRequestFragment), finalRequestFragment.size());
     QVERIFY(client.waitForBytesWritten(TestTimeout::mediumMs()));
 
     QTRY_COMPARE_WITH_TIMEOUT(client.state(), QAbstractSocket::UnconnectedState, TestTimeout::mediumMs());

--- a/test/UnitTestFramework/Tests/LocalHttpTestServerTest.cc
+++ b/test/UnitTestFramework/Tests/LocalHttpTestServerTest.cc
@@ -1,19 +1,22 @@
 #include "LocalHttpTestServerTest.h"
 
-#include <QtNetwork/QHostAddress>
+#include "Fixtures/LocalHttpTestServer.h"
+
+#include <QtCore/QUrl>
 #include <QtNetwork/QTcpSocket>
 #include <QtTest/QSignalSpy>
 
-#include "Fixtures/LocalHttpTestServer.h"
-
-void LocalHttpTestServerTest::_testEarlyRequest()
+void LocalHttpTestServerTest::_testFragmentedRequestHeader()
 {
     TestFixtures::LocalHttpTestServer server;
     QVERIFY(server.listen());
     server.installHttpResponder(QByteArrayLiteral("ready"));
 
+    const QUrl serverUrl(server.url());
+    QVERIFY(serverUrl.isValid());
+
     QTcpSocket client;
-    client.connectToHost(QHostAddress::LocalHost, server.port());
+    client.connectToHost(serverUrl.host(), static_cast<quint16>(serverUrl.port()));
     QVERIFY(client.waitForConnected(TestTimeout::mediumMs()));
 
     QSignalSpy readyReadSpy(&client, &QTcpSocket::readyRead);

--- a/test/UnitTestFramework/Tests/LocalHttpTestServerTest.h
+++ b/test/UnitTestFramework/Tests/LocalHttpTestServerTest.h
@@ -1,0 +1,11 @@
+#pragma once
+
+#include "UnitTest.h"
+
+class LocalHttpTestServerTest : public UnitTest
+{
+    Q_OBJECT
+
+private slots:
+    void _testFragmentedRequestHeader();
+};

--- a/test/UnitTestFramework/Tests/LocalHttpTestServerTest.h
+++ b/test/UnitTestFramework/Tests/LocalHttpTestServerTest.h
@@ -1,0 +1,11 @@
+#pragma once
+
+#include "UnitTest.h"
+
+class LocalHttpTestServerTest : public UnitTest
+{
+    Q_OBJECT
+
+private slots:
+    void _testEarlyRequest();
+};

--- a/test/UnitTestFramework/Tests/LocalHttpTestServerTest.h
+++ b/test/UnitTestFramework/Tests/LocalHttpTestServerTest.h
@@ -7,5 +7,5 @@ class LocalHttpTestServerTest : public UnitTest
     Q_OBJECT
 
 private slots:
-    void _testEarlyRequest();
+    void _testFragmentedRequestHeader();
 };


### PR DESCRIPTION
## Description

`LocalHttpTestServer` could respond to the first `readyRead` notification even when it contained only part of an HTTP request header. That made camera-free transport tests timing-dependent.

The responder now accumulates a bounded request header across notifications and sends exactly one response after `\r\n\r\n` arrives. Oversized headers latch a terminal state before disconnecting. An immediate read after installing the socket callbacks remains as defensive handling for already-buffered data, but fragmented headers are the regression fixed here.

The regression test splits the header across two writes, verifies that the first fragment receives no response, and connects through `server.url()` so IPv4 and IPv6 fixture binds follow the same contract.

This changes test infrastructure only; application networking is unchanged.

## Type of Change

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update
- [ ] Refactoring
- [ ] CI/Build changes
- [x] Other: test fixture reliability

## Testing

- [x] Tested locally
- [x] Added/updated unit tests
- [ ] Tested with simulator (not applicable)
- [ ] Tested with hardware (not applicable)

Local checks on exact head `67caa46a0cdcb6f3cf4a9c232956dd9a074bdc45`:

- a standalone Qt 6.4.2 network probe verified no response to the incomplete fragment and a complete response after the terminator;
- `git diff --check`.

Exact-head QGC CI is complete: Linux x64/arm64 release builds, unit and integration tests, ASan/UBSan, coverage thresholds, Windows, macOS, iOS, Android, Docker, custom-plugin, and CodeQL checks passed. Linux evidence: [run 30596338957](https://github.com/mavlink/qgroundcontrol/actions/runs/30596338957).

### Platforms Tested

- [x] Linux
- [x] Windows (QGC exact-head CI build)
- [x] macOS (QGC exact-head CI build)
- [x] Android (QGC exact-head CI build)
- [x] iOS (QGC exact-head CI build)

### Flight Stacks Tested

Not applicable; this is a unit-test fixture.

## Screenshots

Not applicable; there is no UI change.

## Checklist

- [x] I have read the [Contribution Guidelines](CONTRIBUTING.md)
- [x] I have read the [Code of Conduct](CODE_OF_CONDUCT.md)
- [x] My code follows the project coding standards
- [x] I have added a regression test for the fixture behavior
- [x] New and existing unit and integration tests pass at the exact head in QGC CI

## Related Issues

#14730 carries this as a test-infrastructure prerequisite because its camera-free MJPEG delivery test uses `installRawResponder`.

---
By submitting this pull request, I confirm that my contribution is made under the terms of the project's dual license (Apache 2.0 and GPL v3).