### PR TITLE
docs: add telemetry log saving whats-new note and fix broken .qrc links

### DIFF
--- a/docs/en/qgc-dev-guide/custom_build/resource_override.md
+++ b/docs/en/qgc-dev-guide/custom_build/resource_override.md
@@ -2,12 +2,12 @@
 
 A "resource" in QGC source code terminology is anything found in Qt resources file:
 
-* [qgcresources.qrc](https://github.com/mavlink/qgroundcontrol/blob/master/qgcresources.qrc)
+* [qgcresources.qrc](https://github.com/mavlink/qgroundcontrol/blob/Stable_V5.1/qgcresources.qrc)
 * Per-module `.qrc` files declared via `qt_add_resources` in the relevant `CMakeLists.txt` (e.g., under `src/`)
 * Qml files
 
 Overriding a resource allows you to replace it with your own version. This could be as simple as a single icon, or as complex as replacing an entire Vehicle Setup page of UI QML code. Note that using resource overrides means you are duplicating regular QGC source code. This can be a good or a bad thing, depending on how you go about it. By using a resource override on a QML file, for example, allows you to avoid dealing with merge conflicts when merging newer versions of the upstream QGC source. However, it also means that you need to pay attention to the latest version of the QGC source code to see if you need to modify your copied code in a similar way.
 
-Resource overrides work by using `QQmlEngine::addUrlInterceptor` to intercept requests for resources and re-route the request to available custom resources instead of the standard ones. Look at [custom_example/src/CustomPlugin.cc](https://github.com/mavlink/qgroundcontrol/blob/master/custom-example/src/CustomPlugin.cc) for how has been done, and replicate it in your own custom build source.
+Resource overrides work by using `QQmlEngine::addUrlInterceptor` to intercept requests for resources and re-route the request to available custom resources instead of the standard ones. Look at [custom_example/src/CustomPlugin.cc](https://github.com/mavlink/qgroundcontrol/blob/Stable_V5.1/custom-example/src/CustomPlugin.cc) for how has been done, and replicate it in your own custom build source.
 
-Custom resources, that are meant to override, have the prefix `/Custom` added to their resource name in the custom resource file. The file alias for the resource should be exactly the same as the standard QGC resource. For examples of how to do any of this, take a look at [custom_example/custom.qrc](https://github.com/mavlink/qgroundcontrol/blob/master/custom-example/custom.qrc) and [custom_example/CMakeLists.txt](https://github.com/mavlink/qgroundcontrol/blob/master/custom-example/CMakeLists.txt).
+Custom resources, that are meant to override, have the prefix `/Custom` added to their resource name in the custom resource file. The file alias for the resource should be exactly the same as the standard QGC resource. For examples of how to do any of this, take a look at [custom_example/custom.qrc](https://github.com/mavlink/qgroundcontrol/blob/Stable_V5.1/custom-example/custom.qrc) and [custom_example/CMakeLists.txt](https://github.com/mavlink/qgroundcontrol/blob/Stable_V5.1/custom-example/CMakeLists.txt).

--- a/docs/en/qgc-user-guide/getting_started/whats_new.md
+++ b/docs/en/qgc-user-guide/getting_started/whats_new.md
@@ -256,6 +256,15 @@ Toolbar indicators show a compact view immediately, and Vehicle Configuration of
 
 ## General
 
+### Telemetry Log Saving on Mobile
+
+Saving telemetry logs after each flight now defaults to **on** for Android and iOS (previously it was off on mobile devices).
+
+::: warning
+On devices with limited storage, keep an eye on the telemetry logs directory — saved logs can accumulate and fill up your disk space.
+The **Save log after each flight** setting can be turned off in Application Settings > Telemetry.
+:::
+
 ### Android Improvements
 
 - On Android 11+, application data (logs, plans, settings) is now saved to the root of a removable SD card when one is present, using the "All files access" permission.


### PR DESCRIPTION
Fixes #14918

Two docs updates for the V5.1 stable docs:

## What's New: Telemetry Log Saving on Mobile

Documents that saving telemetry logs after each flight now defaults to **on** for Android and iOS, with a warning for devices with limited storage that the telemetry logs directory can fill up disk space. Names the exact setting (**Save log after each flight**, Application Settings > Telemetry) so users can find it.

## Fix broken .qrc links in resource_override.md

`docs/en/qgc-dev-guide/custom_build/resource_override.md` linked to `master` copies of `qgcresources.qrc` and `custom-example/custom.qrc`, which were removed from master by #14894 and now 404, failing the Check Links CI job on docs PRs targeting `Stable_V5.1`.

All source links on the page now point at `Stable_V5.1`, where all referenced files exist (verified: `qgcresources.qrc`, `custom-example/custom.qrc`, `custom-example/CMakeLists.txt`, `custom-example/src/CustomPlugin.cc`).

Note: the master copy of this page still needs a separate content rework since `qgcresources.qrc` no longer exists there at all.
