### PR TITLE
fix(AppSettings): default to first available settings page instead of General

### DIFF
--- a/src/QmlControls/AppSettings.qml
+++ b/src/QmlControls/AppSettings.qml
@@ -136,18 +136,9 @@ Rectangle {
     QGCPalette { id: qgcPal }
 
     Component.onCompleted: {
-        // Find and select the default page
-        var targetUrl = globals.commingFromRIDIndicator
-            ? "qrc:/qml/QGroundControl/AppSettings/RemoteIDSettings.qml"
-            : "qrc:/qml/QGroundControl/AppSettings/GeneralSettings.qml"
-        globals.commingFromRIDIndicator = false
-
-        for (var i = 0; i < settingsPagesModel.count; i++) {
-            var entry = settingsPagesModel.get(i)
-            if (entry && entry.url === targetUrl) {
-                _navigateTo(i, -1)
-                break
-            }
+        if (globals.commingFromRIDIndicator) {
+            globals.commingFromRIDIndicator = false
+            showSettingsPage("Remote ID")
         }
 
         if (_selectedPageIndex === -1) {


### PR DESCRIPTION
`AppSettings.qml` hardcoded `GeneralSettings.qml` as the page to select when the settings view opens. A custom build that inserts its own settings page before General (via the `SettingsPages.json` overlay) still landed on General.

Now the view selects the first available page in `SettingsPagesModel`, so whatever page is first wins. In stock QGC that is still General, so no behavior change for the default build.

Also simplifies the Remote ID indicator entry path to reuse the existing `showSettingsPage("Remote ID")` helper instead of a second URL-based lookup loop.
