### PR TITLE
fix(Vehicle): remove initial connect outer timeouts causing slow-link failures

### DIFF
--- a/src/Comms/MockLink/MockLink.cc
+++ b/src/Comms/MockLink/MockLink.cc
@@ -444,11 +444,6 @@ void MockLink::run1HzTasks()
         _sendHomePositionDelayCount--;
     } else {
         _sendHomePosition();
-        // We piggy back on this delay to signal we have new standard modes available
-        if (_availableModesMonitorSeqNumber == 0) {
-            qCDebug(MockLinkLog) << "Bumping sequence number for available modes monitor to trigger requery of modes";
-            _availableModesMonitorSeqNumber = 1;
-        }
     }
 }
 
@@ -488,6 +483,11 @@ void MockLink::run10HzTasks()
 
 void MockLink::run500HzTasks()
 {
+    if (_mavlinkStarted && _connected && mavlinkChannelIsSet()) {
+        // Standard modes are served even on high-latency links since the request is still accepted there.
+        _availableModesWorker();
+    }
+
     if (linkConfiguration()->isHighLatency()) {
         return;
     }
@@ -498,7 +498,6 @@ void MockLink::run500HzTasks()
             _paramRequestListWorker();
         }
         _logDownloadWorker();
-        _availableModesWorker();
         _apmCompassCalWorker();
         _apmAccelCalWorker();
     }

--- a/src/Comms/MockLink/MockLink.h
+++ b/src/Comms/MockLink/MockLink.h
@@ -118,6 +118,10 @@ public:
     }
     int receivedMissionRequestListCount(MAV_MISSION_TYPE type) const { return _missionItemHandler->requestListCount(type); }
 
