### PR TITLE
GeoView: surface analysis diagnostics, terrain-aware culling and texture seam fixes

### DIFF
--- a/src/GeoView/CMakeLists.txt
+++ b/src/GeoView/CMakeLists.txt
@@ -7,6 +7,8 @@ target_sources(${CMAKE_PROJECT_NAME}
     PRIVATE
         HeightSource.cc
         HeightSource.h
+        SurfaceAnalysis.cc
+        SurfaceAnalysis.h
         SurfaceModel.cc
         SurfaceModel.h
         TerrainHeightSource.cc

--- a/src/GeoView/GeoView.qml
+++ b/src/GeoView/GeoView.qml
@@ -174,6 +174,10 @@ Item {
 
                         Texture {
                             id: patchTexture
+                            // Clamp: default Repeat wrap bleeds opposite-edge texels
+                            // at UV 0/1, drawing 1-px seams on every patch border
+                            tilingModeHorizontal: Texture.ClampToEdge
+                            tilingModeVertical: Texture.ClampToEdge
                             textureData: PatchTextureData {
                                 image: patchDelegate.tileImage
                             }

--- a/src/GeoView/GeoView.qml
+++ b/src/GeoView/GeoView.qml
@@ -353,6 +353,14 @@ Item {
                         headingAnimation.start()
                     }
                 }
+
+                // Diagnostic: report holes, terrain cliffs, and bad height
+                // data to the debug output
+                QGCButton {
+                    objectName: "geoViewAnalyzeButton"
+                    text: qsTr("Analyze")
+                    onClicked: patchModel.analyzeSurface()
+                }
             }
         }
     }

