### PR TITLE
docs(whats-new): add Video Streaming section covering GStreamer overhaul

### DIFF
--- a/docs/en/qgc-user-guide/getting_started/whats_new.md
+++ b/docs/en/qgc-user-guide/getting_started/whats_new.md
@@ -1,6 +1,6 @@
 # What's New
 
-This page highlights user-facing changes since the last stable release (V5.1).
+This page highlights user-facing changes since the last stable release (V5.0).
 
 ## Fly View
 
@@ -38,6 +38,24 @@ Multi-vehicle support improvements: configurable telemetry display and better su
 
 The 3D View free-fly camera has been replaced with Gazebo-style cursor-anchored controls — the ground point you grab stays under the cursor while you pan, orbit, and zoom.
 Full mouse and touch gesture support is included, along with a scale bar showing ground distance.
+
+## Video Streaming
+
+The GStreamer video backend has been overhauled across all platforms:
+
+- **Updated GStreamer** — all platforms now ship with a newer GStreamer runtime, bringing improved codec support and stability.
+- **New rendering path** — video is now rendered through a common pipeline on every platform (including a Metal-based path on macOS), fixing platform-specific display issues.
+- **Faster startup** — GStreamer now initializes asynchronously, so video no longer delays application startup.
+- **Improved reliability** — fixes for crashes when stopping video or rebooting the vehicle, more robust video startup sequencing, and automatic pipeline restart on stream errors.
+- **USB (UVC) cameras** — multiple fixes, including the selected UVC device now persisting across restarts.
+- **Recording** — the default recording format has changed to **mp4**, and recording file splitting now works correctly.
+
+New video settings in Application Settings:
+
+- **Force video decoder** — override automatic decoder selection (software, hardware, NVIDIA, VA-API, Direct3D 11, VideoToolbox, Intel, Vulkan).
+- **RTP jitter buffer latency** — tune the playout latency of the stream.
+- **RTSP auto-reconnect** — automatically restart the pipeline on timeout or error.
+- Advanced troubleshooting options to force the CPU frame path and override the color-conversion element.
 
 ## Plan View
 


### PR DESCRIPTION
The V5.1 What's New page had no mention of the extensive video/GStreamer work that landed between 5.0 and 5.1 (backend overhaul, new rendering path, async init, new video settings, mp4 default recording format, UVC fixes, etc.).

Adds a **Video Streaming** section summarizing the user-facing changes:

- GStreamer runtime update and cross-platform rendering-path overhaul (Metal on macOS)
- Async GStreamer init (faster app startup)
- Reliability fixes: stop/reboot crashes, startup sequencing, RTSP auto-reconnect
- USB (UVC) camera fixes and device persistence
- mp4 default recording format and recording file-splitting fix
- New settings: force video decoder, RTP jitter-buffer latency, RTSP auto-reconnect, advanced CPU-path troubleshooting options
