### PR TITLE
fix(build): register mock video encoder plugins in Android Debug builds

### DIFF
--- a/cmake/GStreamer/Orchestrator.cmake
+++ b/cmake/GStreamer/Orchestrator.cmake
@@ -155,6 +155,14 @@ gstreamer_current_platform_key(_qgc_gst_plat_key)
 gstreamer_plugins_for(PLATFORM "${_qgc_gst_plat_key}" OUT_VAR GSTREAMER_PLUGINS)
 unset(_qgc_gst_plat_key)
 
+# Android has no filesystem plugin scan — only statically registered plugins exist at
+# runtime. Add the encode-side plugins the Debug-only MockLink video stream server
+# needs (GSTREAMER_MOCK_SERVER_DEBUG_PLUGINS, PluginPolicy.cmake) in Debug builds.
+if(ANDROID AND CMAKE_BUILD_TYPE STREQUAL "Debug")
+    list(APPEND GSTREAMER_PLUGINS ${GSTREAMER_MOCK_SERVER_DEBUG_PLUGINS})
+    list(REMOVE_DUPLICATES GSTREAMER_PLUGINS)
+endif()
+
 if(ANDROID)
     set(GStreamer_Mobile_MODULE_NAME gstreamer_android)
     set(G_IO_MODULES openssl)

--- a/cmake/GStreamer/PluginPolicy.cmake
+++ b/cmake/GStreamer/PluginPolicy.cmake
@@ -34,6 +34,14 @@ set(GSTREAMER_XCFRAMEWORK_SKIP_PLUGINS
     x265
 )
 
+# Encode-side plugins needed only by the Debug-only MockLink test video stream
+# server (MockVideoStreamServer). Statically registered on Android Debug builds
+# only — desktop builds find them via the full SDK plugin scan, and release
+# builds must not ship them (APK size; x264/x265 are GPL).
+set(GSTREAMER_MOCK_SERVER_DEBUG_PLUGINS
+    mpegtsmux videotestsrc x264 x265
+)
+
 # Invariant: no plugin may be both runtime-required and xcframework-skipped.
 function(_gstreamer_assert_policy_consistent)
     foreach(_skip IN LISTS GSTREAMER_XCFRAMEWORK_SKIP_PLUGINS)


### PR DESCRIPTION
## Problem

Using a MockLink camera with any mock video stream type on Android logs:

```
Requested stream type is not available for this GStreamer build
```

Android builds have no filesystem plugin scan — only statically registered plugins exist at runtime. The static plugin list comes from the decode-only `gstreamer.plugins` set in `.github/build-config.json`, so the encode-side elements the Debug-only MockLink video stream server (`MockVideoStreamServer`) needs (`videotestsrc`, `x264enc`, `x265enc`, `mpegtsmux`) were never registered, and every mock stream type failed its `factoryExists()` check.

## Fix

- Add `GSTREAMER_MOCK_SERVER_DEBUG_PLUGINS` (`mpegtsmux videotestsrc x264 x265`) to `PluginPolicy.cmake`.
- Append it to `GSTREAMER_PLUGINS` in `Orchestrator.cmake` for **Android Debug builds only**.

Release builds are untouched — no APK size increase, and the GPL-licensed x264/x265 encoders are never shipped in release artifacts (CI-published Android APKs are Release builds). Desktop builds are unaffected: they find these plugins via the normal SDK plugin scan. The static libs (`libgstx264.a`, etc.) and pkg-config files are all present in the bundled Android GStreamer 1.28.4 SDK.

Verified on device: all MockLink stream types (RTP/UDP H.264/H.265, MPEG-TS, RTSP) now work on an Android Debug build.
