### PR TITLE
fix(FlyView): correct launching typo in checklists

### DIFF
--- a/src/FlyView/DefaultChecklist.qml
+++ b/src/FlyView/DefaultChecklist.qml
@@ -68,7 +68,7 @@ Item {
 
             PreFlightCheckButton {
                 name:           qsTr("Wind & weather")
-                manualText:     qsTr("OK for your platform? Lauching into the wind?")
+                manualText:     qsTr("OK for your platform? Launching into the wind?")
             }
 
             PreFlightCheckButton {

--- a/src/FlyView/FixedWingChecklist.qml
+++ b/src/FlyView/FixedWingChecklist.qml
@@ -68,7 +68,7 @@ Item {
 
             PreFlightCheckButton {
                 name:           qsTr("Wind & weather")
-                manualText:     qsTr("OK for your platform? Lauching into the wind?")
+                manualText:     qsTr("OK for your platform? Launching into the wind?")
             }
 
             PreFlightCheckButton {

--- a/src/FlyView/VTOLChecklist.qml
+++ b/src/FlyView/VTOLChecklist.qml
@@ -68,7 +68,7 @@ Item {
 
             PreFlightCheckButton {
                 name:        "Wind & weather"
-                manualText:  qsTr("OK for your platform? Lauching into the wind?")
+                manualText:  qsTr("OK for your platform? Launching into the wind?")
             }
 
             PreFlightCheckButton {


### PR DESCRIPTION
## Summary

- Fix `Lauching` to `Launching` in the pre-flight weather check.
- Apply the correction to the default, fixed-wing, and VTOL checklists.

## Problem

The pre-flight checklist question contains the spelling error `Lauching`.
The same string is present in three checklist implementations.

## Test plan

- Ran `git diff --check`.
- Verified that no `Lauching` occurrences remain under `src/FlyView`.
- Verified that only the three checklist QML files are modified.
- Verified that checklist behavior is unchanged.