### PR TITLE
fix(PlanView): remove pending plan rename, restore Save as... including mobile

### DIFF
--- a/docs/en/qgc-user-guide/plan_view/plan_view.md
+++ b/docs/en/qgc-user-guide/plan_view/plan_view.md
@@ -90,6 +90,7 @@ File operations are located in the **Plan Toolbar** at the top of the view:
 - **Upload** — Upload the plan to the vehicle. Highlighted when the plan has un-uploaded changes.
 - **Clear** — Remove all mission items, geofence, and rally points. If connected to a vehicle, also clears them from the vehicle.
 - **Hamburger menu** (☰) — Additional options:
+  - _Save as..._ — Save the plan to a new file.
   - _Save as KML_ — Export the plan as a KML file.
   - _Download_ — Download the current plan from the vehicle (only available when connected).
 
@@ -115,7 +116,7 @@ Selecting a layer also expands the corresponding section in the [Plan Editor Pan
 
 The Plan Info section contains general plan-level settings:
 
-- **Plan File** — An editable name for the plan file.
+- **Plan File** — The name of the currently loaded plan file (`<Untitled>` if the plan has not been saved yet).
 - **Vehicle Info** — Firmware and vehicle type selectors. When connected to a vehicle these are determined automatically; when planning offline you must set them before adding any mission items so that the correct mission commands are available.
 - **Expected Home Position** — The altitude (AMSL) for the planned home position is determined automatically from terrain data. A **Move To Map Center** button repositions the home marker to the center of the map. This is only the _planned_ home position for estimating mission times and drawing waypoint lines — the actual home position is set by the vehicle when it arms.
 

--- a/src/MissionManager/PlanMasterController.cc
+++ b/src/MissionManager/PlanMasterController.cc
@@ -13,15 +13,10 @@
 #include "QmlObjectListModel.h"
 #include "GeoFenceManager.h"
 #include "RallyPointManager.h"
-#include "QGCCompression.h"
-#include "QGCCompressionJob.h"
 #include "QGCLoggingCategory.h"
 
-#include <QtCore/QDir>
-#include <QtCore/QDirIterator>
 #include <QtCore/QFileInfo>
 #include <QtCore/QJsonDocument>
-#include <QtCore/QRegularExpression>
 
 QGC_LOGGING_CATEGORY(PlanMasterControllerLog, "PlanManager.PlanMasterController")
 
@@ -110,9 +105,14 @@ void PlanMasterController::_activeVehicleChanged(Vehicle* activeVehicle)
 
     if (_managerVehicle) {
         // Disconnect old vehicle. Be careful of wildcarding disconnect too much since _managerVehicle may equal _controllerVehicle
+        disconnect(_managerVehicle,                         &Vehicle::initialPlanRequestCompleteChanged, this, nullptr);
         disconnect(_managerVehicle->missionManager(),       nullptr, this, nullptr);
         disconnect(_managerVehicle->geoFenceManager(),      nullptr, this, nullptr);
         disconnect(_managerVehicle->rallyPointManager(),    nullptr, this, nullptr);
+
+        // Any in-flight transfer chain can never complete against the new vehicle's managers
+        _loadSequence = SyncSequence::Idle;
+        _sendSequence = SyncSequence::Idle;
     }
 
     bool newOffline = false;
@@ -130,6 +130,7 @@ void PlanMasterController::_activeVehicleChanged(Vehicle* activeVehicle)
         appSettings->offlineEditingVehicleClass()->setRawValue(QGCMAVLink::vehicleClass(_managerVehicle->vehicleType()));
 
         // We use these signals to sequence upload and download to the multiple controller/managers
+        connect(_managerVehicle,                        &Vehicle::initialPlanRequestCompleteChanged, this, &PlanMasterController::_initialPlanRequestCompleteChanged);
         connect(_managerVehicle->missionManager(),      &MissionManager::newMissionItemsAvailable,  this, &PlanMasterController::_loadMissionComplete);
         connect(_managerVehicle->geoFenceManager(),     &GeoFenceManager::loadComplete,             this, &PlanMasterController::_loadGeoFenceComplete);
         connect(_managerVehicle->rallyPointManager(),   &RallyPointManager::loadComplete,           this, &PlanMasterController::_loadRallyPointsComplete);
@@ -219,7 +220,7 @@ void PlanMasterController::loadFromVehicle(void)
     } else if (syncInProgress()) {
         qCCritical(PlanMasterControllerLog) << "PlanMasterController::loadFromVehicle called while syncInProgress";
     } else {
-        _loadGeoFence = true;
+        _loadSequence = SyncSequence::Mission;
         qCDebug(PlanMasterControllerLog) << "PlanMasterController::loadFromVehicle calling _missionController.loadFromVehicle";
         _missionController.loadFromVehicle();
     }
