### PR TITLE
fix(FlyView): use raw meters for forward-flight goto loiter radius

### DIFF
--- a/src/FlyView/FlyViewGeoMap.qml
+++ b/src/FlyView/FlyViewGeoMap.qml
@@ -238,7 +238,9 @@ GeoMap {
         radiusMeters: _fwdFlightGotoCircleModel.radius.rawValue
         // Loiter happens at the goto altitude (carried in the center coordinate)
         altitudeMode: (center && !isNaN(center.altitude)) ? GeoMapItem.Absolute : GeoMapItem.ClampToGround
+        // PX4 ignores the commanded loiter radius (flies NAV_LOITER_RAD), so the circle size is unknown
         visible: gotoLocationItem.visible && root._activeVehicle &&
+                 !root._activeVehicle.px4Firmware &&
                  root._activeVehicle.inFwdFlight &&
                  !root._activeVehicle.orbitActive
 
@@ -276,7 +278,7 @@ GeoMap {
             showRotation: true
             clockwiseRotation: true
 
-            property real _defaultLoiterRadius: root._flyViewSettings.forwardFlightGoToLocationLoiterRad.value
+            property real _defaultLoiterRadius: root._flyViewSettings.forwardFlightGoToLocationLoiterRad.rawValue
             property real _committedRadius
 
             onCenterChanged: {

--- a/src/FlyView/FlyViewMap.qml
+++ b/src/FlyView/FlyViewMap.qml
@@ -317,7 +317,9 @@ FlightMap {
         mapControl:         parent
         mapCircle:          _fwdFlightGotoMapCircle
         radiusLabelVisible: true
+        // PX4 ignores the commanded loiter radius (flies NAV_LOITER_RAD), so the circle size is unknown
         visible:            gotoLocationItem.visible && _activeVehicle &&
+                            !_activeVehicle.px4Firmware &&
                             _activeVehicle.inFwdFlight &&
                             !_activeVehicle.orbitActive
 
@@ -360,7 +362,7 @@ FlightMap {
             showRotation:       true
             clockwiseRotation:  true
 
-            property real _defaultLoiterRadius: _flyViewSettings.forwardFlightGoToLocationLoiterRad.value
+            property real _defaultLoiterRadius: _flyViewSettings.forwardFlightGoToLocationLoiterRad.rawValue
             property real _committedRadius;
 
             onCenterChanged: {

--- a/src/FlyView/GuidedActionsController.qml
+++ b/src/FlyView/GuidedActionsController.qml
@@ -634,7 +634,7 @@ Item {
             if (!_activeVehicle.guidedModeGotoLocation(
                 actionData,
                 _vehicleInFwdFlight /* forwardFlightLoiterRadius */
-                    ? _flyViewSettings.forwardFlightGoToLocationLoiterRad.value
+                    ? _flyViewSettings.forwardFlightGoToLocationLoiterRad.rawValue
                     : 0
             )) {
                 return false

--- a/src/Settings/FlyView.SettingsGroup.json
+++ b/src/Settings/FlyView.SettingsGroup.json
@@ -96,7 +96,7 @@
         },
         {
             "name": "forwardFlightGoToLocationLoiterRad",
-            "shortDesc": "Loiter radius when circling a go-to destination during fixed-wing flight.",
+            "shortDesc": "Loiter radius when circling a go-to destination during fixed-wing flight. (ArduPilot only)",
             "type": "double",
             "units": "m",
             "default": 80,


### PR DESCRIPTION
Fixes #14936

The `forwardFlightGoToLocationLoiterRad` setting is stored raw in meters, but the map circle visuals (`FlyViewMap.qml`, `FlyViewGeoMap.qml`) and `actionGoto` in `GuidedActionsController.qml` read the cooked display-units `.value`. With feet display units the 80 m default became ~262 treated as meters (3.28x error) — drawn oversized on the map and, on ArduPilot, sent as `MAV_CMD_DO_REPOSITION` param3.

Changes:
- Read `.rawValue` (meters) at all three call sites, matching what `actionChangeLoiterRadius` already does.
- Hide the goto loiter circle (and thereby the "Change loiter radius" action) for PX4: the PX4 navigator ignores DO_REPOSITION param3 and flies `NAV_LOITER_RAD` instead, so the drawn circle size was meaningless.
- Note "(ArduPilot only)" in the setting description.

The `.rawValue` fix should be cherry-picked to `Stable_V5.1` (both call sites present there).
