### PR TITLE
fix(i18n): make APM goto location error translatable

### DIFF
--- a/src/FirmwarePlugin/APM/APMFirmwarePlugin.cc
+++ b/src/FirmwarePlugin/APM/APMFirmwarePlugin.cc
@@ -775,7 +775,7 @@ out:
 bool APMFirmwarePlugin::guidedModeGotoLocation(Vehicle *vehicle, const QGeoCoordinate &gotoCoord, double forwardFlightLoiterRadius) const
 {
     if (qIsNaN(vehicle->altitudeRelative()->rawValue().toDouble())) {
-        QGC::showAppMessage(QStringLiteral("Unable to go to location, vehicle position not known."));
+        QGC::showAppMessage(tr("Unable to go to location, vehicle position not known."));
         return false;
     }
 


### PR DESCRIPTION
## Summary

- Make the APM guided-mode goto-location error message translatable.

## Problem

When the vehicle position is unknown, the user-facing error message is created
with `QStringLiteral()` and therefore bypasses Qt translation.

## Test plan

- Ran `git diff --check`.
- Verified that only `APMFirmwarePlugin.cc` is modified.
- Verified by code inspection that the error condition and displayed English
  fallback text are unchanged.