### PR TITLE
fix(i18n): make gimbal control dialog translatable

### DIFF
--- a/src/Toolbar/GimbalIndicator.qml
+++ b/src/Toolbar/GimbalIndicator.qml
@@ -318,8 +318,8 @@ Item {
                 acquirePopupConnection.isPopupOpen = true;
                 QGroundControl.showMessageDialog(
                     control,
-                    "Request Gimbal Control?",
-                    "Command not sent. Another user has control of the gimbal.",
+                    qsTr("Request Gimbal Control?"),
+                    qsTr("Command not sent. Another user has control of the gimbal."),
                     Dialog.Yes | Dialog.No,
                     gimbalController.acquireGimbalControl,
                     function() { acquirePopupConnection.isPopupOpen = false }


### PR DESCRIPTION
## Summary

- Make the gimbal control request dialog translatable.

## Problem

The dialog title and message are user-facing QML strings, but they are passed
to `showMessageDialog()` without `qsTr()` and therefore bypass Qt translation.

## Test plan

- Ran `git diff --check`.
- Verified that only `GimbalIndicator.qml` is modified.
- Verified that the dialog buttons and callbacks are unchanged.
- Verified that the English fallback text remains unchanged.