### PR TITLE
fix(PlanView): make new mission items draggable

### DIFF
--- a/src/PlanView/MissionItemMapVisualBase.qml
+++ b/src/PlanView/MissionItemMapVisualBase.qml
@@ -48,7 +48,7 @@ Item {
     }
 
     function updateDragArea() {
-        if (_missionItem.isCurrentItem && map.planView && _missionItem.specifiesCoordinate) {
+        if (_missionItem.isCurrentItem && map.planView && _missionItem.specifiesCoordinate && itemVisualLoader.item) {
             showDragArea()
         } else {
             hideDragArea()
@@ -108,6 +108,7 @@ Item {
             if (item) {
                 item.parent = map
                 map.addMapItem(item)
+                updateDragArea()
             }
         }
     }


### PR DESCRIPTION
Replaces #14670, taking one of its three fixes.

## Description

### fix(PlanView): make new mission items draggable
Newly inserted simple mission items (e.g. waypoints created with the plus button on mission legs) could become current before their asynchronous map indicator finished loading, leaving their drag area unusable until the item was selected again. `updateDragArea()` now waits for the indicator to load and is re-run once the indicator loader completes, making new items immediately draggable.

## Why the other two fixes from #14670 were not taken

### MapLineArrow (hide direction arrows on short legs)
* It causes unit test failures in CI (`PlanViewUITest`, `PlanViewLayerUITest`, `AppCloseWarningUITest`). The `required property FlightMap mapControl` on the `MapLineArrow` delegate disables implicit model context injection, producing `ReferenceError: object is not defined` in the `MapItemView` delegates in PlanView.qml.
* The `Connections` on `centerChanged`/`zoomLevelChanged` re-runs JS (`fromCoordinate` × 2) per arrow on **every pan/zoom frame**. Arrow counts are small, so probably fine, but it's new per-frame work in both PlanView *and* FlyView (via `PlanMapItems`), so a regression here touches the in-flight map, not just planning.

### Current-item z-order bump (draw current mission item on top)
The `zOrderMapItems + 1` lift collides with the established overlay stacking scheme: `MissionItemIndicatorDrag`, the takeoff click-capture overlay, landing pattern visuals, and polygon/polyline edit handles all rely on `zOrderMapItems + 1..3` being strictly above every item indicator. Raising the current item's indicator to `+ 1` ties it with its own drag control and those overlays, making click/drag precedence insertion-order dependent.

## Type of Change
- [X] Bug fix (non-breaking change that fixes an issue)

## Testing
- [X] Tested locally
- [X] PlanViewUITest, PlanViewLayerUITest, AppCloseWarningUITest pass locally

### Platforms Tested
- [X] macOS

---
By submitting this pull request, I confirm that my contribution is made under the terms of the project's dual license (Apache 2.0 and GPL v3).
