### PR TITLE
fix(PlanManager): resend last mission waypoint in case of final ack timeout

### DIFF
--- a/src/Comms/MockLink/MockLinkMissionItemHandler.cc
+++ b/src/Comms/MockLink/MockLinkMissionItemHandler.cc
@@ -415,6 +415,12 @@ void MockLinkMissionItemHandler::_handleMissionItem(const mavlink_message_t &msg
         return;
     }
 
+    if (_failureMode == FailWriteFinalAckFirstResponse && _failWriteFinalAckFirstResponse) {
+        _failWriteFinalAckFirstResponse = false;
+        qCDebug(MockLinkMissionItemHandlerLog) << "not sending final ack due to failure mode FailWriteFinalAckFirstResponse, first response";
+        return;
+    }
+
     if (_failureMode != FailWriteFinalAckNoResponse) {
         MAV_MISSION_RESULT ack = MAV_MISSION_ACCEPTED;
 

--- a/src/Comms/MockLink/MockLinkMissionItemHandler.h
+++ b/src/Comms/MockLink/MockLinkMissionItemHandler.h
@@ -43,6 +43,7 @@ public:
         FailWriteRequest0ErrorAck,          // Instead of sending MISSION_REQUEST 0, send MISSION_ACK error
         FailWriteRequest1ErrorAck,          // Instead of sending MISSION_REQUEST 1, send MISSION_ACK error
         FailWriteFinalAckNoResponse,        // Don't send the final MISSION_ACK
+        FailWriteFinalAckFirstResponse,     // Don't send the final MISSION_ACK the first time, send it if the last item is sent again
         FailWriteFinalAckErrorAck,          // Send an error as the final MISSION_ACK
         FailWriteFinalAckMissingRequests,   // Send the MISSION_ACK before all items have been requested
     };
@@ -105,5 +106,6 @@ private:
     bool _failReadRequestListFirstResponse = true;
     bool _failReadRequest1FirstResponse = true;
     bool _failWriteMissionCountFirstResponse = true;
+    bool _failWriteFinalAckFirstResponse = true;
     QMap<MAV_MISSION_TYPE, int> _requestListCounts;
 };

