### PR TITLE
fix(Video): parse elementary streams before recording

### DIFF
--- a/cmake/GStreamer/PluginPolicy.cmake
+++ b/cmake/GStreamer/PluginPolicy.cmake
@@ -28,7 +28,19 @@ set(GSTREAMER_PLUGIN_ALTERNATES
 # multifile (splitmuxsink), isomp4 (qtmux/mp4mux), and matroska (matroskamux)
 # are load-bearing for video recording (GstVideoReceiver _kFileMux).
 set(GSTREAMER_RUNTIME_REQUIRED_PLUGINS
-    coreelements isomp4 matroska multifile opengl playback rtsp rtp rtpmanager tcp udp videoconvertscale
+    coreelements
+    isomp4
+    matroska
+    multifile
+    opengl
+    playback
+    rtsp
+    rtp
+    rtpmanager
+    tcp
+    udp
+    videoparsersbad
+    videoconvertscale
 )
 
 # iOS xcframework: plugins whose dependent static libs aren't bundled in the

--- a/cmake/GStreamer/tests/test_plugin_policy.cmake
+++ b/cmake/GStreamer/tests/test_plugin_policy.cmake
@@ -79,7 +79,20 @@ qgc_test_assert_in_list("partial: x264enc retained"           x264enc           
 qgc_test_pass("filter_alternates partial-pair unsatisfied")
 
 gstreamer_runtime_required_plugins(_required)
-foreach(_p IN ITEMS coreelements isomp4 matroska multifile opengl playback rtsp rtp rtpmanager tcp udp videoconvertscale)
+foreach(_p IN ITEMS
+        coreelements
+        isomp4
+        matroska
+        multifile
+        opengl
+        playback
+        rtsp
+        rtp
+        rtpmanager
+        tcp
+        udp
+        videoparsersbad
+        videoconvertscale)
     qgc_test_assert_in_list("runtime required: ${_p}" "${_p}" _required)
 endforeach()
 qgc_test_assert_not_in_list("runtime required: openh264 is optional codec implementation" openh264 _required)

--- a/src/VideoManager/VideoReceiver/GStreamer/GStreamer.cc
+++ b/src/VideoManager/VideoReceiver/GStreamer/GStreamer.cc
@@ -119,9 +119,9 @@ bool _verifyPlugins()
     };
     // Mirrors GSTREAMER_RUNTIME_REQUIRED_PLUGINS (PluginPolicy.cmake) plus qgc,
     // so a stripped registry fails loudly instead of at first stream attempt.
-    static constexpr std::array<const char*, 12> kRequiredPlugins = {
-        "qgc", "coreelements", "isomp4", "matroska", "multifile", "opengl",
-        "playback", "rtp", "rtpmanager", "rtsp", "tcp", "udp",
+    static constexpr std::array<const char*, 13> kRequiredPlugins = {
+        "qgc", "coreelements", "isomp4", "matroska", "multifile", "opengl",          "playback",
+        "rtp", "rtpmanager",   "rtsp",   "tcp",      "udp",       "videoparsersbad",
     };
     for (const char* name : kRequiredPlugins) {
         if (!hasPlugin(name)) {

--- a/src/VideoManager/VideoReceiver/GStreamer/GstSourceFactory.cc
+++ b/src/VideoManager/VideoReceiver/GStreamer/GstSourceFactory.cc
@@ -16,6 +16,28 @@ constexpr guint64 kRtspTcpTimeoutUs = G_GUINT64_CONSTANT(5000000);
 constexpr int kRtspRetry = 3;
 constexpr int kUdpBufferSizeBytes = 8 * 1024 * 1024;
 
+void configureH26xParser(GstElement* element)
+{
+    GstElementFactory* factory = gst_element_get_factory(element);
+    if (!factory) {
+        return;
+    }
+
+    const char* factoryName = gst_plugin_feature_get_name(GST_PLUGIN_FEATURE(factory));
+    if ((g_strcmp0(factoryName, "h264parse") == 0) || (g_strcmp0(factoryName, "h265parse") == 0)) {
+        // Recording can begin long after RTSP setup. Repeat codec parameter sets at every IDR so
+        // the late-opened recording branch can construct MP4/MOV codec_data without relying on
+        // the camera to resend its startup-only VPS/SPS/PPS or SPS/PPS.
+        g_object_set(element, "config-interval", -1, nullptr);
+    }
+}
+
+void configureAutopluggedParser([[maybe_unused]] GstBin* bin, [[maybe_unused]] GstBin* subBin, GstElement* element,
+                                [[maybe_unused]] gpointer data)
+{
+    configureH26xParser(element);
+}
+
 // Older Linux/system GStreamer needs an autoplug-query caps filter to keep parsebin on byte-stream output.
 #if defined(QGC_GST_ENABLE_LEGACY_PARSEBIN_CAPS_FILTER)
 gboolean filterParserCaps([[maybe_unused]] GstElement* bin, [[maybe_unused]] GstPad* pad,
@@ -552,7 +574,11 @@ GstElement* create(const QString& uri, const Config& config)
                 qCCritical(GstSourceFactoryLog) << "gst_element_factory_make('rtph265depay') failed";
                 break;
             }
-            g_object_set(parser, "config-interval", -1, nullptr);
+            configureH26xParser(parser);
+        } else {
+            // parsebin creates the codec parser only after it sees the stream caps. Configure that
+            // parser as soon as it is autoplugged, before the pipeline reaches PLAYING.
+            (void) g_signal_connect(parser, "deep-element-added", G_CALLBACK(configureAutopluggedParser), nullptr);
         }
 
         // Older Linux/system GStreamer misnegotiates parser->decoder caps; force avc/hvc1 there only.

--- a/src/VideoManager/VideoReceiver/GStreamer/GstVideoReceiver.cc
+++ b/src/VideoManager/VideoReceiver/GStreamer/GstVideoReceiver.cc
@@ -202,6 +202,9 @@ void GstVideoReceiver::start(uint32_t timeout)
         g_object_set(_recorderValve,
                      "drop", TRUE,
                      nullptr);
+        // Preserve stream-start/caps/segment events while buffers are dropped. When recording
+        // starts later, the newly linked parser receives the negotiated codec configuration.
+        gst_util_set_object_arg(G_OBJECT(_recorderValve), "drop-mode", "forward-sticky-events");
 
         _pipeline = gst_pipeline_new("receiver");
         if (!_pipeline) {
@@ -581,6 +584,9 @@ void GstVideoReceiver::startRecording(const QString &videoFile, FILE_FORMAT form
         gst_clear_object(&probepad);
         if (_fileSink) {
             (void) gst_element_set_state(_fileSink, GST_STATE_NULL);
+            // Safe before and after a successful link. Removing a still-linked bin leaves the
+            // valve's src pad attached to a finalized peer and breaks every later retry.
+            gst_element_unlink(_recorderValve, _fileSink);
             GstObject* parent = gst_element_get_parent(_fileSink);
             if (parent) {
                 (void) gst_bin_remove(GST_BIN(parent), _fileSink);
@@ -591,9 +597,12 @@ void GstVideoReceiver::startRecording(const QString &videoFile, FILE_FORMAT form
         emit onStartRecordingComplete(STATUS_FAIL);
     };
 
-    // A closed valve has no current caps, but its caps query is proxied upstream and identifies
-    // the elementary stream. The recording bin uses this to insert the matching codec parser.
-    GstCaps* inputCaps = gst_pad_query_caps(probepad, nullptr);
+    // forward-sticky-events preserves the exact negotiated caps while the valve is closed. Fall
+    // back to a proxied caps query during the narrow startup window before negotiation completes.
+    GstCaps* inputCaps = gst_pad_get_current_caps(probepad);
+    if (!inputCaps) {
+        inputCaps = gst_pad_query_caps(probepad, nullptr);
+    }
     _fileSink = _makeFileSink(videoFile, format, inputCaps);
     gst_clear_caps(&inputCaps);
     if (!_fileSink) {
@@ -862,6 +871,7 @@ GstElement* GstVideoReceiver::_makeFileSink(const QString& videoFile, FILE_FORMA
                 qCCritical(GstVideoReceiverLog) << "gst_element_factory_make() failed for" << parserFactory;
                 break;
             }
+            g_object_set(parser, "config-interval", -1, nullptr);
         }
 
         // splitmuxsink owns its own muxer + filesink internally, handles request-pad

--- a/src/VideoManager/VideoReceiver/GStreamer/GstVideoReceiver.cc
+++ b/src/VideoManager/VideoReceiver/GStreamer/GstVideoReceiver.cc
@@ -57,6 +57,25 @@ bool isRecoverableH265PaciError(GstMessage *msg, const GError *error, const gcha
     return factory && (g_strcmp0(GST_OBJECT_NAME(factory), "rtph265depay") == 0);
 }
 
+const char* recordingParserFactory(const GstCaps* caps)
+{
+    if (!caps || gst_caps_is_any(caps) || gst_caps_is_empty(caps)) {
+        return nullptr;
+    }
+
+    for (guint i = 0; i < gst_caps_get_size(caps); ++i) {
+        const GstStructure* structure = gst_caps_get_structure(caps, i);
+        if (gst_structure_has_name(structure, "video/x-h264")) {
+            return "h264parse";
+        }
+        if (gst_structure_has_name(structure, "video/x-h265")) {
+            return "h265parse";
+        }
+    }
+
+    return nullptr;
+}
+
 } // namespace
 
 GstVideoReceiver::GstVideoReceiver(QObject *parent)
@@ -551,40 +570,70 @@ void GstVideoReceiver::startRecording(const QString &videoFile, FILE_FORMAT form
 
     qCDebug(GstVideoReceiverLog) << "New video file:" << videoFile << _uri;
 
-    _fileSink = _makeFileSink(videoFile, format);
-    if (!_fileSink) {
-        qCCritical(GstVideoReceiverLog) << "_makeFileSink() failed" << _uri;
-        emit onStartRecordingComplete(STATUS_FAIL);
-        return;
-    }
-
-    _removingRecorder = false;
-
-    (void) gst_object_ref(_fileSink);
-
-    gst_bin_add(GST_BIN(_pipeline), _fileSink);
-
-    if (!gst_element_link(_recorderValve, _fileSink)) {
-        qCCritical(GstVideoReceiverLog) << "Failed to link valve and file sink" << _uri;
-        emit onStartRecordingComplete(STATUS_FAIL);
-        return;
-    }
-
-    (void) gst_element_sync_state_with_parent(_fileSink);
-
-    GST_DEBUG_BIN_TO_DOT_FILE(GST_BIN(_pipeline), GST_DEBUG_GRAPH_SHOW_ALL, "pipeline-with-filesink");
-
-    // Install a probe on the recording branch to drop buffers until we hit our first keyframe
-    // When we hit our first keyframe, we can offset the timestamps appropriately according to the first keyframe time
-    // This will ensure the first frame is a keyframe at t=0, and decoding can begin immediately on playback
-    GstPad *probepad = gst_element_get_static_pad(_recorderValve, "src");
+    GstPad* probepad = gst_element_get_static_pad(_recorderValve, "src");
     if (!probepad) {
         qCCritical(GstVideoReceiverLog) << "gst_element_get_static_pad() failed" << _uri;
         emit onStartRecordingComplete(STATUS_FAIL);
         return;
     }
 
+    const auto failRecordingStart = [this, &probepad]() {
+        gst_clear_object(&probepad);
+        if (_fileSink) {
+            (void) gst_element_set_state(_fileSink, GST_STATE_NULL);
+            GstObject* parent = gst_element_get_parent(_fileSink);
+            if (parent) {
+                (void) gst_bin_remove(GST_BIN(parent), _fileSink);
+                gst_clear_object(&parent);
+            }
+            gst_clear_object(&_fileSink);
+        }
+        emit onStartRecordingComplete(STATUS_FAIL);
+    };
+
+    // A closed valve has no current caps, but its caps query is proxied upstream and identifies
+    // the elementary stream. The recording bin uses this to insert the matching codec parser.
+    GstCaps* inputCaps = gst_pad_query_caps(probepad, nullptr);
+    _fileSink = _makeFileSink(videoFile, format, inputCaps);
+    gst_clear_caps(&inputCaps);
+    if (!_fileSink) {
+        qCCritical(GstVideoReceiverLog) << "_makeFileSink() failed" << _uri;
+        failRecordingStart();
+        return;
+    }
+
+    _removingRecorder = false;
+
+    if (!gst_bin_add(GST_BIN(_pipeline), _fileSink)) {
+        qCCritical(GstVideoReceiverLog) << "gst_bin_add(file sink) failed" << _uri;
+        failRecordingStart();
+        return;
+    }
+    (void) gst_object_ref(_fileSink);  // Keep a reference in addition to the pipeline's ownership.
+
+    if (!gst_element_link(_recorderValve, _fileSink)) {
+        qCCritical(GstVideoReceiverLog) << "Failed to link valve and file sink" << _uri;
+        failRecordingStart();
+        return;
+    }
+
+    if (!gst_element_sync_state_with_parent(_fileSink)) {
+        qCCritical(GstVideoReceiverLog) << "gst_element_sync_state_with_parent(file sink) failed" << _uri;
+        failRecordingStart();
+        return;
+    }
+
+    GST_DEBUG_BIN_TO_DOT_FILE(GST_BIN(_pipeline), GST_DEBUG_GRAPH_SHOW_ALL, "pipeline-with-filesink");
+
+    // Install a probe on the recording branch to drop buffers until we hit our first keyframe
+    // When we hit our first keyframe, we can offset the timestamps appropriately according to the first keyframe time
+    // This will ensure the first frame is a keyframe at t=0, and decoding can begin immediately on playback
     _keyframeWatchId = gst_pad_add_probe(probepad, GST_PAD_PROBE_TYPE_BUFFER, _keyframeWatch, this, nullptr);
+    if (_keyframeWatchId == 0) {
+        qCCritical(GstVideoReceiverLog) << "gst_pad_add_probe(_keyframeWatch) failed" << _uri;
+        failRecordingStart();
+        return;
+    }
     gst_clear_object(&probepad);
 
     g_object_set(_recorderValve,
@@ -789,18 +838,30 @@ GstElement *GstVideoReceiver::_makeDecoder()
     return decoder;
 }
 
-GstElement *GstVideoReceiver::_makeFileSink(const QString &videoFile, FILE_FORMAT format)
+GstElement* GstVideoReceiver::_makeFileSink(const QString& videoFile, FILE_FORMAT format, const GstCaps* inputCaps)
 {
     GstElement *fileSink = nullptr;
     GstElement *splitmux = nullptr;
+    GstElement* parser = nullptr;
     GstElement *bin = nullptr;
     GstPad *videopad = nullptr;
+    GstPad* parserSrcPad = nullptr;
+    GstPad* parserSinkPad = nullptr;
     GstPad *ghostpad = nullptr;
 
     do {
         if (!isValidFileFormat(format)) {
             qCCritical(GstVideoReceiverLog) << "Unsupported file format";
             break;
+        }
+
+        const char* parserFactory = recordingParserFactory(inputCaps);
+        if (parserFactory) {
+            parser = gst_element_factory_make(parserFactory, nullptr);
+            if (!parser) {
+                qCCritical(GstVideoReceiverLog) << "gst_element_factory_make() failed for" << parserFactory;
+                break;
+            }
         }
 
         // splitmuxsink owns its own muxer + filesink internally, handles request-pad
@@ -853,13 +914,41 @@ GstElement *GstVideoReceiver::_makeFileSink(const QString &videoFile, FILE_FORMA
             break;
         }
 
+        GstElement* binParser = nullptr;
+        if (parser) {
+            if (!gst_bin_add(GST_BIN(bin), parser)) {
+                qCCritical(GstVideoReceiverLog) << "gst_bin_add(parser) failed";
+                break;
+            }
+            binParser = parser;
+            parser = nullptr;  // bin now owns it
+        }
+
         if (!gst_bin_add(GST_BIN(bin), splitmux)) {
             qCCritical(GstVideoReceiverLog) << "gst_bin_add(splitmuxsink) failed";
             break;
         }
         splitmux = nullptr;  // bin now owns it
 
-        ghostpad = gst_ghost_pad_new("sink", videopad);
+        GstPad* ghostTarget = videopad;
+        if (binParser) {
+            parserSrcPad = gst_element_get_static_pad(binParser, "src");
+            parserSinkPad = gst_element_get_static_pad(binParser, "sink");
+            if (!parserSrcPad || !parserSinkPad) {
+                qCCritical(GstVideoReceiverLog) << "gst_element_get_static_pad(parser) failed";
+                break;
+            }
+
+            const GstPadLinkReturn linkResult = gst_pad_link(parserSrcPad, videopad);
+            if (linkResult != GST_PAD_LINK_OK) {
+                qCCritical(GstVideoReceiverLog)
+                    << "Failed to link parser and splitmuxsink:" << gst_pad_link_get_name(linkResult);
+                break;
+            }
+            ghostTarget = parserSinkPad;
+        }
+
+        ghostpad = gst_ghost_pad_new("sink", ghostTarget);
         if (!ghostpad) {
             qCCritical(GstVideoReceiverLog) << "gst_ghost_pad_new() failed";
             break;
@@ -876,10 +965,13 @@ GstElement *GstVideoReceiver::_makeFileSink(const QString &videoFile, FILE_FORMA
     } while(0);
 
     gst_clear_object(&ghostpad);
+    gst_clear_object(&parserSinkPad);
+    gst_clear_object(&parserSrcPad);
     // No release_request_pad: on success splitmux is already NULL (owned by bin), and on failure the
     // bin/splitmux unref below finalizes splitmuxsink, which reclaims its "video" request pad itself.
     gst_clear_object(&videopad);
     gst_clear_object(&splitmux);
+    gst_clear_object(&parser);
     gst_clear_object(&bin);
     return fileSink;
 }

--- a/src/VideoManager/VideoReceiver/GStreamer/GstVideoReceiver.h
+++ b/src/VideoManager/VideoReceiver/GStreamer/GstVideoReceiver.h
@@ -42,6 +42,8 @@ private:
 
 typedef struct _GstElement GstElement;
 
+class GStreamerTest;
+
 class GstVideoReceiver : public VideoReceiver
 {
     Q_OBJECT
@@ -85,8 +87,10 @@ private slots:
     void _handleEOS();
 
 private:
+    friend class GStreamerTest;
+
     GstElement *_makeDecoder();
-    GstElement *_makeFileSink(const QString &videoFile, FILE_FORMAT format);
+    static GstElement* _makeFileSink(const QString& videoFile, FILE_FORMAT format, const GstCaps* inputCaps);
 
     void _onNewSourcePad(GstPad *pad);
     void _onNewDecoderPad(GstPad *pad);

--- a/test/VideoManager/GStreamer/GStreamerTest.cc
+++ b/test/VideoManager/GStreamer/GStreamerTest.cc
@@ -460,6 +460,69 @@ void GStreamerTest::_testCreateVideoReceiver()
     QVERIFY(qobject_cast<GstVideoReceiver*>(receiver.get()));
 }
 
+void GStreamerTest::_testRecordingSinkAcceptsElementaryStreams_data()
+{
+    QTest::addColumn<QString>("capsString");
+    QTest::addColumn<int>("format");
+
+    constexpr const char* h264Caps = "video/x-h264,stream-format=byte-stream,alignment=au";
+    constexpr const char* h265Caps = "video/x-h265,stream-format=byte-stream,alignment=au";
+
+    QTest::newRow("h264-mkv") << QString::fromLatin1(h264Caps) << int(VideoReceiver::FILE_FORMAT_MKV);
+    QTest::newRow("h264-mov") << QString::fromLatin1(h264Caps) << int(VideoReceiver::FILE_FORMAT_MOV);
+    QTest::newRow("h264-mp4") << QString::fromLatin1(h264Caps) << int(VideoReceiver::FILE_FORMAT_MP4);
+    QTest::newRow("h265-mkv") << QString::fromLatin1(h265Caps) << int(VideoReceiver::FILE_FORMAT_MKV);
+    QTest::newRow("h265-mov") << QString::fromLatin1(h265Caps) << int(VideoReceiver::FILE_FORMAT_MOV);
+    QTest::newRow("h265-mp4") << QString::fromLatin1(h265Caps) << int(VideoReceiver::FILE_FORMAT_MP4);
+}
+
+void GStreamerTest::_testRecordingSinkAcceptsElementaryStreams()
+{
+    QFETCH(QString, capsString);
+    QFETCH(int, format);
+
+    const auto fileFormat = static_cast<VideoReceiver::FILE_FORMAT>(format);
+    const char* parserFactory = capsString.startsWith(QLatin1String("video/x-h265")) ? "h265parse" : "h264parse";
+    const char* muxerFactory = (fileFormat == VideoReceiver::FILE_FORMAT_MKV)
+                                   ? "matroskamux"
+                                   : ((fileFormat == VideoReceiver::FILE_FORMAT_MOV) ? "qtmux" : "mp4mux");
+
+    for (const char* factoryName : {"capsfilter", parserFactory, "splitmuxsink", muxerFactory}) {
+        GstElementFactory* factory = gst_element_factory_find(factoryName);
+        if (!factory) {
+            QSKIP(qPrintable(
+                QStringLiteral("Required GStreamer factory is unavailable: %1").arg(QString::fromLatin1(factoryName))));
+        }
+        gst_object_unref(factory);
+    }
+
+    const QByteArray capsUtf8 = capsString.toUtf8();
+    GstCaps* inputCaps = gst_caps_from_string(capsUtf8.constData());
+    QVERIFY(inputCaps);
+
+    GstElement* source = nullptr;
+    GstElement* sink = nullptr;
+    bool linked = false;
+    const auto cleanup = qScopeGuard([&]() {
+        if (linked) {
+            gst_element_unlink(source, sink);
+        }
+        gst_clear_object(&sink);
+        gst_clear_object(&source);
+        gst_clear_caps(&inputCaps);
+    });
+
+    source = gst_element_factory_make("capsfilter", nullptr);
+    QVERIFY(source);
+    g_object_set(source, "caps", inputCaps, nullptr);
+
+    sink = GstVideoReceiver::_makeFileSink(QStringLiteral("recording-test"), fileFormat, inputCaps);
+    QVERIFY(sink);
+
+    linked = gst_element_link(source, sink);
+    QVERIFY2(linked, qPrintable(QStringLiteral("Recording sink rejected %1").arg(capsString)));
+}
+
 void GStreamerTest::_testBindDebugLevelFactRejectsNullContext()
 {
     Fact fact;
@@ -519,6 +582,15 @@ QGC_GST_SKIP_TEST(_testEnvironmentSetup)
 QGC_GST_SKIP_TEST(_testWritePipelineDotReturnsEmptyOnWriteFailure)
 QGC_GST_SKIP_TEST(_testCompleteInit)
 QGC_GST_SKIP_TEST(_testCreateVideoReceiver)
+
+void GStreamerTest::_testRecordingSinkAcceptsElementaryStreams_data()
+{
+    QTest::addColumn<QString>("capsString");
+    QTest::addColumn<int>("format");
+    QTest::newRow("gstreamer-disabled") << QString() << 0;
+}
+
+QGC_GST_SKIP_TEST(_testRecordingSinkAcceptsElementaryStreams)
 QGC_GST_SKIP_TEST(_testBindDebugLevelFactRejectsNullContext)
 QGC_GST_SKIP_TEST(_testRuntimeVersionCheck)
 QGC_GST_SKIP_TEST(_testAppsinkFrameDelivery)

--- a/test/VideoManager/GStreamer/GStreamerTest.cc
+++ b/test/VideoManager/GStreamer/GStreamerTest.cc
@@ -7,23 +7,124 @@ QGC_LOGGING_CATEGORY(GStreamerTestLog, "Video.GStreamer.GStreamerTest")
 #ifdef QGC_GST_STREAMING
 
 #include <QtCore/QDir>
+#include <QtCore/QFile>
 #include <QtCore/QFileInfo>
 #include <QtCore/QLoggingCategory>
 #include <QtCore/QRegularExpression>
 #include <QtCore/QScopeGuard>
 #include <QtCore/QStandardPaths>
+#include <QtCore/QTemporaryDir>
+
+#include <atomic>
+#include <gst/app/gstappsrc.h>
 #include <gst/gst.h>
 #include <memory>
 #include <vector>
 
-#include "Fixtures/RAIIFixtures.h"
 #include "Fact.h"
+#include "Fixtures/RAIIFixtures.h"
 #include "GStreamer.h"
 #include "GStreamerHelpers.h"
 #include "GStreamerLogging.h"
 #include "GstVideoReceiver.h"
 #include "LogManager.h"
 #include "VideoBackend.h"
+
+namespace {
+
+constexpr GstClockTime kRecordingTestTimeout = 5 * GST_SECOND;
+
+GstPadProbeReturn countBufferProbe([[maybe_unused]] GstPad* pad, GstPadProbeInfo* info, gpointer userData)
+{
+    if (GST_PAD_PROBE_INFO_TYPE(info) & GST_PAD_PROBE_TYPE_BUFFER) {
+        static_cast<std::atomic<int>*>(userData)->fetch_add(1, std::memory_order_relaxed);
+    }
+    return GST_PAD_PROBE_OK;
+}
+
+struct DemuxPadContext
+{
+    GstElement* parser = nullptr;
+    std::atomic<bool> linked{false};
+};
+
+void linkH265DemuxPad([[maybe_unused]] GstElement* demux, GstPad* pad, gpointer userData)
+{
+    auto* context = static_cast<DemuxPadContext*>(userData);
+    GstCaps* caps = gst_pad_get_current_caps(pad);
+    if (!caps) {
+        caps = gst_pad_query_caps(pad, nullptr);
+    }
+    if (!caps || gst_caps_is_any(caps) || gst_caps_is_empty(caps)) {
+        gst_clear_caps(&caps);
+        return;
+    }
+
+    bool isH265 = false;
+    for (guint i = 0; i < gst_caps_get_size(caps); ++i) {
+        if (gst_structure_has_name(gst_caps_get_structure(caps, i), "video/x-h265")) {
+            isH265 = true;
+            break;
+        }
+    }
+    gst_clear_caps(&caps);
+    if (!isH265) {
+        return;
+    }
+
+    GstPad* sinkPad = gst_element_get_static_pad(context->parser, "sink");
+    if (sinkPad) {
+        context->linked.store(gst_pad_link(pad, sinkPad) == GST_PAD_LINK_OK, std::memory_order_relaxed);
+        gst_clear_object(&sinkPad);
+    }
+}
+
+bool waitForPipelineEos(GstElement* pipeline, QString& failure)
+{
+    GstBus* bus = gst_element_get_bus(pipeline);
+    if (!bus) {
+        failure = QStringLiteral("Pipeline has no bus");
+        return false;
+    }
+
+    GstMessage* message = gst_bus_timed_pop_filtered(bus, kRecordingTestTimeout,
+                                                     static_cast<GstMessageType>(GST_MESSAGE_EOS | GST_MESSAGE_ERROR));
+    gst_clear_object(&bus);
+    if (!message) {
+        failure = QStringLiteral("Timed out waiting for EOS");
+        return false;
+    }
+
+    const auto cleanup = qScopeGuard([&] { gst_message_unref(message); });
+    if (GST_MESSAGE_TYPE(message) == GST_MESSAGE_EOS) {
+        return true;
+    }
+
+    GError* error = nullptr;
+    gchar* debug = nullptr;
+    gst_message_parse_error(message, &error, &debug);
+    failure = QStringLiteral("%1 (%2)").arg(
+        error ? QString::fromUtf8(error->message) : QStringLiteral("unknown GStreamer error"),
+        debug ? QString::fromUtf8(debug) : QString());
+    g_clear_error(&error);
+    g_clear_pointer(&debug, g_free);
+    return false;
+}
+
+GstFlowReturn pushAccessUnit(GstElement* appsrc, const QByteArray& bytes, GstClockTime timestamp)
+{
+    GstBuffer* buffer = gst_buffer_new_allocate(nullptr, static_cast<gsize>(bytes.size()), nullptr);
+    if (!buffer) {
+        return GST_FLOW_ERROR;
+    }
+    (void) gst_buffer_fill(buffer, 0, bytes.constData(), static_cast<gsize>(bytes.size()));
+    GST_BUFFER_PTS(buffer) = timestamp;
+    GST_BUFFER_DTS(buffer) = timestamp;
+    GST_BUFFER_DURATION(buffer) = GST_SECOND / 4;
+    return gst_app_src_push_buffer(GST_APP_SRC(appsrc), buffer);
+}
+
+}  // namespace
 
 void GStreamerTest::init()
 {
@@ -340,6 +441,10 @@ void GStreamerTest::_testVerifyRequiredPlugins()
     QVERIFY2(corePlugin, "Required plugin not found: coreelements");
     gst_clear_object(&corePlugin);
 
+    GstPlugin* parserPlugin = gst_registry_find_plugin(registry, "videoparsersbad");
+    QVERIFY2(parserPlugin, "Required plugin not found: videoparsersbad");
+    gst_clear_object(&parserPlugin);
+
     GList* plugins = gst_registry_get_plugin_list(registry);
     const int pluginCount = g_list_length(plugins);
     gst_plugin_list_free(plugins);
@@ -523,6 +628,160 @@ void GStreamerTest::_testRecordingSinkAcceptsElementaryStreams()
     QVERIFY2(linked, qPrintable(QStringLiteral("Recording sink rejected %1").arg(capsString)));
 }
 
+void GStreamerTest::_testRecordingSinkFinalizesMidStreamH265Mp4()
+{
+    for (const char* factoryName : {"appsrc", "h265parse", "tee", "queue", "fakesink", "valve", "splitmuxsink",
+                                    "mp4mux", "filesrc", "qtdemux", "avdec_h265"}) {
+        GstElementFactory* factory = gst_element_factory_find(factoryName);
+        if (!factory) {
+            QSKIP(qPrintable(
+                QStringLiteral("Required GStreamer factory is unavailable: %1").arg(QString::fromLatin1(factoryName))));
+        }
+        gst_object_unref(factory);
+    }
+
+    // Synthetic 32x32 Annex-B H.265 access units. Only the first AU contains VPS/SPS/PPS; the
+    // later IDRs intentionally contain just a slice. This reproduces a camera that sends codec
+    // configuration once at session startup, before the user begins recording.
+    const QByteArray initialAu = QByteArray::fromBase64(QByteArrayLiteral(
+        "AAAAAUABDAH//wQIAAADAJgoAAADAAAeugJAAAAAAUIBAQQIAAADAJgoAAADAAAekAhBCKUt0lJhf/gACAALUGBgYEAAAAMAQ"
+        "AAAAwECAAAAAUQBwHAwYBEgAAAAASgBrC2AE6/7X1g="));
+    const QByteArray secondAu = QByteArray::fromBase64(QByteArrayLiteral("AAAAASgBrC2AE6/7X1g="));
+    const QByteArray thirdAu = QByteArray::fromBase64(QByteArrayLiteral("AAAAASgBrCyAE6/7X1g="));
+    QVERIFY(!initialAu.isEmpty());
+    QVERIFY(!secondAu.isEmpty());
+    QVERIFY(!thirdAu.isEmpty());
+
+    QTemporaryDir tempDir;
+    QVERIFY(tempDir.isValid());
+    const QString outputPath = QDir(tempDir.path()).filePath(QStringLiteral("mid-stream.mp4"));
+
+    GstElement* pipeline = gst_pipeline_new("mid-stream-recording-test");
+    QVERIFY(pipeline);
+    const auto pipelineCleanup = qScopeGuard([&] {
+        (void) gst_element_set_state(pipeline, GST_STATE_NULL);
+        gst_object_unref(pipeline);
+    });
+
+    GstElement* source = gst_element_factory_make("appsrc", nullptr);
+    GstElement* upstreamParser = gst_element_factory_make("h265parse", nullptr);
+    GstElement* tee = gst_element_factory_make("tee", nullptr);
+    GstElement* displayQueue = gst_element_factory_make("queue", nullptr);
+    GstElement* displaySink = gst_element_factory_make("fakesink", nullptr);
+    GstElement* recorderQueue = gst_element_factory_make("queue", nullptr);
+    GstElement* recorderValve = gst_element_factory_make("valve", nullptr);
+    QVERIFY(source);
+    QVERIFY(upstreamParser);
+    QVERIFY(tee);
+    QVERIFY(displayQueue);
+    QVERIFY(displaySink);
+    QVERIFY(recorderQueue);
+    QVERIFY(recorderValve);
+
+    GstCaps* sourceCaps =
+        gst_caps_from_string("video/x-h265,stream-format=byte-stream,alignment=au,width=32,height=32,framerate=4/1");
+    QVERIFY(sourceCaps);
+    g_object_set(source, "caps", sourceCaps, "format", GST_FORMAT_TIME, nullptr);
+    gst_clear_caps(&sourceCaps);
+    g_object_set(upstreamParser, "config-interval", -1, nullptr);
+    g_object_set(displaySink, "sync", FALSE, "async", FALSE, nullptr);
+    g_object_set(recorderValve, "drop", TRUE, nullptr);
+    gst_util_set_object_arg(G_OBJECT(recorderValve), "drop-mode", "forward-sticky-events");
+
+    gst_bin_add_many(GST_BIN(pipeline), source, upstreamParser, tee, displayQueue, displaySink, recorderQueue,
+                     recorderValve, nullptr);
+    QVERIFY(gst_element_link_many(source, upstreamParser, tee, nullptr));
+    QVERIFY(gst_element_link_many(tee, displayQueue, displaySink, nullptr));
+    QVERIFY(gst_element_link_many(tee, recorderQueue, recorderValve, nullptr));
+
+    std::atomic<int> displayedBuffers{0};
+    GstPad* displayPad = gst_element_get_static_pad(displaySink, "sink");
+    QVERIFY(displayPad);
+    const gulong displayProbe =
+        gst_pad_add_probe(displayPad, GST_PAD_PROBE_TYPE_BUFFER, countBufferProbe, &displayedBuffers, nullptr);
+    QVERIFY(displayProbe != 0);
+    const auto displayProbeCleanup = qScopeGuard([&] {
+        gst_pad_remove_probe(displayPad, displayProbe);
+        gst_clear_object(&displayPad);
+    });
+
+    QVERIFY(gst_element_set_state(pipeline, GST_STATE_PLAYING) != GST_STATE_CHANGE_FAILURE);
+    QVERIFY(pushAccessUnit(source, initialAu, 0) == GST_FLOW_OK);
+    QTRY_VERIFY_WITH_TIMEOUT(displayedBuffers.load(std::memory_order_relaxed) >= 1, 2000);
+
+    GstPad* valveSrcPad = gst_element_get_static_pad(recorderValve, "src");
+    QVERIFY(valveSrcPad);
+    GstCaps* recordingCaps = gst_pad_get_current_caps(valveSrcPad);
+    QVERIFY2(recordingCaps, "Closed recording valve did not preserve negotiated caps");
+
+    GstElement* fileSink = GstVideoReceiver::_makeFileSink(outputPath, VideoReceiver::FILE_FORMAT_MP4, recordingCaps);
+    gst_clear_caps(&recordingCaps);
+    QVERIFY(fileSink);
+    QVERIFY(gst_bin_add(GST_BIN(pipeline), fileSink));
+    QVERIFY(gst_element_link(recorderValve, fileSink));
+    QVERIFY(gst_element_sync_state_with_parent(fileSink));
+    g_object_set(recorderValve, "drop", FALSE, nullptr);
+    gst_clear_object(&valveSrcPad);
+
+    QVERIFY(pushAccessUnit(source, secondAu, GST_SECOND / 4) == GST_FLOW_OK);
+    QVERIFY(pushAccessUnit(source, thirdAu, GST_SECOND / 2) == GST_FLOW_OK);
+    QVERIFY(gst_app_src_end_of_stream(GST_APP_SRC(source)) == GST_FLOW_OK);
+
+    QString failure;
+    QVERIFY2(waitForPipelineEos(pipeline, failure), qPrintable(failure));
+    (void) gst_element_set_state(pipeline, GST_STATE_NULL);
+    QVERIFY2(QFileInfo(outputPath).size() > 0, "Recording did not produce an MP4 file");
+
+    GstElement* verifyPipeline = gst_pipeline_new("verify-mid-stream-recording");
+    QVERIFY(verifyPipeline);
+    const auto verifyCleanup = qScopeGuard([&] {
+        (void) gst_element_set_state(verifyPipeline, GST_STATE_NULL);
+        gst_object_unref(verifyPipeline);
+    });
+
+    GstElement* fileSource = gst_element_factory_make("filesrc", nullptr);
+    GstElement* demux = gst_element_factory_make("qtdemux", nullptr);
+    GstElement* verifyParser = gst_element_factory_make("h265parse", nullptr);
+    GstElement* verifyDecoder = gst_element_factory_make("avdec_h265", nullptr);
+    GstElement* verifySink = gst_element_factory_make("fakesink", nullptr);
+    QVERIFY(fileSource);
+    QVERIFY(demux);
+    QVERIFY(verifyParser);
+    QVERIFY(verifyDecoder);
+    QVERIFY(verifySink);
+
+    const QByteArray outputPathBytes = QFile::encodeName(outputPath);
+    g_object_set(fileSource, "location", outputPathBytes.constData(), nullptr);
+    g_object_set(verifySink, "sync", FALSE, "async", FALSE, nullptr);
+    gst_bin_add_many(GST_BIN(verifyPipeline), fileSource, demux, verifyParser, verifyDecoder, verifySink, nullptr);
+    QVERIFY(gst_element_link(fileSource, demux));
+    QVERIFY(gst_element_link_many(verifyParser, verifyDecoder, verifySink, nullptr));
+
+    DemuxPadContext demuxContext{verifyParser};
+    const gulong padAddedHandler =
+        g_signal_connect(demux, "pad-added", G_CALLBACK(linkH265DemuxPad), &demuxContext);
+    QVERIFY(padAddedHandler != 0);
+    const auto padAddedCleanup = qScopeGuard([&] { g_signal_handler_disconnect(demux, padAddedHandler); });
+
+    std::atomic<int> verifiedBuffers{0};
+    GstPad* verifyPad = gst_element_get_static_pad(verifySink, "sink");
+    QVERIFY(verifyPad);
+    const gulong verifyProbe =
+        gst_pad_add_probe(verifyPad, GST_PAD_PROBE_TYPE_BUFFER, countBufferProbe, &verifiedBuffers, nullptr);
+    QVERIFY(verifyProbe != 0);
+    const auto verifyProbeCleanup = qScopeGuard([&] {
+        gst_pad_remove_probe(verifyPad, verifyProbe);
+        gst_clear_object(&verifyPad);
+    });
+
+    QVERIFY(gst_element_set_state(verifyPipeline, GST_STATE_PLAYING) != GST_STATE_CHANGE_FAILURE);
+    failure.clear();
+    QVERIFY2(waitForPipelineEos(verifyPipeline, failure), qPrintable(failure));
+    QVERIFY2(demuxContext.linked.load(std::memory_order_relaxed), "MP4 has no H.265 video track");
+    QVERIFY2(verifiedBuffers.load(std::memory_order_relaxed) >= 2,
+             "Finalized MP4 did not decode the two mid-stream H.265 access units");
+}
+
 void GStreamerTest::_testBindDebugLevelFactRejectsNullContext()
 {
     Fact fact;
@@ -591,6 +850,7 @@ void GStreamerTest::_testRecordingSinkAcceptsElementaryStreams_data()
 }
 
 QGC_GST_SKIP_TEST(_testRecordingSinkAcceptsElementaryStreams)
+QGC_GST_SKIP_TEST(_testRecordingSinkFinalizesMidStreamH265Mp4)
 QGC_GST_SKIP_TEST(_testBindDebugLevelFactRejectsNullContext)
 QGC_GST_SKIP_TEST(_testRuntimeVersionCheck)
 QGC_GST_SKIP_TEST(_testAppsinkFrameDelivery)

--- a/test/VideoManager/GStreamer/GStreamerTest.h
+++ b/test/VideoManager/GStreamer/GStreamerTest.h
@@ -26,6 +26,7 @@ private slots:
     void _testCreateVideoReceiver();
     void _testRecordingSinkAcceptsElementaryStreams_data();
     void _testRecordingSinkAcceptsElementaryStreams();
+    void _testRecordingSinkFinalizesMidStreamH265Mp4();
     void _testBindDebugLevelFactRejectsNullContext();
     void _testRuntimeVersionCheck();
     void _testAppsinkFrameDelivery();

--- a/test/VideoManager/GStreamer/GStreamerTest.h
+++ b/test/VideoManager/GStreamer/GStreamerTest.h
@@ -24,6 +24,8 @@ private slots:
     void _testWritePipelineDotReturnsEmptyOnWriteFailure();
     void _testCompleteInit();
     void _testCreateVideoReceiver();
+    void _testRecordingSinkAcceptsElementaryStreams_data();
+    void _testRecordingSinkAcceptsElementaryStreams();
     void _testBindDebugLevelFactRejectsNullContext();
     void _testRuntimeVersionCheck();
     void _testAppsinkFrameDelivery();


### PR DESCRIPTION
## Bug Description

Recording can fail when an H.264 or H.265 elementary stream reaches the recording branch in byte-stream format. This reproduces with an H.265 RTSP camera on Android: the live view works, but MP4 recording cannot negotiate a compatible stream with the muxer and no usable recording is produced.

Related to #10366.

## Root Cause

The recording bin exposed the `splitmuxsink` video request pad directly. RTSP depayloaders commonly output H.264/H.265 byte-stream caps, while the MP4/MOV muxers require parsed AVC/HVC1-style input. Without `h264parse` or `h265parse` in the recording branch, pad linking or caps negotiation fails.

There is an additional late-start case: recording normally begins after the live stream is already running. Some cameras send VPS/SPS/PPS only at session startup, so a parser created when recording begins cannot construct the codec data needed by MP4/MOV unless an upstream parser repeats those parameter sets.

## Solution

- Preserve negotiated sticky events while the recorder valve is closed and use its current caps when constructing the recording branch.
- Configure source-side H.264/H.265 parsers with `config-interval=-1`, including parsers autoplugged inside `parsebin`, so codec parameter sets are repeated at IDR frames.
- Insert the matching `h264parse` or `h265parse` before `splitmuxsink` for elementary streams; keep the existing direct path for other caps.
- Mark `videoparsersbad` as runtime-required in both plugin policy and startup verification (it is already in the common mobile bundle list).
- Unconditionally unlink a partially started file sink before removing it, so a transient setup failure cannot make later recording attempts fail.
- Add both a six-case H.264/H.265 x MKV/MOV/MP4 link matrix and a running mid-stream H.265 MP4 regression test.

## Testing

- [x] Tested locally
- [x] Added regression test
- [ ] Tested with simulator (SITL)
- [x] Tested with hardware

### Platforms Tested

- [x] Linux
- [ ] Windows
- [ ] macOS
- [x] Android
- [ ] iOS

### Flight Stacks Tested

- [ ] PX4
- [ ] ArduPilot
- [x] N/A

Results:

- Linux Debug QGC test-enabled build completed successfully after rebasing onto current `master`.
- Focused `GStreamerTest`: 86 passed, 0 failed, 16 platform-dependent skips.
- Six-case link matrix: all H.264/H.265 x MKV/MOV/MP4 combinations passed.
- The functional regression sends VPS/SPS/PPS only before recording starts, records two later IDRs, finalizes MP4, demuxes it, and decodes both saved frames.
- GStreamer plugin-policy CMake test passed.
- Changed lines pass the repository-pinned clang-format 22.1.5 check; `git diff --check` passes.
- Earlier revision: Android arm64 Debug APK built successfully, and a live H.265 RTSP hardware test produced a seekable MP4 (H.265 Main, 1280x720, 30 fps, 6.60 s) that played correctly.
- SITL and the complete repository-wide unit-test suite were not run; this change is isolated to GStreamer recording.

## Checklist

- [x] I have read the [Contribution Guidelines](../CONTRIBUTING.md)
- [x] My code follows the project's coding standards
- [x] I have added a test that reproduces the bug
- [ ] New and existing unit tests pass locally

The focused GStreamer unit-test suite passes in full; the last checkbox remains clear because the complete repository-wide suite was not run.

---
By submitting this pull request, I confirm that my contribution is made under the terms of the project's dual license (Apache 2.0 and GPL v3).
