### PR TITLE
fix(FlyView): use raw meters for forward-flight goto loiter radius (Stable_V5.1)

### DIFF
--- a/src/FlyView/FlyViewMap.qml
+++ b/src/FlyView/FlyViewMap.qml
@@ -362,7 +362,9 @@ FlightMap {
         mapControl:         parent
         mapCircle:          _fwdFlightGotoMapCircle
         radiusLabelVisible: true
+        // PX4 ignores the commanded loiter radius (flies NAV_LOITER_RAD), so the circle size is unknown
         visible:            gotoLocationItem.visible && _activeVehicle &&
+                            !_activeVehicle.px4Firmware &&
                             _activeVehicle.inFwdFlight &&
                             !_activeVehicle.orbitActive
 
@@ -405,7 +407,7 @@ FlightMap {
             showRotation:       true
             clockwiseRotation:  true
 
-            property real _defaultLoiterRadius: _flyViewSettings.forwardFlightGoToLocationLoiterRad.value
+            property real _defaultLoiterRadius: _flyViewSettings.forwardFlightGoToLocationLoiterRad.rawValue
             property real _committedRadius;
 
             onCenterChanged: {

--- a/src/FlyView/GuidedActionsController.qml
+++ b/src/FlyView/GuidedActionsController.qml
@@ -625,7 +625,7 @@ Item {
             if (!_activeVehicle.guidedModeGotoLocation(
                 actionData,
                 _vehicleInFwdFlight /* forwardFlightLoiterRadius */
-                    ? _flyViewSettings.forwardFlightGoToLocationLoiterRad.value
+                    ? _flyViewSettings.forwardFlightGoToLocationLoiterRad.rawValue
                     : 0
             )) {
                 return false

--- a/src/Settings/FlyView.SettingsGroup.json
+++ b/src/Settings/FlyView.SettingsGroup.json
@@ -79,7 +79,7 @@
         },
         {
             "name": "forwardFlightGoToLocationLoiterRad",
-            "shortDesc": "Loiter radius when circling a go-to destination during fixed-wing flight.",
+            "shortDesc": "Loiter radius when circling a go-to destination during fixed-wing flight. (ArduPilot only)",
             "type": "double",
             "units": "m",
             "default": 80,


### PR DESCRIPTION
Backport of #14938 to Stable_V5.1. Fixes #14936 there.

The `forwardFlightGoToLocationLoiterRad` setting is stored raw in meters, but the map circle visual (`FlyViewMap.qml`) and `actionGoto` in `GuidedActionsController.qml` read the cooked display-units `.value`. With feet display units the 80 m default became ~262 treated as meters (3.28x error) — drawn oversized on the map and, on ArduPilot, sent as `MAV_CMD_DO_REPOSITION` param3.

Changes (same as master; stable has no FlyViewGeoMap.qml):
- Read `.rawValue` (meters) at both call sites.
- Hide the goto loiter circle (and thereby the "Change loiter radius" action) for PX4, which ignores DO_REPOSITION param3 and flies `NAV_LOITER_RAD`.
- Note "(ArduPilot only)" in the setting description.
