### PR TITLE
feat(flyview): name the target aircraft in guided-action confirmations

### DIFF
--- a/src/FlyView/GuidedActionsController.qml
+++ b/src/FlyView/GuidedActionsController.qml
@@ -552,7 +552,35 @@ Item {
                 return
             }
         }
+        // With more than one vehicle connected, name the target(s) in the confirmation title so the
+        // operator can verify which aircraft the command applies to before committing.
+        if (QGroundControl.multiVehicleManager.vehicles.count > 1) {
+            var targetText = confirmationTargetText(actionCode)
+            if (targetText !== "") {
+                confirmDialog.title = confirmDialog.title + " — " + targetText
+            }
+        }
         confirmDialog.show(showImmediate)
+    }
+
+    /// Names the vehicle(s) a guided action will apply to: the selected-vehicle set for
+    /// multi-vehicle actions, the active vehicle for everything else.
+    function confirmationTargetText(actionCode) {
+        if (actionCode === actionMVArm || actionCode === actionMVDisarm || actionCode === actionMVPause || actionCode === actionMVStartMission) {
+            var selectedVehicles = QGroundControl.multiVehicleManager.selectedVehicles
+            var vehicleIds = []
+            for (var i = 0; i < selectedVehicles.count; i++) {
+                vehicleIds.push(selectedVehicles.get(i).id)
+            }
+            if (vehicleIds.length === 0) {
+                return qsTr("no vehicles selected")
+            }
+            if (vehicleIds.length <= 4) {
+                return qsTr("Vehicles %1").arg(vehicleIds.join(", "))
+            }
+            return qsTr("%1 vehicles").arg(vehicleIds.length)
+        }
+        return _activeVehicle ? qsTr("Vehicle %1").arg(_activeVehicle.id) : ""
     }
 
     // Executes the specified action


### PR DESCRIPTION
## Description
With more than one vehicle connected, no guided-action confirmation says which aircraft it is about to command — "Arm the vehicle." / "Arm selected vehicles." carry no id, count or enumeration, so the operator cannot verify the target before committing.

This decorates the confirmation **title** with the target identity, only when more than one vehicle is connected:

- single-vehicle actions name the active vehicle: `Arm — Vehicle 2`
- the four multi-vehicle actions enumerate the selected set: `Arm (MV) — Vehicles 1, 3` (count-only above four; "no vehicles selected" when the selection is empty)

Single-vehicle operation is visually unchanged. One decoration point after the `confirmAction()` switch plus a `confirmationTargetText()` helper — no per-action edits. Follows the identity-prefix precedent already merged twice (`Vehicle::_vehicleIdSpeech()`, #14313).

## Type of Change
- [x] New feature (non-breaking change that adds functionality)

## Testing
- [x] Tested locally

Build clean (qmlcachegen); FlyView loads with zero QML warnings/errors on an offscreen boot. The two-vehicle rendered text follows directly from the helper's cases; a `tst_*.qml` case can be added if desired — happy to extend.

### Platforms Tested
- [x] Windows

## Checklist
- [x] I have read the Contribution Guidelines
- [x] I have read the Code of Conduct
- [x] New and existing unit tests pass locally

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)
