### PR TITLE
fix(QmlControls): keep qgc_version.h out of moc'd header to preserve moc cache

### DIFF
--- a/src/QmlControls/QGroundControlQmlGlobal.cc
+++ b/src/QmlControls/QGroundControlQmlGlobal.cc
@@ -30,6 +30,8 @@
 #include <QtGui/QClipboard>
 #include <QtGui/QGuiApplication>
 
+#include "qgc_version.h"
+
 #include "QGCLoggingCategory.h"
 
 QGC_LOGGING_CATEGORY(GuidedActionsControllerLog, "QMLControls.GuidedActionsController")
@@ -294,6 +296,11 @@ QString QGroundControlQmlGlobal::qgcVersion(void)
     return versionStr;
 }
 
+QString QGroundControlQmlGlobal::qgcAppDate()
+{
+    return QGC_APP_DATE;
+}
+
 QString QGroundControlQmlGlobal::altitudeFrameExtraUnits(AltitudeFrame altFrame)
 {
     switch (altFrame) {
@@ -381,5 +388,3 @@ QString QGroundControlQmlGlobal::appName()
 {
     return QCoreApplication::applicationName();
 }
-
-

--- a/src/QmlControls/QGroundControlQmlGlobal.h
+++ b/src/QmlControls/QGroundControlQmlGlobal.h
@@ -7,7 +7,6 @@
 #include <QtQmlIntegration/QtQmlIntegration>
 
 #include "QmlUnitsConversion.h"
-#include "qgc_version.h"
 
 class ADSBVehicleManager;
 class FactGroup;
@@ -194,7 +193,7 @@ public:
     QString telemetryFileExtension  (void) const;
 
     static QString qgcVersion();
-    static QString qgcAppDate() { return QGC_APP_DATE; }
+    static QString qgcAppDate();
 #ifdef QGC_DAILY_BUILD
     static bool qgcDailyBuild() { return true; }
 #else


### PR DESCRIPTION
Fixes #14867

### Problem

`qgc_version.h` is regenerated at configure time with `git describe` / commit-date output, so any branch or commit change alters its content. `QGroundControlQmlGlobal.h` included it directly, making it a transitive moc dependency of that header and everything downstream (`CameraCalc.h`, `ComplexMissionItem.h`, `MissionController.h`, `SimpleMissionItem.h`, and all headers including those). moccache validates dep contents by hash, so those entries missed on every branch switch — and on every CI run, since each run builds a new commit.

The moc output never actually depended on the version macros, so the invalidation was pure waste.

### Fix

Move the `qgc_version.h` include into `QGroundControlQmlGlobal.cc` and define `qgcAppDate()` there instead of inline in the header.

### Verification

- `just build` clean.
- No moccache manifest from the new build references `qgc_version.h`.
- Simulated branch change: appended a comment to the generated `qgc_version.h`, wiped all AUTOMOC state, rebuilt all 237 autogen targets → **710/710 moccache hits, 0 misses**. Pre-fix, the entire QGroundControlQmlGlobal/MissionManager subtree missed.

Should also improve CI moccache hit rates (#14719), which were at 88–95% partly due to this per-commit miss class.
