### PR TITLE
fix(PlanView): Land tool showed Land/Alt Land but inserted RTL for rover (Stable_V5.1)

### DIFF
--- a/src/MissionManager/MissionController.cc
+++ b/src/MissionManager/MissionController.cc
@@ -346,9 +346,10 @@ VisualMissionItem* MissionController::insertTakeoffItem(QGeoCoordinate /*coordin
 }
 
 bool MissionController::multipleLandPatternsAllowed(void) const {
-    // Can't have more than one land sequence unless allowed in settings and
-    // supported by the firmware
-    return _planViewSettings->allowMultipleLandingPatterns()
+    // Multiple landing sequences are a fixed-wing/VTOL landing pattern concept.
+    // Other vehicle types insert RTL, which only makes sense once per mission.
+    return (_controllerVehicle->fixedWing() || _controllerVehicle->vtol()) &&
+           _planViewSettings->allowMultipleLandingPatterns()
                ->rawValue().toBool() &&
            !_masterController->managerVehicle()->px4Firmware();
 }
@@ -362,7 +363,7 @@ VisualMissionItem* MissionController::insertLandItem(QGeoCoordinate coordinate, 
         VTOLLandingComplexItem* vtolLanding = qobject_cast<VTOLLandingComplexItem*>(insertComplexMissionItem(VTOLLandingComplexItem::canonicalName, coordinate, visualItemIndex, makeCurrentItem));
         return vtolLanding;
     } else {
-        return _insertSimpleMissionItemWorker(coordinate, _controllerVehicle->vtol() ? MAV_CMD_NAV_VTOL_LAND : MAV_CMD_NAV_RETURN_TO_LAUNCH, visualItemIndex, makeCurrentItem);
+        return _insertSimpleMissionItemWorker(coordinate, MAV_CMD_NAV_RETURN_TO_LAUNCH, visualItemIndex, makeCurrentItem);
     }
 }
 

--- a/src/PlanView/PlanView.qml
+++ b/src/PlanView/PlanView.qml
@@ -199,6 +199,17 @@ Item {
         _missionController.insertLandItem(mapCenter(), nextIndex, true /* makeCurrentItem */)
     }
 
