### PR TITLE
fix(MissionController): correct inverted flight path segment cache reuse condition (Stable_V5.1)

### DIFF
--- a/src/MissionManager/MissionController.cc
+++ b/src/MissionManager/MissionController.cc
@@ -912,6 +912,17 @@ void MissionController::save(QJsonObject& json)
     json[_jsonItemsKey] = rgJsonMissionItems;
 }
 
+static FlightPathSegment::SegmentType segmentTypeForPair(const VisualItemPair& pair, bool mavlinkTerrainFrame)
+{
+    if (pair.second->isTakeoffItem()) {
+        return FlightPathSegment::SegmentTypeTakeoff;
+    }
+    if (pair.second->isLandCommand()) {
+        return FlightPathSegment::SegmentTypeLand;
+    }
+    return mavlinkTerrainFrame ? FlightPathSegment::SegmentTypeTerrainFrame : FlightPathSegment::SegmentTypeGeneric;
+}
+
 FlightPathSegment* MissionController::_createFlightPathSegmentWorker(VisualItemPair& pair, bool mavlinkTerrainFrame)
 {
     // The takeoff goes straight up from ground to alt and then over to specified position at same alt. Which means
@@ -923,14 +934,9 @@ FlightPathSegment* MissionController::_createFlightPathSegmentWorker(VisualItemP
     double              coord2AMSLAlt       = pair.second->amslEntryAlt();
     double              coord1AMSLAlt       = takeoffStraightUp ? coord2AMSLAlt : pair.first->amslExitAlt();
 
-    FlightPathSegment::SegmentType segmentType = mavlinkTerrainFrame ? FlightPathSegment::SegmentTypeTerrainFrame : FlightPathSegment::SegmentTypeGeneric;
-    if (pair.second->isTakeoffItem()) {
-        segmentType = FlightPathSegment::SegmentTypeTakeoff;
-    } else if (pair.second->isLandCommand()) {
-        segmentType = FlightPathSegment::SegmentTypeLand;
-    }
-
-    FlightPathSegment* segment = new FlightPathSegment(segmentType, coord1, coord1AMSLAlt, coord2, coord2AMSLAlt, !_flyView /* queryTerrainData */,  this);
+    FlightPathSegment* segment =
+        new FlightPathSegment(segmentTypeForPair(pair, mavlinkTerrainFrame), coord1, coord1AMSLAlt, coord2,
+                              coord2AMSLAlt, !_flyView /* queryTerrainData */, this);
 
     if (takeoffStraightUp) {
         connect(pair.second, &VisualMissionItem::amslEntryAltChanged, segment, &FlightPathSegment::setCoord1AMSLAlt);
@@ -957,7 +963,8 @@ FlightPathSegment* MissionController::_addFlightPathSegment(FlightPathSegmentHas
 {
     FlightPathSegment* segment = nullptr;
 
-    if (prevItemPairHashTable.contains(pair) && (prevItemPairHashTable[pair]->segmentType() == FlightPathSegment::SegmentTypeTerrainFrame) != mavlinkTerrainFrame) {
+    if (prevItemPairHashTable.contains(pair) &&
+        prevItemPairHashTable[pair]->segmentType() == segmentTypeForPair(pair, mavlinkTerrainFrame)) {
         // Pair already exists and connected, just re-use
         _flightPathSegmentHashTable[pair] = segment = prevItemPairHashTable.take(pair);
     } else {

--- a/test/MissionManager/MissionControllerTest.cc
+++ b/test/MissionManager/MissionControllerTest.cc
@@ -4,6 +4,7 @@
 #include "AppSettings.h"
 #include "CameraCalc.h"
 #include "CorridorScanComplexItem.h"
+#include "FlightPathSegment.h"
 #include "StructureScanComplexItem.h"
 #include "SurveyComplexItem.h"
 #include "UnitTestCoords.h"
@@ -458,6 +459,92 @@ void MissionControllerTest::_testGlobalAltFrame()
             QCOMPARE(siLoop->missionItem().frame(), testCase.expectedMavFrame);
         }
     }
+}
+
+void MissionControllerTest::_testFlightPathSegmentCacheReuse()
+{
+    _initForFirmwareType(MAV_AUTOPILOT_PX4);
+
+    MissionSettingsItem* settingsItem = _missionController->visualItems()->value<MissionSettingsItem*>(0);
+    QVERIFY(settingsItem);
+    const QGeoCoordinate home = Coord::zurich();
+    settingsItem->setCoordinate(home);
+
+    // home(0) takeoff(1) spacer(2) wp3(3) wp4(4) landWp(5)
+    VisualMissionItem* takeoffItem = _missionController->insertTakeoffItem(home, 1);
+    VisualMissionItem* spacerItem = _missionController->insertSimpleMissionItem(home.atDistanceAndAzimuth(50, 0), 2);
+    SimpleMissionItem* wp3 =
+        qobject_cast<SimpleMissionItem*>(_missionController->insertSimpleMissionItem(home.atDistanceAndAzimuth(100, 0), 3));
+    SimpleMissionItem* wp4 =
+        qobject_cast<SimpleMissionItem*>(_missionController->insertSimpleMissionItem(home.atDistanceAndAzimuth(200, 0), 4));
+    SimpleMissionItem* landWp =
+        qobject_cast<SimpleMissionItem*>(_missionController->insertSimpleMissionItem(home.atDistanceAndAzimuth(300, 0), 5));
+    QVERIFY(takeoffItem);
+    QVERIFY(spacerItem);
+    QVERIFY(wp3);
+    QVERIFY(wp4);
+    QVERIFY(landWp);
+
+    QmlObjectListModel* segments = _missionController->simpleFlightPathSegments();
+    QCOMPARE_TRUE_WAIT(segments->count(), 5, TestTimeout::mediumMs());
+    QVERIFY(settingsItem->simpleFlightPathSegment());
+    QVERIFY(spacerItem->simpleFlightPathSegment());
+    QCOMPARE(settingsItem->simpleFlightPathSegment()->segmentType(), FlightPathSegment::SegmentTypeTakeoff);
+    QCOMPARE(spacerItem->simpleFlightPathSegment()->segmentType(), FlightPathSegment::SegmentTypeGeneric);
+
+    // Change frames/command underneath the cached segments. Segment type is CONSTANT, so the
+    // next recalc must recreate these segments rather than reuse the stale-typed ones.
+    wp3->setAltitudeFrame(QGroundControlQmlGlobal::AltitudeFrameTerrain);
+    wp4->setAltitudeFrame(QGroundControlQmlGlobal::AltitudeFrameTerrain);
+    landWp->setCommand(MAV_CMD_NAV_LAND);
+
+    FlightPathSegment* staleWp3Wp4 = wp3->simpleFlightPathSegment();
+    FlightPathSegment* staleWp4Land = wp4->simpleFlightPathSegment();
+    QVERIFY(staleWp3Wp4);
+    QVERIFY(staleWp4Land);
+    QCOMPARE(staleWp3Wp4->segmentType(), FlightPathSegment::SegmentTypeGeneric);
+    QCOMPARE(staleWp4Land->segmentType(), FlightPathSegment::SegmentTypeGeneric);
+    // Identity is compared as quintptr: on regression the stale segments are dangling and
+    // QCOMPARE on QObject* dereferences them when formatting the failure message.
+    const quintptr preRecalcHomeTakeoffPtr = quintptr(settingsItem->simpleFlightPathSegment());
+    const quintptr staleWp3Wp4Ptr = quintptr(staleWp3Wp4);
+    const quintptr staleWp4LandPtr = quintptr(staleWp4Land);
+
+    // Removing the spacer triggers a recalc: pairs whose computed type changed must be
+    // recreated with the new type, pairs whose type is unchanged must be reused.
+    _missionController->removeVisualItem(2);
+    QCOMPARE_TRUE_WAIT(segments->count(), 4, TestTimeout::mediumMs());
+
+    QVERIFY(settingsItem->simpleFlightPathSegment());
+    QVERIFY(takeoffItem->simpleFlightPathSegment());
+    QVERIFY(wp3->simpleFlightPathSegment());
+    QVERIFY(wp4->simpleFlightPathSegment());
+    QCOMPARE(quintptr(settingsItem->simpleFlightPathSegment()), preRecalcHomeTakeoffPtr);
+    QCOMPARE(settingsItem->simpleFlightPathSegment()->segmentType(), FlightPathSegment::SegmentTypeTakeoff);
+    // Terrain frame comes from the pair's first item: takeoff item is Relative, so still Generic
+    QCOMPARE(takeoffItem->simpleFlightPathSegment()->segmentType(), FlightPathSegment::SegmentTypeGeneric);
+    QVERIFY(quintptr(wp3->simpleFlightPathSegment()) != staleWp3Wp4Ptr);
+    QCOMPARE(wp3->simpleFlightPathSegment()->segmentType(), FlightPathSegment::SegmentTypeTerrainFrame);
+    // Land item as pair.second overrides the terrain frame of wp4
+    QVERIFY(quintptr(wp4->simpleFlightPathSegment()) != staleWp4LandPtr);
+    QCOMPARE(wp4->simpleFlightPathSegment()->segmentType(), FlightPathSegment::SegmentTypeLand);
+
+    const quintptr segHomeTakeoffPtr = quintptr(settingsItem->simpleFlightPathSegment());
+    const quintptr segWp3Wp4Ptr = quintptr(wp3->simpleFlightPathSegment());
+    const quintptr segWp4LandPtr = quintptr(wp4->simpleFlightPathSegment());
+
+    // Recalc again without touching these pairs: every segment must be reused as-is,
+    // including takeoff/land segments whose type never equals SegmentTypeTerrainFrame.
+    _missionController->insertSimpleMissionItem(home.atDistanceAndAzimuth(75, 0), 2);
+    QCOMPARE_TRUE_WAIT(segments->count(), 5, TestTimeout::mediumMs());
+
+    QVERIFY(wp3->simpleFlightPathSegment());
+    QVERIFY(wp4->simpleFlightPathSegment());
+    QCOMPARE(quintptr(settingsItem->simpleFlightPathSegment()), segHomeTakeoffPtr);
+    QCOMPARE(quintptr(wp3->simpleFlightPathSegment()), segWp3Wp4Ptr);
+    QCOMPARE(quintptr(wp4->simpleFlightPathSegment()), segWp4LandPtr);
+    QCOMPARE(wp3->simpleFlightPathSegment()->segmentType(), FlightPathSegment::SegmentTypeTerrainFrame);
+    QCOMPARE(wp4->simpleFlightPathSegment()->segmentType(), FlightPathSegment::SegmentTypeLand);
 }
 
 void MissionControllerTest::_testInsertComplexItemFromKML()

--- a/test/MissionManager/MissionControllerTest.h
+++ b/test/MissionManager/MissionControllerTest.h
@@ -21,6 +21,7 @@ private slots:
 
     void _testLoadJsonSectionAvailable();
     void _testGlobalAltFrame();
+    void _testFlightPathSegmentCacheReuse();
     void _testGimbalRecalc();
     void _testVehicleYawRecalc();
     void _testMissionReposition();


### PR DESCRIPTION
Stable_V5.1 backport of #14934 (clean cherry-pick of ffd02e702354f54c641a4ef863d7989491b7eef5, fix + unit test).

## Problem

The flight path segment cache reuse check in `MissionController::_addFlightPathSegment` had inverted logic: it reused a cached segment exactly when its type did **not** match the required type, and ignored the takeoff/land type overrides applied at creation. Terrain collision checks were silently skipped for segments that should have them, and the terrain profile rendered with the wrong segment type. Generated/uploaded mission items are unaffected — Plan view display/warning behavior only.

## Fix

Factor the segment type computation into `segmentTypeForPair()` and only reuse a cached segment when its type matches the type it would be created with.

## Testing

Includes `_testFlightPathSegmentCacheReuse` from the original PR; all test infrastructure it uses exists on Stable_V5.1.
