### PR TITLE
fix(AppSettings): fill settings sidebar

### DIFF
--- a/src/QmlControls/AppSettings.qml
+++ b/src/QmlControls/AppSettings.qml
@@ -180,6 +180,7 @@ Rectangle {
 
         ColumnLayout {
             id:         buttonColumn
+            width:      buttonList.width
             spacing:    0
 
             Repeater {


### PR DESCRIPTION
## Description
A recent refactor left the Flickable content at its implicit width, making its items narrower than the sidebar. Restores the previous layout by using the full Flickable width.

## Type of Change
- [X] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] CI/Build changes
- [ ] Other

## Testing
- [X] Tested locally
- [ ] Added/updated unit tests
- [ ] Tested with simulator (SITL)
- [ ] Tested with hardware

### Platforms Tested
- [ ] Linux
- [X] Windows
- [ ] macOS
- [X] Android
- [ ] iOS

## Checklist
- [X] I have read the [Contribution Guidelines](CONTRIBUTING.md)
- [X] I have read the [Code of Conduct](CODE_OF_CONDUCT.md)
- [X] My code follows the project's coding standards
- [ ] I have added tests that prove my fix/feature works
- [X] New and existing unit tests pass locally

---
By submitting this pull request, I confirm that my contribution is made under the terms of the project's dual license (Apache 2.0 and GPL v3).
