### PR TITLE
fix(pre-commit): install vale-sync from the cmd/vale package

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -152,8 +152,11 @@ repos:
       - id: vale-sync
         name: vale sync (download styles)
         language: golang
+        # The vale module root carries no Go package (the binary lives under cmd/vale), so a go
+        # install of the bare module fails and aborts the whole pre-commit run before any hook
+        # fires.
         additional_dependencies:
-          - 'github.com/errata-ai/vale/v3@v3.14.2'
+          - 'github.com/errata-ai/vale/v3/cmd/vale@v3.14.2'
         entry: vale sync
         files: ^(docs/|\.vale\.ini$)
         pass_filenames: false

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -227,14 +227,20 @@ repos:
 
       - id: check-categorized-logging
         name: Check for category function passed to uncategorized logging macro
-        entry: bash -c 'if grep -EnH "(^|[^A-Za-z0-9_])q(Debug|Info|Warning|Critical)\([[:space:]]*[A-Za-z_]+Log[[:space:]]*\)" "$@" 2>/dev/null; then echo "::error::Category function passed to qDebug/qInfo/qWarning/qCritical. Use the qCDebug/qCInfo/qCWarning/qCCritical macros instead." >&2; exit 1; fi' --
+        entry: >-
+          bash -c 'if grep -EnH "(^|[^A-Za-z0-9_])q(Debug|Info|Warning|Critical)\([[:space:]]*[A-Za-z_]+Log[[:space:]]*\)" "$@" 2>/dev/null;
+          then echo "::error::Category function passed to qDebug/qInfo/qWarning/qCritical.
+          Use the qCDebug/qCInfo/qCWarning/qCCritical macros instead." >&2; exit 1; fi' --
         language: system
         types: [c++]
         pass_filenames: true
 
       - id: check-no-qtest-ignore-message
         name: Check for QTest::ignoreMessage in test code
-        entry: bash -c 'if grep -nH "QTest::ignoreMessage" "$@" 2>/dev/null; then echo "::error::QTest::ignoreMessage found. Use expectLogMessage+verifyExpectedLogMessage or ignoreLogMessage instead." >&2; exit 1; fi' --
+        entry: >-
+          bash -c 'if grep -nH "QTest::ignoreMessage" "$@" 2>/dev/null;
+          then echo "::error::QTest::ignoreMessage found.
+          Use expectLogMessage+verifyExpectedLogMessage or ignoreLogMessage instead." >&2; exit 1; fi' --
         language: system
         types: [c++]
         files: ^test/
@@ -242,7 +248,11 @@ repos:
 
       - id: check-no-fixed-qwait
         name: Check for fixed-delay QTest::qWait in test code
-        entry: bash -c 'if grep -EnH "qWait\([1-9][0-9]*\)" "$@" 2>/dev/null; then echo "::error::QTest::qWait(<non-zero>) found. Use QTRY_VERIFY_WITH_TIMEOUT, QTRY_COMPARE_WITH_TIMEOUT, or QSignalSpy::wait with a TestTimeout::* constant instead." >&2; exit 1; fi' --
+        entry: >-
+          bash -c 'if grep -EnH "qWait\([1-9][0-9]*\)" "$@" 2>/dev/null;
+          then echo "::error::QTest::qWait(<non-zero>) found.
+          Use QTRY_VERIFY_WITH_TIMEOUT, QTRY_COMPARE_WITH_TIMEOUT,
+          or QSignalSpy::wait with a TestTimeout::* constant instead." >&2; exit 1; fi' --
         language: system
         types: [c++]
         files: ^test/


### PR DESCRIPTION
[<img src="https://avatars.githubusercontent.com/u/825410?v=4" alt="RIIS" width="56" align="left">](https://riis.com)

Contributed on behalf of [RIIS, LLC](https://riis.com).

<br clear="all">

---

## CI/Build Changes

Two commits to the pre-commit configuration:

1. The `vale-sync` hook installs its Go dependency from `github.com/errata-ai/vale/v3/cmd/vale` instead of the module root. The module root does not contain a Go package (the vale binary lives under `cmd/vale`), so `go install` fails and pre-commit aborts the entire run before a single hook fires.
2. Three inline bash hook entries (`check-categorized-logging`, `check-no-qtest-ignore-message`, `check-no-fixed-qwait`) are folded into YAML block scalars because they run past the 200 column limit that yamllint enforces, so the config was failing its own gate as soon as the file gets linted. YAML folds the lines with single spaces, so the entries parse to exactly the same command as before.

## Reason

Right now the whole pre-commit gate is silently dead: the broken `vale-sync` environment install makes pre-commit exit with code 3 and zero hook verdicts, everywhere this config runs, CI included. The error is:

```
go: module github.com/errata-ai/vale/v3@v3.14.2 found, but does not contain package github.com/errata-ai/vale/v3
```

So clang-format, typos, qmllint, actionlint and everything else in the config have not actually been running. I found this while chasing a pre-commit results artifact that reported `exit_code: 3, passed: 0, failed: 0` on a fork. There is a companion PR that makes the workflow fail loudly when this class of breakage happens again.

## Testing

- [x] Tested workflow locally (ran the pre-commit runner itself with this config: it installs the environment and produces hook verdicts again)
- [x] Verified YAML syntax (check-yaml and yamllint pass on the file)
- [x] Tested on fork before submitting (the same fix is running on my fork, and each folded hook was checked to still exit 1 on a synthetic violation and 0 on a clean file)

## Impact

The pre-commit workflow on every PR, and every local `pre-commit run`. No workflow files change in this PR.

## Checklist

- [x] I have read the [Contribution Guidelines](../CONTRIBUTING.md)
- [x] Workflow permissions follow least-privilege principle (no workflow changes here)
- [x] No secrets are exposed in logs

---
By submitting this pull request, I confirm that my contribution is made under the terms of the project's dual license (Apache 2.0 and GPL v3).
