### PR TITLE
feat(Android): save application data to SD card root via all files access

### DIFF
--- a/android/src/org/mavlink/qgroundcontrol/QGCActivity.java
+++ b/android/src/org/mavlink/qgroundcontrol/QGCActivity.java
@@ -45,6 +45,9 @@ public class QGCActivity extends QtActivity {
 
     @Override
     protected void onPause() {
+        if (m_storagePermissionController != null) {
+            m_storagePermissionController.onPause();
+        }
         QGCSDLManager.onPause();
         super.onPause();
     }
@@ -53,6 +56,13 @@ public class QGCActivity extends QtActivity {
     protected void onResume() {
         super.onResume();
         QGCSDLManager.onResume();
+
+        if (m_storagePermissionController != null) {
+            final Boolean granted = m_storagePermissionController.onResume();
+            if (granted != null) {
+                nativeStoragePermissionsResult(granted);
+            }
+        }
     }
 
     @Override

--- a/android/src/org/mavlink/qgroundcontrol/QGCStoragePermissionController.java
+++ b/android/src/org/mavlink/qgroundcontrol/QGCStoragePermissionController.java
@@ -1,11 +1,15 @@
 package org.mavlink.qgroundcontrol;
 
 import android.content.Context;
+import android.content.Intent;
+import android.content.pm.PackageInfo;
 import android.content.pm.PackageManager;
+import android.net.Uri;
 import android.os.Build;
 import android.os.Environment;
 import android.os.storage.StorageManager;
 import android.os.storage.StorageVolume;
+import android.provider.Settings;
 
 import androidx.core.app.ActivityCompat;
 import androidx.core.content.ContextCompat;
@@ -13,6 +17,7 @@ import androidx.core.content.ContextCompat;
 import java.io.File;
 import java.lang.reflect.Method;
 import java.util.List;
+import java.util.concurrent.atomic.AtomicBoolean;
 
 final class QGCStoragePermissionController {
     private static final String TAG = QGCStoragePermissionController.class.getSimpleName();
@@ -20,6 +25,8 @@ final class QGCStoragePermissionController {
 
     private final QGCActivity _activity;
     private volatile boolean _storagePermissionRequestInFlight = false;
+    private final AtomicBoolean _allFilesAccessRequestInFlight = new AtomicBoolean(false);
+    private final AtomicBoolean _pausedSinceAllFilesAccessRequest = new AtomicBoolean(false);
 
     QGCStoragePermissionController(final QGCActivity activity) {
         _activity = activity;
@@ -27,6 +34,32 @@ final class QGCStoragePermissionController {
 
     static boolean requiresRuntimeStoragePermission(final int sdkInt) {
         return sdkInt < Build.VERSION_CODES.R;
+    }
+
+    // All-files access (MANAGE_EXTERNAL_STORAGE) applies only on API 30+ builds whose manifest declares it
+    private boolean usesAllFilesAccess() {
+        return Build.VERSION.SDK_INT >= Build.VERSION_CODES.R && manifestDeclaresManageStorage();
+    }
+
+    private static boolean isExternalStorageManager() {
+        return Build.VERSION.SDK_INT >= Build.VERSION_CODES.R && Environment.isExternalStorageManager();
+    }
+
+    private boolean manifestDeclaresManageStorage() {
+        try {
+            final PackageInfo info = _activity.getPackageManager()
+                .getPackageInfo(_activity.getPackageName(), PackageManager.GET_PERMISSIONS);
+            if (info.requestedPermissions != null) {
+                for (String permission : info.requestedPermissions) {
+                    if (android.Manifest.permission.MANAGE_EXTERNAL_STORAGE.equals(permission)) {
+                        return true;
+                    }
+                }
+            }
+        } catch (Exception e) {
+            QGCLogger.e(TAG, "Failed to read manifest permissions", e);
+        }
+        return false;
     }
 
     static boolean areAllPermissionsGranted(final int[] grantResults) {
@@ -52,6 +85,35 @@ final class QGCStoragePermissionController {
     }
 
     String getSDCardPath() {
+        if (usesAllFilesAccess()) {
+            if (!isExternalStorageManager()) {
+                QGCLogger.w(TAG, "All files access not granted");
+                return "";
+            }
+
+            final StorageManager storageManager = (StorageManager) _activity.getSystemService(Context.STORAGE_SERVICE);
+            if (storageManager == null) {
+                QGCLogger.w(TAG, "StorageManager unavailable");
+                return "";
+            }
+
+            for (StorageVolume vol : storageManager.getStorageVolumes()) {
+                if (!vol.isRemovable()) {
+                    continue;
+                }
+
+                final File dir = vol.getDirectory();
+                if (dir != null) {
+                    final String path = dir.getAbsolutePath();
+                    QGCLogger.i(TAG, "removable sd card root at " + path);
+                    return path;
+                }
+            }
+
+            QGCLogger.w(TAG, "No removable SD card found");
+            return "";
+        }
+
         if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.R) {
             File[] appExternalDirs = _activity.getExternalFilesDirs(null);
             if (appExternalDirs != null) {
@@ -106,7 +168,24 @@ final class QGCStoragePermissionController {
 
     boolean checkStoragePermissions() {
         if (!requiresRuntimeStoragePermission(Build.VERSION.SDK_INT)) {
-            return true;
+            if (!usesAllFilesAccess()) {
+                // Scoped storage: app-specific SD card directory needs no permission
+                return true;
+            }
+
+            if (isExternalStorageManager()) {
+                QGCLogger.i(TAG, "All files access already granted");
+                return true;
+            }
+
+            if (_allFilesAccessRequestInFlight.compareAndSet(false, true)) {
+                QGCLogger.i(TAG, "All files access not granted, opening system settings...");
+                _pausedSinceAllFilesAccessRequest.set(false);
+                _activity.runOnUiThread(this::_launchAllFilesAccessSettings);
+            } else {
+                QGCLogger.d(TAG, "All files access request already in flight");
+            }
+            return false;
         }
 
         String[] permissions = {
@@ -149,6 +228,50 @@ final class QGCStoragePermissionController {
             QGCLogger.i(TAG, "Storage permissions granted via runtime prompt");
         } else {
             QGCLogger.w(TAG, "Storage permissions denied via runtime prompt");
+        }
+
+        return granted;
+    }
+
+    private void _launchAllFilesAccessSettings() {
+        // Note: the settings screen opens in the Settings app's own task, so startActivityForResult
+        // would deliver an immediate RESULT_CANCELED. The outcome is instead evaluated in onResume().
+        try {
+            final Intent intent = new Intent(
+                Settings.ACTION_MANAGE_APP_ALL_FILES_ACCESS_PERMISSION,
+                Uri.fromParts("package", _activity.getPackageName(), null));
+            _activity.startActivity(intent);
+        } catch (Exception e) {
+            QGCLogger.w(TAG, "Failed to open app all files access settings, trying global settings", e);
+            try {
+                final Intent intent = new Intent(Settings.ACTION_MANAGE_ALL_FILES_ACCESS_PERMISSION);
+                _activity.startActivity(intent);
+            } catch (Exception e2) {
+                QGCLogger.e(TAG, "Failed to open all files access settings", e2);
+                _allFilesAccessRequestInFlight.set(false);
+            }
+        }
+    }
+
+    void onPause() {
+        if (_allFilesAccessRequestInFlight.get()) {
+            _pausedSinceAllFilesAccessRequest.set(true);
+        }
+    }
+
+    /// Returns the grant decision when returning from the all files access settings screen, null otherwise
+    Boolean onResume() {
+        // compareAndSet atomically consumes the in-flight request so the result is delivered exactly once
+        if (!_pausedSinceAllFilesAccessRequest.get() || !_allFilesAccessRequestInFlight.compareAndSet(true, false)) {
+            return null;
+        }
+
+        final boolean granted = isExternalStorageManager();
+
+        if (granted) {
+            QGCLogger.i(TAG, "All files access granted via system settings");
+        } else {
+            QGCLogger.w(TAG, "All files access denied via system settings");
         }
 
         return granted;

--- a/cmake/platform/Android.cmake
+++ b/cmake/platform/Android.cmake
@@ -154,12 +154,11 @@ qt_add_android_permission(${CMAKE_PROJECT_NAME}
         maxSdkVersion 33
 )
 
-option(QGC_ANDROID_ENABLE_MANAGE_EXTERNAL_STORAGE "Request MANAGE_EXTERNAL_STORAGE (not Play Store compliant by default)" OFF)
-if(QGC_ANDROID_ENABLE_MANAGE_EXTERNAL_STORAGE)
-    qt_add_android_permission(${CMAKE_PROJECT_NAME}
-        NAME android.permission.MANAGE_EXTERNAL_STORAGE
-    )
-endif()
+# All files access on Android 11+ so the save path can live at the SD card root.
+# Requires Play Store approval via a permissions declaration if distributed there.
+qt_add_android_permission(${CMAKE_PROJECT_NAME}
+    NAME android.permission.MANAGE_EXTERNAL_STORAGE
+)
 
 # Joystick
 qt_add_android_permission(${CMAKE_PROJECT_NAME}

--- a/src/Android/AndroidInterface.cc
+++ b/src/Android/AndroidInterface.cc
@@ -36,12 +36,31 @@ static void jniLogWarning(JNIEnv*, jobject, jstring message)
 
 static void jniStoragePermissionsResult(JNIEnv*, jobject, jboolean granted)
 {
-    if (!granted) {
-        qCWarning(AndroidInterfaceLog) << "Storage permission request denied";
+    if (!qgcApp()) {
         return;
     }
 
-    if (!qgcApp()) {
+    if (!granted) {
+        qCWarning(AndroidInterfaceLog) << "Storage permission request denied; disabling save to SD card";
+
+        (void)QMetaObject::invokeMethod(
+            qgcApp(),
+            []() {
+                SettingsManager* const settingsManager = SettingsManager::instance();
+                if (!settingsManager) {
+                    return;
+                }
+
+                AppSettings* const appSettings = settingsManager->appSettings();
+                if (!appSettings) {
+                    return;
+                }
+
+                if (!appSettings->androidDontSaveToSDCard()->rawValue().toBool()) {
+                    appSettings->androidDontSaveToSDCard()->setRawValue(true);
+                }
+            },
+            Qt::QueuedConnection);
         return;
     }
 

--- a/src/Settings/App.SettingsGroup.json
+++ b/src/Settings/App.SettingsGroup.json
@@ -245,7 +245,6 @@
             "longDesc": "If this option is enabled, application data will not be saved to the SD card.",
             "type": "bool",
             "default": false,
-            "qgcRebootRequired": true,
             "label": "Don't save to SD card, even if available",
             "keywords": "sd card,storage,android,save path"
         },

--- a/src/Settings/AppSettings.cc
+++ b/src/Settings/AppSettings.cc
@@ -3,6 +3,7 @@
 #include "QGCPalette.h"
 #include "AppMessages.h"
 #include "QGCApplication.h"
+#include "QGCLoggingCategory.h"
 #include "QGCMAVLink.h"
 #include "LinkManager.h"
 
@@ -13,6 +14,8 @@
 #include <QtCore/QStandardPaths>
 #include <QtCore/QDir>
 #include <QtCore/QSettings>
+
+QGC_LOGGING_CATEGORY(AppSettingsLog, "Settings.AppSettings")
 
 // Release languages are 90%+ complete
 QList<QLocale::Language> AppSettings::_rgReleaseLanguages = {
@@ -80,10 +83,10 @@ DECLARE_SETTINGGROUP(App, "")
         #ifdef Q_OS_ANDROID
             if (!androidDontSaveToSDCard()->rawValue().toBool()) {
                 rootDirPath = AndroidInterface::getSDCardPath();
-                qDebug() << "AndroidInterface::getSDCardPath();" << rootDirPath;
+                qCDebug(AppSettingsLog) << "AndroidInterface::getSDCardPath()" << rootDirPath;
                 if (rootDirPath.isEmpty() || !QDir(rootDirPath).exists()) {
                     rootDirPath.clear();
-                    qDebug() << "Save to SD card specified for application data. But no SD card present or permissions not granted. Using internal storage.";
+                    qCWarning(AppSettingsLog) << "Save to SD card specified for application data. But no SD card present or permissions not granted. Using internal storage.";
                 } else if (!QFileInfo(rootDirPath).isWritable()) {
                     rootDirPath.clear();
                     QGC::showAppMessage(AppSettings::tr("Save to SD card specified for application data. But SD card is write protected. Using internal storage."));
@@ -109,6 +112,25 @@ DECLARE_SETTINGGROUP(App, "")
 
     connect(savePathFact, &Fact::rawValueChanged, this, &AppSettings::savePathsChanged);
     connect(savePathFact, &Fact::rawValueChanged, this, &AppSettings::_checkSavePathDirectories);
+
+#ifdef Q_OS_ANDROID
+    // React to runtime toggling of the SD card setting
+    connect(androidDontSaveToSDCard(), &Fact::rawValueChanged, this, [this, appName](QVariant value) {
+        Fact* const fact = savePath();
+        if (value.toBool()) {
+            const QString internalBasePath = QStandardPaths::writableLocation(QStandardPaths::GenericDataLocation);
+            fact->setRawValue(QDir(internalBasePath).filePath(appName));
+        } else {
+            // If permission is already granted this returns the SD card root and we set the path here.
+            // If not, it returns empty and launches the system permission UI. The result comes back through
+            // jniStoragePermissionsResult, which sets the SD card save path (or reverts this setting on denial).
+            const QString sdRootPath = AndroidInterface::getSDCardPath();
+            if (!sdRootPath.isEmpty() && QDir(sdRootPath).exists() && QFileInfo(sdRootPath).isWritable()) {
+                fact->setRawValue(QDir(sdRootPath).filePath(appName));
+            }
+        }
+    });
+#endif
 
     _checkSavePathDirectories();
 

--- a/src/Utilities/Platform/Platform.cc
+++ b/src/Utilities/Platform/Platform.cc
@@ -10,10 +10,6 @@
 
 #include "QGCCommandLineParser.h"
 
-#ifdef Q_OS_ANDROID
-    #include "AndroidInterface.h"
-#endif
-
 #if !defined(Q_OS_IOS) && !defined(Q_OS_ANDROID)
     #include "RunGuard.h"
     #include "SignalHandler.h"
@@ -244,10 +240,6 @@ void Platform::setupPostApp()
 #if !defined(Q_OS_IOS) && !defined(Q_OS_ANDROID)
     SignalHandler* signalHandler = new SignalHandler(QCoreApplication::instance());
     (void) signalHandler->setupSignalHandlers();
-#endif
-
-#ifdef Q_OS_ANDROID
-    AndroidInterface::checkStoragePermissions();
 #endif
 }
 


### PR DESCRIPTION
Fixes #14736

## Summary

Places the top-level QGC save directory at the root of the removable SD card (`/storage/XXXX-XXXX/QGroundControl`) on Android 11+ using the MANAGE_EXTERNAL_STORAGE ("All files access") permission.

## Changes

- **Manifest/CMake**: `MANAGE_EXTERNAL_STORAGE` is now always declared (removed the `QGC_ANDROID_ENABLE_MANAGE_EXTERNAL_STORAGE` option). Note: this permission requires a Play Store permissions declaration if distributed there.
- **Java** (`QGCStoragePermissionController`): on API 30+, `getSDCardPath()` returns the removable volume root when All files access is granted. If not granted, `checkStoragePermissions()` launches the system All-files-access settings screen. The grant/deny outcome is detected in `onResume()` (the settings screen opens in the Settings app's own task, so `startActivityForResult` delivers an immediate `RESULT_CANCELED` and can't be used). Request/consume state uses `AtomicBoolean` compare-and-set so the native callback fires exactly once per request.
- **C++** (`AndroidInterface`): on grant, applies the SD-root save path (only when the current path is empty or the internal default). On denial, turns the "Don't save to SD card" setting on so the user isn't re-prompted.
- **Settings**: the SD card setting now takes effect at runtime (no app restart) — toggling it switches `savePath` between internal storage and the SD card root, prompting for permission if needed. Removed the stale `qgcRebootRequired` marking.
- Permission prompt only appears when the setting requests SD card storage (removed the unconditional boot-time check in `Platform::setupPostApp()`).

## Behavior

- Boot with SD saving enabled + permission not granted → system settings screen opens; deny → setting flips off and internal storage is used; grant → save path moves to the SD card root.
- Re-enabling the setting later re-prompts if needed.
- Pre-Android 11 devices keep the existing behavior (app-scoped SD directory / legacy runtime permissions).

Verified on device: grant, deny, and runtime re-enable flows.
