### PR TITLE
docs(PlanView): update Plan View docs for the plan tree UI

### DIFF
--- a/docs/en/qgc-dev-guide/views/plan.md
+++ b/docs/en/qgc-dev-guide/views/plan.md
@@ -2,4 +2,5 @@
 
 - Top level QML code is in [PlanView.qml](https://github.com/mavlink/qgroundcontrol/blob/master/src/PlanView/PlanView.qml)
 - Main visual UI is a FlightMap control
+- The right panel is a unified plan tree: [PlanTreeView.qml](https://github.com/mavlink/qgroundcontrol/blob/master/src/PlanView/PlanTreeView.qml)
 - QML communicates with MissionController (C++) which provides the view with the mission item data and methods

--- a/docs/en/qgc-user-guide/plan_view/plan_geofence.md
+++ b/docs/en/qgc-user-guide/plan_view/plan_geofence.md
@@ -3,21 +3,18 @@
 GeoFences allow you to create virtual regions within which the vehicle can fly, or in which it is _not allowed_ to fly.
 You can also configure the action taken if you fly outside permitted areas.
 
-
 ::: info
-**ArduPilot users:** GeoFence support is only supported by Rover 3.6 and Copter 3.7 or higher. It also requires usage of a Daily build or Stable 3.6 (once available).
-_QGroundControl_ will not display the GeoFence options if they are not supported by the connected vehicle.
+_QGroundControl_ will not display the GeoFence options if they are not supported by the connected vehicle firmware.
 :::
 
-## Create a Geofence
+## Create a GeoFence
 
 To create a GeoFence:
 
 1. Navigate to the Plan View
-1. Select the _Geofence_ radio button above the Mission Command List
+1. Select the **GeoFence** layer using the [Layer Switcher](plan_view.md#layer_switcher) in the top-right area of the map (or expand the **GeoFence** section in the [Plan Editor Panel](plan_view.md#plan_editor_panel))
 
-
-1. Insert a circular or polygon region by pressing the **Circular Fence** or **Polygon Fence** button, respectively.
+1. Insert a circular or polygon region by pressing the **Circular Fence** or **Polygon Fence** button in the GeoFence section.
    A new region will be added to the map and to the associated list of fences below the buttons.
 
 :::tip
@@ -39,17 +36,15 @@ You can create multiple regions by pressing the buttons multiple times, allowing
 1. By default new regions are created as _inclusion_ zones (vehicles must stay within the region).
    Change them to exclusion zones (where the vehicle can't travel) by unchecking the associated _Inclusion_ checkbox in the fence panel.
 
+Depending on the firmware, the GeoFence section may also show fence parameters (e.g. breach action) and a **Breach Return Point** that the vehicle will fly to if it breaches the fence.
+
 ## Edit/Delete a GeoFence
 
-You can select a geofence region to edit by selecting its _Edit_ radio button in the GeoFence panel.
+You can select a GeoFence region to edit by selecting its _Edit_ radio button in the GeoFence section.
 You can then edit the region on the map as described in the previous section.
 
 Regions can be deleted by pressing the associated **Del** button.
 
 ## Upload a GeoFence
 
-The GeoFence is uploaded in the same way as a mission, using **File** in the [Plan tools](../plan_view/plan_view.md).
-
-## Remaining tools
-
-The rest of the tools work exactly as they do while editing a Mission.
+The GeoFence is uploaded along with the rest of the plan using the **Upload** button in the [Plan Toolbar](plan_view.md#file).

--- a/docs/en/qgc-user-guide/plan_view/plan_rally_points.md
+++ b/docs/en/qgc-user-guide/plan_view/plan_rally_points.md
@@ -4,30 +4,22 @@ Rally Points are alternative landing or loiter locations.
 They are typically used to provide a safer or more convenient (e.g. closer) destination than the home position in Return/RTL mode.
 
 ::: info
-Rally Points are only supported by ArduPilot on Rover 3.6 and Copter 3.7 (or higher).
-PX4 support is planned in PX4 v1.10 timeframes.
-It also requires usage of a Daily build or Stable 3.6 (once available).
-_QGroundControl_ will not display the Rally Point options if they are not supported by the connected vehicle.
+_QGroundControl_ will not display the Rally Point options if they are not supported by the connected vehicle firmware.
 :::
-
 
 ## Rally Point Usage
 
 To create Rally Points:
 
 1. Navigate to the Plan View
-1. Select the _Rally_ radio button above the Mission Command List
+1. Select the **Rally Points** layer using the [Layer Switcher](plan_view.md#layer_switcher) in the top-right area of the map (or expand the **Rally Points** section in the [Plan Editor Panel](plan_view.md#plan_editor_panel))
 1. Click the map wherever you want rally points.
    - An **R** marker is added for each
-   - the currently active marker has a different colour (green) and can be edited using the _Rally Point_ panel.
-1. Make any rally point active by selecting it on the map:
-   - Move the active rally point by either dragging it on the map or editing the position in the panel.
-   - Delete the active rally point by selecting the menu option on the _Rally Point_ panel
+   - The currently active marker has a different color (green) and its editor is expanded in the _Rally Points_ section.
+1. Make any rally point active by selecting it on the map or in the _Rally Points_ section:
+   - Move the active rally point by either dragging it on the map or editing the position fields in its editor.
+   - Delete a rally point by pressing the **X** delete button on its editor.
 
 ## Upload Rally Points
 
-Rally points are uploaded in the same way as a mission, using **File** in the [Plan tools](../plan_view/plan_view.md).
-
-## Remaining tools
-
-The rest of the tools work exactly as they do while editing a Mission.
+Rally points are uploaded along with the rest of the plan using the **Upload** button in the [Plan Toolbar](plan_view.md#file).

--- a/docs/en/qgc-user-guide/plan_view/plan_view.md
+++ b/docs/en/qgc-user-guide/plan_view/plan_view.md
@@ -20,7 +20,7 @@ The main elements of the UI are:
   The **Save** and **Upload** buttons are highlighted when there are unsaved or un-uploaded changes.
 - **[Plan Tools](#plan_tools):** A vertical tool strip on the left side of the map used to add mission items (Takeoff, Waypoint, Pattern, ROI, Return/Land) and toggle the stats panel.
 - **[Plan Editor Panel](#plan_editor_panel):** A collapsible tree view on the right side containing the plan file info, mission items, GeoFence, and rally point editors.
-- **Layer Switcher:** Buttons in the top-right area for switching between **Mission**, **Geo-Fence**, and **Rally Point** editing layers.
+- **Layer Switcher:** Buttons in the top-right area for switching between the **Mission**, **GeoFence**, and **Rally Points** editing layers.
 - **Mission Stats / Terrain Panel:** A panel at the bottom of the map that can toggle between a terrain altitude profile chart (height AMSL vs. distance) and mission statistics (selected waypoint info, total distance, max telemetry distance, estimated flight time, and battery info).
 
 ## Planning a Mission {#plan_mission}
@@ -100,12 +100,15 @@ Before you fly a mission you must upload it to the vehicle.
 
 The Plan Editor Panel is a collapsible tree view on the right side of the view.
 The panel can be collapsed or expanded using the toggle button on its left edge.
-It is organized into the following collapsible sections: **Plan Info**, **Defaults**, **Mission**, **GeoFence**, **Rally Points**, and **Transform**.
+It is organized into the following collapsible sections: **Plan Info**, **Defaults**, **Mission Items**, **GeoFence**, **Rally Points**, and **Transform**.
+
+The **Mission Items**, **GeoFence**, and **Rally Points** sections correspond to the map editing layers and are mutually exclusive — expanding one collapses the others and makes it the active editing layer.
 
 ### Layer Switcher {#layer_switcher}
 
-Buttons in the top-right area of the map allow switching between the **Mission**, **Geo-Fence**, and **Rally Point** editing layers.
-The active layer button is always visible; the other layer buttons slide in briefly when toggled and auto-hide after a few seconds.
+Buttons in the top-right area of the map allow switching between the **Mission**, **GeoFence**, and **Rally Points** editing layers.
+Only the active layer's button is shown; click it to expand the other layer choices, which auto-collapse after a few seconds.
+Selecting a layer also expands the corresponding section in the [Plan Editor Panel](#plan_editor_panel).
 
 ### Plan Info {#plan_info}
 
@@ -115,7 +118,7 @@ The Plan Info section contains general plan-level settings:
 - **Vehicle Info** — Firmware and vehicle type selectors. When connected to a vehicle these are determined automatically; when planning offline you must set them before adding any mission items so that the correct mission commands are available.
 - **Expected Home Position** — The altitude (AMSL) for the planned home position is determined automatically from terrain data. A **Move To Map Center** button repositions the home marker to the center of the map. This is only the _planned_ home position for estimating mission times and drawing waypoint lines — the actual home position is set by the vehicle when it arms.
 
-### Defaults {#mission_settings}
+### Defaults {#defaults}
 
 The Defaults section sets plan-wide values that apply to new mission items:
 
@@ -126,7 +129,7 @@ The Defaults section sets plan-wide values that apply to new mission items:
 
 ### Mission Items {#mission_items}
 
-The Mission section lists all mission items (waypoints, commands, patterns, etc.) in order.
+The Mission Items section lists all mission items (waypoints, commands, patterns, etc.) in order.
 Each item can be expanded to edit its parameters.
 
 - Click an item to select it on the map and expand its editor.


### PR DESCRIPTION
Updates the Plan View documentation to match the new plan tree UI:

- **plan_view.md** — Fix section/layer naming to match the actual UI ("Mission Items", "GeoFence", "Rally Points"), rewrite the Layer Switcher description (active button expands choices, auto-collapse), and document that the three layer sections in the editor panel are mutually exclusive and drive the active editing layer. Renamed the Defaults anchor from `#mission_settings` to `#defaults`.
- **plan_geofence.md** — Replace pre-tree "radio button above the Mission Command List" instructions with the Layer Switcher / Plan Editor Panel, update upload instructions to the toolbar **Upload** button, add breach return point note, and drop the obsolete ArduPilot 3.6/3.7 version caveat.
- **plan_rally_points.md** — Same layer switcher/tree updates, delete via the X button on the item editor, toolbar upload, and removal of the obsolete "PX4 support planned in v1.10" note.
- Removed the stale "Remaining tools" sections — the plan tool strip is now hidden outside the Mission layer.
- **qgc-dev-guide/views/plan.md** — Add a pointer to PlanTreeView.qml.
