### PR TITLE
fix(Comms): read link connection state from atomic flag, not thread-affine socket (Stable_V5.1)

### DIFF
--- a/src/Comms/LogReplayLink.h
+++ b/src/Comms/LogReplayLink.h
@@ -92,7 +92,7 @@ private:
     const LogReplayConfiguration *_logReplayConfig = nullptr;
     QTimer *_readTickTimer = nullptr;
 
-    bool _isConnected = false;
+    std::atomic<bool> _isConnected{false};
     uint8_t _mavlinkChannel = 0;
 
     quint64 _logCurrentTimeUSecs = 0;

--- a/src/Comms/SerialLink.cc
+++ b/src/Comms/SerialLink.cc
@@ -212,7 +212,8 @@ SerialWorker::~SerialWorker()
 
 bool SerialWorker::isConnected() const
 {
-    return (_port && _port->isOpen());
+    // Called cross-thread from SerialLink; must not touch the thread-affine _port
+    return _isConnected;
 }
 
 void SerialWorker::setupPort()
@@ -334,6 +335,7 @@ void SerialWorker::_onPortConnected()
         _timer->start(CONNECT_TIMEOUT_MS);
     }
 
+    _isConnected = true;
     _errorEmitted = false;
     emit connected();
 }
@@ -346,6 +348,7 @@ void SerialWorker::_onPortDisconnected()
         _timer->stop();
     }
 
+    _isConnected = false;
     _errorEmitted = false;
     emit disconnected();
 }

--- a/src/Comms/SerialLink.h
+++ b/src/Comms/SerialLink.h
@@ -133,6 +133,7 @@ private:
     const SerialConfiguration *_serialConfig = nullptr;
     QSerialPort *_port = nullptr;
     QTimer *_timer = nullptr;
+    std::atomic<bool> _isConnected{false};
     bool _errorEmitted = false;
 };
 

--- a/src/Comms/TCPLink.cc
+++ b/src/Comms/TCPLink.cc
@@ -100,7 +100,8 @@ TCPWorker::~TCPWorker()
 
 bool TCPWorker::isConnected() const
 {
-    return (_socket && _socket->isOpen() && (_socket->state() == QAbstractSocket::ConnectedState));
+    // Called cross-thread from TCPLink; must not touch the thread-affine _socket
+    return _isConnected;
 }
 
 void TCPWorker::setupSocket()
@@ -208,6 +209,7 @@ void TCPWorker::writeData(const QByteArray &data)
 void TCPWorker::_onSocketConnected()
 {
     qCDebug(TCPLinkLog) << "Socket connected:" << _config->host() << _config->port();
+    _isConnected = true;
     _errorEmitted = false;
     emit connected();
 }
@@ -215,6 +217,7 @@ void TCPWorker::_onSocketConnected()
 void TCPWorker::_onSocketDisconnected()
 {
     qCDebug(TCPLinkLog) << "Socket disconnected:" << _config->host() << _config->port();
+    _isConnected = false;
     _errorEmitted = false;
     emit disconnected();
 }

--- a/src/Comms/TCPLink.h
+++ b/src/Comms/TCPLink.h
@@ -82,6 +82,7 @@ private slots:
 private:
     const TCPConfiguration *_config = nullptr;
     QTcpSocket *_socket = nullptr;
+    std::atomic<bool> _isConnected{false};
     std::atomic<bool> _errorEmitted{false};
 };
 

--- a/src/Comms/UDPLink.cc
+++ b/src/Comms/UDPLink.cc
@@ -293,7 +293,8 @@ UDPWorker::~UDPWorker()
 
 bool UDPWorker::isConnected() const
 {
-    return (_socket && _socket->isValid() && _isConnected);
+    // Called cross-thread from UDPLink; must not touch the thread-affine _socket
+    return _isConnected;
 }
 
 void UDPWorker::setupSocket()

--- a/src/Comms/UDPLink.h
+++ b/src/Comms/UDPLink.h
@@ -138,7 +138,7 @@ private:
     QUdpSocket *_socket = nullptr;
     QMutex _sessionTargetsMutex;
     QList<std::shared_ptr<UDPClient>> _sessionTargets;
-    bool _isConnected = false;
+    std::atomic<bool> _isConnected{false};
     bool _errorEmitted = false;
     QSet<QHostAddress> _localAddresses;
 


### PR DESCRIPTION
Backport of #15069 to Stable_V5.1.

Fixes #15016