### PR TITLE
docs: update macOS install instructions for signed universal builds

### DIFF
--- a/docs/en/qgc-user-guide/getting_started/download_and_install.md
+++ b/docs/en/qgc-user-guide/getting_started/download_and_install.md
@@ -23,7 +23,7 @@ Supported versions: Windows 10 (1809 or later), Windows 11:
 1. Download the installer:
    - [x86_64](https://d176tv9ibo4jno.cloudfront.net/builds/master/QGroundControl-installer-AMD64.exe)
    - [Arm64](https://d176tv9ibo4jno.cloudfront.net/builds/master/QGroundControl-installer-ARM64.exe)
-1. Double click the executable to launch the installer.
+1. Double-click the executable to launch the installer.
 
 ::: info
 The Windows installer creates 3 shortcuts: **QGroundControl**, **GPU Compatibility Mode**, **GPU Safe Mode**.
@@ -39,10 +39,11 @@ Supported versions: macOS 13 (Ventura) or later:
 <!-- usually based on Qt macOS dependency -->
 
 1. Download [QGroundControl.dmg](https://d176tv9ibo4jno.cloudfront.net/builds/master/QGroundControl.dmg).
-1. Double-click the .dmg file to mount it, then drag the _QGroundControl_ application to your _Application_ folder.
+1. Double-click the .dmg file to mount it. In the window that opens, drag the _QGroundControl_ icon onto the _Applications_ folder shortcut shown next to it.
 
 ::: info
-QGroundControl continues to not be signed. You will not to allow permission for it to install based on your macOS version.
+The download is a universal binary that runs natively on both Apple Silicon and Intel Macs.
+Official builds are signed and notarized, so no Gatekeeper security overrides are needed to run the app.
 :::
 
 ## Ubuntu Linux {#ubuntu}


### PR DESCRIPTION
Updates the macOS section of the download and install guide to match the current release pipeline:

- Replace the outdated note claiming QGC is unsigned — official builds are now signed and notarized with an Apple Developer ID (`SignMacBundle.cmake`, enabled in CI for non-PR builds), so no Gatekeeper overrides are needed.
- Note that the DMG contains a universal binary (`x86_64h;arm64`) running natively on Apple Silicon and Intel Macs.
- Reword the install step to match the actual DMG layout: `create-dmg` with `--app-drop-link` shows an Applications folder shortcut in the DMG window.