### PR TITLE
refactor(GeoMap): unify bilinear sampling and split oversized functions

### DIFF
--- a/src/GeoMap/BilinearUV.h
+++ b/src/GeoMap/BilinearUV.h
@@ -1,0 +1,41 @@
+/****************************************************************************
+ *
+ * (c) 2009-2024 QGROUNDCONTROL PROJECT <http://www.qgroundcontrol.org>
+ *
+ * QGroundControl is licensed according to the terms in the file
+ * COPYING.md in the root of the source code directory.
+ *
+ ****************************************************************************/
+
+#pragma once
+
+#include <QtCore/QtMinMax>
+
+#include <cmath>
+
+/// Bilinear sample at a unit-UV position within a w x h sample grid (origin
+/// NW corner), sample-center convention, clamped at grid edges. `at(x, y)`
+/// returns the sample value as double.
+///
+/// The one shared interpolation for all elevation samplers: cross-source
+/// vertex identity requires bit-identical arithmetic, so samplers must go
+/// through this template rather than reimplementing it.
+template <typename SampleAt>
+double bilinearAtUV(int w, int h, double u, double v, SampleAt at)
+{
+    if ((w <= 0) || (h <= 0)) {
+        return 0.0;
+    }
+    const double px = (u * w) - 0.5;
+    const double py = (v * h) - 0.5;
+    const int x0 = qBound(0, static_cast<int>(std::floor(px)), w - 1);
+    const int y0 = qBound(0, static_cast<int>(std::floor(py)), h - 1);
+    const int x1 = qMin(x0 + 1, w - 1);
+    const int y1 = qMin(y0 + 1, h - 1);
+    const double fx = qBound(0.0, px - x0, 1.0);
+    const double fy = qBound(0.0, py - y0, 1.0);
+
+    const double north = (at(x0, y0) * (1.0 - fx)) + (at(x1, y0) * fx);
+    const double south = (at(x0, y1) * (1.0 - fx)) + (at(x1, y1) * fx);
+    return (north * (1.0 - fy)) + (south * fy);
+}

--- a/src/GeoMap/CMakeLists.txt
+++ b/src/GeoMap/CMakeLists.txt
@@ -5,12 +5,15 @@
 
 target_sources(${CMAKE_PROJECT_NAME}
     PRIVATE
+        BilinearUV.h
         ElevationTilePyramid.cc
         ElevationTilePyramid.h
         HeightField.cc
         HeightField.h
         HeightSource.cc
         HeightSource.h
+        PatchSampler.cc
+        PatchSampler.h
         SurfaceAnalysis.cc
         SurfaceAnalysis.h
         SurfaceModel.cc

--- a/src/GeoMap/HeightField.cc
+++ b/src/GeoMap/HeightField.cc
@@ -9,43 +9,13 @@
 
 #include "HeightField.h"
 
-#include <QtCore/QVarLengthArray>
-#include <QtCore/QtMinMax>
-
-#include <cmath>
 #include <utility>
 
+#include "PatchSampler.h"
 #include "QGCLoggingCategory.h"
 
 QGC_LOGGING_CATEGORY(GeoMapHeightFieldLog, "GeoMap.HeightField")
 QGC_LOGGING_CATEGORY(GeoMapHeightFieldVerboseLog, "GeoMap.HeightField.Verbose")
-
-namespace {
-
-/// Bilinear height at a unit-UV position within a grid (origin NW corner),
-/// sample-center convention, clamped at grid edges.
-/// Must stay numerically identical to TerrariumTileFetcher.cc's heightAtUV:
-/// cross-source vertex identity depends on both samplers agreeing
-double heightAtUV(const ElevationTilePyramid::Grid& grid, double u, double v)
-{
-    const int w = grid.width;
-    const int h = grid.height;
-    const double px = (u * w) - 0.5;
-    const double py = (v * h) - 0.5;
-    const int x0 = qBound(0, static_cast<int>(std::floor(px)), w - 1);
-    const int y0 = qBound(0, static_cast<int>(std::floor(py)), h - 1);
-    const int x1 = qMin(x0 + 1, w - 1);
-    const int y1 = qMin(y0 + 1, h - 1);
-    const double fx = qBound(0.0, px - x0, 1.0);
-    const double fy = qBound(0.0, py - y0, 1.0);
-
-    const auto at = [&grid](int x, int y) { return double(grid.heights[(qsizetype(y) * grid.width) + x]); };
-    const double north = (at(x0, y0) * (1.0 - fx)) + (at(x1, y0) * fx);
-    const double south = (at(x0, y1) * (1.0 - fx)) + (at(x1, y1) * fx);
-    return (north * (1.0 - fy)) + (south * fy);
-}
-
-}  // namespace
 
 HeightField::HeightField(QObject* parent) : QObject(parent) {}
 
@@ -91,7 +61,7 @@ double HeightField::heightAt(const QPointF& world) const
         if (((query.x >> shift) == _memoView.key.x) && ((query.y >> shift) == _memoView.key.y)) {
             const double u = (world.x() - _memoMinX) / _memoSpan;
             const double v = (_memoMaxY - world.y()) / _memoSpan;  // grid origin is the NW corner
-            return heightAtUV(*_memoView.grid, u, v);
+            return PatchSampler::heightAtUV(*_memoView.grid, u, v);
         }
     }
 
