### PR TITLE
Fix APM takeoff when vehicle is already armed and on the ground

### DIFF
--- a/src/FirmwarePlugin/APM/APMFirmwarePlugin.cc
+++ b/src/FirmwarePlugin/APM/APMFirmwarePlugin.cc
@@ -1052,13 +1052,13 @@ void APMFirmwarePlugin::startTakeoff(Vehicle *vehicle) const
         return;
     }
 
-    // The vehicle is on the ground, so it's safe to switch to Takeoff mode regardless of arming state.
+    // The vehicle is on the ground, so it's safe to switch to Takeoff mode regardless of arming state
     if (!_setFlightModeAndValidate(vehicle, takeOffFlightMode())) {
         QGC::showAppMessage(tr("Unable to start takeoff: Vehicle failed to change to Takeoff mode."));
         return;
     }
 
-    // Only arm the vehicle if it is not already armed.
+    // Only arm the vehicle if it is not already armed
     if (!vehicle->armed() && !_armVehicleAndValidate(vehicle)) {
         QGC::showAppMessage(tr("Unable to start takeoff: Vehicle failed to arm."));
         return;

--- a/src/FirmwarePlugin/APM/APMFirmwarePlugin.cc
+++ b/src/FirmwarePlugin/APM/APMFirmwarePlugin.cc
@@ -1044,6 +1044,7 @@ bool APMFirmwarePlugin::_guidedModeTakeoff(Vehicle *vehicle, double altitudeRel)
     return true;
 }
 
+
 void APMFirmwarePlugin::startTakeoff(Vehicle *vehicle) const
 {
     if (vehicle->flying()) {
@@ -1051,16 +1052,16 @@ void APMFirmwarePlugin::startTakeoff(Vehicle *vehicle) const
         return;
     }
 
-    if (!vehicle->armed()) {
-        if (!_setFlightModeAndValidate(vehicle, takeOffFlightMode())) {
-            QGC::showAppMessage(tr("Unable to start takeoff: Vehicle failed to change to Takeoff mode."));
-            return;
-        }
+    // The vehicle is on the ground, so it's safe to switch to Takeoff mode regardless of arming state.
+    if (!_setFlightModeAndValidate(vehicle, takeOffFlightMode())) {
+        QGC::showAppMessage(tr("Unable to start takeoff: Vehicle failed to change to Takeoff mode."));
+        return;
+    }
 
-        if (!_armVehicleAndValidate(vehicle)) {
-            QGC::showAppMessage(tr("Unable to start takeoff: Vehicle failed to arm."));
-            return;
-        }
+    // Only arm the vehicle if it is not already armed.
+    if (!vehicle->armed() && !_armVehicleAndValidate(vehicle)) {
+        QGC::showAppMessage(tr("Unable to start takeoff: Vehicle failed to arm."));
+        return;
     }
 }
 


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail. What problem does this solve? -->

Fixes an issue where APM takeoff does nothing if the vehicle is already armed while on the ground.

Previously, `APMFirmwarePlugin::startTakeoff()` only switched to Takeoff mode and attempted to arm the vehicle when it was disarmed. If the vehicle was already armed, the takeoff sequence was skipped entirely.

This change ensures that:

* The vehicle switches to Takeoff mode regardless of its arming state.
* No redundant arm command is sent when the vehicle is already armed.
* The existing behavior for vehicles that are already flying is preserved.

## Type of Change
<!-- Put an 'x' in the relevant boxes -->
- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] CI/Build changes
- [ ] Other

## Testing
<!-- Describe the tests you ran and how to reproduce them -->
- [x] Tested locally
- [ ] Added/updated unit tests
- [x] Tested with simulator (SITL)
- [ ] Tested with hardware

### Platforms Tested
<!-- Check all that apply -->
- [x] Linux
- [ ] Windows
- [ ] macOS
- [ ] Android
- [ ] iOS

### Flight Stacks Tested
<!-- If applicable -->
- [x] PX4
- [x] ArduPilot

## Screenshots
<!-- If applicable, add screenshots to help explain your changes -->

## Checklist
<!-- Go over all the following points, and put an 'x' in all the boxes that apply -->
- [x] I have read the [Contribution Guidelines](CONTRIBUTING.md)
- [x] I have read the [Code of Conduct](CODE_OF_CONDUCT.md)
- [x] My code follows the project's coding standards
- [x] I have added tests that prove my fix/feature works
- [x] New and existing unit tests pass locally

## Related Issues
<!-- Link any related issues using #issue_number -->

---
By submitting this pull request, I confirm that my contribution is made under the terms of the project's dual license (Apache 2.0 and GPL v3).

