### PR TITLE
refactor(tools): add shared utility primitives

### DIFF
--- a/tools/common/README.md
+++ b/tools/common/README.md
@@ -18,6 +18,7 @@ from common.proc import run_captured
 | `aws.py` | Allowlisted public S3 object checks and uploads |
 | `build_config.py` | `.github/build-config.json` lookup, validation, and CI export |
 | `cli.py` | Shared command-line arguments for developer tools |
+| `cmake.py` | CMake cache variable parsing |
 | `cobertura.py` | Cobertura line and branch coverage metrics |
 | `deps.py` | External-tool checks and project-aware Python package installation |
 | `env.py` | CI environment detection |

--- a/tools/common/README.md
+++ b/tools/common/README.md
@@ -1,79 +1,89 @@
-# QGC Tools Common Library
+# QGC Shared Tooling
 
-Shared utilities used by QGC developer tools.
-
-## Modules
-
-### patterns.py
-
-QGC-specific regex patterns for code analysis.
+`tools/common/` contains small, dependency-light helpers shared by QGC developer and CI scripts.
+New code should import from the module that defines a helper. `common/__init__.py` retains lazy
+compatibility exports for existing scripts without eagerly importing optional dependencies.
 
 ```python
-from tools.common.patterns import (
-    FACT_MEMBER_PATTERN,        # Match: Fact _speedFact = ...
-    FACTGROUP_CLASS_PATTERN,    # Match: class VehicleGPSFactGroup : ...
-    MAVLINK_MSG_ID_PATTERN,     # Match: MAVLINK_MSG_ID_HEARTBEAT
-    PARAM_NAME_PATTERN,         # Match: "name": "latitude" in JSON
-    ACTIVE_VEHICLE_DIRECT_PATTERN,   # Match: activeVehicle()->method()
-    ACTIVE_VEHICLE_ASSIGN_PATTERN,   # Match: var = activeVehicle()
-    GET_PARAMETER_DIRECT_PATTERN,    # Match: getParameter()->method()
-    NULL_CHECK_PATTERNS,        # List of null-check pattern strings
-    make_query_pattern,         # Create filtered pattern from query
-)
+from common.file_traversal import find_repo_root
+from common.proc import run_captured
 ```
 
-### file_traversal.py
+## Module Index
 
-File discovery with proper filtering for QGC codebase.
+| Module | Purpose |
+| ------ | ------- |
+| `analyzer.py` | Analyzer result types, base class, and ordered parallel execution |
+| `artifact_metadata.py` | Validated GitHub Actions artifact name and size interchange |
+| `aws.py` | Allowlisted public S3 object checks and uploads |
+| `build_config.py` | `.github/build-config.json` lookup, validation, and CI export |
+| `cli.py` | Shared command-line arguments for developer tools |
+| `cobertura.py` | Cobertura line and branch coverage metrics |
+| `deps.py` | External-tool checks and project-aware Python package installation |
+| `env.py` | CI environment detection |
+| `errors.py` | Shared tooling exceptions |
+| `file_traversal.py` | Repository-root discovery and filtered C++ file traversal |
+| `format.py` | Human-readable byte and size-delta formatting |
+| `gh_actions.py` | GitHub CLI calls, annotations, outputs, environment, and step summaries |
+| `git.py` | Captured Git commands and default-branch discovery |
+| `github_runs.py` | Workflow-run loading, filtering, and latest-run selection |
+| `io.py` | JSON/TOML I/O, checksums, atomic writes, and safe archive extraction |
+| `logging.py` | Color-aware terminal logging |
+| `markdown.py` | Escaped GitHub-Flavored Markdown tables |
+| `net.py` | Dependency-free downloads and retry policies |
+| `opener.py` | Cross-platform default-application launching |
+| `patterns.py` | QGC-specific source-analysis regular expressions |
+| `platform.py` | OS and CPU architecture normalization |
+| `proc.py` | Captured text, byte, and tee subprocess execution |
+| `tool_version.py` | External-tool and `uv.lock` version lookup |
+| `xml.py` | Safe XML parsing with entity-declaration rejection |
+| `shell-utils.sh` | Shared shell logging for developer scripts |
+
+API behavior and edge cases are covered by matching files under `tools/tests/`, such as
+`test_proc.py`, `test_io.py`, and `test_gh_actions.py`.
+
+## Bootstrapping Imports
+
+Scripts under `tools/` must initialize the tools path before importing `common`:
 
 ```python
-from tools.common.file_traversal import (
-    find_repo_root,      # Find .git root directory
-    find_cpp_files,      # Find .cc, .cpp, .h, .hpp files
-    find_header_files,   # Find .h, .hpp files only
-    find_source_files,   # Find .cc, .cpp files only
-    find_json_files,     # Find JSON files by pattern
-    should_skip_path,    # Check if path should be skipped
-    DEFAULT_SKIP_DIRS,   # {'build', 'libs', 'test', ...}
-)
+from _bootstrap import ensure_tools_dir
+
+ensure_tools_dir(__file__)
+
+from common.proc import run_captured
 ```
 
-### gh_actions.py
-
-Shared GitHub Actions API helpers (via `gh`) used by CI scripts.
+Scripts under `.github/scripts/` use the CI shim instead:
 
 ```python
-from tools.common.gh_actions import (
-    gh,                        # Run gh command and capture output
-    list_workflow_runs_for_sha,# List workflow runs for commit SHA
-    list_run_artifacts,        # List artifacts for a workflow run
-)
+from ci_bootstrap import ensure_tools_dir
+
+ensure_tools_dir(__file__)
+
+from common.gh_actions import write_github_output
 ```
 
-## Usage Example
+The import after `ensure_tools_dir` is intentionally separated and may need `# noqa: E402` in
+files covered by Ruff's import-position rule. Do not manually modify `sys.path` in new scripts.
 
-```python
-import sys
-from pathlib import Path
+CI jobs that use sparse checkout must include the entrypoint, bootstrap shim, and transitive
+`common` modules. `test_bootstrap_sparse_checkout.py` checks that closure automatically.
 
-# Add tools to path
-sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
+## Adding or Reusing Helpers
 
-from common.patterns import FACT_MEMBER_PATTERN, make_query_pattern
-from common.file_traversal import find_header_files, find_repo_root
+Before adding a helper, search this directory and its call sites. Add shared code only when it has
+multiple consumers or centralizes a correctness boundary such as safe extraction, retries, GitHub
+output encoding, or platform normalization.
 
-# Search for Facts matching a query
-repo_root = find_repo_root()
-query_pattern = make_query_pattern(FACT_MEMBER_PATTERN, "lat")
+When a new helper is warranted:
 
-for header in find_header_files(repo_root / "src"):
-    content = header.read_text()
-    for match in query_pattern.finditer(content):
-        print(f"Found: {match.group(1)} in {header}")
-```
+1. Put it in the narrowest existing module; create a module only for a distinct concern.
+2. Keep imports dependency-light and defer optional packages until the function that needs them.
+3. Export the supported surface through the module's `__all__` when it has one.
+4. Add focused tests under `tools/tests/`.
+5. Run `pytest -q tools/tests .github/scripts/tests`, Ruff, Pyright, and import-linter.
+6. Update sparse-checkout lists if the automatic policy test reports a missing module.
 
-## Adding New Patterns
-
-1. Add pattern to `patterns.py` with descriptive name and docstring
-2. Export from `__init__.py`
-3. Add tests if pattern is complex
+Standalone packages under `tools/skills/` are copied and run outside the repository, so their
+reference scripts must not depend on `tools/common/`.

