### PR TITLE
fix(docs): Add v5.1 site title

### DIFF
--- a/docs/.vitepress/config.mjs
+++ b/docs/.vitepress/config.mjs
@@ -3,7 +3,7 @@ import { defineConfig } from "vitepress";
 
 // https://vitepress.dev/reference/site-config
 export default defineConfig({
-  title: "QGC Guide",
+  title: "QGC Guide (5.1)",
   description:
     "How to use and develop QGroundControl for PX4 or ArduPilot powered vehicles.",
   ignoreDeadLinks: true, // Do this for stable, where we don't yet have all translations


### PR DESCRIPTION
Adds a version number to the guide. You can see this is v4.4 but it seems to have been missed in this build.

<img width="926" height="368" alt="image" src="https://github.com/user-attachments/assets/4671f21d-4851-4e40-9852-245912d1568c" />
