### PR TITLE
docs: update stable version references to V5.1

### DIFF
--- a/docs/.vitepress/config.mjs
+++ b/docs/.vitepress/config.mjs
@@ -159,6 +159,10 @@ export default defineConfig({
             link: "https://docs.qgroundcontrol.com/master/en/",
           },
           {
+            text: "v5.1",
+            link: "https://docs.qgroundcontrol.com/Stable_V5.1/en/",
+          },
+          {
             text: "v5.0",
             link: "https://docs.qgroundcontrol.com/Stable_V5.0/en/",
           },

--- a/docs/en/qgc-user-guide/getting_started/download_and_install.md
+++ b/docs/en/qgc-user-guide/getting_started/download_and_install.md
@@ -1,7 +1,7 @@
 # Download and Install
 
 ::: tip
-These are **daily build** download links with the latest features. If you are looking for the last stable release, see the [stable docs](https://docs.qgroundcontrol.com/Stable_V5.0/en/qgc-user-guide/getting_started/download_and_install.html).
+These are **daily build** download links with the latest features. If you are looking for the last stable release, see the [stable docs](https://docs.qgroundcontrol.com/Stable_V5.1/en/qgc-user-guide/getting_started/download_and_install.html).
 :::
 
 ::: tip

--- a/docs/en/qgc-user-guide/getting_started/whats_new.md
+++ b/docs/en/qgc-user-guide/getting_started/whats_new.md
@@ -1,6 +1,6 @@
 # What's New
 
-This page highlights user-facing changes since the last stable release (V5.0).
+This page highlights user-facing changes since the last stable release (V5.1).
 
 ## Fly View
 

--- a/docs/en/qgc-user-guide/index.md
+++ b/docs/en/qgc-user-guide/index.md
@@ -19,7 +19,7 @@ It provides easy and straightforward usage for beginners, while still delivering
 
 ::: info
 These docs cover the **daily build** (master branch).
-If you are using the stable release, see the [Stable V5.0 docs](https://docs.qgroundcontrol.com/Stable_V5.0/en/qgc-user-guide/).
+If you are using the stable release, see the [Stable V5.1 docs](https://docs.qgroundcontrol.com/Stable_V5.1/en/qgc-user-guide/).
 :::
 
 ## Getting Started

--- a/docs/ko/qgc-user-guide/getting_started/download_and_install.md
+++ b/docs/ko/qgc-user-guide/getting_started/download_and_install.md
@@ -1,7 +1,7 @@
 # 다운로드 및 설치
 
 :::tip
-These are **daily build** download links with the latest features. If you are looking for the last stable release, see the [stable docs](https://docs.qgroundcontrol.com/Stable_V5.0/en/qgc-user-guide/getting_started/download_and_install.html).
+These are **daily build** download links with the latest features. If you are looking for the last stable release, see the [stable docs](https://docs.qgroundcontrol.com/Stable_V5.1/en/qgc-user-guide/getting_started/download_and_install.html).
 :::
 
 :::tip

--- a/docs/ko/qgc-user-guide/getting_started/whats_new.md
+++ b/docs/ko/qgc-user-guide/getting_started/whats_new.md
@@ -1,6 +1,6 @@
 # What's New
 
-This page highlights user-facing changes since the last stable release (V5.0).
+This page highlights user-facing changes since the last stable release (V5.1).
 
 ## Fly View
 

--- a/docs/ko/qgc-user-guide/index.md
+++ b/docs/ko/qgc-user-guide/index.md
@@ -19,7 +19,7 @@ _QGroundControl_을 이용하여 PX4나 ArduPilot 구동 차량을 설정하고 
 
 :::info
 These docs cover the **daily build** (master branch).
-If you are using the stable release, see the [Stable V5.0 docs](https://docs.qgroundcontrol.com/Stable_V5.0/en/qgc-user-guide/).
+If you are using the stable release, see the [Stable V5.1 docs](https://docs.qgroundcontrol.com/Stable_V5.1/en/qgc-user-guide/).
 :::
 
 ## Getting Started

--- a/docs/tr/qgc-user-guide/getting_started/download_and_install.md
+++ b/docs/tr/qgc-user-guide/getting_started/download_and_install.md
@@ -1,7 +1,7 @@
 # İndirme ve Kurulum
 
 :::tip
-These are **daily build** download links with the latest features. If you are looking for the last stable release, see the [stable docs](https://docs.qgroundcontrol.com/Stable_V5.0/en/qgc-user-guide/getting_started/download_and_install.html).
+These are **daily build** download links with the latest features. If you are looking for the last stable release, see the [stable docs](https://docs.qgroundcontrol.com/Stable_V5.1/en/qgc-user-guide/getting_started/download_and_install.html).
 :::
 
 :::tip

--- a/docs/tr/qgc-user-guide/getting_started/whats_new.md
+++ b/docs/tr/qgc-user-guide/getting_started/whats_new.md
@@ -1,6 +1,6 @@
 # What's New
 
-This page highlights user-facing changes since the last stable release (V5.0).
+This page highlights user-facing changes since the last stable release (V5.1).
 
 ## Fly View
 

--- a/docs/tr/qgc-user-guide/index.md
+++ b/docs/tr/qgc-user-guide/index.md
@@ -19,7 +19,7 @@ It provides easy and straightforward usage for beginners, while still delivering
 
 :::info
 These docs cover the **daily build** (master branch).
-If you are using the stable release, see the [Stable V5.0 docs](https://docs.qgroundcontrol.com/Stable_V5.0/en/qgc-user-guide/).
+If you are using the stable release, see the [Stable V5.1 docs](https://docs.qgroundcontrol.com/Stable_V5.1/en/qgc-user-guide/).
 :::
 
 ## Getting Started

--- a/docs/zh/qgc-user-guide/getting_started/download_and_install.md
+++ b/docs/zh/qgc-user-guide/getting_started/download_and_install.md
@@ -1,7 +1,7 @@
 # 下载和安装
 
 :::tip
-These are **daily build** download links with the latest features. If you are looking for the last stable release, see the [stable docs](https://docs.qgroundcontrol.com/Stable_V5.0/en/qgc-user-guide/getting_started/download_and_install.html).
+These are **daily build** download links with the latest features. If you are looking for the last stable release, see the [stable docs](https://docs.qgroundcontrol.com/Stable_V5.1/en/qgc-user-guide/getting_started/download_and_install.html).
 :::
 
 :::tip

--- a/docs/zh/qgc-user-guide/getting_started/whats_new.md
+++ b/docs/zh/qgc-user-guide/getting_started/whats_new.md
@@ -1,6 +1,6 @@
 # What's New
 
-This page highlights user-facing changes since the last stable release (V5.0).
+This page highlights user-facing changes since the last stable release (V5.1).
 
 ## Fly View
 

--- a/docs/zh/qgc-user-guide/index.md
+++ b/docs/zh/qgc-user-guide/index.md
@@ -19,7 +19,7 @@ _QGroundControl_ 向PX4 或 ArduPilot 驱动的载具平台提供了全方位的
 
 :::info
 These docs cover the **daily build** (master branch).
-If you are using the stable release, see the [Stable V5.0 docs](https://docs.qgroundcontrol.com/Stable_V5.0/en/qgc-user-guide/).
+If you are using the stable release, see the [Stable V5.1 docs](https://docs.qgroundcontrol.com/Stable_V5.1/en/qgc-user-guide/).
 :::
 
 ## Getting Started


### PR DESCRIPTION
Cherry-pick of #14750 from Stable_V5.1 to master.

- Adds the v5.1 → Stable_V5.1 entry to the docs version switcher
- Updates whats_new.md heading to (V5.1) in all four languages
- Updates the stable docs links in download_and_install.md and index.md from Stable_V5.0 to Stable_V5.1 in all four languages