@@ -228,74 +229,86 @@ void PlanMasterController::loadFromVehicle(void)
 
 void PlanMasterController::_loadMissionComplete(void)
 {
-    if (!_flyView && _loadGeoFence) {
-        _loadGeoFence = false;
-        _loadRallyPoints = true;
-        if (_geoFenceController.supported()) {
-            qCDebug(PlanMasterControllerLog) << "PlanMasterController::_loadMissionComplete calling _geoFenceController.loadFromVehicle";
-            _geoFenceController.loadFromVehicle();
-        } else {
-            qCDebug(PlanMasterControllerLog) << "PlanMasterController::_loadMissionComplete GeoFence not supported skipping";
-            _geoFenceController.removeAll();
-            _loadGeoFenceComplete();
-        }
+    if (_loadSequence != SyncSequence::Mission) {
+        return;
+    }
+    _loadSequence = SyncSequence::GeoFence;
+    if (_geoFenceController.supported()) {
+        qCDebug(PlanMasterControllerLog) << "PlanMasterController::_loadMissionComplete calling _geoFenceController.loadFromVehicle";
+        _geoFenceController.loadFromVehicle();
+    } else {
+        qCDebug(PlanMasterControllerLog) << "PlanMasterController::_loadMissionComplete GeoFence not supported skipping";
+        _geoFenceController.removeAll();
+        _loadGeoFenceComplete();
     }
 }
 
 void PlanMasterController::_loadGeoFenceComplete(void)
 {
-    if (!_flyView && _loadRallyPoints) {
-        _loadRallyPoints = false;
-        if (_rallyPointController.supported()) {
-            qCDebug(PlanMasterControllerLog) << "PlanMasterController::_loadGeoFenceComplete calling _rallyPointController.loadFromVehicle";
-            _rallyPointController.loadFromVehicle();
-        } else {
-            qCDebug(PlanMasterControllerLog) << "PlanMasterController::_loadMissionComplete Rally Points not supported skipping";
-            _rallyPointController.removeAll();
-            _loadRallyPointsComplete();
-        }
+    if (_loadSequence != SyncSequence::GeoFence) {
+        return;
+    }
+    _loadSequence = SyncSequence::RallyPoints;
+    if (_rallyPointController.supported()) {
+        qCDebug(PlanMasterControllerLog) << "PlanMasterController::_loadGeoFenceComplete calling _rallyPointController.loadFromVehicle";
+        _rallyPointController.loadFromVehicle();
+    } else {
+        qCDebug(PlanMasterControllerLog) << "PlanMasterController::_loadGeoFenceComplete Rally Points not supported skipping";
+        _rallyPointController.removeAll();
+        _loadRallyPointsComplete();
     }
 }
 
 void PlanMasterController::_loadRallyPointsComplete(void)
 {
+    if (_loadSequence != SyncSequence::RallyPoints) {
+        return;
+    }
+    _loadSequence = SyncSequence::Idle;
     qCDebug(PlanMasterControllerLog) << "PlanMasterController::_loadRallyPointsComplete";
     // A plan just downloaded from the vehicle reflects exactly what is on the vehicle.
-    // The user has made no edits, so it must not be dirty for save or upload.
+    // The user has made no edits, so it must not be dirty for save or upload. Any previous
+    // file association no longer describes the editor contents.
+    _clearCurrentPlanFile();
     _setDirtyStates(false /* dirtyForSave */, false /* dirtyForUpload */);
 }
 
 void PlanMasterController::_sendMissionComplete(void)
 {
-    if (_sendGeoFence) {
-        _sendGeoFence = false;
-        _sendRallyPoints = true;
-        if (_geoFenceController.supported()) {
-            qCDebug(PlanMasterControllerLog) << "PlanMasterController::sendToVehicle start GeoFence sendToVehicle";
-            _geoFenceController.sendToVehicle();
-        } else {
-            qCDebug(PlanMasterControllerLog) << "PlanMasterController::sendToVehicle GeoFence not supported skipping";
-            _sendGeoFenceComplete();
-        }
+    if (_sendSequence != SyncSequence::Mission) {
+        return;
+    }
+    _sendSequence = SyncSequence::GeoFence;
+    if (_geoFenceController.supported()) {
+        qCDebug(PlanMasterControllerLog) << "PlanMasterController::sendToVehicle start GeoFence sendToVehicle";
+        _geoFenceController.sendToVehicle();
+    } else {
+        qCDebug(PlanMasterControllerLog) << "PlanMasterController::sendToVehicle GeoFence not supported skipping";
+        _sendGeoFenceComplete();
     }
 }
 
 void PlanMasterController::_sendGeoFenceComplete(void)
 {
-    if (_sendRallyPoints) {
-        _sendRallyPoints = false;
-        if (_rallyPointController.supported()) {
-            qCDebug(PlanMasterControllerLog) << "PlanMasterController::sendToVehicle start rally sendToVehicle";
-            _rallyPointController.sendToVehicle();
-        } else {
-            qCDebug(PlanMasterControllerLog) << "PlanMasterController::sendToVehicle Rally Points not support skipping";
-            _sendRallyPointsComplete();
-        }
+    if (_sendSequence != SyncSequence::GeoFence) {
+        return;
+    }
+    _sendSequence = SyncSequence::RallyPoints;
+    if (_rallyPointController.supported()) {
+        qCDebug(PlanMasterControllerLog) << "PlanMasterController::sendToVehicle start rally sendToVehicle";
+        _rallyPointController.sendToVehicle();
+    } else {
+        qCDebug(PlanMasterControllerLog) << "PlanMasterController::sendToVehicle Rally Points not support skipping";
+        _sendRallyPointsComplete();
     }
 }
 
 void PlanMasterController::_sendRallyPointsComplete(void)
 {
+    if (_sendSequence != SyncSequence::RallyPoints) {
+        return;
+    }
+    _sendSequence = SyncSequence::Idle;
     qCDebug(PlanMasterControllerLog) << "PlanMasterController::sendToVehicle Rally Point send complete";
     _setDirtyForUpload(false);
     if (_deleteWhenSendCompleted) {
@@ -322,7 +335,7 @@ void PlanMasterController::sendToVehicle(void)
         qCCritical(PlanMasterControllerLog) << "PlanMasterController::sendToVehicle called while syncInProgress";
     } else {
         qCDebug(PlanMasterControllerLog) << "PlanMasterController::sendToVehicle start mission sendToVehicle";
-        _sendGeoFence = true;
+        _sendSequence = SyncSequence::Mission;
         _missionController.sendToVehicle();
     }
 }
@@ -347,90 +360,57 @@ void PlanMasterController::loadFromFile(const QString& filename)
 
     bool success = false;
     if (fileInfo.suffix() == AppSettings::waypointsFileExtension || fileInfo.suffix() == QStringLiteral("txt")) {
-        if (!_missionController.loadTextFile(file, errorString)) {
-            QGC::showAppMessage(errorMessage.arg(errorString));
-        } else {
-            success = true;
-        }
+        success = _missionController.loadTextFile(file, errorString);
     } else {
-        QJsonDocument   jsonDoc;
-        QByteArray      bytes = file.readAll();
-
-        if (!JsonParsing::isJsonFile(bytes, jsonDoc, errorString)) {
-            QGC::showAppMessage(errorMessage.arg(errorString));
-            return;
-        }
-
-        QJsonObject json = jsonDoc.object();
-        //-- Allow plugins to pre process the load
-        QGCCorePlugin::instance()->preLoadFromJson(this, json);
-
-        int version;
-        if (!JsonParsing::validateExternalQGCJsonFile(json, kPlanFileType, kPlanFileVersion, kPlanFileVersion, version, errorString)) {
-            QGC::showAppMessage(errorMessage.arg(errorString));
-            return;
-        }
-
-        QList<JsonParsing::KeyValidateInfo> rgKeyInfo = {
-            { kJsonMissionObjectKey,        QJsonValue::Object, true },
-            { kJsonGeoFenceObjectKey,       QJsonValue::Object, true },
-            { kJsonRallyPointsObjectKey,    QJsonValue::Object, true },
-        };
-        if (!JsonParsing::validateKeys(json, rgKeyInfo, errorString)) {
-            QGC::showAppMessage(errorMessage.arg(errorString));
-            return;
-        }
-
-        if (!_missionController.load(json[kJsonMissionObjectKey].toObject(), errorString) ||
-                !_geoFenceController.load(json[kJsonGeoFenceObjectKey].toObject(), errorString) ||
-                !_rallyPointController.load(json[kJsonRallyPointsObjectKey].toObject(), errorString)) {
-            QGC::showAppMessage(errorMessage.arg(errorString));
-        } else {
-            //-- Allow plugins to post process the load
-            QGCCorePlugin::instance()->postLoadFromJson(this, json);
-            success = true;
-        }
+        success = _loadPlanJson(file.readAll(), errorString);
+    }
+    if (!success) {
+        QGC::showAppMessage(errorMessage.arg(errorString));
     }
 
     if (success){
-        const bool oldRenamed = planFileRenamed();
         _currentPlanFile = QString::asprintf("%s/%s.%s", fileInfo.path().toLocal8Bit().data(), fileInfo.completeBaseName().toLocal8Bit().data(), AppSettings::planFileExtension);
-        const bool currentNameChanged = (_currentPlanFileName != fileInfo.completeBaseName());
-        const bool originalNameChanged = (_originalPlanFileName != fileInfo.completeBaseName());
-        _currentPlanFileName = fileInfo.completeBaseName();
-        _originalPlanFileName = _currentPlanFileName;
-        _setDirtyStates(false /* dirtyForSave */, true /* dirtyForUpload */);
         emit currentPlanFileChanged();
-        if (currentNameChanged) {
-            emit currentPlanFileNameChanged();
-        }
-        if (originalNameChanged) {
-            emit originalPlanFileNameChanged();
-        }
-        if (oldRenamed != planFileRenamed()) {
-            emit planFileRenamedChanged();
-        }
+        _setDirtyStates(false /* dirtyForSave */, true /* dirtyForUpload */);
     } else {
-        const bool hadFile = !_currentPlanFile.isEmpty();
-        const bool hadCurrentName = !_currentPlanFileName.isEmpty();
-        const bool hadOriginalName = !_originalPlanFileName.isEmpty();
-        const bool wasRenamed = planFileRenamed();
-        _currentPlanFile.clear();
-        _currentPlanFileName.clear();
-        _originalPlanFileName.clear();
-        if (hadFile) {
-            emit currentPlanFileChanged();
-        }
-        if (hadCurrentName) {
-            emit currentPlanFileNameChanged();
-        }
-        if (hadOriginalName) {
-            emit originalPlanFileNameChanged();
-        }
-        if (wasRenamed != planFileRenamed()) {
-            emit planFileRenamedChanged();
-        }
+        _clearCurrentPlanFile();
     }
+}
+
+bool PlanMasterController::_loadPlanJson(const QByteArray& bytes, QString& errorString)
+{
+    QJsonDocument jsonDoc;
+    if (!JsonParsing::isJsonFile(bytes, jsonDoc, errorString)) {
+        return false;
+    }
+
+    QJsonObject json = jsonDoc.object();
+    //-- Allow plugins to pre process the load
+    QGCCorePlugin::instance()->preLoadFromJson(this, json);
+
+    int version;
+    if (!JsonParsing::validateExternalQGCJsonFile(json, kPlanFileType, kPlanFileVersion, kPlanFileVersion, version, errorString)) {
+        return false;
+    }
+
+    const QList<JsonParsing::KeyValidateInfo> rgKeyInfo = {
+        { kJsonMissionObjectKey,        QJsonValue::Object, true },
+        { kJsonGeoFenceObjectKey,       QJsonValue::Object, true },
+        { kJsonRallyPointsObjectKey,    QJsonValue::Object, true },
+    };
+    if (!JsonParsing::validateKeys(json, rgKeyInfo, errorString)) {
+        return false;
+    }
+
+    if (!_missionController.load(json[kJsonMissionObjectKey].toObject(), errorString) ||
+            !_geoFenceController.load(json[kJsonGeoFenceObjectKey].toObject(), errorString) ||
+            !_rallyPointController.load(json[kJsonRallyPointsObjectKey].toObject(), errorString)) {
+        return false;
+    }
+
+    //-- Allow plugins to post process the load
+    QGCCorePlugin::instance()->postLoadFromJson(this, json);
+    return true;
 }
 
 QJsonDocument PlanMasterController::saveToJson()
@@ -493,19 +473,6 @@ bool PlanMasterController::saveToFile(const QString& filename)
             _currentPlanFile = planFilename;
             emit currentPlanFileChanged();
         }
-        const bool wasRenamed = planFileRenamed();
-        const QString savedBaseName = QFileInfo(planFilename).completeBaseName();
-        if (_currentPlanFileName != savedBaseName) {
-            _currentPlanFileName = savedBaseName;
-            emit currentPlanFileNameChanged();
-        }
-        if (_originalPlanFileName != savedBaseName) {
-            _originalPlanFileName = savedBaseName;
-            emit originalPlanFileNameChanged();
-        }
-        if (wasRenamed != planFileRenamed()) {
-            emit planFileRenamedChanged();
-        }
         _setDirtyForSave(false);
     }
 
@@ -549,7 +516,7 @@ void PlanMasterController::removeAll(void)
 
     _setDirtyStates(false, false);
     if (_offline) {
-        _clearFileNames();
+        _clearCurrentPlanFile();
     }
     setUserSelectedManualCreation(false);
 }