@@ -114,7 +84,7 @@ double HeightField::heightAt(const QPointF& world) const
 
     const double u = (world.x() - corner.x()) / span;
     const double v = ((corner.y() + span) - world.y()) / span;  // grid origin is the NW corner
-    return heightAtUV(*view.grid, u, v);
+    return PatchSampler::heightAtUV(*view.grid, u, v);
 }
 
 QList<float> HeightField::samplePatch(const TileMath::TileKey& key, int gridSize) const
@@ -133,93 +103,5 @@ QList<float> HeightField::samplePatch(const TileMath::TileKey& key, int gridSize
     // the same stored tile no matter which patch asks. Positions are exact
     // dyadic values, so coincident vertices compute bit-identical UVs and
     // sample bit-identical heights: meshes never crack where data exists.
-    const ElevationTilePyramid::View patchView = _pyramid.bestTileFor(key);
-
-    // Height at the exact vertex position (n/gridSize, m/gridSize in tile
-    // units at key.zoom) within a resolved view; ldexp rescales exactly, so
-    // equal positions give equal UV bits regardless of the asking patch
-    const auto viewHeight = [&key, gridSize](const ElevationTilePyramid::View& view, qint64 n, qint64 m) {
-        const double u = (std::ldexp(double(n), view.key.zoom - key.zoom) / gridSize) - view.key.x;
-        const double v = (std::ldexp(double(m), view.key.zoom - key.zoom) / gridSize) - view.key.y;
-        return static_cast<float>(heightAtUV(*view.grid, u, v));
-    };
-
-    // Memo of resolved views per key.zoom tile: when a tile has no stored
-    // descendant, every cell inside it resolves identically (chain below the
-    // tile is empty, ancestors are shared), so one lookup answers the whole
-    // edge run along it. An invalid view memoizes the same way — repeated
-    // misses over uncovered neighbors stay O(1). A patch's boundary touches
-    // at most 9 such tiles (own + 8 neighbors).
-    struct TileMemo
-    {
-        TileMath::TileKey tile;
-        ElevationTilePyramid::View view;
-    };
-
-    QVarLengthArray<TileMemo, 9> memos;
-
-    const int shiftToMax = TileMath::kMaxZoom - key.zoom;
-    const auto resolveCell = [&, this](qint64 cx, qint64 cy) {
-        const TileMath::TileKey tile{int(cx >> shiftToMax), int(cy >> shiftToMax), key.zoom};
-        for (const TileMemo& memo : memos) {
-            if (memo.tile == tile) {
-                return memo.view;
-            }
-        }
-        const ElevationTilePyramid::View view =
-            _pyramid.bestTileFor(TileMath::TileKey{int(cx), int(cy), TileMath::kMaxZoom});
-        if (!_pyramid.hasDescendant(tile) && (memos.size() < memos.capacity())) {
-            memos.append({tile, view});
-        }
-        return view;
-    };
-
-    const auto boundaryHeight = [&](qint64 n, qint64 m) -> float {
-        // Cells touching the vertex on each axis, east/south side first; a
-        // vertex not exactly on a cell boundary lies in a single cell
-        const qint64 cellCount = qint64(1) << TileMath::kMaxZoom;
-        const auto touchingCells = [&](qint64 s, qint64(&cells)[2]) {
-            int count = 0;
-            const qint64 cell = s / gridSize;
-            if (cell < cellCount) {
-                cells[count++] = cell;
-            }
-            if (((s % gridSize) == 0) && (cell > 0)) {
-                cells[count++] = cell - 1;
-            }
-            return count;
-        };
-        qint64 xCells[2];
-        qint64 yCells[2];
-        const int xCount = touchingCells(n << shiftToMax, xCells);
-        const int yCount = touchingCells(m << shiftToMax, yCells);
-
-        // Fixed candidate order derived purely from the position: every
-        // patch sharing this vertex walks the same cells and returns the
-        // first resolvable view, so the height is canonical
-        for (int yi = 0; yi < yCount; yi++) {
-            for (int xi = 0; xi < xCount; xi++) {
-                const ElevationTilePyramid::View view = resolveCell(xCells[xi], yCells[yi]);
-                if (view.isValid()) {
-                    return viewHeight(view, n, m);
-                }
-            }
-        }
-        return 0.0f;  // no stored data touches the vertex: every sharer agrees on zero
-    };
-
-    QList<float> heights;
-    heights.reserve(qsizetype(gridSize + 1) * (gridSize + 1));
-    for (int row = 0; row <= gridSize; row++) {
-        const qint64 m = (qint64(key.y) * gridSize) + row;
-        for (int col = 0; col <= gridSize; col++) {
-            const qint64 n = (qint64(key.x) * gridSize) + col;
-            if ((row == 0) || (row == gridSize) || (col == 0) || (col == gridSize)) {
-                heights.append(boundaryHeight(n, m));
-            } else {
-                heights.append(patchView.isValid() ? viewHeight(patchView, n, m) : 0.0f);
-            }
-        }
-    }
-    return heights;
+    return PatchSampler(_pyramid, key, gridSize).sample();
 }

--- a/src/GeoMap/HeightField.h
+++ b/src/GeoMap/HeightField.h
@@ -59,6 +59,8 @@ public:
 
     /// The (gridSize+1)^2 vertex heights of a patch, row-major from the NW
     /// corner. Empty for invalid keys or gridSize outside [1, kMaxGridSize].
