### PR TITLE
fix(AppSettings): fill settings sidebar (Stable_V5.1)

### DIFF
--- a/src/QmlControls/AppSettings.qml
+++ b/src/QmlControls/AppSettings.qml
@@ -180,6 +180,7 @@ Rectangle {
 
         ColumnLayout {
             id:         buttonColumn
+            width:      buttonList.width
             spacing:    0
 
             Repeater {


### PR DESCRIPTION
Backport of #14921 to Stable_V5.1.

## Description
The JSON-driven settings refactor (#14216, present in Stable_V5.1) left the settings sidebar button column at its implicit width, making the buttons narrower than the sidebar. This binds the column width to the Flickable width, restoring the previous layout.

Credit to @rubenp02 for the original fix.
