### PR TITLE
feat(API): add destroyQmlApplicationEngine plugin hook

### DIFF
--- a/custom-example/src/CustomPlugin.cc
+++ b/custom-example/src/CustomPlugin.cc
@@ -46,15 +46,6 @@ QGCCorePlugin *CustomPlugin::instance()
     return _customPluginInstance();
 }
 
-void CustomPlugin::cleanup()
-{
-    if (_qmlEngine) {
-        _qmlEngine->removeUrlInterceptor(_selector);
-    }
-
-    delete _selector;
-}
-
 void CustomPlugin::_advancedChanged(bool changed)
 {
     // Firmware Upgrade page is only show in Advanced mode
@@ -261,10 +252,22 @@ QQmlApplicationEngine* CustomPlugin::createQmlApplicationEngine(QObject* parent)
     _qmlEngine->addImportPath("qrc:/qml/Custom/Plan");
     // TODO: Investigate _qmlEngine->setExtraSelectors({"custom"})
 
-    _selector = new CustomOverrideInterceptor();
-    _qmlEngine->addUrlInterceptor(_selector);
+    _urlInterceptor = new CustomOverrideInterceptor();
+    _qmlEngine->addUrlInterceptor(_urlInterceptor);
 
     return _qmlEngine;
+}
+
+void CustomPlugin::destroyQmlApplicationEngine(QQmlApplicationEngine *qmlEngine)
+{
+    if (qmlEngine && (qmlEngine == _qmlEngine)) {
+        qmlEngine->removeUrlInterceptor(_urlInterceptor);
+        delete _urlInterceptor;
+        _urlInterceptor = nullptr;
+        _qmlEngine = nullptr;
+    }
+
+    QGCCorePlugin::destroyQmlApplicationEngine(qmlEngine);
 }
 
 /*===========================================================================*/

--- a/custom-example/src/CustomPlugin.h
+++ b/custom-example/src/CustomPlugin.h
@@ -65,7 +65,6 @@ public:
 
     // Overrides from QGCCorePlugin
 
-    void cleanup() final;
     QGCOptions *options() final { return _options; }
     /// This allows you to override/hide QGC Application settings
     void adjustSettingMetaData(const QString &settingsGroup, FactMetaData &metaData, bool &userVisible) final;
@@ -73,6 +72,8 @@ public:
     void paletteOverride(const QString &colorName, QGCPalette::PaletteColorInfo_t &colorInfo) final;
     /// We override this so we can get access to QQmlApplicationEngine and use it to register our qml module
     QQmlApplicationEngine *createQmlApplicationEngine(QObject *parent) final;
+    /// Releases the url interceptor attached in createQmlApplicationEngine before the engine is destroyed
+    void destroyQmlApplicationEngine(QQmlApplicationEngine *qmlEngine) final;
 
     /// Adds the Perimeter Scan item to the complex-item menu.
     QVariantList complexMissionItemNames(Vehicle *vehicle) final;
@@ -92,7 +93,7 @@ private:
 
     CustomOptions *_options = nullptr;
     QQmlApplicationEngine *_qmlEngine = nullptr;
-    class CustomOverrideInterceptor *_selector = nullptr;
+    class CustomOverrideInterceptor *_urlInterceptor = nullptr;
     QVariantList _customSettingsList; // Not to be mixed up with QGCCorePlugin implementation
 };
 

--- a/src/API/QGCCorePlugin.cc
+++ b/src/API/QGCCorePlugin.cc
@@ -303,6 +303,11 @@ QQmlApplicationEngine *QGCCorePlugin::createQmlApplicationEngine(QObject *parent
     return qmlEngine;
 }
 
+void QGCCorePlugin::destroyQmlApplicationEngine(QQmlApplicationEngine *qmlEngine)
+{
+    delete qmlEngine;
+}
+
 void QGCCorePlugin::createRootWindow(QQmlApplicationEngine *qmlEngine)
 {
     qmlEngine->load(QUrl(QStringLiteral("qrc:/qml/QGroundControl/MainWindow.qml")));

--- a/src/API/QGCCorePlugin.h
+++ b/src/API/QGCCorePlugin.h
@@ -97,6 +97,11 @@ public:
     /// path or stuff things into the context prior to window creation.
     virtual QQmlApplicationEngine *createQmlApplicationEngine(QObject *parent);
 
+    /// Symmetric counterpart to createQmlApplicationEngine. Engines obtained from the create hook
+    /// must be destroyed through this hook so the plugin can release any per-engine state it
+    /// attached at creation (url interceptors, etc) before the engine goes away.
+    virtual void destroyQmlApplicationEngine(QQmlApplicationEngine *qmlEngine);
+
     /// Allows the plugin to override the creation of the root (native) window.
     virtual void createRootWindow(QQmlApplicationEngine *qmlEngine);
 

--- a/src/QGCApplication.cc
+++ b/src/QGCApplication.cc
@@ -767,6 +767,13 @@ void QGCApplication::shutdown()
         VideoManager::instance()->cleanup();
     }
 
+    // Engines from createQmlApplicationEngine must die through the destroy hook so the plugin
+    // can release per-engine state; parent-based teardown in ~QGCApplication would bypass it.
+    if (_qmlAppEngine) {
+        QGCCorePlugin::instance()->destroyQmlApplicationEngine(_qmlAppEngine);
+        _qmlAppEngine = nullptr;
+    }
+
     QGCCorePlugin::instance()->cleanup();
 
     if (_runningUnitTests || _simpleBootTest) {

--- a/test/MissionManager/MissionCommandTreeEditorTest.cc
+++ b/test/MissionManager/MissionCommandTreeEditorTest.cc
@@ -47,7 +47,7 @@ void MissionCommandTreeEditorTest::_testEditorsWorker(QGCMAVLinkTypes::FirmwareC
                               vehicleClassString));
     qmlAppEngine->load(QUrl(QStringLiteral("qrc:/qml/MissionCommandTreeEditorTestWindow.qml")));
     QVERIFY_TRUE_WAIT(!qmlAppEngine->rootObjects().isEmpty(), TestTimeout::mediumMs());
-    delete qmlAppEngine;
+    QGCCorePlugin::instance()->destroyQmlApplicationEngine(qmlAppEngine);
 }
 
 void MissionCommandTreeEditorTest::testEditors()

--- a/test/QmlUITests/QmlUITestBase.cc
+++ b/test/QmlUITests/QmlUITestBase.cc
@@ -202,7 +202,7 @@ void QmlUITestBase::destroyUIEngine()
         QCoreApplication::processEvents();
     }
     qgcApp()->setQmlAppEngine(nullptr);
-    delete _engine;
+    QGCCorePlugin::instance()->destroyQmlApplicationEngine(_engine);
     _engine   = nullptr;
     _window   = nullptr;
     _rootItem = nullptr;


### PR DESCRIPTION
## Summary

Adds `QGCCorePlugin::destroyQmlApplicationEngine()` as the symmetric counterpart to `createQmlApplicationEngine()`. Engines obtained from the create hook are now destroyed through the plugin, so it can release any per-engine state it attached at creation (url interceptors, etc) before the engine goes away.

- `QGCApplication` shutdown and the QML test harnesses destroy the engine through the hook instead of `delete`.
- The custom-example plugin uses it to release its url interceptor, replacing the previous `cleanup()` approach.