+    /// gridSize must be a power of two: vertex UVs are then exact dyadic
+    /// doubles, which the bit-identity guarantee below relies on.
     /// Boundary vertices resolve by canonical world position rather than the
     /// patch's own backing view, so coincident vertices of neighboring
     /// patches sample bit-identical heights even across different backing

--- a/src/GeoMap/HeightSource.h
+++ b/src/GeoMap/HeightSource.h
@@ -33,6 +33,7 @@ public:
     explicit HeightSource(QObject* parent = nullptr);
 
     /// Request the vertex height grid for a patch. Returns a request id (> 0).
+    /// gridSize must be a power of two (see HeightField::samplePatch).
     virtual int requestPatchHeights(const TileMath::TileKey& key, int gridSize) = 0;
 
     /// Cancel a pending request. No signal is emitted for a cancelled request.

--- a/src/GeoMap/PatchSampler.cc
+++ b/src/GeoMap/PatchSampler.cc
@@ -1,0 +1,109 @@
+/****************************************************************************
+ *
+ * (c) 2009-2024 QGROUNDCONTROL PROJECT <http://www.qgroundcontrol.org>
+ *
+ * QGroundControl is licensed according to the terms in the file
+ * COPYING.md in the root of the source code directory.
+ *
+ ****************************************************************************/
+
+#include "PatchSampler.h"
+
+#include <cmath>
+
+#include "BilinearUV.h"
+
+double PatchSampler::heightAtUV(const ElevationTilePyramid::Grid& grid, double u, double v)
+{
+    const auto at = [&grid](int x, int y) { return double(grid.heights[(qsizetype(y) * grid.width) + x]); };
+    return bilinearAtUV(grid.width, grid.height, u, v, at);
+}
+
+PatchSampler::PatchSampler(const ElevationTilePyramid& pyramid, const TileMath::TileKey& key, int gridSize)
+    : _pyramid(pyramid),
+      _key(key),
+      _gridSize(gridSize),
+      _shiftToMax(TileMath::kMaxZoom - key.zoom),
+      _patchView(pyramid.bestTileFor(key))
+{}
+
+QList<float> PatchSampler::sample()
+{
+    QList<float> heights;
+    heights.reserve(qsizetype(_gridSize + 1) * (_gridSize + 1));
+    for (int row = 0; row <= _gridSize; row++) {
+        const qint64 m = (qint64(_key.y) * _gridSize) + row;
+        for (int col = 0; col <= _gridSize; col++) {
+            const qint64 n = (qint64(_key.x) * _gridSize) + col;
+            if ((row == 0) || (row == _gridSize) || (col == 0) || (col == _gridSize)) {
+                heights.append(_boundaryHeight(n, m));
+            } else {
+                heights.append(_patchView.isValid() ? _viewHeight(_patchView, n, m) : 0.0f);
+            }
+        }
+    }
+    return heights;
+}
+
+/// Height at the exact vertex position (n/gridSize, m/gridSize in tile units
+/// at key.zoom) within a resolved view; ldexp rescales exactly, so equal
+/// positions give equal UV bits regardless of the asking patch
+float PatchSampler::_viewHeight(const ElevationTilePyramid::View& view, qint64 n, qint64 m) const
+{
+    const double u = (std::ldexp(double(n), view.key.zoom - _key.zoom) / _gridSize) - view.key.x;
+    const double v = (std::ldexp(double(m), view.key.zoom - _key.zoom) / _gridSize) - view.key.y;
+    return static_cast<float>(heightAtUV(*view.grid, u, v));
+}
+
+/// Cells at kMaxZoom touching a vertex position on one axis, east/south side
+/// first; a vertex not exactly on a cell boundary lies in a single cell
+int PatchSampler::_touchingCells(qint64 s, qint64 (&cells)[2]) const
+{
+    const qint64 cellCount = qint64(1) << TileMath::kMaxZoom;
+    int count = 0;
+    const qint64 cell = s / _gridSize;
+    if (cell < cellCount) {
+        cells[count++] = cell;
+    }
+    if (((s % _gridSize) == 0) && (cell > 0)) {
+        cells[count++] = cell - 1;
+    }
+    return count;
+}
+
+ElevationTilePyramid::View PatchSampler::_resolveCell(qint64 cx, qint64 cy)
+{
+    const TileMath::TileKey tile{int(cx >> _shiftToMax), int(cy >> _shiftToMax), _key.zoom};
+    for (const TileMemo& memo : _memos) {
+        if (memo.tile == tile) {
+            return memo.view;
+        }
+    }
+    const ElevationTilePyramid::View view =
+        _pyramid.bestTileFor(TileMath::TileKey{int(cx), int(cy), TileMath::kMaxZoom});
+    if (!_pyramid.hasDescendant(tile) && (_memos.size() < _memos.capacity())) {
+        _memos.append({tile, view});
+    }
+    return view;
+}
+
+float PatchSampler::_boundaryHeight(qint64 n, qint64 m)
+{
+    qint64 xCells[2];
+    qint64 yCells[2];
+    const int xCount = _touchingCells(n << _shiftToMax, xCells);
+    const int yCount = _touchingCells(m << _shiftToMax, yCells);
+
+    // Fixed candidate order derived purely from the position: every patch
+    // sharing this vertex walks the same cells and returns the first
+    // resolvable view, so the height is canonical
+    for (int yi = 0; yi < yCount; yi++) {
+        for (int xi = 0; xi < xCount; xi++) {
+            const ElevationTilePyramid::View view = _resolveCell(xCells[xi], yCells[yi]);
+            if (view.isValid()) {
+                return _viewHeight(view, n, m);
+            }
+        }
+    }
+    return 0.0f;  // no stored data touches the vertex: every sharer agrees on zero
+}

