### PR TITLE
fix(FirmwarePlugin): keep enum sentinel values outside param operating range

### DIFF
--- a/src/FirmwarePlugin/ParameterMetaData.cc
+++ b/src/FirmwarePlugin/ParameterMetaData.cc
@@ -167,10 +167,14 @@ void ParameterMetaData::setEnumFromPairs(FactMetaData *metaData, const QList<Val
     QStringList enumStrings;
     QVariantList enumValues;
 
+    // Validate against storage type only: firmware often declares sentinel enum
+    // values (e.g. 0 = Disabled) outside the operating min/max range.
+    FactMetaData typeMetaData(metaData->type());
+
     for (const auto &[code, description] : pairs) {
         QVariant enumValue;
         QString errorString;
-        if (metaData->convertAndValidateRaw(code, false, enumValue, errorString)) {
+        if (typeMetaData.convertAndValidateRaw(code, false, enumValue, errorString)) {
             enumValues << enumValue;
             enumStrings << description;
         } else {

--- a/test/FactSystem/APMParameterMetaDataTest.cc
+++ b/test/FactSystem/APMParameterMetaDataTest.cc
@@ -425,4 +425,57 @@ void APMParameterMetaDataTest::_outOfRangeBitmaskIndexSkipped()
     QCOMPARE(fact->bitmaskStrings()[1], "Second");
 }
 
+void APMParameterMetaDataTest::_parseEnumSentinelOutsideRange()
+{
+    static const char *json = R"({
+        "TEST_": {
+            "TEST_SENTINEL": {
+                "DisplayName": "Sentinel enum",
+                "Description": "Enum with sentinel value outside operating range",
+                "Range": {"low": "0.5", "high": "10"},
+                "Values": {"0": "Disabled", "1": "Enabled"}
+            }
+        }
+    })";
+
+    QScopedPointer<APMParameterMetaData> meta(_loadFromJson(json, nullptr));
+    QVERIFY(meta);
+
+    FactMetaData *fact = meta->getMetaDataForFact("TEST_SENTINEL", FactMetaData::valueTypeFloat);
+    QVERIFY(fact);
+    QCOMPARE(fact->rawMin().toFloat(), 0.5f);
+    QCOMPARE(fact->rawMax().toFloat(), 10.0f);
+    QCOMPARE(fact->enumStrings(), QStringList({"Disabled", "Enabled"}));
+    QCOMPARE(fact->enumValues().size(), 2);
+    QCOMPARE(fact->enumValues()[0].toFloat(), 0.0f);
+    QCOMPARE(fact->enumValues()[1].toFloat(), 1.0f);
+}
+
+void APMParameterMetaDataTest::_parseEnumNegativeSentinelIntType()
+{
+    static const char *json = R"({
+        "TEST_": {
+            "TEST_SENTINEL_INT": {
+                "DisplayName": "Int sentinel enum",
+                "Description": "Negative sentinel below integer operating range",
+                "Range": {"low": "0", "high": "100"},
+                "Values": {"-1": "Disabled", "0": "First", "1": "Second"}
+            }
+        }
+    })";
+
+    QScopedPointer<APMParameterMetaData> meta(_loadFromJson(json, nullptr));
+    QVERIFY(meta);
+
+    FactMetaData *fact = meta->getMetaDataForFact("TEST_SENTINEL_INT", FactMetaData::valueTypeInt32);
+    QVERIFY(fact);
+    QCOMPARE(fact->rawMin().toInt(), 0);
+    QCOMPARE(fact->rawMax().toInt(), 100);
+    QCOMPARE(fact->enumStrings(), QStringList({"Disabled", "First", "Second"}));
+    QCOMPARE(fact->enumValues().size(), 3);
+    QCOMPARE(fact->enumValues()[0].toInt(), -1);
+    QCOMPARE(fact->enumValues()[1].toInt(), 0);
+    QCOMPARE(fact->enumValues()[2].toInt(), 1);
+}
+
 UT_REGISTER_TEST(APMParameterMetaDataTest, TestLabel::Unit)

--- a/test/FactSystem/APMParameterMetaDataTest.h
+++ b/test/FactSystem/APMParameterMetaDataTest.h
@@ -28,4 +28,6 @@ private slots:
     void _invalidEnumKeySkipped();
     void _invalidBitmaskIndexSkipped();
     void _outOfRangeBitmaskIndexSkipped();
+    void _parseEnumSentinelOutsideRange();
+    void _parseEnumNegativeSentinelIntType();
 };


### PR DESCRIPTION
Fixes #14854

## Problem

`ParameterMetaData::setEnumFromPairs` validated each enum code against the fact's full metadata — including the firmware-declared min/max operating range. Firmware metadata frequently defines sentinel enum values outside that range (e.g. `RTL_CONE_SLOPE` with range `0.5..10` plus `0 = Disabled`). These legitimate entries failed range validation and were silently dropped, so options like "Disabled" never appeared in the parameter editor combo box.

Affected bundled APM metadata (Copter/Plane/Rover/Sub/Tracker ≤ 4.6): `RTL_CONE_SLOPE` (`0 = Disabled`), `CAN_Dx_TST_ID` (values 5–7 above range 0–4), `INS_HNTCH_MODE`/`INS_HNTC2_MODE` (`5 = Second RPM Sensor`), and `CAN_Dx_UC_Sx_IDX` (`-1 = Disabled` below range 0–100). ArduPilot 4.7+/PX4 metadata is clean.

## Fix

Validate enum codes against the storage type only: construct a bare `FactMetaData(type)` (hoisted outside the loop) and use it for `convertAndValidateRaw`. Codes that don't fit the storage type are still rejected; valid sentinels survive. This matches the PX4 path (`FactMetaData::createFromJsonObject`), which already parses enums before min/max is applied.

## Tests

- `_parseEnumSentinelOutsideRange` — float param, `0 = Disabled` below range `0.5..10` (TDD test from #14855 item 2; verified failing before the fix)
- `_parseEnumNegativeSentinelIntType` — int32 param, `-1 = Disabled` below range `0..100`, covering the integer conversion branch and sign handling (also verified failing before the fix)
