### PR TITLE
ci(pre-commit): fail the job when hooks never ran

### DIFF
--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -88,10 +88,15 @@ jobs:
           path: pre-commit-results
           retention-days: 7
 
-      # Hook failures are surfaced via the PR comment; only fail the job when
-      # the runner script itself didn't complete (no exit_code output written).
+      # Hook failures are surfaced via the PR comment; the job itself fails only when the runner
+      # never produced hook verdicts. That is two shapes: the script died before writing results
+      # (no exit_code output), or pre-commit aborted before running hooks (exit codes other than
+      # 0/1, e.g. a hook environment that fails to install). Treating the second shape as green
+      # leaves every hook silently skipped while the check shows passing.
       - name: Fail job on pre-commit script crash
-        if: always() && steps.pre-commit.outcome == 'failure' && steps.pre-commit.outputs.exit_code == ''
+        if: always() && steps.pre-commit.outcome == 'failure' && steps.pre-commit.outputs.exit_code != '1'
+        env:
+          EXIT_CODE: ${{ steps.pre-commit.outputs.exit_code }}
         run: |
-          echo "::error::pre-commit runner crashed before writing results"
+          echo "::error::pre-commit runner crashed before running hooks (exit_code='${EXIT_CODE}')"
           exit 1


### PR DESCRIPTION
[<img src="https://avatars.githubusercontent.com/u/825410?v=4" alt="RIIS" width="56" align="left">](https://riis.com)

Contributed on behalf of [RIIS, LLC](https://riis.com).

<br clear="all">

---

## CI/Build Changes

The pre-commit job's crash guard now fails the job on any pre-commit completion other than exit 0 (all hooks passed) or exit 1 (hooks ran and some failed). It keeps the current report-only design for real hook findings: those still land in the PR comment and do not red the job.

## Reason

The current guard only fails the job when the runner script dies without writing an exit code at all. pre-commit has a second failure shape the guard misses: it can abort before running any hook and still exit with a code, for example when a hook environment fails to install (exit code 3). In that shape the step writes `exit_code=3` with zero hook verdicts, the guard sees a non-empty code, and the check lands green while every hook in the config was skipped. That is exactly what has been happening: see the companion PR fixing the `vale-sync` install, which was silently killing every pre-commit run. A gate that can pass without running is not a gate, so this closes the detection side while the companion PR fixes the current trigger.

## Testing

- [ ] Tested workflow locally (act or similar)
- [x] Verified YAML syntax (actionlint, zizmor and yamllint pass on the workflow)
- [x] Tested on fork before submitting (the failing shape is reproduced on my fork: a run with `exit_code: 3, passed: 0, failed: 0` in the results artifact and a green check; with this guard that run fails)

## Impact

Only the pre-commit workflow. Hook findings keep their report-only behaviour; the job only goes red when pre-commit never produced verdicts.

## Checklist

- [x] I have read the [Contribution Guidelines](../CONTRIBUTING.md)
- [x] Workflow permissions follow least-privilege principle (permissions unchanged)
- [x] No secrets are exposed in logs

---
By submitting this pull request, I confirm that my contribution is made under the terms of the project's dual license (Apache 2.0 and GPL v3).
