### PR TITLE
docs: add v5.1 to version dropdown

### DIFF
--- a/docs/.vitepress/config.mjs
+++ b/docs/.vitepress/config.mjs
@@ -159,6 +159,10 @@ export default defineConfig({
             link: "https://docs.qgroundcontrol.com/master/en/",
           },
           {
+            text: "v5.1",
+            link: "https://docs.qgroundcontrol.com/Stable_V5.1/en/",
+          },
+          {
             text: "v5.0",
             link: "https://docs.qgroundcontrol.com/Stable_V5.0/en/",
           },


### PR DESCRIPTION
The version dropdown in the Stable_V5.0 docs build predates the v5.1 release, so users browsing the v5.0 docs can't navigate to the v5.1 docs. Adds the v5.1 entry to match master's dropdown.
