### PR TITLE
fix(APMFirmwarePlugin): start mission correctly for already-armed vehicles (Stable_V5.1)

### DIFF
--- a/src/Comms/MockLink/MockLink.cc
+++ b/src/Comms/MockLink/MockLink.cc
@@ -59,6 +59,103 @@ QList<MockLink::FlightMode_t> MockLink::_availableFlightModes = {
     { "MockLink Mode (delayed)",0,                          PX4CustomMode::AUTO_FOLLOW_TARGET,  true,       false},
 };
 
+// The ArduPilot lists below mirror the availableFlightModes lists in the corresponding
+// firmware plugins (names and custom mode values must match) so that StandardModes streaming
+// results in the same mode names the plugins use.
+QList<MockLink::FlightMode_t> MockLink::_apmCopterAvailableFlightModes = {
+    // Mode Name          Standard Mode   Custom Mode     CanBeSet    adv
+    { "Stabilize",        0,              0,              true,       true },
+    { "Acro",             0,              1,              true,       true },
+    { "Altitude Hold",    0,              2,              true,       true },
+    { "Auto",             0,              3,              true,       true },
+    { "Guided",           0,              4,              true,       true },
+    { "Loiter",           0,              5,              true,       true },
+    { "RTL",              0,              6,              true,       true },
+    { "Circle",           0,              7,              true,       true },
+    { "Land",             0,              9,              true,       true },
+    { "Drift",            0,              11,             true,       true },
+    { "Sport",            0,              13,             true,       true },
+    { "Flip",             0,              14,             true,       true },
+    { "Autotune",         0,              15,             true,       true },
+    { "Position Hold",    0,              16,             true,       true },
+    { "Brake",            0,              17,             true,       true },
+    { "Throw",            0,              18,             true,       true },
+    { "Avoid ADSB",       0,              19,             true,       true },
+    { "Guided No GPS",    0,              20,             true,       true },
+    { "Smart RTL",        0,              21,             true,       true },
+    { "Flow Hold",        0,              22,             true,       true },
+    { "Follow",           0,              23,             true,       true },
+    { "ZigZag",           0,              24,             true,       true },
+    { "SystemID",         0,              25,             true,       true },
+    { "AutoRotate",       0,              26,             true,       true },
+    { "AutoRTL",          0,              27,             true,       true },
+    { "Turtle",           0,              28,             true,       true },
+};
+
+QList<MockLink::FlightMode_t> MockLink::_apmPlaneAvailableFlightModes = {
+    // Mode Name              Standard Mode   Custom Mode     CanBeSet    adv
+    { "Manual",               0,              0,              true,       true },
+    { "Circle",               0,              1,              true,       true },
+    { "Stabilize",            0,              2,              true,       true },
+    { "Training",             0,              3,              true,       true },
+    { "Acro",                 0,              4,              true,       true },
+    { "FBW A",                0,              5,              true,       true },
+    { "FBW B",                0,              6,              true,       true },
+    { "Cruise",               0,              7,              true,       true },
+    { "Autotune",             0,              8,              true,       true },
+    { "Auto",                 0,              10,             true,       true },
+    { "RTL",                  0,              11,             true,       true },
+    { "Loiter",               0,              12,             true,       true },
+    { "Takeoff",              0,              13,             true,       true },
+    { "Avoid ADSB",           0,              14,             true,       true },
+    { "Guided",               0,              15,             true,       true },
+    { "Initializing",         0,              16,             false,      true },
+    { "QuadPlane Stabilize",  0,              17,             true,       true },
+    { "QuadPlane Hover",      0,              18,             true,       true },
+    { "QuadPlane Loiter",     0,              19,             true,       true },
+    { "QuadPlane Land",       0,              20,             true,       true },
+    { "QuadPlane RTL",        0,              21,             true,       true },
+    { "QuadPlane AutoTune",   0,              22,             true,       true },
+    { "QuadPlane Acro",       0,              23,             true,       true },
+    { "Thermal",              0,              24,             true,       true },
+    { "Loiter to QLand",      0,              25,             true,       true },
+    { "Autoland",             0,              26,             true,       true },
+};
+
+QList<MockLink::FlightMode_t> MockLink::_apmRoverAvailableFlightModes = {
+    // Mode Name          Standard Mode   Custom Mode     CanBeSet    adv
+    { "Manual",           0,              0,              true,       true },
+    { "Acro",             0,              1,              true,       true },
+    { "Learning",         0,              2,              false,      true },
+    { "Steering",         0,              3,              true,       true },
+    { "Hold",             0,              4,              true,       true },
+    { "Loiter",           0,              5,              true,       true },
+    { "Follow",           0,              6,              true,       true },
+    { "Simple",           0,              7,              true,       true },
+    { "Dock",             0,              8,              true,       true },
+    { "Circle",           0,              9,              true,       true },
+    { "Auto",             0,              10,             true,       true },
+    { "RTL",              0,              11,             true,       true },
+    { "Smart RTL",        0,              12,             true,       true },
+    { "Guided",           0,              15,             true,       true },
+    { "Initializing",     0,              16,             false,      true },
+};
+
+QList<MockLink::FlightMode_t> MockLink::_apmSubAvailableFlightModes = {
+    // Mode Name          Standard Mode   Custom Mode     CanBeSet    adv
+    { "Manual",           0,              19,             true,       true },
+    { "Stabilize",        0,              0,              true,       true },
+    { "Acro",             0,              1,              true,       true },
+    { "Depth Hold",       0,              2,              true,       true },
+    { "Auto",             0,              3,              true,       true },
+    { "Guided",           0,              4,              true,       true },
+    { "Circle",           0,              7,              true,       true },
+    { "Surface",          0,              9,              true,       true },
+    { "Position Hold",    0,              16,             true,       true },
+    { "Motor Detection",  0,              20,             false,      true },
+    { "Surftrak",         0,              21,             true,       true },
+};
+
 MockLink::MockLink(SharedLinkConfigurationPtr &config, QObject *parent)
     : LinkInterface(config, parent)
     , _mockConfig(qobject_cast<const MockConfiguration*>(_config.get()))