--- a/tools/common/__init__.py
+++ b/tools/common/__init__.py
@@ -44,6 +44,9 @@ if TYPE_CHECKING:
         check_dependencies as check_dependencies,
     )
     from .deps import (
+        pip_install as pip_install,
+    )
+    from .deps import (
         require_tool as require_tool,
     )
     from .env import (
@@ -223,6 +226,7 @@ _LAZY_SYMBOLS: dict[str, str] = {
     "check_dependencies": "deps",
     "require_tool": "deps",
     "check_and_report": "deps",
+    "pip_install": "deps",
     "get_default_branch_ref": "git",
     "run_captured": "proc",
     "run_text": "proc",
@@ -253,7 +257,7 @@ _LAZY_SYMBOLS: dict[str, str] = {
     "md_table": "markdown",
 }
 
-__all__ = [*_LAZY_SYMBOLS.keys(), "pip_install"]
+__all__ = list(_LAZY_SYMBOLS)
 
 
 def __getattr__(name: str):
@@ -264,30 +268,3 @@ def __getattr__(name: str):
     value = getattr(mod, name)
     globals()[name] = value
     return value
-
-
-def pip_install(packages: list[str], quiet: bool = True) -> None:
-    """Install packages using uv (preferred) or pip.
-
-    Targets the project .venv (on PATH in CI) rather than --system: the system
-    interpreter may be externally managed (PEP 668) when no writable runner
-    Python is provisioned. Falls back to --system when no .venv exists.
-    """
-    import shutil
-    import subprocess
-    import sys
-
-    if shutil.which("uv"):
-        from .file_traversal import find_repo_root
-
-        rel = "Scripts/python.exe" if sys.platform == "win32" else "bin/python"
-        venv_python = find_repo_root() / ".venv" / rel
-        if venv_python.exists():
-            cmd = ["uv", "pip", "install", "--python", str(venv_python), *packages]
-        else:
-            cmd = ["uv", "pip", "install", "--system", *packages]
-    else:
-        cmd = [sys.executable, "-m", "pip", "install", *packages]
-        if quiet:
-            cmd.append("--quiet")
-    subprocess.run(cmd, check=True)

--- a/tools/common/artifact_metadata.py
+++ b/tools/common/artifact_metadata.py
@@ -67,7 +67,7 @@ def read_run_artifact_metadata(path: Path) -> dict[int, list[dict[str, Any]]]:
         if not isinstance(run_id_text, str) or not run_id_text.isdecimal():
             raise ArtifactMetadataError("workflow run IDs must be positive decimal strings")
         run_id = int(run_id_text)
-        if run_id <= 0:
+        if run_id <= 0 or str(run_id) != run_id_text:
             raise ArtifactMetadataError("workflow run IDs must be positive decimal strings")
         if not isinstance(artifacts, list):
             raise ArtifactMetadataError(f"artifacts for workflow run {run_id} must be a list")

--- a/tools/common/artifact_metadata.py
+++ b/tools/common/artifact_metadata.py
@@ -1,0 +1,80 @@
+"""Validated JSON interchange for GitHub Actions artifact metadata."""
+
+from __future__ import annotations
+
+import json
+from typing import TYPE_CHECKING, Any
+
+from .io import read_json, write_json
+
+if TYPE_CHECKING:
+    from collections.abc import Mapping, Sequence
+    from pathlib import Path
+
+__all__ = [
+    "ArtifactMetadataError",
+    "read_run_artifact_metadata",
+    "write_run_artifact_metadata",
+]
+
+
+class ArtifactMetadataError(ValueError):
+    """Raised when run artifact metadata does not match the expected schema."""
+
+
+def _normalize_artifact(artifact: Mapping[str, Any]) -> dict[str, Any]:
+    name = artifact.get("name")
+    if not isinstance(name, str) or not name:
+        raise ArtifactMetadataError("artifact name must be a non-empty string")
+
+    size = artifact.get("size_in_bytes")
+    if isinstance(size, bool) or not isinstance(size, int) or size < 0:
+        raise ArtifactMetadataError("artifact size_in_bytes must be a non-negative integer")
+
+    return {"name": name, "size_in_bytes": size}
+
+
+def write_run_artifact_metadata(
+    path: Path,
+    artifacts_by_run_id: Mapping[int, Sequence[Mapping[str, Any]]],
+) -> None:
+    """Validate and write artifact name/size metadata grouped by workflow run ID."""
+    runs: dict[str, list[dict[str, Any]]] = {}
+    for run_id, artifacts in artifacts_by_run_id.items():
+        if isinstance(run_id, bool) or not isinstance(run_id, int) or run_id <= 0:
+            raise ArtifactMetadataError("workflow run IDs must be positive integers")
+        runs[str(run_id)] = [_normalize_artifact(artifact) for artifact in artifacts]
+
+    path.parent.mkdir(parents=True, exist_ok=True)
+    write_json(path, {"runs": runs}, sort_keys=True)
+
+
+def read_run_artifact_metadata(path: Path) -> dict[int, list[dict[str, Any]]]:
+    """Read and validate artifact name/size metadata grouped by workflow run ID."""
+    try:
+        data = read_json(path)
+    except (json.JSONDecodeError, OSError) as exc:
+        raise ArtifactMetadataError(f"invalid artifact metadata file {path}: {exc}") from exc
+
+    if not isinstance(data, dict) or set(data) != {"runs"}:
+        raise ArtifactMetadataError("artifact metadata must contain only a 'runs' object")
+    runs_data = data["runs"]
+    if not isinstance(runs_data, dict):
+        raise ArtifactMetadataError("artifact metadata 'runs' must be an object")
+
+    result: dict[int, list[dict[str, Any]]] = {}
+    for run_id_text, artifacts in runs_data.items():
+        if not isinstance(run_id_text, str) or not run_id_text.isdecimal():
+            raise ArtifactMetadataError("workflow run IDs must be positive decimal strings")
+        run_id = int(run_id_text)
+        if run_id <= 0:
+            raise ArtifactMetadataError("workflow run IDs must be positive decimal strings")
+        if not isinstance(artifacts, list):
+            raise ArtifactMetadataError(f"artifacts for workflow run {run_id} must be a list")
+        if not all(isinstance(artifact, dict) for artifact in artifacts):
+            raise ArtifactMetadataError(
+                f"artifacts for workflow run {run_id} must contain only objects"
+            )
+        result[run_id] = [_normalize_artifact(artifact) for artifact in artifacts]
+
+    return result

--- a/tools/common/aws.py
+++ b/tools/common/aws.py
@@ -1,0 +1,68 @@
+"""Shared policy and subprocess helpers for QGC's public S3 artifacts."""
+
+from __future__ import annotations
+
+from pathlib import Path, PurePosixPath
+from typing import TYPE_CHECKING
+
+from .proc import run_captured
+
+if TYPE_CHECKING:
+    from collections.abc import Mapping
+
+__all__ = [
+    "PUBLIC_BUCKETS",
+    "public_s3_uri",
+    "s3_object_exists",
+    "upload_public_file",
+    "validate_public_bucket",
+]
+
+PUBLIC_BUCKETS = frozenset({"qgroundcontrol"})
+
+
+def validate_public_bucket(bucket: str) -> None:
+    """Reject uploads outside the explicit QGC public-distribution allowlist."""
+    if bucket not in PUBLIC_BUCKETS:
+        raise ValueError(f"Bucket {bucket!r} not in allowlist: {sorted(PUBLIC_BUCKETS)}")
+
+
+def _validate_key(key: str) -> None:
+    parts = PurePosixPath(key).parts
+    if not key or key.startswith("/") or "\\" in key or ".." in parts:
+        raise ValueError(f"Invalid S3 object key: {key!r}")
+
+
+def public_s3_uri(bucket: str, key: str) -> str:
+    """Return an allowlisted, path-safe public S3 URI."""
+    validate_public_bucket(bucket)
+    _validate_key(key)
+    return f"s3://{bucket}/{key}"
+
+
+def s3_object_exists(bucket: str, key: str) -> bool:
+    """Return whether an allowlisted S3 object is visible to the AWS CLI."""
+    validate_public_bucket(bucket)
+    _validate_key(key)
+    result = run_captured(["aws", "s3api", "head-object", "--bucket", bucket, "--key", key])
+    return result.returncode == 0
+
+
+def upload_public_file(
+    source: Path,
+    bucket: str,
+    key: str,
+    *,
+    env: Mapping[str, str] | None = None,
+) -> None:
+    """Upload *source* with the public-read ACL after validating bucket and key."""
+    if not source.is_file():
+        raise ValueError(f"Artifact not found: {source}")
+    destination = public_s3_uri(bucket, key)
+    result = run_captured(
+        ["aws", "s3", "cp", str(source), destination, "--acl", "public-read"],
+        env=env,
+    )
+    if result.returncode != 0:
+        detail = result.stderr.strip() or f"aws exited with status {result.returncode}"
+        raise RuntimeError(f"S3 upload failed for {destination}: {detail}")

--- a/tools/common/build_config.py
+++ b/tools/common/build_config.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import os
+from collections.abc import Mapping
 from pathlib import Path
 from typing import Any
 
@@ -35,6 +36,28 @@ DEFAULT_EXPORT_KEYS = [
     "build.platform_workflows",
 ]
 IOS_QT_MODULE_EXCLUDES = {"qtserialport"}
+_MISSING = object()
+
+
+def lookup_dotted(
+    mapping: Mapping[str, Any],
+    key: str,
+    default: Any = _MISSING,
+) -> Any:
+    """Return the value at dotted *key* or *default* when a segment is missing.
+
+    With no default, a missing path raises ``KeyError``. An explicit JSON null
+    is returned as ``None`` and is therefore distinct from a missing path.
+    """
+    value: Any = mapping
+    for part in key.split("."):
+        if isinstance(value, Mapping) and part in value:
+            value = value[part]
+            continue
+        if default is _MISSING:
+            raise KeyError(key)
+        return default
+    return value
 
 
 def find_build_config(
@@ -97,12 +120,7 @@ def get_build_config_value(
         config = load_build_config(config_file, start=start, extra_candidates=extra_candidates)
     except (FileNotFoundError, OSError):
         return default
-    value: Any = config
-    for part in key.split("."):
-        if isinstance(value, dict) and part in value:
-            value = value[part]
-        else:
-            return default
+    value = lookup_dotted(config, key, default)
     return str(value) if value is not None else default
 
 
@@ -118,8 +136,8 @@ _GSTREAMER_VERSION_ENV_NAMES: dict[str, str] = {
     "gstreamer.version.default": "GSTREAMER_VERSION",
     "gstreamer.version.minimum": "GSTREAMER_MINIMUM_VERSION",
     "gstreamer.version.android": "GSTREAMER_ANDROID_VERSION",
-    "gstreamer.version.ios":     "GSTREAMER_IOS_VERSION",
-    "gstreamer.version.macos":   "GSTREAMER_MACOS_VERSION",
+    "gstreamer.version.ios": "GSTREAMER_IOS_VERSION",
+    "gstreamer.version.macos": "GSTREAMER_MACOS_VERSION",
     "gstreamer.version.windows": "GSTREAMER_WINDOWS_VERSION",
 }
 
@@ -132,13 +150,7 @@ def export_build_config_values(
     """Return uppercase env-style values exported from the config."""
     exported: dict[str, str] = {}
     for key in keys or DEFAULT_EXPORT_KEYS:
-        value: Any = config
-        for part in key.split("."):
-            if isinstance(value, dict) and part in value:
-                value = value[part]
-            else:
-                value = None
-                break
+        value = lookup_dotted(config, key, None)
         if value is not None:
             primary = _GSTREAMER_VERSION_ENV_NAMES.get(key, key.replace(".", "_").upper())
             exported[primary] = str(value)

--- a/tools/common/cmake.py
+++ b/tools/common/cmake.py
@@ -1,0 +1,29 @@
+"""Dependency-light helpers for reading CMake cache metadata."""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+__all__ = ["read_cache_dict", "read_cache_var"]
+
+_CACHE_LINE_RE = re.compile(r"^([A-Za-z0-9_.\-]+):[^=]+=(.*)$")
+
+
+def read_cache_dict(cache_path: Path | str) -> dict[str, str]:
+    """Return typed ``CMakeCache.txt`` entries as a flat name-to-value mapping."""
+    entries: dict[str, str] = {}
+    try:
+        with Path(cache_path).open(encoding="utf-8") as cache:
+            for line in cache:
+                match = _CACHE_LINE_RE.match(line.rstrip("\n"))
+                if match:
+                    entries[match.group(1)] = match.group(2)
+    except FileNotFoundError:
+        pass
+    return entries
+
+
+def read_cache_var(cache_path: Path | str, name: str) -> str | None:
+    """Return one CMake cache value, or ``None`` when it is absent."""
+    return read_cache_dict(cache_path).get(name)

--- a/tools/common/cobertura.py
+++ b/tools/common/cobertura.py
@@ -1,0 +1,77 @@
+"""Typed parsing for Cobertura coverage reports."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import TYPE_CHECKING
+
+from .xml import XMLParseError, xml_parse
+
+if TYPE_CHECKING:
+    from os import PathLike
+    from xml.etree.ElementTree import Element
+
+__all__ = ["CoberturaError", "CoberturaMetrics", "read_cobertura"]
+
+
+class CoberturaError(ValueError):
+    """Raised when a Cobertura report cannot provide valid metrics."""
+
+
+@dataclass(frozen=True)
+class CoberturaMetrics:
+    """Normalized coverage percentages and source-line counts."""
+
+    line_percent: float
+    branch_percent: float | None
+    lines_valid: int
+    lines_covered: int
+
+
+def _optional_percent(element: Element, attribute: str) -> float | None:
+    value = element.get(attribute)
+    if value is None or value == "":
+        return None
+    return float(value) * 100.0
+
+
+def _integer(element: Element, attribute: str) -> int:
+    value = element.get(attribute)
+    if value is None or value == "":
+        return 0
+    return int(value)
+
+
+def read_cobertura(path: str | PathLike[str]) -> CoberturaMetrics:
+    """Read root metrics, falling back to the first package with a line rate."""
+    try:
+        root = xml_parse(path).getroot()
+        if root is None:
+            raise CoberturaError("coverage report has no root element")
+
+        metrics_element = root
+        if root.get("line-rate") in {None, ""}:
+            metrics_element = next(
+                (
+                    package
+                    for package in root.findall(".//package")
+                    if package.get("line-rate") not in {None, ""}
+                ),
+                None,
+            )
+            if metrics_element is None:
+                raise CoberturaError("coverage report has no line-rate metric")
+
+        line_percent = _optional_percent(metrics_element, "line-rate")
+        if line_percent is None:
+            raise CoberturaError("coverage report has no line-rate metric")
+        return CoberturaMetrics(
+            line_percent=line_percent,
+            branch_percent=_optional_percent(metrics_element, "branch-rate"),
+            lines_valid=_integer(metrics_element, "lines-valid"),
+            lines_covered=_integer(metrics_element, "lines-covered"),
+        )
+    except CoberturaError:
+        raise
+    except (XMLParseError, OSError, TypeError, ValueError) as exc:
+        raise CoberturaError(f"failed to parse {path}: {exc}") from exc

--- a/tools/common/cobertura.py
+++ b/tools/common/cobertura.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import math
 from dataclasses import dataclass
 from typing import TYPE_CHECKING
 
@@ -32,7 +33,10 @@ def _optional_percent(element: Element, attribute: str) -> float | None:
     value = element.get(attribute)
     if value is None or value == "":
         return None
-    return float(value) * 100.0
+    rate = float(value)
+    if not math.isfinite(rate) or not 0.0 <= rate <= 1.0:
+        raise CoberturaError(f"{attribute} must be a finite value from 0 through 1")
+    return rate * 100.0
 
 
 def _integer(element: Element, attribute: str) -> int:

--- a/tools/common/deps.py
+++ b/tools/common/deps.py
@@ -13,12 +13,20 @@ Usage:
 from __future__ import annotations
 
 import shutil
+import subprocess
+import sys
 from pathlib import Path
+from typing import TYPE_CHECKING
 
 from .errors import ToolNotFoundError
 
+if TYPE_CHECKING:
+    from collections.abc import Iterable, Sequence
 
-def check_dependencies(tools: list[str]) -> list[str]:
+__all__ = ["check_and_report", "check_dependencies", "pip_install", "require_tool"]
+
+
+def check_dependencies(tools: Iterable[str]) -> list[str]:
     """Return list of tools not found in PATH."""
     return [t for t in tools if shutil.which(t) is None]
 
@@ -31,7 +39,7 @@ def require_tool(name: str, *, hint: str = "") -> Path:
     return Path(path)
 
 
-def check_and_report(tools: list[str], *, exit_on_missing: bool = True) -> bool:
+def check_and_report(tools: Sequence[str], *, exit_on_missing: bool = True) -> bool:
     """Check tools and print a summary. Returns True if all found."""
     from .logging import log_error, log_ok
 
@@ -43,6 +51,27 @@ def check_and_report(tools: list[str], *, exit_on_missing: bool = True) -> bool:
     for tool in missing:
         log_error(f"Missing: {tool}")
     if exit_on_missing:
-        import sys
         sys.exit(1)
     return False
+
+
+def pip_install(packages: Sequence[str], quiet: bool = True) -> None:
+    """Install packages into the project virtual environment when available.
+
+    ``uv`` is preferred so setup scripts use the same environment as the rest
+    of the tooling. The stdlib pip fallback uses the current interpreter.
+    """
+    if shutil.which("uv"):
+        from .file_traversal import find_repo_root
+
+        relative_python = "Scripts/python.exe" if sys.platform == "win32" else "bin/python"
+        venv_python = find_repo_root() / ".venv" / relative_python
+        if venv_python.exists():
+            command = ["uv", "pip", "install", "--python", str(venv_python), *packages]
+        else:
+            command = ["uv", "pip", "install", "--system", *packages]
+    else:
+        command = [sys.executable, "-m", "pip", "install", *packages]
+        if quiet:
+            command.append("--quiet")
+    subprocess.run(command, check=True)

--- a/tools/common/gh_actions.py
+++ b/tools/common/gh_actions.py
@@ -63,6 +63,15 @@ def parse_csv_list(value: str) -> list[str]:
     return [item.strip() for item in value.split(",") if item.strip()]
 
 
+def require_repository() -> str:
+    """Return the configured owner/repo or terminate with a CI annotation."""
+    repo = os.environ.get("GH_REPO") or os.environ.get("GITHUB_REPOSITORY", "")
+    if not repo:
+        gh_error("GH_REPO or GITHUB_REPOSITORY must be set")
+        raise SystemExit(1)
+    return repo
+
+
 def is_fork_pr() -> bool:
     """Check if the current event is a PR from a fork repository."""
     event = os.environ.get("EVENT_NAME", os.environ.get("GITHUB_EVENT_NAME", ""))
@@ -96,11 +105,11 @@ def write_github_output(outputs: dict[str, str]) -> None:
     """
     import hashlib
 
-    github_output = os.environ.get('GITHUB_OUTPUT')
+    github_output = os.environ.get("GITHUB_OUTPUT")
     if not github_output:
         return
 
-    with open(github_output, 'a', encoding="utf-8") as f:
+    with open(github_output, "a", encoding="utf-8") as f:
         for key, value in outputs.items():
             if "\n" in value:
                 value_hash = hashlib.sha256(value.encode("utf-8")).hexdigest()[:12]

--- a/tools/common/gh_actions.py
+++ b/tools/common/gh_actions.py
@@ -65,11 +65,11 @@ def parse_csv_list(value: str) -> list[str]:
 
 def require_repository() -> str:
     """Return the configured owner/repo or terminate with a CI annotation."""
-    repo = os.environ.get("GH_REPO") or os.environ.get("GITHUB_REPOSITORY", "")
-    if not repo:
-        gh_error("GH_REPO or GITHUB_REPOSITORY must be set")
-        raise SystemExit(1)
-    return repo
+    for variable in ("GH_REPO", "GITHUB_REPOSITORY"):
+        if repo := os.environ.get(variable, "").strip():
+            return repo
+    gh_error("GH_REPO or GITHUB_REPOSITORY must be set")
+    raise SystemExit(1)
 
 
 def is_fork_pr() -> bool:

--- a/tools/common/github_runs.py
+++ b/tools/common/github_runs.py
@@ -2,8 +2,49 @@
 
 from __future__ import annotations
 
+import json
+import sys
 from datetime import datetime
-from typing import Any
+from pathlib import Path
+from typing import TYPE_CHECKING, Any
+
+from .io import read_json
+
+if TYPE_CHECKING:
+    from collections.abc import Callable
+
+
+class WorkflowRunsFileError(ValueError):
+    """Raised when cached workflow-run JSON cannot be used."""
+
+
+def load_workflow_runs(path: Path) -> list[dict[str, Any]]:
+    """Load and validate a cached JSON list of GitHub workflow-run objects."""
+    try:
+        data = read_json(path)
+    except (json.JSONDecodeError, OSError) as exc:
+        raise WorkflowRunsFileError(f"failed to read runs file {path}: {exc}") from exc
+    if not isinstance(data, list):
+        raise WorkflowRunsFileError(f"runs file {path} must contain a JSON list of workflow runs")
+    if not all(isinstance(run, dict) for run in data):
+        raise WorkflowRunsFileError(f"runs file {path} must contain only workflow-run objects")
+    return data
+
+
+def resolve_workflow_runs(
+    repo: str,
+    head_sha: str,
+    runs_file: str,
+    fetcher: Callable[[str, str], list[dict[str, Any]]],
+) -> list[dict[str, Any]] | None:
+    """Load cached runs or call *fetcher*, reporting cached-file errors consistently."""
+    if not runs_file:
+        return fetcher(repo, head_sha)
+    try:
+        return load_workflow_runs(Path(runs_file))
+    except WorkflowRunsFileError as exc:
+        print(f"Error: {exc}", file=sys.stderr)
+        return None
 
 
 def parse_created_at(created_at: Any) -> datetime | None:

--- a/tools/common/io.py
+++ b/tools/common/io.py
@@ -7,6 +7,7 @@ Centralizes the encoding and atomic-write patterns that get repeated in
 from __future__ import annotations
 
 import contextlib
+import hashlib
 import json
 import os
 import tempfile
@@ -14,14 +15,19 @@ from typing import TYPE_CHECKING, Any
 
 if TYPE_CHECKING:
     from pathlib import Path
+    from typing import Literal
 
 __all__ = [
     "atomic_write",
     "chdir",
+    "extract_tar_data",
+    "extract_zip_safe",
     "read_json",
     "read_toml",
     "require_tar_data_filter",
+    "sha256_file",
     "write_json",
+    "write_text_if_changed",
 ]
 
 
@@ -51,6 +57,41 @@ def require_tar_data_filter() -> None:
             "(Python 3.10.12+, 3.11.4+, or 3.12+). Update Python "
             "(Ubuntu 22.04 ships 3.10.12+) to extract this archive."
         )
+
+
+def extract_tar_data(
+    archive: Path,
+    destination: Path,
+    *,
+    mode: Literal["r", "r:*", "r:gz", "r:bz2", "r:xz"] = "r:*",
+) -> None:
+    """Extract a tar archive using Python's path-safe PEP 706 data filter."""
+    import tarfile
+
+    require_tar_data_filter()
+    with tarfile.open(archive, mode) as tar:
+        tar.extractall(destination, filter="data")
+
+
+def extract_zip_safe(archive: Path, destination: Path) -> None:
+    """Extract a zip archive, rejecting members that resolve outside *destination*."""
+    import zipfile
+
+    dest = destination.resolve()
+    with zipfile.ZipFile(archive) as zf:
+        for name in zf.namelist():
+            if not (dest / name).resolve().is_relative_to(dest):
+                raise ValueError(f"Unsafe zip member path: {name!r}")
+        zf.extractall(dest)
+
+
+def sha256_file(path: Path, *, chunk_size: int = 1024 * 1024) -> str:
+    """Return the SHA-256 digest of *path* without loading it all into memory."""
+    digest = hashlib.sha256()
+    with path.open("rb") as file:
+        while chunk := file.read(chunk_size):
+            digest.update(chunk)
+    return digest.hexdigest()
 
 
 def read_json(path: Path) -> Any:
@@ -103,3 +144,14 @@ def atomic_write(path: Path, content: str, *, encoding: str = "utf-8") -> None:
         with contextlib.suppress(FileNotFoundError):
             os.unlink(tmp_name)
         raise
+
+
+def write_text_if_changed(path: Path, content: str, *, encoding: str = "utf-8") -> bool:
+    """Atomically write *content* when it differs; return whether the file changed."""
+    try:
+        if path.read_text(encoding=encoding) == content:
+            return False
+    except FileNotFoundError:
+        pass
+    atomic_write(path, content, encoding=encoding)
+    return True

--- a/tools/common/io.py
+++ b/tools/common/io.py
@@ -87,6 +87,8 @@ def extract_zip_safe(archive: Path, destination: Path) -> None:
 
 def sha256_file(path: Path, *, chunk_size: int = 1024 * 1024) -> str:
     """Return the SHA-256 digest of *path* without loading it all into memory."""
+    if chunk_size <= 0:
+        raise ValueError("chunk_size must be a positive integer")
     digest = hashlib.sha256()
     with path.open("rb") as file:
         while chunk := file.read(chunk_size):

--- a/tools/common/net.py
+++ b/tools/common/net.py
@@ -20,7 +20,13 @@ if TYPE_CHECKING:
     from collections.abc import Sequence
     from pathlib import Path
 
-__all__ = ["download_file", "download_with_retry", "run_with_retries"]
+__all__ = ["download_file", "download_with_retry", "read_url_text", "run_with_retries"]
+
+
+def read_url_text(url: str, *, timeout: int = 60, encoding: str = "utf-8") -> str:
+    """Fetch a small text response using the dependency-free CI HTTP boundary."""
+    with urllib.request.urlopen(urllib.request.Request(url), timeout=timeout) as response:
+        return response.read().decode(encoding)
 
 
 def run_with_retries(

--- a/tools/common/platform.py
+++ b/tools/common/platform.py
@@ -7,12 +7,44 @@ checks scattered through ``configure.py``, ``run_tests.py``,
 
 from __future__ import annotations
 
+import os
+import platform
 import sys
 from typing import Literal
 
-__all__ = ["current_platform", "is_linux", "is_macos", "is_windows"]
+__all__ = [
+    "current_platform",
+    "host_arch",
+    "is_linux",
+    "is_macos",
+    "is_windows",
+    "normalize_arch",
+]
 
 Platform = Literal["linux", "macos", "windows", "other"]
+Architecture = Literal["x86_64", "aarch64"]
+
+_ARCH_ALIASES: dict[str, Architecture] = {
+    "x86_64": "x86_64",
+    "amd64": "x86_64",
+    "x64": "x86_64",
+    "aarch64": "aarch64",
+    "arm64": "aarch64",
+}
+
+
+def normalize_arch(value: str) -> Architecture:
+    """Normalize common local and GitHub runner architecture spellings."""
+    normalized = value.strip().lower()
+    try:
+        return _ARCH_ALIASES[normalized]
+    except KeyError as exc:
+        raise ValueError(f"Unsupported architecture: {value or '(empty)'}") from exc
+
+
+def host_arch() -> Architecture:
+    """Return the normalized CI runner or local host architecture."""
+    return normalize_arch(os.environ.get("RUNNER_ARCH") or platform.machine())
 
 
 def is_windows() -> bool:

--- a/tools/common/proc.py
+++ b/tools/common/proc.py
@@ -9,14 +9,17 @@ Use ``run_text`` when you only care about stdout and want it as a string.
 
 from __future__ import annotations
 
+import shlex
+import shutil
 import subprocess
+import sys
 from typing import TYPE_CHECKING
 
 if TYPE_CHECKING:
     from collections.abc import Mapping, Sequence
     from pathlib import Path
 
-__all__ = ["run_bytes", "run_captured", "run_text"]
+__all__ = ["run_bytes", "run_captured", "run_tee", "run_text"]
 
 
 def run_bytes(
@@ -67,6 +70,47 @@ def run_captured(
         check=check,
         input=input_text,
     )
+
+
+def run_tee(
+    cmd: Sequence[str],
+    output_file: Path | str,
+    *,
+    cwd: Path | str | None = None,
+    env: Mapping[str, str] | None = None,
+) -> int:
+    """Stream combined output to the console and *output_file*; return the exit code.
+
+    Prefer a Bash pipeline when available so grandchildren retain a real stdout.
+    This avoids Gradle/javac deadlocks observed with a Python-owned pipe on
+    Windows runners. The direct streaming fallback supports hosts without Bash.
+    """
+    command = list(cmd)
+    log_path = str(output_file)
+    process_env = dict(env) if env is not None else None
+    bash = shutil.which("bash")
+    if bash:
+        quoted_cmd = " ".join(shlex.quote(part) for part in command)
+        script = f"set -o pipefail; {quoted_cmd} 2>&1 | tee {shlex.quote(log_path)}"
+        return subprocess.run(
+            [bash, "-c", script], cwd=cwd, env=process_env, check=False
+        ).returncode
+
+    with open(output_file, "w", encoding="utf-8") as log:
+        process = subprocess.Popen(
+            command,
+            cwd=cwd,
+            env=process_env,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.STDOUT,
+            text=True,
+        )
+        assert process.stdout is not None
+        for line in process.stdout:
+            sys.stdout.write(line)
+            log.write(line)
+        process.wait()
+        return process.returncode
 
 
 def run_text(

--- a/tools/common/proc.py
+++ b/tools/common/proc.py
@@ -13,11 +13,11 @@ import shlex
 import shutil
 import subprocess
 import sys
+from pathlib import Path
 from typing import TYPE_CHECKING
 
 if TYPE_CHECKING:
     from collections.abc import Mapping, Sequence
-    from pathlib import Path
 
 __all__ = ["run_bytes", "run_captured", "run_tee", "run_text"]
 
@@ -86,17 +86,17 @@ def run_tee(
     Windows runners. The direct streaming fallback supports hosts without Bash.
     """
     command = list(cmd)
-    log_path = str(output_file)
+    log_path = Path(output_file).resolve()
     process_env = dict(env) if env is not None else None
     bash = shutil.which("bash")
     if bash:
         quoted_cmd = " ".join(shlex.quote(part) for part in command)
-        script = f"set -o pipefail; {quoted_cmd} 2>&1 | tee {shlex.quote(log_path)}"
+        script = f"set -o pipefail; {quoted_cmd} 2>&1 | tee {shlex.quote(str(log_path))}"
         return subprocess.run(
             [bash, "-c", script], cwd=cwd, env=process_env, check=False
         ).returncode
 
-    with open(output_file, "w", encoding="utf-8") as log:
+    with log_path.open("w", encoding="utf-8") as log:
         process = subprocess.Popen(
             command,
             cwd=cwd,

--- a/tools/common/tool_version.py
+++ b/tools/common/tool_version.py
@@ -17,11 +17,21 @@ from .proc import run_captured
 if TYPE_CHECKING:
     from collections.abc import Sequence
 
-__all__ = ["DEFAULT_VERSION_RE", "probe_version", "uv_lock_version"]
+__all__ = ["DEFAULT_VERSION_RE", "probe_version", "uv_lock_version", "version_prefix_matches"]
 
 DEFAULT_VERSION_RE: re.Pattern[str] = re.compile(r"(\d+)\.(\d+)(?:\.(\d+))?")
 
 _UV_LOCK = Path(__file__).resolve().parents[1] / "uv.lock"
+
+
+def version_prefix_matches(installed: tuple[int, ...], expected: str) -> bool:
+    """Compare installed and expected versions over their shared components."""
+    try:
+        wanted = tuple(int(part) for part in expected.split("."))
+    except ValueError:
+        return False
+    compare_len = min(len(installed), len(wanted))
+    return compare_len > 0 and installed[:compare_len] == wanted[:compare_len]
 
 
 def uv_lock_version(package: str, *, lock_path: Path | None = None) -> str | None:
@@ -38,7 +48,9 @@ def uv_lock_version(package: str, *, lock_path: Path | None = None) -> str | Non
     except OSError:
         return None
     match = re.search(
-        r'\[\[package\]\]\s*\nname\s*=\s*"' + re.escape(package) + r'"\s*\nversion\s*=\s*"([\d.]+)"',
+        r'\[\[package\]\]\s*\nname\s*=\s*"'
+        + re.escape(package)
+        + r'"\s*\nversion\s*=\s*"([\d.]+)"',
         text,
     )
     return match.group(1) if match else None

--- a/tools/common/xml.py
+++ b/tools/common/xml.py
@@ -1,0 +1,24 @@
+"""Safe XML parsing helpers."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import TYPE_CHECKING
+from xml.etree.ElementTree import ParseError as XMLParseError
+
+from defusedxml.ElementTree import parse as _xml_parse_impl
+
+if TYPE_CHECKING:
+    from os import PathLike
+    from xml.etree.ElementTree import ElementTree
+
+__all__ = ["XMLParseError", "xml_parse"]
+
+
+def xml_parse(path: str | PathLike[str]) -> ElementTree:
+    """Parse XML safely, rejecting entity declarations."""
+    xml_path = Path(path)
+    text = xml_path.read_text(encoding="utf-8", errors="replace")
+    if "<!ENTITY" in text:
+        raise XMLParseError("ENTITY declarations are not allowed")
+    return _xml_parse_impl(xml_path)

--- a/tools/common/xml.py
+++ b/tools/common/xml.py
@@ -2,10 +2,10 @@
 
 from __future__ import annotations
 
-from pathlib import Path
 from typing import TYPE_CHECKING
 from xml.etree.ElementTree import ParseError as XMLParseError
 
+from defusedxml.common import DefusedXmlException
 from defusedxml.ElementTree import parse as _xml_parse_impl
 
 if TYPE_CHECKING:
@@ -17,8 +17,7 @@ __all__ = ["XMLParseError", "xml_parse"]
 
 def xml_parse(path: str | PathLike[str]) -> ElementTree:
     """Parse XML safely, rejecting entity declarations."""
-    xml_path = Path(path)
-    text = xml_path.read_text(encoding="utf-8", errors="replace")
-    if "<!ENTITY" in text:
-        raise XMLParseError("ENTITY declarations are not allowed")
-    return _xml_parse_impl(xml_path)
+    try:
+        return _xml_parse_impl(path)
+    except DefusedXmlException as exc:
+        raise XMLParseError(str(exc)) from exc

--- a/tools/setup/read_config.py
+++ b/tools/setup/read_config.py
@@ -39,6 +39,7 @@ from common.build_config import (  # noqa: E402
     find_build_config,
     github_output_values,
     load_build_config,
+    lookup_dotted,
 )
 from common.gh_actions import append_github_env, write_github_output  # noqa: E402
 
@@ -113,13 +114,7 @@ def main() -> int:
         key = args.get.lower()  # Normalize to lowercase
         if key == "gstreamer_version":
             key = "gstreamer.version.default"
-        value: Any = config
-        for part in key.split("."):
-            if isinstance(value, dict) and part in value:
-                value = value[part]
-            else:
-                value = None
-                break
+        value: Any = lookup_dotted(config, key, None)
         if value is not None:
             print(value if isinstance(value, (str, int, float, bool)) else json.dumps(value))
             return 0

--- a/tools/tests/test_artifact_metadata.py
+++ b/tools/tests/test_artifact_metadata.py
@@ -64,3 +64,11 @@ def test_read_wraps_invalid_json(tmp_path: Path) -> None:
 
     with pytest.raises(ArtifactMetadataError, match="invalid artifact metadata file"):
         read_run_artifact_metadata(path)
+
+
+def test_write_rejects_invalid_run_ids_and_artifacts(tmp_path: Path) -> None:
+    path = tmp_path / "artifacts.json"
+    with pytest.raises(ArtifactMetadataError, match="run IDs"):
+        write_run_artifact_metadata(path, {0: []})
+    with pytest.raises(ArtifactMetadataError, match="artifact name"):
+        write_run_artifact_metadata(path, {42: [{"name": "", "size_in_bytes": 1}]})

--- a/tools/tests/test_artifact_metadata.py
+++ b/tools/tests/test_artifact_metadata.py
@@ -1,0 +1,66 @@
+"""Tests for validated GitHub Actions artifact metadata interchange."""
+
+from __future__ import annotations
+
+import json
+from typing import TYPE_CHECKING
+
+import pytest
+from common.artifact_metadata import (
+    ArtifactMetadataError,
+    read_run_artifact_metadata,
+    write_run_artifact_metadata,
+)
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+
+def test_run_artifact_metadata_round_trip(tmp_path: Path) -> None:
+    path = tmp_path / "nested" / "artifacts.json"
+    artifacts = {
+        42: [
+            {"name": "QGroundControl.AppImage", "size_in_bytes": 200, "ignored": True},
+            {"name": "coverage-report", "size_in_bytes": 100},
+        ]
+    }
+
+    write_run_artifact_metadata(path, artifacts)
+
+    assert read_run_artifact_metadata(path) == {
+        42: [
+            {"name": "QGroundControl.AppImage", "size_in_bytes": 200},
+            {"name": "coverage-report", "size_in_bytes": 100},
+        ]
+    }
+
+
+@pytest.mark.parametrize(
+    "payload",
+    [
+        [],
+        {},
+        {"runs": []},
+        {"runs": {"0": []}},
+        {"runs": {"run": []}},
+        {"runs": {"42": {}}},
+        {"runs": {"42": ["artifact"]}},
+        {"runs": {"42": [{"name": "", "size_in_bytes": 1}]}},
+        {"runs": {"42": [{"name": "QGC", "size_in_bytes": -1}]}},
+        {"runs": {"42": [{"name": "QGC", "size_in_bytes": True}]}},
+    ],
+)
+def test_read_rejects_invalid_schema(tmp_path: Path, payload: object) -> None:
+    path = tmp_path / "artifacts.json"
+    path.write_text(json.dumps(payload), encoding="utf-8")
+
+    with pytest.raises(ArtifactMetadataError):
+        read_run_artifact_metadata(path)
+
+
+def test_read_wraps_invalid_json(tmp_path: Path) -> None:
+    path = tmp_path / "artifacts.json"
+    path.write_text("{invalid", encoding="utf-8")
+
+    with pytest.raises(ArtifactMetadataError, match="invalid artifact metadata file"):
+        read_run_artifact_metadata(path)

--- a/tools/tests/test_artifact_metadata.py
+++ b/tools/tests/test_artifact_metadata.py
@@ -42,6 +42,7 @@ def test_run_artifact_metadata_round_trip(tmp_path: Path) -> None:
         {},
         {"runs": []},
         {"runs": {"0": []}},
+        {"runs": {"042": []}},
         {"runs": {"run": []}},
         {"runs": {"42": {}}},
         {"runs": {"42": ["artifact"]}},

--- a/tools/tests/test_aws.py
+++ b/tools/tests/test_aws.py
@@ -1,0 +1,78 @@
+"""Tests for allowlisted public S3 operations."""
+
+from __future__ import annotations
+
+import subprocess
+
+import pytest
+from common import aws
+
+
+def test_public_s3_uri_rejects_unapproved_or_unsafe_destinations() -> None:
+    assert aws.public_s3_uri("qgroundcontrol", "builds/main/qgc.bin") == (
+        "s3://qgroundcontrol/builds/main/qgc.bin"
+    )
+    for bucket, key in (
+        ("other", "builds/main/qgc.bin"),
+        ("qgroundcontrol", "../secret"),
+        ("qgroundcontrol", "/absolute"),
+        ("qgroundcontrol", "path\\windows"),
+    ):
+        with pytest.raises(ValueError):
+            aws.public_s3_uri(bucket, key)
+
+
+def test_s3_object_exists_uses_validated_bucket_and_key(monkeypatch: pytest.MonkeyPatch) -> None:
+    calls: list[list[str]] = []
+
+    def run(command, **_kwargs):
+        calls.append(command)
+        return subprocess.CompletedProcess(command, 0, "", "")
+
+    monkeypatch.setattr(aws, "run_captured", run)
+    assert aws.s3_object_exists("qgroundcontrol", "builds/main/qgc.bin") is True
+    assert calls == [
+        [
+            "aws",
+            "s3api",
+            "head-object",
+            "--bucket",
+            "qgroundcontrol",
+            "--key",
+            "builds/main/qgc.bin",
+        ]
+    ]
+
+
+def test_upload_public_file_builds_command_and_surfaces_failure(
+    tmp_path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    source = tmp_path / "qgc.bin"
+    source.write_bytes(b"qgc")
+    calls: list[list[str]] = []
+
+    def run(command, **_kwargs):
+        calls.append(command)
+        return subprocess.CompletedProcess(command, 0, "", "")
+
+    monkeypatch.setattr(aws, "run_captured", run)
+    aws.upload_public_file(source, "qgroundcontrol", "latest/qgc.bin")
+    assert calls == [
+        [
+            "aws",
+            "s3",
+            "cp",
+            str(source),
+            "s3://qgroundcontrol/latest/qgc.bin",
+            "--acl",
+            "public-read",
+        ]
+    ]
+
+    monkeypatch.setattr(
+        aws,
+        "run_captured",
+        lambda command, **_kwargs: subprocess.CompletedProcess(command, 1, "", "denied"),
+    )
+    with pytest.raises(RuntimeError, match="denied"):
+        aws.upload_public_file(source, "qgroundcontrol", "latest/qgc.bin")

--- a/tools/tests/test_aws.py
+++ b/tools/tests/test_aws.py
@@ -43,6 +43,13 @@ def test_s3_object_exists_uses_validated_bucket_and_key(monkeypatch: pytest.Monk
         ]
     ]
 
+    monkeypatch.setattr(
+        aws,
+        "run_captured",
+        lambda command, **_kwargs: subprocess.CompletedProcess(command, 1, "", "missing"),
+    )
+    assert aws.s3_object_exists("qgroundcontrol", "builds/main/missing.bin") is False
+
 
 def test_upload_public_file_builds_command_and_surfaces_failure(
     tmp_path, monkeypatch: pytest.MonkeyPatch
@@ -76,3 +83,6 @@ def test_upload_public_file_builds_command_and_surfaces_failure(
     )
     with pytest.raises(RuntimeError, match="denied"):
         aws.upload_public_file(source, "qgroundcontrol", "latest/qgc.bin")
+
+    with pytest.raises(ValueError, match="Artifact not found"):
+        aws.upload_public_file(tmp_path / "missing.bin", "qgroundcontrol", "latest/missing.bin")

--- a/tools/tests/test_build_config.py
+++ b/tools/tests/test_build_config.py
@@ -1,0 +1,16 @@
+"""Tests for shared build-configuration primitives."""
+
+from __future__ import annotations
+
+import pytest
+from common.build_config import lookup_dotted
+
+
+def test_lookup_dotted_distinguishes_null_missing_and_values() -> None:
+    config = {"qt": {"version": 611, "minimum_version": None}}
+
+    assert lookup_dotted(config, "qt.version") == 611
+    assert lookup_dotted(config, "qt.minimum_version", "fallback") is None
+    assert lookup_dotted(config, "qt.missing", "fallback") == "fallback"
+    with pytest.raises(KeyError, match=r"qt\.missing"):
+        lookup_dotted(config, "qt.missing")

--- a/tools/tests/test_cmake.py
+++ b/tools/tests/test_cmake.py
@@ -1,0 +1,22 @@
+"""Tests for shared CMake metadata parsing."""
+
+from __future__ import annotations
+
+from common.cmake import read_cache_dict, read_cache_var
+
+
+def test_cache_parser_matches_complete_names_and_types(tmp_path) -> None:
+    cache = tmp_path / "CMakeCache.txt"
+    cache.write_text(
+        "CMAKE_BUILD_TYPE:STRING=Release\n"
+        "QGC_COVERAGE_LINE_THRESHOLD:STRING=42\n"
+        "QGC_ENABLE_GST:BOOL=ON\n",
+        encoding="utf-8",
+    )
+
+    assert read_cache_dict(cache)["CMAKE_BUILD_TYPE"] == "Release"
+    assert read_cache_var(cache, "QGC_COVERAGE_LINE_THRESHOLD") == "42"
+    assert read_cache_var(cache, "QGC_ENABLE_GST") == "ON"
+    for name in ("ABSENT_VAR", "QGC_COVERAGE_LINE"):
+        assert read_cache_var(cache, name) is None
+    assert read_cache_var(tmp_path / "missing", "X") is None

--- a/tools/tests/test_cobertura.py
+++ b/tools/tests/test_cobertura.py
@@ -36,3 +36,15 @@ def test_rejects_invalid_unsafe_or_metric_free_reports(tmp_path) -> None:
         report.write_text(content, encoding="utf-8")
         with pytest.raises(CoberturaError):
             read_cobertura(report)
+
+
+@pytest.mark.parametrize("rate", ["nan", "inf", "-0.01", "1.01"])
+def test_rejects_invalid_coverage_rates(tmp_path, rate: str) -> None:
+    report = tmp_path / "coverage.xml"
+    report.write_text(f'<coverage line-rate="{rate}"/>', encoding="utf-8")
+    with pytest.raises(CoberturaError, match="line-rate"):
+        read_cobertura(report)
+
+    report.write_text(f'<coverage line-rate="0.5" branch-rate="{rate}"/>', encoding="utf-8")
+    with pytest.raises(CoberturaError, match="branch-rate"):
+        read_cobertura(report)

--- a/tools/tests/test_cobertura.py
+++ b/tools/tests/test_cobertura.py
@@ -1,0 +1,38 @@
+"""Tests for shared Cobertura metrics parsing."""
+
+from __future__ import annotations
+
+import pytest
+from common.cobertura import CoberturaError, CoberturaMetrics, read_cobertura
+
+
+def test_reads_root_and_package_metrics(tmp_path) -> None:
+    report = tmp_path / "coverage.xml"
+    cases = [
+        (
+            '<coverage line-rate="0.75" branch-rate="0.50" lines-valid="100" lines-covered="75"/>',
+            CoberturaMetrics(75.0, 50.0, 100, 75),
+        ),
+        (
+            '<coverage><packages><package line-rate="0.62" branch-rate="0.40"/>'
+            "</packages></coverage>",
+            CoberturaMetrics(62.0, 40.0, 0, 0),
+        ),
+        ('<coverage line-rate="0.80"/>', CoberturaMetrics(80.0, None, 0, 0)),
+    ]
+    for content, expected in cases:
+        report.write_text(content, encoding="utf-8")
+        assert read_cobertura(report) == expected
+
+
+def test_rejects_invalid_unsafe_or_metric_free_reports(tmp_path) -> None:
+    report = tmp_path / "coverage.xml"
+    for content in (
+        "<coverage",
+        '<!DOCTYPE coverage [<!ENTITY xxe SYSTEM "file:///etc/passwd">]>'
+        '<coverage line-rate="0.75"/>',
+        "<coverage/>",
+    ):
+        report.write_text(content, encoding="utf-8")
+        with pytest.raises(CoberturaError):
+            read_cobertura(report)

--- a/tools/tests/test_common_docs.py
+++ b/tools/tests/test_common_docs.py
@@ -1,0 +1,19 @@
+"""Keep the shared-tooling module index complete and free of stale entries."""
+
+from __future__ import annotations
+
+import re
+
+from ._helpers import TOOLS_DIR
+
+
+def test_common_readme_indexes_every_shared_module() -> None:
+    common_dir = TOOLS_DIR / "common"
+    actual = {
+        path.name
+        for path in common_dir.iterdir()
+        if path.is_file() and path.name not in {"README.md", "__init__.py"}
+    }
+    readme = (common_dir / "README.md").read_text(encoding="utf-8")
+    documented = set(re.findall(r"^\| `([^`]+)` \|", readme, flags=re.MULTILINE))
+    assert documented == actual

--- a/tools/tests/test_common_import_isolation.py
+++ b/tools/tests/test_common_import_isolation.py
@@ -17,8 +17,11 @@ import pytest
 from ._helpers import TOOLS_DIR
 
 CI_CRITICAL_SUBMODULES = [
+    "artifact_metadata",
+    "aws",
     "gh_actions",
     "build_config",
+    "cobertura",
     "git",
     "proc",
     "github_runs",
@@ -26,6 +29,7 @@ CI_CRITICAL_SUBMODULES = [
     "format",
     "io",
     "tool_version",
+    "xml",
 ]
 
 

--- a/tools/tests/test_common_import_isolation.py
+++ b/tools/tests/test_common_import_isolation.py
@@ -21,6 +21,7 @@ CI_CRITICAL_SUBMODULES = [
     "aws",
     "gh_actions",
     "build_config",
+    "cmake",
     "cobertura",
     "git",
     "proc",

--- a/tools/tests/test_deps.py
+++ b/tools/tests/test_deps.py
@@ -87,3 +87,9 @@ def test_pip_install_falls_back_to_current_interpreter(monkeypatch: pytest.Monke
     monkeypatch.setattr(deps.subprocess, "run", lambda command, **_kwargs: calls.append(command))
     pip_install(["gcovr"], quiet=False)
     assert calls == [[sys.executable, "-m", "pip", "install", "gcovr"]]
+
+
+def test_pip_install_remains_available_through_lazy_facade() -> None:
+    from common import pip_install as facade_pip_install
+
+    assert facade_pip_install is pip_install

--- a/tools/tests/test_deps.py
+++ b/tools/tests/test_deps.py
@@ -3,11 +3,14 @@
 from __future__ import annotations
 
 import shutil
+import subprocess
+import sys
 from pathlib import Path
 from unittest.mock import patch
 
+import common.deps as deps
 import pytest
-from common.deps import check_dependencies, require_tool
+from common.deps import check_dependencies, pip_install, require_tool
 from common.errors import ToolNotFoundError
 
 
@@ -21,6 +24,7 @@ class TestCheckDependencies:
 
     def test_some_missing(self):
         """Returns names of missing tools."""
+
         def fake_which(name):
             return "/usr/bin/cmake" if name == "cmake" else None
 
@@ -45,12 +49,41 @@ class TestRequireTool:
 
     def test_not_found_raises(self):
         """Raises ToolNotFoundError when tool is missing."""
-        with patch.object(shutil, "which", return_value=None), \
-             pytest.raises(ToolNotFoundError, match="cmake"):
+        with (
+            patch.object(shutil, "which", return_value=None),
+            pytest.raises(ToolNotFoundError, match="cmake"),
+        ):
             require_tool("cmake")
 
     def test_hint_in_message(self):
         """Hint text appears in the error message."""
-        with patch.object(shutil, "which", return_value=None), \
-             pytest.raises(ToolNotFoundError, match="pip install"):
+        with (
+            patch.object(shutil, "which", return_value=None),
+            pytest.raises(ToolNotFoundError, match="pip install"),
+        ):
             require_tool("gcovr", hint="pip install gcovr")
+
+
+def test_pip_install_prefers_project_venv_with_uv(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    python = (
+        tmp_path / ".venv" / ("Scripts/python.exe" if sys.platform == "win32" else "bin/python")
+    )
+    python.parent.mkdir(parents=True)
+    python.touch()
+    calls: list[list[str]] = []
+    monkeypatch.setattr(shutil, "which", lambda name: "/usr/bin/uv" if name == "uv" else None)
+    monkeypatch.setattr("common.file_traversal.find_repo_root", lambda: tmp_path)
+    monkeypatch.setattr(subprocess, "run", lambda command, **_kwargs: calls.append(command))
+
+    pip_install(["pre-commit"])
+    assert calls == [["uv", "pip", "install", "--python", str(python), "pre-commit"]]
+
+
+def test_pip_install_falls_back_to_current_interpreter(monkeypatch: pytest.MonkeyPatch) -> None:
+    calls: list[list[str]] = []
+    monkeypatch.setattr(shutil, "which", lambda _name: None)
+    monkeypatch.setattr(deps.subprocess, "run", lambda command, **_kwargs: calls.append(command))
+    pip_install(["gcovr"], quiet=False)
+    assert calls == [[sys.executable, "-m", "pip", "install", "gcovr"]]

--- a/tools/tests/test_gh_actions.py
+++ b/tools/tests/test_gh_actions.py
@@ -7,6 +7,7 @@ import json
 import os
 from unittest.mock import patch
 
+import pytest
 from common import gh_actions as mod
 
 from ._helpers import completed
@@ -57,6 +58,20 @@ def test_list_run_artifacts_rejects_invalid_run_id() -> None:
         assert "run_id must be an integer" in str(exc)
     else:
         raise AssertionError("Expected ValueError for invalid run_id")
+
+
+def test_require_repository_prefers_override_and_requires_value(capsys) -> None:
+    with patch.dict(
+        os.environ,
+        {"GH_REPO": "override/repo", "GITHUB_REPOSITORY": "event/repo"},
+        clear=True,
+    ):
+        assert mod.require_repository() == "override/repo"
+    with patch.dict(os.environ, {"GITHUB_REPOSITORY": "event/repo"}, clear=True):
+        assert mod.require_repository() == "event/repo"
+    with patch.dict(os.environ, {}, clear=True), pytest.raises(SystemExit):
+        mod.require_repository()
+    assert capsys.readouterr().out == "::error::GH_REPO or GITHUB_REPOSITORY must be set\n"
 
 
 class TestIsForkPr:

--- a/tools/tests/test_gh_actions.py
+++ b/tools/tests/test_gh_actions.py
@@ -69,6 +69,12 @@ def test_require_repository_prefers_override_and_requires_value(capsys) -> None:
         assert mod.require_repository() == "override/repo"
     with patch.dict(os.environ, {"GITHUB_REPOSITORY": "event/repo"}, clear=True):
         assert mod.require_repository() == "event/repo"
+    with patch.dict(
+        os.environ,
+        {"GH_REPO": "  ", "GITHUB_REPOSITORY": " fallback/repo "},
+        clear=True,
+    ):
+        assert mod.require_repository() == "fallback/repo"
     with patch.dict(os.environ, {}, clear=True), pytest.raises(SystemExit):
         mod.require_repository()
     assert capsys.readouterr().out == "::error::GH_REPO or GITHUB_REPOSITORY must be set\n"

--- a/tools/tests/test_github_runs.py
+++ b/tools/tests/test_github_runs.py
@@ -1,0 +1,57 @@
+"""Tests for cached GitHub workflow-run handling."""
+
+from __future__ import annotations
+
+import json
+from typing import TYPE_CHECKING
+
+import pytest
+from common.github_runs import (
+    WorkflowRunsFileError,
+    load_workflow_runs,
+    resolve_workflow_runs,
+)
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+
+def test_load_workflow_runs_validates_json_list(tmp_path: Path) -> None:
+    path = tmp_path / "runs.json"
+    runs = [{"id": 1, "name": "Linux"}, {"id": 2, "name": "Windows"}]
+    path.write_text(json.dumps(runs), encoding="utf-8")
+    assert load_workflow_runs(path) == runs
+
+    for payload in ({"id": 1}, ["invalid"]):
+        path.write_text(json.dumps(payload), encoding="utf-8")
+        with pytest.raises(WorkflowRunsFileError):
+            load_workflow_runs(path)
+
+
+def test_load_workflow_runs_wraps_file_and_json_errors(tmp_path: Path) -> None:
+    with pytest.raises(WorkflowRunsFileError, match="failed to read runs file"):
+        load_workflow_runs(tmp_path / "missing.json")
+
+    path = tmp_path / "runs.json"
+    path.write_text("{invalid", encoding="utf-8")
+    with pytest.raises(WorkflowRunsFileError, match="failed to read runs file"):
+        load_workflow_runs(path)
+
+
+def test_resolve_workflow_runs_uses_cache_or_fetcher(tmp_path: Path, capsys) -> None:
+    path = tmp_path / "runs.json"
+    path.write_text('[{"id": 2}]', encoding="utf-8")
+    calls: list[tuple[str, str]] = []
+
+    def fetcher(repo: str, sha: str) -> list[dict[str, int]]:
+        calls.append((repo, sha))
+        return [{"id": 3}]
+
+    assert resolve_workflow_runs("owner/repo", "abc", str(path), fetcher) == [{"id": 2}]
+    assert calls == []
+    assert resolve_workflow_runs("owner/repo", "abc", "", fetcher) == [{"id": 3}]
+    assert calls == [("owner/repo", "abc")]
+
+    path.write_text("{invalid", encoding="utf-8")
+    assert resolve_workflow_runs("owner/repo", "abc", str(path), fetcher) is None
+    assert "failed to read runs file" in capsys.readouterr().err

--- a/tools/tests/test_io.py
+++ b/tools/tests/test_io.py
@@ -94,6 +94,9 @@ def test_write_text_if_changed_and_sha256_file(tmp_path: Path) -> None:
     assert sha256_file(payload, chunk_size=1) == (
         "ba7816bf8f01cfea414140de5dae2223b00361a396177a9cb410ff61f20015ad"
     )
+    for invalid_size in (0, -1):
+        with pytest.raises(ValueError, match="chunk_size must be a positive integer"):
+            sha256_file(payload, chunk_size=invalid_size)
 
 
 def test_extract_tar_data_rejects_traversal(tmp_path: Path) -> None:

--- a/tools/tests/test_io.py
+++ b/tools/tests/test_io.py
@@ -3,10 +3,22 @@
 
 from __future__ import annotations
 
+import io
+import tarfile
+import zipfile
 from typing import TYPE_CHECKING
 
 import pytest
-from common.io import atomic_write, read_json, read_toml, write_json
+from common.io import (
+    atomic_write,
+    extract_tar_data,
+    extract_zip_safe,
+    read_json,
+    read_toml,
+    sha256_file,
+    write_json,
+    write_text_if_changed,
+)
 
 if TYPE_CHECKING:
     from pathlib import Path
@@ -56,7 +68,9 @@ def test_atomic_write_overwrites(tmp_path: Path) -> None:
     assert target.read_text(encoding="utf-8") == "new"
 
 
-def test_atomic_write_cleans_up_tmp_on_failure(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+def test_atomic_write_cleans_up_tmp_on_failure(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
     target = tmp_path / "z.txt"
 
     def boom(*args: object, **kwargs: object) -> None:
@@ -66,3 +80,44 @@ def test_atomic_write_cleans_up_tmp_on_failure(tmp_path: Path, monkeypatch: pyte
     with pytest.raises(OSError, match="disk full"):
         atomic_write(target, "x")
     assert not list(tmp_path.glob(".z.txt.*"))
+
+
+def test_write_text_if_changed_and_sha256_file(tmp_path: Path) -> None:
+    target = tmp_path / "generated" / "output.txt"
+    assert write_text_if_changed(target, "first") is True
+    assert write_text_if_changed(target, "first") is False
+    assert write_text_if_changed(target, "second") is True
+    assert target.read_text(encoding="utf-8") == "second"
+
+    payload = tmp_path / "payload.bin"
+    payload.write_bytes(b"abc")
+    assert sha256_file(payload, chunk_size=1) == (
+        "ba7816bf8f01cfea414140de5dae2223b00361a396177a9cb410ff61f20015ad"
+    )
+
+
+def test_extract_tar_data_rejects_traversal(tmp_path: Path) -> None:
+    archive_path = tmp_path / "unsafe.tar"
+    with tarfile.open(archive_path, "w") as archive:
+        info = tarfile.TarInfo("../escape.txt")
+        info.size = 1
+        archive.addfile(info, io.BytesIO(b"x"))
+
+    with pytest.raises(tarfile.FilterError):
+        extract_tar_data(archive_path, tmp_path / "output")
+    assert not (tmp_path / "escape.txt").exists()
+
+
+def test_extract_zip_safe_allows_nested_files_and_rejects_traversal(tmp_path: Path) -> None:
+    unsafe_archive = tmp_path / "unsafe.zip"
+    with zipfile.ZipFile(unsafe_archive, "w") as archive:
+        archive.writestr("../escape.txt", "x")
+    with pytest.raises(ValueError, match="Unsafe zip member"):
+        extract_zip_safe(unsafe_archive, tmp_path / "unsafe-output")
+    assert not (tmp_path / "escape.txt").exists()
+
+    safe_archive = tmp_path / "safe.zip"
+    with zipfile.ZipFile(safe_archive, "w") as archive:
+        archive.writestr("dir/file.txt", "content")
+    extract_zip_safe(safe_archive, tmp_path / "safe-output")
+    assert (tmp_path / "safe-output" / "dir" / "file.txt").read_text(encoding="utf-8") == "content"

--- a/tools/tests/test_net.py
+++ b/tools/tests/test_net.py
@@ -1,0 +1,18 @@
+#!/usr/bin/env python3
+"""Tests for tools/common/net.py."""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock, patch
+
+from common.net import read_url_text
+
+
+def test_read_url_text_decodes_response() -> None:
+    response = MagicMock()
+    response.__enter__.return_value.read.return_value = b"hello\n"
+    with patch("common.net.urllib.request.urlopen", return_value=response) as urlopen:
+        assert read_url_text("https://example.test/value", timeout=7) == "hello\n"
+    request = urlopen.call_args.args[0]
+    assert request.full_url == "https://example.test/value"
+    assert urlopen.call_args.kwargs["timeout"] == 7

--- a/tools/tests/test_platform.py
+++ b/tools/tests/test_platform.py
@@ -3,12 +3,15 @@
 
 from __future__ import annotations
 
-from typing import TYPE_CHECKING
-
-from common.platform import current_platform, is_linux, is_macos, is_windows
-
-if TYPE_CHECKING:
-    import pytest
+import pytest
+from common.platform import (
+    current_platform,
+    host_arch,
+    is_linux,
+    is_macos,
+    is_windows,
+    normalize_arch,
+)
 
 
 def test_is_windows(monkeypatch: pytest.MonkeyPatch) -> None:
@@ -55,3 +58,27 @@ def test_current_platform_linux(monkeypatch: pytest.MonkeyPatch) -> None:
 def test_current_platform_other(monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.setattr("sys.platform", "freebsd14")
     assert current_platform() == "other"
+
+
+def test_architecture_normalization() -> None:
+    expected = {
+        "x86_64": "x86_64",
+        "amd64": "x86_64",
+        "X64": "x86_64",
+        "aarch64": "aarch64",
+        "arm64": "aarch64",
+        "ARM64": "aarch64",
+    }
+    for value, architecture in expected.items():
+        assert normalize_arch(value) == architecture
+    with pytest.raises(ValueError, match="Unsupported architecture"):
+        normalize_arch("riscv64")
+
+
+def test_host_arch_prefers_runner_then_machine(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("RUNNER_ARCH", "ARM64")
+    monkeypatch.setattr("platform.machine", lambda: "x86_64")
+    assert host_arch() == "aarch64"
+    monkeypatch.delenv("RUNNER_ARCH")
+    monkeypatch.setattr("platform.machine", lambda: "AMD64")
+    assert host_arch() == "x86_64"

--- a/tools/tests/test_proc.py
+++ b/tools/tests/test_proc.py
@@ -59,3 +59,17 @@ def test_run_tee_falls_back_without_bash(tmp_path: Path, monkeypatch: pytest.Mon
     monkeypatch.setattr("common.proc.shutil.which", lambda _name: None)
     assert run_tee([sys.executable, "-c", "print('fallback')"], output) == 0
     assert output.read_text(encoding="utf-8").strip() == "fallback"
+
+
+def test_run_tee_resolves_relative_output_before_changing_cwd(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    invocation_dir = tmp_path / "invocation"
+    working_dir = tmp_path / "working"
+    invocation_dir.mkdir()
+    working_dir.mkdir()
+    monkeypatch.chdir(invocation_dir)
+
+    assert run_tee([sys.executable, "-c", "print('relative')"], "command.log", cwd=working_dir) == 0
+    assert (invocation_dir / "command.log").read_text(encoding="utf-8").strip() == "relative"
+    assert not (working_dir / "command.log").exists()

--- a/tools/tests/test_proc.py
+++ b/tools/tests/test_proc.py
@@ -5,9 +5,13 @@ from __future__ import annotations
 
 import subprocess
 import sys
+from typing import TYPE_CHECKING
 
 import pytest
 from common.proc import run_captured, run_tee, run_text
+
+if TYPE_CHECKING:
+    from pathlib import Path
 
 
 def test_run_captured_returns_completed_process() -> None:
@@ -44,7 +48,14 @@ def test_run_text_default_on_nonzero_exit() -> None:
     assert run_text(["false"], default="fb") == "fb"
 
 
-def test_run_tee_streams_output_and_returns_exit_code(tmp_path) -> None:
+def test_run_tee_streams_output_and_returns_exit_code(tmp_path: Path) -> None:
     output = tmp_path / "command.log"
     assert run_tee([sys.executable, "-c", "print('streamed')"], output) == 0
     assert output.read_text(encoding="utf-8").strip() == "streamed"
+
+
+def test_run_tee_falls_back_without_bash(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    output = tmp_path / "fallback.log"
+    monkeypatch.setattr("common.proc.shutil.which", lambda _name: None)
+    assert run_tee([sys.executable, "-c", "print('fallback')"], output) == 0
+    assert output.read_text(encoding="utf-8").strip() == "fallback"

--- a/tools/tests/test_proc.py
+++ b/tools/tests/test_proc.py
@@ -4,9 +4,10 @@
 from __future__ import annotations
 
 import subprocess
+import sys
 
 import pytest
-from common.proc import run_captured, run_text
+from common.proc import run_captured, run_tee, run_text
 
 
 def test_run_captured_returns_completed_process() -> None:
@@ -41,3 +42,9 @@ def test_run_text_default_on_missing_binary() -> None:
 
 def test_run_text_default_on_nonzero_exit() -> None:
     assert run_text(["false"], default="fb") == "fb"
+
+
+def test_run_tee_streams_output_and_returns_exit_code(tmp_path) -> None:
+    output = tmp_path / "command.log"
+    assert run_tee([sys.executable, "-c", "print('streamed')"], output) == 0
+    assert output.read_text(encoding="utf-8").strip() == "streamed"

--- a/tools/tests/test_tool_version.py
+++ b/tools/tests/test_tool_version.py
@@ -6,7 +6,7 @@ from __future__ import annotations
 import re
 from unittest.mock import patch
 
-from common.tool_version import probe_version
+from common.tool_version import probe_version, version_prefix_matches
 
 from ._helpers import completed
 
@@ -78,3 +78,13 @@ def test_probe_version_custom_args() -> None:
         probe_version("git", args=("version",))
         run.assert_called_once()
         assert run.call_args[0][0] == ["git", "version"]
+
+
+def test_version_prefix_matches_shared_components() -> None:
+    for actual, expected, matches in (
+        ((4, 13), "4.13.6", True),
+        ((4, 13, 6), "4.13", True),
+        ((4, 12, 6), "4.13.6", False),
+        ((4, 13, 6), "latest", False),
+    ):
+        assert version_prefix_matches(actual, expected) is matches

--- a/tools/tests/test_xml.py
+++ b/tools/tests/test_xml.py
@@ -15,6 +15,8 @@ def test_parser_returns_trees_for_plain_and_doctype_xml(tmp_path: Path) -> None:
     for name, content, tag in (
         ("plain.xml", "<root><child/></root>", "root"),
         ("doctype.xml", "<!DOCTYPE foo [<!ELEMENT foo ANY>]><foo/>", "foo"),
+        ("comment.xml", "<root><!-- harmless <!ENTITY text> --></root>", "root"),
+        ("cdata.xml", "<root><![CDATA[harmless <!ENTITY text>]]></root>", "root"),
     ):
         path = tmp_path / name
         path.write_text(content, encoding="utf-8")

--- a/tools/tests/test_xml.py
+++ b/tools/tests/test_xml.py
@@ -1,0 +1,31 @@
+"""Tests for safe XML parsing."""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+import pytest
+from common.xml import XMLParseError, xml_parse
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+
+def test_parser_returns_trees_for_plain_and_doctype_xml(tmp_path: Path) -> None:
+    for name, content, tag in (
+        ("plain.xml", "<root><child/></root>", "root"),
+        ("doctype.xml", "<!DOCTYPE foo [<!ELEMENT foo ANY>]><foo/>", "foo"),
+    ):
+        path = tmp_path / name
+        path.write_text(content, encoding="utf-8")
+        tree = xml_parse(path)
+        root = tree.getroot()
+        assert root is not None
+        assert root.tag == tag
+
+
+def test_parser_rejects_entity_declarations(tmp_path: Path) -> None:
+    path = tmp_path / "entity.xml"
+    path.write_text('<!DOCTYPE foo [<!ENTITY xxe "bad">]><foo/>', encoding="utf-8")
+    with pytest.raises(XMLParseError):
+        xml_parse(path)


### PR DESCRIPTION
## Summary

- add dependency-light helpers for safe archive extraction, hashing, write-if-changed output, process teeing, URL reads, architecture normalization, and version matching
- move `pip_install` into `common.deps` while preserving the lazy `from common import pip_install` facade
- add validated workflow-run and artifact metadata interchange for GitHub Actions reporting
- add allowlisted public S3 operations and safe XML/Cobertura parsing
- add shared CMake-cache and dotted build-configuration lookup helpers
- document the shared module boundaries and cover the new primitives with focused contracts

## Why

CI and developer scripts currently reimplement these boundaries with slightly different behavior.
Providing small, dependency-light helpers gives later script migrations one tested implementation
without forcing eager imports or breaking existing facade consumers.

This PR intentionally provides the tools-library foundation only. Migrating the existing
`.github/scripts/` entrypoints can follow separately, keeping behavior changes out of this refactor.

## Validation

- `uv run --project tools --extra scripts --extra test pytest -q --basetemp=/home/holden/.tmp/qgc-copilot-full tools/tests .github/scripts/tests` (`996 passed`)
- changed-file Ruff and Ruff format hooks
- changed-file Pyright hook
- tools import-linter hook
- changed-file whitespace, line-ending, large-file, typos, and Markdown lint checks
- `git diff --check`

The aggregate local `pre-commit run --files ...` could not initialize the repository's
`markdownlint-cli` environment with the host Node 18 installation because
`markdownlint-cli@0.49.0` requires Node 22 or newer. Markdown lint was run successfully by invoking
the pinned version under Node 22, and all other applicable hooks passed directly.
