### PR TITLE
ci(pre-commit): fail the job when pre-commit produced no hook verdicts

### DIFF
--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -88,10 +88,22 @@ jobs:
           path: pre-commit-results
           retention-days: 7
 
-      # Hook failures are surfaced via the PR comment; only fail the job when
-      # the runner script itself didn't complete (no exit_code output written).
-      - name: Fail job on pre-commit script crash
-        if: always() && steps.pre-commit.outcome == 'failure' && steps.pre-commit.outputs.exit_code == ''
+      # Hook failures are surfaced via the PR comment; the job itself fails only when the runner
+      # never produced hook verdicts. That is three shapes: the script died before writing results
+      # (no exit_code output), pre-commit aborted before running hooks (exit codes other than
+      # 0/1, e.g. a hook environment that fails to install), or pre-commit exited 1 with zero
+      # verdicts recorded — counts of 0 or missing count outputs (e.g. a fatal config error).
+      # Treating any of those as a passing check leaves every hook silently skipped.
+      - name: Fail job when pre-commit produced no hook verdicts
+        if: >-
+          always() && steps.pre-commit.outcome == 'failure' &&
+          (steps.pre-commit.outputs.exit_code != '1' ||
+           ((steps.pre-commit.outputs.passed == '0' || steps.pre-commit.outputs.passed == '') &&
+            (steps.pre-commit.outputs.failed == '0' || steps.pre-commit.outputs.failed == '')))
+        env:
+          EXIT_CODE: ${{ steps.pre-commit.outputs.exit_code }}
+          PASSED: ${{ steps.pre-commit.outputs.passed }}
+          FAILED: ${{ steps.pre-commit.outputs.failed }}
         run: |
-          echo "::error::pre-commit runner crashed before writing results"
+          echo "::error::pre-commit produced no hook verdicts (exit_code='${EXIT_CODE}' passed='${PASSED}' failed='${FAILED}')"
           exit 1


### PR DESCRIPTION
Replaces #14754 (@TSC21's work) and incorporates the review feedback from that PR.

## CI/Build Changes

The pre-commit job's crash guard now fails the job whenever pre-commit produced
no hook verdicts. Real hook findings keep the current report-only design: they
still land in the PR comment and do not red the job.

## Reason

The current guard only fails the job when the runner script dies without writing
an exit code at all. That misses two more shapes where every hook is silently
skipped while the check lands green:

1. pre-commit aborts before running any hook but still exits with a code, e.g. a
   hook environment that fails to install (exit code 3). This is exactly what
   happened with the `vale-sync` install failure fixed in #14753.
2. pre-commit exits 1 for fatal errors, not just hook failures — e.g. a malformed
   `.pre-commit-config.yaml` raises `FatalError`, which exits 1 with zero hooks
   run (`exit_code=1, passed=0, failed=0`). This shape was flagged in review on
   #14754 and is covered here.

Missing count outputs are treated the same as zero verdicts, so the guard's
invariant (green requires verdicts) holds even if the runner ever writes
`exit_code` without the counts.

A gate that can pass without running is not a gate; this closes the detection
side for all known shapes.

## Impact

Only the pre-commit workflow. Hook findings keep their report-only behaviour;
the job only goes red when pre-commit never produced verdicts.
