### PR TITLE
feat(mocklink): add readiness failure injection

### DIFF
--- a/src/Comms/MockLink/MockLink.cc
+++ b/src/Comms/MockLink/MockLink.cc
@@ -754,6 +754,20 @@ void MockLink::_sendHighLatency2()
     respondWithMavlinkMessage(msg);
 }
 
+void MockLink::setSysStatusSensorBits(quint32 present, quint32 enabled, quint32 health)
+{
+    _sysStatusSensorsPresent = present;
+    _sysStatusSensorsEnabled = enabled;
+    _sysStatusSensorsHealth = health;
+}
+
+void MockLink::setPreArmDenied(bool denied, const QString &reason)
+{
+    QMutexLocker locker(&_preArmDeniedReasonMutex);
+    _preArmDenied = denied;
+    _preArmDeniedReason = reason.isEmpty() ? QStringLiteral("Mock readiness check failed") : reason;
+}
+
 void MockLink::_sendSysStatus()
 {
     mavlink_message_t msg{};
@@ -762,9 +776,9 @@ void MockLink::_sendSysStatus()
         _vehicleComponentId,
         _outgoingMavlinkChannel,
         &msg,
-        MAV_SYS_STATUS_SENSOR_GPS,  // onboard_control_sensors_present
-        0,                          // onboard_control_sensors_enabled
-        0,                          // onboard_control_sensors_health
+        _sysStatusSensorsPresent,   // onboard_control_sensors_present
+        _sysStatusSensorsEnabled,   // onboard_control_sensors_enabled
+        _sysStatusSensorsHealth,    // onboard_control_sensors_health
         250,                        // load
         4200 * 4,                   // voltage_battery
         8000,                       // current_battery
@@ -776,7 +790,11 @@ void MockLink::_sendSysStatus()
 
 void MockLink::_sendBatteryStatus()
 {
-    if (_battery1PctRemaining > 1) {
+    if (_batteryCritical) {
+        _battery1PctRemaining = 5;
+        _battery1TimeRemaining = _batteryMaxTimeRemaining * 5 / 100;
+        _battery1ChargeState = MAV_BATTERY_CHARGE_STATE_EMERGENCY;
+    } else if (_battery1PctRemaining > 1) {
         _battery1PctRemaining = static_cast<int8_t>(100 - (_runningTime.elapsed() / 1000));
         _battery1TimeRemaining = static_cast<double>(_batteryMaxTimeRemaining) * (static_cast<double>(_battery1PctRemaining) / 100.0);
         if (_battery1PctRemaining > 50) {
@@ -1926,10 +1944,19 @@ void MockLink::_handleCommandLong(const mavlink_message_t &msg)
     case MAV_CMD_COMPONENT_ARM_DISARM:
         if (request.param1 == 0.0f) {
             _mavBaseMode &= ~MAV_MODE_FLAG_SAFETY_ARMED;
+            commandResult = MAV_RESULT_ACCEPTED;
+        } else if (_preArmDenied) {
+            QString reason;
+            {
+                QMutexLocker locker(&_preArmDeniedReasonMutex);
+                reason = _preArmDeniedReason;
+            }
+            sendStatusTextMessage(MAV_SEVERITY_CRITICAL, QStringLiteral("PreArm: %1").arg(reason));
+            commandResult = MAV_RESULT_TEMPORARILY_REJECTED;
         } else {
             _mavBaseMode |= MAV_MODE_FLAG_SAFETY_ARMED;
+            commandResult = MAV_RESULT_ACCEPTED;
         }
-        commandResult = MAV_RESULT_ACCEPTED;
         break;
     case MAV_CMD_PREFLIGHT_CALIBRATION:
         _handlePreFlightCalibration(request);
@@ -2205,6 +2232,8 @@ void MockLink::_sendGpsRawInt()
 {
     static uint64_t timeTick = 0;
 
+    const bool fixLost = _gpsFixLost;
+
     mavlink_message_t msg{};
     (void) mavlink_msg_gps_raw_int_pack_chan(
         _vehicleSystemId,
@@ -2212,15 +2241,15 @@ void MockLink::_sendGpsRawInt()
         _outgoingMavlinkChannel,
         &msg,
         timeTick++,                             // time since boot
-        GPS_FIX_TYPE_3D_FIX,
+        fixLost ? GPS_FIX_TYPE_NO_FIX : GPS_FIX_TYPE_3D_FIX,
         static_cast<int32_t>(_vehicleLatitude * 1E7),
         static_cast<int32_t>(_vehicleLongitude * 1E7),
         static_cast<int32_t>(_vehicleAltitudeAMSL * 1000),
-        3 * 100,                                // hdop
-        3 * 100,                                // vdop
+        fixLost ? UINT16_MAX : 3 * 100,         // hdop
+        fixLost ? UINT16_MAX : 3 * 100,         // vdop
         UINT16_MAX,                             // velocity not known
         UINT16_MAX,                             // course over ground not known
-        8,                                      // satellites visible
+        fixLost ? 0 : 8,                        // satellites visible
         //-- Extension
         0,                                      // Altitude (above WGS84, EGM96 ellipsoid), in meters * 1000 (positive for up).
         0,                                      // Position uncertainty in meters * 1000 (positive for up).

--- a/src/Comms/MockLink/MockLink.h
+++ b/src/Comms/MockLink/MockLink.h
@@ -47,6 +47,28 @@ public:
     Q_INVOKABLE void setCommLost(bool commLost) { _commLost = commLost; }
     Q_INVOKABLE void simulateConnectionRemoved();
 
+    // Readiness failure injection. Runtime-toggleable so tests can drive healthy -> failed -> recovered
+    // transitions. Q_INVOKABLE so debug QML can drive it without further C++ changes.
+
+    /// Overrides the SYS_STATUS onboard_control_sensors_present/enabled/health fields.
+    /// Defaults match the previous hard-coded values (present=GPS, enabled=0, health=0).
+    Q_INVOKABLE void setSysStatusSensorBits(quint32 present, quint32 enabled, quint32 health);
+
+    /// true: GPS_RAW_INT reports GPS_FIX_TYPE_NO_FIX, zero satellites and unknown hdop/vdop
+    Q_INVOKABLE void setGpsFixLost(bool lost) { _gpsFixLost = lost; }
+    bool gpsFixLost() const { return _gpsFixLost; }
+
+    /// true: battery 1 reports 5% remaining with MAV_BATTERY_CHARGE_STATE_EMERGENCY.
+    /// SYS_STATUS battery_remaining follows since it reports the same value.
+    Q_INVOKABLE void setBatteryCritical(bool critical) { _batteryCritical = critical; }
+    bool batteryCritical() const { return _batteryCritical; }
+
+    /// true: arm requests are rejected with MAV_RESULT_TEMPORARILY_REJECTED and a
+    /// "PreArm: <reason>" critical STATUSTEXT, mirroring autopilot pre-arm behavior.
+    /// Disarm requests are always accepted.
+    Q_INVOKABLE void setPreArmDenied(bool denied, const QString &reason = QString());
+    bool preArmDenied() const { return _preArmDenied; }
+
     int vehicleId() const { return _vehicleSystemId; }
     MAV_AUTOPILOT getFirmwareType() const { return _firmwareType; }
 
@@ -447,6 +469,18 @@ private:
     int _hashCheckRequestCount = 0;
     bool _paramRequestListHashCheckSent = false;
     bool _resetSysAutostartOnParamReset = false;
+
+    // Readiness failure injection state. Setters run on the caller's (test/main) thread while the
+    // send loops read on the worker thread: plain values are atomics, the reason string is guarded
+    // by _preArmDeniedReasonMutex.
+    std::atomic<uint32_t> _sysStatusSensorsPresent = MAV_SYS_STATUS_SENSOR_GPS;
+    std::atomic<uint32_t> _sysStatusSensorsEnabled = 0;
+    std::atomic<uint32_t> _sysStatusSensorsHealth = 0;
+    std::atomic<bool> _gpsFixLost = false;
+    std::atomic<bool> _batteryCritical = false;
+    std::atomic<bool> _preArmDenied = false;
+    QMutex _preArmDeniedReasonMutex;
+    QString _preArmDeniedReason;
 
     // Periodic OPEN_DRONE_ID_ARM_STATUS content (overridable via setRemoteIDArmStatus).
     // Written by the test (main) thread, read by the 1Hz worker: guarded by _remoteIDArmStatusMutex.

--- a/test/Comms/CMakeLists.txt
+++ b/test/Comms/CMakeLists.txt
@@ -15,6 +15,8 @@ target_sources(${CMAKE_PROJECT_NAME}
         LogReplayLinkTest.h
         MAVLinkV1TrafficTest.cc
         MAVLinkV1TrafficTest.h
+        MockLinkReadinessInjectionTest.cc
+        MockLinkReadinessInjectionTest.h
         QGCSerialPortInfoTest.cc
         QGCSerialPortInfoTest.h
 )
@@ -28,4 +30,5 @@ add_qgc_test(LinkManagerTest LABELS Integration Comms SERIAL)
 add_qgc_test(LogReplayLinkControllerTest LABELS Unit Comms)
 add_qgc_test(LogReplayLinkTest LABELS Unit Comms)
 add_qgc_test(MAVLinkV1TrafficTest LABELS Integration Comms)
+add_qgc_test(MockLinkReadinessInjectionTest LABELS Integration Comms Vehicle)
 add_qgc_test(QGCSerialPortInfoTest LABELS Unit Comms)

--- a/test/Comms/MockLinkReadinessInjectionTest.cc
+++ b/test/Comms/MockLinkReadinessInjectionTest.cc
@@ -1,0 +1,100 @@
+#include "MockLinkReadinessInjectionTest.h"
+
+#include <QtTest/QSignalSpy>
+
+#include "BatteryFactGroupListModel.h"
+#include "FactGroup.h"
+#include "Vehicle.h"
+
+void MockLinkReadinessInjectionTest::_testSysStatusSensorBitsInjection()
+{
+    QVERIFY(vehicle());
+    QVERIFY(mockLink());
+
+    // Default MockLink SYS_STATUS: enabled = 0 makes (enabled & health) == enabled vacuously true
+    QTRY_COMPARE_WITH_TIMEOUT(vehicle()->sensorsPresentBits(), static_cast<int>(MAV_SYS_STATUS_SENSOR_GPS), TestTimeout::mediumMs());
+    QCOMPARE(vehicle()->sensorsUnhealthyBits(), 0);
+
+    // Inject: GPS + RC present and enabled, only GPS healthy -> RC must surface as unhealthy
+    const quint32 presentEnabled = MAV_SYS_STATUS_SENSOR_GPS | MAV_SYS_STATUS_SENSOR_RC_RECEIVER;
+    mockLink()->setSysStatusSensorBits(presentEnabled, presentEnabled, MAV_SYS_STATUS_SENSOR_GPS);
+
+    QTRY_COMPARE_WITH_TIMEOUT(vehicle()->sensorsPresentBits(), static_cast<int>(presentEnabled), TestTimeout::mediumMs());
+    QCOMPARE(vehicle()->sensorsEnabledBits(), static_cast<int>(presentEnabled));
+    QCOMPARE(vehicle()->sensorsUnhealthyBits(), static_cast<int>(MAV_SYS_STATUS_SENSOR_RC_RECEIVER));
+    QVERIFY(!vehicle()->allSensorsHealthy());
+
+    // Recover -> healthy again
+    mockLink()->setSysStatusSensorBits(presentEnabled, presentEnabled, presentEnabled);
+    QTRY_COMPARE_WITH_TIMEOUT(vehicle()->sensorsUnhealthyBits(), 0, TestTimeout::mediumMs());
+    QVERIFY(vehicle()->allSensorsHealthy());
+}
+
+void MockLinkReadinessInjectionTest::_testGpsFixLostInjection()
+{
+    QVERIFY(vehicle());
+    QVERIFY(mockLink());
+
+    Fact* lockFact = vehicle()->gpsFactGroup()->getFact(QStringLiteral("lock"));
+    QVERIFY(lockFact);
+
+    QTRY_COMPARE_WITH_TIMEOUT(lockFact->rawValue().toInt(), static_cast<int>(GPS_FIX_TYPE_3D_FIX), TestTimeout::mediumMs());
+
+    mockLink()->setGpsFixLost(true);
+    QTRY_COMPARE_WITH_TIMEOUT(lockFact->rawValue().toInt(), static_cast<int>(GPS_FIX_TYPE_NO_FIX), TestTimeout::mediumMs());
+
+    mockLink()->setGpsFixLost(false);
+    QTRY_COMPARE_WITH_TIMEOUT(lockFact->rawValue().toInt(), static_cast<int>(GPS_FIX_TYPE_3D_FIX), TestTimeout::mediumMs());
+}
+
+void MockLinkReadinessInjectionTest::_testBatteryCriticalInjection()
+{
+    QVERIFY(vehicle());
+    QVERIFY(mockLink());
+
+    mockLink()->setBatteryCritical(true);
+
+    // Battery 1 is the first entry in the list model (MockLink sends ids 1 then 2)
+    QVERIFY(UnitTest::waitForCondition(
+        [this]() {
+            if (vehicle()->batteries()->count() < 1) {
+                return false;
+            }
+            BatteryFactGroup* battery = vehicle()->batteries()->value<BatteryFactGroup*>(0);
+            return battery
+                && (battery->percentRemaining()->rawValue().toInt() == 5)
+                && (battery->chargeState()->rawValue().toInt() == static_cast<int>(MAV_BATTERY_CHARGE_STATE_EMERGENCY));
+        },
+        TestTimeout::mediumMs(),
+        QStringLiteral("battery 1 reports 5% remaining in EMERGENCY charge state")));
+}
+
+void MockLinkReadinessInjectionTest::_testPreArmDeniedInjection()
+{
+    QVERIFY(vehicle());
+    QVERIFY(mockLink());
+    QVERIFY(!vehicle()->armed());
+
+    mockLink()->setPreArmDenied(true, QStringLiteral("Injected pre-arm failure"));
+
+    QSignalSpy commandResultSpy(vehicle(), &Vehicle::mavCommandResult);
+    QVERIFY(commandResultSpy.isValid());
+
+    vehicle()->setArmed(true, false /* showError */);
+
+    QVERIFY_SIGNAL_WAIT(commandResultSpy, TestTimeout::mediumMs());
+    const QList<QVariant> arguments = commandResultSpy.takeFirst();
+    QCOMPARE(arguments.at(2).toInt(), static_cast<int>(MAV_CMD_COMPONENT_ARM_DISARM));
+    QCOMPARE(arguments.at(3).toInt(), static_cast<int>(MAV_RESULT_TEMPORARILY_REJECTED));
+    QVERIFY(!mockLink()->armed());
+
+    // Clearing the injection must allow a normal arm
+    mockLink()->setPreArmDenied(false);
+    vehicle()->setArmed(true, false /* showError */);
+    QTRY_VERIFY_WITH_TIMEOUT(vehicle()->armed(), TestTimeout::mediumMs());
+
+    vehicle()->setArmed(false, false /* showError */);
+    QTRY_VERIFY_WITH_TIMEOUT(!vehicle()->armed(), TestTimeout::mediumMs());
+}
+
+UT_REGISTER_TEST(MockLinkReadinessInjectionTest, TestLabel::Integration, TestLabel::Comms, TestLabel::Vehicle)

--- a/test/Comms/MockLinkReadinessInjectionTest.h
+++ b/test/Comms/MockLinkReadinessInjectionTest.h
@@ -1,0 +1,16 @@
+#pragma once
+
+#include "BaseClasses/VehicleTest.h"
+
+/// Verifies MockLink readiness failure injection is observable on the connected Vehicle:
+/// SYS_STATUS sensor bits, GPS fix loss, battery-critical state and pre-arm denial.
+class MockLinkReadinessInjectionTest : public VehicleTest
+{
+    Q_OBJECT
+
+private slots:
+    void _testSysStatusSensorBitsInjection();
+    void _testGpsFixLostInjection();
+    void _testBatteryCriticalInjection();
+    void _testPreArmDeniedInjection();
+};


### PR DESCRIPTION
## Description
MockLink cannot currently be *unhealthy*: `_sendSysStatus()` hard-codes `present=GPS, enabled=0, health=0` (which makes "all sensors healthy" — `(enabled & health) == enabled` — vacuously true for every developer running MockLink), GPS always reports a 3D fix, batteries only decay with runtime, and arm requests always succeed. That makes readiness/health UI behavior untestable against the simulator.

This adds runtime-toggleable failure injection, following the existing MockLink test-API idiom (atomics for worker-thread reads; mutex-guarded reason string, same pattern as `_remoteIDArmStatusMutex`):

- `setSysStatusSensorBits(present, enabled, health)` — SYS_STATUS sensor fields become configurable; **defaults keep today's values byte-identical**
- `setGpsFixLost(bool)` — GPS_RAW_INT reports `NO_FIX`, 0 satellites, hdop/vdop unknown
- `setBatteryCritical(bool)` — battery 1 reports 5 % with `MAV_BATTERY_CHARGE_STATE_EMERGENCY`; SYS_STATUS `battery_remaining` follows
- `setPreArmDenied(bool, reason)` — arm requests answered `MAV_RESULT_TEMPORARILY_REJECTED` plus a critical `PreArm: <reason>` STATUSTEXT (disarm unaffected)

All `Q_INVOKABLE` so the debug settings page can drive them later. Runtime setters (rather than `MockConfiguration` options) because readiness scenarios need healthy → failed → recovered transitions mid-test.

## Type of Change
- [x] New feature (non-breaking change that adds functionality)

## Testing
- [x] Tested locally
- [x] Added/updated unit tests
- [x] Tested with simulator (MockLink)

New `MockLinkReadinessInjectionTest` (Integration, Comms, Vehicle) verifies all four injections on a connected Vehicle including recovery transitions. Full Unit label + non-UI Integration label runs show no regressions on Windows (MSVC 2022 / Qt 6.11.1); defaults verified byte-identical.

### Platforms Tested
- [x] Windows

### Flight Stacks Tested
- [x] PX4 (MockLink PX4 profile)

## Checklist
- [x] I have read the Contribution Guidelines
- [x] I have read the Code of Conduct
- [x] I have added tests that prove my fix/feature works
- [x] New and existing unit tests pass locally

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)
