### PR TITLE
fix(VideoManager): correct recording error message typo

### DIFF
--- a/src/VideoManager/VideoManager.cc
+++ b/src/VideoManager/VideoManager.cc
@@ -361,7 +361,7 @@ void VideoManager::startRecording(const QString &videoFile)
 
     const QString savePath = SettingsManager::instance()->appSettings()->videoSavePath();
     if (savePath.isEmpty()) {
-        QGC::showAppMessage(tr("Unabled to record video. Video save path must be specified in Settings."));
+        QGC::showAppMessage(tr("Unable to record video. Video save path must be specified in Settings."));
         return;
     }
 


### PR DESCRIPTION
## Summary

- Fix `Unabled` to `Unable` in the video recording error message.

## Problem

When video recording is started without a configured save path, the displayed
English error message contains the typo `Unabled`.

## Test plan

- Ran `git diff --check`.
- Verified that only `VideoManager.cc` is modified.
- Verified by code inspection that the error condition and control flow are
  unchanged.