### PR TITLE
test(Vehicle): fix link-order flake in VehicleLinkManagerTest

### DIFF
--- a/test/Vehicle/VehicleLinkManagerTest.cc
+++ b/test/Vehicle/VehicleLinkManagerTest.cc
@@ -113,12 +113,15 @@ void VehicleLinkManagerTest::_multiLinkSingleVehicleTest()
     // Losing comms while the AVAILABLE_MODES enumeration is still in flight fails the request.
     ignoreLogMessage("Vehicle.StandardModes", QtWarningMsg,
                      QRegularExpression("Failed to retrieve available modes"));
-    SharedLinkConfigurationPtr mockConfig1;
-    SharedLinkInterfacePtr mockLink1;
-    SharedLinkConfigurationPtr mockConfig2;
-    SharedLinkInterfacePtr mockLink2;
-    _startMockLink(1, false /*highLatency*/, false /*incrementVehicleId*/, mockConfig1, mockLink1);
-    _startMockLink(2, false /*highLatency*/, false /*incrementVehicleId*/, mockConfig2, mockLink2);
+    struct MockLinkInfo {
+        SharedLinkConfigurationPtr config;
+        SharedLinkInterfacePtr link;
+        MockLink* mock = nullptr;
+    };
+    MockLinkInfo primary;
+    MockLinkInfo secondary;
+    _startMockLink(1, false /*highLatency*/, false /*incrementVehicleId*/, primary.config, primary.link);
+    _startMockLink(2, false /*highLatency*/, false /*incrementVehicleId*/, secondary.config, secondary.link);
 
     Vehicle* const vehicle = waitForVehicleConnect(TestTimeout::shortMs());
     QVERIFY(vehicle);
@@ -132,84 +135,91 @@ void VehicleLinkManagerTest::_multiLinkSingleVehicleTest()
                       TestTimeout::mediumMs());
 
     // The first link to start sending a heartbeat will be the primary link.
-    // Depending on how the thread scheduling works, that could be the mockLink2.
+    // Depending on how the thread scheduling works, that could be the second link started.
     const SharedLinkInterfacePtr primaryLink = vehicleLinkManager->primaryLink().lock();
