### PR TITLE
test(Camera): ignore connect-time StandardModes warning in lost camera test

### DIFF
--- a/test/Camera/QGCCameraManagerTest.cc
+++ b/test/Camera/QGCCameraManagerTest.cc
@@ -35,6 +35,10 @@ void QGCCameraManagerTest::_testLostCameraCleanupWithPendingRequest()
 {
     ignoreLogMessage("Vehicle.MavCommandQueue", QtWarningMsg,
                      QRegularExpression("Giving up sending command after max retries:"));
+    // The AVAILABLE_MODES enumeration started during connect can still be in flight here and
+    // fails against MockLink. Timing dependent, so it only shows up on the slower CI lanes.
+    ignoreLogMessage("Vehicle.StandardModes", QtWarningMsg,
+                     QRegularExpression("Failed to retrieve available modes"));
 
     // Enable camera manager debug logging: the failure handlers log CameraStruct
     // fields, widening the use-after-free reads for ASan to catch. Scoped so the


### PR DESCRIPTION
## Problem

`QGCCameraManagerTest::_testLostCameraCleanupWithPendingRequest` fails intermittently on the ASan+UBSan lane:

```
FAIL!  : QGCCameraManagerTest::_testLostCameraCleanupWithPendingRequest() Unexpected log messages (strict mode):
  [warning][Vehicle.StandardModes] Failed to retrieve available modes - REQUEST_MESSAGE:MAV_RESULT "MAV_RESULT_UNSUPPORTED" failureCode: 1
```

The test deliberately waits for a `CAMERA_INFORMATION` request to exhaust its retries. That window is long enough that the `AVAILABLE_MODES` enumeration started during connect can still be in flight, and it fails against MockLink, logging the warning from `StandardModes.cc:92`. Strict mode turns any unexpected log message into a failure.

The test suppresses the `MavCommandQueue` give-up warning but not this one, so whenever the timing lines up it fails. Only the sanitizer lane is consistently slow enough to hit it, which is where it showed up.

## Fix

Suppress the `Vehicle.StandardModes` warning too, matching what `VehicleLinkManagerTest` (4 call sites) and `InitialConnectTest` already do for exactly this message.

`ignoreLogMessage` is a suppression rather than an expectation, so it is safe on the runs where the warning does not occur — which is why the test also still passes where it was already green.

## Testing

`QGCCameraManagerTest` passes locally (4/4). The flake is timing dependent and does not reproduce on a non-sanitizer local build, so this cannot be demonstrated failing here; the diagnosis comes from the CI log above.