### PR TITLE
fix(PX4): remove dead UAVCAN ESC enumeration from Power setup

### DIFF
--- a/docs/en/qgc-user-guide/setup_view/power.md
+++ b/docs/en/qgc-user-guide/setup_view/power.md
@@ -1,7 +1,6 @@
 # Power Setup
 
-The _Power Setup_ screen is used to configure battery parameters and also provide advanced settings for propellers.
-
+The _Power Setup_ screen is used to configure battery parameters and calibrate ESCs.
 
 ## Battery Voltage/Current Calibration
 
@@ -46,7 +45,3 @@ Never attempt ESC calibration with props on.
 Motors should not spin during ESC calibration.
 However if an ESC doesn't properly support/detect the calibration sequence then it will respond to the PWM input by running the motor at maximum speed.
 :::
-
-## Other Settings
-
-Select the **Show UAVCAN Settings** checkbox to access additional settings for UAVCAN Bus Configuration and motor index and direction assignment.

--- a/src/AutoPilotPlugins/PX4/PowerComponent.cc
+++ b/src/AutoPilotPlugins/PX4/PowerComponent.cc
@@ -15,7 +15,7 @@ QString PowerComponent::name(void) const
 
 QString PowerComponent::description(void) const
 {
-    return tr("Configure battery parameters, ESC calibration, and UAVCAN bus settings.");
+    return tr("Configure battery parameters and ESC calibration.");
 }
 
 QString PowerComponent::iconResource(void) const

--- a/src/AutoPilotPlugins/PX4/PowerComponentController.cc
+++ b/src/AutoPilotPlugins/PX4/PowerComponentController.cc
@@ -13,27 +13,9 @@ void PowerComponentController::calibrateEsc(void)
     _vehicle->startCalibration(QGCMAVLink::CalibrationEsc);
 }
 
-void PowerComponentController::startBusConfigureActuators(void)
-{
-    _warningMessages.clear();
-    connect(_vehicle, &Vehicle::textMessageReceived, this, &PowerComponentController::_handleVehicleTextMessage);
-    _vehicle->startUAVCANBusConfig();
-}
-
-void PowerComponentController::stopBusConfigureActuators(void)
-{
-    disconnect(_vehicle, &Vehicle::textMessageReceived, this, &PowerComponentController::_handleVehicleTextMessage);
-    _vehicle->stopUAVCANBusConfig();
-}
-
 void PowerComponentController::_stopCalibration(void)
 {
     disconnect(_vehicle, &Vehicle::textMessageReceived, this, &PowerComponentController::_handleVehicleTextMessage);
-}
-
-void PowerComponentController::_stopBusConfig(void)
-{
-    _stopCalibration();
 }
 
 void PowerComponentController::_handleVehicleTextMessage(int vehicleId, int /* compId */, int /* severity */, QString text, const QString &description)
