### PR TITLE
test(platform): match platform guards in unit-test environment expectations

### DIFF
--- a/test/Utilities/Platform/PlatformTest.cc
+++ b/test/Utilities/Platform/PlatformTest.cc
@@ -47,10 +47,16 @@ void PlatformTest::_testInitializeSetsUnitTestEnvironment()
     TestFixtures::EnvVarFixture restoreConsole("QT_ASSUME_STDERR_HAS_CONSOLE");
     TestFixtures::EnvVarFixture restoreLogging("QT_FORCE_STDERR_LOGGING");
     TestFixtures::EnvVarFixture restoreQpa("QT_QPA_PLATFORM");
+#ifdef Q_OS_WIN
+    TestFixtures::EnvVarFixture restoreWinConsole("QT_WIN_DEBUG_CONSOLE");
+#endif
 
     (void) qunsetenv("QT_ASSUME_STDERR_HAS_CONSOLE");
     (void) qunsetenv("QT_FORCE_STDERR_LOGGING");
     (void) qunsetenv("QT_QPA_PLATFORM");
+#ifdef Q_OS_WIN
+    (void) qunsetenv("QT_WIN_DEBUG_CONSOLE");
+#endif
 
     QGCCommandLineParser::CommandLineParseResult args;
     args.runningUnitTests = true;
@@ -61,8 +67,14 @@ void PlatformTest::_testInitializeSetsUnitTestEnvironment()
     const std::optional<int> initResult = Platform::initialize(1, argv, args);
 
     QVERIFY(!initResult.has_value());
+#if defined(Q_OS_UNIX) && !defined(Q_OS_ANDROID)
+    // The stderr logging setup is guarded by the same condition in Platform::initialize()
     QCOMPARE(qgetenv("QT_ASSUME_STDERR_HAS_CONSOLE"), QByteArray("1"));
     QCOMPARE(qgetenv("QT_FORCE_STDERR_LOGGING"), QByteArray("1"));
+#endif
+#ifdef Q_OS_WIN
+    QCOMPARE(qgetenv("QT_WIN_DEBUG_CONSOLE"), QByteArray("attach"));
+#endif
     QCOMPARE(qgetenv("QT_QPA_PLATFORM"), QByteArray("offscreen"));
 }
 #endif


### PR DESCRIPTION
## Description
`PlatformTest::_testInitializeSetsUnitTestEnvironment` expects `QT_ASSUME_STDERR_HAS_CONSOLE` / `QT_FORCE_STDERR_LOGGING` to be set unconditionally after `Platform::initialize()`, but `Platform.cc` only sets them under `Q_OS_UNIX && !Q_OS_ANDROID` — so the test always fails on Windows. This guards the expectations with the same condition and, on Windows, asserts the platform's actual contract instead (`QT_WIN_DEBUG_CONSOLE=attach`).

(CI never sees this because the test suite runs on Linux only; found while establishing a Windows unit-test baseline: full Unit label run, MSVC 2022 / Qt 6.11.1.)

## Type of Change
- [x] Bug fix (non-breaking change that fixes an issue)

## Testing
- [x] Tested locally
- [x] New and existing unit tests pass locally

`ctest -C Debug -R PlatformTest` passes on Windows after this change (failed before).

### Platforms Tested
- [x] Windows

## Checklist
- [x] I have read the Contribution Guidelines
- [x] I have read the Code of Conduct
- [x] New and existing unit tests pass locally

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)
