### PR TITLE
feat(Survey): split transects at concave polygon boundaries

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -124,7 +124,6 @@ target_link_libraries(${CMAKE_PROJECT_NAME}
         Qt6::Location
         Qt6::LocationPrivate
         Qt6::Positioning
-        Qt6::PositioningPrivate
         Qt6::Sql
 
         # Qt6 Multimedia

--- a/src/MissionManager/CorridorScanComplexItem.cc
+++ b/src/MissionManager/CorridorScanComplexItem.cc
@@ -1,13 +1,16 @@
 #include "CorridorScanComplexItem.h"
-#include "JsonParsing.h"
-#include "SettingsManager.h"
-#include "AppSettings.h"
-#include "PlanMasterController.h"
-#include "AppMessages.h"
-#include "QGCApplication.h"
-#include "QGCLoggingCategory.h"
 
 #include <QtCore/QJsonArray>
+
+#include "AppMessages.h"
+#include "AppSettings.h"
+#include "JsonParsing.h"
+#include "PlanMasterController.h"
+#include "QGCApplication.h"
+#include "QGCGeo.h"
+#include "QGCLoggingCategory.h"
+#include "QGCPolygonClipper.h"
+#include "SettingsManager.h"
 
 QGC_LOGGING_CATEGORY(CorridorScanComplexItemLog, "Plan.CorridorScanComplexItem")
 
@@ -231,21 +234,27 @@ void CorridorScanComplexItem::_rebuildCorridorPolygon(void)
         return;
     }
 
-    double halfWidth = _corridorWidthFact.rawValue().toDouble() / 2.0;
-
-    QList<QGeoCoordinate> firstSideVertices = _corridorPolyline.offsetPolyline(halfWidth);
-    QList<QGeoCoordinate> secondSideVertices = _corridorPolyline.offsetPolyline(-halfWidth);
-
     _surveyAreaPolygon.clear();
+    const double halfWidth = _corridorWidthFact.rawValue().toDouble() / 2.0;
+    if (halfWidth <= 0.0) {
+        return;
+    }
 
-    QList<QGeoCoordinate> rgCoord;
-    for (const QGeoCoordinate& vertex: firstSideVertices) {
-        rgCoord.append(vertex);
+    const QPolygonF corridorPolygon = QGCPolygonClipper::bufferPolyline(_corridorPolyline.nedPolyline(), halfWidth);
+    if (corridorPolygon.isEmpty()) {
+        qCWarning(CorridorScanComplexItemLog) << "Unable to build corridor buffer";
+        return;
     }
-    for (int i=secondSideVertices.count() - 1; i >= 0; i--) {
-        rgCoord.append(secondSideVertices[i]);
+
+    const QGeoCoordinate tangentOrigin = _corridorPolyline.vertexCoordinate(0);
+    QList<QGeoCoordinate> coordinates;
+    coordinates.reserve(corridorPolygon.size());
+    for (const QPointF& point : corridorPolygon) {
+        QGeoCoordinate coordinate;
+        QGCGeo::convertNedToGeo(point.y(), point.x(), 0.0, tangentOrigin, coordinate);
+        coordinates.append(coordinate);
     }
-    _surveyAreaPolygon.appendVertices(rgCoord);
+    _surveyAreaPolygon.appendVertices(coordinates);
 }
 
 void CorridorScanComplexItem::_rebuildTransectsPhase1(void)
@@ -284,13 +293,17 @@ void CorridorScanComplexItem::_rebuildTransectsPhase1(void)
             // Turn transect into CoordInfo transect
             QList<TransectStyleComplexItem::CoordInfo_t> transect;
             QList<QGeoCoordinate> transectCoords = _corridorPolyline.offsetPolyline(offsetDistance);
-            for (int j=1; j<transectCoords.count() - 1; j++) {
-                TransectStyleComplexItem::CoordInfo_t coordInfo = { transectCoords[j], CoordTypeInterior };
+            if (transectCoords.size() < 2) {
+                qCWarning(CorridorScanComplexItemLog) << "Unable to offset corridor transect";
+                continue;
+            }
+            for (int j = 1; j < transectCoords.count() - 1; j++) {
+                TransectStyleComplexItem::CoordInfo_t coordInfo = {transectCoords[j], CoordTypeInterior};
                 transect.append(coordInfo);
             }
-            TransectStyleComplexItem::CoordInfo_t coordInfo = { transectCoords.first(), CoordTypeSurveyEntry };
+            TransectStyleComplexItem::CoordInfo_t coordInfo = {transectCoords.first(), CoordTypeSurveyEntry};
             transect.prepend(coordInfo);
-            coordInfo = { transectCoords.last(), CoordTypeSurveyExit };
+            coordInfo = {transectCoords.last(), CoordTypeSurveyExit};
             transect.append(coordInfo);
 
             // Extend the transect ends for turnaround

--- a/src/MissionManager/Survey.SettingsGroup.json
+++ b/src/MissionManager/Survey.SettingsGroup.json
@@ -21,10 +21,9 @@
 },
 {
     "name":             "SplitConcavePolygons",
-    "shortDesc": "Split mission concave polygons into separate regular, convex polygons.",
+    "shortDesc": "Split transects at concave polygon boundaries.",
     "type":             "bool",
-    "default":     false,
-    "comment":      "Although this setting is here, the code for it is disabled since it was not working."
+    "default":     false
 }
 ]
 }

--- a/src/MissionManager/SurveyComplexItem.cc
+++ b/src/MissionManager/SurveyComplexItem.cc
@@ -1,6 +1,7 @@
 #include "SurveyComplexItem.h"
 #include "JsonParsing.h"
 #include "QGCGeo.h"
+#include "QGCPolygonClipper.h"
 #include "QGCQGeoCoordinate.h"
 #include "SettingsManager.h"
 #include "AppSettings.h"
@@ -15,7 +16,71 @@
 #include <QtCore/QJsonArray>
 #include <QtCore/QLineF>
 
+#include <algorithm>
+
 QGC_LOGGING_CATEGORY(SurveyComplexItemLog, "Plan.SurveyComplexItem")
+
+namespace {
+
+using GeoTransect = QList<QGeoCoordinate>;
+using GeoTransectGroup = QList<GeoTransect>;
+using GeoTransectGroups = QList<GeoTransectGroup>;
+
+void reverseGroupDirection(GeoTransectGroup& group)
+{
+    std::reverse(group.begin(), group.end());
+    for (GeoTransect& transect : group) {
+        std::reverse(transect.begin(), transect.end());
+    }
+}
+
+void reverseAllGroupDirections(GeoTransectGroups& groups)
+{
+    for (GeoTransectGroup& group : groups) {
+        reverseGroupDirection(group);
+    }
+}
+
+void optimizeGroupsForShortestDistance(const QGeoCoordinate& distanceCoordinate, GeoTransectGroups& groups)
+{
+    if (groups.isEmpty()) {
+        return;
+    }
+
+    const GeoTransectGroup& firstGroup = groups.first();
+    const GeoTransectGroup& lastGroup = groups.last();
+    const double groupDistances[] = {
+        firstGroup.first().first().distanceTo(distanceCoordinate),
+        firstGroup.last().last().distanceTo(distanceCoordinate),
+        lastGroup.first().first().distanceTo(distanceCoordinate),
+        lastGroup.last().last().distanceTo(distanceCoordinate),
+    };
+
+    int shortestIndex = 0;
+    for (int index = 1; index < 4; ++index) {
+        if (groupDistances[index] < groupDistances[shortestIndex]) {
+            shortestIndex = index;
+        }
+    }
+
+    if (shortestIndex > 1) {
+        std::reverse(groups.begin(), groups.end());
+    }
+    if (shortestIndex & 1) {
+        reverseAllGroupDirections(groups);
+    }
+}
+
+qsizetype transectCount(const QList<QList<QLineF>>& lineGroups)
+{
+    qsizetype count = 0;
+    for (const QList<QLineF>& group : lineGroups) {
+        count += group.size();
+    }
+    return count;
+}
+
+}  // namespace
 
 SurveyComplexItem::SurveyComplexItem(PlanMasterController* masterController, bool flyView, const QString& kmlOrShpFile)
     : TransectStyleComplexItem  (masterController, flyView, settingsGroup)
@@ -342,60 +407,6 @@ bool SurveyComplexItem::_loadV3(const QJsonObject& complexObject, int sequenceNu
     return true;
 }
 
-/// Reverse the order of the transects. First transect becomes last and so forth.
-void SurveyComplexItem::_reverseTransectOrder(QList<QList<QGeoCoordinate>>& transects)
-{
-    QList<QList<QGeoCoordinate>> rgReversedTransects;
-    for (int i=transects.count() - 1; i>=0; i--) {
-        rgReversedTransects.append(transects[i]);
-    }
-    transects = rgReversedTransects;
-}
-
-/// Reverse the order of all points within each transect, First point becomes last and so forth.
-void SurveyComplexItem::_reverseInternalTransectPoints(QList<QList<QGeoCoordinate>>& transects)
-{
-    for (int i=0; i<transects.count(); i++) {
-        QList<QGeoCoordinate> rgReversedCoords;
-        QList<QGeoCoordinate>& rgOriginalCoords = transects[i];
-        for (int j=rgOriginalCoords.count()-1; j>=0; j--) {
-            rgReversedCoords.append(rgOriginalCoords[j]);
-        }
-        transects[i] = rgReversedCoords;
-    }
-}
-
-/// Reorders the transects such that the first transect is the shortest distance to the specified coordinate
-/// and the first point within that transect is the shortest distance to the specified coordinate.
-///     @param distanceCoord Coordinate to measure distance against
-///     @param transects Transects to test and reorder
-void SurveyComplexItem::_optimizeTransectsForShortestDistance(const QGeoCoordinate& distanceCoord, QList<QList<QGeoCoordinate>>& transects)
-{
-    double rgTransectDistance[4];
-    rgTransectDistance[0] = transects.first().first().distanceTo(distanceCoord);
-    rgTransectDistance[1] = transects.first().last().distanceTo(distanceCoord);
-    rgTransectDistance[2] = transects.last().first().distanceTo(distanceCoord);
-    rgTransectDistance[3] = transects.last().last().distanceTo(distanceCoord);
-
-    int shortestIndex = 0;
-    double shortestDistance = rgTransectDistance[0];
-    for (int i=1; i<3; i++) {
-        if (rgTransectDistance[i] < shortestDistance) {
-            shortestIndex = i;
-            shortestDistance = rgTransectDistance[i];
-        }
-    }
-
-    if (shortestIndex > 1) {
-        // We need to reverse the order of segments
-        _reverseTransectOrder(transects);
-    }
-    if (shortestIndex & 1) {
-        // We need to reverse the points within each segment
-        _reverseInternalTransectPoints(transects);
-    }
-}
-
 qreal SurveyComplexItem::_ccw(QPointF pt1, QPointF pt2, QPointF pt3)
 {
     return (pt2.x()-pt1.x())*(pt3.y()-pt1.y()) - (pt2.y()-pt1.y())*(pt3.x()-pt1.x());
@@ -421,34 +432,6 @@ bool SurveyComplexItem::_gridAngleIsNorthSouthTransects()
     return gridAngle < 45.0 || (gridAngle > 360.0 - 45.0) || (gridAngle > 90.0 + 45.0 && gridAngle < 270.0 - 45.0);
 }
 
