### PR TITLE
feat(GeoMap): terrain surface picking, mission item click support, ROI altitude

### DIFF
--- a/src/FlyView/FlyViewGeoMap.qml
+++ b/src/FlyView/FlyViewGeoMap.qml
@@ -152,6 +152,10 @@ GeoMap {
         surfaceModel: root.surfaceModel
         missionController: root._missionController
         homeTerrainBias: root._activeVehicleHomeTerrainBias
+        // Same action as PlanMapItems in the QtLocation fly view: clicking a
+        // marker adjusts the vehicle's current mission item (after confirm)
+        onItemClicked: (item) => globals.guidedControllerFlyView.confirmAction(
+            globals.guidedControllerFlyView.actionSetWaypoint, Math.max(item.sequenceNumber, 1))
     }
 
     GeoMapMissionDirectionArrows {
@@ -428,10 +432,31 @@ GeoMap {
         checked: true
         label: qsTr("ROI here", "Make this a Region Of Interest")
 
+        // The vehicle reports the ROI center as lat/lon only; the commanded
+        // height lives in roiRelativeAltitudeMeters (relative to home).
+        // Render at that height, DEM bias-corrected like the mission markers.
+        property var _roiCenter: QtPositioning.coordinate()
+
+        // Picked coordinates carry altitude 0 (worldToGeo), so isNaN(altitude)
+        // cannot detect the missing-composition case; ground-clamp on this
+        readonly property bool _haveComposedAltitude: _roiCenter.isValid && root._activeVehicle
+                                                      && root._activeVehicle.homePosition.isValid
+                                                      && !isNaN(root._activeVehicle.homePosition.altitude)
+
+        // Re-check the vehicle here: _haveComposedAltitude can be stale-true
+        // during binding re-evaluation when the active vehicle goes null
+        coordinate: (_haveComposedAltitude && root._activeVehicle)
+                    ? QtPositioning.coordinate(_roiCenter.latitude, _roiCenter.longitude,
+                                               root._activeVehicle.homePosition.altitude
+                                               + root._activeVehicle.roiRelativeAltitudeMeters
+                                               + root._activeVehicleHomeTerrainBias)
+                    : _roiCenter
+        altitudeMode: _haveComposedAltitude ? GeoMapItem.Absolute : GeoMapItem.ClampToGround
+
         Connections {
             target: root._activeVehicle
             function onRoiCoordChanged(centerCoord) {
-                roiLocationItem.coordinate = centerCoord
+                roiLocationItem._roiCenter = centerCoord
             }
         }
 
@@ -478,18 +503,30 @@ GeoMap {
         id: roiEditPositionDialogComponent
 
         EditPositionDialog {
+            // Edit the raw reported center, not the composed display coordinate:
+            // that binding recomputes on home/terrain-bias updates, which would
+            // fire onCoordinateChanged and re-command the ROI while editing
             title: qsTr("Edit ROI Position")
-            coordinate: roiLocationItem.coordinate
+            coordinate: roiLocationItem._roiCenter
 
             readonly property var _activeVehicle: QGroundControl.multiVehicleManager.activeVehicle
+            property var _openedForVehicle: null
+
+            Component.onCompleted: _openedForVehicle = _activeVehicle
 
             // The ROI belongs to the vehicle the dialog was opened for; close
             // if that vehicle goes away or the active vehicle changes
             on_ActiveVehicleChanged: close()
 
             onCoordinateChanged: {
-                roiLocationItem.coordinate = coordinate
-                _activeVehicle.guidedModeROI(coordinate, _activeVehicle.roiRelativeAltitudeMeters)
+                // Guards the init-time change and the vehicle-switch race, where
+                // the rebound coordinate could command the new vehicle with the
+                // old vehicle's ROI before the close() handler runs
+                if (!_openedForVehicle || (_activeVehicle !== _openedForVehicle)) {
+                    return
+                }
+                roiLocationItem._roiCenter = coordinate
+                _openedForVehicle.guidedModeROI(coordinate, _openedForVehicle.roiRelativeAltitudeMeters)
             }
         }
     }

--- a/src/FlyView/FlyViewGeoMapAdapter.qml
+++ b/src/FlyView/FlyViewGeoMapAdapter.qml
@@ -83,11 +83,11 @@ Item {
         geoMapControl.camera.center = center
     }
 
-    // Screen point -> ground coordinate through the camera pick ray
+    // Screen point -> coordinate of the rendered terrain surface under it
     // (clipToViewPort accepted for signature parity, screen points are
     // always inside the viewport for the fly view use cases)
     function toCoordinate(point, clipToViewPort) {
-        return geoMapControl.camera.coordinateAtScreenPoint(point)
+        return geoMapControl.surfaceCoordinateAt(point)
     }
 
     // Geographic coordinate -> screen point; invalid/behind-camera projects
@@ -105,11 +105,10 @@ Item {
         keepVehicleCentered: root.pipMode || QGroundControl.settingsManager.flyViewSettings.keepMapCenteredOnVehicle.rawValue
 
         // Guided-action popup on click (FlyViewMap.onMapClicked parity).
-        // 2D-only: interactive map editing is view-only in 3D (issue #14901),
-        // and a tilted-camera pick can land kilometers from the visual target.
-        // isTopDown: the mode flips to 2D before the tilt animation finishes.
+        // Allowed at any tilt: toCoordinate picks the rendered terrain
+        // surface, so the click lands where the user sees it even in 3D.
         onMapClicked: (position) => {
-            if (root.pipMode || geoMapControl.camera.mode !== GeoMapCamera.Mode2D || !geoMapControl.camera.isTopDown) {
+            if (root.pipMode) {
                 return
             }
             if (!globals.guidedControllerFlyView.guidedUIVisible &&

--- a/src/FlyView/FlyViewMap.qml
+++ b/src/FlyView/FlyViewMap.qml
@@ -578,6 +578,13 @@ FlightMap {
         EditPositionDialog {
             title:                  qsTr("Edit ROI Position")
             coordinate:             roiLocationItem.coordinate
+
+            readonly property var _activeVehicle: QGroundControl.multiVehicleManager.activeVehicle
+
+            // The ROI belongs to the vehicle the dialog was opened for; close
+            // if that vehicle goes away or the active vehicle changes
+            on_ActiveVehicleChanged: close()
+
             onCoordinateChanged: {
                 roiLocationItem.coordinate = coordinate
                 _activeVehicle.guidedModeROI(coordinate, _activeVehicle.roiRelativeAltitudeMeters)
@@ -590,6 +597,15 @@ FlightMap {
 
         DropPanel {
             id: roiEditDropPanel
+
+            readonly property var _activeVehicle: QGroundControl.multiVehicleManager.activeVehicle
+
+            // The ROI belongs to the vehicle the panel was opened for; close
+            // if that vehicle goes away or the active vehicle changes
+            on_ActiveVehicleChanged: close()
+
+            // Created dynamically per ROI click; close() alone would leak the panel
+            onClosed: destroy()
 
             sourceComponent: Component {
                 ColumnLayout {

--- a/src/GeoMap/CMakeLists.txt
+++ b/src/GeoMap/CMakeLists.txt
@@ -74,6 +74,8 @@ qt_add_qml_module(GeoMapModule
         GeoMap.qml
         GeoMapADSBVehicleItem.qml
         GeoMapCircle.qml
+        GeoMapDropLine.qml
+        GeoMapDropShadow.qml
         GeoMapFenceWall.qml
         GeoMapFlightPath.qml
         GeoMapFWLandingPatternVisual.qml

--- a/src/GeoMap/GeoMap.qml
+++ b/src/GeoMap/GeoMap.qml
@@ -34,8 +34,18 @@ Item {
     property bool pinchZoomDisabledByVirtualJoysticks: false
 
     // Same contract as FlightMap: plain left-click/tap (no drag, no modifier)
-    // in viewport coordinates; consumers convert via camera.coordinateAtScreenPoint
+    // in viewport coordinates; consumers convert via surfaceCoordinateAt
     signal mapClicked(var position)
+
+    // Geographic coordinate of the rendered terrain surface under a screen
+    // point (viewport pixels): the pick lands on the visible front surface,
+    // so ridges occlude the ground behind them. Works at any tilt, unlike a
+    // ground-plane pick which can land kilometers past elevated terrain.
+    // Invalid coordinate on a sky pick.
+    function surfaceCoordinateAt(screenPos) {
+        return patchModel.surfaceCoordinateAtScreenPoint(geoCamera, screenPos,
+                                                         geoScene.verticalScale * geoScene.terrainScale)
+    }
 
     // Auto-centering (parity with FlightMap): one-shot GCS/vehicle centering
     // plus vehicle following, all decided by the shared MapPositionTracker

--- a/src/GeoMap/GeoMapCamera.cc
+++ b/src/GeoMap/GeoMapCamera.cc
@@ -252,6 +252,17 @@ QQuaternion GeoMapCamera::sceneRotation() const
            QQuaternion::fromAxisAndAngle(1, 0, 0, static_cast<float>(_tilt));
 }
 
+std::optional<GeoMapCamera::PickRay> GeoMapCamera::pickRayAt(const QPointF& screenPos) const
+{
+    if (_viewportSize.isEmpty()) {
+        return std::nullopt;
+    }
+
+    const Ray ray = pickRay(_centerWorld, _heading, _tilt, _distance, _centerElevation, _viewportSize,
+                            verticalFieldOfView(), screenPos);
+    return PickRay{ray.origin.x, ray.origin.y, ray.origin.z, ray.dir.x, ray.dir.y, ray.dir.z};
+}
+
 std::optional<QPointF> GeoMapCamera::screenToGround(const QPointF& screenPos, double planeZ) const
 {
     if (_viewportSize.isEmpty()) {

--- a/src/GeoMap/GeoMapCamera.h
+++ b/src/GeoMap/GeoMapCamera.h
@@ -241,6 +241,24 @@ public:
     /// north up (matches the pose convention R = Rz(heading) * Rx(tilt))
     QQuaternion sceneRotation() const;
 
+    /// World-space pick ray in double precision (QVector3D floats lose meters
+    /// at mercator world scale). Origin is the camera position (world meters,
+    /// z in scene units); dir points into the scene, un-normalized.
+    struct PickRay
+    {
+        double originX = 0.0;
+        double originY = 0.0;
+        double originZ = 0.0;
+        double dirX = 0.0;
+        double dirY = 0.0;
+        double dirZ = 0.0;
+    };
+
+    /// Pick ray through screenPos (pixels), for consumers that intersect it with
+    /// something other than a horizontal plane (e.g. the terrain surface).
+    /// std::nullopt when the viewport is not set.
+    std::optional<PickRay> pickRayAt(const QPointF& screenPos) const;
+
     /// Intersect the pick ray through screenPos (pixels) with the horizontal plane
     /// at planeZ (scene units, default the ground plane z=0). Returns the hit point
     /// in world meters, or std::nullopt when the ray misses (at/above the horizon or

--- a/src/GeoMap/GeoMapDropLine.qml
+++ b/src/GeoMap/GeoMapDropLine.qml
@@ -1,0 +1,35 @@
+/****************************************************************************
+ *
+ * (c) 2009-2024 QGROUNDCONTROL PROJECT <http://www.qgroundcontrol.org>
+ *
+ * QGroundControl is licensed according to the terms in the file
+ * COPYING.md in the root of the source code directory.
+ *
+ ****************************************************************************/
+
+import QtQuick
+import QtQuick3D
+
+/// Drop line from a floating marker to the terrain below (Google Earth-style
+/// "extrude"): anchors the marker visually so its altitude is readable.
+/// Place inside the marker's delegate3D node; dropLength / lineScale come
+/// from the marker's GeoMapDropShadow, which owns the drop computation.
+Model {
+    id: root
+
+    property real dropLength: 0     ///< Scene-space marker-to-ground distance
+    property real lineScale: 0      ///< Diameter scale (GeoMapDropShadow.dropLineScale)
+    property color lineColor: "white"
+
+    source: "#Cylinder"   // built-in: 100x100 units, height along +Y
+    visible: dropLength > 0
+    opacity: 0.75
+    eulerRotation.x: 90   // stand the height axis up along scene z
+    position: Qt.vector3d(0, 0, -dropLength / 2)
+    scale: Qt.vector3d(lineScale, dropLength / 100, lineScale)
+
+    materials: PrincipledMaterial {
+        lighting: PrincipledMaterial.NoLighting
+        baseColor: root.lineColor
+    }
+}

--- a/src/GeoMap/GeoMapDropShadow.qml
+++ b/src/GeoMap/GeoMapDropShadow.qml
@@ -1,0 +1,88 @@
+/****************************************************************************
+ *
+ * (c) 2009-2024 QGROUNDCONTROL PROJECT <http://www.qgroundcontrol.org>
+ *
+ * QGroundControl is licensed according to the terms in the file
+ * COPYING.md in the root of the source code directory.
+ *
+ ****************************************************************************/
+
+import QtQuick
+import QtPositioning
+
+import QGroundControl
+import QGroundControl.Controls
+import QGroundControl.GeoMap
+
+/// Draped ground shadow under a floating marker's drop line: GeoMapCircle
+/// clamps each rim point to the terrain mesh, so the shadow follows slopes
+/// instead of half-burying like a flat disc. Instantiate as a direct child
+/// of the marker's GeoMapItem — the item repositions itself in viewport
+/// coordinates and this undoes that offset (screen-space geometry).
+/// Also owns the marker-to-ground drop computation (dropLength /
+/// dropLineScale) shared with the delegate3D's GeoMapDropLine, since the
+/// shadow already samples the terrain under the marker.
+GeoMapCircle {
+    id: root
+
+    property var geoItem            ///< Owning GeoMapItem (the marker)
+    property real indicatorSize: 0  ///< Marker diameter in pixels; sets the shadow radius
+
+    /// Scene-space length of the drop line from marker to the rendered
+    /// terrain (tracks terrainScale, so it flattens in lockstep with the
+    /// anchor z); 0 for clamped markers, so they show no line
+    readonly property real dropLength: {
+        if (!scene || !geoItem || geoItem.altitudeMode !== GeoMapItem.Absolute || isNaN(geoItem.coordinate.altitude)) {
+            return 0
+        }
+        const drop = (geoItem.coordinate.altitude - _groundHeight) * scene.verticalScale * scene.terrainScale
+        return isFinite(drop) ? Math.max(0, drop) : 0
+    }
+
+    /// Drop line diameter: constant apparent width, like the marker
+    /// (built-in QtQuick3D meshes are 100 units across)
+    readonly property real dropLineScale: _camera
+        ? (ScreenTools.defaultFontPixelHeight / 8) * _camera.distance * _camera.unitsPerPixelAtUnitDistance / 100
+        : 0
+
+    readonly property var _camera: scene ? scene.camera : null
+
+    // Rendered-terrain height (true meters) under the marker; terrainHeightAt
+    // is not a binding dependency, so re-sampled explicitly as terrain tiles
+    // arrive and when the marker moves. Keyed on lat/lon so altitude-only
+    // coordinate changes (e.g. terrain-bias updates) skip the resample.
+    property real _groundHeight: 0
+    readonly property real _latitude: geoItem ? geoItem.coordinate.latitude : NaN
+    readonly property real _longitude: geoItem ? geoItem.coordinate.longitude : NaN
+
+    function _updateGroundHeight() {
+        _groundHeight = (surfaceModel && geoItem && geoItem.coordinate.isValid)
+            ? surfaceModel.terrainHeightAt(geoItem.coordinate) : 0
+    }
+
+    Component.onCompleted: _updateGroundHeight()
+    onSurfaceModelChanged: _updateGroundHeight()
+    on_LatitudeChanged: _updateGroundHeight()
+    on_LongitudeChanged: _updateGroundHeight()
+
+    Connections {
+        target: root.surfaceModel
+        function onTerrainHeightsChanged() { root._updateGroundHeight() }
+    }
+
+    x: geoItem ? -geoItem.x : 0
+    y: geoItem ? -geoItem.y : 0
+    visible: dropLength > 0
+    opacity: scene ? scene.terrainScale : 0
+    scene: geoItem ? geoItem.scene : null
+    surfaceModel: geoItem ? geoItem.surfaceModel : null
+    center: geoItem ? geoItem.coordinate : QtPositioning.coordinate()
+    radiusMeters: _camera
+        ? (indicatorSize / 2) * _camera.distance * _camera.unitsPerPixelAtUnitDistance
+        : 1
+    strokeColor: "transparent"
+    strokeWidth: 0
+    // Translucent black (ADS-B shadow convention) so the colored drop line
+    // stays visible where it meets the shadow
+    fillColor: Qt.alpha("black", 0.35)
+}

--- a/src/GeoMap/GeoMapLandingPatternVisuals.qml
+++ b/src/GeoMap/GeoMapLandingPatternVisuals.qml
@@ -16,8 +16,8 @@ import QGroundControl.GeoMap
 /// read-only GeoMap-native port of the common elements in
 /// src/PlanView/FWLandingPatternMapVisual.qml / VTOLLandingPatternMapVisual.qml
 /// (flight path, loiter ring, final-approach/landing markers). No
-/// mouse-area/drag-to-place code ports over — FlyView missions are already
-/// loaded and immutable.
+/// drag-to-place code ports over — FlyView missions are already loaded and
+/// immutable; the markers are clickable only to change the current item.
 Item {
     id: root
 
@@ -27,6 +27,8 @@ Item {
     // DEM-vs-home-AMSL bias, wired by GeoMapMissionItems (see GeoMapWaypointItem)
     property real homeTerrainBias: 0
     property string landingLabel: ""   ///< Label for the landing-point marker (VTOL overrides to "Land")
+
+    signal clicked()
 
     readonly property bool _useLoiterToAlt: item.useLoiterToAlt.rawValue
     // Approach leg descends from the final-approach altitude to the landing
@@ -98,6 +100,11 @@ Item {
         label: root._useLoiterToAlt ? qsTr("Loiter") : qsTr("Approach")
         checked: root.item.isCurrentItem
         visible: root.item.landingCoordSet
+
+        MouseArea {
+            anchors.fill: parent
+            onClicked: root.clicked()
+        }
     }
 
     // Landing point
@@ -112,5 +119,10 @@ Item {
         label: root.landingLabel
         checked: root.item.isCurrentItem
         visible: root.item.landingCoordSet
+
+        MouseArea {
+            anchors.fill: parent
+            onClicked: root.clicked()
+        }
     }
 }

--- a/src/GeoMap/GeoMapMissionItems.qml
+++ b/src/GeoMap/GeoMapMissionItems.qml
@@ -28,6 +28,10 @@ Item {
     property var surfaceModel
     property real homeTerrainBias: 0   ///< See GeoMapWaypointItem.homeTerrainBias
 
+    /// A marker was clicked; item is its VisualMissionItem (mirrors
+    /// MissionItemMapVisual.clicked as consumed by PlanMapItems)
+    signal itemClicked(var item)
+
     Repeater {
         model: root.missionController ? root.missionController.visualItems : 0
 
@@ -50,6 +54,9 @@ Item {
                 // visuals; wire it up without hardcoding filenames here
                 if (item.hasOwnProperty("homeTerrainBias")) {
                     item.homeTerrainBias = Qt.binding(() => root.homeTerrainBias)
+                }
+                if (item.clicked !== undefined) {
+                    item.clicked.connect(() => root.itemClicked(object))
                 }
             }
         }

--- a/src/GeoMap/GeoMapMissionLabel.qml
+++ b/src/GeoMap/GeoMapMissionLabel.qml
@@ -65,6 +65,12 @@ GeoMapItem {
         font.bold: true
     }
 
+    GeoMapDropShadow {
+        id: dropShadow
+        geoItem: root
+        indicatorSize: root._indicatorSize
+    }
+
     Rectangle {
         anchors.left: parent.right
         anchors.leftMargin: ScreenTools.defaultFontPixelWidth / 2
@@ -85,14 +91,22 @@ GeoMapItem {
 
     delegate3D: Component {
         Node {
-            scale: Qt.vector3d(root._modelScale, root._modelScale, root._modelScale)
+            Node {
+                scale: Qt.vector3d(root._modelScale, root._modelScale, root._modelScale)
 
-            Model {
-                source: "#Sphere"
+                Model {
+                    source: "#Sphere"
 
-                materials: PrincipledMaterial {
-                    baseColor: root._markerColor
+                    materials: PrincipledMaterial {
+                        baseColor: root._markerColor
+                    }
                 }
+            }
+
+            GeoMapDropLine {
+                dropLength: dropShadow.dropLength
+                lineScale: dropShadow.dropLineScale
+                lineColor: root._markerColor
             }
         }
     }

--- a/src/GeoMap/GeoMapWaypointItem.qml
+++ b/src/GeoMap/GeoMapWaypointItem.qml
@@ -32,6 +32,8 @@ GeoMapItem {
     property real homeTerrainBias: 0
     property real size: ScreenTools.defaultFontPixelHeight * 1.5
 
+    signal clicked()
+
     width: size
     height: size
     anchorPoint: Qt.point(width / 2, height / 2)
@@ -68,43 +70,6 @@ GeoMapItem {
         ? root._indicatorSize * _camera.distance * _camera.unitsPerPixelAtUnitDistance / 100
         : 1
 
-    // Rendered-terrain height (true meters) under the marker, for the drop
-    // line; terrainHeightAt is not a binding dependency, so re-sampled
-    // explicitly as terrain tiles arrive and when the item moves
-    property real _groundHeight: 0
-
-    function _updateGroundHeight() {
-        _groundHeight = (root.surfaceModel && root.item) ? root.surfaceModel.terrainHeightAt(root.item.coordinate) : 0
-    }
-
-    Component.onCompleted: _updateGroundHeight()
-    onSurfaceModelChanged: _updateGroundHeight()
-
-    Connections {
-        target: root.surfaceModel
-        function onTerrainHeightsChanged() { root._updateGroundHeight() }
-    }
-
-    Connections {
-        target: root.item
-        function onCoordinateChanged() { root._updateGroundHeight() }
-    }
-
-    // Scene-space length of the drop line from marker to the rendered terrain
-    // (tracks terrainScale, so it flattens in lockstep with the anchor z)
-    readonly property real _dropLength: {
-        if (!scene || !item) {
-            return 0
-        }
-        const drop = (item.amslEntryAlt + homeTerrainBias - _groundHeight) * scene.verticalScale * scene.terrainScale
-        return isFinite(drop) ? Math.max(0, drop) : 0
-    }
-
-    // Drop line diameter: constant apparent width, like the marker
-    readonly property real _dropLineScale: _camera
-        ? (ScreenTools.defaultFontPixelHeight / 8) * _camera.distance * _camera.unitsPerPixelAtUnitDistance / 100
-        : 0
-
     Rectangle {
         anchors.centerIn: parent
         width: root._indicatorSize
@@ -134,6 +99,19 @@ GeoMapItem {
         font.bold: true
     }
 
+    // The item itself tracks the projected marker position at any tilt, so
+    // this hit target follows the 3D sphere through the 2D<->3D crossfade
+    MouseArea {
+        anchors.fill: parent
+        onClicked: root.clicked()
+    }
+
+    GeoMapDropShadow {
+        id: dropShadow
+        geoItem: root
+        indicatorSize: root._indicatorSize
+    }
+
     delegate3D: Component {
         Node {
             Node {
@@ -148,35 +126,10 @@ GeoMapItem {
                 }
             }
 
-            // Drop line to the terrain below (Google Earth-style "extrude"):
-            // anchors the floating marker visually so its altitude is readable
-            Model {
-                source: "#Cylinder"   // built-in: 100x100 units, height along +Y
-                visible: root._dropLength > 0
-                opacity: 0.75
-                eulerRotation.x: 90   // stand the height axis up along scene z
-                position: Qt.vector3d(0, 0, -root._dropLength / 2)
-                scale: Qt.vector3d(root._dropLineScale, root._dropLength / 100, root._dropLineScale)
-
-                materials: PrincipledMaterial {
-                    lighting: PrincipledMaterial.NoLighting
-                    baseColor: root._markerColor
-                }
-            }
-
-            // Ground footprint: half-buried flattened sphere reads as a disc
-            // without z-fighting the terrain mesh
-            Model {
-                source: "#Sphere"
-                visible: root._dropLength > 0
-                opacity: 0.75
-                position: Qt.vector3d(0, 0, -root._dropLength)
-                scale: Qt.vector3d(root._modelScale, root._modelScale, root._modelScale * 0.15)
-
-                materials: PrincipledMaterial {
-                    lighting: PrincipledMaterial.NoLighting
-                    baseColor: root._markerColor
-                }
+            GeoMapDropLine {
+                dropLength: dropShadow.dropLength
+                lineScale: dropShadow.dropLineScale
+                lineColor: root._markerColor
             }
         }
     }

--- a/src/GeoMap/SurfacePatchModel.cc
+++ b/src/GeoMap/SurfacePatchModel.cc
@@ -11,6 +11,7 @@
 
 #include <algorithm>
 #include <cmath>
+#include <limits>
 #include <utility>
 
 #ifdef Q_OS_ANDROID
@@ -322,6 +323,99 @@ double SurfacePatchModel::terrainHeightAt(const QGeoCoordinate& coordinate) cons
         return 0.0;
     }
     return _heightField->heightAt(TileMath::geoToWorld(coordinate));
+}
+
+QGeoCoordinate SurfacePatchModel::surfaceCoordinateAtScreenPoint(const GeoMapCamera* camera, const QPointF& screenPos,
+                                                                 double zScale) const
+{
+    // Negative zScale would invert the terrain band math below
+    if (!camera || !_heightField || (zScale < 0.0)) {
+        return QGeoCoordinate();
+    }
+    const auto rayOpt = camera->pickRayAt(screenPos);
+    if (!rayOpt) {
+        return QGeoCoordinate();
+    }
+    const GeoMapCamera::PickRay& ray = *rayOpt;
+
+    // Signed height of the ray above the rendered surface at parameter t
+    const auto surfaceOffset = [&](double t) {
+        const QPointF ground(ray.originX + (t * ray.dirX), ray.originY + (t * ray.dirY));
+        return (ray.originZ + (t * ray.dirZ)) - (_heightField->heightAt(ground) * zScale);
+    };
+
+    // Earth terrain bounds (Terrarium tiles encode bathymetry, so the floor is
+    // the ocean trenches, not sea level). The ray can only cross the surface
+    // while its z is inside [minZ, maxZ]: march that band only.
+    constexpr double kMinTerrainMeters = -11000.0;
+    constexpr double kMaxTerrainMeters = 9000.0;
+    const double minZ = kMinTerrainMeters * zScale;
+    const double maxZ = kMaxTerrainMeters * zScale;
+
+    double tStart = 0.0;
+    double tEnd = 0.0;
+    if (ray.dirZ < 0.0) {
+        tStart = std::max(0.0, (maxZ - ray.originZ) / ray.dirZ);
+        tEnd = (minZ - ray.originZ) / ray.dirZ;
+    } else if (ray.originZ < maxZ) {
+        // Ascending ray below the terrain ceiling (screen edge above the camera
+        // horizon) can still hit terrain rising in front of the camera
+        tEnd = (ray.dirZ > 0.0) ? ((maxZ - ray.originZ) / ray.dirZ) : std::numeric_limits<double>::infinity();
+    } else {
+        return QGeoCoordinate();
+    }
+
+    // Nothing renders beyond the retained patch range, so a hit past it would
+    // be a hit on invisible terrain; this also bounds the coarse step length
+    const double horizontal = std::hypot(ray.dirX, ray.dirY);
+    if (horizontal > 1e-12) {
+        tEnd = std::min(tEnd, (SurfaceModel::kMaxRangeMultiplier * camera->distance()) / horizontal);
+    }
+    if (!std::isfinite(tEnd) || (tEnd < tStart)) {
+        return QGeoCoordinate();
+    }
+
+    const auto coordinateAt = [&](double t) {
+        return TileMath::worldToGeo(QPointF(ray.originX + (t * ray.dirX), ray.originY + (t * ray.dirY)));
+    };
+
+    if (surfaceOffset(tStart) <= 0.0) {
+        // Already at/below the surface at the band entry (includes the zScale=0
+        // degenerate case, where the band collapses to the z=0 plane hit)
+        return coordinateAt(tStart);
+    }
+
+    // Coarse march to the first above->below crossing (the visible surface),
+    // then bisect the bracket down to sub-meter precision. The step length
+    // scales with camera distance like the rendered LOD does, so a visible
+    // ridge cannot fall between samples; only features narrower than
+    // ~distance/64 can be stepped over. With the range capped at
+    // kMaxRangeMultiplier distances this bounds the march at a few thousand
+    // heightAt lookups, fine for a one-shot click.
+    constexpr double kStepsPerCameraDistance = 64.0;
+    constexpr int kBisectSteps = 24;
+    const double stepMeters = std::max(camera->distance() / kStepsPerCameraDistance, 1.0);
+    const double groundRange = (tEnd - tStart) * horizontal;
+    const int coarseSteps = std::max(1, static_cast<int>(std::ceil(groundRange / stepMeters)));
+    double prevT = tStart;
+    for (int i = 1; i <= coarseSteps; i++) {
+        const double t = tStart + (((tEnd - tStart) * i) / coarseSteps);
+        if (surfaceOffset(t) <= 0.0) {
+            double lo = prevT;
+            double hi = t;
+            for (int j = 0; j < kBisectSteps; j++) {
+                const double mid = (lo + hi) / 2.0;
+                if (surfaceOffset(mid) <= 0.0) {
+                    hi = mid;
+                } else {
+                    lo = mid;
+                }
+            }
+            return coordinateAt(hi);
+        }
+        prevT = t;
+    }
+    return QGeoCoordinate();  // sky: no crossing within the rendered range
 }
 
 int SurfacePatchModel::gridSize() const

--- a/src/GeoMap/SurfacePatchModel.h
+++ b/src/GeoMap/SurfacePatchModel.h
@@ -30,6 +30,7 @@ class QTimer;
 class SurfaceModel;
 class TileImageSource;
 
+Q_MOC_INCLUDE("GeoMapCamera.h")
 Q_MOC_INCLUDE("GeoScene.h")
 Q_MOC_INCLUDE("HeightField.h")
 
@@ -105,6 +106,16 @@ public:
     /// where loaded, coarser estimate or 0 elsewhere (see HeightField). Emits
     /// terrainHeightsChanged as estimates improve.
     Q_INVOKABLE double terrainHeightAt(const QGeoCoordinate& coordinate) const;
+
+    /// Coordinate of the rendered surface under screenPos: marches the camera's
+    /// pick ray to its first crossing of z = heightAt(x, y) * zScale, so the pick
+    /// lands on the visible front surface and ridges occlude the ground behind
+    /// them. zScale is the height-to-scene-z factor (verticalScale * terrainScale,
+    /// never negative); 0 reduces to a flat z=0 plane pick. The march is capped at
+    /// the rendered range (maxRangeMultiplier * camera distance). Invalid coordinate
+    /// when nothing is hit (sky pick) or camera is null.
+    Q_INVOKABLE QGeoCoordinate surfaceCoordinateAtScreenPoint(const GeoMapCamera* camera, const QPointF& screenPos,
+                                                              double zScale) const;
 
     /// SurfaceModel::kMaxRangeMultiplier, exposed so the scene camera's far
     /// clip plane can cover the full retained patch range

--- a/test/GeoMap/SurfacePatchModelTest.cc
+++ b/test/GeoMap/SurfacePatchModelTest.cc
@@ -30,6 +30,20 @@ void attach(SurfacePatchModel& model, GeoScene& scene, GeoMapCamera& camera)
     model.drainUpdates();
 }
 
+ElevationTilePyramid::Grid uniformGrid(float height)
+{
+    ElevationTilePyramid::Grid grid;
+    grid.width = 4;
+    grid.height = 4;
+    grid.heights = QList<float>(16, height);
+    return grid;
+}
+
+double groundDistance(const QPointF& a, const QPointF& b)
+{
+    return std::hypot(a.x() - b.x(), a.y() - b.y());
+}
+
 }  // namespace
 
 void SurfacePatchModelTest::_emptyWithoutCamera()
@@ -332,6 +346,142 @@ void SurfacePatchModelTest::_terrainHeightAt()
     QVERIFY(model.heightField()->insertTile(key, grid));
     QCOMPARE(model.terrainHeightAt(kCenter), 100.0);
     QCOMPARE_GE(heightsSpy.count(), 1);
+}
+
+// The surface-pick tests below never spin the event loop after attach: the
+// flat height source delivers its all-zero tiles through queued singleShots,
+// so the field holds exactly the tiles each test inserts.
+
+void SurfacePatchModelTest::_surfacePickFlatMatchesPlanePick()
+{
+    GeoMapCamera camera;
+    GeoScene scene;
+    SurfacePatchModel model;
+    setupCamera(camera);
+    camera.setTilt(60);
+    camera.setHeading(30);
+    attach(model, scene, camera);
+
+    QVERIFY(!model.surfaceCoordinateAtScreenPoint(nullptr, QPointF(400, 300), 1.0).isValid());
+
+    // With no height data the surface is the z=0 plane: the march must agree
+    // with the analytic plane pick everywhere on screen
+    const QList<QPointF> points{QPointF(400, 300), QPointF(200, 150), QPointF(600, 450)};
+    for (const QPointF& p : points) {
+        const QGeoCoordinate surface = model.surfaceCoordinateAtScreenPoint(&camera, p, 1.0);
+        const QGeoCoordinate plane = camera.coordinateAtScreenPoint(p);
+        QVERIFY(surface.isValid());
+        QVERIFY(plane.isValid());
+        QCOMPARE_LT(groundDistance(TileMath::geoToWorld(surface), TileMath::geoToWorld(plane)), 0.01);
+    }
+}
+
+void SurfacePatchModelTest::_surfacePickLandsOnPlateau()
+{
+    // Camera centered on a zoom-12 tile raised to a 500 m plateau
+    const TileMath::TileKey key = TileMath::tileForWorld(TileMath::geoToWorld(kCenter), 12);
+    const double span = TileMath::tileSpanAtZoom(12);
+    const QPointF tileCenter = TileMath::tileMinCorner(key) + QPointF(span / 2.0, span / 2.0);
+
+    GeoMapCamera camera;
+    GeoScene scene;
+    SurfacePatchModel model;
+    setupCamera(camera, TileMath::worldToGeo(tileCenter));
+    camera.setTilt(60);
+    camera.setDistance(4000);  // camera z stays above the scaled plateau top
+    attach(model, scene, camera);
+    QVERIFY(model.heightField()->insertTile(key, uniformGrid(500.0f)));
+
+    const QPointF screenPos(400, 300);
+    const double zScale = 2.0;  // exercise scale independence (mercator vertical stretch)
+    const QGeoCoordinate pick = model.surfaceCoordinateAtScreenPoint(&camera, screenPos, zScale);
+    QVERIFY(pick.isValid());
+    QCOMPARE_LE(std::abs(model.terrainHeightAt(pick) - 500.0), 1e-6);
+
+    // The invariant of a correct pick: the returned surface point projects
+    // back to the clicked pixel
+    const auto roundTrip = camera.worldToScreen(TileMath::geoToWorld(pick), 500.0 * zScale);
+    QVERIFY(roundTrip.has_value());
+    QCOMPARE_LT(std::hypot(roundTrip->x() - screenPos.x(), roundTrip->y() - screenPos.y()), 0.5);
+
+    // And it lands nearer the camera than the ground-plane pick would
+    const QGeoCoordinate plane = camera.coordinateAtScreenPoint(screenPos);
+    QCOMPARE_LT(groundDistance(camera.cameraGroundPosition(), TileMath::geoToWorld(pick)),
+                groundDistance(camera.cameraGroundPosition(), TileMath::geoToWorld(plane)));
+}
+
+void SurfacePatchModelTest::_surfacePickOccludesGroundBehindRidge()
+{
+    const TileMath::TileKey key = TileMath::tileForWorld(TileMath::geoToWorld(kCenter), 12);
+    const double span = TileMath::tileSpanAtZoom(12);
+    const QPointF tileCenter = TileMath::tileMinCorner(key) + QPointF(span / 2.0, span / 2.0);
+    const double tileMaxY = TileMath::tileMinCorner(key).y() + span;
+
+    GeoMapCamera camera;
+    GeoScene scene;
+    SurfacePatchModel model;
+    setupCamera(camera, TileMath::worldToGeo(tileCenter));
+    camera.setTilt(70);
+    camera.setDistance(3000);
+    attach(model, scene, camera);
+    QVERIFY(model.heightField()->insertTile(key, uniformGrid(500.0f)));
+
+    // A ground point north of (behind) the plateau, on screen when terrain is
+    // ignored: the ray to it passes below the plateau top on the way there
+    const QPointF behind(tileCenter.x(), tileMaxY + 1000.0);
+    const auto screenPos = camera.worldToScreen(behind, 0.0);
+    QVERIFY(screenPos.has_value());
+
+    const QGeoCoordinate pick = model.surfaceCoordinateAtScreenPoint(&camera, *screenPos, 1.0);
+    QVERIFY(pick.isValid());
+    const QPointF pickWorld = TileMath::geoToWorld(pick);
+
+    // The pick lands on the plateau top, not on the occluded ground behind it
+    QCOMPARE_LE(std::abs(model.terrainHeightAt(pick) - 500.0), 1e-6);
+    QCOMPARE_LT(pickWorld.y(), tileMaxY);
+    QCOMPARE_LT(groundDistance(camera.cameraGroundPosition(), pickWorld),
+                groundDistance(camera.cameraGroundPosition(), behind));
+}
+
+void SurfacePatchModelTest::_surfacePickSkyInvalid()
+{
+    GeoMapCamera camera;
+    GeoScene scene;
+    SurfacePatchModel model;
+    setupCamera(camera);
+    camera.setTilt(85);
+    attach(model, scene, camera);
+
+    // Top-of-screen ray points above the horizon at max tilt: nothing to hit
+    QVERIFY(!model.surfaceCoordinateAtScreenPoint(&camera, QPointF(400, 10), 1.0).isValid());
+
+    // A camera without a viewport cannot form a pick ray
+    GeoMapCamera bare;
+    QVERIFY(!model.surfaceCoordinateAtScreenPoint(&bare, QPointF(400, 300), 1.0).isValid());
+}
+
+void SurfacePatchModelTest::_surfacePickZeroZScaleMatchesPlanePick()
+{
+    // terrainScale animates to 0 in 2D: even with height data loaded the pick
+    // must collapse to the analytic z=0 plane pick
+    const TileMath::TileKey key = TileMath::tileForWorld(TileMath::geoToWorld(kCenter), 12);
+    const double span = TileMath::tileSpanAtZoom(12);
+    const QPointF tileCenter = TileMath::tileMinCorner(key) + QPointF(span / 2.0, span / 2.0);
+
+    GeoMapCamera camera;
+    GeoScene scene;
+    SurfacePatchModel model;
+    setupCamera(camera, TileMath::worldToGeo(tileCenter));
+    camera.setTilt(45);
+    attach(model, scene, camera);
+    QVERIFY(model.heightField()->insertTile(key, uniformGrid(500.0f)));
+
+    const QPointF screenPos(400, 300);
+    const QGeoCoordinate pick = model.surfaceCoordinateAtScreenPoint(&camera, screenPos, 0.0);
+    const QGeoCoordinate plane = camera.coordinateAtScreenPoint(screenPos);
+    QVERIFY(pick.isValid());
+    QVERIFY(plane.isValid());
+    QCOMPARE_LT(groundDistance(TileMath::geoToWorld(pick), TileMath::geoToWorld(plane)), 0.01);
 }
 
 UT_REGISTER_TEST_LIGHTWEIGHT(SurfacePatchModelTest, TestLabel::Unit)

--- a/test/GeoMap/SurfacePatchModelTest.h
+++ b/test/GeoMap/SurfacePatchModelTest.h
@@ -18,4 +18,9 @@ private slots:
     void _edgeLodDeltasRoleStitchesLodRings();
     void _tileKeyAndHeightFieldExposedToDelegates();
     void _terrainHeightAt();
+    void _surfacePickFlatMatchesPlanePick();
+    void _surfacePickLandsOnPlateau();
+    void _surfacePickOccludesGroundBehindRidge();
+    void _surfacePickSkyInvalid();
+    void _surfacePickZeroZScaleMatchesPlanePick();
 };


### PR DESCRIPTION
## Summary

Adds true terrain surface picking to the 3D GeoMap and builds click interaction and ROI altitude rendering on top of it.

### Surface picking
- `GeoMapCamera::pickRayAt` returns a double-precision pick ray (QVector3D floats lose meters at mercator scale).
- `SurfacePatchModel::surfaceCoordinateAtScreenPoint` ray-marches the rendered terrain heightfield: terrain-band clipping (incl. bathymetry floor), render-range cap, coarse march + bisection refinement. Clicks land where the user sees them at any camera tilt instead of on the zero plane.
- FlyView 3D map clicks route through the surface pick; guided-action map clicks are now allowed at any tilt; sky picks are ignored.

### Mission item click support
- Waypoint, mission label, and landing pattern markers are clickable in 3D, wired to the same set-current-waypoint guided action as the 2D map (`PlanMapItems` parity, including the `Math.max(seq, 1)` home-item guard).

### ROI altitude
- The ROI marker renders at its actual altitude (relative altitude + home terrain bias) with a vertical drop line, instead of clamped to ground, falling back to ground-clamp when altitude is unknown.
- ROI edit dialog/drop panel close when the active vehicle changes; the dynamically-created drop panel is destroyed on close to fix a leak (both FlyViewMap and GeoMap copies).

### Refactor
- Shared `GeoMapDropShadow` / `GeoMapDropLine` components replace the duplicated draped-shadow + drop-line blocks in waypoint and label markers; ground height is resampled only on lat/lon changes.

## Testing
- New `SurfacePatchModelTest` cases: flat-plane parity with the plane pick, plateau landing (zScale-independent, round-trip projection), ridge occlusion, sky/no-viewport invalid picks, and zero vertical-scale collapse to the plane pick.
- `ctest -R SurfacePatchModelTest` passes; build and qmllint clean.
- Manual verification in FlyView: clicks at high tilt land on visible terrain, waypoint markers select the current item, ROI renders at altitude with drop line and shadow.