### PR TITLE
chore(GeoMap): add patch-add timing to perf capture and logcat CSV dump on Android

### DIFF
--- a/src/GeoMap/SurfaceModel.cc
+++ b/src/GeoMap/SurfaceModel.cc
@@ -118,6 +118,8 @@ void SurfaceModel::update()
     QVarLengthArray<QRectF, 8> churnRects;  // added/removed extents: neighbors there re-stitch
     int adds = 0;
     _addsDeferred = false;
+    QElapsedTimer addTimer;
+    addTimer.start();
     for (const TileMath::TileKey& key : desired) {
         if (_patches.contains(key)) {
             continue;
@@ -135,6 +137,7 @@ void SurfaceModel::update()
         emit patchAdded(key);
         adds++;
     }
+    const qint64 addUs = addTimer.nsecsElapsed() / 1000;
 
     // Rects of desired patches still not resident after the capped adds: a
     // no-longer-desired patch overlapping one may not be removed yet, or the
@@ -219,10 +222,12 @@ void SurfaceModel::update()
     qCDebug(GeoMapSurfaceModelVerboseLog)
         << "update pass: desired" << desired.count() << "resident" << _patches.count() << "adds" << adds << "removals"
         << _removalsThisPass << "deferred adds" << _addsDeferred << "deferred removals" << _removalsDeferred
-        << "elapsedUs" << elapsedUs;
+        << "elapsedUs" << elapsedUs << "addUs" << addUs;
     _updateStats.updates++;
     _updateStats.totalUs += elapsedUs;
     _updateStats.maxUs = std::max(_updateStats.maxUs, elapsedUs);
+    _updateStats.addTotalUs += addUs;
+    _updateStats.addMaxUs = std::max(_updateStats.addMaxUs, addUs);
 }
 
 SurfaceModel::UpdateStats SurfaceModel::takeUpdateStats()

--- a/src/GeoMap/SurfaceModel.h
+++ b/src/GeoMap/SurfaceModel.h
@@ -105,6 +105,8 @@ public:
         int updates = 0;
         qint64 totalUs = 0;
         qint64 maxUs = 0;
+        qint64 addTotalUs = 0;  ///< time inside the patch-add loop (delegate creation share)
+        qint64 addMaxUs = 0;
     };
 
     /// Returns the counters accumulated since the previous call and resets them

--- a/src/GeoMap/SurfacePatchModel.cc
+++ b/src/GeoMap/SurfacePatchModel.cc
@@ -13,6 +13,10 @@
 #include <cmath>
 #include <utility>
 
+#ifdef Q_OS_ANDROID
+#include <android/log.h>
+#endif
+
 #include "GeoMapCamera.h"
 #include "GeoScene.h"
 #include "HeightField.h"
@@ -387,6 +391,8 @@ void SurfacePatchModel::_statsTick()
         _surfaceModel ? _surfaceModel->takeUpdateStats() : SurfaceModel::UpdateStats{};
     const double avgMs = stats.updates ? (stats.totalUs / 1000.0) / stats.updates : 0.0;
     const double maxMs = stats.maxUs / 1000.0;
+    const double addAvgMs = stats.updates ? (stats.addTotalUs / 1000.0) / stats.updates : 0.0;
+    const double addMaxMs = stats.addMaxUs / 1000.0;
     _statsText = QStringLiteral("upd/s %1  avg %2 ms  max %3 ms  |  patch +%4 -%5 /s  comp/s %6")
                      .arg(stats.updates)
                      .arg(avgMs, 0, 'f', 2)
@@ -398,11 +404,13 @@ void SurfacePatchModel::_statsTick()
         _captureWorstMaxMs = std::max(_captureWorstMaxMs, maxMs);
         _captureWorstAvgMs = std::max(_captureWorstAvgMs, avgMs);
         GeoMapCamera* const camera = _camera();
-        _captureRows.append(QStringLiteral("%1,%2,%3,%4,%5,%6,%7,%8,%9,%10,%11,%12")
+        _captureRows.append(QStringLiteral("%1,%2,%3,%4,%5,%6,%7,%8,%9,%10,%11,%12,%13,%14")
                                 .arg(_captureClock.elapsed() / 1000.0, 0, 'f', 1)
                                 .arg(stats.updates)
                                 .arg(avgMs, 0, 'f', 3)
                                 .arg(maxMs, 0, 'f', 3)
+                                .arg(addAvgMs, 0, 'f', 3)
+                                .arg(addMaxMs, 0, 'f', 3)
                                 .arg(_statAdds)
                                 .arg(_statRemoves)
                                 .arg(_statComposites)
@@ -430,8 +438,8 @@ void SurfacePatchModel::startCapture()
     _captureWorstMaxMs = 0.0;
     _captureWorstAvgMs = 0.0;
     _captureRows.append(
-        QStringLiteral("time_s,updates,avg_ms,max_ms,patch_adds,patch_removes,composites,patches,pending,max_zoom,cam_"
-                       "dist_m,cam_tilt_deg"));
+        QStringLiteral("time_s,updates,avg_ms,max_ms,add_avg_ms,add_max_ms,patch_adds,patch_removes,composites,"
+                       "patches,pending,max_zoom,cam_dist_m,cam_tilt_deg"));
     _captureClock.start();
     // Run the sampler directly rather than via statsEnabled: that property is
     // QML-bound to the overlay toggle, and writing it here would fight the
@@ -471,6 +479,16 @@ QString SurfacePatchModel::stopCapture()
         emit statsTextChanged();
         return QString();
     }
+
+#ifdef Q_OS_ANDROID
+    // Non-debuggable release builds hide the app cache from adb; dump the CSV
+    // to logcat so it can be pulled with: adb logcat -d -s GeoMapCapture
+    for (const QByteArray& line : data.split('\n')) {
+        if (!line.isEmpty()) {
+            __android_log_print(ANDROID_LOG_WARN, "GeoMapCapture", "%s", line.constData());
+        }
+    }
+#endif
 
     // No log output on success: the overlay shows the path, and UI tests run
     // with strict log checking. The worst-case summary makes the overlay a


### PR DESCRIPTION
Adds instrumentation to the GeoMap perf capture used for low-end Android feasibility testing (#14880):

- **Patch-add loop timing**: `UpdateStats` gains `addTotalUs`/`addMaxUs`, measured around the add loop in `SurfaceModel::update()`. Exposed in the capture CSV as `add_avg_ms`/`add_max_ms`, splitting synchronous delegate-creation cost out of total update time.
- **Logcat CSV dump on Android**: non-debuggable release builds hide the app cache from adb (`run-as` fails), so `stopCapture()` also dumps the CSV to logcat under tag `GeoMapCapture`. Pull with `adb logcat -d -s GeoMapCapture`. Android-only, fires only on explicit capture stop.

Data gathered with this on a RadioMaster AX12 (Mali-G72, Android 9) release build: delegate creation is 75-80% of surface update time (~3.3 ms/patch add), worst single update 15.5 ms — inside the 16.6 ms frame budget.