@@ -697,6 +794,10 @@ void MockLink::_applyAPMFreshFlashState()
 
 void MockLink::_sendHeartBeat()
 {
+    // Like real firmware: ACTIVE while airborne, STANDBY on the ground (same condition as
+    // EXTENDED_SYS_STATE landed state, and what ArduPilot's flying detection in QGC keys off)
+    const uint8_t mavState = (_vehicleAltitudeAMSL > _defaultVehicleHomeAltitude) ? MAV_STATE_ACTIVE : MAV_STATE_STANDBY;
+
     mavlink_message_t msg{};
     (void) mavlink_msg_heartbeat_pack_chan(
         _vehicleSystemId,
@@ -707,7 +808,7 @@ void MockLink::_sendHeartBeat()
         _firmwareType,      // MAV_AUTOPILOT
         _mavBaseMode,       // MAV_MODE
         _mavCustomMode,     // custom mode
-        _mavState           // MAV_STATE
+        mavState            // MAV_STATE
     );
     respondWithMavlinkMessage(msg);
 }
@@ -1931,6 +2032,15 @@ void MockLink::_handleCommandLong(const mavlink_message_t &msg)
         }
         commandResult = MAV_RESULT_ACCEPTED;
         break;
+    case MAV_CMD_DO_SET_MODE:
+        // Preserve the armed flag like real firmware does
+        _mavBaseMode = (_mavBaseMode & MAV_MODE_FLAG_SAFETY_ARMED) | static_cast<uint8_t>(request.param1);
+        _mavCustomMode = static_cast<uint32_t>(request.param2);
+        commandResult = MAV_RESULT_ACCEPTED;
+        break;
+    case MAV_CMD_MISSION_START:
+        commandResult = MAV_RESULT_ACCEPTED;
+        break;
     case MAV_CMD_PREFLIGHT_CALIBRATION:
         _handlePreFlightCalibration(request);
         commandResult = MAV_RESULT_ACCEPTED;
