### PR TITLE
fix(Android): save videos and photos directly to MediaStore

### DIFF
--- a/android/proguard-rules.pro
+++ b/android/proguard-rules.pro
@@ -21,6 +21,7 @@
 -keep class org.mavlink.qgroundcontrol.QGCUsbId { *; }
 -keep class org.mavlink.qgroundcontrol.QGCUsbSerialProber { *; }
 -keep class org.mavlink.qgroundcontrol.QGCLogger { *; }
+-keep class org.mavlink.qgroundcontrol.QGCMediaStore { *; }
 -keep class org.mavlink.qgroundcontrol.QGCFtdiSerialDriver { *; }
 -keep class org.mavlink.qgroundcontrol.QGCFtdiSerialDriver$QGCFtdiSerialPort { *; }
 -keep class org.mavlink.qgroundcontrol.QGCFtdiDriver { *; }

--- a/android/src/org/mavlink/qgroundcontrol/QGCMediaStore.java
+++ b/android/src/org/mavlink/qgroundcontrol/QGCMediaStore.java
@@ -1,0 +1,213 @@
+package org.mavlink.qgroundcontrol;
+
+import android.content.ContentResolver;
+import android.content.ContentUris;
+import android.content.ContentValues;
+import android.content.Context;
+import android.database.Cursor;
+import android.net.Uri;
+import android.os.Build;
+import android.os.Environment;
+import android.os.ParcelFileDescriptor;
+import android.provider.MediaStore;
+
+import androidx.annotation.RequiresApi;
+
+import java.io.IOException;
+import java.util.Locale;
+
+/** Owns a pending media item and lends its descriptor to the native writer. */
+public final class QGCMediaStore {
+    private static final String TAG = QGCMediaStore.class.getSimpleName();
+    private static final String VIDEO_DIRECTORY = Environment.DIRECTORY_MOVIES + "/QGroundControl/";
+    private static final String IMAGE_DIRECTORY = Environment.DIRECTORY_PICTURES + "/QGroundControl/";
+
+    private final ContentResolver m_resolver;
+    private final Uri m_uri;
+    private ParcelFileDescriptor m_descriptor;
+
+    private QGCMediaStore(ContentResolver resolver, Uri uri, ParcelFileDescriptor descriptor) {
+        m_resolver = resolver;
+        m_uri = uri;
+        m_descriptor = descriptor;
+    }
+
+    public static QGCMediaStore createVideo(Context context, String displayName) {
+        if (Build.VERSION.SDK_INT < Build.VERSION_CODES.Q || context == null) {
+            return null;
+        }
+
+        return create(context, displayName, videoMimeType(displayName), videoCollection(), VIDEO_DIRECTORY);
+    }
+
+    public static QGCMediaStore createImage(Context context, String displayName) {
+        if (Build.VERSION.SDK_INT < Build.VERSION_CODES.Q || context == null) {
+            return null;
+        }
+
+        final Uri collection = MediaStore.Images.Media.getContentUri(MediaStore.VOLUME_EXTERNAL_PRIMARY);
+        return create(context, displayName, imageMimeType(displayName), collection, IMAGE_DIRECTORY);
+    }
+
+    private static QGCMediaStore create(Context context, String displayName, String mimeType,
+                                       Uri collection, String directory) {
+        if (mimeType == null || displayName.contains("/") || displayName.contains("\\")) {
+            QGCLogger.w(TAG, "Invalid media name: " + displayName);
+            return null;
+        }
+
+        final ContentResolver resolver = context.getContentResolver();
+        Uri uri = null;
+        try {
+            final ContentValues values = new ContentValues();
+            values.put(MediaStore.MediaColumns.DISPLAY_NAME, displayName);
+            values.put(MediaStore.MediaColumns.MIME_TYPE, mimeType);
+            values.put(MediaStore.MediaColumns.RELATIVE_PATH, directory);
+            values.put(MediaStore.MediaColumns.IS_PENDING, 1);
+            uri = resolver.insert(collection, values);
+            if (uri == null) {
+                throw new IOException("MediaStore did not create a media item");
+            }
+            final ParcelFileDescriptor descriptor = resolver.openFileDescriptor(uri, "rw");
+            if (descriptor == null) {
+                throw new IOException("MediaStore did not open the media item");
+            }
+            QGCLogger.i(TAG, "Writing directly to " + uri);
+            return new QGCMediaStore(resolver, uri, descriptor);
+        } catch (IOException | RuntimeException e) {
+            QGCLogger.e(TAG, "Cannot create gallery media", e);
+            if (uri != null) {
+                deletePending(resolver, uri);
+            }
+            return null;
+        }
+    }
+
+    public int fileDescriptor() {
+        return m_descriptor != null ? m_descriptor.getFd() : -1;
+    }
+
+    /** Called only after the native writer has stopped using the borrowed descriptor. */
+    public boolean finish(boolean finalized) {
+        if (m_descriptor == null) {
+            return false;
+        }
+        final long size;
+        try (ParcelFileDescriptor descriptor = m_descriptor) {
+            m_descriptor = null;
+            size = descriptor.getStatSize();
+        } catch (IOException | RuntimeException e) {
+            QGCLogger.e(TAG, "Cannot close gallery media: " + m_uri, e);
+            return false;
+        }
+        try {
+            if (size == 0) {
+                deletePending(m_resolver, m_uri);
+                return false;
+            }
+            if (!finalized || size < 0) {
+                // Do not destroy potentially recoverable data or expose an unfinished video.
+                // Android's pending-item expiry still applies; crash recovery is separate.
+                QGCLogger.w(TAG, "Media not finalized; leaving pending: " + m_uri);
+                return false;
+            }
+            final ContentValues values = new ContentValues();
+            values.put(MediaStore.MediaColumns.IS_PENDING, 0);
+            if (m_resolver.update(m_uri, values, null, null) != 1) {
+                QGCLogger.w(TAG, "MediaStore did not publish the media item: " + m_uri);
+                return false;
+            }
+            QGCLogger.i(TAG, "Published gallery media: " + m_uri);
+            return true;
+        } catch (RuntimeException e) {
+            QGCLogger.e(TAG, "Cannot publish gallery media: " + m_uri, e);
+            return false;
+        }
+    }
+
+    /** Discard a known failed write without deleting any published item. */
+    public void discard() {
+        final ParcelFileDescriptor descriptor = m_descriptor;
+        m_descriptor = null;
+        try {
+            if (descriptor != null) {
+                descriptor.close();
+            }
+        } catch (IOException | RuntimeException e) {
+            QGCLogger.e(TAG, "Cannot close failed gallery media: " + m_uri, e);
+        }
+        deletePending(m_resolver, m_uri);
+    }
+
+    public static void cleanupOldVideos(Context context, long maxBytes) {
+        if (Build.VERSION.SDK_INT < Build.VERSION_CODES.Q || context == null || maxBytes <= 0) {
+            return;
+        }
+
+        final ContentResolver resolver = context.getContentResolver();
+        final Uri collection = videoCollection();
+        final String[] projection = {MediaStore.Video.Media._ID, MediaStore.Video.Media.SIZE};
+        // Never delete another app's media or a recording still being finalized.
+        final String selection = MediaStore.Video.Media.OWNER_PACKAGE_NAME + " = ? AND "
+                + MediaStore.Video.Media.RELATIVE_PATH + " = ? AND "
+                + MediaStore.Video.Media.IS_PENDING + " = 0";
+        final String[] selectionArgs = {context.getPackageName(), VIDEO_DIRECTORY};
+        final String sort = MediaStore.Video.Media.DATE_ADDED + " DESC, " + MediaStore.Video.Media._ID + " DESC";
+        try (Cursor cursor = resolver.query(collection, projection, selection, selectionArgs, sort)) {
+            if (cursor == null) {
+                return;
+            }
+            long total = 0;
+            while (cursor.moveToNext()) {
+                total += cursor.getLong(1);
+            }
+            while (total >= maxBytes && cursor.moveToPrevious()) {
+                final Uri uri = ContentUris.withAppendedId(collection, cursor.getLong(0));
+                if (resolver.delete(uri, selection, selectionArgs) == 1) {
+                    total -= cursor.getLong(1);
+                    QGCLogger.i(TAG, "Storage limit removed old recording: " + uri);
+                }
+            }
+        } catch (RuntimeException e) {
+            QGCLogger.e(TAG, "Cannot enforce gallery recording storage limit", e);
+        }
+    }
+
+    static String videoMimeType(String displayName) {
+        if (displayName == null) {
+            return null;
+        }
+        final String name = displayName.toLowerCase(Locale.ROOT);
+        if (name.endsWith(".mp4")) {
+            return "video/mp4";
+        }
+        if (name.endsWith(".mov")) {
+            return "video/quicktime";
+        }
+        if (name.endsWith(".mkv")) {
+            return "video/x-matroska";
+        }
+        return null;
+    }
+
+    static String imageMimeType(String displayName) {
+        if (displayName == null) {
+            return null;
+        }
+        final String name = displayName.toLowerCase(Locale.ROOT);
+        return name.endsWith(".jpg") || name.endsWith(".jpeg") ? "image/jpeg" : null;
+    }
+
+    @RequiresApi(Build.VERSION_CODES.Q)
+    private static Uri videoCollection() {
+        return MediaStore.Video.Media.getContentUri(MediaStore.VOLUME_EXTERNAL_PRIMARY);
+    }
+
+    private static void deletePending(ContentResolver resolver, Uri uri) {
+        try {
+            resolver.delete(uri, MediaStore.MediaColumns.IS_PENDING + " = 1", null);
+        } catch (RuntimeException e) {
+            QGCLogger.e(TAG, "Cannot remove pending media: " + uri, e);
+        }
+    }
+}

