### PR TITLE
fix(mavlink): retain sensors that stop being reported as Lost

### DIFF
--- a/src/MAVLink/SysStatusSensorInfo.cc
+++ b/src/MAVLink/SysStatusSensorInfo.cc
@@ -18,6 +18,7 @@ SysStatusSensorInfo::~SysStatusSensorInfo()
 void SysStatusSensorInfo::update(const mavlink_sys_status_t &sysStatus)
 {
     bool dirty = false;
+    const QDateTime now = QDateTime::currentDateTimeUtc();
 
     // Walk the bits
     for (int bitPosition = 0; bitPosition < 32; bitPosition++) {
@@ -25,6 +26,12 @@ void SysStatusSensorInfo::update(const mavlink_sys_status_t &sysStatus)
         if (sysStatus.onboard_control_sensors_present & sensorBitMask) {
             if (_sensorInfoMap.contains(sensorBitMask)) {
                 SensorInfo &sensorInfo = _sensorInfoMap[sensorBitMask];
+                sensorInfo.lastUpdated = now;
+
+                if (!sensorInfo.present) {
+                    dirty = true;
+                    sensorInfo.present = true;
+                }
 
                 const bool newEnabled = sysStatus.onboard_control_sensors_enabled & sensorBitMask;
                 if (sensorInfo.enabled != newEnabled) {
@@ -39,12 +46,17 @@ void SysStatusSensorInfo::update(const mavlink_sys_status_t &sysStatus)
                 }
             } else {
                 dirty = true;
-                const SensorInfo sensorInfo = { !!(sysStatus.onboard_control_sensors_enabled & sensorBitMask), !!(sysStatus.onboard_control_sensors_health & sensorBitMask) };
+                const SensorInfo sensorInfo = { !!(sysStatus.onboard_control_sensors_enabled & sensorBitMask), !!(sysStatus.onboard_control_sensors_health & sensorBitMask), true, now };
                 _sensorInfoMap[sensorBitMask] = sensorInfo;
             }
         } else if (_sensorInfoMap.contains(sensorBitMask)) {
-            dirty = true;
-            (void) _sensorInfoMap.remove(sensorBitMask);
+            // A sensor that stops being reported is a failure signal, not a reason to shrink the
+            // list: retain the entry, flag it Lost, and keep the last time it was actually seen.
+            SensorInfo &sensorInfo = _sensorInfoMap[sensorBitMask];
+            if (sensorInfo.present) {
+                dirty = true;
+                sensorInfo.present = false;
+            }
         }
     }
 
@@ -53,25 +65,36 @@ void SysStatusSensorInfo::update(const mavlink_sys_status_t &sysStatus)
     }
 }
 