+    /// Unit test support: bumps the AVAILABLE_MODES_MONITOR sequence number, which unlocks the
+    /// delayed flight mode and causes QGC to re-query standard modes.
+    void bumpAvailableModesMonitorSequence() { ++_availableModesMonitorSeqNumber; }
+
     enum RequestMessageFailureMode_t {
         FailRequestMessageNone,
         FailRequestMessageCommandAcceptedMsgNotSent,
@@ -422,7 +426,9 @@ private:
     ///   - Main thread: _handleRequestMessageAvailableModes() checking/starting/stopping worker
     ///   - Worker thread: _availableModesWorker() incrementing index every 2ms (500Hz)
     QMutex _availableModesWorkerMutex;
-    uint8_t _availableModesMonitorSeqNumber = 0;        ///< Sequence number for the next available mode message to send
+    /// Sequence number sent in AVAILABLE_MODES_MONITOR. Written from the test (main) thread via
+    /// bumpAvailableModesMonitorSequence, read from the worker thread at 1Hz/500Hz.
+    std::atomic<uint8_t> _availableModesMonitorSeqNumber = 0;
 
     QString _logDownloadFilename;                       ///< Filename for log download which is in progress
     bool _logsErased = false;                           ///< Set by LOG_ERASE, LOG_REQUEST_LIST reports no logs

--- a/src/FactSystem/ParameterManager.cc
+++ b/src/FactSystem/ParameterManager.cc
@@ -264,7 +264,7 @@ void ParameterManager::_handleParamValue(int componentId, const QString &paramet
 
     _checkInitialLoadComplete();
 
-    qCDebug(ParameterManagerVerbose1Log) << _logVehiclePrefix(componentId) << "_parameterUpdate complete";
+    qCDebug(ParameterManagerVerbose1Log) << _logVehiclePrefix(componentId) << "_handleParamValue complete";
 }
 
 QString ParameterManager::_vehicleAndComponentString(int componentId) const
@@ -851,7 +851,7 @@ bool ParameterManager::_fillIndexBatchQueue(bool waitingParamTimeout)
     for (const int componentId: _waitingReadParamIndexMap.keys()) {
         if (_waitingReadParamIndexMap[componentId].count()) {
             qCDebug(ParameterManagerLog) << _logVehiclePrefix(componentId) << "_waitingReadParamIndexMap count" << _waitingReadParamIndexMap[componentId].count();
-            qCDebug(ParameterManagerVerbose1Log) << _logVehiclePrefix(componentId) << "_waitingReadParamIndexMap" << _waitingReadParamIndexMap[componentId];
+            qCDebug(ParameterManagerVerbose1Log) << _logVehiclePrefix(componentId) << "_waitingReadParamIndexMap (index, retry count)" << _waitingReadParamIndexMap[componentId];
         }
 
         for (const int paramIndex: _waitingReadParamIndexMap[componentId].keys()) {
@@ -888,7 +888,7 @@ void ParameterManager::_waitingParamTimeout()
         return;
     }
 
-    qCDebug(ParameterManagerLog) << _logVehiclePrefix(-1) << "_waitingParamTimeout";
+    qCDebug(ParameterManagerLog) << _logVehiclePrefix(-1) << "_waitingParamTimeout after" << _waitingParamTimeoutTimer.interval() << "ms";
 
     // Now that we have timed out for possibly the first time we can activate the index batch queue
     _indexBatchQueueActive = true;
@@ -1073,6 +1073,7 @@ void ParameterManager::_writeLocalParamCache(int vehicleId, int componentId)
     if (cacheFile.open(QIODevice::WriteOnly | QIODevice::Truncate)) {
         QDataStream ds(&cacheFile);
         ds << cacheMap;
+        qCDebug(ParameterManagerLog) << "Parameter cache written" << cacheFile.fileName() << "paramCount:" << cacheMap.count();
     } else {
         qCWarning(ParameterManagerLog) << "Failed to open cache file for writing" << cacheFile.fileName();
     }
@@ -1100,7 +1101,7 @@ void ParameterManager::_tryCacheHashLoad(int vehicleId, int componentId, const Q
     CacheMapName2ParamTypeVal cacheMap;
     QFile cacheFile(parameterCacheFile(vehicleId, componentId));
     if (!cacheFile.exists()) {
-        qCDebug(ParameterManagerLog) << "No parameter cache file";
+        qCDebug(ParameterManagerLog) << "Parameter cache usage failed - No parameter cache file";
         if (!_hashCheckDone) {
             _hashCheckDone = true;
             if (_cacheOnlyHashCheck) {
@@ -1405,12 +1406,17 @@ void ParameterManager::_paramRequestListTimeout()
     if (!_disableAllRetries && (++_initialRequestRetryCount <= _maxInitialRequestListRetry)) {
         qCDebug(ParameterManagerLog) << _logVehiclePrefix(-1) << "Retrying initial parameter request list";
         _startParameterDownload(MAV_COMP_ID_ALL);
-    } else if (!_vehicle->genericFirmware()) {
+        return;
+    }
+
+    qCDebug(ParameterManagerLog) << _logVehiclePrefix(-1) << "Initial parameter request list retries exhausted, giving up";
+    if (!_vehicle->genericFirmware()) {
         const QString errorMsg = tr("Vehicle %1 did not respond to request for parameters. "
                                     "This will cause %2 to be unable to display its full user interface.").arg(_vehicle->id()).arg(QCoreApplication::applicationName());
         qCDebug(ParameterManagerLog) << errorMsg;
         QGC::showAppMessage(errorMsg);
     }
+    emit initialParametersRequestFailed();
 }
 
 QString ParameterManager::_remapParamNameToVersion(const QString &paramName) const
@@ -1431,7 +1437,7 @@ QString ParameterManager::_remapParamNameToVersion(const QString &paramName) con
     const FirmwarePlugin::remapParamNameMajorVersionMap_t &majorVersionRemap = _vehicle->firmwarePlugin()->paramNameRemapMajorVersionMap();
     if (!majorVersionRemap.contains(majorVersion)) {
         // No mapping for this major version
-        qCDebug(ParameterManagerLog) << "_remapParamNameToVersion: no major version mapping";
+        qCDebug(ParameterManagerVerbose1Log) << "_remapParamNameToVersion: no major version mapping";
         return paramName;
     }
 

--- a/src/FactSystem/ParameterManager.h
+++ b/src/FactSystem/ParameterManager.h
@@ -122,6 +122,7 @@ signals:
     void missingParametersChanged(bool missingParameters);
     void loadProgressChanged(float value);
     void cacheCheckOnlyFailed();
+    void initialParametersRequestFailed();      ///< Vehicle never responded to PARAM_REQUEST_LIST, all retries exhausted
     void pendingWritesChanged(bool pendingWrites);
     void parameterDownloadSkippedChanged();
     void factAdded(int componentId, Fact *fact);

--- a/src/Gimbal/GimbalController.cc
+++ b/src/Gimbal/GimbalController.cc
@@ -271,11 +271,35 @@ void GimbalController::_requestGimbalInformation(uint8_t compid)
 {
     qCDebug(GimbalControllerLog) << "_requestGimbalInformation(" << compid << ")";
 
-    if (_vehicle) {
-        _vehicle->sendMavCommand(compid,
-                                 MAV_CMD_REQUEST_MESSAGE,
-                                 false /* no error */,
-                                 MAVLINK_MSG_ID_GIMBAL_MANAGER_INFORMATION);
+    if (!_vehicle) {
+        return;
+    }
+    if (_pendingInformationRequestCompId != -1) {
+        qCDebug(GimbalControllerLog) << "_requestGimbalInformation: request already in flight for compid" << _pendingInformationRequestCompId;
+        return;
+    }
+
+    // Must go through requestMessage rather than sending MAV_CMD_REQUEST_MESSAGE directly so
+    // that it serializes with other request-message users targeting the same component
+    // (a raw send collides with theirs in the command queue's duplicate-command check).
+    _pendingInformationRequestCompId = compid;
+    _vehicle->requestMessage(_requestMessageResultHandler,
+                             this,
+                             compid,
+                             MAVLINK_MSG_ID_GIMBAL_MANAGER_INFORMATION);
+}
+
+void GimbalController::_requestMessageResultHandler(void* resultHandlerData, MAV_RESULT result, VehicleTypes::RequestMessageResultHandlerFailureCode_t failureCode, const mavlink_message_t& message)
+{
+    Q_UNUSED(message);
+
+    auto* controller = static_cast<GimbalController*>(resultHandlerData);
+    controller->_pendingInformationRequestCompId = -1;
+
+    // Success is handled by the normal GIMBAL_MANAGER_INFORMATION message dispatch and
+    // failures are retried from _checkComplete, so just log here.
+    if (result != MAV_RESULT_ACCEPTED) {
+        qCDebug(GimbalControllerLog) << "GIMBAL_MANAGER_INFORMATION request failed - result:" << result << "failureCode:" << failureCode;
     }
 }
 

--- a/src/Gimbal/GimbalController.h
+++ b/src/Gimbal/GimbalController.h
@@ -5,6 +5,7 @@
 
 #include "Gimbal.h"
 #include "MAVLinkMessageType.h"
+#include "VehicleTypes.h"
 
 class QmlObjectListModel;
 class Vehicle;
@@ -91,6 +92,7 @@ private:
     };
 
     void _requestGimbalInformation(uint8_t compid);
+    static void _requestMessageResultHandler(void* resultHandlerData, MAV_RESULT result, VehicleTypes::RequestMessageResultHandlerFailureCode_t failureCode, const mavlink_message_t& message);
     void _handleHeartbeat(const mavlink_message_t &message);
     void _handleGimbalManagerInformation(const mavlink_message_t &message);
     void _handleGimbalManagerStatus(const mavlink_message_t &message);
@@ -104,6 +106,7 @@ private:
     QTimer _rateSenderTimer;
     Vehicle *_vehicle = nullptr;
     Gimbal *_activeGimbal = nullptr;
+    int _pendingInformationRequestCompId = -1; ///< compid of in-flight GIMBAL_MANAGER_INFORMATION request, -1 if none
 
     struct PotentialGimbalManager {
         unsigned requestGimbalManagerInformationRetries = 6;

--- a/src/Utilities/Network/QGCFileDownload.cc
+++ b/src/Utilities/Network/QGCFileDownload.cc
@@ -143,7 +143,9 @@ bool QGCFileDownload::start(const QString &remoteUrl, const QGCNetworkHelper::Re
     // Create request with configuration
     QNetworkRequest request = QGCNetworkHelper::createRequest(url, config);
 
-    qCDebug(QGCFileDownloadLog) << "Starting download:" << url.toString() << "to" << _localPath;
+    qCDebug(QGCFileDownloadLog) << "Starting download:"
+                                << url.toDisplayString(QUrl::RemoveUserInfo | QUrl::RemoveQuery | QUrl::RemoveFragment)
+                                << "to" << _localPath;
 
     // Start download
     _currentReply = _networkManager->get(request);
@@ -346,7 +348,8 @@ void QGCFileDownload::_onDownloadError(QNetworkReply::NetworkError code)
         break;
     }
 
-    qCWarning(QGCFileDownloadLog) << "Download error:" << errorMsg;
+    qCWarning(QGCFileDownloadLog) << "Download error:" << errorMsg << "url:"
+                                  << _url.toDisplayString(QUrl::RemoveUserInfo | QUrl::RemoveQuery | QUrl::RemoveFragment);
     _setErrorString(errorMsg);
 }
 

--- a/src/Utilities/StateMachine/States/WaitStateBase.cc
+++ b/src/Utilities/StateMachine/States/WaitStateBase.cc
@@ -46,7 +46,7 @@ void WaitStateBase::_onTimeout()
         return;
     }
 
-    qCDebug(QGCStateMachineLog) << "Timeout" << stateName();
+    qCWarning(QGCStateMachineLog) << "Timeout" << stateName() << "after" << _timeoutTimer.interval() << "ms";
 
     // Record timeout for statistics
     if (machine()) {

--- a/src/Utilities/StateMachine/Transitions/RetryTransition.cc
+++ b/src/Utilities/StateMachine/Transitions/RetryTransition.cc
@@ -20,7 +20,7 @@ bool RetryTransition::eventTest(QEvent* event)
 
     if (_retryCount < _maxRetries) {
         _retryCount++;
-        qCDebug(RetryTransitionLog) << stateName << "timeout, retry" << _retryCount << "of" << _maxRetries;
+        qCWarning(RetryTransitionLog) << stateName << "timeout, retry" << _retryCount << "of" << _maxRetries;
 
         if (auto* waitState = qobject_cast<WaitStateBase*>(sourceState())) {
             waitState->restartWait();

--- a/src/Vehicle/ComponentInformation/ComponentInformationManager.cc
+++ b/src/Vehicle/ComponentInformation/ComponentInformationManager.cc
@@ -179,10 +179,8 @@ void ComponentInformationManager::requestAllComponentInformation(RequestAllCompl
     _requestAllCompleteFn       = requestAllCompletFn;
     _requestAllCompleteFnData   = requestAllCompleteFnData;
 
-    // Guard against double-start: when InitialConnectStateMachine's CompInfo
-    // state times out, the retry callback re-invokes this method while the CIM
-    // state machine is still running. Only start if not already in progress;
-    // the updated callback pointers above are sufficient for the retry path.
+    // Guard against double-start: a request while already running just updates the
+    // callback pointers; the running machine still emits requestAllComplete at the end.
     if (!isRunning()) {
         start();
     }
@@ -242,6 +240,7 @@ void ComponentInformationManager::_signalComplete()
         _requestAllCompleteFn      = nullptr;
         _requestAllCompleteFnData  = nullptr;
     }
+    emit requestAllComplete();
 }
 
 bool ComponentInformationManager::_isCompTypeSupported(COMP_METADATA_TYPE type) const

--- a/src/Vehicle/ComponentInformation/ComponentInformationManager.h
+++ b/src/Vehicle/ComponentInformation/ComponentInformationManager.h
@@ -39,6 +39,7 @@ public:
 
 signals:
     void progressUpdate(float progress);
+    void requestAllComplete();
 
 private:
     void _createStates();

--- a/src/Vehicle/ComponentInformation/RequestMetaDataTypeStateMachine.cc
+++ b/src/Vehicle/ComponentInformation/RequestMetaDataTypeStateMachine.cc
@@ -387,7 +387,7 @@ void RequestMetaDataTypeStateMachine::_requestTranslate()
                                                        typeToString())) {
         disconnect(_compMgr->translation(), &ComponentInformationTranslation::downloadComplete,
                    this, &RequestMetaDataTypeStateMachine::_downloadAndTranslationComplete);
-        qCDebug(RequestMetaDataTypeStateMachineLog) << "downloadAndTranslate() failed";
+        qCDebug(RequestMetaDataTypeStateMachineLog) << typeToString() << ": translation skipped (English locale, locale unavailable, or download failure), using untranslated metadata";
         _stateRequestTranslate->complete();
     }
 }
@@ -499,7 +499,7 @@ void RequestMetaDataTypeStateMachine::_requestFile(const QString& cacheFileTag, 
         qCDebug(RequestMetaDataTypeStateMachineLog) << typeToString() << ": not found in cache, downloading";
     }
 
-    qCDebug(RequestMetaDataTypeStateMachineLog) << "Downloading json" << uri;
+    qCDebug(RequestMetaDataTypeStateMachineLog) << typeToString() << ": downloading json" << uri;
 
     if (_uriIsMAVLinkFTP(uri)) {
         if (trackMetadataSource) {

--- a/src/Vehicle/InitialConnectStateMachine.cc
+++ b/src/Vehicle/InitialConnectStateMachine.cc
@@ -29,7 +29,6 @@ InitialConnectStateMachine::InitialConnectStateMachine(Vehicle* vehicle, QObject
     _createStates();
     _wireTransitions();
     _wireProgressTracking();
-    _wireTimeoutHandling();
 
     setInitialState(_stateAutopilotVersion);
 }
@@ -54,9 +53,8 @@ void InitialConnectStateMachine::_createStates()
         [this](Vehicle*, const mavlink_message_t& message) {
             _handleAutopilotVersionSuccess(message);
         },
-        _maxRetries,
-        MAV_COMP_ID_AUTOPILOT1,
-        _timeoutAutopilotVersion
+        _autopilotVersionMaxRetries,
+        MAV_COMP_ID_AUTOPILOT1
     );
     _stateAutopilotVersion->setSkipPredicate([this]() {
         return _shouldSkipAutopilotVersionRequest();
@@ -66,22 +64,27 @@ void InitialConnectStateMachine::_createStates()
     });
 
     // State 1: Request standard modes
+    // No timeout: download duration varies too much with link speed and mode count.
+    // The standard modes protocol handles all timeouts internally and always signals completion.
     _stateStandardModes = new AsyncFunctionState(
         QStringLiteral("RequestStandardModes"),
         this,
-        [this](AsyncFunctionState* state) { _requestStandardModes(state); },
-        _timeoutStandardModes
+        [this](AsyncFunctionState* state) { _requestStandardModes(state); }
     );
 
     // State 2: Request component information
+    // No timeout: ComponentInformationManager's nested state machines have per-state
+    // timeouts on every step and always signal completion.
     _stateCompInfo = new AsyncFunctionState(
         QStringLiteral("RequestCompInfo"),
         this,
-        [this](AsyncFunctionState* state) { _requestCompInfo(state); },
-        _timeoutCompInfo
+        [this](AsyncFunctionState* state) { _requestCompInfo(state); }
     );
 
     // State 3: Request parameters (skippable)
+    // No timeout: download duration varies too much with link speed and param count.
+    // ParameterManager handles all timeouts internally and always terminates via
+    // parametersReadyChanged or initialParametersRequestFailed.
     _stateParameters = new SkippableAsyncState(
         QStringLiteral("RequestParameters"),
         this,
@@ -100,11 +103,11 @@ void InitialConnectStateMachine::_createStates()
         [this]() {
             qCDebug(InitialConnectStateMachineLog) << "Skipping parameter download" << _lastSkipReason;
             vehicle()->_parameterManager->setParameterDownloadSkipped(true);
-        },
-        _timeoutParameters
+        }
     );
 
     // State 4: Request mission (skippable)
+    // No timeout: PlanManager handles all timeouts/retries internally and always signals completion.
     _stateMission = new SkippableAsyncState(
         QStringLiteral("RequestMission"),
         this,
@@ -112,11 +115,11 @@ void InitialConnectStateMachine::_createStates()
         [this](SkippableAsyncState* state) { _requestMission(state); },
         [this]() {
             qCDebug(InitialConnectStateMachineLog) << "Skipping mission load" << _lastSkipReason;
-        },
-        _timeoutMission
+        }
     );
 
     // State 5: Request geofence (skippable)
+    // No timeout: PlanManager handles all timeouts/retries internally and always signals completion.
     _stateGeoFence = new SkippableAsyncState(
         QStringLiteral("RequestGeoFence"),
         this,
@@ -133,11 +136,11 @@ void InitialConnectStateMachine::_createStates()
         [this](SkippableAsyncState* state) { _requestGeoFence(state); },
         [this]() {
             qCDebug(InitialConnectStateMachineLog) << "Skipping geofence load" << _lastSkipReason;
-        },
-        _timeoutGeoFence
+        }
     );
 
     // State 6: Request rally points (skippable)
+    // No timeout: PlanManager handles all timeouts/retries internally and always signals completion.
     _stateRallyPoints = new SkippableAsyncState(
         QStringLiteral("RequestRallyPoints"),
         this,
@@ -157,8 +160,7 @@ void InitialConnectStateMachine::_createStates()
             // Mark plan request complete when skipping
             vehicle()->_initialPlanRequestComplete = true;
             emit vehicle()->initialPlanRequestCompleteChanged(true);
-        },
-        _timeoutRallyPoints
+        }
     );
 
     // State 7: Signal completion
