### PR TITLE
chore(OnboardLogs): add FTP listing diagnostics for log date/time issue

### DIFF
--- a/src/AnalyzeView/OnboardLogs/OnboardLogController.cc
+++ b/src/AnalyzeView/OnboardLogs/OnboardLogController.cc
@@ -980,6 +980,11 @@ void OnboardLogController::_ftpListDirComplete(const QStringList &dirList, const
         return;
     }
 
+    // Raw entries expose whether the server included the optional mtime field (date/time diagnosis)
+    qCDebug(OnboardLogControllerLog) << "ftp: raw entries for"
+        << ((_ftpListState == FtpListState::ListingRoot) ? _ftpLogRoot : (_ftpDirsToList.isEmpty() ? QString() : _ftpDirsToList.first()))
+        << dirList;
+
     if (_ftpListState == FtpListState::ListingRoot) {
         // The root listing may contain log files directly (flat layout, e.g. @MAV_LOG)
         // and/or date subdirectories to descend into (PX4 fallback /fs/microsd/log).

--- a/src/Vehicle/FTPManager.cc
+++ b/src/Vehicle/FTPManager.cc
@@ -163,6 +163,14 @@ bool FTPManager::listDirectory(uint8_t fromCompId, const QString& fromURI)
             ? MavlinkFTP::kCmdListDirectory
             : MavlinkFTP::kCmdListDirectoryWithTime;
 
+    // Re-report the cached capability on every listing so any log capture window shows it
+    const char* supportStr =
+            (_listDirWithTimeSupport == WithTimeSupport_t::Supported)   ? "vehicle supports it" :
+            (_listDirWithTimeSupport == WithTimeSupport_t::Unsupported) ? "vehicle Nak'ed it earlier this connection" :
+                                                                          "support unknown, probing";
+    qCDebug(FTPManagerLog) << "listDirectory using" << MavlinkFTP::opCodeToString(_listDirectoryState.opCode)
+                           << "-" << supportStr;
+
     if (!_parseURI(fromCompId, fromURI, _listDirectoryState.fullPathOnVehicle, _ftpCompId)) {
         qCWarning(FTPManagerLog) << "_parseURI failed";
         return false;


### PR DESCRIPTION
Diagnostics for #14789 (onboard log entries showing "Date Unknown" over the FTP transport — regression from 5.0.8).

Two debug-log additions so a single App Log capture answers the open questions:

- `OnboardLogController`: log the raw FTP directory entries for each listed directory, exposing whether the vehicle included the optional mtime field (`name\tsize[\tmtime]`).
- `FTPManager`: on every `listDirectory()`, log which list command is in use (`List Directory` vs `List Directory With Time`) and why (cached capability: supported / Nak'ed earlier this connection / unknown-probing). Previously the capability negotiation was only logged at the transition, so captures started after the first listing showed nothing.

No functional changes; both lines are behind the existing disabled-by-default debug categories.
