### PR TITLE
fix(statustext): render each severity class distinctly

### DIFF
--- a/src/MAVLink/StatusTextHandler.cc
+++ b/src/MAVLink/StatusTextHandler.cc
@@ -154,10 +154,9 @@ void StatusTextHandler::handleHTMLEscapedTextMessage(MAV_COMPONENT compId, MAV_S
 
     MessageType messageType = MessageType::MessageNone;
 
-    // Color the output depending on the message severity. We have 3 distinct cases:
-    // 1: If we have an ERROR or worse, make it bigger, bolder, and highlight it red.
-    // 2: If we have a warning or notice, just make it bold and color it orange.
-    // 3: Otherwise color it the standard color, white.
+    // Style the output by severity. Each placeholder is resolved to concrete CSS by the
+    // renderer (VehicleMessageList.qml). Distinct tags keep ERROR-class, WARNING, NOTICE,
+    // INFO and DEBUG visually distinguishable instead of collapsing to three looks.
     QString style;
     switch (severity) {
         case MAV_SEVERITY_EMERGENCY:
@@ -168,10 +167,19 @@ void StatusTextHandler::handleHTMLEscapedTextMessage(MAV_COMPONENT compId, MAV_S
             messageType = MessageType::MessageError;
             break;
 
-        case MAV_SEVERITY_NOTICE:
         case MAV_SEVERITY_WARNING:
+            style = QStringLiteral("<#W>");
+            messageType = MessageType::MessageWarning;
+            break;
+
+        case MAV_SEVERITY_NOTICE:
             style = QStringLiteral("<#I>");
             messageType = MessageType::MessageWarning;
+            break;
+
+        case MAV_SEVERITY_DEBUG:
+            style = QStringLiteral("<#D>");
+            messageType = MessageType::MessageNormal;
             break;
 
         default:

--- a/src/Toolbar/VehicleMessageList.qml
+++ b/src/Toolbar/VehicleMessageList.qml
@@ -22,9 +22,14 @@ TextArea {
     property var _fact: null
 
     function formatMessage(message) {
-        message = message.replace(new RegExp("<#E>", "g"), "color: " + qgcPal.warningText + "; font: " + (ScreenTools.defaultFontPointSize.toFixed(0) - 1) + "pt monospace;");
-        message = message.replace(new RegExp("<#I>", "g"), "color: " + qgcPal.warningText + "; font: " + (ScreenTools.defaultFontPointSize.toFixed(0) - 1) + "pt monospace;");
-        message = message.replace(new RegExp("<#N>", "g"), "color: " + qgcPal.text + "; font: " + (ScreenTools.defaultFontPointSize.toFixed(0) - 1) + "pt monospace;");
+        // Distinct look per severity class: errors red+bold, warnings orange, notices
+        // emphasized, info normal, debug dimmed. Tags come from StatusTextHandler.
+        var messageFont = "font: " + (ScreenTools.defaultFontPointSize.toFixed(0) - 1) + "pt monospace;"
+        message = message.replace(new RegExp("<#E>", "g"), "color: " + qgcPal.colorRed + "; " + messageFont + " font-weight: bold;");
+        message = message.replace(new RegExp("<#W>", "g"), "color: " + qgcPal.warningText + "; " + messageFont);
+        message = message.replace(new RegExp("<#I>", "g"), "color: " + qgcPal.text + "; " + messageFont + " font-weight: bold;");
+        message = message.replace(new RegExp("<#N>", "g"), "color: " + qgcPal.text + "; " + messageFont);
+        message = message.replace(new RegExp("<#D>", "g"), "color: " + qgcPal.colorGrey + "; " + messageFont);
         return message;
     }
 

--- a/test/MAVLink/StatusTextHandlerTest.cc
+++ b/test/MAVLink/StatusTextHandlerTest.cc
@@ -102,6 +102,38 @@ void StatusTextHandlerTest::_testHandleErrorMessageAndMultiComponentPrefix()
     QVERIFY(formatted.contains(QStringLiteral("Error")));
 }
 
+void StatusTextHandlerTest::_testSeverityStyleTag_data()
+{
+    QTest::addColumn<int>("severity");
+    QTest::addColumn<QString>("styleTag");
+
+    QTest::newRow("emergency") << static_cast<int>(MAV_SEVERITY_EMERGENCY) << QStringLiteral("<#E>");
+    QTest::newRow("alert")     << static_cast<int>(MAV_SEVERITY_ALERT)     << QStringLiteral("<#E>");
+    QTest::newRow("critical")  << static_cast<int>(MAV_SEVERITY_CRITICAL)  << QStringLiteral("<#E>");
+    QTest::newRow("error")     << static_cast<int>(MAV_SEVERITY_ERROR)     << QStringLiteral("<#E>");
+    QTest::newRow("warning")   << static_cast<int>(MAV_SEVERITY_WARNING)   << QStringLiteral("<#W>");
+    QTest::newRow("notice")    << static_cast<int>(MAV_SEVERITY_NOTICE)    << QStringLiteral("<#I>");
+    QTest::newRow("info")      << static_cast<int>(MAV_SEVERITY_INFO)      << QStringLiteral("<#N>");
+    QTest::newRow("debug")     << static_cast<int>(MAV_SEVERITY_DEBUG)     << QStringLiteral("<#D>");
+}
+
+void StatusTextHandlerTest::_testSeverityStyleTag()
+{
+    QFETCH(int, severity);
+    QFETCH(QString, styleTag);
+
+    StatusTextHandler statusTextHandler;
+    QSignalSpy formattedSpy(&statusTextHandler, &StatusTextHandler::newFormattedMessage);
+    QVERIFY(formattedSpy.isValid());
+
+    statusTextHandler.handleHTMLEscapedTextMessage(MAV_COMP_ID_USER1, static_cast<MAV_SEVERITY>(severity), "StyleTagMessage", "");
+
+    QCOMPARE(formattedSpy.count(), 1);
+    const QString formatted = formattedSpy.at(0).at(0).toString();
+    QVERIFY2(formatted.contains(styleTag),
+             qPrintable(QStringLiteral("expected tag %1 in: %2").arg(styleTag, formatted)));
+}
+
 void StatusTextHandlerTest::_testResetErrorLevelMessages()
 {
     StatusTextHandler statusTextHandler;

--- a/test/MAVLink/StatusTextHandlerTest.h
+++ b/test/MAVLink/StatusTextHandlerTest.h
@@ -11,6 +11,8 @@ private slots:
     void _testHandleTextMessage();
     void _testHandleErrorMessageAndMultiComponentPrefix();
     void _testResetErrorLevelMessages();
+    void _testSeverityStyleTag_data();
+    void _testSeverityStyleTag();
     void _testChunkedStatusTextMissingChunk();
     void _testChunkedStatusTextTimeoutAddsEllipsis();
     void _testChunkedStatusTextResetsWhenChunkIdChanges();


### PR DESCRIPTION
## Description
The eight MAVLink severities collapse to three styles in `StatusTextHandler` (`<#E>` = EMERGENCY…ERROR, `<#I>` = NOTICE+WARNING, `<#N>` = INFO+DEBUG), and `VehicleMessageList.qml` then maps **both** `<#E>` and `<#I>` to `qgcPal.warningText` — so an ERROR renders exactly like a WARNING, a WARNING like a NOTICE, and DEBUG like INFO.

This emits five distinct style tags (`<#E>` errors, `<#W>` WARNING, `<#I>` NOTICE, `<#N>` INFO, `<#D>` DEBUG) and renders them distinctly: errors `colorRed` + bold, warnings `warningText`, notices emphasized, info normal, debug `colorGrey`. The `MessageType` counting taxonomy (message counters / indicator state) is deliberately unchanged — this is presentation only. The two files changed are the only consumers of the tags.

Related context: #13797 (lossy message pipeline).

## Type of Change
- [x] Bug fix (non-breaking change that fixes an issue)

## Testing
- [x] Tested locally
- [x] Added/updated unit tests

New data-driven `_testSeverityStyleTag` covers all eight severities via the `newFormattedMessage` signal; `ctest -C Debug -R StatusTextHandlerTest` passes; full Unit label run clean on Windows (MSVC 2022 / Qt 6.11.1).

### Platforms Tested
- [x] Windows

## Checklist
- [x] I have read the Contribution Guidelines
- [x] I have read the Code of Conduct
- [x] I have added tests that prove my fix/feature works
- [x] New and existing unit tests pass locally

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)
