### PR TITLE
fix(QmlControls): use QtQuick.Dialogs FolderDialog so folder pickers work without native dialogs

### DIFF
--- a/src/AnalyzeView/OnboardLogs/OnboardLogPage.qml
+++ b/src/AnalyzeView/OnboardLogs/OnboardLogPage.qml
@@ -1,7 +1,6 @@
 import QtQuick
 import QtQuick.Controls
 import QtQuick.Layouts
-import Qt.labs.qmlmodels
 
 import QGroundControl
 import QGroundControl.Controls

--- a/src/FlightMap/FlightMap.qml
+++ b/src/FlightMap/FlightMap.qml
@@ -3,7 +3,6 @@ import QtQuick.Controls
 import QtLocation
 import QtPositioning
 import QtQuick.Dialogs
-import Qt.labs.animation
 
 import QGroundControl
 import QGroundControl.Controls

--- a/src/QmlControls/ClickableColor.qml
+++ b/src/QmlControls/ClickableColor.qml
@@ -1,7 +1,6 @@
 import QtQuick
 import QtQuick.Controls
 import QtQuick.Dialogs
-import Qt.labs.platform
 
 Rectangle {
     id:             _root
@@ -15,7 +14,7 @@ Rectangle {
     ColorDialog {
         id: colorDialog
         onAccepted: {
-            _root.colorSelected(colorDialog.color)
+            _root.colorSelected(colorDialog.selectedColor)
             colorDialog.close()
         }
     }
@@ -24,8 +23,8 @@ Rectangle {
         anchors.fill: parent
 
         onClicked: {
-            colorDialog.color = _root.color
-            colorDialog.visible = true
+            colorDialog.selectedColor = _root.color
+            colorDialog.open()
         }
     }
 }

--- a/src/QmlControls/QGCFileDialog.qml
+++ b/src/QmlControls/QGCFileDialog.qml
@@ -2,7 +2,6 @@ import QtQuick
 import QtQuick.Controls
 import QtQuick.Dialogs
 import QtQuick.Layouts
-import Qt.labs.platform as Labs
 
 import QGroundControl
 import QGroundControl.Controls
@@ -140,12 +139,12 @@ Item {
         onRejected: _root.rejected()
     }
 
-    Labs.FolderDialog {
+    FolderDialog {
         id:             fullFolderDialog
         currentFolder:  "file:///" + _root.folder
         title:          _root.title
 
-        onAccepted: _root.acceptedForLoad(QGCFileDialogController.urlToLocalFile(folder))
+        onAccepted: _root.acceptedForLoad(QGCFileDialogController.urlToLocalFile(selectedFolder))
         onRejected: _root.rejected()
     }
 


### PR DESCRIPTION
Related to #14789

## Problem

`Qt.labs.platform` dialogs (`FolderDialog`, `ColorDialog`) only show when the platform theme provides a native dialog implementation. The QtWidgets fallback they otherwise rely on was lost when QGC moved from `QApplication` to `QGuiApplication` in 5.1. On systems where no native dialog helper is available (e.g. the reported Kubuntu 24.04 AppImage case), `open()` silently does nothing — clicks on the onboard log Download button (and any other folder picker: Browse save path, GeoTag directories) are ignored.

Regular file open/save was unaffected because `QtQuick.Dialogs.FileDialog` has a pure-QML fallback implementation.

## Fix

- `QGCFileDialog.qml`: replace `Qt.labs.platform.FolderDialog` with `QtQuick.Dialogs.FolderDialog`, which falls back to the QML implementation when no native dialog exists. All folder pickers go through this wrapper, so this fixes them all at once.
- `ClickableColor.qml`: remove the `Qt.labs.platform` import which shadowed the `QtQuick.Dialogs.ColorDialog` (same silent-failure mode) and migrate to the `selectedColor`/`open()` API.
- Remove stale unused `Qt.labs.animation` / `Qt.labs.qmlmodels` imports (FlightMap, OnboardLogPage). No `Qt.labs.platform` usage remains in the repo.

Note: the missing date/time column also mentioned in #14789 is a separate FTP-listing data issue and is not addressed here.
