### PR TITLE
ci: harden workflows and finalize release attestations

### DIFF
--- a/.github/actions/README.md
+++ b/.github/actions/README.md
@@ -1,0 +1,17 @@
+# GitHub Actions
+
+This directory contains the local composite actions shared by QGroundControl workflows. See
+[`../ci-overview.md`](../ci-overview.md) for the complete workflow, action, and script layout.
+
+## External Action Reference Policy
+
+QGroundControl intentionally references external GitHub Actions by stable major-version tag, such as
+`actions/checkout@v7`, instead of pinning each action to a full commit SHA. Dependabot monitors these
+references and proposes action updates, while [the zizmor policy](../zizmor.yml) requires a tag or
+other ref pin and rejects unpinned branch references.
+
+Automated findings whose only concern is that a released action tag is mutable or is not a full
+commit SHA are accepted under this repository policy and do not require a code change. Reference
+this section when dismissing or responding to those findings. This exception does not apply to
+unversioned actions, branch references such as `@main`, unknown actions, or any warning that reports
+an additional security problem.

--- a/.github/actions/attest-and-upload/action.yml
+++ b/.github/actions/attest-and-upload/action.yml
@@ -88,7 +88,7 @@ runs:
       shell: bash
       env:
         BUILD_DIR: ${{ inputs.build-dir || format('{0}/build', runner.temp) }}
-        SBOM_PATH: ${{ runner.temp }}/${{ inputs.subject-name || inputs.package-name }}.dependencies.cdx.json
+        SBOM_PATH: ${{ format('{0}/{1}.dependencies.cdx.json', steps.src.outputs.parent, inputs.subject-name || inputs.package-name) }}
       run: |
         python3 "${GITHUB_WORKSPACE}/.github/scripts/generate_cpm_sbom.py" \
           --build-dir "${BUILD_DIR}" \

--- a/.github/actions/attest-and-upload/action.yml
+++ b/.github/actions/attest-and-upload/action.yml
@@ -12,6 +12,10 @@ inputs:
     description: 'Path to scan for SBOM (defaults to build dir)'
     required: false
     default: ''
+  build-dir:
+    description: 'CMake build directory used to inventory CPM dependencies'
+    required: false
+    default: ''
   subject-name:
     description: 'SBOM subject name (defaults to package-name)'
     required: false
@@ -55,14 +59,6 @@ inputs:
     description: 'Optional newline-separated paths to include in the GitHub artifact'
     required: false
     default: ''
-  additional-aws-artifact-name:
-    description: 'Optional filename for a second artifact uploaded to AWS'
-    required: false
-    default: ''
-  additional-aws-artifact-path:
-    description: 'Optional path for a second artifact uploaded to AWS'
-    required: false
-    default: ''
 
 runs:
   using: composite
@@ -78,6 +74,28 @@ runs:
           --override "${OVERRIDE}" \
           --default "${DEFAULT}"
 
+    - name: Verify or create SHA-256 checksum
+      id: checksum
+      shell: bash
+      env:
+        SOURCE_PATH: ${{ steps.src.outputs.path }}
+      run: |
+        python3 "${GITHUB_WORKSPACE}/.github/scripts/attest_helper.py" checksum \
+          --source-path "${SOURCE_PATH}"
+
+    - name: Generate CPM dependency SBOM
+      id: dependency-sbom
+      shell: bash
+      env:
+        BUILD_DIR: ${{ inputs.build-dir || format('{0}/build', runner.temp) }}
+        SBOM_PATH: ${{ runner.temp }}/${{ inputs.subject-name || inputs.package-name }}.dependencies.cdx.json
+      run: |
+        python3 "${GITHUB_WORKSPACE}/.github/scripts/generate_cpm_sbom.py" \
+          --build-dir "${BUILD_DIR}" \
+          --output "${SBOM_PATH}" \
+          --require-components
+        echo "path=${SBOM_PATH}" >> "${GITHUB_OUTPUT}"
+
     - name: Attest Build with SBOM
       uses: ./.github/actions/attest-sbom
       with:
@@ -85,12 +103,21 @@ runs:
         subject-name: ${{ inputs.subject-name || inputs.package-name }}
         scan-path: ${{ inputs.scan-path || format('{0}/build', runner.temp) }}
 
+    - name: Attest CPM dependency SBOM
+      if: github.event_name != 'pull_request'
+      uses: actions/attest@v4
+      with:
+        subject-path: ${{ steps.src.outputs.path }}
+        sbom-path: ${{ steps.dependency-sbom.outputs.path }}
+
     - name: Save artifact
       uses: actions/upload-artifact@v7
       with:
         name: ${{ inputs.package-name }}
         path: |
           ${{ steps.src.outputs.path }}
+          ${{ steps.checksum.outputs.path }}
+          ${{ steps.dependency-sbom.outputs.path }}
           ${{ inputs.additional-artifact-paths }}
         retention-days: ${{ inputs.retention-days != '' && inputs.retention-days || (github.event_name == 'pull_request' && '7' || '30') }}
         compression-level: ${{ inputs.compression-level }}
@@ -98,7 +125,7 @@ runs:
     - name: Upload to AWS
       if: >-
         fromJSON(inputs.upload-aws) &&
-        github.event_name == 'push' &&
+        (github.event_name == 'push' || (github.event_name == 'workflow_dispatch' && github.ref_type == 'tag')) &&
         github.repository_owner == 'mavlink' &&
         (inputs.aws-role-arn != '' || (inputs.aws-key-id != '' && inputs.aws-secret-access-key != ''))
       uses: ./.github/actions/aws-upload
@@ -110,17 +137,16 @@ runs:
         aws-secret-access-key: ${{ inputs.aws-secret-access-key }}
         aws-distribution-id: ${{ inputs.aws-distribution-id }}
 
-    - name: Upload additional artifact to AWS
+    - name: Upload checksum to AWS
       if: >-
         fromJSON(inputs.upload-aws) &&
-        github.event_name == 'push' &&
+        (github.event_name == 'push' || (github.event_name == 'workflow_dispatch' && github.ref_type == 'tag')) &&
         github.repository_owner == 'mavlink' &&
-        (inputs.aws-role-arn != '' || (inputs.aws-key-id != '' && inputs.aws-secret-access-key != '')) &&
-        (inputs.additional-aws-artifact-name != '' || inputs.additional-aws-artifact-path != '')
+        (inputs.aws-role-arn != '' || (inputs.aws-key-id != '' && inputs.aws-secret-access-key != ''))
       uses: ./.github/actions/aws-upload
       with:
-        artifact-name: ${{ inputs.additional-aws-artifact-name }}
-        artifact-path: ${{ inputs.additional-aws-artifact-path }}
+        artifact-name: ${{ inputs.artifact-name }}.sha256
+        artifact-path: ${{ steps.checksum.outputs.path }}
         aws-role-arn: ${{ inputs.aws-role-arn }}
         aws-key-id: ${{ inputs.aws-key-id }}
         aws-secret-access-key: ${{ inputs.aws-secret-access-key }}

--- a/.github/actions/attest-sbom/action.yml
+++ b/.github/actions/attest-sbom/action.yml
@@ -20,7 +20,7 @@ inputs:
 outputs:
   sbom-path:
     description: "Path to generated SBOM file"
-    value: ${{ steps.sbom.outputs.sbom-path }}
+    value: ${{ steps.check.outputs.sbom-path }}
 
 runs:
   using: composite

