### PR TITLE
docs: update macOS install instructions for signed universal builds (Stable_V5.1)

### DIFF
--- a/docs/en/qgc-user-guide/getting_started/download_and_install.md
+++ b/docs/en/qgc-user-guide/getting_started/download_and_install.md
@@ -21,7 +21,7 @@ Supported versions: Windows 10 (1809 or later), Windows 11:
 1. Download the installer:
    - [x86_64](https://d176tv9ibo4jno.cloudfront.net/latest/QGroundControl-installer-AMD64.exe)
    - [Arm64](https://d176tv9ibo4jno.cloudfront.net/latest/QGroundControl-installer-ARM64.exe)
-1. Double click the executable to launch the installer.
+1. Double-click the executable to launch the installer.
 
 ::: info
 The Windows installer creates 3 shortcuts: **QGroundControl**, **GPU Compatibility Mode**, **GPU Safe Mode**.
@@ -37,10 +37,11 @@ Supported versions: macOS 13 (Ventura) or later:
 <!-- usually based on Qt macOS dependency -->
 
 1. Download [QGroundControl.dmg](https://d176tv9ibo4jno.cloudfront.net/latest/QGroundControl.dmg).
-1. Double-click the .dmg file to mount it, then drag the _QGroundControl_ application to your _Application_ folder.
+1. Double-click the .dmg file to mount it. In the window that opens, drag the _QGroundControl_ icon onto the _Applications_ folder shortcut shown next to it.
 
 ::: info
-QGroundControl continues to not be signed. You will not to allow permission for it to install based on your macOS version.
+The download is a universal binary that runs natively on both Apple Silicon and Intel Macs.
+Official builds are signed and notarized, so no Gatekeeper security overrides are needed to run the app.
 :::
 
 ## Ubuntu Linux {#ubuntu}


### PR DESCRIPTION
Backport of #14775 to Stable_V5.1.

- Replace the outdated note claiming QGC is unsigned — official builds are signed and notarized, so no Gatekeeper overrides are needed.
- Note that the DMG contains a universal binary running natively on Apple Silicon and Intel Macs.
- Reword the install step to match the actual DMG layout (Applications folder shortcut shown in the DMG window).