### PR TITLE
fix(dialog): label vehicle reboot prompt Reboot/Continue

### DIFF
--- a/src/MainWindow/MainWindow.qml
+++ b/src/MainWindow/MainWindow.qml
@@ -206,17 +206,22 @@ ApplicationWindow {
         _showMessageDialogWorker(mainWindow, dialogTitle, dialogText)
     }
 
-    // This variant is only meant to be called by QGCApplication. Ok reboots the active vehicle.
+    // This variant is only meant to be called by QGCApplication. Reboot reboots the active vehicle; Continue dismisses.
     function _showRebootVehicleDialog(dialogTitle, dialogText) {
-        _showMessageDialogWorker(mainWindow, dialogTitle,
-                                 dialogText + " " + qsTr("Click Ok to reboot the vehicle now."),
-                                 Dialog.Ok | Dialog.Cancel,
-                                 function() {
-                                     const activeVehicle = QGroundControl.multiVehicleManager.activeVehicle
-                                     if (activeVehicle) {
-                                         activeVehicle.rebootVehicle()
-                                     }
-                                 })
+        let dialog = simpleMessageDialogComponent.createObject(mainWindow, {
+            title: dialogTitle,
+            text: dialogText + " " + qsTr("Click Reboot to reboot the vehicle now."),
+            buttons: Dialog.Ok | Dialog.Cancel,
+            acceptButtonText: qsTr("Reboot"),
+            rejectButtonText: qsTr("Continue"),
+            acceptFunction: function() {
+                const activeVehicle = QGroundControl.multiVehicleManager.activeVehicle
+                if (activeVehicle) {
+                    activeVehicle.rebootVehicle()
+                }
+            }
+        })
+        dialog.open()
     }
 
     Connections {

--- a/src/QmlControls/QGCPopupDialog.qml
+++ b/src/QmlControls/QGCPopupDialog.qml
@@ -45,6 +45,8 @@ Popup {
 
     property string title
     property var    buttons:                Dialog.Ok
+    property string acceptButtonText
+    property string rejectButtonText
     property alias  acceptButtonEnabled:    acceptButton.enabled
     property alias  rejectButtonEnabled:    rejectButton.enabled
     property var    dialogProperties
@@ -185,6 +187,15 @@ Popup {
             rejectButton.visible = true
         } else if (buttons & Dialog.Abort) {
             rejectButton.text = qsTr("Abort")
+            rejectButton.visible = true
+        }
+
+        if (acceptButtonText) {
+            acceptButton.text = acceptButtonText
+            acceptButton.visible = true
+        }
+        if (rejectButtonText) {
+            rejectButton.text = rejectButtonText
             rejectButton.visible = true
         }
 


### PR DESCRIPTION
## Summary
Rename the vehicle-reboot-required dialog buttons from Ok/Cancel to Reboot/Continue.

## Problem
Ok is the highlighted action and reboots the vehicle. Configuring several reboot-required parameters makes it easy to reboot after each change.

## Solution
Keep the Ok/Cancel roles, override the labels to Reboot and Continue, and match the prompt text. Continue dismisses; Reboot still reboots.