### PR TITLE
perf(GeoMap): reduce update-pass cost and terrain fetch load

### DIFF
--- a/src/FlyView/FlyViewGeo.qml
+++ b/src/FlyView/FlyViewGeo.qml
@@ -58,7 +58,8 @@ Item {
                 anchors.fill: parent
             }
 
-            // Debug overlay: live SurfaceModel stats for manual verification
+            // Debug overlay: live SurfaceModel stats for manual verification;
+            // second line adds the perf counters while Stats is on
             QGCLabel {
                 objectName: "flyViewGeoDebugOverlay"
                 anchors.left: parent.left
@@ -69,6 +70,7 @@ Item {
                           .arg(geoMap.patchCount)
                           .arg(geoMap.pendingCount)
                           .arg(geoMap.maxZoomLevel)
+                      + (geoMap.modelStats !== "" ? "\n" + geoMap.modelStats : "")
             }
 
             Column {
@@ -100,6 +102,21 @@ Item {
                     objectName: "flyViewGeoAnalyzeButton"
                     text: qsTr("Analyze")
                     onClicked: geoMap.analyzeSurface()
+                }
+
+                // Render-statistics overlay toggle (perf diagnostics)
+                QGCButton {
+                    objectName: "flyViewGeoStatsButton"
+                    text: qsTr("Stats")
+                    onClicked: geoMap.renderStats = !geoMap.renderStats
+                }
+
+                // Perf capture: records per-second counters; the CSV path
+                // shows in the debug overlay when stopped
+                QGCButton {
+                    objectName: "flyViewGeoRecordButton"
+                    text: geoMap.perfCapturing ? qsTr("Stop") : qsTr("Record")
+                    onClicked: geoMap.perfCapturing ? geoMap.stopPerfCapture() : geoMap.startPerfCapture()
                 }
             }
         }

