### PR TITLE
fix(Settings): save telemetry logs by default on mobile

### DIFF
--- a/src/API/QGCCorePlugin.cc
+++ b/src/API/QGCCorePlugin.cc
@@ -1,8 +1,5 @@
 #include "QGCCorePlugin.h"
 #include "AppSettings.h"
-#if defined(Q_OS_ANDROID) || defined(Q_OS_IOS)
-#include "MavlinkSettings.h"
-#endif
 #ifdef Q_OS_ANDROID
 #include "Viewer3DSettings.h"
 #ifndef QGC_NO_SERIAL_LINK
@@ -150,12 +147,6 @@ void QGCCorePlugin::adjustSettingMetaData(const QString &settingsGroup, FactMeta
             metaData.setRawDefaultValue(outdoorPalette);
             return;
         }
-#if defined(Q_OS_ANDROID) || defined(Q_OS_IOS)
-        else if (metaData.name() == MavlinkSettings::telemetrySaveName) {
-            metaData.setRawDefaultValue(false);
-            return;
-        }
-#endif
 #ifndef Q_OS_ANDROID
         else if (metaData.name() == AppSettings::androidDontSaveToSDCardName) {
             userVisible = false;


### PR DESCRIPTION
Removes the `QGCCorePlugin::adjustSettingMetaData` override that forced the `telemetrySave` setting default to off on Android/iOS.

All platforms now use the metadata default from `Mavlink.SettingsGroup.json` (on), so mobile users get telemetry logs saved after each flight without having to find and enable the setting.

Note: users who previously explicitly disabled the setting keep their saved value — only the default changes.
