### PR TITLE
fix(cmake): isolate patched CPM source caches

### DIFF
--- a/.cmake-format.yaml
+++ b/.cmake-format.yaml
@@ -67,6 +67,7 @@ parse:
         GIT_SHALLOW: 1
         EXCLUDE_FROM_ALL: 1
         SOURCE_SUBDIR: 1
+        CUSTOM_CACHE_KEY: 1
         URL: 1
         URL_HASH: 1
         URL_MD5: 1

--- a/.github/scripts/tests/test_cpm_patch_cache_contract.py
+++ b/.github/scripts/tests/test_cpm_patch_cache_contract.py
@@ -1,0 +1,93 @@
+"""Contracts for CPM source caches derived from external patch contents."""
+
+from __future__ import annotations
+
+import subprocess
+from typing import TYPE_CHECKING
+
+from _helpers import REPO_ROOT
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+
+MODULE_PATH = REPO_ROOT / "cmake/modules/CPMPatchCache.cmake"
+
+
+def _cache_key(
+    tmp_path: Path,
+    patch_contents: str,
+    *,
+    git_repository: str = "https://example.invalid/dependency.git",
+    git_tag: str = "0123456789abcdef",
+) -> str:
+    patch_path = tmp_path / "dependency.patch"
+    result_path = tmp_path / "cache-key.txt"
+    script_path = tmp_path / "cache-key-contract.cmake"
+    patch_path.write_text(patch_contents, encoding="utf-8")
+    script_path.write_text(
+        f'include("{MODULE_PATH.as_posix()}")\n'
+        "qgc_cpm_patch_cache_key(\n"
+        "    cache_key\n"
+        f'    GIT_REPOSITORY "{git_repository}"\n'
+        f'    GIT_TAG "{git_tag}"\n'
+        f'    PATCHES "{patch_path.as_posix()}"\n'
+        ")\n"
+        f'file(WRITE "{result_path.as_posix()}" "${{cache_key}}")\n',
+        encoding="utf-8",
+    )
+
+    subprocess.run(["cmake", "-P", str(script_path)], check=True, capture_output=True, text=True)
+    return result_path.read_text(encoding="utf-8")
+
+
+def test_patch_contents_are_part_of_cpm_cache_key(tmp_path: Path) -> None:
+    initial_key = _cache_key(tmp_path, "first patch contents\n")
+
+    assert len(initial_key) == 64
+    assert set(initial_key) <= set("0123456789abcdef")
+    assert initial_key == _cache_key(tmp_path, "first patch contents\n")
+    assert initial_key != _cache_key(tmp_path, "different patch contents\n")
+    assert initial_key != _cache_key(tmp_path, "first patch contents\n", git_tag="fedcba9876543210")
+    assert initial_key != _cache_key(
+        tmp_path,
+        "first patch contents\n",
+        git_repository="https://example.invalid/other-dependency.git",
+    )
+
+
+def test_patch_change_triggers_cmake_reconfigure(tmp_path: Path) -> None:
+    source_path = tmp_path / "source"
+    build_path = tmp_path / "build"
+    patch_path = source_path / "dependency.patch"
+    result_path = build_path / "cache-key.txt"
+    source_path.mkdir()
+    patch_path.write_text("first patch contents\n", encoding="utf-8")
+    (source_path / "CMakeLists.txt").write_text(
+        "cmake_minimum_required(VERSION 3.25)\n"
+        "project(cache_key_contract NONE)\n"
+        f'include("{MODULE_PATH.as_posix()}")\n'
+        "qgc_cpm_patch_cache_key(\n"
+        "    cache_key\n"
+        '    GIT_REPOSITORY "https://example.invalid/dependency.git"\n'
+        '    GIT_TAG "0123456789abcdef"\n'
+        '    PATCHES "${CMAKE_CURRENT_SOURCE_DIR}/dependency.patch"\n'
+        ")\n"
+        'file(WRITE "${CMAKE_BINARY_DIR}/cache-key.txt" "${cache_key}")\n',
+        encoding="utf-8",
+    )
+
+    subprocess.run(
+        ["cmake", "-S", str(source_path), "-B", str(build_path)],
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+    initial_key = result_path.read_text(encoding="utf-8")
+
+    patch_path.write_text("different patch contents\n", encoding="utf-8")
+    subprocess.run(
+        ["cmake", "--build", str(build_path)], check=True, capture_output=True, text=True
+    )
+
+    assert result_path.read_text(encoding="utf-8") != initial_key

--- a/.github/workflows/ci-scripts.yml
+++ b/.github/workflows/ci-scripts.yml
@@ -10,6 +10,7 @@ on:
       - '.vscode/*.default.json'
       - 'CMakePresets.json'
       - 'cmake/Helpers.cmake'
+      - 'cmake/modules/CPMPatchCache.cmake'
       - 'cmake/presets/**'
       - 'justfile'
       - 'tools/setup/**'
@@ -34,6 +35,7 @@ on:
       - '.vscode/*.default.json'
       - 'CMakePresets.json'
       - 'cmake/Helpers.cmake'
+      - 'cmake/modules/CPMPatchCache.cmake'
       - 'cmake/presets/**'
       - 'justfile'
       - 'tools/setup/**'
@@ -139,6 +141,7 @@ jobs:
             cmake/CustomOptions.cmake
             cmake/modules/Hardening.cmake
             cmake/modules/LinuxDistro.cmake
+            cmake/modules/CPMPatchCache.cmake
             cmake/modules/PythonVenv.cmake
             cmake/Helpers.cmake
             cmake/Toolchain.cmake

--- a/cmake/modules/CPMPatchCache.cmake
+++ b/cmake/modules/CPMPatchCache.cmake
@@ -1,0 +1,49 @@
+include_guard(GLOBAL)
+
+# Derive a deterministic CPM source-cache key from a Git origin and patch contents.
+function(qgc_cpm_patch_cache_key output_variable)
+    if(NOT "${output_variable}" MATCHES "^[A-Za-z_][A-Za-z0-9_]*$")
+        message(FATAL_ERROR "qgc_cpm_patch_cache_key: output variable name is required")
+    endif()
+
+    cmake_parse_arguments(PARSE_ARGV 1 ARG "" "GIT_REPOSITORY;GIT_TAG" "PATCHES")
+    if(ARG_KEYWORDS_MISSING_VALUES)
+        message(FATAL_ERROR "qgc_cpm_patch_cache_key: missing values for: ${ARG_KEYWORDS_MISSING_VALUES}")
+    endif()
+    if(ARG_UNPARSED_ARGUMENTS)
+        message(FATAL_ERROR "qgc_cpm_patch_cache_key: unknown arguments: ${ARG_UNPARSED_ARGUMENTS}")
+    endif()
+
+    foreach(required GIT_REPOSITORY GIT_TAG)
+        if(NOT DEFINED ARG_${required} OR "${ARG_${required}}" STREQUAL "")
+            message(FATAL_ERROR "qgc_cpm_patch_cache_key: ${required} is required")
+        endif()
+    endforeach()
+    if(NOT ARG_PATCHES)
+        message(FATAL_ERROR "qgc_cpm_patch_cache_key: at least one patch is required")
+    endif()
+
+    set(key_material "repository=${ARG_GIT_REPOSITORY}\ntag=${ARG_GIT_TAG}")
+    foreach(patch IN LISTS ARG_PATCHES)
+        get_filename_component(patch_path "${patch}" ABSOLUTE BASE_DIR "${CMAKE_CURRENT_SOURCE_DIR}")
+        if(NOT EXISTS "${patch_path}" OR IS_DIRECTORY "${patch_path}")
+            message(FATAL_ERROR "qgc_cpm_patch_cache_key: patch does not exist: ${patch_path}")
+        endif()
+
+        if(NOT CMAKE_SCRIPT_MODE_FILE)
+            set_property(
+                DIRECTORY
+                APPEND
+                PROPERTY CMAKE_CONFIGURE_DEPENDS "${patch_path}"
+            )
+        endif()
+        file(SHA256 "${patch_path}" patch_sha256)
+        string(APPEND key_material "\npatch=${patch_sha256}")
+    endforeach()
+
+    string(SHA256 cache_key "${key_material}")
+    set(${output_variable}
+        "${cache_key}"
+        PARENT_SCOPE
+    )
+endfunction()

--- a/src/MAVLink/CMakeLists.txt
+++ b/src/MAVLink/CMakeLists.txt
@@ -30,15 +30,27 @@ target_include_directories(${CMAKE_PROJECT_NAME} PRIVATE ${CMAKE_CURRENT_SOURCE_
 
 message(STATUS "QGC: Building MAVLink")
 
+include(CPMPatchCache)
+
+set(_mavlink_patch "${CMAKE_CURRENT_LIST_DIR}/mavlink-deterministic-mavgen.patch")
+qgc_cpm_patch_cache_key(
+    _mavlink_cache_key
+    GIT_REPOSITORY "${QGC_MAVLINK_GIT_REPO}"
+    GIT_TAG "${QGC_MAVLINK_GIT_TAG}"
+    PATCHES "${_mavlink_patch}"
+)
+
 CPMAddPackage(
     NAME mavlink
     GIT_REPOSITORY ${QGC_MAVLINK_GIT_REPO}
     GIT_TAG ${QGC_MAVLINK_GIT_TAG}
+    # CPM's default source-cache key does not hash PATCHES file contents.
+    CUSTOM_CACHE_KEY "${_mavlink_cache_key}"
     OPTIONS
         "MAVLINK_DIALECT ${QGC_MAVLINK_DIALECT}"
         "MAVLINK_VERSION ${QGC_MAVLINK_VERSION}"
     # Retry upstream's build-time pip install and make mavgen hashes deterministic.
-    PATCHES mavlink-deterministic-mavgen.patch
+    PATCHES "${_mavlink_patch}"
 )
 
 qgc_require_cpm_added(mavlink)


### PR DESCRIPTION
## Summary

- derive a custom CPM cache key from the MAVLink Git repository, pinned tag, and SHA-256 digest of every applied patch
- use the same absolute patch path for cache-key calculation and `CPMAddPackage`
- add regression coverage proving that patch, tag, and repository changes produce distinct keys
- route the helper into the CI script sparse checkout and register `CUSTOM_CACHE_KEY` with cmake-format

## Why

CPM 0.42.3 hashes the generated patch command/path for its default source-cache key, but not the patch file contents. `master` and `Stable_V5.1` currently use the same MAVLink repository, tag, and patch path with different patch contents, so switching branches can reuse a source tree patched by the other branch.

The content-derived custom key gives each patched source state a distinct cache directory while preserving deterministic reuse when the inputs are unchanged.

Fixes #14972

## Validation

- `just configure` (MAVLink resolved from the new 64-character content-derived cache directory)
- `just build`
- `uv run --project tools --extra scripts --extra test pytest -q tools/tests .github/scripts/tests` (`1103 passed`)
- focused pre-commit hooks for the new helper, regression test, CI workflow, and formatter configuration
- `just test`: 332/334 passed; the two failures were host-dependent Bluetooth tests reacting to a powered-off adapter and strict unexpected-log checks