### PR TITLE
fix(AppSettings): correct MAVLink capitalization

### DIFF
--- a/src/AppSettings/pages/Video.SettingsUI.json
+++ b/src/AppSettings/pages/Video.SettingsUI.json
@@ -13,7 +13,7 @@
             "heading": "Video Source",
             "keywords": ["video source", "camera", "stream"],
             "enableWhen": "!autoStreamConfig",
-            "headingDescription": "autoStreamConfig ? qsTr(\"Mavlink camera stream is automatically configured\") : \"\"",
+            "headingDescription": "autoStreamConfig ? qsTr(\"MAVLink camera stream is automatically configured\") : \"\"",
             "controls": [
                 {
                     "setting": "videoSettings.videoSource",


### PR DESCRIPTION
## Summary

- Correct the capitalization of MAVLink in the automatic camera stream
  description.

## Problem

The protocol name is currently displayed as `Mavlink` instead of the official
capitalization `MAVLink`.

## Test plan

- Validated `Video.SettingsUI.json`.
- Ran `git diff --check`.
- Verified that only `Video.SettingsUI.json` is modified.
- Verified that application behavior is unchanged.