### PR TITLE
fix(Joystick): match actual update rate to joystick setting

### DIFF
--- a/src/Joystick/Joystick.cc
+++ b/src/Joystick/Joystick.cc
@@ -935,7 +935,7 @@ uint16_t Joystick::_adjustRangeToRcOverridePwm(int value, const AxisCalibration_
 void Joystick::_handleAxis()
 {
     const int axisDelay = static_cast<int>(1000.0 / _joystickSettings.axisFrequencyHz()->rawValue().toDouble());
-    if (_axisElapsedTimer.elapsed() <= axisDelay) {
+    if (!_axisUpdateDue(_axisElapsedTimer.elapsed(), axisDelay)) {
         return;
     }
 

--- a/src/Joystick/Joystick.h
+++ b/src/Joystick/Joystick.h
@@ -448,6 +448,8 @@ private:
     void _addAvailableButtonActionIfMissing(const QString &action);
     bool _validAxis(int axis) const;
     bool _validButton(int button) const;
+
+    static constexpr bool _axisUpdateDue(qint64 elapsed, int delay) { return elapsed >= delay; }
     void _handleAxis();
     void _handleButtons();
     void _buildAvailableButtonsActionList(Vehicle *vehicle);

--- a/test/Joystick/JoystickTest.cc
+++ b/test/Joystick/JoystickTest.cc
@@ -186,6 +186,13 @@ void JoystickTest::_axisRangeTest()
     QVERIFY(js != nullptr);
 }
 
+void JoystickTest::_axisUpdateDueTest()
+{
+    QVERIFY(!Joystick::_axisUpdateDue(39, 40));
+    QVERIFY(Joystick::_axisUpdateDue(40, 40));
+    QVERIFY(Joystick::_axisUpdateDue(41, 40));
+}
+
 //-----------------------------------------------------------------------------
 // Button Tests
 //-----------------------------------------------------------------------------

--- a/test/Joystick/JoystickTest.h
+++ b/test/Joystick/JoystickTest.h
@@ -34,6 +34,7 @@ private slots:
     // Axis reading tests
     void _readAxisValuesTest();
     void _axisRangeTest();
+    void _axisUpdateDueTest();
 
     // Button reading tests
     void _readButtonStatesTest();


### PR DESCRIPTION
## Bug Description

The joystick's actual axis update rate can be lower than the value configured in **Axis frequency**. With the default 25 Hz setting, the configured interval is 40 ms, but an update at exactly 40 ms was rejected.

## Root Cause

The polling thread checks joystick state approximately every 20 ms. `_handleAxis()` returned while the elapsed time was *less than or equal to* the configured interval. A poll at exactly 40 ms was therefore skipped and the update could be delayed until the next poll, around 60 ms.

## Solution

Treat the configured interval as inclusive: an axis update is due when `elapsed >= delay`. A deterministic regression test covers the boundary at 39, 40, and 41 ms.

## Testing

- [x] Tested locally
- [x] Added regression test
- [ ] Tested with simulator (SITL)
- [ ] Tested with hardware

Validation performed:

- Debug build completed successfully.
- All joystick-labelled unit tests pass (4/4).
- Relevant repository policy hooks and changed-line clang-format checks pass.
- The full Unit label passes 193/194 tests. The unrelated `BluetoothWorkerTest` fails because the host BlueZ backend emits an unexpected warning for the test's invalid Bluetooth address; the failure reproduces when that test is run alone.

### Platforms Tested

- [x] Linux
- [ ] Windows
- [ ] macOS
- [ ] Android
- [ ] iOS

### Flight Stacks Tested

- [ ] PX4
- [ ] ArduPilot
- [x] N/A

## Checklist

- [x] I have read the [Contribution Guidelines](../CONTRIBUTING.md)
- [x] My code follows the project's coding standards
- [x] I have added a test that reproduces the bug
- [ ] New and existing unit tests pass locally (193/194; unrelated Bluetooth failure described above)

---
By submitting this pull request, I confirm that my contribution is made under the terms of the project's dual license (Apache 2.0 and GPL v3).