--- a/android/src/test/java/org/mavlink/qgroundcontrol/QGCMediaStoreTest.java
+++ b/android/src/test/java/org/mavlink/qgroundcontrol/QGCMediaStoreTest.java
@@ -1,0 +1,41 @@
+package org.mavlink.qgroundcontrol;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
+
+import org.junit.Test;
+
+public class QGCMediaStoreTest {
+    @Test
+    public void videoMimeType_matchesSupportedRecordingFormats() {
+        final String[][] cases = {
+            {"2026-09-10_12.00.00.123.mp4", "video/mp4"},
+            {"2026-09-10_12.00.00.123.thermalVideo.mov", "video/quicktime"},
+            {"video.MKV", "video/x-matroska"}
+        };
+        for (String[] entry : cases) {
+            assertEquals(entry[0], entry[1], QGCMediaStore.videoMimeType(entry[0]));
+        }
+    }
+
+    @Test
+    public void videoMimeType_rejectsUnknownFormats() {
+        for (String name : new String[]{null, "", "video", "video.mp4.tmp", "photo.jpg"}) {
+            assertNull(QGCMediaStore.videoMimeType(name));
+        }
+    }
+
+    @Test
+    public void imageMimeType_matchesJpegSnapshots() {
+        for (String name : new String[]{"2026-09-10_15.07.20.921.jpg", "photo.jpeg", "photo.JPG"}) {
+            assertEquals(name, "image/jpeg", QGCMediaStore.imageMimeType(name));
+        }
+    }
+
+    @Test
+    public void imageMimeType_rejectsNonJpegFormats() {
+        for (String name : new String[]{null, "", "photo", "photo.jpg.tmp", "photo.png", "video.mp4"}) {
+            assertNull(QGCMediaStore.imageMimeType(name));
+        }
+    }
+}

--- a/src/Android/AndroidMediaStore.cc
+++ b/src/Android/AndroidMediaStore.cc
@@ -1,0 +1,76 @@
+#include "AndroidMediaStore.h"
+
+#include <QtCore/QCoreApplication>
+
+namespace {
+constexpr const char* kMediaStoreClass = "org/mavlink/qgroundcontrol/QGCMediaStore";
+}
+
+AndroidMediaStore::~AndroidMediaStore()
+{
+    if (_entry.isValid()) {
+        (void) finish(false);
+    }
+}
+
+bool AndroidMediaStore::isSupported()
+{
+    return QNativeInterface::QAndroidApplication::sdkVersion() >= 29;
+}
+
+bool AndroidMediaStore::openVideo(const QString& fileName)
+{
+    return _open("createVideo", fileName);
+}
+
+bool AndroidMediaStore::openImage(const QString& fileName)
+{
+    return _open("createImage", fileName);
+}
+
+bool AndroidMediaStore::_open(const char* factoryMethod, const QString& fileName)
+{
+    if (_entry.isValid() || !isSupported()) {
+        return false;
+    }
+    const QJniObject context = QNativeInterface::QAndroidApplication::context();
+    const QJniObject name = QJniObject::fromString(fileName);
+    _entry = QJniObject::callStaticObjectMethod(
+        kMediaStoreClass, factoryMethod,
+        "(Landroid/content/Context;Ljava/lang/String;)Lorg/mavlink/qgroundcontrol/QGCMediaStore;", context.object(),
+        name.object<jstring>());
+    return _entry.isValid() && fileDescriptor() >= 0;
+}
+
+int AndroidMediaStore::fileDescriptor() const
+{
+    return _entry.isValid() ? _entry.callMethod<jint>("fileDescriptor", "()I") : -1;
+}
+
+bool AndroidMediaStore::finish(bool finalized)
+{
+    if (!_entry.isValid()) {
+        return false;
+    }
+    const bool published = _entry.callMethod<jboolean>("finish", "(Z)Z", static_cast<jboolean>(finalized));
+    _entry = QJniObject();
+    return published;
+}
+
+void AndroidMediaStore::discard()
+{
+    if (_entry.isValid()) {
+        _entry.callMethod<void>("discard", "()V");
+        _entry = QJniObject();
+    }
+}
+
+void AndroidMediaStore::cleanupOldVideos(qint64 maxBytes)
+{
+    if (!isSupported()) {
+        return;
+    }
+    const QJniObject context = QNativeInterface::QAndroidApplication::context();
+    QJniObject::callStaticMethod<void>(kMediaStoreClass, "cleanupOldVideos", "(Landroid/content/Context;J)V",
+                                       context.object(), static_cast<jlong>(maxBytes));
+}

