### PR TITLE
ci(gstreamer): download SDK exclusively from S3 mirror on stable

### DIFF
--- a/.github/build-config.json
+++ b/.github/build-config.json
@@ -73,6 +73,6 @@
         "ios": "d82c51bd81eafa77fd322c39ce7e6d663a5b860359ace6ed98060c87092e4845"
       }
     },
-    "ca_bundle_sha256": "3ff344e30b9b1ed2971044eabb438a08f2e2245ddb5f8ab1a3ad8b63ab4eaf91"
+    "ca_bundle_sha256": "f66dff1bdf8f96060b8177976f8b7d9254bc89bc4db933d769f7384d28480bc9"
   }
 }

--- a/cmake/GStreamer/Download.cmake
+++ b/cmake/GStreamer/Download.cmake
@@ -245,13 +245,18 @@ endfunction()
 function(gstreamer_download_sdk PLATFORM VERSION FILENAME DESTINATION_DIR RESULT_VAR)
     cmake_parse_arguments(_DL "ALLOW_FAILURE" "" "" ${ARGN})
 
-    gstreamer_get_package_url("${PLATFORM}" "${VERSION}" _url)
+    # S3 mirror only (populated by mirror-gstreamer.yml) — upstream can change
+    # or vanish under a stable release. The .sha256sum sidecar is not mirrored,
+    # so the in-tree pinned checksum is the only integrity source.
     gstreamer_get_s3_mirror_url("${PLATFORM}" "${VERSION}" _s3_url)
-    gstreamer_fetch_checksum("${PLATFORM}" "${VERSION}" _hash)
+    if(NOT _s3_url)
+        message(FATAL_ERROR "gstreamer_download_sdk: No S3 mirror for platform '${PLATFORM}'")
+    endif()
+    set(_urls "${_s3_url}")
 
