### PR TITLE
fix(i18n): make user-facing strings translatable

### DIFF
--- a/src/ADSB/ADSBVehicleManager.cc
+++ b/src/ADSB/ADSBVehicleManager.cc
@@ -225,10 +225,11 @@ void ADSBVehicleManager::_linkError(const QString &errorMsg, bool stopped)
 {
     qCDebug(ADSBVehicleManagerLog) << errorMsg;
 
-    QString msg = QStringLiteral("ADSB Server Error: %1").arg(errorMsg);
+    QString msg = tr("ADSB Server Error: %1").arg(errorMsg);
 
     if (stopped) {
-        (void) msg.append("\nADSB has been disabled");
+        (void) msg.append(QLatin1Char('\n'));
+        (void) msg.append(tr("ADSB has been disabled"));
         _adsbSettings->adsbServerConnectEnabled()->setRawValue(false);
     }
 

--- a/src/AutoPilotPlugins/APM/APMAdvancedTuningCopterComponent.qml
+++ b/src/AutoPilotPlugins/APM/APMAdvancedTuningCopterComponent.qml
@@ -141,7 +141,7 @@ SetupPage {
                     }
                 }
 
-                title:          "Rate"
+                title:          qsTr("Rate")
                 tuningMode:     Vehicle.ModeDisabled
                 unit:           "deg/s"
                 axis:           [ roll, pitch, yaw ]

--- a/src/AutoPilotPlugins/APM/APMSensorsComponent.qml
+++ b/src/AutoPilotPlugins/APM/APMSensorsComponent.qml
@@ -506,7 +506,7 @@ SetupPage {
                             }
 
                             QGCCheckBox {
-                                text: "Simple Accelerometer Calibration"
+                                text: qsTr("Simple Accelerometer Calibration")
                                 onClicked: _doSimpleAccelCal = this.checked
                             }
                         }
@@ -598,7 +598,8 @@ SetupPage {
                                 width:      parent.width
                                 visible:    useMapPositionCheckbox.checked
                                 wrapMode:   Text.WordWrap
-                                text:       qsTr(`Lat: ${_mapPosition.latitude.toFixed(4)} Lon: ${_mapPosition.longitude.toFixed(4)}`)
+                                //: %1 is latitude, %2 is longitude
+                                text:       qsTr("Lat: %1 Lon: %2").arg(_mapPosition.latitude.toFixed(4)).arg(_mapPosition.longitude.toFixed(4))
                             }
 
                             FactTextField {

--- a/src/AutoPilotPlugins/APM/APMSubFrameComponentSummary.qml
+++ b/src/AutoPilotPlugins/APM/APMSubFrameComponentSummary.qml
@@ -32,9 +32,9 @@ Item {
         case 6:
             return "SimpleROV-5"
         case 7:
-            return "Custom"
+            return qsTr("Custom")
         default:
-            return "Unknown"
+            return qsTr("Unknown")
         }
     }
 

--- a/src/AutoPilotPlugins/APM/APMSubMotorComponent.qml
+++ b/src/AutoPilotPlugins/APM/APMSubMotorComponent.qml
@@ -224,7 +224,7 @@ SetupPage {
 
                     QGCButton {
                         id: startAutoDetection
-                        text: "Auto-Detect Directions"
+                        text: qsTr("Auto-Detect Directions")
                         enabled: controller.vehicle.flightMode !== controller.vehicle.motorDetectionFlightMode
 
                         onClicked: function() {

--- a/src/AutoPilotPlugins/Common/SyslinkComponent.qml
+++ b/src/AutoPilotPlugins/Common/SyslinkComponent.qml
@@ -65,7 +65,7 @@ SetupPage {
                         Layout.fillWidth:   true
                         font.pointSize:     ScreenTools.smallFontPointSize
                         wrapMode:           Text.WordWrap
-                        text:               "Channel can be between 0 and 125"
+                        text:               qsTr("Channel can be between 0 and 125")
                     }
 
                     QGCLabel {

--- a/src/AutoPilotPlugins/PX4/PX4TuningComponentCopterAttitude.qml
+++ b/src/AutoPilotPlugins/PX4/PX4TuningComponentCopterAttitude.qml
@@ -66,7 +66,7 @@ ColumnLayout {
                 }
             }
         }
-        title: "Attitude"
+        title: qsTr("Attitude")
         tuningMode: Vehicle.ModeRateAndAttitude
         unit: "deg"
         axis: [ roll, pitch, yaw ]

--- a/src/AutoPilotPlugins/PX4/PX4TuningComponentCopterPosition.qml
+++ b/src/AutoPilotPlugins/PX4/PX4TuningComponentCopterPosition.qml
@@ -65,7 +65,7 @@ ColumnLayout {
                 }
             }
         }
