### PR TITLE
fix(FTPManager): fall back to non-burst read when a burst cannot compete

### DIFF
--- a/src/Comms/MockLink/MockLinkFTP.cc
+++ b/src/Comms/MockLink/MockLinkFTP.cc
@@ -330,9 +330,16 @@ void MockLinkFTP::_burstReadCommand(uint8_t senderSystemId, uint8_t senderCompon
 
     constexpr int burstMax = 10;
     int burstCount = 1;
+    int packetsSent = 0;
     uint32_t burstOffset = request->hdr.offset;
 
     while ((burstOffset < _currentFile.size()) && (burstCount++ < burstMax)) {
+        if ((_burstPacketLimit > 0) && (packetsSent == _burstPacketLimit)) {
+            // Go silent mid-burst without marking it complete, leaving the client to time out
+            qCDebug(MockLinkFTPLog) << "MockLinkFTP: truncating burst after packets" << packetsSent;
+            return;
+        }
+
         _currentFile.seek(burstOffset);
 
         const uint8_t cBytes = static_cast<uint8_t>(qMin(static_cast<qint64>(sizeof(response.data)), _currentFile.size() - burstOffset));
@@ -349,6 +356,7 @@ void MockLinkFTP::_burstReadCommand(uint8_t senderSystemId, uint8_t senderCompon
         response.hdr.burstComplete = (burstCount == burstMax) ? 1 : 0;
 
         _sendResponse(senderSystemId, senderComponentId, &response, outgoingSeqNumber);
+        packetsSent++;
 
         outgoingSeqNumber = _nextSeqNumber(outgoingSeqNumber);
         burstOffset += cBytes;
@@ -356,6 +364,10 @@ void MockLinkFTP::_burstReadCommand(uint8_t senderSystemId, uint8_t senderCompon
 
     if (burstOffset >= _currentFile.size()) {
         // Burst is fully complete
+        if (!_burstEofEnabled) {
+            qCDebug(MockLinkFTPLog) << "MockLinkFTP: dropping burst EOF Nak";
+            return;
+        }
         _sendNak(senderSystemId, senderComponentId, MavlinkFTP::kErrEOF, outgoingSeqNumber, MavlinkFTP::kCmdBurstReadFile);
     }
 }

--- a/src/Comms/MockLink/MockLinkFTP.h
+++ b/src/Comms/MockLink/MockLinkFTP.h
@@ -46,6 +46,15 @@ public:
     /// MockLink worker thread so it paces transfers without blocking the main thread.
     void setBurstReadDelayMs(int delayMs) { _burstReadDelayMs = delayMs; }
 
+    /// Stops each burst response after packetCount data packets without completing the burst,
+    /// as a link which cannot absorb the full burst stream does. 0 (the default) serves bursts
+    /// in full.
+    void setBurstPacketLimit(int packetCount) { _burstPacketLimit = packetCount; }
+
+    /// When false, the EOF Nak which terminates a burst that reached the end of the file is not
+    /// sent, simulating the loss of that final packet.
+    void setBurstEofEnabled(bool enabled) { _burstEofEnabled = enabled; }
+
     /// When false, OpenFileRO of @PARAM/param.pck NAKs errno ENOENT, as PX4 without the virtual file does.
     void setParamPckEnabled(bool enabled) { _paramPckEnabled = enabled; }
 
@@ -146,6 +155,8 @@ private:
     bool _lastReplyValid = false;
     bool _randomDropsEnabled = false;
     int _burstReadDelayMs = 0;                  ///< Per-burst delay to simulate a slow link
+    int _burstPacketLimit = 0;                  ///< Max data packets served per burst, 0 for no limit
+    bool _burstEofEnabled = true;               ///< Whether a completed burst is terminated with an EOF Nak
     ErrorMode_t _errMode = errModeNone;         ///< Currently set error mode, as specified by setErrorMode
     bool _listDirectoryWithTimeSupported = true; ///< Whether the server implements kCmdListDirectoryWithTime
     bool _paramPckEnabled = true;               ///< Serve @PARAM/param.pck; false NAKs errno ENOENT

--- a/src/Vehicle/FTPManager.cc
+++ b/src/Vehicle/FTPManager.cc
@@ -910,9 +910,36 @@ void FTPManager::_burstReadFileAckOrNak(const MavlinkFTP::Request* ackOrNak)
     }
 }
 
+void FTPManager::_recordMissingTail(void)
+{
+    if ((_downloadState.fileSize == 0) || (_downloadState.expectedOffset >= _downloadState.fileSize)) {
+        return;
+    }
+
+    MissingData_t missingData;
+    missingData.offset          = _downloadState.expectedOffset;
+    missingData.cBytesMissing   = _downloadState.fileSize - _downloadState.expectedOffset;
+    _downloadState.rgMissingData.append(missingData);
+
+    qCDebug(FTPManagerLog) << "_recordMissingTail: offset:cBytesMissing" << missingData.offset << missingData.cBytesMissing;
+}
+
 void FTPManager::_burstReadFileTimeout(void)
 {
     if (++_downloadState.retryCount > _maxRetry) {
+        // A burst streams packets until the file ends, with no way for us to ask for less. Links
+        // which can't absorb that (a router with a shallow forwarding queue, for example) deliver
+        // only the first few packets of every burst, so retrying the burst makes the same small
+        // amount of progress each time and then gives up. Fall back to the non-burst read used to
+        // repair holes instead: it fetches one chunk per request and never has more than a single
+        // message in flight.
+        _recordMissingTail();
+        if (!_downloadState.rgMissingData.isEmpty()) {
+            qCDebug(FTPManagerLog) << "_burstReadFileTimeout: retries exceeded, falling back to non-burst read";
+            _advanceStateMachine();
+            return;
+        }
+
         qCDebug(FTPManagerLog) << QString("_burstReadFileTimeout retries exceeded");
         _downloadComplete(tr("Download failed"));
     } else {

--- a/src/Vehicle/FTPManager.cc
+++ b/src/Vehicle/FTPManager.cc
@@ -932,16 +932,12 @@ void FTPManager::_burstReadFileTimeout(void)
         // only the first few packets of every burst, so retrying the burst makes the same small
         // amount of progress each time and then gives up. Fall back to the non-burst read used to
         // repair holes instead: it fetches one chunk per request and never has more than a single
-        // message in flight.
+        // message in flight. Nothing is recorded as missing when every byte already arrived and
+        // only the terminating EOF Nak was lost; the fill state completes such a download rather
+        // than failing it.
         _recordMissingTail();
-        if (!_downloadState.rgMissingData.isEmpty()) {
-            qCDebug(FTPManagerLog) << "_burstReadFileTimeout: retries exceeded, falling back to non-burst read";
-            _advanceStateMachine();
-            return;
-        }
-
-        qCDebug(FTPManagerLog) << QString("_burstReadFileTimeout retries exceeded");
-        _downloadComplete(tr("Download failed"));
+        qCDebug(FTPManagerLog) << "_burstReadFileTimeout: retries exceeded, falling back to non-burst read";
+        _advanceStateMachine();
     } else {
         // Try again
         qCDebug(FTPManagerLog) << QString("_burstReadFileTimeout: retrying - retryCount(%1) offset(%2)").arg(_downloadState.retryCount).arg(_downloadState.expectedOffset);

--- a/src/Vehicle/FTPManager.h
+++ b/src/Vehicle/FTPManager.h
@@ -220,6 +220,8 @@ private:
     void    _fillRequestDataWithString(MavlinkFTP::Request* request, const QString& str);
     void    _fillMissingBlocksWorker    (bool firstRequest);
     void    _burstReadFileWorker        (bool firstRequest);
+    /// Records anything not yet received as missing so the non-burst read can fetch it.
+    void    _recordMissingTail          (void);
     void    _listDirectoryWorker        (bool firstRequest);
     bool    _parseURI                   (uint8_t fromCompId, const QString& uri, QString& parsedURI, uint8_t& compId);
     void    _listDirectoryCompleteNoError(void) { _listDirectoryComplete(QString()); }

--- a/test/Vehicle/FTPManagerTest.cc
+++ b/test/Vehicle/FTPManagerTest.cc
@@ -109,6 +109,44 @@ void FTPManagerTest::_testLostPackets()
     _disconnectMockLink();
 }
 
+void FTPManagerTest::_testBurstFallback_data()
+{
+    QTest::addColumn<int>("burstPacketLimit");
+    QTest::addColumn<bool>("burstEofEnabled");
+    QTest::addColumn<int>("fileSize");
+
+    // Server truncates every burst, so the burst can never reach the end of the file no matter how
+    // often it is retried. The tail must be fetched with non-burst reads instead.
+    QTest::addRow("truncated_bursts") << 2 << true << (4 * 1024);
+    // All data arrives in a single burst but the Nak which terminates it is lost. Nothing is
+    // missing, so the download must still complete.
+    QTest::addRow("lost_burst_eof") << 0 << false << 1024;
+}
+
+void FTPManagerTest::_testBurstFallback()
+{
+    QFETCH(int, burstPacketLimit);
+    QFETCH(bool, burstEofEnabled);
+    QFETCH(int, fileSize);
+
+    _connectMockLinkNoInitialConnectSequence();
+    _mockLink->mockLinkFTP()->setBurstPacketLimit(burstPacketLimit);
+    _mockLink->mockLinkFTP()->setBurstEofEnabled(burstEofEnabled);
+
+    FTPManager* ftpManager = _vehicle->ftpManager();
+    QString filename = QStringLiteral("%1%2").arg(MockLinkFTP::sizeFilenamePrefix).arg(fileSize);
+    QSignalSpy spyDownloadComplete(ftpManager, &FTPManager::downloadComplete);
+    ftpManager->download(MAV_COMP_ID_AUTOPILOT1, filename,
+                         QStandardPaths::writableLocation(QStandardPaths::TempLocation));
+    QVERIFY_SIGNAL_WAIT(spyDownloadComplete, TestTimeout::longMs());
+    QCOMPARE(spyDownloadComplete.count(), 1);
+    // void downloadComplete   (const QString& file, const QString& errorMsg);
+    QList<QVariant> arguments = spyDownloadComplete.takeFirst();
+    QVERIFY2(arguments[1].toString().isEmpty(), qPrintable(arguments[1].toString()));
+    _verifyFileSizeAndDelete(arguments[0].toString(), fileSize);
+    _disconnectMockLink();
+}
+
 void FTPManagerTest::_verifyFileSizeAndDelete(const QString& filename, int expectedSize)
 {
     QFileInfo fileInfo(filename);

--- a/test/Vehicle/FTPManagerTest.h
+++ b/test/Vehicle/FTPManagerTest.h
@@ -12,6 +12,8 @@ private slots:
     void _performSizeBasedTestCases_data();
     void _performSizeBasedTestCases();
     void _testLostPackets();
+    void _testBurstFallback_data();
+    void _testBurstFallback();
     void _testListDirectory();
     void _testListDirectoryWithTime();
     void _testListDirectoryWithTimeFallback();


### PR DESCRIPTION
## Description

When trying out burst downloading xml files from a camera via PX4, the burst failed because PX4 would not forward more than two messages at a time, and MAVSDK sends them too quickly (to be addressed separately).

This change falls back to non-burst download if the burst fails.



## Type of Change
<!-- Put an 'x' in the relevant boxes -->
- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] CI/Build changes
- [ ] Other

## Testing
<!-- Describe the tests you ran and how to reproduce them -->
- [x] Tested locally
- [ ] Added/updated unit tests
- [x] Tested with simulator (SITL)
- [ ] Tested with hardware

### Platforms Tested
<!-- Check all that apply -->
- [x] Linux
- [ ] Windows
- [ ] macOS
- [ ] Android
- [ ] iOS

### Flight Stacks Tested
<!-- If applicable -->
- [x] PX4
- [ ] ArduPilot

## Screenshots
<!-- If applicable, add screenshots to help explain your changes -->

## Checklist
<!-- Go over all the following points, and put an 'x' in all the boxes that apply -->
- [x] I have read the [Contribution Guidelines](CONTRIBUTING.md)
- [x] I have read the [Code of Conduct](CODE_OF_CONDUCT.md)
- [x] My code follows the project's coding standards
- [ ] I have added tests that prove my fix/feature works
- [ ] New and existing unit tests pass locally

## Related Issues
<!-- Link any related issues using #issue_number -->

---
By submitting this pull request, I confirm that my contribution is made under the terms of the project's dual license (Apache 2.0 and GPL v3).
