### PR TITLE
docs: Linux AppImage requires Ubuntu 24.04 LTS or later

### DIFF
--- a/docs/en/qgc-user-guide/getting_started/download_and_install.md
+++ b/docs/en/qgc-user-guide/getting_started/download_and_install.md
@@ -45,7 +45,11 @@ QGroundControl continues to not be signed. You will not to allow permission for 
 
 ## Ubuntu Linux {#ubuntu}
 
-Supported versions: Ubuntu 22.04, 24.04:
+Supported versions: Ubuntu 24.04 LTS, 26.04 LTS:
+
+::: info
+The AppImage downloads below run on Ubuntu 24.04 LTS and 26.04 LTS. If you need a version of _QGroundControl_ that runs on Ubuntu 22.04, it is possible, but you have to [build it yourself](../../qgc-dev-guide/getting_started/index.md).
+:::
 
 Ubuntu comes with a serial modem manager that interferes with any robotics related use of a serial port (or USB serial).
 Before installing _QGroundControl_ you should remove the modem manager and grant yourself permissions to access the serial port.

--- a/docs/en/qgc-user-guide/getting_started/download_and_install.md
+++ b/docs/en/qgc-user-guide/getting_started/download_and_install.md
@@ -53,7 +53,6 @@ The AppImage downloads below run on Ubuntu 24.04 LTS and 26.04 LTS. If you need 
 
 Ubuntu comes with a serial modem manager that interferes with any robotics related use of a serial port (or USB serial).
 Before installing _QGroundControl_ you should remove the modem manager and grant yourself permissions to access the serial port.
-You also need to install _GStreamer_ in order to support video streaming.
 
 **Before installing _QGroundControl_ for the first time:**
 
@@ -80,10 +79,8 @@ sudo apt remove --purge modemmanager
 
 1. On the command prompt, enter:
 ```sh
-sudo apt install gstreamer1.0-plugins-bad gstreamer1.0-libav gstreamer1.0-gl -y
-sudo apt install python3-gi python3-gst-1.0 -y
 sudo apt install libfuse2 -y
-sudo apt install libxcb-xinerama0 libxkbcommon-x11-0 libxcb-cursor-dev -y
+sudo apt install libxcb-xinerama0 libxkbcommon-x11-0 libxcb-cursor0 -y
 ```
 
 **To install _QGroundControl_:**

--- a/docs/ko/qgc-user-guide/getting_started/download_and_install.md
+++ b/docs/ko/qgc-user-guide/getting_started/download_and_install.md
@@ -46,7 +46,11 @@ QGroundControl continues to not be signed. You will not to allow permission for 
 
 ## 우분투 리눅스 {#ubuntu}
 
-Supported versions: Ubuntu 22.04, 24.04:
+Supported versions: Ubuntu 24.04 LTS, 26.04 LTS:
+
+::: info
+The AppImage downloads below run on Ubuntu 24.04 LTS and 26.04 LTS. If you need a version of _QGroundControl_ that runs on Ubuntu 22.04, it is possible, but you have to [build it yourself](../../qgc-dev-guide/getting_started/index.md).
+:::
 
 Ubuntu comes with a serial modem manager that interferes with any robotics related use of a serial port (or USB serial).
 _QGroundControl_을 설치 전에 모뎀 관리자를 제거하고, 직렬 포트 접근 권한을 부여합니다.

--- a/docs/ko/qgc-user-guide/getting_started/download_and_install.md
+++ b/docs/ko/qgc-user-guide/getting_started/download_and_install.md
@@ -48,13 +48,12 @@ QGroundControl continues to not be signed. You will not to allow permission for 
 
 Supported versions: Ubuntu 24.04 LTS, 26.04 LTS:
 
-::: info
+:::info
 The AppImage downloads below run on Ubuntu 24.04 LTS and 26.04 LTS. If you need a version of _QGroundControl_ that runs on Ubuntu 22.04, it is possible, but you have to [build it yourself](../../qgc-dev-guide/getting_started/index.md).
 :::
 
 Ubuntu comes with a serial modem manager that interferes with any robotics related use of a serial port (or USB serial).
 _QGroundControl_을 설치 전에 모뎀 관리자를 제거하고, 직렬 포트 접근 권한을 부여합니다.
-동영상 스트리밍을 지원하려면 _GStreamer_을 설치합니다.
 
 **Before installing _QGroundControl_ for the first time:**
 
@@ -83,10 +82,8 @@ sudo apt remove --purge modemmanager
 1. On the command prompt, enter:
 
 ```sh
-sudo apt install gstreamer1.0-plugins-bad gstreamer1.0-libav gstreamer1.0-gl -y
-sudo apt install python3-gi python3-gst-1.0 -y
 sudo apt install libfuse2 -y
-sudo apt install libxcb-xinerama0 libxkbcommon-x11-0 libxcb-cursor-dev -y
+sudo apt install libxcb-xinerama0 libxkbcommon-x11-0 libxcb-cursor0 -y
 ```
 
 **To install _QGroundControl_:**

--- a/docs/tr/qgc-user-guide/getting_started/download_and_install.md
+++ b/docs/tr/qgc-user-guide/getting_started/download_and_install.md
@@ -46,7 +46,11 @@ QGroundControl continues to not be signed. You will not to allow permission for 
 
 ## Ubuntu Linux {#ubuntu}
 
