### PR TITLE
ci: retry docs deploy push with rebase on concurrent-deploy rejection

### DIFF
--- a/.github/scripts/deploy_docs.py
+++ b/.github/scripts/deploy_docs.py
@@ -15,6 +15,8 @@ ensure_tools_dir(__file__)
 
 from common.git import run_git
 
+PUSH_ATTEMPTS = 3
+
 
 def sanitize_branch(name: str) -> str:
     """Remove unsafe characters from branch name for use as a directory."""
@@ -61,8 +63,21 @@ def deploy_branch(
 
     today = datetime.datetime.now(datetime.timezone.utc).strftime("%Y-%m-%d")
     run_git("commit", "-m", f"{commit_message} {today}", cwd=target_dir, check=True)
-    run_git("push", "origin", target_branch, cwd=target_dir, check=True)
+    _push_with_retry(target_dir, target_branch)
     return True
+
+
+def _push_with_retry(target_dir: Path, target_branch: str) -> None:
+    """Push, rebasing onto concurrent deploys from other branches on rejection."""
+    for attempt in range(1, PUSH_ATTEMPTS + 1):
+        push = run_git("push", "origin", target_branch, cwd=target_dir)
+        if push.returncode == 0:
+            return
+        print(f"Push attempt {attempt}/{PUSH_ATTEMPTS} failed:\n{push.stderr.strip()}")
+        if attempt < PUSH_ATTEMPTS:
+            run_git("pull", "--rebase", "origin", target_branch, cwd=target_dir, check=True)
+    msg = f"git push failed after {PUSH_ATTEMPTS} attempts"
+    raise RuntimeError(msg)
 
 
 def main() -> None:


### PR DESCRIPTION
Docs deploy runs on master and Stable branches push into the same target repo (mavlink/docs.qgroundcontrol.com). When two branches deploy at the same time, the second push is rejected as non-fast-forward and the deploy job fails — this happened twice today (Docs runs #172 and #176, master losing the race against simultaneous Stable_V5.1 deploys), leaving the /master/ docs stale.

Fix: retry the push up to 3 times, doing `git pull --rebase` on rejection. Deploys write to disjoint per-branch subdirectories, so the rebase cannot conflict. After 3 failed attempts the job still fails loudly.

A shared concurrency group was considered instead, but GitHub Actions keeps only one pending run per group and cancels older ones — a cancelled deploy would be silently lost with nothing to re-trigger it.
