### PR TITLE
docs: restore the multi-vehicle unique-id safety warning

### DIFF
--- a/docs/en/qgc-user-guide/fly_view/fly_view_toolbar.md
+++ b/docs/en/qgc-user-guide/fly_view/fly_view_toolbar.md
@@ -113,6 +113,10 @@ Expanding the indicator provides full key management: you can enable a key on th
 
 The Multi-Vehicle selector appears when more than one vehicle is connected. It allows you to quickly switch the active vehicle from the toolbar.
 
+::: warning
+Each vehicle connected to QGC must have a unique id, otherwise QGC will think the vehicles are actually the same vehicle. The symptom of this is the Plan view jerking around as it tries to position itself to one vehicle and then the next. For PX4 firmwares the id is the `MAV_SYS_ID` parameter; for ArduPilot firmwares it is the `SYSID_THISMAV` parameter.
+:::
+
 ### APM Support Forwarding <img src="../../../assets/fly/toolbar/apm_support_indicator.png" alt="APM Support Forwarding indicator" style="height: 1.15em; vertical-align: text-bottom;" />
 
 On ArduPilot, an APM Support Forwarding indicator appears when MAVLink traffic forwarding to a support server is enabled.


### PR DESCRIPTION
## Description
Restores the "unique vehicle ids" multi-vehicle warning that was dropped from `docs/en` during the v3.2 release-note restructure — the `tr`/`zh`/`ko` trees still carry it. Duplicate `MAV_SYS_ID` / `SYSID_THISMAV` is the most common multi-vehicle failure and its symptom (the Plan view jerking around between vehicles) is otherwise undocumented in English. The warning is restored where users will actually find it: the Fly View toolbar's Multi-Vehicle Selector section.

## Type of Change
- [x] Documentation update

## Testing
- [x] Tested locally (markdown renders; wording taken from the original v3.2 release note, updated parameter naming)

## Checklist
- [x] I have read the Contribution Guidelines
- [x] I have read the Code of Conduct

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)
