### PR TITLE
feat(GeoMap): render mission visuals on the fly view map

### DIFF
--- a/src/FlyView/FlyViewGeoMap.qml
+++ b/src/FlyView/FlyViewGeoMap.qml
@@ -22,6 +22,42 @@ GeoMap {
     keepVehicleCentered: QGroundControl.settingsManager.flyViewSettings.keepMapCenteredOnVehicle.rawValue
 
     readonly property var _activeVehicle: QGroundControl.multiVehicleManager.activeVehicle
+    readonly property var _missionController: globals.planMasterControllerFlyView ? globals.planMasterControllerFlyView.missionController : null
+
+    // DEM height minus vehicle-reported AMSL, sampled at home for the active
+    // vehicle. Computed once here and shared by GeoMapMissionPath and every
+    // GeoMapMissionItems marker instead of each re-sampling the same DEM
+    // lookup independently (see GeoMapVehicleItem for the same correction
+    // applied per-vehicle in the marker Repeater below, where it can't be
+    // shared since each vehicle has its own home position).
+    property real _activeVehicleHomeTerrainBias: 0
+
+    function _updateActiveVehicleHomeTerrainBias() {
+        if (root.surfaceModel && root._activeVehicle && root._activeVehicle.homePosition.isValid && !isNaN(root._activeVehicle.homePosition.altitude)) {
+            root._activeVehicleHomeTerrainBias = root.surfaceModel.terrainHeightAt(root._activeVehicle.homePosition) - root._activeVehicle.homePosition.altitude
+        } else {
+            root._activeVehicleHomeTerrainBias = 0
+        }
+    }
+
+    on_ActiveVehicleChanged: _updateActiveVehicleHomeTerrainBias()
+    onSurfaceModelChanged: _updateActiveVehicleHomeTerrainBias()
+
+    Connections {
+        target: root.surfaceModel
+
+        function onTerrainHeightsChanged() {
+            root._updateActiveVehicleHomeTerrainBias()
+        }
+    }
+
+    Connections {
+        target: root._activeVehicle
+
+        function onHomePositionChanged() {
+            root._updateActiveVehicleHomeTerrainBias()
+        }
+    }
 
     // Vehicle home (launch) location
     GeoMapPin {
@@ -46,5 +82,27 @@ GeoMap {
         scene: root.scene
         surfaceModel: root.surfaceModel
         vehicle: root._activeVehicle
+    }
+
+    GeoMapMissionPath {
+        scene: root.scene
+        surfaceModel: root.surfaceModel
+        missionController: root._missionController
+        vehicle: root._activeVehicle
+        homeTerrainBias: root._activeVehicleHomeTerrainBias
+    }
+
+    GeoMapMissionItems {
+        scene: root.scene
+        surfaceModel: root.surfaceModel
+        missionController: root._missionController
+        homeTerrainBias: root._activeVehicleHomeTerrainBias
+    }
+
+    GeoMapMissionDirectionArrows {
+        scene: root.scene
+        surfaceModel: root.surfaceModel
+        missionController: root._missionController
+        homeTerrainBias: root._activeVehicleHomeTerrainBias
     }
 }

--- a/src/GeoMap/CMakeLists.txt
+++ b/src/GeoMap/CMakeLists.txt
@@ -35,6 +35,7 @@ qt_add_qml_module(GeoMapModule
         QtQuick
         QtQuick3D
         QtQuick3D.Helpers
+        QtQuick.Shapes
     SOURCES
         CheckerboardTextureData.cc
         CheckerboardTextureData.h
@@ -46,6 +47,8 @@ qt_add_qml_module(GeoMapModule
         GeoMapCamera.h
         GeoMapItem.cc
         GeoMapItem.h
+        GeoMapProjectedPath.cc
+        GeoMapProjectedPath.h
         PaperPlaneGeometry.cc
         PaperPlaneGeometry.h
         PatchGeometry.cc
@@ -57,8 +60,19 @@ qt_add_qml_module(GeoMapModule
     QML_FILES
         GeoMap.qml
         GeoMapFlightPath.qml
+        GeoMapFWLandingPatternVisual.qml
+        GeoMapLandingPatternVisuals.qml
+        GeoMapMissionArrow.qml
+        GeoMapMissionDirectionArrows.qml
+        GeoMapMissionHeightBadge.qml
+        GeoMapMissionItems.qml
+        GeoMapMissionLabel.qml
+        GeoMapMissionPath.qml
         GeoMapPin.qml
+        GeoMapSegmentArrow.qml
         GeoMapVehicleItem.qml
+        GeoMapVTOLLandingPatternVisual.qml
+        GeoMapWaypointItem.qml
     RESOURCES
         shaders/flightpath.frag
         shaders/flightpath.vert

--- a/src/GeoMap/GeoMap.qml
+++ b/src/GeoMap/GeoMap.qml
@@ -235,7 +235,7 @@ Item {
             objectName: "geoMapSceneCamera"
             position: geoCamera.scenePosition
             rotation: geoCamera.sceneRotation
-            fieldOfView: geoCamera.fieldOfView
+            fieldOfView: geoCamera.verticalFieldOfView
             clipNear: Math.max(1, geoCamera.distance / 1000)
             // Ray length to the farthest retained ground point is at most
             // maxRange + camera height <= (maxRangeMultiplier + 1) * distance

--- a/src/GeoMap/GeoMapCamera.cc
+++ b/src/GeoMap/GeoMapCamera.cc
@@ -150,8 +150,13 @@ void GeoMapCamera::setViewportSize(const QSizeF& size)
     if (size == _viewportSize) {
         return;
     }
+    const qreal previousVerticalFov = verticalFieldOfView();
     _viewportSize = size;
     emit viewportSizeChanged();
+    if (!qFuzzyCompare(verticalFieldOfView(), previousVerticalFov)) {
+        emit verticalFieldOfViewChanged();
+    }
+    emit unitsPerPixelAtUnitDistanceChanged();
 }
 
 void GeoMapCamera::setFieldOfView(qreal fov)
@@ -162,6 +167,25 @@ void GeoMapCamera::setFieldOfView(qreal fov)
     }
     _fieldOfView = clamped;
     emit fieldOfViewChanged();
+    emit verticalFieldOfViewChanged();
+    emit unitsPerPixelAtUnitDistanceChanged();
+}
+
+qreal GeoMapCamera::verticalFieldOfView() const
+{
+    if (_viewportSize.isEmpty() || _viewportSize.width() <= _viewportSize.height()) {
+        return _fieldOfView;
+    }
+    const double aspect = _viewportSize.width() / _viewportSize.height();
+    return qRadiansToDegrees(2.0 * std::atan(std::tan(qDegreesToRadians(_fieldOfView) / 2.0) / aspect));
+}
+
+qreal GeoMapCamera::unitsPerPixelAtUnitDistance() const
+{
+    if (_viewportSize.height() <= 0) {
+        return 0.0;
+    }
+    return 2.0 * std::tan(qDegreesToRadians(verticalFieldOfView()) / 2.0) / _viewportSize.height();
 }
 
 void GeoMapCamera::setMode(Mode mode)
@@ -235,7 +259,7 @@ std::optional<QPointF> GeoMapCamera::screenToGround(const QPointF& screenPos) co
     }
 
     const Ray ray =
-        pickRay(_centerWorld, _heading, _tilt, _distance, _centerElevation, _viewportSize, _fieldOfView, screenPos);
+        pickRay(_centerWorld, _heading, _tilt, _distance, _centerElevation, _viewportSize, verticalFieldOfView(), screenPos);
     if (ray.dir.z >= 0.0) {
         return std::nullopt;  // at or above the horizon
     }
@@ -251,7 +275,7 @@ std::optional<QPointF> GeoMapCamera::groundPointCapped(const QPointF& screenPos,
     }
 
     const Ray ray =
-        pickRay(_centerWorld, _heading, _tilt, _distance, _centerElevation, _viewportSize, _fieldOfView, screenPos);
+        pickRay(_centerWorld, _heading, _tilt, _distance, _centerElevation, _viewportSize, verticalFieldOfView(), screenPos);
     const QPointF cameraGround(ray.origin.x, ray.origin.y);
 
     if (ray.dir.z < 0.0) {
@@ -296,7 +320,7 @@ std::optional<QPointF> GeoMapCamera::worldToScreen(const QPointF& worldGround, d
     }
 
     const double aspect = _viewportSize.width() / _viewportSize.height();
-    const double tanHalfFov = std::tan(qDegreesToRadians(_fieldOfView) / 2.0);
+    const double tanHalfFov = std::tan(qDegreesToRadians(verticalFieldOfView()) / 2.0);
     const double ndcX = c.x / (depth * tanHalfFov * aspect);
     const double ndcY = c.y / (depth * tanHalfFov);
     return QPointF(((ndcX + 1.0) / 2.0) * _viewportSize.width(), ((1.0 - ndcY) / 2.0) * _viewportSize.height());
@@ -323,7 +347,7 @@ qreal GeoMapCamera::distanceForZoomLevel(qreal zoomLevel) const
         return kDefaultDistance;
     }
     const double metersPerPixel = TileMath::worldSize() / (TileMath::kTilePixels * std::exp2(zoomLevel));
-    const double tanHalfFov = std::tan(qDegreesToRadians(_fieldOfView) / 2.0);
+    const double tanHalfFov = std::tan(qDegreesToRadians(verticalFieldOfView()) / 2.0);
     return std::clamp((metersPerPixel * _viewportSize.height()) / (2.0 * tanHalfFov), kMinDistance, kMaxDistance);
 }
 
