### PR TITLE
fix(Android): populate D2XX device list and disable duplicate USB permission request

### DIFF
--- a/android/src/org/mavlink/qgroundcontrol/QGCFtdiDriver.java
+++ b/android/src/org/mavlink/qgroundcontrol/QGCFtdiDriver.java
@@ -30,6 +30,8 @@ final class QGCFtdiDriver {
         sAppContext = context.getApplicationContext();
         try {
             sManager = D2xxManager.getInstance(sAppContext);
+            // QGC handles USB permission requests itself; don't let D2XX pop its own dialog.
+            sManager.setRequestPermission(false);
         } catch (D2xxManager.D2xxException e) {
             sManager = null;
             QGCLogger.w(TAG, "D2XX manager unavailable: " + e.getMessage());
@@ -60,8 +62,14 @@ final class QGCFtdiDriver {
         }
 
         try {
+            // openByUsbDevice() only finds devices registered in the manager's internal
+            // list, which is populated by createDeviceInfoList(). USB permission has already
+            // been granted by this point, so this cannot trigger a permission dialog.
+            final int deviceCount = sManager.createDeviceInfoList(sAppContext);
             final FT_Device d2xxDevice = sManager.openByUsbDevice(sAppContext, device);
             if (d2xxDevice == null || !d2xxDevice.isOpen()) {
+                QGCLogger.w(TAG, "D2XX openByUsbDevice returned no open device for " + device.getDeviceName()
+                        + " (enumerated FTDI device count: " + deviceCount + ")");
                 return null;
             }
             return new QGCFtdiDriver(d2xxDevice);


### PR DESCRIPTION
Fixes #14146
Fixes #11728

### Problem

Opening any FTDI serial device on Android failed with `Failed to open D2XX FTDI device`, exactly as reported in #14146.

### Root cause

`QGCFtdiDriver.open()` called `D2xxManager.openByUsbDevice()` without ever calling `createDeviceInfoList()`. `openByUsbDevice()` only opens devices registered in the manager's internal device list, which starts empty — so it silently returned null every time.

### Fix

- Call `createDeviceInfoList()` before `openByUsbDevice()` so the D2XX manager's internal list is populated.
- Call `setRequestPermission(false)` at init: QGC already handles USB permission requests itself, so D2XX must not pop its own duplicate permission dialog (which raced with QGC's).
- Log the enumerated device count when open fails, replacing a silent `return null`.

### Testing

Verified on a Samsung Galaxy Tab A9+ (Android 16) with real hardware: SiK Radio, direct connection to Cube Orange, and RTK GPS — all connect and work.

### Remaining item from #14146

#14146 also notes the port is displayed as `/dev/bus/usb/001/003` instead of a readable device name. That cosmetic fix requires touching cross-platform serial port naming (`SerialLink`/`LinkManager`), which is too risky this late in the release cycle. It is deferred to 5.2 and tracked in #14733.

