### PR TITLE
fix(AppSettings): backport settings section visibility fixes to Stable_V5.1

### DIFF
--- a/src/AppSettings/CMakeLists.txt
+++ b/src/AppSettings/CMakeLists.txt
@@ -8,7 +8,12 @@ set(SETTINGS_METADATA_DIR      "${CMAKE_SOURCE_DIR}/src/Settings")
 set(SETTINGS_QML_GEN_DIR       "${CMAKE_CURRENT_BINARY_DIR}/generated")
 
 # Generator source files (changes here should trigger regeneration)
-file(GLOB _generator_sources CONFIGURE_DEPENDS "${SETTINGS_QML_GENERATOR_DIR}/*.py")
+file(GLOB _generator_sources CONFIGURE_DEPENDS
+    "${SETTINGS_QML_GENERATOR_DIR}/*.py"
+    "${SETTINGS_QML_GENERATOR_DIR}/templates/*.j2"
+    "${CMAKE_SOURCE_DIR}/tools/generators/common/*.py"
+    "${CMAKE_SOURCE_DIR}/tools/generators/*.py"
+)
 
 # JSON inputs: page definitions + settings metadata
 file(GLOB _page_definitions  CONFIGURE_DEPENDS "${SETTINGS_PAGES_DIR}/*.json")

