### PR TITLE
feat(params): download PX4 parameters via MAVFTP after hash miss

### DIFF
--- a/src/Comms/MockLink/MockLinkFTP.cc
+++ b/src/Comms/MockLink/MockLinkFTP.cc
@@ -2,6 +2,8 @@
 #include "MockLink.h"
 #include "QGCLoggingCategory.h"
 
+#include <cerrno>
+
 #include <QtCore/QDataStream>
 #include <QtCore/QDir>
 #include <QtCore/QTemporaryFile>
@@ -153,6 +155,10 @@ void MockLinkFTP::_openCommand(uint8_t senderSystemId, uint8_t senderComponentId
     } else if (path == "/parameter.json.xz") {
         tmpFilename = QStringLiteral(":MockLink/Parameter.MetaData.json.xz");
     } else if (path == "@PARAM/param.pck" || path.startsWith("@PARAM/param.pck?")) {
+        if (!_paramPckEnabled) {
+            _sendNakErrno(senderSystemId, senderComponentId, ENOENT, outgoingSeqNumber, MavlinkFTP::kCmdOpenFileRO);
+            return;
+        }
         const bool withDefaults = path.contains(QStringLiteral("withdefaults=1"));
         tmpFilename = _generateParamPck(withDefaults);
     } else if (path.startsWith(QStringLiteral("@MAV_LOG/"))) {

--- a/src/Comms/MockLink/MockLinkFTP.h
+++ b/src/Comms/MockLink/MockLinkFTP.h
@@ -46,6 +46,9 @@ public:
     /// MockLink worker thread so it paces transfers without blocking the main thread.
     void setBurstReadDelayMs(int delayMs) { _burstReadDelayMs = delayMs; }
 
+    /// When false, OpenFileRO of @PARAM/param.pck NAKs errno ENOENT, as PX4 without the virtual file does.
+    void setParamPckEnabled(bool enabled) { _paramPckEnabled = enabled; }
+
     /// Called to handle an FTP message
     void mavlinkMessageReceived(const mavlink_message_t &message);
 
@@ -145,6 +148,7 @@ private:
     int _burstReadDelayMs = 0;                  ///< Per-burst delay to simulate a slow link
     ErrorMode_t _errMode = errModeNone;         ///< Currently set error mode, as specified by setErrorMode
     bool _listDirectoryWithTimeSupported = true; ///< Whether the server implements kCmdListDirectoryWithTime
+    bool _paramPckEnabled = true;               ///< Serve @PARAM/param.pck; false NAKs errno ENOENT
     mavlink_message_t _lastReply{};
     QFile _currentFile;
     QString _paramPckTempFile;

--- a/src/FactSystem/ParameterManager.cc
+++ b/src/FactSystem/ParameterManager.cc
@@ -538,6 +538,7 @@ void ParameterManager::_ftpDownloadComplete(const QString &fileName, const QStri
     bool continueWithDefaultParameterdownload = true;
     bool immediateRetry = false;
 
+    _ftpDownloadInProgress = false;
     (void) disconnect(_vehicle->ftpManager(), &FTPManager::downloadComplete, this, &ParameterManager::_ftpDownloadComplete);
     (void) disconnect(_vehicle->ftpManager(), &FTPManager::commandProgress, this, &ParameterManager::_ftpDownloadProgress);
 
@@ -658,6 +659,11 @@ void ParameterManager::_startParameterDownload(uint8_t componentId)
             : componentId;
         _requestHashCheck(hashCheckCompId);
     } else if (_tryftp && ((componentId == MAV_COMP_ID_ALL) || (componentId == MAV_COMP_ID_AUTOPILOT1))) {
+        if (_ftpDownloadInProgress) {
+            // A retry while the file is still transferring would disconnect the completion handler below
+            qCDebug(ParameterManagerLog) << _logVehiclePrefix(-1) << "Parameter file download already in progress";
+            return;
+        }
         if (!_initialLoadComplete) {
             _paramRequestListTimer.start();
         }
@@ -669,6 +675,7 @@ void ParameterManager::_startParameterDownload(uint8_t componentId)
                                  QStandardPaths::writableLocation(QStandardPaths::TempLocation),
                                  QStringLiteral("param.pck"),
                                  false /* No filesize check */)) {
+            _ftpDownloadInProgress = true;
             (void) connect(ftpManager, &FTPManager::commandProgress, this, &ParameterManager::_ftpDownloadProgress);
         } else {
             qCWarning(ParameterManagerLog) << "ParameterManager::_startParameterDownload FTPManager::download returned failure";

--- a/src/FactSystem/ParameterManager.cc
+++ b/src/FactSystem/ParameterManager.cc
@@ -39,7 +39,7 @@ ParameterManager::ParameterManager(Vehicle *vehicle)
     , _logReplay(!vehicle->vehicleLinkManager()->primaryLink().expired() && vehicle->vehicleLinkManager()->primaryLink().lock()->isLogReplay())
     , _disableAllRetries(_logReplay)
     , _waitForParamValueAckMs(QGC::runningUnitTests() ? 50 : kWaitForParamValueAckMs)
-    , _tryftp(vehicle->apmFirmware())
+    , _tryftp(vehicle->apmFirmware() || vehicle->px4Firmware())
 {
     qCDebug(ParameterManagerLog) << this;
 
@@ -98,9 +98,6 @@ void ParameterManager::_updateProgressBar()
 
 void ParameterManager::mavlinkMessageReceived(const mavlink_message_t &message)
 {
-    if (_tryftp && (message.compid == MAV_COMP_ID_AUTOPILOT1) && !_initialLoadComplete)
-        return;
-
     if (message.msgid == MAVLINK_MSG_ID_PARAM_VALUE) {
         mavlink_param_value_t param_value{};
         mavlink_msg_param_value_decode(&message, &param_value);
@@ -109,6 +106,13 @@ void ParameterManager::mavlinkMessageReceived(const mavlink_message_t &message)
         char parameterNameWithNull[MAVLINK_MSG_PARAM_VALUE_FIELD_PARAM_ID_LEN + 1] = {};
         (void) strncpy(parameterNameWithNull, param_value.param_id, MAVLINK_MSG_PARAM_VALUE_FIELD_PARAM_ID_LEN);
         const QString parameterName(parameterNameWithNull);
+
+        // FTP download ignores the PARAM_VALUE stream, but PX4 _HASH_CHECK is a PARAM_VALUE
+        // and must still be handled so the cache can skip the download.
+        if (_tryftp && (message.compid == MAV_COMP_ID_AUTOPILOT1) && !_initialLoadComplete
+            && (parameterName != QStringLiteral("_HASH_CHECK"))) {
+            return;
+        }
 
         mavlink_param_union_t paramUnion{};
         paramUnion.param_float = param_value.param_value;
@@ -644,7 +648,16 @@ void ParameterManager::_startParameterDownload(uint8_t componentId)
         return;
     }
 
-    if (_tryftp && ((componentId == MAV_COMP_ID_ALL) || (componentId == MAV_COMP_ID_AUTOPILOT1))) {
+    if (_vehicle->px4Firmware() && !_initialLoadComplete && !_hashCheckDone) {
+        // PX4: Try _HASH_CHECK first to see if we can load from cache without a full parameter stream
+        _cacheOnlyHashCheck = false;
+        _hashCheckTimer.start();
+        qCDebug(ParameterManagerLog) << _logVehiclePrefix(-1) << "Requesting _HASH_CHECK before full parameter list";
+        const uint8_t hashCheckCompId = (componentId == MAV_COMP_ID_ALL)
+            ? static_cast<uint8_t>(MAV_COMP_ID_AUTOPILOT1)
+            : componentId;
+        _requestHashCheck(hashCheckCompId);
+    } else if (_tryftp && ((componentId == MAV_COMP_ID_ALL) || (componentId == MAV_COMP_ID_AUTOPILOT1))) {
         if (!_initialLoadComplete) {
             _paramRequestListTimer.start();
         }
@@ -661,15 +674,6 @@ void ParameterManager::_startParameterDownload(uint8_t componentId)
             qCWarning(ParameterManagerLog) << "ParameterManager::_startParameterDownload FTPManager::download returned failure";
             (void) disconnect(ftpManager, &FTPManager::downloadComplete, this, &ParameterManager::_ftpDownloadComplete);
         }
-    } else if (_vehicle->px4Firmware() && !_initialLoadComplete && !_hashCheckDone) {
-        // PX4: Try _HASH_CHECK first to see if we can load from cache without a full parameter stream
-        _cacheOnlyHashCheck = false;
-        _hashCheckTimer.start();
-        qCDebug(ParameterManagerLog) << _logVehiclePrefix(-1) << "Requesting _HASH_CHECK before full parameter list";
-        const uint8_t hashCheckCompId = (componentId == MAV_COMP_ID_ALL)
-            ? static_cast<uint8_t>(MAV_COMP_ID_AUTOPILOT1)
-            : componentId;
-        _requestHashCheck(hashCheckCompId);
     } else {
         if (!_initialLoadComplete) {
             _paramRequestListTimer.start();
@@ -1097,7 +1101,7 @@ void ParameterManager::_tryCacheHashLoad(int vehicleId, int componentId, const Q
                 emit cacheCheckOnlyFailed();
                 return;
             }
-            // Standalone hash check path — fall back to PARAM_REQUEST_LIST
+            // Standalone hash check path — fall back to FTP / PARAM_REQUEST_LIST
             _startParameterDownload(MAV_COMP_ID_ALL);
         }
         // If already in PARAM_REQUEST_LIST flow, just let the stream continue
@@ -1199,7 +1203,7 @@ void ParameterManager::_tryCacheHashLoad(int vehicleId, int componentId, const Q
                 emit cacheCheckOnlyFailed();
                 return;
             }
-            // Standalone hash check path — fall back to PARAM_REQUEST_LIST
+            // Standalone hash check path — fall back to FTP / PARAM_REQUEST_LIST
             _startParameterDownload(MAV_COMP_ID_ALL);
         }
         // If already in PARAM_REQUEST_LIST flow, just let the stream continue
@@ -1373,7 +1377,7 @@ void ParameterManager::_hashCheckTimeout()
         emit cacheCheckOnlyFailed();
         return;
     }
-    qCDebug(ParameterManagerLog) << _logVehiclePrefix(-1) << "_HASH_CHECK timed out, falling back to PARAM_REQUEST_LIST";
+    qCDebug(ParameterManagerLog) << _logVehiclePrefix(-1) << "_HASH_CHECK timed out, falling back to parameter download";
     _startParameterDownload(MAV_COMP_ID_ALL);
 }
 
@@ -1786,6 +1790,9 @@ Success:
     _paramCountMap[componentId] = num_params;
     _totalParamCount += num_params;
     _waitingReadParamIndexMap[componentId] = QMap<int, int>();
+    if (!_logReplay && _vehicle->px4Firmware()) {
+        _writeLocalParamCache(_vehicle->id(), componentId);
+    }
     _checkInitialLoadComplete();
     _setLoadProgress(0.0);
     return true;

--- a/src/FactSystem/ParameterManager.h
+++ b/src/FactSystem/ParameterManager.h
@@ -237,4 +237,5 @@ private:
     Fact _defaultFact;   ///< Used to return default fact, when parameter not found
 
     bool _tryftp = false;
+    bool _ftpDownloadInProgress = false;        ///< true: @PARAM/param.pck transfer in flight
 };