-        title: "Position"
+        title: qsTr("Position")
         tuningMode: Vehicle.ModeVelocityAndPosition
         unit: "m"
         axis: [ horizontal, vertical ]

--- a/src/AutoPilotPlugins/PX4/PX4TuningComponentCopterVelocity.qml
+++ b/src/AutoPilotPlugins/PX4/PX4TuningComponentCopterVelocity.qml
@@ -97,7 +97,7 @@ ColumnLayout {
                 }
             }
         }
-        title: "Velocity"
+        title: qsTr("Velocity")
         tuningMode: Vehicle.ModeVelocityAndPosition
         unit: "m/s"
         axis: [ horizontal, vertical ]

--- a/src/AutoPilotPlugins/PX4/PX4TuningComponentPlaneAttitude.qml
+++ b/src/AutoPilotPlugins/PX4/PX4TuningComponentPlaneAttitude.qml
@@ -49,7 +49,7 @@ ColumnLayout {
                 }
             }
         }
-        title: "Attitude"
+        title: qsTr("Attitude")
         tuningMode: Vehicle.ModeRateAndAttitude
         unit: "deg"
         axis: [ roll, pitch ]

--- a/src/AutoPilotPlugins/PX4/PX4TuningComponentPlaneRate.qml
+++ b/src/AutoPilotPlugins/PX4/PX4TuningComponentPlaneRate.qml
@@ -146,7 +146,7 @@ ColumnLayout {
                 }
             }
         }
-        title: "Rate"
+        title: qsTr("Rate")
         tuningMode: Vehicle.ModeRateAndAttitude
         unit: "deg/s"
         axis: [ roll, pitch, yaw ]

--- a/src/AutoPilotPlugins/PX4/PX4TuningComponentSpacecraftAttitude.qml
+++ b/src/AutoPilotPlugins/PX4/PX4TuningComponentSpacecraftAttitude.qml
@@ -66,7 +66,7 @@ ColumnLayout {
                 }
             }
         }
-        title: "Attitude"
+        title: qsTr("Attitude")
         tuningMode: Vehicle.ModeRateAndAttitude
         unit: "deg"
         axis: [ roll, pitch, yaw ]

--- a/src/AutoPilotPlugins/PX4/PX4TuningComponentSpacecraftPosition.qml
+++ b/src/AutoPilotPlugins/PX4/PX4TuningComponentSpacecraftPosition.qml
@@ -57,7 +57,7 @@ ColumnLayout {
                 }
             }
         }
-        title: "Position"
+        title: qsTr("Position")
         tuningMode: Vehicle.ModeVelocityAndPosition
         unit: "m"
         axis: [ position ]

--- a/src/AutoPilotPlugins/PX4/PX4TuningComponentSpacecraftVelocity.qml
+++ b/src/AutoPilotPlugins/PX4/PX4TuningComponentSpacecraftVelocity.qml
@@ -57,7 +57,7 @@ ColumnLayout {
                 }
             }
         }
-        title: "Velocity"
+        title: qsTr("Velocity")
         tuningMode: Vehicle.ModeVelocityAndPosition
         unit: "m/s"
         axis: [ position]

