### PR TITLE
fix(QGCCorePlugin): destroy QML engines through a plugin hook symmetric to creation

### DIFF
--- a/custom-example/src/CustomPlugin.cc
+++ b/custom-example/src/CustomPlugin.cc
@@ -46,15 +46,6 @@ QGCCorePlugin *CustomPlugin::instance()
     return _customPluginInstance();
 }
 
-void CustomPlugin::cleanup()
-{
-    if (_qmlEngine) {
-        _qmlEngine->removeUrlInterceptor(_selector);
-    }
-
-    delete _selector;
-}
-
 void CustomPlugin::_advancedChanged(bool changed)
 {
     // Firmware Upgrade page is only show in Advanced mode
@@ -265,6 +256,18 @@ QQmlApplicationEngine* CustomPlugin::createQmlApplicationEngine(QObject* parent)
     _qmlEngine->addUrlInterceptor(_selector);
 
     return _qmlEngine;
+}
+
+void CustomPlugin::destroyQmlApplicationEngine(QQmlApplicationEngine *qmlEngine)
+{
+    if (qmlEngine && (qmlEngine == _qmlEngine)) {
+        qmlEngine->removeUrlInterceptor(_selector);
+        delete _selector;
+        _selector = nullptr;
+        _qmlEngine = nullptr;
+    }
+
+    QGCCorePlugin::destroyQmlApplicationEngine(qmlEngine);
 }
 
 /*===========================================================================*/

--- a/custom-example/src/CustomPlugin.h
+++ b/custom-example/src/CustomPlugin.h
@@ -65,7 +65,6 @@ public:
 
     // Overrides from QGCCorePlugin
 
-    void cleanup() final;
     QGCOptions *options() final { return _options; }
     /// This allows you to override/hide QGC Application settings
     void adjustSettingMetaData(const QString &settingsGroup, FactMetaData &metaData, bool &userVisible) final;
@@ -73,6 +72,8 @@ public:
     void paletteOverride(const QString &colorName, QGCPalette::PaletteColorInfo_t &colorInfo) final;
     /// We override this so we can get access to QQmlApplicationEngine and use it to register our qml module
     QQmlApplicationEngine *createQmlApplicationEngine(QObject *parent) final;
+    /// Releases the url interceptor attached in createQmlApplicationEngine before the engine is destroyed
+    void destroyQmlApplicationEngine(QQmlApplicationEngine *qmlEngine) final;
 
     /// Adds the Perimeter Scan item to the complex-item menu.
     QVariantList complexMissionItemNames(Vehicle *vehicle) final;

--- a/src/API/QGCCorePlugin.cc
+++ b/src/API/QGCCorePlugin.cc
@@ -303,6 +303,11 @@ QQmlApplicationEngine *QGCCorePlugin::createQmlApplicationEngine(QObject *parent
     return qmlEngine;
 }
 
+void QGCCorePlugin::destroyQmlApplicationEngine(QQmlApplicationEngine *qmlEngine)
+{
+    delete qmlEngine;
+}
+
 void QGCCorePlugin::createRootWindow(QQmlApplicationEngine *qmlEngine)
 {
     qmlEngine->load(QUrl(QStringLiteral("qrc:/qml/QGroundControl/MainWindow.qml")));

--- a/src/API/QGCCorePlugin.h
+++ b/src/API/QGCCorePlugin.h
@@ -97,6 +97,11 @@ public:
     /// path or stuff things into the context prior to window creation.
     virtual QQmlApplicationEngine *createQmlApplicationEngine(QObject *parent);
 
+    /// Symmetric counterpart to createQmlApplicationEngine. Engines obtained from the create hook
+    /// must be destroyed through this hook so the plugin can release any per-engine state it
+    /// attached at creation (url interceptors, etc) before the engine goes away.
+    virtual void destroyQmlApplicationEngine(QQmlApplicationEngine *qmlEngine);
+
     /// Allows the plugin to override the creation of the root (native) window.
     virtual void createRootWindow(QQmlApplicationEngine *qmlEngine);
 

--- a/src/QGCApplication.cc
+++ b/src/QGCApplication.cc
@@ -767,6 +767,13 @@ void QGCApplication::shutdown()
         VideoManager::instance()->cleanup();
     }
 
