### PR TITLE
fix(Settings): correct descent speed description

### DIFF
--- a/src/Settings/App.SettingsGroup.json
+++ b/src/Settings/App.SettingsGroup.json
@@ -84,7 +84,7 @@
         {
             "name": "offlineEditingDescentSpeed",
             "shortDesc": "Offline editing descent speed",
-            "longDesc": "This value defines the cruising speed for multi-rotor vehicles for use in calculating mission duration.",
+            "longDesc": "This value defines the descent speed for multi-rotor vehicles for use in calculating mission duration.",
             "type": "double",
             "default": 1.0,
             "min": 0.1,


### PR DESCRIPTION
## Summary

- Correct the description of the offline editing descent speed setting.

## Problem

The `offlineEditingDescentSpeed` setting currently describes its value as a
`cruising speed`, although it is used as the multi-rotor descent speed when
calculating mission duration.

## Test plan

- Validated `App.SettingsGroup.json`.
- Ran `git diff --check`.
- Verified that only `App.SettingsGroup.json` is modified.
- Verified that the setting name, type, limits, and default value are unchanged.