### PR TITLE
fix(LogManager): expand/collapse arrows too hard to tap on Android

### DIFF
--- a/src/LogManager/LoggingCategoriesDialog.qml
+++ b/src/LogManager/LoggingCategoriesDialog.qml
@@ -144,9 +144,7 @@ QGCPopupDialog {
                         visible: treeViewRowLayout.hasChildren
 
                         QGCMouseArea {
-                            anchors.fill: parent
-                            anchors.margins: -ScreenTools.defaultFontPixelWidth
-
+                            fillItem: parent
                             onClicked: treeView.toggleExpanded(treeViewRowLayout.row)
                         }
                     }


### PR DESCRIPTION
Fixes #14706

The expand/collapse arrows in the Logging Categories dialog were nearly impossible to tap on Android. The arrow's mouse area used a small fixed margin, which did not provide an adequate touch target on mobile.

Switch the `QGCMouseArea` to use `fillItem: parent`, which automatically enlarges the touch area to `ScreenTools.minTouchPixels` on mobile devices.