--- a/src/Vehicle/FTPManager.cc
+++ b/src/Vehicle/FTPManager.cc
@@ -8,6 +8,7 @@
 #include <QtCore/QFile>
 #include <QtCore/QFileInfo>
 #include <QtCore/QDir>
+#include <cerrno>
 #include <limits>
 
 QGC_LOGGING_CATEGORY(FTPManagerLog, "Vehicle.FTPManager")
@@ -731,7 +732,10 @@ QString FTPManager::_errorMsgFromNak(const MavlinkFTP::Request* nak)
     if ((errorCode == MavlinkFTP::kErrFailErrno && nak->hdr.size != 2) || ((errorCode != MavlinkFTP::kErrFailErrno) && nak->hdr.size != 1)) {
         errorMsg = tr("Invalid Nak format");
     } else if (errorCode == MavlinkFTP::kErrFailErrno) {
-        errorMsg = tr("errno %1").arg(nak->data[1]);
+        // PX4 reports a missing file as errno rather than kErrFailFileNotFound. The value is the
+        // vehicle's, but ENOENT is 2 on every platform PX4 runs on.
+        errorMsg = (nak->data[1] == ENOENT) ? MavlinkFTP::errorCodeToString(MavlinkFTP::kErrFailFileNotFound)
+                                            : tr("errno %1").arg(nak->data[1]);
     } else {
         errorMsg = MavlinkFTP::errorCodeToString(errorCode);
     }

