### PR TITLE
feat(FactSystem): update Facts on unit changes

### DIFF
--- a/src/FactSystem/Fact.cc
+++ b/src/FactSystem/Fact.cc
@@ -740,10 +740,22 @@ QString Fact::group() const
 
 void Fact::setMetaData(FactMetaData *metaData, bool setDefaultFromMetaData)
 {
+    if (_metaData) {
+        disconnect(_metaData, &FactMetaData::appSettingsUnitsChanged, this, &Fact::_appSettingsUnitsChanged);
+    }
     _metaData = metaData;
+    if (_metaData) {
+        connect(_metaData, &FactMetaData::appSettingsUnitsChanged, this, &Fact::_appSettingsUnitsChanged);
+    }
     if (setDefaultFromMetaData && metaData->defaultValueAvailable()) {
         setRawValue(rawDefaultValue());
     }
+    emit valueChanged(cookedValue());
+}
+
+void Fact::_appSettingsUnitsChanged()
+{
+    emit cookedValuesChanged();
     emit valueChanged(cookedValue());
 }
 

--- a/src/FactSystem/Fact.h
+++ b/src/FactSystem/Fact.h
@@ -24,8 +24,8 @@ class Fact : public QObject
     Q_PROPERTY(QStringList  selectedBitmaskStrings  READ selectedBitmaskStrings                                 NOTIFY valueChanged)
     Q_PROPERTY(int          decimalPlaces           READ decimalPlaces                                          CONSTANT)
     Q_PROPERTY(int          maxStringLength         READ maxStringLength                                        CONSTANT)
-    Q_PROPERTY(QVariant     defaultValue            READ cookedDefaultValue                                     CONSTANT)
-    Q_PROPERTY(QString      defaultValueString      READ cookedDefaultValueString                               CONSTANT)
+    Q_PROPERTY(QVariant     defaultValue            READ cookedDefaultValue                                     NOTIFY cookedValuesChanged)
+    Q_PROPERTY(QString      defaultValueString      READ cookedDefaultValueString                               NOTIFY cookedValuesChanged)
     Q_PROPERTY(bool         defaultValueAvailable   READ defaultValueAvailable                                  CONSTANT)
     Q_PROPERTY(int          enumIndex               READ enumIndex                  WRITE setEnumIndex          NOTIFY valueChanged)
     Q_PROPERTY(QStringList  enumStrings             READ enumStrings                                            NOTIFY enumsChanged)
@@ -34,29 +34,29 @@ class Fact : public QObject
     Q_PROPERTY(QString      category                READ category                                               CONSTANT)
     Q_PROPERTY(QString      group                   READ group                                                  CONSTANT)
     Q_PROPERTY(QString      longDescription         READ longDescription                                        CONSTANT)
-    Q_PROPERTY(QVariant     max                     READ cookedMax                                              CONSTANT)
-    Q_PROPERTY(QString      maxString               READ cookedMaxString                                        CONSTANT)
+    Q_PROPERTY(QVariant     max                     READ cookedMax                                              NOTIFY cookedValuesChanged)
+    Q_PROPERTY(QString      maxString               READ cookedMaxString                                        NOTIFY cookedValuesChanged)
     Q_PROPERTY(bool         maxIsDefaultForType     READ maxIsDefaultForType                                    CONSTANT)
-    Q_PROPERTY(QVariant     min                     READ cookedMin                                              CONSTANT)
-    Q_PROPERTY(QString      minString               READ cookedMinString                                        CONSTANT)
+    Q_PROPERTY(QVariant     min                     READ cookedMin                                              NOTIFY cookedValuesChanged)
+    Q_PROPERTY(QString      minString               READ cookedMinString                                        NOTIFY cookedValuesChanged)
     Q_PROPERTY(bool         minIsDefaultForType     READ minIsDefaultForType                                    CONSTANT)
