### PR TITLE
fix multivehicle mission start for armed vehicles

### DIFF
--- a/src/FirmwarePlugin/APM/APMFirmwarePlugin.cc
+++ b/src/FirmwarePlugin/APM/APMFirmwarePlugin.cc
@@ -1066,8 +1066,8 @@ void APMFirmwarePlugin::startTakeoff(Vehicle *vehicle) const
 
 void APMFirmwarePlugin::startMission(Vehicle *vehicle) const
 {
-    if (vehicle->flying()) {
-        // Vehicle already in the air, we just need to switch to auto
+    if (vehicle->flying() || vehicle->armed()) {
+        // Vehicle already in the air or armed, we just need to switch to auto
         if (!_setFlightModeAndValidate(vehicle, missionFlightMode())) {
             QGC::showAppMessage(tr("Unable to start mission: Vehicle failed to change to Auto mode."));
         }


### PR DESCRIPTION
## Problem

When starting a mission for multiple vehicles, mission start could fail for a vehicle that was already armed but not currently flying.

In `APMFirmwarePlugin::startMission()`, the initial condition only checked `vehicle->flying()`. An already-armed vehicle that was not flying would therefore skip the first condition, while also skipping the subsequent `!vehicle->armed()` block. As a result, the vehicle would fall through without switching to the mission flight mode.

## Fix

Changed the initial condition from:

`vehicle->flying()`

to:

`vehicle->flying() || vehicle->armed()`

This ensures that an already-armed vehicle is switched to the mission flight mode instead of falling through without taking action.

## Testing

* Reproduced the mission-start issue with multiple vehicles.
* Confirmed the issue with a vehicle that was already armed but not flying.
* Confirmed that the change causes the already-armed vehicle to switch to Auto.
* `git diff --check` passes.
* QGroundControl builds successfully with the change.
