### PR TITLE
fix(i18n): make firmware upgrade errors translatable

### DIFF
--- a/src/Vehicle/VehicleSetup/FirmwareUpgradeController.cc
+++ b/src/Vehicle/VehicleSetup/FirmwareUpgradeController.cc
@@ -326,7 +326,7 @@ void FirmwareUpgradeController::_foundBoardInfo(int bootloaderVersion, int board
 ///         machine to the appropriate error state.
 void FirmwareUpgradeController::_bootloaderSyncFailed(void)
 {
-    _errorCancel("Unable to sync with bootloader.");
+    _errorCancel(tr("Unable to sync with bootloader."));
 }
 
 QHash<FirmwareUpgradeController::FirmwareIdentifier, QString>* FirmwareUpgradeController::_firmwareHashForBoardId(int boardId)
@@ -493,7 +493,7 @@ void FirmwareUpgradeController::_error(const QString& errorString)
     delete _image;
     _image = nullptr;
 
-    _errorCancel(QString("Error: %1").arg(errorString));
+    _errorCancel(tr("Error: %1").arg(errorString));
 }
 
 void FirmwareUpgradeController::_status(const QString& statusString)


### PR DESCRIPTION
## Summary

- Make two firmware upgrade error messages translatable.

## Problem

The bootloader synchronization failure and generic upgrade error are shown in
the firmware upgrade status log, but are currently created without `tr()` and
therefore bypass Qt translation.

## Test plan

- Ran `git diff --check`.
- Verified that only `FirmwareUpgradeController.cc` is modified.
- Verified that the `%1` placeholder and supplied error text are preserved.
- Verified that firmware upgrade error handling is unchanged.