-void SurveyComplexItem::_adjustTransectsToEntryPointLocation(QList<QList<QGeoCoordinate>>& transects)
-{
-    if (transects.count() == 0) {
-        return;
-    }
-
-    bool reversePoints = false;
-    bool reverseTransects = false;
-
-    if (_entryPoint == EntryLocationBottomLeft || _entryPoint == EntryLocationBottomRight) {
-        reversePoints = true;
-    }
-    if (_entryPoint == EntryLocationTopRight || _entryPoint == EntryLocationBottomRight) {
-        reverseTransects = true;
-    }
-
-    if (reversePoints) {
-        qCDebug(SurveyComplexItemLog) << "_adjustTransectsToEntryPointLocation Reverse Points";
-        _reverseInternalTransectPoints(transects);
-    }
-    if (reverseTransects) {
-        qCDebug(SurveyComplexItemLog) << "_adjustTransectsToEntryPointLocation Reverse Transects";
-        _reverseTransectOrder(transects);
-    }
-
-    qCDebug(SurveyComplexItemLog) << "_adjustTransectsToEntryPointLocation Modified entry point:entryLocation" << transects.first().first() << _entryPoint;
-}
-
 QPointF SurveyComplexItem::_rotatePoint(const QPointF& point, const QPointF& origin, double angle)
 {
     QPointF rotated;
@@ -460,132 +443,23 @@ QPointF SurveyComplexItem::_rotatePoint(const QPointF& point, const QPointF& ori
     return rotated;
 }
 
-void SurveyComplexItem::_intersectLinesWithRect(const QList<QLineF>& lineList, const QRectF& boundRect, QList<QLineF>& resultLines)
+void SurveyComplexItem::_intersectLinesWithPolygon(const QList<QLineF>& lineList, const QPolygonF& polygon,
+                                                   QList<QList<QLineF>>& resultLineGroups)
 {
-    QLineF topLine      (boundRect.topLeft(),       boundRect.topRight());
-    QLineF bottomLine   (boundRect.bottomLeft(),    boundRect.bottomRight());
-    QLineF leftLine     (boundRect.topLeft(),       boundRect.bottomLeft());
-    QLineF rightLine    (boundRect.topRight(),      boundRect.bottomRight());
+    resultLineGroups.clear();
 
-    for (int i=0; i<lineList.count(); i++) {
-        QPointF intersectPoint;
-        QLineF intersectLine;
-        const QLineF& line = lineList[i];
-
-        auto isLineBoundedIntersect = [&line, &intersectPoint](const QLineF& linePosition) {
-            return line.intersects(linePosition, &intersectPoint) == QLineF::BoundedIntersection;
-        };
-
-        int foundCount = 0;
-        if (isLineBoundedIntersect(topLine)) {
-            intersectLine.setP1(intersectPoint);
-            foundCount++;
-        }
-        if (isLineBoundedIntersect(rightLine)) {
-            if (foundCount == 0) {
-                intersectLine.setP1(intersectPoint);
-            } else {
-                if (foundCount != 1) {
-                    qWarning() << "Found more than two intersecting points";
-                }
-                intersectLine.setP2(intersectPoint);
-            }
-            foundCount++;
-        }
-        if (isLineBoundedIntersect(bottomLine)) {
-            if (foundCount == 0) {
-                intersectLine.setP1(intersectPoint);
-            } else {
-                if (foundCount != 1) {
-                    qWarning() << "Found more than two intersecting points";
-                }
-                intersectLine.setP2(intersectPoint);
-            }
-            foundCount++;
-        }
-        if (isLineBoundedIntersect(leftLine)) {
-            if (foundCount == 0) {
-                intersectLine.setP1(intersectPoint);
-            } else {
-                if (foundCount != 1) {
-                    qWarning() << "Found more than two intersecting points";
-                }
-                intersectLine.setP2(intersectPoint);
-            }
-            foundCount++;
+    const QList<QList<QLineF>> clippedLineGroups = QGCPolygonClipper::intersectLines(lineList, polygon);
+    const bool splitConcavePolygons = _splitConcavePolygonsFact.rawValue().toBool();
+    for (const QList<QLineF>& clippedLines : clippedLineGroups) {
+        if (clippedLines.isEmpty()) {
+            continue;
         }
 
-        if (foundCount == 2) {
-            resultLines += intersectLine;
-        }
-    }
-}
-
-void SurveyComplexItem::_intersectLinesWithPolygon(const QList<QLineF>& lineList, const QPolygonF& polygon, QList<QLineF>& resultLines)
-{
-    resultLines.clear();
-
-    for (int i=0; i<lineList.count(); i++) {
-        const QLineF& line = lineList[i];
-        QList<QPointF> intersections;
-
-        // Intersect the line with all the polygon edges
-        for (int j=0; j<polygon.count()-1; j++) {
-            QPointF intersectPoint;
-            QLineF polygonLine = QLineF(polygon[j], polygon[j+1]);
-
-            auto intersect = line.intersects(polygonLine, &intersectPoint);
-            if (intersect == QLineF::BoundedIntersection) {
-                if (!intersections.contains(intersectPoint)) {
-                    intersections.append(intersectPoint);
-                }
-            }
-        }
-
-        // We now have one or more intersection points all along the same line. Find the two
-        // which are furthest away from each other to form the transect.
-        if (intersections.count() > 1) {
-            QPointF firstPoint;
-            QPointF secondPoint;
-            double currentMaxDistance = 0;
-
-            for (int intersectionIndex=0; intersectionIndex<intersections.count(); intersectionIndex++) {
-                for (int compareIndex=0; compareIndex<intersections.count(); compareIndex++) {
-                    QLineF lineTest(intersections[intersectionIndex], intersections[compareIndex]);
-                    double newMaxDistance = lineTest.length();
-                    if (newMaxDistance > currentMaxDistance) {
-                        firstPoint = intersections[intersectionIndex];
-                        secondPoint = intersections[compareIndex];
-                        currentMaxDistance = newMaxDistance;
-                    }
-                }
-            }
-
-            resultLines += QLineF(firstPoint, secondPoint);
-        }
-    }
-}
-
-/// Adjust the line segments such that they are all going the same direction with respect to going from P1->P2
-void SurveyComplexItem::_adjustLineDirection(const QList<QLineF>& lineList, QList<QLineF>& resultLines)
-{
-    qreal firstAngle = 0;
-    for (int i=0; i<lineList.count(); i++) {
-        const QLineF& line = lineList[i];
-        QLineF adjustedLine;
-
-        if (i == 0) {
-            firstAngle = line.angle();
-        }
-
-        if (qAbs(line.angle() - firstAngle) > 1.0) {
-            adjustedLine.setP1(line.p2());
-            adjustedLine.setP2(line.p1());
+        if (splitConcavePolygons) {
+            resultLineGroups.append(clippedLines);
         } else {
-            adjustedLine = line;
+            resultLineGroups.append({QLineF(clippedLines.first().p1(), clippedLines.last().p2())});
         }
-
-        resultLines += adjustedLine;
     }
 }
 
@@ -691,127 +565,153 @@ void SurveyComplexItem::_rebuildTransectsPhase1WorkerSinglePolygon(bool refly)
     // Create set of rotated parallel lines within the expanded bounding rect. Make the lines larger than the
     // bounding box to guarantee intersection.
 
-    QList<QLineF> lineList;
-
     // Sweep lines must extend beyond the polygon boundary regardless of grid angle.
     // The worst case is when the polygon is rotated 45° relative to the sweep direction,
     // where the required reach equals half the diagonal of the bounding rect.
     // We use diagonal * 1.5 to provide a 50% safety margin beyond that worst case.
     // Note: the old fixed +2000m was insufficient for polygons larger than ~10km.
-    const double diagonal = qSqrt(boundingRect.width() * boundingRect.width() + boundingRect.height() * boundingRect.height());
+    const double diagonal =
+        qSqrt(boundingRect.width() * boundingRect.width() + boundingRect.height() * boundingRect.height());
     double maxWidth = diagonal * 1.5;
     if (maxWidth <= 0.0) {
-        qCWarning(SurveyComplexItemLog) << "Degenerate polygon bounding rect (all vertices coincident or collinear), aborting transect rebuild";
+        qCWarning(SurveyComplexItemLog)
+            << "Degenerate polygon bounding rect (all vertices coincident or collinear), aborting transect rebuild";
         return;
     }
 
+    const auto generateSweepLines = [this, boundingCenter, gridAngle, maxWidth](double spacing) {
+        QList<QLineF> lines;
+        const double halfWidth = maxWidth / 2.0;
+        const double transectXMax = boundingCenter.x() + halfWidth;
+        for (double transectX = boundingCenter.x() - halfWidth; transectX < transectXMax; transectX += spacing) {
+            const double transectYTop = boundingCenter.y() - halfWidth;
+            const double transectYBottom = boundingCenter.y() + halfWidth;
+            lines.append(QLineF(_rotatePoint(QPointF(transectX, transectYTop), boundingCenter, gridAngle),
+                                _rotatePoint(QPointF(transectX, transectYBottom), boundingCenter, gridAngle)));
+        }
+        return lines;
+    };
+
+    QList<QLineF> lineList;
     if (gridSpacing <= 0) {
         // Invalid spacing: seed one center line so the < 2 fallback produces a single center transect.
-        qCWarning(SurveyComplexItemLog) << "Grid spacing" << gridSpacing << "is invalid, falling back to single center transect";
+        qCWarning(SurveyComplexItemLog) << "Grid spacing" << gridSpacing
+                                        << "is invalid, falling back to single center transect";
         const double halfW = maxWidth / 2.0;
-        lineList += QLineF(
-            _rotatePoint(QPointF(boundingCenter.x(), boundingCenter.y() - halfW), boundingCenter, gridAngle),
-            _rotatePoint(QPointF(boundingCenter.x(), boundingCenter.y() + halfW), boundingCenter, gridAngle));
+        lineList +=
+            QLineF(_rotatePoint(QPointF(boundingCenter.x(), boundingCenter.y() - halfW), boundingCenter, gridAngle),
+                   _rotatePoint(QPointF(boundingCenter.x(), boundingCenter.y() + halfW), boundingCenter, gridAngle));
     } else {
         // Cap spacing so the sweep never generates more than maxTransectCount transects.
         // Uses diagonal (not maxWidth) so the count reflects actual polygon-crossing transects.
         if (gridSpacing < diagonal / maxTransectCount) {
-            qCWarning(SurveyComplexItemLog) << "Transect spacing" << gridSpacing << "raised to" << diagonal / maxTransectCount << "to limit transect count to" << maxTransectCount;
+            qCWarning(SurveyComplexItemLog)
+                << "Transect spacing" << gridSpacing << "raised to" << diagonal / maxTransectCount
+                << "to limit transect count to" << maxTransectCount;
             gridSpacing = diagonal / maxTransectCount;
         }
-
-        double halfWidth = maxWidth / 2.0;
-        double transectX = boundingCenter.x() - halfWidth;
-        double transectXMax = transectX + maxWidth;
-        while (transectX < transectXMax) {
-            double transectYTop = boundingCenter.y() - halfWidth;
-            double transectYBottom = boundingCenter.y() + halfWidth;
-
-            lineList += QLineF(_rotatePoint(QPointF(transectX, transectYTop), boundingCenter, gridAngle), _rotatePoint(QPointF(transectX, transectYBottom), boundingCenter, gridAngle));
-            transectX += gridSpacing;
-        }
+        lineList = generateSweepLines(gridSpacing);
     }
 
-    // Now intersect the lines with the polygon
-    QList<QLineF> intersectLines;
-#if 1
-    _intersectLinesWithPolygon(lineList, polygon, intersectLines);
-#else
-    // This is handy for debugging grid problems, not for release
-    intersectLines = lineList;
-#endif
+    // Keep fragments from the same sweep line grouped so route ordering can reverse a complete
+    // sweep without joining separate fragments across a concave gap.
+    QList<QList<QLineF>> intersectLineGroups;
+    _intersectLinesWithPolygon(lineList, polygon, intersectLineGroups);
+
+    if (_splitConcavePolygonsFact.rawValue().toBool() && (gridSpacing > 0.0) &&
+        (transectCount(intersectLineGroups) > maxTransectCount)) {
+        const double originalGridSpacing = gridSpacing;
+        for (int attempt = 0; (attempt < 8) && (transectCount(intersectLineGroups) > maxTransectCount); ++attempt) {
+            const double scale = static_cast<double>(transectCount(intersectLineGroups)) / maxTransectCount;
+            gridSpacing *= (std::max) (scale * 1.01, 1.01);
+            lineList = generateSweepLines(gridSpacing);
+            _intersectLinesWithPolygon(lineList, polygon, intersectLineGroups);
+        }
+        qCWarning(SurveyComplexItemLog) << "Transect spacing" << originalGridSpacing << "raised to" << gridSpacing
+                                        << "to limit split transect count to" << maxTransectCount;
+    }
 
     // Less than two transects intersected with the polygon:
     //      Create a single transect which goes through the center of the polygon
     //      Intersect it with the polygon
-    if (intersectLines.count() < 2) {
-        _surveyAreaPolygon.center();
+    if (transectCount(intersectLineGroups) < 2) {
         QLineF firstLine = lineList.first();
         QPointF lineCenter = firstLine.pointAt(0.5);
         QPointF centerOffset = boundingCenter - lineCenter;
         firstLine.translate(centerOffset);
         lineList.clear();
         lineList.append(firstLine);
-        intersectLines = lineList;
-        _intersectLinesWithPolygon(lineList, polygon, intersectLines);
+        _intersectLinesWithPolygon(lineList, polygon, intersectLineGroups);
     }
 
-    // Make sure all lines are going the same direction. Polygon intersection leads to lines which
-    // can be in varied directions depending on the order of the intesecting sides.
-    QList<QLineF> resultLines;
-    _adjustLineDirection(intersectLines, resultLines);
+    if (transectCount(intersectLineGroups) > maxTransectCount) {
+        qCWarning(SurveyComplexItemLog) << "Unable to limit split transect count to" << maxTransectCount;
+        return;
+    }
 
     // Convert from NED to Geo
-    QList<QList<QGeoCoordinate>> transects;
-    for (const QLineF& line : resultLines) {
-        QGeoCoordinate          coord;
-        QList<QGeoCoordinate>   transect;
+    GeoTransectGroups transectGroups;
+    transectGroups.reserve(intersectLineGroups.size());
+    for (const QList<QLineF>& lineGroup : intersectLineGroups) {
+        GeoTransectGroup transectGroup;
+        transectGroup.reserve(lineGroup.size());
+        for (const QLineF& line : lineGroup) {
+            QGeoCoordinate coord;
+            GeoTransect transect;
 
-        QGCGeo::convertNedToGeo(line.p1().y(), line.p1().x(), 0, tangentOrigin, coord);
-        transect.append(coord);
-        QGCGeo::convertNedToGeo(line.p2().y(), line.p2().x(), 0, tangentOrigin, coord);
-        transect.append(coord);
-
-        transects.append(transect);
+            QGCGeo::convertNedToGeo(line.p1().y(), line.p1().x(), 0, tangentOrigin, coord);
+            transect.append(coord);
+            QGCGeo::convertNedToGeo(line.p2().y(), line.p2().x(), 0, tangentOrigin, coord);
+            transect.append(coord);
+            transectGroup.append(transect);
+        }
+        transectGroups.append(transectGroup);
     }
 
-    _adjustTransectsToEntryPointLocation(transects);
+    if (transectGroups.isEmpty()) {
+        return;
+    }
+
+    if (_entryPoint == EntryLocationBottomLeft || _entryPoint == EntryLocationBottomRight) {
+        reverseAllGroupDirections(transectGroups);
+    }
+    if (_entryPoint == EntryLocationTopRight || _entryPoint == EntryLocationBottomRight) {
+        std::reverse(transectGroups.begin(), transectGroups.end());
+    }
 
     if (refly) {
-        _optimizeTransectsForShortestDistance(_transects.last().last().coord, transects);
+        if (_transects.isEmpty()) {
+            return;
+        }
+        optimizeGroupsForShortestDistance(_transects.last().last().coord, transectGroups);
     }
 
     if (_flyAlternateTransectsFact.rawValue().toBool()) {
-        QList<QList<QGeoCoordinate>> alternatingTransects;
-        for (int i=0; i<transects.count(); i++) {
+        GeoTransectGroups alternatingGroups;
+        alternatingGroups.reserve(transectGroups.size());
+        for (int i = 0; i < transectGroups.size(); ++i) {
             if (!(i & 1)) {
-                alternatingTransects.append(transects[i]);
+                alternatingGroups.append(transectGroups[i]);
             }
         }
-        for (int i=transects.count()-1; i>0; i--) {
+        for (int i = transectGroups.size() - 1; i > 0; --i) {
             if (i & 1) {
-                alternatingTransects.append(transects[i]);
+                alternatingGroups.append(transectGroups[i]);
             }
         }
-        transects = alternatingTransects;
+        transectGroups = alternatingGroups;
     }
 
-    // Adjust to lawnmower pattern
-    bool reverseVertices = false;
-    for (int i=0; i<transects.count(); i++) {
-        // We must reverse the vertices for every other transect in order to make a lawnmower pattern
-        QList<QGeoCoordinate> transectVertices = transects[i];
-        if (reverseVertices) {
-            reverseVertices = false;
-            QList<QGeoCoordinate> reversedVertices;
-            for (int j=transectVertices.count()-1; j>=0; j--) {
-                reversedVertices.append(transectVertices[j]);
-            }
-            transectVertices = reversedVertices;
-        } else {
-            reverseVertices = true;
+    for (qsizetype index = 1; index < transectGroups.size(); index += 2) {
+        reverseGroupDirection(transectGroups[index]);
+    }
+
+    QList<GeoTransect> transects;
+    transects.reserve(transectCount(intersectLineGroups));
+    for (const GeoTransectGroup& group : transectGroups) {
+        for (const GeoTransect& transect : group) {
+            transects.append(transect);
         }
-        transects[i] = transectVertices;
     }
 
     // Convert to CoordInfo transects and append to _transects

--- a/src/MissionManager/SurveyComplexItem.cc
+++ b/src/MissionManager/SurveyComplexItem.cc
@@ -80,6 +80,15 @@ qsizetype transectCount(const QList<QList<QLineF>>& lineGroups)
     return count;
 }
 
+void joinLineFragments(QList<QList<QLineF>>& lineGroups)
+{
+    for (QList<QLineF>& group : lineGroups) {
+        if (group.size() > 1) {
+            group = {QLineF(group.first().p1(), group.last().p2())};
+        }
+    }
+}
+
 }  // namespace
 
 SurveyComplexItem::SurveyComplexItem(PlanMasterController* masterController, bool flyView, const QString& kmlOrShpFile)
@@ -645,8 +654,13 @@ void SurveyComplexItem::_rebuildTransectsPhase1WorkerSinglePolygon(bool refly)
     }
 
     if (transectCount(intersectLineGroups) > maxTransectCount) {
-        qCWarning(SurveyComplexItemLog) << "Unable to limit split transect count to" << maxTransectCount;
-        return;
+        qCWarning(SurveyComplexItemLog) << "Unable to limit split transect count to" << maxTransectCount
+                                        << "joining fragments instead";
+        joinLineFragments(intersectLineGroups);
+        if (transectCount(intersectLineGroups) > maxTransectCount) {
+            qCWarning(SurveyComplexItemLog) << "Unable to limit joined transect count to" << maxTransectCount;
+            return;
+        }
     }
 
     // Convert from NED to Geo

--- a/src/MissionManager/SurveyComplexItem.h
+++ b/src/MissionManager/SurveyComplexItem.h
@@ -90,18 +90,13 @@ private:
     };
 
     QPointF _rotatePoint(const QPointF& point, const QPointF& origin, double angle);
-    void _intersectLinesWithRect(const QList<QLineF>& lineList, const QRectF& boundRect, QList<QLineF>& resultLines);
-    void _intersectLinesWithPolygon(const QList<QLineF>& lineList, const QPolygonF& polygon, QList<QLineF>& resultLines);
-    void _adjustLineDirection(const QList<QLineF>& lineList, QList<QLineF>& resultLines);
+    void _intersectLinesWithPolygon(const QList<QLineF>& lineList, const QPolygonF& polygon,
+                                    QList<QList<QLineF>>& resultLineGroups);
     bool _nextTransectCoord(const QList<QGeoCoordinate>& transectPoints, int pointIndex, QGeoCoordinate& coord);
     bool _appendMissionItemsWorker(QList<MissionItem*>& items, QObject* missionItemParent, int& seqNum, bool hasRefly, bool buildRefly);
-    void _optimizeTransectsForShortestDistance(const QGeoCoordinate& distanceCoord, QList<QList<QGeoCoordinate>>& transects);
     qreal _ccw(QPointF pt1, QPointF pt2, QPointF pt3);
     qreal _dp(QPointF pt1, QPointF pt2);
     void _swapPoints(QList<QPointF>& points, int index1, int index2);
-    void _reverseTransectOrder(QList<QList<QGeoCoordinate>>& transects);
-    void _reverseInternalTransectPoints(QList<QList<QGeoCoordinate>>& transects);
-    void _adjustTransectsToEntryPointLocation(QList<QList<QGeoCoordinate>>& transects);
     bool _gridAngleIsNorthSouthTransects();
     double _clampGridAngle90(double gridAngle);
     bool _imagesEverywhere(void) const;

--- a/src/PlanView/SurveyItemEditor.qml
+++ b/src/PlanView/SurveyItemEditor.qml
@@ -86,6 +86,12 @@ TransectStyleComplexItemEditor {
                         fact:       missionItem.flyAlternateTransects,
                         enabled:    true,
                         visible:    _vehicle ? (_vehicle.fixedWing || _vehicle.vtol) : false
+                    },
+                    {
+                        text:       qsTr("Split concave polygons"),
+                        fact:       missionItem.splitConcavePolygons,
+                        enabled:    true,
+                        visible:    true
                     }
                 ]
             }

--- a/src/QmlControls/QGCMapPolygon.cc
+++ b/src/QmlControls/QGCMapPolygon.cc
@@ -1,16 +1,17 @@
 #include "QGCMapPolygon.h"
-#include "QGCGeo.h"
+
+#include <QMetaMethod>
+
+#include "AppMessages.h"
 #include "GeoJsonHelper.h"
 #include "JsonParsing.h"
-#include "QGCQGeoCoordinate.h"
-#include "AppMessages.h"
-#include "QGCApplication.h"
-#include "QGCLoggingCategory.h"
-#include "ShapeFileHelper.h"
 #include "KMLDomDocument.h"
-
-#include <QtCore/QLineF>
-#include <QMetaMethod>
+#include "QGCApplication.h"
+#include "QGCGeo.h"
+#include "QGCLoggingCategory.h"
+#include "QGCPolygonClipper.h"
+#include "QGCQGeoCoordinate.h"
+#include "ShapeFileHelper.h"
 
 QGC_LOGGING_CATEGORY(QGCMapPolygonLog, "QMLControls.QGCMapPolygon")
 
@@ -513,58 +514,42 @@ QList<QPointF> QGCMapPolygon::nedPolygon(void) const
     return nedPolygon;
 }
 
-
 void QGCMapPolygon::offset(double distance)
 {
-    QList<QGeoCoordinate> rgNewPolygon;
+    if (count() <= 2) {
+        return;
+    }
 
-    // I'm sure there is some beautiful famous algorithm to do this, but here is a brute force method
+    QPolygonF planarPolygon;
+    const QList<QPointF> nedVertices = nedPolygon();
+    planarPolygon.reserve(nedVertices.size());
+    for (const QPointF& vertex : nedVertices) {
+        planarPolygon.append(vertex);
+    }
 
-    if (count() > 2) {
-        // Convert the polygon to NED
-        QList<QPointF> rgNedVertices = nedPolygon();
+    const QList<QPolygonF> offsetPolygons = QGCPolygonClipper::offsetPolygon(planarPolygon, distance);
+    if (offsetPolygons.isEmpty()) {
+        qCWarning(QGCMapPolygonLog) << "Polygon offset produced no geometry";
+        return;
+    }
+    if (offsetPolygons.size() > 1) {
+        qCWarning(QGCMapPolygonLog) << "Polygon offset produced multiple disjoint polygons";
+        return;
+    }
 
-        // Walk the edges, offsetting by the specified distance
-        QList<QLineF> rgOffsetEdges;
-        for (int i=0; i<rgNedVertices.count(); i++) {
-            int     lastIndex = i == rgNedVertices.count() - 1 ? 0 : i + 1;
-            QLineF  offsetEdge;
-            QLineF  originalEdge(rgNedVertices[i], rgNedVertices[lastIndex]);
-
-            QLineF workerLine = originalEdge;
-            workerLine.setLength(distance);
-            workerLine.setAngle(workerLine.angle() - 90.0);
-            offsetEdge.setP1(workerLine.p2());
-
-            workerLine.setPoints(originalEdge.p2(), originalEdge.p1());
-            workerLine.setLength(distance);
-            workerLine.setAngle(workerLine.angle() + 90.0);
-            offsetEdge.setP2(workerLine.p2());
-
-            rgOffsetEdges.append(offsetEdge);
-        }
-
-        // Intersect the offset edges to generate new vertices
-        QPointF         newVertex;
-        QGeoCoordinate  tangentOrigin = vertexCoordinate(0);
-        for (int i=0; i<rgOffsetEdges.count(); i++) {
-            int prevIndex = i == 0 ? rgOffsetEdges.count() - 1 : i - 1;
-            auto intersect = rgOffsetEdges[prevIndex].intersects(rgOffsetEdges[i], &newVertex);
-            if (intersect == QLineF::NoIntersection) {
-                // FIXME: Better error handling?
-                qCWarning(QGCMapPolygonLog, "Intersection failed");
-                return;
-            }
-            QGeoCoordinate coord;
-            QGCGeo::convertNedToGeo(newVertex.y(), newVertex.x(), 0, tangentOrigin, coord);
-            rgNewPolygon.append(coord);
-        }
+    QList<QGeoCoordinate> newPolygon;
+    const QGeoCoordinate tangentOrigin = vertexCoordinate(0);
+    newPolygon.reserve(offsetPolygons.first().size());
+    for (const QPointF& vertex : offsetPolygons.first()) {
+        QGeoCoordinate coordinate;
+        QGCGeo::convertNedToGeo(vertex.y(), vertex.x(), 0, tangentOrigin, coordinate);
+        newPolygon.append(coordinate);
     }
 
     // Update internals
     beginReset();
     clear();
-    appendVertices(rgNewPolygon);
+    appendVertices(newPolygon);
     endReset();
 }
 

--- a/src/QmlControls/QGCMapPolyline.cc
+++ b/src/QmlControls/QGCMapPolyline.cc
@@ -1,22 +1,20 @@
 #include "QGCMapPolyline.h"
-#include "QGCGeo.h"
+
+#include <QMetaMethod>
+
+#include "AppMessages.h"
 #include "GeoJsonHelper.h"
 #include "JsonParsing.h"
-#include "QGCQGeoCoordinate.h"
-#include "AppMessages.h"
 #include "QGCApplication.h"
+#include "QGCGeo.h"
 #include "QGCLoggingCategory.h"
+#include "QGCPolygonClipper.h"
+#include "QGCQGeoCoordinate.h"
 #include "ShapeFileHelper.h"
-
-#include <QtCore/QLineF>
-#include <QMetaMethod>
 
 QGC_LOGGING_CATEGORY(QGCMapPolylineLog, "QMLControls.QGCMapPolyline")
 
-QGCMapPolyline::QGCMapPolyline(QObject* parent)
-    : QObject               (parent)
-    , _dirty                (false)
-    , _interactive          (false)
+QGCMapPolyline::QGCMapPolyline(QObject* parent) : QObject(parent), _dirty(false), _interactive(false)
 {
     _init();
 }
@@ -318,62 +316,23 @@ QList<QPointF> QGCMapPolyline::nedPolyline(void)
 
 QList<QGeoCoordinate> QGCMapPolyline::offsetPolyline(double distance)
 {
-    QList<QGeoCoordinate> rgNewPolyline;
-
-    // I'm sure there is some beautiful famous algorithm to do this, but here is a brute force method
-
-    if (count() > 1) {
-        // Convert the polygon to NED
-        QList<QPointF> rgNedVertices = nedPolyline();
-
-        // Walk the edges, offsetting by the specified distance
-        QList<QLineF> rgOffsetEdges;
-        for (int i=0; i<rgNedVertices.count() - 1; i++) {
-            QLineF  offsetEdge;
-            QLineF  originalEdge(rgNedVertices[i], rgNedVertices[i + 1]);
-
-            QLineF workerLine = originalEdge;
-            workerLine.setLength(distance);
-            workerLine.setAngle(workerLine.angle() - 90.0);
-            offsetEdge.setP1(workerLine.p2());
-
-            workerLine.setPoints(originalEdge.p2(), originalEdge.p1());
-            workerLine.setLength(distance);
-            workerLine.setAngle(workerLine.angle() + 90.0);
-            offsetEdge.setP2(workerLine.p2());
-
-            rgOffsetEdges.append(offsetEdge);
-        }
-
-        QGeoCoordinate  tangentOrigin = vertexCoordinate(0);
-
-        // Add first vertex
-        QGeoCoordinate coord;
-        QGCGeo::convertNedToGeo(rgOffsetEdges[0].p1().y(), rgOffsetEdges[0].p1().x(), 0, tangentOrigin, coord);
-        rgNewPolyline.append(coord);
-
-        // Intersect the offset edges to generate new central vertices
-        QPointF  newVertex;
-        for (int i=1; i<rgOffsetEdges.count(); i++) {
-            auto intersect = rgOffsetEdges[i - 1].intersects(rgOffsetEdges[i], &newVertex);
-            if (intersect == QLineF::NoIntersection) {
-                // Two lines are colinear
-                newVertex = rgOffsetEdges[i].p2();
-            }
-            QGCGeo::convertNedToGeo(newVertex.y(), newVertex.x(), 0, tangentOrigin, coord);
-            rgNewPolyline.append(coord);
-        }
-
-        // Add last vertex
-        int lastIndex = rgOffsetEdges.count() - 1;
-        QGCGeo::convertNedToGeo(rgOffsetEdges[lastIndex].p2().y(), rgOffsetEdges[lastIndex].p2().x(), 0, tangentOrigin, coord);
-        rgNewPolyline.append(coord);
+    const QList<QPointF> offsetPoints = QGCPolygonClipper::offsetPolyline(nedPolyline(), distance);
+    if (offsetPoints.isEmpty()) {
+        return {};
     }
 
-    return rgNewPolyline;
+    const QGeoCoordinate tangentOrigin = vertexCoordinate(0);
+    QList<QGeoCoordinate> result;
+    result.reserve(offsetPoints.size());
+    for (const QPointF& point : offsetPoints) {
+        QGeoCoordinate coordinate;
+        QGCGeo::convertNedToGeo(point.y(), point.x(), 0.0, tangentOrigin, coordinate);
+        result.append(coordinate);
+    }
+    return result;
 }
 
-bool QGCMapPolyline::loadKMLOrSHPFile(const QString &file)
+bool QGCMapPolyline::loadKMLOrSHPFile(const QString& file)
 {
     QString errorString;
     QList<QList<QGeoCoordinate>> polylines;

--- a/src/Utilities/Geo/CMakeLists.txt
+++ b/src/Utilities/Geo/CMakeLists.txt
@@ -31,6 +31,20 @@ CPMAddPackage(
     PATCHES geographiclib.patch
 )
 
+CPMAddPackage(
+    NAME clipper2
+    VERSION 2.0.1
+    GITHUB_REPOSITORY AngusJohnson/Clipper2
+    GIT_TAG Clipper2_2.0.1
+    SOURCE_SUBDIR CPP
+    FIND_PACKAGE_ARGUMENTS "NAMES Clipper2 CONFIG"
+    OPTIONS
+        "CLIPPER2_USINGZ OFF"
+        "CLIPPER2_UTILS OFF"
+        "CLIPPER2_EXAMPLES OFF"
+        "CLIPPER2_TESTS OFF"
+)
+
 # geographiclib_ADDED is set only when CPM downloads; geographiclib_FOUND when
 # resolved via find_package (QGC_USE_SYSTEM_LIBS). Either is success.
 if(NOT geographiclib_ADDED AND NOT geographiclib_FOUND)
@@ -43,15 +57,24 @@ if(TARGET GeographicLib_STATIC)
     qgc_disable_dependency_warnings(GeographicLib_STATIC)
 endif()
 
+if(TARGET Clipper2::Clipper2)
+    set(_qgc_clipper2_target Clipper2::Clipper2)
+elseif(TARGET Clipper2)
+    set(_qgc_clipper2_target Clipper2)
+    qgc_disable_dependency_warnings(Clipper2)
+else()
+    message(FATAL_ERROR "QGC: Clipper2 (required dependency) was not resolved")
+endif()
+
 target_link_libraries(QGCGeoMath
     PUBLIC
         Qt6::Core
         Qt6::Gui
         Qt6::Positioning
     PRIVATE
+        ${_qgc_clipper2_target}
         GeographicLib::GeographicLib
         QGCLogging
-        Qt6::PositioningPrivate
 )
 
 target_include_directories(QGCGeoMath PUBLIC ${CMAKE_CURRENT_SOURCE_DIR})

--- a/src/Utilities/Geo/CMakeLists.txt
+++ b/src/Utilities/Geo/CMakeLists.txt
@@ -1,6 +1,8 @@
 qt_add_library(QGCGeoMath STATIC
     QGCGeo.cc
     QGCGeo.h
+    QGCPolygonClipper.cc
+    QGCPolygonClipper.h
 )
 
 CPMAddPackage(
@@ -49,6 +51,7 @@ target_link_libraries(QGCGeoMath
     PRIVATE
         GeographicLib::GeographicLib
         QGCLogging
+        Qt6::PositioningPrivate
 )
 
 target_include_directories(QGCGeoMath PUBLIC ${CMAKE_CURRENT_SOURCE_DIR})

--- a/src/Utilities/Geo/QGCPolygonClipper.cc
+++ b/src/Utilities/Geo/QGCPolygonClipper.cc
@@ -1,13 +1,17 @@
 #include "QGCPolygonClipper.h"
 
-#include <QtPositioning/private/qclipperutils_p.h>
-
 #include <algorithm>
+#include <clipper2/clipper.h>
 #include <cmath>
 #include <limits>
 #include <numeric>
 
 namespace {
+
+constexpr double coordinateScale = 1e14;
+constexpr double miterLimit = 1000.0;
+constexpr double maximumScaledOffset = 4e18 / (miterLimit + 1.0);
+constexpr double normalizedPointTolerance = 1.0 / coordinateScale;
 
 struct CoordinateNormalizer
 {
@@ -16,51 +20,247 @@ struct CoordinateNormalizer
 
     [[nodiscard]] bool isValid() const { return std::isfinite(extent) && (extent > 0.0); }
 
-    [[nodiscard]] QDoubleVector2D normalize(const QPointF& point) const
+    [[nodiscard]] QPointF normalize(const QPointF& point) const
     {
-        return QDoubleVector2D((point.x() - center.x()) / extent, (point.y() - center.y()) / extent);
+        return QPointF((point.x() - center.x()) / extent, (point.y() - center.y()) / extent);
+    }
+
+    [[nodiscard]] QPointF denormalize(const QPointF& point) const
+    {
+        return QPointF((point.x() * extent) + center.x(), (point.y() * extent) + center.y());
     }
 };
 
-bool updateBounds(const QPointF& point, double& minimumX, double& minimumY, double& maximumX, double& maximumY)
-{
-    if (!std::isfinite(point.x()) || !std::isfinite(point.y())) {
-        return false;
-    }
-
-    minimumX = (std::min) (minimumX, point.x());
-    minimumY = (std::min) (minimumY, point.y());
-    maximumX = (std::max) (maximumX, point.x());
-    maximumY = (std::max) (maximumY, point.y());
-    return true;
-}
-
-bool createNormalizer(const QList<QLineF>& lines, const QPolygonF& polygon, CoordinateNormalizer& normalizer)
+struct Bounds
 {
     double minimumX = std::numeric_limits<double>::infinity();
     double minimumY = std::numeric_limits<double>::infinity();
     double maximumX = -std::numeric_limits<double>::infinity();
     double maximumY = -std::numeric_limits<double>::infinity();
 
-    for (const QLineF& line : lines) {
-        if (!updateBounds(line.p1(), minimumX, minimumY, maximumX, maximumY) ||
-            !updateBounds(line.p2(), minimumX, minimumY, maximumX, maximumY)) {
+    bool add(const QPointF& point)
+    {
+        if (!std::isfinite(point.x()) || !std::isfinite(point.y())) {
             return false;
         }
+
+        minimumX = (std::min) (minimumX, point.x());
+        minimumY = (std::min) (minimumY, point.y());
+        maximumX = (std::max) (maximumX, point.x());
+        maximumY = (std::max) (maximumY, point.y());
+        return true;
     }
+
+    bool configure(CoordinateNormalizer& normalizer) const
+    {
+        if (!std::isfinite(minimumX)) {
+            return false;
+        }
+
+        normalizer.center = QPointF(std::midpoint(minimumX, maximumX), std::midpoint(minimumY, maximumY));
+        normalizer.extent = (std::max) (maximumX - minimumX, maximumY - minimumY);
+        return normalizer.isValid();
+    }
+};
+
+bool createNormalizer(const QPolygonF& polygon, CoordinateNormalizer& normalizer)
+{
+    Bounds bounds;
     for (const QPointF& point : polygon) {
-        if (!updateBounds(point, minimumX, minimumY, maximumX, maximumY)) {
+        if (!bounds.add(point)) {
             return false;
         }
     }
+    return bounds.configure(normalizer);
+}
 
-    if (!std::isfinite(minimumX)) {
-        return false;
+bool createNormalizer(const QList<QPointF>& points, CoordinateNormalizer& normalizer)
+{
+    Bounds bounds;
+    for (const QPointF& point : points) {
+        if (!bounds.add(point)) {
+            return false;
+        }
+    }
+    return bounds.configure(normalizer);
+}
+
+QPolygonF normalizedPath(const QPolygonF& polygon, const CoordinateNormalizer& normalizer)
+{
+    qsizetype pointCount = polygon.size();
+    if ((pointCount > 1) && (polygon.first() == polygon.last())) {
+        --pointCount;
     }
 
-    normalizer.center = QPointF(std::midpoint(minimumX, maximumX), std::midpoint(minimumY, maximumY));
-    normalizer.extent = (std::max) (maximumX - minimumX, maximumY - minimumY);
-    return normalizer.isValid();
+    QPolygonF result;
+    result.reserve(pointCount);
+    for (qsizetype index = 0; index < pointCount; ++index) {
+        result.append(normalizer.normalize(polygon[index]));
+    }
+    return result;
+}
+
+double crossProduct(const QPointF& first, const QPointF& second)
+{
+    return (first.x() * second.y()) - (first.y() * second.x());
+}
+
+double dotProduct(const QPointF& first, const QPointF& second)
+{
+    return (first.x() * second.x()) + (first.y() * second.y());
+}
+
+double distanceSquared(const QPointF& first, const QPointF& second)
+{
+    const double deltaX = first.x() - second.x();
+    const double deltaY = first.y() - second.y();
+    return (deltaX * deltaX) + (deltaY * deltaY);
+}
+
+void appendUnique(QList<QPointF>& points, const QPointF& point)
+{
+    if (points.isEmpty() ||
+        (distanceSquared(points.last(), point) > (normalizedPointTolerance * normalizedPointTolerance))) {
+        points.append(point);
+    }
+}
+
+struct OffsetSegment
+{
+    QPointF direction;
+    QPointF leftNormal;
+};
+
+void appendOffsetJoin(QList<QPointF>& result, const QPointF& vertex, const OffsetSegment& previousSegment,
+                      const OffsetSegment& nextSegment, double distance)
+{
+    const QPointF previousOffset = vertex + (previousSegment.leftNormal * distance);
+    const QPointF nextOffset = vertex + (nextSegment.leftNormal * distance);
+    const double denominator = crossProduct(previousSegment.direction, nextSegment.direction);
+    const double directionDotProduct = dotProduct(previousSegment.direction, nextSegment.direction);
+
+    if (std::abs(denominator) <= normalizedPointTolerance) {
+        if (directionDotProduct > 0.0) {
+            appendUnique(result, nextOffset);
+        } else {
+            appendUnique(result, previousOffset);
+            appendUnique(result, nextOffset);
+        }
+        return;
+    }
+
+    const double previousLineDistance = crossProduct(nextOffset - previousOffset, nextSegment.direction) / denominator;
+    const QPointF intersection = previousOffset + (previousSegment.direction * previousLineDistance);
+    const double maximumMiterDistance = std::abs(distance) * miterLimit;
+    if (std::isfinite(intersection.x()) && std::isfinite(intersection.y()) &&
+        (distanceSquared(vertex, intersection) <= (maximumMiterDistance * maximumMiterDistance))) {
+        appendUnique(result, intersection);
+    } else {
+        appendUnique(result, previousOffset);
+        appendUnique(result, nextOffset);
+    }
+}
+
+Clipper2Lib::Point64 toClipperPoint(const QPointF& point)
+{
+    return {std::llround(point.x() * coordinateScale), std::llround(point.y() * coordinateScale)};
+}
+
+QPointF fromClipperPoint(const Clipper2Lib::Point64& point)
+{
+    return QPointF(static_cast<double>(point.x) / coordinateScale, static_cast<double>(point.y) / coordinateScale);
+}
+
+Clipper2Lib::Path64 toClipperPath(const QPolygonF& path)
+{
+    Clipper2Lib::Path64 result;
+    result.reserve(path.size());
+    for (const QPointF& point : path) {
+        result.push_back(toClipperPoint(point));
+    }
+    return result;
+}
+
+Clipper2Lib::Path64 toClipperPath(const QList<QPointF>& path, const CoordinateNormalizer& normalizer)
+{
+    Clipper2Lib::Path64 result;
+    result.reserve(path.size());
+    for (const QPointF& point : path) {
+        result.push_back(toClipperPoint(normalizer.normalize(point)));
+    }
+    return result;
+}
+
+QList<QPolygonF> fromClipperPaths(const Clipper2Lib::Paths64& paths, const CoordinateNormalizer& normalizer)
+{
+    QList<QPolygonF> result;
+    result.reserve(static_cast<qsizetype>(paths.size()));
+    for (const Clipper2Lib::Path64& path : paths) {
+        if (path.size() < 3) {
+            continue;
+        }
+
+        QPolygonF polygon;
+        polygon.reserve(static_cast<qsizetype>(path.size()));
+        for (const Clipper2Lib::Point64& point : path) {
+            polygon.append(normalizer.denormalize(fromClipperPoint(point)));
+        }
+        result.append(polygon);
+    }
+    return result;
+}
+
+QPolygonF fromClipperCompoundPath(const Clipper2Lib::Paths64& paths, const CoordinateNormalizer& normalizer)
+{
+    const QList<QPolygonF> polygons = fromClipperPaths(paths, normalizer);
+    if (polygons.isEmpty()) {
+        return {};
+    }
+    if (polygons.size() == 1) {
+        return polygons.first();
+    }
+
+    qsizetype pointCount = polygons.first().size() + 1;
+    for (qsizetype index = 1; index < polygons.size(); ++index) {
+        pointCount += polygons[index].size() + 2;
+    }
+
+    QPolygonF result;
+    result.reserve(pointCount);
+    result.append(polygons.first());
+
+    const QPointF anchor = result.first();
+    result.append(anchor);
+    for (qsizetype index = 1; index < polygons.size(); ++index) {
+        const QPolygonF& polygon = polygons[index];
+        result.append(polygon.first());
+        for (qsizetype pointIndex = 1; pointIndex < polygon.size(); ++pointIndex) {
+            result.append(polygon[pointIndex]);
+        }
+        result.append(polygon.first());
+        result.append(anchor);
+    }
+    return result;
+}
+
+void alignPolygonStart(QPolygonF& polygon, const QPointF& sourceStart)
+{
+    if (polygon.isEmpty()) {
+        return;
+    }
+
+    qsizetype nearestIndex = 0;
+    double nearestDistanceSquared = std::numeric_limits<double>::infinity();
+    for (qsizetype index = 0; index < polygon.size(); ++index) {
+        const double deltaX = polygon[index].x() - sourceStart.x();
+        const double deltaY = polygon[index].y() - sourceStart.y();
+        const double distanceSquared = (deltaX * deltaX) + (deltaY * deltaY);
+        if (distanceSquared < nearestDistanceSquared) {
+            nearestIndex = index;
+            nearestDistanceSquared = distanceSquared;
+        }
+    }
+    std::rotate(polygon.begin(), polygon.begin() + nearestIndex, polygon.end());
 }
 
 struct LineInterval
@@ -69,94 +269,24 @@ struct LineInterval
     double end = 0.0;
 };
 
-QList<QDoubleVector2D> normalizedPath(const QPolygonF& polygon, const CoordinateNormalizer& normalizer)
-{
-    qsizetype pointCount = polygon.size();
-    if ((pointCount > 1) && (polygon.first() == polygon.last())) {
-        --pointCount;
-    }
+constexpr double intervalTolerance = 1e-12;
 
-    QList<QDoubleVector2D> result;
-    result.reserve(pointCount);
-    for (qsizetype index = 0; index < pointCount; ++index) {
-        result.append(normalizer.normalize(polygon[index]));
-    }
-    return result;
+bool isDegenerateLine(const QLineF& line)
+{
+    return (line.dx() == 0.0) && (line.dy() == 0.0);
 }
 
-QList<QLineF> intersectNormalizedLine(const QLineF& line, const QList<QDoubleVector2D>& clipPath,
-                                      const CoordinateNormalizer& normalizer)
+void appendInterval(QList<LineInterval>& intervals, double start, double end)
 {
-    if (line.isNull()) {
-        return {};
+    start = std::clamp(start, 0.0, 1.0);
+    end = std::clamp(end, 0.0, 1.0);
+    if ((end - start) > intervalTolerance) {
+        intervals.append({start, end});
     }
+}
 
-    QClipperUtils clipper;
-    const QDoubleVector2D normalizedLineStart = normalizer.normalize(line.p1());
-    const QDoubleVector2D normalizedLineEnd = normalizer.normalize(line.p2());
-    clipper.addSubjectPath({normalizedLineStart, normalizedLineEnd}, false);
-    clipper.addClipPolygon(clipPath);
-
-    const double directionX = normalizedLineEnd.x() - normalizedLineStart.x();
-    const double directionY = normalizedLineEnd.y() - normalizedLineStart.y();
-    const double directionLengthSquared = (directionX * directionX) + (directionY * directionY);
-    if (!std::isfinite(directionLengthSquared) || (directionLengthSquared <= 0.0)) {
-        return {};
-    }
-
-    const auto projection = [directionX, directionY, directionLengthSquared,
-                             &normalizedLineStart](const QDoubleVector2D& point) {
-        return (((point.x() - normalizedLineStart.x()) * directionX) +
-                ((point.y() - normalizedLineStart.y()) * directionY)) /
-               directionLengthSquared;
-    };
-
-    constexpr double intervalTolerance = 1e-12;
-    const double collinearityTolerance =
-        64.0 * std::numeric_limits<double>::epsilon() * std::sqrt(directionLengthSquared);
-    QList<LineInterval> intervals;
-    const auto appendInterval = [&intervals](double start, double end) {
-        start = std::clamp(start, 0.0, 1.0);
-        end = std::clamp(end, 0.0, 1.0);
-        if ((end - start) > intervalTolerance) {
-            intervals.append({start, end});
-        }
-    };
-
-    const QList<QList<QDoubleVector2D>> clippedPaths =
-        clipper.execute(QClipperUtils::Intersection, QClipperUtils::pftEvenOdd, QClipperUtils::pftEvenOdd);
-    for (const QList<QDoubleVector2D>& path : clippedPaths) {
-        if (path.size() < 2) {
-            continue;
-        }
-
-        double firstProjection = std::numeric_limits<double>::infinity();
-        double lastProjection = -std::numeric_limits<double>::infinity();
-        for (const QDoubleVector2D& point : path) {
-            const double pointProjection = projection(point);
-            firstProjection = (std::min) (firstProjection, pointProjection);
-            lastProjection = (std::max) (lastProjection, pointProjection);
-        }
-        appendInterval(firstProjection, lastProjection);
-    }
-
-    // Clipper excludes open paths coincident with a clip boundary. Preserve those valid line
-    // segments explicitly, then merge them with the interior intervals below.
-    for (qsizetype index = 0; index < clipPath.size(); ++index) {
-        const QDoubleVector2D& edgeStart = clipPath[index];
-        const QDoubleVector2D& edgeEnd = clipPath[(index + 1) % clipPath.size()];
-        const double edgeStartCross = (directionX * (edgeStart.y() - normalizedLineStart.y())) -
-                                      (directionY * (edgeStart.x() - normalizedLineStart.x()));
-        const double edgeEndCross = (directionX * (edgeEnd.y() - normalizedLineStart.y())) -
-                                    (directionY * (edgeEnd.x() - normalizedLineStart.x()));
-        if ((std::abs(edgeStartCross) <= collinearityTolerance) && (std::abs(edgeEndCross) <= collinearityTolerance)) {
-            const double edgeStartProjection = projection(edgeStart);
-            const double edgeEndProjection = projection(edgeEnd);
-            appendInterval((std::min) (edgeStartProjection, edgeEndProjection),
-                           (std::max) (edgeStartProjection, edgeEndProjection));
-        }
-    }
-
+QList<QLineF> linesFromIntervals(const QLineF& line, QList<LineInterval> intervals)
+{
     std::sort(intervals.begin(), intervals.end(),
               [](const LineInterval& first, const LineInterval& second) { return first.start < second.start; });
 
@@ -177,6 +307,192 @@ QList<QLineF> intersectNormalizedLine(const QLineF& line, const QList<QDoubleVec
     return result;
 }
 
+QList<QLineF> intersectCollapsedLine(const QLineF& line, const QPolygonF& polygon)
+{
+    const long double directionX = static_cast<long double>(line.dx());
+    const long double directionY = static_cast<long double>(line.dy());
+    const long double directionLengthSquared = (directionX * directionX) + (directionY * directionY);
+    if (directionLengthSquared <= 0.0L) {
+        return {};
+    }
+
+    qsizetype pointCount = polygon.size();
+    if ((pointCount > 1) && (polygon.first() == polygon.last())) {
+        --pointCount;
+    }
+
+    constexpr long double parameterTolerance = 1e-12L;
+    constexpr long double crossProductTolerance = 64.0L * std::numeric_limits<long double>::epsilon();
+    QList<double> intersectionParameters = {0.0, 1.0};
+    QList<LineInterval> intervals;
+    for (qsizetype index = 0; index < pointCount; ++index) {
+        const QPointF& edgeStart = polygon[index];
+        const QPointF& edgeEnd = polygon[(index + 1) % pointCount];
+        const long double edgeDirectionX = static_cast<long double>(edgeEnd.x()) - edgeStart.x();
+        const long double edgeDirectionY = static_cast<long double>(edgeEnd.y()) - edgeStart.y();
+        const long double offsetX = static_cast<long double>(edgeStart.x()) - line.x1();
+        const long double offsetY = static_cast<long double>(edgeStart.y()) - line.y1();
+        const long double denominator = (directionX * edgeDirectionY) - (directionY * edgeDirectionX);
+        const long double denominatorError = crossProductTolerance * ((std::abs) (directionX * edgeDirectionY) +
+                                                                      (std::abs) (directionY * edgeDirectionX));
+
+        if ((std::abs) (denominator) > denominatorError) {
+            const long double lineParameter = ((offsetX * edgeDirectionY) - (offsetY * edgeDirectionX)) / denominator;
+            const long double edgeParameter = ((offsetX * directionY) - (offsetY * directionX)) / denominator;
+            if ((lineParameter >= -parameterTolerance) && (lineParameter <= (1.0L + parameterTolerance)) &&
+                (edgeParameter >= -parameterTolerance) && (edgeParameter <= (1.0L + parameterTolerance))) {
+                intersectionParameters.append(std::clamp(static_cast<double>(lineParameter), 0.0, 1.0));
+            }
+            continue;
+        }
+
+        const long double offsetCrossProduct = (offsetX * directionY) - (offsetY * directionX);
+        const long double offsetError =
+            crossProductTolerance * ((std::abs) (offsetX * directionY) + (std::abs) (offsetY * directionX));
+        if ((std::abs) (offsetCrossProduct) > offsetError) {
+            continue;
+        }
+
+        const long double edgeEndOffsetX = static_cast<long double>(edgeEnd.x()) - line.x1();
+        const long double edgeEndOffsetY = static_cast<long double>(edgeEnd.y()) - line.y1();
+        const double edgeStartParameter =
+            static_cast<double>(((offsetX * directionX) + (offsetY * directionY)) / directionLengthSquared);
+        const double edgeEndParameter = static_cast<double>(
+            ((edgeEndOffsetX * directionX) + (edgeEndOffsetY * directionY)) / directionLengthSquared);
+        appendInterval(intervals, (std::min) (edgeStartParameter, edgeEndParameter),
+                       (std::max) (edgeStartParameter, edgeEndParameter));
+    }
+
+    std::sort(intersectionParameters.begin(), intersectionParameters.end());
+    const auto uniqueEnd =
+        std::unique(intersectionParameters.begin(), intersectionParameters.end(),
+                    [](double first, double second) { return std::abs(first - second) <= intervalTolerance; });
+    intersectionParameters.erase(uniqueEnd, intersectionParameters.end());
+
+    for (qsizetype index = 1; index < intersectionParameters.size(); ++index) {
+        const double start = intersectionParameters[index - 1];
+        const double end = intersectionParameters[index];
+        if (((end - start) > intervalTolerance) &&
+            polygon.containsPoint(line.pointAt(std::midpoint(start, end)), Qt::OddEvenFill)) {
+            appendInterval(intervals, start, end);
+        }
+    }
+
+    return linesFromIntervals(line, intervals);
+}
+
+bool clipLineToBounds(const QLineF& line, const QRectF& bounds, QLineF& clippedLine)
+{
+    if (isDegenerateLine(line) || !std::isfinite(line.x1()) || !std::isfinite(line.y1()) || !std::isfinite(line.x2()) ||
+        !std::isfinite(line.y2())) {
+        return false;
+    }
+
+    double start = 0.0;
+    double end = 1.0;
+    const auto clipBoundary = [&start, &end](double direction, double distance) {
+        if (direction == 0.0) {
+            return distance >= 0.0;
+        }
+
+        const double parameter = distance / direction;
+        if (direction < 0.0) {
+            start = (std::max) (start, parameter);
+        } else {
+            end = (std::min) (end, parameter);
+        }
+        return start <= end;
+    };
+
+    if (!clipBoundary(-line.dx(), line.x1() - bounds.left()) || !clipBoundary(line.dx(), bounds.right() - line.x1()) ||
+        !clipBoundary(-line.dy(), line.y1() - bounds.top()) || !clipBoundary(line.dy(), bounds.bottom() - line.y1())) {
+        return false;
+    }
+
+    clippedLine = QLineF(line.pointAt(start), line.pointAt(end));
+    return !isDegenerateLine(clippedLine);
+}
+
+QList<QLineF> intersectNormalizedLine(const QLineF& line, const Clipper2Lib::Path64& clipPath,
+                                      const CoordinateNormalizer& normalizer, const QPolygonF& polygon)
+{
+    if (isDegenerateLine(line)) {
+        return {};
+    }
+
+    const QPointF normalizedLineStart = normalizer.normalize(line.p1());
+    const QPointF normalizedLineEnd = normalizer.normalize(line.p2());
+    const double directionX = normalizedLineEnd.x() - normalizedLineStart.x();
+    const double directionY = normalizedLineEnd.y() - normalizedLineStart.y();
+
+    const Clipper2Lib::Point64 clipperLineStart = toClipperPoint(normalizedLineStart);
+    const Clipper2Lib::Point64 clipperLineEnd = toClipperPoint(normalizedLineEnd);
+    if (clipperLineStart == clipperLineEnd) {
+        return intersectCollapsedLine(line, polygon);
+    }
+
+    const double directionLengthSquared = (directionX * directionX) + (directionY * directionY);
+    if (!std::isfinite(directionLengthSquared) || (directionLengthSquared <= 0.0)) {
+        return {};
+    }
+
+    Clipper2Lib::Clipper64 clipper;
+    clipper.AddOpenSubject({{clipperLineStart, clipperLineEnd}});
+    clipper.AddClip({clipPath});
+
+    Clipper2Lib::Paths64 closedPaths;
+    Clipper2Lib::Paths64 clippedPaths;
+    if (!clipper.Execute(Clipper2Lib::ClipType::Intersection, Clipper2Lib::FillRule::EvenOdd, closedPaths,
+                         clippedPaths)) {
+        return {};
+    }
+
+    const auto projection = [directionX, directionY, directionLengthSquared,
+                             &normalizedLineStart](const QPointF& point) {
+        return (((point.x() - normalizedLineStart.x()) * directionX) +
+                ((point.y() - normalizedLineStart.y()) * directionY)) /
+               directionLengthSquared;
+    };
+
+    const double collinearityTolerance =
+        64.0 * std::numeric_limits<double>::epsilon() * std::sqrt(directionLengthSquared);
+    QList<LineInterval> intervals;
+
+    for (const Clipper2Lib::Path64& path : clippedPaths) {
+        if (path.size() < 2) {
+            continue;
+        }
+
+        double firstProjection = std::numeric_limits<double>::infinity();
+        double lastProjection = -std::numeric_limits<double>::infinity();
+        for (const Clipper2Lib::Point64& point : path) {
+            const double pointProjection = projection(fromClipperPoint(point));
+            firstProjection = (std::min) (firstProjection, pointProjection);
+            lastProjection = (std::max) (lastProjection, pointProjection);
+        }
+        appendInterval(intervals, firstProjection, lastProjection);
+    }
+
+    // Open-path clipping intentionally omits some paths that coincide with a clip boundary.
+    // Preserve these valid line segments explicitly, then merge them with the interior intervals.
+    for (size_t index = 0; index < clipPath.size(); ++index) {
+        const QPointF edgeStart = fromClipperPoint(clipPath[index]);
+        const QPointF edgeEnd = fromClipperPoint(clipPath[(index + 1) % clipPath.size()]);
+        const double edgeStartCross = (directionX * (edgeStart.y() - normalizedLineStart.y())) -
+                                      (directionY * (edgeStart.x() - normalizedLineStart.x()));
+        const double edgeEndCross = (directionX * (edgeEnd.y() - normalizedLineStart.y())) -
+                                    (directionY * (edgeEnd.x() - normalizedLineStart.x()));
+        if ((std::abs(edgeStartCross) <= collinearityTolerance) && (std::abs(edgeEndCross) <= collinearityTolerance)) {
+            const double edgeStartProjection = projection(edgeStart);
+            const double edgeEndProjection = projection(edgeEnd);
+            appendInterval(intervals, (std::min) (edgeStartProjection, edgeEndProjection),
+                           (std::max) (edgeStartProjection, edgeEndProjection));
+        }
+    }
+
+    return linesFromIntervals(line, intervals);
+}
+
 }  // namespace
 
 QList<QLineF> QGCPolygonClipper::intersectLine(const QLineF& line, const QPolygonF& polygon)
@@ -193,17 +509,162 @@ QList<QList<QLineF>> QGCPolygonClipper::intersectLines(const QList<QLineF>& line
     }
 
     CoordinateNormalizer normalizer;
-    if (!createNormalizer(lines, polygon, normalizer)) {
+    if (!createNormalizer(polygon, normalizer)) {
         return results;
     }
 
-    const QList<QDoubleVector2D> clipPath = normalizedPath(polygon, normalizer);
-    if (clipPath.size() < 3) {
+    const QPolygonF clipPolygon = normalizedPath(polygon, normalizer);
+    if (clipPolygon.size() < 3) {
         return results;
     }
+    const Clipper2Lib::Path64 clipPath = toClipperPath(clipPolygon);
+    const QRectF polygonBounds = polygon.boundingRect();
 
     for (qsizetype index = 0; index < lines.size(); ++index) {
-        results[index] = intersectNormalizedLine(lines[index], clipPath, normalizer);
+        QLineF boundedLine;
+        if (clipLineToBounds(lines[index], polygonBounds, boundedLine)) {
+            results[index] = intersectNormalizedLine(boundedLine, clipPath, normalizer, polygon);
+        }
     }
     return results;
+}
+
+QList<QPolygonF> QGCPolygonClipper::offsetPolygon(const QPolygonF& polygon, double distance)
+{
+    if ((polygon.size() < 3) || !std::isfinite(distance)) {
+        return {};
+    }
+
+    CoordinateNormalizer normalizer;
+    if (!createNormalizer(polygon, normalizer)) {
+        return {};
+    }
+
+    const QPolygonF normalizedPolygon = normalizedPath(polygon, normalizer);
+    if (normalizedPolygon.size() < 3) {
+        return {};
+    }
+    if (qFuzzyIsNull(distance)) {
+        return {polygon};
+    }
+
+    const double scaledDistance = (distance / normalizer.extent) * coordinateScale;
+    if (!std::isfinite(scaledDistance) || (std::abs(scaledDistance) > maximumScaledOffset)) {
+        return {};
+    }
+
+    const Clipper2Lib::Paths64 resultPaths =
+        Clipper2Lib::InflatePaths({toClipperPath(normalizedPolygon)}, scaledDistance, Clipper2Lib::JoinType::Miter,
+                                  Clipper2Lib::EndType::Polygon, miterLimit);
+    QList<QPolygonF> result = fromClipperPaths(resultPaths, normalizer);
+    for (QPolygonF& resultPolygon : result) {
+        alignPolygonStart(resultPolygon, polygon.first());
+    }
+    return result;
+}
+
+QList<QPointF> QGCPolygonClipper::offsetPolyline(const QList<QPointF>& polyline, double distance)
+{
+    if ((polyline.size() < 2) || !std::isfinite(distance)) {
+        return {};
+    }
+
+    CoordinateNormalizer normalizer;
+    if (!createNormalizer(polyline, normalizer)) {
+        return {};
+    }
+    if (qFuzzyIsNull(distance)) {
+        return polyline;
+    }
+
+    QList<QPointF> normalizedPolyline;
+    normalizedPolyline.reserve(polyline.size());
+    for (const QPointF& point : polyline) {
+        appendUnique(normalizedPolyline, normalizer.normalize(point));
+    }
+
+    bool explicitlyClosed = false;
+    if ((normalizedPolyline.size() > 2) && (distanceSquared(normalizedPolyline.first(), normalizedPolyline.last()) <=
+                                            (normalizedPointTolerance * normalizedPointTolerance))) {
+        explicitlyClosed = true;
+        normalizedPolyline.removeLast();
+    }
+    if ((explicitlyClosed && (normalizedPolyline.size() < 3)) ||
+        (!explicitlyClosed && (normalizedPolyline.size() < 2))) {
+        return {};
+    }
+
+    const qsizetype segmentCount = explicitlyClosed ? normalizedPolyline.size() : normalizedPolyline.size() - 1;
+    QList<OffsetSegment> segments;
+    segments.reserve(segmentCount);
+    for (qsizetype index = 0; index < segmentCount; ++index) {
+        const QPointF delta = normalizedPolyline[(index + 1) % normalizedPolyline.size()] - normalizedPolyline[index];
+        const double length = std::hypot(delta.x(), delta.y());
+        if (!std::isfinite(length) || (length <= normalizedPointTolerance)) {
+            return {};
+        }
+        const QPointF direction(delta.x() / length, delta.y() / length);
+        segments.append({direction, QPointF(-direction.y(), direction.x())});
+    }
+
+    const double normalizedDistance = distance / normalizer.extent;
+    if (!std::isfinite(normalizedDistance)) {
+        return {};
+    }
+
+    QList<QPointF> normalizedResult;
+    normalizedResult.reserve(normalizedPolyline.size() + 2);
+    if (explicitlyClosed) {
+        for (qsizetype index = 0; index < normalizedPolyline.size(); ++index) {
+            const qsizetype previousSegmentIndex = (index + segmentCount - 1) % segmentCount;
+            appendOffsetJoin(normalizedResult, normalizedPolyline[index], segments[previousSegmentIndex],
+                             segments[index], normalizedDistance);
+        }
+        if (!normalizedResult.isEmpty()) {
+            normalizedResult.append(normalizedResult.first());
+        }
+    } else {
+        appendUnique(normalizedResult, normalizedPolyline.first() + (segments.first().leftNormal * normalizedDistance));
+        for (qsizetype index = 1; index < normalizedPolyline.size() - 1; ++index) {
+            appendOffsetJoin(normalizedResult, normalizedPolyline[index], segments[index - 1], segments[index],
+                             normalizedDistance);
+        }
+        appendUnique(normalizedResult, normalizedPolyline.last() + (segments.last().leftNormal * normalizedDistance));
+    }
+
+    QList<QPointF> result;
+    result.reserve(normalizedResult.size());
+    for (const QPointF& point : normalizedResult) {
+        result.append(normalizer.denormalize(point));
+    }
+    return result;
+}
+
+QPolygonF QGCPolygonClipper::bufferPolyline(const QList<QPointF>& polyline, double distance)
+{
+    if ((polyline.size() < 2) || !std::isfinite(distance) || (distance <= 0.0)) {
+        return {};
+    }
+
+    CoordinateNormalizer normalizer;
+    if (!createNormalizer(polyline, normalizer)) {
+        return {};
+    }
+
+    const double scaledDistance = (distance / normalizer.extent) * coordinateScale;
+    if (!std::isfinite(scaledDistance) || (scaledDistance > maximumScaledOffset)) {
+        return {};
+    }
+
+    Clipper2Lib::Path64 clipperPath = toClipperPath(polyline, normalizer);
+    Clipper2Lib::EndType endType = Clipper2Lib::EndType::Butt;
+    if ((clipperPath.size() > 2) && (clipperPath.front().x == clipperPath.back().x) &&
+        (clipperPath.front().y == clipperPath.back().y)) {
+        clipperPath.pop_back();
+        endType = Clipper2Lib::EndType::Joined;
+    }
+
+    const Clipper2Lib::Paths64 resultPaths =
+        Clipper2Lib::InflatePaths({clipperPath}, scaledDistance, Clipper2Lib::JoinType::Miter, endType, miterLimit);
+    return fromClipperCompoundPath(resultPaths, normalizer);
 }

--- a/src/Utilities/Geo/QGCPolygonClipper.cc
+++ b/src/Utilities/Geo/QGCPolygonClipper.cc
@@ -1,0 +1,209 @@
+#include "QGCPolygonClipper.h"
+
+#include <QtPositioning/private/qclipperutils_p.h>
+
+#include <algorithm>
+#include <cmath>
+#include <limits>
+#include <numeric>
+
+namespace {
+
+struct CoordinateNormalizer
+{
+    QPointF center;
+    double extent = 0.0;
+
+    [[nodiscard]] bool isValid() const { return std::isfinite(extent) && (extent > 0.0); }
+
+    [[nodiscard]] QDoubleVector2D normalize(const QPointF& point) const
+    {
+        return QDoubleVector2D((point.x() - center.x()) / extent, (point.y() - center.y()) / extent);
+    }
+};
+
+bool updateBounds(const QPointF& point, double& minimumX, double& minimumY, double& maximumX, double& maximumY)
+{
+    if (!std::isfinite(point.x()) || !std::isfinite(point.y())) {
+        return false;
+    }
+
+    minimumX = (std::min) (minimumX, point.x());
+    minimumY = (std::min) (minimumY, point.y());
+    maximumX = (std::max) (maximumX, point.x());
+    maximumY = (std::max) (maximumY, point.y());
+    return true;
+}
+
+bool createNormalizer(const QList<QLineF>& lines, const QPolygonF& polygon, CoordinateNormalizer& normalizer)
+{
+    double minimumX = std::numeric_limits<double>::infinity();
+    double minimumY = std::numeric_limits<double>::infinity();
+    double maximumX = -std::numeric_limits<double>::infinity();
+    double maximumY = -std::numeric_limits<double>::infinity();
+
+    for (const QLineF& line : lines) {
+        if (!updateBounds(line.p1(), minimumX, minimumY, maximumX, maximumY) ||
+            !updateBounds(line.p2(), minimumX, minimumY, maximumX, maximumY)) {
+            return false;
+        }
+    }
+    for (const QPointF& point : polygon) {
+        if (!updateBounds(point, minimumX, minimumY, maximumX, maximumY)) {
+            return false;
+        }
+    }
+
+    if (!std::isfinite(minimumX)) {
+        return false;
+    }
+
+    normalizer.center = QPointF(std::midpoint(minimumX, maximumX), std::midpoint(minimumY, maximumY));
+    normalizer.extent = (std::max) (maximumX - minimumX, maximumY - minimumY);
+    return normalizer.isValid();
+}
+
+struct LineInterval
+{
+    double start = 0.0;
+    double end = 0.0;
+};
+
+QList<QDoubleVector2D> normalizedPath(const QPolygonF& polygon, const CoordinateNormalizer& normalizer)
+{
+    qsizetype pointCount = polygon.size();
+    if ((pointCount > 1) && (polygon.first() == polygon.last())) {
+        --pointCount;
+    }
+
+    QList<QDoubleVector2D> result;
+    result.reserve(pointCount);
+    for (qsizetype index = 0; index < pointCount; ++index) {
+        result.append(normalizer.normalize(polygon[index]));
+    }
+    return result;
+}
+
+QList<QLineF> intersectNormalizedLine(const QLineF& line, const QList<QDoubleVector2D>& clipPath,
+                                      const CoordinateNormalizer& normalizer)
+{
+    if (line.isNull()) {
+        return {};
+    }
+
+    QClipperUtils clipper;
+    const QDoubleVector2D normalizedLineStart = normalizer.normalize(line.p1());
+    const QDoubleVector2D normalizedLineEnd = normalizer.normalize(line.p2());
+    clipper.addSubjectPath({normalizedLineStart, normalizedLineEnd}, false);
+    clipper.addClipPolygon(clipPath);
+
+    const double directionX = normalizedLineEnd.x() - normalizedLineStart.x();
+    const double directionY = normalizedLineEnd.y() - normalizedLineStart.y();
+    const double directionLengthSquared = (directionX * directionX) + (directionY * directionY);
+    if (!std::isfinite(directionLengthSquared) || (directionLengthSquared <= 0.0)) {
+        return {};
+    }
+
+    const auto projection = [directionX, directionY, directionLengthSquared,
+                             &normalizedLineStart](const QDoubleVector2D& point) {
+        return (((point.x() - normalizedLineStart.x()) * directionX) +
+                ((point.y() - normalizedLineStart.y()) * directionY)) /
+               directionLengthSquared;
+    };
+
+    constexpr double intervalTolerance = 1e-12;
+    const double collinearityTolerance =
+        64.0 * std::numeric_limits<double>::epsilon() * std::sqrt(directionLengthSquared);
+    QList<LineInterval> intervals;
+    const auto appendInterval = [&intervals](double start, double end) {
+        start = std::clamp(start, 0.0, 1.0);
+        end = std::clamp(end, 0.0, 1.0);
+        if ((end - start) > intervalTolerance) {
+            intervals.append({start, end});
+        }
+    };
+
+    const QList<QList<QDoubleVector2D>> clippedPaths =
+        clipper.execute(QClipperUtils::Intersection, QClipperUtils::pftEvenOdd, QClipperUtils::pftEvenOdd);
+    for (const QList<QDoubleVector2D>& path : clippedPaths) {
+        if (path.size() < 2) {
+            continue;
+        }
+
+        double firstProjection = std::numeric_limits<double>::infinity();
+        double lastProjection = -std::numeric_limits<double>::infinity();
+        for (const QDoubleVector2D& point : path) {
+            const double pointProjection = projection(point);
+            firstProjection = (std::min) (firstProjection, pointProjection);
+            lastProjection = (std::max) (lastProjection, pointProjection);
+        }
+        appendInterval(firstProjection, lastProjection);
+    }
+
+    // Clipper excludes open paths coincident with a clip boundary. Preserve those valid line
+    // segments explicitly, then merge them with the interior intervals below.
+    for (qsizetype index = 0; index < clipPath.size(); ++index) {
+        const QDoubleVector2D& edgeStart = clipPath[index];
+        const QDoubleVector2D& edgeEnd = clipPath[(index + 1) % clipPath.size()];
+        const double edgeStartCross = (directionX * (edgeStart.y() - normalizedLineStart.y())) -
+                                      (directionY * (edgeStart.x() - normalizedLineStart.x()));
+        const double edgeEndCross = (directionX * (edgeEnd.y() - normalizedLineStart.y())) -
+                                    (directionY * (edgeEnd.x() - normalizedLineStart.x()));
+        if ((std::abs(edgeStartCross) <= collinearityTolerance) && (std::abs(edgeEndCross) <= collinearityTolerance)) {
+            const double edgeStartProjection = projection(edgeStart);
+            const double edgeEndProjection = projection(edgeEnd);
+            appendInterval((std::min) (edgeStartProjection, edgeEndProjection),
+                           (std::max) (edgeStartProjection, edgeEndProjection));
+        }
+    }
+
+    std::sort(intervals.begin(), intervals.end(),
+              [](const LineInterval& first, const LineInterval& second) { return first.start < second.start; });
+
+    QList<LineInterval> mergedIntervals;
+    for (const LineInterval& interval : intervals) {
+        if (!mergedIntervals.isEmpty() && (interval.start <= (mergedIntervals.last().end + intervalTolerance))) {
+            mergedIntervals.last().end = (std::max) (mergedIntervals.last().end, interval.end);
+        } else {
+            mergedIntervals.append(interval);
+        }
+    }
+
+    QList<QLineF> result;
+    result.reserve(mergedIntervals.size());
+    for (const LineInterval& interval : mergedIntervals) {
+        result.append(QLineF(line.pointAt(interval.start), line.pointAt(interval.end)));
+    }
+    return result;
+}
+
+}  // namespace
+
+QList<QLineF> QGCPolygonClipper::intersectLine(const QLineF& line, const QPolygonF& polygon)
+{
+    const QList<QList<QLineF>> results = intersectLines({line}, polygon);
+    return results.isEmpty() ? QList<QLineF>{} : results.first();
+}
+
+QList<QList<QLineF>> QGCPolygonClipper::intersectLines(const QList<QLineF>& lines, const QPolygonF& polygon)
+{
+    QList<QList<QLineF>> results(lines.size());
+    if (lines.isEmpty()) {
+        return results;
+    }
+
+    CoordinateNormalizer normalizer;
+    if (!createNormalizer(lines, polygon, normalizer)) {
+        return results;
+    }
+
+    const QList<QDoubleVector2D> clipPath = normalizedPath(polygon, normalizer);
+    if (clipPath.size() < 3) {
+        return results;
+    }
+
+    for (qsizetype index = 0; index < lines.size(); ++index) {
+        results[index] = intersectNormalizedLine(lines[index], clipPath, normalizer);
+    }
+    return results;
+}

--- a/src/Utilities/Geo/QGCPolygonClipper.h
+++ b/src/Utilities/Geo/QGCPolygonClipper.h
@@ -1,0 +1,17 @@
+#pragma once
+
+#include <QtCore/QLineF>
+#include <QtCore/QList>
+#include <QtGui/QPolygonF>
+
+namespace QGCPolygonClipper {
+
+/// Clips a directed line segment to a planar polygon.
+/// Results are ordered from line.p1() to line.p2() and preserve that direction.
+[[nodiscard]] QList<QLineF> intersectLine(const QLineF& line, const QPolygonF& polygon);
+
+/// Clips directed line segments to a planar polygon.
+/// The result at each index contains the ordered fragments for the corresponding input line.
+[[nodiscard]] QList<QList<QLineF>> intersectLines(const QList<QLineF>& lines, const QPolygonF& polygon);
+
+}  // namespace QGCPolygonClipper

--- a/src/Utilities/Geo/QGCPolygonClipper.h
+++ b/src/Utilities/Geo/QGCPolygonClipper.h
@@ -14,4 +14,16 @@ namespace QGCPolygonClipper {
 /// The result at each index contains the ordered fragments for the corresponding input line.
 [[nodiscard]] QList<QList<QLineF>> intersectLines(const QList<QLineF>& lines, const QPolygonF& polygon);
 
+/// Offsets a planar polygon by distance. Positive distances expand the polygon.
+/// Multiple polygons can be returned when an inward offset separates a concave polygon.
+[[nodiscard]] QList<QPolygonF> offsetPolygon(const QPolygonF& polygon, double distance);
+
+/// Builds a directed parallel path. Positive distances offset to the left of travel.
+/// Explicitly closed input produces explicitly closed output.
+[[nodiscard]] QList<QPointF> offsetPolyline(const QList<QPointF>& polyline, double distance);
+
+/// Builds a planar buffer around a polyline. Explicitly closed paths preserve their interior hole.
+/// Multiple contours are joined by zero-width bridges for use with odd-even polygon filling.
+[[nodiscard]] QPolygonF bufferPolyline(const QList<QPointF>& polyline, double distance);
+
 }  // namespace QGCPolygonClipper

--- a/test/MissionManager/QGCMapPolygonTest.cc
+++ b/test/MissionManager/QGCMapPolygonTest.cc
@@ -313,6 +313,22 @@ void QGCMapPolygonTest::_testCenterDegenerate()
     QCOMPARE_COORDS(center, expectedCenter);
 }
 
+void QGCMapPolygonTest::_testOffset()
+{
+    _mapPolygon->appendVertices(_polyPoints);
+    _mapPolygon->verifyClockwiseWinding();
+    const QList<QGeoCoordinate> originalCoordinates = _mapPolygon->coordinateList();
+    const double originalArea = _mapPolygon->area();
+
+    _mapPolygon->offset(10.0);
+
+    QCOMPARE(_mapPolygon->count(), originalCoordinates.size());
+    QVERIFY(_mapPolygon->area() > originalArea);
+    for (const QGeoCoordinate& coordinate : originalCoordinates) {
+        QVERIFY(_mapPolygon->containsCoordinate(coordinate));
+    }
+}
+
 #include "UnitTest.h"
 
 UT_REGISTER_TEST(QGCMapPolygonTest, TestLabel::Unit, TestLabel::MissionManager)

--- a/test/MissionManager/QGCMapPolygonTest.h
+++ b/test/MissionManager/QGCMapPolygonTest.h
@@ -28,6 +28,7 @@ private slots:
     void _testCenterRectangle();
     void _testCenterExtraVertex();
     void _testCenterDegenerate();
+    void _testOffset();
 
 private:
     std::unique_ptr<MultiSignalSpy> _multiSpyPolygon;

--- a/test/MissionManager/QGCMapPolylineTest.cc
+++ b/test/MissionManager/QGCMapPolylineTest.cc
@@ -4,13 +4,15 @@
 #include <QtCore/QDir>
 #include <QtCore/QFile>
 #include <QtCore/QRegularExpression>
+#include <QtCore/QTemporaryDir>
+
+#include <cmath>
 
 #include "MultiSignalSpy.h"
-#include "UnitTestCoords.h"
 #include "QGCMapPolyline.h"
 #include "QGCQGeoCoordinate.h"
 #include "QmlObjectListModel.h"
-#include <QtCore/QTemporaryDir>
+#include "UnitTestCoords.h"
 
 void QGCMapPolylineTest::init()
 {
@@ -197,6 +199,23 @@ void QGCMapPolylineTest::_testSelectVertex()
     _mapPolyline->selectVertex(_linePoints.count() - 1);
     _mapPolyline->removeVertex(0);
     QVERIFY(_mapPolyline->selectedVertex() == (_mapPolyline->count() - 1));
+}
+
+void QGCMapPolylineTest::_testOffset()
+{
+    const QGeoCoordinate start = TestFixtures::Coord::missionTestOrigin();
+    const QGeoCoordinate end = start.atDistanceAndAzimuth(100.0, 90.0);
+    _mapPolyline->appendVertices({start, end});
+
+    const QList<QGeoCoordinate> leftOffset = _mapPolyline->offsetPolyline(10.0);
+    QCOMPARE(leftOffset.size(), 2);
+    QVERIFY(std::abs(start.distanceTo(leftOffset.first()) - 10.0) < 0.01);
+    QVERIFY(std::abs(std::remainder(start.azimuthTo(leftOffset.first()), 360.0)) < 0.01);
+
+    const QList<QGeoCoordinate> rightOffset = _mapPolyline->offsetPolyline(-10.0);
+    QCOMPARE(rightOffset.size(), 2);
+    QVERIFY(std::abs(start.distanceTo(rightOffset.first()) - 10.0) < 0.01);
+    QVERIFY(std::abs(std::remainder(start.azimuthTo(rightOffset.first()) - 180.0, 360.0)) < 0.01);
 }
 
 UT_REGISTER_TEST(QGCMapPolylineTest, TestLabel::Unit, TestLabel::MissionManager)

--- a/test/MissionManager/QGCMapPolylineTest.h
+++ b/test/MissionManager/QGCMapPolylineTest.h
@@ -20,6 +20,7 @@ private slots:
     void _testVertexManipulation();
     void _testShapeLoad();
     void _testSelectVertex();
+    void _testOffset();
 
 private:
     QString _copyRes(const QString& dirPath, const QString& name);

--- a/test/MissionManager/SurveyComplexItemTest.cc
+++ b/test/MissionManager/SurveyComplexItemTest.cc
@@ -412,7 +412,44 @@ void SurveyComplexItemTest::_testSplitConcavePolygon()
     _surveyItem->flyAlternateTransects()->setRawValue(false);
     ignoreLogMessage("Plan.SurveyComplexItem", QtWarningMsg, QRegularExpression("Transect spacing.*raised"));
     _surveyItem->cameraCalc()->adjustedFootprintSide()->setRawValue(0.001);
-    QVERIFY(_surveyItem->_transectCount() <= TransectStyleComplexItem::maxTransectCount);
+    const int cappedTransectCount = _surveyItem->_transectCount();
+    QVERIFY(cappedTransectCount > 0);
+    QVERIFY(cappedTransectCount <= TransectStyleComplexItem::maxTransectCount);
+
+    constexpr int combToothCount = TransectStyleComplexItem::maxTransectCount + 1;
+    constexpr double combHeight = 3.0;
+    constexpr double combNotchDepth = 1.0;
+    const double combWidth = (2.0 * combToothCount) - 1.0;
+    QPolygonF combPolygon = {{0.0, 0.0}, {combWidth, 0.0}, {combWidth, combHeight}};
+    for (int toothIndex = combToothCount - 1; toothIndex >= 0; --toothIndex) {
+        const double toothLeft = 2.0 * toothIndex;
+        combPolygon.append(QPointF(toothLeft, combHeight));
+        if (toothIndex > 0) {
+            combPolygon.append(QPointF(toothLeft, combNotchDepth));
+            combPolygon.append(QPointF(toothLeft - 1.0, combNotchDepth));
+            combPolygon.append(QPointF(toothLeft - 1.0, combHeight));
+        }
+    }
+    combPolygon.append(QPointF(0.0, 0.0));
+
+    QList<QGeoCoordinate> combCoordinates;
+    combCoordinates.reserve(combPolygon.size() - 1);
+    for (qsizetype index = 0; index + 1 < combPolygon.size(); ++index) {
+        QGeoCoordinate coordinate;
+        QGCGeo::convertNedToGeo(combPolygon[index].y(), combPolygon[index].x(), 0.0, tangentOrigin, coordinate);
+        combCoordinates.append(coordinate);
+    }
+
+    _surveyItem->cameraCalc()->adjustedFootprintSide()->setRawValue(1e9);
+    ignoreLogMessage("Plan.SurveyComplexItem", QtWarningMsg,
+                     QRegularExpression("Unable to limit split transect count.*joining fragments"));
+    _mapPolygon->beginReset();
+    _mapPolygon->clear();
+    _mapPolygon->appendVertices(combCoordinates);
+    _mapPolygon->endReset();
+    const int fallbackTransectCount = _surveyItem->_transectCount();
+    QVERIFY(fallbackTransectCount > 0);
+    QVERIFY(fallbackTransectCount <= TransectStyleComplexItem::maxTransectCount);
 }
 
 UT_REGISTER_TEST(SurveyComplexItemTest, TestLabel::Unit, TestLabel::MissionManager)

--- a/test/MissionManager/SurveyComplexItemTest.cc
+++ b/test/MissionManager/SurveyComplexItemTest.cc
@@ -3,6 +3,7 @@
 #include "CoordFixtures.h"
 #include "MultiSignalSpy.h"
 #include "PlanViewSettings.h"
+#include "QGCGeo.h"
 #include "SurveyComplexItem.h"
 #include "TransectStyleComplexItem.h"
 
@@ -68,7 +69,7 @@ void SurveyComplexItemTest::_testDirty()
     _multiSpy->clearAllSignals();
     // These facts should set dirty when changed
     QList<Fact*> rgFacts;
-    rgFacts << _surveyItem->gridAngle() << _surveyItem->flyAlternateTransects();
+    rgFacts << _surveyItem->gridAngle() << _surveyItem->flyAlternateTransects() << _surveyItem->splitConcavePolygons();
     for (Fact* fact : rgFacts) {
         qCDebug(UnitTestLog) << fact->name();
         QVERIFY(!_surveyItem->dirty());
@@ -334,6 +335,84 @@ void SurveyComplexItemTest::_testMaxTransectCount()
         QCOMPARE(rebuildSpy.count(), 1);
         QCOMPARE(_surveyItem->_transectCount(), 1);
     }
+}
+
+void SurveyComplexItemTest::_testSplitConcavePolygon()
+{
+    const QGeoCoordinate tangentOrigin = TestFixtures::Coord::missionTestOrigin();
+    const QPolygonF localPolygon = {
+        {0.0, 0.0},   {100.0, 0.0},  {100.0, 100.0}, {60.0, 100.0}, {60.0, 40.0},
+        {40.0, 40.0}, {40.0, 100.0}, {0.0, 100.0},   {0.0, 0.0},
+    };
+
+    QList<QGeoCoordinate> polygonCoordinates;
+    polygonCoordinates.reserve(localPolygon.size() - 1);
+    for (qsizetype index = 0; index + 1 < localPolygon.size(); ++index) {
+        QGeoCoordinate coordinate;
+        QGCGeo::convertNedToGeo(localPolygon[index].y(), localPolygon[index].x(), 0.0, tangentOrigin, coordinate);
+        polygonCoordinates.append(coordinate);
+    }
+
+    _mapPolygon->beginReset();
+    _mapPolygon->clear();
+    _mapPolygon->appendVertices(polygonCoordinates);
+    _mapPolygon->endReset();
+    _surveyItem->turnAroundDistance()->setRawValue(0.0);
+    _surveyItem->hoverAndCapture()->setRawValue(false);
+    _surveyItem->gridAngle()->setRawValue(90.0);
+    _surveyItem->cameraCalc()->adjustedFootprintSide()->setRawValue(20.0);
+
+    const auto allTransectMidpointsInside = [&localPolygon, &tangentOrigin](const QVariantList& points) {
+        if ((points.size() % 2) != 0) {
+            return false;
+        }
+
+        for (qsizetype index = 0; index < points.size(); index += 2) {
+            double firstNorth = 0.0;
+            double firstEast = 0.0;
+            double firstDown = 0.0;
+            double secondNorth = 0.0;
+            double secondEast = 0.0;
+            double secondDown = 0.0;
+            QGCGeo::convertGeoToNed(points[index].value<QGeoCoordinate>(), tangentOrigin, firstNorth, firstEast,
+                                    firstDown);
+            QGCGeo::convertGeoToNed(points[index + 1].value<QGeoCoordinate>(), tangentOrigin, secondNorth, secondEast,
+                                    secondDown);
+            const QPointF midpoint((firstEast + secondEast) / 2.0, (firstNorth + secondNorth) / 2.0);
+            if (!localPolygon.containsPoint(midpoint, Qt::OddEvenFill)) {
+                return false;
+            }
+        }
+        return true;
+    };
+
+    _surveyItem->splitConcavePolygons()->setRawValue(false);
+    const int joinedTransectCount = _surveyItem->_transectCount();
+    QVERIFY(!allTransectMidpointsInside(_surveyItem->visualTransectPoints()));
+
+    _surveyItem->splitConcavePolygons()->setRawValue(true);
+    const int splitTransectCount = _surveyItem->_transectCount();
+    QVERIFY(splitTransectCount > joinedTransectCount);
+
+    for (int refly = 0; refly < 2; ++refly) {
+        _surveyItem->refly90Degrees()->setRawValue(refly != 0);
+        const int expectedTransectCount = _surveyItem->_transectCount();
+        QVERIFY(expectedTransectCount >= splitTransectCount);
+        for (int alternate = 0; alternate < 2; ++alternate) {
+            _surveyItem->flyAlternateTransects()->setRawValue(alternate != 0);
+            for (int entryLocation = 0; entryLocation < 4; ++entryLocation) {
+                QCOMPARE(_surveyItem->_transectCount(), expectedTransectCount);
+                QVERIFY(allTransectMidpointsInside(_surveyItem->visualTransectPoints()));
+                _surveyItem->rotateEntryPoint();
+            }
+        }
+    }
+
+    _surveyItem->refly90Degrees()->setRawValue(false);
+    _surveyItem->flyAlternateTransects()->setRawValue(false);
+    ignoreLogMessage("Plan.SurveyComplexItem", QtWarningMsg, QRegularExpression("Transect spacing.*raised"));
+    _surveyItem->cameraCalc()->adjustedFootprintSide()->setRawValue(0.001);
+    QVERIFY(_surveyItem->_transectCount() <= TransectStyleComplexItem::maxTransectCount);
 }
 
 UT_REGISTER_TEST(SurveyComplexItemTest, TestLabel::Unit, TestLabel::MissionManager)

--- a/test/MissionManager/SurveyComplexItemTest.h
+++ b/test/MissionManager/SurveyComplexItemTest.h
@@ -30,6 +30,7 @@ private slots:
     void _testItemCount();
     void _testHoverCaptureItemGeneration();
     void _testMaxTransectCount();
+    void _testSplitConcavePolygon();
 
 private:
     double _clampGridAngle180(double gridAngle);

--- a/test/Utilities/Geo/CMakeLists.txt
+++ b/test/Utilities/Geo/CMakeLists.txt
@@ -11,6 +11,8 @@ target_sources(${CMAKE_PROJECT_NAME}
         GeoTest.h
         KMLDomDocumentTest.cc
         KMLDomDocumentTest.h
+        PolygonClipperTest.cc
+        PolygonClipperTest.h
         ShapeTest.cc
         ShapeTest.h
 )
@@ -38,4 +40,5 @@ qt_add_resources(${CMAKE_PROJECT_NAME} "Test_Utilities_Geo_res"
 add_qgc_test(GeoTest LABELS Unit Utilities)
 add_qgc_test(GeoJsonHelperTest LABELS Unit Utilities)
 add_qgc_test(KMLDomDocumentTest LABELS Unit Utilities)
+add_qgc_test(PolygonClipperTest LABELS Unit Utilities)
 add_qgc_test(ShapeTest LABELS Unit Utilities)

--- a/test/Utilities/Geo/PolygonClipperTest.cc
+++ b/test/Utilities/Geo/PolygonClipperTest.cc
@@ -1,5 +1,9 @@
 #include "PolygonClipperTest.h"
 
+#include <algorithm>
+#include <cmath>
+#include <limits>
+
 #include "QGCPolygonClipper.h"
 
 namespace {
@@ -43,7 +47,21 @@ void PolygonClipperTest::_lineIntersection_test()
     QVERIFY(QGCPolygonClipper::intersectLine(QLineF(-5.0, 15.0, 15.0, 15.0), polygon).isEmpty());
 
     const QPolygonF largePolygon = square(0.0, 0.0, 1e9, 1e9);
+    const QLineF shortContainedLine(1.0, 5e8, 1.000001, 5e8);
+    const QList<QLineF> shortContained = QGCPolygonClipper::intersectLine(shortContainedLine, largePolygon);
+    QCOMPARE(shortContained, QList<QLineF>{shortContainedLine});
     QVERIFY(QGCPolygonClipper::intersectLine(QLineF(1.0, 2e9, 1.000001, 2e9), largePolygon).isEmpty());
+
+    const QPolygonF largeConcavePolygon = {
+        {0.0, 0.0}, {1e9, 0.0}, {1e9, 1e9}, {4e8 + 1.0, 1e9}, {4e8 + 1.0, 4e8},
+        {4e8, 4e8}, {4e8, 1e9}, {0.0, 1e9}, {0.0, 0.0},
+    };
+    const QList<QLineF> shortBoundaryCrossing =
+        QGCPolygonClipper::intersectLine(QLineF(4e8 - 1e-6, 5e8, 4e8 + 1e-6, 5e8), largeConcavePolygon);
+    QCOMPARE(shortBoundaryCrossing.size(), 1);
+    QVERIFY(fuzzyPointCompare(shortBoundaryCrossing.first().p1(), QPointF(4e8 - 1e-6, 5e8), 1e-9));
+    QVERIFY(fuzzyPointCompare(shortBoundaryCrossing.first().p2(), QPointF(4e8, 5e8), 1e-9));
+    QVERIFY(QGCPolygonClipper::intersectLine(QLineF(4e8 + 1e-6, 5e8, 4e8 + 2e-6, 5e8), largeConcavePolygon).isEmpty());
 }
 
 void PolygonClipperTest::_batchLineIntersection_test()
@@ -64,6 +82,12 @@ void PolygonClipperTest::_batchLineIntersection_test()
     QCOMPARE(clippedLines[2].size(), 1);
     QVERIFY(fuzzyPointCompare(clippedLines[2].first().p1(), QPointF(10.0, 8.0)));
     QVERIFY(fuzzyPointCompare(clippedLines[2].first().p2(), QPointF(0.0, 8.0)));
+
+    const QList<QList<QLineF>> clippedWithDistantLine =
+        QGCPolygonClipper::intersectLines({QLineF(2.0, 5.0, 8.0, 5.0), QLineF(1e16, 1e16, 1e16 + 10.0, 1e16)}, polygon);
+    QCOMPARE(clippedWithDistantLine.size(), 2);
+    QCOMPARE(clippedWithDistantLine.first(), QList<QLineF>{QLineF(2.0, 5.0, 8.0, 5.0)});
+    QVERIFY(clippedWithDistantLine.last().isEmpty());
 }
 
 void PolygonClipperTest::_concaveLineIntersection_test()
@@ -91,6 +115,101 @@ void PolygonClipperTest::_largeCoordinateLineIntersection_test()
     QCOMPARE(clipped.size(), 1);
     QVERIFY(fuzzyPointCompare(clipped.first().p1(), QPointF(offset, offset + 5.0), 1e-6));
     QVERIFY(fuzzyPointCompare(clipped.first().p2(), QPointF(offset + 10.0, offset + 5.0), 1e-6));
+}
+
+void PolygonClipperTest::_polygonOffset_test()
+{
+    const QList<QPolygonF> expanded = QGCPolygonClipper::offsetPolygon(square(0.0, 0.0, 10.0, 10.0), 2.0);
+    QCOMPARE(expanded.size(), 1);
+    const QRectF expandedBounds = expanded.first().boundingRect();
+    QVERIFY(fuzzyPointCompare(expandedBounds.topLeft(), QPointF(-2.0, -2.0), 1e-9));
+    QVERIFY(fuzzyPointCompare(expandedBounds.bottomRight(), QPointF(12.0, 12.0), 1e-9));
+
+    QPolygonF reversedPolygon = square(0.0, 0.0, 10.0, 10.0);
+    std::reverse(reversedPolygon.begin(), reversedPolygon.end());
+    const QList<QPolygonF> reversedExpanded = QGCPolygonClipper::offsetPolygon(reversedPolygon, 2.0);
+    QCOMPARE(reversedExpanded.size(), 1);
+    QCOMPARE(reversedExpanded.first().boundingRect(), expandedBounds);
+
+    const QList<QPolygonF> contracted = QGCPolygonClipper::offsetPolygon(square(0.0, 0.0, 10.0, 10.0), -2.0);
+    QCOMPARE(contracted.size(), 1);
+    const QRectF contractedBounds = contracted.first().boundingRect();
+    QVERIFY(fuzzyPointCompare(contractedBounds.topLeft(), QPointF(2.0, 2.0), 1e-9));
+    QVERIFY(fuzzyPointCompare(contractedBounds.bottomRight(), QPointF(8.0, 8.0), 1e-9));
+
+    QVERIFY(QGCPolygonClipper::offsetPolygon(square(0.0, 0.0, 10.0, 10.0), -6.0).isEmpty());
+}
+
+void PolygonClipperTest::_polylineOffset_test()
+{
+    const QList<QPointF> polyline = {QPointF(0.0, 0.0), QPointF(10.0, 0.0), QPointF(10.0, 10.0)};
+
+    const QList<QPointF> leftOffset = QGCPolygonClipper::offsetPolyline(polyline, 2.0);
+    QCOMPARE(leftOffset.size(), 3);
+    QVERIFY(fuzzyPointCompare(leftOffset[0], QPointF(0.0, 2.0)));
+    QVERIFY(fuzzyPointCompare(leftOffset[1], QPointF(8.0, 2.0)));
+    QVERIFY(fuzzyPointCompare(leftOffset[2], QPointF(8.0, 10.0)));
+
+    const QList<QPointF> rightOffset = QGCPolygonClipper::offsetPolyline(polyline, -2.0);
+    QCOMPARE(rightOffset.size(), 3);
+    QVERIFY(fuzzyPointCompare(rightOffset[0], QPointF(0.0, -2.0)));
+    QVERIFY(fuzzyPointCompare(rightOffset[1], QPointF(12.0, -2.0)));
+    QVERIFY(fuzzyPointCompare(rightOffset[2], QPointF(12.0, 10.0)));
+
+    QCOMPARE(QGCPolygonClipper::offsetPolyline(polyline, 0.0), polyline);
+    QVERIFY(QGCPolygonClipper::offsetPolyline({QPointF(0.0, 0.0)}, 2.0).isEmpty());
+    QVERIFY(QGCPolygonClipper::offsetPolyline(polyline, std::numeric_limits<double>::infinity()).isEmpty());
+
+    const QList<QPointF> duplicatePointOffset =
+        QGCPolygonClipper::offsetPolyline({QPointF(0.0, 0.0), QPointF(0.0, 0.0), QPointF(10.0, 0.0)}, 2.0);
+    QCOMPARE(duplicatePointOffset.size(), 2);
+    QVERIFY(fuzzyPointCompare(duplicatePointOffset[0], QPointF(0.0, 2.0)));
+    QVERIFY(fuzzyPointCompare(duplicatePointOffset[1], QPointF(10.0, 2.0)));
+
+    constexpr double largeCoordinate = 1e9;
+    const QList<QPointF> largeCoordinateOffset = QGCPolygonClipper::offsetPolyline(
+        {QPointF(largeCoordinate, largeCoordinate), QPointF(largeCoordinate + 10.0, largeCoordinate)}, 2.0);
+    QCOMPARE(largeCoordinateOffset.size(), 2);
+    QVERIFY(fuzzyPointCompare(largeCoordinateOffset[0], QPointF(largeCoordinate, largeCoordinate + 2.0), 1e-6));
+    QVERIFY(fuzzyPointCompare(largeCoordinateOffset[1], QPointF(largeCoordinate + 10.0, largeCoordinate + 2.0), 1e-6));
+
+    const QList<QPointF> reversal = QGCPolygonClipper::offsetPolyline(
+        {QPointF(0.0, 0.0), QPointF(10.0, 0.0), QPointF(0.0, 0.0), QPointF(-10.0, 0.0)}, 2.0);
+    QCOMPARE(reversal.size(), 5);
+    for (const QPointF& point : reversal) {
+        QVERIFY(std::isfinite(point.x()));
+        QVERIFY(std::isfinite(point.y()));
+        QVERIFY(std::abs(point.x()) <= 10.0);
+        QVERIFY(std::abs(point.y()) <= 2.0);
+    }
+
+    const QList<QPointF> closedOffset = QGCPolygonClipper::offsetPolyline(square(0.0, 0.0, 10.0, 10.0), 2.0);
+    QCOMPARE(closedOffset.size(), 5);
+    QCOMPARE(closedOffset.first(), closedOffset.last());
+    const QRectF closedOffsetBounds = QPolygonF(closedOffset).boundingRect();
+    QVERIFY(fuzzyPointCompare(closedOffsetBounds.topLeft(), QPointF(2.0, 2.0)));
+    QVERIFY(fuzzyPointCompare(closedOffsetBounds.bottomRight(), QPointF(8.0, 8.0)));
+}
+
+void PolygonClipperTest::_polylineBuffer_test()
+{
+    const QPolygonF buffered =
+        QGCPolygonClipper::bufferPolyline({QPointF(0.0, 0.0), QPointF(10.0, 0.0), QPointF(10.0, 10.0)}, 2.0);
+    QVERIFY(buffered.containsPoint(QPointF(5.0, 1.0), Qt::OddEvenFill));
+    QVERIFY(buffered.containsPoint(QPointF(9.0, 5.0), Qt::OddEvenFill));
+    QVERIFY(!buffered.containsPoint(QPointF(5.0, 3.0), Qt::OddEvenFill));
+    QVERIFY(!buffered.containsPoint(QPointF(-1.0, 0.0), Qt::OddEvenFill));
+    QVERIFY(QGCPolygonClipper::bufferPolyline({QPointF(0.0, 0.0)}, 2.0).isEmpty());
+    QVERIFY(QGCPolygonClipper::bufferPolyline({QPointF(0.0, 0.0), QPointF(10.0, 0.0)}, 0.0).isEmpty());
+}
+
+void PolygonClipperTest::_closedPolylineBuffer_test()
+{
+    const QPolygonF buffered = QGCPolygonClipper::bufferPolyline(square(0.0, 0.0, 10.0, 10.0), 2.0);
+
+    QVERIFY(buffered.containsPoint(QPointF(1.0, 5.0), Qt::OddEvenFill));
+    QVERIFY(!buffered.containsPoint(QPointF(5.0, 5.0), Qt::OddEvenFill));
+    QVERIFY(!buffered.containsPoint(QPointF(15.0, 5.0), Qt::OddEvenFill));
 }
 
 UT_REGISTER_TEST(PolygonClipperTest, TestLabel::Unit, TestLabel::Utilities)

--- a/test/Utilities/Geo/PolygonClipperTest.cc
+++ b/test/Utilities/Geo/PolygonClipperTest.cc
@@ -1,0 +1,96 @@
+#include "PolygonClipperTest.h"
+
+#include "QGCPolygonClipper.h"
+
+namespace {
+
+bool fuzzyPointCompare(const QPointF& actual, const QPointF& expected, double tolerance = 1e-9)
+{
+    return (QLineF(actual, expected).length() <= tolerance);
+}
+
+QPolygonF square(double left, double top, double right, double bottom)
+{
+    return {{left, top}, {right, top}, {right, bottom}, {left, bottom}, {left, top}};
+}
+
+}  // namespace
+
+void PolygonClipperTest::_lineIntersection_test()
+{
+    const QPolygonF polygon = square(0.0, 0.0, 10.0, 10.0);
+
+    const QList<QLineF> clipped = QGCPolygonClipper::intersectLine(QLineF(-5.0, 5.0, 15.0, 5.0), polygon);
+    QCOMPARE(clipped.size(), 1);
+    QVERIFY(fuzzyPointCompare(clipped.first().p1(), QPointF(0.0, 5.0)));
+    QVERIFY(fuzzyPointCompare(clipped.first().p2(), QPointF(10.0, 5.0)));
+
+    const QList<QLineF> reversed = QGCPolygonClipper::intersectLine(QLineF(15.0, 5.0, -5.0, 5.0), polygon);
+    QCOMPARE(reversed.size(), 1);
+    QVERIFY(fuzzyPointCompare(reversed.first().p1(), QPointF(10.0, 5.0)));
+    QVERIFY(fuzzyPointCompare(reversed.first().p2(), QPointF(0.0, 5.0)));
+
+    const QList<QLineF> contained = QGCPolygonClipper::intersectLine(QLineF(2.0, 5.0, 8.0, 5.0), polygon);
+    QCOMPARE(contained.size(), 1);
+    QVERIFY(fuzzyPointCompare(contained.first().p1(), QPointF(2.0, 5.0)));
+    QVERIFY(fuzzyPointCompare(contained.first().p2(), QPointF(8.0, 5.0)));
+
+    const QList<QLineF> boundary = QGCPolygonClipper::intersectLine(QLineF(-5.0, 0.0, 15.0, 0.0), polygon);
+    QCOMPARE(boundary.size(), 1);
+    QVERIFY(fuzzyPointCompare(boundary.first().p1(), QPointF(0.0, 0.0)));
+    QVERIFY(fuzzyPointCompare(boundary.first().p2(), QPointF(10.0, 0.0)));
+
+    QVERIFY(QGCPolygonClipper::intersectLine(QLineF(-5.0, 15.0, 15.0, 15.0), polygon).isEmpty());
+
+    const QPolygonF largePolygon = square(0.0, 0.0, 1e9, 1e9);
+    QVERIFY(QGCPolygonClipper::intersectLine(QLineF(1.0, 2e9, 1.000001, 2e9), largePolygon).isEmpty());
+}
+
+void PolygonClipperTest::_batchLineIntersection_test()
+{
+    const QPolygonF polygon = square(0.0, 0.0, 10.0, 10.0);
+    const QList<QLineF> lines = {
+        QLineF(-5.0, 2.0, 15.0, 2.0),
+        QLineF(-5.0, 15.0, 15.0, 15.0),
+        QLineF(15.0, 8.0, -5.0, 8.0),
+    };
+
+    const QList<QList<QLineF>> clippedLines = QGCPolygonClipper::intersectLines(lines, polygon);
+    QCOMPARE(clippedLines.size(), lines.size());
+    QCOMPARE(clippedLines[0].size(), 1);
+    QVERIFY(fuzzyPointCompare(clippedLines[0].first().p1(), QPointF(0.0, 2.0)));
+    QVERIFY(fuzzyPointCompare(clippedLines[0].first().p2(), QPointF(10.0, 2.0)));
+    QVERIFY(clippedLines[1].isEmpty());
+    QCOMPARE(clippedLines[2].size(), 1);
+    QVERIFY(fuzzyPointCompare(clippedLines[2].first().p1(), QPointF(10.0, 8.0)));
+    QVERIFY(fuzzyPointCompare(clippedLines[2].first().p2(), QPointF(0.0, 8.0)));
+}
+
+void PolygonClipperTest::_concaveLineIntersection_test()
+{
+    const QPolygonF polygon = {
+        {0.0, 0.0}, {10.0, 0.0}, {10.0, 10.0}, {7.0, 10.0}, {7.0, 3.0},
+        {3.0, 3.0}, {3.0, 10.0}, {0.0, 10.0},  {0.0, 0.0},
+    };
+
+    const QList<QLineF> clipped = QGCPolygonClipper::intersectLine(QLineF(-5.0, 5.0, 15.0, 5.0), polygon);
+    QCOMPARE(clipped.size(), 2);
+    QVERIFY(fuzzyPointCompare(clipped[0].p1(), QPointF(0.0, 5.0)));
+    QVERIFY(fuzzyPointCompare(clipped[0].p2(), QPointF(3.0, 5.0)));
+    QVERIFY(fuzzyPointCompare(clipped[1].p1(), QPointF(7.0, 5.0)));
+    QVERIFY(fuzzyPointCompare(clipped[1].p2(), QPointF(10.0, 5.0)));
+}
+
+void PolygonClipperTest::_largeCoordinateLineIntersection_test()
+{
+    constexpr double offset = 1e9;
+    const QPolygonF polygon = square(offset, offset, offset + 10.0, offset + 10.0);
+    const QList<QLineF> clipped =
+        QGCPolygonClipper::intersectLine(QLineF(offset - 5.0, offset + 5.0, offset + 15.0, offset + 5.0), polygon);
+
+    QCOMPARE(clipped.size(), 1);
+    QVERIFY(fuzzyPointCompare(clipped.first().p1(), QPointF(offset, offset + 5.0), 1e-6));
+    QVERIFY(fuzzyPointCompare(clipped.first().p2(), QPointF(offset + 10.0, offset + 5.0), 1e-6));
+}
+
+UT_REGISTER_TEST(PolygonClipperTest, TestLabel::Unit, TestLabel::Utilities)

--- a/test/Utilities/Geo/PolygonClipperTest.h
+++ b/test/Utilities/Geo/PolygonClipperTest.h
@@ -11,4 +11,8 @@ private slots:
     void _batchLineIntersection_test();
     void _concaveLineIntersection_test();
     void _largeCoordinateLineIntersection_test();
+    void _polygonOffset_test();
+    void _polylineOffset_test();
+    void _polylineBuffer_test();
+    void _closedPolylineBuffer_test();
 };

--- a/test/Utilities/Geo/PolygonClipperTest.h
+++ b/test/Utilities/Geo/PolygonClipperTest.h
@@ -1,0 +1,14 @@
+#pragma once
+
+#include "UnitTest.h"
+
+class PolygonClipperTest : public UnitTest
+{
+    Q_OBJECT
+
+private slots:
+    void _lineIntersection_test();
+    void _batchLineIntersection_test();
+    void _concaveLineIntersection_test();
+    void _largeCoordinateLineIntersection_test();
+};


### PR DESCRIPTION
## Summary

- enable the existing `SplitConcavePolygons` survey option and expose it in the survey editor
- split each survey grid line into all continuous intersections with a concave polygon, while preserving an efficient alternating transect order
- add a shared `QGCPolygonClipper` geometry adapter backed by Clipper2 2.0.1
- replace private Qt Positioning clipping and the map polygon/polyline brute-force offset implementations
- reuse the shared polygon and polyline operations for corridor buffers and guard degenerate offset results

## Validation

- `JOBS=10 just build`
- focused geometry and mission tests: 6/6 passed
- full Unit label: 261/262 passed; the only failure was the environment-dependent `BluetoothWorkerTest` reacting to local BlueZ `Device is powered off` warnings
- scoped formatting, logging, assertion, fixed-wait, and test-message checks passed for the new geometry code
