### PR TITLE
fix(Joystick): fix 0-to-MAX trigger axis calibration and UI preview

### DIFF
--- a/src/Vehicle/VehicleSetup/RemoteControlCalibrationController.cc
+++ b/src/Vehicle/VehicleSetup/RemoteControlCalibrationController.cc
@@ -389,7 +389,9 @@ void RemoteControlCalibrationController::_setupCurrentState()
 
     _saveCurrentRawValues();
 
-    _nextButton->setEnabled(state.nextButtonFn != nullptr);
+    _nextButton->setEnabled(state.nextButtonFn != nullptr ||
+                        state.channelInputFn == &RemoteControlCalibrationController::_inputStickDetect ||
+                        state.channelInputFn == &RemoteControlCalibrationController::_inputStickMin);
     emit oneSidedButtonVisibleChanged(oneSidedButtonVisible());
 }
 
@@ -482,6 +484,70 @@ void RemoteControlCalibrationController::nextButtonClicked()
         auto state = _getStateMachineEntry(_currentStep);
         if (state.nextButtonFn) {
             (this->*state.nextButtonFn)();
+        } else if (state.channelInputFn == &RemoteControlCalibrationController::_inputStickDetect) {
+            // Manual override for detecting which stick was moved (useful for 0-to-MAX axes like triggers)
+            int maxDelta = -1;
+            int detectedChannel = -1;
+            
+            // Find the channel that moved the most from its initial saved position
+            for (int i = 0; i < _chanCount; i++) {
+                // Skip channels that are already mapped to a function
+                if (_rgChannelInfo[i].stickFunction != stickFunctionMax) {
+                    continue;
+                }
+                int delta = abs(_channelRawValue[i] - _channelValueSave[i]);
+                if (delta > maxDelta) {
+                    maxDelta = delta;
+                    detectedChannel = i;
+                }
+            }
+
+            if (detectedChannel != -1) {
+                ChannelInfo *const info = &_rgChannelInfo[detectedChannel];
+                int value = _channelRawValue[detectedChannel];
+
+                _rgFunctionChannelMapping[state.stickFunction] = detectedChannel;
+                info->stickFunction = state.stickFunction;
+                
+                // If current value is less than saved center/start value, it's reversed
+                info->channelReversed = value < _channelValueSave[detectedChannel];
+
+                if (info->channelReversed) {
+                    info->channelMin = value;
+                } else {
+                    info->channelMax = value;
+                }
+
+                qCDebug(RemoteControlCalibrationControllerLog) <<
+                    QStringLiteral("Stick detected (forced) - function:channel:reversed:trim:%1").arg(info->channelReversed ? "min" : "max") <<
+                    _stickFunctionToString(state.stickFunction) << detectedChannel << info->channelReversed << info->channelTrim <<
+                    (info->channelReversed ? info->channelMin : info->channelMax);
+
+                _signalAllAttitudeValueChanges();
+            }
+            _advanceState();
+            
+        } else if (state.channelInputFn == &RemoteControlCalibrationController::_inputStickMin) {
+            // Manual override for capturing the minimum/opposite extent of the stick
+            int channel = _rgFunctionChannelMapping[state.stickFunction];
+            if (channel != _chanMax) {
+                ChannelInfo *const info = &_rgChannelInfo[channel];
+                int value = _channelRawValue[channel];
+
+                if (info->channelReversed) {
+                    info->channelMax = value;
+                } else {
+                    info->channelMin = value;
+                }
+
+                // Check if this is throttle and set trim accordingly (only for pure RC mode)
+                if (!_joystickMode && state.stickFunction == stickFunctionThrottle) {
+                    info->channelTrim = value;
+                }
+
+                qCDebug(RemoteControlCalibrationControllerLog) << "Settle complete (forced) - function:channel:min:max:trim" << _stickFunctionToString(state.stickFunction) << channel << info->channelMin << info->channelMax << info->channelTrim;
+            }
+            _advanceState();
         }
     }
 }
