### PR TITLE
feat(GeoMap): drape terrain-frame mission legs over DEM in 3D

### DIFF
--- a/src/GeoMap/GeoMapMissionDirectionArrows.qml
+++ b/src/GeoMap/GeoMapMissionDirectionArrows.qml
@@ -10,6 +10,8 @@
 import QtQuick
 import QtPositioning
 
+import QGroundControl.Controls
+
 /// General flight-path direction indicators for the GeoMap: one arrow per
 /// entry in MissionController.directionArrows (added to the second flight
 /// path segment and every 5 segments thereafter, regardless of simple vs
@@ -27,11 +29,58 @@ Item {
         model: root.missionController ? root.missionController.directionArrows : 0
 
         GeoMapSegmentArrow {
+            id: arrow
             scene: root.scene
             surfaceModel: root.surfaceModel
-            fromCoord: QtPositioning.coordinate(object.coordinate1.latitude, object.coordinate1.longitude, object.coord1AMSLAlt + root.homeTerrainBias)
-            toCoord: QtPositioning.coordinate(object.coordinate2.latitude, object.coordinate2.longitude, object.coord2AMSLAlt + root.homeTerrainBias)
-            fraction: 0.75
+            fromCoord: {
+                _terrainRev
+                return _terrainLeg ? _drapedPoint(0.75 - _halfChordFraction)
+                                   : QtPositioning.coordinate(object.coordinate1.latitude, object.coordinate1.longitude,
+                                                              object.coord1AMSLAlt + root.homeTerrainBias)
+            }
+            toCoord: {
+                _terrainRev
+                return _terrainLeg ? _drapedPoint(0.75 + _halfChordFraction)
+                                   : QtPositioning.coordinate(object.coordinate2.latitude, object.coordinate2.longitude,
+                                                              object.coord2AMSLAlt + root.homeTerrainBias)
+            }
+            fraction: _terrainLeg ? 0.5 : 0.75
+
+            // Terrain-frame legs are draped over the DEM (see
+            // GeoMapMissionPath), so anchor the arrow to a short draped chord
+            // around the 0.75 mark rather than the straight AMSL chord: the
+            // chord midpoint puts the arrow on the ribbon and the chord ends
+            // give it the local tangent heading
+            readonly property bool _terrainLeg: !!root.surfaceModel && object.segmentType === FlightPathSegment.SegmentTypeTerrainFrame
+
+            // Cap the chord at 50 m so it stays local to the ribbon on long
+            // legs (a 10% chord averages away terrain curvature), while short
+            // legs keep enough screen separation for a stable heading
+            readonly property real _halfChordFraction: {
+                const len = object.coordinate1.distanceTo(object.coordinate2)
+                return len > 0 ? Math.min(0.05, 25 / len) : 0.05
+            }
+
+            // terrainHeightAt is not NOTIFY-reactive; read in the coordinate
+            // bindings above so they re-sample as DEM patches stream in
+            property int _terrainRev: 0
+
+            // Same AGL-ramp draping as GeoMapMissionPath._appendTerrainLeg
+            function _drapedPoint(f) {
+                const c1 = object.coordinate1
+                const c2 = object.coordinate2
+                const point = c1.atDistanceAndAzimuth(c1.distanceTo(c2) * f, c1.azimuthTo(c2))
+                const agl1 = object.coord1AMSLAlt - root.surfaceModel.terrainHeightAt(c1)
+                const agl2 = object.coord2AMSLAlt - root.surfaceModel.terrainHeightAt(c2)
+                return QtPositioning.coordinate(point.latitude, point.longitude,
+                                                root.surfaceModel.terrainHeightAt(point) + agl1 + ((agl2 - agl1) * f) + root.homeTerrainBias)
+            }
+
+            Connections {
+                target: root.surfaceModel
+                enabled: arrow._terrainLeg
+                function onTerrainHeightsChanged() { arrow._terrainRev++ }
+            }
         }
     }
 }

--- a/src/GeoMap/GeoMapMissionPath.qml
+++ b/src/GeoMap/GeoMapMissionPath.qml
@@ -19,10 +19,12 @@ import QGroundControl.GeoMap
 /// sequence order (simple items at their coordinate; complex items via their
 /// generic entryCoordinate/exitCoordinate, so the ribbon routes straight
 /// through a complex item's own footprint rather than skipping it), at true
