### PR TITLE
chore: backport V5.1 milestoned fixes to Stable_V5.1

### DIFF
--- a/src/AnalyzeView/OnboardLogs/OnboardLogController.cc
+++ b/src/AnalyzeView/OnboardLogs/OnboardLogController.cc
@@ -498,9 +498,13 @@ void OnboardLogController::refresh()
     emit selectionChanged();
 
     if (_vehicle && !_ftpDisabled && _vehicle->capabilitiesKnown() && (_vehicle->capabilityBits() & MAV_PROTOCOL_CAPABILITY_FTP)) {
+        qCDebug(OnboardLogControllerLog) << "refresh: using ftp transport";
         _setTransport(Transport::Ftp);
         _ftpStartListing();
     } else {
+        qCDebug(OnboardLogControllerLog) << "refresh: using message transport - ftpDisabled:" << _ftpDisabled
+            << "capabilitiesKnown:" << (_vehicle && _vehicle->capabilitiesKnown())
+            << "ftpCapable:" << bool(_vehicle && (_vehicle->capabilityBits() & MAV_PROTOCOL_CAPABILITY_FTP));
         _setTransport(Transport::Messages);
         _requestLogList(0, 0xffff);
     }

--- a/src/AnalyzeView/OnboardLogs/OnboardLogController.cc
+++ b/src/AnalyzeView/OnboardLogs/OnboardLogController.cc
@@ -980,6 +980,11 @@ void OnboardLogController::_ftpListDirComplete(const QStringList &dirList, const
         return;
     }
 
