### PR TITLE
docs: combine AppImage dependency install into one apt command

### DIFF
--- a/docs/en/qgc-user-guide/getting_started/download_and_install.md
+++ b/docs/en/qgc-user-guide/getting_started/download_and_install.md
@@ -81,8 +81,7 @@ sudo apt remove --purge modemmanager
 
 1. On the command prompt, enter:
 ```sh
-sudo apt install libfuse2 -y
-sudo apt install libxcb-xinerama0 libxkbcommon-x11-0 libxcb-cursor0 -y
+sudo apt install -y libfuse2 libxcb-xinerama0 libxkbcommon-x11-0 libxcb-cursor0
 ```
 
 **To install _QGroundControl_:**

--- a/docs/ko/qgc-user-guide/getting_started/download_and_install.md
+++ b/docs/ko/qgc-user-guide/getting_started/download_and_install.md
@@ -84,8 +84,7 @@ sudo apt remove --purge modemmanager
 1. On the command prompt, enter:
 
 ```sh
-sudo apt install libfuse2 -y
-sudo apt install libxcb-xinerama0 libxkbcommon-x11-0 libxcb-cursor0 -y
+sudo apt install -y libfuse2 libxcb-xinerama0 libxkbcommon-x11-0 libxcb-cursor0
 ```
 
 **To install _QGroundControl_:**

--- a/docs/tr/qgc-user-guide/getting_started/download_and_install.md
+++ b/docs/tr/qgc-user-guide/getting_started/download_and_install.md
@@ -84,8 +84,7 @@ sudo apt remove --purge modemmanager
 1. On the command prompt, enter:
 
 ```sh
-sudo apt install libfuse2 -y
-sudo apt install libxcb-xinerama0 libxkbcommon-x11-0 libxcb-cursor0 -y
+sudo apt install -y libfuse2 libxcb-xinerama0 libxkbcommon-x11-0 libxcb-cursor0
 ```
 
 **To install _QGroundControl_:**

--- a/docs/zh/qgc-user-guide/getting_started/download_and_install.md
+++ b/docs/zh/qgc-user-guide/getting_started/download_and_install.md
@@ -84,8 +84,7 @@ sudo apt remove --purge modemmanager
 1. On the command prompt, enter:
 
 ```sh
-sudo apt install libfuse2 -y
-sudo apt install libxcb-xinerama0 libxkbcommon-x11-0 libxcb-cursor0 -y
+sudo apt install -y libfuse2 libxcb-xinerama0 libxkbcommon-x11-0 libxcb-cursor0
 ```
 
 **To install _QGroundControl_:**


### PR DESCRIPTION
Combine the two remaining AppImage dependency install lines into a single apt command. Followup to the dependency cleanup — the split grouping was leftover from when GStreamer packages were listed separately.