@@ -565,7 +532,7 @@ void PlanMasterController::removeAllFromVehicle(void)
             _rallyPointController.removeAllFromVehicle();
         }
         _setDirtyForUpload(false);
-        _clearFileNames();
+        _clearCurrentPlanFile();
     } else {
         qCCritical(PlanMasterControllerLog) << "PlanMasterController::removeAllFromVehicle called while offline";
     }
@@ -597,75 +564,16 @@ QString PlanMasterController::fileExtension(void) const
     return AppSettings::planFileExtension;
 }
 
-void PlanMasterController::setCurrentPlanFileName(const QString& name)
+QString PlanMasterController::currentPlanFileName(void) const
 {
-    // Normalize to a base name: trim whitespace, strip known extension, remove illegal characters
-    QString sanitized = name.trimmed();
-    const QString ext = QStringLiteral(".") + fileExtension();
-    if (sanitized.endsWith(ext, Qt::CaseInsensitive)) {
-        sanitized.chop(ext.length());
-        sanitized = sanitized.trimmed();
-    }
-    sanitized.remove(QRegularExpression(QStringLiteral("[/\\\\:*?\"<>|]")));
-    if (_currentPlanFileName != sanitized) {
-        const bool wasRenamed = planFileRenamed();
-        _currentPlanFileName = sanitized;
-        emit currentPlanFileNameChanged();
-        if (wasRenamed != planFileRenamed()) {
-            emit planFileRenamedChanged();
-        }
-    }
+    return _currentPlanFile.isEmpty() ? QString() : QFileInfo(_currentPlanFile).completeBaseName();
 }
 
-bool PlanMasterController::saveWithCurrentName()
+void PlanMasterController::_clearCurrentPlanFile()
 {
-    if (_currentPlanFileName.isEmpty()) {
-        return false;
-    }
-    return saveToFile(_resolvedPlanFilePath());
-}
-
-bool PlanMasterController::planFileRenamed() const
-{
-    return !_originalPlanFileName.isEmpty() && _currentPlanFileName != _originalPlanFileName;
-}
-
-bool PlanMasterController::resolvedPlanFileExists() const
-{
-    if (_currentPlanFileName.isEmpty()) {
-        return false;
-    }
-    return QFile::exists(_resolvedPlanFilePath());
-}
-
-QString PlanMasterController::_resolvedPlanFilePath() const
-{
-    const QString dir = _currentPlanFile.isEmpty()
-        ? SettingsManager::instance()->appSettings()->missionSavePath()
-        : QFileInfo(_currentPlanFile).path();
-    return QStringLiteral("%1/%2.%3").arg(dir, _currentPlanFileName, fileExtension());
-}
-
-void PlanMasterController::_clearFileNames()
-{
-    const bool hadFile = !_currentPlanFile.isEmpty();
-    const bool hadCurrentName = !_currentPlanFileName.isEmpty();
-    const bool hadOriginalName = !_originalPlanFileName.isEmpty();
-    const bool wasRenamed = planFileRenamed();
-    _currentPlanFile.clear();
-    _currentPlanFileName.clear();
-    _originalPlanFileName.clear();
-    if (hadFile) {
+    if (!_currentPlanFile.isEmpty()) {
+        _currentPlanFile.clear();
         emit currentPlanFileChanged();
-    }
-    if (hadCurrentName) {
-        emit currentPlanFileNameChanged();
-    }
-    if (hadOriginalName) {
-        emit originalPlanFileNameChanged();
-    }
-    if (wasRenamed != planFileRenamed()) {
-        emit planFileRenamedChanged();
     }
 }
 
@@ -704,7 +612,8 @@ void PlanMasterController::sendPlanToVehicle(Vehicle* vehicle, const QString& fi
 void PlanMasterController::_showPlanFromManagerVehicle(void)
 {
     if (!_managerVehicle->initialPlanRequestComplete()) {
-        // We need to wait until initial load is complete before we show anything.
+        // The sub-controllers pick up the editor contents as the initial download arrives
+        _loadSequence = SyncSequence::InitialPlanLoad;
         return;
     }
 
@@ -715,11 +624,25 @@ void PlanMasterController::_showPlanFromManagerVehicle(void)
         }
     }
 
-    // Showing the vehicle plan should leave both dirty states clean.
+    // The editor now shows the vehicle's plan: not dirty, and any previous file
+    // association no longer describes the contents
     _missionController.setDirty(false);
     _geoFenceController.setDirty(false);
     _rallyPointController.setDirty(false);
+    _clearCurrentPlanFile();
     _setDirtyStates(false, false);
+}
+
+void PlanMasterController::_initialPlanRequestCompleteChanged(bool initialPlanRequestComplete)
+{
+    if (!initialPlanRequestComplete || _loadSequence != SyncSequence::InitialPlanLoad) {
+        return;
+    }
+    _loadSequence = SyncSequence::Idle;
+    qCDebug(PlanMasterControllerLog) << "_initialPlanRequestCompleteChanged: initial download complete";
+    // Import the manager data into the editor (non-empty sub-controllers reject the automatic
+    // manager updates during download) and scrub dirty/file association.
+    _showPlanFromManagerVehicle();
 }
 
 bool PlanMasterController::syncInProgress(void) const
@@ -846,68 +769,4 @@ void PlanMasterController::setUserSelectedManualCreation(bool userSelectedManual
             emit showCreateFromTemplateChanged();
         }
     }