@@ -340,7 +364,7 @@ QGeoCoordinate GeoMapCamera::centerForCoordinateAtScreenPoint(const QGeoCoordina
     // an elevated point (e.g. a flying vehicle) high on screen under a tilted camera.
     const double pivotElevation = std::isfinite(centerElevation) ? centerElevation : _centerElevation;
     const Ray ray =
-        pickRay(_centerWorld, _heading, _tilt, _distance, pivotElevation, _viewportSize, _fieldOfView, screenPos);
+        pickRay(_centerWorld, _heading, _tilt, _distance, pivotElevation, _viewportSize, verticalFieldOfView(), screenPos);
     if (ray.dir.z >= 0.0) {
         return center();  // at or above the horizon
     }

--- a/src/GeoMap/GeoMapCamera.h
+++ b/src/GeoMap/GeoMapCamera.h
@@ -42,6 +42,8 @@ class GeoMapCamera : public QObject
     Q_PROPERTY(qreal centerElevation READ centerElevation WRITE setCenterElevation NOTIFY centerElevationChanged)
     Q_PROPERTY(QSizeF viewportSize READ viewportSize WRITE setViewportSize NOTIFY viewportSizeChanged)
     Q_PROPERTY(qreal fieldOfView READ fieldOfView WRITE setFieldOfView NOTIFY fieldOfViewChanged)
+    Q_PROPERTY(qreal verticalFieldOfView READ verticalFieldOfView NOTIFY verticalFieldOfViewChanged)
+    Q_PROPERTY(qreal unitsPerPixelAtUnitDistance READ unitsPerPixelAtUnitDistance NOTIFY unitsPerPixelAtUnitDistanceChanged)
     Q_PROPERTY(bool isTopDown READ isTopDown NOTIFY tiltChanged)
     Q_PROPERTY(Mode mode READ mode WRITE setMode NOTIFY modeChanged)
     Q_PROPERTY(qreal default3DTilt READ default3DTilt CONSTANT)
@@ -67,7 +69,10 @@ public:
     static constexpr qreal kMinTilt = 0.0;
     static constexpr qreal kMaxTilt = 85.0;
     static constexpr qreal kDefaultDistance = 1500.0;
-    static constexpr qreal kDefaultFieldOfView = 60.0;
+    // Applied to the larger viewport axis (see verticalFieldOfView). Moderate
+    // angle: wide-angle values skew level circles into tilted ellipses at the
+    // screen edges (off-axis rectilinear distortion)
+    static constexpr qreal kDefaultFieldOfView = 45.0;
     static constexpr qreal kDefault3DTilt = 55.0;
 
     QGeoCoordinate center() const;
@@ -106,6 +111,16 @@ public:
     qreal fieldOfView() const { return _fieldOfView; }
 
     void setFieldOfView(qreal fov);
+
+    /// fieldOfView applied to the larger viewport axis (Cesium-style): on wide
+    /// viewports the vertical FOV narrows instead of the horizontal FOV
+    /// exploding into fisheye distortion. All projection math uses this.
+    qreal verticalFieldOfView() const;
+
+    /// Scene units spanned by one pixel per unit of camera distance; multiply
+    /// by a point's camera distance for its units-per-pixel (constant apparent
+    /// size scaling). Returns 0 when the viewport size is not set.
+    qreal unitsPerPixelAtUnitDistance() const;
 
     /// Pose predicate: the camera currently looks straight down (tilt ~0).
     /// Distinct from mode(): Mode2D can be mid-transition with tilt > 0, and a
@@ -233,6 +248,8 @@ signals:
     void centerElevationChanged();
     void viewportSizeChanged();
     void fieldOfViewChanged();
+    void verticalFieldOfViewChanged();
+    void unitsPerPixelAtUnitDistanceChanged();
     void modeChanged();
     /// Emitted whenever scenePosition/sceneRotation may have changed (any pose
     /// component or the scene origin)

--- a/src/GeoMap/GeoMapFWLandingPatternVisual.qml
+++ b/src/GeoMap/GeoMapFWLandingPatternVisual.qml
@@ -1,0 +1,210 @@
+/****************************************************************************
+ *
+ * (c) 2009-2024 QGROUNDCONTROL PROJECT <http://www.qgroundcontrol.org>
+ *
+ * QGroundControl is licensed according to the terms in the file
+ * COPYING.md in the root of the source code directory.
+ *
+ ****************************************************************************/
+
+import QtQuick
+import QtQuick.Shapes
+import QtPositioning
+
+import QGroundControl
+import QGroundControl.Controls
+import QGroundControl.GeoMap
+
+/// Fixed Wing landing pattern visual for GeoMap: the shared landing-pattern
+/// base plus the FW-only landing-area/glide-slope polygons, labels and
+/// height annotations (src/PlanView/FWLandingPatternMapVisual.qml). Polygon
+/// shapes are exact
+/// geo-math ports (great-circle distance/azimuth, camera-orientation
+/// independent); label rotation uses on-screen bearing instead of geographic
+/// azimuth since GeoMap's 2D camera heading is user-rotatable (see
+/// GeoMapMissionArrow for the same adaptation).
+GeoMapLandingPatternVisuals {
+    id: root
+
+    readonly property real _landingWidthMeters: 15
+    readonly property real _landingLengthMeters: 100
+    readonly property real _landingAreaBearing: item.landingCoordinate.azimuthTo(item.slopeStartCoordinate)
+
+    readonly property real _angleRadians: Math.atan((_landingWidthMeters / 2) / (_landingLengthMeters / 2))
+    readonly property real _angleDegrees: _angleRadians * (180 / Math.PI)
+    readonly property real _hypotenuse: (_landingWidthMeters / 2) / Math.sin(_angleRadians)
+
+    readonly property var _landingAreaCorner1: item.landingCoordinate.atDistanceAndAzimuth(_hypotenuse, _landingAreaBearing - _angleDegrees)
+    readonly property var _landingAreaCorner2: item.landingCoordinate.atDistanceAndAzimuth(_hypotenuse, _landingAreaBearing + _angleDegrees)
+    readonly property var _landingAreaCorner3: item.landingCoordinate.atDistanceAndAzimuth(_hypotenuse, _landingAreaBearing + (180 - _angleDegrees))
+    readonly property var _landingAreaCorner4: item.landingCoordinate.atDistanceAndAzimuth(_hypotenuse, _landingAreaBearing - (180 - _angleDegrees))
+    readonly property var _glideSlopeThirdCoordinate: _useLoiterToAlt ? item.slopeStartCoordinate : item.finalApproachCoordinate
+
+    GeoMapProjectedPath {
+        id: landingAreaPath
+        scene: root.scene
+        surfaceModel: root.surfaceModel
+        // First corner repeated: PathPolyline strokes an open path, so the
+        // outline needs the closing edge spelled out
+        coordinates: [root._landingAreaCorner1, root._landingAreaCorner2, root._landingAreaCorner3, root._landingAreaCorner4, root._landingAreaCorner1]
+    }
+
+    // The source gates these FW-only elements on isCurrentItem (the item
+    // selected in the Plan editor); in the read-only fly view an item is only
+    // "current" while the vehicle is executing that exact sequence number, so
+    // that gate would hide them essentially always. Show them whenever the
+    // pattern is set instead.
+    readonly property bool _showExtendedVisuals: item.landingCoordSet
+
+    Shape {
+        visible: root._showExtendedVisuals && landingAreaPath.projected
+        ShapePath {
+            strokeColor: "black"
+            strokeWidth: 1
+            // ShapePath has no fillOpacity; bake the alpha into the fill color
+            fillColor: Qt.alpha("green", 0.5)
+            PathPolyline { path: landingAreaPath.screenPoints }
+        }
+    }
+
+    GeoMapProjectedPath {
+        id: glideSlopePath
+        scene: root.scene
+        surfaceModel: root.surfaceModel
+        altitudeMode: GeoMapItem.Absolute
+        // Unlike the flat 2D source, render the slope as a true 3D surface:
+        // base edge at the transition altitude over the landing-area edge
+        // (the slope's actual crossing height there), apex up at the final
+        // approach altitude
+        coordinates: [
+            QtPositioning.coordinate(root._landingAreaCorner1.latitude, root._landingAreaCorner1.longitude,
+                                     root._landAltAMSL + root._transitionAltitudeMeters),
+            QtPositioning.coordinate(root._landingAreaCorner2.latitude, root._landingAreaCorner2.longitude,
+                                     root._landAltAMSL + root._transitionAltitudeMeters),
+            QtPositioning.coordinate(root._glideSlopeThirdCoordinate.latitude, root._glideSlopeThirdCoordinate.longitude,
+                                     root._approachAltAMSL),
+            // Repeat the first base corner: PathPolyline strokes an open path
+            QtPositioning.coordinate(root._landingAreaCorner1.latitude, root._landingAreaCorner1.longitude,
+                                     root._landAltAMSL + root._transitionAltitudeMeters)
+        ]
+    }
+
+    Shape {
+        visible: root._showExtendedVisuals && glideSlopePath.projected
+        ShapePath {
+            strokeColor: "black"
+            strokeWidth: 1
+            fillColor: Qt.alpha(root.item.terrainCollision ? "red" : "orange", 0.5)
+            PathPolyline { path: glideSlopePath.screenPoints }
+        }
+    }
+
+    // Screen-space bearing (0 = up, clockwise) of the landing-area direction,
+    // folded the same way the source folds the geographic azimuth so the
+    // label text never renders upside down
+    function _adjustedBearing(rawBearing) {
+        let adjusted = rawBearing < 0 ? rawBearing + 360 : rawBearing
+        if (adjusted > 180) {
+            adjusted -= 180
+        }
+        adjusted -= 90
+        if (adjusted < 0) {
+            adjusted += 360
+        }
+        return adjusted
+    }
+
+    GeoMapProjectedPath {
+        id: bearingPath
+        scene: root.scene
+        surfaceModel: root.surfaceModel
+        coordinates: [root.item.landingCoordinate, root.item.slopeStartCoordinate]
+    }
+
+    // Normalized to [0, 360) to match the source visual's geographic-azimuth
+    // conventions (atan2 alone yields [-180, 180])
+    readonly property real _screenBearing: {
+        if (!bearingPath.projected || bearingPath.screenPoints.length < 2) {
+            return 0
+        }
+        const bearing = Math.atan2(bearingPath.screenPoints[1].x - bearingPath.screenPoints[0].x,
+                                   -(bearingPath.screenPoints[1].y - bearingPath.screenPoints[0].y)) * 180 / Math.PI
+        return bearing < 0 ? bearing + 360 : bearing
+    }
+
+    GeoMapItem {
+        scene: root.scene
+        surfaceModel: root.surfaceModel
+        altitudeMode: GeoMapItem.ClampToGround
+        coordinate: root.item.landingCoordinate
+        visible: root._showExtendedVisuals
+        anchorPoint: Qt.point(landingAreaLabel.width / 2, landingAreaLabel.height / 2)
+        width: landingAreaLabel.width
+        height: landingAreaLabel.height
+
+        QGCLabel {
+            id: landingAreaLabel
+            text: qsTr("Landing Area")
+            color: "white"
+            rotation: root._adjustedBearing(root._screenBearing)
+        }
+    }
+
+    GeoMapItem {
+        scene: root.scene
+        surfaceModel: root.surfaceModel
+        altitudeMode: GeoMapItem.ClampToGround
+        coordinate: root.item.landingCoordinate.atDistanceAndAzimuth(root._landingLengthMeters / 2 + 2, root._landingAreaBearing)
+        visible: root._showExtendedVisuals
+        anchorPoint: Qt.point(root._screenBearing > 180 ? glideSlopeLabel.width : 0, glideSlopeLabel.height / 2)
+        width: glideSlopeLabel.width
+        height: glideSlopeLabel.height
+
+        QGCLabel {
+            id: glideSlopeLabel
+            text: qsTr("Glide Slope")
+            color: "white"
+            rotation: root._adjustedBearing(root._screenBearing)
+        }
+    }
+
+    readonly property real _finalApproachAltitudeMeters: item.finalApproachAltitude.rawValue
+    readonly property real _landingAltitudeMeters: item.landingAltitude.rawValue
+    readonly property real _glideSlopeAdjacent: _useLoiterToAlt ? item.landingCoordinate.distanceTo(item.slopeStartCoordinate)
+                                                                 : item.landingCoordinate.distanceTo(item.finalApproachCoordinate)
+    readonly property real _glideSlopeAngleRadians: Math.atan((_finalApproachAltitudeMeters - _landingAltitudeMeters) / _glideSlopeAdjacent)
+    readonly property real _transitionDistance: _landingLengthMeters / 2
+    readonly property real _transitionAltitudeMeters: Math.tan(_glideSlopeAngleRadians) * _transitionDistance
+    readonly property real _midSlopeAltitudeMeters: Math.tan(_glideSlopeAngleRadians) * (_transitionDistance + ((_glideSlopeAdjacent - _transitionDistance) / 2))
+
+    readonly property int _angleIncrement: _landingAreaBearing > 180 ? -90 : 90
+    readonly property var _transitionCoordinate: item.landingCoordinate.atDistanceAndAzimuth(_landingLengthMeters / 2, _landingAreaBearing)
+    readonly property var _midSlopeCenterCoordinate: _transitionCoordinate.atDistanceAndAzimuth(
+        _transitionCoordinate.distanceTo(_glideSlopeThirdCoordinate) / 2, _landingAreaBearing)
+
+    GeoMapMissionHeightBadge {
+        scene: root.scene
+        surfaceModel: root.surfaceModel
+        coordinate: root._transitionCoordinate.atDistanceAndAzimuth(root._landingWidthMeters, root._landingAreaBearing + root._angleIncrement)
+        visible: root._showExtendedVisuals
+        text: Math.floor(QGroundControl.unitsConversion.metersToAppSettingsVerticalDistanceUnits(root._transitionAltitudeMeters)) + " "
+              + QGroundControl.unitsConversion.appSettingsVerticalDistanceUnitsString
+    }
+
+    GeoMapMissionHeightBadge {
+        scene: root.scene
+        surfaceModel: root.surfaceModel
+        coordinate: root._midSlopeCenterCoordinate.atDistanceAndAzimuth(root._landingWidthMeters / 2, root._landingAreaBearing + root._angleIncrement)
+        visible: root._showExtendedVisuals
+        text: Math.floor(QGroundControl.unitsConversion.metersToAppSettingsVerticalDistanceUnits(root._midSlopeAltitudeMeters)) + " "
+              + QGroundControl.unitsConversion.appSettingsVerticalDistanceUnitsString
+    }
+
+    GeoMapMissionHeightBadge {
+        scene: root.scene
+        surfaceModel: root.surfaceModel
+        coordinate: root.item.slopeStartCoordinate
+        visible: root._showExtendedVisuals
+        text: root.item.finalApproachAltitude.value.toFixed(1) + " " + root.item.finalApproachAltitude.units
+    }
+}

--- a/src/GeoMap/GeoMapFlightPath.qml
+++ b/src/GeoMap/GeoMapFlightPath.qml
@@ -48,9 +48,7 @@ GeoMapItem {
 
     // Pixel-to-scene-unit factor at unit distance; the shader scales it by
     // each vertex's own camera distance
-    readonly property real _screenFactor: _camera && _camera.viewportSize.height > 0
-        ? 2 * Math.tan(_camera.fieldOfView * Math.PI / 360) / _camera.viewportSize.height
-        : 0
+    readonly property real _screenFactor: _camera ? _camera.unitsPerPixelAtUnitDistance : 0
 
     // DEM height minus vehicle-reported AMSL, sampled at home (same
     // correction as GeoMapVehicleItem so trail and marker stay aligned)

--- a/src/GeoMap/GeoMapLandingPatternVisuals.qml
+++ b/src/GeoMap/GeoMapLandingPatternVisuals.qml
@@ -1,0 +1,116 @@
+/****************************************************************************
+ *
+ * (c) 2009-2024 QGROUNDCONTROL PROJECT <http://www.qgroundcontrol.org>
+ *
+ * QGroundControl is licensed according to the terms in the file
+ * COPYING.md in the root of the source code directory.
+ *
+ ****************************************************************************/
+
+import QtPositioning
+import QtQuick.Shapes
+
+import QGroundControl.GeoMap
+
+/// Base visual shared by Fixed Wing and VTOL landing patterns on GeoMap:
+/// read-only GeoMap-native port of the common elements in
+/// src/PlanView/FWLandingPatternMapVisual.qml / VTOLLandingPatternMapVisual.qml
+/// (flight path, loiter ring, final-approach/landing markers). No
+/// mouse-area/drag-to-place code ports over — FlyView missions are already
+/// loaded and immutable.
+Item {
+    id: root
+
+    property var item          ///< VisualMissionItem (LandingComplexItem)
+    property var scene
+    property var surfaceModel
+    // DEM-vs-home-AMSL bias, wired by GeoMapMissionItems (see GeoMapWaypointItem)
+    property real homeTerrainBias: 0
+    property string landingLabel: ""   ///< Label for the landing-point marker (VTOL overrides to "Land")
+
+    readonly property bool _useLoiterToAlt: item.useLoiterToAlt.rawValue
+    // Approach leg descends from the final-approach altitude to the landing
+    // altitude; project at those AMSL heights so the 3D view shows the slope
+    // instead of a ground-hugging line
+    readonly property real _approachAltAMSL: item.amslEntryAlt + homeTerrainBias
+    readonly property real _landAltAMSL: item.amslExitAlt + homeTerrainBias
+    readonly property var _flightPath: {
+        const from = _useLoiterToAlt ? item.slopeStartCoordinate : item.finalApproachCoordinate
+        return [QtPositioning.coordinate(from.latitude, from.longitude, _approachAltAMSL),
+                QtPositioning.coordinate(item.landingCoordinate.latitude, item.landingCoordinate.longitude, _landAltAMSL)]
+    }
+
+    GeoMapProjectedPath {
+        id: flightPathProjector
+        scene: root.scene
+        surfaceModel: root.surfaceModel
+        altitudeMode: GeoMapItem.Absolute
+        coordinates: root._flightPath
+    }
+
+    // Flight path (final approach/loiter exit -> landing point)
+    Shape {
+        visible: root.item.landingCoordSet && flightPathProjector.projected
+        ShapePath {
+            strokeColor: "#be781c"
+            strokeWidth: 2
+            fillColor: "transparent"
+            PathPolyline { path: flightPathProjector.screenPoints }
+        }
+    }
+
+    GeoMapProjectedPath {
+        id: loiterPath
+        scene: root.scene
+        surfaceModel: root.surfaceModel
+        altitudeMode: GeoMapItem.Absolute
+        // Static invokables aren't callable via the QML type name; call
+        // through the instance instead. Ring altitude rides on the center
+        // coordinate (atDistanceAndAzimuth preserves it).
+        coordinates: root._useLoiterToAlt
+                     ? loiterPath.circleCoordinates(QtPositioning.coordinate(root.item.finalApproachCoordinate.latitude,
+                                                                             root.item.finalApproachCoordinate.longitude,
+                                                                             root._approachAltAMSL),
+                                                    root.item.loiterRadius.rawValue)
+                     : []
+    }
+
+    // Loiter ring
+    Shape {
+        visible: root._useLoiterToAlt && loiterPath.projected
+        ShapePath {
+            strokeColor: "green"
+            strokeWidth: 2
+            fillColor: "transparent"
+            PathPolyline { path: loiterPath.screenPoints }
+        }
+    }
+
+    // Final approach / loiter point
+    GeoMapMissionLabel {
+        scene: root.scene
+        surfaceModel: root.surfaceModel
+        altitudeMode: GeoMapItem.Absolute
+        coordinate: QtPositioning.coordinate(root.item.finalApproachCoordinate.latitude,
+                                             root.item.finalApproachCoordinate.longitude,
+                                             root._approachAltAMSL)
+        index: root.item.sequenceNumber
+        label: root._useLoiterToAlt ? qsTr("Loiter") : qsTr("Approach")
+        checked: root.item.isCurrentItem
+        visible: root.item.landingCoordSet
+    }
+
+    // Landing point
+    GeoMapMissionLabel {
+        scene: root.scene
+        surfaceModel: root.surfaceModel
+        altitudeMode: GeoMapItem.Absolute
+        coordinate: QtPositioning.coordinate(root.item.landingCoordinate.latitude,
+                                             root.item.landingCoordinate.longitude,
+                                             root._landAltAMSL)
+        index: root.item.lastSequenceNumber
+        label: root.landingLabel
+        checked: root.item.isCurrentItem
+        visible: root.item.landingCoordSet
+    }
+}

--- a/src/GeoMap/GeoMapMissionArrow.qml
+++ b/src/GeoMap/GeoMapMissionArrow.qml
@@ -1,0 +1,50 @@
+/****************************************************************************
+ *
+ * (c) 2009-2024 QGROUNDCONTROL PROJECT <http://www.qgroundcontrol.org>
+ *
+ * QGroundControl is licensed according to the terms in the file
+ * COPYING.md in the root of the source code directory.
+ *
+ ****************************************************************************/
+
+import QtQuick
+
+/// Direction-indicator chevron for complex item visuals, positioned and
+/// rotated in screen space (not anchored via GeoMapItem): GeoMap's 2D camera
+/// heading is user-rotatable, so a geographic azimuth (as used by
+/// src/FlightMap/MapItems/MapLineArrow.qml) would point the wrong way on
+/// screen once the map is rotated. Callers derive screenPoint/heading from
+/// already-projected GeoMapProjectedPath.screenPoints (see
+/// GeoMapSegmentArrow.qml), avoiding a second projector per arrow.
+Canvas {
+    id: root
+
+    property point screenPoint: Qt.point(0, 0)
+    property real heading: 0    ///< degrees, 0 = up, clockwise
+
+    readonly property real _arrowSize: 15
+
+    x: screenPoint.x - width / 2
+    y: screenPoint.y
+    width: _arrowSize * 2
+    height: _arrowSize
+    rotation: heading
+    transformOrigin: Item.Top
+
+    onPaint: {
+        const ctx = getContext("2d")
+        ctx.clearRect(0, 0, width, height)
+        ctx.lineWidth = 2
+        ctx.strokeStyle = "white"
+        ctx.beginPath()
+        ctx.moveTo(_arrowSize, 0)
+        ctx.lineTo(_arrowSize * 2, _arrowSize)
+        ctx.stroke()
+        ctx.beginPath()
+        ctx.moveTo(_arrowSize, 0)
+        ctx.lineTo(0, _arrowSize)
+        ctx.stroke()
+    }
+
+    Component.onCompleted: requestPaint()
+}

--- a/src/GeoMap/GeoMapMissionDirectionArrows.qml
+++ b/src/GeoMap/GeoMapMissionDirectionArrows.qml
@@ -1,0 +1,37 @@
+/****************************************************************************
+ *
+ * (c) 2009-2024 QGROUNDCONTROL PROJECT <http://www.qgroundcontrol.org>
+ *
+ * QGroundControl is licensed according to the terms in the file
+ * COPYING.md in the root of the source code directory.
+ *
+ ****************************************************************************/
+
+import QtQuick
+import QtPositioning
+
+/// General flight-path direction indicators for the GeoMap: one arrow per
+/// entry in MissionController.directionArrows (added to the second flight
+/// path segment and every 5 segments thereafter, regardless of simple vs
+/// complex item — see MissionController::_recalcFlightPathSegments),
+/// mirroring the MapLineArrow Repeater in src/FlightMap/MapItems/PlanMapItems.qml.
+Item {
+    id: root
+
+    property var missionController
+    property var scene
+    property var surfaceModel
+    property real homeTerrainBias: 0   ///< See GeoMapWaypointItem.homeTerrainBias
+
+    Repeater {
+        model: root.missionController ? root.missionController.directionArrows : 0
+
+        GeoMapSegmentArrow {
+            scene: root.scene
+            surfaceModel: root.surfaceModel
+            fromCoord: QtPositioning.coordinate(object.coordinate1.latitude, object.coordinate1.longitude, object.coord1AMSLAlt + root.homeTerrainBias)
+            toCoord: QtPositioning.coordinate(object.coordinate2.latitude, object.coordinate2.longitude, object.coord2AMSLAlt + root.homeTerrainBias)
+            fraction: 0.75
+        }
+    }
+}

--- a/src/GeoMap/GeoMapMissionHeightBadge.qml
+++ b/src/GeoMap/GeoMapMissionHeightBadge.qml
@@ -1,0 +1,33 @@
+/****************************************************************************
+ *
+ * (c) 2009-2024 QGROUNDCONTROL PROJECT <http://www.qgroundcontrol.org>
+ *
+ * QGroundControl is licensed according to the terms in the file
+ * COPYING.md in the root of the source code directory.
+ *
+ ****************************************************************************/
+
+import QGroundControl.Controls
+import QGroundControl.GeoMap
+
+/// Small height-value annotation anchored at a coordinate, top-center (label
+/// grows down from the point) — a simplified GeoMap-native stand-in for
+/// src/QmlControls/HeightIndicator.qml, which relies on QtLocation map-style
+/// light/dark detection (QGCMapPalette/QGCMapLabel) not available on GeoMap.
+GeoMapItem {
+    id: root
+
+    property alias text: label.text
+
+    altitudeMode: GeoMapItem.ClampToGround
+    anchorPoint: Qt.point(width / 2, 0)
+    width: label.implicitWidth
+    height: label.implicitHeight
+
+    QGCLabel {
+        id: label
+
+        color: "white"
+        font.bold: true
+    }
+}

--- a/src/GeoMap/GeoMapMissionItems.qml
+++ b/src/GeoMap/GeoMapMissionItems.qml
@@ -1,0 +1,57 @@
+/****************************************************************************
+ *
+ * (c) 2009-2024 QGROUNDCONTROL PROJECT <http://www.qgroundcontrol.org>
+ *
+ * QGroundControl is licensed according to the terms in the file
+ * COPYING.md in the root of the source code directory.
+ *
+ ****************************************************************************/
+
+import QtQuick
+
+import QGroundControl.GeoMap
+
+/// Mission-item overlay for the GeoMap: instantiates the GeoMap-native visual
+/// declared by each item's VisualMissionItem.geoMapVisualQML (mirrors the
+/// existing mapVisualQML dispatch consumed by src/PlanView/MissionItemMapVisual.qml
+/// — every item type states its own visual, simple items included, rather
+/// than special-casing GeoMapWaypointItem outside the dispatch). Items with
+/// no GeoMap-native visual render nothing: the home item (already shown via
+/// its own GeoMapPin) and the Survey/Corridor/Structure complex items, which
+/// never appear in the fly-view controller (vehicle downloads reconstruct
+/// only simple items and landing patterns).
+Item {
+    id: root
+
+    property var missionController
+    property var scene
+    property var surfaceModel
+    property real homeTerrainBias: 0   ///< See GeoMapWaypointItem.homeTerrainBias
+
+    Repeater {
+        model: root.missionController ? root.missionController.visualItems : 0
+
+        Loader {
+            asynchronous: true
+            active: object.geoMapVisualQML !== ""
+
+            Component.onCompleted: {
+                if (active) {
+                    setSource(object.geoMapVisualQML, {
+                        item: object,
+                        scene: root.scene,
+                        surfaceModel: root.surfaceModel
+                    })
+                }
+            }
+
+            onLoaded: {
+                // Declared by GeoMapWaypointItem and the landing pattern
+                // visuals; wire it up without hardcoding filenames here
+                if (item.hasOwnProperty("homeTerrainBias")) {
+                    item.homeTerrainBias = Qt.binding(() => root.homeTerrainBias)
+                }
+            }
+        }
+    }
+}

--- a/src/GeoMap/GeoMapMissionLabel.qml
+++ b/src/GeoMap/GeoMapMissionLabel.qml
@@ -1,0 +1,98 @@
+/****************************************************************************
+ *
+ * (c) 2009-2024 QGROUNDCONTROL PROJECT <http://www.qgroundcontrol.org>
+ *
+ * QGroundControl is licensed according to the terms in the file
+ * COPYING.md in the root of the source code directory.
+ *
+ ****************************************************************************/
+
+pragma ComponentBehavior: Bound
+
+import QtQuick
+import QtQuick3D
+
+import QGroundControl
+import QGroundControl.Controls
+import QGroundControl.GeoMap
+
+/// Point marker for complex mission item visuals: same colored dot that
+/// crossfades into a 3D sphere as GeoMapWaypointItem, plus an always-visible
+/// side text label (e.g. "Loiter", "Land").
+GeoMapItem {
+    id: root
+
+    property int index: -1     ///< Sequence number shown in the dot; < 0 shows none
+    property string label: ""
+    property bool checked: false
+    property real size: ScreenTools.defaultFontPixelHeight * 1.5
+
+    width: size
+    height: size
+    anchorPoint: Qt.point(width / 2, height / 2)
+    // altitudeMode defaults to ClampToGround (GeoMapItem); callers may override
+
+    QGCPalette { id: qgcPal; colorGroupEnabled: root.enabled }
+
+    // Same conventions as GeoMapWaypointItem / MissionItemIndexLabel:
+    // checked is "green" and grown, everything else the plain indicator color
+    readonly property color _markerColor: root.checked ? "green" : qgcPal.mapIndicator
+    readonly property real _indicatorSize: root.checked ? root.size : root.size * 0.75
+
+    readonly property var _camera: scene ? scene.camera : null
+
+    // Constant apparent size, same technique as GeoMapWaypointItem: scene
+    // units per screen pixel at the camera's look-at distance. Built-in
+    // QtQuick3D meshes are 100 units across.
+    readonly property real _modelScale: _camera
+        ? root._indicatorSize * _camera.distance * _camera.unitsPerPixelAtUnitDistance / 100
+        : 1
+
+    Rectangle {
+        anchors.centerIn: parent
+        width: root._indicatorSize
+        height: root._indicatorSize
+        radius: width / 2
+        color: root._markerColor
+        opacity: root.contentOpacity2D
+    }
+
+    QGCLabel {
+        anchors.centerIn: parent
+        text: root.index >= 0 ? root.index : ""
+        color: "white"
+        font.bold: true
+    }
+
+    Rectangle {
+        anchors.left: parent.right
+        anchors.leftMargin: ScreenTools.defaultFontPixelWidth / 2
+        anchors.verticalCenter: parent.verticalCenter
+        width: sideLabel.width + ScreenTools.defaultFontPixelWidth
+        height: sideLabel.height
+        radius: height / 2
+        color: root._markerColor
+        visible: root.label.length > 0
+
+        QGCLabel {
+            id: sideLabel
+            anchors.centerIn: parent
+            text: root.label
+            color: "white"
+        }
+    }
+
+    delegate3D: Component {
+        Node {
+            scale: Qt.vector3d(root._modelScale, root._modelScale, root._modelScale)
+
+            Model {
+                source: "#Sphere"
+
+                materials: PrincipledMaterial {
+                    baseColor: root._markerColor
+                }
+            }
+        }
+    }
+}

--- a/src/GeoMap/GeoMapMissionPath.qml
+++ b/src/GeoMap/GeoMapMissionPath.qml
@@ -1,0 +1,193 @@
+/****************************************************************************
+ *
+ * (c) 2009-2024 QGROUNDCONTROL PROJECT <http://www.qgroundcontrol.org>
+ *
+ * QGroundControl is licensed according to the terms in the file
+ * COPYING.md in the root of the source code directory.
+ *
+ ****************************************************************************/
+
+import QtQuick
+import QtQuick3D
+import QtPositioning
+
+import QGroundControl
+import QGroundControl.Controls
+import QGroundControl.GeoMap
+
+/// Mission path for the GeoMap: a 3D ribbon connecting every mission item in
+/// sequence order (simple items at their coordinate; complex items via their
+/// generic entryCoordinate/exitCoordinate, so the ribbon routes straight
+/// through a complex item's own footprint rather than skipping it), at true
+/// (AMSL) altitude. Stays visible in 2D mode (crossfade3D off), same as
+/// GeoMapFlightPath. Rebuilt wholesale on any mission change (missions are
+/// edited, not streamed, so the flight path's incremental append API is not
+/// needed here).
+GeoMapItem {
+    id: root
+
+    property var missionController
+    property var vehicle       ///< Active vehicle, for the RTL-to-home segment
+    // DEM-vs-home-AMSL bias (see GeoMapVehicleItem), computed once by the
+    // consumer for the active vehicle and shared with GeoMapMissionItems
+    // instead of being re-sampled here independently
+    property real homeTerrainBias: 0
+    property real lineWidth: ScreenTools.defaultFontPixelHeight / 5
+    // Matches MissionLineView.qml's existing flight-path line color
+    property color lineColor: QGroundControl.globalPalette.mapMissionTrajectory
+
+    altitudeMode: GeoMapItem.Absolute
+    crossfade3D: false
+    coordinate: {
+        if (!_geometry || !_geometry.anchorCoordinate.isValid) {
+            return QtPositioning.coordinate()
+        }
+        const anchor = _geometry.anchorCoordinate
+        return QtPositioning.coordinate(anchor.latitude, anchor.longitude, anchor.altitude + root.homeTerrainBias)
+    }
+    visible: !!missionController
+
+    // The geometry lives inside the 3D delegate (created/destroyed with the
+    // scene); this bridges its anchor out for the coordinate binding above
+    property var _geometry: null
+
+    readonly property var _camera: scene ? scene.camera : null
+
+    // Pixel-to-scene-unit factor at unit distance; the shader scales it by
+    // each vertex's own camera distance
+    readonly property real _screenFactor: _camera ? _camera.unitsPerPixelAtUnitDistance : 0
+
+    // Ordered coordinates (with AMSL altitude) of every item the vehicle
+    // actually routes through, mirroring MissionController::_recalcFlightPathSegments:
+    // items must specifiesCoordinate && !isStandaloneCoordinate to get a
+    // segment (excludes RTL, which has no mission-encoded coordinate, and
+    // standalone items like ROI); a qualifying item contributes its
+    // entryCoordinate, plus its exitCoordinate too when that differs
+    // (exitCoordinateSameAsEntry false) — for a simple item these are always
+    // the same point, for a complex item this routes the ribbon straight
+    // through its footprint edge-to-edge. Hitting RTL stops the walk and
+    // links the last point to home instead (linkEndToHome). A land item ends
+    // the walk at its entry: its interior path (loiter exit -> touchdown) is
+    // drawn by the landing pattern visual from the slope start, not straight
+    // from the loiter center, and _recalcFlightPathSegments draws no segment
+    // after a landing item either. The walk starts at item 1 (item 0 is the
+    // MissionSettingsItem, i.e. home); home is prepended only when the mission
+    // starts from the ground — rover, or a takeoff command before the first
+    // coordinate item — mirroring linkStartToHome. Recomputes automatically on
+    // any structural or per-item change since the loop below reads every
+    // NOTIFY-backed property it depends on.
+    readonly property var _pathCoordinates: {
+        const coordinates = []
+        if (root.missionController) {
+            const items = root.missionController.visualItems
+            let linkStartToHome = root.vehicle ? root.vehicle.rover : false
+            for (let i = 1; i < items.count; ++i) {
+                const visualItem = items.get(i)
+                if (visualItem.isSimpleItem && visualItem.command === MAVLinkEnums.MAV_CMD_NAV_RETURN_TO_LAUNCH) {
+                    if (coordinates.length > 0 && root.vehicle && root.vehicle.homePosition.isValid) {
+                        coordinates.push(root.vehicle.homePosition)
+                    }
+                    break
+                }
+                if (coordinates.length === 0 && visualItem.isTakeoffItem) {
+                    linkStartToHome = true
+                }
+                if (visualItem.specifiesCoordinate && !visualItem.isStandaloneCoordinate) {
+                    coordinates.push(QtPositioning.coordinate(visualItem.entryCoordinate.latitude,
+                                                               visualItem.entryCoordinate.longitude,
+                                                               visualItem.amslEntryAlt))
+                    if (visualItem.isLandCommand) {
+                        break
+                    }
+                    if (!visualItem.exitCoordinateSameAsEntry) {
+                        coordinates.push(QtPositioning.coordinate(visualItem.exitCoordinate.latitude,
+                                                                   visualItem.exitCoordinate.longitude,
+                                                                   visualItem.amslExitAlt))
+                    }
+                }
+            }
+            if (linkStartToHome && coordinates.length > 0 && items.count > 0) {
+                const home = items.get(0)
+                if (home.coordinate.isValid) {
+                    coordinates.unshift(QtPositioning.coordinate(home.coordinate.latitude,
+                                                                  home.coordinate.longitude,
+                                                                  home.amslEntryAlt))
+                }
+            }
+        }
+        return root._subdivided(coordinates)
+    }
+
+    // Legs longer than this are subdivided along the great circle (matching
+    // MissionLineView.qml): the geometry joins points linearly in Web
+    // Mercator, which diverges materially from the actual route over long
+    // distances
+    readonly property real _maxSegmentLengthM: 50000
+
+    function _subdivided(coordinates) {
+        const result = []
+        for (let i = 0; i < coordinates.length; ++i) {
+            const coord = coordinates[i]
+            if (i > 0) {
+                const prev = coordinates[i - 1]
+                const distance = prev.distanceTo(coord)
+                if (distance > root._maxSegmentLengthM) {
+                    const segments = Math.ceil(distance / root._maxSegmentLengthM)
+                    const azimuth = prev.azimuthTo(coord)
+                    for (let j = 1; j < segments; ++j) {
+                        const point = prev.atDistanceAndAzimuth((j * distance) / segments, azimuth)
+                        result.push(QtPositioning.coordinate(point.latitude, point.longitude,
+                                                             prev.altitude + ((coord.altitude - prev.altitude) * j) / segments))
+                    }
+                }
+            }
+            result.push(coord)
+        }
+        return result
+    }
+
+    function _reloadPath() {
+        if (_geometry) {
+            _geometry.setPath(root._pathCoordinates)
+        }
+    }
+
+    on_PathCoordinatesChanged: _reloadPath()
+
+    delegate3D: Component {
+        // z offsets are relative altitudes; flatten them with the terrain
+        // during the 2D<->3D transition (anchor z already tracks terrainScale
+        // through GeoMapItem)
+        Node {
+            scale: Qt.vector3d(1, 1, root.scene ? root.scene.terrainScale : 1)
+
+            Model {
+                geometry: FlightPathGeometry {
+                    id: pathGeometry
+
+                    scene: root.scene
+                }
+
+                materials: CustomMaterial {
+                    shadingMode: CustomMaterial.Unshaded
+                    cullMode: Material.NoCulling
+                    vertexShader: "shaders/flightpath.vert"
+                    fragmentShader: "shaders/flightpath.frag"
+
+                    property real lineWidth: root.lineWidth
+                    property real screenFactor: root._screenFactor
+                    property color pathColor: root.lineColor
+                    // Ramps in as the terrain flattens, effectively disabling
+                    // depth testing in 2D mode (see flightpath.vert)
+                    property real depthPull: root.scene ? 0.5 * (1.0 - root.scene.terrainScale) : 0.0
+                }
+
+                Component.onCompleted: {
+                    root._geometry = pathGeometry
+                    root._reloadPath()
+                }
+                Component.onDestruction: root._geometry = null
+            }
+        }
+    }
+}

--- a/src/GeoMap/GeoMapProjectedPath.cc
+++ b/src/GeoMap/GeoMapProjectedPath.cc
@@ -1,0 +1,170 @@
+/****************************************************************************
+ *
+ * (c) 2009-2024 QGROUNDCONTROL PROJECT <http://www.qgroundcontrol.org>
+ *
+ * QGroundControl is licensed according to the terms in the file
+ * COPYING.md in the root of the source code directory.
+ *
+ ****************************************************************************/
+
+#include "GeoMapProjectedPath.h"
+
+#include <cmath>
+
+#include "GeoMapCamera.h"
+#include "GeoScene.h"
+#include "SurfacePatchModel.h"
+#include "TileMath.h"
+
+GeoMapProjectedPath::GeoMapProjectedPath(QObject* parent) : QObject(parent) {}
+
+void GeoMapProjectedPath::setCoordinates(const QVariantList& coordinates)
+{
+    if (coordinates == _coordinates) {
+        return;
+    }
+    _coordinates = coordinates;
+    _rebuild();
+    emit coordinatesChanged();
+}
+
+void GeoMapProjectedPath::setScene(GeoScene* scene)
+{
+    if (scene == _scene) {
+        return;
+    }
+    if (_scene) {
+        disconnect(_scene, nullptr, this, nullptr);
+    }
+    _scene = scene;
+    if (_scene) {
+        connect(_scene, &GeoScene::sceneOriginChanged, this, &GeoMapProjectedPath::_rebuild);
+        connect(_scene, &GeoScene::terrainScaleChanged, this, &GeoMapProjectedPath::_rebuild);
+        connect(_scene, &GeoScene::cameraChanged, this, &GeoMapProjectedPath::_connectCamera);
+        connect(_scene, &QObject::destroyed, this, [this] {
+            _scene = nullptr;
+            _connectCamera();
+            emit sceneChanged();
+        });
+    }
+    _connectCamera();
+    emit sceneChanged();
+}
+
+void GeoMapProjectedPath::setSurfaceModel(SurfacePatchModel* surfaceModel)
+{
+    if (surfaceModel == _surfaceModel) {
+        return;
+    }
+    if (_surfaceModel) {
+        disconnect(_surfaceModel, nullptr, this, nullptr);
+    }
+    _surfaceModel = surfaceModel;
+    if (_surfaceModel) {
+        connect(_surfaceModel, &SurfacePatchModel::terrainHeightsChanged, this,
+                &GeoMapProjectedPath::_terrainHeightsChanged);
+        connect(_surfaceModel, &QObject::destroyed, this, [this] {
+            _surfaceModel = nullptr;
+            _rebuild();
+            emit surfaceModelChanged();
+        });
+    }
+    _rebuild();
+    emit surfaceModelChanged();
+}
+
+void GeoMapProjectedPath::setAltitudeMode(GeoMapItem::AltitudeMode mode)
+{
+    if (mode == _altitudeMode) {
+        return;
+    }
+    _altitudeMode = mode;
+    _rebuild();
+    emit altitudeModeChanged();
+}
+
+void GeoMapProjectedPath::_connectCamera()
+{
+    GeoMapCamera* const camera = _scene ? _scene->camera() : nullptr;
+    if (camera == _connectedCamera) {
+        _rebuild();
+        return;
+    }
+    if (_connectedCamera) {
+        disconnect(_connectedCamera, nullptr, this, nullptr);
+    }
+    _connectedCamera = camera;
+    if (_connectedCamera) {
+        connect(_connectedCamera, &GeoMapCamera::scenePoseChanged, this, &GeoMapProjectedPath::_rebuild);
+        connect(_connectedCamera, &GeoMapCamera::viewportSizeChanged, this, &GeoMapProjectedPath::_rebuild);
+        connect(_connectedCamera, &GeoMapCamera::fieldOfViewChanged, this, &GeoMapProjectedPath::_rebuild);
+        connect(_connectedCamera, &QObject::destroyed, this, [this] {
+            _connectedCamera = nullptr;
+            _rebuild();
+        });
+    }
+    _rebuild();
+}
+
+void GeoMapProjectedPath::_terrainHeightsChanged()
+{
+    if (_altitudeMode == GeoMapItem::AltitudeMode::ClampToGround) {
+        _rebuild();
+    }
+}
+
+void GeoMapProjectedPath::_rebuild()
+{
+    QVariantList points;
+    points.reserve(_coordinates.size());
+    bool allProjected = !_coordinates.isEmpty();
+
+    GeoMapCamera* const camera = _scene ? _scene->camera() : nullptr;
+
+    for (const QVariant& variant : std::as_const(_coordinates)) {
+        const QGeoCoordinate coordinate = variant.value<QGeoCoordinate>();
+        if (!_scene || !camera || !coordinate.isValid()) {
+            allProjected = false;
+            continue;
+        }
+
+        double altitude = 0.0;
+        if (_altitudeMode == GeoMapItem::AltitudeMode::Absolute) {
+            altitude = std::isfinite(coordinate.altitude()) ? coordinate.altitude() : 0.0;
+        } else if (_surfaceModel) {
+            altitude = _surfaceModel->terrainHeightAt(coordinate);
+        }
+
+        const QPointF world = TileMath::geoToWorld(coordinate);
+        const double sceneZ = altitude * _scene->verticalScale() * _scene->terrainScale();
+        const auto screen = camera->worldToScreen(world, sceneZ);
+        if (!screen) {
+            allProjected = false;
+            continue;
+        }
+        points.append(*screen);
+    }
+
+    if (points != _screenPoints) {
+        _screenPoints = points;
+        emit screenPointsChanged();
+    }
+    if (allProjected != _projected) {
+        _projected = allProjected;
+        emit projectedChanged();
+    }
+}
+
+QVariantList GeoMapProjectedPath::circleCoordinates(const QGeoCoordinate& center, double radiusMeters, int segments)
+{
+    QVariantList coordinates;
+    if (!center.isValid() || radiusMeters <= 0.0 || segments < 3) {
+        return coordinates;
+    }
+    coordinates.reserve(segments + 1);
+    for (int i = 0; i <= segments; ++i) {
+        const double azimuth = (360.0 * i) / segments;
+        coordinates.append(QVariant::fromValue(center.atDistanceAndAzimuth(radiusMeters, azimuth)));
+    }
+    return coordinates;
+}

--- a/src/GeoMap/GeoMapProjectedPath.h
+++ b/src/GeoMap/GeoMapProjectedPath.h
@@ -1,0 +1,98 @@
+/****************************************************************************
+ *
+ * (c) 2009-2024 QGROUNDCONTROL PROJECT <http://www.qgroundcontrol.org>
+ *
+ * QGroundControl is licensed according to the terms in the file
+ * COPYING.md in the root of the source code directory.
+ *
+ ****************************************************************************/
+
+#pragma once
+
+#include <QtCore/QVariantList>
+#include <QtPositioning/QGeoCoordinate>
+#include <QtQmlIntegration/QtQmlIntegration>
+
+#include "GeoMapItem.h"
+
+class GeoScene;
+class GeoMapCamera;
+class SurfacePatchModel;
+
+Q_MOC_INCLUDE("GeoScene.h")
+Q_MOC_INCLUDE("SurfacePatchModel.h")
+
+/// Batch coordinate->screen projector for the GeoMap 2D overlay. Mirrors
+/// GeoMapItem's own single-point camera-reactive projection
+/// (GeoMapItem::_updatePosition), batched over N points: projects
+/// coordinates through the camera whenever the camera pose, scene anchor, or
+/// (in ClampToGround mode) terrain heights change, and republishes the
+/// result as screenPoints. Meant for QtQuick.Shapes-based polygon/polyline
+/// overlays (survey area, transect lines, landing approach lines, ...) that
+/// need many vertices reprojected reactively without each caller hand-wiring
+/// its own camera Connections.
+class GeoMapProjectedPath : public QObject
+{
+    Q_OBJECT
+    QML_ELEMENT
+    Q_PROPERTY(QVariantList coordinates READ coordinates WRITE setCoordinates NOTIFY coordinatesChanged)
+    Q_PROPERTY(GeoScene* scene READ scene WRITE setScene NOTIFY sceneChanged)
+    Q_PROPERTY(SurfacePatchModel* surfaceModel READ surfaceModel WRITE setSurfaceModel NOTIFY surfaceModelChanged)
+    Q_PROPERTY(GeoMapItem::AltitudeMode altitudeMode READ altitudeMode WRITE setAltitudeMode NOTIFY altitudeModeChanged)
+    Q_PROPERTY(QVariantList screenPoints READ screenPoints NOTIFY screenPointsChanged)
+    Q_PROPERTY(bool projected READ projected NOTIFY projectedChanged)
+
+public:
+    explicit GeoMapProjectedPath(QObject* parent = nullptr);
+
+    QVariantList coordinates() const { return _coordinates; }
+
+    void setCoordinates(const QVariantList& coordinates);
+
+    GeoScene* scene() const { return _scene; }
+
+    void setScene(GeoScene* scene);
+
+    SurfacePatchModel* surfaceModel() const { return _surfaceModel; }
+
+    void setSurfaceModel(SurfacePatchModel* surfaceModel);
+
+    GeoMapItem::AltitudeMode altitudeMode() const { return _altitudeMode; }
+
+    void setAltitudeMode(GeoMapItem::AltitudeMode mode);
+
+    QVariantList screenPoints() const { return _screenPoints; }
+
+    /// False while any coordinate fails to project (invalid, no scene/camera,
+    /// behind the camera plane, or beyond the horizon)
+    bool projected() const { return _projected; }
+
+    /// Points evenly spaced around a circle (great-circle distance/azimuth
+    /// from center, closed back to the first point), for consumers that want
+    /// a loiter-ring outline as an ordinary coordinates list
+    Q_INVOKABLE static QVariantList circleCoordinates(const QGeoCoordinate& center, double radiusMeters,
+                                                      int segments = 32);
+
+signals:
+    void coordinatesChanged();
+    void sceneChanged();
+    void surfaceModelChanged();
+    void altitudeModeChanged();
+    void screenPointsChanged();
+    void projectedChanged();
+
+private slots:
+    void _rebuild();
+    void _terrainHeightsChanged();
+
+private:
+    void _connectCamera();
+
+    QVariantList _coordinates;
+    GeoScene* _scene = nullptr;
+    SurfacePatchModel* _surfaceModel = nullptr;
+    GeoMapCamera* _connectedCamera = nullptr;
+    GeoMapItem::AltitudeMode _altitudeMode = GeoMapItem::AltitudeMode::ClampToGround;
+    QVariantList _screenPoints;
+    bool _projected = false;
+};

--- a/src/GeoMap/GeoMapSegmentArrow.qml
+++ b/src/GeoMap/GeoMapSegmentArrow.qml
@@ -1,0 +1,49 @@
+/****************************************************************************
+ *
+ * (c) 2009-2024 QGROUNDCONTROL PROJECT <http://www.qgroundcontrol.org>
+ *
+ * QGroundControl is licensed according to the terms in the file
+ * COPYING.md in the root of the source code directory.
+ *
+ ****************************************************************************/
+
+import QtQuick
+import QtPositioning
+
+import QGroundControl.GeoMap
+
+/// Direction-indicator chevron positioned along a single fromCoord->toCoord
+/// segment, at fraction of the way between them (screen-space, see
+/// GeoMapMissionArrow). Self-contained (owns its own GeoMapProjectedPath)
+/// for one-off segments.
+Item {
+    id: root
+
+    property var scene
+    property var surfaceModel
+    property var fromCoord: QtPositioning.coordinate()
+    property var toCoord: QtPositioning.coordinate()
+    property real fraction: 0.75   ///< 0..1 along fromCoord -> toCoord
+
+    GeoMapProjectedPath {
+        id: segmentPath
+        scene: root.scene
+        surfaceModel: root.surfaceModel
+        altitudeMode: GeoMapItem.Absolute
+        coordinates: [root.fromCoord, root.toCoord]
+    }
+
+    readonly property bool _ready: segmentPath.projected && segmentPath.screenPoints.length > 1
+
+    GeoMapMissionArrow {
+        visible: root._ready
+        screenPoint: root._ready
+            ? Qt.point(segmentPath.screenPoints[0].x + (segmentPath.screenPoints[1].x - segmentPath.screenPoints[0].x) * root.fraction,
+                       segmentPath.screenPoints[0].y + (segmentPath.screenPoints[1].y - segmentPath.screenPoints[0].y) * root.fraction)
+            : Qt.point(0, 0)
+        heading: root._ready
+            ? Math.atan2(segmentPath.screenPoints[1].x - segmentPath.screenPoints[0].x,
+                         -(segmentPath.screenPoints[1].y - segmentPath.screenPoints[0].y)) * 180 / Math.PI
+            : 0
+    }
+}

--- a/src/GeoMap/GeoMapVTOLLandingPatternVisual.qml
+++ b/src/GeoMap/GeoMapVTOLLandingPatternVisual.qml
@@ -1,0 +1,16 @@
+/****************************************************************************
+ *
+ * (c) 2009-2024 QGROUNDCONTROL PROJECT <http://www.qgroundcontrol.org>
+ *
+ * QGroundControl is licensed according to the terms in the file
+ * COPYING.md in the root of the source code directory.
+ *
+ ****************************************************************************/
+
+import QGroundControl.GeoMap
+
+/// VTOL landing pattern visual for GeoMap: just the shared base (VTOL has no
+/// landing-area/glide-slope polygon, unlike Fixed Wing)
+GeoMapLandingPatternVisuals {
+    landingLabel: qsTr("Land")
+}

--- a/src/GeoMap/GeoMapVehicleItem.qml
+++ b/src/GeoMap/GeoMapVehicleItem.qml
@@ -64,13 +64,9 @@ GeoMapItem {
 
     // Constant apparent size: scene units per screen pixel at the camera's
     // look-at distance. Built-in QtQuick3D meshes are 100 units across.
-    readonly property real _modelScale: {
-        if (!_camera || _camera.viewportSize.height <= 0) {
-            return 1
-        }
-        const unitsPerPixel = 2 * _camera.distance * Math.tan(_camera.fieldOfView * Math.PI / 360) / _camera.viewportSize.height
-        return root.size * unitsPerPixel / 100
-    }
+    readonly property real _modelScale: _camera
+        ? root.size * _camera.distance * _camera.unitsPerPixelAtUnitDistance / 100
+        : 1
 
     Image {
         id: vehicleIcon

--- a/src/GeoMap/GeoMapWaypointItem.qml
+++ b/src/GeoMap/GeoMapWaypointItem.qml
@@ -1,0 +1,113 @@
+/****************************************************************************
+ *
+ * (c) 2009-2024 QGROUNDCONTROL PROJECT <http://www.qgroundcontrol.org>
+ *
+ * QGroundControl is licensed according to the terms in the file
+ * COPYING.md in the root of the source code directory.
+ *
+ ****************************************************************************/
+
+import QtQuick
+import QtQuick3D
+import QtPositioning
+
+import QGroundControl
+import QGroundControl.Controls
+import QGroundControl.GeoMap
+
+/// Simple-mission waypoint marker for the GeoMap: a colored dot that
+/// crossfades into a 3D sphere, with an always-visible sequence-number label.
+/// Marker color matches the existing 2D FlyView convention (MissionItemIndexLabel):
+/// current item highlighted, everything else a plain indicator color.
+/// Renders nothing for complex mission items, the home item, or items with
+/// no real coordinate (e.g. RTL, which flies to home dynamically rather than
+/// a mission-encoded lat/lon) — see visible.
+GeoMapItem {
+    id: root
+
+    property var item          ///< VisualMissionItem for this marker
+    // DEM-vs-home-AMSL bias (see GeoMapVehicleItem), computed once by the
+    // consumer for the active vehicle and shared across every marker instead
+    // of each one re-sampling the same DEM lookup independently
+    property real homeTerrainBias: 0
+    property real size: ScreenTools.defaultFontPixelHeight * 1.5
+
+    width: size
+    height: size
+    anchorPoint: Qt.point(width / 2, height / 2)
+    altitudeMode: GeoMapItem.Absolute
+    // item.amslEntryAlt is AMSL per QGC's own terrain-query pipeline, which
+    // can disagree with GeoMap's own DEM tiles; bias-corrected the same way
+    // GeoMapVehicleItem aligns the vehicle marker to the rendered mesh
+    coordinate: item ? QtPositioning.coordinate(item.coordinate.latitude,
+                                                item.coordinate.longitude,
+                                                item.amslEntryAlt + homeTerrainBias)
+                     : QtPositioning.coordinate()
+    visible: item ? item.isSimpleItem && item.specifiesCoordinate : false
+
+    QGCPalette { id: qgcPal; colorGroupEnabled: root.enabled }
+
+    // Matches MissionItemIndicator.qml's _isCurrentItem exactly: current item
+    // (or a complex item with a current child) is highlighted
+    readonly property bool _isCurrentItem: item ? (item.isCurrentItem || item.hasCurrentChildItem) : false
+
+    // Matches MissionItemIndexLabel.qml's existing convention: current item
+    // is "green", everything else is the plain map indicator color
+    readonly property color _markerColor: root._isCurrentItem ? "green" : qgcPal.mapIndicator
+
+    // MissionItemIndexLabel also grows the indicator for the current item
+    // (small: !checked); mirrored here for both the 2D dot and 3D sphere
+    readonly property real _indicatorSize: root._isCurrentItem ? root.size : root.size * 0.75
+
+    readonly property var _camera: scene ? scene.camera : null
+
+    // Constant apparent size, same technique as GeoMapVehicleItem: scene
+    // units per screen pixel at the camera's look-at distance. Built-in
+    // QtQuick3D meshes are 100 units across.
+    readonly property real _modelScale: _camera
+        ? root._indicatorSize * _camera.distance * _camera.unitsPerPixelAtUnitDistance / 100
+        : 1
+
+    Rectangle {
+        anchors.centerIn: parent
+        width: root._indicatorSize
+        height: root._indicatorSize
+        radius: width / 2
+        color: root._markerColor
+        opacity: root.contentOpacity2D
+    }
+
+    // Matches MissionItemIndicator.qml's "extra circle to indicate selection"
+    Rectangle {
+        anchors.centerIn: parent
+        width: root._indicatorSize * 1.4
+        height: width
+        radius: width / 2
+        color: "transparent"
+        border.color: Qt.rgba(1, 1, 1, 0.5)
+        border.width: 1
+        opacity: root.contentOpacity2D
+        visible: root._isCurrentItem
+    }
+
+    QGCLabel {
+        anchors.centerIn: parent
+        text: root.item ? root.item.sequenceNumber : ""
+        color: "white"
+        font.bold: true
+    }
+
+    delegate3D: Component {
+        Node {
+            scale: Qt.vector3d(root._modelScale, root._modelScale, root._modelScale)
+
+            Model {
+                source: "#Sphere"
+
+                materials: PrincipledMaterial {
+                    baseColor: root._markerColor
+                }
+            }
+        }
+    }
+}

--- a/src/GeoMap/SurfaceModel.cc
+++ b/src/GeoMap/SurfaceModel.cc
@@ -368,7 +368,7 @@ double SurfaceModel::_projectedPixels(const TileMath::TileKey& key, const QPoint
     const double distance = std::hypot(std::hypot(dx, dy), cameraHeight);
 
     const double metersPerPixel =
-        (2.0 * distance * std::tan(qDegreesToRadians(_camera->fieldOfView()) / 2.0)) / _camera->viewportSize().height();
+        (2.0 * distance * std::tan(qDegreesToRadians(_camera->verticalFieldOfView()) / 2.0)) / _camera->viewportSize().height();
     return span / metersPerPixel;
 }
 

--- a/src/MissionManager/FixedWingLandingComplexItem.h
+++ b/src/MissionManager/FixedWingLandingComplexItem.h
@@ -28,6 +28,7 @@ public:
     QString patternName         (void) const final;
     bool    load                (const QJsonObject& complexObject, int sequenceNumber, QString& errorString) final;
     QString mapVisualQML        (void) const final { return QStringLiteral("FWLandingPatternMapVisual.qml"); }
+    QString geoMapVisualQML     (void) const final { return QStringLiteral("GeoMapFWLandingPatternVisual.qml"); }
 
     // Overrides from VisualMissionItem
     void                save                        (QJsonArray&  missionItems) final;

--- a/src/MissionManager/SimpleMissionItem.h
+++ b/src/MissionManager/SimpleMissionItem.h
@@ -123,6 +123,7 @@ public:
     double          specifiedGimbalPitch        (void) override;
     double          specifiedVehicleYaw         (void) override;
     QString         mapVisualQML                (void) const override { return QStringLiteral("SimpleItemMapVisual.qml"); }
+    QString         geoMapVisualQML             (void) const override { return QStringLiteral("GeoMapWaypointItem.qml"); }
     void            appendMissionItems          (QList<MissionItem*>& items, QObject* missionItemParent) final;
     void            applyNewAltitude            (double newAltitude) final;
     void            setMissionFlightStatus      (MissionFlightStatus_t& missionFlightStatus) final;

--- a/src/MissionManager/VTOLLandingComplexItem.h
+++ b/src/MissionManager/VTOLLandingComplexItem.h
@@ -21,6 +21,7 @@ public:
     QString patternName         (void) const final;
     bool    load                (const QJsonObject& complexObject, int sequenceNumber, QString& errorString) final;
     QString mapVisualQML        (void) const final { return QStringLiteral("VTOLLandingPatternMapVisual.qml"); }
+    QString geoMapVisualQML     (void) const final { return QStringLiteral("GeoMapVTOLLandingPatternVisual.qml"); }
 
     // Overrides from VisualMissionItem
     void                save                        (QJsonArray&  missionItems) final;

--- a/src/MissionManager/VisualMissionItem.h
+++ b/src/MissionManager/VisualMissionItem.h
@@ -66,6 +66,7 @@ public:
     Q_PROPERTY(bool             isSurveyItem                        READ isSurveyItem                                                       )                                                   ///< true: Survey item special case for editing center position through mission item list menue
     Q_PROPERTY(QString          editorQml                           MEMBER _editorQml                                                       CONSTANT)                                           ///< Qml code for editing this item
     Q_PROPERTY(QString          mapVisualQML                        READ mapVisualQML                                                       CONSTANT)                                           ///< QMl code for map visuals
+    Q_PROPERTY(QString          geoMapVisualQML                     READ geoMapVisualQML                                                    CONSTANT)                                           ///< QGroundControl.GeoMap-native QML code for this item's visuals, empty if none
     Q_PROPERTY(double           specifiedFlightSpeed                READ specifiedFlightSpeed                                               NOTIFY specifiedFlightSpeedChanged)                 ///< NaN for not specified
     Q_PROPERTY(double           specifiedGimbalYaw                  READ specifiedGimbalYaw                                                 NOTIFY specifiedGimbalYawChanged)                   ///< NaN for not specified
     Q_PROPERTY(double           specifiedGimbalPitch                READ specifiedGimbalPitch                                               NOTIFY specifiedGimbalPitchChanged)                 ///< NaN for not specified
@@ -179,6 +180,10 @@ public:
 
     /// @return The QML resource file which contains the control which visualizes the item on the map.
     virtual QString mapVisualQML(void) const = 0;
+
+    /// @return The QGroundControl.GeoMap-native QML resource file which visualizes the item on
+    /// GeoMap, or an empty string if this item type has none (the default).
+    virtual QString geoMapVisualQML(void) const { return QString(); }
 
     /// Returns the mission items associated with the complex item. Caller is responsible for freeing.
     ///     @param items List to append to

--- a/test/GeoMap/CMakeLists.txt
+++ b/test/GeoMap/CMakeLists.txt
@@ -17,6 +17,8 @@ target_sources(${CMAKE_PROJECT_NAME}
         GeoMapCameraTest.h
         GeoMapItemTest.cc
         GeoMapItemTest.h
+        GeoMapProjectedPathTest.cc
+        GeoMapProjectedPathTest.h
         HeightFieldTest.cc
         HeightFieldTest.h
         HeightSourceTest.cc
@@ -51,6 +53,7 @@ add_qgc_test(FlightPathGeometryTest LABELS Unit)
 add_qgc_test(GeoSceneTest LABELS Unit)
 add_qgc_test(GeoMapCameraTest LABELS Unit)
 add_qgc_test(GeoMapItemTest LABELS Unit)
+add_qgc_test(GeoMapProjectedPathTest LABELS Unit)
 add_qgc_test(HeightFieldTest LABELS Unit)
 add_qgc_test(HeightSourceTest LABELS Unit)
 add_qgc_test(PaperPlaneGeometryTest LABELS Unit)

--- a/test/GeoMap/GeoMapCameraTest.cc
+++ b/test/GeoMap/GeoMapCameraTest.cc
@@ -96,6 +96,20 @@ void GeoMapCameraTest::_fieldOfView()
     QCOMPARE(camera.fieldOfView(), 10.0);
     camera.setFieldOfView(200);
     QCOMPARE(camera.fieldOfView(), 120.0);
+
+    // verticalFieldOfView: without a viewport it follows fieldOfView unchanged
+    camera.setFieldOfView(45);
+    QCOMPARE(camera.verticalFieldOfView(), 45.0);
+
+    // Landscape viewport: fov applies to the wider axis, the vertical fov narrows
+    camera.setViewportSize(QSizeF(800, 600));
+    const double expectedVfov =
+        qRadiansToDegrees(2.0 * std::atan(std::tan(qDegreesToRadians(45.0) / 2.0) / (800.0 / 600.0)));
+    QCOMPARE_LT(qAbs(camera.verticalFieldOfView() - expectedVfov), 1e-9);
+
+    // Portrait viewport: the vertical axis is the larger one, fov applies directly
+    camera.setViewportSize(QSizeF(600, 800));
+    QCOMPARE(camera.verticalFieldOfView(), 45.0);
 }
 
 void GeoMapCameraTest::_reset()
@@ -237,8 +251,9 @@ void GeoMapCameraTest::_groundPointCapped()
     setupCamera(camera, GeoMapCamera::kMaxTilt);
     // Double precision (cameraPosition() is float and loses meters at world scale)
     const QPointF cameraGround = camera.cameraGroundPosition();
-    // At tilt 85 (fov 60, 600px viewport) the horizon is at y~254: the screen bottom
-    // hits at ~190m, y=280 hits at ~2.7km. maxRange=2km separates the cases robustly.
+    // At tilt 85 (fov 45 -> vfov ~34.5 on the 800x600 viewport) the horizon is at
+    // y~215: the screen bottom hits at ~320m, y=260 hits at ~2.8km. maxRange=2km
+    // separates the cases robustly.
     const double maxRange = 2000.0;
 
     // Hit within range: agrees exactly with screenToGround
@@ -250,7 +265,7 @@ void GeoMapCameraTest::_groundPointCapped()
     QCOMPARE_LT(groundDistance(*capped, *hit), kWorldEpsilon);
 
     // Near-horizon hit beyond maxRange: pulled back to exactly maxRange from the camera ground position
-    const QPointF nearHorizon(kViewport.width() / 2, 280);
+    const QPointF nearHorizon(kViewport.width() / 2, 260);
     const auto farHit = camera.screenToGround(nearHorizon);
     QVERIFY(farHit.has_value());
     QCOMPARE_GT(groundDistance(*farHit, cameraGround), maxRange);
@@ -273,9 +288,10 @@ void GeoMapCameraTest::_sceneUnitsPerPixel()
     GeoMapCamera camera;
     setupCamera(camera);
 
-    // Top-down: vertical fov spans 2*d*tan(fov/2) world meters over the viewport height
+    // Top-down: the vertical fov (fov narrowed to the smaller axis on this
+    // landscape viewport) spans 2*d*tan(vfov/2) world meters over the viewport height
     const double expected =
-        (2.0 * camera.distance() * std::tan(qDegreesToRadians(camera.fieldOfView()) / 2.0)) / kViewport.height();
+        (2.0 * camera.distance() * std::tan(qDegreesToRadians(camera.verticalFieldOfView()) / 2.0)) / kViewport.height();
     QCOMPARE_LT(qAbs(camera.sceneUnitsPerPixel() - expected), expected * 0.01);
 }
 

--- a/test/GeoMap/GeoMapProjectedPathTest.cc
+++ b/test/GeoMap/GeoMapProjectedPathTest.cc
@@ -1,0 +1,262 @@
+#include "GeoMapProjectedPathTest.h"
+
+#include <QtPositioning/QGeoCoordinate>
+#include <QtTest/QSignalSpy>
+
+#include <cmath>
+
+#include "GeoMapCamera.h"
+#include "GeoMapProjectedPath.h"
+#include "GeoScene.h"
+#include "HeightField.h"
+#include "SurfacePatchModel.h"
+#include "TileMath.h"
+
+namespace {
+
+const QGeoCoordinate kCenter(47.3977419, 8.5455938);
+constexpr QSizeF kViewport(800, 600);
+
+void setupCamera(GeoMapCamera& camera, qreal tilt = 0)
+{
+    camera.setViewportSize(kViewport);
+    camera.lookAt(kCenter, 0, tilt, 2000);
+}
+
+QPointF expectedScreen(const GeoMapCamera& camera, const GeoScene& scene, const QGeoCoordinate& coordinate,
+                       double altitude)
+{
+    const auto screen =
+        camera.worldToScreen(TileMath::geoToWorld(coordinate), altitude * scene.verticalScale() * scene.terrainScale());
+    return screen.value();
+}
+
+double screenError(const QVariant& actual, const QPointF& expected)
+{
+    const QPointF point = actual.toPointF();
+    return std::hypot(point.x() - expected.x(), point.y() - expected.y());
+}
+
+QVariantList coordinateList(std::initializer_list<QGeoCoordinate> coordinates)
+{
+    QVariantList list;
+    for (const QGeoCoordinate& coordinate : coordinates) {
+        list.append(QVariant::fromValue(coordinate));
+    }
+    return list;
+}
+
+ElevationTilePyramid::Grid uniformGrid(float height)
+{
+    ElevationTilePyramid::Grid grid;
+    grid.width = 4;
+    grid.height = 4;
+    grid.heights = QList<float>(16, height);
+    return grid;
+}
+
+}  // namespace
+
+void GeoMapProjectedPathTest::_projectsAbsolute()
+{
+    GeoMapCamera camera;
+    setupCamera(camera, 45);
+    GeoScene scene;
+    scene.setCamera(&camera);
+    scene.setTerrainScale(1.0);
+
+    GeoMapProjectedPath path;
+    path.setAltitudeMode(GeoMapItem::AltitudeMode::Absolute);
+    path.setScene(&scene);
+
+    // No coordinates: nothing to project
+    QVERIFY(!path.projected());
+    QVERIFY(path.screenPoints().isEmpty());
+
+    QGeoCoordinate elevated(47.3990, 8.5470, 150.0);
+    path.setCoordinates(coordinateList({kCenter, elevated}));
+
+    QVERIFY(path.projected());
+    QCOMPARE(path.screenPoints().count(), 2);
+    QCOMPARE_LT(screenError(path.screenPoints()[0], expectedScreen(camera, scene, kCenter, 0)), 0.01);
+    QCOMPARE_LT(screenError(path.screenPoints()[1], expectedScreen(camera, scene, elevated, 150.0)), 0.01);
+}
+
+void GeoMapProjectedPathTest::_clampToGroundTracksTerrain()
+{
+    GeoMapCamera camera;
+    setupCamera(camera, 45);
+    GeoScene scene;
+    scene.setCamera(&camera);
+    scene.setTerrainScale(1.0);
+    SurfacePatchModel model;
+    model.setScene(&scene);
+    model.drainUpdates();
+
+    GeoMapProjectedPath path;
+    path.setScene(&scene);
+    path.setSurfaceModel(&model);
+    // Ignores the coordinate's own altitude in ClampToGround mode
+    path.setCoordinates(coordinateList({QGeoCoordinate(kCenter.latitude(), kCenter.longitude(), 500.0)}));
+
+    // No terrain data yet: on the ground plane
+    QVERIFY(path.projected());
+    QCOMPARE_LT(screenError(path.screenPoints()[0], expectedScreen(camera, scene, kCenter, 0)), 0.01);
+
+    // Terrain arriving must re-seat the points on the surface without a
+    // coordinate or camera change
+    QSignalSpy pointsSpy(&path, &GeoMapProjectedPath::screenPointsChanged);
+    const TileMath::TileKey key = TileMath::tileForWorld(TileMath::geoToWorld(kCenter), 10);
+    QVERIFY(model.heightField()->insertTile(key, uniformGrid(100.0f)));
+    QCOMPARE(pointsSpy.count(), 1);
+    QCOMPARE_LT(screenError(path.screenPoints()[0], expectedScreen(camera, scene, kCenter, 100.0)), 0.01);
+}
+
+void GeoMapProjectedPathTest::_failedProjections()
+{
+    GeoMapCamera camera;
+    setupCamera(camera);
+    GeoScene scene;
+    scene.setCamera(&camera);
+    scene.setTerrainScale(1.0);
+
+    GeoMapProjectedPath path;
+    path.setAltitudeMode(GeoMapItem::AltitudeMode::Absolute);
+
+    // Coordinates without a scene: not projected
+    path.setCoordinates(coordinateList({kCenter}));
+    QVERIFY(!path.projected());
+    QVERIFY(path.screenPoints().isEmpty());
+
+    // Scene arrives: projected
+    QSignalSpy projectedSpy(&path, &GeoMapProjectedPath::projectedChanged);
+    path.setScene(&scene);
+    QVERIFY(path.projected());
+    QCOMPARE(projectedSpy.count(), 1);
+
+    // Invalid coordinate poisons the whole path
+    path.setCoordinates(coordinateList({kCenter, QGeoCoordinate()}));
+    QVERIFY(!path.projected());
+    QCOMPARE(path.screenPoints().count(), 1);  // the valid point still projects
+
+    // Above the camera (distance 2000, top-down): behind the view plane
+    path.setCoordinates(coordinateList({QGeoCoordinate(kCenter.latitude(), kCenter.longitude(), 5000.0)}));
+    QVERIFY(!path.projected());
+    QVERIFY(path.screenPoints().isEmpty());
+}
+
+void GeoMapProjectedPathTest::_reprojectsOnCameraPose()
+{
+    GeoMapCamera camera;
+    setupCamera(camera);
+    GeoScene scene;
+    scene.setCamera(&camera);
+    scene.setTerrainScale(1.0);
+
+    GeoMapProjectedPath path;
+    path.setScene(&scene);
+    path.setCoordinates(coordinateList({kCenter, QGeoCoordinate(47.3990, 8.5470)}));
+    QVERIFY(path.projected());
+
+    QSignalSpy pointsSpy(&path, &GeoMapProjectedPath::screenPointsChanged);
+    camera.setCenter(QGeoCoordinate(47.3990, 8.5480));
+    QCOMPARE(pointsSpy.count(), 1);
+    QCOMPARE_LT(screenError(path.screenPoints()[0], expectedScreen(camera, scene, kCenter, 0)), 0.01);
+
+    // Re-assigning identical coordinates must not re-emit
+    path.setCoordinates(path.coordinates());
+    QCOMPARE(pointsSpy.count(), 1);
+}
+
+void GeoMapProjectedPathTest::_cameraReplacement()
+{
+    GeoMapCamera cameraA;
+    setupCamera(cameraA);
+    GeoScene scene;
+    scene.setCamera(&cameraA);
+    scene.setTerrainScale(1.0);
+
+    GeoMapProjectedPath path;
+    path.setScene(&scene);
+    path.setCoordinates(coordinateList({kCenter}));
+    QVERIFY(path.projected());
+
+    // Swapping the scene's camera reconnects: pose changes on the new camera reproject
+    GeoMapCamera cameraB;
+    setupCamera(cameraB);
+    cameraB.setCenter(QGeoCoordinate(47.3990, 8.5480));
+    scene.setCamera(&cameraB);
+    QCOMPARE_LT(screenError(path.screenPoints()[0], expectedScreen(cameraB, scene, kCenter, 0)), 0.01);
+
+    QSignalSpy pointsSpy(&path, &GeoMapProjectedPath::screenPointsChanged);
+    cameraB.setDistance(3000);
+    QCOMPARE(pointsSpy.count(), 1);
+
+    // Old camera no longer drives the path
+    cameraA.setDistance(5000);
+    QCOMPARE(pointsSpy.count(), 1);
+}
+
+void GeoMapProjectedPathTest::_sceneAndModelDestruction()
+{
+    GeoMapProjectedPath path;
+    path.setCoordinates(coordinateList({kCenter}));
+
+    auto* camera = new GeoMapCamera();
+    setupCamera(*camera);
+    auto* scene = new GeoScene();
+    scene->setCamera(camera);
+    scene->setTerrainScale(1.0);
+    auto* model = new SurfacePatchModel();
+    model->setScene(scene);
+    model->drainUpdates();
+
+    path.setScene(scene);
+    path.setSurfaceModel(model);
+    QVERIFY(path.projected());
+
+    // Model destruction detaches cleanly and reprojects on the ground plane
+    QSignalSpy modelSpy(&path, &GeoMapProjectedPath::surfaceModelChanged);
+    delete model;
+    QCOMPARE(modelSpy.count(), 1);
+    QVERIFY(!path.surfaceModel());
+    QVERIFY(path.projected());
+
+    // Scene destruction (which also destroys the camera parent-child or not)
+    QSignalSpy sceneSpy(&path, &GeoMapProjectedPath::sceneChanged);
+    delete scene;
+    QCOMPARE(sceneSpy.count(), 1);
+    QVERIFY(!path.scene());
+    QVERIFY(!path.projected());
+    QVERIFY(path.screenPoints().isEmpty());
+
+    delete camera;
+}
+
+void GeoMapProjectedPathTest::_circleCoordinates()
+{
+    const QGeoCoordinate center(kCenter.latitude(), kCenter.longitude(), 120.0);
+    const double radius = 75.0;
+    const int segments = 16;
+    const QVariantList circle = GeoMapProjectedPath::circleCoordinates(center, radius, segments);
+
+    // Closed ring: segments points plus the closing copy of the first
+    QCOMPARE(circle.count(), segments + 1);
+    const QGeoCoordinate first = circle.first().value<QGeoCoordinate>();
+    const QGeoCoordinate last = circle.last().value<QGeoCoordinate>();
+    QCOMPARE_LT(first.distanceTo(last), 0.01);
+
+    // Every point sits on the circle and preserves the center's altitude
+    for (const QVariant& variant : circle) {
+        const QGeoCoordinate coordinate = variant.value<QGeoCoordinate>();
+        QCOMPARE_LT(qAbs(center.distanceTo(coordinate) - radius), 0.01);
+        QCOMPARE(coordinate.altitude(), 120.0);
+    }
+
+    // Degenerate inputs produce no ring
+    QVERIFY(GeoMapProjectedPath::circleCoordinates(QGeoCoordinate(), radius).isEmpty());
+    QVERIFY(GeoMapProjectedPath::circleCoordinates(center, 0.0).isEmpty());
+    QVERIFY(GeoMapProjectedPath::circleCoordinates(center, radius, 2).isEmpty());
+}
+
+UT_REGISTER_TEST_LIGHTWEIGHT(GeoMapProjectedPathTest, TestLabel::Unit)

--- a/test/GeoMap/GeoMapProjectedPathTest.h
+++ b/test/GeoMap/GeoMapProjectedPathTest.h
@@ -1,0 +1,17 @@
+#pragma once
+
+#include "UnitTest.h"
+
+class GeoMapProjectedPathTest : public UnitTest
+{
+    Q_OBJECT
+
+private slots:
+    void _projectsAbsolute();
+    void _clampToGroundTracksTerrain();
+    void _failedProjections();
+    void _reprojectsOnCameraPose();
+    void _cameraReplacement();
+    void _sceneAndModelDestruction();
+    void _circleCoordinates();
+};

--- a/test/GeoMap/SurfaceModelTest.cc
+++ b/test/GeoMap/SurfaceModelTest.cc
@@ -191,6 +191,10 @@ QString coverageHole(const SurfaceModel& model, const GeoMapCamera& camera)
             if (!ground) {
                 continue;  // sky
             }
+            const double half = TileMath::worldSize() / 2.0;
+            if ((std::abs(ground->x()) > half) || (std::abs(ground->y()) > half)) {
+                continue;  // off-world: no tile exists beyond the mercator square
+            }
             const double range = std::hypot(ground->x() - cameraGround.x(), ground->y() - cameraGround.y());
             if (range > demandRange) {
                 continue;  // beyond the coverage contract

--- a/test/MissionManager/LandingComplexItemTest.h
+++ b/test/MissionManager/LandingComplexItemTest.h
@@ -60,6 +60,11 @@ public:
         return QStringLiteral("FWLandingPatternMapVisual.qml");
     }
 
+    QString geoMapVisualQML() const final
+    {
+        return QStringLiteral("GeoMapFWLandingPatternVisual.qml");
+    }
+
     // Overrides from VisualMissionItem
     void save(QJsonArray& /*missionItems*/) override {};
 


### PR DESCRIPTION
## Summary

Adds GeoMap-native mission rendering to the fly view (experimental GeoMap engine):

- **Waypoint markers** — 2D dot that crossfades into a 3D sphere, sequence number, current-item highlight (`GeoMapWaypointItem`)
- **Mission path** — 3D ribbon at true AMSL altitudes, routed through complex item entry/exit coordinates, RTL-to-home link, stops at landing items (`GeoMapMissionPath`)
- **Direction arrows** — screen-space chevrons along flight path segments, correct under user map rotation (`GeoMapMissionDirectionArrows`)
- **Landing patterns** — FW and VTOL visuals: loiter ring at approach altitude, 3D glide-slope surface, landing-area polygon, rotated labels, and height badges (`GeoMapLandingPatternVisuals` + FW/VTOL specializations)

All altitudes are corrected by a shared DEM-vs-home-AMSL terrain bias, computed once per active vehicle in `FlyViewGeoMap`.

## Implementation notes

- New `VisualMissionItem::geoMapVisualQML` pure virtual (mirrors `mapVisualQML`) lets each item type declare its GeoMap visual; `GeoMapMissionItems` dispatches via Repeater + Loader.
- `GeoMapProjectedPath` provides batched, camera-reactive coordinate→screen projection for QtQuick.Shapes overlays (polygons, rings, segments).
- `GeoMapCamera` gains `verticalFieldOfView` — the configured FOV now applies to the larger viewport axis (Cesium-style), preventing fisheye distortion on wide viewports — and `unitsPerPixelAtUnitDistance` for constant-apparent-size scaling. Default FOV narrows from 60° to 45°.

## Testing

- Built and run locally (macOS, Qt 6.11.1) against SITL with FW and VTOL landing pattern missions in 2D and 3D modes.
- Test doubles updated for the new pure virtual (`LandingComplexItemTest`, `TransectStyleComplexItemTest`).
- qmllint clean on all new/modified QML.