### PR TITLE
fix(i18n): make custom flight mode fallback translatable

### DIFF
--- a/src/FirmwarePlugin/FirmwarePlugin.cc
+++ b/src/FirmwarePlugin/FirmwarePlugin.cc
@@ -65,7 +65,7 @@ QString FirmwarePlugin::flightMode(uint8_t base_mode, uint32_t custom_mode) cons
     if (base_mode == 0) {
         flightMode = "PreFlight";
     } else if (base_mode & MAV_MODE_FLAG_CUSTOM_MODE_ENABLED) {
-        flightMode = _modeEnumToString.value(custom_mode, QStringLiteral("Custom:0x%1").arg(custom_mode, 0, 16));
+        flightMode = _modeEnumToString.value(custom_mode, tr("Custom:0x%1").arg(custom_mode, 0, 16));
     } else {
         for (size_t i = 0; i < std::size(rgBit2Name); i++) {
             if (base_mode & rgBit2Name[i].baseModeBit) {


### PR DESCRIPTION
## Summary

- Make the fallback name for an unknown custom flight mode translatable.

## Problem

When a custom flight mode value is not present in the mode map, QGroundControl
displays `Custom:0x%1`. This user-facing fallback is currently created with
`QStringLiteral()` and bypasses Qt translation.

## Test plan

- Ran `git diff --check`.
- Verified that only `FirmwarePlugin.cc` is modified.
- Verified that the custom mode value remains formatted as hexadecimal.
- Verified that the fallback English text and lookup behavior are unchanged.