### PR TITLE
feat(QGCCorePlugin): allow hiding initial setup sections

### DIFF
--- a/src/API/QGCCorePlugin.cc
+++ b/src/API/QGCCorePlugin.cc
@@ -10,6 +10,7 @@
 #endif
 #endif
 #include "FactMetaData.h"
+#include "FirmwarePluginManager.h"
 #include "QGCMAVLink.h"
 #include "HorizontalFactValueGrid.h"
 #include "InstrumentValueData.h"
@@ -181,6 +182,18 @@ QString QGCCorePlugin::showAdvancedUIMessage() const
               "Are you sure you want to enable Advanced Mode?");
 }
 
+bool QGCCorePlugin::showInitialSetupVehiclePreferences() const
+{
+    const QList<QGCMAVLink::FirmwareClass_t> supportedFirmwareClasses = FirmwarePluginManager::instance()->supportedFirmwareClasses();
+    return supportedFirmwareClasses.count() != 1 ||
+           FirmwarePluginManager::instance()->supportedVehicleClasses(supportedFirmwareClasses[0]).count() != 1;
+}
+
+bool QGCCorePlugin::showInitialSetupMeasurementUnits() const
+{
+    return true;
+}
+
 void QGCCorePlugin::factValueGridCreateDefaultSettings(FactValueGrid* factValueGrid)
 {
 #if defined(Q_OS_ANDROID) || defined(Q_OS_IOS)
@@ -337,6 +350,15 @@ const QVariantList &QGCCorePlugin::toolBarIndicators()
     );
 
     return toolBarIndicatorList;
+}
+
+QList<int> QGCCorePlugin::firstRunPromptStdIds()
+{
+    if (showInitialSetupVehiclePreferences() || showInitialSetupMeasurementUnits()) {
+        return { kInitialSetupPromptId };
+    }
+
+    return {};
 }
 
 QVariantList QGCCorePlugin::firstRunPromptsToShow()

--- a/src/API/QGCCorePlugin.h
+++ b/src/API/QGCCorePlugin.h
@@ -41,6 +41,8 @@ class QGCCorePlugin : public QObject
     Q_MOC_INCLUDE("QmlObjectListModel.h")
     Q_PROPERTY(bool showAdvancedUI                      READ showAdvancedUI                     WRITE _setShowAdvancedUI    NOTIFY showAdvancedUIChanged)
     Q_PROPERTY(bool showTouchAreas                      READ showTouchAreas                     WRITE _setShowTouchAreas    NOTIFY showTouchAreasChanged)
+    Q_PROPERTY(bool showInitialSetupVehiclePreferences  READ showInitialSetupVehiclePreferences                              CONSTANT)
+    Q_PROPERTY(bool showInitialSetupMeasurementUnits    READ showInitialSetupMeasurementUnits                                CONSTANT)
     Q_PROPERTY(int defaultSettings                      READ defaultSettings                                                CONSTANT)
     Q_PROPERTY(int initialSetupPromptId                 MEMBER kInitialSetupPromptId                                       CONSTANT)
     Q_PROPERTY(const QGCOptions *options                READ options                                                        CONSTANT)
@@ -84,6 +86,12 @@ public:
 
     /// @return The message to show to the user when they are prompted to confirm turning on advanced ui.
     virtual QString showAdvancedUIMessage() const;
+
+    /// @return true if the initial setup prompt should show vehicle preferences.
+    virtual bool showInitialSetupVehiclePreferences() const;
+
+    /// @return true if the initial setup prompt should show measurement units.
+    virtual bool showInitialSetupMeasurementUnits() const;
 
     /// @return An instance of an alternate position source (or NULL if not available)
     virtual QGeoPositionInfoSource *createPositionSource(QObject *parent) { Q_UNUSED(parent); return nullptr; }
@@ -186,7 +194,7 @@ public:
     /// Returns the standard list of first run prompt ids for possible display. Actual display is based on the
     /// current AppSettings::firstRunPromptIds value. The order of this list also determines the order the prompts
     /// will be displayed in.
-    virtual QList<int> firstRunPromptStdIds() { return QList<int>({ kInitialSetupPromptId }); }
+    virtual QList<int> firstRunPromptStdIds();
 
     /// Returns the custom build list of first run prompt ids for possible display. Actual display is based on the
     /// current AppSettings::firstRunPromptIds value. The order of this list also determines the order the prompts

--- a/src/FirstRunPromptDialogs/InitialSetupPrompt.qml
+++ b/src/FirstRunPromptDialogs/InitialSetupPrompt.qml
@@ -53,6 +53,7 @@ FirstRunPrompt {
         SettingsGroupLayout {
             Layout.fillWidth: true
             Layout.maximumWidth: _descriptionWidth
+            visible: QGroundControl.corePlugin.showInitialSetupVehiclePreferences
             heading: qsTr("Vehicle Preferences")
             headingDescription: qsTr("Select the firmware and vehicle type you typically use.")
 
@@ -76,6 +77,7 @@ FirstRunPrompt {
         SettingsGroupLayout {
             Layout.fillWidth: true
             Layout.maximumWidth: _descriptionWidth
+            visible: QGroundControl.corePlugin.showInitialSetupMeasurementUnits
             heading: qsTr("Measurement Units")
             headingDescription: qsTr("Choose the measurement units you want to use. You can also change it later in General Settings.")
 


### PR DESCRIPTION
## Description
Makes it possible for custom builds to hide either the Vehicle Preferences or Measurement Units section from the initial setup prompt. Hiding both sections omits the prompt. This restores the control available before the two prompts were merged.

In addition to this, this commit fixes a bug where the initial setup prompt showed an empty Vehicle Preferences section when only one firmware and one vehicle type are supported. Its heading and description now hide with its controls. The visibility logic that drives this now lives in QGCCorePlugin instead of QML.

## Type of Change
- [X] Bug fix (non-breaking change that fixes an issue)
- [X] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] CI/Build changes
- [ ] Other

## Testing
- [X] Tested locally
- [ ] Added/updated unit tests
- [ ] Tested with simulator (SITL)
- [ ] Tested with hardware

### Platforms Tested
- [ ] Linux
- [X] Windows
- [ ] macOS
- [ ] Android
- [ ] iOS

## Checklist
- [X] I have read the [Contribution Guidelines](CONTRIBUTING.md)
- [X] I have read the [Code of Conduct](CODE_OF_CONDUCT.md)
- [X] My code follows the project's coding standards
- [ ] I have added tests that prove my fix/feature works
- [X] New and existing unit tests pass locally

---
By submitting this pull request, I confirm that my contribution is made under the terms of the project's dual license (Apache 2.0 and GPL v3).
