### PR TITLE
APM: add AF9838 compass device name

### DIFF
--- a/src/AutoPilotPlugins/APM/APMSensorIdDecoder.qml
+++ b/src/AutoPilotPlugins/APM/APMSensorIdDecoder.qml
@@ -45,7 +45,8 @@ QGCLabel {
         0x15: 'AK09915',
         0x16: 'QMC5883P',
         0x17: 'BMM350',
-        0x18: 'IIS2MDC'
+        0x18: 'IIS2MDC',
+        0x1A: 'AF9838'
     }
 
     property var imuTypes: {


### PR DESCRIPTION
Add the AF9838 compass device type mapping (0x1A) to APMSensorIDDecoder.qml.

AF9838 support has already been merged into ArduPilot master. Without this mapping, QGroundControl receives the correct compass device type but does not display the sensor name.

Verified locally by building QGroundControl and confirming that the sensor is displayed as AF9838.
