### PR TITLE
fix(AnalyzeView): prevent segfault when re-entering Onboard Logs during download

### DIFF
--- a/src/AnalyzeView/AnalyzeView.qml
+++ b/src/AnalyzeView/AnalyzeView.qml
@@ -93,7 +93,6 @@ Rectangle {
 
                 Component.onCompleted: {
                     if (count > 0) {
-                        itemAt(0).checked = true
                         _currentPage = QGroundControl.corePlugin.analyzePages[0]
                         panelContainer.title = _currentPage.title
                         _updatePanelSource()
@@ -103,14 +102,16 @@ Rectangle {
                 SubMenuButton {
                     objectName:         "analyzeButton_" + modelData.title
                     imageResource:      modelData.icon
-                    autoExclusive:      true
                     text:               modelData.title
                     width:              buttonColumn._maxButtonWidth
+                    checked:            _currentPage === modelData
 
                     onClicked: {
+                        if (!mainWindow.allowViewSwitch()) {
+                            return
+                        }
                         _currentPage        = modelData
                         panelContainer.title = modelData.title
-                        checked             = true
                         _updatePanelSource()
                     }
                 }

--- a/src/AnalyzeView/OnboardLogs/OnboardLogController.cc
+++ b/src/AnalyzeView/OnboardLogs/OnboardLogController.cc
@@ -494,6 +494,13 @@ bool OnboardLogController::_prepareLogDownload()
 
 void OnboardLogController::refresh()
 {
+    if (_downloadingLogs || _requestingLogEntries || _ftpDeleting) {
+        // Re-entering the page while a transfer is active must not clear the model:
+        // the transfer holds pointers into it (issue #14881)
+        qCDebug(OnboardLogControllerLog) << "refresh: ignored - transfer in progress";
+        return;
+    }
+
     _logEntriesModel->clearAndDeleteContents();
     emit selectionChanged();
 

--- a/src/AnalyzeView/OnboardLogs/OnboardLogPage.qml
+++ b/src/AnalyzeView/OnboardLogs/OnboardLogPage.qml
@@ -10,6 +10,22 @@ AnalyzePage {
     pageComponent: pageComponent
     pageDescription: qsTr("Onboard Logs allows you to download binary log files from your vehicle. Click Refresh to get list of available logs.")
 
+    function _updateNavigationBlocked() {
+        if (OnboardLogController.downloadingLogs) {
+            globals.navigationBlockedReason = qsTr("Wait for the log download to complete or cancel it first")
+        } else {
+            globals.navigationBlockedReason = ""
+        }
+    }
+
+    Connections {
+        target: OnboardLogController
+        function onDownloadingLogsChanged() { onboardLogPage._updateNavigationBlocked() }
+    }
+
+    Component.onCompleted: _updateNavigationBlocked()
+    Component.onDestruction: globals.navigationBlockedReason = ""
+
     Component {
         id: pageComponent
 

--- a/test/AnalyzeView/OnboardLogDownloadTest.cc
+++ b/test/AnalyzeView/OnboardLogDownloadTest.cc
@@ -80,13 +80,13 @@ void OnboardLogDownloadTest::_downloadTest()
     QCOMPARE(model->count(), 1);
     model->value<QGCOnboardLogEntry*>(0)->setSelected(true);
 
-    const QString downloadTo = QDir::currentPath();
-    QVERIFY(downloadAndWaitForComplete(controller, multiSpy, downloadTo));
+    QTemporaryDir tempDir;
+    QVERIFY(tempDir.isValid());
+    QVERIFY(downloadAndWaitForComplete(controller, multiSpy, tempDir.path()));
 
-    const QString downloadFile = QDir(downloadTo).filePath("log_0_UnknownDate.ulg");
+    const QString downloadFile = QDir(tempDir.path()).filePath("log_0_UnknownDate.ulg");
     QVERIFY(UnitTest::fileCompare(downloadFile, _mockLink->logDownloadFile()));
     QCOMPARE(model->value<QGCOnboardLogEntry*>(0)->status(), QStringLiteral("Downloaded"));
-    (void)QFile::remove(downloadFile);
 }
 
 void OnboardLogDownloadTest::_selectAllTest()
@@ -129,8 +129,9 @@ void OnboardLogDownloadTest::_cancelDownloadTest()
 
     // download() synchronously creates the local file and requests the first chunk,
     // so canceling immediately exercises the cancel-while-downloading path.
-    const QString downloadTo = QDir::currentPath();
-    controller->download(downloadTo);
+    QTemporaryDir tempDir;
+    QVERIFY(tempDir.isValid());
+    controller->download(tempDir.path());
     QVERIFY(controller->_getDownloadingLogs());
     controller->cancel();
 
@@ -139,7 +140,46 @@ void OnboardLogDownloadTest::_cancelDownloadTest()
     QCOMPARE(controller->selectedCount(), 0);
 
     // The partially downloaded file must have been removed
-    QVERIFY(!QFile::exists(QDir(downloadTo).filePath("log_0_UnknownDate.ulg")));
+    QVERIFY(!QFile::exists(QDir(tempDir.path()).filePath("log_0_UnknownDate.ulg")));
+}
+
+void OnboardLogDownloadTest::_refreshDuringDownloadTest()
+{
+    // Re-entering the Onboard Logs page triggers a refresh(). While a download is in
+    // progress this must be a no-op: clearing the model would leave the download
+    // referencing deleted entries (issue #14881).
+    OnboardLogController* const controller = new OnboardLogController(this);
+    MultiSignalSpy* multiSpy = new MultiSignalSpy(this);
+    QVERIFY(multiSpy->init(controller));
+
+    QVERIFY(refreshAndWaitForListComplete(controller, multiSpy));
+
+    QmlObjectListModel* const model = controller->_getModel();
+    QVERIFY(model);
+    QCOMPARE(model->count(), 1);
+    model->value<QGCOnboardLogEntry*>(0)->setSelected(true);
+
+    QTemporaryDir tempDir;
+    QVERIFY(tempDir.isValid());
+    multiSpy->clearAllSignals();
+    controller->download(tempDir.path());
+    QVERIFY(controller->_getDownloadingLogs());
+
+    controller->refresh();
+
+    QVERIFY(controller->_getDownloadingLogs());
+    QCOMPARE(model->count(), 1);
+
+    // The download must still run to completion
+    multiSpy->clearAllSignals();
+    if (controller->property("downloadingLogs").toBool()) {
+        QVERIFY(multiSpy->waitForSignal("downloadingLogsChanged", TestTimeout::longMs()));
+    }
+    QVERIFY(!controller->_getDownloadingLogs());
+
+    const QString downloadFile = QDir(tempDir.path()).filePath("log_0_UnknownDate.ulg");
+    QVERIFY(UnitTest::fileCompare(downloadFile, _mockLink->logDownloadFile()));
+    QCOMPARE(model->value<QGCOnboardLogEntry*>(0)->status(), QStringLiteral("Downloaded"));
 }
 
 void OnboardLogDownloadTest::_vehicleDisconnectDuringDownloadTest()
@@ -527,6 +567,51 @@ void OnboardLogFtpDownloadTest::_ftpCancelDownloadTest()
 
     QVERIFY(!controller->_getDownloadingLogs());
     QCOMPARE(entry->status(), QStringLiteral("Canceled"));
+}
+
+void OnboardLogFtpDownloadTest::_ftpRefreshDuringDownloadTest()
+{
+    _connectMockLink(MAV_AUTOPILOT_PX4, MockConfiguration::FailNone, MockConfiguration::OptionFtpCapability);
+    if (QTest::currentTestFailed()) return;
+
+    // Large enough that the download spans multiple FTP bursts and outlives the refresh() call
+    _mockLink->mockLinkFTP()->setLogFiles({ { QStringLiteral("log_big.ulg"), 1000000, 1700000000 } });
+
+    OnboardLogController* const controller = new OnboardLogController(this);
+    MultiSignalSpy* multiSpy = new MultiSignalSpy(this);
+    QVERIFY(multiSpy->init(controller));
+
+    QVERIFY(refreshAndWaitForListComplete(controller, multiSpy));
+    QmlObjectListModel* const model = controller->_getModel();
+    QCOMPARE(model->count(), 1);
+    QGCOnboardLogEntry* const entry = model->value<QGCOnboardLogEntry*>(0);
+    entry->setSelected(true);
+
+    QTemporaryDir tempDir;
+    QVERIFY(tempDir.isValid());
+    multiSpy->clearAllSignals();
+    controller->download(tempDir.path());
+    QVERIFY(controller->_getDownloadingLogs());
+
+    // Re-entering the Onboard Logs page triggers a refresh(). While a download is in
+    // progress this must be a no-op: clearing the model would leave the download
+    // referencing deleted entries (issue #14881).
+    controller->refresh();
+
+    QVERIFY(controller->_getDownloadingLogs());
+    QCOMPARE(model->count(), 1);
+    QCOMPARE(model->value<QGCOnboardLogEntry*>(0), entry);
+
+    // The download must still run to completion
+    multiSpy->clearAllSignals();
+    if (controller->property("downloadingLogs").toBool()) {
+        QVERIFY(multiSpy->waitForSignal("downloadingLogsChanged", TestTimeout::longMs()));
+    }
+    QVERIFY(!controller->_getDownloadingLogs());
+
+    const QString downloadFile = QDir(tempDir.path()).filePath(QStringLiteral("log_big.ulg"));
+    QVERIFY(QFile::exists(downloadFile));
+    QCOMPARE(entry->status(), QStringLiteral("Downloaded"));
 }
 
 void OnboardLogFtpDownloadTest::_ftpEraseSelectedTest()

--- a/test/AnalyzeView/OnboardLogDownloadTest.h
+++ b/test/AnalyzeView/OnboardLogDownloadTest.h
@@ -14,6 +14,7 @@ private slots:
     void _downloadTest();
     void _selectAllTest();
     void _cancelDownloadTest();
+    void _refreshDuringDownloadTest();
     void _vehicleDisconnectDuringDownloadTest();
     void _eraseAllTest();
 };
@@ -33,6 +34,7 @@ private slots:
     void _ftpDownloadErrorDisablesFtpTest();
     void _ftpSortOrderTest();
     void _ftpCancelDownloadTest();
+    void _ftpRefreshDuringDownloadTest();
     void _ftpEraseSelectedTest();
     void _ftpCancelEraseSelectedTest();
 };


### PR DESCRIPTION
Fixes #14881

QGC segfaulted when re-entering the Onboard Logs page while a log download was in progress. The page's `Component.onCompleted` calls `OnboardLogController.refresh()`, which unconditionally cleared the log entries model while the active transfer (`_ftpCurrentDownloadEntry`, `_ftpDownloadQueue`, `_downloadData->entry`) still held pointers into it.

### Changes

- **OnboardLogController::refresh()**: ignore the call while a download, listing, or FTP delete is in progress, so the model can never be cleared out from under an active transfer.
- **OnboardLogPage.qml**: block view/page navigation while a download is in progress via `globals.navigationBlockedReason` (same pattern as SensorsSetup), per the issue discussion — the user must complete or cancel the download first.
- **AnalyzeView.qml**: sidebar page buttons now respect `mainWindow.allowViewSwitch()` and use a declarative `checked` binding, so switching analyze pages is also blocked during a download.

### Testing

- New unit tests (TDD — both reproduced the failure before the fix):
  - `_refreshDuringDownloadTest` (message transport)
  - `_ftpRefreshDuringDownloadTest` (FTP transport, reproduced the exact segfault from the issue)
- `OnboardLogDownloadTest` 8/8, `OnboardLogFtpDownloadTest` 13/13, `TopLevelViewsTest` 3/3, `OnboardLogUITest` 6/6 all pass.
