### PR TITLE
fix(Comms): read link connection state from atomic flag, not thread-affine socket

### DIFF
--- a/src/Comms/LogReplayLink.h
+++ b/src/Comms/LogReplayLink.h
@@ -92,7 +92,7 @@ private:
     const LogReplayConfiguration *_logReplayConfig = nullptr;
     QTimer *_readTickTimer = nullptr;
 
-    bool _isConnected = false;
+    std::atomic<bool> _isConnected{false};
     uint8_t _mavlinkChannel = 0;
 
     quint64 _logCurrentTimeUSecs = 0;

--- a/src/Comms/SerialLink.cc
+++ b/src/Comms/SerialLink.cc
@@ -156,7 +156,8 @@ SerialWorker::~SerialWorker()
 
 bool SerialWorker::isConnected() const
 {
-    return (_port && _port->isOpen());
+    // Called cross-thread from SerialLink; must not touch the thread-affine _port
+    return _isConnected;
 }
 
 void SerialWorker::setupPort()
@@ -278,6 +279,7 @@ void SerialWorker::_onPortConnected()
         _timer->start(CONNECT_TIMEOUT_MS);
     }
 
+    _isConnected = true;
     _errorEmitted = false;
     emit connected();
 }
@@ -290,6 +292,7 @@ void SerialWorker::_onPortDisconnected()
         _timer->stop();
     }
 
+    _isConnected = false;
     _errorEmitted = false;
     emit disconnected();
 }

--- a/src/Comms/SerialLink.h
+++ b/src/Comms/SerialLink.h
@@ -133,6 +133,7 @@ private:
     const SerialConfiguration *_serialConfig = nullptr;
     QSerialPort *_port = nullptr;
     QTimer *_timer = nullptr;
+    std::atomic<bool> _isConnected{false};
     bool _errorEmitted = false;
 };
 

--- a/src/Comms/TCPLink.cc
+++ b/src/Comms/TCPLink.cc
@@ -100,7 +100,8 @@ TCPWorker::~TCPWorker()
 
 bool TCPWorker::isConnected() const
 {
-    return (_socket && _socket->isOpen() && (_socket->state() == QAbstractSocket::ConnectedState));
+    // Called cross-thread from TCPLink; must not touch the thread-affine _socket
+    return _isConnected;
 }
 
 void TCPWorker::setupSocket()
@@ -208,6 +209,7 @@ void TCPWorker::writeData(const QByteArray &data)
 void TCPWorker::_onSocketConnected()
 {
     qCDebug(TCPLinkLog) << "Socket connected:" << _config->host() << _config->port();
+    _isConnected = true;
     _errorEmitted = false;
     emit connected();
 }
@@ -215,6 +217,7 @@ void TCPWorker::_onSocketConnected()
 void TCPWorker::_onSocketDisconnected()
 {
     qCDebug(TCPLinkLog) << "Socket disconnected:" << _config->host() << _config->port();
+    _isConnected = false;
     _errorEmitted = false;
     emit disconnected();
 }

--- a/src/Comms/TCPLink.h
+++ b/src/Comms/TCPLink.h
@@ -82,6 +82,7 @@ private slots:
 private:
     const TCPConfiguration *_config = nullptr;
     QTcpSocket *_socket = nullptr;
+    std::atomic<bool> _isConnected{false};
     std::atomic<bool> _errorEmitted{false};
 };
 

--- a/src/Comms/UDPLink.cc
+++ b/src/Comms/UDPLink.cc
@@ -293,7 +293,8 @@ UDPWorker::~UDPWorker()
 
 bool UDPWorker::isConnected() const
 {
-    return (_socket && _socket->isValid() && _isConnected);
+    // Called cross-thread from UDPLink; must not touch the thread-affine _socket
+    return _isConnected;
 }
 
 void UDPWorker::setupSocket()

--- a/src/Comms/UDPLink.h
+++ b/src/Comms/UDPLink.h
@@ -138,7 +138,7 @@ private:
     QUdpSocket *_socket = nullptr;
     QMutex _sessionTargetsMutex;
     QList<std::shared_ptr<UDPClient>> _sessionTargets;
-    bool _isConnected = false;
+    std::atomic<bool> _isConnected{false};
     bool _errorEmitted = false;
     QSet<QHostAddress> _localAddresses;
 


### PR DESCRIPTION
Fixes #15016

## Problem

`UDPWorker::isConnected()` (and the TCP/Serial equivalents) is called from the main thread via `LinkInterface::isConnected()` and the link destructors, but it dereferenced the worker-thread-owned socket:

```cpp
return (_socket && _socket->isValid() && _isConnected);
```

`QAbstractSocket::isValid()` is a virtual call through `d->socketEngine`. During shutdown, `QAbstractSocket::disconnectFromHost()` on the worker thread emits `stateChanged(ClosingState)` (which queues our `disconnected` to the main thread) *before* it runs `resetSocketLayer()` and deletes the engine. The main thread picks up the queued signal, `LinkManager::_linkDisconnected()` drops the last `shared_ptr`, `~UDPLink()` calls `isConnected()`, and lands on the engine while the worker is mid-`delete` — hence the garbage frame 0 in the crash report.

## Fix

Each worker tracks connection state in a `std::atomic<bool>` that is set/cleared from its own socket signal handlers (`_onSocketConnected` / `_onSocketDisconnected`). `isConnected()` returns only that flag and never touches the thread-affine socket.

Applied uniformly:
- **UDP** — existing `_isConnected` made atomic; dropped `_socket->isValid()`.
- **TCP** — new atomic flag; dropped `_socket->isOpen() && state() == ConnectedState`.
- **Serial** — new atomic flag; dropped `_port->isOpen()`.
- **LogReplay** — existing flag made atomic (was already the only thing read).
- **Bluetooth** — already used this pattern; unchanged.

No behavioral change: the flags flip on exactly the signals that previously drove the socket-state checks.

## Testing

- `just build` clean.
- `ctest -R "Link|Serial|LogReplay"` — 20/20 pass.
