### PR TITLE
fix(VehicleSetup): follow-up fixes for summary card grid layout

### DIFF
--- a/src/AutoPilotPlugins/APM/APMPowerComponentSummary.qml
+++ b/src/AutoPilotPlugins/APM/APMPowerComponentSummary.qml
@@ -28,7 +28,7 @@ Item {
             model: battParams.getBatteryCount()
 
             delegate: ColumnLayout {
-                width: parent.width
+                Layout.fillWidth: true
                 required property int index
                 spacing: 0
                 visible: _monitorEnabled

--- a/src/AutoPilotPlugins/PX4/PowerComponentSummary.qml
+++ b/src/AutoPilotPlugins/PX4/PowerComponentSummary.qml
@@ -33,7 +33,6 @@ Item {
 
             Loader {
                 Layout.fillWidth: true
-                width: parent.width
                 sourceComponent: batterySummaryComponent
 
                 property int    batteryIndex:       index + 1

--- a/src/AutoPilotPlugins/PX4/SafetyComponentSummary.qml
+++ b/src/AutoPilotPlugins/PX4/SafetyComponentSummary.qml
@@ -13,21 +13,24 @@ Item {
 
     FactPanelController { id: controller; }
 
-    property Fact   returnAltFact:      controller.getParameterFact(-1, "RTL_RETURN_ALT")
+    property Fact   _returnAltFact:     controller.getParameterFact(-1, "RTL_RETURN_ALT")
     property Fact   _descendAltFact:    controller.getParameterFact(-1, "RTL_DESCEND_ALT")
-    property Fact   landDelayFact:      controller.getParameterFact(-1, "RTL_LAND_DELAY")
-    property Fact   commRCLossFact:     controller.getParameterFact(-1, "COM_RC_LOSS_T")
-    property Fact   lowBattAction:      controller.getParameterFact(-1, "COM_LOW_BAT_ACT")
-    property Fact   rcLossAction:       controller.getParameterFact(-1, "NAV_RCL_ACT")
-    property Fact   dataLossAction:     controller.getParameterFact(-1, "NAV_DLL_ACT")
+    property Fact   _commRCLossFact:    controller.getParameterFact(-1, "COM_RC_LOSS_T")
+    property Fact   _lowBattAction:     controller.getParameterFact(-1, "COM_LOW_BAT_ACT")
+    property Fact   _rcLossAction:      controller.getParameterFact(-1, "NAV_RCL_ACT")
+    property Fact   _dataLossAction:    controller.getParameterFact(-1, "NAV_DLL_ACT")
     property Fact   _rtlLandDelayFact:  controller.getParameterFact(-1, "RTL_LAND_DELAY")
     property int    _rtlLandDelayValue: _rtlLandDelayFact ? _rtlLandDelayFact.value : 0
-    property var    _lowBattParts:      lowBattAction ? lowBattAction.enumStringValue.split(",") : []
+    property var    _lowBattParts:      _lowBattAction ? _lowBattAction.enumStringValue.split(",") : []
 
     function _cleanBehavior(str) {
-        if (!str) return ""
-        var cleaned = str.replace(/at\s+(critical|emergency)\s+level/gi, "").trim()
-        if (cleaned === "") return str.trim()
+        if (!str) {
+            return ""
+        }
+        let cleaned = str.replace(/at\s+(critical|emergency)\s+level/gi, "").trim()
+        if (cleaned === "") {
+            return str.trim()
+        }
         return cleaned.charAt(0).toUpperCase() + cleaned.slice(1)
     }
 
@@ -38,7 +41,7 @@ Item {
 
         VehicleSummaryRow {
             labelText: qsTr("Low Battery Failsafe")
-            valueText: _lowBattParts.length > 1 ? "" : (lowBattAction ? lowBattAction.enumStringValue : "")
+            valueText: _lowBattParts.length > 1 ? "" : (_lowBattAction ? _lowBattAction.enumStringValue : "")
         }
 
         VehicleSummaryRow {
@@ -55,22 +58,22 @@ Item {
 
         VehicleSummaryRow {
             labelText: qsTr("RC/Joystick Loss Failsafe")
-            valueText: rcLossAction ? rcLossAction.enumStringValue : ""
+            valueText: _rcLossAction ? _rcLossAction.enumStringValue : ""
         }
 
         VehicleSummaryRow {
             labelText: qsTr("RC/Joystick Loss Timeout")
-            valueText: commRCLossFact ? commRCLossFact.valueString + " " + commRCLossFact.units : ""
+            valueText: _commRCLossFact ? _commRCLossFact.valueString + " " + _commRCLossFact.units : ""
         }
 
         VehicleSummaryRow {
             labelText: qsTr("Data Link Loss Failsafe")
-            valueText: dataLossAction ? dataLossAction.enumStringValue : ""
+            valueText: _dataLossAction ? _dataLossAction.enumStringValue : ""
         }
 
         VehicleSummaryRow {
             labelText: qsTr("RTL Climb To")
-            valueText: returnAltFact ? returnAltFact.valueString + " " + returnAltFact.units : ""
+            valueText: _returnAltFact ? _returnAltFact.valueString + " " + _returnAltFact.units : ""
         }
 
         VehicleSummaryRow {
@@ -85,13 +88,13 @@ Item {
 
         VehicleSummaryRow {
             labelText: qsTr("Loiter Alt")
-            valueText: _descendAltFact.valueString + " " + _descendAltFact.units
-            visible:    _rtlLandDelayValue !== 0
+            valueText: _descendAltFact ? _descendAltFact.valueString + " " + _descendAltFact.units : ""
+            visible:    _descendAltFact && _rtlLandDelayValue !== 0
         }
 
         VehicleSummaryRow {
             labelText: qsTr("Land Delay")
-            valueText: _rtlLandDelayValue + " " + _rtlLandDelayFact.units
+            valueText: _rtlLandDelayFact ? _rtlLandDelayValue + " " + _rtlLandDelayFact.units : ""
             visible:    _rtlLandDelayValue > 0
         }
     }

--- a/src/QmlControls/VehicleSummaryRow.qml
+++ b/src/QmlControls/VehicleSummaryRow.qml
@@ -15,8 +15,6 @@ ColumnLayout {
     property string valueColor: ""
     property bool showDivider: true
 
-    QGCPalette { id: qgcPal; colorGroupEnabled: true }
-
     RowLayout {
         id: rowLayout
         Layout.fillWidth: true
@@ -38,15 +36,15 @@ ColumnLayout {
             Layout.alignment: Qt.AlignRight | Qt.AlignVCenter
             horizontalAlignment: Text.AlignRight
             text: root.valueText
-            color: root.valueColor !== "" ? root.valueColor : qgcPal.text
+            color: root.valueColor !== "" ? root.valueColor : QGroundControl.globalPalette.text
             wrapMode: Text.WordWrap
         }
     }
 
     Rectangle {
         Layout.fillWidth: true
-        height: 1
-        color: Qt.rgba(qgcPal.text.r, qgcPal.text.g, qgcPal.text.b, 0.08)
+        Layout.preferredHeight: 1
+        color: Qt.rgba(QGroundControl.globalPalette.text.r, QGroundControl.globalPalette.text.g, QGroundControl.globalPalette.text.b, 0.08)
         visible: root.showDivider
     }
 }

--- a/src/Vehicle/VehicleSetup/VehicleSummary.qml
+++ b/src/Vehicle/VehicleSetup/VehicleSummary.qml
@@ -13,27 +13,8 @@ Rectangle {
     color:          qgcPal.window
 
     property real _minSummaryW:     ScreenTools.isTinyScreen ? ScreenTools.defaultFontPixelWidth * 28 : ScreenTools.defaultFontPixelWidth * 36
-    property real _summaryBoxWidth: _minSummaryW
     property real _summaryBoxSpace: ScreenTools.defaultFontPixelWidth * 2
     property real _margins:        ScreenTools.defaultFontPixelHeight / 2
-
-    function computeSummaryBoxSize() {
-        var sw  = 0
-        var rw  = 0
-        var idx = Math.floor(_summaryRoot.width / (_minSummaryW + ScreenTools.defaultFontPixelWidth))
-        if(idx < 1) {
-            _summaryBoxWidth = _summaryRoot.width
-            _summaryBoxSpace = 0
-        } else {
-            _summaryBoxSpace = 0
-            if(idx > 1) {
-                _summaryBoxSpace = ScreenTools.defaultFontPixelWidth * 2
-                sw = _summaryBoxSpace * (idx - 1)
-            }
-            rw = _summaryRoot.width - sw
-            _summaryBoxWidth = rw / idx
-        }
-    }
 
     function capitalizeWords(sentence) {
         return sentence.replace(/(?:^|\s)\S/g, function(a) { return a.toUpperCase(); });
@@ -42,14 +23,6 @@ Rectangle {
     QGCPalette {
         id:                 qgcPal
         colorGroupEnabled:  enabled
-    }
-
-    Component.onCompleted: {
-        computeSummaryBoxSize()
-    }
-
-    onWidthChanged: {
-        computeSummaryBoxSize()
     }
 
     QGCFlickable {
@@ -80,7 +53,7 @@ Rectangle {
             GridLayout {
                 id:             _gridCtl
                 width:          _summaryRoot.width
-                columns:        Math.max(1, Math.floor(_summaryRoot.width / (_minSummaryW + ScreenTools.defaultFontPixelWidth)))
+                columns:        Math.max(1, Math.floor((_summaryRoot.width + _summaryBoxSpace) / (_minSummaryW + _summaryBoxSpace)))
                 columnSpacing:  _summaryBoxSpace
                 rowSpacing:     ScreenTools.defaultFontPixelHeight
 
@@ -91,7 +64,7 @@ Rectangle {
                     Rectangle {
                         Layout.fillWidth: true
                         Layout.fillHeight: true
-                        implicitWidth: _summaryBoxWidth
+                        implicitWidth: _minSummaryW
                         implicitHeight: mainLayout.implicitHeight + (_margins * 2)
                         radius: ScreenTools.defaultFontPixelHeight / 4
                         color: qgcPal.windowShade
@@ -114,9 +87,11 @@ Rectangle {
                                 Layout.fillWidth: true
                                 Layout.preferredHeight: titleHeight
                                 text: capitalizeWords(modelData.name)
+                                rightPadding: setupIndicator.visible ? setupIndicator.width + ScreenTools.defaultFontPixelWidth * 2 : leftPadding
 
                                 // Setup indicator
                                 Rectangle {
+                                    id:                     setupIndicator
                                     anchors.rightMargin:    ScreenTools.defaultFontPixelWidth
                                     anchors.right:          parent.right
                                     anchors.verticalCenter: parent.verticalCenter


### PR DESCRIPTION
Related to #14712

Follow-up fixes and cleanup to the summary card grid layout changes from #14712:

- **VehicleSummary.qml**
  - Remove legacy `computeSummaryBoxSize()` / `_summaryBoxWidth` sizing system left over from the old Flow layout; cards now size purely via `implicitWidth` + `Layout.fillWidth`.
  - Fix GridLayout column count math to account for column spacing: `floor((width + spacing) / (minWidth + spacing))`.
  - Add `rightPadding` to the card title button so long titles don't underlap the setup indicator dot.
- **VehicleSummaryRow.qml**
  - Use `Layout.preferredHeight` instead of `height` for the divider (layout-managed child).
  - Replace per-row `QGCPalette` instantiation with `QGroundControl.globalPalette` (one less object per row).
- **SafetyComponentSummary.qml**
  - Add Fact null guards to "Loiter Alt" / "Land Delay" rows so missing parameters can't render blank or throw.
  - Remove unused duplicate `RTL_LAND_DELAY` fact property; make fact property naming consistently private.
  - Style: braced ifs, `let` instead of `var`.
- **PowerComponentSummary.qml / APMPowerComponentSummary.qml**
  - Remove `width: parent.width` on layout-managed children (conflicts with `Layout.fillWidth`).
