### PR TITLE
fix(appimage): resolve build paths during install

### DIFF
--- a/cmake/CreateAppImage.cmake
+++ b/cmake/CreateAppImage.cmake
@@ -1,9 +1,9 @@
 message(STATUS "Creating AppImage")
 # TODO: https://github.com/AppImageCommunity/AppImageUpdate
 
-set(APPDIR_PATH "${CMAKE_BINARY_DIR}/AppDir")
-set(APPIMAGETOOL_PATH "${CMAKE_BINARY_DIR}/appimagetool-x86_64.AppImage")
-set(LD_PATH "${CMAKE_BINARY_DIR}/linuxdeploy-x86_64.AppImage")
+set(APPDIR_PATH "${QGC_BUILD_DIR}/AppDir")
+set(APPIMAGETOOL_PATH "${QGC_BUILD_DIR}/appimagetool-x86_64.AppImage")
+set(LD_PATH "${QGC_BUILD_DIR}/linuxdeploy-x86_64.AppImage")
 # set(LD_APPIMAGEPLUGIN_PATH "${CMAKE_BINARY_DIR}/linuxdeploy-plugin-appimage-x86_64.AppImage")
 # set(LD_QTPLUGIN_PATH "${CMAKE_BINARY_DIR}/linuxdeploy-plugin-qt-x86_64.AppImage")
 # set(LD_GSTPLUGIN_PATH "${CMAKE_BINARY_DIR}/linuxdeploy-plugin-gstreamer.sh")
@@ -39,7 +39,7 @@ execute_process(COMMAND ${LD_PATH}
     --appdir ${APPDIR_PATH}
     --executable ${APPDIR_PATH}/usr/bin/QGroundControl
     --desktop-file ${APPDIR_PATH}/usr/share/applications/org.mavlink.qgroundcontrol.desktop
-    --custom-apprun ${CMAKE_BINARY_DIR}/AppRun)
+    --custom-apprun ${QGC_BUILD_DIR}/AppRun)
 # --exclude-library "libgst*"
 # --plugin qt --plugin gtk --plugin gstreamer
 

--- a/cmake/Install.cmake
+++ b/cmake/Install.cmake
@@ -63,6 +63,7 @@ elseif(LINUX)
         FILES ${CMAKE_SOURCE_DIR}/deploy/linux/AppRun
         DESTINATION ${CMAKE_BINARY_DIR}
     )
+    install(CODE "set(QGC_BUILD_DIR \"${CMAKE_BINARY_DIR}\")")
     install(SCRIPT "${CMAKE_SOURCE_DIR}/cmake/CreateAppImage.cmake")
 elseif(WIN32)
     install(CODE "set(CMAKE_PROJECT_NAME ${CMAKE_PROJECT_NAME})")


### PR DESCRIPTION
## Description

Fix AppImage creation on `Stable_V5.0` when using an out-of-source CMake build directory.

`CreateAppImage.cmake` previously relied on `CMAKE_BINARY_DIR` during the install step. In install-script mode, this may not refer to the configured QGroundControl build directory, causing the script to look for `AppDir`, `AppRun`, `linuxdeploy`, and `appimagetool` in the wrong location.

This change preserves the configured build directory as `QGC_BUILD_DIR` in `Install.cmake` and uses it explicitly in `CreateAppImage.cmake`.

## Testing

Tested locally on Ubuntu 22.04 LTS with Qt 6.8.3 and CMake 3.31.6.

Before the change, running:

```text
cmake --install build-release
```

caused AppImage packaging to use incorrect build paths.

After the change:

- `cmake --install build-release` successfully completed AppImage packaging
- `AppRun` was deployed from the configured build directory
- `appimagetool` completed with `Success`
- The generated AppImage launched successfully and exited normally

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [x] CI/Build changes

## Testing Checklist

- [x] Tested locally

## Platforms Tested

- [x] Linux