### PR TITLE
fix(Joystick): match actual update rate to setting (Stable_V5.1)

### DIFF
--- a/src/Joystick/Joystick.cc
+++ b/src/Joystick/Joystick.cc
@@ -935,7 +935,7 @@ uint16_t Joystick::_adjustRangeToRcOverridePwm(int value, const AxisCalibration_
 void Joystick::_handleAxis()
 {
     const int axisDelay = static_cast<int>(1000.0 / _joystickSettings.axisFrequencyHz()->rawValue().toDouble());
-    if (_axisElapsedTimer.elapsed() <= axisDelay) {
+    if (!_axisUpdateDue(_axisElapsedTimer.elapsed(), axisDelay)) {
         return;
     }
 

--- a/src/Joystick/Joystick.h
+++ b/src/Joystick/Joystick.h
@@ -448,6 +448,8 @@ private:
     void _addAvailableButtonActionIfMissing(const QString &action);
     bool _validAxis(int axis) const;
     bool _validButton(int button) const;
+
+    static constexpr bool _axisUpdateDue(qint64 elapsed, int delay) { return elapsed >= delay; }
     void _handleAxis();
     void _handleButtons();
     void _buildAvailableButtonsActionList(Vehicle *vehicle);

--- a/test/Joystick/JoystickTest.cc
+++ b/test/Joystick/JoystickTest.cc
@@ -186,6 +186,13 @@ void JoystickTest::_axisRangeTest()
     QVERIFY(js != nullptr);
 }
 
+void JoystickTest::_axisUpdateDueTest()
+{
+    QVERIFY(!Joystick::_axisUpdateDue(39, 40));
+    QVERIFY(Joystick::_axisUpdateDue(40, 40));
+    QVERIFY(Joystick::_axisUpdateDue(41, 40));
+}
+
 //-----------------------------------------------------------------------------
 // Button Tests
 //-----------------------------------------------------------------------------

--- a/test/Joystick/JoystickTest.h
+++ b/test/Joystick/JoystickTest.h
@@ -34,6 +34,7 @@ private slots:
     // Axis reading tests
     void _readAxisValuesTest();
     void _axisRangeTest();
+    void _axisUpdateDueTest();
 
     // Button reading tests
     void _readButtonStatesTest();


### PR DESCRIPTION
Stable backport of #14797.

Cherry-pick of e9012e3f77d378598860697e80d748386a1103c7 (clean, no conflicts).

Fixes an off-by-one in the joystick axis rate limiter: `_handleAxis()` rejected updates when elapsed time was exactly equal to the configured interval (`<=` instead of `>=`), causing the actual axis update rate to fall below the configured Axis frequency. Includes the boundary regression test.
