### PR TITLE
fix(QmlControls): build file dialog currentFolder url properly

### DIFF
--- a/src/QmlControls/QGCFileDialog.qml
+++ b/src/QmlControls/QGCFileDialog.qml
@@ -123,7 +123,7 @@ Item {
 
     FileDialog {
         id:             fullFileDialog
-        currentFolder:  "file:///" + _root.folder
+        currentFolder:  QGCFileDialogController.localFileToUrl(_root.folder)
         nameFilters:    _root.nameFilters ? _root.nameFilters : []
         title:          _root.title
         defaultSuffix:  _root.defaultSuffix
@@ -141,7 +141,7 @@ Item {
 
     FolderDialog {
         id:             fullFolderDialog
-        currentFolder:  "file:///" + _root.folder
+        currentFolder:  QGCFileDialogController.localFileToUrl(_root.folder)
         title:          _root.title
 
         onAccepted: _root.acceptedForLoad(QGCFileDialogController.urlToLocalFile(selectedFolder))

--- a/src/QmlControls/QGCFileDialogController.cc
+++ b/src/QmlControls/QGCFileDialogController.cc
@@ -163,6 +163,12 @@ QString QGCFileDialogController::urlToLocalFile(QUrl url)
     return result;
 }
 
+QUrl QGCFileDialogController::localFileToUrl(const QString &localFile)
+{
+    // Empty in, empty out - QUrl::fromLocalFile("") would return the degenerate "file:" url
+    return localFile.isEmpty() ? QUrl() : QUrl::fromLocalFile(localFile);
+}
+
 void QGCFileDialogController::importFromNativePicker()
 {
 #ifdef Q_OS_ANDROID

--- a/src/QmlControls/QGCFileDialogController.h
+++ b/src/QmlControls/QGCFileDialogController.h
@@ -29,6 +29,9 @@ public:
 
     Q_INVOKABLE static QString urlToLocalFile(QUrl url);
 
+    /// Converts a local file path to a properly formed file:// url.
+    Q_INVOKABLE static QUrl localFileToUrl(const QString &localFile);
+
     /// Important: Should only be used in mobile builds where default save location cannot be changed.
     /// Returns the standard QGC location portion of a fully qualified folder path.
     /// Example: "/Users/Don/Document/QGroundControl/Missions" returns "QGroundControl/Missions"


### PR DESCRIPTION
Related to #14789 (the file dialog breadcrumb/listing mismatch and crash reported there).

`QGCFileDialog.qml` built `currentFolder` with `"file:///" + folder`. On non-Windows platforms `folder` is an absolute path starting with `/`, so this produced a malformed four-slash url (`file:////home/user/...`). Feeding that to the Qt Quick `FileDialog`/`FolderDialog` can desync the breadcrumb path from the folder listing (breadcrumb shows one directory, listing shows its parent) and crash when accepting a folder selected in that state. The concatenation also never percent-encoded spaces/unicode in paths.

Fix: new `QGCFileDialogController::localFileToUrl()` helper wrapping `QUrl::fromLocalFile()`, used for both `currentFolder` bindings. Empty path returns an empty `QUrl` (dialog default) instead of a degenerate `file:` url.
