### PR TITLE
fix: Android serial crash on close and human-readable port names

### DIFF
--- a/src/Android/qtandroidserialport/qserialport_android.cpp
+++ b/src/Android/qtandroidserialport/qserialport_android.cpp
@@ -78,6 +78,16 @@ void QSerialPortPrivate::close()
 
     _stopAsyncRead();
 
+    {
+        // Drop any undelivered data so a queued drain or later re-open can't
+        // deliver stale bytes into cleared QIODevice buffers.
+        QMutexLocker locker(&_readMutex);
+        _pendingData.clear();
+        _pendingDataOffset = 0;
+        _readyReadPending.store(false);
+        _bufferBytesEstimate.store(0, std::memory_order_relaxed);
+    }
+
     if (_deviceId != INVALID_DEVICE_ID) {
         if (!AndroidSerial::close(_deviceId)) {
             qCWarning(AndroidSerialPortLog) << "Failed to close device with ID" << _deviceId;
@@ -243,7 +253,10 @@ void QSerialPortPrivate::_scheduleReadyRead()
         QMetaObject::invokeMethod(
             q,
             [this, guard]() {
-                if (!guard) {
+                if (!guard || !guard->isOpen()) {
+                    // Device closed before the queued drain ran. close() clears the
+                    // QIODevice read buffers, so draining into them would assert.
+                    _readyReadPending.store(false);
                     return;
                 }
 

--- a/src/Comms/SerialLink.cc
+++ b/src/Comms/SerialLink.cc
@@ -45,8 +45,12 @@ void SerialConfiguration::setPortName(const QString &name)
         emit portNameChanged();
     }
 
+    // Only update the display name if the port is currently available. Otherwise keep
+    // the existing (e.g. persisted) display name rather than clearing it.
     const QString portDisplayName = cleanPortDisplayName(portName);
-    setPortDisplayName(portDisplayName);
+    if (!portDisplayName.isEmpty()) {
+        setPortDisplayName(portDisplayName);
+    }
 }
 
 void SerialConfiguration::copyFrom(const LinkConfiguration *source)
@@ -75,8 +79,10 @@ void SerialConfiguration::loadSettings(QSettings &settings, const QString &root)
     setFlowControl(static_cast<QSerialPort::FlowControl>(settings.value("flowControl", _flowControl).toInt()));
     setStopBits(static_cast<QSerialPort::StopBits>(settings.value("stopBits", _stopBits).toInt()));
     setParity(static_cast<QSerialPort::Parity>(settings.value("parity", _parity).toInt()));
-    setPortName(settings.value("portName", _portName).toString());
+    // Load the saved display name first as a fallback; setPortName() recomputes a
+    // fresh display name which takes precedence when the device is present.
     setPortDisplayName(settings.value("portDisplayName", _portDisplayName).toString());
+    setPortName(settings.value("portName", _portName).toString());
     setdtrForceLow(settings.value("dtrForceLow", _dtrForceLow).toBool());
 
     settings.endGroup();
@@ -167,6 +173,19 @@ QString SerialConfiguration::cleanPortDisplayName(const QString &name)
     const QList<QSerialPortInfo> availablePorts = QSerialPortInfo::availablePorts();
     for (const QSerialPortInfo &portInfo : availablePorts) {
         if (portInfo.systemLocation() == name) {
+#ifdef Q_OS_ANDROID
+            // Android port names (bus/usb/001/003) aren't human-readable. Prefer the USB
+            // description/manufacturer, with the port name appended to keep entries unique.
+            QString displayName;
+            if (!portInfo.description().isEmpty()) {
+                displayName = portInfo.description();
+            } else if (!portInfo.manufacturer().isEmpty()) {
+                displayName = portInfo.manufacturer();
+            }
+            if (!displayName.isEmpty()) {
+                return QStringLiteral("%1 (%2)").arg(displayName, portInfo.portName());
+            }
+#endif
             return portInfo.portName();
         }
     }
@@ -382,9 +401,12 @@ void SerialWorker::_checkPortAvailability()
     }
 
     bool portExists = false;
+    const QString configuredPort = _serialConfig->portName();
     const auto availablePorts = QSerialPortInfo::availablePorts();
     for (const QSerialPortInfo &info : availablePorts) {
-        if (info.portName() == _serialConfig->portDisplayName()) {
+        // Compare against the real port identity, not the human-readable display
+        // name, which may be a USB description string (e.g. on Android).
+        if ((info.systemLocation() == configuredPort) || (info.portName() == configuredPort)) {
             portExists = true;
             break;
         }


### PR DESCRIPTION
Fixes #14733

## Android serial fixes

Two related fixes for Android serial connections (tested on device with Cube Orange):

### Crash fix (qserialport_android.cpp)
- Clear pending read data and scheduling state when the port closes
- Guard the queued readyRead drain against running after close

Prevents a queued drain from delivering stale bytes into cleared QIODevice buffers, which could assert or deliver data from a previous session on re-open.

### Port naming / availability (SerialLink.cc)
- Android serial port lists now show the USB description/manufacturer with the port name appended (e.g. "CubeOrange (bus/usb/001/003)") instead of the raw device path. The port name suffix keeps composite devices (which expose multiple ports with the same description) distinguishable.
- `_checkPortAvailability()` now compares the real port identity (systemLocation/portName) instead of the display name. Previously the display name change caused the availability check to always fail, closing the port every timer tick (connect/disconnect loop).
- Persisted display names are refreshed from the live device when available, so stale bus paths from previous sessions don't show in the UI.
