### PR TITLE
docs: fix typos in release note generation sentence

### DIFF
--- a/docs/en/qgc-dev-guide/contribute/pull_requests.md
+++ b/docs/en/qgc-dev-guide/contribute/pull_requests.md
@@ -4,7 +4,7 @@ All pull requests go through the QGC CI build system which builds release and de
 
 ## Automatic Release Note Generation
 
-Releases notes are generated from the following GitHub labels qhich should be set on Pull Requests as appropriate:
+Release notes are generated from the following GitHub labels, which should be set on Pull Requests as appropriate:
 
 * "RN: MAJOR FEATURE"
 * "RN: MINOR FEATURE"


### PR DESCRIPTION
Replaces #14757 — thanks to @rockonsoft for spotting the typo and submitting the original fix!

Fixes both typos in the same sentence of the release-note generation docs:
- "qhich" -> "which" (from #14757)
- "Releases notes" -> "Release notes"