--- a/src/AppSettings/pages/Video.SettingsUI.json
+++ b/src/AppSettings/pages/Video.SettingsUI.json
@@ -77,6 +77,7 @@
         {
             "heading": "Local Video Storage",
             "keywords": ["record", "recording format", "mp4", "mkv", "storage limit", "video file"],
+            "showWhen": "!sourceDisabled",
             "controls": [
                 {
                     "setting": "videoSettings.recordingFormat"

--- a/src/AutoPilotPlugins/APM/APMAutoPilotPlugin.cc
+++ b/src/AutoPilotPlugins/APM/APMAutoPilotPlugin.cc
@@ -93,9 +93,13 @@ const QVariantList &APMAutoPilotPlugin::vehicleComponents()
             _powerComponent->setupTriggerSignals();
             _components.append(QVariant::fromValue(qobject_cast<VehicleComponent*>(_powerComponent)));
 
-            _escComponent = new APMESCComponent(_vehicle, this);
-            _escComponent->setupTriggerSignals();
-            _components.append(QVariant::fromValue(qobject_cast<VehicleComponent*>(_escComponent)));
+            // ESC page is blank without the motor PWM params (e.g. fixed-wing Plane)
+            if (_vehicle->parameterManager()->parameterExists(-1, QStringLiteral("MOT_PWM_TYPE")) ||
+                _vehicle->parameterManager()->parameterExists(-1, QStringLiteral("Q_M_PWM_TYPE"))) {
+                _escComponent = new APMESCComponent(_vehicle, this);
+                _escComponent->setupTriggerSignals();
+                _components.append(QVariant::fromValue(qobject_cast<VehicleComponent*>(_escComponent)));
+            }
 
             if (!_vehicle->sub() || (_vehicle->versionCompare(3, 5, 3) >= 0)) {
                 _motorComponent = new APMMotorComponent(_vehicle, this);

--- a/src/AutoPilotPlugins/APM/CMakeLists.txt
+++ b/src/AutoPilotPlugins/APM/CMakeLists.txt
@@ -72,7 +72,9 @@ set(APM_CONFIG_QML_GEN_DIR       "${CMAKE_CURRENT_BINARY_DIR}/generated")
 # Generator source files (changes here trigger regeneration)
 file(GLOB _apm_config_generator_sources CONFIGURE_DEPENDS
     "${APM_CONFIG_QML_GENERATOR_DIR}/*.py"
+    "${APM_CONFIG_QML_GENERATOR_DIR}/templates/*.j2"
     "${CMAKE_SOURCE_DIR}/tools/generators/common/*.py"
+    "${CMAKE_SOURCE_DIR}/tools/generators/*.py"
 )
 
 # JSON inputs

--- a/src/AutoPilotPlugins/PX4/CMakeLists.txt
+++ b/src/AutoPilotPlugins/PX4/CMakeLists.txt
@@ -60,7 +60,9 @@ set(CONFIG_QML_GEN_DIR       "${CMAKE_CURRENT_BINARY_DIR}/generated")
 # Generator source files (changes here trigger regeneration)
 file(GLOB _config_generator_sources CONFIGURE_DEPENDS
     "${CONFIG_QML_GENERATOR_DIR}/*.py"
+    "${CONFIG_QML_GENERATOR_DIR}/templates/*.j2"
     "${CMAKE_SOURCE_DIR}/tools/generators/common/*.py"
+    "${CMAKE_SOURCE_DIR}/tools/generators/*.py"
 )
 
 # JSON inputs

--- a/src/AutoPilotPlugins/PX4/FlightModesComponent.cc
+++ b/src/AutoPilotPlugins/PX4/FlightModesComponent.cc
@@ -38,7 +38,18 @@ QUrl FlightModesComponent::summaryQmlSource(void) const
     return QUrl::fromUserInput("qrc:/qml/QGroundControl/AutoPilotPlugins/PX4/FlightModesComponentSummary.qml");
 }
 
-QStringList FlightModesComponent::sections() const
+QStringList FlightModesComponent::sectionIds() const
 {
-    return { tr("Flight Modes"), tr("Switch Settings") };
+    return { QStringLiteral("Flight Modes"), QStringLiteral("Switch Settings") };
+}
+
+QString FlightModesComponent::sectionDisplayName(const QString& sectionId) const
+{
+    if (sectionId == QStringLiteral("Flight Modes")) {
+        return tr("Flight Modes");
+    }
+    if (sectionId == QStringLiteral("Switch Settings")) {
+        return tr("Switch Settings");
+    }
+    return sectionId;
 }

--- a/src/AutoPilotPlugins/PX4/FlightModesComponent.h
+++ b/src/AutoPilotPlugins/PX4/FlightModesComponent.h
@@ -18,7 +18,8 @@ public:
     bool requiresSetup() const final { return false; }
     bool setupComplete() const final { return true; }
     QStringList setupCompleteChangedTriggerList() const final { return QStringList(); }
-    QStringList sections() const final;
+    QStringList sectionIds() const final;
+    QString sectionDisplayName(const QString& sectionId) const final;
 
 private:
     const QString   _name;

--- a/src/AutoPilotPlugins/PX4/PX4FlightModes.qml
+++ b/src/AutoPilotPlugins/PX4/PX4FlightModes.qml
@@ -16,7 +16,7 @@ SetupPage {
             width:  availableWidth
             height: availableHeight
 
-            property string sectionNameFilter: ""
+            property string sectionIdFilter: ""
 
             property real _margins:         ScreenTools.defaultFontPixelHeight / 2
             property var  _switchNameList:  [ "RC_MAP_ARM_SW", "RC_MAP_GEAR_SW", "RC_MAP_KILL_SW", "RC_MAP_LOITER_SW", "RC_MAP_OFFB_SW", "RC_MAP_RETURN_SW" ]
@@ -57,7 +57,7 @@ SetupPage {
                         Column {
                             id:      flightModeSettingsColumn
                             spacing: _margins
-                            visible: sectionNameFilter === "" || sectionNameFilter === qsTr("Flight Modes")
+                            visible: sectionIdFilter === "" || sectionIdFilter === "Flight Modes"
 
                             QGCLabel {
                                 id:             flightModeLabel
@@ -120,7 +120,7 @@ SetupPage {
                         Column {
                             id:         column2
                             spacing:    _margins
-                            visible:    sectionNameFilter === "" || sectionNameFilter === qsTr("Switch Settings")
+                            visible:    sectionIdFilter === "" || sectionIdFilter === "Switch Settings"
 
                             QGCLabel {
                                 text:           qsTr("Switch Settings")

--- a/src/AutoPilotPlugins/PX4/SensorsComponent.cc
+++ b/src/AutoPilotPlugins/PX4/SensorsComponent.cc
@@ -89,7 +89,7 @@ QUrl SensorsComponent::setupSource(void) const
     return QUrl::fromUserInput("qrc:/qml/QGroundControl/AutoPilotPlugins/PX4/SensorsComponent.qml");
 }
 
-QStringList SensorsComponent::sections() const
+QStringList SensorsComponent::sectionIds() const
 {
     QStringList sectionList;
 
@@ -99,20 +99,43 @@ QStringList SensorsComponent::sections() const
         allMagsDisabled = !_vehicle->parameterManager()->getParameter(ParameterManager::defaultComponentId, _magEnabledParam)->rawValue().toBool();
     }
     if (!allMagsDisabled) {
-        sectionList << tr("Compass");
+        sectionList << QStringLiteral("Compass");
     }
 
-    sectionList << tr("Gyroscope");
-    sectionList << tr("Accelerometer");
-    sectionList << tr("Level Horizon");
+    sectionList << QStringLiteral("Gyroscope");
+    sectionList << QStringLiteral("Accelerometer");
+    sectionList << QStringLiteral("Level Horizon");
 
     if (_airspeedCalSupported()) {
-        sectionList << tr("Airspeed");
+        sectionList << QStringLiteral("Airspeed");
     }
 
-    sectionList << tr("Orientations");
+    sectionList << QStringLiteral("Orientations");
 
     return sectionList;
+}
+
+QString SensorsComponent::sectionDisplayName(const QString& sectionId) const
+{
+    if (sectionId == QStringLiteral("Compass")) {
+        return tr("Compass");
+    }
+    if (sectionId == QStringLiteral("Gyroscope")) {
+        return tr("Gyroscope");
+    }
+    if (sectionId == QStringLiteral("Accelerometer")) {
+        return tr("Accelerometer");
+    }
+    if (sectionId == QStringLiteral("Level Horizon")) {
+        return tr("Level Horizon");
+    }
+    if (sectionId == QStringLiteral("Airspeed")) {
+        return tr("Airspeed");
+    }
+    if (sectionId == QStringLiteral("Orientations")) {
+        return tr("Orientations");
+    }
+    return sectionId;
 }
 
 QUrl SensorsComponent::summaryQmlSource(void) const
@@ -151,11 +174,11 @@ QUrl SensorsComponent::summaryQmlSource(void) const
     return _airspeedCalSupported() && _vehicle->parameterManager()->getParameter(ParameterManager::defaultComponentId, "SENS_DPRES_OFF")->rawValue().toFloat() == 0.0f;
  }
 
-bool SensorsComponent::sectionSetupComplete(const QString &sectionName) const
+bool SensorsComponent::sectionSetupComplete(const QString &sectionId) const
 {
     auto *pm = _vehicle->parameterManager();
 
-    if (sectionName == tr("Compass")) {
+    if (sectionId == QStringLiteral("Compass")) {
         bool magEnabled = true;
         if (pm->parameterExists(ParameterManager::defaultComponentId, _magEnabledParam)) {
             magEnabled = pm->getParameter(ParameterManager::defaultComponentId, _magEnabledParam)->rawValue().toBool();
@@ -163,18 +186,18 @@ bool SensorsComponent::sectionSetupComplete(const QString &sectionName) const
         if (!magEnabled) return true;
         return pm->getParameter(ParameterManager::defaultComponentId, _magCalParam)->rawValue().toFloat() != 0.0f;
     }
-    if (sectionName == tr("Gyroscope")) {
+    if (sectionId == QStringLiteral("Gyroscope")) {
         return pm->getParameter(ParameterManager::defaultComponentId, "CAL_GYRO0_ID")->rawValue().toFloat() != 0.0f;
     }
-    if (sectionName == tr("Accelerometer")) {
+    if (sectionId == QStringLiteral("Accelerometer")) {
         return pm->getParameter(ParameterManager::defaultComponentId, "CAL_ACC0_ID")->rawValue().toFloat() != 0.0f;
     }
-    if (sectionName == tr("Level Horizon")) {
+    if (sectionId == QStringLiteral("Level Horizon")) {
         // Level cal doesn't have a distinct completion indicator — consider complete if accel+gyro are done
         return pm->getParameter(ParameterManager::defaultComponentId, "CAL_ACC0_ID")->rawValue().toFloat() != 0.0f
             && pm->getParameter(ParameterManager::defaultComponentId, "CAL_GYRO0_ID")->rawValue().toFloat() != 0.0f;
     }
-    if (sectionName == tr("Airspeed")) {
+    if (sectionId == QStringLiteral("Airspeed")) {
         return !_airspeedCalRequired();
     }
 

--- a/src/AutoPilotPlugins/PX4/SensorsComponent.h
+++ b/src/AutoPilotPlugins/PX4/SensorsComponent.h
@@ -23,9 +23,10 @@ public:
     virtual bool setupComplete(void) const override;
     virtual QUrl setupSource(void) const override;
     virtual QUrl summaryQmlSource(void) const override;
-    QStringList sections() const override;
+    QStringList sectionIds() const override;
+    QString sectionDisplayName(const QString& sectionId) const override;
     bool showFirstSectionOnRootClick() const override { return true; }
-    bool sectionSetupComplete(const QString &sectionName) const override;
+    bool sectionSetupComplete(const QString &sectionId) const override;
 
 private:
     bool _airspeedCalSupported  (void) const;

--- a/src/AutoPilotPlugins/PX4/SensorsSetup.qml
+++ b/src/AutoPilotPlugins/PX4/SensorsSetup.qml
@@ -313,21 +313,31 @@ Item {
         } // QGCPopupDialog
     } // Component - setOrientationsDialogComponent
 
-    property string sectionNameFilter: ""
+    property string sectionIdFilter: ""
 
     // Completed (green) side indicators are only meaningful for the sensor that was
     // just calibrated. Return them to the neutral idle state when the preview switches
     // to a different sensor.
-    onSectionNameFilterChanged: controller.resetSidesToIdle()
+    onSectionIdFilterChanged: controller.resetSidesToIdle()
 
-    function sectionVisible(name) {
-        if (name === qsTr("Compass")) return !_allMagsDisabled && QGroundControl.corePlugin.options.showSensorCalibrationCompass && showSensorCalibrationCompass
-        if (name === qsTr("Gyroscope")) return QGroundControl.corePlugin.options.showSensorCalibrationGyro && showSensorCalibrationGyro
-        if (name === qsTr("Accelerometer")) return QGroundControl.corePlugin.options.showSensorCalibrationAccel && showSensorCalibrationAccel
-        if (name === qsTr("Level Horizon")) return QGroundControl.corePlugin.options.showSensorCalibrationLevel && showSensorCalibrationLevel
-        if (name === qsTr("Airspeed")) return vehicleComponent.airspeedCalSupported && QGroundControl.corePlugin.options.showSensorCalibrationAirspeed && showSensorCalibrationAirspeed
-        if (name === qsTr("Orientations")) return orientationsButtonVisible()
-        return true
+    // Section IDs are untranslated — compare with raw literals.
+    function sectionVisible(sectionId) {
+        switch (sectionId) {
+        case "Compass":
+            return !_allMagsDisabled && QGroundControl.corePlugin.options.showSensorCalibrationCompass && showSensorCalibrationCompass
+        case "Gyroscope":
+            return QGroundControl.corePlugin.options.showSensorCalibrationGyro && showSensorCalibrationGyro
+        case "Accelerometer":
+            return QGroundControl.corePlugin.options.showSensorCalibrationAccel && showSensorCalibrationAccel
+        case "Level Horizon":
+            return QGroundControl.corePlugin.options.showSensorCalibrationLevel && showSensorCalibrationLevel
+        case "Airspeed":
+            return vehicleComponent.airspeedCalSupported && QGroundControl.corePlugin.options.showSensorCalibrationAirspeed && showSensorCalibrationAirspeed
+        case "Orientations":
+            return orientationsButtonVisible()
+        default:
+            return true
+        }
     }
 
     function _startCalibration(type, help, title) {
@@ -342,22 +352,22 @@ Item {
     }
 
     property bool _showOrientationPreview: !controller.calibrationActive &&
-        (sectionNameFilter === qsTr("Accelerometer") || sectionNameFilter === qsTr("Compass") || sectionNameFilter === qsTr("Gyroscope"))
+        (sectionIdFilter === "Accelerometer" || sectionIdFilter === "Compass" || sectionIdFilter === "Gyroscope")
 
     property bool _showAllSidesPreview: _showOrientationPreview &&
-        (sectionNameFilter === qsTr("Accelerometer") || sectionNameFilter === qsTr("Compass"))
+        (sectionIdFilter === "Accelerometer" || sectionIdFilter === "Compass")
 
     property bool _showDownOnlyPreview: _showOrientationPreview &&
-        sectionNameFilter === qsTr("Gyroscope")
+        sectionIdFilter === "Gyroscope"
 
     property bool _showStatusPreview: !controller.calibrationActive &&
-        (sectionNameFilter === qsTr("Level Horizon") || sectionNameFilter === qsTr("Airspeed"))
+        (sectionIdFilter === "Level Horizon" || sectionIdFilter === "Airspeed")
 
     ColumnLayout {
         anchors.fill: parent
         spacing: 0
 
-        // Calibration trigger buttons — one per section, shown based on sectionNameFilter
+        // Calibration trigger buttons — one per section, shown based on sectionIdFilter
         ColumnLayout {
             Layout.fillWidth: true
             spacing: ScreenTools.defaultFontPixelHeight / 2
@@ -367,14 +377,14 @@ Item {
                 objectName: "sensorsSetup_calibrateCompass"
                 Layout.fillWidth: true
                 text:       qsTr("Calibrate Compass")
-                visible:    sectionNameFilter === "" || sectionNameFilter === qsTr("Compass")
+                visible:    sectionIdFilter === "" || sectionIdFilter === "Compass"
                 onClicked:  _startCalibration("compass", compassHelp, qsTr("Calibrate Compass"))
             }
 
             QGCButton {
                 Layout.fillWidth: true
                 text:       qsTr("Calibrate Gyroscope")
-                visible:    sectionNameFilter === "" || sectionNameFilter === qsTr("Gyroscope")
+                visible:    sectionIdFilter === "" || sectionIdFilter === "Gyroscope"
                 onClicked:  _startCalibration("gyro", gyroHelp, qsTr("Calibrate Gyro"))
             }
 
@@ -382,7 +392,7 @@ Item {
                 objectName: "sensorsSetup_calibrateAccel"
                 Layout.fillWidth: true
                 text:       qsTr("Calibrate Accelerometer")
-                visible:    sectionNameFilter === "" || sectionNameFilter === qsTr("Accelerometer")
+                visible:    sectionIdFilter === "" || sectionIdFilter === "Accelerometer"
                 onClicked:  _startCalibration("accel", accelHelp, qsTr("Calibrate Accelerometer"))
             }
 
@@ -390,21 +400,21 @@ Item {
                 Layout.fillWidth: true
                 text:       qsTr("Level Horizon")
                 enabled:    cal_acc0_id.value !== 0 && cal_gyro0_id.value !== 0
-                visible:    sectionNameFilter === "" || sectionNameFilter === qsTr("Level Horizon")
+                visible:    sectionIdFilter === "" || sectionIdFilter === "Level Horizon"
                 onClicked:  _startCalibration("level", levelHelp, qsTr("Level Horizon"))
             }
 
             QGCButton {
                 Layout.fillWidth: true
                 text:       qsTr("Calibrate Airspeed")
-                visible:    sectionNameFilter === "" || sectionNameFilter === qsTr("Airspeed")
+                visible:    sectionIdFilter === "" || sectionIdFilter === "Airspeed"
                 onClicked:  _startCalibration("airspeed", airspeedHelp, qsTr("Calibrate Airspeed"))
             }
 
             QGCButton {
                 Layout.fillWidth: true
                 text:       qsTr("Set Orientations")
-                visible:    sectionNameFilter === "" || sectionNameFilter === qsTr("Orientations")
+                visible:    sectionIdFilter === "" || sectionIdFilter === "Orientations"
                 onClicked: {
                     setOrientationsDialogShowBoardOrientation = true
                     setOrientationsDialogFactory.open({ title: qsTr("Set Orientations"), showRebootVehicleButton: false })
@@ -414,7 +424,7 @@ Item {
             QGCButton {
                 Layout.fillWidth: true
                 text:       qsTr("Factory Reset")
-                visible:    sectionNameFilter === "" || sectionNameFilter === qsTr("Orientations")
+                visible:    sectionIdFilter === "" || sectionIdFilter === "Orientations"
                 onClicked:  controller.resetFactoryParameters()
             }
 

--- a/src/AutoPilotPlugins/VehicleComponent.cc
+++ b/src/AutoPilotPlugins/VehicleComponent.cc
@@ -31,27 +31,27 @@ VehicleComponent::~VehicleComponent()
     // qCDebug(VehicleComponentLog) << Q_FUNC_INFO << this;
 }
 
-QStringList VehicleComponent::sections() const
+QStringList VehicleComponent::sectionIds() const
 {
     _ensureSectionsCached();
 
     if (_repeatFilters.isEmpty()) {
-        return _expandedSections;
+        return _expandedSectionIds;
     }
 
     auto *pm = _vehicle ? _vehicle->parameterManager() : nullptr;
     if (!pm) {
-        return _expandedSections;
+        return _expandedSectionIds;
     }
 
-    QStringList result = _expandedSections;
+    QStringList result = _expandedSectionIds;
     for (const auto &filter : _repeatFilters) {
         bool hasDisabled = false;
-        for (int i = 0; i < filter.sectionNames.size(); i++) {
+        for (int i = 0; i < filter.sectionIds.size(); i++) {
             if (!pm->parameterExists(ParameterManager::defaultComponentId, filter.paramNames[i]))
                 continue;
             if (pm->getParameter(ParameterManager::defaultComponentId, filter.paramNames[i])->rawValue().toInt() == filter.disabledValue) {
-                result.removeAll(filter.sectionNames[i]);
+                result.removeAll(filter.sectionIds[i]);
                 hasDisabled = true;
             }
         }
@@ -171,19 +171,19 @@ void VehicleComponent::_ensureSectionsCached() const
                     count++;
                 }
                 if (count <= 1) {
-                    _expandedSections.append(name);
+                    _expandedSectionIds.append(name);
                     _sectionKeywords.insert(name, terms);
                     if (hasFilter) {
-                        filter.sectionNames.append(name);
+                        filter.sectionIds.append(name);
                         filter.paramNames.append(battPrefix(0) + enableParam);
                     }
                 } else {
                     for (int i = 0; i < count; i++) {
-                        const QString sectionName = name + QStringLiteral(" ") + battLabel(i);
-                        _expandedSections.append(sectionName);
-                        _sectionKeywords.insert(sectionName, terms);
+                        const QString sectionId = name + QStringLiteral(" ") + battLabel(i);
+                        _expandedSectionIds.append(sectionId);
+                        _sectionKeywords.insert(sectionId, terms);
                         if (hasFilter) {
-                            filter.sectionNames.append(sectionName);
+                            filter.sectionIds.append(sectionId);
                             filter.paramNames.append(battPrefix(i) + enableParam);
                         }
                     }
@@ -198,21 +198,21 @@ void VehicleComponent::_ensureSectionsCached() const
                 }
 
                 if (count <= 1) {
-                    _expandedSections.append(name);
+                    _expandedSectionIds.append(name);
                     _sectionKeywords.insert(name, terms);
                     if (hasFilter) {
                         const QString idx = (firstOmits) ? QString() : QString::number(startIndex);
-                        filter.sectionNames.append(name);
+                        filter.sectionIds.append(name);
                         filter.paramNames.append(paramPrefix + idx + enableParam);
                     }
                 } else {
                     for (int i = 0; i < count; i++) {
                         const QString idx = (firstOmits && i == 0) ? QString() : QString::number(startIndex + i);
-                        const QString sectionName = name + QStringLiteral(" ") + QString::number(startIndex + i);
-                        _expandedSections.append(sectionName);
-                        _sectionKeywords.insert(sectionName, terms);
+                        const QString sectionId = name + QStringLiteral(" ") + QString::number(startIndex + i);
+                        _expandedSectionIds.append(sectionId);
+                        _sectionKeywords.insert(sectionId, terms);
                         if (hasFilter) {
-                            filter.sectionNames.append(sectionName);
+                            filter.sectionIds.append(sectionId);
                             filter.paramNames.append(paramPrefix + idx + enableParam);
                         }
                     }
@@ -223,8 +223,8 @@ void VehicleComponent::_ensureSectionsCached() const
                 _repeatFilters.append(filter);
             }
         } else {
-            if (!_expandedSections.contains(name)) {
-                _expandedSections.append(name);
+            if (!_expandedSectionIds.contains(name)) {
+                _expandedSectionIds.append(name);
             }
             _sectionKeywords.insert(name, terms);
         }
@@ -270,7 +270,7 @@ void VehicleComponent::setupTriggerSignals()
         for (const QString &paramName : filter.paramNames) {
             if (_vehicle->parameterManager()->parameterExists(ParameterManager::defaultComponentId, paramName)) {
                 Fact *const fact = _vehicle->parameterManager()->getParameter(ParameterManager::defaultComponentId, paramName);
-                (void) connect(fact, &Fact::valueChanged, this, &VehicleComponent::sectionsChanged);
+                (void) connect(fact, &Fact::valueChanged, this, &VehicleComponent::sectionIdsChanged);
             }
         }
     }

--- a/src/AutoPilotPlugins/VehicleComponent.h
+++ b/src/AutoPilotPlugins/VehicleComponent.h
@@ -31,8 +31,8 @@ class VehicleComponent : public QObject
     Q_PROPERTY(bool     allowSetupWhileArmed                                READ allowSetupWhileArmed   CONSTANT)
     Q_PROPERTY(bool     allowSetupWhileFlying                               READ allowSetupWhileFlying  CONSTANT)
     Q_PROPERTY(AutoPilotPlugin::KnownVehicleComponent KnownVehicleComponent READ KnownVehicleComponent  CONSTANT)
-    Q_PROPERTY(QStringList sections                                         READ sections               NOTIFY sectionsChanged)
-    Q_PROPERTY(QVariantMap sectionKeywords                                   READ sectionKeywords        NOTIFY sectionsChanged)
+    Q_PROPERTY(QStringList sectionIds                                       READ sectionIds             NOTIFY sectionIdsChanged)
+    Q_PROPERTY(QVariantMap sectionKeywords                                  READ sectionKeywords        NOTIFY sectionIdsChanged)
     Q_PROPERTY(QString  vehicleConfigJson                                   READ vehicleConfigJson      CONSTANT)
     Q_PROPERTY(bool     showFirstSectionOnRootClick                         READ showFirstSectionOnRootClick CONSTANT)
 
@@ -51,18 +51,23 @@ public:
     /// Resource path to a VehicleConfig.json page definition, or empty if none.
     virtual QString vehicleConfigJson() const { return QString(); }
 
-    /// Section names for sidebar navigation. Auto-populated from vehicleConfigJson() JSON.
-    /// Repeat sections are expanded by probing vehicle parameters.
-    virtual QStringList sections() const;
+    /// Untranslated section IDs for sidebar navigation. Auto-populated from vehicleConfigJson() JSON.
+    /// Repeat sections are expanded by probing vehicle parameters. IDs are stable across locales and
+    /// are used for section filtering; display uses sectionDisplayName() or the JSON translation context.
+    virtual QStringList sectionIds() const;
 
-    /// Search keywords per section, keyed by section title. Values are original-case translatable terms.
+    /// Translated display name for a section ID. Default returns the ID unchanged (JSON-driven
+    /// components are translated by the view using the JSON filename context).
+    Q_INVOKABLE virtual QString sectionDisplayName(const QString& sectionId) const { return sectionId; }
+
+    /// Search keywords per section, keyed by section ID. Values are original-case translatable terms.
     QVariantMap sectionKeywords() const;
 
     /// When true, clicking the root component in the tree selects the first section instead of showing all.
     virtual bool showFirstSectionOnRootClick() const { return false; }
 
-    /// Returns setup-complete status for a named section. Default returns true (no per-section tracking).
-    Q_INVOKABLE virtual bool sectionSetupComplete(const QString &sectionName) const { Q_UNUSED(sectionName); return true; }
+    /// Returns setup-complete status for a section ID. Default returns true (no per-section tracking).
+    Q_INVOKABLE virtual bool sectionSetupComplete(const QString &sectionId) const { Q_UNUSED(sectionId); return true; }
 
     // @return true: Setup panel can be shown while vehicle is armed
     virtual bool allowSetupWhileArmed() const { return false; }
@@ -85,7 +90,7 @@ public:
 signals:
     void setupCompleteChanged();
     void setupSourceChanged();
-    void sectionsChanged();
+    void sectionIdsChanged();
 
 protected slots:
     void _triggerUpdated(QVariant /*value*/) { emit setupCompleteChanged(); }
@@ -96,19 +101,19 @@ protected:
     AutoPilotPlugin::KnownVehicleComponent _KnownVehicleComponent;
 
 private:
-    /// Lazily parse the vehicleConfigJson() file to populate _expandedSections and _repeatFilters.
+    /// Lazily parse the vehicleConfigJson() file to populate _expandedSectionIds and _repeatFilters.
     void _ensureSectionsCached() const;
 
     /// Metadata for a repeat group that has enableParam/disabledParamValue filtering.
     struct RepeatFilter {
-        QStringList sectionNames;   ///< Expanded section names in this repeat group
+        QStringList sectionIds;     ///< Expanded section IDs in this repeat group
         QStringList paramNames;     ///< Corresponding full enableParam names (e.g., BATT_MONITOR)
         int         disabledValue = 0;
         QString     disabledHeading; ///< From disabledSection.heading (empty if no disabledSection)
     };
 
-    mutable QStringList            _expandedSections;  ///< All sections before enable/disable filtering
+    mutable QStringList            _expandedSectionIds;  ///< All section IDs before enable/disable filtering
     mutable QVector<RepeatFilter>  _repeatFilters;     ///< Filter metadata for repeat groups with enableParam
-    mutable QMap<QString, QStringList> _sectionKeywords;  ///< section title -> original-case translatable search terms
+    mutable QMap<QString, QStringList> _sectionKeywords;  ///< section ID -> original-case translatable search terms
     mutable bool                   _sectionsCached = false;
 };

--- a/src/QmlControls/AppSettings.qml
+++ b/src/QmlControls/AppSettings.qml
@@ -105,10 +105,11 @@ Rectangle {
         }
     }
 
+    // settingsPage is the untranslated page name from SettingsPages.json
     function showSettingsPage(settingsPage) {
         for (var i = 0; i < settingsPagesModel.count; i++) {
             var entry = settingsPagesModel.get(i)
-            if (entry && entry.name === settingsPage) {
+            if (entry && entry.nameKey === settingsPage) {
                 _navigateTo(i, -1)
                 break
             }

--- a/src/QmlControls/AppSettings.qml
+++ b/src/QmlControls/AppSettings.qml
@@ -34,50 +34,47 @@ Rectangle {
         return !!_expandedPages[pageIndex]
     }
 
+    function _pageSections(entry) {
+        return entry && typeof entry.sections === "function" ? entry.sections() : []
+    }
+
+    function _pageAvailable(entry) {
+        if (!entry || entry.name === "Divider" ||
+                (typeof entry.pageVisible === "function" && !entry.pageVisible())) {
+            return false
+        }
+
+        var sections = _pageSections(entry)
+        return sections.length === 0 || sections.some(function(section) { return section.visible })
+    }
+
+    function _sectionAvailable(sections, sectionIndex) {
+        if (sectionIndex === -1) return true
+        for (var i = 0; i < sections.length; i++) {
+            if (sections[i].index === sectionIndex) return sections[i].visible
+        }
+        return false
+    }
+
     // Search: returns array of matching section indices for a page, or empty if no match
     function _matchingSections(pageIndex) {
         var query = _searchQuery.toLowerCase().trim()
         if (query === "") return []  // empty = no filtering
 
         var entry = settingsPagesModel.get(pageIndex)
-        if (!entry) return []
+        if (!_pageAvailable(entry)) return []
 
-        // Check English search terms
-        var termsStr = entry.searchTerms
+        var sections = _pageSections(entry)
         var matches = []
-        var matched = {}
-        if (termsStr && termsStr !== "") {
-            try {
-                var terms = JSON.parse(termsStr)
-                for (var i = 0; i < terms.length; i++) {
-                    if (terms[i].terms.indexOf(query) !== -1) {
-                        matched[terms[i].section] = true
-                        matches.push(terms[i].section)
-                    }
+        for (var i = 0; i < sections.length; i++) {
+            if (!sections[i].visible) continue
+            for (var j = 0; j < sections[i].searchTerms.length; j++) {
+                if (sections[i].searchTerms[j].indexOf(query) !== -1) {
+                    matches.push(sections[i].index)
+                    break
                 }
-            } catch(e) { console.warn("AppSettings: JSON parse error in searchTerms:", e) }
+            }
         }
-
-        // Check translatable terms (translated at runtime)
-        var trStr = entry.translatableTerms
-        if (trStr && trStr !== "") {
-            try {
-                var trTerms = JSON.parse(trStr)
-                for (var j = 0; j < trTerms.length; j++) {
-                    if (matched[trTerms[j].section]) continue
-                    var ctx = trTerms[j].context
-                    var tList = trTerms[j].terms
-                    for (var k = 0; k < tList.length; k++) {
-                        if (qsTranslate(ctx, tList[k]).toLowerCase().indexOf(query) !== -1) {
-                            matched[trTerms[j].section] = true
-                            matches.push(trTerms[j].section)
-                            break
-                        }
-                    }
-                }
-            } catch(e) { console.warn("AppSettings: JSON parse error in translatableTerms:", e) }
-        }
-
         return matches
     }
 
@@ -90,6 +87,8 @@ Rectangle {
     function _navigateTo(pageIndex, sectionIndex) {
         var entry = settingsPagesModel.get(pageIndex)
         if (!entry || entry.name === "Divider") return
+        if (!_pageAvailable(entry)) return
+        if (!_sectionAvailable(_pageSections(entry), sectionIndex)) return
 
         var url = entry.url
         _selectedSectionIndex = sectionIndex
@@ -103,6 +102,19 @@ Rectangle {
         if (rightPanel.item && typeof rightPanel.item.sectionFilter !== "undefined") {
             rightPanel.item.sectionFilter = sectionIndex
         }
+    }
+
+    function _navigateToFirstAvailablePage() {
+        for (var i = 0; i < settingsPagesModel.count; i++) {
+            if (_pageAvailable(settingsPagesModel.get(i))) {
+                _navigateTo(i, -1)
+                return
+            }
+        }
+
+        _selectedPageIndex = -1
+        _selectedSectionIndex = -1
+        rightPanel.source = ""
     }
 
     // settingsPage is the untranslated page name from SettingsPages.json
@@ -136,6 +148,10 @@ Rectangle {
                 _navigateTo(i, -1)
                 break
             }
+        }
+
+        if (_selectedPageIndex === -1) {
+            _navigateToFirstAvailablePage()
         }
     }
 
@@ -200,32 +216,34 @@ Rectangle {
                     property string pageUrl:     model.url ?? ""
                     property string pageIconUrl: model.iconUrl ?? ""
                     property var    pageVisible: model.pageVisible ?? function() { return true }
-                    property var    pageSections: {
-                        try {
-                            var trStr = model.translatableTerms
-                            if (trStr && trStr !== "") {
-                                var trTerms = JSON.parse(trStr)
-                                return trTerms.map(function(t) {
-                                    if (!t.terms || t.terms.length === 0) return ""
-                                    return qsTranslate(t.context, t.terms[0])
-                                }).filter(function(s) { return s !== "" })
-                            }
-                            var s = model.sections
-                            return (s && s !== "") ? JSON.parse(s) : []
-                        } catch(e) {
-                            console.warn("AppSettings: JSON parse error in pageSections:", e)
-                            return []
+                    property var    pageSections: pageVisible() ? settingsView._pageSections(model) : []
+                    property var    visiblePageSections: pageSections.filter(function(section) {
+                        return section.visible
+                    })
+                    property bool pageAvailable: pageVisible() &&
+                                                 (pageSections.length === 0 || visiblePageSections.length > 0)
+                    property bool isSelected: settingsView._selectedPageIndex === index
+                    property bool hasMultipleSections: visiblePageSections.length > 1
+                    property bool isSearching: settingsView._searchQuery.trim() !== ""
+                    property bool matchesSearch: pageAvailable && settingsView._pageMatchesSearch(index)
+                    property bool isExpanded: hasMultipleSections && (isSearching ? matchesSearch : settingsView._isExpanded(index))
+
+                    onPageSectionsChanged: {
+                        if (isSelected && pageAvailable &&
+                                !settingsView._sectionAvailable(pageSections, settingsView._selectedSectionIndex)) {
+                            settingsView._navigateTo(index, -1)
                         }
                     }
-                    property bool isSelected: settingsView._selectedPageIndex === index
-                    property bool hasMultipleSections: pageSections.length > 1
-                    property bool isSearching: settingsView._searchQuery.trim() !== ""
-                    property bool matchesSearch: settingsView._pageMatchesSearch(index)
-                    property bool isExpanded: hasMultipleSections && (isSearching ? matchesSearch : settingsView._isExpanded(index))
+
+                    onPageAvailableChanged: {
+                        if (isSelected && !pageAvailable) {
+                            settingsView._navigateToFirstAvailablePage()
+                        }
+                    }
 
                     visible: {
                         if (pageName === "Divider") return !isSearching
-                        if (!pageVisible()) return false
+                        if (!pageAvailable) return false
                         if (isSearching) return matchesSearch
                         return true
                     }
@@ -246,7 +264,7 @@ Rectangle {
                         expandable:    hasMultipleSections
                         expanded:      isExpanded
                         checked:       isSelected && settingsView._selectedSectionIndex === -1
-                        visible:       pageName !== "Divider" && pageVisible()
+                        visible:       pageName !== "Divider" && pageAvailable
 
                         onClicked: {
                             if (mainWindow.allowViewSwitch()) {
@@ -276,7 +294,7 @@ Rectangle {
 
                     // Section sub-items (indented, shown when page is expanded)
                     Repeater {
-                        model: isExpanded ? pageSections : []
+                        model: isExpanded ? visiblePageSections : []
 
                         Button {
                             id:             sectionBtn
@@ -285,21 +303,15 @@ Rectangle {
                             leftPadding:    ScreenTools.defaultFontPixelWidth * 3
                             hoverEnabled:   !ScreenTools.isMobile
 
-                            property int sectionIndex: index
+                            property int sectionIndex: modelData.index
                             property bool sectionChecked: pageColumn.isSelected && settingsView._selectedSectionIndex === sectionIndex
                             property bool sectionMatchesSearch: {
                                 if (!pageColumn.isSearching) return true
                                 var matches = settingsView._matchingSections(pageColumn.index)
                                 return matches.indexOf(sectionIndex) !== -1
                             }
-                            property bool sectionContentVisible: {
-                                if (!pageColumn.isSelected) return true
-                                if (!rightPanel.item) return true
-                                if (typeof rightPanel.item.sectionVisible !== "function") return true
-                                return rightPanel.item.sectionVisible(sectionIndex)
-                            }
                             property color textColor: sectionChecked || pressed ? qgcPal.buttonHighlightText : qgcPal.buttonText
-                            visible: sectionMatchesSearch && sectionContentVisible
+                            visible: sectionMatchesSearch
 
                             background: Rectangle {
                                 color:   qgcPal.buttonHighlight
@@ -308,7 +320,7 @@ Rectangle {
                             }
 
                             contentItem: QGCLabel {
-                                text:  modelData
+                                text:  modelData.name
                                 color: sectionBtn.textColor
                                 font.pointSize: ScreenTools.defaultFontPointSize * 0.9
                                 horizontalAlignment: Text.AlignLeft

--- a/src/QmlControls/AppSettings.qml
+++ b/src/QmlControls/AppSettings.qml
@@ -178,6 +178,7 @@ Rectangle {
 
         QGCTextField {
             id:                 searchField
+            objectName:         "settings_searchField"
             Layout.fillWidth:   true
             placeholderText:    qsTr("Search settings...")
 
@@ -229,8 +230,11 @@ Rectangle {
                     property bool isExpanded: hasMultipleSections && (isSearching ? matchesSearch : settingsView._isExpanded(index))
 
                     onPageSectionsChanged: {
-                        if (isSelected && pageAvailable &&
-                                !settingsView._sectionAvailable(pageSections, settingsView._selectedSectionIndex)) {
+                        let sections = pageSections ?? []
+                        let visibleCount = sections.filter(function(section) { return section.visible }).length
+                        if (isSelected && pageAvailable && settingsView._selectedSectionIndex !== -1 &&
+                                (visibleCount <= 1 ||
+                                 !settingsView._sectionAvailable(sections, settingsView._selectedSectionIndex))) {
                             settingsView._navigateTo(index, -1)
                         }
                     }

--- a/src/QmlControls/SetupPage.qml
+++ b/src/QmlControls/SetupPage.qml
@@ -19,18 +19,18 @@ Item {
     property real   availableHeight:        height - pageLoader.y
     property bool   showAdvanced:           false
     property alias  advanced:               advancedCheckBox.checked
-    property string sectionNameFilter:       ""
+    property string sectionIdFilter:        ""
 
-    function sectionVisible(name) {
+    function sectionVisible(sectionId) {
         if (pageLoader.item && typeof pageLoader.item.sectionVisible === "function") {
-            return pageLoader.item.sectionVisible(name)
+            return pageLoader.item.sectionVisible(sectionId)
         }
         return true
     }
 
-    onSectionNameFilterChanged: {
-        if (pageLoader.item && typeof pageLoader.item.sectionNameFilter !== "undefined") {
-            pageLoader.item.sectionNameFilter = sectionNameFilter
+    onSectionIdFilterChanged: {
+        if (pageLoader.item && typeof pageLoader.item.sectionIdFilter !== "undefined") {
+            pageLoader.item.sectionIdFilter = sectionIdFilter
         }
     }
 
@@ -47,8 +47,8 @@ Item {
         if(pageLoader.item && pageLoader.item.setupPageCompleted) {
             pageLoader.item.setupPageCompleted()
         }
-        if (pageLoader.item && typeof pageLoader.item.sectionNameFilter !== "undefined") {
-            pageLoader.item.sectionNameFilter = sectionNameFilter
+        if (pageLoader.item && typeof pageLoader.item.sectionIdFilter !== "undefined") {
+            pageLoader.item.sectionIdFilter = sectionIdFilter
         }
     }
 
@@ -94,6 +94,7 @@ Item {
 
         Loader {
             id:                 pageLoader
+            objectName:         "setupPage_contentLoader"
             anchors.topMargin:  _margins
             anchors.top:        headingRow.bottom
         }

--- a/src/Toolbar/MainStatusIndicatorOfflinePage.qml
+++ b/src/Toolbar/MainStatusIndicatorOfflinePage.qml
@@ -63,7 +63,8 @@ ToolIndicatorPage {
                     buttonText: qsTr("Configure")
 
                     onClicked: {
-                        mainWindow.showSettingsTool(qsTr("Comm Links"))
+                        // Untranslated page key from SettingsPages.json — do not qsTr()
+                        mainWindow.showSettingsTool("Comm Links")
                         mainWindow.closeIndicatorDrawer()
                     }
                 }

--- a/src/Vehicle/VehicleSetup/VehicleConfigView.qml
+++ b/src/Vehicle/VehicleSetup/VehicleConfigView.qml
@@ -50,20 +50,25 @@ Rectangle {
         return !!_expandedComponents[compIndex]
     }
 
-    /// Translate a section name using the component's JSON filename as context.
-    /// Falls back to the raw name when no vehicleConfigJson is set.
-    function _translateSection(component, name) {
-        var context = _translationContext(component)
-        if (!context) return name
-        return qsTranslate(context, name)
+    /// Translated display name for a section ID. JSON-driven components translate via the JSON
+    /// filename context; hand-coded components provide sectionDisplayName().
+    function _sectionDisplayName(component, sectionId) {
+        let context = _translationContext(component)
+        if (context) {
+            return qsTranslate(context, sectionId)
+        }
+        if (component && typeof component.sectionDisplayName === "function") {
+            return component.sectionDisplayName(sectionId)
+        }
+        return sectionId
     }
 
-    /// Get the section name for a sidebar entry.
-    function _sectionName(compIndex, sectionIndex) {
+    /// Get the section ID for a sidebar entry.
+    function _sectionId(compIndex, sectionIndex) {
         if (sectionIndex < 0 || !_fullParameterVehicleAvailable) return ""
         var components = _activeVehicle.autopilotPlugin.vehicleComponents
         if (compIndex < 0 || compIndex >= components.length) return ""
-        var secs = components[compIndex].sections
+        var secs = components[compIndex].sectionIds
         if (sectionIndex < secs.length) return secs[sectionIndex]
         return ""
     }
@@ -81,11 +86,14 @@ Rectangle {
         var query = _searchQuery.toLowerCase().trim()
         if (component.name.toLowerCase().indexOf(query) !== -1) return true
         var context = _translationContext(component)
-        var secs = component.sections
+        var secs = component.sectionIds
         if (secs) {
             for (var i = 0; i < secs.length; i++) {
                 if (secs[i].toLowerCase().indexOf(query) !== -1) return true
-                if (context && qsTranslate(context, secs[i]).toLowerCase().indexOf(query) !== -1) return true
+                let displayName = _sectionDisplayName(component, secs[i])
+                if (displayName !== secs[i] && displayName.toLowerCase().indexOf(query) !== -1) {
+                    return true
+                }
             }
         }
         var keywords = component.sectionKeywords
@@ -101,15 +109,18 @@ Rectangle {
         return false
     }
 
-    function _sectionMatchesSearch(component, sectionName) {
+    function _sectionMatchesSearch(component, sectionId) {
         if (_searchQuery.trim() === "") return true
         var query = _searchQuery.toLowerCase().trim()
-        if (sectionName.toLowerCase().indexOf(query) !== -1) return true
+        if (sectionId.toLowerCase().indexOf(query) !== -1) return true
         var context = _translationContext(component)
-        if (context && qsTranslate(context, sectionName).toLowerCase().indexOf(query) !== -1) return true
+        let displayName = _sectionDisplayName(component, sectionId)
+        if (displayName !== sectionId && displayName.toLowerCase().indexOf(query) !== -1) {
+            return true
+        }
         var keywords = component.sectionKeywords
-        if (keywords && keywords[sectionName]) {
-            var terms = keywords[sectionName]
+        if (keywords && keywords[sectionId]) {
+            var terms = keywords[sectionId]
             for (var i = 0; i < terms.length; i++) {
                 if (terms[i].toLowerCase().indexOf(query) !== -1) return true
                 if (context && qsTranslate(context, terms[i]).toLowerCase().indexOf(query) !== -1) return true
@@ -161,7 +172,7 @@ Rectangle {
         _selectedSpecial = ""
 
         // If component opts in and root was clicked, auto-select first section
-        if (sectionIndex < 0 && vehicleComponent.showFirstSectionOnRootClick && vehicleComponent.sections.length > 0) {
+        if (sectionIndex < 0 && vehicleComponent.showFirstSectionOnRootClick && vehicleComponent.sectionIds.length > 0) {
             sectionIndex = 0
         }
         _selectedSectionIndex = sectionIndex
@@ -185,8 +196,8 @@ Rectangle {
         }
 
         // Apply section filter
-        if (panelLoader.item && typeof panelLoader.item.sectionNameFilter !== "undefined") {
-            panelLoader.item.sectionNameFilter = _sectionName(compIndex, sectionIndex)
+        if (panelLoader.item && typeof panelLoader.item.sectionIdFilter !== "undefined") {
+            panelLoader.item.sectionIdFilter = _sectionId(compIndex, sectionIndex)
         }
     }
 
@@ -230,8 +241,8 @@ Rectangle {
     Connections {
         target: panelLoader
         function onLoaded() {
-            if (panelLoader.item && typeof panelLoader.item.sectionNameFilter !== "undefined") {
-                panelLoader.item.sectionNameFilter = _sectionName(_selectedComponentIndex, _selectedSectionIndex)
+            if (panelLoader.item && typeof panelLoader.item.sectionIdFilter !== "undefined") {
+                panelLoader.item.sectionIdFilter = _sectionId(_selectedComponentIndex, _selectedSectionIndex)
             }
         }
     }
@@ -389,9 +400,9 @@ Rectangle {
 
                         property var    comp:           modelData
                         property string compName:       comp ? comp.name : ""
-                        property var    compSections:   comp ? comp.sections : []
+                        property var    compSectionIds: comp ? comp.sectionIds : []
                         property bool   isSelected:     vehicleConfigView._selectedComponentIndex === index && vehicleConfigView._selectedSpecial === ""
-                        property bool   hasSections:    compSections.length > 1
+                        property bool   hasSections:    compSectionIds.length > 1
                         property bool   isSearching:    vehicleConfigView._searchQuery.trim() !== ""
                         property bool   matchesSearch:  comp ? vehicleConfigView._componentMatchesSearch(comp) : false
                         property bool   isExpanded:     hasSections && (isSearching ? matchesSearch : vehicleConfigView._isExpanded(index))
@@ -436,7 +447,7 @@ Rectangle {
 
                         // Section sub-items
                         Repeater {
-                            model: compColumn.isExpanded ? compColumn.compSections : []
+                            model: compColumn.isExpanded ? compColumn.compSectionIds : []
 
                             Button {
                                 id:             sectionBtn
@@ -491,7 +502,7 @@ Rectangle {
                                     }
 
                                     QGCLabel {
-                                        text:  vehicleConfigView._translateSection(compColumn.comp, modelData)
+                                        text:  vehicleConfigView._sectionDisplayName(compColumn.comp, modelData)
                                         color: sectionBtn.textColor
                                         font.pointSize: ScreenTools.defaultFontPointSize * 0.9
                                         horizontalAlignment: Text.AlignLeft

--- a/test/QmlUITests/APMVehicleConfigUITest.cc
+++ b/test/QmlUITests/APMVehicleConfigUITest.cc
@@ -41,9 +41,9 @@ void APMVehicleConfigUITest::_runNavigateVehicleConfig(
     QTest::qWait(_viewDelay);
 
     // -------------------------------------------------------------------------
-    // Click through each vehicle component
+    // Click through each vehicle component, in English and Chinese
     // -------------------------------------------------------------------------
-    clickThroughAllComponents(vehicle, vehicleName);
+    clickThroughAllComponentsAllLocales(vehicle, vehicleName);
 
     });
 }

--- a/test/QmlUITests/PX4VehicleConfigUITest.cc
+++ b/test/QmlUITests/PX4VehicleConfigUITest.cc
@@ -26,9 +26,9 @@ void PX4VehicleConfigUITest::_testNavigateVehicleConfig()
     QTest::qWait(_viewDelay);
 
     // -------------------------------------------------------------------------
-    // Click through each vehicle component
+    // Click through each vehicle component, in English and Chinese
     // -------------------------------------------------------------------------
-    clickThroughAllComponents(vehicle);
+    clickThroughAllComponentsAllLocales(vehicle);
 
     });
 }

--- a/test/QmlUITests/TopLevelViewsTest.cc
+++ b/test/QmlUITests/TopLevelViewsTest.cc
@@ -2,7 +2,6 @@
 
 #include <QtCore/QScopeGuard>
 #include <QtQuick/QQuickItem>
-#include <QtQuick/QQuickWindow>
 #include <QtTest/QTest>
 
 #include "Fact.h"
@@ -14,85 +13,113 @@ UT_REGISTER_TEST(TopLevelViewsTest, TestLabel::Integration)
 // This test assumes Advanced UI mode is enabled (the default). All views including
 // Analyze are expected to be visible.
 
-static QQuickItem* findVisibleSectionButton(QQuickItem* root, int sectionIndex)
+// Section nav buttons carry a sectionIndex property; match on the label text so
+// tests don't depend on section ordering in the page definition JSON.
+static QQuickItem* findVisibleSectionButton(QQuickItem* root, const QString& sectionName)
 {
     if (!root || !root->isVisible()) {
         return nullptr;
     }
-    if (root->property("sectionIndex").isValid() && root->property("sectionIndex").toInt() == sectionIndex) {
-        return root;
-    }
     const auto children = root->childItems();
+    if (root->property("sectionIndex").isValid()) {
+        for (auto* label : children) {
+            if (label->isVisible() && label->property("text").toString() == sectionName) {
+                return root;
+            }
+        }
+    }
     for (auto* child : children) {
-        if (auto* found = findVisibleSectionButton(child, sectionIndex)) {
+        if (auto* found = findVisibleSectionButton(child, sectionName)) {
             return found;
         }
     }
     return nullptr;
 }
 
+static void setVideoSource(const char* source)
+{
+    SettingsManager::instance()->videoSettings()->videoSource()->setRawValue(QString::fromLatin1(source));
+}
+
+// Sets the video source and returns a guard restoring the original value on scope exit
+[[nodiscard]] static auto setVideoSourceWithRestore(const char* source)
+{
+    Fact* const videoSource = SettingsManager::instance()->videoSettings()->videoSource();
+    const QVariant savedVideoSource = videoSource->rawValue();
+    videoSource->setRawValue(QString::fromLatin1(source));
+    return qScopeGuard([videoSource, savedVideoSource] { videoSource->setRawValue(savedVideoSource); });
+}
+
+QQuickItem* TopLevelViewsTest::_clickSettingsButton(const QString& pageName)
+{
+    const QString objectName = QStringLiteral("settingsButton_") + pageName;
+    QQuickItem* const button = findVisibleItem(_rootItem, objectName);
+    if (!button) {
+        QTest::qFail(qPrintable(QStringLiteral("Settings button not found: %1").arg(pageName)), __FILE__, __LINE__);
+        return nullptr;
+    }
+    if (!scrollIntoView(button, QStringLiteral("settings_buttonList"))) {
+        QTest::qFail(qPrintable(QStringLiteral("Failed to scroll settings button into view: %1").arg(pageName)),
+                     __FILE__, __LINE__);
+        return nullptr;
+    }
+    if (!_clickItemAt(button, 0.5, 0.5, objectName)) {
+        return nullptr;
+    }
+    return button;
+}
+
 void TopLevelViewsTest::_testNavigateViews()
 {
     startUI();
-    if (QTest::currentTestFailed()) return;
+    if (QTest::currentTestFailed())
+        return;
 
     QVERIFY2(findVisibleItem(_rootItem, QStringLiteral("toolbar_qgcLogo")), "Q logo button not found");
 
     // Navigate to a view and verify which main panels become visible
-    auto navigateAndVerify = [this](const QString &view, bool expectFlyView, bool expectPlanView, bool expectToolDrawer) {
+    auto navigateAndVerify = [this](const QString& view, bool expectFlyView, bool expectPlanView,
+                                    bool expectToolDrawer) {
         const QString buttonName = QStringLiteral("toolbar_view") + view;
         QVERIFY2(clickToolSelectDropdownButton(buttonName),
                  qPrintable(QStringLiteral("Failed to navigate to %1").arg(view)));
 
-        const int flyTimeout    = expectFlyView    ? 1000 : 0;
-        const int planTimeout   = expectPlanView   ? 1000 : 0;
+        const int flyTimeout = expectFlyView ? 1000 : 0;
+        const int planTimeout = expectPlanView ? 1000 : 0;
         const int drawerTimeout = expectToolDrawer ? 1000 : 0;
-        QVERIFY2((findVisibleItem(_rootItem, QStringLiteral("mainView_fly"),        flyTimeout)    != nullptr) == expectFlyView,
+        QVERIFY2((findVisibleItem(_rootItem, QStringLiteral("mainView_fly"), flyTimeout) != nullptr) == expectFlyView,
                  qPrintable(QStringLiteral("mainView_fly visibility wrong after switching to %1").arg(view)));
-        QVERIFY2((findVisibleItem(_rootItem, QStringLiteral("mainView_plan"),       planTimeout)   != nullptr) == expectPlanView,
-                 qPrintable(QStringLiteral("mainView_plan visibility wrong after switching to %1").arg(view)));
-        QVERIFY2((findVisibleItem(_rootItem, QStringLiteral("mainView_toolDrawer"), drawerTimeout) != nullptr) == expectToolDrawer,
+        QVERIFY2(
+            (findVisibleItem(_rootItem, QStringLiteral("mainView_plan"), planTimeout) != nullptr) == expectPlanView,
+            qPrintable(QStringLiteral("mainView_plan visibility wrong after switching to %1").arg(view)));
+        QVERIFY2((findVisibleItem(_rootItem, QStringLiteral("mainView_toolDrawer"), drawerTimeout) != nullptr) ==
+                     expectToolDrawer,
                  qPrintable(QStringLiteral("mainView_toolDrawer visibility wrong after switching to %1").arg(view)));
         QTest::qWait(_viewDelay);
     };
 
     //                      view name      flyView  planView  toolDrawer
-    navigateAndVerify(QStringLiteral("Fly"),       true,    false,    false);
-    navigateAndVerify(QStringLiteral("Plan"),      false,   true,     false);
-    navigateAndVerify(QStringLiteral("Configure"), false,   true,     true);
-    navigateAndVerify(QStringLiteral("Analyze"),   false,   true,     true);
-    navigateAndVerify(QStringLiteral("Settings"),  false,   true,     true);
+    navigateAndVerify(QStringLiteral("Fly"), true, false, false);
+    navigateAndVerify(QStringLiteral("Plan"), false, true, false);
+    navigateAndVerify(QStringLiteral("Configure"), false, true, true);
+    navigateAndVerify(QStringLiteral("Analyze"), false, true, true);
+    navigateAndVerify(QStringLiteral("Settings"), false, true, true);
 
     // Navigate through settings pages that are unconditionally visible
     {
         navigateAndVerify(QStringLiteral("Settings"), false, true, true);
 
         const QStringList settingsPages = {
-            QStringLiteral("General"),
-            QStringLiteral("Fly View"),
-            QStringLiteral("Plan View"),
-            QStringLiteral("ADSB Server"),
-            QStringLiteral("Comm Links"),
-            QStringLiteral("App Logging"),
-            QStringLiteral("App Log Viewer"),
-            QStringLiteral("Maps"),
-            QStringLiteral("Remote ID"),
-            QStringLiteral("Telemetry"),
-            QStringLiteral("Video"),
-            QStringLiteral("Help"),
+            QStringLiteral("General"),        QStringLiteral("Fly View"),   QStringLiteral("Plan View"),
+            QStringLiteral("ADSB Server"),    QStringLiteral("Comm Links"), QStringLiteral("App Logging"),
+            QStringLiteral("App Log Viewer"), QStringLiteral("Maps"),       QStringLiteral("Remote ID"),
+            QStringLiteral("Telemetry"),      QStringLiteral("Video"),      QStringLiteral("Help"),
         };
 
-        for (const QString &page : settingsPages) {
-            const QString buttonName = QStringLiteral("settingsButton_") + page;
-
-            QQuickItem *btn = findVisibleItem(_rootItem, buttonName);
-            QVERIFY2(btn, qPrintable(QStringLiteral("Settings page button not found: %1").arg(buttonName)));
-
-            scrollIntoView(btn, QStringLiteral("settings_buttonList"));
-
-            const QPointF center = btn->mapToScene(QPointF(btn->width() / 2, btn->height() / 2));
-            QTest::mouseClick(_window, Qt::LeftButton, Qt::NoModifier, center.toPoint());
-            QTest::qWait(_pageDelay);
+        for (const QString& page : settingsPages) {
+            if (!_clickSettingsButton(page)) {
+                return;
+            }
 
             const QString expectedObjectName = QStringLiteral("settingsPage_") + QString(page).remove(' ');
             QVERIFY2(findVisibleItem(_rootItem, expectedObjectName),
@@ -106,38 +133,159 @@ void TopLevelViewsTest::_testNavigateViews()
 void TopLevelViewsTest::_testSettingsSectionVisibility()
 {
     startUI();
-    if (QTest::currentTestFailed()) return;
+    if (QTest::currentTestFailed())
+        return;
 
-    constexpr int videoSettingsSectionIndex = 2;
-
-    Fact* const videoSource = SettingsManager::instance()->videoSettings()->videoSource();
-    const QVariant savedVideoSource = videoSource->rawValue();
-    const auto restoreVideoSource = qScopeGuard([videoSource, savedVideoSource] {
-        videoSource->setRawValue(savedVideoSource);
-    });
-    videoSource->setRawValue(QString::fromLatin1(VideoSettings::videoSourceRTSP));
+    const auto restoreVideoSource = setVideoSourceWithRestore(VideoSettings::videoSourceRTSP);
 
     QVERIFY(clickToolSelectDropdownButton(QStringLiteral("toolbar_viewSettings")));
 
-    QQuickItem* const videoButton = findVisibleItem(_rootItem, QStringLiteral("settingsButton_Video"));
-    QVERIFY(videoButton);
-    QVERIFY(scrollIntoView(videoButton, QStringLiteral("settings_buttonList")));
-    const QPointF videoCenter = videoButton->mapToScene(QPointF(videoButton->width() / 2, videoButton->height() / 2));
-    QTest::mouseClick(_window, Qt::LeftButton, Qt::NoModifier, videoCenter.toPoint());
+    QQuickItem* const videoButton = _clickSettingsButton(QStringLiteral("Video"));
+    if (!videoButton) {
+        return;
+    }
+    QVERIFY(findVisibleItem(_rootItem, QStringLiteral("settingsPage_Video")));
 
-    QQuickItem* const videoPage = findVisibleItem(_rootItem, QStringLiteral("settingsPage_Video"));
-    QVERIFY(videoPage);
-    QQuickItem* videoSection = nullptr;
-    QTRY_VERIFY((videoSection = findVisibleSectionButton(videoButton->parentItem(), videoSettingsSectionIndex)));
-    const QPointF sectionCenter = videoSection->mapToScene(QPointF(videoSection->width() / 2, videoSection->height() / 2));
-    QTest::mouseClick(_window, Qt::LeftButton, Qt::NoModifier, sectionCenter.toPoint());
+    QQuickItem* settingsSection = nullptr;
+    QTRY_VERIFY((settingsSection = findVisibleSectionButton(videoButton->parentItem(), QStringLiteral("Settings"))));
+    QVERIFY(_clickItemAt(settingsSection, 0.5, 0.5, QStringLiteral("section Settings")));
 
     QVERIFY(findVisibleItem(_rootItem, QStringLiteral("settingsGroup_Settings")));
 
-    videoSource->setRawValue(QString::fromLatin1(VideoSettings::videoDisabled));
+    setVideoSource(VideoSettings::videoDisabled);
 
-    QTRY_VERIFY(!findVisibleSectionButton(videoButton->parentItem(), videoSettingsSectionIndex));
+    QTRY_VERIFY(!findVisibleSectionButton(videoButton->parentItem(), QStringLiteral("Settings")));
     QTRY_VERIFY(!findVisibleItem(_rootItem, QStringLiteral("settingsGroup_Settings"), 0));
-    QTRY_VERIFY(findVisibleItem(_rootItem, QStringLiteral("settingsGroup_VideoSource")));
+    QTRY_VERIFY(findVisibleItem(_rootItem, QStringLiteral("settingsGroup_VideoSource"), 0));
     QVERIFY(findVisibleItem(_rootItem, QStringLiteral("settingsPage_Video")));
+}
+
+// Primary #14898 regression: hidden sections must not reappear in the nav tree
+// after another page is selected and the Video page contents unload.
+void TopLevelViewsTest::_testSettingsHiddenSectionAfterPageSwitch()
+{
+    startUI();
+    if (QTest::currentTestFailed())
+        return;
+
+    const auto restoreVideoSource = setVideoSourceWithRestore(VideoSettings::videoSourceRTSP);
+
+    QVERIFY(clickToolSelectDropdownButton(QStringLiteral("toolbar_viewSettings")));
+
+    QQuickItem* const videoButton = _clickSettingsButton(QStringLiteral("Video"));
+    if (!videoButton) {
+        return;
+    }
+    QVERIFY(findVisibleItem(_rootItem, QStringLiteral("settingsPage_Video")));
+    QTRY_VERIFY(findVisibleSectionButton(videoButton->parentItem(), QStringLiteral("Settings")));
+
+    setVideoSource(VideoSettings::videoDisabled);
+    QTRY_VERIFY(!findVisibleSectionButton(videoButton->parentItem(), QStringLiteral("Settings")));
+
+    // Select another page; the Video entry stays expanded in the nav tree,
+    // which is the path that used to resurrect the hidden sections
+    if (!_clickSettingsButton(QStringLiteral("General"))) {
+        return;
+    }
+    QTRY_VERIFY(findVisibleItem(_rootItem, QStringLiteral("settingsPage_General"), 0));
+    QTRY_VERIFY(!findVisibleSectionButton(videoButton->parentItem(), QStringLiteral("Settings")));
+    QTRY_VERIFY(!findVisibleSectionButton(videoButton->parentItem(), QStringLiteral("Connection")));
+
+    // Back to Video: panel must show the remaining content, not go blank
+    if (!_clickSettingsButton(QStringLiteral("Video"))) {
+        return;
+    }
+    QTRY_VERIFY(findVisibleItem(_rootItem, QStringLiteral("settingsPage_Video"), 0));
+    QTRY_VERIFY(findVisibleItem(_rootItem, QStringLiteral("settingsGroup_VideoSource"), 0));
+    QTRY_VERIFY(!findVisibleSectionButton(videoButton->parentItem(), QStringLiteral("Settings")));
+}
+
+// When a page collapses to a single visible section while one of its sections is
+// selected, the selection must normalize to the page itself so the nav still has
+// a checked item.
+void TopLevelViewsTest::_testSettingsSectionCollapseToSingle()
+{
+    startUI();
+    if (QTest::currentTestFailed())
+        return;
+
+    const auto restoreVideoSource = setVideoSourceWithRestore(VideoSettings::videoSourceRTSP);
+
+    QVERIFY(clickToolSelectDropdownButton(QStringLiteral("toolbar_viewSettings")));
+
+    QQuickItem* const videoButton = _clickSettingsButton(QStringLiteral("Video"));
+    if (!videoButton) {
+        return;
+    }
+    QVERIFY(findVisibleItem(_rootItem, QStringLiteral("settingsPage_Video")));
+
+    // Select the always-visible "Video Source" section
+    QQuickItem* sourceSection = nullptr;
+    QTRY_VERIFY((sourceSection = findVisibleSectionButton(videoButton->parentItem(), QStringLiteral("Video Source"))));
+    QVERIFY(_clickItemAt(sourceSection, 0.5, 0.5, QStringLiteral("section Video Source")));
+    QTRY_VERIFY(!videoButton->property("checked").toBool());
+
+    // Disabling the source hides all other sections, leaving only "Video Source"
+    setVideoSource(VideoSettings::videoDisabled);
+
+    QTRY_VERIFY(!findVisibleSectionButton(videoButton->parentItem(), QStringLiteral("Video Source")));
+    QTRY_VERIFY(videoButton->property("checked").toBool());
+    QTRY_VERIFY(findVisibleItem(_rootItem, QStringLiteral("settingsGroup_VideoSource"), 0));
+}
+
+// When the selected page becomes entirely unavailable the view must fall back to
+// the first available page instead of leaving stale content or a blank panel.
+void TopLevelViewsTest::_testSettingsPageUnavailableFallback()
+{
+    startUI();
+    if (QTest::currentTestFailed())
+        return;
+
+    VideoSettings* const videoSettings = SettingsManager::instance()->videoSettings();
+    const auto restoreUserVisible = qScopeGuard([videoSettings] { videoSettings->setUserVisible(true); });
+
+    QVERIFY(clickToolSelectDropdownButton(QStringLiteral("toolbar_viewSettings")));
+
+    if (!_clickSettingsButton(QStringLiteral("Video"))) {
+        return;
+    }
+    QTRY_VERIFY(findVisibleItem(_rootItem, QStringLiteral("settingsPage_Video"), 0));
+
+    videoSettings->setUserVisible(false);
+
+    QTRY_VERIFY(!findVisibleItem(_rootItem, QStringLiteral("settingsButton_Video"), 0));
+    QTRY_VERIFY(findVisibleItem(_rootItem, QStringLiteral("settingsPage_General"), 0));
+    QQuickItem* const generalButton = findVisibleItem(_rootItem, QStringLiteral("settingsButton_General"));
+    QVERIFY(generalButton);
+    QTRY_VERIFY(generalButton->property("checked").toBool());
+}
+
+// Search must not match or offer navigation to sections that are hidden.
+void TopLevelViewsTest::_testSettingsSearchExcludesHiddenSections()
+{
+    startUI();
+    if (QTest::currentTestFailed())
+        return;
+
+    const auto restoreVideoSource = setVideoSourceWithRestore(VideoSettings::videoSourceRTSP);
+
+    QVERIFY(clickToolSelectDropdownButton(QStringLiteral("toolbar_viewSettings")));
+
+    QQuickItem* const searchField = findVisibleItem(_rootItem, QStringLiteral("settings_searchField"));
+    QVERIFY(searchField);
+
+    // "zero-copy" is a keyword of the Video page's hideable "Settings" section
+    searchField->setProperty("text", QStringLiteral("zero-copy"));
+    QQuickItem* videoButton = nullptr;
+    QTRY_VERIFY((videoButton = findVisibleItem(_rootItem, QStringLiteral("settingsButton_Video"), 0)));
+    QTRY_VERIFY(findVisibleSectionButton(videoButton->parentItem(), QStringLiteral("Settings")));
+
+    setVideoSource(VideoSettings::videoDisabled);
+
+    QTRY_VERIFY(!findVisibleItem(_rootItem, QStringLiteral("settingsButton_Video"), 0));
+
+    // The page vanished because its only search match is in the now-hidden section,
+    // not because the page became unavailable: clearing the search brings it back
+    searchField->setProperty("text", QString());
+    QTRY_VERIFY(findVisibleItem(_rootItem, QStringLiteral("settingsButton_Video"), 0));
 }

--- a/test/QmlUITests/TopLevelViewsTest.cc
+++ b/test/QmlUITests/TopLevelViewsTest.cc
@@ -1,13 +1,35 @@
 #include "TopLevelViewsTest.h"
 
+#include <QtCore/QScopeGuard>
 #include <QtQuick/QQuickItem>
 #include <QtQuick/QQuickWindow>
 #include <QtTest/QTest>
+
+#include "Fact.h"
+#include "SettingsManager.h"
+#include "VideoSettings.h"
 
 UT_REGISTER_TEST(TopLevelViewsTest, TestLabel::Integration)
 
 // This test assumes Advanced UI mode is enabled (the default). All views including
 // Analyze are expected to be visible.
+
+static QQuickItem* findVisibleSectionButton(QQuickItem* root, int sectionIndex)
+{
+    if (!root || !root->isVisible()) {
+        return nullptr;
+    }
+    if (root->property("sectionIndex").isValid() && root->property("sectionIndex").toInt() == sectionIndex) {
+        return root;
+    }
+    const auto children = root->childItems();
+    for (auto* child : children) {
+        if (auto* found = findVisibleSectionButton(child, sectionIndex)) {
+            return found;
+        }
+    }
+    return nullptr;
+}
 
 void TopLevelViewsTest::_testNavigateViews()
 {
@@ -79,4 +101,43 @@ void TopLevelViewsTest::_testNavigateViews()
     }
 
     stopUI();
+}
+
+void TopLevelViewsTest::_testSettingsSectionVisibility()
+{
+    startUI();
+    if (QTest::currentTestFailed()) return;
+
+    constexpr int videoSettingsSectionIndex = 2;
+
+    Fact* const videoSource = SettingsManager::instance()->videoSettings()->videoSource();
+    const QVariant savedVideoSource = videoSource->rawValue();
+    const auto restoreVideoSource = qScopeGuard([videoSource, savedVideoSource] {
+        videoSource->setRawValue(savedVideoSource);
+    });
+    videoSource->setRawValue(QString::fromLatin1(VideoSettings::videoSourceRTSP));
+
+    QVERIFY(clickToolSelectDropdownButton(QStringLiteral("toolbar_viewSettings")));
+
+    QQuickItem* const videoButton = findVisibleItem(_rootItem, QStringLiteral("settingsButton_Video"));
+    QVERIFY(videoButton);
+    QVERIFY(scrollIntoView(videoButton, QStringLiteral("settings_buttonList")));
+    const QPointF videoCenter = videoButton->mapToScene(QPointF(videoButton->width() / 2, videoButton->height() / 2));
+    QTest::mouseClick(_window, Qt::LeftButton, Qt::NoModifier, videoCenter.toPoint());
+
+    QQuickItem* const videoPage = findVisibleItem(_rootItem, QStringLiteral("settingsPage_Video"));
+    QVERIFY(videoPage);
+    QQuickItem* videoSection = nullptr;
+    QTRY_VERIFY((videoSection = findVisibleSectionButton(videoButton->parentItem(), videoSettingsSectionIndex)));
+    const QPointF sectionCenter = videoSection->mapToScene(QPointF(videoSection->width() / 2, videoSection->height() / 2));
+    QTest::mouseClick(_window, Qt::LeftButton, Qt::NoModifier, sectionCenter.toPoint());
+
+    QVERIFY(findVisibleItem(_rootItem, QStringLiteral("settingsGroup_Settings")));
+
+    videoSource->setRawValue(QString::fromLatin1(VideoSettings::videoDisabled));
+
+    QTRY_VERIFY(!findVisibleSectionButton(videoButton->parentItem(), videoSettingsSectionIndex));
+    QTRY_VERIFY(!findVisibleItem(_rootItem, QStringLiteral("settingsGroup_Settings"), 0));
+    QTRY_VERIFY(findVisibleItem(_rootItem, QStringLiteral("settingsGroup_VideoSource")));
+    QVERIFY(findVisibleItem(_rootItem, QStringLiteral("settingsPage_Video")));
 }

--- a/test/QmlUITests/TopLevelViewsTest.h
+++ b/test/QmlUITests/TopLevelViewsTest.h
@@ -17,4 +17,11 @@ public:
 private slots:
     void _testNavigateViews();
     void _testSettingsSectionVisibility();
+    void _testSettingsHiddenSectionAfterPageSwitch();
+    void _testSettingsSectionCollapseToSingle();
+    void _testSettingsPageUnavailableFallback();
+    void _testSettingsSearchExcludesHiddenSections();
+
+private:
+    QQuickItem* _clickSettingsButton(const QString& pageName);
 };

--- a/test/QmlUITests/TopLevelViewsTest.h
+++ b/test/QmlUITests/TopLevelViewsTest.h
@@ -16,4 +16,5 @@ public:
 
 private slots:
     void _testNavigateViews();
+    void _testSettingsSectionVisibility();
 };

--- a/test/QmlUITests/VehicleConfigUITestBase.cc
+++ b/test/QmlUITests/VehicleConfigUITestBase.cc
@@ -1,16 +1,48 @@
 #include "VehicleConfigUITestBase.h"
 
 #include <QtCore/QElapsedTimer>
+#include <QtCore/QLocale>
 #include <QtCore/QPointer>
+#include <QtCore/QRegularExpression>
+#include <QtCore/QScopeGuard>
 #include <QtQuick/QQuickItem>
 #include <QtQuick/QQuickWindow>
 #include <QtTest/QTest>
 
+#include "AppSettings.h"
 #include "AutoPilotPlugin.h"
 #include "Fact.h"
 #include "ParameterManager.h"
+#include "QGCApplication.h"
+#include "SettingsManager.h"
 #include "Vehicle.h"
 #include "VehicleComponent.h"
+
+namespace {
+
+/// Returns true if the item tree (including \a item itself) contains at least
+/// one visible text, control or image item with a non-zero size. Layout
+/// containers report a size even when all their children are hidden, so only
+/// leaf content items count.
+bool hasVisibleContent(QQuickItem *item)
+{
+    if (!item->isVisible()) {
+        return false;
+    }
+    if ((item->width() > 0) && (item->height() > 0) &&
+        (item->inherits("QQuickText") || item->inherits("QQuickControl") || item->inherits("QQuickImageBase"))) {
+        return true;
+    }
+    const QList<QQuickItem *> children = item->childItems();
+    for (QQuickItem *child : children) {
+        if (hasVisibleContent(child)) {
+            return true;
+        }
+    }
+    return false;
+}
+
+} // namespace
 
 void VehicleConfigUITestBase::navigateToConfigureView()
 {
@@ -111,6 +143,130 @@ void VehicleConfigUITestBase::clickThroughAllComponents(Vehicle *vehicle, const 
         QVERIFY2(loader->property("item").value<QQuickItem *>() != nullptr,
                  qPrintable(QStringLiteral("%1Panel loader has no item after clicking %2")
                                 .arg(prefix, comp->name())));
+
+        verifyPanelContentVisible(prefix + comp->name());
+        if (QTest::currentTestFailed()) return;
+
+        // Click each section button in the expanded tree and verify the page
+        // shows content for that section
+        const QStringList sectionIds = comp->sectionIds();
+        for (const QString &sectionId : sectionIds) {
+            // Matches objectName in VehicleConfigView.qml: "vehicleConfig_section_" + id without spaces
+            const QString sectionButtonName =
+                QStringLiteral("vehicleConfig_section_") + QString(sectionId).remove(QLatin1Char(' '));
+            if (!findVisibleItem(_rootItem, sectionButtonName, 250)) {
+                // Section hidden by sectionVisible() filtering – skip silently
+                continue;
+            }
+            clickSidebarButton(sectionButtonName);
+            if (QTest::currentTestFailed()) return;
+            verifyPanelContentVisible(prefix + comp->name() + QStringLiteral(" / ") + sectionId);
+            if (QTest::currentTestFailed()) return;
+        }
+    }
+}
+
+void VehicleConfigUITestBase::verifyPanelContentVisible(const QString &context)
+{
+    QQuickItem *loader = findVisibleItem(_rootItem, QStringLiteral("vehicleConfig_panelLoader"), 2000);
+    QVERIFY2(loader, qPrintable(context + QStringLiteral(": vehicleConfig_panelLoader not found")));
+
+    QQuickItem *panel = loader->property("item").value<QQuickItem *>();
+    QVERIFY2(panel, qPrintable(context + QStringLiteral(": panel loader has no item")));
+
+    // For SetupPage-based panels check the page content, not the SetupPage
+    // chrome (title/description) which renders even when the content is blank
+    QQuickItem *target = panel;
+    if (QQuickItem *contentLoader = panel->findChild<QQuickItem *>(QStringLiteral("setupPage_contentLoader"))) {
+        QQuickItem *contentItem = contentLoader->property("item").value<QQuickItem *>();
+        QVERIFY2(contentItem, qPrintable(context + QStringLiteral(": setup page content loader has no item")));
+        target = contentItem;
+    }
+
+    QVERIFY2(QTest::qWaitFor([&] { return hasVisibleContent(target); }, 3000),
+             qPrintable(context + QStringLiteral(": page loaded but renders no visible content (blank page)")));
+}
+
+void VehicleConfigUITestBase::clickThroughAllComponentsAllLocales(Vehicle *vehicle, const QString &vehicleName)
+{
+    Fact *languageFact = SettingsManager::instance()->appSettings()->qLocaleLanguage();
+    const QVariant savedLanguage = languageFact->rawValue();
+
+    // A mid-test failure must not leak the language setting into later tests
+    auto restoreLanguage = qScopeGuard([this, languageFact, savedLanguage] {
+        if (languageFact->rawValue() == savedLanguage) {
+            return;
+        }
+        qgcApp()->resetRebootMessageDebounce();
+        languageFact->setRawValue(savedLanguage);
+        (void) acceptDialog(5000);
+    });
+
+    // Translations may not exist for the machine's system locale (e.g. "C" on CI)
+    ignoreLogMessage("API.QGCApplication", QtWarningMsg,
+                     QRegularExpression(QStringLiteral("Qt lib localization for .* is not present")));
+    ignoreLogMessage("API.QGCApplication", QtWarningMsg,
+                     QRegularExpression(QStringLiteral("Error loading source localization for .*")));
+    ignoreLogMessage("API.QGCApplication", QtWarningMsg,
+                     QRegularExpression(QStringLiteral("Error loading json localization for .*")));
+
+    // The stored locale is machine-dependent: force English so the first pass and
+    // the anchor text capture are actually English.
+    // Language is a reboot-required setting: each change announces a restart via
+    // an app message dialog which must be dismissed before clicking the UI.
+    if (languageFact->rawValue().toInt() != QLocale::English) {
+        expectAppMessage(QRegularExpression(QStringLiteral("Restart application for changes to take effect")));
+        languageFact->setRawValue(QLocale::English);
+        QVERIFY2(acceptDialog(5000), "Restart-required dialog never shown after switching language to English");
+        verifyExpectedLogMessage();
+        if (QTest::currentTestFailed()) return;
+    }
+
+    clickThroughAllComponents(vehicle, vehicleName);
+    if (QTest::currentTestFailed()) return;
+
+    // Language anchor: capture live English text so the switch can be verified
+    // to actually retranslate the UI (not just flip the setting)
+    clickSidebarButton(QStringLiteral("vehicleConfig_comp_Sensors"));
+    if (QTest::currentTestFailed()) return;
+    QPointer<QQuickItem> anchor = findVisibleItem(_rootItem, QStringLiteral("sensorsSetup_calibrateCompass"), 3000);
+    QVERIFY2(anchor, "Calibrate Compass language anchor not found");
+    const QString englishAnchorText = anchor->property("text").toString();
+
+    qgcApp()->resetRebootMessageDebounce();
+    expectAppMessage(QRegularExpression(QStringLiteral("Restart application for changes to take effect")));
+    languageFact->setRawValue(QLocale::Chinese);
+    QVERIFY2(acceptDialog(5000), "Restart-required dialog never shown after switching language to Chinese");
+    verifyExpectedLogMessage();
+    if (QTest::currentTestFailed()) return;
+
+    QVERIFY2(anchor, "Language anchor destroyed during language switch");
+    QVERIFY2(QTest::qWaitFor([&] { return anchor && (anchor->property("text").toString() != englishAnchorText); }, 3000),
+             qPrintable(QStringLiteral("UI text did not change after switching to Chinese (still '%1')")
+                            .arg(englishAnchorText)));
+
+    const QString zhPrefix = vehicleName.isEmpty() ? QStringLiteral("zh_CN") : vehicleName + QStringLiteral(" zh_CN");
+    clickThroughAllComponents(vehicle, zhPrefix);
+    if (QTest::currentTestFailed()) return;
+
+    // No restore needed when the saved language was already Chinese (no change, no dialog)
+    if (languageFact->rawValue() != savedLanguage) {
+        // showRebootAppMessage() debounces repeats: reset so the restore change shows its own dialog
+        qgcApp()->resetRebootMessageDebounce();
+        expectAppMessage(QRegularExpression(QStringLiteral("Restart application for changes to take effect")));
+        languageFact->setRawValue(savedLanguage);
+        QVERIFY2(acceptDialog(5000), "Restart-required dialog never shown after restoring language");
+        verifyExpectedLogMessage();
+    }
+
+    // The saved language may itself be non-English, so only verify retranslation
+    // back to the English anchor when it renders English
+    if (savedLanguage.toInt() == QLocale::English) {
+        QPointer<QQuickItem> restoredAnchor = findVisibleItem(_rootItem, QStringLiteral("sensorsSetup_calibrateCompass"), 3000);
+        if (restoredAnchor) {
+            QVERIFY2(QTest::qWaitFor([&] { return restoredAnchor && (restoredAnchor->property("text").toString() == englishAnchorText); }, 3000),
+                     "UI text did not return to English after restoring language");
+        }
     }
 }
 

--- a/test/QmlUITests/VehicleConfigUITestBase.h
+++ b/test/QmlUITests/VehicleConfigUITestBase.h
@@ -45,6 +45,16 @@ protected:
     /// prepended to failure messages.
     void clickThroughAllComponents(Vehicle *vehicle, const QString &vehicleName = QString());
 
+    /// Run clickThroughAllComponents() in English and then again with the
+    /// Chinese translations loaded. Guards against section filtering that
+    /// compares translated strings rendering blank pages (issue #14929).
+    void clickThroughAllComponentsAllLocales(Vehicle *vehicle, const QString &vehicleName = QString());
+
+    /// Verify the currently loaded config panel actually renders visible
+    /// content (at least one visible text/control/image item), not just that
+    /// the loader has an item. Catches blank-page regressions.
+    void verifyPanelContentVisible(const QString &context);
+
     /// Wait for _refreshParams() traffic to settle so link teardown doesn't cut
     /// off in-flight PARAM_REQUEST_READs (which can log warnings that fail
     /// strict mode). Fails the test if traffic is still active after 10s;

--- a/tools/generators/common/validation.py
+++ b/tools/generators/common/validation.py
@@ -51,3 +51,23 @@ def require_dict(value: object, context: str, source: object) -> dict:
             f"got {type(value).__name__}: {_repr.repr(value)}"
         )
     return value
+
+
+def require_qml_safe_string(value: object, context: str, source: object) -> str:
+    """Reject strings that would break out of a generated QML string literal.
+
+    These strings are embedded verbatim inside "..." in generated QML and also
+    serve as untranslated section IDs, so quote/backslash/newline are banned
+    rather than escaped.
+    """
+    if not isinstance(value, str):
+        raise ValueError(
+            f"{source}: {context} must be a string, "
+            f"got {type(value).__name__}: {_repr.repr(value)}"
+        )
+    if any(c in value for c in ('"', "\\", "\n", "\r")):
+        raise ValueError(
+            f"{source}: {context} must not contain double-quote, backslash, or "
+            f"newline characters: {clamped_repr(value)}"
+        )
+    return value

--- a/tools/generators/config_qml/emit.py
+++ b/tools/generators/config_qml/emit.py
@@ -374,6 +374,7 @@ def _inject_prop(qml: str, prop_line: str) -> str:
 
 
 def _section_visible(sec: SectionDef) -> str:
+    # The untranslated title is the section ID (must match VehicleComponent::sectionIds())
     name_vis = f'sectionMatchesFilter("{sec.title}")'
     return f"{name_vis} && {sec.showWhen}" if sec.showWhen else name_vis
 
@@ -438,7 +439,8 @@ def _qml_repeat_section(sec: SectionDef, sec_idx: int, tr_context: str = "") -> 
     assert rep is not None
     ind = "                "
 
-    name_vis = "sectionMatchesFilter(heading)"
+    # Filter on the untranslated per-index section ID, not the translated heading
+    name_vis = f'sectionMatchesFilter(_sectionId, "{sec.title}")'
     show_vis = f"{name_vis} && {sec.showWhen}" if sec.showWhen else name_vis
     safe = _safe_id(sec.title)
 
@@ -485,6 +487,7 @@ def _qml_repeat_section(sec: SectionDef, sec_idx: int, tr_context: str = "") -> 
             ind=ind,
             safe=safe,
             visible=visible,
+            raw_title=sec.title,
             heading_expr=heading_expr,
             image=sec.image,
             apm_battery=apm_battery,
@@ -570,11 +573,11 @@ def _terms_entries(terms_map: dict) -> list[dict]:
     items = list(terms_map.items())
     return [
         {
-            "title": title,
+            "section_id": section_id,
             "terms": ", ".join(f'"{t}"' for t in terms),
             "comma": "," if i < len(items) - 1 else "",
         }
-        for i, (title, terms) in enumerate(items)
+        for i, (section_id, terms) in enumerate(items)
     ]
 
 

--- a/tools/generators/config_qml/model.py
+++ b/tools/generators/config_qml/model.py
@@ -21,7 +21,12 @@ from ..common.controls import (
     parse_radio_options,
     parse_toggle_checkbox,
 )
-from ..common.validation import reject_unknown_keys, require_dict, require_list
+from ..common.validation import (
+    reject_unknown_keys,
+    require_dict,
+    require_list,
+    require_qml_safe_string,
+)
 
 
 @dataclass
@@ -220,7 +225,9 @@ def _build_page_def(data: dict, json_filename: str) -> PageDef:
                 ControlDef(
                     param=ctrl_data.get("param", ""),
                     setting=ctrl_data.get("setting", ""),
-                    label=ctrl_data.get("label", ""),
+                    label=require_qml_safe_string(
+                        ctrl_data.get("label", ""), "control label", json_filename
+                    ),
                     control=ctrl_data.get("control", ""),
                     showWhen=ctrl_data.get("showWhen", ""),
                     enableWhen=ctrl_data.get("enableWhen", ""),
@@ -258,6 +265,7 @@ def _build_page_def(data: dict, json_filename: str) -> PageDef:
             )
         repeat_data = sec_data.get("repeat")
         repeat_def = None
+        title = require_qml_safe_string(sec_data.get("title", ""), "section title", json_filename)
         if repeat_data:
             reject_unknown_keys(repeat_data, _ALLOWED_REPEAT_KEYS, "repeat", json_filename)
             ds_data = repeat_data.get("disabledSection")
@@ -265,7 +273,9 @@ def _build_page_def(data: dict, json_filename: str) -> PageDef:
             if ds_data:
                 reject_unknown_keys(ds_data, _ALLOWED_DISABLED_SECTION_KEYS, "disabledSection", json_filename)
                 ds_def = DisabledSectionDef(
-                    heading=ds_data.get("heading", ""),
+                    heading=require_qml_safe_string(
+                        ds_data.get("heading", ""), "disabledSection heading", json_filename
+                    ),
                     enabledParamValue=str(ds_data.get("enabledParamValue", "")),
                 )
             repeat_def = RepeatDef(
@@ -280,18 +290,28 @@ def _build_page_def(data: dict, json_filename: str) -> PageDef:
             )
             if repeat_def.enableParam and not repeat_def.disabledParamValue:
                 raise ValueError(
-                    f"Section '{sec_data.get('title', '')}': enableParam requires "
+                    f"Section '{title}': enableParam requires "
                     f"disabledParamValue to be specified"
+                )
+            # C++ VehicleComponent::sectionIds() cannot expand {index}, so it
+            # would produce section IDs that never match the generated QML
+            if "{index}" in title:
+                raise ValueError(
+                    f"{json_filename}: repeat section title must not contain "
+                    f"{{index}}: '{title}'"
                 )
         sections.append(
             SectionDef(
-                title=sec_data.get("title", ""),
+                title=title,
                 image=sec_data.get("image", ""),
                 controls=controls,
                 component=sec_data.get("component", ""),
                 showWhen=sec_data.get("showWhen", ""),
                 repeat=repeat_def,
-                keywords=sec_data.get("keywords", []),
+                keywords=[
+                    require_qml_safe_string(kw, "section keyword", json_filename)
+                    for kw in sec_data.get("keywords", [])
+                ],
             )
         )
     return PageDef(
@@ -324,7 +344,7 @@ def _propagate_optional(page: PageDef) -> None:
 
 
 def _build_search_terms(page: PageDef) -> dict[str, list[str]]:
-    """Build a mapping of section title → list of lowercase search terms.
+    """Build a mapping of section ID (untranslated title) → list of lowercase search terms.
 
     Search terms are derived from: section title words, control labels,
     referenced param names, and explicit keywords from JSON.
@@ -353,7 +373,7 @@ def _build_search_terms(page: PageDef) -> dict[str, list[str]]:
 
 
 def _build_translatable_terms(page: PageDef) -> dict[str, list[str]]:
-    """Build a mapping of section title → list of original-case translatable strings.
+    """Build a mapping of section ID (untranslated title) → list of original-case translatable strings.
 
     These are passed through qsTranslate() at runtime so the search works in
     the user's language.  Param names are excluded (not translatable).

--- a/tools/generators/config_qml/templates/page.qml.j2
+++ b/tools/generators/config_qml/templates/page.qml.j2
@@ -45,44 +45,61 @@ SetupPage {
 {{ rc }}
 
 {% endfor %}
-            property string sectionNameFilter: ""
+            property string sectionIdFilter: ""
 
+            // Keyed by untranslated section ID (must match VehicleComponent::sectionIds())
             readonly property var _searchTerms: ({
 {% for st in search_terms %}
-                "{{ st.title }}": [{{ st.terms }}]{{ st.comma }}
+                "{{ st.section_id }}": [{{ st.terms }}]{{ st.comma }}
 {% endfor %}
             })
 
             readonly property var _translatableSearchTerms: ({
 {% for tt in tr_terms %}
-                "{{ tt.title }}": [{{ tt.terms }}]{{ tt.comma }}
+                "{{ tt.section_id }}": [{{ tt.terms }}]{{ tt.comma }}
 {% endfor %}
             })
 
-            function sectionMatchesFilter(sectionTitle) {
-                if (sectionNameFilter === "") return true
-                if (sectionNameFilter === sectionTitle) return true
-                var filter = sectionNameFilter.toLowerCase()
-                var terms = _searchTerms[sectionTitle]
+            // sectionId must be untranslated; repeat sections pass their base ID as searchKey
+            function sectionMatchesFilter(sectionId, searchKey) {
+                if (sectionIdFilter === "") {
+                    return true
+                }
+                if (sectionIdFilter === sectionId) {
+                    return true
+                }
+                if (searchKey === undefined) {
+                    searchKey = sectionId
+                }
+                let filter = sectionIdFilter.toLowerCase()
+                let terms = _searchTerms[searchKey]
                 if (terms) {
-                    for (var i = 0; i < terms.length; i++) {
-                        if (terms[i].indexOf(filter) >= 0) return true
+                    for (let i = 0; i < terms.length; i++) {
+                        if (terms[i].indexOf(filter) >= 0) {
+                            return true
+                        }
                     }
                 }
-                var trTerms = _translatableSearchTerms[sectionTitle]
+                let trTerms = _translatableSearchTerms[searchKey]
                 if (trTerms) {
-                    for (var j = 0; j < trTerms.length; j++) {
-                        if (qsTranslate("{{ tr_ctx }}", trTerms[j]).toLowerCase().indexOf(filter) >= 0) return true
+                    for (let j = 0; j < trTerms.length; j++) {
+                        if (qsTranslate("{{ tr_ctx }}", trTerms[j]).toLowerCase().indexOf(filter) >= 0) {
+                            return true
+                        }
                     }
                 }
                 return false
             }
 
-            function sectionVisible(name) {
+            function sectionVisible(sectionId) {
+                switch (sectionId) {
 {% for vc in visible_conditions %}
-                if (name === "{{ vc.name }}") return {{ vc.expr }}
+                case "{{ vc.name }}":
+                    return {{ vc.expr }}
 {% endfor %}
-                return true
+                default:
+                    return true
+                }
             }
 
             property real _maxLeftMargin: ScreenTools.defaultFontPixelWidth * 20

--- a/tools/generators/config_qml/templates/repeat_section.qml.j2
+++ b/tools/generators/config_qml/templates/repeat_section.qml.j2
@@ -13,11 +13,16 @@
 {{ ind }}        property int _rawIndex: index
 {{ ind }}        property string _prefix: _battPrefixForIndex(_rawIndex)
 {{ ind }}        property string _displayIndex: _battLabelForIndex(_rawIndex)
-{{ ind }}        function _fullParamName(postfix) { return _prefix + postfix }
 {% else %}
 {{ ind }}        property int _rawIndex: index + {{ start_index }}
 {{ ind }}        property string _indexStr: {{ index_str_expr }}
 {{ ind }}        property string _displayIndex: String(_rawIndex)
+{% endif %}
+{{ ind }}        // Untranslated section ID; must match VehicleComponent::sectionIds() expansion
+{{ ind }}        property string _sectionId: _{{ safe }}Count > 1 ? "{{ raw_title }} " + _displayIndex : "{{ raw_title }}"
+{% if apm_battery %}
+{{ ind }}        function _fullParamName(postfix) { return _prefix + postfix }
+{% else %}
 {{ ind }}        function _fullParamName(postfix) { return "{{ param_prefix }}" + _indexStr + postfix }
 {% endif %}
 {% for ctrl_qml in controls %}

--- a/tools/generators/settings_qml/emit.py
+++ b/tools/generators/settings_qml/emit.py
@@ -14,7 +14,7 @@ from ..common.controls import (
     render_slider,
     render_textfield,
 )
-from ..common.validation import reject_unknown_keys, require_list
+from ..common.validation import reject_unknown_keys, require_list, require_qml_safe_string
 from .metadata import get_fact_type, has_enum_strings
 from .model import ControlDef, PageDef, load_page_def
 
@@ -303,8 +303,12 @@ def generate_pages_model_qml(pages_json_path: Path) -> str:
             entries.append({"divider": True})
             continue
 
-        name = entry["name"]
-        url = entry.get("url") or f"qrc:/qml/QGroundControl/AppSettings/{entry['qml']}"
+        name = require_qml_safe_string(entry["name"], "page name", pages_json_path)
+        url = require_qml_safe_string(
+            entry.get("url") or f"qrc:/qml/QGroundControl/AppSettings/{entry['qml']}",
+            "page url",
+            pages_json_path,
+        )
 
         sections: list[str] = []
         search_terms: list[dict] = []
@@ -338,8 +342,8 @@ def generate_pages_model_qml(pages_json_path: Path) -> str:
             "divider": False,
             "name": name,
             "url": url,
-            "icon": entry["icon"],
-            "sections_json": json.dumps(sections),
+            "icon": require_qml_safe_string(entry["icon"], "page icon", pages_json_path),
+            "sections_json": json.dumps(sections).replace("'", "\\'"),
             "search_json": json.dumps(search_terms).replace("'", "\\'"),
             "translatable_json": json.dumps(translatable_terms).replace("'", "\\'"),
             "visible": entry.get("visible", ""),

--- a/tools/generators/settings_qml/emit.py
+++ b/tools/generators/settings_qml/emit.py
@@ -188,6 +188,20 @@ def _group_auto_vis(grp) -> str:
     return " || ".join(f"{ref}.userVisible" for ref in fact_refs)
 
 
+def _group_visibility_parts(grp) -> list[str]:
+    vis_parts: list[str] = []
+    if grp.showWhen:
+        vis_parts.append(f"({grp.showWhen})")
+    auto_vis = _group_auto_vis(grp)
+    if auto_vis:
+        vis_parts.append(f"({auto_vis})")
+    return vis_parts
+
+
+def _qml_translate(context: str, text: str) -> str:
+    return f"qsTranslate({json.dumps(context)}, {json.dumps(text)})"
+
+
 def generate_page_qml(
     page: PageDef, settings_dir: Path, json_context: str = "", page_name: str = ""
 ) -> str:
@@ -203,28 +217,11 @@ def generate_page_qml(
         for name, expr in page.bindings.items()
     ]
 
-    section_cases: list[dict] = []
-    for grp_idx, grp in enumerate(page.groups):
-        vis_parts: list[str] = []
-        if grp.showWhen:
-            vis_parts.append(f"({grp.showWhen})")
-        auto_vis = _group_auto_vis(grp)
-        if auto_vis:
-            vis_parts.append(f"({auto_vis})")
-        if vis_parts:
-            section_cases.append({"idx": grp_idx, "expr": " && ".join(vis_parts)})
-
     group_blocks: list[str] = []
     seen_object_names: dict[str, str] = {}  # objectName -> heading that produced it
     for grp_idx, grp in enumerate(page.groups):
         section_vis = f"(sectionFilter === -1 || sectionFilter === {grp_idx})"
-        vis_parts = [section_vis]
-        if grp.showWhen:
-            vis_parts.append(f"({grp.showWhen})")
-        auto_vis = _group_auto_vis(grp)
-        if auto_vis:
-            vis_parts.append(f"({auto_vis})")
-        visible_expr = " && ".join(vis_parts)
+        visible_expr = " && ".join([section_vis, *_group_visibility_parts(grp)])
 
         if grp.component:
             group_blocks.append(_env.get_template("group_component.qml.j2").render(
@@ -276,7 +273,6 @@ def generate_page_qml(
         object_name=page_object_name,
         has_string_fields=_needs_string_field_width(page, settings_dir),
         bindings=bindings,
-        section_cases=section_cases,
         groups=group_blocks,
     ) + "\n"
 
@@ -296,6 +292,7 @@ def generate_pages_model_qml(pages_json_path: Path) -> str:
 
     pages_dir = pages_json_path.parent
     entries: list[dict] = []
+    imports: list[str] = []
 
     for entry in require_list(data.get("pages", []), "'pages'", pages_json_path):
         reject_unknown_keys(entry, _ALLOWED_PAGE_ENTRY_KEYS, "page entry", pages_json_path)
@@ -310,32 +307,49 @@ def generate_pages_model_qml(pages_json_path: Path) -> str:
             pages_json_path,
         )
 
-        sections: list[str] = []
-        search_terms: list[dict] = []
-        translatable_terms: list[dict] = []
+        sections: list[dict] = []
+        section_bindings: list[dict] = []
+        section_state_name = ""
         page_def_name = entry.get("pageDefinition")
         if page_def_name:
             page_def_path = pages_dir / page_def_name
             if page_def_path.exists():
                 page_def = load_page_def(page_def_path)
+                if page_def.bindings or any(group.showWhen for group in page_def.groups):
+                    imports.extend(
+                        page_import for page_import in page_def.imports if page_import not in imports
+                    )
+                section_bindings = [
+                    {
+                        "type": _binding_qml_type(expr),
+                        "name": name,
+                        "expr": expr,
+                    }
+                    for name, expr in page_def.bindings.items()
+                ]
+                if section_bindings:
+                    section_state_name = f"_page{len(entries)}SectionState"
                 for grp_idx, grp in enumerate(page_def.groups):
                     section_name = grp.display_name
-                    sections.append(section_name)
+                    vis_parts = _group_visibility_parts(grp)
+                    visible = " && ".join(vis_parts) if vis_parts else "true"
 
                     terms_parts = [name.lower(), section_name.lower()]
                     terms_parts.extend(kw.lower() for kw in grp.keywords)
                     terms_parts.extend(c.label.lower() for c in grp.controls if c.label)
-                    search_terms.append({
-                        "section": grp_idx,
-                        "terms": " ".join(dict.fromkeys(terms_parts)),
-                    })
-
                     tr_parts: list[str] = [section_name, *grp.keywords]
                     tr_parts.extend(c.label for c in grp.controls if c.label)
-                    translatable_terms.append({
-                        "section": grp_idx,
-                        "context": page_def_name,
-                        "terms": list(dict.fromkeys(tr_parts)),
+                    search_terms = [json.dumps(" ".join(dict.fromkeys(terms_parts)))]
+                    search_terms.extend(
+                        f"{_qml_translate(page_def_name, term)}.toLowerCase()"
+                        for term in dict.fromkeys(tr_parts)
+                    )
+
+                    sections.append({
+                        "index": grp_idx,
+                        "name": _qml_translate(page_def_name, section_name),
+                        "search_terms": f'[{", ".join(search_terms)}]',
+                        "visible": visible,
                     })
 
         entries.append({
@@ -343,10 +357,13 @@ def generate_pages_model_qml(pages_json_path: Path) -> str:
             "name": name,
             "url": url,
             "icon": require_qml_safe_string(entry["icon"], "page icon", pages_json_path),
-            "sections_json": json.dumps(sections).replace("'", "\\'"),
-            "search_json": json.dumps(search_terms).replace("'", "\\'"),
-            "translatable_json": json.dumps(translatable_terms).replace("'", "\\'"),
+            "sections": sections,
+            "section_bindings": section_bindings,
+            "section_state_name": section_state_name,
             "visible": entry.get("visible", ""),
         })
 
-    return _env.get_template("pages_model.qml.j2").render(entries=entries) + "\n"
+    return _env.get_template("pages_model.qml.j2").render(
+        entries=entries,
+        imports=imports,
+    ) + "\n"

--- a/tools/generators/settings_qml/model.py
+++ b/tools/generators/settings_qml/model.py
@@ -12,7 +12,13 @@ from ..common.controls import (
     parse_button,
     parse_enable_checkbox,
 )
-from ..common.validation import clamped_repr, reject_unknown_keys, require_dict, require_list
+from ..common.validation import (
+    clamped_repr,
+    reject_unknown_keys,
+    require_dict,
+    require_list,
+    require_qml_safe_string,
+)
 
 # Matches C++ FactMetaData::splitTranslatedList: [,，、] (ASCII / fullwidth / enumeration commas).
 _TRANSLATED_LIST_RE = re.compile("[,，、]")
@@ -133,24 +139,36 @@ def load_page_def(json_path: Path) -> PageDef:
     for grp_data in require_list(data.get("groups", []), "'groups'", json_path):
         reject_unknown_keys(grp_data, _ALLOWED_GROUP_KEYS, "group", json_path)
         grp = GroupDef(
-            heading=grp_data.get("heading", ""),
+            heading=require_qml_safe_string(
+                grp_data.get("heading", ""), "group heading", json_path
+            ),
             showWhen=grp_data.get("showWhen", ""),
             enableWhen=grp_data.get("enableWhen", ""),
+            # headingDescription is a QML expression (e.g. qsTr(...)), emitted raw
             headingDescription=grp_data.get("headingDescription", ""),
             component=grp_data.get("component", ""),
-            sectionName=grp_data.get("sectionName", ""),
-            keywords=parse_keywords(grp_data.get("keywords", [])),
+            sectionName=require_qml_safe_string(
+                grp_data.get("sectionName", ""), "group sectionName", json_path
+            ),
+            keywords=[
+                require_qml_safe_string(kw, "group keyword", json_path)
+                for kw in parse_keywords(grp_data.get("keywords", []))
+            ],
             missing=require_list(grp_data.get("missing", []), "group 'missing'", json_path),
         )
         for ctrl_data in require_list(grp_data.get("controls", []), "group 'controls'", json_path):
             reject_unknown_keys(ctrl_data, _ALLOWED_CONTROL_KEYS, "control", json_path)
             ctrl = ControlDef(
                 setting=ctrl_data.get("setting", ""),
-                label=ctrl_data.get("label", ""),
+                label=require_qml_safe_string(
+                    ctrl_data.get("label", ""), "control label", json_path
+                ),
                 control=ctrl_data.get("control", ""),
                 showWhen=ctrl_data.get("showWhen", ""),
                 enableWhen=ctrl_data.get("enableWhen", ""),
-                placeholder=ctrl_data.get("placeholder", ""),
+                placeholder=require_qml_safe_string(
+                    ctrl_data.get("placeholder", ""), "control placeholder", json_path
+                ),
                 value=ctrl_data.get("value", ""),
                 component=ctrl_data.get("component", ""),
                 properties=require_dict(ctrl_data.get("properties", {}), "control 'properties'", json_path),

--- a/tools/generators/settings_qml/templates/page.qml.j2
+++ b/tools/generators/settings_qml/templates/page.qml.j2
@@ -20,17 +20,6 @@ SettingsPage {
     property {{ b.type }} {{ b.name }}: {{ b.expr }}
 {% endfor %}
 
-{% if section_cases %}
-    function sectionVisible(index) {
-        switch (index) {
-{% for case in section_cases %}
-        case {{ case.idx }}: return {{ case.expr }}
-{% endfor %}
-        default: return true
-        }
-    }
-
-{% endif %}
 {% for group_qml in groups %}
 {{ group_qml }}
 {% if not loop.last %}

--- a/tools/generators/settings_qml/templates/pages_model.qml.j2
+++ b/tools/generators/settings_qml/templates/pages_model.qml.j2
@@ -1,9 +1,26 @@
 import QtQml.Models
+import QtQml
 
 import QGroundControl
 import QGroundControl.Controls
+{% for imp in imports %}
+import {{ imp }}
+{% endfor %}
 
 ListModel {
+{% for entry in entries if not entry.divider and entry.section_bindings %}
+    property QtObject {{ entry.section_state_name }}: QtObject {
+{% for binding in entry.section_bindings %}
+        property {{ binding.type }} {{ binding.name }}: {{ binding.expr }}
+{% endfor %}
+        property var _sectionVisibility: [
+{% for section in entry.sections %}
+            {{ section.visible }}{{ "," if not loop.last else "" }}
+{% endfor %}
+        ]
+    }
+
+{% endfor %}
 {% for entry in entries %}
 
 {% if entry.divider %}
@@ -16,9 +33,22 @@ ListModel {
         nameKey: "{{ entry.name }}"
         url: "{{ entry.url }}"
         iconUrl: "{{ entry.icon }}"
-        sections: '{{ entry.sections_json }}'
-        searchTerms: '{{ entry.search_json }}'
-        translatableTerms: '{{ entry.translatable_json }}'
+        sections: function() {
+            return [
+{% for section in entry.sections %}
+                {
+                    index: {{ section.index }},
+                    name: {{ section.name }},
+                    searchTerms: {{ section.search_terms }},
+{% if entry.section_state_name %}
+                    visible: {{ entry.section_state_name }}._sectionVisibility[{{ loop.index0 }}]
+{% else %}
+                    visible: {{ section.visible }}
+{% endif %}
+                }{{ "," if not loop.last else "" }}
+{% endfor %}
+            ]
+        }
 {% if entry.visible %}
         pageVisible: function() { return {{ entry.visible }} }
 {% else %}

--- a/tools/tests/test_config_qml_generator.py
+++ b/tools/tests/test_config_qml_generator.py
@@ -109,6 +109,64 @@ class TestUnknownKeyRejection:
             load_page_def(_make_page_json(tmp_path, data))
 
 
+class TestQmlUnsafeStringRejection:
+    """Strings embedded in generated QML literals must not contain quote/backslash/newline."""
+
+    @pytest.mark.parametrize("bad_char", ['"', "\\", "\n"])
+    def test_unsafe_section_title_rejected(self, tmp_path: Path, bad_char: str):
+        data = _minimal_page()
+        data["sections"][0]["title"] = f"Bad{bad_char}Title"
+        with pytest.raises(ValueError, match="section title"):
+            load_page_def(_make_page_json(tmp_path, data))
+
+    def test_non_string_repeat_title_rejected(self, tmp_path: Path):
+        # Must raise the validator's ValueError, not a TypeError from the {index} check
+        data = _minimal_page()
+        data["sections"][0]["title"] = 42
+        data["sections"][0]["repeat"] = {"paramPrefix": "BATT", "probePostfix": "_MONITOR"}
+        with pytest.raises(ValueError, match="section title"):
+            load_page_def(_make_page_json(tmp_path, data))
+
+    def test_unsafe_disabled_heading_rejected(self, tmp_path: Path):
+        data = _minimal_page()
+        data["sections"][0]["repeat"] = {
+            "paramPrefix": "BATT",
+            "probePostfix": "_MONITOR",
+            "enableParam": "MONITOR",
+            "disabledParamValue": "0",
+            "disabledSection": {"heading": 'Disabled "Batteries"'},
+        }
+        with pytest.raises(ValueError, match="disabledSection heading"):
+            load_page_def(_make_page_json(tmp_path, data))
+
+    def test_unsafe_control_label_rejected(self, tmp_path: Path):
+        data = _minimal_page()
+        data["sections"][0]["controls"][0]["label"] = 'A "label"'
+        with pytest.raises(ValueError, match="control label"):
+            load_page_def(_make_page_json(tmp_path, data))
+
+    def test_unsafe_keyword_rejected(self, tmp_path: Path):
+        data = _minimal_page()
+        data["sections"][0]["keywords"] = ["esc\\motor"]
+        with pytest.raises(ValueError, match="section keyword"):
+            load_page_def(_make_page_json(tmp_path, data))
+
+    def test_index_placeholder_in_repeat_title_rejected(self, tmp_path: Path):
+        # C++ VehicleComponent::sectionIds() cannot expand {index}, so repeat
+        # titles using it would generate mismatched section IDs
+        data = _minimal_page()
+        data["sections"][0]["title"] = "Battery {index}"
+        data["sections"][0]["repeat"] = {"paramPrefix": "BATT", "probePostfix": "_MONITOR"}
+        with pytest.raises(ValueError, match="index"):
+            load_page_def(_make_page_json(tmp_path, data))
+
+    def test_safe_strings_accepted(self, tmp_path: Path):
+        data = _minimal_page()
+        data["sections"][0]["title"] = "ESC's & Motors (12-inch)"
+        page = load_page_def(_make_page_json(tmp_path, data))
+        assert page.sections[0].title == "ESC's & Motors (12-inch)"
+
+
 class TestRealPageDefinitions:
     """Audit: every VehicleConfig.json in the repo must load under strict validation."""
 

--- a/tools/tests/test_settings_qml_generator.py
+++ b/tools/tests/test_settings_qml_generator.py
@@ -4,6 +4,8 @@ import json
 from pathlib import Path
 
 import pytest
+from generators.common.validation import require_qml_safe_string
+from generators.settings_qml import generate_pages as settings_generator
 from generators.settings_qml.page_generator import (
     ControlDef,
     GroupDef,
@@ -1088,6 +1090,143 @@ class TestGeneratePagesModelQml:
         pages_path.write_text(json.dumps({"version": 1, "pages": "oops"}), encoding="utf-8")
         with pytest.raises(ValueError, match="must be a JSON array"):
             generate_pages_model_qml(pages_path)
+
+
+class TestQmlUnsafeStringRejection:
+    """Strings embedded in generated QML literals must not contain quote/backslash/newline."""
+
+    @pytest.mark.parametrize("bad_value", [["safe"], 123, None, {"a": 1}])
+    def test_non_string_rejected(self, bad_value: object):
+        with pytest.raises(ValueError, match="must be a string"):
+            require_qml_safe_string(bad_value, "test field", "test.json")
+
+    def test_unsafe_section_name_rejected(self, tmp_path: Path):
+        data = {
+            "version": 1,
+            "groups": [
+                {
+                    "heading": "G",
+                    "sectionName": 'Bad "Section"',
+                    "controls": [{"setting": "appSettings.x"}],
+                }
+            ],
+        }
+        with pytest.raises(ValueError, match="group sectionName"):
+            load_page_def(_make_page_json(tmp_path, data))
+
+    def test_unsafe_group_keyword_rejected(self, tmp_path: Path):
+        data = {
+            "version": 1,
+            "groups": [
+                {
+                    "heading": "G",
+                    "keywords": ["map\\layers"],
+                    "controls": [{"setting": "appSettings.x"}],
+                }
+            ],
+        }
+        with pytest.raises(ValueError, match="group keyword"):
+            load_page_def(_make_page_json(tmp_path, data))
+
+    @pytest.mark.parametrize("bad_char", ['"', "\\", "\n"])
+    def test_unsafe_group_heading_rejected(self, tmp_path: Path, bad_char: str):
+        data = {
+            "version": 1,
+            "groups": [{"heading": f"Bad{bad_char}Heading", "controls": [{"setting": "appSettings.x"}]}],
+        }
+        with pytest.raises(ValueError, match="group heading"):
+            load_page_def(_make_page_json(tmp_path, data))
+
+    def test_heading_description_expression_accepted(self, tmp_path: Path):
+        # headingDescription is a QML expression field, emitted raw — quotes allowed
+        data = {
+            "version": 1,
+            "groups": [
+                {
+                    "heading": "G",
+                    "headingDescription": 'qsTr("Has \\"quotes\\"")',
+                    "controls": [{"setting": "appSettings.x"}],
+                }
+            ],
+        }
+        page = load_page_def(_make_page_json(tmp_path, data))
+        assert page.groups[0].headingDescription
+
+    def test_unsafe_control_label_rejected(self, tmp_path: Path):
+        data = {
+            "version": 1,
+            "groups": [
+                {"heading": "G", "controls": [{"setting": "appSettings.x", "label": 'A "label"'}]}
+            ],
+        }
+        with pytest.raises(ValueError, match="control label"):
+            load_page_def(_make_page_json(tmp_path, data))
+
+    def test_unsafe_placeholder_rejected(self, tmp_path: Path):
+        data = {
+            "version": 1,
+            "groups": [
+                {
+                    "heading": "G",
+                    "controls": [{"setting": "appSettings.x", "placeholder": "a\\b"}],
+                }
+            ],
+        }
+        with pytest.raises(ValueError, match="placeholder"):
+            load_page_def(_make_page_json(tmp_path, data))
+
+    @pytest.mark.parametrize("field", ["name", "url", "icon"])
+    def test_unsafe_pages_model_entry_rejected(self, tmp_path: Path, field: str):
+        entry = {"name": "Page", "qml": "P.qml", "icon": "qrc:/i.svg"}
+        entry[field] = f'bad"{field}'
+        pages_json = {"version": 1, "pages": [entry]}
+        p = tmp_path / "SettingsPages.json"
+        p.write_text(json.dumps(pages_json), encoding="utf-8")
+        with pytest.raises(ValueError, match=f"page {field}"):
+            generate_pages_model_qml(p)
+
+    def test_safe_strings_accepted(self, tmp_path: Path):
+        data = {
+            "version": 1,
+            "groups": [
+                {
+                    "heading": "Fly View (What's Shown)",
+                    "controls": [{"setting": "appSettings.x", "label": "UI Scale (%)"}],
+                }
+            ],
+        }
+        page = load_page_def(_make_page_json(tmp_path, data))
+        assert page.groups[0].heading == "Fly View (What's Shown)"
+
+    def test_apostrophe_heading_escaped_in_pages_model(self, tmp_path: Path):
+        # sections is emitted inside a single-quoted QML literal, so apostrophes
+        # in headings must be escaped like the other JSON fields
+        page_def = {
+            "version": 1,
+            "groups": [
+                {
+                    "heading": "Fly View (What's Shown)",
+                    "controls": [{"setting": "appSettings.x"}],
+                }
+            ],
+        }
+        (tmp_path / "Test.SettingsUI.json").write_text(json.dumps(page_def), encoding="utf-8")
+        pages_json = {
+            "version": 1,
+            "pages": [
+                {
+                    "name": "Test",
+                    "qml": "T.qml",
+                    "icon": "qrc:/i.svg",
+                    "pageDefinition": "Test.SettingsUI.json",
+                }
+            ],
+        }
+        p = tmp_path / "SettingsPages.json"
+        p.write_text(json.dumps(pages_json), encoding="utf-8")
+        qml = generate_pages_model_qml(p)
+        assert "What\\'s Shown" in qml
+        assert "What's Shown" not in qml
 
 
 class TestRealPageDefinitions:

--- a/tools/tests/test_settings_qml_generator.py
+++ b/tools/tests/test_settings_qml_generator.py
@@ -970,9 +970,24 @@ class TestGeneratePagesModelQml:
         # Page definition
         page_def = {
             "version": 1,
+            "imports": ["Test.Settings"],
+            "bindings": {
+                "pageVisible": "advancedMode && !unusedBinding",
+                "advancedMode": "QGroundControl.corePlugin.showAdvancedUI",
+                "unusedBinding": "QGroundControl.settingsManager.appSettings.y.userVisible",
+            },
             "groups": [
-                {"heading": "Section A", "controls": [{"setting": "appSettings.x"}]},
+                {
+                    "heading": "Section A",
+                    "showWhen": "pageVisible",
+                    "controls": [{"setting": "appSettings.x"}],
+                },
                 {"heading": "Section B", "controls": [{"setting": "appSettings.y"}]},
+                {
+                    "component": "TestComponent",
+                    "sectionName": "Section C",
+                    "showWhen": "advancedMode",
+                },
             ],
         }
         (pages_dir / "Test.SettingsUI.json").write_text(json.dumps(page_def), encoding="utf-8")
@@ -1025,12 +1040,32 @@ class TestGeneratePagesModelQml:
 
     def test_sections_extracted(self, pages_setup: Path):
         qml = generate_pages_model_qml(pages_setup)
-        assert "Section A" in qml
-        assert "Section B" in qml
+        assert 'name: qsTranslate("Test.SettingsUI.json", "Section A")' in qml
+        assert 'name: qsTranslate("Test.SettingsUI.json", "Section B")' in qml
+
+    def test_section_visibility_generated(self, pages_setup: Path):
+        qml = generate_pages_model_qml(pages_setup)
+        assert "sections: function()" in qml
+        assert "property QtObject _page0SectionState: QtObject" in qml
+        assert "property var advancedMode: QGroundControl.corePlugin.showAdvancedUI" in qml
+        assert "property bool pageVisible: advancedMode && !unusedBinding" in qml
+        assert "property var unusedBinding: QGroundControl.settingsManager.appSettings.y.userVisible" in qml
+        assert "visible: _page0SectionState._sectionVisibility[0]" in qml
+        assert (
+            "(pageVisible) && "
+            "(QGroundControl.settingsManager.appSettings.x.userVisible)" in qml
+        )
+        assert "(QGroundControl.settingsManager.appSettings.y.userVisible)" in qml
+        assert "visible: _page0SectionState._sectionVisibility[2]" in qml
 
     def test_search_terms_present(self, pages_setup: Path):
         qml = generate_pages_model_qml(pages_setup)
-        assert "searchTerms" in qml
+        assert 'searchTerms: ["test page section a"' in qml
+        assert 'qsTranslate("Test.SettingsUI.json", "Section A")' in qml
+
+    def test_page_imports_propagated(self, pages_setup: Path):
+        qml = generate_pages_model_qml(pages_setup)
+        assert "import Test.Settings" in qml
 
     def test_page_visible_default(self, pages_setup: Path):
         qml = generate_pages_model_qml(pages_setup)
@@ -1197,37 +1232,6 @@ class TestQmlUnsafeStringRejection:
         }
         page = load_page_def(_make_page_json(tmp_path, data))
         assert page.groups[0].heading == "Fly View (What's Shown)"
-
-    def test_apostrophe_heading_escaped_in_pages_model(self, tmp_path: Path):
-        # sections is emitted inside a single-quoted QML literal, so apostrophes
-        # in headings must be escaped like the other JSON fields
-        page_def = {
-            "version": 1,
-            "groups": [
-                {
-                    "heading": "Fly View (What's Shown)",
-                    "controls": [{"setting": "appSettings.x"}],
-                }
-            ],
-        }
-        (tmp_path / "Test.SettingsUI.json").write_text(json.dumps(page_def), encoding="utf-8")
-        pages_json = {
-            "version": 1,
-            "pages": [
-                {
-                    "name": "Test",
-                    "qml": "T.qml",
-                    "icon": "qrc:/i.svg",
-                    "pageDefinition": "Test.SettingsUI.json",
-                }
-            ],
-        }
-        p = tmp_path / "SettingsPages.json"
-        p.write_text(json.dumps(pages_json), encoding="utf-8")
-        qml = generate_pages_model_qml(p)
-        assert "What\\'s Shown" in qml
-        assert "What's Shown" not in qml
-
 
 class TestRealPageDefinitions:
     """Test against real QGC page definition files if available."""


### PR DESCRIPTION
Backport of #14959 and #14991 to Stable_V5.1, plus their prerequisite #14943 (all commits cherry-picked with -x).

## Included PRs

- #14943 — fix: blank vehicle config pages in non-English locales (6 commits; prerequisite — #14959/#14991 conflict without it, and it is a user-facing locale bugfix in its own right. Its final translation commit was already on stable.)
- #14959 — fix(AppSettings): hide unavailable sections
- #14991 — fix(AppSettings): normalize section selection when page collapses to one section

## Testing

- macOS Debug build succeeds
- Settings/config generator pytests: 148 passed
- `TopLevelViewsTest`, `PX4VehicleConfigUITest`, `APMVehicleConfigUITest`: passed
- `AppSettingsTest`: passed
