### PR TITLE
fix(AppSettings): correct UDP performance typo

### DIFF
--- a/src/AppSettings/UdpSettings.qml
+++ b/src/AppSettings/UdpSettings.qml
@@ -17,7 +17,7 @@ ColumnLayout {
         Layout.fillWidth:       true
         font.pointSize:         ScreenTools.smallFontPointSize
         wrapMode:               Text.WordWrap
-        text:                   qsTr("Note: For best perfomance, please disable AutoConnect to UDP devices on the General page.")
+        text:                   qsTr("Note: For best performance, please disable AutoConnect to UDP devices on the General page.")
     }
 
     RowLayout {


### PR DESCRIPTION
## Summary

- Fix `perfomance` to `performance` in the UDP settings note.

## Problem

The user-facing note shown in UDP settings contains a spelling error in the
word `performance`.

## Test plan

- Ran `git diff --check`.
- Verified that only `UdpSettings.qml` is modified.
- Verified that the displayed message and application behavior are otherwise
  unchanged.