--- a/.github/ci-overview.md
+++ b/.github/ci-overview.md
@@ -23,7 +23,7 @@ via composite actions and reusable workflows. Python helpers in `scripts/` are i
 ```text
 .github/
 ├── workflows/                 # Platform builds, reusable workflows, and repo automation
-├── actions/                   # Composite actions shared across workflows
+├── actions/                   # Composite actions and external-action policy (see actions/README.md)
 ├── scripts/                   # Python helpers invoked by workflows and actions
 │   ├── templates/             # Jinja2 templates (build_results.md.j2)
 │   └── tests/                 # pytest suite for scripts/ (see #tests)
@@ -122,6 +122,9 @@ Configure these repository secrets:
 | `test-duration-report` | Analyze JUnit test durations and summarize slow tests |
 | `test-report` | Publish and upload test results |
 | `verify-executable` | Post-build executable boot-test verification |
+
+See [`actions/README.md`](actions/README.md) for the repository's external-action reference policy,
+including how to handle automated warnings about major-version tags.
 
 ## Scripts
 

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -15,3 +15,5 @@ updates:
     groups:
       github-actions:
         patterns: ["*"]
+    cooldown:
+      default-days: 7

--- a/.github/scripts/README.md
+++ b/.github/scripts/README.md
@@ -40,6 +40,7 @@ with multiple consumers in [`tools/common/`](../../tools/common/README.md).
 | `mold_helper.py` | Build | Install a pinned and checksum-verified mold linker |
 | `plan_docker_builds.py` | Planning | Generate Docker build matrices from changed files |
 | `precommit_results.py` | Reporting | Normalize pre-commit output into CI artifacts |
+| `release_assets.py` | Release | Validate checksums and enumerate release packages and SBOMs |
 | `resolve_gstreamer_config.py` | GStreamer | Select the platform-specific GStreamer version |
 | `size_analysis.py` | Reporting | Analyze and report binary-size changes |
 | `test_duration_report.py` | Reporting | Report slow tests and duration regressions from JUnit XML |

--- a/.github/scripts/attest_helper.py
+++ b/.github/scripts/attest_helper.py
@@ -1,4 +1,3 @@
-#!/usr/bin/env python3
 """Attestation helpers: gate SBOM signing and resolve artifact paths."""
 
 from __future__ import annotations
@@ -13,6 +12,7 @@ from ci_bootstrap import ensure_tools_dir
 ensure_tools_dir(__file__)
 
 from common.gh_actions import gh_error, gh_warning, write_github_output
+from common.io import ensure_sha256_sidecar
 
 
 def cmd_check(args: argparse.Namespace) -> None:
@@ -60,6 +60,15 @@ def cmd_resolve_path(args: argparse.Namespace) -> None:
     write_github_output({"path": str(path)})
 
 
+def cmd_checksum(args: argparse.Namespace) -> None:
+    try:
+        checksum = ensure_sha256_sidecar(Path(args.source_path))
+    except (OSError, ValueError) as exc:
+        gh_error(f"attest-and-upload: {exc}")
+        sys.exit(1)
+    write_github_output({"path": str(checksum)})
+
+
 def main() -> None:
     parser = argparse.ArgumentParser(description=__doc__)
     sub = parser.add_subparsers(dest="command", required=True)
@@ -77,8 +86,13 @@ def main() -> None:
     p_resolve.add_argument("--override", default="")
     p_resolve.add_argument("--default", required=True)
 
+    p_checksum = sub.add_parser("checksum", help="Verify or create the artifact's SHA-256 sidecar")
+    p_checksum.add_argument("--source-path", required=True)
+
     args = parser.parse_args()
-    {"check": cmd_check, "resolve-path": cmd_resolve_path}[args.command](args)
+    {"check": cmd_check, "checksum": cmd_checksum, "resolve-path": cmd_resolve_path}[args.command](
+        args
+    )
 
 
 if __name__ == "__main__":

--- a/.github/scripts/attest_helper.py
+++ b/.github/scripts/attest_helper.py
@@ -57,7 +57,7 @@ def cmd_resolve_path(args: argparse.Namespace) -> None:
         else:
             print("(parent dir missing)")
         sys.exit(1)
-    write_github_output({"path": str(path)})
+    write_github_output({"parent": str(p.parent), "path": str(path)})
 
 
 def cmd_checksum(args: argparse.Namespace) -> None:

--- a/.github/scripts/generate_cpm_sbom.py
+++ b/.github/scripts/generate_cpm_sbom.py
@@ -1,11 +1,10 @@
-#!/usr/bin/env python3
 """Generate a CycloneDX SBOM from a CMake build directory's CPM package metadata.
 
 Parses CMakeCache.txt for CPM_PACKAGES and per-package VERSION/SOURCE_DIR,
 then reads git metadata (remote URL, commit hash) from each source directory.
 
 Usage:
-    generate_cpm_sbom.py --build-dir DIR [--output FILE]
+    generate_cpm_sbom.py --build-dir DIR [--output FILE] [--require-components]
 
 Outputs CycloneDX 1.6 JSON to stdout or the specified file.
 """
@@ -159,9 +158,18 @@ def main() -> int:
     parser = argparse.ArgumentParser(description=__doc__)
     parser.add_argument("--build-dir", type=Path, required=True, help="CMake build directory")
     parser.add_argument("--output", "-o", type=Path, help="Output file (default: stdout)")
+    parser.add_argument(
+        "--require-components",
+        action="store_true",
+        help="Fail when the CMake cache contains no CPM dependencies",
+    )
     args = parser.parse_args()
 
     sbom = generate_sbom(args.build_dir)
+    if args.require_components and not sbom["components"]:
+        print("Error: CPM dependency SBOM contains no components", file=sys.stderr)
+        return 1
+
     output = json.dumps(sbom, indent=2)
 
     if args.output:

--- a/.github/scripts/release_assets.py
+++ b/.github/scripts/release_assets.py
@@ -1,0 +1,138 @@
+"""Validate and enumerate the artifacts published with a QGC release."""
+
+from __future__ import annotations
+
+import argparse
+from pathlib import Path
+
+from ci_bootstrap import ensure_tools_dir
+
+ensure_tools_dir(__file__)
+
+from common.gh_actions import gh_error
+from common.io import read_json, verify_sha256_sidecar, write_text_if_changed
+
+REQUIRED_PACKAGES: tuple[tuple[str, str], ...] = (
+    ("Linux x86_64 AppImage", "QGroundControl-x86_64/*.AppImage"),
+    ("Linux aarch64 AppImage", "QGroundControl-aarch64/*.AppImage"),
+    ("macOS disk image", "QGroundControl/*.dmg"),
+    ("Windows AMD64 installer", "QGroundControl-installer-AMD64/*.exe"),
+    ("Windows ARM64 installer", "QGroundControl-installer-ARM64/*.exe"),
+    (
+        "Windows AMD64/ARM64 installer",
+        "QGroundControl-installer-AMD64-ARM64/*.exe",
+    ),
+    ("Android APK", "QGroundControl-linux/*.apk"),
+    ("iOS IPA", "QGroundControl-ios/*.ipa"),
+)
+
+REQUIRED_PLATFORM_SBOMS: tuple[str, ...] = (
+    "QGroundControl-x86_64.sbom.spdx.json",
+    "QGroundControl-aarch64.sbom.spdx.json",
+    "QGroundControl-macos.sbom.spdx.json",
+    "QGroundControl-installer-AMD64-windows.sbom.spdx.json",
+    "QGroundControl-installer-ARM64-windows.sbom.spdx.json",
+    "QGroundControl-installer-AMD64-ARM64-windows.sbom.spdx.json",
+    "QGroundControl-linux.sbom.spdx.json",
+    "QGroundControl-ios.sbom.spdx.json",
+)
+
+REQUIRED_DEPENDENCY_SBOMS: tuple[str, ...] = (
+    "QGroundControl-x86_64.dependencies.cdx.json",
+    "QGroundControl-aarch64.dependencies.cdx.json",
+    "QGroundControl-macos.dependencies.cdx.json",
+    "QGroundControl-installer-AMD64-windows.dependencies.cdx.json",
+    "QGroundControl-installer-ARM64-windows.dependencies.cdx.json",
+    "QGroundControl-installer-AMD64-ARM64-windows.dependencies.cdx.json",
+    "QGroundControl-linux.dependencies.cdx.json",
+    "QGroundControl-ios.dependencies.cdx.json",
+)
+
+
+def _require_unique(root: Path, pattern: str, label: str) -> Path:
+    matches = sorted(path for path in root.glob(pattern) if path.is_file())
+    if len(matches) != 1:
+        raise ValueError(f"Expected exactly one {label} matching {pattern!r}; found {len(matches)}")
+    return matches[0]
+
+
+def _validate_sbom(sbom: Path, *, require_components: bool = False) -> None:
+    document = read_json(sbom)
+    if not isinstance(document, dict):
+        raise ValueError(f"SBOM must contain a JSON object: {sbom}")
+
+    if sbom.name.endswith(".spdx.json"):
+        version = document.get("spdxVersion")
+        if not isinstance(version, str) or not version.startswith("SPDX-"):
+            raise ValueError(f"Invalid SPDX SBOM: {sbom}")
+    elif sbom.name.endswith(".cdx.json"):
+        if document.get("bomFormat") != "CycloneDX":
+            raise ValueError(f"Invalid CycloneDX SBOM: {sbom}")
+        if require_components:
+            components = document.get("components")
+            if not isinstance(components, list) or not components:
+                raise ValueError(f"CycloneDX dependency SBOM contains no components: {sbom}")
+    else:
+        raise ValueError(f"Unsupported SBOM filename: {sbom}")
+
+
+def collect_release_assets(artifacts_dir: Path, source_sboms: list[Path]) -> list[Path]:
+    """Return the complete, validated release asset list."""
+    if not artifacts_dir.is_dir():
+        raise FileNotFoundError(f"Artifact directory does not exist: {artifacts_dir}")
+
+    assets: list[Path] = []
+    for label, pattern in REQUIRED_PACKAGES:
+        package = _require_unique(artifacts_dir, pattern, label)
+        checksum = package.with_name(f"{package.name}.sha256")
+        verify_sha256_sidecar(package, checksum)
+        assets.extend((package, checksum))
+
+        if package.suffix == ".AppImage":
+            zsync = package.with_name(f"{package.name}.zsync")
+            if not zsync.is_file():
+                raise FileNotFoundError(f"AppImage update metadata is missing: {zsync}")
+            assets.append(zsync)
+
+    for sbom_name in REQUIRED_PLATFORM_SBOMS:
+        sbom = _require_unique(artifacts_dir, f"**/{sbom_name}", f"SBOM {sbom_name}")
+        _validate_sbom(sbom)
+        assets.append(sbom)
+
+    for sbom_name in REQUIRED_DEPENDENCY_SBOMS:
+        sbom = _require_unique(artifacts_dir, f"**/{sbom_name}", f"SBOM {sbom_name}")
+        _validate_sbom(sbom, require_components=True)
+        assets.append(sbom)
+
+    for source_sbom in source_sboms:
+        if not source_sbom.is_file():
+            raise FileNotFoundError(f"Source SBOM does not exist: {source_sbom}")
+        _validate_sbom(source_sbom)
+        assets.append(source_sbom)
+
+    return sorted(set(assets), key=lambda path: path.as_posix())
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--artifacts-dir", required=True, type=Path)
+    parser.add_argument("--source-sbom", action="append", required=True, type=Path)
+    parser.add_argument("--output", required=True, type=Path)
+    return parser.parse_args()
+
+
+def main() -> int:
+    args = parse_args()
+    try:
+        assets = collect_release_assets(args.artifacts_dir, args.source_sbom)
+        write_text_if_changed(args.output, "".join(f"{path}\n" for path in assets))
+    except (OSError, ValueError) as exc:
+        gh_error(str(exc))
+        return 1
+
+    print(f"Validated {len(assets)} release assets; manifest: {args.output}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/.github/scripts/tests/test_appimage_packaging_contract.py
+++ b/.github/scripts/tests/test_appimage_packaging_contract.py
@@ -36,7 +36,7 @@ def test_official_appimages_publish_delta_update_metadata() -> None:
     install = (REPO_ROOT / "cmake/install/Install.cmake").read_text()
     create_appimage = (REPO_ROOT / "cmake/install/CreateAppImage.cmake").read_text()
     linux_workflow = (REPO_ROOT / ".github/workflows/linux.yml").read_text()
-    release_workflow = (REPO_ROOT / ".github/workflows/release.yml").read_text()
+    release_assets = (REPO_ROOT / ".github/scripts/release_assets.py").read_text()
     verify_action = (REPO_ROOT / ".github/actions/verify-executable/action.yml").read_text()
     verify_script = (REPO_ROOT / ".github/scripts/verify_executable.py").read_text()
 
@@ -56,4 +56,5 @@ def test_official_appimages_publish_delta_update_metadata() -> None:
     assert "expected-appimage-update-information:" in verify_action
     assert "--appimage-updateinformation" in verify_script
     assert "{1}.AppImage.zsync" in linux_workflow
-    assert "artifacts/**/*.AppImage.zsync" in release_workflow
+    assert 'package.suffix == ".AppImage"' in release_assets
+    assert "AppImage update metadata is missing" in release_assets

--- a/.github/scripts/tests/test_attest_helper.py
+++ b/.github/scripts/tests/test_attest_helper.py
@@ -146,3 +146,26 @@ class TestAttestHelper:
                 ]
             )
         assert excinfo.value.code == 1
+
+    def test_checksum_creates_sidecar(self, tmp_path):
+        artifact = tmp_path / "QGroundControl.AppImage"
+        artifact.write_bytes(b"artifact")
+
+        outputs = self._run_main(["checksum", "--source-path", str(artifact)])
+
+        checksum = tmp_path / "QGroundControl.AppImage.sha256"
+        assert outputs == {"path": str(checksum)}
+        assert checksum.read_text(encoding="utf-8").endswith("  QGroundControl.AppImage\n")
+
+    def test_checksum_rejects_mismatch(self, tmp_path):
+        import pytest
+
+        artifact = tmp_path / "QGroundControl.dmg"
+        artifact.write_bytes(b"artifact")
+        checksum = tmp_path / "QGroundControl.dmg.sha256"
+        checksum.write_text(f"{'0' * 64}  QGroundControl.dmg\n", encoding="utf-8")
+
+        with pytest.raises(SystemExit) as excinfo:
+            self._run_main(["checksum", "--source-path", str(artifact)])
+
+        assert excinfo.value.code == 1

--- a/.github/scripts/tests/test_attest_helper.py
+++ b/.github/scripts/tests/test_attest_helper.py
@@ -116,7 +116,7 @@ class TestAttestHelper:
                 str(artifact),
             ]
         )
-        assert outputs == {"path": str(artifact)}
+        assert outputs == {"parent": str(artifact.parent), "path": str(artifact)}
 
     def test_resolve_path_prefers_override(self, tmp_path):
         override = tmp_path / "override.zip"
@@ -132,7 +132,7 @@ class TestAttestHelper:
                 str(default),
             ]
         )
-        assert outputs == {"path": str(override)}
+        assert outputs == {"parent": str(override.parent), "path": str(override)}
 
     def test_resolve_path_missing_artifact_exits(self, tmp_path):
         import pytest

--- a/.github/scripts/tests/test_generate_cpm_sbom.py
+++ b/.github/scripts/tests/test_generate_cpm_sbom.py
@@ -159,3 +159,51 @@ def test_main_file_output(tmp_path: Path, monkeypatch) -> None:
     assert ret == 0
     sbom = json.loads(out_file.read_text())
     assert len(sbom["components"]) == 3
+
+
+def test_main_requires_components(tmp_path: Path, monkeypatch) -> None:
+    cache = tmp_path / "CMakeCache.txt"
+    cache.write_text(SAMPLE_CACHE)
+    out_file = tmp_path / "sbom.json"
+    monkeypatch.setattr(
+        "sys.argv",
+        [
+            "prog",
+            "--build-dir",
+            str(tmp_path),
+            "--output",
+            str(out_file),
+            "--require-components",
+        ],
+    )
+
+    with patch("generate_cpm_sbom.git_info", side_effect=_mock_git_info):
+        from generate_cpm_sbom import main
+
+        ret = main()
+
+    assert ret == 0
+    assert len(json.loads(out_file.read_text())["components"]) == 3
+
+
+def test_main_rejects_empty_required_components(tmp_path: Path, monkeypatch, capsys) -> None:
+    cache = tmp_path / "CMakeCache.txt"
+    cache.write_text("CMAKE_BUILD_TYPE:STRING=Release\n")
+    out_file = tmp_path / "sbom.json"
+    monkeypatch.setattr(
+        "sys.argv",
+        [
+            "prog",
+            "--build-dir",
+            str(tmp_path),
+            "--output",
+            str(out_file),
+            "--require-components",
+        ],
+    )
+
+    from generate_cpm_sbom import main
+
+    assert main() == 1
+    assert "contains no components" in capsys.readouterr().err
+    assert not out_file.exists()

--- a/.github/scripts/tests/test_ios_packaging_contract.py
+++ b/.github/scripts/tests/test_ios_packaging_contract.py
@@ -184,6 +184,9 @@ def test_ios_workflow_builds_device_and_simulator_targets() -> None:
         assert "startsWith(github.ref_name, 'v')" in condition
 
     assert '[[ "$GITHUB_REF_TYPE" == "tag" && "$GITHUB_REF_NAME" == v* ]]' in package
+    attest = steps["Attest and Upload"]["with"]
+    assert attest["package-name"] == "${{ env.PACKAGE }}-ios"
+    assert attest["subject-name"] == "${{ env.PACKAGE }}-ios"
 
 
 def test_ios_qt_action_exports_cross_compile_roots() -> None:

--- a/.github/scripts/tests/test_native_packaging_contract.py
+++ b/.github/scripts/tests/test_native_packaging_contract.py
@@ -110,12 +110,11 @@ def test_windows_installer_uses_only_the_cpack_nsis_path() -> None:
     assert "$checksumFields = @($checksumLine -split '\\s+', 2)" in workflow
     assert "$checksumInstallerName -cne $installerName" in workflow
     assert "Checksum filename mismatch" in workflow
-    assert "additional-artifact-paths: ${{ steps.installer.outputs.checksum_path }}" in workflow
-    assert "additional-aws-artifact-name: ${{ matrix.package }}.exe.sha256" in workflow
-    assert "additional-aws-artifact-path: ${{ steps.installer.outputs.checksum_path }}" in workflow
-    assert "Upload additional artifact to AWS" in upload_action
-    assert "artifact-name: ${{ inputs.additional-aws-artifact-name }}" in upload_action
-    assert "artifact-path: ${{ inputs.additional-aws-artifact-path }}" in upload_action
+    assert "subject-name: ${{ matrix.package }}-windows" in workflow
+    assert "Verify or create SHA-256 checksum" in upload_action
+    assert "Upload checksum to AWS" in upload_action
+    assert "artifact-name: ${{ inputs.artifact-name }}.sha256" in upload_action
+    assert "artifact-path: ${{ steps.checksum.outputs.path }}" in upload_action
     assert "InstallLocation mismatch" in workflow
     assert "Windows Error Reporting registry key not found" in workflow
     assert "QGroundControl (GPU Safe Mode).lnk" in workflow

--- a/.github/scripts/tests/test_native_packaging_contract.py
+++ b/.github/scripts/tests/test_native_packaging_contract.py
@@ -93,6 +93,8 @@ def test_windows_installer_uses_only_the_cpack_nsis_path() -> None:
     )
     assert "CPACK_NSIS_EXTRA_PREINSTALL_COMMANDS" in nsis
     assert "-LEAVE_DATA=1" in nsis
+    assert "DisableX64FSRedirection" in nsis
+    assert "EnableX64FSRedirection" in nsis
     assert "QGCCrashDumps" in nsis
     assert "GPU Safe Mode" in nsis
     assert "set(CPACK_NSIS_ENABLE_UNINSTALL_BEFORE_INSTALL OFF)" in nsis
@@ -164,6 +166,8 @@ include(CreateCPackNSIS)
         assert 'set(CPACK_GENERATOR "NSIS")' in config
         assert f'set(CPACK_PACKAGE_FILE_NAME "QGroundControl-installer-{package_arch}")' in config
         assert "-LEAVE_DATA=1" in config
+        assert "DisableX64FSRedirection" in config
+        assert "EnableX64FSRedirection" in config
         assert "QGCCrashDumps" in config
         assert "GPU Safe Mode" in config
 

--- a/.github/scripts/tests/test_platform_workflow_names.py
+++ b/.github/scripts/tests/test_platform_workflow_names.py
@@ -1,4 +1,3 @@
-#!/usr/bin/env python3
 """Detect drift between platform workflow display names and the places that
 match against them by literal string.
 
@@ -35,6 +34,10 @@ PLATFORM_FILES: dict[str, str] = {
     "MacOS": "macos.yml",
     "Android": "android.yml",
 }
+
+# iOS produces release artifacts but is intentionally excluded from the
+# build-results workflow's regular PR platform set.
+RELEASE_PLATFORM_FILES: dict[str, str] = PLATFORM_FILES | {"iOS": "ios.yml"}
 
 
 def _workflow_name(path: Path) -> str:
@@ -118,15 +121,28 @@ def test_release_wait_for_builds_lists_match_platforms() -> None:
     wait = jobs.get("wait-for-builds") or {}
     steps = wait.get("steps") or []
     names_block: str | None = None
+    wait_inputs: dict[str, object] = {}
     for step in steps:
         with_ = step.get("with") or {}
-        if "workflow-names" in with_:
-            names_block = str(with_["workflow-names"])
+        if "filter-workflow-names" in with_:
+            names_block = str(with_["filter-workflow-names"])
+            wait_inputs = with_
             break
-    assert names_block is not None, "wait-for-builds step missing workflow-names"
+    assert names_block is not None, "wait-for-builds step missing filter-workflow-names"
     listed = {line.strip() for line in names_block.splitlines() if line.strip()}
-    expected = set(_platform_workflows())
+    expected = set(RELEASE_PLATFORM_FILES)
     assert listed == expected, (
-        f"release.yml wait-for-builds workflow-names {sorted(listed)} != "
-        f"build-config.json platform_workflows {sorted(expected)}"
+        f"release.yml filter-workflow-names {sorted(listed)} != "
+        f"release platform workflows {sorted(expected)}"
     )
+    assert wait_inputs["filter-workflow-events"] == "workflow_dispatch"
+    assert wait_inputs["sha"] == "${{ github.sha }}"
+    assert wait_inputs["initial-delay-seconds"] == 30
+    assert wait_inputs["period-seconds"] == 300
+
+    dispatch = next(
+        step for step in steps if step.get("name") == "Dispatch platform release builds"
+    )
+    assert dispatch["env"]["GH_REPO"] == "${{ github.repository }}"
+    for workflow_file in RELEASE_PLATFORM_FILES.values():
+        assert workflow_file in dispatch["run"]

--- a/.github/scripts/tests/test_release_assets.py
+++ b/.github/scripts/tests/test_release_assets.py
@@ -1,0 +1,177 @@
+"""Tests for release_assets.py and its release workflow contract."""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+import pytest
+import yaml
+from _helpers import REPO_ROOT
+from common.io import ensure_sha256_sidecar
+from release_assets import (
+    REQUIRED_DEPENDENCY_SBOMS,
+    REQUIRED_PLATFORM_SBOMS,
+    collect_release_assets,
+)
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+PACKAGE_PATHS = (
+    "QGroundControl-x86_64/QGroundControl-x86_64.AppImage",
+    "QGroundControl-aarch64/QGroundControl-aarch64.AppImage",
+    "QGroundControl/QGroundControl.dmg",
+    "QGroundControl-installer-AMD64/QGroundControl-installer-AMD64.exe",
+    "QGroundControl-installer-ARM64/QGroundControl-installer-ARM64.exe",
+    "QGroundControl-installer-AMD64-ARM64/QGroundControl-installer-AMD64-ARM64.exe",
+    "QGroundControl-linux/QGroundControl.apk",
+    "QGroundControl-ios/QGroundControl.ipa",
+)
+
+SPDX_DOCUMENT = '{"spdxVersion": "SPDX-2.3"}\n'
+CYCLONEDX_DOCUMENT = '{"bomFormat": "CycloneDX"}\n'
+CYCLONEDX_DEPENDENCY_DOCUMENT = (
+    '{"bomFormat": "CycloneDX", "components": [{"name": "dependency"}]}\n'
+)
+
+
+def _create_complete_release(tmp_path: Path) -> tuple[Path, list[Path]]:
+    artifacts = tmp_path / "artifacts"
+    for relative_path in PACKAGE_PATHS:
+        package = artifacts / relative_path
+        package.parent.mkdir(parents=True, exist_ok=True)
+        package.write_bytes(relative_path.encode())
+        ensure_sha256_sidecar(package)
+        if package.suffix == ".AppImage":
+            package.with_name(f"{package.name}.zsync").write_text("zsync\n", encoding="utf-8")
+
+    for sbom_name in REQUIRED_PLATFORM_SBOMS:
+        sbom = artifacts / f"sbom-{sbom_name}" / sbom_name
+        sbom.parent.mkdir(parents=True)
+        sbom.write_text(SPDX_DOCUMENT, encoding="utf-8")
+
+    for sbom_name in REQUIRED_DEPENDENCY_SBOMS:
+        sbom = artifacts / sbom_name.removesuffix(".dependencies.cdx.json") / sbom_name
+        sbom.parent.mkdir(parents=True, exist_ok=True)
+        sbom.write_text(CYCLONEDX_DEPENDENCY_DOCUMENT, encoding="utf-8")
+
+    source_sboms = [tmp_path / "sbom-source.spdx.json", tmp_path / "sbom-source.cdx.json"]
+    source_sboms[0].write_text(SPDX_DOCUMENT, encoding="utf-8")
+    source_sboms[1].write_text(CYCLONEDX_DOCUMENT, encoding="utf-8")
+    return artifacts, source_sboms
+
+
+def test_collect_release_assets_requires_complete_validated_set(tmp_path: Path) -> None:
+    artifacts, source_sboms = _create_complete_release(tmp_path)
+
+    assets = collect_release_assets(artifacts, source_sboms)
+
+    assert len(assets) == 36
+    assert assets == sorted(assets, key=lambda path: path.as_posix())
+    assert all(path.is_file() for path in assets)
+
+
+def test_collect_release_assets_rejects_missing_or_bad_checksum(tmp_path: Path) -> None:
+    artifacts, source_sboms = _create_complete_release(tmp_path)
+    package = artifacts / PACKAGE_PATHS[0]
+    checksum = package.with_name(f"{package.name}.sha256")
+    checksum.unlink()
+
+    with pytest.raises(FileNotFoundError):
+        collect_release_assets(artifacts, source_sboms)
+
+    checksum.write_text(f"{'0' * 64}  {package.name}\n", encoding="utf-8")
+    with pytest.raises(ValueError, match="checksum mismatch"):
+        collect_release_assets(artifacts, source_sboms)
+
+
+def test_collect_release_assets_rejects_missing_sbom_or_duplicate_package(tmp_path: Path) -> None:
+    artifacts, source_sboms = _create_complete_release(tmp_path)
+    missing_sbom = next(artifacts.rglob(REQUIRED_PLATFORM_SBOMS[0]))
+    missing_sbom.unlink()
+
+    with pytest.raises(ValueError, match="found 0"):
+        collect_release_assets(artifacts, source_sboms)
+
+    missing_sbom.write_text(SPDX_DOCUMENT, encoding="utf-8")
+    duplicate = artifacts / "QGroundControl-x86_64/duplicate.AppImage"
+    duplicate.write_bytes(b"duplicate")
+    ensure_sha256_sidecar(duplicate)
+    duplicate.with_name(f"{duplicate.name}.zsync").write_text("zsync\n", encoding="utf-8")
+
+    with pytest.raises(ValueError, match="found 2"):
+        collect_release_assets(artifacts, source_sboms)
+
+
+def test_collect_release_assets_rejects_invalid_sbom(tmp_path: Path) -> None:
+    artifacts, source_sboms = _create_complete_release(tmp_path)
+    source_sboms[1].write_text('{"bomFormat": "not-cyclonedx"}\n', encoding="utf-8")
+
+    with pytest.raises(ValueError, match="Invalid CycloneDX SBOM"):
+        collect_release_assets(artifacts, source_sboms)
+
+
+def test_collect_release_assets_rejects_empty_dependency_sbom(tmp_path: Path) -> None:
+    artifacts, source_sboms = _create_complete_release(tmp_path)
+    dependency_sbom = next(artifacts.rglob(REQUIRED_DEPENDENCY_SBOMS[0]))
+    dependency_sbom.write_text(CYCLONEDX_DOCUMENT, encoding="utf-8")
+
+    with pytest.raises(ValueError, match="contains no components"):
+        collect_release_assets(artifacts, source_sboms)
+
+
+def test_release_uses_platform_sboms_without_reattesting() -> None:
+    workflow = yaml.safe_load((REPO_ROOT / ".github/workflows/release.yml").read_text())
+    upload = workflow["jobs"]["upload-artifacts"]
+    steps = {step["name"]: step for step in upload["steps"]}
+
+    assert upload["permissions"] == {"actions": "read", "contents": "write"}
+    assert steps["Download artifacts"]["uses"] == "./.github/actions/download-all-artifacts"
+    assert steps["Download artifacts"]["with"] == {
+        "head-sha": "${{ github.sha }}",
+        "workflows": "Linux,Windows,MacOS,Android,iOS",
+        "event": "workflow_dispatch",
+        "output-dir": "artifacts",
+        "artifact-prefixes": "QGroundControl,sbom-",
+    }
+    step_names = list(steps)
+    assert step_names.index("Generate source SBOM (CycloneDX)") < step_names.index(
+        "Download artifacts"
+    )
+    assert (
+        "${{ runner.temp }}/sbom-source.spdx.json"
+        in steps["Generate source SBOM (SPDX)"]["with"]["output-file"]
+    )
+    assert "release_assets.py" in steps["Validate release assets"]["run"]
+    assert '"${RUNNER_TEMP}/sbom-source.spdx.json"' in steps["Validate release assets"]["run"]
+    assert "gh release upload" in steps["Upload to Release"]["run"]
+    assert not any("attest-sbom" in str(step.get("uses", "")) for step in upload["steps"])
+
+
+def test_attestation_actions_publish_checksum_and_resolved_sbom_output() -> None:
+    upload_action = yaml.safe_load(
+        (REPO_ROOT / ".github/actions/attest-and-upload/action.yml").read_text()
+    )
+    upload_steps = {step["name"]: step for step in upload_action["runs"]["steps"]}
+    checksum = upload_steps["Verify or create SHA-256 checksum"]
+    dependency_sbom = upload_steps["Generate CPM dependency SBOM"]
+    dependency_attestation = upload_steps["Attest CPM dependency SBOM"]
+    save = upload_steps["Save artifact"]
+    aws_checksum = upload_steps["Upload checksum to AWS"]
+
+    assert 'attest_helper.py" checksum' in checksum["run"]
+    assert 'generate_cpm_sbom.py"' in dependency_sbom["run"]
+    assert "--require-components" in dependency_sbom["run"]
+    assert dependency_attestation["uses"] == "actions/attest@v4"
+    assert dependency_attestation["with"] == {
+        "subject-path": "${{ steps.src.outputs.path }}",
+        "sbom-path": "${{ steps.dependency-sbom.outputs.path }}",
+    }
+    assert "${{ steps.checksum.outputs.path }}" in save["with"]["path"]
+    assert "${{ steps.dependency-sbom.outputs.path }}" in save["with"]["path"]
+    assert aws_checksum["with"]["artifact-path"] == "${{ steps.checksum.outputs.path }}"
+    assert "github.event_name == 'workflow_dispatch'" in aws_checksum["if"]
+    assert "github.ref_type == 'tag'" in aws_checksum["if"]
+
+    sbom_action = yaml.safe_load((REPO_ROOT / ".github/actions/attest-sbom/action.yml").read_text())
+    assert sbom_action["outputs"]["sbom-path"]["value"] == "${{ steps.check.outputs.sbom-path }}"

--- a/.github/scripts/tests/test_release_assets.py
+++ b/.github/scripts/tests/test_release_assets.py
@@ -149,6 +149,13 @@ def test_release_uses_platform_sboms_without_reattesting() -> None:
 
 
 def test_attestation_actions_publish_checksum_and_resolved_sbom_output() -> None:
+    ci_workflow = yaml.safe_load((REPO_ROOT / ".github/workflows/ci-scripts.yml").read_text())
+    ci_steps = ci_workflow["jobs"]["test-ci-scripts"]["steps"]
+    checkout = next(step for step in ci_steps if step["name"] == "Checkout")
+    sparse_checkout = set(checkout["with"]["sparse-checkout"].splitlines())
+    assert ".github/actions/attest-and-upload" in sparse_checkout
+    assert ".github/actions/attest-sbom" in sparse_checkout
+
     upload_action = yaml.safe_load(
         (REPO_ROOT / ".github/actions/attest-and-upload/action.yml").read_text()
     )
@@ -162,6 +169,10 @@ def test_attestation_actions_publish_checksum_and_resolved_sbom_output() -> None
     assert 'attest_helper.py" checksum' in checksum["run"]
     assert 'generate_cpm_sbom.py"' in dependency_sbom["run"]
     assert "--require-components" in dependency_sbom["run"]
+    assert dependency_sbom["env"]["SBOM_PATH"] == (
+        "${{ format('{0}/{1}.dependencies.cdx.json', steps.src.outputs.parent, "
+        "inputs.subject-name || inputs.package-name) }}"
+    )
     assert dependency_attestation["uses"] == "actions/attest@v4"
     assert dependency_attestation["with"] == {
         "subject-path": "${{ steps.src.outputs.path }}",

--- a/.github/scripts/tests/test_workflow_security_policy.py
+++ b/.github/scripts/tests/test_workflow_security_policy.py
@@ -1,0 +1,141 @@
+"""Repository-wide security policy checks for GitHub Actions workflows."""
+
+from __future__ import annotations
+
+import re
+from typing import TYPE_CHECKING, Any
+
+import yaml
+from _helpers import REPO_ROOT
+
+if TYPE_CHECKING:
+    from collections.abc import Iterator
+    from pathlib import Path
+
+WORKFLOWS_DIR = REPO_ROOT / ".github" / "workflows"
+WORKFLOWS = sorted(WORKFLOWS_DIR.glob("*.y*ml"))
+COMPOSITE_ACTIONS = sorted((REPO_ROOT / ".github" / "actions").rglob("action.y*ml"))
+CI_SCRIPTS_WORKFLOW = WORKFLOWS_DIR / "ci-scripts.yml"
+DEPENDENCY_REVIEW_WORKFLOW = WORKFLOWS_DIR / "dependency-review.yml"
+HARDEN_RUNNER = "step-security/harden-runner@v2"
+RUNS_ON_ACTION = "runs-on/action@v2"
+VERSIONED_ACTION_REF = re.compile(r"(?:[0-9a-f]{40}|v\d+(?:\.\d+){0,2})")
+FORK_SAFETY_GUARDS = (
+    "github.repository_owner == 'mavlink'",
+    "github.event_name != 'pull_request'",
+    "github.event.pull_request.head.repo.full_name == github.repository",
+)
+
+
+def _load_yaml_mapping(path: Path) -> dict[str, Any]:
+    document = yaml.safe_load(path.read_text(encoding="utf-8"))
+    assert isinstance(document, dict), f"{path} must contain a YAML mapping"
+    if True in document and "on" not in document:
+        document["on"] = document.pop(True)
+    return document
+
+
+def _executable_jobs(path: Path) -> Iterator[tuple[str, dict[str, Any]]]:
+    jobs = _load_yaml_mapping(path).get("jobs", {})
+    assert isinstance(jobs, dict), f"{path.name} jobs must be a mapping"
+    for job_name, job in jobs.items():
+        if isinstance(job, dict) and "steps" in job:
+            yield job_name, job
+
+
+def _uses_values(value: Any) -> Iterator[str]:
+    if isinstance(value, dict):
+        for key, child in value.items():
+            if key == "uses" and isinstance(child, str):
+                yield child
+            else:
+                yield from _uses_values(child)
+    elif isinstance(value, list):
+        for child in value:
+            yield from _uses_values(child)
+
+
+def test_ci_scripts_checks_every_workflow() -> None:
+    workflow = _load_yaml_mapping(CI_SCRIPTS_WORKFLOW)
+    steps = workflow["jobs"]["test-ci-scripts"]["steps"]
+    checkout = next(step for step in steps if step.get("uses", "").startswith("actions/checkout@"))
+    sparse_checkout = checkout["with"]["sparse-checkout"].splitlines()
+    assert ".github/workflows" in sparse_checkout
+
+
+def test_workflows_have_explicit_permissions() -> None:
+    for path in WORKFLOWS:
+        permissions = _load_yaml_mapping(path).get("permissions")
+        assert isinstance(permissions, dict), (
+            f"{path.name} must declare an explicit permission baseline"
+        )
+
+
+def test_executable_jobs_are_bounded_and_hardened() -> None:
+    for path in WORKFLOWS:
+        for job_name, job in _executable_jobs(path):
+            steps = job["steps"]
+            assert isinstance(steps, list) and steps, f"{path.name}:{job_name} must have steps"
+            timeout = job.get("timeout-minutes")
+            assert (isinstance(timeout, int) and not isinstance(timeout, bool) and timeout > 0) or (
+                isinstance(timeout, str) and timeout.startswith("${{") and timeout.endswith("}}")
+            ), f"{path.name}:{job_name} must set a positive timeout-minutes"
+            assert steps[0].get("uses") == HARDEN_RUNNER, (
+                f"{path.name}:{job_name} must run {HARDEN_RUNNER} before other steps"
+            )
+
+
+def test_workflow_checkouts_do_not_persist_credentials() -> None:
+    for path in WORKFLOWS:
+        for job_name, job in _executable_jobs(path):
+            for step in job["steps"]:
+                if not str(step.get("uses", "")).startswith("actions/checkout@"):
+                    continue
+                assert step.get("with", {}).get("persist-credentials") is False, (
+                    f"{path.name}:{job_name} checkout must set persist-credentials: false"
+                )
+
+
+def test_runson_selection_is_fork_safe() -> None:
+    for path in WORKFLOWS:
+        for job_name, job in _executable_jobs(path):
+            runner = str(job.get("runs-on", ""))
+            if "runs-on=" in runner:
+                assert all(guard in runner for guard in FORK_SAFETY_GUARDS), (
+                    f"{path.name}:{job_name} must keep RunsOn selection fork-safe"
+                )
+                assert "||" in runner, (
+                    f"{path.name}:{job_name} must provide a GitHub-hosted runner fallback"
+                )
+
+            for step in job["steps"]:
+                if step.get("uses") != RUNS_ON_ACTION:
+                    continue
+                condition = str(step.get("if", ""))
+                assert all(guard in condition for guard in FORK_SAFETY_GUARDS), (
+                    f"{path.name}:{job_name} must not enable RunsOn for fork pull requests"
+                )
+
+
+def test_external_actions_use_versioned_refs() -> None:
+    for path in [*WORKFLOWS, *COMPOSITE_ACTIONS]:
+        document = _load_yaml_mapping(path)
+        for uses in _uses_values(document):
+            if uses.startswith("./"):
+                continue
+            action, separator, ref = uses.rpartition("@")
+            assert separator and action, f"{path}: external action must include a ref: {uses}"
+            assert VERSIONED_ACTION_REF.fullmatch(ref), (
+                f"{path}: external action must use a numeric version tag or commit SHA: {uses}"
+            )
+
+
+def test_dependency_review_covers_every_pull_request() -> None:
+    workflow = _load_yaml_mapping(DEPENDENCY_REVIEW_WORKFLOW)
+    assert workflow["on"]["pull_request"] is None
+    assert workflow["permissions"] == {"contents": "read", "pull-requests": "write"}
+
+    steps = workflow["jobs"]["dependency-review"]["steps"]
+    uses = {step.get("uses") for step in steps}
+    assert "actions/dependency-review-action@v5" in uses
+    assert "gradle/actions/wrapper-validation@v4" in uses

--- a/.github/workflows/_cache-cleanup.yml
+++ b/.github/workflows/_cache-cleanup.yml
@@ -44,6 +44,11 @@ jobs:
       # Required to delete cache entries.
       actions: write
     steps:
+      - name: Harden Runner
+        uses: step-security/harden-runner@v2
+        with:
+          egress-policy: audit
+
       - uses: actions/checkout@v7
         with:
           sparse-checkout: |

--- a/.github/workflows/_detect-changes.yml
+++ b/.github/workflows/_detect-changes.yml
@@ -53,6 +53,11 @@ jobs:
       docker_linux: ${{ steps.nonpr.outputs.docker_linux || steps.pr.outputs.docker_linux }}
       docker_android: ${{ steps.nonpr.outputs.docker_android || steps.pr.outputs.docker_android }}
     steps:
+      - name: Harden Runner
+        uses: step-security/harden-runner@v2
+        with:
+          egress-policy: audit
+
       # Non-PR events (push, merge_group, workflow_dispatch) always rebuild
       # everything. Sparse-checkout just the script + bootstrap shim it needs.
       - name: Checkout passthrough script (non-PR)
@@ -77,12 +82,6 @@ jobs:
         id: nonpr
         shell: bash
         run: python3 "${GITHUB_WORKSPACE}/.github/scripts/detect_changes.py" --non-pr-passthrough
-
-      - name: Harden Runner
-        if: github.event_name == 'pull_request'
-        uses: step-security/harden-runner@v2
-        with:
-          egress-policy: audit
 
       - name: Checkout repo
         if: github.event_name == 'pull_request'

--- a/.github/workflows/android.yml
+++ b/.github/workflows/android.yml
@@ -46,6 +46,11 @@ jobs:
     outputs:
       include: ${{ steps.build.outputs.include }}
     steps:
+      - name: Harden Runner
+        uses: step-security/harden-runner@v2
+        with:
+          egress-policy: audit
+
       - uses: actions/checkout@v7
         with:
           sparse-checkout: |
@@ -69,7 +74,14 @@ jobs:
     needs: [changes, build-matrix]
     if: needs.changes.outputs.should_build == 'true'
     # RunsOn runners only when the leg defines one, on mavlink, and not from a fork.
-    runs-on: ${{ github.repository_owner == 'mavlink' && matrix.runson_runner != '' && (github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository) && format('runs-on={0}/runner={1}', github.run_id, matrix.runson_runner) || matrix.fallback_runner }}
+    runs-on: >-
+      ${{
+        github.repository_owner == 'mavlink' &&
+        matrix.runson_runner != '' &&
+        (github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository) &&
+        format('runs-on={0}/runner={1}', github.run_id, matrix.runson_runner) ||
+        matrix.fallback_runner
+      }}
     timeout-minutes: 120
 
     # id-token/attestations scoped here: only the "Attest and Upload" step needs them.
@@ -102,17 +114,17 @@ jobs:
       HAS_PLAYSTORE_SECRET: ${{ secrets.GOOGLE_SERVICE_ACCOUNT != '' }}
 
     steps:
+      - name: Harden Runner
+        uses: step-security/harden-runner@v2
+        with:
+          egress-policy: audit
+
       - name: Enable RunsOn magic cache
         if: github.repository_owner == 'mavlink' && (github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository) && matrix.host != 'mac'
         uses: runs-on/action@v2
         with:
           metrics: cpu,network,memory,disk,io
           show_costs: summary
-
-      - name: Harden Runner
-        uses: step-security/harden-runner@v2
-        with:
-          egress-policy: audit
 
       - name: Checkout repo
         uses: actions/checkout@v7

--- a/.github/workflows/ci-scripts.yml
+++ b/.github/workflows/ci-scripts.yml
@@ -129,20 +129,7 @@ jobs:
             .github/actions/verify-executable
             .github/build-config.json
             .github/scripts
-            .github/workflows/build-results.yml
-            .github/workflows/ci-scripts.yml
-            .github/workflows/docker.yml
-            .github/workflows/analysis.yml
-            .github/workflows/android.yml
-            .github/workflows/build-profile.yml
-            .github/workflows/build-gstreamer.yml
-            .github/workflows/custom-build.yml
-            .github/workflows/cache-cleanup.yml
-            .github/workflows/ios.yml
-            .github/workflows/linux.yml
-            .github/workflows/macos.yml
-            .github/workflows/release.yml
-            .github/workflows/windows.yml
+            .github/workflows
             .vscode
             CMakeLists.txt
             CMakePresets.json

--- a/.github/workflows/ci-scripts.yml
+++ b/.github/workflows/ci-scripts.yml
@@ -120,6 +120,7 @@ jobs:
             .github/actions/cmake-configure
             .github/actions/build-prerequisites
             .github/actions/attest-and-upload
+            .github/actions/attest-sbom
             .github/actions/cache
             .github/actions/docker
             .github/actions/free-disk-space

--- a/.github/workflows/crowdin.yml
+++ b/.github/workflows/crowdin.yml
@@ -23,6 +23,9 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: false
 
+permissions:
+  contents: read
+
 jobs:
   sync:
     name: Crowdin Sync
@@ -33,6 +36,11 @@ jobs:
       contents: read
 
     steps:
+      - name: Harden Runner
+        uses: step-security/harden-runner@v2
+        with:
+          egress-policy: audit
+
       - name: Determine action
         id: action
         env:
@@ -46,12 +54,6 @@ jobs:
           else
             echo "mode=skip" >> "$GITHUB_OUTPUT"
           fi
-
-      - name: Harden Runner
-        if: steps.action.outputs.mode != 'skip'
-        uses: step-security/harden-runner@v2
-        with:
-          egress-policy: audit
 
       - name: Checkout
         if: steps.action.outputs.mode != 'skip'

--- a/.github/workflows/custom-build.yml
+++ b/.github/workflows/custom-build.yml
@@ -41,17 +41,17 @@ jobs:
         shell: bash
 
     steps:
+      - name: Harden Runner
+        uses: step-security/harden-runner@v2
+        with:
+          egress-policy: audit
+
       - name: Enable RunsOn magic cache
         if: github.repository_owner == 'mavlink' && (github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository)
         uses: runs-on/action@v2
         with:
           metrics: cpu,network,memory,disk,io
           show_costs: summary
-
-      - name: Harden Runner
-        uses: step-security/harden-runner@v2
-        with:
-          egress-policy: audit
 
       - name: Checkout
         uses: actions/checkout@v7
@@ -122,17 +122,17 @@ jobs:
         shell: bash
 
     steps:
+      - name: Harden Runner
+        uses: step-security/harden-runner@v2
+        with:
+          egress-policy: audit
+
       - name: Enable RunsOn magic cache
         if: github.repository_owner == 'mavlink' && (github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository)
         uses: runs-on/action@v2
         with:
           metrics: cpu,network,memory,disk,io
           show_costs: summary
-
-      - name: Harden Runner
-        uses: step-security/harden-runner@v2
-        with:
-          egress-policy: audit
 
       - name: Checkout
         uses: actions/checkout@v7

--- a/.github/workflows/dependency-review.yml
+++ b/.github/workflows/dependency-review.yml
@@ -2,17 +2,6 @@ name: Dependency Review
 
 on:
   pull_request:
-    paths:
-      - 'package*.json'
-      - 'android/**'
-      - '**/*.gradle'
-      - '**/*.gradle.kts'
-      - 'requirements*.txt'
-      - '**/requirements*.txt'
-      - 'pyproject.toml'
-      - '**/pyproject.toml'
-      - 'setup.py'
-      - '**/setup.py'
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
@@ -44,3 +33,6 @@ jobs:
         with:
           fail-on-severity: high
           comment-summary-in-pr: on-failure
+
+      - name: Validate Gradle Wrapper
+        uses: gradle/actions/wrapper-validation@v4

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -38,6 +38,11 @@ jobs:
       matrix: ${{ steps.plan.outputs.matrix }}
       has_jobs: ${{ steps.plan.outputs.has_jobs }}
     steps:
+      - name: Harden Runner
+        uses: step-security/harden-runner@v2
+        with:
+          egress-policy: audit
+
       - name: Checkout planner
         uses: actions/checkout@v7
         with:
@@ -90,17 +95,17 @@ jobs:
         shell: bash
 
     steps:
+      - name: Harden Runner
+        uses: step-security/harden-runner@v2
+        with:
+          egress-policy: audit
+
       - name: Enable RunsOn magic cache
         if: github.repository_owner == 'mavlink' && (github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository)
         uses: runs-on/action@v2
         with:
           metrics: cpu,network,memory,disk,io
           show_costs: summary
-
-      - name: Harden Runner
-        uses: step-security/harden-runner@v2
-        with:
-          egress-policy: audit
 
       - name: Checkout
         uses: actions/checkout@v7

--- a/.github/workflows/ios.yml
+++ b/.github/workflows/ios.yml
@@ -197,7 +197,8 @@ jobs:
         with:
           artifact-name: ${{ env.PACKAGE }}.ipa
           artifact-source-path: ${{ runner.temp }}/build/${{ matrix.build_type }}/${{ env.PACKAGE }}.ipa
-          package-name: ${{ env.PACKAGE }}
+          package-name: ${{ env.PACKAGE }}-ios
+          subject-name: ${{ env.PACKAGE }}-ios
           upload-aws: 'false'
 
       - name: Upload to TestFlight

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -83,13 +83,6 @@ jobs:
         shell: bash
 
     steps:
-      - name: Enable RunsOn magic cache
-        if: github.repository_owner == 'mavlink' && (github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository)
-        uses: runs-on/action@v2
-        with:
-          metrics: cpu,network,memory,disk,io
-          show_costs: summary
-
       # harden-runner is x86_64 Linux only — skip on the ubuntu-24.04-arm matrix entry.
       # macOS/Windows runners no-op silently, so other workflows don't need the guard.
       - name: Harden Runner
@@ -97,6 +90,13 @@ jobs:
         uses: step-security/harden-runner@v2
         with:
           egress-policy: audit
+
+      - name: Enable RunsOn magic cache
+        if: github.repository_owner == 'mavlink' && (github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository)
+        uses: runs-on/action@v2
+        with:
+          metrics: cpu,network,memory,disk,io
+          show_costs: summary
 
       - name: Checkout repo
         uses: actions/checkout@v7
@@ -208,6 +208,11 @@ jobs:
     outputs:
       include: ${{ steps.build.outputs.include }}
     steps:
+      - name: Harden Runner
+        uses: step-security/harden-runner@v2
+        with:
+          egress-policy: audit
+
       - uses: actions/checkout@v7
         with:
           sparse-checkout: |
@@ -252,17 +257,17 @@ jobs:
         shell: bash
 
     steps:
+      - name: Harden Runner
+        uses: step-security/harden-runner@v2
+        with:
+          egress-policy: audit
+
       - name: Enable RunsOn magic cache
         if: github.repository_owner == 'mavlink' && (github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository)
         uses: runs-on/action@v2
         with:
           metrics: cpu,network,memory,disk,io
           show_costs: summary
-
-      - name: Harden Runner
-        uses: step-security/harden-runner@v2
-        with:
-          egress-policy: audit
 
       - name: Checkout repo
         uses: actions/checkout@v7

--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -144,6 +144,7 @@ jobs:
         with:
           artifact-name: QGroundControl.dmg
           package-name: QGroundControl
+          subject-name: QGroundControl-macos
           aws-role-arn: ${{ secrets.AWS_ROLE_ARN }}
           aws-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
           aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -78,6 +78,11 @@ jobs:
       actions: read  # wait-for-workflows-action polls workflow runs
 
     steps:
+      - name: Harden Runner
+        uses: step-security/harden-runner@v2
+        with:
+          egress-policy: audit
+
       - name: Wait for builds to complete
         uses: int128/wait-for-workflows-action@v1
         with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -75,7 +75,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 180
     permissions:
-      actions: read  # wait-for-workflows-action polls workflow runs
+      actions: write  # dispatch platform workflows, then poll their runs
 
     steps:
       - name: Harden Runner
@@ -83,27 +83,42 @@ jobs:
         with:
           egress-policy: audit
 
+      # Tags created with GITHUB_TOKEN do not trigger tag-push workflows, so
+      # release builds are explicitly dispatched at the new release tag.
+      - name: Dispatch platform release builds
+        env:
+          GH_REPO: ${{ github.repository }}
+          GH_TOKEN: ${{ github.token }}
+          RELEASE_TAG: v${{ needs.semantic-release.outputs.version }}
+        run: |
+          set -euo pipefail
+          for workflow in linux.yml windows.yml macos.yml android.yml ios.yml; do
+            gh workflow run "$workflow" --ref "$RELEASE_TAG"
+          done
+
       - name: Wait for builds to complete
         uses: int128/wait-for-workflows-action@v1
         with:
-          workflow-names: |
+          filter-workflow-names: |
             Linux
             Windows
             MacOS
             Android
-          timeout-minutes: 170
-          poll-interval-minutes: 5
+            iOS
+          filter-workflow-events: workflow_dispatch
+          sha: ${{ github.sha }}
+          initial-delay-seconds: 30
+          period-seconds: 300
 
   upload-artifacts:
     name: Upload Release Artifacts
     needs: [semantic-release, wait-for-builds]
     if: needs.semantic-release.outputs.new_release == 'true'
     runs-on: ubuntu-latest
-    timeout-minutes: 30
+    timeout-minutes: 60
     permissions:
+      actions: read
       contents: write
-      id-token: write
-      attestations: write
 
     steps:
       - name: Harden Runner
@@ -117,26 +132,6 @@ jobs:
           fetch-depth: 0
           persist-credentials: false
 
-      - name: Download artifacts
-        uses: actions/download-artifact@v8
-        with:
-          path: artifacts
-          merge-multiple: true
-
-      - name: List artifacts
-        run: find artifacts -type f | head -50 || echo "No artifacts found"
-
-      - name: Resolve artifact paths
-        id: paths
-        shell: bash
-        run: |
-          python3 "${GITHUB_WORKSPACE}/.github/scripts/find_artifact.py" \
-            --build-dir artifacts \
-            --match "appimage=QGroundControl*.AppImage" \
-            --match "apk=*.apk" \
-            --match "dmg=*.dmg" \
-            --match "exe=QGroundControl*.exe"
-
       # Source-tree SBOM is kept as a release artifact for source traceability,
       # but it is NOT used as the attestation evidence (per-platform SBOMs are).
       - name: Generate source SBOM (SPDX)
@@ -144,7 +139,7 @@ jobs:
         with:
           path: .
           format: spdx-json
-          output-file: sbom-source.spdx.json
+          output-file: ${{ runner.temp }}/sbom-source.spdx.json
           artifact-name: sbom-source-spdx
 
       - name: Generate source SBOM (CycloneDX)
@@ -152,88 +147,32 @@ jobs:
         with:
           path: .
           format: cyclonedx-json
-          output-file: sbom-source.cdx.json
+          output-file: ${{ runner.temp }}/sbom-source.cdx.json
           artifact-name: sbom-source-cyclonedx
 
-      - name: Extract AppImage contents
-        if: steps.paths.outputs.appimage != ''
-        shell: bash
+      - name: Download artifacts
+        uses: ./.github/actions/download-all-artifacts
+        with:
+          head-sha: ${{ github.sha }}
+          workflows: Linux,Windows,MacOS,Android,iOS
+          event: workflow_dispatch
+          output-dir: artifacts
+          artifact-prefixes: QGroundControl,sbom-
+
+      - name: Validate release assets
         run: |
-          set -euo pipefail
-          mkdir -p extracted/linux
-          cp "${STEPS_PATHS_OUTPUTS_APPIMAGE}" extracted/linux/qgc.AppImage
-          chmod +x extracted/linux/qgc.AppImage
-          (cd extracted/linux && ./qgc.AppImage --appimage-extract >/dev/null)
-          rm extracted/linux/qgc.AppImage
-        env:
-          STEPS_PATHS_OUTPUTS_APPIMAGE: ${{ steps.paths.outputs.appimage }}
-
-      - name: Attest Linux AppImage
-        id: attest-linux
-        if: steps.paths.outputs.appimage != ''
-        uses: ./.github/actions/attest-sbom
-        with:
-          subject-path: ${{ steps.paths.outputs.appimage }}
-          subject-name: linux-appimage
-          scan-path: extracted/linux/squashfs-root
-        continue-on-error: true
-
-      - name: Extract APK contents
-        if: steps.paths.outputs.apk != ''
-        shell: bash
-        run: |
-          set -euo pipefail
-          mkdir -p extracted/android
-          unzip -q -o "${STEPS_PATHS_OUTPUTS_APK}" -d extracted/android
-        env:
-          STEPS_PATHS_OUTPUTS_APK: ${{ steps.paths.outputs.apk }}
-
-      - name: Attest Android APK
-        id: attest-android
-        if: steps.paths.outputs.apk != ''
-        uses: ./.github/actions/attest-sbom
-        with:
-          subject-path: ${{ steps.paths.outputs.apk }}
-          subject-name: android-apk
-          scan-path: extracted/android
-        continue-on-error: true
-
-      # DMG/EXE: Linux runner can't deeply extract these; Syft scans the file
-      # best-effort. For full coverage, mac/Windows builds should emit their
-      # own SBOM as an artifact (followup).
-      - name: Attest macOS DMG
-        id: attest-macos
-        if: steps.paths.outputs.dmg != ''
-        uses: ./.github/actions/attest-sbom
-        with:
-          subject-path: ${{ steps.paths.outputs.dmg }}
-          subject-name: macos-dmg
-        continue-on-error: true
-
-      - name: Attest Windows EXE
-        id: attest-windows
-        if: steps.paths.outputs.exe != ''
-        uses: ./.github/actions/attest-sbom
-        with:
-          subject-path: ${{ steps.paths.outputs.exe }}
-          subject-name: windows-exe
-        continue-on-error: true
+          python3 .github/scripts/release_assets.py \
+            --artifacts-dir artifacts \
+            --source-sbom "${RUNNER_TEMP}/sbom-source.spdx.json" \
+            --source-sbom "${RUNNER_TEMP}/sbom-source.cdx.json" \
+            --output release-assets.txt
 
       - name: Upload to Release
-        # Multi-glob asset upload and release create/update semantics are intentional here.
-        uses: softprops/action-gh-release@v3  # zizmor: ignore[superfluous-actions]
-        with:
-          tag_name: v${{ needs.semantic-release.outputs.version }}
-          files: |
-            artifacts/**/*.AppImage
-            artifacts/**/*.AppImage.zsync
-            artifacts/**/*.dmg
-            artifacts/**/*.exe
-            artifacts/**/*.apk
-            sbom-source.spdx.json
-            sbom-source.cdx.json
-            ${{ steps.attest-linux.outputs.sbom-path }}
-            ${{ steps.attest-android.outputs.sbom-path }}
-            ${{ steps.attest-macos.outputs.sbom-path }}
-            ${{ steps.attest-windows.outputs.sbom-path }}
-          fail_on_unmatched_files: false
+        env:
+          GH_REPO: ${{ github.repository }}
+          GH_TOKEN: ${{ github.token }}
+          RELEASE_TAG: v${{ needs.semantic-release.outputs.version }}
+        run: |
+          set -euo pipefail
+          mapfile -t release_assets < release-assets.txt
+          gh release upload "$RELEASE_TAG" "${release_assets[@]}" --clobber

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -94,17 +94,17 @@ jobs:
         shell: cmd
 
     steps:
+      - name: Harden Runner
+        uses: step-security/harden-runner@v2
+        with:
+          egress-policy: audit
+
       - name: Enable RunsOn magic cache
         if: github.repository_owner == 'mavlink' && (github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository) && matrix.variant != 'arm64'
         uses: runs-on/action@v2
         with:
           metrics: cpu,network,memory,disk,io
           show_costs: summary
-
-      - name: Harden Runner
-        uses: step-security/harden-runner@v2
-        with:
-          egress-policy: audit
 
       - name: Checkout repo
         uses: actions/checkout@v7

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -406,10 +406,8 @@ jobs:
         with:
           artifact-name: ${{ matrix.package }}.exe
           package-name: ${{ matrix.package }}
+          subject-name: ${{ matrix.package }}-windows
           artifact-source-path: ${{ steps.installer.outputs.path }}
-          additional-artifact-paths: ${{ steps.installer.outputs.checksum_path }}
-          additional-aws-artifact-name: ${{ matrix.package }}.exe.sha256
-          additional-aws-artifact-path: ${{ steps.installer.outputs.checksum_path }}
           aws-role-arn: ${{ secrets.AWS_ROLE_ARN }}
           aws-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
           aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}

--- a/.github/zizmor.yml
+++ b/.github/zizmor.yml
@@ -1,6 +1,10 @@
 # Repo convention is version-tag pinning (@v2, @v6, ...) for all actions, not SHA pins.
 # ref-pin keeps the floating-ref protection (rejects @main / branch refs) while allowing tags.
 rules:
+  # QGC still uses checkout-backed ./ references for its local action suite.
+  # Treat the new $/ recommendation as a future repository-wide migration.
+  self-repository:
+    disable: true
   unpinned-uses:
     config:
       policies:

--- a/cmake/install/CPack/CreateCPackNSIS.cmake
+++ b/cmake/install/CPack/CreateCPackNSIS.cmake
@@ -133,6 +133,7 @@ string(CONFIGURE "${_qgc_nsis_extra_install}" CPACK_NSIS_EXTRA_INSTALL_COMMANDS 
 set(_qgc_nsis_extra_uninstall
     [=[
     !include "FileFunc.nsh"
+    !include "x64.nsh"
     SetRegView 64
     ; The CPack template reads these before this block runs, in the 32-bit
     ; view; re-read them under the 64-bit view the installer wrote them in.
@@ -150,7 +151,9 @@ set(_qgc_nsis_extra_uninstall
     ${GetOptions} $R0 "-LEAVE_DATA=" $R1
     StrCmp $R1 "1" qgc_keep_app_data
     SetShellVarContext current
+    ${DisableX64FSRedirection}
     RMDir /r /REBOOTOK "$APPDATA\@QGC_ORG_NAME@"
+    ${EnableX64FSRedirection}
     SetShellVarContext all
 
 qgc_keep_app_data:

--- a/src/QtLocationPlugin/QGCCachedTileSet.h
+++ b/src/QtLocationPlugin/QGCCachedTileSet.h
@@ -173,5 +173,5 @@ private:
     QGCMapEngineManager *_manager = nullptr;
     QNetworkAccessManager *_networkManager = nullptr;
 
-    static constexpr uint32_t kTileBatchSize = 256;
+    static constexpr int kTileBatchSize = 256;
 };

--- a/src/QtLocationPlugin/QGeoTileFetcherQGC.h
+++ b/src/QtLocationPlugin/QGeoTileFetcherQGC.h
@@ -19,7 +19,7 @@ public:
     static QNetworkRequest getNetworkRequest(int mapId, int x, int y, int zoom);
     /* Note: QNetworkAccessManager queues the requests it receives. The number of requests executed in parallel is dependent on the protocol.
      * Currently, for the HTTP protocol on desktop platforms, 6 requests are executed in parallel for one host/port combination. */
-    static uint32_t concurrentDownloads(const QString &type) { Q_UNUSED(type); return 6; }
+    static int concurrentDownloads(const QString &type) { Q_UNUSED(type); return 6; }
 
 private:
     QGeoTiledMapReply* getTileImage(const QGeoTileSpec &spec) final;

--- a/tools/common/io.py
+++ b/tools/common/io.py
@@ -8,8 +8,10 @@ from __future__ import annotations
 
 import contextlib
 import hashlib
+import hmac
 import json
 import os
+import re
 import tempfile
 from typing import TYPE_CHECKING, Any
 
@@ -20,15 +22,19 @@ if TYPE_CHECKING:
 __all__ = [
     "atomic_write",
     "chdir",
+    "ensure_sha256_sidecar",
     "extract_tar_data",
     "extract_zip_safe",
     "read_json",
     "read_toml",
     "require_tar_data_filter",
     "sha256_file",
+    "verify_sha256_sidecar",
     "write_json",
     "write_text_if_changed",
 ]
+
+_SHA256_SIDECAR_LINE = re.compile(r"([0-9a-fA-F]{64}) [ *](.+)")
 
 
 @contextlib.contextmanager
@@ -94,6 +100,47 @@ def sha256_file(path: Path, *, chunk_size: int = 1024 * 1024) -> str:
         while chunk := file.read(chunk_size):
             digest.update(chunk)
     return digest.hexdigest()
+
+
+def verify_sha256_sidecar(source: Path, checksum: Path | None = None) -> str:
+    """Validate a sha256sum-compatible sidecar and return the actual digest."""
+    if not source.is_file():
+        raise FileNotFoundError(f"Artifact is not a file: {source}")
+
+    checksum = checksum or source.with_name(f"{source.name}.sha256")
+    lines = [
+        line.strip()
+        for line in checksum.read_text(encoding="utf-8-sig").splitlines()
+        if line.strip()
+    ]
+    if len(lines) != 1:
+        raise ValueError(f"Expected exactly one checksum entry in {checksum}")
+
+    match = _SHA256_SIDECAR_LINE.fullmatch(lines[0])
+    if match is None:
+        raise ValueError(f"Malformed SHA-256 checksum entry in {checksum}")
+
+    expected_digest, listed_name = match.groups()
+    if listed_name.casefold() != source.name.casefold():
+        raise ValueError(
+            f"Checksum filename {listed_name!r} does not match artifact {source.name!r}"
+        )
+
+    actual_digest = sha256_file(source)
+    if not hmac.compare_digest(expected_digest.casefold(), actual_digest):
+        raise ValueError(f"SHA-256 checksum mismatch for {source}")
+    return actual_digest
+
+
+def ensure_sha256_sidecar(source: Path, checksum: Path | None = None) -> Path:
+    """Verify or create a canonical sha256sum-compatible checksum sidecar."""
+    if not source.is_file():
+        raise FileNotFoundError(f"Artifact is not a file: {source}")
+
+    checksum = checksum or source.with_name(f"{source.name}.sha256")
+    digest = verify_sha256_sidecar(source, checksum) if checksum.exists() else sha256_file(source)
+    write_text_if_changed(checksum, f"{digest}  {source.name}\n")
+    return checksum
 
 
 def read_json(path: Path) -> Any:

--- a/tools/tests/test_io.py
+++ b/tools/tests/test_io.py
@@ -1,4 +1,3 @@
-#!/usr/bin/env python3
 """Tests for tools/common/io.py."""
 
 from __future__ import annotations
@@ -11,11 +10,13 @@ from typing import TYPE_CHECKING
 import pytest
 from common.io import (
     atomic_write,
+    ensure_sha256_sidecar,
     extract_tar_data,
     extract_zip_safe,
     read_json,
     read_toml,
     sha256_file,
+    verify_sha256_sidecar,
     write_json,
     write_text_if_changed,
 )
@@ -97,6 +98,47 @@ def test_write_text_if_changed_and_sha256_file(tmp_path: Path) -> None:
     for invalid_size in (0, -1):
         with pytest.raises(ValueError, match="chunk_size must be a positive integer"):
             sha256_file(payload, chunk_size=invalid_size)
+
+
+def test_ensure_sha256_sidecar_creates_canonical_checksum(tmp_path: Path) -> None:
+    artifact = tmp_path / "QGroundControl.AppImage"
+    artifact.write_bytes(b"release artifact")
+
+    checksum = ensure_sha256_sidecar(artifact)
+
+    digest = sha256_file(artifact)
+    assert checksum == tmp_path / "QGroundControl.AppImage.sha256"
+    assert checksum.read_text(encoding="utf-8") == f"{digest}  {artifact.name}\n"
+    assert verify_sha256_sidecar(artifact) == digest
+
+
+def test_ensure_sha256_sidecar_normalizes_valid_windows_checksum(tmp_path: Path) -> None:
+    artifact = tmp_path / "QGroundControl-installer-AMD64.exe"
+    artifact.write_bytes(b"installer")
+    digest = sha256_file(artifact)
+    checksum = artifact.with_name(f"{artifact.name}.sha256")
+    checksum.write_text(f"\ufeff{digest.upper()} *{artifact.name.upper()}\r\n", encoding="utf-8")
+
+    ensure_sha256_sidecar(artifact)
+
+    assert checksum.read_text(encoding="utf-8") == f"{digest}  {artifact.name}\n"
+
+
+def test_verify_sha256_sidecar_rejects_invalid_content(tmp_path: Path) -> None:
+    artifact = tmp_path / "QGroundControl.dmg"
+    artifact.write_bytes(b"disk image")
+    checksum = artifact.with_name(f"{artifact.name}.sha256")
+
+    invalid_entries = (
+        f"{'0' * 64}  {artifact.name}\n",
+        f"{sha256_file(artifact)}  another.dmg\n",
+        "not a checksum\n",
+        f"{sha256_file(artifact)}  {artifact.name}\nextra\n",
+    )
+    for content in invalid_entries:
+        checksum.write_text(content, encoding="utf-8")
+        with pytest.raises(ValueError):
+            verify_sha256_sidecar(artifact, checksum)
 
 
 def test_extract_tar_data_rejects_traversal(tmp_path: Path) -> None:


### PR DESCRIPTION
## CI/Build Changes

- Enforce least-privilege workflow permissions, non-persistent checkout credentials, and other workflow security invariants with a dedicated policy test.
- Finalize the release pipeline so semantic releases dispatch the platform package workflows for the release SHA, wait for those runs, validate the complete native asset set, and publish checksums plus source and dependency SBOMs.
- Generate and attest CPM dependency SBOMs alongside each native package, while retaining the platform-produced attestations for the actual installers.
- Fix the Android ARMv7 signedness build failure and make Windows NSIS cleanup reliable for 32-bit installers running under 64-bit service accounts.

## Reason

Release tags created with `GITHUB_TOKEN` do not trigger tag-based platform workflows, so the release job must explicitly dispatch and bind those builds to the release commit. The release also needs to fail closed when an expected package, checksum, or SBOM is absent.

The workflow policy checks make the security expectations executable instead of relying on review alone. The final commit also addresses the current `master` Android and Windows packaging failures encountered while validating the affected workflows.

## Testing

- [ ] Tested workflow locally (act or similar)
- [x] Verified YAML syntax
- [ ] Tested on fork before submitting

Additional validation:

- `just build`
- `uv run --project tools --extra scripts --extra test pytest -q tools/tests .github/scripts/tests` (`1170 passed`)
- `ctest -R QGCCacheWorkerTest --output-on-failure`
- `ctest -R QGCCachedTileSetTest --output-on-failure`
- Focused release-asset, attestation, SBOM, workflow-policy, and native-packaging contract tests
- Local CPM SBOM generation against the configured build produced a CycloneDX 1.6 document with 21 components

## Impact

This affects the release workflow, native Android/iOS/Linux/macOS/Windows package workflows, reusable CI workflows and actions, and the CI Scripts policy/contract test suite. Normal application runtime behavior is unchanged except for the signed type correction needed by the Android ARMv7 build.

The new zizmor `self-repository` audit is scoped out for now because the repository's existing checkout-backed local-action calls require a separate repo-wide migration. All other security-policy checks added here remain enforced.

## Checklist

- [x] I have read the [Contribution Guidelines](../CONTRIBUTING.md)
- [x] Workflow permissions follow least-privilege principle
- [x] No secrets are exposed in logs

---
By submitting this pull request, I confirm that my contribution is made under the terms of the project's dual license (Apache 2.0 and GPL v3).
