### PR TITLE
Gimbal: help tell multiple gimbal managers apart

### DIFF
--- a/src/Toolbar/GimbalIndicator.qml
+++ b/src/Toolbar/GimbalIndicator.qml
@@ -32,6 +32,12 @@ Item {
 
     property var _gimbalControllerSettings: QGroundControl.settingsManager.gimbalControllerSettings
 
+    /// Names a gimbal as "<manager compid>-<device id>", e.g. "154-1", so that gimbals
+    /// belonging to different managers can be told apart.
+    function gimbalName(gimbal) {
+        return gimbal ? (gimbal.managerCompid.valueString + "-" + gimbal.deviceId.valueString) : ""
+    }
+
     QGCPalette { id: qgcPal }
 
     Row {
@@ -61,7 +67,7 @@ Item {
                 id:                     gimbalIdLabel
                 anchors.horizontalCenter: parent.horizontalCenter
                 font.pointSize:         ScreenTools.smallFontPointSize
-                text:                   activeGimbal ? (activeGimbal.managerCompid.valueString + "-" + activeGimbal.deviceId.valueString) : ""
+                text:                   control.gimbalName(activeGimbal)
                 color:                  qgcPal.text
                 visible:                multiGimbalSetup
             }
@@ -141,7 +147,7 @@ Item {
                         let activeIndex = -1
                         for (var i = 0; i < gimbals.count; i++) {
                             var gimbal = gimbals.get(i)
-                            gimbalModel.push(qsTr("Gimbal %1-%2").arg(gimbal.managerCompid.valueString).arg(gimbal.deviceId.valueString))
+                            gimbalModel.push(qsTr("Gimbal %1").arg(control.gimbalName(gimbal)))
                             if (gimbal === activeGimbal) {
                                 activeIndex = i
                             }

--- a/src/Toolbar/GimbalIndicator.qml
+++ b/src/Toolbar/GimbalIndicator.qml
@@ -61,7 +61,7 @@ Item {
                 id:                     gimbalIdLabel
                 anchors.horizontalCenter: parent.horizontalCenter
                 font.pointSize:         ScreenTools.smallFontPointSize
-                text:                   activeGimbal ? activeGimbal.deviceId.rawValue : ""
+                text:                   activeGimbal ? (activeGimbal.managerCompid.valueString + "-" + activeGimbal.deviceId.valueString) : ""
                 color:                  qgcPal.text
                 visible:                multiGimbalSetup
             }
@@ -141,7 +141,7 @@ Item {
                         let activeIndex = -1
                         for (var i = 0; i < gimbals.count; i++) {
                             var gimbal = gimbals.get(i)
-                            gimbalModel.push(qsTr("Gimbal %1").arg(gimbal.deviceId.valueString))
+                            gimbalModel.push(qsTr("Gimbal %1-%2").arg(gimbal.managerCompid.valueString).arg(gimbal.deviceId.valueString))
                             if (gimbal === activeGimbal) {
                                 activeIndex = i
                             }


### PR DESCRIPTION
## Description

When we have more than one gimbal manager in the system, it is not clear which gimbal is which.

For example:
- Autopilot with internal gimbal (compid 1, gimbal device 1)
- External Mavlink gimbal manager (compid 154, gimbal device 1)

Previously, both of these gimbals would show as "Gimbal 1".

With this change, they show up as "Gimbal 1-1" and "Gimbal 154-1".

## Type of Change
<!-- Put an 'x' in the relevant boxes -->
- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] CI/Build changes
- [ ] Other

## Testing
<!-- Describe the tests you ran and how to reproduce them -->
- [x] Tested locally
- [ ] Added/updated unit tests
- [x] Tested with simulator (SITL)
- [ ] Tested with hardware

### Platforms Tested
<!-- Check all that apply -->
- [x] Linux
- [ ] Windows
- [ ] macOS
- [ ] Android
- [ ] iOS

### Flight Stacks Tested
<!-- If applicable -->
- [x] PX4
- [ ] ArduPilot

## Screenshots
<!-- If applicable, add screenshots to help explain your changes -->

## Checklist
<!-- Go over all the following points, and put an 'x' in all the boxes that apply -->
- [x] I have read the [Contribution Guidelines](CONTRIBUTING.md)
- [x] I have read the [Code of Conduct](CODE_OF_CONDUCT.md)
- [x] My code follows the project's coding standards
- [ ] I have added tests that prove my fix/feature works
- [ ] New and existing unit tests pass locally

## Related Issues
<!-- Link any related issues using #issue_number -->

---
By submitting this pull request, I confirm that my contribution is made under the terms of the project's dual license (Apache 2.0 and GPL v3).
