### PR TITLE
docs: update download page to stable release links for V5.1

### DIFF
--- a/docs/en/qgc-user-guide/getting_started/download_and_install.md
+++ b/docs/en/qgc-user-guide/getting_started/download_and_install.md
@@ -1,8 +1,6 @@
 # Download and Install
 
-::: tip
-These are **daily build** download links with the latest features. If you are looking for the last stable release, see the [stable docs](https://docs.qgroundcontrol.com/Stable_V5.1/en/qgc-user-guide/getting_started/download_and_install.html).
-:::
+The sections below can be used to download the [current stable release](https://github.com/mavlink/qgroundcontrol/releases) of _QGroundControl_ for each platform.
 
 ::: tip
 See [Troubleshooting QGC Setup](../troubleshooting/qgc_setup.md) if _QGroundControl_ doesn't start and run properly after installation!
@@ -21,8 +19,8 @@ For the best experience and compatibility, we recommend you the newest version o
 Supported versions: Windows 10 (1809 or later), Windows 11:
 
 1. Download the installer:
-   - [x86_64](https://d176tv9ibo4jno.cloudfront.net/builds/master/QGroundControl-installer-AMD64.exe)
-   - [Arm64](https://d176tv9ibo4jno.cloudfront.net/builds/master/QGroundControl-installer-ARM64.exe)
+   - [x86_64](https://d176tv9ibo4jno.cloudfront.net/latest/QGroundControl-installer-AMD64.exe)
+   - [Arm64](https://d176tv9ibo4jno.cloudfront.net/latest/QGroundControl-installer-ARM64.exe)
 1. Double click the executable to launch the installer.
 
 ::: info
@@ -38,7 +36,7 @@ Supported versions: macOS 13 (Ventura) or later:
 <!-- match version using https://docs.qgroundcontrol.com/master/en/qgc-dev-guide/getting_started/#native-builds -->
 <!-- usually based on Qt macOS dependency -->
 
-1. Download [QGroundControl.dmg](https://d176tv9ibo4jno.cloudfront.net/builds/master/QGroundControl.dmg).
+1. Download [QGroundControl.dmg](https://d176tv9ibo4jno.cloudfront.net/latest/QGroundControl.dmg).
 1. Double-click the .dmg file to mount it, then drag the _QGroundControl_ application to your _Application_ folder.
 
 ::: info
@@ -87,8 +85,8 @@ sudo apt install libxcb-xinerama0 libxkbcommon-x11-0 libxcb-cursor-dev -y
 **To install _QGroundControl_:**
 
 1. Download the AppImage for your architecture:
-   - [Linux x86_64](https://d176tv9ibo4jno.cloudfront.net/builds/master/QGroundControl-x86_64.AppImage)
-   - [Linux aarch64](https://d176tv9ibo4jno.cloudfront.net/builds/master/QGroundControl-aarch64.AppImage)
+   - [Linux x86_64](https://d176tv9ibo4jno.cloudfront.net/latest/QGroundControl-x86_64.AppImage)
+   - [Linux aarch64](https://d176tv9ibo4jno.cloudfront.net/latest/QGroundControl-aarch64.AppImage)
 
 1. Make the AppImage executable
 ```
@@ -106,7 +104,7 @@ Either double-click the AppImage in your file manager or launch it from a termin
 
 Supported versions: Android 9 (API 28) or later (arm 32/64):
 
-- [Android APK](https://d176tv9ibo4jno.cloudfront.net/builds/master/QGroundControl.apk)
+- [Android APK](https://d176tv9ibo4jno.cloudfront.net/latest/QGroundControl.apk)
 
 ::: important
 The version of Qt used by QGroundControl requires Android 9 (API 28) as the minimum supported version. It is not possible to support older Android releases. This means that some integrated controllers running older versions of Android are no longer compatible with current builds of QGroundControl. QGroundControl 5.0 stable is the last release that supports these older devices. Note that 5.0 may not fully support firmware versions released after it, so users on older controllers may experience limited compatibility with newer autopilot firmware.

--- a/docs/ko/qgc-user-guide/getting_started/download_and_install.md
+++ b/docs/ko/qgc-user-guide/getting_started/download_and_install.md
@@ -1,8 +1,6 @@
 # 다운로드 및 설치
 
-:::tip
-These are **daily build** download links with the latest features. If you are looking for the last stable release, see the [stable docs](https://docs.qgroundcontrol.com/Stable_V5.1/en/qgc-user-guide/getting_started/download_and_install.html).
-:::
+The sections below can be used to download the [current stable release](https://github.com/mavlink/qgroundcontrol/releases) of _QGroundControl_ for each platform.
 
 :::tip
 설치 후 QGroundControl이 정상적으로 실행되지 않으면, [QGC 설정 문제 해결](../troubleshooting/qgc_setup.md)편을 참고하여 문제를 해결할 수 있습니다.
@@ -21,8 +19,8 @@ More capable hardware will provide a better experience.
 Supported versions: Windows 10 (1809 or later), Windows 11:
 
 1. Download the installer:
-   - [x86_64](https://d176tv9ibo4jno.cloudfront.net/builds/master/QGroundControl-installer-AMD64.exe)
-   - [Arm64](https://d176tv9ibo4jno.cloudfront.net/builds/master/QGroundControl-installer-ARM64.exe)
+   - [x86_64](https://d176tv9ibo4jno.cloudfront.net/latest/QGroundControl-installer-AMD64.exe)
+   - [Arm64](https://d176tv9ibo4jno.cloudfront.net/latest/QGroundControl-installer-ARM64.exe)
 2. 다운로드한 설치 파일을 더블 클릭하여 프로그램을 실행합니다.
 
 :::info
@@ -39,7 +37,7 @@ Supported versions: macOS 13 (Ventura) or later:
 
 <!-- usually based on Qt macOS dependency -->
 
-1. Download [QGroundControl.dmg](https://d176tv9ibo4jno.cloudfront.net/builds/master/QGroundControl.dmg).
+1. Download [QGroundControl.dmg](https://d176tv9ibo4jno.cloudfront.net/latest/QGroundControl.dmg).
 2. 다운로드한 dmg 파일을 더블 클릭하여 마운트하여, _QGroundControl_ 애플리케이션을 _Application_ 폴더로 드래그합니다.
 
 :::info
@@ -90,8 +88,8 @@ sudo apt install libxcb-xinerama0 libxkbcommon-x11-0 libxcb-cursor-dev -y
 **To install _QGroundControl_:**
 
 1. Download the AppImage for your architecture:
-   - [Linux x86_64](https://d176tv9ibo4jno.cloudfront.net/builds/master/QGroundControl-x86_64.AppImage)
-   - [Linux aarch64](https://d176tv9ibo4jno.cloudfront.net/builds/master/QGroundControl-aarch64.AppImage)
+   - [Linux x86_64](https://d176tv9ibo4jno.cloudfront.net/latest/QGroundControl-x86_64.AppImage)
+   - [Linux aarch64](https://d176tv9ibo4jno.cloudfront.net/latest/QGroundControl-aarch64.AppImage)
 
 2. Make the AppImage executable
 
@@ -110,7 +108,7 @@ chmod +x QGroundControl-<arch>.AppImage
 
 Supported versions: Android 9 (API 28) or later (arm 32/64):
 
-- [Android APK](https://d176tv9ibo4jno.cloudfront.net/builds/master/QGroundControl.apk)
+- [Android APK](https://d176tv9ibo4jno.cloudfront.net/latest/QGroundControl.apk)
 
 :::important
 The version of Qt used by QGroundControl requires Android 9 (API 28) as the minimum supported version. It is not possible to support older Android releases. This means that some integrated controllers running older versions of Android are no longer compatible with current builds of QGroundControl. QGroundControl 5.0 stable is the last release that supports these older devices. Note that 5.0 may not fully support firmware versions released after it, so users on older controllers may experience limited compatibility with newer autopilot firmware.

--- a/docs/tr/qgc-user-guide/getting_started/download_and_install.md
+++ b/docs/tr/qgc-user-guide/getting_started/download_and_install.md
@@ -1,8 +1,6 @@
 # İndirme ve Kurulum
 
-:::tip
-These are **daily build** download links with the latest features. If you are looking for the last stable release, see the [stable docs](https://docs.qgroundcontrol.com/Stable_V5.1/en/qgc-user-guide/getting_started/download_and_install.html).
-:::
+The sections below can be used to download the [current stable release](https://github.com/mavlink/qgroundcontrol/releases) of _QGroundControl_ for each platform.
 
 :::tip
 See [Troubleshooting QGC Setup](../troubleshooting/qgc_setup.md) if _QGroundControl_ doesn't start and run properly after installation!
@@ -21,8 +19,8 @@ En iyi deneyim ve uyumluluk için size işletim sisteminizin en yeni sürümün�
 Supported versions: Windows 10 (1809 or later), Windows 11:
 
 1. Download the installer:
-   - [x86_64](https://d176tv9ibo4jno.cloudfront.net/builds/master/QGroundControl-installer-AMD64.exe)
-   - [Arm64](https://d176tv9ibo4jno.cloudfront.net/builds/master/QGroundControl-installer-ARM64.exe)
+   - [x86_64](https://d176tv9ibo4jno.cloudfront.net/latest/QGroundControl-installer-AMD64.exe)
+   - [Arm64](https://d176tv9ibo4jno.cloudfront.net/latest/QGroundControl-installer-ARM64.exe)
 2. exe'ye çift tıklayın.
 
 :::info
@@ -39,7 +37,7 @@ Supported versions: macOS 13 (Ventura) or later:
 
 <!-- usually based on Qt macOS dependency -->
 
-1. Download [QGroundControl.dmg](https://d176tv9ibo4jno.cloudfront.net/builds/master/QGroundControl.dmg).
+1. Download [QGroundControl.dmg](https://d176tv9ibo4jno.cloudfront.net/latest/QGroundControl.dmg).
 2. .dmg dosyasına çift tıklayın, ardından çıkan ekranda _QGroundControl_'ü _Application_ dosyasına sürükleyin.
 
 :::info
@@ -90,8 +88,8 @@ sudo apt install libxcb-xinerama0 libxkbcommon-x11-0 libxcb-cursor-dev -y
 **To install _QGroundControl_:**
 
 1. Download the AppImage for your architecture:
-   - [Linux x86_64](https://d176tv9ibo4jno.cloudfront.net/builds/master/QGroundControl-x86_64.AppImage)
-   - [Linux aarch64](https://d176tv9ibo4jno.cloudfront.net/builds/master/QGroundControl-aarch64.AppImage)
+   - [Linux x86_64](https://d176tv9ibo4jno.cloudfront.net/latest/QGroundControl-x86_64.AppImage)
+   - [Linux aarch64](https://d176tv9ibo4jno.cloudfront.net/latest/QGroundControl-aarch64.AppImage)
 
 2. Make the AppImage executable
 
@@ -110,7 +108,7 @@ chmod +x QGroundControl-<arch>.AppImage
 
 Supported versions: Android 9 (API 28) or later (arm 32/64):
 
-- [Android APK](https://d176tv9ibo4jno.cloudfront.net/builds/master/QGroundControl.apk)
+- [Android APK](https://d176tv9ibo4jno.cloudfront.net/latest/QGroundControl.apk)
 
 :::important
 The version of Qt used by QGroundControl requires Android 9 (API 28) as the minimum supported version. It is not possible to support older Android releases. This means that some integrated controllers running older versions of Android are no longer compatible with current builds of QGroundControl. QGroundControl 5.0 stable is the last release that supports these older devices. Note that 5.0 may not fully support firmware versions released after it, so users on older controllers may experience limited compatibility with newer autopilot firmware.

--- a/docs/zh/qgc-user-guide/getting_started/download_and_install.md
+++ b/docs/zh/qgc-user-guide/getting_started/download_and_install.md
@@ -1,8 +1,6 @@
 # 下载和安装
 
-:::tip
-These are **daily build** download links with the latest features. If you are looking for the last stable release, see the [stable docs](https://docs.qgroundcontrol.com/Stable_V5.1/en/qgc-user-guide/getting_started/download_and_install.html).
-:::
+The sections below can be used to download the [current stable release](https://github.com/mavlink/qgroundcontrol/releases) of _QGroundControl_ for each platform.
 
 :::tip
 如果 _QGroundControl_ 没有在安装后启动和正常运行，请参阅[故障排除QGC配置](../troubleshooting/qgc_setup.md)！
@@ -21,8 +19,8 @@ QGC可以在任何当下流行的计算机或移动设备上正常运行。 性�
 Supported versions: Windows 10 (1809 or later), Windows 11:
 
 1. Download the installer:
-   - [x86_64](https://d176tv9ibo4jno.cloudfront.net/builds/master/QGroundControl-installer-AMD64.exe)
-   - [Arm64](https://d176tv9ibo4jno.cloudfront.net/builds/master/QGroundControl-installer-ARM64.exe)
+   - [x86_64](https://d176tv9ibo4jno.cloudfront.net/latest/QGroundControl-installer-AMD64.exe)
+   - [Arm64](https://d176tv9ibo4jno.cloudfront.net/latest/QGroundControl-installer-ARM64.exe)
 2. 双击可执行文件来启动安装程序。
 
 :::info
@@ -39,7 +37,7 @@ Supported versions: macOS 13 (Ventura) or later:
 
 <!-- usually based on Qt macOS dependency -->
 
-1. Download [QGroundControl.dmg](https://d176tv9ibo4jno.cloudfront.net/builds/master/QGroundControl.dmg).
+1. Download [QGroundControl.dmg](https://d176tv9ibo4jno.cloudfront.net/latest/QGroundControl.dmg).
 2. 双击 .dmg 文件以挂载它，然后将 _QGroundControl_ 应用程序拖动到您的 _Application_ 文件夹。
 
 :::info
@@ -90,8 +88,8 @@ sudo apt install libxcb-xinerama0 libxkbcommon-x11-0 libxcb-cursor-dev -y
 **To install _QGroundControl_:**
 
 1. Download the AppImage for your architecture:
-   - [Linux x86_64](https://d176tv9ibo4jno.cloudfront.net/builds/master/QGroundControl-x86_64.AppImage)
-   - [Linux aarch64](https://d176tv9ibo4jno.cloudfront.net/builds/master/QGroundControl-aarch64.AppImage)
+   - [Linux x86_64](https://d176tv9ibo4jno.cloudfront.net/latest/QGroundControl-x86_64.AppImage)
+   - [Linux aarch64](https://d176tv9ibo4jno.cloudfront.net/latest/QGroundControl-aarch64.AppImage)
 
 2. Make the AppImage executable
 
@@ -110,7 +108,7 @@ chmod +x QGroundControl-<arch>.AppImage
 
 Supported versions: Android 9 (API 28) or later (arm 32/64):
 
-- [Android APK](https://d176tv9ibo4jno.cloudfront.net/builds/master/QGroundControl.apk)
+- [Android APK](https://d176tv9ibo4jno.cloudfront.net/latest/QGroundControl.apk)
 
 :::important
 The version of Qt used by QGroundControl requires Android 9 (API 28) as the minimum supported version. It is not possible to support older Android releases. This means that some integrated controllers running older versions of Android are no longer compatible with current builds of QGroundControl. QGroundControl 5.0 stable is the last release that supports these older devices. Note that 5.0 may not fully support firmware versions released after it, so users on older controllers may experience limited compatibility with newer autopilot firmware.


### PR DESCRIPTION
The download and install page on the Stable_V5.1 docs still had daily-build wording and `builds/master/` CDN links.

- Replace the daily-build tip with stable-release intro text (matches Stable_V5.0 precedent; links to GitHub releases since `release_notes.md` no longer exists in the docs tree)
- Switch all download links from `builds/master/` to `/latest/`, which is updated on every tag push and already contains the v5.1.0 RC1 artifacts under the new multi-arch filenames
- Applied to all four language copies (en/ko/tr/zh)
