### PR TITLE
Gimbal: Use delta_yaw in heading calc when provided rather than vehicle

### DIFF
--- a/src/Comms/MockLink/MockLinkGimbal.cc
+++ b/src/Comms/MockLink/MockLinkGimbal.cc
@@ -320,7 +320,8 @@ void MockLinkGimbal::_sendGimbalDeviceAttitudeStatus()
         q,
         0.0f, 0.0f, 0.0f,   // angular_velocity_x, y, z
         0,                  // failure flags
-        _pitch, _yaw,       // delta_pitch, delta_yaw (Euler angles in degrees)
+        yawRad,             // delta_yaw (rad)
+        0.0f,               // delta_yaw_velocity (rad/s)
         0);                 // gimbal_device_id = 0 means the device id is the same as the message component ID
     _mockLink->respondWithMavlinkMessage(msg);
 }

--- a/src/Gimbal/Gimbal.cc
+++ b/src/Gimbal/Gimbal.cc
@@ -41,6 +41,7 @@ const Gimbal &Gimbal::operator=(const Gimbal &other)
     _absolutePitchFact = other._absolutePitchFact;
     _bodyYawFact = other._bodyYawFact;
     _absoluteYawFact = other._absoluteYawFact;
+    _deltaYawFact = other._deltaYawFact;
     _deviceIdFact = other._deviceIdFact;
     _yawLock = other._yawLock;
     _haveControl = other._haveControl;
@@ -55,6 +56,7 @@ void Gimbal::_initFacts()
     _addFact(&_absolutePitchFact);
     _addFact(&_bodyYawFact);
     _addFact(&_absoluteYawFact);
+    _addFact(&_deltaYawFact);
     _addFact(&_deviceIdFact);
     _addFact(&_managerCompidFact);
 
@@ -62,6 +64,7 @@ void Gimbal::_initFacts()
     _absolutePitchFact.setRawValue(0.0f);
     _bodyYawFact.setRawValue(0.0f);
     _absoluteYawFact.setRawValue(0.0f);
+    _deltaYawFact.setRawValue(qQNaN());
     _deviceIdFact.setRawValue(0);
     _managerCompidFact.setRawValue(0);
 }

--- a/src/Gimbal/Gimbal.h
+++ b/src/Gimbal/Gimbal.h
@@ -12,6 +12,7 @@ class Gimbal : public FactGroup
     Q_PROPERTY(Fact     *absolutePitch          READ absolutePitch              CONSTANT)
     Q_PROPERTY(Fact     *bodyYaw                READ bodyYaw                    CONSTANT)
     Q_PROPERTY(Fact     *absoluteYaw            READ absoluteYaw                CONSTANT)
+    Q_PROPERTY(Fact     *deltaYaw               READ deltaYaw                   CONSTANT)
     Q_PROPERTY(Fact     *deviceId               READ deviceId                   CONSTANT)
     Q_PROPERTY(Fact     *managerCompid          READ managerCompid              CONSTANT)
     Q_PROPERTY(float    pitchRate               READ pitchRate                  NOTIFY pitchRateChanged)
@@ -35,6 +36,7 @@ public:
     Fact *absolutePitch() { return &_absolutePitchFact; }
     Fact *bodyYaw() { return &_bodyYawFact; }
     Fact *absoluteYaw() { return &_absoluteYawFact; }
+    Fact *deltaYaw() { return &_deltaYawFact; }
     Fact *deviceId() { return &_deviceIdFact; }
     Fact *managerCompid() { return &_managerCompidFact; }
 
@@ -49,6 +51,7 @@ public:
     void setAbsolutePitch(float absPitch) { absolutePitch()->setRawValue(absPitch); }
     void setBodyYaw(float yaw) { bodyYaw()->setRawValue(yaw); }
     void setAbsoluteYaw(float absYaw) { absoluteYaw()->setRawValue(absYaw); }
+    void setDeltaYaw(float delta) { deltaYaw()->setRawValue(delta); _receivedDeltaYaw = true; }
     void setDeviceId(uint id) { deviceId()->setRawValue(id); }
     void setManagerCompid(uint id) { managerCompid()->setRawValue(id); }
 