-}
-
-void PlanMasterController::loadFromArchive(const QString& archivePath)
-{
-    if (archivePath.isEmpty()) {
-        return;
-    }
-
-    if (!QFile::exists(archivePath)) {
-        QGC::showAppMessage(tr("Archive file not found: %1").arg(archivePath));
-        return;
-    }
-
-    if (!QGCCompression::isArchiveFile(archivePath)) {
-        QGC::showAppMessage(tr("Not a supported archive format: %1").arg(archivePath));
-        return;
-    }
-
-    const QString tempPath = QDir::temp().filePath(QStringLiteral("qgc_plan_") + QString::number(QDateTime::currentMSecsSinceEpoch()));
-    if (!QDir().mkpath(tempPath)) {
-        QGC::showAppMessage(tr("Could not create temporary directory"));
-        return;
-    }
-
-    _extractionOutputDir = tempPath;
-
-    if (_extractionJob == nullptr) {
-        _extractionJob = new QGCCompressionJob(this);
-        connect(_extractionJob, &QGCCompressionJob::finished,
-                this, &PlanMasterController::_handleExtractionFinished);
-    }
-
-    _extractionJob->extractArchive(archivePath, tempPath);
-}
-
-void PlanMasterController::_handleExtractionFinished(bool success)
-{
-    if (!success) {
-        const QString error = _extractionJob != nullptr ? _extractionJob->errorString() : tr("Extraction failed");
-        QGC::showAppMessage(tr("Failed to extract plan archive: %1").arg(error));
-        QDir(_extractionOutputDir).removeRecursively();
-        _extractionOutputDir.clear();
-        return;
-    }
-
-    QString planPath;
-    const QString planExt = QStringLiteral("*.") + AppSettings::planFileExtension;
-    QDirIterator it(_extractionOutputDir, {planExt}, QDir::Files, QDirIterator::Subdirectories);
-    if (it.hasNext()) {
-        planPath = it.next();
-    }
-
-    if (planPath.isEmpty()) {
-        QGC::showAppMessage(tr("No plan file found in archive"));
-        QDir(_extractionOutputDir).removeRecursively();
-        _extractionOutputDir.clear();
-        return;
-    }
-
-    qCDebug(PlanMasterControllerLog) << "Found plan file in archive:" << planPath;
-    loadFromFile(planPath);
-
-    QDir(_extractionOutputDir).removeRecursively();
-    _extractionOutputDir.clear();
 }

--- a/src/MissionManager/PlanMasterController.h
+++ b/src/MissionManager/PlanMasterController.h
@@ -8,7 +8,6 @@
 #include "RallyPointController.h"
 #include "QGCMAVLinkTypes.h"
 
-class QGCCompressionJob;
 class QmlObjectListModel;
 class MultiVehicleManager;
 class Vehicle;
@@ -53,9 +52,7 @@ public:
     Q_PROPERTY(QString                  fileExtension           READ fileExtension                          CONSTANT)                               ///< File extension for missions
     Q_PROPERTY(QString                  kmlFileExtension        READ kmlFileExtension                       CONSTANT)
     Q_PROPERTY(QString                  currentPlanFile         READ currentPlanFile                        NOTIFY currentPlanFileChanged)          ///< Fully qualified path, empty if not yet saved
-    Q_PROPERTY(QString                  currentPlanFileName     READ currentPlanFileName WRITE setCurrentPlanFileName NOTIFY currentPlanFileNameChanged)  ///< Editable base name, no path or extension
-    Q_PROPERTY(QString                  originalPlanFileName    READ originalPlanFileName                   NOTIFY originalPlanFileNameChanged)     ///< On-disk name when last loaded/saved
-    Q_PROPERTY(bool                     planFileRenamed         READ planFileRenamed                        NOTIFY planFileRenamedChanged)          ///< true if currentPlanFileName differs from originalPlanFileName
+    Q_PROPERTY(QString                  currentPlanFileName     READ currentPlanFileName                    NOTIFY currentPlanFileChanged)          ///< Base name of currentPlanFile, no path or extension
     Q_PROPERTY(QStringList              loadNameFilters         READ loadNameFilters                        CONSTANT)                               ///< File filter list loading plan files
     Q_PROPERTY(QStringList              saveNameFilters         READ saveNameFilters                        CONSTANT)                               ///< File filter list saving plan files
     Q_PROPERTY(QmlObjectListModel*      planCreators            READ planCreators                           NOTIFY planCreatorsChanged)
@@ -84,18 +81,10 @@ public:
     Q_INVOKABLE void loadFromVehicle(void);
     Q_INVOKABLE void sendToVehicle(void);
     Q_INVOKABLE void loadFromFile(const QString& filename);
-
-    /// Load a plan from an archive file (.zip, .tar.gz, etc.)
-    /// Extracts the archive and loads the first .plan file found.
-    /// @param archivePath Path to the archive file
-    Q_INVOKABLE void loadFromArchive(const QString& archivePath);
-
     Q_INVOKABLE bool saveToCurrent();
     Q_INVOKABLE bool saveToFile(const QString& filename);
     Q_INVOKABLE void saveToKml(const QString& filename);
 
-    Q_INVOKABLE bool saveWithCurrentName(); ///< Save using the (possibly renamed) currentPlanFileName
-    Q_INVOKABLE bool resolvedPlanFileExists() const; ///< true if a file at the renamed path already exists on disk
     Q_INVOKABLE void removeAll(void); ///< Removes all from controller only, sync required to remove from vehicle
     Q_INVOKABLE void removeAllFromVehicle(void); ///< Removes all from vehicle and controller
 
@@ -112,10 +101,7 @@ public:
     QString fileExtension(void) const;
     QString kmlFileExtension(void) const;
     QString currentPlanFile(void) const { return _currentPlanFile; }
-    QString currentPlanFileName(void) const { return _currentPlanFileName; }
-    void setCurrentPlanFileName(const QString& name);
-    QString originalPlanFileName(void) const { return _originalPlanFileName; }
-    bool planFileRenamed(void) const;
+    QString currentPlanFileName(void) const;
     QStringList loadNameFilters(void) const;
     QStringList saveNameFilters(void) const;
     bool isEmpty(void) const;
@@ -144,9 +130,6 @@ signals:
     void dirtyForUploadChanged(bool dirtyForUpload);
     void offlineChanged(bool offlineEditing);
     void currentPlanFileChanged(void);
-    void currentPlanFileNameChanged(void);
-    void originalPlanFileNameChanged(void);
-    void planFileRenamedChanged(void);
     void planCreatorsChanged(QmlObjectListModel* planCreators);
     void managerVehicleChanged(Vehicle* managerVehicle);
     void promptForPlanUsageOnVehicleChange(void);
@@ -163,16 +146,29 @@ private slots:
     void _updateOverallDirty(void);
     void _updateShowCreateFromTemplate(void);
     void _updatePlanCreatorsList(void);
-    void _handleExtractionFinished(bool success);
 
 private:
+    /// Sequences the explicit loadFromVehicle/sendToVehicle chains: Mission -> GeoFence -> RallyPoints.
+    /// Idle means no transfer was requested, so manager loadComplete/sendComplete signals (e.g. a send
+    /// from another controller) must be ignored. InitialPlanLoad marks the automatic download at vehicle
+    /// connect and completes on Vehicle::initialPlanRequestCompleteChanged (unsupported sections never
+    /// emit loadComplete).
+    enum class SyncSequence {
+        Idle,
+        Mission,
+        GeoFence,
+        RallyPoints,
+        InitialPlanLoad,
+    };
+
     void _commonInit(void);
     void _showPlanFromManagerVehicle(void);
+    void _initialPlanRequestCompleteChanged(bool initialPlanRequestComplete);
     void _setDirtyForSave(bool dirtyForSave);
     void _setDirtyForUpload(bool dirtyForUpload);
     void _setDirtyStates(bool dirtyForSave, bool dirtyForUpload);
-    QString _resolvedPlanFilePath() const;
-    void _clearFileNames();
+    void _clearCurrentPlanFile();
+    bool _loadPlanJson(const QByteArray& bytes, QString& errorString);
 
 #ifdef QGC_UNITTEST_BUILD
     // Used by unit tests to set dirty flags for initial state
@@ -188,18 +184,9 @@ private:
     MissionController _missionController;
     GeoFenceController _geoFenceController;
     RallyPointController _rallyPointController;
-    bool _loadGeoFence = false;
-    bool _loadRallyPoints = false;
-    bool _sendGeoFence = false;
-    bool _sendRallyPoints = false;
+    SyncSequence _loadSequence = SyncSequence::Idle;
+    SyncSequence _sendSequence = SyncSequence::Idle;
     QString _currentPlanFile;
-
-    // NOTE: _currentPlanFileName and _originalPlanFileName must be kept in sync
-    // with _currentPlanFile across all code paths that modify any of them:
-    // loadFromFile, saveToFile, removeAll, removeAllFromVehicle, _clearFileNames.
-    QString _currentPlanFileName;
-    QString _originalPlanFileName;
-
     bool _deleteWhenSendCompleted = false;
     bool _dirtyForSave = false;
     bool _dirtyForUpload = false;
