### PR TITLE
fix(UI): correct misleading PX4 tuning and video setting labels

### DIFF
--- a/src/AutoPilotPlugins/PX4/PX4TuningComponentPlaneAll.qml
+++ b/src/AutoPilotPlugins/PX4/PX4TuningComponentPlaneAll.qml
@@ -12,7 +12,7 @@ PX4TuningComponent {
             tuningPage: "PX4TuningComponentPlaneRate.qml"
         }
         ListElement {
-            buttonText: qsTr("Rate Controller")
+            buttonText: qsTr("Attitude Controller")
             tuningPage: "PX4TuningComponentPlaneAttitude.qml"
         }
     }

--- a/src/AutoPilotPlugins/PX4/PX4TuningComponentPlaneRate.qml
+++ b/src/AutoPilotPlugins/PX4/PX4TuningComponentPlaneRate.qml
@@ -23,8 +23,8 @@ ColumnLayout {
             ]
             property var params: ListModel {
                 ListElement {
-                    title:          qsTr("Porportional gain (FW_RR_P)")
-                    description:    qsTr("Porportional gain.")
+                    title:          qsTr("Proportional gain (FW_RR_P)")
+                    description:    qsTr("Proportional gain.")
                     param:          "FW_RR_P"
                     min:            0.0
                     max:            1
@@ -48,7 +48,7 @@ ColumnLayout {
                 }
                 ListElement {
                     title:          qsTr("Feedforward Gain (FW_RR_FF)")
-                    description:    qsTr("Feedforward gused to compensate for aerodynamic damping.")
+                    description:    qsTr("Feedforward used to compensate for aerodynamic damping.")
                     param:          "FW_RR_FF"
                     min:            0.0
                     max:            10.0
@@ -64,8 +64,8 @@ ColumnLayout {
             ]
             property var params: ListModel {
                 ListElement {
-                    title:          qsTr("Porportional Gain (FW_PR_P)")
-                    description:    qsTr("Porportional Gain.")
+                    title:          qsTr("Proportional Gain (FW_PR_P)")
+                    description:    qsTr("Proportional Gain.")
                     param:          "FW_PR_P"
                     min:            0.0
                     max:            1
@@ -89,7 +89,7 @@ ColumnLayout {
                 }
                 ListElement {
                     title:          qsTr("Feedforward Gain (FW_PR_FF)")
-                    description:    qsTr("Feedforward gused to compensate for aerodynamic damping.")
+                    description:    qsTr("Feedforward used to compensate for aerodynamic damping.")
                     param:          "FW_PR_FF"
                     min:            0.0
                     max:            10.0
@@ -105,16 +105,16 @@ ColumnLayout {
             ]
             property var params: ListModel {
                 ListElement {
-                    title:          qsTr("Porportional Gain (FW_YR_P)")
-                    description:    qsTr("Porportional Gain.")
+                    title:          qsTr("Proportional Gain (FW_YR_P)")
+                    description:    qsTr("Proportional Gain.")
                     param:          "FW_YR_P"
                     min:            0.0
                     max:            1
                     step:           0.005
                 }
                 ListElement {
-                    title:          qsTr("Integral Gain (FW_YR_D)")
-                    description:    qsTr("Generally does not need much adjustment, reduce this when seeing slow oscillations.")
+                    title:          qsTr("Differential Gain (FW_YR_D)")
+                    description:    qsTr("Damping: increase to reduce overshoots and oscillations, but not higher than really needed.")
                     param:          "FW_YR_D"
                     min:            0.0
                     max:            1.0
@@ -130,7 +130,7 @@ ColumnLayout {
                 }
                 ListElement {
                     title:          qsTr("Feedforward Gain (FW_YR_FF)")
-                    description:    qsTr("Feedforward gused to compensate for aerodynamic damping.")
+                    description:    qsTr("Feedforward used to compensate for aerodynamic damping.")
                     param:          "FW_YR_FF"
                     min:            0.0
                     max:            10.0

--- a/src/Settings/Video.SettingsGroup.json
+++ b/src/Settings/Video.SettingsGroup.json
@@ -136,10 +136,10 @@
         {
             "name": "disableWhenDisarmed",
             "shortDesc": "Disables the video stream when the vehicle is disarmed to save bandwidth.",
-            "longDesc": "Disable Video Stream when disarmed.",
+            "longDesc": "Disables the video stream when the vehicle is disarmed.",
             "type": "bool",
             "default": false,
-            "label": "Stop recording when disarmed",
+            "label": "Disable Video Stream When Disarmed",
             "keywords": "disable when disarmed"
         },
         {


### PR DESCRIPTION
Backports the user-error-prone label fixes from #14847 to Stable_V5.1. Text-only, no runtime behavior change; translation files intentionally untouched (Crowdin workflow).

- PX4 fixed-wing tuning: the second tuning button was labeled "Rate Controller" but loads the Attitude page — now "Attitude Controller"
- FW_YR_D was labeled "Integral Gain" with integral-tuning guidance — now "Differential Gain" with the damping description matching the roll/pitch D-gain entries
- Fixed "Porportional" and "Feedforward gused" typos in the same tuning page
- Video setting `disableWhenDisarmed` was labeled "Stop recording when disarmed" but it disables the video stream — label and longDesc now say so