--- a/src/GeoView/SurfaceAnalysis.cc
+++ b/src/GeoView/SurfaceAnalysis.cc
@@ -1,0 +1,550 @@
+#include "SurfaceAnalysis.h"
+
+#include <QtCore/QHash>
+#include <algorithm>
+#include <cmath>
+#include <optional>
+
+#include "TerrainHeightSource.h"
+
+namespace SurfaceAnalysis {
+
+namespace {
+
+enum Edge
+{
+    North,
+    South,
+    East,
+    West
+};
+
+constexpr QChar kEdgeChars[] = {u'N', u'S', u'E', u'W'};
+
+QRectF patchRect(const TileMath::TileKey& key)
+{
+    const double span = TileMath::tileSpanAtZoom(key.zoom);
+    const QPointF minCorner = TileMath::tileMinCorner(key);
+    return QRectF(minCorner.x(), minCorner.y(), span, span);
+}
+
+bool isPending(const SurfaceModel::Patch& patch)
+{
+    return !patch.ready;
+}
+
+bool isDegraded(const SurfaceModel::Patch& patch)
+{
+    return patch.ready && patch.heights.isEmpty();
+}
+
+/// Vertex height with the flat fallback for empty grids (pending/degraded)
+float heightAt(const SurfaceModel::Patch& patch, int verticesPerEdge, int row, int col)
+{
+    if (patch.heights.isEmpty()) {
+        return 0.0f;
+    }
+    return patch.heights.at((row * verticesPerEdge) + col);
+}
+
+/// Height along one edge of a patch at fractional grid coordinate t in
+/// [0, gridSize], linearly interpolated: what the rendered mesh shows there
+double edgeHeight(const SurfaceModel::Patch& patch, int gridSize, Edge edge, double t)
+{
+    t = std::clamp(t, 0.0, static_cast<double>(gridSize));
+    const int i0 = std::min(static_cast<int>(std::floor(t)), gridSize - 1);
+    const double frac = t - i0;
+    const int vpe = gridSize + 1;
+
+    double h0 = 0.0;
+    double h1 = 0.0;
+    switch (edge) {
+        case North:
+            h0 = heightAt(patch, vpe, 0, i0);
+            h1 = heightAt(patch, vpe, 0, i0 + 1);
+            break;
+        case South:
+            h0 = heightAt(patch, vpe, gridSize, i0);
+            h1 = heightAt(patch, vpe, gridSize, i0 + 1);
+            break;
+        case East:
+            h0 = heightAt(patch, vpe, i0, gridSize);
+            h1 = heightAt(patch, vpe, i0 + 1, gridSize);
+            break;
+        case West:
+            h0 = heightAt(patch, vpe, i0, 0);
+            h1 = heightAt(patch, vpe, i0 + 1, 0);
+            break;
+    }
+    return (h0 * (1.0 - frac)) + (h1 * frac);
+}
+
+SeamCause classify(const SurfaceModel::Patch& patch, const SurfaceModel::Patch& neighbor)
+{
+    if (isPending(patch) || isPending(neighbor)) {
+        return SeamCause::PendingFlat;
+    }
+    if (isDegraded(patch) || isDegraded(neighbor)) {
+        return SeamCause::DegradedFlat;
+    }
+    const double scaleP = TerrainHeightSource::heightScaleForZoom(patch.key.zoom);
+    const double scaleN = TerrainHeightSource::heightScaleForZoom(neighbor.key.zoom);
+    if (!qFuzzyCompare(scaleP, scaleN)) {
+        return SeamCause::BlendBandScale;
+    }
+    if (patch.key.zoom != neighbor.key.zoom) {
+        return SeamCause::LodTJunction;
+    }
+    return SeamCause::SameZoomMismatch;
+}
+
+/// Rendered surface height at a world point: bilinear sample of the finest
+/// rendered patch containing it (what the mesh shows there); nullopt when no
+/// rendered patch with heights spans the point
+std::optional<double> surfaceHeightAt(const QList<SurfaceModel::Patch>& patches, int gridSize, const QPointF& point)
+{
+    const SurfaceModel::Patch* best = nullptr;
+    for (const SurfaceModel::Patch& patch : patches) {
+        if (patch.covered || patch.heights.isEmpty() || !patchRect(patch.key).contains(point)) {
+            continue;
+        }
+        if (!best || (patch.key.zoom > best->key.zoom)) {
+            best = &patch;
+        }
+    }
+    if (!best) {
+        return std::nullopt;
+    }
+
+    const QRectF rect = patchRect(best->key);
+    const double step = rect.width() / gridSize;
+    // Row 0 is the north (max y) edge
+    const double colF = std::clamp((point.x() - rect.left()) / step, 0.0, static_cast<double>(gridSize));
+    const double rowF =
+        std::clamp(((rect.top() + rect.height()) - point.y()) / step, 0.0, static_cast<double>(gridSize));
+    const int col0 = std::min(static_cast<int>(std::floor(colF)), gridSize - 1);
+    const int row0 = std::min(static_cast<int>(std::floor(rowF)), gridSize - 1);
+    const double fCol = colF - col0;
+    const double fRow = rowF - row0;
+    const int vpe = gridSize + 1;
+    const double north =
+        (heightAt(*best, vpe, row0, col0) * (1.0 - fCol)) + (heightAt(*best, vpe, row0, col0 + 1) * fCol);
+    const double south =
+        (heightAt(*best, vpe, row0 + 1, col0) * (1.0 - fCol)) + (heightAt(*best, vpe, row0 + 1, col0 + 1) * fCol);
+    return (north * (1.0 - fRow)) + (south * fRow);
+}
+
+/// March the eye-to-hit sightline: a hole exists where the ray drops below
+/// the rendered terrain height while over ground no patch renders (the screen
+/// would show terrain there, but nothing is drawn). Returns the hole location,
+/// or nullopt when the sightline meets rendered terrain (or nothing at all).
+std::optional<QPointF> sightlineHole(const QList<SurfaceModel::Patch>& patches, int gridSize, const ViewState& view,
+                                     const QPointF& hit)
+{
+    constexpr int kRaySteps = 64;
+
+    // Terrain height is unknown over unrendered ground: carry the nearest
+    // rendered height along the ray as the continuity estimate
+    std::optional<double> nearbySurface;
+    for (int step = 1; step <= kRaySteps; step++) {
+        const double t = static_cast<double>(step) / kRaySteps;
+        const std::optional<double> height =
+            surfaceHeightAt(patches, gridSize, view.cameraGround + ((hit - view.cameraGround) * t));
+        if (height) {
+            nearbySurface = *height * view.heightScale;
+            break;
+        }
+    }
+    if (!nearbySurface) {
+        return std::nullopt;  // nothing rendered along the ray: legacy check reports it
+    }
+
+    for (int step = 1; step <= kRaySteps; step++) {
+        const double t = static_cast<double>(step) / kRaySteps;
+        const QPointF point = view.cameraGround + ((hit - view.cameraGround) * t);
+        const double rayZ = view.cameraHeight * (1.0 - t);
+        const std::optional<double> height = surfaceHeightAt(patches, gridSize, point);
+        if (height) {
+            const double surface = *height * view.heightScale;
+            if (rayZ <= surface) {
+                return std::nullopt;  // sightline meets rendered terrain: pixel is drawn
+            }
+            nearbySurface = surface;
+        } else if (rayZ <= *nearbySurface) {
+            return point;
+        }
+    }
+    return std::nullopt;
+}
+
+void findHoles(const QList<SurfaceModel::Patch>& patches, int gridSize, const ViewState& view, Report& report)
+{
+    const bool sightlines = (view.heightScale > 0.0) && (view.cameraHeight > 0.0);
+
+    for (const QPointF& point : view.groundSamples) {
+        report.totalSamples++;
+
+        if (sightlines) {
+            const std::optional<QPointF> blocked = sightlineHole(patches, gridSize, view, point);
+            if (blocked) {
+                Hole hole;
+                hole.at = TileMath::worldToGeo(*blocked);
+                hole.cause = HoleCause::ElevatedTerrainCulled;
+                report.holes.append(hole);
+                continue;
+            }
+        }
+
+        // Flat-ground hit: if no rendered patch spans it, the screen shows a
+        // hole there
+        bool renderedHere = false;
+        const SurfaceModel::Patch* suppressed = nullptr;
+        for (const SurfaceModel::Patch& patch : patches) {
+            if (!patchRect(patch.key).contains(point)) {
+                continue;
+            }
+            if (patch.covered) {
+                suppressed = &patch;
+            } else {
+                renderedHere = true;
+                break;
+            }
+        }
+        if (renderedHere) {
+            continue;
+        }
+
+        Hole hole;
+        hole.at = TileMath::worldToGeo(point);
+        if (suppressed) {
+            hole.cause = HoleCause::SuppressedCovered;
+            hole.patch = suppressed->key;
+        }
+        report.holes.append(hole);
+    }
+}
+
+void findBadHeights(const QList<SurfaceModel::Patch>& patches, Report& report)
+{
+    for (const SurfaceModel::Patch& patch : patches) {
+        int badCount = 0;
+        for (const float height : patch.heights) {
+            if (!std::isfinite(height)) {
+                badCount++;
+            }
+        }
+        if (badCount > 0) {
+            report.badHeights.append(BadHeights{patch.key, badCount});
+        }
+    }
+}
+
+}  // namespace
+
+QString seamCauseDescription(SeamCause cause)
+{
+    switch (cause) {
+        case SeamCause::PendingFlat:
+            return QStringLiteral("patch renders flat while its terrain heights are still loading");
+        case SeamCause::DegradedFlat:
+            return QStringLiteral("terrain height fetch failed; patch degraded to a flat fallback");
+        case SeamCause::BlendBandScale:
+            return QStringLiteral(
+                "neighbors use different blend-band height scales (coarse zoom heights are scaled down by design)");
+        case SeamCause::LodTJunction:
+            return QStringLiteral(
+                "LOD boundary T-junction: fine edge vertices vs the coarse neighbor's interpolated edge");
+        case SeamCause::SameZoomMismatch:
+            return QStringLiteral("same-zoom edge mismatch (unexpected sampling inconsistency)");
+    }
+    return QString();
+}
+
+QString holeCauseDescription(HoleCause cause)
+{
+    switch (cause) {
+        case HoleCause::NoPatch:
+            return QStringLiteral("no resident patch covers this visible area (culling/refinement bug)");
+        case HoleCause::SuppressedCovered:
+            return QStringLiteral(
+                "pending patch suppressed as covered, but the covering geometry does not span this area");
+        case HoleCause::ElevatedTerrainCulled:
+            return QStringLiteral(
+                "sightline passes below nearby terrain height over unrendered ground "
+                "(ground-plane visibility culling misses tall terrain near the camera)");
+    }
+    return QString();
+}
+
+QString Report::text() const
+{
+    QString out;
+    out += QStringLiteral("GeoView surface analysis\n");
+    out += QStringLiteral("Rendered patches: %1 (heights loading: %2, terrain fetch failed: %3)\n")
+               .arg(rendered)
+               .arg(pending)
+               .arg(degraded);
+
+    if (totalSamples > 0) {
+        if (holes.isEmpty()) {
+            out += QStringLiteral("Coverage holes: none (%1 sample points)\n").arg(totalSamples);
+        } else {
+            out += QStringLiteral("Coverage holes: %1 of %2 sample points uncovered\n")
+                       .arg(holes.count())
+                       .arg(totalSamples);
+            QHash<HoleCause, int> counts;
+            QHash<HoleCause, const Hole*> examples;
+            for (const Hole& hole : holes) {
+                counts[hole.cause]++;
+                if (!examples.contains(hole.cause)) {
+                    examples.insert(hole.cause, &hole);
+                }
+            }
+            for (auto it = counts.cbegin(); it != counts.cend(); ++it) {
+                const Hole* example = examples.value(it.key());
+                out += QStringLiteral("   %1x %2\n").arg(it.value()).arg(holeCauseDescription(it.key()));
+                out += QStringLiteral("      e.g. at %1,%2")
+                           .arg(example->at.latitude(), 0, 'f', 5)
+                           .arg(example->at.longitude(), 0, 'f', 5);
+                if (it.key() == HoleCause::SuppressedCovered) {
+                    out += QStringLiteral(" - zoom %1 tile (%2,%3)")
+                               .arg(example->patch.zoom)
+                               .arg(example->patch.x)
+                               .arg(example->patch.y);
+                }
+                out += QLatin1Char('\n');
+            }
+        }
+    }
+
+    if (cameraChecked) {
+        if (surfaceUnderCamera) {
+            out += QStringLiteral("Camera: %1 m above ground plane, surface under camera %2 m, max near camera %3 m")
+                       .arg(cameraHeight, 0, 'f', 1)
+                       .arg(surfaceAtCamera, 0, 'f', 1)
+                       .arg(maxSurfaceNearCamera, 0, 'f', 1);
+        } else {
+            out += QStringLiteral("Camera: %1 m above ground plane, no rendered terrain under the camera")
+                       .arg(cameraHeight, 0, 'f', 1);
+        }
+        if (cameraBelowSurface) {
+            out += QStringLiteral(" - CAMERA CLIPS INTO TERRAIN (eye below rendered surface; hole at screen bottom)");
+        }
+        out += QLatin1Char('\n');
+    }
+
+    if (badHeights.isEmpty()) {
+        out += QStringLiteral("Non-finite heights: none\n");
+    } else {
+        for (const BadHeights& bad : badHeights) {
+            out += QStringLiteral("Non-finite heights: %1 vertices in zoom %2 tile (%3,%4)\n")
+                       .arg(bad.count)
+                       .arg(bad.key.zoom)
+                       .arg(bad.key.x)
+                       .arg(bad.key.y);
+        }
+    }
+
+    out += QStringLiteral("Seams >= %1 m: %2\n").arg(minStep, 0, 'f', 1).arg(seams.count());
+    constexpr qsizetype kMaxListed = 20;
+    for (qsizetype i = 0; i < std::min(seams.count(), kMaxListed); i++) {
+        const Seam& seam = seams.at(i);
+        out += QStringLiteral("%1. %2 m step at %3,%4 - zoom %5 tile (%6,%7) %8 edge vs zoom %9 tile (%10,%11)\n")
+                   .arg(i + 1)
+                   .arg(seam.maxStep, 0, 'f', 1)
+                   .arg(seam.worstAt.latitude(), 0, 'f', 5)
+                   .arg(seam.worstAt.longitude(), 0, 'f', 5)
+                   .arg(seam.patch.zoom)
+                   .arg(seam.patch.x)
+                   .arg(seam.patch.y)
+                   .arg(seam.edge)
+                   .arg(seam.neighbor.zoom)
+                   .arg(seam.neighbor.x)
+                   .arg(seam.neighbor.y);
+        out += QStringLiteral("   cause: %1\n").arg(seamCauseDescription(seam.cause));
+    }
+    if (seams.count() > kMaxListed) {
+        out += QStringLiteral("... %1 more not listed\n").arg(seams.count() - kMaxListed);
+    }
+    if (!seams.isEmpty()) {
+        QHash<SeamCause, int> counts;
+        for (const Seam& seam : seams) {
+            counts[seam.cause]++;
+        }
+        out += QStringLiteral("Seam cause summary:\n");
+        for (auto it = counts.cbegin(); it != counts.cend(); ++it) {
+            out += QStringLiteral("   %1x %2\n").arg(it.value()).arg(seamCauseDescription(it.key()));
+        }
+    }
+    return out;
+}
+
+Report analyze(const QList<SurfaceModel::Patch>& patches, int gridSize, const ViewState& view, double minStep)
+{
+    Report report;
+    report.minStep = minStep;
+
+    // Covered patches do not render; everything else does (flat when no heights)
+    QHash<TileMath::TileKey, const SurfaceModel::Patch*> rendered;
+    for (const SurfaceModel::Patch& patch : patches) {
+        if (patch.covered) {
+            continue;
+        }
+        rendered.insert(patch.key, &patch);
+        report.rendered++;
+        if (isPending(patch)) {
+            report.pending++;
+        } else if (isDegraded(patch)) {
+            report.degraded++;
+        }
+    }
+
+    findHoles(patches, gridSize, view, report);
+    findBadHeights(patches, report);
+
+    if ((view.heightScale > 0.0) && (view.cameraHeight > 0.0)) {
+        report.cameraChecked = true;
+        report.cameraHeight = view.cameraHeight;
+
+        const std::optional<double> underCamera = surfaceHeightAt(patches, gridSize, view.cameraGround);
+        if (underCamera) {
+            report.surfaceUnderCamera = true;
+            report.surfaceAtCamera = *underCamera * view.heightScale;
+            report.maxSurfaceNearCamera = report.surfaceAtCamera;
+        }
+
+        // Terrain taller than the eye within roughly eye-height of the camera
+        // intrudes into the bottom of the frustum even when the point directly
+        // under the camera is low
+        for (const QPointF& point : view.groundSamples) {
+            const QPointF offset = point - view.cameraGround;
+            if (std::hypot(offset.x(), offset.y()) > view.cameraHeight) {
+                continue;
+            }
+            const std::optional<double> height = surfaceHeightAt(patches, gridSize, point);
+            if (height) {
+                report.maxSurfaceNearCamera = std::max(report.maxSurfaceNearCamera, *height * view.heightScale);
+            }
+        }
+
+        report.cameraBelowSurface = (report.surfaceUnderCamera && (view.cameraHeight < report.surfaceAtCamera)) ||
+                                    (view.cameraHeight < report.maxSurfaceNearCamera);
+    }
+
+    for (auto it = rendered.cbegin(); it != rendered.cend(); ++it) {
+        const SurfaceModel::Patch& patch = *it.value();
+        const TileMath::TileKey key = patch.key;
+        const int tilesAtZoom = 1 << key.zoom;
+        const QPointF minCorner = TileMath::tileMinCorner(key);
+        const double span = TileMath::tileSpanAtZoom(key.zoom);
+        const double step = span / gridSize;
+        const double maxY = minCorner.y() + span;
+
+        for (const Edge edge : {North, South, East, West}) {
+            TileMath::TileKey neighborKey = key;
+            switch (edge) {
+                case North:
+                    neighborKey.y--;  // tile y grows south
+                    break;
+                case South:
+                    neighborKey.y++;
+                    break;
+                case East:
+                    neighborKey.x++;
+                    break;
+                case West:
+                    neighborKey.x--;
+                    break;
+            }
+            if ((neighborKey.x < 0) || (neighborKey.x >= tilesAtZoom) || (neighborKey.y < 0) ||
+                (neighborKey.y >= tilesAtZoom)) {
+                continue;
+            }
+
+            // Find the rendered patch across this edge: the same-zoom neighbor,
+            // or the closest resident ancestor of it. Finer neighbors are
+            // handled from their own (fine) side.
+            const SurfaceModel::Patch* neighbor = nullptr;
+            if (rendered.contains(neighborKey)) {
+                if ((edge == West) || (edge == North)) {
+                    continue;  // same-zoom seams reported once, from the E/S side
+                }
+                neighbor = rendered.value(neighborKey);
+            } else {
+                for (int d = 1; (key.zoom - d) >= TileMath::kMinZoom; d++) {
+                    const TileMath::TileKey candidate{neighborKey.x >> d, neighborKey.y >> d, key.zoom - d};
+                    const TileMath::TileKey patchAncestor{key.x >> d, key.y >> d, key.zoom - d};
+                    if (candidate == patchAncestor) {
+                        break;  // candidate contains this patch: overlap cover, not a boundary
+                    }
+                    if (rendered.contains(candidate)) {
+                        neighbor = rendered.value(candidate);
+                        break;
+                    }
+                }
+            }
+            if (!neighbor) {
+                continue;
+            }
+
+            const QPointF nbMin = TileMath::tileMinCorner(neighbor->key);
+            const double nbSpan = TileMath::tileSpanAtZoom(neighbor->key.zoom);
+            const double nbStep = nbSpan / gridSize;
+            const double nbMaxY = nbMin.y() + nbSpan;
+
+            // Compare each of this patch's edge vertices against the neighbor's
+            // opposing rendered edge at the same world position
+            double maxStep = 0.0;
+            QPointF worstWorld;
+            const int vpe = gridSize + 1;
+            for (int i = 0; i <= gridSize; i++) {
+                double x = 0.0;
+                double y = 0.0;
+                double patchHeight = 0.0;
+                double neighborHeight = 0.0;
+                switch (edge) {
+                    case North:
+                        x = minCorner.x() + (i * step);
+                        y = maxY;
+                        patchHeight = heightAt(patch, vpe, 0, i);
+                        neighborHeight = edgeHeight(*neighbor, gridSize, South, (x - nbMin.x()) / nbStep);
+                        break;
+                    case South:
+                        x = minCorner.x() + (i * step);
+                        y = minCorner.y();
+                        patchHeight = heightAt(patch, vpe, gridSize, i);
+                        neighborHeight = edgeHeight(*neighbor, gridSize, North, (x - nbMin.x()) / nbStep);
+                        break;
+                    case East:
+                        x = minCorner.x() + span;
+                        y = maxY - (i * step);
+                        patchHeight = heightAt(patch, vpe, i, gridSize);
+                        neighborHeight = edgeHeight(*neighbor, gridSize, West, (nbMaxY - y) / nbStep);
+                        break;
+                    case West:
+                        x = minCorner.x();
+                        y = maxY - (i * step);
+                        patchHeight = heightAt(patch, vpe, i, 0);
+                        neighborHeight = edgeHeight(*neighbor, gridSize, East, (nbMaxY - y) / nbStep);
+                        break;
+                }
+                const double delta = std::abs(patchHeight - neighborHeight);
+                if (delta > maxStep) {
+                    maxStep = delta;
+                    worstWorld = QPointF(x, y);
+                }
+            }
+
+            if (maxStep >= minStep) {
+                report.seams.append(Seam{key, neighbor->key, kEdgeChars[edge], maxStep,
+                                         TileMath::worldToGeo(worstWorld), classify(patch, *neighbor)});
+            }
+        }
+    }
+
+    std::sort(report.seams.begin(), report.seams.end(),
+              [](const Seam& a, const Seam& b) { return a.maxStep > b.maxStep; });
+    return report;
+}
+
+}  // namespace SurfaceAnalysis

