### PR TITLE
fix: blank vehicle config pages in non-English locales (Stable 5.1)

### DIFF
--- a/translations/qgc_source_zh_CN.ts
+++ b/translations/qgc_source_zh_CN.ts
@@ -14160,7 +14160,7 @@ Is this really what you want?</translation>
     <message>
       <location filename="../src/QmlControls/PIDTuning.qml" line="334"/>
       <source>Switches to &apos;%1&apos; when you click Stop.</source>
-      <translation>点击“停止”后，切换到 &apos;稳定&apos;。</translation>
+      <translation>点击“停止”后，切换到 &apos;%1&apos;。</translation>
     </message>
     <message>
       <location filename="../src/QmlControls/PIDTuning.qml" line="350"/>


### PR DESCRIPTION
Stable 5.1 backport of #14943.

Fixes blank vehicle config pages in non-English locales (zh_CN translation dropped the %1 placeholder in the PIDTuning message).
