### PR TITLE
fix(i18n): make ArduSub motor direction label translatable

### DIFF
--- a/src/AutoPilotPlugins/APM/APMSubMotorComponent.qml
+++ b/src/AutoPilotPlugins/APM/APMSubMotorComponent.qml
@@ -224,7 +224,7 @@ SetupPage {
 
                     QGCButton {
                         id: startAutoDetection
-                        text: "Auto-Detect Directions"
+                        text: qsTr("Auto-Detect Directions")
                         enabled: controller.vehicle.flightMode !== controller.vehicle.motorDetectionFlightMode
 
                         onClicked: function() {


### PR DESCRIPTION
## Summary

- Wrap the ArduSub `Auto-Detect Directions` button label in `qsTr()`.

## Problem

The button label is currently hard-coded in English and therefore cannot be
translated.

## Test plan

- Ran `git diff --check`.
- Verified that only `APMSubMotorComponent.qml` is modified.
- Verified by code inspection that the English fallback text is unchanged.