### PR TITLE
fix(GeoMap): pan anchor after pinch and trackpad orbit support

### DIFF
--- a/src/FlyView/FlyViewGeo.qml
+++ b/src/FlyView/FlyViewGeo.qml
@@ -60,17 +60,27 @@ Item {
 
             // Debug overlay: live SurfaceModel stats for manual verification;
             // second line adds the perf counters while Stats is on
-            QGCLabel {
-                objectName: "flyViewGeoDebugOverlay"
+            Rectangle {
                 anchors.left: parent.left
                 anchors.bottom: parent.bottom
-                anchors.margins: ScreenTools.defaultFontPixelWidth
-                font.family: ScreenTools.fixedFontFamily
-                text: qsTr("patches: %1  pending: %2  max zoom: %3")
-                          .arg(geoMap.patchCount)
-                          .arg(geoMap.pendingCount)
-                          .arg(geoMap.maxZoomLevel)
-                      + (geoMap.modelStats !== "" ? "\n" + geoMap.modelStats : "")
+                anchors.margins: ScreenTools.defaultFontPixelWidth / 2
+                width: debugOverlayLabel.implicitWidth + ScreenTools.defaultFontPixelWidth
+                height: debugOverlayLabel.implicitHeight + ScreenTools.defaultFontPixelWidth
+                radius: ScreenTools.defaultFontPixelWidth / 2
+                color: Qt.rgba(0, 0, 0, 0.5)
+
+                QGCLabel {
+                    id: debugOverlayLabel
+                    objectName: "flyViewGeoDebugOverlay"
+                    anchors.centerIn: parent
+                    font.family: ScreenTools.fixedFontFamily
+                    color: "white"
+                    text: qsTr("patches: %1  pending: %2  max zoom: %3")
+                              .arg(geoMap.patchCount)
+                              .arg(geoMap.pendingCount)
+                              .arg(geoMap.maxZoomLevel)
+                          + (geoMap.modelStats !== "" ? "\n" + geoMap.modelStats : "")
+                }
             }
 
             Column {

--- a/src/GeoMap/GeoMap.qml
+++ b/src/GeoMap/GeoMap.qml
@@ -226,7 +226,10 @@ Item {
             onActiveChanged: {
                 if (active) {
                     root.completeCameraAnimations()
-                    geoCamera.beginPan(centroid.pressPosition)
+                    // Anchor at the current position, not pressPosition: after a
+                    // two-finger pinch drops to one finger this handler re-activates
+                    // with a stale pressPosition, and anchoring there jumps the map.
+                    geoCamera.beginPan(centroid.position)
                 }
             }
             onCentroidChanged: {
@@ -236,10 +239,15 @@ Item {
             }
         }
 
-        // Right-drag orbits: full width = 360 deg heading, full height = 180 deg tilt
+        // Right-drag orbits: full width = 360 deg heading, full height = 180 deg tilt.
+        // Mouse/touchpad only: acceptedButtons doesn't filter touch points, so
+        // without acceptedDevices this handler steals single-finger drags from
+        // panHandler on touchscreens (touch orbits via PinchHandler twist instead).
+        // TouchPad keeps trackpad secondary-click drag working.
         DragHandler {
             id: orbitHandler
             target: null
+            acceptedDevices: PointerDevice.Mouse | PointerDevice.TouchPad
             acceptedButtons: Qt.RightButton
             onActiveChanged: {
                 if (active) {


### PR DESCRIPTION
## Summary

Gesture fixes for the experimental GeoMap control, plus a readability tweak for the FlyViewGeo debug overlay.

- **Pan anchor after pinch**: anchor pan at `centroid.position` instead of `pressPosition`. When a two-finger pinch drops to one finger, the pan DragHandler re-activates with a stale `pressPosition`, and anchoring there jumped the map.
- **Trackpad orbit**: accept `PointerDevice.TouchPad` on the orbit handler so trackpad secondary-click drag orbits. Touchscreens remain excluded so single-finger drags still pan (touch orbits via pinch twist).
- **Debug overlay backdrop**: semi-transparent rounded backdrop behind the SurfaceModel stats overlay so it stays readable over map imagery.

## Test

- Manual: verified pinch→single-finger transition no longer jumps, right-drag orbit works with mouse, touchscreen single-finger drag still pans.
- `just lint` clean (pre-commit hooks ran on commit).