-    Q_PROPERTY(QVariant     userMin                 READ cookedUserMin                                          CONSTANT)
-    Q_PROPERTY(QString      userMinString           READ cookedUserMinString                                    CONSTANT)
-    Q_PROPERTY(QVariant     userMax                 READ cookedUserMax                                          CONSTANT)
-    Q_PROPERTY(QString      userMaxString           READ cookedUserMaxString                                    CONSTANT)
+    Q_PROPERTY(QVariant     userMin                 READ cookedUserMin                                          NOTIFY cookedValuesChanged)
+    Q_PROPERTY(QString      userMinString           READ cookedUserMinString                                    NOTIFY cookedValuesChanged)
+    Q_PROPERTY(QVariant     userMax                 READ cookedUserMax                                          NOTIFY cookedValuesChanged)
+    Q_PROPERTY(QString      userMaxString           READ cookedUserMaxString                                    NOTIFY cookedValuesChanged)
     Q_PROPERTY(QString      name                    READ name                                                   CONSTANT)
     Q_PROPERTY(bool         vehicleRebootRequired   READ vehicleRebootRequired                                  CONSTANT)
     Q_PROPERTY(bool         qgcRebootRequired       READ qgcRebootRequired                                      CONSTANT)
     Q_PROPERTY(QString      shortDescription        READ shortDescription                                       CONSTANT)
     Q_PROPERTY(QString      label                   READ label                                                  CONSTANT)
-    Q_PROPERTY(QString      units                   READ cookedUnits                                            CONSTANT)
+    Q_PROPERTY(QString      units                   READ cookedUnits                                            NOTIFY cookedValuesChanged)
     Q_PROPERTY(QVariant     value                   READ cookedValue                WRITE setCookedValue        NOTIFY valueChanged)
     Q_PROPERTY(QVariant     rawValue                READ rawValue                   WRITE setRawValue           NOTIFY rawValueChanged)
     Q_PROPERTY(bool         valueEqualsDefault      READ valueEqualsDefault                                     NOTIFY valueChanged)
     Q_PROPERTY(QString      invalidValueString      READ invalidValueString                                     CONSTANT)
     Q_PROPERTY(QString      valueString             READ cookedValueString                                      NOTIFY valueChanged)
     Q_PROPERTY(QString      enumOrValueString       READ enumOrValueString                                      NOTIFY valueChanged)
-    Q_PROPERTY(double       increment               READ cookedIncrement                                        CONSTANT)
+    Q_PROPERTY(double       increment               READ cookedIncrement                                        NOTIFY cookedValuesChanged)
     Q_PROPERTY(bool         typeIsString            READ typeIsString                                           CONSTANT)
     Q_PROPERTY(bool         typeIsBool              READ typeIsBool                                             CONSTANT)
     Q_PROPERTY(bool         hasControl              READ hasControl                                             CONSTANT)
@@ -188,6 +188,7 @@ public:
 signals:
     void bitmaskStringsChanged();
     void bitmaskValuesChanged();
+    void cookedValuesChanged();
     void enumsChanged();
     void sendValueChangedSignalsChanged(bool sendValueChangedSignals);
 
@@ -218,6 +219,7 @@ protected:
     static constexpr const char *kMissingMetadata = "Meta data pointer missing";
 
 private slots:
+    void _appSettingsUnitsChanged();
     void _checkForRebootMessaging();
 
 private:

--- a/src/FactSystem/FactMetaData.cc
+++ b/src/FactSystem/FactMetaData.cc
@@ -1,4 +1,5 @@
 #include "FactMetaData.h"
+#include "Fact.h"
 #include "JsonParsing.h"
 #include "MAVLinkLib.h"
 #include "QGCLoggingCategory.h"
@@ -861,6 +862,7 @@ QVariant FactMetaData::_gramsToPunds(const QVariant &g)
 
 void FactMetaData::setRawUnits(const QString &rawUnits)
 {
+    disconnect(_appSettingsUnitsConnection);
     _rawUnits = rawUnits;
     _cookedUnits = rawUnits;
 
@@ -930,34 +932,35 @@ void FactMetaData::_setAppSettingsTranslators()
             }
 
             UnitsSettings *const settings = SettingsManager::instance()->unitsSettings();