--- a/src/GeoMap/CMakeLists.txt
+++ b/src/GeoMap/CMakeLists.txt
@@ -30,6 +30,7 @@ qt_add_qml_module(GeoMapModule
     IMPORTS
         QtQuick
         QtQuick3D
+        QtQuick3D.Helpers
     SOURCES
         CheckerboardTextureData.cc
         CheckerboardTextureData.h

--- a/src/GeoMap/GeoMap.qml
+++ b/src/GeoMap/GeoMap.qml
@@ -9,6 +9,7 @@
 
 import QtQuick
 import QtQuick3D
+import QtQuick3D.Helpers
 import QtPositioning
 
 import QGroundControl
@@ -26,8 +27,23 @@ Item {
     property alias patchCount: patchModel.patchCount
     property alias pendingCount: patchModel.pendingCount
     property alias maxZoomLevel: patchModel.maxZoomLevel
+    property alias modelStats: patchModel.statsText
+    property alias perfCapturing: patchModel.capturing
+
+    function startPerfCapture() {
+        patchModel.startCapture()
+    }
+
+    // Returns the CSV file path (empty on failure)
+    function stopPerfCapture() {
+        return patchModel.stopCapture()
+    }
 
     readonly property int cameraAnimationMs: 500
+
+    // Render-statistics overlay (FPS, frame timing, draw calls, texture/mesh
+    // memory) for perf work; owned here because it needs the internal View3D
+    property bool renderStats: false
 
     // Terrain displacement factor: 1 in 3D, 0 in 2D (map stays flat).
     // Startup mode is 2D, so terrain starts flattened.
@@ -44,6 +60,12 @@ Item {
         // final value back to 0
         headingAnimation.to = (geoCamera.heading > 180) ? 360 : 0
         headingAnimation.start()
+    }
+
+    // LOD checker colors for debug mode (imagery off)
+    function _lodColor(centerX, centerY, span, zoomLevel) {
+        const parity = (Math.round(centerX / span) + Math.round(centerY / span)) & 1
+        return Qt.hsla((zoomLevel * 0.13) % 1.0, 0.5, parity ? 0.45 : 0.6, 1.0)
     }
 
     // Gestures jump a running mode transition to its end state rather
@@ -80,6 +102,7 @@ Item {
         objectName: "geoMapPatchModel"
         scene: geoScene
         terrain: true
+        statsEnabled: root.renderStats
         // Drape the map imagery the rest of QGC uses (empty disables imagery)
         mapType: QGroundControl.settingsManager.flightMapSettings.mapProvider.rawValue
                  + " " + QGroundControl.settingsManager.flightMapSettings.mapType.rawValue
@@ -125,70 +148,70 @@ Item {
         }
 
         // One surface patch per active SurfaceModel entry: draped tile
-        // imagery once delivered, LOD-colored fallback while loading
-        Repeater3D {
-            model: patchModel
-            delegate: Model {
-                id: patchDelegate
-                objectName: "geoMapPatchDelegate"
-                required property real centerX
-                required property real centerY
-                required property real span
-                required property int zoomLevel
-                required property var heights
-                required property bool covered
-                required property var tileImage
-                required property bool hasTileImage
+        // imagery once delivered, LOD-colored fallback while loading.
+        // The shared z-scale converts true-meter heights into mercator scene
+        // units (verticalScale) and animates terrain flat<->full during the
+        // 2D/3D mode transition (terrainScale) without geometry rebuilds:
+        // one binding here instead of one per delegate (delegate creation
+        // cost dominates patch churn, and transitions re-evaluated it N
+        // times per frame). Never exactly 0: a singular scale breaks the
+        // normal matrix.
+        Node {
+            scale: Qt.vector3d(1, 1, Math.max(0.0001, root.terrainScale * geoScene.verticalScale))
 
-                // A covered pending patch stays hidden: its empty flat grid
-                // would z-fight the retained retiring cover
-                visible: !covered
-                position: Qt.vector3d(centerX, centerY, 0)
-                // z-scale converts true-meter heights into mercator scene units
-                // (verticalScale) and animates terrain flat<->full during the
-                // 2D/3D mode transition (terrainScale) without geometry rebuilds.
-                // Never exactly 0: a singular scale breaks the normal matrix.
-                scale: Qt.vector3d(1, 1, Math.max(0.0001, root.terrainScale * geoScene.verticalScale))
-                geometry: PatchGeometry {
-                    gridSize: patchModel.gridSize
-                    span: patchDelegate.span
-                    heights: patchDelegate.heights
-                }
+            Repeater3D {
+                model: patchModel
+                delegate: Model {
+                    id: patchDelegate
+                    objectName: "geoMapPatchDelegate"
+                    required property real centerX
+                    required property real centerY
+                    required property real span
+                    required property int zoomLevel
+                    required property var heights
+                    required property bool covered
+                    required property var tileImage
+                    required property bool hasTileImage
 
-                Texture {
-                    id: patchTexture
-                    // Clamp: default Repeat wrap bleeds opposite-edge texels
-                    // at UV 0/1, drawing 1-px seams on every patch border
-                    tilingModeHorizontal: Texture.ClampToEdge
-                    tilingModeVertical: Texture.ClampToEdge
-                    textureData: PatchTextureData {
-                        image: patchDelegate.tileImage
+                    // A covered pending patch stays hidden: its empty flat grid
+                    // would z-fight the retained retiring cover
+                    visible: !covered
+                    position: Qt.vector3d(centerX, centerY, 0)
+                    geometry: PatchGeometry {
+                        gridSize: patchModel.gridSize
+                        span: patchDelegate.span
+                        heights: patchDelegate.heights
                     }
-                }
 
-                materials: [
-                    DefaultMaterial {
-                        cullMode: Material.NoCulling
-                        // Unlit: tiles carry their own shading, and lighting
-                        // would show the per-patch normal seams
-                        lighting: DefaultMaterial.NoLighting
-                        diffuseMap: patchDelegate.hasTileImage ? patchTexture : null
-                        // Loading fallback: quiet neutral when imagery is on
-                        // (LOD flash on zoom); LOD checker colors in debug mode
-                        diffuseColor: {
-                            if (patchDelegate.hasTileImage) {
-                                return "white"
-                            }
-                            if (patchModel.mapType !== "") {
-                                return "#3a4048"
-                            }
-                            const parity = (Math.round(patchDelegate.centerX / patchDelegate.span)
-                                            + Math.round(patchDelegate.centerY / patchDelegate.span)) & 1
-                            return Qt.hsla((patchDelegate.zoomLevel * 0.13) % 1.0, 0.5,
-                                           parity ? 0.45 : 0.6, 1.0)
+                    Texture {
+                        id: patchTexture
+                        // Clamp: default Repeat wrap bleeds opposite-edge texels
+                        // at UV 0/1, drawing 1-px seams on every patch border
+                        tilingModeHorizontal: Texture.ClampToEdge
+                        tilingModeVertical: Texture.ClampToEdge
+                        textureData: PatchTextureData {
+                            image: patchDelegate.tileImage
                         }
                     }
-                ]
+
+                    materials: [
+                        DefaultMaterial {
+                            cullMode: Material.NoCulling
+                            // Unlit: tiles carry their own shading, and lighting
+                            // would show the per-patch normal seams
+                            lighting: DefaultMaterial.NoLighting
+                            diffuseMap: patchDelegate.hasTileImage ? patchTexture : null
+                            // Loading fallback: quiet neutral when imagery is on
+                            // (LOD flash on zoom); LOD checker colors in debug mode
+                            diffuseColor: patchDelegate.hasTileImage
+                                          ? "white"
+                                          : (patchModel.mapType !== ""
+                                             ? "#3a4048"
+                                             : root._lodColor(patchDelegate.centerX, patchDelegate.centerY,
+                                                              patchDelegate.span, patchDelegate.zoomLevel))
+                        }
+                    ]
+                }
             }
         }
 
@@ -253,6 +276,15 @@ Item {
             onScaleChanged: (delta) => geoCamera.zoomBy(1 / delta, centroid.position)
             onRotationChanged: (delta) => geoCamera.rotateBy(delta, centroid.position)
         }
+    }
+
+    DebugView {
+        objectName: "geoMapRenderStats"
+        anchors.left: parent.left
+        anchors.top: parent.top
+        source: viewport
+        visible: root.renderStats
+        resourceDetailsVisible: true
     }
 
     NumberAnimation {

--- a/src/GeoMap/SurfaceModel.cc
+++ b/src/GeoMap/SurfaceModel.cc
@@ -1,9 +1,11 @@
 #include "SurfaceModel.h"
 
+#include <QtCore/QElapsedTimer>
 #include <QtCore/QSet>
 #include <QtCore/QTimer>
 #include <QtCore/QVarLengthArray>
 #include <QtCore/QtMath>
+#include <algorithm>
 #include <cmath>
 #include <queue>
 #include <vector>
@@ -30,22 +32,44 @@ SurfaceModel::SurfaceModel(GeoMapCamera* camera, HeightSource* heightSource, QOb
     connect(_heightSource, &HeightSource::patchHeightsReady, this, &SurfaceModel::_heightsReady);
     connect(_heightSource, &HeightSource::patchHeightsFailed, this, &SurfaceModel::_heightsFailed);
 
-    connect(_camera, &GeoMapCamera::centerChanged, this, &SurfaceModel::update);
-    connect(_camera, &GeoMapCamera::headingChanged, this, &SurfaceModel::update);
-    connect(_camera, &GeoMapCamera::tiltChanged, this, &SurfaceModel::update);
-    connect(_camera, &GeoMapCamera::distanceChanged, this, &SurfaceModel::update);
-    connect(_camera, &GeoMapCamera::viewportSizeChanged, this, &SurfaceModel::update);
-    connect(_camera, &GeoMapCamera::fieldOfViewChanged, this, &SurfaceModel::update);
+    // Coalesce: camera signals fire per input event (up to 120/s during a
+    // gesture); one queued pass per event-loop iteration bounds the cost
+    connect(_camera, &GeoMapCamera::centerChanged, this, &SurfaceModel::_scheduleUpdate);
+    connect(_camera, &GeoMapCamera::headingChanged, this, &SurfaceModel::_scheduleUpdate);
+    connect(_camera, &GeoMapCamera::tiltChanged, this, &SurfaceModel::_scheduleUpdate);
+    connect(_camera, &GeoMapCamera::distanceChanged, this, &SurfaceModel::_scheduleUpdate);
+    connect(_camera, &GeoMapCamera::viewportSizeChanged, this, &SurfaceModel::_scheduleUpdate);
+    connect(_camera, &GeoMapCamera::fieldOfViewChanged, this, &SurfaceModel::_scheduleUpdate);
+}
+
+void SurfaceModel::_scheduleUpdate()
+{
+    if (_updatePending) {
+        return;
+    }
+    _updatePending = true;
+    QTimer::singleShot(0, this, [this] {
+        if (!_updatePending) {
+            return;  // absorbed by a direct update() call meanwhile
+        }
+        update();
+    });
 }
 
 void SurfaceModel::update()
 {
+    // Any direct pass supersedes a queued coalesced one (its singleShot
+    // becomes a no-op), so updateSettled() is truthful right after a call
+    _updatePending = false;
     if (!_camera->isPositioned()) {
         return;  // the default pose is null island; building patches there fires doomed terrain fetches
     }
     if (_camera->viewportSize().isEmpty()) {
         return;  // keep the last valid set; transient 0-size viewports occur during layout
     }
+
+    QElapsedTimer updateTimer;
+    updateTimer.start();
 
     // Max terrain height scans every resident vertex: compute once per update
     const double terrainZ = _maxTerrainZ();
@@ -61,7 +85,11 @@ void SurfaceModel::update()
     // Drop pending patches no longer desired, cancelling in-flight height
     // requests. Ready patches being replaced retire instead: they keep
     // rendering until their replacements have heights, so LOD churn and
-    // panning never open holes in the surface.
+    // panning never open holes in the surface. Removals are capped like adds:
+    // each erase synchronously destroys a render delegate, and pose jumps
+    // (high-tilt orbits) can invalidate hundreds of patches at once.
+    _removalsThisPass = 0;
+    _removalsDeferred = false;
     for (auto it = _patches.begin(); it != _patches.end();) {
         if (desiredSet.contains(it.key())) {
             it.value().retiring = false;  // re-desired while retiring: it is ready, keep as-is
@@ -77,6 +105,11 @@ void SurfaceModel::update()
             ++it;
             continue;
         }
+        if (_removalsThisPass >= kMaxPatchRemovalsPerUpdate) {
+            _removalsDeferred = true;  // stays resident one more pass; follow-up finishes the cull
+            ++it;
+            continue;
+        }
         // Pending patches own a tracked request, except while awaiting a retry
         // (requestId 0, never issued by a source): then both calls are no-ops.
         // _heightsReady untracks the id when a patch becomes ready (guard also
@@ -86,11 +119,23 @@ void SurfaceModel::update()
         const TileMath::TileKey removedKey = it.key();
         it = _patches.erase(it);
         emit patchRemoved(removedKey);
+        _removalsThisPass++;
     }
 
-    // Request heights for newly desired patches
+    // Request heights for newly desired patches, capped per pass: each add
+    // synchronously builds a render delegate downstream, and uncapped bursts
+    // (300+ adds/s while zooming) blow the frame budget. No further
+    // backpressure: the resident set may transiently exceed kMaxPatches while
+    // slow heights pin retiring covers, which is accepted - fixing terrain
+    // fetch latency is the pipeline's job, not this model's.
+    int adds = 0;
+    _addsDeferred = false;
     for (const TileMath::TileKey& key : desired) {
         if (_patches.contains(key)) {
+            continue;
+        }
+        if (adds >= kMaxPatchAddsPerUpdate) {
+            _addsDeferred = true;
             continue;
         }
         PatchData data;
@@ -98,9 +143,28 @@ void SurfaceModel::update()
         _requestKeys.insert(data.requestId, key);
         _patches.insert(key, data);
         emit patchAdded(key);
+        adds++;
     }
 
     _sweepRetiring();
+
+    // The caps guarantee every deferred pass makes progress, so follow-ups
+    // always converge
+    if (_addsDeferred || _removalsDeferred) {
+        _scheduleUpdate();
+    }
+
+    const qint64 elapsedUs = updateTimer.nsecsElapsed() / 1000;
+    _updateStats.updates++;
+    _updateStats.totalUs += elapsedUs;
+    _updateStats.maxUs = std::max(_updateStats.maxUs, elapsedUs);
+}
+
+SurfaceModel::UpdateStats SurfaceModel::takeUpdateStats()
+{
+    const UpdateStats stats = _updateStats;
+    _updateStats = UpdateStats{};
+    return stats;
 }
 
 QList<SurfaceModel::Patch> SurfaceModel::patches() const
@@ -215,11 +279,7 @@ double SurfaceModel::_maxTerrainZ() const
 {
     float maxHeight = 0.0f;
     for (const PatchData& data : _patches) {
-        for (const float height : data.heights) {
-            if (std::isfinite(height)) {
-                maxHeight = std::max(maxHeight, height);
-            }
-        }
+        maxHeight = std::max(maxHeight, data.maxHeight);
     }
     if (maxHeight <= 0.0f) {
         return 0.0;
@@ -318,29 +378,56 @@ void SurfaceModel::_heightsReady(int requestId, const QList<float>& heights)
         return;
     }
     patchIt.value().heights = heights;
+    float patchMax = 0.0f;
+    for (const float height : heights) {
+        if (std::isfinite(height)) {
+            patchMax = std::max(patchMax, height);
+        }
+    }
+    patchIt.value().maxHeight = patchMax;
     patchIt.value().ready = true;
     emit patchReady(key);
+    // Fresh removal budget: this is its own event-loop activation. Removals
+    // here also unblock ceiling-deferred adds, so schedule a follow-up.
+    _removalsThisPass = 0;
+    _removalsDeferred = false;
     _sweepRetiring();
+    if (_removalsDeferred || (_removalsThisPass > 0)) {
+        _scheduleUpdate();
+    }
 
     // Terrain taller than the last cull assumed may be visible below/behind
     // the camera: re-cull terrain-aware
     if (_maxTerrainZ() > (_culledTerrainZ + kRecullHeightMargin)) {
-        update();
+        _scheduleUpdate();
     }
 }
 
 void SurfaceModel::_sweepRetiring()
 {
     // A retiring patch may go once every pending patch it covers for has its
-    // heights (or it covers for none, e.g. it was panned out of the view)
+    // heights (or it covers for none, e.g. it was panned out of the view).
+    // While adds are deferred, replacements may not be resident yet, so covers
+    // cannot be judged - skip the sweep; the capped follow-up passes always
+    // drain the backlog, after which sweeping resumes. Shares the caller's
+    // removal budget: sweeps after mass invalidation are the largest
+    // destruction bursts.
+    if (_addsDeferred) {
+        return;
+    }
     for (auto it = _patches.begin(); it != _patches.end();) {
         if (!it.value().retiring || _overlapsPendingPatch(it.key())) {
             ++it;
             continue;
         }
+        if (_removalsThisPass >= kMaxPatchRemovalsPerUpdate) {
+            _removalsDeferred = true;
+            break;
+        }
         const TileMath::TileKey key = it.key();
         it = _patches.erase(it);
         emit patchRemoved(key);
+        _removalsThisPass++;
     }
 }
 

--- a/src/GeoMap/SurfaceModel.h
+++ b/src/GeoMap/SurfaceModel.h
@@ -46,6 +46,17 @@ public:
     /// it. The resident set can transiently exceed it while retiring patches from the
     /// previous LOD generation cover for pending replacements (worst case ~2x).
     static constexpr int kMaxPatches = 256;
+    /// Churn cap: each added patch synchronously creates a render delegate
+    /// (geometry + texture, ~0.75 ms on desktop), so one update pass adds at
+    /// most this many; the remainder streams over follow-up scheduled passes.
+    /// Budgets size the worst-case pass, not throughput: saturated passes run
+    /// back-to-back, so ops/sec is budget/passCost and stays constant.
+    static constexpr int kMaxPatchAddsPerUpdate = 2;
+    /// Removal counterpart: delegate destruction is also synchronous, and
+    /// high-tilt pose jumps invalidate hundreds of patches at once (400+ ms
+    /// single passes in capture data when removals were unbounded). Higher
+    /// than the add cap so drains outpace fills under sustained churn.
+    static constexpr int kMaxPatchRemovalsPerUpdate = 4;
     static constexpr double kRefinePixelThreshold = 384.0;  ///< subdivide above this projected size
     static constexpr double kMaxRangeMultiplier = 40.0;     ///< visible-range cap in camera distances
     static constexpr int kVisibleSampleGrid = 5;            ///< NxN screen samples for visible-region estimation
@@ -67,12 +78,28 @@ public:
 
     /// Recompute the active patch set from the current camera state. Called
     /// automatically on camera changes; safe to call directly (idempotent).
+    /// One call adds at most kMaxPatchAddsPerUpdate patches; leftovers are
+    /// completed by self-scheduled follow-up passes (see updateSettled).
     void update();
+
+    /// False while a scheduled update pass or deferred patch churn is outstanding
+    bool updateSettled() const { return !_updatePending && !_addsDeferred && !_removalsDeferred; }
 
     QList<Patch> patches() const;
 
     /// Single-patch lookup; std::nullopt when the key is not resident
     std::optional<Patch> patch(const TileMath::TileKey& key) const;
+
+    /// update() call/duration counters for the perf overlay
+    struct UpdateStats
+    {
+        int updates = 0;
+        qint64 totalUs = 0;
+        qint64 maxUs = 0;
+    };
+
+    /// Returns the counters accumulated since the previous call and resets them
+    UpdateStats takeUpdateStats();
 
     /// Estimated visible ground region in world meters (see class comment)
     QRectF visibleGroundRect() const { return _visibleGroundRect(_maxTerrainZ()); }
@@ -84,6 +111,16 @@ public:
 #ifdef QGC_UNITTEST_BUILD
     /// Test hook: shortens the failed-request retry delay
     void setHeightRetryDelayMs(int ms) { _heightRetryDelayMs = ms; }
+
+    /// Test hook: runs capped update passes synchronously to completion.
+    /// The caps guarantee every pass makes progress, so this terminates.
+    void drainUpdates()
+    {
+        int guard = kMaxPatches;
+        do {
+            update();
+        } while ((_addsDeferred || _removalsDeferred) && (--guard > 0));
+    }
 #endif
 
 signals:
@@ -98,11 +135,12 @@ private slots:
 private:
     struct PatchData
     {
-        int requestId = 0;  ///< 0 = no request in flight (awaiting retry or ready)
+        int requestId = 0;       ///< 0 = no request in flight (awaiting retry or ready)
         QList<float> heights;
+        float maxHeight = 0.0f;  ///< cached vertex max so _maxTerrainZ is O(patches) not O(vertices)
         bool ready = false;
-        bool retiring = false;  ///< ready but replaced; renders until replacements are ready
-        bool degraded = false;  ///< flat fallback after exhausted retries; keeps its retiring cover
+        bool retiring = false;   ///< ready but replaced; renders until replacements are ready
+        bool degraded = false;   ///< flat fallback after exhausted retries; keeps its retiring cover
         int retriesLeft = kMaxHeightRetries;
     };
 
@@ -112,6 +150,7 @@ private:
     QRectF _visibleGroundRect(double terrainZ) const;
     double _maxTerrainZ() const;
     void _retryHeights(const TileMath::TileKey& key);
+    void _scheduleUpdate();
     void _sweepRetiring();
     bool _overlapsPendingPatch(const TileMath::TileKey& key) const;
     bool _isCovered(const TileMath::TileKey& key, const PatchData& data) const;
@@ -120,6 +159,11 @@ private:
     HeightSource* const _heightSource;
     QHash<TileMath::TileKey, PatchData> _patches;
     QHash<int, TileMath::TileKey> _requestKeys;
-    double _culledTerrainZ = 0.0;  ///< terrain-top height assumed by the last cull (scene units)
+    UpdateStats _updateStats;
+    bool _updatePending = false;     ///< a coalesced update pass is queued on the event loop
+    bool _addsDeferred = false;      ///< the last pass hit the add cap; a follow-up pass is queued
+    bool _removalsDeferred = false;  ///< the last pass hit the removal cap; a follow-up pass is queued
+    int _removalsThisPass = 0;       ///< removal budget shared by the cull loop and the retiring sweep
+    double _culledTerrainZ = 0.0;    ///< terrain-top height assumed by the last cull (scene units)
     int _heightRetryDelayMs = kDefaultHeightRetryDelayMs;
 };

--- a/src/GeoMap/SurfacePatchModel.cc
+++ b/src/GeoMap/SurfacePatchModel.cc
@@ -1,10 +1,16 @@
 #include "SurfacePatchModel.h"
 
+#include <QtCore/QByteArray>
+#include <QtCore/QDateTime>
 #include <QtCore/QDebug>
+#include <QtCore/QDir>
+#include <QtCore/QFile>
+#include <QtCore/QTimer>
 #include <QtCore/QtMath>
 #include <QtGui/QPainter>
 #include <algorithm>
 #include <cmath>
+#include <utility>
 
 #include "GeoMapCamera.h"
 #include "GeoScene.h"
@@ -46,6 +52,29 @@ GeoMapCamera* SurfacePatchModel::_camera() const
 {
     return _scene ? _scene->camera() : nullptr;
 }
+
+void SurfacePatchModel::_scheduleStatsChanged()
+{
+    // Patch events arrive in bursts (up to hundreds/s during churn); one
+    // emit per event-loop pass bounds the QML binding re-evaluations
+    if (_statsNotifyPending) {
+        return;
+    }
+    _statsNotifyPending = true;
+    QTimer::singleShot(0, this, [this] {
+        _statsNotifyPending = false;
+        emit statsChanged();
+    });
+}
+
+#ifdef QGC_UNITTEST_BUILD
+void SurfacePatchModel::drainUpdates()
+{
+    if (_surfaceModel) {
+        _surfaceModel->drainUpdates();
+    }
+}
+#endif
 
 void SurfacePatchModel::setTerrain(bool terrain)
 {
@@ -99,6 +128,7 @@ void SurfacePatchModel::_resetImagery()
     _imageRequestKey.clear();
     _imageRequestByKey.clear();
     _retiredOrder.clear();
+    _fallbackCache.clear();
     if (!_tileImages.isEmpty()) {
         _tileImages.clear();
         if (!_keys.isEmpty()) {
@@ -132,7 +162,30 @@ void SurfacePatchModel::_tileImageReady(int requestId, const QImage& image)
         return;
     }
     _tileImages.insert(key, image);
+    _fallbackCache.remove(key);  // own image supersedes any cached miss
+    _invalidateFallbacks(key);
     _notifyTileImageChanged(key);
+}
+
+void SurfacePatchModel::_invalidateFallbacks(const TileMath::TileKey& tile)
+{
+    // A patch's fallback sources from its direct children and its ancestors
+    // (up to kMaxAncestorFallbackLevels), so a changed tile invalidates its
+    // parent's composite and every cached descendant's crop. Fallbacks read
+    // only delivered images, never other fallbacks, so invalidation never
+    // cascades further.
+    if (tile.zoom > 0) {
+        _fallbackCache.remove(TileMath::TileKey{tile.x >> 1, tile.y >> 1, tile.zoom - 1});
+    }
+    for (auto it = _fallbackCache.begin(); it != _fallbackCache.end();) {
+        const int down = it.key().zoom - tile.zoom;
+        if ((down > 0) && (down <= kMaxAncestorFallbackLevels) && ((it.key().x >> down) == tile.x) &&
+            ((it.key().y >> down) == tile.y)) {
+            it = _fallbackCache.erase(it);
+        } else {
+            ++it;
+        }
+    }
 }
 
 void SurfacePatchModel::_notifyTileImageChanged(const TileMath::TileKey& key)
@@ -226,6 +279,145 @@ int SurfacePatchModel::maxZoomLevel() const
     return maxZoom;
 }
 
+void SurfacePatchModel::_startStatsSampling()
+{
+    if (!_statsTimer) {
+        _statsTimer = new QTimer(this);
+        _statsTimer->setInterval(1000);
+        connect(_statsTimer, &QTimer::timeout, this, &SurfacePatchModel::_statsTick);
+    }
+    _statAdds = 0;
+    _statRemoves = 0;
+    _statComposites = 0;
+    if (_surfaceModel) {
+        _surfaceModel->takeUpdateStats();  // discard pre-window accumulation
+    }
+    _statsTimer->start();
+}
+
+void SurfacePatchModel::setStatsEnabled(bool enabled)
+{
+    if (enabled == _statsEnabled) {
+        return;
+    }
+    _statsEnabled = enabled;
+    emit statsEnabledChanged();
+
+    // The sampler is shared with capture recording, which owns it while
+    // capturing: the overlay toggling must not reset or stop a live capture
+    if (_statsEnabled) {
+        if (!_capturing) {
+            _startStatsSampling();
+        }
+    } else if (!_capturing && _statsTimer) {
+        _statsTimer->stop();
+    }
+    _statsText.clear();
+    emit statsTextChanged();
+}
+
+void SurfacePatchModel::_statsTick()
+{
+    const SurfaceModel::UpdateStats stats =
+        _surfaceModel ? _surfaceModel->takeUpdateStats() : SurfaceModel::UpdateStats{};
+    const double avgMs = stats.updates ? (stats.totalUs / 1000.0) / stats.updates : 0.0;
+    const double maxMs = stats.maxUs / 1000.0;
+    _statsText = QStringLiteral("upd/s %1  avg %2 ms  max %3 ms  |  patch +%4 -%5 /s  comp/s %6")
+                     .arg(stats.updates)
+                     .arg(avgMs, 0, 'f', 2)
+                     .arg(maxMs, 0, 'f', 2)
+                     .arg(_statAdds)
+                     .arg(_statRemoves)
+                     .arg(_statComposites);
+    if (_capturing) {
+        _captureWorstMaxMs = std::max(_captureWorstMaxMs, maxMs);
+        _captureWorstAvgMs = std::max(_captureWorstAvgMs, avgMs);
+        GeoMapCamera* const camera = _camera();
+        _captureRows.append(QStringLiteral("%1,%2,%3,%4,%5,%6,%7,%8,%9,%10,%11,%12")
+                                .arg(_captureClock.elapsed() / 1000.0, 0, 'f', 1)
+                                .arg(stats.updates)
+                                .arg(avgMs, 0, 'f', 3)
+                                .arg(maxMs, 0, 'f', 3)
+                                .arg(_statAdds)
+                                .arg(_statRemoves)
+                                .arg(_statComposites)
+                                .arg(patchCount())
+                                .arg(pendingCount())
+                                .arg(maxZoomLevel())
+                                .arg(camera ? camera->distance() : 0.0, 0, 'f', 0)
+                                .arg(camera ? camera->tilt() : 0.0, 0, 'f', 1));
+    }
+    _statAdds = 0;
+    _statRemoves = 0;
+    _statComposites = 0;
+    emit statsTextChanged();
+}
+
+void SurfacePatchModel::startCapture()
+{
+    if (_capturing) {
+        return;
+    }
+    _capturing = true;
+    emit capturingChanged();
+
+    _captureRows.clear();
+    _captureWorstMaxMs = 0.0;
+    _captureWorstAvgMs = 0.0;
+    _captureRows.append(
+        QStringLiteral("time_s,updates,avg_ms,max_ms,patch_adds,patch_removes,composites,patches,pending,max_zoom,cam_"
+                       "dist_m,cam_tilt_deg"));
+    _captureClock.start();
+    // Run the sampler directly rather than via statsEnabled: that property is
+    // QML-bound to the overlay toggle, and writing it here would fight the
+    // binding (and leave the sampler running after the capture ends)
+    _startStatsSampling();
+}
+
+QString SurfacePatchModel::stopCapture()
+{
+    if (!_capturing) {
+        return QString();
+    }
+    _statsTick();  // flush the partial interval: the final settle pass must reach the CSV and worst-case values
+    _capturing = false;
+    emit capturingChanged();
+    if (!_statsEnabled && _statsTimer) {
+        _statsTimer->stop();
+    }
+
+    const QString path = QDir::temp().filePath(
+        QStringLiteral("qgc-geomap-capture-%1.csv").arg(QDateTime::currentDateTime().toString("yyyyMMdd-hhmmss")));
+    QFile file(path);
+    if (!file.open(QIODevice::WriteOnly | QIODevice::Text)) {
+        qWarning() << "GeoMap capture: cannot write" << path;
+        _statsText = QStringLiteral("capture failed: %1").arg(path);
+        emit statsTextChanged();
+        return QString();
+    }
+    const QByteArray data = _captureRows.join(QLatin1Char('\n')).toUtf8() + '\n';
+    const bool written = (file.write(data) == data.size()) && file.flush();
+    file.close();
+    _captureRows.clear();
+    if (!written) {
+        (void) file.remove();  // never hand back a truncated CSV
+        qWarning() << "GeoMap capture: write failed" << path;
+        _statsText = QStringLiteral("capture failed: %1").arg(path);
+        emit statsTextChanged();
+        return QString();
+    }
+
+    // No log output on success: the overlay shows the path, and UI tests run
+    // with strict log checking. The worst-case summary makes the overlay a
+    // one-glance verdict without reading the CSV.
+    _statsText = QStringLiteral("capture: worst max %1 ms  worst avg %2 ms  ->  %3")
+                     .arg(_captureWorstMaxMs, 0, 'f', 2)
+                     .arg(_captureWorstAvgMs, 0, 'f', 2)
+                     .arg(path);
+    emit statsTextChanged();
+    return path;
+}
+
 void SurfacePatchModel::analyzeSurface() const
 {
     GeoMapCamera* const camera = _camera();
@@ -306,7 +498,16 @@ QVariant SurfacePatchModel::data(const QModelIndex& index, int role) const
         }
         case TileImageRole: {
             const QImage own = _tileImages.value(key);
-            return own.isNull() ? _fallbackImage(key) : own;
+            if (!own.isNull()) {
+                return own;
+            }
+            const auto cached = _fallbackCache.constFind(key);
+            if (cached != _fallbackCache.constEnd()) {
+                return *cached;
+            }
+            const QImage fallback = _fallbackImage(key);
+            _fallbackCache.insert(key, fallback);
+            return fallback;
         }
         case HasTileImageRole:
             return _tileImages.contains(key) || _fallbackAvailable(key);
@@ -344,6 +545,7 @@ QImage SurfacePatchModel::_fallbackImage(const TileMath::TileKey& key) const
     }
     if (anyChild) {
         constexpr int kCanvas = 256;
+        _statComposites++;
         QImage canvas(kCanvas, kCanvas, QImage::Format_RGBA8888);
         canvas.fill(QColor(0x3a, 0x40, 0x48));  // missing quadrants stay neutral
         QPainter painter(&canvas);
@@ -373,6 +575,7 @@ QImage SurfacePatchModel::_fallbackImage(const TileMath::TileKey& key) const
         const double cellHeight = static_cast<double>(image.height()) / split;
         const int cellX = key.x - (ancestor.x << up);
         const int cellY = key.y - (ancestor.y << up);
+        _statComposites++;
         return image.copy(QRect(qRound(cellX * cellWidth), qRound(cellY * cellHeight), qMax(1, qRound(cellWidth)),
                                 qMax(1, qRound(cellHeight))));
     }
@@ -393,6 +596,7 @@ void SurfacePatchModel::_patchAdded(const TileMath::TileKey& key)
     beginInsertRows(QModelIndex(), _keys.count(), _keys.count());
     _keys.append(key);
     endInsertRows();
+    _statAdds++;
     if (_tileSource) {
         if (_tileImages.contains(key)) {
             _retiredOrder.removeOne(key);  // back to live: exempt from eviction again
@@ -400,7 +604,7 @@ void SurfacePatchModel::_patchAdded(const TileMath::TileKey& key)
             _requestTileImage(key);
         }
     }
-    emit statsChanged();
+    _scheduleStatsChanged();
 }
 
 void SurfacePatchModel::_patchReady(const TileMath::TileKey& key)
@@ -412,8 +616,8 @@ void SurfacePatchModel::_patchReady(const TileMath::TileKey& key)
     const QModelIndex idx = index(row);
     emit dataChanged(idx, idx, {HeightsRole, ReadyRole, CoveredRole});
     // A new ready patch can newly cover other pending rows
-    _notifyCoveredMayHaveChanged();
-    emit statsChanged();
+    _notifyCoveredMayHaveChanged(key);
+    _scheduleStatsChanged();
 }
 
 void SurfacePatchModel::_patchRemoved(const TileMath::TileKey& key)
@@ -425,15 +629,19 @@ void SurfacePatchModel::_patchRemoved(const TileMath::TileKey& key)
     beginRemoveRows(QModelIndex(), row, row);
     _keys.removeAt(row);
     endRemoveRows();
+    _statRemoves++;
 
     // Retire the delivered image instead of dropping it: it seeds the
     // fallback for patches that replace this one across LOD changes
     if (_tileImages.contains(key)) {
         _retiredOrder.append(key);
         while (_retiredOrder.count() > kMaxRetiredImages) {
-            _tileImages.remove(_retiredOrder.takeFirst());
+            const TileMath::TileKey evicted = _retiredOrder.takeFirst();
+            _tileImages.remove(evicted);
+            _invalidateFallbacks(evicted);
         }
     }
+    _fallbackCache.remove(key);  // row gone: keep the cache bounded by live rows
     const auto requestIt = _imageRequestByKey.constFind(key);
     if (requestIt != _imageRequestByKey.constEnd()) {
         _tileSource->cancelRequest(requestIt.value());
@@ -441,15 +649,25 @@ void SurfacePatchModel::_patchRemoved(const TileMath::TileKey& key)
         _imageRequestByKey.erase(requestIt);
     }
     // A removed ready patch may have been the cover of pending rows
-    _notifyCoveredMayHaveChanged();
-    emit statsChanged();
+    _notifyCoveredMayHaveChanged(key);
+    _scheduleStatsChanged();
 }
 
-void SurfacePatchModel::_notifyCoveredMayHaveChanged()
+void SurfacePatchModel::_notifyCoveredMayHaveChanged(const TileMath::TileKey& changedKey)
 {
-    // Ready rows are never covered, so only pending rows need re-evaluation
+    // Ready rows are never covered, and only rows overlapping the changed
+    // patch can gain/lose their cover. The rect prefilter keeps this O(rows)
+    // per event; unscoped notification was O(rows^2) via the CoveredRole
+    // re-evaluations and dominated passes at high resident counts.
+    const double span = TileMath::tileSpanAtZoom(changedKey.zoom);
+    const QRectF changedRect(TileMath::tileMinCorner(changedKey), QSizeF(span, span));
     for (int row = 0; row < _keys.count(); row++) {
-        const auto patch = _surfaceModel->patch(_keys.at(row));
+        const TileMath::TileKey& rowKey = _keys.at(row);
+        const double rowSpan = TileMath::tileSpanAtZoom(rowKey.zoom);
+        if (!changedRect.intersects(QRectF(TileMath::tileMinCorner(rowKey), QSizeF(rowSpan, rowSpan)))) {
+            continue;
+        }
+        const auto patch = _surfaceModel->patch(rowKey);
         if (patch && !patch->ready) {
             const QModelIndex idx = index(row);
             emit dataChanged(idx, idx, {CoveredRole});

--- a/src/GeoMap/SurfacePatchModel.h
+++ b/src/GeoMap/SurfacePatchModel.h
@@ -10,9 +10,11 @@
 #pragma once
 
 #include <QtCore/QAbstractListModel>
+#include <QtCore/QElapsedTimer>
 #include <QtCore/QHash>
 #include <QtCore/QList>
 #include <QtCore/QString>
+#include <QtCore/QStringList>
 #include <QtGui/QImage>
 #include <QtQmlIntegration/QtQmlIntegration>
 
@@ -21,6 +23,7 @@
 class GeoScene;
 class GeoMapCamera;
 class HeightSource;
+class QTimer;
 class SurfaceModel;
 class TileImageSource;
 
@@ -44,6 +47,9 @@ class SurfacePatchModel : public QAbstractListModel
     Q_PROPERTY(int patchCount READ patchCount NOTIFY statsChanged)
     Q_PROPERTY(int pendingCount READ pendingCount NOTIFY statsChanged)
     Q_PROPERTY(int maxZoomLevel READ maxZoomLevel NOTIFY statsChanged)
+    Q_PROPERTY(bool statsEnabled READ statsEnabled WRITE setStatsEnabled NOTIFY statsEnabledChanged)
+    Q_PROPERTY(QString statsText READ statsText NOTIFY statsTextChanged)
+    Q_PROPERTY(bool capturing READ capturing NOTIFY capturingChanged)
 
 public:
     explicit SurfacePatchModel(QObject* parent = nullptr);
@@ -93,10 +99,32 @@ public:
     int pendingCount() const;
     int maxZoomLevel() const;
 
+    bool statsEnabled() const { return _statsEnabled; }
+
+    /// Enables the once-per-second perf counter sampling behind statsText:
+    /// model update rate/duration, patch churn, and fallback composites
+    void setStatsEnabled(bool enabled);
+
+    QString statsText() const { return _statsText; }
+
+    bool capturing() const { return _capturing; }
+
+    /// Starts recording the per-second perf samples (plus camera context)
+    Q_INVOKABLE void startCapture();
+
+    /// Stops recording and writes the samples as CSV; returns the file path
+    /// (empty on write failure)
+    Q_INVOKABLE QString stopCapture();
+
     /// Diagnostic pass over the current patch set: reports coverage holes,
     /// boundary height cliffs, and bad height data, with the reason each
     /// exists (see SurfaceAnalysis). The report goes to the debug output.
     Q_INVOKABLE void analyzeSurface() const;
+
+#ifdef QGC_UNITTEST_BUILD
+    /// Test hook: completes all capped SurfaceModel update passes synchronously
+    void drainUpdates();
+#endif
 
     int rowCount(const QModelIndex& parent = QModelIndex()) const override;
     QVariant data(const QModelIndex& index, int role) const override;
@@ -108,6 +136,9 @@ signals:
     void debugHillsChanged();
     void mapTypeChanged();
     void statsChanged();
+    void statsEnabledChanged();
+    void statsTextChanged();
+    void capturingChanged();
 
 private slots:
     void _patchAdded(const TileMath::TileKey& key);
@@ -116,13 +147,17 @@ private slots:
     void _sceneOriginChanged();
     void _tileImageReady(int requestId, const QImage& image);
     void _tileImageFailed(int requestId);
+    void _statsTick();
 
 private:
     void _rebuildSurfaceModel();
     void _resetImagery();
     void _requestTileImage(const TileMath::TileKey& key);
     void _notifyTileImageChanged(const TileMath::TileKey& key);
-    void _notifyCoveredMayHaveChanged();
+    void _invalidateFallbacks(const TileMath::TileKey& tile);
+    void _notifyCoveredMayHaveChanged(const TileMath::TileKey& changedKey);
+    void _scheduleStatsChanged();
+    void _startStatsSampling();
     QImage _fallbackImage(const TileMath::TileKey& key) const;
     bool _fallbackAvailable(const TileMath::TileKey& key) const;
     GeoMapCamera* _camera() const;
@@ -137,9 +172,29 @@ private:
     bool _debugHills = false;
     QString _mapType;
     TileImageSource* _tileSource = nullptr;
-    QHash<TileMath::TileKey, QImage> _tileImages;      ///< delivered images: live patches + retired fallbacks
+    QHash<TileMath::TileKey, QImage> _tileImages;  ///< delivered images: live patches + retired fallbacks
+    /// Built fallbacks (incl. null misses) keyed by patch; rebuilding on every
+    /// data() call cost ~1ms per new patch during zoom churn. Invalidated when
+    /// a source tile changes (see _invalidateFallbacks), dropped with the row.
+    mutable QHash<TileMath::TileKey, QImage> _fallbackCache;
     QList<TileMath::TileKey> _retiredOrder;            ///< retired keys oldest-first, for eviction
     QHash<int, TileMath::TileKey> _imageRequestKey;    ///< in-flight image request id -> patch
     QHash<TileMath::TileKey, int> _imageRequestByKey;  ///< reverse map for cancellation
     QList<TileMath::TileKey> _keys;                    ///< row order; data fetched from SurfaceModel by key
+
+    // Perf counters sampled by _statsTick (see setStatsEnabled)
+    QTimer* _statsTimer = nullptr;
+    bool _statsEnabled = false;
+    bool _statsNotifyPending = false;  ///< coalesces statsChanged to one emit per event-loop pass
+    QString _statsText;
+    int _statAdds = 0;
+    int _statRemoves = 0;
+    mutable int _statComposites = 0;  ///< fallback images built (data() is const)
+
+    // Capture recording (see startCapture)
+    bool _capturing = false;
+    QStringList _captureRows;
+    QElapsedTimer _captureClock;
+    double _captureWorstMaxMs = 0.0;  ///< session-worst single update, for the stop verdict
+    double _captureWorstAvgMs = 0.0;
 };

--- a/src/GeoMap/TerrainHeightSource.cc
+++ b/src/GeoMap/TerrainHeightSource.cc
@@ -16,6 +16,41 @@
 #include "TerrainQueryInterface.h"
 #include "TerrainTileCopernicus.h"
 
+namespace {
+
+/// Max 0.01-degree elevation tiles a patch may touch per axis; patches spanning
+/// more sample sparsely and interpolate (the extra detail is sub-pixel there)
+constexpr int kMaxFetchTilesPerAxis = 4;
+
+/// Bilinear upsample of a square vertex grid (row-major from NW) to a finer one.
+/// Requires sparseGridSize >= 1 and fullGridSize > sparseGridSize (the caller's
+/// gridSize < 1 boundary check guarantees this).
+QList<float> upsampleGrid(const QList<float>& sparse, int sparseGridSize, int fullGridSize)
+{
+    const int sparseEdge = sparseGridSize + 1;
+    const int fullEdge = fullGridSize + 1;
+    QList<float> full;
+    full.reserve(qsizetype(fullEdge) * fullEdge);
+    for (int row = 0; row < fullEdge; row++) {
+        const double v = (static_cast<double>(row) * sparseGridSize) / fullGridSize;
+        const int v0 = qMin(static_cast<int>(v), sparseGridSize - 1);
+        const double fv = v - v0;
+        for (int col = 0; col < fullEdge; col++) {
+            const double u = (static_cast<double>(col) * sparseGridSize) / fullGridSize;
+            const int u0 = qMin(static_cast<int>(u), sparseGridSize - 1);
+            const double fu = u - u0;
+            const double north = (sparse.at((qsizetype(v0) * sparseEdge) + u0) * (1.0 - fu)) +
+                                 (sparse.at((qsizetype(v0) * sparseEdge) + u0 + 1) * fu);
+            const double south = (sparse.at((qsizetype(v0 + 1) * sparseEdge) + u0) * (1.0 - fu)) +
+                                 (sparse.at((qsizetype(v0 + 1) * sparseEdge) + u0 + 1) * fu);
+            full.append(static_cast<float>((north * (1.0 - fv)) + (south * fv)));
+        }
+    }
+    return full;
+}
+
+}  // namespace
+
 TerrainHeightSource::TerrainHeightSource(QObject* parent) : HeightSource(parent) {}
 
 double TerrainHeightSource::heightScaleForZoom(int zoom)
@@ -35,8 +70,7 @@ int TerrainHeightSource::requestPatchHeights(const TileMath::TileKey& key, int g
         return requestId;
     }
 
-    const int verticesPerEdge = gridSize + 1;
-    const int expectedCount = verticesPerEdge * verticesPerEdge;
+    const int expectedCount = (gridSize + 1) * (gridSize + 1);
 
     if (key.zoom < kMinTerrainZoom) {
         // Flat zeros for coarse patches: see class comment
@@ -47,13 +81,23 @@ int TerrainHeightSource::requestPatchHeights(const TileMath::TileKey& key, int g
 
     const QPointF minCorner = TileMath::tileMinCorner(key);
     const double span = TileMath::tileSpanAtZoom(key.zoom);
-    const double step = span / gridSize;
+
+    // Cap elevation tiles touched: patches spanning many fixed 0.01-degree tiles
+    // sample a sparse vertex grid instead (upsampled to the full grid on delivery)
+    const double lonSpanDeg = (span / TileMath::worldSize()) * 360.0;
+    int sampleGridSize = gridSize;
+    if (lonSpanDeg > (kMaxFetchTilesPerAxis * TerrainTileCopernicus::kTileSizeDegrees)) {
+        sampleGridSize = qMin(gridSize, kMaxFetchTilesPerAxis - 1);
+    }
+
+    const int verticesPerEdge = sampleGridSize + 1;
+    const double step = span / sampleGridSize;
     constexpr double cell = TerrainTileCopernicus::kTileValueSpacingDegrees;
 
     QList<QGeoCoordinate> coordinates;  // four surrounding grid-cell samples per vertex
     QList<QPointF> fractions;
-    coordinates.reserve(qsizetype(4) * expectedCount);
-    fractions.reserve(expectedCount);
+    coordinates.reserve(qsizetype(4) * verticesPerEdge * verticesPerEdge);
+    fractions.reserve(qsizetype(verticesPerEdge) * verticesPerEdge);
     // Row-major from the north-west corner, matching the HeightSource contract
     for (int row = 0; row < verticesPerEdge; row++) {
         const double y = minCorner.y() + span - (row * step);
@@ -74,13 +118,15 @@ int TerrainHeightSource::requestPatchHeights(const TileMath::TileKey& key, int g
     }
 
     TerrainOfflineQuery* const query = new TerrainOfflineQuery(this);
-    _queryPending.insert(requestId, PendingQuery{query, fractions, heightScaleForZoom(key.zoom)});
+    _queryPending.insert(requestId,
+                         PendingQuery{query, fractions, heightScaleForZoom(key.zoom), sampleGridSize, gridSize});
     // Queued: the terrain pipeline answers synchronously on cache hits, but the
     // HeightSource contract promises delivery only after this call returns
     connect(
         query, &TerrainQueryInterface::coordinateHeightsReceived, this,
         [this, requestId](bool success, const QList<double>& heights) { _queryFinished(requestId, success, heights); },
         Qt::QueuedConnection);
+    _lastQueryCoordinateCount = coordinates.count();
     query->requestCoordinateHeights(coordinates);
     return requestId;
 }
@@ -132,6 +178,9 @@ void TerrainHeightSource::_queryFinished(int requestId, bool success, const QLis
         const double south = (heights.at(base) * (1.0 - fLon)) + (heights.at(base + 1) * fLon);
         const double north = (heights.at(base + 2) * (1.0 - fLon)) + (heights.at(base + 3) * fLon);
         converted.append(static_cast<float>(((south * (1.0 - fLat)) + (north * fLat)) * pending.heightScale));
+    }
+    if (pending.sampleGridSize < pending.gridSize) {
+        converted = upsampleGrid(converted, pending.sampleGridSize, pending.gridSize);
     }
     emit patchHeightsReady(requestId, converted);
 }

--- a/src/GeoMap/TerrainHeightSource.h
+++ b/src/GeoMap/TerrainHeightSource.h
@@ -26,6 +26,12 @@ class TerrainOfflineQuery;
 /// closer than the ~30m cells. Each vertex therefore samples its four surrounding
 /// grid cells and blends them bilinearly.
 ///
+/// Elevation tiles are a fixed 0.01-degree grid regardless of patch zoom, so fetch cost
+/// grows with patch span. Patches spanning more than a few tiles sample a sparse vertex
+/// grid (bilinearly upsampled to the delivery grid): the skipped detail is sub-pixel at
+/// those view distances, and the tile fetches saved are the difference between holes
+/// filling in seconds versus minutes on the serial tile pipeline.
+///
 /// Patches coarser than kMinTerrainZoom get flat zero heights delivered locally: their
 /// sample grid would touch hundreds of 0.01-degree elevation tiles each (a fetch storm),
 /// while terrain relief at those view distances is only a few pixels. To avoid a single
@@ -51,6 +57,10 @@ public:
     int requestPatchHeights(const TileMath::TileKey& key, int gridSize) final;
     void cancelRequest(int requestId) final;
 
+    /// Coordinates submitted by the most recent terrain query (test observability
+    /// for the sparse-sampling fetch cap; 0 for locally answered requests)
+    qsizetype lastQueryCoordinateCount() const { return _lastQueryCoordinateCount; }
+
 private:
     void _deliverLocal(int requestId);
     void _queryFinished(int requestId, bool success, const QList<double>& heights);
@@ -58,10 +68,13 @@ private:
     struct PendingQuery
     {
         TerrainOfflineQuery* query = nullptr;
-        QList<QPointF> fractions;  ///< per vertex: position within its grid cell (x=lon, y=lat)
+        QList<QPointF> fractions;  ///< per sampled vertex: position within its grid cell (x=lon, y=lat)
         double heightScale = 1.0;  ///< blend-band scale for the patch zoom
+        int sampleGridSize = 0;    ///< sparse sample grid (== gridSize when fully sampled)
+        int gridSize = 0;          ///< delivery grid the result is upsampled to
     };
 
     QHash<int, QList<float>> _localPending;  ///< coarse-zoom results awaiting queued delivery
     QHash<int, PendingQuery> _queryPending;  ///< in-flight terrain queries
+    qsizetype _lastQueryCoordinateCount = 0;
 };

--- a/test/GeoMap/SurfaceModelTest.cc
+++ b/test/GeoMap/SurfaceModelTest.cc
@@ -1,5 +1,7 @@
 #include "SurfaceModelTest.h"
 
+#include <QtCore/QCoreApplication>
+#include <QtCore/QPair>
 #include <QtCore/QSet>
 #include <QtTest/QSignalSpy>
 #include <algorithm>
@@ -68,6 +70,44 @@ private:
     int _failuresRemaining = 0;
 };
 
+/// Holds every request until deliverAll(): pins pending patches the way a
+/// slow terrain backend does, so tests can accumulate retiring covers
+class HoldingHeightSource : public HeightSource
+{
+public:
+    using HeightSource::HeightSource;
+
+    int requestPatchHeights(const TileMath::TileKey& key, int gridSize) override
+    {
+        Q_UNUSED(key);
+        const int requestId = _nextRequestId();
+        _held.append(qMakePair(requestId, (gridSize + 1) * (gridSize + 1)));
+        return requestId;
+    }
+
+    void cancelRequest(int requestId) override
+    {
+        for (int i = 0; i < _held.count(); i++) {
+            if (_held.at(i).first == requestId) {
+                _held.removeAt(i);
+                return;
+            }
+        }
+    }
+
+    void deliverAll()
+    {
+        const auto held = _held;
+        _held.clear();
+        for (const auto& request : held) {
+            emit patchHeightsReady(request.first, QList<float>(request.second, 0.0f));
+        }
+    }
+
+private:
+    QList<QPair<int, int>> _held;
+};
+
 int maxZoomOf(const QList<SurfaceModel::Patch>& patches)
 {
     int maxZoom = 0;
@@ -116,9 +156,11 @@ void SurfaceModelTest::_unpositionedCameraNoPatches()
     // A sized viewport alone must not build patches: the camera still holds
     // the null-island default pose (doomed terrain fetches would follow)
     camera.setViewportSize(kViewport);
+    model.drainUpdates();
     QCOMPARE(model.patchCount(), 0);
 
     camera.setCenter(kCenter);
+    model.drainUpdates();
     QCOMPARE_GT(model.patchCount(), 0);
 }
 
@@ -130,6 +172,7 @@ void SurfaceModelTest::_coarseWhenFar()
 
     camera.setViewportSize(kViewport);
     camera.lookAt(kCenter, 0, 0, GeoMapCamera::kMaxDistance);
+    model.drainUpdates();
 
     QCOMPARE_GT(model.patchCount(), 0);
     // From max distance the whole world fits the view: only low zoom levels
@@ -144,9 +187,11 @@ void SurfaceModelTest::_refinesWhenNear()
 
     camera.setViewportSize(kViewport);
     camera.lookAt(kCenter, 0, 0, GeoMapCamera::kMaxDistance);
+    model.drainUpdates();
     const int farMaxZoom = maxZoomOf(model.patches());
 
     camera.lookAt(kCenter, 0, 0, 2000);
+    model.drainUpdates();
     const int nearMaxZoom = maxZoomOf(model.patches());
 
     QCOMPARE_GT(nearMaxZoom, farMaxZoom);
@@ -163,6 +208,7 @@ void SurfaceModelTest::_patchCountBounded()
     for (double distance : {50.0, 2000.0, 100000.0, GeoMapCamera::kMaxDistance}) {
         for (double tilt : {0.0, 45.0, GeoMapCamera::kMaxTilt}) {
             camera.lookAt(kCenter, 30, tilt, distance);
+            model.drainUpdates();
             QCOMPARE_LE(model.patchCount(), SurfaceModel::kMaxPatches);
         }
     }
@@ -178,6 +224,7 @@ void SurfaceModelTest::_budgetExhaustedKeepsCoverage()
     // exceeds the patch budget
     camera.setViewportSize(QSizeF(8000, 6000));
     camera.lookAt(kCenter, 0, 45, 2000);
+    model.drainUpdates();
 
     QCOMPARE_LE(model.patchCount(), SurfaceModel::kMaxPatches);
     // A split replaces one patch with up to four children, so an exhausted
@@ -225,6 +272,7 @@ void SurfaceModelTest::_heightsArrive()
 
     camera.setViewportSize(kViewport);
     camera.lookAt(kCenter, 0, 0, 2000);
+    model.drainUpdates();
 
     QCOMPARE_GT(model.patchCount(), 0);
     QTRY_COMPARE_WITH_TIMEOUT(model.pendingCount(), 0, 5000);
@@ -245,6 +293,7 @@ void SurfaceModelTest::_diffOnMove()
 
     camera.setViewportSize(kViewport);
     camera.lookAt(kCenter, 0, 0, 2000);
+    model.drainUpdates();
     QTRY_COMPARE_WITH_TIMEOUT(model.pendingCount(), 0, 5000);
 
     QSignalSpy addedSpy(&model, &SurfaceModel::patchAdded);
@@ -252,6 +301,7 @@ void SurfaceModelTest::_diffOnMove()
 
     // Move to the other side of the planet: full set replacement
     camera.setCenter(QGeoCoordinate(-33.8688, 151.2093));
+    model.drainUpdates();
     QCOMPARE_GT(addedSpy.count(), 0);
     QCOMPARE_GT(removedSpy.count(), 0);
 
@@ -269,6 +319,7 @@ void SurfaceModelTest::_noChurnOnIdenticalUpdate()
 
     camera.setViewportSize(kViewport);
     camera.lookAt(kCenter, 0, 0, 2000);
+    model.drainUpdates();
 
     QSignalSpy addedSpy(&model, &SurfaceModel::patchAdded);
     QSignalSpy removedSpy(&model, &SurfaceModel::patchRemoved);
@@ -285,6 +336,7 @@ void SurfaceModelTest::_cullsInvisibleRegion()
 
     camera.setViewportSize(kViewport);
     camera.lookAt(kCenter, 0, 0, 2000);
+    model.drainUpdates();
 
     // At 2km altitude over Zurich the antipodean hemisphere must not be resident
     const QPointF sydney = TileMath::geoToWorld(QGeoCoordinate(-33.8688, 151.2093));
@@ -305,6 +357,7 @@ void SurfaceModelTest::_failedHeightsDegradeToFlat()
 
     camera.setViewportSize(kViewport);
     camera.lookAt(kCenter, 0, 0, 2000);
+    model.drainUpdates();
 
     // Every patch burns through its retries before degrading to flat
     QCOMPARE_GT(model.patchCount(), 0);
@@ -324,6 +377,7 @@ void SurfaceModelTest::_failedHeightsRetryAndRecover()
 
     camera.setViewportSize(kViewport);
     camera.lookAt(kCenter, 0, 0, 2000);
+    model.drainUpdates();
 
     QCOMPARE_GT(model.patchCount(), 0);
     QTRY_COMPARE_WITH_TIMEOUT(model.pendingCount(), 0, 5000);
@@ -342,6 +396,7 @@ void SurfaceModelTest::_degradedPatchesKeepRetiringCover()
 
     camera.setViewportSize(kViewport);
     camera.lookAt(kCenter, 0, 0, GeoMapCamera::kMaxDistance);
+    model.drainUpdates();
     QTRY_COMPARE_WITH_TIMEOUT(model.pendingCount(), 0, 5000);
     const int coarseMaxZoom = maxZoomOf(model.patches());
 
@@ -350,6 +405,7 @@ void SurfaceModelTest::_degradedPatchesKeepRetiringCover()
     // real-height patches must keep covering instead of being swept
     source.setFailuresRemaining(-1);
     camera.lookAt(kCenter, 0, 0, 2000);
+    model.drainUpdates();
     QTRY_COMPARE_WITH_TIMEOUT(model.pendingCount(), 0, 5000);
 
     bool hasReadyCoarse = false;
@@ -367,12 +423,14 @@ void SurfaceModelTest::_keepsReadyPatchesDuringLodChurn()
 
     camera.setViewportSize(kViewport);
     camera.lookAt(kCenter, 0, 0, GeoMapCamera::kMaxDistance);
+    model.drainUpdates();
     QTRY_COMPARE_WITH_TIMEOUT(model.pendingCount(), 0, 5000);
     const int coarseMaxZoom = maxZoomOf(model.patches());
 
     // Refine: the coarse ready patches must keep covering the view (retiring)
     // until the fine replacements have heights - no holes during LOD churn
     camera.lookAt(kCenter, 0, 0, 2000);
+    model.drainUpdates();
     QCOMPARE_GT(model.pendingCount(), 0);
     bool hasReadyCoarse = false;
     for (const SurfaceModel::Patch& patch : model.patches()) {
@@ -397,6 +455,7 @@ void SurfaceModelTest::_degradedRetiringPatchesSwept()
 
     camera.setViewportSize(kViewport);
     camera.lookAt(kCenter, 0, 0, 2000);
+    model.drainUpdates();
     QTRY_COMPARE_WITH_TIMEOUT(model.pendingCount(), 0, 5000);  // all degraded to flat
 
     QSet<TileMath::TileKey> oldKeys;
@@ -408,6 +467,7 @@ void SurfaceModelTest::_degradedRetiringPatchesSwept()
     // (a degraded flat fallback is not worth retaining as cover), otherwise
     // movement after terrain failures grows the model without bound
     camera.lookAt(QGeoCoordinate(40.0, -105.0), 0, 0, 2000);
+    model.drainUpdates();
     QTRY_COMPARE_WITH_TIMEOUT(model.pendingCount(), 0, 5000);
 
     for (const SurfaceModel::Patch& patch : model.patches()) {
@@ -423,12 +483,14 @@ void SurfaceModelTest::_pendingPatchesCoveredDuringLodChurn()
 
     camera.setViewportSize(kViewport);
     camera.lookAt(kCenter, 0, 0, GeoMapCamera::kMaxDistance);
+    model.drainUpdates();
     QTRY_COMPARE_WITH_TIMEOUT(model.pendingCount(), 0, 5000);
 
     // Refine: every pending replacement overlaps a retained ready patch, so it
     // reports covered - renderers suppress it instead of drawing a flat
     // placeholder that z-fights the retiring cover
     camera.lookAt(kCenter, 0, 0, 2000);
+    model.drainUpdates();
     QCOMPARE_GT(model.pendingCount(), 0);
     int pendingCovered = 0;
     for (const SurfaceModel::Patch& patch : model.patches()) {
@@ -461,6 +523,7 @@ void SurfaceModelTest::_tallTerrainKeepsCameraTileResident()
 
     camera.setViewportSize(kViewport);
     camera.lookAt(kCenter, 0, 55, 400);
+    model.drainUpdates();
     QTRY_COMPARE_WITH_TIMEOUT(model.pendingCount(), 0, 5000);
 
     const QPointF cameraGround = camera.cameraGroundPosition();
@@ -494,7 +557,7 @@ void SurfaceModelTest::_cameraGroundTileResidentOverFlatTerrain()
 
     FlatHeightSource source;
     SurfaceModel model(&camera, &source);
-    model.update();
+    model.drainUpdates();
 
     QVERIFY(model.visibleGroundRect().contains(cameraGround));
 
@@ -509,6 +572,68 @@ void SurfaceModelTest::_cameraGroundTileResidentOverFlatTerrain()
         }
     }
     QVERIFY2(renderedUnderCamera, "no rendered patch spans the camera ground position");
+}
+
+void SurfaceModelTest::_slowHeightsChurnSettlesWithoutHoles()
+{
+    // Stress: LOD churn with heights held pins retiring covers while adds
+    // stream. Once heights drain, refinement must resume, settle, and leave
+    // full ready coverage - no frozen holes and no unbounded resident growth.
+    GeoMapCamera camera;
+    HoldingHeightSource source;
+    SurfaceModel model(&camera, &source);
+
+    camera.setViewportSize(kViewport);
+    camera.lookAt(kCenter, 0, 0, GeoMapCamera::kMaxDistance);
+    model.drainUpdates();
+    source.deliverAll();
+
+    // Churn through LOD levels with heights held: every refine retires the
+    // previous ready set while its replacements stay pinned pending
+    for (double distance : {100000.0, 20000.0, 4000.0, 800.0}) {
+        camera.lookAt(kCenter, 0, 55, distance);
+        model.drainUpdates();
+    }
+    QCOMPARE_GT(model.pendingCount(), 0);
+
+    // Drain deliveries and scheduled passes alternately until settled; the
+    // event loop must pump so queued update passes clear their pending flag
+    for (int i = 0; (i < 200) && !(model.updateSettled() && (model.pendingCount() == 0)); i++) {
+        source.deliverAll();
+        QCoreApplication::processEvents();
+    }
+
+    QCOMPARE(model.pendingCount(), 0);
+    QVERIFY(model.updateSettled());
+    // Settled resident set: desired patches plus swept-down remainder stays
+    // within ~2x the refinement budget (see kMaxPatches doc)
+    QCOMPARE_LE(model.patchCount(), 2 * SurfaceModel::kMaxPatches);
+
+    // No holes: every visible ground sample lies inside a resident ready patch
+    const QList<SurfaceModel::Patch> patches = model.patches();
+    const double maxRange = camera.distance() * SurfaceModel::kMaxRangeMultiplier;
+    const double half = TileMath::worldSize() / 2.0;
+    constexpr int sampleGrid = 9;
+    for (int row = 0; row < sampleGrid; row++) {
+        for (int col = 0; col < sampleGrid; col++) {
+            const QPointF screenPos((camera.viewportSize().width() * col) / (sampleGrid - 1),
+                                    (camera.viewportSize().height() * row) / (sampleGrid - 1));
+            const auto ground = camera.groundPointCapped(screenPos, maxRange);
+            if (!ground || (qAbs(ground->x()) > half) || (qAbs(ground->y()) > half)) {
+                continue;
+            }
+            bool covered = false;
+            for (const SurfaceModel::Patch& patch : patches) {
+                const double span = TileMath::tileSpanAtZoom(patch.key.zoom);
+                if (patch.ready && QRectF(TileMath::tileMinCorner(patch.key), QSizeF(span, span)).contains(*ground)) {
+                    covered = true;
+                    break;
+                }
+            }
+            QVERIFY2(covered,
+                     qPrintable(QStringLiteral("hole at screen (%1, %2)").arg(screenPos.x()).arg(screenPos.y())));
+        }
+    }
 }
 
 UT_REGISTER_TEST_LIGHTWEIGHT(SurfaceModelTest, TestLabel::Unit)

--- a/test/GeoMap/SurfaceModelTest.h
+++ b/test/GeoMap/SurfaceModelTest.h
@@ -25,4 +25,5 @@ private slots:
     void _pendingPatchesCoveredDuringLodChurn();
     void _tallTerrainKeepsCameraTileResident();
     void _cameraGroundTileResidentOverFlatTerrain();
+    void _slowHeightsChurnSettlesWithoutHoles();
 };

--- a/test/GeoMap/SurfacePatchImageryTest.cc
+++ b/test/GeoMap/SurfacePatchImageryTest.cc
@@ -30,6 +30,7 @@ void attach(SurfacePatchModel& model, GeoScene& scene, GeoMapCamera& camera)
     camera.lookAt(kCenter, 0, 0, 2000);
     scene.setCamera(&camera);
     model.setScene(&scene);
+    model.drainUpdates();
 }
 
 int rowsWithImage(const SurfacePatchModel& model)
@@ -89,6 +90,7 @@ void SurfacePatchImageryTest::_emptyMapTypeDisablesImagery()
 
     // Patch churn with imagery disabled stays image-free
     camera.setCenter(QGeoCoordinate(47.42, 8.58));
+    model.drainUpdates();
     QCOMPARE(rowsWithImage(model), 0);
 }
 
@@ -134,6 +136,7 @@ void SurfacePatchImageryTest::_fallbackCoversLodChanges()
     // Zoom in (LOD refines): every new patch lies inside previously imaged
     // ground and must immediately drape an ancestor fallback -- no flash
     camera.setDistance(500);
+    model.drainUpdates();
     QCOMPARE_GT(model.rowCount(), 0);
     QCOMPARE(rowsReportingImage(model), model.rowCount());
     QCOMPARE(rowsWithImage(model), model.rowCount());
@@ -141,6 +144,7 @@ void SurfacePatchImageryTest::_fallbackCoversLodChanges()
     // Zoom back out to the original LOD: the retired originals revive from
     // the cache without any new fetch
     camera.setDistance(2000);
+    model.drainUpdates();
     QCOMPARE_GT(model.rowCount(), 0);
     QCOMPARE(rowsReportingImage(model), model.rowCount());
 
@@ -148,6 +152,7 @@ void SurfacePatchImageryTest::_fallbackCoversLodChanges()
     // cached children. Edge patches cover never-seen ground and legitimately
     // have no fallback source, so only partial coverage is guaranteed.
     camera.setDistance(4000);
+    model.drainUpdates();
     QCOMPARE_GT(model.rowCount(), 0);
     QCOMPARE_GT(rowsReportingImage(model), 0);
     QCOMPARE(rowsWithImage(model), rowsReportingImage(model));

--- a/test/GeoMap/SurfacePatchModelTest.cc
+++ b/test/GeoMap/SurfacePatchModelTest.cc
@@ -24,6 +24,7 @@ void attach(SurfacePatchModel& model, GeoScene& scene, GeoMapCamera& camera)
 {
     scene.setCamera(&camera);
     model.setScene(&scene);
+    model.drainUpdates();
 }
 
 }  // namespace