@@ -62,6 +65,7 @@ public:
     void setCapabilityFlags(uint32_t flags);
     bool supportsRetract() const { return (_capabilityFlags & GIMBAL_MANAGER_CAP_FLAGS_HAS_RETRACT) != 0; }
     bool supportsYawLock() const { return (_capabilityFlags & GIMBAL_MANAGER_CAP_FLAGS_HAS_YAW_LOCK) != 0; }
+    bool hasDeltaYaw() { return _receivedDeltaYaw; }
 
 signals:
     void pitchRateChanged();
@@ -81,6 +85,7 @@ private:
     bool _receivedGimbalManagerInformation = false;
     bool _receivedGimbalManagerStatus = false;
     bool _receivedGimbalDeviceAttitudeStatus = false;
+    bool _receivedDeltaYaw = false;
     bool _isComplete = false;
     bool _neutral = false;
     uint32_t _capabilityFlags = 0; // GIMBAL_MANAGER_CAP_FLAGS
@@ -89,6 +94,7 @@ private:
     Fact _absolutePitchFact = Fact(0, QStringLiteral("gimbalPitch"), FactMetaData::valueTypeFloat);
     Fact _bodyYawFact = Fact(0, QStringLiteral("gimbalYaw"), FactMetaData::valueTypeFloat);
     Fact _absoluteYawFact = Fact(0, QStringLiteral("gimbalAzimuth"), FactMetaData::valueTypeFloat);
+    Fact _deltaYawFact = Fact(0, QStringLiteral("gimbalDeltaYaw"), FactMetaData::valueTypeFloat);
     Fact _deviceIdFact = Fact(0, QStringLiteral("deviceId"), FactMetaData::valueTypeUint8); ///< Component ID of gimbal device (or 1-6 for non-MAVLink gimbal)
     Fact _managerCompidFact = Fact(0, QStringLiteral("managerCompid"), FactMetaData::valueTypeUint8);
 

