### PR TITLE
fix(PX4FirmwarePlugin): detect gripper via PD_GRIPPER_TYPE on PX4 v1.17+ (Stable_V5.1)

### DIFF
--- a/src/FirmwarePlugin/PX4/PX4FirmwarePlugin.cc
+++ b/src/FirmwarePlugin/PX4/PX4FirmwarePlugin.cc
@@ -743,10 +743,20 @@ QString PX4FirmwarePlugin::getHobbsMeter(Vehicle* vehicle) const
 
 bool PX4FirmwarePlugin::hasGripper(const Vehicle* vehicle) const
 {
-    if(vehicle->parameterManager()->parameterExists(ParameterManager::defaultComponentId, QStringLiteral("PD_GRIPPER_EN"))) {
-        bool _hasGripper = (vehicle->parameterManager()->getParameter(ParameterManager::defaultComponentId, QStringLiteral("PD_GRIPPER_EN"))->rawValue().toInt()) != 0 ? true : false;
-        return _hasGripper;
+    ParameterManager* paramMgr = vehicle->parameterManager();
+
+    // PX4 versions prior to v1.17 use the PD_GRIPPER_EN boolean
+    const QString gripperEnableParam = QStringLiteral("PD_GRIPPER_EN");
+    if (paramMgr->parameterExists(ParameterManager::defaultComponentId, gripperEnableParam)) {
+        return paramMgr->getParameter(ParameterManager::defaultComponentId, gripperEnableParam)->rawValue().toInt() != 0;
     }
+
+    // PX4 v1.17+ removed PD_GRIPPER_EN; PD_GRIPPER_TYPE >= 0 means enabled (-1 = Undefined)
+    const QString gripperTypeParam = QStringLiteral("PD_GRIPPER_TYPE");
+    if (paramMgr->parameterExists(ParameterManager::defaultComponentId, gripperTypeParam)) {
+        return paramMgr->getParameter(ParameterManager::defaultComponentId, gripperTypeParam)->rawValue().toInt() >= 0;
+    }
+
     return false;
 }
 

--- a/test/Vehicle/CMakeLists.txt
+++ b/test/Vehicle/CMakeLists.txt
@@ -25,6 +25,8 @@ target_sources(${CMAKE_PROJECT_NAME}
         MultiVehicleManagerTest.h
         PX4ExternalFlightModesTest.cc
         PX4ExternalFlightModesTest.h
+        PX4HasGripperTest.cc
+        PX4HasGripperTest.h
         RemoteIDManagerTest.cc
         RemoteIDManagerTest.h
         RequestMessageTest.cc
@@ -58,6 +60,7 @@ add_qgc_test(MAVLinkLogManagerTest LABELS Integration Vehicle)
 add_qgc_test(MavCommandQueueReentrancyTest LABELS Integration Vehicle)
 add_qgc_test(MultiVehicleManagerTest LABELS Integration Vehicle)
 add_qgc_test(PX4ExternalFlightModesTest LABELS Unit Vehicle)
+add_qgc_test(PX4HasGripperTest LABELS Integration Vehicle)
 add_qgc_test(RemoteIDManagerTest LABELS Integration Vehicle)
 add_qgc_test(RequestMessageTest LABELS Integration Vehicle TIMEOUT ${QGC_TEST_TIMEOUT_EXTENDED})
 add_qgc_test(SendMavCommandWithHandlerTest LABELS Integration Vehicle)

--- a/test/Vehicle/PX4HasGripperTest.cc
+++ b/test/Vehicle/PX4HasGripperTest.cc
@@ -1,0 +1,29 @@
+#include "PX4HasGripperTest.h"
+
+#include "Fact.h"
+#include "ParameterManager.h"
+#include "QGCMAVLink.h"
+#include "Vehicle.h"
+
+void PX4HasGripperTest::_gripperDetectedFromGripperType()
+{
+    QVERIFY(vehicle());
+
+    // PX4MockLink.params has PD_GRIPPER_TYPE=0 and no PD_GRIPPER_EN, matching PX4 v1.17+
+    QVERIFY(vehicle()->hasGripper());
+
+    // PD_GRIPPER_TYPE=-1 (Undefined) means gripper disabled
+    Fact* gripperType = vehicle()->parameterManager()->getParameter(ParameterManager::defaultComponentId,
+                                                                    QStringLiteral("PD_GRIPPER_TYPE"));
+    QVERIFY(gripperType);
+    gripperType->setRawValue(-1);
+    QVERIFY(!vehicle()->hasGripper());
+
+    // Wait for the write to fully complete. Otherwise the async PARAM_SET fires during link
+    // teardown, logging unexpected warnings which fail the test in strict log mode.
+    QTRY_COMPARE_WITH_TIMEOUT(mockLink()->paramValue(MAV_COMP_ID_AUTOPILOT1, QStringLiteral("PD_GRIPPER_TYPE")).toInt(),
+                              -1, TestTimeout::mediumMs());
+    QVERIFY_TRUE_WAIT(!vehicle()->parameterManager()->pendingWrites(), TestTimeout::mediumMs());
+}
+
+UT_REGISTER_TEST(PX4HasGripperTest, TestLabel::Integration, TestLabel::Vehicle)

--- a/test/Vehicle/PX4HasGripperTest.h
+++ b/test/Vehicle/PX4HasGripperTest.h
@@ -1,0 +1,16 @@
+#pragma once
+
+#include "BaseClasses/VehicleTest.h"
+
+/// Verifies gripper detection against PX4 v1.17+ parameters where PD_GRIPPER_EN was removed
+/// and enablement is expressed via PD_GRIPPER_TYPE >= 0 (issue #14930).
+class PX4HasGripperTest : public VehicleTest
+{
+    Q_OBJECT
+
+public:
+    explicit PX4HasGripperTest(QObject* parent = nullptr) : VehicleTest(parent) { setWaitForParameters(true); }
+
+private slots:
+    void _gripperDetectedFromGripperType();
+};


### PR DESCRIPTION
Fixes #14930

PX4 v1.17 removed the `PD_GRIPPER_EN` parameter, so the Fly View gripper button never appeared for vehicles running v1.17+. Gripper enablement is now expressed via `PD_GRIPPER_TYPE`: `-1` = Undefined (disabled), `>= 0` = a configured gripper type.

### Changes
- `PX4FirmwarePlugin::hasGripper()`: keep the legacy `PD_GRIPPER_EN != 0` check for pre-1.17 firmware, fall back to `PD_GRIPPER_TYPE >= 0` when `PD_GRIPPER_EN` does not exist.
- New `PX4HasGripperTest` (MockLink integration test): verifies gripper detection with the v1.17+ parameter layout (`PD_GRIPPER_TYPE` present, no `PD_GRIPPER_EN`) and that `PD_GRIPPER_TYPE = -1` disables detection.