@@ -103,6 +104,7 @@ void SurfacePatchModelTest::_incrementalUpdatesOnMove()
 
     // Small pan within the re-anchor threshold: incremental row churn, no reset
     camera.setCenter(QGeoCoordinate(47.42, 8.58));
+    model.drainUpdates();
     QCOMPARE(resetSpy.count(), 0);
     QCOMPARE_GT(insertSpy.count() + removeSpy.count(), 0);
     QCOMPARE(model.rowCount(), model.patchCount());
@@ -121,6 +123,7 @@ void SurfacePatchModelTest::_reanchorsOnLargeMove()
     // Move far beyond kReanchorDistance: origin follows the camera
     const QGeoCoordinate faraway(48.85, 2.35);  // Paris, ~490km from Zurich
     camera.setCenter(faraway);
+    model.drainUpdates();
     QCOMPARE_GT(originSpy.count(), 0);
 
     const QPointF expectedOrigin = TileMath::geoToWorld(faraway);
@@ -154,6 +157,7 @@ void SurfacePatchModelTest::_cameraSwapAnchorsFresh()
     const QGeoCoordinate sydney(-33.8688, 151.2093);
     setupCamera(sydneyCamera, sydney);
     scene.setCamera(&sydneyCamera);
+    model.drainUpdates();
 
     const QPointF expectedOrigin = TileMath::geoToWorld(sydney);
     QCOMPARE_LT(std::hypot(scene.sceneOrigin().x() - expectedOrigin.x(), scene.sceneOrigin().y() - expectedOrigin.y()),
@@ -173,6 +177,7 @@ void SurfacePatchModelTest::_debugHillsSwitchResets()
 
     QSignalSpy resetSpy(&model, &QAbstractItemModel::modelReset);
     model.setDebugHills(true);
+    model.drainUpdates();
     QCOMPARE_GT(resetSpy.count(), 0);
     QCOMPARE_GT(model.rowCount(), 0);
     QTRY_COMPARE_WITH_TIMEOUT(model.pendingCount(), 0, 5000);
@@ -204,6 +209,7 @@ void SurfacePatchModelTest::_pendingRowsCoveredDuringLodChurn()
     // Refine: pending replacements report covered so the delegate hides their
     // empty flat mesh instead of z-fighting the retained retiring cover
     camera.lookAt(kCenter, 0, 0, 2000);
+    model.drainUpdates();
     QCOMPARE_GT(model.pendingCount(), 0);
     int coveredRows = 0;
     for (int row = 0; row < model.rowCount(); row++) {

--- a/test/GeoMap/TerrainHeightSourceTest.cc
+++ b/test/GeoMap/TerrainHeightSourceTest.cc
@@ -90,6 +90,47 @@ void TerrainHeightSourceTest::_interpolatesAcrossCellSteps()
     }
 }
 