-/// (AMSL) altitude. Stays visible in 2D mode (crossfade3D off), same as
-/// GeoMapFlightPath. Rebuilt wholesale on any mission change (missions are
-/// edited, not streamed, so the flight path's incremental append API is not
-/// needed here).
+/// (AMSL) altitude. A leg is flown in its destination item's frame (ArduPilot
+/// AC_WPNav): legs arriving at a terrain-frame item are draped over the DEM
+/// with a linear AGL ramp, all other legs are straight lines. Stays visible
+/// in 2D mode (crossfade3D off), same as GeoMapFlightPath. Rebuilt wholesale
+/// on any mission change (missions are edited, not streamed, so the flight
+/// path's incremental append API is not needed here).
 GeoMapItem {
     id: root
 
@@ -57,7 +59,7 @@ GeoMapItem {
     // each vertex's own camera distance
     readonly property real _screenFactor: _camera ? _camera.unitsPerPixelAtUnitDistance : 0
 
-    // Ordered coordinates (with AMSL altitude) of every item the vehicle
+    // Ordered route points ({coordinate, terrainLeg}) of every item the vehicle
     // actually routes through, mirroring MissionController::_recalcFlightPathSegments:
     // items must specifiesCoordinate && !isStandaloneCoordinate to get a
     // segment (excludes RTL, which has no mission-encoded coordinate, and
@@ -73,72 +75,91 @@ GeoMapItem {
     // after a landing item either. The walk starts at item 1 (item 0 is the
     // MissionSettingsItem, i.e. home); home is prepended only when the mission
     // starts from the ground — rover, or a takeoff command before the first
-    // coordinate item — mirroring linkStartToHome. Recomputes automatically on
-    // any structural or per-item change since the loop below reads every
+    // coordinate item — mirroring linkStartToHome. terrainLeg marks the leg
+    // ARRIVING at a point as terrain-frame (destination item is
+    // MAV_FRAME_GLOBAL_TERRAIN_ALT), except takeoff/land destinations, which
+    // the 2D view also draws as takeoff/land rather than terrain
+    // (segmentTypeForPair's takeoff/land override). Recomputes automatically on any
+    // structural or per-item change since the loop below reads every
     // NOTIFY-backed property it depends on.
-    readonly property var _pathCoordinates: {
-        const coordinates = []
+    readonly property var _routePoints: {
+        const points = []
         if (root.missionController) {
             const items = root.missionController.visualItems
             let linkStartToHome = root.vehicle ? root.vehicle.rover : false
             for (let i = 1; i < items.count; ++i) {
                 const visualItem = items.get(i)
                 if (visualItem.isSimpleItem && visualItem.command === MAVLinkEnums.MAV_CMD_NAV_RETURN_TO_LAUNCH) {
-                    if (coordinates.length > 0 && root.vehicle && root.vehicle.homePosition.isValid) {
-                        coordinates.push(root.vehicle.homePosition)
+                    if (points.length > 0 && root.vehicle && root.vehicle.homePosition.isValid) {
+                        points.push({ coordinate: root.vehicle.homePosition, terrainLeg: false })
                     }
                     break
                 }
-                if (coordinates.length === 0 && visualItem.isTakeoffItem) {
+                if (points.length === 0 && visualItem.isTakeoffItem) {
                     linkStartToHome = true
                 }
                 if (visualItem.specifiesCoordinate && !visualItem.isStandaloneCoordinate) {
-                    coordinates.push(QtPositioning.coordinate(visualItem.entryCoordinate.latitude,
-                                                               visualItem.entryCoordinate.longitude,
-                                                               visualItem.amslEntryAlt))
+                    points.push({
+                        coordinate: QtPositioning.coordinate(visualItem.entryCoordinate.latitude,
+                                                             visualItem.entryCoordinate.longitude,
+                                                             visualItem.amslEntryAlt),
+                        terrainLeg: visualItem.isSimpleItem && visualItem.altitudeFrame === QGroundControl.AltitudeFrameTerrain
+                                    && !visualItem.isTakeoffItem && !visualItem.isLandCommand
+                    })
                     if (visualItem.isLandCommand) {
                         break
                     }
                     if (!visualItem.exitCoordinateSameAsEntry) {
-                        coordinates.push(QtPositioning.coordinate(visualItem.exitCoordinate.latitude,
-                                                                   visualItem.exitCoordinate.longitude,
-                                                                   visualItem.amslExitAlt))
+                        points.push({
+                            coordinate: QtPositioning.coordinate(visualItem.exitCoordinate.latitude,
+                                                                 visualItem.exitCoordinate.longitude,
+                                                                 visualItem.amslExitAlt),
+                            terrainLeg: false
+                        })
                     }
                 }
             }
-            if (linkStartToHome && coordinates.length > 0 && items.count > 0) {
+            if (linkStartToHome && points.length > 0 && items.count > 0) {
                 const home = items.get(0)
                 if (home.coordinate.isValid) {
-                    coordinates.unshift(QtPositioning.coordinate(home.coordinate.latitude,
-                                                                  home.coordinate.longitude,
-                                                                  home.amslEntryAlt))
+                    points.unshift({
+                        coordinate: QtPositioning.coordinate(home.coordinate.latitude,
+                                                             home.coordinate.longitude,
+                                                             home.amslEntryAlt),
+                        terrainLeg: false
+                    })
                 }
             }
         }
-        return root._subdivided(coordinates)
+        return points
     }
 
-    // Legs longer than this are subdivided along the great circle (matching
-    // MissionLineView.qml): the geometry joins points linearly in Web
-    // Mercator, which diverges materially from the actual route over long
+    // Straight legs longer than this are subdivided along the great circle
+    // (matching MissionLineView.qml): the geometry joins points linearly in
+    // Web Mercator, which diverges materially from the actual route over long
     // distances
     readonly property real _maxSegmentLengthM: 50000
 
-    function _subdivided(coordinates) {
+    // Terrain-frame legs sample the DEM at this spacing (same idea as
+    // FenceWallGeometry), capped so a degenerate long leg can't explode the
+    // vertex count
+    readonly property real _terrainSampleSpacingM: 50
+    readonly property int _maxTerrainSamplesPerLeg: 200
+
+    // Terrain sampling can't live in the _routePoints binding: terrainHeightAt
+    // is not NOTIFY-reactive, so draping is re-run explicitly here on route
+    // changes and on terrainHeightsChanged as DEM patches stream in
+    function _expandedPath() {
+        const points = root._routePoints
         const result = []
-        for (let i = 0; i < coordinates.length; ++i) {
-            const coord = coordinates[i]
+        for (let i = 0; i < points.length; ++i) {
+            const coord = points[i].coordinate
             if (i > 0) {
-                const prev = coordinates[i - 1]
-                const distance = prev.distanceTo(coord)
-                if (distance > root._maxSegmentLengthM) {
-                    const segments = Math.ceil(distance / root._maxSegmentLengthM)
-                    const azimuth = prev.azimuthTo(coord)
-                    for (let j = 1; j < segments; ++j) {
-                        const point = prev.atDistanceAndAzimuth((j * distance) / segments, azimuth)
-                        result.push(QtPositioning.coordinate(point.latitude, point.longitude,
-                                                             prev.altitude + ((coord.altitude - prev.altitude) * j) / segments))
-                    }
+                const prev = points[i - 1].coordinate
+                if (points[i].terrainLeg && root.surfaceModel) {
+                    root._appendTerrainLeg(result, prev, coord)
+                } else {
+                    root._appendLongLegSubdivision(result, prev, coord)
                 }
             }
             result.push(coord)
@@ -146,13 +167,72 @@ GeoMapItem {
         return result
     }
 
-    function _reloadPath() {
-        if (_geometry) {
-            _geometry.setPath(root._pathCoordinates)
+    function _appendLongLegSubdivision(result, prev, coord) {
+        const distance = prev.distanceTo(coord)
+        if (distance <= root._maxSegmentLengthM) {
+            return
+        }
+        const segments = Math.ceil(distance / root._maxSegmentLengthM)
+        const azimuth = prev.azimuthTo(coord)
+        for (let j = 1; j < segments; ++j) {
+            const point = prev.atDistanceAndAzimuth((j * distance) / segments, azimuth)
+            result.push(QtPositioning.coordinate(point.latitude, point.longitude,
+                                                 prev.altitude + ((coord.altitude - prev.altitude) * j) / segments))
         }
     }
 
-    on_PathCoordinatesChanged: _reloadPath()
+    // ArduPilot flies a terrain-frame leg at a height above terrain that
+    // ramps from the origin's AGL to the destination's while riding the
+    // terrain profile (AC_WPNav terrain offset); approximate that by draping
+    // the leg over the DEM with a linear AGL ramp. AGLs are computed against
+    // the same DEM the surface renders from, so the ribbon meets both
+    // endpoint markers exactly (the DEM-vs-home AMSL bias cancels between
+    // the endpoint and sample terms).
+    function _appendTerrainLeg(result, prev, coord) {
+        const distance = prev.distanceTo(coord)
+        const steps = Math.min(Math.ceil(distance / root._terrainSampleSpacingM), root._maxTerrainSamplesPerLeg)
+        if (steps < 2) {
+            return
+        }
+        const azimuth = prev.azimuthTo(coord)
+        const prevAgl = prev.altitude - root.surfaceModel.terrainHeightAt(prev)
+        const destAgl = coord.altitude - root.surfaceModel.terrainHeightAt(coord)
+        for (let j = 1; j < steps; ++j) {
+            const s = j / steps
+            const point = prev.atDistanceAndAzimuth(distance * s, azimuth)
+            result.push(QtPositioning.coordinate(point.latitude, point.longitude,
+                                                 root.surfaceModel.terrainHeightAt(point) + prevAgl + ((destAgl - prevAgl) * s)))
+        }
+    }
+
+    function _reloadPath() {
+        if (_geometry) {
+            _geometry.setPath(root._expandedPath())
+        }
+    }
+
+    // Qt.callLater coalesces rebuild bursts (per-patch terrainHeightsChanged
+    // during tile streaming, route + terrain changes in one pass) into one
+    // re-drape, same idea as FenceWallGeometry::_scheduleRebuild
+    function _scheduleReloadPath() {
+        Qt.callLater(root._reloadPath)
+    }
+
+    on_RoutePointsChanged: _scheduleReloadPath()
+
+    // Only draped legs depend on the DEM; skip terrain-driven rebuilds for
+    // missions with straight legs only
+    readonly property bool _hasTerrainLeg: _routePoints.some(p => p.terrainLeg)
+
+    Connections {
+        target: root.surfaceModel
+
+        function onTerrainHeightsChanged() {
+            if (root._hasTerrainLeg) {
+                root._scheduleReloadPath()
+            }
+        }
+    }
 
     delegate3D: Component {
         // z offsets are relative altitudes; flatten them with the terrain

--- a/src/MissionManager/MissionController.cc
+++ b/src/MissionManager/MissionController.cc
@@ -1094,8 +1094,8 @@ void MissionController::_recalcFlightPathSegments(void)
                     }
 
                     lastSegmentVisualItemPair =  VisualItemPair(lastFlyThroughVI, visualItem);
-                    SimpleMissionItem* lastSimpleItem = qobject_cast<SimpleMissionItem*>(lastFlyThroughVI);
-                    bool mavlinkTerrainFrame = lastSimpleItem ? lastSimpleItem->missionItem().frame() == MAV_FRAME_GLOBAL_TERRAIN_ALT : false;
+                    // A leg is flown in its destination item's frame (ArduPilot AC_WPNav)
+                    bool mavlinkTerrainFrame = simpleItem ? simpleItem->missionItem().frame() == MAV_FRAME_GLOBAL_TERRAIN_ALT : false;
                     FlightPathSegment* segment = _addFlightPathSegment(oldSegmentTable, lastSegmentVisualItemPair, mavlinkTerrainFrame);
                     segment->setSpecialVisual(roiActive);
                     if (addDirectionArrow) {
@@ -1573,6 +1573,9 @@ void MissionController::_initVisualItem(VisualMissionItem* visualItem)
         SimpleMissionItem* simpleItem = qobject_cast<SimpleMissionItem*>(visualItem);
         if (simpleItem) {
             connect(&simpleItem->missionItem()._commandFact, &Fact::valueChanged, this, &MissionController::_itemCommandChanged);
+            // The altitude frame drives segmentTypeForPair, and segment type is immutable once created
+            connect(simpleItem, &SimpleMissionItem::altitudeFrameChanged, this,
+                    &MissionController::_recalcFlightPathSegmentsSignal, Qt::QueuedConnection);
         } else {
             qWarning() << "isSimpleItem == true, yet not SimpleMissionItem";
         }

--- a/src/MissionManager/PlanManager.cc
+++ b/src/MissionManager/PlanManager.cc
@@ -418,6 +418,8 @@ void PlanManager::_handleMissionItem(const mavlink_message_t& message)
         frame = MAV_FRAME_GLOBAL;
     } else if (frame == MAV_FRAME_GLOBAL_RELATIVE_ALT_INT) {
         frame = MAV_FRAME_GLOBAL_RELATIVE_ALT;
+    } else if (frame == MAV_FRAME_GLOBAL_TERRAIN_ALT_INT) {
+        frame = MAV_FRAME_GLOBAL_TERRAIN_ALT;
     }
 
     bool ardupilotHomePositionUpdate = false;

--- a/src/MissionManager/SimpleMissionItem.h
+++ b/src/MissionManager/SimpleMissionItem.h
@@ -124,6 +124,7 @@ public:
     double          specifiedVehicleYaw         (void) override;
     QString         mapVisualQML                (void) const override { return QStringLiteral("SimpleItemMapVisual.qml"); }
     QString         geoMapVisualQML             (void) const override { return QStringLiteral("GeoMapWaypointItem.qml"); }
+    bool            terrainAltitudeRequiredInFlyView(void) const final { return _altitudeFrame == QGroundControlQmlGlobal::AltitudeFrameTerrain; }
     void            appendMissionItems          (QList<MissionItem*>& items, QObject* missionItemParent) final;
     void            applyNewAltitude            (double newAltitude) final;
     void            setMissionFlightStatus      (MissionFlightStatus_t& missionFlightStatus) final;

--- a/src/MissionManager/VisualMissionItem.cc
+++ b/src/MissionManager/VisualMissionItem.cc
@@ -170,7 +170,7 @@ void VisualMissionItem::_updateTerrainAltitude(void)
         emit terrainQueryFailedChanged(_terrainQueryFailed);
     }
 
-    if (!_flyView && specifiesCoordinate() && coordinate().isValid()) {
+    if ((!_flyView || terrainAltitudeRequiredInFlyView()) && specifiesCoordinate() && coordinate().isValid()) {
         // We use a timer so that any additional requests before the timer fires result in only a single request
         _updateTerrainTimer.start();
     }

--- a/src/MissionManager/VisualMissionItem.h
+++ b/src/MissionManager/VisualMissionItem.h
@@ -185,6 +185,10 @@ public:
     /// GeoMap, or an empty string if this item type has none (the default).
     virtual QString geoMapVisualQML(void) const { return QString(); }
 
+    /// FlyView items normally skip terrain queries to save resources. Override to return true
+    /// when the item's AMSL altitude cannot be computed without the terrain height (e.g. terrain frame).
+    virtual bool terrainAltitudeRequiredInFlyView(void) const { return false; }
+
     /// Returns the mission items associated with the complex item. Caller is responsible for freeing.
     ///     @param items List to append to
     ///     @param missionItemParent Parent object for newly created MissionItems

--- a/src/QmlControls/TerrainProfile.cc
+++ b/src/QmlControls/TerrainProfile.cc
@@ -245,7 +245,11 @@ void TerrainProfile::_addFlightPoints(FlightPathSegment* segment, double current
 
     if (segment->segmentType() == FlightPathSegment::SegmentTypeTerrainFrame) {
         double terrainDistance = 0;
-        double distanceToSurface = segment->coord1AMSLAlt() - segment->amslTerrainHeights().first().value<double>();
+        const double totalDistance = segment->totalDistance();
+        const double beginDistanceToSurface =
+            segment->coord1AMSLAlt() - segment->amslTerrainHeights().first().value<double>();
+        const double endDistanceToSurface =
+            segment->coord2AMSLAlt() - segment->amslTerrainHeights().last().value<double>();
         for (int heightIndex=0; heightIndex<segment->amslTerrainHeights().count(); heightIndex++) {
             if (heightIndex == 0) {
                 // First point
@@ -255,6 +259,14 @@ void TerrainProfile::_addFlightPoints(FlightPathSegment* segment, double current
                 terrainDistance += segment->distanceBetween();
             }
 
+            // Terrain clearance ramps linearly from origin AGL to destination AGL (ArduPilot AC_WPNav terrain offset).
+            // The last sample is pinned to the destination clearance: accumulated sample distance can drift from
+            // totalDistance, and a zero-length leg would otherwise never reach it.
+            const bool lastSample = heightIndex == segment->amslTerrainHeights().count() - 1;
+            const double fraction =
+                lastSample ? 1.0 : (totalDistance > 0 ? qMin(terrainDistance / totalDistance, 1.0) : 0.0);
+            const double distanceToSurface =
+                beginDistanceToSurface + ((endDistanceToSurface - beginDistanceToSurface) * fraction);
             const double amslTerrainHeight = (segment->amslTerrainHeights()[heightIndex].value<double>() + distanceToSurface) * _verticalScale;
             points.append(QPointF((currentDistance + terrainDistance) * _horizontalScale, amslTerrainHeight));
         }

--- a/test/MissionManager/MissionControllerTest.cc
+++ b/test/MissionManager/MissionControllerTest.cc
@@ -492,12 +492,9 @@ void MissionControllerTest::_testFlightPathSegmentCacheReuse()
     QCOMPARE(settingsItem->simpleFlightPathSegment()->segmentType(), FlightPathSegment::SegmentTypeTakeoff);
     QCOMPARE(spacerItem->simpleFlightPathSegment()->segmentType(), FlightPathSegment::SegmentTypeGeneric);
 
-    // Change frames/command underneath the cached segments. Segment type is CONSTANT, so the
-    // next recalc must recreate these segments rather than reuse the stale-typed ones.
-    wp3->setAltitudeFrame(QGroundControlQmlGlobal::AltitudeFrameTerrain);
-    wp4->setAltitudeFrame(QGroundControlQmlGlobal::AltitudeFrameTerrain);
-    landWp->setCommand(MAV_CMD_NAV_LAND);
-
+    // Change frames/command underneath the cached segments. Segment type is CONSTANT, so these
+    // changes schedule a recalc that must recreate the affected segments rather than reuse the
+    // stale-typed ones, without needing any structural edit.
     FlightPathSegment* staleWp3Wp4 = wp3->simpleFlightPathSegment();
     FlightPathSegment* staleWp4Land = wp4->simpleFlightPathSegment();
     QVERIFY(staleWp3Wp4);
@@ -510,7 +507,28 @@ void MissionControllerTest::_testFlightPathSegmentCacheReuse()
     const quintptr staleWp3Wp4Ptr = quintptr(staleWp3Wp4);
     const quintptr staleWp4LandPtr = quintptr(staleWp4Land);
 
-    // Removing the spacer triggers a recalc: pairs whose computed type changed must be
+    wp3->setAltitudeFrame(QGroundControlQmlGlobal::AltitudeFrameTerrain);
+    wp4->setAltitudeFrame(QGroundControlQmlGlobal::AltitudeFrameTerrain);
+    landWp->setCommand(MAV_CMD_NAV_LAND);
+
+    QTRY_VERIFY_WITH_TIMEOUT(quintptr(wp3->simpleFlightPathSegment()) != staleWp3Wp4Ptr, TestTimeout::mediumMs());
+    QVERIFY(wp3->simpleFlightPathSegment());
+    QVERIFY(wp4->simpleFlightPathSegment());
+    QCOMPARE(wp3->simpleFlightPathSegment()->segmentType(), FlightPathSegment::SegmentTypeTerrainFrame);
+    // Land item as pair.second overrides the terrain frame of wp4
+    QVERIFY(quintptr(wp4->simpleFlightPathSegment()) != staleWp4LandPtr);
+    QCOMPARE(wp4->simpleFlightPathSegment()->segmentType(), FlightPathSegment::SegmentTypeLand);
+    // Terrain frame comes from the pair's destination item: wp3 is Terrain, so the spacer->wp3 leg is TerrainFrame
+    QVERIFY(spacerItem->simpleFlightPathSegment());
+    QCOMPARE(spacerItem->simpleFlightPathSegment()->segmentType(), FlightPathSegment::SegmentTypeTerrainFrame);
+    // Untouched pairs are reused as-is
+    QCOMPARE(quintptr(settingsItem->simpleFlightPathSegment()), preRecalcHomeTakeoffPtr);
+    QCOMPARE(settingsItem->simpleFlightPathSegment()->segmentType(), FlightPathSegment::SegmentTypeTakeoff);
+
+    const quintptr postFrameChangeWp3Ptr = quintptr(wp3->simpleFlightPathSegment());
+    const quintptr postFrameChangeWp4Ptr = quintptr(wp4->simpleFlightPathSegment());
+
+    // Removing the spacer triggers a structural recalc: pairs whose computed type changed must be
     // recreated with the new type, pairs whose type is unchanged must be reused.
     _missionController->removeVisualItem(2);
     QCOMPARE_TRUE_WAIT(segments->count(), 4, TestTimeout::mediumMs());
@@ -521,12 +539,11 @@ void MissionControllerTest::_testFlightPathSegmentCacheReuse()
     QVERIFY(wp4->simpleFlightPathSegment());
     QCOMPARE(quintptr(settingsItem->simpleFlightPathSegment()), preRecalcHomeTakeoffPtr);
     QCOMPARE(settingsItem->simpleFlightPathSegment()->segmentType(), FlightPathSegment::SegmentTypeTakeoff);
-    // Terrain frame comes from the pair's first item: takeoff item is Relative, so still Generic
-    QCOMPARE(takeoffItem->simpleFlightPathSegment()->segmentType(), FlightPathSegment::SegmentTypeGeneric);
-    QVERIFY(quintptr(wp3->simpleFlightPathSegment()) != staleWp3Wp4Ptr);
+    // The new takeoff->wp3 leg arrives at a terrain-frame item
+    QCOMPARE(takeoffItem->simpleFlightPathSegment()->segmentType(), FlightPathSegment::SegmentTypeTerrainFrame);
+    QCOMPARE(quintptr(wp3->simpleFlightPathSegment()), postFrameChangeWp3Ptr);
     QCOMPARE(wp3->simpleFlightPathSegment()->segmentType(), FlightPathSegment::SegmentTypeTerrainFrame);
-    // Land item as pair.second overrides the terrain frame of wp4
-    QVERIFY(quintptr(wp4->simpleFlightPathSegment()) != staleWp4LandPtr);
+    QCOMPARE(quintptr(wp4->simpleFlightPathSegment()), postFrameChangeWp4Ptr);
     QCOMPARE(wp4->simpleFlightPathSegment()->segmentType(), FlightPathSegment::SegmentTypeLand);
 
     const quintptr segHomeTakeoffPtr = quintptr(settingsItem->simpleFlightPathSegment());

--- a/test/MissionManager/SimpleMissionItemTest.cc
+++ b/test/MissionManager/SimpleMissionItemTest.cc
@@ -5,6 +5,7 @@
 #include <QtPositioning/QGeoCoordinate>
 
 #include "AppSettings.h"
+#include "BaseClasses/TerrainTest.h"
 #include "CameraSection.h"
 #include "MissionCommandTree.h"
 #include "MissionCommandUIInfo.h"
@@ -370,6 +371,40 @@ void SimpleMissionItemTest::_testCalcAboveTerrainSaveLoad()
     QCOMPARE(loadedItem.amslAltAboveTerrain()->rawValue().toDouble(), amslAlt);
     QCOMPARE(loadedItem.missionItem().frame(), MAV_FRAME_GLOBAL);
     QCOMPARE(loadedItem.missionItem().param7(), amslAlt);
+}
+
+void SimpleMissionItemTest::_testFlyViewTerrainQuery()
+{
+    // Regression test for VisualMissionItem::terrainAltitudeRequiredInFlyView: FlyView items
+    // normally skip terrain queries, but terrain-frame items need terrain altitude to compute
+    // their AMSL altitude (used by the 3D view and altitude displays).
+
+    const QGeoCoordinate terrainCoord = UnitTestTerrainData::flat10Region.center();
+    const double aboveTerrainAlt = 40.0;
+
+    // Items are constructed at (0,0); the terrain query is triggered by the coordinate change
+    // below, mirroring the FlyView mission download flow. The relative item is nudged first so
+    // that a wrongly issued query for it would have resolved by the time the terrain item's does.
+    MissionItem relativeMissionItem(1, MAV_CMD_NAV_WAYPOINT, MAV_FRAME_GLOBAL_RELATIVE_ALT, 0, 0, 0, 0, 0, 0,
+                                    aboveTerrainAlt,
+                                    true,    // autoContinue
+                                    false);  // isCurrentItem
+    SimpleMissionItem* relativeItem = new SimpleMissionItem(planController(), true /* flyView */, relativeMissionItem);
+    relativeItem->setCoordinate(terrainCoord);
+
+    MissionItem terrainMissionItem(2, MAV_CMD_NAV_WAYPOINT, MAV_FRAME_GLOBAL_TERRAIN_ALT, 0, 0, 0, 0, 0, 0,
+                                   aboveTerrainAlt,
+                                   true,    // autoContinue
+                                   false);  // isCurrentItem
+    SimpleMissionItem* terrainItem = new SimpleMissionItem(planController(), true /* flyView */, terrainMissionItem);
+    terrainItem->setCoordinate(terrainCoord);
+
+    QTRY_COMPARE_WITH_TIMEOUT(terrainItem->terrainAltitude(), UnitTestTerrainData::Flat10Region::amslElevation,
+                              TestTimeout::mediumMs());
+    QCOMPARE(terrainItem->amslEntryAlt(), UnitTestTerrainData::Flat10Region::amslElevation + aboveTerrainAlt);
+
+    // Non-terrain FlyView items must not have queried
+    QVERIFY(qIsNaN(relativeItem->terrainAltitude()));
 }
 
 UT_REGISTER_TEST(SimpleMissionItemTest, TestLabel::Unit, TestLabel::MissionManager)

--- a/test/MissionManager/SimpleMissionItemTest.h
+++ b/test/MissionManager/SimpleMissionItemTest.h
@@ -29,6 +29,7 @@ private slots:
     void _testSpeedSection();
     void _testAltitudePropogation();
     void _testCalcAboveTerrainSaveLoad();
+    void _testFlyViewTerrainQuery();
 
 private:
     void _testEditorFactsWorker(QGCMAVLinkTypes::VehicleClass_t vehicleClass, QGCMAVLinkTypes::VehicleClass_t vtolMode);


### PR DESCRIPTION
## Summary

Follow-up to #14956. Renders mission legs arriving at terrain-frame (`MAV_FRAME_GLOBAL_TERRAIN_ALT`) waypoints as terrain-following ribbons in the GeoMap 3D view, matching how ArduPilot actually flies them.

A leg is flown in its **destination** item's frame (ArduPilot AC_WPNav): legs arriving at a terrain-frame item ride the terrain profile with a linear AGL ramp from the origin's AGL to the destination's; all other legs remain straight lines in AMSL.

## Changes

- **GeoMapMissionPath.qml** — terrain-frame legs are draped over the same DEM the surface renders from, sampled every 50 m (capped at 200 samples/leg). The path re-drapes as elevation tiles stream in (`terrainHeightsChanged`), with `Qt.callLater` coalescing rebuild bursts. Endpoint AGL math cancels the DEM-vs-home-AMSL bias so the ribbon meets the waypoint markers exactly.
- **MissionController** — 2D flight path segments now key `mavlinkTerrainFrame` off the destination item instead of the origin, matching AC_WPNav semantics (affects the terrain-collision-check skip).
- **VisualMissionItem / SimpleMissionItem** — FlyView items normally skip terrain queries to save resources; a new `terrainAltitudeRequiredInFlyView()` virtual lets terrain-frame items opt in, fixing terrain-frame waypoints and legs rendering at NaN altitude (under the terrain) in the FlyView 3D map.

## Testing

- `MissionControllerTest` expectation updated for destination-frame keying; `MissionControllerTest` + `SimpleMissionItemTest` pass.
- Manually verified with ArduPilot terrain-frame missions over varying terrain: ribbon hugs terrain with AGL ramp, straight legs unaffected, ribbon refines as DEM tiles load, works in both PlanView-loaded and vehicle-downloaded (FlyView) missions.