--- a/test/FactSystem/HashCheckTest.cc
+++ b/test/FactSystem/HashCheckTest.cc
@@ -10,6 +10,7 @@
 #include "LinkManager.h"
 #include "MAVLinkLib.h"
 #include "MockConfiguration.h"
+#include "MockLinkFTP.h"
 #include "MultiVehicleManager.h"
 #include "ParameterManager.h"
 #include "Vehicle.h"
@@ -97,19 +98,23 @@ MockLink *HashCheckTest::_startPX4MockLinkHighLatency()
 
 // Data-driven test matrix for all _HASH_CHECK parameter cache scenarios.
 //
-// FirstConnect_NoCache:   First PX4 connection with no cache. Sends _HASH_CHECK, gets full param list.
-// Reconnect_CacheHit:     Reconnect after populating cache. Hash matches so no PARAM_REQUEST_LIST needed.
-// Reconnect_CacheMiss:    Reconnect after a parameter changed. Hash mismatch triggers full param reload.
-// HashTimeout_CacheHit:   Vehicle never responds to _HASH_CHECK. Falls back to PARAM_REQUEST_LIST, cache still valid.
-// HashTimeout_NoCache:    Vehicle never responds to _HASH_CHECK and no cache exists. Falls back to full param list.
-// HashTimeout_CacheStale: Vehicle never responds to _HASH_CHECK and cache is stale. Falls back to full param list.
-// BothTimersExhaust:      Vehicle responds to neither _HASH_CHECK nor PARAM_REQUEST_LIST. Params never become ready.
-// CacheDeleted_Between:   Cache populated then deleted before reconnect. Forces full param reload despite same vehicle.
-// ManualRefresh:          User-triggered refreshAllParameters() bypasses _HASH_CHECK and requests full param list.
+// FirstConnect_NoCache:   First PX4 connection with no cache. Sends _HASH_CHECK, then FTP param.pck.
+// Reconnect_CacheHit:     Reconnect after populating cache. Hash matches so no download needed.
+// Reconnect_CacheMiss:    Reconnect after a parameter changed. Hash mismatch, FTP param.pck.
+// HashTimeout_CacheHit:   Vehicle never responds to _HASH_CHECK. Falls back to FTP param.pck.
+// HashTimeout_NoCache:    Vehicle never responds to _HASH_CHECK and no cache exists. Falls back to FTP.
+// HashTimeout_CacheStale: Vehicle never responds to _HASH_CHECK and cache is stale. Falls back to FTP.
+// BothTimersExhaust:      No hash, FTP file missing, PARAM_REQUEST_LIST ignored. Params never become ready.
+// CacheDeleted_Between:   Cache populated then deleted before reconnect. FTP param.pck.
+// ManualRefresh:          User-triggered refreshAllParameters() bypasses _HASH_CHECK and uses FTP.
 // ArduPilot:              ArduPilot uses FTP for parameters, so no _HASH_CHECK or PARAM_REQUEST_LIST traffic.
 // HighLatency:            High-latency links skip parameter download entirely; params marked as missing.
 //