-            uint settingsUnits = 0;
+            Fact *settingsFact = nullptr;
 
             switch (pAppSettingsTranslation->unitType) {
             case UnitHorizontalDistance:
-                settingsUnits = settings->horizontalDistanceUnits()->rawValue().toUInt();
+                settingsFact = settings->horizontalDistanceUnits();
                 break;
             case UnitVerticalDistance:
-                settingsUnits = settings->verticalDistanceUnits()->rawValue().toUInt();
+                settingsFact = settings->verticalDistanceUnits();
                 break;
             case UnitSpeed:
-                settingsUnits = settings->speedUnits()->rawValue().toUInt();
+                settingsFact = settings->speedUnits();
                 break;
             case UnitArea:
-                settingsUnits = settings->areaUnits()->rawValue().toUInt();
+                settingsFact = settings->areaUnits();
                 break;
             case UnitTemperature:
-                settingsUnits = settings->temperatureUnits()->rawValue().toUInt();
+                settingsFact = settings->temperatureUnits();
                 break;
             case UnitWeight:
-                settingsUnits = settings->weightUnits()->rawValue().toUInt();
+                settingsFact = settings->weightUnits();
                 break;
             default:
                 break;
             }
 
-            if (settingsUnits == pAppSettingsTranslation->unitOption) {
+            if (settingsFact && (settingsFact->rawValue().toUInt() == pAppSettingsTranslation->unitOption)) {
                 _cookedUnits = pAppSettingsTranslation->cookedUnits;
                 setTranslators(pAppSettingsTranslation->rawTranslator, pAppSettingsTranslation->cookedTranslator);
+                _appSettingsUnitsConnection = connect(settingsFact, &Fact::rawValueChanged, this, &FactMetaData::_appSettingsUnitsChanged);
                 return;
             }
         }
@@ -968,6 +971,13 @@ void FactMetaData::_setAppSettingsTranslators()
     if (_cookedUnits.compare(QStringLiteral("vertical m"), Qt::CaseInsensitive) == 0) {
         _cookedUnits = QStringLiteral("m");
     }
+}
+
+void FactMetaData::_appSettingsUnitsChanged()
+{
+    disconnect(_appSettingsUnitsConnection);
+    setBuiltInTranslator();
+    emit appSettingsUnitsChanged();
 }
 
 const FactMetaData::AppSettingsTranslation_s* FactMetaData::_findAppSettingsUnitsTranslation(const QString &rawUnits, UnitTypes type)

--- a/src/FactSystem/FactMetaData.h
+++ b/src/FactSystem/FactMetaData.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <QtCore/QHash>
+#include <QtCore/QMetaObject>
 #include <QtCore/QObject>
 #include <QtCore/QString>
 #include <QtCore/QVariant>
@@ -242,11 +243,15 @@ public:
     static constexpr const char *kDefaultGroup = QT_TRANSLATE_NOOP("FactMetaData", "Misc");
     static constexpr const char *qgcFileType = "FactMetaData";
 
+signals:
+    void appSettingsUnitsChanged();
+
 private:
     QVariant _minForType() const { return minForType(_type); };
     QVariant _maxForType() const { return maxForType(_type); };
     /// Set translators according to app settings
     void _setAppSettingsTranslators();
+    void _appSettingsUnitsChanged();
 
     /// Clamp a value to be within cookedMin and cookedMax
     template<class T>
@@ -361,6 +366,7 @@ private:
     QString _cookedUnits;
     Translator _rawTranslator = _defaultTranslator;
     Translator _cookedTranslator = _defaultTranslator;
+    QMetaObject::Connection _appSettingsUnitsConnection;
     bool _vehicleRebootRequired = false;
     bool _qgcRebootRequired = false;
     double _rawIncrement = std::numeric_limits<double>::quiet_NaN();

