### PR TITLE
feat(Actuators): per-channel protocol column on PWM outputs

### DIFF
--- a/src/AutoPilotPlugins/PX4/ActuatorComponent.qml
+++ b/src/AutoPilotPlugins/PX4/ActuatorComponent.qml
@@ -436,12 +436,101 @@ SetupPage {
                             }
 
 
+                            // PWM/timer outputs: one row per channel, protocol as a column.
+                            // Channels that share a timer bind the same primary Fact, so changing
+                            // any protocol dropdown in the group updates the rest.
+                            GridLayout {
+                                id: protocolGrid
+                                visible: selActuatorOutput.actuatorOutput.hasPrimaryProtocol && selActuatorOutput.actuatorOutput.groupsVisible
+                                property var output:            selActuatorOutput.actuatorOutput
+                                property var channelConfigs:    output.tableChannelConfigs
+                                property real groupGap:         ScreenTools.defaultFontPixelHeight / 2
+
+                                rows:       output.tableRowCount
+                                columns:    2 + (channelConfigs ? channelConfigs.count : 0)
+                                columnSpacing: ScreenTools.defaultFontPixelWidth
+                                rowSpacing:    ScreenTools.defaultFontPixelHeight / 6
+
+                                QGCLabel {
+                                    text:           ""
+                                    Layout.row:     0
+                                    Layout.column:  0
+                                }
+                                QGCLabel {
+                                    text:           qsTr("Protocol")
+                                    Layout.row:     0
+                                    Layout.column:  1
+                                }
+                                Repeater {
+                                    model: protocolGrid.channelConfigs
+                                    QGCLabel {
+                                        text:           object.label
+                                        visible:        _showAdvanced || !object.advanced
+                                        Layout.row:     0
+                                        Layout.column:  2 + index
+                                    }
+                                }
+
+                                Repeater {
+                                    model: protocolGrid.output.channelRows
+                                    QGCLabel {
+                                        visible:            object.showTimerHeader
+                                        text:               qsTr("Timer %1").arg(object.timerIndex)
+                                        font.bold:          true
+                                        Layout.row:         object.headerGridRow
+                                        Layout.column:      0
+                                        Layout.columnSpan:  protocolGrid.columns
+                                        Layout.topMargin:   object.timerIndex > 1 ? protocolGrid.groupGap : 0
+                                    }
+                                }
+                                Repeater {
+                                    model: protocolGrid.output.channelRows
+                                    QGCLabel {
+                                        text:               object.label + ":"
+                                        Layout.row:         object.gridRow
+                                        Layout.column:      0
+                                        Layout.alignment:   Qt.AlignVCenter
+                                    }
+                                }
+                                Repeater {
+                                    model: protocolGrid.output.channelRows
+                                    ActuatorFact {
+                                        fact:               object.primaryParam ? object.primaryParam.fact : null
+                                        visible:            object.primaryParam != null
+                                        Layout.row:         object.gridRow
+                                        Layout.column:      1
+                                        Layout.alignment:   Qt.AlignVCenter
+                                    }
+                                }
+                                Repeater {
+                                    model: protocolGrid.output.channelRows
+                                    Repeater {
+                                        property var rowObj:    object
+                                        model:                  object.channel.configInstances
+                                        Item {
+                                            visible:            _showAdvanced || !object.config.advanced
+                                            implicitWidth:      cellFact.visible ? cellFact.implicitWidth : 0
+                                            implicitHeight:     cellFact.visible ? cellFact.implicitHeight : ScreenTools.defaultFontPixelHeight
+                                            Layout.row:         rowObj.gridRow
+                                            Layout.column:      2 + index
+                                            Layout.alignment:   Qt.AlignVCenter
+                                            ActuatorFact {
+                                                id:         cellFact
+                                                fact:       object.fact
+                                                visible:    object.config.visible
+                                            }
+                                        }
+                                    }
+                                }
+                            }
+
+                            // Non-timer outputs (UAVCAN, etc.): keep labeled subgroups.
                             Repeater {
                                 model: selActuatorOutput.actuatorOutput.subgroups
 
                                 ColumnLayout {
                                     property var subgroup: object
-                                    visible:               selActuatorOutput.actuatorOutput.groupsVisible
+                                    visible:               !selActuatorOutput.actuatorOutput.hasPrimaryProtocol && selActuatorOutput.actuatorOutput.groupsVisible
 
                                     RowLayout {
                                         visible: subgroup.label != ""
@@ -465,7 +554,6 @@ SetupPage {
                                             text: ""
                                         }
 
-                                        // param config labels
                                         Repeater {
                                             model: subgroup.channelConfigs
                                             QGCLabel {
@@ -475,7 +563,6 @@ SetupPage {
                                                 Layout.column:  1 + index
                                             }
                                         }
-                                        // param instances
                                         Repeater {
                                             model: subgroup.channels
                                             QGCLabel {
@@ -500,7 +587,6 @@ SetupPage {
                                         }
                                     }
 
-                                    // extra subgroup config params
                                     Repeater {
                                         model: subgroup.configParams
 
@@ -516,6 +602,22 @@ SetupPage {
 
                                 }
                             } // subgroup Repeater
+
+                            Repeater {
+                                model: selActuatorOutput.actuatorOutput.subgroups
+                                visible: selActuatorOutput.actuatorOutput.hasPrimaryProtocol
+                                Repeater {
+                                    model: object.configParams
+                                    RowLayout {
+                                        QGCLabel {
+                                            text: object.label + ":"
+                                        }
+                                        ActuatorFact {
+                                            fact: object.fact
+                                        }
+                                    }
+                                }
+                            }
 
                             // extra actuator config params
                             Repeater {

--- a/src/AutoPilotPlugins/PX4/ActuatorComponent.qml
+++ b/src/AutoPilotPlugins/PX4/ActuatorComponent.qml
@@ -506,9 +506,9 @@ SetupPage {
                                     model: protocolGrid.output.channelRows
                                     Repeater {
                                         property var rowObj:    object
-                                        model:                  object.channel.configInstances
+                                        model:                  object.configInstances
                                         Item {
-                                            visible:            _showAdvanced || !object.config.advanced
+                                            visible:            object.hasConfig && (_showAdvanced || !object.advanced)
                                             implicitWidth:      cellFact.visible ? cellFact.implicitWidth : 0
                                             implicitHeight:     cellFact.visible ? cellFact.implicitHeight : ScreenTools.defaultFontPixelHeight
                                             Layout.row:         rowObj.gridRow
@@ -517,7 +517,7 @@ SetupPage {
                                             ActuatorFact {
                                                 id:         cellFact
                                                 fact:       object.fact
-                                                visible:    object.config.visible
+                                                visible:    object.visible
                                             }
                                         }
                                     }

--- a/src/Vehicle/Actuators/ActuatorOutputs.cc
+++ b/src/Vehicle/Actuators/ActuatorOutputs.cc
@@ -3,6 +3,9 @@
 #include "ParameterManager.h"
 #include "QGCLoggingCategory.h"
 
+#include <QtCore/QHash>
+#include <QtCore/QSet>
+
 QGC_LOGGING_CATEGORY(ActuatorOutputsLog, "Vehicle.Actuators.ActuatorOutputs")
 
 using namespace ActuatorOutputs;
@@ -23,7 +26,7 @@ ActuatorOutputChannel::ActuatorOutputChannel(QObject *parent, const QString &lab
         param.replace("${i}", sparamIndex);
 
         Fact* fact = nullptr;
-        if (parameterManager->parameterExists(ParameterManager::defaultComponentId, param)) {
+        if (parameterManager && parameterManager->parameterExists(ParameterManager::defaultComponentId, param)) {
             fact = parameterManager->getParameter(ParameterManager::defaultComponentId, param);
             if (channelConfig->displayOption() == Parameter::DisplayOption::Bitset) {
                 fact = new FactBitset(channelConfig, fact, paramIndex + channelConfig->indexOffset());
@@ -76,9 +79,85 @@ void ActuatorOutput::addSubgroup(ActuatorOutputSubgroup *subgroup)
     emit subgroupsChanged();
 }
 
+ActuatorChannelCell::ActuatorChannelCell(QObject *parent, ChannelConfigInstance *instance)
+    : QObject(parent)
+    , _instance(instance)
+{
+    if (_instance && _instance->channelConfig()) {
+        connect(_instance->channelConfig(), &ChannelConfig::visibleChanged, this, &ActuatorChannelCell::visibleChanged);
+    }
+}
+
+Fact* ActuatorChannelCell::fact()
+{
+    return _instance ? _instance->fact() : nullptr;
+}
+
+bool ActuatorChannelCell::visible() const
+{
+    return _instance && _instance->channelConfig() && _instance->channelConfig()->visible();
+}
+
+bool ActuatorChannelCell::advanced() const
+{
+    return _instance && _instance->channelConfig() && _instance->channelConfig()->advanced();
+}
+
+ActuatorChannelRow::ActuatorChannelRow(QObject *parent, ActuatorOutputChannel *channel, ConfigParameter *primaryParam,
+        bool firstInGroup, int timerIndex, int gridRow, int headerGridRow, bool showTimerHeader,
+        const QStringList &tableKeys)
+    : QObject(parent)
+    , _channel(channel)
+    , _primaryParam(primaryParam)
+    , _firstInGroup(firstInGroup)
+    , _timerIndex(timerIndex)
+    , _gridRow(gridRow)
+    , _headerGridRow(headerGridRow)
+    , _showTimerHeader(showTimerHeader)
+{
+    QHash<QString, ChannelConfigInstance*> byParam;
+    if (_channel) {
+        QmlObjectListModel *instances = _channel->configInstances();
+        for (int i = 0; i < instances->count(); i++) {
+            auto instance = qobject_cast<ChannelConfigInstance*>(instances->get(i));
+            if (instance && instance->channelConfig()) {
+                byParam.insert(instance->channelConfig()->parameter(), instance);
+            }
+        }
+    }
+    for (const QString &key : tableKeys) {
+        _configInstances->append(new ActuatorChannelCell(this, byParam.value(key, nullptr)));
+    }
+}
+
 void ActuatorOutput::rebuildChannelRows()
 {
     _channelRows->clearAndDeleteContents();
+    _tableChannelConfigs->clear();
+
+    // Union by parameter name so subgroups with extra per-channel params still get a header.
+    QStringList tableKeys;
+    QSet<QString> seenKeys;
+    for (int sgIdx = 0; sgIdx < _subgroups->count(); sgIdx++) {
+        ActuatorOutputSubgroup *subgroup = qobject_cast<ActuatorOutputSubgroup*>(_subgroups->get(sgIdx));
+        if (!subgroup) {
+            continue;
+        }
+        for (int cfgIdx = 0; cfgIdx < subgroup->channelConfigs()->count(); cfgIdx++) {
+            ChannelConfig *config = qobject_cast<ChannelConfig*>(subgroup->channelConfigs()->get(cfgIdx));
+            if (!config) {
+                continue;
+            }
+            const QString key = config->parameter();
+            if (seenKeys.contains(key)) {
+                continue;
+            }
+            seenKeys.insert(key);
+            tableKeys.append(key);
+            _tableChannelConfigs->append(config);
+        }
+    }
+
     const bool shared = hasSharedTimerGroups();
     int timerIndex = 0;
     int gridRow = 1;
@@ -95,7 +174,7 @@ void ActuatorOutput::rebuildChannelRows()
                 continue;
             }
             _channelRows->append(new ActuatorChannelRow(this, channel, subgroup->primaryParam(),
-                    chIdx == 0, timerIndex, gridRow, headerGridRow, shared && chIdx == 0));
+                    chIdx == 0, timerIndex, gridRow, headerGridRow, shared && chIdx == 0, tableKeys));
             ++gridRow;
         }
     }
@@ -123,15 +202,6 @@ bool ActuatorOutput::hasSharedTimerGroups() const
         }
     }
     return false;
-}
-
-QmlObjectListModel* ActuatorOutput::tableChannelConfigs()
-{
-    if (_subgroups->count() == 0) {
-        return nullptr;
-    }
-    ActuatorOutputSubgroup *subgroup = qobject_cast<ActuatorOutputSubgroup*>(_subgroups->get(0));
-    return subgroup ? subgroup->channelConfigs() : nullptr;
 }
 
 void ActuatorOutput::addConfigParam(ConfigParameter *param)

--- a/src/Vehicle/Actuators/ActuatorOutputs.cc
+++ b/src/Vehicle/Actuators/ActuatorOutputs.cc
@@ -76,6 +76,64 @@ void ActuatorOutput::addSubgroup(ActuatorOutputSubgroup *subgroup)
     emit subgroupsChanged();
 }
 
+void ActuatorOutput::rebuildChannelRows()
+{
+    _channelRows->clearAndDeleteContents();
+    const bool shared = hasSharedTimerGroups();
+    int timerIndex = 0;
+    int gridRow = 1;
+    for (int sgIdx = 0; sgIdx < _subgroups->count(); sgIdx++) {
+        ActuatorOutputSubgroup *subgroup = qobject_cast<ActuatorOutputSubgroup*>(_subgroups->get(sgIdx));
+        if (!subgroup || subgroup->channels()->count() == 0) {
+            continue;
+        }
+        ++timerIndex;
+        const int headerGridRow = shared ? gridRow++ : 0;
+        for (int chIdx = 0; chIdx < subgroup->channels()->count(); chIdx++) {
+            ActuatorOutputChannel *channel = qobject_cast<ActuatorOutputChannel*>(subgroup->channels()->get(chIdx));
+            if (!channel) {
+                continue;
+            }
+            _channelRows->append(new ActuatorChannelRow(this, channel, subgroup->primaryParam(),
+                    chIdx == 0, timerIndex, gridRow, headerGridRow, shared && chIdx == 0));
+            ++gridRow;
+        }
+    }
+    _tableRowCount = gridRow;
+    emit subgroupsChanged();
+}
+
+bool ActuatorOutput::hasPrimaryProtocol() const
+{
+    for (int sgIdx = 0; sgIdx < _subgroups->count(); sgIdx++) {
+        ActuatorOutputSubgroup *subgroup = qobject_cast<ActuatorOutputSubgroup*>(_subgroups->get(sgIdx));
+        if (subgroup && subgroup->primaryParam() && subgroup->primaryParam()->fact()) {
+            return true;
+        }
+    }
+    return false;
+}
+
+bool ActuatorOutput::hasSharedTimerGroups() const
+{
+    for (int sgIdx = 0; sgIdx < _subgroups->count(); sgIdx++) {
+        ActuatorOutputSubgroup *subgroup = qobject_cast<ActuatorOutputSubgroup*>(_subgroups->get(sgIdx));
+        if (subgroup && subgroup->channels()->count() > 1) {
+            return true;
+        }
+    }
+    return false;
+}
+
+QmlObjectListModel* ActuatorOutput::tableChannelConfigs()
+{
+    if (_subgroups->count() == 0) {
+        return nullptr;
+    }
+    ActuatorOutputSubgroup *subgroup = qobject_cast<ActuatorOutputSubgroup*>(_subgroups->get(0));
+    return subgroup ? subgroup->channelConfigs() : nullptr;
+}
+
 void ActuatorOutput::addConfigParam(ConfigParameter *param)
 {
     if (param->function() == ConfigParameter::Function::Enable) {

--- a/src/Vehicle/Actuators/ActuatorOutputs.h
+++ b/src/Vehicle/Actuators/ActuatorOutputs.h
@@ -133,6 +133,53 @@ private:
     QmlObjectListModel* _configInstances = new QmlObjectListModel(this); ///< list of ChannelConfigInstance*
 };
 
+/**
+ * One channel in a flattened output table. Channels in the same timer subgroup
+ * share primaryParam so their protocol dropdowns stay in sync.
+ */
+class ActuatorChannelRow : public QObject
+{
+    Q_OBJECT
+public:
+    ActuatorChannelRow(QObject* parent, ActuatorOutputChannel* channel, ConfigParameter* primaryParam,
+            bool firstInGroup, int timerIndex, int gridRow, int headerGridRow, bool showTimerHeader)
+        : QObject(parent)
+        , _channel(channel)
+        , _primaryParam(primaryParam)
+        , _firstInGroup(firstInGroup)
+        , _timerIndex(timerIndex)
+        , _gridRow(gridRow)
+        , _headerGridRow(headerGridRow)
+        , _showTimerHeader(showTimerHeader) {}
+
+    Q_PROPERTY(QString label                    READ label            CONSTANT)
+    Q_PROPERTY(ActuatorOutputChannel* channel   READ channel          CONSTANT)
+    Q_PROPERTY(ConfigParameter* primaryParam    READ primaryParam     CONSTANT)
+    Q_PROPERTY(bool firstInGroup                READ firstInGroup     CONSTANT)
+    Q_PROPERTY(int timerIndex                   READ timerIndex       CONSTANT)
+    Q_PROPERTY(int gridRow                      READ gridRow          CONSTANT)
+    Q_PROPERTY(int headerGridRow                READ headerGridRow    CONSTANT)
+    Q_PROPERTY(bool showTimerHeader             READ showTimerHeader  CONSTANT)
+
+    const QString& label() const { return _channel->label(); }
+    ActuatorOutputChannel* channel() const { return _channel; }
+    ConfigParameter* primaryParam() const { return _primaryParam; }
+    bool firstInGroup() const { return _firstInGroup; }
+    int timerIndex() const { return _timerIndex; }
+    int gridRow() const { return _gridRow; }
+    int headerGridRow() const { return _headerGridRow; }
+    bool showTimerHeader() const { return _showTimerHeader; }
+
+private:
+    ActuatorOutputChannel* _channel{nullptr};
+    ConfigParameter* _primaryParam{nullptr};
+    const bool _firstInGroup;
+    const int _timerIndex{0};
+    const int _gridRow{0};
+    const int _headerGridRow{0};
+    const bool _showTimerHeader{false};
+};
+
 class ActuatorOutputSubgroup : public QObject
 {
     Q_OBJECT
@@ -184,21 +231,32 @@ class ActuatorOutput : public QObject
 public:
     ActuatorOutput(QObject* parent, const QString& label, const Condition& groupVisibilityCondition);
 
-    Q_PROPERTY(QString label                     READ label              CONSTANT)
-    Q_PROPERTY(bool groupsVisible                READ groupsVisible      NOTIFY groupsVisibleChanged)
-    Q_PROPERTY(QmlObjectListModel* subgroups     READ subgroups          NOTIFY subgroupsChanged)
-    Q_PROPERTY(ConfigParameter* enableParam      READ enableParam        CONSTANT)
-    Q_PROPERTY(QmlObjectListModel* configParams  READ configParams       CONSTANT)
-    Q_PROPERTY(QStringList notes                 READ notes              NOTIFY notesChanged)
+    Q_PROPERTY(QString label                            READ label                   CONSTANT)
+    Q_PROPERTY(bool groupsVisible                       READ groupsVisible           NOTIFY groupsVisibleChanged)
+    Q_PROPERTY(QmlObjectListModel* subgroups            READ subgroups               NOTIFY subgroupsChanged)
+    Q_PROPERTY(QmlObjectListModel* channelRows          READ channelRows             CONSTANT)
+    Q_PROPERTY(QmlObjectListModel* tableChannelConfigs  READ tableChannelConfigs     NOTIFY subgroupsChanged)
+    Q_PROPERTY(bool hasPrimaryProtocol                  READ hasPrimaryProtocol      NOTIFY subgroupsChanged)
+    Q_PROPERTY(bool hasSharedTimerGroups                READ hasSharedTimerGroups    NOTIFY subgroupsChanged)
+    Q_PROPERTY(int tableRowCount                        READ tableRowCount           NOTIFY subgroupsChanged)
+    Q_PROPERTY(ConfigParameter* enableParam             READ enableParam             CONSTANT)
+    Q_PROPERTY(QmlObjectListModel* configParams         READ configParams            CONSTANT)
+    Q_PROPERTY(QStringList notes                        READ notes                   NOTIFY notesChanged)
 
     const QString& label() const { return _label; }
 
     QmlObjectListModel* subgroups() { return _subgroups; }
+    QmlObjectListModel* channelRows() { return _channelRows; }
+    QmlObjectListModel* tableChannelConfigs();
+    bool hasPrimaryProtocol() const;
+    bool hasSharedTimerGroups() const;
+    int tableRowCount() const { return _tableRowCount; }
     bool groupsVisible() const { return _groupVisibilityCondition.evaluate(); }
     ConfigParameter* enableParam() const { return _enableParam; }
     QmlObjectListModel* configParams() { return _params; }
 
     void addSubgroup(ActuatorOutputSubgroup* subgroup);
+    void rebuildChannelRows();
 
     void addConfigParam(ConfigParameter* param);
 
@@ -221,6 +279,8 @@ private:
     const QString _label;
     const Condition _groupVisibilityCondition;
     QmlObjectListModel* _subgroups = new QmlObjectListModel(this); ///< list of ActuatorOutputSubgroup*
+    QmlObjectListModel* _channelRows = new QmlObjectListModel(this); ///< list of ActuatorChannelRow*
+    int _tableRowCount{1};
 
     ConfigParameter* _enableParam{nullptr};
     QmlObjectListModel* _params  = new QmlObjectListModel(this); ///< list of ConfigParameter*

--- a/src/Vehicle/Actuators/ActuatorOutputs.h
+++ b/src/Vehicle/Actuators/ActuatorOutputs.h
@@ -6,6 +6,7 @@
 
 #include <QtCore/QObject>
 #include <QtCore/QString>
+#include <QtCore/QStringList>
 
 #include <functional>
 
@@ -133,6 +134,31 @@ private:
     QmlObjectListModel* _configInstances = new QmlObjectListModel(this); ///< list of ChannelConfigInstance*
 };
 
+/// One cell in a flattened output row, aligned to ActuatorOutput::tableChannelConfigs().
+class ActuatorChannelCell : public QObject
+{
+    Q_OBJECT
+    Q_MOC_INCLUDE("Fact.h")
+public:
+    ActuatorChannelCell(QObject* parent, ChannelConfigInstance* instance);
+
+    Q_PROPERTY(Fact* fact           READ fact           CONSTANT)
+    Q_PROPERTY(bool visible         READ visible        NOTIFY visibleChanged)
+    Q_PROPERTY(bool advanced        READ advanced       CONSTANT)
+    Q_PROPERTY(bool hasConfig       READ hasConfig      CONSTANT)
+
+    Fact* fact();
+    bool visible() const;
+    bool advanced() const;
+    bool hasConfig() const { return _instance != nullptr; }
+
+signals:
+    void visibleChanged();
+
+private:
+    ChannelConfigInstance* _instance{nullptr};
+};
+
 /**
  * One channel in a flattened output table. Channels in the same timer subgroup
  * share primaryParam so their protocol dropdowns stay in sync.
@@ -142,28 +168,23 @@ class ActuatorChannelRow : public QObject
     Q_OBJECT
 public:
     ActuatorChannelRow(QObject* parent, ActuatorOutputChannel* channel, ConfigParameter* primaryParam,
-            bool firstInGroup, int timerIndex, int gridRow, int headerGridRow, bool showTimerHeader)
-        : QObject(parent)
-        , _channel(channel)
-        , _primaryParam(primaryParam)
-        , _firstInGroup(firstInGroup)
-        , _timerIndex(timerIndex)
-        , _gridRow(gridRow)
-        , _headerGridRow(headerGridRow)
-        , _showTimerHeader(showTimerHeader) {}
+            bool firstInGroup, int timerIndex, int gridRow, int headerGridRow, bool showTimerHeader,
+            const QStringList& tableKeys);
 
-    Q_PROPERTY(QString label                    READ label            CONSTANT)
-    Q_PROPERTY(ActuatorOutputChannel* channel   READ channel          CONSTANT)
-    Q_PROPERTY(ConfigParameter* primaryParam    READ primaryParam     CONSTANT)
-    Q_PROPERTY(bool firstInGroup                READ firstInGroup     CONSTANT)
-    Q_PROPERTY(int timerIndex                   READ timerIndex       CONSTANT)
-    Q_PROPERTY(int gridRow                      READ gridRow          CONSTANT)
-    Q_PROPERTY(int headerGridRow                READ headerGridRow    CONSTANT)
-    Q_PROPERTY(bool showTimerHeader             READ showTimerHeader  CONSTANT)
+    Q_PROPERTY(QString label                        READ label            CONSTANT)
+    Q_PROPERTY(ActuatorOutputChannel* channel       READ channel          CONSTANT)
+    Q_PROPERTY(ConfigParameter* primaryParam        READ primaryParam     CONSTANT)
+    Q_PROPERTY(QmlObjectListModel* configInstances  READ configInstances  CONSTANT)
+    Q_PROPERTY(bool firstInGroup                    READ firstInGroup     CONSTANT)
+    Q_PROPERTY(int timerIndex                       READ timerIndex       CONSTANT)
+    Q_PROPERTY(int gridRow                          READ gridRow          CONSTANT)
+    Q_PROPERTY(int headerGridRow                    READ headerGridRow    CONSTANT)
+    Q_PROPERTY(bool showTimerHeader                 READ showTimerHeader  CONSTANT)
 
     const QString& label() const { return _channel->label(); }
     ActuatorOutputChannel* channel() const { return _channel; }
     ConfigParameter* primaryParam() const { return _primaryParam; }
+    QmlObjectListModel* configInstances() { return _configInstances; }
     bool firstInGroup() const { return _firstInGroup; }
     int timerIndex() const { return _timerIndex; }
     int gridRow() const { return _gridRow; }
@@ -173,6 +194,7 @@ public:
 private:
     ActuatorOutputChannel* _channel{nullptr};
     ConfigParameter* _primaryParam{nullptr};
+    QmlObjectListModel* _configInstances = new QmlObjectListModel(this); ///< list of ActuatorChannelCell*
     const bool _firstInGroup;
     const int _timerIndex{0};
     const int _gridRow{0};
@@ -247,7 +269,7 @@ public:
 
     QmlObjectListModel* subgroups() { return _subgroups; }
     QmlObjectListModel* channelRows() { return _channelRows; }
-    QmlObjectListModel* tableChannelConfigs();
+    QmlObjectListModel* tableChannelConfigs() { return _tableChannelConfigs; }
     bool hasPrimaryProtocol() const;
     bool hasSharedTimerGroups() const;
     int tableRowCount() const { return _tableRowCount; }
@@ -280,6 +302,7 @@ private:
     const Condition _groupVisibilityCondition;
     QmlObjectListModel* _subgroups = new QmlObjectListModel(this); ///< list of ActuatorOutputSubgroup*
     QmlObjectListModel* _channelRows = new QmlObjectListModel(this); ///< list of ActuatorChannelRow*
+    QmlObjectListModel* _tableChannelConfigs = new QmlObjectListModel(this); ///< union of ChannelConfig*, not owned
     int _tableRowCount{1};
 
     ConfigParameter* _enableParam{nullptr};

--- a/src/Vehicle/Actuators/Actuators.cc
+++ b/src/Vehicle/Actuators/Actuators.cc
@@ -527,6 +527,8 @@ bool Actuators::parseJson(const QJsonDocument &json)
                                 _vehicle->parameterManager(), [this](Fact* fact) { subscribeFact(fact); }));
             }
         }
+
+        currentActuatorOutput->rebuildChannelRows();
     }
 
     _showUi = makeConditionFromValue(QJsonValue(obj), "show-ui-if");

--- a/test/Vehicle/Actuators/ActuatorOutputsTest.cc
+++ b/test/Vehicle/Actuators/ActuatorOutputsTest.cc
@@ -1,0 +1,109 @@
+#include "ActuatorOutputsTest.h"
+
+#include <QtCore/QFile>
+#include <QtCore/QJsonArray>
+#include <QtCore/QJsonDocument>
+#include <QtCore/QJsonObject>
+
+#include "ActuatorOutputs.h"
+
+using namespace ActuatorOutputs;
+
+namespace {
+
+QJsonObject auxOutputFromFixture()
+{
+    QFile file(QStringLiteral(":/unittest/actuators.example.json"));
+    if (!file.open(QIODevice::ReadOnly)) {
+        return {};
+    }
+    const QJsonDocument doc = QJsonDocument::fromJson(file.readAll());
+    const QJsonArray outputs = doc.object().value(QStringLiteral("outputs_v1")).toArray();
+    for (const QJsonValue& outputVal : outputs) {
+        const QJsonObject output = outputVal.toObject();
+        if (output.value(QStringLiteral("label")).toString() == QLatin1String("AUX")) {
+            return output;
+        }
+    }
+    return {};
+}
+
+void addSubgroupFromJson(ActuatorOutput* output, const QJsonObject& subgroupJson)
+{
+    auto* subgroup = new ActuatorOutputSubgroup(output, subgroupJson.value(QStringLiteral("label")).toString());
+    const QJsonArray channelParameters = subgroupJson.value(QStringLiteral("per-channel-parameters")).toArray();
+    for (const QJsonValue& paramVal : channelParameters) {
+        Parameter param;
+        param.parse(paramVal);
+        subgroup->addChannelConfig(
+            new ChannelConfig(subgroup, param, ChannelConfig::Function::Unspecified, Condition()));
+    }
+    const QJsonArray channels = subgroupJson.value(QStringLiteral("channels")).toArray();
+    for (const QJsonValue& channelVal : channels) {
+        const QJsonObject channel = channelVal.toObject();
+        subgroup->addChannel(new ActuatorOutputChannel(subgroup, channel.value(QStringLiteral("label")).toString(),
+                                                       channel.value(QStringLiteral("param-index")).toInt(),
+                                                       *subgroup->channelConfigs(), nullptr, [](Fact*) {}));
+    }
+    output->addSubgroup(subgroup);
+}
+
+ActuatorChannelRow* rowByLabel(ActuatorOutput* output, const QString& label)
+{
+    for (int i = 0; i < output->channelRows()->count(); i++) {
+        auto* row = qobject_cast<ActuatorChannelRow*>(output->channelRows()->get(i));
+        if (row && row->label() == label) {
+            return row;
+        }
+    }
+    return nullptr;
+}
+
+}  // namespace
+
+void ActuatorOutputsTest::_auxTableUnionsDshotMin()
+{
+    const QJsonObject auxJson = auxOutputFromFixture();
+    QVERIFY(!auxJson.isEmpty());
+
+    ActuatorOutput output(this, QStringLiteral("AUX"), Condition());
+    const QJsonArray subgroups = auxJson.value(QStringLiteral("subgroups")).toArray();
+    for (const QJsonValue& subgroupVal : subgroups) {
+        addSubgroupFromJson(&output, subgroupVal.toObject());
+    }
+    output.rebuildChannelRows();
+
+    QCOMPARE(output.tableChannelConfigs()->count(), 6);
+    auto* dshotMin = qobject_cast<ChannelConfig*>(output.tableChannelConfigs()->get(5));
+    QVERIFY(dshotMin);
+    QCOMPARE(dshotMin->parameter(), QStringLiteral("DSHOT_FMU_MIN${i}"));
+    QCOMPARE(dshotMin->label(), QStringLiteral("Min"));
+
+    const QStringList pwmOnly = {QStringLiteral("AUX 1"), QStringLiteral("AUX 4"), QStringLiteral("CAP 1")};
+    const QStringList withDshot = {QStringLiteral("AUX 5"), QStringLiteral("AUX 6"), QStringLiteral("AUX 7"),
+                                   QStringLiteral("AUX 8")};
+
+    for (int i = 0; i < output.channelRows()->count(); i++) {
+        auto* row = qobject_cast<ActuatorChannelRow*>(output.channelRows()->get(i));
+        QVERIFY(row);
+        QCOMPARE(row->configInstances()->count(), output.tableChannelConfigs()->count());
+    }
+
+    for (const QString& label : pwmOnly) {
+        ActuatorChannelRow* row = rowByLabel(&output, label);
+        QVERIFY2(row, qPrintable(label));
+        auto* cell = qobject_cast<ActuatorChannelCell*>(row->configInstances()->get(5));
+        QVERIFY(cell);
+        QVERIFY(!cell->hasConfig());
+    }
+    for (const QString& label : withDshot) {
+        ActuatorChannelRow* row = rowByLabel(&output, label);
+        QVERIFY2(row, qPrintable(label));
+        auto* cell = qobject_cast<ActuatorChannelCell*>(row->configInstances()->get(5));
+        QVERIFY(cell);
+        QVERIFY(cell->hasConfig());
+        QCOMPARE(row->channel()->configInstances()->count(), 6);
+    }
+}
+
+UT_REGISTER_TEST_LIGHTWEIGHT(ActuatorOutputsTest, TestLabel::Unit, TestLabel::Vehicle)

--- a/test/Vehicle/Actuators/ActuatorOutputsTest.h
+++ b/test/Vehicle/Actuators/ActuatorOutputsTest.h
@@ -1,0 +1,11 @@
+#pragma once
+
+#include "UnitTest.h"
+
+class ActuatorOutputsTest : public UnitTest
+{
+    Q_OBJECT
+
+private slots:
+    void _auxTableUnionsDshotMin();
+};

--- a/test/Vehicle/Actuators/CMakeLists.txt
+++ b/test/Vehicle/Actuators/CMakeLists.txt
@@ -1,0 +1,5 @@
+target_sources(${CMAKE_PROJECT_NAME} PRIVATE ActuatorOutputsTest.cc ActuatorOutputsTest.h)
+
+target_include_directories(${CMAKE_PROJECT_NAME} PRIVATE ${CMAKE_CURRENT_SOURCE_DIR})
+
+add_qgc_test(ActuatorOutputsTest LABELS Unit Vehicle)

--- a/test/Vehicle/CMakeLists.txt
+++ b/test/Vehicle/CMakeLists.txt
@@ -50,6 +50,11 @@ target_sources(${CMAKE_PROJECT_NAME}
 target_include_directories(${CMAKE_PROJECT_NAME} PRIVATE ${CMAKE_CURRENT_SOURCE_DIR})
 
 # ----------------------------------------------------------------------------
+# Actuator Tests
+# ----------------------------------------------------------------------------
+add_subdirectory(Actuators)
+
+# ----------------------------------------------------------------------------
 # Component Information Tests
 # ----------------------------------------------------------------------------
 add_subdirectory(ComponentInformation)


### PR DESCRIPTION
## Summary
Flatten PWM actuator outputs into one table with protocol as a column.

## Problem
QGC grouped channels by timer and put the protocol dropdown on the group. That matches STM32 (several pins per timer) but not iMXRT, where each FlexPWM submodule is its own timer, so the page became one block per pin.

## Solution
Render every PWM channel as a row and put protocol in a column. Channels that share a timer still share one TIM parameter, so changing any dropdown in the group updates the rest. Timer N headers appear only when a timer has multiple channels. UAVCAN and other non-timer outputs keep the old subgroup layout.
<img width="2285" height="1375" alt="Screenshot from 2026-08-27 11-57-28" src="https://github.com/user-attachments/assets/a0b1e1fd-3d88-46bb-add9-d7966474ac20" />
<img width="2285" height="1375" alt="Screenshot from 2026-08-27 11-56-44" src="https://github.com/user-attachments/assets/90b44071-08ef-410f-bca5-4c50704c0d1c" />