--- a/src/GeoView/SurfaceAnalysis.h
+++ b/src/GeoView/SurfaceAnalysis.h
@@ -1,0 +1,103 @@
+#pragma once
+
+#include <QtCore/QList>
+#include <QtCore/QPointF>
+#include <QtCore/QString>
+#include <QtPositioning/QGeoCoordinate>
+
+#include "SurfaceModel.h"
+#include "TileMath.h"
+
+/// Diagnostic pass over the rendered patch set: finds anything visibly wrong
+/// with the surface and classifies why it exists. Checks:
+///  - coverage holes: visible screen points with no rendered geometry under them
+///  - camera below the rendered surface (view clips into the mesh)
+///  - seams: height discontinuities ("cliffs") along patch boundaries
+///  - non-finite height data (NaN/inf vertices)
+///
+/// Seam cause classification assumes the TerrainHeightSource blend-band
+/// scaling (see TerrainHeightSource::heightScaleForZoom); with other height
+/// sources the scale-mismatch cause never triggers.
+namespace SurfaceAnalysis {
+
+enum class SeamCause
+{
+    PendingFlat,       ///< a patch renders flat because its heights are still loading
+    DegradedFlat,      ///< a patch renders flat because terrain fetches failed (retries exhausted)
+    BlendBandScale,    ///< neighbors use different blend-band height scales (by design)
+    LodTJunction,      ///< fine edge vertices vs the coarse neighbor's interpolated edge
+    SameZoomMismatch,  ///< same zoom, same scale: unexpected sampling inconsistency
+};
+
+enum class HoleCause
+{
+    NoPatch,                ///< no resident patch covers the visible point at all
+    SuppressedCovered,      ///< only a covered (render-suppressed) patch spans the point
+    ElevatedTerrainCulled,  ///< sightline passes below nearby terrain height over unrendered ground
+};
+
+QString seamCauseDescription(SeamCause cause);
+QString holeCauseDescription(HoleCause cause);
+
+struct Seam
+{
+    TileMath::TileKey patch;
+    TileMath::TileKey neighbor;
+    QChar edge;              ///< 'N','S','E','W': the patch's edge facing the neighbor
+    double maxStep = 0.0;    ///< largest vertex height difference along the shared edge (m)
+    QGeoCoordinate worstAt;  ///< geo position of the largest step
+    SeamCause cause = SeamCause::SameZoomMismatch;
+};
+
+struct Hole
+{
+    QGeoCoordinate at;        ///< uncovered sample point
+    HoleCause cause = HoleCause::NoPatch;
+    TileMath::TileKey patch;  ///< the suppressed patch (SuppressedCovered only)
+};
+
+struct BadHeights
+{
+    TileMath::TileKey key;
+    int count = 0;  ///< non-finite vertices in the patch
+};
+
+/// Camera-view context for the checks that need more than the patch set.
+/// groundSamples come from unprojecting screen points, so they catch holes
+/// the model's own visible-region estimate cannot see. When cameraGround,
+/// cameraHeight and heightScale are set, each sample is checked along the
+/// full eye-to-ground sightline, not just at the flat-ground hit point.
+struct ViewState
+{
+    QList<QPointF> groundSamples;  ///< world points visible on screen; must have rendered coverage
+    QPointF cameraGround;          ///< camera ground position (world meters)
+    double cameraHeight = 0.0;     ///< camera height above the ground plane (scene units); 0 skips the camera check
+    double heightScale = 0.0;      ///< vertical scale applied to patch heights; 0 skips the camera check
+};
+
+struct Report
+{
+    QList<Seam> seams;                ///< sorted by maxStep, largest first
+    QList<Hole> holes;                ///< one entry per uncovered sample point
+    QList<BadHeights> badHeights;
+    int totalSamples = 0;             ///< coverage sample points tested (0 = hole check skipped)
+    int rendered = 0;                 ///< patches participating (ready, or rendering flat uncovered)
+    int pending = 0;                  ///< rendered flat: heights still loading
+    int degraded = 0;                 ///< rendered flat: terrain fetches failed
+    bool cameraChecked = false;
+    bool surfaceUnderCamera = false;  ///< a rendered patch with heights spans the camera ground point
+    bool cameraBelowSurface = false;  ///< eye is below rendered terrain at/near the camera: hole at screen bottom
+    double cameraHeight = 0.0;        ///< scene units above the ground plane
+    double surfaceAtCamera = 0.0;     ///< rendered surface height at the camera ground position (scene units)
+    double maxSurfaceNearCamera =
+        0.0;                          ///< highest rendered surface at ground samples within cameraHeight of the camera
+    double minStep = 0.0;
+
+    QString text() const;  ///< human-readable report
+};
+
+/// Analyze the given patch set (SurfaceModel::patches()). Covered patches do
+/// not render and cannot close holes; seams below minStep meters are ignored.
+Report analyze(const QList<SurfaceModel::Patch>& patches, int gridSize, const ViewState& view, double minStep = 1.0);
+
+}  // namespace SurfaceAnalysis

