### PR TITLE
fix(AppSettings): fix group divider visuals

### DIFF
--- a/src/QmlControls/AppSettings.qml
+++ b/src/QmlControls/AppSettings.qml
@@ -34,6 +34,33 @@ Rectangle {
         return !!_expandedPages[pageIndex]
     }
 
+    function _pageVisible(entry) {
+        return entry && entry.name !== "Divider" &&
+               (typeof entry.pageVisible !== "function" || entry.pageVisible())
+    }
+
+    function _dividerVisible(pageIndex) {
+        if (_searchQuery.trim() !== "") return false
+
+        var previousPageIndex = -1
+        for (var i = pageIndex - 1; i >= 0; i--) {
+            if (_pageVisible(settingsPagesModel.get(i))) {
+                previousPageIndex = i
+                break
+            }
+        }
+        if (previousPageIndex < 0) return false
+
+        for (var j = previousPageIndex + 1; j < pageIndex; j++) {
+            if (settingsPagesModel.get(j).name === "Divider") return false
+        }
+
+        for (var k = pageIndex + 1; k < settingsPagesModel.count; k++) {
+            if (_pageVisible(settingsPagesModel.get(k))) return true
+        }
+        return false
+    }
+
     // Search: returns array of matching section indices for a page, or empty if no match
     function _matchingSections(pageIndex) {
         var query = _searchQuery.toLowerCase().trim()
@@ -222,7 +249,7 @@ Rectangle {
                     property bool isExpanded: hasMultipleSections && (isSearching ? matchesSearch : settingsView._isExpanded(index))
 
                     visible: {
-                        if (pageName === "Divider") return !isSearching
+                        if (pageName === "Divider") return settingsView._dividerVisible(index)
                         if (!pageVisible()) return false
                         if (isSearching) return matchesSearch
                         return true
@@ -233,6 +260,14 @@ Rectangle {
                         Layout.fillWidth: true
                         height: ScreenTools.defaultFontPixelHeight / 2
                         visible: pageName === "Divider"
+
+                        Rectangle {
+                            anchors.left:           parent.left
+                            anchors.right:          parent.right
+                            anchors.verticalCenter: parent.verticalCenter
+                            height:                 1
+                            color:                  qgcPal.windowShade
+                        }
                     }
 
                     // Page button


### PR DESCRIPTION
## Description
Adds a visible divider line between settings groups. Hides dividers when there is no visible settings group on both sides to avoid duplicates.

New divider style is consistent with the existing divider between this settings page navigation list and the settings view. 

## Type of Change
- [X] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] CI/Build changes
- [ ] Other

## Testing
- [X] Tested locally
- [ ] Added/updated unit tests
- [ ] Tested with simulator (SITL)
- [ ] Tested with hardware

### Platforms Tested
- [ ] Linux
- [X] Windows
- [ ] macOS
- [X] Android
- [ ] iOS

## Checklist
- [X] I have read the [Contribution Guidelines](CONTRIBUTING.md)
- [X] I have read the [Code of Conduct](CODE_OF_CONDUCT.md)
- [X] My code follows the project's coding standards
- [ ] I have added tests that prove my fix/feature works
- [X] New and existing unit tests pass locally

---
By submitting this pull request, I confirm that my contribution is made under the terms of the project's dual license (Apache 2.0 and GPL v3).
