### PR TITLE
fix(i18n): make Survey-In duration unit translatable

### DIFF
--- a/src/Toolbar/GPSIndicatorPage.qml
+++ b/src/Toolbar/GPSIndicatorPage.qml
@@ -134,7 +134,8 @@ ToolIndicatorPage {
 
                 LabelledLabel {
                     label:      qsTr("Duration")
-                    labelText:  QGroundControl.gpsRtk.currentDuration.value + ' s'
+                    //: %1 is Survey-In duration in seconds
+                    labelText:  qsTr("%1 s").arg(QGroundControl.gpsRtk.currentDuration.value)
                 }
 
                 LabelledLabel {


### PR DESCRIPTION
## Summary

- Make the Survey-In duration value and unit translatable.
- Add context for the `%1` duration placeholder.

## Problem

The RTK GPS status page currently appends the seconds unit as a plain QML
literal. Languages that use a different seconds abbreviation or value/unit
ordering cannot localize the complete label.

## Test plan

- Ran `git diff --check`.
- Verified that only `GPSIndicatorPage.qml` is modified.
- Verified that `%1` is replaced with the current Survey-In duration.
- Verified that the English output remains `<duration> s`.