### PR TITLE
test(geotag): compare paths case-insensitively on Windows

### DIFF
--- a/test/AnalyzeView/GeoTag/GeoTagControllerTest.cc
+++ b/test/AnalyzeView/GeoTag/GeoTagControllerTest.cc
@@ -16,6 +16,17 @@
 
 namespace {
 
+// Windows filesystems are case-insensitive and different path sources disagree on
+// drive-letter case (e.g. "c:/" from QTemporaryDir vs "C:/"), so compare case-insensitively there.
+QString comparablePath(const QString& path)
+{
+#ifdef Q_OS_WIN
+    return QDir::cleanPath(path).toLower();
+#else
+    return QDir::cleanPath(path);
+#endif
+}
+
 QString generateTestULogFile(const QString& directoryPath, int numEvents = 20)
 {
     const QString ulogPath = QDir(directoryPath).filePath(QStringLiteral("test.ulg"));
@@ -82,9 +93,9 @@ void GeoTagControllerTest::_propertyAccessorsTest()
     QVERIFY(!controller->imageDirectory().isEmpty());
     QVERIFY(!controller->saveDirectory().isEmpty());
 
-    QCOMPARE(QDir::cleanPath(controller->logFile()), QDir::cleanPath(ulogPath));
-    QCOMPARE(QDir::cleanPath(controller->imageDirectory()), QDir::cleanPath(imageDirPath));
-    QCOMPARE(QDir::cleanPath(controller->saveDirectory()), QDir::cleanPath(taggedDirPath));
+    QCOMPARE(comparablePath(controller->logFile()), comparablePath(ulogPath));
+    QCOMPARE(comparablePath(controller->imageDirectory()), comparablePath(imageDirPath));
+    QCOMPARE(comparablePath(controller->saveDirectory()), comparablePath(taggedDirPath));
     QCOMPARE(controller->progress(), 0.0);
     QVERIFY(!controller->inProgress());
 
@@ -113,7 +124,7 @@ void GeoTagControllerTest::_urlPathConversionTest()
     testFile.close();
 
     controller->setLogFile(QUrl::fromLocalFile(testPath).toString());
-    QCOMPARE(QDir::cleanPath(controller->logFile()), QDir::cleanPath(testPath));
+    QCOMPARE(comparablePath(controller->logFile()), comparablePath(testPath));
 
     testFile.remove();
 }


### PR DESCRIPTION
## Description
`GeoTagControllerTest::_propertyAccessorsTest` fails on Windows on drive-letter case alone: `QTemporaryDir` yields `c:/Users/...` while the compared path is `C:/Users/...`. `QDir::cleanPath()` does not normalize case, and NTFS is case-insensitive, so the strings differ while the paths are the same file. This compares via a small `comparablePath()` helper that lowercases on Windows only; behavior on other platforms is unchanged.

(CI never sees this because the test suite runs on Linux only; found while establishing a Windows unit-test baseline, MSVC 2022 / Qt 6.11.1.)

## Type of Change
- [x] Bug fix (non-breaking change that fixes an issue)

## Testing
- [x] Tested locally
- [x] New and existing unit tests pass locally

`ctest -C Debug -R GeoTagControllerTest` passes on Windows after this change (failed before).

### Platforms Tested
- [x] Windows

## Checklist
- [x] I have read the Contribution Guidelines
- [x] I have read the Code of Conduct
- [x] New and existing unit tests pass locally

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)