--- a/src/MissionManager/PlanManager.cc
+++ b/src/MissionManager/PlanManager.cc
@@ -199,9 +199,21 @@ void PlanManager::_ackTimeout(void)
     case AckMissionRequest:
         // MISSION_REQUEST is expected, or MISSION_ACK to end sequence
         if (_itemIndicesToWrite.count() == 0) {
-            // Vehicle did not send final MISSION_ACK at end of sequence
-            _sendError(ProtocolError, tr("Mission write failed, vehicle failed to send final ack."));
-            _finishTransaction(false);
+            if (_lastMissionRequest < 0) {
+                // No item was ever requested (e.g. writing an empty mission), so there is nothing to resend.
+                _sendError(ProtocolError, tr("Mission write failed, vehicle failed to send final ack."));
+                _finishTransaction(false);
+            } else if (_retryCount > _maxRetryCount) {
+                _sendError(MaxRetryExceeded, tr("Mission write failed, maximum retries exceeded waiting for final ack."));
+                _finishTransaction(false);
+            } else {
+                // Vehicle did not send final MISSION_ACK at end of sequence. It may have stored the mission
+                // successfully and just lost the ack on the way back, so nudge it by resending the last item -
+                // the vehicle is expected to treat this as a duplicate and resend its ack in response.
+                _retryCount++;
+                qCDebug(PlanManagerLog) << QStringLiteral("Retrying %1 final ack by resending last item, retry Count").arg(_planTypeString()) << _retryCount;
+                _sendMissionItem(_lastMissionRequest);
+            }
         } else if (_itemIndicesToWrite[0] == 0) {
             // Vehicle did not respond to MISSION_COUNT, try again
             if (_retryCount > _maxRetryCount) {
@@ -522,8 +534,16 @@ void PlanManager::_handleMissionRequest(const mavlink_message_t& message)
         _itemIndicesToWrite.removeOne(missionRequestSeq);
     }
 
-    MissionItem* item = _writeMissionItems[missionRequestSeq];
-    qCDebug(PlanManagerLog) << QStringLiteral("_handleMissionRequest %1 sequenceNumber:command").arg(_planTypeString()) << missionRequestSeq << item->command();
+    _sendMissionItem(missionRequestSeq);
+}
+
+/// Sends a single mission item to the vehicle as part of a write transaction and (re-)starts the ack timeout.
+/// Used both for the initial send in response to MISSION_REQUEST(_INT), and to resend the last item if the
+/// final MISSION_ACK times out (the vehicle may have stored it but the ack got dropped on the way back).
+void PlanManager::_sendMissionItem(int seq)
+{
+    MissionItem* item = _writeMissionItems[seq];
+    qCDebug(PlanManagerLog) << QStringLiteral("_sendMissionItem %1 sequenceNumber:command").arg(_planTypeString()) << seq << item->command();
 
     SharedLinkInterfacePtr sharedLink = _vehicle->vehicleLinkManager()->primaryLink().lock();
     if (sharedLink) {
@@ -535,10 +555,10 @@ void PlanManager::_handleMissionRequest(const mavlink_message_t& message)
                                                &messageOut,
                                                _vehicle->id(),
                                                MAV_COMP_ID_AUTOPILOT1,
-                                               missionRequestSeq,
+                                               seq,
                                                item->frame(),
                                                item->command(),
-                                               missionRequestSeq == 0,
+                                               seq == 0,
                                                item->autoContinue(),
                                                item->param1(),
                                                item->param2(),

--- a/src/MissionManager/PlanManager.h
+++ b/src/MissionManager/PlanManager.h
@@ -105,6 +105,7 @@ protected:
     void _handleMissionRequest(const mavlink_message_t& message);
     void _handleMissionAck(const mavlink_message_t& message);
     void _requestNextMissionItem(void);
+    void _sendMissionItem(int seq);
     void _clearMissionItems(void);
     void _sendError(ErrorCode_t errorCode, const QString& errorMsg);
     QString _ackTypeToString(AckType_t ackType);

--- a/test/MissionManager/MissionManagerTest.cc
+++ b/test/MissionManager/MissionManagerTest.cc
@@ -203,6 +203,7 @@ void MissionManagerTest::_testWriteFailureHandlingWorker()
         {"FailWriteRequest0ErrorAck", MockLinkMissionItemHandler::FailWriteRequest0ErrorAck, true},
         {"FailWriteRequest1ErrorAck", MockLinkMissionItemHandler::FailWriteRequest1ErrorAck, true},
         {"FailWriteFinalAckNoResponse", MockLinkMissionItemHandler::FailWriteFinalAckNoResponse, true},
+        {"FailWriteFinalAckFirstResponse", MockLinkMissionItemHandler::FailWriteFinalAckFirstResponse, false},
         {"FailWriteFinalAckErrorAck", MockLinkMissionItemHandler::FailWriteFinalAckErrorAck, true},
         {"FailWriteFinalAckMissingRequests", MockLinkMissionItemHandler::FailWriteFinalAckMissingRequests, true},
     };


### PR DESCRIPTION
## Problem
If the final mission ack is lost on the link the user gets the message "Mission write failed, vehicle failed to send final ack." even though the mission was uploaded succesfully. Based on the message he'll manually reupload the entire mission again.

## Solution
[PX4 does resend the final ack upon receiving the last waypoint again](https://github.com/PX4/PX4-Autopilot/blob/cda3c3603f0b0c52e878ed1852c1a80131bddf01/src/modules/mavlink/mavlink_mission.cpp#L1164). So in case the last mission ack times out, we should not immediately give up but retransmit the last waypoint like we do if a waypoint or an ack in the middle of the mission transfer goes missing.

## Type of Change
- Bug fix (non-breaking change that fixes an issue)

## Testing
<!-- Describe the tests you ran and how to reproduce them -->
- [ ] Tested locally
- [ ] Added/updated unit tests
- [ ] Tested with simulator (SITL)
- [ ] Tested with hardware

### Platforms Tested
<!-- Check all that apply -->
- [ ] Linux
- [ ] Windows
- [ ] macOS
- [ ] Android
- [ ] iOS

### Flight Stacks Tested
<!-- If applicable -->
- [ ] PX4
- [ ] ArduPilot

## Checklist
<!-- Go over all the following points, and put an 'x' in all the boxes that apply -->
- [x] I have read the [Contribution Guidelines](CONTRIBUTING.md)
- [x] I have read the [Code of Conduct](CODE_OF_CONDUCT.md)
- [x] My code follows the project's coding standards
- [x] I have added tests that prove my fix/feature works
- [ ] New and existing unit tests pass locally

---
By submitting this pull request, I confirm that my contribution is made under the terms of the project's dual license (Apache 2.0 and GPL v3).