+QDateTime SysStatusSensorInfo::sensorLastUpdated(int sensorBitMask) const
+{
+    return _sensorInfoMap.value(static_cast<MAV_SYS_STATUS_SENSOR>(sensorBitMask)).lastUpdated;
+}
+
 QStringList SysStatusSensorInfo::sensorNames() const
 {
     QStringList rgNames;
 
-    // List ordering is unhealthy, healthy, disabled
+    // List ordering is lost, unhealthy, healthy, disabled — must match sensorStatus()
     for (std::pair<MAV_SYS_STATUS_SENSOR, const SensorInfo&> sensorInfo : _sensorInfoMap.asKeyValueRange()) {
-        if (sensorInfo.second.enabled && !sensorInfo.second.healthy) {
+        if (!sensorInfo.second.present) {
             rgNames.append(QGCMAVLink::mavSysStatusSensorToString(sensorInfo.first));
         }
     }
 
     for (std::pair<MAV_SYS_STATUS_SENSOR, const SensorInfo&> sensorInfo : _sensorInfoMap.asKeyValueRange()) {
-        if (sensorInfo.second.enabled && sensorInfo.second.healthy) {
+        if (sensorInfo.second.present && sensorInfo.second.enabled && !sensorInfo.second.healthy) {
             rgNames.append(QGCMAVLink::mavSysStatusSensorToString(sensorInfo.first));
         }
     }
 
     for (std::pair<MAV_SYS_STATUS_SENSOR, const SensorInfo&> sensorInfo : _sensorInfoMap.asKeyValueRange()) {
-        if (!sensorInfo.second.enabled) {
+        if (sensorInfo.second.present && sensorInfo.second.enabled && sensorInfo.second.healthy) {
+            rgNames.append(QGCMAVLink::mavSysStatusSensorToString(sensorInfo.first));
+        }
+    }
+
+    for (std::pair<MAV_SYS_STATUS_SENSOR, const SensorInfo&> sensorInfo : _sensorInfoMap.asKeyValueRange()) {
+        if (sensorInfo.second.present && !sensorInfo.second.enabled) {
             rgNames.append(QGCMAVLink::mavSysStatusSensorToString(sensorInfo.first));
         }
     }
@@ -83,21 +106,27 @@ QStringList SysStatusSensorInfo::sensorStatus() const
 {
     QStringList rgStatus;
 
-    // List ordering is unhealthy, healthy, disabled
+    // List ordering is lost, unhealthy, healthy, disabled — must match sensorNames()
     for (const SensorInfo &sensorInfo : _sensorInfoMap.values()) {
-        if (sensorInfo.enabled && !sensorInfo.healthy) {
+        if (!sensorInfo.present) {
+            rgStatus.append(tr("Lost"));
+        }
+    }
+
+    for (const SensorInfo &sensorInfo : _sensorInfoMap.values()) {
+        if (sensorInfo.present && sensorInfo.enabled && !sensorInfo.healthy) {
             rgStatus.append(tr("Error"));
         }
     }
 
     for (const SensorInfo &sensorInfo : _sensorInfoMap.values()) {
-        if (sensorInfo.enabled && sensorInfo.healthy) {
+        if (sensorInfo.present && sensorInfo.enabled && sensorInfo.healthy) {
             rgStatus.append(tr("Normal"));
         }
     }
 
     for (const SensorInfo &sensorInfo : _sensorInfoMap.values()) {
-        if (!sensorInfo.enabled) {
+        if (sensorInfo.present && !sensorInfo.enabled) {
             rgStatus.append(tr("Disabled"));
         }
     }

--- a/src/MAVLink/SysStatusSensorInfo.h
+++ b/src/MAVLink/SysStatusSensorInfo.h
@@ -1,5 +1,6 @@
 #pragma once
 
+#include <QtCore/QDateTime>
 #include <QtCore/QMap>
 #include <QtCore/QObject>
 
@@ -21,6 +22,10 @@ public:
     QStringList sensorNames() const;
     QStringList sensorStatus() const;
 
+    /// Time the sensor's state was last reported in SYS_STATUS.
+    /// Invalid QDateTime if the sensor has never been reported.
+    Q_INVOKABLE QDateTime sensorLastUpdated(int sensorBitMask) const;
+
 signals:
     void sensorInfoChanged();
 
@@ -28,6 +33,8 @@ private:
     struct SensorInfo {
         bool enabled = false;
         bool healthy = false;
+        bool present = true;    ///< false: sensor dropped out of onboard_control_sensors_present mid-session
+        QDateTime lastUpdated;  ///< last time this sensor was reported present
     };
 
     QMap<MAV_SYS_STATUS_SENSOR, SensorInfo> _sensorInfoMap;

--- a/test/MAVLink/SysStatusSensorInfoTest.cc
+++ b/test/MAVLink/SysStatusSensorInfoTest.cc
@@ -1,4 +1,5 @@
 #include "SysStatusSensorInfoTest.h"
+#include <QtCore/QDateTime>
 #include <QtTest/QSignalSpy>
 
 
@@ -114,21 +115,61 @@ void SysStatusSensorInfoTest::_noSignalOnSameState_test()
     QCOMPARE(spy.count(), 0);
 }
 
-void SysStatusSensorInfoTest::_sensorRemoval_test()
+void SysStatusSensorInfoTest::_sensorLostAndRecovery_test()
 {
     SysStatusSensorInfo info;
 
     const uint32_t gyro = MAV_SYS_STATUS_SENSOR_3D_GYRO;
+    QVERIFY(!info.sensorLastUpdated(gyro).isValid());
+
     info.update(_makeSysStatus(gyro, gyro, gyro));
     QCOMPARE(info.sensorNames().count(), 1);
+    const QDateTime lastSeen = info.sensorLastUpdated(gyro);
+    QVERIFY(lastSeen.isValid());
 
     QSignalSpy spy(&info, &SysStatusSensorInfo::sensorInfoChanged);
+    QVERIFY(spy.isValid());
 
-    // Sensor no longer present
+    // A sensor that stops being reported must be retained and flagged Lost, not deleted:
+    // a silently shrinking list makes the failure invisible by construction.
     info.update(_makeSysStatus(0, 0, 0));
     QCOMPARE(spy.count(), 1);
-    QVERIFY(info.sensorNames().isEmpty());
-    QVERIFY(info.sensorStatus().isEmpty());
+    QCOMPARE(info.sensorNames().count(), 1);
+    QCOMPARE(info.sensorStatus(), QStringList({QStringLiteral("Lost")}));
+    QCOMPARE(info.sensorLastUpdated(gyro), lastSeen);
+
+    // Staying lost is not a change
+    info.update(_makeSysStatus(0, 0, 0));
+    QCOMPARE(spy.count(), 1);
+
+    // Reappearance recovers the previous state
+    info.update(_makeSysStatus(gyro, gyro, gyro));
+    QCOMPARE(spy.count(), 2);
+    QCOMPARE(info.sensorStatus(), QStringList({QStringLiteral("Normal")}));
+    QVERIFY(info.sensorLastUpdated(gyro) >= lastSeen);
+}
+
+void SysStatusSensorInfoTest::_lostOrdersFirst_test()
+{
+    SysStatusSensorInfo info;
+
+    // Gyro healthy, accel unhealthy, mag disabled, baro present - then baro drops out
+    const uint32_t gyro = MAV_SYS_STATUS_SENSOR_3D_GYRO;
+    const uint32_t accel = MAV_SYS_STATUS_SENSOR_3D_ACCEL;
+    const uint32_t mag = MAV_SYS_STATUS_SENSOR_3D_MAG;
+    const uint32_t baro = MAV_SYS_STATUS_SENSOR_ABSOLUTE_PRESSURE;
+
+    info.update(_makeSysStatus(gyro | accel | mag | baro, gyro | accel | baro, gyro | baro));
+    info.update(_makeSysStatus(gyro | accel | mag, gyro | accel, gyro));
+
+    const QStringList expectedStatus = {
+        QStringLiteral("Lost"),
+        QStringLiteral("Error"),
+        QStringLiteral("Normal"),
+        QStringLiteral("Disabled"),
+    };
+    QCOMPARE(info.sensorStatus(), expectedStatus);
+    QCOMPARE(info.sensorNames().at(0), QGCMAVLink::mavSysStatusSensorToString(static_cast<MAV_SYS_STATUS_SENSOR>(baro)));
 }
 
 void SysStatusSensorInfoTest::_multipleSensors_test()

--- a/test/MAVLink/SysStatusSensorInfoTest.h
+++ b/test/MAVLink/SysStatusSensorInfoTest.h
@@ -14,7 +14,8 @@ private slots:
     void _sensorOrdering_test();
     void _sensorInfoChangedSignal_test();
     void _noSignalOnSameState_test();
-    void _sensorRemoval_test();
+    void _sensorLostAndRecovery_test();
+    void _lostOrdersFirst_test();
     void _multipleSensors_test();
     void _updateExistingSensorFlipsHealth_test();
     void _updateExistingSensorDisables_test();


### PR DESCRIPTION
## Description
A sensor whose bit drops out of `onboard_control_sensors_present` mid-session is deleted from `SysStatusSensorInfo`, so the Sensor Status list silently gets shorter — the failure mode is invisible by construction (same bug class as #8072: nothing turns red, an item just vanishes).

This retains the entry instead: it renders as **"Lost"**, sorted ahead of Error/Normal/Disabled in both parallel lists, keeps its `lastUpdated` timestamp frozen at the moment of loss, and recovers its normal state if the sensor reappears. A `Q_INVOKABLE sensorLastUpdated(bitmask)` accessor exposes the per-sensor timestamp. Consumers need no change ("Lost" flows through the existing `sensorNames`/`sensorStatus` string lists).

## Type of Change
- [x] Bug fix (non-breaking change that fixes an issue)

## Testing
- [x] Tested locally
- [x] Added/updated unit tests

The deletion-asserting test is replaced by `_sensorLostAndRecovery_test` (lost → retained + "Lost", timestamp frozen, staying-lost emits no change signal, reappearance recovers) and `_lostOrdersFirst_test` (ordering). `ctest -C Debug -R SysStatusSensorInfoTest` passes; full Unit label run clean on Windows.

### Platforms Tested
- [x] Windows

### Flight Stacks Tested
- [x] ArduPilot (SYS_STATUS path; verified against MockLink sensor-bit changes)

## Checklist
- [x] I have read the Contribution Guidelines
- [x] I have read the Code of Conduct
- [x] I have added tests that prove my fix/feature works
- [x] New and existing unit tests pass locally

## Related Issues
Same failure-visibility class as #8072.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)