--- a/src/FirmwarePlugin/APM/APMFirmwarePlugin.cc
+++ b/src/FirmwarePlugin/APM/APMFirmwarePlugin.cc
@@ -775,7 +775,7 @@ out:
 bool APMFirmwarePlugin::guidedModeGotoLocation(Vehicle *vehicle, const QGeoCoordinate &gotoCoord, double forwardFlightLoiterRadius) const
 {
     if (qIsNaN(vehicle->altitudeRelative()->rawValue().toDouble())) {
-        QGC::showAppMessage(QStringLiteral("Unable to go to location, vehicle position not known."));
+        QGC::showAppMessage(tr("Unable to go to location, vehicle position not known."));
         return false;
     }
 
@@ -1173,7 +1173,7 @@ void APMFirmwarePlugin::sendGCSMotionReport(Vehicle *vehicle, const FollowMe::GC
         static bool sentOnce = false;
         if (!sentOnce) {
             sentOnce = true;
-            QGC::showAppMessage(QStringLiteral("Follow failed: Home position not set."));
+            QGC::showAppMessage(tr("Follow failed: Home position not set."));
         }
         return;
     }
@@ -1183,7 +1183,7 @@ void APMFirmwarePlugin::sendGCSMotionReport(Vehicle *vehicle, const FollowMe::GC
         if (!sentOnce) {
             sentOnce = true;
             qCWarning(APMFirmwarePluginLog) << "estimateCapabilities" << estimationCapabilities;
-            QGC::showAppMessage(QStringLiteral("Follow failed: Ground station cannot provide required position information."));
+            QGC::showAppMessage(tr("Follow failed: Ground station cannot provide required position information."));
         }
         return;
     }

--- a/src/FirmwarePlugin/APM/ArduRoverFirmwarePlugin.cc
+++ b/src/FirmwarePlugin/APM/ArduRoverFirmwarePlugin.cc
@@ -72,7 +72,7 @@ int ArduRoverFirmwarePlugin::remapParamNameHigestMinorVersionNumber(int majorVer
 
 void ArduRoverFirmwarePlugin::guidedModeChangeAltitude(Vehicle* /*vehicle*/, double /*altitudeChange*/, bool /*pauseVehicle*/)
 {
-    QGC::showAppMessage(QStringLiteral("Change altitude not supported."));
+    QGC::showAppMessage(tr("Change altitude not supported."));
 }
 
 QString ArduRoverFirmwarePlugin::stabilizedFlightMode() const

--- a/src/FlyView/VTOLChecklist.qml
+++ b/src/FlyView/VTOLChecklist.qml
@@ -67,7 +67,7 @@ Item {
             }
 
             PreFlightCheckButton {
-                name:        "Wind & weather"
+                name:        qsTr("Wind & weather")
                 manualText:  qsTr("OK for your platform? Launching into the wind?")
             }
 

--- a/src/GPS/NTRIP/NTRIPHttpTransport.cc
+++ b/src/GPS/NTRIP/NTRIPHttpTransport.cc
@@ -28,7 +28,7 @@ NTRIPHttpTransport::NTRIPHttpTransport(const NTRIPTransportConfig& config, QObje
     _connectTimeoutTimer.setInterval(kConnectTimeout);
     _connectTimeoutTimer.callOnTimeout(this, [this]() {
         qCWarning(NTRIPHttpTransportLog) << "Connection timeout";
-        _fail(NTRIPError::ConnectionTimeout, QStringLiteral("Connection timeout"));
+        _fail(NTRIPError::ConnectionTimeout, tr("Connection timeout"));
     });
 
     _dataWatchdogTimer.setSingleShot(true);
@@ -193,7 +193,8 @@ void NTRIPHttpTransport::_connect()
         QString msg = _socket->errorString();
         if (code == QAbstractSocket::RemoteHostClosedError && !_httpHandshakeDone) {
             if (!_config.mountpoint.isEmpty()) {
-                msg += " (peer closed before HTTP response; check mountpoint and credentials)";
+                msg += QLatin1Char(' ');
+                msg += tr("(peer closed before HTTP response; check mountpoint and credentials)");
             }
         }
 
@@ -213,7 +214,7 @@ void NTRIPHttpTransport::_connect()
                 if (!trailing.isEmpty()) {
                     reason = QString::fromUtf8(trailing).trimmed();
                 } else {
-                    reason = QStringLiteral("Server disconnected");
+                    reason = tr("Server disconnected");
                 }
 
                 qCWarning(NTRIPHttpTransportLog)

--- a/src/MissionManager/CorridorScanComplexItem.cc
+++ b/src/MissionManager/CorridorScanComplexItem.cc
@@ -82,7 +82,7 @@ void CorridorScanComplexItem::loadPreset(const QString& presetName)
 
     QJsonObject presetObject = _loadPresetJson(presetName);
     if (!_loadWorker(presetObject, 0, errorString, true /* forPresets */)) {
-        QGC::showAppMessage(QStringLiteral("Internal Error: Preset load failed. Name: %1 Error: %2").arg(presetName).arg(errorString));
+        QGC::showAppMessage(tr("Internal Error: Preset load failed. Name: %1 Error: %2").arg(presetName).arg(errorString));
     }
     _rebuildTransects();
 }

--- a/src/MissionManager/SurveyComplexItem.cc
+++ b/src/MissionManager/SurveyComplexItem.cc
@@ -95,7 +95,7 @@ void SurveyComplexItem::loadPreset(const QString& presetName)
 
     QJsonObject presetObject = _loadPresetJson(presetName);
     if (!_loadV4V5(presetObject, 0, errorString, 5, true /* forPresets */)) {
-        QGC::showAppMessage(QStringLiteral("Internal Error: Preset load failed. Name: %1 Error: %2").arg(presetName).arg(errorString));
+        QGC::showAppMessage(tr("Internal Error: Preset load failed. Name: %1 Error: %2").arg(presetName).arg(errorString));
     }
     _rebuildTransects();
 }

--- a/src/PlanView/CameraCalcCamera.qml
+++ b/src/PlanView/CameraCalcCamera.qml
@@ -75,14 +75,14 @@ ColumnLayout {
 
                 QGCRadioButton {
                     width:          _editFieldWidth
-                    text:           "Landscape"
+                    text:           qsTr("Landscape")
                     checked:        !!cameraCalc.landscape.value
                     onClicked:      cameraCalc.landscape.value = 1
                 }
 
                 QGCRadioButton {
                     id:             cameraOrientationPortrait
-                    text:           "Portrait"
+                    text:           qsTr("Portrait")
                     checked:        !cameraCalc.landscape.value
                     onClicked:      cameraCalc.landscape.value = 0
                 }

--- a/src/PlanView/StructureScanMapVisual.qml
+++ b/src/PlanView/StructureScanMapVisual.qml
@@ -64,7 +64,7 @@ Item {
 
             sourceItem: MissionItemIndexLabel {
                 index:      _missionItem.sequenceNumber
-                label:      "Entry"
+                label:      qsTr("Entry")
                 checked:    _missionItem.isCurrentItem
                 onClicked:  _root.clicked(_missionItem.sequenceNumber)
             }
@@ -84,7 +84,7 @@ Item {
 
             sourceItem: MissionItemIndexLabel {
                 index:      _missionItem.lastSequenceNumber
-                label:      "Exit"
+                label:      qsTr("Exit")
                 checked:    _missionItem.isCurrentItem
                 onClicked:  _root.clicked(_missionItem.sequenceNumber)
             }

--- a/src/PlanView/TransectStyleComplexItemEditor.qml
+++ b/src/PlanView/TransectStyleComplexItemEditor.qml
@@ -24,7 +24,7 @@ Rectangle {
     property var    transectValuesComponent:        undefined
     property var    presetsTransectValuesComponent: undefined
 
-    readonly property string _internalError: "Internal Error"
+    readonly property string _internalError: qsTr("Internal Error")
 
     property var    _missionItem:               missionItem
     property real   _margin:                    ScreenTools.defaultFontPixelWidth / 2

--- a/src/Toolbar/GPSIndicatorPage.qml
+++ b/src/Toolbar/GPSIndicatorPage.qml
@@ -134,7 +134,8 @@ ToolIndicatorPage {
 
                 LabelledLabel {
                     label:      qsTr("Duration")
-                    labelText:  QGroundControl.gpsRtk.currentDuration.value + ' s'
+                    //: %1 is Survey-In duration in seconds
+                    labelText:  qsTr("%1 s").arg(QGroundControl.gpsRtk.currentDuration.value)
                 }
 
                 LabelledLabel {

--- a/src/Toolbar/GimbalIndicator.qml
+++ b/src/Toolbar/GimbalIndicator.qml
@@ -324,8 +324,8 @@ Item {
                 acquirePopupConnection.isPopupOpen = true;
                 QGroundControl.showMessageDialog(
                     control,
-                    "Request Gimbal Control?",
-                    "Command not sent. Another user has control of the gimbal.",
+                    qsTr("Request Gimbal Control?"),
+                    qsTr("Command not sent. Another user has control of the gimbal."),
                     Dialog.Yes | Dialog.No,
                     gimbalController.acquireGimbalControl,
                     function() { acquirePopupConnection.isPopupOpen = false }

--- a/src/Vehicle/Vehicle.cc
+++ b/src/Vehicle/Vehicle.cc
@@ -1943,7 +1943,7 @@ Vehicle::guidedModeChangeEquivalentAirspeedMetersSecond(double airspeed)
 void Vehicle::guidedModeOrbit(const QGeoCoordinate& centerCoord, double radius, double amslAltitude)
 {
     if (!_vehicleSupports->orbitMode()) {
-        QGC::showAppMessage(QStringLiteral("Orbit mode not supported by Vehicle."));
+        QGC::showAppMessage(tr("Orbit mode not supported by Vehicle."));
         return;
     }
     if (capabilityBits() & MAV_PROTOCOL_CAPABILITY_COMMAND_INT) {
@@ -1978,7 +1978,7 @@ bool Vehicle::guidedModeROI(const QGeoCoordinate& centerCoord, double relativeAl
         return false;
     }
     if (!_vehicleSupports->roiMode()) {
-        QGC::showAppMessage(QStringLiteral("ROI mode not supported by Vehicle."));
+        QGC::showAppMessage(tr("ROI mode not supported by Vehicle."));
         return false;
     }
 
@@ -2003,7 +2003,7 @@ bool Vehicle::guidedModeROI(const QGeoCoordinate& centerCoord, double relativeAl
 void Vehicle::stopGuidedModeROI()
 {
     if (!_vehicleSupports->roiMode()) {
-        QGC::showAppMessage(QStringLiteral("ROI mode not supported by Vehicle."));
+        QGC::showAppMessage(tr("ROI mode not supported by Vehicle."));
         return;
     }
     if (capabilityBits() & MAV_PROTOCOL_CAPABILITY_COMMAND_INT) {
@@ -2047,7 +2047,7 @@ void Vehicle::guidedModeChangeHeading(const QGeoCoordinate &headingCoord)
 void Vehicle::pauseVehicle()
 {
     if (!_vehicleSupports->pauseVehicle()) {
-        QGC::showAppMessage(QStringLiteral("Pause not supported by vehicle."));
+        QGC::showAppMessage(tr("Pause not supported by vehicle."));
         return;
     }
     _firmwarePlugin->pauseVehicle(this);

--- a/src/Vehicle/VehicleSetup/FirmwareUpgradeController.cc
+++ b/src/Vehicle/VehicleSetup/FirmwareUpgradeController.cc
@@ -326,7 +326,7 @@ void FirmwareUpgradeController::_foundBoardInfo(int bootloaderVersion, int board
 ///         machine to the appropriate error state.
 void FirmwareUpgradeController::_bootloaderSyncFailed(void)
 {
-    _errorCancel("Unable to sync with bootloader.");
+    _errorCancel(tr("Unable to sync with bootloader."));
 }
 
 QHash<FirmwareUpgradeController::FirmwareIdentifier, QString>* FirmwareUpgradeController::_firmwareHashForBoardId(int boardId)
@@ -493,7 +493,7 @@ void FirmwareUpgradeController::_error(const QString& errorString)
     delete _image;
     _image = nullptr;
 
-    _errorCancel(QString("Error: %1").arg(errorString));
+    _errorCancel(tr("Error: %1").arg(errorString));
 }
 
 void FirmwareUpgradeController::_status(const QString& statusString)

--- a/src/Vehicle/VehicleSetup/RemoteControlCalibrationController.cc
+++ b/src/Vehicle/VehicleSetup/RemoteControlCalibrationController.cc
@@ -475,7 +475,7 @@ void RemoteControlCalibrationController::nextButtonClicked()
     if (_currentStep == -1) {
         // Need to have enough channels
         if (_chanCount < _chanMinimum) {
-            QGC::showAppMessage(QStringLiteral("Detected %1 channels. To operate vehicle, you need at least %2 channels.").arg(_chanCount).arg(_chanMinimum));
+            QGC::showAppMessage(tr("Detected %1 channels. To operate vehicle, you need at least %2 channels.").arg(_chanCount).arg(_chanMinimum));
             return;
         }
         _startCalibration();

--- a/src/VideoManager/VideoReceiver/QtMultimedia/UVCReceiver.cc
+++ b/src/VideoManager/VideoReceiver/QtMultimedia/UVCReceiver.cc
@@ -85,7 +85,7 @@ void UVCReceiver::checkPermission()
     if (qApp->checkPermission(cameraPermission) == Qt::PermissionStatus::Undetermined) {
         qApp->requestPermission(cameraPermission, qgcApp(), [](const QPermission &permission) {
             if (permission.status() != Qt::PermissionStatus::Granted) {
-                QGC::showAppMessage(QStringLiteral("Failed to get camera permission"));
+                QGC::showAppMessage(tr("Failed to get camera permission"));
             }
         });
     }


### PR DESCRIPTION
## Description

This PR consolidates related translatability fixes across QGroundControl.

It supersedes the previously submitted single-purpose i18n PRs #14824...#14827 and #14834...#14840, which were closed at the maintainer's request so the changes could be grouped into a cohesive PR with lower review overhead.

This is intended to be translation enablement only. It wraps existing user-facing strings in `tr()` or `qsTr()` and replaces dynamic translation keys with stable positional placeholders.

The English UI text, application behavior, settings behavior, runtime identifiers, enum values, and data formats are unchanged.

Translation files are intentionally not included. The newly exposed source strings can be handled through the existing Crowdin workflow.

### Changes

- Make user-facing error and status messages translatable in:
  - APM and ArduRover firmware plugins
  - generic vehicle guided-mode handling
  - ADSB server handling
  - firmware upgrade and preset loading
  - NTRIP transport
  - camera permission handling
  - remote-control calibration
- Make QML labels translatable in:
  - APM sensor, motor, frame, and tuning pages
  - PX4 tuning graphs
  - camera orientation controls
  - Structure Scan entry and exit markers
  - Syslink setup
  - VTOL pre-flight checklist
  - GPS Survey-In duration
  - gimbal control dialog
- Replace the dynamically interpolated compass-calibration coordinate key with:
  - a stable `Lat: %1 Lon: %2` source string
  - positional arguments
  - a translator comment describing both placeholders
- Keep line breaks and punctuation separate where appropriate, avoiding translation keys with embedded formatting characters.

## Type of Change

- [x] Bug fix (non-breaking, translation enablement only)
- [ ] Functional change
- [ ] Breaking change
- [ ] Documentation update
- [ ] Refactoring
- [ ] CI/Build changes

## Functional Impact

No functional behavior is intended to change.

The PR only changes how existing user-facing strings are passed to Qt's translation system. The untranslated English output remains the same, except that runtime values now use stable positional placeholders instead of being embedded in translation keys.

## Testing

- [x] Ran `git diff --check`
- [x] Ran Qt 6.11.1 `lupdate` against all 30 modified source files
- [x] Verified that all expected translation keys were extracted
- [x] Verified that the `%1`/`%2` coordinate translator comment was extracted
- [x] Verified that no repository translation files were modified
- [x] Built the complete `all` target successfully
- [x] Launched and smoke-tested the application twice

### Local build

- Windows
- Qt 6.11.1
- MSVC 2022, x64 Release configuration
- CMake/Ninja build
- Complete `all` target finished successfully
- `QGroundControl.exe` linked successfully
- Application launched twice from Qt Creator and exited normally

The runtime emitted an existing warning about `QQuickPinchArea.enabled` overriding a base-object member. It is unrelated to these translation changes and did not prevent startup or normal shutdown.

No regression test was added because the changes only expose existing source strings to Qt's translation system.

### Platforms Tested

- [ ] Linux
- [x] Windows
- [ ] macOS
- [ ] Android
- [ ] iOS

### Flight Stacks Tested

- [ ] PX4
- [ ] ArduPilot
- [x] N/A

## Screenshots

Not applicable. The untranslated English UI output and layout are unchanged.

## Checklist

- [x] No translation files were modified
- [x] No runtime identifiers or enum values were changed
- [x] Translation keys use stable source strings and positional placeholders
- [x] The application builds, starts, and exits successfully on Windows
- [ ] New and existing automated tests pass locally
