### PR TITLE
fix(PX4): sync px4_custom_mode.h with PX4 1.18 so external modes are selectable

### DIFF
--- a/src/FirmwarePlugin/PX4/px4_custom_mode.h
+++ b/src/FirmwarePlugin/PX4/px4_custom_mode.h
@@ -1,5 +1,9 @@
 #pragma once
 
+// Mirror of PX4's src/modules/commander/px4_custom_mode.h (source of truth),
+// except PX4CustomMode at the bottom which is QGC-specific.
+// Values are transmitted over MAVLink: never renumber or insert, only append.
+
 #include <stdint.h>
 
 enum PX4_CUSTOM_MAIN_MODE {
@@ -27,7 +31,15 @@ enum PX4_CUSTOM_SUB_MODE_AUTO {
 	PX4_CUSTOM_SUB_MODE_AUTO_FOLLOW_TARGET = 8,
 	PX4_CUSTOM_SUB_MODE_AUTO_PRECLAND = 9,
 	PX4_CUSTOM_SUB_MODE_AUTO_VTOL_TAKEOFF = 10,
-	PX4_CUSTOM_SUB_MODE_GUIDED_COURSE = 11,
+	PX4_CUSTOM_SUB_MODE_EXTERNAL1 = 11,
+	PX4_CUSTOM_SUB_MODE_EXTERNAL2 = 12,
+	PX4_CUSTOM_SUB_MODE_EXTERNAL3 = 13,
+	PX4_CUSTOM_SUB_MODE_EXTERNAL4 = 14,
+	PX4_CUSTOM_SUB_MODE_EXTERNAL5 = 15,
+	PX4_CUSTOM_SUB_MODE_EXTERNAL6 = 16,
+	PX4_CUSTOM_SUB_MODE_EXTERNAL7 = 17,
+	PX4_CUSTOM_SUB_MODE_EXTERNAL8 = 18,
+	PX4_CUSTOM_SUB_MODE_GUIDED_COURSE = 19,
 };
 
 enum PX4_CUSTOM_SUB_MODE_POSCTL {

--- a/test/Vehicle/CMakeLists.txt
+++ b/test/Vehicle/CMakeLists.txt
@@ -25,6 +25,8 @@ target_sources(${CMAKE_PROJECT_NAME}
         MavCommandQueueReentrancyTest.h
         MultiVehicleManagerTest.cc
         MultiVehicleManagerTest.h
+        PX4ExternalFlightModesTest.cc
+        PX4ExternalFlightModesTest.h
         RemoteIDManagerTest.cc
         RemoteIDManagerTest.h
         RequestMessageTest.cc
@@ -61,6 +63,7 @@ add_qgc_test(InitialConnectPeripheralStartupTest LABELS Integration Vehicle)
 add_qgc_test(MAVLinkLogManagerTest LABELS Integration Vehicle)
 add_qgc_test(MavCommandQueueReentrancyTest LABELS Integration Vehicle)
 add_qgc_test(MultiVehicleManagerTest LABELS Integration Vehicle)
+add_qgc_test(PX4ExternalFlightModesTest LABELS Unit Vehicle)
 add_qgc_test(RemoteIDManagerTest LABELS Integration Vehicle)
 add_qgc_test(RequestMessageTest LABELS Integration Vehicle TIMEOUT ${QGC_TEST_TIMEOUT_EXTENDED})
 add_qgc_test(SendMavCommandWithHandlerTest LABELS Integration Vehicle)

--- a/test/Vehicle/PX4ExternalFlightModesTest.cc
+++ b/test/Vehicle/PX4ExternalFlightModesTest.cc
@@ -1,0 +1,29 @@
+#include "PX4ExternalFlightModesTest.h"
+
+#include "PX4FirmwarePlugin.h"
+#include "Vehicle.h"
+#include "px4_custom_mode.h"
+
+void PX4ExternalFlightModesTest::_externalModeSelectableOnMultiRotor()
+{
+    Vehicle vehicle(MAV_AUTOPILOT_PX4, MAV_TYPE_QUADROTOR);
+
+    // Local plugin instance so the shared firmware plugin singleton is not mutated
+    PX4FirmwarePlugin plugin;
+
+    // External mode 1 (PX4 AUTO sub_mode 11) as reported via AVAILABLE_MODES.
+    // Must not collide with any built-in PX4CustomMode value (see issue #14886).
+    px4_custom_mode ext1{};
+    ext1.main_mode = PX4_CUSTOM_MAIN_MODE_AUTO;
+    ext1.sub_mode = PX4_CUSTOM_SUB_MODE_EXTERNAL1;
+
+    FlightModeList modeList = {
+        FirmwareFlightMode{QStringLiteral("Position"), 1, PX4CustomMode::POSCTL_POSCTL, true, false, true, true},
+        FirmwareFlightMode{QStringLiteral("Cage (Autonomous)"), 0, ext1.data, true, false, true, true},
+    };
+    plugin.updateAvailableFlightModes(modeList);
+
+    QVERIFY(plugin.flightModes(&vehicle).contains(QStringLiteral("Cage (Autonomous)")));
+}
+
+UT_REGISTER_TEST(PX4ExternalFlightModesTest, TestLabel::Unit, TestLabel::Vehicle)

--- a/test/Vehicle/PX4ExternalFlightModesTest.h
+++ b/test/Vehicle/PX4ExternalFlightModesTest.h
@@ -1,0 +1,11 @@
+#pragma once
+
+#include "UnitTest.h"
+
+class PX4ExternalFlightModesTest : public UnitTest
+{
+    Q_OBJECT
+
+private slots:
+    void _externalModeSelectableOnMultiRotor();
+};


### PR DESCRIPTION
Fixes #14886

## Problem

Externally-registered PX4 ROS 2 flight modes (e.g. "Cage (Autonomous)") reported via `AVAILABLE_MODES` were not shown in the flight mode selector, even though the mode name displayed correctly in the toolbar.

## Root Cause

QGC's copy of `px4_custom_mode.h` was stale: it still had `PX4_CUSTOM_SUB_MODE_GUIDED_COURSE = 11`, but PX4 assigned sub-modes 11–18 to `EXTERNAL1`–`EXTERNAL8` and moved `GUIDED_COURSE` to 19. An external mode's `custom_mode` (AUTO main mode, sub-mode 11) therefore matched the `PX4CustomMode::AUTO_GUIDED_COURSE` case in `PX4FirmwarePlugin::updateAvailableFlightModes()`, which sets `multiRotor = false` — so the mode was filtered out of `flightModes()` on multirotors.

## Fix

Re-sync the `PX4_CUSTOM_SUB_MODE_AUTO` enum with PX4 v1.18 (`src/modules/commander/px4_custom_mode.h`): `EXTERNAL1`–`EXTERNAL8` = 11–18, `GUIDED_COURSE` = 19. All other values in the file were verified against the PX4 v1.18 source. `AUTO_GUIDED_COURSE` consumers automatically pick up the corrected wire value.

## Testing

New unit test `PX4ExternalFlightModesTest` registers an external mode via `updateAvailableFlightModes()` and verifies it appears in `flightModes()` for a multirotor. Verified failing before the fix, passing after.