-// PARAM_REQUEST_LIST (xPRL) is only asserted for PX4 vehicles; ArduPilot uses FTP.
+// PARAM_REQUEST_LIST (xPRL) is asserted for PX4 only when the hash miss falls back
+// to the conventional stream (FTP @PARAM/param.pck unavailable). A hash miss with
+// FTP enabled does not send PARAM_REQUEST_LIST.
+// A cache hit (xCache) is the only path that sends PARAM_SET during connect: it answers
+// the vehicle with _HASH_CHECK instead of downloading.
 // missingParameters (xMiss) is only asserted when expectParametersReady (xReady) is true.
 
 void HashCheckTest::_hashCheckMatrix_data()
@@ -126,22 +131,23 @@ void HashCheckTest::_hashCheckMatrix_data()
 
     // Expected outcomes
     QTest::addColumn<bool>("xHashCheck");
+    QTest::addColumn<bool>("xCacheHit");
     QTest::addColumn<bool>("xPRL");
     QTest::addColumn<bool>("xReady");
     QTest::addColumn<bool>("xMissing");
 
-    //                                          px4      hl       popC     chgP     delC     noResp   failNR   manRef    xHC      xPRL     xReady   xMiss
-    QTest::newRow("FirstConnect_NoCache")    << true  << false << false << false << false << false << false << false  << true  << true  << true  << false;
-    QTest::newRow("Reconnect_CacheHit")      << true  << false << true  << false << false << false << false << false  << true  << false << true  << false;
-    QTest::newRow("Reconnect_CacheMiss")     << true  << false << true  << true  << false << false << false << false  << true  << true  << true  << false;
-    QTest::newRow("HashTimeout_CacheHit")    << true  << false << true  << false << false << true  << false << false  << true  << true  << true  << false;
-    QTest::newRow("HashTimeout_NoCache")     << true  << false << false << false << false << true  << false << false  << true  << true  << true  << false;
-    QTest::newRow("HashTimeout_CacheStale")  << true  << false << true  << true  << false << true  << false << false  << true  << true  << true  << false;
-    QTest::newRow("BothTimersExhaust")       << true  << false << false << false << false << true  << true  << false  << true  << true  << false << false;
-    QTest::newRow("CacheDeleted_Between")    << true  << false << true  << false << true  << false << false << false  << true  << true  << true  << false;
-    QTest::newRow("ManualRefresh")           << true  << false << false << false << false << false << false << true   << false << true  << true  << false;
-    QTest::newRow("ArduPilot")              << false  << false << false << false << false << false << false << false  << false << false << true  << false;
-    QTest::newRow("HighLatency")             << true  << true  << false << false << false << false << false << false  << false << false << true  << true;
+    //                                          px4      hl       popC     chgP     delC     noResp   failNR   manRef    xHC      xCache   xPRL     xReady   xMiss
+    QTest::newRow("FirstConnect_NoCache")    << true  << false << false << false << false << false << false << false  << true  << false << false << true  << false;
+    QTest::newRow("Reconnect_CacheHit")      << true  << false << true  << false << false << false << false << false  << true  << true  << false << true  << false;
+    QTest::newRow("Reconnect_CacheMiss")     << true  << false << true  << true  << false << false << false << false  << true  << false << false << true  << false;
+    QTest::newRow("HashTimeout_CacheHit")    << true  << false << true  << false << false << true  << false << false  << true  << false << false << true  << false;
+    QTest::newRow("HashTimeout_NoCache")     << true  << false << false << false << false << true  << false << false  << true  << false << false << true  << false;
+    QTest::newRow("HashTimeout_CacheStale")  << true  << false << true  << true  << false << true  << false << false  << true  << false << false << true  << false;
+    QTest::newRow("BothTimersExhaust")       << true  << false << false << false << false << true  << true  << false  << true  << false << true  << false << false;
+    QTest::newRow("CacheDeleted_Between")    << true  << false << true  << false << true  << false << false << false  << true  << false << false << true  << false;
+    QTest::newRow("ManualRefresh")           << true  << false << false << false << false << false << false << true   << false << false << false << true  << false;
+    QTest::newRow("ArduPilot")              << false  << false << false << false << false << false << false << false  << false << false << false << true  << false;
+    QTest::newRow("HighLatency")             << true  << true  << false << false << false << false << false << false  << false << false << false << true  << true;
 }
 
 void HashCheckTest::_hashCheckMatrix()
