### PR TITLE
docs: fix command line logging examples (paths, --log-output, unsupported --logging:full exclusion)

### DIFF
--- a/docs/en/qgc-dev-guide/command_line_options.md
+++ b/docs/en/qgc-dev-guide/command_line_options.md
@@ -4,26 +4,26 @@ You can start _QGroundControl_ with command line options. These are used to enab
 
 ## Starting QGroundControl with Options
 
-You will need to open a command prompt or terminal, change directory to where **qgroundcontrol.exe** is stored, and then run it. This is shown below for each platform (using the `--logging:full` option):
+You will need to open a command prompt or terminal, change directory to where the _QGroundControl_ executable is stored, and then run it. This is shown below for each platform (using the `--logging:full --log-output` options):
 
-Windows Command Prompt:
+Windows Command Prompt (_QGroundControl_ is a GUI application with no console window, so redirect stderr to a file to capture the output):
 
 ```sh
-cd "\Program Files (x86)\qgroundcontrol"
-qgroundcontrol --logging:full
+cd "%ProgramFiles%\QGroundControl\bin"
+QGroundControl --logging:full --log-output > "%USERPROFILE%\qgc_log.txt" 2>&1
 ```
 
-OSX Terminal app (**Applications/Utilities**):
+macOS Terminal app (**Applications/Utilities**):
 
 ```sh
-cd /Applications/qgroundcontrol.app/Contents/MacOS/
-./qgroundcontrol --logging:full
+cd /Applications/QGroundControl.app/Contents/MacOS
+./QGroundControl --logging:full --log-output
 ```
 
 Linux Terminal:
 
 ```sh
-./qgroundcontrol-start.sh --logging:full
+./QGroundControl-<arch>.AppImage --logging:full --log-output
 ```
 
 ## Options
@@ -34,8 +34,8 @@ The options/command line arguments are listed in the table below.
 | ---------------------------------------------------------------------- | --------------------------------------------------------------------------------------------------------------------------------- |
 | `--clear-settings`                                                     | Clears the app settings (reverts _QGroundControl_ back to default settings).                                                      |
 | `--logging:full`                                                       | Turns on full logging. See [Console Logging](../qgc-user-guide/troubleshooting/console_logging.md#logging-from-the-command-line). |
-| `--logging:full,Comms.LinkManager:verbose,FactSystem.ParameterManager` | Turns on full logging and turns off the following listed comma-separated logging categories.                                      |
 | `--logging:Comms.LinkManager,FactSystem.ParameterManager`              | Turns on the specified comma separated logging categories.                                                                        |
+| `--log-output`                                                         | Writes log messages to stderr (the terminal on macOS/Linux).                                                                      |
 | `--unittest:name`                                                      | (Debug builds only) Runs the specified unit test. Leave off `:name` to run all tests.                                             |
 | `--unittest-stress:name`                                               | (Debug builds only) Runs the specified unit test 20 times in a row. Leave off :name to run all tests.                             |
 | `--fake-mobile`                                                        | Simulates running on a mobile device.                                                                                             |

--- a/docs/en/qgc-user-guide/troubleshooting/console_logging.md
+++ b/docs/en/qgc-user-guide/troubleshooting/console_logging.md
@@ -24,34 +24,39 @@ The most commonly used logging categories are listed below.
 
 An alternate mechanism for logging is using the `--logging` command line option. This is handy if you are trying to get logs from a situation where _QGroundControl_ crashes.
 
+Two options work together:
+
+- `--logging:full` (or `--logging:<comma-separated categories>`) enables the logging categories.
+- `--log-output` writes the log messages to stderr (the terminal on macOS/Linux). Without it, messages are only visible in the _App Log Viewer_ and the **AppLog.log** file in the application log directory.
+
 How you do this and where the traces are output vary by OS:
 
 - Windows
 
-  - You must open a command prompt, change directory to the **qgroundcontrol.exe** location, and run it from there:
+  - Open a command prompt and run _QGroundControl_ from its install location (the installer default is shown below). Because _QGroundControl_ is a GUI application it has no console window, so stderr isn't displayed — redirect it to a file to capture it:
 
     ```sh
-    cd "\Program Files (x86)\qgroundcontrol"
-    qgroundcontrol --logging:full
+    cd "%ProgramFiles%\QGroundControl\bin"
+    QGroundControl --logging:full --log-output > "%USERPROFILE%\qgc_log.txt" 2>&1
     ```
 
-  - When _QGroundControl_ starts you should see a separate console window open which will have the log output
+- macOS
 
-- OSX
-
-  - You must run _QGroundControl_ from Terminal. The Terminal app is located in Applications/Utilities. Once Terminal is open paste the following into it:
+  - You must run _QGroundControl_ from Terminal. The Terminal app is located in **Applications/Utilities**. Once Terminal is open paste the following into it:
 
     ```sh
-    cd /Applications/qgroundcontrol.app/Contents/MacOS/
-    ./qgroundcontrol --logging:full
+    cd /Applications/QGroundControl.app/Contents/MacOS
+    ./QGroundControl --logging:full --log-output
     ```
 
   - Log traces will output to the Terminal window.
 
 - Linux
 
-  ```sh
-  ./qgroundcontrol-start.sh --logging:full
-  ```
+  - Run the AppImage from a terminal:
+
+    ```sh
+    ./QGroundControl-<arch>.AppImage --logging:full --log-output
+    ```
 
   - Log traces will output to the shell you are running from.


### PR DESCRIPTION
Fixes #14916

Follow-up from the #14915 review — fixes the command line logging docs:

### console_logging.md ("Logging from the Command Line")
- Explains the two flags: `--logging:...` enables categories, `--log-output` writes messages to stderr (previously the examples omitted `--log-output`, so users got no console trace)
- **Windows**: corrected path to the NSIS installer default (`%ProgramFiles%\QGroundControl\bin`), and since QGC is a GUI-subsystem app with no console window, the example redirects stderr to a file
- **macOS**: corrected bundle/executable casing to `QGroundControl` (old lowercase paths fail on case-sensitive volumes)
- **Linux**: replaced the dev-only `qgroundcontrol-start.sh` with the user-facing AppImage (`./QGroundControl-<arch>.AppImage`, matching the download docs placeholder)

### command_line_options.md
- Same platform example fixes
- Removed the `--logging:full,<categories>` exclusion row — `QGCLoggingCategoryManager::installFilter` enables full logging when `full` is the first token and ignores remaining tokens, so the documented exclusion behavior does not exist
- Added a `--log-output` row to the options table

Translated docs (ko/tr/zh) untouched (Crowdin-managed).
