### PR TITLE
build(mavlink): drop MAVLINK_BUILD_DATE from generated version.h

### DIFF
--- a/src/MAVLink/mavlink-deterministic-mavgen.patch
+++ b/src/MAVLink/mavlink-deterministic-mavgen.patch
@@ -29,3 +29,12 @@
 -
 +
  # Unfortunately, the dependencies don't work for INTERFACE libraries.
+--- a/pymavlink/generator/mavgen_c.py
++++ b/pymavlink/generator/mavgen_c.py
+@@ -24,6 +24,5 @@ def generate_version_h(directory, xml):
+ #ifndef MAVLINK_VERSION_H
+ #define MAVLINK_VERSION_H
+
+-#define MAVLINK_BUILD_DATE "${parse_time}"
+ #define MAVLINK_WIRE_PROTOCOL_VERSION "${wire_protocol_version}"
+ #define MAVLINK_MAX_DIALECT_PAYLOAD_SIZE ${largest_payload}


### PR DESCRIPTION
Fixes #15070

mavgen stamps `include/mavlink/all/version.h` with the current day (`#define MAVLINK_BUILD_DATE "Wed Sep 09 2026"`). Any regeneration on a new day rewrites the header, and since nearly every QGC header including `MAVLinkLib.h` transitively includes `version.h`, this invalidates moccache for every moc'd header in that subtree and ccache for every TU that includes it.

Nothing in QGC (`src/`, `test/`) or the MAVLink C library itself references `MAVLINK_BUILD_DATE`, so this extends `src/MAVLink/mavlink-deterministic-mavgen.patch` with a hunk that removes the define from the `version.h` template in `pymavlink/generator/mavgen_c.py`. `version.h` is now byte-stable across regenerations, so mavgen re-runs (mtime churn, clean builds, CI, different build trees) are full moccache + ccache hits for the MAVLink-including subtree.

Verified `git apply --check` against the pinned MAVLink commit (`c409cf6`, pymavlink `5977f44`). `qgc_cpm_patch_cache_key` hashes patch contents, so the next configure automatically re-fetches and re-patches.
