### PR TITLE
chore(pre-commit): align vale-sync pin with vale hook version

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -156,7 +156,7 @@ repos:
         # install of the bare module fails and aborts the whole pre-commit run before any hook
         # fires.
         additional_dependencies:
-          - 'github.com/errata-ai/vale/v3/cmd/vale@v3.14.2'
+          - 'github.com/errata-ai/vale/v3/cmd/vale@v3.15.1'
         entry: vale sync
         files: ^(docs/|\.vale\.ini$)
         pass_filenames: false


### PR DESCRIPTION
Follow-up to #14753.

`vale-sync` installed `github.com/errata-ai/vale/v3/cmd/vale@v3.14.2` while the `vale` lint hook uses repo rev `v3.15.1`, so styles were synced with a different vale version than the one that lints. This bumps the `vale-sync` dependency to `v3.15.1` to keep the two pins in lockstep.

Verified locally: hook environments rebuilt from scratch (`pre-commit clean`), `vale-sync` passes with the new pin.