-Supported versions: Ubuntu 22.04, 24.04:
+Supported versions: Ubuntu 24.04 LTS, 26.04 LTS:
+
+::: info
+The AppImage downloads below run on Ubuntu 24.04 LTS and 26.04 LTS. If you need a version of _QGroundControl_ that runs on Ubuntu 22.04, it is possible, but you have to [build it yourself](../../qgc-dev-guide/getting_started/index.md).
+:::
 
 Ubuntu, bir seri bağlantı noktasının (veya USB serisinin) robotikle ilgili kullanımına müdahale eden bir seri modem yöneticisi ile birlikte gelir.
 _ QGroundControl _ 'ü kurmadan önce modem yöneticisini kaldırmalı ve seri bağlantı noktasına erişim için kendinize izin vermelisiniz.

--- a/docs/tr/qgc-user-guide/getting_started/download_and_install.md
+++ b/docs/tr/qgc-user-guide/getting_started/download_and_install.md
@@ -48,13 +48,12 @@ QGroundControl continues to not be signed. You will not to allow permission for 
 
 Supported versions: Ubuntu 24.04 LTS, 26.04 LTS:
 
-::: info
+:::info
 The AppImage downloads below run on Ubuntu 24.04 LTS and 26.04 LTS. If you need a version of _QGroundControl_ that runs on Ubuntu 22.04, it is possible, but you have to [build it yourself](../../qgc-dev-guide/getting_started/index.md).
 :::
 
 Ubuntu, bir seri bağlantı noktasının (veya USB serisinin) robotikle ilgili kullanımına müdahale eden bir seri modem yöneticisi ile birlikte gelir.
 _ QGroundControl _ 'ü kurmadan önce modem yöneticisini kaldırmalı ve seri bağlantı noktasına erişim için kendinize izin vermelisiniz.
-Ayrıca video akışını desteklemek için _ GStreamer _ 'ı da yüklemeniz gerekmektedir.
 
 **Before installing _QGroundControl_ for the first time:**
 
@@ -83,10 +82,8 @@ sudo apt remove --purge modemmanager
 1. On the command prompt, enter:
 
 ```sh
-sudo apt install gstreamer1.0-plugins-bad gstreamer1.0-libav gstreamer1.0-gl -y
-sudo apt install python3-gi python3-gst-1.0 -y
 sudo apt install libfuse2 -y
-sudo apt install libxcb-xinerama0 libxkbcommon-x11-0 libxcb-cursor-dev -y
+sudo apt install libxcb-xinerama0 libxkbcommon-x11-0 libxcb-cursor0 -y
 ```
 
 **To install _QGroundControl_:**

--- a/docs/zh/qgc-user-guide/getting_started/download_and_install.md
+++ b/docs/zh/qgc-user-guide/getting_started/download_and_install.md
@@ -46,7 +46,11 @@ QGroundControl continues to not be signed. You will not to allow permission for 
 
 ## Ubuntu Linux 系统 {#ubuntu}
 
-Supported versions: Ubuntu 22.04, 24.04:
+Supported versions: Ubuntu 24.04 LTS, 26.04 LTS:
+
+::: info
+The AppImage downloads below run on Ubuntu 24.04 LTS and 26.04 LTS. If you need a version of _QGroundControl_ that runs on Ubuntu 22.04, it is possible, but you have to [build it yourself](../../qgc-dev-guide/getting_started/index.md).
+:::
 
 Ubuntu 自带一个串口调制解调器管理器，它会干扰串口（或 USB 转串口）在任何与机器人相关方面的使用。
 在安装 _QGroundControl_ 之前，您应该删除调制解调器管理器并授予自己访问串行端口的权限。

--- a/docs/zh/qgc-user-guide/getting_started/download_and_install.md
+++ b/docs/zh/qgc-user-guide/getting_started/download_and_install.md
@@ -48,13 +48,12 @@ QGroundControl continues to not be signed. You will not to allow permission for 
 
 Supported versions: Ubuntu 24.04 LTS, 26.04 LTS:
 
-::: info
+:::info
 The AppImage downloads below run on Ubuntu 24.04 LTS and 26.04 LTS. If you need a version of _QGroundControl_ that runs on Ubuntu 22.04, it is possible, but you have to [build it yourself](../../qgc-dev-guide/getting_started/index.md).
 :::
 
 Ubuntu 自带一个串口调制解调器管理器，它会干扰串口（或 USB 转串口）在任何与机器人相关方面的使用。
 在安装 _QGroundControl_ 之前，您应该删除调制解调器管理器并授予自己访问串行端口的权限。
-您还需要安装 _GStreamer_以支持视频流。
 
 **Before installing _QGroundControl_ for the first time:**
 
@@ -83,10 +82,8 @@ sudo apt remove --purge modemmanager
 1. On the command prompt, enter:
 
 ```sh
-sudo apt install gstreamer1.0-plugins-bad gstreamer1.0-libav gstreamer1.0-gl -y
-sudo apt install python3-gi python3-gst-1.0 -y
 sudo apt install libfuse2 -y
-sudo apt install libxcb-xinerama0 libxkbcommon-x11-0 libxcb-cursor-dev -y
+sudo apt install libxcb-xinerama0 libxkbcommon-x11-0 libxcb-cursor0 -y
 ```
 
 **To install _QGroundControl_:**


### PR DESCRIPTION
The Linux AppImages are built on Ubuntu 24.04 runners, so they require glibc 2.38+ and do not run on Ubuntu 22.04 (confirmed by the appimagelint report in the release CI run).

- Update supported versions to Ubuntu 24.04 LTS, 26.04 LTS
- Add a note that Ubuntu 22.04 users can build from source, linking to the dev guide
- Applied to all four language copies (en/ko/tr/zh)