--- a/src/Android/AndroidMediaStore.h
+++ b/src/Android/AndroidMediaStore.h
@@ -1,0 +1,26 @@
+#pragma once
+
+#include <QtCore/QJniObject>
+#include <QtCore/QString>
+
+class AndroidMediaStore
+{
+public:
+    AndroidMediaStore() = default;
+    ~AndroidMediaStore();
+    Q_DISABLE_COPY_MOVE(AndroidMediaStore)
+
+    static bool isSupported();
+    static void cleanupOldVideos(qint64 maxBytes);
+
+    bool openVideo(const QString& fileName);
+    bool openImage(const QString& fileName);
+    int fileDescriptor() const;
+    bool finish(bool finalized);
+    void discard();
+
+private:
+    bool _open(const char* factoryMethod, const QString& fileName);
+
+    QJniObject _entry;
+};

--- a/src/Android/CMakeLists.txt
+++ b/src/Android/CMakeLists.txt
@@ -15,6 +15,8 @@ target_sources(${CMAKE_PROJECT_NAME}
         AndroidInit.cc
         AndroidInterface.cc
         AndroidInterface.h
+        AndroidMediaStore.cc
+        AndroidMediaStore.h
         AndroidSerial.cc
         AndroidSerial.h
 )

--- a/src/FlyView/FlightDisplayViewVideoOutput.qml
+++ b/src/FlyView/FlightDisplayViewVideoOutput.qml
@@ -4,6 +4,8 @@ import QtMultimedia
 import QGroundControl
 
 VideoOutput {
+    id: root
+
     objectName: "videoContent"
 
     // Do NOT set `orientation` here — VideoOutput composes orientation on top of the
@@ -19,8 +21,11 @@ VideoOutput {
     Connections {
         target: QGroundControl.videoManager
         function onImageFileChanged(filename) {
-            grabToImage(function(result) {
-                if (!result.saveToFile(filename)) {
+            if (root.objectName !== "videoContent") {
+                return;
+            }
+            root.grabToImage(function(result) {
+                if (!QGroundControl.videoManager.saveImage(filename, result.image)) {
                     console.error('Error capturing video frame');
                 }
             });

--- a/src/VideoManager/VideoManager.cc
+++ b/src/VideoManager/VideoManager.cc
@@ -25,12 +25,18 @@
 #include <QtCore/QCoreApplication>
 #include <QtCore/QDir>
 #include <QtCore/QEventLoop>
+#include <QtCore/QFile>
+#include <QtCore/QFileInfo>
 #include <QtCore/QFutureWatcher>
 #include <QtCore/QRunnable>
 #include <QtCore/QTimer>
 #include <QtQml/QQmlEngine>
 #include <QtQuick/QQuickItem>
 #include <QtQuick/QQuickWindow>
+
+#if defined(Q_OS_ANDROID) && defined(QGC_GST_STREAMING)
+#include "AndroidMediaStore.h"
+#endif
 
 QGC_LOGGING_CATEGORY(VideoManagerLog, "Video.VideoManager")
 
@@ -318,6 +324,14 @@ void VideoManager::_cleanupOldVideos()
         return;
     }
 
+#if defined(Q_OS_ANDROID) && defined(QGC_GST_STREAMING)
+    if (!isUvc() && AndroidMediaStore::isSupported()) {
+        const qint64 maxBytes = _videoSettings->maxVideoSize()->rawValue().toLongLong() * 1024 * 1024;
+        AndroidMediaStore::cleanupOldVideos(maxBytes);
+        return;
+    }
+#endif
+
     const QString savePath = SettingsManager::instance()->appSettings()->videoSavePath();
     QDir videoDir = QDir(savePath);
     videoDir.setFilter(QDir::Files | QDir::Readable | QDir::NoSymLinks | QDir::Writable);
@@ -365,7 +379,8 @@ void VideoManager::startRecording(const QString &videoFile)
         return;
     }
 
-    const QString videoFileUrl = videoFile.isEmpty() ? QDateTime::currentDateTime().toString("yyyy-MM-dd_hh.mm.ss") : videoFile;
+    const QString videoFileUrl =
+        videoFile.isEmpty() ? QDateTime::currentDateTime().toString("yyyy-MM-dd_hh.mm.ss.zzz") : videoFile;
     const QString ext = kFileExtension[fileFormat];
 
     const QString videoFileNameTemplate = savePath + "/" + videoFileUrl + ".%1" + ext;
@@ -403,6 +418,39 @@ void VideoManager::grabImage(const QString &imageFile)
         receiver->takeScreenshot(_imageFile);
         // QSharedPointer<QQuickItemGrabResult> result = receiver->widget()->grabToImage(const QSize &targetSize = QSize())
     }
+}
+
+bool VideoManager::saveImage(const QString& imageFile, const QImage& image)
+{
+    if (image.isNull() || imageFile.isEmpty()) {
+        return false;
+    }
+
+#if defined(Q_OS_ANDROID) && defined(QGC_GST_STREAMING)
+    if (!isUvc() && AndroidMediaStore::isSupported()) {
+        // The path supplies only the display name. Encode directly into the pending
+        // Gallery item, without also writing a copy under Android/data.
+        AndroidMediaStore mediaStore;
+        if (mediaStore.openImage(QFileInfo(imageFile).fileName())) {
+            QFile output;
+            if (output.open(mediaStore.fileDescriptor(), QIODevice::WriteOnly, QFileDevice::DontCloseHandle)) {
+                const bool saved = image.save(&output, "JPEG") && output.flush();
+                output.close();  // Java owns the descriptor and closes it before publication.
+                if (saved) {
+                    return mediaStore.finish(true);
+                }
+            }
+        }
+        // A failed JPEG write is not a recoverable recording. Remove only this
+        // request's pending item, and never fall back to an invisible private copy.
+        mediaStore.discard();
+        return false;
+    }
+#endif
+
+    // The QtMultimedia-only backend also has its own snapshot writer; keep its
+    // existing destination until the capture/completion paths are unified.
+    return image.save(imageFile);
 }
 
 double VideoManager::aspectRatio() const
@@ -942,6 +990,19 @@ void VideoManager::_initVideoReceiver(VideoReceiver *receiver, QQuickWindow *win
         qCDebug(VideoManagerLog) << "Video" << receiver->name() << "recording started";
         if (!receiver->isThermal()) {
             _subtitleWriter->startCapturingTelemetry(filename, videoSize());
+        }
+    });
+
+    (void) connect(receiver, &VideoReceiver::onStartRecordingComplete, this, [](VideoReceiver::STATUS status) {
+        if (status == VideoReceiver::STATUS_FAIL || status == VideoReceiver::STATUS_INVALID_URL) {
+            QGC::showAppMessage(tr("Unable to start video recording. Check available storage and application logs."));
+        }
+    });
+
+    (void) connect(receiver, &VideoReceiver::onStopRecordingComplete, this, [](VideoReceiver::STATUS status) {
+        if (status == VideoReceiver::STATUS_FAIL) {
+            QGC::showAppMessage(
+                tr("Video recording could not be saved. Check available storage and application logs."));
         }
     });
 

--- a/src/VideoManager/VideoManager.h
+++ b/src/VideoManager/VideoManager.h
@@ -8,6 +8,7 @@
 #include <QtCore/QPromise>
 #include <QtCore/QObject>
 #include <QtCore/QSize>
+#include <QtGui/QImage>
 #include <QtQmlIntegration/QtQmlIntegration>
 
 #ifdef QGC_UNITTEST_BUILD
@@ -53,6 +54,7 @@ public:
     static VideoManager *instance();
 
     Q_INVOKABLE void grabImage(const QString &imageFile = QString());
+    Q_INVOKABLE bool saveImage(const QString& imageFile, const QImage& image);
     Q_INVOKABLE void startRecording(const QString &videoFile = QString());
     Q_INVOKABLE void startVideo();
     Q_INVOKABLE void stopRecording();
@@ -123,7 +125,7 @@ private:
     void _restartVideo(VideoReceiver *receiver);
     void _startReceiver(VideoReceiver *receiver);
     void _stopReceiver(VideoReceiver *receiver);
-    static void _cleanupOldVideos();
+    void _cleanupOldVideos();
 
     QList<VideoReceiver*> _videoReceivers;
     SubtitleWriter *_subtitleWriter = nullptr;

--- a/src/VideoManager/VideoReceiver/GStreamer/GstVideoReceiver.cc
+++ b/src/VideoManager/VideoReceiver/GStreamer/GstVideoReceiver.cc
@@ -18,6 +18,7 @@
 #include "QGCQVideoSinkController.h"
 
 #include <QtCore/QDateTime>
+#include <QtCore/QFileInfo>
 #include <QtCore/QMutexLocker>
 #include <QtCore/QUrl>
 #include <QtQuick/QQuickItem>
@@ -333,6 +334,7 @@ void GstVideoReceiver::stop()
     }
 
     if (_pipeline) {
+        bool recordingFinalized = _recordingFragmentClosed.load();
         GstBus *bus = gst_pipeline_get_bus(GST_PIPELINE(_pipeline));
         if (bus) {
             gst_bus_disable_sync_message_emission(bus);
@@ -341,13 +343,14 @@ void GstVideoReceiver::stop()
             gboolean recordingValveClosed = TRUE;
             g_object_get(_recorderValve, "drop", &recordingValveClosed, nullptr);
 
-            if (!recordingValveClosed) {
-                (void) gst_element_send_event(_pipeline, gst_event_new_eos());
+            if (_fileSink && !recordingFinalized) {
+                if (!recordingValveClosed) {
+                    (void) gst_element_send_event(_pipeline, gst_event_new_eos());
+                }
 
-                // Wait for splitmuxsink to actually finalize its current fragment. async-finalize
-                // pushes muxer teardown off the streaming thread; the splitmuxsink-fragment-closed
-                // element message is posted (via message-forward=TRUE) exactly when the muxer's
-                // state has gone NULL. EOS is the fallback for older builds / unexpected paths;
+                // Wait for splitmuxsink to finalize its current fragment. The fragment-closed
+                // message follows the sink's EOS; we still wait for NULL below before closing
+                // a borrowed descriptor. EOS is the fallback for older builds / unexpected paths;
                 // ERROR breaks out so we don't burn the full budget on a known failure. Track
                 // elapsed time so unrelated ELEMENT messages don't abort the wait early.
                 const GstClockTime deadline = kEosTimeoutNs;
@@ -367,12 +370,14 @@ void GstVideoReceiver::stop()
                         if (s && gst_structure_has_name(s, "splitmuxsink-fragment-closed")) {
                             qCDebug(GstVideoReceiverLog) << "splitmuxsink fragment finalized";
                             finalized = true;
+                            recordingFinalized = true;
                         }
                         break;
                     }
                     case GST_MESSAGE_EOS:
                         qCDebug(GstVideoReceiverLog) << "End of stream received (fallback path)";
                         finalized = true;
+                        recordingFinalized = true;
                         break;
                     case GST_MESSAGE_ERROR:
                         qCCritical(GstVideoReceiverLog) << "Error stopping pipeline!";
@@ -385,10 +390,9 @@ void GstVideoReceiver::stop()
                     if (finalized) break;
                 }
                 if (!finalized) {
-                    qCWarning(GstVideoReceiverLog) << "splitmuxsink finalize signal not received within"
-                                                   << (kEosTimeoutNs / GST_MSECOND)
-                                                   << "ms — forcing pipeline NULL (recording may be truncated; "
-                                                   << "faststart + reserved-moov-update-period keep the file playable)";
+                    qCWarning(GstVideoReceiverLog)
+                        << "splitmuxsink finalize signal not received within" << (kEosTimeoutNs / GST_MSECOND)
+                        << "ms — forcing pipeline NULL (recording may be incomplete)";
                 }
             }
 
@@ -402,7 +406,7 @@ void GstVideoReceiver::stop()
 
         // FIXME: check if branch is connected and remove all elements from branch
         if (_fileSink) {
-           _shutdownRecordingBranch();
+            _shutdownRecordingBranch(recordingFinalized);
         }
 
         if (_videoSink) {
@@ -594,8 +598,24 @@ void GstVideoReceiver::startRecording(const QString &videoFile, FILE_FORMAT form
             }
             gst_clear_object(&_fileSink);
         }
+#ifdef Q_OS_ANDROID
+        (void) _mediaStore.finish(false);
+#endif
         emit onStartRecordingComplete(STATUS_FAIL);
     };
+
+    int fileDescriptor = -1;
+    _recordingFragmentClosed = false;
+#ifdef Q_OS_ANDROID
+    if (AndroidMediaStore::isSupported()) {
+        if (!_mediaStore.openVideo(QFileInfo(videoFile).fileName())) {
+            qCWarning(GstVideoReceiverLog) << "Cannot open MediaStore recording";
+            failRecordingStart();
+            return;
+        }
+        fileDescriptor = _mediaStore.fileDescriptor();
+    }
+#endif
 
     // forward-sticky-events preserves the exact negotiated caps while the valve is closed. Fall
     // back to a proxied caps query during the narrow startup window before negotiation completes.
@@ -603,7 +623,7 @@ void GstVideoReceiver::startRecording(const QString &videoFile, FILE_FORMAT form
     if (!inputCaps) {
         inputCaps = gst_pad_query_caps(probepad, nullptr);
     }
-    _fileSink = _makeFileSink(videoFile, format, inputCaps);
+    _fileSink = _makeFileSink(videoFile, format, inputCaps, fileDescriptor);
     gst_clear_caps(&inputCaps);
     if (!_fileSink) {
         qCCritical(GstVideoReceiverLog) << "_makeFileSink() failed" << _uri;
@@ -634,6 +654,10 @@ void GstVideoReceiver::startRecording(const QString &videoFile, FILE_FORMAT form
 
     GST_DEBUG_BIN_TO_DOT_FILE(GST_BIN(_pipeline), GST_DEBUG_GRAPH_SHOW_ALL, "pipeline-with-filesink");
 
+    _recordingOutput = videoFile;  // Keep the local basename for the telemetry subtitle sidecar.
+    _recordingHasKeyframe = false;
+    _recordingStopRequested = false;
+
     // Install a probe on the recording branch to drop buffers until we hit our first keyframe
     // When we hit our first keyframe, we can offset the timestamps appropriately according to the first keyframe time
     // This will ensure the first frame is a keyframe at t=0, and decoding can begin immediately on playback
@@ -649,7 +673,6 @@ void GstVideoReceiver::startRecording(const QString &videoFile, FILE_FORMAT form
                  "drop", FALSE,
                  nullptr);
 
-    _recordingOutput = videoFile;
     _recording = true;
     qCDebug(GstVideoReceiverLog) << "Recording started" << _uri;
     emit onStartRecordingComplete(STATUS_OK);
@@ -831,7 +854,7 @@ void GstVideoReceiver::_handleEOS()
     } else if (_decoding && _removingDecoder) {
         _shutdownDecodingBranch();
     } else if (_recording && _removingRecorder) {
-        _shutdownRecordingBranch();
+        _shutdownRecordingBranch(_recordingFragmentClosed.load());
     } /*else {
         qCWarning(GstVideoReceiverLog) << "Unexpected EOS!";
         stop();
@@ -847,7 +870,8 @@ GstElement *GstVideoReceiver::_makeDecoder()
     return decoder;
 }
 
-GstElement* GstVideoReceiver::_makeFileSink(const QString& videoFile, FILE_FORMAT format, const GstCaps* inputCaps)
+GstElement* GstVideoReceiver::_makeFileSink(const QString& videoFile, FILE_FORMAT format, const GstCaps* inputCaps,
+                                            int fileDescriptor)
 {
     GstElement *fileSink = nullptr;
     GstElement *splitmux = nullptr;
@@ -897,9 +921,16 @@ GstElement* GstVideoReceiver::_makeFileSink(const QString& videoFile, FILE_FORMA
                      "message-forward", TRUE,
                      nullptr);
 
-        // Crash-safe MP4/MOV: faststart writes moov up-front; reserved-moov-update-period
-        // refreshes the moov on a 1 s cadence so an abrupt kill still leaves a playable file.
-        // matroskamux is naturally streamable; skip the GstStructure dance.
+        if (fileDescriptor >= 0) {
+            // A content URI is not a filesystem path. The caller owns this seekable descriptor
+            // until the muxer/sink have reached NULL; fdsink only borrows it.
+            GstStructure* sinkProperties = gst_structure_new("properties", "fd", G_TYPE_INT, fileDescriptor, nullptr);
+            g_object_set(splitmux, "sink-factory", "fdsink", "sink-properties", sinkProperties, nullptr);
+            gst_structure_free(sinkProperties);
+        }
+
+        // Preserve the existing muxing policy. Faststart needs normal finalization and uses
+        // temporary storage; MediaStore does not make interrupted MP4/MOV recordings crash-safe.
         if (format == FILE_FORMAT_MP4 || format == FILE_FORMAT_MOV) {
             GstStructure *muxerProps = gst_structure_new("properties",
                 "faststart", G_TYPE_BOOLEAN, TRUE,
@@ -1369,7 +1400,7 @@ void GstVideoReceiver::_shutdownDecodingBranch()
     GST_DEBUG_BIN_TO_DOT_FILE(GST_BIN(_pipeline), GST_DEBUG_GRAPH_SHOW_ALL, "pipeline-decoding-stopped");
 }
 
-void GstVideoReceiver::_shutdownRecordingBranch()
+void GstVideoReceiver::_shutdownRecordingBranch(bool finalized)
 {
     if (_keyframeWatchId != 0 && _recorderValve) {
         GstPad *probepad = gst_element_get_static_pad(_recorderValve, "src");
@@ -1385,6 +1416,15 @@ void GstVideoReceiver::_shutdownRecordingBranch()
     (void) gst_element_get_state(_fileSink, nullptr, nullptr, GST_CLOCK_TIME_NONE);
     gst_clear_object(&_fileSink);
 
+    bool saved = true;
+#ifdef Q_OS_ANDROID
+    if (_mediaStore.fileDescriptor() >= 0) {
+        saved = _mediaStore.finish(finalized && _recordingHasKeyframe.load());
+    }
+#else
+    Q_UNUSED(finalized);
+#endif
+
     _removingRecorder = false;
 
     if (_recording) {
@@ -1393,9 +1433,9 @@ void GstVideoReceiver::_shutdownRecordingBranch()
         emit recordingChanged(_recording);
     }
 
-    if (_recordingStopRequested) {
+    if (_recordingStopRequested || !saved) {
         _recordingStopRequested = false;
-        emit onStopRecordingComplete(STATUS_OK);
+        emit onStopRecordingComplete(saved ? STATUS_OK : STATUS_FAIL);
     }
 
     GST_DEBUG_BIN_TO_DOT_FILE(GST_BIN(_pipeline), GST_DEBUG_GRAPH_SHOW_ALL, "pipeline-recording-stopped");
@@ -1538,6 +1578,12 @@ gboolean GstVideoReceiver::_onBusMessage(GstBus * /* bus */, GstMessage *msg, gp
     }
     case GST_MESSAGE_ELEMENT: {
         const GstStructure *structure = gst_message_get_structure(msg);
+        if (structure && gst_structure_has_name(structure, "splitmuxsink-fragment-closed")) {
+            // Remember completion even if EOS subsequently enters stop() after the bus message
+            // has been consumed. Publication must not depend on receiving a second EOS.
+            pThis->_recordingFragmentClosed = true;
+            break;
+        }
         if (structure && gst_structure_has_name(structure, "qgc-caps-info")) {
             gint w = 0, h = 0;
             const gchar *fmt = gst_structure_get_string(structure, "format");
@@ -1727,6 +1773,7 @@ GstPadProbeReturn GstVideoReceiver::_keyframeWatch(GstPad *pad, GstPadProbeInfo 
     qCDebug(GstVideoReceiverLog) << "Got keyframe, stop dropping buffers";
 
     GstVideoReceiver *pThis = static_cast<GstVideoReceiver*>(user_data);
+    pThis->_recordingHasKeyframe = true;
     emit pThis->recordingStarted(pThis->recordingOutput());
 
     return GST_PAD_PROBE_REMOVE;

--- a/src/VideoManager/VideoReceiver/GStreamer/GstVideoReceiver.h
+++ b/src/VideoManager/VideoReceiver/GStreamer/GstVideoReceiver.h
@@ -14,6 +14,10 @@
 
 #include "VideoReceiver.h"
 
+#ifdef Q_OS_ANDROID
+#include "AndroidMediaStore.h"
+#endif
+
 typedef std::function<void()> Task;
 
 /*===========================================================================*/
@@ -90,7 +94,8 @@ private:
     friend class GStreamerTest;
 
     GstElement *_makeDecoder();
-    static GstElement* _makeFileSink(const QString& videoFile, FILE_FORMAT format, const GstCaps* inputCaps);
+    static GstElement* _makeFileSink(const QString& videoFile, FILE_FORMAT format, const GstCaps* inputCaps,
+                                     int fileDescriptor = -1);
 
     void _onNewSourcePad(GstPad *pad);
     void _onNewDecoderPad(GstPad *pad);
@@ -104,7 +109,7 @@ private:
     /// -Send an EOS event at the beginning of that branch
     bool _unlinkBranch(GstElement *from);
     void _shutdownDecodingBranch();
-    void _shutdownRecordingBranch();
+    void _shutdownRecordingBranch(bool finalized);
     void _logDecodebin3SelectedCodec(GstElement *decodebin3);
 
     bool _needDispatch();
@@ -146,6 +151,11 @@ private:
     GstPad *_eosProbePad = nullptr;  // ref-held: probe install pad, kept so removal targets the right pad regardless of _decoder lifecycle
     gulong _keyframeWatchId = 0;
     bool _recordingStopRequested = false;
+    std::atomic<bool> _recordingHasKeyframe = false;
+    std::atomic<bool> _recordingFragmentClosed = false;
+#ifdef Q_OS_ANDROID
+    AndroidMediaStore _mediaStore;
+#endif
 
     mutable QMutex _decoderNameMutex;  // QString refcount isn't thread-safe across reader/writer threads
     QString _decoderName;

--- a/src/VideoManager/VideoReceiver/GStreamer/README.md
+++ b/src/VideoManager/VideoReceiver/GStreamer/README.md
@@ -87,6 +87,71 @@ Auto-downloaded during CMake configure. No manual setup required.
 
 > **Windows users building for Android**: Enable Developer Mode (Settings > System > For developers) to support symbolic links during the build.
 
+#### Android videos and photos in Gallery
+
+On Android 10 (API 29) and newer, this backend records directly to a pending
+`MediaStore.Video` item in `Movies/QGroundControl/`. Stop recording normally to
+publish the video. A Gallery app can then find it in the QGroundControl device
+album (for example, Google Photos: Collections > On this device). Gallery codec
+support still varies: check H.264/H.265 MP4 playback on the actual controller.
+
+Local snapshots of the main video stream are JPEGs in `Pictures/QGroundControl/`,
+created through `MediaStore.Images`. The existing QML frame grab writes directly
+to the pending item's descriptor and publishes only after encoding and flushing.
+A failed JPEG write removes that request's pending item. There is no additional
+private JPEG copy. This is a snapshot of the displayed stream, not an onboard
+camera still-photo command; native MAVLink camera capture is unchanged.
+
+The native sink borrows a seekable file descriptor, which stays open until the
+recording branch reaches NULL. There is one retained video, not an app-private
+video plus an exported copy. The existing MP4/MOV faststart muxer can still use
+temporary disk space while recording; this change does not add crash recovery.
+Empty attempts are removed; nonempty recordings without successful finalization
+stay pending, subject to Android's pending-item expiry, rather than appearing as
+successful Gallery videos. A failed save is reported in QGC and the application log.
+
+No new storage, photo-library, or all-files permission is required for QGC to
+create its own media. Published recordings survive app uninstall, are accessible
+to appropriately authorized media apps, and may be backed up if the user has
+enabled backup of this album in a Gallery/cloud app.
+
+The existing **Auto-Delete Saved Recordings** / **Max Storage Usage** settings still apply:
+cleanup considers only published videos owned by this package in this album,
+never other apps' videos or pending recordings. Auto-delete is enabled by default
+on mobile; disable it to retain all published recordings. Old app-private clips
+are not migrated or deleted by this MediaStore cleanup. Telemetry `.ass` sidecars
+remain in the original private Video directory under the matching basename;
+Gallery players do not automatically load them. Other QGC data paths are
+unchanged. Older Android versions, UVC, and the QtMultimedia-only backend
+continue using their existing destinations. MediaStore uses primary shared
+storage, not the legacy private/SD-card video path.
+
+Manual Android acceptance checks (use disposable test recordings):
+
+1. Record and normally stop H.264 and H.265 MP4 clips. Check Gallery thumbnails,
+   duration, playback, and seeking; confirm one MediaStore item per stream and no
+   new private video copy. Repeat with MOV/MKV, noting player support separately.
+2. Check that a still-recording item is pending/hidden, and that the descriptor
+   remains open through finalization. Stop/start quickly and record thermal and
+   primary streams together; verify distinct names and subtitle sidecars.
+3. Test no-keyframe startup, low space, failed open, stream loss, and interrupted
+   finalization. Do not publish an empty/header-only or unfinalized item, and do
+   not silently fall back to an invisible private recording on MediaStore error.
+4. Disable auto-delete and confirm all published clips remain. On sacrificial
+   data, enable it and exceed the limit: only this app's oldest completed videos
+   in this album may be removed, not unrelated/user-imported or other-app media.
+5. Verify no new permission prompt for owned-media creation on API 29+, check the
+   API 28 fallback, and verify a release build preserves the JNI helper.
+6. Test app kill/restart without mistaking MediaStore publication for crash
+   resilience. Pending data recovery and historical private-video migration are
+   separate features, not guarantees of this implementation.
+7. Take repeated local photos of changing video. Check one decodable JPEG per tap
+   in Gallery/Files and no corresponding private copy, including while thermal
+   video is visible. Test empty/failed captures without publishing partial JPEGs.
+   The existing photo counter counts vehicle MAVLink capture reports, not local
+   snapshots; counter and backend screenshot-completion feedback are separate
+   from this storage change.
+
 ### Caching downloaded SDKs
 
 Auto-downloaded SDK archives are cached to `${CPM_SOURCE_CACHE}/gstreamer-*` when `CPM_SOURCE_CACHE` is set, otherwise to `${CMAKE_BINARY_DIR}/_deps/gstreamer-*` (lost on `rm -rf build`). Set `CPM_SOURCE_CACHE` to a stable location (e.g. `~/.cache/CPM`) to avoid re-downloading the 200-700 MB archives on every clean build:

--- a/test/Camera/VideoManagerTest.cc
+++ b/test/Camera/VideoManagerTest.cc
@@ -1,6 +1,11 @@
 #include "VideoManagerTest.h"
 
+#include <QtCore/QScopedPointer>
+#include <QtCore/QTemporaryDir>
+#include <QtCore/QVariant>
+#include <QtGui/QImageReader>
 #include <QtQml/QQmlComponent>
+#include <QtQml/QQmlContext>
 #include <QtQml/QQmlEngine>
 #include <QtQuick/QQuickItem>
 
@@ -33,6 +38,52 @@ VideoOutput {
     QVERIFY(qobject_cast<QQuickItem *>(item) != nullptr);
 
     delete item;
+}
+
+void VideoManagerTest::_saveImageFromQml_test()
+{
+#ifdef Q_OS_ANDROID
+    QSKIP("Gallery publication requires a device test; do not create real Gallery items in unit tests.");
+#else
+    QTemporaryDir tempDir;
+    QVERIFY(tempDir.isValid());
+    const QString fileName = tempDir.filePath(QStringLiteral("snapshot.jpg"));
+    QImage frame(32, 24, QImage::Format_RGB32);
+    frame.fill(Qt::red);
+
+    VideoManager testManager;
+    QQmlEngine engine;
+    engine.rootContext()->setContextProperty(QStringLiteral("testVideoManager"), &testManager);
+    engine.rootContext()->setContextProperty(QStringLiteral("testFileName"), fileName);
+    engine.rootContext()->setContextProperty(QStringLiteral("testFrame"), QVariant::fromValue(frame));
+    QQmlComponent component(&engine);
+    component.setData(R"QML(
+import QtQml
+
+QtObject {
+    property bool saved: testVideoManager.saveImage(testFileName, testFrame)
+}
+)QML",
+                      QUrl(QStringLiteral("qrc:/VideoManagerSaveImageTest.qml")));
+
+    const QScopedPointer<QObject> result(component.create());
+    QVERIFY2(component.errors().isEmpty(), qPrintable(component.errorString()));
+    QVERIFY(result);
+    QVERIFY(result->property("saved").toBool());
+
+    QImageReader reader(fileName);
+    QCOMPARE(reader.format(), QByteArray("jpeg"));
+    const QImage savedFrame = reader.read();
+    QVERIFY2(!savedFrame.isNull(), qPrintable(reader.errorString()));
+    QCOMPARE(savedFrame.size(), frame.size());
+#endif
+}
+
+void VideoManagerTest::_saveImageRejectsEmptyInput_test()
+{
+    VideoManager testManager;
+    QVERIFY(!testManager.saveImage(QStringLiteral("unused.jpg"), QImage()));
+    QVERIFY(!testManager.saveImage(QString(), QImage(1, 1, QImage::Format_RGB32)));
 }
 
 UT_REGISTER_TEST(VideoManagerTest, TestLabel::Unit)

--- a/test/Camera/VideoManagerTest.h
+++ b/test/Camera/VideoManagerTest.h
@@ -8,5 +8,6 @@ class VideoManagerTest : public UnitTest
 
 private slots:
     void _videoOutputQmlTypeAvailableInUnitTestMode_test();
+    void _saveImageFromQml_test();
+    void _saveImageRejectsEmptyInput_test();
 };
-

--- a/test/VideoManager/GStreamer/GStreamerTest.cc
+++ b/test/VideoManager/GStreamer/GStreamerTest.cc
@@ -4,6 +4,15 @@
 
 QGC_LOGGING_CATEGORY(GStreamerTestLog, "Video.GStreamer.GStreamerTest")
 
+void GStreamerTest::_testRecordingSinkFinalizesMidStreamH265Mp4_data()
+{
+    QTest::addColumn<bool>("useFileDescriptor");
+    QTest::newRow("filesystem") << false;
+#ifdef Q_OS_UNIX
+    QTest::newRow("borrowed-file-descriptor") << true;
+#endif
+}
+
 #ifdef QGC_GST_STREAMING
 
 #include <QtCore/QDir>
@@ -630,8 +639,9 @@ void GStreamerTest::_testRecordingSinkAcceptsElementaryStreams()
 
 void GStreamerTest::_testRecordingSinkFinalizesMidStreamH265Mp4()
 {
+    QFETCH(bool, useFileDescriptor);
     for (const char* factoryName : {"appsrc", "h265parse", "tee", "queue", "fakesink", "valve", "splitmuxsink",
-                                    "mp4mux", "filesrc", "qtdemux", "avdec_h265"}) {
+                                    "mp4mux", "filesrc", "fdsink", "qtdemux", "avdec_h265"}) {
         GstElementFactory* factory = gst_element_factory_find(factoryName);
         if (!factory) {
             QSKIP(qPrintable(
@@ -655,6 +665,11 @@ void GStreamerTest::_testRecordingSinkFinalizesMidStreamH265Mp4()
     QTemporaryDir tempDir;
     QVERIFY(tempDir.isValid());
     const QString outputPath = QDir(tempDir.path()).filePath(QStringLiteral("mid-stream.mp4"));
+    QFile outputFile(outputPath);
+    if (useFileDescriptor) {
+        QVERIFY(outputFile.open(QIODevice::ReadWrite));
+        QVERIFY(outputFile.handle() >= 0);
+    }
 
     GstElement* pipeline = gst_pipeline_new("mid-stream-recording-test");
     QVERIFY(pipeline);
@@ -714,7 +729,9 @@ void GStreamerTest::_testRecordingSinkFinalizesMidStreamH265Mp4()
     GstCaps* recordingCaps = gst_pad_get_current_caps(valveSrcPad);
     QVERIFY2(recordingCaps, "Closed recording valve did not preserve negotiated caps");
 
-    GstElement* fileSink = GstVideoReceiver::_makeFileSink(outputPath, VideoReceiver::FILE_FORMAT_MP4, recordingCaps);
+    const int fileDescriptor = useFileDescriptor ? outputFile.handle() : -1;
+    GstElement* fileSink =
+        GstVideoReceiver::_makeFileSink(outputPath, VideoReceiver::FILE_FORMAT_MP4, recordingCaps, fileDescriptor);
     gst_clear_caps(&recordingCaps);
     QVERIFY(fileSink);
     QVERIFY(gst_bin_add(GST_BIN(pipeline), fileSink));
@@ -730,6 +747,12 @@ void GStreamerTest::_testRecordingSinkFinalizesMidStreamH265Mp4()
     QString failure;
     QVERIFY2(waitForPipelineEos(pipeline, failure), qPrintable(failure));
     (void) gst_element_set_state(pipeline, GST_STATE_NULL);
+    if (useFileDescriptor) {
+        // The sink must not close the descriptor owned by the Android/Qt caller.
+        QVERIFY(outputFile.seek(0));
+        QVERIFY(!outputFile.read(16).isEmpty());
+        outputFile.close();
+    }
     QVERIFY2(QFileInfo(outputPath).size() > 0, "Recording did not produce an MP4 file");
 
     GstElement* verifyPipeline = gst_pipeline_new("verify-mid-stream-recording");

--- a/test/VideoManager/GStreamer/GStreamerTest.h
+++ b/test/VideoManager/GStreamer/GStreamerTest.h
@@ -26,6 +26,7 @@ private slots:
     void _testCreateVideoReceiver();
     void _testRecordingSinkAcceptsElementaryStreams_data();
     void _testRecordingSinkAcceptsElementaryStreams();
+    void _testRecordingSinkFinalizesMidStreamH265Mp4_data();
     void _testRecordingSinkFinalizesMidStreamH265Mp4();
     void _testBindDebugLevelFactRejectsNullContext();
     void _testRuntimeVersionCheck();


### PR DESCRIPTION
## Bug Description

On recent Android versions, streaming videos and local video snapshots are saved under QGC's app-specific `Android/data/...` directory. A successful capture is therefore difficult to find in Gallery/Photos or ordinary file managers.

Related to the storage-location discussion in #12989. #12999 fixed the recording filename, but did not resolve shared-media discoverability. This PR addresses new GStreamer recordings and local snapshots on Android 10/API 29+; it does not implement SD-card selection or migrate existing files.

## Root Cause

The writers use filesystem paths in QGC's app-specific storage. These paths do not create shared MediaStore entries. A MediaStore content URI also cannot be passed to a GStreamer filesystem sink as a pathname.

## Solution

- Use one small Java/JNI helper to create pending owned media, lend a seekable descriptor to the writer, and publish only after completion.
- Record directly into `MediaStore.Video` under `Movies/QGroundControl/` using `fdsink`. Keep descriptor ownership through muxer shutdown, require finalization and a received keyframe, and remove empty attempts.
- Route the existing QML main-video frame grab through `VideoManager::saveImage`. Encode JPEG directly into `MediaStore.Images` under `Pictures/QGroundControl/`, flush/close before publication, and discard failed image writes. The main-stream guard avoids duplicate snapshots when thermal video is visible.
- Preserve the video storage limit: cleanup considers only this package's completed videos in this album, never photos, other apps' media, or pending items.
- Keep existing destinations for desktop, API 28, UVC, and the QtMultimedia-only backend. Native MAVLink camera still capture is unchanged.

There is one retained media file, not an app-private copy plus an exported copy. The existing MP4/MOV faststart muxer can still use temporary storage. No new storage permission or export UI is added.

### User-visible behavior and limitations

This intentionally changes the default destination for the supported Android path to primary shared storage. Published media survives uninstall and can be accessed by appropriately authorized media apps or included in user-configured Gallery/cloud backup. Publication itself does not upload anything.

**Auto-Delete Saved Recordings still applies and is enabled by default on mobile.** Users who want to retain all published videos must disable it. Existing private clips are not migrated; telemetry `.ass` sidecars remain private.

Nonempty unfinished recordings remain pending, subject to Android expiry; this is not crash recovery. There is no silent private-storage fallback on MediaStore error. Gallery codec/container support varies. The local-photo counter and backend screenshot-completion logs are separate from this destination change.

## Testing

- [x] Tested locally
- [x] Added regression tests
- [ ] Tested with simulator (SITL)
- [ ] Tested with hardware on this combined revision

Validation on commit `057897b0f`:

- Android arm64 Debug native/Java build and APK packaging passed: Qt 6.11.1, NDK 27.2.12479018, GStreamer 1.28.4, min API 28 / target API 36, Java 21.
- Linux Debug test-enabled build passed. The final amendment after that build is Java-only; the verified C++/QML sources are unchanged.
- `VideoManagerTest` passed, including a real QML-to-C++ invocation producing a decodable JPEG and empty-input rejection.
- `GStreamerTest` passed: 89 passes and 16 platform/GPU-capability skips. Both filesystem and borrowed-descriptor H.265 MP4 finalization/decoding cases passed, not skipped; the latter verifies the sink leaves its caller-owned descriptor open.
- `QGCMediaStoreTest`: 4 passed (video/JPEG MIME mapping and unsupported input).
- Fresh pre-submission `ctest --output-on-failure -L Unit --parallel 4`: **266/267 passed**. The untouched `BluetoothWorkerTest::_testDisconnectResetsReconnectState` fails on the host BlueZ warning `Invalid address to remote address passed.` This also reproduces alone and was present in the local validation notes for #14797.
- `git diff --check`, focused formatting and source-policy checks passed. The broader pre-commit run still reports existing whole-file formatting/QML/assertion findings and missing local clang-tidy; no unrelated cleanup is included.
- Android lint has no findings in the new helper, but the project report retains an existing USB-receiver registration error in `QGCUsbSerialManager.java` and 77 warnings. `lintDebug` returning success is not a clean lint gate because `abortOnError=false`.

The backend README includes manual Gallery, repeated capture/stop-start, thermal, permissions, retention, failure-path, API-28 fallback, and release/JNI acceptance checks. End-to-end device acceptance of this combined revision and release/R8 runtime validation are not claimed by the automated tests.

### Platforms Tested

- [x] Linux
- [ ] Windows
- [ ] macOS
- [x] Android (build/package and Java unit tests; device acceptance still needed)
- [ ] iOS

### Flight Stacks Tested

- [ ] PX4
- [ ] ArduPilot
- [x] N/A — local media storage; no vehicle protocol change

## Checklist

- [x] I have read the Contribution Guidelines and Code of Conduct
- [x] Added focused regression coverage and documented manual acceptance
- [x] One focused commit based on current official `master`
- [ ] All style/static-analysis gates pass (limitations above)
- [ ] New and existing unit tests pass locally (266/267; limitation above)

---
By submitting this pull request, I confirm that my contribution is made under the terms of the project's dual license (Apache 2.0 and GPL v3).