-    set(_urls "${_url}")
-    if(_s3_url)
-        list(APPEND _urls "${_s3_url}")
+    gstreamer_get_fallback_checksum("${PLATFORM}" "${VERSION}" _hash)
+    if(NOT _hash)
+        _gstreamer_fallback_or_warn("${PLATFORM}" "${VERSION}" _hash "No pinned checksum")
     endif()
 
     set(_args

--- a/tools/setup/install_dependencies/_cli.py
+++ b/tools/setup/install_dependencies/_cli.py
@@ -61,7 +61,7 @@ def list_packages(platform: str | None = None) -> None:
         print("=" * 40)
         for pkg in MACOS_PACKAGES:
             print(f"  - {pkg}")
-        print("\nGStreamer: Downloaded from gstreamer.freedesktop.org")
+        print("\nGStreamer: Downloaded from the QGroundControl S3 mirror")
 
 
 def parse_args(args: list[str] | None = None) -> argparse.Namespace:

--- a/tools/setup/install_dependencies/_macos.py
+++ b/tools/setup/install_dependencies/_macos.py
@@ -13,11 +13,12 @@ from ._packages import get_macos_packages
 
 
 def get_gstreamer_macos_urls(version: str) -> tuple[str, str]:
-    """Get GStreamer download URLs for macOS."""
-    base_url = f"https://gstreamer.freedesktop.org/data/pkg/osx/{version}"
+    """Get GStreamer download URLs for macOS (QGC S3 mirror)."""
+    base_url = "https://qgroundcontrol.s3.us-west-2.amazonaws.com/dependencies/gstreamer/macos"
     runtime = f"{base_url}/gstreamer-1.0-{version}-universal.pkg"
     devel = f"{base_url}/gstreamer-1.0-devel-{version}-universal.pkg"
     return runtime, devel
+
 
 def install_macos(dry_run: bool = False) -> bool:
     """Install macOS dependencies."""
@@ -99,5 +100,6 @@ def install_macos(dry_run: bool = False) -> bool:
 
     print("\nmacOS dependencies installed successfully!")
     return True
+
 
 __all__ = ["get_gstreamer_macos_urls", "install_macos"]

--- a/tools/setup/install_dependencies/_windows.py
+++ b/tools/setup/install_dependencies/_windows.py
@@ -13,7 +13,6 @@ from . import _common as _c
 WINDOWS_GSTREAMER_BASE_URL = (
     "https://qgroundcontrol.s3.us-west-2.amazonaws.com/dependencies/gstreamer/windows"
 )
-_WINDOWS_GSTREAMER_OFFICIAL_URL = "https://gstreamer.freedesktop.org/data/pkg/windows"
 WINDOWS_GSTREAMER_PREFIX = "C:\\gstreamer\\1.0\\msvc_x86_64"
 WINDOWS_VULKAN_INSTALL_DIR = "C:\\VulkanSDK\\latest"
 WINDOWS_VULKAN_URL = "https://sdk.lunarg.com/sdk/download/latest/windows/vulkan-sdk.exe"
@@ -124,16 +123,11 @@ def install_windows_gstreamer(version: str, dry_run: bool = False) -> bool:
     print(f"\nInstalling GStreamer {version}...")
     with tempfile.TemporaryDirectory() as tmpdir:
         installer = Path(tmpdir) / installer_name
-        installer_urls = (
-            f"{WINDOWS_GSTREAMER_BASE_URL}/{installer_name}",
-            f"{_WINDOWS_GSTREAMER_OFFICIAL_URL}/{version}/msvc/{installer_name}",
-        )
         if not _c.download_file(
-            installer_urls[0],
+            f"{WINDOWS_GSTREAMER_BASE_URL}/{installer_name}",
             installer,
             dry_run,
-            warn_on_failure=True,
-        ) and not _c.download_file(installer_urls[1], installer, dry_run):
+        ):
             return False
         if not _c.run_command(
             [

--- a/tools/tests/test_install_dependencies.py
+++ b/tools/tests/test_install_dependencies.py
@@ -463,27 +463,19 @@ def test_install_windows_gstreamer(monkeypatch, tmp_path: Path) -> None:
     monkeypatch.setenv("PROCESSOR_ARCHITECTURE", "AMD64")
     monkeypatch.setattr(_windows, "WINDOWS_GSTREAMER_PREFIX", str(tmp_path))
     with (
-        patch.object(_windows._c, "download_file", side_effect=[False, True]) as dl,
+        patch.object(_windows._c, "download_file", return_value=True) as dl,
         patch.object(_windows._c, "run_command", return_value=True) as rc,
         patch.object(_windows._c, "set_env_var"),
         patch.object(_windows._c, "add_to_path"),
     ):
         assert _windows.install_windows_gstreamer("1.28.4") is True
 
-    installer = dl.call_args_list[0].args[1]
+    dl.assert_called_once()
+    installer = dl.call_args.args[1]
     assert installer.name == "gstreamer-1.0-msvc-x86_64-1.28.4.exe"
-    assert [call.args[0] for call in dl.call_args_list] == [
-        (
-            f"{_windows.WINDOWS_GSTREAMER_BASE_URL}/"
-            "gstreamer-1.0-msvc-x86_64-1.28.4.exe"
-        ),
-        (
-            "https://gstreamer.freedesktop.org/data/pkg/windows/1.28.4/msvc/"
-            "gstreamer-1.0-msvc-x86_64-1.28.4.exe"
-        ),
-    ]
-    assert dl.call_args_list[0].kwargs == {"warn_on_failure": True}
-    assert dl.call_args_list[1].kwargs == {}
+    assert dl.call_args.args[0] == (
+        f"{_windows.WINDOWS_GSTREAMER_BASE_URL}/gstreamer-1.0-msvc-x86_64-1.28.4.exe"
+    )
     assert rc.call_args.args[0] == [
         str(installer),
         "/VERYSILENT",


### PR DESCRIPTION
## Problem

Stable builds pulled the GStreamer SDK from gstreamer.freedesktop.org, meaning upstream packages could change or disappear out from under a stable release.

## Change

GStreamer SDK downloads (CMake configure for android/ios/macos/windows, plus the Windows/macOS install-dependencies scripts) now come **exclusively from the QGroundControl S3 mirror** (`dependencies/gstreamer/...`, populated by mirror-gstreamer.yml). No public fallback.

- Integrity is verified against the in-tree pinned SHA256 checksums in `.github/build-config.json` (all 6 platform packages for 1.28.4 are pinned). The upstream `.sha256sum` sidecar is not mirrored, so the pin is the sole integrity source; a missing pin is a hard configure error by default (`GStreamer_REQUIRE_CHECKSUM=ON`).
- All 6 mirrored 1.28.4 packages verified present on S3.
- Diff kept deliberately minimal for the stable branch: the now-unused sidecar-fetch helpers (`gstreamer_fetch_checksum`, `_gstreamer_download_sidecar`) are left in place to avoid churn.

Stable-branch-only change.