+    function _landButtonText() {
+        // Must mirror MissionController::insertLandItem: only fixed-wing/VTOL get landing patterns
+        if (!_planMasterController.controllerVehicle.fixedWing && !_planMasterController.controllerVehicle.vtol) {
+            return qsTr("Return")
+        }
+        if (_missionController.isInsertLandValid && _missionController.hasLandItem) {
+            return qsTr("Alt Land")
+        }
+        return qsTr("Land")
+    }
+
     QGCFileDialog {
         id: fileDialog
         folder: _appSettings ? _appSettings.missionSavePath : ""
@@ -496,11 +507,7 @@ Item {
                     },
                     ToolStripAction {
                         objectName: "planToolStrip_landButton"
-                        text: _planMasterController.controllerVehicle.multiRotor
-                                    ? qsTr("Return")
-                                    : _missionController.isInsertLandValid && _missionController.hasLandItem
-                                      ? qsTr("Alt Land")
-                                      : qsTr("Land")
+                        text: _landButtonText()
                         iconSource: "/res/rtl.svg"
                         enabled: _missionController.isInsertLandValid
                         visible: toolStrip._isMissionLayer

--- a/test/MissionManager/MissionControllerTest.cc
+++ b/test/MissionManager/MissionControllerTest.cc
@@ -18,6 +18,7 @@
 #include "MultiSignalSpy.h"
 
 #include <QtCore/QRegularExpression>
+#include <QtCore/QScopeGuard>
 #include <QtCore/QTemporaryDir>
 using namespace TestFixtures;
 
@@ -132,6 +133,54 @@ void MissionControllerTest::_testInsertValidityHomePositionGating()
     QCOMPARE(boolProperty("isInsertLandValid"), true);
     QCOMPARE(boolProperty("isInsertROIValid"), true);
     QCOMPARE(boolProperty("flyThroughCommandsAllowed"), true);
+}
+
+void MissionControllerTest::_testLandToolInsertsSingleRtl_data()
+{
+    QTest::addColumn<int>("vehicleClass");
+
+    QTest::newRow("RoverBoat") << static_cast<int>(QGCMAVLink::VehicleClassRoverBoat);
+    QTest::newRow("MultiRotor") << static_cast<int>(QGCMAVLink::VehicleClassMultiRotor);
+}
+
+void MissionControllerTest::_testLandToolInsertsSingleRtl()
+{
+    // Multiple landing patterns are a fixed-wing/VTOL concept. For other vehicle types the
+    // Land tool inserts RTL and must not offer a second insert once the plan has one.
+    // Offline planning (no connected vehicle) matches the report in issue #14957.
+    QFETCH(int, vehicleClass);
+
+    AppSettings* appSettings = SettingsManager::instance()->appSettings();
+    appSettings->offlineEditingFirmwareClass()->setRawValue(QGCMAVLink::firmwareClass(MAV_AUTOPILOT_ARDUPILOTMEGA));
+    appSettings->offlineEditingVehicleClass()->setRawValue(vehicleClass);
+    Fact* const allowMultipleLandingPatterns = SettingsManager::instance()->planViewSettings()->allowMultipleLandingPatterns();
+    const QVariant savedAllowMultiple = allowMultipleLandingPatterns->rawValue();
+    const auto restoreGuard = qScopeGuard([allowMultipleLandingPatterns, savedAllowMultiple] { allowMultipleLandingPatterns->setRawValue(savedAllowMultiple); });
+    allowMultipleLandingPatterns->setRawValue(true);
+
+    _masterController = std::make_unique<PlanMasterController>();
+    _masterController->setFlyView(false);
+    _missionController = _masterController->missionController();
+    MultiSignalSpy missionControllerSpy;
+    QVERIFY(missionControllerSpy.init(_missionController));
+    _masterController->start();
+    QVERIFY(missionControllerSpy.waitForSignal("visualItemsReset", TestTimeout::mediumMs()));
+
+    _missionController->setHomePosition(Coord::zurich());
+
+    // Vehicles which support a takeoff command only allow takeoff insert on an empty plan
+    if (!_missionController->property("isInsertLandValid").toBool()) {
+        QVERIFY(_missionController->insertTakeoffItem(Coord::zurich(), 1, true /* makeCurrentItem */));
+    }
+    QCOMPARE(_missionController->property("isInsertLandValid").toBool(), true);
+
+    VisualMissionItem* landItem = _missionController->insertLandItem(Coord::zurich(), -1, true /* makeCurrentItem */);
+    SimpleMissionItem* simpleItem = qobject_cast<SimpleMissionItem*>(landItem);
+    QVERIFY(simpleItem);
+    QCOMPARE(simpleItem->mavCommand(), MAV_CMD_NAV_RETURN_TO_LAUNCH);
+
+    QCOMPARE(_missionController->property("hasLandItem").toBool(), true);
+    QCOMPARE(_missionController->property("isInsertLandValid").toBool(), false);
 }
 
 void MissionControllerTest::_testGimbalRecalc()

--- a/test/MissionManager/MissionControllerTest.h
+++ b/test/MissionManager/MissionControllerTest.h
@@ -33,6 +33,8 @@ private slots:
     void _testInsertNonSurveyComplexItemMixedModeNoCrash();
     void _testInsertComplexItemFromKML();
     void _testInsertValidityHomePositionGating();
+    void _testLandToolInsertsSingleRtl_data();
+    void _testLandToolInsertsSingleRtl();
 
     // Parameterized tests - runs once per autopilot type
     UT_PARAMETERIZED_TEST(_testEmptyVehicle);

--- a/test/QmlUITests/PlanViewUITest.cc
+++ b/test/QmlUITests/PlanViewUITest.cc
@@ -132,6 +132,10 @@ void PlanViewUITest::_testRoverWaypointOnEmptyPlan()
     SettingsManager::instance()->appSettings()->offlineEditingVehicleClass()->setRawValue(QGCMAVLink::VehicleClassRoverBoat);
 
     _verifyWaypointToolAddsWaypointOnEmptyPlan(false /* expectTakeoffButtonVisible */);
+    if (QTest::currentTestFailed()) return;
+
+    // Rover Land tool inserts RTL, so the label must read Return (issue #14957)
+    verifyText(QStringLiteral("planToolStrip_landButton"), QStringLiteral("Return"), QStringLiteral("rover land tool"));
 }
 
 void PlanViewUITest::_testTakeoffNotRequiredWaypointOnEmptyPlan()


### PR DESCRIPTION
Stable_V5.1 backport of #15000 (clean cherry-pick of 980bdc992).

Fixes the Plan View Land tool for rover/boat (and other non-fixed-wing/VTOL vehicles): the tool showed "Land"/"Alt Land" but actually inserted an RTL item (#14957).

- PlanView.qml: label the tool "Return" when it inserts RTL (mirrors `MissionController::insertLandItem`)
- MissionController: restrict multiple landing patterns to fixed-wing/VTOL
- Tests: new MissionControllerTest rows (RoverBoat + MultiRotor) asserting single-RTL insertion, plus PlanViewUITest assertion that the rover land button reads "Return"

MissionControllerTest and PlanViewUITest pass on this branch.
