### PR TITLE
fix(AppSettings): hide unavailable sections

### DIFF
--- a/src/QmlControls/AppSettings.qml
+++ b/src/QmlControls/AppSettings.qml
@@ -34,50 +34,47 @@ Rectangle {
         return !!_expandedPages[pageIndex]
     }
 
+    function _pageSections(entry) {
+        return entry && typeof entry.sections === "function" ? entry.sections() : []
+    }
+
+    function _pageAvailable(entry) {
+        if (!entry || entry.name === "Divider" ||
+                (typeof entry.pageVisible === "function" && !entry.pageVisible())) {
+            return false
+        }
+
+        var sections = _pageSections(entry)
+        return sections.length === 0 || sections.some(function(section) { return section.visible })
+    }
+
+    function _sectionAvailable(sections, sectionIndex) {
+        if (sectionIndex === -1) return true
+        for (var i = 0; i < sections.length; i++) {
+            if (sections[i].index === sectionIndex) return sections[i].visible
+        }
+        return false
+    }
+
     // Search: returns array of matching section indices for a page, or empty if no match
     function _matchingSections(pageIndex) {
         var query = _searchQuery.toLowerCase().trim()
         if (query === "") return []  // empty = no filtering
 
         var entry = settingsPagesModel.get(pageIndex)
-        if (!entry) return []
+        if (!_pageAvailable(entry)) return []
 
-        // Check English search terms
-        var termsStr = entry.searchTerms
+        var sections = _pageSections(entry)
         var matches = []
-        var matched = {}
-        if (termsStr && termsStr !== "") {
-            try {
-                var terms = JSON.parse(termsStr)
-                for (var i = 0; i < terms.length; i++) {
-                    if (terms[i].terms.indexOf(query) !== -1) {
-                        matched[terms[i].section] = true
-                        matches.push(terms[i].section)
-                    }
+        for (var i = 0; i < sections.length; i++) {
+            if (!sections[i].visible) continue
+            for (var j = 0; j < sections[i].searchTerms.length; j++) {
+                if (sections[i].searchTerms[j].indexOf(query) !== -1) {
+                    matches.push(sections[i].index)
+                    break
                 }
-            } catch(e) { console.warn("AppSettings: JSON parse error in searchTerms:", e) }
+            }
         }
-
-        // Check translatable terms (translated at runtime)
-        var trStr = entry.translatableTerms
-        if (trStr && trStr !== "") {
-            try {
-                var trTerms = JSON.parse(trStr)
-                for (var j = 0; j < trTerms.length; j++) {
-                    if (matched[trTerms[j].section]) continue
-                    var ctx = trTerms[j].context
-                    var tList = trTerms[j].terms
-                    for (var k = 0; k < tList.length; k++) {
-                        if (qsTranslate(ctx, tList[k]).toLowerCase().indexOf(query) !== -1) {
-                            matched[trTerms[j].section] = true
-                            matches.push(trTerms[j].section)
-                            break
-                        }
-                    }
-                }
-            } catch(e) { console.warn("AppSettings: JSON parse error in translatableTerms:", e) }
-        }
-
         return matches
     }
 
@@ -90,6 +87,8 @@ Rectangle {
     function _navigateTo(pageIndex, sectionIndex) {
         var entry = settingsPagesModel.get(pageIndex)
         if (!entry || entry.name === "Divider") return
+        if (!_pageAvailable(entry)) return
+        if (!_sectionAvailable(_pageSections(entry), sectionIndex)) return
 
         var url = entry.url
         _selectedSectionIndex = sectionIndex
@@ -103,6 +102,19 @@ Rectangle {
         if (rightPanel.item && typeof rightPanel.item.sectionFilter !== "undefined") {
             rightPanel.item.sectionFilter = sectionIndex
         }
+    }
+
+    function _navigateToFirstAvailablePage() {
+        for (var i = 0; i < settingsPagesModel.count; i++) {
+            if (_pageAvailable(settingsPagesModel.get(i))) {
+                _navigateTo(i, -1)
+                return
+            }
+        }
+
+        _selectedPageIndex = -1
+        _selectedSectionIndex = -1
+        rightPanel.source = ""
     }
 
     // settingsPage is the untranslated page name from SettingsPages.json
@@ -136,6 +148,10 @@ Rectangle {
                 _navigateTo(i, -1)
                 break
             }
+        }
+
+        if (_selectedPageIndex === -1) {
+            _navigateToFirstAvailablePage()
         }
     }
 
@@ -199,32 +215,34 @@ Rectangle {
                     property string pageUrl:     model.url ?? ""
                     property string pageIconUrl: model.iconUrl ?? ""
                     property var    pageVisible: model.pageVisible ?? function() { return true }
-                    property var    pageSections: {
-                        try {
-                            var trStr = model.translatableTerms
-                            if (trStr && trStr !== "") {
-                                var trTerms = JSON.parse(trStr)
-                                return trTerms.map(function(t) {
-                                    if (!t.terms || t.terms.length === 0) return ""
-                                    return qsTranslate(t.context, t.terms[0])
-                                }).filter(function(s) { return s !== "" })
-                            }
-                            var s = model.sections
-                            return (s && s !== "") ? JSON.parse(s) : []
-                        } catch(e) {
-                            console.warn("AppSettings: JSON parse error in pageSections:", e)
-                            return []
+                    property var    pageSections: pageVisible() ? settingsView._pageSections(model) : []
+                    property var    visiblePageSections: pageSections.filter(function(section) {
+                        return section.visible
+                    })
+                    property bool pageAvailable: pageVisible() &&
+                                                 (pageSections.length === 0 || visiblePageSections.length > 0)
+                    property bool isSelected: settingsView._selectedPageIndex === index
+                    property bool hasMultipleSections: visiblePageSections.length > 1
+                    property bool isSearching: settingsView._searchQuery.trim() !== ""
+                    property bool matchesSearch: pageAvailable && settingsView._pageMatchesSearch(index)
+                    property bool isExpanded: hasMultipleSections && (isSearching ? matchesSearch : settingsView._isExpanded(index))
+
+                    onPageSectionsChanged: {
+                        if (isSelected && pageAvailable &&
+                                !settingsView._sectionAvailable(pageSections, settingsView._selectedSectionIndex)) {
+                            settingsView._navigateTo(index, -1)
                         }
                     }
-                    property bool isSelected: settingsView._selectedPageIndex === index
-                    property bool hasMultipleSections: pageSections.length > 1
-                    property bool isSearching: settingsView._searchQuery.trim() !== ""
-                    property bool matchesSearch: settingsView._pageMatchesSearch(index)
-                    property bool isExpanded: hasMultipleSections && (isSearching ? matchesSearch : settingsView._isExpanded(index))
+
+                    onPageAvailableChanged: {
+                        if (isSelected && !pageAvailable) {
+                            settingsView._navigateToFirstAvailablePage()
+                        }
+                    }
 
                     visible: {
                         if (pageName === "Divider") return !isSearching
-                        if (!pageVisible()) return false
+                        if (!pageAvailable) return false
                         if (isSearching) return matchesSearch
                         return true
                     }
@@ -245,7 +263,7 @@ Rectangle {
                         expandable:    hasMultipleSections
                         expanded:      isExpanded
                         checked:       isSelected && settingsView._selectedSectionIndex === -1
-                        visible:       pageName !== "Divider" && pageVisible()
+                        visible:       pageName !== "Divider" && pageAvailable
 
                         onClicked: {
                             if (mainWindow.allowViewSwitch()) {
@@ -275,7 +293,7 @@ Rectangle {
 
                     // Section sub-items (indented, shown when page is expanded)
                     Repeater {
-                        model: isExpanded ? pageSections : []
+                        model: isExpanded ? visiblePageSections : []
 
                         Button {
                             id:             sectionBtn
@@ -284,21 +302,15 @@ Rectangle {
                             leftPadding:    ScreenTools.defaultFontPixelWidth * 3
                             hoverEnabled:   !ScreenTools.isMobile
 
-                            property int sectionIndex: index
+                            property int sectionIndex: modelData.index
                             property bool sectionChecked: pageColumn.isSelected && settingsView._selectedSectionIndex === sectionIndex
                             property bool sectionMatchesSearch: {
                                 if (!pageColumn.isSearching) return true
                                 var matches = settingsView._matchingSections(pageColumn.index)
                                 return matches.indexOf(sectionIndex) !== -1
                             }
-                            property bool sectionContentVisible: {
-                                if (!pageColumn.isSelected) return true
-                                if (!rightPanel.item) return true
-                                if (typeof rightPanel.item.sectionVisible !== "function") return true
-                                return rightPanel.item.sectionVisible(sectionIndex)
-                            }
                             property color textColor: sectionChecked || pressed ? qgcPal.buttonHighlightText : qgcPal.buttonText
-                            visible: sectionMatchesSearch && sectionContentVisible
+                            visible: sectionMatchesSearch
 
                             background: Rectangle {
                                 color:   qgcPal.buttonHighlight
@@ -307,7 +319,7 @@ Rectangle {
                             }
 
                             contentItem: QGCLabel {
-                                text:  modelData
+                                text:  modelData.name
                                 color: sectionBtn.textColor
                                 font.pointSize: ScreenTools.defaultFontPointSize * 0.9
                                 horizontalAlignment: Text.AlignLeft

--- a/test/QmlUITests/TopLevelViewsTest.cc
+++ b/test/QmlUITests/TopLevelViewsTest.cc
@@ -1,13 +1,35 @@
 #include "TopLevelViewsTest.h"
 
+#include <QtCore/QScopeGuard>
 #include <QtQuick/QQuickItem>
 #include <QtQuick/QQuickWindow>
 #include <QtTest/QTest>
+
+#include "Fact.h"
+#include "SettingsManager.h"
+#include "VideoSettings.h"
 
 UT_REGISTER_TEST(TopLevelViewsTest, TestLabel::Integration)
 
 // This test assumes Advanced UI mode is enabled (the default). All views including
 // Analyze are expected to be visible.
+
+static QQuickItem* findVisibleSectionButton(QQuickItem* root, int sectionIndex)
+{
+    if (!root || !root->isVisible()) {
+        return nullptr;
+    }
+    if (root->property("sectionIndex").isValid() && root->property("sectionIndex").toInt() == sectionIndex) {
+        return root;
+    }
+    const auto children = root->childItems();
+    for (auto* child : children) {
+        if (auto* found = findVisibleSectionButton(child, sectionIndex)) {
+            return found;
+        }
+    }
+    return nullptr;
+}
 
 void TopLevelViewsTest::_testNavigateViews()
 {
@@ -79,4 +101,43 @@ void TopLevelViewsTest::_testNavigateViews()
     }
 
     stopUI();
+}
+
+void TopLevelViewsTest::_testSettingsSectionVisibility()
+{
+    startUI();
+    if (QTest::currentTestFailed()) return;
+
+    constexpr int videoSettingsSectionIndex = 2;
+
+    Fact* const videoSource = SettingsManager::instance()->videoSettings()->videoSource();
+    const QVariant savedVideoSource = videoSource->rawValue();
+    const auto restoreVideoSource = qScopeGuard([videoSource, savedVideoSource] {
+        videoSource->setRawValue(savedVideoSource);
+    });
+    videoSource->setRawValue(QString::fromLatin1(VideoSettings::videoSourceRTSP));
+
+    QVERIFY(clickToolSelectDropdownButton(QStringLiteral("toolbar_viewSettings")));
+
+    QQuickItem* const videoButton = findVisibleItem(_rootItem, QStringLiteral("settingsButton_Video"));
+    QVERIFY(videoButton);
+    QVERIFY(scrollIntoView(videoButton, QStringLiteral("settings_buttonList")));
+    const QPointF videoCenter = videoButton->mapToScene(QPointF(videoButton->width() / 2, videoButton->height() / 2));
+    QTest::mouseClick(_window, Qt::LeftButton, Qt::NoModifier, videoCenter.toPoint());
+
+    QQuickItem* const videoPage = findVisibleItem(_rootItem, QStringLiteral("settingsPage_Video"));
+    QVERIFY(videoPage);
+    QQuickItem* videoSection = nullptr;
+    QTRY_VERIFY((videoSection = findVisibleSectionButton(videoButton->parentItem(), videoSettingsSectionIndex)));
+    const QPointF sectionCenter = videoSection->mapToScene(QPointF(videoSection->width() / 2, videoSection->height() / 2));
+    QTest::mouseClick(_window, Qt::LeftButton, Qt::NoModifier, sectionCenter.toPoint());
+
+    QVERIFY(findVisibleItem(_rootItem, QStringLiteral("settingsGroup_Settings")));
+
+    videoSource->setRawValue(QString::fromLatin1(VideoSettings::videoDisabled));
+
+    QTRY_VERIFY(!findVisibleSectionButton(videoButton->parentItem(), videoSettingsSectionIndex));
+    QTRY_VERIFY(!findVisibleItem(_rootItem, QStringLiteral("settingsGroup_Settings"), 0));
+    QTRY_VERIFY(findVisibleItem(_rootItem, QStringLiteral("settingsGroup_VideoSource")));
+    QVERIFY(findVisibleItem(_rootItem, QStringLiteral("settingsPage_Video")));
 }

--- a/test/QmlUITests/TopLevelViewsTest.h
+++ b/test/QmlUITests/TopLevelViewsTest.h
@@ -16,4 +16,5 @@ public:
 
 private slots:
     void _testNavigateViews();
+    void _testSettingsSectionVisibility();
 };

--- a/tools/generators/settings_qml/emit.py
+++ b/tools/generators/settings_qml/emit.py
@@ -188,6 +188,20 @@ def _group_auto_vis(grp) -> str:
     return " || ".join(f"{ref}.userVisible" for ref in fact_refs)
 
 
+def _group_visibility_parts(grp) -> list[str]:
+    vis_parts: list[str] = []
+    if grp.showWhen:
+        vis_parts.append(f"({grp.showWhen})")
+    auto_vis = _group_auto_vis(grp)
+    if auto_vis:
+        vis_parts.append(f"({auto_vis})")
+    return vis_parts
+
+
+def _qml_translate(context: str, text: str) -> str:
+    return f"qsTranslate({json.dumps(context)}, {json.dumps(text)})"
+
+
 def generate_page_qml(
     page: PageDef, settings_dir: Path, json_context: str = "", page_name: str = ""
 ) -> str:
@@ -203,28 +217,11 @@ def generate_page_qml(
         for name, expr in page.bindings.items()
     ]
 
-    section_cases: list[dict] = []
-    for grp_idx, grp in enumerate(page.groups):
-        vis_parts: list[str] = []
-        if grp.showWhen:
-            vis_parts.append(f"({grp.showWhen})")
-        auto_vis = _group_auto_vis(grp)
-        if auto_vis:
-            vis_parts.append(f"({auto_vis})")
-        if vis_parts:
-            section_cases.append({"idx": grp_idx, "expr": " && ".join(vis_parts)})
-
     group_blocks: list[str] = []
     seen_object_names: dict[str, str] = {}  # objectName -> heading that produced it
     for grp_idx, grp in enumerate(page.groups):
         section_vis = f"(sectionFilter === -1 || sectionFilter === {grp_idx})"
-        vis_parts = [section_vis]
-        if grp.showWhen:
-            vis_parts.append(f"({grp.showWhen})")
-        auto_vis = _group_auto_vis(grp)
-        if auto_vis:
-            vis_parts.append(f"({auto_vis})")
-        visible_expr = " && ".join(vis_parts)
+        visible_expr = " && ".join([section_vis, *_group_visibility_parts(grp)])
 
         if grp.component:
             group_blocks.append(_env.get_template("group_component.qml.j2").render(
@@ -276,7 +273,6 @@ def generate_page_qml(
         object_name=page_object_name,
         has_string_fields=_needs_string_field_width(page, settings_dir),
         bindings=bindings,
-        section_cases=section_cases,
         groups=group_blocks,
     ) + "\n"
 
@@ -296,6 +292,7 @@ def generate_pages_model_qml(pages_json_path: Path) -> str:
 
     pages_dir = pages_json_path.parent
     entries: list[dict] = []
+    imports: list[str] = []
 
     for entry in require_list(data.get("pages", []), "'pages'", pages_json_path):
         reject_unknown_keys(entry, _ALLOWED_PAGE_ENTRY_KEYS, "page entry", pages_json_path)
@@ -310,32 +307,49 @@ def generate_pages_model_qml(pages_json_path: Path) -> str:
             pages_json_path,
         )
 
-        sections: list[str] = []
-        search_terms: list[dict] = []
-        translatable_terms: list[dict] = []
+        sections: list[dict] = []
+        section_bindings: list[dict] = []
+        section_state_name = ""
         page_def_name = entry.get("pageDefinition")
         if page_def_name:
             page_def_path = pages_dir / page_def_name
             if page_def_path.exists():
                 page_def = load_page_def(page_def_path)
+                if page_def.bindings or any(group.showWhen for group in page_def.groups):
+                    imports.extend(
+                        page_import for page_import in page_def.imports if page_import not in imports
+                    )
+                section_bindings = [
+                    {
+                        "type": _binding_qml_type(expr),
+                        "name": name,
+                        "expr": expr,
+                    }
+                    for name, expr in page_def.bindings.items()
+                ]
+                if section_bindings:
+                    section_state_name = f"_page{len(entries)}SectionState"
                 for grp_idx, grp in enumerate(page_def.groups):
                     section_name = grp.display_name
-                    sections.append(section_name)
+                    vis_parts = _group_visibility_parts(grp)
+                    visible = " && ".join(vis_parts) if vis_parts else "true"
 
                     terms_parts = [name.lower(), section_name.lower()]
                     terms_parts.extend(kw.lower() for kw in grp.keywords)
                     terms_parts.extend(c.label.lower() for c in grp.controls if c.label)
-                    search_terms.append({
-                        "section": grp_idx,
-                        "terms": " ".join(dict.fromkeys(terms_parts)),
-                    })
-
                     tr_parts: list[str] = [section_name, *grp.keywords]
                     tr_parts.extend(c.label for c in grp.controls if c.label)
-                    translatable_terms.append({
-                        "section": grp_idx,
-                        "context": page_def_name,
-                        "terms": list(dict.fromkeys(tr_parts)),
+                    search_terms = [json.dumps(" ".join(dict.fromkeys(terms_parts)))]
+                    search_terms.extend(
+                        f"{_qml_translate(page_def_name, term)}.toLowerCase()"
+                        for term in dict.fromkeys(tr_parts)
+                    )
+
+                    sections.append({
+                        "index": grp_idx,
+                        "name": _qml_translate(page_def_name, section_name),
+                        "search_terms": f'[{", ".join(search_terms)}]',
+                        "visible": visible,
                     })
 
         entries.append({
@@ -343,10 +357,13 @@ def generate_pages_model_qml(pages_json_path: Path) -> str:
             "name": name,
             "url": url,
             "icon": require_qml_safe_string(entry["icon"], "page icon", pages_json_path),
-            "sections_json": json.dumps(sections).replace("'", "\\'"),
-            "search_json": json.dumps(search_terms).replace("'", "\\'"),
-            "translatable_json": json.dumps(translatable_terms).replace("'", "\\'"),
+            "sections": sections,
+            "section_bindings": section_bindings,
+            "section_state_name": section_state_name,
             "visible": entry.get("visible", ""),
         })
 
-    return _env.get_template("pages_model.qml.j2").render(entries=entries) + "\n"
+    return _env.get_template("pages_model.qml.j2").render(
+        entries=entries,
+        imports=imports,
+    ) + "\n"

--- a/tools/generators/settings_qml/templates/page.qml.j2
+++ b/tools/generators/settings_qml/templates/page.qml.j2
@@ -20,17 +20,6 @@ SettingsPage {
     property {{ b.type }} {{ b.name }}: {{ b.expr }}
 {% endfor %}
 
-{% if section_cases %}
-    function sectionVisible(index) {
-        switch (index) {
-{% for case in section_cases %}
-        case {{ case.idx }}: return {{ case.expr }}
-{% endfor %}
-        default: return true
-        }
-    }
-
-{% endif %}
 {% for group_qml in groups %}
 {{ group_qml }}
 {% if not loop.last %}

--- a/tools/generators/settings_qml/templates/pages_model.qml.j2
+++ b/tools/generators/settings_qml/templates/pages_model.qml.j2
@@ -1,9 +1,26 @@
 import QtQml.Models
+import QtQml
 
 import QGroundControl
 import QGroundControl.Controls
+{% for imp in imports %}
+import {{ imp }}
+{% endfor %}
 
 ListModel {
+{% for entry in entries if not entry.divider and entry.section_bindings %}
+    property QtObject {{ entry.section_state_name }}: QtObject {
+{% for binding in entry.section_bindings %}
+        property {{ binding.type }} {{ binding.name }}: {{ binding.expr }}
+{% endfor %}
+        property var _sectionVisibility: [
+{% for section in entry.sections %}
+            {{ section.visible }}{{ "," if not loop.last else "" }}
+{% endfor %}
+        ]
+    }
+
+{% endfor %}
 {% for entry in entries %}
 
 {% if entry.divider %}
@@ -16,9 +33,22 @@ ListModel {
         nameKey: "{{ entry.name }}"
         url: "{{ entry.url }}"
         iconUrl: "{{ entry.icon }}"
-        sections: '{{ entry.sections_json }}'
-        searchTerms: '{{ entry.search_json }}'
-        translatableTerms: '{{ entry.translatable_json }}'
+        sections: function() {
+            return [
+{% for section in entry.sections %}
+                {
+                    index: {{ section.index }},
+                    name: {{ section.name }},
+                    searchTerms: {{ section.search_terms }},
+{% if entry.section_state_name %}
+                    visible: {{ entry.section_state_name }}._sectionVisibility[{{ loop.index0 }}]
+{% else %}
+                    visible: {{ section.visible }}
+{% endif %}
+                }{{ "," if not loop.last else "" }}
+{% endfor %}
+            ]
+        }
 {% if entry.visible %}
         pageVisible: function() { return {{ entry.visible }} }
 {% else %}

--- a/tools/tests/test_settings_qml_generator.py
+++ b/tools/tests/test_settings_qml_generator.py
@@ -996,9 +996,24 @@ class TestGeneratePagesModelQml:
         # Page definition
         page_def = {
             "version": 1,
+            "imports": ["Test.Settings"],
+            "bindings": {
+                "pageVisible": "advancedMode && !unusedBinding",
+                "advancedMode": "QGroundControl.corePlugin.showAdvancedUI",
+                "unusedBinding": "QGroundControl.settingsManager.appSettings.y.userVisible",
+            },
             "groups": [
-                {"heading": "Section A", "controls": [{"setting": "appSettings.x"}]},
+                {
+                    "heading": "Section A",
+                    "showWhen": "pageVisible",
+                    "controls": [{"setting": "appSettings.x"}],
+                },
                 {"heading": "Section B", "controls": [{"setting": "appSettings.y"}]},
+                {
+                    "component": "TestComponent",
+                    "sectionName": "Section C",
+                    "showWhen": "advancedMode",
+                },
             ],
         }
         (pages_dir / "Test.SettingsUI.json").write_text(json.dumps(page_def), encoding="utf-8")
@@ -1051,12 +1066,32 @@ class TestGeneratePagesModelQml:
 
     def test_sections_extracted(self, pages_setup: Path):
         qml = generate_pages_model_qml(pages_setup)
-        assert "Section A" in qml
-        assert "Section B" in qml
+        assert 'name: qsTranslate("Test.SettingsUI.json", "Section A")' in qml
+        assert 'name: qsTranslate("Test.SettingsUI.json", "Section B")' in qml
+
+    def test_section_visibility_generated(self, pages_setup: Path):
+        qml = generate_pages_model_qml(pages_setup)
+        assert "sections: function()" in qml
+        assert "property QtObject _page0SectionState: QtObject" in qml
+        assert "property var advancedMode: QGroundControl.corePlugin.showAdvancedUI" in qml
+        assert "property bool pageVisible: advancedMode && !unusedBinding" in qml
+        assert "property var unusedBinding: QGroundControl.settingsManager.appSettings.y.userVisible" in qml
+        assert "visible: _page0SectionState._sectionVisibility[0]" in qml
+        assert (
+            "(pageVisible) && "
+            "(QGroundControl.settingsManager.appSettings.x.userVisible)" in qml
+        )
+        assert "(QGroundControl.settingsManager.appSettings.y.userVisible)" in qml
+        assert "visible: _page0SectionState._sectionVisibility[2]" in qml
 
     def test_search_terms_present(self, pages_setup: Path):
         qml = generate_pages_model_qml(pages_setup)
-        assert "searchTerms" in qml
+        assert 'searchTerms: ["test page section a"' in qml
+        assert 'qsTranslate("Test.SettingsUI.json", "Section A")' in qml
+
+    def test_page_imports_propagated(self, pages_setup: Path):
+        qml = generate_pages_model_qml(pages_setup)
+        assert "import Test.Settings" in qml
 
     def test_page_visible_default(self, pages_setup: Path):
         qml = generate_pages_model_qml(pages_setup)
@@ -1242,37 +1277,6 @@ class TestQmlUnsafeStringRejection:
         }
         page = load_page_def(_make_page_json(tmp_path, data))
         assert page.groups[0].heading == "Fly View (What's Shown)"
-
-    def test_apostrophe_heading_escaped_in_pages_model(self, tmp_path: Path):
-        # sections is emitted inside a single-quoted QML literal, so apostrophes
-        # in headings must be escaped like the other JSON fields
-        page_def = {
-            "version": 1,
-            "groups": [
-                {
-                    "heading": "Fly View (What's Shown)",
-                    "controls": [{"setting": "appSettings.x"}],
-                }
-            ],
-        }
-        (tmp_path / "Test.SettingsUI.json").write_text(json.dumps(page_def), encoding="utf-8")
-        pages_json = {
-            "version": 1,
-            "pages": [
-                {
-                    "name": "Test",
-                    "qml": "T.qml",
-                    "icon": "qrc:/i.svg",
-                    "pageDefinition": "Test.SettingsUI.json",
-                }
-            ],
-        }
-        p = tmp_path / "SettingsPages.json"
-        p.write_text(json.dumps(pages_json), encoding="utf-8")
-        qml = generate_pages_model_qml(p)
-        assert "What\\'s Shown" in qml
-        assert "What's Shown" not in qml
-
 
 class TestRealPageDefinitions:
     """Test against real QGC page definition files if available."""


### PR DESCRIPTION
## Description
Moves section metadata and visibility into SettingsPagesModel, allowing the navigation tree to use the same visibility state as the settings page before it is loaded.

Key changes:
- Fixes hidden sections reappearing after another page is selected.
- Removes redundant child navigation when only one section is available.
- Prevents search or direct navigation from selecting unavailable content.
- Selects the first available page when the current page becomes unavailable.

## Type of Change
- [X] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] CI/Build changes
- [ ] Other

## Testing
- [X] Tested locally
- [ ] Added/updated unit tests
- [ ] Tested with simulator (SITL)
- [ ] Tested with hardware

### Platforms Tested
- [ ] Linux
- [X] Windows
- [ ] macOS
- [X] Android
- [ ] iOS

## Checklist
- [X] I have read the [Contribution Guidelines](CONTRIBUTING.md)
- [X] I have read the [Code of Conduct](CODE_OF_CONDUCT.md)
- [X] My code follows the project's coding standards
- [X] I have added tests that prove my fix/feature works
- [X] New and existing unit tests pass locally

## Related Issues
Fixes #14898.

---
By submitting this pull request, I confirm that my contribution is made under the terms of the project's dual license (Apache 2.0 and GPL v3).