@@ -162,6 +168,7 @@ void HashCheckTest::_hashCheckMatrix()
     QFETCH(bool, failNoResponse);
     QFETCH(bool, manualRefresh);
     QFETCH(bool, xHashCheck);
+    QFETCH(bool, xCacheHit);
     QFETCH(bool, xPRL);
     QFETCH(bool, xReady);
     QFETCH(bool, xMissing);
@@ -226,6 +233,9 @@ void HashCheckTest::_hashCheckMatrix()
     } else if (xReady) {
         // PX4 normal path — params will become ready
         _mockLink = _startPX4MockLinkNoIncrement(failMode);
+        if (failNoResponse) {
+            _mockLink->mockLinkFTP()->setParamPckEnabled(false);
+        }
         if (changeParam) {
             _mockLink->setMockParamValue(MAV_COMP_ID_AUTOPILOT1, QStringLiteral("BAT1_V_CHARGED"), 99.0f);
         }
@@ -235,8 +245,11 @@ void HashCheckTest::_hashCheckMatrix()
         _connectAndWaitForParams();
 
     } else {
-        // PX4 path where params never become ready (both timers exhaust)
+        // PX4 path where params never become ready (hash, FTP, and PARAM_REQUEST_LIST all fail)
         _mockLink = _startPX4MockLinkNoIncrement(failMode);
+        if (failNoResponse) {
+            _mockLink->mockLinkFTP()->setParamPckEnabled(false);
+        }
         if (hashCheckNoResponse) {
             _mockLink->setHashCheckNoResponse(true);
         }
@@ -259,6 +272,8 @@ void HashCheckTest::_hashCheckMatrix()
 
     // Phase 4: Verify outcomes
     QCOMPARE(_mockLink->hashCheckRequestCount() > 0, xHashCheck);
+    // The PARAM_SET reply is the last thing a cache hit sends, so it may still be in flight
+    QCOMPARE_TRUE_WAIT(_mockLink->receivedMavlinkMessageCount(MAVLINK_MSG_ID_PARAM_SET) > 0, xCacheHit, TestTimeout::shortMs());
 
     if (xReady) {
         Vehicle *const vehicle = MultiVehicleManager::instance()->activeVehicle();

--- a/test/FactSystem/ParameterManagerTest.cc
+++ b/test/FactSystem/ParameterManagerTest.cc
@@ -78,6 +78,7 @@ void ParameterManagerTest::_requestListNoResponse()
 {
     QVERIFY2(!_mockLink, "MockLink already connected");
     _mockLink = MockLink::startPX4MockLink(MockConfiguration::OptionNone, MockConfiguration::FailParamNoResponseToRequestList);
+    _mockLink->mockLinkFTP()->setParamPckEnabled(false);
     MultiVehicleManager* vehicleMgr = MultiVehicleManager::instance();
     QVERIFY(vehicleMgr);
     // Wait for the Vehicle to get created
@@ -100,11 +101,12 @@ void ParameterManagerTest::_requestListNoResponse()
 }
 
 // MockLink will fail to send a param on initial request, it will also fail to send it on subsequent
-// param_read requests.
+// param_read requests. The packed file is disabled so the stream path is exercised.
 void ParameterManagerTest::_requestListMissingParamFail()
 {
     QVERIFY2(!_mockLink, "MockLink already connected");
     _mockLink = MockLink::startPX4MockLink(MockConfiguration::OptionNone, MockConfiguration::FailMissingParamOnAllRequests);
+    _mockLink->mockLinkFTP()->setParamPckEnabled(false);
     MultiVehicleManager* vehicleMgr = MultiVehicleManager::instance();
     QVERIFY(vehicleMgr);
     // Wait for the Vehicle to get created

--- a/test/Vehicle/InitialConnectPeripheralStartupTest.cc
+++ b/test/Vehicle/InitialConnectPeripheralStartupTest.cc
@@ -29,12 +29,10 @@ void InitialConnectPeripheralStartupTest::_noCameraOrGimbalRequestsBeforeInitial
     _vehicle = MultiVehicleManager::instance()->activeVehicle();
     QVERIFY(_vehicle);
 
-    // Test pre-complete behavior only while initial connect is still in progress.
-    QVERIFY2(!_vehicle->isInitialConnectComplete(), "Initial connect completed too quickly for pre-complete assertions");
-
     // Received-message counts are monotonic, so counts that are still zero when initialConnectComplete
     // fires prove no peripheral request was sent before completion. They are sampled inside the signal
     // handler because the managers send their first request on the next peripheral message after it.
+    // Subscribe before the too-quick check so a completion that lands in that window is still captured.
     int gimbalInfoRequestsAtComplete = -1;
     int cameraInfoRequestsAtComplete = -1;
     int cameraInfoCommandsAtComplete = -1;
@@ -43,6 +41,9 @@ void InitialConnectPeripheralStartupTest::_noCameraOrGimbalRequestsBeforeInitial
         cameraInfoRequestsAtComplete = _mockLink->receivedRequestMessageCount(MAVLINK_MSG_ID_CAMERA_INFORMATION);
         cameraInfoCommandsAtComplete = _mockLink->receivedMavCommandCount(MAV_CMD_REQUEST_CAMERA_INFORMATION);
     });
+
+    QVERIFY2(!_vehicle->isInitialConnectComplete() || (gimbalInfoRequestsAtComplete >= 0),
+             "Initial connect completed too quickly for pre-complete assertions");
     QVERIFY_TRUE_WAIT(_vehicle->isInitialConnectComplete(), TestTimeout::longMs());
     QCOMPARE(gimbalInfoRequestsAtComplete, 0);
     QCOMPARE(cameraInfoRequestsAtComplete, 0);

--- a/test/Vehicle/InitialConnectPeripheralStartupTest.cc
+++ b/test/Vehicle/InitialConnectPeripheralStartupTest.cc
@@ -29,19 +29,24 @@ void InitialConnectPeripheralStartupTest::_noCameraOrGimbalRequestsBeforeInitial
     _vehicle = MultiVehicleManager::instance()->activeVehicle();
     QVERIFY(_vehicle);
 
-    QSignalSpy initialConnectCompleteSpy(_vehicle, &Vehicle::initialConnectComplete);
-    QVERIFY(initialConnectCompleteSpy.isValid());
-
     // Test pre-complete behavior only while initial connect is still in progress.
     QVERIFY2(!_vehicle->isInitialConnectComplete(), "Initial connect completed too quickly for pre-complete assertions");
 
-    // Received-message counts are monotonic, so verifying they are still zero at the instant
-    // initial connect completes proves no peripheral request was sent before completion.
-    QVERIFY_TRUE_WAIT(_vehicle->isInitialConnectComplete() || (initialConnectCompleteSpy.count() > 0),
-                      TestTimeout::longMs());
-    QCOMPARE(_mockLink->receivedRequestMessageCount(MAVLINK_MSG_ID_GIMBAL_MANAGER_INFORMATION), 0);
-    QCOMPARE(_mockLink->receivedRequestMessageCount(MAVLINK_MSG_ID_CAMERA_INFORMATION), 0);
-    QCOMPARE(_mockLink->receivedMavCommandCount(MAV_CMD_REQUEST_CAMERA_INFORMATION), 0);
+    // Received-message counts are monotonic, so counts that are still zero when initialConnectComplete
+    // fires prove no peripheral request was sent before completion. They are sampled inside the signal
+    // handler because the managers send their first request on the next peripheral message after it.
+    int gimbalInfoRequestsAtComplete = -1;
+    int cameraInfoRequestsAtComplete = -1;
+    int cameraInfoCommandsAtComplete = -1;
+    (void) connect(_vehicle, &Vehicle::initialConnectComplete, this, [&]() {
+        gimbalInfoRequestsAtComplete = _mockLink->receivedRequestMessageCount(MAVLINK_MSG_ID_GIMBAL_MANAGER_INFORMATION);
+        cameraInfoRequestsAtComplete = _mockLink->receivedRequestMessageCount(MAVLINK_MSG_ID_CAMERA_INFORMATION);
+        cameraInfoCommandsAtComplete = _mockLink->receivedMavCommandCount(MAV_CMD_REQUEST_CAMERA_INFORMATION);
+    });
+    QVERIFY_TRUE_WAIT(_vehicle->isInitialConnectComplete(), TestTimeout::longMs());
+    QCOMPARE(gimbalInfoRequestsAtComplete, 0);
+    QCOMPARE(cameraInfoRequestsAtComplete, 0);
+    QCOMPARE(cameraInfoCommandsAtComplete, 0);
 
     // After initial connect completes, both managers should begin startup requests.
     QVERIFY_TRUE_WAIT(

--- a/test/Vehicle/InitialConnectTest.cc
+++ b/test/Vehicle/InitialConnectTest.cc
@@ -11,6 +11,7 @@
 #include "MultiVehicleManager.h"
 #include "MockConfiguration.h"
 #include "MockLink.h"
+#include "MockLinkFTP.h"
 #include "MockLinkMissionItemHandler.h"
 #include "MissionManager.h"
 #include "ParameterManager.h"
@@ -357,6 +358,10 @@ void InitialConnectTest::_stateTimeoutFallsThrough()
         _mockLink->setRequestMessageNoResponse(messageId);
     }
 
+    if (configFailureMode == static_cast<int>(MockConfiguration::FailParamNoResponseToRequestList)) {
+        _mockLink->mockLinkFTP()->setParamPckEnabled(false);
+    }
+
     if (blockMissionProtocolImmediately) {
         _mockLink->setMissionItemFailureMode(
             MockLinkMissionItemHandler::FailReadRequestListNoResponse, MAV_MISSION_ACCEPTED);
@@ -488,7 +493,6 @@ void InitialConnectTest::_stateRunMatrix()
         _mockLink->receivedRequestMessageCount(MAV_COMP_ID_AUTOPILOT1, MAVLINK_MSG_ID_AUTOPILOT_VERSION);
     const int availableModesReqCount =
         _mockLink->receivedRequestMessageCount(MAV_COMP_ID_AUTOPILOT1, MAVLINK_MSG_ID_AVAILABLE_MODES);
-    const int paramRequestListCount = _mockLink->receivedMavlinkMessageCount(MAVLINK_MSG_ID_PARAM_REQUEST_LIST);
 
     // AutopilotVersion expectation is matrix-driven.
     QCOMPARE(autopilotVersionReqCount > 0, expectAutopilotVersionRequest);
@@ -500,12 +504,10 @@ void InitialConnectTest::_stateRunMatrix()
     QCOMPARE(_vehicle->parameterManager()->parameterDownloadSkipped(), expectParameterDownloadSkipped);
 
     // Parameters: skipped when flying (with setting enabled) or on HL/LR links.
-    // PX4 flying: cache-only hash check attempted, no full download.
+    // PX4 starts every download with _HASH_CHECK; flying only tries the cache.
     if (expectParamRequest) {
-        QVERIFY2(paramRequestListCount > 0, "Expected PARAM_REQUEST_LIST");
+        QVERIFY2(_mockLink->hashCheckRequestCount() > 0, "Expected _HASH_CHECK request");
     } else if (expectHashCheckOnly) {
-        // PX4 flying: hash check was attempted but no full download
-        QCOMPARE(paramRequestListCount, 0);
         QVERIFY2(_mockLink->hashCheckRequestCount() > 0, "Expected _HASH_CHECK request in cache-only mode");
         // No cache file in test env → cache miss → params not ready
         QVERIFY(!_vehicle->parameterManager()->parametersReady());


### PR DESCRIPTION
## Summary

On PX4, keep `_HASH_CHECK` first and download `@PARAM/param.pck` on a miss instead of `PARAM_REQUEST_LIST`.

Companion: https://github.com/PX4/PX4-Autopilot/pull/28435. Cache-key follow-up: #14982

## Problem

A hash miss starts the PARAM_VALUE stream. On SiK that transfer often stalls and never completes, so Vehicle Setup stays gated. QGC already has the packed-file client and parser for ArduPilot.

## Solution

Enable the FTP param path for PX4 as well, after the existing hash check. `_HASH_CHECK` is still accepted while FTP is armed so the cache can skip the download. Firmware without the virtual file NAKs `kErrFailErrno`/ENOENT rather than `kErrFailFileNotFound`; FTPManager now reports that as File Not Found so the fallback to `PARAM_REQUEST_LIST` stays immediate instead of arriving two retry timeouts later. A successful packed parse writes the PX4 param cache so the next hash can hit. A retry while the file is still transferring no longer discards the in-flight download. Companion/DroneCAN components are still not in the packed file (same as ArduPilot today).
