### PR TITLE
fix(Audio): don't warn about unusable TTS engine during async backend init

### DIFF
--- a/src/Utilities/Audio/AudioOutput.cc
+++ b/src/Utilities/Audio/AudioOutput.cc
@@ -5,6 +5,7 @@
 
 #include <QtCore/QRegularExpression>
 #include <QtCore/QApplicationStatic>
+#include <QtCore/QTimer>
 #include <QtTextToSpeech/QTextToSpeech>
 #include <QtTextToSpeech/QVoice>
 
@@ -98,16 +99,22 @@ void AudioOutput::init(Fact* volumeFact, Fact* mutedFact)
         _applyEngineSettings();
     });
 
-    switch (_engine->state()) {
-    case QTextToSpeech::State::Ready:
+    if (_engine->state() == QTextToSpeech::State::Ready) {
         _finishInit();
-        break;
-    case QTextToSpeech::State::Error:
-        qCWarning(AudioOutputLog) << "No usable QTextToSpeech engine available.";
-        break;
-    default:
+    } else {
+        // Some backends (notably Android) start in Error state while binding to the system TTS
+        // service, then transition to Ready. Defer and only warn if the engine never becomes usable.
         qCDebug(AudioOutputLog) << "QTextToSpeech engine not ready; deferring init. State:" << _engine->state();
-        break;
+        if (!QGC::runningUnitTests()) {
+            // Skip under unit tests: the "none" backend never becomes Ready and the warning would trip the strict log check.
+            QTimer::singleShot(kEngineInitWarnTimeout, this, [this]() {
+                if (!_initialized) {
+                    qCWarning(AudioOutputLog) << "No usable QTextToSpeech engine available. Engine:" << _engine->engine()
+                                              << "State:" << _engine->state()
+                                              << "Reason:" << _engine->errorReason() << _engine->errorString();
+                }
+            });
+        }
     }
 }
 

--- a/src/Utilities/Audio/AudioOutput.h
+++ b/src/Utilities/Audio/AudioOutput.h
@@ -2,6 +2,8 @@
 
 #include <QtCore/QObject>
 
+#include <chrono>
+
 class QTextToSpeech;
 class Fact;
 class AudioOutputTest;
@@ -72,6 +74,9 @@ private:
     static const QHash<QString, QString> _textHash;
 
     static constexpr qsizetype kMaxTextQueueSize = 20;
+
+    /// Grace period for async TTS backends (e.g. Android service binding) to reach Ready before warning.
+    static constexpr std::chrono::seconds kEngineInitWarnTimeout{10};
 
     /// Fixes text messages for audio output.
     ///     @param string The text message to fix.


### PR DESCRIPTION
On Android, QGroundControl logged "No usable QTextToSpeech engine available" at startup even though text-to-speech worked fine.

The Android QTextToSpeech backend initializes asynchronously: it starts in `Error` state while binding to the system TTS service, then transitions to `Ready`. `AudioOutput::init()` treated the initial `Error` state as final and warned immediately.

Changes:
- Defer the warning: only emit it if the engine still hasn't become usable after a 10 second grace period (`kEngineInitWarnTimeout`). Init completion continues to be driven by the `stateChanged` → `Ready` handler as before.
- Include engine name, state, `errorReason()` and `errorString()` in the warning so genuine failures (missing plugin, service bind failure) are diagnosable from user logs.
- Skip the warning timer under unit tests, where the intentionally-unusable "none" backend would otherwise trip the strict log check.
