### PR TITLE
chore(pre-commit): align vale-sync pin with vale hook version (5.1)

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -156,7 +156,7 @@ repos:
         # install of the bare module fails and aborts the whole pre-commit run before any hook
         # fires.
         additional_dependencies:
-          - 'github.com/errata-ai/vale/v3/cmd/vale@v3.14.2'
+          - 'github.com/errata-ai/vale/v3/cmd/vale@v3.15.1'
         entry: vale sync
         files: ^(docs/|\.vale\.ini$)
         pass_filenames: false


### PR DESCRIPTION
Cherry-pick of #14798 to Stable_V5.1.

Depends on #14799 (stacked on the vale-sync backport branch).
