### PR TITLE
fix(Vehicle): use standard PX4 airspeed calibration value

### DIFF
--- a/src/Vehicle/Vehicle.cc
+++ b/src/Vehicle/Vehicle.cc
@@ -2364,7 +2364,7 @@ void Vehicle::startCalibration(QGCMAVLink::CalibrationType calType)
         param7 = 1;
         break;
     case QGCMAVLink::CalibrationPX4Airspeed:
-        param6 = 1;
+        param6 = 2;  // 1 is deprecated by PX4, still accepted but 2 is the standard value
         break;
     case QGCMAVLink::CalibrationPX4Pressure:
         param3 = 1;


### PR DESCRIPTION
Replaces #14774 — thanks to @tustin-dev for identifying this and submitting the original fix!

## Summary

Use the standard MAVLink value `2` for airspeed calibration in `MAV_CMD_PREFLIGHT_CALIBRATION` param6. PX4 deprecated `1` in Feb 2017 but still accepts both, so this is a spec-compliance cleanup: `2` matches the MAVLink spec and what PX4's own `commander calibrate airspeed` CLI sends, and protects QGC if PX4 ever drops the deprecated value.

## Why the unit test from #14774 was dropped

The test asserted that `startCalibration(CalibrationPX4Airspeed)` sends `param6 == 2` — it simply mirrors the constant set in the production code back, with no independent oracle. It cannot catch the actual bug class here (a magic number that disagrees with the firmware's expectation), covers only one of the ~8 calibration types, and would live in `SendMavCommandWithHandlerTest`, which is about command send/ack/retry handling rather than calibration payloads. If payload pinning is wanted later, a table-driven test over all `CalibrationType` values would guard the whole switch instead of one row.
