### PR TITLE
fix(i18n): make transect editor fallback translatable

### DIFF
--- a/src/PlanView/TransectStyleComplexItemEditor.qml
+++ b/src/PlanView/TransectStyleComplexItemEditor.qml
@@ -24,7 +24,7 @@ Rectangle {
     property var    transectValuesComponent:        undefined
     property var    presetsTransectValuesComponent: undefined
 
-    readonly property string _internalError: "Internal Error"
+    readonly property string _internalError: qsTr("Internal Error")
 
     property var    _missionItem:               missionItem
     property real   _margin:                    ScreenTools.defaultFontPixelWidth / 2


### PR DESCRIPTION
## Summary

- Make the transect editor's `Internal Error` fallback text translatable.

## Problem

The fallback value is displayed to users when a derived transect editor does
not provide its help text or values header. It is currently a plain QML string
and bypasses Qt translation.

## Test plan

- Ran `git diff --check`.
- Verified that only `TransectStyleComplexItemEditor.qml` is modified.
- Verified that the fallback English text and property behavior are unchanged.