### PR TITLE
test(VideoManager): address Windows sink review follow-up

### DIFF
--- a/src/VideoManager/VideoReceiver/GStreamer/gstqgc/gstqgcvideosinkbin.cc
+++ b/src/VideoManager/VideoReceiver/GStreamer/gstqgc/gstqgcvideosinkbin.cc
@@ -296,8 +296,9 @@ static gboolean wireGpuPath(GstQgcVideoSinkBin* self, GstElement* videosink, Gst
     }
 #else
     GstElement* glupload = nullptr;
-    // Keep native GPU memory direct. buildGpuCapsString() also offers system memory, which
-    // qgcqvideosink maps through its CPU fallback instead of uploading software-decoded frames.
+    // Keep advertised native GPU formats direct. Formats outside buildGpuCapsString() must
+    // renegotiate upstream; converting here would also upload software frames instead of
+    // letting qgcqvideosink use its CPU mapping fallback.
     if (!chain.linkChain({capsf, videosink}) || !chain.ghostSink(capsf)) {
         GST_ERROR_OBJECT(self, "Failed to link/ghost qgcqvideosink (GPU path)");
         return FALSE;

--- a/test/VideoManager/GStreamer/gstqgc/GStreamerGstQgcTest.cc
+++ b/test/VideoManager/GStreamer/gstqgc/GStreamerGstQgcTest.cc
@@ -732,7 +732,7 @@ void GStreamerTest::_testWindowsGpuSinkPreservesSoftwarePixels()
                                                      /*captureCenterPixel*/ true);
 
     QVERIFY2(result.eos, qUtf8Printable(QStringLiteral("Software-frame pipeline: %1").arg(result.errorMessage)));
-    QTRY_VERIFY_WITH_TIMEOUT(result.frameCount > 0, 2000);
+    QVERIFY(result.frameCount > 0);
     QCOMPARE(result.lastPixelFormat, QVideoFrameFormat::Format_BGRA8888);
     QVERIFY2(result.centerPixelValid, "System-memory fallback frame could not be mapped for pixel verification");
     QVERIFY2((result.centerPixel.red() > 200) && (result.centerPixel.green() < 50) && (result.centerPixel.blue() < 50),
@@ -763,14 +763,13 @@ void GStreamerTest::_testWindowsGpuSinkPreservesDirectD3D11Memory()
         runPipelineThroughQVideoSink(videoSink, controller,
                                      "video/x-raw,format=NV12,width=320,height=240,framerate=30/1 ! d3d11upload ! "
                                      "video/x-raw(memory:D3D11Memory),format=NV12",
-                                     /*numBuffers*/ 5, /*gpuZerocopy*/ true, "pattern=red");
-    if (!result.eos && (result.errorMessage.contains(QStringLiteral("D3D"), Qt::CaseInsensitive) ||
-                        result.errorMessage.contains(QStringLiteral("device"), Qt::CaseInsensitive))) {
+                                     /*numBuffers*/ 5, /*gpuZerocopy*/ true);
+    if (!result.eos && result.errorMessage.contains(QStringLiteral("d3d11"), Qt::CaseInsensitive)) {
         QSKIP(qPrintable(QStringLiteral("D3D11 device unavailable in this runner: %1").arg(result.errorMessage)));
     }
 
     QVERIFY2(result.eos, qUtf8Printable(QStringLiteral("D3D11 pipeline: %1").arg(result.errorMessage)));
-    QTRY_VERIFY_WITH_TIMEOUT(result.frameCount > 0, 2000);
+    QVERIFY(result.frameCount > 0);
     QCOMPARE(result.lastPixelFormat, QVideoFrameFormat::Format_NV12);
 #else
     QSKIP("D3D11 GPU sink path is only available in supported Windows builds");


### PR DESCRIPTION
## Description

This is the post-merge review cleanup requested on #14728.

It does not change runtime behavior. It:

- clarifies why the D3D11 sink advertises only native GPU formats;
- removes asynchronous waits from synchronous caps assertions;
- removes an unused `videotestsrc` property; and
- narrows the Windows skip condition to D3D11-specific initialization failures.

The original CPU-frame fallback was reproduced and verified by the maintainer before #14728 was merged. This follow-up does not claim separate hardware-decoder coverage for 4:2:2 or 4:4:4 streams.

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change or feature
- [ ] Documentation update
- [x] Refactoring (no functional changes)
- [ ] CI/Build changes
- [ ] Other

## Testing

- [x] Tested locally: reviewed the focused diff and ran `git diff --check`
- [x] Added/updated unit tests

Exact PR head: `37fc2884e83d733d15efcf839b40175a9cda0cd6`.

- [x] Exact-head QGC CI passed Linux x64/arm64 release builds, unit and integration tests, ASan/UBSan, coverage thresholds, Windows, macOS, iOS, Android, Docker, custom-plugin, and CodeQL checks. Linux evidence: [run 30596390058](https://github.com/mavlink/qgroundcontrol/actions/runs/30596390058)
- [x] Codecov reports every modified coverable line covered
- [ ] Tested with simulator (not applicable)
- [ ] Tested with hardware (no new runtime behavior)

### Platforms Tested

- [x] Linux (QGC exact-head CI)
- [x] Windows: the underlying fallback in #14728 was manually verified before merge
- [x] macOS (QGC exact-head CI build)
- [x] Android (QGC exact-head CI build)
- [x] iOS (QGC exact-head CI build)

### Flight Stacks Tested

Not applicable; this only refines GStreamer sink tests and comments.

## Screenshots

Not applicable; there is no UI change.

## Checklist

- [x] I have read the [Contribution Guidelines](CONTRIBUTING.md)
- [x] I have read the [Code of Conduct](CODE_OF_CONDUCT.md)
- [x] My code follows the project coding standards
- [x] I have updated tests to capture the reviewed behavior
- [x] New and existing unit and integration tests pass at the exact head in QGC CI

## Related Issues

Follow-up to #14728.

---
By submitting this pull request, I confirm that my contribution is made under the terms of the project's dual license (Apache 2.0 and GPL v3).