-    QVERIFY(primaryLink == mockLink1 || primaryLink == mockLink2);
-
-    MockLink* pMockLink1 = qobject_cast<MockLink*>(mockLink1.get());
-    MockLink* pMockLink2 = qobject_cast<MockLink*>(mockLink2.get());
-    QVERIFY(pMockLink1);
-    QVERIFY(pMockLink2);
-    if (primaryLink == mockLink2) {
-        std::swap(pMockLink1, pMockLink2);
+    QVERIFY(primaryLink == primary.link || primaryLink == secondary.link);
+    if (primaryLink == secondary.link) {
+        std::swap(primary, secondary);
     }
+
+    primary.mock = qobject_cast<MockLink*>(primary.link.get());
+    secondary.mock = qobject_cast<MockLink*>(secondary.link.get());
+    QVERIFY(primary.mock);
+    QVERIFY(secondary.mock);
 
     const QStringList rgNames = vehicleLinkManager->linkNames();
     QStringList rgStatus = vehicleLinkManager->linkStatuses();
     QCOMPARE(rgNames.count(), 2);
-    QCOMPARE(rgNames[0], mockConfig1->name());
-    QCOMPARE(rgNames[1], mockConfig2->name());
+    // linkNames()/linkStatuses() are ordered by link add order, not primary-first,
+    // so look up indices by name
+    const qsizetype primaryIdx = rgNames.indexOf(primary.config->name());
+    const qsizetype secondaryIdx = rgNames.indexOf(secondary.config->name());
+    QVERIFY(primaryIdx != -1);
+    QVERIFY(secondaryIdx != -1);
+    QVERIFY(primaryIdx != secondaryIdx);
     QCOMPARE(rgStatus.count(), 2);
-    QVERIFY(rgStatus[0].isEmpty());
-    QVERIFY(rgStatus[1].isEmpty());
+    QVERIFY(rgStatus[primaryIdx].isEmpty());
+    QVERIFY(rgStatus[secondaryIdx].isEmpty());
 
     MultiSignalSpy multiSpy;
     QVERIFY(multiSpy.init(vehicleLinkManager));
 
-    // Comm lost on 2: 1 is primary, 2 is secondary so comm loss/regain on 2 should only update status text
-    pMockLink2->setCommLost(true);
+    // Comm loss/regain on the secondary link should only update status text
+    secondary.mock->setCommLost(true);
     QCOMPARE(multiSpy.waitForSignal(_linkStatusesChangedSignalName, VehicleLinkManager::kTestCommLostDetectionTimeoutMs),
              true);
     QVERIFY(multiSpy.onlyEmitted(_linkStatusesChangedSignalName));
 
     rgStatus = vehicleLinkManager->linkStatuses();
     QCOMPARE(rgStatus.count(), 2);
-    QVERIFY(rgStatus[0].isEmpty());
-    QVERIFY(!rgStatus[1].isEmpty());
+    QVERIFY(rgStatus[primaryIdx].isEmpty());
+    QVERIFY(!rgStatus[secondaryIdx].isEmpty());
 
     multiSpy.clearAllSignals();
 
-    pMockLink2->setCommLost(false);
+    secondary.mock->setCommLost(false);
     QCOMPARE(multiSpy.waitForSignal(_linkStatusesChangedSignalName, VehicleLinkManager::kTestCommLostDetectionTimeoutMs),
              true);
     QVERIFY(multiSpy.onlyEmitted(_linkStatusesChangedSignalName));
 
     rgStatus = vehicleLinkManager->linkStatuses();
     QCOMPARE(rgStatus.count(), 2);
-    QVERIFY(rgStatus[0].isEmpty());
-    QVERIFY(rgStatus[1].isEmpty());
+    QVERIFY(rgStatus[primaryIdx].isEmpty());
+    QVERIFY(rgStatus[secondaryIdx].isEmpty());
 
     multiSpy.clearAllSignals();
 
-    // Comm loss on 1: 1 is primary so should trigger switch of primary to 2
+    // Comm loss on the primary link should switch primary to the secondary
     // Switching primary produces a showAppMessage debug log.
     ignoreLogMessage("API.QGCApplication.AppMessage", QtDebugMsg,
                      QRegularExpression("Switching communication to secondary link"));
-    pMockLink1->setCommLost(true);
+    primary.mock->setCommLost(true);
     QCOMPARE(multiSpy.waitForSignal(_primaryLinkChangedSignalName, VehicleLinkManager::kTestCommLostDetectionTimeoutMs),
              true);
     QVERIFY(
         multiSpy.onlyEmittedOnce(_primaryLinkChangedSignalName, _linkStatusesChangedSignalName));
 
-    QCOMPARE(pMockLink2, vehicleLinkManager->primaryLink().lock().get());
+    QCOMPARE(secondary.mock, vehicleLinkManager->primaryLink().lock().get());
+    // Primary switch must not reorder the link list, otherwise the cached indices are invalid
+    QCOMPARE(vehicleLinkManager->linkNames(), rgNames);
     rgStatus = vehicleLinkManager->linkStatuses();
     QCOMPARE(rgStatus.count(), 2);
-    QVERIFY(!rgStatus[0].isEmpty());
-    QVERIFY(rgStatus[1].isEmpty());
+    QVERIFY(!rgStatus[primaryIdx].isEmpty());
+    QVERIFY(rgStatus[secondaryIdx].isEmpty());
 
     multiSpy.clearAllSignals();
 
-    // Comm regained on 1 should leave 2 as primary and only update status
-    pMockLink1->setCommLost(false);
+    // Comm regained on the original primary should leave the secondary as primary and only update status
+    primary.mock->setCommLost(false);
     QCOMPARE(multiSpy.waitForSignal(_linkStatusesChangedSignalName, VehicleLinkManager::kTestCommLostDetectionTimeoutMs),
              true);
     QVERIFY(multiSpy.onlyEmitted(_linkStatusesChangedSignalName));
 
-    QCOMPARE(pMockLink2, vehicleLinkManager->primaryLink().lock().get());
+    QCOMPARE(secondary.mock, vehicleLinkManager->primaryLink().lock().get());
     rgStatus = vehicleLinkManager->linkStatuses();
     QCOMPARE(rgStatus.count(), 2);
-    QVERIFY(rgStatus[0].isEmpty());
-    QVERIFY(rgStatus[1].isEmpty());
+    QVERIFY(rgStatus[primaryIdx].isEmpty());
+    QVERIFY(rgStatus[secondaryIdx].isEmpty());
 
     multiSpy.clearAllSignals();
 }


### PR DESCRIPTION
Fixes the intermittent `VehicleLinkManagerTest::_multiLinkSingleVehicleTest` failure seen in CI (e.g. on #15032):

```
FAIL!  : VehicleLinkManagerTest::_multiLinkSingleVehicleTest() Compared values are not the same
   Actual   (rgNames[0])         : "Mock 2"
   Expected (mockConfig1->name()): "Mock 1"
```

Whichever mock link delivers the first heartbeat becomes primary. The test handled that by swapping the `MockLink*` pointers, but left `mockConfig1`/`mockConfig2` unswapped, so the name assertions failed whenever "Mock 2" won the race.

Changes (test-only):
- Bundle config/link/mock into a local struct swapped as a unit so the per-link state can't drift.
- Look up `linkNames()`/`linkStatuses()` indices by name instead of assuming the primary link is at index 0 (the lists are in link-add order).
- Assert the link list order is unchanged after the primary switch, since the indices are cached.

Verified locally with `ctest -R VehicleLinkManagerTest --repeat until-fail:3`.
