### PR TITLE
build(cmake): reject QGC_BUILD_TESTING on a non-Debug build

### DIFF
--- a/cmake/CustomOptions.cmake
+++ b/cmake/CustomOptions.cmake
@@ -47,6 +47,19 @@ option(QGC_BUILD_TESTING "Enable unit tests" ${_QGC_DEBUG_BUILD})
 option(QGC_DEBUG_QML "Enable QML debugging/profiling" ${_QGC_DEBUG_BUILD})
 option(QT_QML_NO_CACHEGEN "Skip qmlcachegen (faster Debug builds, slower QML startup)" ${_QGC_DEBUG_BUILD})
 option(QGC_ENABLE_COVERAGE "Enable code coverage instrumentation" OFF)
+
+# Every vehicle-level test links MockLink, which is only built for Debug (see
+# Comms/MockLink/CMakeLists.txt) because its app-side entry points are guarded by
+# #ifdef QT_DEBUG. Catch the mismatch here: otherwise the build runs for thousands of
+# files before dying on a bare "MockLink.h: No such file or directory".
+# Multi-config generators pick the configuration at build time, so CMAKE_BUILD_TYPE
+# carries no answer here and they are left to the build-time failure.
+if(QGC_BUILD_TESTING AND NOT CMAKE_CONFIGURATION_TYPES AND NOT CMAKE_BUILD_TYPE STREQUAL "Debug")
+    message(FATAL_ERROR
+        "QGC_BUILD_TESTING requires CMAKE_BUILD_TYPE=Debug, MockLink is not built for "
+        "'${CMAKE_BUILD_TYPE}'. Either configure a Debug build or pass -DQGC_BUILD_TESTING=OFF.")
+endif()
+
 unset(_QGC_DEBUG_BUILD)
 option(QGC_ENABLE_CLANG_TIDY "Enable clang-tidy static analysis during build" OFF)
 option(QGC_TIME_TRACE "Emit per-TU Clang -ftime-trace JSON for build profiling (Clang only)" OFF)


### PR DESCRIPTION
## Description

Without this I got missing header MockLink.h. I don't fully understand this though, so feel free to ignore or address differently.

## Type of Change
<!-- Put an 'x' in the relevant boxes -->
- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] CI/Build changes
- [ ] Other

## Testing
<!-- Describe the tests you ran and how to reproduce them -->
- [x] Tested locally
- [ ] Added/updated unit tests
- [ ] Tested with simulator (SITL)
- [ ] Tested with hardware

### Platforms Tested
<!-- Check all that apply -->
- [x] Linux
- [ ] Windows
- [ ] macOS
- [ ] Android
- [ ] iOS

### Flight Stacks Tested
<!-- If applicable -->
- [ ] PX4
- [ ] ArduPilot

## Screenshots
<!-- If applicable, add screenshots to help explain your changes -->

## Checklist
<!-- Go over all the following points, and put an 'x' in all the boxes that apply -->
- [x] I have read the [Contribution Guidelines](CONTRIBUTING.md)
- [x] I have read the [Code of Conduct](CODE_OF_CONDUCT.md)
- [x] My code follows the project's coding standards
- [ ] I have added tests that prove my fix/feature works
- [ ] New and existing unit tests pass locally

## Related Issues
<!-- Link any related issues using #issue_number -->

---
By submitting this pull request, I confirm that my contribution is made under the terms of the project's dual license (Apache 2.0 and GPL v3).