--- a/src/GeoView/SurfaceModel.cc
+++ b/src/GeoView/SurfaceModel.cc
@@ -47,7 +47,10 @@ void SurfaceModel::update()
         return;  // keep the last valid set; transient 0-size viewports occur during layout
     }
 
-    const QRectF visible = _visibleGroundRect();
+    // Max terrain height scans every resident vertex: compute once per update
+    const double terrainZ = _maxTerrainZ();
+    const QRectF visible = _visibleGroundRect(terrainZ);
+    _culledTerrainZ = terrainZ;
     const QPointF cameraGround = _camera->cameraGroundPosition();
     const double cameraHeight = _camera->distance() * std::cos(qDegreesToRadians(_camera->tilt()));
 
@@ -148,10 +151,17 @@ int SurfaceModel::pendingCount() const
     return pending;
 }
 
-QRectF SurfaceModel::_visibleGroundRect() const
+QRectF SurfaceModel::_visibleGroundRect(double terrainZ) const
 {
     const QSizeF viewport = _camera->viewportSize();
     const double maxRange = _camera->distance() * kMaxRangeMultiplier;
+
+    // Terrain-aware near boundary: rays that hit the ground plane far ahead
+    // cross the terrain-top plane much closer to (or behind) the camera, so
+    // tall terrain there is visible even though its flat-ground point is not
+    const double eyeZ = _camera->distance() * std::cos(qDegreesToRadians(_camera->tilt()));
+    const QPointF cameraGround = _camera->cameraGroundPosition();
+    const double terrainT = ((terrainZ > 0.0) && (eyeZ > terrainZ)) ? (1.0 - (terrainZ / eyeZ)) : 0.0;
 
     // Sample a screen grid; horizon misses are capped at maxRange. Accumulate
     // extremes manually (zero-size QRectFs are "null" and united() ignores them).
@@ -160,6 +170,18 @@ QRectF SurfaceModel::_visibleGroundRect() const
     double maxX = 0;
     double maxY = 0;
     bool first = true;
+    const auto include = [&](const QPointF& point) {
+        if (first) {
+            minX = maxX = point.x();
+            minY = maxY = point.y();
+            first = false;
+        } else {
+            minX = std::min(minX, point.x());
+            maxX = std::max(maxX, point.x());
+            minY = std::min(minY, point.y());
+            maxY = std::max(maxY, point.y());
+        }
+    };
     for (int row = 0; row < kVisibleSampleGrid; row++) {
         for (int col = 0; col < kVisibleSampleGrid; col++) {
             const QPointF screenPos((viewport.width() * col) / (kVisibleSampleGrid - 1),
@@ -168,25 +190,41 @@ QRectF SurfaceModel::_visibleGroundRect() const
             if (!ground) {
                 continue;
             }
-            if (first) {
-                minX = maxX = ground->x();
-                minY = maxY = ground->y();
-                first = false;
-            } else {
-                minX = std::min(minX, ground->x());
-                maxX = std::max(maxX, ground->x());
-                minY = std::min(minY, ground->y());
-                maxY = std::max(maxY, ground->y());
+            include(*ground);
+            if (terrainT > 0.0) {
+                include(cameraGround + ((*ground - cameraGround) * terrainT));
             }
         }
     }
     if (first) {
         return QRectF();
     }
+    // Always keep the camera's tile in range: the terrain ceiling above only
+    // knows resident patches, so terrain living solely in never-requested
+    // tiles near the camera could otherwise never be discovered
+    include(cameraGround);
 
     const double half = TileMath::worldSize() / 2.0;
     return QRectF(QPointF(minX, minY), QPointF(maxX, maxY))
         .intersected(QRectF(-half, -half, TileMath::worldSize(), TileMath::worldSize()));
+}
+
+/// Tallest resident terrain in scene units (heights render scaled by the
+/// mercator vertical scale); 0 when nothing has heights yet
+double SurfaceModel::_maxTerrainZ() const
+{
+    float maxHeight = 0.0f;
+    for (const PatchData& data : _patches) {
+        for (const float height : data.heights) {
+            if (std::isfinite(height)) {
+                maxHeight = std::max(maxHeight, height);
+            }
+        }
+    }
+    if (maxHeight <= 0.0f) {
+        return 0.0;
+    }
+    return maxHeight * TileMath::mercatorScale(_camera->center().latitude());
 }
 
 double SurfaceModel::_projectedPixels(const TileMath::TileKey& key, const QPointF& cameraGround,
@@ -283,6 +321,12 @@ void SurfaceModel::_heightsReady(int requestId, const QList<float>& heights)
     patchIt.value().ready = true;
     emit patchReady(key);
     _sweepRetiring();
+
+    // Terrain taller than the last cull assumed may be visible below/behind
+    // the camera: re-cull terrain-aware
+    if (_maxTerrainZ() > (_culledTerrainZ + kRecullHeightMargin)) {
+        update();
+    }
 }
 
 void SurfaceModel::_sweepRetiring()

--- a/src/GeoView/SurfaceModel.h
+++ b/src/GeoView/SurfaceModel.h
@@ -49,7 +49,10 @@ public:
     static constexpr double kRefinePixelThreshold = 384.0;  ///< subdivide above this projected size
     static constexpr double kMaxRangeMultiplier = 40.0;     ///< visible-range cap in camera distances
     static constexpr int kVisibleSampleGrid = 5;            ///< NxN screen samples for visible-region estimation
-    static constexpr int kMaxHeightRetries = 3;             ///< re-requests before a patch degrades to flat
+    /// Re-cull when resident terrain grows taller than the last cull assumed by
+    /// more than this (scene units); avoids update churn on every patch delivery
+    static constexpr double kRecullHeightMargin = 25.0;
+    static constexpr int kMaxHeightRetries = 3;  ///< re-requests before a patch degrades to flat
     /// Default retry delay: past TerrainTileManager's 5s failed-tile backoff so a
     /// retry refetches instead of short-circuiting on the cached failure
     static constexpr int kDefaultHeightRetryDelayMs = 6000;
@@ -70,6 +73,9 @@ public:
 
     /// Single-patch lookup; std::nullopt when the key is not resident
     std::optional<Patch> patch(const TileMath::TileKey& key) const;
+
+    /// Estimated visible ground region in world meters (see class comment)
+    QRectF visibleGroundRect() const { return _visibleGroundRect(_maxTerrainZ()); }
 
     int patchCount() const { return _patches.count(); }
 
@@ -100,10 +106,11 @@ private:
         int retriesLeft = kMaxHeightRetries;
     };
 
-    QRectF _visibleGroundRect() const;
     double _projectedPixels(const TileMath::TileKey& key, const QPointF& cameraGround, double cameraHeight) const;
     QList<TileMath::TileKey> _desiredPatches(const QRectF& visible, const QPointF& cameraGround,
                                              double cameraHeight) const;
+    QRectF _visibleGroundRect(double terrainZ) const;
+    double _maxTerrainZ() const;
     void _retryHeights(const TileMath::TileKey& key);
     void _sweepRetiring();
     bool _overlapsPendingPatch(const TileMath::TileKey& key) const;
@@ -113,5 +120,6 @@ private:
     HeightSource* const _heightSource;
     QHash<TileMath::TileKey, PatchData> _patches;
     QHash<int, TileMath::TileKey> _requestKeys;
+    double _culledTerrainZ = 0.0;  ///< terrain-top height assumed by the last cull (scene units)
     int _heightRetryDelayMs = kDefaultHeightRetryDelayMs;
 };