--- a/src/Settings/UnitsSettings.cc
+++ b/src/Settings/UnitsSettings.cc
@@ -30,7 +30,6 @@ DECLARE_SETTINGSFACT_NO_FUNC(UnitsSettings, horizontalDistanceUnits)
                 break;
         }
         metaData->setRawDefaultValue(defaultHorizontalDistanceUnit);
-        metaData->setQGCRebootRequired(true);
         _horizontalDistanceUnitsFact = new SettingsFact(_settingsGroup, metaData, this);
     }
     return _horizontalDistanceUnitsFact;
@@ -61,7 +60,6 @@ DECLARE_SETTINGSFACT_NO_FUNC(UnitsSettings, verticalDistanceUnits)
                 break;
         }
         metaData->setRawDefaultValue(defaultVerticalAltitudeUnit);
-        metaData->setQGCRebootRequired(true);
         _verticalDistanceUnitsFact = new SettingsFact(_settingsGroup, metaData, this);
     }
     return _verticalDistanceUnitsFact;
@@ -98,7 +96,6 @@ DECLARE_SETTINGSFACT_NO_FUNC(UnitsSettings, areaUnits)
                 break;
         }
         metaData->setRawDefaultValue(defaultAreaUnit);
-        metaData->setQGCRebootRequired(true);
         _areaUnitsFact = new SettingsFact(_settingsGroup, metaData, this);
     }
     return _areaUnitsFact;
@@ -134,7 +131,6 @@ DECLARE_SETTINGSFACT_NO_FUNC(UnitsSettings, speedUnits)
                 break;
         }
         metaData->setRawDefaultValue(defaultSpeedUnit);
-        metaData->setQGCRebootRequired(true);
         _speedUnitsFact = new SettingsFact(_settingsGroup, metaData, this);
     }
     return _speedUnitsFact;
@@ -165,7 +161,6 @@ DECLARE_SETTINGSFACT_NO_FUNC(UnitsSettings, temperatureUnits)
                 break;
         }
         metaData->setRawDefaultValue(defaultTemperatureUnit);
-        metaData->setQGCRebootRequired(true);
         _temperatureUnitsFact = new SettingsFact(_settingsGroup, metaData, this);
     }
     return _temperatureUnitsFact;
@@ -199,7 +194,6 @@ DECLARE_SETTINGSFACT_NO_FUNC(UnitsSettings, weightUnits)
                 break;
         }
         metaData->setRawDefaultValue(defaultWeightUnit);
-        metaData->setQGCRebootRequired(true);
         _weightUnitsFact = new SettingsFact(_settingsGroup, metaData, this);
     }
     return _weightUnitsFact;

--- a/test/FactSystem/FactMetaDataTest.cc
+++ b/test/FactSystem/FactMetaDataTest.cc
@@ -358,11 +358,6 @@ void FactMetaDataTest::_verticalMetersUnitsFeetTranslation_test()
     const auto restoreUnits = qScopeGuard([vertUnitsFact, savedUnits] {
         vertUnitsFact->setRawValue(savedUnits);
     });
-    // Changing units is a qgcRebootRequired setting, so the restart-app message
-    // fires — but only when the locale-dependent default isn't already feet, so
-    // it cannot be asserted deterministically with expectAppMessage()
-    ignoreLogMessage("API.QGCApplication.AppMessage", QtDebugMsg,
-                     QRegularExpression(QStringLiteral("Restart application for changes to take effect")));
     vertUnitsFact->setRawValue(UnitsSettings::VerticalDistanceUnitsFeet);
 
     FactMetaData meta(FactMetaData::valueTypeDouble);

--- a/test/FactSystem/FactTest.cc
+++ b/test/FactSystem/FactTest.cc
@@ -5,6 +5,8 @@
 
 #include "Fact.h"
 #include "FactMetaData.h"
