### PR TITLE
fix(i18n): make unsupported vehicle command errors translatable

### DIFF
--- a/src/Vehicle/Vehicle.cc
+++ b/src/Vehicle/Vehicle.cc
@@ -1937,7 +1937,7 @@ Vehicle::guidedModeChangeEquivalentAirspeedMetersSecond(double airspeed)
 void Vehicle::guidedModeOrbit(const QGeoCoordinate& centerCoord, double radius, double amslAltitude)
 {
     if (!_vehicleSupports->orbitMode()) {
-        QGC::showAppMessage(QStringLiteral("Orbit mode not supported by Vehicle."));
+        QGC::showAppMessage(tr("Orbit mode not supported by Vehicle."));
         return;
     }
     if (capabilityBits() & MAV_PROTOCOL_CAPABILITY_COMMAND_INT) {
@@ -1972,7 +1972,7 @@ void Vehicle::guidedModeROI(const QGeoCoordinate& centerCoord)
         return;
     }
     if (!_vehicleSupports->roiMode()) {
-        QGC::showAppMessage(QStringLiteral("ROI mode not supported by Vehicle."));
+        QGC::showAppMessage(tr("ROI mode not supported by Vehicle."));
         return;
     }
 
@@ -1997,7 +1997,7 @@ void Vehicle::guidedModeROI(const QGeoCoordinate& centerCoord)
 void Vehicle::stopGuidedModeROI()
 {
     if (!_vehicleSupports->roiMode()) {
-        QGC::showAppMessage(QStringLiteral("ROI mode not supported by Vehicle."));
+        QGC::showAppMessage(tr("ROI mode not supported by Vehicle."));
         return;
     }
     if (capabilityBits() & MAV_PROTOCOL_CAPABILITY_COMMAND_INT) {
@@ -2041,7 +2041,7 @@ void Vehicle::guidedModeChangeHeading(const QGeoCoordinate &headingCoord)
 void Vehicle::pauseVehicle()
 {
     if (!_vehicleSupports->pauseVehicle()) {
-        QGC::showAppMessage(QStringLiteral("Pause not supported by vehicle."));
+        QGC::showAppMessage(tr("Pause not supported by vehicle."));
         return;
     }
     _firmwarePlugin->pauseVehicle(this);


### PR DESCRIPTION
## Summary

- Make unsupported Orbit, ROI, and Pause command messages translatable.

## Problem

These user-facing errors are currently created with `QStringLiteral()` and
therefore bypass Qt translation.

The three unique messages occur at four call sites because the ROI error is
used in two code paths.

## Test plan

- Ran `git diff --check`.
- Verified that only `Vehicle.cc` is modified.
- Verified that all four affected call sites now use `Vehicle::tr()`.
- Verified that the message text and command handling logic are unchanged.