--- a/src/Gimbal/GimbalController.cc
+++ b/src/Gimbal/GimbalController.cc
@@ -240,23 +240,28 @@ void GimbalController::_handleGimbalDeviceAttitudeStatus(const mavlink_message_t
     gimbal->setAbsoluteRoll(qRadiansToDegrees(roll));
     gimbal->setAbsolutePitch(qRadiansToDegrees(pitch));
 
+    const float deltaYawDeg = qRadiansToDegrees(attitude_status.delta_yaw);
+    // Extension field: unsent decodes as 0.0, so ignore 0 until a value proves support.
+    if (gimbal->hasDeltaYaw() || attitude_status.delta_yaw != 0.0f) {
+        gimbal->setDeltaYaw(deltaYawDeg);
+    }
+
+    // Prefer the gimbal's own heading estimate; fall back to vehicle heading.
+    const float headingDeg = (gimbal->hasDeltaYaw() && !qIsNaN(deltaYawDeg))
+        ? deltaYawDeg
+        : _vehicle->heading()->rawValue().toFloat();
+
     const bool yaw_in_vehicle_frame = _yawInVehicleFrame(attitude_status.flags);
     if (yaw_in_vehicle_frame) {
         const float bodyYaw = qRadiansToDegrees(yaw);
-        float absoluteYaw = bodyYaw + _vehicle->heading()->rawValue().toFloat();
-        if (absoluteYaw > 180.0f) {
-            absoluteYaw -= 360.0f;
-        }
+        const float absoluteYaw = std::remainder(bodyYaw + headingDeg, 360.0f);
 
         gimbal->setBodyYaw(bodyYaw);
         gimbal->setAbsoluteYaw(absoluteYaw);
 
     } else {
         const float absoluteYaw = qRadiansToDegrees(yaw);
-        float bodyYaw = absoluteYaw - _vehicle->heading()->rawValue().toFloat();
-        if (bodyYaw < -180.0f) {
-            bodyYaw += 360.0f;
-        }
+        const float bodyYaw = std::remainder(absoluteYaw - headingDeg, 360.0f);
 
         gimbal->setBodyYaw(bodyYaw);
         gimbal->setAbsoluteYaw(absoluteYaw);
@@ -450,7 +455,7 @@ void GimbalController::gimbalOnScreenControl(float panPct, float tiltPct, bool c
         const float tiltDesired = tiltIncDesired + _activeGimbal->absolutePitch()->rawValue().toFloat();
 
         if (_activeGimbal->yawLock()) {
-            sendPitchAbsoluteYaw(tiltDesired, panDesired + _vehicle->heading()->rawValue().toFloat(), false);
+            sendPitchAbsoluteYaw(tiltDesired, std::remainder(panIncDesired + _activeGimbal->absoluteYaw()->rawValue().toFloat(), 360.0f), false);
         } else {
             sendPitchBodyYaw(tiltDesired, panDesired, false);
         }
@@ -467,7 +472,7 @@ void GimbalController::gimbalOnScreenControl(float panPct, float tiltPct, bool c
         const float tiltDesired = tiltIncDesired + _activeGimbal->absolutePitch()->rawValue().toFloat();
 
         if (_activeGimbal->yawLock()) {
-            sendPitchAbsoluteYaw(tiltDesired, panDesired + _vehicle->heading()->rawValue().toFloat(), false);
+            sendPitchAbsoluteYaw(tiltDesired, std::remainder(panIncDesired + _activeGimbal->absoluteYaw()->rawValue().toFloat(), 360.0f), false);
         } else {
             sendPitchBodyYaw(tiltDesired, panDesired, false);
         }

--- a/src/Gimbal/GimbalFact.json
+++ b/src/Gimbal/GimbalFact.json
@@ -25,6 +25,13 @@
     "units":            "deg"
 },
 {
+    "name":             "gimbalDeltaYaw",
+    "shortDesc":        "Gimbal Delta Yaw",
+    "type":             "float",
+    "decimalPlaces":    1,
+    "units":            "deg"
+},
+{
     "name":             "gimbalAzimuth",
     "shortDesc":        "Azimuth",
     "type":             "float",


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail. What problem does this solve? -->

Some gimbals have a seperate mag/compass to the vehicle and may provide delta_yaw. For these specific gimbals, utilizing delta_yaw is better than basing gimbal yaw on vehicle heading, because it removes the risk of inaccuracy if the gimbal's sensor readings differ from vehicle. A gimbal device maintains its own yaw estimate, which can differ from the vehicle's heading.

Motivation: The Pixy LR gimbal when sending the `GIMBAL_DEVICE_ATTITUDE_STATUS` message always gives `YAW_IN_VEHICLE_FRAME`, regardless of if follow/lock. When tested indoors and utilizing vehicle heading in the yaw calculation, switching between follow to lock causes the gimbal to move. Utilizing delta_yaw fixes this.

Related PR: https://github.com/ArduPilot/ardupilot/pull/33870

## Type of Change
<!-- Put an 'x' in the relevant boxes -->
- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] CI/Build changes
- [ ] Other

## Testing
<!-- Describe the tests you ran and how to reproduce them -->
- [x] Tested locally
- [ ] Added/updated unit tests
- [ ] Tested with simulator (SITL)
- [x] Tested with hardware

### Platforms Tested
<!-- Check all that apply -->
- [x] Linux
- [ ] Windows
- [ ] macOS
- [ ] Android
- [ ] iOS

### Flight Stacks Tested
<!-- If applicable -->
- [ ] PX4
- [x] ArduPilot ([tested in my PR branch which adds delta yaw support](https://github.com/ArduPilot/ardupilot/pull/33870))

Tested with Gremsy Pixy LR gimbal on v7.8.7 with my ArduPilot PR. Without my change, switching from follow to lock causes the gimbal to shift and not maintain yaw. With my change, this issue disappears.

PX4 still needs testing, but **should** work already because it forwards delta_yaw from the gimbal in `GIMBAL_DEVICE_ATTITUDE_STATUS` already.

## Screenshots
<!-- If applicable, add screenshots to help explain your changes -->

## Checklist
<!-- Go over all the following points, and put an 'x' in all the boxes that apply -->
- [x] I have read the [Contribution Guidelines](CONTRIBUTING.md)
- [x] I have read the [Code of Conduct](CODE_OF_CONDUCT.md)
- [x] My code follows the project's coding standards
- [ ] I have added tests that prove my fix/feature works
- [ ] New and existing unit tests pass locally

## Related Issues
<!-- Link any related issues using #issue_number -->

---
By submitting this pull request, I confirm that my contribution is made under the terms of the project's dual license (Apache 2.0 and GPL v3).
