### PR TITLE
feat(GeoMap): Google Earth-style gestures, waypoint drop lines, GeoView docs

### DIFF
--- a/docs/en/SUMMARY.md
+++ b/docs/en/SUMMARY.md
@@ -15,6 +15,7 @@
     - [Video](qgc-user-guide/fly_view/video.md)
     - [Video Overlay](qgc-user-guide/fly_view/video_overlay.md)
   - [3D View](qgc-user-guide/viewer_3d/viewer_3d.md)
+  - [GeoView (Tech Preview)](qgc-user-guide/fly_view/geoview.md)
 - [Plan](qgc-user-guide/plan_view/plan_view.md)
   - [GeoFence](qgc-user-guide/plan_view/plan_geofence.md)
   - [Rally Points](qgc-user-guide/plan_view/plan_rally_points.md)

--- a/docs/en/qgc-user-guide/fly_view/geoview.md
+++ b/docs/en/qgc-user-guide/fly_view/geoview.md
@@ -1,0 +1,47 @@
+# GeoView (Tech Preview)
+
+:::warning
+GeoView is an experimental technology preview and is under active development. Expect missing features and rough edges.
+It is too early to report issues against this feature — there is still too much work left to do.
+:::
+
+GeoView is a new map engine for QGroundControl that renders a single, seamless 2D/3D map: satellite/street imagery draped over real terrain elevation, with Google Earth-style camera controls. It displays your vehicles, the planned mission (with waypoint markers, connecting path, and drop lines showing each waypoint's height above the terrain), the flown flight path, the launch location, and the ground station position — all in true 3D.
+
+:::info
+GeoView is currently a display-only view. You must still use the regular [Fly View](fly_view.md) to control the vehicle (arm, takeoff, guided actions, mission control, and so on).
+:::
+
+The long-term goal is for the GeoView engine to eventually replace all map usage throughout QGroundControl, including the Fly and Plan views, providing one consistent 2D/3D map experience everywhere.
+
+## Enabling GeoView
+
+GeoView is disabled by default. To enable it, go to **Application Settings > GeoView** and turn on **Enable GeoView (preview)**. It then appears in the view selector dropdown in the main toolbar.
+
+## View Controls
+
+Camera gestures follow Google Earth semantics: the ground point under the cursor when a gesture starts stays pinned under the cursor throughout the gesture.
+
+- **Mouse:**
+  - **Pan**: Left-drag. The terrain point you grabbed follows the cursor.
+  - **Orbit (rotate)**: Right-drag or middle-drag. The view rotates around the ground point you pressed on (marked by a pivot ring): left/right changes heading, up/down changes tilt between top-down and near-horizontal.
+  - **Zoom**: Scroll wheel or trackpad scroll. Zooms toward/away from the point under the cursor.
+- **Touch:**
+  - **Pan**: Single-finger drag.
+  - **Zoom**: Two-finger pinch, centered on the pinch point.
+  - **Rotate**: Two-finger twist.
+
+### Keyboard Support
+
+Keyboard modifiers provide alternatives to the multi-button mouse gestures (useful with one-button mice and trackpads):
+
+- **Shift + left-drag**: Orbit, same as right/middle-drag.
+- **Ctrl + left-drag**: First-person look. The camera stays in place and the view rotates, like turning your head — drag toward where you want to look. On macOS both **Ctrl** and **Cmd** work.
+
+### 2D/3D Modes
+
+- The **3D/2D** button in the top-right switches between modes. Switching animates the camera tilt and flattens/raises the terrain; 2D mode behaves like a traditional top-down map (tilt is locked).
+- The **compass** button rotates with the current heading; click it to animate the view back to north-up.
+
+## Imagery and Terrain
+
+GeoView drapes the same map imagery you have selected in **Application Settings > Maps** over its terrain surface. Terrain elevation comes from the Mapzen/Tilezen terrain tiles dataset (SRTM, 3DEP, GMTED2010, ETOPO1); attribution is shown in the lower-left overlay.

--- a/docs/en/qgc-user-guide/getting_started/whats_new.md
+++ b/docs/en/qgc-user-guide/getting_started/whats_new.md
@@ -2,6 +2,13 @@
 
 This page highlights user-facing changes since the last stable release (V5.1).
 
+## GeoView (Tech Preview)
+
+A new experimental map engine that renders a single, seamless 2D/3D map: your selected map imagery draped over real terrain elevation, with Google Earth-style camera controls.
+It displays vehicles, the planned mission, the flown flight path, launch and ground station locations in true 3D.
+GeoView is currently display-only (vehicle control stays in the regular Fly View), but the goal is for it to eventually replace all map usage in QGroundControl.
+It is disabled by default — see [GeoView (Tech Preview)](../fly_view/geoview.md) for how to enable it and full details.
+
 ## Fly View
 
 ### Click to ROI Altitude

--- a/src/GeoMap/GeoMap.qml
+++ b/src/GeoMap/GeoMap.qml
@@ -18,7 +18,8 @@ import QGroundControl.GeoMap
 
 /// Experimental 2D/3D map control (preview feature): the GeoMap-engine
 /// counterpart of FlightMap. Renders the LOD surface patch quadtree with full
-/// camera gestures (pan, orbit, zoom, twist) and no view chrome.
+/// Google Earth-style camera gestures (pan, orbit, zoom, twist, first-person
+/// look) and no view chrome.
 Item {
     id: root
 
@@ -126,6 +127,21 @@ Item {
                                     * geoScene.verticalScale * geoScene.terrainScale
     }
 
+    // Scene-space z of the rendered surface under a screen point, so gestures
+    // anchor to the terrain the user actually clicked instead of the z=0
+    // plane far beneath it. Sample at the ground-plane hit, then refine once
+    // at that elevation (same two-step solve as onRecenterVehicleTo).
+    function _surfaceZAt(screenPos) {
+        const coord = geoCamera.coordinateAtScreenPoint(screenPos)
+        if (!coord.isValid) {
+            return 0
+        }
+        const zScale = geoScene.verticalScale * geoScene.terrainScale
+        const z = patchModel.terrainHeightAt(coord) * zScale
+        const refined = geoCamera.coordinateAtScreenPoint(screenPos, z)
+        return refined.isValid ? (patchModel.terrainHeightAt(refined) * zScale) : z
+    }
+
     GeoMapCamera {
         id: geoCamera
         objectName: "geoMapCamera"
@@ -164,7 +180,8 @@ Item {
         gcsPosition: QGroundControl.qgcPositionManger.gcsPosition
         vehicleCoordinate: root._activeVehicleCoordinate
         centerGCSWhenVehicleValid: QGroundControl.settingsManager.flyViewSettings.keepMapCenteredOnVehicle.rawValue
-        userInteracting: panHandler.active || orbitHandler.active || pinchHandler.active
+        userInteracting: panHandler.active || orbitHandler.active || shiftOrbitHandler.active
+                         || lookHandler.active || metaLookHandler.active || pinchHandler.active
         animating: recenterAnimation.running
 
         onCenterMap: (coordinate, firstPosition) => {
@@ -319,7 +336,7 @@ Item {
             id: mapContent3D
         }
 
-        // Gestures (Viewer3D semantics): the ground point under the cursor
+        // Gestures (Google Earth semantics): the ground point under the cursor
         // at gesture start stays under the cursor throughout. Any gesture
         // completes a running mode/compass animation to its end state so
         // the two never fight over the same pose properties.
@@ -327,13 +344,15 @@ Item {
             id: panHandler
             target: null
             acceptedButtons: Qt.LeftButton
+            // Plain drag only: Shift/Ctrl+left-drag are the orbit/look gestures below
+            acceptedModifiers: Qt.NoModifier
             onActiveChanged: {
                 if (active) {
                     root.completeCameraAnimations()
                     // Anchor at the current position, not pressPosition: after a
                     // two-finger pinch drops to one finger this handler re-activates
                     // with a stale pressPosition, and anchoring there jumps the map.
-                    geoCamera.beginPan(centroid.position)
+                    geoCamera.beginPan(centroid.position, root._surfaceZAt(centroid.position))
                 }
             }
             onCentroidChanged: {
@@ -343,7 +362,8 @@ Item {
             }
         }
 
-        // Right-drag orbits: full width = 360 deg heading, full height = 180 deg tilt.
+        // Right/middle-drag orbits about the pressed ground point: full width =
+        // 360 deg heading, full height = 180 deg tilt.
         // Mouse/touchpad only: acceptedButtons doesn't filter touch points, so
         // without acceptedDevices this handler steals single-finger drags from
         // panHandler on touchscreens (touch orbits via PinchHandler twist instead).
@@ -352,11 +372,17 @@ Item {
             id: orbitHandler
             target: null
             acceptedDevices: PointerDevice.Mouse | PointerDevice.TouchPad
-            acceptedButtons: Qt.RightButton
+            acceptedButtons: Qt.RightButton | Qt.MiddleButton
+            // Unmodified only: macOS synthesizes Ctrl+left-click as a right-click
+            // (carrying MetaModifier), which must fall through to metaLookHandler
+            acceptedModifiers: Qt.NoModifier
             onActiveChanged: {
                 if (active) {
                     root.completeCameraAnimations()
-                    geoCamera.beginOrbit(centroid.pressPosition)
+                    geoCamera.beginOrbit(centroid.pressPosition, root._surfaceZAt(centroid.pressPosition))
+                    // Apply motion accumulated before activation: a short drag
+                    // can activate and release with no further centroid change
+                    geoCamera.orbitTo(centroid.position)
                 }
             }
             onCentroidChanged: {
@@ -368,9 +394,87 @@ Item {
 
         WheelHandler {
             target: null
+            // Default acceptedDevices=Mouse drops trackpad scroll (and mouse
+            // wheel on Wayland/xcb, which misreport as TouchPad) — see the
+            // FlightMap WheelHandler comment for the full platform rundown
+            acceptedDevices: PointerDevice.Mouse | PointerDevice.TouchPad
             onWheel: (event) => {
                 root.completeCameraAnimations()
                 geoCamera.zoom(event.angleDelta.y, point.position)
+            }
+        }
+
+        // Shift+left-drag orbits about the pressed ground point, same as
+        // right/middle-drag (keyboard-modifier alternative for one-button mice)
+        DragHandler {
+            id: shiftOrbitHandler
+            target: null
+            acceptedDevices: PointerDevice.Mouse | PointerDevice.TouchPad
+            acceptedButtons: Qt.LeftButton
+            acceptedModifiers: Qt.ShiftModifier
+            onActiveChanged: {
+                if (active) {
+                    root.completeCameraAnimations()
+                    geoCamera.beginOrbit(centroid.pressPosition, root._surfaceZAt(centroid.pressPosition))
+                    // Apply motion accumulated before activation (see orbitHandler)
+                    geoCamera.orbitTo(centroid.position)
+                }
+            }
+            onCentroidChanged: {
+                if (active) {
+                    geoCamera.orbitTo(centroid.position)
+                }
+            }
+        }
+
+        // Ctrl+left-drag is first-person look: the camera stays put and the
+        // view rotates, like turning your head (Google Earth Ctrl+drag).
+        // Drag toward where you want to look.
+        DragHandler {
+            id: lookHandler
+            target: null
+            acceptedDevices: PointerDevice.Mouse | PointerDevice.TouchPad
+            acceptedButtons: Qt.LeftButton
+            acceptedModifiers: Qt.ControlModifier
+            onActiveChanged: {
+                if (active) {
+                    root.completeCameraAnimations()
+                    geoCamera.beginLook(centroid.pressPosition)
+                    // Apply motion accumulated before activation (see orbitHandler)
+                    geoCamera.lookTo(centroid.position)
+                }
+            }
+            onCentroidChanged: {
+                if (active) {
+                    geoCamera.lookTo(centroid.position)
+                }
+            }
+        }
+
+        // macOS delivers the physical Ctrl key as Qt.MetaModifier (Qt swaps
+        // Ctrl/Cmd), so accept it too: Ctrl+drag looks on every platform
+        // (and Cmd+drag still works via lookHandler, matching Google Earth).
+        // RightButton included because macOS synthesizes Ctrl+left-click as a
+        // right-click, so that's the button this drag actually arrives on.
+        DragHandler {
+            id: metaLookHandler
+            target: null
+            enabled: Qt.platform.os === "osx"
+            acceptedDevices: PointerDevice.Mouse | PointerDevice.TouchPad
+            acceptedButtons: Qt.LeftButton | Qt.RightButton
+            acceptedModifiers: Qt.MetaModifier
+            onActiveChanged: {
+                if (active) {
+                    root.completeCameraAnimations()
+                    geoCamera.beginLook(centroid.pressPosition)
+                    // Apply motion accumulated before activation (see orbitHandler)
+                    geoCamera.lookTo(centroid.position)
+                }
+            }
+            onCentroidChanged: {
+                if (active) {
+                    geoCamera.lookTo(centroid.position)
+                }
             }
         }
 
@@ -387,6 +491,45 @@ Item {
             }
             onScaleChanged: (delta) => geoCamera.zoomBy(1 / delta, centroid.position)
             onRotationChanged: (delta) => geoCamera.rotateBy(delta, centroid.position)
+        }
+    }
+
+    // Pivot ring (Google Earth-style): marks the ground point an orbit drag
+    // rotates about, visible only while the drag is active. The pivot stays
+    // pinned to its press position on screen, so the ring never moves.
+    Rectangle {
+        id: orbitPivotIndicator
+        objectName: "geoMapOrbitPivotIndicator"
+
+        readonly property point _pivot: orbitHandler.active ? orbitHandler.centroid.pressPosition
+                                                            : shiftOrbitHandler.centroid.pressPosition
+
+        visible: orbitHandler.active || shiftOrbitHandler.active
+        x: _pivot.x - (width / 2)
+        y: _pivot.y - (height / 2)
+        width: ScreenTools.defaultFontPixelHeight * 1.5
+        height: width
+        radius: width / 2
+        color: "transparent"
+        // Dark halo keeps the white ring visible over light imagery
+        border.color: Qt.rgba(0, 0, 0, 0.4)
+        border.width: (ScreenTools.defaultFontPixelHeight / 8) + 2
+
+        Rectangle {
+            anchors.fill: parent
+            anchors.margins: 1
+            radius: width / 2
+            color: "transparent"
+            border.color: "white"
+            border.width: ScreenTools.defaultFontPixelHeight / 8
+        }
+
+        Rectangle {
+            anchors.centerIn: parent
+            width: ScreenTools.defaultFontPixelHeight / 4
+            height: width
+            radius: width / 2
+            color: "white"
         }
     }
 

--- a/src/GeoMap/GeoMapCamera.cc
+++ b/src/GeoMap/GeoMapCamera.cc
@@ -252,7 +252,7 @@ QQuaternion GeoMapCamera::sceneRotation() const
            QQuaternion::fromAxisAndAngle(1, 0, 0, static_cast<float>(_tilt));
 }
 
-std::optional<QPointF> GeoMapCamera::screenToGround(const QPointF& screenPos) const
+std::optional<QPointF> GeoMapCamera::screenToGround(const QPointF& screenPos, double planeZ) const
 {
     if (_viewportSize.isEmpty()) {
         return std::nullopt;
@@ -264,8 +264,20 @@ std::optional<QPointF> GeoMapCamera::screenToGround(const QPointF& screenPos) co
         return std::nullopt;  // at or above the horizon
     }
 
-    const double s = -ray.origin.z / ray.dir.z;
+    const double s = (planeZ - ray.origin.z) / ray.dir.z;
+    if (s <= 0.0) {
+        return std::nullopt;  // plane is behind/above the camera
+    }
     return QPointF(ray.origin.x + (s * ray.dir.x), ray.origin.y + (s * ray.dir.y));
+}
+
+QGeoCoordinate GeoMapCamera::coordinateAtScreenPoint(const QPointF& screenPos, double worldZ) const
+{
+    const auto hit = screenToGround(screenPos, worldZ);
+    if (!hit) {
+        return QGeoCoordinate();
+    }
+    return TileMath::worldToGeo(*hit);
 }
 
 std::optional<QPointF> GeoMapCamera::groundPointCapped(const QPointF& screenPos, double maxRange) const
@@ -378,9 +390,10 @@ QGeoCoordinate GeoMapCamera::centerForCoordinateAtScreenPoint(const QGeoCoordina
     return TileMath::worldToGeo(_centerWorld + delta);
 }
 
-void GeoMapCamera::beginPan(const QPointF& screenPos)
+void GeoMapCamera::beginPan(const QPointF& screenPos, double anchorZ)
 {
-    _panAnchorWorld = screenToGround(screenPos);
+    _panAnchorZ = anchorZ;
+    _panAnchorWorld = screenToGround(screenPos, anchorZ);
 }
 
 void GeoMapCamera::panTo(const QPointF& screenPos)
@@ -388,12 +401,13 @@ void GeoMapCamera::panTo(const QPointF& screenPos)
     if (!_panAnchorWorld) {
         return;
     }
-    _anchorToScreen(*_panAnchorWorld, screenPos);
+    _anchorToScreen(*_panAnchorWorld, screenPos, _panAnchorZ);
 }
 
-void GeoMapCamera::beginOrbit(const QPointF& screenPos)
+void GeoMapCamera::beginOrbit(const QPointF& screenPos, double anchorZ)
 {
-    _orbitAnchorWorld = screenToGround(screenPos);
+    _orbitAnchorZ = anchorZ;
+    _orbitAnchorWorld = screenToGround(screenPos, anchorZ);
     _orbitAnchorScreen = screenPos;
     _orbitStartScreen = screenPos;
     _orbitStartHeading = _heading;
@@ -421,7 +435,52 @@ void GeoMapCamera::orbitTo(const QPointF& screenPos)
     }
 
     // Keep the anchor pinned to its on-screen position from gesture start
-    _anchorToScreen(*_orbitAnchorWorld, _orbitAnchorScreen);
+    _anchorToScreen(*_orbitAnchorWorld, _orbitAnchorScreen, _orbitAnchorZ);
+}
+
+void GeoMapCamera::beginLook(const QPointF& screenPos)
+{
+    const Vec3 offset = cameraOffset(_heading, _tilt, _distance);
+    _lookCameraGround = QPointF(_centerWorld.x() + offset.x, _centerWorld.y() + offset.y);
+    _lookCameraZ = _centerElevation + offset.z;
+    _lookStartScreen = screenPos;
+    _lookStartHeading = _heading;
+    _lookStartTilt = _tilt;
+}
+
+void GeoMapCamera::lookTo(const QPointF& screenPos)
+{
+    if (!_lookCameraGround || _viewportSize.isEmpty()) {
+        return;
+    }
+
+    const QPointF delta = screenPos - _lookStartScreen;
+    const qreal headingDelta = (delta.x() / _viewportSize.width()) * 360.0;
+    const qreal tiltDelta = (-delta.y() / _viewportSize.height()) * 180.0;
+
+    const qreal newHeading = _normalizedHeading(_lookStartHeading + headingDelta);
+    const qreal newTilt = (_mode == Mode::Mode3D) ? std::clamp(_lookStartTilt + tiltDelta, kMinTilt, kMaxTilt) : _tilt;
+
+    // The new center is the fixed camera's forward ray intersected with the
+    // pivot-elevation plane; solved via the pose convention so camera z tracks
+    // _lookCameraZ exactly even when centerElevation moves mid-gesture.
+    // When the consumer re-samples centerElevation on centerChanged (GeoMap
+    // terrain-following), that update lands after this solve: camera z is off
+    // by the per-event elevation delta until the next lookTo re-solves — a
+    // one-event lag, self-correcting while the drag continues.
+    const double height = _lookCameraZ - _centerElevation;
+    if (height <= 0.0) {
+        return;  // camera at/below the pivot plane: no forward ground intersection
+    }
+    // Range-safety clamp: when it engages, the fixed-camera invariant yields
+    // and the camera slides along the view axis to stay within distance limits
+    const qreal newDistance = std::clamp(height / std::cos(qDegreesToRadians(newTilt)), kMinDistance, kMaxDistance);
+
+    const Vec3 offset = cameraOffset(newHeading, newTilt, newDistance);
+    _setCenterWorld(QPointF(_lookCameraGround->x() - offset.x, _lookCameraGround->y() - offset.y));
+    setHeading(newHeading);
+    setTilt(newTilt);
+    setDistance(newDistance);
 }
 
 void GeoMapCamera::rotateBy(qreal degrees, const QPointF& screenPos)
@@ -464,9 +523,9 @@ void GeoMapCamera::zoomBy(qreal factor, const QPointF& screenPos)
     }
 }
 
-void GeoMapCamera::_anchorToScreen(const QPointF& anchorWorld, const QPointF& screenPos)
+void GeoMapCamera::_anchorToScreen(const QPointF& anchorWorld, const QPointF& screenPos, double anchorZ)
 {
-    const auto current = screenToGround(screenPos);
+    const auto current = screenToGround(screenPos, anchorZ);
     if (!current) {
         return;
     }

--- a/src/GeoMap/GeoMapCamera.h
+++ b/src/GeoMap/GeoMapCamera.h
@@ -153,16 +153,28 @@ public:
         setTilt(kDefault3DTilt);
     }
 
-    /// Start a pan gesture at the given screen position (pixels)
-    Q_INVOKABLE void beginPan(const QPointF& screenPos);
-    /// Continue a pan gesture: the ground point picked at beginPan stays under the cursor
+    /// Start a pan gesture at the given screen position (pixels). anchorZ is the
+    /// world-z (scene units) of the grabbed surface point: gestures must anchor to
+    /// the rendered terrain surface, not the z=0 ground plane, or the map slides
+    /// off the cursor over elevated terrain.
+    Q_INVOKABLE void beginPan(const QPointF& screenPos, double anchorZ = 0.0);
+    /// Continue a pan gesture: the surface point picked at beginPan stays under the cursor
     Q_INVOKABLE void panTo(const QPointF& screenPos);
 
-    /// Start an orbit gesture at the given screen position (pixels)
-    Q_INVOKABLE void beginOrbit(const QPointF& screenPos);
-    /// Continue an orbit gesture: rotate rigidly about the ground point picked at beginOrbit.
+    /// Start an orbit gesture at the given screen position (pixels); anchorZ as in beginPan
+    Q_INVOKABLE void beginOrbit(const QPointF& screenPos, double anchorZ = 0.0);
+    /// Continue an orbit gesture: rotate rigidly about the surface point picked at beginOrbit,
+    /// which stays pinned to its on-screen position from gesture start.
     /// Full viewport width of drag = 360 deg heading, full height = 180 deg tilt.
     Q_INVOKABLE void orbitTo(const QPointF& screenPos);
+
+    /// Start a first-person look gesture at the given screen position (pixels)
+    Q_INVOKABLE void beginLook(const QPointF& screenPos);
+    /// Continue a look gesture: rotate the view about the camera position picked at
+    /// beginLook, which stays fixed while heading/tilt (and thus center and distance)
+    /// change (Google Earth Ctrl+drag first-person perspective). Same drag ratios as
+    /// orbitTo. 2D mode locks tilt, leaving a rotation about the camera's vertical axis.
+    Q_INVOKABLE void lookTo(const QPointF& screenPos);
 
     /// Rotate the camera rigidly by degrees about the ground point under screenPos
     /// (positive = counterclockwise heading change). Used for two-finger twist gestures.
@@ -224,10 +236,16 @@ public:
     /// north up (matches the pose convention R = Rz(heading) * Rx(tilt))
     QQuaternion sceneRotation() const;
 
-    /// Intersect the pick ray through screenPos (pixels) with the ground plane z=0.
-    /// Returns the ground point in world meters, or std::nullopt when the ray misses
-    /// (at/above the horizon) or the viewport is not set.
-    std::optional<QPointF> screenToGround(const QPointF& screenPos) const;
+    /// Intersect the pick ray through screenPos (pixels) with the horizontal plane
+    /// at planeZ (scene units, default the ground plane z=0). Returns the hit point
+    /// in world meters, or std::nullopt when the ray misses (at/above the horizon or
+    /// the plane is behind the camera) or the viewport is not set.
+    std::optional<QPointF> screenToGround(const QPointF& screenPos, double planeZ = 0.0) const;
+
+    /// QML-facing screenToGround: geographic coordinate of the pick-ray hit on the
+    /// horizontal plane at worldZ (scene units, same as screenToGround's planeZ).
+    /// Invalid coordinate when the ray misses.
+    Q_INVOKABLE QGeoCoordinate coordinateAtScreenPoint(const QPointF& screenPos, double worldZ = 0.0) const;
 
     /// Like screenToGround, but never fails for horizon misses: the result is capped
     /// at maxRange ground meters from the camera's ground position, along the ray's
@@ -257,8 +275,8 @@ signals:
 
 private:
     void _setCenterWorld(const QPointF& world);
-    /// Shift the center so the ground point anchorWorld appears under screenPos
-    void _anchorToScreen(const QPointF& anchorWorld, const QPointF& screenPos);
+    /// Shift the center so the point anchorWorld (at height anchorZ) appears under screenPos
+    void _anchorToScreen(const QPointF& anchorWorld, const QPointF& screenPos, double anchorZ = 0.0);
     static qreal _normalizedHeading(qreal heading);
 
     QPointF _centerWorld;  // mercator meters
@@ -274,9 +292,16 @@ private:
 
     // Gesture state
     std::optional<QPointF> _panAnchorWorld;
+    double _panAnchorZ = 0.0;
     std::optional<QPointF> _orbitAnchorWorld;
+    double _orbitAnchorZ = 0.0;
     QPointF _orbitAnchorScreen;
     QPointF _orbitStartScreen;
     qreal _orbitStartHeading = 0.0;
     qreal _orbitStartTilt = 0.0;
+    std::optional<QPointF> _lookCameraGround;  // fixed camera ground position (world meters)
+    qreal _lookCameraZ = 0.0;
+    QPointF _lookStartScreen;
+    qreal _lookStartHeading = 0.0;
+    qreal _lookStartTilt = 0.0;
 };

--- a/src/GeoMap/GeoMapWaypointItem.qml
+++ b/src/GeoMap/GeoMapWaypointItem.qml
@@ -68,6 +68,43 @@ GeoMapItem {
         ? root._indicatorSize * _camera.distance * _camera.unitsPerPixelAtUnitDistance / 100
         : 1
 
+    // Rendered-terrain height (true meters) under the marker, for the drop
+    // line; terrainHeightAt is not a binding dependency, so re-sampled
+    // explicitly as terrain tiles arrive and when the item moves
+    property real _groundHeight: 0
+
+    function _updateGroundHeight() {
+        _groundHeight = (root.surfaceModel && root.item) ? root.surfaceModel.terrainHeightAt(root.item.coordinate) : 0
+    }
+
+    Component.onCompleted: _updateGroundHeight()
+    onSurfaceModelChanged: _updateGroundHeight()
+
+    Connections {
+        target: root.surfaceModel
+        function onTerrainHeightsChanged() { root._updateGroundHeight() }
+    }
+
+    Connections {
+        target: root.item
+        function onCoordinateChanged() { root._updateGroundHeight() }
+    }
+
+    // Scene-space length of the drop line from marker to the rendered terrain
+    // (tracks terrainScale, so it flattens in lockstep with the anchor z)
+    readonly property real _dropLength: {
+        if (!scene || !item) {
+            return 0
+        }
+        const drop = (item.amslEntryAlt + homeTerrainBias - _groundHeight) * scene.verticalScale * scene.terrainScale
+        return isFinite(drop) ? Math.max(0, drop) : 0
+    }
+
+    // Drop line diameter: constant apparent width, like the marker
+    readonly property real _dropLineScale: _camera
+        ? (ScreenTools.defaultFontPixelHeight / 8) * _camera.distance * _camera.unitsPerPixelAtUnitDistance / 100
+        : 0
+
     Rectangle {
         anchors.centerIn: parent
         width: root._indicatorSize
@@ -99,12 +136,45 @@ GeoMapItem {
 
     delegate3D: Component {
         Node {
-            scale: Qt.vector3d(root._modelScale, root._modelScale, root._modelScale)
+            Node {
+                scale: Qt.vector3d(root._modelScale, root._modelScale, root._modelScale)
 
+                Model {
+                    source: "#Sphere"
+
+                    materials: PrincipledMaterial {
+                        baseColor: root._markerColor
+                    }
+                }
+            }
+
+            // Drop line to the terrain below (Google Earth-style "extrude"):
+            // anchors the floating marker visually so its altitude is readable
             Model {
-                source: "#Sphere"
+                source: "#Cylinder"   // built-in: 100x100 units, height along +Y
+                visible: root._dropLength > 0
+                opacity: 0.75
+                eulerRotation.x: 90   // stand the height axis up along scene z
+                position: Qt.vector3d(0, 0, -root._dropLength / 2)
+                scale: Qt.vector3d(root._dropLineScale, root._dropLength / 100, root._dropLineScale)
 
                 materials: PrincipledMaterial {
+                    lighting: PrincipledMaterial.NoLighting
+                    baseColor: root._markerColor
+                }
+            }
+
+            // Ground footprint: half-buried flattened sphere reads as a disc
+            // without z-fighting the terrain mesh
+            Model {
+                source: "#Sphere"
+                visible: root._dropLength > 0
+                opacity: 0.75
+                position: Qt.vector3d(0, 0, -root._dropLength)
+                scale: Qt.vector3d(root._modelScale, root._modelScale, root._modelScale * 0.15)
+
+                materials: PrincipledMaterial {
+                    lighting: PrincipledMaterial.NoLighting
                     baseColor: root._markerColor
                 }
             }

--- a/src/GeoMap/README.md
+++ b/src/GeoMap/README.md
@@ -102,8 +102,10 @@ renderable positions itself through `GeoScene`, so a re-anchor shifts the whole
 scene consistently.
 
 `GeoMapCamera` is the camera pose model: center coordinate, heading, tilt, and
-distance, with 2D/3D modes. All gestures (pan, orbit, zoom) are cursor-anchored —
-the ground point under the cursor stays under it — and zoom levels match
+distance, with 2D/3D modes. Gestures mirror Google Earth: pan, orbit (right,
+middle, or Shift+left drag), and zoom are cursor-anchored — the ground point
+under the cursor at gesture start stays pinned — plus first-person look about a
+fixed camera position (Ctrl+drag). Zoom levels match
 QtLocation's for familiar behavior. Its outputs drive the `View3D`'s
 `PerspectiveCamera`, and its projection math (`screenToGround`, `worldToScreen`)
 underpins visibility estimation and overlay placement.

--- a/test/GeoMap/GeoMapCameraTest.cc
+++ b/test/GeoMap/GeoMapCameraTest.cc
@@ -395,15 +395,18 @@ void GeoMapCameraTest::_panAnchorInvariant_data()
 {
     QTest::addColumn<double>("tilt");
     QTest::addColumn<double>("centerElevation");
-    QTest::newRow("top-down") << 0.0 << 0.0;
-    QTest::newRow("tilted 45") << 45.0 << 0.0;
-    QTest::newRow("tilted 45 elevated") << 45.0 << 700.0;
+    QTest::addColumn<double>("anchorZ");
+    QTest::newRow("top-down") << 0.0 << 0.0 << 0.0;
+    QTest::newRow("tilted 45") << 45.0 << 0.0 << 0.0;
+    QTest::newRow("tilted 45 elevated") << 45.0 << 700.0 << 0.0;
+    QTest::newRow("tilted 45 elevated surface") << 45.0 << 700.0 << 500.0;
 }
 
 void GeoMapCameraTest::_panAnchorInvariant()
 {
     QFETCH(double, tilt);
     QFETCH(double, centerElevation);
+    QFETCH(double, anchorZ);
 
     GeoMapCamera camera;
     setupCamera(camera, tilt);
@@ -412,14 +415,14 @@ void GeoMapCameraTest::_panAnchorInvariant()
     const QPointF pressPos(200, 400);
     const QPointF dragPos(450, 320);
 
-    const auto anchor = camera.screenToGround(pressPos);
+    const auto anchor = camera.screenToGround(pressPos, anchorZ);
     QVERIFY(anchor.has_value());
 
-    camera.beginPan(pressPos);
+    camera.beginPan(pressPos, anchorZ);
     camera.panTo(dragPos);
 
-    // The ground point picked at press is now under the drag position
-    const auto current = camera.screenToGround(dragPos);
+    // The surface point picked at press is now under the drag position
+    const auto current = camera.screenToGround(dragPos, anchorZ);
     QVERIFY(current.has_value());
     QCOMPARE_LT(groundDistance(*current, *anchor), kWorldEpsilon);
 
@@ -514,6 +517,93 @@ void GeoMapCameraTest::_orbitDragRatios()
     QVERIFY(anchorNow.has_value());
     const auto expected = TileMath::geoToWorld(kCenter);
     QCOMPARE_LT(groundDistance(*anchorNow, expected), kWorldEpsilon);
+}
+
+void GeoMapCameraTest::_orbitSurfaceAnchorInvariant_data()
+{
+    QTest::addColumn<double>("tilt");
+    QTest::addColumn<double>("anchorZ");
+    QTest::addColumn<double>("centerElevation");
+    QTest::addColumn<QPointF>("dragDelta");
+    QTest::newRow("tilt up, flat") << 40.0 << 0.0 << 0.0 << QPointF(0, -120);
+    QTest::newRow("tilt down, flat") << 40.0 << 0.0 << 0.0 << QPointF(0, 90);
+    QTest::newRow("tilt up, elevated surface") << 40.0 << 220.0 << 150.0 << QPointF(0, -120);
+    QTest::newRow("tilt down, elevated surface") << 55.0 << 220.0 << 150.0 << QPointF(0, 90);
+    QTest::newRow("rotate, elevated surface") << 40.0 << 220.0 << 150.0 << QPointF(200, 0);
+    QTest::newRow("combined, elevated surface") << 40.0 << 220.0 << 150.0 << QPointF(200, -120);
+}
+
+// The fundamental orbit-gesture contract: the surface point picked at press
+// (at its rendered elevation, not the z=0 plane below it) stays at the press
+// screen position for the entire tilt/rotate drag
+void GeoMapCameraTest::_orbitSurfaceAnchorInvariant()
+{
+    QFETCH(double, tilt);
+    QFETCH(double, anchorZ);
+    QFETCH(double, centerElevation);
+    QFETCH(QPointF, dragDelta);
+
+    GeoMapCamera camera;
+    setupCamera(camera, tilt);
+    camera.setCenterElevation(centerElevation);
+
+    const QPointF pressPos(300, 420);
+    const auto anchor = camera.screenToGround(pressPos, anchorZ);
+    QVERIFY(anchor.has_value());
+
+    camera.beginOrbit(pressPos, anchorZ);
+    constexpr int steps = 6;
+    for (int i = 1; i <= steps; i++) {
+        camera.orbitTo(pressPos + ((dragDelta * i) / steps));
+        const auto onScreen = camera.worldToScreen(*anchor, anchorZ);
+        QVERIFY(onScreen.has_value());
+        QCOMPARE_LT(std::hypot(onScreen->x() - pressPos.x(), onScreen->y() - pressPos.y()), 0.01);
+    }
+}
+
+void GeoMapCameraTest::_lookKeepsCameraFixed()
+{
+    GeoMapCamera camera;
+    setupCamera(camera, 40.0, 10.0);
+    camera.setCenterElevation(300.0);
+
+    const QPointF startCamGround = camera.cameraGroundPosition();
+    const float startCamZ = camera.cameraPosition().z();
+
+    const QPointF pressPos(400, 300);
+    camera.beginLook(pressPos);
+    camera.lookTo(pressPos + QPointF(kViewport.width() / 8, kViewport.height() / 8));
+
+    // Eighth of the width = 45 deg heading; drag down = look down 22.5 deg
+    QCOMPARE_LT(qAbs(camera.heading() - 55.0), 1e-9);
+    QCOMPARE_LT(qAbs(camera.tilt() - 17.5), 1e-9);
+
+    // Camera position unchanged; center/distance re-solved along the new view axis
+    QCOMPARE_LT(groundDistance(camera.cameraGroundPosition(), startCamGround), kWorldEpsilon);
+    QCOMPARE_LT(qAbs(camera.cameraPosition().z() - startCamZ), 0.5);
+    const qreal expectedDistance =
+        (GeoMapCamera::kDefaultDistance * std::cos(qDegreesToRadians(40.0))) / std::cos(qDegreesToRadians(17.5));
+    QCOMPARE_LT(qAbs(camera.distance() - expectedDistance), 1e-6);
+}
+
+void GeoMapCameraTest::_lookHeadingOnlyIn2D()
+{
+    GeoMapCamera camera;
+    camera.setViewportSize(kViewport);
+    camera.lookAt(kCenter, 0, 0, GeoMapCamera::kDefaultDistance);
+    QCOMPARE(camera.mode(), GeoMapCamera::Mode::Mode2D);
+
+    const QPointF startCamGround = camera.cameraGroundPosition();
+
+    const QPointF pressPos(400, 300);
+    camera.beginLook(pressPos);
+    camera.lookTo(pressPos + QPointF(kViewport.width() / 4, kViewport.height() / 4));
+
+    // Tilt locked: heading-only rotation about the camera's vertical axis
+    QCOMPARE_LT(qAbs(camera.heading() - 90.0), 1e-9);
+    QCOMPARE(camera.tilt(), 0.0);
+    QCOMPARE(camera.distance(), GeoMapCamera::kDefaultDistance);
+    QCOMPARE_LT(groundDistance(camera.cameraGroundPosition(), startCamGround), kWorldEpsilon);
 }
 
 void GeoMapCameraTest::_modeSwitch()

--- a/test/GeoMap/GeoMapCameraTest.h
+++ b/test/GeoMap/GeoMapCameraTest.h
@@ -29,6 +29,10 @@ private slots:
     void _rotateAnchorInvariant();
     void _tiltAnchorInvariant();
     void _orbitDragRatios();
+    void _orbitSurfaceAnchorInvariant_data();
+    void _orbitSurfaceAnchorInvariant();
+    void _lookKeepsCameraFixed();
+    void _lookHeadingOnlyIn2D();
     void _modeSwitch();
     void _tiltLockedIn2D();
     void _scenePose();

--- a/test/QmlUITests/FlyViewGeoUITest.cc
+++ b/test/QmlUITests/FlyViewGeoUITest.cc
@@ -3,6 +3,8 @@
 #include <QtCore/QList>
 #include <QtCore/QScopeGuard>
 #include <QtCore/QtMath>
+#include <QtGui/QGuiApplication>
+#include <QtGui/QMouseEvent>
 #include <QtGui/QPointingDevice>
 #include <QtGui/QQuaternion>
 #include <QtGui/QVector3D>
@@ -11,6 +13,7 @@
 #include <QtQuick/QQuickWindow>
 #include <QtTest/QTest>
 
+#include <cmath>
 #include <optional>
 
 #include "Fact.h"
@@ -109,7 +112,8 @@ void FlyViewGeoUITest::_testViewSwitchWhenEnabled()
 }
 
 // Exercises every camera gesture against the real view: left-drag pan,
-// right-drag orbit, wheel zoom, and synthesized multi-touch (pinch zoom,
+// right-drag orbit, Shift+left-drag orbit (with pivot ring), Ctrl+left-drag
+// first-person look, wheel zoom, and synthesized multi-touch (pinch zoom,
 // two-finger twist).
 void FlyViewGeoUITest::_testCameraGestures()
 {
@@ -180,6 +184,82 @@ void FlyViewGeoUITest::_testCameraGestures()
     resetPose();
     mouseDrag(Qt::RightButton, center, QPoint(0, qRound(-h / 4)));
     QTRY_VERIFY_WITH_TIMEOUT(qAbs(cam->tilt() - 75.0) < 0.5, 5000);
+
+    // Shift+left drag: same orbit — pivot ring visible at the press point
+    // while dragging, pressed ground point pinned to its screen position,
+    // ring gone on release
+    resetPose();
+    {
+        const QPointF pressLocal(w / 2, h * 0.6);
+        const QPoint pressPos = toWin(pressLocal.x(), pressLocal.y());
+        const auto anchorBefore = cam->screenToGround(pressLocal);
+        QVERIFY(anchorBefore.has_value());
+
+        QTest::mousePress(_window, Qt::LeftButton, Qt::ShiftModifier, pressPos);
+        const QPoint delta(qRound(w / 4), qRound(-h / 8));
+        for (int i = 1; i <= 10; i++) {
+            // QTest::mouseMove drops keyboard modifiers, which would deactivate
+            // the modifier-gated handler: send the move with Shift held
+            const QPoint pos = pressPos + ((delta * i) / 10);
+            QMouseEvent move(QEvent::MouseMove, pos, _window->mapToGlobal(pos), Qt::NoButton, Qt::LeftButton,
+                             Qt::ShiftModifier);
+            QGuiApplication::sendEvent(_window, &move);
+        }
+
+        QQuickItem* const pivotRing = findVisibleItem(_rootItem, QStringLiteral("geoMapOrbitPivotIndicator"));
+        QVERIFY2(pivotRing, "Pivot ring not visible during Shift+left drag");
+        const QPointF ringCenter = pivotRing->mapToScene(QPointF(pivotRing->width() / 2, pivotRing->height() / 2));
+        QCOMPARE_LT((ringCenter - QPointF(pressPos)).manhattanLength(), 3.0);
+
+        QTest::mouseRelease(_window, Qt::LeftButton, Qt::ShiftModifier, pressPos + delta);
+        QTRY_VERIFY_WITH_TIMEOUT(qAbs(cam->heading() - 90.0) < 0.5, 5000);
+        QVERIFY(qAbs(cam->tilt() - 52.5) < 0.5);
+        QCOMPARE(cam->distance(), 1500.0);
+
+        // The clicked ground point never left its press screen position
+        const auto anchorAfter = cam->screenToGround(pressLocal);
+        QVERIFY(anchorAfter.has_value());
+        QCOMPARE_LT((*anchorAfter - *anchorBefore).manhattanLength(), 2.0);
+
+        QVERIFY2(!findVisibleItem(_rootItem, QStringLiteral("geoMapOrbitPivotIndicator"), 0),
+                 "Pivot ring still visible after release");
+    }
+
+    // Ctrl+left drag: first-person look — the camera stays fixed while
+    // heading/tilt follow the drag (center and distance re-solve). QTest
+    // synthesizes Qt modifiers directly (no macOS native Ctrl-click
+    // right-button swap), so this exercises lookHandler on every platform.
+    resetPose();
+    {
+        const QPointF camGroundBefore = cam->cameraGroundPosition();
+        const float camZBefore = cam->cameraPosition().z();
+
+        QTest::mousePress(_window, Qt::LeftButton, Qt::ControlModifier, center);
+        const QPoint delta(qRound(w / 4), qRound(h / 8));
+        for (int i = 1; i <= 10; i++) {
+            // QTest::mouseMove drops keyboard modifiers (see Shift+left drag above)
+            const QPoint pos = center + ((delta * i) / 10);
+            QMouseEvent move(QEvent::MouseMove, pos, _window->mapToGlobal(pos), Qt::NoButton, Qt::LeftButton,
+                             Qt::ControlModifier);
+            QGuiApplication::sendEvent(_window, &move);
+        }
+
+        // Look has no ground pivot: the orbit ring must not appear
+        QVERIFY2(!findVisibleItem(_rootItem, QStringLiteral("geoMapOrbitPivotIndicator"), 0),
+                 "Pivot ring visible during Ctrl+left look drag");
+
+        QTest::mouseRelease(_window, Qt::LeftButton, Qt::ControlModifier, center + delta);
+
+        // Quarter width = 90 deg heading; drag down an eighth = look down 22.5 deg
+        QTRY_VERIFY_WITH_TIMEOUT(qAbs(cam->heading() - 90.0) < 0.5, 5000);
+        QVERIFY(qAbs(cam->tilt() - 7.5) < 0.5);
+
+        // Camera position unchanged; distance re-solved along the new view axis
+        QCOMPARE_LT((cam->cameraGroundPosition() - camGroundBefore).manhattanLength(), 1.0);
+        QCOMPARE_LT(qAbs(cam->cameraPosition().z() - camZBefore), 1.0f);
+        const qreal expectedDistance = (1500.0 * std::cos(qDegreesToRadians(30.0))) / std::cos(qDegreesToRadians(7.5));
+        QVERIFY(qAbs(cam->distance() - expectedDistance) < 1.0);
+    }
 
     // Wheel up: zoom in; wheel down: zoom out
     resetPose();


### PR DESCRIPTION
## Summary

GeoView (tech preview) gesture and mission-visual improvements:

- **Terrain-anchored pan/orbit**: gestures now anchor to the rendered surface point under the cursor instead of the z=0 ground plane, so the map stays pinned to the cursor over elevated terrain (`screenToGround`/`beginPan`/`beginOrbit` gained a plane-z parameter).
- **First-person look gesture**: Ctrl+drag (Cmd+drag also works on macOS) rotates the view about a fixed camera position, matching Google Earth. Includes handling for macOS's Ctrl+left-click → right-click synthesis via a Meta-modifier fall-through handler.
- **Orbit improvements**: middle-button orbit, Shift+left-drag orbit for one-button mice, and a Google Earth-style pivot ring marking the orbit point while dragging.
- **Waypoint drop lines**: mission waypoint markers gain a drop line to the rendered terrain and a ground-footprint disc (25% transparent, constant apparent size), making waypoint altitude readable in 3D.

## Docs

- New [GeoView (Tech Preview)](docs/en/qgc-user-guide/fly_view/geoview.md) user guide page (overview, enabling, mouse/touch/keyboard controls, 2D/3D modes, imagery/terrain sources) plus SUMMARY and What's New entries.
- GeoMap README gesture section updated.

## Testing

- New unit tests: surface-anchored orbit invariant (data-driven), look keeps camera fixed, look is heading-only in 2D.
- UI tests: Shift+left-drag orbit with pivot-ring visibility checks, Ctrl+left-drag look with fixed-camera assertions.
- `GeoMapCameraTest`, `GeoMapItemTest`, and `FlyViewGeoUITest` pass locally; pre-commit clean.