@@ -2076,11 +2186,24 @@ void MockLink::_handleCommandInt(const mavlink_message_t &msg)
     mavlink_command_int_t request{};
     mavlink_msg_command_int_decode(&msg, &request);
 
-    // MockLink does not implement any COMMAND_INT commands yet, so it reports them as
-    // unsupported (mirroring the COMMAND_LONG default for unrecognized commands). This
-    // lets unit tests exercise "try command, fall back to legacy message" code paths
+    // Unrecognized commands are reported as unsupported (mirroring the COMMAND_LONG default).
+    // This lets unit tests exercise "try command, fall back to legacy message" code paths
     // such as Vehicle::setEstimatorOrigin.
-    const uint8_t commandResult = MAV_RESULT_UNSUPPORTED;
+    uint8_t commandResult = MAV_RESULT_UNSUPPORTED;
+
+    switch (request.command) {
+    case MAV_CMD_DO_SET_MODE:
+        // Preserve the armed flag like real firmware does
+        _mavBaseMode = (_mavBaseMode & MAV_MODE_FLAG_SAFETY_ARMED) | static_cast<uint8_t>(request.param1);
+        _mavCustomMode = static_cast<uint32_t>(request.param2);
+        commandResult = MAV_RESULT_ACCEPTED;
+        break;
+    case MAV_CMD_MISSION_START:
+        commandResult = MAV_RESULT_ACCEPTED;
+        break;
+    default:
+        break;
+    }
 
     mavlink_message_t commandAck{};
     (void) mavlink_msg_command_ack_pack_chan(
@@ -2958,8 +3081,8 @@ void MockLink::_handleRequestMessageAvailableModes(const mavlink_command_long_t 
         _availableModesWorkerNextModeIndex = 1; // Start with the first mode in sequence (1-based index)
     } else {
         // Request for specific mode
-        if (request.param2 > _availableFlightModes.count()) {
-            qCWarning(MockLinkLog) << "MAVLINK_MSG_ID_AVAILABLE_MODES: requested mode index out of range" << request.param2 << _availableFlightModes.count();
+        if (request.param2 < 1 || request.param2 > _flightModeList().count()) {
+            qCWarning(MockLinkLog) << "MAVLINK_MSG_ID_AVAILABLE_MODES: requested mode index out of range" << request.param2 << _flightModeList().count();
             accepted = false;
             return;
         }
@@ -3134,14 +3257,14 @@ MockLinkFTP *MockLink::mockLinkFTP() const
 
 void MockLink::_sendAvailableMode(uint8_t modeIndexOneBased)
 {
-    if (modeIndexOneBased > _availableModesCount()) {
+    if (modeIndexOneBased < 1 || modeIndexOneBased > _availableModesCount()) {
         qCWarning(MockLinkLog) << "modeIndexOneBased out of range" << modeIndexOneBased << _availableModesCount();
         return;
     }
 
     qCDebug(MockLinkLog) << "_sendAvailableMode modeIndexOneBased:" << modeIndexOneBased;
 
-    const FlightMode_t &availableMode = _availableFlightModes[modeIndexOneBased - 1];
+    const FlightMode_t &availableMode = _flightModeList()[modeIndexOneBased - 1];
     char modeName[MAVLINK_MSG_AVAILABLE_MODES_FIELD_MODE_NAME_LEN] = {};
     std::strncpy(modeName, availableMode.name, sizeof(modeName) - 1);
 
@@ -3198,7 +3321,28 @@ void MockLink::_sendAvailableModesMonitor()
 
 int MockLink::_availableModesCount() const
 {
-    return _availableFlightModes.count() - (_availableModesMonitorSeqNumber == 0 ? 1 : 0); // Exclude the delayed mode
+    if (_firmwareType == MAV_AUTOPILOT_ARDUPILOTMEGA) {
+        return _flightModeList().count();
+    }
+    return _flightModeList().count() - (_availableModesMonitorSeqNumber == 0 ? 1 : 0); // Exclude the delayed mode
+}
+
+const QList<MockLink::FlightMode_t> &MockLink::_flightModeList() const
+{
+    if (_firmwareType != MAV_AUTOPILOT_ARDUPILOTMEGA) {
+        return _availableFlightModes;
+    }
+
+    switch (_vehicleType) {
+    case MAV_TYPE_FIXED_WING:
+        return _apmPlaneAvailableFlightModes;
+    case MAV_TYPE_GROUND_ROVER:
+        return _apmRoverAvailableFlightModes;
+    case MAV_TYPE_SUBMARINE:
+        return _apmSubAvailableFlightModes;
+    default:
+        return _apmCopterAvailableFlightModes;
+    }
 }
 
 // ---------------------------------------------------------------------------

--- a/src/Comms/MockLink/MockLink.h
+++ b/src/Comms/MockLink/MockLink.h
@@ -387,7 +387,6 @@ private:
 
     uint8_t _mavBaseMode = MAV_MODE_FLAG_MANUAL_INPUT_ENABLED | MAV_MODE_FLAG_CUSTOM_MODE_ENABLED;
     uint32_t _mavCustomMode = PX4CustomMode::MANUAL;
-    uint8_t _mavState = MAV_STATE_STANDBY;
 
     QElapsedTimer _runningTime;
     static constexpr int kTestParamRequestListBatch = 25;
@@ -534,6 +533,13 @@ private:
     };
 
     static QList<FlightMode_t> _availableFlightModes;
+    static QList<FlightMode_t> _apmCopterAvailableFlightModes;
+    static QList<FlightMode_t> _apmPlaneAvailableFlightModes;
+    static QList<FlightMode_t> _apmRoverAvailableFlightModes;
+    static QList<FlightMode_t> _apmSubAvailableFlightModes;
+
+    /// Returns the flight mode list appropriate for the simulated firmware/vehicle type
+    const QList<FlightMode_t> &_flightModeList() const;
 
     std::atomic<bool> _disconnectedEmitted{false};
 };

--- a/src/FirmwarePlugin/APM/APMFirmwarePlugin.cc
+++ b/src/FirmwarePlugin/APM/APMFirmwarePlugin.cc
@@ -1074,30 +1074,34 @@ void APMFirmwarePlugin::startMission(Vehicle *vehicle) const
         return;
     }
 
-    if (!vehicle->armed()) {
-        // First switch to flight mode we can arm from
-        // In Ardupilot for vtols and airplanes we need to set the mode to auto and then arm, otherwise if arming in guided
-        // If the vehicle has tilt rotors, it will arm them in forward flight position, being dangerous.
-        if (vehicle->fixedWing()) {
-            if (!_setFlightModeAndValidate(vehicle, missionFlightMode())) {
-                QGC::showAppMessage(tr("Unable to start mission: Vehicle failed to change to Auto mode."));
-                return;
-            }
-        } else {
+    // If we get here vehicle is assumed to be on the ground (it may or may not be already armed)
+
+    if (vehicle->fixedWing() || vehicle->vtol()) {
+        // Plane/VTOL starts the mission from Auto mode. Set the mode before arming, since arming in Guided
+        // with tilt rotors would arm them in forward flight position, being dangerous.
+        if (!_setFlightModeAndValidate(vehicle, missionFlightMode())) {
+            QGC::showAppMessage(tr("Unable to start mission: Vehicle failed to change to Auto mode."));
+            return;
+        }
+
+        if (!vehicle->armed() && !_armVehicleAndValidate(vehicle)) {
+            QGC::showAppMessage(tr("Unable to start mission: Vehicle failed to arm."));
+            return;
+        }
+    } else {
+        // All other vehicle types arm in Guided and start the mission with MAV_CMD_MISSION_START
+        if (!vehicle->armed()) {
             if (!_setFlightModeAndValidate(vehicle, guidedFlightMode())) {
                 QGC::showAppMessage(tr("Unable to start mission: Vehicle failed to change to Guided mode."));
                 return;
             }
+
+            if (!_armVehicleAndValidate(vehicle)) {
+                QGC::showAppMessage(tr("Unable to start mission: Vehicle failed to arm."));
+                return;
+            }
         }
 
-        if (!_armVehicleAndValidate(vehicle)) {
-            QGC::showAppMessage(tr("Unable to start mission: Vehicle failed to arm."));
-            return;
-        }
-    }
-
-    // For non aircraft vehicles, we would be in guided mode, so we need to send the mission start command
-    if (!vehicle->fixedWing()) {
         vehicle->sendMavCommand(vehicle->defaultComponentId(), MAV_CMD_MISSION_START, true /*show error */);
     }
 }

--- a/test/Vehicle/APMStartMissionTest.cc
+++ b/test/Vehicle/APMStartMissionTest.cc
@@ -1,0 +1,150 @@
+#include "APMStartMissionTest.h"
+
+#include <QtCore/QRegularExpression>
+#include <QtTest/QSignalSpy>
+#include <QtTest/QTest>
+
+#include "APMFirmwarePlugin.h"
+#include "FirmwarePlugin.h"
+#include "MockLink.h"
+#include "MultiVehicleManager.h"
+#include "Vehicle.h"
+
+UT_REGISTER_TEST(APMStartMissionTest, TestLabel::Integration, TestLabel::Vehicle)
+
+void APMStartMissionTest::init()
+{
+    if (!apmFirmwareSupported()) {
+        QSKIP("ArduPilot support not registered in this build");
+    }
+
+    VehicleTestManualConnect::init();
+}
+
+void APMStartMissionTest::_connectAPMVehicle(bool plane)
+{
+    QSignalSpy spyVehicle(MultiVehicleManager::instance(), &MultiVehicleManager::activeVehicleChanged);
+    QVERIFY2(spyVehicle.isValid(), "Failed to create spy for activeVehicleChanged");
+
+    _mockLink = plane ? MockLink::startAPMArduPlaneMockLink() : MockLink::startAPMArduCopterMockLink();
+    QVERIFY2(_mockLink, "Failed to start MockLink");
+    (void) connect(_mockLink, &QObject::destroyed, this, [this]() { _mockLink = nullptr; });
+
+    QVERIFY2(UnitTest::waitForSignal(spyVehicle, TestTimeout::longMs(), QStringLiteral("activeVehicleChanged")),
+             "Timeout waiting for vehicle connection");
+    _vehicle = MultiVehicleManager::instance()->activeVehicle();
+    QVERIFY2(_vehicle, "Vehicle should not be null after connection");
+
+    QSignalSpy spyConnect(_vehicle, &Vehicle::initialConnectComplete);
+    QVERIFY2(spyConnect.isValid(), "Failed to create spy for initialConnectComplete");
+    QVERIFY2(UnitTest::waitForSignal(spyConnect, TestTimeout::longMs(), QStringLiteral("initialConnectComplete")),
+             "Timeout waiting for initial connect");
+
+    mockLink()->clearReceivedMavCommandCounts();
+}
+
+void APMStartMissionTest::_setArmedOnGround()
+{
+    mockLink()->setArmed(true);
+    QVERIFY_TRUE_WAIT(vehicle()->armed(), TestTimeout::mediumMs());
+    QVERIFY(!vehicle()->flying());
+}
+
+void APMStartMissionTest::_verifyNoMissionStartSent()
+{
+    // Flush the command queue with a tracked no-op so any MISSION_START would already be counted
+    vehicle()->sendMavCommand(vehicle()->defaultComponentId(), MockLink::MAV_CMD_MOCKLINK_ALWAYS_RESULT_ACCEPTED, false /* showError */);
+    QVERIFY_TRUE_WAIT(mockLink()->receivedMavCommandCount(MockLink::MAV_CMD_MOCKLINK_ALWAYS_RESULT_ACCEPTED) == 1,
+                      TestTimeout::mediumMs());
+    QCOMPARE(mockLink()->receivedMavCommandCount(MAV_CMD_MISSION_START), 0);
+}
+
+void APMStartMissionTest::_flyingCopterSwitchesToAuto()
+{
+    _connectAPMVehicle(false /* plane */);
+    if (QTest::currentTestFailed()) {
+        return;
+    }
+
+    // Takeoff raises the mock altitude, which drives both flying signals (HEARTBEAT
+    // MAV_STATE_ACTIVE for ArduPilot and EXTENDED_SYS_STATE IN_AIR).
+    // The flying transition creates QGCPressure, which warns on hosts without a pressure backend.
+    ignoreLogMessage("Utilities.QGCSensors", QtWarningMsg,
+                     QRegularExpression(QStringLiteral("Failed to connect to pressure backend")));
+    ignoreLogMessage("Utilities.QGCSensors", QtWarningMsg,
+                     QRegularExpression(QStringLiteral("Error Initializing Pressure Sensor")));
+    mockLink()->setArmed(true);
+    vehicle()->sendMavCommand(vehicle()->defaultComponentId(), MAV_CMD_NAV_TAKEOFF, false /* showError */,
+                              0.0f, 0.0f, 0.0f, 0.0f, 0.0f, 0.0f, 10.0f /* altitude */);
+    QVERIFY_TRUE_WAIT(vehicle()->flying(), TestTimeout::mediumMs());
+
+    vehicle()->startMission();
+
+    QCOMPARE(vehicle()->flightMode(), vehicle()->firmwarePlugin()->missionFlightMode());
+    _verifyNoMissionStartSent();
+}
+
+void APMStartMissionTest::_disarmedCopterArmsInGuidedThenMissionStart()
+{
+    _connectAPMVehicle(false /* plane */);
+    if (QTest::currentTestFailed()) {
+        return;
+    }
+
+    QVERIFY(!vehicle()->armed());
+    vehicle()->startMission();
+
+    const APMFirmwarePlugin* apmPlugin = qobject_cast<const APMFirmwarePlugin*>(vehicle()->firmwarePlugin());
+    QVERIFY(apmPlugin);
+    QCOMPARE(vehicle()->flightMode(), apmPlugin->guidedFlightMode());
+    QVERIFY(vehicle()->armed());
+    QVERIFY_TRUE_WAIT(mockLink()->receivedMavCommandCount(MAV_CMD_MISSION_START) == 1, TestTimeout::mediumMs());
+}
+
+void APMStartMissionTest::_armedCopterSendsMissionStart()
+{
+    _connectAPMVehicle(false /* plane */);
+    if (QTest::currentTestFailed()) {
+        return;
+    }
+
+    _setArmedOnGround();
+    const QString flightModeBefore = vehicle()->flightMode();
+
+    vehicle()->startMission();
+
+    // Armed non-fixed-wing must start the mission via MISSION_START, not a bare mode change
+    QVERIFY_TRUE_WAIT(mockLink()->receivedMavCommandCount(MAV_CMD_MISSION_START) == 1, TestTimeout::mediumMs());
+    QCOMPARE(vehicle()->flightMode(), flightModeBefore);
+}
+
+void APMStartMissionTest::_disarmedPlaneSwitchesToAutoThenArms()
+{
+    _connectAPMVehicle(true /* plane */);
+    if (QTest::currentTestFailed()) {
+        return;
+    }
+
+    QVERIFY(!vehicle()->armed());
+    vehicle()->startMission();
+
+    QCOMPARE(vehicle()->flightMode(), vehicle()->firmwarePlugin()->missionFlightMode());
+    QVERIFY(vehicle()->armed());
+    _verifyNoMissionStartSent();
+}
+
+void APMStartMissionTest::_armedPlaneSwitchesToAuto()
+{
+    _connectAPMVehicle(true /* plane */);
+    if (QTest::currentTestFailed()) {
+        return;
+    }
+
+    _setArmedOnGround();
+
+    vehicle()->startMission();
+
+    // An armed fixed wing on the ground must be switched to Auto to start the mission
+    QCOMPARE(vehicle()->flightMode(), vehicle()->firmwarePlugin()->missionFlightMode());
+    _verifyNoMissionStartSent();
+}

--- a/test/Vehicle/APMStartMissionTest.h
+++ b/test/Vehicle/APMStartMissionTest.h
@@ -1,0 +1,27 @@
+#pragma once
+
+#include "BaseClasses/VehicleTestManualConnect.h"
+
+/// Verifies APMFirmwarePlugin::startMission behavior for each vehicle state:
+/// flying vehicles just switch to Auto; a grounded fixed wing switches to Auto
+/// and arms (no MAV_CMD_MISSION_START); other grounded vehicles arm in Guided
+/// and start the mission via MAV_CMD_MISSION_START.
+class APMStartMissionTest : public VehicleTestManualConnect
+{
+    Q_OBJECT
+
+protected slots:
+    void init() override;
+
+private slots:
+    void _flyingCopterSwitchesToAuto();
+    void _disarmedCopterArmsInGuidedThenMissionStart();
+    void _armedCopterSendsMissionStart();
+    void _disarmedPlaneSwitchesToAutoThenArms();
+    void _armedPlaneSwitchesToAuto();
+
+private:
+    void _connectAPMVehicle(bool plane);
+    void _setArmedOnGround();
+    void _verifyNoMissionStartSent();
+};

--- a/test/Vehicle/CMakeLists.txt
+++ b/test/Vehicle/CMakeLists.txt
@@ -7,6 +7,8 @@ target_sources(${CMAKE_PROJECT_NAME}
     PRIVATE
         APMAirframeComponentControllerTest.cc
         APMAirframeComponentControllerTest.h
+        APMStartMissionTest.cc
+        APMStartMissionTest.h
         FTPManagerTest.cc
         FTPManagerTest.h
         FTPControllerTest.cc
@@ -51,6 +53,7 @@ target_include_directories(${CMAKE_PROJECT_NAME} PRIVATE ${CMAKE_CURRENT_SOURCE_
 add_subdirectory(ComponentInformation)
 
 add_qgc_test(APMAirframeComponentControllerTest LABELS Integration Vehicle)
+add_qgc_test(APMStartMissionTest LABELS Integration Vehicle)
 add_qgc_test(FTPControllerTest LABELS Integration Vehicle RESOURCE_LOCK TempFiles)
 add_qgc_test(FTPManagerTest LABELS Integration Vehicle)
 add_qgc_test(FirmwareUpgradeControllerTest LABELS Unit Vehicle)


### PR DESCRIPTION
Stable backport of #14978.

Fixes APMFirmwarePlugin::startMission for already-armed vehicles:
- Flying vehicles just switch to Auto.
- Grounded Plane/VTOL switches to Auto before arming (arming in Guided with tilt rotors would position them for forward flight).
- All other grounded vehicle types arm in Guided and start the mission via MAV_CMD_MISSION_START.

Includes MockLink APM mode simulation and the new APMStartMissionTest.

Cherry-pick note: the MAV_CMD_DO_SET_ROI_LOCATION MockLink case from #14879 (feature, master-only) was dropped during conflict resolution.

Tested Start Mission against ArduPilot SITL on all vehicle types.