@@ -224,34 +226,6 @@ void InitialConnectStateMachine::_wireProgressTracking()
 void InitialConnectStateMachine::_onSubProgressUpdate(double progressValue)
 {
     setSubProgress(static_cast<float>(progressValue));
-}
-
-// ============================================================================
-// Timeout Handling
-// ============================================================================
-
-void InitialConnectStateMachine::_wireTimeoutHandling()
-{
-    // Note: _stateAutopilotVersion is RetryableRequestMessageState which handles its own retry
-
-    // Use addRetryTransition builder for cleaner timeout handling
-    addRetryTransition(_stateStandardModes, &WaitStateBase::timedOut, _stateCompInfo,
-                       [this]() { _requestStandardModes(_stateStandardModes); }, _maxRetries);
-
-    addRetryTransition(_stateCompInfo, &WaitStateBase::timedOut, _stateParameters,
-                       [this]() { _requestCompInfo(_stateCompInfo); }, _maxRetries);
-
-    addRetryTransition(_stateParameters, &WaitStateBase::timedOut, _stateMission,
-                       [this]() { _requestParameters(_stateParameters); }, _maxRetries);
-
-    addRetryTransition(_stateMission, &WaitStateBase::timedOut, _stateGeoFence,
-                       [this]() { _requestMission(_stateMission); }, _maxRetries);
-
-    addRetryTransition(_stateGeoFence, &WaitStateBase::timedOut, _stateRallyPoints,
-                       [this]() { _requestGeoFence(_stateGeoFence); }, _maxRetries);
-
-    addRetryTransition(_stateRallyPoints, &WaitStateBase::timedOut, _stateComplete,
-                       [this]() { _requestRallyPoints(_stateRallyPoints); }, _maxRetries);
 }
 
 // ============================================================================
@@ -406,15 +380,8 @@ void InitialConnectStateMachine::_requestCompInfo(AsyncFunctionState* state)
                    this, &InitialConnectStateMachine::_onSubProgressUpdate);
     });
 
-    vehicle()->_componentInformationManager->requestAllComponentInformation(
-        [](void* requestAllCompleteFnData) {
-            auto* self = static_cast<InitialConnectStateMachine*>(requestAllCompleteFnData);
-            if (self->_stateCompInfo) {
-                self->_stateCompInfo->complete();
-            }
-        },
-        this
-    );
+    state->connectToCompletion(vehicle()->_componentInformationManager, &ComponentInformationManager::requestAllComplete);
+    vehicle()->_componentInformationManager->requestAllComponentInformation(nullptr, nullptr);
 }
 
 void InitialConnectStateMachine::_requestParameters(SkippableAsyncState* state)
@@ -436,15 +403,23 @@ void InitialConnectStateMachine::_requestParameters(SkippableAsyncState* state)
     connect(vehicle()->_parameterManager, &ParameterManager::loadProgressChanged,
             this, &InitialConnectStateMachine::_onSubProgressUpdate, Qt::UniqueConnection);
 
+    // If the vehicle never answers PARAM_REQUEST_LIST, advance without parameters
+    const QMetaObject::Connection requestFailedConn = connect(vehicle()->_parameterManager, &ParameterManager::initialParametersRequestFailed,
+            state, [state]() {
+                qCDebug(InitialConnectStateMachineLog) << "Initial parameter request failed, advancing without parameters";
+                state->complete();
+            });
+
     state->connectToCompletion(vehicle()->_parameterManager, &ParameterManager::parametersReadyChanged,
         [this](bool parametersReady) {
             _onParametersReady(parametersReady);
         });
 
