### PR TITLE
fix(OnboardLogs): don't lose or double-count logs when listing over FTP

### DIFF
--- a/src/AnalyzeView/OnboardLogs/OnboardLogController.cc
+++ b/src/AnalyzeView/OnboardLogs/OnboardLogController.cc
@@ -1000,9 +1000,19 @@ void OnboardLogController::_ftpListDirComplete(const QStringList &dirList, const
         // and/or date subdirectories to descend into (PX4 fallback /fs/microsd/log).
         const uint flatLogs = _ftpProcessFileEntries(dirList, QString());
 
+        // A kCmdListDirectoryWithTime listing may give a directory the same trailing
+        // fields as a file: "D<name>\t<size>\t<modification time>". Servers differ on
+        // whether they send them (MAVSDK does, PX4 does not), so tolerate either. A
+        // plain kCmdListDirectory entry is just "D<name>", where a tab would be part
+        // of the name, so only strip the fields when times were asked for.
+        const bool withTime = _vehicle && !_vehicle->ftpManager()->listDirectoryWithTimeUnsupported();
+
         for (const QString &entry : dirList) {
             if (entry.startsWith(QLatin1Char('D'))) {
-                const QString dirName = entry.mid(1);
+                QString dirName = entry.mid(1);
+                if (withTime) {
+                    dirName = dirName.section(QLatin1Char('\t'), 0, 0);
+                }
                 if (!dirName.isEmpty()) {
                     _ftpDirsToList.append(dirName);
                 }

--- a/src/AnalyzeView/OnboardLogs/OnboardLogController.cc
+++ b/src/AnalyzeView/OnboardLogs/OnboardLogController.cc
@@ -1013,7 +1013,11 @@ void OnboardLogController::_ftpListDirComplete(const QStringList &dirList, const
                 if (withTime) {
                     dirName = dirName.section(QLatin1Char('\t'), 0, 0);
                 }
-                if (!dirName.isEmpty()) {
+                // Some servers list "." and ".."; descending into those would
+                // list this directory again, or its parent (ArduPilot sends
+                // them, PX4 does not).
+                if (!dirName.isEmpty() &&
+                    (dirName != QStringLiteral(".")) && (dirName != QStringLiteral(".."))) {
                     _ftpDirsToList.append(dirName);
                 }
             }


### PR DESCRIPTION
## Bug Description
<!-- What bug does this fix? Link to issue if exists -->

Fixes # <!-- no issue filed -->

Two problems in the FTP path of the onboard log list, both of which lose logs
rather than merely displaying them oddly:

1. A directory entry which carries a modification time is mis-parsed, and its
   name comes out as `<name>\t0\t<mtime>`. Listing that "directory" then fails,
   so **every log inside it is missing** from the list.
2. A server which lists `.` and `..` makes us descend into them: `.` lists the
   log directory a second time, so **every log in it is counted twice**, and
   `..` sends us off into its parent.

Neither is hypothetical. MAVSDK's FTP server already sends the trailing fields
on directory entries, so QGC is mis-parsing them today. ArduPilot lists `.` and
`..` in every directory listing.

## Root Cause
<!-- What was causing the bug? -->

**1. Directory entries were assumed to be a bare name.**
`OnboardLogController::_ftpListDirComplete()` took `entry.mid(1)` — everything
after the `D` — as the directory name. That is only correct for the plain
`kCmdListDirectory` format.

The MAVFTP entry format is `<type><name>\t<size>\t<mtime>`, and the
[specification](https://mavlink.io/en/services/ftp.html) does not say whether a
directory carries the two trailing fields, so implementations differ:

| server | directory entry under `kCmdListDirectoryWithTime` |
| --- | --- |
| MAVSDK | `D<name>\t0\t<mtime>` ([mavlink_ftp_server.cpp](https://github.com/mavlink/MAVSDK/blob/34b417d45c2c33ce0414bc1bc61b54010d055224/cpp/src/mavsdk/core/mavlink_ftp_server.cpp#L444-L452)) |
| PX4 | bare `D<name>`, being changed in [PX4/PX4-Autopilot#28628](https://github.com/PX4/PX4-Autopilot/pull/28628) |
| ArduPilot | being added in [ArduPilot/ardupilot#34229](https://github.com/ArduPilot/ardupilot/pull/34229) |

`FTPManager` asks for `kCmdListDirectoryWithTime` by default and only falls back
on a NAK, so QGC does see these entries. The file branch was already correct —
it parses the optional third field — it was only the directory branch that
assumed a bare name.

**2. Nothing filtered `.` and `..`.**
Every `D` entry was appended to `_ftpDirsToList` and then listed as
`<root>/<name>`. PX4 skips both entries; ArduPilot sends them.

## Solution
<!-- How does this PR fix the bug? -->

**`fix(OnboardLogs): tolerate directory entries carrying a time`**
Take the directory name as the text up to the first tab — but only when times
were requested, using the existing `listDirectoryWithTimeUnsupported()`. In a
plain `kCmdListDirectory` listing a directory entry really is a bare name, so a
tab there is part of the name and is left alone; **opcode 3 behaviour is
unchanged**. This accepts servers that send the fields and servers that don't,
so it needs no firmware to land first.

**`fix(OnboardLogs): do not descend into "." and ".."`**
Skip those two entries when collecting subdirectories.

Together: +16/-2 in one file, no API or behaviour change beyond the listing
itself.

## Testing

- [x] Tested locally
- [ ] Added regression test
- [x] Tested with simulator (SITL)
- [ ] Tested with hardware

  Verification so far has been of the wire format the server produces, against
  ArduPilot SITL carrying ArduPilot/ardupilot#34229. Captured listing of
  @MAV_LOG over kCmdListDirectoryWithTime:

      'D.\t0\t1788928014'
      'D..\t0\t1788927817'
      'F00000001.BIN\t757760\t1788928014'
      'FLASTLOG.TXT\t3\t1788928014'
      'F00000002.BIN\t729088\t1788928023'

  which is exactly the shape both bugs trip over: directory entries with the
  trailing fields, and "." / ".." present.

### Platforms Tested

- [x] Linux
- [ ] Windows
- [ ] macOS
- [ ] Android
- [ ] iOS

### Flight Stacks Tested

- [ ] PX4
- [x] ArduPilot
- [ ] N/A

## Checklist

- [x] I have read the [Contribution Guidelines](../CONTRIBUTING.md)
- [x] My code follows the project's coding standards
- [ ] I have added a test that reproduces the bug
- [ ] New and existing unit tests pass locally

---
By submitting this pull request, I confirm that my contribution is made under the terms of the project's dual license (Apache 2.0 and GPL v3).
