### PR TITLE
fix(QmlControls): restore image URL overrides

### DIFF
--- a/src/QmlControls/QGCColoredImage.qml
+++ b/src/QmlControls/QGCColoredImage.qml
@@ -28,8 +28,9 @@ Item {
 
     // Strip qrc: scheme and ensure leading '/' so the provider URL stays well-formed.
     readonly property string _path: {
-        const s = source.toString()
+        let s = source.toString()
         if (s.length === 0)        return ""
+        s = Qt.resolvedUrl(s).toString()
         if (s.startsWith("qrc:/")) return s.substring(4)
         if (s.startsWith("/"))     return s
         return "/" + s


### PR DESCRIPTION
## Description
QGCColoredImage previously loaded its source through a QML Image, allowing custom builds to replace QRC resources through a URL interceptor. A migration bypassed this functionality and broke branded image overrides.

Restores the previous behaviour by resolving the source before constructing the provider URL.

## Type of Change
- [X] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] CI/Build changes
- [ ] Other

## Testing
- [X] Tested locally
- [ ] Added/updated unit tests
- [ ] Tested with simulator (SITL)
- [ ] Tested with hardware

### Platforms Tested
- [ ] Linux
- [X] Windows
- [ ] macOS
- [ ] Android
- [ ] iOS

## Checklist
- [X] I have read the [Contribution Guidelines](CONTRIBUTING.md)
- [X] I have read the [Code of Conduct](CODE_OF_CONDUCT.md)
- [X] My code follows the project's coding standards
- [ ] I have added tests that prove my fix/feature works
- [X] New and existing unit tests pass locally

---
By submitting this pull request, I confirm that my contribution is made under the terms of the project's dual license (Apache 2.0 and GPL v3).