+void TerrainHeightSourceTest::_sparseSamplingUpsamplesCoarsePatch()
+{
+    // Pins the sparse-sampling path deliberately: a zoom-13 patch spans
+    // ~0.044 degrees, past the 0.04-degree sparse threshold, so a 16-cell
+    // grid samples only 4x4 vertices and bilinearly upsamples to 17x17.
+    // If the sparse threshold constant changes, revisit the zoom here so
+    // this test keeps exercising the upsample.
+    TerrainHeightSource source;
+    QSignalSpy readySpy(&source, &HeightSource::patchHeightsReady);
+    QSignalSpy failedSpy(&source, &HeightSource::patchHeightsFailed);
+
+    constexpr int sparseZoom = TerrainHeightSource::kMinTerrainZoom + 1;  // zoom 13: patch fits inside the 11km region
+    constexpr int fineGrid = 16;
+    source.requestPatchHeights(keyOver(linearSlopeRegion().center(), sparseZoom), fineGrid);
+    // Sparse fetch actually occurred: 4 cell samples per vertex over 4x4 sampled
+    // vertices, not the 17x17 delivery grid (which would be 1156 coordinates)
+    QCOMPARE(source.lastQueryCoordinateCount(), 4 * 4 * 4);
+    QTRY_COMPARE_WITH_TIMEOUT(readySpy.count(), 1, TestTimeout::mediumMs());
+    QVERIFY(failedSpy.isEmpty());
+
+    // Full-size delivery despite the sparse fetch
+    const auto heights = readySpy.first().at(1).value<QList<float>>();
+    const int verticesPerEdge = fineGrid + 1;
+    QCOMPARE(heights.count(), verticesPerEdge * verticesPerEdge);
+
+    // The slope rises 100m/km west to east: every row must preserve a
+    // substantial monotonic rise through the upsample (a row/column
+    // transpose would flatten rows), with smooth interpolated steps
+    for (int row = 0; row < verticesPerEdge; row++) {
+        const float west = heights.at(row * verticesPerEdge);
+        const float east = heights.at((row * verticesPerEdge) + fineGrid);
+        QCOMPARE_GT(east - west, 100.0f);
+        for (int col = 0; col < fineGrid; col++) {
+            const float step =
+                heights.at((row * verticesPerEdge) + col + 1) - heights.at((row * verticesPerEdge) + col);
+            QCOMPARE_GE(step, -1.0f);  // monotonic modulo data noise
+            QCOMPARE_LT(step, 50.0f);  // no upsample discontinuities
+        }
+    }
+}
+
 void TerrainHeightSourceTest::_blendBandScalesHeights()
 {
     // Zooms in the blend band deliver fractionally scaled heights so the

--- a/test/GeoMap/TerrainHeightSourceTest.h
+++ b/test/GeoMap/TerrainHeightSourceTest.h
@@ -10,6 +10,7 @@ private slots:
     void _deliversFlatRegionHeights();
     void _deliversSlopeRegionHeights();
     void _interpolatesAcrossCellSteps();
+    void _sparseSamplingUpsamplesCoarsePatch();
     void _blendBandScalesHeights();
     void _coarseZoomDeliversFlatZeros();
     void _cancelPreventsDelivery();

--- a/test/QmlUITests/CMakeLists.txt
+++ b/test/QmlUITests/CMakeLists.txt
@@ -34,6 +34,10 @@ target_sources(${CMAKE_PROJECT_NAME}
         ${CMAKE_CURRENT_SOURCE_DIR}/FlyViewProximityRadarUITest.h
         ${CMAKE_CURRENT_SOURCE_DIR}/FlyViewGeoUITest.cc
         ${CMAKE_CURRENT_SOURCE_DIR}/FlyViewGeoUITest.h
+        # Manual perf benchmark: standalone-registered, deliberately NOT added
+        # via add_qgc_test so no ctest/CI sweep ever runs it
+        ${CMAKE_CURRENT_SOURCE_DIR}/GeoMapPerfUITest.cc
+        ${CMAKE_CURRENT_SOURCE_DIR}/GeoMapPerfUITest.h
         ${CMAKE_CURRENT_SOURCE_DIR}/NTRIPSettingsUITest.cc
         ${CMAKE_CURRENT_SOURCE_DIR}/NTRIPSettingsUITest.h
         ${CMAKE_CURRENT_SOURCE_DIR}/OnboardLogUITest.cc

--- a/test/QmlUITests/GeoMapPerfUITest.cc
+++ b/test/QmlUITests/GeoMapPerfUITest.cc
@@ -1,0 +1,149 @@
+#include "GeoMapPerfUITest.h"
+
+#include <QtCore/QEventLoop>
+#include <QtCore/QPoint>
+#include <QtCore/QScopeGuard>
+#include <QtCore/QTextStream>
+#include <QtCore/QTimer>
+#include <QtPositioning/QGeoCoordinate>
+#include <QtQuick/QQuickItem>
+#include <QtQuick/QQuickWindow>
+#include <QtTest/QTest>
+#include <optional>
+
+#include "Fact.h"
+#include "GeoMapCamera.h"
+#include "GeoViewSettings.h"
+#include "SettingsManager.h"
+#include "SurfacePatchModel.h"
+
+UT_REGISTER_TEST_STANDALONE(GeoMapPerfUITest, TestLabel::Integration)
+
+// Fixed benchmark pose: same land area with terrain relief the view starts on,
+// so imagery and elevation paths are exercised identically run to run
+namespace {
+const QGeoCoordinate kBenchCenter(47.6329078, -122.0876875);
+}
+
+void GeoMapPerfUITest::_benchmark()
+{
+    Fact* const enabled = SettingsManager::instance()->geoViewSettings()->enabled();
+    const QVariant savedEnabled = enabled->rawValue();
+    const auto guard = qScopeGuard([enabled, savedEnabled] { enabled->setRawValue(savedEnabled); });
+    enabled->setRawValue(true);
+
+    startUI();
+    if (QTest::currentTestFailed())
+        return;
+
+    const std::optional<bool> rhiBased = expectSoftwareBackendWarnings(/*strict*/ false);
+    QVERIFY2(rhiBased.has_value(), "No renderer interface on the main window");
+
+    QVERIFY(clickToolSelectDropdownButton(QStringLiteral("toolbar_viewGeo")));
+    QQuickItem* const viewport = findVisibleItem(_rootItem, QStringLiteral("geoMapViewport"), 10000);
+    QVERIFY2(viewport, "GeoMap 3D viewport not visible");
+
+    auto* const cam = viewport->parentItem()->findChild<GeoMapCamera*>(QStringLiteral("geoMapCamera"));
+    QVERIFY2(cam, "GeoMapCamera not found");
+    auto* const patchModel = viewport->parentItem()->findChild<SurfacePatchModel*>(QStringLiteral("geoMapPatchModel"));
+    QVERIFY2(patchModel, "SurfacePatchModel not found");
+
+    const qreal w = viewport->width();
+    const qreal h = viewport->height();
+    QVERIFY2((w > 300) && (h > 300), "viewport too small for gesture synthesis");
+    const auto toWin = [viewport](qreal x, qreal y) { return viewport->mapToScene(QPointF(x, y)).toPoint(); };
+    const QPoint center = toWin(w / 2, h / 2);
+
+    // Wall-clock pacing between synthesized input events: this reproduces
+    // human gesture speed so per-second capture rows resolve the phases. It
+    // is deliberate benchmark pacing, not a flaky synchronization wait.
+    const auto pace = [](int ms) {
+        QEventLoop loop;
+        QTimer::singleShot(ms, &loop, &QEventLoop::quit);
+        loop.exec();
+    };
+
+    const auto mouseDrag = [this, &pace](const QPoint& from, const QPoint& delta, int steps) {
+        QTest::mousePress(_window, Qt::LeftButton, Qt::NoModifier, from);
+        for (int i = 1; i <= steps; i++) {
+            QTest::mouseMove(_window, from + ((delta * i) / steps));
+            pace(40);
+        }
+        QTest::mouseRelease(_window, Qt::LeftButton, Qt::NoModifier, from + delta);
+    };
+    const auto wheelSteps = [this, &pace, center](int stepDelta, int count) {
+        for (int i = 0; i < count; i++) {
+            QTest::wheelEvent(_window, center, QPoint(0, stepDelta));
+            pace(200);
+        }
+    };
+    const auto settle = [patchModel] { QTRY_COMPARE_WITH_TIMEOUT(patchModel->pendingCount(), 0, 30000); };
+
+    // Deterministic start pose: 3D mode at street zoom over the bench area.
+    // debugHills replaces the terrain pipeline with analytic heights: the
+    // unit-test sandbox has no terrain data (fetches fail and degrade to
+    // flat), and hills give repeatable non-flat geometry everywhere.
+    patchModel->setDebugHills(true);
+    cam->setMode(GeoMapCamera::Mode::Mode3D);
+    QTRY_COMPARE_WITH_TIMEOUT(cam->tilt(), GeoMapCamera::kDefault3DTilt, 5000);
+    cam->lookAt(kBenchCenter, 0, GeoMapCamera::kDefault3DTilt, 1500);
+    settle();
+
+    patchModel->startCapture();
+
+    // Phase A: street-zoom pan - 8 alternating drags (churn at high LOD)
+    for (int i = 0; i < 8; i++) {
+        const QPoint delta((i % 2) ? QPoint(-220, -80) : QPoint(220, 80));
+        mouseDrag(center, delta, 20);
+    }
+    settle();
+
+    // Phase B: zoom out toward whole-earth (LOD coarsening burst)
+    wheelSteps(-120, 25);
+    settle();
+
+    // Phase C: pan zoomed out (cheap-churn control)
+    for (int i = 0; i < 6; i++) {
+        const QPoint delta((i % 2) ? QPoint(-220, 0) : QPoint(220, 0));
+        mouseDrag(center, delta, 20);
+    }
+    settle();
+
+    // Phase D: zoom back in to street level (refinement burst)
+    wheelSteps(120, 25);
+    settle();
+
+    // Phase E: high-tilt orbit churn - manual capture data showed near-horizon
+    // tilts at street zoom blowing the patch budget into retiring overshoot and
+    // mass delegate destruction (400+ ms passes when removals were uncapped).
+    // lookAt poses jump between tilts/headings to force full-set replacement.
+    for (int i = 0; i < 6; i++) {
+        cam->lookAt(kBenchCenter, (i * 120) % 360, (i % 2) ? 70.0 : 40.0, 955);
+        pace(800);
+    }
+    settle();
+
+    // Phase F: sustained no-settle churn - continuous zoom oscillation at high
+    // tilt with SLOW heights. Height latency pins pending patches, so retiring
+    // covers cannot sweep and the resident set transiently exceeds the patch
+    // budget (accepted; see SurfaceModel::kMaxPatches) - this phase measures
+    // the per-pass costs under that load. debugHills answers instantly and
+    // cannot reproduce it, so this phase runs the real terrain source, whose
+    // sandbox fetches retry on multi-second backoff.
+    patchModel->setDebugHills(false);
+    cam->lookAt(kBenchCenter, 0, 60.0, 1500);
+    for (int i = 0; i < 12; i++) {
+        wheelSteps((i % 2) ? 120 : -120, 8);
+    }
+    // Instant heights again: the switch rebuilds the model, so the tail of the
+    // capture settles quickly instead of waiting out terrain retry backoffs
+    patchModel->setDebugHills(true);
+    settle();
+
+    const QString capturePath = patchModel->stopCapture();
+    QVERIFY2(!capturePath.isEmpty(), "capture file was not written");
+    // stdout, not the Qt log: the UI test harness fails on unexpected log messages
+    QTextStream(stdout) << "GeoMap benchmark capture: " << capturePath << Qt::endl;
+
+    stopUI();
+}

--- a/test/QmlUITests/GeoMapPerfUITest.h
+++ b/test/QmlUITests/GeoMapPerfUITest.h
@@ -1,0 +1,18 @@
+#pragma once
+
+#include "QmlUITestBase.h"
+
+/// Manual GeoMap performance benchmark (not registered with CTest, never runs
+/// in CI or standard test sweeps). Drives a fixed, repeatable gesture script
+/// against the live FlyViewGeo view while the SurfacePatchModel perf capture
+/// records per-second counters, then prints the CSV path for offline analysis.
+///
+/// Run explicitly (--onscreen: offscreen/software rendering makes the timings meaningless):
+///   ./QGroundControl.app/Contents/MacOS/QGroundControl --unittest:GeoMapPerfUITest --onscreen
+class GeoMapPerfUITest : public QmlUITestBase
+{
+    Q_OBJECT
+
+private slots:
+    void _benchmark();
+};


### PR DESCRIPTION
## Summary

Performance work on the GeoMap 2D/3D engine, measured and validated with a repeatable benchmark added in this PR. Worst single `SurfaceModel` update pass drops from **95 ms to ~5 ms** (desktop, 120 Hz) across all benchmark phases, including the high-tilt orbit scenario that produced 421 ms freezes at baseline.

## Changes

**SurfaceModel** — coalesce camera-driven updates to one pass per event-loop iteration; cap patch adds/removals per pass (delegate create/destroy is synchronous, ~0.75 ms each) with self-scheduled follow-up passes; cache per-patch max height so terrain-aware culling is O(patches).

**SurfacePatchModel** — cache composited fallback images per patch (invalidated on source-tile changes); scope covered-row notifications by rect intersection (was O(rows²) and dominated passes at high resident counts); coalesce stats notifications; add 1 Hz perf sampling + CSV capture recording behind debug buttons.

**TerrainHeightSource** — sparse sampling for coarse patches: elevation tiles are a fixed 0.01° grid regardless of patch zoom, so a zoom-12 patch's full sample grid touched ~100 distinct tiles (each a multi-second serial fetch through the shared terrain pipeline). Patches spanning more than 4 tiles per axis now sample a 4×4 vertex grid bilinearly upsampled to the delivery grid, capping fetches at ~16 tiles per patch. **Display-only path** — mission planning and TERRAIN_REQUEST terrain queries are unaffected.

**GeoMap.qml** — hoist the terrain z-scale binding to a shared parent Node (one binding instead of one per delegate); slim the patch delegate (profiling showed QML object creation dominating patch churn ~4:1 over geometry); add a `DebugView` render-stats overlay.

## Benchmark

`GeoMapPerfUITest` (standalone, on-screen, not part of ctest/CI runs) drives repeatable gesture phases — street-zoom pan, zoom-out/zoom-in LOD bursts, high-tilt orbit churn, sustained slow-heights churn — while capturing per-second counters to CSV:

```
./QGroundControl --unittest:GeoMapPerfUITest --onscreen
```

3-run results on this branch: worst max 5.0–5.1 ms, mean avg 1.29 ms, peak residency well under budget.

## Not addressed here (tracked separately)

Slow terrain fill-in and occasional flat-patch cliffs under bad server conditions are **pre-existing on master** (verified by A/B testing tonight) and owned by the terrain fetch pipeline, not this rendering layer:
- #14819 — TerrainTileManager serial single-flight fetching + shared cache-queue starvation (5.2)
- #14820 — client-side slippy elevation pyramid (5.2)

An earlier iteration of this branch added resident-set backpressure (ceiling + deferred-add tracking) to survive slow heights; it was deliberately removed in favor of simple per-pass caps after it caused a deadlock-class bug — the complexity belonged to the pipeline problem, not this model. The resident set may transiently exceed budget while heights are slow, which is accepted and documented.

## Testing

- All GeoMap unit/integration suites pass (SurfaceModel, SurfacePatchModel, SurfacePatchImagery, TerrainHeightSource, GeoMapCamera, GeoScene, FlyViewGeoUITest)
- New tests: slow-heights churn settles without holes or unbounded residency; sparse sampling delivers full-size, transpose-safe, continuous grids