@@ -111,25 +93,6 @@ void PowerComponentController::_handleVehicleTextMessage(int vehicleId, int /* c
 
     QString warningPrefix("config warning: ");
     if (text.startsWith(warningPrefix)) {
-        _warningMessages << text.right(text.length() - warningPrefix.length());
-    }
-
-    QString busFailedPrefix("bus conf fail:");
-    if (text.startsWith(busFailedPrefix)) {
-
-        _stopBusConfig();
-        emit calibrationFailed(text.right(text.length() - failedPrefix.length()));
-        return;
-    }
-
-    if (text.startsWith(calCompletePrefix)) {
-        _stopBusConfig();
-        emit calibrationSuccess(_warningMessages);
-        return;
-    }
-
-    QString busWarningPrefix("bus conf warn: ");
-    if (text.startsWith(busWarningPrefix)) {
         _warningMessages << text.right(text.length() - warningPrefix.length());
     }
 }

--- a/src/AutoPilotPlugins/PX4/PowerComponentController.h
+++ b/src/AutoPilotPlugins/PX4/PowerComponentController.h
@@ -14,8 +14,6 @@ public:
     PowerComponentController(void);
 
     Q_INVOKABLE void calibrateEsc(void);
-    Q_INVOKABLE void startBusConfigureActuators(void);
-    Q_INVOKABLE void stopBusConfigureActuators(void);
 
 signals:
     void oldFirmware(void);
@@ -32,7 +30,6 @@ private slots:
 
 private:
     void _stopCalibration(void);
-    void _stopBusConfig(void);
 
     QStringList _warningMessages;
     static const int _neededFirmwareRev = 1;

--- a/src/AutoPilotPlugins/PX4/VehicleConfig/Power.VehicleConfig.json
+++ b/src/AutoPilotPlugins/PX4/VehicleConfig/Power.VehicleConfig.json
@@ -5,13 +5,6 @@
         "QGroundControl.AutoPilotPlugins.PX4"
     ],
     "controllerType": "PowerComponentController",
-    "params": {
-        "_uavcanEnable": "UAVCAN_ENABLE",
-        "_uavcanAvailable": {
-            "name": "UAVCAN_ENABLE",
-            "existsOnly": true
-        }
-    },
     "sections": [
         {
             "title": "Battery",
@@ -120,52 +113,6 @@
                     "dialogButton": {
                         "text": "Calibrate",
                         "dialogComponent": "ESCCalibrationDialog"
-                    }
-                }
-            ]
-        },
-        {
-            "title": "UAVCAN Bus Configuration",
-            "keywords": [
-                "uavcan",
-                "can bus",
-                "dronecan",
-                "esc",
-                "node"
-            ],
-            "image": "/qmlimages/Gears.svg",
-            "showWhen": "_uavcanAvailable && _uavcanEnable.rawValue !== 0",
-            "controls": [
-                {
-                    "param": "UAVCAN_ENABLE",
-                    "label": "UAVCAN",
-                    "control": "combobox"
-                },
-                {
-                    "control": "label",
-                    "label": "WARNING: Propellers must be removed from vehicle prior to performing UAVCAN ESC configuration.",
-                    "warning": true
-                },
-                {
-                    "control": "label",
-                    "label": "ESC parameters will only be accessible in the editor after assignment."
-                },
-                {
-                    "control": "label",
-                    "label": "Start the process, then turn each motor into its turn direction, in the order of their motor indices."
-                },
-                {
-                    "control": "actionButton",
-                    "actionButton": {
-                        "text": "Start Assignment",
-                        "onClicked": "controller.startBusConfigureActuators()"
-                    }
-                },
-                {
-                    "control": "actionButton",
-                    "actionButton": {
-                        "text": "Stop Assignment",
-                        "onClicked": "controller.stopBusConfigureActuators()"
                     }
                 }
             ]

--- a/src/Vehicle/Vehicle.cc
+++ b/src/Vehicle/Vehicle.cc
@@ -2413,22 +2413,6 @@ void Vehicle::stopCalibration(bool showError)
                    0);                                // unused
 }
 
-void Vehicle::startUAVCANBusConfig(void)
-{
-    sendMavCommand(defaultComponentId(),        // target component
-                   MAV_CMD_PREFLIGHT_UAVCAN,    // command id
-                   true,                        // showError
-                   1);                          // start config
-}
-
-void Vehicle::stopUAVCANBusConfig(void)
-{
-    sendMavCommand(defaultComponentId(),        // target component
-                   MAV_CMD_PREFLIGHT_UAVCAN,    // command id
-                   true,                        // showError
-                   0);                          // stop config
-}
-
 void Vehicle::setSoloFirmware(bool soloFirmware)
 {
     if (soloFirmware != _soloFirmware) {

--- a/src/Vehicle/Vehicle.h
+++ b/src/Vehicle/Vehicle.h
@@ -548,9 +548,6 @@ public:
     void startCalibration   (QGCMAVLink::CalibrationType calType);
     void stopCalibration    (bool showError);
 
-    void startUAVCANBusConfig(void);
-    void stopUAVCANBusConfig(void);
-
     FactGroup* vehicleFactGroup             () { return _vehicleFactGroup; }
     FactGroup* gpsFactGroup                 ();
     FactGroup* gps2FactGroup                ();


### PR DESCRIPTION
Fixes #14911

PX4 removed the FC-side `MAV_CMD_PREFLIGHT_UAVCAN` handler in 1.13 (PX4/PX4-Autopilot@2e2ac36) and ArduPilot never implemented it, so the Power page's UAVCAN "Start/Stop Assignment" buttons only produced "Vehicle did not respond to command: MAV_CMD_PREFLIGHT_UAVCAN". A request to restore it in PX4 was closed as not planned (PX4/PX4-Autopilot#21913).

Changes:
- Remove the "UAVCAN Bus Configuration" section from the PX4 Power vehicle config page (including the `UAVCAN_ENABLE` combobox, which was only visible when UAVCAN was already enabled elsewhere)
- Remove `PowerComponentController::startBusConfigureActuators()` / `stopBusConfigureActuators()` and the associated "bus conf" text-message handling
- Remove `Vehicle::startUAVCANBusConfig()` / `stopUAVCANBusConfig()`
- Update the Power component description and the user guide power page to stop advertising UAVCAN motor index/direction assignment

Users needing to set DroneCAN ESC indices should set `ESC_INDEX`/`esc_index` per node via Parameters (Component N), the DroneCAN GUI tool, or a script.