--- a/src/GeoView/SurfacePatchModel.cc
+++ b/src/GeoView/SurfacePatchModel.cc
@@ -1,11 +1,15 @@
 #include "SurfacePatchModel.h"
 
+#include <QtCore/QDebug>
+#include <QtCore/QtMath>
 #include <QtGui/QPainter>
 #include <algorithm>
+#include <cmath>
 
 #include "GeoScene.h"
 #include "GeoViewCamera.h"
 #include "HeightSource.h"
+#include "SurfaceAnalysis.h"
 #include "SurfaceModel.h"
 #include "TerrainHeightSource.h"
 #include "TileImageSource.h"
@@ -217,6 +221,48 @@ int SurfacePatchModel::maxZoomLevel() const
         maxZoom = std::max(maxZoom, key.zoom);
     }
     return maxZoom;
+}
+
+void SurfacePatchModel::analyzeSurface() const
+{
+    GeoViewCamera* const camera = _camera();
+    if (!_surfaceModel || !camera) {
+        qDebug() << "Surface analysis: no surface model active";
+        return;
+    }
+
+    SurfaceAnalysis::ViewState view;
+
+    // Unproject a dense screen grid to ground points: coverage is checked
+    // where the screen actually looks, independent of the model's own
+    // visible-region estimate
+    const QSizeF viewport = camera->viewportSize();
+    const double maxRange = camera->distance() * SurfaceModel::kMaxRangeMultiplier;
+    constexpr int kScreenGrid = 24;
+    if (!viewport.isEmpty()) {
+        for (int row = 0; row < kScreenGrid; row++) {
+            for (int col = 0; col < kScreenGrid; col++) {
+                const QPointF screenPos(viewport.width() * (col + 0.5) / kScreenGrid,
+                                        viewport.height() * (row + 0.5) / kScreenGrid);
+                const std::optional<QPointF> ground = camera->groundPointCapped(screenPos, maxRange);
+                if (ground) {
+                    view.groundSamples.append(*ground);
+                }
+            }
+        }
+    }
+
+    // Camera-below-surface check only applies in 3D (in 2D the mesh renders
+    // flattened, so comparing against real heights would be wrong)
+    if (_scene && (camera->tilt() > 0.0)) {
+        view.cameraGround = camera->cameraGroundPosition();
+        view.cameraHeight = camera->distance() * std::cos(qDegreesToRadians(camera->tilt()));
+        view.heightScale = _scene->verticalScale();
+    }
+
+    const SurfaceAnalysis::Report report =
+        SurfaceAnalysis::analyze(_surfaceModel->patches(), SurfaceModel::kGridSize, view);
+    qDebug().noquote() << report.text();  // user-triggered diagnostic: always emitted
 }
 
 int SurfacePatchModel::rowCount(const QModelIndex& parent) const

--- a/src/GeoView/SurfacePatchModel.h
+++ b/src/GeoView/SurfacePatchModel.h
@@ -93,6 +93,11 @@ public:
     int pendingCount() const;
     int maxZoomLevel() const;
 
+    /// Diagnostic pass over the current patch set: reports coverage holes,
+    /// boundary height cliffs, and bad height data, with the reason each
+    /// exists (see SurfaceAnalysis). The report goes to the debug output.
+    Q_INVOKABLE void analyzeSurface() const;
+
     int rowCount(const QModelIndex& parent = QModelIndex()) const override;
     QVariant data(const QModelIndex& index, int role) const override;
     QHash<int, QByteArray> roleNames() const override;

