### PR TITLE
fix(linux): remove system GLib preload and use bundled GIO modules in AppRun

### DIFF
--- a/deploy/linux/AppRun
+++ b/deploy/linux/AppRun
@@ -20,8 +20,6 @@ unset GIO_EXTRA_MODULES
 unset GIO_MODULE_DIR
 unset GIO_USE_VFS
 
-# Preload system GLib 2.76+ for TTS compatibility.
-# Set QGC_NO_SYSTEM_GLIB=1 to disable.
 _resolve_system_lib() {
     # Try hardcoded paths first (fast), then ldconfig fallback (NixOS, Guix, etc.)
     local _lib="$1"
@@ -45,42 +43,14 @@ _resolve_system_lib() {
     return 1
 }
 
-if [ -z "$QGC_NO_SYSTEM_GLIB" ]; then
-    SYSTEM_GLIB=""
-    SYSTEM_GIO=""
-    SYSTEM_LIBDIR=""
-    SYSTEM_GLIB=$(_resolve_system_lib "libglib-2.0.so.0") || true
-    if [ -n "$SYSTEM_GLIB" ]; then
-        SYSTEM_LIBDIR="$(dirname "$SYSTEM_GLIB")"
-        SYSTEM_GIO="${SYSTEM_LIBDIR}/libgio-2.0.so.0"
-        if [ ! -f "$SYSTEM_GIO" ]; then
-            SYSTEM_GIO=$(_resolve_system_lib "libgio-2.0.so.0") || true
-        fi
-    fi
-
-    if [ -n "$SYSTEM_GLIB" ]; then
-        if nm -D "$SYSTEM_GLIB" 2>/dev/null | grep -qm1 g_string_free_and_steal; then
-            GLIB_PRELOAD="${SYSTEM_GLIB}"
-            if [ -f "$SYSTEM_GIO" ]; then
-                GLIB_PRELOAD="${GLIB_PRELOAD}:${SYSTEM_GIO}"
-                SYSTEM_LIBMOUNT="${SYSTEM_LIBDIR}/libmount.so.1"
-                if [ -f "$SYSTEM_LIBMOUNT" ]; then
-                    GLIB_PRELOAD="${GLIB_PRELOAD}:${SYSTEM_LIBMOUNT}"
-                fi
-            fi
-            export LD_PRELOAD="${GLIB_PRELOAD}${LD_PRELOAD:+:$LD_PRELOAD}"
-        fi
-    fi
-
-    if [ -n "$SYSTEM_GIO" ] && nm -D "$SYSTEM_GIO" 2>/dev/null | grep -qm1 g_task_set_static_name; then
-        export GIO_MODULE_DIR="${APPDIR}/usr/lib/gio/modules"
-        export GIO_USE_VFS="local"
-    else
-        export GIO_EXTRA_MODULES="${APPDIR}/usr/lib/gio/modules"
-    fi
-else
-    export GIO_EXTRA_MODULES="${APPDIR}/usr/lib/gio/modules"
-fi
+# The bundled GLib/GIO stack always wins symbol resolution (LD_LIBRARY_PATH
+# puts the AppDir first), so load only the bundled GIO modules — they are
+# built against the bundled GIO and always ABI-consistent, regardless of the
+# system GLib version (works the same on Ubuntu 22.04/24.04/26.04, Arch, etc.).
+# The bundle ships glib-networking (TLS/proxy) and the dconf GSettings backend;
+# GIO_USE_VFS=local avoids any dependency on host gvfs.
+export GIO_MODULE_DIR="${APPDIR}/usr/lib/gio/modules"
+export GIO_USE_VFS="local"
 
 # Use system OpenGL to avoid conflicts with bundled libGLESv2
 SYSTEM_EGL=$(_resolve_system_lib "libEGL.so.1") || true


### PR DESCRIPTION
## Summary

Removes the system GLib/GIO `LD_PRELOAD` block from the AppImage AppRun and unconditionally uses the bundled GIO modules. The AppImage now runs on one self-consistent GLib stack (the bundled one) on every host.

Fixes #14110
Fixes #14615
Replaces #14616

## Root cause

AppRun preloaded system `libglib-2.0` + `libgio-2.0` (+ `libmount`) whenever the host GLib was ≥ 2.76 — but **not** `libgobject`, which still resolved from the bundled copy via `LD_LIBRARY_PATH`. That split the GLib family across two versions inside one process. On hosts newer than the bundled GLib 2.80 (Ubuntu 26.04 ships ~2.86), host desktop libraries (GTK3, atk-bridge, dconf) that enter the process via the qgtk3 platform theme hit the mismatched stack and segfault during startup in `atk_bridge_adaptor_init` → `g_bus_get_sync`. Reproduces 100% on an Ubuntu 26.04 ARM64 machine. Setting `QGC_NO_SYSTEM_GLIB=1` (which skips the preload) eliminates the crash — confirming the diagnosis.

The preload was added (#13757) only so TTS/libspeechd could find GLib 2.76+ symbols (`g_string_free_and_steal`) when the bundle carried an older GLib. Since CI moved to ubuntu-24.04 the bundle ships GLib 2.80, so the preload no longer serves any purpose — it only creates the mixed-ABI hazard.

## Why this works on Ubuntu 22.04 / 24.04 / 26.04

**22.04 (GLib 2.72):** the old preload gate (`nm -D | grep g_string_free_and_steal` against the system GLib) never triggered on 2.72, so shipping AppImages already run bundled-GLib-only on 22.04 today — this PR does not change the library-loading picture there at all. The only delta is GIO modules: 22.04 previously used `GIO_EXTRA_MODULES` (system + bundled); it now gets the same bundled-only `GIO_MODULE_DIR` + `GIO_USE_VFS=local` config that ≥ 2.76 hosts (24.04, Arch, CI) already ship with. The bundle carries glib-networking (TLS/proxy) and the dconf GSettings backend, so nothing needed at startup depends on host GIO modules. (Note: the aarch64 AppImage can't run on 22.04 regardless — bundled libmvec requires glibc ≥ 2.38 — a pre-existing constraint unrelated to this change.)

**24.04 (GLib 2.80):** host GLib == bundled GLib, so the old preload changed nothing version-wise, and the GIO branch already selected `GIO_MODULE_DIR` + `GIO_USE_VFS=local`. Behavior is unchanged; this is also the CI build/verify OS, so it's boot-tested on every run.

**26.04 (GLib ~2.86):** the crash case. With the preload gone, the entire GLib family resolves consistently from the bundle, removing the split-version failure mode. Verified: the fixed aarch64 AppImage boots cleanly and stays up 60s+ in an Ubuntu 26.04 environment with GTK3/at-spi/dconf/D-Bus active — the a11y bus and atspi registry activate through the exact frames that previously crashed.

Bundled GIO modules are correct by construction on all hosts: they are built against the bundled GIO, so they can never be ABI-inconsistent with it regardless of host GLib version. This also fixes the Arch GStreamer failure (#14615) and the `MOUNT_2_40`-class symbol errors (#14124), which share the same mixed-stack root cause.

## Relationship to #14616

Same core change (drop the system GLib preload) — credit to @jack-obrien for the diagnosis direction. This PR additionally:

- removes the stale `g_task_set_static_name` feature-probe for GIO module selection (a proxy for "host GIO ≥ bundled" that went stale when the bundle moved to 2.80) and makes bundled GIO modules unconditional, and
- removes the now-dead `QGC_NO_SYSTEM_GLIB` escape hatch.

## Testing

- Ubuntu 26.04 (GTK3 + at-spi + dconf + D-Bus + Xvfb, non-root): fixed AppImage boots and stays up 60s; a11y bus and atspi registry activate cleanly through the previously-crashing path.
- Ubuntu 26.04 ARM64 physical machine: current daily crashes 100% with the #14110 stack; `QGC_NO_SYSTEM_GLIB=1` on the daily eliminates the crash, matching this fix's mechanism.
- `bash -n` / shellcheck clean.
- Not empirically run on real 22.04 x86_64 hardware; the 22.04 argument above is based on the shipping AppRun's gate behavior on GLib 2.72.
