### PR TITLE
fix(AnalyzeView): show Date Unknown for onboard logs with invalid dates

### DIFF
--- a/src/AnalyzeView/OnboardLogs/OnboardLogController.cc
+++ b/src/AnalyzeView/OnboardLogs/OnboardLogController.cc
@@ -498,9 +498,13 @@ void OnboardLogController::refresh()
     emit selectionChanged();
 
     if (_vehicle && !_ftpDisabled && _vehicle->capabilitiesKnown() && (_vehicle->capabilityBits() & MAV_PROTOCOL_CAPABILITY_FTP)) {
+        qCDebug(OnboardLogControllerLog) << "refresh: using ftp transport";
         _setTransport(Transport::Ftp);
         _ftpStartListing();
     } else {
+        qCDebug(OnboardLogControllerLog) << "refresh: using message transport - ftpDisabled:" << _ftpDisabled
+            << "capabilitiesKnown:" << (_vehicle && _vehicle->capabilitiesKnown())
+            << "ftpCapable:" << bool(_vehicle && (_vehicle->capabilityBits() & MAV_PROTOCOL_CAPABILITY_FTP));
         _setTransport(Transport::Messages);
         _requestLogList(0, 0xffff);
     }

--- a/src/AnalyzeView/OnboardLogs/OnboardLogPage.qml
+++ b/src/AnalyzeView/OnboardLogs/OnboardLogPage.qml
@@ -71,7 +71,9 @@ AnalyzePage {
                                     return ""
                                 }
 
-                                if (object.time.getUTCFullYear() < 2010) {
+                                // getUTCFullYear() is NaN for an invalid date
+                                const year = object.time.getUTCFullYear()
+                                if (Number.isNaN(year) || year < 2010) {
                                     return qsTr("Date Unknown")
                                 }
 

--- a/test/QmlUITests/OnboardLogUITest.cc
+++ b/test/QmlUITests/OnboardLogUITest.cc
@@ -346,8 +346,9 @@ void OnboardLogUITest::_ftpDownloadUITest()
 {
     runWithMockLink([] { return MockLink::startPX4MockLink(MockConfiguration::OptionFtpCapability); },
                     [&](QPointer<MockLink> mockLink, Vehicle* /*vehicle*/) {
+                        // log_1 has no modification time so its date is unknown
                         const QList<MockLinkFTP::LogFile> logFiles = {
-                            {QStringLiteral("log_1.ulg"), 5000, 1700000000},
+                            {QStringLiteral("log_1.ulg"), 5000, 0},
                             {QStringLiteral("log_2.ulg"), 12345, 1700086400},
                         };
                         mockLink->mockLinkFTP()->setLogFiles(logFiles);
@@ -355,6 +356,15 @@ void OnboardLogUITest::_ftpDownloadUITest()
                         _navigateToOnboardLogsPage();
                         if (QTest::currentTestFailed())
                             return;
+
+                        // Entries without a valid timestamp sort last and must show "Date Unknown", not a blank cell
+                        QQuickItem* const knownDateLabel = findVisibleItem(_rootItem, QStringLiteral("onboardLogDate_0"), 15000);
+                        QVERIFY(knownDateLabel);
+                        QTRY_VERIFY_WITH_TIMEOUT(!knownDateLabel->property("text").toString().isEmpty(), 5000);
+                        QVERIFY(knownDateLabel->property("text").toString() != QStringLiteral("Date Unknown"));
+                        QQuickItem* const unknownDateLabel = findVisibleItem(_rootItem, QStringLiteral("onboardLogDate_1"), 2000);
+                        QVERIFY(unknownDateLabel);
+                        QTRY_COMPARE_WITH_TIMEOUT(unknownDateLabel->property("text").toString(), QStringLiteral("Date Unknown"), 5000);
 
                         QTemporaryDir tempDir;
                         QVERIFY(tempDir.isValid());


### PR DESCRIPTION
Related to #14789

## Problem

On the Analyze view Onboard Logs page, log entries with an invalid date (FTP listing with no modification time and no `yyyy-MM-dd` date directory to reconstruct from) rendered a **blank** date cell instead of "Date Unknown". `getUTCFullYear()` returns `NaN` for an invalid date, and `NaN < 2010` is false, so the "Date Unknown" branch was skipped and `toLocaleString()` on the invalid date produced an empty string. This matches the blank date cells in the #14789 report.

## Changes

- `OnboardLogPage.qml`: guard `Number.isNaN(year)` before the `< 2010` check so invalid dates show "Date Unknown".
- `OnboardLogController.cc`: `refresh()` now logs which transport was selected via `qCDebug(OnboardLogControllerLog)`, including the reason flags (`ftpDisabled`, `capabilitiesKnown`, `ftpCapable`) when falling back to the message transport — to aid diagnosing transport selection issues like #14789 (`QT_LOGGING_RULES="AnalyzeView.OnboardLogController.debug=true"`).
- `OnboardLogUITest`: the FTP download test now serves one log with `mtime = 0`, asserting the unknown-date entry sorts last and shows "Date Unknown" while the known-date entry shows a real date in row 0. This assertion fails without the QML fix (blank cell).

Note: the dead folder-picker part of #14789 is addressed separately in #14810.
