### PR TITLE
fix(i18n): make ADSB server errors translatable

### DIFF
--- a/src/ADSB/ADSBVehicleManager.cc
+++ b/src/ADSB/ADSBVehicleManager.cc
@@ -225,10 +225,11 @@ void ADSBVehicleManager::_linkError(const QString &errorMsg, bool stopped)
 {
     qCDebug(ADSBVehicleManagerLog) << errorMsg;
 
-    QString msg = QStringLiteral("ADSB Server Error: %1").arg(errorMsg);
+    QString msg = tr("ADSB Server Error: %1").arg(errorMsg);
 
     if (stopped) {
-        (void) msg.append("\nADSB has been disabled");
+        (void) msg.append(QLatin1Char('\n'));
+        (void) msg.append(tr("ADSB has been disabled"));
         _adsbSettings->adsbServerConnectEnabled()->setRawValue(false);
     }
 


### PR DESCRIPTION
## Summary

- Make ADSB server error messages translatable.
- Keep the newline separator outside the translated text.

## Problem

The ADSB server error and disabled notification are user-facing strings, but
they are currently created without `tr()` and therefore bypass Qt translation.

## Test plan

- Ran `git diff --check`.
- Verified that only `ADSBVehicleManager.cc` is modified.
- Verified that the `%1` placeholder and error text are preserved.
- Verified that the disabled notification remains separated by a newline.