### PR TITLE
fix(Settings): clarify voice notification audio controls

### DIFF
--- a/src/Settings/App.SettingsGroup.json
+++ b/src/Settings/App.SettingsGroup.json
@@ -121,17 +121,17 @@
         },
         {
             "name": "audioMuted",
-            "shortDesc": "Mute audio output",
-            "longDesc": "Mutes all audio output without changing the volume level.",
+            "shortDesc": "Mute voice notifications",
+            "longDesc": "Mutes voice notifications without changing the volume level.",
             "type": "bool",
             "default": false,
-            "label": "Mute Audio Output",
-            "keywords": "audio,mute,sound"
+            "label": "Mute Voice Notifications",
+            "keywords": "audio,mute,sound,voice,notifications"
         },
         {
             "name": "audioVolume",
-            "shortDesc": "Controls the volume level for audio alerts and notifications.",
-            "longDesc": "Sets the audio output volume percentage.",
+            "shortDesc": "Controls the volume level for voice notifications.",
+            "longDesc": "Sets the voice notification volume percentage.",
             "type": "double",
             "default": 100.0,
             "units": "%",
@@ -139,8 +139,8 @@
             "decimalPlaces": 1,
             "userMin": 0.0,
             "userMax": 100.0,
-            "label": "Audio Output Volume",
-            "keywords": "audio,volume,sound"
+            "label": "Voice Notification Volume",
+            "keywords": "audio,volume,sound,voice,notifications"
         },
         {
             "name": "virtualJoystick",


### PR DESCRIPTION
## Summary

- Rename the audio settings to clarify that they control voice notifications.
- Update the related descriptions and search keywords.

## Problem

The current labels `Mute Audio Output` and `Audio Output Volume` suggest that
these settings affect all application audio.

In practice, `audioMuted` and `audioVolume` are used by `AudioOutput` to control
text-to-speech alerts and notifications. They do not control video audio or
other system sounds.

## Changes

- `Mute Audio Output` → `Mute Voice Notifications`
- `Audio Output Volume` → `Voice Notification Volume`
- Update the short and long descriptions accordingly.
- Add `voice` and `notifications` to the search keywords.
- Keep the internal setting names unchanged for compatibility.

## Test plan

- Validated `App.SettingsGroup.json`.
- Ran `git diff --check`.
- Verified that only `App.SettingsGroup.json` is modified.
- Verified that no translation files are changed.