### PR TITLE
fix(Vehicle): use standard PX4 airspeed calibration value (5.1)

### DIFF
--- a/src/Vehicle/Vehicle.cc
+++ b/src/Vehicle/Vehicle.cc
@@ -2364,7 +2364,7 @@ void Vehicle::startCalibration(QGCMAVLink::CalibrationType calType)
         param7 = 1;
         break;
     case QGCMAVLink::CalibrationPX4Airspeed:
-        param6 = 1;
+        param6 = 2;  // 1 is deprecated by PX4, still accepted but 2 is the standard value
         break;
     case QGCMAVLink::CalibrationPX4Pressure:
         param3 = 1;


### PR DESCRIPTION
Stable_V5.1 version of #14780, replacing #14774 — thanks to @tustin-dev for identifying this and submitting the original fix!

## Summary

Use the standard MAVLink value `2` for airspeed calibration in `MAV_CMD_PREFLIGHT_CALIBRATION` param6. PX4 deprecated `1` in Feb 2017 but still accepts both, so this is a spec-compliance cleanup: `2` matches the MAVLink spec and what PX4's own `commander calibrate airspeed` CLI sends.

The unit test from #14774 was dropped — see #14780 for the rationale.
