### PR TITLE
ci(github): add stale issue workflow (dry-run)

### DIFF
--- a/.github/ci-overview.md
+++ b/.github/ci-overview.md
@@ -57,6 +57,7 @@ via composite actions and reusable workflows. Python helpers in `scripts/` are i
 | `crowdin.yml`, `lupdate.yml` | Translation workflows |
 | `dependency-review.yml` | Dependency security review |
 | `scorecard.yml` | OpenSSF Scorecard |
+| `stale.yml` | Nightly stale-issue labeling and closing (feature requests get their own close message) |
 | `flatpak.yml` | Flatpak builds |
 | `mirror-gstreamer.yml` | Mirror upstream GStreamer releases to the QGC S3 bucket |
 | `px4-metadata.yml` | PX4 metadata sync |

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -1,0 +1,93 @@
+name: Stale Issues
+
+on:
+  schedule:
+    - cron: '30 1 * * *'
+  workflow_dispatch:
+
+concurrency:
+  group: ${{ github.workflow }}
+  cancel-in-progress: false
+
+permissions: {}
+
+jobs:
+  stale-issues:
+    name: Stale Issues (non-feature)
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    permissions:
+      issues: write
+      # Required to reset the Actions cache entry that persists resume state between capped runs.
+      actions: write
+
+    steps:
+      - name: Harden Runner
+        uses: step-security/harden-runner@v2
+        with:
+          egress-policy: audit
+
+      - name: Mark and close stale issues
+        uses: actions/stale@v11
+        with:
+          # Remove debug-only once the dry-run output has been reviewed.
+          debug-only: true
+          days-before-issue-stale: 90
+          days-before-issue-close: 30
+          days-before-pr-stale: -1
+          days-before-pr-close: -1
+          remove-pr-stale-when-updated: false
+          stale-issue-label: stale
+          exempt-issue-labels: 'Priority: Critical,Feature Request'
+          exempt-all-issue-milestones: true
+          remove-issue-stale-when-updated: true
+          ascending: true
+          # Dry run: state is not persisted in debug mode, so the cap must cover the whole backlog.
+          # Lower to 400 when going live: two jobs share the 1000 req/hr GITHUB_TOKEN budget.
+          operations-per-run: 1500
+          # Empty message labels silently to avoid a notification flood on the initial backlog sweep.
+          stale-issue-message: ''
+          close-issue-message: >
+            This issue was automatically closed after 120 days of inactivity. It most likely refers
+            to a version of QGroundControl that is no longer current. If it is still relevant on the
+            latest Stable or Daily build, please reopen or file a new issue including the QGC version,
+            firmware (PX4/ArduPilot) and version, platform, and steps to reproduce.
+
+  stale-features:
+    name: Stale Feature Requests
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    needs: stale-issues
+    permissions:
+      issues: write
+      actions: write
+
+    steps:
+      - name: Harden Runner
+        uses: step-security/harden-runner@v2
+        with:
+          egress-policy: audit
+
+      - name: Mark and close stale feature requests
+        uses: actions/stale@v11
+        with:
+          # Remove debug-only once the dry-run output has been reviewed.
+          debug-only: true
+          days-before-issue-stale: 90
+          days-before-issue-close: 30
+          days-before-pr-stale: -1
+          days-before-pr-close: -1
+          remove-pr-stale-when-updated: false
+          stale-issue-label: stale
+          any-of-issue-labels: 'Feature Request'
+          exempt-issue-labels: 'Priority: Critical'
+          exempt-all-issue-milestones: true
+          remove-issue-stale-when-updated: true
+          ascending: true
+          # Lower to 400 when going live (see stale-issues).
+          operations-per-run: 1500
+          # Empty message labels silently to avoid a notification flood on the initial backlog sweep.
+          stale-issue-message: ''
+          close-issue-message: >
+            This feature request was automatically closed after 120 days of inactivity. If there is
+            still interest, please reopen or start a GitHub Discussion so it can be reconsidered.


### PR DESCRIPTION
## Summary

Adds a nightly `actions/stale` workflow to work down the open issue backlog (~976 open, ~630 untouched for over a year, ~540 filed more than 5 years ago). Modeled on PX4-Autopilot's `stale.yml`.

## Behavior

- Issues with no activity for **90 days** get the `stale` label (silently — no comment, to avoid a notification flood on the initial sweep).
- Issues still inactive **30 days after** being labeled are closed with a canned message.
- Any comment or edit removes the `stale` label.
- Two jobs so the close message fits the issue type:
  - **Non-feature issues** — asks the reporter to retest on the latest Stable/Daily and reopen or file a new issue with version/firmware/platform/repro.
  - **Feature Request** — asks to reopen or start a Discussion if there is still interest.
- **Exempt:** any issue with a milestone, `Priority: Critical`.
- **Pull requests are not touched.**
- `operations-per-run: 400` per job keeps both jobs under the `GITHUB_TOKEN` 1000 req/hr cap; the initial sweep spreads over a few nights.

## Rollout

This PR ships with `debug-only: true`, so the workflow only **logs** what it would label/close. Plan:

1. Merge, trigger via `workflow_dispatch`, review the log to confirm counts and that exemptions are honored.
2. Follow-up PR removes `debug-only` to go live. First nightly run labels; closes begin 30 days later.

Note: 68 open issues already carry a manually applied `stale` label. Once live, those that have not been updated since labeling will be closed on the first run (no additional grace period).
