### PR TITLE
fix(Comms): never leave link worker threads running at destruction

### DIFF
--- a/src/Comms/Bluetooth/BluetoothLink.cc
+++ b/src/Comms/Bluetooth/BluetoothLink.cc
@@ -53,12 +53,7 @@ BluetoothLink::~BluetoothLink()
             (void) QMetaObject::invokeMethod(_worker, "disconnectLink", Qt::QueuedConnection);
         }
 
-        _workerThread->quit();
-        if (!_workerThread->wait(5000)) {
-            qCWarning(BluetoothLinkLog) << "Worker thread did not stop within timeout, terminating";
-            _workerThread->terminate();
-            (void) _workerThread->wait(1000);
-        }
+        _shutdownWorkerThread(_workerThread, BluetoothLinkLog());
     }
 
     qCDebug(BluetoothLinkLog) << this;

--- a/src/Comms/LinkInterface.cc
+++ b/src/Comms/LinkInterface.cc
@@ -6,9 +6,14 @@
 #include "QGCLoggingCategory.h"
 #include "SigningController.h"
 
+#include <QtCore/QThread>
 #include <QtQml/QQmlEngine>
 
 QGC_LOGGING_CATEGORY(LinkInterfaceLog, "Comms.LinkInterface")
+
+namespace {
+    constexpr int WORKER_SHUTDOWN_TIMEOUT_MS = 3000;
+}
 
 LinkInterface::LinkInterface(SharedLinkConfigurationPtr &config, QObject *parent)
     : QObject(parent)
@@ -24,6 +29,52 @@ LinkInterface::~LinkInterface()
     }
 
     _config.reset();
+}
+
+void LinkInterface::_shutdownWorkerThread(QThread *thread, const QLoggingCategory &category, bool allowTerminate)
+{
+    if (!thread) {
+        return;
+    }
+
+    // Self-shutdown: wait() would fail and terminate() would kill the calling thread mid-destructor
+    if (thread->isCurrentThread()) {
+        qCCritical(category) << "Shutdown called from worker thread itself, orphaning";
+        thread->quit();
+        _orphanWorkerThread(thread);
+        return;
+    }
+
+    thread->quit();
+    if (thread->wait(WORKER_SHUTDOWN_TIMEOUT_MS)) {
+        return;
+    }
+
+    if (allowTerminate) {
+        qCWarning(category) << "Worker thread did not stop within timeout, terminating";
+        thread->terminate();
+        if (thread->wait(WORKER_SHUTDOWN_TIMEOUT_MS)) {
+            return;
+        }
+    }
+
+    // Orphan the running thread — leaking it beats the ~QThread abort in deleteChildren()
+    qCCritical(category) << "Worker thread could not be stopped, leaking it to avoid abort";
+    _orphanWorkerThread(thread);
+}
+
+void LinkInterface::_orphanWorkerThread(QThread *thread)
+{
+    thread->setParent(nullptr);
+
+    // Workers hold raw pointers into the configuration: keep it alive until the thread
+    // finishes so a stalled worker that resumes can't dereference a destroyed config.
+    (void) QObject::connect(thread, &QThread::finished, thread, [config = _config]() { Q_UNUSED(config); });
+
+    // Self-heal if the thread eventually exits: deleting the thread destroys the
+    // connection above, releasing the config. At app exit there is no main loop to
+    // deliver this, so both leak — the intended last-resort behavior.
+    (void) QObject::connect(thread, &QThread::finished, thread, &QObject::deleteLater);
 }
 
 uint8_t LinkInterface::mavlinkChannel() const

--- a/src/Comms/LinkInterface.h
+++ b/src/Comms/LinkInterface.h
@@ -9,6 +9,8 @@
 #include "MAVLinkMessageType.h"
 
 class LinkManager;
+class QLoggingCategory;
+class QThread;
 class SigningController;
 
 /// \brief The link interface defines the interface for all links used to communicate with the ground station application.
@@ -76,6 +78,15 @@ protected:
 
     void _connectionRemoved();
 
