### PR TITLE
add logviewer altituge graph toggle for map tab

### DIFF
--- a/src/AnalyzeView/LogViewer/LogViewerPage.qml
+++ b/src/AnalyzeView/LogViewer/LogViewerPage.qml
@@ -303,9 +303,12 @@ AnalyzePage {
                                 onCursorMoved: (t) => {
                                     _mapTab._markerVisible = true
                                     _mapTab._markerCoord   = logParser.gpsCoordAt(t)
+                                    _mapTab._sharedCursorT = t
                                     if (_altChart.visible) _altChart.setSharedCursor(t)
                                 }
                                 onZoomApplied: (minX, maxX) => {
+                                    _mapTab._sharedZoomMinX = minX
+                                    _mapTab._sharedZoomMaxX = maxX
                                     if (_altChart.visible) _altChart.setSharedZoom(minX, maxX)
                                 }
                             }
@@ -336,6 +339,15 @@ AnalyzePage {
                     // Shared cursor state (driven by altitude chart, displayed on map)
                     property bool _markerVisible: false
                     property var _markerCoord: ({})
+
+                    // Collapsed state for the altitude chart, so the map can use the full tab height
+                    property bool _altChartCollapsed: false
+
+                    // Last cursor/zoom synced from the Charting tab while the altitude chart was
+                    // hidden (collapsed, or its tab not current); reapplied once it becomes visible.
+                    property real _sharedCursorT: NaN
+                    property real _sharedZoomMinX: NaN
+                    property real _sharedZoomMaxX: NaN
 
                     ColumnLayout {
                         anchors.fill: parent
@@ -427,12 +439,34 @@ AnalyzePage {
                             }
                         }
 
+                        // ---- Altitude chart header (collapse/expand toggle) ----
+                        RowLayout {
+                            Layout.fillWidth: true
+                            visible: _mapTab._hasAltField && _mapTab._hasPath
+                            spacing: ScreenTools.defaultFontPixelWidth * 0.5
+
+                            QGCLabel {
+                                Layout.fillWidth: true
+                                text: qsTr("Altitude")
+                            }
+
+                            QGCButton {
+                                id: _altChartToggle
+                                iconSource: _mapTab._altChartCollapsed ? "/res/chevron-up.svg" : "/res/chevron-down.svg"
+                                Accessible.name: _mapTab._altChartCollapsed ? qsTr("Expand altitude chart") : qsTr("Collapse altitude chart")
+                                ToolTip.text: Accessible.name
+                                ToolTip.visible: hovered
+                                focusPolicy: Qt.StrongFocus
+                                onClicked: _mapTab._altChartCollapsed = !_mapTab._altChartCollapsed
+                            }
+                        }
+
                         // ---- Altitude chart ----
                         LogViewerAltChart {
                             id: _altChart
                             Layout.fillWidth: true
                             Layout.preferredHeight: ScreenTools.defaultFontPixelHeight * 14
-                            visible: _mapTab._hasAltField && _mapTab._hasPath
+                            visible: _mapTab._hasAltField && _mapTab._hasPath && !_mapTab._altChartCollapsed
                             logParser: logParser
                             altFieldName: _mapTab._altFieldName
                             xAxisShowLocalTime: _xAxisShowLocalTime
@@ -447,6 +481,16 @@ AnalyzePage {
                             }
                             onZoomApplied: (minX, maxX) => {
                                 logViewerChart.setSharedZoom(minX, maxX)
+                            }
+                        }
+
+                        // Catch up on cursor/zoom changes that occurred while this chart was hidden.
+                        Connections {
+                            target: _altChart
+                            function onVisibleChanged() {
+                                if (!_altChart.visible) return
+                                if (!isNaN(_mapTab._sharedZoomMinX)) _altChart.setSharedZoom(_mapTab._sharedZoomMinX, _mapTab._sharedZoomMaxX)
+                                if (!isNaN(_mapTab._sharedCursorT)) _altChart.setSharedCursor(_mapTab._sharedCursorT)
                             }
                         }
                     }


### PR DESCRIPTION
## Description
In the log viewer map tab the screen area for the map is quite limited. This toggle can collapse the altitude graph to allow more view area for the map and flight plot.

<img width="640" height="448" alt="output" src="https://github.com/user-attachments/assets/c5ce022f-126e-49e6-a331-0e1c3cc4eb00" />

## Type of Change
<!-- Put an 'x' in the relevant boxes -->
- [ ] Bug fix (non-breaking change that fixes an issue)
- [ x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] CI/Build changes
- [ ] Other

## Testing
<!-- Describe the tests you ran and how to reproduce them -->
- [ x] Tested locally
- [ ] Added/updated unit tests
- [ ] Tested with simulator (SITL)
- [ ] Tested with hardware

### Platforms Tested
<!-- Check all that apply -->
- [ x] Linux
- [ ] Windows
- [ ] macOS
- [ ] Android
- [ ] iOS

### Flight Stacks Tested
<!-- If applicable -->
- [ ] PX4
- [x ] ArduPilot

## Screenshots
<!-- If applicable, add screenshots to help explain your changes -->

## Checklist
<!-- Go over all the following points, and put an 'x' in all the boxes that apply -->
- [ x] I have read the [Contribution Guidelines](CONTRIBUTING.md)
- [ x] I have read the [Code of Conduct](CODE_OF_CONDUCT.md)
- [ x] My code follows the project's coding standards
- [ ] I have added tests that prove my fix/feature works
- [x ] New and existing unit tests pass locally

## Related Issues
<!-- Link any related issues using #issue_number -->

---
By submitting this pull request, I confirm that my contribution is made under the terms of the project's dual license (Apache 2.0 and GPL v3).