--- a/test/GeoView/CMakeLists.txt
+++ b/test/GeoView/CMakeLists.txt
@@ -17,6 +17,8 @@ target_sources(${CMAKE_PROJECT_NAME}
         PatchGeometryTest.h
         PatchTextureDataTest.cc
         PatchTextureDataTest.h
+        SurfaceAnalysisTest.cc
+        SurfaceAnalysisTest.h
         SurfaceModelTest.cc
         SurfaceModelTest.h
         SurfacePatchImageryTest.cc
@@ -39,6 +41,7 @@ add_qgc_test(GeoViewCameraTest LABELS Unit)
 add_qgc_test(HeightSourceTest LABELS Unit)
 add_qgc_test(PatchGeometryTest LABELS Unit)
 add_qgc_test(PatchTextureDataTest LABELS Unit)
+add_qgc_test(SurfaceAnalysisTest LABELS Unit)
 add_qgc_test(SurfaceModelTest LABELS Unit)
 add_qgc_test(SurfacePatchImageryTest LABELS Integration)
 add_qgc_test(SurfacePatchModelTest LABELS Unit)

--- a/test/GeoView/SurfaceAnalysisTest.cc
+++ b/test/GeoView/SurfaceAnalysisTest.cc
@@ -1,0 +1,424 @@
+#include "SurfaceAnalysisTest.h"
+
+#include <cmath>
+#include <limits>
+
+#include "SurfaceAnalysis.h"
+#include "SurfaceModel.h"
+#include "TileMath.h"
+
+namespace {
+
+constexpr int kGridSize = 4;
+constexpr int kVertexCount = (kGridSize + 1) * (kGridSize + 1);
+
+/// Ready patch with a constant height everywhere
+SurfaceModel::Patch readyPatch(const TileMath::TileKey& key, float height)
+{
+    return SurfaceModel::Patch{key, QList<float>(kVertexCount, height), true, false};
+}
+
+/// Pending patch: heights still loading, renders flat unless covered
+SurfaceModel::Patch pendingPatch(const TileMath::TileKey& key, bool covered = false)
+{
+    return SurfaceModel::Patch{key, {}, false, covered};
+}
+
+/// Degraded patch: retries exhausted, ready with empty heights (flat fallback)
+SurfaceModel::Patch degradedPatch(const TileMath::TileKey& key)
+{
+    return SurfaceModel::Patch{key, {}, true, false};
+}
+
+QRectF worldRect(const TileMath::TileKey& key)
+{
+    const double span = TileMath::tileSpanAtZoom(key.zoom);
+    const QPointF minCorner = TileMath::tileMinCorner(key);
+    return QRectF(minCorner.x(), minCorner.y(), span, span);
+}
+
+// Adjacent same-zoom pair at full terrain scale (zoom >= 14)
+constexpr TileMath::TileKey kWestKey{100, 100, 15};
+constexpr TileMath::TileKey kEastKey{101, 100, 15};
+
+// Seam-only analysis: no ground samples skips the coverage-hole scan, no
+// height scale skips the camera check
+const SurfaceAnalysis::ViewState kSeamsOnly;
+
+constexpr int kSampleGrid = 8;
+
+/// View state whose ground samples cover the rect with a cell-center grid
+SurfaceAnalysis::ViewState samplesOver(const QRectF& rect)
+{
+    SurfaceAnalysis::ViewState view;
+    for (int row = 0; row < kSampleGrid; row++) {
+        for (int col = 0; col < kSampleGrid; col++) {
+            view.groundSamples.append(QPointF(rect.left() + (rect.width() * (col + 0.5) / kSampleGrid),
+                                              rect.top() + (rect.height() * (row + 0.5) / kSampleGrid)));
+        }
+    }
+    return view;
+}
+
+}  // namespace
+
+void SurfaceAnalysisTest::_noSeamsOnMatchingEdges()
+{
+    const QList<SurfaceModel::Patch> patches{readyPatch(kWestKey, 25.0f), readyPatch(kEastKey, 25.0f)};
+
+    const SurfaceAnalysis::Report report = SurfaceAnalysis::analyze(patches, kGridSize, kSeamsOnly);
+    QVERIFY(report.seams.isEmpty());
+    QCOMPARE(report.rendered, 2);
+    QCOMPARE(report.pending, 0);
+    QCOMPARE(report.degraded, 0);
+}
+
+void SurfaceAnalysisTest::_pendingFlatSeam()
+{
+    const QList<SurfaceModel::Patch> patches{readyPatch(kWestKey, 50.0f), pendingPatch(kEastKey)};
+
+    const SurfaceAnalysis::Report report = SurfaceAnalysis::analyze(patches, kGridSize, kSeamsOnly);
+    QCOMPARE(report.seams.count(), 1);
+    QCOMPARE(report.pending, 1);
+
+    const SurfaceAnalysis::Seam& seam = report.seams.first();
+    QCOMPARE(seam.cause, SurfaceAnalysis::SeamCause::PendingFlat);
+    QCOMPARE(seam.maxStep, 50.0);
+    QVERIFY(seam.worstAt.isValid());
+}
+
+void SurfaceAnalysisTest::_degradedFlatSeam()
+{
+    const QList<SurfaceModel::Patch> patches{readyPatch(kWestKey, 50.0f), degradedPatch(kEastKey)};
+
+    const SurfaceAnalysis::Report report = SurfaceAnalysis::analyze(patches, kGridSize, kSeamsOnly);
+    QCOMPARE(report.seams.count(), 1);
+    QCOMPARE(report.degraded, 1);
+    QCOMPARE(report.seams.first().cause, SurfaceAnalysis::SeamCause::DegradedFlat);
+}
+
+void SurfaceAnalysisTest::_coveredPatchIgnored()
+{
+    // A covered pending patch does not render, so it cannot form a seam
+    const QList<SurfaceModel::Patch> patches{readyPatch(kWestKey, 50.0f), pendingPatch(kEastKey, true)};
+
+    const SurfaceAnalysis::Report report = SurfaceAnalysis::analyze(patches, kGridSize, kSeamsOnly);
+    QVERIFY(report.seams.isEmpty());
+    QCOMPARE(report.rendered, 1);
+}
+
+void SurfaceAnalysisTest::_belowThresholdIgnored()
+{
+    const QList<SurfaceModel::Patch> patches{readyPatch(kWestKey, 0.0f), readyPatch(kEastKey, 0.5f)};
+
+    const SurfaceAnalysis::Report report = SurfaceAnalysis::analyze(patches, kGridSize, kSeamsOnly);
+    QVERIFY(report.seams.isEmpty());
+}
+
+void SurfaceAnalysisTest::_sameZoomMismatch()
+{
+    const QList<SurfaceModel::Patch> patches{readyPatch(kWestKey, 0.0f), readyPatch(kEastKey, 50.0f)};
+
+    const SurfaceAnalysis::Report report = SurfaceAnalysis::analyze(patches, kGridSize, kSeamsOnly);
+    QCOMPARE(report.seams.count(), 1);
+
+    const SurfaceAnalysis::Seam& seam = report.seams.first();
+    QCOMPARE(seam.cause, SurfaceAnalysis::SeamCause::SameZoomMismatch);
+    QCOMPARE(seam.maxStep, 50.0);
+    QCOMPARE(seam.patch, kWestKey);
+    QCOMPARE(seam.neighbor, kEastKey);
+    QCOMPARE(seam.edge, QChar('E'));
+}
+
+void SurfaceAnalysisTest::_sameZoomSeamReportedOnce()
+{
+    // The shared boundary must not be reported from both sides
+    const QList<SurfaceModel::Patch> patches{readyPatch(kEastKey, 50.0f), readyPatch(kWestKey, 0.0f)};
+
+    const SurfaceAnalysis::Report report = SurfaceAnalysis::analyze(patches, kGridSize, kSeamsOnly);
+    QCOMPARE(report.seams.count(), 1);
+}
+
+void SurfaceAnalysisTest::_lodTJunction()
+{
+    // Coarse (1,1,14) east edge borders fine (4,2,15) west edge; both at full
+    // height scale, so the only cause left is the LOD boundary itself
+    const TileMath::TileKey coarseKey{1, 1, 14};
+    const TileMath::TileKey fineKey{4, 2, 15};
+
+    // Coarse heights vary by row (row * 10): the fine edge spans the coarse
+    // edge's northern half, so interpolated coarse heights run 0..20
+    QList<float> coarseHeights;
+    coarseHeights.reserve(kVertexCount);
+    for (int row = 0; row <= kGridSize; row++) {
+        for (int col = 0; col <= kGridSize; col++) {
+            coarseHeights.append(row * 10.0f);
+        }
+    }
+
+    const QList<SurfaceModel::Patch> patches{
+        SurfaceModel::Patch{coarseKey, coarseHeights, true, false},
+        readyPatch(fineKey, 0.0f),
+    };
+
+    const SurfaceAnalysis::Report report = SurfaceAnalysis::analyze(patches, kGridSize, kSeamsOnly);
+    QCOMPARE(report.seams.count(), 1);
+
+    const SurfaceAnalysis::Seam& seam = report.seams.first();
+    QCOMPARE(seam.cause, SurfaceAnalysis::SeamCause::LodTJunction);
+    QCOMPARE(seam.patch, fineKey);
+    QCOMPARE(seam.neighbor, coarseKey);
+    QCOMPARE(seam.edge, QChar('W'));
+    QVERIFY(std::abs(seam.maxStep - 20.0) < 1e-6);
+}
+
+void SurfaceAnalysisTest::_blendBandScale()
+{
+    // Zoom 12 vs 13 neighbors sit in the blend band with different height
+    // scales: classified as the (by design) scale mismatch, not a T-junction
+    const TileMath::TileKey coarseKey{1, 1, 12};
+    const TileMath::TileKey fineKey{4, 2, 13};
+
+    const QList<SurfaceModel::Patch> patches{readyPatch(coarseKey, 10.0f), readyPatch(fineKey, 20.0f)};
+
+    const SurfaceAnalysis::Report report = SurfaceAnalysis::analyze(patches, kGridSize, kSeamsOnly);
+    QCOMPARE(report.seams.count(), 1);
+    QCOMPARE(report.seams.first().cause, SurfaceAnalysis::SeamCause::BlendBandScale);
+    QCOMPARE(report.seams.first().maxStep, 10.0);
+}
+
+void SurfaceAnalysisTest::_overlappingAncestorNotASeamNeighbor()
+{
+    // (2,1,14) contains (4,2,15) entirely (a retiring cover): overlap, not a
+    // boundary, so no seam despite the height difference
+    const TileMath::TileKey coverKey{2, 1, 14};
+    const TileMath::TileKey fineKey{4, 2, 15};
+
+    const QList<SurfaceModel::Patch> patches{readyPatch(coverKey, 0.0f), readyPatch(fineKey, 50.0f)};
+
+    const SurfaceAnalysis::Report report = SurfaceAnalysis::analyze(patches, kGridSize, kSeamsOnly);
+    QVERIFY(report.seams.isEmpty());
+}
+
+void SurfaceAnalysisTest::_noHolesWhenFullyCovered()
+{
+    const QList<SurfaceModel::Patch> patches{readyPatch(kWestKey, 0.0f)};
+
+    const SurfaceAnalysis::Report report =
+        SurfaceAnalysis::analyze(patches, kGridSize, samplesOver(worldRect(kWestKey)));
+    QVERIFY(report.holes.isEmpty());
+    QCOMPARE(report.totalSamples, kSampleGrid * kSampleGrid);
+}
+
+void SurfaceAnalysisTest::_holeNoPatch()
+{
+    // Visible region spans two tiles but only the west one is resident
+    const QRectF visible = worldRect(kWestKey).united(worldRect(kEastKey));
+    const QList<SurfaceModel::Patch> patches{readyPatch(kWestKey, 0.0f)};
+
+    const SurfaceAnalysis::Report report = SurfaceAnalysis::analyze(patches, kGridSize, samplesOver(visible));
+    QVERIFY(!report.holes.isEmpty());
+    for (const SurfaceAnalysis::Hole& hole : report.holes) {
+        QCOMPARE(hole.cause, SurfaceAnalysis::HoleCause::NoPatch);
+        QVERIFY(hole.at.isValid());
+    }
+}
+
+void SurfaceAnalysisTest::_holeSuppressedCovered()
+{
+    // The east tile is resident but suppressed as covered while nothing
+    // actually renders over it: every sample there is a hole
+    const QList<SurfaceModel::Patch> patches{readyPatch(kWestKey, 0.0f), pendingPatch(kEastKey, true)};
+
+    const SurfaceAnalysis::Report report =
+        SurfaceAnalysis::analyze(patches, kGridSize, samplesOver(worldRect(kEastKey)));
+    QVERIFY(!report.holes.isEmpty());
+    for (const SurfaceAnalysis::Hole& hole : report.holes) {
+        QCOMPARE(hole.cause, SurfaceAnalysis::HoleCause::SuppressedCovered);
+        QCOMPARE(hole.patch, kEastKey);
+    }
+}
+
+void SurfaceAnalysisTest::_holeCheckSkippedWithoutSamples()
+{
+    const QList<SurfaceModel::Patch> patches{readyPatch(kWestKey, 0.0f)};
+
+    const SurfaceAnalysis::Report report = SurfaceAnalysis::analyze(patches, kGridSize, kSeamsOnly);
+    QCOMPARE(report.totalSamples, 0);
+    QVERIFY(report.holes.isEmpty());
+}
+
+void SurfaceAnalysisTest::_holeElevatedTerrainCulled()
+{
+    // The eye sits over an unrendered tile at 100 units up; the only rendered
+    // patch ahead shows 200 m terrain. The sightline to its flat-ground hit
+    // passes below that terrain height while still over the unrendered tile:
+    // the screen shows a hole there even though the hit point itself is covered
+    const QList<SurfaceModel::Patch> patches{readyPatch(kEastKey, 200.0f)};
+
+    SurfaceAnalysis::ViewState view;
+    view.cameraGround = worldRect(kWestKey).center();
+    view.cameraHeight = 100.0;
+    view.heightScale = 1.0;
+    view.groundSamples.append(worldRect(kEastKey).center());
+
+    const SurfaceAnalysis::Report report = SurfaceAnalysis::analyze(patches, kGridSize, view);
+    QCOMPARE(report.holes.count(), 1);
+    QCOMPARE(report.holes.first().cause, SurfaceAnalysis::HoleCause::ElevatedTerrainCulled);
+    QVERIFY(report.holes.first().at.isValid());
+    QVERIFY(report.text().contains(
+        SurfaceAnalysis::holeCauseDescription(SurfaceAnalysis::HoleCause::ElevatedTerrainCulled)));
+}
+
+void SurfaceAnalysisTest::_elevatedTerrainRenderedNoHole()
+{
+    // Same geometry, but the tile under the eye renders too: the sightline
+    // meets rendered terrain, so tall terrain in view is not a hole
+    const QList<SurfaceModel::Patch> patches{readyPatch(kWestKey, 200.0f), readyPatch(kEastKey, 200.0f)};
+
+    SurfaceAnalysis::ViewState view;
+    view.cameraGround = worldRect(kWestKey).center();
+    view.cameraHeight = 100.0;
+    view.heightScale = 1.0;
+    view.groundSamples.append(worldRect(kEastKey).center());
+
+    const SurfaceAnalysis::Report report = SurfaceAnalysis::analyze(patches, kGridSize, view);
+    QVERIFY(report.holes.isEmpty());
+}
+
+void SurfaceAnalysisTest::_cameraBelowSurface()
+{
+    // Camera sits 80 units above the ground plane but the rendered surface
+    // there is 100 m * 1.5 scale = 150 units: the view clips into the mesh
+    const QList<SurfaceModel::Patch> patches{readyPatch(kWestKey, 100.0f)};
+
+    SurfaceAnalysis::ViewState view;
+    view.cameraGround = worldRect(kWestKey).center();
+    view.cameraHeight = 80.0;
+    view.heightScale = 1.5;
+
+    const SurfaceAnalysis::Report report = SurfaceAnalysis::analyze(patches, kGridSize, view);
+    QVERIFY(report.cameraChecked);
+    QVERIFY(report.cameraBelowSurface);
+    QCOMPARE(report.surfaceAtCamera, 150.0);
+    QCOMPARE(report.cameraHeight, 80.0);
+    QVERIFY(report.text().contains("CAMERA CLIPS INTO TERRAIN"));
+}
+
+void SurfaceAnalysisTest::_cameraAboveSurface()
+{
+    const QList<SurfaceModel::Patch> patches{readyPatch(kWestKey, 100.0f)};
+
+    SurfaceAnalysis::ViewState view;
+    view.cameraGround = worldRect(kWestKey).center();
+    view.cameraHeight = 200.0;
+    view.heightScale = 1.0;
+    view.groundSamples.append(worldRect(kWestKey).center());
+
+    const SurfaceAnalysis::Report report = SurfaceAnalysis::analyze(patches, kGridSize, view);
+    QVERIFY(report.cameraChecked);
+    QVERIFY(!report.cameraBelowSurface);
+    QCOMPARE(report.surfaceAtCamera, 100.0);
+    QVERIFY(!report.text().contains("CAMERA CLIPS INTO TERRAIN"));
+}
+
+void SurfaceAnalysisTest::_cameraClipsNearbyTerrain()
+{
+    // Surface directly under the camera is low, but a nearby visible sample
+    // (well within cameraHeight range) rises above the camera eye height
+    const QList<SurfaceModel::Patch> patches{readyPatch(kWestKey, 10.0f), readyPatch(kEastKey, 200.0f)};
+
+    const QRectF westRect = worldRect(kWestKey);
+    SurfaceAnalysis::ViewState view;
+    view.cameraGround = QPointF(westRect.right() - 10.0, westRect.center().y());
+    view.cameraHeight = 150.0;
+    view.heightScale = 1.0;
+    view.groundSamples.append(QPointF(westRect.right() + 10.0, westRect.center().y()));
+
+    const SurfaceAnalysis::Report report = SurfaceAnalysis::analyze(patches, kGridSize, view);
+    QVERIFY(report.cameraChecked);
+    QVERIFY(report.cameraBelowSurface);
+    QCOMPARE(report.surfaceAtCamera, 10.0);
+    QCOMPARE(report.maxSurfaceNearCamera, 200.0);
+    QVERIFY(report.text().contains("CAMERA CLIPS INTO TERRAIN"));
+}
+
+void SurfaceAnalysisTest::_noSurfaceUnderCamera()
+{
+    // Camera ground point sits outside every resident patch (happens at high
+    // tilt: nearest visible ground is well in front of the camera): the
+    // report must say so instead of claiming a surface height of 0
+    const QList<SurfaceModel::Patch> patches{readyPatch(kWestKey, 100.0f)};
+
+    SurfaceAnalysis::ViewState view;
+    view.cameraGround = worldRect(kEastKey).center();
+    view.cameraHeight = 200.0;
+    view.heightScale = 1.0;
+
+    const SurfaceAnalysis::Report report = SurfaceAnalysis::analyze(patches, kGridSize, view);
+    QVERIFY(report.cameraChecked);
+    QVERIFY(!report.surfaceUnderCamera);
+    QVERIFY(!report.cameraBelowSurface);
+    QVERIFY(report.text().contains("no rendered terrain under the camera"));
+}
+
+void SurfaceAnalysisTest::_cameraCheckSkippedWithoutScale()
+{
+    const QList<SurfaceModel::Patch> patches{readyPatch(kWestKey, 100.0f)};
+
+    const SurfaceAnalysis::Report report = SurfaceAnalysis::analyze(patches, kGridSize, kSeamsOnly);
+    QVERIFY(!report.cameraChecked);
+    QVERIFY(!report.cameraBelowSurface);
+}
+
+void SurfaceAnalysisTest::_cameraCheckSkippedWithoutHeight()
+{
+    // heightScale set but cameraHeight left at its default of 0: the camera
+    // fields are invalid, so the check must not run (and must not report a
+    // false clip against terrain above the 0-height eye)
+    const QList<SurfaceModel::Patch> patches{readyPatch(kWestKey, 100.0f)};
+
+    SurfaceAnalysis::ViewState view;
+    view.cameraGround = worldRect(kWestKey).center();
+    view.heightScale = 1.0;
+
+    const SurfaceAnalysis::Report report = SurfaceAnalysis::analyze(patches, kGridSize, view);
+    QVERIFY(!report.cameraChecked);
+    QVERIFY(!report.cameraBelowSurface);
+    QVERIFY(!report.text().contains("CAMERA CLIPS INTO TERRAIN"));
+}
+
+void SurfaceAnalysisTest::_nonFiniteHeights()
+{
+    QList<float> heights(kVertexCount, 10.0f);
+    heights[3] = std::numeric_limits<float>::quiet_NaN();
+    heights[7] = std::numeric_limits<float>::infinity();
+    const QList<SurfaceModel::Patch> patches{SurfaceModel::Patch{kWestKey, heights, true, false}};
+
+    const SurfaceAnalysis::Report report = SurfaceAnalysis::analyze(patches, kGridSize, kSeamsOnly);
+    QCOMPARE(report.badHeights.count(), 1);
+    QCOMPARE(report.badHeights.first().key, kWestKey);
+    QCOMPARE(report.badHeights.first().count, 2);
+}
+
+void SurfaceAnalysisTest::_reportText()
+{
+    // One seam plus one coverage hole: both must show up in the text
+    const QRectF visible =
+        worldRect(kWestKey).united(worldRect(kEastKey)).adjusted(0, 0, worldRect(kEastKey).width(), 0);
+    const QList<SurfaceModel::Patch> patches{readyPatch(kWestKey, 0.0f), readyPatch(kEastKey, 50.0f)};
+
+    const SurfaceAnalysis::Report report = SurfaceAnalysis::analyze(patches, kGridSize, samplesOver(visible));
+    const QString text = report.text();
+
+    QVERIFY(!text.isEmpty());
+    QVERIFY(text.contains(SurfaceAnalysis::seamCauseDescription(SurfaceAnalysis::SeamCause::SameZoomMismatch)));
+    QVERIFY(text.contains(SurfaceAnalysis::holeCauseDescription(SurfaceAnalysis::HoleCause::NoPatch)));
+    QVERIFY(text.contains("50.0"));
+
+    QVERIFY(!SurfaceAnalysis::seamCauseDescription(SurfaceAnalysis::SeamCause::PendingFlat).isEmpty());
+    QVERIFY(SurfaceAnalysis::seamCauseDescription(SurfaceAnalysis::SeamCause::PendingFlat) !=
+            SurfaceAnalysis::seamCauseDescription(SurfaceAnalysis::SeamCause::DegradedFlat));
+}
+
+UT_REGISTER_TEST_LIGHTWEIGHT(SurfaceAnalysisTest, TestLabel::Unit)

--- a/test/GeoView/SurfaceAnalysisTest.h
+++ b/test/GeoView/SurfaceAnalysisTest.h
@@ -1,0 +1,34 @@
+#pragma once
+
+#include "UnitTest.h"
+
+class SurfaceAnalysisTest : public UnitTest
+{
+    Q_OBJECT
+
+private slots:
+    void _noSeamsOnMatchingEdges();
+    void _pendingFlatSeam();
+    void _degradedFlatSeam();
+    void _coveredPatchIgnored();
+    void _belowThresholdIgnored();
+    void _sameZoomMismatch();
+    void _sameZoomSeamReportedOnce();
+    void _lodTJunction();
+    void _blendBandScale();
+    void _overlappingAncestorNotASeamNeighbor();
+    void _noHolesWhenFullyCovered();
+    void _holeNoPatch();
+    void _holeSuppressedCovered();
+    void _holeCheckSkippedWithoutSamples();
+    void _holeElevatedTerrainCulled();
+    void _elevatedTerrainRenderedNoHole();
+    void _cameraBelowSurface();
+    void _cameraAboveSurface();
+    void _cameraClipsNearbyTerrain();
+    void _noSurfaceUnderCamera();
+    void _cameraCheckSkippedWithoutScale();
+    void _cameraCheckSkippedWithoutHeight();
+    void _nonFiniteHeights();
+    void _reportText();
+};

--- a/test/GeoView/SurfaceModelTest.cc
+++ b/test/GeoView/SurfaceModelTest.cc
@@ -77,6 +77,24 @@ int maxZoomOf(const QList<SurfaceModel::Patch>& patches)
     return maxZoom;
 }
 