@@ -208,6 +195,4 @@ private:
     QmlObjectListModel* _planCreators = nullptr;
     QGCMAVLinkTypes::VehicleClass_t _planCreatorsVehicleClass = -1;
     bool _userSelectedManualCreation = false;
-    QGCCompressionJob* _extractionJob = nullptr;
-    QString _extractionOutputDir;
 };

--- a/src/PlanView/PlanInfoEditor.qml
+++ b/src/PlanView/PlanInfoEditor.qml
@@ -45,23 +45,12 @@ Rectangle {
                 text: qsTr("Plan File")
             }
 
-            QGCTextField {
-                id: planNameField
-                placeholderText: qsTr("Untitled")
+            QGCLabel {
                 Layout.fillWidth: true
-
-                Component.onCompleted: text = _root.planMasterController.currentPlanFileName
-
-                Connections {
-                    target: _root.planMasterController
-                    function onCurrentPlanFileNameChanged() {
-                        if (!planNameField.activeFocus) {
-                            planNameField.text = _root.planMasterController.currentPlanFileName
-                        }
-                    }
-                }
-
-                onEditingFinished: _root.planMasterController.currentPlanFileName = text
+                elide: Text.ElideMiddle
+                textFormat: Text.PlainText
+                enabled: _root.planMasterController.currentPlanFileName !== ""
+                text: _root.planMasterController.currentPlanFileName === "" ? qsTr("<Untitled>") : _root.planMasterController.currentPlanFileName
             }
         }
 

