### PR TITLE
fix(i18n): make APM sensor calibration strings translatable

### DIFF
--- a/src/AutoPilotPlugins/APM/APMSensorsComponent.qml
+++ b/src/AutoPilotPlugins/APM/APMSensorsComponent.qml
@@ -506,7 +506,7 @@ SetupPage {
                             }
 
                             QGCCheckBox {
-                                text: "Simple Accelerometer Calibration"
+                                text: qsTr("Simple Accelerometer Calibration")
                                 onClicked: _doSimpleAccelCal = this.checked
                             }
                         }
@@ -598,7 +598,7 @@ SetupPage {
                                 width:      parent.width
                                 visible:    useMapPositionCheckbox.checked
                                 wrapMode:   Text.WordWrap
-                                text:       qsTr(`Lat: ${_mapPosition.latitude.toFixed(4)} Lon: ${_mapPosition.longitude.toFixed(4)}`)
+                                text: qsTr("Lat: %1 Lon: %2").arg(_mapPosition.latitude.toFixed(4)).arg(_mapPosition.longitude.toFixed(4)) //: %1 is latitude, %2 is longitude
                             }
 
                             FactTextField {


### PR DESCRIPTION
## Summary

- Wrap the `Simple Accelerometer Calibration` label in `qsTr()`.
- Replace the dynamically generated `qsTr()` input for latitude and longitude
  with a stable source string using `%1` and `%2` placeholders.
- Add translator context for the coordinate placeholders.

## Problem

The calibration label is currently hard-coded in English.

The coordinate string is interpolated before it is passed to `qsTr()`, so the
runtime value cannot match a stable key in the translation catalog.

## Test plan

- Verified that only `APMSensorsComponent.qml` is modified.
- Ran `git diff --check`.
- Verified by code inspection that both coordinate values are preserved.

## Additional context

Both issues were confirmed against the current `master` branch.