--- a/src/GeoMap/PatchSampler.h
+++ b/src/GeoMap/PatchSampler.h
@@ -1,0 +1,59 @@
+/****************************************************************************
+ *
+ * (c) 2009-2024 QGROUNDCONTROL PROJECT <http://www.qgroundcontrol.org>
+ *
+ * QGroundControl is licensed according to the terms in the file
+ * COPYING.md in the root of the source code directory.
+ *
+ ****************************************************************************/
+
+#pragma once
+
+#include <QtCore/QList>
+#include <QtCore/QVarLengthArray>
+
+#include "ElevationTilePyramid.h"
+#include "TileMath.h"
+
+/// Canonical vertex-height resolution for one patch: interior vertices
+/// sample the patch's own backing view; boundary vertices resolve by
+/// position so every patch sharing the vertex samples bit-identical heights
+/// (see HeightField::samplePatch). gridSize must be a power of two so
+/// vertex UVs are exact dyadic doubles. Single-use: construct, sample() once.
+class PatchSampler
+{
+public:
+    PatchSampler(const ElevationTilePyramid& pyramid, const TileMath::TileKey& key, int gridSize);
+
+    /// The (gridSize+1)^2 vertex heights, row-major from the NW corner
+    QList<float> sample();
+
+    /// Bilinear height at a unit-UV position within a grid (origin NW corner),
+    /// sample-center convention, clamped at grid edges (see BilinearUV.h)
+    static double heightAtUV(const ElevationTilePyramid::Grid& grid, double u, double v);
+
+private:
+    float _viewHeight(const ElevationTilePyramid::View& view, qint64 n, qint64 m) const;
+    float _boundaryHeight(qint64 n, qint64 m);
+    ElevationTilePyramid::View _resolveCell(qint64 cx, qint64 cy);
+    int _touchingCells(qint64 s, qint64 (&cells)[2]) const;
+
+    /// Memo of resolved views per key.zoom tile: when a tile has no stored
+    /// descendant, every cell inside it resolves identically (chain below the
+    /// tile is empty, ancestors are shared), so one lookup answers the whole
+    /// edge run along it. An invalid view memoizes the same way — repeated
+    /// misses over uncovered neighbors stay O(1). A patch's boundary touches
+    /// at most 9 such tiles (own + 8 neighbors).
+    struct TileMemo
+    {
+        TileMath::TileKey tile;
+        ElevationTilePyramid::View view;
+    };
+
+    const ElevationTilePyramid& _pyramid;
+    const TileMath::TileKey _key;
+    const int _gridSize;
+    const int _shiftToMax;
+    const ElevationTilePyramid::View _patchView;
+    QVarLengthArray<TileMemo, 9> _memos;
+};

--- a/src/GeoMap/SurfaceModel.cc
+++ b/src/GeoMap/SurfaceModel.cc
@@ -110,13 +110,40 @@ void SurfaceModel::update()
 
     QSet<TileMath::TileKey> desiredSet(desired.cbegin(), desired.cend());
 
-    // Add newly desired patches, capped per pass: each add synchronously
-    // builds a render delegate downstream, and uncapped bursts (300+ adds/s
-    // while zooming) blow the frame budget. A new patch meshes immediately
-    // from the field's best estimate; tile coverage is requested so the
-    // estimate refines when data arrives.
     QVarLengthArray<QRectF, 8> churnRects;  // added/removed extents: neighbors there re-stitch
-    int adds = 0;
+    const AddResult added = _addDesiredPatches(desired, churnRects);
+    const int removals = _removeStalePatches(desired, desiredSet, churnRects);
+    _notifyEdgeChurn(churnRects);
+
+    if ((added.adds > 0) || (removals > 0)) {
+        _repinAncestors();
+    }
+
+    // The caps guarantee every deferred pass makes progress, so follow-ups
+    // always converge
+    if (_addsDeferred || _removalsDeferred) {
+        _scheduleUpdate();
+    }
+
+    const qint64 elapsedUs = updateTimer.nsecsElapsed() / 1000;
+    qCDebug(GeoMapSurfaceModelVerboseLog)
+        << "update pass: desired" << desired.count() << "resident" << _patches.count() << "adds" << added.adds
+        << "removals" << removals << "deferred adds" << _addsDeferred << "deferred removals" << _removalsDeferred
+        << "elapsedUs" << elapsedUs << "addUs" << added.addUs;
+    _updateStats.updates++;
+    _updateStats.totalUs += elapsedUs;
+    _updateStats.maxUs = std::max(_updateStats.maxUs, elapsedUs);
+}
+
+/// Add newly desired patches, capped per pass: each add synchronously builds
+/// a render delegate downstream, and uncapped bursts (300+ adds/s while
+/// zooming) blow the frame budget. A new patch meshes immediately from the
+/// field's best estimate; tile coverage is requested so the estimate refines
+/// when data arrives.
+SurfaceModel::AddResult SurfaceModel::_addDesiredPatches(const QList<TileMath::TileKey>& desired,
+                                                         QVarLengthArray<QRectF, 8>& churnRects)
+{
+    AddResult result;
     _addsDeferred = false;
     QElapsedTimer addTimer;
     addTimer.start();
@@ -124,7 +151,7 @@ void SurfaceModel::update()
         if (_patches.contains(key)) {
             continue;
         }
-        if (adds >= kMaxPatchAddsPerUpdate) {
+        if (result.adds >= kMaxPatchAddsPerUpdate) {
             _addsDeferred = true;
             continue;
         }
@@ -135,10 +162,21 @@ void SurfaceModel::update()
         churnRects.append(patchRect(key));
         _heightSource->requestTile(key);
         emit patchAdded(key);
-        adds++;
+        result.adds++;
     }
-    const qint64 addUs = addTimer.nsecsElapsed() / 1000;
+    result.addUs = addTimer.nsecsElapsed() / 1000;
+    _updateStats.addTotalUs += result.addUs;
+    _updateStats.addMaxUs = std::max(_updateStats.addMaxUs, result.addUs);
+    return result;
+}
 
