### PR TITLE
refactor(FirmwarePlugin): centralize single firmware/vehicle support queries

### DIFF
--- a/src/API/QGCCorePlugin.cc
+++ b/src/API/QGCCorePlugin.cc
@@ -184,9 +184,7 @@ QString QGCCorePlugin::showAdvancedUIMessage() const
 
 bool QGCCorePlugin::showInitialSetupVehiclePreferences() const
 {
-    const QList<QGCMAVLink::FirmwareClass_t> supportedFirmwareClasses = FirmwarePluginManager::instance()->supportedFirmwareClasses();
-    return supportedFirmwareClasses.count() != 1 ||
-           FirmwarePluginManager::instance()->supportedVehicleClasses(supportedFirmwareClasses[0]).count() != 1;
+    return !FirmwarePluginManager::instance()->singleVehicleSupport();
 }
 
 bool QGCCorePlugin::showInitialSetupMeasurementUnits() const

--- a/src/FirmwarePlugin/FirmwarePluginManager.cc
+++ b/src/FirmwarePlugin/FirmwarePluginManager.cc
@@ -43,6 +43,17 @@ bool FirmwarePluginManager::firmwareClassSupported(QGCMAVLink::FirmwareClass_t f
     return supportedFirmwareClasses().contains(firmwareClass);
 }
 
+bool FirmwarePluginManager::singleFirmwareSupport()
+{
+    return supportedFirmwareClasses().count() == 1;
+}
+
+bool FirmwarePluginManager::singleVehicleSupport()
+{
+    const QList<QGCMAVLink::FirmwareClass_t> firmwareClasses = supportedFirmwareClasses();
+    return (firmwareClasses.count() == 1) && (supportedVehicleClasses(firmwareClasses[0]).count() == 1);
+}
+
 QList<QGCMAVLink::VehicleClass_t> FirmwarePluginManager::supportedVehicleClasses(QGCMAVLink::FirmwareClass_t firmwareClass)
 {
     QList<QGCMAVLink::VehicleClass_t> vehicleClasses;

--- a/src/FirmwarePlugin/FirmwarePluginManager.h
+++ b/src/FirmwarePlugin/FirmwarePluginManager.h
@@ -31,6 +31,12 @@ public:
     /// Returns true if the specified firmware class is supported by the system
     bool firmwareClassSupported(QGCMAVLink::FirmwareClass_t firmwareClass);
 
+    /// Returns true if the system supports only a single firmware class
+    bool singleFirmwareSupport();
+
+    /// Returns true if the system supports only a single firmware class with a single vehicle type
+    bool singleVehicleSupport();
+
     /// Returns the list of supported vehicle types for the specified firmware
     QList<QGCMAVLink::VehicleClass_t> supportedVehicleClasses(QGCMAVLink::FirmwareClass_t firmwareClass);
 

--- a/src/QmlControls/QGroundControlQmlGlobal.cc
+++ b/src/QmlControls/QGroundControlQmlGlobal.cc
@@ -231,16 +231,12 @@ void QGroundControlQmlGlobal::stopOneMockLink(void)
 
 bool QGroundControlQmlGlobal::singleFirmwareSupport(void)
 {
-    return FirmwarePluginManager::instance()->supportedFirmwareClasses().count() == 1;
+    return FirmwarePluginManager::instance()->singleFirmwareSupport();
 }
 
 bool QGroundControlQmlGlobal::singleVehicleSupport(void)
 {
-    if (singleFirmwareSupport()) {
-        return FirmwarePluginManager::instance()->supportedVehicleClasses(FirmwarePluginManager::instance()->supportedFirmwareClasses()[0]).count() == 1;
-    }
-
-    return false;
+    return FirmwarePluginManager::instance()->singleVehicleSupport();
 }
 
 bool QGroundControlQmlGlobal::px4ProFirmwareSupported()
@@ -381,5 +377,3 @@ QString QGroundControlQmlGlobal::appName()
 {
     return QCoreApplication::applicationName();
 }
-
-


### PR DESCRIPTION
## Description
Follow-up to #14864. Centralizes the single-firmware / single-vehicle support logic in `FirmwarePluginManager` (`singleFirmwareSupport()` / `singleVehicleSupport()`), which previously existed in duplicated form in both `QGroundControlQmlGlobal` and `QGCCorePlugin::showInitialSetupVehiclePreferences()`. Both call sites now delegate to the single implementation. No behavior change.

## Type of Change
- [X] Refactoring (no functional changes)

## Testing
- [X] Tested locally

### Platforms Tested
- [X] macOS
