### PR TITLE
feat(GeoView): drape real map imagery and terrain onto the surface mesh

### DIFF
--- a/src/GeoView/CMakeLists.txt
+++ b/src/GeoView/CMakeLists.txt
@@ -9,6 +9,10 @@ target_sources(${CMAKE_PROJECT_NAME}
         HeightSource.h
         SurfaceModel.cc
         SurfaceModel.h
+        TerrainHeightSource.cc
+        TerrainHeightSource.h
+        TileImageSource.cc
+        TileImageSource.h
         TileMath.cc
         TileMath.h
 )
@@ -27,10 +31,14 @@ qt_add_qml_module(GeoViewModule
     SOURCES
         CheckerboardTextureData.cc
         CheckerboardTextureData.h
+        GeoScene.cc
+        GeoScene.h
         GeoViewCamera.cc
         GeoViewCamera.h
         PatchGeometry.cc
         PatchGeometry.h
+        PatchTextureData.cc
+        PatchTextureData.h
         SurfacePatchModel.cc
         SurfacePatchModel.h
     QML_FILES

--- a/src/GeoView/GeoScene.cc
+++ b/src/GeoView/GeoScene.cc
@@ -1,0 +1,83 @@
+/****************************************************************************
+ *
+ * (c) 2009-2024 QGROUNDCONTROL PROJECT <http://www.qgroundcontrol.org>
+ *
+ * QGroundControl is licensed according to the terms in the file
+ * COPYING.md in the root of the source code directory.
+ *
+ ****************************************************************************/
+
+#include "GeoScene.h"
+
+#include <cmath>
+
+#include "GeoViewCamera.h"
+#include "TileMath.h"
+
+GeoScene::GeoScene(QObject* parent) : QObject(parent) {}
+
+void GeoScene::setCamera(GeoViewCamera* camera)
+{
+    if (camera == _camera) {
+        return;
+    }
+    if (_camera) {
+        disconnect(_camera, nullptr, this, nullptr);
+    }
+    _camera = camera;
+    _originSet = false;  // new camera anchors fresh; a stale origin breaks float precision silently
+
+    if (_camera) {
+        connect(_camera, &GeoViewCamera::centerChanged, this, &GeoScene::_maybeReanchor);
+        connect(_camera, &QObject::destroyed, this, [this] {
+            _camera = nullptr;
+            _originSet = false;
+            emit cameraChanged();
+        });
+        // Anchor before announcing: cameraChanged listeners must never see an
+        // origin inconsistent with the new camera
+        _maybeReanchor();
+    }
+    emit cameraChanged();
+}
+
+qreal GeoScene::verticalScale() const
+{
+    return TileMath::mercatorScale(TileMath::worldToGeo(_origin).latitude());
+}
+
+QVector3D GeoScene::scenePositionFor(const QGeoCoordinate& coordinate) const
+{
+    const QPointF world = TileMath::geoToWorld(coordinate);
+    const double altitude = std::isfinite(coordinate.altitude()) ? coordinate.altitude() : 0.0;
+    return QVector3D(static_cast<float>(world.x() - _origin.x()), static_cast<float>(world.y() - _origin.y()),
+                     static_cast<float>(altitude * verticalScale()));
+}
+
+QVariant GeoScene::screenPositionFor(const QGeoCoordinate& coordinate) const
+{
+    if (!_camera) {
+        return {};
+    }
+    const QPointF world = TileMath::geoToWorld(coordinate);
+    const double altitude = std::isfinite(coordinate.altitude()) ? coordinate.altitude() : 0.0;
+    const auto screen = _camera->worldToScreen(world, altitude * verticalScale());
+    return screen ? QVariant(*screen) : QVariant();
+}
+
+void GeoScene::_maybeReanchor()
+{
+    if (!_camera) {
+        return;
+    }
+    const QPointF cameraWorld = TileMath::geoToWorld(_camera->center());
+    if (_originSet) {
+        const QPointF offset = cameraWorld - _origin;
+        if (QPointF::dotProduct(offset, offset) < (kReanchorDistance * kReanchorDistance)) {
+            return;
+        }
+    }
+    _origin = cameraWorld;
+    _originSet = true;
+    emit sceneOriginChanged();
+}

--- a/src/GeoView/GeoScene.h
+++ b/src/GeoView/GeoScene.h
@@ -1,0 +1,83 @@
+/****************************************************************************
+ *
+ * (c) 2009-2024 QGROUNDCONTROL PROJECT <http://www.qgroundcontrol.org>
+ *
+ * QGroundControl is licensed according to the terms in the file
+ * COPYING.md in the root of the source code directory.
+ *
+ ****************************************************************************/
+
+#pragma once
+
+#include <QtCore/QObject>
+#include <QtCore/QPointF>
+#include <QtCore/QVariant>
+#include <QtGui/QVector3D>
+#include <QtPositioning/QGeoCoordinate>
+#include <QtQmlIntegration/QtQmlIntegration>
+
+class GeoViewCamera;
+
+Q_MOC_INCLUDE("GeoViewCamera.h")
+
+/// Owns the scene-space definition shared by everything GeoView renders.
+///
+/// Scene coordinates are world mercator meters relative to sceneOrigin. The
+/// origin re-anchors to the camera center whenever the camera strays more than
+/// kReanchorDistance from it, keeping scene coordinates small enough for the
+/// renderer's float precision.
+///
+/// All renderable content (surface patches, and later map items such as
+/// vehicles, flight paths, and mission markers) must place itself through this
+/// one origin so everything shifts consistently on re-anchor.
+class GeoScene : public QObject
+{
+    Q_OBJECT
+    QML_ELEMENT
+    Q_PROPERTY(GeoViewCamera* camera READ camera WRITE setCamera NOTIFY cameraChanged)
+    Q_PROPERTY(QPointF sceneOrigin READ sceneOrigin NOTIFY sceneOriginChanged)
+    Q_PROPERTY(qreal verticalScale READ verticalScale NOTIFY sceneOriginChanged)
+
+public:
+    explicit GeoScene(QObject* parent = nullptr);
+
+    static constexpr double kReanchorDistance = 50000.0;  ///< scene-origin re-anchor threshold (m)
+
+    GeoViewCamera* camera() const { return _camera; }
+
+    void setCamera(GeoViewCamera* camera);
+
+    /// Until a camera anchors the scene, the origin is the mercator origin
+    /// (0, 0): results stay well-defined but are not precision-safe far from
+    /// it. If the camera goes away, the origin retains its last anchor.
+    QPointF sceneOrigin() const { return _origin; }
+
+    /// Mercator scale factor at the scene origin: heights and altitudes are
+    /// true meters, but scene x/y are mercator meters (stretched by
+    /// 1/cos(lat)). Rendering must scale z by this factor or geometry appears
+    /// vertically squashed away from the equator.
+    qreal verticalScale() const;
+
+    /// Scene position for a geographic coordinate (double math internally;
+    /// once a camera has anchored the origin the result is origin-relative
+    /// and small enough for floats). Altitude (true meters, NaN treated as 0)
+    /// lands on z scaled to scene units.
+    Q_INVOKABLE QVector3D scenePositionFor(const QGeoCoordinate& coordinate) const;
+
+    /// Screen position (pixels) of a geographic coordinate through the
+    /// camera. Invalid QVariant when there is no camera or the point is at or
+    /// behind the camera plane.
+    Q_INVOKABLE QVariant screenPositionFor(const QGeoCoordinate& coordinate) const;
+
+signals:
+    void cameraChanged();
+    void sceneOriginChanged();
+
+private slots:
+    void _maybeReanchor();
+
+private:
+    GeoViewCamera* _camera = nullptr;
+    QPointF _origin;
+    bool _originSet = false;
+};

--- a/src/GeoView/GeoView.qml
+++ b/src/GeoView/GeoView.qml
@@ -76,19 +76,30 @@ Item {
                 id: geoCamera
                 objectName: "geoViewCamera"
                 viewportSize: Qt.size(sceneRoot.width, sceneRoot.height)
-                sceneOrigin: patchModel.sceneOrigin
-                Component.onCompleted: {
-                    // Startup pose: overhead view of the mercator origin at
-                    // default distance (home-position integration comes later)
-                    lookAt(QtPositioning.coordinate(0, 0), 0, 0, 1500)
-                }
+                sceneOrigin: geoScene.sceneOrigin
+                // Startup pose: overhead view of a land area with terrain relief so
+                // imagery and elevation are visually verifiable (home-position
+                // integration comes later). Until this center applies, the camera is
+                // unpositioned and SurfaceModel builds nothing (see
+                // GeoViewCamera::isPositioned), so the null-island default pose never
+                // triggers doomed terrain fetches at (0,0).
+                center: QtPositioning.coordinate(47.6329078, -122.0876875)
+            }
+
+            GeoScene {
+                id: geoScene
+                objectName: "geoViewScene"
+                camera: geoCamera
             }
 
             SurfacePatchModel {
                 id: patchModel
                 objectName: "geoViewPatchModel"
-                camera: geoCamera
-                debugHills: true
+                scene: geoScene
+                terrain: true
+                // Drape the map imagery the rest of QGC uses (empty disables imagery)
+                mapType: QGroundControl.settingsManager.flightMapSettings.mapProvider.rawValue
+                         + " " + QGroundControl.settingsManager.flightMapSettings.mapType.rawValue
             }
 
             View3D {
@@ -99,6 +110,15 @@ Item {
                 environment: SceneEnvironment {
                     clearColor: "#1a2028"
                     backgroundMode: SceneEnvironment.Color
+                    // Distance haze toward the background color hides the far-field
+                    // LOD rings (terrain blend band and patch range edge)
+                    fog: Fog {
+                        enabled: true
+                        color: "#1a2028"
+                        depthEnabled: true
+                        depthNear: 10 * geoCamera.distance
+                        depthFar: (patchModel.maxRangeMultiplier + 1) * geoCamera.distance
+                    }
                 }
 
                 DirectionalLight {
@@ -121,7 +141,8 @@ Item {
                     clipFar: Math.max(100000, geoCamera.distance * (patchModel.maxRangeMultiplier + 1))
                 }
 
-                // One surface patch per active SurfaceModel entry, LOD-colored
+                // One surface patch per active SurfaceModel entry: draped tile
+                // imagery once delivered, LOD-colored fallback while loading
                 Repeater3D {
                     model: patchModel
                     delegate: Model {
@@ -132,24 +153,48 @@ Item {
                         required property real span
                         required property int zoomLevel
                         required property var heights
+                        required property bool covered
+                        required property var tileImage
+                        required property bool hasTileImage
 
+                        // A covered pending patch stays hidden: its empty flat grid
+                        // would z-fight the retained retiring cover
+                        visible: !covered
                         position: Qt.vector3d(centerX, centerY, 0)
                         // z-scale converts true-meter heights into mercator scene units
                         // (verticalScale) and animates terrain flat<->full during the
                         // 2D/3D mode transition (terrainScale) without geometry rebuilds.
                         // Never exactly 0: a singular scale breaks the normal matrix.
-                        scale: Qt.vector3d(1, 1, Math.max(0.0001, sceneRoot.terrainScale * patchModel.verticalScale))
+                        scale: Qt.vector3d(1, 1, Math.max(0.0001, sceneRoot.terrainScale * geoScene.verticalScale))
                         geometry: PatchGeometry {
                             gridSize: patchModel.gridSize
                             span: patchDelegate.span
                             heights: patchDelegate.heights
                         }
+
+                        Texture {
+                            id: patchTexture
+                            textureData: PatchTextureData {
+                                image: patchDelegate.tileImage
+                            }
+                        }
+
                         materials: [
                             DefaultMaterial {
                                 cullMode: Material.NoCulling
-                                // Hue by zoom level (LOD rings), lightness by tile checker
-                                // parity so same-zoom patch boundaries are visible
+                                // Unlit: tiles carry their own shading, and lighting
+                                // would show the per-patch normal seams
+                                lighting: DefaultMaterial.NoLighting
+                                diffuseMap: patchDelegate.hasTileImage ? patchTexture : null
+                                // Loading fallback: quiet neutral when imagery is on
+                                // (LOD flash on zoom); LOD checker colors in debug mode
                                 diffuseColor: {
+                                    if (patchDelegate.hasTileImage) {
+                                        return "white"
+                                    }
+                                    if (patchModel.mapType !== "") {
+                                        return "#3a4048"
+                                    }
                                     const parity = (Math.round(patchDelegate.centerX / patchDelegate.span)
                                                     + Math.round(patchDelegate.centerY / patchDelegate.span)) & 1
                                     return Qt.hsla((patchDelegate.zoomLevel * 0.13) % 1.0, 0.5,
@@ -303,17 +348,6 @@ Item {
                         headingAnimation.to = (geoCamera.heading > 180) ? 360 : 0
                         headingAnimation.start()
                     }
-                }
-
-                // Dev toggle: analytic sin-hill heights (on by default) to visually
-                // verify terrain displacement and LOD before real terrain data lands.
-                // One-way button -> model: this is the sole writer of debugHills
-                QGCButton {
-                    objectName: "geoViewHillsButton"
-                    text: qsTr("Hills")
-                    checkable: true
-                    checked: true
-                    onClicked: patchModel.debugHills = checked
                 }
             }
         }

--- a/src/GeoView/GeoViewCamera.cc
+++ b/src/GeoView/GeoViewCamera.cc
@@ -86,7 +86,9 @@ void GeoViewCamera::_setCenterWorld(const QPointF& world)
 {
     const double half = TileMath::worldSize() / 2.0;
     const QPointF clamped(std::clamp(world.x(), -half, half), std::clamp(world.y(), -half, half));
-    if (clamped == _centerWorld) {
+    const bool firstPosition = !_positioned;
+    _positioned = true;  // any explicit center counts, even one equal to the default
+    if ((clamped == _centerWorld) && !firstPosition) {
         return;
     }
     _centerWorld = clamped;
@@ -250,6 +252,35 @@ std::optional<QPointF> GeoViewCamera::groundPointCapped(const QPointF& screenPos
         return cameraGround;  // straight up
     }
     return cameraGround + (QPointF(ray.dir.x, ray.dir.y) * (maxRange / horizontal));
+}
+
+std::optional<QPointF> GeoViewCamera::worldToScreen(const QPointF& worldGround, double worldZ) const
+{
+    if (_viewportSize.isEmpty()) {
+        return std::nullopt;
+    }
+
+    const Vec3 offset = cameraOffset(_heading, _tilt, _distance);
+    const Vec3 d{worldGround.x() - (_centerWorld.x() + offset.x), worldGround.y() - (_centerWorld.y() + offset.y),
+                 worldZ - offset.z};
+
+    // World-to-camera: inverse of the pose rotation, R^T = Rx(-tilt) * Rz(-heading)
+    const double h = qDegreesToRadians(_heading);
+    const double t = qDegreesToRadians(_tilt);
+    const Vec3 a{(d.x * std::cos(h)) + (d.y * std::sin(h)), (-d.x * std::sin(h)) + (d.y * std::cos(h)), d.z};
+    const Vec3 c{a.x, (a.y * std::cos(t)) + (a.z * std::sin(t)), (-a.y * std::sin(t)) + (a.z * std::cos(t))};
+
+    // Camera looks along -z; the epsilon guards the projection divide (not a near plane)
+    const double depth = -c.z;
+    if (depth <= 1e-9) {
+        return std::nullopt;
+    }
+
+    const double aspect = _viewportSize.width() / _viewportSize.height();
+    const double tanHalfFov = std::tan(qDegreesToRadians(_fieldOfView) / 2.0);
+    const double ndcX = c.x / (depth * tanHalfFov * aspect);
+    const double ndcY = c.y / (depth * tanHalfFov);
+    return QPointF(((ndcX + 1.0) / 2.0) * _viewportSize.width(), ((1.0 - ndcY) / 2.0) * _viewportSize.height());
 }
 
 qreal GeoViewCamera::sceneUnitsPerPixel() const

--- a/src/GeoView/GeoViewCamera.h
+++ b/src/GeoView/GeoViewCamera.h
@@ -70,6 +70,11 @@ public:
     QGeoCoordinate center() const;
     void setCenter(const QGeoCoordinate& center);
 
+    /// False until the camera is explicitly positioned (setCenter/lookAt). The
+    /// construction-default pose is null island; consumers must not treat it as
+    /// a real location (e.g. by fetching terrain there).
+    bool isPositioned() const { return _positioned; }
+
     qreal heading() const { return _heading; }
 
     void setHeading(qreal heading);
@@ -162,7 +167,7 @@ public:
     QPointF cameraGroundPosition() const;
 
     /// World-space reference origin for scene coordinates (set by the renderer,
-    /// normally bound to SurfacePatchModel::sceneOrigin)
+    /// normally bound to GeoScene::sceneOrigin)
     QPointF sceneOrigin() const { return _sceneOrigin; }
 
     void setSceneOrigin(const QPointF& origin);
@@ -186,6 +191,11 @@ public:
     /// only when the viewport is not set.
     std::optional<QPointF> groundPointCapped(const QPointF& screenPos, double maxRange) const;
 
+    /// Projects a world-space point (mercator meters, z in scene units) to screen
+    /// pixels. Double precision throughout. Returns std::nullopt when the point is
+    /// at or behind the camera plane or the viewport is not set.
+    std::optional<QPointF> worldToScreen(const QPointF& worldGround, double worldZ = 0.0) const;
+
 signals:
     void centerChanged();
     void headingChanged();
@@ -205,6 +215,7 @@ private:
     static qreal _normalizedHeading(qreal heading);
 
     QPointF _centerWorld;  // mercator meters
+    bool _positioned = false;
     QPointF _sceneOrigin;  // mercator meters
     Mode _mode = Mode::Mode2D;
     qreal _heading = 0.0;

--- a/src/GeoView/HeightSource.h
+++ b/src/GeoView/HeightSource.h
@@ -22,8 +22,7 @@
 /// the north-west corner. Results are always delivered asynchronously (queued), even
 /// for sources that can answer immediately, so consumers see one consistent flow.
 ///
-/// Designed so a future TerrainHeightSource can adapt QGC's terrain query backend
-/// (TerrainQueryInterface::requestCoordinateHeights) behind the same interface.
+/// TerrainHeightSource adapts QGC's terrain query backend behind this interface.
 class HeightSource : public QObject
 {
     Q_OBJECT

--- a/src/GeoView/PatchTextureData.cc
+++ b/src/GeoView/PatchTextureData.cc
@@ -1,0 +1,39 @@
+/****************************************************************************
+ *
+ * (c) 2009-2024 QGROUNDCONTROL PROJECT <http://www.qgroundcontrol.org>
+ *
+ * QGroundControl is licensed according to the terms in the file
+ * COPYING.md in the root of the source code directory.
+ *
+ ****************************************************************************/
+
+#include "PatchTextureData.h"
+
+PatchTextureData::PatchTextureData(QQuick3DObject* parent) : QQuick3DTextureData(parent) {}
+
+void PatchTextureData::setImage(const QImage& image)
+{
+    if (image == _image) {
+        return;
+    }
+    _image = image;
+    emit imageChanged();
+    _rebuild();
+}
+
+void PatchTextureData::_rebuild()
+{
+    if (_image.isNull()) {
+        setSize(QSize());
+        setTextureData(QByteArray());
+        return;
+    }
+
+    const QImage converted = _image.convertToFormat(QImage::Format_RGBA8888);
+    setSize(converted.size());
+    setFormat(QQuick3DTextureData::RGBA8);
+    // The conversion always yields an alpha channel; only the source knows opacity
+    setHasTransparency(_image.hasAlphaChannel());
+    // Deep copy: the converted image's buffer dies with this scope
+    setTextureData(QByteArray(reinterpret_cast<const char*>(converted.constBits()), converted.sizeInBytes()));
+}

--- a/src/GeoView/PatchTextureData.h
+++ b/src/GeoView/PatchTextureData.h
@@ -1,0 +1,38 @@
+/****************************************************************************
+ *
+ * (c) 2009-2024 QGROUNDCONTROL PROJECT <http://www.qgroundcontrol.org>
+ *
+ * QGroundControl is licensed according to the terms in the file
+ * COPYING.md in the root of the source code directory.
+ *
+ ****************************************************************************/
+
+#pragma once
+
+#include <QtGui/QImage>
+#include <QtQuick3D/QQuick3DTextureData>
+
+/// Feeds a QImage (a map tile from SurfacePatchModel's tileImage role) to a
+/// Qt Quick 3D Texture. A null image produces an empty texture; consumers
+/// switch materials on image validity rather than rendering it.
+class PatchTextureData : public QQuick3DTextureData
+{
+    Q_OBJECT
+    QML_ELEMENT
+    Q_PROPERTY(QImage image READ image WRITE setImage NOTIFY imageChanged)
+
+public:
+    explicit PatchTextureData(QQuick3DObject* parent = nullptr);
+
+    QImage image() const { return _image; }
+
+    void setImage(const QImage& image);
+
+signals:
+    void imageChanged();
+
+private:
+    void _rebuild();
+
+    QImage _image;
+};

--- a/src/GeoView/SurfaceModel.cc
+++ b/src/GeoView/SurfaceModel.cc
@@ -1,6 +1,7 @@
 #include "SurfaceModel.h"
 
 #include <QtCore/QSet>
+#include <QtCore/QTimer>
 #include <QtCore/QVarLengthArray>
 #include <QtCore/QtMath>
 #include <cmath>
@@ -39,6 +40,9 @@ SurfaceModel::SurfaceModel(GeoViewCamera* camera, HeightSource* heightSource, QO
 
 void SurfaceModel::update()
 {
+    if (!_camera->isPositioned()) {
+        return;  // the default pose is null island; building patches there fires doomed terrain fetches
+    }
     if (_camera->viewportSize().isEmpty()) {
         return;  // keep the last valid set; transient 0-size viewports occur during layout
     }
@@ -51,19 +55,31 @@ void SurfaceModel::update()
 
     QSet<TileMath::TileKey> desiredSet(desired.cbegin(), desired.cend());
 
-    // Drop patches no longer desired, cancelling in-flight height requests.
-    // Only pending patches own a tracked request: _heightsReady untracks the
-    // id when a patch becomes ready (guard also protects against a future
-    // source reusing ids).
+    // Drop pending patches no longer desired, cancelling in-flight height
+    // requests. Ready patches being replaced retire instead: they keep
+    // rendering until their replacements have heights, so LOD churn and
+    // panning never open holes in the surface.
     for (auto it = _patches.begin(); it != _patches.end();) {
         if (desiredSet.contains(it.key())) {
+            it.value().retiring = false;  // re-desired while retiring: it is ready, keep as-is
             ++it;
             continue;
         }
-        if (!it.value().ready) {
-            _heightSource->cancelRequest(it.value().requestId);
-            _requestKeys.remove(it.value().requestId);
+        if (it.value().retiring) {
+            ++it;  // awaiting sweep
+            continue;
         }
+        if (it.value().ready) {
+            it.value().retiring = true;
+            ++it;
+            continue;
+        }
+        // Pending patches own a tracked request, except while awaiting a retry
+        // (requestId 0, never issued by a source): then both calls are no-ops.
+        // _heightsReady untracks the id when a patch becomes ready (guard also
+        // protects against a future source reusing ids).
+        _heightSource->cancelRequest(it.value().requestId);
+        _requestKeys.remove(it.value().requestId);
         const TileMath::TileKey removedKey = it.key();
         it = _patches.erase(it);
         emit patchRemoved(removedKey);
@@ -80,6 +96,8 @@ void SurfaceModel::update()
         _patches.insert(key, data);
         emit patchAdded(key);
     }
+
+    _sweepRetiring();
 }
 
 QList<SurfaceModel::Patch> SurfaceModel::patches() const
@@ -87,7 +105,7 @@ QList<SurfaceModel::Patch> SurfaceModel::patches() const
     QList<Patch> result;
     result.reserve(_patches.count());
     for (auto it = _patches.cbegin(); it != _patches.cend(); ++it) {
-        result.append(Patch{it.key(), it.value().heights, it.value().ready});
+        result.append(Patch{it.key(), it.value().heights, it.value().ready, _isCovered(it.key(), it.value())});
     }
     return result;
 }
@@ -98,7 +116,25 @@ std::optional<SurfaceModel::Patch> SurfaceModel::patch(const TileMath::TileKey& 
     if (it == _patches.constEnd()) {
         return std::nullopt;
     }
-    return Patch{key, it.value().heights, it.value().ready};
+    return Patch{key, it.value().heights, it.value().ready, _isCovered(key, it.value())};
+}
+
+bool SurfaceModel::_isCovered(const TileMath::TileKey& key, const PatchData& data) const
+{
+    if (data.ready) {
+        return false;
+    }
+    // A pending patch overlapped by ready geometry (its retiring ancestor,
+    // descendants, or a degraded flat fallback) is covered: rendering its
+    // empty flat grid too would z-fight the cover and occlude terrain below
+    // sea level
+    const QRectF rect = patchRect(key);
+    for (auto it = _patches.cbegin(); it != _patches.cend(); ++it) {
+        if (it.value().ready && (it.key() != key) && rect.intersects(patchRect(it.key()))) {
+            return true;
+        }
+    }
+    return false;
 }
 
 int SurfaceModel::pendingCount() const
@@ -246,10 +282,75 @@ void SurfaceModel::_heightsReady(int requestId, const QList<float>& heights)
     patchIt.value().heights = heights;
     patchIt.value().ready = true;
     emit patchReady(key);
+    _sweepRetiring();
+}
+
+void SurfaceModel::_sweepRetiring()
+{
+    // A retiring patch may go once every pending patch it covers for has its
+    // heights (or it covers for none, e.g. it was panned out of the view)
+    for (auto it = _patches.begin(); it != _patches.end();) {
+        if (!it.value().retiring || _overlapsPendingPatch(it.key())) {
+            ++it;
+            continue;
+        }
+        const TileMath::TileKey key = it.key();
+        it = _patches.erase(it);
+        emit patchRemoved(key);
+    }
+}
+
+bool SurfaceModel::_overlapsPendingPatch(const TileMath::TileKey& key) const
+{
+    const QRectF rect = patchRect(key);
+    for (auto it = _patches.cbegin(); it != _patches.cend(); ++it) {
+        // Touching edges do not intersect, so only true overlaps (the
+        // quadtree ancestor/descendant replacements) count. Desired degraded
+        // patches still need cover: their flat fallback is worse than the
+        // cover. Retiring patches never do (they are on their way out) -
+        // otherwise a retiring degraded patch would retain itself forever.
+        if (it.value().retiring) {
+            continue;
+        }
+        if ((!it.value().ready || it.value().degraded) && rect.intersects(patchRect(it.key()))) {
+            return true;
+        }
+    }
+    return false;
 }
 
 void SurfaceModel::_heightsFailed(int requestId)
 {
-    // Degrade to flat ground (empty heights); a later cull/re-add retries naturally
+    const auto it = _requestKeys.constFind(requestId);
+    if (it == _requestKeys.constEnd()) {
+        return;  // patch was dropped before delivery
+    }
+    const auto patchIt = _patches.find(it.value());
+    if ((patchIt != _patches.end()) && !patchIt.value().ready && (patchIt.value().retriesLeft > 0)) {
+        // Transient failures (elevation tile fetch timeouts) self-heal: keep the
+        // patch pending and re-request after the backoff delay
+        patchIt.value().retriesLeft--;
+        patchIt.value().requestId = 0;
+        const TileMath::TileKey key = patchIt.key();
+        _requestKeys.erase(it);
+        QTimer::singleShot(_heightRetryDelayMs, this, [this, key] { _retryHeights(key); });
+        return;
+    }
+    // Retries exhausted: degrade to flat ground; a later cull/re-add starts
+    // fresh. Degraded patches keep any retiring cover (see _overlapsPendingPatch),
+    // so a real-height predecessor is not replaced by the flat fallback.
+    if (patchIt != _patches.end()) {
+        patchIt.value().degraded = true;
+    }
     _heightsReady(requestId, QList<float>());
+}
+
+void SurfaceModel::_retryHeights(const TileMath::TileKey& key)
+{
+    const auto it = _patches.find(key);
+    if ((it == _patches.end()) || it.value().ready || (it.value().requestId != 0)) {
+        return;  // dropped, delivered, or re-requested meanwhile
+    }
+    it.value().requestId = _heightSource->requestPatchHeights(key, kGridSize);
+    _requestKeys.insert(it.value().requestId, key);
 }

--- a/src/GeoView/SurfaceModel.h
+++ b/src/GeoView/SurfaceModel.h
@@ -26,8 +26,10 @@ class HeightSource;
 /// refines the quadtree by screen-space error (a patch subdivides while its
 /// projected size exceeds the refinement threshold), culls against the visible
 /// ground region, and diffs the result against the current set: new patches get
-/// height requests from the HeightSource, dropped patches get their pending
-/// requests cancelled.
+/// height requests from the HeightSource, dropped pending patches get their
+/// requests cancelled, and dropped ready patches retire - they keep rendering
+/// until the patches replacing them have heights, so LOD churn and panning
+/// never open holes in the surface.
 ///
 /// The visible ground region is estimated by sampling screen points through the
 /// camera and capping horizon misses at a distance-scaled range, so far-horizon
@@ -39,17 +41,25 @@ class SurfaceModel : public QObject
 public:
     SurfaceModel(GeoViewCamera* camera, HeightSource* heightSource, QObject* parent = nullptr);
 
-    static constexpr int kGridSize = 16;     ///< mesh cells per patch edge
-    static constexpr int kMaxPatches = 256;  ///< patch budget; refinement stays coarser rather than exceed it
+    static constexpr int kGridSize = 16;  ///< mesh cells per patch edge
+    /// Budget for the desired patch set; refinement stays coarser rather than exceed
+    /// it. The resident set can transiently exceed it while retiring patches from the
+    /// previous LOD generation cover for pending replacements (worst case ~2x).
+    static constexpr int kMaxPatches = 256;
     static constexpr double kRefinePixelThreshold = 384.0;  ///< subdivide above this projected size
     static constexpr double kMaxRangeMultiplier = 40.0;     ///< visible-range cap in camera distances
     static constexpr int kVisibleSampleGrid = 5;            ///< NxN screen samples for visible-region estimation
+    static constexpr int kMaxHeightRetries = 3;             ///< re-requests before a patch degrades to flat
+    /// Default retry delay: past TerrainTileManager's 5s failed-tile backoff so a
+    /// retry refetches instead of short-circuiting on the cached failure
+    static constexpr int kDefaultHeightRetryDelayMs = 6000;
 
     struct Patch
     {
         TileMath::TileKey key;
         QList<float> heights;  ///< (kGridSize+1)^2 entries once ready; empty = flat (pending or failed request)
         bool ready = false;
+        bool covered = false;  ///< pending and overlapped by a ready patch: suppress rendering
     };
 
     /// Recompute the active patch set from the current camera state. Called
@@ -65,6 +75,11 @@ public:
 
     int pendingCount() const;
 
+#ifdef QGC_UNITTEST_BUILD
+    /// Test hook: shortens the failed-request retry delay
+    void setHeightRetryDelayMs(int ms) { _heightRetryDelayMs = ms; }
+#endif
+
 signals:
     void patchAdded(const TileMath::TileKey& key);
     void patchReady(const TileMath::TileKey& key);
@@ -77,18 +92,26 @@ private slots:
 private:
     struct PatchData
     {
-        int requestId = 0;
+        int requestId = 0;  ///< 0 = no request in flight (awaiting retry or ready)
         QList<float> heights;
         bool ready = false;
+        bool retiring = false;  ///< ready but replaced; renders until replacements are ready
+        bool degraded = false;  ///< flat fallback after exhausted retries; keeps its retiring cover
+        int retriesLeft = kMaxHeightRetries;
     };
 
     QRectF _visibleGroundRect() const;
     double _projectedPixels(const TileMath::TileKey& key, const QPointF& cameraGround, double cameraHeight) const;
     QList<TileMath::TileKey> _desiredPatches(const QRectF& visible, const QPointF& cameraGround,
                                              double cameraHeight) const;
+    void _retryHeights(const TileMath::TileKey& key);
+    void _sweepRetiring();
+    bool _overlapsPendingPatch(const TileMath::TileKey& key) const;
+    bool _isCovered(const TileMath::TileKey& key, const PatchData& data) const;
 
     GeoViewCamera* const _camera;
     HeightSource* const _heightSource;
     QHash<TileMath::TileKey, PatchData> _patches;
     QHash<int, TileMath::TileKey> _requestKeys;
+    int _heightRetryDelayMs = kDefaultHeightRetryDelayMs;
 };

--- a/src/GeoView/SurfacePatchModel.cc
+++ b/src/GeoView/SurfacePatchModel.cc
@@ -1,35 +1,55 @@
 #include "SurfacePatchModel.h"
 
+#include <QtGui/QPainter>
 #include <algorithm>
 
+#include "GeoScene.h"
 #include "GeoViewCamera.h"
 #include "HeightSource.h"
 #include "SurfaceModel.h"
+#include "TerrainHeightSource.h"
+#include "TileImageSource.h"
 
 SurfacePatchModel::SurfacePatchModel(QObject* parent) : QAbstractListModel(parent) {}
 
 SurfacePatchModel::~SurfacePatchModel() = default;
 
-void SurfacePatchModel::setCamera(GeoViewCamera* camera)
+void SurfacePatchModel::setScene(GeoScene* scene)
 {
-    if (camera == _camera) {
+    if (scene == _scene) {
         return;
     }
-    if (_camera) {
-        disconnect(_camera, nullptr, this, nullptr);
+    if (_scene) {
+        disconnect(_scene, nullptr, this, nullptr);
     }
-    _camera = camera;
-    _originSet = false;  // new camera anchors fresh; a stale origin breaks float precision silently
-    emit cameraChanged();
+    _scene = scene;
+    emit sceneChanged();
 
-    if (_camera) {
-        connect(_camera, &GeoViewCamera::centerChanged, this, &SurfacePatchModel::_maybeReanchor);
-        connect(_camera, &QObject::destroyed, this, [this] {
-            _camera = nullptr;
-            _originSet = false;
+    if (_scene) {
+        // cameraChanged also fires on camera destruction (scene clears its pointer)
+        connect(_scene, &GeoScene::cameraChanged, this, &SurfacePatchModel::_rebuildSurfaceModel);
+        connect(_scene, &GeoScene::sceneOriginChanged, this, &SurfacePatchModel::_sceneOriginChanged);
+        connect(_scene, &QObject::destroyed, this, [this] {
+            _scene = nullptr;
+            emit sceneChanged();
             _rebuildSurfaceModel();
         });
     }
+    _rebuildSurfaceModel();
+}
+
+GeoViewCamera* SurfacePatchModel::_camera() const
+{
+    return _scene ? _scene->camera() : nullptr;
+}
+
+void SurfacePatchModel::setTerrain(bool terrain)
+{
+    if (terrain == _terrain) {
+        return;
+    }
+    _terrain = terrain;
+    emit terrainChanged();
     _rebuildSurfaceModel();
 }
 
@@ -43,30 +63,132 @@ void SurfacePatchModel::setDebugHills(bool debugHills)
     _rebuildSurfaceModel();
 }
 
+void SurfacePatchModel::setMapType(const QString& mapType)
+{
+    if (mapType == _mapType) {
+        return;
+    }
+    _mapType = mapType;
+    emit mapTypeChanged();
+
+    _resetImagery();
+    delete _tileSource;
+    _tileSource = nullptr;
+    if (!_mapType.isEmpty()) {
+        _tileSource = new TileImageSource(_mapType, this);
+        connect(_tileSource, &TileImageSource::tileImageReady, this, &SurfacePatchModel::_tileImageReady);
+        connect(_tileSource, &TileImageSource::tileImageFailed, this, &SurfacePatchModel::_tileImageFailed);
+        for (const TileMath::TileKey& key : std::as_const(_keys)) {
+            _requestTileImage(key);
+        }
+    }
+}
+
+void SurfacePatchModel::_resetImagery()
+{
+    if (_tileSource) {
+        // Cancelled requests never signal, so iterating the live map is safe
+        for (auto it = _imageRequestKey.cbegin(); it != _imageRequestKey.cend(); ++it) {
+            _tileSource->cancelRequest(it.key());
+        }
+    }
+    _imageRequestKey.clear();
+    _imageRequestByKey.clear();
+    _retiredOrder.clear();
+    if (!_tileImages.isEmpty()) {
+        _tileImages.clear();
+        if (!_keys.isEmpty()) {
+            emit dataChanged(index(0), index(_keys.count() - 1), {TileImageRole, HasTileImageRole});
+        }
+    }
+}
+
+void SurfacePatchModel::_requestTileImage(const TileMath::TileKey& key)
+{
+    const int requestId = _tileSource->requestTileImage(key);
+    _imageRequestKey.insert(requestId, key);
+    _imageRequestByKey.insert(key, requestId);
+}
+
+void SurfacePatchModel::_tileImageReady(int requestId, const QImage& image)
+{
+    const auto it = _imageRequestKey.constFind(requestId);
+    if (it == _imageRequestKey.constEnd()) {
+        return;
+    }
+    const TileMath::TileKey key = it.value();
+    _imageRequestKey.erase(it);
+    _imageRequestByKey.remove(key);
+
+    const int row = _keys.indexOf(key);
+    if (row < 0) {
+        return;
+    }
+    _tileImages.insert(key, image);
+    _notifyTileImageChanged(key);
+}
+
+void SurfacePatchModel::_notifyTileImageChanged(const TileMath::TileKey& key)
+{
+    // A delivered tile changes its own row plus the rows whose fallback
+    // sources from it: descendants (ancestor crop) and the direct parent
+    // (child composite). Rows with their own image are unaffected.
+    for (int row = 0; row < _keys.count(); row++) {
+        const TileMath::TileKey& rowKey = _keys.at(row);
+        bool affected = (rowKey == key);
+        if (!affected && !_tileImages.contains(rowKey)) {
+            if ((key.zoom > 0) && (rowKey.zoom == (key.zoom - 1))) {
+                affected = (rowKey.x == (key.x >> 1)) && (rowKey.y == (key.y >> 1));
+            } else if (rowKey.zoom > key.zoom) {
+                const int up = rowKey.zoom - key.zoom;
+                affected =
+                    (up <= kMaxAncestorFallbackLevels) && ((rowKey.x >> up) == key.x) && ((rowKey.y >> up) == key.y);
+            }
+        }
+        if (affected) {
+            const QModelIndex idx = index(row);
+            emit dataChanged(idx, idx, {TileImageRole, HasTileImageRole});
+        }
+    }
+}
+
+void SurfacePatchModel::_tileImageFailed(int requestId)
+{
+    // Leave the image null: the delegate keeps its fallback, and patch churn re-requests
+    const auto it = _imageRequestKey.constFind(requestId);
+    if (it == _imageRequestKey.constEnd()) {
+        return;
+    }
+    _imageRequestByKey.remove(it.value());
+    _imageRequestKey.erase(it);
+}
+
 void SurfacePatchModel::_rebuildSurfaceModel()
 {
     beginResetModel();
     _keys.clear();
+    _resetImagery();
     delete _surfaceModel;
     _surfaceModel = nullptr;
     delete _heightSource;
     _heightSource = nullptr;
 
-    if (_camera) {
-        _heightSource = _debugHills ? static_cast<HeightSource*>(new DebugHeightSource(this))
-                                    : static_cast<HeightSource*>(new FlatHeightSource(this));
-        _surfaceModel = new SurfaceModel(_camera, _heightSource, this);
+    GeoViewCamera* const camera = _camera();
+    if (camera) {
+        if (_debugHills) {
+            _heightSource = new DebugHeightSource(this);
+        } else if (_terrain) {
+            _heightSource = new TerrainHeightSource(this);
+        } else {
+            _heightSource = new FlatHeightSource(this);
+        }
+        _surfaceModel = new SurfaceModel(camera, _heightSource, this);
         connect(_surfaceModel, &SurfaceModel::patchAdded, this, &SurfacePatchModel::_patchAdded);
         connect(_surfaceModel, &SurfaceModel::patchReady, this, &SurfacePatchModel::_patchReady);
         connect(_surfaceModel, &SurfaceModel::patchRemoved, this, &SurfacePatchModel::_patchRemoved);
     }
     endResetModel();
 
-    if (_camera && !_originSet) {
-        _sceneOrigin = TileMath::geoToWorld(_camera->center());
-        _originSet = true;
-        emit sceneOriginChanged();
-    }
     if (_surfaceModel) {
         _surfaceModel->update();
     }
@@ -81,11 +203,6 @@ int SurfacePatchModel::gridSize() const
 double SurfacePatchModel::maxRangeMultiplier() const
 {
     return SurfaceModel::kMaxRangeMultiplier;
-}
-
-qreal SurfacePatchModel::verticalScale() const
-{
-    return TileMath::mercatorScale(TileMath::worldToGeo(_sceneOrigin).latitude());
 }
 
 int SurfacePatchModel::pendingCount() const
@@ -115,12 +232,13 @@ QVariant SurfacePatchModel::data(const QModelIndex& index, int role) const
 
     const TileMath::TileKey& key = _keys.at(index.row());
     const double span = TileMath::tileSpanAtZoom(key.zoom);
+    const QPointF origin = _scene ? _scene->sceneOrigin() : QPointF();
 
     switch (role) {
         case CenterXRole:
-            return (TileMath::tileMinCorner(key).x() + (span / 2.0)) - _sceneOrigin.x();
+            return (TileMath::tileMinCorner(key).x() + (span / 2.0)) - origin.x();
         case CenterYRole:
-            return (TileMath::tileMinCorner(key).y() + (span / 2.0)) - _sceneOrigin.y();
+            return (TileMath::tileMinCorner(key).y() + (span / 2.0)) - origin.y();
         case SpanRole:
             return span;
         case ZoomRole:
@@ -133,16 +251,93 @@ QVariant SurfacePatchModel::data(const QModelIndex& index, int role) const
             const auto patch = _surfaceModel->patch(key);
             return patch ? patch->ready : false;
         }
+        case CoveredRole: {
+            const auto patch = _surfaceModel->patch(key);
+            return patch ? patch->covered : false;
+        }
+        case TileImageRole: {
+            const QImage own = _tileImages.value(key);
+            return own.isNull() ? _fallbackImage(key) : own;
+        }
+        case HasTileImageRole:
+            return _tileImages.contains(key) || _fallbackAvailable(key);
         default:
             return {};
     }
 }
 
+bool SurfacePatchModel::_fallbackAvailable(const TileMath::TileKey& key) const
+{
+    for (int childY = 0; childY < 2; childY++) {
+        for (int childX = 0; childX < 2; childX++) {
+            if (_tileImages.contains(TileMath::TileKey{(key.x * 2) + childX, (key.y * 2) + childY, key.zoom + 1})) {
+                return true;
+            }
+        }
+    }
+    for (int up = 1; (up <= kMaxAncestorFallbackLevels) && ((key.zoom - up) >= 0); up++) {
+        if (_tileImages.contains(TileMath::TileKey{key.x >> up, key.y >> up, key.zoom - up})) {
+            return true;
+        }
+    }
+    return false;
+}
+
+QImage SurfacePatchModel::_fallbackImage(const TileMath::TileKey& key) const
+{
+    // Sharper first: composite direct children (LOD coarsening keeps their detail)
+    bool anyChild = false;
+    for (int childY = 0; (childY < 2) && !anyChild; childY++) {
+        for (int childX = 0; (childX < 2) && !anyChild; childX++) {
+            anyChild =
+                _tileImages.contains(TileMath::TileKey{(key.x * 2) + childX, (key.y * 2) + childY, key.zoom + 1});
+        }
+    }
+    if (anyChild) {
+        constexpr int kCanvas = 256;
+        QImage canvas(kCanvas, kCanvas, QImage::Format_RGBA8888);
+        canvas.fill(QColor(0x3a, 0x40, 0x48));  // missing quadrants stay neutral
+        QPainter painter(&canvas);
+        for (int childY = 0; childY < 2; childY++) {
+            for (int childX = 0; childX < 2; childX++) {
+                const QImage child =
+                    _tileImages.value(TileMath::TileKey{(key.x * 2) + childX, (key.y * 2) + childY, key.zoom + 1});
+                if (!child.isNull()) {
+                    // Tile y grows south and image row 0 is north, so child y maps to top half directly
+                    painter.drawImage(QRect((childX * kCanvas) / 2, (childY * kCanvas) / 2, kCanvas / 2, kCanvas / 2),
+                                      child);
+                }
+            }
+        }
+        return canvas;
+    }
+
+    // Blurrier: crop the covering region out of the nearest available ancestor
+    for (int up = 1; (up <= kMaxAncestorFallbackLevels) && ((key.zoom - up) >= 0); up++) {
+        const TileMath::TileKey ancestor{key.x >> up, key.y >> up, key.zoom - up};
+        const QImage image = _tileImages.value(ancestor);
+        if (image.isNull()) {
+            continue;
+        }
+        const int split = 1 << up;
+        const double cellWidth = static_cast<double>(image.width()) / split;
+        const double cellHeight = static_cast<double>(image.height()) / split;
+        const int cellX = key.x - (ancestor.x << up);
+        const int cellY = key.y - (ancestor.y << up);
+        return image.copy(QRect(qRound(cellX * cellWidth), qRound(cellY * cellHeight), qMax(1, qRound(cellWidth)),
+                                qMax(1, qRound(cellHeight))));
+    }
+    return {};
+}
+
 QHash<int, QByteArray> SurfacePatchModel::roleNames() const
 {
     return {
-        {CenterXRole, "centerX"}, {SpanRole, "span"},       {CenterYRole, "centerY"},
-        {ZoomRole, "zoomLevel"},  {HeightsRole, "heights"}, {ReadyRole, "ready"},
+        {CenterXRole, "centerX"},     {SpanRole, "span"},
+        {CenterYRole, "centerY"},     {ZoomRole, "zoomLevel"},
+        {HeightsRole, "heights"},     {ReadyRole, "ready"},
+        {CoveredRole, "covered"},     {TileImageRole, "tileImage"},
+        {HasTileImageRole, "hasTileImage"},
     };
 }
 
@@ -151,6 +346,13 @@ void SurfacePatchModel::_patchAdded(const TileMath::TileKey& key)
     beginInsertRows(QModelIndex(), _keys.count(), _keys.count());
     _keys.append(key);
     endInsertRows();
+    if (_tileSource) {
+        if (_tileImages.contains(key)) {
+            _retiredOrder.removeOne(key);  // back to live: exempt from eviction again
+        } else {
+            _requestTileImage(key);
+        }
+    }
     emit statsChanged();
 }
 
@@ -161,7 +363,9 @@ void SurfacePatchModel::_patchReady(const TileMath::TileKey& key)
         return;
     }
     const QModelIndex idx = index(row);
-    emit dataChanged(idx, idx, {HeightsRole, ReadyRole});
+    emit dataChanged(idx, idx, {HeightsRole, ReadyRole, CoveredRole});
+    // A new ready patch can newly cover other pending rows
+    _notifyCoveredMayHaveChanged();
     emit statsChanged();
 }
 
@@ -174,27 +378,40 @@ void SurfacePatchModel::_patchRemoved(const TileMath::TileKey& key)
     beginRemoveRows(QModelIndex(), row, row);
     _keys.removeAt(row);
     endRemoveRows();
+
+    // Retire the delivered image instead of dropping it: it seeds the
+    // fallback for patches that replace this one across LOD changes
+    if (_tileImages.contains(key)) {
+        _retiredOrder.append(key);
+        while (_retiredOrder.count() > kMaxRetiredImages) {
+            _tileImages.remove(_retiredOrder.takeFirst());
+        }
+    }
+    const auto requestIt = _imageRequestByKey.constFind(key);
+    if (requestIt != _imageRequestByKey.constEnd()) {
+        _tileSource->cancelRequest(requestIt.value());
+        _imageRequestKey.remove(requestIt.value());
+        _imageRequestByKey.erase(requestIt);
+    }
+    // A removed ready patch may have been the cover of pending rows
+    _notifyCoveredMayHaveChanged();
     emit statsChanged();
 }
 
-void SurfacePatchModel::_maybeReanchor()
+void SurfacePatchModel::_notifyCoveredMayHaveChanged()
 {
-    if (!_camera) {
-        return;
+    // Ready rows are never covered, so only pending rows need re-evaluation
+    for (int row = 0; row < _keys.count(); row++) {
+        const auto patch = _surfaceModel->patch(_keys.at(row));
+        if (patch && !patch->ready) {
+            const QModelIndex idx = index(row);
+            emit dataChanged(idx, idx, {CoveredRole});
+        }
     }
-    const QPointF cameraWorld = TileMath::geoToWorld(_camera->center());
-    if (!_originSet) {
-        _sceneOrigin = cameraWorld;
-        _originSet = true;
-        emit sceneOriginChanged();
-        return;
-    }
-    const QPointF offset = cameraWorld - _sceneOrigin;
-    if (QPointF::dotProduct(offset, offset) < (kReanchorDistance * kReanchorDistance)) {
-        return;
-    }
-    _sceneOrigin = cameraWorld;
-    emit sceneOriginChanged();
+}
+
+void SurfacePatchModel::_sceneOriginChanged()
+{
     // All scene positions shift with the origin
     if (!_keys.isEmpty()) {
         emit dataChanged(index(0), index(_keys.count() - 1), {CenterXRole, CenterYRole});

--- a/src/GeoView/SurfacePatchModel.h
+++ b/src/GeoView/SurfacePatchModel.h
@@ -10,33 +10,35 @@
 #pragma once
 
 #include <QtCore/QAbstractListModel>
+#include <QtCore/QHash>
 #include <QtCore/QList>
-#include <QtCore/QPointF>
+#include <QtCore/QString>
+#include <QtGui/QImage>
 #include <QtQmlIntegration/QtQmlIntegration>
 
 #include "TileMath.h"
 
+class GeoScene;
 class GeoViewCamera;
 class HeightSource;
 class SurfaceModel;
+class TileImageSource;
 
-Q_MOC_INCLUDE("GeoViewCamera.h")
+Q_MOC_INCLUDE("GeoScene.h")
 
 /// QML bridge between SurfaceModel and the Repeater3D that renders the surface:
 /// one row per active patch, updated incrementally (no model resets on pan/zoom).
 ///
-/// Patch positions are exposed in scene coordinates: world mercator meters
-/// relative to sceneOrigin. The origin re-anchors to the camera center whenever
-/// the camera strays more than kReanchorDistance from it, keeping scene
-/// coordinates small enough for the renderer's float precision.
+/// Patch positions are exposed in scene coordinates (see GeoScene): world
+/// mercator meters relative to the scene's re-anchorable origin.
 class SurfacePatchModel : public QAbstractListModel
 {
     Q_OBJECT
     QML_ELEMENT
-    Q_PROPERTY(GeoViewCamera* camera READ camera WRITE setCamera NOTIFY cameraChanged)
+    Q_PROPERTY(GeoScene* scene READ scene WRITE setScene NOTIFY sceneChanged)
+    Q_PROPERTY(bool terrain READ terrain WRITE setTerrain NOTIFY terrainChanged)
     Q_PROPERTY(bool debugHills READ debugHills WRITE setDebugHills NOTIFY debugHillsChanged)
-    Q_PROPERTY(QPointF sceneOrigin READ sceneOrigin NOTIFY sceneOriginChanged)
-    Q_PROPERTY(qreal verticalScale READ verticalScale NOTIFY sceneOriginChanged)
+    Q_PROPERTY(QString mapType READ mapType WRITE setMapType NOTIFY mapTypeChanged)
     Q_PROPERTY(int gridSize READ gridSize CONSTANT)
     Q_PROPERTY(double maxRangeMultiplier READ maxRangeMultiplier CONSTANT)
     Q_PROPERTY(int patchCount READ patchCount NOTIFY statsChanged)
@@ -47,8 +49,6 @@ public:
     explicit SurfacePatchModel(QObject* parent = nullptr);
     ~SurfacePatchModel() override;
 
-    static constexpr double kReanchorDistance = 50000.0;  ///< scene-origin re-anchor threshold (m)
-
     enum Roles
     {
         CenterXRole = Qt::UserRole + 1,  ///< patch center x in scene meters
@@ -57,23 +57,30 @@ public:
         ZoomRole,                        ///< quadtree zoom level
         HeightsRole,                     ///< vertex height grid (empty = flat)
         ReadyRole,
+        CoveredRole,                     ///< pending but overlapped by a ready patch: delegate suppresses rendering
+        TileImageRole,                   ///< drapable image: own tile, or ancestor/descendant fallback while loading
+        HasTileImageRole,                ///< QImage is opaque to QML; bool validity for bindings
     };
 
-    GeoViewCamera* camera() const { return _camera; }
+    GeoScene* scene() const { return _scene; }
 
-    void setCamera(GeoViewCamera* camera);
+    void setScene(GeoScene* scene);
+
+    bool terrain() const { return _terrain; }
+
+    /// Real terrain elevations from QGC's terrain pipeline (see TerrainHeightSource);
+    /// false gives a flat z=0 surface. debugHills overrides either.
+    void setTerrain(bool terrain);
 
     bool debugHills() const { return _debugHills; }
 
     void setDebugHills(bool debugHills);
 
-    QPointF sceneOrigin() const { return _sceneOrigin; }
+    QString mapType() const { return _mapType; }
 
-    /// Mercator scale factor at the scene origin: heights are delivered in true
-    /// meters, but scene x/y are mercator meters (stretched by 1/cos(lat)).
-    /// Rendering must scale z by this factor or terrain and altitudes appear
-    /// vertically squashed away from the equator.
-    qreal verticalScale() const;
+    /// Provider type string for tile imagery (see TileImageSource). Empty
+    /// disables imagery: TileImageRole stays a null QImage for every patch.
+    void setMapType(const QString& mapType);
 
     int gridSize() const;
 
@@ -91,25 +98,43 @@ public:
     QHash<int, QByteArray> roleNames() const override;
 
 signals:
-    void cameraChanged();
+    void sceneChanged();
+    void terrainChanged();
     void debugHillsChanged();
-    void sceneOriginChanged();
+    void mapTypeChanged();
     void statsChanged();
 
 private slots:
     void _patchAdded(const TileMath::TileKey& key);
     void _patchReady(const TileMath::TileKey& key);
     void _patchRemoved(const TileMath::TileKey& key);
-    void _maybeReanchor();
+    void _sceneOriginChanged();
+    void _tileImageReady(int requestId, const QImage& image);
+    void _tileImageFailed(int requestId);
 
 private:
     void _rebuildSurfaceModel();
+    void _resetImagery();
+    void _requestTileImage(const TileMath::TileKey& key);
+    void _notifyTileImageChanged(const TileMath::TileKey& key);
+    void _notifyCoveredMayHaveChanged();
+    QImage _fallbackImage(const TileMath::TileKey& key) const;
+    bool _fallbackAvailable(const TileMath::TileKey& key) const;
+    GeoViewCamera* _camera() const;
 
-    GeoViewCamera* _camera = nullptr;
+    static constexpr int kMaxRetiredImages = 128;         ///< tiles kept after patch removal (fallback source)
+    static constexpr int kMaxAncestorFallbackLevels = 8;  ///< how far up the quadtree fallback looks
+
+    GeoScene* _scene = nullptr;
     HeightSource* _heightSource = nullptr;
     SurfaceModel* _surfaceModel = nullptr;
+    bool _terrain = false;
     bool _debugHills = false;
-    QPointF _sceneOrigin;
-    bool _originSet = false;
-    QList<TileMath::TileKey> _keys;  ///< row order; data fetched from SurfaceModel by key
+    QString _mapType;
+    TileImageSource* _tileSource = nullptr;
+    QHash<TileMath::TileKey, QImage> _tileImages;      ///< delivered images: live patches + retired fallbacks
+    QList<TileMath::TileKey> _retiredOrder;            ///< retired keys oldest-first, for eviction
+    QHash<int, TileMath::TileKey> _imageRequestKey;    ///< in-flight image request id -> patch
+    QHash<TileMath::TileKey, int> _imageRequestByKey;  ///< reverse map for cancellation
+    QList<TileMath::TileKey> _keys;                    ///< row order; data fetched from SurfaceModel by key
 };

--- a/src/GeoView/TerrainHeightSource.cc
+++ b/src/GeoView/TerrainHeightSource.cc
@@ -1,0 +1,137 @@
+/****************************************************************************
+ *
+ * (c) 2009-2024 QGROUNDCONTROL PROJECT <http://www.qgroundcontrol.org>
+ *
+ * QGroundControl is licensed according to the terms in the file
+ * COPYING.md in the root of the source code directory.
+ *
+ ****************************************************************************/
+
+#include "TerrainHeightSource.h"
+
+#include <QtCore/QTimer>
+#include <QtPositioning/QGeoCoordinate>
+#include <cmath>
+
+#include "TerrainQueryInterface.h"
+#include "TerrainTileCopernicus.h"
+
+TerrainHeightSource::TerrainHeightSource(QObject* parent) : HeightSource(parent) {}
+
+double TerrainHeightSource::heightScaleForZoom(int zoom)
+{
+    if (zoom < kMinTerrainZoom) {
+        return 0.0;
+    }
+    const int bandSteps = kFullTerrainZoom - kMinTerrainZoom + 1;
+    return qMin(1.0, static_cast<double>(zoom - kMinTerrainZoom + 1) / bandSteps);
+}
+
+int TerrainHeightSource::requestPatchHeights(const TileMath::TileKey& key, int gridSize)
+{
+    const int requestId = _nextRequestId();
+    if (gridSize < 1) {
+        QTimer::singleShot(0, this, [this, requestId] { emit patchHeightsFailed(requestId); });
+        return requestId;
+    }
+
+    const int verticesPerEdge = gridSize + 1;
+    const int expectedCount = verticesPerEdge * verticesPerEdge;
+
+    if (key.zoom < kMinTerrainZoom) {
+        // Flat zeros for coarse patches: see class comment
+        _localPending.insert(requestId, QList<float>(expectedCount, 0.0f));
+        QTimer::singleShot(0, this, [this, requestId] { _deliverLocal(requestId); });
+        return requestId;
+    }
+
+    const QPointF minCorner = TileMath::tileMinCorner(key);
+    const double span = TileMath::tileSpanAtZoom(key.zoom);
+    const double step = span / gridSize;
+    constexpr double cell = TerrainTileCopernicus::kTileValueSpacingDegrees;
+
+    QList<QGeoCoordinate> coordinates;  // four surrounding grid-cell samples per vertex
+    QList<QPointF> fractions;
+    coordinates.reserve(qsizetype(4) * expectedCount);
+    fractions.reserve(expectedCount);
+    // Row-major from the north-west corner, matching the HeightSource contract
+    for (int row = 0; row < verticesPerEdge; row++) {
+        const double y = minCorner.y() + span - (row * step);
+        for (int col = 0; col < verticesPerEdge; col++) {
+            const QGeoCoordinate vertex = TileMath::worldToGeo(QPointF(minCorner.x() + (col * step), y));
+            const double latCells = vertex.latitude() / cell;
+            const double lonCells = vertex.longitude() / cell;
+            const double lat0 = std::floor(latCells);
+            const double lon0 = std::floor(lonCells);
+            fractions.append(QPointF(lonCells - lon0, latCells - lat0));
+            // Sample cell centers so each query floor-indexes to the intended cell
+            for (int dLat = 0; dLat <= 1; dLat++) {
+                for (int dLon = 0; dLon <= 1; dLon++) {
+                    coordinates.append(QGeoCoordinate((lat0 + dLat + 0.5) * cell, (lon0 + dLon + 0.5) * cell));
+                }
+            }
+        }
+    }
+
+    TerrainOfflineQuery* const query = new TerrainOfflineQuery(this);
+    _queryPending.insert(requestId, PendingQuery{query, fractions, heightScaleForZoom(key.zoom)});
+    // Queued: the terrain pipeline answers synchronously on cache hits, but the
+    // HeightSource contract promises delivery only after this call returns
+    connect(
+        query, &TerrainQueryInterface::coordinateHeightsReceived, this,
+        [this, requestId](bool success, const QList<double>& heights) { _queryFinished(requestId, success, heights); },
+        Qt::QueuedConnection);
+    query->requestCoordinateHeights(coordinates);
+    return requestId;
+}
+
+void TerrainHeightSource::cancelRequest(int requestId)
+{
+    _localPending.remove(requestId);
+    const auto it = _queryPending.constFind(requestId);
+    if (it != _queryPending.constEnd()) {
+        // TerrainTileManager tracks queries via QPointer, so deleting one cancels safely
+        it.value().query->deleteLater();
+        _queryPending.erase(it);
+    }
+}
+
+void TerrainHeightSource::_deliverLocal(int requestId)
+{
+    const auto it = _localPending.constFind(requestId);
+    if (it == _localPending.constEnd()) {
+        return;  // cancelled
+    }
+    const QList<float> heights = it.value();
+    _localPending.erase(it);
+    emit patchHeightsReady(requestId, heights);
+}
+
+void TerrainHeightSource::_queryFinished(int requestId, bool success, const QList<double>& heights)
+{
+    const auto it = _queryPending.constFind(requestId);
+    if (it == _queryPending.constEnd()) {
+        return;  // cancelled after the result was already queued
+    }
+    const PendingQuery pending = it.value();
+    _queryPending.erase(it);
+    pending.query->deleteLater();
+
+    if (!success || (heights.count() != (qsizetype(4) * pending.fractions.count()))) {
+        emit patchHeightsFailed(requestId);
+        return;
+    }
+
+    // Bilinear blend of the four grid-cell samples surrounding each vertex
+    QList<float> converted;
+    converted.reserve(pending.fractions.count());
+    for (qsizetype vertex = 0; vertex < pending.fractions.count(); vertex++) {
+        const double fLon = pending.fractions.at(vertex).x();
+        const double fLat = pending.fractions.at(vertex).y();
+        const qsizetype base = vertex * 4;
+        const double south = (heights.at(base) * (1.0 - fLon)) + (heights.at(base + 1) * fLon);
+        const double north = (heights.at(base + 2) * (1.0 - fLon)) + (heights.at(base + 3) * fLon);
+        converted.append(static_cast<float>(((south * (1.0 - fLat)) + (north * fLat)) * pending.heightScale));
+    }
+    emit patchHeightsReady(requestId, converted);
+}

--- a/src/GeoView/TerrainHeightSource.h
+++ b/src/GeoView/TerrainHeightSource.h
@@ -1,0 +1,67 @@
+/****************************************************************************
+ *
+ * (c) 2009-2024 QGROUNDCONTROL PROJECT <http://www.qgroundcontrol.org>
+ *
+ * QGroundControl is licensed according to the terms in the file
+ * COPYING.md in the root of the source code directory.
+ *
+ ****************************************************************************/
+
+#pragma once
+
+#include <QtCore/QHash>
+#include <QtCore/QList>
+#include <QtCore/QPointF>
+
+#include "HeightSource.h"
+
+class TerrainOfflineQuery;
+
+/// HeightSource adapter over QGC's shared terrain pipeline (TerrainTileManager via
+/// TerrainOfflineQuery): real AMSL elevations from the terrain tile cache, downloading
+/// missing elevation tiles as needed.
+///
+/// The pipeline returns one value per 1-arc-second elevation grid cell (floor-indexed,
+/// no interpolation), which renders as terraced steps once mesh vertices are spaced
+/// closer than the ~30m cells. Each vertex therefore samples its four surrounding
+/// grid cells and blends them bilinearly.
+///
+/// Patches coarser than kMinTerrainZoom get flat zero heights delivered locally: their
+/// sample grid would touch hundreds of 0.01-degree elevation tiles each (a fetch storm),
+/// while terrain relief at those view distances is only a few pixels. To avoid a single
+/// full-height cliff at that boundary, heights ramp in across the blend band from
+/// kMinTerrainZoom (scaled down) to kFullTerrainZoom (true height): each ring boundary
+/// then steps by only a fraction of the local terrain height.
+class TerrainHeightSource : public HeightSource
+{
+    Q_OBJECT
+
+public:
+    explicit TerrainHeightSource(QObject* parent = nullptr);
+
+    /// Coarsest patch zoom that queries real terrain data (fetch-cost/visual tradeoff)
+    static constexpr int kMinTerrainZoom = 12;
+    /// First zoom delivered at full height (end of the blend band)
+    static constexpr int kFullTerrainZoom = 14;
+
+    /// Height scale for a patch zoom: 0 below the terrain threshold, ramping to 1
+    /// at kFullTerrainZoom
+    static double heightScaleForZoom(int zoom);
+
+    int requestPatchHeights(const TileMath::TileKey& key, int gridSize) final;
+    void cancelRequest(int requestId) final;
+
+private:
+    void _deliverLocal(int requestId);
+    void _queryFinished(int requestId, bool success, const QList<double>& heights);
+
+    struct PendingQuery
+    {
+        TerrainOfflineQuery* query = nullptr;
+        QList<QPointF> fractions;  ///< per vertex: position within its grid cell (x=lon, y=lat)
+        double heightScale = 1.0;  ///< blend-band scale for the patch zoom
+    };
+
+    QHash<int, QList<float>> _localPending;  ///< coarse-zoom results awaiting queued delivery
+    QHash<int, PendingQuery> _queryPending;  ///< in-flight terrain queries
+};

--- a/src/GeoView/TileImageSource.cc
+++ b/src/GeoView/TileImageSource.cc
@@ -1,0 +1,165 @@
+/****************************************************************************
+ *
+ * (c) 2009-2024 QGROUNDCONTROL PROJECT <http://www.qgroundcontrol.org>
+ *
+ * QGroundControl is licensed according to the terms in the file
+ * COPYING.md in the root of the source code directory.
+ *
+ ****************************************************************************/
+
+#include "TileImageSource.h"
+
+#include <QtCore/QFile>
+#include <QtNetwork/QNetworkAccessManager>
+#include <QtNetwork/QNetworkReply>
+#include <memory>
+
+#include "MapProvider.h"
+#include "QGCCacheTile.h"
+#include "QGCMapEngine.h"
+#include "QGCMapTasks.h"
+#include "QGCMapUrlEngine.h"
+#include "QGeoFileTileCacheQGC.h"
+#include "QGeoTileFetcherQGC.h"
+
+namespace {
+
+// Bing serves a placeholder image instead of an HTTP error where it has no
+// imagery; delivering or caching it as a tile would drape it onto patches
+bool isBingEmptyTile(int mapId, const QByteArray& data)
+{
+    static const QByteArray bingNoTileImage = [] {
+        QFile file(QStringLiteral(":/res/BingNoTileBytes.dat"));
+        return file.open(QFile::ReadOnly) ? file.readAll() : QByteArray();
+    }();
+
+    if (bingNoTileImage.isEmpty() || (data != bingNoTileImage)) {
+        return false;
+    }
+    const SharedMapProvider provider = UrlFactory::getMapProviderFromQtMapId(mapId);
+    return provider && provider->isBingProvider();
+}
+
+}  // namespace
+
+TileImageSource::TileImageSource(const QString& mapType, QObject* parent)
+    : QObject(parent),
+      _mapType(mapType),
+      _mapId(UrlFactory::getQtMapIdFromProviderType(mapType)),
+      _networkManager(new QNetworkAccessManager(this))
+{}
+
+int TileImageSource::requestTileImage(const TileMath::TileKey& key)
+{
+    const int requestId = ++_requestIdCounter;
+    _pending.insert(requestId);
+
+    if (_mapId < 0) {
+        _failAsync(requestId);  // unknown provider: don't spam the cache/URL factory per request
+        return requestId;
+    }
+
+    QGCFetchTileTask* const task = QGeoFileTileCacheQGC::createFetchTileTask(_mapType, key.x, key.y, key.zoom);
+    connect(task, &QGCFetchTileTask::tileFetched, this, [this, requestId](QGCCacheTile* tile) {
+        const std::unique_ptr<QGCCacheTile> guard(tile);  // caller-owned per task contract
+        if (!_pending.contains(requestId)) {
+            return;                                       // cancelled while the lookup was in flight
+        }
+        if (!tile || tile->img.isEmpty()) {
+            _finishFailed(requestId);
+            return;
+        }
+        _deliver(requestId, tile->img);
+    });
+    connect(task, &QGCMapTask::error, this, [this, requestId, key](QGCMapTask::TaskType, const QString&) {
+        if (!_pending.contains(requestId)) {
+            return;
+        }
+        _fetchFromNetwork(requestId, key);
+    });
+
+    if (!getQGCMapEngine()->addTask(task)) {
+        task->deleteLater();  // never enqueued: the worker will not clean it up
+        _failAsync(requestId);
+    }
+    return requestId;
+}
+
+void TileImageSource::_failAsync(int requestId)
+{
+    // Deliver asynchronously so callers see one consistent flow
+    QMetaObject::invokeMethod(
+        this,
+        [this, requestId] {
+            if (_pending.contains(requestId)) {
+                _finishFailed(requestId);
+            }
+        },
+        Qt::QueuedConnection);
+}
+
+void TileImageSource::cancelRequest(int requestId)
+{
+    if (!_pending.remove(requestId)) {
+        return;
+    }
+    QNetworkReply* const reply = _activeReplies.take(requestId);
+    if (reply) {
+        reply->abort();  // finished handler is a no-op once the id is not pending
+    }
+}
+
+void TileImageSource::_fetchFromNetwork(int requestId, const TileMath::TileKey& key)
+{
+    const QNetworkRequest request = QGeoTileFetcherQGC::getNetworkRequest(_mapId, key.x, key.y, key.zoom);
+    QNetworkReply* const reply = _networkManager->get(request);
+    _activeReplies.insert(requestId, reply);
+
+    connect(reply, &QNetworkReply::finished, this, [this, requestId, key, reply] {
+        reply->deleteLater();
+        _activeReplies.remove(requestId);
+        if (!_pending.contains(requestId)) {
+            return;  // cancelled (abort also lands here)
+        }
+        if (reply->error() != QNetworkReply::NoError) {
+            _finishFailed(requestId);
+            return;
+        }
+        const QByteArray data = reply->readAll();
+        if (data.isEmpty() || isBingEmptyTile(_mapId, data)) {
+            _finishFailed(requestId);
+            return;
+        }
+        QImage image;
+        if (!image.loadFromData(data)) {
+            _finishFailed(requestId);  // never cache undecodable bodies (e.g. HTTP-200 error pages)
+            return;
+        }
+        // Store back so the shared cache serves this tile from now on
+        QGeoFileTileCacheQGC::cacheTile(_mapType, key.x, key.y, key.zoom, data,
+                                        UrlFactory::getImageFormat(_mapType, data));
+        _finishSucceeded(requestId, image);
+    });
+}
+
+void TileImageSource::_deliver(int requestId, const QByteArray& data)
+{
+    QImage image;
+    if (isBingEmptyTile(_mapId, data) || !image.loadFromData(data)) {
+        _finishFailed(requestId);
+        return;
+    }
+    _finishSucceeded(requestId, image);
+}
+
+void TileImageSource::_finishSucceeded(int requestId, const QImage& image)
+{
+    _pending.remove(requestId);
+    emit tileImageReady(requestId, image);
+}
+
+void TileImageSource::_finishFailed(int requestId)
+{
+    _pending.remove(requestId);
+    emit tileImageFailed(requestId);
+}

--- a/src/GeoView/TileImageSource.h
+++ b/src/GeoView/TileImageSource.h
@@ -1,0 +1,71 @@
+/****************************************************************************
+ *
+ * (c) 2009-2024 QGROUNDCONTROL PROJECT <http://www.qgroundcontrol.org>
+ *
+ * QGroundControl is licensed according to the terms in the file
+ * COPYING.md in the root of the source code directory.
+ *
+ ****************************************************************************/
+
+#pragma once
+
+#include <QtCore/QHash>
+#include <QtCore/QObject>
+#include <QtCore/QSet>
+#include <QtCore/QString>
+#include <QtGui/QImage>
+
+#include "TileMath.h"
+
+class QNetworkAccessManager;
+class QNetworkReply;
+
+/// Async cache-first source of map tile images for draping onto surface patches.
+///
+/// Thin adapter over QGC's existing map tile infrastructure: tile requests hit
+/// the shared tile cache database first, fall back to a provider network fetch
+/// on miss (URL/headers from the provider registry), and store fetched tiles
+/// back into the cache. Patches are slippy-tile addressed, so one request maps
+/// to exactly one provider tile.
+///
+/// Results are always delivered asynchronously. No signal is emitted for a
+/// cancelled request. No internal retries: a failed request stays failed, and
+/// consumers re-request on their own cadence (patch eviction and re-add).
+class TileImageSource : public QObject
+{
+    Q_OBJECT
+
+public:
+    /// mapType is a provider type string from UrlFactory::getProviderTypes()
+    /// (e.g. "Google Satellite"). With an unknown type every request fails
+    /// (asynchronously) without touching the cache or network.
+    explicit TileImageSource(const QString& mapType, QObject* parent = nullptr);
+
+    QString mapType() const { return _mapType; }
+
+    /// Request the image for a tile. Returns a request id (> 0).
+    int requestTileImage(const TileMath::TileKey& key);
+
+    /// Cancel a pending request, aborting any in-flight network fetch.
+    void cancelRequest(int requestId);
+
+    int pendingCount() const { return _pending.count(); }
+
+signals:
+    void tileImageReady(int requestId, const QImage& image);
+    void tileImageFailed(int requestId);
+
+private:
+    void _fetchFromNetwork(int requestId, const TileMath::TileKey& key);
+    void _failAsync(int requestId);
+    void _deliver(int requestId, const QByteArray& data);
+    void _finishSucceeded(int requestId, const QImage& image);
+    void _finishFailed(int requestId);
+
+    const QString _mapType;
+    const int _mapId;
+    QNetworkAccessManager* _networkManager = nullptr;
+    int _requestIdCounter = 0;
+    QSet<int> _pending;                         ///< ids that have not finished or been cancelled
+    QHash<int, QNetworkReply*> _activeReplies;  ///< in-flight network fetches by request id
+};

--- a/test/GeoView/CMakeLists.txt
+++ b/test/GeoView/CMakeLists.txt
@@ -7,16 +7,26 @@ target_sources(${CMAKE_PROJECT_NAME}
     PRIVATE
         CheckerboardTextureDataTest.cc
         CheckerboardTextureDataTest.h
+        GeoSceneTest.cc
+        GeoSceneTest.h
         GeoViewCameraTest.cc
         GeoViewCameraTest.h
         HeightSourceTest.cc
         HeightSourceTest.h
         PatchGeometryTest.cc
         PatchGeometryTest.h
+        PatchTextureDataTest.cc
+        PatchTextureDataTest.h
         SurfaceModelTest.cc
         SurfaceModelTest.h
+        SurfacePatchImageryTest.cc
+        SurfacePatchImageryTest.h
         SurfacePatchModelTest.cc
         SurfacePatchModelTest.h
+        TerrainHeightSourceTest.cc
+        TerrainHeightSourceTest.h
+        TileImageSourceTest.cc
+        TileImageSourceTest.h
         TileMathTest.cc
         TileMathTest.h
 )
@@ -24,9 +34,14 @@ target_sources(${CMAKE_PROJECT_NAME}
 target_include_directories(${CMAKE_PROJECT_NAME} PRIVATE ${CMAKE_CURRENT_SOURCE_DIR})
 
 add_qgc_test(CheckerboardTextureDataTest LABELS Unit)
+add_qgc_test(GeoSceneTest LABELS Unit)
 add_qgc_test(GeoViewCameraTest LABELS Unit)
 add_qgc_test(HeightSourceTest LABELS Unit)
 add_qgc_test(PatchGeometryTest LABELS Unit)
+add_qgc_test(PatchTextureDataTest LABELS Unit)
 add_qgc_test(SurfaceModelTest LABELS Unit)
+add_qgc_test(SurfacePatchImageryTest LABELS Integration)
 add_qgc_test(SurfacePatchModelTest LABELS Unit)
+add_qgc_test(TerrainHeightSourceTest LABELS Integration Terrain)
+add_qgc_test(TileImageSourceTest LABELS Integration)
 add_qgc_test(TileMathTest LABELS Unit)

--- a/test/GeoView/GeoSceneTest.cc
+++ b/test/GeoView/GeoSceneTest.cc
@@ -1,0 +1,147 @@
+#include "GeoSceneTest.h"
+
+#include <QtTest/QSignalSpy>
+#include <cmath>
+
+#include "GeoScene.h"
+#include "GeoViewCamera.h"
+#include "TileMath.h"
+
+namespace {
+
+const QGeoCoordinate kCenter(47.3977419, 8.5455938);
+constexpr QSizeF kViewport(800, 600);
+
+void setupCamera(GeoViewCamera& camera, const QGeoCoordinate& center = kCenter)
+{
+    camera.setViewportSize(kViewport);
+    camera.lookAt(center, 0, 0, 2000);
+}
+
+double originDistance(const GeoScene& scene, const QPointF& expected)
+{
+    return std::hypot(scene.sceneOrigin().x() - expected.x(), scene.sceneOrigin().y() - expected.y());
+}
+
+}  // namespace
+
+void GeoSceneTest::_originAnchorsOnCameraSet()
+{
+    // Unanchored scene: well-defined defaults at the mercator origin
+    GeoScene scene;
+    QCOMPARE(scene.sceneOrigin(), QPointF(0, 0));
+    QCOMPARE(scene.verticalScale(), 1.0);
+    QCOMPARE_LT(scene.scenePositionFor(QGeoCoordinate(0, 0)).length(), 1.0f);
+
+    GeoViewCamera camera;
+    setupCamera(camera);
+    scene.setCamera(&camera);
+
+    QCOMPARE_LT(originDistance(scene, TileMath::geoToWorld(kCenter)), 1.0);
+}
+
+void GeoSceneTest::_reanchorsEuclidean()
+{
+    GeoViewCamera camera;
+    setupCamera(camera);
+    GeoScene scene;
+    scene.setCamera(&camera);
+    const QPointF startOrigin = scene.sceneOrigin();
+
+    QSignalSpy originSpy(&scene, &GeoScene::sceneOriginChanged);
+
+    // Small move within the threshold: origin holds
+    camera.setCenter(TileMath::worldToGeo(startOrigin + QPointF(10000, 10000)));
+    QCOMPARE(originSpy.count(), 0);
+
+    // Diagonal move under the threshold per axis but over it in Euclidean
+    // distance (40k, 40k) -> ~56.6km: must re-anchor
+    const QPointF diagonalWorld = startOrigin + QPointF(40000, 40000);
+    camera.setCenter(TileMath::worldToGeo(diagonalWorld));
+    QCOMPARE(originSpy.count(), 1);
+    QCOMPARE_LT(originDistance(scene, diagonalWorld), 1.0);
+}
+
+void GeoSceneTest::_cameraSwapAnchorsFresh()
+{
+    GeoViewCamera zurichCamera;
+    setupCamera(zurichCamera);
+    GeoScene scene;
+    scene.setCamera(&zurichCamera);
+
+    // Swap to a static camera on another continent: the origin must follow even
+    // though the new camera's center never changes after the swap
+    GeoViewCamera sydneyCamera;
+    const QGeoCoordinate sydney(-33.8688, 151.2093);
+    setupCamera(sydneyCamera, sydney);
+    scene.setCamera(&sydneyCamera);
+
+    QCOMPARE_LT(originDistance(scene, TileMath::geoToWorld(sydney)), 1.0);
+}
+
+void GeoSceneTest::_verticalScaleTracksOrigin()
+{
+    GeoViewCamera camera;
+    setupCamera(camera);
+    GeoScene scene;
+    scene.setCamera(&camera);
+
+    // Anchored at Zurich: 1/cos(47.3977...)
+    const double zurichScale = TileMath::mercatorScale(kCenter.latitude());
+    QCOMPARE_GT(zurichScale, 1.4);
+    QCOMPARE_LT(qAbs(scene.verticalScale() - zurichScale), 1e-6);
+
+    // Re-anchoring updates the factor to the new origin latitude
+    const QGeoCoordinate reykjavik(64.15, -21.95);
+    camera.setCenter(reykjavik);
+    QCOMPARE_LT(qAbs(scene.verticalScale() - TileMath::mercatorScale(reykjavik.latitude())), 1e-3);
+}
+
+void GeoSceneTest::_scenePositionFor()
+{
+    GeoViewCamera camera;
+    setupCamera(camera);
+    GeoScene scene;
+    scene.setCamera(&camera);
+
+    // The anchor coordinate lands at the scene origin
+    const QVector3D atOrigin = scene.scenePositionFor(kCenter);
+    QCOMPARE_LT(atOrigin.length(), 1.0f);
+
+    // A known world offset is preserved in scene coordinates
+    const QPointF offsetWorld = TileMath::geoToWorld(kCenter) + QPointF(1000, -500);
+    const QVector3D offset = scene.scenePositionFor(TileMath::worldToGeo(offsetWorld));
+    QCOMPARE_LT(qAbs(offset.x() - 1000.0f), 0.01f);
+    QCOMPARE_LT(qAbs(offset.y() - (-500.0f)), 0.01f);
+
+    // Altitude (true meters) is scaled into mercator scene units
+    QGeoCoordinate withAltitude = kCenter;
+    withAltitude.setAltitude(100.0);
+    const QVector3D elevated = scene.scenePositionFor(withAltitude);
+    QCOMPARE_LT(qAbs(elevated.z() - (100.0 * scene.verticalScale())), 0.01);
+}
+
+void GeoSceneTest::_screenPositionFor()
+{
+    GeoScene scene;
+    // No camera: invalid
+    QVERIFY(!scene.screenPositionFor(kCenter).isValid());
+
+    GeoViewCamera camera;
+    setupCamera(camera);
+    scene.setCamera(&camera);
+
+    // Top-down over the anchor: the anchor projects to the viewport center
+    const QVariant center = scene.screenPositionFor(kCenter);
+    QVERIFY(center.isValid());
+    const QPointF centerPos = center.toPointF();
+    QCOMPARE_LT(qAbs(centerPos.x() - (kViewport.width() / 2.0)), 0.5);
+    QCOMPARE_LT(qAbs(centerPos.y() - (kViewport.height() / 2.0)), 0.5);
+
+    // A point above the camera is behind the view plane: invalid
+    QGeoCoordinate aboveCamera = kCenter;
+    aboveCamera.setAltitude(5000.0);  // camera sits at 2000 scene units top-down
+    QVERIFY(!scene.screenPositionFor(aboveCamera).isValid());
+}
+
+UT_REGISTER_TEST_LIGHTWEIGHT(GeoSceneTest, TestLabel::Unit)

--- a/test/GeoView/GeoSceneTest.h
+++ b/test/GeoView/GeoSceneTest.h
@@ -1,0 +1,16 @@
+#pragma once
+
+#include "UnitTest.h"
+
+class GeoSceneTest : public UnitTest
+{
+    Q_OBJECT
+
+private slots:
+    void _originAnchorsOnCameraSet();
+    void _reanchorsEuclidean();
+    void _cameraSwapAnchorsFresh();
+    void _verticalScaleTracksOrigin();
+    void _scenePositionFor();
+    void _screenPositionFor();
+};

--- a/test/GeoView/GeoViewCameraTest.cc
+++ b/test/GeoView/GeoViewCameraTest.cc
@@ -41,6 +41,19 @@ void GeoViewCameraTest::_defaults()
     QCOMPARE(camera.fieldOfView(), GeoViewCamera::kDefaultFieldOfView);
     QVERIFY(camera.isTopDown());
     QCOMPARE(camera.mode(), GeoViewCamera::Mode::Mode2D);
+    QVERIFY(!camera.isPositioned());
+}
+
+void GeoViewCameraTest::_positionedOnExplicitCenter()
+{
+    GeoViewCamera camera;
+    QSignalSpy centerSpy(&camera, &GeoViewCamera::centerChanged);
+
+    // Setting the center to the default location still counts as positioning
+    // and must announce it, so consumers gated on isPositioned wake up
+    camera.setCenter(QGeoCoordinate(0, 0));
+    QVERIFY(camera.isPositioned());
+    QCOMPARE(centerSpy.count(), 1);
 }
 
 void GeoViewCameraTest::_clamps()
@@ -174,6 +187,41 @@ void GeoViewCameraTest::_screenToGroundNoViewport()
     camera.panTo(QPointF(50, 50));
     camera.zoomBy(0.5, QPointF(1, 1));
     QCOMPARE_LT(qAbs(camera.center().latitude() - before.latitude()), 1e-12);
+}
+
+void GeoViewCameraTest::_worldToScreen()
+{
+    // No viewport: the only unconditional failure mode
+    {
+        const GeoViewCamera camera;
+        QVERIFY(!camera.worldToScreen(QPointF(0, 0)).has_value());
+    }
+
+    GeoViewCamera camera;
+    setupCamera(camera);
+    const QPointF centerWorld = TileMath::geoToWorld(kCenter);
+    const QPointF screenCenter(kViewport.width() / 2.0, kViewport.height() / 2.0);
+
+    // Top-down: the look-at center projects to the viewport center
+    const auto projected = camera.worldToScreen(centerWorld);
+    QVERIFY(projected.has_value());
+    QCOMPARE_LT(groundDistance(*projected, screenCenter), 0.01);
+
+    // A point directly above the camera is behind the view plane
+    QVERIFY(!camera.worldToScreen(centerWorld, camera.distance() * 2).has_value());
+
+    // Inverse of screenToGround at arbitrary screen points and tilts
+    for (qreal tilt : {0.0, 30.0, 55.0}) {
+        camera.lookAt(kCenter, 42, tilt, 3000);
+        for (const QPointF& screenPos :
+             {QPointF(200, 150), QPointF(650, 480), QPointF(kViewport.width() / 2.0, kViewport.height() / 2.0)}) {
+            const auto ground = camera.screenToGround(screenPos);
+            QVERIFY(ground.has_value());
+            const auto roundTrip = camera.worldToScreen(*ground);
+            QVERIFY(roundTrip.has_value());
+            QCOMPARE_LT(groundDistance(*roundTrip, screenPos), 0.01);
+        }
+    }
 }
 
 void GeoViewCameraTest::_groundPointCapped()

--- a/test/GeoView/GeoViewCameraTest.h
+++ b/test/GeoView/GeoViewCameraTest.h
@@ -8,6 +8,7 @@ class GeoViewCameraTest : public UnitTest
 
 private slots:
     void _defaults();
+    void _positionedOnExplicitCenter();
     void _clamps();
     void _fieldOfView();
     void _reset();
@@ -16,6 +17,7 @@ private slots:
     void _screenToGroundHorizonMiss();
     void _screenToGroundNoViewport();
     void _groundPointCapped();
+    void _worldToScreen();
     void _sceneUnitsPerPixel();
     void _panAnchorInvariant_data();
     void _panAnchorInvariant();

--- a/test/GeoView/PatchTextureDataTest.cc
+++ b/test/GeoView/PatchTextureDataTest.cc
@@ -1,0 +1,41 @@
+#include "PatchTextureDataTest.h"
+
+#include <QtGui/QColor>
+#include <QtGui/QImage>
+
+#include "PatchTextureData.h"
+
+void PatchTextureDataTest::_sizeFormatAndByteCount()
+{
+    PatchTextureData texture;
+    QImage image(8, 4, QImage::Format_RGB32);
+    image.fill(QColor(10, 20, 30));
+    texture.setImage(image);
+
+    QCOMPARE(texture.size(), QSize(8, 4));
+    QCOMPARE(texture.format(), QQuick3DTextureData::RGBA8);
+    QCOMPARE(texture.textureData().size(), 8 * 4 * 4);
+
+    texture.setImage(QImage());
+    QCOMPARE(texture.size(), QSize());
+    QCOMPARE(texture.textureData().size(), 0);
+}
+
+void PatchTextureDataTest::_transparencyTracksSourceImage()
+{
+    PatchTextureData texture;
+
+    // Opaque map tiles (JPEG decodes without alpha) must not be flagged
+    // transparent even though the upload format is RGBA8
+    QImage opaque(4, 4, QImage::Format_RGB32);
+    opaque.fill(QColor(10, 20, 30));
+    texture.setImage(opaque);
+    QVERIFY(!texture.hasTransparency());
+
+    QImage translucent(4, 4, QImage::Format_ARGB32);
+    translucent.fill(QColor(10, 20, 30, 128));
+    texture.setImage(translucent);
+    QVERIFY(texture.hasTransparency());
+}
+
+UT_REGISTER_TEST(PatchTextureDataTest, TestLabel::Unit)

--- a/test/GeoView/PatchTextureDataTest.h
+++ b/test/GeoView/PatchTextureDataTest.h
@@ -1,0 +1,12 @@
+#pragma once
+
+#include "UnitTest.h"
+
+class PatchTextureDataTest : public UnitTest
+{
+    Q_OBJECT
+
+private slots:
+    void _sizeFormatAndByteCount();
+    void _transparencyTracksSourceImage();
+};

--- a/test/GeoView/SurfaceModelTest.cc
+++ b/test/GeoView/SurfaceModelTest.cc
@@ -1,5 +1,6 @@
 #include "SurfaceModelTest.h"
 
+#include <QtCore/QSet>
 #include <QtTest/QSignalSpy>
 #include <algorithm>
 
@@ -32,6 +33,41 @@ public:
     void cancelRequest(int requestId) override { Q_UNUSED(requestId); }
 };
 
+/// Fails the first failCount requests, then delivers flat zeros: a terrain
+/// backend recovering from transient fetch errors. -1 fails forever.
+class RecoveringHeightSource : public HeightSource
+{
+public:
+    explicit RecoveringHeightSource(int failCount, QObject* parent = nullptr)
+        : HeightSource(parent), _failuresRemaining(failCount)
+    {}
+
+    void setFailuresRemaining(int n) { _failuresRemaining = n; }
+
+    int requestPatchHeights(const TileMath::TileKey& key, int gridSize) override
+    {
+        Q_UNUSED(key);
+        const int requestId = _nextRequestId();
+        if (_failuresRemaining != 0) {
+            if (_failuresRemaining > 0) {
+                _failuresRemaining--;
+            }
+            QMetaObject::invokeMethod(
+                this, [this, requestId] { emit patchHeightsFailed(requestId); }, Qt::QueuedConnection);
+        } else {
+            const QList<float> heights((gridSize + 1) * (gridSize + 1), 0.0f);
+            QMetaObject::invokeMethod(
+                this, [this, requestId, heights] { emit patchHeightsReady(requestId, heights); }, Qt::QueuedConnection);
+        }
+        return requestId;
+    }
+
+    void cancelRequest(int requestId) override { Q_UNUSED(requestId); }
+
+private:
+    int _failuresRemaining = 0;
+};
+
 int maxZoomOf(const QList<SurfaceModel::Patch>& patches)
 {
     int maxZoom = 0;
@@ -51,6 +87,21 @@ void SurfaceModelTest::_noViewportNoPatches()
 
     model.update();
     QCOMPARE(model.patchCount(), 0);
+}
+
+void SurfaceModelTest::_unpositionedCameraNoPatches()
+{
+    GeoViewCamera camera;
+    FlatHeightSource source;
+    SurfaceModel model(&camera, &source);
+
+    // A sized viewport alone must not build patches: the camera still holds
+    // the null-island default pose (doomed terrain fetches would follow)
+    camera.setViewportSize(kViewport);
+    QCOMPARE(model.patchCount(), 0);
+
+    camera.setCenter(kCenter);
+    QCOMPARE_GT(model.patchCount(), 0);
 }
 
 void SurfaceModelTest::_coarseWhenFar()
@@ -232,6 +283,26 @@ void SurfaceModelTest::_failedHeightsDegradeToFlat()
     GeoViewCamera camera;
     FailingHeightSource source;
     SurfaceModel model(&camera, &source);
+    model.setHeightRetryDelayMs(10);
+
+    camera.setViewportSize(kViewport);
+    camera.lookAt(kCenter, 0, 0, 2000);
+
+    // Every patch burns through its retries before degrading to flat
+    QCOMPARE_GT(model.patchCount(), 0);
+    QTRY_COMPARE_WITH_TIMEOUT(model.pendingCount(), 0, 5000);
+    for (const SurfaceModel::Patch& patch : model.patches()) {
+        QVERIFY(patch.ready);
+        QVERIFY(patch.heights.isEmpty());  // empty = flat fallback
+    }
+}
+
+void SurfaceModelTest::_failedHeightsRetryAndRecover()
+{
+    GeoViewCamera camera;
+    RecoveringHeightSource source(1);  // first request fails, retry succeeds
+    SurfaceModel model(&camera, &source);
+    model.setHeightRetryDelayMs(10);
 
     camera.setViewportSize(kViewport);
     camera.lookAt(kCenter, 0, 0, 2000);
@@ -240,7 +311,122 @@ void SurfaceModelTest::_failedHeightsDegradeToFlat()
     QTRY_COMPARE_WITH_TIMEOUT(model.pendingCount(), 0, 5000);
     for (const SurfaceModel::Patch& patch : model.patches()) {
         QVERIFY(patch.ready);
-        QVERIFY(patch.heights.isEmpty());  // empty = flat fallback
+        QVERIFY(!patch.heights.isEmpty());  // delivered heights, not the empty flat fallback
+    }
+}
+
+void SurfaceModelTest::_degradedPatchesKeepRetiringCover()
+{
+    GeoViewCamera camera;
+    RecoveringHeightSource source(0);  // healthy backend first
+    SurfaceModel model(&camera, &source);
+    model.setHeightRetryDelayMs(10);
+
+    camera.setViewportSize(kViewport);
+    camera.lookAt(kCenter, 0, 0, GeoViewCamera::kMaxDistance);
+    QTRY_COMPARE_WITH_TIMEOUT(model.pendingCount(), 0, 5000);
+    const int coarseMaxZoom = maxZoomOf(model.patches());
+
+    // Backend dies, then a refine replaces the ready coarse set: the fine
+    // patches exhaust their retries and degrade to flat, but the coarse
+    // real-height patches must keep covering instead of being swept
+    source.setFailuresRemaining(-1);
+    camera.lookAt(kCenter, 0, 0, 2000);
+    QTRY_COMPARE_WITH_TIMEOUT(model.pendingCount(), 0, 5000);
+
+    bool hasReadyCoarse = false;
+    for (const SurfaceModel::Patch& patch : model.patches()) {
+        hasReadyCoarse |= (patch.ready && !patch.heights.isEmpty() && (patch.key.zoom <= coarseMaxZoom));
+    }
+    QVERIFY(hasReadyCoarse);
+}
+
+void SurfaceModelTest::_keepsReadyPatchesDuringLodChurn()
+{
+    GeoViewCamera camera;
+    FlatHeightSource source;
+    SurfaceModel model(&camera, &source);
+
+    camera.setViewportSize(kViewport);
+    camera.lookAt(kCenter, 0, 0, GeoViewCamera::kMaxDistance);
+    QTRY_COMPARE_WITH_TIMEOUT(model.pendingCount(), 0, 5000);
+    const int coarseMaxZoom = maxZoomOf(model.patches());
+
+    // Refine: the coarse ready patches must keep covering the view (retiring)
+    // until the fine replacements have heights - no holes during LOD churn
+    camera.lookAt(kCenter, 0, 0, 2000);
+    QCOMPARE_GT(model.pendingCount(), 0);
+    bool hasReadyCoarse = false;
+    for (const SurfaceModel::Patch& patch : model.patches()) {
+        hasReadyCoarse |= (patch.ready && (patch.key.zoom <= coarseMaxZoom));
+    }
+    QVERIFY(hasReadyCoarse);
+
+    // Once the fine set is ready the retired coarse patches are swept
+    QTRY_COMPARE_WITH_TIMEOUT(model.pendingCount(), 0, 5000);
+    for (const SurfaceModel::Patch& patch : model.patches()) {
+        QVERIFY(patch.ready);
+        QCOMPARE_GT(patch.key.zoom, coarseMaxZoom);
+    }
+}
+
+void SurfaceModelTest::_degradedRetiringPatchesSwept()
+{
+    GeoViewCamera camera;
+    RecoveringHeightSource source(-1);  // backend down for good
+    SurfaceModel model(&camera, &source);
+    model.setHeightRetryDelayMs(10);
+
+    camera.setViewportSize(kViewport);
+    camera.lookAt(kCenter, 0, 0, 2000);
+    QTRY_COMPARE_WITH_TIMEOUT(model.pendingCount(), 0, 5000);  // all degraded to flat
+
+    QSet<TileMath::TileKey> oldKeys;
+    for (const SurfaceModel::Patch& patch : model.patches()) {
+        oldKeys.insert(patch.key);
+    }
+
+    // Pan far away: the degraded patches become undesired and must be swept
+    // (a degraded flat fallback is not worth retaining as cover), otherwise
+    // movement after terrain failures grows the model without bound
+    camera.lookAt(QGeoCoordinate(40.0, -105.0), 0, 0, 2000);
+    QTRY_COMPARE_WITH_TIMEOUT(model.pendingCount(), 0, 5000);
+
+    for (const SurfaceModel::Patch& patch : model.patches()) {
+        QVERIFY2(!oldKeys.contains(patch.key), "degraded retiring patch was never swept");
+    }
+}
+
+void SurfaceModelTest::_pendingPatchesCoveredDuringLodChurn()
+{
+    GeoViewCamera camera;
+    FlatHeightSource source;
+    SurfaceModel model(&camera, &source);
+
+    camera.setViewportSize(kViewport);
+    camera.lookAt(kCenter, 0, 0, GeoViewCamera::kMaxDistance);
+    QTRY_COMPARE_WITH_TIMEOUT(model.pendingCount(), 0, 5000);
+
+    // Refine: every pending replacement overlaps a retained ready patch, so it
+    // reports covered - renderers suppress it instead of drawing a flat
+    // placeholder that z-fights the retiring cover
+    camera.lookAt(kCenter, 0, 0, 2000);
+    QCOMPARE_GT(model.pendingCount(), 0);
+    int pendingCovered = 0;
+    for (const SurfaceModel::Patch& patch : model.patches()) {
+        if (patch.ready) {
+            QVERIFY(!patch.covered);
+        } else {
+            QVERIFY(patch.covered);
+            pendingCovered++;
+        }
+    }
+    QCOMPARE_GT(pendingCovered, 0);
+
+    // Once ready nothing is covered
+    QTRY_COMPARE_WITH_TIMEOUT(model.pendingCount(), 0, 5000);
+    for (const SurfaceModel::Patch& patch : model.patches()) {
+        QVERIFY(!patch.covered);
     }
 }
 

--- a/test/GeoView/SurfaceModelTest.h
+++ b/test/GeoView/SurfaceModelTest.h
@@ -8,6 +8,7 @@ class SurfaceModelTest : public UnitTest
 
 private slots:
     void _noViewportNoPatches();
+    void _unpositionedCameraNoPatches();
     void _coarseWhenFar();
     void _refinesWhenNear();
     void _patchCountBounded();
@@ -17,4 +18,9 @@ private slots:
     void _noChurnOnIdenticalUpdate();
     void _cullsInvisibleRegion();
     void _failedHeightsDegradeToFlat();
+    void _failedHeightsRetryAndRecover();
+    void _keepsReadyPatchesDuringLodChurn();
+    void _degradedPatchesKeepRetiringCover();
+    void _degradedRetiringPatchesSwept();
+    void _pendingPatchesCoveredDuringLodChurn();
 };

--- a/test/GeoView/SurfacePatchImageryTest.cc
+++ b/test/GeoView/SurfacePatchImageryTest.cc
@@ -1,0 +1,156 @@
+#include "SurfacePatchImageryTest.h"
+
+#include <QtTest/QSignalSpy>
+
+#include "GeoScene.h"
+#include "GeoViewCamera.h"
+#include "QGCMapUrlEngine.h"
+#include "SurfacePatchModel.h"
+
+namespace {
+
+const QGeoCoordinate kCenter(47.3977419, 8.5455938);
+constexpr QSizeF kViewport(800, 600);
+
+// The unit-test tile generator serves a placeholder image on every cache miss
+QString mapType()
+{
+    const QStringList elevationTypes = UrlFactory::getElevationProviderTypes();
+    for (const QString& type : UrlFactory::getProviderTypes()) {
+        if (!elevationTypes.contains(type)) {
+            return type;
+        }
+    }
+    return QString();
+}
+
+void attach(SurfacePatchModel& model, GeoScene& scene, GeoViewCamera& camera)
+{
+    camera.setViewportSize(kViewport);
+    camera.lookAt(kCenter, 0, 0, 2000);
+    scene.setCamera(&camera);
+    model.setScene(&scene);
+}
+
+int rowsWithImage(const SurfacePatchModel& model)
+{
+    int count = 0;
+    for (int row = 0; row < model.rowCount(); row++) {
+        if (!model.data(model.index(row), SurfacePatchModel::TileImageRole).value<QImage>().isNull()) {
+            count++;
+        }
+    }
+    return count;
+}
+
+int rowsReportingImage(const SurfacePatchModel& model)
+{
+    int count = 0;
+    for (int row = 0; row < model.rowCount(); row++) {
+        if (model.data(model.index(row), SurfacePatchModel::HasTileImageRole).toBool()) {
+            count++;
+        }
+    }
+    return count;
+}
+
+}  // namespace
+
+void SurfacePatchImageryTest::_imagesArriveForAllPatches()
+{
+    const QString type = mapType();
+    QVERIFY2(!type.isEmpty(), "no non-elevation map provider registered");
+
+    GeoViewCamera camera;
+    GeoScene scene;
+    SurfacePatchModel model;
+    attach(model, scene, camera);
+    model.setMapType(type);
+
+    QCOMPARE_GT(model.rowCount(), 0);
+    QTRY_COMPARE_WITH_TIMEOUT(rowsWithImage(model), model.rowCount(), 5000);
+}
+
+void SurfacePatchImageryTest::_emptyMapTypeDisablesImagery()
+{
+    const QString type = mapType();
+    QVERIFY2(!type.isEmpty(), "no non-elevation map provider registered");
+
+    GeoViewCamera camera;
+    GeoScene scene;
+    SurfacePatchModel model;
+    attach(model, scene, camera);
+    model.setMapType(type);
+    QTRY_COMPARE_WITH_TIMEOUT(rowsWithImage(model), model.rowCount(), 5000);
+
+    // Clearing the map type drops all imagery and stops requesting
+    model.setMapType(QString());
+    QCOMPARE(rowsWithImage(model), 0);
+
+    // Patch churn with imagery disabled stays image-free
+    camera.setCenter(QGeoCoordinate(47.42, 8.58));
+    QCOMPARE(rowsWithImage(model), 0);
+}
+
+void SurfacePatchImageryTest::_mapTypeSwitchRefetches()
+{
+    const QStringList elevationTypes = UrlFactory::getElevationProviderTypes();
+    QStringList types;
+    for (const QString& type : UrlFactory::getProviderTypes()) {
+        if (!elevationTypes.contains(type)) {
+            types.append(type);
+        }
+        if (types.count() == 2) {
+            break;
+        }
+    }
+    QVERIFY2(types.count() == 2, "need two non-elevation map providers");
+
+    GeoViewCamera camera;
+    GeoScene scene;
+    SurfacePatchModel model;
+    attach(model, scene, camera);
+    model.setMapType(types.first());
+    QTRY_COMPARE_WITH_TIMEOUT(rowsWithImage(model), model.rowCount(), 5000);
+
+    // Provider switch clears delivered images, then refetches for the new provider
+    model.setMapType(types.last());
+    QTRY_COMPARE_WITH_TIMEOUT(rowsWithImage(model), model.rowCount(), 5000);
+    QCOMPARE(model.mapType(), types.last());
+}
+
+void SurfacePatchImageryTest::_fallbackCoversLodChanges()
+{
+    const QString type = mapType();
+    QVERIFY2(!type.isEmpty(), "no non-elevation map provider registered");
+
+    GeoViewCamera camera;
+    GeoScene scene;
+    SurfacePatchModel model;
+    attach(model, scene, camera);
+    model.setMapType(type);
+    QTRY_COMPARE_WITH_TIMEOUT(rowsWithImage(model), model.rowCount(), 5000);
+
+    // Zoom in (LOD refines): every new patch lies inside previously imaged
+    // ground and must immediately drape an ancestor fallback -- no flash
+    camera.setDistance(500);
+    QCOMPARE_GT(model.rowCount(), 0);
+    QCOMPARE(rowsReportingImage(model), model.rowCount());
+    QCOMPARE(rowsWithImage(model), model.rowCount());
+
+    // Zoom back out to the original LOD: the retired originals revive from
+    // the cache without any new fetch
+    camera.setDistance(2000);
+    QCOMPARE_GT(model.rowCount(), 0);
+    QCOMPARE(rowsReportingImage(model), model.rowCount());
+
+    // Coarsen further: patches over previously seen ground composite their
+    // cached children. Edge patches cover never-seen ground and legitimately
+    // have no fallback source, so only partial coverage is guaranteed.
+    camera.setDistance(4000);
+    QCOMPARE_GT(model.rowCount(), 0);
+    QCOMPARE_GT(rowsReportingImage(model), 0);
+    QCOMPARE(rowsWithImage(model), rowsReportingImage(model));
+}
+
+UT_REGISTER_TEST(SurfacePatchImageryTest, TestLabel::Integration)

--- a/test/GeoView/SurfacePatchImageryTest.h
+++ b/test/GeoView/SurfacePatchImageryTest.h
@@ -1,0 +1,14 @@
+#pragma once
+
+#include "UnitTest.h"
+
+class SurfacePatchImageryTest : public UnitTest
+{
+    Q_OBJECT
+
+private slots:
+    void _imagesArriveForAllPatches();
+    void _emptyMapTypeDisablesImagery();
+    void _mapTypeSwitchRefetches();
+    void _fallbackCoversLodChanges();
+};

--- a/test/GeoView/SurfacePatchModelTest.cc
+++ b/test/GeoView/SurfacePatchModelTest.cc
@@ -3,6 +3,7 @@
 #include <QtTest/QSignalSpy>
 #include <cmath>
 
+#include "GeoScene.h"
 #include "GeoViewCamera.h"
 #include "SurfaceModel.h"
 #include "SurfacePatchModel.h"
@@ -19,6 +20,12 @@ void setupCamera(GeoViewCamera& camera, const QGeoCoordinate& center = kCenter)
     camera.lookAt(center, 0, 0, 2000);
 }
 
+void attach(SurfacePatchModel& model, GeoScene& scene, GeoViewCamera& camera)
+{
+    scene.setCamera(&camera);
+    model.setScene(&scene);
+}
+
 }  // namespace
 
 void SurfacePatchModelTest::_emptyWithoutCamera()
@@ -32,9 +39,10 @@ void SurfacePatchModelTest::_emptyWithoutCamera()
 void SurfacePatchModelTest::_populatesFromCamera()
 {
     GeoViewCamera camera;
+    GeoScene scene;
     SurfacePatchModel model;
     setupCamera(camera);
-    model.setCamera(&camera);
+    attach(model, scene, camera);
 
     QCOMPARE_GT(model.rowCount(), 0);
     QCOMPARE(model.rowCount(), model.patchCount());
@@ -42,16 +50,17 @@ void SurfacePatchModelTest::_populatesFromCamera()
 
     // Scene origin anchors at the camera center
     const QPointF expectedOrigin = TileMath::geoToWorld(kCenter);
-    QCOMPARE_LT(std::hypot(model.sceneOrigin().x() - expectedOrigin.x(), model.sceneOrigin().y() - expectedOrigin.y()),
+    QCOMPARE_LT(std::hypot(scene.sceneOrigin().x() - expectedOrigin.x(), scene.sceneOrigin().y() - expectedOrigin.y()),
                 1.0);
 }
 
 void SurfacePatchModelTest::_rolesValid()
 {
     GeoViewCamera camera;
+    GeoScene scene;
     SurfacePatchModel model;
     setupCamera(camera);
-    model.setCamera(&camera);
+    attach(model, scene, camera);
     QTRY_COMPARE_WITH_TIMEOUT(model.pendingCount(), 0, 5000);
 
     const int expectedHeights = (model.gridSize() + 1) * (model.gridSize() + 1);
@@ -82,9 +91,10 @@ void SurfacePatchModelTest::_rolesValid()
 void SurfacePatchModelTest::_incrementalUpdatesOnMove()
 {
     GeoViewCamera camera;
+    GeoScene scene;
     SurfacePatchModel model;
     setupCamera(camera);
-    model.setCamera(&camera);
+    attach(model, scene, camera);
     QTRY_COMPARE_WITH_TIMEOUT(model.pendingCount(), 0, 5000);
 
     QSignalSpy resetSpy(&model, &QAbstractItemModel::modelReset);
@@ -101,11 +111,12 @@ void SurfacePatchModelTest::_incrementalUpdatesOnMove()
 void SurfacePatchModelTest::_reanchorsOnLargeMove()
 {
     GeoViewCamera camera;
+    GeoScene scene;
     SurfacePatchModel model;
     setupCamera(camera);
-    model.setCamera(&camera);
+    attach(model, scene, camera);
 
-    QSignalSpy originSpy(&model, &SurfacePatchModel::sceneOriginChanged);
+    QSignalSpy originSpy(&scene, &GeoScene::sceneOriginChanged);
 
     // Move far beyond kReanchorDistance: origin follows the camera
     const QGeoCoordinate faraway(48.85, 2.35);  // Paris, ~490km from Zurich
@@ -113,7 +124,7 @@ void SurfacePatchModelTest::_reanchorsOnLargeMove()
     QCOMPARE_GT(originSpy.count(), 0);
 
     const QPointF expectedOrigin = TileMath::geoToWorld(faraway);
-    QCOMPARE_LT(std::hypot(model.sceneOrigin().x() - expectedOrigin.x(), model.sceneOrigin().y() - expectedOrigin.y()),
+    QCOMPARE_LT(std::hypot(scene.sceneOrigin().x() - expectedOrigin.x(), scene.sceneOrigin().y() - expectedOrigin.y()),
                 1.0);
 
     // Scene positions stay small after the re-anchor
@@ -124,36 +135,40 @@ void SurfacePatchModelTest::_reanchorsOnLargeMove()
         const double centerX = model.data(idx, SurfacePatchModel::CenterXRole).toDouble();
         const double centerY = model.data(idx, SurfacePatchModel::CenterYRole).toDouble();
         // Bounded by the visible region around the camera, not by world scale
-        QCOMPARE_LT(qAbs(centerX), SurfacePatchModel::kReanchorDistance + span);
-        QCOMPARE_LT(qAbs(centerY), SurfacePatchModel::kReanchorDistance + span);
+        QCOMPARE_LT(qAbs(centerX), GeoScene::kReanchorDistance + span);
+        QCOMPARE_LT(qAbs(centerY), GeoScene::kReanchorDistance + span);
     }
 }
 
 void SurfacePatchModelTest::_cameraSwapAnchorsFresh()
 {
     GeoViewCamera zurichCamera;
+    GeoScene scene;
     SurfacePatchModel model;
     setupCamera(zurichCamera);
-    model.setCamera(&zurichCamera);
+    attach(model, scene, zurichCamera);
 
     // Swap to a static camera on another continent: the origin must follow even
     // though the new camera's center never changes after the swap
     GeoViewCamera sydneyCamera;
     const QGeoCoordinate sydney(-33.8688, 151.2093);
     setupCamera(sydneyCamera, sydney);
-    model.setCamera(&sydneyCamera);
+    scene.setCamera(&sydneyCamera);
 
     const QPointF expectedOrigin = TileMath::geoToWorld(sydney);
-    QCOMPARE_LT(std::hypot(model.sceneOrigin().x() - expectedOrigin.x(), model.sceneOrigin().y() - expectedOrigin.y()),
+    QCOMPARE_LT(std::hypot(scene.sceneOrigin().x() - expectedOrigin.x(), scene.sceneOrigin().y() - expectedOrigin.y()),
                 1.0);
+    // The model rebuilt against the new camera
+    QCOMPARE_GT(model.rowCount(), 0);
 }
 
 void SurfacePatchModelTest::_debugHillsSwitchResets()
 {
     GeoViewCamera camera;
+    GeoScene scene;
     SurfacePatchModel model;
     setupCamera(camera);
-    model.setCamera(&camera);
+    attach(model, scene, camera);
     QTRY_COMPARE_WITH_TIMEOUT(model.pendingCount(), 0, 5000);
 
     QSignalSpy resetSpy(&model, &QAbstractItemModel::modelReset);
@@ -176,22 +191,36 @@ void SurfacePatchModelTest::_debugHillsSwitchResets()
     QVERIFY(nonZeroSeen);
 }
 
-void SurfacePatchModelTest::_verticalScaleTracksOrigin()
+void SurfacePatchModelTest::_pendingRowsCoveredDuringLodChurn()
 {
     GeoViewCamera camera;
+    GeoScene scene;
     SurfacePatchModel model;
-    setupCamera(camera);
-    model.setCamera(&camera);
+    camera.setViewportSize(kViewport);
+    camera.lookAt(kCenter, 0, 0, GeoViewCamera::kMaxDistance);
+    attach(model, scene, camera);
+    QTRY_COMPARE_WITH_TIMEOUT(model.pendingCount(), 0, 5000);
 
-    // Anchored at Zurich: 1/cos(47.3977...)
-    const double zurichScale = TileMath::mercatorScale(kCenter.latitude());
-    QCOMPARE_GT(zurichScale, 1.4);
-    QCOMPARE_LT(qAbs(model.verticalScale() - zurichScale), 1e-6);
+    // Refine: pending replacements report covered so the delegate hides their
+    // empty flat mesh instead of z-fighting the retained retiring cover
+    camera.lookAt(kCenter, 0, 0, 2000);
+    QCOMPARE_GT(model.pendingCount(), 0);
+    int coveredRows = 0;
+    for (int row = 0; row < model.rowCount(); row++) {
+        const QModelIndex idx = model.index(row);
+        const bool ready = model.data(idx, SurfacePatchModel::ReadyRole).toBool();
+        const bool covered = model.data(idx, SurfacePatchModel::CoveredRole).toBool();
+        QCOMPARE(covered, !ready);
+        if (covered) {
+            coveredRows++;
+        }
+    }
+    QCOMPARE_GT(coveredRows, 0);
 
-    // Re-anchoring updates the factor to the new origin latitude
-    const QGeoCoordinate reykjavik(64.15, -21.95);
-    camera.setCenter(reykjavik);
-    QCOMPARE_LT(qAbs(model.verticalScale() - TileMath::mercatorScale(reykjavik.latitude())), 1e-3);
+    QTRY_COMPARE_WITH_TIMEOUT(model.pendingCount(), 0, 5000);
+    for (int row = 0; row < model.rowCount(); row++) {
+        QVERIFY(!model.data(model.index(row), SurfacePatchModel::CoveredRole).toBool());
+    }
 }
 
 UT_REGISTER_TEST_LIGHTWEIGHT(SurfacePatchModelTest, TestLabel::Unit)

--- a/test/GeoView/SurfacePatchModelTest.h
+++ b/test/GeoView/SurfacePatchModelTest.h
@@ -14,5 +14,5 @@ private slots:
     void _reanchorsOnLargeMove();
     void _cameraSwapAnchorsFresh();
     void _debugHillsSwitchResets();
-    void _verticalScaleTracksOrigin();
+    void _pendingRowsCoveredDuringLodChurn();
 };

--- a/test/GeoView/TerrainHeightSourceTest.cc
+++ b/test/GeoView/TerrainHeightSourceTest.cc
@@ -1,0 +1,166 @@
+#include "TerrainHeightSourceTest.h"
+
+#include <QtTest/QSignalSpy>
+
+#include "TerrainHeightSource.h"
+#include "TileMath.h"
+
+// These tests run the full production terrain pipeline: TerrainHeightSource routes
+// through TerrainTileManager, whose elevation tile cache misses are served synthetic
+// tiles built from the UnitTestTerrainData regions (see UnitTestTileGenerator). No
+// network access ever occurs.
+
+namespace {
+constexpr int kGridSize = 4;
+constexpr int kExpectedCount = (kGridSize + 1) * (kGridSize + 1);
+constexpr int kFineZoom = 14;  ///< patch span ~2.4km, well inside the 11km test regions
+
+TileMath::TileKey keyOver(const QGeoCoordinate& coord, int zoom)
+{
+    return TileMath::tileForWorld(TileMath::geoToWorld(coord), zoom);
+}
+}  // namespace
+
+void TerrainHeightSourceTest::_deliversFlatRegionHeights()
+{
+    TerrainHeightSource source;
+    QSignalSpy readySpy(&source, &HeightSource::patchHeightsReady);
+    QSignalSpy failedSpy(&source, &HeightSource::patchHeightsFailed);
+
+    const int requestId = source.requestPatchHeights(keyOver(flat10Region().center(), kFineZoom), kGridSize);
+    QCOMPARE_GT(requestId, 0);
+    QVERIFY(readySpy.isEmpty());  // delivery is async, never re-entrant
+
+    QTRY_COMPARE_WITH_TIMEOUT(readySpy.count(), 1, TestTimeout::mediumMs());
+    QCOMPARE(readySpy.first().at(0).toInt(), requestId);
+    QVERIFY(failedSpy.isEmpty());
+
+    const auto heights = readySpy.first().at(1).value<QList<float>>();
+    QCOMPARE(heights.count(), kExpectedCount);
+    for (float h : heights) {
+        QCOMPARE(h, static_cast<float>(UnitTestTerrainData::Flat10Region::amslElevation));
+    }
+}
+
+void TerrainHeightSourceTest::_deliversSlopeRegionHeights()
+{
+    TerrainHeightSource source;
+    QSignalSpy readySpy(&source, &HeightSource::patchHeightsReady);
+
+    source.requestPatchHeights(keyOver(linearSlopeRegion().center(), kFineZoom), kGridSize);
+    QTRY_COMPARE_WITH_TIMEOUT(readySpy.count(), 1, TestTimeout::mediumMs());
+
+    // The slope rises 100m/km west to east: each row must rise substantially
+    // across the ~1.6km ground span of a zoom-14 patch at this latitude
+    const auto heights = readySpy.first().at(1).value<QList<float>>();
+    QCOMPARE(heights.count(), kExpectedCount);
+    const int verticesPerEdge = kGridSize + 1;
+    for (int row = 0; row < verticesPerEdge; row++) {
+        const float west = heights.at(row * verticesPerEdge);
+        const float east = heights.at((row * verticesPerEdge) + kGridSize);
+        QCOMPARE_GT(east - west, 50.0f);
+    }
+}
+
+void TerrainHeightSourceTest::_interpolatesAcrossCellSteps()
+{
+    TerrainHeightSource source;
+    QSignalSpy readySpy(&source, &HeightSource::patchHeightsReady);
+
+    // Vertices a few meters apart on the slope: the raw 1-arc-second grid steps
+    // ~2m per ~20m cell, so without bilinear interpolation adjacent vertices
+    // would show whole-cell jumps instead of a smooth ~0.3m-per-vertex rise
+    constexpr int closeZoom = 19;  // patch ~50m ground span at this latitude
+    constexpr int fineGrid = 16;
+    source.requestPatchHeights(keyOver(linearSlopeRegion().center(), closeZoom), fineGrid);
+    QTRY_COMPARE_WITH_TIMEOUT(readySpy.count(), 1, TestTimeout::mediumMs());
+
+    const auto heights = readySpy.first().at(1).value<QList<float>>();
+    const int verticesPerEdge = fineGrid + 1;
+    QCOMPARE(heights.count(), verticesPerEdge * verticesPerEdge);
+    for (int row = 0; row < verticesPerEdge; row++) {
+        for (int col = 0; col < fineGrid; col++) {
+            const float west = heights.at((row * verticesPerEdge) + col);
+            const float east = heights.at((row * verticesPerEdge) + col + 1);
+            QCOMPARE_LT(qAbs(east - west), 1.0f);
+        }
+        // Interpolation must not flatten the slope away
+        const float rise = heights.at((row * verticesPerEdge) + fineGrid) - heights.at(row * verticesPerEdge);
+        QCOMPARE_GT(rise, 3.0f);
+    }
+}
+
+void TerrainHeightSourceTest::_blendBandScalesHeights()
+{
+    // Zooms in the blend band deliver fractionally scaled heights so the
+    // flat-zero far field is approached in steps instead of one cliff
+    for (int zoom = TerrainHeightSource::kMinTerrainZoom; zoom <= TerrainHeightSource::kFullTerrainZoom; zoom++) {
+        TerrainHeightSource source;
+        QSignalSpy readySpy(&source, &HeightSource::patchHeightsReady);
+
+        source.requestPatchHeights(keyOver(flat10Region().center(), zoom), kGridSize);
+        QTRY_COMPARE_WITH_TIMEOUT(readySpy.count(), 1, TestTimeout::mediumMs());
+
+        const double scale = TerrainHeightSource::heightScaleForZoom(zoom);
+        QCOMPARE_GT(scale, 0.0);
+        const auto heights = readySpy.first().at(1).value<QList<float>>();
+        QCOMPARE(heights.count(), kExpectedCount);
+        // Coarse patches extend past the 11km test region, so only the center
+        // vertex is guaranteed to sample the flat region's elevation
+        const int center = (kGridSize / 2 * (kGridSize + 1)) + (kGridSize / 2);
+        QCOMPARE(heights.at(center), static_cast<float>(UnitTestTerrainData::Flat10Region::amslElevation * scale));
+    }
+    QCOMPARE(TerrainHeightSource::heightScaleForZoom(TerrainHeightSource::kFullTerrainZoom), 1.0);
+    QCOMPARE(TerrainHeightSource::heightScaleForZoom(TerrainHeightSource::kMinTerrainZoom - 1), 0.0);
+}
+
+void TerrainHeightSourceTest::_coarseZoomDeliversFlatZeros()
+{
+    TerrainHeightSource source;
+    QSignalSpy readySpy(&source, &HeightSource::patchHeightsReady);
+
+    // Below the terrain zoom threshold the source answers locally with zeros,
+    // even over a region that has real (10m) elevation data
+    const int requestId = source.requestPatchHeights(
+        keyOver(flat10Region().center(), TerrainHeightSource::kMinTerrainZoom - 1), kGridSize);
+    QVERIFY(readySpy.wait());
+    QCOMPARE(readySpy.first().at(0).toInt(), requestId);
+
+    const auto heights = readySpy.first().at(1).value<QList<float>>();
+    QCOMPARE(heights.count(), kExpectedCount);
+    for (float h : heights) {
+        QCOMPARE(h, 0.0f);
+    }
+}
+
+void TerrainHeightSourceTest::_cancelPreventsDelivery()
+{
+    TerrainHeightSource source;
+    QSignalSpy readySpy(&source, &HeightSource::patchHeightsReady);
+    QSignalSpy failedSpy(&source, &HeightSource::patchHeightsFailed);
+
+    const TileMath::TileKey key = keyOver(flat10Region().center(), kFineZoom);
+    const int cancelledId = source.requestPatchHeights(key, kGridSize);
+    source.cancelRequest(cancelledId);
+    const int liveId = source.requestPatchHeights(key, kGridSize);
+
+    // Identical requests resolve through the same tile path in order: once the
+    // live request delivers, the cancelled one would already have been delivered
+    QTRY_COMPARE_WITH_TIMEOUT(readySpy.count(), 1, TestTimeout::mediumMs());
+    QCOMPARE(readySpy.first().at(0).toInt(), liveId);
+    QVERIFY(failedSpy.isEmpty());
+}
+
+void TerrainHeightSourceTest::_invalidGridSizeFails()
+{
+    TerrainHeightSource source;
+    QSignalSpy readySpy(&source, &HeightSource::patchHeightsReady);
+    QSignalSpy failedSpy(&source, &HeightSource::patchHeightsFailed);
+
+    const int requestId = source.requestPatchHeights(keyOver(flat10Region().center(), kFineZoom), 0);
+    QVERIFY(failedSpy.wait());
+    QCOMPARE(failedSpy.first().at(0).toInt(), requestId);
+    QVERIFY(readySpy.isEmpty());
+}
+
+UT_REGISTER_TEST(TerrainHeightSourceTest, TestLabel::Integration, TestLabel::Terrain)

--- a/test/GeoView/TerrainHeightSourceTest.h
+++ b/test/GeoView/TerrainHeightSourceTest.h
@@ -1,0 +1,17 @@
+#pragma once
+
+#include "TerrainTest.h"
+
+class TerrainHeightSourceTest : public TerrainTest
+{
+    Q_OBJECT
+
+private slots:
+    void _deliversFlatRegionHeights();
+    void _deliversSlopeRegionHeights();
+    void _interpolatesAcrossCellSteps();
+    void _blendBandScalesHeights();
+    void _coarseZoomDeliversFlatZeros();
+    void _cancelPreventsDelivery();
+    void _invalidGridSizeFails();
+};

--- a/test/GeoView/TileImageSourceTest.cc
+++ b/test/GeoView/TileImageSourceTest.cc
@@ -1,0 +1,114 @@
+#include "TileImageSourceTest.h"
+
+#include <QtTest/QSignalSpy>
+
+#include "QGCMapUrlEngine.h"
+#include "TileImageSource.h"
+#include "TileMath.h"
+
+namespace {
+
+// Any registered map provider works: the unit-test tile generator serves a
+// deterministic placeholder image on every cache miss, so no network is hit
+QString mapType()
+{
+    const QStringList elevationTypes = UrlFactory::getElevationProviderTypes();
+    for (const QString& type : UrlFactory::getProviderTypes()) {
+        if (!elevationTypes.contains(type)) {
+            return type;
+        }
+    }
+    return QString();
+}
+
+const TileMath::TileKey kKey{4302, 2867, 13};  // Zurich area
+
+}  // namespace
+
+void TileImageSourceTest::_tileDelivered()
+{
+    const QString type = mapType();
+    QVERIFY2(!type.isEmpty(), "no non-elevation map provider registered");
+
+    TileImageSource source(type);
+    QSignalSpy readySpy(&source, &TileImageSource::tileImageReady);
+    QSignalSpy failedSpy(&source, &TileImageSource::tileImageFailed);
+
+    const int requestId = source.requestTileImage(kKey);
+    QCOMPARE_GT(requestId, 0);
+    QCOMPARE(source.pendingCount(), 1);
+
+    QTRY_COMPARE_WITH_TIMEOUT(readySpy.count(), 1, 5000);
+    QCOMPARE(failedSpy.count(), 0);
+    QCOMPARE(source.pendingCount(), 0);
+
+    QCOMPARE(readySpy.first().at(0).toInt(), requestId);
+    const QImage image = readySpy.first().at(1).value<QImage>();
+    QVERIFY(!image.isNull());
+    QCOMPARE_GT(image.width(), 0);
+}
+
+void TileImageSourceTest::_cancelledRequestSilent()
+{
+    const QString type = mapType();
+    QVERIFY2(!type.isEmpty(), "no non-elevation map provider registered");
+
+    TileImageSource source(type);
+    QSignalSpy readySpy(&source, &TileImageSource::tileImageReady);
+    QSignalSpy failedSpy(&source, &TileImageSource::tileImageFailed);
+
+    const int cancelledId = source.requestTileImage(kKey);
+    source.cancelRequest(cancelledId);
+    QCOMPARE(source.pendingCount(), 0);
+
+    // The cache worker runs tasks in order: once this later request delivers,
+    // the cancelled one has already run its course without signalling
+    const int sentinelId = source.requestTileImage(TileMath::TileKey{kKey.x + 1, kKey.y, kKey.zoom});
+    QTRY_COMPARE_WITH_TIMEOUT(readySpy.count(), 1, 5000);
+    QCOMPARE(readySpy.first().at(0).toInt(), sentinelId);
+    QCOMPARE(failedSpy.count(), 0);
+}
+
+void TileImageSourceTest::_multipleRequestsIndependent()
+{
+    const QString type = mapType();
+    QVERIFY2(!type.isEmpty(), "no non-elevation map provider registered");
+
+    TileImageSource source(type);
+    QSignalSpy readySpy(&source, &TileImageSource::tileImageReady);
+
+    const int first = source.requestTileImage(kKey);
+    const int second = source.requestTileImage(TileMath::TileKey{kKey.x + 1, kKey.y, kKey.zoom});
+    QCOMPARE_NE(first, second);
+
+    QTRY_COMPARE_WITH_TIMEOUT(readySpy.count(), 2, 5000);
+
+    QSet<int> deliveredIds;
+    for (const QList<QVariant>& args : readySpy) {
+        deliveredIds.insert(args.at(0).toInt());
+    }
+    QCOMPARE(deliveredIds, (QSet<int>{first, second}));
+}
+
+void TileImageSourceTest::_unknownProviderFails()
+{
+    // The provider lookup deliberately warns once at construction
+    expectLogMessage("QtLocationPlugin.QGCMapUrlEngine", QtWarningMsg,
+                     QRegularExpression(QStringLiteral("type not found: \"No Such Provider\"")));
+    TileImageSource source(QStringLiteral("No Such Provider"));
+    verifyExpectedLogMessage();
+
+    QSignalSpy readySpy(&source, &TileImageSource::tileImageReady);
+    QSignalSpy failedSpy(&source, &TileImageSource::tileImageFailed);
+
+    const int requestId = source.requestTileImage(kKey);
+    QCOMPARE_GT(requestId, 0);
+    QCOMPARE(source.pendingCount(), 1);  // failure is still delivered asynchronously
+
+    QTRY_COMPARE_WITH_TIMEOUT(failedSpy.count(), 1, 5000);
+    QCOMPARE(failedSpy.first().at(0).toInt(), requestId);
+    QCOMPARE(readySpy.count(), 0);
+    QCOMPARE(source.pendingCount(), 0);
+}
+
+UT_REGISTER_TEST(TileImageSourceTest, TestLabel::Integration)

--- a/test/GeoView/TileImageSourceTest.h
+++ b/test/GeoView/TileImageSourceTest.h
@@ -1,0 +1,14 @@
+#pragma once
+
+#include "UnitTest.h"
+
+class TileImageSourceTest : public UnitTest
+{
+    Q_OBJECT
+
+private slots:
+    void _tileDelivered();
+    void _cancelledRequestSilent();
+    void _multipleRequestsIndependent();
+    void _unknownProviderFails();
+};

--- a/test/QmlUITests/GeoViewUITest.cc
+++ b/test/QmlUITests/GeoViewUITest.cc
@@ -68,6 +68,25 @@ void GeoViewUITest::_testViewSwitchWhenEnabled()
     QTRY_VERIFY_WITH_TIMEOUT(!viewport->findChildren<QObject*>(QStringLiteral("geoViewPatchDelegate")).isEmpty(), 5000);
     QVERIFY2(findVisibleItem(_rootItem, QStringLiteral("geoViewDebugOverlay")), "Debug overlay not visible");
 
+    // Tile imagery flows end-to-end: the model is wired to the flight map
+    // provider setting and every patch receives an image (the test tile
+    // generator serves placeholders on cache miss, so no network is involved)
+    auto* const patchModel = viewport->parentItem()->findChild<SurfacePatchModel*>(QStringLiteral("geoViewPatchModel"));
+    QVERIFY2(patchModel, "SurfacePatchModel not found");
+    QVERIFY2(!patchModel->mapType().isEmpty(), "Patch model not wired to a map provider");
+    const auto allPatchesImaged = [patchModel] {
+        if (patchModel->rowCount() == 0) {
+            return false;
+        }
+        for (int row = 0; row < patchModel->rowCount(); row++) {
+            if (!patchModel->data(patchModel->index(row), SurfacePatchModel::HasTileImageRole).toBool()) {
+                return false;
+            }
+        }
+        return true;
+    };
+    QTRY_VERIFY_WITH_TIMEOUT(allPatchesImaged(), 5000);
+
     // Scene camera node tracks the GeoViewCamera debug pose (overhead at 1500m,
     // identity rotation, origin anchored at the camera center)
     QObject* const sceneCamera = viewport->findChild<QObject*>(QStringLiteral("geoViewSceneCamera"));
@@ -270,8 +289,12 @@ void GeoViewUITest::_testModeToggleAndCompass()
     stopUI();
 }
 
-// The Hills dev toggle switches the height source (on by default): toggling
-// off flattens, toggling back on re-delivers non-flat heights
+// The debugHills dev override (settable from QML/C++ during development, no UI
+// affordance) swaps the terrain height source for analytic sin-hills: toggling
+// on delivers non-flat heights, toggling off flattens again. The test scene
+// sits outside the synthetic terrain regions, so the terrain source itself
+// delivers all-zero heights here (see TerrainHeightSourceTest for real
+// elevations).
 void GeoViewUITest::_testDebugHillsToggle()
 {
     Fact* const enabled = SettingsManager::instance()->geoViewSettings()->enabled();
@@ -306,21 +329,22 @@ void GeoViewUITest::_testDebugHillsToggle()
         return false;
     };
 
-    // Hills are on by default: non-flat heights from the start
-    QVERIFY(patchModel->debugHills());
-    QTRY_COMPARE_WITH_TIMEOUT(patchModel->pendingCount(), 0, 5000);
-    QTRY_VERIFY_WITH_TIMEOUT(anyNonZeroHeight(), 5000);
-
-    // Toggle off: flat source
-    QVERIFY(clickButton(QStringLiteral("geoViewHillsButton")));
+    // Terrain is the default: flat zero heights outside the synthetic regions
     QVERIFY(!patchModel->debugHills());
+    QVERIFY(patchModel->terrain());
     QTRY_COMPARE_WITH_TIMEOUT(patchModel->pendingCount(), 0, 5000);
     QVERIFY(!anyNonZeroHeight());
 
-    // Toggle back on: hills re-deliver
-    QVERIFY(clickButton(QStringLiteral("geoViewHillsButton")));
+    // Toggle hills on: non-flat heights
+    patchModel->setDebugHills(true);
     QVERIFY(patchModel->debugHills());
     QTRY_VERIFY_WITH_TIMEOUT(anyNonZeroHeight(), 5000);
+
+    // Toggle back off: terrain source flattens again
+    patchModel->setDebugHills(false);
+    QVERIFY(!patchModel->debugHills());
+    QTRY_COMPARE_WITH_TIMEOUT(patchModel->pendingCount(), 0, 5000);
+    QVERIFY(!anyNonZeroHeight());
 
     stopUI();
 }


### PR DESCRIPTION
Second step for the experimental GeoView map engine (preview feature, disabled by default): the surface goes from procedural placeholder to a real draped map. Builds on #14806.

## What's here

**Scene space** — `GeoScene` is extracted as the owner of the re-anchorable scene origin and vertical scale, giving overlays and the patch model one shared geo<->scene conversion point (`scenePositionFor`/`screenPositionFor`).

**Imagery** — `TileImageSource` is a cache-first adapter over QGC's shared map tile pipeline (tile cache, fetch tasks, provider registry; no new network stack). `SurfacePatchModel` drapes delivered tiles onto surface patches and keeps retired tiles as ancestor/descendant fallbacks, so LOD transitions refine blurry->sharp instead of flashing.

**Terrain** — `TerrainHeightSource` adapts the shared terrain pipeline behind the `HeightSource` interface. Vertex heights bilinearly interpolate the 1-arc-second elevation grid (the raw per-cell lookup renders as ~30 m terraces up close). Heights ramp in across a zoom blend band so the flat-zero far field is approached in steps instead of one cliff, and distance fog hides the far-field LOD rings.

**Resilience** — failed height requests (elevation tile fetch timeouts) retry past `TerrainTileManager`'s failed-tile backoff; patches replaced by LOD churn retire and keep rendering until their replacements have heights, so slow or flaky terrain fetches no longer punch holes in the surface; patches that exhaust retries keep their retiring cover instead of replacing real terrain with the flat fallback. `GeoViewCamera` gains an `isPositioned` gate so the null-island construction default never generates doomed terrain fetches at (0,0).

## Scope

All changes are contained to `src/GeoView` and its tests — no shared QGC code (tile pipeline, terrain manager, main window) is modified.

## Known limitations (deferred)

- Elevation tiles download serially through the shared `TerrainTileManager`, so terrain sharpens slowly when the elevation server is flaky; parallelizing that is a separate discussion.
- Patches coarser than zoom 12 render flat (blend band + fog mask the boundary); a coarse-elevation pyramid is future work.

## Testing

Three new suites (`TerrainHeightSourceTest`, `TileImageSourceTest`, `SurfacePatchImageryTest`, plus `GeoSceneTest`) run the full production pipelines against the synthetic tile/terrain test data — no network. Existing GeoView suites extended for retries, retiring patches, and the positioned gate. All 15 related suites green locally; manually verified over terrain-heavy ground with satellite and street imagery in 2D and 3D.