+/// Drop patches no longer desired. Removals are capped like adds: each erase
+/// synchronously destroys a render delegate, and pose jumps (high-tilt
+/// orbits) can invalidate hundreds of patches at once. Patches whose
+/// replacements are not resident yet stay for a follow-up pass.
+int SurfaceModel::_removeStalePatches(const QList<TileMath::TileKey>& desired,
+                                      const QSet<TileMath::TileKey>& desiredSet, QVarLengthArray<QRectF, 8>& churnRects)
+{
     // Rects of desired patches still not resident after the capped adds: a
     // no-longer-desired patch overlapping one may not be removed yet, or the
     // surface would show a hole until the adds catch up. Computed after the
@@ -160,18 +198,14 @@ void SurfaceModel::update()
         return false;
     };
 
-    // Drop patches no longer desired. Removals are capped like adds: each
-    // erase synchronously destroys a render delegate, and pose jumps
-    // (high-tilt orbits) can invalidate hundreds of patches at once. Patches
-    // whose replacements are not resident yet stay for a follow-up pass.
-    _removalsThisPass = 0;
+    int removals = 0;
     _removalsDeferred = false;
     for (auto it = _patches.begin(); it != _patches.end();) {
         if (desiredSet.contains(it.key())) {
             ++it;
             continue;
         }
-        if ((_removalsThisPass >= kMaxPatchRemovalsPerUpdate) || overlapsMissing(it.key())) {
+        if ((removals >= kMaxPatchRemovalsPerUpdate) || overlapsMissing(it.key())) {
             _removalsDeferred = true;  // stays resident one more pass; follow-up finishes the cull
             ++it;
             continue;
@@ -180,11 +214,15 @@ void SurfaceModel::update()
         it = _patches.erase(it);
         churnRects.append(patchRect(removedKey));
         emit patchRemoved(removedKey);
-        _removalsThisPass++;
+        removals++;
     }
+    return removals;
+}
 
-    // Added/removed patches change their neighbors' edge LOD deltas: notify
-    // every resident patch touching a churned extent so it re-stitches
+/// Added/removed patches change their neighbors' edge LOD deltas: notify
+/// every resident patch touching a churned extent so it re-stitches
+void SurfaceModel::_notifyEdgeChurn(const QVarLengthArray<QRectF, 8>& churnRects)
+{
     for (auto it = _patches.cbegin(); it != _patches.cend(); ++it) {
         for (const QRectF& rect : churnRects) {
             if (patchTouchesRegion(it.key(), rect)) {
@@ -193,49 +231,36 @@ void SurfaceModel::update()
             }
         }
     }
-
-    // Pin every resident patch's key and its full ancestor chain: whatever
-    // tile the field resolves a patch sample to is in that chain, and an
-    // eviction there would silently coarsen a rendered mesh
-    if ((adds > 0) || (_removalsThisPass > 0)) {
-        QSet<TileMath::TileKey> pinned;
-        for (auto it = _patches.cbegin(); it != _patches.cend(); ++it) {
-            TileMath::TileKey key = it.key();
-            while (true) {
-                pinned.insert(key);
-                if (key.zoom == TileMath::kMinZoom) {
-                    break;
-                }
-                key = TileMath::TileKey{key.x >> 1, key.y >> 1, key.zoom - 1};
-            }
-        }
-        _field->setPinnedKeys(std::move(pinned));
-    }
-
-    // The caps guarantee every deferred pass makes progress, so follow-ups
-    // always converge
-    if (_addsDeferred || _removalsDeferred) {
-        _scheduleUpdate();
-    }
-
-    const qint64 elapsedUs = updateTimer.nsecsElapsed() / 1000;
-    qCDebug(GeoMapSurfaceModelVerboseLog)
-        << "update pass: desired" << desired.count() << "resident" << _patches.count() << "adds" << adds << "removals"
-        << _removalsThisPass << "deferred adds" << _addsDeferred << "deferred removals" << _removalsDeferred
-        << "elapsedUs" << elapsedUs << "addUs" << addUs;
-    _updateStats.updates++;
-    _updateStats.totalUs += elapsedUs;
-    _updateStats.maxUs = std::max(_updateStats.maxUs, elapsedUs);
-    _updateStats.addTotalUs += addUs;
-    _updateStats.addMaxUs = std::max(_updateStats.addMaxUs, addUs);
 }
 
+/// Pin every resident patch's key and its full ancestor chain: whatever tile
+/// the field resolves a patch sample to is in that chain, and an eviction
+/// there would silently coarsen a rendered mesh
+void SurfaceModel::_repinAncestors()
+{
+    QSet<TileMath::TileKey> pinned;
+    for (auto it = _patches.cbegin(); it != _patches.cend(); ++it) {
+        TileMath::TileKey key = it.key();
+        while (true) {
+            pinned.insert(key);
+            if (key.zoom == TileMath::kMinZoom) {
+                break;
+            }
+            key = TileMath::TileKey{key.x >> 1, key.y >> 1, key.zoom - 1};
+        }
+    }
+    _field->setPinnedKeys(std::move(pinned));
+}
+
+// GCOVR_EXCL_START — perf-stats instrumentation for the debug overlay/capture
 SurfaceModel::UpdateStats SurfaceModel::takeUpdateStats()
 {
     const UpdateStats stats = _updateStats;
     _updateStats = UpdateStats{};
     return stats;
 }
+
+// GCOVR_EXCL_STOP
 
 QList<SurfaceModel::Patch> SurfaceModel::patches() const
 {

--- a/src/GeoMap/SurfaceModel.h
+++ b/src/GeoMap/SurfaceModel.h
@@ -13,6 +13,8 @@
 #include <QtCore/QList>
 #include <QtCore/QObject>
 #include <QtCore/QRectF>
+#include <QtCore/QSet>
+#include <QtCore/QVarLengthArray>
 
 #include <optional>
 
@@ -160,6 +162,19 @@ private:
     int _edgeDelta(const TileMath::TileKey& key, int dx, int dy) const;
     void _scheduleUpdate();
 
+    // update() phases (see update() for the pass structure)
+    struct AddResult
+    {
+        int adds = 0;
+        qint64 addUs = 0;
+    };
+
+    AddResult _addDesiredPatches(const QList<TileMath::TileKey>& desired, QVarLengthArray<QRectF, 8>& churnRects);
+    int _removeStalePatches(const QList<TileMath::TileKey>& desired, const QSet<TileMath::TileKey>& desiredSet,
+                            QVarLengthArray<QRectF, 8>& churnRects);
+    void _notifyEdgeChurn(const QVarLengthArray<QRectF, 8>& churnRects);
+    void _repinAncestors();
+
     GeoMapCamera* const _camera;
     HeightSource* const _heightSource;
     HeightField* const _field;
@@ -168,6 +183,5 @@ private:
     bool _updatePending = false;     ///< a coalesced update pass is queued on the event loop
     bool _addsDeferred = false;      ///< the last pass hit the add cap; a follow-up pass is queued
     bool _removalsDeferred = false;  ///< the last pass hit the removal cap; a follow-up pass is queued
-    int _removalsThisPass = 0;       ///< removal budget for the cull loop
     double _culledTerrainZ = 0.0;    ///< terrain-top height assumed by the last cull (scene units)
 };

--- a/src/GeoMap/SurfacePatchModel.cc
+++ b/src/GeoMap/SurfacePatchModel.cc
@@ -348,6 +348,7 @@ int SurfacePatchModel::maxZoomLevel() const
     return maxZoom;
 }
 
