### PR TITLE
fix(CorridorScanComplexItem): emit specifiesCoordinateChanged when polyline validity changes

### DIFF
--- a/src/MissionManager/CorridorScanComplexItem.cc
+++ b/src/MissionManager/CorridorScanComplexItem.cc
@@ -32,8 +32,13 @@ CorridorScanComplexItem::CorridorScanComplexItem(PlanMasterController* masterCon
     connect(&_corridorPolyline,     &QGCMapPolyline::pathChanged,                   this, &CorridorScanComplexItem::_rebuildCorridorPolygon);
     connect(&_corridorWidthFact,    &Fact::valueChanged,                            this, &CorridorScanComplexItem::_rebuildCorridorPolygon);
 
+    connect(&_corridorPolyline,     &QGCMapPolyline::countChanged,                  this, &CorridorScanComplexItem::_updateSpecifiesCoordinate);
+
     connect(&_corridorPolyline,     &QGCMapPolyline::isValidChanged,                this, &CorridorScanComplexItem::_updateWizardMode);
     connect(&_corridorPolyline,     &QGCMapPolyline::traceModeChanged,              this, &CorridorScanComplexItem::_updateWizardMode);
+
+    // Anchor the cache to current state so correctness doesn't depend on constructor ordering
+    _updateSpecifiesCoordinate();
 
     if (!kmlOrShpFile.isEmpty()) {
         _corridorPolyline.loadKMLOrSHPFile(kmlOrShpFile);
@@ -151,6 +156,16 @@ bool CorridorScanComplexItem::load(const QJsonObject& complexObject, int sequenc
 bool CorridorScanComplexItem::specifiesCoordinate(void) const
 {
     return _corridorPolyline.count() > 1;
+}
+
+// specifiesCoordinate() depends on polyline count, so the NOTIFY signal must be emitted when it flips
+void CorridorScanComplexItem::_updateSpecifiesCoordinate(void)
+{
+    const bool newSpecifiesCoordinate = specifiesCoordinate();
+    if (newSpecifiesCoordinate != _specifiesCoordinate) {
+        _specifiesCoordinate = newSpecifiesCoordinate;
+        emit specifiesCoordinateChanged();
+    }
 }
 
 void CorridorScanComplexItem::setCoordinate(const QGeoCoordinate& coordinate)

--- a/src/MissionManager/CorridorScanComplexItem.h
+++ b/src/MissionManager/CorridorScanComplexItem.h
@@ -63,6 +63,7 @@ private slots:
     void _polylineDirtyChanged          (bool dirty);
     void _rebuildCorridorPolygon        (void);
     void _updateWizardMode              (void);
+    void _updateSpecifiesCoordinate     (void);
 
     // Overrides from TransectStyleComplexItem
     void _rebuildTransectsPhase1    (void) final;
@@ -81,6 +82,7 @@ private:
 
     QMap<QString, FactMetaData*>    _metaDataMap;
     SettingsFact                    _corridorWidthFact;
+    bool                            _specifiesCoordinate = false;
 
     static constexpr const char* _jsonEntryPointKey =       "EntryPoint";
 };

--- a/test/MissionManager/CorridorScanComplexItemTest.cc
+++ b/test/MissionManager/CorridorScanComplexItemTest.cc
@@ -57,6 +57,41 @@ void CorridorScanComplexItemTest::_testDirty()
     _corridorItem->setDirty(false);
 }
 
+void CorridorScanComplexItemTest::_testSpecifiesCoordinateChanged()
+{
+    // Fresh item with an empty polyline so we can watch the 1 -> 2 vertex transition
+    CorridorScanComplexItem* item = new CorridorScanComplexItem(planController(), false /* flyView */, QString() /* kmlOrShpFile */);
+
+    MultiSignalSpy spy;
+    QVERIFY(spy.init(item, QStringList{QStringLiteral("specifiesCoordinateChanged")}));
+
+    QVERIFY(!item->specifiesCoordinate());
+
+    item->corridorPolyline()->appendVertex(_polyLineVertices[0]);
+    QVERIFY(!item->specifiesCoordinate());
+    QVERIFY(spy.noneEmitted());
+
+    item->corridorPolyline()->appendVertex(_polyLineVertices[1]);
+    QVERIFY(item->specifiesCoordinate());
+    QVERIFY(spy.emittedOnce("specifiesCoordinateChanged"));
+
+    spy.clearAllSignals();
+    item->corridorPolyline()->appendVertex(_polyLineVertices[2]);
+    QVERIFY(item->specifiesCoordinate());
+    QVERIFY(spy.noneEmitted());
+
+    // Unrelated corridor rebuild triggers must not emit spuriously
+    spy.clearAllSignals();
+    changeFactValue(item->corridorWidth());
+    QVERIFY(spy.noneEmitted());
+
+    // true -> false transition when the polyline is cleared
+    spy.clearAllSignals();
+    item->corridorPolyline()->clear();
+    QVERIFY(!item->specifiesCoordinate());
+    QVERIFY(spy.emittedOnce("specifiesCoordinateChanged"));
+}
+
 void CorridorScanComplexItemTest::_waitForReadyForSave()
 {
     QVERIFY_TRUE_WAIT(_corridorItem->readyForSaveState() == CorridorScanComplexItem::ReadyForSave,

--- a/test/MissionManager/CorridorScanComplexItemTest.h
+++ b/test/MissionManager/CorridorScanComplexItemTest.h
@@ -22,6 +22,7 @@ protected:
 
 private slots:
     void _testDirty();
+    void _testSpecifiesCoordinateChanged();
     void _testPathChanges();
     void _testItemGeneration();
     void _testItemCount();


### PR DESCRIPTION
Replaces #14725.

## Description

`CorridorScanComplexItem::specifiesCoordinate()` is dynamic (`_corridorPolyline.count() > 1`) but the class never emitted the `specifiesCoordinateChanged` NOTIFY signal. `MissionController` only rebuilds waypoint connector lines on that signal (plus a one-shot `isIncompleteChanged` which is consumed during item construction), so after tracing a corridor the connector line from the previous waypoint to the corridor entry never appeared until some unrelated action forced a full recalc.

## Why this approach instead of #14725

#14725 fixed the same bug but had a few weaknesses this PR addresses:

- **Emission is tied to the actual state change.** `specifiesCoordinate()` depends on the polyline vertex count, so the new `_updateSpecifiesCoordinate()` slot is connected to `QGCMapPolyline::countChanged` rather than piggybacking the emit inside `_rebuildCorridorPolygon()`. The polygon-rebuild slot is also triggered by corridor width changes (which can never affect `specifiesCoordinate()`), and a future refactor of the rebuild logic can't silently drop the signal emission.
- **`countChanged` covers every mutation path** — `appendVertex`, `clear()`, and `setPath`/JSON load all route through it (verified through `QmlObjectListModel`/`ObjectItemModelBase`, including the depth-counted model-reset path), so both the false→true and true→false transitions are always signaled.
- **No redundant constructor cache initialization.** #14725 added a `_specifiesCoordinate = specifiesCoordinate()` line at a point where the polyline is guaranteed empty (the KML/SHP load runs after the signal connections). Instead the cache is anchored once after the connects via `_updateSpecifiesCoordinate()`, which keeps it correct regardless of future constructor reordering.
- **Regression test included.** New `_testSpecifiesCoordinateChanged` unit test covers: no emission below 2 vertices, exactly one emission on the 1→2 transition, no spurious emission on 2→3 or corridor width changes, and the true→false transition on `clear()`. The test fails on master and passes with this fix.

## Type of Change
- [x] Bug fix (non-breaking change that fixes an issue)

## Testing
- [x] Tested locally
- [x] Added/updated unit tests

### Platforms Tested
- [x] macOS

---
By submitting this pull request, I confirm that my contribution is made under the terms of the project's dual license (Apache 2.0 and GPL v3).