-    // Ensure progress tracking is always cleaned up, including timeout/skip paths.
-    state->setOnExit([this, cacheFailedConn]() {
+    // Ensure progress tracking is always cleaned up, including failure/skip paths.
+    state->setOnExit([this, cacheFailedConn, requestFailedConn]() {
         disconnect(vehicle()->_parameterManager, &ParameterManager::loadProgressChanged,
                    this, &InitialConnectStateMachine::_onSubProgressUpdate);
+        disconnect(requestFailedConn);
         if (cacheFailedConn) {
             disconnect(cacheFailedConn);
         }

--- a/src/Vehicle/InitialConnectStateMachine.h
+++ b/src/Vehicle/InitialConnectStateMachine.h
@@ -36,7 +36,6 @@ private:
     void _createStates();
     void _wireTransitions();
     void _wireProgressTracking();
-    void _wireTimeoutHandling();
 
     // State callbacks
     void _handleAutopilotVersionSuccess(const mavlink_message_t& message);
@@ -70,15 +69,5 @@ private:
     RetryState* _stateComplete = nullptr;
     QGCFinalState* _stateFinal = nullptr;
 
-    // Timeout handling with retry
-    static constexpr int _maxRetries = 1;
-
-    // Timeout values (ms)
-    static constexpr int _timeoutAutopilotVersion = 5000;
-    static constexpr int _timeoutStandardModes = 5000;
-    static constexpr int _timeoutCompInfo = 30000;
-    static constexpr int _timeoutParameters = 60000;
-    static constexpr int _timeoutMission = 30000;
-    static constexpr int _timeoutGeoFence = 15000;
-    static constexpr int _timeoutRallyPoints = 15000;
+    static constexpr int _autopilotVersionMaxRetries = 1;
 };

--- a/src/Vehicle/RequestMessageCoordinator.cc
+++ b/src/Vehicle/RequestMessageCoordinator.cc
@@ -33,6 +33,35 @@ void RequestMessageCoordinator::stop()
     _queueMap.clear();
 }
 
+void RequestMessageCoordinator::_noOpResultHandler(void*, MAV_RESULT, RequestMessageResultHandlerFailureCode_t, const mavlink_message_t&)
+{
+}
+
+void RequestMessageCoordinator::cancelRequests(void* resultHandlerData)
+{
+    // Repoint outstanding requests (active or queued) owned by resultHandlerData to the no-op
+    // handler rather than deleting them: an active request may still have a pending command in
+    // MavCommandQueue that references its RequestMessageInfo_t, so the info must stay alive and
+    // be cleaned up through the normal ack/timeout path — just without calling back into the
+    // now-dead context.
+    const auto repoint = [resultHandlerData](RequestMessageInfo_t* info) {
+        if (info->resultHandlerData == resultHandlerData) {
+            info->resultHandler     = &_noOpResultHandler;
+            info->resultHandlerData = nullptr;
+        }
+    };
+    for (auto& msgMap : _infoMap) {
+        for (RequestMessageInfo_t* info : msgMap) {
+            repoint(info);
+        }
+    }
+    for (auto& requestQueue : _queueMap) {
+        for (RequestMessageInfo_t* info : requestQueue) {
+            repoint(info);
+        }
+    }
+}
+
 bool RequestMessageCoordinator::_duplicate(int compId, int msgId) const
 {
     const mavlink_message_info_t* info = mavlink_get_message_info_by_id(msgId);
@@ -185,8 +214,7 @@ void RequestMessageCoordinator::handleReceivedMessage(const mavlink_message_t& m
     void*                       timedOutHandlerData   = nullptr;
     for (auto& compIdEntry : _infoMap) {
         for (auto info : compIdEntry) {
-            // Unit-test environments can have enough scheduling jitter that a 50ms
-            // response deadline causes false request-message timeouts.
+            // Shorter timeout during unit tests keeps failure-path tests fast.
             const int messageWaitTimeoutMs = QGC::runningUnitTests() ? 500 : 1000;
             if (info->messageWaitElapsedTimer.isValid() && info->messageWaitElapsedTimer.elapsed() > messageWaitTimeoutMs) {
                 const mavlink_message_info_t* msgInfo = mavlink_get_message_info_by_id(info->msgId);

--- a/src/Vehicle/RequestMessageCoordinator.h
+++ b/src/Vehicle/RequestMessageCoordinator.h
@@ -38,6 +38,11 @@ public:
     /// Clear pending state without firing callbacks (used during vehicle shutdown).
     void stop();
 
+    /// Neutralizes any outstanding requests owned by @a resultHandlerData so their result
+    /// callback is never invoked. Call this when the callback's context is being destroyed
+    /// while the vehicle (and this coordinator) keep running.
+    void cancelRequests(void* resultHandlerData);
+
     static QString failureCodeToString(RequestMessageResultHandlerFailureCode_t failureCode);
 
 private:
@@ -65,6 +70,10 @@ private:
     void _sendNextFromQueue(int compId);
 
     static void _cmdResultHandler(void* resultHandlerData, int compId, const mavlink_command_ack_t& ack, MavCmdResultFailureCode_t failureCode);
+
+    /// Result handler that outstanding requests are repointed to once their owning context is
+    /// destroyed. Intentionally does nothing.
+    static void _noOpResultHandler(void* resultHandlerData, MAV_RESULT commandResult, RequestMessageResultHandlerFailureCode_t failureCode, const mavlink_message_t& message);
 
     Vehicle*                                                _vehicle     = nullptr;
     MavCommandQueue*                                        _commandQueue = nullptr;

--- a/src/Vehicle/StandardModes.cc
+++ b/src/Vehicle/StandardModes.cc
@@ -1,15 +1,16 @@
 #include "StandardModes.h"
 #include "Vehicle.h"
 #include "QGCLoggingCategory.h"
+#include "QGCMAVLink.h"
 
 QGC_LOGGING_CATEGORY(StandardModesLog, "Vehicle.StandardModes")
 
 static void requestMessageResultHandler(void *resultHandlerData, MAV_RESULT result,
-                                        [[maybe_unused]] Vehicle::RequestMessageResultHandlerFailureCode_t failureCode,
+                                        VehicleTypes::RequestMessageResultHandlerFailureCode_t failureCode,
                                         const mavlink_message_t &message)
 {
     StandardModes* standardModes = static_cast<StandardModes*>(resultHandlerData);
-    standardModes->gotMessage(result, message);
+    standardModes->gotMessage(result, failureCode, message);
 }
 
 StandardModes::StandardModes(QObject *parent, Vehicle *vehicle)
@@ -17,7 +18,7 @@ StandardModes::StandardModes(QObject *parent, Vehicle *vehicle)
 {
 }
 
-void StandardModes::gotMessage(MAV_RESULT result, const mavlink_message_t &message)
+void StandardModes::gotMessage(MAV_RESULT result, VehicleTypes::RequestMessageResultHandlerFailureCode_t failureCode, const mavlink_message_t &message)
 {
     _requestActive = false;
     if (_wantReset) {
@@ -88,7 +89,7 @@ void StandardModes::gotMessage(MAV_RESULT result, const mavlink_message_t &messa
             requestMode(availableModes.mode_index + 1);
         }
     } else {
-        qCDebug(StandardModesLog) << "Failed to retrieve available modes - REQUEST_MESSAGE:MAV_RESULT" << result;
+        qCWarning(StandardModesLog) << "Failed to retrieve available modes - REQUEST_MESSAGE:MAV_RESULT" << QGCMAVLink::mavResultToString(result) << "failureCode:" << failureCode;
         emit requestCompleted();
     }
 }

--- a/src/Vehicle/StandardModes.h
+++ b/src/Vehicle/StandardModes.h
@@ -3,6 +3,7 @@
 #include "FirmwarePlugin.h"
 #include "MAVLinkEnums.h"
 #include "MAVLinkMessageType.h"
+#include "VehicleTypes.h"
 
 #include <QtCore/QObject>
 #include <QtCore/QString>
@@ -27,7 +28,7 @@ public:
 
     void availableModesMonitorReceived(uint8_t seq);
 
-    void gotMessage(MAV_RESULT result, const mavlink_message_t &message);
+    void gotMessage(MAV_RESULT result, VehicleTypes::RequestMessageResultHandlerFailureCode_t failureCode, const mavlink_message_t &message);
 
 signals:
     void modesUpdated();

--- a/src/Vehicle/Vehicle.cc
+++ b/src/Vehicle/Vehicle.cc
@@ -449,6 +449,12 @@ void Vehicle::_deleteGimbalController()
     if (_gimbalController) {
         // Disconnect all signals to prevent any callbacks during or after deletion
         _gimbalController->disconnect();
+        // The gimbal controller registers itself as the callback context for its GIMBAL_MANAGER_INFORMATION
+        // requestMessage calls. Cancel any still-outstanding request so the coordinator never calls back
+        // into the freed controller.
+        if (_reqMsgCoord) {
+            _reqMsgCoord->cancelRequests(_gimbalController);
+        }
         delete _gimbalController;
         _gimbalController = nullptr;
     }

--- a/test/FactSystem/ParameterManagerTest.cc
+++ b/test/FactSystem/ParameterManagerTest.cc
@@ -14,6 +14,13 @@
 #include "QGCMath.h"
 #include "Vehicle.h"
 
+// Call from tests that deliberately let PARAM_SET / PARAM_REQUEST_READ waits time out.
+void ParameterManagerTest::_ignoreParamResponseTimeouts()
+{
+    ignoreLogMessage("Utilities.QGCStateMachine", QtWarningMsg,
+                     QRegularExpression("Timeout \".*WaitForParamResponseState\""));
+}
+
 void ParameterManagerTest::cleanup()
 {
     // Some tests create MockLink directly (not via _connectMockLink), so we need special handling.
@@ -104,6 +111,7 @@ void ParameterManagerTest::_requestListNoResponse()
 // param_read requests. The packed file is disabled so the stream path is exercised.
 void ParameterManagerTest::_requestListMissingParamFail()
 {
+    _ignoreParamResponseTimeouts();
     QVERIFY2(!_mockLink, "MockLink already connected");
     _mockLink = MockLink::startPX4MockLink(MockConfiguration::OptionNone, MockConfiguration::FailMissingParamOnAllRequests);
     _mockLink->mockLinkFTP()->setParamPckEnabled(false);
@@ -134,6 +142,7 @@ void ParameterManagerTest::_requestListMissingParamFail()
 
 void ParameterManagerTest::_paramWriteNoAckRetry()
 {
+    _ignoreParamResponseTimeouts();
     // BAT1_V_CHARGED requires a vehicle reboot, so writing it pops the reboot
     // app message (debounce is reset per-test by the framework)
     expectAppMessage(QRegularExpression("Reboot vehicle for changes to take effect"));
@@ -144,6 +153,7 @@ void ParameterManagerTest::_paramWriteNoAckRetry()
 
 void ParameterManagerTest::_paramWriteNoAckPermanent()
 {
+    _ignoreParamResponseTimeouts();
     // Expectations verify in FIFO order: reboot message first (fires at local
     // setRawValue), then the write-failed message (fires after retries exhaust)
     expectAppMessage(QRegularExpression("Reboot vehicle for changes to take effect"));
@@ -168,6 +178,7 @@ void ParameterManagerTest::_paramWriteUInt16()
 
 void ParameterManagerTest::_paramReadFirstAttemptNoResponseRetry()
 {
+    _ignoreParamResponseTimeouts();
     QVERIFY2(!_mockLink, "MockLink already connected");
     _connectMockLink();
     QVERIFY(_mockLink);
@@ -192,6 +203,7 @@ void ParameterManagerTest::_paramReadFirstAttemptNoResponseRetry()
 
 void ParameterManagerTest::_paramReadNoResponse()
 {
+    _ignoreParamResponseTimeouts();
     QVERIFY2(!_mockLink, "MockLink already connected");
     _connectMockLink();
     QVERIFY(_mockLink);
@@ -560,6 +572,7 @@ void ParameterManagerTest::_bulkRefreshUnknownNameSkipped()
 // Round 0 fails (no response from MockLink), round 1 succeeds after failure mode is cleared.
 void ParameterManagerTest::_bulkRefreshRetrySucceeds()
 {
+    _ignoreParamResponseTimeouts();
     _connectMockLink();
     QVERIFY(_mockLink);
     QVERIFY(_vehicle);
@@ -593,6 +606,7 @@ void ParameterManagerTest::_bulkRefreshRetrySucceeds()
 // All kMaxRetryRounds+1 rounds fail — BulkRefreshJob gives up without a success signal.
 void ParameterManagerTest::_bulkRefreshAllRetriesExhausted()
 {
+    _ignoreParamResponseTimeouts();
     _connectMockLink();
     QVERIFY(_mockLink);
     QVERIFY(_vehicle);

--- a/test/FactSystem/ParameterManagerTest.h
+++ b/test/FactSystem/ParameterManagerTest.h
@@ -30,6 +30,7 @@ private slots:
     void _bulkRefreshAllRetriesExhausted();
 
 private:
+    void _ignoreParamResponseTimeouts();
     void _noFailureWorker(MockConfiguration::FailureMode_t failureMode);
     void _setParamWithFailureMode(MockLink::ParamSetFailureMode_t failureMode, bool expectSuccess,
                                   const QString &paramName, MAV_AUTOPILOT autopilot);

--- a/test/UnitTestFramework/BaseClasses/StateMachineTest.cc
+++ b/test/UnitTestFramework/BaseClasses/StateMachineTest.cc
@@ -1,7 +1,14 @@
 #include "StateMachineTest.h"
 
+#include <QtCore/QRegularExpression>
 #include <QtStateMachine/QStateMachine>
 #include <QtTest/QSignalSpy>
+
+void StateMachineTest::ignoreTimeoutWarnings()
+{
+    ignoreLogMessage("Utilities.QGCStateMachine", QtWarningMsg, QRegularExpression(QStringLiteral("^Timeout \"")));
+    ignoreLogMessage("Utilities.StateMachine.RetryTransition", QtWarningMsg, QRegularExpression(QStringLiteral("timeout, retry")));
+}
 
 bool StateMachineTest::startAndWaitForFinished(QStateMachine* machine, int timeoutMs)
 {

--- a/test/UnitTestFramework/BaseClasses/StateMachineTest.h
+++ b/test/UnitTestFramework/BaseClasses/StateMachineTest.h
@@ -50,6 +50,9 @@ public:
     }
 
 protected:
+    /// Call from tests that deliberately drive a wait state to timeout/retry.
+    void ignoreTimeoutWarnings();
+
     /// Run a single state to completion using the default advance() signal.
     /// Creates a QFinalState, wires state's advance→final, sets initial state, starts, waits.
     /// @param state The state to run (must already be parented to @a machine)

--- a/test/Utilities/StateMachine/QGCStateMachineTest.cc
+++ b/test/Utilities/StateMachine/QGCStateMachineTest.cc
@@ -222,6 +222,7 @@ void QGCStateMachineTest::_testTimeoutTransitionBuilder()
 
 void QGCStateMachineTest::_testRetryTransitionBuilder()
 {
+    ignoreTimeoutWarnings();
     QGCStateMachine machine(QStringLiteral("RetryBuilderTest"), nullptr);
     int retryCount = 0;
 

--- a/test/Utilities/StateMachine/states/AsyncFunctionStateTest.cc
+++ b/test/Utilities/StateMachine/states/AsyncFunctionStateTest.cc
@@ -32,6 +32,7 @@ void AsyncFunctionStateTest::_testAsyncFunctionState()
 
 void AsyncFunctionStateTest::_testAsyncFunctionStateTimeout()
 {
+    ignoreTimeoutWarnings();
     QStateMachine machine;
     bool timeoutReached = false;
     const int timeoutMs = 100;

--- a/test/Utilities/StateMachine/states/RetryableRequestMessageStateTest.cc
+++ b/test/Utilities/StateMachine/states/RetryableRequestMessageStateTest.cc
@@ -52,6 +52,8 @@ void RetryableRequestMessageStateTest::_testRetryOnFailure()
     // FailRequestMessageCommandAcceptedMsgNotSent triggers duplicate-request warnings and retries exhausted.
     ignoreLogMessage("Vehicle.RequestMessageCoordinator", QtWarningMsg,
                      QRegularExpression("failing exact duplicate compId:msgId"));
+    ignoreLogMessage("Utilities.QGCStateMachine", QtWarningMsg,
+                     QRegularExpression("^Timeout \"TestMachine:RequestDebug\""));
     ignoreLogMessage("Utilities.StateMachine.RetryableRequestMessageState", QtWarningMsg,
                      QRegularExpression("Max retries exhausted"));
     _connectMockLinkNoInitialConnectSequence();
@@ -103,6 +105,8 @@ void RetryableRequestMessageStateTest::_testMaxRetriesExhausted()
     // FailRequestMessageCommandNoResponse triggers duplicate-request warnings and retries exhausted.
     ignoreLogMessage("Vehicle.RequestMessageCoordinator", QtWarningMsg,
                      QRegularExpression("failing exact duplicate compId:msgId"));
+    ignoreLogMessage("Utilities.QGCStateMachine", QtWarningMsg,
+                     QRegularExpression("^Timeout \"TestMachine:RequestDebug\""));
     ignoreLogMessage("Utilities.StateMachine.RetryableRequestMessageState", QtWarningMsg,
                      QRegularExpression("Max retries exhausted"));
     _connectMockLinkNoInitialConnectSequence();
@@ -149,6 +153,8 @@ void RetryableRequestMessageStateTest::_testFailOnMaxRetries()
     // Timeout + no-response mode causes MavCommandQueue and state machine to emit expected warnings.
     ignoreLogMessage("Utilities.StateMachine.RetryableRequestMessageState", QtWarningMsg,
                      QRegularExpression("Max retries exhausted"));
+    ignoreLogMessage("Utilities.QGCStateMachine", QtWarningMsg,
+                     QRegularExpression("^Timeout \"TestMachine:RequestDebug\""));
     ignoreLogMessage("Vehicle.MavCommandQueue", QtWarningMsg,
                      QRegularExpression("Giving up sending command after max retries:"));
     _connectMockLinkNoInitialConnectSequence();

--- a/test/Utilities/StateMachine/states/SkippableAsyncStateTest.cc
+++ b/test/Utilities/StateMachine/states/SkippableAsyncStateTest.cc
@@ -87,6 +87,7 @@ void SkippableAsyncStateTest::_testSkippableAsyncStateSkip()
 
 void SkippableAsyncStateTest::_testSkippableAsyncStateTimeout()
 {
+    ignoreTimeoutWarnings();
     QStateMachine machine;
     bool timeoutReached = false;
     const int timeoutMs = 100;

--- a/test/Utilities/StateMachine/states/WaitForSignalStateTest.cc
+++ b/test/Utilities/StateMachine/states/WaitForSignalStateTest.cc
@@ -36,6 +36,7 @@ void WaitForSignalStateTest::_testWaitForSignalState()
 
 void WaitForSignalStateTest::_testWaitForSignalStateTimeout()
 {
+    ignoreTimeoutWarnings();
     QStateMachine machine;
     QObject signalSource;
     bool timeoutReached = false;
@@ -108,6 +109,7 @@ void WaitForSignalStateTest::_testCompletedSignal()
 
 void WaitForSignalStateTest::_testTimedOutSignal()
 {
+    ignoreTimeoutWarnings();
     // Test that timedOut() is emitted alongside timeout() for wait states
     QStateMachine machine;
     QObject signalSource;

--- a/test/Utilities/StateMachine/states/WaitStateBaseTest.cc
+++ b/test/Utilities/StateMachine/states/WaitStateBaseTest.cc
@@ -26,6 +26,7 @@ protected:
 
 void WaitStateBaseTest::_testTimeoutEmission()
 {
+    ignoreTimeoutWarnings();
     QStateMachine machine;
     const int timeoutMs = 50;
 

--- a/test/Utilities/StateMachine/transitions/RetryTransitionTest.cc
+++ b/test/Utilities/StateMachine/transitions/RetryTransitionTest.cc
@@ -18,6 +18,7 @@ protected:
 
 void RetryTransitionTest::_testRetryActionCalled()
 {
+    ignoreTimeoutWarnings();
     QStateMachine machine;
     int retryCount = 0;
     bool targetReached = false;
@@ -58,6 +59,7 @@ void RetryTransitionTest::_testRetryActionCalled()
 
 void RetryTransitionTest::_testTransitionAfterMaxRetries()
 {
+    ignoreTimeoutWarnings();
     QStateMachine machine;
     int retryCount = 0;
     bool targetReached = false;
@@ -104,6 +106,7 @@ void RetryTransitionTest::_testTransitionAfterMaxRetries()
 
 void RetryTransitionTest::_testRetryCountResets()
 {
+    ignoreTimeoutWarnings();
     // Test that retry count resets after transition is taken
     QStateMachine machine;
     int retryCount = 0;
@@ -138,6 +141,7 @@ void RetryTransitionTest::_testRetryCountResets()
 
 void RetryTransitionTest::_testMultipleRetries()
 {
+    ignoreTimeoutWarnings();
     QStateMachine machine;
     int retryCount = 0;
     bool targetReached = false;
@@ -174,6 +178,7 @@ void RetryTransitionTest::_testMultipleRetries()
 
 void RetryTransitionTest::_testZeroRetries()
 {
+    ignoreTimeoutWarnings();
     QStateMachine machine;
     int retryCount = 0;
     bool targetReached = false;
@@ -210,6 +215,7 @@ void RetryTransitionTest::_testZeroRetries()
 
 void RetryTransitionTest::_testWaitRearmedBeforeRetryAction()
 {
+    ignoreTimeoutWarnings();
     QStateMachine machine;
     bool waitWasRearmedBeforeRetryAction = false;
 

--- a/test/Vehicle/CMakeLists.txt
+++ b/test/Vehicle/CMakeLists.txt
@@ -41,6 +41,8 @@ target_sources(${CMAKE_PROJECT_NAME}
         SendMavCommandWithSignallingTest.h
         SetEstimatorOriginTest.cc
         SetEstimatorOriginTest.h
+        StandardModesTest.cc
+        StandardModesTest.h
         TrajectoryPointsTest.cc
         TrajectoryPointsTest.h
         VehicleDistanceSensorFactGroupTest.cc
@@ -75,6 +77,7 @@ add_qgc_test(RequestMessageTest LABELS Integration Vehicle TIMEOUT ${QGC_TEST_TI
 add_qgc_test(SendMavCommandWithHandlerTest LABELS Integration Vehicle)
 add_qgc_test(SendMavCommandWithSignallingTest LABELS Integration Vehicle)
 add_qgc_test(SetEstimatorOriginTest LABELS Integration Vehicle)
+add_qgc_test(StandardModesTest LABELS Integration Vehicle)
 add_qgc_test(TrajectoryPointsTest LABELS Unit Vehicle)
 add_qgc_test(VehicleDistanceSensorFactGroupTest LABELS Integration Vehicle)
 add_qgc_test(VehicleLinkManagerTest LABELS Integration Vehicle SERIAL)

--- a/test/Vehicle/InitialConnectTest.cc
+++ b/test/Vehicle/InitialConnectTest.cc
@@ -5,7 +5,6 @@
 #include <QtTest/QSignalSpy>
 
 #include "GeoFenceManager.h"
-#include "InitialConnectStateMachine.h"
 #include "LinkManager.h"
 #include "MAVLinkProtocol.h"
 #include "MultiVehicleManager.h"
@@ -26,24 +25,6 @@
 #include <QtCore/QRegularExpression>
 #include <QtCore/qscopeguard.h>
 #include <QtTest/QTest>
-
-void InitialConnectTest::init()
-{
-    VehicleTestManualConnect::init();
-    // Many initial-connect tests exercise failure or timeout paths that produce these expected warnings.
-    ignoreLogMessage("ComponentInformation.RequestMetaDataTypeStateMachine", QtWarningMsg,
-                     QRegularExpression("failed to load metadata"));
-    ignoreLogMessage("Utilities.StateMachine.RetryableRequestMessageState", QtWarningMsg,
-                     QRegularExpression("Max retries exhausted"));
-    ignoreLogMessage("Utilities.StateMachine.RetryTransition", QtWarningMsg,
-                     QRegularExpression("timeout after .* retries, advancing"));
-    // Timeout tests for Mission/GeoFence/Rally states cause transfer-failed showAppMessage logs.
-    ignoreLogMessage("API.QGCApplication.AppMessage", QtDebugMsg,
-                     QRegularExpression("transfer failed"));
-    // StandardModes timeout exhausts MAV_CMD_REQUEST_MESSAGE retries in MavCommandQueue.
-    ignoreLogMessage("Vehicle.MavCommandQueue", QtWarningMsg,
-                     QRegularExpression("Giving up sending command after max retries:"));
-}
 
 void InitialConnectTest::_performTestCases_data()
 {
@@ -75,6 +56,11 @@ void InitialConnectTest::_performTestCases()
     QFETCH(int, failureMode);
     QFETCH(QString, failureModeStr);
     TEST_DEBUG(QStringLiteral("Testing case failure mode: %1").arg(failureModeStr));
+    if (failureMode != static_cast<int>(MockConfiguration::FailNone)) {
+        // AUTOPILOT_VERSION failure rows exhaust request-message retries.
+        ignoreLogMessage("Utilities.StateMachine.RetryableRequestMessageState", QtWarningMsg,
+                         QRegularExpression("Max retries exhausted"));
+    }
     _connectMockLink(MAV_AUTOPILOT_PX4, static_cast<MockConfiguration::FailureMode_t>(failureMode));
     _disconnectMockLink();
 }
@@ -149,6 +135,9 @@ void InitialConnectTest::_progressTracking()
 
 void InitialConnectTest::_highLatencySkipsPlanRequests()
 {
+    // High-latency links cannot fetch component metadata.
+    ignoreLogMessage("ComponentInformation.RequestMetaDataTypeStateMachine", QtWarningMsg,
+                     QRegularExpression("failed to load metadata"));
     LinkManager::instance()->setConnectionsAllowed();
 
     auto* mvm = MultiVehicleManager::instance();
@@ -183,6 +172,11 @@ void InitialConnectTest::_highLatencySkipsPlanRequests()
 
 void InitialConnectTest::_genericAutopilotVersionFailureSkipsUnsupportedPlanTypes()
 {
+    // AUTOPILOT_VERSION failure exhausts request-message retries; generic firmware has no metadata source.
+    ignoreLogMessage("Utilities.StateMachine.RetryableRequestMessageState", QtWarningMsg,
+                     QRegularExpression("Max retries exhausted"));
+    ignoreLogMessage("ComponentInformation.RequestMetaDataTypeStateMachine", QtWarningMsg,
+                     QRegularExpression("failed to load metadata"));
     _connectMockLink(MAV_AUTOPILOT_GENERIC, MockConfiguration::FailInitialConnectRequestMessageAutopilotVersionFailure);
 
     QVERIFY(_vehicle);
@@ -216,8 +210,11 @@ void InitialConnectTest::_multipleReconnects()
     }
 }
 
-void InitialConnectTest::_rallyTimeoutPathDoesNotLeakCompletionHandler()
+void InitialConnectTest::_rallyFailurePathDoesNotLeakCompletionHandler()
 {
+    // Injected rally read failure pops a transfer-failed app message.
+    ignoreLogMessage("API.QGCApplication.AppMessage", QtDebugMsg,
+                     QRegularExpression("Rally Point transfer failed"));
     LinkManager::instance()->setConnectionsAllowed();
 
     auto* mvm = MultiVehicleManager::instance();
@@ -239,102 +236,113 @@ void InitialConnectTest::_rallyTimeoutPathDoesNotLeakCompletionHandler()
 
     auto* geoFenceManager = _vehicle->findChild<GeoFenceManager*>();
     auto* rallyPointManager = _vehicle->findChild<RallyPointManager*>();
-    auto* initialConnectStateMachine = _vehicle->findChild<InitialConnectStateMachine*>();
     QVERIFY(geoFenceManager);
     QVERIFY(rallyPointManager);
-    QVERIFY(initialConnectStateMachine);
 
-    connect(geoFenceManager, &GeoFenceManager::loadComplete, this, [this, initialConnectStateMachine]() {
+    connect(geoFenceManager, &GeoFenceManager::loadComplete, this, [this]() {
         _mockLink->setMissionItemFailureMode(
             MockLinkMissionItemHandler::FailReadRequestListNoResponse, MAV_MISSION_ACCEPTED);
-        initialConnectStateMachine->setTimeoutOverride(QStringLiteral("RequestRallyPoints"), 100);
     });
 
+    // Rally read fails internally (PlanManager exhausts retries) but still signals
+    // loadComplete, so initial connect completes with the plan request marked complete.
     QSignalSpy initialConnectCompleteSpy{_vehicle, &Vehicle::initialConnectComplete};
     QVERIFY(initialConnectCompleteSpy.wait(TestTimeout::longMs()) || _vehicle->isInitialConnectComplete());
-    QVERIFY(!_vehicle->initialPlanRequestComplete());
+    QVERIFY(_vehicle->initialPlanRequestComplete());
 
     _mockLink->setMissionItemFailureMode(MockLinkMissionItemHandler::FailNone, MAV_MISSION_ACCEPTED);
 
+    // A leaked initial-connect completion handler would re-fire on this manual reload.
     QSignalSpy planCompleteSpy{_vehicle, &Vehicle::initialPlanRequestCompleteChanged};
     QSignalSpy rallyLoadCompleteSpy{rallyPointManager, &RallyPointManager::loadComplete};
 
     rallyPointManager->loadFromVehicle();
     QVERIFY(rallyLoadCompleteSpy.wait(TestTimeout::longMs()));
-    QCOMPARE(planCompleteSpy.count(), 1);
+    QCOMPARE(planCompleteSpy.count(), 0);
 
     _disconnectMockLink();
 }
 
-void InitialConnectTest::_stateTimeoutFallsThrough_data()
+void InitialConnectTest::_subsystemFailureFallsThrough_data()
 {
     QTest::addColumn<QList<uint32_t>>("blockedMessageIds");
     QTest::addColumn<int>("configFailureMode");
     QTest::addColumn<bool>("blockMissionProtocolImmediately");
     QTest::addColumn<bool>("blockMissionProtocolAfterMissionLoad");
-    QTest::addColumn<QStringList>("timeoutOverrideStates");
     QTest::addColumn<bool>("expectParametersReady");
-    QTest::addColumn<bool>("expectPlanRequestComplete");
 
-    // Timeout matrix:
-    // +----------------+-------------------+------------------+---------+--------+
-    // | State          | Failure Injection | Timeout States   | Params? | Plans? |
-    // +----------------+-------------------+------------------+---------+--------+
-    // | StandardModes  | Block AVAIL_MODES | StdModes         | Yes     | Yes    |
-    // | CompInfo       | Block COMP_META   | CompInfo         | Yes     | Yes    |
-    // | Parameters     | No param response | Parameters       | No      | Yes    |
-    // | Mission        | Block mission req | Msn+Fence+Rally  | Yes     | No     |
-    // | GeoFence       | Block after msn   | Fence+Rally      | Yes     | No     |
-    // +----------------+-------------------+------------------+---------+--------+
+    // Each state's underlying subsystem must handle its own timeouts/retries and
+    // always signal completion, so initial connect finishes without outer timeouts.
+    // +----------------+-------------------+---------+
+    // | State          | Failure Injection | Params? |
+    // +----------------+-------------------+---------+
+    // | StandardModes  | Block AVAIL_MODES | Yes     |
+    // | CompInfo       | Block COMP_META   | Yes     |
+    // | Parameters     | No param response | No      |
+    // | Mission        | Block mission req | Yes     |
+    // | GeoFence       | Block after msn   | Yes     |
+    // +----------------+-------------------+---------+
 
     QTest::addRow("StandardModes")
         << QList<uint32_t>{MAVLINK_MSG_ID_AVAILABLE_MODES}
         << static_cast<int>(MockConfiguration::FailNone)
         << false << false
-        << QStringList{QStringLiteral("RequestStandardModes")}
-        << true << true;
+        << true;
 
     QTest::addRow("CompInfo")
         << QList<uint32_t>{MAVLINK_MSG_ID_COMPONENT_METADATA}
         << static_cast<int>(MockConfiguration::FailNone)
         << false << false
-        << QStringList{QStringLiteral("RequestCompInfo")}
-        << true << true;
+        << true;
 
     QTest::addRow("Parameters")
         << QList<uint32_t>{}
         << static_cast<int>(MockConfiguration::FailParamNoResponseToRequestList)
         << false << false
-        << QStringList{QStringLiteral("RequestParameters")}
-        << false << true;
+        << false;
 
     QTest::addRow("Mission")
         << QList<uint32_t>{}
         << static_cast<int>(MockConfiguration::FailNone)
         << true << false
-        << QStringList{QStringLiteral("RequestMission"),
-                       QStringLiteral("RequestGeoFence"),
-                       QStringLiteral("RequestRallyPoints")}
-        << true << false;
+        << true;
 
     QTest::addRow("GeoFence")
         << QList<uint32_t>{}
         << static_cast<int>(MockConfiguration::FailNone)
         << false << true
-        << QStringList{QStringLiteral("RequestGeoFence"),
-                       QStringLiteral("RequestRallyPoints")}
-        << true << false;
+        << true;
 }
 
-void InitialConnectTest::_stateTimeoutFallsThrough()
+void InitialConnectTest::_subsystemFailureFallsThrough()
 {
     QFETCH(QList<uint32_t>, blockedMessageIds);
     QFETCH(int, configFailureMode);
     QFETCH(bool, blockMissionProtocolImmediately);
     QFETCH(bool, blockMissionProtocolAfterMissionLoad);
-    QFETCH(QStringList, timeoutOverrideStates);
     QFETCH(bool, expectParametersReady);
-    QFETCH(bool, expectPlanRequestComplete);
+
+    // Per-row expected noise from the injected subsystem failure.
+    if (blockedMessageIds.contains(MAVLINK_MSG_ID_AVAILABLE_MODES) || blockedMessageIds.contains(MAVLINK_MSG_ID_COMPONENT_METADATA)) {
+        ignoreLogMessage("Vehicle.MavCommandQueue", QtWarningMsg,
+                         QRegularExpression("Giving up sending command after max retries:"));
+    }
+    if (blockedMessageIds.contains(MAVLINK_MSG_ID_AVAILABLE_MODES)) {
+        ignoreLogMessage("Vehicle.StandardModes", QtWarningMsg,
+                         QRegularExpression("Failed to retrieve available modes"));
+    }
+    if (blockedMessageIds.contains(MAVLINK_MSG_ID_COMPONENT_METADATA)) {
+        ignoreLogMessage("ComponentInformation.RequestMetaDataTypeStateMachine", QtWarningMsg,
+                         QRegularExpression("failed to load metadata"));
+    }
+    if (configFailureMode == static_cast<int>(MockConfiguration::FailParamNoResponseToRequestList)) {
+        ignoreLogMessage("API.QGCApplication.AppMessage", QtDebugMsg,
+                         QRegularExpression("did not respond to request for parameters"));
+    }
+    if (blockMissionProtocolImmediately || blockMissionProtocolAfterMissionLoad) {
+        ignoreLogMessage("API.QGCApplication.AppMessage", QtDebugMsg,
+                         QRegularExpression("transfer failed"));
+    }
 
     LinkManager::instance()->setConnectionsAllowed();
 
@@ -371,13 +379,6 @@ void InitialConnectTest::_stateTimeoutFallsThrough()
     _vehicle = mvm->activeVehicle();
     QVERIFY(_vehicle);
 
-    auto* initialConnectStateMachine = _vehicle->findChild<InitialConnectStateMachine*>();
-    QVERIFY(initialConnectStateMachine);
-
-    for (const QString& stateName : timeoutOverrideStates) {
-        initialConnectStateMachine->setTimeoutOverride(stateName, 100);
-    }
-
     if (blockMissionProtocolAfterMissionLoad) {
         auto* missionManager = _vehicle->findChild<MissionManager*>();
         QVERIFY(missionManager);
@@ -392,7 +393,7 @@ void InitialConnectTest::_stateTimeoutFallsThrough()
         QVERIFY(initialConnectCompleteSpy.wait(TestTimeout::longMs()));
     }
     QCOMPARE(_vehicle->parameterManager()->parametersReady(), expectParametersReady);
-    QCOMPARE(_vehicle->initialPlanRequestComplete(), expectPlanRequestComplete);
+    QVERIFY(_vehicle->initialPlanRequestComplete());
 
     _disconnectMockLink();
 }
@@ -452,6 +453,12 @@ void InitialConnectTest::_stateRunMatrix()
 
     // Effective skip path in InitialConnectStateMachine is (isHighLatency || isLogReplay)
     const bool skipForLinkType = highLatency || logReplay;
+
+    if (skipForLinkType) {
+        // High-latency/log-replay links cannot fetch component metadata.
+        ignoreLogMessage("ComponentInformation.RequestMetaDataTypeStateMachine", QtWarningMsg,
+                         QRegularExpression("failed to load metadata"));
+    }
 
     // Enable noInitialDownloadWhenFlying setting for flying rows
     auto* noInitialDownloadWhenFlying = SettingsManager::instance()->mavlinkSettings()->noInitialDownloadWhenFlying();

--- a/test/Vehicle/InitialConnectTest.h
+++ b/test/Vehicle/InitialConnectTest.h
@@ -7,7 +7,6 @@ class InitialConnectTest : public VehicleTestManualConnect
     Q_OBJECT
 
 private slots:
-    void init() override;
     void _performTestCases_data();
     void _performTestCases();
     void _boardVendorProductId();
@@ -15,9 +14,9 @@ private slots:
     void _highLatencySkipsPlanRequests();
     void _genericAutopilotVersionFailureSkipsUnsupportedPlanTypes();
     void _multipleReconnects();
-    void _rallyTimeoutPathDoesNotLeakCompletionHandler();
-    void _stateTimeoutFallsThrough_data();
-    void _stateTimeoutFallsThrough();
+    void _rallyFailurePathDoesNotLeakCompletionHandler();
+    void _subsystemFailureFallsThrough_data();
+    void _subsystemFailureFallsThrough();
     void _stateRunMatrix_data();
     void _stateRunMatrix();
 };

--- a/test/Vehicle/StandardModesTest.cc
+++ b/test/Vehicle/StandardModesTest.cc
@@ -1,0 +1,23 @@
+#include "StandardModesTest.h"
+
+#include "QGCMAVLink.h"
+#include "Vehicle.h"
+
+void StandardModesTest::_monitorSequenceBumpTriggersRequery()
+{
+    // Initial connect has completed, so the initial AVAILABLE_MODES enumeration has settled.
+    // Assert on the re-query itself rather than on flightModes(), which a FirmwarePlugin can
+    // filter (e.g. custom builds hide modes that cannot be set by the user).
+    const int baselineRequests = _mockLink->receivedRequestMessageCount(MAVLINK_MSG_ID_AVAILABLE_MODES);
+    QVERIFY(baselineRequests > 0);
+
+    // Bumping the sequence number changes the 1Hz AVAILABLE_MODES_MONITOR, which must cause
+    // StandardModes to re-query the mode list.
+    _mockLink->bumpAvailableModesMonitorSequence();
+
+    QTRY_VERIFY_WITH_TIMEOUT(
+        _mockLink->receivedRequestMessageCount(MAVLINK_MSG_ID_AVAILABLE_MODES) > baselineRequests,
+        TestTimeout::longMs());
+}
+
+UT_REGISTER_TEST(StandardModesTest, TestLabel::Integration, TestLabel::Vehicle)

--- a/test/Vehicle/StandardModesTest.h
+++ b/test/Vehicle/StandardModesTest.h
@@ -1,0 +1,14 @@
+#pragma once
+
+#include "BaseClasses/VehicleTest.h"
+
+class StandardModesTest : public VehicleTest
+{
+    Q_OBJECT
+
+public:
+    explicit StandardModesTest(QObject* parent = nullptr) : VehicleTest(parent) {}
+
+private slots:
+    void _monitorSequenceBumpTriggersRequery();
+};

--- a/test/Vehicle/VehicleLinkManagerTest.cc
+++ b/test/Vehicle/VehicleLinkManagerTest.cc
@@ -67,6 +67,9 @@ void VehicleLinkManagerTest::_simpleCommLossTest()
     // Comm loss with pending vehicle commands causes MavCommandQueue to give up.
     ignoreLogMessage("Vehicle.MavCommandQueue", QtWarningMsg,
                      QRegularExpression("Giving up sending command after max retries:"));
+    // Losing comms while the AVAILABLE_MODES enumeration is still in flight fails the request.
+    ignoreLogMessage("Vehicle.StandardModes", QtWarningMsg,
+                     QRegularExpression("Failed to retrieve available modes"));
     SharedLinkConfigurationPtr mockConfig;
     SharedLinkInterfacePtr mockLink;
     _startMockLink(1, false /*highLatency*/, true /*incrementVehicleId*/, mockConfig, mockLink);
@@ -107,6 +110,9 @@ void VehicleLinkManagerTest::_simpleCommLossTest()
 
 void VehicleLinkManagerTest::_multiLinkSingleVehicleTest()
 {
+    // Losing comms while the AVAILABLE_MODES enumeration is still in flight fails the request.
+    ignoreLogMessage("Vehicle.StandardModes", QtWarningMsg,
+                     QRegularExpression("Failed to retrieve available modes"));
     SharedLinkConfigurationPtr mockConfig1;
     SharedLinkInterfacePtr mockLink1;
     SharedLinkConfigurationPtr mockConfig2;
@@ -216,6 +222,9 @@ void VehicleLinkManagerTest::_multiLinkTotalCommLossRecoveryTest()
     // Primary link switchover produces a showAppMessage debug log.
     ignoreLogMessage("API.QGCApplication.AppMessage", QtDebugMsg,
                      QRegularExpression("Switching communication to"));
+    // Losing comms while the AVAILABLE_MODES enumeration is still in flight fails the request.
+    ignoreLogMessage("Vehicle.StandardModes", QtWarningMsg,
+                     QRegularExpression("Failed to retrieve available modes"));
 
     SharedLinkConfigurationPtr mockConfig1;
     SharedLinkInterfacePtr mockLink1;
@@ -301,6 +310,10 @@ void VehicleLinkManagerTest::_highLatencyLinkTest()
     // Giving up on the COMPONENT_METADATA request leaves the metadata load unable to complete.
     ignoreLogMessage("ComponentInformation.RequestMetaDataTypeStateMachine", QtWarningMsg,
                      QRegularExpression("failed to load metadata \\(primary and fallback\\)"));
+    // The slow high-latency link can still have the AVAILABLE_MODES request in flight when the
+    // test forces comm loss, which fails the request.
+    ignoreLogMessage("Vehicle.StandardModes", QtWarningMsg,
+                     QRegularExpression("Failed to retrieve available modes"));
     SharedLinkConfigurationPtr mockConfig1;
     SharedLinkInterfacePtr mockLink1;
     SharedLinkConfigurationPtr mockConfig2;


### PR DESCRIPTION
## Problem

Users reported sporadic initial-connect failures over slow links (e.g. SiK radios). The cause is the fixed outer timeouts on each `InitialConnectStateMachine` state (params 60s, comp info 30s, mission 30s, etc.). On slow links these fire even though the transfer is progressing normally. The timeout retry path then force-advanced the machine, leaving the vehicle half-initialized (missing params, modes, or plan).

## Fix

Remove all outer timeouts and the retry-transition wiring from `InitialConnectStateMachine`. Every underlying subsystem already handles its own per-step timeouts/retries and always signals completion:

- **Parameters** — `ParameterManager` retries per-param and signals `parametersReadyChanged`. A new terminal `initialParametersRequestFailed` signal covers the case where the vehicle never answers PARAM_REQUEST_LIST, so the state advances without parameters instead of relying on an outer timeout.
- **Mission/GeoFence/Rally** — `PlanManager` has per-message timeouts/retries.
- **Component information** — `ComponentInformationManager`'s nested state machines have per-state timeouts on every step. A new `requestAllComplete` signal replaces the callback plumbing for completion.
- **Standard modes** — the protocol handles timeouts internally and always signals `requestCompleted`.
- **AUTOPILOT_VERSION** — the one request with no lower-level protocol timeout keeps its per-attempt timeout/retry inside `RetryableRequestMessageState`.

## Additional fix: GimbalController request collision

`GimbalController` sent `MAV_CMD_REQUEST_MESSAGE` (GIMBAL_MANAGER_INFORMATION) raw via `sendMavCommand`. The command queue's duplicate-command check ignores param1 (the requested message id), so this flakily collided with `RequestMessageCoordinator` users targeting the same component (e.g. the AVAILABLE_MODES fetch during initial connect), failing them as duplicates. Now routed through `Vehicle::requestMessage()` with an in-flight guard so it serializes with other request-message users.

## Supporting changes

- State machine wait timeouts and retries now log at warning level (visible without logging filters) including the elapsed timeout value, so genuine stalls are diagnosable in the field.
- `StandardModes` failure logs the `MAV_RESULT` name and failure code and is promoted to warning.
- `ParameterManager` logging cleanup (cache write log, clearer timeout/cache messages, per-param remap log moved to verbose).
- `QGCFileDownload` logs URLs with user info/query stripped.
- MockLink: AVAILABLE_MODES now served on high-latency links; the automatic modes-monitor sequence bump is replaced with an explicit test API (`bumpAvailableModesMonitorSequence`) exercised by a new `StandardModesTest`.
- Tests: fixture-wide log ignores replaced with per-test scoped ignores documenting the expected cause; obsolete outer-timeout tests reworked to verify subsystem failures fall through to initial-connect completion.
