### PR TITLE
fix(CMake): use host platform for Python venv

### DIFF
--- a/cmake/modules/PythonVenv.cmake
+++ b/cmake/modules/PythonVenv.cmake
@@ -1,6 +1,6 @@
 option(QGC_AUTO_PYTHON_VENV "Auto-create <repo>/.venv with generator deps if missing" ON)
 
-if(WIN32)
+if(CMAKE_HOST_WIN32)
     set(_qgc_venv_python "${CMAKE_SOURCE_DIR}/.venv/Scripts/python.exe")
 else()
     set(_qgc_venv_python "${CMAKE_SOURCE_DIR}/.venv/bin/python")


### PR DESCRIPTION
## Description
Selects the workspace virtual environment interpreter based on the host platform instead of the target platform. This fixes Android cross-compilation on Windows selecting the Unix `.venv/bin/python` path.

## Type of Change
- [X] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)
- [X] CI/Build changes
- [ ] Other

## Testing
- [X] Tested locally
- [ ] Added/updated unit tests
- [ ] Tested with simulator (SITL)
- [X] Tested with hardware

### Platforms Tested
- [ ] Linux
- [X] Windows
- [ ] macOS
- [X] Android
- [ ] iOS

## Checklist
- [X] I have read the [Contribution Guidelines](CONTRIBUTING.md)
- [X] I have read the [Code of Conduct](CODE_OF_CONDUCT.md)
- [X] My code follows the project's coding standards
- [ ] I have added tests that prove my fix/feature works
- [X] New and existing unit tests pass locally

---
By submitting this pull request, I confirm that my contribution is made under the terms of the project's dual license (Apache 2.0 and GPL v3).
