### PR TITLE
ci(github): enable stale issue closing

### DIFF
--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -30,8 +30,6 @@ jobs:
       - name: Mark and close stale issues
         uses: actions/stale@v11
         with:
-          # Remove debug-only once the dry-run output has been reviewed.
-          debug-only: true
           days-before-issue-stale: 90
           days-before-issue-close: 30
           days-before-pr-stale: -1
@@ -40,11 +38,11 @@ jobs:
           stale-issue-label: stale
           exempt-issue-labels: 'Priority: Critical,Feature Request'
           exempt-all-issue-milestones: true
+          exempt-issue-assignees: 'DonLakeFlyer,HTRamsey'
           remove-issue-stale-when-updated: true
           ascending: true
-          # Dry run: state is not persisted in debug mode, so the cap must cover the whole backlog.
-          # Lower to 400 when going live: two jobs share the 1000 req/hr GITHUB_TOKEN budget.
-          operations-per-run: 1500
+          # ~3 API ops per issue; covers the full backlog in one run, well under the 15000 req/hr limit.
+          operations-per-run: 2500
           # Empty message labels silently to avoid a notification flood on the initial backlog sweep.
           stale-issue-message: ''
           close-issue-message: >
@@ -71,8 +69,6 @@ jobs:
       - name: Mark and close stale feature requests
         uses: actions/stale@v11
         with:
-          # Remove debug-only once the dry-run output has been reviewed.
-          debug-only: true
           days-before-issue-stale: 90
           days-before-issue-close: 30
           days-before-pr-stale: -1
@@ -82,10 +78,10 @@ jobs:
           any-of-issue-labels: 'Feature Request'
           exempt-issue-labels: 'Priority: Critical'
           exempt-all-issue-milestones: true
+          exempt-issue-assignees: 'DonLakeFlyer,HTRamsey'
           remove-issue-stale-when-updated: true
           ascending: true
-          # Lower to 400 when going live (see stale-issues).
-          operations-per-run: 1500
+          operations-per-run: 2500
           # Empty message labels silently to avoid a notification flood on the initial backlog sweep.
           stale-issue-message: ''
           close-issue-message: >


### PR DESCRIPTION
Follow-up to #15027. Removes `debug-only` so the stale workflow starts labeling and closing.

## Dry-run results ([run 33772184852](https://github.com/mavlink/qgroundcontrol/actions/runs/33772184852))

| | Non-feature issues | Feature requests |
|---|---|---|
| Would be marked stale | ~656 | 150 |
| Skipped: exempt label | 106 | — |
| Skipped: milestone | 35 | 23 |
| PRs touched | 0 | 0 |

Exemptions behaved as intended; no errors.

## Changes from the dry-run config

- **`operations-per-run: 2500`** (was 1500). The dry run showed each marked issue costs ~3 API ops and the org rate limit is 15000/hr, so a higher cap lets one run cover the full backlog with plenty of headroom.
- **`exempt-issue-assignees: 'DonLakeFlyer,HTRamsey'`** in both jobs. Issues assigned to active maintainers stay open; the ~35 assigned to maintainers no longer active on QGC are allowed to age out normally.

## Pre-work already done

The 68 open issues that carried a manually applied `stale` label had that label removed so they enter the normal 90-day + 30-day cycle rather than closing on the first live run.

## What happens after merge

- First nightly run (01:30 UTC) labels ~600 inactive issues `stale` silently (the dry-run counts above minus ~200 now exempt by assignee) (no comment).
- 30 days later, issues still inactive are closed with the type-specific message.
- Any comment or edit on a labeled issue removes the label.