+    /// Stops a link's worker thread, bounding the wait so destruction can always proceed.
+    /// Guarantees the thread is never left as a QObject child while running (which would abort
+    /// in ~QThread when child cleanup deletes it) — NOT that execution has stopped on return:
+    /// on quit timeout the thread is terminated, and as a last resort it is orphaned and leaked,
+    /// still running, with the link configuration kept alive so a resumed worker can't
+    /// dereference a destroyed config. Pass allowTerminate = false when the worker holds locks
+    /// that termination could leave locked.
+    void _shutdownWorkerThread(QThread *thread, const QLoggingCategory &category, bool allowTerminate = true);
+
     SharedLinkConfigurationPtr _config;
 
 private slots:
@@ -85,6 +96,8 @@ private slots:
 private:
     /// connect is private since all links should be created through LinkManager::createConnectedLink calls
     virtual bool _connect() = 0;
+
+    void _orphanWorkerThread(QThread *thread);
 
     uint8_t _mavlinkChannel = std::numeric_limits<uint8_t>::max();
     bool _decodedFirstMavlinkPacket = false;

--- a/src/Comms/LogReplayLink.cc
+++ b/src/Comms/LogReplayLink.cc
@@ -451,14 +451,14 @@ LogReplayLink::LogReplayLink(SharedLinkConfigurationPtr &config, QObject *parent
 LogReplayLink::~LogReplayLink()
 {
     if (isConnected()) {
-        (void) QMetaObject::invokeMethod(_worker, "disconnectFromLog", Qt::BlockingQueuedConnection);
+        // Queued, not blocking: keeps a wedged worker from hanging the destructor before
+        // _shutdownWorkerThread can bound the wait. If quit() beats the queued call,
+        // ~LogReplayWorker still disconnects on thread finish.
+        (void) QMetaObject::invokeMethod(_worker, "disconnectFromLog", Qt::QueuedConnection);
         _onDisconnected();
     }
 
-    _workerThread->quit();
-    if (!_workerThread->wait()) {
-        qCWarning(LogReplayLinkLog) << "Failed to wait for LogReplay Thread to close";
-    }
+    _shutdownWorkerThread(_workerThread, LogReplayLinkLog());
 
     qCDebug(LogReplayLinkLog) << this;
 }

--- a/src/Comms/SerialLink.cc
+++ b/src/Comms/SerialLink.cc
@@ -9,7 +9,6 @@ QGC_LOGGING_CATEGORY(SerialLinkLog, "Comms.SerialLink")
 
 namespace {
     constexpr int CONNECT_TIMEOUT_MS = 1000;
-    constexpr int DISCONNECT_TIMEOUT_MS = 3000;
 }
 
 /*===========================================================================*/
@@ -446,14 +445,14 @@ SerialLink::SerialLink(SharedLinkConfigurationPtr &config, QObject *parent)
 SerialLink::~SerialLink()
 {
     if (isConnected()) {
-        (void) QMetaObject::invokeMethod(_worker, "disconnectFromPort", Qt::BlockingQueuedConnection);
+        // Queued, not blocking: a wedged worker (e.g. QSerialPort::close() hung in a driver)
+        // would block here forever, before _shutdownWorkerThread can bound the wait.
+        // If quit() beats the queued call, ~SerialWorker still disconnects on thread finish.
+        (void) QMetaObject::invokeMethod(_worker, "disconnectFromPort", Qt::QueuedConnection);
         _onDisconnected();
     }
 
-    _workerThread->quit();
-    if (!_workerThread->wait(DISCONNECT_TIMEOUT_MS)) {
-        qCWarning(SerialLinkLog) << "Failed to wait for Serial Thread to close";
-    }
+    _shutdownWorkerThread(_workerThread, SerialLinkLog());
 
     qCDebug(SerialLinkLog) << this;
 }

--- a/src/Comms/TCPLink.cc
+++ b/src/Comms/TCPLink.cc
@@ -11,7 +11,6 @@ QGC_LOGGING_CATEGORY(TCPLinkLog, "Comms.TCPLink")
 
 namespace {
     constexpr int CONNECT_TIMEOUT_MS = 3000;
-    constexpr int DISCONNECT_TIMEOUT_MS = 3000;
     constexpr int TYPE_OF_SERVICE = 32; // Set ToS to priority for low delay
 }
 
@@ -272,14 +271,14 @@ TCPLink::TCPLink(SharedLinkConfigurationPtr &config, QObject *parent)
 TCPLink::~TCPLink()
 {
     if (isConnected()) {
-        (void) QMetaObject::invokeMethod(_worker, "disconnectFromHost", Qt::BlockingQueuedConnection);
+        // Queued, not blocking: keeps a wedged worker from hanging the destructor before
+        // _shutdownWorkerThread can bound the wait. If quit() beats the queued call,
+        // ~TCPWorker still disconnects on thread finish.
+        (void) QMetaObject::invokeMethod(_worker, "disconnectFromHost", Qt::QueuedConnection);
         _onDisconnected();
     }
 
-    _workerThread->quit();
-    if (!_workerThread->wait(DISCONNECT_TIMEOUT_MS)) {
-        qCWarning(TCPLinkLog) << "Failed to wait for TCP Thread to close";
-    }
+    _shutdownWorkerThread(_workerThread, TCPLinkLog());
 
     qCDebug(TCPLinkLog) << this;
 }

--- a/src/Comms/UDPLink.cc
+++ b/src/Comms/UDPLink.cc
@@ -533,14 +533,15 @@ UDPLink::UDPLink(SharedLinkConfigurationPtr &config, QObject *parent)
 UDPLink::~UDPLink()
 {
     if (isConnected()) {
-        (void) QMetaObject::invokeMethod(_worker, "disconnectLink", Qt::BlockingQueuedConnection);
+        // Queued, not blocking: keeps a wedged worker from hanging the destructor before
+        // _shutdownWorkerThread can bound the wait. If quit() beats the queued call,
+        // ~UDPWorker still disconnects on thread finish.
+        (void) QMetaObject::invokeMethod(_worker, "disconnectLink", Qt::QueuedConnection);
         _onDisconnected();
     }
 
-    _workerThread->quit();
-    if (!_workerThread->wait()) {
-        qCWarning(UDPLinkLog) << "Failed to wait for UDP Thread to close";
-    }
+    // No terminate: it could kill the worker while it holds _sessionTargetsMutex
+    _shutdownWorkerThread(_workerThread, UDPLinkLog(), false /* allowTerminate */);
 
     qCDebug(UDPLinkLog) << this;
 }


### PR DESCRIPTION
Fixes #14942

### Problem

On exit, `~LinkManager` destroys links on the main thread. If a link's worker thread failed to stop within the disconnect timeout (e.g. macOS serial driver blocking in close), the destructor just logged a warning and returned — leaving the running `QThread` to be deleted by `QObjectPrivate::deleteChildren()`, which hits the fatal `QThread: Destroyed while thread is still running` abort seen in the crash report.

### Fix

Centralize worker-thread shutdown in a new `LinkInterface::_shutdownWorkerThread()` helper used by Serial, TCP, UDP, Bluetooth, and LogReplay links:

1. `quit()` + bounded `wait()` (3s)
2. On timeout, `terminate()` + bounded `wait()` — except UDP, whose worker holds `_sessionTargetsMutex` that termination could leave locked (`allowTerminate = false`)
3. As a last resort, orphan the thread object (`setParent(nullptr)`) so the worst case is a deterministic leak at exit instead of an abort

Also fixes related latent issues:

- `UDPLink` and `LogReplayLink` previously used an *infinite* `wait()`, which could hang exit forever
- `BluetoothLink` ignored the result of its post-terminate wait, so it could still abort
- Guards against self-shutdown (helper called from the worker thread itself), where `terminate()` would kill the calling thread mid-destructor

`MockLink` (test-only, trivial worker) is intentionally left unchanged.