+/// Constant tall terrain everywhere
+class TallHeightSource : public ProceduralHeightSource
+{
+public:
+    explicit TallHeightSource(float height, QObject* parent = nullptr) : ProceduralHeightSource(parent), _height(height)
+    {}
+
+protected:
+    float heightAtWorld(const QPointF& world) const override
+    {
+        Q_UNUSED(world);
+        return _height;
+    }
+
+private:
+    const float _height;
+};
+
 }  // namespace
 
 void SurfaceModelTest::_noViewportNoPatches()
@@ -428,6 +446,69 @@ void SurfaceModelTest::_pendingPatchesCoveredDuringLodChurn()
     for (const SurfaceModel::Patch& patch : model.patches()) {
         QVERIFY(!patch.covered);
     }
+}
+
+void SurfaceModelTest::_tallTerrainKeepsCameraTileResident()
+{
+    // Terrain (500 m) rises far above the camera eye (~229 up at tilt 55,
+    // distance 400). Ground-plane culling alone would drop the ground under
+    // and just behind the bottom screen edge, leaving a hole where that tall
+    // terrain should render. Once heights arrive the model must re-cull
+    // terrain-aware without any camera movement.
+    GeoViewCamera camera;
+    TallHeightSource source(500.0f);
+    SurfaceModel model(&camera, &source);
+
+    camera.setViewportSize(kViewport);
+    camera.lookAt(kCenter, 0, 55, 400);
+    QTRY_COMPARE_WITH_TIMEOUT(model.pendingCount(), 0, 5000);
+
+    const QPointF cameraGround = camera.cameraGroundPosition();
+    QTRY_VERIFY_WITH_TIMEOUT(model.visibleGroundRect().contains(cameraGround), 5000);
+
+    // The re-cull spawns fresh height fetches; wait for those too
+    QTRY_COMPARE_WITH_TIMEOUT(model.pendingCount(), 0, 5000);
+    bool renderedUnderCamera = false;
+    for (const SurfaceModel::Patch& patch : model.patches()) {
+        const double span = TileMath::tileSpanAtZoom(patch.key.zoom);
+        const QRectF rect(TileMath::tileMinCorner(patch.key), QSizeF(span, span));
+        if (!patch.covered && rect.contains(cameraGround)) {
+            renderedUnderCamera = true;
+            break;
+        }
+    }
+    QVERIFY2(renderedUnderCamera, "no rendered patch spans the camera ground position");
+}
+
+void SurfaceModelTest::_cameraGroundTileResidentOverFlatTerrain()
+{
+    // The terrain ceiling comes only from resident patches, so tall terrain
+    // living solely in never-requested tiles (e.g. a cliff under the camera
+    // with flat water everywhere visible) could never be discovered. The
+    // visible region must therefore include the camera ground point even
+    // when every resident patch is flat.
+    GeoViewCamera camera;
+    camera.setViewportSize(kViewport);
+    camera.lookAt(kCenter, 0, 55, 400);
+    const QPointF cameraGround = camera.cameraGroundPosition();
+
+    FlatHeightSource source;
+    SurfaceModel model(&camera, &source);
+    model.update();
+
+    QVERIFY(model.visibleGroundRect().contains(cameraGround));
+
+    QTRY_COMPARE_WITH_TIMEOUT(model.pendingCount(), 0, 5000);
+    bool renderedUnderCamera = false;
+    for (const SurfaceModel::Patch& patch : model.patches()) {
+        const double span = TileMath::tileSpanAtZoom(patch.key.zoom);
+        const QRectF rect(TileMath::tileMinCorner(patch.key), QSizeF(span, span));
+        if (!patch.covered && rect.contains(cameraGround)) {
+            renderedUnderCamera = true;
+            break;
+        }
+    }
+    QVERIFY2(renderedUnderCamera, "no rendered patch spans the camera ground position");
 }
 
 UT_REGISTER_TEST_LIGHTWEIGHT(SurfaceModelTest, TestLabel::Unit)