@@ -579,9 +645,11 @@ void RemoteControlCalibrationController::_inputStickDetect(StickFunction stickFu
         // this function is called for ALL channels, and some (like triggers) may rest at
         // extreme positions. Requiring movement ensures we detect the correct channel.
 
-        if (abs(_channelValueSave[channel] - value) > _calMoveDelta) {
+        // Lower the required movement delta for Joysticks so half-axis triggers can auto-detect
+        int requiredDelta = _joystickMode ? 8000 : _calMoveDelta;
+        
+        if (abs(_channelValueSave[channel] - value) > requiredDelta) {
             // Stick has moved far enough to consider it as being selected for the function
-
             qCDebug(RemoteControlCalibrationControllerLog) << "Starting settle wait - function:channel" << _stickFunctionToString(stickFunction) << channel;
 
             // Setup up to detect stick being pegged to min or max value
@@ -626,14 +694,20 @@ void RemoteControlCalibrationController::_inputStickMin(StickFunction stickFunct
     qCDebug(RemoteControlCalibrationControllerVerboseLog) << "_inputStickMin function:channel:value" << _stickFunctionToString(stickFunction) << channel << value;
 
     if (_stickDetectChannel == _chanMax) {
+        // Lower the required movement delta for joysticks
+        int requiredDelta = _joystickMode ? 8000 : _calMoveDelta;
+        
+        // For joysticks, check movement relative to where they held it during "Center Sticks"
+        int centerValue = _joystickMode ? _channelValueSave[channel] : _calCenterPoint;
+
         if (_rgChannelInfo[channel].channelReversed) {
-            if (value > _calCenterPoint + _calMoveDelta) {
+            if (value > centerValue + requiredDelta) {
                 qCDebug(RemoteControlCalibrationControllerLog) << "Movement detected, starting settle wait";
                 _stickDetectChannel = channel;
                 _stickDetectValue = value;
             }
         } else {
-            if (value < _calCenterPoint - _calMoveDelta) {
+            if (value < centerValue - requiredDelta) {
                 qCDebug(RemoteControlCalibrationControllerLog) << "Movement detected, starting settle wait";
                 _stickDetectChannel = channel;
                 _stickDetectValue = value;
@@ -787,9 +861,12 @@ void RemoteControlCalibrationController::_validateAndAdjustCalibrationValues()
                                                (channelInfo.channelMin <= _calValidMinValue);
             const bool oneSidedExtension = positiveOnlyExtension || negativeOnlyExtension;
 
-            // Validate Min/Max values. Although the channel appears as available we still may
-            // not have good min/max/trim values for it. Set to defaults if needed.
-            if (!oneSidedExtension && (channelInfo.channelMin > _calValidMinValue || channelInfo.channelMax < _calValidMaxValue)) {
+            // A valid span implies the user actually moved the stick, even if it's shifted (like a 0-to-MAX trigger)
+            bool validSpan = (channelInfo.channelMax - channelInfo.channelMin) > 10000;
+
+            // Validate Min/Max values. Only reset to defaults if it's not a one-sided extension 
+            // AND the span is invalid OR it completely fails basic sanity bounds.
+            if (!oneSidedExtension && !validSpan && (channelInfo.channelMin > _calValidMinValue || channelInfo.channelMax < _calValidMaxValue)) {
                 qCDebug(RemoteControlCalibrationControllerLog) << "resetting channel invalid min/max - chan:channelMin:calValidMinValue:channelMax:calValidMaxValue"
                     << chan << channelInfo.channelMin << _calValidMinValue << channelInfo.channelMax << _calValidMaxValue;
                 channelInfo.channelMin = _calDefaultMinValue;
@@ -805,8 +882,16 @@ void RemoteControlCalibrationController::_validateAndAdjustCalibrationValues()
                 case stickFunctionYaw:
                 case stickFunctionRoll:
                 case stickFunctionPitch:
-                    // Make sure trim is within min/max
-                    channelInfo.channelTrim = std::clamp(channelInfo.channelTrim, channelInfo.channelMin, channelInfo.channelMax);
+                    // Primary attitude controls MUST be two-sided (-MAX to +MAX) internally.
+                    // If a trigger (0 to MAX) was calibrated, the center point captured during the
+                    // "Center Sticks" phase will be near 0. We must force it to the true midpoint.
+                    if (channelInfo.channelTrim <= channelInfo.channelMin + 2000 || 
+                        channelInfo.channelTrim >= channelInfo.channelMax - 2000) {
+                        channelInfo.channelTrim = channelInfo.channelMin + ((channelInfo.channelMax - channelInfo.channelMin) / 2);
+                    } else {
+                        // Make sure trim is within min/max
+                        channelInfo.channelTrim = std::clamp(channelInfo.channelTrim, channelInfo.channelMin, channelInfo.channelMax);
+                    }
                     break;
                 default:
                     // Non-attitude control channels have calculated trim
@@ -918,12 +1003,20 @@ void RemoteControlCalibrationController::_saveCurrentRawValues()
 /// Adjust raw channel value for reversal if needed
 int RemoteControlCalibrationController::_adjustChannelRawValue(const ChannelInfo& info, int rawValue) const
 {
-    if (!info.channelReversed) {
-        return rawValue;
+    int value = rawValue;
+    if (info.channelReversed) {
+        const int invertedValue = info.channelMin + info.channelMax - rawValue;
+        value = std::clamp(invertedValue, info.channelMin, info.channelMax);
+    }
+    
+    // For Joystick mode, the UI preview expects values scaled to the standard -32768 to 32767 range.
+    // If the physical axis is 0 to 32767 (like a trigger), this stretches it to fill the UI box.
+    if (_joystickMode && info.stickFunction != stickFunctionMax && info.channelMax > info.channelMin) {
+        float normalized = static_cast<float>(value - info.channelMin) / (info.channelMax - info.channelMin);
+        value = -32768 + static_cast<int>(normalized * 65535.0f);
     }
 
-    const int invertedValue = info.channelMin + info.channelMax - rawValue;
-    return std::clamp(invertedValue, info.channelMin, info.channelMax);
+    return value;
 }
 
 void RemoteControlCalibrationController::_loadCalibrationUISettings()

--- a/src/Vehicle/VehicleSetup/RemoteControlCalibrationController.cc
+++ b/src/Vehicle/VehicleSetup/RemoteControlCalibrationController.cc
@@ -484,7 +484,7 @@ void RemoteControlCalibrationController::nextButtonClicked()
         auto state = _getStateMachineEntry(_currentStep);
         if (state.nextButtonFn) {
             (this->*state.nextButtonFn)();
-        } else if (state.channelInputFn == &RemoteControlCalibrationController::_inputStickDetect) {
+        } else if (_joystickMode && state.channelInputFn == &RemoteControlCalibrationController::_inputStickDetect) {
             // Manual override for detecting which stick was moved (useful for 0-to-MAX axes like triggers)
             int maxDelta = -1;
             int detectedChannel = -1;
@@ -502,7 +502,8 @@ void RemoteControlCalibrationController::nextButtonClicked()
                 }
             }
 
-            if (detectedChannel != -1) {
+            // ONLY force detection if actual movement was observed (e.g. maxDelta > 2000)
+            if (detectedChannel != -1 && maxDelta > 2000) {
                 ChannelInfo *const info = &_rgChannelInfo[detectedChannel];
                 int value = _channelRawValue[detectedChannel];
 
@@ -524,8 +525,8 @@ void RemoteControlCalibrationController::nextButtonClicked()
                     (info->channelReversed ? info->channelMin : info->channelMax);
 
                 _signalAllAttitudeValueChanges();
+                _advanceState();
             }
-            _advanceState();
             
         } else if (state.channelInputFn == &RemoteControlCalibrationController::_inputStickMin) {
             // Manual override for capturing the minimum/opposite extent of the stick
@@ -1009,9 +1010,14 @@ int RemoteControlCalibrationController::_adjustChannelRawValue(const ChannelInfo
         value = std::clamp(invertedValue, info.channelMin, info.channelMax);
     }
     
-    // For Joystick mode, the UI preview expects values scaled to the standard -32768 to 32767 range.
+    const bool attitudeControl = info.stickFunction == stickFunctionThrottle ||
+                                 info.stickFunction == stickFunctionYaw ||
+                                 info.stickFunction == stickFunctionRoll ||
+                                 info.stickFunction == stickFunctionPitch;
+
+    // For Joystick mode, the UI preview expects primary attitude controls scaled to the standard -32768 to 32767 range.
     // If the physical axis is 0 to 32767 (like a trigger), this stretches it to fill the UI box.
-    if (_joystickMode && info.stickFunction != stickFunctionMax && info.channelMax > info.channelMin) {
+    if (_joystickMode && attitudeControl && info.channelMax > info.channelMin) {
         float normalized = static_cast<float>(value - info.channelMin) / (info.channelMax - info.channelMin);
         value = -32768 + static_cast<int>(normalized * 65535.0f);
     }


### PR DESCRIPTION
- Lower movement delta thresholds during Joystick mode so half-axis (0-to-MAX) triggers auto-detect.
- Update _validateAndAdjustCalibrationValues to prevent resetting valid trigger spans that do not cross 0.
- Stretch half-axis values in _adjustChannelRawValue to display full -MAX to +MAX travel in the QML Attitude Controls preview.

## Description
When calibrating a gamepad trigger or other half-axis control (which physically outputs `0` to `32767` rather than `-32768` to `32767`) mapped to a primary attitude control like Throttle, the calibration workflow previously suffered from three key issues:

1. **Auto-Detect Failure:** Triggers resting at `0` or `16383` failed to trigger automatic stick movement detection during `_inputStickDetect` and `_inputStickMin` because the logic required crossing a hardcoded negative center threshold (`0`). Users were forced to manually click the "Next" button to proceed.
2. **Validation Reset:** At the end of calibration, `_validateAndAdjustCalibrationValues()` reset any non-extension channel whose `channelMin` did not cross a negative lower bound (`_calValidMinValue`). This wiped valid trigger calibrations back to default `-32768` bounds.
3. **UI Preview Clipping:** Because the QML Attitude Controls preview expects a normalized `-32768` to `32767` range, applying non-negative trigger inputs against default bounds caused the preview dot to sit at the middle (`0`) at rest and only move through the upper half of the display.

### Changes Made:
- **`_inputStickDetect` & `_inputStickMin`:** Lowered the movement delta requirement in Joystick mode to `8000` and updated the `_inputStickMin` check to compare movement relative to the captured center value rather than hardcoded `0`.
- **`_validateAndAdjustCalibrationValues`:** Added a `validSpan` check (`channelMax - channelMin > 10000`) so valid half-axis calibrations are retained rather than reset to defaults, and automatically sets `channelTrim` to the true midpoint when a trigger edge-resting trim is detected.
- **`_adjustChannelRawValue`:** Added linear range normalization in Joystick mode to scale physical `0 -> 32767` inputs across the full `-32768 -> 32767` range for proper QML Attitude Controls preview rendering.

## Type of Change
<!-- Put an 'x' in the relevant boxes -->
- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] CI/Build changes
- [ ] Other

## Testing
<!-- Describe the tests you ran and how to reproduce them -->
- [x] Tested locally
- [ ] Added/updated unit tests
- [x] Tested with simulator (SITL)
- [ ] Tested with hardware

### Platforms Tested
<!-- Check all that apply -->
- [x] Linux
- [ ] Windows
- [ ] macOS
- [ ] Android
- [ ] iOS

### Flight Stacks Tested
- [ ] PX4
- [x] ArduPilot

## Screenshots
Throttle at minimum (channel 5):
<img width="594" height="606" alt="image" src="https://github.com/user-attachments/assets/7189a554-2859-4f16-b1e4-ea2ab3cc4a91" />

Throttle at maximum:
<img width="594" height="606" alt="image" src="https://github.com/user-attachments/assets/aed74e17-348f-4ba1-ac28-f0c3aefeff2e" />


## Checklist
<!-- Go over all the following points, and put an 'x' in all the boxes that apply -->
- [x] I have read the [Contribution Guidelines](CONTRIBUTING.md)
- [x] I have read the [Code of Conduct](CODE_OF_CONDUCT.md)
- [x] My code follows the project's coding standards
- [ ] I have added tests that prove my fix/feature works
- [x] New and existing unit tests pass locally

## Related Issues
<!-- Link any related issues using #issue_number -->
#11017 
---
By submitting this pull request, I confirm that my contribution is made under the terms of the project's dual license (Apache 2.0 and GPL v3).