+    // Engines from createQmlApplicationEngine must die through the destroy hook so the plugin
+    // can release per-engine state; parent-based teardown in ~QGCApplication would bypass it.
+    if (_qmlAppEngine) {
+        QGCCorePlugin::instance()->destroyQmlApplicationEngine(_qmlAppEngine);
+        _qmlAppEngine = nullptr;
+    }
+
     QGCCorePlugin::instance()->cleanup();
 
     if (_runningUnitTests || _simpleBootTest) {

--- a/test/MissionManager/MissionCommandTreeEditorTest.cc
+++ b/test/MissionManager/MissionCommandTreeEditorTest.cc
@@ -47,7 +47,7 @@ void MissionCommandTreeEditorTest::_testEditorsWorker(QGCMAVLinkTypes::FirmwareC
                               vehicleClassString));
     qmlAppEngine->load(QUrl(QStringLiteral("qrc:/qml/MissionCommandTreeEditorTestWindow.qml")));
     QVERIFY_TRUE_WAIT(!qmlAppEngine->rootObjects().isEmpty(), TestTimeout::mediumMs());
-    delete qmlAppEngine;
+    QGCCorePlugin::instance()->destroyQmlApplicationEngine(qmlAppEngine);
 }
 
 void MissionCommandTreeEditorTest::testEditors()

--- a/test/QmlUITests/QmlUITestBase.cc
+++ b/test/QmlUITests/QmlUITestBase.cc
@@ -202,7 +202,7 @@ void QmlUITestBase::destroyUIEngine()
         QCoreApplication::processEvents();
     }
     qgcApp()->setQmlAppEngine(nullptr);
-    delete _engine;
+    QGCCorePlugin::instance()->destroyQmlApplicationEngine(_engine);
     _engine   = nullptr;
     _window   = nullptr;
     _rootItem = nullptr;


### PR DESCRIPTION
Replaces #14755. Full credit to @TSC21 / [RIIS, LLC](https://riis.com) for identifying the crash and pinning the root cause with a gdb backtrace.

## Bug

In a custom build (`QGC_CUSTOM_DIR`), unit tests that create a QML engine via `QGCCorePlugin::createQmlApplicationEngine()` and later `delete` it (MissionCommandTreeEditorTest, every QmlUITestBase-derived test) leave `CustomPlugin::_qmlEngine` dangling — the plugin attached a url interceptor and cached the engine pointer at creation, but never hears about destruction. `QGCApplication::shutdown()` then calls `cleanup()`, which dereferences the dangling pointer in `removeUrlInterceptor()`: use-after-free, SIGSEGV.

## Why not QPointer (#14755's approach)

`QPointer` makes the plugin *tolerate* being kept in the dark about engine destruction. The actual design flaw is the asymmetry: **creation** goes through a plugin hook so the plugin can attach per-engine state, but **destruction** was a raw `delete` by the caller, bypassing the plugin entirely. Any plugin state hung on an engine rots silently — the dangling pointer was just the first symptom (the per-create interceptor leak was another).

## Fix: symmetric destroy hook

- `QGCCorePlugin::destroyQmlApplicationEngine(QQmlApplicationEngine*)` — new virtual, base implementation just deletes. Engines obtained from the create hook must be destroyed through it.
- All three teardown sites now use the hook: `QGCApplication::shutdown()` (the app engine previously died via parent teardown, bypassing the plugin), `QmlUITestBase::destroyUIEngine()`, `MissionCommandTreeEditorTest`.
- `CustomPlugin` overrides the destroy hook to unhook and release its interceptor with the engine it belongs to. `cleanup()` loses all engine knowledge and is deleted; the interceptor teardown lives next to its creation.

This structurally removes the dangling pointer, the interceptor leak, and models the correct lifecycle in `custom-example` — the template downstream custom builds copy.

## Testing

- [x] `MissionCommandTreeEditorTest` passes
- [x] All 16 QmlUITestBase-derived UI tests pass
- [x] `--simple-boot-test` exits cleanly (exit 0) — validates the new shutdown-path engine destruction

### Platforms Tested

- [x] macOS