--- a/test/GeoView/SurfaceModelTest.h
+++ b/test/GeoView/SurfaceModelTest.h
@@ -23,4 +23,6 @@ private slots:
     void _degradedPatchesKeepRetiringCover();
     void _degradedRetiringPatchesSwept();
     void _pendingPatchesCoveredDuringLodChurn();
+    void _tallTerrainKeepsCameraTileResident();
+    void _cameraGroundTileResidentOverFlatTerrain();
 };


### PR DESCRIPTION
Follow-up to #14807 for the experimental GeoView preview. Three changes:

## Surface analysis diagnostics (`Analyze` button)

New `SurfaceAnalysis` pass over the rendered patch set that reports, with the reason each exists:
- coverage holes (visible screen points with no rendered geometry)
- camera clipping below the rendered surface
- boundary height "cliffs" (pending/degraded flat patches, blend-band scale, LOD T-junctions, same-zoom mismatch)
- non-finite height data

Triggered from a new `Analyze` button next to the existing debug overlay; report goes to the debug output. This is how the two bugs below were found and verified.

## Fix: terrain-aware visibility culling

`SurfaceModel` culled patches against ground-plane visibility only. Terrain that rises far above the camera eye (e.g. camera close to a 500 m ridge) sits over ground whose flat-plane hit point is behind the bottom screen edge, so its tiles were culled — leaving a persistent hole at the bottom of the screen. The visible-region estimate now also includes where each sightline crosses the terrain-top plane, and the model re-culls when delivered heights rise materially above what the last cull assumed. Covered by a new unit test (`_tallTerrainKeepsCameraTileResident`).

## Fix: 1-px texture seams on tile borders

`Texture` defaults to `Repeat` wrap, so linear filtering at UV 0/1 blended opposite-edge texels, drawing faint 1-px seams along every patch border in both 2D and 3D. Clamp to edge fixes it.