+#include "SettingsManager.h"
+#include "UnitsSettings.h"
 
 void FactTest::_constructWithTypeAndName_test()
 {
@@ -107,6 +109,38 @@ void FactTest::_rawToCooked_test()
     // Default identity translator - value passes through unchanged
     Fact plainFact(0, "PlainParam", FactMetaData::valueTypeDouble);
     QCOMPARE(plainFact.rawToCooked(QVariant(42.0)).toDouble(), 42.0);
+}
+
+void FactTest::_appSettingsUnitsChanged_test()
+{
+    Fact *const verticalUnitsFact = SettingsManager::instance()->unitsSettings()->verticalDistanceUnits();
+    const QVariant savedUnits = verticalUnitsFact->rawValue();
+    const auto restoreUnits = qScopeGuard([verticalUnitsFact, savedUnits] {
+        verticalUnitsFact->setRawValue(savedUnits);
+    });
+
+    Fact fact(0, "Altitude", FactMetaData::valueTypeDouble);
+    fact.metaData()->setRawUnits("vertical m");
+    fact.setRawValue(50.0);
+
+    QSignalSpy cookedValuesSpy(&fact, &Fact::cookedValuesChanged);
+    QSignalSpy valueSpy(&fact, &Fact::valueChanged);
+    QSignalSpy rawValueSpy(&fact, &Fact::rawValueChanged);
+    QVERIFY(cookedValuesSpy.isValid());
+    QVERIFY(valueSpy.isValid());
+    QVERIFY(rawValueSpy.isValid());
+
+    const bool useFeet = verticalUnitsFact->rawValue().toUInt() != UnitsSettings::VerticalDistanceUnitsFeet;
+    verticalUnitsFact->setRawValue(useFeet
+                                       ? UnitsSettings::VerticalDistanceUnitsFeet
+                                       : UnitsSettings::VerticalDistanceUnitsMeters);
+
+    QCOMPARE(fact.cookedUnits(), useFeet ? QStringLiteral("ft") : QStringLiteral("m"));
+    QCOMPARE_FUZZY(fact.cookedValue().toDouble(), useFeet ? 164.042 : 50.0, 1e-3);
+    QCOMPARE(fact.rawValue().toDouble(), 50.0);
+    QCOMPARE(cookedValuesSpy.count(), 1);
+    QCOMPARE(valueSpy.count(), 1);
+    QCOMPARE(rawValueSpy.count(), 0);
 }
 
 void FactTest::_validateValid_test()

--- a/test/FactSystem/FactTest.h
+++ b/test/FactSystem/FactTest.h
@@ -13,6 +13,7 @@ private slots:
     void _setRawValueString_test();
     void _setCookedValueWithTranslator_test();
     void _rawToCooked_test();
+    void _appSettingsUnitsChanged_test();
     void _validateValid_test();
     void _validateInvalid_test();
     void _validateConvertOnly_test();


### PR DESCRIPTION
## Description
FactMetaData now observes the corresponding UnitsSettings Fact and notifies existing Fact instances when it changes, refreshing cooked values, ranges, and units.

Before, unit changes made during Initial Setup prompted users to restart QGroundControl, disrupting the first-run UX. Unit settings now take effect immediately and no longer require a restart.

## Type of Change
- [ ] Bug fix (non-breaking change that fixes an issue)
- [X] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] CI/Build changes
- [ ] Other

## Testing
- [X] Tested locally
- [X] Added/updated unit tests
- [ ] Tested with simulator (SITL)
- [ ] Tested with hardware

### Platforms Tested
- [ ] Linux
- [X] Windows
- [ ] macOS
- [ ] Android
- [ ] iOS

## Checklist
- [X] I have read the [Contribution Guidelines](CONTRIBUTING.md)
- [X] I have read the [Code of Conduct](CODE_OF_CONDUCT.md)
- [X] My code follows the project's coding standards
- [X] I have added tests that prove my fix/feature works
- [X] New and existing unit tests pass locally

---
By submitting this pull request, I confirm that my contribution is made under the terms of the project's dual license (Apache 2.0 and GPL v3).