--- a/src/PlanView/PlanToolBarIndicators.qml
+++ b/src/PlanView/PlanToolBarIndicators.qml
@@ -46,9 +46,20 @@ RowLayout {
     }
 
     function _openButtonClicked() {
-        if (_saveDirty || _uploadDirty) {
+        // Unsent changes don't matter when offline or when the plan is safely saved to a file
+        let planSafeOnDisk = !_saveDirty && _planMasterController.currentPlanFile !== ""
+        let unsentChanges = _uploadDirty && !_controllerOffline && !planSafeOnDisk
+        if (_saveDirty || unsentChanges) {
+            let msg
+            if (_saveDirty && unsentChanges) {
+                msg = qsTr("You have unsaved/unsent changes. Loading a new Plan will lose these changes. Are you sure?")
+            } else if (_saveDirty) {
+                msg = qsTr("You have unsaved changes. Loading a new Plan will lose these changes. Are you sure?")
+            } else {
+                msg = qsTr("You have unsent changes. Loading a new Plan will lose these changes. Are you sure?")
+            }
             QGroundControl.showMessageDialog(root, qsTr("Open Plan"),
-                                        qsTr("You have unsaved/unsent changes. Loading a new Plan will lose these changes. Are you sure?"),
+                                        msg,
                                         Dialog.Yes | Dialog.Cancel,
                                         function() { _planMasterController.loadFromSelectedFile() } )
         } else {
@@ -57,26 +68,8 @@ RowLayout {
     }
 
     function _saveButtonClicked() {
-        if (_planMasterController.currentPlanFileName === "") {
-            if (_planMasterController.currentPlanFile === "") {
-                // No file and no name typed — open the file dialog
-                _planMasterController.saveToSelectedFile()
-            } else {
-                // Have a file but name was cleared — save to the existing file
-                _planMasterController.saveToCurrent()
-            }
-            return
-        }
-
-        if (_planMasterController.currentPlanFile === "" || _planMasterController.planFileRenamed) {
-            // First save with a typed name, or name was changed since last save
-            let fullName = _planMasterController.currentPlanFileName + "." + _planMasterController.fileExtension
-            let msg = _planMasterController.resolvedPlanFileExists()
-                ? qsTr("'%1' already exists. Overwrite?").arg(fullName)
-                : qsTr("Save as '%1'?").arg(fullName)
-            QGroundControl.showMessageDialog(root, qsTr("Save"), msg,
-                Dialog.Yes | Dialog.No,
-                function() { _planMasterController.saveWithCurrentName() })
+        if (_planMasterController.currentPlanFile === "") {
+            _planMasterController.saveToSelectedFile()
         } else {
             _planMasterController.saveToCurrent()
         }
@@ -152,6 +145,7 @@ RowLayout {
     }
 
     QGCButton {
+        objectName: "planToolbar_hamburgerButton"
         iconSource: "qrc:/qmlimages/Hamburger.svg"
 
         onClicked: {
@@ -178,6 +172,18 @@ RowLayout {
             sourceComponent: Component {
                 ColumnLayout {
                     spacing: ScreenTools.defaultFontPixelHeight / 2
+
+                    QGCButton {
+                        objectName: "planToolbar_saveAsButton"
+                        Layout.fillWidth: true
+                        text: qsTr("Save as...")
+                        enabled: !_syncInProgress && _hasPlanItems
+
+                        onClicked: {
+                            dropPanel.close()
+                            _planMasterController.saveToSelectedFile()
+                        }
+                    }
 
                     QGCButton {
                         Layout.fillWidth: true

--- a/src/PlanView/PlanTreeView.qml
+++ b/src/PlanView/PlanTreeView.qml
@@ -392,6 +392,7 @@ TreeView {
                         Layout.fillWidth: true
                         text: root._groupSubtitle(delegateRoot.nodeType)
                         elide: Text.ElideRight
+                        textFormat: Text.PlainText
                         font.pointSize: ScreenTools.smallFontPointSize
                         color: qgcPal.colorGrey
                     }

--- a/test/MissionManager/PlanMasterControllerTest.cc
+++ b/test/MissionManager/PlanMasterControllerTest.cc
@@ -227,13 +227,13 @@ void PlanMasterControllerTest::_testDirtyFlagsMatrix()
 
     switch (scenario) {
     case UploadPreservesSaveDirtyFalse: {
-        const bool invoked = QMetaObject::invokeMethod(_masterController, "_sendRallyPointsComplete", Qt::DirectConnection);
-        QVERIFY(invoked);
+        _masterController->_sendSequence = PlanMasterController::SyncSequence::RallyPoints;
+        _masterController->_sendRallyPointsComplete();
         break;
     }
     case UploadPreservesSaveDirtyTrue: {
-        const bool invoked = QMetaObject::invokeMethod(_masterController, "_sendRallyPointsComplete", Qt::DirectConnection);
-        QVERIFY(invoked);
+        _masterController->_sendSequence = PlanMasterController::SyncSequence::RallyPoints;
+        _masterController->_sendRallyPointsComplete();
         break;
     }
     case UploadFalseOnPlanClear:
@@ -268,14 +268,14 @@ void PlanMasterControllerTest::_testDirtyFlagsMatrix()
         break;
     case DownloadWithItemsNotDirtyForSave: {
         QVERIFY(_masterController->containsItems());
-        const bool invoked = QMetaObject::invokeMethod(_masterController, "_loadRallyPointsComplete", Qt::DirectConnection);
-        QVERIFY(invoked);
+        _masterController->_loadSequence = PlanMasterController::SyncSequence::RallyPoints;
+        _masterController->_loadRallyPointsComplete();
         break;
     }
     case DownloadEmptyNotDirtyForSave: {
         QVERIFY(!_masterController->containsItems());
-        const bool invoked = QMetaObject::invokeMethod(_masterController, "_loadRallyPointsComplete", Qt::DirectConnection);
-        QVERIFY(invoked);
+        _masterController->_loadSequence = PlanMasterController::SyncSequence::RallyPoints;
+        _masterController->_loadRallyPointsComplete();
         break;
     }
     }
@@ -316,189 +316,176 @@ void PlanMasterControllerTest::_testDirtyFlagsMatrix()
     }
 }
 
-void PlanMasterControllerTest::_testFileNamesSetOnLoad()
+void PlanMasterControllerTest::_testFileAssociationSetOnLoad()
 {
-    QSignalSpy currentNameSpy(_masterController, &PlanMasterController::currentPlanFileNameChanged);
-    QSignalSpy originalNameSpy(_masterController, &PlanMasterController::originalPlanFileNameChanged);
+    QSignalSpy currentFileSpy(_masterController, &PlanMasterController::currentPlanFileChanged);
 
-    // Before load, names should be empty
+    // Before load, file association should be empty
+    QVERIFY(_masterController->currentPlanFile().isEmpty());
     QVERIFY(_masterController->currentPlanFileName().isEmpty());
-    QVERIFY(_masterController->originalPlanFileName().isEmpty());
 
     _masterController->loadFromFile(":/unittest/MissionPlanner.waypoints");
 
-    // After successful load, both names should be set to the base name
+    // After successful load, the file association should be set
+    QVERIFY(!_masterController->currentPlanFile().isEmpty());
     QCOMPARE(_masterController->currentPlanFileName(), QStringLiteral("MissionPlanner"));
-    QCOMPARE(_masterController->originalPlanFileName(), QStringLiteral("MissionPlanner"));
-
-    // Signals should have fired
-    QVERIFY(currentNameSpy.count() >= 1);
-    QVERIFY(originalNameSpy.count() >= 1);
+    QVERIFY(currentFileSpy.count() >= 1);
 }
 
-void PlanMasterControllerTest::_testCurrentPlanFileNameWritable()
+void PlanMasterControllerTest::_testFailedLoadClearsFileAssociation()
+{
+    struct MalformedFileCase {
+        const char* fileName;
+        const char* contents;
+    };
+    const QList<MalformedFileCase> malformedCases = {
+        { "Malformed.waypoints", "not a mission file" }, // Text parse failure
+        { "Malformed.plan",      "{ not valid json" },   // JSON validation failure
+    };
+
+    QTemporaryDir tempDir;
+    QVERIFY(tempDir.isValid());
+
+    for (const MalformedFileCase& malformedCase : malformedCases) {
+        const QString context = QString::fromLatin1(malformedCase.fileName);
+
+        _masterController->loadFromFile(":/unittest/MissionPlanner.waypoints");
+        QVERIFY2(!_masterController->currentPlanFile().isEmpty(), qPrintable(context));
+
+        const QString malformedPath = tempDir.filePath(context);
+        QFile malformedFile(malformedPath);
+        QVERIFY2(malformedFile.open(QIODevice::WriteOnly), qPrintable(context));
+        QVERIFY2(malformedFile.write(malformedCase.contents) != -1, qPrintable(context));
+        malformedFile.close();
+
+        // A failed load clears the file association
+        expectLogMessage("API.QGCApplication.AppMessage", QtDebugMsg,
+                         QRegularExpression("Error loading Plan file"));
+        _masterController->loadFromFile(malformedPath);
+        verifyExpectedLogMessage();
+
+        QVERIFY2(_masterController->currentPlanFile().isEmpty(), qPrintable(context));
+        QVERIFY2(_masterController->currentPlanFileName().isEmpty(), qPrintable(context));
+    }
+}
+
+void PlanMasterControllerTest::_testDownloadClearsFileAssociation()
 {
     _masterController->loadFromFile(":/unittest/MissionPlanner.waypoints");
+    QVERIFY(!_masterController->currentPlanFile().isEmpty());
 
-    QSignalSpy currentNameSpy(_masterController, &PlanMasterController::currentPlanFileNameChanged);
-    QSignalSpy originalNameSpy(_masterController, &PlanMasterController::originalPlanFileNameChanged);
+    // Download completion replaces editor contents with the vehicle's plan, so the
+    // previous file association no longer describes what is in the editor
+    _masterController->_loadSequence = PlanMasterController::SyncSequence::RallyPoints;
+    _masterController->_loadRallyPointsComplete();
 
-    // Rename via the writable property
-    _masterController->setCurrentPlanFileName(QStringLiteral("RenamedPlan"));
-
-    QCOMPARE(_masterController->currentPlanFileName(), QStringLiteral("RenamedPlan"));
-    // Original should remain unchanged
-    QCOMPARE(_masterController->originalPlanFileName(), QStringLiteral("MissionPlanner"));
-
-    QCOMPARE(currentNameSpy.count(), 1);
-    QCOMPARE(originalNameSpy.count(), 0);
-
-    // Setting to the same value should not emit again
-    _masterController->setCurrentPlanFileName(QStringLiteral("RenamedPlan"));
-    QCOMPARE(currentNameSpy.count(), 1);
+    QVERIFY(_masterController->currentPlanFile().isEmpty());
+    QVERIFY(_masterController->currentPlanFileName().isEmpty());
+    QVERIFY(!_masterController->dirtyForSave());
+    QVERIFY(!_masterController->dirtyForUpload());
 }
 
-void PlanMasterControllerTest::_testPlanFileRenamed()
-{
-    // Before load, planFileRenamed should be false (both names empty)
-    QVERIFY(!_masterController->planFileRenamed());
-
-    _masterController->loadFromFile(":/unittest/MissionPlanner.waypoints");
-
-    // After load, current == original → not renamed
-    QVERIFY(!_masterController->planFileRenamed());
-
-    // Rename
-    _masterController->setCurrentPlanFileName(QStringLiteral("NewName"));
-    QVERIFY(_masterController->planFileRenamed());
-
-    // Rename back to original
-    _masterController->setCurrentPlanFileName(QStringLiteral("MissionPlanner"));
-    QVERIFY(!_masterController->planFileRenamed());
-}
-
-void PlanMasterControllerTest::_testSaveWithCurrentName()
+void PlanMasterControllerTest::_testBackgroundSyncPreservesFileAssociation()
 {
     _masterController->loadFromFile(":/unittest/MissionPlanner.waypoints");
+    QVERIFY(!_masterController->currentPlanFile().isEmpty());
+    _masterController->_setDirtyForSaveUnitTest(true);
 
-    // First save to a real (writable) directory so _currentPlanFile points somewhere valid
-    QTemporaryDir tmpDir;
-    QVERIFY(tmpDir.isValid());
-    const QString initialPath = QStringLiteral("%1/MissionPlanner.%2").arg(tmpDir.path(), _masterController->fileExtension());
-    QVERIFY(_masterController->saveToFile(initialPath));
+    // Manager loadComplete also fires for the automatic download at vehicle connect. When no
+    // download was requested the editor contents are preserved, so the file association and
+    // dirty state must survive.
+    _masterController->_loadRallyPointsComplete();
 
-    // Rename
-    _masterController->setCurrentPlanFileName(QStringLiteral("TestSaveRenamed"));
-
-    // Save with the renamed name
-    QVERIFY(_masterController->saveWithCurrentName());
-
-    // After save, original should now match the renamed name
-    QCOMPARE(_masterController->originalPlanFileName(), QStringLiteral("TestSaveRenamed"));
-    QCOMPARE(_masterController->currentPlanFileName(), QStringLiteral("TestSaveRenamed"));
-    QVERIFY(!_masterController->planFileRenamed());
+    QVERIFY(!_masterController->currentPlanFile().isEmpty());
+    QCOMPARE(_masterController->currentPlanFileName(), QStringLiteral("MissionPlanner"));
+    QVERIFY(_masterController->dirtyForSave());
 }
 
-void PlanMasterControllerTest::_testSaveWithCurrentNameNoFile()
-{
-    // No file loaded — saveWithCurrentName with empty name should fail
-    QVERIFY(!_masterController->saveWithCurrentName());
-
-    // Set a name without loading a file first (simulates typing a name in the UI)
-    _masterController->setCurrentPlanFileName(QStringLiteral("BrandNewPlan"));
-
-    // Should save to the default mission save directory
-    QVERIFY(_masterController->saveWithCurrentName());
-
-    const QString expectedDir = SettingsManager::instance()->appSettings()->missionSavePath();
-    const QString expectedPath = QStringLiteral("%1/BrandNewPlan.%2").arg(expectedDir, _masterController->fileExtension());
-    QCOMPARE(_masterController->currentPlanFile(), expectedPath);
-    QCOMPARE(_masterController->originalPlanFileName(), QStringLiteral("BrandNewPlan"));
-
-    // Clean up
-    QFile::remove(expectedPath);
-}
-
-void PlanMasterControllerTest::_testResolvedPlanFileExists()
-{
-    // Empty name → should return false
-    QVERIFY(!_masterController->resolvedPlanFileExists());
-
-    // Save a file so it exists on disk
-    QTemporaryDir tmpDir;
-    QVERIFY(tmpDir.isValid());
-    const QString savePath = QStringLiteral("%1/ExistingPlan.%2").arg(tmpDir.path(), _masterController->fileExtension());
-    QVERIFY(_masterController->saveToFile(savePath));
-
-    // Now rename to the same base name — file exists at resolved path
-    _masterController->setCurrentPlanFileName(QStringLiteral("ExistingPlan"));
-    QVERIFY(_masterController->resolvedPlanFileExists());
-
-    // Rename to something non-existent
-    _masterController->setCurrentPlanFileName(QStringLiteral("DoesNotExist"));
-    QVERIFY(!_masterController->resolvedPlanFileExists());
-}
-
-void PlanMasterControllerTest::_testFileNamesClearedOnRemoveAll()
+void PlanMasterControllerTest::_testUnrequestedSendCompletePreservesDirtyForUpload()
 {
     _masterController->loadFromFile(":/unittest/MissionPlanner.waypoints");
+    QVERIFY(_masterController->dirtyForUpload());
 
-    // Verify names are set
-    QVERIFY(!_masterController->currentPlanFileName().isEmpty());
-    QVERIFY(!_masterController->originalPlanFileName().isEmpty());
+    // Manager sendComplete can fire for sends this controller did not request (Fly view and
+    // Plan view controllers share the same vehicle managers), so dirtyForUpload must survive.
+    _masterController->_sendRallyPointsComplete();
 
-    QSignalSpy currentNameSpy(_masterController, &PlanMasterController::currentPlanFileNameChanged);
-    QSignalSpy originalNameSpy(_masterController, &PlanMasterController::originalPlanFileNameChanged);
+    QVERIFY(_masterController->dirtyForUpload());
+}
+
+void PlanMasterControllerTest::_testStaleInitialPlanLoadRallyCompletePreservesPlan()
+{
+    // A rally-unsupported vehicle never emits rally loadComplete during initial connect, so the
+    // sequence can still be InitialPlanLoad long after the download. A later unrelated rally
+    // completion must not clear a newly opened plan.
+    _masterController->loadFromFile(":/unittest/MissionPlanner.waypoints");
+    QVERIFY(!_masterController->currentPlanFile().isEmpty());
+
+    _masterController->_loadSequence = PlanMasterController::SyncSequence::InitialPlanLoad;
+    _masterController->_loadRallyPointsComplete();
+
+    QVERIFY(!_masterController->currentPlanFile().isEmpty());
+    QCOMPARE(_masterController->currentPlanFileName(), QStringLiteral("MissionPlanner"));
+}
+
+void PlanMasterControllerTest::_testShowPlanFromVehicleClearsFileAssociation()
+{
+    _connectMockLink(MAV_AUTOPILOT_PX4);
+    QTRY_VERIFY_WITH_TIMEOUT(_masterController->managerVehicle()->initialPlanRequestComplete(), 10000);
+
+    _masterController->loadFromFile(":/unittest/MissionPlanner.waypoints");
+    QVERIFY(!_masterController->currentPlanFile().isEmpty());
+
+    // Showing the vehicle's plan replaces the editor contents, so the previous file
+    // association no longer describes them
+    _masterController->showPlanFromManagerVehicle();
+
+    QVERIFY(_masterController->currentPlanFile().isEmpty());
+    QVERIFY(!_masterController->dirtyForSave());
+}
+
+void PlanMasterControllerTest::_testFileAssociationClearedOnRemoveAll()
+{
+    _masterController->loadFromFile(":/unittest/MissionPlanner.waypoints");
+    QVERIFY(!_masterController->currentPlanFile().isEmpty());
+
+    QSignalSpy currentFileSpy(_masterController, &PlanMasterController::currentPlanFileChanged);
 
     _masterController->removeAll();
 
-    // Names should be cleared
-    QVERIFY(_masterController->currentPlanFileName().isEmpty());
-    QVERIFY(_masterController->originalPlanFileName().isEmpty());
     QVERIFY(_masterController->currentPlanFile().isEmpty());
-
-    QVERIFY(currentNameSpy.count() >= 1);
-    QVERIFY(originalNameSpy.count() >= 1);
+    QVERIFY(_masterController->currentPlanFileName().isEmpty());
+    QVERIFY(currentFileSpy.count() >= 1);
 }
 
-void PlanMasterControllerTest::_testFileNamesClearedOnRemoveAllFromVehicle()
+void PlanMasterControllerTest::_testFileAssociationClearedOnRemoveAllFromVehicle()
 {
     _connectMockLink(MAV_AUTOPILOT_PX4);
 
     _masterController->loadFromFile(":/unittest/MissionPlanner.waypoints");
+    QVERIFY(!_masterController->currentPlanFile().isEmpty());
 
-    // Verify names are set
-    QVERIFY(!_masterController->currentPlanFileName().isEmpty());
-    QVERIFY(!_masterController->originalPlanFileName().isEmpty());
-
-    QSignalSpy currentNameSpy(_masterController, &PlanMasterController::currentPlanFileNameChanged);
-    QSignalSpy originalNameSpy(_masterController, &PlanMasterController::originalPlanFileNameChanged);
+    QSignalSpy currentFileSpy(_masterController, &PlanMasterController::currentPlanFileChanged);
 
     _masterController->removeAllFromVehicle();
 
-    // Names should be cleared
-    QVERIFY(_masterController->currentPlanFileName().isEmpty());
-    QVERIFY(_masterController->originalPlanFileName().isEmpty());
     QVERIFY(_masterController->currentPlanFile().isEmpty());
-
-    QVERIFY(currentNameSpy.count() >= 1);
-    QVERIFY(originalNameSpy.count() >= 1);
+    QVERIFY(_masterController->currentPlanFileName().isEmpty());
+    QVERIFY(currentFileSpy.count() >= 1);
 }
 
-void PlanMasterControllerTest::_testSaveUpdatesOriginalFileName()
+void PlanMasterControllerTest::_testSaveUpdatesFileName()
 {
     _masterController->loadFromFile(":/unittest/MissionPlanner.waypoints");
-    QCOMPARE(_masterController->originalPlanFileName(), QStringLiteral("MissionPlanner"));
+    QCOMPARE(_masterController->currentPlanFileName(), QStringLiteral("MissionPlanner"));
 
     // Save to a completely different path
     const QString saveFile = QDir::temp().filePath(
         QStringLiteral("qgc_planmaster_rename_%1.plan").arg(QDateTime::currentMSecsSinceEpoch()));
     QVERIFY(_masterController->saveToFile(saveFile));
 
-    // Both names should now reflect the new file base name
-    const QString expectedBase = QFileInfo(saveFile).completeBaseName();
-    QCOMPARE(_masterController->currentPlanFileName(), expectedBase);
-    QCOMPARE(_masterController->originalPlanFileName(), expectedBase);
+    // Name should now reflect the new file base name
+    QCOMPARE(_masterController->currentPlanFileName(), QFileInfo(saveFile).completeBaseName());
 
     // Clean up
     QFile::remove(saveFile);

--- a/test/MissionManager/PlanMasterControllerTest.h
+++ b/test/MissionManager/PlanMasterControllerTest.h
@@ -19,15 +19,16 @@ private slots:
     void _testDirtyFlagsMatrix();
 
     // File name property tests
-    void _testFileNamesSetOnLoad();
-    void _testCurrentPlanFileNameWritable();
-    void _testPlanFileRenamed();
-    void _testSaveWithCurrentName();
-    void _testSaveWithCurrentNameNoFile();
-    void _testResolvedPlanFileExists();
-    void _testFileNamesClearedOnRemoveAll();
-    void _testFileNamesClearedOnRemoveAllFromVehicle();
-    void _testSaveUpdatesOriginalFileName();
+    void _testFileAssociationSetOnLoad();
+    void _testFileAssociationClearedOnRemoveAll();
+    void _testFileAssociationClearedOnRemoveAllFromVehicle();
+    void _testSaveUpdatesFileName();
+    void _testFailedLoadClearsFileAssociation();
+    void _testDownloadClearsFileAssociation();
+    void _testBackgroundSyncPreservesFileAssociation();
+    void _testUnrequestedSendCompletePreservesDirtyForUpload();
+    void _testStaleInitialPlanLoadRallyCompletePreservesPlan();
+    void _testShowPlanFromVehicleClearsFileAssociation();
 
     // showCreateFromTemplate tests — template selection mode
     void _testTemplateModeHidesTemplatesOnPlanCreatorSelection();

--- a/test/QmlUITests/PlanViewUITest.cc
+++ b/test/QmlUITests/PlanViewUITest.cc
@@ -564,3 +564,88 @@ void PlanViewUITest::_testPlanViewStates()
 
     stopUI();
 }
+
+// Save as... lives in the hamburger drop panel.
+void PlanViewUITest::_testSaveAsMenu()
+{
+    startUI();
+    if (QTest::currentTestFailed()) return;
+
+    _navigateToPlanAndCenterMap();
+    if (QTest::currentTestFailed()) return;
+
+    const QString hamburgerBtn = QStringLiteral("planToolbar_hamburgerButton");
+    const QString saveAsBtn    = QStringLiteral("planToolbar_saveAsButton");
+
+    // ------------------------------------------------------------------
+    // 2.1 Empty plan: Save as... visible but disabled
+    // ------------------------------------------------------------------
+    QVERIFY2(clickButton(hamburgerBtn), "Failed to click hamburger button");
+    QVERIFY2(findVisibleItem(_rootItem, saveAsBtn, 2000), "2.1: Save as... did not appear in drop panel");
+    verifyEnabled(saveAsBtn, false, QStringLiteral("2.1 save as on empty plan"));
+    if (QTest::currentTestFailed()) return;
+
+    // Dismiss the drop panel (CloseOnPressOutside)
+    _clickMap(0.5, 0.5);
+    if (QTest::currentTestFailed()) return;
+    QVERIFY2(waitForCondition([&] { return findVisibleItem(_rootItem, saveAsBtn, 0) == nullptr; }, 2000,
+                              QStringLiteral("drop panel closed")),
+             "2.1: drop panel did not close");
+
+    // ------------------------------------------------------------------
+    // 2.2 Build a savable plan: home position + takeoff item
+    // ------------------------------------------------------------------
+    if (!_plannedHomePosition().isValid()) {
+        // The dismiss press may have been consumed by the popup overlay
+        _clickMap(0.5, 0.5);
+        if (QTest::currentTestFailed()) return;
+    }
+    QVERIFY2(waitForCondition([&] { return _plannedHomePosition().isValid(); }, 2000,
+                              QStringLiteral("home position set")),
+             "2.2: map click did not set home position");
+
+    QVERIFY2(clickButton(QStringLiteral("planToolStrip_takeoffButton")), "Failed to click Takeoff button");
+    QVERIFY2(waitForCondition([&] { return _missionItemCount() == 2; }, 2000,
+                              QStringLiteral("takeoff item inserted")),
+             "2.2: takeoff item was not inserted");
+
+    // ------------------------------------------------------------------
+    // 2.3 Cancelled Save as...: nothing written, plan stays dirty
+    // ------------------------------------------------------------------
+    QTemporaryDir tempDir;
+    QVERIFY(tempDir.isValid());
+    const QString planFile = tempDir.filePath(QStringLiteral("PlanViewUITestSaveAs.plan"));
+
+    QVERIFY2(clickButton(hamburgerBtn), "Failed to click hamburger button (cancelled save as)");
+    QVERIFY2(findVisibleItem(_rootItem, saveAsBtn, 2000), "2.3: Save as... did not appear in drop panel");
+    verifyEnabled(saveAsBtn, true, QStringLiteral("2.3 save as with plan items"));
+    if (QTest::currentTestFailed()) return;
+
+    QGCFileDialogController::setTestRejectNext();
+    QVERIFY2(clickButton(saveAsBtn), "Failed to click Save as... button (cancelled save as)");
+
+    QVERIFY2(waitForCondition([] { return !QGCFileDialogController::testHookArmed(); }, 5000,
+                              QStringLiteral("file dialog shim consumed")),
+             "2.3 cancelled save as: file dialog shim was not consumed");
+    QVERIFY2(!QFile::exists(planFile), "2.3 cancelled save as: plan file was unexpectedly written");
+    verifyPrimary(QStringLiteral("planToolbar_saveButton"), true, QStringLiteral("2.3 cancelled save as"));
+    if (QTest::currentTestFailed()) return;
+
+    // ------------------------------------------------------------------
+    // 2.4 Accepted Save as...: file written, dirty-for-save cleared
+    // ------------------------------------------------------------------
+    QVERIFY2(clickButton(hamburgerBtn), "Failed to click hamburger button (save as)");
+    QVERIFY2(findVisibleItem(_rootItem, saveAsBtn, 2000), "2.4: Save as... did not appear in drop panel");
+
+    QGCFileDialogController::setTestNextFileForAccept(planFile);
+    QVERIFY2(clickButton(saveAsBtn), "Failed to click Save as... button");
+
+    QVERIFY2(waitForCondition([&] { return QFile::exists(planFile); }, 5000,
+                              QStringLiteral("plan file written")),
+             "2.4 save as: plan file was not written");
+    QVERIFY2(!QGCFileDialogController::testHookArmed(), "2.4 save as: file dialog shim was not consumed");
+    verifyPrimary(QStringLiteral("planToolbar_saveButton"), false, QStringLiteral("2.4 save as"));
+    if (QTest::currentTestFailed()) return;
+
+    stopUI();
+}

--- a/test/QmlUITests/PlanViewUITest.h
+++ b/test/QmlUITests/PlanViewUITest.h
@@ -20,6 +20,7 @@ public:
 
 private slots:
     void _testPlanViewStates();
+    void _testSaveAsMenu();
     void _testRoverWaypointOnEmptyPlan();
     void _testTakeoffNotRequiredWaypointOnEmptyPlan();
 


### PR DESCRIPTION
Removes the editable plan-name (pending rename) feature and restores the simpler Stable V5.0 file model, fixing the dirty-state and Save as... issues along the way.

## Changes

- **Removed pending rename machinery** from `PlanMasterController`: `originalPlanFileName`, `planFileRenamed`, `setCurrentPlanFileName`, `saveWithCurrentName`, `resolvedPlanFileExists` and the associated dual-name state tracking. `currentPlanFileName` is now a read-only property derived from `currentPlanFile`.
- **Plan Info panel** shows the plan file name as a read-only field (`<Untitled>` and disabled styling when no file is associated), matching the tree view header. Both labels use `Text.PlainText` so `<Untitled>` isn't parsed as markup.
- **Save as... restored to the hamburger menu on all platforms, including mobile.** The mobile file dialog's filename entry handles naming, same as Stable V5.0.
- **Save button** back to the simple model: no file → Save As dialog, otherwise save to the current file.
- **Failed plan loads clear the file association** on JSON/text parse and validation failures via a shared `_loadPlanJson` helper. (A file that fails to open leaves the editor and its association untouched.)
- **Explicit `SyncSequence` state machine for the loadFromVehicle/sendToVehicle chains.** The scattered `_loadGeoFence`/`_loadRallyPoints`/`_sendGeoFence`/`_sendRallyPoints` booleans left the final chain step unguarded, so manager `loadComplete`/`sendComplete` signals from *unrequested* transfers (automatic plan download at vehicle connect, sends initiated by the other view's controller) cleared the file association and dirty state. Each step now only runs when the chain is at that step; an explicit plan download from the vehicle still clears the file association.

## Rationale

The pending-rename model required keeping two name fields in sync across every load/save/clear/download path and computing an "effective dirty" state, which produced repeated edge-case bugs (dirty-state tracking, close-warning gaps, missed reset paths). Removing it eliminates that entire class of problems while keeping full functionality: renaming a plan is Save as... under a new name.

## Testing

- `PlanMasterControllerTest` reworked: 69 tests passing (rename-specific tests removed, file-association tests retained; new `_testBackgroundSyncPreservesFileAssociation` and `_testUnrequestedSendCompletePreservesDirtyForUpload` were written first and confirmed failing before the `SyncSequence` fix)
- `PlanViewUITest`: 6 tests passing, including Save as... menu round-trip (mobile QSKIP guard removed)