+    // Raw entries expose whether the server included the optional mtime field (date/time diagnosis)
+    qCDebug(OnboardLogControllerLog) << "ftp: raw entries for"
+        << ((_ftpListState == FtpListState::ListingRoot) ? _ftpLogRoot : (_ftpDirsToList.isEmpty() ? QString() : _ftpDirsToList.first()))
+        << dirList;
+
     if (_ftpListState == FtpListState::ListingRoot) {
         // The root listing may contain log files directly (flat layout, e.g. @MAV_LOG)
         // and/or date subdirectories to descend into (PX4 fallback /fs/microsd/log).

--- a/src/AnalyzeView/OnboardLogs/OnboardLogPage.qml
+++ b/src/AnalyzeView/OnboardLogs/OnboardLogPage.qml
@@ -1,7 +1,6 @@
 import QtQuick
 import QtQuick.Controls
 import QtQuick.Layouts
-import Qt.labs.qmlmodels
 
 import QGroundControl
 import QGroundControl.Controls

--- a/src/AnalyzeView/OnboardLogs/OnboardLogPage.qml
+++ b/src/AnalyzeView/OnboardLogs/OnboardLogPage.qml
@@ -70,7 +70,9 @@ AnalyzePage {
                                     return ""
                                 }
 
-                                if (object.time.getUTCFullYear() < 2010) {
+                                // getUTCFullYear() is NaN for an invalid date
+                                const year = object.time.getUTCFullYear()
+                                if (Number.isNaN(year) || year < 2010) {
                                     return qsTr("Date Unknown")
                                 }
 

--- a/src/FlightMap/FlightMap.qml
+++ b/src/FlightMap/FlightMap.qml
@@ -3,7 +3,6 @@ import QtQuick.Controls
 import QtLocation
 import QtPositioning
 import QtQuick.Dialogs
-import Qt.labs.animation
 
 import QGroundControl
 import QGroundControl.Controls

--- a/src/FlightMap/Widgets/IntegratedCompassAttitude.qml
+++ b/src/FlightMap/Widgets/IntegratedCompassAttitude.qml
@@ -33,7 +33,9 @@ Item {
 
     IntegratedAttitudeIndicator {
         x:                      -_totalAttitudeSize
-        attitudeAngleDegrees:   vehicle ? vehicle.pitch.rawValue : 0
+        // Negated: rotating the indicator 90° clockwise moves its zero tick to the right of the
+        // compass but leaves the sweep direction clockwise, which would draw nose up as downward.
+        attitudeAngleDegrees:   vehicle ? -vehicle.pitch.rawValue : 0
         compassRadius:          control.compassRadius
         attitudeSize:           control.attitudeSize
         attitudeSpacing:        control.attitudeSpacing

--- a/src/QmlControls/ClickableColor.qml
+++ b/src/QmlControls/ClickableColor.qml
@@ -1,7 +1,6 @@
 import QtQuick
 import QtQuick.Controls
 import QtQuick.Dialogs
-import Qt.labs.platform
 
 Rectangle {
     id:             _root
@@ -15,7 +14,7 @@ Rectangle {
     ColorDialog {
         id: colorDialog
         onAccepted: {
-            _root.colorSelected(colorDialog.color)
+            _root.colorSelected(colorDialog.selectedColor)
             colorDialog.close()
         }
     }
@@ -24,8 +23,8 @@ Rectangle {
         anchors.fill: parent
 
         onClicked: {
-            colorDialog.color = _root.color
-            colorDialog.visible = true
+            colorDialog.selectedColor = _root.color
+            colorDialog.open()
         }
     }
 }

--- a/src/QmlControls/QGCFileDialog.qml
+++ b/src/QmlControls/QGCFileDialog.qml
@@ -123,7 +123,7 @@ Item {
 
     FileDialog {
         id:             fullFileDialog
-        currentFolder:  "file:///" + _root.folder
+        currentFolder:  QGCFileDialogController.localFileToUrl(_root.folder)
         nameFilters:    _root.nameFilters ? _root.nameFilters : []
         title:          _root.title
         defaultSuffix:  _root.defaultSuffix
@@ -141,7 +141,7 @@ Item {
 
     FolderDialog {
         id:             fullFolderDialog
-        currentFolder:  "file:///" + _root.folder
+        currentFolder:  QGCFileDialogController.localFileToUrl(_root.folder)
         title:          _root.title
 
         onAccepted: _root.acceptedForLoad(QGCFileDialogController.urlToLocalFile(selectedFolder))

--- a/src/QmlControls/QGCFileDialog.qml
+++ b/src/QmlControls/QGCFileDialog.qml
@@ -2,7 +2,6 @@ import QtQuick
 import QtQuick.Controls
 import QtQuick.Dialogs
 import QtQuick.Layouts
-import Qt.labs.platform as Labs
 
 import QGroundControl
 import QGroundControl.Controls
@@ -140,12 +139,12 @@ Item {
         onRejected: _root.rejected()
     }
 
-    Labs.FolderDialog {
+    FolderDialog {
         id:             fullFolderDialog
         currentFolder:  "file:///" + _root.folder
         title:          _root.title
 
-        onAccepted: _root.acceptedForLoad(QGCFileDialogController.urlToLocalFile(folder))
+        onAccepted: _root.acceptedForLoad(QGCFileDialogController.urlToLocalFile(selectedFolder))
         onRejected: _root.rejected()
     }
 

--- a/src/QmlControls/QGCFileDialogController.cc
+++ b/src/QmlControls/QGCFileDialogController.cc
@@ -163,6 +163,12 @@ QString QGCFileDialogController::urlToLocalFile(QUrl url)
     return result;
 }
 
+QUrl QGCFileDialogController::localFileToUrl(const QString &localFile)
+{
+    // Empty in, empty out - QUrl::fromLocalFile("") would return the degenerate "file:" url
+    return localFile.isEmpty() ? QUrl() : QUrl::fromLocalFile(localFile);
+}
+
 void QGCFileDialogController::importFromNativePicker()
 {
 #ifdef Q_OS_ANDROID

--- a/src/QmlControls/QGCFileDialogController.h
+++ b/src/QmlControls/QGCFileDialogController.h
@@ -29,6 +29,9 @@ public:
 
     Q_INVOKABLE static QString urlToLocalFile(QUrl url);
 
+    /// Converts a local file path to a properly formed file:// url.
+    Q_INVOKABLE static QUrl localFileToUrl(const QString &localFile);
+
     /// Important: Should only be used in mobile builds where default save location cannot be changed.
     /// Returns the standard QGC location portion of a fully qualified folder path.
     /// Example: "/Users/Don/Document/QGroundControl/Missions" returns "QGroundControl/Missions"

--- a/src/Toolbar/GimbalIndicator.qml
+++ b/src/Toolbar/GimbalIndicator.qml
@@ -32,6 +32,12 @@ Item {
 
     property var _gimbalControllerSettings: QGroundControl.settingsManager.gimbalControllerSettings
 
+    /// Names a gimbal as "<manager compid>-<device id>", e.g. "154-1", so that gimbals
+    /// belonging to different managers can be told apart.
+    function gimbalName(gimbal) {
+        return gimbal ? (gimbal.managerCompid.valueString + "-" + gimbal.deviceId.valueString) : ""
+    }
+
     QGCPalette { id: qgcPal }
 
     Row {
@@ -61,7 +67,7 @@ Item {
                 id:                     gimbalIdLabel
                 anchors.horizontalCenter: parent.horizontalCenter
                 font.pointSize:         ScreenTools.smallFontPointSize
-                text:                   activeGimbal ? (activeGimbal.managerCompid.valueString + "-" + activeGimbal.deviceId.valueString) : ""
+                text:                   control.gimbalName(activeGimbal)
                 color:                  qgcPal.text
                 visible:                multiGimbalSetup
             }
@@ -141,7 +147,7 @@ Item {
                         let activeIndex = -1
                         for (var i = 0; i < gimbals.count; i++) {
                             var gimbal = gimbals.get(i)
-                            gimbalModel.push(qsTr("Gimbal %1-%2").arg(gimbal.managerCompid.valueString).arg(gimbal.deviceId.valueString))
+                            gimbalModel.push(qsTr("Gimbal %1").arg(control.gimbalName(gimbal)))
                             if (gimbal === activeGimbal) {
                                 activeIndex = i
                             }

--- a/src/Toolbar/GimbalIndicator.qml
+++ b/src/Toolbar/GimbalIndicator.qml
@@ -61,7 +61,7 @@ Item {
                 id:                     gimbalIdLabel
                 anchors.horizontalCenter: parent.horizontalCenter
                 font.pointSize:         ScreenTools.smallFontPointSize
-                text:                   activeGimbal ? activeGimbal.deviceId.rawValue : ""
+                text:                   activeGimbal ? (activeGimbal.managerCompid.valueString + "-" + activeGimbal.deviceId.valueString) : ""
                 color:                  qgcPal.text
                 visible:                multiGimbalSetup
             }
@@ -141,7 +141,7 @@ Item {
                         let activeIndex = -1
                         for (var i = 0; i < gimbals.count; i++) {
                             var gimbal = gimbals.get(i)
-                            gimbalModel.push(qsTr("Gimbal %1").arg(gimbal.deviceId.valueString))
+                            gimbalModel.push(qsTr("Gimbal %1-%2").arg(gimbal.managerCompid.valueString).arg(gimbal.deviceId.valueString))
                             if (gimbal === activeGimbal) {
                                 activeIndex = i
                             }

--- a/src/Vehicle/FTPManager.cc
+++ b/src/Vehicle/FTPManager.cc
@@ -163,6 +163,14 @@ bool FTPManager::listDirectory(uint8_t fromCompId, const QString& fromURI)
             ? MavlinkFTP::kCmdListDirectory
             : MavlinkFTP::kCmdListDirectoryWithTime;
 
+    // Re-report the cached capability on every listing so any log capture window shows it
+    const char* supportStr =
+            (_listDirWithTimeSupport == WithTimeSupport_t::Supported)   ? "vehicle supports it" :
+            (_listDirWithTimeSupport == WithTimeSupport_t::Unsupported) ? "vehicle Nak'ed it earlier this connection" :
+                                                                          "support unknown, probing";
+    qCDebug(FTPManagerLog) << "listDirectory using" << MavlinkFTP::opCodeToString(_listDirectoryState.opCode)
+                           << "-" << supportStr;
+
     if (!_parseURI(fromCompId, fromURI, _listDirectoryState.fullPathOnVehicle, _ftpCompId)) {
         qCWarning(FTPManagerLog) << "_parseURI failed";
         return false;

--- a/test/QmlUITests/OnboardLogUITest.cc
+++ b/test/QmlUITests/OnboardLogUITest.cc
@@ -346,8 +346,9 @@ void OnboardLogUITest::_ftpDownloadUITest()
 {
     runWithMockLink([] { return MockLink::startPX4MockLink(MockConfiguration::OptionFtpCapability); },
                     [&](QPointer<MockLink> mockLink, Vehicle* /*vehicle*/) {
+                        // log_1 has no modification time so its date is unknown
                         const QList<MockLinkFTP::LogFile> logFiles = {
-                            {QStringLiteral("log_1.ulg"), 5000, 1700000000},
+                            {QStringLiteral("log_1.ulg"), 5000, 0},
                             {QStringLiteral("log_2.ulg"), 12345, 1700086400},
                         };
                         mockLink->mockLinkFTP()->setLogFiles(logFiles);
@@ -355,6 +356,15 @@ void OnboardLogUITest::_ftpDownloadUITest()
                         _navigateToOnboardLogsPage();
                         if (QTest::currentTestFailed())
                             return;
+
+                        // Entries without a valid timestamp sort last and must show "Date Unknown", not a blank cell
+                        QQuickItem* const knownDateLabel = findVisibleItem(_rootItem, QStringLiteral("onboardLogDate_0"), 15000);
+                        QVERIFY(knownDateLabel);
+                        QTRY_VERIFY_WITH_TIMEOUT(!knownDateLabel->property("text").toString().isEmpty(), 5000);
+                        QVERIFY(knownDateLabel->property("text").toString() != QStringLiteral("Date Unknown"));
+                        QQuickItem* const unknownDateLabel = findVisibleItem(_rootItem, QStringLiteral("onboardLogDate_1"), 2000);
+                        QVERIFY(unknownDateLabel);
+                        QTRY_COMPARE_WITH_TIMEOUT(unknownDateLabel->property("text").toString(), QStringLiteral("Date Unknown"), 5000);
 
                         QTemporaryDir tempDir;
                         QVERIFY(tempDir.isValid());


### PR DESCRIPTION
Cherry-picks the Release V5.1 milestoned PRs merged to master that were missing from Stable_V5.1:

- #14810 fix(QmlControls): use QtQuick.Dialogs FolderDialog so folder pickers work without native dialogs
- #14811 fix(AnalyzeView): show Date Unknown for onboard logs with invalid dates
- #14815 chore(OnboardLogs): add FTP listing diagnostics for log date/time issue
- #14816 fix(QmlControls): build file dialog currentFolder url properly
- #14818 FlightView: Fix sign of pitch indicator
- #14793 Gimbal: help tell multiple gimbal managers apart

All cherry-picks applied cleanly.
