### PR TITLE
Vagrant: upate for new QT / move convenience scripts into directory

### DIFF
--- a/deploy/vagrant/Vagrantfile
+++ b/deploy/vagrant/Vagrantfile
@@ -139,42 +139,9 @@ Vagrant.configure(2) do |config|
      systemctl stop apparmor
      aa-teardown
 
-     # write out a pair of scripts to make rebuilding on the VM easy:
-     su - vagrant -c "cat <<CONFIGURE >do-configure.sh
-#!/bin/bash
-
-set -e
-set -x
-
-# shadow_build in /home to avoid linking problems on vboxfs
-SHADOW_BUILD=\"\\\$HOME/shadow_build\"
-QT_ROOT=\"\\\$HOME/Qt/${version}/gcc_64\"
-export QT_ROOT_DIR=\"\\\$QT_ROOT\"
-rm -rf \"\\\$SHADOW_BUILD\"
-mkdir \"\\\$SHADOW_BUILD\"
-cd \"\\\$SHADOW_BUILD\"
-time \"\\\$QT_ROOT/bin/qt-cmake\" --preset Linux -S /vagrant -B \"\\\$SHADOW_BUILD\" -DQGC_STABLE_BUILD=OFF # 34s
-CONFIGURE
-"
-
-     su - vagrant -c "cat <<MAKE >do-make.sh
-#!/bin/bash
-
-set -e
-set -x
-
-SHADOW_BUILD=\"\\\$HOME/shadow_build\"
-
-cd \"\\\$SHADOW_BUILD\"
-
-time cmake --build . --target all --config Release  # 75m
-rm -rf AppDir
-time cmake --install . --config Release
-
-MAKE
-"
-
-    su - vagrant -c "chmod +x do-configure.sh do-make.sh"
+     # copy into place a pair of scripts to make rebuilding on the VM easy:
+     su - vagrant -c "cp -a /vagrant/deploy/vagrant/do-make.sh /home/vagrant/"
+     su - vagrant -c "cp -a /vagrant/deploy/vagrant/do-configure.sh /home/vagrant/"
 
     # increase the allowed number of open files (the link step takes a
     # lot of open filehandles!):
@@ -183,12 +150,6 @@ echo '*               soft    nofile          2048' >/etc/security/limits.d/file
     # now run the scripts:
     su - vagrant -c ./do-configure.sh
     su - vagrant -c ./do-make.sh
-
-    # local dev only: expose build products on the host via the two-way
-    # /vagrant share (CI pulls the AppImage over scp instead; see vm-builds.yml)
-    if [ -z "${QGC_CI:-}" ]; then
-      su - vagrant -c 'rsync --delete -aPH "$HOME/shadow_build" /vagrant/shadow_build'
-    fi
 
    SHELL
 

--- a/deploy/vagrant/do-configure.sh
+++ b/deploy/vagrant/do-configure.sh
@@ -1,0 +1,29 @@
+#!/bin/bash
+
+set -e
+set -x
+
+# Override with e.g. CONFIG=Debug ./do-configure.sh; do-make.sh honours the same variable.
+CONFIG="${CONFIG:-Release}"
+
+PYTHON="$HOME/venv-qgroundcontrol/bin/python3"
+
+# Single source of truth for the Qt version is .github/build-config.json (also used by the Vagrantfile).
+QT_VERSION=$("$PYTHON" -c 'import json, sys; print(json.load(open(sys.argv[1]))["qt"]["version"])' /vagrant/.github/build-config.json)
+QT_ROOT="$HOME/Qt/$QT_VERSION/gcc_64"
+
+# shadow_build in /home to avoid linking problems on vboxfs
+SHADOW_BUILD="$HOME/shadow_build"
+rm -rf "$SHADOW_BUILD"
+mkdir "$SHADOW_BUILD"
+cd "$SHADOW_BUILD"
+time cmake \
+  -S /vagrant \
+  -B . \
+  -G Ninja \
+  -DCMAKE_BUILD_TYPE="$CONFIG" \
+  -DQGC_BUILD_TESTING=OFF \
+  -DQGC_STABLE_BUILD=OFF \
+  -DPython3_EXECUTABLE="$PYTHON" \
+  -DPython_EXECUTABLE="$PYTHON" \
+  -DCMAKE_PREFIX_PATH="$QT_ROOT" # 34s

