### PR TITLE
fix(i18n): make custom ArduSub frame names translatable

### DIFF
--- a/src/AutoPilotPlugins/APM/APMSubFrameComponentSummary.qml
+++ b/src/AutoPilotPlugins/APM/APMSubFrameComponentSummary.qml
@@ -32,9 +32,9 @@ Item {
         case 6:
             return "SimpleROV-5"
         case 7:
-            return "Custom"
+            return qsTr("Custom")
         default:
-            return "Unknown"
+            return qsTr("Unknown frame")
         }
     }
 


### PR DESCRIPTION
## Summary

- Make the custom ArduSub frame name translatable.
- Use a separate translatable string for an unknown frame configuration.

## Problem

`Custom` and `Unknown` are returned as plain strings from `frameName()`, so
they cannot be localized.

A separate `Unknown frame` source string avoids sharing the generic `Unknown`
translation already used for firmware versions and Git hashes in this file.

## Test plan

- Ran `git diff --check`.
- Verified that only `APMSubFrameComponentSummary.qml` is modified.
- Verified the `FRAME_CONFIG = 7` and fallback branches by code inspection.