+// GCOVR_EXCL_START — perf-stats/capture/diagnostics instrumentation, not shipping behavior
 void SurfacePatchModel::_startStatsSampling()
 {
     if (!_statsTimer) {
@@ -544,6 +545,8 @@ void SurfacePatchModel::analyzeSurface() const
     qDebug().noquote() << report.text();  // user-triggered diagnostic: always emitted
 }
 
+// GCOVR_EXCL_STOP
+
 int SurfacePatchModel::rowCount(const QModelIndex& parent) const
 {
     return parent.isValid() ? 0 : _keys.count();
@@ -626,6 +629,16 @@ bool SurfacePatchModel::_fallbackAvailable(const TileMath::TileKey& key) const
 QImage SurfacePatchModel::_fallbackImage(const TileMath::TileKey& key) const
 {
     // Sharper first: composite direct children (LOD coarsening keeps their detail)
+    QImage image = _compositeFromChildren(key);
+    if (image.isNull()) {
+        // Blurrier: crop the covering region out of the nearest available ancestor
+        image = _cropFromAncestor(key);
+    }
+    return image;
+}
+
+QImage SurfacePatchModel::_compositeFromChildren(const TileMath::TileKey& key) const
+{
     bool anyChild = false;
     for (int childY = 0; (childY < 2) && !anyChild; childY++) {
         for (int childX = 0; (childX < 2) && !anyChild; childX++) {
@@ -633,27 +646,30 @@ QImage SurfacePatchModel::_fallbackImage(const TileMath::TileKey& key) const
                 _tileImages.contains(TileMath::TileKey{(key.x * 2) + childX, (key.y * 2) + childY, key.zoom + 1});
         }
     }
-    if (anyChild) {
-        constexpr int kCanvas = 256;
-        _statComposites++;
-        QImage canvas(kCanvas, kCanvas, QImage::Format_RGBA8888);
-        canvas.fill(QColor(0x3a, 0x40, 0x48));  // missing quadrants stay neutral
-        QPainter painter(&canvas);
-        for (int childY = 0; childY < 2; childY++) {
-            for (int childX = 0; childX < 2; childX++) {
-                const QImage child =
-                    _tileImages.value(TileMath::TileKey{(key.x * 2) + childX, (key.y * 2) + childY, key.zoom + 1});
-                if (!child.isNull()) {
-                    // Tile y grows south and image row 0 is north, so child y maps to top half directly
-                    painter.drawImage(QRect((childX * kCanvas) / 2, (childY * kCanvas) / 2, kCanvas / 2, kCanvas / 2),
-                                      child);
-                }
+    if (!anyChild) {
+        return {};
+    }
+    constexpr int kCanvas = 256;
+    _statComposites++;
+    QImage canvas(kCanvas, kCanvas, QImage::Format_RGBA8888);
+    canvas.fill(QColor(0x3a, 0x40, 0x48));  // missing quadrants stay neutral
+    QPainter painter(&canvas);
+    for (int childY = 0; childY < 2; childY++) {
+        for (int childX = 0; childX < 2; childX++) {
+            const QImage child =
+                _tileImages.value(TileMath::TileKey{(key.x * 2) + childX, (key.y * 2) + childY, key.zoom + 1});
+            if (!child.isNull()) {
+                // Tile y grows south and image row 0 is north, so child y maps to top half directly
+                painter.drawImage(QRect((childX * kCanvas) / 2, (childY * kCanvas) / 2, kCanvas / 2, kCanvas / 2),
+                                  child);
             }
         }
-        return canvas;
     }
+    return canvas;
+}
 
-    // Blurrier: crop the covering region out of the nearest available ancestor
+QImage SurfacePatchModel::_cropFromAncestor(const TileMath::TileKey& key) const
+{
     for (int up = 1; (up <= kMaxAncestorFallbackLevels) && ((key.zoom - up) >= 0); up++) {
         const TileMath::TileKey ancestor{key.x >> up, key.y >> up, key.zoom - up};
         const QImage image = _tileImages.value(ancestor);

--- a/src/GeoMap/SurfacePatchModel.h
+++ b/src/GeoMap/SurfacePatchModel.h
@@ -125,7 +125,7 @@ public:
         _tileImageNetworkManager = networkManager;
     }
 
-    bool statsEnabled() const { return _statsEnabled; }
+    bool statsEnabled() const { return _statsEnabled; }  // GCOVR_EXCL_LINE
 
     /// Enables the once-per-second perf counter sampling behind statsText:
     /// model update rate/duration, patch churn, and fallback composites
@@ -189,6 +189,8 @@ private:
     void _scheduleStatsChanged();
     void _startStatsSampling();
     QImage _fallbackImage(const TileMath::TileKey& key) const;
+    QImage _compositeFromChildren(const TileMath::TileKey& key) const;
+    QImage _cropFromAncestor(const TileMath::TileKey& key) const;
     bool _fallbackAvailable(const TileMath::TileKey& key) const;
     GeoMapCamera* _camera() const;
 

--- a/src/GeoMap/TerrariumTileFetcher.cc
+++ b/src/GeoMap/TerrariumTileFetcher.cc
@@ -13,9 +13,9 @@
 #include <QtNetwork/QNetworkAccessManager>
 #include <QtNetwork/QNetworkReply>
 
-#include <cmath>
 #include <memory>
 
+#include "BilinearUV.h"
 #include "ElevationMapProvider.h"
 #include "HeightField.h"
 #include "PatchGeometry.h"
@@ -48,25 +48,11 @@ double heightAtPixel(const QImage& image, int px, int py)
 }
 
 /// Bilinear height at a unit-UV position (origin NW corner), pixel-center
-/// convention, clamped at tile edges.
-/// Must stay numerically identical to HeightField.cc's heightAtUV:
-/// cross-source vertex identity depends on both samplers agreeing
+/// convention, clamped at tile edges; terrarium decode per pixel
 double heightAtUV(const QImage& image, double u, double v)
 {
-    const int w = image.width();
-    const int h = image.height();
-    const double px = (u * w) - 0.5;
-    const double py = (v * h) - 0.5;
-    const int x0 = qBound(0, static_cast<int>(std::floor(px)), w - 1);
-    const int y0 = qBound(0, static_cast<int>(std::floor(py)), h - 1);
-    const int x1 = qMin(x0 + 1, w - 1);
-    const int y1 = qMin(y0 + 1, h - 1);
-    const double fx = qBound(0.0, px - x0, 1.0);
-    const double fy = qBound(0.0, py - y0, 1.0);
-
-    const double north = (heightAtPixel(image, x0, y0) * (1.0 - fx)) + (heightAtPixel(image, x1, y0) * fx);
-    const double south = (heightAtPixel(image, x0, y1) * (1.0 - fx)) + (heightAtPixel(image, x1, y1) * fx);
-    return (north * (1.0 - fy)) + (south * fy);
+    const auto at = [&image](int x, int y) { return heightAtPixel(image, x, y); };
+    return bilinearAtUV(image.width(), image.height(), u, v, at);
 }
 
 /// Samples the (gridSize+1)^2 vertex grid, row-major from the NW corner, from the

--- a/test/GeoMap/TerrariumTileFetcherTest.cc
+++ b/test/GeoMap/TerrariumTileFetcherTest.cc
@@ -166,6 +166,31 @@ void TerrariumTileFetcherTest::_deliversSlopeRegionHeights()
     }
 }
 
+void TerrariumTileFetcherTest::_patchSamplingMatchesFieldSampling()
+{
+    // Cross-source vertex identity: heights sampled from the tile image (patch
+    // delivery) and from the decoded field grid must be bit-identical, or
+    // patches meshed from different sources crack at shared edges
+    HeightField field;
+    TerrariumTileFetcher source;
+    source.setHeightField(&field);
+    QSignalSpy readySpy(&source, &HeightSource::patchHeightsReady);
+    QSignalSpy regionSpy(&field, &HeightField::regionChanged);
+
+    const TileMath::TileKey key = keyOver(linearSlopeRegion().center(), kFineZoom);
+    const int requestId = source.requestPatchHeights(key, kGridSize);
+    QVERIFY(source.requestTile(key));
+
+    QTRY_COMPARE_WITH_TIMEOUT(readySpy.count(), 1, TestTimeout::mediumMs());
+    QTRY_COMPARE_WITH_TIMEOUT(regionSpy.count(), 1, TestTimeout::mediumMs());
+    QCOMPARE(readySpy.first().at(0).toInt(), requestId);
+
+    const auto imageHeights = readySpy.first().at(1).value<QList<float>>();
+    const QList<float> fieldHeights = field.samplePatch(key, kGridSize);
+    QCOMPARE(imageHeights.count(), kExpectedCount);
+    QCOMPARE(fieldHeights, imageHeights);
+}
+
 void TerrariumTileFetcherTest::_coarseZoomDeliversRealTerrain()
 {
     // Terrarium serves one tile per patch at any zoom, so coarse patches get real

--- a/test/GeoMap/TerrariumTileFetcherTest.h
+++ b/test/GeoMap/TerrariumTileFetcherTest.h
@@ -9,6 +9,7 @@ class TerrariumTileFetcherTest : public TerrainTest
 private slots:
     void _deliversFlatRegionHeights();
     void _deliversSlopeRegionHeights();
+    void _patchSamplingMatchesFieldSampling();
     void _coarseZoomDeliversRealTerrain();
     void _deepZoomSamplesAncestorTile();
     void _cancelPreventsDelivery();


### PR DESCRIPTION
Post-refactor QA cleanup for the GeoMap terrain surface code, driven by a lizard complexity scan (`-C 15 -L 80`).

## Lizard analysis (driver)

All five over-threshold GeoMap functions were analyzed individually, with a fix/no-fix decision for each:

| Function | CCN | Length | Decision |
|---|---|---|---|
| `SurfaceModel::update` | 24 | 145 | **Fixed here** — linear pipeline with clearly delimited phases; split along the existing comment boundaries into `_addDesiredPatches` / `_removeStalePatches` / `_notifyEdgeChurn` / `_repinAncestors` |
| `HeightField::samplePatch` | 21 | 106 | **Fixed here** — complexity was already decomposed, but into heavily-capturing lambdas that lizard counts against the enclosing function; promoted to the `PatchSampler` class so the boundary logic is unit-testable |
| `SurfaceAnalysis::analyze` | 37 | 167 | **Skip** — user-triggered diagnostic report, not shipping behavior (now also coverage-excluded); genuine complexity but a code-health-only concern with no runtime risk |
| `SurfacePatchModel::data` | 24 | 56 | **Skip** — CCN is almost entirely the idiomatic `QAbstractListModel::data()` role switch with flat 1–4 line cases; lizard false positive |
| `SurfaceAnalysis::Report::text` | 17 | 102 | **Skip** — linear string-building for the diagnostic report, zero algorithmic risk |

After this PR, no shipping-behavior GeoMap function flags.

## Changes

- **Shared bilinear sampler** (`BilinearUV.h`): `HeightField` and `TerrariumTileFetcher` each carried a hand-duplicated bilinear interpolation with a "must stay numerically identical" comment. Both now route through a single `bilinearAtUV` template, so cross-source vertex identity (patches from different height sources meeting without cracks) is enforced by construction instead of by comment. Includes a defensive empty-grid guard.
- **`PatchSampler` class**: `HeightField::samplePatch()` was a ~100-line function built from nested lambdas. The canonical vertex-height resolution (interior vs boundary vertices, tile memoization) now lives in its own single-use class with named private methods.
- **`SurfaceModel::update()` split** into focused phases: `_addDesiredPatches`, `_removeStalePatches`, `_notifyEdgeChurn`, `_repinAncestors`. Behavior-preserving; phase order and caps unchanged.
- **`SurfacePatchModel::_fallbackImage()` split** into `_compositeFromChildren` / `_cropFromAncestor`.
- **Coverage exclusions**: perf-stats/capture/diagnostics-only code (stats sampling, capture, `analyzeSurface`) marked with `GCOVR_EXCL` so coverage reports track shipping behavior.
- **New test** `_patchSamplingMatchesFieldSampling`: requests the same tile through both production paths (patch delivery from the tile image vs `HeightField::samplePatch` on the decoded grid) and asserts the full vertex grids are bit-identical, pinning the cross-source contract mechanically.

## Testing

All 20 GeoMap tests pass; touched files pass lint.