--- a/deploy/vagrant/do-make.sh
+++ b/deploy/vagrant/do-make.sh
@@ -1,0 +1,19 @@
+#!/bin/bash
+
+set -e
+set -x
+
+# Must match the CONFIG used by do-configure.sh (Ninja is a single-config generator).
+CONFIG="${CONFIG:-Release}"
+
+SHADOW_BUILD_DIRNAME="shadow_build"
+SHADOW_BUILD="$HOME/$SHADOW_BUILD_DIRNAME"
+
+cd "$SHADOW_BUILD"
+
+time cmake --build . --target all --config "$CONFIG"  # 75m
+rm -rf AppDir
+time cmake --install . --config "$CONFIG"
+
+# make the build output visible on the host
+rsync --delete -aPH "$SHADOW_BUILD"/ "/vagrant/$SHADOW_BUILD_DIRNAME"


### PR DESCRIPTION
## Bug Description
<!-- What bug does this fix? Link to issue if exists -->

The Vagrant developer VM (`deploy/vagrant/`) no longer produced a working build on
master. The `do-configure.sh` / `do-make.sh` helper scripts that the `Vagrantfile`
wrote into the VM were out of date with the current build: they invoked
`qt-cmake --preset Linux` with `QT_ROOT_DIR` and ignored the Python venv that the
provisioner creates, so configure failed inside the VM.

## Root Cause
<!-- What was causing the bug? -->

The helper scripts were embedded in the `Vagrantfile` as triple-escaped heredocs
inside `su -c "cat <<EOF"`, which made them hard to read and easy to leave stale
when the CMake/Qt setup changed. They were not updated for the current Qt version
(6.11.1) and CMake configuration, and did not point CMake at the venv Python
(`~/venv-qgroundcontrol`) that the rest of the provisioning relies on.

## Solution
<!-- How does this PR fix the bug? -->

- Move `do-configure.sh` and `do-make.sh` out of the `Vagrantfile` heredocs into
  real files under `deploy/vagrant/`, and have the provisioner `cp -a` them into
  `/home/vagrant/`. Now that the Vagrant bits live in their own directory there is
  no reason to inline them.
- `do-configure.sh`: plain `cmake -G Ninja` against `/vagrant`, with
  `CMAKE_PREFIX_PATH` pointing at the aqt-installed Qt 6.11.1, `Python3_EXECUTABLE`
  pointing at the venv Python, and `QGC_BUILD_TESTING=OFF` / `QGC_STABLE_BUILD=OFF`.
- `do-make.sh`: build + install into the shadow build dir in `$HOME` (avoids
  vboxfs linking problems), then `rsync` the result back to `/vagrant/shadow_build`
  so the artifacts are visible on the host.

## Testing

- [x] Tested locally
- [ ] Added regression test
- [ ] Tested with simulator (SITL)
- [ ] Tested with hardware

`rm -rf shadow_build && vagrant up` produced a QGC binary for me

### Platforms Tested

- [x] Linux
- [ ] Windows
- [ ] macOS
- [ ] Android
- [ ] iOS

### Flight Stacks Tested

- [ ] PX4
- [x] ArduPilot (with the produced binary)
- [ ] N/A

## Checklist

- [x] I have read the [Contribution Guidelines](../CONTRIBUTING.md)
- [x] My code follows the project's coding standards
- [ ] I have added a test that reproduces the bug
- [x] New and existing unit tests pass locally

---
By submitting this pull request, I confirm that my contribution is made under the terms of the project's dual license (Apache 2.0 and GPL v3).
